### PR TITLE
round: implement boarding FSM state machine

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/btcsuite/btcd v0.25.0
 	github.com/btcsuite/btcd/btcec/v2 v2.3.6
 	github.com/btcsuite/btcd/btcutil v1.1.5
+	github.com/btcsuite/btcd/btcutil/psbt v1.1.10
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0
 	github.com/btcsuite/btclog/v2 v2.0.1-0.20250728225537-6090e87c6c5b
 	github.com/btcsuite/btcwallet v0.16.17
@@ -44,7 +45,6 @@ require (
 	github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da // indirect
 	github.com/aead/siphash v1.0.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/btcsuite/btcd/btcutil/psbt v1.1.10 // indirect
 	github.com/btcsuite/btcd/v2transport v1.0.1 // indirect
 	github.com/btcsuite/btclog v0.0.0-20241003133417-09c4e92e319c // indirect
 	github.com/btcsuite/btcwallet/wallet/txauthor v1.3.5 // indirect

--- a/lib/tree/tree.go
+++ b/lib/tree/tree.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/scripts"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
 )
@@ -313,4 +315,163 @@ func (t *Tree) NewTreeSignerSession(wallet input.MuSig2Signer,
 		wallet, signerKey, t.SweepTapscriptRoot, prevOutFetcher,
 		t.Root,
 	)
+}
+
+// ValidatePath validates the tree path from the batch output to the client's
+// VTXO for a given signing key. Each signing key maps to exactly one VTXO,
+// providing a unique identifier for the VTXO and keeping MuSig2 signing simple.
+//
+// The client MUST validate the complete path before signing the boarding UTXO.
+// This ensures they can recover their funds even if the operator disappears.
+//
+// Returns the extracted client sub-tree on success.
+func (t *Tree) ValidatePath(signingKey *btcec.PublicKey,
+	expectedLeaf LeafDescriptor,
+	operatorKey *btcec.PublicKey) (*Tree, error) {
+
+	if t == nil {
+		return nil, fmt.Errorf("tree is nil")
+	}
+
+	// Use VerifyVTXOPath for core validation: script match, exactly 1 leaf
+	// per signing key, anchor output, and cosigner presence in all nodes.
+	if err := t.VerifyVTXOPath(
+		signingKey, expectedLeaf.PkScript,
+	); err != nil {
+		return nil, fmt.Errorf("VTXO path verification failed: %w", err)
+	}
+
+	// Extract the client's sub-tree for additional validation and to
+	// return to caller.
+	clientTree, err := t.ExtractPathForCoSigners(signingKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract client path: %w", err)
+	}
+
+	// Get the single leaf node (VerifyVTXOPath already enforced exactly 1).
+	leaves := clientTree.Root.GetLeafNodes()
+	leaf := leaves[0]
+	vtxoOutput := leaf.Outputs[0]
+
+	// Ensure the VTXO amount matches the request to prevent value
+	// extraction by the operator.
+	if vtxoOutput.Value != int64(expectedLeaf.Amount) {
+		return nil, fmt.Errorf("VTXO output value %d != expected %d",
+			vtxoOutput.Value, expectedLeaf.Amount)
+	}
+
+	// Confirm operator key is present as co-signer to enable collaborative
+	// spending path.
+	if !ContainsCosigner(leaf.CoSigners, operatorKey) {
+		return nil, fmt.Errorf("leaf does not include operator key " +
+			"in co-signers")
+	}
+
+	return clientTree, nil
+}
+
+// ValidateAndSubmitSignatures validates and submits the complete VTXT
+// signatures to the tree. This must be called BEFORE the client signs the
+// boarding UTXO input.
+//
+// The signatures are provided as a map from transaction ID to raw signature
+// bytes. Each entry corresponds to a transaction in the VTXT.
+//
+// The client MUST NOT sign the boarding UTXO until the VTXT is fully signed
+// and validated. Otherwise, the operator could include the boarding UTXO in a
+// commitment tx without providing valid VTXOs.
+func (t *Tree) ValidateAndSubmitSignatures(
+	signatures map[chainhash.Hash][]byte) error {
+
+	if t == nil {
+		return fmt.Errorf("tree is nil")
+	}
+	if len(signatures) == 0 {
+		return fmt.Errorf("no signatures provided")
+	}
+
+	// Parse each raw signature into a Schnorr signature structure.
+	sigMap := make(map[TxID]*schnorr.Signature, len(signatures))
+	for txid, sigBytes := range signatures {
+		sig, err := schnorr.ParseSignature(sigBytes)
+		if err != nil {
+			return fmt.Errorf("failed to parse signature for "+
+				"tx %s: %w", txid, err)
+		}
+		sigMap[txid] = sig
+	}
+
+	// Submit and validate all signatures atomically to ensure the entire
+	// tree is properly signed.
+	if err := t.SubmitTreeSigs(sigMap); err != nil {
+		return fmt.Errorf("failed to submit tree signatures: %w", err)
+	}
+
+	// Perform cryptographic verification of all signatures to guarantee
+	// the operator has properly co-signed the VTXT.
+	if err := t.VerifySigned(); err != nil {
+		return fmt.Errorf("tree signature verification failed: %w",
+			err)
+	}
+
+	return nil
+}
+
+// ValidateAnchors validates that all transactions in the tree have valid
+// ephemeral anchor outputs for CPFP fee bumping (BIP 431).
+//
+// Without valid anchors, the client cannot broadcast the VTXT chain for
+// unilateral exit, resulting in fund loss.
+func (t *Tree) ValidateAnchors() error {
+	if t == nil {
+		return fmt.Errorf("tree is nil")
+	}
+
+	// Validate anchors in all tree nodes recursively.
+	return t.Root.ForEach(func(node *Node) error {
+		if node == nil {
+			return fmt.Errorf("tree node is nil")
+		}
+
+		// Convert node to transaction to check version and outputs.
+		tx, err := node.ToTx()
+		if err != nil {
+			return fmt.Errorf("failed to convert node "+
+				"to tx: %w", err)
+		}
+
+		// Verify transaction version is 3 for BIP 431 ephemeral
+		// anchors.
+		if tx.Version != 3 {
+			return fmt.Errorf("transaction version is "+
+				"%d, expected 3 for BIP 431 ephemeral anchors",
+				tx.Version)
+		}
+
+		// All virtual transactions must have at least one output
+		// (anchor).
+		if len(node.Outputs) == 0 {
+			return fmt.Errorf("transaction has no outputs")
+		}
+
+		// The last output must be the ephemeral anchor.
+		anchorIdx := len(node.Outputs) - 1
+		anchorOutput := node.Outputs[anchorIdx]
+
+		// Anchor must have zero value.
+		if anchorOutput.Value != 0 {
+			return fmt.Errorf("anchor output at index %d "+
+				"has value %d, expected 0", anchorIdx,
+				anchorOutput.Value)
+		}
+
+		// Anchor script must match the standard ephemeral anchor
+		// script.
+		if !bytes.Equal(anchorOutput.PkScript, scripts.AnchorPkScript) {
+			return fmt.Errorf("anchor output at index %d has "+
+				"invalid script", anchorIdx)
+		}
+
+		return nil
+	})
 }

--- a/lib/tree/tree_test.go
+++ b/lib/tree/tree_test.go
@@ -978,3 +978,237 @@ func TestTreePrettyPrint(t *testing.T) {
 		require.Contains(t, output, "Transaction Tree")
 	})
 }
+
+// TestValidatePath tests the ValidatePath method.
+func TestValidatePath(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil tree returns error", func(t *testing.T) {
+		t.Parallel()
+
+		var tree *Tree
+		_, err := tree.ValidatePath(nil, LeafDescriptor{}, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "tree is nil")
+	})
+
+	t.Run("nil signing key returns error", func(t *testing.T) {
+		t.Parallel()
+
+		_, operatorKey := createTestKey(t)
+		_, ownerKey := createTestKey(t)
+
+		leaves := []LeafDescriptor{
+			{
+				PkScript:    []byte("script"),
+				Amount:      1000,
+				CoSignerKey: ownerKey,
+			},
+		}
+
+		tree, err := NewTree(
+			wire.OutPoint{}, &wire.TxOut{Value: 1000}, leaves,
+			operatorKey, make([]byte, 32), 2,
+		)
+		require.NoError(t, err)
+
+		expectedLeaf := LeafDescriptor{
+			PkScript:    []byte("script"),
+			Amount:      1000,
+			CoSignerKey: ownerKey,
+		}
+		_, err = tree.ValidatePath(nil, expectedLeaf, operatorKey)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "cosigner key cannot be nil")
+	})
+
+	t.Run("valid path returns client tree", func(t *testing.T) {
+		t.Parallel()
+
+		_, operatorKey := createTestKey(t)
+		_, ownerKey := createTestKey(t)
+		vtxoScript := []byte("vtxo_script")
+
+		leaves := []LeafDescriptor{
+			{
+				PkScript:    vtxoScript,
+				Amount:      1000,
+				CoSignerKey: ownerKey,
+			},
+		}
+
+		tree, err := NewTree(
+			wire.OutPoint{Hash: chainhash.HashH([]byte("batch"))},
+			&wire.TxOut{Value: sumLeafAmounts(leaves)}, leaves,
+			operatorKey, make([]byte, 32), 2,
+		)
+		require.NoError(t, err)
+
+		expectedLeaf := LeafDescriptor{
+			PkScript:    vtxoScript,
+			Amount:      1000,
+			CoSignerKey: ownerKey,
+		}
+		clientTree, err := tree.ValidatePath(
+			ownerKey, expectedLeaf, operatorKey,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, clientTree)
+
+		// Verify client tree has exactly one leaf.
+		leafNodes := clientTree.Root.GetLeafNodes()
+		require.Len(t, leafNodes, 1)
+	})
+
+	t.Run("amount mismatch returns error", func(t *testing.T) {
+		t.Parallel()
+
+		_, operatorKey := createTestKey(t)
+		_, ownerKey := createTestKey(t)
+		vtxoScript := []byte("vtxo_script")
+
+		leaves := []LeafDescriptor{
+			{
+				PkScript:    vtxoScript,
+				Amount:      1000,
+				CoSignerKey: ownerKey,
+			},
+		}
+
+		tree, err := NewTree(
+			wire.OutPoint{Hash: chainhash.HashH([]byte("batch"))},
+			&wire.TxOut{Value: sumLeafAmounts(leaves)}, leaves,
+			operatorKey, make([]byte, 32), 2,
+		)
+		require.NoError(t, err)
+
+		// Use wrong amount to trigger validation error.
+		expectedLeaf := LeafDescriptor{
+			PkScript:    vtxoScript,
+			Amount:      2000,
+			CoSignerKey: ownerKey,
+		}
+		_, err = tree.ValidatePath(ownerKey, expectedLeaf, operatorKey)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "VTXO output value")
+	})
+
+	t.Run("missing operator key returns error", func(t *testing.T) {
+		t.Parallel()
+
+		_, operatorKey := createTestKey(t)
+		_, ownerKey := createTestKey(t)
+		_, wrongOperatorKey := createTestKey(t)
+		vtxoScript := []byte("vtxo_script")
+
+		leaves := []LeafDescriptor{
+			{
+				PkScript:    vtxoScript,
+				Amount:      1000,
+				CoSignerKey: ownerKey,
+			},
+		}
+
+		tree, err := NewTree(
+			wire.OutPoint{Hash: chainhash.HashH([]byte("batch"))},
+			&wire.TxOut{Value: sumLeafAmounts(leaves)}, leaves,
+			operatorKey, make([]byte, 32), 2,
+		)
+		require.NoError(t, err)
+
+		expectedLeaf := LeafDescriptor{
+			PkScript:    vtxoScript,
+			Amount:      1000,
+			CoSignerKey: ownerKey,
+		}
+
+		// Use wrong operator key to trigger validation error.
+		_, err = tree.ValidatePath(
+			ownerKey, expectedLeaf, wrongOperatorKey,
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "operator key")
+	})
+}
+
+// TestValidateAndSubmitSignatures tests the ValidateAndSubmitSignatures method.
+func TestValidateAndSubmitSignatures(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil tree returns error", func(t *testing.T) {
+		t.Parallel()
+
+		fakeTxid := chainhash.HashH([]byte("fake-tx"))
+		var tree *Tree
+		err := tree.ValidateAndSubmitSignatures(
+			map[chainhash.Hash][]byte{fakeTxid: {0x01}},
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "tree is nil")
+	})
+
+	t.Run("empty signatures returns error", func(t *testing.T) {
+		t.Parallel()
+
+		_, operatorKey := createTestKey(t)
+		_, ownerKey := createTestKey(t)
+
+		leaves := []LeafDescriptor{
+			{
+				PkScript:    []byte("script"),
+				Amount:      1000,
+				CoSignerKey: ownerKey,
+			},
+		}
+
+		tree, err := NewTree(
+			wire.OutPoint{}, &wire.TxOut{Value: 1000}, leaves,
+			operatorKey, make([]byte, 32), 2,
+		)
+		require.NoError(t, err)
+
+		emptySigs := map[chainhash.Hash][]byte{}
+		err = tree.ValidateAndSubmitSignatures(emptySigs)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no signatures provided")
+	})
+
+	t.Run("nil signatures returns error", func(t *testing.T) {
+		t.Parallel()
+
+		_, operatorKey := createTestKey(t)
+		_, ownerKey := createTestKey(t)
+
+		leaves := []LeafDescriptor{
+			{
+				PkScript:    []byte("script"),
+				Amount:      1000,
+				CoSignerKey: ownerKey,
+			},
+		}
+
+		tree, err := NewTree(
+			wire.OutPoint{}, &wire.TxOut{Value: 1000}, leaves,
+			operatorKey, make([]byte, 32), 2,
+		)
+		require.NoError(t, err)
+
+		err = tree.ValidateAndSubmitSignatures(nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no signatures provided")
+	})
+}
+
+// TestValidateAnchors tests the ValidateAnchors method.
+func TestValidateAnchors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil tree returns error", func(t *testing.T) {
+		t.Parallel()
+
+		var tree *Tree
+		err := tree.ValidateAnchors()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "tree is nil")
+	})
+}

--- a/lib/types/boarding.go
+++ b/lib/types/boarding.go
@@ -31,6 +31,27 @@ type OperatorTerms struct {
 	// penalty output in forfeit transactions. This allows the server to
 	// claim forfeited funds.
 	ForfeitScript []byte
+
+	// SweepKey is the operator key used in VTXT sweep paths.
+	SweepKey *btcec.PublicKey
+
+	// SweepDelay is the batch-wide absolute timelock (blocks).
+	SweepDelay uint32
+
+	// DustLimit enforces minimum output value for boarding/funding flows.
+	DustLimit btcutil.Amount
+
+	// MinBoardingAmount is the minimum amount clients must contribute.
+	MinBoardingAmount btcutil.Amount
+
+	// MaxBoardingAmount caps the amount accepted per request (optional).
+	MaxBoardingAmount btcutil.Amount
+
+	// FeeRate reflects the operator's target package feerate (sat/vByte).
+	FeeRate btcutil.Amount
+
+	// MinConfirmations is the minimum confs required on boarding inputs.
+	MinConfirmations uint32
 }
 
 // JoinRoundRequest represents a participant's request to join a round.

