### PR TITLE
docs+build: introduce ast-grep to encode some of the style guide elements not captured by the linter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,43 @@
 - Spacing between switch/select cases
 - When wrapping function calls, put closing paren on its own line with all args on new lines
 
+### ast-grep for Code Search and Linting
+
+This project uses ast-grep (`sg`) for AST-level code search and style enforcement.
+
+**Code Search (prefer over grep for Go patterns):**
+- Use `sg run -p 'pattern' -l go` for structural code search
+- ast-grep understands Go syntax, so `sg run -p 'func $NAME($$$ARGS)' -l go` finds all functions
+- For simple text search, grep is fine; for code patterns, use ast-grep
+
+**Pattern examples:**
+- Find all function calls: `sg run -p '$FUNC($$$ARGS)' -l go`
+- Find method calls: `sg run -p '$OBJ.$METHOD($$$ARGS)' -l go`
+- Find error returns: `sg run -p 'return $ERR' -l go`
+- Find struct literals: `sg run -p '&$TYPE{$$$FIELDS}' -l go`
+
+**Linting commands:**
+- `make ast-lint` - Check for style issues (use `pkg=<dir>` to focus on a directory)
+- `make ast-grep-fix` - Auto-fix safe issues (use `pkg=<dir>` to focus on a directory)
+- `sg scan --interactive` - Review fixes one by one
+
+**Rules enforced:**
+
+*Formatting (go-formatting.yml):*
+- `struct-literal-asymmetric-close`: Multi-line struct literals need closing `}` on its own line
+- `func-call-asymmetric-wrap`: Multi-line function calls need symmetric wrapping (excludes log/error calls)
+- `log-error-expanded-form`: Log/error calls should use compact form, not expanded
+- `switch-case-needs-spacing`: Switch cases should be separated by blank lines
+- `select-case-needs-spacing`: Select cases should be separated by blank lines
+
+*Function definitions (go-func-def.yml):*
+- `func-def-dangling-param-comma`: Function params should not end with dangling comma
+- `func-def-dangling-return-paren`: Return types should not start on a new line with `(`
+
+**Note:** Structured logging calls (`InfoS`, `DebugS`, etc.) are correctly formatted with closing `)` on the same line as the last attribute per the development guidelines.
+
+See `rules/` directory for full rule definitions.
+
 ### Structured Logging
 **YOU MUST** use structured log methods (ending in `S`) with static messages:
 - First parameter: `context.Context`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,43 @@
 - Spacing between switch/select cases
 - When wrapping function calls, put closing paren on its own line with all args on new lines
 
+### ast-grep for Code Search and Linting
+
+This project uses ast-grep (`sg`) for AST-level code search and style enforcement.
+
+**Code Search (prefer over grep for Go patterns):**
+- Use `sg run -p 'pattern' -l go` for structural code search
+- ast-grep understands Go syntax, so `sg run -p 'func $NAME($$$ARGS)' -l go` finds all functions
+- For simple text search, grep is fine; for code patterns, use ast-grep
+
+**Pattern examples:**
+- Find all function calls: `sg run -p '$FUNC($$$ARGS)' -l go`
+- Find method calls: `sg run -p '$OBJ.$METHOD($$$ARGS)' -l go`
+- Find error returns: `sg run -p 'return $ERR' -l go`
+- Find struct literals: `sg run -p '&$TYPE{$$$FIELDS}' -l go`
+
+**Linting commands:**
+- `make ast-lint` - Check for style issues (use `pkg=<dir>` to focus on a directory)
+- `make ast-grep-fix` - Auto-fix safe issues (use `pkg=<dir>` to focus on a directory)
+- `sg scan --interactive` - Review fixes one by one
+
+**Rules enforced:**
+
+*Formatting (go-formatting.yml):*
+- `struct-literal-asymmetric-close`: Multi-line struct literals need closing `}` on its own line
+- `func-call-asymmetric-wrap`: Multi-line function calls need symmetric wrapping (excludes log/error calls)
+- `log-error-expanded-form`: Log/error calls should use compact form, not expanded
+- `switch-case-needs-spacing`: Switch cases should be separated by blank lines
+- `select-case-needs-spacing`: Select cases should be separated by blank lines
+
+*Function definitions (go-func-def.yml):*
+- `func-def-dangling-param-comma`: Function params should not end with dangling comma
+- `func-def-dangling-return-paren`: Return types should not start on a new line with `(`
+
+**Note:** Structured logging calls (`InfoS`, `DebugS`, etc.) are correctly formatted with closing `)` on the same line as the last attribute per the development guidelines.
+
+See `rules/` directory for full rule definitions.
+
 ### Structured Logging
 **YOU MUST** use structured log methods (ending in `S`) with static messages:
 - First parameter: `context.Context`

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: sqlc sqlc-check migrate-create migrate-up migrate-down gen
 .PHONY: lint lint-source docker-tools fmt fmt-check tidy-module tidy-module-check
