### PR TITLE
baselib/actor: request deadlines and resource cleanup

### DIFF
--- a/baselib/PROTOFSM_ACTOR_GUIDE.md
+++ b/baselib/PROTOFSM_ACTOR_GUIDE.md
@@ -232,7 +232,7 @@ func main() {
 	system := actor.NewActorSystemWithConfig(actor.SystemConfig{
 		MailboxCapacity: 100,
 	})
-	defer system.Shutdown()
+	defer system.Shutdown(context.Background())
 
 	// Register shared actors.
 	storeActor := &StoreActorBehavior{store: NewStore()}
@@ -712,7 +712,7 @@ Test the full actor + FSM integration:
 func TestWorkflowIntegration(t *testing.T) {
 	ctx := context.Background()
 	system := actor.NewActorSystemWithConfig(actor.SystemConfig{})
-	defer system.Shutdown()
+	defer system.Shutdown(context.Background())
 
 	// Register actors.
 	actor.RegisterWithSystem(system, "store", StoreServiceKey, &StoreActorBehavior{})

--- a/baselib/actor/actor.go
+++ b/baselib/actor/actor.go
@@ -114,6 +114,8 @@ func NewActor[M Message, R any](cfg ActorConfig[M, R]) *Actor[M, R] {
 // exited before proceeding with resource cleanup.
 func (a *Actor[M, R]) Start() {
 	a.startOnce.Do(func() {
+		log.DebugS(a.ctx, "Starting actor", "actor_id", a.id)
+
 		if a.wg != nil {
 			a.wg.Add(1)
 		}
@@ -137,6 +139,11 @@ func (a *Actor[M, R]) process() {
 	// Process messages from the mailbox using the iterator pattern. The
 	// iterator will stop when the actor's context is cancelled.
 	for env := range a.mailbox.Receive(a.ctx) {
+		log.TraceS(a.ctx, "Actor processing message",
+			"actor_id", a.id,
+			"msg_type", env.message.MessageType(),
+			"is_ask", env.promise != nil)
+
 		result := a.behavior.Receive(a.ctx, env.message)
 
 		// If a promise was provided (i.e., it was an "ask" operation),
@@ -153,7 +160,15 @@ func (a *Actor[M, R]) process() {
 
 	// Drain any remaining messages that were enqueued before the mailbox
 	// was closed.
+	drainedCount := 0
 	for env := range a.mailbox.Drain() {
+		drainedCount++
+
+		log.TraceS(a.ctx, "Draining message from terminated actor",
+			"actor_id", a.id,
+			"msg_type", env.message.MessageType(),
+			"has_dlo", a.dlo != nil)
+
 		// If a DLO is configured, send the original message there for
 		// auditing or potential manual reprocessing.
 		if a.dlo != nil {
@@ -166,6 +181,10 @@ func (a *Actor[M, R]) process() {
 			env.promise.Complete(fn.Err[R](ErrActorTerminated))
 		}
 	}
+
+	log.DebugS(a.ctx, "Actor terminated",
+		"actor_id", a.id,
+		"drained_messages", drainedCount)
 }
 
 // Stop signals the actor to terminate its processing loop and shut down.
@@ -196,6 +215,10 @@ type actorRefImpl[M Message, R any] struct {
 //
 //nolint:lll
 func (ref *actorRefImpl[M, R]) Tell(ctx context.Context, msg M) {
+	log.TraceS(ctx, "Sending Tell message",
+		"actor_id", ref.actor.id,
+		"msg_type", msg.MessageType())
+
 	// Attempt to send the message to the mailbox. The mailbox's Send
 	// method handles context cancellation and actor termination internally.
 	env := envelope[M, R]{message: msg, promise: nil}
@@ -208,7 +231,15 @@ func (ref *actorRefImpl[M, R]) Tell(ctx context.Context, msg M) {
 	// where caller-aborted messages are not revived via the DLO.
 	if !ok {
 		if ctx.Err() == nil || ref.actor.ctx.Err() != nil {
+			log.DebugS(ctx, "Tell failed, routing to DLO",
+				"actor_id", ref.actor.id,
+				"msg_type", msg.MessageType())
+
 			ref.trySendToDLO(msg)
+		} else {
+			log.TraceS(ctx, "Tell failed, caller cancelled",
+				"actor_id", ref.actor.id,
+				"msg_type", msg.MessageType())
 		}
 	}
 }
@@ -219,6 +250,10 @@ func (ref *actorRefImpl[M, R]) Tell(ctx context.Context, msg M) {
 //
 //nolint:lll
 func (ref *actorRefImpl[M, R]) Ask(ctx context.Context, msg M) Future[R] {
+	log.TraceS(ctx, "Sending Ask message",
+		"actor_id", ref.actor.id,
+		"msg_type", msg.MessageType())
+
 	// Create a new promise that will be fulfilled with the actor's
 	// response.
 	promise := NewPromise[R]()
@@ -227,6 +262,10 @@ func (ref *actorRefImpl[M, R]) Ask(ctx context.Context, msg M) Future[R] {
 	// ErrActorTerminated and return immediately. This is the primary guard
 	// against trying to send to a stopped actor.
 	if ref.actor.ctx.Err() != nil {
+		log.DebugS(ctx, "Ask failed, actor already terminated",
+			"actor_id", ref.actor.id,
+			"msg_type", msg.MessageType())
+
 		promise.Complete(fn.Err[R](ErrActorTerminated))
 		return promise.Future()
 	}

--- a/baselib/actor/actor.go
+++ b/baselib/actor/actor.go
@@ -7,6 +7,54 @@ import (
 	"github.com/lightningnetwork/lnd/fn/v2"
 )
 
+// mergeContexts creates a new context that cancels when either parent context
+// cancels, enabling actors to respect both system shutdown and caller deadlines
+// simultaneously. It preserves the shortest deadline between the two contexts
+// to ensure the most restrictive timeout is honored.
+//
+// A background goroutine monitors both parent contexts and cancels the merged
+// context when either parent cancels. The goroutine exits as soon as any
+// cancellation is detected, preventing goroutine leaks. Callers must call the
+// returned cancel function to release resources when the merged context is no
+// longer needed.
+//
+// Performance note: This function spawns a goroutine for each call. For
+// high-throughput actors processing thousands of messages per second, this
+// overhead should be measured. The goroutine is short-lived and exits when
+// message processing completes.
+func mergeContexts(ctx1, ctx2 context.Context) (context.Context, context.CancelFunc) {
+	// Get deadlines from both contexts.
+	deadline1, hasDeadline1 := ctx1.Deadline()
+	deadline2, hasDeadline2 := ctx2.Deadline()
+
+	// Determine which context has the earliest deadline. By default, we'll
+	// use ctx1 and only switch to ctx2 if it has an earlier deadline.
+	baseCtx := ctx1
+	if hasDeadline2 {
+		if !hasDeadline1 || deadline2.Before(deadline1) {
+			baseCtx = ctx2
+		}
+	}
+
+	// Create a new context that will be cancelled explicitly.
+	mergedCtx, cancel := context.WithCancel(baseCtx)
+
+	// Watch both parent contexts and cancel the merged one when either
+	// parent cancels.
+	go func() {
+		select {
+		case <-ctx1.Done():
+			cancel()
+		case <-ctx2.Done():
+			cancel()
+		case <-mergedCtx.Done():
+			// Already cancelled.
+		}
+	}()
+
+	return mergedCtx, cancel
+}
+
 // ActorConfig holds the configuration parameters for creating a new Actor.
 // It is generic over M (Message type) and R (Response type) to accommodate
 // the actor's specific behavior.
@@ -31,12 +79,14 @@ type ActorConfig[M Message, R any] struct {
 	Wg *sync.WaitGroup
 }
 
-// envelope wraps a message with its associated promise. This allows the sender
-// of an "ask" message to await a response. If the promise is nil, it
-// signifies a "tell" operation (fire-and-forget).
+// envelope wraps a message with its associated promise and caller context. This
+// allows the sender of an "ask" message to await a response. If the promise is
+// nil, it signifies a "tell" operation (fire-and-forget). The callerCtx allows
+// actors to respect request-scoped deadlines and cancellation.
 type envelope[M Message, R any] struct {
-	message M
-	promise Promise[R]
+	message   M
+	promise   Promise[R]
+	callerCtx context.Context
 }
 
 // Actor represents a concrete actor implementation. It encapsulates a behavior,
@@ -139,12 +189,29 @@ func (a *Actor[M, R]) process() {
 	// Process messages from the mailbox using the iterator pattern. The
 	// iterator will stop when the actor's context is cancelled.
 	for env := range a.mailbox.Receive(a.ctx) {
-		log.TraceS(a.ctx, "Actor processing message",
+		// For Ask messages, merge the actor's context with the
+		// caller's context so the behavior can detect both actor
+		// shutdown and caller deadline expiration. For Tell messages,
+		// use only the actor's context to preserve fire-and-forget
+		// semantics. Once a Tell message is enqueued, it should not be
+		// cancelled by the caller's context.
+		var processCtx context.Context
+		var cancel context.CancelFunc
+		if env.promise != nil {
+			processCtx, cancel = mergeContexts(a.ctx, env.callerCtx)
+		} else {
+			processCtx = a.ctx
+			cancel = func() {}
+		}
+
+		log.TraceS(processCtx, "Actor processing message",
 			"actor_id", a.id,
 			"msg_type", env.message.MessageType(),
 			"is_ask", env.promise != nil)
 
-		result := a.behavior.Receive(a.ctx, env.message)
+		result := a.behavior.Receive(processCtx, env.message)
+
+		cancel()
 
 		// If a promise was provided (i.e., it was an "ask" operation),
 		// complete the promise with the result from the behavior.
@@ -179,6 +246,21 @@ func (a *Actor[M, R]) process() {
 		// indicating the actor terminated.
 		if env.promise != nil {
 			env.promise.Complete(fn.Err[R](ErrActorTerminated))
+		}
+	}
+
+	// If the behavior implements the Stoppable interface, call its OnStop
+	// hook to allow cleanup of external resources. Use a timeout to ensure
+	// cleanup doesn't hang indefinitely.
+	if stoppable, ok := a.behavior.(Stoppable); ok {
+		cleanupCtx, cancel := context.WithTimeout(
+			context.Background(), a.cleanupTimeout,
+		)
+		defer cancel()
+
+		if err := stoppable.OnStop(cleanupCtx); err != nil {
+			log.WarnS(a.ctx, "Actor cleanup error during shutdown",
+				err, "actor_id", a.id)
 		}
 	}
 
@@ -221,7 +303,11 @@ func (ref *actorRefImpl[M, R]) Tell(ctx context.Context, msg M) {
 
 	// Attempt to send the message to the mailbox. The mailbox's Send
 	// method handles context cancellation and actor termination internally.
-	env := envelope[M, R]{message: msg, promise: nil}
+	env := envelope[M, R]{
+		message:   msg,
+		promise:   nil,
+		callerCtx: ctx,
+	}
 	ok := ref.actor.mailbox.Send(ctx, env)
 
 	// If the send failed, determine whether to route to DLO. We only send
@@ -273,7 +359,11 @@ func (ref *actorRefImpl[M, R]) Ask(ctx context.Context, msg M) Future[R] {
 	// Attempt to send the message with the promise to the mailbox. The
 	// mailbox's Send method handles context cancellation and actor
 	// termination internally.
-	env := envelope[M, R]{message: msg, promise: promise}
+	env := envelope[M, R]{
+		message:   msg,
+		promise:   promise,
+		callerCtx: ctx,
+	}
 	ok := ref.actor.mailbox.Send(ctx, env)
 
 	// If the send failed (mailbox closed, context cancelled, or actor

--- a/baselib/actor/actor.go
+++ b/baselib/actor/actor.go
@@ -24,6 +24,11 @@ type ActorConfig[M Message, R any] struct {
 
 	// MailboxSize defines the buffer capacity of the actor's mailbox.
 	MailboxSize int
+
+	// Wg is an optional WaitGroup for tracking actor lifecycle. If
+	// non-nil, the actor will call Add(1) when starting and Done() when
+	// its process loop exits. This enables deterministic shutdown.
+	Wg *sync.WaitGroup
 }
 
 // envelope wraps a message with its associated promise. This allows the sender
@@ -56,6 +61,10 @@ type Actor[M Message, R any] struct {
 	// dlo is a reference to the dead letter office for this actor system.
 	dlo ActorRef[Message, any]
 
+	// wg is an optional WaitGroup for tracking this actor's lifecycle. If
+	// non-nil, Done() is called when the process loop exits.
+	wg *sync.WaitGroup
+
 	// startOnce ensures the actor's processing loop is started only once.
 	startOnce sync.Once
 
@@ -86,6 +95,7 @@ func NewActor[M Message, R any](cfg ActorConfig[M, R]) *Actor[M, R] {
 		ctx:      ctx,
 		cancel:   cancel,
 		dlo:      cfg.DLO,
+		wg:       cfg.Wg,
 	}
 
 	// Create and cache the actor's own reference.
@@ -96,17 +106,34 @@ func NewActor[M Message, R any](cfg ActorConfig[M, R]) *Actor[M, R] {
 	return actor
 }
 
-// Start initiates the actor's message processing loop in a new goroutine. This
-// method should be called once after the actor is created.
+// Start initiates the actor's message processing loop in a new goroutine.
+// This method should be called exactly once after actor creation; repeated
+// calls are safe but have no effect (enforced via startOnce). When a WaitGroup
+// is configured, we increment it here to enable deterministic shutdown—the
+// system can block on wg.Wait() to ensure all actor goroutines have fully
+// exited before proceeding with resource cleanup.
 func (a *Actor[M, R]) Start() {
 	a.startOnce.Do(func() {
+		if a.wg != nil {
+			a.wg.Add(1)
+		}
 		go a.process()
 	})
 }
 
-// process is the main event loop for the actor. It receives messages from the
-// mailbox and processes them using the actor's behavior.
+// process is the main event loop that drives actor message handling. We iterate
+// over the mailbox using the receive iterator pattern, which automatically stops
+// when the actor's context is cancelled during shutdown. The deferred Done()
+// call (when wg is non-nil) ensures the WaitGroup counter is decremented even if
+// the behavior panics, enabling the system to detect when all actors have
+// terminated.
 func (a *Actor[M, R]) process() {
+	// Decrement the WaitGroup counter when this goroutine exits. Using defer
+	// ensures this runs even if the behavior panics.
+	if a.wg != nil {
+		defer a.wg.Done()
+	}
+
 	// Process messages from the mailbox using the iterator pattern. The
 	// iterator will stop when the actor's context is cancelled.
 	for env := range a.mailbox.Receive(a.ctx) {

--- a/baselib/actor/actor.go
+++ b/baselib/actor/actor.go
@@ -3,6 +3,7 @@ package actor
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/lightningnetwork/lnd/fn/v2"
 )
@@ -77,6 +78,10 @@ type ActorConfig[M Message, R any] struct {
 	// non-nil, the actor will call Add(1) when starting and Done() when
 	// its process loop exits. This enables deterministic shutdown.
 	Wg *sync.WaitGroup
+
+	// CleanupTimeout specifies the maximum duration for OnStop cleanup.
+	// If None, a default of 5 seconds is used.
+	CleanupTimeout fn.Option[time.Duration]
 }
 
 // envelope wraps a message with its associated promise and caller context. This
@@ -115,6 +120,9 @@ type Actor[M Message, R any] struct {
 	// non-nil, Done() is called when the process loop exits.
 	wg *sync.WaitGroup
 
+	// cleanupTimeout is the maximum duration for OnStop cleanup.
+	cleanupTimeout time.Duration
+
 	// startOnce ensures the actor's processing loop is started only once.
 	startOnce sync.Once
 
@@ -139,13 +147,14 @@ func NewActor[M Message, R any](cfg ActorConfig[M, R]) *Actor[M, R] {
 	}
 
 	actor := &Actor[M, R]{
-		id:       cfg.ID,
-		behavior: cfg.Behavior,
-		mailbox:  NewChannelMailbox[M, R](ctx, mailboxCapacity),
-		ctx:      ctx,
-		cancel:   cancel,
-		dlo:      cfg.DLO,
-		wg:       cfg.Wg,
+		id:             cfg.ID,
+		behavior:       cfg.Behavior,
+		mailbox:        NewChannelMailbox[M, R](ctx, mailboxCapacity),
+		ctx:            ctx,
+		cancel:         cancel,
+		dlo:            cfg.DLO,
+		wg:             cfg.Wg,
+		cleanupTimeout: cfg.CleanupTimeout.UnwrapOr(5 * time.Second),
 	}
 
 	// Create and cache the actor's own reference.

--- a/baselib/actor/caller_context_test.go
+++ b/baselib/actor/caller_context_test.go
@@ -1,0 +1,218 @@
+package actor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCallerDeadlineRespected verifies that actors can detect and respect
+// caller deadlines passed through the merged context.
+func TestCallerDeadlineRespected(t *testing.T) {
+	t.Parallel()
+
+	system := NewActorSystem()
+	defer func() {
+		err := system.Shutdown(context.Background())
+		require.NoError(t, err)
+	}()
+
+	// Track whether the behavior detected context cancellation.
+	ctxCancelDetected := make(chan struct{})
+
+	// Create a behavior that checks for context cancellation.
+	behavior := NewFunctionBehavior(
+		func(ctx context.Context, msg *testMsg) fn.Result[string] {
+			// Simulate work that might take a while.
+			select {
+			case <-time.After(500 * time.Millisecond):
+				// Work completed.
+				return fn.Ok("completed")
+			case <-ctx.Done():
+				// Context cancelled before work finished.
+				close(ctxCancelDetected)
+				return fn.Err[string](ctx.Err())
+			}
+		},
+	)
+
+	// Register the actor.
+	key := NewServiceKey[*testMsg, string]("deadline-aware")
+	ref := RegisterWithSystem(system, "deadline-actor", key, behavior)
+
+	// Send Ask with a short deadline (50ms).
+	askCtx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	future := ref.Ask(askCtx, newTestMsg("work"))
+	result := future.Await(context.Background())
+
+	// The Ask should fail due to deadline.
+	require.True(t, result.IsErr(), "Ask should fail due to deadline")
+
+	// The behavior should have detected the context cancellation.
+	select {
+	case <-ctxCancelDetected:
+		// Good - actor detected the caller's deadline.
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("Actor did not detect caller deadline")
+	}
+}
+
+// TestCallerContextCancellation verifies that actors detect when the caller
+// cancels their context.
+func TestCallerContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	system := NewActorSystem()
+	defer func() {
+		err := system.Shutdown(context.Background())
+		require.NoError(t, err)
+	}()
+
+	// Signal when actor detects cancellation.
+	cancelDetected := make(chan struct{})
+
+	behavior := NewFunctionBehavior(
+		func(ctx context.Context, msg *testMsg) fn.Result[string] {
+			select {
+			case <-time.After(1 * time.Second):
+				return fn.Ok("done")
+			case <-ctx.Done():
+				close(cancelDetected)
+				return fn.Err[string](ctx.Err())
+			}
+		},
+	)
+
+	key := NewServiceKey[*testMsg, string]("cancel-aware")
+	ref := RegisterWithSystem(system, "cancel-actor", key, behavior)
+
+	// Create cancellable context.
+	askCtx, cancel := context.WithCancel(context.Background())
+
+	// Send Ask.
+	future := ref.Ask(askCtx, newTestMsg("work"))
+
+	// Cancel immediately.
+	cancel()
+
+	// Actor should detect the cancellation.
+	select {
+	case <-cancelDetected:
+		// Good.
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("Actor didn't detect cancellation")
+	}
+
+	// Result should be an error.
+	result := future.Await(context.Background())
+	require.True(t, result.IsErr())
+}
+
+// TestActorShutdownOverridesCallerDeadline verifies that actor shutdown takes
+// precedence even if the caller's deadline is longer.
+func TestActorShutdownOverridesCallerDeadline(t *testing.T) {
+	t.Parallel()
+
+	system := NewActorSystem()
+
+	shutdownDetected := make(chan struct{})
+
+	behavior := NewFunctionBehavior(
+		func(ctx context.Context, msg *testMsg) fn.Result[string] {
+			select {
+			case <-time.After(2 * time.Second):
+				return fn.Ok("done")
+			case <-ctx.Done():
+				close(shutdownDetected)
+				return fn.Err[string](ctx.Err())
+			}
+		},
+	)
+
+	key := NewServiceKey[*testMsg, string]("shutdown-test")
+	ref := RegisterWithSystem(system, "shutdown-actor", key, behavior)
+
+	// Send Ask with a LONG deadline (5 seconds).
+	askCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	future := ref.Ask(askCtx, newTestMsg("work"))
+
+	// Give time for message to be received.
+	time.Sleep(10 * time.Millisecond)
+
+	// Shutdown the system (which cancels actor context).
+	shutdownCtx, shutdownCancel := context.WithTimeout(
+		context.Background(), 1*time.Second,
+	)
+	defer shutdownCancel()
+
+	err := system.Shutdown(shutdownCtx)
+	require.NoError(t, err)
+
+	// Actor should have detected shutdown despite long caller deadline.
+	select {
+	case <-shutdownDetected:
+		// Good - actor context took precedence.
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("Actor didn't detect shutdown")
+	}
+
+	// Result should reflect the error.
+	result := future.Await(context.Background())
+	require.True(t, result.IsErr())
+}
+
+// TestTellIgnoresCallerContextAfterEnqueue verifies that Tell preserves
+// fire-and-forget semantics. Once a Tell message is enqueued, cancelling the
+// caller's context should not prevent the message from being processed.
+func TestTellIgnoresCallerContextAfterEnqueue(t *testing.T) {
+	t.Parallel()
+
+	system := NewActorSystem()
+	defer func() {
+		err := system.Shutdown(context.Background())
+		require.NoError(t, err)
+	}()
+
+	processed := make(chan struct{})
+
+	behavior := NewFunctionBehavior(
+		func(ctx context.Context, msg *testMsg) fn.Result[string] {
+			time.Sleep(50 * time.Millisecond)
+
+			select {
+			case <-ctx.Done():
+				return fn.Err[string](ctx.Err())
+			default:
+				close(processed)
+				return fn.Ok("completed")
+			}
+		},
+	)
+
+	key := NewServiceKey[*testMsg, string]("tell-test")
+	ref := RegisterWithSystem(system, "tell-actor", key, behavior)
+
+	tellCtx, cancel := context.WithTimeout(
+		context.Background(), 100*time.Millisecond,
+	)
+	defer cancel()
+
+	ref.Tell(tellCtx, newTestMsg("fire-and-forget"))
+
+	time.Sleep(10 * time.Millisecond)
+
+	cancel()
+
+	select {
+	case <-processed:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("Tell message was not processed despite being enqueued")
+	}
+}

--- a/baselib/actor/channel_mailbox.go
+++ b/baselib/actor/channel_mailbox.go
@@ -83,12 +83,22 @@ func (m *ChannelMailbox[M, R]) Send(ctx context.Context,
 	// and the actor's context for cancellation.
 	select {
 	case m.ch <- env:
+		log.TraceS(ctx, "Mailbox send succeeded",
+			"msg_type", env.message.MessageType(),
+			"queue_len", len(m.ch))
+
 		return true
 
 	case <-ctx.Done():
+		log.TraceS(ctx, "Mailbox send failed, caller context cancelled",
+			"msg_type", env.message.MessageType())
+
 		return false
 
 	case <-m.actorCtx.Done():
+		log.TraceS(ctx, "Mailbox send failed, actor context cancelled",
+			"msg_type", env.message.MessageType())
+
 		return false
 	}
 }
@@ -124,27 +134,33 @@ func (m *ChannelMailbox[M, R]) TrySend(env envelope[M, R]) bool {
 // Receive returns an iterator over envelopes in the mailbox. The iterator will
 // yield envelopes as they arrive and will stop when the provided context is
 // cancelled or when the mailbox is closed and drained.
+//
+// Context cancellation is checked before each receive attempt to ensure
+// deterministic shutdown behavior. This prevents the select statement from
+// racing between a ready channel and cancelled context.
 func (m *ChannelMailbox[M, R]) Receive(
 	ctx context.Context) iter.Seq[envelope[M, R]] {
 
 	return func(yield func(envelope[M, R]) bool) {
 		for {
+			// Check context first for deterministic shutdown. This
+			// ensures we stop receiving as soon as the context is
+			// cancelled, rather than racing in the select.
+			if ctx.Err() != nil {
+				return
+			}
+
 			select {
 			case env, ok := <-m.ch:
-				// Channel was closed, stop iteration.
 				if !ok {
 					return
 				}
 
-				// Yield the envelope to the consumer. If yield
-				// returns false, the consumer wants to stop
-				// iteration early.
 				if !yield(env) {
 					return
 				}
 
 			case <-ctx.Done():
-				// Context was cancelled, stop iteration.
 				return
 			}
 		}
@@ -158,6 +174,10 @@ func (m *ChannelMailbox[M, R]) Close() {
 	m.closeOnce.Do(func() {
 		m.mu.Lock()
 		defer m.mu.Unlock()
+
+		remainingMsgs := len(m.ch)
+		log.DebugS(m.actorCtx, "Mailbox closing",
+			"remaining_messages", remainingMsgs)
 
 		m.closed.Store(true)
 		close(m.ch)

--- a/baselib/actor/example_basic_actor_test.go
+++ b/baselib/actor/example_basic_actor_test.go
@@ -24,7 +24,7 @@ type BasicGreetingResponse struct {
 }
 
 // ExampleActor demonstrates creating a single actor, sending it a message
-// directly using Ask, and then unregistering and stopping it.
+// directly using Ask, and then unregistering it from service discovery.
 func ExampleActor() {
 	system := actor.NewActorSystem()
 	defer system.Shutdown(context.Background())
@@ -73,10 +73,12 @@ func ExampleActor() {
 		fmt.Printf("Received: %s\n", response.Greeting)
 	})
 
-	// Unregister the actor. This also stops the actor.
+	// Unregister the actor from the receptionist. This removes it from
+	// service discovery but does NOT stop the actor. To stop the actor,
+	// use StopAndRemoveActor or let Shutdown handle it.
 	unregistered := greeterKey.Unregister(system, greeterRef)
 	if unregistered {
-		fmt.Printf("Actor %s unregistered and stopped.\n",
+		fmt.Printf("Actor %s unregistered from receptionist.\n",
 			greeterRef.ID())
 	} else {
 		fmt.Printf("Failed to unregister actor %s.\n", greeterRef.ID())
@@ -89,9 +91,12 @@ func ExampleActor() {
 	fmt.Printf("Actors for key '%s' after unregister: %d\n",
 		"basic-greeter", len(refsAfterUnregister))
 
+	// The deferred system.Shutdown() will stop all actors when this
+	// function returns.
+
 	// Output:
 	// Actor my-greeter spawned.
 	// Received: Hello, World from my-greeter
-	// Actor my-greeter unregistered and stopped.
+	// Actor my-greeter unregistered from receptionist.
 	// Actors for key 'basic-greeter' after unregister: 0
 }

--- a/baselib/actor/example_basic_actor_test.go
+++ b/baselib/actor/example_basic_actor_test.go
@@ -27,7 +27,7 @@ type BasicGreetingResponse struct {
 // directly using Ask, and then unregistering and stopping it.
 func ExampleActor() {
 	system := actor.NewActorSystem()
-	defer system.Shutdown()
+	defer system.Shutdown(context.Background())
 
 	//nolint:ll
 	greeterKey := actor.NewServiceKey[BasicGreetingMsg, BasicGreetingResponse](

--- a/baselib/actor/example_router_test.go
+++ b/baselib/actor/example_router_test.go
@@ -28,7 +28,7 @@ type RouterGreetingResponse struct {
 // key and using a router to dispatch messages to them.
 func ExampleRouter() {
 	system := actor.NewActorSystem()
-	defer system.Shutdown()
+	defer system.Shutdown(context.Background())
 
 	//nolint:ll
 	routerGreeterKey := actor.NewServiceKey[RouterGreetingMsg, RouterGreetingResponse](

--- a/baselib/actor/example_struct_actor_test.go
+++ b/baselib/actor/example_struct_actor_test.go
@@ -72,7 +72,7 @@ func (s *StatefulCounterActor) Receive(ctx context.Context,
 // by a struct with methods, allowing it to maintain internal state.
 func ExampleActor_stateful() {
 	system := actor.NewActorSystem()
-	defer system.Shutdown()
+	defer system.Shutdown(context.Background())
 
 	counterServiceKey := actor.NewServiceKey[CounterMsg, CounterResponse](
 		"struct-counter-service",

--- a/baselib/actor/example_tell_only_test.go
+++ b/baselib/actor/example_tell_only_test.go
@@ -69,7 +69,7 @@ func (l *LoggerActorBehavior) GetLogs() []string {
 // messaging with an actor.
 func ExampleTellOnlyRef() {
 	system := actor.NewActorSystem()
-	defer system.Shutdown()
+	defer system.Shutdown(context.Background())
 
 	// The logger actor doesn't really have a response type for Ask, so we
 	// use 'any'.

--- a/baselib/actor/interface.go
+++ b/baselib/actor/interface.go
@@ -120,6 +120,19 @@ type ActorBehavior[M Message, R any] interface {
 	Receive(ctx context.Context, msg M) fn.Result[R]
 }
 
+// Stoppable is an optional interface that ActorBehavior implementations can
+// implement to perform cleanup when the actor is stopping. This is useful for
+// releasing external resources such as database connections, file handles, or
+// network listeners that the behavior manages.
+type Stoppable interface {
+	// OnStop is called during actor shutdown, after the message processing
+	// loop exits but before the actor's goroutine terminates. The provided
+	// context has a deadline for cleanup operations. Implementations should
+	// release resources and return promptly, respecting the context
+	// deadline to avoid blocking system shutdown.
+	OnStop(ctx context.Context) error
+}
+
 // Mailbox defines the interface for an actor's message queue. This abstraction
 // allows different mailbox strategies to be plugged in, such as priority
 // queues, durable on-disk queues, or backpressure-aware mailboxes, without

--- a/baselib/actor/interface.go
+++ b/baselib/actor/interface.go
@@ -113,9 +113,11 @@ type ActorRef[M Message, R any] interface {
 // It is a strategy interface that encapsulates the actor's reaction to messages.
 type ActorBehavior[M Message, R any] interface {
 	// Receive processes a message and returns a Result. The provided
-	// context is the actor's internal context, which can be used to
-	// detect actor shutdown requests.
-	Receive(actorCtx context.Context, msg M) fn.Result[R]
+	// context merges the actor's lifecycle context with the caller's
+	// request context. It cancels when either the actor shuts down OR the
+	// caller's deadline expires, allowing actors to respect request-scoped
+	// timeouts while also detecting system shutdown.
+	Receive(ctx context.Context, msg M) fn.Result[R]
 }
 
 // Mailbox defines the interface for an actor's message queue. This abstraction

--- a/baselib/actor/log.go
+++ b/baselib/actor/log.go
@@ -1,0 +1,26 @@
+package actor
+
+import (
+	"github.com/btcsuite/btclog/v2"
+)
+
+// Subsystem defines the logging code for this subsystem.
+const Subsystem = "ACTR"
+
+// log is a logger that is initialized with no output filters. This means the
+// package will not perform any logging by default until the caller requests
+// it.
+var log = btclog.Disabled
+
+// DisableLog disables all library log output. Logging output is disabled by
+// default until UseLogger is called.
+func DisableLog() {
+	UseLogger(btclog.Disabled)
+}
+
+// UseLogger uses a specified Logger to output package logging info. This
+// should be used in preference to SetLogWriter if the caller is also using
+// btclog.
+func UseLogger(logger btclog.Logger) {
+	log = logger
+}

--- a/baselib/actor/mailbox_test.go
+++ b/baselib/actor/mailbox_test.go
@@ -487,14 +487,18 @@ func TestChannelMailboxReceiveStopsOnClose(t *testing.T) {
 func TestActorDrainToDLO(t *testing.T) {
 	t.Parallel()
 
-	// Create a DLO to capture drained messages.
-	dloMsgs := make(chan Message, 10)
+	const numQueuedMessages = 4
+	dloReceived := make(chan *testMessage, numQueuedMessages)
+
 	dloBehavior := NewFunctionBehavior(
 		func(_ context.Context, msg Message) fn.Result[any] {
-			dloMsgs <- msg
+			if tm, ok := msg.(*testMessage); ok {
+				dloReceived <- tm
+			}
 			return fn.Ok[any](nil)
 		},
 	)
+
 	dloActor := NewActor(ActorConfig[Message, any]{
 		ID:          "test-dlo",
 		Behavior:    dloBehavior,
@@ -503,69 +507,79 @@ func TestActorDrainToDLO(t *testing.T) {
 	dloActor.Start()
 	defer dloActor.Stop()
 
-	// Create a blocking behavior that will hold the actor busy.
-	blockCh := make(chan struct{})
+	var actorWg sync.WaitGroup
+	firstMsgProcessing := make(chan struct{})
+
 	blockingBehavior := NewFunctionBehavior(
-		func(ctx context.Context, _ *testMessage) fn.Result[string] {
-			select {
-			case <-blockCh:
-				return fn.Ok("done")
-			case <-ctx.Done():
-				return fn.Err[string](ctx.Err())
+		func(ctx context.Context, msg *testMessage) fn.Result[string] {
+			if msg.value == 0 {
+				close(firstMsgProcessing)
+				<-ctx.Done()
 			}
+			return fn.Ok("processed")
 		},
 	)
 
-	// Create the main actor with the DLO configured.
 	actor := NewActor(ActorConfig[*testMessage, string]{
 		ID:          "test-actor",
 		Behavior:    blockingBehavior,
 		DLO:         dloActor.Ref(),
 		MailboxSize: 10,
+		Wg:          &actorWg,
 	})
 	actor.Start()
 
 	ctx := context.Background()
 
-	// Send several messages. The first one will block the actor, causing
-	// subsequent messages to queue up in the mailbox.
-	numMessages := 5
-	for i := 0; i < numMessages; i++ {
+	// Send the blocking message and wait for it to start processing.
+	actor.Ref().Tell(ctx, &testMessage{value: 0})
+	<-firstMsgProcessing
+
+	// Now send messages that will queue up since message 0 is blocking.
+	for i := 1; i <= numQueuedMessages; i++ {
 		actor.Ref().Tell(ctx, &testMessage{value: i})
 	}
 
-	// Give messages time to queue up.
-	time.Sleep(50 * time.Millisecond)
-
-	// Stop the actor while messages are still queued. This should drain the
-	// queued messages to the DLO.
+	// Stop actor. With deterministic shutdown (context check before receive),
+	// message 0 returns, then Receive exits immediately, and messages 1-4
+	// are drained to DLO.
 	actor.Stop()
+	actorWg.Wait()
 
-	// The blocking message's context will be cancelled, and it won't be sent
-	// to DLO since it was being processed. The remaining queued messages
-	// should be drained to the DLO.
-	receivedCount := 0
+	// Collect all DLO messages with event-driven approach.
+	receivedValues := make([]int, 0, numQueuedMessages)
 	timeout := time.After(2 * time.Second)
-	for receivedCount < numMessages-1 {
+
+	for len(receivedValues) < numQueuedMessages {
 		select {
-		case msg := <-dloMsgs:
-			testMsg, ok := msg.(*testMessage)
-			require.True(t, ok, "DLO received unexpected message type")
-			t.Logf("DLO received message with value: %d", testMsg.value)
-			receivedCount++
+		case msg := <-dloReceived:
+			receivedValues = append(receivedValues, msg.value)
+			t.Logf("DLO received message with value: %d", msg.value)
 
 		case <-timeout:
-			t.Fatalf("Timed out waiting for DLO messages. "+
-				"Received %d, expected %d",
-				receivedCount, numMessages-1)
+			t.Fatalf(
+				"Timed out waiting for DLO messages. "+
+					"Received %d, expected %d: %v",
+				len(receivedValues), numQueuedMessages,
+				receivedValues,
+			)
 		}
 	}
 
-	// Verify we got the expected number of drained messages (all but the
-	// first one which was being processed).
-	require.Equal(t, numMessages-1, receivedCount,
-		"DLO should receive all queued messages except the one "+
-			"being processed")
+	require.Len(t, receivedValues, numQueuedMessages)
+
+	// Verify we got all the queued messages (1-4), not the blocking one (0).
+	for i := 1; i <= numQueuedMessages; i++ {
+		require.Contains(
+			t, receivedValues, i,
+			"DLO should have received message %d", i,
+		)
+	}
+
+	require.NotContains(
+		t, receivedValues, 0,
+		"DLO should not receive message 0 (it was being processed)",
+	)
 }
 
 // TestChannelMailboxWithPromises tests that envelopes with promises are

--- a/baselib/actor/shutdown_test.go
+++ b/baselib/actor/shutdown_test.go
@@ -1,0 +1,142 @@
+package actor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDeterministicShutdownWaits verifies that Shutdown blocks until all
+// actors have completely finished their process loops.
+func TestDeterministicShutdownWaits(t *testing.T) {
+	t.Parallel()
+
+	system := NewActorSystem()
+
+	// Simple behavior.
+	behavior := NewFunctionBehavior(
+		func(ctx context.Context, msg *testMsg) fn.Result[string] {
+			return fn.Ok("ok")
+		},
+	)
+
+	// Register multiple actors.
+	key := NewServiceKey[*testMsg, string]("test-actors")
+	ref1 := RegisterWithSystem(system, "actor-1", key, behavior)
+	ref2 := RegisterWithSystem(system, "actor-2", key, behavior)
+	ref3 := RegisterWithSystem(system, "actor-3", key, behavior)
+
+	// Send messages.
+	for i := 0; i < 5; i++ {
+		ref1.Tell(context.Background(), newTestMsg("msg"))
+		ref2.Tell(context.Background(), newTestMsg("msg"))
+		ref3.Tell(context.Background(), newTestMsg("msg"))
+	}
+
+	// Shutdown should block until all 3 actors + DLO finish.
+	err := system.Shutdown(context.Background())
+	require.NoError(t, err, "Shutdown should complete successfully")
+
+	// After Shutdown returns, all actor goroutines have exited. The
+	// actorWg counter is back to zero.
+}
+
+// TestShutdownWithTimeout verifies that Shutdown respects context deadline
+// when actors take too long to finish.
+func TestShutdownWithTimeout(t *testing.T) {
+	t.Parallel()
+
+	system := NewActorSystem()
+
+	// Channel that will never close, making the actor hang.
+	hangForever := make(chan struct{})
+
+	// Create a behavior that hangs in message processing.
+	behavior := NewFunctionBehavior(
+		func(ctx context.Context, msg *testMsg) fn.Result[string] {
+			// This will block forever, preventing the actor from
+			// finishing even after context cancellation.
+			select {
+			case <-hangForever:
+				return fn.Ok("done")
+			case <-ctx.Done():
+				// Even with context cancelled, we continue to hang.
+				<-hangForever
+				return fn.Err[string](ctx.Err())
+			}
+		},
+	)
+
+	// Register actor.
+	key := NewServiceKey[*testMsg, string]("hanging-actor")
+	ref := RegisterWithSystem(system, "hanging-1", key, behavior)
+
+	// Send message to trigger the hang.
+	ref.Tell(context.Background(), newTestMsg("hang"))
+
+	// Give it time to start processing.
+	time.Sleep(20 * time.Millisecond)
+
+	// Shutdown with short timeout - should return with error before actor
+	// finishes.
+	shutdownCtx, cancel := context.WithTimeout(
+		context.Background(), 50*time.Millisecond,
+	)
+	defer cancel()
+
+	err := system.Shutdown(shutdownCtx)
+
+	// Should return timeout error.
+	require.Error(t, err, "Shutdown should timeout")
+	require.ErrorIs(t, err, context.DeadlineExceeded,
+		"Should be DeadlineExceeded")
+
+	// Cleanup - release the hang.
+	close(hangForever)
+}
+
+// TestShutdownIdempotency verifies calling Shutdown multiple times is safe.
+func TestShutdownIdempotency(t *testing.T) {
+	t.Parallel()
+
+	system := NewActorSystem()
+
+	// Register a simple actor.
+	behavior := NewFunctionBehavior(
+		func(ctx context.Context, msg *testMsg) fn.Result[string] {
+			return fn.Ok("ok")
+		},
+	)
+
+	key := NewServiceKey[*testMsg, string]("test-actor")
+	_ = RegisterWithSystem(system, "test-actor-1", key, behavior)
+
+	ctx := context.Background()
+
+	// Multiple shutdowns should all succeed.
+	err := system.Shutdown(ctx)
+	require.NoError(t, err)
+
+	err = system.Shutdown(ctx)
+	require.NoError(t, err)
+
+	err = system.Shutdown(ctx)
+	require.NoError(t, err)
+}
+
+// TestShutdownEmptySystem verifies shutting down with no actors works.
+func TestShutdownEmptySystem(t *testing.T) {
+	t.Parallel()
+
+	system := NewActorSystem()
+
+	// Shutdown immediately (only DLO is running).
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	err := system.Shutdown(ctx)
+	require.NoError(t, err)
+}

--- a/baselib/actor/stoppable_test.go
+++ b/baselib/actor/stoppable_test.go
@@ -1,0 +1,146 @@
+package actor
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// stoppableBehavior implements both ActorBehavior and Stoppable for testing.
+type stoppableBehavior struct {
+	onStopCalled atomic.Bool
+	cleanupDone  chan struct{}
+}
+
+func newStoppableBehavior() *stoppableBehavior {
+	return &stoppableBehavior{
+		cleanupDone: make(chan struct{}),
+	}
+}
+
+func (b *stoppableBehavior) Receive(ctx context.Context, msg *testMsg) fn.Result[string] {
+	return fn.Ok("processed")
+}
+
+func (b *stoppableBehavior) OnStop(ctx context.Context) error {
+	b.onStopCalled.Store(true)
+	close(b.cleanupDone)
+	return nil
+}
+
+// TestStoppableInterfaceInvoked verifies that OnStop is called during actor
+// shutdown.
+func TestStoppableInterfaceInvoked(t *testing.T) {
+	t.Parallel()
+
+	system := NewActorSystem()
+
+	behavior := newStoppableBehavior()
+
+	key := NewServiceKey[*testMsg, string]("stoppable-actor")
+	_ = RegisterWithSystem(system, "stoppable-1", key, behavior)
+
+	// Shutdown the system.
+	err := system.Shutdown(context.Background())
+	require.NoError(t, err)
+
+	// Verify OnStop was called.
+	require.True(t, behavior.onStopCalled.Load(),
+		"OnStop should have been called")
+
+	// Verify cleanup completed.
+	select {
+	case <-behavior.cleanupDone:
+		// Good.
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("OnStop cleanup didn't complete")
+	}
+}
+
+// stoppableCleanupBehavior has slow cleanup.
+type stoppableCleanupBehavior struct {
+	cleanupStarted  chan struct{}
+	cleanupFinished chan struct{}
+}
+
+func (b *stoppableCleanupBehavior) Receive(ctx context.Context, msg *testMsg) fn.Result[string] {
+	return fn.Ok("ok")
+}
+
+func (b *stoppableCleanupBehavior) OnStop(ctx context.Context) error {
+	close(b.cleanupStarted)
+	// Simulate slow cleanup.
+	time.Sleep(100 * time.Millisecond)
+	close(b.cleanupFinished)
+	return nil
+}
+
+// TestStoppableOnStopCompletes verifies that OnStop cleanup completes even with
+// slow operations.
+func TestStoppableOnStopCompletes(t *testing.T) {
+	t.Parallel()
+
+	system := NewActorSystem()
+
+	cleanupBehavior := &stoppableCleanupBehavior{
+		cleanupStarted:  make(chan struct{}),
+		cleanupFinished: make(chan struct{}),
+	}
+
+	key := NewServiceKey[*testMsg, string]("cleanup-test")
+	ref := RegisterWithSystem(system, "cleanup-actor", key, cleanupBehavior)
+
+	// Send a message to ensure actor is running.
+	result := ref.Ask(context.Background(), newTestMsg("test")).Await(context.Background())
+	require.True(t, result.IsOk())
+
+	// Shutdown the system.
+	err := system.Shutdown(context.Background())
+	require.NoError(t, err)
+
+	// Verify cleanup started.
+	select {
+	case <-cleanupBehavior.cleanupStarted:
+		// Good.
+	default:
+		t.Fatal("Cleanup didn't start")
+	}
+
+	// Verify cleanup finished.
+	select {
+	case <-cleanupBehavior.cleanupFinished:
+		// Good.
+	default:
+		t.Fatal("Cleanup didn't finish")
+	}
+}
+
+// TestNonStoppableBehaviorWorksNormally verifies that behaviors that don't
+// implement Stoppable continue to work without OnStop hooks.
+func TestNonStoppableBehaviorWorksNormally(t *testing.T) {
+	t.Parallel()
+
+	system := NewActorSystem()
+
+	// Use a regular function behavior (doesn't implement Stoppable).
+	behavior := NewFunctionBehavior(
+		func(ctx context.Context, msg *testMsg) fn.Result[string] {
+			return fn.Ok("normal")
+		},
+	)
+
+	key := NewServiceKey[*testMsg, string]("normal-actor")
+	ref := RegisterWithSystem(system, "normal-1", key, behavior)
+
+	// Should work normally.
+	result := ref.Ask(context.Background(), newTestMsg("test")).Await(context.Background())
+	require.True(t, result.IsOk())
+
+	// Shutdown should work normally.
+	err := system.Shutdown(context.Background())
+	require.NoError(t, err)
+}

--- a/baselib/actor/system.go
+++ b/baselib/actor/system.go
@@ -174,6 +174,14 @@ func (as *ActorSystem) DeadLetters() ActorRef[Message, any] {
 // provided context expires. This ensures deterministic shutdown with guaranteed
 // resource cleanup. This method is safe for concurrent use.
 func (as *ActorSystem) Shutdown(ctx context.Context) error {
+	// Cancel the main system context first to prevent new actor
+	// registrations. Any RegisterWithSystem call that occurs after this
+	// point will see as.ctx.Err() != nil and return a dummy stopped actor.
+	// This ordering is critical to prevent a race where a new actor could
+	// be registered and increment the WaitGroup after we snapshot but
+	// before we wait, causing indefinite blocking.
+	as.cancel()
+
 	// Create a slice of actors to stop. This avoids holding the lock while
 	// calling Stop() on each actor, and includes the dead letter actor.
 	var actorsToStop []stoppable
@@ -197,10 +205,6 @@ func (as *ActorSystem) Shutdown(ctx context.Context) error {
 	as.mu.Lock()
 	as.actors = nil
 	as.mu.Unlock()
-
-	// Cancel the main system context to signal shutdown to any components
-	// observing it.
-	as.cancel()
 
 	// Wait for all actor goroutines to exit. We launch a goroutine to wait
 	// on the WaitGroup so we can also respect the context deadline. If the

--- a/baselib/actor/system.go
+++ b/baselib/actor/system.go
@@ -147,6 +147,10 @@ func RegisterWithSystem[M Message, R any](as *ActorSystem, id string, key Servic
 	// service key, making it discoverable by other parts of the system.
 	RegisterWithReceptionist(as.receptionist, key, actorInstance.Ref())
 
+	log.DebugS(as.ctx, "Actor registered with system",
+		"actor_id", id,
+		"service_key", key.name)
+
 	return actorInstance.Ref()
 }
 
@@ -178,6 +182,9 @@ func (as *ActorSystem) Shutdown(ctx context.Context) error {
 		actorsToStop = append(actorsToStop, actor)
 	}
 	as.mu.RUnlock()
+
+	log.InfoS(ctx, "Actor system shutting down",
+		"num_actors", len(actorsToStop))
 
 	// Notify all managed actors to stop. Actor.Stop() is non-blocking.
 	// Each actor's Stop method will cancel its internal context, leading
@@ -211,10 +218,17 @@ func (as *ActorSystem) Shutdown(ctx context.Context) error {
 	select {
 	case <-done:
 		// All actors have finished processing.
+		log.InfoS(ctx, "Actor system shutdown completed")
+
 		return nil
+
 	case <-ctx.Done():
-		// Context expired before all actors finished. Return the
-		// context error to indicate incomplete shutdown.
+		// Context expired before all actors finished—some goroutines
+		// are still running and may leak. This indicates either
+		// misbehaving actors or insufficient shutdown timeout.
+		log.ErrorS(ctx, "Actor system shutdown incomplete, "+
+			"some actors may have leaked", ctx.Err())
+
 		return ctx.Err()
 	}
 }
@@ -236,6 +250,9 @@ func (as *ActorSystem) StopAndRemoveActor(id string) bool {
 
 	// Remove from the system's management.
 	delete(as.actors, id)
+
+	log.DebugS(as.ctx, "Actor stopped and removed from system",
+		"actor_id", id)
 
 	return true
 }

--- a/baselib/actor/system.go
+++ b/baselib/actor/system.go
@@ -54,6 +54,9 @@ type ActorSystem struct {
 
 	// cancel cancels the main system context.
 	cancel context.CancelFunc
+
+	// actorWg tracks running actor goroutines for deterministic shutdown.
+	actorWg sync.WaitGroup
 }
 
 // NewActorSystem creates a new actor system using the default configuration.
@@ -91,6 +94,7 @@ func NewActorSystemWithConfig(config SystemConfig) *ActorSystem {
 		Behavior:    deadLetterBehavior,
 		DLO:         nil,
 		MailboxSize: config.MailboxCapacity,
+		Wg:          &system.actorWg,
 	}
 	deadLetterRawActor := NewActor[Message, any](deadLetterActorCfg)
 	deadLetterRawActor.Start()
@@ -128,6 +132,7 @@ func RegisterWithSystem[M Message, R any](as *ActorSystem, id string, key Servic
 		Behavior:    behavior,
 		DLO:         as.deadLetterActor,
 		MailboxSize: as.config.MailboxCapacity,
+		Wg:          &as.actorWg,
 	}
 	actorInstance := NewActor(actorCfg)
 	actorInstance.Start()
@@ -159,11 +164,12 @@ func (as *ActorSystem) DeadLetters() ActorRef[Message, any] {
 	return as.deadLetterActor
 }
 
-// Shutdown gracefully stops the actor system. It iterates through all managed
-// actors, including the dead letter actor, and calls their Stop method.
-// After initiating the stop for all actors, it cancels the main system context.
-// This method is safe for concurrent use.
-func (as *ActorSystem) Shutdown() error {
+// Shutdown gracefully stops the actor system and waits for all actors to
+// finish processing. It iterates through all managed actors, calls their Stop
+// method, and then blocks until all actor goroutines have exited or the
+// provided context expires. This ensures deterministic shutdown with guaranteed
+// resource cleanup. This method is safe for concurrent use.
+func (as *ActorSystem) Shutdown(ctx context.Context) error {
 	// Create a slice of actors to stop. This avoids holding the lock while
 	// calling Stop() on each actor, and includes the dead letter actor.
 	var actorsToStop []stoppable
@@ -185,12 +191,32 @@ func (as *ActorSystem) Shutdown() error {
 	as.actors = nil
 	as.mu.Unlock()
 
-	// Finally cancel the main context
-	// This signals to any other components observing the system's context
-	// that shutdown has been initiated.
+	// Cancel the main system context to signal shutdown to any components
+	// observing it.
 	as.cancel()
 
-	return nil
+	// Wait for all actor goroutines to exit. We launch a goroutine to wait
+	// on the WaitGroup so we can also respect the context deadline. If the
+	// context times out, this goroutine continues running until the
+	// WaitGroup reaches zero (which could be indefinite if actors are truly
+	// hung). This is acceptable since shutdown timeouts indicate abnormal
+	// conditions and the single goroutine overhead is negligible compared
+	// to potentially leaked actor goroutines.
+	done := make(chan struct{})
+	go func() {
+		as.actorWg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// All actors have finished processing.
+		return nil
+	case <-ctx.Done():
+		// Context expired before all actors finished. Return the
+		// context error to indicate incomplete shutdown.
+		return ctx.Err()
+	}
 }
 
 // StopAndRemoveActor stops a specific actor by its ID and removes it from the

--- a/baselib/actor/system.go
+++ b/baselib/actor/system.go
@@ -314,56 +314,66 @@ func (sk ServiceKey[M, R]) Spawn(as *ActorSystem, id string,
 }
 
 // Unregister removes an actor reference associated with this service key from
-// the ActorSystem's receptionist and also stops the actor.
-// It returns true if the actor was successfully unregistered from the
-// receptionist AND successfully stopped and removed from the system's
-// management. Otherwise, it returns false.
+// the ActorSystem's receptionist. The actor continues running and can still be
+// accessed through other service keys it may be registered under. To stop the
+// actor, use StopAndRemoveActor separately. This separation allows actors to
+// provide multiple services and gracefully degrade by stopping advertisement
+// on some interfaces while continuing to serve others.
+//
+// Returns true if the actor was found and unregistered, false otherwise.
 func (sk ServiceKey[M, R]) Unregister(as *ActorSystem,
 	refToRemove ActorRef[M, R]) bool {
 
-	unregisteredFromReceptionist := UnregisterFromReceptionist(
+	return UnregisterFromReceptionist(
 		as.Receptionist(), sk, refToRemove,
 	)
-
-	// If not found in receptionist, no need to try stopping.
-	if !unregisteredFromReceptionist {
-		return false
-	}
-
-	// Attempt to stop and remove the actor from the system.
-	stoppedAndRemoved := as.StopAndRemoveActor(refToRemove.ID())
-
-	return unregisteredFromReceptionist && stoppedAndRemoved
 }
 
-// UnregisterAll finds all actor references associated with this service key in
-// the ActorSystem's receptionist. For each found actor, it attempts to stop it
-// and remove it from system management, and also unregisters it from the
-// receptionist.
+// UnregisterAll removes all actor references associated with this service key
+// from the ActorSystem's receptionist. The actors continue running and can
+// still be accessed through other service keys. To stop the actors, use
+// StopAndRemoveActor separately for each actor reference.
+//
+// Returns the number of actors that were unregistered.
 func (sk ServiceKey[M, R]) UnregisterAll(as *ActorSystem) int {
-	// First find all the refs that match this service key.
-	refsFound := FindInReceptionist(as.Receptionist(), sk)
+	r := as.Receptionist()
 
-	actorsStoppedCount := 0
-	for _, ref := range refsFound {
-		// Attempt to stop and remove the actor from the system's active
-		// management. This is the primary action to deactivate the
-		// actor. If StopAndRemoveActor returns true, it means an active
-		// actor was found in the system's `actors` map and was stopped.
-		if as.StopAndRemoveActor(ref.ID()) {
-			actorsStoppedCount++
-		}
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
-		// Regardless of whether the actor was actively managed by the
-		// system (i.e., found in as.actors), attempt to unregister its
-		// reference from the receptionist. This helps clean up any
-		// potentially stale entries in the receptionist if an actor was
-		// removed from the system's management without also being
-		// unregistered from the receptionist.
-		UnregisterFromReceptionist(as.Receptionist(), sk, ref)
+	currentRefs, exists := r.registrations[sk.name]
+	if !exists {
+		return 0
 	}
 
-	return actorsStoppedCount
+	// Build a new slice containing only references that don't match our
+	// service key's type. This handles the case where the same key name
+	// might have refs of different types registered.
+	newRefs := make([]any, 0, len(currentRefs))
+	unregisteredCount := 0
+
+	for _, item := range currentRefs {
+		if _, ok := item.(ActorRef[M, R]); ok {
+			// This ref matches our type, so we're unregistering it.
+			unregisteredCount++
+		} else {
+			// Different type, keep it.
+			newRefs = append(newRefs, item)
+		}
+	}
+
+	if unregisteredCount == 0 {
+		return 0
+	}
+
+	// Update or delete the registration entry.
+	if len(newRefs) == 0 {
+		delete(r.registrations, sk.name)
+	} else {
+		r.registrations[sk.name] = newRefs
+	}
+
+	return unregisteredCount
 }
 
 // Receptionist provides service discovery for actors. Actors can be registered

--- a/baselib/actor/system_test.go
+++ b/baselib/actor/system_test.go
@@ -353,19 +353,39 @@ func TestServiceKeyMethods(t *testing.T) {
 	foundAfter := FindInReceptionist(as.Receptionist(), key)
 	require.Empty(t, foundAfter)
 
+	// The actor should STILL be in the system's actors map because
+	// Unregister only removes from the receptionist, not from the system.
 	as.mu.RLock()
 	_, sysExistsAfter := as.actors[actorRef.ID()]
 	as.mu.RUnlock()
-	require.False(t, sysExistsAfter)
+	require.True(t, sysExistsAfter,
+		"Actor should still be in system after Unregister")
 
-	// If we try to send a message to the actor after unregistering it, then
-	// we should get an error.
+	// The actor should STILL respond to messages because it's still running.
 	future := actorRef.Ask(context.Background(), newTestMsg("ping"))
 	res := future.Await(context.Background())
-	require.True(t, res.IsErr() && errors.Is(res.Err(), ErrActorTerminated))
+	require.True(t, res.IsOk(), "Actor should still respond after Unregister")
 
+	// Unregistering again should return false (not found in receptionist).
 	successAgain := key.Unregister(as, actorRef)
 	require.False(t, successAgain)
+
+	// Now explicitly stop the actor.
+	stopped := as.StopAndRemoveActor(actorRef.ID())
+	require.True(t, stopped, "StopAndRemoveActor should succeed")
+
+	// Now the actor should be gone from the system.
+	as.mu.RLock()
+	_, sysExistsAfterStop := as.actors[actorRef.ID()]
+	as.mu.RUnlock()
+	require.False(t, sysExistsAfterStop,
+		"Actor should be removed after StopAndRemoveActor")
+
+	// And it should no longer respond.
+	futureAfterStop := actorRef.Ask(context.Background(), newTestMsg("ping"))
+	resAfterStop := futureAfterStop.Await(context.Background())
+	require.True(t, resAfterStop.IsErr() &&
+		errors.Is(resAfterStop.Err(), ErrActorTerminated))
 
 	otherSys := NewActorSystem() // Create a different actor system
 	defer func() {
@@ -431,9 +451,9 @@ func TestServiceKeyUnregisterAll(t *testing.T) {
 		)
 
 		// Unregister all for key1.
-		stoppedCountKey1 := key1.UnregisterAll(as)
+		unregisteredCountKey1 := key1.UnregisterAll(as)
 		require.Equal(
-			st, 2, stoppedCountKey1,
+			st, 2, unregisteredCountKey1,
 			"UnregisterAll for key1 returned incorrect count.",
 		)
 
@@ -447,45 +467,38 @@ func TestServiceKeyUnregisterAll(t *testing.T) {
 				"UnregisterAll.",
 		)
 
-		// Verify they are removed from system actors map.
+		// Verify they are STILL in the system actors map because
+		// UnregisterAll only removes from receptionist, not system.
 		as.mu.RLock()
 		_, actor1Key1ExistsAfter := as.actors[actor1Key1.ID()]
 		_, actor2Key1ExistsAfter := as.actors[actor2Key1.ID()]
 		as.mu.RUnlock()
-		require.False(
+		require.True(
 			st, actor1Key1ExistsAfter,
-			"Actor1 for key1 still in system actors "+
-				"map after UnregisterAll.",
+			"Actor1 for key1 should still be in system after "+
+				"UnregisterAll.",
 		)
-		require.False(
+		require.True(
 			st, actor2Key1ExistsAfter,
-			"Actor2 for key1 still in system actors "+
-				"map after UnregisterAll.",
+			"Actor2 for key1 should still be in system after "+
+				"UnregisterAll.",
 		)
 
-		// Verify actors are stopped.
+		// Verify actors are STILL running and responding.
 		resultActor1Key1 := actor1Key1.Ask(
 			context.Background(), newTestMsg("ping-k1-a1"),
 		).Await(context.Background())
 		require.True(
-			st, resultActor1Key1.IsErr(),
-			"Actor1 key1 Ask should fail after UnregisterAll.",
-		)
-		require.ErrorIs(
-			st, resultActor1Key1.Err(), ErrActorTerminated,
-			"Actor1 key1 not terminated with correct error.",
+			st, resultActor1Key1.IsOk(),
+			"Actor1 key1 should still respond after UnregisterAll.",
 		)
 
 		resultActor2Key1 := actor2Key1.Ask(
 			context.Background(), newTestMsg("ping-k1-a2"),
 		).Await(context.Background())
 		require.True(
-			st, resultActor2Key1.IsErr(),
-			"Actor2 key1 Ask should fail after UnregisterAll.",
-		)
-		require.ErrorIs(
-			st, resultActor2Key1.Err(), ErrActorTerminated,
-			"Actor2 key1 not terminated with correct error.",
+			st, resultActor2Key1.IsOk(),
+			"Actor2 key1 should still respond after UnregisterAll.",
 		)
 	})
 
@@ -527,9 +540,9 @@ func TestServiceKeyUnregisterAll(t *testing.T) {
 		)
 
 		// We'll start by unregistering all actors for keyA.
-		stoppedCountKeyA := keyA.UnregisterAll(as)
+		unregisteredCountKeyA := keyA.UnregisterAll(as)
 		require.Equal(
-			st, 2, stoppedCountKeyA,
+			st, 2, unregisteredCountKeyA,
 			"UnregisterAll for keyA returned incorrect count.",
 		)
 
@@ -552,45 +565,41 @@ func TestServiceKeyUnregisterAll(t *testing.T) {
 			"Wrong actor found for keyB.",
 		)
 
-		// Verify keyA actors are removed from system map, keyB actor
-		// remains.
+		// Verify keyA actors are STILL in system map (UnregisterAll
+		// doesn't stop actors), keyB actor remains.
 		as.mu.RLock()
 		_, actorA1ExistsAfterMixed := as.actors[actorA1.ID()]
 		_, actorA2ExistsAfterMixed := as.actors[actorA2.ID()]
 		_, actorB1ExistsAfterMixed := as.actors[actorB1.ID()]
 		as.mu.RUnlock()
-		require.False(
+		require.True(
 			st, actorA1ExistsAfterMixed,
-			"ActorA1 still in system actors map after "+
-				"mixed UnregisterAll.",
+			"ActorA1 should still be in system after UnregisterAll.",
 		)
-		require.False(
+		require.True(
 			st, actorA2ExistsAfterMixed,
-			"ActorA2 still in system actors map after "+
-				"mixed UnregisterAll.",
+			"ActorA2 should still be in system after UnregisterAll.",
 		)
 		require.True(
 			st, actorB1ExistsAfterMixed,
 			"ActorB1 removed from system actors map incorrectly.",
 		)
 
-		// Verify keyA actors are stopped, keyB actor is running.
+		// Verify ALL actors are still running (UnregisterAll doesn't stop).
 		resultActorA1Mixed := actorA1.Ask(
 			context.Background(), newTestMsg("ping-kA-a1"),
 		).Await(context.Background())
-		require.True(st, resultActorA1Mixed.IsErr())
-		require.ErrorIs(
-			st, resultActorA1Mixed.Err(), ErrActorTerminated,
-		)
+		require.True(st, resultActorA1Mixed.IsOk(),
+			"ActorA1 should still respond after UnregisterAll")
+		resultActorA1Mixed.WhenOk(func(s string) {
+			require.Equal(st, "echo: ping-kA-a1", s)
+		})
 
 		resultActorB1Mixed := actorB1.Ask(
 			context.Background(), newTestMsg("ping-kB-a1"),
 		).Await(context.Background())
-		require.False(
-			st, resultActorB1Mixed.IsErr(),
-			"ActorB1 terminated incorrectly (mixed test): %v",
-			resultActorB1Mixed.Err(),
-		)
+		require.True(st, resultActorB1Mixed.IsOk(),
+			"ActorB1 should still respond")
 		resultActorB1Mixed.WhenOk(func(s string) {
 			require.Equal(st, "echo: ping-kB-a1", s)
 		})
@@ -602,42 +611,43 @@ func TestServiceKeyUnregisterAll(t *testing.T) {
 		)
 		actorIdem := keyIdempotent.Spawn(as, "actor-idem-ua", beh)
 
-		// First call should unregister and stop.
-		stoppedCountFirstCall := keyIdempotent.UnregisterAll(as)
+		// First call should unregister.
+		unregisteredCountFirstCall := keyIdempotent.UnregisterAll(as)
 		require.Equal(
-			st, 1, stoppedCountFirstCall,
+			st, 1, unregisteredCountFirstCall,
 			"UnregisterAll (first call) incorrect count.",
 		)
 
 		// Second call should do nothing and return 0.
-		stoppedCountSecondCall := keyIdempotent.UnregisterAll(as)
+		unregisteredCountSecondCall := keyIdempotent.UnregisterAll(as)
 		require.Equal(
-			st, 0, stoppedCountSecondCall,
+			st, 0, unregisteredCountSecondCall,
 			"UnregisterAll (second call) incorrect count, not "+
 				"idempotent.",
 		)
 
-		// Verify actor is gone from receptionist and system map, and is
-		// stopped.
+		// Verify actor is gone from receptionist.
 		require.Empty(
 			st, FindInReceptionist(as.Receptionist(), keyIdempotent),
 			"Actors for keyIdempotent still in receptionist "+
 				"after calls.",
 		)
 
+		// Verify actor is STILL in system (UnregisterAll doesn't stop).
 		as.mu.RLock()
 		_, actorIdemExistsAfter := as.actors[actorIdem.ID()]
 		as.mu.RUnlock()
-		require.False(
+		require.True(
 			st, actorIdemExistsAfter,
-			"ActorIdem still in system actors map after calls.",
+			"ActorIdem should still be in system after UnregisterAll.",
 		)
 
+		// Verify actor is STILL responding.
 		resultActorIdem := actorIdem.Ask(
 			context.Background(), newTestMsg("ping-kidem-a1"),
 		).Await(context.Background())
-		require.True(st, resultActorIdem.IsErr())
-		require.ErrorIs(st, resultActorIdem.Err(), ErrActorTerminated)
+		require.True(st, resultActorIdem.IsOk(),
+			"ActorIdem should still respond after UnregisterAll")
 	})
 }
 

--- a/baselib/actor/system_test.go
+++ b/baselib/actor/system_test.go
@@ -38,7 +38,7 @@ func TestActorSystemNewActorSystem(t *testing.T) {
 	)
 
 	// Shutdown the system to clean up resources.
-	err := as.Shutdown()
+	err := as.Shutdown(context.Background())
 	require.NoError(t, err, "actorSystem shutdown failed")
 }
 
@@ -49,7 +49,7 @@ func TestActorSystemRegisterWithSystem(t *testing.T) {
 
 	as := NewActorSystem()
 	defer func() {
-		err := as.Shutdown()
+		err := as.Shutdown(context.Background())
 		require.NoError(t, err)
 	}()
 
@@ -136,7 +136,7 @@ func TestActorSystemShutdown(t *testing.T) {
 
 	// Next, trigger a shutdown, and assert that the done channel gets
 	// closed.
-	err := as.Shutdown()
+	err := as.Shutdown(context.Background())
 	require.NoError(t, err, "actorSystem shutdown failed")
 
 	// Check if the system context is done using RecvOrTimeout with a zero
@@ -186,7 +186,7 @@ func TestActorSystemStopAndRemoveActor(t *testing.T) {
 
 	as := NewActorSystem()
 	defer func() {
-		err := as.Shutdown()
+		err := as.Shutdown(context.Background())
 		require.NoError(t, err)
 	}()
 
@@ -250,7 +250,7 @@ func TestReceptionist(t *testing.T) {
 
 	as := NewActorSystem()
 	defer func() {
-		err := as.Shutdown()
+		err := as.Shutdown(context.Background())
 		require.NoError(t, err)
 	}()
 	receptionist := as.Receptionist()
@@ -322,7 +322,7 @@ func TestServiceKeyMethods(t *testing.T) {
 
 	as := NewActorSystem()
 	defer func() {
-		err := as.Shutdown()
+		err := as.Shutdown(context.Background())
 		require.NoError(t, err)
 	}()
 
@@ -369,7 +369,7 @@ func TestServiceKeyMethods(t *testing.T) {
 
 	otherSys := NewActorSystem() // Create a different actor system
 	defer func() {
-		err := otherSys.Shutdown()
+		err := otherSys.Shutdown(context.Background())
 		require.NoError(t, err)
 	}()
 
@@ -395,7 +395,7 @@ func TestServiceKeyUnregisterAll(t *testing.T) {
 	// Common setup for all sub-tests.
 	as := NewActorSystem()
 	defer func() {
-		err := as.Shutdown()
+		err := as.Shutdown(context.Background())
 		require.NoError(t, err, "ActorSystem shutdown failed.")
 	}()
 
@@ -656,7 +656,7 @@ func newRouterTestHarness(t *testing.T) *routerTestHarness {
 	t.Helper()
 	system := NewActorSystem()
 	t.Cleanup(func() {
-		err := system.Shutdown()
+		err := system.Shutdown(context.Background())
 		require.NoError(t, err, "router test actor system shutdown failed")
 	})
 

--- a/baselib/example/example_test.go
+++ b/baselib/example/example_test.go
@@ -21,7 +21,7 @@ func ExampleActorStateMachine() {
 		MailboxCapacity: 10,
 	})
 	defer func() {
-		_ = system.Shutdown()
+		_ = system.Shutdown(context.Background())
 	}()
 
 	// Register ReviewService actor.


### PR DESCRIPTION
This PR enables actors to respect caller-provided deadlines and implement resource cleanup hooks. The envelope now carries caller context which is merged with the actor's context, allowing behaviors to detect both system shutdown and request timeouts.

The optional Stoppable interface provides an OnStop hook for cleaning up external resources like database connections or file handles during shutdown. These features enable proper backpressure handling and guaranteed resource release.