### PR TITLE
Support multi-leaf tree extraction and expand client boarding info

### DIFF
--- a/lib/tree/batch_test.go
+++ b/lib/tree/batch_test.go
@@ -490,7 +490,7 @@ func TestBuildConnectorTree(t *testing.T) {
 
 		// Extract each connector by index.
 		for i := 0; i < 4; i++ {
-			extracted, err := tree.ExtractPathForIndex(i)
+			extracted, err := tree.ExtractPathForIndices(i)
 			require.NoError(t, err, "index %d", i)
 			require.NotNil(t, extracted, "index %d", i)
 

--- a/lib/tree/node.go
+++ b/lib/tree/node.go
@@ -555,16 +555,20 @@ func (n *Node) ExtractPathForIndices(targetIndices ...int) (*Node, error) {
 	targetSet := fn.NewSet(targetIndices...)
 
 	// Find the paths to all target leaves.
-	extracted, _ := n.extractPathForIndicesRecursive(targetSet, 0)
+	extracted, _, found := n.extractPathForIndicesRecursive(targetSet, 0)
+	if !found {
+		return nil, fmt.Errorf("no paths found for target indices")
+	}
 
 	return extracted, nil
 }
 
 // extractPathForIndicesRecursive recursively extracts paths to multiple target
-// leaf indices. Returns the extracted node and the number of leaves consumed in
-// this subtree.
-func (n *Node) extractPathForIndicesRecursive(
-	targetSet fn.Set[int], currentIndex int) (*Node, int) {
+// leaf indices. Returns the extracted node, the number of leaves consumed in
+// this subtree, and a boolean indicating whether any target indices were found
+// in this subtree.
+func (n *Node) extractPathForIndicesRecursive(targetSet fn.Set[int],
+	currentIndex int) (*Node, int, bool) {
 
 	// If this is a leaf node.
 	if n.IsLeaf() {
@@ -577,10 +581,10 @@ func (n *Node) extractPathForIndicesRecursive(
 				Signature: n.Signature,
 				FinalKey:  n.FinalKey,
 				Children:  make(map[uint32]*Node),
-			}, currentIndex + 1
+			}, currentIndex + 1, true
 		}
 
-		return nil, currentIndex + 1
+		return nil, currentIndex + 1, false
 	}
 
 	// This is a branch node, check children.
@@ -603,10 +607,11 @@ func (n *Node) extractPathForIndicesRecursive(
 			continue
 		}
 
-		childExtracted, newLeafIndex :=
-			child.extractPathForIndicesRecursive(targetSet, leafIndex)
-
-		if childExtracted != nil {
+		childExtracted, newLeafIndex, found :=
+			child.extractPathForIndicesRecursive(
+				targetSet, leafIndex,
+			)
+		if found {
 			extracted.Children[i] = childExtracted
 			foundAnyTarget = true
 		}
@@ -615,10 +620,10 @@ func (n *Node) extractPathForIndicesRecursive(
 	}
 
 	if foundAnyTarget {
-		return extracted, leafIndex
+		return extracted, leafIndex, true
 	}
 
-	return nil, leafIndex
+	return nil, leafIndex, false
 }
 
 // PrevOutputFetcher creates a PrevOutputFetcher that can provide transaction

--- a/lib/tree/node.go
+++ b/lib/tree/node.go
@@ -14,6 +14,7 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/lib/scripts"
+	"github.com/lightningnetwork/lnd/fn/v2"
 )
 
 // Node represents a single transaction in a virtual transaction tree.
@@ -458,14 +459,25 @@ func (n *Node) NumTx() int {
 	return count
 }
 
-// ExtractPathForCoSigner takes a Node and extracts the path that is relevant
-// for a given cosigner. It returns a new Node that contains only the nodes and
-// children where the cosigner's key is present in the CoSigners list from root
-// to leaf.
-func (n *Node) ExtractPathForCoSigner(targetKey *btcec.PublicKey) *Node {
-	// Check if the target key is in this node's cosigners.
-	if !ContainsCosigner(n.CoSigners, targetKey) {
-		return nil
+// ExtractPathForCoSigners takes a Node and extracts the path that is relevant
+// for one or more cosigners. It returns a new Node that contains only the nodes
+// and children where any of the provided cosigner keys are present in the
+// CoSigners list from root to leaf. The boolean return value indicates whether
+// any matching cosigners were found in this subtree.
+func (n *Node) ExtractPathForCoSigners(targetKeys ...*btcec.PublicKey) (*Node,
+	bool) {
+
+	// Check if any of the target keys are in this node's cosigners.
+	hasMatch := false
+	for _, targetKey := range targetKeys {
+		if ContainsCosigner(n.CoSigners, targetKey) {
+			hasMatch = true
+			break
+		}
+	}
+
+	if !hasMatch {
+		return nil, false
 	}
 
 	// Create a new node with the same basic info.
@@ -480,33 +492,17 @@ func (n *Node) ExtractPathForCoSigner(targetKey *btcec.PublicKey) *Node {
 
 	// Recursively extract relevant children.
 	for outputIndex, child := range n.Children {
-		extractedChild := child.ExtractPathForCoSigner(targetKey)
-		if extractedChild != nil {
-			extracted.Children[outputIndex] = extractedChild
+		extractedChild, ok := child.ExtractPathForCoSigners(
+			targetKeys...,
+		)
+		if !ok {
+			continue
 		}
+
+		extracted.Children[outputIndex] = extractedChild
 	}
 
-	return extracted
-}
-
-// ExtractPathForIndex extracts the path to a specific leaf by its index.
-// Returns nil if the index is out of bounds.
-func (n *Node) ExtractPathForIndex(targetIndex int) (*Node, error) {
-	if targetIndex < 0 {
-		return nil, fmt.Errorf("leaf index must be non-negative, "+
-			"got %d", targetIndex)
-	}
-
-	// First, count total leaves to validate index.
-	totalLeaves := n.countLeaves()
-	if targetIndex >= totalLeaves {
-		return nil, nil // Index out of bounds, return nil (no error).
-	}
-
-	// Find the path to the target leaf.
-	extracted, _ := n.extractPathForIndexRecursive(targetIndex, 0)
-
-	return extracted, nil
+	return extracted, true
 }
 
 // countLeaves returns the total number of leaf nodes in this subtree.
@@ -523,15 +519,57 @@ func (n *Node) countLeaves() int {
 	return count
 }
 
-// extractPathForIndexRecursive recursively extracts the path to the
-// target leaf index. Returns the extracted node and the number of leaves
-// consumed in this subtree.
-func (n *Node) extractPathForIndexRecursive(
-	targetIndex, currentIndex int) (*Node, int) {
+// ExtractPathForIndices extracts the minimal subtree containing paths to all
+// specified leaf indices. Accepts one or more indices as variadic parameters.
+// This is useful when a client has multiple leaves in the same tree (e.g.,
+// multiple connector leaves for multiple forfeit requests).
+//
+// IMPORTANT: Indices are relative to the current tree structure. After
+// extraction, leaves in the returned subtree will be renumbered starting from
+// 0. This means ExtractPathForIndices is NOT idempotent - calling it twice
+// with the same indices will fail on the second call since the leaf positions
+// have changed. If you need stable identifiers across extractions, use
+// ExtractPathForCoSigners instead.
+func (n *Node) ExtractPathForIndices(targetIndices ...int) (*Node, error) {
+	if len(targetIndices) == 0 {
+		return nil, fmt.Errorf("no target indices provided")
+	}
+
+	// Validate the indices.
+	totalLeaves := n.countLeaves()
+	for _, idx := range targetIndices {
+		// Check for negative or out-of-bounds indices.
+		if idx < 0 {
+			return nil, fmt.Errorf("leaf index must be "+
+				"non-negative, got %d", idx)
+		}
+		if idx >= totalLeaves {
+			// At least one index is out of bounds, return nil (no
+			// error).
+			return nil, fmt.Errorf("leaf index %d out of bounds "+
+				"(total leaves: %d)", idx, totalLeaves)
+		}
+	}
+
+	// Create a set of target indices for efficient lookup.
+	targetSet := fn.NewSet(targetIndices...)
+
+	// Find the paths to all target leaves.
+	extracted, _ := n.extractPathForIndicesRecursive(targetSet, 0)
+
+	return extracted, nil
+}
+
+// extractPathForIndicesRecursive recursively extracts paths to multiple target
+// leaf indices. Returns the extracted node and the number of leaves consumed in
+// this subtree.
+func (n *Node) extractPathForIndicesRecursive(
+	targetSet fn.Set[int], currentIndex int) (*Node, int) {
+
 	// If this is a leaf node.
 	if n.IsLeaf() {
-		if currentIndex == targetIndex {
-			// Found our target leaf.
+		if targetSet.Contains(currentIndex) {
+			// This is one of our target leaves.
 			return &Node{
 				Input:     n.Input,
 				CoSigners: n.CoSigners,
@@ -556,7 +594,7 @@ func (n *Node) extractPathForIndexRecursive(
 	}
 
 	leafIndex := currentIndex
-	foundTarget := false
+	foundAnyTarget := false
 
 	// Process children in sorted order for consistent indexing.
 	for i := uint32(0); i < uint32(len(n.Outputs)-1); i++ {
@@ -566,19 +604,17 @@ func (n *Node) extractPathForIndexRecursive(
 		}
 
 		childExtracted, newLeafIndex :=
-			child.extractPathForIndexRecursive(
-				targetIndex, leafIndex,
-			)
+			child.extractPathForIndicesRecursive(targetSet, leafIndex)
 
 		if childExtracted != nil {
 			extracted.Children[i] = childExtracted
-			foundTarget = true
+			foundAnyTarget = true
 		}
 
 		leafIndex = newLeafIndex
 	}
 
-	if foundTarget {
+	if foundAnyTarget {
 		return extracted, leafIndex
 	}
 

--- a/lib/tree/node_test.go
+++ b/lib/tree/node_test.go
@@ -735,9 +735,9 @@ func TestNodeLeafOperations(t *testing.T) {
 		})
 }
 
-// TestExtractPathForCoSigner tests extracting a tree path for a specific
+// TestExtractPathForCoSigners tests extracting a tree path for a specific
 // cosigner.
-func TestExtractPathForCoSigner(t *testing.T) {
+func TestExtractPathForCoSigners(t *testing.T) {
 	t.Parallel()
 
 	t.Run("extracts path for cosigner in simple tree", func(t *testing.T) {
@@ -745,7 +745,8 @@ func TestExtractPathForCoSigner(t *testing.T) {
 		root, leaf1, _, keys := createTestTree(t)
 
 		// Extract path for key1 (should get root -> leaf1).
-		extracted := root.ExtractPathForCoSigner(keys[0])
+		extracted, ok := root.ExtractPathForCoSigners(keys[0])
+		require.True(t, ok)
 		require.NotNil(t, extracted)
 
 		// Should have same root properties.
@@ -775,7 +776,8 @@ func TestExtractPathForCoSigner(t *testing.T) {
 
 		// Extract path for first leaf's cosigner.
 		targetKey := leaves[0].CoSigners[0]
-		extracted := deepRoot.ExtractPathForCoSigner(targetKey)
+		extracted, ok := deepRoot.ExtractPathForCoSigners(targetKey)
+		require.True(t, ok)
 		require.NotNil(t, extracted)
 
 		// Verify the extracted path reaches the target leaf.
@@ -794,7 +796,8 @@ func TestExtractPathForCoSigner(t *testing.T) {
 		root, _, _, _ := createTestTree(t)
 		_, unknownKey := createTestKey(t)
 
-		extracted := root.ExtractPathForCoSigner(unknownKey)
+		extracted, ok := root.ExtractPathForCoSigners(unknownKey)
+		require.False(t, ok)
 		require.Nil(t, extracted)
 	})
 
@@ -803,7 +806,8 @@ func TestExtractPathForCoSigner(t *testing.T) {
 		root, _, _, keys := createTestTree(t)
 
 		// Extract for key[0] which is only in leaf1.
-		extracted := root.ExtractPathForCoSigner(keys[0])
+		extracted, ok := root.ExtractPathForCoSigners(keys[0])
+		require.True(t, ok)
 		require.NotNil(t, extracted)
 
 		// Should only have 1 leaf in extracted tree.
@@ -815,15 +819,15 @@ func TestExtractPathForCoSigner(t *testing.T) {
 	})
 }
 
-// TestExtractPathForIndex tests extracting a tree path by leaf index.
-func TestExtractPathForIndex(t *testing.T) {
+// TestExtractPathForIndices tests extracting a tree path by leaf index.
+func TestExtractPathForIndices(t *testing.T) {
 	t.Parallel()
 
 	t.Run("extracts first leaf", func(t *testing.T) {
 		t.Parallel()
 		root, leaf1, _, _ := createTestTree(t)
 
-		extracted, err := root.ExtractPathForIndex(0)
+		extracted, err := root.ExtractPathForIndices(0)
 		require.NoError(t, err)
 		require.NotNil(t, extracted)
 
@@ -841,7 +845,7 @@ func TestExtractPathForIndex(t *testing.T) {
 		t.Parallel()
 		root, _, leaf2, _ := createTestTree(t)
 
-		extracted, err := root.ExtractPathForIndex(1)
+		extracted, err := root.ExtractPathForIndices(1)
 		require.NoError(t, err)
 		require.NotNil(t, extracted)
 
@@ -857,7 +861,7 @@ func TestExtractPathForIndex(t *testing.T) {
 
 		// Tree has 4 leaves, try extracting each.
 		for i := 0; i < 4; i++ {
-			extracted, err := deepRoot.ExtractPathForIndex(i)
+			extracted, err := deepRoot.ExtractPathForIndices(i)
 			require.NoError(t, err)
 			require.NotNil(
 				t, extracted, "failed to extract leaf %d", i,
@@ -872,12 +876,12 @@ func TestExtractPathForIndex(t *testing.T) {
 		}
 	})
 
-	t.Run("returns nil for out of bounds index", func(t *testing.T) {
+	t.Run("returns error for out of bounds index", func(t *testing.T) {
 		t.Parallel()
 		root, _, _, _ := createTestTree(t)
 
-		extracted, err := root.ExtractPathForIndex(999)
-		require.NoError(t, err)
+		extracted, err := root.ExtractPathForIndices(999)
+		require.Error(t, err)
 		require.Nil(t, extracted)
 	})
 
@@ -885,7 +889,7 @@ func TestExtractPathForIndex(t *testing.T) {
 		t.Parallel()
 		root, _, _, _ := createTestTree(t)
 
-		extracted, err := root.ExtractPathForIndex(-1)
+		extracted, err := root.ExtractPathForIndices(-1)
 		require.Error(t, err)
 		require.Nil(t, extracted)
 		require.Contains(t, err.Error(), "must be non-negative")
@@ -895,7 +899,7 @@ func TestExtractPathForIndex(t *testing.T) {
 		t.Parallel()
 		leaf := createSimpleLeaf("single", 1000, nil)
 
-		extracted, err := leaf.ExtractPathForIndex(0)
+		extracted, err := leaf.ExtractPathForIndices(0)
 		require.NoError(t, err)
 		require.NotNil(t, extracted)
 		require.Equal(t, leaf.Input, extracted.Input)

--- a/lib/tree/signing.go
+++ b/lib/tree/signing.go
@@ -157,8 +157,8 @@ func NewSignerSession(signer input.MuSig2Signer,
 	}
 
 	// Extract the path for this cosigner only.
-	signerPath := tree.ExtractPathForCoSigner(signerKey.PubKey)
-	if signerPath == nil {
+	signerPath, ok := tree.ExtractPathForCoSigners(signerKey.PubKey)
+	if !ok {
 		return nil, fmt.Errorf("no path found for signer")
 	}
 

--- a/lib/tree/tree.go
+++ b/lib/tree/tree.go
@@ -75,18 +75,25 @@ func NewTree(rootOutpoint wire.OutPoint, rootOutput *wire.TxOut,
 	}, nil
 }
 
-// ExtractPathForCoSigner extracts the path relevant for a given cosigner and
-// returns a new Tree containing only the nodes where the cosigner's key is
-// present.
-func (t *Tree) ExtractPathForCoSigner(targetKey *btcec.PublicKey) (*Tree,
+// ExtractPathForCoSigners extracts the path relevant for one or more cosigners
+// and returns a new Tree containing only the nodes where any of the provided
+// cosigner keys are present. This is useful when a client has multiple VTXOs
+// with different keys in the same tree.
+func (t *Tree) ExtractPathForCoSigners(targetKeys ...*btcec.PublicKey) (*Tree,
 	error) {
 
-	if targetKey == nil {
-		return nil, fmt.Errorf("target key cannot be nil")
+	if len(targetKeys) == 0 {
+		return nil, fmt.Errorf("at least one target key required")
 	}
 
-	extractedRoot := t.Root.ExtractPathForCoSigner(targetKey)
-	if extractedRoot == nil {
+	for _, key := range targetKeys {
+		if key == nil {
+			return nil, fmt.Errorf("target key cannot be nil")
+		}
+	}
+
+	extractedRoot, ok := t.Root.ExtractPathForCoSigners(targetKeys...)
+	if !ok {
 		return nil, nil
 	}
 
@@ -98,17 +105,28 @@ func (t *Tree) ExtractPathForCoSigner(targetKey *btcec.PublicKey) (*Tree,
 	}, nil
 }
 
-// ExtractPathForIndex extracts the path to a specific leaf by its index.
-// The index is 0-based and refers to the leaf position in the tree's in-order
-// traversal. This is useful for connector trees where all leaves have the same
-// cosigner key, but clients need access to a specific leaf by index.
-func (t *Tree) ExtractPathForIndex(leafIndex int) (*Tree, error) {
-	extractedRoot, err := t.Root.ExtractPathForIndex(leafIndex)
+// ExtractPathForIndices extracts a minimal subtree containing all the paths to
+// the specified leaf indices. Accepts one or more indices as variadic
+// parameters. The returned tree will contain only the nodes necessary to reach
+// all target leaves.
+//
+// IMPORTANT: Indices are relative to the current tree structure. After
+// extraction, leaves in the returned subtree will be renumbered starting from
+// 0. This means ExtractPathForIndices is NOT idempotent - calling it twice
+// with the same indices will fail on the second call since the leaf positions
+// have changed. If you need stable identifiers across extractions, use
+// ExtractPathForCoSigners instead.
+func (t *Tree) ExtractPathForIndices(leafIndices ...int) (*Tree, error) {
+	if len(leafIndices) == 0 {
+		return nil, nil
+	}
+
+	extractedRoot, err := t.Root.ExtractPathForIndices(leafIndices...)
 	if err != nil {
 		return nil, err
 	}
 	if extractedRoot == nil {
-		return nil, nil
+		return nil, fmt.Errorf("no extracted root found")
 	}
 
 	return &Tree{
@@ -147,7 +165,7 @@ func (t *Tree) VerifyVTXOPath(coSignerKey *btcec.PublicKey,
 	}
 
 	// Extract path for cosigner.
-	extracted, err := t.ExtractPathForCoSigner(coSignerKey)
+	extracted, err := t.ExtractPathForCoSigners(coSignerKey)
 	if err != nil {
 		return fmt.Errorf("failed to extract path: %w", err)
 	}

--- a/lib/tree/tree_test.go
+++ b/lib/tree/tree_test.go
@@ -273,8 +273,8 @@ func TestTreeVerify(t *testing.T) {
 	})
 }
 
-// TestTreeExtractPathForCoSigner tests extracting tree paths for cosigners.
-func TestTreeExtractPathForCoSigner(t *testing.T) {
+// TestTreeExtractPathForCoSigners tests extracting tree paths for cosigners.
+func TestTreeExtractPathForCoSigners(t *testing.T) {
 	t.Parallel()
 
 	t.Run("extracts path for cosigner", func(t *testing.T) {
@@ -309,7 +309,7 @@ func TestTreeExtractPathForCoSigner(t *testing.T) {
 		require.NoError(t, err)
 
 		// Extract for key1.
-		extracted, err := tree.ExtractPathForCoSigner(key1)
+		extracted, err := tree.ExtractPathForCoSigners(key1)
 		require.NoError(t, err)
 		require.NotNil(t, extracted)
 
@@ -346,9 +346,74 @@ func TestTreeExtractPathForCoSigner(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		extracted, err := tree.ExtractPathForCoSigner(unknownKey)
+		extracted, err := tree.ExtractPathForCoSigners(unknownKey)
 		require.NoError(t, err)
 		require.Nil(t, extracted)
+	})
+
+	t.Run("extracts path for multiple cosigners", func(t *testing.T) {
+		t.Parallel()
+		_, operatorKey := createTestKey(t)
+		_, key1 := createTestKey(t)
+		_, key2 := createTestKey(t)
+		_, key3 := createTestKey(t)
+
+		leaves := []LeafDescriptor{
+			{
+				PkScript:    []byte("script1"),
+				Amount:      1000,
+				CoSignerKey: key1,
+			},
+			{
+				PkScript:    []byte("script2"),
+				Amount:      2000,
+				CoSignerKey: key2,
+			},
+			{
+				PkScript:    []byte("script3"),
+				Amount:      3000,
+				CoSignerKey: key3,
+			},
+		}
+
+		rootOutpoint := wire.OutPoint{
+			Hash:  chainhash.HashH([]byte("batch")),
+			Index: 0,
+		}
+		rootOutput := &wire.TxOut{Value: 10000}
+
+		tree, err := NewTree(
+			rootOutpoint, rootOutput, leaves, operatorKey,
+			make([]byte, 32), 2,
+		)
+		require.NoError(t, err)
+
+		// Extract for both key1 and key2 at once.
+		extracted, err := tree.ExtractPathForCoSigners(key1, key2)
+		require.NoError(t, err)
+		require.NotNil(t, extracted)
+
+		// Should have same batch context.
+		require.Equal(t, tree.BatchOutpoint, extracted.BatchOutpoint)
+		require.Equal(t, tree.BatchOutput, extracted.BatchOutput)
+		require.Equal(
+			t, tree.SweepTapscriptRoot,
+			extracted.SweepTapscriptRoot,
+		)
+
+		// Should have 2 leaves (key1 and key2, but not key3).
+		require.Equal(t, 2, extracted.NumLeaves())
+
+		// Verify both paths are valid.
+		err = extracted.VerifyVTXOPath(key1, []byte("script1"))
+		require.NoError(t, err)
+
+		err = extracted.VerifyVTXOPath(key2, []byte("script2"))
+		require.NoError(t, err)
+
+		// key3 should not be in the extracted tree.
+		err = extracted.VerifyVTXOPath(key3, []byte("script3"))
+		require.Error(t, err)
 	})
 
 	t.Run("rejects nil target key", func(t *testing.T) {
@@ -370,15 +435,40 @@ func TestTreeExtractPathForCoSigner(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		extracted, err := tree.ExtractPathForCoSigner(nil)
+		extracted, err := tree.ExtractPathForCoSigners(nil)
 		require.Error(t, err)
 		require.Nil(t, extracted)
 		require.Contains(t, err.Error(), "target key cannot be nil")
 	})
+
+	t.Run("rejects empty target keys", func(t *testing.T) {
+		t.Parallel()
+		_, operatorKey := createTestKey(t)
+		_, ownerKey := createTestKey(t)
+
+		leaves := []LeafDescriptor{
+			{
+				PkScript:    []byte("script"),
+				Amount:      1000,
+				CoSignerKey: ownerKey,
+			},
+		}
+
+		tree, err := NewTree(
+			wire.OutPoint{}, &wire.TxOut{Value: 10000}, leaves,
+			operatorKey, make([]byte, 32), 2,
+		)
+		require.NoError(t, err)
+
+		extracted, err := tree.ExtractPathForCoSigners()
+		require.Error(t, err)
+		require.Nil(t, extracted)
+		require.Contains(t, err.Error(), "at least one target key required")
+	})
 }
 
-// TestTreeExtractPathForIndex tests extracting tree paths by index.
-func TestTreeExtractPathForIndex(t *testing.T) {
+// TestTreeExtractPathForIndices tests extracting tree paths by index.
+func TestTreeExtractPathForIndices(t *testing.T) {
 	t.Parallel()
 
 	t.Run("extracts path for each leaf index", func(t *testing.T) {
@@ -405,14 +495,14 @@ func TestTreeExtractPathForIndex(t *testing.T) {
 
 		// Extract each leaf by index.
 		for i := 0; i < 4; i++ {
-			extracted, err := tree.ExtractPathForIndex(i)
+			extracted, err := tree.ExtractPathForIndices(i)
 			require.NoError(t, err)
 			require.NotNil(t, extracted, "failed for index %d", i)
 			require.Equal(t, 1, extracted.NumLeaves())
 		}
 	})
 
-	t.Run("returns nil for out of bounds index", func(t *testing.T) {
+	t.Run("returns error for out of bounds index", func(t *testing.T) {
 		t.Parallel()
 		_, operatorKey := createTestKey(t)
 		_, ownerKey := createTestKey(t)
@@ -431,8 +521,8 @@ func TestTreeExtractPathForIndex(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		extracted, err := tree.ExtractPathForIndex(999)
-		require.NoError(t, err)
+		extracted, err := tree.ExtractPathForIndices(999)
+		require.Error(t, err)
 		require.Nil(t, extracted)
 	})
 
@@ -455,9 +545,38 @@ func TestTreeExtractPathForIndex(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		extracted, err := tree.ExtractPathForIndex(-1)
+		extracted, err := tree.ExtractPathForIndices(-1)
 		require.Error(t, err)
 		require.Nil(t, extracted)
+	})
+
+	t.Run("extracts multiple indices", func(t *testing.T) {
+		t.Parallel()
+		_, operatorKey := createTestKey(t)
+
+		// Create 4 leaves.
+		leaves := make([]LeafDescriptor, 4)
+		for i := range leaves {
+			_, key := createTestKey(t)
+			leaves[i] = LeafDescriptor{
+				PkScript:    []byte("script"),
+				Amount:      btcutil.Amount(1000 * (i + 1)),
+				CoSignerKey: key,
+			}
+		}
+
+		tree, err := NewTree(
+			wire.OutPoint{Hash: chainhash.HashH([]byte("batch"))},
+			&wire.TxOut{Value: 10000}, leaves, operatorKey,
+			make([]byte, 32), 2,
+		)
+		require.NoError(t, err)
+
+		// Extract leaves at index 1 and 3.
+		extracted, err := tree.ExtractPathForIndices(1, 3)
+		require.NoError(t, err)
+		require.NotNil(t, extracted)
+		require.Equal(t, 2, extracted.NumLeaves())
 	})
 }
 

--- a/lib/tree/tree_test.go
+++ b/lib/tree/tree_test.go
@@ -435,10 +435,8 @@ func TestTreeExtractPathForCoSigners(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		extracted, err := tree.ExtractPathForCoSigners(nil)
-		require.Error(t, err)
-		require.Nil(t, extracted)
-		require.Contains(t, err.Error(), "target key cannot be nil")
+		_, err = tree.ExtractPathForCoSigners(nil)
+		require.ErrorContains(t, err, "target key cannot be nil")
 	})
 
 	t.Run("rejects empty target keys", func(t *testing.T) {
@@ -460,10 +458,9 @@ func TestTreeExtractPathForCoSigners(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		extracted, err := tree.ExtractPathForCoSigners()
-		require.Error(t, err)
-		require.Nil(t, extracted)
-		require.Contains(t, err.Error(), "at least one target key required")
+		_, err = tree.ExtractPathForCoSigners()
+		require.ErrorContains(t, err, "at least one target key "+
+			"required")
 	})
 }
 

--- a/lib/tx/forfeit_test.go
+++ b/lib/tx/forfeit_test.go
@@ -109,7 +109,7 @@ func TestForfeitTransactionFlow(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	connectorPath, err := connectorTree.ExtractPathForIndex(3)
+	connectorPath, err := connectorTree.ExtractPathForIndices(3)
 	require.NoError(t, err)
 	connectorLeaf := connectorPath.Root.GetLeafNodes()[0]
 

--- a/lib/types/boarding.go
+++ b/lib/types/boarding.go
@@ -26,6 +26,11 @@ type OperatorTerms struct {
 	// delay will give the server time to respond to unilateral spends of
 	// a VTXO that has been forfeit or spent.
 	VTXOExitDelay uint32
+
+	// ForfeitScript is the output script that clients must use for the
+	// penalty output in forfeit transactions. This allows the server to
+	// claim forfeited funds.
+	ForfeitScript []byte
 }
 
 // JoinRoundRequest represents a participant's request to join a round.
@@ -140,23 +145,18 @@ type ForfeitTxSig struct {
 	ClientVTXOSig *schnorr.Signature
 }
 
-// ConnectorOutputInfo contains the information about a connector output
-// in the batch transaction. A batch transaction can have multiple connector
-// outputs, each with its own connector VTX tree.
-type ConnectorOutputInfo struct {
-	// Idx is the index of this connector output in the batch transaction.
-	Idx int
+// ConnectorLeafInfo contains information about a connector leaf assigned to a
+// specific forfeit request.
+type ConnectorLeafInfo struct {
+	// LeafOutpoint is the outpoint of the connector leaf that the forfeit
+	// transaction should spend. This is the actual outpoint from the leaf
+	// transaction in the connector tree.
+	LeafOutpoint wire.OutPoint
 
-	// NumLeaves is the number of leaves in the connector VTX tree for this
-	// connector output.
-	NumLeaves int
-
-	// ConnectorKey is the key that the operator will use as its key for
-	// each output in the connector VTX tree.
-	ConnectorKey *btcec.PublicKey
-
-	// Tree is the connector VTX tree for this connector output.
-	Tree *tree.Tree
+	// LeafOutput is the transaction output for the connector leaf. This
+	// contains the value and pkScript needed to construct the forfeit
+	// transaction witness.
+	LeafOutput *wire.TxOut
 }
 
 // BatchOutputInfo contains the information about a batch output in the
@@ -194,8 +194,8 @@ type ClientBatchInfo struct {
 	// match the number of VTXO requests made by the client.
 	BatchOutputs []*BatchOutputInfo
 
-	// ConnectorOutputs contains the connector output info for each
-	// connector output that is relevant to the client. The number of
-	// connector leaves should match the number of connector requests.
-	ConnectorOutputs []*ConnectorOutputInfo
+	// ConnectorLeafMap maps each forfeited VTXO outpoint to its assigned
+	// connector leaf information. This allows the client to determine which
+	// connector leaf corresponds to each of their forfeit requests.
+	ConnectorLeafMap map[wire.OutPoint]*ConnectorLeafInfo
 }


### PR DESCRIPTION
- add forfeit script field and map connector leaves directly to forfeited VTXOs so clients know which leaf/output to spend
- update tree extraction helpers to accept multiple cosigners/leaf indices, enabling multi-path subtree delivery with expanded tests and usages
- extend Makefile unit targets with per-package filters, logging/timeout options, and a debug test shortcut plus updated help examples