+.PHONY: ast-lint ast-grep-fix
 .PHONY: unit unit-cover unit-race check-go-version build install clean release
 .PHONY: build rpc install help
 
@@ -185,6 +186,20 @@ docker-tools:
 lint-source: docker-tools
 	@$(call print, "Linting source.")
 	$(DOCKER_TOOLS) custom-gcl run -v $(LINT_WORKERS)
+
+# Globs to exclude generated files from ast-grep.
+AST_GREP_EXCLUDE := --globs '!**/*.pb.go' --globs '!**/*.pb.gw.go' --globs '!**/*.pb.json.go' --globs '!**/db/sqlc/*.go'
+
+# Optional directory/package filter for ast-grep (e.g., make ast-lint pkg=wallet).
+AST_GREP_PATH := $(if $(pkg),$(pkg),.)
+
+ast-lint: #? Run ast-grep style checks (requires ast-grep/sg installed). Use pkg=<dir> to focus on a specific directory.
+	@$(call print, "Running ast-grep style checks.")
+	sg scan $(AST_GREP_EXCLUDE) $(AST_GREP_PATH)
+
+ast-grep-fix: #? Auto-fix ast-grep style issues (requires ast-grep/sg installed). Use pkg=<dir> to focus on a specific directory.
+	@$(call print, "Auto-fixing ast-grep style issues.")
+	sg scan --update-all $(AST_GREP_EXCLUDE) $(AST_GREP_PATH)
 
 lint: check-go-version lint-source #? Run static code analysis
 

--- a/db/migrations.go
+++ b/db/migrations.go
@@ -112,16 +112,22 @@ func (m *migrationLogger) Printf(format string, v ...interface{}) {
 	switch m.log.Level() {
 	case btclog.LevelTrace:
 		m.log.Tracef(format, v...)
+
 	case btclog.LevelDebug:
 		m.log.Debugf(format, v...)
+
 	case btclog.LevelInfo:
 		m.log.Infof(format, v...)
+
 	case btclog.LevelWarn:
 		m.log.Warnf(format, v...)
+
 	case btclog.LevelError:
 		m.log.Errorf(format, v...)
+
 	case btclog.LevelCritical:
 		m.log.Criticalf(format, v...)
+
 	case btclog.LevelOff:
 	}
 }

--- a/db/migrations_test.go
+++ b/db/migrations_test.go
@@ -69,9 +69,9 @@ func TestMigrationSteps(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify the new entry exists.
-	err = db.QueryRowContext(ctx, `
-		SELECT chain_name FROM chain_info WHERE id = 2
-	`).Scan(&chainName)
+	err = db.QueryRowContext(
+		ctx, `SELECT chain_name FROM chain_info WHERE id = 2`,
+	).Scan(&chainName)
 	require.NoError(t, err)
 	require.Equal(t, "testnet", chainName)
 }
