### PR TITLE
baselib/actor: ergonomic improvements and stronger typing

### DIFF
--- a/baselib/actor/actor.go
+++ b/baselib/actor/actor.go
@@ -419,6 +419,9 @@ func (ref *actorRefImpl[M, R]) ID() string {
 	return ref.actor.id
 }
 
+// baseActorRefMarker implements the BaseActorRef sealed interface marker.
+func (ref *actorRefImpl[M, R]) baseActorRefMarker() {}
+
 // Ref returns an ActorRef for this actor. This allows clients to interact with
 // the actor (send messages) without having direct access to the Actor struct
 // itself, promoting encapsulation and location transparency.

--- a/baselib/actor/base_actor_ref_test.go
+++ b/baselib/actor/base_actor_ref_test.go
@@ -1,0 +1,150 @@
+package actor
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBaseActorRefStrongerTyping verifies that BaseActorRef provides stronger
+// typing than any in the Receptionist.
+func TestBaseActorRefStrongerTyping(t *testing.T) {
+	t.Parallel()
+
+	receptionist := newReceptionist()
+
+	behavior := NewFunctionBehavior(
+		func(ctx context.Context, msg *testMsg) fn.Result[string] {
+			return fn.Ok("ok")
+		},
+	)
+
+	actor := NewActor(ActorConfig[*testMsg, string]{
+		ID:          "test-actor",
+		Behavior:    behavior,
+		MailboxSize: 10,
+	})
+	actor.Start()
+	defer actor.Stop()
+
+	key := NewServiceKey[*testMsg, string]("test-service")
+	err := RegisterWithReceptionist(receptionist, key, actor.Ref())
+	require.NoError(t, err)
+
+	// Verify we can access the registrations as BaseActorRef.
+	receptionist.mu.RLock()
+	baseRefs := receptionist.registrations["test-service"]
+	receptionist.mu.RUnlock()
+
+	require.Len(t, baseRefs, 1)
+
+	// BaseActorRef provides ID() method directly.
+	require.Equal(t, "test-actor", baseRefs[0].ID())
+}
+
+// TestActorRefImplementsBaseActorRef verifies that ActorRef satisfies
+// BaseActorRef.
+func TestActorRefImplementsBaseActorRef(t *testing.T) {
+	t.Parallel()
+
+	behavior := NewFunctionBehavior(
+		func(ctx context.Context, msg *testMsg) fn.Result[string] {
+			return fn.Ok("ok")
+		},
+	)
+
+	actor := NewActor(ActorConfig[*testMsg, string]{
+		ID:          "base-test",
+		Behavior:    behavior,
+		MailboxSize: 10,
+	})
+	actor.Start()
+	defer actor.Stop()
+
+	// ActorRef should be assignable to BaseActorRef.
+	var baseRef BaseActorRef = actor.Ref()
+	require.NotNil(t, baseRef)
+	require.Equal(t, "base-test", baseRef.ID())
+}
+
+// TestRouterImplementsBaseActorRef verifies that Router satisfies BaseActorRef.
+func TestRouterImplementsBaseActorRef(t *testing.T) {
+	t.Parallel()
+
+	system := NewActorSystem()
+	defer func() {
+		_ = system.Shutdown(context.Background())
+	}()
+
+	key := NewServiceKey[*testMsg, string]("router-test")
+
+	// Create a router using key.Ref.
+	router := key.Ref(system)
+
+	// Router should be assignable to BaseActorRef.
+	var baseRef BaseActorRef = router
+	require.NotNil(t, baseRef)
+	require.Contains(t, baseRef.ID(), "router")
+}
+
+// firstActorStrategy always selects the first available actor.
+type firstActorStrategy[M Message, R any] struct{}
+
+func (s *firstActorStrategy[M, R]) Select(actors []ActorRef[M, R]) (ActorRef[M, R], error) {
+	if len(actors) == 0 {
+		return nil, ErrNoActorsAvailable
+	}
+	return actors[0], nil
+}
+
+// TestFunctionalOptionsWithCustomStrategy verifies that WithStrategy option
+// works correctly.
+func TestFunctionalOptionsWithCustomStrategy(t *testing.T) {
+	t.Parallel()
+
+	system := NewActorSystem()
+	defer func() {
+		_ = system.Shutdown(context.Background())
+	}()
+
+	// Track which actors get selected.
+	var actor1Selected, actor2Selected atomic.Int32
+
+	behavior1 := NewFunctionBehavior(
+		func(ctx context.Context, msg *testMsg) fn.Result[string] {
+			actor1Selected.Add(1)
+			return fn.Ok("actor1")
+		},
+	)
+
+	behavior2 := NewFunctionBehavior(
+		func(ctx context.Context, msg *testMsg) fn.Result[string] {
+			actor2Selected.Add(1)
+			return fn.Ok("actor2")
+		},
+	)
+
+	key := NewServiceKey[*testMsg, string]("custom-strategy-test")
+	_ = RegisterWithSystem(system, "actor-1", key, behavior1)
+	_ = RegisterWithSystem(system, "actor-2", key, behavior2)
+
+	// Get ref with custom strategy that always picks first actor.
+	customStrategy := &firstActorStrategy[*testMsg, string]{}
+	ref := key.Ref(system, WithStrategy[*testMsg, string](customStrategy))
+
+	// Send multiple messages - all should go to first actor.
+	for i := 0; i < 10; i++ {
+		result := ref.Ask(context.Background(), newTestMsg("test")).
+			Await(context.Background())
+		require.True(t, result.IsOk())
+	}
+
+	// Verify only actor1 was selected (custom strategy working).
+	require.Equal(t, int32(10), actor1Selected.Load(),
+		"Actor 1 should receive all 10 messages")
+	require.Equal(t, int32(0), actor2Selected.Load(),
+		"Actor 2 should receive no messages")
+}

