### PR TITLE
chainsource: add IncludeBlock option for confirmation registration

### DIFF
--- a/chainbackends/lnd.go
+++ b/chainbackends/lnd.go
@@ -138,11 +138,18 @@ func (b *LNDBackend) BroadcastTx(ctx context.Context, tx *wire.MsgTx,
 // receiving confirmation events.
 func (b *LNDBackend) RegisterConf(ctx context.Context,
 	txid *chainhash.Hash, pkScript []byte, numConfs uint32,
-	heightHint uint32) (*chainsource.ConfRegistration, error) {
+	heightHint uint32,
+	includeBlock bool) (*chainsource.ConfRegistration, error) {
 
-	// Register with lnd's notifier.
+	// Build options for lnd's notifier. If includeBlock is true, we use
+	// WithIncludeBlock() to request the full block in the confirmation.
+	var opts []chainntnfs.NotifierOption
+	if includeBlock {
+		opts = append(opts, chainntnfs.WithIncludeBlock())
+	}
+
 	event, err := b.notifier.RegisterConfirmationsNtfn(
-		txid, pkScript, numConfs, heightHint,
+		txid, pkScript, numConfs, heightHint, opts...,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to register confirmation: %w",
@@ -152,7 +159,6 @@ func (b *LNDBackend) RegisterConf(ctx context.Context,
 	// Create a channel to convert lnd's TxConfirmation to our type.
 	confChan := make(chan *chainsource.TxConfirmation, 1)
 
-	// Start a goroutine to convert and forward the confirmation.
 	go func() {
 		defer close(confChan)
 		defer event.Cancel()
@@ -163,12 +169,12 @@ func (b *LNDBackend) RegisterConf(ctx context.Context,
 				return
 			}
 
-			// Convert to our type.
 			conf := &chainsource.TxConfirmation{
 				BlockHash:   lndConf.BlockHash,
 				BlockHeight: lndConf.BlockHeight,
 				TxIndex:     lndConf.TxIndex,
 				Tx:          lndConf.Tx,
+				Block:       lndConf.Block,
 			}
 
 			confChan <- conf
@@ -277,7 +283,6 @@ func (b *LNDBackend) RegisterBlocks(
 					timestamp = ts.Unix()
 				}
 
-				// Convert to our type.
 				epoch := &chainsource.BlockEpoch{
 					Hash:      *lndEpoch.Hash,
 					Height:    lndEpoch.Height,

--- a/chainsource/backend.go
+++ b/chainsource/backend.go
@@ -52,12 +52,14 @@ type ChainBackend interface {
 	//   - pkScript: The public key script to watch for
 	//   - numConfs: Target number of confirmations
 	//   - heightHint: Earliest block containing the tx (0 if unknown)
+	//   - includeBlock: If true, include the full block in the confirmation
+	//     event for merkle proof construction
 	//
 	// The returned ConfRegistration must have buffered channels and a
 	// Cancel function for cleanup.
 	RegisterConf(ctx context.Context, txid *chainhash.Hash,
 		pkScript []byte, numConfs uint32,
-		heightHint uint32) (*ConfRegistration, error)
+		heightHint uint32, includeBlock bool) (*ConfRegistration, error)
 
 	// RegisterSpend registers for spend notifications of a transaction
 	// output. The registration returns a SpendRegistration that provides
@@ -121,6 +123,11 @@ type TxConfirmation struct {
 
 	// Tx is the confirmed transaction itself.
 	Tx *wire.MsgTx
+
+	// Block is the full block containing the transaction. Only populated
+	// when the confirmation was registered with IncludeBlock=true. This
+	// matches lnd's chainntnfs behavior.
+	Block *wire.MsgBlock
 }
 
 // SpendRegistration encapsulates the channels and control functions for a

--- a/chainsource/chainsource_errors_test.go
+++ b/chainsource/chainsource_errors_test.go
@@ -128,7 +128,7 @@ func (b *errorBackend) BroadcastTx(ctx context.Context, tx *wire.MsgTx,
 
 func (b *errorBackend) RegisterConf(ctx context.Context,
 	txid *chainhash.Hash, pkScript []byte, numConfs uint32,
-	heightHint uint32) (*ConfRegistration, error) {
+	heightHint uint32, includeBlock bool) (*ConfRegistration, error) {
 
 	return nil, b.err
 }
@@ -179,9 +179,11 @@ func TestChainSourceActorBackendErrors(t *testing.T) {
 	)
 
 	tx := wire.NewMsgTx(2)
-	mempoolResult := ref.Ask(ctx, &TestMempoolAcceptRequest{
-		Tx: tx,
-	}).Await(ctx)
+	mempoolResult := ref.Ask(
+		ctx, &TestMempoolAcceptRequest{
+			Tx: tx,
+		},
+	).Await(ctx)
 
 	require.True(t, mempoolResult.IsErr())
 	require.Contains(
@@ -189,9 +191,11 @@ func TestChainSourceActorBackendErrors(t *testing.T) {
 		"failed to test mempool accept",
 	)
 
-	broadcastResult := ref.Ask(ctx, &BroadcastTxRequest{
-		Tx: tx,
-	}).Await(ctx)
+	broadcastResult := ref.Ask(
+		ctx, &BroadcastTxRequest{
+			Tx: tx,
+		},
+	).Await(ctx)
 	require.True(t, broadcastResult.IsErr())
 	require.Contains(
 		t, broadcastResult.Err().Error(),
@@ -277,7 +281,9 @@ func TestBlockEpochActorBackendError(t *testing.T) {
 }
 
 // TestConfActorDuplicateSubscription tests that ConfActor rejects duplicate
-// subscriptions on the same actor instance.
+// subscriptions on the same actor instance. Each actor is designed to handle
+// exactly one subscription for resource isolation and simpler lifecycle
+// management.
 func TestConfActorDuplicateSubscription(t *testing.T) {
 	t.Parallel()
 
@@ -286,7 +292,6 @@ func TestConfActorDuplicateSubscription(t *testing.T) {
 	confActor := NewConfActor(backend, ctx)
 	defer confActor.Stop()
 
-	// First subscription should succeed.
 	result1 := confActor.Receive(ctx, &RegisterConfRequest{
 		CallerID:    "test-duplicate-1",
 		Txid:        &chainhash.Hash{},
@@ -295,7 +300,7 @@ func TestConfActorDuplicateSubscription(t *testing.T) {
 	})
 	require.True(t, result1.IsOk(), "first subscription should succeed")
 
-	// Second subscription on same actor should fail.
+	// Attempting a second subscription must fail to enforce single-use.
 	result2 := confActor.Receive(ctx, &RegisterConfRequest{
 		CallerID:    "test-duplicate-2",
 		Txid:        &chainhash.Hash{},
@@ -308,7 +313,9 @@ func TestConfActorDuplicateSubscription(t *testing.T) {
 }
 
 // TestSpendActorDuplicateSubscription tests that SpendActor rejects duplicate
-// subscriptions on the same actor instance.
+// subscriptions on the same actor instance. Each actor is designed to handle
+// exactly one subscription for resource isolation and simpler lifecycle
+// management.
 func TestSpendActorDuplicateSubscription(t *testing.T) {
 	t.Parallel()
 
@@ -317,7 +324,6 @@ func TestSpendActorDuplicateSubscription(t *testing.T) {
 	spendActor := NewSpendActor(backend, ctx)
 	defer spendActor.Stop()
 
-	// First subscription should succeed.
 	result1 := spendActor.Receive(ctx, &RegisterSpendRequest{
 		CallerID: "test-spend-duplicate-1",
 		Outpoint: &wire.OutPoint{},
@@ -325,7 +331,7 @@ func TestSpendActorDuplicateSubscription(t *testing.T) {
 	})
 	require.True(t, result1.IsOk(), "first subscription should succeed")
 
-	// Second subscription on same actor should fail.
+	// Attempting a second subscription must fail to enforce single-use.
 	result2 := spendActor.Receive(ctx, &RegisterSpendRequest{
 		CallerID: "test-spend-duplicate-2",
 		Outpoint: &wire.OutPoint{},
@@ -337,7 +343,9 @@ func TestSpendActorDuplicateSubscription(t *testing.T) {
 }
 
 // TestBlockEpochActorDuplicateSubscription tests that BlockEpochActor rejects
-// duplicate subscriptions on the same actor instance.
+// duplicate subscriptions on the same actor instance. Each actor is designed to
+// handle exactly one subscription for resource isolation and simpler lifecycle
+// management.
 func TestBlockEpochActorDuplicateSubscription(t *testing.T) {
 	t.Parallel()
 
@@ -346,13 +354,12 @@ func TestBlockEpochActorDuplicateSubscription(t *testing.T) {
 	epochActor := NewBlockEpochActor(backend, ctx)
 	defer epochActor.Stop()
 
-	// First subscription should succeed.
 	result1 := epochActor.Receive(ctx, &SubscribeBlocksRequest{
 		CallerID: "test-epoch-duplicate-1",
 	})
 	require.True(t, result1.IsOk(), "first subscription should succeed")
 
-	// Second subscription on same actor should fail.
+	// Attempting a second subscription must fail to enforce single-use.
 	result2 := epochActor.Receive(ctx, &SubscribeBlocksRequest{
 		CallerID: "test-epoch-duplicate-2",
 	})

--- a/chainsource/chainsource_test.go
+++ b/chainsource/chainsource_test.go
@@ -15,14 +15,12 @@ import (
 
 // mockBackend implements ChainBackend for testing.
 type mockBackend struct {
-	// Channels for controlling mock behavior.
 	confChan  chan *TxConfirmation
 	spendChan chan *SpendDetail
 	epochChan chan *BlockEpoch
-	// epochCancel is notified whenever a block registration is cancelled.
+
 	epochCancel chan struct{}
 
-	// Stored values for direct queries.
 	feeRate    btcutil.Amount
 	bestHeight int32
 	bestHash   chainhash.Hash
@@ -40,38 +38,33 @@ func newMockBackend() *mockBackend {
 	}
 }
 
-// EstimateFee implements ChainBackend.
 func (m *mockBackend) EstimateFee(ctx context.Context,
 	targetConf uint32) (btcutil.Amount, error) {
 
 	return m.feeRate, nil
 }
 
-// BestBlock implements ChainBackend.
 func (m *mockBackend) BestBlock(ctx context.Context) (int32, chainhash.Hash,
 	error) {
 
 	return m.bestHeight, m.bestHash, nil
 }
 
-// TestMempoolAccept implements ChainBackend.
 func (m *mockBackend) TestMempoolAccept(ctx context.Context,
 	tx *wire.MsgTx) (bool, string, error) {
 
 	return true, "", nil
 }
 
-// BroadcastTx implements ChainBackend.
 func (m *mockBackend) BroadcastTx(ctx context.Context, tx *wire.MsgTx,
 	label string) error {
 
 	return nil
 }
 
-// RegisterConf implements ChainBackend.
 func (m *mockBackend) RegisterConf(ctx context.Context,
 	txid *chainhash.Hash, pkScript []byte, numConfs uint32,
-	heightHint uint32) (*ConfRegistration, error) {
+	heightHint uint32, includeBlock bool) (*ConfRegistration, error) {
 
 	return &ConfRegistration{
 		Confirmed: m.confChan,
@@ -79,7 +72,6 @@ func (m *mockBackend) RegisterConf(ctx context.Context,
 	}, nil
 }
 
-// RegisterSpend implements ChainBackend.
 func (m *mockBackend) RegisterSpend(ctx context.Context,
 	outpoint *wire.OutPoint, pkScript []byte,
 	heightHint uint32) (*SpendRegistration, error) {
@@ -90,7 +82,6 @@ func (m *mockBackend) RegisterSpend(ctx context.Context,
 	}, nil
 }
 
-// RegisterBlocks implements ChainBackend.
 func (m *mockBackend) RegisterBlocks(
 	ctx context.Context) (*BlockRegistration, error) {
 
@@ -105,12 +96,10 @@ func (m *mockBackend) RegisterBlocks(
 	}, nil
 }
 
-// Start implements ChainBackend.
 func (m *mockBackend) Start() error {
 	return nil
 }
 
-// Stop implements ChainBackend.
 func (m *mockBackend) Stop() error {
 	close(m.confChan)
 	close(m.spendChan)
@@ -247,12 +236,14 @@ func TestChainSourceActorRegisterConf(t *testing.T) {
 
 	ctx := t.Context()
 	txHash := chainhash.Hash{}
-	result := ref.Ask(ctx, &RegisterConfRequest{
-		CallerID:    "test-chainsource-conf",
-		Txid:        &txHash,
-		PkScript:    []byte{0x00, 0x14},
-		TargetConfs: 1,
-	}).Await(ctx)
+	result := ref.Ask(
+		ctx, &RegisterConfRequest{
+			CallerID:    "test-chainsource-conf",
+			Txid:        &txHash,
+			PkScript:    []byte{0x00, 0x14},
+			TargetConfs: 1,
+		},
+	).Await(ctx)
 	require.True(t, result.IsOk())
 
 	resp, err := result.Unpack()
@@ -296,11 +287,13 @@ func TestChainSourceActorRegisterSpend(t *testing.T) {
 	ref := ChainSourceKey.Spawn(system, "chainsource-spend", chainSource)
 
 	ctx := t.Context()
-	result := ref.Ask(ctx, &RegisterSpendRequest{
-		CallerID: "test-chainsource-spend",
-		Outpoint: &wire.OutPoint{},
-		PkScript: []byte{0x00, 0x14},
-	}).Await(ctx)
+	result := ref.Ask(
+		ctx, &RegisterSpendRequest{
+			CallerID: "test-chainsource-spend",
+			Outpoint: &wire.OutPoint{},
+			PkScript: []byte{0x00, 0x14},
+		},
+	).Await(ctx)
 	require.True(t, result.IsOk())
 
 	resp, err := result.Unpack()
@@ -348,22 +341,24 @@ func TestChainSourceActorUnregisterConf(t *testing.T) {
 	ctx := t.Context()
 	txHash := chainhash.Hash{}
 
-	// First, register a confirmation.
-	regResult := ref.Ask(ctx, &RegisterConfRequest{
-		CallerID:    "test-unreg-conf",
-		Txid:        &txHash,
-		PkScript:    []byte{0x00, 0x14},
-		TargetConfs: 1,
-	}).Await(ctx)
+	regResult := ref.Ask(
+		ctx, &RegisterConfRequest{
+			CallerID:    "test-unreg-conf",
+			Txid:        &txHash,
+			PkScript:    []byte{0x00, 0x14},
+			TargetConfs: 1,
+		},
+	).Await(ctx)
 	require.True(t, regResult.IsOk())
 
-	// Now unregister it.
-	unregResult := ref.Ask(ctx, &UnregisterConfRequest{
-		CallerID:    "test-unreg-conf",
-		Txid:        &txHash,
-		PkScript:    []byte{0x00, 0x14},
-		TargetConfs: 1,
-	}).Await(ctx)
+	unregResult := ref.Ask(
+		ctx, &UnregisterConfRequest{
+			CallerID:    "test-unreg-conf",
+			Txid:        &txHash,
+			PkScript:    []byte{0x00, 0x14},
+			TargetConfs: 1,
+		},
+	).Await(ctx)
 	require.True(t, unregResult.IsOk())
 
 	resp, err := unregResult.Unpack()
@@ -389,20 +384,22 @@ func TestChainSourceActorUnregisterSpend(t *testing.T) {
 	ctx := t.Context()
 	outpoint := &wire.OutPoint{Hash: chainhash.Hash{}, Index: 0}
 
-	// First, register a spend.
-	regResult := ref.Ask(ctx, &RegisterSpendRequest{
-		CallerID: "test-unreg-spend",
-		Outpoint: outpoint,
-		PkScript: []byte{0x00, 0x14},
-	}).Await(ctx)
+	regResult := ref.Ask(
+		ctx, &RegisterSpendRequest{
+			CallerID: "test-unreg-spend",
+			Outpoint: outpoint,
+			PkScript: []byte{0x00, 0x14},
+		},
+	).Await(ctx)
 	require.True(t, regResult.IsOk())
 
-	// Now unregister it.
-	unregResult := ref.Ask(ctx, &UnregisterSpendRequest{
-		CallerID: "test-unreg-spend",
-		Outpoint: outpoint,
-		PkScript: []byte{0x00, 0x14},
-	}).Await(ctx)
+	unregResult := ref.Ask(
+		ctx, &UnregisterSpendRequest{
+			CallerID: "test-unreg-spend",
+			Outpoint: outpoint,
+			PkScript: []byte{0x00, 0x14},
+		},
+	).Await(ctx)
 	require.True(t, unregResult.IsOk())
 
 	resp, err := unregResult.Unpack()
@@ -427,16 +424,18 @@ func TestChainSourceActorUnsubscribeBlocks(t *testing.T) {
 
 	ctx := t.Context()
 
-	// First, subscribe to blocks.
-	subResult := ref.Ask(ctx, &SubscribeBlocksRequest{
-		CallerID: "test-unsub-blocks",
-	}).Await(ctx)
+	subResult := ref.Ask(
+		ctx, &SubscribeBlocksRequest{
+			CallerID: "test-unsub-blocks",
+		},
+	).Await(ctx)
 	require.True(t, subResult.IsOk())
 
-	// Now unsubscribe.
-	unsubResult := ref.Ask(ctx, &UnsubscribeBlocksRequest{
-		CallerID: "test-unsub-blocks",
-	}).Await(ctx)
+	unsubResult := ref.Ask(
+		ctx, &UnsubscribeBlocksRequest{
+			CallerID: "test-unsub-blocks",
+		},
+	).Await(ctx)
 	require.True(t, unsubResult.IsOk())
 
 	resp, err := unsubResult.Unpack()
@@ -458,9 +457,11 @@ func TestChainSourceActorSubscribeBlocks(t *testing.T) {
 	ref := ChainSourceKey.Spawn(system, "chainsource-epoch", chainSource)
 
 	ctx := t.Context()
-	result := ref.Ask(ctx, &SubscribeBlocksRequest{
-		CallerID: "test-chainsource-epoch",
-	}).Await(ctx)
+	result := ref.Ask(
+		ctx, &SubscribeBlocksRequest{
+			CallerID: "test-chainsource-epoch",
+		},
+	).Await(ctx)
 	require.True(t, result.IsOk())
 
 	resp, err := result.Unpack()
@@ -528,7 +529,6 @@ func TestConfActorFutureMode(t *testing.T) {
 		Tx:          tx,
 	}
 
-	// Wait for confirmation event we just sent above.
 	eventCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
@@ -684,7 +684,6 @@ func TestSpendActorFutureMode(t *testing.T) {
 	txHash := chainhash.Hash{}
 	outpoint := wire.OutPoint{Hash: txHash, Index: 0}
 
-	// Register for spend in Future mode.
 	result := spendActor.Receive(ctx, &RegisterSpendRequest{
 		CallerID: "test-spend-future",
 		Outpoint: &outpoint,
@@ -698,7 +697,6 @@ func TestSpendActorFutureMode(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, spendResp.Future)
 
-	// Send spend from backend.
 	spendingTx := wire.NewMsgTx(2)
 	spendingHash := spendingTx.TxHash()
 	backend.spendChan <- &SpendDetail{
@@ -709,7 +707,6 @@ func TestSpendActorFutureMode(t *testing.T) {
 		SpendingHeight:    102,
 	}
 
-	// Wait for spend event.
 	eventCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
@@ -753,7 +750,6 @@ func TestSpendActorNotifyMode(t *testing.T) {
 	// In notify mode, Future should not be set (it's the zero value).
 	require.True(t, spendResp.Future == nil)
 
-	// Send spend from backend.
 	spendingTx := wire.NewMsgTx(2)
 	spendingHash := spendingTx.TxHash()
 	backend.spendChan <- &SpendDetail{
@@ -876,7 +872,6 @@ func TestBlockEpochActorNotifyMode(t *testing.T) {
 	require.Nil(t, epochResp.Iterator)
 	require.NotNil(t, epochResp.Cancel)
 
-	// Send a block from backend.
 	hash := chainhash.Hash{}
 	hash[0] = 0x01
 	backend.epochChan <- &BlockEpoch{
@@ -913,7 +908,6 @@ func TestBlockEpochActorIteratorMode(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, epochResp.Iterator)
 
-	// Send a few blocks from backend.
 	for i := int32(1); i <= 3; i++ {
 		hash := chainhash.Hash{}
 		hash[0] = byte(i)
@@ -925,7 +919,6 @@ func TestBlockEpochActorIteratorMode(t *testing.T) {
 		}
 	}
 
-	// Collect blocks from iterator.
 	var blocks []BlockEpoch
 	iterCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
@@ -1160,6 +1153,116 @@ func TestOutpointOrScriptKey(t *testing.T) {
 					require.Contains(t, key, substr)
 				}
 			}
+		})
+	}
+}
+
+// TestConfActorIncludeBlock verifies that the IncludeBlock option controls
+// whether the full block is returned in the confirmation event.
+func TestConfActorIncludeBlock(t *testing.T) {
+	t.Parallel()
+
+	// Use multiple transactions so we can verify TxIndex points to the
+	// correct one when the full block is returned.
+	testBlock := &wire.MsgBlock{
+		Header: wire.BlockHeader{
+			Version: 1,
+			Nonce:   12345,
+		},
+		Transactions: []*wire.MsgTx{
+			wire.NewMsgTx(2),
+			wire.NewMsgTx(2),
+		},
+	}
+
+	testCases := []struct {
+		name string
+
+		includeBlock bool
+		//
+		// backendBlock is what the backend returns; nil when
+		// IncludeBlock was not requested.
+		backendBlock *wire.MsgBlock
+
+		expectBlock bool
+	}{
+		{
+			name:         "include block",
+			includeBlock: true,
+			backendBlock: testBlock,
+			expectBlock:  true,
+		},
+		{
+			name:         "exclude block",
+			includeBlock: false,
+			backendBlock: nil,
+			expectBlock:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+			backend := newMockBackend()
+			confActor := NewConfActor(backend, ctx)
+
+			// Send a register conf request directly into the
+			// actor.
+			txHash := chainhash.Hash{0x01, 0x02}
+			result := confActor.Receive(ctx, &RegisterConfRequest{
+				CallerID:     "test-include-block",
+				Txid:         &txHash,
+				PkScript:     []byte{0x00, 0x14},
+				TargetConfs:  1,
+				IncludeBlock: tc.includeBlock,
+			})
+			require.True(t, result.IsOk())
+
+			resp, err := result.Unpack()
+			require.NoError(t, err)
+			confResp, ok := resp.(*RegisterConfResponse)
+			require.True(t, ok)
+			require.NotNil(t, confResp.Future)
+
+			// We'll now send in a confirmation from the backend,
+			// including the block based on our rquest.
+			blockHash := chainhash.Hash{0xaa, 0xbb}
+			backend.confChan <- &TxConfirmation{
+				BlockHash:   &blockHash,
+				BlockHeight: 200,
+				TxIndex:     1,
+				Tx:          testBlock.Transactions[1],
+				Block:       tc.backendBlock,
+			}
+
+			eventCtx, cancel := context.WithTimeout(
+				ctx, 5*time.Second,
+			)
+			defer cancel()
+			eventResult := confResp.Future.Await(eventCtx)
+			require.True(t, eventResult.IsOk())
+
+			event, err := eventResult.Unpack()
+			require.NoError(t, err)
+
+			// Assert that the block is, or isn't included as
+			// expected.
+			if tc.expectBlock {
+				require.NotNil(t, event.Block)
+				require.Equal(
+					t, testBlock.Header.Nonce,
+					event.Block.Header.Nonce,
+				)
+				require.Len(t, event.Block.Transactions, 2)
+			} else {
+				require.Nil(t, event.Block)
+			}
+
+			require.Equal(t, blockHash, event.BlockHash)
+			require.Equal(t, int32(200), event.BlockHeight)
+			require.NotNil(t, event.Tx)
 		})
 	}
 }

--- a/chainsource/conf_actor.go
+++ b/chainsource/conf_actor.go
@@ -33,6 +33,10 @@ type ConfActor struct {
 	// heightHint is the earliest block that could contain the transaction.
 	heightHint uint32
 
+	// includeBlock indicates whether to include the full block in the
+	// confirmation event. This is needed for constructing merkle proofs.
+	includeBlock bool
+
 	// promise is used in Future mode to complete the future when the
 	// confirmation is detected.
 	promise fn.Option[actor.Promise[ConfirmationEvent]]
@@ -108,6 +112,7 @@ func (a *ConfActor) handleRegisterConf(actorCtx context.Context,
 	a.pkScript = req.PkScript
 	a.targetConfs = req.TargetConfs
 	a.heightHint = req.HeightHint
+	a.includeBlock = req.IncludeBlock
 	a.notifyActor = req.NotifyActor
 
 	// We're either in future or iterator mode, set the promise
@@ -125,6 +130,7 @@ func (a *ConfActor) handleRegisterConf(actorCtx context.Context,
 	// the caller if registration fails.
 	registration, err := a.backend.RegisterConf(
 		a.ctx, a.txid, a.pkScript, a.targetConfs, a.heightHint,
+		a.includeBlock,
 	)
 	if err != nil {
 		return fn.Err[ConfResp](fmt.Errorf(
@@ -236,6 +242,8 @@ func buildConfirmationEvent(details *TxConfirmation,
 		BlockHeight: int32(details.BlockHeight),
 		BlockHash:   *details.BlockHash,
 		NumConfs:    watch.targetConfs,
+		Tx:          details.Tx,
+		Block:       details.Block,
 	}
 
 	return event, nil

--- a/chainsource/messages.go
+++ b/chainsource/messages.go
@@ -212,6 +212,12 @@ type RegisterConfRequest struct {
 	// light clients. Set to 0 if unknown.
 	HeightHint uint32
 
+	// IncludeBlock indicates whether the confirmation event should include
+	// the full block containing the transaction. This is needed for
+	// constructing merkle proofs. When true, the ConfirmationEvent.Block
+	// field will be populated.
+	IncludeBlock bool
+
 	// NotifyActor is an optional actor reference. If Some, confirmation
 	// events will be sent to this actor asynchronously. If None, a Future
 	// is returned in the response for blocking await.
@@ -271,6 +277,15 @@ type ConfirmationEvent struct {
 	// NumConfs is the actual number of confirmations at the time of this
 	// event.
 	NumConfs uint32
+
+	// Tx is the confirmed transaction. This allows consumers to inspect
+	// transaction outputs without making additional chain queries.
+	Tx *wire.MsgTx
+
+	// Block is the full block containing the confirmed transaction. This
+	// is only populated when the confirmation was registered with
+	// IncludeBlock=true. Used for constructing merkle proofs.
+	Block *wire.MsgBlock
 }
 
 // MessageType returns the message type identifier for logging and debugging.


### PR DESCRIPTION
This commit extends the confirmation registration API to optionally include the full block containing the confirmed transaction. This capability is needed for constructing merkle proofs, which require access to all transactions in the block to compute the merkle root and proof path.

This commit also fixes ast-grep style violations in test files.