### PR TITLE
baselib/actor: add Receptionist type safety validation

### DIFF
--- a/baselib/actor/interface.go
+++ b/baselib/actor/interface.go
@@ -12,6 +12,11 @@ import (
 // actor was terminated or in the process of shutting down.
 var ErrActorTerminated = fmt.Errorf("actor terminated")
 
+// ErrServiceKeyTypeMismatch indicates that a registration attempt failed
+// because the service key name is already registered with a different message
+// or response type.
+var ErrServiceKeyTypeMismatch = fmt.Errorf("service key type mismatch")
+
 // BaseMessage is a helper struct that can be embedded in message types defined
 // outside the actor package to satisfy the Message interface's unexported
 // messageMarker method.

--- a/baselib/actor/system.go
+++ b/baselib/actor/system.go
@@ -3,6 +3,8 @@ package actor
 import (
 	"context"
 	"errors"
+	"fmt"
+	"reflect"
 	"sync"
 
 	"github.com/lightningnetwork/lnd/fn/v2"
@@ -108,6 +110,17 @@ func NewActorSystemWithConfig(config SystemConfig) *ActorSystem {
 	return system
 }
 
+// newStoppedActorRef creates a stopped actor reference with the given ID.
+// This is used to return a safe non-nil reference when actor creation fails,
+// ensuring any calls to the returned ref will fail with ErrActorTerminated
+// rather than causing a nil pointer panic.
+func newStoppedActorRef[M Message, R any](id string) ActorRef[M, R] {
+	cfg := ActorConfig[M, R]{ID: id}
+	actor := NewActor(cfg)
+	actor.Stop()
+	return actor.Ref()
+}
+
 // RegisterWithSystem creates an actor with the given ID, service key, and
 // behavior within the specified ActorSystem. It starts the actor, adds it to
 // the system's management, registers it with the receptionist using the
@@ -121,10 +134,7 @@ func RegisterWithSystem[M Message, R any](as *ActorSystem, id string, key Servic
 		// return a reference to a dummy actor that is already stopped.
 		// This ensures that any calls to the returned ref will fail
 		// with ErrActorTerminated.
-		dummyCfg := ActorConfig[M, R]{ID: id}
-		dummyActor := NewActor(dummyCfg)
-		dummyActor.Stop()
-		return dummyActor.Ref()
+		return newStoppedActorRef[M, R](id)
 	}
 
 	actorCfg := ActorConfig[M, R]{
@@ -145,7 +155,17 @@ func RegisterWithSystem[M Message, R any](as *ActorSystem, id string, key Servic
 
 	// Register the actor's reference with the receptionist under the given
 	// service key, making it discoverable by other parts of the system.
-	RegisterWithReceptionist(as.receptionist, key, actorInstance.Ref())
+	err := RegisterWithReceptionist(as.receptionist, key, actorInstance.Ref())
+	if err != nil {
+		// Type mismatch detected. Stop the actor we just created and
+		// return a dummy stopped actor to avoid nil panic.
+		actorInstance.Stop()
+		as.mu.Lock()
+		delete(as.actors, actorInstance.id)
+		as.mu.Unlock()
+
+		return newStoppedActorRef[M, R](id)
+	}
 
 	log.DebugS(as.ctx, "Actor registered with system",
 		"actor_id", id,
@@ -300,10 +320,12 @@ func UnregisterFromReceptionist[M Message, R any](r *Receptionist,
 		return false
 	}
 
-	// If the new list of references is empty, remove the key from the map.
-	// Otherwise, update the map with the new slice.
+	// If the new list of references is empty, remove the key from the map
+	// and clean up the type registry. This prevents memory leaks and allows
+	// re-registration with different types after all actors are unregistered.
 	if len(newRefs) == 0 {
 		delete(r.registrations, key.name)
+		delete(r.typeRegistry, key.name)
 	} else {
 		r.registrations[key.name] = newRefs
 	}
@@ -387,14 +409,23 @@ func (sk ServiceKey[M, R]) UnregisterAll(as *ActorSystem) int {
 		return 0
 	}
 
-	// Update or delete the registration entry.
+	// Update or delete the registration entry. If all refs are removed,
+	// also clean up the type registry to prevent memory leaks and allow
+	// re-registration with different types.
 	if len(newRefs) == 0 {
 		delete(r.registrations, sk.name)
+		delete(r.typeRegistry, sk.name)
 	} else {
 		r.registrations[sk.name] = newRefs
 	}
 
 	return unregisteredCount
+}
+
+// serviceTypeInfo captures the type signature of a service for validation.
+type serviceTypeInfo struct {
+	msgTypeName  string
+	respTypeName string
 }
 
 // Receptionist provides service discovery for actors. Actors can be registered
@@ -403,7 +434,11 @@ type Receptionist struct {
 	// registrations stores ActorRef instances, keyed by ServiceKey.name.
 	registrations map[string][]any
 
-	// mu protects access to registrations.
+	// typeRegistry tracks the types registered under each service name to
+	// prevent type conflicts.
+	typeRegistry map[string]serviceTypeInfo
+
+	// mu protects access to registrations and typeRegistry.
 	mu sync.RWMutex
 }
 
@@ -411,17 +446,45 @@ type Receptionist struct {
 func newReceptionist() *Receptionist {
 	return &Receptionist{
 		registrations: make(map[string][]any),
+		typeRegistry:  make(map[string]serviceTypeInfo),
 	}
 }
 
 // RegisterWithReceptionist registers an actor with a service key in the given
 // receptionist. This is a package-level generic function because methods
 // cannot have their own type parameters in Go (as of the current version).
-// It appends the actor reference to the list associated with the key's name.
+// It validates that the service key types match any existing registrations
+// under the same name and returns an error if there's a type mismatch.
 func RegisterWithReceptionist[M Message, R any](
-	r *Receptionist, key ServiceKey[M, R], ref ActorRef[M, R]) {
+	r *Receptionist, key ServiceKey[M, R], ref ActorRef[M, R]) error {
+
 	r.mu.Lock()
 	defer r.mu.Unlock()
+
+	// Get type names for validation using reflect to avoid allocating
+	// zero-value instances. This is more efficient and idiomatic for
+	// extracting type information from generic type parameters.
+	msgTypeName := reflect.TypeOf((*M)(nil)).Elem().String()
+	respTypeName := reflect.TypeOf((*R)(nil)).Elem().String()
+
+	expectedTypes := serviceTypeInfo{
+		msgTypeName:  msgTypeName,
+		respTypeName: respTypeName,
+	}
+
+	// Check if this service name is already registered with different types.
+	if existingTypes, exists := r.typeRegistry[key.name]; exists {
+		if existingTypes != expectedTypes {
+			return fmt.Errorf("%w: service '%s' already registered "+
+				"with types (%s, %s), cannot register with (%s, %s)",
+				ErrServiceKeyTypeMismatch, key.name,
+				existingTypes.msgTypeName, existingTypes.respTypeName,
+				msgTypeName, respTypeName)
+		}
+	} else {
+		// First registration for this name, record the types.
+		r.typeRegistry[key.name] = expectedTypes
+	}
 
 	// Initialize the slice for this key if it's the first registration.
 	if _, exists := r.registrations[key.name]; !exists {
@@ -429,6 +492,8 @@ func RegisterWithReceptionist[M Message, R any](
 	}
 
 	r.registrations[key.name] = append(r.registrations[key.name], ref)
+
+	return nil
 }
 
 // FindInReceptionist returns all actors registered with a service key in the

--- a/baselib/actor/type_safety_test.go
+++ b/baselib/actor/type_safety_test.go
@@ -1,0 +1,172 @@
+package actor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// testMsgA is a distinct message type for testing type conflicts.
+type testMsgA struct {
+	BaseMessage
+	value string
+}
+
+func (m *testMsgA) MessageType() string {
+	return "testMsgA"
+}
+
+// testMsgB is a different message type with the same purpose.
+type testMsgB struct {
+	BaseMessage
+	count int
+}
+
+func (m *testMsgB) MessageType() string {
+	return "testMsgB"
+}
+
+// TestReceptionistTypeSafetyPreventsConflicts verifies that the Receptionist
+// prevents registering actors with the same service name but different types.
+func TestReceptionistTypeSafetyPreventsConflicts(t *testing.T) {
+	t.Parallel()
+
+	system := NewActorSystem()
+	defer func() {
+		_ = system.Shutdown(context.Background())
+	}()
+
+	// Create behaviors for different message types.
+	behaviorA := NewFunctionBehavior(
+		func(ctx context.Context, msg *testMsgA) fn.Result[string] {
+			return fn.Ok("A: " + msg.value)
+		},
+	)
+
+	behaviorB := NewFunctionBehavior(
+		func(ctx context.Context, msg *testMsgB) fn.Result[int] {
+			return fn.Ok(msg.count)
+		},
+	)
+
+	// Register first actor with name "conflict-test" for type A.
+	keyA := NewServiceKey[*testMsgA, string]("conflict-test")
+	refA := RegisterWithSystem(system, "actor-a", keyA, behaviorA)
+
+	// Verify actor A is registered and working.
+	resultA := refA.Ask(context.Background(), &testMsgA{value: "test"}).
+		Await(context.Background())
+	require.True(t, resultA.IsOk(), "Actor A should work")
+
+	// Attempt to register second actor with SAME name but DIFFERENT type.
+	keyB := NewServiceKey[*testMsgB, int]("conflict-test")
+	refB := RegisterWithSystem(system, "actor-b", keyB, behaviorB)
+
+	// The second actor should fail to respond because it wasn't actually
+	// registered (type mismatch detected).
+	resultB := refB.Ask(context.Background(), &testMsgB{count: 42}).
+		Await(context.Background())
+	require.True(t, resultB.IsErr(), "Actor B should fail (type conflict)")
+	require.ErrorIs(t, resultB.Err(), ErrActorTerminated,
+		"Should return ErrActorTerminated for conflicted actor")
+
+	// Verify only actor A is in the receptionist.
+	foundA := FindInReceptionist(system.Receptionist(), keyA)
+	require.Len(t, foundA, 1, "Only actor A should be registered")
+
+	foundB := FindInReceptionist(system.Receptionist(), keyB)
+	require.Len(t, foundB, 0, "Actor B should not be in receptionist")
+}
+
+// TestReceptionistAllowsSameTypeRegistrations verifies that multiple actors
+// with the SAME types can register under the same name (load balancing).
+func TestReceptionistAllowsSameTypeRegistrations(t *testing.T) {
+	t.Parallel()
+
+	system := NewActorSystem()
+	defer func() {
+		_ = system.Shutdown(context.Background())
+	}()
+
+	behavior := NewFunctionBehavior(
+		func(ctx context.Context, msg *testMsg) fn.Result[string] {
+			return fn.Ok("processed")
+		},
+	)
+
+	// Register multiple actors with the SAME service key (same name + types).
+	key := NewServiceKey[*testMsg, string]("load-balanced-service")
+	ref1 := RegisterWithSystem(system, "worker-1", key, behavior)
+	ref2 := RegisterWithSystem(system, "worker-2", key, behavior)
+	ref3 := RegisterWithSystem(system, "worker-3", key, behavior)
+
+	// All should be registered and working.
+	result1 := ref1.Ask(context.Background(), newTestMsg("test")).
+		Await(context.Background())
+	require.True(t, result1.IsOk())
+
+	result2 := ref2.Ask(context.Background(), newTestMsg("test")).
+		Await(context.Background())
+	require.True(t, result2.IsOk())
+
+	result3 := ref3.Ask(context.Background(), newTestMsg("test")).
+		Await(context.Background())
+	require.True(t, result3.IsOk())
+
+	// All three should be found in the receptionist.
+	found := FindInReceptionist(system.Receptionist(), key)
+	require.Len(t, found, 3, "All three actors should be registered")
+}
+
+// TestReceptionistDirectRegistrationValidation verifies type safety when
+// calling RegisterWithReceptionist directly.
+func TestReceptionistDirectRegistrationValidation(t *testing.T) {
+	t.Parallel()
+
+	receptionist := newReceptionist()
+
+	behaviorA := NewFunctionBehavior(
+		func(ctx context.Context, msg *testMsgA) fn.Result[string] {
+			return fn.Ok("A")
+		},
+	)
+
+	behaviorB := NewFunctionBehavior(
+		func(ctx context.Context, msg *testMsgB) fn.Result[int] {
+			return fn.Ok(1)
+		},
+	)
+
+	// Create actors directly (not through system).
+	actorA := NewActor(ActorConfig[*testMsgA, string]{
+		ID:          "actor-a",
+		Behavior:    behaviorA,
+		MailboxSize: 10,
+	})
+	actorA.Start()
+	defer actorA.Stop()
+
+	actorB := NewActor(ActorConfig[*testMsgB, int]{
+		ID:          "actor-b",
+		Behavior:    behaviorB,
+		MailboxSize: 10,
+	})
+	actorB.Start()
+	defer actorB.Stop()
+
+	// Register first actor.
+	keyA := NewServiceKey[*testMsgA, string]("direct-test")
+	err := RegisterWithReceptionist(receptionist, keyA, actorA.Ref())
+	require.NoError(t, err, "First registration should succeed")
+
+	// Attempt to register second actor with different types.
+	keyB := NewServiceKey[*testMsgB, int]("direct-test")
+	err = RegisterWithReceptionist(receptionist, keyB, actorB.Ref())
+	require.Error(t, err, "Second registration should fail")
+	require.ErrorIs(t, err, ErrServiceKeyTypeMismatch,
+		"Should return ErrServiceKeyTypeMismatch")
+	require.Contains(t, err.Error(), "direct-test",
+		"Error should mention the conflicting service name")
+}


### PR DESCRIPTION
This PR prevents dangerous runtime panics by validating that service keys with the same name use consistent types. The Receptionist now maintains a type registry and returns ErrServiceKeyTypeMismatch when conflicting types attempt to register under the same service name.

This catches configuration errors at registration time rather than causing cryptic failures during message routing when type assertions fail. The implementation preserves load balancing where multiple actors of the SAME type share a service name.