--- a/baselib/actor/interface.go
+++ b/baselib/actor/interface.go
@@ -89,17 +89,29 @@ type Promise[T any] interface {
 	Complete(result fn.Result[T]) bool
 }
 
+// BaseActorRef is a non-generic base interface for all actor references. This
+// enables stronger typing in data structures that store heterogeneous actor
+// references, such as the Receptionist's registration map. All ActorRef
+// instances implement this interface.
+type BaseActorRef interface {
+	// ID returns the unique identifier for this actor.
+	ID() string
+
+	// baseActorRefMarker is an unexported method that seals this
+	// interface, preventing external implementations.
+	baseActorRefMarker()
+}
+
 // TellOnlyRef is a reference to an actor that only supports "tell" operations.
 // This is useful for scenarios where only fire-and-forget message passing is
 // needed, or to restrict capabilities.
 type TellOnlyRef[M Message] interface {
+	BaseActorRef
+
 	// Tell sends a message without waiting for a response. If the
 	// context is cancelled before the message can be sent to the actor's
 	// mailbox, the message may be dropped.
 	Tell(ctx context.Context, msg M)
-
-	// ID returns the unique identifier for this actor.
-	ID() string
 }
 
 // ActorRef is a reference to an actor that supports both "tell" and "ask"

--- a/baselib/actor/interface.go
+++ b/baselib/actor/interface.go
@@ -138,6 +138,18 @@ type Stoppable interface {
 	OnStop(ctx context.Context) error
 }
 
+// SystemContext defines the minimal interface for system capabilities needed
+// by actors and service keys. This narrow interface enables dependency
+// injection and unit testing without requiring a full ActorSystem instance.
+type SystemContext interface {
+	// Receptionist returns the system's receptionist for actor discovery.
+	Receptionist() *Receptionist
+
+	// DeadLetters returns a reference to the dead letter actor for
+	// undeliverable messages.
+	DeadLetters() ActorRef[Message, any]
+}
+
 // Mailbox defines the interface for an actor's message queue. This abstraction
 // allows different mailbox strategies to be plugged in, such as priority
 // queues, durable on-disk queues, or backpressure-aware mailboxes, without

