### PR TITLE
Closures

### DIFF
--- a/db/boarding_wallet.go
+++ b/db/boarding_wallet.go
@@ -460,7 +460,7 @@ func (b *BoardingWalletStore) LookupIntentByScript(ctx context.Context,
 // dbAddrToDomainAddr converts a sqlc BoardingAddress to a
 // wallet.BoardingAddress. The tapscript is reconstructed from the stored
 // component fields (client pubkey, operator pubkey, exit delay) using
-// scripts.VTXOTapScript().
+// scripts.DefaultVTXOTapScript().
 func dbAddrToDomainAddr(chainParams *chaincfg.Params,
 	dbAddr BoardingAddrRow) (*wallet.BoardingAddress, error) {
 
@@ -472,7 +472,7 @@ func dbAddrToDomainAddr(chainParams *chaincfg.Params,
 	if err != nil {
 		return nil, fmt.Errorf("parse operator pubkey: %w", err)
 	}
-	tapscript, err := scripts.VTXOTapScript(
+	tapscript, err := scripts.DefaultVTXOTapScript(
 		clientPubkey, operatorPubkey, uint32(dbAddr.ExitDelay),
 	)
 	if err != nil {

--- a/db/boarding_wallet.md
+++ b/db/boarding_wallet.md
@@ -99,7 +99,7 @@ UTXO at this address, used for restart recovery to resume monitoring from the
 last known checkpoint
 
 **Tapscript reconstruction**: The tapscript is not stored directly. Instead, it
-is reconstructed on read using `scripts.VTXOTapScript(clientPubkey,
+is reconstructed on read using `scripts.DefaultVTXOTapScript(clientPubkey,
 operatorPubkey, exitDelay)`. This avoids JSON serialization complexity and
 ensures the tapscript is always consistent with the stored parameters.
 
@@ -160,7 +160,7 @@ enable progressive updates. When an intent is re-inserted:
 
 1. Wallet actor derives a new key using `DeriveNextKey(family=42)`
 2. Constructs 2-of-2 tapscript with operator key and CSV timelock using
-   `scripts.VTXOTapScript`
+   `scripts.DefaultVTXOTapScript`
 3. Imports tapscript into LND via `ImportTaprootScript`
 4. Persists to `boarding_addresses` with `last_confirmed_height=0`
 5. Returns address to caller

--- a/db/boarding_wallet_test.go
+++ b/db/boarding_wallet_test.go
@@ -42,7 +42,7 @@ func newBoardingStoreForTest(
 }
 
 // createTestBoardingAddress creates a test boarding address with proper
-// tapscript construction using scripts.VTXOTapScript.
+// tapscript construction using scripts.DefaultVTXOTapScript.
 func createTestBoardingAddress(t *testing.T,
 	keyIndex uint32) (*wallet.BoardingAddress, *btcec.PrivateKey) {
 
@@ -57,7 +57,7 @@ func createTestBoardingAddress(t *testing.T,
 	exitDelay := uint32(144)
 
 	// Build the tapscript using the proper VTXO construction.
-	tapscript, err := scripts.VTXOTapScript(
+	tapscript, err := scripts.DefaultVTXOTapScript(
 		clientPubKey, operatorPubKey, exitDelay,
 	)
 	require.NoError(t, err)

--- a/db/sqlc/migrations/000002_boarding_tables.up.sql
+++ b/db/sqlc/migrations/000002_boarding_tables.up.sql
@@ -22,7 +22,7 @@ INSERT INTO boarding_statuses (id, status_name) VALUES
 -- boarding funds. Each address includes the keys and CSV timelock parameters
 -- needed to construct collaborative and timeout spending paths.
 -- The tapscript is reconstructed on read from the stored component fields
--- (client_pubkey, operator_pubkey, exit_delay) using scripts.VTXOTapScript().
+-- (client_pubkey, operator_pubkey, exit_delay) using scripts.DefaultVTXOTapScript().
 CREATE TABLE IF NOT EXISTS boarding_addresses (
     -- pk_script is the raw output script (P2TR script) and serves as the
     -- primary key since it uniquely identifies an address.

--- a/lib/closure/closure.go
+++ b/lib/closure/closure.go
@@ -1,0 +1,824 @@
+package closure
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+)
+
+// Closure represents a single tapscript leaf that can be spent.
+type Closure interface {
+	Script() ([]byte, error)
+	Decode(script []byte) (bool, error)
+	Witness(controlBlock []byte, opts map[string][]byte) (wire.TxWitness, error)
+}
+
+// MultisigClosure is a closure that contains a list of public keys and a
+// CHECKSIG for each key. The witness size is 64 bytes per key, admitting the
+// sighash type is SIGHASH_DEFAULT.
+type MultisigClosure struct {
+	PubKeys []*btcec.PublicKey
+	Type    MultisigType
+}
+
+// DecodeClosure attempts to decode a script into a known closure type.
+func DecodeClosure(script []byte) (Closure, error) {
+	if len(script) == 0 {
+		return nil, fmt.Errorf("cannot decode empty script")
+	}
+
+	types := []struct {
+		closure Closure
+		name    string
+	}{
+		// CSVSigClosure must come before CSVMultisigClosure since it's
+		// more specific (single key vs multiple keys).
+		{&CSVSigClosure{}, "CSV Sig"},
+		{&CSVMultisigClosure{}, "CSV Multisig"},
+		{&CLTVMultisigClosure{}, "CLTV Multisig"},
+		{&MultisigClosure{}, "Multisig"},
+		{&ConditionMultisigClosure{}, "Condition Multisig"},
+		{&ConditionCSVMultisigClosure{}, "Condition CSV Multisig"},
+	}
+
+	var decodeErr []string
+	for _, t := range types {
+		scriptCopy := make([]byte, len(script))
+		copy(scriptCopy, script)
+		valid, err := t.closure.Decode(scriptCopy)
+		if err != nil {
+			decodeErr = append(decodeErr, fmt.Sprintf("%s: %v", t.name, err))
+			continue
+		}
+		if valid {
+			return t.closure, nil
+		}
+	}
+
+	if len(decodeErr) > 0 {
+		return nil, fmt.Errorf(
+			"failed to decode script %x.\n%s", script, strings.Join(decodeErr, "\n"),
+		)
+	}
+
+	return nil, fmt.Errorf("script does not match any known closure type: %s",
+		hex.EncodeToString(script))
+}
+
+// Script returns the tapscript bytes for this closure.
+func (f *MultisigClosure) Script() ([]byte, error) {
+	scriptBuilder := txscript.NewScriptBuilder()
+
+	switch f.Type {
+	case MultisigTypeChecksig:
+		for i, pubkey := range f.PubKeys {
+			scriptBuilder.AddData(schnorr.SerializePubKey(pubkey))
+			if i == len(f.PubKeys)-1 {
+				scriptBuilder.AddOp(txscript.OP_CHECKSIG)
+				continue
+			}
+			scriptBuilder.AddOp(txscript.OP_CHECKSIGVERIFY)
+		}
+	case MultisigTypeChecksigAdd:
+		for i, pubkey := range f.PubKeys {
+			scriptBuilder.AddData(schnorr.SerializePubKey(pubkey))
+			if i == 0 {
+				scriptBuilder.AddOp(txscript.OP_CHECKSIG)
+				continue
+			}
+			scriptBuilder.AddOp(txscript.OP_CHECKSIGADD)
+		}
+		scriptBuilder.AddInt64(int64(len(f.PubKeys)))
+		scriptBuilder.AddOp(txscript.OP_NUMEQUAL)
+	}
+
+	return scriptBuilder.Script()
+}
+
+// Decode attempts to parse the given script into this closure type.
+func (f *MultisigClosure) Decode(script []byte) (bool, error) {
+	if len(script) == 0 {
+		return false, fmt.Errorf("failed to decode: script is empty")
+	}
+
+	valid, err := f.decodeChecksig(script)
+
+	if err != nil {
+		return false, fmt.Errorf("failed to decode checksig: %w", err)
+	}
+
+	if valid {
+		return true, nil
+	}
+
+	valid, err = f.decodeChecksigAdd(script)
+
+	if err != nil {
+		return false, fmt.Errorf("failed to decode checksigadd: %w", err)
+	}
+
+	if valid {
+		return valid, nil
+	}
+
+	return false, nil
+
+}
+
+func (f *MultisigClosure) decodeChecksigAdd(script []byte) (bool, error) {
+	tokenizer := txscript.MakeScriptTokenizer(0, script)
+
+	pubkeys := make([]*btcec.PublicKey, 0)
+
+	for tokenizer.Next() {
+		// Stop processing if a small integer opcode is encountered,
+		// indicating the required threshold for signature validation.
+		if txscript.IsSmallInt(tokenizer.Opcode()) {
+			break
+		}
+
+		// Verify we have a 32-byte data push
+		if tokenizer.Opcode() != txscript.OP_DATA_32 {
+			return false, nil
+		}
+
+		// Parse the public key
+		pubkey, err := schnorr.ParsePubKey(tokenizer.Data())
+		if err != nil {
+			return false, err
+		}
+
+		pubkeys = append(pubkeys, pubkey)
+
+		// Check if we've reached the end
+		if !tokenizer.Next() {
+			return false, nil
+		}
+
+		if tokenizer.Opcode() == txscript.OP_CHECKSIGADD ||
+			tokenizer.Opcode() == txscript.OP_CHECKSIG {
+			continue
+		} else {
+			return false, nil
+		}
+	}
+
+	// Verify public keys len
+	if tokenizer.Err() != nil || len(pubkeys) != txscript.AsSmallInt(tokenizer.Opcode()) {
+		return false, nil
+	}
+
+	if !tokenizer.Next() || tokenizer.Opcode() != txscript.OP_NUMEQUAL {
+		return false, nil
+	}
+
+	f.PubKeys = pubkeys
+	f.Type = MultisigTypeChecksigAdd
+
+	// Verify the script matches what we would generate
+	rebuilt, err := f.Script()
+	if err != nil {
+		f.PubKeys = nil
+		f.Type = 0
+		return false, err
+	}
+
+	if !bytes.Equal(rebuilt, script) {
+		f.PubKeys = nil
+		f.Type = 0
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (f *MultisigClosure) decodeChecksig(script []byte) (bool, error) {
+	tokenizer := txscript.MakeScriptTokenizer(0, script)
+
+	pubkeys := make([]*btcec.PublicKey, 0)
+
+	for tokenizer.Next() {
+		// Verify we have a 32-byte data push
+		if tokenizer.Opcode() != txscript.OP_DATA_32 {
+			return false, nil
+		}
+
+		// Parse the public key
+		pubkey, err := schnorr.ParsePubKey(tokenizer.Data())
+		if err != nil {
+			return false, err
+		}
+
+		pubkeys = append(pubkeys, pubkey)
+
+		// Check if we've reached the end
+		if !tokenizer.Next() {
+			return false, nil
+		}
+
+		if tokenizer.Opcode() == txscript.OP_CHECKSIGVERIFY {
+			continue
+		} else {
+			break
+		}
+	}
+
+	// This should be the last operation
+	if tokenizer.Err() != nil || tokenizer.Opcode() != txscript.OP_CHECKSIG {
+		return false, nil
+	}
+
+	// Verify we found at least one public key
+	if len(pubkeys) == 0 {
+		return false, nil
+	}
+
+	f.PubKeys = pubkeys
+	f.Type = MultisigTypeChecksig
+
+	// Verify the script matches what we would generate
+	rebuilt, err := f.Script()
+	if err != nil {
+		f.PubKeys = nil
+		f.Type = 0
+		return false, err
+	}
+
+	if !bytes.Equal(rebuilt, script) {
+		f.PubKeys = nil
+		f.Type = 0
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// Witness constructs the witness stack for spending this closure.
+func (f *MultisigClosure) Witness(
+	controlBlock []byte, signatures map[string][]byte,
+) (wire.TxWitness, error) {
+	// Create witness stack with capacity for all signatures plus script and control block
+	witness := make(wire.TxWitness, 0, len(f.PubKeys)+2)
+
+	// Add signatures in the reverse order as public keys
+	for i := len(f.PubKeys) - 1; i >= 0; i-- {
+		pubkey := f.PubKeys[i]
+		xOnlyPubkey := schnorr.SerializePubKey(pubkey)
+		sig, ok := signatures[hex.EncodeToString(xOnlyPubkey)]
+		if !ok {
+			return nil, fmt.Errorf("missing signature for pubkey %x", xOnlyPubkey)
+		}
+		witness = append(witness, sig)
+	}
+
+	// Get script
+	script, err := f.Script()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate script: %w", err)
+	}
+
+	// Add script and control block
+	witness = append(witness, script)
+	witness = append(witness, controlBlock)
+
+	return witness, nil
+}
+
+// CSVSigClosure is a closure for the mandatory single-sig CSV exit path.
+// This is the standard exit closure for VTXOs, allowing the owner to
+// unilaterally recover funds after the timelock expires.
+//
+// Script: <locktime> OP_CHECKSEQUENCEVERIFY OP_DROP <pubkey> OP_CHECKSIG
+type CSVSigClosure struct {
+	PubKey   *btcec.PublicKey
+	Locktime RelativeLocktime
+}
+
+// Script returns the tapscript bytes for this closure.
+func (c *CSVSigClosure) Script() ([]byte, error) {
+	sequence, err := BIP68Sequence(c.Locktime)
+	if err != nil {
+		return nil, err
+	}
+
+	return txscript.NewScriptBuilder().
+		AddInt64(int64(sequence)).
+		AddOp(txscript.OP_CHECKSEQUENCEVERIFY).
+		AddOp(txscript.OP_DROP).
+		AddData(schnorr.SerializePubKey(c.PubKey)).
+		AddOp(txscript.OP_CHECKSIG).
+		Script()
+}
+
+// Decode attempts to parse the given script into this closure type.
+func (c *CSVSigClosure) Decode(script []byte) (bool, error) {
+	if len(script) == 0 {
+		return false, fmt.Errorf("empty script")
+	}
+
+	tokenizer := txscript.MakeScriptTokenizer(0, script)
+
+	// Parse sequence/locktime
+	if !tokenizer.Next() {
+		return false, nil
+	}
+
+	var sequence []byte
+	if txscript.IsSmallInt(tokenizer.Opcode()) {
+		sequence = []byte{tokenizer.Opcode()}
+	} else {
+		sequence = tokenizer.Data()
+	}
+
+	// Expect OP_CHECKSEQUENCEVERIFY OP_DROP
+	for _, opCode := range []byte{txscript.OP_CHECKSEQUENCEVERIFY, txscript.OP_DROP} {
+		if !tokenizer.Next() || tokenizer.Opcode() != opCode {
+			return false, nil
+		}
+	}
+
+	// Parse pubkey (32 bytes)
+	if !tokenizer.Next() || tokenizer.Opcode() != txscript.OP_DATA_32 {
+		return false, nil
+	}
+
+	pubkey, err := schnorr.ParsePubKey(tokenizer.Data())
+	if err != nil {
+		return false, err
+	}
+
+	// Expect OP_CHECKSIG
+	if !tokenizer.Next() || tokenizer.Opcode() != txscript.OP_CHECKSIG {
+		return false, nil
+	}
+
+	// Should be at end of script
+	if tokenizer.Next() {
+		return false, nil
+	}
+
+	locktime, err := BIP68DecodeSequenceFromBytes(sequence)
+	if err != nil {
+		return false, err
+	}
+	if locktime == nil {
+		return false, fmt.Errorf("failed to decode sequence")
+	}
+
+	c.PubKey = pubkey
+	c.Locktime = *locktime
+
+	// Verify the script matches what we would generate
+	rebuilt, err := c.Script()
+	if err != nil {
+		c.PubKey = nil
+		return false, err
+	}
+
+	if !bytes.Equal(rebuilt, script) {
+		c.PubKey = nil
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// Witness constructs the witness stack for spending this closure.
+func (c *CSVSigClosure) Witness(
+	controlBlock []byte, args map[string][]byte,
+) (wire.TxWitness, error) {
+
+	xOnlyPubkey := schnorr.SerializePubKey(c.PubKey)
+	sig, ok := args[hex.EncodeToString(xOnlyPubkey)]
+	if !ok {
+		return nil, fmt.Errorf("missing signature for pubkey %x", xOnlyPubkey)
+	}
+
+	script, err := c.Script()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate script: %w", err)
+	}
+
+	return wire.TxWitness{sig, script, controlBlock}, nil
+}
+
+// CSVMultisigClosure is a closure that contains a list of public keys and a
+// CHECKSEQUENCEVERIFY. The witness size is 64 bytes per key, admitting
+// the sighash type is SIGHASH_DEFAULT.
+type CSVMultisigClosure struct {
+	MultisigClosure
+	Locktime RelativeLocktime
+}
+
+// Witness constructs the witness stack for spending this closure.
+func (f *CSVMultisigClosure) Witness(
+	controlBlock []byte, signatures map[string][]byte,
+) (wire.TxWitness, error) {
+	multisigWitness, err := f.MultisigClosure.Witness(controlBlock, signatures)
+	if err != nil {
+		return nil, err
+	}
+
+	script, err := f.Script()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate script: %w", err)
+	}
+
+	// replace script with csv script
+	multisigWitness[len(multisigWitness)-2] = script
+
+	return multisigWitness, nil
+}
+
+// Script returns the tapscript bytes for this closure.
+func (d *CSVMultisigClosure) Script() ([]byte, error) {
+	sequence, err := BIP68Sequence(d.Locktime)
+	if err != nil {
+		return nil, err
+	}
+
+	csvScript, err := txscript.NewScriptBuilder().
+		AddInt64(int64(sequence)).
+		AddOps([]byte{
+			txscript.OP_CHECKSEQUENCEVERIFY,
+			txscript.OP_DROP,
+		}).
+		Script()
+	if err != nil {
+		return nil, err
+	}
+
+	multisigScript, err := d.MultisigClosure.Script()
+	if err != nil {
+		return nil, err
+	}
+
+	return append(csvScript, multisigScript...), nil
+}
+
+// Decode attempts to parse the given script into this closure type.
+func (d *CSVMultisigClosure) Decode(script []byte) (bool, error) {
+	if len(script) == 0 {
+		return false, fmt.Errorf("empty script")
+	}
+
+	tokenizer := txscript.MakeScriptTokenizer(0, script)
+
+	// Advance the tokenizer to the next token and extract the sequence.
+	// If the opcode represents a small integer, store it as a single byte
+	// in the sequence. Otherwise, extract the data directly from the
+	// tokenizer.
+	if !tokenizer.Next() {
+		return false, nil
+	}
+
+	var sequence []byte
+	if txscript.IsSmallInt(tokenizer.Opcode()) {
+		sequence = []byte{tokenizer.Opcode()}
+	} else {
+		sequence = tokenizer.Data()
+	}
+
+	for _, opCode := range []byte{txscript.OP_CHECKSEQUENCEVERIFY, txscript.OP_DROP} {
+
+		if !tokenizer.Next() || tokenizer.Opcode() != opCode {
+			return false, nil
+		}
+
+	}
+
+	locktime, err := BIP68DecodeSequenceFromBytes(sequence)
+	if err != nil {
+		return false, err
+	}
+	if locktime == nil {
+		return false, fmt.Errorf("failed to decode sequence: locktime is nil")
+	}
+
+	multisigClosure := &MultisigClosure{}
+	subScript := tokenizer.Script()[tokenizer.ByteIndex():]
+	valid, err := multisigClosure.Decode(subScript)
+	if err != nil {
+		return false, err
+	}
+
+	if !valid {
+		return false, nil
+	}
+
+	d.Locktime = *locktime
+	d.MultisigClosure = *multisigClosure
+
+	return valid, nil
+}
+
+// CLTVMultisigClosure is a closure that contains a list of public keys and a
+// CHECKLOCKTIMEVERIFY. The witness size is 64 bytes per key, admitting
+// the sighash type is SIGHASH_DEFAULT.
+type CLTVMultisigClosure struct {
+	MultisigClosure
+	Locktime AbsoluteLocktime
+}
+
+// Witness constructs the witness stack for spending this closure.
+func (f *CLTVMultisigClosure) Witness(
+	controlBlock []byte, signatures map[string][]byte,
+) (wire.TxWitness, error) {
+	multisigWitness, err := f.MultisigClosure.Witness(controlBlock, signatures)
+	if err != nil {
+		return nil, err
+	}
+
+	script, err := f.Script()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate script: %w", err)
+	}
+
+	// replace script with cltv script
+	multisigWitness[len(multisigWitness)-2] = script
+
+	return multisigWitness, nil
+}
+
+// Script returns the tapscript bytes for this closure.
+func (d *CLTVMultisigClosure) Script() ([]byte, error) {
+	cltvScript, err := txscript.NewScriptBuilder().
+		AddInt64(int64(d.Locktime)).
+		AddOps([]byte{
+			txscript.OP_CHECKLOCKTIMEVERIFY,
+			txscript.OP_DROP,
+		}).
+		Script()
+	if err != nil {
+		return nil, err
+	}
+
+	multisigScript, err := d.MultisigClosure.Script()
+	if err != nil {
+		return nil, err
+	}
+
+	return append(cltvScript, multisigScript...), nil
+}
+
+// Decode attempts to parse the given script into this closure type.
+func (d *CLTVMultisigClosure) Decode(script []byte) (bool, error) {
+	if len(script) == 0 {
+		return false, fmt.Errorf("empty script")
+	}
+
+	tokenizer := txscript.MakeScriptTokenizer(0, script)
+
+	// Advance the tokenizer to the next token and extract the locktime.
+	// If the opcode represents a small integer, store it as a single byte
+	// in the sequence. Otherwise, extract the data directly from the
+	// tokenizer.
+	if !tokenizer.Next() {
+		return false, nil
+	}
+
+	var locktime int32
+	isSmallInt := txscript.IsSmallInt(tokenizer.Opcode())
+	if isSmallInt {
+		locktime = int32(tokenizer.Opcode() - txscript.OP_1 + 1)
+	} else {
+		locktimeValue, err := txscript.MakeScriptNum(tokenizer.Data(), true, 6)
+		if err != nil {
+			return false, err
+		}
+		locktime = locktimeValue.Int32()
+		if locktime > 0 && locktime <= 16 {
+			return false, fmt.Errorf("expected minimal encoding OP_%d for locktime value %d", locktime, locktime)
+		}
+	}
+
+	for _, opCode := range []byte{txscript.OP_CHECKLOCKTIMEVERIFY, txscript.OP_DROP} {
+		if !tokenizer.Next() || tokenizer.Opcode() != opCode {
+			return false, nil
+		}
+	}
+
+	multisigClosure := &MultisigClosure{}
+	subScript := tokenizer.Script()[tokenizer.ByteIndex():]
+	valid, err := multisigClosure.Decode(subScript)
+	if err != nil {
+		return false, err
+	}
+
+	if !valid {
+		return false, nil
+	}
+
+	d.Locktime = AbsoluteLocktime(locktime)
+	d.MultisigClosure = *multisigClosure
+
+	return valid, nil
+}
+
+// ConditionMultisigClosure is a closure that contains a condition and a
+// multisig closure. The condition is a boolean script that is executed with the
+// multisig witness.
+type ConditionMultisigClosure struct {
+	MultisigClosure
+	Condition []byte
+}
+
+// Script returns the tapscript bytes for this closure.
+func (f *ConditionMultisigClosure) Script() ([]byte, error) {
+	scriptBuilder := txscript.NewScriptBuilder()
+
+	scriptBuilder.AddOps(f.Condition)
+	scriptBuilder.AddOp(txscript.OP_VERIFY)
+
+	// Add the multisig script
+	multisigScript, err := f.MultisigClosure.Script()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate multisig script: %w", err)
+	}
+	scriptBuilder.AddOps(multisigScript)
+
+	return scriptBuilder.Script()
+}
+
+// Decode attempts to parse the given script into this closure type.
+func (f *ConditionMultisigClosure) Decode(script []byte) (bool, error) {
+	tokenizer := txscript.MakeScriptTokenizer(0, script)
+
+	if len(tokenizer.Script()) == 0 {
+		return false, fmt.Errorf("empty script")
+	}
+
+	condition := make([]byte, 0)
+	for tokenizer.Next() {
+		if tokenizer.Opcode() == txscript.OP_VERIFY {
+			break
+		} else {
+			condition = append(condition, tokenizer.Opcode())
+			if len(tokenizer.Data()) > 0 {
+				condition = append(condition, tokenizer.Data()...)
+			}
+		}
+	}
+
+	f.Condition = condition
+
+	// Decode multisig closure
+	subScript := tokenizer.Script()[tokenizer.ByteIndex():]
+	valid, err := f.MultisigClosure.Decode(subScript)
+	if err != nil || !valid {
+		return false, err
+	}
+
+	// Verify the script matches what we would generate
+	rebuilt, err := f.Script()
+	if err != nil {
+		return false, err
+	}
+
+	return bytes.Equal(rebuilt, script), nil
+}
+
+// Witness constructs the witness stack for spending this closure.
+func (f *ConditionMultisigClosure) Witness(
+	controlBlock []byte, args map[string][]byte,
+) (wire.TxWitness, error) {
+	script, err := f.Script()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate script: %w", err)
+	}
+
+	// Read and execute condition witness
+	condWitness, err := ReadTxWitness(args[ConditionWitnessKey])
+	if err != nil {
+		return nil, fmt.Errorf("failed to read condition witness: %w", err)
+	}
+
+	returnValue, err := EvaluateScriptToBool(f.Condition, condWitness)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute condition: %w", err)
+	}
+
+	if !returnValue {
+		return nil, fmt.Errorf("condition evaluated to false")
+	}
+
+	// Get multisig witness
+	multisigWitness, err := f.MultisigClosure.Witness(controlBlock, args)
+	if err != nil {
+		return nil, err
+	}
+
+	multisigWitness = multisigWitness[:len(multisigWitness)-2] // remove control block and script
+	witness := append(multisigWitness, condWitness...)
+	witness = append(witness, script)
+	witness = append(witness, controlBlock)
+
+	return witness, nil
+}
+
+// ConditionCSVMultisigClosure is a closure that contains a condition and a
+// CSV multisig closure. The condition is a boolean script that is executed
+// with the multisig witness.
+type ConditionCSVMultisigClosure struct {
+	CSVMultisigClosure
+	Condition []byte
+}
+
+// Script returns the tapscript bytes for this closure.
+func (f *ConditionCSVMultisigClosure) Script() ([]byte, error) {
+	scriptBuilder := txscript.NewScriptBuilder()
+
+	scriptBuilder.AddOps(f.Condition)
+	scriptBuilder.AddOp(txscript.OP_VERIFY)
+
+	// Add the multisig script
+	multisigScript, err := f.CSVMultisigClosure.Script()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate multisig script: %w", err)
+	}
+	scriptBuilder.AddOps(multisigScript)
+
+	return scriptBuilder.Script()
+}
+
+// Decode attempts to parse the given script into this closure type.
+func (f *ConditionCSVMultisigClosure) Decode(script []byte) (bool, error) {
+	tokenizer := txscript.MakeScriptTokenizer(0, script)
+
+	if len(tokenizer.Script()) == 0 {
+		return false, fmt.Errorf("empty script")
+	}
+
+	condition := make([]byte, 0)
+	for tokenizer.Next() {
+		if tokenizer.Opcode() == txscript.OP_VERIFY {
+			break
+		} else {
+			condition = append(condition, tokenizer.Opcode())
+			if len(tokenizer.Data()) > 0 {
+				condition = append(condition, tokenizer.Data()...)
+			}
+		}
+	}
+
+	f.Condition = condition
+
+	// Decode multisig closure
+	subScript := tokenizer.Script()[tokenizer.ByteIndex():]
+	valid, err := f.CSVMultisigClosure.Decode(subScript)
+	if err != nil || !valid {
+		return false, err
+	}
+
+	// Verify the script matches what we would generate
+	rebuilt, err := f.Script()
+	if err != nil {
+		return false, err
+	}
+
+	return bytes.Equal(rebuilt, script), nil
+}
+
+// Witness constructs the witness stack for spending this closure.
+func (f *ConditionCSVMultisigClosure) Witness(
+	controlBlock []byte, args map[string][]byte,
+) (wire.TxWitness, error) {
+	script, err := f.Script()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate script: %w", err)
+	}
+
+	// Read and execute condition witness
+	condWitness, err := ReadTxWitness(args[ConditionWitnessKey])
+	if err != nil {
+		return nil, fmt.Errorf("failed to read condition witness: %w", err)
+	}
+
+	returnValue, err := EvaluateScriptToBool(f.Condition, condWitness)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute condition: %w", err)
+	}
+
+	if !returnValue {
+		return nil, fmt.Errorf("condition evaluated to false")
+	}
+
+	// Get multisig witness
+	multisigWitness, err := f.CSVMultisigClosure.Witness(controlBlock, args)
+	if err != nil {
+		return nil, err
+	}
+
+	multisigWitness = multisigWitness[:len(multisigWitness)-2] // remove control block and script
+	witness := append(multisigWitness, condWitness...)
+	witness = append(witness, script)
+	witness = append(witness, controlBlock)
+
+	return witness, nil
+}

--- a/lib/closure/closure_test.go
+++ b/lib/closure/closure_test.go
@@ -1,0 +1,794 @@
+package closure
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/stretchr/testify/require"
+)
+
+// TestClosureScriptRoundtrip verifies that Script() -> Decode() preserves
+// data for all closure types.
+func TestClosureScriptRoundtrip(t *testing.T) {
+	t.Parallel()
+
+	key1 := createTestKey(1)
+	key2 := createTestKey(2)
+	key3 := createTestKey(3)
+
+	t.Run("CSVSigClosure roundtrip", func(t *testing.T) {
+		t.Parallel()
+
+		original := &CSVSigClosure{
+			PubKey: key1,
+			Locktime: RelativeLocktime{
+				Type:  LocktimeTypeSecond,
+				Value: 1024,
+			},
+		}
+
+		script, err := original.Script()
+		require.NoError(t, err)
+		require.NotEmpty(t, script)
+
+		decoded := &CSVSigClosure{}
+		valid, err := decoded.Decode(script)
+		require.NoError(t, err)
+		require.True(t, valid)
+
+		require.True(t, original.PubKey.IsEqual(decoded.PubKey))
+		require.Equal(t, original.Locktime, decoded.Locktime)
+	})
+
+	t.Run("CSVSigClosure with block locktime", func(t *testing.T) {
+		t.Parallel()
+
+		original := &CSVSigClosure{
+			PubKey: key1,
+			Locktime: RelativeLocktime{
+				Type:  LocktimeTypeBlock,
+				Value: 100,
+			},
+		}
+
+		script, err := original.Script()
+		require.NoError(t, err)
+
+		decoded := &CSVSigClosure{}
+		valid, err := decoded.Decode(script)
+		require.NoError(t, err)
+		require.True(t, valid)
+
+		require.True(t, original.PubKey.IsEqual(decoded.PubKey))
+		require.Equal(t, original.Locktime, decoded.Locktime)
+	})
+
+	t.Run("CSVMultisigClosure roundtrip", func(t *testing.T) {
+		t.Parallel()
+
+		original := &CSVMultisigClosure{
+			MultisigClosure: MultisigClosure{
+				PubKeys: []*btcec.PublicKey{key1, key2},
+				Type:    MultisigTypeChecksig,
+			},
+			Locktime: RelativeLocktime{
+				Type:  LocktimeTypeSecond,
+				Value: 2048,
+			},
+		}
+
+		script, err := original.Script()
+		require.NoError(t, err)
+		require.NotEmpty(t, script)
+
+		decoded := &CSVMultisigClosure{}
+		valid, err := decoded.Decode(script)
+		require.NoError(t, err)
+		require.True(t, valid)
+
+		require.Len(t, decoded.PubKeys, 2)
+		require.True(t, original.PubKeys[0].IsEqual(decoded.PubKeys[0]))
+		require.True(t, original.PubKeys[1].IsEqual(decoded.PubKeys[1]))
+		require.Equal(t, original.Locktime, decoded.Locktime)
+	})
+
+	t.Run("MultisigClosure CHECKSIG roundtrip", func(t *testing.T) {
+		t.Parallel()
+
+		original := &MultisigClosure{
+			PubKeys: []*btcec.PublicKey{key1, key2},
+			Type:    MultisigTypeChecksig,
+		}
+
+		script, err := original.Script()
+		require.NoError(t, err)
+		require.NotEmpty(t, script)
+
+		decoded := &MultisigClosure{}
+		valid, err := decoded.Decode(script)
+		require.NoError(t, err)
+		require.True(t, valid)
+
+		require.Len(t, decoded.PubKeys, 2)
+		require.True(t, original.PubKeys[0].IsEqual(decoded.PubKeys[0]))
+		require.True(t, original.PubKeys[1].IsEqual(decoded.PubKeys[1]))
+		require.Equal(t, MultisigTypeChecksig, decoded.Type)
+	})
+
+	t.Run("MultisigClosure CHECKSIGADD roundtrip", func(t *testing.T) {
+		t.Parallel()
+
+		original := &MultisigClosure{
+			PubKeys: []*btcec.PublicKey{key1, key2, key3},
+			Type:    MultisigTypeChecksigAdd,
+		}
+
+		script, err := original.Script()
+		require.NoError(t, err)
+		require.NotEmpty(t, script)
+
+		decoded := &MultisigClosure{}
+		valid, err := decoded.Decode(script)
+		require.NoError(t, err)
+		require.True(t, valid)
+
+		require.Len(t, decoded.PubKeys, 3)
+		for i := range original.PubKeys {
+			isEqual := original.PubKeys[i].IsEqual(decoded.PubKeys[i])
+			require.True(t, isEqual)
+		}
+		require.Equal(t, MultisigTypeChecksigAdd, decoded.Type)
+	})
+
+	t.Run("CLTVMultisigClosure roundtrip", func(t *testing.T) {
+		t.Parallel()
+
+		original := &CLTVMultisigClosure{
+			MultisigClosure: MultisigClosure{
+				PubKeys: []*btcec.PublicKey{key1, key2},
+				Type:    MultisigTypeChecksig,
+			},
+			// Seconds-based (>= 500000000).
+			Locktime: AbsoluteLocktime(500000001),
+		}
+
+		script, err := original.Script()
+		require.NoError(t, err)
+		require.NotEmpty(t, script)
+
+		decoded := &CLTVMultisigClosure{}
+		valid, err := decoded.Decode(script)
+		require.NoError(t, err)
+		require.True(t, valid)
+
+		require.Len(t, decoded.PubKeys, 2)
+		require.True(t, original.PubKeys[0].IsEqual(decoded.PubKeys[0]))
+		require.True(t, original.PubKeys[1].IsEqual(decoded.PubKeys[1]))
+		require.Equal(t, original.Locktime, decoded.Locktime)
+	})
+
+	t.Run("CLTVMultisigClosure block-based locktime", func(t *testing.T) {
+		t.Parallel()
+
+		original := &CLTVMultisigClosure{
+			MultisigClosure: MultisigClosure{
+				PubKeys: []*btcec.PublicKey{key1, key2},
+				Type:    MultisigTypeChecksig,
+			},
+			// Block-based (< 500000000).
+			Locktime: AbsoluteLocktime(1000),
+		}
+
+		script, err := original.Script()
+		require.NoError(t, err)
+		require.NotEmpty(t, script)
+
+		decoded := &CLTVMultisigClosure{}
+		valid, err := decoded.Decode(script)
+		require.NoError(t, err)
+		require.True(t, valid)
+
+		require.Equal(t, original.Locktime, decoded.Locktime)
+	})
+
+	t.Run("ConditionMultisigClosure roundtrip", func(t *testing.T) {
+		t.Parallel()
+
+		// Simple condition: OP_1 (always true).
+		condition := []byte{txscript.OP_1}
+
+		original := &ConditionMultisigClosure{
+			MultisigClosure: MultisigClosure{
+				PubKeys: []*btcec.PublicKey{key1, key2},
+				Type:    MultisigTypeChecksig,
+			},
+			Condition: condition,
+		}
+
+		script, err := original.Script()
+		require.NoError(t, err)
+		require.NotEmpty(t, script)
+
+		decoded := &ConditionMultisigClosure{}
+		valid, err := decoded.Decode(script)
+		require.NoError(t, err)
+		require.True(t, valid)
+
+		require.Len(t, decoded.PubKeys, 2)
+		require.True(t, original.PubKeys[0].IsEqual(decoded.PubKeys[0]))
+		require.True(t, original.PubKeys[1].IsEqual(decoded.PubKeys[1]))
+		require.Equal(t, original.Condition, decoded.Condition)
+	})
+
+	t.Run("ConditionCSVMultisigClosure roundtrip", func(t *testing.T) {
+		t.Parallel()
+
+		// Simple condition: OP_1 (always true).
+		condition := []byte{txscript.OP_1}
+
+		original := &ConditionCSVMultisigClosure{
+			CSVMultisigClosure: CSVMultisigClosure{
+				MultisigClosure: MultisigClosure{
+					PubKeys: []*btcec.PublicKey{key1, key2},
+					Type:    MultisigTypeChecksig,
+				},
+				Locktime: RelativeLocktime{
+					Type:  LocktimeTypeSecond,
+					Value: 1024,
+				},
+			},
+			Condition: condition,
+		}
+
+		script, err := original.Script()
+		require.NoError(t, err)
+		require.NotEmpty(t, script)
+
+		decoded := &ConditionCSVMultisigClosure{}
+		valid, err := decoded.Decode(script)
+		require.NoError(t, err)
+		require.True(t, valid)
+
+		require.Len(t, decoded.PubKeys, 2)
+		require.True(t, original.PubKeys[0].IsEqual(decoded.PubKeys[0]))
+		require.True(t, original.PubKeys[1].IsEqual(decoded.PubKeys[1]))
+		require.Equal(t, original.Condition, decoded.Condition)
+		require.Equal(t, original.Locktime, decoded.Locktime)
+	})
+}
+
+// TestDecodeClosure_AutoDetection verifies that DecodeClosure correctly
+// identifies the closure type from raw script bytes.
+func TestDecodeClosure_AutoDetection(t *testing.T) {
+	t.Parallel()
+
+	key1 := createTestKey(1)
+	key2 := createTestKey(2)
+
+	t.Run("detects CSVSigClosure", func(t *testing.T) {
+		t.Parallel()
+
+		original := &CSVSigClosure{
+			PubKey: key1,
+			Locktime: RelativeLocktime{
+				Type:  LocktimeTypeSecond,
+				Value: 1024,
+			},
+		}
+
+		script, err := original.Script()
+		require.NoError(t, err)
+
+		decoded, err := DecodeClosure(script)
+		require.NoError(t, err)
+
+		csv, ok := decoded.(*CSVSigClosure)
+		require.True(t, ok, "expected CSVSigClosure, got %T", decoded)
+		require.True(t, original.PubKey.IsEqual(csv.PubKey))
+	})
+
+	t.Run("detects CSVMultisigClosure", func(t *testing.T) {
+		t.Parallel()
+
+		original := &CSVMultisigClosure{
+			MultisigClosure: MultisigClosure{
+				PubKeys: []*btcec.PublicKey{key1, key2},
+				Type:    MultisigTypeChecksig,
+			},
+			Locktime: RelativeLocktime{
+				Type:  LocktimeTypeSecond,
+				Value: 1024,
+			},
+		}
+
+		script, err := original.Script()
+		require.NoError(t, err)
+
+		decoded, err := DecodeClosure(script)
+		require.NoError(t, err)
+
+		csv, ok := decoded.(*CSVMultisigClosure)
+		require.True(t, ok, "expected CSVMultisigClosure, got %T", decoded)
+		require.Len(t, csv.PubKeys, 2)
+	})
+
+	t.Run("detects MultisigClosure CHECKSIG", func(t *testing.T) {
+		t.Parallel()
+
+		original := &MultisigClosure{
+			PubKeys: []*btcec.PublicKey{key1, key2},
+			Type:    MultisigTypeChecksig,
+		}
+
+		script, err := original.Script()
+		require.NoError(t, err)
+
+		decoded, err := DecodeClosure(script)
+		require.NoError(t, err)
+
+		ms, ok := decoded.(*MultisigClosure)
+		require.True(t, ok, "expected MultisigClosure, got %T", decoded)
+		require.Equal(t, MultisigTypeChecksig, ms.Type)
+	})
+
+	t.Run("detects MultisigClosure CHECKSIGADD", func(t *testing.T) {
+		t.Parallel()
+
+		key3 := createTestKey(3)
+		original := &MultisigClosure{
+			PubKeys: []*btcec.PublicKey{key1, key2, key3},
+			Type:    MultisigTypeChecksigAdd,
+		}
+
+		script, err := original.Script()
+		require.NoError(t, err)
+
+		decoded, err := DecodeClosure(script)
+		require.NoError(t, err)
+
+		ms, ok := decoded.(*MultisigClosure)
+		require.True(t, ok, "expected MultisigClosure, got %T", decoded)
+		require.Equal(t, MultisigTypeChecksigAdd, ms.Type)
+	})
+
+	t.Run("detects CLTVMultisigClosure", func(t *testing.T) {
+		t.Parallel()
+
+		original := &CLTVMultisigClosure{
+			MultisigClosure: MultisigClosure{
+				PubKeys: []*btcec.PublicKey{key1, key2},
+				Type:    MultisigTypeChecksig,
+			},
+			Locktime: AbsoluteLocktime(500000001),
+		}
+
+		script, err := original.Script()
+		require.NoError(t, err)
+
+		decoded, err := DecodeClosure(script)
+		require.NoError(t, err)
+
+		cltv, ok := decoded.(*CLTVMultisigClosure)
+		require.True(t, ok, "expected CLTVMultisigClosure, got %T", decoded)
+		require.Equal(t, original.Locktime, cltv.Locktime)
+	})
+
+	t.Run("detects ConditionMultisigClosure", func(t *testing.T) {
+		t.Parallel()
+
+		condition := []byte{txscript.OP_1}
+		original := &ConditionMultisigClosure{
+			MultisigClosure: MultisigClosure{
+				PubKeys: []*btcec.PublicKey{key1, key2},
+				Type:    MultisigTypeChecksig,
+			},
+			Condition: condition,
+		}
+
+		script, err := original.Script()
+		require.NoError(t, err)
+
+		decoded, err := DecodeClosure(script)
+		require.NoError(t, err)
+
+		cond, ok := decoded.(*ConditionMultisigClosure)
+		require.True(t, ok, "expected ConditionMultisigClosure, got %T", decoded)
+		require.Equal(t, condition, cond.Condition)
+	})
+
+	t.Run("detects ConditionCSVMultisigClosure", func(t *testing.T) {
+		t.Parallel()
+
+		condition := []byte{txscript.OP_1}
+		original := &ConditionCSVMultisigClosure{
+			CSVMultisigClosure: CSVMultisigClosure{
+				MultisigClosure: MultisigClosure{
+					PubKeys: []*btcec.PublicKey{key1, key2},
+					Type:    MultisigTypeChecksig,
+				},
+				Locktime: RelativeLocktime{
+					Type:  LocktimeTypeSecond,
+					Value: 1024,
+				},
+			},
+			Condition: condition,
+		}
+
+		script, err := original.Script()
+		require.NoError(t, err)
+
+		decoded, err := DecodeClosure(script)
+		require.NoError(t, err)
+
+		cond, ok := decoded.(*ConditionCSVMultisigClosure)
+		require.True(t, ok,
+			"expected ConditionCSVMultisigClosure, got %T", decoded)
+		require.Equal(t, condition, cond.Condition)
+	})
+
+	t.Run("empty script returns error", func(t *testing.T) {
+		t.Parallel()
+
+		decoded, err := DecodeClosure([]byte{})
+		require.Error(t, err)
+		require.Nil(t, decoded)
+		require.Contains(t, err.Error(), "cannot decode empty script")
+	})
+
+	t.Run("invalid script returns error", func(t *testing.T) {
+		t.Parallel()
+
+		// Random invalid bytes.
+		invalidScript := []byte{0x01, 0x02, 0x03}
+
+		decoded, err := DecodeClosure(invalidScript)
+		require.Error(t, err)
+		require.Nil(t, decoded)
+	})
+}
+
+// TestMultisigClosure_Variants verifies both CHECKSIG and CHECKSIGADD
+// variants produce correct scripts.
+func TestMultisigClosure_Variants(t *testing.T) {
+	t.Parallel()
+
+	key1 := createTestKey(1)
+	key2 := createTestKey(2)
+	key3 := createTestKey(3)
+
+	t.Run("CHECKSIG variant with 2 keys", func(t *testing.T) {
+		t.Parallel()
+
+		closure := &MultisigClosure{
+			PubKeys: []*btcec.PublicKey{key1, key2},
+			Type:    MultisigTypeChecksig,
+		}
+
+		script, err := closure.Script()
+		require.NoError(t, err)
+
+		// Verify script structure:
+		// <pubkey1> OP_CHECKSIGVERIFY <pubkey2> OP_CHECKSIG
+		tokenizer := txscript.MakeScriptTokenizer(0, script)
+
+		// First pubkey.
+		require.True(t, tokenizer.Next())
+		require.Equal(t, byte(txscript.OP_DATA_32), tokenizer.Opcode())
+		require.Equal(t, schnorr.SerializePubKey(key1), tokenizer.Data())
+
+		// CHECKSIGVERIFY.
+		require.True(t, tokenizer.Next())
+		require.Equal(t, byte(txscript.OP_CHECKSIGVERIFY), tokenizer.Opcode())
+
+		// Second pubkey.
+		require.True(t, tokenizer.Next())
+		require.Equal(t, byte(txscript.OP_DATA_32), tokenizer.Opcode())
+		require.Equal(t, schnorr.SerializePubKey(key2), tokenizer.Data())
+
+		// CHECKSIG.
+		require.True(t, tokenizer.Next())
+		require.Equal(t, byte(txscript.OP_CHECKSIG), tokenizer.Opcode())
+
+		// End of script.
+		require.False(t, tokenizer.Next())
+	})
+
+	t.Run("CHECKSIGADD variant with 3 keys", func(t *testing.T) {
+		t.Parallel()
+
+		closure := &MultisigClosure{
+			PubKeys: []*btcec.PublicKey{key1, key2, key3},
+			Type:    MultisigTypeChecksigAdd,
+		}
+
+		script, err := closure.Script()
+		require.NoError(t, err)
+
+		// Verify script structure:
+		// <pk1> CHECKSIG <pk2> CHECKSIGADD <pk3> CHECKSIGADD 3 NUMEQUAL
+		tokenizer := txscript.MakeScriptTokenizer(0, script)
+
+		// First pubkey + CHECKSIG.
+		require.True(t, tokenizer.Next())
+		require.Equal(t, schnorr.SerializePubKey(key1), tokenizer.Data())
+		require.True(t, tokenizer.Next())
+		require.Equal(t, byte(txscript.OP_CHECKSIG), tokenizer.Opcode())
+
+		// Second pubkey + CHECKSIGADD.
+		require.True(t, tokenizer.Next())
+		require.Equal(t, schnorr.SerializePubKey(key2), tokenizer.Data())
+		require.True(t, tokenizer.Next())
+		require.Equal(t, byte(txscript.OP_CHECKSIGADD), tokenizer.Opcode())
+
+		// Third pubkey + CHECKSIGADD.
+		require.True(t, tokenizer.Next())
+		require.Equal(t, schnorr.SerializePubKey(key3), tokenizer.Data())
+		require.True(t, tokenizer.Next())
+		require.Equal(t, byte(txscript.OP_CHECKSIGADD), tokenizer.Opcode())
+
+		// OP_3 OP_NUMEQUAL.
+		require.True(t, tokenizer.Next())
+		require.Equal(t, byte(txscript.OP_3), tokenizer.Opcode())
+		require.True(t, tokenizer.Next())
+		require.Equal(t, byte(txscript.OP_NUMEQUAL), tokenizer.Opcode())
+	})
+
+	t.Run("single key CHECKSIG", func(t *testing.T) {
+		t.Parallel()
+
+		closure := &MultisigClosure{
+			PubKeys: []*btcec.PublicKey{key1},
+			Type:    MultisigTypeChecksig,
+		}
+
+		script, err := closure.Script()
+		require.NoError(t, err)
+
+		// Verify script structure: <pubkey> OP_CHECKSIG
+		tokenizer := txscript.MakeScriptTokenizer(0, script)
+
+		require.True(t, tokenizer.Next())
+		require.Equal(t, schnorr.SerializePubKey(key1), tokenizer.Data())
+
+		require.True(t, tokenizer.Next())
+		require.Equal(t, byte(txscript.OP_CHECKSIG), tokenizer.Opcode())
+
+		require.False(t, tokenizer.Next())
+	})
+}
+
+// TestMultisigClosure_DecodeDistinguishesVariants verifies that Decode
+// correctly identifies which multisig variant is being used.
+func TestMultisigClosure_DecodeDistinguishesVariants(t *testing.T) {
+	t.Parallel()
+
+	key1 := createTestKey(1)
+	key2 := createTestKey(2)
+	key3 := createTestKey(3)
+
+	t.Run("distinguishes CHECKSIG from CHECKSIGADD", func(t *testing.T) {
+		t.Parallel()
+
+		// Create CHECKSIG variant.
+		checksigClosure := &MultisigClosure{
+			PubKeys: []*btcec.PublicKey{key1, key2},
+			Type:    MultisigTypeChecksig,
+		}
+		checksigScript, err := checksigClosure.Script()
+		require.NoError(t, err)
+
+		// Create CHECKSIGADD variant.
+		checksigAddClosure := &MultisigClosure{
+			PubKeys: []*btcec.PublicKey{key1, key2, key3},
+			Type:    MultisigTypeChecksigAdd,
+		}
+		checksigAddScript, err := checksigAddClosure.Script()
+		require.NoError(t, err)
+
+		// Scripts should be different.
+		require.False(t, bytes.Equal(checksigScript, checksigAddScript))
+
+		// Decode and verify types.
+		decoded1 := &MultisigClosure{}
+		valid, err := decoded1.Decode(checksigScript)
+		require.NoError(t, err)
+		require.True(t, valid)
+		require.Equal(t, MultisigTypeChecksig, decoded1.Type)
+
+		decoded2 := &MultisigClosure{}
+		valid, err = decoded2.Decode(checksigAddScript)
+		require.NoError(t, err)
+		require.True(t, valid)
+		require.Equal(t, MultisigTypeChecksigAdd, decoded2.Type)
+	})
+}
+
+// TestClosure_DecodeEmptyScript verifies that all closure types handle
+// empty scripts correctly.
+func TestClosure_DecodeEmptyScript(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		closure Closure
+	}{
+		{"CSVSigClosure", &CSVSigClosure{}},
+		{"CSVMultisigClosure", &CSVMultisigClosure{}},
+		{"MultisigClosure", &MultisigClosure{}},
+		{"CLTVMultisigClosure", &CLTVMultisigClosure{}},
+		{"ConditionMultisigClosure", &ConditionMultisigClosure{}},
+		{"ConditionCSVMultisigClosure", &ConditionCSVMultisigClosure{}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			valid, err := tc.closure.Decode([]byte{})
+
+			// All closures should reject empty scripts.
+			if err == nil {
+				require.False(t, valid)
+			}
+		})
+	}
+}
+
+// TestCLTVMultisigClosure_LocktimeTypes verifies that CLTV closures correctly
+// handle both block-based and seconds-based locktimes.
+func TestCLTVMultisigClosure_LocktimeTypes(t *testing.T) {
+	t.Parallel()
+
+	key1 := createTestKey(1)
+	key2 := createTestKey(2)
+
+	t.Run("seconds-based locktime (>= 500000000)", func(t *testing.T) {
+		t.Parallel()
+
+		closure := &CLTVMultisigClosure{
+			MultisigClosure: MultisigClosure{
+				PubKeys: []*btcec.PublicKey{key1, key2},
+				Type:    MultisigTypeChecksig,
+			},
+			Locktime: AbsoluteLocktime(500000001),
+		}
+
+		require.True(t, closure.Locktime.IsSeconds())
+
+		script, err := closure.Script()
+		require.NoError(t, err)
+
+		decoded := &CLTVMultisigClosure{}
+		valid, err := decoded.Decode(script)
+		require.NoError(t, err)
+		require.True(t, valid)
+		require.True(t, decoded.Locktime.IsSeconds())
+		require.Equal(t, closure.Locktime, decoded.Locktime)
+	})
+
+	t.Run("block-based locktime (< 500000000)", func(t *testing.T) {
+		t.Parallel()
+
+		closure := &CLTVMultisigClosure{
+			MultisigClosure: MultisigClosure{
+				PubKeys: []*btcec.PublicKey{key1, key2},
+				Type:    MultisigTypeChecksig,
+			},
+			Locktime: AbsoluteLocktime(800000),
+		}
+
+		require.False(t, closure.Locktime.IsSeconds())
+
+		script, err := closure.Script()
+		require.NoError(t, err)
+
+		decoded := &CLTVMultisigClosure{}
+		valid, err := decoded.Decode(script)
+		require.NoError(t, err)
+		require.True(t, valid)
+		require.False(t, decoded.Locktime.IsSeconds())
+		require.Equal(t, closure.Locktime, decoded.Locktime)
+	})
+}
+
+// TestCSVSigClosure_LocktimeTypes verifies that CSV closures correctly handle
+// both block-based and seconds-based locktimes.
+func TestCSVSigClosure_LocktimeTypes(t *testing.T) {
+	t.Parallel()
+
+	key1 := createTestKey(1)
+
+	t.Run("seconds-based relative locktime", func(t *testing.T) {
+		t.Parallel()
+
+		closure := &CSVSigClosure{
+			PubKey: key1,
+			Locktime: RelativeLocktime{
+				Type:  LocktimeTypeSecond,
+				Value: 512 * 7, // Multiple of 512 seconds (3584s).
+			},
+		}
+
+		script, err := closure.Script()
+		require.NoError(t, err)
+
+		decoded := &CSVSigClosure{}
+		valid, err := decoded.Decode(script)
+		require.NoError(t, err)
+		require.True(t, valid)
+		require.Equal(t, LocktimeTypeSecond, decoded.Locktime.Type)
+	})
+
+	t.Run("block-based relative locktime", func(t *testing.T) {
+		t.Parallel()
+
+		closure := &CSVSigClosure{
+			PubKey: key1,
+			Locktime: RelativeLocktime{
+				Type:  LocktimeTypeBlock,
+				Value: 144,
+			},
+		}
+
+		script, err := closure.Script()
+		require.NoError(t, err)
+
+		decoded := &CSVSigClosure{}
+		valid, err := decoded.Decode(script)
+		require.NoError(t, err)
+		require.True(t, valid)
+		require.Equal(t, LocktimeTypeBlock, decoded.Locktime.Type)
+		require.Equal(t, uint32(144), decoded.Locktime.Value)
+	})
+}
+
+// TestConditionMultisigClosure_ComplexCondition verifies that condition
+// closures can handle more complex condition scripts.
+func TestConditionMultisigClosure_ComplexCondition(t *testing.T) {
+	t.Parallel()
+
+	key1 := createTestKey(1)
+	key2 := createTestKey(2)
+
+	t.Run("condition with data push", func(t *testing.T) {
+		t.Parallel()
+
+		// Condition: OP_SHA256 <hash> OP_EQUAL
+		// This checks if a preimage hashes to a specific value.
+		preimage := []byte("test_preimage")
+		hash := txscript.NewScriptBuilder()
+		hash.AddOp(txscript.OP_SHA256)
+		// Note: In real usage, you'd compute the actual hash.
+
+		// Simplified condition: OP_DUP OP_DROP OP_1
+		// (Duplicates top of stack, drops it, pushes 1 = always true).
+		condition := []byte{
+			txscript.OP_DUP,
+			txscript.OP_DROP,
+			txscript.OP_1,
+		}
+
+		original := &ConditionMultisigClosure{
+			MultisigClosure: MultisigClosure{
+				PubKeys: []*btcec.PublicKey{key1, key2},
+				Type:    MultisigTypeChecksig,
+			},
+			Condition: condition,
+		}
+
+		script, err := original.Script()
+		require.NoError(t, err)
+
+		decoded := &ConditionMultisigClosure{}
+		valid, err := decoded.Decode(script)
+		require.NoError(t, err)
+		require.True(t, valid)
+
+		_ = preimage // Unused in this simplified test.
+
+		require.Equal(t, condition, decoded.Condition)
+	})
+}

--- a/lib/closure/locktime.go
+++ b/lib/closure/locktime.go
@@ -1,0 +1,129 @@
+package closure
+
+import (
+	"fmt"
+
+	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+)
+
+const (
+	SEQUENCE_LOCKTIME_MASK         = 0x0000ffff
+	SEQUENCE_LOCKTIME_TYPE_FLAG    = 1 << 22
+	SEQUENCE_LOCKTIME_GRANULARITY  = 9
+	SECONDS_MOD                    = 1 << SEQUENCE_LOCKTIME_GRANULARITY
+	SECONDS_MAX                    = SEQUENCE_LOCKTIME_MASK << SEQUENCE_LOCKTIME_GRANULARITY
+	SEQUENCE_LOCKTIME_DISABLE_FLAG = 1 << 31
+
+	SECONDS_PER_BLOCK = 10 * 60 // 10 minutes
+
+	// before this value, nLocktime is interpreted as blockheight
+	nLocktimeMinSeconds = 500_000_000
+)
+
+// RelativeLocktimeType represents a BIP68 relative locktime
+// it is passed as argument to CheckSequenceVerify opcode
+type RelativeLocktimeType uint
+
+const (
+	LocktimeTypeSecond RelativeLocktimeType = iota
+	LocktimeTypeBlock
+)
+
+// AbsoluteLocktime represents an nLocktime value
+// it is used as argument to a CheckLocktimeVerify opcode
+type AbsoluteLocktime uint32
+
+func (l AbsoluteLocktime) IsSeconds() bool {
+	return l >= nLocktimeMinSeconds
+}
+
+// RelativeLocktime represents a BIP68 relative timelock value
+type RelativeLocktime struct {
+	Type  RelativeLocktimeType
+	Value uint32
+}
+
+func (l RelativeLocktime) Seconds() int64 {
+	if l.Type == LocktimeTypeBlock {
+		return int64(l.Value) * SECONDS_PER_BLOCK
+	}
+	return int64(l.Value)
+}
+
+func (l RelativeLocktime) Compare(other RelativeLocktime) int {
+	val := l.Seconds()
+	otherVal := other.Seconds()
+
+	if val == otherVal {
+		return 0
+	}
+	if val < otherVal {
+		return -1
+	}
+	return 1
+}
+
+// LessThan returns true if this locktime is less than the other locktime
+func (l RelativeLocktime) LessThan(other RelativeLocktime) bool {
+	return l.Compare(other) < 0
+}
+
+func BIP68Sequence(locktime RelativeLocktime) (uint32, error) {
+	value := locktime.Value
+	isSeconds := locktime.Type == LocktimeTypeSecond
+	if isSeconds {
+		if value > SECONDS_MAX {
+			return 0, fmt.Errorf("seconds too large, max is %d", SECONDS_MAX)
+		}
+		if value%SECONDS_MOD != 0 {
+			return 0, fmt.Errorf("seconds must be a multiple of %d", SECONDS_MOD)
+		}
+	}
+
+	return blockchain.LockTimeToSequence(isSeconds, value), nil
+}
+
+func BIP68DecodeSequenceFromBytes(sequence []byte) (*RelativeLocktime, error) {
+	scriptNumber, err := txscript.MakeScriptNum(sequence, true, len(sequence))
+	if err != nil {
+		return nil, err
+	}
+
+	if scriptNumber >= txscript.OP_1 && scriptNumber <= txscript.OP_16 {
+		scriptNumber = scriptNumber - (txscript.OP_1 - 1)
+	}
+
+	asNumber := int64(scriptNumber)
+
+	if asNumber&SEQUENCE_LOCKTIME_DISABLE_FLAG != 0 {
+		return nil, fmt.Errorf("sequence is disabled")
+	}
+	if asNumber&SEQUENCE_LOCKTIME_TYPE_FLAG != 0 {
+		seconds := asNumber & SEQUENCE_LOCKTIME_MASK << SEQUENCE_LOCKTIME_GRANULARITY
+		return &RelativeLocktime{Type: LocktimeTypeSecond, Value: uint32(seconds)}, nil
+	}
+
+	return &RelativeLocktime{Type: LocktimeTypeBlock, Value: uint32(asNumber)}, nil
+}
+
+func BIP68DecodeSequence(sequenceNum uint32) (*RelativeLocktime, bool) {
+	relativeLock := int64(sequenceNum & wire.SequenceLockTimeMask)
+
+	switch {
+	case sequenceNum&wire.SequenceLockTimeDisabled == wire.SequenceLockTimeDisabled:
+		return nil, true
+	case sequenceNum&wire.SequenceLockTimeIsSeconds == wire.SequenceLockTimeIsSeconds:
+		timeLockSeconds := (relativeLock << wire.SequenceLockTimeGranularity) - 1
+		return &RelativeLocktime{
+			Type:  LocktimeTypeSecond,
+			Value: uint32(timeLockSeconds),
+		}, false
+	default:
+		return &RelativeLocktime{
+			Type:  LocktimeTypeBlock,
+			Value: uint32(relativeLock),
+		}, false
+	}
+}

--- a/lib/closure/locktime_test.go
+++ b/lib/closure/locktime_test.go
@@ -1,0 +1,437 @@
+package closure
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/wire"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBIP68Sequence_Encoding verifies that BIP68Sequence correctly encodes
+// relative locktimes for both blocks and seconds.
+func TestBIP68Sequence_Encoding(t *testing.T) {
+	t.Parallel()
+
+	t.Run("block-based encoding", func(t *testing.T) {
+		t.Parallel()
+
+		testCases := []struct {
+			blocks   uint32
+			expected uint32
+		}{
+			{blocks: 1, expected: 1},
+			{blocks: 10, expected: 10},
+			{blocks: 144, expected: 144},     // ~1 day
+			{blocks: 1008, expected: 1008},   // ~1 week
+			{blocks: 65535, expected: 65535}, // Maximum blocks
+		}
+
+		for _, tc := range testCases {
+			locktime := RelativeLocktime{
+				Type:  LocktimeTypeBlock,
+				Value: tc.blocks,
+			}
+
+			seq, err := BIP68Sequence(locktime)
+			require.NoError(t, err)
+
+			// Block-based should not have the time flag set.
+			require.Zero(t, seq&SEQUENCE_LOCKTIME_TYPE_FLAG,
+				"block-based should not have time flag")
+
+			// Value should be in the lower 16 bits.
+			require.Equal(t, tc.expected, seq&SEQUENCE_LOCKTIME_MASK)
+		}
+	})
+
+	t.Run("seconds-based encoding", func(t *testing.T) {
+		t.Parallel()
+
+		testCases := []struct {
+			seconds  uint32
+			expected uint32
+		}{
+			// Minimum unit (512s = 1 unit).
+			{seconds: 512, expected: 1},
+			// 1024s = 2 units.
+			{seconds: 1024, expected: 2},
+			// ~1 hour (rounded down to multiple of 512).
+			{seconds: 3600 - 3600%512, expected: (3600 - 3600%512) / 512},
+			// ~1 day (rounded down to multiple of 512).
+			{seconds: 86400 - 86400%512, expected: (86400 - 86400%512) / 512},
+		}
+
+		for _, tc := range testCases {
+			locktime := RelativeLocktime{
+				Type:  LocktimeTypeSecond,
+				Value: tc.seconds,
+			}
+
+			seq, err := BIP68Sequence(locktime)
+			require.NoError(t, err)
+
+			// Seconds-based should have the time flag set.
+			require.NotZero(t, seq&SEQUENCE_LOCKTIME_TYPE_FLAG,
+				"seconds-based should have time flag")
+
+			// Value should be seconds / 512 in the lower 16 bits.
+			require.Equal(t, tc.expected, seq&SEQUENCE_LOCKTIME_MASK)
+		}
+	})
+
+	t.Run("seconds must be multiple of 512", func(t *testing.T) {
+		t.Parallel()
+
+		locktime := RelativeLocktime{
+			Type:  LocktimeTypeSecond,
+			Value: 513, // Not a multiple of 512.
+		}
+
+		_, err := BIP68Sequence(locktime)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "must be a multiple of 512")
+	})
+
+	t.Run("seconds maximum value", func(t *testing.T) {
+		t.Parallel()
+
+		// SECONDS_MAX = 65535 * 512 = 33553920 seconds.
+		locktime := RelativeLocktime{
+			Type:  LocktimeTypeSecond,
+			Value: SECONDS_MAX,
+		}
+
+		seq, err := BIP68Sequence(locktime)
+		require.NoError(t, err)
+		require.NotZero(t, seq)
+
+		// Exceeding max should fail.
+		locktime.Value = SECONDS_MAX + 512
+		_, err = BIP68Sequence(locktime)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "seconds too large")
+	})
+}
+
+// TestBIP68DecodeSequenceFromBytes verifies that BIP68DecodeSequenceFromBytes
+// correctly decodes BIP68 sequences from script number bytes.
+func TestBIP68DecodeSequenceFromBytes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("decode block-based sequence", func(t *testing.T) {
+		t.Parallel()
+
+		testCases := []struct {
+			name   string
+			blocks uint32
+		}{
+			{"small blocks", 10},
+			{"medium blocks", 144},
+			{"large blocks", 1000},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				// Encode first.
+				original := RelativeLocktime{
+					Type:  LocktimeTypeBlock,
+					Value: tc.blocks,
+				}
+				seq, err := BIP68Sequence(original)
+				require.NoError(t, err)
+
+				// Convert to script bytes.
+				seqBytes := encodeSequenceToBytes(seq)
+
+				// Decode.
+				decoded, err := BIP68DecodeSequenceFromBytes(seqBytes)
+				require.NoError(t, err)
+				require.NotNil(t, decoded)
+
+				require.Equal(t, LocktimeTypeBlock, decoded.Type)
+				require.Equal(t, tc.blocks, decoded.Value)
+			})
+		}
+	})
+
+	t.Run("decode seconds-based sequence", func(t *testing.T) {
+		t.Parallel()
+
+		testCases := []struct {
+			name    string
+			seconds uint32
+		}{
+			{"minimum seconds", 512},
+			{"hour of seconds", 3584}, // 7 * 512
+			{"day of seconds", 86016}, // 168 * 512
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				// Encode first.
+				original := RelativeLocktime{
+					Type:  LocktimeTypeSecond,
+					Value: tc.seconds,
+				}
+				seq, err := BIP68Sequence(original)
+				require.NoError(t, err)
+
+				// Convert to script bytes.
+				seqBytes := encodeSequenceToBytes(seq)
+
+				// Decode.
+				decoded, err := BIP68DecodeSequenceFromBytes(seqBytes)
+				require.NoError(t, err)
+				require.NotNil(t, decoded)
+
+				require.Equal(t, LocktimeTypeSecond, decoded.Type)
+				require.Equal(t, tc.seconds, decoded.Value)
+			})
+		}
+	})
+
+	t.Run("roundtrip encoding/decoding", func(t *testing.T) {
+		t.Parallel()
+
+		testCases := []RelativeLocktime{
+			{Type: LocktimeTypeBlock, Value: 1},
+			{Type: LocktimeTypeBlock, Value: 100},
+			{Type: LocktimeTypeBlock, Value: 65535},
+			{Type: LocktimeTypeSecond, Value: 512},
+			{Type: LocktimeTypeSecond, Value: 1024},
+			{Type: LocktimeTypeSecond, Value: 512 * 100},
+		}
+
+		for _, original := range testCases {
+			seq, err := BIP68Sequence(original)
+			require.NoError(t, err)
+
+			seqBytes := encodeSequenceToBytes(seq)
+			decoded, err := BIP68DecodeSequenceFromBytes(seqBytes)
+			require.NoError(t, err)
+			require.NotNil(t, decoded)
+
+			require.Equal(t, original.Type, decoded.Type)
+			require.Equal(t, original.Value, decoded.Value)
+		}
+	})
+}
+
+// TestBIP68DecodeSequence verifies that BIP68DecodeSequence correctly decodes
+// BIP68 sequences from uint32 values.
+func TestBIP68DecodeSequence(t *testing.T) {
+	t.Parallel()
+
+	t.Run("decode disabled sequence", func(t *testing.T) {
+		t.Parallel()
+
+		// Sequence with disable flag set.
+		seq := uint32(wire.SequenceLockTimeDisabled)
+
+		decoded, disabled := BIP68DecodeSequence(seq)
+		require.True(t, disabled)
+		require.Nil(t, decoded)
+	})
+
+	t.Run("decode block-based sequence", func(t *testing.T) {
+		t.Parallel()
+
+		// Block-based sequence (no time flag).
+		seq := uint32(100)
+
+		decoded, disabled := BIP68DecodeSequence(seq)
+		require.False(t, disabled)
+		require.NotNil(t, decoded)
+		require.Equal(t, LocktimeTypeBlock, decoded.Type)
+		require.Equal(t, uint32(100), decoded.Value)
+	})
+
+	t.Run("decode seconds-based sequence", func(t *testing.T) {
+		t.Parallel()
+
+		// Seconds-based sequence (time flag set).
+		// 10 units * 512 seconds/unit = 5120 seconds.
+		seq := uint32(wire.SequenceLockTimeIsSeconds | 10)
+
+		decoded, disabled := BIP68DecodeSequence(seq)
+		require.False(t, disabled)
+		require.NotNil(t, decoded)
+		require.Equal(t, LocktimeTypeSecond, decoded.Type)
+		// Note: BIP68DecodeSequence subtracts 1 from the time calculation.
+		require.Equal(t, uint32(10*512-1), decoded.Value)
+	})
+}
+
+// TestRelativeLocktime_Comparison verifies the comparison methods of
+// RelativeLocktime work correctly.
+func TestRelativeLocktime_Comparison(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Compare returns correct ordering", func(t *testing.T) {
+		t.Parallel()
+
+		small := RelativeLocktime{Type: LocktimeTypeSecond, Value: 512}
+		medium := RelativeLocktime{Type: LocktimeTypeSecond, Value: 1024}
+		large := RelativeLocktime{Type: LocktimeTypeSecond, Value: 2048}
+
+		// Small < Medium.
+		require.Equal(t, -1, small.Compare(medium))
+
+		// Medium > Small.
+		require.Equal(t, 1, medium.Compare(small))
+
+		// Equal values (comparing to self should return 0).
+		mediumCopy := medium
+		require.Equal(t, 0, medium.Compare(mediumCopy))
+
+		// Large > Small.
+		require.Equal(t, 1, large.Compare(small))
+	})
+
+	t.Run("LessThan returns correct result", func(t *testing.T) {
+		t.Parallel()
+
+		small := RelativeLocktime{Type: LocktimeTypeSecond, Value: 512}
+		large := RelativeLocktime{Type: LocktimeTypeSecond, Value: 2048}
+
+		require.True(t, small.LessThan(large))
+		require.False(t, large.LessThan(small))
+		require.False(t, small.LessThan(small))
+	})
+
+	t.Run("compare blocks to seconds", func(t *testing.T) {
+		t.Parallel()
+
+		// 1 block = ~10 minutes = 600 seconds.
+		oneBlock := RelativeLocktime{Type: LocktimeTypeBlock, Value: 1}
+		fiveMinutes := RelativeLocktime{Type: LocktimeTypeSecond, Value: 512}
+
+		// 1 block (600s) > 512s.
+		require.Equal(t, 1, oneBlock.Compare(fiveMinutes))
+		require.False(t, oneBlock.LessThan(fiveMinutes))
+		require.True(t, fiveMinutes.LessThan(oneBlock))
+	})
+
+	t.Run("equivalent block and seconds values", func(t *testing.T) {
+		t.Parallel()
+
+		// 1 block = 600 seconds (10 minutes).
+		oneBlock := RelativeLocktime{
+			Type: LocktimeTypeBlock, Value: 1,
+		}
+		sixHundredSeconds := RelativeLocktime{
+			Type: LocktimeTypeSecond, Value: 600,
+		}
+
+		// They should be equal when compared via Seconds().
+		require.Equal(t, oneBlock.Seconds(), sixHundredSeconds.Seconds())
+		require.Equal(t, 0, oneBlock.Compare(sixHundredSeconds))
+	})
+}
+
+// TestRelativeLocktime_Seconds verifies that the Seconds() method correctly
+// converts relative locktimes to seconds.
+func TestRelativeLocktime_Seconds(t *testing.T) {
+	t.Parallel()
+
+	t.Run("seconds type returns value directly", func(t *testing.T) {
+		t.Parallel()
+
+		locktime := RelativeLocktime{
+			Type:  LocktimeTypeSecond,
+			Value: 3600,
+		}
+
+		require.Equal(t, int64(3600), locktime.Seconds())
+	})
+
+	t.Run("blocks type converts to seconds", func(t *testing.T) {
+		t.Parallel()
+
+		// 1 block = SECONDS_PER_BLOCK = 600 seconds.
+		locktime := RelativeLocktime{
+			Type:  LocktimeTypeBlock,
+			Value: 1,
+		}
+
+		require.Equal(t, int64(SECONDS_PER_BLOCK), locktime.Seconds())
+
+		// 144 blocks = 1 day = 86400 seconds.
+		locktime.Value = 144
+		require.Equal(t, int64(144*SECONDS_PER_BLOCK), locktime.Seconds())
+	})
+}
+
+// TestAbsoluteLocktime_IsSeconds verifies that AbsoluteLocktime.IsSeconds()
+// correctly identifies seconds vs block-based locktimes.
+func TestAbsoluteLocktime_IsSeconds(t *testing.T) {
+	t.Parallel()
+
+	t.Run("values >= 500000000 are seconds", func(t *testing.T) {
+		t.Parallel()
+
+		// Exactly at threshold.
+		locktime := AbsoluteLocktime(500000000)
+		require.True(t, locktime.IsSeconds())
+
+		// Above threshold.
+		locktime = AbsoluteLocktime(500000001)
+		require.True(t, locktime.IsSeconds())
+
+		locktime = AbsoluteLocktime(1700000000) // Unix timestamp.
+		require.True(t, locktime.IsSeconds())
+	})
+
+	t.Run("values < 500000000 are blocks", func(t *testing.T) {
+		t.Parallel()
+
+		// Just below threshold.
+		locktime := AbsoluteLocktime(499999999)
+		require.False(t, locktime.IsSeconds())
+
+		// Typical block heights.
+		locktime = AbsoluteLocktime(800000)
+		require.False(t, locktime.IsSeconds())
+
+		locktime = AbsoluteLocktime(1)
+		require.False(t, locktime.IsSeconds())
+
+		locktime = AbsoluteLocktime(0)
+		require.False(t, locktime.IsSeconds())
+	})
+}
+
+// encodeSequenceToBytes is a helper that encodes a uint32 sequence into
+// script number bytes for testing purposes.
+func encodeSequenceToBytes(seq uint32) []byte {
+	if seq == 0 {
+		return []byte{0}
+	}
+
+	// Encode as little-endian with proper sign handling.
+	result := make([]byte, 0, 5)
+	neg := seq < 0
+
+	absValue := seq
+	if neg {
+		absValue = -seq
+	}
+
+	for absValue > 0 {
+		result = append(result, byte(absValue&0xff))
+		absValue >>= 8
+	}
+
+	// If the high bit is set, we need to add another byte to indicate sign.
+	if result[len(result)-1]&0x80 != 0 {
+		if neg {
+			result = append(result, 0x80)
+		} else {
+			result = append(result, 0x00)
+		}
+	} else if neg {
+		result[len(result)-1] |= 0x80
+	}
+
+	return result
+}

--- a/lib/closure/script.go
+++ b/lib/closure/script.go
@@ -1,0 +1,177 @@
+package closure
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+)
+
+const (
+	OP_INSPECTOUTPUTSCRIPTPUBKEY = 0xd1
+	OP_INSPECTOUTPUTVALUE        = 0xcf
+	OP_PUSHCURRENTINPUTINDEX     = 0xcd
+	OP_INSPECTINPUTVALUE         = 0xc9
+	OP_SUB64                     = 0xd8
+)
+
+type MultisigType int
+
+const (
+	MultisigTypeChecksig MultisigType = iota
+	MultisigTypeChecksigAdd
+)
+
+var ConditionWitnessKey = "condition"
+
+// forbiddenOpcodes are opcodes that are not allowed in a condition script
+var forbiddenOpcodes = []byte{
+	txscript.OP_CHECKMULTISIG,
+	txscript.OP_CHECKSIG,
+	txscript.OP_CHECKSIGVERIFY,
+	txscript.OP_CHECKSIGADD,
+	txscript.OP_CHECKMULTISIGVERIFY,
+	txscript.OP_CHECKLOCKTIMEVERIFY,
+	txscript.OP_CHECKSEQUENCEVERIFY,
+}
+
+// EvaluateScriptToBool executes the script with the provided witness as
+// argument and returns a boolean result that can be evaluated by OP_IF /
+// OP_NOIF opcodes.
+func EvaluateScriptToBool(script []byte, witness wire.TxWitness) (bool, error) {
+	// make sure the script doesn't contain any introspections opcodes
+	// (sig or locktime)
+	tokenizer := txscript.MakeScriptTokenizer(0, script)
+	for tokenizer.Next() {
+		for _, opcode := range forbiddenOpcodes {
+			if tokenizer.OpcodePosition() != -1 && tokenizer.Opcode() == opcode {
+				return false, fmt.Errorf("forbidden opcode %x", opcode)
+			}
+		}
+	}
+
+	// Create a fake transaction with minimal required fields
+	// this is needed to instantiate the script engine without a tx
+	// as we don't validate any tx data, we just need to have a valid tx
+	// structure
+	fakeTx := &wire.MsgTx{
+		Version: 2,
+		TxIn:    []*wire.TxIn{{Sequence: 0xffffffff}}, // At least one input required
+		TxOut:   []*wire.TxOut{{Value: 0}},            // At least one output required
+	}
+
+	// Create a new script engine with the fake tx
+	vm, err := txscript.NewEngine(
+		script,
+		fakeTx,
+		0, // Input index
+		txscript.ScriptVerifyTaproot,
+		nil,
+		nil,
+		0,
+		nil,
+	)
+	if err != nil {
+		return false, fmt.Errorf("failed to create script engine: %w", err)
+	}
+
+	vm.SetStack(witness)
+
+	// Execute the script with the provided witness
+	if err := vm.Execute(); err != nil {
+		if scriptError, ok := err.(txscript.Error); ok {
+			if scriptError.ErrorCode == txscript.ErrEvalFalse {
+				return false, nil
+			}
+		}
+		return false, err
+	}
+
+	finalStack := vm.GetStack()
+
+	if len(finalStack) != 0 {
+		return false, fmt.Errorf(
+			"script must return zero value on the stack, got %d",
+			len(finalStack),
+		)
+	}
+
+	return true, nil
+}
+
+// arkNUMSHex is the hex encoded version of the ARK NUMS key. This is a NUMS
+// key (nothing up my sleeves number) that has no known private key, generated
+// using seed phrase "Ark Protocol NUMS".
+const arkNUMSHex = "02372f225b3caee8213096de3229ee4335306b07c3c169438461b5d4749884ec65"
+
+// UnspendableKey returns the NUMS (nothing up my sleeves) key used as the
+// internal key for taproot outputs where the key path should be unspendable.
+func UnspendableKey() *btcec.PublicKey {
+	pubBytes, _ := hex.DecodeString(arkNUMSHex)
+	pub, _ := btcec.ParsePubKey(pubBytes)
+	return pub
+}
+
+// P2TRScript returns a pay-to-taproot script for the given taproot key.
+func P2TRScript(taprootKey *btcec.PublicKey) ([]byte, error) {
+	return txscript.NewScriptBuilder().
+		AddOp(txscript.OP_1).
+		AddData(schnorr.SerializePubKey(taprootKey)).
+		Script()
+}
+
+// SubDustScript returns an OP_RETURN script with the taproot key as data.
+func SubDustScript(taprootKey *btcec.PublicKey) ([]byte, error) {
+	return txscript.NewScriptBuilder().
+		AddOp(txscript.OP_RETURN).
+		AddData(schnorr.SerializePubKey(taprootKey)).
+		Script()
+}
+
+// IsSubDustScript returns true if the script is a sub-dust OP_RETURN script.
+func IsSubDustScript(script []byte) bool {
+	return len(script) == 32+1+1 &&
+		script[0] == txscript.OP_RETURN &&
+		script[1] == 0x20
+}
+
+// EncodeTaprootSignature encodes a signature with the given sighash type.
+func EncodeTaprootSignature(sig []byte, sigHashType txscript.SigHashType) []byte {
+	if sigHashType == txscript.SigHashDefault {
+		return sig
+	}
+
+	return append(sig, byte(sigHashType))
+}
+
+// ParseTaprootSignature parses a raw signature into its signature and sighash
+// type components.
+func ParseTaprootSignature(rawSig []byte) (*schnorr.Signature, txscript.SigHashType, error) {
+	// If the signature is exactly 64 bytes, then we know we're using the
+	// implicit SIGHASH_DEFAULT sighash type.
+	if len(rawSig) == schnorr.SignatureSize {
+		sig, err := schnorr.ParseSignature(rawSig)
+		if err != nil {
+			return nil, 0, err
+		}
+		return sig, txscript.SigHashDefault, nil
+	}
+
+	// Otherwise, if this is a signature, with a sighash looking byte
+	// appended that isn't all zero, then we'll extract the sighash from
+	// the end of the signature.
+	if len(rawSig) == schnorr.SignatureSize+1 && rawSig[schnorr.SignatureSize] != 0 {
+		sigHashType := txscript.SigHashType(rawSig[schnorr.SignatureSize])
+
+		sig, err := schnorr.ParseSignature(rawSig[:schnorr.SignatureSize])
+		if err != nil {
+			return nil, 0, err
+		}
+		return sig, sigHashType, nil
+	}
+
+	return nil, 0, fmt.Errorf("invalid sig len: %v", len(rawSig))
+}

--- a/lib/closure/vtxo_script.go
+++ b/lib/closure/vtxo_script.go
@@ -1,0 +1,342 @@
+// Package closure provides a flexible system for building VTXO (Virtual
+// Transaction Output) tapscripts from composable closure primitives.
+//
+// A TapscriptsVtxoScript holds an arbitrary collection of Closures, each
+// defining a spend condition as a tapscript leaf. The system supports:
+//
+//   - CSVSigClosure: Exit paths with relative timelocks (single key)
+//   - CSVMultisigClosure: Exit paths with relative timelocks (multiple keys)
+//   - MultisigClosure: Collaborative paths requiring multiple signatures
+//   - CLTVMultisigClosure: Paths with absolute timelocks (CLTV)
+//   - ConditionMultisigClosure: Paths with custom script conditions
+//   - ConditionCSVMultisigClosure: Conditional paths with relative timelocks
+//
+// The key requirement is that every valid VTXO must have at least one exit
+// closure (CSVSigClosure or CSVMultisigClosure) to ensure the owner can
+// unilaterally recover funds after the timeout expires.
+//
+// Closures are categorized by type:
+//   - ExitClosures(): Returns CSVSigClosure and CSVMultisigClosure instances
+//   - ForfeitClosures(): Returns MultisigClosure, CLTVMultisigClosure,
+//     and ConditionMultisigClosure instances (collaborative paths)
+//
+// NOTE: The exit vs collaborative distinction is semantic. Exit closures
+// contain only owner key(s). Collaborative closures include the signer key.
+
+package closure
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+)
+
+var ErrNoExitLeaf = fmt.Errorf("no exit leaf")
+
+// TaprootMerkleProof contains the proof data needed to spend a taproot leaf.
+type TaprootMerkleProof struct {
+	ControlBlock []byte
+	Script       []byte
+}
+
+// NewDefaultVtxoScript returns the common VTXO script: A + S | A after T with:
+// - A: the owner of the VTXO.
+// - S: the pubkey of the signer who provided the liquidity for the VTXO.
+// - T: exit delay that must be waited by alice to spend the VTXO once unrolled
+//
+// onchain.
+func NewDefaultVtxoScript(
+	owner, signer *btcec.PublicKey, exitDelay RelativeLocktime,
+) *TapscriptsVtxoScript {
+	return &TapscriptsVtxoScript{
+		[]Closure{
+			// Exit: owner can spend after CSV delay expires.
+			&CSVSigClosure{
+				PubKey:   owner,
+				Locktime: exitDelay,
+			},
+			// Collab: owner + signer can spend immediately.
+			&MultisigClosure{
+				PubKeys: []*btcec.PublicKey{owner, signer},
+			},
+		},
+	}
+}
+
+// ParseVtxoScript attempts to parse a list of hex-encoded scripts into a
+// VtxoScript.
+func ParseVtxoScript(scripts []string) (*TapscriptsVtxoScript, error) {
+	if len(scripts) == 0 {
+		return nil, fmt.Errorf("empty tapscripts array")
+	}
+
+	vtxoScript := &TapscriptsVtxoScript{}
+	if err := vtxoScript.Decode(scripts); err != nil {
+		return nil, fmt.Errorf("invalid vtxo scripts: %s", scripts)
+	}
+
+	return vtxoScript, nil
+}
+
+// TapscriptsVtxoScript holds a list of closures that make up a VTXO tapscript.
+type TapscriptsVtxoScript struct {
+	Closures []Closure
+}
+
+// Encode returns the hex-encoded scripts for all closures.
+func (v *TapscriptsVtxoScript) Encode() ([]string, error) {
+	encoded := make([]string, 0)
+	for _, closure := range v.Closures {
+		script, err := closure.Script()
+		if err != nil {
+			return nil, err
+		}
+		encoded = append(encoded, hex.EncodeToString(script))
+	}
+	return encoded, nil
+}
+
+// Decode parses hex-encoded scripts into closures.
+func (v *TapscriptsVtxoScript) Decode(scripts []string) error {
+	if len(scripts) == 0 {
+		return fmt.Errorf("empty scripts array")
+	}
+
+	v.Closures = make([]Closure, 0, len(scripts))
+	for _, script := range scripts {
+		scriptBytes, err := hex.DecodeString(script)
+		if err != nil {
+			return err
+		}
+
+		closure, err := DecodeClosure(scriptBytes)
+		if err != nil {
+			return err
+		}
+		v.Closures = append(v.Closures, closure)
+	}
+
+	if len(v.Closures) == 0 {
+		return fmt.Errorf("no valid closures found in scripts")
+	}
+
+	return nil
+}
+
+// Validate checks that the VTXO script is valid for the given signer and
+// minimum locktime.
+func (v *TapscriptsVtxoScript) Validate(
+	signer *btcec.PublicKey, minLocktime RelativeLocktime, blockTypeAllowed bool,
+) error {
+	xOnlySigner := schnorr.SerializePubKey(signer)
+	for _, forfeit := range v.ForfeitClosures() {
+		keys := make([]*btcec.PublicKey, 0)
+		switch c := forfeit.(type) {
+		case *MultisigClosure:
+			keys = c.PubKeys
+		case *CLTVMultisigClosure:
+			if !blockTypeAllowed && !c.Locktime.IsSeconds() {
+				return fmt.Errorf("invalid forfeit closure, CLTV block type not allowed")
+			}
+			keys = c.PubKeys
+		case *ConditionMultisigClosure:
+			keys = c.PubKeys
+		}
+
+		if len(keys) == 0 {
+			return fmt.Errorf(
+				"invalid forfeit closure, expected MultisigClosure, CLTVMultisigClosure or ConditionMultisigClosure",
+			)
+		}
+
+		// must contain signer pubkey
+		found := false
+		for _, pubkey := range keys {
+			if bytes.Equal(schnorr.SerializePubKey(pubkey), xOnlySigner) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("invalid forfeit closure, signer pubkey not found")
+		}
+	}
+
+	for _, closure := range v.ExitClosures() {
+		var locktimeType RelativeLocktimeType
+
+		switch c := closure.(type) {
+		case *CSVSigClosure:
+			locktimeType = c.Locktime.Type
+		case *CSVMultisigClosure:
+			locktimeType = c.Locktime.Type
+		}
+
+		if !blockTypeAllowed && locktimeType == LocktimeTypeBlock {
+			return fmt.Errorf("invalid exit closure, CSV block type not allowed")
+		}
+	}
+
+	smallestExit, err := v.SmallestExitDelay()
+	if err != nil {
+		if err == ErrNoExitLeaf {
+			return nil
+		}
+		return err
+	}
+
+	if smallestExit.LessThan(minLocktime) {
+		return fmt.Errorf("exit delay is too short")
+	}
+
+	return nil
+}
+
+// SmallestExitDelay returns the smallest exit delay among all CSV closures.
+// This checks both CSVSigClosure and CSVMultisigClosure types.
+func (v *TapscriptsVtxoScript) SmallestExitDelay() (*RelativeLocktime, error) {
+	var smallest *RelativeLocktime
+
+	for _, closure := range v.Closures {
+		var locktime *RelativeLocktime
+
+		switch c := closure.(type) {
+		case *CSVSigClosure:
+			locktime = &c.Locktime
+		case *CSVMultisigClosure:
+			locktime = &c.Locktime
+		default:
+			continue
+		}
+
+		if smallest == nil || locktime.LessThan(*smallest) {
+			smallest = locktime
+		}
+	}
+
+	if smallest == nil {
+		return nil, ErrNoExitLeaf
+	}
+
+	return smallest, nil
+}
+
+// ForfeitClosures returns the closures that can be used for forfeit (immediate
+// spend with signer).
+func (v *TapscriptsVtxoScript) ForfeitClosures() []Closure {
+	forfeits := make([]Closure, 0)
+	for _, closure := range v.Closures {
+		switch closure.(type) {
+		case *MultisigClosure, *CLTVMultisigClosure, *ConditionMultisigClosure:
+			forfeits = append(forfeits, closure)
+		}
+	}
+	return forfeits
+}
+
+// ExitClosures returns the closures that can be used for exit (delayed spend
+// by owner only). This includes both CSVSigClosure (single-sig) and
+// CSVMultisigClosure (multi-sig) types.
+func (v *TapscriptsVtxoScript) ExitClosures() []Closure {
+	exits := make([]Closure, 0)
+	for _, closure := range v.Closures {
+		switch closure.(type) {
+		case *CSVSigClosure, *CSVMultisigClosure:
+			exits = append(exits, closure)
+		}
+	}
+	return exits
+}
+
+// TapTree returns the taproot output key and indexed script tree for this VTXO
+// script.
+func (v *TapscriptsVtxoScript) TapTree() (*btcec.PublicKey, *TaprootTree, error) {
+	leaves := make([]txscript.TapLeaf, len(v.Closures))
+	for i, closure := range v.Closures {
+		script, err := closure.Script()
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to get script for closure %d: %w", i, err)
+		}
+		leaves[i] = txscript.NewBaseTapLeaf(script)
+	}
+
+	tapTree := txscript.AssembleTaprootScriptTree(leaves...)
+	root := tapTree.RootNode.TapHash()
+	taprootKey := txscript.ComputeTaprootOutputKey(
+		UnspendableKey(),
+		root[:],
+	)
+
+	return taprootKey, &TaprootTree{tapTree}, nil
+}
+
+// TaprootTree is a wrapper around txscript.IndexedTapScriptTree to provide
+// additional helper methods.
+type TaprootTree struct {
+	*txscript.IndexedTapScriptTree
+}
+
+// GetRoot returns the root hash of the taproot tree.
+func (b *TaprootTree) GetRoot() chainhash.Hash {
+	return b.RootNode.TapHash()
+}
+
+// GetTaprootMerkleProof returns the merkle proof for the given leaf hash.
+func (b *TaprootTree) GetTaprootMerkleProof(
+	leafhash chainhash.Hash,
+) (*TaprootMerkleProof, error) {
+	index, ok := b.LeafProofIndex[leafhash]
+	if !ok {
+		return nil, fmt.Errorf("leaf %s not found in tree", leafhash.String())
+	}
+	proof := b.LeafMerkleProofs[index]
+
+	controlBlock := proof.ToControlBlock(UnspendableKey())
+	controlBlockBytes, err := controlBlock.ToBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	return &TaprootMerkleProof{
+		ControlBlock: controlBlockBytes,
+		Script:       proof.Script,
+	}, nil
+}
+
+// GetLeaves returns all leaf hashes in the tree.
+func (b *TaprootTree) GetLeaves() []chainhash.Hash {
+	leafHashes := make([]chainhash.Hash, 0)
+	for hash := range b.LeafProofIndex {
+		leafHashes = append(leafHashes, hash)
+	}
+	return leafHashes
+}
+
+// GetSpendInfo returns the spend information for a closure at the given index.
+func (v *TapscriptsVtxoScript) GetSpendInfo(
+	closureIndex int,
+) (*TaprootMerkleProof, error) {
+	if closureIndex < 0 || closureIndex >= len(v.Closures) {
+		return nil, fmt.Errorf("closure index %d out of bounds", closureIndex)
+	}
+
+	_, tree, err := v.TapTree()
+	if err != nil {
+		return nil, err
+	}
+
+	script, err := v.Closures[closureIndex].Script()
+	if err != nil {
+		return nil, err
+	}
+
+	leaf := txscript.NewBaseTapLeaf(script)
+	leafHash := leaf.TapHash()
+
+	return tree.GetTaprootMerkleProof(leafHash)
+}

--- a/lib/closure/vtxo_script_test.go
+++ b/lib/closure/vtxo_script_test.go
@@ -1,0 +1,907 @@
+package closure
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// createTestKey creates a deterministic key for testing.
+func createTestKey(index int32) *btcec.PublicKey {
+	_, pubKey := btcec.PrivKeyFromBytes([]byte{
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, byte(index + 1),
+	})
+	return pubKey
+}
+
+// TestValidate_ServerKeyRequirement verifies that the server/signer key must
+// be present in all forfeit (collaborative) closures.
+func TestValidate_ServerKeyRequirement(t *testing.T) {
+	t.Parallel()
+
+	ownerKey := createTestKey(1)
+	signerKey := createTestKey(2)
+	otherKey := createTestKey(3)
+
+	minLocktime := RelativeLocktime{
+		Type:  LocktimeTypeSecond,
+		Value: 512,
+	}
+	exitDelay := RelativeLocktime{
+		Type:  LocktimeTypeSecond,
+		Value: 1024,
+	}
+
+	t.Run("valid MultisigClosure with owner and signer", func(t *testing.T) {
+		vtxoScript := &TapscriptsVtxoScript{
+			Closures: []Closure{
+				&CSVSigClosure{
+					PubKey:   ownerKey,
+					Locktime: exitDelay,
+				},
+				&MultisigClosure{
+					PubKeys: []*btcec.PublicKey{ownerKey, signerKey},
+				},
+			},
+		}
+
+		err := vtxoScript.Validate(signerKey, minLocktime, true)
+		require.NoError(t, err)
+	})
+
+	t.Run("invalid MultisigClosure missing signer key", func(t *testing.T) {
+		vtxoScript := &TapscriptsVtxoScript{
+			Closures: []Closure{
+				&CSVSigClosure{
+					PubKey:   ownerKey,
+					Locktime: exitDelay,
+				},
+				&MultisigClosure{
+					PubKeys: []*btcec.PublicKey{ownerKey, otherKey},
+				},
+			},
+		}
+
+		err := vtxoScript.Validate(signerKey, minLocktime, true)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "signer pubkey not found")
+	})
+
+	t.Run("valid CLTVMultisigClosure with signer key", func(t *testing.T) {
+		vtxoScript := &TapscriptsVtxoScript{
+			Closures: []Closure{
+				&CSVSigClosure{
+					PubKey:   ownerKey,
+					Locktime: exitDelay,
+				},
+				&CLTVMultisigClosure{
+					MultisigClosure: MultisigClosure{
+						PubKeys: []*btcec.PublicKey{ownerKey, signerKey},
+					},
+					Locktime: AbsoluteLocktime(500000001),
+				},
+			},
+		}
+
+		err := vtxoScript.Validate(signerKey, minLocktime, true)
+		require.NoError(t, err)
+	})
+
+	t.Run("invalid CLTVMultisigClosure missing signer key", func(t *testing.T) {
+		vtxoScript := &TapscriptsVtxoScript{
+			Closures: []Closure{
+				&CSVSigClosure{
+					PubKey:   ownerKey,
+					Locktime: exitDelay,
+				},
+				&CLTVMultisigClosure{
+					MultisigClosure: MultisigClosure{
+						PubKeys: []*btcec.PublicKey{ownerKey},
+					},
+					Locktime: AbsoluteLocktime(500000001),
+				},
+			},
+		}
+
+		err := vtxoScript.Validate(signerKey, minLocktime, true)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "signer pubkey not found")
+	})
+
+	t.Run("valid ConditionMultisigClosure with signer key", func(t *testing.T) {
+		// Simple condition: OP_TRUE
+		condition := []byte{0x51}
+
+		vtxoScript := &TapscriptsVtxoScript{
+			Closures: []Closure{
+				&CSVSigClosure{
+					PubKey:   ownerKey,
+					Locktime: exitDelay,
+				},
+				&ConditionMultisigClosure{
+					MultisigClosure: MultisigClosure{
+						PubKeys: []*btcec.PublicKey{ownerKey, signerKey},
+					},
+					Condition: condition,
+				},
+			},
+		}
+
+		err := vtxoScript.Validate(signerKey, minLocktime, true)
+		require.NoError(t, err)
+	})
+
+	t.Run("valid 3-of-3 MultisigClosure with signer key", func(t *testing.T) {
+		// Signer key present among 3 keys.
+		vtxoScript := &TapscriptsVtxoScript{
+			Closures: []Closure{
+				&CSVSigClosure{
+					PubKey:   ownerKey,
+					Locktime: exitDelay,
+				},
+				&MultisigClosure{
+					PubKeys: []*btcec.PublicKey{
+						ownerKey, signerKey, otherKey,
+					},
+				},
+			},
+		}
+
+		err := vtxoScript.Validate(signerKey, minLocktime, true)
+		require.NoError(t, err)
+	})
+}
+
+// TestValidate_LocktimeMinimum verifies that exit closures must meet the
+// minimum locktime requirement.
+func TestValidate_LocktimeMinimum(t *testing.T) {
+	t.Parallel()
+
+	ownerKey := createTestKey(1)
+	signerKey := createTestKey(2)
+
+	minLocktime := RelativeLocktime{
+		Type:  LocktimeTypeSecond,
+		Value: 1024,
+	}
+
+	t.Run("valid exit delay >= minimum", func(t *testing.T) {
+		vtxoScript := &TapscriptsVtxoScript{
+			Closures: []Closure{
+				&CSVSigClosure{
+					PubKey: ownerKey,
+					Locktime: RelativeLocktime{
+						Type:  LocktimeTypeSecond,
+						Value: 2048,
+					},
+				},
+				&MultisigClosure{
+					PubKeys: []*btcec.PublicKey{ownerKey, signerKey},
+				},
+			},
+		}
+
+		err := vtxoScript.Validate(signerKey, minLocktime, true)
+		require.NoError(t, err)
+	})
+
+	t.Run("valid exit delay exactly equal to minimum", func(t *testing.T) {
+		vtxoScript := &TapscriptsVtxoScript{
+			Closures: []Closure{
+				&CSVSigClosure{
+					PubKey:   ownerKey,
+					Locktime: minLocktime,
+				},
+				&MultisigClosure{
+					PubKeys: []*btcec.PublicKey{ownerKey, signerKey},
+				},
+			},
+		}
+
+		err := vtxoScript.Validate(signerKey, minLocktime, true)
+		require.NoError(t, err)
+	})
+
+	t.Run("invalid exit delay less than minimum", func(t *testing.T) {
+		vtxoScript := &TapscriptsVtxoScript{
+			Closures: []Closure{
+				&CSVSigClosure{
+					PubKey: ownerKey,
+					Locktime: RelativeLocktime{
+						Type:  LocktimeTypeSecond,
+						Value: 512,
+					},
+				},
+				&MultisigClosure{
+					PubKeys: []*btcec.PublicKey{ownerKey, signerKey},
+				},
+			},
+		}
+
+		err := vtxoScript.Validate(signerKey, minLocktime, true)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "exit delay is too short")
+	})
+
+	t.Run("multiple exits - smallest must meet minimum", func(t *testing.T) {
+		vtxoScript := &TapscriptsVtxoScript{
+			Closures: []Closure{
+				// Long delay - meets minimum.
+				&CSVSigClosure{
+					PubKey: ownerKey,
+					Locktime: RelativeLocktime{
+						Type:  LocktimeTypeSecond,
+						Value: 4096,
+					},
+				},
+				// Short delay - below minimum.
+				&CSVSigClosure{
+					PubKey: ownerKey,
+					Locktime: RelativeLocktime{
+						Type:  LocktimeTypeSecond,
+						Value: 512,
+					},
+				},
+				&MultisigClosure{
+					PubKeys: []*btcec.PublicKey{ownerKey, signerKey},
+				},
+			},
+		}
+
+		err := vtxoScript.Validate(signerKey, minLocktime, true)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "exit delay is too short")
+	})
+
+	t.Run("CSVMultisigClosure respects minimum locktime", func(t *testing.T) {
+		vtxoScript := &TapscriptsVtxoScript{
+			Closures: []Closure{
+				&CSVMultisigClosure{
+					MultisigClosure: MultisigClosure{
+						PubKeys: []*btcec.PublicKey{ownerKey},
+					},
+					Locktime: RelativeLocktime{
+						Type:  LocktimeTypeSecond,
+						Value: 512,
+					},
+				},
+				&MultisigClosure{
+					PubKeys: []*btcec.PublicKey{ownerKey, signerKey},
+				},
+			},
+		}
+
+		err := vtxoScript.Validate(signerKey, minLocktime, true)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "exit delay is too short")
+	})
+}
+
+// TestValidate_BlockTypeRestriction verifies that block-type locktimes can
+// be disallowed via the blockTypeAllowed parameter.
+func TestValidate_BlockTypeRestriction(t *testing.T) {
+	t.Parallel()
+
+	ownerKey := createTestKey(1)
+	signerKey := createTestKey(2)
+
+	minLocktime := RelativeLocktime{
+		Type:  LocktimeTypeBlock,
+		Value: 10,
+	}
+
+	t.Run("block-based CSV allowed when blockTypeAllowed=true", func(t *testing.T) {
+		vtxoScript := &TapscriptsVtxoScript{
+			Closures: []Closure{
+				&CSVSigClosure{
+					PubKey: ownerKey,
+					Locktime: RelativeLocktime{
+						Type:  LocktimeTypeBlock,
+						Value: 100,
+					},
+				},
+				&MultisigClosure{
+					PubKeys: []*btcec.PublicKey{ownerKey, signerKey},
+				},
+			},
+		}
+
+		err := vtxoScript.Validate(signerKey, minLocktime, true)
+		require.NoError(t, err)
+	})
+
+	t.Run("block-based CSV rejected when blockTypeAllowed=false", func(t *testing.T) {
+		vtxoScript := &TapscriptsVtxoScript{
+			Closures: []Closure{
+				&CSVSigClosure{
+					PubKey: ownerKey,
+					Locktime: RelativeLocktime{
+						Type:  LocktimeTypeBlock,
+						Value: 100,
+					},
+				},
+				&MultisigClosure{
+					PubKeys: []*btcec.PublicKey{ownerKey, signerKey},
+				},
+			},
+		}
+
+		err := vtxoScript.Validate(signerKey, minLocktime, false)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "CSV block type not allowed")
+	})
+
+	t.Run("seconds-based CSV allowed when blockTypeAllowed=false", func(t *testing.T) {
+		minLocktimeSeconds := RelativeLocktime{
+			Type:  LocktimeTypeSecond,
+			Value: 512,
+		}
+
+		vtxoScript := &TapscriptsVtxoScript{
+			Closures: []Closure{
+				&CSVSigClosure{
+					PubKey: ownerKey,
+					Locktime: RelativeLocktime{
+						Type:  LocktimeTypeSecond,
+						Value: 1024,
+					},
+				},
+				&MultisigClosure{
+					PubKeys: []*btcec.PublicKey{ownerKey, signerKey},
+				},
+			},
+		}
+
+		err := vtxoScript.Validate(signerKey, minLocktimeSeconds, false)
+		require.NoError(t, err)
+	})
+
+	t.Run("block-based CLTV rejected when blockTypeAllowed=false", func(t *testing.T) {
+		minLocktimeSeconds := RelativeLocktime{
+			Type:  LocktimeTypeSecond,
+			Value: 512,
+		}
+
+		vtxoScript := &TapscriptsVtxoScript{
+			Closures: []Closure{
+				&CSVSigClosure{
+					PubKey: ownerKey,
+					Locktime: RelativeLocktime{
+						Type:  LocktimeTypeSecond,
+						Value: 1024,
+					},
+				},
+				&CLTVMultisigClosure{
+					MultisigClosure: MultisigClosure{
+						PubKeys: []*btcec.PublicKey{ownerKey, signerKey},
+					},
+					// Block-based (< 500000000).
+					Locktime: AbsoluteLocktime(1000),
+				},
+			},
+		}
+
+		err := vtxoScript.Validate(signerKey, minLocktimeSeconds, false)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "CLTV block type not allowed")
+	})
+
+	t.Run("seconds-based CLTV allowed when blockTypeAllowed=false", func(t *testing.T) {
+		minLocktimeSeconds := RelativeLocktime{
+			Type:  LocktimeTypeSecond,
+			Value: 512,
+		}
+
+		vtxoScript := &TapscriptsVtxoScript{
+			Closures: []Closure{
+				&CSVSigClosure{
+					PubKey: ownerKey,
+					Locktime: RelativeLocktime{
+						Type:  LocktimeTypeSecond,
+						Value: 1024,
+					},
+				},
+				&CLTVMultisigClosure{
+					MultisigClosure: MultisigClosure{
+						PubKeys: []*btcec.PublicKey{ownerKey, signerKey},
+					},
+					// Seconds-based (>= 500000000).
+					Locktime: AbsoluteLocktime(500000001),
+				},
+			},
+		}
+
+		err := vtxoScript.Validate(signerKey, minLocktimeSeconds, false)
+		require.NoError(t, err)
+	})
+}
+
+// TestValidate_NoExitClosures verifies that VTXOs with no exit closures
+// pass validation (special case where ErrNoExitLeaf is ignored).
+func TestValidate_NoExitClosures(t *testing.T) {
+	t.Parallel()
+
+	ownerKey := createTestKey(1)
+	signerKey := createTestKey(2)
+
+	minLocktime := RelativeLocktime{
+		Type:  LocktimeTypeSecond,
+		Value: 512,
+	}
+
+	t.Run("forfeit-only VTXO passes validation", func(t *testing.T) {
+		vtxoScript := &TapscriptsVtxoScript{
+			Closures: []Closure{
+				&MultisigClosure{
+					PubKeys: []*btcec.PublicKey{ownerKey, signerKey},
+				},
+			},
+		}
+
+		err := vtxoScript.Validate(signerKey, minLocktime, true)
+		require.NoError(t, err)
+	})
+}
+
+// TestValidate_MultipleForfeitClosures verifies that ALL forfeit closures
+// must contain the server key, not just some of them.
+func TestValidate_MultipleForfeitClosures(t *testing.T) {
+	t.Parallel()
+
+	ownerKey := createTestKey(1)
+	signerKey := createTestKey(2)
+	otherKey := createTestKey(3)
+
+	minLocktime := RelativeLocktime{
+		Type:  LocktimeTypeSecond,
+		Value: 512,
+	}
+	exitDelay := RelativeLocktime{
+		Type:  LocktimeTypeSecond,
+		Value: 1024,
+	}
+
+	t.Run("all forfeit closures have signer key", func(t *testing.T) {
+		vtxoScript := &TapscriptsVtxoScript{
+			Closures: []Closure{
+				&CSVSigClosure{
+					PubKey:   ownerKey,
+					Locktime: exitDelay,
+				},
+				&MultisigClosure{
+					PubKeys: []*btcec.PublicKey{ownerKey, signerKey},
+				},
+				&CLTVMultisigClosure{
+					MultisigClosure: MultisigClosure{
+						PubKeys: []*btcec.PublicKey{ownerKey, signerKey},
+					},
+					Locktime: AbsoluteLocktime(500000001),
+				},
+			},
+		}
+
+		err := vtxoScript.Validate(signerKey, minLocktime, true)
+		require.NoError(t, err)
+	})
+
+	t.Run("one forfeit closure missing signer key fails", func(t *testing.T) {
+		vtxoScript := &TapscriptsVtxoScript{
+			Closures: []Closure{
+				&CSVSigClosure{
+					PubKey:   ownerKey,
+					Locktime: exitDelay,
+				},
+				// This one has signer key.
+				&MultisigClosure{
+					PubKeys: []*btcec.PublicKey{ownerKey, signerKey},
+				},
+				// This one does NOT have signer key.
+				&CLTVMultisigClosure{
+					MultisigClosure: MultisigClosure{
+						PubKeys: []*btcec.PublicKey{ownerKey, otherKey},
+					},
+					Locktime: AbsoluteLocktime(500000001),
+				},
+			},
+		}
+
+		err := vtxoScript.Validate(signerKey, minLocktime, true)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "signer pubkey not found")
+	})
+}
+
+// TestExitClosures_FilteringLogic verifies that ExitClosures returns only
+// CSV-based closures (CSVSigClosure and CSVMultisigClosure).
+func TestExitClosures_FilteringLogic(t *testing.T) {
+	t.Parallel()
+
+	ownerKey := createTestKey(1)
+	signerKey := createTestKey(2)
+
+	exitDelay := RelativeLocktime{
+		Type:  LocktimeTypeSecond,
+		Value: 1024,
+	}
+
+	vtxoScript := &TapscriptsVtxoScript{
+		Closures: []Closure{
+			&CSVSigClosure{
+				PubKey:   ownerKey,
+				Locktime: exitDelay,
+			},
+			&CSVMultisigClosure{
+				MultisigClosure: MultisigClosure{
+					PubKeys: []*btcec.PublicKey{ownerKey},
+				},
+				Locktime: exitDelay,
+			},
+			&MultisigClosure{
+				PubKeys: []*btcec.PublicKey{ownerKey, signerKey},
+			},
+			&CLTVMultisigClosure{
+				MultisigClosure: MultisigClosure{
+					PubKeys: []*btcec.PublicKey{ownerKey, signerKey},
+				},
+				Locktime: AbsoluteLocktime(500000001),
+			},
+		},
+	}
+
+	exits := vtxoScript.ExitClosures()
+	require.Len(t, exits, 2)
+
+	// Verify types.
+	_, ok := exits[0].(*CSVSigClosure)
+	require.True(t, ok, "first exit should be CSVSigClosure")
+
+	_, ok = exits[1].(*CSVMultisigClosure)
+	require.True(t, ok, "second exit should be CSVMultisigClosure")
+}
+
+// TestForfeitClosures_FilteringLogic verifies that ForfeitClosures returns
+// only collaborative closures (MultisigClosure, CLTVMultisigClosure,
+// ConditionMultisigClosure).
+func TestForfeitClosures_FilteringLogic(t *testing.T) {
+	t.Parallel()
+
+	ownerKey := createTestKey(1)
+	signerKey := createTestKey(2)
+
+	exitDelay := RelativeLocktime{
+		Type:  LocktimeTypeSecond,
+		Value: 1024,
+	}
+
+	condition := []byte{0x51} // OP_TRUE
+
+	vtxoScript := &TapscriptsVtxoScript{
+		Closures: []Closure{
+			&CSVSigClosure{
+				PubKey:   ownerKey,
+				Locktime: exitDelay,
+			},
+			&MultisigClosure{
+				PubKeys: []*btcec.PublicKey{ownerKey, signerKey},
+			},
+			&CLTVMultisigClosure{
+				MultisigClosure: MultisigClosure{
+					PubKeys: []*btcec.PublicKey{ownerKey, signerKey},
+				},
+				Locktime: AbsoluteLocktime(500000001),
+			},
+			&ConditionMultisigClosure{
+				MultisigClosure: MultisigClosure{
+					PubKeys: []*btcec.PublicKey{ownerKey, signerKey},
+				},
+				Condition: condition,
+			},
+		},
+	}
+
+	forfeits := vtxoScript.ForfeitClosures()
+	require.Len(t, forfeits, 3)
+
+	// Verify types.
+	_, ok := forfeits[0].(*MultisigClosure)
+	require.True(t, ok, "first forfeit should be MultisigClosure")
+
+	_, ok = forfeits[1].(*CLTVMultisigClosure)
+	require.True(t, ok, "second forfeit should be CLTVMultisigClosure")
+
+	_, ok = forfeits[2].(*ConditionMultisigClosure)
+	require.True(t, ok, "third forfeit should be ConditionMultisigClosure")
+}
+
+// TestSmallestExitDelay verifies that SmallestExitDelay correctly finds the
+// minimum exit delay across all CSV closures.
+func TestSmallestExitDelay(t *testing.T) {
+	t.Parallel()
+
+	ownerKey := createTestKey(1)
+	signerKey := createTestKey(2)
+
+	t.Run("single exit closure returns its delay", func(t *testing.T) {
+		exitDelay := RelativeLocktime{
+			Type:  LocktimeTypeSecond,
+			Value: 1024,
+		}
+
+		vtxoScript := &TapscriptsVtxoScript{
+			Closures: []Closure{
+				&CSVSigClosure{
+					PubKey:   ownerKey,
+					Locktime: exitDelay,
+				},
+				&MultisigClosure{
+					PubKeys: []*btcec.PublicKey{ownerKey, signerKey},
+				},
+			},
+		}
+
+		smallest, err := vtxoScript.SmallestExitDelay()
+		require.NoError(t, err)
+		require.Equal(t, exitDelay, *smallest)
+	})
+
+	t.Run("multiple exit closures returns smallest", func(t *testing.T) {
+		shortDelay := RelativeLocktime{
+			Type:  LocktimeTypeSecond,
+			Value: 512,
+		}
+		longDelay := RelativeLocktime{
+			Type:  LocktimeTypeSecond,
+			Value: 4096,
+		}
+
+		vtxoScript := &TapscriptsVtxoScript{
+			Closures: []Closure{
+				&CSVSigClosure{
+					PubKey:   ownerKey,
+					Locktime: longDelay,
+				},
+				&CSVSigClosure{
+					PubKey:   ownerKey,
+					Locktime: shortDelay,
+				},
+				&MultisigClosure{
+					PubKeys: []*btcec.PublicKey{ownerKey, signerKey},
+				},
+			},
+		}
+
+		smallest, err := vtxoScript.SmallestExitDelay()
+		require.NoError(t, err)
+		require.Equal(t, shortDelay, *smallest)
+	})
+
+	t.Run("no exit closures returns ErrNoExitLeaf", func(t *testing.T) {
+		vtxoScript := &TapscriptsVtxoScript{
+			Closures: []Closure{
+				&MultisigClosure{
+					PubKeys: []*btcec.PublicKey{ownerKey, signerKey},
+				},
+			},
+		}
+
+		smallest, err := vtxoScript.SmallestExitDelay()
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrNoExitLeaf)
+		require.Nil(t, smallest)
+	})
+
+	t.Run("mixed CSV types finds smallest", func(t *testing.T) {
+		shortDelay := RelativeLocktime{
+			Type:  LocktimeTypeSecond,
+			Value: 512,
+		}
+		longDelay := RelativeLocktime{
+			Type:  LocktimeTypeSecond,
+			Value: 4096,
+		}
+
+		vtxoScript := &TapscriptsVtxoScript{
+			Closures: []Closure{
+				&CSVSigClosure{
+					PubKey:   ownerKey,
+					Locktime: longDelay,
+				},
+				&CSVMultisigClosure{
+					MultisigClosure: MultisigClosure{
+						PubKeys: []*btcec.PublicKey{ownerKey},
+					},
+					Locktime: shortDelay,
+				},
+				&MultisigClosure{
+					PubKeys: []*btcec.PublicKey{ownerKey, signerKey},
+				},
+			},
+		}
+
+		smallest, err := vtxoScript.SmallestExitDelay()
+		require.NoError(t, err)
+		require.Equal(t, shortDelay, *smallest)
+	})
+}
+
+// TestEncodeDecodeRoundtrip verifies that encoding and decoding a VTXO script
+// preserves all closure data.
+func TestEncodeDecodeRoundtrip(t *testing.T) {
+	t.Parallel()
+
+	ownerKey := createTestKey(1)
+	signerKey := createTestKey(2)
+
+	exitDelay := RelativeLocktime{
+		Type:  LocktimeTypeSecond,
+		Value: 1024,
+	}
+
+	t.Run("default VTXO script roundtrip", func(t *testing.T) {
+		original := NewDefaultVtxoScript(ownerKey, signerKey, exitDelay)
+
+		encoded, err := original.Encode()
+		require.NoError(t, err)
+		require.Len(t, encoded, 2)
+
+		decoded := &TapscriptsVtxoScript{}
+		err = decoded.Decode(encoded)
+		require.NoError(t, err)
+		require.Len(t, decoded.Closures, 2)
+
+		// Verify exit closure.
+		exitClosure, ok := decoded.Closures[0].(*CSVSigClosure)
+		require.True(t, ok)
+		require.Equal(t, exitDelay, exitClosure.Locktime)
+
+		// Verify collab closure.
+		collabClosure, ok := decoded.Closures[1].(*MultisigClosure)
+		require.True(t, ok)
+		require.Len(t, collabClosure.PubKeys, 2)
+	})
+
+	t.Run("custom VTXO script roundtrip", func(t *testing.T) {
+		original := &TapscriptsVtxoScript{
+			Closures: []Closure{
+				&CSVMultisigClosure{
+					MultisigClosure: MultisigClosure{
+						PubKeys: []*btcec.PublicKey{ownerKey, signerKey},
+						Type:    MultisigTypeChecksig,
+					},
+					Locktime: exitDelay,
+				},
+				&CLTVMultisigClosure{
+					MultisigClosure: MultisigClosure{
+						PubKeys: []*btcec.PublicKey{ownerKey, signerKey},
+						Type:    MultisigTypeChecksig,
+					},
+					Locktime: AbsoluteLocktime(500000001),
+				},
+			},
+		}
+
+		encoded, err := original.Encode()
+		require.NoError(t, err)
+		require.Len(t, encoded, 2)
+
+		decoded := &TapscriptsVtxoScript{}
+		err = decoded.Decode(encoded)
+		require.NoError(t, err)
+		require.Len(t, decoded.Closures, 2)
+
+		// Verify first closure is CSVMultisigClosure.
+		_, ok := decoded.Closures[0].(*CSVMultisigClosure)
+		require.True(t, ok)
+
+		// Verify second closure is CLTVMultisigClosure.
+		_, ok = decoded.Closures[1].(*CLTVMultisigClosure)
+		require.True(t, ok)
+	})
+}
+
+// TestParseVtxoScript verifies the ParseVtxoScript helper function.
+func TestParseVtxoScript(t *testing.T) {
+	t.Parallel()
+
+	ownerKey := createTestKey(1)
+	signerKey := createTestKey(2)
+
+	exitDelay := RelativeLocktime{
+		Type:  LocktimeTypeSecond,
+		Value: 1024,
+	}
+
+	t.Run("valid scripts", func(t *testing.T) {
+		original := NewDefaultVtxoScript(ownerKey, signerKey, exitDelay)
+		encoded, err := original.Encode()
+		require.NoError(t, err)
+
+		parsed, err := ParseVtxoScript(encoded)
+		require.NoError(t, err)
+		require.Len(t, parsed.Closures, 2)
+	})
+
+	t.Run("empty scripts returns error", func(t *testing.T) {
+		parsed, err := ParseVtxoScript([]string{})
+		require.Error(t, err)
+		require.Nil(t, parsed)
+	})
+
+	t.Run("invalid hex returns error", func(t *testing.T) {
+		parsed, err := ParseVtxoScript([]string{"not_valid_hex"})
+		require.Error(t, err)
+		require.Nil(t, parsed)
+	})
+}
+
+// TestTapTree verifies that TapTree correctly builds a taproot tree from
+// the closures.
+func TestTapTree(t *testing.T) {
+	t.Parallel()
+
+	ownerKey := createTestKey(1)
+	signerKey := createTestKey(2)
+
+	exitDelay := RelativeLocktime{
+		Type:  LocktimeTypeSecond,
+		Value: 1024,
+	}
+
+	vtxoScript := NewDefaultVtxoScript(ownerKey, signerKey, exitDelay)
+
+	taprootKey, tree, err := vtxoScript.TapTree()
+	require.NoError(t, err)
+	require.NotNil(t, taprootKey)
+	require.NotNil(t, tree)
+
+	// Verify we can get leaves.
+	leaves := tree.GetLeaves()
+	require.Len(t, leaves, 2)
+
+	// Verify we can get spend info for each closure.
+	for i := range vtxoScript.Closures {
+		spendInfo, err := vtxoScript.GetSpendInfo(i)
+		require.NoError(t, err)
+		require.NotEmpty(t, spendInfo.Script)
+		require.NotEmpty(t, spendInfo.ControlBlock)
+	}
+}
+
+// TestGetSpendInfo verifies the GetSpendInfo method.
+func TestGetSpendInfo(t *testing.T) {
+	t.Parallel()
+
+	ownerKey := createTestKey(1)
+	signerKey := createTestKey(2)
+
+	exitDelay := RelativeLocktime{
+		Type:  LocktimeTypeSecond,
+		Value: 1024,
+	}
+
+	vtxoScript := NewDefaultVtxoScript(ownerKey, signerKey, exitDelay)
+
+	t.Run("valid index returns spend info", func(t *testing.T) {
+		spendInfo, err := vtxoScript.GetSpendInfo(0)
+		require.NoError(t, err)
+		require.NotNil(t, spendInfo)
+		require.NotEmpty(t, spendInfo.Script)
+		require.NotEmpty(t, spendInfo.ControlBlock)
+	})
+
+	t.Run("negative index returns error", func(t *testing.T) {
+		spendInfo, err := vtxoScript.GetSpendInfo(-1)
+		require.Error(t, err)
+		require.Nil(t, spendInfo)
+		require.Contains(t, err.Error(), "out of bounds")
+	})
+
+	t.Run("index out of bounds returns error", func(t *testing.T) {
+		spendInfo, err := vtxoScript.GetSpendInfo(10)
+		require.Error(t, err)
+		require.Nil(t, spendInfo)
+		require.Contains(t, err.Error(), "out of bounds")
+	})
+}

--- a/lib/closure/witness.go
+++ b/lib/closure/witness.go
@@ -1,0 +1,30 @@
+package closure
+
+import (
+	"bytes"
+
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+)
+
+// ReadTxWitness deserializes a witness from a byte slice.
+func ReadTxWitness(witnessSerialized []byte) (wire.TxWitness, error) {
+	r := bytes.NewReader(witnessSerialized)
+
+	// first we extract the number of witness elements
+	witCount, err := wire.ReadVarInt(r, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	// read each witness item
+	witness := make(wire.TxWitness, witCount)
+	for i := uint64(0); i < witCount; i++ {
+		witness[i], err = wire.ReadVarBytes(r, 0, txscript.MaxScriptSize, "witness")
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return witness, nil
+}

--- a/lib/scripts/vtxo.go
+++ b/lib/scripts/vtxo.go
@@ -1,41 +1,58 @@
 package scripts
 
-// VTXO Taproot Tree Structure:
+// VTXO Closure System:
 //
-// - The "Owner" is the participant who is able to unilaterally recover funds
-//   after the CSV delay expires.
-// - The "Cosigner" is the participant who collaborates with the owner to spend
-//   the output at any time.
+// A VTXO (Virtual Transaction Output) is a taproot output built from a
+// collection of closures. Each closure defines a spend condition as a
+// tapscript leaf. The closure system is flexible - VTXOs can have any number
+// of closures, enabling various spend paths and conditions.
+//
+// Closure Types:
+//   - CSVSigClosure: Exit path with CSV timelock, single owner key
+//   - CSVMultisigClosure: Exit path with CSV timelock, multiple keys
+//   - MultisigClosure: Collaborative path requiring multiple signatures
+//   - CLTVMultisigClosure: Collaborative path with absolute timelock
+//   - ConditionMultisigClosure: Collaborative path with custom conditions
+//
+// Key Requirement:
+//   Every VTXO MUST have at least one exit closure (CSVSigClosure or
+//   CSVMultisigClosure) to ensure the owner can always unilaterally recover
+//   funds after the timeout.
+//
+// NOTE: The exit vs collaborative distinction is semantic, not structural.
+// Exit closures contain only owner key(s) - owner can spend unilaterally.
+// Collaborative closures include signer key - require signer cooperation.
+// The type-based categorization (ExitClosures/ForfeitClosures) is a
+// simplification that works for the standard VTXO structure.
+//
+// Default VTXO Structure (created by NewDefaultVtxoScript):
 //
 //	                    Taproot Output
 //	                   (NUMS Key Path)
 //	                         |
 //	            +------------+------------+
 //	            |                         |
-//	    [Collaborative Path]      [Timeout Path]
-//	    (Leaf Index: 0)           (Leaf Index: 1)
+//	    [Exit Closure]           [Collab Closure]
+//	    CSVSigClosure            MultisigClosure
 //	            |                         |
 //	  +-------------------+     +--------------------+
-//	  | Owner PK          |     | Owner PK          |
-//	  | OP_CHECKSIGVERIFY |     | OP_CHECKSIG        |
-//	  | Cosigner PK       |     | <exit_delay>       |
-//	  | OP_CHECKSIG       |     | OP_CSV             |
-//	  +-------------------+     | OP_DROP            |
-//	                            +--------------------+
+//	  | <exit_delay>       |     | Owner PK          |
+//	  | OP_CSV             |     | OP_CHECKSIGVERIFY |
+//	  | OP_DROP            |     | Cosigner PK       |
+//	  | Owner PK           |     | OP_CHECKSIG       |
+//	  | OP_CHECKSIG        |     +--------------------+
+//	  +-------------------+
 //
-// Spending Paths:
-//   - Collaborative: Both owner and cosigner signatures required (anytime)
-//   - Timeout: Owner signature only (after CSV delay expires)
-//   - Key Path: Unspendable (NUMS point with no known discrete log)
+// Custom VTXOs can include additional closures with different conditions,
+// multiple exit paths with varying delays, or conditional spend paths.
 
 import (
 	"fmt"
 
 	"github.com/btcsuite/btcd/btcec/v2"
-	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/lightninglabs/darepo-client/lib/closure"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lntypes"
@@ -56,98 +73,17 @@ const (
 	//
 	// 1 + 64 bytes for owner signature + length byte.
 	UnilateralTimeoutLeafWitnessSize = lntypes.WeightUnit(1 + 64)
-
-	// vtxoCollabPathLeafIndex is the index of the collaborative multisig
-	// path leaf in the VTXO tapscript tree.
-	vtxoCollabPathLeafIndex = 0
-
-	// vtxoTimeoutPathLeafIndex is the index of the timeout path leaf in the
-	// VTXO tapscript tree.
-	vtxoTimeoutPathLeafIndex = 1
 )
 
-// VTXOLeafType is an enum-like type to identify the different leaves in a VTXO
-// tapscript tree.
-type VTXOLeafType int
+var (
+	// ErrNoExitClosure is returned when a VTXO script has no exit closure.
+	ErrNoExitClosure = fmt.Errorf("no exit closure found in vtxo script")
 
-const (
-	// VTXOCollabPathLeaf is the leaf type for the collaborative multisig
-	// path in a VTXO tapscript tree.
-	VTXOCollabPathLeaf VTXOLeafType = iota
-
-	// VTXOTimeoutPathLeaf is the leaf type for the timeout path in a VTXO
-	// tapscript tree.
-	VTXOTimeoutPathLeaf
+	// ErrNoCollabClosure is returned when a VTXO script has no
+	// collaborative closure.
+	ErrNoCollabClosure = fmt.Errorf("no collaborative closure found in " +
+		"vtxo script")
 )
-
-// LeafIndex returns the index of the VTXO leaf type in the tapscript tree.
-func (l VTXOLeafType) LeafIndex() (int, error) {
-	switch l {
-	case VTXOCollabPathLeaf:
-		return vtxoCollabPathLeafIndex, nil
-
-	case VTXOTimeoutPathLeaf:
-		return vtxoTimeoutPathLeafIndex, nil
-
-	default:
-		return 0, fmt.Errorf("unknown VTXO leaf type: %d", l)
-	}
-}
-
-// VTXOTapScript constructs the full tapscript for a VTXO type output. This
-// output structure is used for both boarding UTXOs as well as VTXOs. The tree
-// consists of:
-//   - an unspendable NUMS keypath.
-//   - Collaborative spend path between owner and cosigner.
-//   - Timeout path allowing the owner to recover funds after a CSV exit delay.
-func VTXOTapScript(ownerKey, cosignerKey *btcec.PublicKey,
-	exitDelay uint32) (*waddrmgr.Tapscript, error) {
-
-	collabLeaf, err := MultiSigCollabTapLeaf(ownerKey, cosignerKey)
-	if err != nil {
-		return nil, err
-	}
-
-	// Timeout path is always controlled by the owner.
-	timeoutLeaf, err := UnilateralCSVTimeoutTapLeaf(ownerKey, exitDelay)
-	if err != nil {
-		return nil, err
-	}
-
-	tapscript := input.TapscriptFullTree(
-		&ARKNUMSKey, collabLeaf, timeoutLeaf,
-	)
-
-	// Compute and set the root hash since TapscriptFullTree doesn't
-	// populate it. Callers need this to construct taproot addresses.
-	tree := txscript.AssembleTaprootScriptTree(tapscript.Leaves...)
-	rootHash := tree.RootNode.TapHash()
-	tapscript.RootHash = rootHash[:]
-
-	return tapscript, nil
-}
-
-// VTXOTapKey computes the taproot output key for a standard VTXO tapscript.
-// The timeout path is controlled by the owner key.
-func VTXOTapKey(ownerKey, cosignerKey *btcec.PublicKey,
-	exitDelay uint32) (*btcec.PublicKey, error) {
-
-	vtxoTapscript, err := VTXOTapScript(
-		ownerKey, cosignerKey, exitDelay,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create VTXO tapscript: %w",
-			err)
-	}
-
-	// Compute the taproot output key from the internal key and tree root.
-	outputKey := txscript.ComputeTaprootOutputKey(
-		vtxoTapscript.ControlBlock.InternalKey,
-		vtxoTapscript.RootHash,
-	)
-
-	return outputKey, nil
-}
 
 // VTXOSpendData houses the necessary information needed to spend a VTXO
 // output via either the collaborative multisig path or the timeout path.
@@ -159,45 +95,141 @@ type VTXOSpendData struct {
 	ControlBlock []byte
 }
 
-// NewVTXOSpendInfo derives the spend information for the specified leaf
-// type from the provided tapscript.
-func NewVTXOSpendInfo(tapscript *waddrmgr.Tapscript,
-	leaf VTXOLeafType) (*VTXOSpendData, error) {
+// NewVtxoScript creates a VTXO script from the provided closures.
+// Note: Callers should ensure at least one CSVMultisigClosure (exit closure)
+// is included to allow unilateral recovery.
+func NewVtxoScript(closures []closure.Closure) *closure.TapscriptsVtxoScript {
+	return &closure.TapscriptsVtxoScript{Closures: closures}
+}
 
-	leafIndex, err := leaf.LeafIndex()
+// HasExitClosure returns true if the VTXO script contains at least one exit
+// closure (CSVMultisigClosure). Every valid VTXO must have an exit closure.
+func HasExitClosure(vtxoScript *closure.TapscriptsVtxoScript) bool {
+	return len(vtxoScript.ExitClosures()) > 0
+}
+
+// NewDefaultVtxoScript creates a standard VTXO script with exit (CSV timeout)
+// and collaborative (multisig) paths using the closure system.
+func NewDefaultVtxoScript(owner, cosigner *btcec.PublicKey,
+	exitDelay closure.RelativeLocktime) *closure.TapscriptsVtxoScript {
+
+	return closure.NewDefaultVtxoScript(owner, cosigner, exitDelay)
+}
+
+// VtxoTapKey computes the taproot output key for a standard VTXO tapscript.
+func VtxoTapKey(owner, cosigner *btcec.PublicKey,
+	exitDelay closure.RelativeLocktime) (*btcec.PublicKey, error) {
+
+	vtxoScript := closure.NewDefaultVtxoScript(owner, cosigner, exitDelay)
+	key, _, err := vtxoScript.TapTree()
+	return key, err
+}
+
+// VtxoPkScript returns the P2TR script for a VTXO.
+func VtxoPkScript(owner, cosigner *btcec.PublicKey,
+	exitDelay closure.RelativeLocktime) ([]byte, error) {
+
+	key, err := VtxoTapKey(owner, cosigner, exitDelay)
 	if err != nil {
 		return nil, err
 	}
 
-	// Ensure the leaf index is within bounds before accessing.
-	if len(tapscript.Leaves) <= leafIndex {
-		return nil, fmt.Errorf("leaf index %d out of bounds, "+
-			"tapscript has %d leaves", leafIndex,
-			len(tapscript.Leaves))
-	}
+	return txscript.PayToTaprootScript(key)
+}
 
-	// Get the leaf.
-	targetLeaf := tapscript.Leaves[leafIndex]
+// NewVtxoSpendInfo derives the spend information for the specified closure
+// index from the provided VTXO script.
+func NewVtxoSpendInfo(vtxoScript *closure.TapscriptsVtxoScript,
+	closureIndex int) (*VTXOSpendData, error) {
 
-	// Derive the full tap tree to extract the control block for the
-	// target leaf.
-	tapTree := txscript.AssembleTaprootScriptTree(tapscript.Leaves...)
-	if len(tapTree.LeafMerkleProofs) <= leafIndex {
-		return nil, fmt.Errorf("missing taproot proof for vtxo leaf")
-	}
-
-	leafProof := tapTree.LeafMerkleProofs[leafIndex]
-
-	controlBlock := leafProof.ToControlBlock(&ARKNUMSKey)
-	ctrlBytes, err := controlBlock.ToBytes()
+	proof, err := vtxoScript.GetSpendInfo(closureIndex)
 	if err != nil {
 		return nil, err
 	}
 
 	return &VTXOSpendData{
-		WitnessScript: targetLeaf.Script,
-		ControlBlock:  ctrlBytes,
+		WitnessScript: proof.Script,
+		ControlBlock:  proof.ControlBlock,
 	}, nil
+}
+
+// VtxoExitSpendInfo returns the spend info for the first exit (CSV timeout)
+// closure found in the VTXO script. Returns ErrNoExitClosure if no exit
+// closure exists. Exit closures include CSVSigClosure (single-sig) and
+// CSVMultisigClosure (multi-sig).
+func VtxoExitSpendInfo(vtxoScript *closure.TapscriptsVtxoScript) (*VTXOSpendData,
+	error) {
+
+	// Find the first exit closure by scanning all closures. Both
+	// CSVSigClosure and CSVMultisigClosure are valid exit closures.
+	for i, c := range vtxoScript.Closures {
+		switch c.(type) {
+		case *closure.CSVSigClosure, *closure.CSVMultisigClosure:
+			return NewVtxoSpendInfo(vtxoScript, i)
+		}
+	}
+
+	return nil, ErrNoExitClosure
+}
+
+// VtxoCollabSpendInfo returns the spend info for the first collaborative
+// closure found in the VTXO script. Collaborative closures include
+// MultisigClosure, CLTVMultisigClosure, and ConditionMultisigClosure.
+// Returns ErrNoCollabClosure if no collaborative closure exists.
+func VtxoCollabSpendInfo(vtxoScript *closure.TapscriptsVtxoScript) (
+	*VTXOSpendData, error) {
+
+	// Find the first collaborative closure by scanning all closures.
+	for i, c := range vtxoScript.Closures {
+		switch c.(type) {
+		case *closure.MultisigClosure, *closure.CLTVMultisigClosure,
+			*closure.ConditionMultisigClosure:
+
+			return NewVtxoSpendInfo(vtxoScript, i)
+		}
+	}
+
+	return nil, ErrNoCollabClosure
+}
+
+// CSVTimeoutTapLeaf constructs the tap leaf used as the timeout (exit) path
+// for boarding or VTXO outputs using the closure system.
+func CSVTimeoutTapLeaf(timeoutKey *btcec.PublicKey,
+	csvDelay closure.RelativeLocktime) (txscript.TapLeaf, error) {
+
+	csvClosure := &closure.CSVMultisigClosure{
+		MultisigClosure: closure.MultisigClosure{
+			PubKeys: []*btcec.PublicKey{timeoutKey},
+			Type:    closure.MultisigTypeChecksig,
+		},
+		Locktime: csvDelay,
+	}
+
+	script, err := csvClosure.Script()
+	if err != nil {
+		return txscript.TapLeaf{}, err
+	}
+
+	return txscript.NewBaseTapLeaf(script), nil
+}
+
+// MultisigCollabTapLeaf returns the full tapscript leaf for the collaborative
+// multisig script spend path between owner and cosigner using the closure
+// system.
+func MultisigCollabTapLeaf(ownerKey,
+	cosignerKey *btcec.PublicKey) (txscript.TapLeaf, error) {
+
+	multisigClosure := &closure.MultisigClosure{
+		PubKeys: []*btcec.PublicKey{ownerKey, cosignerKey},
+		Type:    closure.MultisigTypeChecksig,
+	}
+
+	script, err := multisigClosure.Script()
+	if err != nil {
+		return txscript.TapLeaf{}, err
+	}
+
+	return txscript.NewBaseTapLeaf(script), nil
 }
 
 // VTXOSignDesc returns the sign descriptor needed to sign for any leaf path
@@ -220,9 +252,9 @@ func VTXOSignDesc(keyDesc keychain.KeyDescriptor, output *wire.TxOut,
 	}
 }
 
-// VTXOTimeoutSpendWitness constructs the witness stack needed to spend the
-// timeout path of a VTXO output.
-func VTXOTimeoutSpendWitness(signer input.Signer,
+// VtxoExitSpendWitness constructs the witness stack needed to spend the
+// exit (timeout) path of a VTXO output.
+func VtxoExitSpendWitness(signer input.Signer,
 	signDesc *input.SignDescriptor, sweepTx *wire.MsgTx) (wire.TxWitness,
 	error) {
 
@@ -254,8 +286,9 @@ func VTXOTimeoutSpendWitness(signer input.Signer,
 	return witnessStack, nil
 }
 
-// SignVTXOCollabInput signs the collaborative multisig input of a VTXO output.
-func SignVTXOCollabInput(signer input.Signer, tx *wire.MsgTx,
+// SignVtxoCollabInput signs the collaborative multisig input of a VTXO
+// output.
+func SignVtxoCollabInput(signer input.Signer, tx *wire.MsgTx,
 	inputIndex int, spendInfo *VTXOSpendData,
 	keyDesc *keychain.KeyDescriptor, output *wire.TxOut,
 	sigHashes *txscript.TxSigHashes,
@@ -268,9 +301,9 @@ func SignVTXOCollabInput(signer input.Signer, tx *wire.MsgTx,
 	return signer.SignOutputRaw(tx, signDesc)
 }
 
-// VTXOCollabSpendWitness constructs the witness stack needed to spend the
-// collaborative path of a VTXO output.
-func VTXOCollabSpendWitness(ownerSig, cosignerSig input.Signature,
+// VtxoCollabSpendWitness constructs the witness stack needed to spend the
+// collaborative (multisig) path of a VTXO output.
+func VtxoCollabSpendWitness(ownerSig, cosignerSig input.Signature,
 	spendInfo *VTXOSpendData) (wire.TxWitness, error) {
 
 	if ownerSig == nil || cosignerSig == nil {
@@ -292,62 +325,6 @@ func VTXOCollabSpendWitness(ownerSig, cosignerSig input.Signature,
 	witnessStack[3] = spendInfo.ControlBlock
 
 	return witnessStack, nil
-}
-
-// UnilateralCSVTimeoutTapLeaf constructs the tap leaf used as the timeout path
-// for boarding or VTXO outputs.
-//
-// The final script used is:
-//
-//	<timeout_key> OP_CHECKSIG
-//	<exit_delay>  OP_CHECKSEQUENCEVERIFY OP_DROP
-func UnilateralCSVTimeoutTapLeaf(timeoutKey *btcec.PublicKey,
-	csvDelay uint32) (txscript.TapLeaf, error) {
-
-	// Use ScriptTemplate to construct the timeout script. This script
-	// ensures the proper party can sign for this output, and that the CSV
-	// delay has been upheld.
-	secondLevelLeafScript, err := txscript.ScriptTemplate(`
-		{{ hex .ExitKey }} OP_CHECKSIG
-		{{.CSVDelay}} OP_CHECKSEQUENCEVERIFY OP_DROP`,
-		txscript.WithScriptTemplateParams(map[string]interface{}{
-			"ExitKey":  schnorr.SerializePubKey(timeoutKey),
-			"CSVDelay": int64(csvDelay),
-		}),
-	)
-	if err != nil {
-		return txscript.TapLeaf{}, err
-	}
-
-	return txscript.NewBaseTapLeaf(secondLevelLeafScript), nil
-}
-
-// MultiSigCollabTapLeaf returns the full tapscript leaf for the collaborative
-// multisig script spend path between owner and cosigner. This is used for both
-// boarding and VTXO outputs.
-//
-// The final script used is:
-//
-//	<owner_key>    OP_CHECKSIGVERIFY
-//	<cosigner_key> OP_CHECKSIG
-func MultiSigCollabTapLeaf(ownerKey,
-	cosignerKey *btcec.PublicKey) (txscript.TapLeaf, error) {
-
-	// Use ScriptTemplate to construct the collaborative multisig script.
-	// This script requires both owner and cosigner signatures to spend.
-	timeoutLeafScript, err := txscript.ScriptTemplate(`
-		{{ hex .OwnerKey }} OP_CHECKSIGVERIFY
-		{{ hex .CosignerKey }} OP_CHECKSIG`,
-		txscript.WithScriptTemplateParams(map[string]interface{}{
-			"OwnerKey":    schnorr.SerializePubKey(ownerKey),
-			"CosignerKey": schnorr.SerializePubKey(cosignerKey),
-		}),
-	)
-	if err != nil {
-		return txscript.TapLeaf{}, err
-	}
-
-	return txscript.NewBaseTapLeaf(timeoutLeafScript), nil
 }
 
 // maybeAppendSighashType appends a sighash type to the end of a signature if

--- a/lib/scripts/vtxo.go
+++ b/lib/scripts/vtxo.go
@@ -52,6 +52,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/lightninglabs/darepo-client/lib/closure"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
@@ -93,6 +94,64 @@ type VTXOSpendData struct {
 
 	// ControlBlock is the control block for the leaf being spent.
 	ControlBlock []byte
+}
+
+// DefaultVTXOTapScript constructs the full tapscript for a standard VTXO type
+// output. This output structure is used for both boarding UTXOs as well as
+// default VTXOs. The tree consists of:
+//   - an unspendable NUMS keypath.
+//   - Collaborative spend path between owner and cosigner.
+//   - Timeout path allowing the owner to recover funds after a CSV exit delay.
+//
+// For custom VTXO scripts with additional closures, use the closure package
+// directly.
+func DefaultVTXOTapScript(ownerKey, cosignerKey *btcec.PublicKey,
+	exitDelay uint32) (*waddrmgr.Tapscript, error) {
+
+	// Create the closure-based VTXO script.
+	vtxoScript := closure.NewDefaultVtxoScript(
+		ownerKey, cosignerKey,
+		closure.RelativeLocktime{
+			Type:  closure.LocktimeTypeBlock,
+			Value: exitDelay,
+		},
+	)
+
+	// Build the tap leaves from the closures.
+	leaves := make([]txscript.TapLeaf, len(vtxoScript.Closures))
+	for i, c := range vtxoScript.Closures {
+		script, err := c.Script()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get script for "+
+				"closure %d: %w", i, err)
+		}
+		leaves[i] = txscript.NewBaseTapLeaf(script)
+	}
+
+	// Build the tapscript tree and compute the root hash.
+	tapTree := txscript.AssembleTaprootScriptTree(leaves...)
+	rootHash := tapTree.RootNode.TapHash()
+
+	// Get the internal key (NUMS key).
+	internalKey := closure.UnspendableKey()
+
+	// Compute the output key and parity for the control block.
+	outputKey := txscript.ComputeTaprootOutputKey(internalKey, rootHash[:])
+	outputKeyYIsOdd := outputKey.SerializeCompressed()[0] == 0x03
+
+	// Create the waddrmgr.Tapscript structure.
+	tapscript := &waddrmgr.Tapscript{
+		Type: waddrmgr.TapscriptTypeFullTree,
+		ControlBlock: &txscript.ControlBlock{
+			InternalKey:     internalKey,
+			OutputKeyYIsOdd: outputKeyYIsOdd,
+			LeafVersion:     txscript.BaseLeafVersion,
+		},
+		Leaves:   leaves,
+		RootHash: rootHash[:],
+	}
+
+	return tapscript, nil
 }
 
 // NewVtxoScript creates a VTXO script from the provided closures.

--- a/lib/scripts/vtxo_test.go
+++ b/lib/scripts/vtxo_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/internal/testutils"
+	"github.com/lightninglabs/darepo-client/lib/closure"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/stretchr/testify/require"
@@ -24,33 +25,29 @@ func TestVTXOSpending(t *testing.T) {
 	wrongPub, wrongSigner := testutils.CreateKey(3)
 
 	// Other output parameters.
-	exitDelay := uint32(100)
+	exitDelay := closure.RelativeLocktime{
+		Type:  closure.LocktimeTypeBlock,
+		Value: 100,
+	}
 	outputAmt := btcutil.Amount(500000)
 
 	// Create a VTXO output. We will attempt to spend this via the various
 	// paths.
 	//
-	// Start by creating the tapscript.
-	vtxoTapScript, err := VTXOTapScript(
-		clientPub, operatorPub, exitDelay,
-	)
-	require.NoError(t, err)
+	// Start by creating the VTXO script using closures.
+	vtxoScript := NewDefaultVtxoScript(clientPub, operatorPub, exitDelay)
 
 	// Now use that to create the pkscript for the output.
-	taprootKey, err := vtxoTapScript.TaprootKey()
+	taprootKey, _, err := vtxoScript.TapTree()
 	require.NoError(t, err)
 	vtxoPkScript, err := txscript.PayToTaprootScript(taprootKey)
 	require.NoError(t, err)
 
-	// From the tapscript, we can already derive all the spend info.
-	timeoutSpendInfo, err := NewVTXOSpendInfo(
-		vtxoTapScript, VTXOTimeoutPathLeaf,
-	)
+	// From the VTXO script, we can already derive all the spend info.
+	exitSpendInfo, err := VtxoExitSpendInfo(vtxoScript)
 	require.NoError(t, err)
 
-	collabSpendInfo, err := NewVTXOSpendInfo(
-		vtxoTapScript, VTXOCollabPathLeaf,
-	)
+	collabSpendInfo, err := VtxoCollabSpendInfo(vtxoScript)
 	require.NoError(t, err)
 
 	// Create our output that we will be spending.
@@ -99,7 +96,7 @@ func TestVTXOSpending(t *testing.T) {
 		spendTx *wire.MsgTx, prevFetcher txscript.PrevOutputFetcher,
 		sigHashes *txscript.TxSigHashes) input.Signature {
 
-		sig, err := SignVTXOCollabInput(
+		sig, err := SignVtxoCollabInput(
 			signer, spendTx, inputIndex, collabSpendInfo,
 			&keychain.KeyDescriptor{PubKey: pubKey},
 			vtxoOutput, sigHashes, prevFetcher,
@@ -130,7 +127,7 @@ func TestVTXOSpending(t *testing.T) {
 	collabWitness := func(spendTx *wire.MsgTx) wire.TxWitness {
 		clientSig, operatorSig := signCollab(spendTx)
 
-		witness, err := VTXOCollabSpendWitness(
+		witness, err := VtxoCollabSpendWitness(
 			clientSig, operatorSig, collabSpendInfo,
 		)
 		require.NoError(t, err)
@@ -138,16 +135,16 @@ func TestVTXOSpending(t *testing.T) {
 		return witness
 	}
 
-	timeoutWitness := func(tx *wire.MsgTx) wire.TxWitness {
+	exitWitness := func(tx *wire.MsgTx) wire.TxWitness {
 		sigHashes := txscript.NewTxSigHashes(tx, prevOutFetcher)
 
 		signDesc := VTXOSignDesc(
 			keychain.KeyDescriptor{PubKey: clientPub},
 			vtxoOutput, sigHashes, prevOutFetcher, inputIndex,
-			timeoutSpendInfo,
+			exitSpendInfo,
 		)
 
-		witness, err := VTXOTimeoutSpendWitness(
+		witness, err := VtxoExitSpendWitness(
 			clientSigner, signDesc, tx,
 		)
 		require.NoError(t, err)
@@ -162,10 +159,10 @@ func TestVTXOSpending(t *testing.T) {
 		useSequence uint32
 	}{
 		{
-			// The script should be spendable via the collaborative
-			// multisig path at any time if both client and
+			// The script should be spendable via the collab
+			// (collaborative) path at any time if both client and
 			// server cooperate.
-			name: "valid collaborative multisig spend",
+			name: "valid collab (collaborative) spend",
 			witnessGen: func(tx *wire.MsgTx) wire.TxWitness {
 				return collabWitness(tx)
 			},
@@ -174,25 +171,24 @@ func TestVTXOSpending(t *testing.T) {
 		},
 		{
 			// The script should be spendable by the client after
-			// the CSV delay.
-			name: "valid unilateral timout path spend",
+			// the CSV delay via the exit path.
+			name: "valid exit (timeout) path spend",
 			witnessGen: func(tx *wire.MsgTx) wire.TxWitness {
-				return timeoutWitness(tx)
+				return exitWitness(tx)
 			},
 			valid:       true,
-			useSequence: exitDelay,
+			useSequence: exitDelay.Value,
 		},
 		{
-			name: "invalid unilateral timeout spend before csv " +
-				"delay",
+			name: "invalid exit spend before csv delay",
 			witnessGen: func(tx *wire.MsgTx) wire.TxWitness {
-				return timeoutWitness(tx)
+				return exitWitness(tx)
 			},
 			valid:       false,
-			useSequence: exitDelay - 1,
+			useSequence: exitDelay.Value - 1,
 		},
 		{
-			name: "invalid collaborative spend missing operator " +
+			name: "invalid collab spend missing operator " +
 				"signature",
 			witnessGen: func(tx *wire.MsgTx) wire.TxWitness {
 				clientSig, _ := signCollab(tx)
@@ -207,8 +203,7 @@ func TestVTXOSpending(t *testing.T) {
 			useSequence: 0,
 		},
 		{
-			name: "invalid collaborative spend signature order " +
-				"swapped",
+			name: "invalid collab spend signature order swapped",
 			witnessGen: func(tx *wire.MsgTx) wire.TxWitness {
 				clientSig, operatorSig := signCollab(tx)
 
@@ -223,8 +218,7 @@ func TestVTXOSpending(t *testing.T) {
 			useSequence: wire.MaxTxInSequenceNum,
 		},
 		{
-			name: "client uses wrong key to sign collaborative " +
-				"spend",
+			name: "client uses wrong key to sign collab spend",
 			witnessGen: func(tx *wire.MsgTx) wire.TxWitness {
 				wrongSig := signWith(
 					wrongSigner, wrongPub, tx,
@@ -241,7 +235,7 @@ func TestVTXOSpending(t *testing.T) {
 					),
 				)
 
-				witness, err := VTXOCollabSpendWitness(
+				witness, err := VtxoCollabSpendWitness(
 					wrongSig, operatorSig, collabSpendInfo,
 				)
 				require.NoError(t, err)
@@ -312,17 +306,20 @@ func TestVTXOSpending(t *testing.T) {
 	}
 }
 
-// TestVTXOTapKey tests the VTXOTapKey helper function that computes the
+// TestVtxoTapKey tests the VtxoTapKey helper function that computes the
 // taproot output key for a VTXO.
-func TestVTXOTapKey(t *testing.T) {
+func TestVtxoTapKey(t *testing.T) {
 	t.Parallel()
 
 	clientPub, _ := testutils.CreateKey(1)
 	operatorPub, _ := testutils.CreateKey(2)
-	exitDelay := uint32(100)
+	exitDelay := closure.RelativeLocktime{
+		Type:  closure.LocktimeTypeBlock,
+		Value: 100,
+	}
 
 	t.Run("computes valid taproot key", func(t *testing.T) {
-		outputKey, err := VTXOTapKey(clientPub, operatorPub, exitDelay)
+		outputKey, err := VtxoTapKey(clientPub, operatorPub, exitDelay)
 		require.NoError(t, err)
 		require.NotNil(t, outputKey)
 
@@ -332,29 +329,22 @@ func TestVTXOTapKey(t *testing.T) {
 
 	t.Run("matches manual computation", func(t *testing.T) {
 		// Compute using helper.
-		outputKey1, err := VTXOTapKey(clientPub, operatorPub, exitDelay)
+		outputKey1, err := VtxoTapKey(clientPub, operatorPub, exitDelay)
 		require.NoError(t, err)
 
-		// Compute manually using VTXOTapScript.
-		vtxoTapScript, err := VTXOTapScript(
-			clientPub, operatorPub, exitDelay,
-		)
-		require.NoError(t, err)
+		// Compute manually using NewDefaultVtxoScript.
+		vtxoScript := NewDefaultVtxoScript(clientPub, operatorPub, exitDelay)
 
-		tree := txscript.AssembleTaprootScriptTree(
-			vtxoTapScript.Leaves...,
-		)
-		rootHash := tree.RootNode.TapHash()
-		outputKey2 := txscript.ComputeTaprootOutputKey(
-			vtxoTapScript.ControlBlock.InternalKey, rootHash[:],
-		)
+		taprootKey, tree, err := vtxoScript.TapTree()
+		require.NoError(t, err)
+		_ = tree // tree is used for verification
 
 		// Both methods should produce the same key.
-		require.Equal(t, outputKey1, outputKey2)
+		require.Equal(t, outputKey1, taprootKey)
 	})
 
 	t.Run("creates valid P2TR script", func(t *testing.T) {
-		outputKey, err := VTXOTapKey(clientPub, operatorPub, exitDelay)
+		outputKey, err := VtxoTapKey(clientPub, operatorPub, exitDelay)
 		require.NoError(t, err)
 
 		pkScript, err := txscript.PayToTaprootScript(outputKey)
@@ -370,39 +360,497 @@ func TestVTXOTapKey(t *testing.T) {
 			otherClientPub, _ := testutils.CreateKey(3)
 			otherOperatorPub, _ := testutils.CreateKey(4)
 
-			key1, err := VTXOTapKey(
+			key1, err := VtxoTapKey(
 				clientPub, operatorPub, exitDelay,
 			)
 			require.NoError(t, err)
 
 			// Different client.
-			key2, err := VTXOTapKey(
+			key2, err := VtxoTapKey(
 				otherClientPub, operatorPub, exitDelay,
 			)
 			require.NoError(t, err)
 			require.NotEqual(t, key1, key2)
 
 			// Different operator.
-			key3, err := VTXOTapKey(
+			key3, err := VtxoTapKey(
 				clientPub, otherOperatorPub, exitDelay,
 			)
 			require.NoError(t, err)
 			require.NotEqual(t, key1, key3)
 
 			// Different exit delay.
-			key4, err := VTXOTapKey(clientPub, operatorPub, 200)
+			differentDelay := closure.RelativeLocktime{
+				Type:  closure.LocktimeTypeBlock,
+				Value: 200,
+			}
+			key4, err := VtxoTapKey(
+				clientPub, operatorPub, differentDelay,
+			)
 			require.NoError(t, err)
 			require.NotEqual(t, key1, key4)
 		})
 
 	t.Run("deterministic computation", func(t *testing.T) {
 		// Same inputs should always produce same output.
-		key1, err := VTXOTapKey(clientPub, operatorPub, exitDelay)
+		key1, err := VtxoTapKey(clientPub, operatorPub, exitDelay)
 		require.NoError(t, err)
 
-		key2, err := VTXOTapKey(clientPub, operatorPub, exitDelay)
+		key2, err := VtxoTapKey(clientPub, operatorPub, exitDelay)
 		require.NoError(t, err)
 
 		require.Equal(t, key1, key2)
+	})
+}
+
+// TestCustomVTXOSpending tests spending VTXO outputs with non-default closure
+// configurations, including CSVMultisigClosure (multi-key exit), exit-only
+// VTXOs, and VTXOs with multiple exit paths.
+func TestCustomVTXOSpending(t *testing.T) {
+	t.Parallel()
+
+	outputAmt := btcutil.Amount(500000)
+
+	// Helper to create a VTXO output and test spending it.
+	testVTXOSpend := func(t *testing.T, vtxoScript *closure.TapscriptsVtxoScript,
+		closureIdx int, witnessGen func(
+			spendInfo *VTXOSpendData,
+			output *wire.TxOut,
+			tx *wire.MsgTx,
+			prevFetcher txscript.PrevOutputFetcher,
+		) wire.TxWitness, sequence uint32, shouldSucceed bool) {
+
+		// Create taproot output from the script.
+		taprootKey, _, err := vtxoScript.TapTree()
+		require.NoError(t, err)
+
+		vtxoPkScript, err := txscript.PayToTaprootScript(taprootKey)
+		require.NoError(t, err)
+
+		vtxoOutput := &wire.TxOut{
+			Value:    int64(outputAmt),
+			PkScript: vtxoPkScript,
+		}
+
+		prevOut := wire.OutPoint{
+			Hash:  [32]byte{1, 2, 3, 4, 5, 6, 7, 8},
+			Index: 0,
+		}
+
+		prevOutFetcher := txscript.NewMultiPrevOutFetcher(
+			map[wire.OutPoint]*wire.TxOut{prevOut: vtxoOutput},
+		)
+
+		// Get spend info for the specific closure.
+		spendInfo, err := NewVtxoSpendInfo(vtxoScript, closureIdx)
+		require.NoError(t, err)
+
+		// Create spending transaction.
+		spendTx := wire.NewMsgTx(2)
+		spendTx.AddTxIn(&wire.TxIn{
+			PreviousOutPoint: prevOut,
+			Sequence:         sequence,
+		})
+		spendTx.AddTxOut(&wire.TxOut{
+			Value:    int64(outputAmt) - 1000,
+			PkScript: []byte{0x51, 0x20},
+		})
+
+		// Generate witness. Pass vtxoOutput for correct signing.
+		witness := witnessGen(spendInfo, vtxoOutput, spendTx, prevOutFetcher)
+		spendTx.TxIn[0].Witness = witness
+
+		// Validate the script.
+		hashCache := txscript.NewTxSigHashes(spendTx, prevOutFetcher)
+		engine, err := txscript.NewEngine(
+			vtxoPkScript, spendTx, 0,
+			txscript.StandardVerifyFlags, nil, hashCache,
+			int64(outputAmt), prevOutFetcher,
+		)
+		require.NoError(t, err)
+
+		err = engine.Execute()
+		if shouldSucceed {
+			require.NoError(t, err)
+		} else {
+			require.Error(t, err)
+		}
+	}
+
+	t.Run("CSVMultisigClosure 2-of-2 exit", func(t *testing.T) {
+		// Create keys for a 2-of-2 multisig exit.
+		client1Pub, client1Signer := testutils.CreateKey(10)
+		client2Pub, client2Signer := testutils.CreateKey(11)
+		operatorPub, operatorSigner := testutils.CreateKey(12)
+
+		exitDelay := closure.RelativeLocktime{
+			Type:  closure.LocktimeTypeBlock,
+			Value: 100,
+		}
+
+		// VTXO with CSVMultisigClosure (2-of-2 for exit) + MultisigClosure
+		// for collab.
+		vtxoScript := &closure.TapscriptsVtxoScript{
+			Closures: []closure.Closure{
+				// Exit: requires both clients after delay.
+				&closure.CSVMultisigClosure{
+					MultisigClosure: closure.MultisigClosure{
+						PubKeys: []*btcec.PublicKey{
+							client1Pub, client2Pub,
+						},
+						Type: closure.MultisigTypeChecksig,
+					},
+					Locktime: exitDelay,
+				},
+				// Collab: all three parties.
+				&closure.MultisigClosure{
+					PubKeys: []*btcec.PublicKey{
+						client1Pub, client2Pub, operatorPub,
+					},
+					Type: closure.MultisigTypeChecksig,
+				},
+			},
+		}
+
+		t.Run("valid 2-of-2 exit spend", func(t *testing.T) {
+			testVTXOSpend(t, vtxoScript, 0,
+				func(spendInfo *VTXOSpendData, output *wire.TxOut,
+					tx *wire.MsgTx,
+					prevFetcher txscript.PrevOutputFetcher,
+				) wire.TxWitness {
+
+					sigHashes := txscript.NewTxSigHashes(
+						tx, prevFetcher,
+					)
+
+					// Sign with client1.
+					signDesc1 := VTXOSignDesc(
+						keychain.KeyDescriptor{
+							PubKey: client1Pub,
+						},
+						output,
+						sigHashes, prevFetcher, 0, spendInfo,
+					)
+					sig1, err := client1Signer.SignOutputRaw(
+						tx, signDesc1,
+					)
+					require.NoError(t, err)
+
+					// Sign with client2.
+					signDesc2 := VTXOSignDesc(
+						keychain.KeyDescriptor{
+							PubKey: client2Pub,
+						},
+						output,
+						sigHashes, prevFetcher, 0, spendInfo,
+					)
+					sig2, err := client2Signer.SignOutputRaw(
+						tx, signDesc2,
+					)
+					require.NoError(t, err)
+
+					// Build witness: sig2, sig1, script,
+					// control.
+					return wire.TxWitness{
+						sig2.Serialize(),
+						sig1.Serialize(),
+						spendInfo.WitnessScript,
+						spendInfo.ControlBlock,
+					}
+				},
+				exitDelay.Value, true,
+			)
+		})
+
+		t.Run("valid 3-of-3 collab spend", func(t *testing.T) {
+			testVTXOSpend(t, vtxoScript, 1,
+				func(spendInfo *VTXOSpendData, output *wire.TxOut,
+					tx *wire.MsgTx,
+					prevFetcher txscript.PrevOutputFetcher,
+				) wire.TxWitness {
+
+					sigHashes := txscript.NewTxSigHashes(
+						tx, prevFetcher,
+					)
+
+					signers := []struct {
+						pub    *btcec.PublicKey
+						signer input.Signer
+					}{
+						{client1Pub, client1Signer},
+						{client2Pub, client2Signer},
+						{operatorPub, operatorSigner},
+					}
+
+					sigs := make([][]byte, len(signers))
+					for i, s := range signers {
+						signDesc := VTXOSignDesc(
+							keychain.KeyDescriptor{
+								PubKey: s.pub,
+							},
+							output,
+							sigHashes, prevFetcher, 0,
+							spendInfo,
+						)
+						sig, err := s.signer.SignOutputRaw(
+							tx, signDesc,
+						)
+						require.NoError(t, err)
+						sigs[i] = sig.Serialize()
+					}
+
+					// Witness: sig3, sig2, sig1, script,
+					// control.
+					return wire.TxWitness{
+						sigs[2], sigs[1], sigs[0],
+						spendInfo.WitnessScript,
+						spendInfo.ControlBlock,
+					}
+				},
+				wire.MaxTxInSequenceNum, true,
+			)
+		})
+	})
+
+	t.Run("exit-only VTXO (no collab path)", func(t *testing.T) {
+		clientPub, clientSigner := testutils.CreateKey(20)
+
+		exitDelay := closure.RelativeLocktime{
+			Type:  closure.LocktimeTypeBlock,
+			Value: 50,
+		}
+
+		// VTXO with only a single exit closure.
+		vtxoScript := &closure.TapscriptsVtxoScript{
+			Closures: []closure.Closure{
+				&closure.CSVSigClosure{
+					PubKey:   clientPub,
+					Locktime: exitDelay,
+				},
+			},
+		}
+
+		t.Run("valid exit spend", func(t *testing.T) {
+			testVTXOSpend(t, vtxoScript, 0,
+				func(spendInfo *VTXOSpendData, output *wire.TxOut,
+					tx *wire.MsgTx,
+					prevFetcher txscript.PrevOutputFetcher,
+				) wire.TxWitness {
+
+					sigHashes := txscript.NewTxSigHashes(
+						tx, prevFetcher,
+					)
+
+					signDesc := VTXOSignDesc(
+						keychain.KeyDescriptor{
+							PubKey: clientPub,
+						},
+						output,
+						sigHashes, prevFetcher, 0, spendInfo,
+					)
+
+					witness, err := VtxoExitSpendWitness(
+						clientSigner, signDesc, tx,
+					)
+					require.NoError(t, err)
+
+					return witness
+				},
+				exitDelay.Value, true,
+			)
+		})
+
+		t.Run("invalid exit spend before delay", func(t *testing.T) {
+			testVTXOSpend(t, vtxoScript, 0,
+				func(spendInfo *VTXOSpendData, output *wire.TxOut,
+					tx *wire.MsgTx,
+					prevFetcher txscript.PrevOutputFetcher,
+				) wire.TxWitness {
+
+					sigHashes := txscript.NewTxSigHashes(
+						tx, prevFetcher,
+					)
+
+					signDesc := VTXOSignDesc(
+						keychain.KeyDescriptor{
+							PubKey: clientPub,
+						},
+						output,
+						sigHashes, prevFetcher, 0, spendInfo,
+					)
+
+					witness, err := VtxoExitSpendWitness(
+						clientSigner, signDesc, tx,
+					)
+					require.NoError(t, err)
+
+					return witness
+				},
+				exitDelay.Value-1, false,
+			)
+		})
+
+		t.Run("no collab closure returns error", func(t *testing.T) {
+			_, err := VtxoCollabSpendInfo(vtxoScript)
+			require.Error(t, err)
+			require.ErrorIs(t, err, ErrNoCollabClosure)
+		})
+	})
+
+	t.Run("multiple exit closures with different delays", func(t *testing.T) {
+		clientPub, clientSigner := testutils.CreateKey(30)
+		operatorPub, operatorSigner := testutils.CreateKey(31)
+
+		shortDelay := closure.RelativeLocktime{
+			Type:  closure.LocktimeTypeBlock,
+			Value: 10,
+		}
+		longDelay := closure.RelativeLocktime{
+			Type:  closure.LocktimeTypeBlock,
+			Value: 100,
+		}
+
+		// VTXO with two exit paths: short delay and long delay.
+		vtxoScript := &closure.TapscriptsVtxoScript{
+			Closures: []closure.Closure{
+				// Short exit.
+				&closure.CSVSigClosure{
+					PubKey:   clientPub,
+					Locktime: shortDelay,
+				},
+				// Long exit.
+				&closure.CSVSigClosure{
+					PubKey:   clientPub,
+					Locktime: longDelay,
+				},
+				// Collab path.
+				&closure.MultisigClosure{
+					PubKeys: []*btcec.PublicKey{
+						clientPub, operatorPub,
+					},
+					Type: closure.MultisigTypeChecksig,
+				},
+			},
+		}
+
+		t.Run("valid short delay exit", func(t *testing.T) {
+			testVTXOSpend(t, vtxoScript, 0,
+				func(spendInfo *VTXOSpendData, output *wire.TxOut,
+					tx *wire.MsgTx,
+					prevFetcher txscript.PrevOutputFetcher,
+				) wire.TxWitness {
+
+					sigHashes := txscript.NewTxSigHashes(
+						tx, prevFetcher,
+					)
+
+					signDesc := VTXOSignDesc(
+						keychain.KeyDescriptor{
+							PubKey: clientPub,
+						},
+						output,
+						sigHashes, prevFetcher, 0, spendInfo,
+					)
+
+					witness, err := VtxoExitSpendWitness(
+						clientSigner, signDesc, tx,
+					)
+					require.NoError(t, err)
+
+					return witness
+				},
+				shortDelay.Value, true,
+			)
+		})
+
+		t.Run("valid long delay exit", func(t *testing.T) {
+			testVTXOSpend(t, vtxoScript, 1,
+				func(spendInfo *VTXOSpendData, output *wire.TxOut,
+					tx *wire.MsgTx,
+					prevFetcher txscript.PrevOutputFetcher,
+				) wire.TxWitness {
+
+					sigHashes := txscript.NewTxSigHashes(
+						tx, prevFetcher,
+					)
+
+					signDesc := VTXOSignDesc(
+						keychain.KeyDescriptor{
+							PubKey: clientPub,
+						},
+						output,
+						sigHashes, prevFetcher, 0, spendInfo,
+					)
+
+					witness, err := VtxoExitSpendWitness(
+						clientSigner, signDesc, tx,
+					)
+					require.NoError(t, err)
+
+					return witness
+				},
+				longDelay.Value, true,
+			)
+		})
+
+		t.Run("valid collab spend", func(t *testing.T) {
+			testVTXOSpend(t, vtxoScript, 2,
+				func(spendInfo *VTXOSpendData, output *wire.TxOut,
+					tx *wire.MsgTx,
+					prevFetcher txscript.PrevOutputFetcher,
+				) wire.TxWitness {
+
+					sigHashes := txscript.NewTxSigHashes(
+						tx, prevFetcher,
+					)
+
+					// Sign with client.
+					clientSignDesc := VTXOSignDesc(
+						keychain.KeyDescriptor{
+							PubKey: clientPub,
+						},
+						output,
+						sigHashes, prevFetcher, 0, spendInfo,
+					)
+					clientSig, err := clientSigner.SignOutputRaw(
+						tx, clientSignDesc,
+					)
+					require.NoError(t, err)
+
+					// Sign with operator.
+					opSignDesc := VTXOSignDesc(
+						keychain.KeyDescriptor{
+							PubKey: operatorPub,
+						},
+						output,
+						sigHashes, prevFetcher, 0, spendInfo,
+					)
+					opSig, err := operatorSigner.SignOutputRaw(
+						tx, opSignDesc,
+					)
+					require.NoError(t, err)
+
+					witness, err := VtxoCollabSpendWitness(
+						clientSig, opSig, spendInfo,
+					)
+					require.NoError(t, err)
+
+					return witness
+				},
+				wire.MaxTxInSequenceNum, true,
+			)
+		})
+
+		t.Run("VtxoExitSpendInfo returns first exit", func(t *testing.T) {
+			spendInfo, err := VtxoExitSpendInfo(vtxoScript)
+			require.NoError(t, err)
+
+			// Should get the first exit closure (short delay).
+			firstSpendInfo, err := NewVtxoSpendInfo(vtxoScript, 0)
+			require.NoError(t, err)
+
+			require.Equal(t, firstSpendInfo.WitnessScript,
+				spendInfo.WitnessScript)
+		})
 	})
 }

--- a/lib/tree/batch.go
+++ b/lib/tree/batch.go
@@ -13,15 +13,19 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/closure"
 	"github.com/lightninglabs/darepo-client/lib/scripts"
 )
 
 // VTXODescriptor defines the complete specification for a single VTXO leaf.
+// It stores the underlying tapscript closures as hex-encoded strings, allowing
+// the full closure information to be preserved and retrieved.
 type VTXODescriptor struct {
-	// PkScript is the P2TR script for the VTXO output. This is typically
-	// generated using scripts.VTXOTapKey which creates a taproot script
-	// with both keyspend (collaborative) and scriptspend (timeout) paths.
-	PkScript []byte
+	// Scripts contains the hex-encoded tapscript leaves for this VTXO.
+	// These can be decoded into Closure objects using closure.ParseVtxoScript().
+	// The scripts define the spending conditions (exit paths, collab paths,
+	// etc.) for this VTXO.
+	Scripts []string
 
 	// Amount is the value of this VTXO in satoshis.
 	Amount btcutil.Amount
@@ -31,37 +35,82 @@ type VTXODescriptor struct {
 	CoSignerKey *btcec.PublicKey
 }
 
-// NewVTXODescriptor constructs a VTXODescriptor by building the VTXO taproot
-// script using the scripts package. This is a convenience helper for clients to
-// easily create VTXO descriptors for tree construction.
-func NewVTXODescriptor(amount btcutil.Amount, ownerKey *btcec.PublicKey,
-	cosignerKey *btcec.PublicKey, exitDelay uint32) (*VTXODescriptor,
-	error) {
-
-	// Use scripts package to compute the VTXO output key.
-	outputKey, err := scripts.VTXOTapKey(ownerKey, cosignerKey, exitDelay)
+// PkScript derives the P2TR output script from the stored tapscripts.
+func (v *VTXODescriptor) PkScript() ([]byte, error) {
+	vtxoScript, err := closure.ParseVtxoScript(v.Scripts)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compute VTXO tap key: %w",
-			err)
+		return nil, fmt.Errorf("failed to parse vtxo scripts: %w", err)
 	}
 
-	// Create the P2TR script.
-	pkScript, err := txscript.PayToTaprootScript(outputKey)
+	key, _, err := vtxoScript.TapTree()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create taproot script: %w",
-			err)
+		return nil, fmt.Errorf("failed to compute tap tree: %w", err)
+	}
+
+	return txscript.PayToTaprootScript(key)
+}
+
+// VtxoScript parses the stored scripts into a TapscriptsVtxoScript.
+func (v *VTXODescriptor) VtxoScript() (*closure.TapscriptsVtxoScript, error) {
+	return closure.ParseVtxoScript(v.Scripts)
+}
+
+// NewVTXODescriptor creates a descriptor from a TapscriptsVtxoScript.
+// The vtxoScript closures are encoded to hex strings for storage, allowing
+// the full closure information to be preserved and retrieved later.
+func NewVTXODescriptor(amount btcutil.Amount,
+	vtxoScript *closure.TapscriptsVtxoScript,
+	coSignerKey *btcec.PublicKey) (*VTXODescriptor, error) {
+
+	if vtxoScript == nil {
+		return nil, fmt.Errorf("vtxo script cannot be nil")
+	}
+
+	if coSignerKey == nil {
+		return nil, fmt.Errorf("cosigner key cannot be nil")
+	}
+
+	// Encode closures to hex strings for storage.
+	scripts, err := vtxoScript.Encode()
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode vtxo scripts: %w", err)
 	}
 
 	return &VTXODescriptor{
-		PkScript:    pkScript,
+		Scripts:     scripts,
 		Amount:      amount,
-		CoSignerKey: ownerKey,
+		CoSignerKey: coSignerKey,
 	}, nil
 }
 
-// ToLeafDescriptor converts a VTXODescriptor to a generic LeafDescriptor.
-func (v VTXODescriptor) ToLeafDescriptor() LeafDescriptor {
-	return LeafDescriptor(v)
+// NewDefaultVTXODescriptor creates a descriptor with the standard exit + collab
+// closures. This is a convenience function for creating VTXOs with the default
+// structure: owner can exit after CSV delay, or owner + cosigner can spend
+// collaboratively.
+func NewDefaultVTXODescriptor(amount btcutil.Amount, ownerKey,
+	cosignerKey *btcec.PublicKey,
+	exitDelay closure.RelativeLocktime) (*VTXODescriptor, error) {
+
+	vtxoScript := closure.NewDefaultVtxoScript(
+		ownerKey, cosignerKey, exitDelay,
+	)
+
+	return NewVTXODescriptor(amount, vtxoScript, ownerKey)
+}
+
+// ToLeafDescriptor converts a VTXODescriptor to a generic LeafDescriptor by
+// deriving the PkScript from the stored tapscripts.
+func (v *VTXODescriptor) ToLeafDescriptor() (LeafDescriptor, error) {
+	pkScript, err := v.PkScript()
+	if err != nil {
+		return LeafDescriptor{}, err
+	}
+
+	return LeafDescriptor{
+		PkScript:    pkScript,
+		Amount:      v.Amount,
+		CoSignerKey: v.CoSignerKey,
+	}, nil
 }
 
 // ConnectorDescriptor defines the specification for a connector tree.
@@ -90,19 +139,32 @@ func ValidateVTXODescriptors(vtxos []VTXODescriptor) error {
 
 	seen := make(map[string]struct{})
 
-	for i, vtxo := range vtxos {
+	for i := range vtxos {
+		vtxo := &vtxos[i]
+
 		if vtxo.Amount <= 0 {
 			return fmt.Errorf("VTXO %d has invalid amount: %d", i,
 				vtxo.Amount)
 		}
-		if len(vtxo.PkScript) == 0 {
-			return fmt.Errorf("VTXO %d has empty PkScript", i)
+
+		if len(vtxo.Scripts) == 0 {
+			return fmt.Errorf("VTXO %d has empty Scripts", i)
 		}
-		if !txscript.IsPayToTaproot(vtxo.PkScript) {
+
+		// Validate that scripts can be parsed and produce valid
+		// taproot output.
+		pkScript, err := vtxo.PkScript()
+		if err != nil {
+			return fmt.Errorf("VTXO %d has invalid scripts: %w",
+				i, err)
+		}
+
+		if !txscript.IsPayToTaproot(pkScript) {
 			return fmt.Errorf(
 				"VTXO %d has invalid taproot script", i,
 			)
 		}
+
 		if vtxo.CoSignerKey == nil {
 			return fmt.Errorf("VTXO %d has nil co-signer key", i)
 		}
@@ -173,7 +235,7 @@ func BuildVTXOTree(
 	vtxos []VTXODescriptor,
 	operatorCoSignKey *btcec.PublicKey,
 	sweepKey *btcec.PublicKey,
-	sweepDelay uint32,
+	sweepDelay closure.RelativeLocktime,
 	radix int,
 ) (*Tree, error) {
 
@@ -196,8 +258,12 @@ func BuildVTXOTree(
 
 	// Convert to generic leaf descriptors.
 	leaves := make([]LeafDescriptor, len(vtxos))
-	for i, v := range vtxos {
-		leaves[i] = v.ToLeafDescriptor()
+	for i := range vtxos {
+		leaf, err := vtxos[i].ToLeafDescriptor()
+		if err != nil {
+			return nil, fmt.Errorf("VTXO %d: %w", i, err)
+		}
+		leaves[i] = leaf
 	}
 
 	// Sort leaves by amount (descending) using LPT (Longest Processing
@@ -214,9 +280,7 @@ func BuildVTXOTree(
 	})
 
 	// Compute the sweep tap leaf for branch tweaking.
-	sweepTapLeaf, err := scripts.UnilateralCSVTimeoutTapLeaf(
-		sweepKey, sweepDelay,
-	)
+	sweepTapLeaf, err := scripts.CSVTimeoutTapLeaf(sweepKey, sweepDelay)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create sweep tap leaf: %w",
 			err)
@@ -276,7 +340,7 @@ func BuildConnectorTree(
 // total amount is simply the sum of all VTXO amounts.
 func BuildBatchOutput(vtxos []VTXODescriptor,
 	operatorMuSigKey *btcec.PublicKey, sweepKey *btcec.PublicKey,
-	sweepDelay uint32) (*wire.TxOut, error) {
+	sweepDelay closure.RelativeLocktime) (*wire.TxOut, error) {
 
 	if len(vtxos) == 0 {
 		return nil, fmt.Errorf("batch output requires at least " +
@@ -292,9 +356,7 @@ func BuildBatchOutput(vtxos []VTXODescriptor,
 	}
 
 	// Compute the sweep tap leaf for tweaking.
-	sweepTapLeaf, err := scripts.UnilateralCSVTimeoutTapLeaf(
-		sweepKey, sweepDelay,
-	)
+	sweepTapLeaf, err := scripts.CSVTimeoutTapLeaf(sweepKey, sweepDelay)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create sweep tap leaf: %w",
 			err)
@@ -398,7 +460,8 @@ func BuildConnectorOutput(
 // sweep path that is committed to in branch transactions. The internalKey
 // parameter must be the pre-tweaked MuSig2 aggregate key for the branch output.
 func NewBranchSweepSpendInfo(
-	internalKey, sweepKey *btcec.PublicKey, csvDelay uint32,
+	internalKey, sweepKey *btcec.PublicKey,
+	csvDelay closure.RelativeLocktime,
 ) (*scripts.VTXOSpendData, error) {
 
 	if internalKey == nil {
@@ -409,9 +472,7 @@ func NewBranchSweepSpendInfo(
 		return nil, fmt.Errorf("sweep key cannot be nil")
 	}
 
-	sweepLeaf, err := scripts.UnilateralCSVTimeoutTapLeaf(
-		sweepKey, csvDelay,
-	)
+	sweepLeaf, err := scripts.CSVTimeoutTapLeaf(sweepKey, csvDelay)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/tree/batch_test.go
+++ b/lib/tree/batch_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/internal/testutils"
+	"github.com/lightninglabs/darepo-client/lib/closure"
 	"github.com/lightninglabs/darepo-client/lib/scripts"
 	"github.com/stretchr/testify/require"
 )
@@ -48,17 +49,19 @@ func TestBuildVTXOTree(t *testing.T) {
 	}
 
 	t.Run("single VTXO tree", func(t *testing.T) {
-		// Create VTXO script.
-		vtxoScript, err := txscript.PayToTaprootScript(user1PubKey)
+		sweepDelay := closure.RelativeLocktime{
+			Type:  closure.LocktimeTypeBlock,
+			Value: 144,
+		}
+
+		// Create VTXO descriptor using the new constructor.
+		vtxoDesc, err := NewDefaultVTXODescriptor(
+			btcutil.Amount(5000), user1PubKey, operatorPubKey,
+			sweepDelay,
+		)
 		require.NoError(t, err)
 
-		vtxos := []VTXODescriptor{
-			{
-				PkScript:    vtxoScript,
-				Amount:      btcutil.Amount(5000),
-				CoSignerKey: user1PubKey,
-			},
-		}
+		vtxos := []VTXODescriptor{*vtxoDesc}
 
 		tree, err := BuildVTXOTree(
 			batchOutpoint,
@@ -66,8 +69,8 @@ func TestBuildVTXOTree(t *testing.T) {
 			vtxos,
 			operatorPubKey,
 			sweepPubKey,
-			144, // sweep delay
-			2,   // radix
+			sweepDelay,
+			2, // radix
 		)
 		require.NoError(t, err)
 		require.NotNil(t, tree)
@@ -85,7 +88,11 @@ func TestBuildVTXOTree(t *testing.T) {
 		// Should have VTXO output + anchor output.
 		require.Len(t, tree.Root.Outputs, 2)
 		require.Equal(t, int64(5000), tree.Root.Outputs[0].Value)
-		require.Equal(t, vtxoScript, tree.Root.Outputs[0].PkScript)
+
+		// Verify output script matches derived PkScript.
+		expectedPkScript, err := vtxoDesc.PkScript()
+		require.NoError(t, err)
+		require.Equal(t, expectedPkScript, tree.Root.Outputs[0].PkScript)
 		require.Equal(t, int64(0), tree.Root.Outputs[1].Value)
 
 		// Should have operator + user1 as cosigners.
@@ -95,24 +102,24 @@ func TestBuildVTXOTree(t *testing.T) {
 	})
 
 	t.Run("two VTXO tree", func(t *testing.T) {
-		vtxo1Script, err := txscript.PayToTaprootScript(user1PubKey)
-		require.NoError(t, err)
-
-		vtxo2Script, err := txscript.PayToTaprootScript(user2PubKey)
-		require.NoError(t, err)
-
-		vtxos := []VTXODescriptor{
-			{
-				PkScript:    vtxo1Script,
-				Amount:      btcutil.Amount(5000),
-				CoSignerKey: user1PubKey,
-			},
-			{
-				PkScript:    vtxo2Script,
-				Amount:      btcutil.Amount(3000),
-				CoSignerKey: user2PubKey,
-			},
+		sweepDelay := closure.RelativeLocktime{
+			Type:  closure.LocktimeTypeBlock,
+			Value: 144,
 		}
+
+		vtxo1, err := NewDefaultVTXODescriptor(
+			btcutil.Amount(5000), user1PubKey, operatorPubKey,
+			sweepDelay,
+		)
+		require.NoError(t, err)
+
+		vtxo2, err := NewDefaultVTXODescriptor(
+			btcutil.Amount(3000), user2PubKey, operatorPubKey,
+			sweepDelay,
+		)
+		require.NoError(t, err)
+
+		vtxos := []VTXODescriptor{*vtxo1, *vtxo2}
 
 		tree, err := BuildVTXOTree(
 			batchOutpoint,
@@ -120,7 +127,7 @@ func TestBuildVTXOTree(t *testing.T) {
 			vtxos,
 			operatorPubKey,
 			sweepPubKey,
-			144,
+			sweepDelay,
 			2,
 		)
 		require.NoError(t, err)
@@ -164,20 +171,23 @@ func TestBuildVTXOTree(t *testing.T) {
 	})
 
 	t.Run("five VTXO tree with radix 2", func(t *testing.T) {
+		sweepDelay := closure.RelativeLocktime{
+			Type:  closure.LocktimeTypeBlock,
+			Value: 144,
+		}
+
 		// Create 5 VTXOs with different amounts.
 		vtxos := make([]VTXODescriptor, 5)
 		for i := 0; i < 5; i++ {
 			key, err := btcec.NewPrivateKey()
 			require.NoError(t, err)
 
-			script, err := txscript.PayToTaprootScript(key.PubKey())
+			vtxo, err := NewDefaultVTXODescriptor(
+				btcutil.Amount(1000*(5-i)), key.PubKey(),
+				operatorPubKey, sweepDelay,
+			)
 			require.NoError(t, err)
-
-			vtxos[i] = VTXODescriptor{
-				PkScript:    script,
-				Amount:      btcutil.Amount(1000 * (5 - i)),
-				CoSignerKey: key.PubKey(),
-			}
+			vtxos[i] = *vtxo
 		}
 
 		tree, err := BuildVTXOTree(
@@ -186,7 +196,7 @@ func TestBuildVTXOTree(t *testing.T) {
 			vtxos,
 			operatorPubKey,
 			sweepPubKey,
-			144,
+			sweepDelay,
 			2,
 		)
 		require.NoError(t, err)
@@ -214,20 +224,23 @@ func TestBuildVTXOTree(t *testing.T) {
 	})
 
 	t.Run("error cases", func(t *testing.T) {
-		vtxoScript, err := txscript.PayToTaprootScript(user1PubKey)
-		require.NoError(t, err)
-
-		validVTXO := VTXODescriptor{
-			PkScript:    vtxoScript,
-			Amount:      btcutil.Amount(1000),
-			CoSignerKey: user1PubKey,
+		sweepDelay := closure.RelativeLocktime{
+			Type:  closure.LocktimeTypeBlock,
+			Value: 144,
 		}
+
+		validVTXOPtr, err := NewDefaultVTXODescriptor(
+			btcutil.Amount(1000), user1PubKey, operatorPubKey,
+			sweepDelay,
+		)
+		require.NoError(t, err)
+		validVTXO := *validVTXOPtr
 
 		t.Run("empty VTXOs fails", func(t *testing.T) {
 			tree, err := BuildVTXOTree(
 				batchOutpoint, batchOutput,
 				[]VTXODescriptor{},
-				operatorPubKey, sweepPubKey, 144, 2,
+				operatorPubKey, sweepPubKey, sweepDelay, 2,
 			)
 			require.Error(t, err)
 			require.Nil(t, tree)
@@ -239,7 +252,7 @@ func TestBuildVTXOTree(t *testing.T) {
 			tree, err := BuildVTXOTree(
 				batchOutpoint, batchOutput,
 				[]VTXODescriptor{validVTXO},
-				operatorPubKey, sweepPubKey, 144, 1,
+				operatorPubKey, sweepPubKey, sweepDelay, 1,
 			)
 			require.Error(t, err)
 			require.Nil(t, tree)
@@ -251,7 +264,7 @@ func TestBuildVTXOTree(t *testing.T) {
 			tree, err := BuildVTXOTree(
 				batchOutpoint, batchOutput,
 				[]VTXODescriptor{validVTXO},
-				nil, sweepPubKey, 144, 2,
+				nil, sweepPubKey, sweepDelay, 2,
 			)
 			require.Error(t, err)
 			require.Nil(t, tree)
@@ -262,7 +275,7 @@ func TestBuildVTXOTree(t *testing.T) {
 			tree, err := BuildVTXOTree(
 				batchOutpoint, batchOutput,
 				[]VTXODescriptor{validVTXO},
-				operatorPubKey, nil, 144, 2,
+				operatorPubKey, nil, sweepDelay, 2,
 			)
 			require.Error(t, err)
 			require.Nil(t, tree)
@@ -283,37 +296,41 @@ func TestBuildVTXOTreeStableSort(t *testing.T) {
 	}
 	batchOutput := &wire.TxOut{Value: 10000, PkScript: []byte("batch")}
 
+	sweepDelay := closure.RelativeLocktime{
+		Type:  closure.LocktimeTypeBlock,
+		Value: 144,
+	}
+
 	// Create 3 VTXOs with SAME amount but different scripts.
-	// The scripts are intentionally out of lexicographic order.
-	key10, _ := testutils.CreateKey(10)
-	script1, _ := txscript.PayToTaprootScript(key10)
-
-	key20, _ := testutils.CreateKey(20)
-	script2, _ := txscript.PayToTaprootScript(key20)
-
-	key30, _ := testutils.CreateKey(30)
-	script3, _ := txscript.PayToTaprootScript(key30)
-
 	coSigner1, _ := testutils.CreateKey(101)
 	coSigner2, _ := testutils.CreateKey(102)
 	coSigner3, _ := testutils.CreateKey(103)
 
-	vtxos := []VTXODescriptor{
-		{PkScript: script3, Amount: 1000, CoSignerKey: coSigner3},
-		{PkScript: script1, Amount: 1000, CoSignerKey: coSigner1},
-		{PkScript: script2, Amount: 1000, CoSignerKey: coSigner2},
-	}
+	vtxo1, err := NewDefaultVTXODescriptor(1000, coSigner1, operatorKey,
+		sweepDelay)
+	require.NoError(t, err)
+
+	vtxo2, err := NewDefaultVTXODescriptor(1000, coSigner2, operatorKey,
+		sweepDelay)
+	require.NoError(t, err)
+
+	vtxo3, err := NewDefaultVTXODescriptor(1000, coSigner3, operatorKey,
+		sweepDelay)
+	require.NoError(t, err)
+
+	// Order intentionally mixed.
+	vtxos := []VTXODescriptor{*vtxo3, *vtxo1, *vtxo2}
 
 	// Build tree multiple times - should be identical.
 	tree1, err := BuildVTXOTree(
-		batchOutpoint, batchOutput, vtxos, operatorKey, sweepKey, 144,
-		2,
+		batchOutpoint, batchOutput, vtxos, operatorKey, sweepKey,
+		sweepDelay, 2,
 	)
 	require.NoError(t, err)
 
 	tree2, err := BuildVTXOTree(
-		batchOutpoint, batchOutput, vtxos, operatorKey, sweepKey, 144,
-		2,
+		batchOutpoint, batchOutput, vtxos, operatorKey, sweepKey,
+		sweepDelay, 2,
 	)
 	require.NoError(t, err)
 
@@ -596,22 +613,21 @@ func TestBuildBatchOutput(t *testing.T) {
 	sweepKey, _ := testutils.CreateKey(2)
 
 	user1Key, _ := testutils.CreateKey(10)
-	user1Script, _ := txscript.PayToTaprootScript(user1Key)
-
 	user2Key, _ := testutils.CreateKey(20)
-	user2Script, _ := txscript.PayToTaprootScript(user2Key)
+
+	sweepDelay := closure.RelativeLocktime{
+		Type:  closure.LocktimeTypeBlock,
+		Value: 144,
+	}
 
 	t.Run("single VTXO", func(t *testing.T) {
-		vtxos := []VTXODescriptor{
-			{
-				PkScript:    user1Script,
-				Amount:      btcutil.Amount(5000),
-				CoSignerKey: user1Key,
-			},
-		}
+		vtxo, err := NewDefaultVTXODescriptor(
+			btcutil.Amount(5000), user1Key, operatorKey, sweepDelay,
+		)
+		require.NoError(t, err)
 
 		output, err := BuildBatchOutput(
-			vtxos, operatorKey, sweepKey, 144,
+			[]VTXODescriptor{*vtxo}, operatorKey, sweepKey, sweepDelay,
 		)
 		require.NoError(t, err)
 		require.NotNil(t, output)
@@ -624,21 +640,19 @@ func TestBuildBatchOutput(t *testing.T) {
 	})
 
 	t.Run("multiple VTXOs", func(t *testing.T) {
-		vtxos := []VTXODescriptor{
-			{
-				PkScript:    user1Script,
-				Amount:      btcutil.Amount(5000),
-				CoSignerKey: user1Key,
-			},
-			{
-				PkScript:    user2Script,
-				Amount:      btcutil.Amount(3000),
-				CoSignerKey: user2Key,
-			},
-		}
+		vtxo1, err := NewDefaultVTXODescriptor(
+			btcutil.Amount(5000), user1Key, operatorKey, sweepDelay,
+		)
+		require.NoError(t, err)
+
+		vtxo2, err := NewDefaultVTXODescriptor(
+			btcutil.Amount(3000), user2Key, operatorKey, sweepDelay,
+		)
+		require.NoError(t, err)
 
 		output, err := BuildBatchOutput(
-			vtxos, operatorKey, sweepKey, 144,
+			[]VTXODescriptor{*vtxo1, *vtxo2}, operatorKey, sweepKey,
+			sweepDelay,
 		)
 		require.NoError(t, err)
 		require.NotNil(t, output)
@@ -652,21 +666,19 @@ func TestBuildBatchOutput(t *testing.T) {
 
 	t.Run("duplicate cosigners handled", func(t *testing.T) {
 		// Same user has 2 VTXOs.
-		vtxos := []VTXODescriptor{
-			{
-				PkScript:    user1Script,
-				Amount:      btcutil.Amount(2000),
-				CoSignerKey: user1Key,
-			},
-			{
-				PkScript:    user1Script,
-				Amount:      btcutil.Amount(3000),
-				CoSignerKey: user1Key, // Same key!
-			},
-		}
+		vtxo1, err := NewDefaultVTXODescriptor(
+			btcutil.Amount(2000), user1Key, operatorKey, sweepDelay,
+		)
+		require.NoError(t, err)
+
+		vtxo2, err := NewDefaultVTXODescriptor(
+			btcutil.Amount(3000), user1Key, operatorKey, sweepDelay,
+		)
+		require.NoError(t, err)
 
 		output, err := BuildBatchOutput(
-			vtxos, operatorKey, sweepKey, 144,
+			[]VTXODescriptor{*vtxo1, *vtxo2}, operatorKey, sweepKey,
+			sweepDelay,
 		)
 		require.NoError(t, err)
 		require.NotNil(t, output)
@@ -676,16 +688,16 @@ func TestBuildBatchOutput(t *testing.T) {
 	})
 
 	t.Run("error cases", func(t *testing.T) {
-		validVTXO := VTXODescriptor{
-			PkScript:    user1Script,
-			Amount:      btcutil.Amount(1000),
-			CoSignerKey: user1Key,
-		}
+		validVTXOPtr, err := NewDefaultVTXODescriptor(
+			btcutil.Amount(1000), user1Key, operatorKey, sweepDelay,
+		)
+		require.NoError(t, err)
+		validVTXO := *validVTXOPtr
 
 		t.Run("empty VTXOs fails", func(t *testing.T) {
 			output, err := BuildBatchOutput(
 				[]VTXODescriptor{},
-				operatorKey, sweepKey, 144,
+				operatorKey, sweepKey, sweepDelay,
 			)
 			require.Error(t, err)
 			require.Nil(t, output)
@@ -695,7 +707,7 @@ func TestBuildBatchOutput(t *testing.T) {
 		t.Run("nil operator key fails", func(t *testing.T) {
 			output, err := BuildBatchOutput(
 				[]VTXODescriptor{validVTXO},
-				nil, sweepKey, 144,
+				nil, sweepKey, sweepDelay,
 			)
 			require.Error(t, err)
 			require.Nil(t, output)
@@ -705,7 +717,7 @@ func TestBuildBatchOutput(t *testing.T) {
 		t.Run("nil sweep key fails", func(t *testing.T) {
 			output, err := BuildBatchOutput(
 				[]VTXODescriptor{validVTXO},
-				operatorKey, nil, 144,
+				operatorKey, nil, sweepDelay,
 			)
 			require.Error(t, err)
 			require.Nil(t, output)
@@ -798,49 +810,44 @@ func TestValidateVTXODescriptors(t *testing.T) {
 	require.NoError(t, err)
 	key3Pub := key3.PubKey()
 
-	// Create a valid taproot script for testing.
-	validTaprootScript, err := txscript.PayToTaprootScript(key1Pub)
+	operatorKey, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
+	operatorPub := operatorKey.PubKey()
+
+	exitDelay := closure.RelativeLocktime{
+		Type:  closure.LocktimeTypeBlock,
+		Value: 144,
+	}
 
 	t.Run("valid single VTXO", func(t *testing.T) {
-		vtxos := []VTXODescriptor{
-			{
-				PkScript:    validTaprootScript,
-				Amount:      btcutil.Amount(10000),
-				CoSignerKey: key1Pub,
-			},
-		}
+		vtxo, err := NewDefaultVTXODescriptor(
+			btcutil.Amount(10000), key1Pub, operatorPub, exitDelay,
+		)
+		require.NoError(t, err)
 
-		err := ValidateVTXODescriptors(vtxos)
+		err = ValidateVTXODescriptors([]VTXODescriptor{*vtxo})
 		require.NoError(t, err)
 	})
 
 	t.Run("valid multiple VTXOs", func(t *testing.T) {
-		script2, err := txscript.PayToTaprootScript(key2Pub)
+		vtxo1, err := NewDefaultVTXODescriptor(
+			btcutil.Amount(10000), key1Pub, operatorPub, exitDelay,
+		)
 		require.NoError(t, err)
 
-		script3, err := txscript.PayToTaprootScript(key3Pub)
+		vtxo2, err := NewDefaultVTXODescriptor(
+			btcutil.Amount(20000), key2Pub, operatorPub, exitDelay,
+		)
 		require.NoError(t, err)
 
-		vtxos := []VTXODescriptor{
-			{
-				PkScript:    validTaprootScript,
-				Amount:      btcutil.Amount(10000),
-				CoSignerKey: key1Pub,
-			},
-			{
-				PkScript:    script2,
-				Amount:      btcutil.Amount(20000),
-				CoSignerKey: key2Pub,
-			},
-			{
-				PkScript:    script3,
-				Amount:      btcutil.Amount(30000),
-				CoSignerKey: key3Pub,
-			},
-		}
+		vtxo3, err := NewDefaultVTXODescriptor(
+			btcutil.Amount(30000), key3Pub, operatorPub, exitDelay,
+		)
+		require.NoError(t, err)
 
-		err = ValidateVTXODescriptors(vtxos)
+		err = ValidateVTXODescriptors([]VTXODescriptor{
+			*vtxo1, *vtxo2, *vtxo3,
+		})
 		require.NoError(t, err)
 	})
 
@@ -857,37 +864,37 @@ func TestValidateVTXODescriptors(t *testing.T) {
 	})
 
 	t.Run("zero amount fails", func(t *testing.T) {
-		vtxos := []VTXODescriptor{
-			{
-				PkScript:    validTaprootScript,
-				Amount:      btcutil.Amount(0),
-				CoSignerKey: key1Pub,
-			},
-		}
+		vtxo, err := NewDefaultVTXODescriptor(
+			btcutil.Amount(1000), key1Pub, operatorPub, exitDelay,
+		)
+		require.NoError(t, err)
 
-		err := ValidateVTXODescriptors(vtxos)
+		// Manually set amount to 0 to test validation.
+		vtxo.Amount = 0
+
+		err = ValidateVTXODescriptors([]VTXODescriptor{*vtxo})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid amount")
 	})
 
 	t.Run("negative amount fails", func(t *testing.T) {
-		vtxos := []VTXODescriptor{
-			{
-				PkScript:    validTaprootScript,
-				Amount:      btcutil.Amount(-1000),
-				CoSignerKey: key1Pub,
-			},
-		}
+		vtxo, err := NewDefaultVTXODescriptor(
+			btcutil.Amount(1000), key1Pub, operatorPub, exitDelay,
+		)
+		require.NoError(t, err)
 
-		err := ValidateVTXODescriptors(vtxos)
+		// Manually set amount to negative to test validation.
+		vtxo.Amount = btcutil.Amount(-1000)
+
+		err = ValidateVTXODescriptors([]VTXODescriptor{*vtxo})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid amount")
 	})
 
-	t.Run("empty PkScript fails", func(t *testing.T) {
+	t.Run("empty Scripts fails", func(t *testing.T) {
 		vtxos := []VTXODescriptor{
 			{
-				PkScript:    []byte{},
+				Scripts:     []string{},
 				Amount:      btcutil.Amount(10000),
 				CoSignerKey: key1Pub,
 			},
@@ -895,13 +902,13 @@ func TestValidateVTXODescriptors(t *testing.T) {
 
 		err := ValidateVTXODescriptors(vtxos)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "empty PkScript")
+		require.Contains(t, err.Error(), "empty Scripts")
 	})
 
-	t.Run("nil PkScript fails", func(t *testing.T) {
+	t.Run("nil Scripts fails", func(t *testing.T) {
 		vtxos := []VTXODescriptor{
 			{
-				PkScript:    nil,
+				Scripts:     nil,
 				Amount:      btcutil.Amount(10000),
 				CoSignerKey: key1Pub,
 			},
@@ -909,21 +916,13 @@ func TestValidateVTXODescriptors(t *testing.T) {
 
 		err := ValidateVTXODescriptors(vtxos)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "empty PkScript")
+		require.Contains(t, err.Error(), "empty Scripts")
 	})
 
-	t.Run("non-taproot script fails", func(t *testing.T) {
-		// Create a P2WPKH script (not taproot).
-		p2wpkhScript := []byte{
-			0x00, 0x14, // OP_0 + 20 bytes
-			0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
-			0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
-			0x11, 0x12, 0x13, 0x14,
-		}
-
+	t.Run("invalid script hex fails", func(t *testing.T) {
 		vtxos := []VTXODescriptor{
 			{
-				PkScript:    p2wpkhScript,
+				Scripts:     []string{"not_valid_hex"},
 				Amount:      btcutil.Amount(10000),
 				CoSignerKey: key1Pub,
 			},
@@ -931,71 +930,64 @@ func TestValidateVTXODescriptors(t *testing.T) {
 
 		err := ValidateVTXODescriptors(vtxos)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "invalid taproot script")
+		require.Contains(t, err.Error(), "invalid scripts")
 	})
 
 	t.Run("nil co-signer key fails", func(t *testing.T) {
-		vtxos := []VTXODescriptor{
-			{
-				PkScript:    validTaprootScript,
-				Amount:      btcutil.Amount(10000),
-				CoSignerKey: nil,
-			},
-		}
+		vtxo, err := NewDefaultVTXODescriptor(
+			btcutil.Amount(10000), key1Pub, operatorPub, exitDelay,
+		)
+		require.NoError(t, err)
 
-		err := ValidateVTXODescriptors(vtxos)
+		// Manually set CoSignerKey to nil.
+		vtxo.CoSignerKey = nil
+
+		err = ValidateVTXODescriptors([]VTXODescriptor{*vtxo})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "nil co-signer key")
 	})
 
 	t.Run("duplicate co-signer keys fail", func(t *testing.T) {
-		script2, err := txscript.PayToTaprootScript(key2Pub)
+		vtxo1, err := NewDefaultVTXODescriptor(
+			btcutil.Amount(10000), key1Pub, operatorPub, exitDelay,
+		)
 		require.NoError(t, err)
 
-		vtxos := []VTXODescriptor{
-			{
-				PkScript:    validTaprootScript,
-				Amount:      btcutil.Amount(10000),
-				CoSignerKey: key1Pub,
-			},
-			{
-				PkScript:    script2,
-				Amount:      btcutil.Amount(20000),
-				CoSignerKey: key1Pub, // Duplicate!
-			},
-		}
+		vtxo2, err := NewDefaultVTXODescriptor(
+			btcutil.Amount(20000), key2Pub, operatorPub, exitDelay,
+		)
+		require.NoError(t, err)
 
-		err = ValidateVTXODescriptors(vtxos)
+		// Set the second VTXO to use the same cosigner key.
+		vtxo2.CoSignerKey = key1Pub
+
+		err = ValidateVTXODescriptors([]VTXODescriptor{*vtxo1, *vtxo2})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "duplicate co-signer key")
 	})
 
 	t.Run("duplicate detection multiple VTXOs", func(t *testing.T) {
-		script2, err := txscript.PayToTaprootScript(key2Pub)
+		vtxo1, err := NewDefaultVTXODescriptor(
+			btcutil.Amount(10000), key1Pub, operatorPub, exitDelay,
+		)
 		require.NoError(t, err)
 
-		script3, err := txscript.PayToTaprootScript(key3Pub)
+		vtxo2, err := NewDefaultVTXODescriptor(
+			btcutil.Amount(20000), key2Pub, operatorPub, exitDelay,
+		)
 		require.NoError(t, err)
 
-		vtxos := []VTXODescriptor{
-			{
-				PkScript:    validTaprootScript,
-				Amount:      btcutil.Amount(10000),
-				CoSignerKey: key1Pub,
-			},
-			{
-				PkScript:    script2,
-				Amount:      btcutil.Amount(20000),
-				CoSignerKey: key2Pub,
-			},
-			{
-				PkScript:    script3,
-				Amount:      btcutil.Amount(30000),
-				CoSignerKey: key2Pub, // Duplicate of second!
-			},
-		}
+		vtxo3, err := NewDefaultVTXODescriptor(
+			btcutil.Amount(30000), key3Pub, operatorPub, exitDelay,
+		)
+		require.NoError(t, err)
 
-		err = ValidateVTXODescriptors(vtxos)
+		// Set the third VTXO to use key2's cosigner key.
+		vtxo3.CoSignerKey = key2Pub
+
+		err = ValidateVTXODescriptors([]VTXODescriptor{
+			*vtxo1, *vtxo2, *vtxo3,
+		})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "duplicate co-signer key")
 	})
@@ -1101,58 +1093,398 @@ func TestValidateConnectorDescriptor(t *testing.T) {
 	})
 }
 
-// TestMakeVTXODescriptor tests the VTXO descriptor construction helper.
+// TestMakeVTXODescriptor tests the VTXO descriptor construction helpers.
 func TestMakeVTXODescriptor(t *testing.T) {
-	timeoutKey, _ := testutils.CreateKey(1)
+	ownerKey, _ := testutils.CreateKey(1)
 	cosignerKey, _ := testutils.CreateKey(2)
 
-	t.Run("creates valid descriptor", func(t *testing.T) {
-		desc, err := NewVTXODescriptor(
+	exitDelay := closure.RelativeLocktime{
+		Type:  closure.LocktimeTypeBlock,
+		Value: 144,
+	}
+
+	t.Run("NewDefaultVTXODescriptor creates valid descriptor", func(t *testing.T) {
+		desc, err := NewDefaultVTXODescriptor(
 			btcutil.Amount(5000),
-			timeoutKey,
+			ownerKey,
 			cosignerKey,
-			144, // exit delay
+			exitDelay,
 		)
 		require.NoError(t, err)
 		require.NotNil(t, desc)
 
 		// Verify descriptor fields.
 		require.Equal(t, btcutil.Amount(5000), desc.Amount)
-		require.Equal(t, timeoutKey, desc.CoSignerKey)
+		require.Equal(t, ownerKey, desc.CoSignerKey)
+		require.NotEmpty(t, desc.Scripts)
 
-		// Verify PkScript is valid taproot.
-		require.NotEmpty(t, desc.PkScript)
-		require.True(t, txscript.IsPayToTaproot(desc.PkScript))
+		// Verify PkScript() derives valid taproot.
+		pkScript, err := desc.PkScript()
+		require.NoError(t, err)
+		require.NotEmpty(t, pkScript)
+		require.True(t, txscript.IsPayToTaproot(pkScript))
+
+		// Verify VtxoScript() parses correctly.
+		vtxoScript, err := desc.VtxoScript()
+		require.NoError(t, err)
+		require.Len(t, vtxoScript.Closures, 2) // Exit + Collab
 
 		// Verify descriptor passes validation.
 		err = ValidateVTXODescriptors([]VTXODescriptor{*desc})
 		require.NoError(t, err)
 	})
 
+	t.Run("NewVTXODescriptor accepts custom closures", func(t *testing.T) {
+		// Create a custom VTXO script with only an exit closure.
+		customScript := &closure.TapscriptsVtxoScript{
+			Closures: []closure.Closure{
+				&closure.CSVSigClosure{
+					PubKey:   ownerKey,
+					Locktime: exitDelay,
+				},
+			},
+		}
+
+		desc, err := NewVTXODescriptor(
+			btcutil.Amount(3000), customScript, ownerKey,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, desc)
+
+		// Verify closure was preserved.
+		vtxoScript, err := desc.VtxoScript()
+		require.NoError(t, err)
+		require.Len(t, vtxoScript.Closures, 1)
+
+		// Verify it's a CSVSigClosure.
+		_, ok := vtxoScript.Closures[0].(*closure.CSVSigClosure)
+		require.True(t, ok)
+	})
+
 	t.Run("integrates with scripts package", func(t *testing.T) {
 		// Create multiple VTXOs with different cosigner keys.
 		cosigner1, _ := testutils.CreateKey(10)
 		operator, _ := testutils.CreateKey(20)
-		desc1, err := NewVTXODescriptor(
+		desc1, err := NewDefaultVTXODescriptor(
 			btcutil.Amount(1000),
 			cosigner1,
 			operator,
-			144,
+			exitDelay,
 		)
 		require.NoError(t, err)
 
-		cosigner2, _ := testutils.CreateKey(20)
-		desc2, err := NewVTXODescriptor(
+		cosigner2, _ := testutils.CreateKey(30)
+		desc2, err := NewDefaultVTXODescriptor(
 			btcutil.Amount(2000),
 			cosigner2,
 			operator,
-			144,
+			exitDelay,
 		)
 		require.NoError(t, err)
 
 		// Both should be valid and have unique cosigners.
 		err = ValidateVTXODescriptors([]VTXODescriptor{*desc1, *desc2})
 		require.NoError(t, err)
+	})
+
+	t.Run("error cases", func(t *testing.T) {
+		t.Run("nil vtxo script fails", func(t *testing.T) {
+			_, err := NewVTXODescriptor(
+				btcutil.Amount(1000), nil, ownerKey,
+			)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "vtxo script cannot be nil")
+		})
+
+		t.Run("nil cosigner key fails", func(t *testing.T) {
+			customScript := &closure.TapscriptsVtxoScript{
+				Closures: []closure.Closure{
+					&closure.CSVSigClosure{
+						PubKey:   ownerKey,
+						Locktime: exitDelay,
+					},
+				},
+			}
+			_, err := NewVTXODescriptor(
+				btcutil.Amount(1000), customScript, nil,
+			)
+			require.Error(t, err)
+			require.Contains(t, err.Error(),
+				"cosigner key cannot be nil")
+		})
+	})
+}
+
+// TestBuildVTXOTreeWithCustomClosures tests that the VTXO tree can be built
+// with non-default closure configurations, verifying that custom VTXODescriptors
+// created via NewVTXODescriptor work correctly and that the closure roundtrip
+// through VtxoScript() preserves the original closure structure.
+func TestBuildVTXOTreeWithCustomClosures(t *testing.T) {
+	t.Parallel()
+
+	operatorKey, _ := testutils.CreateKey(1)
+	sweepKey, _ := testutils.CreateKey(2)
+
+	batchOutpoint := wire.OutPoint{
+		Hash:  chainhash.HashH([]byte("custom_closures_test")),
+		Index: 0,
+	}
+	batchOutput := &wire.TxOut{
+		Value:    20000,
+		PkScript: []byte("batch_script"),
+	}
+
+	sweepDelay := closure.RelativeLocktime{
+		Type:  closure.LocktimeTypeBlock,
+		Value: 144,
+	}
+
+	t.Run("CSVMultisigClosure exit with MultisigClosure collab", func(t *testing.T) {
+		client1Key, _ := testutils.CreateKey(10)
+		client2Key, _ := testutils.CreateKey(11)
+
+		exitDelay := closure.RelativeLocktime{
+			Type:  closure.LocktimeTypeBlock,
+			Value: 100,
+		}
+
+		// Create a custom VTXO script with CSVMultisigClosure for exit.
+		customScript := &closure.TapscriptsVtxoScript{
+			Closures: []closure.Closure{
+				// Exit: 2-of-2 multisig after CSV delay.
+				&closure.CSVMultisigClosure{
+					MultisigClosure: closure.MultisigClosure{
+						PubKeys: []*btcec.PublicKey{
+							client1Key, client2Key,
+						},
+						Type: closure.MultisigTypeChecksig,
+					},
+					Locktime: exitDelay,
+				},
+				// Collab: all three parties.
+				&closure.MultisigClosure{
+					PubKeys: []*btcec.PublicKey{
+						client1Key, client2Key, operatorKey,
+					},
+					Type: closure.MultisigTypeChecksig,
+				},
+			},
+		}
+
+		// Create VTXO descriptor with custom closures.
+		vtxoDesc, err := NewVTXODescriptor(
+			btcutil.Amount(5000), customScript, client1Key,
+		)
+		require.NoError(t, err)
+
+		// Verify roundtrip: VtxoScript() should reconstruct closures.
+		roundtrip, err := vtxoDesc.VtxoScript()
+		require.NoError(t, err)
+		require.Len(t, roundtrip.Closures, 2)
+
+		// Verify first closure is CSVMultisigClosure.
+		csvMultisig, ok := roundtrip.Closures[0].(*closure.CSVMultisigClosure)
+		require.True(t, ok, "first closure should be CSVMultisigClosure")
+		require.Len(t, csvMultisig.PubKeys, 2)
+		require.Equal(t, exitDelay.Value, csvMultisig.Locktime.Value)
+
+		// Verify second closure is MultisigClosure.
+		multisig, ok := roundtrip.Closures[1].(*closure.MultisigClosure)
+		require.True(t, ok, "second closure should be MultisigClosure")
+		require.Len(t, multisig.PubKeys, 3)
+
+		// Build tree with custom VTXO.
+		tree, err := BuildVTXOTree(
+			batchOutpoint, batchOutput,
+			[]VTXODescriptor{*vtxoDesc},
+			operatorKey, sweepKey, sweepDelay, 2,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, tree)
+
+		// Verify tree structure.
+		require.True(t, tree.Root.IsLeaf())
+		require.Len(t, tree.Root.Outputs, 2) // VTXO + anchor
+
+		// Verify PkScript matches the custom script.
+		expectedPkScript, err := vtxoDesc.PkScript()
+		require.NoError(t, err)
+		require.Equal(t, expectedPkScript, tree.Root.Outputs[0].PkScript)
+	})
+
+	t.Run("exit-only VTXO (single closure, no collab)", func(t *testing.T) {
+		clientKey, _ := testutils.CreateKey(20)
+
+		exitDelay := closure.RelativeLocktime{
+			Type:  closure.LocktimeTypeBlock,
+			Value: 50,
+		}
+
+		// VTXO with only a single exit closure - no collaborative path.
+		customScript := &closure.TapscriptsVtxoScript{
+			Closures: []closure.Closure{
+				&closure.CSVSigClosure{
+					PubKey:   clientKey,
+					Locktime: exitDelay,
+				},
+			},
+		}
+
+		vtxoDesc, err := NewVTXODescriptor(
+			btcutil.Amount(3000), customScript, clientKey,
+		)
+		require.NoError(t, err)
+
+		// Verify roundtrip preserves the single closure.
+		roundtrip, err := vtxoDesc.VtxoScript()
+		require.NoError(t, err)
+		require.Len(t, roundtrip.Closures, 1)
+
+		csvSig, ok := roundtrip.Closures[0].(*closure.CSVSigClosure)
+		require.True(t, ok, "closure should be CSVSigClosure")
+		require.Equal(t, exitDelay.Value, csvSig.Locktime.Value)
+
+		// Build tree with exit-only VTXO.
+		tree, err := BuildVTXOTree(
+			batchOutpoint, batchOutput,
+			[]VTXODescriptor{*vtxoDesc},
+			operatorKey, sweepKey, sweepDelay, 2,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, tree)
+
+		// Verify output script.
+		expectedPkScript, err := vtxoDesc.PkScript()
+		require.NoError(t, err)
+		require.Equal(t, expectedPkScript, tree.Root.Outputs[0].PkScript)
+	})
+
+	t.Run("multiple VTXOs with different closure configurations", func(t *testing.T) {
+		user1Key, _ := testutils.CreateKey(30)
+		user2Key, _ := testutils.CreateKey(31)
+		user3Key, _ := testutils.CreateKey(32)
+
+		exitDelay := closure.RelativeLocktime{
+			Type:  closure.LocktimeTypeBlock,
+			Value: 100,
+		}
+
+		// First VTXO: default configuration.
+		vtxo1, err := NewDefaultVTXODescriptor(
+			btcutil.Amount(1000), user1Key, operatorKey, exitDelay,
+		)
+		require.NoError(t, err)
+
+		// Second VTXO: custom 2-of-2 exit.
+		customScript2 := &closure.TapscriptsVtxoScript{
+			Closures: []closure.Closure{
+				&closure.CSVMultisigClosure{
+					MultisigClosure: closure.MultisigClosure{
+						PubKeys: []*btcec.PublicKey{
+							user2Key, operatorKey,
+						},
+						Type: closure.MultisigTypeChecksig,
+					},
+					Locktime: exitDelay,
+				},
+				&closure.MultisigClosure{
+					PubKeys: []*btcec.PublicKey{
+						user2Key, operatorKey,
+					},
+					Type: closure.MultisigTypeChecksig,
+				},
+			},
+		}
+		vtxo2, err := NewVTXODescriptor(
+			btcutil.Amount(2000), customScript2, user2Key,
+		)
+		require.NoError(t, err)
+
+		// Third VTXO: exit-only.
+		customScript3 := &closure.TapscriptsVtxoScript{
+			Closures: []closure.Closure{
+				&closure.CSVSigClosure{
+					PubKey:   user3Key,
+					Locktime: exitDelay,
+				},
+			},
+		}
+		vtxo3, err := NewVTXODescriptor(
+			btcutil.Amount(3000), customScript3, user3Key,
+		)
+		require.NoError(t, err)
+
+		// Build tree with mixed VTXO types.
+		tree, err := BuildVTXOTree(
+			batchOutpoint, batchOutput,
+			[]VTXODescriptor{*vtxo1, *vtxo2, *vtxo3},
+			operatorKey, sweepKey, sweepDelay, 2,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, tree)
+
+		// Verify all leaves are present.
+		leaves := tree.Root.GetLeafNodes()
+		require.Len(t, leaves, 3)
+
+		// Verify total amount is preserved.
+		var totalAmount int64
+		for _, leaf := range leaves {
+			totalAmount += leaf.Outputs[0].Value
+		}
+		require.Equal(t, int64(6000), totalAmount)
+	})
+
+	t.Run("CLTVMultisigClosure for absolute timelock", func(t *testing.T) {
+		clientKey, _ := testutils.CreateKey(40)
+
+		// CLTV absolute locktime (block height).
+		cltvLocktime := closure.AbsoluteLocktime(850000)
+
+		// VTXO with CLTVMultisigClosure for absolute timelock exit.
+		customScript := &closure.TapscriptsVtxoScript{
+			Closures: []closure.Closure{
+				// Exit: after CLTV block height.
+				&closure.CLTVMultisigClosure{
+					MultisigClosure: closure.MultisigClosure{
+						PubKeys: []*btcec.PublicKey{clientKey},
+						Type:    closure.MultisigTypeChecksig,
+					},
+					Locktime: cltvLocktime,
+				},
+				// Collab path.
+				&closure.MultisigClosure{
+					PubKeys: []*btcec.PublicKey{
+						clientKey, operatorKey,
+					},
+					Type: closure.MultisigTypeChecksig,
+				},
+			},
+		}
+
+		vtxoDesc, err := NewVTXODescriptor(
+			btcutil.Amount(4000), customScript, clientKey,
+		)
+		require.NoError(t, err)
+
+		// Verify roundtrip.
+		roundtrip, err := vtxoDesc.VtxoScript()
+		require.NoError(t, err)
+		require.Len(t, roundtrip.Closures, 2)
+
+		cltvMultisig, ok := roundtrip.Closures[0].(*closure.CLTVMultisigClosure)
+		require.True(t, ok, "first closure should be CLTVMultisigClosure")
+		require.Equal(t, cltvLocktime, cltvMultisig.Locktime)
+
+		// Build tree.
+		tree, err := BuildVTXOTree(
+			batchOutpoint, batchOutput,
+			[]VTXODescriptor{*vtxoDesc},
+			operatorKey, sweepKey, sweepDelay, 2,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, tree)
+		require.True(t, tree.Root.IsLeaf())
 	})
 }
 
@@ -1164,7 +1496,10 @@ func TestNewBranchSweepSpendInfo(t *testing.T) {
 
 	internalKey, _ := testutils.CreateKey(5)
 	sweepKey, _ := testutils.CreateKey(6)
-	csvDelay := uint32(144)
+	csvDelay := closure.RelativeLocktime{
+		Type:  closure.LocktimeTypeBlock,
+		Value: 144,
+	}
 
 	spendInfo, err := NewBranchSweepSpendInfo(
 		internalKey, sweepKey, csvDelay,
@@ -1174,7 +1509,7 @@ func TestNewBranchSweepSpendInfo(t *testing.T) {
 	require.NotEmpty(t, spendInfo.WitnessScript)
 	require.NotEmpty(t, spendInfo.ControlBlock)
 
-	timeoutLeaf, err := scripts.UnilateralCSVTimeoutTapLeaf(
+	timeoutLeaf, err := scripts.CSVTimeoutTapLeaf(
 		sweepKey, csvDelay,
 	)
 	require.NoError(t, err)

--- a/lib/tx/forfeit.go
+++ b/lib/tx/forfeit.go
@@ -6,7 +6,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/lightninglabs/darepo-client/lib/closure"
 	"github.com/lightninglabs/darepo-client/lib/scripts"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
@@ -30,9 +30,9 @@ type VTXOSpendContext struct {
 	// amount.
 	Output *wire.TxOut
 
-	// TapScript contains the taproot script details for the VTXO,
-	// including the internal key and all script paths.
-	TapScript *waddrmgr.Tapscript
+	// VtxoScript contains the closure-based tapscript for the VTXO,
+	// including all script paths (exit and forfeit closures).
+	VtxoScript *closure.TapscriptsVtxoScript
 }
 
 // ConnectorSpendContext describes the connector input being spent.
@@ -107,20 +107,18 @@ func NewForfeitPrevOutFetcher(vtxo *VTXOSpendContext,
 }
 
 // NewVTXOCollabSignDescriptor returns the sign descriptor + spend info for a
-// collaborative VTXO spend.
+// collaborative (forfeit) VTXO spend.
 func NewVTXOCollabSignDescriptor(vtxo *VTXOSpendContext,
 	keyDesc keychain.KeyDescriptor, inputIndex int,
 	sigHashes *txscript.TxSigHashes,
 	prevFetcher txscript.PrevOutputFetcher) (*input.SignDescriptor,
 	*scripts.VTXOSpendData, error) {
 
-	if vtxo == nil || vtxo.TapScript == nil {
-		return nil, nil, fmt.Errorf("vtxo tapscript must be provided")
+	if vtxo == nil || vtxo.VtxoScript == nil {
+		return nil, nil, fmt.Errorf("vtxo script must be provided")
 	}
 
-	spendInfo, err := scripts.NewVTXOSpendInfo(
-		vtxo.TapScript, scripts.VTXOCollabPathLeaf,
-	)
+	spendInfo, err := scripts.VtxoCollabSpendInfo(vtxo.VtxoScript)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to derive collaborative "+
 			"spend info: %w", err)

--- a/lib/tx/forfeit_test.go
+++ b/lib/tx/forfeit_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/internal/testutils"
+	"github.com/lightninglabs/darepo-client/lib/closure"
 	"github.com/lightninglabs/darepo-client/lib/scripts"
 	"github.com/lightninglabs/darepo-client/lib/tree"
 	"github.com/lightninglabs/darepo-client/lib/tx"
@@ -39,10 +40,13 @@ func TestForfeitTransactionFlow(t *testing.T) {
 		KeyLocator: keychain.KeyLocator{Family: 10, Index: 0},
 	}
 
-	const exitDelay = 144
+	exitDelay := closure.RelativeLocktime{
+		Type:  closure.LocktimeTypeBlock,
+		Value: 144,
+	}
 	vtxoAmount := btcutil.Amount(5_000)
 
-	vtxoDesc, err := tree.NewVTXODescriptor(
+	vtxoDesc, err := tree.NewDefaultVTXODescriptor(
 		vtxoAmount, clientKey, operatorKey, exitDelay,
 	)
 	require.NoError(t, err)
@@ -71,15 +75,14 @@ func TestForfeitTransactionFlow(t *testing.T) {
 	vtxoOutput := nonAnchorOutput(t, leaf)
 	require.NotNil(t, vtxoOutput)
 
-	vtxoTapScript, err := scripts.VTXOTapScript(
+	vtxoScript := scripts.NewDefaultVtxoScript(
 		clientKey, operatorKey, exitDelay,
 	)
-	require.NoError(t, err)
 
 	vtxoCtx := &tx.VTXOSpendContext{
-		Outpoint:  *vtxoOutpoint,
-		Output:    vtxoOutput,
-		TapScript: vtxoTapScript,
+		Outpoint:   *vtxoOutpoint,
+		Output:     vtxoOutput,
+		VtxoScript: vtxoScript,
 	}
 
 	connectorTapKey := txscript.ComputeTaprootOutputKey(operatorKey, nil)
@@ -163,7 +166,7 @@ func TestForfeitTransactionFlow(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	witness, err := scripts.VTXOCollabSpendWitness(
+	witness, err := scripts.VtxoCollabSpendWitness(
 		clientSig, operatorSig, spendInfo,
 	)
 	require.NoError(t, err)
@@ -232,4 +235,235 @@ func nonAnchorOutput(t *testing.T, node *tree.Node) *wire.TxOut {
 	}
 
 	return nil
+}
+
+// TestForfeitWithCustomVTXO verifies that forfeit transactions work correctly
+// with non-default VTXO closure configurations, specifically testing that the
+// collaborative spend path functions with CSVMultisigClosure exit closures.
+func TestForfeitWithCustomVTXO(t *testing.T) {
+	t.Parallel()
+
+	// Create keys for a 2-of-2 client exit and 3-of-3 collab path.
+	client1Key, client1Wallet := testutils.CreateKey(1)
+	client1KeyDesc := &keychain.KeyDescriptor{
+		PubKey:     client1Key,
+		KeyLocator: keychain.KeyLocator{Family: 1, Index: 0},
+	}
+
+	client2Key, client2Wallet := testutils.CreateKey(2)
+	client2KeyDesc := &keychain.KeyDescriptor{
+		PubKey:     client2Key,
+		KeyLocator: keychain.KeyLocator{Family: 2, Index: 0},
+	}
+
+	operatorKey, operatorWallet := testutils.CreateKey(3)
+	operatorKeyDesc := &keychain.KeyDescriptor{
+		PubKey:     operatorKey,
+		KeyLocator: keychain.KeyLocator{Family: 3, Index: 0},
+	}
+
+	sweepKey, _ := testutils.CreateKey(4)
+
+	exitDelay := closure.RelativeLocktime{
+		Type:  closure.LocktimeTypeBlock,
+		Value: 144,
+	}
+	vtxoAmount := btcutil.Amount(5_000)
+
+	// Create custom VTXO with CSVMultisigClosure for exit (2-of-2)
+	// and MultisigClosure for collab (3-of-3).
+	customVtxoScript := &closure.TapscriptsVtxoScript{
+		Closures: []closure.Closure{
+			// Exit: 2-of-2 multisig after CSV delay.
+			&closure.CSVMultisigClosure{
+				MultisigClosure: closure.MultisigClosure{
+					PubKeys: []*btcec.PublicKey{
+						client1Key, client2Key,
+					},
+					Type: closure.MultisigTypeChecksig,
+				},
+				Locktime: exitDelay,
+			},
+			// Collab: all three parties.
+			&closure.MultisigClosure{
+				PubKeys: []*btcec.PublicKey{
+					client1Key, client2Key, operatorKey,
+				},
+				Type: closure.MultisigTypeChecksig,
+			},
+		},
+	}
+
+	vtxoDesc, err := tree.NewVTXODescriptor(
+		vtxoAmount, customVtxoScript, client1Key,
+	)
+	require.NoError(t, err)
+
+	batchOutput, err := tree.BuildBatchOutput(
+		[]tree.VTXODescriptor{*vtxoDesc}, operatorKey, sweepKey,
+		exitDelay,
+	)
+	require.NoError(t, err)
+
+	batchOutpoint := wire.OutPoint{
+		Hash:  chainhash.HashH([]byte("custom-forfeit-commitment")),
+		Index: 0,
+	}
+
+	vtxoTree, err := tree.BuildVTXOTree(
+		batchOutpoint, batchOutput, []tree.VTXODescriptor{*vtxoDesc},
+		operatorKey, sweepKey, exitDelay, 2,
+	)
+	require.NoError(t, err)
+
+	leaf := vtxoTree.Root.GetLeafNodes()[0]
+	vtxoOutpoint, err := leaf.GetNonAnchorOutpoint()
+	require.NoError(t, err)
+
+	vtxoOutput := nonAnchorOutput(t, leaf)
+	require.NotNil(t, vtxoOutput)
+
+	// Get the VTXO script for spend context.
+	vtxoScript, err := vtxoDesc.VtxoScript()
+	require.NoError(t, err)
+
+	vtxoCtx := &tx.VTXOSpendContext{
+		Outpoint:   *vtxoOutpoint,
+		Output:     vtxoOutput,
+		VtxoScript: vtxoScript,
+	}
+
+	// Build connector tree (same as original test).
+	connectorTapKey := txscript.ComputeTaprootOutputKey(operatorKey, nil)
+	connectorScript, err := txscript.PayToTaprootScript(connectorTapKey)
+	require.NoError(t, err)
+
+	connectorDesc := tree.ConnectorDescriptor{
+		PkScript:  connectorScript,
+		NumLeaves: 8,
+		Amount:    btcutil.Amount(330),
+	}
+
+	connectorOutput, err := tree.BuildConnectorOutput(
+		connectorDesc.NumLeaves, connectorDesc.Amount,
+		mustTaprootAddr(connectorTapKey),
+	)
+	require.NoError(t, err)
+
+	connectorOutpoint := wire.OutPoint{
+		Hash:  chainhash.HashH([]byte("custom-connector-forfeit")),
+		Index: 0,
+	}
+
+	connectorTree, err := tree.BuildConnectorTree(
+		connectorOutpoint, connectorOutput, connectorDesc,
+		operatorKey, 2,
+	)
+	require.NoError(t, err)
+
+	connectorPath, err := connectorTree.ExtractPathForIndex(3)
+	require.NoError(t, err)
+	connectorLeaf := connectorPath.Root.GetLeafNodes()[0]
+
+	connectorLeafOutpoint, err := connectorLeaf.GetNonAnchorOutpoint()
+	require.NoError(t, err)
+
+	connectorLeafOutput := nonAnchorOutput(t, connectorLeaf)
+	require.NotNil(t, connectorLeafOutput)
+
+	serverForfeitKey := txscript.ComputeTaprootOutputKey(
+		operatorKey, nil,
+	)
+	serverForfeitScript, err := txscript.PayToTaprootScript(
+		serverForfeitKey,
+	)
+	require.NoError(t, err)
+
+	forfeitTx, err := tx.BuildForfeitTx(
+		vtxoOutpoint, vtxoAmount, connectorLeafOutpoint,
+		serverForfeitScript,
+	)
+	require.NoError(t, err)
+
+	prevFetcher, err := tx.NewForfeitPrevOutFetcher(
+		vtxoCtx, &tx.ConnectorSpendContext{
+			Outpoint: *connectorLeafOutpoint,
+			Output:   connectorLeafOutput,
+		},
+	)
+	require.NoError(t, err)
+
+	sigHashes := txscript.NewTxSigHashes(forfeitTx, prevFetcher)
+
+	// Get collab spend info for the custom VTXO.
+	collabSpendInfo, err := scripts.VtxoCollabSpendInfo(vtxoScript)
+	require.NoError(t, err)
+
+	// Sign with all three parties for the 3-of-3 collab path.
+	signVTXOInput := func(signer input.Signer,
+		keyDesc *keychain.KeyDescriptor) input.Signature {
+
+		signDesc := scripts.VTXOSignDesc(
+			*keyDesc, vtxoOutput, sigHashes, prevFetcher,
+			tx.ForfeitVTXOInputIndex, collabSpendInfo,
+		)
+
+		sig, err := signer.SignOutputRaw(forfeitTx, signDesc)
+		require.NoError(t, err)
+
+		return sig
+	}
+
+	client1Sig := signVTXOInput(client1Wallet, client1KeyDesc)
+	client2Sig := signVTXOInput(client2Wallet, client2KeyDesc)
+	operatorSig := signVTXOInput(operatorWallet, operatorKeyDesc)
+
+	// Build witness for 3-of-3 multisig: sig3, sig2, sig1, script, control.
+	witness := wire.TxWitness{
+		operatorSig.Serialize(),
+		client2Sig.Serialize(),
+		client1Sig.Serialize(),
+		collabSpendInfo.WitnessScript,
+		collabSpendInfo.ControlBlock,
+	}
+	forfeitTx.TxIn[tx.ForfeitVTXOInputIndex].Witness = witness
+
+	// Sign connector input with operator key spend.
+	connectorSignDesc := &input.SignDescriptor{
+		KeyDesc:           *operatorKeyDesc,
+		Output:            connectorLeafOutput,
+		HashType:          txscript.SigHashDefault,
+		InputIndex:        tx.ForfeitConnectorInputIndex,
+		SignMethod:        input.TaprootKeySpendBIP0086SignMethod,
+		SigHashes:         sigHashes,
+		PrevOutputFetcher: prevFetcher,
+		TapTweak:          []byte{},
+	}
+
+	connectorSig, err := operatorWallet.SignOutputRaw(
+		forfeitTx, connectorSignDesc,
+	)
+	require.NoError(t, err)
+	forfeitTx.TxIn[tx.ForfeitConnectorInputIndex].Witness = wire.TxWitness{
+		connectorSig.Serialize(),
+	}
+
+	// Validate the VTXO input.
+	engine, err := txscript.NewEngine(
+		vtxoOutput.PkScript, forfeitTx, tx.ForfeitVTXOInputIndex,
+		txscript.StandardVerifyFlags, nil, sigHashes,
+		vtxoOutput.Value, prevFetcher,
+	)
+	require.NoError(t, err)
+	require.NoError(t, engine.Execute())
+
+	// Validate the connector input.
+	engine, err = txscript.NewEngine(
+		connectorLeafOutput.PkScript, forfeitTx,
+		tx.ForfeitConnectorInputIndex,
+		txscript.StandardVerifyFlags, nil, sigHashes,
+		connectorLeafOutput.Value, prevFetcher,
+	)
+	require.NoError(t, err)
+	require.NoError(t, engine.Execute())
 }

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -490,7 +490,7 @@ func buildBoardingTapscript(clientKey, operatorKey *btcec.PublicKey,
 	// VTXOs use the same script structure. The client is the "owner" who
 	// can recover funds after the CSV delay, and the operator is the
 	// "cosigner" who collaborates with the client for immediate spends.
-	tapscript, err := scripts.VTXOTapScript(
+	tapscript, err := scripts.DefaultVTXOTapScript(
 		clientKey, operatorKey, exitDelay,
 	)
 	if err != nil {


### PR DESCRIPTION
##  Summary

  This PR introduces a flexible closure-based system for VTXO (Virtual Transaction Output) scripts, replacing the hardcoded script
  construction with a modular architecture that supports custom spend conditions.

  - Add closure package (lib/closure/) - Core closure types (CSVSigClosure, CSVMultisigClosure, MultisigClosure, CLTVMultisigClosure,
  ConditionMultisigClosure, ConditionCSVMultisigClosure) with Script/Decode/Witness methods
  - Replace existing vtxo scripts with closures - Migrate lib/scripts/, lib/tree/, and lib/tx/ to use the new closure system
  - Add DefaultVTXOTapScript for compatibility - Bridge function for code requiring waddrmgr.Tapscript type

 ## Motivation

  The previous VTXO implementation had hardcoded 2-of-2 multisig + CSV timeout structure. This PR enables:
  - Custom VTXO scripts with arbitrary closure combinations
  - Additional spend conditions (CLTV timelocks, conditional scripts)
  - Flexible validation rules that can be extended per-closure type

 ## Key Changes

  New lib/closure/ Package

  | File           | Purpose                                                            |
  |----------------|--------------------------------------------------------------------|
  | closure.go     | 6 closure types with Script/Decode/Witness methods                 |
  | vtxo_script.go | TapscriptsVtxoScript container with Validate/TapTree/Encode/Decode |
  | locktime.go    | BIP68 relative and absolute locktime encoding                      |
  | script.go      | Script evaluation helpers                                          |
  | *_test.go      | Comprehensive test coverage (~2100 lines)                          |

 ## Closure Types

  - CSVSigClosure - Single-sig exit with CSV timelock
  - CSVMultisigClosure - Multi-sig exit with CSV timelock
  - MultisigClosure - Collaborative path (CHECKSIG or CHECKSIGADD variants)
  - CLTVMultisigClosure - Collaborative with absolute timelock
  - ConditionMultisigClosure - Collaborative with custom condition script
  - ConditionCSVMultisigClosure - Exit with condition + CSV timelock

 ## Validation Rules

  - Server/signer key must be present in all forfeit (collaborative) closures
  - Exit closures must meet minimum locktime requirement
  - Block-type locktimes can be restricted via parameter
