### PR TITLE
chainsource: add Tx field to ConfirmationEvent

### DIFF
--- a/chainsource/messages.go
+++ b/chainsource/messages.go
@@ -271,6 +271,10 @@ type ConfirmationEvent struct {
 	// NumConfs is the actual number of confirmations at the time of this
 	// event.
 	NumConfs uint32
+
+	// Tx is the confirmed transaction. This allows consumers to inspect
+	// transaction outputs without making additional chain queries.
+	Tx *wire.MsgTx
 }
 
 // MessageType returns the message type identifier for logging and debugging.


### PR DESCRIPTION
Enhances the `ConfirmationEvent` structure by adding a `Tx` field that contains the complete confirmed transaction. This allows consumers of confirmation events to inspect transaction outputs directly without making additional chain queries.

This optimization is particularly useful for the boarding flow where the client needs to validate that the confirmed transaction matches expected outputs and amounts. By including the full transaction in the confirmation event, we eliminate an extra round trip to the chain backend.