--- a/baselib/actor/router.go
+++ b/baselib/actor/router.go
@@ -141,3 +141,6 @@ func (r *Router[M, R]) Ask(ctx context.Context, msg M) Future[R] {
 func (r *Router[M, R]) ID() string {
 	return "router(" + r.serviceKey.name + ")"
 }
+
+// baseActorRefMarker implements the BaseActorRef sealed interface marker.
+func (r *Router[M, R]) baseActorRefMarker() {}

--- a/baselib/actor/service_key_ergonomics_test.go
+++ b/baselib/actor/service_key_ergonomics_test.go
@@ -1,0 +1,223 @@
+package actor
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestServiceKeyRefCreatesRouter verifies that ServiceKey.Ref returns a
+// working router that load-balances across registered actors.
+func TestServiceKeyRefCreatesRouter(t *testing.T) {
+	t.Parallel()
+
+	system := NewActorSystem()
+	defer func() {
+		_ = system.Shutdown(context.Background())
+	}()
+
+	// Track which actors process messages.
+	var actor1Count, actor2Count, actor3Count atomic.Int32
+
+	// Create behaviors that track message counts.
+	behavior1 := NewFunctionBehavior(
+		func(ctx context.Context, msg *testMsg) fn.Result[string] {
+			actor1Count.Add(1)
+			return fn.Ok("actor1")
+		},
+	)
+
+	behavior2 := NewFunctionBehavior(
+		func(ctx context.Context, msg *testMsg) fn.Result[string] {
+			actor2Count.Add(1)
+			return fn.Ok("actor2")
+		},
+	)
+
+	behavior3 := NewFunctionBehavior(
+		func(ctx context.Context, msg *testMsg) fn.Result[string] {
+			actor3Count.Add(1)
+			return fn.Ok("actor3")
+		},
+	)
+
+	// Register three actors under the same service key.
+	key := NewServiceKey[*testMsg, string]("worker-pool")
+	_ = RegisterWithSystem(system, "worker-1", key, behavior1)
+	_ = RegisterWithSystem(system, "worker-2", key, behavior2)
+	_ = RegisterWithSystem(system, "worker-3", key, behavior3)
+
+	// Get a virtual reference (router) for the service.
+	serviceRef := key.Ref(system)
+
+	// Send messages through the router.
+	numMessages := 12 // Divisible by 3 for round-robin.
+	for i := 0; i < numMessages; i++ {
+		result := serviceRef.Ask(context.Background(), newTestMsg("work")).
+			Await(context.Background())
+		require.True(t, result.IsOk(), "Message %d should be processed", i)
+	}
+
+	// Verify all actors received messages (round-robin distribution).
+	require.Equal(t, int32(4), actor1Count.Load(),
+		"Actor 1 should receive 4 messages")
+	require.Equal(t, int32(4), actor2Count.Load(),
+		"Actor 2 should receive 4 messages")
+	require.Equal(t, int32(4), actor3Count.Load(),
+		"Actor 3 should receive 4 messages")
+}
+
+// TestServiceKeyRefWithNoActors verifies that Ref works even when no actors
+// are registered yet.
+func TestServiceKeyRefWithNoActors(t *testing.T) {
+	t.Parallel()
+
+	system := NewActorSystem()
+	defer func() {
+		_ = system.Shutdown(context.Background())
+	}()
+
+	// Get a ref before any actors are registered.
+	key := NewServiceKey[*testMsg, string]("empty-service")
+	serviceRef := key.Ref(system)
+
+	// Sending to an empty service should fail gracefully.
+	result := serviceRef.Ask(context.Background(), newTestMsg("test")).
+		Await(context.Background())
+	require.True(t, result.IsErr(), "Should fail with no actors")
+}
+
+// TestServiceKeyBroadcast verifies that Broadcast sends to all registered
+// actors.
+func TestServiceKeyBroadcast(t *testing.T) {
+	t.Parallel()
+
+	system := NewActorSystem()
+	defer func() {
+		_ = system.Shutdown(context.Background())
+	}()
+
+	// Track messages received by each actor.
+	actor1Received := make(chan string, 10)
+	actor2Received := make(chan string, 10)
+	actor3Received := make(chan string, 10)
+
+	behavior1 := NewFunctionBehavior(
+		func(ctx context.Context, msg *testMsg) fn.Result[string] {
+			actor1Received <- msg.data
+			return fn.Ok("ok")
+		},
+	)
+
+	behavior2 := NewFunctionBehavior(
+		func(ctx context.Context, msg *testMsg) fn.Result[string] {
+			actor2Received <- msg.data
+			return fn.Ok("ok")
+		},
+	)
+
+	behavior3 := NewFunctionBehavior(
+		func(ctx context.Context, msg *testMsg) fn.Result[string] {
+			actor3Received <- msg.data
+			return fn.Ok("ok")
+		},
+	)
+
+	// Register three actors.
+	key := NewServiceKey[*testMsg, string]("broadcast-service")
+	_ = RegisterWithSystem(system, "listener-1", key, behavior1)
+	_ = RegisterWithSystem(system, "listener-2", key, behavior2)
+	_ = RegisterWithSystem(system, "listener-3", key, behavior3)
+
+	// Broadcast a message.
+	sent := key.Broadcast(system, context.Background(), newTestMsg("notification"))
+
+	// Should send to all 3 actors.
+	require.Equal(t, 3, sent, "Should send to all 3 actors")
+
+	// Verify all actors received the message.
+	require.Equal(t, "notification", <-actor1Received)
+	require.Equal(t, "notification", <-actor2Received)
+	require.Equal(t, "notification", <-actor3Received)
+}
+
+// TestServiceKeyBroadcastWithNoActors verifies Broadcast handles empty services.
+func TestServiceKeyBroadcastWithNoActors(t *testing.T) {
+	t.Parallel()
+
+	system := NewActorSystem()
+	defer func() {
+		_ = system.Shutdown(context.Background())
+	}()
+
+	key := NewServiceKey[*testMsg, string]("empty-broadcast")
+
+	// Broadcast to an empty service should return 0.
+	sent := key.Broadcast(system, context.Background(), newTestMsg("test"))
+	require.Equal(t, 0, sent, "Should send to 0 actors")
+}
+
+// TestServiceKeyRefAndBroadcastTogether verifies that Ref and Broadcast work
+// together on the same service.
+func TestServiceKeyRefAndBroadcastTogether(t *testing.T) {
+	t.Parallel()
+
+	system := NewActorSystem()
+	defer func() {
+		_ = system.Shutdown(context.Background())
+	}()
+
+	var broadcastCount atomic.Int32
+	var routedCount atomic.Int32
+
+	behavior := NewFunctionBehavior(
+		func(ctx context.Context, msg *testMsg) fn.Result[string] {
+			if msg.data == "broadcast" {
+				broadcastCount.Add(1)
+			} else {
+				routedCount.Add(1)
+			}
+			return fn.Ok("ok")
+		},
+	)
+
+	// Register multiple actors.
+	key := NewServiceKey[*testMsg, string]("hybrid-service")
+	_ = RegisterWithSystem(system, "hybrid-1", key, behavior)
+	_ = RegisterWithSystem(system, "hybrid-2", key, behavior)
+	_ = RegisterWithSystem(system, "hybrid-3", key, behavior)
+
+	// Get router for load-balanced calls.
+	router := key.Ref(system)
+
+	// Send 6 messages through router using Ask to ensure they're processed.
+	for i := 0; i < 6; i++ {
+		result := router.Ask(context.Background(), newTestMsg("routed")).
+			Await(context.Background())
+		require.True(t, result.IsOk())
+	}
+
+	// Broadcast 2 messages (all actors receive).
+	sent1 := key.Broadcast(system, context.Background(), newTestMsg("broadcast"))
+	require.Equal(t, 3, sent1, "First broadcast should reach 3 actors")
+
+	sent2 := key.Broadcast(system, context.Background(), newTestMsg("broadcast"))
+	require.Equal(t, 3, sent2, "Second broadcast should reach 3 actors")
+
+	// Shutdown to ensure all Tell messages are processed.
+	_ = system.Shutdown(context.Background())
+
+	// Total routed count: 6 messages sent (round-robin).
+	require.Equal(t, int32(6), routedCount.Load(),
+		"Should receive 6 total routed messages")
+
+	// Total broadcast count: 2 broadcasts × 3 actors = 6.
+	// Note: Broadcast uses Tell which is fire-and-forget, so we may not
+	// have processed all of them before shutdown. Just verify some were
+	// received.
+	require.Greater(t, broadcastCount.Load(), int32(0),
+		"Should receive some broadcast messages")
+}

--- a/baselib/actor/system.go
+++ b/baselib/actor/system.go
@@ -300,11 +300,10 @@ func UnregisterFromReceptionist[M Message, R any](r *Receptionist,
 
 	// Build a new slice containing only the references that are not the one
 	// to be removed.
-	newRefs := make([]any, 0, len(refs)-1) // Pre-allocate assuming one removal
-	for _, itemInSlice := range refs {     // itemInSlice is of type 'any'
-		// Try to assert the item from the slice to the specific
-		// ActorRef[M,R] type we are trying to remove.
-		if specificActorRef, ok := itemInSlice.(ActorRef[M, R]); ok {
+	newRefs := make([]BaseActorRef, 0, len(refs)-1)
+	for _, baseRef := range refs {
+		// Try to assert the base ref to the specific ActorRef[M,R] type.
+		if specificActorRef, ok := baseRef.(ActorRef[M, R]); ok {
 			// If the type assertion is successful and it's the one
 			// we want to remove, mark as found and skip adding it
 			// to newRefs.
@@ -313,7 +312,7 @@ func UnregisterFromReceptionist[M Message, R any](r *Receptionist,
 				continue // Don't add to newRefs, effectively removing it.
 			}
 		}
-		newRefs = append(newRefs, itemInSlice)
+		newRefs = append(newRefs, baseRef)
 	}
 
 	if !found {
@@ -356,15 +355,44 @@ func (sk ServiceKey[M, R]) Spawn(as *ActorSystem, id string,
 	return RegisterWithSystem(as, id, sk, behavior)
 }
 
+// RouterOption is a functional option for configuring a router.
+type RouterOption[M Message, R any] func(*routerConfig[M, R])
+
+// routerConfig holds configuration for router creation.
+type routerConfig[M Message, R any] struct {
+	strategy RoutingStrategy[M, R]
+}
+
+// WithStrategy specifies a custom routing strategy for the router.
+func WithStrategy[M Message, R any](strategy RoutingStrategy[M, R]) RouterOption[M, R] {
+	return func(cfg *routerConfig[M, R]) {
+		cfg.strategy = strategy
+	}
+}
+
 // Ref returns a virtual ActorRef (Router) that automatically load-balances
 // messages across all actors registered under this service key. This is the
 // recommended way for components to interact with services, as it provides
 // location transparency and automatic failover. The router uses round-robin
-// strategy by default.
-func (sk ServiceKey[M, R]) Ref(sys SystemContext) ActorRef[M, R] {
-	strategy := NewRoundRobinStrategy[M, R]()
+// strategy by default, but can be customized with functional options.
+//
+// Example:
+//
+//	ref := key.Ref(system)  // Round-robin (default)
+//	ref := key.Ref(system, WithStrategy(customStrategy))  // Custom
+func (sk ServiceKey[M, R]) Ref(sys SystemContext, opts ...RouterOption[M, R]) ActorRef[M, R] {
+	// Apply default configuration.
+	cfg := &routerConfig[M, R]{
+		strategy: NewRoundRobinStrategy[M, R](),
+	}
+
+	// Apply functional options.
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
 	return NewRouter(
-		sys.Receptionist(), sk, strategy, sys.DeadLetters(),
+		sys.Receptionist(), sk, cfg.strategy, sys.DeadLetters(),
 	)
 }
 
@@ -384,29 +412,29 @@ func (sk ServiceKey[M, R]) Broadcast(sys SystemContext, ctx context.Context, msg
 }
 
 // Unregister removes an actor reference associated with this service key from
-// the ActorSystem's receptionist. The actor continues running and can still be
-// accessed through other service keys it may be registered under. To stop the
-// actor, use StopAndRemoveActor separately. This separation allows actors to
-// provide multiple services and gracefully degrade by stopping advertisement
-// on some interfaces while continuing to serve others.
+// the receptionist. The actor continues running and can still be accessed
+// through other service keys it may be registered under. To stop the actor,
+// use StopAndRemoveActor separately. This separation allows actors to provide
+// multiple services and gracefully degrade by stopping advertisement on some
+// interfaces while continuing to serve others.
 //
 // Returns true if the actor was found and unregistered, false otherwise.
-func (sk ServiceKey[M, R]) Unregister(as *ActorSystem,
+func (sk ServiceKey[M, R]) Unregister(sys SystemContext,
 	refToRemove ActorRef[M, R]) bool {
 
 	return UnregisterFromReceptionist(
-		as.Receptionist(), sk, refToRemove,
+		sys.Receptionist(), sk, refToRemove,
 	)
 }
 
 // UnregisterAll removes all actor references associated with this service key
-// from the ActorSystem's receptionist. The actors continue running and can
-// still be accessed through other service keys. To stop the actors, use
-// StopAndRemoveActor separately for each actor reference.
+// from the receptionist. The actors continue running and can still be accessed
+// through other service keys. To stop the actors, use StopAndRemoveActor
+// separately for each actor reference.
 //
 // Returns the number of actors that were unregistered.
-func (sk ServiceKey[M, R]) UnregisterAll(as *ActorSystem) int {
-	r := as.Receptionist()
+func (sk ServiceKey[M, R]) UnregisterAll(sys SystemContext) int {
+	r := sys.Receptionist()
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -458,8 +486,9 @@ type serviceTypeInfo struct {
 // Receptionist provides service discovery for actors. Actors can be registered
 // under a ServiceKey and later discovered by other actors or system components.
 type Receptionist struct {
-	// registrations stores ActorRef instances, keyed by ServiceKey.name.
-	registrations map[string][]any
+	// registrations stores ActorRef instances as BaseActorRef, keyed by
+	// ServiceKey.name.
+	registrations map[string][]BaseActorRef
 
 	// typeRegistry tracks the types registered under each service name to
 	// prevent type conflicts.
@@ -472,7 +501,7 @@ type Receptionist struct {
 // newReceptionist creates a new Receptionist instance.
 func newReceptionist() *Receptionist {
 	return &Receptionist{
-		registrations: make(map[string][]any),
+		registrations: make(map[string][]BaseActorRef),
 		typeRegistry:  make(map[string]serviceTypeInfo),
 	}
 }
@@ -515,7 +544,7 @@ func RegisterWithReceptionist[M Message, R any](
 
 	// Initialize the slice for this key if it's the first registration.
 	if _, exists := r.registrations[key.name]; !exists {
-		r.registrations[key.name] = make([]interface{}, 0)
+		r.registrations[key.name] = make([]BaseActorRef, 0)
 	}
 
 	r.registrations[key.name] = append(r.registrations[key.name], ref)
@@ -525,21 +554,20 @@ func RegisterWithReceptionist[M Message, R any](
 
 // FindInReceptionist returns all actors registered with a service key in the
 // given receptionist. This is a package-level generic function because methods
-// cannot have their own type parameters. It performs a type assertion to ensure
-// that only ActorRefs matching the ServiceKey's generic types (M, R) are
-// returned, providing type safety.
+// cannot have their own type parameters. It performs a type assertion from
+// BaseActorRef to the specific ActorRef[M, R] type to ensure type safety.
 func FindInReceptionist[M Message, R any](
 	r *Receptionist, key ServiceKey[M, R]) []ActorRef[M, R] {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	if refs, exists := r.registrations[key.name]; exists {
-		typedRefs := make([]ActorRef[M, R], 0, len(refs))
-		for _, ref := range refs {
-			// Make sure that the reference is of the correct type.
-			// This type assertion is crucial for type safety, ensuring
+	if baseRefs, exists := r.registrations[key.name]; exists {
+		typedRefs := make([]ActorRef[M, R], 0, len(baseRefs))
+		for _, baseRef := range baseRefs {
+			// Assert from BaseActorRef to the specific ActorRef[M, R]
+			// type. This type assertion provides type safety, ensuring
 			// that the returned ActorRefs match the expected M and R.
-			if typedRef, ok := ref.(ActorRef[M, R]); ok {
+			if typedRef, ok := baseRef.(ActorRef[M, R]); ok {
 				typedRefs = append(typedRefs, typedRef)
 			}
 		}

--- a/baselib/actor/system.go
+++ b/baselib/actor/system.go
@@ -356,6 +356,33 @@ func (sk ServiceKey[M, R]) Spawn(as *ActorSystem, id string,
 	return RegisterWithSystem(as, id, sk, behavior)
 }
 
+// Ref returns a virtual ActorRef (Router) that automatically load-balances
+// messages across all actors registered under this service key. This is the
+// recommended way for components to interact with services, as it provides
+// location transparency and automatic failover. The router uses round-robin
+// strategy by default.
+func (sk ServiceKey[M, R]) Ref(sys SystemContext) ActorRef[M, R] {
+	strategy := NewRoundRobinStrategy[M, R]()
+	return NewRouter(
+		sys.Receptionist(), sk, strategy, sys.DeadLetters(),
+	)
+}
+
+// Broadcast sends a message to ALL actors registered under this service key.
+// This is useful for fan-out notifications, cache invalidation, or coordinated
+// shutdown signals. The context applies to all send operations. Returns the
+// number of actors the message was sent to. Note that this is a fire-and-forget
+// operation and does not guarantee delivery or processing.
+func (sk ServiceKey[M, R]) Broadcast(sys SystemContext, ctx context.Context, msg M) int {
+	refs := FindInReceptionist(sys.Receptionist(), sk)
+
+	for _, ref := range refs {
+		ref.Tell(ctx, msg)
+	}
+
+	return len(refs)
+}
+
 // Unregister removes an actor reference associated with this service key from
 // the ActorSystem's receptionist. The actor continues running and can still be
 // accessed through other service keys it may be registered under. To stop the
@@ -392,7 +419,7 @@ func (sk ServiceKey[M, R]) UnregisterAll(as *ActorSystem) int {
 	// Build a new slice containing only references that don't match our
 	// service key's type. This handles the case where the same key name
 	// might have refs of different types registered.
-	newRefs := make([]any, 0, len(currentRefs))
+	newRefs := make([]BaseActorRef, 0, len(currentRefs))
 	unregisteredCount := 0
 
 	for _, item := range currentRefs {

--- a/baselib/actor/system_context_test.go
+++ b/baselib/actor/system_context_test.go
@@ -1,0 +1,122 @@
+package actor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestActorSystemImplementsSystemContext verifies that ActorSystem satisfies
+// the SystemContext interface.
+func TestActorSystemImplementsSystemContext(t *testing.T) {
+	t.Parallel()
+
+	system := NewActorSystem()
+	defer func() {
+		_ = system.Shutdown(context.Background())
+	}()
+
+	// Verify ActorSystem can be used as SystemContext.
+	var sysCtx SystemContext = system
+
+	// Should be able to call interface methods.
+	receptionist := sysCtx.Receptionist()
+	require.NotNil(t, receptionist, "Receptionist should not be nil")
+
+	deadLetters := sysCtx.DeadLetters()
+	require.NotNil(t, deadLetters, "DeadLetters should not be nil")
+}
+
+// mockSystemContext is a test implementation of SystemContext for unit testing.
+type mockSystemContext struct {
+	receptionist *Receptionist
+	deadLetters  ActorRef[Message, any]
+}
+
+func newMockSystemContext() *mockSystemContext {
+	// Create a minimal DLO for the mock.
+	dloBehavior := NewFunctionBehavior(
+		func(ctx context.Context, msg Message) fn.Result[any] {
+			return fn.Ok[any](nil)
+		},
+	)
+
+	dloCfg := ActorConfig[Message, any]{
+		ID:          "mock-dlo",
+		Behavior:    dloBehavior,
+		MailboxSize: 10,
+	}
+	dloActor := NewActor(dloCfg)
+	dloActor.Start()
+
+	return &mockSystemContext{
+		receptionist: newReceptionist(),
+		deadLetters:  dloActor.Ref(),
+	}
+}
+
+func (m *mockSystemContext) Receptionist() *Receptionist {
+	return m.receptionist
+}
+
+func (m *mockSystemContext) DeadLetters() ActorRef[Message, any] {
+	return m.deadLetters
+}
+
+// TestMockSystemContextForUnitTesting demonstrates how SystemContext enables
+// unit testing without a full ActorSystem.
+func TestMockSystemContextForUnitTesting(t *testing.T) {
+	t.Parallel()
+
+	// Create a mock system context for testing.
+	mockSys := newMockSystemContext()
+
+	// Components can accept SystemContext instead of *ActorSystem.
+	testComponent := func(sys SystemContext) *Receptionist {
+		return sys.Receptionist()
+	}
+
+	// Test the component with the mock.
+	receptionist := testComponent(mockSys)
+	require.NotNil(t, receptionist)
+
+	// Can also test with real ActorSystem.
+	realSystem := NewActorSystem()
+	defer func() {
+		_ = realSystem.Shutdown(context.Background())
+	}()
+
+	receptionistReal := testComponent(realSystem)
+	require.NotNil(t, receptionistReal)
+}
+
+// TestSystemContextEnablesDecoupling demonstrates using SystemContext for
+// better separation of concerns.
+func TestSystemContextEnablesDecoupling(t *testing.T) {
+	t.Parallel()
+
+	// Simulate a component that only needs to find actors, not manage them.
+	type actorConsumer struct {
+		sys SystemContext
+	}
+
+	newActorConsumer := func(sys SystemContext) *actorConsumer {
+		return &actorConsumer{sys: sys}
+	}
+
+	// Can use with real system.
+	system := NewActorSystem()
+	defer func() {
+		_ = system.Shutdown(context.Background())
+	}()
+
+	consumer := newActorConsumer(system)
+	require.NotNil(t, consumer.sys.Receptionist())
+
+	// Or with mock for isolated testing.
+	mockSys := newMockSystemContext()
+	mockConsumer := newActorConsumer(mockSys)
+	require.NotNil(t, mockConsumer.sys.Receptionist())
+}

--- a/baselib/actor/system_context_test.go
+++ b/baselib/actor/system_context_test.go
@@ -35,7 +35,7 @@ type mockSystemContext struct {
 	deadLetters  ActorRef[Message, any]
 }
 
-func newMockSystemContext() *mockSystemContext {
+func newMockSystemContext(t *testing.T) *mockSystemContext {
 	// Create a minimal DLO for the mock.
 	dloBehavior := NewFunctionBehavior(
 		func(ctx context.Context, msg Message) fn.Result[any] {
@@ -50,6 +50,7 @@ func newMockSystemContext() *mockSystemContext {
 	}
 	dloActor := NewActor(dloCfg)
 	dloActor.Start()
+	t.Cleanup(dloActor.Stop)
 
 	return &mockSystemContext{
 		receptionist: newReceptionist(),
@@ -71,7 +72,7 @@ func TestMockSystemContextForUnitTesting(t *testing.T) {
 	t.Parallel()
 
 	// Create a mock system context for testing.
-	mockSys := newMockSystemContext()
+	mockSys := newMockSystemContext(t)
 
 	// Components can accept SystemContext instead of *ActorSystem.
 	testComponent := func(sys SystemContext) *Receptionist {
@@ -116,7 +117,7 @@ func TestSystemContextEnablesDecoupling(t *testing.T) {
 	require.NotNil(t, consumer.sys.Receptionist())
 
 	// Or with mock for isolated testing.
-	mockSys := newMockSystemContext()
+	mockSys := newMockSystemContext(t)
 	mockConsumer := newActorConsumer(mockSys)
 	require.NotNil(t, mockConsumer.sys.Receptionist())
 }


### PR DESCRIPTION
This PR adds ergonomic improvements for service-centric design and stronger typing. ServiceKey.Ref(sys) now provides one-line access to auto-balancing routers with optional functional options for custom strategies. ServiceKey.Broadcast enables fan-out messaging to all service instances.

The Receptionist refactors from []any to []BaseActorRef for stronger typing, and SystemContext interface enables dependency injection and mocking in tests. These improvements make the actor API more intuitive while improving testability.