@@ -166,9 +166,9 @@ func TestSqliteMigrationBackup(t *testing.T) {
 
 	// Verify the data is still present in the database.
 	var chainName string
-	err = db2.QueryRowContext(ctx, `
-		SELECT chain_name FROM chain_info WHERE id = 2
-	`).Scan(&chainName)
+	err = db2.QueryRowContext(
+		ctx, `SELECT chain_name FROM chain_info WHERE id = 2`,
+	).Scan(&chainName)
 	require.NoError(t, err)
 	require.Equal(t, "regtest", chainName)
 
@@ -176,8 +176,10 @@ func TestSqliteMigrationBackup(t *testing.T) {
 	// created. This test verifies the backup logic works correctly by
 	// NOT creating a backup when unnecessary.
 	dbBackupFilePath := findDBBackupFilePath(t, dbFileName)
-	require.Empty(t, dbBackupFilePath, "no backup should be created "+
-		"when already at latest version")
+	require.Empty(
+		t, dbBackupFilePath,
+		"no backup should be created when already at latest version",
+	)
 }
 
 // TestDirtySqliteVersion tests that if a migration fails and leaves a SQLite
@@ -213,9 +215,11 @@ func TestDirtySqliteVersion(t *testing.T) {
 	})
 
 	// Attempt to execute migrations with a failing callback.
-	err = db.ExecuteMigrations(db.backupAndMigrate, WithPostStepCallbacks(
-		makePostStepCallbacks(db, log, testPostMigrationChecks),
-	))
+	err = db.ExecuteMigrations(
+		db.backupAndMigrate, WithPostStepCallbacks(
+			makePostStepCallbacks(db, log, testPostMigrationChecks),
+		),
+	)
 	require.ErrorIs(t, err, testError)
 
 	// If we now attempt to execute migrations again, it should fail with an

--- a/db/sqlite.go
+++ b/db/sqlite.go
@@ -229,8 +229,9 @@ func (s *SqliteStore) backupAndMigrate(mig *migrate.Migrate,
 			"Creating database backup (before applying migration(s))",
 		)
 
-		err := backupSqliteDatabase(s.DB, s.cfg.DatabaseFileName,
-			s.log)
+		err := backupSqliteDatabase(
+			s.DB, s.cfg.DatabaseFileName, s.log,
+		)
 		if err != nil {
 			return err
 		}

