### PR TITLE
baselib/actor: add abstract Mailbox interface

### DIFF
--- a/baselib/actor/actor.go
+++ b/baselib/actor/actor.go
@@ -45,7 +45,7 @@ type Actor[M Message, R any] struct {
 	behavior ActorBehavior[M, R]
 
 	// mailbox is the incoming message queue for the actor.
-	mailbox chan envelope[M, R]
+	mailbox Mailbox[M, R]
 
 	// ctx is the context governing the actor's lifecycle.
 	ctx context.Context
@@ -73,20 +73,16 @@ type Actor[M Message, R any] struct {
 func NewActor[M Message, R any](cfg ActorConfig[M, R]) *Actor[M, R] {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	// Ensure MailboxSize has a sane default if not specified or zero. A
-	// capacity of 0 would make the channel unbuffered, which is generally
-	// not desired for actor mailboxes.
+	// Ensure MailboxSize has a sane default if not specified or zero.
 	mailboxCapacity := cfg.MailboxSize
 	if mailboxCapacity <= 0 {
-		// Default to a small capacity if an invalid one is given. This
-		// could also come from a global constant.
 		mailboxCapacity = 1
 	}
 
 	actor := &Actor[M, R]{
 		id:       cfg.ID,
 		behavior: cfg.Behavior,
-		mailbox:  make(chan envelope[M, R], mailboxCapacity),
+		mailbox:  NewChannelMailbox[M, R](ctx, mailboxCapacity),
 		ctx:      ctx,
 		cancel:   cancel,
 		dlo:      cfg.DLO,
@@ -108,59 +104,53 @@ func (a *Actor[M, R]) Start() {
 	})
 }
 
-// process is the main event loop for the actor. It continuously monitors its
-// mailbox for incoming messages and its context for cancellation signals.
+// process is the main event loop for the actor. It receives messages from the
+// mailbox and processes them using the actor's behavior.
 func (a *Actor[M, R]) process() {
-	for {
-		select {
-		case env := <-a.mailbox:
-			result := a.behavior.Receive(a.ctx, env.message)
+	// Process messages from the mailbox using the iterator pattern. The
+	// iterator will stop when the actor's context is cancelled.
+	for env := range a.mailbox.Receive(a.ctx) {
+		result := a.behavior.Receive(a.ctx, env.message)
 
-			// If a promise was provided (i.e., it was an "ask"
-			// operation), complete the promise with the result from
-			// the behavior.
-			if env.promise != nil {
-				env.promise.Complete(result)
-			}
+		// If a promise was provided (i.e., it was an "ask" operation),
+		// complete the promise with the result from the behavior.
+		if env.promise != nil {
+			env.promise.Complete(result)
+		}
+	}
 
-		// The actor's context has been cancelled, signaling a stop
-		// request. Exit the processing loop to terminate the actor's
-		// goroutine. Before exiting, drain any remaining messages from
-		// the mailbox.
-		case <-a.ctx.Done():
-			// Close the mailbox to prevent new incoming messages
-			// and to allow the range operator below to terminate.
-			close(a.mailbox)
+	// The actor's context has been cancelled. Close the mailbox to prevent
+	// new messages from being enqueued, then drain any remaining messages
+	// to the DLO.
+	a.mailbox.Close()
 
-			// Drain any remaining messages.
-			for env := range a.mailbox {
-				// If a DLO is configured, send the original
-				// message there for auditing or potential
-				// manual reprocessing.
-				if a.dlo != nil {
-					a.dlo.Tell(
-						context.Background(),
-						env.message,
-					)
-				}
+	// Drain any remaining messages that were enqueued before the mailbox
+	// was closed.
+	for env := range a.mailbox.Drain() {
+		// If a DLO is configured, send the original message there for
+		// auditing or potential manual reprocessing.
+		if a.dlo != nil {
+			a.dlo.Tell(context.Background(), env.message)
+		}
 
-				// If it was an Ask, complete the promise with
-				// an error indicating the actor terminated.
-				if env.promise != nil {
-					env.promise.Complete(fn.Err[R](
-						ErrActorTerminated),
-					)
-				}
-			}
-
-			return
+		// If it was an Ask, complete the promise with an error
+		// indicating the actor terminated.
+		if env.promise != nil {
+			env.promise.Complete(fn.Err[R](ErrActorTerminated))
 		}
 	}
 }
 
 // Stop signals the actor to terminate its processing loop and shut down.
 // This is achieved by cancelling the actor's internal context. The actor's
-// goroutine will exit once it detects the context cancellation.
+// goroutine will exit once it detects the context cancellation, then close
+// the mailbox and drain remaining messages to the DLO.
+//
+// Note: Messages cannot be lost between Receive() exiting and Close() being
+// called because Send() checks actorCtx.Err() first, failing fast after
+// context cancellation. Any message that passes the actorCtx check before
+// cancellation will either complete its send or see actorCtx.Done() in the
+// select and return false.
 func (a *Actor[M, R]) Stop() {
 	a.stopOnce.Do(func() {
 		a.cancel()
@@ -179,26 +169,20 @@ type actorRefImpl[M Message, R any] struct {
 //
 //nolint:lll
 func (ref *actorRefImpl[M, R]) Tell(ctx context.Context, msg M) {
-	// If the actor's own context is already done, don't try to send.
-	// Route to DLO if available.
-	if ref.actor.ctx.Err() != nil {
-		ref.trySendToDLO(msg)
-		return
-	}
+	// Attempt to send the message to the mailbox. The mailbox's Send
+	// method handles context cancellation and actor termination internally.
+	env := envelope[M, R]{message: msg, promise: nil}
+	ok := ref.actor.mailbox.Send(ctx, env)
 
-	select {
-	// Message successfully enqueued in the actor's mailbox.
-	case ref.actor.mailbox <- envelope[M, R]{message: msg, promise: nil}:
-
-	// The context for the Tell operation was cancelled before the message
-	// could be enqueued. The message is dropped.
-	case <-ctx.Done():
-
-	// The actor itself has been stopped/terminated.
-	case <-ref.actor.ctx.Done():
-		// If the actor is terminated and has a DLO, send the message
-		// there. Otherwise, it's dropped.
-		ref.trySendToDLO(msg)
+	// If the send failed, determine whether to route to DLO. We only send
+	// to the DLO when the failure was due to actor termination or mailbox
+	// closure (actor-side failures). If the caller's context was cancelled,
+	// the message is intentionally dropped to preserve prior semantics
+	// where caller-aborted messages are not revived via the DLO.
+	if !ok {
+		if ctx.Err() == nil || ref.actor.ctx.Err() != nil {
+			ref.trySendToDLO(msg)
+		}
 	}
 }
 
@@ -208,7 +192,8 @@ func (ref *actorRefImpl[M, R]) Tell(ctx context.Context, msg M) {
 //
 //nolint:lll
 func (ref *actorRefImpl[M, R]) Ask(ctx context.Context, msg M) Future[R] {
-	// Create a new promise that will be fulfilled with the actor's response.
+	// Create a new promise that will be fulfilled with the actor's
+	// response.
 	promise := NewPromise[R]()
 
 	// If the actor's own context is already done, complete the promise with
@@ -219,29 +204,33 @@ func (ref *actorRefImpl[M, R]) Ask(ctx context.Context, msg M) Future[R] {
 		return promise.Future()
 	}
 
-	// Check if the context is already done before attempting to send. This
-	// ensures deterministic behavior and prevents a race where the message
-	// could be enqueued even though the context was already cancelled.
-	if ctx.Err() != nil {
-		promise.Complete(fn.Err[R](ctx.Err()))
-		return promise.Future()
-	}
+	// Attempt to send the message with the promise to the mailbox. The
+	// mailbox's Send method handles context cancellation and actor
+	// termination internally.
+	env := envelope[M, R]{message: msg, promise: promise}
+	ok := ref.actor.mailbox.Send(ctx, env)
 
-	select {
-	// Attempt to send the message along with its promise to the actor's
-	// mailbox.
-	case ref.actor.mailbox <- envelope[M, R]{message: msg, promise: promise}:
+	// If the send failed (mailbox closed, context cancelled, or actor
+	// terminated), complete the promise with an appropriate error.
+	if !ok {
+		// Determine the appropriate error based on the state. Check
+		// the actor context first as actor termination takes
+		// precedence over caller context cancellation.
+		if ref.actor.ctx.Err() != nil {
+			promise.Complete(fn.Err[R](ErrActorTerminated))
+		} else {
+			err := ctx.Err()
+			if err == nil {
+				// This indicates an unexpected state: the send
+				// failed, but neither the actor nor the caller
+				// context appears to be done. Default to
+				// ErrActorTerminated as the most likely cause
+				// (e.g., mailbox was closed directly).
+				err = ErrActorTerminated
+			}
 
-	// The context for the Ask operation was cancelled before the message
-	// could be enqueued. Complete the promise with the context's error to
-	// unblock the caller.
-	case <-ctx.Done():
-		promise.Complete(fn.Err[R](ctx.Err()))
-
-	// The actor's context was cancelled (e.g., actor stopped) while this
-	// Ask operation was attempting to send (e.g., mailbox was full).
-	case <-ref.actor.ctx.Done():
-		promise.Complete(fn.Err[R](ErrActorTerminated))
+			promise.Complete(fn.Err[R](err))
+		}
 	}
 
 	// Return the future associated with the promise, allowing the caller to

--- a/baselib/actor/channel_mailbox.go
+++ b/baselib/actor/channel_mailbox.go
@@ -1,0 +1,206 @@
+package actor
+
+import (
+	"context"
+	"iter"
+	"sync"
+	"sync/atomic"
+)
+
+// ChannelMailbox is a Mailbox implementation backed by a Go channel. It
+// provides thread-safe send and receive operations with support for context
+// cancellation.
+type ChannelMailbox[M Message, R any] struct {
+	// ch is the underlying channel used to store envelopes.
+	ch chan envelope[M, R]
+
+	// closed indicates whether the mailbox has been closed. Uses atomic
+	// operations for lock-free reads.
+	closed atomic.Bool
+
+	// mu protects send operations to prevent sending to a closed channel.
+	mu sync.RWMutex
+
+	// closeOnce ensures Close() is executed exactly once.
+	closeOnce sync.Once
+
+	// actorCtx is the context governing the actor's lifecycle. When this
+	// context is cancelled, receive operations will terminate.
+	actorCtx context.Context
+}
+
+// NewChannelMailbox creates a new channel-based mailbox with the given
+// capacity and actor context. If capacity is 0 or negative, it defaults to 1
+// to ensure the mailbox is buffered.
+func NewChannelMailbox[M Message, R any](
+	actorCtx context.Context, capacity int) *ChannelMailbox[M, R] {
+
+	if capacity <= 0 {
+		capacity = 1
+	}
+
+	return &ChannelMailbox[M, R]{
+		ch:       make(chan envelope[M, R], capacity),
+		actorCtx: actorCtx,
+	}
+}
+
+// Send attempts to send an envelope to the mailbox. It blocks until either the
+// envelope is accepted, the caller's context is cancelled, or the actor's
+// context is cancelled. Returns true if the envelope was successfully sent,
+// false otherwise.
+func (m *ChannelMailbox[M, R]) Send(ctx context.Context,
+	env envelope[M, R]) bool {
+
+	// Check contexts before acquiring the lock as an optimization. This
+	// allows fast-path rejection when contexts are already cancelled,
+	// avoiding unnecessary lock acquisition. The select statement below
+	// still handles the case where contexts are cancelled after this check.
+	if ctx.Err() != nil {
+		return false
+	}
+	if m.actorCtx.Err() != nil {
+		return false
+	}
+
+	// Hold the read lock for the entire send operation to prevent
+	// send-on-closed-channel panics. The read lock allows concurrent sends
+	// but blocks when Close() acquires the write lock.
+	//
+	// Safety: The channel send in the select below cannot panic because:
+	// 1. We hold the read lock for the entire operation
+	// 2. Close() must acquire the write lock before closing the channel
+	// 3. The write lock cannot be acquired while any read lock is held
+	// 4. Therefore, the channel cannot be closed while we're in this block
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if m.closed.Load() {
+		return false
+	}
+
+	// Attempt to send the envelope, respecting both the caller's context
+	// and the actor's context for cancellation.
+	select {
+	case m.ch <- env:
+		return true
+
+	case <-ctx.Done():
+		return false
+
+	case <-m.actorCtx.Done():
+		return false
+	}
+}
+
+// TrySend attempts to send an envelope to the mailbox without blocking. It
+// returns true if the envelope was successfully sent, false if the mailbox is
+// full, closed, or the actor has been terminated.
+func (m *ChannelMailbox[M, R]) TrySend(env envelope[M, R]) bool {
+	// Check if the actor has been terminated before attempting to send.
+	// This ensures TrySend respects the actor's lifecycle consistently
+	// with Send.
+	if m.actorCtx.Err() != nil {
+		return false
+	}
+
+	// Hold the read lock for the entire send operation to prevent
+	// send-on-closed-channel panics.
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if m.closed.Load() {
+		return false
+	}
+
+	select {
+	case m.ch <- env:
+		return true
+	default:
+		return false
+	}
+}
+
+// Receive returns an iterator over envelopes in the mailbox. The iterator will
+// yield envelopes as they arrive and will stop when the provided context is
+// cancelled or when the mailbox is closed and drained.
+func (m *ChannelMailbox[M, R]) Receive(
+	ctx context.Context) iter.Seq[envelope[M, R]] {
+
+	return func(yield func(envelope[M, R]) bool) {
+		for {
+			select {
+			case env, ok := <-m.ch:
+				// Channel was closed, stop iteration.
+				if !ok {
+					return
+				}
+
+				// Yield the envelope to the consumer. If yield
+				// returns false, the consumer wants to stop
+				// iteration early.
+				if !yield(env) {
+					return
+				}
+
+			case <-ctx.Done():
+				// Context was cancelled, stop iteration.
+				return
+			}
+		}
+	}
+}
+
+// Close closes the mailbox, preventing any further sends. This method is safe
+// to call multiple times; only the first call will have an effect. The write
+// lock blocks concurrent sends, preventing send-on-closed-channel panics.
+func (m *ChannelMailbox[M, R]) Close() {
+	m.closeOnce.Do(func() {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+
+		m.closed.Store(true)
+		close(m.ch)
+	})
+}
+
+// IsClosed returns true if the mailbox has been closed. This method performs a
+// lock-free read using atomic operations.
+func (m *ChannelMailbox[M, R]) IsClosed() bool {
+	return m.closed.Load()
+}
+
+// Drain returns an iterator over any remaining envelopes in the mailbox. This
+// should only be called after Close() has been invoked. The iterator will
+// yield all remaining envelopes and then stop. If the mailbox is not closed,
+// it returns immediately without draining.
+func (m *ChannelMailbox[M, R]) Drain() iter.Seq[envelope[M, R]] {
+	return func(yield func(envelope[M, R]) bool) {
+		// Only drain if the mailbox has been closed.
+		if !m.IsClosed() {
+			return
+		}
+
+		// Drain remaining messages using a non-blocking select to avoid
+		// hanging if the channel is empty.
+		for {
+			select {
+			case env, ok := <-m.ch:
+				// Channel was closed and fully drained.
+				if !ok {
+					return
+				}
+
+				// Yield the envelope. If yield returns false, the
+				// consumer wants to stop early.
+				if !yield(env) {
+					return
+				}
+
+			default:
+				// No more messages available, return.
+				return
+			}
+		}
+	}
+}

--- a/baselib/actor/interface.go
+++ b/baselib/actor/interface.go
@@ -3,6 +3,7 @@ package actor
 import (
 	"context"
 	"fmt"
+	"iter"
 
 	"github.com/lightningnetwork/lnd/fn/v2"
 )
@@ -115,4 +116,48 @@ type ActorBehavior[M Message, R any] interface {
 	// context is the actor's internal context, which can be used to
 	// detect actor shutdown requests.
 	Receive(actorCtx context.Context, msg M) fn.Result[R]
+}
+
+// Mailbox defines the interface for an actor's message queue. This abstraction
+// allows different mailbox strategies to be plugged in, such as priority
+// queues, durable on-disk queues, or backpressure-aware mailboxes, without
+// changing the actor implementation.
+//
+// Thread Safety:
+//   - Send and TrySend may be called concurrently from multiple goroutines.
+//   - Receive should only be called from a single goroutine (the actor's
+//     process loop).
+//   - Close may be called concurrently with Send/TrySend and is idempotent.
+//   - IsClosed may be called concurrently from any goroutine.
+//   - Drain should only be called after Close and from a single goroutine.
+//   - Send and TrySend return false after Close has been called.
+type Mailbox[M Message, R any] interface {
+	// Send attempts to send an envelope to the mailbox, blocking until
+	// either the envelope is accepted, the provided context is cancelled,
+	// or the actor's context is cancelled. It returns true if the envelope
+	// was successfully sent, false otherwise.
+	Send(ctx context.Context, env envelope[M, R]) bool
+
+	// TrySend attempts to send an envelope to the mailbox without
+	// blocking. It returns true if the envelope was successfully sent,
+	// false if the mailbox is full or closed.
+	TrySend(env envelope[M, R]) bool
+
+	// Receive returns an iterator over envelopes in the mailbox. The
+	// iterator will block when the mailbox is empty and yield envelopes as
+	// they arrive. The iterator will stop when the provided context is
+	// cancelled or when the mailbox is closed.
+	Receive(ctx context.Context) iter.Seq[envelope[M, R]]
+
+	// Close closes the mailbox, preventing any further sends. After
+	// closing, Receive will yield any remaining envelopes and then stop.
+	Close()
+
+	// IsClosed returns true if the mailbox has been closed.
+	IsClosed() bool
+
+	// Drain returns an iterator over any remaining envelopes in the
+	// mailbox after it has been closed. This is useful for cleanup logic
+	// during actor shutdown.
+	Drain() iter.Seq[envelope[M, R]]
 }

--- a/baselib/actor/mailbox_test.go
+++ b/baselib/actor/mailbox_test.go
@@ -1,0 +1,612 @@
+package actor
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// testMessage is a simple message type for testing.
+type testMessage struct {
+	BaseMessage
+	value int
+}
+
+func (m *testMessage) MessageType() string {
+	return "testMessage"
+}
+
+// TestChannelMailboxSend tests that Send successfully delivers an envelope to
+// the mailbox.
+func TestChannelMailboxSend(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	actorCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	mailbox := NewChannelMailbox[*testMessage, string](actorCtx, 10)
+	defer mailbox.Close()
+
+	msg := &testMessage{value: 42}
+	env := envelope[*testMessage, string]{
+		message: msg,
+		promise: nil,
+	}
+
+	// Send should succeed.
+	ok := mailbox.Send(ctx, env)
+	require.True(t, ok, "Send should succeed")
+
+	// Verify the message can be received.
+	for receivedEnv := range mailbox.Receive(ctx) {
+		require.Equal(t, msg.value, receivedEnv.message.value)
+		break
+	}
+}
+
+// TestChannelMailboxSendContextCancelled tests that Send returns false when
+// the caller's context is cancelled before the send completes.
+func TestChannelMailboxSendContextCancelled(t *testing.T) {
+	t.Parallel()
+
+	actorCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Create a mailbox with capacity 0 (will default to 1) and fill it.
+	mailbox := NewChannelMailbox[*testMessage, string](actorCtx, 1)
+	defer mailbox.Close()
+
+	// Fill the mailbox.
+	env := envelope[*testMessage, string]{
+		message: &testMessage{value: 1},
+		promise: nil,
+	}
+	ok := mailbox.TrySend(env)
+	require.True(t, ok, "First send should succeed")
+
+	// Create a cancelled context and attempt to send. This should return
+	// false immediately.
+	cancelledCtx, cancelFunc := context.WithCancel(context.Background())
+	cancelFunc()
+
+	ok = mailbox.Send(cancelledCtx, envelope[*testMessage, string]{
+		message: &testMessage{value: 2},
+		promise: nil,
+	})
+	require.False(t, ok, "Send with cancelled context should fail")
+}
+
+// TestChannelMailboxSendToClosedMailbox tests that Send returns false when
+// attempting to send to a closed mailbox.
+func TestChannelMailboxSendToClosedMailbox(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	actorCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	mailbox := NewChannelMailbox[*testMessage, string](actorCtx, 10)
+	mailbox.Close()
+
+	env := envelope[*testMessage, string]{
+		message: &testMessage{value: 42},
+		promise: nil,
+	}
+
+	// Send should fail because the mailbox is closed.
+	ok := mailbox.Send(ctx, env)
+	require.False(t, ok, "Send to closed mailbox should fail")
+}
+
+// TestChannelMailboxTrySend tests the non-blocking TrySend operation.
+func TestChannelMailboxTrySend(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	actorCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	mailbox := NewChannelMailbox[*testMessage, string](actorCtx, 1)
+	defer mailbox.Close()
+
+	env1 := envelope[*testMessage, string]{
+		message: &testMessage{value: 1},
+		promise: nil,
+	}
+
+	// First TrySend should succeed.
+	ok := mailbox.TrySend(env1)
+	require.True(t, ok, "First TrySend should succeed")
+
+	env2 := envelope[*testMessage, string]{
+		message: &testMessage{value: 2},
+		promise: nil,
+	}
+
+	// Second TrySend should fail because the mailbox is full.
+	ok = mailbox.TrySend(env2)
+	require.False(t, ok, "TrySend to full mailbox should fail")
+
+	// Receive the first message.
+	for receivedEnv := range mailbox.Receive(ctx) {
+		require.Equal(t, 1, receivedEnv.message.value)
+		break
+	}
+
+	// Now TrySend should succeed again.
+	ok = mailbox.TrySend(env2)
+	require.True(t, ok, "TrySend after receive should succeed")
+}
+
+// TestChannelMailboxTrySendToClosed tests that TrySend returns false when
+// attempting to send to a closed mailbox.
+func TestChannelMailboxTrySendToClosed(t *testing.T) {
+	t.Parallel()
+
+	actorCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mailbox := NewChannelMailbox[*testMessage, string](actorCtx, 10)
+	mailbox.Close()
+
+	env := envelope[*testMessage, string]{
+		message: &testMessage{value: 42},
+		promise: nil,
+	}
+
+	// TrySend should fail because the mailbox is closed.
+	ok := mailbox.TrySend(env)
+	require.False(t, ok, "TrySend to closed mailbox should fail")
+}
+
+// TestChannelMailboxReceive tests that Receive yields envelopes from the
+// mailbox using the iterator pattern.
+func TestChannelMailboxReceive(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	actorCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	mailbox := NewChannelMailbox[*testMessage, string](actorCtx, 10)
+	defer mailbox.Close()
+
+	// Send multiple messages.
+	numMessages := 5
+	for i := 0; i < numMessages; i++ {
+		env := envelope[*testMessage, string]{
+			message: &testMessage{value: i},
+			promise: nil,
+		}
+		ok := mailbox.Send(ctx, env)
+		require.True(t, ok, "Send should succeed")
+	}
+
+	// Receive messages using the iterator.
+	receivedCount := 0
+	for env := range mailbox.Receive(ctx) {
+		require.Equal(t, receivedCount, env.message.value)
+		receivedCount++
+
+		// Stop after receiving all messages.
+		if receivedCount == numMessages {
+			break
+		}
+	}
+
+	require.Equal(t, numMessages, receivedCount,
+		"Should receive all sent messages")
+}
+
+// TestChannelMailboxReceiveContextCancelled tests that Receive stops iteration
+// when the context is cancelled.
+func TestChannelMailboxReceiveContextCancelled(t *testing.T) {
+	t.Parallel()
+
+	actorCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mailbox := NewChannelMailbox[*testMessage, string](actorCtx, 10)
+	defer mailbox.Close()
+
+	// Send a message.
+	env := envelope[*testMessage, string]{
+		message: &testMessage{value: 1},
+		promise: nil,
+	}
+	ok := mailbox.Send(context.Background(), env)
+	require.True(t, ok, "Send should succeed")
+
+	// Create a context that will be cancelled.
+	receiveCtx, receiveCancel := context.WithCancel(context.Background())
+
+	// Start receiving in a goroutine.
+	receivedCount := atomic.Int32{}
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		for env := range mailbox.Receive(receiveCtx) {
+			receivedCount.Add(1)
+			require.Equal(t, 1, env.message.value)
+
+			// Cancel the context after receiving the first message.
+			receiveCancel()
+		}
+	}()
+
+	// Wait for the goroutine to finish.
+	select {
+	case <-done:
+		// Iteration stopped due to context cancellation.
+	case <-time.After(2 * time.Second):
+		t.Fatal("Receive did not stop after context cancellation")
+	}
+
+	require.Equal(t, int32(1), receivedCount.Load(),
+		"Should receive exactly one message")
+}
+
+// TestChannelMailboxCloseAndIsClosed tests the Close and IsClosed methods.
+func TestChannelMailboxCloseAndIsClosed(t *testing.T) {
+	t.Parallel()
+
+	actorCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mailbox := NewChannelMailbox[*testMessage, string](actorCtx, 10)
+
+	// Initially not closed.
+	require.False(t, mailbox.IsClosed(), "Mailbox should not be closed")
+
+	// Close the mailbox.
+	mailbox.Close()
+
+	// Now it should be closed.
+	require.True(t, mailbox.IsClosed(), "Mailbox should be closed")
+
+	// Calling Close again should be safe (idempotent).
+	mailbox.Close()
+	require.True(t, mailbox.IsClosed(), "Mailbox should still be closed")
+}
+
+// TestChannelMailboxDrain tests that Drain returns remaining envelopes after
+// the mailbox is closed.
+func TestChannelMailboxDrain(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	actorCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	mailbox := NewChannelMailbox[*testMessage, string](actorCtx, 10)
+
+	// Send multiple messages.
+	numMessages := 5
+	for i := 0; i < numMessages; i++ {
+		env := envelope[*testMessage, string]{
+			message: &testMessage{value: i},
+			promise: nil,
+		}
+		ok := mailbox.Send(ctx, env)
+		require.True(t, ok, "Send should succeed")
+	}
+
+	// Close the mailbox without receiving the messages.
+	mailbox.Close()
+
+	// Drain should yield all the messages.
+	drainedCount := 0
+	for env := range mailbox.Drain() {
+		require.Equal(t, drainedCount, env.message.value)
+		drainedCount++
+	}
+
+	require.Equal(t, numMessages, drainedCount,
+		"Drain should yield all remaining messages")
+}
+
+// TestChannelMailboxConcurrentSends tests that multiple goroutines can send to
+// the mailbox concurrently without causing panics or data races.
+func TestChannelMailboxConcurrentSends(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	actorCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	numSenders := 10
+	messagesPerSender := 100
+	totalMessages := numSenders * messagesPerSender
+
+	// Use a large enough mailbox to hold all messages without blocking.
+	mailbox := NewChannelMailbox[*testMessage, string](
+		actorCtx, totalMessages,
+	)
+	defer mailbox.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(numSenders)
+
+	// Launch multiple senders.
+	for i := 0; i < numSenders; i++ {
+		go func(senderID int) {
+			defer wg.Done()
+
+			for j := 0; j < messagesPerSender; j++ {
+				env := envelope[*testMessage, string]{
+					message: &testMessage{
+						value: senderID*1000 + j,
+					},
+					promise: nil,
+				}
+				ok := mailbox.Send(ctx, env)
+				require.True(t, ok, "Send should succeed")
+			}
+		}(i)
+	}
+
+	// Wait for all senders to finish.
+	wg.Wait()
+
+	// Verify that all messages were received.
+	receivedCount := 0
+
+	for range mailbox.Receive(ctx) {
+		receivedCount++
+		if receivedCount == totalMessages {
+			break
+		}
+	}
+
+	require.Equal(t, totalMessages, receivedCount,
+		"Should receive all sent messages")
+}
+
+// TestChannelMailboxZeroCapacity tests that a mailbox with zero capacity
+// defaults to capacity 1.
+func TestChannelMailboxZeroCapacity(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	actorCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Create a mailbox with zero capacity, which should default to 1.
+	mailbox := NewChannelMailbox[*testMessage, string](actorCtx, 0)
+	defer mailbox.Close()
+
+	env := envelope[*testMessage, string]{
+		message: &testMessage{value: 42},
+		promise: nil,
+	}
+
+	// TrySend should succeed because the mailbox has at least capacity 1.
+	ok := mailbox.TrySend(env)
+	require.True(t, ok, "TrySend should succeed with default capacity")
+
+	// Verify the message can be received.
+	for receivedEnv := range mailbox.Receive(ctx) {
+		require.Equal(t, 42, receivedEnv.message.value)
+		break
+	}
+}
+
+// TestChannelMailboxSendWithActorContextCancelled tests that Send returns
+// false when the actor's context is cancelled.
+func TestChannelMailboxSendWithActorContextCancelled(t *testing.T) {
+	t.Parallel()
+
+	actorCtx, actorCancel := context.WithCancel(context.Background())
+
+	// Create a mailbox with capacity 1 and fill it.
+	mailbox := NewChannelMailbox[*testMessage, string](actorCtx, 1)
+	defer mailbox.Close()
+
+	// Fill the mailbox.
+	env1 := envelope[*testMessage, string]{
+		message: &testMessage{value: 1},
+		promise: nil,
+	}
+	ok := mailbox.TrySend(env1)
+	require.True(t, ok, "First send should succeed")
+
+	// Cancel the actor context.
+	actorCancel()
+
+	// Attempt to send another message. This should fail because the actor
+	// context is cancelled.
+	env2 := envelope[*testMessage, string]{
+		message: &testMessage{value: 2},
+		promise: nil,
+	}
+	ok = mailbox.Send(context.Background(), env2)
+	require.False(t, ok, "Send should fail when actor context is cancelled")
+}
+
+// TestChannelMailboxReceiveStopsOnClose tests that the Receive iterator stops
+// when the mailbox is closed.
+func TestChannelMailboxReceiveStopsOnClose(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	actorCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	mailbox := NewChannelMailbox[*testMessage, string](actorCtx, 10)
+
+	// Send a few messages.
+	for i := 0; i < 3; i++ {
+		env := envelope[*testMessage, string]{
+			message: &testMessage{value: i},
+			promise: nil,
+		}
+		ok := mailbox.Send(ctx, env)
+		require.True(t, ok, "Send should succeed")
+	}
+
+	// Start receiving in a goroutine.
+	receivedCount := atomic.Int32{}
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		for range mailbox.Receive(ctx) {
+			receivedCount.Add(1)
+		}
+	}()
+
+	// Give the receiver time to process messages.
+	time.Sleep(100 * time.Millisecond)
+
+	// Close the mailbox.
+	mailbox.Close()
+
+	// Wait for the receiver to finish.
+	select {
+	case <-done:
+		// Iteration stopped after mailbox was closed.
+	case <-time.After(2 * time.Second):
+		t.Fatal("Receive did not stop after mailbox close")
+	}
+
+	require.Equal(t, int32(3), receivedCount.Load(),
+		"Should receive all messages before close")
+}
+
+// TestActorDrainToDLO tests that when an actor is stopped, any unprocessed
+// messages in the mailbox are drained and sent to the Dead Letter Office.
+func TestActorDrainToDLO(t *testing.T) {
+	t.Parallel()
+
+	// Create a DLO to capture drained messages.
+	dloMsgs := make(chan Message, 10)
+	dloBehavior := NewFunctionBehavior(
+		func(_ context.Context, msg Message) fn.Result[any] {
+			dloMsgs <- msg
+			return fn.Ok[any](nil)
+		},
+	)
+	dloActor := NewActor(ActorConfig[Message, any]{
+		ID:          "test-dlo",
+		Behavior:    dloBehavior,
+		MailboxSize: 10,
+	})
+	dloActor.Start()
+	defer dloActor.Stop()
+
+	// Create a blocking behavior that will hold the actor busy.
+	blockCh := make(chan struct{})
+	blockingBehavior := NewFunctionBehavior(
+		func(ctx context.Context, _ *testMessage) fn.Result[string] {
+			select {
+			case <-blockCh:
+				return fn.Ok("done")
+			case <-ctx.Done():
+				return fn.Err[string](ctx.Err())
+			}
+		},
+	)
+
+	// Create the main actor with the DLO configured.
+	actor := NewActor(ActorConfig[*testMessage, string]{
+		ID:          "test-actor",
+		Behavior:    blockingBehavior,
+		DLO:         dloActor.Ref(),
+		MailboxSize: 10,
+	})
+	actor.Start()
+
+	ctx := context.Background()
+
+	// Send several messages. The first one will block the actor, causing
+	// subsequent messages to queue up in the mailbox.
+	numMessages := 5
+	for i := 0; i < numMessages; i++ {
+		actor.Ref().Tell(ctx, &testMessage{value: i})
+	}
+
+	// Give messages time to queue up.
+	time.Sleep(50 * time.Millisecond)
+
+	// Stop the actor while messages are still queued. This should drain the
+	// queued messages to the DLO.
+	actor.Stop()
+
+	// The blocking message's context will be cancelled, and it won't be sent
+	// to DLO since it was being processed. The remaining queued messages
+	// should be drained to the DLO.
+	receivedCount := 0
+	timeout := time.After(2 * time.Second)
+	for receivedCount < numMessages-1 {
+		select {
+		case msg := <-dloMsgs:
+			testMsg, ok := msg.(*testMessage)
+			require.True(t, ok, "DLO received unexpected message type")
+			t.Logf("DLO received message with value: %d", testMsg.value)
+			receivedCount++
+
+		case <-timeout:
+			t.Fatalf("Timed out waiting for DLO messages. "+
+				"Received %d, expected %d",
+				receivedCount, numMessages-1)
+		}
+	}
+
+	// Verify we got the expected number of drained messages (all but the
+	// first one which was being processed).
+	require.Equal(t, numMessages-1, receivedCount,
+		"DLO should receive all queued messages except the one "+
+			"being processed")
+}
+
+// TestChannelMailboxWithPromises tests that envelopes with promises are
+// handled correctly.
+func TestChannelMailboxWithPromises(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	actorCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	mailbox := NewChannelMailbox[*testMessage, string](actorCtx, 10)
+	defer mailbox.Close()
+
+	// Create a promise for the response.
+	promise := NewPromise[string]()
+
+	env := envelope[*testMessage, string]{
+		message: &testMessage{value: 42},
+		promise: promise,
+	}
+
+	// Send the envelope with a promise.
+	ok := mailbox.Send(ctx, env)
+	require.True(t, ok, "Send should succeed")
+
+	// Receive the envelope and complete the promise.
+	for receivedEnv := range mailbox.Receive(ctx) {
+		require.Equal(t, 42, receivedEnv.message.value)
+		require.NotNil(t, receivedEnv.promise,
+			"Envelope should contain promise")
+
+		// Complete the promise.
+		receivedEnv.promise.Complete(fn.Ok("response"))
+		break
+	}
+
+	// Verify the promise was completed.
+	future := promise.Future()
+	result := future.Await(ctx)
+	response, err := result.Unpack()
+	require.NoError(t, err, "Promise should be completed successfully")
+	require.Equal(t, "response", response)
+}


### PR DESCRIPTION
This PR ports the abstract mailbox interface from lnd PR 10142, replacing direct channel usage in actors with a pluggable Mailbox interface. The implementation uses Go 1.23's iter.Seq pattern for clean message iteration and includes atomic synchronization to prevent race conditions.

The refactoring simplifies the Actor's process loop from ~50 lines to ~30 lines while enabling future mailbox strategies like priority queues or durable storage. All 15 new mailbox tests pass with the race detector, and the change is backward compatible.