--- a/round/README.md
+++ b/round/README.md
@@ -1,0 +1,362 @@
+# Ark Boarding State Machine
+
+The round package implements the client-side protocol for boarding Bitcoin
+outputs into an Ark virtual UTXO tree through coordinated multi-party rounds.
+Boarding converts on-chain Bitcoin into off-chain VTXOs that enable instant,
+private transfers within the Ark system.
+
+The architecture strictly separates business logic from side effects. The finite
+state machine (FSM) owns all protocol logic, validation, and state transitions.
+A thin actor layer translates between the FSM's event model and external
+systems (operator server, blockchain, wallet). This separation ensures the
+protocol remains testable and deterministic regardless of IO timing.
+
+## Protocol Overview
+
+Boarding begins when a user requests a boarding address, a time-locked 2-of-2
+multisig between client and operator. The user deposits Bitcoin to this address,
+creating a boarding UTXO. Once confirmed, the client registers this intent with
+the operator's coordination server, which batches multiple clients' boarding
+UTXOs into a single round.
+
+The operator constructs a commitment transaction spending all boarding inputs
+and creating a single taproot output containing the complete VTXO tree. Each
+tree leaf represents a VTXO owned by a participant, with tapscript branches
+enabling either cooperative spending (client + operator) or unilateral exit
+after timeout.
+
+Creating this transaction requires a MuSig2 signing ceremony. Participants
+generate nonces, exchange them, produce partial signatures over their tree
+portions, and validate the operator's completion. Only after the entire tree is
+provably signed do clients release signatures for their boarding inputs.
+
+This ordering (tree signatures before boarding input signatures) is critical for
+security. If clients signed boarding inputs first, a malicious operator could
+broadcast the commitment transaction with an invalid tree, locking funds without
+providing expected VTXOs. Validating complete tree signatures first ensures
+funds will be accessible before relinquishing control of boarding inputs.
+
+## State Machine Architecture
+
+The FSM progresses through states representing protocol phases. Each state
+processes events, performs validation or cryptographic operations, then
+transitions to the next state and emits outbound messages. States are immutable;
+transitions create new instances rather than mutating.
+
+### Idle State
+
+The FSM begins in Idle, representing readiness for new boarding requests. When
+the user requests a boarding address, the FSM derives a key pair, constructs a
+2-of-2 boarding script with the operator's key and CSV timelock, and emits an
+`AddressReceived` notification.
+
+The FSM returns to Idle after completing a boarding round, allowing the same
+instance to process additional addresses across different rounds.
+
+### PendingRoundAssembly State
+
+After receiving an address, the user funds it by broadcasting a Bitcoin
+transaction. Once confirmed via `BoardingUTXOConfirmed`, the FSM transitions
+from Idle to PendingRoundAssembly, registering a boarding intent containing
+the address, on-chain UTXO, and VTXO template (amount, expiry, keys).
+
+The FSM accumulates multiple intents, handling additional `BoardingUTXOConfirmed`
+events as a self-loop. When `RegistrationRequested` is received, it transitions
+to RegistrationSentState, emitting a `JoinRoundRequest` that aggregates all
+intents into a single server request. The FSM can also resume existing intents
+on restart via `ResumeBoardingIntents`.
+
+### RegistrationSent and RoundJoined States
+
+The `JoinRoundRequest` carries serialized boarding requests and VTXO templates
+to the operator. The server aggregates requests from multiple clients and, once
+sufficient participation is reached, initiates a round by assigning a round ID.
+
+The FSM transitions to RoundJoined upon receiving the `RoundJoined` response,
+which includes the round ID used to track this batch through completion.
+
+### CommitmentTxReceived and CommitmentTxValidated States
+
+The operator constructs a commitment transaction and sends it via
+`CommitmentTxBuilt`. The FSM performs extensive validation, verifying every
+boarding UTXO appears as input, the taproot output commits to a Merkle tree with
+all expected VTXOs, and extracts client-specific sub-trees indexed by signing
+key.
+
+Client trees are essential for constructing MuSig2 sessions and must be
+persisted alongside final VTXOs, as spending a VTXO off-chain requires proving
+its position via complete Merkle path to root.
+
+The FSM also maps each boarding input to its position in the commitment
+transaction's input array, required later for signing (Bitcoin signatures commit
+to input indices via SIGHASH).
+
+### Nonce Exchange: NoncesSent and NoncesAggregated States
+
+MuSig2 signing begins with nonce exchange. Each participant generates nonce
+pairs for each signing session (one per client tree). The FSM generates these
+cryptographically, ensuring no reuse across sessions (nonce reuse leaks private
+keys).
+
+The NoncesSent state emits `SubmitNoncesRequest` messages. The operator collects
+and aggregates all nonces, returning them in `NoncesAggregated`. The FSM stores
+aggregated nonces with MuSig2 sessions for producing partial signatures.
+
+### Partial Signature Exchange: PartialSigsSent State
+
+With nonces exchanged, participants create partial signatures over their tree
+portions. The FSM iterates each client tree and associated session, producing
+partial signatures via `SubmitPartialSigRequest`.
+
+The operator aggregates all partial signatures to produce complete Schnorr
+signatures over every tree branch, making each VTXO spendable through the
+cooperative path.
+
+### InputSigSent State: The Point of No Return
+
+When the operator completes aggregation, it returns `OperatorSigned` containing
+final signatures for all tree branches. The FSM verifies every signature,
+reconstructing expected signing messages, validating each against the correct
+aggregated public key, and confirming signatures enable cooperative tapscript
+spending.
+
+This validation is the security checkpoint: valid signatures mean funds will be
+accessible as VTXOs after commitment transaction confirms. Invalid or missing
+signatures trigger failure state transition without releasing boarding input
+signatures.
+
+Upon successful validation, the FSM signs each boarding input using Taproot key
+path spending. Combined with operator signatures, these complete the commitment
+transaction. The FSM immediately checkpoints the entire round state (commitment
+transaction, VTXO tree, boarding intents, client trees) to persistent storage.
+
+This checkpoint is the "point of no return." After sending boarding input
+signatures, the operator may broadcast at any time. If the client crashes before
+checkpoint completes, the operator might broadcast while the client has no
+record, potentially causing fund loss. The checkpoint ensures recovery even if
+the client crashes immediately after sending signatures.
+
+The FSM emits `SubmitForfeitSigRequest` messages containing boarding input
+signatures, registers a confirmation watch for the commitment TXID, and emits
+`RoundCheckpointedNotification` triggering actor-level FSM migration to a
+dedicated round-specific FSM for confirmation monitoring.
+
+### Confirmed State and VTXO Creation
+
+When the commitment transaction confirms with sufficient depth, the chain
+monitoring subsystem delivers `BoardingConfirmed`. The FSM constructs
+`ClientVTXO` descriptors from intents and client trees, including the VTXO's
+outpoint, amount, taproot script, key descriptors, CSV expiry, and complete tree
+path proving inclusion in the commitment transaction output.
+
+Descriptors are persisted to the VTXO store and emitted via
+`VTXOCreatedNotification`, making them available to the wallet for spending.
+
+### Failure Handling
+
+At any point, the FSM may receive `BoardingFailed` indicating round abort or
+unrecoverable error. The FSM transitions to `ClientFailedState`, capturing
+failure reason and recoverability.
+
+Recoverable failures (operator canceling due to insufficient participation)
+leave boarding UTXOs unspent on-chain, allowing retry. Unrecoverable failures
+indicate protocol violations requiring user intervention.
+
+## Actor Architecture: Primary and Dedicated FSMs
+
+The actor manages FSM lifecycles and message routing. Rather than creating a new
+FSM per boarding address, the system maintains a single primary FSM handling
+initial protocol phases (address generation, intent registration, round joining,
+signature exchange) through InputSigSent.
+
+When a round reaches InputSigSent, the primary FSM emits
+`RoundCheckpointedNotification`. The actor spawns a dedicated FSM instance for
+that round, initialized from checkpointed state. This dedicated FSM monitors for
+commitment transaction confirmation, a potentially long operation that shouldn't
+block the primary FSM from processing new addresses.
+
+Migration occurs precisely where the protocol shifts from interactive (requires
+operator responses) to passive (waiting for blockchain events). Before
+InputSigSent, the FSM actively exchanges messages with the operator. After, it
+only waits for confirmation.
+
+If the client crashes, the actor recreates dedicated FSMs for all checkpointed
+rounds by scanning persistent storage on startup.
+
+## Event and Message Flow
+
+The FSM communicates exclusively through events, structured messages
+representing external occurrences (operator responses, blockchain confirmations)
+or internal triggers (validation complete, signatures generated). The actor
+translates between external message formats and the FSM's uniform event model.
+
+### Outbox Pattern
+
+State transitions produce outbound events via the outbox, preventing the FSM
+from depending on external interfaces. The FSM emits side effects as data
+(outbound events) rather than invoking methods directly. The actor examines
+outbox contents and dispatches to appropriate subsystems:
+
+- **Server messages**: `JoinRoundRequest`, `SubmitNoncesRequest`,
+  `SubmitPartialSigRequest`, `SubmitForfeitSigRequest`
+- **Chain monitoring**: `RegisterConfirmationRequest`
+- **Wallet notifications**: `VTXOCreatedNotification`, `AddressReceived`
+
+This design enables trivial testing (FSM runs in-memory with mock stores) and
+ensures all side effects are visible and serializable.
+
+Internal events support multi-step transitions within a single external event
+delivery. The CommitmentTxReceived state performs initial parsing, then emits an
+internal event triggering CommitmentTxValidated's detailed validation. This
+keeps states focused and testable while maintaining atomicity from the actor's
+perspective.
+
+## Client-Server Message Sequence
+
+The following sequence shows the complete protocol message flow between client
+and server during a successful boarding round:
+
+```mermaid
+sequenceDiagram
+    participant C as Client FSM
+    participant A as Actor
+    participant S as Server
+    participant B as Blockchain
+
+    Note over C,B: Address Generation Phase
+    C->>A: AddressReceived (outbox)
+    A->>C: User: Wallet deposits to address
+
+    Note over C,B: Intent Registration Phase
+    B->>A: UTXO confirmed
+    A->>C: BoardingUTXOConfirmed
+    C->>A: JoinRoundRequest (outbox)
+    A->>S: JoinRound
+    S->>A: RoundJoined(roundID)
+    A->>C: RoundJoined
+
+    Note over C,B: Commitment Transaction Phase
+    S->>A: CommitmentTxBuilt(tx, trees)
+    A->>C: CommitmentTxBuilt
+    Note over C: Validate tx & extract client trees
+
+    Note over C,B: MuSig2 Nonce Exchange
+    C->>A: SubmitNoncesRequest (outbox)
+    A->>S: SubmitNonces
+    S->>A: NoncesAggregated(aggNonces)
+    A->>C: NoncesAggregated
+
+    Note over C,B: MuSig2 Partial Signature Exchange
+    C->>A: SubmitPartialSigRequest (outbox)
+    A->>S: SubmitPartialSig
+    S->>A: OperatorSigned(signatures)
+    A->>C: OperatorSigned
+
+    Note over C,B: Boarding Input Signing (Point of No Return)
+    Note over C: Validate all tree signatures
+    Note over C: Sign boarding inputs
+    Note over C: Checkpoint round to storage
+    C->>A: SubmitForfeitSigRequest (outbox)
+    C->>A: RoundCheckpointedNotification (outbox)
+    A->>S: SubmitForfeitSig
+    A->>A: Spawn dedicated FSM for confirmation
+
+    Note over C,B: Confirmation Monitoring
+    C->>A: RegisterConfirmationRequest (outbox)
+    A->>B: Watch commitment TXID
+    S->>B: Broadcast commitment tx
+    B->>A: Confirmed(txid, height)
+    A->>C: BoardingConfirmed
+
+    Note over C,B: VTXO Creation
+    Note over C: Build ClientVTXO descriptors
+    C->>A: VTXOCreatedNotification (outbox)
+    Note over C: Transition to Idle
+```
+
+Key observations:
+
+- All server-bound messages flow through the outbox, never directly from FSM
+- The actor routes outbox messages to appropriate destinations based on type
+- Internal validation (tree extraction, signature verification, descriptor
+  building) happens within state transitions, invisible to external systems
+- The checkpoint before sending boarding input signatures is critical for
+  recovery
+- FSM migration occurs after `RoundCheckpointedNotification`, separating
+  interactive and monitoring phases
+
+## Persistence and Recovery
+
+The FSM interacts with storage through `ClientEnvironment`, providing interfaces
+for boarding intent storage, round checkpointing, VTXO storage, and wallet
+operations. This indirection enables testing with in-memory stores while
+production uses SQLite.
+
+Boarding intents persist from registration until round completion or failure.
+Round checkpointing occurs at the InputSigSent transition, including complete
+commitment transaction, full VTXO tree, client sub-trees, boarding input
+signatures, and every intent with updated status.
+
+FSM state checkpointing complements round checkpointing by persisting the FSM's
+current state structure. The actor inspects checkpoints on startup to spawn
+dedicated FSMs for all checkpointed rounds, ensuring no confirmation monitoring
+is lost across restarts.
+
+The storage layer implements checkpoints atomically where possible, preventing
+partial writes. Transaction semantics ensure either the entire checkpoint
+succeeds or none of it does, maintaining consistency even if the process crashes
+during checkpoint.
+
+## State Machine Diagram
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle
+    Idle --> PendingRoundAssembly: BoardingUTXOConfirmed
+    Idle --> PendingRoundAssembly: ResumeBoardingIntents
+    PendingRoundAssembly --> PendingRoundAssembly: BoardingUTXOConfirmed
+    PendingRoundAssembly --> RegistrationSent: RegistrationRequested
+    RegistrationSent --> RoundJoined: RoundJoined
+    RoundJoined --> CommitmentTxReceived: CommitmentTxBuilt
+    CommitmentTxReceived --> CommitmentTxValidated: CommitmentTxValidated
+    CommitmentTxValidated --> NoncesSent: GenerateNonces
+    NoncesSent --> NoncesAggregated: NoncesAggregated
+    NoncesAggregated --> PartialSigsSent: GeneratePartialSigs
+    PartialSigsSent --> InputSigSent: OperatorSigned
+    InputSigSent --> Confirmed: BoardingConfirmed
+    Confirmed --> Idle: RoundComplete
+
+    PendingRoundAssembly --> ClientFailed: BoardingFailed
+    RegistrationSent --> ClientFailed: BoardingFailed
+    RoundJoined --> ClientFailed: BoardingFailed
+    CommitmentTxReceived --> ClientFailed: BoardingFailed
+    CommitmentTxValidated --> ClientFailed: BoardingFailed
+    NoncesSent --> ClientFailed: BoardingFailed
+    NoncesAggregated --> ClientFailed: BoardingFailed
+    PartialSigsSent --> ClientFailed: BoardingFailed
+    InputSigSent --> ClientFailed: BoardingFailed
+    InputSigSent --> RecoveryInitiated: RecoveryInitiated
+```
+
+The diagram omits internal events for clarity, showing only major transitions
+triggered by external events. Each state may perform significant computation
+(validation, cryptography, checkpoint operations) before transitioning.
+
+## Future Extensions
+
+The current implementation supports boarding, the entry point for Ark
+participation. Future extensions will add exit paths (unilateral timeout-based
+and cooperative), VTXO transfers between participants, and VTXO refresh rounds
+preventing timeouts by moving VTXOs into new trees with extended expirations.
+
+These extensions may introduce additional states or entirely separate FSMs for
+different protocol flows. Exit flows coordinate with the operator but follow
+distinct state progressions (no multi-party coordination required). VTXO
+transfers need their own round coordination, potentially reusing portions of the
+boarding FSM's MuSig2 ceremony with different validation and output
+construction.
+
+The actor's primary/dedicated FSM pattern should extend naturally. Each protocol
+type (boarding, exit, transfer) can maintain a primary FSM for interactive
+phases and spawn dedicated FSMs for monitoring, ensuring responsiveness
+regardless of simultaneous operation count.

--- a/round/events.go
+++ b/round/events.go
@@ -1,0 +1,248 @@
+package round
+
+import (
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/tree"
+	"github.com/lightninglabs/darepo-client/wallet"
+	"github.com/lightninglabs/taproot-assets/proof"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+)
+
+// ClientEvent is a sealed interface for all events that can be processed by
+// the client round interaction state machine. The sealed interface pattern
+// prevents external packages from implementing this interface, ensuring type
+// safety and exhaustive pattern matching in state transitions.
+type ClientEvent interface {
+	// clientEventSealed is an unexported method that marks this interface
+	// as sealed, preventing external implementations.
+	clientEventSealed()
+}
+
+// ClientOutMsg is a sealed interface for messages emitted via the FSM outbox.
+// These are typically sent to the server or other actors. Separating this from
+// ClientEvent improves readability by distinguishing internal FSM events from
+// outgoing messages.
+type ClientOutMsg interface {
+	// clientOutMsgSealed is an unexported method that marks this interface
+	// as sealed, preventing external implementations.
+	clientOutMsgSealed()
+}
+
+// ResumeBoardingIntents is emitted to instruct the FSM to resume monitoring
+// boarding intents that were in progress. The intents are provided as a
+// parameter (pre-filtered by the actor) rather than fetched from storage.
+type ResumeBoardingIntents struct {
+	// Intents are the boarding intents to resume, keyed by their outpoint.
+	// These are pre-filtered to include only Confirmed-but-not-Adopted
+	// intents.
+	Intents map[wire.OutPoint]BoardingIntent
+}
+
+func (e *ResumeBoardingIntents) clientEventSealed() {}
+
+// BoardingUTXOConfirmed is emitted when the boarding UTXO has received
+// sufficient confirmations and is ready to be used for boarding.
+type BoardingUTXOConfirmed struct {
+	// Outpoint identifies the confirmed boarding UTXO.
+	Outpoint wire.OutPoint
+
+	// Address is the boarding address for this UTXO. Contains the keys,
+	// tapscript, and exit delay needed to build the BoardingRequest.
+	Address wallet.BoardingAddress
+
+	// BlockHeight is the height at which the UTXO was confirmed.
+	BlockHeight int32
+
+	// BlockHash is the hash of the block containing the transaction.
+	BlockHash chainhash.Hash
+
+	// Confirmations is the number of confirmations the UTXO has.
+	Confirmations int32
+
+	// Tx is the confirmed transaction containing the boarding UTXO. This
+	// allows the FSM to extract output details without additional chain
+	// queries.
+	Tx *wire.MsgTx
+
+	// TxProof is the optional SPV proof for this boarding UTXO. Includes
+	// merkle proof, block header, and output construction details. None if
+	// the proof hasn't been constructed yet.
+	TxProof fn.Option[proof.TxProof]
+}
+
+func (e *BoardingUTXOConfirmed) clientEventSealed() {}
+
+// RegistrationRequested is emitted when the FSM is ready to join a round with
+// the currently confirmed set of boarding intents. The actor should treat this
+// as a batch request containing every confirmed intent.
+type RegistrationRequested struct {
+	Intents []BoardingIntent
+
+	// RoundID allows resuming a previously assigned round when rejoining.
+	RoundID string
+}
+
+func (e *RegistrationRequested) clientEventSealed() {}
+
+// RoundJoined is emitted when the server accepts the client's registration
+// and assigns them to a round. This event arrives via the Outbox from the
+// server FSM.
+type RoundJoined struct {
+	// RoundID is the unique identifier for the round.
+	RoundID string
+}
+
+func (e *RoundJoined) clientEventSealed() {}
+
+// CommitmentTxBuilt is emitted when the server sends the commitment
+// transaction and VTXT path to the client. This event arrives via the Outbox
+// from the server FSM after building the transaction that commits all boarding
+// UTXOs.
+type CommitmentTxBuilt struct {
+	// RoundID identifies which round this commitment transaction belongs
+	// to.
+	RoundID string
+
+	// Tx is the unsigned commitment transaction as a PSBT. Using PSBT
+	// allows the server to include WitnessUtxo for all inputs, which is
+	// required for correct Taproot sighash computation (BIP341).
+	Tx *psbt.Packet
+
+	// VTXTTree contains the client's extracted sub-tree from the virtual
+	// transaction tree. The server sends only the minimal path containing
+	// the transactions needed to reach this client's VTXO leaves, not the
+	// full tree (which may contain hundreds of transactions for all
+	// participants). This sub-tree is sufficient for the client to verify
+	// their VTXOs and perform unilateral exit if needed.
+	VTXTTree *tree.Tree
+}
+
+func (e *CommitmentTxBuilt) clientEventSealed() {}
+
+// CommitmentTxValidated is emitted after the client successfully validates
+// the commitment transaction and VTXT path. This is a critical security
+// checkpoint - the client must verify:
+//  1. Boarding UTXO is an input to commitment tx.
+//  2. VTXT path is valid and leads to expected VTXOs.
+//  3. VTXO amounts and scripts match requests.
+type CommitmentTxValidated struct {
+	// VTXTTree is the validated tree.
+	VTXTTree *tree.Tree
+}
+
+func (e *CommitmentTxValidated) clientEventSealed() {}
+
+// GenerateNonces is emitted when the client has validated the vtxt tree, and
+// nonces should be generated for all the client trees.
+type GenerateNonces struct {
+}
+
+func (e *GenerateNonces) clientEventSealed() {}
+
+// NoncesAggregated is emitted when the server sends back the aggregated
+// nonces from all participants. This event arrives via the Outbox from the
+// server FSM. The server computes aggregated nonces from all participants and
+// sends them back to clients, who use them to generate partial signatures in
+// the next phase of the MuSig2 signing protocol.
+type NoncesAggregated struct {
+	// RoundID identifies which round these aggregated nonces belong to.
+	RoundID string
+
+	// AggregatedNonces maps transaction IDs to their aggregated MuSig2
+	// nonces. Each entry corresponds to a transaction in the VTXT that
+	// requires signing.
+	AggregatedNonces map[chainhash.Hash][]byte
+}
+
+func (e *NoncesAggregated) clientEventSealed() {}
+
+// GeneratePartialSigs is emitted when the client has generated partial
+// signatures for all transactions in their VTXT path using the aggregated
+// nonces.
+type GeneratePartialSigs struct {
+	// PartialSigs maps transaction IDs to their MuSig2 partial signatures.
+	// Each entry corresponds to a transaction in the client's VTXT path.
+	PartialSigs map[chainhash.Hash][]byte
+
+	// SigningKey is the key used for signing.
+	SigningKey *btcec.PublicKey
+}
+
+func (e *GeneratePartialSigs) clientEventSealed() {}
+
+// OperatorSigned is emitted when the server sends the complete VTXT
+// signatures after aggregating all partial signatures. This event arrives via
+// the Outbox from the server FSM. After collecting and validating all partial
+// signatures from participants, the operator produces complete Schnorr
+// signatures for each transaction in the VTXT.
+type OperatorSigned struct {
+	// RoundID identifies which round these signatures belong to.
+	RoundID string
+
+	// Signatures maps transaction IDs to their complete aggregated Schnorr
+	// signatures. Each entry corresponds to a transaction in the VTXT.
+	Signatures map[chainhash.Hash][]byte
+
+	// SignedVTXT optionally contains the fully signed virtual transaction
+	// tree in serialized form. This may be omitted and reconstructed from
+	// the signatures if needed.
+	SignedVTXT []byte
+}
+
+func (e *OperatorSigned) clientEventSealed() {}
+
+// BoardingConfirmed is emitted when the commitment transaction has been
+// confirmed on-chain with sufficient confirmations.
+type BoardingConfirmed struct {
+	// TxID is the confirmed commitment transaction ID.
+	TxID chainhash.Hash
+
+	// BlockHeight is the height at which the transaction was confirmed.
+	BlockHeight int32
+
+	// Confirmations is the number of confirmations.
+	Confirmations int32
+}
+
+func (e *BoardingConfirmed) clientEventSealed() {}
+
+// BoardingFailed is emitted when an error occurs during the boarding
+// process.
+type BoardingFailed struct {
+	// Reason is a human-readable description of the failure.
+	Reason string
+
+	// Error is the underlying error.
+	Error error
+
+	// Recoverable indicates if the client can retry or if CSV recovery
+	// is needed.
+	Recoverable bool
+}
+
+func (e *BoardingFailed) clientEventSealed() {}
+
+// RecoveryInitiated is emitted when the client initiates CSV timeout
+// recovery to sweep their boarding UTXO back to their wallet.
+type RecoveryInitiated struct {
+	// Outpoint identifies the boarding UTXO being recovered.
+	Outpoint wire.OutPoint
+
+	// SweepTxID is the transaction ID of the sweep transaction.
+	SweepTxID chainhash.Hash
+
+	// Reason explains why recovery was initiated.
+	Reason string
+}
+
+func (e *RecoveryInitiated) clientEventSealed() {}
+
+// RoundComplete is an internal event emitted after a boarding round completes
+// successfully. This triggers the FSM to transition back to Idle state to
+// process new boarding addresses and intents.
+type RoundComplete struct{}
+
+func (e *RoundComplete) clientEventSealed() {}

--- a/round/fsm_environment.go
+++ b/round/fsm_environment.go
@@ -1,0 +1,51 @@
+package round
+
+import (
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/lightninglabs/darepo-client/lib/types"
+)
+
+// ClientEnvironment provides the client round interaction state machine with
+// access to external systems and storage. This follows the protofsm pattern
+// where the environment contains all dependencies needed for state transitions.
+//
+// Note: Boarding address and intent persistence is handled by the wallet actor.
+// The FSM only needs RoundStore for round checkpointing.
+type ClientEnvironment struct {
+	// RoundStore provides persistence for round coordination and
+	// checkpointing.
+	RoundStore RoundStore
+
+	// VTXOStore provides persistence for off-chain balance.
+	VTXOStore VTXOStore
+
+	// Wallet provides signing capabilities for round participation.
+	Wallet ClientWallet
+
+	// OperatorTerms contains the operator's parameters including sweep
+	// keys, fee targets, confirmation thresholds, and amount limits.
+	OperatorTerms *types.OperatorTerms
+
+	// ChainParams are the Bitcoin network parameters.
+	ChainParams *chaincfg.Params
+}
+
+// Name returns the unique identifier for this FSM instance.
+func (e *ClientEnvironment) Name() string {
+	return "round_fsm"
+}
+
+// NewClientEnvironment creates a new client environment with the provided
+// dependencies.
+func NewClientEnvironment(roundStore RoundStore, vtxoStore VTXOStore,
+	wallet ClientWallet, terms *types.OperatorTerms,
+	chainParams *chaincfg.Params) *ClientEnvironment {
+
+	return &ClientEnvironment{
+		RoundStore:    roundStore,
+		VTXOStore:     vtxoStore,
+		Wallet:        wallet,
+		OperatorTerms: terms,
+		ChainParams:   chainParams,
+	}
+}

--- a/round/harness_test.go
+++ b/round/harness_test.go
@@ -1,0 +1,1817 @@
+package round
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"fmt"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/scripts"
+	"github.com/lightninglabs/darepo-client/lib/tree"
+	"github.com/lightninglabs/darepo-client/lib/types"
+	"github.com/lightninglabs/darepo-client/wallet"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// MockRoundStore implements RoundStore using mock.Mock for testing.
+type MockRoundStore struct {
+	mock.Mock
+}
+
+func (m *MockRoundStore) CommitState(ctx context.Context, round *Round,
+	state ClientState) error {
+
+	args := m.Called(ctx, round, state)
+	return args.Error(0)
+}
+
+//nolint:forcetypeassert
+func (m *MockRoundStore) FetchState(ctx context.Context,
+	roundID string) (*Round, ClientState, error) {
+
+	args := m.Called(ctx, roundID)
+
+	var round *Round
+	if args.Get(0) != nil {
+		round = args.Get(0).(*Round)
+	}
+
+	var state ClientState
+	if args.Get(1) != nil {
+		state = args.Get(1).(ClientState)
+	}
+
+	return round, state, args.Error(2)
+}
+
+//nolint:forcetypeassert
+func (m *MockRoundStore) LookupRoundByCommitmentTx(
+	txid chainhash.Hash) (*Round, error) {
+
+	args := m.Called(txid)
+
+	var round *Round
+	if args.Get(0) != nil {
+		round = args.Get(0).(*Round)
+	}
+
+	return round, args.Error(1)
+}
+
+//nolint:forcetypeassert
+func (m *MockRoundStore) ListActiveRounds() ([]*Round, error) {
+	args := m.Called()
+
+	var rounds []*Round
+	if args.Get(0) != nil {
+		rounds = args.Get(0).([]*Round)
+	}
+
+	return rounds, args.Error(1)
+}
+
+func (m *MockRoundStore) FinalizeRound(roundID string,
+	txid chainhash.Hash) error {
+
+	args := m.Called(roundID, txid)
+	return args.Error(0)
+}
+
+// Compile-time check that MockRoundStore implements RoundStore.
+var _ RoundStore = (*MockRoundStore)(nil)
+
+// MockVTXOStore implements VTXOStore using mock.Mock for testing.
+type MockVTXOStore struct {
+	mock.Mock
+}
+
+func (m *MockVTXOStore) SaveVTXOs(vtxos []*ClientVTXO) error {
+	args := m.Called(vtxos)
+	return args.Error(0)
+}
+
+//nolint:forcetypeassert
+func (m *MockVTXOStore) ListVTXOs() ([]*ClientVTXO, error) {
+	args := m.Called()
+
+	var vtxos []*ClientVTXO
+	if args.Get(0) != nil {
+		vtxos = args.Get(0).([]*ClientVTXO)
+	}
+
+	return vtxos, args.Error(1)
+}
+
+//nolint:forcetypeassert
+func (m *MockVTXOStore) GetVTXO(outpoint wire.OutPoint) (*ClientVTXO, error) {
+	args := m.Called(outpoint)
+
+	var vtxo *ClientVTXO
+	if args.Get(0) != nil {
+		vtxo = args.Get(0).(*ClientVTXO)
+	}
+
+	return vtxo, args.Error(1)
+}
+
+func (m *MockVTXOStore) MarkVTXOSpent(outpoint wire.OutPoint) error {
+	args := m.Called(outpoint)
+	return args.Error(0)
+}
+
+// Compile-time check that MockVTXOStore implements VTXOStore.
+var _ VTXOStore = (*MockVTXOStore)(nil)
+
+// MockClientWallet implements ClientWallet (input.MuSig2Signer + input.Signer)
+// using mock.Mock for testing.
+type MockClientWallet struct {
+	mock.Mock
+}
+
+//nolint:forcetypeassert
+func (m *MockClientWallet) MuSig2CreateSession(
+	version input.MuSig2Version,
+	keyLoc keychain.KeyLocator,
+	signers []*btcec.PublicKey,
+	tweaks *input.MuSig2Tweaks,
+	otherNonces [][musig2.PubNonceSize]byte,
+	localNonces *musig2.Nonces,
+) (*input.MuSig2SessionInfo, error) {
+
+	args := m.Called(
+		version, keyLoc, signers, tweaks, otherNonces, localNonces,
+	)
+
+	var info *input.MuSig2SessionInfo
+	if args.Get(0) != nil {
+		info = args.Get(0).(*input.MuSig2SessionInfo)
+	}
+
+	return info, args.Error(1)
+}
+
+func (m *MockClientWallet) MuSig2RegisterNonces(
+	sessionID input.MuSig2SessionID,
+	nonces [][musig2.PubNonceSize]byte,
+) (bool, error) {
+
+	args := m.Called(sessionID, nonces)
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *MockClientWallet) MuSig2RegisterCombinedNonce(
+	sessionID input.MuSig2SessionID,
+	nonce [musig2.PubNonceSize]byte,
+) error {
+
+	args := m.Called(sessionID, nonce)
+	return args.Error(0)
+}
+
+//nolint:forcetypeassert
+func (m *MockClientWallet) MuSig2GetCombinedNonce(
+	sessionID input.MuSig2SessionID,
+) ([musig2.PubNonceSize]byte, error) {
+
+	args := m.Called(sessionID)
+
+	var nonce [musig2.PubNonceSize]byte
+	if args.Get(0) != nil {
+		nonce = args.Get(0).([musig2.PubNonceSize]byte)
+	}
+
+	return nonce, args.Error(1)
+}
+
+//nolint:forcetypeassert
+func (m *MockClientWallet) MuSig2Sign(
+	sessionID input.MuSig2SessionID,
+	message [sha256.Size]byte,
+	cleanup bool,
+) (*musig2.PartialSignature, error) {
+
+	args := m.Called(sessionID, message, cleanup)
+
+	var sig *musig2.PartialSignature
+	if args.Get(0) != nil {
+		sig = args.Get(0).(*musig2.PartialSignature)
+	}
+
+	return sig, args.Error(1)
+}
+
+//nolint:forcetypeassert
+func (m *MockClientWallet) MuSig2CombineSig(
+	sessionID input.MuSig2SessionID,
+	otherPartials []*musig2.PartialSignature,
+) (*schnorr.Signature, bool, error) {
+
+	args := m.Called(sessionID, otherPartials)
+
+	var sig *schnorr.Signature
+	if args.Get(0) != nil {
+		sig = args.Get(0).(*schnorr.Signature)
+	}
+
+	return sig, args.Bool(1), args.Error(2)
+}
+
+func (m *MockClientWallet) MuSig2Cleanup(
+	sessionID input.MuSig2SessionID) error {
+
+	args := m.Called(sessionID)
+	return args.Error(0)
+}
+
+//nolint:forcetypeassert
+func (m *MockClientWallet) SignOutputRaw(
+	tx *wire.MsgTx,
+	signDesc *input.SignDescriptor,
+) (input.Signature, error) {
+
+	args := m.Called(tx, signDesc)
+
+	var sig input.Signature
+	if args.Get(0) != nil {
+		sig = args.Get(0).(input.Signature)
+	}
+
+	return sig, args.Error(1)
+}
+
+//nolint:forcetypeassert
+func (m *MockClientWallet) ComputeInputScript(
+	tx *wire.MsgTx,
+	signDesc *input.SignDescriptor,
+) (*input.Script, error) {
+
+	args := m.Called(tx, signDesc)
+
+	var script *input.Script
+	if args.Get(0) != nil {
+		script = args.Get(0).(*input.Script)
+	}
+
+	return script, args.Error(1)
+}
+
+// Compile-time check that MockClientWallet implements ClientWallet.
+var _ ClientWallet = (*MockClientWallet)(nil)
+
+// boardingTestHarness is the central test harness housing all common setup,
+// mocks, fixtures, and helper functions for boarding FSM tests.
+//
+//nolint:containedctx
+type boardingTestHarness struct {
+	t      *testing.T
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	// Mocks for FSM dependencies.
+	roundStore *MockRoundStore
+	vtxoStore  *MockVTXOStore
+	wallet     *MockClientWallet
+
+	// Environment for FSM.
+	env *ClientEnvironment
+
+	// Real cryptographic keys for signature testing.
+	clientPrivKey   *btcec.PrivateKey
+	clientPubKey    *btcec.PublicKey
+	operatorPrivKey *btcec.PrivateKey
+	operatorPubKey  *btcec.PublicKey
+
+	// Runtime state tracking for assertions.
+	currentState   ClientState
+	lastTransition *ClientStateTransition
+	outboxMessages []ClientOutMsg
+}
+
+// newTestHarness creates a new test harness with default mock configuration.
+func newTestHarness(t *testing.T) *boardingTestHarness {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	clientPrivKey, clientPubKey := generateTestKeyPair(t)
+	operatorPrivKey, operatorPubKey := generateTestKeyPair(t)
+
+	roundStore := &MockRoundStore{}
+	vtxoStore := &MockVTXOStore{}
+	wallet := &MockClientWallet{}
+
+	terms := &types.OperatorTerms{
+		PubKey:            operatorPubKey,
+		SweepKey:          operatorPubKey,
+		SweepDelay:        1008, // ~1 week in blocks.
+		DustLimit:         546,
+		MinBoardingAmount: 10000,
+		MaxBoardingAmount: 100000000, // 1 BTC.
+		FeeRate:           10,
+		MinConfirmations:  3,
+	}
+
+	env := NewClientEnvironment(
+		roundStore, vtxoStore, wallet, terms,
+		&chaincfg.RegressionNetParams,
+	)
+
+	h := &boardingTestHarness{
+		t:               t,
+		ctx:             ctx,
+		cancel:          cancel,
+		roundStore:      roundStore,
+		vtxoStore:       vtxoStore,
+		wallet:          wallet,
+		env:             env,
+		clientPrivKey:   clientPrivKey,
+		clientPubKey:    clientPubKey,
+		operatorPrivKey: operatorPrivKey,
+		operatorPubKey:  operatorPubKey,
+		currentState:    &Idle{},
+		outboxMessages:  make([]ClientOutMsg, 0),
+	}
+
+	t.Cleanup(func() {
+		cancel()
+	})
+
+	return h
+}
+
+// withState sets the current state for the harness.
+func (h *boardingTestHarness) withState(
+	state ClientState) *boardingTestHarness {
+
+	h.currentState = state
+	return h
+}
+
+// sendEvent sends an event to the current state, captures the transition, and
+// updates internal state tracking for subsequent assertions.
+func (h *boardingTestHarness) sendEvent(
+	event ClientEvent) (*ClientStateTransition, error) {
+
+	h.t.Helper()
+
+	transition, err := h.currentState.ProcessEvent(h.ctx, event, h.env)
+	if err != nil {
+		return nil, err
+	}
+
+	h.lastTransition = transition
+
+	if transition != nil {
+		if nextState, ok := transition.NextState.(ClientState); ok {
+			h.currentState = nextState
+		}
+
+		transition.NewEvents.WhenSome(func(emitted ClientEmittedEvent) {
+			h.outboxMessages = append(
+				h.outboxMessages, emitted.Outbox...,
+			)
+		})
+	}
+
+	return transition, nil
+}
+
+// assertStateType asserts the current state is of the expected type and
+// returns it cast to that type.
+func assertStateType[T ClientState](h *boardingTestHarness) T {
+	h.t.Helper()
+
+	state, ok := h.currentState.(T)
+	require.True(h.t, ok, "current state is not of expected type")
+
+	return state
+}
+
+func (h *boardingTestHarness) newTestOutpoint() wire.OutPoint {
+	h.t.Helper()
+
+	var hash chainhash.Hash
+	_, err := rand.Read(hash[:])
+	require.NoError(h.t, err)
+
+	return wire.OutPoint{
+		Hash:  hash,
+		Index: 0,
+	}
+}
+
+func (h *boardingTestHarness) newTestBoardingAddress() wallet.BoardingAddress {
+	h.t.Helper()
+
+	// ~1 day in blocks.
+	exitDelay := uint32(144)
+
+	// Build the tapscript for the boarding address.
+	tapscript, err := scripts.VTXOTapScript(
+		h.clientPubKey, h.operatorPubKey, exitDelay,
+	)
+	require.NoError(h.t, err)
+
+	// Compute the taproot key and create the address.
+	taprootKey, err := tapscript.TaprootKey()
+	require.NoError(h.t, err)
+
+	address, err := btcutil.NewAddressTaproot(
+		schnorr.SerializePubKey(taprootKey),
+		&chaincfg.RegressionNetParams,
+	)
+	require.NoError(h.t, err)
+
+	return wallet.BoardingAddress{
+		Address:   address,
+		Tapscript: tapscript,
+		KeyDesc: keychain.KeyDescriptor{
+			PubKey: h.clientPubKey,
+			KeyLocator: keychain.KeyLocator{
+				Family: keychain.KeyFamilyMultiSig,
+				Index:  0,
+			},
+		},
+		OperatorKey: h.operatorPubKey,
+		ExitDelay:   exitDelay,
+	}
+}
+
+func (h *boardingTestHarness) newTestBoardingIntent() BoardingIntent {
+	h.t.Helper()
+
+	outpoint := h.newTestOutpoint()
+	address := h.newTestBoardingAddress()
+
+	pkScript, err := txscript.PayToTaprootScript(h.clientPubKey)
+	require.NoError(h.t, err)
+
+	signingKey := keychain.KeyDescriptor{
+		PubKey: h.clientPubKey,
+		KeyLocator: keychain.KeyLocator{
+			Family: keychain.KeyFamilyMultiSig,
+			Index:  0,
+		},
+	}
+
+	return BoardingIntent{
+		BoardingIntent: wallet.BoardingIntent{
+			Address:  address,
+			Outpoint: outpoint,
+			ChainInfo: wallet.BoardingChainInfo{
+				ConfHeight: 100,
+				OutPoint:   outpoint,
+				Amount:     btcutil.Amount(50000),
+			},
+			Status: wallet.BoardingStatusConfirmed,
+		},
+		BoardingRequest: types.BoardingRequest{
+			Outpoint:    &outpoint,
+			ClientKey:   h.clientPubKey,
+			OperatorKey: h.operatorPubKey,
+		},
+		VtxoTemplate: []types.VTXORequest{
+			{
+				Amount:      50000,
+				PkScript:    pkScript,
+				Expiry:      testExitDelay,
+				ClientKey:   h.clientPubKey,
+				OperatorKey: h.operatorPubKey,
+				SigningKey:  signingKey,
+			},
+		},
+	}
+}
+
+// newTestCommitmentTx creates a commitment transaction with the given inputs.
+// Uses version 3 for BIP 431 ephemeral anchor compatibility.
+func (h *boardingTestHarness) newTestCommitmentTx(
+	intents []BoardingIntent) *psbt.Packet {
+
+	h.t.Helper()
+
+	tx := wire.NewMsgTx(3)
+
+	for _, intent := range intents {
+		tx.AddTxIn(&wire.TxIn{
+			PreviousOutPoint: intent.Outpoint,
+		})
+	}
+
+	tx.AddTxOut(&wire.TxOut{
+		Value:    100000,
+		PkScript: make([]byte, 34),
+	})
+
+	tx.AddTxOut(&wire.TxOut{
+		Value:    0,
+		PkScript: []byte{txscript.OP_TRUE, txscript.OP_RETURN},
+	})
+
+	// Create PSBT with WitnessUtxo for each input.
+	packet, err := psbt.NewFromUnsignedTx(tx)
+	require.NoError(h.t, err)
+
+	for i, intent := range intents {
+		addr := intent.Address.Address
+		pkScript := addr.ScriptAddress()
+		amt := intent.ChainInfo.Amount
+
+		packet.Inputs[i] = psbt.PInput{
+			WitnessUtxo: &wire.TxOut{
+				Value:    int64(amt),
+				PkScript: pkScript,
+			},
+		}
+	}
+
+	return packet
+}
+
+func generateTestKeyPair(t *testing.T) (*btcec.PrivateKey, *btcec.PublicKey) {
+	t.Helper()
+
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	return privKey, privKey.PubKey()
+}
+
+func (h *boardingTestHarness) newBoardingUTXOConfirmedEvent(
+	intent BoardingIntent) *BoardingUTXOConfirmed {
+
+	h.t.Helper()
+
+	tx := wire.NewMsgTx(2)
+	tx.AddTxOut(&wire.TxOut{
+		Value:    int64(intent.VtxoTemplate[0].Amount),
+		PkScript: intent.VtxoTemplate[0].PkScript,
+	})
+
+	var blockHash chainhash.Hash
+	_, err := rand.Read(blockHash[:])
+	require.NoError(h.t, err)
+
+	return &BoardingUTXOConfirmed{
+		Outpoint:      intent.Outpoint,
+		Address:       intent.Address,
+		BlockHeight:   intent.ChainInfo.ConfHeight,
+		BlockHash:     blockHash,
+		Confirmations: 6,
+		Tx:            tx,
+	}
+}
+
+const (
+	testExitDelay = uint32(144) // 1 day in blocks.
+)
+
+// newTestVTXOTree creates a minimal valid VTXT tree for testing by
+// delegating to lib/tree.NewTree() which handles all internal construction
+// including proper Taproot tweaking and node structure.
+func (h *boardingTestHarness) newTestVTXOTree(
+	numLeaves int) (*tree.Tree, []tree.LeafDescriptor) {
+
+	h.t.Helper()
+
+	const leafAmount = btcutil.Amount(50000)
+
+	leaves := make([]tree.LeafDescriptor, numLeaves)
+	for i := 0; i < numLeaves; i++ {
+		vtxoScript, err := txscript.PayToTaprootScript(h.clientPubKey)
+		require.NoError(h.t, err)
+
+		leaves[i] = tree.LeafDescriptor{
+			PkScript:    vtxoScript,
+			Amount:      leafAmount,
+			CoSignerKey: h.clientPubKey,
+		}
+	}
+
+	batchOutpoint := h.newTestOutpoint()
+
+	batchPkScript, err := txscript.PayToTaprootScript(h.operatorPubKey)
+	require.NoError(h.t, err)
+
+	// Batch output value must equal the sum of all leaf amounts.
+	batchOutput := &wire.TxOut{
+		Value:    int64(leafAmount) * int64(numLeaves),
+		PkScript: batchPkScript,
+	}
+
+	sweepRoot := sha256.Sum256([]byte("test-sweep-root"))
+
+	vtxtTree, err := tree.NewTree(
+		batchOutpoint, batchOutput, leaves,
+		h.operatorPubKey, sweepRoot[:], 2,
+	)
+	require.NoError(h.t, err)
+
+	return vtxtTree, leaves
+}
+
+// newTestVTXOTreeForIntent creates a VTXT tree configured for a specific
+// boarding intent, deriving leaves from the intent's VTXO template to ensure
+// amounts and keys match what the client expects to receive.
+func (h *boardingTestHarness) newTestVTXOTreeForIntent(
+	intent BoardingIntent) *tree.Tree {
+
+	h.t.Helper()
+
+	leaves := make([]tree.LeafDescriptor, len(intent.VtxoTemplate))
+	for i, vtxoReq := range intent.VtxoTemplate {
+		leaves[i] = tree.LeafDescriptor{
+			PkScript:    vtxoReq.PkScript,
+			Amount:      vtxoReq.Amount,
+			CoSignerKey: h.clientPubKey,
+		}
+	}
+
+	batchOutpoint := h.newTestOutpoint()
+
+	batchPkScript, err := txscript.PayToTaprootScript(h.operatorPubKey)
+	require.NoError(h.t, err)
+
+	batchOutput := &wire.TxOut{
+		Value:    int64(intent.ChainInfo.Amount),
+		PkScript: batchPkScript,
+	}
+
+	sweepRoot := sha256.Sum256([]byte("test-sweep-root"))
+
+	vtxtTree, err := tree.NewTree(
+		batchOutpoint, batchOutput, leaves,
+		h.operatorPubKey, sweepRoot[:], 2,
+	)
+	require.NoError(h.t, err)
+
+	return vtxtTree
+}
+
+// newCommitmentTxBuiltEvent creates a CommitmentTxBuilt event simulating what
+// the server sends after building the commitment transaction with all boarding
+// inputs and the batch VTXT tree output. The transaction is returned as a PSBT
+// with WitnessUtxo populated for all inputs, which is required for correct
+// Taproot sighash computation.
+func (h *boardingTestHarness) newCommitmentTxBuiltEvent(
+	roundID string,
+	intents []BoardingIntent,
+	vtxtTree *tree.Tree) *CommitmentTxBuilt {
+
+	h.t.Helper()
+
+	// Build the unsigned transaction.
+	tx := wire.NewMsgTx(3)
+	for _, intent := range intents {
+		tx.AddTxIn(&wire.TxIn{
+			PreviousOutPoint: intent.Outpoint,
+		})
+	}
+
+	tx.AddTxOut(vtxtTree.BatchOutput)
+
+	tx.AddTxOut(&wire.TxOut{
+		Value:    0,
+		PkScript: []byte{txscript.OP_TRUE, txscript.OP_RETURN},
+	})
+
+	// Create PSBT inputs with WitnessUtxo for each boarding input.
+	pInputs := make([]psbt.PInput, len(intents))
+	for i, intent := range intents {
+		addr := intent.Address.Address
+		pkScript := addr.ScriptAddress()
+		amt := intent.ChainInfo.Amount
+
+		pInputs[i] = psbt.PInput{
+			WitnessUtxo: &wire.TxOut{
+				Value:    int64(amt),
+				PkScript: pkScript,
+			},
+		}
+	}
+
+	// Create PSBT outputs (empty for now).
+	pOutputs := make([]psbt.POutput, len(tx.TxOut))
+
+	packet, err := psbt.NewFromUnsignedTx(tx)
+	require.NoError(h.t, err)
+
+	// Populate the inputs with WitnessUtxo.
+	packet.Inputs = pInputs
+	packet.Outputs = pOutputs
+
+	return &CommitmentTxBuilt{
+		RoundID:  roundID,
+		Tx:       packet,
+		VTXTTree: vtxtTree,
+	}
+}
+
+// newNoncesAggregatedEvent creates aggregated nonces for all tree nodes,
+// simulating what the server sends after collecting and combining nonces from
+// all round participants for the MuSig2 signing protocol.
+func (h *boardingTestHarness) newNoncesAggregatedEvent(
+	roundID string, vtxtTree *tree.Tree) *NoncesAggregated {
+
+	h.t.Helper()
+
+	aggNonces := make(map[chainhash.Hash][]byte)
+	err := vtxtTree.Root.ForEach(func(node *tree.Node) error {
+		txid, err := node.TXID()
+		if err != nil {
+			return err
+		}
+
+		nonce := make([]byte, musig2.PubNonceSize)
+		_, err = rand.Read(nonce)
+		if err != nil {
+			return err
+		}
+
+		aggNonces[txid] = nonce
+
+		return nil
+	})
+	require.NoError(h.t, err)
+
+	return &NoncesAggregated{
+		RoundID:          roundID,
+		AggregatedNonces: aggNonces,
+	}
+}
+
+// newOperatorSignedEvent creates operator signatures for the tree, simulating
+// what the server sends after combining all partial signatures into final
+// Schnorr signatures for each tree node.
+//
+//nolint:unused
+func (h *boardingTestHarness) newOperatorSignedEvent(
+	roundID string, vtxtTree *tree.Tree) *OperatorSigned {
+
+	h.t.Helper()
+
+	// Build a map of signatures keyed by transaction ID.
+	sigs := make(map[chainhash.Hash][]byte)
+	err := vtxtTree.Root.ForEach(func(node *tree.Node) error {
+		txid, err := node.TXID()
+		if err != nil {
+			return err
+		}
+
+		sig := make([]byte, schnorr.SignatureSize)
+		_, err = rand.Read(sig)
+		if err != nil {
+			return err
+		}
+
+		sigs[txid] = sig
+
+		return nil
+	})
+	require.NoError(h.t, err)
+
+	return &OperatorSigned{
+		RoundID:    roundID,
+		Signatures: sigs,
+	}
+}
+
+// newCommitmentTxReceivedState creates a CommitmentTxReceivedState ready for
+// validation testing with a pre-built commitment transaction and VTXT tree.
+func (h *boardingTestHarness) newCommitmentTxReceivedState(
+	roundID string, intents []BoardingIntent) *CommitmentTxReceivedState {
+
+	h.t.Helper()
+
+	vtxtTree := h.newTestVTXOTreeForIntent(intents[0])
+	commitmentTx := h.newTestCommitmentTx(intents)
+
+	return &CommitmentTxReceivedState{
+		RoundID:      roundID,
+		CommitmentTx: commitmentTx,
+		TxID:         commitmentTx.UnsignedTx.TxHash(),
+		VTXTTree:     vtxtTree,
+		Intents:      intents,
+		ClientTrees:  make(map[SignerKey]*tree.Tree),
+	}
+}
+
+// newCommitmentTxValidatedState creates a CommitmentTxValidatedState ready
+// for nonce generation, with boarding input indices pre-mapped for efficient
+// input signature placement during the signing phase.
+func (h *boardingTestHarness) newCommitmentTxValidatedState(
+	roundID string, intents []BoardingIntent) *CommitmentTxValidatedState {
+
+	h.t.Helper()
+
+	vtxtTree := h.newTestVTXOTreeForIntent(intents[0])
+	commitmentTx := h.newTestCommitmentTx(intents)
+
+	boardingInputIndices := make(map[wire.OutPoint]int)
+	for i, intent := range intents {
+		boardingInputIndices[intent.Outpoint] = i
+	}
+
+	return &CommitmentTxValidatedState{
+		RoundID:              roundID,
+		CommitmentTx:         commitmentTx,
+		VTXTTree:             vtxtTree,
+		Intents:              intents,
+		ClientTrees:          make(map[SignerKey]*tree.Tree),
+		BoardingInputIndices: boardingInputIndices,
+	}
+}
+
+// MockSignerSession is a mock implementation of tree.SignerSession for
+// testing error injection in the MuSig2 signing flow without requiring
+// real cryptographic operations.
+type MockSignerSession struct {
+	mock.Mock
+
+	pubKey *btcec.PublicKey
+}
+
+// NewMockSignerSession creates a new MockSignerSession with the given public
+// key.
+func NewMockSignerSession(pubKey *btcec.PublicKey) *MockSignerSession {
+	return &MockSignerSession{
+		pubKey: pubKey,
+	}
+}
+
+//nolint:forcetypeassert
+func (m *MockSignerSession) GetNonces() (
+	map[string]tree.Musig2PubNonce, error) {
+
+	args := m.Called()
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).(map[string]tree.Musig2PubNonce), args.Error(1)
+}
+
+func (m *MockSignerSession) RegisterNonces(
+	nonces map[string][]tree.Musig2PubNonce) error {
+
+	args := m.Called(nonces)
+	return args.Error(0)
+}
+
+//nolint:forcetypeassert
+func (m *MockSignerSession) Signatures(cleanup bool) (
+	map[string]*musig2.PartialSignature, error) {
+
+	args := m.Called(cleanup)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).(map[string]*musig2.PartialSignature), args.Error(1)
+}
+
+func (m *MockSignerSession) PubKey() *btcec.PublicKey {
+	return m.pubKey
+}
+
+//nolint:unused
+func (h *boardingTestHarness) newBoardingConfirmedEvent(
+	commitmentTx *wire.MsgTx, blockHeight int32) *BoardingConfirmed {
+
+	h.t.Helper()
+
+	return &BoardingConfirmed{
+		TxID:          commitmentTx.TxHash(),
+		BlockHeight:   blockHeight,
+		Confirmations: 6,
+	}
+}
+
+//nolint:unused
+func (h *boardingTestHarness) newBoardingFailedEvent(
+	reason string, recoverable bool) *BoardingFailed {
+
+	h.t.Helper()
+
+	return &BoardingFailed{
+		Reason:      reason,
+		Recoverable: recoverable,
+	}
+}
+
+// setupMockWalletForMuSig2 configures all MuSig2 mock methods needed for tree
+// signing flows: session creation, nonce registration (both individual and
+// combined), and partial signature generation.
+func (h *boardingTestHarness) setupMockWalletForMuSig2() {
+	h.t.Helper()
+
+	// Session creation mock.
+	var sessionID input.MuSig2SessionID
+	_, err := rand.Read(sessionID[:])
+	require.NoError(h.t, err)
+
+	var pubNonce [musig2.PubNonceSize]byte
+	_, err = rand.Read(pubNonce[:])
+	require.NoError(h.t, err)
+
+	sessionInfo := &input.MuSig2SessionInfo{
+		SessionID:   sessionID,
+		PublicNonce: pubNonce,
+		CombinedKey: h.clientPubKey,
+	}
+
+	h.wallet.On(
+		"MuSig2CreateSession", mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+	).Return(sessionInfo, nil)
+
+	// Nonce registration mocks (individual and combined/aggregated).
+	h.wallet.On(
+		"MuSig2RegisterNonces", mock.Anything, mock.Anything,
+	).Return(true, nil)
+
+	h.wallet.On(
+		"MuSig2RegisterCombinedNonce", mock.Anything, mock.Anything,
+	).Return(nil)
+
+	// Signing mock.
+	var scalarBytes [32]byte
+	_, err = rand.Read(scalarBytes[:])
+	require.NoError(h.t, err)
+
+	var scalar btcec.ModNScalar
+	scalar.SetBytes(&scalarBytes)
+
+	partialSig := &musig2.PartialSignature{
+		S: &scalar,
+	}
+
+	h.wallet.On(
+		"MuSig2Sign", mock.Anything, mock.Anything, mock.Anything,
+	).Return(partialSig, nil)
+}
+
+//nolint:unused
+func (h *boardingTestHarness) setupMockWalletForBoardingSigning() {
+	h.t.Helper()
+
+	sig := &schnorr.Signature{}
+
+	h.wallet.On("SignOutputRaw", mock.Anything, mock.Anything).Return(
+		sig, nil,
+	)
+}
+
+//nolint:unused
+func (h *boardingTestHarness) setupMockRoundStoreForCheckpoint() {
+	h.t.Helper()
+
+	h.roundStore.On(
+		"CommitState",
+		mock.Anything, // ctx
+		mock.Anything, // round
+		mock.Anything, // state
+	).Return(nil)
+}
+
+func (h *boardingTestHarness) setupMockVTXOStoreForSave() {
+	h.t.Helper()
+
+	h.vtxoStore.On(
+		"SaveVTXOs",
+		mock.Anything, // vtxos
+	).Return(nil)
+}
+
+//nolint:unused
+func (h *boardingTestHarness) newNoncesSentState(
+	roundID string, intents []BoardingIntent) *NoncesSentState {
+
+	h.t.Helper()
+
+	vtxtTree := h.newTestVTXOTreeForIntent(intents[0])
+	commitmentTx := h.newTestCommitmentTx(intents)
+
+	boardingInputIndices := make(map[wire.OutPoint]int)
+	for i, intent := range intents {
+		boardingInputIndices[intent.Outpoint] = i
+	}
+
+	musig2Sessions := make(map[SignerKey]*tree.SignerSession)
+
+	return &NoncesSentState{
+		RoundID:              roundID,
+		CommitmentTx:         commitmentTx,
+		VTXTTree:             vtxtTree,
+		Intents:              intents,
+		ClientTrees:          make(map[SignerKey]*tree.Tree),
+		Musig2Sessions:       musig2Sessions,
+		BoardingInputIndices: boardingInputIndices,
+	}
+}
+
+//nolint:unused
+func (h *boardingTestHarness) newNoncesAggregatedState(
+	roundID string, intents []BoardingIntent) *NoncesAggregatedState {
+
+	h.t.Helper()
+
+	vtxtTree := h.newTestVTXOTreeForIntent(intents[0])
+	commitmentTx := h.newTestCommitmentTx(intents)
+
+	boardingInputIndices := make(map[wire.OutPoint]int)
+	for i, intent := range intents {
+		boardingInputIndices[intent.Outpoint] = i
+	}
+
+	aggNonces := make(map[chainhash.Hash][]byte)
+	err := vtxtTree.Root.ForEach(func(node *tree.Node) error {
+		txid, err := node.TXID()
+		if err != nil {
+			return err
+		}
+
+		nonce := make([]byte, musig2.PubNonceSize)
+		_, err = rand.Read(nonce)
+		if err != nil {
+			return err
+		}
+
+		aggNonces[txid] = nonce
+
+		return nil
+	})
+	require.NoError(h.t, err)
+
+	return &NoncesAggregatedState{
+		RoundID:              roundID,
+		CommitmentTx:         commitmentTx,
+		VTXTTree:             vtxtTree,
+		Intents:              intents,
+		ClientTrees:          make(map[SignerKey]*tree.Tree),
+		Musig2Sessions:       make(map[SignerKey]*tree.SignerSession),
+		AggregatedNonces:     aggNonces,
+		BoardingInputIndices: boardingInputIndices,
+	}
+}
+
+//nolint:unused
+func (h *boardingTestHarness) newPartialSigsSentState(
+	roundID string, intents []BoardingIntent) *PartialSigsSentState {
+
+	h.t.Helper()
+
+	vtxtTree := h.newTestVTXOTreeForIntent(intents[0])
+	commitmentTx := h.newTestCommitmentTx(intents)
+
+	boardingInputIndices := make(map[wire.OutPoint]int)
+	for i, intent := range intents {
+		boardingInputIndices[intent.Outpoint] = i
+	}
+
+	return &PartialSigsSentState{
+		RoundID:              roundID,
+		CommitmentTx:         commitmentTx,
+		VTXTTree:             vtxtTree,
+		Intents:              intents,
+		ClientTrees:          make(map[SignerKey]*tree.Tree),
+		Musig2Sessions:       make(map[SignerKey]*tree.SignerSession),
+		BoardingInputIndices: boardingInputIndices,
+	}
+}
+
+func (h *boardingTestHarness) newInputSigSentState(
+	roundID string, intents []BoardingIntent) *InputSigSentState {
+
+	h.t.Helper()
+
+	vtxtTree := h.newTestVTXOTreeForIntent(intents[0])
+	commitmentTx := h.newTestCommitmentTx(intents)
+
+	inputSigs := make([][]byte, len(intents))
+	for i := range inputSigs {
+		inputSigs[i] = make([]byte, schnorr.SignatureSize)
+		_, err := rand.Read(inputSigs[i])
+		require.NoError(h.t, err)
+	}
+
+	clientTrees := make(map[SignerKey]*tree.Tree)
+	for _, intent := range intents {
+		for _, vtxoReq := range intent.VtxoTemplate {
+			signerKey := NewSignerKey(vtxoReq.SigningKey.PubKey)
+			clientTrees[signerKey] = vtxtTree
+		}
+	}
+
+	return &InputSigSentState{
+		RoundID:      roundID,
+		CommitmentTx: commitmentTx,
+		VTXTTree:     vtxtTree,
+		Intents:      intents,
+		ClientTrees:  clientTrees,
+		InputSigs:    inputSigs,
+	}
+}
+
+func (h *boardingTestHarness) assertOutboxContainsType(msgType string) {
+	h.t.Helper()
+
+	found := false
+	for _, msg := range h.outboxMessages {
+		typeName := fmt.Sprintf("%T", msg)
+		if typeName == msgType || typeName == "*round."+msgType {
+			found = true
+			break
+		}
+	}
+	require.True(
+		h.t, found, "outbox does not contain message of type %s",
+		msgType,
+	)
+}
+
+//nolint:unused
+func assertOutboxContains[T ClientEvent](h *boardingTestHarness) T {
+	h.t.Helper()
+
+	for _, msg := range h.outboxMessages {
+		if typed, ok := msg.(T); ok {
+			return typed
+		}
+	}
+
+	var zero T
+	h.t.Fatalf("outbox does not contain event of type %T", zero)
+
+	return zero
+}
+
+func (h *boardingTestHarness) assertOutboxLen(expected int) {
+	h.t.Helper()
+
+	require.Len(
+		h.t, h.outboxMessages, expected,
+		"outbox has %d messages, expected %d",
+		len(h.outboxMessages), expected,
+	)
+}
+
+func (h *boardingTestHarness) clearOutbox() {
+	h.outboxMessages = nil
+}
+
+// assertTransitionEmitsInternalEvent verifies the transition emitted an
+// internal event of the expected type, used for testing FSM event propagation.
+func assertTransitionEmitsInternalEvent[T ClientEvent](
+	h *boardingTestHarness, transition *ClientStateTransition) {
+
+	h.t.Helper()
+
+	require.True(
+		h.t, transition.NewEvents.IsSome(),
+		"transition should emit events",
+	)
+
+	var found bool
+	transition.NewEvents.WhenSome(func(emitted ClientEmittedEvent) {
+		for _, evt := range emitted.InternalEvent {
+			if _, ok := evt.(T); ok {
+				found = true
+				break
+			}
+		}
+	})
+
+	var zero T
+	require.True(
+		h.t, found, "transition does not emit internal event of "+
+			"type %T", zero,
+	)
+}
+
+// realMuSig2Signer provides real MuSig2 cryptographic operations for testing
+// instead of mocks, allowing tests to verify actual signature validity and
+// protocol correctness.
+type realMuSig2Signer struct {
+	privKey       *btcec.PrivateKey
+	sessions      map[input.MuSig2SessionID]*realSession
+	nextSessionID int
+}
+
+// realSession maintains cryptographic state for an active MuSig2 signing
+// session, tracking nonces and partial signatures until finalization.
+type realSession struct {
+	info           *input.MuSig2SessionInfo
+	nonces         *musig2.Nonces
+	musigSession   *musig2.Session
+	allNoncesKnown bool
+}
+
+func newRealMuSig2Signer(privKey *btcec.PrivateKey) *realMuSig2Signer {
+	return &realMuSig2Signer{
+		privKey:  privKey,
+		sessions: make(map[input.MuSig2SessionID]*realSession),
+	}
+}
+
+// MuSig2CreateSession creates a new MuSig2 session with real nonce generation.
+func (r *realMuSig2Signer) MuSig2CreateSession(
+	version input.MuSig2Version, keyLoc keychain.KeyLocator,
+	signers []*btcec.PublicKey, tweaks *input.MuSig2Tweaks,
+	otherNonces [][musig2.PubNonceSize]byte,
+	localNonces *musig2.Nonces) (*input.MuSig2SessionInfo, error) {
+
+	var nonces *musig2.Nonces
+	var err error
+	if localNonces != nil {
+		nonces = localNonces
+	} else {
+		nonces, err = musig2.GenNonces(
+			musig2.WithPublicKey(r.privKey.PubKey()),
+			musig2.WithNonceSecretKeyAux(r.privKey),
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var ctxOpts []musig2.ContextOption
+	ctxOpts = append(ctxOpts, musig2.WithKnownSigners(signers))
+
+	if tweaks != nil && len(tweaks.TaprootTweak) > 0 {
+		twkCtx := musig2.WithTaprootTweakCtx(tweaks.TaprootTweak)
+		ctxOpts = append(ctxOpts, twkCtx)
+	}
+
+	ctx, err := musig2.NewContext(r.privKey, true, ctxOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	musigSession, err := ctx.NewSession()
+	if err != nil {
+		return nil, err
+	}
+
+	sessionID := input.MuSig2SessionID{byte(r.nextSessionID)}
+	r.nextSessionID++
+
+	sess := &realSession{
+		info: &input.MuSig2SessionInfo{
+			SessionID:   sessionID,
+			PublicNonce: nonces.PubNonce,
+		},
+		nonces:       nonces,
+		musigSession: musigSession,
+	}
+
+	r.sessions[sessionID] = sess
+
+	return sess.info, nil
+}
+
+// MuSig2RegisterNonces registers nonces from other signers, accumulating them
+// until all participants have contributed their public nonces.
+func (r *realMuSig2Signer) MuSig2RegisterNonces(
+	sessionID input.MuSig2SessionID,
+	nonces [][musig2.PubNonceSize]byte) (bool, error) {
+
+	session, ok := r.sessions[sessionID]
+	if !ok {
+		return false, fmt.Errorf("session not found: %v", sessionID)
+	}
+
+	var haveAll bool
+	var err error
+	for _, nonce := range nonces {
+		haveAll, err = session.musigSession.RegisterPubNonce(nonce)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	session.allNoncesKnown = haveAll
+
+	return haveAll, nil
+}
+
+// MuSig2RegisterCombinedNonce registers a pre-aggregated combined nonce for
+// the session. This is an alternative to MuSig2RegisterNonces and is used
+// when a coordinator has already aggregated all individual nonces.
+func (r *realMuSig2Signer) MuSig2RegisterCombinedNonce(
+	sessionID input.MuSig2SessionID,
+	nonce [musig2.PubNonceSize]byte,
+) error {
+
+	session, ok := r.sessions[sessionID]
+	if !ok {
+		return fmt.Errorf("session not found: %v", sessionID)
+	}
+
+	// Register the combined nonce as if it's from all other participants.
+	haveAll, err := session.musigSession.RegisterPubNonce(nonce)
+	if err != nil {
+		return err
+	}
+
+	session.allNoncesKnown = haveAll
+
+	return nil
+}
+
+// MuSig2GetCombinedNonce retrieves the combined nonce for the session. This
+// will be available after all individual nonces have been registered or a
+// combined nonce has been registered.
+func (r *realMuSig2Signer) MuSig2GetCombinedNonce(
+	sessionID input.MuSig2SessionID,
+) ([musig2.PubNonceSize]byte, error) {
+
+	session, ok := r.sessions[sessionID]
+	if !ok {
+		return [musig2.PubNonceSize]byte{}, fmt.Errorf(
+			"session not found: %v", sessionID,
+		)
+	}
+
+	if !session.allNoncesKnown {
+		return [musig2.PubNonceSize]byte{}, fmt.Errorf(
+			"combined nonce not available: nonces not registered",
+		)
+	}
+
+	// The combined nonce is available after all nonces are registered.
+	// Return the session's public nonce as a proxy.
+	return session.nonces.PubNonce, nil
+}
+
+// MuSig2Sign creates a partial signature for the given message using
+// the session's secret nonce. Requires all participant nonces to be
+// registered first.
+func (r *realMuSig2Signer) MuSig2Sign(sessionID input.MuSig2SessionID,
+	msg [32]byte, cleanup bool) (*musig2.PartialSignature, error) {
+
+	session, ok := r.sessions[sessionID]
+	if !ok {
+		return nil, fmt.Errorf("session not found: %v", sessionID)
+	}
+
+	if !session.allNoncesKnown {
+		return nil, fmt.Errorf("not all nonces registered")
+	}
+
+	partialSig, err := session.musigSession.Sign(msg)
+	if err != nil {
+		return nil, err
+	}
+
+	return partialSig, nil
+}
+
+// MuSig2CombineSig combines all participants' partial signatures into a final
+// Schnorr signature that validates against the aggregate public key.
+func (r *realMuSig2Signer) MuSig2CombineSig(sessionID input.MuSig2SessionID,
+	partialSigs []*musig2.PartialSignature) (*schnorr.Signature, bool,
+	error) {
+
+	session, ok := r.sessions[sessionID]
+	if !ok {
+		return nil, false, fmt.Errorf(
+			"session not found: %v", sessionID,
+		)
+	}
+
+	var haveAll bool
+	for _, partialSig := range partialSigs {
+		var err error
+		haveAll, err = session.musigSession.CombineSig(partialSig)
+		if err != nil {
+			return nil, false, err
+		}
+	}
+
+	if !haveAll {
+		return nil, false, fmt.Errorf(
+			"not all partial signatures provided",
+		)
+	}
+
+	finalSig := session.musigSession.FinalSig()
+	if finalSig == nil {
+		return nil, false, fmt.Errorf("final signature is invalid")
+	}
+
+	return finalSig, true, nil
+}
+
+func (r *realMuSig2Signer) MuSig2Cleanup(
+	sessionID input.MuSig2SessionID) error {
+
+	delete(r.sessions, sessionID)
+	return nil
+}
+
+// Compile-time check that realMuSig2Signer implements input.MuSig2Signer.
+var _ input.MuSig2Signer = (*realMuSig2Signer)(nil)
+
+// realSigningTestHarness extends boardingTestHarness with real MuSig2
+// signers for both client and operator roles, enabling full end-to-end
+// signature testing.
+type realSigningTestHarness struct {
+	*boardingTestHarness
+
+	clientSigner   *realMuSig2Signer
+	operatorSigner *realMuSig2Signer
+}
+
+func newRealSigningTestHarness(t *testing.T) *realSigningTestHarness {
+	t.Helper()
+
+	base := newTestHarness(t)
+
+	return &realSigningTestHarness{
+		boardingTestHarness: base,
+		clientSigner:        newRealMuSig2Signer(base.clientPrivKey),
+		operatorSigner:      newRealMuSig2Signer(base.operatorPrivKey),
+	}
+}
+
+// setupMockWalletForBoardingSigning configures the wallet mock to return valid
+// Schnorr signatures for boarding inputs, using the client's real private key
+// to ensure signature correctness.
+func (h *realSigningTestHarness) setupMockWalletForBoardingSigning() {
+	h.t.Helper()
+
+	msgHash := sha256.Sum256([]byte("test-boarding-sig"))
+	sig, err := schnorr.Sign(h.clientPrivKey, msgHash[:])
+	require.NoError(h.t, err)
+
+	h.wallet.On("SignOutputRaw", mock.Anything, mock.Anything).Return(
+		sig, nil,
+	)
+}
+
+func (h *realSigningTestHarness) setupMockRoundStoreForCommit() {
+	h.t.Helper()
+
+	h.roundStore.On(
+		"CommitState", mock.Anything, mock.Anything, mock.Anything,
+	).Return(nil)
+}
+
+// newTestBoardingIntentWithTapscript creates a boarding intent with real
+// collaborative/unilateral spend paths for proper VTXO spending tests.
+//
+//nolint:ll
+func (h *realSigningTestHarness) newTestBoardingIntentWithTapscript() BoardingIntent {
+	h.t.Helper()
+
+	outpoint := h.newTestOutpoint()
+
+	// Create the VTXO tapscript with collaborative and timeout paths.
+	tapscript, err := scripts.VTXOTapScript(
+		h.clientPubKey, h.operatorPubKey, testExitDelay,
+	)
+	require.NoError(h.t, err)
+
+	// Derive the taproot output key from the tapscript.
+	taprootKey, err := tapscript.TaprootKey()
+	require.NoError(h.t, err)
+
+	// Create the bech32m address from the taproot key.
+	addr, err := btcutil.NewAddressTaproot(
+		schnorr.SerializePubKey(taprootKey), &chaincfg.MainNetParams,
+	)
+	require.NoError(h.t, err)
+
+	// Create signing key descriptor matching the boarding address.
+	signingKey := keychain.KeyDescriptor{
+		PubKey: h.clientPubKey,
+		KeyLocator: keychain.KeyLocator{
+			Family: keychain.KeyFamilyMultiSig,
+			Index:  0,
+		},
+	}
+
+	// Build the complete boarding address with Tapscript.
+	boardingAddr := wallet.BoardingAddress{
+		Address:     addr,
+		Tapscript:   tapscript,
+		KeyDesc:     signingKey,
+		OperatorKey: h.operatorPubKey,
+		ExitDelay:   testExitDelay,
+	}
+
+	// Create the P2TR pkScript for the VTXO template output.
+	pkScript, err := txscript.PayToTaprootScript(h.clientPubKey)
+	require.NoError(h.t, err)
+
+	return BoardingIntent{
+		BoardingIntent: wallet.BoardingIntent{
+			Address:  boardingAddr,
+			Outpoint: outpoint,
+			ChainInfo: wallet.BoardingChainInfo{
+				ConfHeight: 100,
+				OutPoint:   outpoint,
+				Amount:     btcutil.Amount(50000),
+			},
+			Status: wallet.BoardingStatusConfirmed,
+		},
+		BoardingRequest: types.BoardingRequest{
+			Outpoint:    &outpoint,
+			ClientKey:   h.clientPubKey,
+			OperatorKey: h.operatorPubKey,
+		},
+		VtxoTemplate: []types.VTXORequest{
+			{
+				Amount:      50000,
+				PkScript:    pkScript,
+				Expiry:      testExitDelay,
+				ClientKey:   h.clientPubKey,
+				OperatorKey: h.operatorPubKey,
+				SigningKey:  signingKey,
+			},
+		},
+	}
+}
+
+// newCommitmentTxForIntents builds a commitment TX with inputs from boarding
+// intents in the exact order needed for boardingInputIndices mapping. Returns
+// a PSBT with WitnessUtxo populated for all inputs.
+func (h *realSigningTestHarness) newCommitmentTxForIntents(
+	intents []BoardingIntent, vtxtTree *tree.Tree) *psbt.Packet {
+
+	h.t.Helper()
+
+	tx := wire.NewMsgTx(3)
+
+	// Add inputs from intents in order.
+	for _, intent := range intents {
+		tx.AddTxIn(&wire.TxIn{
+			PreviousOutPoint: intent.Outpoint,
+		})
+	}
+
+	// Add batch output matching tree.
+	tx.AddTxOut(vtxtTree.BatchOutput)
+
+	// Add ephemeral anchor (BIP 431).
+	tx.AddTxOut(&wire.TxOut{
+		Value:    0,
+		PkScript: []byte{txscript.OP_TRUE, txscript.OP_RETURN},
+	})
+
+	// Create PSBT with WitnessUtxo for each input.
+	packet, err := psbt.NewFromUnsignedTx(tx)
+	require.NoError(h.t, err)
+
+	for i, intent := range intents {
+		addr := intent.Address.Address
+		pkScript := addr.ScriptAddress()
+		amt := intent.ChainInfo.Amount
+
+		packet.Inputs[i] = psbt.PInput{
+			WitnessUtxo: &wire.TxOut{
+				Value:    int64(amt),
+				PkScript: pkScript,
+			},
+		}
+	}
+
+	return packet
+}
+
+// generateValidTreeSignatures creates valid Schnorr signatures for nodes.
+//
+// This is a simplified implementation for testing. In production, signatures
+// are generated by a coordinator (server) that combines client + operator
+// partials. For tests, we simulate this by:
+//
+// 1. Creating manual MuSig2 sessions for each tree node.
+// 2. Going through the full nonce exchange and signing protocol.
+// 3. Combining partials to produce final Schnorr signatures.
+func (h *realSigningTestHarness) generateValidTreeSignatures(
+	vtxtTree *tree.Tree) (map[chainhash.Hash][]byte, error) {
+
+	h.t.Helper()
+
+	sweepRoot := vtxtTree.SweepTapscriptRoot
+
+	// Collect all nodes with their txids and sighashes.
+	type nodeInfo struct {
+		txid    chainhash.Hash
+		sigHash [32]byte
+	}
+	var nodes []nodeInfo
+
+	fetcher, err := vtxtTree.Root.PrevOutputFetcher(vtxtTree.BatchOutput)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to create prev output fetcher: %w", err,
+		)
+	}
+
+	err = vtxtTree.Root.ForEach(func(node *tree.Node) error {
+		tx, txErr := node.ToTx()
+		if txErr != nil {
+			return txErr
+		}
+
+		sigHash, sigErr := computeTreeNodeSigHash(node, tx, fetcher)
+		if sigErr != nil {
+			return sigErr
+		}
+
+		nodes = append(nodes, nodeInfo{
+			txid:    tx.TxHash(),
+			sigHash: sigHash,
+		})
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to collect node info: %w", err)
+	}
+
+	// Reset signers for fresh sessions.
+	h.clientSigner = newRealMuSig2Signer(h.clientPrivKey)
+	h.operatorSigner = newRealMuSig2Signer(h.operatorPrivKey)
+
+	// Process each node and build a map of signatures by txid.
+	finalSigs := make(map[chainhash.Hash][]byte, len(nodes))
+	for _, ni := range nodes {
+		sig, sigErr := h.generateSignatureForNode(
+			ni.sigHash, sweepRoot,
+		)
+		if sigErr != nil {
+			return nil, fmt.Errorf("failed to sign node %s: %w",
+				ni.txid, sigErr)
+		}
+		finalSigs[ni.txid] = sig.Serialize()
+	}
+
+	return finalSigs, nil
+}
+
+// generateSignatureForNode creates a complete MuSig2 signature for a single
+// tree node by going through the full 2-party signing protocol.
+func (h *realSigningTestHarness) generateSignatureForNode(
+	sigHash [32]byte, sweepRoot []byte) (*schnorr.Signature, error) {
+
+	cosigners := []*btcec.PublicKey{h.clientPubKey, h.operatorPubKey}
+
+	// Generate nonces upfront for both parties.
+	clientNonces, err := musig2.GenNonces(
+		musig2.WithPublicKey(h.clientPrivKey.PubKey()),
+		musig2.WithNonceSecretKeyAux(h.clientPrivKey),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("client gen nonces: %w", err)
+	}
+
+	operatorNonces, err := musig2.GenNonces(
+		musig2.WithPublicKey(h.operatorPrivKey.PubKey()),
+		musig2.WithNonceSecretKeyAux(h.operatorPrivKey),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("operator gen nonces: %w", err)
+	}
+
+	// Create context options for both parties.
+	ctxOpts := []musig2.ContextOption{
+		musig2.WithKnownSigners(cosigners),
+	}
+	if len(sweepRoot) > 0 {
+		ctxOpts = append(ctxOpts, musig2.WithTaprootTweakCtx(sweepRoot))
+	}
+
+	// Create contexts for both parties.
+	clientCtx, err := musig2.NewContext(h.clientPrivKey, true, ctxOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("client context: %w", err)
+	}
+
+	operatorCtx, err := musig2.NewContext(
+		h.operatorPrivKey, true, ctxOpts...,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("operator context: %w", err)
+	}
+
+	// Create sessions with pre-generated nonces.
+	clientSession, err := clientCtx.NewSession(
+		musig2.WithPreGeneratedNonce(clientNonces),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("client session: %w", err)
+	}
+
+	operatorSession, err := operatorCtx.NewSession(
+		musig2.WithPreGeneratedNonce(operatorNonces),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("operator session: %w", err)
+	}
+
+	// Exchange and register nonces.
+	haveAll, err := clientSession.RegisterPubNonce(operatorNonces.PubNonce)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"client register operator nonce: %w", err,
+		)
+	}
+	if !haveAll {
+		return nil, fmt.Errorf(
+			"client missing nonces after registration",
+		)
+	}
+
+	haveAll, err = operatorSession.RegisterPubNonce(clientNonces.PubNonce)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"operator register client nonce: %w", err,
+		)
+	}
+	if !haveAll {
+		return nil, fmt.Errorf(
+			"operator missing nonces after registration",
+		)
+	}
+
+	// Both parties sign the same message.
+	clientPartial, err := clientSession.Sign(sigHash)
+	if err != nil {
+		return nil, fmt.Errorf("client sign: %w", err)
+	}
+
+	operatorPartial, err := operatorSession.Sign(sigHash)
+	if err != nil {
+		return nil, fmt.Errorf("operator sign: %w", err)
+	}
+
+	// Combine partial signatures on client side.
+	// After Sign(), the client's own partial is already combined.
+	haveAll, err = clientSession.CombineSig(operatorPartial)
+	if err != nil {
+		return nil, fmt.Errorf("combine operator partial: %w", err)
+	}
+	if !haveAll {
+		return nil, fmt.Errorf(
+			"incomplete after combining operator partial",
+		)
+	}
+
+	finalSig := clientSession.FinalSig()
+	if finalSig == nil {
+		// Try combining on operator side instead.
+		haveAll, err = operatorSession.CombineSig(clientPartial)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"combine client partial: %w", err,
+			)
+		}
+		if !haveAll {
+			return nil, fmt.Errorf(
+				"incomplete after combining client partial",
+			)
+		}
+		finalSig = operatorSession.FinalSig()
+	}
+
+	if finalSig == nil {
+		return nil, fmt.Errorf("final signature is invalid")
+	}
+
+	return finalSig, nil
+}
+
+// computeTreeNodeSigHash computes the Taproot signature hash for a tree node.
+func computeTreeNodeSigHash(node *tree.Node, tx *wire.MsgTx,
+	fetcher txscript.PrevOutputFetcher) ([32]byte, error) {
+
+	sigHashes := txscript.NewTxSigHashes(tx, fetcher)
+
+	hashBytes, err := txscript.CalcTaprootSignatureHash(
+		sigHashes, txscript.SigHashDefault, tx, 0, fetcher,
+	)
+	if err != nil {
+		return [32]byte{}, err
+	}
+
+	var result [32]byte
+	copy(result[:], hashBytes)
+
+	return result, nil
+}

--- a/round/interfaces.go
+++ b/round/interfaces.go
@@ -1,0 +1,268 @@
+package round
+
+import (
+	"context"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/baselib/protofsm"
+	"github.com/lightninglabs/darepo-client/lib/tree"
+	"github.com/lightninglabs/darepo-client/lib/types"
+	"github.com/lightninglabs/darepo-client/wallet"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/keychain"
+)
+
+// ClientStateTransition is a type alias for the verbose protofsm.StateTransition
+// type used throughout the client round FSM. The baselib protofsm uses 3
+// type parameters: InternalEvent, OutboxEvent, and Env. In our case:
+//   - InternalEvent = ClientEvent (events that drive the FSM).
+//   - OutboxEvent = ClientOutMsg (outbox messages emitted by transitions).
+//   - Env = *ClientEnvironment.
+//
+//nolint:ll
+type ClientStateTransition = protofsm.StateTransition[
+	ClientEvent, ClientOutMsg, *ClientEnvironment,
+]
+
+// ClientEmittedEvent is a type alias for the verbose protofsm.EmittedEvent type
+// used when state transitions emit new events or outbox messages.
+type ClientEmittedEvent = protofsm.EmittedEvent[ClientEvent, ClientOutMsg]
+
+// ClientStateMachine is a type alias for the client round FSM.
+type ClientStateMachine = protofsm.StateMachine[
+	ClientEvent, ClientOutMsg, *ClientEnvironment,
+]
+
+// ClientStateMachineCfg is a type alias for the client FSM configuration.
+type ClientStateMachineCfg = protofsm.StateMachineCfg[
+	ClientEvent, ClientOutMsg, *ClientEnvironment,
+]
+
+// Musig2PubNonce is an alias for the MuSig2 public nonce type from lib.
+type Musig2PubNonce = tree.Musig2PubNonce
+
+// RoundID is a type alias for round identifiers.
+type RoundID = string
+
+// SignerKey is the 33-byte compressed public key used to identify a signer
+// in MuSig2 sessions and client tree mappings.
+type SignerKey = [33]byte
+
+// NewSignerKey creates a SignerKey from a public key.
+func NewSignerKey(pk *btcec.PublicKey) SignerKey {
+	var key SignerKey
+	copy(key[:], pk.SerializeCompressed())
+	return key
+}
+
+// Type aliases for wallet types. The wallet package owns the canonical
+// definitions of boarding-related types. These aliases allow round package
+// code to use the types without import clutter.
+type (
+	// BoardingAddress is a type alias for wallet.BoardingAddress. The
+	// wallet package owns the canonical definition of boarding addresses
+	// including the tapscript, keys, and exit delay. The round package
+	// uses this type directly without extension.
+	BoardingAddress = wallet.BoardingAddress
+
+	// BoardingChainInfo tracks the chain related information for a given
+	// boarding intent.
+	BoardingChainInfo = wallet.BoardingChainInfo
+
+	// WalletBoardingIntent is the wallet's boarding intent type.
+	WalletBoardingIntent = wallet.BoardingIntent
+)
+
+// BoardingStatus type alias and constants from wallet package. The wallet
+// owns the lifecycle of boarding intents; round just reacts to confirmations.
+type BoardingStatus = wallet.BoardingStatus
+
+const (
+	// BoardingStatusConfirmed indicates that the boarding UTXO has reached
+	// the required number of confirmations and is ready to be included in a
+	// round registration.
+	BoardingStatusConfirmed = wallet.BoardingStatusConfirmed
+
+	// BoardingStatusAdopted indicates that the boarding intent has been
+	// included in a round that has been frozen/finalized on disk (round
+	// checkpoint saved). The intent can no longer be used in other rounds.
+	BoardingStatusAdopted = wallet.BoardingStatusAdopted
+
+	// BoardingStatusFailed indicates that the boarding process failed for
+	// this intent. This could be due to validation errors, server
+	// rejection, or timeout. Recovery may be possible via CSV timeout path.
+	BoardingStatusFailed = wallet.BoardingStatusFailed
+
+	// BoardingStatusExpired indicates that the boarding UTXO's CSV timeout
+	// has elapsed. The client can now spend via the unilateral timeout path
+	// to recover funds.
+	BoardingStatusExpired = wallet.BoardingStatusExpired
+
+	// BoardingStatusSwept indicates that the boarding UTXO has been spent
+	// via the CSV timeout path to recover funds.
+	BoardingStatusSwept = wallet.BoardingStatusSwept
+)
+
+// BoardingIntent captures one confirmed boarding input plus its requested VTXO
+// outputs. This type embeds the wallet's BoardingIntent and adds round-specific
+// fields for tracking VTXO templates and round assignment.
+type BoardingIntent struct {
+	// Embed wallet's BoardingIntent which contains the core boarding data:
+	// Address, Outpoint, ChainInfo, and Status.
+	wallet.BoardingIntent
+
+	// BoardingRequest is the original boarding request details. It targets
+	// a boarding address by outpoint and includes additional metadata.
+	BoardingRequest types.BoardingRequest
+
+	// VtxoTemplate is the template for the VTXO(s) requested as part of
+	// boarding.
+	//
+	// TODO(roasbeef): add auxleaf for tap here.
+	VtxoTemplate []types.VTXORequest
+
+	// RoundID is the identifier of the round this intent was assigned to.
+	// None until the client joins a round.
+	RoundID fn.Option[string]
+}
+
+// Round represents a complete Ark round from the client's perspective. A round
+// coordinates one or more actions (boarding, refresh, offboard) that are
+// batched together in a single commitment transaction.
+type Round struct {
+	// RoundID is the unique identifier assigned by the server when the
+	// client joins this round.
+	RoundID string
+
+	// CommitmentTx is the commitment transaction as a PSBT that anchors all
+	// VTXOs. Using PSBT allows storing prevout info for all inputs. None
+	// until the server constructs it.
+	CommitmentTx fn.Option[*psbt.Packet]
+
+	// VTXTTree is the client's extracted sub-tree from the Virtual
+	// Transaction Tree. This contains only the minimal path needed to
+	// reach the client's VTXO leaves, not the full tree. This is ephemeral
+	// and only kept in memory during signing. After confirmation, only
+	// per-VTXO paths are persisted for unilateral exit.
+	VTXTTree fn.Option[*tree.Tree]
+
+	// BoardingIntents contains all boarding intents participating in this
+	// round.
+	BoardingIntents []BoardingIntent
+
+	// Future extensions:
+	// Refreshes []*RefreshIntent
+	// Offboards []*OffboardIntent
+}
+
+// RoundStore provides persistence for round FSM state. Follows the protofsm
+// StateMachineStore pattern where round data and FSM state are persisted
+// atomically to enable restart recovery.
+//
+// Rounds coordinate multiple boarding intents (and future: refreshes,
+// offboards) into a single commitment transaction.
+//
+// At the "point of no return" (after sending partial signatures), the
+// FSM state must be checkpointed to allow recovery if the server
+// broadcasts the commitment transaction.
+type RoundStore interface {
+	// CommitState atomically persists both the round data and FSM state.
+	// This should be called at the "point of no return" when the client
+	// has sent partial signatures and the server may broadcast.
+	//
+	// The round parameter contains the round data (commitment tx, intents,
+	// tree). The state parameter is the current FSM state. Both are
+	// persisted atomically so restart can recover to the exact state.
+	CommitState(ctx context.Context, round *Round, state ClientState) error
+
+	// FetchState retrieves a round and its FSM state by round ID. Returns
+	// (round, state, err). Both round data and FSM state are returned
+	// together to ensure consistency.
+	//
+	// Returns error if round doesn't exist.
+	FetchState(ctx context.Context, roundID string) (
+		*Round, ClientState, error,
+	)
+
+	// LookupRoundByCommitmentTx finds the round associated with a
+	// commitment transaction TXID. Used to route commitment tx
+	// confirmations to the correct round FSM.
+	LookupRoundByCommitmentTx(txid chainhash.Hash) (*Round, error)
+
+	// ListActiveRounds returns all rounds that are in progress (commitment
+	// tx broadcast but not yet confirmed or expired).
+	ListActiveRounds() ([]*Round, error)
+
+	// FinalizeRound marks a round as complete and archives it.
+	FinalizeRound(roundID string, txid chainhash.Hash) error
+}
+
+// ClientVTXO represents a Virtual UTXO owned by the client, including all
+// information needed to spend it either collaboratively (with operator) or
+// unilaterally (after timelock expires).
+type ClientVTXO struct {
+	// Outpoint identifies the VTXO's location in the virtual transaction
+	// tree.
+	Outpoint wire.OutPoint
+
+	// Amount is the value of this VTXO in satoshis.
+	Amount btcutil.Amount
+
+	// PkScript is the output script for this VTXO (taproot with
+	// collaborative and timeout spend paths).
+	PkScript []byte
+
+	// Expiry is the CSV delay for the unilateral exit path.
+	Expiry uint32
+
+	// ClientKey is the client's key descriptor for this VTXO.
+	ClientKey keychain.KeyDescriptor
+
+	// OperatorKey is the operator's public key for collaborative spends.
+	OperatorKey *btcec.PublicKey
+
+	// TreePath is the extracted path from the commitment transaction output
+	// down to this specific VTXO. Contains only the minimal tree nodes
+	// needed for unilateral exit (extracted via ExtractPathForCosigner).
+	TreePath *tree.Tree
+
+	// RoundID identifies which round created this VTXO. Empty if the VTXO
+	// is being used in a context where the round is not yet known (e.g.,
+	// during FSM state transitions before persistence).
+	RoundID fn.Option[RoundID]
+}
+
+// VTXOStore defines the storage interface for off-chain balance management.
+// VTXOs (Virtual Transaction Outputs) are created when rounds complete
+// successfully and represent the client's off-chain balance.
+type VTXOStore interface {
+	// SaveVTXOs persists one or more VTXOs after a round confirms. Each
+	// VTXO includes its extracted tree path for unilateral exit.
+	SaveVTXOs(vtxos []*ClientVTXO) error
+
+	// ListVTXOs returns all VTXOs currently owned by the client.
+	ListVTXOs() ([]*ClientVTXO, error)
+
+	// GetVTXO retrieves a specific VTXO by its outpoint. Returns an error
+	// if not found.
+	GetVTXO(outpoint wire.OutPoint) (*ClientVTXO, error)
+
+	// MarkVTXOSpent marks a VTXO as spent (either via OOR transaction or
+	// forfeit). This prevents double-spending.
+	MarkVTXOSpent(outpoint wire.OutPoint) error
+}
+
+// ClientWallet defines the interface for client wallet operations used by the
+// round actor. This provides MuSig2 signing capabilities needed for round
+// participation. Boarding address creation is handled by the wallet actor.
+//
+// NOTE: input.Signer already embeds input.MuSig2Signer, so we only need to
+// embed Signer here.
+type ClientWallet interface {
+	input.Signer
+}

--- a/round/outbox_messages.go
+++ b/round/outbox_messages.go
@@ -178,3 +178,27 @@ type RoundCheckpointedNotification struct {
 }
 
 func (m *RoundCheckpointedNotification) clientOutMsgSealed() {}
+
+// RoundFailedNotification is emitted when a round FSM transitions to
+// ClientFailedState. This notifies higher layers (actor, wallet) of the
+// failure so they can update UI, trigger recovery flows, or clean up
+// resources. The server may also be notified to abort the round.
+type RoundFailedNotification struct {
+	actor.BaseMessage
+
+	// RoundID identifies the failed round (if known). Empty if the failure
+	// occurred before a round was assigned.
+	RoundID string
+
+	// Reason is a human-readable description of the failure.
+	Reason string
+
+	// Recoverable indicates if the client can retry the round or if CSV
+	// recovery is needed.
+	Recoverable bool
+
+	// OriginalError contains the underlying error for logging/debugging.
+	OriginalError error
+}
+
+func (m *RoundFailedNotification) clientOutMsgSealed() {}

--- a/round/outbox_messages.go
+++ b/round/outbox_messages.go
@@ -1,0 +1,180 @@
+package round
+
+import (
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/lib/types"
+	"google.golang.org/protobuf/proto"
+)
+
+// JoinRoundRequest is sent from client to server to request joining a round.
+// This implements ClientEvent and is emitted via Outbox.
+type JoinRoundRequest struct {
+	actor.BaseMessage
+
+	// BoardingRequests contains all boarding UTXO details for this
+	// session. Each confirmed intent contributes exactly one boarding
+	// request so the server can register them in a single batch.
+	BoardingRequests []types.BoardingRequest
+
+	// VTXORequests specifies the VTXOs the client wants to receive.
+	VTXORequests []types.VTXORequest
+}
+
+func (m *JoinRoundRequest) clientOutMsgSealed() {}
+
+// SubmitNoncesRequest is sent from client to server with MuSig2 nonces.
+// This implements ClientOutMsg and is emitted via Outbox.
+type SubmitNoncesRequest struct {
+	actor.BaseMessage
+
+	// RoundID identifies the round.
+	RoundID string
+
+	// Nonces maps transaction IDs to signing keys to their MuSig2 public
+	// nonces. The outer map is keyed by transaction ID, and the inner map
+	// is keyed by signing key. Each signing key (VTXO) contributes its own
+	// nonce for each transaction in its path.
+	Nonces map[chainhash.Hash]map[SignerKey][]byte
+}
+
+func (m *SubmitNoncesRequest) clientOutMsgSealed() {}
+
+// SubmitPartialSigRequest is sent from client to server with partial
+// signatures. This implements ClientEvent and is emitted via Outbox.
+type SubmitPartialSigRequest struct {
+	actor.BaseMessage
+
+	// RoundID identifies the round.
+	RoundID string
+
+	// PartialSigs maps transaction IDs to their MuSig2 partial signatures.
+	// Each entry corresponds to a transaction in the client's VTXT path.
+	PartialSigs map[chainhash.Hash][]byte
+}
+
+func (m *SubmitPartialSigRequest) clientOutMsgSealed() {}
+
+// SubmitForfeitSigRequest is sent from client to server with the boarding input
+// signature. This implements ClientEvent and is emitted via Outbox.
+type SubmitForfeitSigRequest struct {
+	actor.BaseMessage
+
+	// RoundID identifies the round.
+	RoundID string
+
+	// ForfeitSigs contains the signature for the boarding UTXO input in the
+	// commitment transaction.
+	ForfeitSigs [][]byte
+}
+
+func (m *SubmitForfeitSigRequest) clientOutMsgSealed() {}
+
+// ToProto converts JoinRoundRequest to a protobuf message.
+// TODO: Implement actual proto conversion once proto definitions are available.
+func (m *JoinRoundRequest) ToProto() proto.Message {
+	// Placeholder: return nil for now. This will be replaced with actual
+	// proto message construction:
+	// return &pb.JoinRoundRequest{...}
+	return nil
+}
+
+// ToProto converts SubmitNoncesRequest to a protobuf message.
+// TODO: Implement actual proto conversion once proto definitions are available.
+func (m *SubmitNoncesRequest) ToProto() proto.Message {
+	// Placeholder: return nil for now. This will be replaced with actual
+	// proto message construction:
+	// return &pb.SubmitNoncesRequest{...}
+	return nil
+}
+
+// ToProto converts SubmitPartialSigRequest to a protobuf message.
+// TODO: Implement actual proto conversion once proto definitions are available.
+func (m *SubmitPartialSigRequest) ToProto() proto.Message {
+	// Placeholder: return nil for now. This will be replaced with actual
+	// proto message construction:
+	// return &pb.SubmitPartialSigRequest{...}
+	return nil
+}
+
+// ToProto converts SubmitForfeitSigRequest to a protobuf message.
+// TODO: Implement actual proto conversion once proto definitions are available.
+func (m *SubmitForfeitSigRequest) ToProto() proto.Message {
+	// Placeholder: return nil for now. This will be replaced with actual
+	// proto message construction:
+	// return &pb.SubmitForfeitSigRequest{...}
+	return nil
+}
+
+// RegisterConfirmationRequest is emitted by the FSM to request chain monitoring
+// for a transaction. The actor will complete this message with the NotifyActor
+// field before sending to ChainSource.
+//
+// This implements ClientEvent so it can be emitted via Outbox. The actor will
+// convert this to a chainsource.RegisterConfRequest and add the NotifyActor
+// field pointing to itself.
+type RegisterConfirmationRequest struct {
+	actor.BaseMessage
+
+	// CallerID is a unique identifier for this monitoring request. This is
+	// used by ChainSource to construct the service key for the dedicated
+	// confirmation actor.
+	CallerID string
+
+	// PkScript is the public key script to monitor.
+	PkScript []byte
+
+	// Txid is optional and, if set, instructs the monitoring backend to
+	// watch for confirmations of the specific transaction.
+	Txid *chainhash.Hash
+
+	// TargetConfs is the number of confirmations to wait for.
+	TargetConfs uint32
+
+	// HeightHint is an optional height hint indicating the earliest block
+	// that could contain the transaction. Set to 0 if unknown.
+	HeightHint uint32
+}
+
+func (m *RegisterConfirmationRequest) clientOutMsgSealed() {}
+
+// VTXOCreatedNotification notifies higher layers (wallet) that new VTXOs are
+// available after successful boarding. This is emitted once the commitment
+// transaction confirms and includes the full descriptors (with tree paths) so
+// the wallet can resume or unroll on-chain if needed.
+type VTXOCreatedNotification struct {
+	actor.BaseMessage
+
+	VTXOs []*ClientVTXO
+}
+
+func (m *VTXOCreatedNotification) clientOutMsgSealed() {}
+
+// RoundCompletedNotification is emitted when a round FSM reaches ConfirmedState
+// which signals the actor to perform cleanup (remove from activeRounds,
+// finalize storage). This replaces the need for manual state inspection via
+// checkRoundCompletion().
+type RoundCompletedNotification struct {
+	actor.BaseMessage
+
+	// RoundID identifies the completed round.
+	RoundID string
+
+	// TxID is the confirmed commitment transaction ID.
+	TxID chainhash.Hash
+}
+
+func (m *RoundCompletedNotification) clientOutMsgSealed() {}
+
+// RoundCheckpointedNotification is emitted by the primary FSM when it reaches
+// InputSigSentState. This signals that a round has been checkpointed to
+// storage and should be migrated to a dedicated round FSM. This replaces the
+// need for manual state inspection via checkPrimaryFSMForNewRound().
+type RoundCheckpointedNotification struct {
+	actor.BaseMessage
+
+	// RoundID identifies the checkpointed round to migrate.
+	RoundID string
+}
+
+func (m *RoundCheckpointedNotification) clientOutMsgSealed() {}

--- a/round/outbox_messages_test.go
+++ b/round/outbox_messages_test.go
@@ -147,4 +147,15 @@ func TestOutboxMessagesClientOutMsgSealed(t *testing.T) {
 		}
 		msg.clientOutMsgSealed()
 	})
+
+	t.Run("RoundFailedNotification", func(t *testing.T) {
+		t.Parallel()
+		msg := &RoundFailedNotification{
+			RoundID:       "round-001",
+			Reason:        "validation failed",
+			Recoverable:   true,
+			OriginalError: nil,
+		}
+		msg.clientOutMsgSealed()
+	})
 }

--- a/round/outbox_messages_test.go
+++ b/round/outbox_messages_test.go
@@ -1,0 +1,150 @@
+package round
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightninglabs/darepo-client/lib/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOutboxMessagesToProto ensures that ToProto() methods compile and return
+// the expected nil placeholders. These placeholders will be replaced with
+// actual proto marshaling once the proto definitions are finalized, but this
+// test prevents accidental breakage of the interface contract in the meantime.
+func TestOutboxMessagesToProto(t *testing.T) {
+	t.Parallel()
+
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	pubKey := privKey.PubKey()
+
+	t.Run("JoinRoundRequest_ToProto", func(t *testing.T) {
+		t.Parallel()
+
+		msg := &JoinRoundRequest{
+			BoardingRequests: []types.BoardingRequest{
+				{ClientKey: pubKey, OperatorKey: pubKey},
+			},
+			VTXORequests: []types.VTXORequest{},
+		}
+
+		result := msg.ToProto()
+		require.Nil(t, result)
+	})
+
+	t.Run("SubmitNoncesRequest_ToProto", func(t *testing.T) {
+		t.Parallel()
+
+		txid := chainhash.HashH([]byte("test-tx"))
+		signerKey := NewSignerKey(pubKey)
+		msg := &SubmitNoncesRequest{
+			RoundID: "round-001",
+			Nonces: map[chainhash.Hash]map[SignerKey][]byte{
+				txid: {
+					signerKey: {0x01, 0x02},
+				},
+			},
+		}
+
+		result := msg.ToProto()
+		require.Nil(t, result)
+	})
+
+	t.Run("SubmitPartialSigRequest_ToProto", func(t *testing.T) {
+		t.Parallel()
+
+		fakeTxid := chainhash.HashH([]byte("test-tx"))
+		msg := &SubmitPartialSigRequest{
+			RoundID: "round-001",
+			PartialSigs: map[chainhash.Hash][]byte{
+				fakeTxid: {0x01, 0x02},
+			},
+		}
+
+		result := msg.ToProto()
+		require.Nil(t, result)
+	})
+
+	t.Run("SubmitForfeitSigRequest_ToProto", func(t *testing.T) {
+		t.Parallel()
+
+		msg := &SubmitForfeitSigRequest{
+			RoundID:     "round-001",
+			ForfeitSigs: [][]byte{{0xaa, 0xbb}},
+		}
+
+		result := msg.ToProto()
+		require.Nil(t, result)
+	})
+}
+
+// TestOutboxMessagesClientOutMsgSealed ensures that all outbox message types
+// implement the ClientOutMsg sealed interface. The clientOutMsgSealed() method
+// acts as a compile-time marker preventing external types from implementing
+// ClientOutMsg, so this test verifies the marker exists on all expected types.
+func TestOutboxMessagesClientOutMsgSealed(t *testing.T) {
+	t.Parallel()
+
+	txid := chainhash.HashH([]byte("test-txid"))
+
+	t.Run("JoinRoundRequest", func(t *testing.T) {
+		t.Parallel()
+		msg := &JoinRoundRequest{}
+		msg.clientOutMsgSealed()
+	})
+
+	t.Run("SubmitNoncesRequest", func(t *testing.T) {
+		t.Parallel()
+		msg := &SubmitNoncesRequest{RoundID: "round-001"}
+		msg.clientOutMsgSealed()
+	})
+
+	t.Run("SubmitPartialSigRequest", func(t *testing.T) {
+		t.Parallel()
+		msg := &SubmitPartialSigRequest{RoundID: "round-001"}
+		msg.clientOutMsgSealed()
+	})
+
+	t.Run("SubmitForfeitSigRequest", func(t *testing.T) {
+		t.Parallel()
+		msg := &SubmitForfeitSigRequest{RoundID: "round-001"}
+		msg.clientOutMsgSealed()
+	})
+
+	t.Run("RegisterConfirmationRequest", func(t *testing.T) {
+		t.Parallel()
+		msg := &RegisterConfirmationRequest{
+			CallerID:    "caller-001",
+			PkScript:    []byte{0x00, 0x14},
+			TargetConfs: 6,
+		}
+		msg.clientOutMsgSealed()
+	})
+
+	t.Run("VTXOCreatedNotification", func(t *testing.T) {
+		t.Parallel()
+		msg := &VTXOCreatedNotification{
+			VTXOs: []*ClientVTXO{},
+		}
+		msg.clientOutMsgSealed()
+	})
+
+	t.Run("RoundCompletedNotification", func(t *testing.T) {
+		t.Parallel()
+		msg := &RoundCompletedNotification{
+			RoundID: "round-001",
+			TxID:    txid,
+		}
+		msg.clientOutMsgSealed()
+	})
+
+	t.Run("RoundCheckpointedNotification", func(t *testing.T) {
+		t.Parallel()
+		msg := &RoundCheckpointedNotification{
+			RoundID: "round-001",
+		}
+		msg.clientOutMsgSealed()
+	})
+}

--- a/round/states.go
+++ b/round/states.go
@@ -1,0 +1,391 @@
+package round
+
+import (
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/baselib/protofsm"
+	"github.com/lightninglabs/darepo-client/lib/tree"
+)
+
+// ClientState is a sealed interface for all states in the client round
+// interaction state machine. Each state implements ProcessEvent to handle
+// events and transition to the next state. This FSM handles the client's
+// participation in Ark rounds, including boarding, refresh, and offboard
+// operations.
+//
+// The baselib protofsm.State interface has 3 type parameters:
+//   - InternalEvent = ClientEvent.
+//   - OutboxEvent = ClientOutMsg.
+//   - Env = *ClientEnvironment.
+type ClientState interface {
+	protofsm.State[ClientEvent, ClientOutMsg, *ClientEnvironment]
+
+	// clientStateSealed is an unexported method that marks this interface
+	// as sealed, preventing external implementations.
+	clientStateSealed()
+}
+
+// Idle is the initial state. No active boarding process is running.
+type Idle struct{}
+
+func (s *Idle) String() string {
+	return "Idle"
+}
+
+func (s *Idle) IsTerminal() bool {
+	return false
+}
+
+func (s *Idle) clientStateSealed() {}
+
+// PendingRoundAssembly tracks all active boarding intents that have been
+// funded on-chain but not yet fully confirmed. Intents are keyed by their
+// on-chain outpoint for efficient lookup when confirmation events arrive. Once
+// all intents reach the required confirmations, the FSM transitions to round
+// registration.
+type PendingRoundAssembly struct {
+	// Intents maps outpoint to boarding intent. Only intents with on-chain
+	// UTXOs (i.e., ChainInfo.OutPoint set) are included in this map.
+	Intents map[wire.OutPoint]BoardingIntent
+}
+
+func (s *PendingRoundAssembly) String() string {
+	return "BoardingIntents"
+}
+
+func (s *PendingRoundAssembly) IsTerminal() bool {
+	return false
+}
+
+func (s *PendingRoundAssembly) clientStateSealed() {}
+
+// RegistrationSentState indicates the client has sent a JoinRoundRequest
+// to the server and is waiting for confirmation.
+type RegistrationSentState struct {
+	// Intents contains all boarding intents being registered in this round.
+	Intents []BoardingIntent
+}
+
+func (s *RegistrationSentState) String() string {
+	return "RegistrationSent"
+}
+
+func (s *RegistrationSentState) IsTerminal() bool {
+	return false
+}
+
+func (s *RegistrationSentState) clientStateSealed() {}
+
+// RoundJoinedState indicates the client has been accepted into a round and
+// is waiting for the commitment transaction.
+type RoundJoinedState struct {
+	// RoundID is the unique identifier assigned by the server for this
+	// round.
+	RoundID string
+
+	// Intents contains all boarding intents participating in this round.
+	Intents []BoardingIntent
+}
+
+func (s *RoundJoinedState) String() string {
+	return "RoundJoined"
+}
+
+func (s *RoundJoinedState) IsTerminal() bool {
+	return false
+}
+
+func (s *RoundJoinedState) clientStateSealed() {}
+
+// CommitmentTxReceivedState indicates the client has received the commitment
+// transaction and VTXT and must now validate them before proceeding.
+type CommitmentTxReceivedState struct {
+	// RoundID is the unique identifier for this round.
+	RoundID string
+
+	// CommitmentTx is the unsigned commitment transaction as a PSBT.
+	CommitmentTx *psbt.Packet
+
+	// TxID is the transaction ID of the commitment transaction.
+	TxID chainhash.Hash
+
+	// VTXTTree is the virtual transaction tree for this round.
+	VTXTTree *tree.Tree
+
+	// Intents contains all boarding intents participating in this round.
+	Intents []BoardingIntent
+
+	// ClientTrees maps signer keys (compressed pubkeys) to the client's
+	// extracted sub-tree for that VTXO.
+	ClientTrees map[SignerKey]*tree.Tree
+}
+
+func (s *CommitmentTxReceivedState) String() string {
+	return "CommitmentTxReceived"
+}
+
+func (s *CommitmentTxReceivedState) IsTerminal() bool {
+	return false
+}
+
+func (s *CommitmentTxReceivedState) clientStateSealed() {}
+
+// CommitmentTxValidatedState indicates the client has validated the VTXT
+// and is ready to participate in MuSig2 signing.
+type CommitmentTxValidatedState struct {
+	// RoundID is the unique identifier for this round.
+	RoundID string
+
+	// CommitmentTx is the unsigned commitment transaction as a PSBT.
+	CommitmentTx *psbt.Packet
+
+	// VTXTTree is the virtual transaction tree for this round.
+	VTXTTree *tree.Tree
+
+	// Intents contains all boarding intents participating in this round.
+	Intents []BoardingIntent
+
+	// ClientTrees maps signer keys (compressed pubkeys) to the client's
+	// extracted sub-tree for that VTXO.
+	ClientTrees map[SignerKey]*tree.Tree
+
+	// BoardingInputIndices maps each boarding intent's outpoint to its
+	// position in the commitment transaction inputs. Used for signing.
+	BoardingInputIndices map[wire.OutPoint]int
+}
+
+func (s *CommitmentTxValidatedState) String() string {
+	return "CommitmentTxValidated"
+}
+
+func (s *CommitmentTxValidatedState) IsTerminal() bool {
+	return false
+}
+
+func (s *CommitmentTxValidatedState) clientStateSealed() {}
+
+// NoncesSentState indicates the client has sent nonces to the server and
+// is waiting for aggregated nonces.
+type NoncesSentState struct {
+	// RoundID is the unique identifier for this round.
+	RoundID string
+
+	// CommitmentTx is the unsigned commitment transaction as a PSBT.
+	CommitmentTx *psbt.Packet
+
+	// VTXTTree is the virtual transaction tree for this round.
+	VTXTTree *tree.Tree
+
+	// Intents contains all boarding intents participating in this round.
+	Intents []BoardingIntent
+
+	// ClientTrees maps signer keys (compressed pubkeys) to the client's
+	// extracted sub-tree for that VTXO.
+	ClientTrees map[SignerKey]*tree.Tree
+
+	// Musig2Sessions maps signer keys (compressed pubkeys) to the MuSig2
+	// signing session for that VTXO.
+	Musig2Sessions map[SignerKey]*tree.SignerSession
+
+	// BoardingInputIndices maps each boarding intent's outpoint to its
+	// position in the commitment transaction inputs. Used for signing.
+	BoardingInputIndices map[wire.OutPoint]int
+}
+
+func (s *NoncesSentState) String() string {
+	return "NoncesSent"
+}
+
+func (s *NoncesSentState) IsTerminal() bool {
+	return false
+}
+
+func (s *NoncesSentState) clientStateSealed() {}
+
+// NoncesAggregatedState indicates the client has received aggregated nonces
+// and is ready to generate partial signatures.
+type NoncesAggregatedState struct {
+	// RoundID is the unique identifier for this round.
+	RoundID string
+
+	// CommitmentTx is the unsigned commitment transaction as a PSBT.
+	CommitmentTx *psbt.Packet
+
+	// VTXTTree is the virtual transaction tree for this round.
+	VTXTTree *tree.Tree
+
+	// Intents contains all boarding intents participating in this round.
+	Intents []BoardingIntent
+
+	// ClientTrees maps signer keys (compressed pubkeys) to the client's
+	// extracted sub-tree for that VTXO.
+	ClientTrees map[SignerKey]*tree.Tree
+
+	// Musig2Sessions maps signer keys (compressed pubkeys) to the MuSig2
+	// signing session for that VTXO.
+	Musig2Sessions map[SignerKey]*tree.SignerSession
+
+	// AggregatedNonces maps transaction IDs to aggregated MuSig2 nonces.
+	AggregatedNonces map[chainhash.Hash][]byte
+
+	// BoardingInputIndices maps each boarding intent's outpoint to its
+	// position in the commitment transaction inputs. Used for signing.
+	BoardingInputIndices map[wire.OutPoint]int
+}
+
+func (s *NoncesAggregatedState) String() string {
+	return "NoncesAggregated"
+}
+
+func (s *NoncesAggregatedState) IsTerminal() bool {
+	return false
+}
+
+func (s *NoncesAggregatedState) clientStateSealed() {}
+
+// PartialSigsSentState indicates the client has sent partial signatures
+// to the server and is waiting for the complete VTXT signatures.
+type PartialSigsSentState struct {
+	// RoundID is the unique identifier for this round.
+	RoundID string
+
+	// CommitmentTx is the unsigned commitment transaction as a PSBT.
+	CommitmentTx *psbt.Packet
+
+	// VTXTTree is the virtual transaction tree for this round.
+	VTXTTree *tree.Tree
+
+	// Intents contains all boarding intents participating in this round.
+	Intents []BoardingIntent
+
+	// ClientTrees maps signer keys (compressed pubkeys) to the client's
+	// extracted sub-tree for that VTXO.
+	ClientTrees map[SignerKey]*tree.Tree
+
+	// Musig2Sessions maps signer keys (compressed pubkeys) to the MuSig2
+	// signing session for that VTXO.
+	Musig2Sessions map[SignerKey]*tree.SignerSession
+
+	// BoardingInputIndices maps each boarding intent's outpoint to its
+	// position in the commitment transaction inputs. Used for signing.
+	BoardingInputIndices map[wire.OutPoint]int
+}
+
+func (s *PartialSigsSentState) String() string {
+	return "PartialSigsSent"
+}
+
+func (s *PartialSigsSentState) IsTerminal() bool {
+	return false
+}
+
+func (s *PartialSigsSentState) clientStateSealed() {}
+
+// InputSigSentState indicates the client has sent their boarding input
+// signature and is waiting for the commitment tx to be broadcast.
+type InputSigSentState struct {
+	// RoundID is the unique identifier for this round.
+	RoundID string
+
+	// CommitmentTx is the unsigned commitment transaction as a PSBT.
+	CommitmentTx *psbt.Packet
+
+	// VTXTTree is the virtual transaction tree for this round.
+	VTXTTree *tree.Tree
+
+	// Intents contains all boarding intents participating in this round.
+	Intents []BoardingIntent
+
+	// ClientTrees maps signer keys (compressed pubkeys) to the client's
+	// extracted sub-tree for that VTXO.
+	ClientTrees map[SignerKey]*tree.Tree
+
+	// InputSigs are the Schnorr signatures for the boarding inputs.
+	InputSigs [][]byte
+}
+
+func (s *InputSigSentState) String() string {
+	return "InputSigSent"
+}
+
+func (s *InputSigSentState) IsTerminal() bool {
+	return false
+}
+
+func (s *InputSigSentState) clientStateSealed() {}
+
+// ConfirmedState is a terminal state indicating the boarding process has
+// completed successfully. The client now owns VTXOs.
+type ConfirmedState struct {
+	// TxID is the confirmed commitment transaction ID.
+	TxID chainhash.Hash
+
+	// BlockHeight is the height at which the transaction was confirmed.
+	BlockHeight int32
+
+	// Confirmations is the number of confirmations.
+	Confirmations int32
+
+	// VTXOs are the virtual UTXOs created for this client.
+	VTXOs []*ClientVTXO
+}
+
+func (s *ConfirmedState) String() string {
+	return "Confirmed"
+}
+
+func (s *ConfirmedState) IsTerminal() bool {
+	return true
+}
+
+func (s *ConfirmedState) clientStateSealed() {}
+
+// ClientFailedState is a terminal state indicating the boarding process failed.
+// The client may be able to retry or initiate CSV recovery.
+type ClientFailedState struct {
+	// Reason is a human-readable description of the failure.
+	Reason string
+
+	// Error is the underlying error that caused the failure.
+	Error error
+
+	// Recoverable indicates if the client can retry or if CSV recovery is
+	// needed.
+	Recoverable bool
+}
+
+func (s *ClientFailedState) String() string {
+	return fmt.Sprintf("ClientFailed: %s", s.Reason)
+}
+
+func (s *ClientFailedState) IsTerminal() bool {
+	return true
+}
+
+func (s *ClientFailedState) clientStateSealed() {}
+
+// RecoveryInitiatedState is a semi-terminal state where the client is
+// recovering their boarding UTXO via CSV timeout sweep.
+type RecoveryInitiatedState struct {
+	// Outpoint identifies the boarding UTXO being recovered.
+	Outpoint wire.OutPoint
+
+	// SweepTxID is the transaction ID of the sweep transaction.
+	SweepTxID chainhash.Hash
+
+	// Reason explains why recovery was initiated.
+	Reason string
+}
+
+func (s *RecoveryInitiatedState) String() string {
+	return "RecoveryInitiated"
+}
+
+func (s *RecoveryInitiatedState) IsTerminal() bool {
+	return true
+}
+
+func (s *RecoveryInitiatedState) clientStateSealed() {}

--- a/round/states.go
+++ b/round/states.go
@@ -362,7 +362,9 @@ func (s *ClientFailedState) String() string {
 }
 
 func (s *ClientFailedState) IsTerminal() bool {
-	return true
+	// ClientFailedState is NOT terminal - it can recover by accepting the
+	// same events as Idle (BoardingUTXOConfirmed, ResumeBoardingIntents).
+	return false
 }
 
 func (s *ClientFailedState) clientStateSealed() {}

--- a/round/transition_table.go
+++ b/round/transition_table.go
@@ -1,0 +1,281 @@
+package round
+
+import (
+	"github.com/lightninglabs/darepo-client/baselib/protofsm"
+)
+
+// ClientTransitionEntry is a type alias for the round FSM transition entry.
+type ClientTransitionEntry = protofsm.TransitionEntry[
+	ClientState, ClientEvent, ClientOutMsg,
+]
+
+// ClientStateTransitions is a type alias for the round FSM state transitions.
+type ClientStateTransitions = protofsm.StateTransitions[
+	ClientState, ClientEvent, ClientOutMsg,
+]
+
+// ClientTransitionTable is a type alias for the round FSM transition table.
+type ClientTransitionTable = protofsm.TransitionTable[
+	ClientState, ClientEvent, ClientOutMsg,
+]
+
+// BoardingClientTransitions defines all valid state transitions for the
+// client round interaction FSM. This serves as both documentation and a
+// validation target for tests.
+//
+//nolint:ll
+var BoardingClientTransitions = ClientTransitionTable{
+	MachineName: "BoardingClient",
+	States: []ClientStateTransitions{
+		// Idle: Initial state, waiting for boarding intents.
+		{
+			FromState: &Idle{},
+			Transitions: []ClientTransitionEntry{
+				{
+					Event:       &ResumeBoardingIntents{},
+					ToState:     &PendingRoundAssembly{},
+					Description: "Resume monitoring existing intents",
+				},
+				{
+					Event:       &BoardingUTXOConfirmed{},
+					ToState:     &PendingRoundAssembly{},
+					Description: "First UTXO confirmed, start assembly",
+				},
+				{
+					Event:       &BoardingFailed{},
+					ToState:     &ClientFailedState{},
+					Description: "Boarding failed before any progress",
+					IsTerminal:  true,
+				},
+			},
+		},
+
+		// PendingRoundAssembly: Collecting confirmed boarding intents.
+		{
+			FromState: &PendingRoundAssembly{},
+			Transitions: []ClientTransitionEntry{
+				{
+					Event:       &BoardingUTXOConfirmed{},
+					ToState:     &PendingRoundAssembly{},
+					Description: "Additional boarding UTXO confirmed",
+				},
+				{
+					Event:       &RegistrationRequested{},
+					ToState:     &RegistrationSentState{},
+					Description: "Intents confirmed, register with server",
+					EmitsOutbox: []ClientOutMsg{&JoinRoundRequest{}},
+				},
+				{
+					Event:       &BoardingFailed{},
+					ToState:     &ClientFailedState{},
+					Description: "Boarding failed during assembly",
+					IsTerminal:  true,
+				},
+			},
+		},
+
+		// RegistrationSentState: Waiting for server acceptance.
+		{
+			FromState: &RegistrationSentState{},
+			Transitions: []ClientTransitionEntry{
+				{
+					Event:       &RoundJoined{},
+					ToState:     &RoundJoinedState{},
+					Description: "Server accepted registration",
+				},
+				{
+					Event:       &BoardingFailed{},
+					ToState:     &ClientFailedState{},
+					Description: "Server rejected registration",
+					IsTerminal:  true,
+				},
+			},
+		},
+
+		// RoundJoinedState: Waiting for commitment tx from server.
+		{
+			FromState: &RoundJoinedState{},
+			Transitions: []ClientTransitionEntry{
+				{
+					Event:       &CommitmentTxBuilt{},
+					ToState:     &CommitmentTxReceivedState{},
+					Description: "Received commitment tx and VTXT",
+				},
+				{
+					Event:       &BoardingFailed{},
+					ToState:     &ClientFailedState{},
+					Description: "Round failed waiting for commitment",
+					IsTerminal:  true,
+				},
+			},
+		},
+
+		// CommitmentTxReceivedState: Validating commitment tx and VTXT.
+		{
+			FromState: &CommitmentTxReceivedState{},
+			Transitions: []ClientTransitionEntry{
+				{
+					Event:       &CommitmentTxValidated{},
+					ToState:     &CommitmentTxValidatedState{},
+					Description: "Commitment tx and VTXT validated",
+				},
+				{
+					Event:       &BoardingFailed{},
+					ToState:     &ClientFailedState{},
+					Description: "Validation failed",
+					IsTerminal:  true,
+				},
+			},
+		},
+
+		// CommitmentTxValidatedState: Generate and send nonces.
+		{
+			FromState: &CommitmentTxValidatedState{},
+			Transitions: []ClientTransitionEntry{
+				{
+					Event:       &GenerateNonces{},
+					ToState:     &NoncesSentState{},
+					Description: "Generated nonces, sending to server",
+					EmitsOutbox: []ClientOutMsg{
+						&SubmitNoncesRequest{},
+					},
+				},
+				{
+					Event:       &BoardingFailed{},
+					ToState:     &ClientFailedState{},
+					Description: "Nonce generation failed",
+					IsTerminal:  true,
+				},
+			},
+		},
+
+		// NoncesSentState: Waiting for aggregated nonces from server.
+		{
+			FromState: &NoncesSentState{},
+			Transitions: []ClientTransitionEntry{
+				{
+					Event:       &NoncesAggregated{},
+					ToState:     &NoncesAggregatedState{},
+					Description: "Received aggregated nonces",
+				},
+				{
+					Event:       &BoardingFailed{},
+					ToState:     &ClientFailedState{},
+					Description: "Nonce aggregation failed",
+					IsTerminal:  true,
+				},
+			},
+		},
+
+		// NoncesAggregatedState: Generate and send partial signatures.
+		{
+			FromState: &NoncesAggregatedState{},
+			Transitions: []ClientTransitionEntry{
+				{
+					Event:       &GeneratePartialSigs{},
+					ToState:     &PartialSigsSentState{},
+					Description: "Generated partial sigs, sending",
+					EmitsOutbox: []ClientOutMsg{
+						&SubmitPartialSigRequest{},
+					},
+				},
+				{
+					Event:       &BoardingFailed{},
+					ToState:     &ClientFailedState{},
+					Description: "Partial signature generation failed",
+					IsTerminal:  true,
+				},
+			},
+		},
+
+		// PartialSigsSentState: Waiting for operator to sign.
+		{
+			FromState: &PartialSigsSentState{},
+			Transitions: []ClientTransitionEntry{
+				{
+					Event:       &OperatorSigned{},
+					ToState:     &InputSigSentState{},
+					Description: "Received VTXT sigs, sending input sig",
+					EmitsOutbox: []ClientOutMsg{
+						&SubmitForfeitSigRequest{},
+					},
+				},
+				{
+					Event:       &BoardingFailed{},
+					ToState:     &ClientFailedState{},
+					Description: "Operator signing failed",
+					IsTerminal:  true,
+				},
+			},
+		},
+
+		// InputSigSentState: Waiting for commitment tx confirmation.
+		{
+			FromState: &InputSigSentState{},
+			Transitions: []ClientTransitionEntry{
+				{
+					Event:       &BoardingConfirmed{},
+					ToState:     &ConfirmedState{},
+					Description: "Commitment tx confirmed, complete",
+					EmitsOutbox: []ClientOutMsg{
+						&VTXOCreatedNotification{},
+						&RoundCompletedNotification{},
+					},
+					IsTerminal: true,
+				},
+				{
+					Event:       &BoardingFailed{},
+					ToState:     &ClientFailedState{},
+					Description: "Commitment tx failed to confirm",
+					IsTerminal:  true,
+				},
+				{
+					Event:       &RecoveryInitiated{},
+					ToState:     &RecoveryInitiatedState{},
+					Description: "CSV timeout, recovering funds",
+					IsTerminal:  true,
+				},
+			},
+		},
+
+		// ConfirmedState: Terminal success state. On RoundComplete,
+		// transition back to Idle to allow processing new boarding
+		// addresses and intents.
+		{
+			FromState: &ConfirmedState{},
+			Transitions: []ClientTransitionEntry{
+				{
+					Event:       &RoundComplete{},
+					ToState:     &Idle{},
+					Description: "Round complete, return to idle",
+				},
+			},
+		},
+
+		// ClientFailedState: Terminal failure state.
+		{
+			FromState: &ClientFailedState{},
+			Transitions: []ClientTransitionEntry{
+				{
+					Event:       &BoardingFailed{},
+					ToState:     &ClientFailedState{},
+					Description: "Self-loop, already failed",
+					IsTerminal:  true,
+				},
+			},
+		},
+
+		// RecoveryInitiatedState: Terminal recovery state.
+		{
+			FromState: &RecoveryInitiatedState{},
+			Transitions: []ClientTransitionEntry{
+				{
+					Event:       &RecoveryInitiated{},
+					ToState:     &RecoveryInitiatedState{},
+					Description: "Self-loop, recovery in progress",
+					IsTerminal:  true,
+				},
+			},
+		},
+	},
+}

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -34,6 +34,40 @@ func buildBoardingRequest(intent BoardingIntent) types.BoardingRequest {
 	}
 }
 
+// failWithNotification creates a state transition to ClientFailedState and
+// emits a RoundFailedNotification. This is the standard pattern for handling
+// internal errors without returning an error to the FSM (which would halt it).
+func failWithNotification(reason string, err error, recoverable bool,
+	roundID string) *ClientStateTransition {
+
+	return &ClientStateTransition{
+		NextState: &ClientFailedState{
+			Reason:      reason,
+			Error:       err,
+			Recoverable: recoverable,
+		},
+		NewEvents: fn.Some(ClientEmittedEvent{
+			Outbox: []ClientOutMsg{
+				&RoundFailedNotification{
+					RoundID:       roundID,
+					Reason:        reason,
+					Recoverable:   recoverable,
+					OriginalError: err,
+				},
+			},
+		}),
+	}
+}
+
+// selfLoop creates a self-loop transition that stays in the current state
+// without emitting any events. Used for unknown events in non-terminal states
+// to avoid halting the FSM.
+func selfLoop(state ClientState) *ClientStateTransition {
+	return &ClientStateTransition{
+		NextState: state,
+	}
+}
+
 // ProcessEvent handles the events from the Idle state. In this state, we'll
 // receive boarding UTXO confirmations or resume existing boarding flows.
 func (s *Idle) ProcessEvent(_ context.Context, event ClientEvent,
@@ -62,14 +96,23 @@ func (s *Idle) ProcessEvent(_ context.Context, event ClientEvent,
 		// persisted the intent; we just need to create an internal
 		// BoardingIntent and transition to PendingRoundAssembly.
 		if evt.Tx == nil {
-			return nil, fmt.Errorf("confirmation event " +
-				"missing transaction")
+			return failWithNotification(
+				"confirmation event missing transaction",
+				fmt.Errorf("BoardingUTXOConfirmed.Tx is nil"),
+				true, "",
+			), nil
 		}
 
 		// Extract the confirmed output value.
 		if int(evt.Outpoint.Index) >= len(evt.Tx.TxOut) {
-			return nil, fmt.Errorf("invalid outpoint index %d for "+
-				"tx %s", evt.Outpoint.Index, evt.Outpoint.Hash)
+			return failWithNotification(
+				fmt.Sprintf(
+					"invalid outpoint index %d for tx %s",
+					evt.Outpoint.Index, evt.Outpoint.Hash,
+				),
+				fmt.Errorf("outpoint index out of range"),
+				true, "",
+			), nil
 		}
 		confirmedOutput := evt.Tx.TxOut[evt.Outpoint.Index]
 
@@ -132,7 +175,8 @@ func (s *Idle) ProcessEvent(_ context.Context, event ClientEvent,
 		}, nil
 
 	default:
-		return nil, fmt.Errorf("idle: unexpected event: %T", event)
+		// Self-loop on unknown events - do not halt the FSM.
+		return selfLoop(s), nil
 	}
 }
 
@@ -147,14 +191,23 @@ func (s *PendingRoundAssembly) ProcessEvent(
 	// we just add to our internal map.
 	case *BoardingUTXOConfirmed:
 		if evt.Tx == nil {
-			return nil, fmt.Errorf("confirmation event missing " +
-				"transaction")
+			return failWithNotification(
+				"confirmation event missing transaction",
+				fmt.Errorf("BoardingUTXOConfirmed.Tx is nil"),
+				true, "",
+			), nil
 		}
 
 		// Extract the confirmed output value.
 		if int(evt.Outpoint.Index) >= len(evt.Tx.TxOut) {
-			return nil, fmt.Errorf("invalid outpoint index %d for "+
-				"tx %s", evt.Outpoint.Index, evt.Outpoint.Hash)
+			return failWithNotification(
+				fmt.Sprintf(
+					"invalid outpoint index %d for tx %s",
+					evt.Outpoint.Index, evt.Outpoint.Hash,
+				),
+				fmt.Errorf("outpoint index out of range"),
+				true, "",
+			), nil
 		}
 		confirmedOutput := evt.Tx.TxOut[evt.Outpoint.Index]
 
@@ -226,8 +279,11 @@ func (s *PendingRoundAssembly) ProcessEvent(
 		intentSlice := slices.Collect(maps.Values(s.Intents))
 		boardingReqs := fn.Map(intentSlice, buildBoardingRequest)
 		if len(boardingReqs) == 0 {
-			return nil, fmt.Errorf("no boarding requests " +
-				"to register")
+			return failWithNotification(
+				"no boarding requests to register",
+				fmt.Errorf("empty boarding requests"),
+				true, "",
+			), nil
 		}
 
 		// Next, we'll extract all the VTXO templates from the set of
@@ -240,7 +296,11 @@ func (s *PendingRoundAssembly) ProcessEvent(
 		)
 		vtxoReqs := fn.Flatten(vtxoReqLists)
 		if len(vtxoReqs) == 0 {
-			return nil, fmt.Errorf("no VTXO requests to register")
+			return failWithNotification(
+				"no VTXO requests to register",
+				fmt.Errorf("empty VTXO requests"),
+				true, "",
+			), nil
 		}
 
 		// With all this extract, we'll now send the JoinRoundRequest
@@ -269,8 +329,8 @@ func (s *PendingRoundAssembly) ProcessEvent(
 		}, nil
 
 	default:
-		return nil, fmt.Errorf("pending_round_assembly: "+
-			"unexpected event: %T", event)
+		// Self-loop on unknown events - do not halt the FSM.
+		return selfLoop(s), nil
 	}
 }
 
@@ -300,8 +360,8 @@ func (s *RegistrationSentState) ProcessEvent(
 		}, nil
 
 	default:
-		return nil, fmt.Errorf("registration_sent: unexpected "+
-			"event: %T", event)
+		// Self-loop on unknown events - do not halt the FSM.
+		return selfLoop(s), nil
 	}
 }
 
@@ -336,8 +396,8 @@ func (s *RoundJoinedState) ProcessEvent(
 		}, nil
 
 	default:
-		return nil, fmt.Errorf("round_joined: unexpected event: "+
-			"%T", event)
+		// Self-loop on unknown events - do not halt the FSM.
+		return selfLoop(s), nil
 	}
 }
 
@@ -485,8 +545,8 @@ func (s *CommitmentTxReceivedState) ProcessEvent(
 		}, nil
 
 	default:
-		return nil, fmt.Errorf("commitment_tx_received: unexpected "+
-			"event: %T", event)
+		// Self-loop on unknown events - do not halt the FSM.
+		return selfLoop(s), nil
 	}
 }
 
@@ -583,8 +643,8 @@ func (s *CommitmentTxValidatedState) ProcessEvent(
 		}, nil
 
 	default:
-		return nil, fmt.Errorf("commitment_tx_validated: unexpected "+
-			"event: %T", event)
+		// Self-loop on unknown events - do not halt the FSM.
+		return selfLoop(s), nil
 	}
 }
 
@@ -652,8 +712,8 @@ func (s *NoncesSentState) ProcessEvent(
 		}, nil
 
 	default:
-		return nil, fmt.Errorf("nonces_sent: unexpected event: %T",
-			event)
+		// Self-loop on unknown events - do not halt the FSM.
+		return selfLoop(s), nil
 	}
 }
 
@@ -721,8 +781,8 @@ func (s *NoncesAggregatedState) ProcessEvent(
 		}, nil
 
 	default:
-		return nil, fmt.Errorf("nonces_aggregated: unexpected "+
-			"event: %T", event)
+		// Self-loop on unknown events - do not halt the FSM.
+		return selfLoop(s), nil
 	}
 }
 
@@ -908,8 +968,8 @@ func (s *PartialSigsSentState) ProcessEvent(
 		}, nil
 
 	default:
-		return nil, fmt.Errorf("partial_sigs_sent: unexpected "+
-			"event: %T", event)
+		// Self-loop on unknown events - do not halt the FSM.
+		return selfLoop(s), nil
 	}
 }
 
@@ -1014,8 +1074,8 @@ func (s *InputSigSentState) ProcessEvent(
 		}, nil
 
 	default:
-		return nil, fmt.Errorf("input_sig_sent: unexpected event: %T",
-			event)
+		// Self-loop on unknown events - do not halt the FSM.
+		return selfLoop(s), nil
 	}
 }
 
@@ -1042,7 +1102,11 @@ func (s *ConfirmedState) ProcessEvent(_ context.Context, event ClientEvent,
 	}
 }
 
-// ProcessEvent for ClientFailedState (terminal state).
+// ProcessEvent for ClientFailedState. This state is now recoverable and
+// accepts the same events as Idle (BoardingUTXOConfirmed,
+// ResumeBoardingIntents) to allow the FSM to restart the boarding process
+// after a failure. Instead of duplicating the Idle logic, we transition to
+// Idle and forward the event as an internal event for Idle to process.
 func (s *ClientFailedState) ProcessEvent(
 	_ context.Context, event ClientEvent, env *ClientEnvironment,
 ) (*ClientStateTransition, error) {
@@ -1060,12 +1124,34 @@ func (s *ClientFailedState) ProcessEvent(
 			},
 		}, nil
 
-	default:
-		// Stay in failed state for other events since no other
-		// transitions are valid from this terminal state.
+	case *ResumeBoardingIntents:
+		// Recovery path: transition to Idle and forward the event.
+		// If no intents are provided, stay in the current state.
+		if len(evt.Intents) == 0 {
+			return selfLoop(s), nil
+		}
+
 		return &ClientStateTransition{
-			NextState: s,
+			NextState: &Idle{},
+			NewEvents: fn.Some(ClientEmittedEvent{
+				InternalEvent: []ClientEvent{evt},
+			}),
 		}, nil
+
+	case *BoardingUTXOConfirmed:
+		// Recovery path: transition to Idle and forward the event
+		// to be processed there. This avoids duplicating the
+		// BoardingUTXOConfirmed handling logic.
+		return &ClientStateTransition{
+			NextState: &Idle{},
+			NewEvents: fn.Some(ClientEmittedEvent{
+				InternalEvent: []ClientEvent{evt},
+			}),
+		}, nil
+
+	default:
+		// Self-loop on unknown events - do not halt the FSM.
+		return selfLoop(s), nil
 	}
 }
 

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -1,0 +1,1083 @@
+package round
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/scripts"
+	"github.com/lightninglabs/darepo-client/lib/tree"
+	"github.com/lightninglabs/darepo-client/lib/types"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+)
+
+// buildBoardingRequest constructs a types.BoardingRequest from a
+// BoardingIntent. This pulls together the outpoint, keys, and exit delay from
+// the embedded wallet intent and address, along with the TxProof from
+// ChainInfo if present.
+func buildBoardingRequest(intent BoardingIntent) types.BoardingRequest {
+	addr := intent.Address
+
+	return types.BoardingRequest{
+		Outpoint:    &intent.Outpoint,
+		ClientKey:   addr.KeyDesc.PubKey,
+		OperatorKey: addr.OperatorKey,
+		ExitDelay:   addr.ExitDelay,
+		TxProof:     intent.ChainInfo.TxProof,
+	}
+}
+
+// ProcessEvent handles the events from the Idle state. In this state, we'll
+// receive boarding UTXO confirmations or resume existing boarding flows.
+func (s *Idle) ProcessEvent(_ context.Context, event ClientEvent,
+	env *ClientEnvironment) (*ClientStateTransition, error) {
+
+	switch evt := event.(type) {
+	case *ResumeBoardingIntents:
+		// If for some reason, there aren't any new intents, then we'll
+		// stay in the idle state.
+		if len(evt.Intents) == 0 {
+			return &ClientStateTransition{
+				NextState: s,
+			}, nil
+		}
+
+		// Otherwise, we'll start to assemble a round with the resumed
+		// intents.
+		return &ClientStateTransition{
+			NextState: &PendingRoundAssembly{
+				Intents: evt.Intents,
+			},
+		}, nil
+
+	case *BoardingUTXOConfirmed:
+		// A boarding UTXO was confirmed. The wallet has already
+		// persisted the intent; we just need to create an internal
+		// BoardingIntent and transition to PendingRoundAssembly.
+		if evt.Tx == nil {
+			return nil, fmt.Errorf("confirmation event " +
+				"missing transaction")
+		}
+
+		// Extract the confirmed output value.
+		if int(evt.Outpoint.Index) >= len(evt.Tx.TxOut) {
+			return nil, fmt.Errorf("invalid outpoint index %d for "+
+				"tx %s", evt.Outpoint.Index, evt.Outpoint.Hash)
+		}
+		confirmedOutput := evt.Tx.TxOut[evt.Outpoint.Index]
+
+		// Create the chain info from the confirmation event, including
+		// the TxProof for SPV verification.
+		chainInfo := BoardingChainInfo{
+			ConfHeight: evt.BlockHeight,
+			ConfHash:   evt.BlockHash,
+			ConfTx:     evt.Tx,
+			OutPoint:   evt.Outpoint,
+			Amount:     btcutil.Amount(confirmedOutput.Value),
+			TxProof:    evt.TxProof,
+		}
+
+		// Create a wallet intent with the full address from the event.
+		walletIntent := WalletBoardingIntent{
+			Address:   evt.Address,
+			Outpoint:  evt.Outpoint,
+			ChainInfo: chainInfo,
+			Status:    BoardingStatusConfirmed,
+		}
+
+		// Build the boarding request from the address.
+		boardingRequest := types.BoardingRequest{
+			Outpoint:    &evt.Outpoint,
+			ClientKey:   evt.Address.KeyDesc.PubKey,
+			OperatorKey: evt.Address.OperatorKey,
+		}
+
+		// Build the VTXO template from the boarding address info. The
+		// client wants a single VTXO with the full confirmed amount.
+		vtxoTemplate := []types.VTXORequest{
+			{
+				Amount: btcutil.Amount(
+					confirmedOutput.Value,
+				),
+				PkScript:    confirmedOutput.PkScript,
+				ClientKey:   evt.Address.KeyDesc.PubKey,
+				OperatorKey: evt.Address.OperatorKey,
+				Expiry:      evt.Address.ExitDelay,
+				SigningKey:  evt.Address.KeyDesc,
+			},
+		}
+
+		// Create the round's BoardingIntent.
+		intent := BoardingIntent{
+			BoardingIntent:  walletIntent,
+			BoardingRequest: boardingRequest,
+			VtxoTemplate:    vtxoTemplate,
+			RoundID:         fn.None[string](),
+		}
+
+		intentMap := make(map[wire.OutPoint]BoardingIntent)
+		intentMap[evt.Outpoint] = intent
+
+		return &ClientStateTransition{
+			NextState: &PendingRoundAssembly{
+				Intents: intentMap,
+			},
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("idle: unexpected event: %T", event)
+	}
+}
+
+// ProcessEvent for PendingRoundAssembly tracks confirmed boarding intents and
+// transitions to registration once all are ready.
+func (s *PendingRoundAssembly) ProcessEvent(
+	_ context.Context, event ClientEvent, env *ClientEnvironment,
+) (*ClientStateTransition, error) {
+
+	switch evt := event.(type) {
+	// A new boarding UTXO was confirmed. The wallet handles persistence;
+	// we just add to our internal map.
+	case *BoardingUTXOConfirmed:
+		if evt.Tx == nil {
+			return nil, fmt.Errorf("confirmation event missing " +
+				"transaction")
+		}
+
+		// Extract the confirmed output value.
+		if int(evt.Outpoint.Index) >= len(evt.Tx.TxOut) {
+			return nil, fmt.Errorf("invalid outpoint index %d for "+
+				"tx %s", evt.Outpoint.Index, evt.Outpoint.Hash)
+		}
+		confirmedOutput := evt.Tx.TxOut[evt.Outpoint.Index]
+
+		// Create the chain info from the confirmation event, including
+		// the TxProof for SPV verification.
+		chainInfo := BoardingChainInfo{
+			ConfHeight: evt.BlockHeight,
+			ConfHash:   evt.BlockHash,
+			ConfTx:     evt.Tx,
+			OutPoint:   evt.Outpoint,
+			Amount:     btcutil.Amount(confirmedOutput.Value),
+			TxProof:    evt.TxProof,
+		}
+
+		// Create a wallet intent with the full address from the event.
+		walletIntent := WalletBoardingIntent{
+			Address:   evt.Address,
+			Outpoint:  evt.Outpoint,
+			ChainInfo: chainInfo,
+			Status:    BoardingStatusConfirmed,
+		}
+
+		// Build the boarding request from the address.
+		boardingRequest := types.BoardingRequest{
+			Outpoint:    &evt.Outpoint,
+			ClientKey:   evt.Address.KeyDesc.PubKey,
+			OperatorKey: evt.Address.OperatorKey,
+		}
+
+		// Build the VTXO template from the boarding address info. The
+		// client wants a single VTXO with the full confirmed amount.
+		vtxoTemplate := []types.VTXORequest{
+			{
+				Amount: btcutil.Amount(
+					confirmedOutput.Value,
+				),
+				PkScript:    confirmedOutput.PkScript,
+				ClientKey:   evt.Address.KeyDesc.PubKey,
+				OperatorKey: evt.Address.OperatorKey,
+				Expiry:      evt.Address.ExitDelay,
+				SigningKey:  evt.Address.KeyDesc,
+			},
+		}
+
+		intent := BoardingIntent{
+			BoardingIntent:  walletIntent,
+			BoardingRequest: boardingRequest,
+			VtxoTemplate:    vtxoTemplate,
+			RoundID:         fn.None[string](),
+		}
+
+		// Add the newly confirmed intent to our map.
+		updatedIntents := maps.Clone(s.Intents)
+		updatedIntents[evt.Outpoint] = intent
+
+		return &ClientStateTransition{
+			NextState: &PendingRoundAssembly{
+				Intents: updatedIntents,
+			},
+		}, nil
+
+	// It's time to register our confirmed boarding UTXOs for the next
+	// round. We'll send a message to the server using our outbox, then
+	// transition to the next phase.
+	case *RegistrationRequested:
+		// Extract the set of values from the intent map, as we don't
+		// need to track them by outpoint any longer.
+		//
+		intentSlice := slices.Collect(maps.Values(s.Intents))
+		boardingReqs := fn.Map(intentSlice, buildBoardingRequest)
+		if len(boardingReqs) == 0 {
+			return nil, fmt.Errorf("no boarding requests " +
+				"to register")
+		}
+
+		// Next, we'll extract all the VTXO templates from the set of
+		// nested intents.
+		vtxoReqLists := fn.Map(
+			intentSlice,
+			func(intent BoardingIntent) []types.VTXORequest {
+				return intent.VtxoTemplate
+			},
+		)
+		vtxoReqs := fn.Flatten(vtxoReqLists)
+		if len(vtxoReqs) == 0 {
+			return nil, fmt.Errorf("no VTXO requests to register")
+		}
+
+		// With all this extract, we'll now send the JoinRoundRequest
+		// to kick off the singing process.
+		return &ClientStateTransition{
+			NextState: &RegistrationSentState{
+				Intents: intentSlice,
+			},
+			NewEvents: fn.Some(ClientEmittedEvent{
+				Outbox: []ClientOutMsg{
+					&JoinRoundRequest{
+						BoardingRequests: boardingReqs,
+						VTXORequests:     vtxoReqs,
+					},
+				},
+			}),
+		}, nil
+
+	case *BoardingFailed:
+		return &ClientStateTransition{
+			NextState: &ClientFailedState{
+				Reason:      evt.Reason,
+				Error:       evt.Error,
+				Recoverable: evt.Recoverable,
+			},
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("pending_round_assembly: "+
+			"unexpected event: %T", event)
+	}
+}
+
+// ProcessEvent for RegistrationSentState.
+func (s *RegistrationSentState) ProcessEvent(
+	_ context.Context, event ClientEvent, env *ClientEnvironment,
+) (*ClientStateTransition, error) {
+
+	switch evt := event.(type) {
+	case *RoundJoined:
+		return &ClientStateTransition{
+			NextState: &RoundJoinedState{
+				RoundID: evt.RoundID,
+				Intents: slices.Clone(s.Intents),
+			},
+		}, nil
+
+	case *BoardingFailed:
+		// Server rejected the registration or the request timed out.
+		// Transition to failure state.
+		return &ClientStateTransition{
+			NextState: &ClientFailedState{
+				Reason:      evt.Reason,
+				Error:       evt.Error,
+				Recoverable: evt.Recoverable,
+			},
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("registration_sent: unexpected "+
+			"event: %T", event)
+	}
+}
+
+// ProcessEvent for RoundJoinedState.
+func (s *RoundJoinedState) ProcessEvent(
+	_ context.Context, event ClientEvent, env *ClientEnvironment,
+) (*ClientStateTransition, error) {
+
+	switch evt := event.(type) {
+	case *CommitmentTxBuilt:
+		return &ClientStateTransition{
+			NextState: &CommitmentTxReceivedState{
+				RoundID:      evt.RoundID,
+				CommitmentTx: evt.Tx,
+				TxID:         evt.Tx.UnsignedTx.TxHash(),
+				VTXTTree:     evt.VTXTTree,
+				Intents:      slices.Clone(s.Intents),
+				ClientTrees:  make(map[SignerKey]*tree.Tree),
+			},
+			NewEvents: fn.Some(ClientEmittedEvent{
+				InternalEvent: []ClientEvent{evt},
+			}),
+		}, nil
+
+	case *BoardingFailed:
+		return &ClientStateTransition{
+			NextState: &ClientFailedState{
+				Reason:      evt.Reason,
+				Error:       evt.Error,
+				Recoverable: evt.Recoverable,
+			},
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("round_joined: unexpected event: "+
+			"%T", event)
+	}
+}
+
+// validateBoardingInputs checks that all boarding UTXOs are present in the
+// commitment transaction and returns a map of outpoint to input index.
+func validateBoardingInputs(commitmentTx *wire.MsgTx,
+	intents []BoardingIntent) (map[wire.OutPoint]int, error) {
+
+	if commitmentTx == nil {
+		return nil, fmt.Errorf("commitment tx is nil")
+	}
+	if len(intents) == 0 {
+		return nil, fmt.Errorf("no boarding intents to validate")
+	}
+
+	// Build map of outpoint to input index.
+	outpointToIdx := make(map[wire.OutPoint]int)
+	for i, txIn := range commitmentTx.TxIn {
+		outpointToIdx[txIn.PreviousOutPoint] = i
+	}
+
+	// Validate all intent outpoints are present in the commitment tx.
+	for _, intent := range intents {
+		outpoint := intent.BoardingRequest.Outpoint
+		if _, found := outpointToIdx[*outpoint]; !found {
+			return nil, fmt.Errorf("boarding UTXO %s not found "+
+				"in commitment tx", outpoint)
+		}
+	}
+
+	return outpointToIdx, nil
+}
+
+// ProcessEvent for CommitmentTxReceivedState.
+//
+//nolint:ll
+func (s *CommitmentTxReceivedState) ProcessEvent(
+	_ context.Context, event ClientEvent, env *ClientEnvironment,
+) (*ClientStateTransition, error) {
+
+	switch evt := event.(type) {
+	case *CommitmentTxBuilt:
+		// First, well make sure that all boarding UTXOs are present
+		// in the round transaction and build the outpoint-to-index map.
+		boardingInputIndices, err := validateBoardingInputs(
+			s.CommitmentTx.UnsignedTx, s.Intents,
+		)
+		if err != nil {
+			return &ClientStateTransition{
+				NextState: &ClientFailedState{
+					Reason: "commitment tx " +
+						"validation failed",
+					Error:       err,
+					Recoverable: true,
+				},
+			}, nil
+		}
+
+		clientTrees := make(map[SignerKey]*tree.Tree)
+
+		// Next, we'll make sure that each of the VTXO requests that we
+		// originally requested are actually present in the VTXT tree
+		// that the server sent us.
+		vtxoRequests := fn.Map(
+			s.Intents,
+			func(intent BoardingIntent) []types.VTXORequest {
+				return intent.VtxoTemplate
+			},
+		)
+		for i, vtxoReq := range fn.Flatten(vtxoRequests) {
+			// Convert VTXORequest to LeafDescriptor for validation.
+			expectedLeaf := tree.LeafDescriptor{
+				Amount:      vtxoReq.Amount,
+				PkScript:    vtxoReq.PkScript,
+				CoSignerKey: vtxoReq.SigningKey.PubKey,
+			}
+
+			clientTree, err := s.VTXTTree.ValidatePath(
+				vtxoReq.SigningKey.PubKey, expectedLeaf,
+				env.OperatorTerms.PubKey,
+			)
+			if err != nil {
+				return &ClientStateTransition{
+					NextState: &ClientFailedState{
+						Reason: fmt.Sprintf(
+							"VTXT validation "+
+								"failed for VTXO "+
+								"request %d", i,
+						),
+						Error:       err,
+						Recoverable: false,
+					},
+				}, nil
+			}
+
+			// Now that we know this VTXO request was properly
+			// included in the tree, we'll store the client-tree
+			// (travesal path from the root to this vtox leaf).
+			signerKey := NewSignerKey(vtxoReq.SigningKey.PubKey)
+			clientTrees[signerKey] = clientTree
+		}
+
+		// Make sure all anchor outputs are valid in the tree, if they
+		// aren't we may not be able to go on chain.
+		if err := s.VTXTTree.ValidateAnchors(); err != nil {
+			return &ClientStateTransition{
+				NextState: &ClientFailedState{
+					Reason: "anchor output " +
+						"validation failed",
+					Error:       err,
+					Recoverable: false,
+				},
+			}, nil
+		}
+
+		// TODO(roasbeef): for refresh and off boarding, need extra
+		// validation for:
+		//   * connector tree
+		//   * outputs on commit, etc
+
+		// We'll now transition to the CommitmentTxValidatedState, and
+		// emit an internal generate nonces event so we can propagate
+		// the state.
+		return &ClientStateTransition{
+			NextState: &CommitmentTxValidatedState{
+				RoundID:              s.RoundID,
+				CommitmentTx:         s.CommitmentTx,
+				VTXTTree:             s.VTXTTree,
+				Intents:              slices.Clone(s.Intents),
+				ClientTrees:          clientTrees,
+				BoardingInputIndices: boardingInputIndices,
+			},
+			NewEvents: fn.Some(ClientEmittedEvent{
+				InternalEvent: []ClientEvent{&GenerateNonces{}},
+			}),
+		}, nil
+
+	case *BoardingFailed:
+		return &ClientStateTransition{
+			NextState: &ClientFailedState{
+				Reason:      evt.Reason,
+				Error:       evt.Error,
+				Recoverable: evt.Recoverable,
+			},
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("commitment_tx_received: unexpected "+
+			"event: %T", event)
+	}
+}
+
+// ProcessEvent for CommitmentTxValidatedState.
+func (s *CommitmentTxValidatedState) ProcessEvent(
+	_ context.Context, event ClientEvent, env *ClientEnvironment,
+) (*ClientStateTransition, error) {
+
+	switch event.(type) {
+	case *GenerateNonces:
+		// Get sweep tapscript root from the validated tree. This was
+		// set when the operator built the tree.
+		sweepTweak := s.VTXTTree.SweepTapscriptRoot
+
+		// Build the prev output fetcher for signing. The batch output
+		// is needed so the root transaction can look up the output it
+		// spends from the commitment transaction.
+		prevOutFetcher, err := s.VTXTTree.Root.PrevOutputFetcher(
+			s.VTXTTree.BatchOutput,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create prev output "+
+				"fetcher: %w", err)
+		}
+
+		// At this point, all the basic validation checks have passed.
+		// So now we'll generate a musig2 session to create nonces to
+		// sign the VTXO tree. Each VTXO that we created will
+		// effectively be a new musig session.
+		musig2Sessions := make(map[SignerKey]*tree.SignerSession)
+		for _, boardingIntent := range s.Intents {
+			for _, vtxoReq := range boardingIntent.VtxoTemplate {
+				signerKey := NewSignerKey(
+					vtxoReq.SigningKey.PubKey,
+				)
+
+				// TODO(roasbeef): actually use the interface
+				// in front of this?
+				session, err := tree.NewSignerSession(
+					env.Wallet, &vtxoReq.SigningKey,
+					sweepTweak, prevOutFetcher,
+					s.VTXTTree.Root,
+				)
+				if err != nil {
+					return nil, fmt.Errorf("failed to "+
+						"create signing session for "+
+						"client %x: %w",
+						signerKey[:], err)
+				}
+
+				musig2Sessions[signerKey] = session
+			}
+		}
+
+		// Now that we have all our sessions created, we'll have each
+		// of them generate nonces to use in tree signing. We collect
+		// all nonces into a nested map: txid -> signerKey -> nonce.
+		// Each signing key (VTXO) contributes its own nonce for each
+		// transaction in its path.
+		allNonces := make(map[chainhash.Hash]map[SignerKey][]byte)
+		for signerKey, session := range musig2Sessions {
+			nonces := session.GetNonces()
+
+			for txid, nonce := range nonces {
+				if allNonces[txid] == nil {
+					allNonces[txid] = make(
+						map[SignerKey][]byte,
+					)
+				}
+				allNonces[txid][signerKey] = nonce[:]
+			}
+		}
+
+		// MuSig2 nonces have been generated locally. Send them to the
+		// server to participate in the aggregated nonce computation.
+		nonceMsg := &SubmitNoncesRequest{
+			RoundID: s.RoundID,
+			Nonces:  allNonces,
+		}
+
+		return &ClientStateTransition{
+			NextState: &NoncesSentState{
+				RoundID:              s.RoundID,
+				CommitmentTx:         s.CommitmentTx,
+				VTXTTree:             s.VTXTTree,
+				Intents:              slices.Clone(s.Intents),
+				ClientTrees:          s.ClientTrees,
+				Musig2Sessions:       musig2Sessions,
+				BoardingInputIndices: s.BoardingInputIndices,
+			},
+			NewEvents: fn.Some(ClientEmittedEvent{
+				Outbox: []ClientOutMsg{nonceMsg},
+			}),
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("commitment_tx_validated: unexpected "+
+			"event: %T", event)
+	}
+}
+
+// ProcessEvent for NoncesSentState.
+func (s *NoncesSentState) ProcessEvent(
+	_ context.Context, event ClientEvent, env *ClientEnvironment,
+) (*ClientStateTransition, error) {
+
+	switch evt := event.(type) {
+	case *NoncesAggregated:
+		// Received aggregated nonces from the server. Now register
+		// them with our signing session and generate partial
+		// signatures.
+		//
+		// The server sends ONE combined/aggregated nonce per
+		// transaction (not individual nonces from each participant).
+		// The server has already aggregated all participants' nonces
+		// using MuSig2 nonce aggregation.
+		//
+		// Convert the raw bytes to Musig2PubNonce for registration.
+		aggNoncesMap := make(map[tree.TxID]tree.Musig2PubNonce)
+		for txid, nonceBytes := range evt.AggregatedNonces {
+			var nonce tree.Musig2PubNonce
+			copy(nonce[:], nonceBytes)
+			aggNoncesMap[txid] = nonce
+		}
+
+		// With the nonces grouped, we need to register the nonces with
+		// each client session.
+		for _, musig2Session := range s.Musig2Sessions {
+			// Register the combined nonces with our signing
+			// session.
+			err := musig2Session.RegisterAggNonces(aggNoncesMap)
+			if err != nil {
+				return nil, fmt.Errorf("failed to register "+
+					"combined nonces: %w", err)
+			}
+		}
+
+		return &ClientStateTransition{
+			NextState: &NoncesAggregatedState{
+				RoundID:              s.RoundID,
+				CommitmentTx:         s.CommitmentTx,
+				VTXTTree:             s.VTXTTree,
+				Intents:              slices.Clone(s.Intents),
+				ClientTrees:          s.ClientTrees,
+				Musig2Sessions:       s.Musig2Sessions,
+				AggregatedNonces:     evt.AggregatedNonces,
+				BoardingInputIndices: s.BoardingInputIndices,
+			},
+			NewEvents: fn.Some(ClientEmittedEvent{
+				InternalEvent: []ClientEvent{
+					&GeneratePartialSigs{},
+				},
+			}),
+		}, nil
+
+	case *BoardingFailed:
+		return &ClientStateTransition{
+			NextState: &ClientFailedState{
+				Reason:      evt.Reason,
+				Error:       evt.Error,
+				Recoverable: evt.Recoverable,
+			},
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("nonces_sent: unexpected event: %T",
+			event)
+	}
+}
+
+// ProcessEvent for NoncesAggregatedState.
+func (s *NoncesAggregatedState) ProcessEvent(
+	_ context.Context, event ClientEvent, env *ClientEnvironment,
+) (*ClientStateTransition, error) {
+
+	switch event.(type) {
+	case *GeneratePartialSigs:
+		// At this stage, the nonces have been aggregated for each
+		// client, so now we'll generate and send our partial
+		// signatures.
+		var submitPartialSigs []ClientOutMsg
+
+		for _, musig2Session := range s.Musig2Sessions {
+			// Generate partial signatures for all transactions in
+			// our path. The map is keyed by transaction ID.
+			partialSigs, err := musig2Session.Signatures(true)
+			if err != nil {
+				return nil, fmt.Errorf("failed to generate "+
+					"partial signatures: %w", err)
+			}
+
+			// Encode each partial signature, preserving the txid
+			// association.
+			partialSigBytes := make(
+				map[chainhash.Hash][]byte, len(partialSigs),
+			)
+			for txid, sig := range partialSigs {
+				var buf bytes.Buffer
+				if err := sig.Encode(&buf); err != nil {
+					return nil, fmt.Errorf("failed to "+
+						"encode partial sig for "+
+						"tx %s: %w", txid, err)
+				}
+				partialSigBytes[txid] = buf.Bytes()
+			}
+
+			submitPartialSigs = append(
+				submitPartialSigs, &SubmitPartialSigRequest{
+					RoundID:     s.RoundID,
+					PartialSigs: partialSigBytes,
+				},
+			)
+		}
+
+		// Partial MuSig2 signatures have been generated using the
+		// aggregated nonces. Send them to the server for signature
+		// aggregation.
+		return &ClientStateTransition{
+			NextState: &PartialSigsSentState{
+				RoundID:              s.RoundID,
+				CommitmentTx:         s.CommitmentTx,
+				VTXTTree:             s.VTXTTree,
+				Intents:              slices.Clone(s.Intents),
+				ClientTrees:          s.ClientTrees,
+				Musig2Sessions:       s.Musig2Sessions,
+				BoardingInputIndices: s.BoardingInputIndices,
+			},
+			// TODO(roasbeef): group into a single message?
+			NewEvents: fn.Some(ClientEmittedEvent{
+				Outbox: submitPartialSigs,
+			}),
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("nonces_aggregated: unexpected "+
+			"event: %T", event)
+	}
+}
+
+// ProcessEvent for PartialSigsSentState.
+func (s *PartialSigsSentState) ProcessEvent(
+	ctx context.Context, event ClientEvent, env *ClientEnvironment,
+) (*ClientStateTransition, error) {
+
+	switch evt := event.(type) {
+	case *OperatorSigned:
+		// At this point, Received complete VTXT signatures from the
+		// server after the operator aggregated all partial signatures.
+		//
+		// Now, we'll validate that the aggregated signatures are valid
+		// for the VTXT before proceeding. This prevents the operator
+		// from providing invalid signatures that would make our VTXOs
+		// unspendable.
+		err := s.VTXTTree.ValidateAndSubmitSignatures(evt.Signatures)
+		if err != nil {
+			return &ClientStateTransition{
+				NextState: &ClientFailedState{
+					Reason: "VTXT signature " +
+						"validation failed",
+					Error:       err,
+					Recoverable: false,
+				},
+			}, nil
+		}
+
+		// Now that we know all the signatures are valid, we'll sign
+		// off on each of our boarding inputs sent to the server.
+		//
+		// Build a PrevOutputFetcher from ALL PSBT inputs. Taproot
+		// sighash (BIP341) requires prevout info for all inputs.
+		tx := s.CommitmentTx.UnsignedTx
+		prevOuts := make(map[wire.OutPoint]*wire.TxOut)
+		for i, pIn := range s.CommitmentTx.Inputs {
+			if pIn.WitnessUtxo == nil {
+				return nil, fmt.Errorf("PSBT input %d missing "+
+					"WitnessUtxo", i)
+			}
+			outpoint := tx.TxIn[i].PreviousOutPoint
+			prevOuts[outpoint] = pIn.WitnessUtxo
+		}
+		prevOutFetcher := txscript.NewMultiPrevOutFetcher(prevOuts)
+		sigHashes := txscript.NewTxSigHashes(tx, prevOutFetcher)
+
+		var boardingSigs []*schnorr.Signature
+		for _, boardingIntent := range s.Intents {
+			outpoint := boardingIntent.BoardingRequest.Outpoint
+			inputIdx, found := s.BoardingInputIndices[*outpoint]
+			if !found {
+				return nil, fmt.Errorf("no input index "+
+					"found for boarding outpoint %s",
+					outpoint)
+			}
+
+			spendInfo, err := scripts.NewVTXOSpendInfo(
+				boardingIntent.Address.Tapscript,
+				scripts.VTXOCollabPathLeaf,
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			// Access chain info directly from the embedded wallet
+			// intent.
+			chainInfo := boardingIntent.ChainInfo
+			addr := boardingIntent.Address.Address
+			pkScript := addr.ScriptAddress()
+			amt := chainInfo.Amount
+
+			// Create the TxOut for the boarding output.
+			output := &wire.TxOut{
+				Value:    int64(amt),
+				PkScript: pkScript,
+			}
+
+			signature, err := scripts.SignVTXOCollabInput(
+				env.Wallet, tx, inputIdx, spendInfo,
+				&boardingIntent.Address.KeyDesc, output,
+				sigHashes, prevOutFetcher,
+			)
+			if err != nil {
+				return nil, fmt.Errorf("failed to sign "+
+					"boarding input %d: %w", inputIdx, err)
+			}
+
+			// Convert input.Signature to *schnorr.Signature.
+			schnorrSig, ok := signature.(*schnorr.Signature)
+			if !ok {
+				return nil, fmt.Errorf("signature is not a " +
+					"schnorr signature")
+			}
+			boardingSigs = append(boardingSigs, schnorrSig)
+		}
+
+		sigBytes := make([][]byte, len(boardingSigs))
+		for i, sig := range boardingSigs {
+			sigBytes[i] = sig.Serialize()
+		}
+		if len(sigBytes) != len(s.Intents) {
+			return nil, fmt.Errorf("signature count %d != intent "+
+				"count %d", len(sigBytes), len(s.Intents))
+		}
+
+		outboxMsgs := make([]ClientOutMsg, 0, len(sigBytes))
+		for i, intent := range s.Intents {
+			if intent.Address.Address == nil {
+				return nil, fmt.Errorf("intent %d missing "+
+					"boarding address", i)
+			}
+			forfeitSig := &SubmitForfeitSigRequest{
+				RoundID:     s.RoundID,
+				ForfeitSigs: [][]byte{sigBytes[i]},
+			}
+			outboxMsgs = append(outboxMsgs, forfeitSig)
+		}
+
+		txid := tx.TxHash()
+		callerID := fmt.Sprintf("commitment-%s", txid.String())
+		outboxMsgs = append(outboxMsgs, &RegisterConfirmationRequest{
+			CallerID:    callerID,
+			Txid:        &txid,
+			TargetConfs: env.OperatorTerms.MinConfirmations,
+		})
+
+		// Checkpoint the round state at the "point of no return".
+		// After sending boarding input signatures, the server may
+		// broadcast the commitment transaction. We must persist all
+		// round data to enable recovery if the client restarts.
+		//
+		// Mark all intents as Adopted (frozen in this round) and set
+		// their RoundID, then save them alongside the round.
+		adoptedIntents := make([]BoardingIntent, len(s.Intents))
+		for i, intent := range s.Intents {
+			intent.Status = BoardingStatusAdopted
+			intent.RoundID = fn.Some(s.RoundID)
+			adoptedIntents[i] = intent
+		}
+		round := &Round{
+			RoundID:         s.RoundID,
+			CommitmentTx:    fn.Some(s.CommitmentTx),
+			VTXTTree:        fn.Some(s.VTXTTree),
+			BoardingIntents: adoptedIntents,
+		}
+
+		// Checkpoint round data + FSM state atomically at the "point
+		// of no return". The next state is persisted so restart can
+		// recover to InputSigSentState.
+		nextState := &InputSigSentState{
+			RoundID:      s.RoundID,
+			CommitmentTx: s.CommitmentTx,
+			VTXTTree:     s.VTXTTree,
+			Intents:      slices.Clone(s.Intents),
+			ClientTrees:  s.ClientTrees,
+			InputSigs:    sigBytes,
+		}
+		err = env.RoundStore.CommitState(ctx, round, nextState)
+		if err != nil {
+			return nil, fmt.Errorf("failed to commit round "+
+				"state: %w", err)
+		}
+
+		checkpointNotify := &RoundCheckpointedNotification{
+			RoundID: s.RoundID,
+		}
+
+		return &ClientStateTransition{
+			NextState: nextState,
+			NewEvents: fn.Some(ClientEmittedEvent{
+				Outbox: append(outboxMsgs, checkpointNotify),
+			}),
+		}, nil
+
+	case *BoardingFailed:
+		return &ClientStateTransition{
+			NextState: &ClientFailedState{
+				Reason:      evt.Reason,
+				Error:       evt.Error,
+				Recoverable: evt.Recoverable,
+			},
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("partial_sigs_sent: unexpected "+
+			"event: %T", event)
+	}
+}
+
+// buildClientVTXOs constructs ClientVTXO instances from the boarding intents
+// and client trees.
+func buildClientVTXOs(intents []BoardingIntent,
+	trees map[SignerKey]*tree.Tree, roundID string) ([]*ClientVTXO, error) {
+
+	vtxos := make([]*ClientVTXO, 0)
+	for _, intent := range intents {
+		// Each intent has a VTXO template with one or more requests.
+		for _, req := range intent.VtxoTemplate {
+			signerKey := NewSignerKey(req.SigningKey.PubKey)
+			tree := trees[signerKey]
+			if tree == nil {
+				return nil, fmt.Errorf("missing client tree " +
+					"for signing key")
+			}
+
+			// Use the key descriptor from the intent's boarding
+			// address.
+			clientKeyDesc := intent.Address.KeyDesc
+
+			leaves := tree.Root.GetLeafNodes()
+
+			for _, leaf := range leaves {
+				outpoint, err := leaf.GetNonAnchorOutpoint()
+				if err != nil {
+					return nil, fmt.Errorf("failed to "+
+						"derive VTXO outpoint: %w", err)
+				}
+
+				vtxos = append(vtxos, &ClientVTXO{
+					Outpoint:    *outpoint,
+					Amount:      req.Amount,
+					PkScript:    req.PkScript,
+					Expiry:      req.Expiry,
+					ClientKey:   clientKeyDesc,
+					OperatorKey: req.OperatorKey,
+					TreePath:    tree,
+					RoundID:     fn.Some(roundID),
+				})
+			}
+		}
+	}
+
+	return vtxos, nil
+}
+
+// ProcessEvent for InputSigSentState.
+func (s *InputSigSentState) ProcessEvent(
+	_ context.Context, event ClientEvent, env *ClientEnvironment,
+) (*ClientStateTransition, error) {
+
+	switch evt := event.(type) {
+	case *BoardingFailed:
+		return &ClientStateTransition{
+			NextState: &ClientFailedState{
+				Reason:      evt.Reason,
+				Error:       evt.Error,
+				Recoverable: evt.Recoverable,
+			},
+		}, nil
+
+	case *BoardingConfirmed:
+		vtxos, err := buildClientVTXOs(
+			s.Intents, s.ClientTrees, s.RoundID,
+		)
+		if err != nil {
+			return &ClientStateTransition{
+				NextState: &ClientFailedState{
+					Reason: "failed to build client " +
+						"VTXOs",
+					Error:       err,
+					Recoverable: false,
+				},
+			}, nil
+		}
+
+		// Persist VTXOs with their extracted tree paths for future
+		// spending.
+		if err := env.VTXOStore.SaveVTXOs(vtxos); err != nil {
+			return nil, fmt.Errorf("failed to save VTXOs: %w", err)
+		}
+
+		return &ClientStateTransition{
+			NextState: &ConfirmedState{
+				TxID:          evt.TxID,
+				BlockHeight:   evt.BlockHeight,
+				Confirmations: evt.Confirmations,
+				VTXOs:         vtxos,
+			},
+			NewEvents: fn.Some(ClientEmittedEvent{
+				Outbox: []ClientOutMsg{
+					&VTXOCreatedNotification{VTXOs: vtxos},
+					&RoundCompletedNotification{
+						RoundID: s.RoundID,
+						TxID:    evt.TxID,
+					},
+				},
+			}),
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("input_sig_sent: unexpected event: %T",
+			event)
+	}
+}
+
+// ProcessEvent for ConfirmedState. After boarding completes successfully, we
+// automatically transition back to Idle to allow processing new boarding
+// addresses and intents.
+func (s *ConfirmedState) ProcessEvent(_ context.Context, event ClientEvent,
+	env *ClientEnvironment) (*ClientStateTransition, error) {
+
+	switch event.(type) {
+	case *RoundComplete:
+		// Boarding is complete for this round. Transition back to Idle
+		// to process new confirmations for existing boarding addresses
+		// or start new rounds.
+		return &ClientStateTransition{
+			NextState: &Idle{},
+		}, nil
+
+	default:
+		// Stay in confirmed state for unexpected events.
+		return &ClientStateTransition{
+			NextState: s,
+		}, nil
+	}
+}
+
+// ProcessEvent for ClientFailedState (terminal state).
+func (s *ClientFailedState) ProcessEvent(
+	_ context.Context, event ClientEvent, env *ClientEnvironment,
+) (*ClientStateTransition, error) {
+
+	switch evt := event.(type) {
+	case *RecoveryInitiated:
+		// Initiate CSV timeout recovery to sweep the boarding UTXO
+		// back to the client's wallet after the relative timelock
+		// expires.
+		return &ClientStateTransition{
+			NextState: &RecoveryInitiatedState{
+				Outpoint:  evt.Outpoint,
+				SweepTxID: evt.SweepTxID,
+				Reason:    evt.Reason,
+			},
+		}, nil
+
+	default:
+		// Stay in failed state for other events since no other
+		// transitions are valid from this terminal state.
+		return &ClientStateTransition{
+			NextState: s,
+		}, nil
+	}
+}
+
+// ProcessEvent for RecoveryInitiatedState (semi-terminal state).
+func (s *RecoveryInitiatedState) ProcessEvent(
+	_ context.Context, event ClientEvent, env *ClientEnvironment,
+) (*ClientStateTransition, error) {
+
+	// Semi-terminal state - self-loop on all events since the recovery
+	// sweep transaction has been broadcast and we're waiting for
+	// confirmation.
+	return &ClientStateTransition{
+		NextState: s,
+	}, nil
+}

--- a/round/transitions_test.go
+++ b/round/transitions_test.go
@@ -1,0 +1,1433 @@
+package round
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/tree"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStateProperties verifies IsTerminal() and String() for all states.
+func TestStateProperties(t *testing.T) {
+	t.Parallel()
+
+	t.Run("terminal_states", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name     string
+			state    ClientState
+			expected string
+		}{
+			{
+				name:     "Confirmed",
+				state:    &ConfirmedState{},
+				expected: "Confirmed",
+			},
+			{
+				name:     "ClientFailed",
+				state:    &ClientFailedState{Reason: "test"},
+				expected: "ClientFailed",
+			},
+			{
+				name: "RecoveryInitiated",
+				state: &RecoveryInitiatedState{
+					Reason: "CSV",
+				},
+				expected: "RecoveryInitiated",
+			},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				require.True(t, tc.state.IsTerminal())
+				require.Contains(
+					t, tc.state.String(), tc.expected,
+				)
+			})
+		}
+	})
+
+	t.Run("non_terminal_states", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name     string
+			state    ClientState
+			expected string
+		}{
+			{
+				"Idle", &Idle{}, "Idle",
+			},
+			{
+				"PendingRoundAssembly", &PendingRoundAssembly{},
+				"BoardingIntents",
+			},
+			{
+				"RegistrationSent", &RegistrationSentState{},
+				"RegistrationSent",
+			},
+			{
+				"RoundJoined", &RoundJoinedState{},
+				"RoundJoined",
+			},
+			{
+				"CommitmentTxReceived",
+				&CommitmentTxReceivedState{},
+				"CommitmentTxReceived",
+			},
+			{
+				"CommitmentTxValidated",
+				&CommitmentTxValidatedState{},
+				"CommitmentTxValidated",
+			},
+			{
+				"NoncesSent", &NoncesSentState{}, "NoncesSent",
+			},
+			{
+				"NoncesAggregated", &NoncesAggregatedState{},
+				"NoncesAggregated",
+			},
+			{
+				"PartialSigsSent", &PartialSigsSentState{},
+				"PartialSigsSent",
+			},
+			{
+				"InputSigSent", &InputSigSentState{},
+				"InputSigSent",
+			},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				require.False(t, tc.state.IsTerminal())
+				require.Equal(t, tc.expected, tc.state.String())
+			})
+		}
+	})
+}
+
+// TestUnexpectedEventErrors verifies all states reject invalid events.
+func TestUnexpectedEventErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		setup func(h *boardingTestHarness) ClientState
+		event ClientEvent
+	}{
+		{
+			name: "Idle_rejects_RoundJoined",
+			setup: func(h *boardingTestHarness) ClientState {
+				return &Idle{}
+			},
+			event: &RoundJoined{RoundID: "test"},
+		},
+		{
+			name: "PendingRoundAssembly_rejects_RoundComplete",
+			setup: func(h *boardingTestHarness) ClientState {
+				intent := h.newTestBoardingIntent()
+				intents := map[wire.OutPoint]BoardingIntent{
+					intent.Outpoint: intent,
+				}
+
+				return &PendingRoundAssembly{
+					Intents: intents,
+				}
+			},
+			event: &RoundComplete{},
+		},
+		{
+			name: "RegistrationSent_rejects_BoardingConfirmed",
+			setup: func(h *boardingTestHarness) ClientState {
+				intent := h.newTestBoardingIntent()
+				return &RegistrationSentState{
+					Intents: []BoardingIntent{intent},
+				}
+			},
+			event: &BoardingConfirmed{},
+		},
+		{
+			name: "RoundJoined_rejects_duplicate_RoundJoined",
+			setup: func(h *boardingTestHarness) ClientState {
+				intent := h.newTestBoardingIntent()
+				return &RoundJoinedState{
+					RoundID: "round-1",
+					Intents: []BoardingIntent{intent},
+				}
+			},
+			event: &RoundJoined{RoundID: "another-round"},
+		},
+		{
+			name: "CommitmentTxReceived_rejects_RoundJoined",
+			setup: func(h *boardingTestHarness) ClientState {
+				intent := h.newTestBoardingIntent()
+				return h.newCommitmentTxReceivedState(
+					"round-001", []BoardingIntent{intent},
+				)
+			},
+			event: &RoundJoined{RoundID: "another-round"},
+		},
+		{
+			name: "CommitmentTxValidated_rejects_RoundJoined",
+			setup: func(h *boardingTestHarness) ClientState {
+				intent := h.newTestBoardingIntent()
+				return h.newCommitmentTxValidatedState(
+					"round-001", []BoardingIntent{intent},
+				)
+			},
+			event: &RoundJoined{RoundID: "another-round"},
+		},
+		{
+			name: "NoncesSent_rejects_RoundJoined",
+			setup: func(h *boardingTestHarness) ClientState {
+				vtxtTree, _ := h.newTestVTXOTree(1)
+				intent := h.newTestBoardingIntent()
+				return &NoncesSentState{
+					RoundID:  "round-001",
+					VTXTTree: vtxtTree,
+					Intents:  []BoardingIntent{intent},
+				}
+			},
+			event: &RoundJoined{RoundID: "another-round"},
+		},
+		{
+			name: "NoncesAggregated_rejects_RoundJoined",
+			setup: func(h *boardingTestHarness) ClientState {
+				vtxtTree, _ := h.newTestVTXOTree(1)
+				intent := h.newTestBoardingIntent()
+				return &NoncesAggregatedState{
+					RoundID:  "round-001",
+					VTXTTree: vtxtTree,
+					Intents:  []BoardingIntent{intent},
+				}
+			},
+			event: &RoundJoined{RoundID: "another-round"},
+		},
+		{
+			name: "PartialSigsSent_rejects_RoundJoined",
+			setup: func(h *boardingTestHarness) ClientState {
+				vtxtTree, _ := h.newTestVTXOTree(1)
+				intent := h.newTestBoardingIntent()
+				return &PartialSigsSentState{
+					RoundID:  "round-001",
+					VTXTTree: vtxtTree,
+					Intents:  []BoardingIntent{intent},
+				}
+			},
+			event: &RoundJoined{RoundID: "another-round"},
+		},
+		{
+			name: "InputSigSent_rejects_RoundJoined",
+			setup: func(h *boardingTestHarness) ClientState {
+				vtxtTree, _ := h.newTestVTXOTree(1)
+				intent := h.newTestBoardingIntent()
+				return &InputSigSentState{
+					RoundID:  "round-001",
+					VTXTTree: vtxtTree,
+					Intents:  []BoardingIntent{intent},
+				}
+			},
+			event: &RoundJoined{RoundID: "another-round"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHarness(t)
+			h.withState(tc.setup(h))
+
+			_, err := h.sendEvent(tc.event)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "unexpected")
+		})
+	}
+}
+
+// TestBoardingFailedTransitions verifies all non-terminal states handle
+// BoardingFailed by transitioning to ClientFailedState.
+func TestBoardingFailedTransitions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		setup func(h *boardingTestHarness) ClientState
+	}{
+		{
+			name: "RegistrationSentState",
+			setup: func(h *boardingTestHarness) ClientState {
+				intent := h.newTestBoardingIntent()
+				return &RegistrationSentState{
+					Intents: []BoardingIntent{intent},
+				}
+			},
+		},
+		{
+			name: "RoundJoinedState",
+			setup: func(h *boardingTestHarness) ClientState {
+				intent := h.newTestBoardingIntent()
+				return &RoundJoinedState{
+					RoundID: "round-001",
+					Intents: []BoardingIntent{intent},
+				}
+			},
+		},
+		{
+			name: "CommitmentTxReceivedState",
+			setup: func(h *boardingTestHarness) ClientState {
+				intent := h.newTestBoardingIntent()
+				return h.newCommitmentTxReceivedState(
+					"round-001", []BoardingIntent{intent},
+				)
+			},
+		},
+		{
+			name: "NoncesSentState",
+			setup: func(h *boardingTestHarness) ClientState {
+				vtxtTree, _ := h.newTestVTXOTree(1)
+				intent := h.newTestBoardingIntent()
+				return &NoncesSentState{
+					RoundID:  "round-001",
+					VTXTTree: vtxtTree,
+					Intents:  []BoardingIntent{intent},
+				}
+			},
+		},
+		{
+			name: "PartialSigsSentState",
+			setup: func(h *boardingTestHarness) ClientState {
+				vtxtTree, _ := h.newTestVTXOTree(1)
+				intent := h.newTestBoardingIntent()
+				return &PartialSigsSentState{
+					RoundID:  "round-001",
+					VTXTTree: vtxtTree,
+					Intents:  []BoardingIntent{intent},
+				}
+			},
+		},
+		{
+			name: "InputSigSentState",
+			setup: func(h *boardingTestHarness) ClientState {
+				vtxtTree, _ := h.newTestVTXOTree(1)
+				intent := h.newTestBoardingIntent()
+				return &InputSigSentState{
+					RoundID:  "round-001",
+					VTXTTree: vtxtTree,
+					Intents:  []BoardingIntent{intent},
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHarness(t)
+			h.withState(tc.setup(h))
+
+			event := &BoardingFailed{
+				Reason:      "test failure reason",
+				Recoverable: true,
+			}
+
+			transition, err := h.sendEvent(event)
+			require.NoError(t, err)
+			require.NotNil(t, transition)
+
+			failedState := assertStateType[*ClientFailedState](h)
+			require.Equal(
+				t, "test failure reason", failedState.Reason,
+			)
+			require.True(t, failedState.Recoverable)
+		})
+	}
+}
+
+// TestTerminalStateSelfLoop verifies terminal states self-loop on any event.
+func TestTerminalStateSelfLoop(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+	intent := h.newTestBoardingIntent()
+
+	tests := []struct {
+		name  string
+		state ClientState
+	}{
+		{"ConfirmedState", &ConfirmedState{BlockHeight: 100}},
+		{"ClientFailedState", &ClientFailedState{Reason: "failed"}},
+		{
+			"RecoveryInitiatedState",
+			&RecoveryInitiatedState{Outpoint: intent.Outpoint},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHarness(t)
+			h.withState(tc.state)
+
+			// Terminal states ignore all events and remain in their
+			// current state, preventing further transitions once
+			// boarding reaches a final outcome.
+			event := &RoundJoined{RoundID: "test"}
+			transition, err := h.sendEvent(event)
+			require.NoError(t, err)
+			require.NotNil(t, transition)
+
+			require.Equal(
+				t, tc.state.String(), h.currentState.String(),
+			)
+		})
+	}
+}
+
+func TestIdleState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("BoardingUTXOConfirmed_to_pending", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+		h.withState(&Idle{})
+
+		intent := h.newTestBoardingIntent()
+		event := h.newBoardingUTXOConfirmedEvent(intent)
+
+		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		nextState := assertStateType[*PendingRoundAssembly](h)
+		require.Len(t, nextState.Intents, 1)
+		require.Contains(t, nextState.Intents, intent.Outpoint)
+	})
+
+	t.Run("ResumeBoardingIntents_with_intents", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+		h.withState(&Idle{})
+
+		intent := h.newTestBoardingIntent()
+		event := &ResumeBoardingIntents{
+			Intents: map[wire.OutPoint]BoardingIntent{
+				intent.Outpoint: intent,
+			},
+		}
+
+		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		nextState := assertStateType[*PendingRoundAssembly](h)
+		require.Len(t, nextState.Intents, 1)
+	})
+
+	t.Run("ResumeBoardingIntents_empty_stays_idle", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+		h.withState(&Idle{})
+
+		event := &ResumeBoardingIntents{
+			Intents: map[wire.OutPoint]BoardingIntent{},
+		}
+
+		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		_ = assertStateType[*Idle](h)
+	})
+
+	t.Run("nil_tx_error", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+		h.withState(&Idle{})
+
+		intent := h.newTestBoardingIntent()
+		event := h.newBoardingUTXOConfirmedEvent(intent)
+		event.Tx = nil
+
+		_, err := h.sendEvent(event)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "missing transaction")
+	})
+
+	t.Run("invalid_outpoint_index_error", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+		h.withState(&Idle{})
+
+		intent := h.newTestBoardingIntent()
+		event := h.newBoardingUTXOConfirmedEvent(intent)
+		event.Outpoint.Index = 999
+
+		_, err := h.sendEvent(event)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid outpoint index")
+	})
+}
+
+func TestPendingRoundAssemblyState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("additional_confirmation_accumulates", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+
+		existingIntent := h.newTestBoardingIntent()
+		h.withState(&PendingRoundAssembly{
+			Intents: map[wire.OutPoint]BoardingIntent{
+				existingIntent.Outpoint: existingIntent,
+			},
+		})
+
+		newIntent := h.newTestBoardingIntent()
+		event := h.newBoardingUTXOConfirmedEvent(newIntent)
+
+		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		nextState := assertStateType[*PendingRoundAssembly](h)
+		require.Len(t, nextState.Intents, 2)
+	})
+
+	t.Run("registration_requested_transitions", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+
+		intent := h.newTestBoardingIntent()
+		h.withState(&PendingRoundAssembly{
+			Intents: map[wire.OutPoint]BoardingIntent{
+				intent.Outpoint: intent,
+			},
+		})
+
+		intents := []BoardingIntent{intent}
+		event := &RegistrationRequested{Intents: intents}
+
+		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		nextState := assertStateType[*RegistrationSentState](h)
+		require.Len(t, nextState.Intents, 1)
+	})
+
+	t.Run("no_intents_error", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+		h.withState(&PendingRoundAssembly{
+			Intents: map[wire.OutPoint]BoardingIntent{},
+		})
+
+		event := &RegistrationRequested{Intents: []BoardingIntent{}}
+
+		_, err := h.sendEvent(event)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no boarding requests")
+	})
+}
+
+func TestRegistrationSentState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("RoundJoined_transitions", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+
+		intent := h.newTestBoardingIntent()
+		h.withState(&RegistrationSentState{
+			Intents: []BoardingIntent{intent},
+		})
+
+		event := &RoundJoined{RoundID: "test-round-123"}
+
+		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		nextState := assertStateType[*RoundJoinedState](h)
+		require.Equal(t, "test-round-123", nextState.RoundID)
+		require.Len(t, nextState.Intents, 1)
+	})
+}
+
+func TestRoundJoinedState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("CommitmentTxBuilt_transitions", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+
+		intent := h.newTestBoardingIntent()
+		h.withState(&RoundJoinedState{
+			RoundID: "round-001",
+			Intents: []BoardingIntent{intent},
+		})
+
+		vtxtTree, _ := h.newTestVTXOTree(1)
+		commitEvent := h.newCommitmentTxBuiltEvent(
+			"round-001", []BoardingIntent{intent}, vtxtTree,
+		)
+
+		transition, err := h.sendEvent(commitEvent)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		nextState := assertStateType[*CommitmentTxReceivedState](h)
+		require.Equal(t, "round-001", nextState.RoundID)
+		require.NotNil(t, nextState.CommitmentTx)
+		require.True(t, transition.NewEvents.IsSome())
+	})
+}
+
+func TestCommitmentTxReceivedState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("validation_succeeds", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+
+		intent := h.newTestBoardingIntent()
+		intents := []BoardingIntent{intent}
+		vtxtTree := h.newTestVTXOTreeForIntent(intent)
+		commitmentTx := h.newTestCommitmentTx(intents)
+
+		state := &CommitmentTxReceivedState{
+			RoundID:      "round-001",
+			CommitmentTx: commitmentTx,
+			TxID:         commitmentTx.UnsignedTx.TxHash(),
+			VTXTTree:     vtxtTree,
+			Intents:      intents,
+			ClientTrees:  make(map[SignerKey]*tree.Tree),
+		}
+		h.withState(state)
+
+		event := &CommitmentTxBuilt{
+			RoundID:  "round-001",
+			Tx:       commitmentTx,
+			VTXTTree: vtxtTree,
+		}
+
+		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		validatedState := assertStateType[*CommitmentTxValidatedState](
+			h,
+		)
+		require.Equal(t, "round-001", validatedState.RoundID)
+		require.NotEmpty(t, validatedState.BoardingInputIndices)
+		assertTransitionEmitsInternalEvent[*GenerateNonces](
+			h, transition,
+		)
+	})
+
+	t.Run("missing_boarding_input_error", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+
+		intent := h.newTestBoardingIntent()
+		vtxtTree := h.newTestVTXOTreeForIntent(intent)
+
+		// Create tx WITHOUT the intent's outpoint. Create a fake intent
+		// with a different outpoint for the commitment tx.
+		differentIntent := h.newTestBoardingIntent()
+		differentIntents := []BoardingIntent{differentIntent}
+		commitmentTx := h.newTestCommitmentTx(differentIntents)
+
+		state := &CommitmentTxReceivedState{
+			RoundID:      "round-001",
+			CommitmentTx: commitmentTx,
+			TxID:         commitmentTx.UnsignedTx.TxHash(),
+			VTXTTree:     vtxtTree,
+			Intents:      []BoardingIntent{intent},
+			ClientTrees:  make(map[SignerKey]*tree.Tree),
+		}
+		h.withState(state)
+
+		event := &CommitmentTxBuilt{
+			RoundID:  "round-001",
+			Tx:       commitmentTx,
+			VTXTTree: vtxtTree,
+		}
+
+		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		failedState := assertStateType[*ClientFailedState](h)
+		require.Contains(t, failedState.Reason, "validation failed")
+	})
+}
+
+func TestCommitmentTxValidatedState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("GenerateNonces_transitions", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+		h.setupMockWalletForMuSig2()
+
+		intent := h.newTestBoardingIntent()
+		state := h.newCommitmentTxValidatedState(
+			"round-001", []BoardingIntent{intent},
+		)
+		h.withState(state)
+
+		transition, err := h.sendEvent(&GenerateNonces{})
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		noncesSentState := assertStateType[*NoncesSentState](h)
+		require.Equal(t, "round-001", noncesSentState.RoundID)
+		require.NotNil(t, noncesSentState.Musig2Sessions)
+
+		h.assertOutboxLen(1)
+		h.assertOutboxContainsType("*round.SubmitNoncesRequest")
+	})
+}
+
+func TestNoncesSentState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("NoncesAggregated_transitions", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+		h.setupMockWalletForMuSig2()
+
+		intent := h.newTestBoardingIntent()
+
+		// Build up through actual flow to get real sessions.
+		validatedState := h.newCommitmentTxValidatedState(
+			"round-001", []BoardingIntent{intent},
+		)
+		h.withState(validatedState)
+
+		_, err := h.sendEvent(&GenerateNonces{})
+		require.NoError(t, err)
+		h.clearOutbox()
+
+		noncesSentState := assertStateType[*NoncesSentState](h)
+
+		event := h.newNoncesAggregatedEvent(
+			"round-001", noncesSentState.VTXTTree,
+		)
+
+		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		noncesAggState := assertStateType[*NoncesAggregatedState](h)
+		require.Equal(t, "round-001", noncesAggState.RoundID)
+		assertTransitionEmitsInternalEvent[*GeneratePartialSigs](
+			h, transition,
+		)
+	})
+}
+
+func TestNoncesAggregatedState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("GeneratePartialSigs_transitions", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+		h.setupMockWalletForMuSig2()
+
+		intent := h.newTestBoardingIntent()
+
+		// We build through the full state machine flow to ensure MuSig2
+		// sessions are properly initialized with real nonce state.
+		validatedState := h.newCommitmentTxValidatedState(
+			"round-001", []BoardingIntent{intent},
+		)
+		h.withState(validatedState)
+
+		_, err := h.sendEvent(&GenerateNonces{})
+		require.NoError(t, err)
+		h.clearOutbox()
+
+		noncesSentState := assertStateType[*NoncesSentState](h)
+
+		aggEvent := h.newNoncesAggregatedEvent(
+			"round-001", noncesSentState.VTXTTree,
+		)
+		_, err = h.sendEvent(aggEvent)
+		require.NoError(t, err)
+		h.clearOutbox()
+
+		_ = assertStateType[*NoncesAggregatedState](h)
+
+		transition, err := h.sendEvent(&GeneratePartialSigs{})
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		partialSigsState := assertStateType[*PartialSigsSentState](h)
+		require.Equal(t, "round-001", partialSigsState.RoundID)
+		h.assertOutboxContainsType("*round.SubmitPartialSigRequest")
+	})
+}
+
+func TestPartialSigsSentState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("OperatorSigned_with_real_signatures", func(t *testing.T) {
+		t.Parallel()
+
+		h := newRealSigningTestHarness(t)
+
+		intent := h.newTestBoardingIntentWithTapscript()
+		vtxtTree := h.newTestVTXOTreeForIntent(intent)
+
+		validSigs, err := h.generateValidTreeSignatures(vtxtTree)
+		require.NoError(t, err)
+		require.NotEmpty(t, validSigs)
+
+		commitmentTx := h.newCommitmentTxForIntents(
+			[]BoardingIntent{intent}, vtxtTree,
+		)
+
+		clientTrees := make(map[SignerKey]*tree.Tree)
+		for _, vtxoReq := range intent.VtxoTemplate {
+			signerKey := NewSignerKey(vtxoReq.SigningKey.PubKey)
+			clientTrees[signerKey] = vtxtTree
+		}
+
+		state := &PartialSigsSentState{
+			RoundID:      "round-real-sig-001",
+			CommitmentTx: commitmentTx,
+			VTXTTree:     vtxtTree,
+			Intents:      []BoardingIntent{intent},
+			ClientTrees:  clientTrees,
+			BoardingInputIndices: map[wire.OutPoint]int{
+				intent.Outpoint: 0,
+			},
+			Musig2Sessions: make(map[SignerKey]*tree.SignerSession),
+		}
+
+		h.setupMockWalletForBoardingSigning()
+		h.setupMockRoundStoreForCommit()
+		h.withState(state)
+
+		event := &OperatorSigned{
+			RoundID:    "round-real-sig-001",
+			Signatures: validSigs,
+		}
+
+		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		inputSigState := assertStateType[*InputSigSentState](
+			h.boardingTestHarness,
+		)
+		require.Equal(t, "round-real-sig-001", inputSigState.RoundID)
+		require.NotEmpty(t, inputSigState.InputSigs)
+
+		h.assertOutboxContainsType("*round.SubmitForfeitSigRequest")
+		h.assertOutboxContainsType("*round.RegisterConfirmationRequest")
+	})
+
+	t.Run("empty_signatures_error", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+
+		intent := h.newTestBoardingIntent()
+		vtxtTree := h.newTestVTXOTreeForIntent(intent)
+		intents := []BoardingIntent{intent}
+		commitmentTx := h.newTestCommitmentTx(intents)
+
+		state := &PartialSigsSentState{
+			RoundID:      "round-001",
+			CommitmentTx: commitmentTx,
+			VTXTTree:     vtxtTree,
+			Intents:      []BoardingIntent{intent},
+			ClientTrees:  make(map[SignerKey]*tree.Tree),
+			BoardingInputIndices: map[wire.OutPoint]int{
+				intent.Outpoint: 0,
+			},
+		}
+		h.withState(state)
+
+		event := &OperatorSigned{
+			RoundID:    "round-001",
+			Signatures: map[chainhash.Hash][]byte{},
+		}
+
+		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		failedState := assertStateType[*ClientFailedState](h)
+		require.Contains(t, failedState.Reason, "signature")
+	})
+
+	t.Run("invalid_signature_format_error", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+
+		intent := h.newTestBoardingIntent()
+		vtxtTree := h.newTestVTXOTreeForIntent(intent)
+		intents := []BoardingIntent{intent}
+		commitmentTx := h.newTestCommitmentTx(intents)
+
+		state := &PartialSigsSentState{
+			RoundID:      "round-001",
+			CommitmentTx: commitmentTx,
+			VTXTTree:     vtxtTree,
+			Intents:      []BoardingIntent{intent},
+			ClientTrees:  make(map[SignerKey]*tree.Tree),
+			BoardingInputIndices: map[wire.OutPoint]int{
+				intent.Outpoint: 0,
+			},
+		}
+		h.withState(state)
+
+		// Use a fake txid with an invalid signature (too short).
+		fakeTxid := chainhash.HashH([]byte("fake-tx"))
+		event := &OperatorSigned{
+			RoundID: "round-001",
+			Signatures: map[chainhash.Hash][]byte{
+				fakeTxid: make([]byte, 10),
+			},
+		}
+
+		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		failedState := assertStateType[*ClientFailedState](h)
+		require.Contains(t, failedState.Reason, "signature")
+	})
+
+	t.Run("missing_input_index_error", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+
+		intent := h.newTestBoardingIntent()
+		vtxtTree := h.newTestVTXOTreeForIntent(intent)
+		intents := []BoardingIntent{intent}
+		commitmentTx := h.newTestCommitmentTx(intents)
+
+		state := &PartialSigsSentState{
+			RoundID:              "round-001",
+			CommitmentTx:         commitmentTx,
+			VTXTTree:             vtxtTree,
+			Intents:              []BoardingIntent{intent},
+			ClientTrees:          make(map[SignerKey]*tree.Tree),
+			BoardingInputIndices: make(map[wire.OutPoint]int),
+			Musig2Sessions: make(
+				map[SignerKey]*tree.SignerSession,
+			),
+		}
+		h.withState(state)
+
+		// Create a valid 64-byte signature with a fake txid.
+		validSig := make([]byte, 64)
+		for i := range validSig {
+			validSig[i] = byte(i + 1)
+		}
+		fakeTxid := chainhash.HashH([]byte("fake-tx"))
+
+		event := &OperatorSigned{
+			RoundID: "round-001",
+			Signatures: map[chainhash.Hash][]byte{
+				fakeTxid: validSig,
+			},
+		}
+
+		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		failedState := assertStateType[*ClientFailedState](h)
+		require.Contains(t, failedState.Reason, "signature")
+	})
+
+	t.Run("too_few_signatures_error", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+
+		intent := h.newTestBoardingIntent()
+		vtxtTree := h.newTestVTXOTreeForIntent(intent)
+		intents := []BoardingIntent{intent}
+		commitmentTx := h.newTestCommitmentTx(intents)
+
+		state := &PartialSigsSentState{
+			RoundID:      "round-001",
+			CommitmentTx: commitmentTx,
+			VTXTTree:     vtxtTree,
+			Intents:      []BoardingIntent{intent},
+			ClientTrees:  make(map[SignerKey]*tree.Tree),
+			BoardingInputIndices: map[wire.OutPoint]int{
+				intent.Outpoint: 0,
+			},
+		}
+		h.withState(state)
+
+		nodeCount := 0
+		_ = vtxtTree.Root.ForEach(func(n *tree.Node) error {
+			nodeCount++
+			return nil
+		})
+
+		if nodeCount > 1 {
+			// Only provide one signature when more are needed.
+			fakeTxid := chainhash.HashH([]byte("fake-tx"))
+			event := &OperatorSigned{
+				RoundID: "round-001",
+				Signatures: map[chainhash.Hash][]byte{
+					fakeTxid: make([]byte, 64),
+				},
+			}
+
+			transition, err := h.sendEvent(event)
+			require.NoError(t, err)
+			require.NotNil(t, transition)
+
+			failedState := assertStateType[*ClientFailedState](h)
+			require.Contains(t, failedState.Reason, "signature")
+		}
+	})
+}
+
+func TestInputSigSentState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("BoardingConfirmed_transitions", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+		h.setupMockVTXOStoreForSave()
+
+		intent := h.newTestBoardingIntent()
+		state := h.newInputSigSentState(
+			"round-001", []BoardingIntent{intent},
+		)
+		h.withState(state)
+
+		event := &BoardingConfirmed{
+			TxID:          state.CommitmentTx.UnsignedTx.TxHash(),
+			BlockHeight:   101,
+			Confirmations: 6,
+		}
+
+		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		confirmedState := assertStateType[*ConfirmedState](h)
+		require.Equal(t, int32(101), confirmedState.BlockHeight)
+		require.Equal(t, int32(6), confirmedState.Confirmations)
+
+		h.assertOutboxLen(2)
+		h.vtxoStore.AssertCalled(t, "SaveVTXOs", mock.Anything)
+	})
+
+	t.Run("buildClientVTXOs_error", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+
+		vtxtTree, _ := h.newTestVTXOTree(1)
+		intent := h.newTestBoardingIntent()
+
+		// Empty ClientTrees will cause buildClientVTXOs to fail.
+		state := &InputSigSentState{
+			RoundID:     "round-001",
+			VTXTTree:    vtxtTree,
+			Intents:     []BoardingIntent{intent},
+			ClientTrees: make(map[SignerKey]*tree.Tree),
+		}
+		h.withState(state)
+
+		event := &BoardingConfirmed{
+			TxID:          vtxtTree.BatchOutpoint.Hash,
+			BlockHeight:   101,
+			Confirmations: 6,
+		}
+
+		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		failedState := assertStateType[*ClientFailedState](h)
+		require.Contains(t, failedState.Reason, "build client VTXOs")
+	})
+}
+
+func TestConfirmedState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("RoundComplete_transitions_to_idle", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+		h.withState(&ConfirmedState{BlockHeight: 100})
+
+		transition, err := h.sendEvent(&RoundComplete{})
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		_ = assertStateType[*Idle](h)
+	})
+}
+
+func TestClientFailedState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("RecoveryInitiated_transitions", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+
+		intent := h.newTestBoardingIntent()
+		h.withState(&ClientFailedState{
+			Reason:      "round failed",
+			Recoverable: true,
+		})
+
+		event := &RecoveryInitiated{
+			Outpoint: intent.Outpoint,
+			Reason:   "CSV timeout recovery",
+		}
+
+		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		recoveryState := assertStateType[*RecoveryInitiatedState](h)
+		require.Equal(t, intent.Outpoint, recoveryState.Outpoint)
+		require.Equal(t, "CSV timeout recovery", recoveryState.Reason)
+	})
+}
+
+func TestValidateBoardingInputs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil_tx", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+		intent := h.newTestBoardingIntent()
+		intents := []BoardingIntent{intent}
+
+		result, err := validateBoardingInputs(nil, intents)
+
+		require.Error(t, err)
+		require.Nil(t, result)
+		require.Contains(t, err.Error(), "commitment tx is nil")
+	})
+
+	t.Run("empty_intents", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+		packet := h.newTestCommitmentTx(nil)
+
+		result, err := validateBoardingInputs(
+			packet.UnsignedTx, []BoardingIntent{},
+		)
+
+		require.Error(t, err)
+		require.Nil(t, result)
+		require.Contains(t, err.Error(), "no boarding intents")
+	})
+
+	t.Run("missing_outpoint", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+		intent := h.newTestBoardingIntent()
+
+		// Create a different intent so the commitment tx has a
+		// different outpoint than what we're validating.
+		differentIntent := h.newTestBoardingIntent()
+		packet := h.newTestCommitmentTx(
+			[]BoardingIntent{differentIntent},
+		)
+		intents := []BoardingIntent{intent}
+
+		result, err := validateBoardingInputs(
+			packet.UnsignedTx, intents,
+		)
+
+		require.Error(t, err)
+		require.Nil(t, result)
+		require.Contains(t, err.Error(), "not found in commitment tx")
+	})
+
+	t.Run("success_single", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+		intent := h.newTestBoardingIntent()
+		intents := []BoardingIntent{intent}
+		packet := h.newTestCommitmentTx(intents)
+
+		result, err := validateBoardingInputs(
+			packet.UnsignedTx, intents,
+		)
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Len(t, result, 1)
+
+		idx, found := result[intent.Outpoint]
+		require.True(t, found)
+		require.Equal(t, 0, idx)
+	})
+
+	t.Run("success_multiple", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+		intent1 := h.newTestBoardingIntent()
+		intent2 := h.newTestBoardingIntent()
+		intent3 := h.newTestBoardingIntent()
+
+		intents := []BoardingIntent{intent1, intent2, intent3}
+		packet := h.newTestCommitmentTx(intents)
+
+		result, err := validateBoardingInputs(
+			packet.UnsignedTx, intents,
+		)
+
+		require.NoError(t, err)
+		require.Len(t, result, 3)
+		require.Equal(t, 0, result[intent1.Outpoint])
+		require.Equal(t, 1, result[intent2.Outpoint])
+		require.Equal(t, 2, result[intent3.Outpoint])
+	})
+}
+
+func TestNewSignerKey(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid_key", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+		result := NewSignerKey(h.clientPubKey)
+
+		// SignerKey is [33]byte (compressed pubkey).
+		require.Len(t, result, 33)
+		require.Equal(
+			t, h.clientPubKey.SerializeCompressed(), result[:],
+		)
+	})
+
+	t.Run("deterministic", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+		result1 := NewSignerKey(h.clientPubKey)
+		result2 := NewSignerKey(h.clientPubKey)
+
+		require.Equal(t, result1, result2)
+	})
+}
+
+func TestBoardingFlowIdleToPendingToRegistrationSent(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+
+	intent := h.newTestBoardingIntent()
+	intentsMap := map[wire.OutPoint]BoardingIntent{intent.Outpoint: intent}
+	h.withState(&PendingRoundAssembly{Intents: intentsMap})
+
+	// Step 1: Request registration.
+	regEvent := &RegistrationRequested{Intents: []BoardingIntent{intent}}
+	_, err := h.sendEvent(regEvent)
+	require.NoError(t, err)
+
+	regState := assertStateType[*RegistrationSentState](h)
+	require.Len(t, regState.Intents, 1)
+
+	// Step 2: Server accepts.
+	joinEvent := &RoundJoined{RoundID: "round-001"}
+	_, err = h.sendEvent(joinEvent)
+	require.NoError(t, err)
+
+	joinedState := assertStateType[*RoundJoinedState](h)
+	require.Equal(t, "round-001", joinedState.RoundID)
+}
+
+func TestBoardingFlowMultipleIntentsAccumulation(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+	h.withState(&Idle{})
+
+	// We confirm multiple UTXOs to verify that PendingRoundAssembly
+	// correctly accumulates boarding intents as they arrive, rather than
+	// replacing or dropping previous ones.
+	for i := 0; i < 3; i++ {
+		intent := h.newTestBoardingIntent()
+		event := h.newBoardingUTXOConfirmedEvent(intent)
+
+		_, err := h.sendEvent(event)
+		require.NoError(t, err)
+
+		state := assertStateType[*PendingRoundAssembly](h)
+		require.Len(t, state.Intents, i+1)
+	}
+}
+
+func TestBoardingFlowPendingToRoundJoined(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+
+	intent := h.newTestBoardingIntent()
+	intentsMap := map[wire.OutPoint]BoardingIntent{intent.Outpoint: intent}
+	h.withState(&PendingRoundAssembly{Intents: intentsMap})
+
+	// Step 1: PendingRoundAssembly → RegistrationSentState.
+	regEvent := &RegistrationRequested{Intents: []BoardingIntent{intent}}
+	_, err := h.sendEvent(regEvent)
+	require.NoError(t, err)
+
+	regSentState := assertStateType[*RegistrationSentState](h)
+	require.Len(t, regSentState.Intents, 1)
+
+	// Step 2: RegistrationSentState → RoundJoinedState.
+	joinEvent := &RoundJoined{RoundID: "round-integration-001"}
+	_, err = h.sendEvent(joinEvent)
+	require.NoError(t, err)
+
+	joinedState := assertStateType[*RoundJoinedState](h)
+	require.Equal(t, "round-integration-001", joinedState.RoundID)
+}
+
+func TestBoardingFlowRoundJoinedToPartialSigsSent(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+	h.setupMockWalletForMuSig2()
+
+	intent := h.newTestBoardingIntent()
+
+	h.withState(&RoundJoinedState{
+		RoundID: "round-integration-002",
+		Intents: []BoardingIntent{intent},
+	})
+
+	// Step 1: RoundJoined → CommitmentTxReceived.
+	vtxtTree := h.newTestVTXOTreeForIntent(intent)
+	commitEvent := h.newCommitmentTxBuiltEvent(
+		"round-integration-002", []BoardingIntent{intent}, vtxtTree,
+	)
+	_, err := h.sendEvent(commitEvent)
+	require.NoError(t, err)
+
+	ctxReceivedState := assertStateType[*CommitmentTxReceivedState](h)
+	require.NotNil(t, ctxReceivedState.CommitmentTx)
+
+	// Step 2: CommitmentTxReceived → CommitmentTxValidated.
+	_, err = h.sendEvent(&CommitmentTxBuilt{
+		RoundID:  "round-integration-002",
+		Tx:       ctxReceivedState.CommitmentTx,
+		VTXTTree: ctxReceivedState.VTXTTree,
+	})
+	require.NoError(t, err)
+
+	ctxValidatedState := assertStateType[*CommitmentTxValidatedState](h)
+	require.NotEmpty(t, ctxValidatedState.BoardingInputIndices)
+	h.clearOutbox()
+
+	// Step 3: CommitmentTxValidated → NoncesSent.
+	_, err = h.sendEvent(&GenerateNonces{})
+	require.NoError(t, err)
+
+	noncesSentState := assertStateType[*NoncesSentState](h)
+	require.NotEmpty(t, noncesSentState.Musig2Sessions)
+	h.clearOutbox()
+
+	// Step 4: NoncesSent → NoncesAggregated.
+	aggNoncesEvent := h.newNoncesAggregatedEvent(
+		"round-integration-002", noncesSentState.VTXTTree,
+	)
+	_, err = h.sendEvent(aggNoncesEvent)
+	require.NoError(t, err)
+
+	noncesAggState := assertStateType[*NoncesAggregatedState](h)
+	require.NotEmpty(t, noncesAggState.AggregatedNonces)
+	h.clearOutbox()
+
+	// Step 5: NoncesAggregated → PartialSigsSent.
+	_, err = h.sendEvent(&GeneratePartialSigs{})
+	require.NoError(t, err)
+
+	partialSigsState := assertStateType[*PartialSigsSentState](h)
+	require.Equal(t, "round-integration-002", partialSigsState.RoundID)
+}
+
+func TestBoardingFlowFailureAndRecovery(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+
+	intent := h.newTestBoardingIntent()
+	h.withState(&RoundJoinedState{
+		RoundID: "round-fail-001",
+		Intents: []BoardingIntent{intent},
+	})
+
+	// We inject a failure event to verify the state machine correctly
+	// transitions to ClientFailedState, preserving the failure reason
+	// and recoverability flag for later recovery attempts.
+	_, err := h.sendEvent(&BoardingFailed{
+		Reason:      "operator went offline",
+		Recoverable: true,
+	})
+	require.NoError(t, err)
+
+	failedState := assertStateType[*ClientFailedState](h)
+	require.Equal(t, "operator went offline", failedState.Reason)
+
+	// After failure, we verify recovery can be initiated by transitioning
+	// to RecoveryInitiatedState, which triggers CSV timeout-based fund
+	// recovery.
+	_, err = h.sendEvent(&RecoveryInitiated{
+		Outpoint: intent.Outpoint,
+		Reason:   "CSV timeout recovery",
+	})
+	require.NoError(t, err)
+
+	recoveryState := assertStateType[*RecoveryInitiatedState](h)
+	require.Equal(t, intent.Outpoint, recoveryState.Outpoint)
+}

--- a/round/transitions_test.go
+++ b/round/transitions_test.go
@@ -28,11 +28,6 @@ func TestStateProperties(t *testing.T) {
 				expected: "Confirmed",
 			},
 			{
-				name:     "ClientFailed",
-				state:    &ClientFailedState{Reason: "test"},
-				expected: "ClientFailed",
-			},
-			{
 				name: "RecoveryInitiated",
 				state: &RecoveryInitiatedState{
 					Reason: "CSV",
@@ -101,6 +96,11 @@ func TestStateProperties(t *testing.T) {
 				"InputSigSent", &InputSigSentState{},
 				"InputSigSent",
 			},
+			{
+				"ClientFailed",
+				&ClientFailedState{Reason: "test"},
+				"ClientFailed: test",
+			},
 		}
 
 		for _, tc := range tests {
@@ -114,8 +114,9 @@ func TestStateProperties(t *testing.T) {
 	})
 }
 
-// TestUnexpectedEventErrors verifies all states reject invalid events.
-func TestUnexpectedEventErrors(t *testing.T) {
+// TestUnexpectedEventSelfLoop verifies all states self-loop on unexpected
+// events instead of returning an error. This prevents FSM halt.
+func TestUnexpectedEventSelfLoop(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -124,14 +125,14 @@ func TestUnexpectedEventErrors(t *testing.T) {
 		event ClientEvent
 	}{
 		{
-			name: "Idle_rejects_RoundJoined",
+			name: "Idle_self_loops_on_RoundJoined",
 			setup: func(h *boardingTestHarness) ClientState {
 				return &Idle{}
 			},
 			event: &RoundJoined{RoundID: "test"},
 		},
 		{
-			name: "PendingRoundAssembly_rejects_RoundComplete",
+			name: "PendingAssembly_self_loops_on_RoundComplete",
 			setup: func(h *boardingTestHarness) ClientState {
 				intent := h.newTestBoardingIntent()
 				intents := map[wire.OutPoint]BoardingIntent{
@@ -145,7 +146,7 @@ func TestUnexpectedEventErrors(t *testing.T) {
 			event: &RoundComplete{},
 		},
 		{
-			name: "RegistrationSent_rejects_BoardingConfirmed",
+			name: "RegSent_self_loops_on_BoardingConfirmed",
 			setup: func(h *boardingTestHarness) ClientState {
 				intent := h.newTestBoardingIntent()
 				return &RegistrationSentState{
@@ -155,7 +156,7 @@ func TestUnexpectedEventErrors(t *testing.T) {
 			event: &BoardingConfirmed{},
 		},
 		{
-			name: "RoundJoined_rejects_duplicate_RoundJoined",
+			name: "RoundJoined_self_loops_on_duplicate_RoundJoined",
 			setup: func(h *boardingTestHarness) ClientState {
 				intent := h.newTestBoardingIntent()
 				return &RoundJoinedState{
@@ -166,7 +167,7 @@ func TestUnexpectedEventErrors(t *testing.T) {
 			event: &RoundJoined{RoundID: "another-round"},
 		},
 		{
-			name: "CommitmentTxReceived_rejects_RoundJoined",
+			name: "CommitmentTxReceived_self_loops_on_RoundJoined",
 			setup: func(h *boardingTestHarness) ClientState {
 				intent := h.newTestBoardingIntent()
 				return h.newCommitmentTxReceivedState(
@@ -176,7 +177,7 @@ func TestUnexpectedEventErrors(t *testing.T) {
 			event: &RoundJoined{RoundID: "another-round"},
 		},
 		{
-			name: "CommitmentTxValidated_rejects_RoundJoined",
+			name: "CommitmentTxValidated_self_loops_on_RoundJoined",
 			setup: func(h *boardingTestHarness) ClientState {
 				intent := h.newTestBoardingIntent()
 				return h.newCommitmentTxValidatedState(
@@ -186,7 +187,7 @@ func TestUnexpectedEventErrors(t *testing.T) {
 			event: &RoundJoined{RoundID: "another-round"},
 		},
 		{
-			name: "NoncesSent_rejects_RoundJoined",
+			name: "NoncesSent_self_loops_on_RoundJoined",
 			setup: func(h *boardingTestHarness) ClientState {
 				vtxtTree, _ := h.newTestVTXOTree(1)
 				intent := h.newTestBoardingIntent()
@@ -199,7 +200,7 @@ func TestUnexpectedEventErrors(t *testing.T) {
 			event: &RoundJoined{RoundID: "another-round"},
 		},
 		{
-			name: "NoncesAggregated_rejects_RoundJoined",
+			name: "NoncesAggregated_self_loops_on_RoundJoined",
 			setup: func(h *boardingTestHarness) ClientState {
 				vtxtTree, _ := h.newTestVTXOTree(1)
 				intent := h.newTestBoardingIntent()
@@ -212,7 +213,7 @@ func TestUnexpectedEventErrors(t *testing.T) {
 			event: &RoundJoined{RoundID: "another-round"},
 		},
 		{
-			name: "PartialSigsSent_rejects_RoundJoined",
+			name: "PartialSigsSent_self_loops_on_RoundJoined",
 			setup: func(h *boardingTestHarness) ClientState {
 				vtxtTree, _ := h.newTestVTXOTree(1)
 				intent := h.newTestBoardingIntent()
@@ -225,7 +226,7 @@ func TestUnexpectedEventErrors(t *testing.T) {
 			event: &RoundJoined{RoundID: "another-round"},
 		},
 		{
-			name: "InputSigSent_rejects_RoundJoined",
+			name: "InputSigSent_self_loops_on_RoundJoined",
 			setup: func(h *boardingTestHarness) ClientState {
 				vtxtTree, _ := h.newTestVTXOTree(1)
 				intent := h.newTestBoardingIntent()
@@ -237,6 +238,16 @@ func TestUnexpectedEventErrors(t *testing.T) {
 			},
 			event: &RoundJoined{RoundID: "another-round"},
 		},
+		{
+			name: "ClientFailed_self_loops_on_unknown",
+			setup: func(h *boardingTestHarness) ClientState {
+				return &ClientFailedState{
+					Reason:      "previous failure",
+					Recoverable: true,
+				}
+			},
+			event: &RoundJoined{RoundID: "test"},
+		},
 	}
 
 	for _, tc := range tests {
@@ -244,11 +255,19 @@ func TestUnexpectedEventErrors(t *testing.T) {
 			t.Parallel()
 
 			h := newTestHarness(t)
-			h.withState(tc.setup(h))
+			initialState := tc.setup(h)
+			h.withState(initialState)
 
-			_, err := h.sendEvent(tc.event)
-			require.Error(t, err)
-			require.Contains(t, err.Error(), "unexpected")
+			transition, err := h.sendEvent(tc.event)
+			require.NoError(t, err)
+			require.NotNil(t, transition)
+
+			// Verify self-loop: state type unchanged.
+			require.Equal(
+				t,
+				initialState.String(),
+				h.currentState.String(),
+			)
 		})
 	}
 }
@@ -453,7 +472,7 @@ func TestIdleState(t *testing.T) {
 		_ = assertStateType[*Idle](h)
 	})
 
-	t.Run("nil_tx_error", func(t *testing.T) {
+	t.Run("nil_tx_transitions_to_failed", func(t *testing.T) {
 		t.Parallel()
 
 		h := newTestHarness(t)
@@ -463,12 +482,15 @@ func TestIdleState(t *testing.T) {
 		event := h.newBoardingUTXOConfirmedEvent(intent)
 		event.Tx = nil
 
-		_, err := h.sendEvent(event)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "missing transaction")
+		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		failedState := assertStateType[*ClientFailedState](h)
+		require.Contains(t, failedState.Reason, "missing transaction")
 	})
 
-	t.Run("invalid_outpoint_index_error", func(t *testing.T) {
+	t.Run("invalid_outpoint_transitions_to_failed", func(t *testing.T) {
 		t.Parallel()
 
 		h := newTestHarness(t)
@@ -478,9 +500,12 @@ func TestIdleState(t *testing.T) {
 		event := h.newBoardingUTXOConfirmedEvent(intent)
 		event.Outpoint.Index = 999
 
-		_, err := h.sendEvent(event)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "invalid outpoint index")
+		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		failedState := assertStateType[*ClientFailedState](h)
+		require.Contains(t, failedState.Reason, "invalid outpoint")
 	})
 }
 
@@ -533,7 +558,7 @@ func TestPendingRoundAssemblyState(t *testing.T) {
 		require.Len(t, nextState.Intents, 1)
 	})
 
-	t.Run("no_intents_error", func(t *testing.T) {
+	t.Run("no_intents_transitions_to_failed", func(t *testing.T) {
 		t.Parallel()
 
 		h := newTestHarness(t)
@@ -543,9 +568,12 @@ func TestPendingRoundAssemblyState(t *testing.T) {
 
 		event := &RegistrationRequested{Intents: []BoardingIntent{}}
 
-		_, err := h.sendEvent(event)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "no boarding requests")
+		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		failedState := assertStateType[*ClientFailedState](h)
+		require.Contains(t, failedState.Reason, "no boarding requests")
 	})
 }
 

--- a/round/validation.go
+++ b/round/validation.go
@@ -1,0 +1,118 @@
+package round
+
+import (
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/lightninglabs/darepo-client/lib/scripts"
+)
+
+// MaxReasonableDelay is the maximum reasonable delay in blocks (~1 year).
+const MaxReasonableDelay = 52560
+
+// ValidateBoardingScript validates that a boarding tapscript has the
+// expected structure with collaborative and timeout paths.
+func ValidateBoardingScript(tapscript *waddrmgr.Tapscript,
+	clientKey *btcec.PublicKey, operatorKey *btcec.PublicKey,
+	expectedExitDelay uint32) error {
+
+	if tapscript == nil {
+		return fmt.Errorf("tapscript is nil")
+	}
+
+	// Ensure control block is present for taproot spending.
+	if tapscript.ControlBlock == nil {
+		return fmt.Errorf("tapscript control block is nil")
+	}
+
+	// Verify the internal key exists for taproot construction.
+	if tapscript.ControlBlock.InternalKey == nil {
+		return fmt.Errorf("control block internal key is nil")
+	}
+
+	// Ensure the internal key is unspendable (ARK NUMS key) to force
+	// script path spending only.
+	if !tapscript.ControlBlock.InternalKey.IsEqual(&scripts.ARKNUMSKey) {
+		return fmt.Errorf("internal key is not ARK NUMS key")
+	}
+
+	// Boarding scripts must be full tree types with both the collaborative
+	// and timeout script paths.
+	if tapscript.Type != waddrmgr.TapscriptTypeFullTree {
+		return fmt.Errorf("boarding script must be "+
+			"TapscriptTypeFullTree, got %v", tapscript.Type)
+	}
+
+	if len(tapscript.Leaves) != 2 {
+		return fmt.Errorf("boarding script has %d leaves, "+
+			"expected 2", len(tapscript.Leaves))
+	}
+
+	// Construct the expected boarding tapscript using lib function. This
+	// ensures we validate against the exact script structure that lib
+	// creates.
+	expectedTapscript, err := scripts.VTXOTapScript(
+		clientKey, operatorKey, expectedExitDelay,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to construct expected "+
+			"boarding script: %w", err)
+	}
+
+	if len(expectedTapscript.Leaves) != 2 {
+		return fmt.Errorf("expected tapscript has %d leaves, "+
+			"should be 2", len(expectedTapscript.Leaves))
+	}
+
+	// Compare each leaf script byte-for-byte. The order may vary, so check
+	// if each actual leaf matches one of expected leaves.
+	actualLeaves := make(map[string]bool)
+	for _, leaf := range tapscript.Leaves {
+		actualLeaves[string(leaf.Script)] = true
+	}
+
+	for i, expectedLeaf := range expectedTapscript.Leaves {
+		if !actualLeaves[string(expectedLeaf.Script)] {
+			return fmt.Errorf("expected leaf %d not "+
+				"found in actual boarding script", i)
+		}
+	}
+
+	return nil
+}
+
+// ValidateDelayParameters validates the delay parameters for security.
+//
+// SweepDelay MUST be greater than VTXOExitDelay to ensure the operator has
+// time to respond to unilateral exits before the batch expires.
+func ValidateDelayParameters(sweepDelay, vtxoExitDelay uint32) error {
+	// Both delays must be non-zero.
+	if sweepDelay == 0 {
+		return fmt.Errorf("sweep delay is zero")
+	}
+	if vtxoExitDelay == 0 {
+		return fmt.Errorf("VTXO exit delay is zero")
+	}
+
+	// Sweep delay must be greater than VTXO exit delay for security.
+	// This ensures the operator has time to respond to griefing attacks.
+	if sweepDelay <= vtxoExitDelay {
+		return fmt.Errorf("sweep delay (%d) must be greater than "+
+			"VTXO exit delay (%d)", sweepDelay, vtxoExitDelay)
+	}
+
+	// Sanity check: Delays should be reasonable (less than ~1 year).
+	if sweepDelay > MaxReasonableDelay {
+		return fmt.Errorf("sweep delay (%d) exceeds maximum "+
+			"reasonable "+
+			"value (%d blocks)", sweepDelay, MaxReasonableDelay)
+	}
+	if vtxoExitDelay > MaxReasonableDelay {
+		return fmt.Errorf("VTXO exit delay (%d) exceeds maximum "+
+			"reasonable value (%d blocks)", vtxoExitDelay,
+			MaxReasonableDelay)
+	}
+
+	return nil
+}

--- a/round/validation_test.go
+++ b/round/validation_test.go
@@ -1,0 +1,312 @@
+package round
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/lightninglabs/darepo-client/lib/scripts"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateDelayParametersValid tests that valid delay parameters pass
+// validation.
+func TestValidateDelayParametersValid(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateDelayParameters(1008, 144)
+	require.NoError(t, err)
+}
+
+// TestValidateDelayParametersZeroSweepDelay tests that zero sweep delay is
+// rejected.
+func TestValidateDelayParametersZeroSweepDelay(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateDelayParameters(0, 144)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "sweep delay is zero")
+}
+
+// TestValidateDelayParametersZeroExitDelay tests that zero exit delay is
+// rejected.
+func TestValidateDelayParametersZeroExitDelay(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateDelayParameters(1008, 0)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "VTXO exit delay is zero")
+}
+
+// TestValidateDelayParametersSweepNotGreaterThanExit tests that sweep delay
+// must strictly exceed exit delay.
+func TestValidateDelayParametersSweepNotGreaterThanExit(t *testing.T) {
+	t.Parallel()
+
+	// Sweep delay must strictly exceed exit delay to ensure users have time
+	// to respond after the exit path becomes available.
+	err := ValidateDelayParameters(144, 144)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "must be greater than")
+
+	err = ValidateDelayParameters(100, 144)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "must be greater than")
+}
+
+// TestValidateDelayParametersSweepDelayTooLarge tests that sweep delay
+// exceeding the maximum is rejected.
+func TestValidateDelayParametersSweepDelayTooLarge(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateDelayParameters(60000, 144)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds maximum reasonable")
+}
+
+// TestValidateDelayParametersExitDelayTooLarge tests that exit delay exceeding
+// the maximum is rejected.
+func TestValidateDelayParametersExitDelayTooLarge(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateDelayParameters(100000, 60000)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds maximum reasonable")
+}
+
+// TestValidateDelayParametersBoundaryValues tests delay parameter validation
+// at boundary values.
+func TestValidateDelayParametersBoundaryValues(t *testing.T) {
+	t.Parallel()
+
+	// Maximum reasonable delay is 52560 blocks (approximately 1 year).
+	err := ValidateDelayParameters(52560, 52559)
+	require.NoError(t, err)
+
+	err = ValidateDelayParameters(52561, 144)
+	require.Error(t, err)
+}
+
+// TestValidateBoardingScriptNilTapscript tests that nil tapscript is rejected.
+func TestValidateBoardingScriptNilTapscript(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+	err := ValidateBoardingScript(
+		nil, h.clientPubKey, h.operatorPubKey, testExitDelay,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "tapscript is nil")
+}
+
+// TestValidateBoardingScriptNilControlBlock tests that nil control block is
+// rejected.
+func TestValidateBoardingScriptNilControlBlock(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+	tapscript := &waddrmgr.Tapscript{
+		ControlBlock: nil,
+	}
+
+	err := ValidateBoardingScript(
+		tapscript, h.clientPubKey, h.operatorPubKey, testExitDelay,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "control block is nil")
+}
+
+// TestValidateBoardingScriptNilInternalKey tests that nil internal key is
+// rejected.
+func TestValidateBoardingScriptNilInternalKey(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+	tapscript := &waddrmgr.Tapscript{
+		ControlBlock: &txscript.ControlBlock{
+			InternalKey: nil,
+		},
+	}
+
+	err := ValidateBoardingScript(
+		tapscript, h.clientPubKey, h.operatorPubKey, testExitDelay,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "internal key is nil")
+}
+
+// TestValidateBoardingScriptWrongInternalKey tests that non-NUMS internal key
+// is rejected.
+func TestValidateBoardingScriptWrongInternalKey(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+
+	// Internal key must be the ARK NUMS key to prevent anyone from
+	// spending via the key path, forcing all spends through scripts.
+	_, wrongKey := generateTestKeyPair(t)
+
+	tapscript := &waddrmgr.Tapscript{
+		ControlBlock: &txscript.ControlBlock{
+			InternalKey: wrongKey,
+		},
+	}
+
+	err := ValidateBoardingScript(
+		tapscript, h.clientPubKey, h.operatorPubKey, testExitDelay,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not ARK NUMS key")
+}
+
+// TestValidateBoardingScriptNotFullTree tests that non-full-tree tapscript
+// types are rejected.
+func TestValidateBoardingScriptNotFullTree(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+
+	// Boarding scripts must be TapscriptTypeFullTree, not partial tree or
+	// control block only.
+	tapscript := &waddrmgr.Tapscript{
+		Type: waddrmgr.TapscriptTypePartialReveal,
+		ControlBlock: &txscript.ControlBlock{
+			InternalKey: &scripts.ARKNUMSKey,
+		},
+		Leaves: []txscript.TapLeaf{
+			{Script: []byte{0x01}},
+			{Script: []byte{0x02}},
+		},
+	}
+
+	err := ValidateBoardingScript(
+		tapscript, h.clientPubKey, h.operatorPubKey, testExitDelay,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "must be TapscriptTypeFullTree")
+}
+
+// TestValidateBoardingScriptFullTreeWrongLeafCount tests that full tree with
+// wrong leaf count is rejected.
+func TestValidateBoardingScriptFullTreeWrongLeafCount(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+
+	// Boarding scripts have exactly 2 leaves: operator sweep and client
+	// exit paths.
+	tapscript := &waddrmgr.Tapscript{
+		Type: waddrmgr.TapscriptTypeFullTree,
+		ControlBlock: &txscript.ControlBlock{
+			InternalKey: &scripts.ARKNUMSKey,
+		},
+		Leaves: []txscript.TapLeaf{
+			{Script: []byte{0x01}},
+		},
+	}
+
+	err := ValidateBoardingScript(
+		tapscript, h.clientPubKey, h.operatorPubKey, testExitDelay,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "expected 2")
+}
+
+// TestValidateDelayParametersTableDriven tests delay parameter validation
+// using table-driven test cases.
+func TestValidateDelayParametersTableDriven(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name          string
+		sweepDelay    uint32
+		vtxoExitDelay uint32
+		expectError   bool
+		errorMsg      string
+	}{
+		{
+			name:          "valid typical values",
+			sweepDelay:    1008,
+			vtxoExitDelay: 144,
+			expectError:   false,
+		},
+		{
+			name:          "valid minimum difference",
+			sweepDelay:    2,
+			vtxoExitDelay: 1,
+			expectError:   false,
+		},
+		{
+			name:          "valid at boundary",
+			sweepDelay:    52560,
+			vtxoExitDelay: 52559,
+			expectError:   false,
+		},
+		{
+			name:          "zero sweep delay",
+			sweepDelay:    0,
+			vtxoExitDelay: 144,
+			expectError:   true,
+			errorMsg:      "sweep delay is zero",
+		},
+		{
+			name:          "zero exit delay",
+			sweepDelay:    1008,
+			vtxoExitDelay: 0,
+			expectError:   true,
+			errorMsg:      "exit delay is zero",
+		},
+		{
+			name:          "both zero",
+			sweepDelay:    0,
+			vtxoExitDelay: 0,
+			expectError:   true,
+			errorMsg:      "sweep delay is zero",
+		},
+		{
+			name:          "sweep equals exit",
+			sweepDelay:    144,
+			vtxoExitDelay: 144,
+			expectError:   true,
+			errorMsg:      "must be greater than",
+		},
+		{
+			name:          "sweep less than exit",
+			sweepDelay:    100,
+			vtxoExitDelay: 200,
+			expectError:   true,
+			errorMsg:      "must be greater than",
+		},
+		{
+			name:          "sweep exceeds max",
+			sweepDelay:    52561,
+			vtxoExitDelay: 144,
+			expectError:   true,
+			errorMsg:      "exceeds maximum",
+		},
+		{
+			name:          "exit exceeds max",
+			sweepDelay:    100000,
+			vtxoExitDelay: 60000,
+			expectError:   true,
+			errorMsg:      "exceeds maximum",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := ValidateDelayParameters(
+				tc.sweepDelay, tc.vtxoExitDelay,
+			)
+			if tc.expectError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.errorMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implements the client-side boarding round state machine for coordinating Bitcoin deposits into the Ark VTXO tree. The architecture strictly separates protocol logic from side effects: a deterministic FSM handles all state transitions and validation.

## Core Components

- **States** (`states.go`): Immutable state types from Idle through BoardingComplete
- **Events** (`events.go`, `common_events.go`): Event definitions driving the FSM
- **Transitions** (`transitions.go`): Core protocol logic for each state's event handling
- **Validation** (`validation.go`): Commitment transaction verification (boarding inputs, VTXO leaves)
- **Outbox Messages** (`outbox_messages.go`): Server communication types with ToProto methods

## Security Model

Security-critical validation ensures clients verify complete VTXO tree signatures before releasing boarding input signatures. This prevents malicious operators from capturing funds without providing promised VTXOs. See `round/README.md` for the full protocol flow.

## Testing

Test coverage includes:
- Validation tests with real MuSig2 signing infrastructure
- FSM test harness for state transition testing
- Multi-intent test scenarios