--- a/db/store.go
+++ b/db/store.go
@@ -89,13 +89,16 @@ func DefaultSqliteConfig(dataDir string) *SqliteConfig {
 // DefaultPostgresConfig returns default Postgres configuration.
 func DefaultPostgresConfig() *PostgresConfig {
 	return &PostgresConfig{
-		Host:               "localhost",
-		Port:               5432,
-		User:               "postgres",
-		Password:           "",
-		DBName:             "arkd",
-		MaxOpenConnections: 0, // Use default
-		MaxIdleConnections: 0, // Use default
+		Host:     "localhost",
+		Port:     5432,
+		User:     "postgres",
+		Password: "",
+		DBName:   "arkd",
+		// Use the default value for max open connections.
+		MaxOpenConnections: 0,
+
+		// Use the default value for max idle connections.
+		MaxIdleConnections: 0,
 		RequireSSL:         false,
 	}
 }

--- a/rules/go-formatting.yml
+++ b/rules/go-formatting.yml
@@ -1,0 +1,212 @@
+# Go formatting rules for multi-line function calls and struct literals.
+# Based on docs/development_guidelines.md.
+#
+# These rules detect asymmetric closing braces/parens where the closing
+# character is on the same line as content instead of its own line.
+
+# Rule: Multi-line struct literal with closing brace on same line as field.
+# This catches patterns like:
+#   &Struct{
+#     Field: value}  // WRONG - } on same line as field
+#
+# Instead of:
+#   &Struct{
+#     Field: value,
+#   }  // RIGHT - } on its own line
+id: struct-literal-asymmetric-close
+language: go
+severity: warning
+message: "Struct literal closing brace should be on its own line"
+note: |
+  Per development_guidelines.md: When a struct literal spans multiple lines,
+  the closing } should be on its own line at the same indentation level
+  as the opening line.
+
+  WRONG:
+    foo(&Bar{
+      Field: value})
+
+  RIGHT:
+    foo(&Bar{
+      Field: value,
+    })
+rule:
+  kind: composite_literal
+  all:
+    # Must span multiple lines (contains newline)
+    - regex: "\\{[\\s\\S]*\\n[\\s\\S]*\\}"
+    # Must have content immediately before closing brace (no trailing comma)
+    - regex: "[a-zA-Z0-9_\"')}]\\}$"
+---
+# Rule: Multi-line function call with asymmetric wrapping.
+# Detects calls where first arg is on same line as opening paren but
+# closing paren is on same line as last arg (asymmetric).
+#
+# EXCLUDES log/error calls which have different formatting rules per guidelines.
+id: func-call-asymmetric-wrap
+language: go
+severity: warning
+message: "Multi-line function call has asymmetric wrapping"
+note: |
+  Per development_guidelines.md: When wrapping function calls,
+  if the first arg is on the opening line, the closing paren
+  should also be on its own line OR all args should fit on one line.
+
+  WRONG:
+    value, err := bar(a,
+        b, c)
+
+  RIGHT (option 1 - all on new lines):
+    value, err := bar(
+        a, b, c,
+    )
+
+  RIGHT (option 2 - all on one line if fits):
+    value, err := bar(a, b, c)
+
+  NOTE: Log and error calls are excluded from this rule per guidelines.
+rule:
+  kind: call_expression
+  all:
+    # Must span multiple lines
+    - regex: "\\n"
+    # Must have first arg on same line as open paren: foo(arg
+    - regex: "\\([^\\n\\)]+,"
+    # Must end with arg immediately before close paren (no trailing comma on own line)
+    - regex: "[a-zA-Z0-9_\"'\\)\\]]\\)$"
+  not:
+    any:
+      # Exclude log calls (compact form is correct for these)
+      - regex: "\\.(Trace|Debug|Info|Warn|Error|Fatal|Critical)(f|S)?\\("
+      # Exclude fmt.Errorf and fmt.Printf
+      - regex: "fmt\\.(Errorf|Printf|Sprintf)\\("
+      # Exclude testing log calls (t.Logf, h.Logf, etc.)
+      - regex: "\\.(Logf|Log)\\("
+---
+# Rule: Log/error calls using expanded form instead of compact.
+# Per guidelines, log and error formatting should minimize lines.
+id: log-error-expanded-form
+language: go
+severity: hint
+message: "Log/error calls should use compact form, not expanded"
+note: |
+  Per development_guidelines.md: Log and error formatting should
+  minimize lines while staying under 80 chars.
+
+  WRONG:
+    return fmt.Errorf(
+        "message",
+        arg,
+    )
+
+  RIGHT:
+    return fmt.Errorf("message "+
+        "continued", arg)
+rule:
+  kind: call_expression
+  all:
+    - any:
+        - pattern: fmt.Errorf($$$ARGS)
+        - pattern: fmt.Printf($$$ARGS)
+        - pattern: $LOG.Debugf($$$ARGS)
+        - pattern: $LOG.Infof($$$ARGS)
+        - pattern: $LOG.Warnf($$$ARGS)
+        - pattern: $LOG.Errorf($$$ARGS)
+        - pattern: $LOG.Tracef($$$ARGS)
+    # Starts with open paren followed by newline (expanded form)
+    - regex: "f\\(\\s*\\n"
+---
+# Rule: Switch/select cases should be separated by blank lines.
+# Detects consecutive case clauses without blank line spacing.
+id: switch-case-needs-spacing
+language: go
+severity: hint
+message: "Switch/select cases should be separated by blank lines"
+note: |
+  Per development_guidelines.md: We favor spacing between stanzas within
+  switch case statements and select statements.
+
+  WRONG:
+    switch x {
+    case a:
+        <code>
+    case b:
+        <code>
+    }
+
+  RIGHT:
+    switch x {
+    // Comment for case a.
+    case a:
+        <code>
+
+    case b:
+        <code>
+    }
+rule:
+  any:
+    - kind: expression_switch_statement
+    - kind: type_switch_statement
+  # Detects case/default following } or ) without blank line
+  # Pattern: closing brace/paren, newline, tab, then case/default keyword
+  regex: "[)}]\\n\\t(case|default)"
+---
+# Rule: Select cases should be separated by blank lines.
+id: select-case-needs-spacing
+language: go
+severity: hint
+message: "Select cases should be separated by blank lines"
+note: |
+  Per development_guidelines.md: We favor spacing between stanzas within
+  select statements.
+
+  WRONG:
+    select {
+    case <-ch1:
+        <code>
+    case <-ch2:
+        <code>
+    }
+
+  RIGHT:
+    select {
+    case <-ch1:
+        <code>
+
+    case <-ch2:
+        <code>
+    }
+rule:
+  kind: select_statement
+  # Detects case/default following } or ) without blank line
+  regex: "[)}]\\n\\t(case|default)"
+---
+# Rule: No inline comments - comments should be on their own line.
+# Detects inline comments by matching composite literals that contain
+# lines with code followed by // comment on the same line.
+id: no-inline-comments
+language: go
+severity: warning
+message: "Inline comment should be on its own line above the code"
+note: |
+  Comments should be on their own line above the code they describe,
+  not at the end of a line.
+
+  WRONG:
+    wallet.BoardingStatusConfirmed, // Two confirmed
+    ConfTx: nil, // No confirmation transaction.
+
+  RIGHT:
+    // Two confirmed.
+    wallet.BoardingStatusConfirmed,
+
+    // No confirmation transaction.
+    ConfTx: nil,
+rule:
+  kind: literal_value
+  has:
+    kind: comment
+  # Match literals containing inline comments: code followed by // on same line.
+  # The key is [^\n] before // ensures they're on the same line.
+  # Pattern: (something other than newline/whitespace), optional spaces, // comment, newline
+  regex: "[a-zA-Z0-9_)\"'\\]},][ \\t]*//[^\\n]*\\n"

--- a/rules/go-func-def.yml
+++ b/rules/go-func-def.yml
@@ -1,0 +1,56 @@
+# Go function definition formatting rules.
+# Based on docs/development_guidelines.md.
+#
+# These rules detect improper wrapping patterns in function definitions.
+
+# Rule: Function parameters ending with dangling comma before close paren.
+id: func-def-dangling-param-comma
+language: go
+severity: warning
+message: "Function parameters should not end with dangling comma before close paren"
+note: |
+  Per development_guidelines.md: Function definition wrapping should
+  continue parameters on the next line, not leave a dangling comma.
+
+  WRONG:
+    func foo(a, b, c,
+    ) (d, error) {
+
+  RIGHT:
+    func foo(a, b,
+        c) (d, error) {
+rule:
+  kind: function_declaration
+  all:
+    # Has parameters that end with comma-newline-close-paren-open-paren (for returns)
+    - regex: ",\\s*\\n\\s*\\)\\s*\\("
+---
+# Rule: Function return types starting with open paren on its own line.
+id: func-def-dangling-return-paren
+language: go
+severity: warning
+message: "Function return types should not start with open paren on its own line"
+note: |
+  Per development_guidelines.md: Return type wrapping should continue
+  on the same line, not start a new line with open paren.
+
+  WRONG:
+    func bar(a, b, c) (
+        d, error,
+    ) {
+
+  RIGHT:
+    func baz(a, b, c) (d,
+        error) {
+rule:
+  kind: function_declaration
+  all:
+    # Return type starts with close-paren-open-paren-newline
+    - regex: "\\)\\s*\\(\\s*\\n"
+# NOTE: The "multi-line function needs blank line before body" rule is disabled.
+# It's difficult to implement correctly with ast-grep because:
+# 1. The regex matches ANY block inside the function (switch, if, etc.), not
+#    just the function's opening brace
+# 2. AST doesn't represent blank lines as nodes - they're only in text
+# 3. The rule would need to match the exact position of text after the {
+# This is a style hint in the guidelines, not a hard requirement.

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -1,0 +1,2 @@
+ruleDirs:
+  - rules


### PR DESCRIPTION
This PR introduces ast-grep (sg) for automated style enforcement, encoding many of the formatting patterns documented in `docs/development_guidelines.md` as machine-checkable rules. The rules cover multi-line function call wrapping, struct literal formatting, switch/select case spacing, inline comments, and function definition wrapping. Log and error calls are correctly excluded from the symmetric wrapping rules since they follow different compact formatting guidelines.

Two new Makefile targets are added: make ast-lint to check for style issues and make ast-grep-fix to auto-fix safe violations. Both support a pkg parameter to focus on specific directories (e.g., make ast-lint pkg=wallet). Generated files like *.pb.go and sqlc output are automatically excluded from scanning.

The PR also updates CLAUDE.md and AGENTS.md to document ast-grep usage for both code search (structural pattern matching that understands Go syntax) and linting. Several existing style violations in the db package are fixed as part of this change.