### PR TITLE
vtxo: start to implement vtxo actor, focusing on forfeit, and expiry behavior 

### DIFF
--- a/lib/tree/tree.go
+++ b/lib/tree/tree.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/scripts"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
 )
@@ -313,4 +315,240 @@ func (t *Tree) NewTreeSignerSession(wallet input.MuSig2Signer,
 		wallet, signerKey, t.SweepTapscriptRoot, prevOutFetcher,
 		t.Root,
 	)
+}
+
+// VTXOExpectation describes expected VTXO leaf outputs for path validation.
+type VTXOExpectation struct {
+	// Amount is the expected satoshi value of the VTXO output.
+	Amount btcutil.Amount
+
+	// PkScript is the expected output script.
+	PkScript []byte
+
+	// OperatorKey is the expected operator co-signer key.
+	OperatorKey *btcec.PublicKey
+}
+
+// ValidatePath validates the tree path from the batch output to the client's
+// VTXOs for a given signing key. It ensures the client can unilaterally unroll
+// their VTXOs if needed.
+//
+// The client MUST validate the complete path before signing the boarding UTXO.
+// This ensures they can recover their funds even if the operator disappears.
+//
+// Returns the extracted client sub-tree on success.
+func (t *Tree) ValidatePath(signingKey *btcec.PublicKey,
+	expectedVTXOs []VTXOExpectation) (*Tree, error) {
+
+	if t == nil {
+		return nil, fmt.Errorf("tree is nil")
+	}
+	if signingKey == nil {
+		return nil, fmt.Errorf("signing key is nil")
+	}
+
+	// Ensure the tree structure is valid before extracting paths to
+	// prevent processing of malformed trees.
+	if err := t.Verify(); err != nil {
+		return nil, fmt.Errorf("tree structure invalid: %w", err)
+	}
+
+	// Extract only the transactions the client needs to sign, reducing the
+	// validation scope to their specific path.
+	clientTree, err := t.ExtractPathForCoSigners(signingKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract client path for "+
+			"signing key: %w", err)
+	}
+
+	// Collect all leaf nodes from the client's path to verify they match
+	// the requested VTXOs.
+	var leafNodes []*Node
+	if err = clientTree.Root.ForEachLeaf(func(node *Node) error {
+		leafNodes = append(leafNodes, node)
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("failed to iterate leaf nodes: %w", err)
+	}
+
+	if len(leafNodes) != len(expectedVTXOs) {
+		return nil, fmt.Errorf("tree has %d leaf nodes, expected %d "+
+			"VTXOs", len(leafNodes), len(expectedVTXOs))
+	}
+
+	// Verify each leaf output matches the expected VTXO parameters to
+	// ensure the client receives exactly what they requested.
+	for i, leaf := range leafNodes {
+		expectedVTXO := expectedVTXOs[i]
+
+		// Each leaf must have at least a VTXO output and an anchor
+		// output for fee bumping.
+		if len(leaf.Outputs) < 2 {
+			return nil, fmt.Errorf("leaf node %d has %d outputs, "+
+				"expected at least 2", i, len(leaf.Outputs))
+		}
+
+		vtxoOutput := leaf.Outputs[0]
+
+		// Ensure the VTXO amount matches the request to prevent value
+		// extraction by the operator.
+		if vtxoOutput.Value != int64(expectedVTXO.Amount) {
+			return nil, fmt.Errorf("leaf node %d output value %d "+
+				"!= expected %d", i, vtxoOutput.Value,
+				expectedVTXO.Amount)
+		}
+
+		// Verify the output script matches to ensure funds go to the
+		// correct destination.
+		if !bytes.Equal(vtxoOutput.PkScript, expectedVTXO.PkScript) {
+			return nil, fmt.Errorf("leaf node %d output script "+
+				"mismatch", i)
+		}
+
+		// Confirm operator key is present as co-signer to enable
+		// collaborative spending path.
+		operatorFound := false
+		for _, cosigner := range leaf.CoSigners {
+			if cosigner.IsEqual(expectedVTXO.OperatorKey) {
+				operatorFound = true
+				break
+			}
+		}
+		if !operatorFound {
+			return nil, fmt.Errorf("leaf node %d does not include "+
+				"operator key in co-signers", i)
+		}
+	}
+
+	return clientTree, nil
+}
+
+// ValidateAndSubmitSignatures validates and submits the complete VTXT
+// signatures to the tree. This must be called BEFORE the client signs the
+// boarding UTXO input.
+//
+// The signatures are provided as raw bytes (one per tree node in traversal
+// order) and will be parsed, submitted, and verified atomically.
+//
+// The client MUST NOT sign the boarding UTXO until the VTXT is fully signed
+// and validated. Otherwise, the operator could include the boarding UTXO in a
+// commitment tx without providing valid VTXOs.
+func (t *Tree) ValidateAndSubmitSignatures(signatures [][]byte) error {
+	if t == nil {
+		return fmt.Errorf("tree is nil")
+	}
+	if len(signatures) == 0 {
+		return fmt.Errorf("no signatures provided")
+	}
+
+	// Build a map of transaction IDs to Schnorr signatures for submission
+	// to the tree validation logic.
+	sigMap := make(map[TxID]*schnorr.Signature)
+	txIndex := 0
+
+	err := t.Root.ForEach(func(node *Node) error {
+		if txIndex >= len(signatures) {
+			return fmt.Errorf("not enough signatures: have "+
+				"%d, need more for all tree nodes",
+				len(signatures))
+		}
+
+		// Convert raw bytes into a Schnorr signature structure for
+		// cryptographic verification.
+		sig, err := schnorr.ParseSignature(signatures[txIndex])
+		if err != nil {
+			return fmt.Errorf("failed to parse signature %d: "+
+				"%w", txIndex, err)
+		}
+
+		// Index signatures by transaction ID to match them with their
+		// corresponding tree nodes.
+		txid, err := node.TXID()
+		if err != nil {
+			return fmt.Errorf("failed to get TXID for node: "+
+				"%w", err)
+		}
+
+		sigMap[txid] = sig
+		txIndex++
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to build signature map: %w", err)
+	}
+
+	// Submit and validate all signatures atomically to ensure the entire
+	// tree is properly signed.
+	if err := t.SubmitTreeSigs(sigMap); err != nil {
+		return fmt.Errorf("failed to submit tree signatures: %w", err)
+	}
+
+	// Perform cryptographic verification of all signatures to guarantee
+	// the operator has properly co-signed the VTXT.
+	if err := t.VerifySigned(); err != nil {
+		return fmt.Errorf("tree signature verification failed: %w",
+			err)
+	}
+
+	return nil
+}
+
+// ValidateAnchors validates that all transactions in the tree have valid
+// ephemeral anchor outputs for CPFP fee bumping (BIP 431).
+//
+// Without valid anchors, the client cannot broadcast the VTXT chain for
+// unilateral exit, resulting in fund loss.
+func (t *Tree) ValidateAnchors() error {
+	if t == nil {
+		return fmt.Errorf("tree is nil")
+	}
+
+	// Validate anchors in all tree nodes recursively.
+	return t.Root.ForEach(func(node *Node) error {
+		if node == nil {
+			return fmt.Errorf("tree node is nil")
+		}
+
+		// Convert node to transaction to check version and outputs.
+		tx, err := node.ToTx()
+		if err != nil {
+			return fmt.Errorf("failed to convert node "+
+				"to tx: %w", err)
+		}
+
+		// Verify transaction version is 3 for BIP 431 ephemeral
+		// anchors.
+		if tx.Version != 3 {
+			return fmt.Errorf("transaction version is "+
+				"%d, expected 3 for BIP 431 ephemeral anchors",
+				tx.Version)
+		}
+
+		// All virtual transactions must have at least one output
+		// (anchor).
+		if len(node.Outputs) == 0 {
+			return fmt.Errorf("transaction has no outputs")
+		}
+
+		// The last output must be the ephemeral anchor.
+		anchorIdx := len(node.Outputs) - 1
+		anchorOutput := node.Outputs[anchorIdx]
+
+		// Anchor must have zero value.
+		if anchorOutput.Value != 0 {
+			return fmt.Errorf("anchor output at index %d "+
+				"has value %d, expected 0", anchorIdx,
+				anchorOutput.Value)
+		}
+
+		// Anchor script must match the standard ephemeral anchor
+		// script.
+		if !bytes.Equal(anchorOutput.PkScript, scripts.AnchorPkScript) {
+			return fmt.Errorf("anchor output at index %d has "+
+				"invalid script", anchorIdx)
+		}
+
+		return nil
+	})
 }

--- a/lib/tree/tree_test.go
+++ b/lib/tree/tree_test.go
@@ -978,3 +978,120 @@ func TestTreePrettyPrint(t *testing.T) {
 		require.Contains(t, output, "Transaction Tree")
 	})
 }
+
+// TestValidatePath tests the ValidatePath method.
+func TestValidatePath(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil tree returns error", func(t *testing.T) {
+		t.Parallel()
+
+		var tree *Tree
+		_, err := tree.ValidatePath(nil, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "tree is nil")
+	})
+
+	t.Run("nil signing key returns error", func(t *testing.T) {
+		t.Parallel()
+
+		_, operatorKey := createTestKey(t)
+		_, ownerKey := createTestKey(t)
+
+		leaves := []LeafDescriptor{
+			{
+				PkScript:    []byte("script"),
+				Amount:      1000,
+				CoSignerKey: ownerKey,
+			},
+		}
+
+		tree, err := NewTree(
+			wire.OutPoint{}, &wire.TxOut{Value: 1000}, leaves,
+			operatorKey, make([]byte, 32), 2,
+		)
+		require.NoError(t, err)
+
+		_, err = tree.ValidatePath(nil, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "signing key is nil")
+	})
+}
+
+// TestValidateAndSubmitSignatures tests the ValidateAndSubmitSignatures method.
+func TestValidateAndSubmitSignatures(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil tree returns error", func(t *testing.T) {
+		t.Parallel()
+
+		var tree *Tree
+		err := tree.ValidateAndSubmitSignatures([][]byte{{0x01}})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "tree is nil")
+	})
+
+	t.Run("empty signatures returns error", func(t *testing.T) {
+		t.Parallel()
+
+		_, operatorKey := createTestKey(t)
+		_, ownerKey := createTestKey(t)
+
+		leaves := []LeafDescriptor{
+			{
+				PkScript:    []byte("script"),
+				Amount:      1000,
+				CoSignerKey: ownerKey,
+			},
+		}
+
+		tree, err := NewTree(
+			wire.OutPoint{}, &wire.TxOut{Value: 1000}, leaves,
+			operatorKey, make([]byte, 32), 2,
+		)
+		require.NoError(t, err)
+
+		err = tree.ValidateAndSubmitSignatures([][]byte{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no signatures provided")
+	})
+
+	t.Run("nil signatures returns error", func(t *testing.T) {
+		t.Parallel()
+
+		_, operatorKey := createTestKey(t)
+		_, ownerKey := createTestKey(t)
+
+		leaves := []LeafDescriptor{
+			{
+				PkScript:    []byte("script"),
+				Amount:      1000,
+				CoSignerKey: ownerKey,
+			},
+		}
+
+		tree, err := NewTree(
+			wire.OutPoint{}, &wire.TxOut{Value: 1000}, leaves,
+			operatorKey, make([]byte, 32), 2,
+		)
+		require.NoError(t, err)
+
+		err = tree.ValidateAndSubmitSignatures(nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no signatures provided")
+	})
+}
+
+// TestValidateAnchors tests the ValidateAnchors method.
+func TestValidateAnchors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil tree returns error", func(t *testing.T) {
+		t.Parallel()
+
+		var tree *Tree
+		err := tree.ValidateAnchors()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "tree is nil")
+	})
+}

--- a/lib/types/boarding.go
+++ b/lib/types/boarding.go
@@ -31,6 +31,27 @@ type OperatorTerms struct {
 	// penalty output in forfeit transactions. This allows the server to
 	// claim forfeited funds.
 	ForfeitScript []byte
+
+	// SweepKey is the operator key used in VTXT sweep paths.
+	SweepKey *btcec.PublicKey
+
+	// SweepDelay is the batch-wide absolute timelock (blocks).
+	SweepDelay uint32
+
+	// DustLimit enforces minimum output value for boarding/funding flows.
+	DustLimit btcutil.Amount
+
+	// MinBoardingAmount is the minimum amount clients must contribute.
+	MinBoardingAmount btcutil.Amount
+
+	// MaxBoardingAmount caps the amount accepted per request (optional).
+	MaxBoardingAmount btcutil.Amount
+
+	// FeeRate reflects the operator's target package feerate (sat/vByte).
+	FeeRate btcutil.Amount
+
+	// MinConfirmations is the minimum confs required on boarding inputs.
+	MinConfirmations uint32
 }
 
 // JoinRoundRequest represents a participant's request to join a round.

--- a/round/README.md
+++ b/round/README.md
@@ -1,0 +1,358 @@
+# Ark Boarding State Machine
+
+The round package implements the client-side protocol for boarding Bitcoin
+outputs into an Ark virtual UTXO tree through coordinated multi-party rounds.
+Boarding converts on-chain Bitcoin into off-chain VTXOs that enable instant,
+private transfers within the Ark system.
+
+The architecture strictly separates business logic from side effects. The finite
+state machine (FSM) owns all protocol logic, validation, and state transitions.
+A thin actor layer translates between the FSM's event model and external
+systems (operator server, blockchain, wallet). This separation ensures the
+protocol remains testable and deterministic regardless of IO timing.
+
+## Protocol Overview
+
+Boarding begins when a user requests a boarding address, a time-locked 2-of-2
+multisig between client and operator. The user deposits Bitcoin to this address,
+creating a boarding UTXO. Once confirmed, the client registers this intent with
+the operator's coordination server, which batches multiple clients' boarding
+UTXOs into a single round.
+
+The operator constructs a commitment transaction spending all boarding inputs
+and creating a single taproot output containing the complete VTXO tree. Each
+tree leaf represents a VTXO owned by a participant, with tapscript branches
+enabling either cooperative spending (client + operator) or unilateral exit
+after timeout.
+
+Creating this transaction requires a MuSig2 signing ceremony. Participants
+generate nonces, exchange them, produce partial signatures over their tree
+portions, and validate the operator's completion. Only after the entire tree is
+provably signed do clients release signatures for their boarding inputs.
+
+This ordering (tree signatures before boarding input signatures) is critical for
+security. If clients signed boarding inputs first, a malicious operator could
+broadcast the commitment transaction with an invalid tree, locking funds without
+providing expected VTXOs. Validating complete tree signatures first ensures
+funds will be accessible before relinquishing control of boarding inputs.
+
+## State Machine Architecture
+
+The FSM progresses through states representing protocol phases. Each state
+processes events, performs validation or cryptographic operations, then
+transitions to the next state and emits outbound messages. States are immutable;
+transitions create new instances rather than mutating.
+
+### Idle State
+
+The FSM begins in Idle, representing readiness for new boarding requests. When
+the user requests a boarding address, the FSM derives a key pair, constructs a
+2-of-2 boarding script with the operator's key and CSV timelock, and emits an
+`AddressReceived` notification.
+
+The FSM returns to Idle after completing a boarding round, allowing the same
+instance to process additional addresses across different rounds.
+
+### BoardingIntents State
+
+After receiving an address, the user funds it by broadcasting a Bitcoin
+transaction. Once confirmed, the wallet registers a boarding intent containing
+the address, on-chain UTXO, and VTXO template (amount, expiry, keys).
+
+The FSM accumulates multiple intents, tracking each intent's confirmation
+status. When all reach confirmed status, it transitions to RegistrationSent,
+emitting a `JoinRoundRequest` that aggregates all intents into a single server
+request.
+
+### RegistrationSent and RoundJoined States
+
+The `JoinRoundRequest` carries serialized boarding requests and VTXO templates
+to the operator. The server aggregates requests from multiple clients and, once
+sufficient participation is reached, initiates a round by assigning a round ID.
+
+The FSM transitions to RoundJoined upon receiving the `RoundJoined` response,
+which includes the round ID used to track this batch through completion.
+
+### CommitmentTxReceived and CommitmentTxValidated States
+
+The operator constructs a commitment transaction and sends it via
+`CommitmentTxBuilt`. The FSM performs extensive validation, verifying every
+boarding UTXO appears as input, the taproot output commits to a Merkle tree with
+all expected VTXOs, and extracts client-specific sub-trees indexed by signing
+key.
+
+Client trees are essential for constructing MuSig2 sessions and must be
+persisted alongside final VTXOs, as spending a VTXO off-chain requires proving
+its position via complete Merkle path to root.
+
+The FSM also maps each boarding input to its position in the commitment
+transaction's input array, required later for signing (Bitcoin signatures commit
+to input indices via SIGHASH).
+
+### Nonce Exchange: NoncesSent and NoncesAggregated States
+
+MuSig2 signing begins with nonce exchange. Each participant generates nonce
+pairs for each signing session (one per client tree). The FSM generates these
+cryptographically, ensuring no reuse across sessions (nonce reuse leaks private
+keys).
+
+The NoncesSent state emits `SubmitNoncesRequest` messages. The operator collects
+and aggregates all nonces, returning them in `NoncesAggregated`. The FSM stores
+aggregated nonces with MuSig2 sessions for producing partial signatures.
+
+### Partial Signature Exchange: PartialSigsSent State
+
+With nonces exchanged, participants create partial signatures over their tree
+portions. The FSM iterates each client tree and associated session, producing
+partial signatures via `SubmitPartialSigRequest`.
+
+The operator aggregates all partial signatures to produce complete Schnorr
+signatures over every tree branch, making each VTXO spendable through the
+cooperative path.
+
+### InputSigSent State: The Point of No Return
+
+When the operator completes aggregation, it returns `OperatorSigned` containing
+final signatures for all tree branches. The FSM verifies every signature,
+reconstructing expected signing messages, validating each against the correct
+aggregated public key, and confirming signatures enable cooperative tapscript
+spending.
+
+This validation is the security checkpoint: valid signatures mean funds will be
+accessible as VTXOs after commitment transaction confirms. Invalid or missing
+signatures trigger failure state transition without releasing boarding input
+signatures.
+
+Upon successful validation, the FSM signs each boarding input using Taproot key
+path spending. Combined with operator signatures, these complete the commitment
+transaction. The FSM immediately checkpoints the entire round state (commitment
+transaction, VTXO tree, boarding intents, client trees) to persistent storage.
+
+This checkpoint is the "point of no return." After sending boarding input
+signatures, the operator may broadcast at any time. If the client crashes before
+checkpoint completes, the operator might broadcast while the client has no
+record, potentially causing fund loss. The checkpoint ensures recovery even if
+the client crashes immediately after sending signatures.
+
+The FSM emits `SubmitForfeitSigRequest` messages containing boarding input
+signatures, registers a confirmation watch for the commitment TXID, and emits
+`RoundCheckpointedNotification` triggering actor-level FSM migration to a
+dedicated round-specific FSM for confirmation monitoring.
+
+### Confirmed State and VTXO Creation
+
+When the commitment transaction confirms with sufficient depth, the chain
+monitoring subsystem delivers `BoardingConfirmed`. The FSM constructs
+`ClientVTXO` descriptors from intents and client trees, including the VTXO's
+outpoint, amount, taproot script, key descriptors, CSV expiry, and complete tree
+path proving inclusion in the commitment transaction output.
+
+Descriptors are persisted to the VTXO store and emitted via
+`VTXOCreatedNotification`, making them available to the wallet for spending.
+
+### Failure Handling
+
+At any point, the FSM may receive `BoardingFailed` indicating round abort or
+unrecoverable error. The FSM transitions to `ClientFailedState`, capturing
+failure reason and recoverability.
+
+Recoverable failures (operator canceling due to insufficient participation)
+leave boarding UTXOs unspent on-chain, allowing retry. Unrecoverable failures
+indicate protocol violations requiring user intervention.
+
+## Actor Architecture: Primary and Dedicated FSMs
+
+The actor manages FSM lifecycles and message routing. Rather than creating a new
+FSM per boarding address, the system maintains a single primary FSM handling
+initial protocol phases (address generation, intent registration, round joining,
+signature exchange) through InputSigSent.
+
+When a round reaches InputSigSent, the primary FSM emits
+`RoundCheckpointedNotification`. The actor spawns a dedicated FSM instance for
+that round, initialized from checkpointed state. This dedicated FSM monitors for
+commitment transaction confirmation, a potentially long operation that shouldn't
+block the primary FSM from processing new addresses.
+
+Migration occurs precisely where the protocol shifts from interactive (requires
+operator responses) to passive (waiting for blockchain events). Before
+InputSigSent, the FSM actively exchanges messages with the operator. After, it
+only waits for confirmation.
+
+If the client crashes, the actor recreates dedicated FSMs for all checkpointed
+rounds by scanning persistent storage on startup.
+
+## Event and Message Flow
+
+The FSM communicates exclusively through events, structured messages
+representing external occurrences (operator responses, blockchain confirmations)
+or internal triggers (validation complete, signatures generated). The actor
+translates between external message formats and the FSM's uniform event model.
+
+### Outbox Pattern
+
+State transitions produce outbound events via the outbox, preventing the FSM
+from depending on external interfaces. The FSM emits side effects as data
+(outbound events) rather than invoking methods directly. The actor examines
+outbox contents and dispatches to appropriate subsystems:
+
+- **Server messages**: `JoinRoundRequest`, `SubmitNoncesRequest`,
+  `SubmitPartialSigRequest`, `SubmitForfeitSigRequest`
+- **Chain monitoring**: `RegisterConfirmationRequest`
+- **Wallet notifications**: `VTXOCreatedNotification`, `AddressReceived`
+
+This design enables trivial testing (FSM runs in-memory with mock stores) and
+ensures all side effects are visible and serializable.
+
+Internal events support multi-step transitions within a single external event
+delivery. The CommitmentTxReceived state performs initial parsing, then emits an
+internal event triggering CommitmentTxValidated's detailed validation. This
+keeps states focused and testable while maintaining atomicity from the actor's
+perspective.
+
+## Client-Server Message Sequence
+
+The following sequence shows the complete protocol message flow between client
+and server during a successful boarding round:
+
+```mermaid
+sequenceDiagram
+    participant C as Client FSM
+    participant A as Actor
+    participant S as Server
+    participant B as Blockchain
+
+    Note over C,B: Address Generation Phase
+    C->>A: AddressReceived (outbox)
+    A->>C: User: Wallet deposits to address
+
+    Note over C,B: Intent Registration Phase
+    B->>A: UTXO confirmed
+    A->>C: BoardingUTXOConfirmed
+    C->>A: JoinRoundRequest (outbox)
+    A->>S: JoinRound
+    S->>A: RoundJoined(roundID)
+    A->>C: RoundJoined
+
+    Note over C,B: Commitment Transaction Phase
+    S->>A: CommitmentTxBuilt(tx, trees)
+    A->>C: CommitmentTxBuilt
+    Note over C: Validate tx & extract client trees
+
+    Note over C,B: MuSig2 Nonce Exchange
+    C->>A: SubmitNoncesRequest (outbox)
+    A->>S: SubmitNonces
+    S->>A: NoncesAggregated(aggNonces)
+    A->>C: NoncesAggregated
+
+    Note over C,B: MuSig2 Partial Signature Exchange
+    C->>A: SubmitPartialSigRequest (outbox)
+    A->>S: SubmitPartialSig
+    S->>A: OperatorSigned(signatures)
+    A->>C: OperatorSigned
+
+    Note over C,B: Boarding Input Signing (Point of No Return)
+    Note over C: Validate all tree signatures
+    Note over C: Sign boarding inputs
+    Note over C: Checkpoint round to storage
+    C->>A: SubmitForfeitSigRequest (outbox)
+    C->>A: RoundCheckpointedNotification (outbox)
+    A->>S: SubmitForfeitSig
+    A->>A: Spawn dedicated FSM for confirmation
+
+    Note over C,B: Confirmation Monitoring
+    C->>A: RegisterConfirmationRequest (outbox)
+    A->>B: Watch commitment TXID
+    S->>B: Broadcast commitment tx
+    B->>A: Confirmed(txid, height)
+    A->>C: BoardingConfirmed
+
+    Note over C,B: VTXO Creation
+    Note over C: Build ClientVTXO descriptors
+    C->>A: VTXOCreatedNotification (outbox)
+    Note over C: Transition to Idle
+```
+
+Key observations:
+
+- All server-bound messages flow through the outbox, never directly from FSM
+- The actor routes outbox messages to appropriate destinations based on type
+- Internal validation (tree extraction, signature verification, descriptor
+  building) happens within state transitions, invisible to external systems
+- The checkpoint before sending boarding input signatures is critical for
+  recovery
+- FSM migration occurs after `RoundCheckpointedNotification`, separating
+  interactive and monitoring phases
+
+## Persistence and Recovery
+
+The FSM interacts with storage through `ClientEnvironment`, providing interfaces
+for boarding intent storage, round checkpointing, VTXO storage, and wallet
+operations. This indirection enables testing with in-memory stores while
+production uses SQLite.
+
+Boarding intents persist from registration until round completion or failure.
+Round checkpointing occurs at the InputSigSent transition, including complete
+commitment transaction, full VTXO tree, client sub-trees, boarding input
+signatures, and every intent with updated status.
+
+FSM state checkpointing complements round checkpointing by persisting the FSM's
+current state structure. The actor inspects checkpoints on startup to spawn
+dedicated FSMs for all checkpointed rounds, ensuring no confirmation monitoring
+is lost across restarts.
+
+The storage layer implements checkpoints atomically where possible, preventing
+partial writes. Transaction semantics ensure either the entire checkpoint
+succeeds or none of it does, maintaining consistency even if the process crashes
+during checkpoint.
+
+## State Machine Diagram
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle
+    Idle --> BoardingIntents: AddressRequested
+    BoardingIntents --> BoardingIntents: BoardingUTXOCreated
+    BoardingIntents --> RegistrationSent: BoardingUTXOConfirmed (all)
+    RegistrationSent --> RoundJoined: RoundJoined
+    RoundJoined --> CommitmentTxReceived: CommitmentTxBuilt
+    CommitmentTxReceived --> CommitmentTxValidated: CommitmentTxBuilt (internal)
+    CommitmentTxValidated --> NoncesSent: NoncesGenerated
+    NoncesSent --> NoncesAggregated: NoncesAggregated
+    NoncesAggregated --> PartialSigsSent: PartialSigsGenerated
+    PartialSigsSent --> InputSigSent: OperatorSigned
+    InputSigSent --> Confirmed: BoardingConfirmed
+    Confirmed --> Idle: RoundComplete
+
+    BoardingIntents --> ClientFailed: BoardingFailed
+    RegistrationSent --> ClientFailed: BoardingFailed
+    RoundJoined --> ClientFailed: BoardingFailed
+    CommitmentTxReceived --> ClientFailed: BoardingFailed
+    CommitmentTxValidated --> ClientFailed: BoardingFailed
+    NoncesSent --> ClientFailed: BoardingFailed
+    NoncesAggregated --> ClientFailed: BoardingFailed
+    PartialSigsSent --> ClientFailed: BoardingFailed
+    InputSigSent --> ClientFailed: BoardingFailed
+```
+
+The diagram omits internal events for clarity, showing only major transitions
+triggered by external events. Each state may perform significant computation
+(validation, cryptography, checkpoint operations) before transitioning.
+
+## Future Extensions
+
+The current implementation supports boarding, the entry point for Ark
+participation. Future extensions will add exit paths (unilateral timeout-based
+and cooperative), VTXO transfers between participants, and VTXO refresh rounds
+preventing timeouts by moving VTXOs into new trees with extended expirations.
+
+These extensions may introduce additional states or entirely separate FSMs for
+different protocol flows. Exit flows coordinate with the operator but follow
+distinct state progressions (no multi-party coordination required). VTXO
+transfers need their own round coordination, potentially reusing portions of the
+boarding FSM's MuSig2 ceremony with different validation and output
+construction.
+
+The actor's primary/dedicated FSM pattern should extend naturally. Each protocol
+type (boarding, exit, transfer) can maintain a primary FSM for interactive
+phases and spawn dedicated FSMs for monitoring, ensuring responsiveness
+regardless of simultaneous operation count.

--- a/round/actor.go
+++ b/round/actor.go
@@ -1,0 +1,631 @@
+//nolint:ll
+package round
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/baselib/protofsm"
+	"github.com/lightninglabs/darepo-client/chainsource"
+	"github.com/lightninglabs/darepo-client/lib/types"
+	"github.com/lightninglabs/darepo-client/serverconn"
+	"github.com/lightninglabs/darepo-client/wallet"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+)
+
+// RoundFSM wraps a state machine instance for a specific round.
+type RoundFSM struct {
+	// FSM is the state machine for this round. The baselib protofsm uses 3
+	// type parameters: InternalEvent, OutboxEvent, Env.
+	FSM *ClientStateMachine
+
+	// RoundID is the unique identifier for this round.
+	RoundID string
+
+	// TxID is the commitment transaction ID for this round.
+	TxID chainhash.Hash
+}
+
+// RoundClientActor wraps the client boarding FSM in an actor interface. The
+// actor manages the FSM lifecycle, handles incoming actor messages, converts
+// them to FSM events, processes outbox messages, and integrates with the
+// chainsource actor for chain monitoring.
+//
+// Architecture:
+//   - Actor holds FSM (protofsm.StateMachine).
+//   - Actor receives actor messages (ClientMsg).
+//   - Actor converts messages to FSM events.
+//   - FSM processes events producing new state and outbox.
+//   - Actor processes outbox by sending messages to server/chainsource.
+type RoundClientActor struct {
+	// cfg contains all the configuration for this actor.
+	cfg *RoundClientConfig
+
+	// primaryFSM is the main FSM for assembling new rounds from Confirmed
+	// intents. It handles the flow from Idle through round registration.
+	primaryFSM *ClientStateMachine
+
+	// activeRounds tracks concurrent round FSMs awaiting commitment tx
+	// confirmation. Map: RoundID → RoundFSM instance.
+	activeRounds map[string]*RoundFSM
+
+	// commitmentTxIndex maps commitment transaction IDs to their round IDs
+	// for routing confirmation events. Map: CommitmentTxID → RoundID.
+	commitmentTxIndex map[chainhash.Hash]string
+
+	// env is the FSM environment containing all dependencies.
+	env *ClientEnvironment
+}
+
+// RoundClientConfig houses the configuration for a RoundClientActor.
+type RoundClientConfig struct {
+	// Name uniquely identifies this actor instance.
+	Name string
+
+	// Wallet provides MuSig2 signing capabilities needed for round
+	// participation. Boarding address creation is handled by the wallet
+	// actor.
+	Wallet ClientWallet
+
+	// RoundStore persists round coordination and checkpointing.
+	RoundStore RoundStore
+
+	// VTXOStore persists off-chain balance.
+	VTXOStore VTXOStore
+
+	// OperatorTerms contains the operator's parameters.
+	OperatorTerms *types.OperatorTerms
+
+	// ServerConn is a reference to the ServerConnectionActor for sending
+	// messages to the Ark server.
+	ServerConn actor.TellOnlyRef[serverconn.ServerConnMsg]
+
+	// ChainSource is a reference to the ChainSource actor for registering
+	// confirmation notifications for commitment transactions.
+	ChainSource actor.TellOnlyRef[chainsource.ChainSourceMsg]
+
+	// WalletActor is a reference to the Ark wallet actor. The round actor
+	// registers to receive BoardingUtxoConfirmedEvent notifications when
+	// new boarding UTXOs are confirmed.
+	WalletActor actor.ActorRef[wallet.WalletMsg, wallet.WalletResp]
+
+	// SelfRef is a reference to this actor for receiving asynchronous
+	// notifications (e.g., confirmations from ChainSource).
+	SelfRef actor.TellOnlyRef[ClientMsg]
+
+	// ChainParams are the Bitcoin network parameters.
+	ChainParams *chaincfg.Params
+}
+
+// NewRoundClientActor creates a new client actor with the provided
+// configuration. The actor starts in the Idle state.
+//
+// The FSM uses interfaces directly and calls lib package functions as needed.
+// Chain operations are handled via outbox messages (not direct calls).
+func NewRoundClientActor(cfg *RoundClientConfig) fn.Result[*RoundClientActor] {
+	// Create FSM environment with direct interface assignments. The FSM
+	// will call lib functions directly when needed (e.g.,
+	// lib.NewTreeSignerSession, signing helpers).
+	env := &ClientEnvironment{
+		RoundStore:    cfg.RoundStore,
+		VTXOStore:     cfg.VTXOStore,
+		Wallet:        cfg.Wallet,
+		OperatorTerms: cfg.OperatorTerms,
+		ChainParams:   cfg.ChainParams,
+	}
+
+	if err := ValidateDelayParameters(
+		cfg.OperatorTerms.SweepDelay, cfg.OperatorTerms.VTXOExitDelay,
+	); err != nil {
+		return fn.Err[*RoundClientActor](err)
+	}
+
+	// Create the FSM with Idle initial state. The baselib protofsm uses 3
+	// type parameters: InternalEvent, OutboxEvent, Env.
+	fsmCfg := ClientStateMachineCfg{
+		Logger:        log.WithPrefix("fsm-primary"),
+		ErrorReporter: newContextErrorReporter(context.Background(), "fsm-primary"),
+		InitialState:  &Idle{},
+		Env:           env,
+	}
+	primaryFSM := protofsm.NewStateMachine(fsmCfg)
+	primaryFSM.Start(context.Background())
+
+	return fn.Ok(&RoundClientActor{
+		cfg:               cfg,
+		primaryFSM:        &primaryFSM,
+		activeRounds:      make(map[string]*RoundFSM),
+		commitmentTxIndex: make(map[chainhash.Hash]string),
+		env:               env,
+	})
+}
+
+// createRoundFSM creates a new FSM instance for a specific round, restoring
+// from checkpointed state. Uses FetchState to load both round data and FSM
+// state atomically.
+func (a *RoundClientActor) createRoundFSM(ctx context.Context,
+	roundID string) (*RoundFSM, error) {
+
+	round, state, err := a.cfg.RoundStore.FetchState(ctx, roundID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch round state: %w", err)
+	}
+	env := &ClientEnvironment{
+		RoundStore:    a.cfg.RoundStore,
+		VTXOStore:     a.cfg.VTXOStore,
+		Wallet:        a.cfg.Wallet,
+		OperatorTerms: a.cfg.OperatorTerms,
+		ChainParams:   a.cfg.ChainParams,
+	}
+
+	fsmPrefix := fmt.Sprintf("fsm-%s", round.RoundID)
+	fsmCfg := ClientStateMachineCfg{
+		Logger:        log.WithPrefix(fsmPrefix),
+		ErrorReporter: newContextErrorReporter(ctx, fsmPrefix),
+		InitialState:  state,
+		Env:           env,
+	}
+	fsm := protofsm.NewStateMachine(fsmCfg)
+	fsm.Start(ctx)
+
+	txid := fn.MapOptionZ(
+		round.CommitmentTx, func(tx *wire.MsgTx) chainhash.Hash {
+			return tx.TxHash()
+		},
+	)
+
+	return &RoundFSM{
+		FSM:     &fsm,
+		RoundID: round.RoundID,
+		TxID:    txid,
+	}, nil
+}
+
+// registerCommitmentConfirmation registers for confirmation monitoring of a
+// commitment transaction with the chainsource actor.
+func (a *RoundClientActor) registerCommitmentConfirmation(ctx context.Context,
+	txid chainhash.Hash) {
+
+	callerID := fmt.Sprintf("commitment-tx-%s", txid.String())
+
+	mappedRef := chainsource.MapConfirmationEvent(
+		a.cfg.SelfRef,
+		func(ce chainsource.ConfirmationEvent) ClientMsg {
+			return &ConfirmationEvent{
+				Txid:          ce.Txid,
+				BlockHeight:   ce.BlockHeight,
+				Confirmations: ce.NumConfs,
+				Tx:            ce.Tx,
+			}
+		},
+	)
+
+	confReq := &chainsource.RegisterConfRequest{
+		CallerID:    callerID,
+		Txid:        &txid,
+		TargetConfs: a.cfg.OperatorTerms.MinConfirmations,
+		NotifyActor: fn.Some(mappedRef),
+	}
+
+	a.cfg.ChainSource.Tell(ctx, confReq)
+}
+
+// askEventAndProcessOutbox sends an event to the FSM and processes any
+// emitted outbox messages. This consolidates a common pattern throughout
+// the actor where FSM events trigger outbox processing.
+func (a *RoundClientActor) askEventAndProcessOutbox(
+	ctx context.Context, fsm *ClientStateMachine, event ClientEvent) error {
+
+	future := fsm.AskEvent(ctx, event)
+	result := future.Await(ctx)
+
+	events, err := result.Unpack()
+	if err != nil {
+		return err
+	}
+
+	if len(events) > 0 {
+		if err := a.processOutbox(ctx, events); err != nil {
+			return fmt.Errorf("failed to process outbox: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// Start initializes the actor by registering with the wallet actor to receive
+// boarding UTXO confirmation notifications, and resuming any active rounds.
+// This should be called once after actor creation to restore state.
+func (a *RoundClientActor) Start(ctx context.Context) error {
+	// Register with the wallet actor to receive BoardingUtxoConfirmedEvent
+	// notifications. The wallet handles all boarding address monitoring and
+	// will notify us when new UTXOs are confirmed.
+	mappedRef := actor.NewMapInputRef(
+		a.cfg.SelfRef,
+		func(evt wallet.BoardingUtxoConfirmedEvent) ClientMsg {
+			return &WalletBoardingConfirmed{
+				Intent: evt.BoardingIntent,
+			}
+		},
+	)
+
+	// Request all historical confirmations. The wallet will send backlog
+	// events for any confirmed intents.
+	regReq := &wallet.RegisterConfirmationNotifierRequest{
+		NotifierID:    fmt.Sprintf("round-actor-%s", a.cfg.Name),
+		NotifyActor:   mappedRef,
+		BacklogHeight: fn.None[int32](),
+		MinConf:       fn.Some(a.cfg.OperatorTerms.MinConfirmations),
+	}
+
+	future := a.cfg.WalletActor.Ask(ctx, regReq)
+	result := future.Await(ctx)
+	if result.IsErr() {
+		return fmt.Errorf("register with wallet: %w", result.Err())
+	}
+
+	// Load active rounds (commitment tx broadcast, not yet confirmed) and
+	// resume their FSMs.
+	activeRounds, err := a.cfg.RoundStore.ListActiveRounds()
+	if err != nil {
+		return fmt.Errorf("failed to load active rounds: %w", err)
+	}
+
+	for _, round := range activeRounds {
+		roundFSM, err := a.createRoundFSM(ctx, round.RoundID)
+		if err != nil {
+			return fmt.Errorf("failed to create FSM for "+
+				"round %s: %w", round.RoundID, err)
+		}
+
+		a.activeRounds[round.RoundID] = roundFSM
+
+		// Register for confirmation of the commitment tx for this
+		// round.
+		if !roundFSM.TxID.IsEqual(&chainhash.Hash{}) {
+			a.commitmentTxIndex[roundFSM.TxID] = round.RoundID
+			a.registerCommitmentConfirmation(ctx, roundFSM.TxID)
+		}
+	}
+
+	return nil
+}
+
+// Receive processes an actor message and returns a response. This is the main
+// entry point for the actor.
+func (a *RoundClientActor) Receive(ctx context.Context,
+	msg ClientMsg) fn.Result[ClientResp] {
+
+	switch m := msg.(type) {
+	case *WalletBoardingConfirmed:
+		return a.handleWalletBoardingConfirmed(ctx, m)
+
+	case *ServerMessageNotification:
+		return a.handleServerMessage(ctx, m)
+
+	case *GetClientStateRequest:
+		return a.handleGetState(ctx, m)
+
+	case *CancelRoundRequest:
+		return a.handleCancelRound(ctx, m)
+
+	case *ConfirmationEvent:
+		return a.handleConfirmation(ctx, m)
+
+	default:
+		return fn.Err[ClientResp](fmt.Errorf(
+			"unknown message type: %T", msg))
+	}
+}
+
+// handleWalletBoardingConfirmed processes a boarding UTXO confirmation event
+// from the wallet actor. This creates the FSM event and drives the state
+// machine forward. The wallet handles all persistence; we just react.
+func (a *RoundClientActor) handleWalletBoardingConfirmed(ctx context.Context,
+	msg *WalletBoardingConfirmed) fn.Result[ClientResp] {
+
+	walletIntent := msg.Intent
+	if walletIntent == nil {
+		return fn.Err[ClientResp](fmt.Errorf(
+			"wallet boarding confirmed event missing intent"))
+	}
+
+	// Create the FSM event from the wallet's confirmed intent. Wallet only
+	// notifies after min confs, so we set confirmations to 1. Include the
+	// Address and TxProof for building the BoardingRequest.
+	confirmEvt := &BoardingUTXOConfirmed{
+		Outpoint:      walletIntent.Outpoint,
+		Address:       walletIntent.Address,
+		BlockHeight:   walletIntent.ChainInfo.ConfHeight,
+		BlockHash:     walletIntent.ChainInfo.ConfHash,
+		Confirmations: int32(a.cfg.OperatorTerms.MinConfirmations),
+		Tx:            walletIntent.ChainInfo.ConfTx,
+		TxProof:       walletIntent.ChainInfo.TxProof,
+	}
+
+	// Drive the FSM with the confirmation event.
+	err := a.askEventAndProcessOutbox(ctx, a.primaryFSM, confirmEvt)
+	if err != nil {
+		return fn.Err[ClientResp](fmt.Errorf(
+			"FSM error processing boarding confirmation: %w", err))
+	}
+
+	return fn.Ok[ClientResp](nil)
+}
+
+// migrateRoundToActiveFSM creates a dedicated FSM for a checkpointed round.
+// This is called when the primary FSM emits a RoundCheckpointedNotification,
+// signaling that a round has been saved to storage and should be migrated to
+// its own FSM instance for independent tracking.
+func (a *RoundClientActor) migrateRoundToActiveFSM(ctx context.Context,
+	roundID string) error {
+
+	// Check if this round is already in activeRounds (idempotency).
+	if _, exists := a.activeRounds[roundID]; exists {
+		return nil
+	}
+
+	// Create FSM for this round (loads round + state via FetchState).
+	roundFSM, err := a.createRoundFSM(ctx, roundID)
+	if err != nil {
+		return fmt.Errorf("failed to create round FSM: %w", err)
+	}
+	a.activeRounds[roundID] = roundFSM
+
+	// Index commitment tx and register for confirmation monitoring.
+	if !roundFSM.TxID.IsEqual(&chainhash.Hash{}) {
+		a.commitmentTxIndex[roundFSM.TxID] = roundID
+		a.registerCommitmentConfirmation(ctx, roundFSM.TxID)
+	}
+
+	return nil
+}
+
+// handleServerMessage processes a message from the server (delivered via
+// Outbox). The actor converts the server message to a client event and
+// processes it through the FSM.
+func (a *RoundClientActor) handleServerMessage(ctx context.Context,
+	msg *ServerMessageNotification) fn.Result[ClientResp] {
+
+	// The ServerMessageNotification contains a ClientEvent (from the
+	// server's outbox). Process it directly through the FSM.
+	err := a.askEventAndProcessOutbox(ctx, a.primaryFSM, msg.Message)
+	if err != nil {
+		return fn.Err[ClientResp](fmt.Errorf(
+			"FSM error processing server message: %w", err))
+	}
+
+	return fn.Ok[ClientResp](&ServerMessageResponse{
+		Success: true,
+	})
+}
+
+// handleGetState returns the current FSM state for monitoring/debugging.
+// This includes both the primary FSM and all active round FSMs.
+func (a *RoundClientActor) handleGetState(_ context.Context,
+	_ *GetClientStateRequest) fn.Result[ClientResp] {
+
+	states := make(map[string]FSMStateInfo)
+
+	// Query the primary FSM state.
+	primaryState, err := a.primaryFSM.CurrentState()
+	if err != nil {
+		return fn.Err[ClientResp](fmt.Errorf(
+			"failed to get primary FSM state: %w", err))
+	}
+
+	// Add primary FSM to the response map.
+	clientState, ok := primaryState.(ClientState)
+	if !ok {
+		return fn.Err[ClientResp](fmt.Errorf(
+			"primary FSM state is not a ClientState"))
+	}
+
+	states["primary"] = FSMStateInfo{
+		State:     clientState,
+		IsPrimary: true,
+		RoundID:   "",
+	}
+
+	for roundID, roundFSM := range a.activeRounds {
+		roundState, err := roundFSM.FSM.CurrentState()
+		if err != nil {
+			continue
+		}
+
+		clientState, ok := roundState.(ClientState)
+		if !ok {
+			continue
+		}
+
+		states[roundID] = FSMStateInfo{
+			State:     clientState,
+			IsPrimary: false,
+			RoundID:   roundID,
+		}
+	}
+
+	return fn.Ok[ClientResp](&GetClientStateResponse{
+		States: states,
+	})
+}
+
+// handleCancelRound attempts to cancel the current round participation.
+func (a *RoundClientActor) handleCancelRound(ctx context.Context,
+	req *CancelRoundRequest) fn.Result[ClientResp] {
+
+	// Inject a BoardingFailed event to transition the FSM to failed state.
+	// This will trigger any cleanup logic in the FSM transitions.
+	cancelEvent := &BoardingFailed{
+		Reason:      "User requested cancellation",
+		Error:       fmt.Errorf("round cancelled by user"),
+		Recoverable: true,
+	}
+
+	err := a.askEventAndProcessOutbox(ctx, a.primaryFSM, cancelEvent)
+	if err != nil {
+		return fn.Ok[ClientResp](&CancelRoundResponse{
+			Success: false,
+			Error:   fmt.Sprintf("failed to cancel: %v", err),
+		})
+	}
+
+	return fn.Ok[ClientResp](&CancelRoundResponse{
+		Success: true,
+	})
+}
+
+// onRoundComplete is called when a round finishes successfully. This removes
+// the round from active tracking and archives the round data.
+func (a *RoundClientActor) onRoundComplete(roundID string,
+	txid chainhash.Hash) error {
+
+	delete(a.activeRounds, roundID)
+	delete(a.commitmentTxIndex, txid)
+
+	return a.cfg.RoundStore.FinalizeRound(roundID, txid)
+}
+
+// handleConfirmation processes a commitment transaction confirmation event
+// from ChainSource. Boarding address confirmations are now handled via
+// WalletBoardingConfirmed events from the wallet actor.
+func (a *RoundClientActor) handleConfirmation(ctx context.Context,
+	event *ConfirmationEvent) fn.Result[ClientResp] {
+
+	if event.Tx == nil {
+		return fn.Err[ClientResp](fmt.Errorf(
+			"confirmation missing tx details"))
+	}
+
+	// Look up the round by commitment transaction ID.
+	round, err := a.cfg.RoundStore.LookupRoundByCommitmentTx(event.Txid)
+	if err != nil {
+		// Not a commitment tx we're tracking. This shouldn't happen
+		// since we only register for commitment tx confirmations.
+		return fn.Ok[ClientResp](nil)
+	}
+
+	// Route to the specific round's FSM.
+	roundFSM, exists := a.activeRounds[round.RoundID]
+	if !exists {
+		return fn.Err[ClientResp](fmt.Errorf(
+			"round FSM not found for round %s", round.RoundID))
+	}
+
+	confirmEvt := &BoardingConfirmed{
+		TxID:          event.Txid,
+		BlockHeight:   event.BlockHeight,
+		Confirmations: int32(event.Confirmations),
+	}
+
+	err = a.askEventAndProcessOutbox(ctx, roundFSM.FSM, confirmEvt)
+	if err != nil {
+		return fn.Err[ClientResp](fmt.Errorf(
+			"FSM error processing commitment confirmation: %w", err))
+	}
+
+	return fn.Ok[ClientResp](nil)
+}
+
+// processOutbox processes messages emitted by the FSM via Outbox and routes
+// them to the appropriate destination (server or chainsource).
+func (a *RoundClientActor) processOutbox(ctx context.Context,
+	outbox []ClientOutMsg) error {
+
+	for _, msg := range outbox {
+		// Check if this message should be sent to the server. All
+		// server-bound messages implement the ServerMessage interface.
+		if serverMsg, ok := msg.(serverconn.ServerMessage); ok {
+			sendReq := &serverconn.SendClientEventRequest{
+				Message: serverMsg,
+			}
+			a.cfg.ServerConn.Tell(ctx, sendReq)
+
+			continue
+		}
+
+		// Handle non-server messages.
+		switch m := msg.(type) {
+		case *RegisterConfirmationRequest:
+			// FSM emitted a confirmation request. Complete it with
+			// the NotifyActor field pointing to ourselves and send
+			// to ChainSource.
+			var sessionID string
+			switch {
+			case len(m.PkScript) > 0:
+				sessionID = hex.EncodeToString(m.PkScript)
+
+			case m.Txid != nil:
+				sessionID = m.Txid.String()
+
+			default:
+				sessionID = "unknown"
+			}
+			callerID := fmt.Sprintf(
+				"boarding-%s-%s", sessionID, m.CallerID,
+			)
+
+			// Use the shared mapper helper so ChainSource can
+			// deliver confirmation events directly without an
+			// intermediate actor.
+			mappedRef := chainsource.MapConfirmationEvent(
+				a.cfg.SelfRef,
+				func(ce chainsource.ConfirmationEvent) ClientMsg {
+					return &ConfirmationEvent{
+						Txid:          ce.Txid,
+						BlockHeight:   ce.BlockHeight,
+						Confirmations: ce.NumConfs,
+						Tx:            ce.Tx,
+					}
+				},
+			)
+
+			// Build the complete RegisterConfRequest with the
+			// mapper as the NotifyActor target.
+			confReq := &chainsource.RegisterConfRequest{
+				CallerID:    callerID,
+				Txid:        m.Txid,
+				PkScript:    m.PkScript,
+				TargetConfs: m.TargetConfs,
+				HeightHint:  m.HeightHint,
+				NotifyActor: fn.Some(mappedRef),
+			}
+
+			a.cfg.ChainSource.Tell(ctx, confReq)
+
+		case *VTXOCreatedNotification:
+			// TODO: forward to wallet actor once implemented.
+			_ = m.VTXOs
+
+		case *RoundCompletedNotification:
+			// Round FSM reached ConfirmedState. Perform actor
+			// cleanup.
+			err := a.onRoundComplete(m.RoundID, m.TxID)
+			if err != nil {
+				return fmt.Errorf("failed to complete "+
+					"round %s: %w", m.RoundID, err)
+			}
+
+		case *RoundCheckpointedNotification:
+			// Primary FSM checkpointed a round. Migrate to
+			// dedicated FSM.
+			err := a.migrateRoundToActiveFSM(ctx, m.RoundID)
+			if err != nil {
+				return fmt.Errorf("failed to migrate "+
+					"round %s: %w", m.RoundID, err)
+			}
+
+		default:
+			// Unknown outbox message. This could be an internal FSM
+			// event that doesn't need routing, so we ignore it.
+			_ = msg
+		}
+	}
+
+	return nil
+}

--- a/round/actor_harness_test.go
+++ b/round/actor_harness_test.go
@@ -1,0 +1,578 @@
+package round
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/chainsource"
+	"github.com/lightninglabs/darepo-client/lib/scripts"
+	"github.com/lightninglabs/darepo-client/lib/types"
+	"github.com/lightninglabs/darepo-client/serverconn"
+	"github.com/lightninglabs/darepo-client/wallet"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// confEventNotifier is a type alias for confirmation event notifiers.
+type confEventNotifier = actor.TellOnlyRef[chainsource.ConfirmationEvent]
+
+// mockServerConnRef captures all messages sent to the server for test
+// verification, implementing actor.TellOnlyRef[serverconn.ServerConnMsg].
+type mockServerConnRef struct {
+	t        *testing.T
+	id       string
+	messages []serverconn.ServerConnMsg
+	mu       sync.Mutex
+}
+
+func newMockServerConnRef(t *testing.T) *mockServerConnRef {
+	return &mockServerConnRef{
+		t:        t,
+		id:       "mock-server-conn",
+		messages: make([]serverconn.ServerConnMsg, 0),
+	}
+}
+
+func (m *mockServerConnRef) ID() string {
+	return m.id
+}
+
+func (m *mockServerConnRef) Tell(
+	_ context.Context, msg serverconn.ServerConnMsg,
+) {
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.messages = append(m.messages, msg)
+}
+
+func (m *mockServerConnRef) clearMessages() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.messages = m.messages[:0]
+}
+
+// assertMessageSent checks that a message of the given type was sent.
+func (m *mockServerConnRef) assertMessageSent(t *testing.T, msgType string) {
+	t.Helper()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, msg := range m.messages {
+		if msg.MessageType() == msgType {
+			return
+		}
+	}
+
+	t.Fatalf("expected message of type %q, but none found in %d messages",
+		msgType, len(m.messages))
+}
+
+// mockChainSourceRef captures chain registration requests for test
+// verification, implementing actor.TellOnlyRef[chainsource.ChainSourceMsg].
+type mockChainSourceRef struct {
+	t             *testing.T
+	id            string
+	registrations []*chainsource.RegisterConfRequest
+	mu            sync.Mutex
+
+	// notifiers stores mapped actor refs, enabling the test to inject
+	// confirmations back to the actor being tested.
+	notifiers map[string]confEventNotifier
+}
+
+func newMockChainSourceRef(t *testing.T) *mockChainSourceRef {
+	return &mockChainSourceRef{
+		t:             t,
+		id:            "mock-chain-source",
+		registrations: make([]*chainsource.RegisterConfRequest, 0),
+		notifiers:     make(map[string]confEventNotifier),
+	}
+}
+
+func (m *mockChainSourceRef) ID() string {
+	return m.id
+}
+
+func (m *mockChainSourceRef) Tell(
+	_ context.Context, msg chainsource.ChainSourceMsg,
+) {
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if req, ok := msg.(*chainsource.RegisterConfRequest); ok {
+		m.registrations = append(m.registrations, req)
+
+		// Store the notifier so tests can inject confirmations back
+		// to the actor.
+		if req.NotifyActor.IsSome() {
+			notifier := req.NotifyActor.UnwrapOrFail(m.t)
+			m.notifiers[req.CallerID] = notifier
+		}
+	}
+}
+
+// mockWalletActorRef captures registration requests and enables tests to
+// inject boarding confirmations back to the actor under test.
+type mockWalletActorRef struct {
+	t  *testing.T
+	id string
+	mu sync.Mutex
+
+	// registeredNotifier holds the actor ref provided during registration,
+	// enabling tests to send boarding confirmations.
+	registeredNotifier actor.TellOnlyRef[wallet.BoardingUtxoConfirmedEvent]
+}
+
+func newMockWalletActorRef(t *testing.T) *mockWalletActorRef {
+	return &mockWalletActorRef{
+		t:  t,
+		id: "mock-wallet-actor",
+	}
+}
+
+func (m *mockWalletActorRef) ID() string {
+	return m.id
+}
+
+func (m *mockWalletActorRef) Tell(_ context.Context, msg wallet.WalletMsg) {
+	// WalletActor uses Ask pattern for registration, so Tell is unused in
+	// these tests.
+}
+
+func (m *mockWalletActorRef) Ask(_ context.Context,
+	msg wallet.WalletMsg) actor.Future[wallet.WalletResp] {
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if req, ok := msg.(*wallet.RegisterConfirmationNotifierRequest); ok {
+		m.registeredNotifier = req.NotifyActor
+
+		resp := &wallet.RegisterConfirmationNotifierResponse{
+			Success: true,
+		}
+
+		return newImmediateFuture[wallet.WalletResp](resp)
+	}
+
+	return newImmediateFuture[wallet.WalletResp](nil)
+}
+
+// sendBoardingConfirmation simulates a boarding UTXO confirmation from wallet.
+func (m *mockWalletActorRef) sendBoardingConfirmation(ctx context.Context,
+	intent *wallet.BoardingIntent) {
+
+	m.mu.Lock()
+	notifier := m.registeredNotifier
+	m.mu.Unlock()
+
+	if notifier == nil {
+		m.t.Fatal("no notifier registered for boarding confirmations")
+	}
+
+	event := wallet.BoardingUtxoConfirmedEvent{
+		BoardingIntent: intent,
+	}
+	notifier.Tell(ctx, event)
+}
+
+// mockSelfRef captures messages that the round actor sends to itself,
+// enabling tests to intercept and verify self-notifications.
+type mockSelfRef struct {
+	t        *testing.T
+	id       string
+	messages []ClientMsg
+	msgChan  chan ClientMsg
+	mu       sync.Mutex
+}
+
+func newMockSelfRef(t *testing.T) *mockSelfRef {
+	return &mockSelfRef{
+		t:        t,
+		id:       "mock-self-ref",
+		messages: make([]ClientMsg, 0),
+		msgChan:  make(chan ClientMsg, 100),
+	}
+}
+
+func (m *mockSelfRef) ID() string {
+	return m.id
+}
+
+func (m *mockSelfRef) Tell(_ context.Context, msg ClientMsg) {
+	m.mu.Lock()
+	m.messages = append(m.messages, msg)
+	m.mu.Unlock()
+
+	// Also send to channel for blocking receives in test assertions.
+	select {
+	case m.msgChan <- msg:
+	default:
+	}
+}
+
+// waitForMessage blocks until a message arrives or the timeout expires,
+// enabling synchronous test assertions on asynchronous actor messages.
+func (m *mockSelfRef) waitForMessage(timeout time.Duration) (ClientMsg, bool) {
+	select {
+	case msg := <-m.msgChan:
+		return msg, true
+	case <-time.After(timeout):
+		return nil, false
+	}
+}
+
+// immediateFuture provides a synchronous Future implementation for tests,
+// avoiding the complexity of async futures when the result is already known.
+type immediateFuture[T any] struct {
+	result fn.Result[T]
+}
+
+func newImmediateFuture[T any](val T) actor.Future[T] {
+	return &immediateFuture[T]{result: fn.Ok(val)}
+}
+
+func (f *immediateFuture[T]) Await(_ context.Context) fn.Result[T] {
+	return f.result
+}
+
+func (f *immediateFuture[T]) ThenApply(ctx context.Context,
+	fn func(T) T) actor.Future[T] {
+
+	val, err := f.result.Unpack()
+	if err != nil {
+		return f
+	}
+
+	return newImmediateFuture[T](fn(val))
+}
+
+func (f *immediateFuture[T]) OnComplete(_ context.Context,
+	callback func(fn.Result[T])) {
+
+	callback(f.result)
+}
+
+// actorTestHarness provides end-to-end testing of RoundClientActor by
+// wrapping it with mock dependencies that capture outgoing messages and enable
+// injection of incoming events, allowing tests to verify full actor workflows
+// without real network or blockchain interactions.
+//
+//nolint:containedctx
+type actorTestHarness struct {
+	t   *testing.T
+	ctx context.Context
+
+	actor *RoundClientActor
+
+	serverConn  *mockServerConnRef
+	chainSource *mockChainSourceRef
+	walletActor *mockWalletActorRef
+	selfRef     *mockSelfRef
+
+	roundStore *MockRoundStore
+	vtxoStore  *MockVTXOStore
+	wallet     *MockClientWallet
+
+	clientPrivKey   *btcec.PrivateKey
+	operatorPrivKey *btcec.PrivateKey
+	clientPubKey    *btcec.PublicKey
+	operatorPubKey  *btcec.PublicKey
+
+	operatorTerms *types.OperatorTerms
+}
+
+func newActorTestHarness(t *testing.T) *actorTestHarness {
+	t.Helper()
+
+	clientPrivKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	operatorPrivKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	clientPubKey := clientPrivKey.PubKey()
+	operatorPubKey := operatorPrivKey.PubKey()
+
+	serverConn := newMockServerConnRef(t)
+	chainSource := newMockChainSourceRef(t)
+	walletActor := newMockWalletActorRef(t)
+	selfRef := newMockSelfRef(t)
+
+	roundStore := &MockRoundStore{}
+	vtxoStore := &MockVTXOStore{}
+	walletMock := &MockClientWallet{}
+
+	operatorTerms := &types.OperatorTerms{
+		PubKey:            operatorPubKey,
+		BoardingExitDelay: 144,
+		VTXOExitDelay:     144,
+		SweepKey:          operatorPubKey,
+		SweepDelay:        1008,
+		MinConfirmations:  1,
+	}
+
+	cfg := &RoundClientConfig{
+		Name:          "test-round-actor",
+		Wallet:        walletMock,
+		RoundStore:    roundStore,
+		VTXOStore:     vtxoStore,
+		OperatorTerms: operatorTerms,
+		ServerConn:    serverConn,
+		ChainSource:   chainSource,
+		WalletActor:   walletActor,
+		SelfRef:       selfRef,
+		ChainParams:   &chaincfg.MainNetParams,
+	}
+
+	actorResult := NewRoundClientActor(cfg)
+	require.True(
+		t, actorResult.IsOk(), "failed to create actor: %v",
+		actorResult.Err(),
+	)
+
+	actor := actorResult.UnwrapOrFail(t)
+
+	return &actorTestHarness{
+		t:               t,
+		ctx:             t.Context(),
+		actor:           actor,
+		serverConn:      serverConn,
+		chainSource:     chainSource,
+		walletActor:     walletActor,
+		selfRef:         selfRef,
+		roundStore:      roundStore,
+		vtxoStore:       vtxoStore,
+		wallet:          walletMock,
+		clientPrivKey:   clientPrivKey,
+		operatorPrivKey: operatorPrivKey,
+		clientPubKey:    clientPubKey,
+		operatorPubKey:  operatorPubKey,
+		operatorTerms:   operatorTerms,
+	}
+}
+
+// setupMockRoundStoreForStart configures the RoundStore mock to return no
+// active rounds, simulating a fresh start with no recovery needed.
+func (h *actorTestHarness) setupMockRoundStoreForStart() {
+	h.t.Helper()
+
+	h.roundStore.On("ListActiveRounds").Return([]*Round{}, nil)
+}
+
+// start initializes the actor by calling Start().
+func (h *actorTestHarness) start() error {
+	return h.actor.Start(h.ctx)
+}
+
+// receive sends a message to the actor and returns the response.
+func (h *actorTestHarness) receive(msg ClientMsg) fn.Result[ClientResp] {
+	return h.actor.Receive(h.ctx, msg)
+}
+
+// sendWalletConfirmation simulates a boarding UTXO confirmation event from the
+// wallet actor, then forwards the self-notification back to the actor to
+// complete the round-trip.
+func (h *actorTestHarness) sendWalletConfirmation(
+	intent *wallet.BoardingIntent) {
+
+	h.walletActor.sendBoardingConfirmation(h.ctx, intent)
+
+	msg, ok := h.selfRef.waitForMessage(time.Second)
+	require.True(h.t, ok, "expected WalletBoardingConfirmed message")
+
+	result := h.receive(msg)
+	require.True(
+		h.t, result.IsOk(), "actor receive failed: %v", result.Err(),
+	)
+}
+
+// sendServerMessage wraps a server event in a notification and delivers it to
+// the actor, simulating server-to-client communication.
+func (h *actorTestHarness) sendServerMessage(event ClientEvent) {
+	msg := &ServerMessageNotification{Message: event}
+	result := h.receive(msg)
+	require.True(
+		h.t, result.IsOk(), "actor receive failed: %v", result.Err(),
+	)
+}
+
+// queryState retrieves the current FSM states for test assertions.
+func (h *actorTestHarness) queryState() map[string]FSMStateInfo {
+	result := h.receive(&GetClientStateRequest{})
+	require.True(h.t, result.IsOk())
+
+	resp, _ := result.Unpack()
+	stateResp, ok := resp.(*GetClientStateResponse)
+	require.True(h.t, ok, "expected GetClientStateResponse")
+
+	return stateResp.States
+}
+
+// newTestBoardingIntent creates a complete boarding intent with proper
+// tapscript and chain info for testing.
+func (h *actorTestHarness) newTestBoardingIntent() *wallet.BoardingIntent {
+	return h.newTestBoardingIntentWithSuffix("")
+}
+
+// newTestBoardingIntentWithSuffix creates a unique boarding intent, using the
+// suffix to generate distinct outpoints when multiple intents are needed.
+func (h *actorTestHarness) newTestBoardingIntentWithSuffix(
+	suffix string) *wallet.BoardingIntent {
+
+	h.t.Helper()
+
+	hash := chainhash.HashH([]byte(h.t.Name() + "-intent" + suffix))
+	outpoint := wire.OutPoint{Hash: hash, Index: 0}
+
+	tapscript, err := scripts.VTXOTapScript(
+		h.clientPubKey, h.operatorPubKey, h.operatorTerms.VTXOExitDelay,
+	)
+	require.NoError(h.t, err)
+
+	taprootKey, err := tapscript.TaprootKey()
+	require.NoError(h.t, err)
+
+	addr, err := btcutil.NewAddressTaproot(
+		taprootKey.SerializeCompressed()[1:], &chaincfg.MainNetParams,
+	)
+	require.NoError(h.t, err)
+
+	keyDesc := keychain.KeyDescriptor{
+		PubKey: h.clientPubKey,
+		KeyLocator: keychain.KeyLocator{
+			Family: keychain.KeyFamilyMultiSig,
+			Index:  0,
+		},
+	}
+
+	boardingAddr := wallet.BoardingAddress{
+		Address:     addr,
+		Tapscript:   tapscript,
+		KeyDesc:     keyDesc,
+		OperatorKey: h.operatorPubKey,
+		ExitDelay:   h.operatorTerms.VTXOExitDelay,
+	}
+
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(h.t, err)
+
+	confTx := wire.NewMsgTx(2)
+	confTx.AddTxOut(&wire.TxOut{
+		Value:    50000,
+		PkScript: pkScript,
+	})
+
+	return &wallet.BoardingIntent{
+		Address:  boardingAddr,
+		Outpoint: outpoint,
+		ChainInfo: wallet.BoardingChainInfo{
+			ConfHeight: 100,
+			OutPoint:   outpoint,
+			Amount:     btcutil.Amount(50000),
+			ConfTx:     confTx,
+		},
+		Status: wallet.BoardingStatusConfirmed,
+	}
+}
+
+// simulateRoundJoined injects a RoundJoined server event to the actor,
+// simulating successful round enrollment.
+func (h *actorTestHarness) simulateRoundJoined(roundID string) {
+	h.t.Helper()
+
+	event := &RoundJoined{
+		RoundID:     roundID,
+		SessionInfo: map[string][]byte{},
+	}
+	h.sendServerMessage(event)
+}
+
+// assertFSMState verifies the primary FSM is in the expected state type.
+func (h *actorTestHarness) assertFSMState(expectedStateType string) {
+	h.t.Helper()
+
+	states := h.queryState()
+	primaryState, exists := states["primary"]
+	require.True(h.t, exists, "expected primary FSM state")
+
+	stateName := fmt.Sprintf("%T", primaryState.State)
+	require.Contains(
+		h.t, stateName, expectedStateType,
+		"expected state %s, got %s", expectedStateType, stateName,
+	)
+}
+
+// assertServerMessageSent verifies a message of the given type was sent to
+// the server.
+func (h *actorTestHarness) assertServerMessageSent(msgType string) {
+	h.t.Helper()
+	h.serverConn.assertMessageSent(h.t, msgType)
+}
+
+// clearServerMessages resets the captured server messages, allowing tests to
+// verify only new messages sent after this point.
+func (h *actorTestHarness) clearServerMessages() {
+	h.serverConn.clearMessages()
+}
+
+// newTestRound creates a test Round with a unique commitment transaction,
+// using the roundID in the script to ensure distinct transaction hashes.
+func (h *actorTestHarness) newTestRound(roundID string) *Round {
+	h.t.Helper()
+
+	commitmentTx := wire.NewMsgTx(2)
+
+	uniqueScript := append([]byte{0x00, 0x14}, []byte(roundID)...)
+	commitmentTx.AddTxOut(&wire.TxOut{
+		Value:    100000,
+		PkScript: uniqueScript,
+	})
+
+	return &Round{
+		RoundID:      roundID,
+		CommitmentTx: fn.Some(commitmentTx),
+	}
+}
+
+// setupMockRoundStoreForRecovery configures the RoundStore mock to return
+// active rounds for recovery on Start(), using PartialSigsSentState which is
+// stable and won't immediately transition on recovery.
+func (h *actorTestHarness) setupMockRoundStoreForRecovery(rounds []*Round) {
+	h.t.Helper()
+
+	h.roundStore.On("ListActiveRounds").Return(rounds, nil)
+
+	for _, round := range rounds {
+		h.roundStore.On(
+			"FetchState", mock.Anything, round.RoundID,
+		).Return(
+			round,
+			&PartialSigsSentState{RoundID: round.RoundID},
+			nil,
+		)
+	}
+}
+
+// unknownClientMsg is a test message type not handled by the actor, used to
+// test error handling for unrecognized message types.
+type unknownClientMsg struct {
+	actor.BaseMessage
+}
+
+func (m *unknownClientMsg) MessageType() string { return "UnknownClientMsg" }
+func (m *unknownClientMsg) clientMsgSealed()    {}

--- a/round/actor_messages.go
+++ b/round/actor_messages.go
@@ -1,0 +1,211 @@
+package round
+
+import (
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/lib/types"
+	"github.com/lightninglabs/darepo-client/wallet"
+)
+
+// ClientMsg is the sealed interface for all messages that can be sent to a
+// RoundClientActor.
+type ClientMsg interface {
+	actor.Message
+	clientMsgSealed()
+}
+
+// ClientResp is the sealed interface for all response messages from a
+// RoundClientActor.
+type ClientResp interface {
+	actor.Message
+	clientRespSealed()
+}
+
+// WalletBoardingConfirmed wraps a wallet.BoardingUtxoConfirmedEvent to make it
+// compatible with the ClientMsg sealed interface. This enables the round actor
+// to receive boarding UTXO confirmations from the wallet actor.
+type WalletBoardingConfirmed struct {
+	actor.BaseMessage
+
+	// Intent is the confirmed boarding intent from the wallet. Contains
+	// the address, outpoint, chain info (amount, conf height/hash), and
+	// status.
+	Intent *wallet.BoardingIntent
+}
+
+func (m *WalletBoardingConfirmed) MessageType() string {
+	return "WalletBoardingConfirmed"
+}
+
+func (m *WalletBoardingConfirmed) clientMsgSealed() {}
+
+// ServerMessageNotification delivers a server FSM outbox message to the client.
+type ServerMessageNotification struct {
+	actor.BaseMessage
+
+	// Message is a ClientEvent from the server (RoundJoined,
+	// CommitmentTxBuilt, NoncesAggregated, OperatorSigned, BoardingFailed).
+	Message ClientEvent
+}
+
+func (m *ServerMessageNotification) MessageType() string {
+	return "ServerMessageNotification"
+}
+
+func (m *ServerMessageNotification) clientMsgSealed() {}
+
+// ServerMessageResponse acknowledges receipt of a server message.
+type ServerMessageResponse struct {
+	actor.BaseMessage
+
+	Success bool
+	Error   string
+}
+
+func (m *ServerMessageResponse) MessageType() string {
+	return "ServerMessageResponse"
+}
+
+func (m *ServerMessageResponse) clientRespSealed() {}
+
+// GetClientStateRequest queries the current client state.
+type GetClientStateRequest struct {
+	actor.BaseMessage
+}
+
+func (m *GetClientStateRequest) MessageType() string {
+	return "GetClientStateRequest"
+}
+
+func (m *GetClientStateRequest) clientMsgSealed() {}
+
+// FSMStateInfo contains information about a single FSM's current state.
+type FSMStateInfo struct {
+	// State is the actual state object (any ClientState implementation).
+	State ClientState
+
+	// IsPrimary indicates whether this is the primary FSM.
+	IsPrimary bool
+
+	// RoundID is the round ID (empty for primary FSM).
+	RoundID string
+}
+
+// GetClientStateResponse returns the current state of all FSMs.
+type GetClientStateResponse struct {
+	actor.BaseMessage
+
+	// States maps FSM identifier to state info. Key "primary" for the
+	// primary FSM, round IDs for round FSMs.
+	States map[string]FSMStateInfo
+}
+
+func (m *GetClientStateResponse) MessageType() string {
+	return "GetClientStateResponse"
+}
+
+func (m *GetClientStateResponse) clientRespSealed() {}
+
+// CancelRoundRequest cancels participation in the current round.
+type CancelRoundRequest struct {
+	actor.BaseMessage
+}
+
+func (m *CancelRoundRequest) MessageType() string {
+	return "CancelRoundRequest"
+}
+
+func (m *CancelRoundRequest) clientMsgSealed() {}
+
+// CancelRoundResponse confirms cancellation.
+type CancelRoundResponse struct {
+	actor.BaseMessage
+
+	Success bool
+	Error   string
+}
+
+func (m *CancelRoundResponse) MessageType() string {
+	return "CancelRoundResponse"
+}
+
+func (m *CancelRoundResponse) clientRespSealed() {}
+
+// RegisterBoardingIntentRequest informs the FSM that the wallet has funded or
+// will fund a specific boarding address so confirmations should be tracked.
+type RegisterBoardingIntentRequest struct {
+	actor.BaseMessage
+
+	Address      *BoardingAddress
+	VTXORequests []*types.VTXORequest
+}
+
+func (m *RegisterBoardingIntentRequest) MessageType() string {
+	return "RegisterBoardingIntentRequest"
+}
+
+func (m *RegisterBoardingIntentRequest) clientMsgSealed() {}
+
+// RegisterBoardingIntentResponse acknowledges the request.
+type RegisterBoardingIntentResponse struct {
+	actor.BaseMessage
+
+	Success bool
+	Error   string
+}
+
+func (m *RegisterBoardingIntentResponse) MessageType() string {
+	return "RegisterBoardingIntentResponse"
+}
+
+func (m *RegisterBoardingIntentResponse) clientRespSealed() {}
+
+// ConfirmationEvent wraps a chain confirmation event from ChainSource.
+// This allows the actor to receive confirmation notifications.
+type ConfirmationEvent struct {
+	actor.BaseMessage
+
+	// Txid is the transaction that was confirmed.
+	Txid chainhash.Hash
+
+	// BlockHeight is the height at which the transaction was confirmed.
+	BlockHeight int32
+
+	// BlockHash is the hash of the block containing the transaction.
+	BlockHash chainhash.Hash
+
+	// Confirmations is the number of confirmations.
+	Confirmations uint32
+
+	// Tx is the confirmed transaction. This allows the actor to scan
+	// outputs to find the specific UTXO that matches the boarding address.
+	Tx *wire.MsgTx
+}
+
+func (m *ConfirmationEvent) MessageType() string {
+	return "ConfirmationEvent"
+}
+
+func (m *ConfirmationEvent) clientMsgSealed() {}
+
+// ============================================================================
+// Server Actor Messages
+// ============================================================================
+
+// ServerMsg is the sealed interface for all messages that can be sent to a
+// RoundServerActor.
+type ServerMsg interface {
+	actor.Message
+	serverMsgSealed()
+}
+
+// ServerResp is the sealed interface for all response messages from a
+// RoundServerActor.
+type ServerResp interface {
+	actor.Message
+	serverRespSealed()
+}
+
+// TODO: Add server actor message types (JoinRoundRequest, SubmitNoncesRequest,
+// etc.) here. These are the actor-level messages, not the FSM outbox messages.

--- a/round/actor_test.go
+++ b/round/actor_test.go
@@ -1,0 +1,760 @@
+package round
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/types"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// TestActorStart verifies the actor initialization sequence, ensuring proper
+// registration with dependencies and correct handling of initial messages.
+func TestActorStart(t *testing.T) {
+	t.Parallel()
+
+	t.Run("registers_with_wallet", func(t *testing.T) {
+		t.Parallel()
+
+		h := newActorTestHarness(t)
+		h.setupMockRoundStoreForStart()
+
+		err := h.start()
+		require.NoError(t, err)
+
+		// The actor must register a notifier with the wallet to
+		// receive boarding confirmations. Without this registration,
+		// the actor would never learn about completed on-chain
+		// deposits.
+		require.NotNil(
+			t, h.walletActor.registeredNotifier,
+			"expected wallet notifier to be registered",
+		)
+	})
+
+	t.Run("receives_wallet_confirmation", func(t *testing.T) {
+		t.Parallel()
+
+		h := newActorTestHarness(t)
+		h.setupMockRoundStoreForStart()
+
+		err := h.start()
+		require.NoError(t, err)
+
+		intent := h.newTestBoardingIntent()
+		h.sendWalletConfirmation(intent)
+
+		// After receiving a wallet confirmation, the FSM should
+		// transition from Idle to PendingRoundAssembly, indicating
+		// the actor is now waiting for the server to signal that a
+		// new round is being assembled.
+		states := h.queryState()
+		primaryState, exists := states["primary"]
+		require.True(t, exists, "expected primary FSM state")
+
+		_, ok := primaryState.State.(*PendingRoundAssembly)
+		require.True(
+			t, ok, "expected PendingRoundAssembly, got %T",
+			primaryState.State,
+		)
+	})
+
+	t.Run("sends_join_round_request", func(t *testing.T) {
+		t.Parallel()
+
+		h := newActorTestHarness(t)
+		h.setupMockRoundStoreForStart()
+
+		err := h.start()
+		require.NoError(t, err)
+
+		intent := h.newTestBoardingIntent()
+		h.sendWalletConfirmation(intent)
+		h.sendServerMessage(&RegistrationRequested{})
+
+		// When the server signals registration is requested, the
+		// actor should respond by sending a join round request
+		// containing all pending boarding intents.
+		h.serverConn.assertMessageSent(t, "SendClientEventRequest")
+	})
+
+	t.Run("handles_get_state_request", func(t *testing.T) {
+		t.Parallel()
+
+		h := newActorTestHarness(t)
+		h.setupMockRoundStoreForStart()
+
+		err := h.start()
+		require.NoError(t, err)
+
+		states := h.queryState()
+
+		primaryState, exists := states["primary"]
+		require.True(t, exists)
+		require.True(t, primaryState.IsPrimary)
+
+		_, ok := primaryState.State.(*Idle)
+		require.True(t, ok, "expected Idle, got %T", primaryState.State)
+	})
+
+	t.Run("handles_cancel_round_request", func(t *testing.T) {
+		t.Parallel()
+
+		h := newActorTestHarness(t)
+		h.setupMockRoundStoreForStart()
+
+		err := h.start()
+		require.NoError(t, err)
+
+		intent := h.newTestBoardingIntent()
+		h.sendWalletConfirmation(intent)
+
+		result := h.receive(&CancelRoundRequest{})
+		require.True(t, result.IsOk())
+
+		resp, _ := result.Unpack()
+		cancelResp, ok := resp.(*CancelRoundResponse)
+		require.True(t, ok, "expected CancelRoundResponse")
+		require.True(t, cancelResp.Success)
+
+		states := h.queryState()
+		primaryState := states["primary"]
+		_, isFailedState := primaryState.State.(*ClientFailedState)
+		require.True(
+			t, isFailedState,
+			"expected ClientFailedState after cancel, got %T",
+			primaryState.State,
+		)
+	})
+}
+
+// TestActorRecovery validates that the actor can restore its state after a
+// restart by loading active rounds from persistent storage and re-establishing
+// chain confirmations.
+func TestActorRecovery(t *testing.T) {
+	t.Parallel()
+
+	t.Run("single_active_round", func(t *testing.T) {
+		t.Parallel()
+
+		h := newActorTestHarness(t)
+
+		round := h.newTestRound("test-round-001")
+		h.setupMockRoundStoreForRecovery([]*Round{round})
+
+		err := h.start()
+		require.NoError(t, err)
+
+		// The actor should have loaded the round from storage and
+		// created a corresponding FSM to resume processing.
+		require.Len(t, h.actor.activeRounds, 1)
+
+		roundFSM, exists := h.actor.activeRounds["test-round-001"]
+		require.True(t, exists, "expected round FSM for test-round-001")
+		require.Equal(t, "test-round-001", roundFSM.RoundID)
+
+		// The commitment tx index is used to route confirmation
+		// events to the correct round FSM, so it must be rebuilt
+		// during recovery.
+		txid := round.CommitmentTx.UnwrapOrFail(t).TxHash()
+		indexedRoundID, exists := h.actor.commitmentTxIndex[txid]
+		require.True(t, exists, "expected commitment tx in index")
+		require.Equal(t, "test-round-001", indexedRoundID)
+
+		// The actor must re-register for chain confirmations during
+		// recovery to resume monitoring the commitment transaction.
+		require.Len(t, h.chainSource.registrations, 1)
+		reg := h.chainSource.registrations[0]
+		require.NotNil(t, reg.Txid)
+		require.True(t, reg.Txid.IsEqual(&txid))
+	})
+
+	t.Run("multiple_active_rounds", func(t *testing.T) {
+		t.Parallel()
+
+		h := newActorTestHarness(t)
+
+		rounds := []*Round{
+			h.newTestRound("round-001"),
+			h.newTestRound("round-002"),
+			h.newTestRound("round-003"),
+		}
+		h.setupMockRoundStoreForRecovery(rounds)
+
+		err := h.start()
+		require.NoError(t, err)
+
+		require.Len(t, h.actor.activeRounds, 3)
+		for _, round := range rounds {
+			_, exists := h.actor.activeRounds[round.RoundID]
+			require.True(
+				t, exists,
+				"expected round FSM for %s", round.RoundID,
+			)
+		}
+
+		require.Len(t, h.actor.commitmentTxIndex, 3)
+		require.Len(t, h.chainSource.registrations, 3)
+	})
+}
+
+// TestActorConfirmation exercises the confirmation event routing logic,
+// ensuring events are delivered to the correct round FSM and error cases are
+// handled gracefully.
+func TestActorConfirmation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("routes_to_correct_fsm", func(t *testing.T) {
+		t.Parallel()
+
+		h := newActorTestHarness(t)
+
+		round := h.newTestRound("test-round-001")
+		h.setupMockRoundStoreForRecovery([]*Round{round})
+
+		err := h.start()
+		require.NoError(t, err)
+
+		require.Contains(t, h.actor.activeRounds, "test-round-001")
+
+		txid := round.CommitmentTx.UnwrapOrFail(t).TxHash()
+		h.roundStore.On("LookupRoundByCommitmentTx", txid).Return(
+			round, nil,
+		)
+
+		confTx := round.CommitmentTx.UnwrapOrFail(t)
+		confEvent := &ConfirmationEvent{
+			Txid:          txid,
+			BlockHeight:   105,
+			Confirmations: 6,
+			Tx:            confTx,
+		}
+
+		// This test verifies the routing path from confirmation event
+		// to the correct FSM. The mock FSM may reject the event, but
+		// we've confirmed the actor's dispatch logic works correctly.
+		_ = h.receive(confEvent)
+	})
+
+	t.Run("missing_tx_error", func(t *testing.T) {
+		t.Parallel()
+
+		h := newActorTestHarness(t)
+		h.setupMockRoundStoreForStart()
+
+		err := h.start()
+		require.NoError(t, err)
+
+		confEvent := &ConfirmationEvent{
+			Txid:          chainhash.Hash{},
+			BlockHeight:   105,
+			Confirmations: 6,
+			Tx:            nil,
+		}
+
+		result := h.receive(confEvent)
+		require.True(t, result.IsErr())
+		require.Contains(t, result.Err().Error(),
+			"confirmation missing tx details")
+	})
+
+	t.Run("unknown_round_graceful", func(t *testing.T) {
+		t.Parallel()
+
+		h := newActorTestHarness(t)
+		h.setupMockRoundStoreForStart()
+
+		err := h.start()
+		require.NoError(t, err)
+
+		unknownTxid := chainhash.HashH([]byte("unknown-tx"))
+		h.roundStore.On(
+			"LookupRoundByCommitmentTx", unknownTxid,
+		).Return(nil, fmt.Errorf("round not found"))
+
+		confEvent := &ConfirmationEvent{
+			Txid:          unknownTxid,
+			BlockHeight:   105,
+			Confirmations: 6,
+			Tx:            wire.NewMsgTx(2),
+		}
+
+		// Confirmations for unknown transactions should be handled
+		// gracefully without errors, as they may be from old rounds
+		// that have already been cleaned up.
+		result := h.receive(confEvent)
+		require.True(t, result.IsOk())
+	})
+
+	t.Run("fsm_not_found_error", func(t *testing.T) {
+		t.Parallel()
+
+		h := newActorTestHarness(t)
+		h.setupMockRoundStoreForStart()
+
+		err := h.start()
+		require.NoError(t, err)
+
+		// This scenario tests the edge case where a round exists in
+		// the database but has no active FSM. This represents an
+		// inconsistent state that should be caught and reported as an
+		// error rather than silently ignored.
+		round := h.newTestRound("orphan-round")
+		txid := round.CommitmentTx.UnwrapOrFail(t).TxHash()
+		h.roundStore.On("LookupRoundByCommitmentTx", txid).Return(
+			round, nil,
+		)
+
+		confEvent := &ConfirmationEvent{
+			Txid:          txid,
+			BlockHeight:   105,
+			Confirmations: 6,
+			Tx:            round.CommitmentTx.UnwrapOrFail(t),
+		}
+
+		result := h.receive(confEvent)
+		require.True(t, result.IsErr())
+		require.Contains(t, result.Err().Error(), "round FSM not found")
+	})
+}
+
+// TestActorProcessOutbox verifies that the actor correctly handles various
+// outbox messages emitted by FSMs, including chain registrations, round
+// lifecycle events, and server communication.
+func TestActorProcessOutbox(t *testing.T) {
+	t.Parallel()
+
+	t.Run("register_confirmation_request", func(t *testing.T) {
+		t.Parallel()
+
+		h := newActorTestHarness(t)
+		h.setupMockRoundStoreForStart()
+
+		err := h.start()
+		require.NoError(t, err)
+
+		h.chainSource.registrations = nil
+
+		testTxid := chainhash.HashH([]byte("test-txid"))
+		outbox := []ClientOutMsg{
+			&RegisterConfirmationRequest{
+				CallerID:    "test-caller",
+				Txid:        &testTxid,
+				TargetConfs: 6,
+				HeightHint:  100,
+			},
+		}
+
+		err = h.actor.processOutbox(h.ctx, outbox)
+		require.NoError(t, err)
+
+		// The actor should translate FSM outbox requests into actual
+		// chain source registrations, preserving all parameters.
+		require.Len(t, h.chainSource.registrations, 1)
+		reg := h.chainSource.registrations[0]
+		require.True(t, reg.Txid.IsEqual(&testTxid))
+		require.Equal(t, uint32(6), reg.TargetConfs)
+	})
+
+	t.Run("pkscript_registration", func(t *testing.T) {
+		t.Parallel()
+
+		h := newActorTestHarness(t)
+		h.setupMockRoundStoreForStart()
+
+		err := h.start()
+		require.NoError(t, err)
+
+		h.chainSource.registrations = nil
+
+		pkScript := []byte{0x00, 0x14, 0x01, 0x02, 0x03, 0x04}
+		outbox := []ClientOutMsg{
+			&RegisterConfirmationRequest{
+				CallerID:    "pkscript-caller",
+				PkScript:    pkScript,
+				TargetConfs: 3,
+				HeightHint:  50,
+			},
+		}
+
+		err = h.actor.processOutbox(h.ctx, outbox)
+		require.NoError(t, err)
+
+		require.Len(t, h.chainSource.registrations, 1)
+		reg := h.chainSource.registrations[0]
+		require.Nil(t, reg.Txid)
+		require.Equal(t, pkScript, reg.PkScript)
+	})
+
+	t.Run("round_completed", func(t *testing.T) {
+		t.Parallel()
+
+		h := newActorTestHarness(t)
+
+		round := h.newTestRound("completing-round")
+		h.setupMockRoundStoreForRecovery([]*Round{round})
+
+		err := h.start()
+		require.NoError(t, err)
+
+		require.Contains(t, h.actor.activeRounds, "completing-round")
+
+		txid := round.CommitmentTx.UnwrapOrFail(t).TxHash()
+		h.roundStore.On(
+			"FinalizeRound", "completing-round", txid,
+		).Return(nil)
+
+		outbox := []ClientOutMsg{
+			&RoundCompletedNotification{
+				RoundID: "completing-round",
+				TxID:    txid,
+			},
+		}
+
+		err = h.actor.processOutbox(h.ctx, outbox)
+		require.NoError(t, err)
+
+		// When a round completes, the actor must clean up all
+		// in-memory state, including the FSM and tx index entry, to
+		// prevent memory leaks and avoid routing events to completed
+		// rounds.
+		require.NotContains(t, h.actor.activeRounds, "completing-round")
+
+		_, exists := h.actor.commitmentTxIndex[txid]
+		require.False(t, exists)
+
+		h.roundStore.AssertCalled(
+			t, "FinalizeRound", "completing-round", txid,
+		)
+	})
+
+	t.Run("round_checkpointed", func(t *testing.T) {
+		t.Parallel()
+
+		h := newActorTestHarness(t)
+		h.setupMockRoundStoreForStart()
+
+		err := h.start()
+		require.NoError(t, err)
+
+		require.Empty(t, h.actor.activeRounds)
+
+		round := h.newTestRound("checkpointed-round")
+		h.roundStore.On(
+			"FetchState", mock.Anything, "checkpointed-round",
+		).Return(
+			round,
+			&InputSigSentState{RoundID: "checkpointed-round"},
+			nil,
+		)
+
+		outbox := []ClientOutMsg{
+			&RoundCheckpointedNotification{
+				RoundID: "checkpointed-round",
+			},
+		}
+
+		err = h.actor.processOutbox(h.ctx, outbox)
+		require.NoError(t, err)
+
+		// When a checkpoint notification is received, the actor must
+		// migrate the round into an active FSM so it can continue
+		// processing events. This handles the transition from primary
+		// FSM states to dedicated round FSMs.
+		require.Contains(t, h.actor.activeRounds, "checkpointed-round")
+
+		txid := round.CommitmentTx.UnwrapOrFail(t).TxHash()
+		indexedRoundID, exists := h.actor.commitmentTxIndex[txid]
+		require.True(t, exists)
+		require.Equal(t, "checkpointed-round", indexedRoundID)
+	})
+
+	t.Run("vtxo_created", func(t *testing.T) {
+		t.Parallel()
+
+		h := newActorTestHarness(t)
+		h.setupMockRoundStoreForStart()
+
+		err := h.start()
+		require.NoError(t, err)
+
+		outbox := []ClientOutMsg{
+			&VTXOCreatedNotification{
+				VTXOs: []*ClientVTXO{},
+			},
+		}
+
+		err = h.actor.processOutbox(h.ctx, outbox)
+		require.NoError(t, err)
+	})
+
+	t.Run("migrate_round_idempotent", func(t *testing.T) {
+		t.Parallel()
+
+		h := newActorTestHarness(t)
+		h.setupMockRoundStoreForStart()
+
+		err := h.start()
+		require.NoError(t, err)
+
+		round := h.newTestRound("idempotent-round")
+		h.roundStore.On(
+			"FetchState", mock.Anything, "idempotent-round",
+		).Return(
+			round,
+			&InputSigSentState{RoundID: "idempotent-round"},
+			nil,
+		)
+
+		err = h.actor.migrateRoundToActiveFSM(h.ctx, "idempotent-round")
+		require.NoError(t, err)
+		require.Len(t, h.actor.activeRounds, 1)
+
+		// Migration must be idempotent to handle duplicate
+		// checkpoint notifications without creating multiple FSMs for
+		// the same round.
+		err = h.actor.migrateRoundToActiveFSM(h.ctx, "idempotent-round")
+		require.NoError(t, err)
+		require.Len(t, h.actor.activeRounds, 1)
+	})
+
+	t.Run("server_messages", func(t *testing.T) {
+		t.Parallel()
+
+		h := newActorTestHarness(t)
+		h.setupMockRoundStoreForStart()
+
+		err := h.start()
+		require.NoError(t, err)
+
+		joinReq := &JoinRoundRequest{
+			BoardingRequests: []types.BoardingRequest{},
+			VTXORequests:     []types.VTXORequest{},
+			RoundID:          "test-round",
+		}
+
+		h.clearServerMessages()
+		err = h.actor.processOutbox(h.ctx, []ClientOutMsg{joinReq})
+		require.NoError(t, err)
+
+		h.assertServerMessageSent("SendClientEventRequest")
+	})
+}
+
+// TestActorGetStateWithActiveRounds validates that the actor correctly
+// reports both the primary FSM state and all active round states when queried.
+func TestActorGetStateWithActiveRounds(t *testing.T) {
+	t.Parallel()
+
+	h := newActorTestHarness(t)
+
+	rounds := []*Round{
+		h.newTestRound("round-001"),
+		h.newTestRound("round-002"),
+	}
+	h.setupMockRoundStoreForRecovery(rounds)
+
+	err := h.start()
+	require.NoError(t, err)
+
+	states := h.queryState()
+
+	// The state map should contain the primary FSM plus one entry for
+	// each active round.
+	require.Len(t, states, 3)
+
+	primaryState, exists := states["primary"]
+	require.True(t, exists)
+	require.True(t, primaryState.IsPrimary)
+
+	for _, round := range rounds {
+		roundState, exists := states[round.RoundID]
+		require.True(t, exists, "expected state for %s", round.RoundID)
+		require.False(t, roundState.IsPrimary)
+		require.Equal(t, round.RoundID, roundState.RoundID)
+	}
+}
+
+// TestActorReceiveUnknownMessageType ensures that the actor rejects
+// unrecognized message types with an appropriate error rather than silently
+// ignoring them.
+func TestActorReceiveUnknownMessageType(t *testing.T) {
+	t.Parallel()
+
+	h := newActorTestHarness(t)
+	h.setupMockRoundStoreForStart()
+
+	err := h.start()
+	require.NoError(t, err)
+
+	unknownMsg := &unknownClientMsg{}
+
+	result := h.receive(unknownMsg)
+	require.True(t, result.IsErr())
+	require.Contains(t, result.Err().Error(), "unknown message type")
+}
+
+// TestActorLifecycle verifies complete end-to-end workflows through various
+// FSM state transitions, ensuring the actor behaves correctly across the full
+// boarding lifecycle.
+func TestActorLifecycle(t *testing.T) {
+	t.Parallel()
+
+	t.Run("full_boarding_flow", func(t *testing.T) {
+		t.Parallel()
+
+		h := newActorTestHarness(t)
+		h.setupMockRoundStoreForStart()
+
+		err := h.start()
+		require.NoError(t, err)
+
+		// The actor begins in Idle state, registered with the wallet
+		// to receive boarding confirmations.
+		require.NotNil(
+			t, h.walletActor.registeredNotifier,
+			"actor should register with wallet on start",
+		)
+		h.assertFSMState("Idle")
+
+		intent := h.newTestBoardingIntent()
+		h.sendWalletConfirmation(intent)
+		h.assertFSMState("PendingRoundAssembly")
+
+		h.clearServerMessages()
+		h.sendServerMessage(&RegistrationRequested{})
+		h.assertFSMState("RegistrationSentState")
+		h.assertServerMessageSent("SendClientEventRequest")
+
+		roundID := "test-round-001"
+		h.simulateRoundJoined(roundID)
+		h.assertFSMState("RoundJoinedState")
+	})
+
+	t.Run("multiple_boarding_confirmations", func(t *testing.T) {
+		t.Parallel()
+
+		h := newActorTestHarness(t)
+		h.setupMockRoundStoreForStart()
+
+		err := h.start()
+		require.NoError(t, err)
+
+		intent1 := h.newTestBoardingIntent()
+		h.sendWalletConfirmation(intent1)
+		h.assertFSMState("PendingRoundAssembly")
+
+		// Multiple boarding confirmations should accumulate in the
+		// pending intents list, with all intents included in the
+		// subsequent join round request.
+		intent2 := h.newTestBoardingIntentWithSuffix("-second")
+		h.sendWalletConfirmation(intent2)
+		h.assertFSMState("PendingRoundAssembly")
+
+		h.clearServerMessages()
+		h.sendServerMessage(&RegistrationRequested{})
+		h.assertFSMState("RegistrationSentState")
+		h.assertServerMessageSent("SendClientEventRequest")
+	})
+
+	t.Run("registration_failure", func(t *testing.T) {
+		t.Parallel()
+
+		h := newActorTestHarness(t)
+		h.setupMockRoundStoreForStart()
+
+		err := h.start()
+		require.NoError(t, err)
+
+		intent := h.newTestBoardingIntent()
+		h.sendWalletConfirmation(intent)
+		h.sendServerMessage(&RegistrationRequested{})
+		h.assertFSMState("RegistrationSentState")
+
+		h.sendServerMessage(&BoardingFailed{
+			Reason:      "Round full",
+			Error:       fmt.Errorf("max participants reached"),
+			Recoverable: true,
+		})
+
+		h.assertFSMState("ClientFailedState")
+	})
+}
+
+// TestActorServerMessageRouting uses table-driven tests to verify that server
+// messages trigger the correct FSM state transitions and produce expected
+// outbox messages across various scenarios.
+func TestActorServerMessageRouting(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name          string
+		setupState    func(*actorTestHarness)
+		serverEvent   ClientEvent
+		expectedState string
+		expectOutbox  bool
+		outboxMsgType string
+	}{
+		{
+			name: "RegistrationRequested_from_PendingRoundAssembly",
+			setupState: func(h *actorTestHarness) {
+				h.setupMockRoundStoreForStart()
+				require.NoError(h.t, h.start())
+				intent := h.newTestBoardingIntent()
+				h.sendWalletConfirmation(intent)
+			},
+			serverEvent:   &RegistrationRequested{},
+			expectedState: "RegistrationSentState",
+			expectOutbox:  true,
+			outboxMsgType: "SendClientEventRequest",
+		},
+		{
+			name: "RoundJoined_from_RegistrationSentState",
+			setupState: func(h *actorTestHarness) {
+				h.setupMockRoundStoreForStart()
+				require.NoError(h.t, h.start())
+				intent := h.newTestBoardingIntent()
+				h.sendWalletConfirmation(intent)
+				h.sendServerMessage(&RegistrationRequested{})
+			},
+			serverEvent:   &RoundJoined{RoundID: "test-round"},
+			expectedState: "RoundJoinedState",
+			expectOutbox:  false,
+		},
+		{
+			name: "BoardingFailed_from_any_state",
+			setupState: func(h *actorTestHarness) {
+				h.setupMockRoundStoreForStart()
+				require.NoError(h.t, h.start())
+				intent := h.newTestBoardingIntent()
+				h.sendWalletConfirmation(intent)
+			},
+			serverEvent: &BoardingFailed{
+				Reason:      "Test failure",
+				Recoverable: true,
+			},
+			expectedState: "ClientFailedState",
+			expectOutbox:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newActorTestHarness(t)
+			tc.setupState(h)
+			h.clearServerMessages()
+
+			h.sendServerMessage(tc.serverEvent)
+
+			h.assertFSMState(tc.expectedState)
+			if tc.expectOutbox {
+				h.assertServerMessageSent(tc.outboxMsgType)
+			}
+		})
+	}
+}

--- a/round/common_events.go
+++ b/round/common_events.go
@@ -1,0 +1,81 @@
+package round
+
+import (
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/tree"
+)
+
+// This file defines common event types that are shared between client and
+// server state machines. These event types are embedded in the specific
+// client and server event structures to avoid duplication and ensure
+// consistency in the data passed between state transitions.
+
+// CommitmentTxBuiltEvent represents the completion of commitment transaction
+// construction. The server emits this event after building the transaction
+// that commits all boarding UTXOs, while clients receive it to validate the
+// transaction structure and their VTXT paths.
+type CommitmentTxBuiltEvent struct {
+	// RoundID identifies which round this commitment transaction belongs
+	// to.
+	RoundID string
+
+	// Tx is the unsigned commitment transaction that locks all boarding
+	// UTXOs and commits to the VTXT tree.
+	Tx *wire.MsgTx
+
+	// VTXTTree contains the client's extracted sub-tree from the virtual
+	// transaction tree. The server sends only the minimal path containing
+	// the transactions needed to reach this client's VTXO leaves, not the
+	// full tree (which may contain hundreds of transactions for all
+	// participants). This sub-tree is sufficient for the client to verify
+	// their VTXOs and perform unilateral exit if needed.
+	VTXTTree *tree.Tree
+}
+
+// NoncesAggregatedEvent represents the completion of MuSig2 nonce aggregation.
+// The server computes aggregated nonces from all participants and sends them
+// back to clients, who use them to generate partial signatures in the next
+// phase of the MuSig2 signing protocol.
+type NoncesAggregatedEvent struct {
+	// RoundID identifies which round these aggregated nonces belong to.
+	RoundID string
+
+	// AggregatedNonces maps transaction IDs to their aggregated MuSig2
+	// nonces. Each entry corresponds to a transaction in the VTXT that
+	// requires signing.
+	AggregatedNonces map[chainhash.Hash][]byte
+}
+
+// OperatorSignedEvent represents the completion of VTXT signature aggregation
+// by the operator. After collecting and validating all partial signatures from
+// participants, the operator produces complete Schnorr signatures for each
+// transaction in the VTXT. Clients must validate these signatures before
+// proceeding to sign the boarding input.
+type OperatorSignedEvent struct {
+	// RoundID identifies which round these signatures belong to.
+	RoundID string
+
+	// Signatures contains the complete aggregated Schnorr signatures for
+	// each transaction in the VTXT. The order corresponds to the
+	// transaction ordering in the VTXT tree.
+	Signatures [][]byte
+
+	// SignedVTXT optionally contains the fully signed virtual transaction
+	// tree in serialized form. This may be omitted and reconstructed from
+	// the signatures if needed.
+	SignedVTXT []byte
+}
+
+// VTXOInfo wraps VTXO information with additional boarding-specific context
+// such as the round in which it was created, the boarding UTXO that funded it,
+// and timestamps for tracking purposes.
+//
+// TODO(boarding): Evaluate if we need a custom wrapper struct or if lib types
+// are sufficient. If we need to add boarding-specific metadata (e.g., round
+// ID, boarding UTXO reference, creation timestamp), create a BoardingVTXO
+// wrapper struct that embeds the lib VTXO type.
+type VTXOInfo struct {
+	// TODO: Add boarding-specific fields here if needed. For now, we'll
+	// use lib types directly.
+}

--- a/round/events.go
+++ b/round/events.go
@@ -1,0 +1,222 @@
+package round
+
+import (
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/tree"
+	"github.com/lightninglabs/darepo-client/wallet"
+	"github.com/lightninglabs/taproot-assets/proof"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+)
+
+// ClientEvent is a sealed interface for all events that can be processed by
+// the client round interaction state machine. The sealed interface pattern
+// prevents external packages from implementing this interface, ensuring type
+// safety and exhaustive pattern matching in state transitions.
+type ClientEvent interface {
+	// clientEventSealed is an unexported method that marks this interface
+	// as sealed, preventing external implementations.
+	clientEventSealed()
+}
+
+// ClientOutMsg is a sealed interface for messages emitted via the FSM outbox.
+// These are typically sent to the server or other actors. Separating this from
+// ClientEvent improves readability by distinguishing internal FSM events from
+// outgoing messages.
+type ClientOutMsg interface {
+	// clientOutMsgSealed is an unexported method that marks this interface
+	// as sealed, preventing external implementations.
+	clientOutMsgSealed()
+}
+
+// ResumeBoardingIntents is emitted to instruct the FSM to resume monitoring
+// boarding intents that were in progress. The intents are provided as a
+// parameter (pre-filtered by the actor) rather than fetched from storage.
+type ResumeBoardingIntents struct {
+	// Intents are the boarding intents to resume, keyed by their outpoint.
+	// These are pre-filtered to include only Confirmed-but-not-Adopted
+	// intents.
+	Intents map[wire.OutPoint]BoardingIntent
+}
+
+func (e *ResumeBoardingIntents) clientEventSealed() {}
+
+// BoardingUTXOConfirmed is emitted when the boarding UTXO has received
+// sufficient confirmations and is ready to be used for boarding.
+type BoardingUTXOConfirmed struct {
+	// Outpoint identifies the confirmed boarding UTXO.
+	Outpoint wire.OutPoint
+
+	// Address is the boarding address for this UTXO. Contains the keys,
+	// tapscript, and exit delay needed to build the BoardingRequest.
+	Address wallet.BoardingAddress
+
+	// BlockHeight is the height at which the UTXO was confirmed.
+	BlockHeight int32
+
+	// BlockHash is the hash of the block containing the transaction.
+	BlockHash chainhash.Hash
+
+	// Confirmations is the number of confirmations the UTXO has.
+	Confirmations int32
+
+	// Tx is the confirmed transaction containing the boarding UTXO. This
+	// allows the FSM to extract output details without additional chain
+	// queries.
+	Tx *wire.MsgTx
+
+	// TxProof is the optional SPV proof for this boarding UTXO. Includes
+	// merkle proof, block header, and output construction details. None if
+	// the proof hasn't been constructed yet.
+	TxProof fn.Option[proof.TxProof]
+}
+
+func (e *BoardingUTXOConfirmed) clientEventSealed() {}
+
+// RegistrationRequested is emitted when the FSM is ready to join a round with
+// the currently confirmed set of boarding intents. The actor should treat this
+// as a batch request containing every confirmed intent.
+type RegistrationRequested struct {
+	Intents []BoardingIntent
+
+	// RoundID allows resuming a previously assigned round when rejoining.
+	RoundID string
+}
+
+func (e *RegistrationRequested) clientEventSealed() {}
+
+// RoundJoined is emitted when the server accepts the client's registration
+// and assigns them to a round. This event arrives via the Outbox from the
+// server FSM.
+type RoundJoined struct {
+	// RoundID is the unique identifier for the round.
+	RoundID string
+
+	// SessionInfo contains any session-specific data from the operator.
+	SessionInfo map[string][]byte
+}
+
+func (e *RoundJoined) clientEventSealed() {}
+
+// CommitmentTxBuilt is emitted when the server sends the commitment
+// transaction and VTXT path to the client. This event arrives via the Outbox
+// from the server FSM. It embeds the common event type.
+type CommitmentTxBuilt struct {
+	CommitmentTxBuiltEvent
+}
+
+func (e *CommitmentTxBuilt) clientEventSealed() {}
+
+// CommitmentTxValidated is emitted after the client successfully validates
+// the commitment transaction and VTXT path. This is a critical security
+// checkpoint - the client must verify:
+//  1. Boarding UTXO is an input to commitment tx.
+//  2. VTXT path is valid and leads to expected VTXOs.
+//  3. VTXO amounts and scripts match requests.
+type CommitmentTxValidated struct {
+	// VTXTTree is the validated tree.
+	VTXTTree *tree.Tree
+
+	// ValidationInfo contains details about what was validated.
+	ValidationInfo map[string]interface{}
+}
+
+func (e *CommitmentTxValidated) clientEventSealed() {}
+
+// GenerateNonces is emitted when the client has validated the vtxt tree, and
+// nonces should be generated for all the client trees.
+type GenerateNonces struct {
+}
+
+func (e *GenerateNonces) clientEventSealed() {}
+
+// NoncesAggregated is emitted when the server sends back the aggregated
+// nonces from all participants. This event arrives via the Outbox from the
+// server FSM. It embeds the common event type.
+type NoncesAggregated struct {
+	NoncesAggregatedEvent
+}
+
+func (e *NoncesAggregated) clientEventSealed() {}
+
+// GeneratePartialSigs is emitted when the client has generated partial
+// signatures for all transactions in their VTXT path using the aggregated
+// nonces.
+type GeneratePartialSigs struct {
+	// PartialSigs are the MuSig2 partial signatures, one per transaction
+	// in the client's VTXT path.
+	PartialSigs [][]byte
+
+	// SigningKey is the key used for signing.
+	SigningKey *btcec.PublicKey
+}
+
+func (e *GeneratePartialSigs) clientEventSealed() {}
+
+// OperatorSigned is emitted when the server sends the complete VTXT
+// signatures after aggregating all partial signatures. This event arrives via
+// the Outbox from the server FSM. It embeds the common event type.
+type OperatorSigned struct {
+	OperatorSignedEvent
+}
+
+func (e *OperatorSigned) clientEventSealed() {}
+
+// BoardingConfirmed is emitted when the commitment transaction has been
+// confirmed on-chain with sufficient confirmations.
+type BoardingConfirmed struct {
+	// TxID is the confirmed commitment transaction ID.
+	TxID chainhash.Hash
+
+	// BlockHeight is the height at which the transaction was confirmed.
+	BlockHeight int32
+
+	// Confirmations is the number of confirmations.
+	Confirmations int32
+
+	// VTXOs are the virtual UTXOs the client now owns. TODO: Evaluate if
+	// we need to wrap lib VTXO types with boarding-specific metadata. For
+	// now, storing as opaque data.
+	VTXOs []byte
+}
+
+func (e *BoardingConfirmed) clientEventSealed() {}
+
+// BoardingFailed is emitted when an error occurs during the boarding
+// process.
+type BoardingFailed struct {
+	// Reason is a human-readable description of the failure.
+	Reason string
+
+	// Error is the underlying error.
+	Error error
+
+	// Recoverable indicates if the client can retry or if CSV recovery
+	// is needed.
+	Recoverable bool
+}
+
+func (e *BoardingFailed) clientEventSealed() {}
+
+// RecoveryInitiated is emitted when the client initiates CSV timeout
+// recovery to sweep their boarding UTXO back to their wallet.
+type RecoveryInitiated struct {
+	// Outpoint identifies the boarding UTXO being recovered.
+	Outpoint wire.OutPoint
+
+	// SweepTxID is the transaction ID of the sweep transaction.
+	SweepTxID chainhash.Hash
+
+	// Reason explains why recovery was initiated.
+	Reason string
+}
+
+func (e *RecoveryInitiated) clientEventSealed() {}
+
+// RoundComplete is an internal event emitted after a boarding round completes
+// successfully. This triggers the FSM to transition back to Idle state to
+// process new boarding addresses and intents.
+type RoundComplete struct{}
+
+func (e *RoundComplete) clientEventSealed() {}

--- a/round/events.go
+++ b/round/events.go
@@ -4,6 +4,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/baselib/actor"
 	"github.com/lightninglabs/darepo-client/lib/tree"
 	"github.com/lightninglabs/darepo-client/wallet"
 	"github.com/lightninglabs/taproot-assets/proof"
@@ -220,3 +221,43 @@ func (e *RecoveryInitiated) clientEventSealed() {}
 type RoundComplete struct{}
 
 func (e *RoundComplete) clientEventSealed() {}
+
+// RefreshVTXORequest is sent from a VTXO actor when its VTXO is approaching
+// expiry and needs to be refreshed in a new round. The round actor should
+// queue this VTXO for inclusion in the next batch swap.
+type RefreshVTXORequest struct {
+	actor.BaseMessage
+
+	// VTXOOutpoint identifies the VTXO to refresh.
+	VTXOOutpoint wire.OutPoint
+
+	// Amount is the VTXO value in satoshis.
+	Amount int64
+}
+
+func (e *RefreshVTXORequest) clientEventSealed()   {}
+func (e *RefreshVTXORequest) roundActorMsgSealed() {}
+func (e *RefreshVTXORequest) MessageType() string  { return "RefreshVTXORequest" }
+
+// ForfeitSignatureResponse is sent from a VTXO actor with its signature for
+// the forfeit transaction. This is the response to a forfeit request during
+// a batch swap round.
+type ForfeitSignatureResponse struct {
+	actor.BaseMessage
+
+	// VTXOOutpoint identifies the VTXO being forfeited.
+	VTXOOutpoint wire.OutPoint
+
+	// RoundID is the round where the forfeit is being processed.
+	RoundID string
+
+	// ForfeitTx is the built forfeit transaction.
+	ForfeitTx *wire.MsgTx
+
+	// Signature is the client's signature for the forfeit tx.
+	Signature []byte
+}
+
+func (e *ForfeitSignatureResponse) clientEventSealed()   {}
+func (e *ForfeitSignatureResponse) roundActorMsgSealed() {}
+func (e *ForfeitSignatureResponse) MessageType() string  { return "ForfeitSignatureResponse" }

--- a/round/fsm_environment.go
+++ b/round/fsm_environment.go
@@ -1,0 +1,51 @@
+package round
+
+import (
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/lightninglabs/darepo-client/lib/types"
+)
+
+// ClientEnvironment provides the client round interaction state machine with
+// access to external systems and storage. This follows the protofsm pattern
+// where the environment contains all dependencies needed for state transitions.
+//
+// Note: Boarding address and intent persistence is handled by the wallet actor.
+// The FSM only needs RoundStore for round checkpointing.
+type ClientEnvironment struct {
+	// RoundStore provides persistence for round coordination and
+	// checkpointing.
+	RoundStore RoundStore
+
+	// VTXOStore provides persistence for off-chain balance.
+	VTXOStore VTXOStore
+
+	// Wallet provides signing capabilities for round participation.
+	Wallet ClientWallet
+
+	// OperatorTerms contains the operator's parameters including sweep
+	// keys, fee targets, confirmation thresholds, and amount limits.
+	OperatorTerms *types.OperatorTerms
+
+	// ChainParams are the Bitcoin network parameters.
+	ChainParams *chaincfg.Params
+}
+
+// Name returns the unique identifier for this FSM instance.
+func (e *ClientEnvironment) Name() string {
+	return "round_fsm"
+}
+
+// NewClientEnvironment creates a new client environment with the provided
+// dependencies.
+func NewClientEnvironment(roundStore RoundStore, vtxoStore VTXOStore,
+	wallet ClientWallet, terms *types.OperatorTerms,
+	chainParams *chaincfg.Params) *ClientEnvironment {
+
+	return &ClientEnvironment{
+		RoundStore:    roundStore,
+		VTXOStore:     vtxoStore,
+		Wallet:        wallet,
+		OperatorTerms: terms,
+		ChainParams:   chainParams,
+	}
+}

--- a/round/harness_test.go
+++ b/round/harness_test.go
@@ -1,0 +1,1744 @@
+package round
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"fmt"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/scripts"
+	"github.com/lightninglabs/darepo-client/lib/tree"
+	"github.com/lightninglabs/darepo-client/lib/types"
+	"github.com/lightninglabs/darepo-client/wallet"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// MockRoundStore implements RoundStore using mock.Mock for testing.
+type MockRoundStore struct {
+	mock.Mock
+}
+
+func (m *MockRoundStore) CommitState(ctx context.Context, round *Round,
+	state ClientState) error {
+
+	args := m.Called(ctx, round, state)
+	return args.Error(0)
+}
+
+//nolint:forcetypeassert
+func (m *MockRoundStore) FetchState(ctx context.Context,
+	roundID string) (*Round, ClientState, error) {
+
+	args := m.Called(ctx, roundID)
+
+	var round *Round
+	if args.Get(0) != nil {
+		round = args.Get(0).(*Round)
+	}
+
+	var state ClientState
+	if args.Get(1) != nil {
+		state = args.Get(1).(ClientState)
+	}
+
+	return round, state, args.Error(2)
+}
+
+//nolint:forcetypeassert
+func (m *MockRoundStore) LookupRoundByCommitmentTx(
+	txid chainhash.Hash) (*Round, error) {
+
+	args := m.Called(txid)
+
+	var round *Round
+	if args.Get(0) != nil {
+		round = args.Get(0).(*Round)
+	}
+
+	return round, args.Error(1)
+}
+
+//nolint:forcetypeassert
+func (m *MockRoundStore) ListActiveRounds() ([]*Round, error) {
+	args := m.Called()
+
+	var rounds []*Round
+	if args.Get(0) != nil {
+		rounds = args.Get(0).([]*Round)
+	}
+
+	return rounds, args.Error(1)
+}
+
+func (m *MockRoundStore) FinalizeRound(roundID string,
+	txid chainhash.Hash) error {
+
+	args := m.Called(roundID, txid)
+	return args.Error(0)
+}
+
+// Compile-time check that MockRoundStore implements RoundStore.
+var _ RoundStore = (*MockRoundStore)(nil)
+
+// MockVTXOStore implements VTXOStore using mock.Mock for testing.
+type MockVTXOStore struct {
+	mock.Mock
+}
+
+func (m *MockVTXOStore) SaveVTXOs(vtxos []*ClientVTXO) error {
+	args := m.Called(vtxos)
+	return args.Error(0)
+}
+
+//nolint:forcetypeassert
+func (m *MockVTXOStore) ListVTXOs() ([]*ClientVTXO, error) {
+	args := m.Called()
+
+	var vtxos []*ClientVTXO
+	if args.Get(0) != nil {
+		vtxos = args.Get(0).([]*ClientVTXO)
+	}
+
+	return vtxos, args.Error(1)
+}
+
+//nolint:forcetypeassert
+func (m *MockVTXOStore) GetVTXO(outpoint wire.OutPoint) (*ClientVTXO, error) {
+	args := m.Called(outpoint)
+
+	var vtxo *ClientVTXO
+	if args.Get(0) != nil {
+		vtxo = args.Get(0).(*ClientVTXO)
+	}
+
+	return vtxo, args.Error(1)
+}
+
+func (m *MockVTXOStore) MarkVTXOSpent(outpoint wire.OutPoint) error {
+	args := m.Called(outpoint)
+	return args.Error(0)
+}
+
+// Compile-time check that MockVTXOStore implements VTXOStore.
+var _ VTXOStore = (*MockVTXOStore)(nil)
+
+// MockClientWallet implements ClientWallet (input.MuSig2Signer + input.Signer)
+// using mock.Mock for testing.
+type MockClientWallet struct {
+	mock.Mock
+}
+
+//nolint:forcetypeassert
+func (m *MockClientWallet) MuSig2CreateSession(
+	version input.MuSig2Version,
+	keyLoc keychain.KeyLocator,
+	signers []*btcec.PublicKey,
+	tweaks *input.MuSig2Tweaks,
+	otherNonces [][musig2.PubNonceSize]byte,
+	localNonces *musig2.Nonces,
+) (*input.MuSig2SessionInfo, error) {
+
+	args := m.Called(
+		version, keyLoc, signers, tweaks, otherNonces, localNonces,
+	)
+
+	var info *input.MuSig2SessionInfo
+	if args.Get(0) != nil {
+		info = args.Get(0).(*input.MuSig2SessionInfo)
+	}
+
+	return info, args.Error(1)
+}
+
+func (m *MockClientWallet) MuSig2RegisterNonces(
+	sessionID input.MuSig2SessionID,
+	nonces [][musig2.PubNonceSize]byte,
+) (bool, error) {
+
+	args := m.Called(sessionID, nonces)
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *MockClientWallet) MuSig2RegisterCombinedNonce(
+	sessionID input.MuSig2SessionID,
+	nonce [musig2.PubNonceSize]byte,
+) error {
+
+	args := m.Called(sessionID, nonce)
+	return args.Error(0)
+}
+
+//nolint:forcetypeassert
+func (m *MockClientWallet) MuSig2GetCombinedNonce(
+	sessionID input.MuSig2SessionID,
+) ([musig2.PubNonceSize]byte, error) {
+
+	args := m.Called(sessionID)
+
+	var nonce [musig2.PubNonceSize]byte
+	if args.Get(0) != nil {
+		nonce = args.Get(0).([musig2.PubNonceSize]byte)
+	}
+
+	return nonce, args.Error(1)
+}
+
+//nolint:forcetypeassert
+func (m *MockClientWallet) MuSig2Sign(
+	sessionID input.MuSig2SessionID,
+	message [sha256.Size]byte,
+	cleanup bool,
+) (*musig2.PartialSignature, error) {
+
+	args := m.Called(sessionID, message, cleanup)
+
+	var sig *musig2.PartialSignature
+	if args.Get(0) != nil {
+		sig = args.Get(0).(*musig2.PartialSignature)
+	}
+
+	return sig, args.Error(1)
+}
+
+//nolint:forcetypeassert
+func (m *MockClientWallet) MuSig2CombineSig(
+	sessionID input.MuSig2SessionID,
+	otherPartials []*musig2.PartialSignature,
+) (*schnorr.Signature, bool, error) {
+
+	args := m.Called(sessionID, otherPartials)
+
+	var sig *schnorr.Signature
+	if args.Get(0) != nil {
+		sig = args.Get(0).(*schnorr.Signature)
+	}
+
+	return sig, args.Bool(1), args.Error(2)
+}
+
+func (m *MockClientWallet) MuSig2Cleanup(
+	sessionID input.MuSig2SessionID) error {
+
+	args := m.Called(sessionID)
+	return args.Error(0)
+}
+
+//nolint:forcetypeassert
+func (m *MockClientWallet) SignOutputRaw(
+	tx *wire.MsgTx,
+	signDesc *input.SignDescriptor,
+) (input.Signature, error) {
+
+	args := m.Called(tx, signDesc)
+
+	var sig input.Signature
+	if args.Get(0) != nil {
+		sig = args.Get(0).(input.Signature)
+	}
+
+	return sig, args.Error(1)
+}
+
+//nolint:forcetypeassert
+func (m *MockClientWallet) ComputeInputScript(
+	tx *wire.MsgTx,
+	signDesc *input.SignDescriptor,
+) (*input.Script, error) {
+
+	args := m.Called(tx, signDesc)
+
+	var script *input.Script
+	if args.Get(0) != nil {
+		script = args.Get(0).(*input.Script)
+	}
+
+	return script, args.Error(1)
+}
+
+// Compile-time check that MockClientWallet implements ClientWallet.
+var _ ClientWallet = (*MockClientWallet)(nil)
+
+// boardingTestHarness is the central test harness housing all common setup,
+// mocks, fixtures, and helper functions for boarding FSM tests.
+//
+//nolint:containedctx
+type boardingTestHarness struct {
+	t      *testing.T
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	// Mocks for FSM dependencies.
+	roundStore *MockRoundStore
+	vtxoStore  *MockVTXOStore
+	wallet     *MockClientWallet
+
+	// Environment for FSM.
+	env *ClientEnvironment
+
+	// Real cryptographic keys for signature testing.
+	clientPrivKey   *btcec.PrivateKey
+	clientPubKey    *btcec.PublicKey
+	operatorPrivKey *btcec.PrivateKey
+	operatorPubKey  *btcec.PublicKey
+
+	// Runtime state tracking for assertions.
+	currentState   ClientState
+	lastTransition *ClientStateTransition
+	outboxMessages []ClientOutMsg
+}
+
+// newTestHarness creates a new test harness with default mock configuration.
+func newTestHarness(t *testing.T) *boardingTestHarness {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	clientPrivKey, clientPubKey := generateTestKeyPair(t)
+	operatorPrivKey, operatorPubKey := generateTestKeyPair(t)
+
+	roundStore := &MockRoundStore{}
+	vtxoStore := &MockVTXOStore{}
+	wallet := &MockClientWallet{}
+
+	terms := &types.OperatorTerms{
+		PubKey:            operatorPubKey,
+		SweepKey:          operatorPubKey,
+		SweepDelay:        1008, // ~1 week in blocks.
+		DustLimit:         546,
+		MinBoardingAmount: 10000,
+		MaxBoardingAmount: 100000000, // 1 BTC.
+		FeeRate:           10,
+		MinConfirmations:  3,
+	}
+
+	env := NewClientEnvironment(
+		roundStore, vtxoStore, wallet, terms,
+		&chaincfg.RegressionNetParams,
+	)
+
+	h := &boardingTestHarness{
+		t:               t,
+		ctx:             ctx,
+		cancel:          cancel,
+		roundStore:      roundStore,
+		vtxoStore:       vtxoStore,
+		wallet:          wallet,
+		env:             env,
+		clientPrivKey:   clientPrivKey,
+		clientPubKey:    clientPubKey,
+		operatorPrivKey: operatorPrivKey,
+		operatorPubKey:  operatorPubKey,
+		currentState:    &Idle{},
+		outboxMessages:  make([]ClientOutMsg, 0),
+	}
+
+	t.Cleanup(func() {
+		cancel()
+	})
+
+	return h
+}
+
+// withState sets the current state for the harness.
+func (h *boardingTestHarness) withState(
+	state ClientState) *boardingTestHarness {
+
+	h.currentState = state
+	return h
+}
+
+// sendEvent sends an event to the current state, captures the transition, and
+// updates internal state tracking for subsequent assertions.
+func (h *boardingTestHarness) sendEvent(
+	event ClientEvent) (*ClientStateTransition, error) {
+
+	h.t.Helper()
+
+	transition, err := h.currentState.ProcessEvent(h.ctx, event, h.env)
+	if err != nil {
+		return nil, err
+	}
+
+	h.lastTransition = transition
+
+	if transition != nil {
+		if nextState, ok := transition.NextState.(ClientState); ok {
+			h.currentState = nextState
+		}
+
+		transition.NewEvents.WhenSome(func(emitted ClientEmittedEvent) {
+			h.outboxMessages = append(
+				h.outboxMessages, emitted.Outbox...,
+			)
+		})
+	}
+
+	return transition, nil
+}
+
+// assertStateType asserts the current state is of the expected type and
+// returns it cast to that type.
+func assertStateType[T ClientState](h *boardingTestHarness) T {
+	h.t.Helper()
+
+	state, ok := h.currentState.(T)
+	require.True(h.t, ok, "current state is not of expected type")
+
+	return state
+}
+
+func (h *boardingTestHarness) newTestOutpoint() wire.OutPoint {
+	h.t.Helper()
+
+	var hash chainhash.Hash
+	_, err := rand.Read(hash[:])
+	require.NoError(h.t, err)
+
+	return wire.OutPoint{
+		Hash:  hash,
+		Index: 0,
+	}
+}
+
+func (h *boardingTestHarness) newTestBoardingAddress() wallet.BoardingAddress {
+	h.t.Helper()
+
+	return wallet.BoardingAddress{
+		KeyDesc: keychain.KeyDescriptor{
+			PubKey: h.clientPubKey,
+			KeyLocator: keychain.KeyLocator{
+				Family: keychain.KeyFamilyMultiSig,
+				Index:  0,
+			},
+		},
+		OperatorKey: h.operatorPubKey,
+		ExitDelay:   144, // ~1 day in blocks.
+	}
+}
+
+func (h *boardingTestHarness) newTestBoardingIntent() BoardingIntent {
+	h.t.Helper()
+
+	outpoint := h.newTestOutpoint()
+	address := h.newTestBoardingAddress()
+
+	pkScript, err := txscript.PayToTaprootScript(h.clientPubKey)
+	require.NoError(h.t, err)
+
+	signingKey := keychain.KeyDescriptor{
+		PubKey: h.clientPubKey,
+		KeyLocator: keychain.KeyLocator{
+			Family: keychain.KeyFamilyMultiSig,
+			Index:  0,
+		},
+	}
+
+	return BoardingIntent{
+		BoardingIntent: wallet.BoardingIntent{
+			Address:  address,
+			Outpoint: outpoint,
+			ChainInfo: wallet.BoardingChainInfo{
+				ConfHeight: 100,
+				OutPoint:   outpoint,
+				Amount:     btcutil.Amount(50000),
+			},
+			Status: wallet.BoardingStatusConfirmed,
+		},
+		BoardingRequest: types.BoardingRequest{
+			Outpoint:    &outpoint,
+			ClientKey:   h.clientPubKey,
+			OperatorKey: h.operatorPubKey,
+		},
+		VtxoTemplate: []types.VTXORequest{
+			{
+				Amount:      50000,
+				PkScript:    pkScript,
+				Expiry:      testExitDelay,
+				ClientKey:   h.clientPubKey,
+				OperatorKey: h.operatorPubKey,
+				SigningKey:  signingKey,
+			},
+		},
+	}
+}
+
+// newTestCommitmentTx creates a commitment transaction with the given inputs.
+// Uses version 3 for BIP 431 ephemeral anchor compatibility.
+func (h *boardingTestHarness) newTestCommitmentTx(
+	inputs []wire.OutPoint) *wire.MsgTx {
+
+	h.t.Helper()
+
+	tx := wire.NewMsgTx(3)
+
+	for _, input := range inputs {
+		tx.AddTxIn(&wire.TxIn{
+			PreviousOutPoint: input,
+		})
+	}
+
+	tx.AddTxOut(&wire.TxOut{
+		Value:    100000,
+		PkScript: make([]byte, 34),
+	})
+
+	tx.AddTxOut(&wire.TxOut{
+		Value:    0,
+		PkScript: []byte{txscript.OP_TRUE, txscript.OP_RETURN},
+	})
+
+	return tx
+}
+
+func generateTestKeyPair(t *testing.T) (*btcec.PrivateKey, *btcec.PublicKey) {
+	t.Helper()
+
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	return privKey, privKey.PubKey()
+}
+
+func (h *boardingTestHarness) newBoardingUTXOConfirmedEvent(
+	intent BoardingIntent) *BoardingUTXOConfirmed {
+
+	h.t.Helper()
+
+	tx := wire.NewMsgTx(2)
+	tx.AddTxOut(&wire.TxOut{
+		Value:    int64(intent.VtxoTemplate[0].Amount),
+		PkScript: intent.VtxoTemplate[0].PkScript,
+	})
+
+	var blockHash chainhash.Hash
+	_, err := rand.Read(blockHash[:])
+	require.NoError(h.t, err)
+
+	return &BoardingUTXOConfirmed{
+		Outpoint:      intent.Outpoint,
+		Address:       intent.Address,
+		BlockHeight:   intent.ChainInfo.ConfHeight,
+		BlockHash:     blockHash,
+		Confirmations: 6,
+		Tx:            tx,
+	}
+}
+
+const (
+	testExitDelay = uint32(144) // 1 day in blocks.
+)
+
+// newTestVTXOTree creates a minimal valid VTXT tree for testing by
+// delegating to lib/tree.NewTree() which handles all internal construction
+// including proper Taproot tweaking and node structure.
+func (h *boardingTestHarness) newTestVTXOTree(
+	numLeaves int) (*tree.Tree, []tree.LeafDescriptor) {
+
+	h.t.Helper()
+
+	const leafAmount = btcutil.Amount(50000)
+
+	leaves := make([]tree.LeafDescriptor, numLeaves)
+	for i := 0; i < numLeaves; i++ {
+		vtxoScript, err := txscript.PayToTaprootScript(h.clientPubKey)
+		require.NoError(h.t, err)
+
+		leaves[i] = tree.LeafDescriptor{
+			PkScript:    vtxoScript,
+			Amount:      leafAmount,
+			CoSignerKey: h.clientPubKey,
+		}
+	}
+
+	batchOutpoint := h.newTestOutpoint()
+
+	batchPkScript, err := txscript.PayToTaprootScript(h.operatorPubKey)
+	require.NoError(h.t, err)
+
+	// Batch output value must equal the sum of all leaf amounts.
+	batchOutput := &wire.TxOut{
+		Value:    int64(leafAmount) * int64(numLeaves),
+		PkScript: batchPkScript,
+	}
+
+	sweepRoot := sha256.Sum256([]byte("test-sweep-root"))
+
+	vtxtTree, err := tree.NewTree(
+		batchOutpoint, batchOutput, leaves,
+		h.operatorPubKey, sweepRoot[:], 2,
+	)
+	require.NoError(h.t, err)
+
+	return vtxtTree, leaves
+}
+
+// newTestVTXOTreeForIntent creates a VTXT tree configured for a specific
+// boarding intent, deriving leaves from the intent's VTXO template to ensure
+// amounts and keys match what the client expects to receive.
+func (h *boardingTestHarness) newTestVTXOTreeForIntent(
+	intent BoardingIntent) *tree.Tree {
+
+	h.t.Helper()
+
+	leaves := make([]tree.LeafDescriptor, len(intent.VtxoTemplate))
+	for i, vtxoReq := range intent.VtxoTemplate {
+		leaves[i] = tree.LeafDescriptor{
+			PkScript:    vtxoReq.PkScript,
+			Amount:      vtxoReq.Amount,
+			CoSignerKey: h.clientPubKey,
+		}
+	}
+
+	batchOutpoint := h.newTestOutpoint()
+
+	batchPkScript, err := txscript.PayToTaprootScript(h.operatorPubKey)
+	require.NoError(h.t, err)
+
+	batchOutput := &wire.TxOut{
+		Value:    int64(intent.ChainInfo.Amount),
+		PkScript: batchPkScript,
+	}
+
+	sweepRoot := sha256.Sum256([]byte("test-sweep-root"))
+
+	vtxtTree, err := tree.NewTree(
+		batchOutpoint, batchOutput, leaves,
+		h.operatorPubKey, sweepRoot[:], 2,
+	)
+	require.NoError(h.t, err)
+
+	return vtxtTree
+}
+
+// newCommitmentTxBuiltEvent creates a CommitmentTxBuilt event simulating what
+// the server sends after building the commitment transaction with all boarding
+// inputs and the batch VTXT tree output.
+func (h *boardingTestHarness) newCommitmentTxBuiltEvent(
+	roundID string,
+	intents []BoardingIntent,
+	vtxtTree *tree.Tree) *CommitmentTxBuilt {
+
+	h.t.Helper()
+
+	tx := wire.NewMsgTx(3)
+	for _, intent := range intents {
+		tx.AddTxIn(&wire.TxIn{
+			PreviousOutPoint: intent.Outpoint,
+		})
+	}
+
+	tx.AddTxOut(vtxtTree.BatchOutput)
+
+	tx.AddTxOut(&wire.TxOut{
+		Value:    0,
+		PkScript: []byte{txscript.OP_TRUE, txscript.OP_RETURN},
+	})
+
+	return &CommitmentTxBuilt{
+		CommitmentTxBuiltEvent: CommitmentTxBuiltEvent{
+			RoundID:  roundID,
+			Tx:       tx,
+			VTXTTree: vtxtTree,
+		},
+	}
+}
+
+// newNoncesAggregatedEvent creates aggregated nonces for all tree nodes,
+// simulating what the server sends after collecting and combining nonces from
+// all round participants for the MuSig2 signing protocol.
+func (h *boardingTestHarness) newNoncesAggregatedEvent(
+	roundID string, vtxtTree *tree.Tree) *NoncesAggregated {
+
+	h.t.Helper()
+
+	aggNonces := make(map[chainhash.Hash][]byte)
+	err := vtxtTree.Root.ForEach(func(node *tree.Node) error {
+		txid, err := node.TXID()
+		if err != nil {
+			return err
+		}
+
+		nonce := make([]byte, musig2.PubNonceSize)
+		_, err = rand.Read(nonce)
+		if err != nil {
+			return err
+		}
+
+		aggNonces[txid] = nonce
+
+		return nil
+	})
+	require.NoError(h.t, err)
+
+	return &NoncesAggregated{
+		NoncesAggregatedEvent: NoncesAggregatedEvent{
+			RoundID:          roundID,
+			AggregatedNonces: aggNonces,
+		},
+	}
+}
+
+// newOperatorSignedEvent creates operator signatures for the tree, simulating
+// what the server sends after combining all partial signatures into final
+// Schnorr signatures for each tree node.
+//
+//nolint:unused
+func (h *boardingTestHarness) newOperatorSignedEvent(
+	roundID string, vtxtTree *tree.Tree) *OperatorSigned {
+
+	h.t.Helper()
+
+	var txCount int
+	err := vtxtTree.Root.ForEach(func(_ *tree.Node) error {
+		txCount++
+		return nil
+	})
+	require.NoError(h.t, err)
+
+	sigs := make([][]byte, txCount)
+	for i := range sigs {
+		sigs[i] = make([]byte, schnorr.SignatureSize)
+		_, err := rand.Read(sigs[i])
+		require.NoError(h.t, err)
+	}
+
+	return &OperatorSigned{
+		OperatorSignedEvent: OperatorSignedEvent{
+			RoundID:    roundID,
+			Signatures: sigs,
+		},
+	}
+}
+
+// newCommitmentTxReceivedState creates a CommitmentTxReceivedState ready for
+// validation testing with a pre-built commitment transaction and VTXT tree.
+func (h *boardingTestHarness) newCommitmentTxReceivedState(
+	roundID string, intents []BoardingIntent) *CommitmentTxReceivedState {
+
+	h.t.Helper()
+
+	vtxtTree := h.newTestVTXOTreeForIntent(intents[0])
+	commitmentTx := h.newTestCommitmentTx(
+		extractOutpoints(intents),
+	)
+
+	return &CommitmentTxReceivedState{
+		RoundID:      roundID,
+		CommitmentTx: commitmentTx,
+		TxID:         commitmentTx.TxHash(),
+		VTXTTree:     vtxtTree,
+		Intents:      intents,
+		ClientTrees:  make(map[SignerKey]*tree.Tree),
+	}
+}
+
+// newCommitmentTxValidatedState creates a CommitmentTxValidatedState ready
+// for nonce generation, with boarding input indices pre-mapped for efficient
+// input signature placement during the signing phase.
+func (h *boardingTestHarness) newCommitmentTxValidatedState(
+	roundID string, intents []BoardingIntent) *CommitmentTxValidatedState {
+
+	h.t.Helper()
+
+	vtxtTree := h.newTestVTXOTreeForIntent(intents[0])
+	commitmentTx := h.newTestCommitmentTx(extractOutpoints(intents))
+
+	boardingInputIndices := make(map[wire.OutPoint]int)
+	for i, intent := range intents {
+		boardingInputIndices[intent.Outpoint] = i
+	}
+
+	return &CommitmentTxValidatedState{
+		RoundID:              roundID,
+		CommitmentTx:         commitmentTx,
+		VTXTTree:             vtxtTree,
+		Intents:              intents,
+		ClientTrees:          make(map[SignerKey]*tree.Tree),
+		BoardingInputIndices: boardingInputIndices,
+	}
+}
+
+func extractOutpoints(intents []BoardingIntent) []wire.OutPoint {
+	outpoints := make([]wire.OutPoint, len(intents))
+	for i, intent := range intents {
+		outpoints[i] = intent.Outpoint
+	}
+
+	return outpoints
+}
+
+// MockSignerSession is a mock implementation of tree.SignerSession for
+// testing error injection in the MuSig2 signing flow without requiring
+// real cryptographic operations.
+type MockSignerSession struct {
+	mock.Mock
+
+	pubKey *btcec.PublicKey
+}
+
+// NewMockSignerSession creates a new MockSignerSession with the given public
+// key.
+func NewMockSignerSession(pubKey *btcec.PublicKey) *MockSignerSession {
+	return &MockSignerSession{
+		pubKey: pubKey,
+	}
+}
+
+//nolint:forcetypeassert
+func (m *MockSignerSession) GetNonces() (
+	map[string]tree.Musig2PubNonce, error) {
+
+	args := m.Called()
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).(map[string]tree.Musig2PubNonce), args.Error(1)
+}
+
+func (m *MockSignerSession) RegisterNonces(
+	nonces map[string][]tree.Musig2PubNonce) error {
+
+	args := m.Called(nonces)
+	return args.Error(0)
+}
+
+//nolint:forcetypeassert
+func (m *MockSignerSession) Signatures(cleanup bool) (
+	map[string]*musig2.PartialSignature, error) {
+
+	args := m.Called(cleanup)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).(map[string]*musig2.PartialSignature), args.Error(1)
+}
+
+func (m *MockSignerSession) PubKey() *btcec.PublicKey {
+	return m.pubKey
+}
+
+//nolint:unused
+func (h *boardingTestHarness) newBoardingConfirmedEvent(
+	commitmentTx *wire.MsgTx, blockHeight int32) *BoardingConfirmed {
+
+	h.t.Helper()
+
+	return &BoardingConfirmed{
+		TxID:          commitmentTx.TxHash(),
+		BlockHeight:   blockHeight,
+		Confirmations: 6,
+	}
+}
+
+//nolint:unused
+func (h *boardingTestHarness) newBoardingFailedEvent(
+	reason string, recoverable bool) *BoardingFailed {
+
+	h.t.Helper()
+
+	return &BoardingFailed{
+		Reason:      reason,
+		Recoverable: recoverable,
+	}
+}
+
+// setupMockWalletForMuSig2 configures all MuSig2 mock methods needed for tree
+// signing flows: session creation, nonce registration (both individual and
+// combined), and partial signature generation.
+func (h *boardingTestHarness) setupMockWalletForMuSig2() {
+	h.t.Helper()
+
+	// Session creation mock.
+	var sessionID input.MuSig2SessionID
+	_, err := rand.Read(sessionID[:])
+	require.NoError(h.t, err)
+
+	var pubNonce [musig2.PubNonceSize]byte
+	_, err = rand.Read(pubNonce[:])
+	require.NoError(h.t, err)
+
+	sessionInfo := &input.MuSig2SessionInfo{
+		SessionID:   sessionID,
+		PublicNonce: pubNonce,
+		CombinedKey: h.clientPubKey,
+	}
+
+	h.wallet.On(
+		"MuSig2CreateSession", mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+	).Return(sessionInfo, nil)
+
+	// Nonce registration mocks (individual and combined/aggregated).
+	h.wallet.On(
+		"MuSig2RegisterNonces", mock.Anything, mock.Anything,
+	).Return(true, nil)
+
+	h.wallet.On(
+		"MuSig2RegisterCombinedNonce", mock.Anything, mock.Anything,
+	).Return(nil)
+
+	// Signing mock.
+	var scalarBytes [32]byte
+	_, err = rand.Read(scalarBytes[:])
+	require.NoError(h.t, err)
+
+	var scalar btcec.ModNScalar
+	scalar.SetBytes(&scalarBytes)
+
+	partialSig := &musig2.PartialSignature{
+		S: &scalar,
+	}
+
+	h.wallet.On(
+		"MuSig2Sign", mock.Anything, mock.Anything, mock.Anything,
+	).Return(partialSig, nil)
+}
+
+//nolint:unused
+func (h *boardingTestHarness) setupMockWalletForBoardingSigning() {
+	h.t.Helper()
+
+	sig := &schnorr.Signature{}
+
+	h.wallet.On("SignOutputRaw", mock.Anything, mock.Anything).Return(
+		sig, nil,
+	)
+}
+
+//nolint:unused
+func (h *boardingTestHarness) setupMockRoundStoreForCheckpoint() {
+	h.t.Helper()
+
+	h.roundStore.On(
+		"CommitState",
+		mock.Anything, // ctx
+		mock.Anything, // round
+		mock.Anything, // state
+	).Return(nil)
+}
+
+func (h *boardingTestHarness) setupMockVTXOStoreForSave() {
+	h.t.Helper()
+
+	h.vtxoStore.On(
+		"SaveVTXOs",
+		mock.Anything, // vtxos
+	).Return(nil)
+}
+
+//nolint:unused
+func (h *boardingTestHarness) newNoncesSentState(
+	roundID string, intents []BoardingIntent) *NoncesSentState {
+
+	h.t.Helper()
+
+	vtxtTree := h.newTestVTXOTreeForIntent(intents[0])
+	commitmentTx := h.newTestCommitmentTx(extractOutpoints(intents))
+
+	boardingInputIndices := make(map[wire.OutPoint]int)
+	for i, intent := range intents {
+		boardingInputIndices[intent.Outpoint] = i
+	}
+
+	musig2Sessions := make(map[SignerKey]*tree.SignerSession)
+
+	return &NoncesSentState{
+		RoundID:              roundID,
+		CommitmentTx:         commitmentTx,
+		VTXTTree:             vtxtTree,
+		Intents:              intents,
+		ClientTrees:          make(map[SignerKey]*tree.Tree),
+		Musig2Sessions:       musig2Sessions,
+		BoardingInputIndices: boardingInputIndices,
+	}
+}
+
+//nolint:unused
+func (h *boardingTestHarness) newNoncesAggregatedState(
+	roundID string, intents []BoardingIntent) *NoncesAggregatedState {
+
+	h.t.Helper()
+
+	vtxtTree := h.newTestVTXOTreeForIntent(intents[0])
+	commitmentTx := h.newTestCommitmentTx(extractOutpoints(intents))
+
+	boardingInputIndices := make(map[wire.OutPoint]int)
+	for i, intent := range intents {
+		boardingInputIndices[intent.Outpoint] = i
+	}
+
+	aggNonces := make(map[chainhash.Hash][]byte)
+	err := vtxtTree.Root.ForEach(func(node *tree.Node) error {
+		txid, err := node.TXID()
+		if err != nil {
+			return err
+		}
+
+		nonce := make([]byte, musig2.PubNonceSize)
+		_, err = rand.Read(nonce)
+		if err != nil {
+			return err
+		}
+
+		aggNonces[txid] = nonce
+
+		return nil
+	})
+	require.NoError(h.t, err)
+
+	return &NoncesAggregatedState{
+		RoundID:              roundID,
+		CommitmentTx:         commitmentTx,
+		VTXTTree:             vtxtTree,
+		Intents:              intents,
+		ClientTrees:          make(map[SignerKey]*tree.Tree),
+		Musig2Sessions:       make(map[SignerKey]*tree.SignerSession),
+		AggregatedNonces:     aggNonces,
+		BoardingInputIndices: boardingInputIndices,
+	}
+}
+
+//nolint:unused
+func (h *boardingTestHarness) newPartialSigsSentState(
+	roundID string, intents []BoardingIntent) *PartialSigsSentState {
+
+	h.t.Helper()
+
+	vtxtTree := h.newTestVTXOTreeForIntent(intents[0])
+	commitmentTx := h.newTestCommitmentTx(extractOutpoints(intents))
+
+	boardingInputIndices := make(map[wire.OutPoint]int)
+	for i, intent := range intents {
+		boardingInputIndices[intent.Outpoint] = i
+	}
+
+	return &PartialSigsSentState{
+		RoundID:              roundID,
+		CommitmentTx:         commitmentTx,
+		VTXTTree:             vtxtTree,
+		Intents:              intents,
+		ClientTrees:          make(map[SignerKey]*tree.Tree),
+		Musig2Sessions:       make(map[SignerKey]*tree.SignerSession),
+		BoardingInputIndices: boardingInputIndices,
+	}
+}
+
+func (h *boardingTestHarness) newInputSigSentState(
+	roundID string, intents []BoardingIntent) *InputSigSentState {
+
+	h.t.Helper()
+
+	vtxtTree := h.newTestVTXOTreeForIntent(intents[0])
+	commitmentTx := h.newTestCommitmentTx(extractOutpoints(intents))
+
+	inputSigs := make([][]byte, len(intents))
+	for i := range inputSigs {
+		inputSigs[i] = make([]byte, schnorr.SignatureSize)
+		_, err := rand.Read(inputSigs[i])
+		require.NoError(h.t, err)
+	}
+
+	clientTrees := make(map[SignerKey]*tree.Tree)
+	for _, intent := range intents {
+		for _, vtxoReq := range intent.VtxoTemplate {
+			signerKey := NewSignerKey(vtxoReq.SigningKey.PubKey)
+			clientTrees[signerKey] = vtxtTree
+		}
+	}
+
+	return &InputSigSentState{
+		RoundID:      roundID,
+		CommitmentTx: commitmentTx,
+		VTXTTree:     vtxtTree,
+		Intents:      intents,
+		ClientTrees:  clientTrees,
+		InputSigs:    inputSigs,
+	}
+}
+
+func (h *boardingTestHarness) assertOutboxContainsType(msgType string) {
+	h.t.Helper()
+
+	found := false
+	for _, msg := range h.outboxMessages {
+		typeName := fmt.Sprintf("%T", msg)
+		if typeName == msgType || typeName == "*round."+msgType {
+			found = true
+			break
+		}
+	}
+	require.True(
+		h.t, found, "outbox does not contain message of type %s",
+		msgType,
+	)
+}
+
+//nolint:unused
+func assertOutboxContains[T ClientEvent](h *boardingTestHarness) T {
+	h.t.Helper()
+
+	for _, msg := range h.outboxMessages {
+		if typed, ok := msg.(T); ok {
+			return typed
+		}
+	}
+
+	var zero T
+	h.t.Fatalf("outbox does not contain event of type %T", zero)
+
+	return zero
+}
+
+func (h *boardingTestHarness) assertOutboxLen(expected int) {
+	h.t.Helper()
+
+	require.Len(
+		h.t, h.outboxMessages, expected,
+		"outbox has %d messages, expected %d",
+		len(h.outboxMessages), expected,
+	)
+}
+
+func (h *boardingTestHarness) clearOutbox() {
+	h.outboxMessages = nil
+}
+
+// assertTransitionEmitsInternalEvent verifies the transition emitted an
+// internal event of the expected type, used for testing FSM event propagation.
+func assertTransitionEmitsInternalEvent[T ClientEvent](
+	h *boardingTestHarness, transition *ClientStateTransition) {
+
+	h.t.Helper()
+
+	require.True(
+		h.t, transition.NewEvents.IsSome(),
+		"transition should emit events",
+	)
+
+	var found bool
+	transition.NewEvents.WhenSome(func(emitted ClientEmittedEvent) {
+		for _, evt := range emitted.InternalEvent {
+			if _, ok := evt.(T); ok {
+				found = true
+				break
+			}
+		}
+	})
+
+	var zero T
+	require.True(
+		h.t, found, "transition does not emit internal event of "+
+			"type %T", zero,
+	)
+}
+
+// realMuSig2Signer provides real MuSig2 cryptographic operations for testing
+// instead of mocks, allowing tests to verify actual signature validity and
+// protocol correctness.
+type realMuSig2Signer struct {
+	privKey       *btcec.PrivateKey
+	sessions      map[input.MuSig2SessionID]*realSession
+	nextSessionID int
+}
+
+// realSession maintains cryptographic state for an active MuSig2 signing
+// session, tracking nonces and partial signatures until finalization.
+type realSession struct {
+	info           *input.MuSig2SessionInfo
+	nonces         *musig2.Nonces
+	musigSession   *musig2.Session
+	allNoncesKnown bool
+}
+
+func newRealMuSig2Signer(privKey *btcec.PrivateKey) *realMuSig2Signer {
+	return &realMuSig2Signer{
+		privKey:  privKey,
+		sessions: make(map[input.MuSig2SessionID]*realSession),
+	}
+}
+
+// MuSig2CreateSession creates a new MuSig2 session with real nonce generation.
+func (r *realMuSig2Signer) MuSig2CreateSession(
+	version input.MuSig2Version, keyLoc keychain.KeyLocator,
+	signers []*btcec.PublicKey, tweaks *input.MuSig2Tweaks,
+	otherNonces [][musig2.PubNonceSize]byte,
+	localNonces *musig2.Nonces) (*input.MuSig2SessionInfo, error) {
+
+	var nonces *musig2.Nonces
+	var err error
+	if localNonces != nil {
+		nonces = localNonces
+	} else {
+		nonces, err = musig2.GenNonces(
+			musig2.WithPublicKey(r.privKey.PubKey()),
+			musig2.WithNonceSecretKeyAux(r.privKey),
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var ctxOpts []musig2.ContextOption
+	ctxOpts = append(ctxOpts, musig2.WithKnownSigners(signers))
+
+	if tweaks != nil && len(tweaks.TaprootTweak) > 0 {
+		twkCtx := musig2.WithTaprootTweakCtx(tweaks.TaprootTweak)
+		ctxOpts = append(ctxOpts, twkCtx)
+	}
+
+	ctx, err := musig2.NewContext(r.privKey, true, ctxOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	musigSession, err := ctx.NewSession()
+	if err != nil {
+		return nil, err
+	}
+
+	sessionID := input.MuSig2SessionID{byte(r.nextSessionID)}
+	r.nextSessionID++
+
+	sess := &realSession{
+		info: &input.MuSig2SessionInfo{
+			SessionID:   sessionID,
+			PublicNonce: nonces.PubNonce,
+		},
+		nonces:       nonces,
+		musigSession: musigSession,
+	}
+
+	r.sessions[sessionID] = sess
+
+	return sess.info, nil
+}
+
+// MuSig2RegisterNonces registers nonces from other signers, accumulating them
+// until all participants have contributed their public nonces.
+func (r *realMuSig2Signer) MuSig2RegisterNonces(
+	sessionID input.MuSig2SessionID,
+	nonces [][musig2.PubNonceSize]byte) (bool, error) {
+
+	session, ok := r.sessions[sessionID]
+	if !ok {
+		return false, fmt.Errorf("session not found: %v", sessionID)
+	}
+
+	var haveAll bool
+	var err error
+	for _, nonce := range nonces {
+		haveAll, err = session.musigSession.RegisterPubNonce(nonce)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	session.allNoncesKnown = haveAll
+
+	return haveAll, nil
+}
+
+// MuSig2RegisterCombinedNonce registers a pre-aggregated combined nonce for
+// the session. This is an alternative to MuSig2RegisterNonces and is used
+// when a coordinator has already aggregated all individual nonces.
+func (r *realMuSig2Signer) MuSig2RegisterCombinedNonce(
+	sessionID input.MuSig2SessionID,
+	nonce [musig2.PubNonceSize]byte,
+) error {
+
+	session, ok := r.sessions[sessionID]
+	if !ok {
+		return fmt.Errorf("session not found: %v", sessionID)
+	}
+
+	// Register the combined nonce as if it's from all other participants.
+	haveAll, err := session.musigSession.RegisterPubNonce(nonce)
+	if err != nil {
+		return err
+	}
+
+	session.allNoncesKnown = haveAll
+
+	return nil
+}
+
+// MuSig2GetCombinedNonce retrieves the combined nonce for the session. This
+// will be available after all individual nonces have been registered or a
+// combined nonce has been registered.
+func (r *realMuSig2Signer) MuSig2GetCombinedNonce(
+	sessionID input.MuSig2SessionID,
+) ([musig2.PubNonceSize]byte, error) {
+
+	session, ok := r.sessions[sessionID]
+	if !ok {
+		return [musig2.PubNonceSize]byte{}, fmt.Errorf(
+			"session not found: %v", sessionID,
+		)
+	}
+
+	if !session.allNoncesKnown {
+		return [musig2.PubNonceSize]byte{}, fmt.Errorf(
+			"combined nonce not available: nonces not registered",
+		)
+	}
+
+	// The combined nonce is available after all nonces are registered.
+	// Return the session's public nonce as a proxy.
+	return session.nonces.PubNonce, nil
+}
+
+// MuSig2Sign creates a partial signature for the given message using
+// the session's secret nonce. Requires all participant nonces to be
+// registered first.
+func (r *realMuSig2Signer) MuSig2Sign(sessionID input.MuSig2SessionID,
+	msg [32]byte, cleanup bool) (*musig2.PartialSignature, error) {
+
+	session, ok := r.sessions[sessionID]
+	if !ok {
+		return nil, fmt.Errorf("session not found: %v", sessionID)
+	}
+
+	if !session.allNoncesKnown {
+		return nil, fmt.Errorf("not all nonces registered")
+	}
+
+	partialSig, err := session.musigSession.Sign(msg)
+	if err != nil {
+		return nil, err
+	}
+
+	return partialSig, nil
+}
+
+// MuSig2CombineSig combines all participants' partial signatures into a final
+// Schnorr signature that validates against the aggregate public key.
+func (r *realMuSig2Signer) MuSig2CombineSig(sessionID input.MuSig2SessionID,
+	partialSigs []*musig2.PartialSignature) (*schnorr.Signature, bool,
+	error) {
+
+	session, ok := r.sessions[sessionID]
+	if !ok {
+		return nil, false, fmt.Errorf(
+			"session not found: %v", sessionID,
+		)
+	}
+
+	var haveAll bool
+	for _, partialSig := range partialSigs {
+		var err error
+		haveAll, err = session.musigSession.CombineSig(partialSig)
+		if err != nil {
+			return nil, false, err
+		}
+	}
+
+	if !haveAll {
+		return nil, false, fmt.Errorf(
+			"not all partial signatures provided",
+		)
+	}
+
+	finalSig := session.musigSession.FinalSig()
+	if finalSig == nil {
+		return nil, false, fmt.Errorf("final signature is invalid")
+	}
+
+	return finalSig, true, nil
+}
+
+func (r *realMuSig2Signer) MuSig2Cleanup(
+	sessionID input.MuSig2SessionID) error {
+
+	delete(r.sessions, sessionID)
+	return nil
+}
+
+// Compile-time check that realMuSig2Signer implements input.MuSig2Signer.
+var _ input.MuSig2Signer = (*realMuSig2Signer)(nil)
+
+// realSigningTestHarness extends boardingTestHarness with real MuSig2
+// signers for both client and operator roles, enabling full end-to-end
+// signature testing.
+type realSigningTestHarness struct {
+	*boardingTestHarness
+
+	clientSigner   *realMuSig2Signer
+	operatorSigner *realMuSig2Signer
+}
+
+func newRealSigningTestHarness(t *testing.T) *realSigningTestHarness {
+	t.Helper()
+
+	base := newTestHarness(t)
+
+	return &realSigningTestHarness{
+		boardingTestHarness: base,
+		clientSigner:        newRealMuSig2Signer(base.clientPrivKey),
+		operatorSigner:      newRealMuSig2Signer(base.operatorPrivKey),
+	}
+}
+
+// setupMockWalletForBoardingSigning configures the wallet mock to return valid
+// Schnorr signatures for boarding inputs, using the client's real private key
+// to ensure signature correctness.
+func (h *realSigningTestHarness) setupMockWalletForBoardingSigning() {
+	h.t.Helper()
+
+	msgHash := sha256.Sum256([]byte("test-boarding-sig"))
+	sig, err := schnorr.Sign(h.clientPrivKey, msgHash[:])
+	require.NoError(h.t, err)
+
+	h.wallet.On("SignOutputRaw", mock.Anything, mock.Anything).Return(
+		sig, nil,
+	)
+}
+
+func (h *realSigningTestHarness) setupMockRoundStoreForCommit() {
+	h.t.Helper()
+
+	h.roundStore.On(
+		"CommitState", mock.Anything, mock.Anything, mock.Anything,
+	).Return(nil)
+}
+
+// newTestBoardingIntentWithTapscript creates a boarding intent with real
+// collaborative/unilateral spend paths for proper VTXO spending tests.
+//
+//nolint:ll
+func (h *realSigningTestHarness) newTestBoardingIntentWithTapscript() BoardingIntent {
+	h.t.Helper()
+
+	outpoint := h.newTestOutpoint()
+
+	// Create the VTXO tapscript with collaborative and timeout paths.
+	tapscript, err := scripts.VTXOTapScript(
+		h.clientPubKey, h.operatorPubKey, testExitDelay,
+	)
+	require.NoError(h.t, err)
+
+	// Derive the taproot output key from the tapscript.
+	taprootKey, err := tapscript.TaprootKey()
+	require.NoError(h.t, err)
+
+	// Create the bech32m address from the taproot key.
+	addr, err := btcutil.NewAddressTaproot(
+		schnorr.SerializePubKey(taprootKey), &chaincfg.MainNetParams,
+	)
+	require.NoError(h.t, err)
+
+	// Create signing key descriptor matching the boarding address.
+	signingKey := keychain.KeyDescriptor{
+		PubKey: h.clientPubKey,
+		KeyLocator: keychain.KeyLocator{
+			Family: keychain.KeyFamilyMultiSig,
+			Index:  0,
+		},
+	}
+
+	// Build the complete boarding address with Tapscript.
+	boardingAddr := wallet.BoardingAddress{
+		Address:     addr,
+		Tapscript:   tapscript,
+		KeyDesc:     signingKey,
+		OperatorKey: h.operatorPubKey,
+		ExitDelay:   testExitDelay,
+	}
+
+	// Create the P2TR pkScript for the VTXO template output.
+	pkScript, err := txscript.PayToTaprootScript(h.clientPubKey)
+	require.NoError(h.t, err)
+
+	return BoardingIntent{
+		BoardingIntent: wallet.BoardingIntent{
+			Address:  boardingAddr,
+			Outpoint: outpoint,
+			ChainInfo: wallet.BoardingChainInfo{
+				ConfHeight: 100,
+				OutPoint:   outpoint,
+				Amount:     btcutil.Amount(50000),
+			},
+			Status: wallet.BoardingStatusConfirmed,
+		},
+		BoardingRequest: types.BoardingRequest{
+			Outpoint:    &outpoint,
+			ClientKey:   h.clientPubKey,
+			OperatorKey: h.operatorPubKey,
+		},
+		VtxoTemplate: []types.VTXORequest{
+			{
+				Amount:      50000,
+				PkScript:    pkScript,
+				Expiry:      testExitDelay,
+				ClientKey:   h.clientPubKey,
+				OperatorKey: h.operatorPubKey,
+				SigningKey:  signingKey,
+			},
+		},
+	}
+}
+
+// newCommitmentTxForIntents builds a commitment TX with inputs from boarding
+// intents in the exact order needed for boardingInputIndices mapping.
+func (h *realSigningTestHarness) newCommitmentTxForIntents(
+	intents []BoardingIntent, vtxtTree *tree.Tree) *wire.MsgTx {
+
+	h.t.Helper()
+
+	tx := wire.NewMsgTx(3)
+
+	// Add inputs from intents in order.
+	for _, intent := range intents {
+		tx.AddTxIn(&wire.TxIn{
+			PreviousOutPoint: intent.Outpoint,
+		})
+	}
+
+	// Add batch output matching tree.
+	tx.AddTxOut(vtxtTree.BatchOutput)
+
+	// Add ephemeral anchor (BIP 431).
+	tx.AddTxOut(&wire.TxOut{
+		Value:    0,
+		PkScript: []byte{txscript.OP_TRUE, txscript.OP_RETURN},
+	})
+
+	return tx
+}
+
+// generateValidTreeSignatures creates valid Schnorr signatures for nodes.
+//
+// This is a simplified implementation for testing. In production, signatures
+// are generated by a coordinator (server) that combines client + operator
+// partials. For tests, we simulate this by:
+//
+// 1. Creating manual MuSig2 sessions for each tree node.
+// 2. Going through the full nonce exchange and signing protocol.
+// 3. Combining partials to produce final Schnorr signatures.
+func (h *realSigningTestHarness) generateValidTreeSignatures(
+	vtxtTree *tree.Tree) ([][]byte, error) {
+
+	h.t.Helper()
+
+	sweepRoot := vtxtTree.SweepTapscriptRoot
+
+	// Collect all nodes in ForEach order (this is the order
+	// ValidateVTXTSignatures expects signatures).
+	type nodeInfo struct {
+		txid    string
+		sigHash [32]byte
+	}
+	var nodes []nodeInfo
+
+	fetcher, err := vtxtTree.Root.PrevOutputFetcher(vtxtTree.BatchOutput)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to create prev output fetcher: %w", err,
+		)
+	}
+
+	err = vtxtTree.Root.ForEach(func(node *tree.Node) error {
+		tx, txErr := node.ToTx()
+		if txErr != nil {
+			return txErr
+		}
+
+		sigHash, sigErr := computeTreeNodeSigHash(node, tx, fetcher)
+		if sigErr != nil {
+			return sigErr
+		}
+
+		nodes = append(nodes, nodeInfo{
+			txid:    tx.TxHash().String(),
+			sigHash: sigHash,
+		})
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to collect node info: %w", err)
+	}
+
+	// Reset signers for fresh sessions.
+	h.clientSigner = newRealMuSig2Signer(h.clientPrivKey)
+	h.operatorSigner = newRealMuSig2Signer(h.operatorPrivKey)
+
+	// Process each node independently.
+	finalSigs := make([][]byte, len(nodes))
+	for i, ni := range nodes {
+		sig, sigErr := h.generateSignatureForNode(
+			ni.sigHash, sweepRoot,
+		)
+		if sigErr != nil {
+			return nil, fmt.Errorf("failed to sign node %s: %w",
+				ni.txid, sigErr)
+		}
+		finalSigs[i] = sig.Serialize()
+	}
+
+	return finalSigs, nil
+}
+
+// generateSignatureForNode creates a complete MuSig2 signature for a single
+// tree node by going through the full 2-party signing protocol.
+func (h *realSigningTestHarness) generateSignatureForNode(
+	sigHash [32]byte, sweepRoot []byte) (*schnorr.Signature, error) {
+
+	cosigners := []*btcec.PublicKey{h.clientPubKey, h.operatorPubKey}
+
+	// Generate nonces upfront for both parties.
+	clientNonces, err := musig2.GenNonces(
+		musig2.WithPublicKey(h.clientPrivKey.PubKey()),
+		musig2.WithNonceSecretKeyAux(h.clientPrivKey),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("client gen nonces: %w", err)
+	}
+
+	operatorNonces, err := musig2.GenNonces(
+		musig2.WithPublicKey(h.operatorPrivKey.PubKey()),
+		musig2.WithNonceSecretKeyAux(h.operatorPrivKey),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("operator gen nonces: %w", err)
+	}
+
+	// Create context options for both parties.
+	ctxOpts := []musig2.ContextOption{
+		musig2.WithKnownSigners(cosigners),
+	}
+	if len(sweepRoot) > 0 {
+		ctxOpts = append(ctxOpts, musig2.WithTaprootTweakCtx(sweepRoot))
+	}
+
+	// Create contexts for both parties.
+	clientCtx, err := musig2.NewContext(h.clientPrivKey, true, ctxOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("client context: %w", err)
+	}
+
+	operatorCtx, err := musig2.NewContext(
+		h.operatorPrivKey, true, ctxOpts...,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("operator context: %w", err)
+	}
+
+	// Create sessions with pre-generated nonces.
+	clientSession, err := clientCtx.NewSession(
+		musig2.WithPreGeneratedNonce(clientNonces),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("client session: %w", err)
+	}
+
+	operatorSession, err := operatorCtx.NewSession(
+		musig2.WithPreGeneratedNonce(operatorNonces),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("operator session: %w", err)
+	}
+
+	// Exchange and register nonces.
+	haveAll, err := clientSession.RegisterPubNonce(operatorNonces.PubNonce)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"client register operator nonce: %w", err,
+		)
+	}
+	if !haveAll {
+		return nil, fmt.Errorf(
+			"client missing nonces after registration",
+		)
+	}
+
+	haveAll, err = operatorSession.RegisterPubNonce(clientNonces.PubNonce)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"operator register client nonce: %w", err,
+		)
+	}
+	if !haveAll {
+		return nil, fmt.Errorf(
+			"operator missing nonces after registration",
+		)
+	}
+
+	// Both parties sign the same message.
+	clientPartial, err := clientSession.Sign(sigHash)
+	if err != nil {
+		return nil, fmt.Errorf("client sign: %w", err)
+	}
+
+	operatorPartial, err := operatorSession.Sign(sigHash)
+	if err != nil {
+		return nil, fmt.Errorf("operator sign: %w", err)
+	}
+
+	// Combine partial signatures on client side.
+	// After Sign(), the client's own partial is already combined.
+	haveAll, err = clientSession.CombineSig(operatorPartial)
+	if err != nil {
+		return nil, fmt.Errorf("combine operator partial: %w", err)
+	}
+	if !haveAll {
+		return nil, fmt.Errorf(
+			"incomplete after combining operator partial",
+		)
+	}
+
+	finalSig := clientSession.FinalSig()
+	if finalSig == nil {
+		// Try combining on operator side instead.
+		haveAll, err = operatorSession.CombineSig(clientPartial)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"combine client partial: %w", err,
+			)
+		}
+		if !haveAll {
+			return nil, fmt.Errorf(
+				"incomplete after combining client partial",
+			)
+		}
+		finalSig = operatorSession.FinalSig()
+	}
+
+	if finalSig == nil {
+		return nil, fmt.Errorf("final signature is invalid")
+	}
+
+	return finalSig, nil
+}
+
+// computeTreeNodeSigHash computes the Taproot signature hash for a tree node.
+func computeTreeNodeSigHash(node *tree.Node, tx *wire.MsgTx,
+	fetcher txscript.PrevOutputFetcher) ([32]byte, error) {
+
+	sigHashes := txscript.NewTxSigHashes(tx, fetcher)
+
+	hashBytes, err := txscript.CalcTaprootSignatureHash(
+		sigHashes, txscript.SigHashDefault, tx, 0, fetcher,
+	)
+	if err != nil {
+		return [32]byte{}, err
+	}
+
+	var result [32]byte
+	copy(result[:], hashBytes)
+
+	return result, nil
+}

--- a/round/interfaces.go
+++ b/round/interfaces.go
@@ -1,0 +1,274 @@
+package round
+
+import (
+	"context"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/baselib/protofsm"
+	"github.com/lightninglabs/darepo-client/lib/tree"
+	"github.com/lightninglabs/darepo-client/lib/types"
+	"github.com/lightninglabs/darepo-client/wallet"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/keychain"
+)
+
+// ClientStateTransition is a type alias for the verbose protofsm.StateTransition
+// type used throughout the client round FSM. The baselib protofsm uses 3
+// type parameters: InternalEvent, OutboxEvent, and Env. In our case:
+//   - InternalEvent = ClientEvent (events that drive the FSM).
+//   - OutboxEvent = ClientOutMsg (outbox messages emitted by transitions).
+//   - Env = *ClientEnvironment.
+//
+//nolint:ll
+type ClientStateTransition = protofsm.StateTransition[
+	ClientEvent, ClientOutMsg, *ClientEnvironment,
+]
+
+// ClientEmittedEvent is a type alias for the verbose protofsm.EmittedEvent type
+// used when state transitions emit new events or outbox messages.
+type ClientEmittedEvent = protofsm.EmittedEvent[ClientEvent, ClientOutMsg]
+
+// ClientStateMachine is a type alias for the client round FSM.
+type ClientStateMachine = protofsm.StateMachine[
+	ClientEvent, ClientOutMsg, *ClientEnvironment,
+]
+
+// ClientStateMachineCfg is a type alias for the client FSM configuration.
+type ClientStateMachineCfg = protofsm.StateMachineCfg[
+	ClientEvent, ClientOutMsg, *ClientEnvironment,
+]
+
+// Musig2PubNonce is an alias for the MuSig2 public nonce type from lib.
+type Musig2PubNonce = tree.Musig2PubNonce
+
+// RoundID is a type alias for round identifiers.
+type RoundID = string
+
+// SignerKey is the 33-byte compressed public key used to identify a signer
+// in MuSig2 sessions and client tree mappings.
+type SignerKey = [33]byte
+
+// NewSignerKey creates a SignerKey from a public key.
+func NewSignerKey(pk *btcec.PublicKey) SignerKey {
+	var key SignerKey
+	copy(key[:], pk.SerializeCompressed())
+	return key
+}
+
+// Type aliases for wallet types. The wallet package owns the canonical
+// definitions of boarding-related types. These aliases allow round package
+// code to use the types without import clutter.
+type (
+	// BoardingAddress is a type alias for wallet.BoardingAddress. The
+	// wallet package owns the canonical definition of boarding addresses
+	// including the tapscript, keys, and exit delay. The round package
+	// uses this type directly without extension.
+	BoardingAddress = wallet.BoardingAddress
+
+	// BoardingChainInfo tracks the chain related information for a given
+	// boarding intent.
+	BoardingChainInfo = wallet.BoardingChainInfo
+
+	// WalletBoardingIntent is the wallet's boarding intent type.
+	WalletBoardingIntent = wallet.BoardingIntent
+)
+
+// BoardingStatus type alias and constants from wallet package. The wallet
+// owns the lifecycle of boarding intents; round just reacts to confirmations.
+type BoardingStatus = wallet.BoardingStatus
+
+const (
+	// BoardingStatusConfirmed indicates that the boarding UTXO has reached
+	// the required number of confirmations and is ready to be included in a
+	// round registration.
+	BoardingStatusConfirmed = wallet.BoardingStatusConfirmed
+
+	// BoardingStatusAdopted indicates that the boarding intent has been
+	// included in a round that has been frozen/finalized on disk (round
+	// checkpoint saved). The intent can no longer be used in other rounds.
+	BoardingStatusAdopted = wallet.BoardingStatusAdopted
+
+	// BoardingStatusFailed indicates that the boarding process failed for
+	// this intent. This could be due to validation errors, server
+	// rejection, or timeout. Recovery may be possible via CSV timeout path.
+	BoardingStatusFailed = wallet.BoardingStatusFailed
+
+	// BoardingStatusExpired indicates that the boarding UTXO's CSV timeout
+	// has elapsed. The client can now spend via the unilateral timeout path
+	// to recover funds.
+	BoardingStatusExpired = wallet.BoardingStatusExpired
+
+	// BoardingStatusSwept indicates that the boarding UTXO has been spent
+	// via the CSV timeout path to recover funds.
+	BoardingStatusSwept = wallet.BoardingStatusSwept
+)
+
+// BoardingIntent captures one confirmed boarding input plus its requested VTXO
+// outputs. This type embeds the wallet's BoardingIntent and adds round-specific
+// fields for tracking VTXO templates and round assignment.
+type BoardingIntent struct {
+	// Embed wallet's BoardingIntent which contains the core boarding data:
+	// Address, Outpoint, ChainInfo, and Status.
+	wallet.BoardingIntent
+
+	// BoardingRequest is the original boarding request details. It targets
+	// a boarding address by outpoint and includes additional metadata.
+	BoardingRequest types.BoardingRequest
+
+	// VtxoTemplate is the template for the VTXO(s) requested as part of
+	// boarding.
+	//
+	// TODO(roasbeef): add auxleaf for tap here.
+	VtxoTemplate []types.VTXORequest
+
+	// RoundID is the identifier of the round this intent was assigned to.
+	// None until the client joins a round.
+	RoundID fn.Option[string]
+}
+
+// Round represents a complete Ark round from the client's perspective. A round
+// coordinates one or more actions (boarding, refresh, offboard) that are
+// batched together in a single commitment transaction.
+type Round struct {
+	// RoundID is the unique identifier assigned by the server when the
+	// client joins this round.
+	RoundID string
+
+	// CommitmentTx is the signed commitment transaction that anchors all
+	// VTXOs. None until the server constructs and broadcasts it.
+	CommitmentTx fn.Option[*wire.MsgTx]
+
+	// VTXTTree is the client's extracted sub-tree from the Virtual
+	// Transaction Tree. This contains only the minimal path needed to
+	// reach the client's VTXO leaves, not the full tree. This is ephemeral
+	// and only kept in memory during signing. After confirmation, only
+	// per-VTXO paths are persisted for unilateral exit.
+	VTXTTree fn.Option[*tree.Tree]
+
+	// BoardingGroup contains all boarding intents for this round.
+	BoardingGroup *BoardingGroup
+
+	// Future extensions:
+	// Refreshes []*RefreshGroup
+	// Offboards []*OffboardGroup
+}
+
+// BoardingGroup represents a set of boarding intents that are batched together
+// in a single round.
+type BoardingGroup struct {
+	// RoundID links this group to its parent round.
+	RoundID string
+
+	// Intents are all boarding intents participating in this round.
+	Intents []BoardingIntent
+}
+
+// RoundStore provides persistence for round FSM state. Follows the protofsm
+// StateMachineStore pattern where round data and FSM state are persisted
+// atomically to enable restart recovery.
+//
+// Rounds coordinate multiple boarding intents (and future: refreshes,
+// offboards) into a single commitment transaction.
+//
+// At the "point of no return" (after sending partial signatures), the
+// FSM state must be checkpointed to allow recovery if the server
+// broadcasts the commitment transaction.
+type RoundStore interface {
+	// CommitState atomically persists both the round data and FSM state.
+	// This should be called at the "point of no return" when the client
+	// has sent partial signatures and the server may broadcast.
+	//
+	// The round parameter contains the round data (commitment tx, intents,
+	// tree). The state parameter is the current FSM state. Both are
+	// persisted atomically so restart can recover to the exact state.
+	CommitState(ctx context.Context, round *Round, state ClientState) error
+
+	// FetchState retrieves a round and its FSM state by round ID. Returns
+	// (round, state, err). Both round data and FSM state are returned
+	// together to ensure consistency.
+	//
+	// Returns error if round doesn't exist.
+	FetchState(ctx context.Context, roundID string) (
+		*Round, ClientState, error,
+	)
+
+	// LookupRoundByCommitmentTx finds the round associated with a
+	// commitment transaction TXID. Used to route commitment tx
+	// confirmations to the correct round FSM.
+	LookupRoundByCommitmentTx(txid chainhash.Hash) (*Round, error)
+
+	// ListActiveRounds returns all rounds that are in progress (commitment
+	// tx broadcast but not yet confirmed or expired).
+	ListActiveRounds() ([]*Round, error)
+
+	// FinalizeRound marks a round as complete and archives it.
+	FinalizeRound(roundID string, txid chainhash.Hash) error
+}
+
+// ClientVTXO represents a Virtual UTXO owned by the client, including all
+// information needed to spend it either collaboratively (with operator) or
+// unilaterally (after timelock expires).
+type ClientVTXO struct {
+	// Outpoint identifies the VTXO's location in the virtual transaction
+	// tree.
+	Outpoint wire.OutPoint
+
+	// Amount is the value of this VTXO in satoshis.
+	Amount btcutil.Amount
+
+	// PkScript is the output script for this VTXO (taproot with
+	// collaborative and timeout spend paths).
+	PkScript []byte
+
+	// Expiry is the CSV delay for the unilateral exit path.
+	Expiry uint32
+
+	// ClientKey is the client's key descriptor for this VTXO.
+	ClientKey keychain.KeyDescriptor
+
+	// OperatorKey is the operator's public key for collaborative spends.
+	OperatorKey *btcec.PublicKey
+
+	// TreePath is the extracted path from the commitment transaction output
+	// down to this specific VTXO. Contains only the minimal tree nodes
+	// needed for unilateral exit (extracted via ExtractPathForCosigner).
+	TreePath *tree.Tree
+
+	// RoundID identifies which round created this VTXO. Empty if the VTXO
+	// is being used in a context where the round is not yet known (e.g.,
+	// during FSM state transitions before persistence).
+	RoundID fn.Option[RoundID]
+}
+
+// VTXOStore defines the storage interface for off-chain balance management.
+// VTXOs (Virtual Transaction Outputs) are created when rounds complete
+// successfully and represent the client's off-chain balance.
+type VTXOStore interface {
+	// SaveVTXOs persists one or more VTXOs after a round confirms. Each
+	// VTXO includes its extracted tree path for unilateral exit.
+	SaveVTXOs(vtxos []*ClientVTXO) error
+
+	// ListVTXOs returns all VTXOs currently owned by the client.
+	ListVTXOs() ([]*ClientVTXO, error)
+
+	// GetVTXO retrieves a specific VTXO by its outpoint. Returns an error
+	// if not found.
+	GetVTXO(outpoint wire.OutPoint) (*ClientVTXO, error)
+
+	// MarkVTXOSpent marks a VTXO as spent (either via OOR transaction or
+	// forfeit). This prevents double-spending.
+	MarkVTXOSpent(outpoint wire.OutPoint) error
+}
+
+// ClientWallet defines the interface for client wallet operations used by the
+// round actor. This provides MuSig2 signing capabilities needed for round
+// participation. Boarding address creation is handled by the wallet actor.
+type ClientWallet interface {
+	input.MuSig2Signer
+
+	input.Signer
+}

--- a/round/log.go
+++ b/round/log.go
@@ -1,0 +1,54 @@
+package round
+
+import (
+	"context"
+
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/baselib/protofsm"
+	"github.com/lightninglabs/darepo-client/build"
+)
+
+// Subsystem defines the logging code for this subsystem.
+const Subsystem = "ROND"
+
+// log is a logger that is initialized with no output filters. This means the
+// package will not perform any logging by default until the caller requests
+// it.
+var log = btclog.Disabled
+
+// DisableLog disables all library log output. Logging output is disabled by
+// default until UseLogger is called.
+func DisableLog() {
+	UseLogger(btclog.Disabled)
+}
+
+// UseLogger uses a specified Logger to output package logging info. This
+// should be used in preference to SetLogWriter if the caller is also using
+// btclog.
+func UseLogger(logger btclog.Logger) {
+	log = logger
+}
+
+// contextErrorReporter implements protofsm.ErrorReporter by logging errors
+// using a logger from the context with a specific prefix.
+//
+//nolint:containedctx
+type contextErrorReporter struct {
+	ctx    context.Context
+	prefix string
+}
+
+// newContextErrorReporter creates an error reporter that logs using the logger
+// from the given context with the specified prefix.
+func newContextErrorReporter(ctx context.Context, prefix string) *contextErrorReporter {
+	return &contextErrorReporter{ctx: ctx, prefix: prefix}
+}
+
+// ReportError logs the error using the context logger.
+func (r *contextErrorReporter) ReportError(err error) {
+	logger := build.LoggerFromContext(r.ctx).WithPrefix(r.prefix)
+	logger.Errorf("FSM error: %v", err)
+}
+
+// Compile-time check that contextErrorReporter implements ErrorReporter.
+var _ protofsm.ErrorReporter = (*contextErrorReporter)(nil)

--- a/round/outbox_messages.go
+++ b/round/outbox_messages.go
@@ -1,0 +1,193 @@
+package round
+
+import (
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/lib/types"
+	"google.golang.org/protobuf/proto"
+)
+
+// JoinRoundRequest is sent from client to server to request joining a round.
+// This implements ClientEvent and is emitted via Outbox.
+type JoinRoundRequest struct {
+	actor.BaseMessage
+
+	// BoardingRequests contains all boarding UTXO details for this
+	// session. Each confirmed intent contributes exactly one boarding
+	// request so the server can register them in a single batch.
+	BoardingRequests []types.BoardingRequest
+
+	// VTXORequests specifies the VTXOs the client wants to receive.
+	VTXORequests []types.VTXORequest
+
+	// RoundID is optional; when empty it instructs the server to assign
+	// a new round. When non-empty, the request is for the specified round.
+	RoundID string
+}
+
+func (m *JoinRoundRequest) clientOutMsgSealed() {}
+
+// SubmitNoncesRequest is sent from client to server with MuSig2 nonces.
+// This implements ClientOutMsg and is emitted via Outbox.
+type SubmitNoncesRequest struct {
+	actor.BaseMessage
+
+	// RoundID identifies the round.
+	RoundID string
+
+	// ParticipantKey identifies the participant.
+	ParticipantKey *btcec.PublicKey
+
+	// Nonces maps transaction IDs to their MuSig2 public nonces. Each
+	// entry corresponds to a transaction in the client's VTXT path that
+	// requires signing.
+	Nonces map[chainhash.Hash][]byte
+}
+
+func (m *SubmitNoncesRequest) clientOutMsgSealed() {}
+
+// SubmitPartialSigRequest is sent from client to server with partial
+// signatures. This implements ClientEvent and is emitted via Outbox.
+type SubmitPartialSigRequest struct {
+	actor.BaseMessage
+
+	// RoundID identifies the round.
+	RoundID string
+
+	// ParticipantKey identifies the participant.
+	ParticipantKey *btcec.PublicKey
+
+	// PartialSigs are the MuSig2 partial signatures for all transactions
+	// in the client's VTXT path.
+	PartialSigs [][]byte
+}
+
+func (m *SubmitPartialSigRequest) clientOutMsgSealed() {}
+
+// SubmitForfeitSigRequest is sent from client to server with the boarding input
+// signature. This implements ClientEvent and is emitted via Outbox.
+type SubmitForfeitSigRequest struct {
+	actor.BaseMessage
+
+	// RoundID identifies the round.
+	RoundID string
+
+	// ParticipantKey identifies the participant.
+	ParticipantKey *btcec.PublicKey
+
+	// ForfeitSigs contains the signature for the boarding UTXO input in the
+	// commitment transaction.
+	ForfeitSigs [][]byte
+}
+
+func (m *SubmitForfeitSigRequest) clientOutMsgSealed() {}
+
+// ToProto converts JoinRoundRequest to a protobuf message.
+// TODO: Implement actual proto conversion once proto definitions are available.
+func (m *JoinRoundRequest) ToProto() proto.Message {
+	// Placeholder: return nil for now. This will be replaced with actual
+	// proto message construction:
+	// return &pb.JoinRoundRequest{...}
+	return nil
+}
+
+// ToProto converts SubmitNoncesRequest to a protobuf message.
+// TODO: Implement actual proto conversion once proto definitions are available.
+func (m *SubmitNoncesRequest) ToProto() proto.Message {
+	// Placeholder: return nil for now. This will be replaced with actual
+	// proto message construction:
+	// return &pb.SubmitNoncesRequest{...}
+	return nil
+}
+
+// ToProto converts SubmitPartialSigRequest to a protobuf message.
+// TODO: Implement actual proto conversion once proto definitions are available.
+func (m *SubmitPartialSigRequest) ToProto() proto.Message {
+	// Placeholder: return nil for now. This will be replaced with actual
+	// proto message construction:
+	// return &pb.SubmitPartialSigRequest{...}
+	return nil
+}
+
+// ToProto converts SubmitForfeitSigRequest to a protobuf message.
+// TODO: Implement actual proto conversion once proto definitions are available.
+func (m *SubmitForfeitSigRequest) ToProto() proto.Message {
+	// Placeholder: return nil for now. This will be replaced with actual
+	// proto message construction:
+	// return &pb.SubmitForfeitSigRequest{...}
+	return nil
+}
+
+// RegisterConfirmationRequest is emitted by the FSM to request chain monitoring
+// for a transaction. The actor will complete this message with the NotifyActor
+// field before sending to ChainSource.
+//
+// This implements ClientEvent so it can be emitted via Outbox. The actor will
+// convert this to a chainsource.RegisterConfRequest and add the NotifyActor
+// field pointing to itself.
+type RegisterConfirmationRequest struct {
+	actor.BaseMessage
+
+	// CallerID is a unique identifier for this monitoring request. This is
+	// used by ChainSource to construct the service key for the dedicated
+	// confirmation actor.
+	CallerID string
+
+	// PkScript is the public key script to monitor.
+	PkScript []byte
+
+	// Txid is optional and, if set, instructs the monitoring backend to
+	// watch for confirmations of the specific transaction.
+	Txid *chainhash.Hash
+
+	// TargetConfs is the number of confirmations to wait for.
+	TargetConfs uint32
+
+	// HeightHint is an optional height hint indicating the earliest block
+	// that could contain the transaction. Set to 0 if unknown.
+	HeightHint uint32
+}
+
+func (m *RegisterConfirmationRequest) clientOutMsgSealed() {}
+
+// VTXOCreatedNotification notifies higher layers (wallet) that new VTXOs are
+// available after successful boarding. This is emitted once the commitment
+// transaction confirms and includes the full descriptors (with tree paths) so
+// the wallet can resume or unroll on-chain if needed.
+type VTXOCreatedNotification struct {
+	actor.BaseMessage
+
+	VTXOs []*ClientVTXO
+}
+
+func (m *VTXOCreatedNotification) clientOutMsgSealed() {}
+
+// RoundCompletedNotification is emitted when a round FSM reaches ConfirmedState
+// which signals the actor to perform cleanup (remove from activeRounds,
+// finalize storage). This replaces the need for manual state inspection via
+// checkRoundCompletion().
+type RoundCompletedNotification struct {
+	actor.BaseMessage
+
+	// RoundID identifies the completed round.
+	RoundID string
+
+	// TxID is the confirmed commitment transaction ID.
+	TxID chainhash.Hash
+}
+
+func (m *RoundCompletedNotification) clientOutMsgSealed() {}
+
+// RoundCheckpointedNotification is emitted by the primary FSM when it reaches
+// InputSigSentState. This signals that a round has been checkpointed to
+// storage and should be migrated to a dedicated round FSM. This replaces the
+// need for manual state inspection via checkPrimaryFSMForNewRound().
+type RoundCheckpointedNotification struct {
+	actor.BaseMessage
+
+	// RoundID identifies the checkpointed round to migrate.
+	RoundID string
+}
+
+func (m *RoundCheckpointedNotification) clientOutMsgSealed() {}

--- a/round/outbox_messages_test.go
+++ b/round/outbox_messages_test.go
@@ -1,0 +1,148 @@
+package round
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightninglabs/darepo-client/lib/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOutboxMessagesToProto ensures that ToProto() methods compile and return
+// the expected nil placeholders. These placeholders will be replaced with
+// actual proto marshaling once the proto definitions are finalized, but this
+// test prevents accidental breakage of the interface contract in the meantime.
+func TestOutboxMessagesToProto(t *testing.T) {
+	t.Parallel()
+
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	pubKey := privKey.PubKey()
+
+	t.Run("JoinRoundRequest_ToProto", func(t *testing.T) {
+		t.Parallel()
+
+		msg := &JoinRoundRequest{
+			BoardingRequests: []types.BoardingRequest{
+				{ClientKey: pubKey, OperatorKey: pubKey},
+			},
+			VTXORequests: []types.VTXORequest{},
+			RoundID:      "round-001",
+		}
+
+		result := msg.ToProto()
+		require.Nil(t, result)
+	})
+
+	t.Run("SubmitNoncesRequest_ToProto", func(t *testing.T) {
+		t.Parallel()
+
+		txid := chainhash.HashH([]byte("test-tx"))
+		msg := &SubmitNoncesRequest{
+			RoundID:        "round-001",
+			ParticipantKey: pubKey,
+			Nonces: map[chainhash.Hash][]byte{
+				txid: {0x01, 0x02},
+			},
+		}
+
+		result := msg.ToProto()
+		require.Nil(t, result)
+	})
+
+	t.Run("SubmitPartialSigRequest_ToProto", func(t *testing.T) {
+		t.Parallel()
+
+		msg := &SubmitPartialSigRequest{
+			RoundID:        "round-001",
+			ParticipantKey: pubKey,
+			PartialSigs:    [][]byte{{0x01, 0x02}},
+		}
+
+		result := msg.ToProto()
+		require.Nil(t, result)
+	})
+
+	t.Run("SubmitForfeitSigRequest_ToProto", func(t *testing.T) {
+		t.Parallel()
+
+		msg := &SubmitForfeitSigRequest{
+			RoundID:        "round-001",
+			ParticipantKey: pubKey,
+			ForfeitSigs:    [][]byte{{0xaa, 0xbb}},
+		}
+
+		result := msg.ToProto()
+		require.Nil(t, result)
+	})
+}
+
+// TestOutboxMessagesClientOutMsgSealed ensures that all outbox message types
+// implement the ClientOutMsg sealed interface. The clientOutMsgSealed() method
+// acts as a compile-time marker preventing external types from implementing
+// ClientOutMsg, so this test verifies the marker exists on all expected types.
+func TestOutboxMessagesClientOutMsgSealed(t *testing.T) {
+	t.Parallel()
+
+	txid := chainhash.HashH([]byte("test-txid"))
+
+	t.Run("JoinRoundRequest", func(t *testing.T) {
+		t.Parallel()
+		msg := &JoinRoundRequest{RoundID: "round-001"}
+		msg.clientOutMsgSealed()
+	})
+
+	t.Run("SubmitNoncesRequest", func(t *testing.T) {
+		t.Parallel()
+		msg := &SubmitNoncesRequest{RoundID: "round-001"}
+		msg.clientOutMsgSealed()
+	})
+
+	t.Run("SubmitPartialSigRequest", func(t *testing.T) {
+		t.Parallel()
+		msg := &SubmitPartialSigRequest{RoundID: "round-001"}
+		msg.clientOutMsgSealed()
+	})
+
+	t.Run("SubmitForfeitSigRequest", func(t *testing.T) {
+		t.Parallel()
+		msg := &SubmitForfeitSigRequest{RoundID: "round-001"}
+		msg.clientOutMsgSealed()
+	})
+
+	t.Run("RegisterConfirmationRequest", func(t *testing.T) {
+		t.Parallel()
+		msg := &RegisterConfirmationRequest{
+			CallerID:    "caller-001",
+			PkScript:    []byte{0x00, 0x14},
+			TargetConfs: 6,
+		}
+		msg.clientOutMsgSealed()
+	})
+
+	t.Run("VTXOCreatedNotification", func(t *testing.T) {
+		t.Parallel()
+		msg := &VTXOCreatedNotification{
+			VTXOs: []*ClientVTXO{},
+		}
+		msg.clientOutMsgSealed()
+	})
+
+	t.Run("RoundCompletedNotification", func(t *testing.T) {
+		t.Parallel()
+		msg := &RoundCompletedNotification{
+			RoundID: "round-001",
+			TxID:    txid,
+		}
+		msg.clientOutMsgSealed()
+	})
+
+	t.Run("RoundCheckpointedNotification", func(t *testing.T) {
+		t.Parallel()
+		msg := &RoundCheckpointedNotification{
+			RoundID: "round-001",
+		}
+		msg.clientOutMsgSealed()
+	})
+}

--- a/round/states.go
+++ b/round/states.go
@@ -1,0 +1,343 @@
+package round
+
+import (
+	"fmt"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/baselib/protofsm"
+	"github.com/lightninglabs/darepo-client/lib/tree"
+)
+
+// ClientState is a sealed interface for all states in the client round
+// interaction state machine. Each state implements ProcessEvent to handle
+// events and transition to the next state. This FSM handles the client's
+// participation in Ark rounds, including boarding, refresh, and offboard
+// operations.
+//
+// The baselib protofsm.State interface has 3 type parameters:
+//   - InternalEvent = ClientEvent.
+//   - OutboxEvent = ClientOutMsg.
+//   - Env = *ClientEnvironment.
+type ClientState interface {
+	protofsm.State[ClientEvent, ClientOutMsg, *ClientEnvironment]
+
+	// clientStateSealed is an unexported method that marks this interface
+	// as sealed, preventing external implementations.
+	clientStateSealed()
+}
+
+// Idle is the initial state. No active boarding process is running.
+type Idle struct{}
+
+func (s *Idle) String() string {
+	return "Idle"
+}
+
+func (s *Idle) IsTerminal() bool {
+	return false
+}
+
+func (s *Idle) clientStateSealed() {}
+
+// PendingRoundAssembly tracks all active boarding intents that have been
+// funded on-chain but not yet fully confirmed. Intents are keyed by their
+// on-chain outpoint for efficient lookup when confirmation events arrive. Once
+// all intents reach the required confirmations, the FSM transitions to round
+// registration.
+type PendingRoundAssembly struct {
+	// Intents maps outpoint to boarding intent. Only intents with on-chain
+	// UTXOs (i.e., ChainInfo.OutPoint set) are included in this map.
+	Intents map[wire.OutPoint]BoardingIntent
+}
+
+func (s *PendingRoundAssembly) String() string {
+	return "BoardingIntents"
+}
+
+func (s *PendingRoundAssembly) IsTerminal() bool {
+	return false
+}
+
+func (s *PendingRoundAssembly) clientStateSealed() {}
+
+// RegistrationSentState indicates the client has sent a JoinRoundRequest
+// to the server and is waiting for confirmation.
+type RegistrationSentState struct {
+	Intents []BoardingIntent
+}
+
+func (s *RegistrationSentState) String() string {
+	return "RegistrationSent"
+}
+
+func (s *RegistrationSentState) IsTerminal() bool {
+	return false
+}
+
+func (s *RegistrationSentState) clientStateSealed() {}
+
+// RoundJoinedState indicates the client has been accepted into a round and
+// is waiting for the commitment transaction.
+type RoundJoinedState struct {
+	RoundID string
+	Intents []BoardingIntent
+}
+
+func (s *RoundJoinedState) String() string {
+	return "RoundJoined"
+}
+
+func (s *RoundJoinedState) IsTerminal() bool {
+	return false
+}
+
+func (s *RoundJoinedState) clientStateSealed() {}
+
+// CommitmentTxReceivedState indicates the client has received the commitment
+// transaction and VTXT and must now validate them before proceeding.
+type CommitmentTxReceivedState struct {
+	RoundID string
+
+	CommitmentTx *wire.MsgTx
+
+	TxID chainhash.Hash
+
+	VTXTTree *tree.Tree
+
+	Intents []BoardingIntent
+
+	// ClientTrees maps signer keys (compressed pubkeys) to the client's
+	// extracted sub-tree for that VTXO.
+	ClientTrees map[SignerKey]*tree.Tree
+}
+
+func (s *CommitmentTxReceivedState) String() string {
+	return "CommitmentTxReceived"
+}
+
+func (s *CommitmentTxReceivedState) IsTerminal() bool {
+	return false
+}
+
+func (s *CommitmentTxReceivedState) clientStateSealed() {}
+
+// CommitmentTxValidatedState indicates the client has validated the VTXT
+// and is ready to participate in MuSig2 signing.
+type CommitmentTxValidatedState struct {
+	RoundID string
+
+	CommitmentTx *wire.MsgTx
+
+	VTXTTree *tree.Tree
+
+	Intents []BoardingIntent
+
+	// ClientTrees maps signer keys (compressed pubkeys) to the client's
+	// extracted sub-tree for that VTXO.
+	ClientTrees map[SignerKey]*tree.Tree
+
+	// BoardingInputIndices maps each boarding intent's outpoint to its
+	// position in the commitment transaction inputs. Used for signing.
+	BoardingInputIndices map[wire.OutPoint]int
+}
+
+func (s *CommitmentTxValidatedState) String() string {
+	return "CommitmentTxValidated"
+}
+
+func (s *CommitmentTxValidatedState) IsTerminal() bool {
+	return false
+}
+
+func (s *CommitmentTxValidatedState) clientStateSealed() {}
+
+// NoncesSentState indicates the client has sent nonces to the server and
+// is waiting for aggregated nonces.
+type NoncesSentState struct {
+	RoundID string
+
+	CommitmentTx *wire.MsgTx
+
+	VTXTTree *tree.Tree
+
+	Intents []BoardingIntent
+
+	// ClientTrees maps signer keys (compressed pubkeys) to the client's
+	// extracted sub-tree for that VTXO.
+	ClientTrees map[SignerKey]*tree.Tree
+
+	// Musig2Sessions maps signer keys (compressed pubkeys) to the MuSig2
+	// signing session for that VTXO.
+	Musig2Sessions map[SignerKey]*tree.SignerSession
+
+	// BoardingInputIndices maps each boarding intent's outpoint to its
+	// position in the commitment transaction inputs. Used for signing.
+	BoardingInputIndices map[wire.OutPoint]int
+}
+
+func (s *NoncesSentState) String() string {
+	return "NoncesSent"
+}
+
+func (s *NoncesSentState) IsTerminal() bool {
+	return false
+}
+
+func (s *NoncesSentState) clientStateSealed() {}
+
+// NoncesAggregatedState indicates the client has received aggregated nonces
+// and is ready to generate partial signatures.
+type NoncesAggregatedState struct {
+	RoundID string
+
+	CommitmentTx *wire.MsgTx
+
+	VTXTTree *tree.Tree
+
+	Intents []BoardingIntent
+
+	// ClientTrees maps signer keys (compressed pubkeys) to the client's
+	// extracted sub-tree for that VTXO.
+	ClientTrees map[SignerKey]*tree.Tree
+
+	// Musig2Sessions maps signer keys (compressed pubkeys) to the MuSig2
+	// signing session for that VTXO.
+	Musig2Sessions map[SignerKey]*tree.SignerSession
+
+	// AggregatedNonces maps transaction IDs to aggregated MuSig2 nonces.
+	AggregatedNonces map[chainhash.Hash][]byte
+
+	// BoardingInputIndices maps each boarding intent's outpoint to its
+	// position in the commitment transaction inputs. Used for signing.
+	BoardingInputIndices map[wire.OutPoint]int
+}
+
+func (s *NoncesAggregatedState) String() string {
+	return "NoncesAggregated"
+}
+
+func (s *NoncesAggregatedState) IsTerminal() bool {
+	return false
+}
+
+func (s *NoncesAggregatedState) clientStateSealed() {}
+
+// PartialSigsSentState indicates the client has sent partial signatures
+// to the server and is waiting for the complete VTXT signatures.
+type PartialSigsSentState struct {
+	RoundID string
+
+	CommitmentTx *wire.MsgTx
+
+	VTXTTree *tree.Tree
+
+	Intents []BoardingIntent
+
+	// ClientTrees maps signer keys (compressed pubkeys) to the client's
+	// extracted sub-tree for that VTXO.
+	ClientTrees map[SignerKey]*tree.Tree
+
+	PartialSigs [][]byte
+
+	// Musig2Sessions maps signer keys (compressed pubkeys) to the MuSig2
+	// signing session for that VTXO.
+	Musig2Sessions map[SignerKey]*tree.SignerSession
+
+	// BoardingInputIndices maps each boarding intent's outpoint to its
+	// position in the commitment transaction inputs. Used for signing.
+	BoardingInputIndices map[wire.OutPoint]int
+}
+
+func (s *PartialSigsSentState) String() string {
+	return "PartialSigsSent"
+}
+
+func (s *PartialSigsSentState) IsTerminal() bool {
+	return false
+}
+
+func (s *PartialSigsSentState) clientStateSealed() {}
+
+// InputSigSentState indicates the client has sent their boarding input
+// signature and is waiting for the commitment tx to be broadcast.
+type InputSigSentState struct {
+	RoundID string
+
+	CommitmentTx *wire.MsgTx
+
+	VTXTTree *tree.Tree
+
+	Intents []BoardingIntent
+
+	// ClientTrees maps signer keys (compressed pubkeys) to the client's
+	// extracted sub-tree for that VTXO.
+	ClientTrees map[SignerKey]*tree.Tree
+
+	InputSigs [][]byte
+}
+
+func (s *InputSigSentState) String() string {
+	return "InputSigSent"
+}
+
+func (s *InputSigSentState) IsTerminal() bool {
+	return false
+}
+
+func (s *InputSigSentState) clientStateSealed() {}
+
+// ConfirmedState is a terminal state indicating the boarding process has
+// completed successfully. The client now owns VTXOs.
+type ConfirmedState struct {
+	TxID          chainhash.Hash
+	BlockHeight   int32
+	Confirmations int32
+	VTXOs         []*ClientVTXO
+}
+
+func (s *ConfirmedState) String() string {
+	return "Confirmed"
+}
+
+func (s *ConfirmedState) IsTerminal() bool {
+	return true
+}
+
+func (s *ConfirmedState) clientStateSealed() {}
+
+// ClientFailedState is a terminal state indicating the boarding process failed.
+// The client may be able to retry or initiate CSV recovery.
+type ClientFailedState struct {
+	Reason      string
+	Error       error
+	Recoverable bool
+}
+
+func (s *ClientFailedState) String() string {
+	return fmt.Sprintf("ClientFailed: %s", s.Reason)
+}
+
+func (s *ClientFailedState) IsTerminal() bool {
+	return true
+}
+
+func (s *ClientFailedState) clientStateSealed() {}
+
+// RecoveryInitiatedState is a semi-terminal state where the client is
+// recovering their boarding UTXO via CSV timeout sweep.
+type RecoveryInitiatedState struct {
+	Outpoint  wire.OutPoint
+	SweepTxID chainhash.Hash
+	Reason    string
+}
+
+func (s *RecoveryInitiatedState) String() string {
+	return "RecoveryInitiated"
+}
+
+func (s *RecoveryInitiatedState) IsTerminal() bool {
+	return true
+}
+
+func (s *RecoveryInitiatedState) clientStateSealed() {}

--- a/round/transition_table.go
+++ b/round/transition_table.go
@@ -1,0 +1,280 @@
+package round
+
+import (
+	"github.com/lightninglabs/darepo-client/baselib/protofsm"
+)
+
+// ClientTransitionEntry is a type alias for the round FSM transition entry.
+type ClientTransitionEntry = protofsm.TransitionEntry[
+	ClientState, ClientEvent, ClientOutMsg,
+]
+
+// ClientStateTransitions is a type alias for the round FSM state transitions.
+type ClientStateTransitions = protofsm.StateTransitions[
+	ClientState, ClientEvent, ClientOutMsg,
+]
+
+// ClientTransitionTable is a type alias for the round FSM transition table.
+type ClientTransitionTable = protofsm.TransitionTable[
+	ClientState, ClientEvent, ClientOutMsg,
+]
+
+// BoardingClientTransitions defines all valid state transitions for the
+// client round interaction FSM. This serves as both documentation and a
+// validation target for tests.
+//
+//nolint:ll
+var BoardingClientTransitions = ClientTransitionTable{
+	MachineName: "BoardingClient",
+	States: []ClientStateTransitions{
+		// Idle: Initial state, waiting for boarding intents.
+		{
+			FromState: &Idle{},
+			Transitions: []ClientTransitionEntry{
+				{
+					Event:       &ResumeBoardingIntents{},
+					ToState:     &PendingRoundAssembly{},
+					Description: "Resume monitoring existing intents",
+				},
+				{
+					Event:       &BoardingUTXOConfirmed{},
+					ToState:     &PendingRoundAssembly{},
+					Description: "First UTXO confirmed, start assembly",
+				},
+				{
+					Event:       &BoardingFailed{},
+					ToState:     &ClientFailedState{},
+					Description: "Boarding failed before any progress",
+					IsTerminal:  true,
+				},
+			},
+		},
+
+		// PendingRoundAssembly: Collecting confirmed boarding intents.
+		{
+			FromState: &PendingRoundAssembly{},
+			Transitions: []ClientTransitionEntry{
+				{
+					Event:       &BoardingUTXOConfirmed{},
+					ToState:     &PendingRoundAssembly{},
+					Description: "Additional boarding UTXO confirmed",
+				},
+				{
+					Event:       &RegistrationRequested{},
+					ToState:     &RegistrationSentState{},
+					Description: "Intents confirmed, register with server",
+					EmitsOutbox: []ClientOutMsg{&JoinRoundRequest{}},
+				},
+				{
+					Event:       &BoardingFailed{},
+					ToState:     &ClientFailedState{},
+					Description: "Boarding failed during assembly",
+					IsTerminal:  true,
+				},
+			},
+		},
+
+		// RegistrationSentState: Waiting for server acceptance.
+		{
+			FromState: &RegistrationSentState{},
+			Transitions: []ClientTransitionEntry{
+				{
+					Event:       &RoundJoined{},
+					ToState:     &RoundJoinedState{},
+					Description: "Server accepted registration",
+				},
+				{
+					Event:       &BoardingFailed{},
+					ToState:     &ClientFailedState{},
+					Description: "Server rejected registration",
+					IsTerminal:  true,
+				},
+			},
+		},
+
+		// RoundJoinedState: Waiting for commitment tx from server.
+		{
+			FromState: &RoundJoinedState{},
+			Transitions: []ClientTransitionEntry{
+				{
+					Event:       &CommitmentTxBuilt{},
+					ToState:     &CommitmentTxReceivedState{},
+					Description: "Received commitment tx and VTXT",
+				},
+				{
+					Event:       &BoardingFailed{},
+					ToState:     &ClientFailedState{},
+					Description: "Round failed waiting for commitment",
+					IsTerminal:  true,
+				},
+			},
+		},
+
+		// CommitmentTxReceivedState: Validating commitment tx and VTXT.
+		{
+			FromState: &CommitmentTxReceivedState{},
+			Transitions: []ClientTransitionEntry{
+				{
+					Event:       &CommitmentTxValidated{},
+					ToState:     &CommitmentTxValidatedState{},
+					Description: "Commitment tx and VTXT validated",
+				},
+				{
+					Event:       &BoardingFailed{},
+					ToState:     &ClientFailedState{},
+					Description: "Validation failed",
+					IsTerminal:  true,
+				},
+			},
+		},
+
+		// CommitmentTxValidatedState: Generate and send nonces.
+		{
+			FromState: &CommitmentTxValidatedState{},
+			Transitions: []ClientTransitionEntry{
+				{
+					Event:       &GenerateNonces{},
+					ToState:     &NoncesSentState{},
+					Description: "Generated nonces, sending to server",
+					EmitsOutbox: []ClientOutMsg{
+						&SubmitNoncesRequest{},
+					},
+				},
+				{
+					Event:       &BoardingFailed{},
+					ToState:     &ClientFailedState{},
+					Description: "Nonce generation failed",
+					IsTerminal:  true,
+				},
+			},
+		},
+
+		// NoncesSentState: Waiting for aggregated nonces from server.
+		{
+			FromState: &NoncesSentState{},
+			Transitions: []ClientTransitionEntry{
+				{
+					Event:       &NoncesAggregated{},
+					ToState:     &NoncesAggregatedState{},
+					Description: "Received aggregated nonces",
+				},
+				{
+					Event:       &BoardingFailed{},
+					ToState:     &ClientFailedState{},
+					Description: "Nonce aggregation failed",
+					IsTerminal:  true,
+				},
+			},
+		},
+
+		// NoncesAggregatedState: Generate and send partial signatures.
+		{
+			FromState: &NoncesAggregatedState{},
+			Transitions: []ClientTransitionEntry{
+				{
+					Event:       &GeneratePartialSigs{},
+					ToState:     &PartialSigsSentState{},
+					Description: "Generated partial sigs, sending",
+					EmitsOutbox: []ClientOutMsg{
+						&SubmitPartialSigRequest{},
+					},
+				},
+				{
+					Event:       &BoardingFailed{},
+					ToState:     &ClientFailedState{},
+					Description: "Partial signature generation failed",
+					IsTerminal:  true,
+				},
+			},
+		},
+
+		// PartialSigsSentState: Waiting for operator to sign.
+		{
+			FromState: &PartialSigsSentState{},
+			Transitions: []ClientTransitionEntry{
+				{
+					Event:       &OperatorSigned{},
+					ToState:     &InputSigSentState{},
+					Description: "Received VTXT sigs, sending input sig",
+					EmitsOutbox: []ClientOutMsg{
+						&SubmitForfeitSigRequest{},
+					},
+				},
+				{
+					Event:       &BoardingFailed{},
+					ToState:     &ClientFailedState{},
+					Description: "Operator signing failed",
+					IsTerminal:  true,
+				},
+			},
+		},
+
+		// InputSigSentState: Waiting for commitment tx confirmation.
+		{
+			FromState: &InputSigSentState{},
+			Transitions: []ClientTransitionEntry{
+				{
+					Event:       &BoardingConfirmed{},
+					ToState:     &ConfirmedState{},
+					Description: "Commitment tx confirmed, complete",
+					EmitsOutbox: []ClientOutMsg{
+						&VTXOCreatedNotification{},
+						&RoundCompletedNotification{},
+					},
+					IsTerminal: true,
+				},
+				{
+					Event:       &BoardingFailed{},
+					ToState:     &ClientFailedState{},
+					Description: "Commitment tx failed to confirm",
+					IsTerminal:  true,
+				},
+				{
+					Event:       &RecoveryInitiated{},
+					ToState:     &RecoveryInitiatedState{},
+					Description: "CSV timeout, recovering funds",
+					IsTerminal:  true,
+				},
+			},
+		},
+
+		// ConfirmedState: Terminal success state.
+		{
+			FromState: &ConfirmedState{},
+			Transitions: []ClientTransitionEntry{
+				{
+					Event:       &RoundComplete{},
+					ToState:     &ConfirmedState{},
+					Description: "Self-loop, round already complete",
+					IsTerminal:  true,
+				},
+			},
+		},
+
+		// ClientFailedState: Terminal failure state.
+		{
+			FromState: &ClientFailedState{},
+			Transitions: []ClientTransitionEntry{
+				{
+					Event:       &BoardingFailed{},
+					ToState:     &ClientFailedState{},
+					Description: "Self-loop, already failed",
+					IsTerminal:  true,
+				},
+			},
+		},
+
+		// RecoveryInitiatedState: Terminal recovery state.
+		{
+			FromState: &RecoveryInitiatedState{},
+			Transitions: []ClientTransitionEntry{
+				{
+					Event:       &RecoveryInitiated{},
+					ToState:     &RecoveryInitiatedState{},
+					Description: "Self-loop, recovery in progress",
+					IsTerminal:  true,
+				},
+			},
+		},
+	},
+}

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -1,0 +1,1093 @@
+package round
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/scripts"
+	"github.com/lightninglabs/darepo-client/lib/tree"
+	"github.com/lightninglabs/darepo-client/lib/types"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+)
+
+// buildBoardingRequest constructs a types.BoardingRequest from a
+// BoardingIntent. This pulls together the outpoint, keys, and exit delay from
+// the embedded wallet intent and address, along with the TxProof from
+// ChainInfo if present.
+func buildBoardingRequest(intent BoardingIntent) types.BoardingRequest {
+	addr := intent.Address
+
+	return types.BoardingRequest{
+		Outpoint:    &intent.Outpoint,
+		ClientKey:   addr.KeyDesc.PubKey,
+		OperatorKey: addr.OperatorKey,
+		ExitDelay:   addr.ExitDelay,
+		TxProof:     intent.ChainInfo.TxProof,
+	}
+}
+
+// ProcessEvent handles the events from the Idle state. In this state, we'll
+// receive boarding UTXO confirmations or resume existing boarding flows.
+func (s *Idle) ProcessEvent(_ context.Context, event ClientEvent,
+	env *ClientEnvironment) (*ClientStateTransition, error) {
+
+	switch evt := event.(type) {
+	case *ResumeBoardingIntents:
+		// If for some reason, there aren't any new intents, then we'll
+		// stay in the idle state.
+		if len(evt.Intents) == 0 {
+			return &ClientStateTransition{
+				NextState: s,
+			}, nil
+		}
+
+		// Otherwise, we'll start to assemble a round with the resumed
+		// intents.
+		return &ClientStateTransition{
+			NextState: &PendingRoundAssembly{
+				Intents: evt.Intents,
+			},
+		}, nil
+
+	case *BoardingUTXOConfirmed:
+		// A boarding UTXO was confirmed. The wallet has already
+		// persisted the intent; we just need to create an internal
+		// BoardingIntent and transition to PendingRoundAssembly.
+		if evt.Tx == nil {
+			return nil, fmt.Errorf("confirmation event " +
+				"missing transaction")
+		}
+
+		// Extract the confirmed output value.
+		if int(evt.Outpoint.Index) >= len(evt.Tx.TxOut) {
+			return nil, fmt.Errorf("invalid outpoint index %d for "+
+				"tx %s", evt.Outpoint.Index, evt.Outpoint.Hash)
+		}
+		confirmedOutput := evt.Tx.TxOut[evt.Outpoint.Index]
+
+		// Create the chain info from the confirmation event, including
+		// the TxProof for SPV verification.
+		chainInfo := BoardingChainInfo{
+			ConfHeight: evt.BlockHeight,
+			ConfHash:   evt.BlockHash,
+			ConfTx:     evt.Tx,
+			OutPoint:   evt.Outpoint,
+			Amount:     btcutil.Amount(confirmedOutput.Value),
+			TxProof:    evt.TxProof,
+		}
+
+		// Create a wallet intent with the full address from the event.
+		walletIntent := WalletBoardingIntent{
+			Address:   evt.Address,
+			Outpoint:  evt.Outpoint,
+			ChainInfo: chainInfo,
+			Status:    BoardingStatusConfirmed,
+		}
+
+		// Build the boarding request from the address.
+		boardingRequest := types.BoardingRequest{
+			Outpoint:    &evt.Outpoint,
+			ClientKey:   evt.Address.KeyDesc.PubKey,
+			OperatorKey: evt.Address.OperatorKey,
+		}
+
+		// Build the VTXO template from the boarding address info. The
+		// client wants a single VTXO with the full confirmed amount.
+		vtxoTemplate := []types.VTXORequest{
+			{
+				Amount: btcutil.Amount(
+					confirmedOutput.Value,
+				),
+				PkScript:    confirmedOutput.PkScript,
+				ClientKey:   evt.Address.KeyDesc.PubKey,
+				OperatorKey: evt.Address.OperatorKey,
+				Expiry:      evt.Address.ExitDelay,
+				SigningKey:  evt.Address.KeyDesc,
+			},
+		}
+
+		// Create the round's BoardingIntent.
+		intent := BoardingIntent{
+			BoardingIntent:  walletIntent,
+			BoardingRequest: boardingRequest,
+			VtxoTemplate:    vtxoTemplate,
+			RoundID:         fn.None[string](),
+		}
+
+		intentMap := make(map[wire.OutPoint]BoardingIntent)
+		intentMap[evt.Outpoint] = intent
+
+		return &ClientStateTransition{
+			NextState: &PendingRoundAssembly{
+				Intents: intentMap,
+			},
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("idle: unexpected event: %T", event)
+	}
+}
+
+// ProcessEvent for PendingRoundAssembly tracks confirmed boarding intents and
+// transitions to registration once all are ready.
+func (s *PendingRoundAssembly) ProcessEvent(
+	_ context.Context, event ClientEvent, env *ClientEnvironment,
+) (*ClientStateTransition, error) {
+
+	switch evt := event.(type) {
+	// A new boarding UTXO was confirmed. The wallet handles persistence;
+	// we just add to our internal map.
+	case *BoardingUTXOConfirmed:
+		if evt.Tx == nil {
+			return nil, fmt.Errorf("confirmation event missing " +
+				"transaction")
+		}
+
+		// Extract the confirmed output value.
+		if int(evt.Outpoint.Index) >= len(evt.Tx.TxOut) {
+			return nil, fmt.Errorf("invalid outpoint index %d for "+
+				"tx %s", evt.Outpoint.Index, evt.Outpoint.Hash)
+		}
+		confirmedOutput := evt.Tx.TxOut[evt.Outpoint.Index]
+
+		// Create the chain info from the confirmation event, including
+		// the TxProof for SPV verification.
+		chainInfo := BoardingChainInfo{
+			ConfHeight: evt.BlockHeight,
+			ConfHash:   evt.BlockHash,
+			ConfTx:     evt.Tx,
+			OutPoint:   evt.Outpoint,
+			Amount:     btcutil.Amount(confirmedOutput.Value),
+			TxProof:    evt.TxProof,
+		}
+
+		// Create a wallet intent with the full address from the event.
+		walletIntent := WalletBoardingIntent{
+			Address:   evt.Address,
+			Outpoint:  evt.Outpoint,
+			ChainInfo: chainInfo,
+			Status:    BoardingStatusConfirmed,
+		}
+
+		// Build the boarding request from the address.
+		boardingRequest := types.BoardingRequest{
+			Outpoint:    &evt.Outpoint,
+			ClientKey:   evt.Address.KeyDesc.PubKey,
+			OperatorKey: evt.Address.OperatorKey,
+		}
+
+		// Build the VTXO template from the boarding address info. The
+		// client wants a single VTXO with the full confirmed amount.
+		vtxoTemplate := []types.VTXORequest{
+			{
+				Amount: btcutil.Amount(
+					confirmedOutput.Value,
+				),
+				PkScript:    confirmedOutput.PkScript,
+				ClientKey:   evt.Address.KeyDesc.PubKey,
+				OperatorKey: evt.Address.OperatorKey,
+				Expiry:      evt.Address.ExitDelay,
+				SigningKey:  evt.Address.KeyDesc,
+			},
+		}
+
+		intent := BoardingIntent{
+			BoardingIntent:  walletIntent,
+			BoardingRequest: boardingRequest,
+			VtxoTemplate:    vtxoTemplate,
+			RoundID:         fn.None[string](),
+		}
+
+		// Add the newly confirmed intent to our map.
+		updatedIntents := maps.Clone(s.Intents)
+		updatedIntents[evt.Outpoint] = intent
+
+		return &ClientStateTransition{
+			NextState: &PendingRoundAssembly{
+				Intents: updatedIntents,
+			},
+		}, nil
+
+	// It's time to register our confirmed boarding UTXOs for the next
+	// round. We'll send a message to the server using our outbox, then
+	// transition to the next phase.
+	case *RegistrationRequested:
+		// Extract the set of values from the intent map, as we don't
+		// need to track them by outpoint any longer.
+		//
+		intentSlice := slices.Collect(maps.Values(s.Intents))
+		boardingReqs := fn.Map(intentSlice, buildBoardingRequest)
+		if len(boardingReqs) == 0 {
+			return nil, fmt.Errorf("no boarding requests " +
+				"to register")
+		}
+
+		// Next, we'll extract all the VTXO templates from the set of
+		// nested intents.
+		vtxoReqLists := fn.Map(
+			intentSlice,
+			func(intent BoardingIntent) []types.VTXORequest {
+				return intent.VtxoTemplate
+			},
+		)
+		vtxoReqs := fn.Flatten(vtxoReqLists)
+		if len(vtxoReqs) == 0 {
+			return nil, fmt.Errorf("no VTXO requests to register")
+		}
+
+		// With all this extract, we'll now send the JoinRoundRequest
+		// to kick off the singing process.
+		return &ClientStateTransition{
+			NextState: &RegistrationSentState{
+				Intents: intentSlice,
+			},
+			NewEvents: fn.Some(ClientEmittedEvent{
+				Outbox: []ClientOutMsg{
+					&JoinRoundRequest{
+						BoardingRequests: boardingReqs,
+						VTXORequests:     vtxoReqs,
+						RoundID:          evt.RoundID,
+					},
+				},
+			}),
+		}, nil
+
+	case *BoardingFailed:
+		return &ClientStateTransition{
+			NextState: &ClientFailedState{
+				Reason:      evt.Reason,
+				Error:       evt.Error,
+				Recoverable: evt.Recoverable,
+			},
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("pending_round_assembly: "+
+			"unexpected event: %T", event)
+	}
+}
+
+// ProcessEvent for RegistrationSentState.
+func (s *RegistrationSentState) ProcessEvent(
+	_ context.Context, event ClientEvent, env *ClientEnvironment,
+) (*ClientStateTransition, error) {
+
+	switch evt := event.(type) {
+	case *RoundJoined:
+		return &ClientStateTransition{
+			NextState: &RoundJoinedState{
+				RoundID: evt.RoundID,
+				Intents: slices.Clone(s.Intents),
+			},
+		}, nil
+
+	case *BoardingFailed:
+		// Server rejected the registration or the request timed out.
+		// Transition to failure state.
+		return &ClientStateTransition{
+			NextState: &ClientFailedState{
+				Reason:      evt.Reason,
+				Error:       evt.Error,
+				Recoverable: evt.Recoverable,
+			},
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("registration_sent: unexpected "+
+			"event: %T", event)
+	}
+}
+
+// ProcessEvent for RoundJoinedState.
+func (s *RoundJoinedState) ProcessEvent(
+	_ context.Context, event ClientEvent, env *ClientEnvironment,
+) (*ClientStateTransition, error) {
+
+	switch evt := event.(type) {
+	case *CommitmentTxBuilt:
+		return &ClientStateTransition{
+			NextState: &CommitmentTxReceivedState{
+				RoundID:      evt.RoundID,
+				CommitmentTx: evt.Tx,
+				TxID:         evt.Tx.TxHash(),
+				VTXTTree:     evt.VTXTTree,
+				Intents:      slices.Clone(s.Intents),
+				ClientTrees:  make(map[SignerKey]*tree.Tree),
+			},
+			NewEvents: fn.Some(ClientEmittedEvent{
+				InternalEvent: []ClientEvent{
+					&CommitmentTxBuilt{
+						CommitmentTxBuiltEvent: evt.
+							CommitmentTxBuiltEvent,
+					},
+				},
+			}),
+		}, nil
+
+	case *BoardingFailed:
+		return &ClientStateTransition{
+			NextState: &ClientFailedState{
+				Reason:      evt.Reason,
+				Error:       evt.Error,
+				Recoverable: evt.Recoverable,
+			},
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("round_joined: unexpected event: "+
+			"%T", event)
+	}
+}
+
+// validateBoardingInputs checks that all boarding UTXOs are present in the
+// commitment transaction and returns a map of outpoint to input index.
+func validateBoardingInputs(commitmentTx *wire.MsgTx,
+	intents []BoardingIntent) (map[wire.OutPoint]int, error) {
+
+	if commitmentTx == nil {
+		return nil, fmt.Errorf("commitment tx is nil")
+	}
+	if len(intents) == 0 {
+		return nil, fmt.Errorf("no boarding intents to validate")
+	}
+
+	// Build map of outpoint to input index.
+	outpointToIdx := make(map[wire.OutPoint]int)
+	for i, txIn := range commitmentTx.TxIn {
+		outpointToIdx[txIn.PreviousOutPoint] = i
+	}
+
+	// Validate all intent outpoints are present in the commitment tx.
+	for _, intent := range intents {
+		outpoint := intent.BoardingRequest.Outpoint
+		if _, found := outpointToIdx[*outpoint]; !found {
+			return nil, fmt.Errorf("boarding UTXO %s not found "+
+				"in commitment tx", outpoint)
+		}
+	}
+
+	return outpointToIdx, nil
+}
+
+// ProcessEvent for CommitmentTxReceivedState.
+//
+//nolint:ll
+func (s *CommitmentTxReceivedState) ProcessEvent(
+	_ context.Context, event ClientEvent, env *ClientEnvironment,
+) (*ClientStateTransition, error) {
+
+	switch evt := event.(type) {
+	case *CommitmentTxBuilt:
+		// First, well make sure that all boarding UTXOs are present
+		// in the round transaction and build the outpoint-to-index map.
+		boardingInputIndices, err := validateBoardingInputs(
+			s.CommitmentTx, s.Intents,
+		)
+		if err != nil {
+			return &ClientStateTransition{
+				NextState: &ClientFailedState{
+					Reason: "commitment tx " +
+						"validation failed",
+					Error:       err,
+					Recoverable: true,
+				},
+			}, nil
+		}
+
+		clientTrees := make(map[SignerKey]*tree.Tree)
+
+		// Next, we'll make sure that each of the VTXO requests that we
+		// originally requested are actually present in the VTXT tree
+		// that the server sent us.
+		vtxoRequests := fn.Map(
+			s.Intents,
+			func(intent BoardingIntent) []types.VTXORequest {
+				return intent.VtxoTemplate
+			},
+		)
+		for i, vtxoReq := range fn.Flatten(vtxoRequests) {
+			// Convert VTXORequest to tree.VTXOExpectation for
+			// validation.
+			expectation := tree.VTXOExpectation{
+				Amount:      vtxoReq.Amount,
+				PkScript:    vtxoReq.PkScript,
+				OperatorKey: env.OperatorTerms.PubKey,
+			}
+
+			clientTree, err := s.VTXTTree.ValidatePath(
+				vtxoReq.SigningKey.PubKey,
+				[]tree.VTXOExpectation{expectation},
+			)
+			if err != nil {
+				return &ClientStateTransition{
+					NextState: &ClientFailedState{
+						Reason: fmt.Sprintf(
+							"VTXT validation "+
+								"failed for VTXO "+
+								"request %d", i,
+						),
+						Error:       err,
+						Recoverable: false,
+					},
+				}, nil
+			}
+
+			// Now that we know this VTXO request was properly
+			// included in the tree, we'll store the client-tree
+			// (travesal path from the root to this vtox leaf).
+			signerKey := NewSignerKey(vtxoReq.SigningKey.PubKey)
+			clientTrees[signerKey] = clientTree
+		}
+
+		// Make sure all anchor outputs are valid in the tree, if they
+		// aren't we may not be able to go on chain.
+		if err := s.VTXTTree.ValidateAnchors(); err != nil {
+			return &ClientStateTransition{
+				NextState: &ClientFailedState{
+					Reason: "anchor output " +
+						"validation failed",
+					Error:       err,
+					Recoverable: false,
+				},
+			}, nil
+		}
+
+		// TODO(roasbeef): for refresh and off boarding, need extra
+		// validation for:
+		//   * connector tree
+		//   * outputs on commit, etc
+
+		// We'll now transition to the CommitmentTxValidatedState, and
+		// emit an internal generate nonces event so we can propagate
+		// the state.
+		return &ClientStateTransition{
+			NextState: &CommitmentTxValidatedState{
+				RoundID:              s.RoundID,
+				CommitmentTx:         s.CommitmentTx,
+				VTXTTree:             s.VTXTTree,
+				Intents:              slices.Clone(s.Intents),
+				ClientTrees:          clientTrees,
+				BoardingInputIndices: boardingInputIndices,
+			},
+			NewEvents: fn.Some(ClientEmittedEvent{
+				InternalEvent: []ClientEvent{&GenerateNonces{}},
+			}),
+		}, nil
+
+	case *BoardingFailed:
+		return &ClientStateTransition{
+			NextState: &ClientFailedState{
+				Reason:      evt.Reason,
+				Error:       evt.Error,
+				Recoverable: evt.Recoverable,
+			},
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("commitment_tx_received: unexpected "+
+			"event: %T", event)
+	}
+}
+
+// ProcessEvent for CommitmentTxValidatedState.
+func (s *CommitmentTxValidatedState) ProcessEvent(
+	_ context.Context, event ClientEvent, env *ClientEnvironment,
+) (*ClientStateTransition, error) {
+
+	switch event.(type) {
+	case *GenerateNonces:
+		// Get sweep tapscript root from the validated tree. This was
+		// set when the operator built the tree.
+		sweepTweak := s.VTXTTree.SweepTapscriptRoot
+
+		// Build the prev output fetcher for signing. The batch output
+		// is needed so the root transaction can look up the output it
+		// spends from the commitment transaction.
+		prevOutFetcher, err := s.VTXTTree.Root.PrevOutputFetcher(
+			s.VTXTTree.BatchOutput,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create prev output "+
+				"fetcher: %w", err)
+		}
+
+		// At this point, all the basic validation checks have passed.
+		// So now we'll generate a musig2 session to create nonces to
+		// sign the VTXO tree. Each VTXO that we created will
+		// effectively be a new musig session.
+		musig2Sessions := make(map[SignerKey]*tree.SignerSession)
+		for _, boardingIntent := range s.Intents {
+			for _, vtxoReq := range boardingIntent.VtxoTemplate {
+				signerKey := NewSignerKey(
+					vtxoReq.SigningKey.PubKey,
+				)
+
+				// TODO(roasbeef): actually use the interface
+				// in front of this?
+				session, err := tree.NewSignerSession(
+					env.Wallet, &vtxoReq.SigningKey,
+					sweepTweak, prevOutFetcher,
+					s.VTXTTree.Root,
+				)
+				if err != nil {
+					return nil, fmt.Errorf("failed to "+
+						"create signing session for "+
+						"client %x: %w",
+						signerKey[:], err)
+				}
+
+				musig2Sessions[signerKey] = session
+			}
+		}
+
+		// Now that we have all our sessions created, we'll have each
+		// of them generate nonces to use in tree signing. We collect
+		// all nonces into a single map keyed by transaction ID.
+		allNonces := make(map[chainhash.Hash][]byte)
+		var participantKey *btcec.PublicKey
+		for _, session := range musig2Sessions {
+			nonces := session.GetNonces()
+
+			// Use the first session's pubkey as the participant
+			// key. All sessions belong to the same client.
+			if participantKey == nil {
+				participantKey = session.PubKey()
+			}
+
+			// Add each nonce to the combined map.
+			for txid, nonce := range nonces {
+				allNonces[txid] = nonce[:]
+			}
+		}
+
+		// MuSig2 nonces have been generated locally. Send them to the
+		// server to participate in the aggregated nonce computation.
+		nonceMsg := &SubmitNoncesRequest{
+			RoundID:        s.RoundID,
+			ParticipantKey: participantKey,
+			Nonces:         allNonces,
+		}
+
+		return &ClientStateTransition{
+			NextState: &NoncesSentState{
+				RoundID:              s.RoundID,
+				CommitmentTx:         s.CommitmentTx,
+				VTXTTree:             s.VTXTTree,
+				Intents:              slices.Clone(s.Intents),
+				ClientTrees:          s.ClientTrees,
+				Musig2Sessions:       musig2Sessions,
+				BoardingInputIndices: s.BoardingInputIndices,
+			},
+			NewEvents: fn.Some(ClientEmittedEvent{
+				Outbox: []ClientOutMsg{nonceMsg},
+			}),
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("commitment_tx_validated: unexpected "+
+			"event: %T", event)
+	}
+}
+
+// ProcessEvent for NoncesSentState.
+func (s *NoncesSentState) ProcessEvent(
+	_ context.Context, event ClientEvent, env *ClientEnvironment,
+) (*ClientStateTransition, error) {
+
+	switch evt := event.(type) {
+	case *NoncesAggregated:
+		// Received aggregated nonces from the server. Now register
+		// them with our signing session and generate partial
+		// signatures.
+		//
+		// The server sends ONE combined/aggregated nonce per
+		// transaction (not individual nonces from each participant).
+		// The server has already aggregated all participants' nonces
+		// using MuSig2 nonce aggregation.
+		//
+		// Convert the raw bytes to Musig2PubNonce for registration.
+		aggNoncesMap := make(map[tree.TxID]tree.Musig2PubNonce)
+		for txid, nonceBytes := range evt.AggregatedNonces {
+			var nonce tree.Musig2PubNonce
+			copy(nonce[:], nonceBytes)
+			aggNoncesMap[txid] = nonce
+		}
+
+		// With the nonces grouped, we need to register the nonces with
+		// each client session.
+		for _, musig2Session := range s.Musig2Sessions {
+			// Register the combined nonces with our signing
+			// session.
+			err := musig2Session.RegisterAggNonces(aggNoncesMap)
+			if err != nil {
+				return nil, fmt.Errorf("failed to register "+
+					"combined nonces: %w", err)
+			}
+		}
+
+		return &ClientStateTransition{
+			NextState: &NoncesAggregatedState{
+				RoundID:              s.RoundID,
+				CommitmentTx:         s.CommitmentTx,
+				VTXTTree:             s.VTXTTree,
+				Intents:              slices.Clone(s.Intents),
+				ClientTrees:          s.ClientTrees,
+				Musig2Sessions:       s.Musig2Sessions,
+				AggregatedNonces:     evt.AggregatedNonces,
+				BoardingInputIndices: s.BoardingInputIndices,
+			},
+			NewEvents: fn.Some(ClientEmittedEvent{
+				InternalEvent: []ClientEvent{
+					&GeneratePartialSigs{},
+				},
+			}),
+		}, nil
+
+	case *BoardingFailed:
+		return &ClientStateTransition{
+			NextState: &ClientFailedState{
+				Reason:      evt.Reason,
+				Error:       evt.Error,
+				Recoverable: evt.Recoverable,
+			},
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("nonces_sent: unexpected event: %T",
+			event)
+	}
+}
+
+// ProcessEvent for NoncesAggregatedState.
+func (s *NoncesAggregatedState) ProcessEvent(
+	_ context.Context, event ClientEvent, env *ClientEnvironment,
+) (*ClientStateTransition, error) {
+
+	switch event.(type) {
+	case *GeneratePartialSigs:
+		// At this stage, the nonces have been aggregated for each
+		// client, so now we'll generate and send our partial
+		// signatures.
+		//
+		// TODO(roasbeef); how should the partial sigs actually be
+		// assembled?
+		var (
+			submitPartialSigs []ClientOutMsg
+		)
+		for _, musig2Session := range s.Musig2Sessions {
+			// Generate partial signatures for all transactions in
+			// our path.
+			partialSigs, err := musig2Session.Signatures(true)
+			if err != nil {
+				return nil, fmt.Errorf("failed to generate "+
+					"partial signatures: %w", err)
+			}
+
+			var partialSigBytes [][]byte
+			for _, sig := range partialSigs {
+				var buf bytes.Buffer
+				err := sig.Encode(&buf)
+				if err != nil {
+					return nil, fmt.Errorf("failed to "+
+						"encode partial "+
+						"signature: %w", err)
+				}
+				partialSigBytes = append(
+					partialSigBytes, buf.Bytes(),
+				)
+			}
+
+			submitPartialSigs = append(
+				submitPartialSigs, &SubmitPartialSigRequest{
+					RoundID:        s.RoundID,
+					ParticipantKey: musig2Session.PubKey(),
+					PartialSigs:    partialSigBytes,
+				},
+			)
+		}
+
+		// Partial MuSig2 signatures have been generated using the
+		// aggregated nonces. Send them to the server for signature
+		// aggregation.
+		return &ClientStateTransition{
+			NextState: &PartialSigsSentState{
+				RoundID:              s.RoundID,
+				CommitmentTx:         s.CommitmentTx,
+				VTXTTree:             s.VTXTTree,
+				Intents:              slices.Clone(s.Intents),
+				ClientTrees:          s.ClientTrees,
+				Musig2Sessions:       s.Musig2Sessions,
+				BoardingInputIndices: s.BoardingInputIndices,
+			},
+			// TODO(roasbeef): group into a single message?
+			NewEvents: fn.Some(ClientEmittedEvent{
+				Outbox: submitPartialSigs,
+			}),
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("nonces_aggregated: unexpected "+
+			"event: %T", event)
+	}
+}
+
+// ProcessEvent for PartialSigsSentState.
+func (s *PartialSigsSentState) ProcessEvent(
+	ctx context.Context, event ClientEvent, env *ClientEnvironment,
+) (*ClientStateTransition, error) {
+
+	switch evt := event.(type) {
+	case *OperatorSigned:
+		// At this point, Received complete VTXT signatures from the
+		// server after the operator aggregated all partial signatures.
+		//
+		// Now, we'll validate that the aggregated signatures are valid
+		// for the VTXT before proceeding. This prevents the operator
+		// from providing invalid signatures that would make our VTXOs
+		// unspendable.
+		err := s.VTXTTree.ValidateAndSubmitSignatures(evt.Signatures)
+		if err != nil {
+			return &ClientStateTransition{
+				NextState: &ClientFailedState{
+					Reason: "VTXT signature " +
+						"validation failed",
+					Error:       err,
+					Recoverable: false,
+				},
+			}, nil
+		}
+
+		// Now that we know all the signatures are valid, we'll sign
+		// off on each of our boarding inputs sent to the server.
+		var boardingSigs []*schnorr.Signature
+		for _, boardingIntent := range s.Intents {
+			outpoint := boardingIntent.BoardingRequest.Outpoint
+			inputIdx, found := s.BoardingInputIndices[*outpoint]
+			if !found {
+				return nil, fmt.Errorf("no input index "+
+					"found for boarding outpoint %s",
+					outpoint)
+			}
+
+			spendInfo, err := scripts.NewVTXOSpendInfo(
+				boardingIntent.Address.Tapscript,
+				scripts.VTXOCollabPathLeaf,
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			// Access chain info directly from the embedded wallet
+			// intent.
+			chainInfo := boardingIntent.ChainInfo
+			addr := boardingIntent.Address.Address
+			pkScript := addr.ScriptAddress()
+			amt := chainInfo.Amount
+
+			// Create the TxOut for the boarding output.
+			output := &wire.TxOut{
+				Value:    int64(amt),
+				PkScript: pkScript,
+			}
+
+			prevOutFetcher := txscript.NewCannedPrevOutputFetcher(
+				pkScript, int64(amt),
+			)
+
+			tx := s.CommitmentTx
+
+			sigHashes := txscript.NewTxSigHashes(tx, prevOutFetcher)
+
+			signature, err := scripts.SignVTXOCollabInput(
+				env.Wallet, tx, inputIdx, spendInfo,
+				&boardingIntent.Address.KeyDesc, output,
+				sigHashes, prevOutFetcher,
+			)
+			if err != nil {
+				return nil, fmt.Errorf("failed to sign "+
+					"boarding input %d: %w", inputIdx, err)
+			}
+
+			// Convert input.Signature to *schnorr.Signature.
+			schnorrSig, ok := signature.(*schnorr.Signature)
+			if !ok {
+				return nil, fmt.Errorf("signature is not a " +
+					"schnorr signature")
+			}
+			boardingSigs = append(boardingSigs, schnorrSig)
+		}
+
+		sigBytes := make([][]byte, len(boardingSigs))
+		for i, sig := range boardingSigs {
+			sigBytes[i] = sig.Serialize()
+		}
+		if len(sigBytes) != len(s.Intents) {
+			return nil, fmt.Errorf("signature count %d != intent "+
+				"count %d", len(sigBytes), len(s.Intents))
+		}
+
+		outboxMsgs := make([]ClientOutMsg, 0, len(sigBytes))
+		for i, intent := range s.Intents {
+			if intent.Address.Address == nil {
+				return nil, fmt.Errorf("intent %d missing "+
+					"boarding address", i)
+			}
+			forfeitSig := &SubmitForfeitSigRequest{
+				RoundID:        s.RoundID,
+				ParticipantKey: intent.Address.KeyDesc.PubKey,
+				ForfeitSigs:    [][]byte{sigBytes[i]},
+			}
+			outboxMsgs = append(outboxMsgs, forfeitSig)
+		}
+
+		txid := s.CommitmentTx.TxHash()
+		callerID := fmt.Sprintf("commitment-%s", txid.String())
+		outboxMsgs = append(outboxMsgs, &RegisterConfirmationRequest{
+			CallerID:    callerID,
+			Txid:        &txid,
+			TargetConfs: env.OperatorTerms.MinConfirmations,
+		})
+
+		// Checkpoint the round state at the "point of no return".
+		// After sending boarding input signatures, the server may
+		// broadcast the commitment transaction. We must persist all
+		// round data to enable recovery if the client restarts.
+		//
+		// Mark all intents as Adopted (frozen in this round) and set
+		// their RoundID, then save them alongside the round.
+		adoptedIntents := make([]BoardingIntent, len(s.Intents))
+		for i, intent := range s.Intents {
+			intent.Status = BoardingStatusAdopted
+			intent.RoundID = fn.Some(s.RoundID)
+			adoptedIntents[i] = intent
+		}
+		round := &Round{
+			RoundID:      s.RoundID,
+			CommitmentTx: fn.Some(s.CommitmentTx),
+			VTXTTree:     fn.Some(s.VTXTTree),
+			BoardingGroup: &BoardingGroup{
+				RoundID: s.RoundID,
+				Intents: adoptedIntents,
+			},
+		}
+
+		// Checkpoint round data + FSM state atomically at the "point
+		// of no return". The next state is persisted so restart can
+		// recover to InputSigSentState.
+		nextState := &InputSigSentState{
+			RoundID:      s.RoundID,
+			CommitmentTx: s.CommitmentTx,
+			VTXTTree:     s.VTXTTree,
+			Intents:      slices.Clone(s.Intents),
+			ClientTrees:  s.ClientTrees,
+			InputSigs:    sigBytes,
+		}
+		err = env.RoundStore.CommitState(ctx, round, nextState)
+		if err != nil {
+			return nil, fmt.Errorf("failed to commit round "+
+				"state: %w", err)
+		}
+
+		checkpointNotify := &RoundCheckpointedNotification{
+			RoundID: s.RoundID,
+		}
+
+		return &ClientStateTransition{
+			NextState: nextState,
+			NewEvents: fn.Some(ClientEmittedEvent{
+				Outbox: append(outboxMsgs, checkpointNotify),
+			}),
+		}, nil
+
+	case *BoardingFailed:
+		return &ClientStateTransition{
+			NextState: &ClientFailedState{
+				Reason:      evt.Reason,
+				Error:       evt.Error,
+				Recoverable: evt.Recoverable,
+			},
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("partial_sigs_sent: unexpected "+
+			"event: %T", event)
+	}
+}
+
+// buildClientVTXOs constructs ClientVTXO instances from the boarding intents
+// and client trees.
+func buildClientVTXOs(intents []BoardingIntent,
+	trees map[SignerKey]*tree.Tree, roundID string) ([]*ClientVTXO, error) {
+
+	vtxos := make([]*ClientVTXO, 0)
+	for _, intent := range intents {
+		// Each intent has a VTXO template with one or more requests.
+		for _, req := range intent.VtxoTemplate {
+			signerKey := NewSignerKey(req.SigningKey.PubKey)
+			tree := trees[signerKey]
+			if tree == nil {
+				return nil, fmt.Errorf("missing client tree " +
+					"for signing key")
+			}
+
+			// Use the key descriptor from the intent's boarding
+			// address.
+			clientKeyDesc := intent.Address.KeyDesc
+
+			leaves := tree.Root.GetLeafNodes()
+
+			for _, leaf := range leaves {
+				outpoint, err := leaf.GetNonAnchorOutpoint()
+				if err != nil {
+					return nil, fmt.Errorf("failed to "+
+						"derive VTXO outpoint: %w", err)
+				}
+
+				vtxos = append(vtxos, &ClientVTXO{
+					Outpoint:    *outpoint,
+					Amount:      req.Amount,
+					PkScript:    req.PkScript,
+					Expiry:      req.Expiry,
+					ClientKey:   clientKeyDesc,
+					OperatorKey: req.OperatorKey,
+					TreePath:    tree,
+					RoundID:     fn.Some(roundID),
+				})
+			}
+		}
+	}
+
+	return vtxos, nil
+}
+
+// ProcessEvent for InputSigSentState.
+func (s *InputSigSentState) ProcessEvent(
+	_ context.Context, event ClientEvent, env *ClientEnvironment,
+) (*ClientStateTransition, error) {
+
+	switch evt := event.(type) {
+	case *BoardingFailed:
+		return &ClientStateTransition{
+			NextState: &ClientFailedState{
+				Reason:      evt.Reason,
+				Error:       evt.Error,
+				Recoverable: evt.Recoverable,
+			},
+		}, nil
+
+	case *BoardingConfirmed:
+		vtxos, err := buildClientVTXOs(
+			s.Intents, s.ClientTrees, s.RoundID,
+		)
+		if err != nil {
+			return &ClientStateTransition{
+				NextState: &ClientFailedState{
+					Reason: "failed to build client " +
+						"VTXOs",
+					Error:       err,
+					Recoverable: false,
+				},
+			}, nil
+		}
+
+		// Persist VTXOs with their extracted tree paths for future
+		// spending.
+		if err := env.VTXOStore.SaveVTXOs(vtxos); err != nil {
+			return nil, fmt.Errorf("failed to save VTXOs: %w", err)
+		}
+
+		return &ClientStateTransition{
+			NextState: &ConfirmedState{
+				TxID:          evt.TxID,
+				BlockHeight:   evt.BlockHeight,
+				Confirmations: evt.Confirmations,
+				VTXOs:         vtxos,
+			},
+			NewEvents: fn.Some(ClientEmittedEvent{
+				Outbox: []ClientOutMsg{
+					&VTXOCreatedNotification{VTXOs: vtxos},
+					&RoundCompletedNotification{
+						RoundID: s.RoundID,
+						TxID:    evt.TxID,
+					},
+				},
+			}),
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("input_sig_sent: unexpected event: %T",
+			event)
+	}
+}
+
+// ProcessEvent for ConfirmedState. After boarding completes successfully, we
+// automatically transition back to Idle to allow processing new boarding
+// addresses and intents.
+func (s *ConfirmedState) ProcessEvent(_ context.Context, event ClientEvent,
+	env *ClientEnvironment) (*ClientStateTransition, error) {
+
+	switch event.(type) {
+	case *RoundComplete:
+		// Boarding is complete for this round. Transition back to Idle
+		// to process new confirmations for existing boarding addresses
+		// or start new rounds.
+		return &ClientStateTransition{
+			NextState: &Idle{},
+		}, nil
+
+	default:
+		// Stay in confirmed state for unexpected events.
+		return &ClientStateTransition{
+			NextState: s,
+		}, nil
+	}
+}
+
+// ProcessEvent for ClientFailedState (terminal state).
+func (s *ClientFailedState) ProcessEvent(
+	_ context.Context, event ClientEvent, env *ClientEnvironment,
+) (*ClientStateTransition, error) {
+
+	switch evt := event.(type) {
+	case *RecoveryInitiated:
+		// Initiate CSV timeout recovery to sweep the boarding UTXO
+		// back to the client's wallet after the relative timelock
+		// expires.
+		return &ClientStateTransition{
+			NextState: &RecoveryInitiatedState{
+				Outpoint:  evt.Outpoint,
+				SweepTxID: evt.SweepTxID,
+				Reason:    evt.Reason,
+			},
+		}, nil
+
+	default:
+		// Stay in failed state for other events since no other
+		// transitions are valid from this terminal state.
+		return &ClientStateTransition{
+			NextState: s,
+		}, nil
+	}
+}
+
+// ProcessEvent for RecoveryInitiatedState (semi-terminal state).
+func (s *RecoveryInitiatedState) ProcessEvent(
+	_ context.Context, event ClientEvent, env *ClientEnvironment,
+) (*ClientStateTransition, error) {
+
+	// Semi-terminal state - self-loop on all events since the recovery
+	// sweep transaction has been broadcast and we're waiting for
+	// confirmation.
+	return &ClientStateTransition{
+		NextState: s,
+	}, nil
+}

--- a/round/transitions_test.go
+++ b/round/transitions_test.go
@@ -1,0 +1,1432 @@
+package round
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/tree"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStateProperties verifies IsTerminal() and String() for all states.
+func TestStateProperties(t *testing.T) {
+	t.Parallel()
+
+	t.Run("terminal_states", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name     string
+			state    ClientState
+			expected string
+		}{
+			{
+				name:     "Confirmed",
+				state:    &ConfirmedState{},
+				expected: "Confirmed",
+			},
+			{
+				name:     "ClientFailed",
+				state:    &ClientFailedState{Reason: "test"},
+				expected: "ClientFailed",
+			},
+			{
+				name: "RecoveryInitiated",
+				state: &RecoveryInitiatedState{
+					Reason: "CSV",
+				},
+				expected: "RecoveryInitiated",
+			},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				require.True(t, tc.state.IsTerminal())
+				require.Contains(
+					t, tc.state.String(), tc.expected,
+				)
+			})
+		}
+	})
+
+	t.Run("non_terminal_states", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name     string
+			state    ClientState
+			expected string
+		}{
+			{
+				"Idle", &Idle{}, "Idle",
+			},
+			{
+				"PendingRoundAssembly", &PendingRoundAssembly{},
+				"BoardingIntents",
+			},
+			{
+				"RegistrationSent", &RegistrationSentState{},
+				"RegistrationSent",
+			},
+			{
+				"RoundJoined", &RoundJoinedState{},
+				"RoundJoined",
+			},
+			{
+				"CommitmentTxReceived",
+				&CommitmentTxReceivedState{},
+				"CommitmentTxReceived",
+			},
+			{
+				"CommitmentTxValidated",
+				&CommitmentTxValidatedState{},
+				"CommitmentTxValidated",
+			},
+			{
+				"NoncesSent", &NoncesSentState{}, "NoncesSent",
+			},
+			{
+				"NoncesAggregated", &NoncesAggregatedState{},
+				"NoncesAggregated",
+			},
+			{
+				"PartialSigsSent", &PartialSigsSentState{},
+				"PartialSigsSent",
+			},
+			{
+				"InputSigSent", &InputSigSentState{},
+				"InputSigSent",
+			},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				require.False(t, tc.state.IsTerminal())
+				require.Equal(t, tc.expected, tc.state.String())
+			})
+		}
+	})
+}
+
+// TestUnexpectedEventErrors verifies all states reject invalid events.
+func TestUnexpectedEventErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		setup func(h *boardingTestHarness) ClientState
+		event ClientEvent
+	}{
+		{
+			name: "Idle_rejects_RoundJoined",
+			setup: func(h *boardingTestHarness) ClientState {
+				return &Idle{}
+			},
+			event: &RoundJoined{RoundID: "test"},
+		},
+		{
+			name: "PendingRoundAssembly_rejects_RoundComplete",
+			setup: func(h *boardingTestHarness) ClientState {
+				intent := h.newTestBoardingIntent()
+				intents := map[wire.OutPoint]BoardingIntent{
+					intent.Outpoint: intent,
+				}
+
+				return &PendingRoundAssembly{
+					Intents: intents,
+				}
+			},
+			event: &RoundComplete{},
+		},
+		{
+			name: "RegistrationSent_rejects_BoardingConfirmed",
+			setup: func(h *boardingTestHarness) ClientState {
+				intent := h.newTestBoardingIntent()
+				return &RegistrationSentState{
+					Intents: []BoardingIntent{intent},
+				}
+			},
+			event: &BoardingConfirmed{},
+		},
+		{
+			name: "RoundJoined_rejects_duplicate_RoundJoined",
+			setup: func(h *boardingTestHarness) ClientState {
+				intent := h.newTestBoardingIntent()
+				return &RoundJoinedState{
+					RoundID: "round-1",
+					Intents: []BoardingIntent{intent},
+				}
+			},
+			event: &RoundJoined{RoundID: "another-round"},
+		},
+		{
+			name: "CommitmentTxReceived_rejects_RoundJoined",
+			setup: func(h *boardingTestHarness) ClientState {
+				intent := h.newTestBoardingIntent()
+				return h.newCommitmentTxReceivedState(
+					"round-001", []BoardingIntent{intent},
+				)
+			},
+			event: &RoundJoined{RoundID: "another-round"},
+		},
+		{
+			name: "CommitmentTxValidated_rejects_RoundJoined",
+			setup: func(h *boardingTestHarness) ClientState {
+				intent := h.newTestBoardingIntent()
+				return h.newCommitmentTxValidatedState(
+					"round-001", []BoardingIntent{intent},
+				)
+			},
+			event: &RoundJoined{RoundID: "another-round"},
+		},
+		{
+			name: "NoncesSent_rejects_RoundJoined",
+			setup: func(h *boardingTestHarness) ClientState {
+				vtxtTree, _ := h.newTestVTXOTree(1)
+				intent := h.newTestBoardingIntent()
+				return &NoncesSentState{
+					RoundID:  "round-001",
+					VTXTTree: vtxtTree,
+					Intents:  []BoardingIntent{intent},
+				}
+			},
+			event: &RoundJoined{RoundID: "another-round"},
+		},
+		{
+			name: "NoncesAggregated_rejects_RoundJoined",
+			setup: func(h *boardingTestHarness) ClientState {
+				vtxtTree, _ := h.newTestVTXOTree(1)
+				intent := h.newTestBoardingIntent()
+				return &NoncesAggregatedState{
+					RoundID:  "round-001",
+					VTXTTree: vtxtTree,
+					Intents:  []BoardingIntent{intent},
+				}
+			},
+			event: &RoundJoined{RoundID: "another-round"},
+		},
+		{
+			name: "PartialSigsSent_rejects_RoundJoined",
+			setup: func(h *boardingTestHarness) ClientState {
+				vtxtTree, _ := h.newTestVTXOTree(1)
+				intent := h.newTestBoardingIntent()
+				return &PartialSigsSentState{
+					RoundID:  "round-001",
+					VTXTTree: vtxtTree,
+					Intents:  []BoardingIntent{intent},
+				}
+			},
+			event: &RoundJoined{RoundID: "another-round"},
+		},
+		{
+			name: "InputSigSent_rejects_RoundJoined",
+			setup: func(h *boardingTestHarness) ClientState {
+				vtxtTree, _ := h.newTestVTXOTree(1)
+				intent := h.newTestBoardingIntent()
+				return &InputSigSentState{
+					RoundID:  "round-001",
+					VTXTTree: vtxtTree,
+					Intents:  []BoardingIntent{intent},
+				}
+			},
+			event: &RoundJoined{RoundID: "another-round"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHarness(t)
+			h.withState(tc.setup(h))
+
+			_, err := h.sendEvent(tc.event)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "unexpected")
+		})
+	}
+}
+
+// TestBoardingFailedTransitions verifies all non-terminal states handle
+// BoardingFailed by transitioning to ClientFailedState.
+func TestBoardingFailedTransitions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		setup func(h *boardingTestHarness) ClientState
+	}{
+		{
+			name: "RegistrationSentState",
+			setup: func(h *boardingTestHarness) ClientState {
+				intent := h.newTestBoardingIntent()
+				return &RegistrationSentState{
+					Intents: []BoardingIntent{intent},
+				}
+			},
+		},
+		{
+			name: "RoundJoinedState",
+			setup: func(h *boardingTestHarness) ClientState {
+				intent := h.newTestBoardingIntent()
+				return &RoundJoinedState{
+					RoundID: "round-001",
+					Intents: []BoardingIntent{intent},
+				}
+			},
+		},
+		{
+			name: "CommitmentTxReceivedState",
+			setup: func(h *boardingTestHarness) ClientState {
+				intent := h.newTestBoardingIntent()
+				return h.newCommitmentTxReceivedState(
+					"round-001", []BoardingIntent{intent},
+				)
+			},
+		},
+		{
+			name: "NoncesSentState",
+			setup: func(h *boardingTestHarness) ClientState {
+				vtxtTree, _ := h.newTestVTXOTree(1)
+				intent := h.newTestBoardingIntent()
+				return &NoncesSentState{
+					RoundID:  "round-001",
+					VTXTTree: vtxtTree,
+					Intents:  []BoardingIntent{intent},
+				}
+			},
+		},
+		{
+			name: "PartialSigsSentState",
+			setup: func(h *boardingTestHarness) ClientState {
+				vtxtTree, _ := h.newTestVTXOTree(1)
+				intent := h.newTestBoardingIntent()
+				return &PartialSigsSentState{
+					RoundID:  "round-001",
+					VTXTTree: vtxtTree,
+					Intents:  []BoardingIntent{intent},
+				}
+			},
+		},
+		{
+			name: "InputSigSentState",
+			setup: func(h *boardingTestHarness) ClientState {
+				vtxtTree, _ := h.newTestVTXOTree(1)
+				intent := h.newTestBoardingIntent()
+				return &InputSigSentState{
+					RoundID:  "round-001",
+					VTXTTree: vtxtTree,
+					Intents:  []BoardingIntent{intent},
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHarness(t)
+			h.withState(tc.setup(h))
+
+			event := &BoardingFailed{
+				Reason:      "test failure reason",
+				Recoverable: true,
+			}
+
+			transition, err := h.sendEvent(event)
+			require.NoError(t, err)
+			require.NotNil(t, transition)
+
+			failedState := assertStateType[*ClientFailedState](h)
+			require.Equal(
+				t, "test failure reason", failedState.Reason,
+			)
+			require.True(t, failedState.Recoverable)
+		})
+	}
+}
+
+// TestTerminalStateSelfLoop verifies terminal states self-loop on any event.
+func TestTerminalStateSelfLoop(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+	intent := h.newTestBoardingIntent()
+
+	tests := []struct {
+		name  string
+		state ClientState
+	}{
+		{"ConfirmedState", &ConfirmedState{BlockHeight: 100}},
+		{"ClientFailedState", &ClientFailedState{Reason: "failed"}},
+		{
+			"RecoveryInitiatedState",
+			&RecoveryInitiatedState{Outpoint: intent.Outpoint},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHarness(t)
+			h.withState(tc.state)
+
+			// Terminal states ignore all events and remain in their
+			// current state, preventing further transitions once
+			// boarding reaches a final outcome.
+			event := &RoundJoined{RoundID: "test"}
+			transition, err := h.sendEvent(event)
+			require.NoError(t, err)
+			require.NotNil(t, transition)
+
+			require.Equal(
+				t, tc.state.String(), h.currentState.String(),
+			)
+		})
+	}
+}
+
+func TestIdleState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("BoardingUTXOConfirmed_to_pending", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+		h.withState(&Idle{})
+
+		intent := h.newTestBoardingIntent()
+		event := h.newBoardingUTXOConfirmedEvent(intent)
+
+		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		nextState := assertStateType[*PendingRoundAssembly](h)
+		require.Len(t, nextState.Intents, 1)
+		require.Contains(t, nextState.Intents, intent.Outpoint)
+	})
+
+	t.Run("ResumeBoardingIntents_with_intents", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+		h.withState(&Idle{})
+
+		intent := h.newTestBoardingIntent()
+		event := &ResumeBoardingIntents{
+			Intents: map[wire.OutPoint]BoardingIntent{
+				intent.Outpoint: intent,
+			},
+		}
+
+		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		nextState := assertStateType[*PendingRoundAssembly](h)
+		require.Len(t, nextState.Intents, 1)
+	})
+
+	t.Run("ResumeBoardingIntents_empty_stays_idle", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+		h.withState(&Idle{})
+
+		event := &ResumeBoardingIntents{
+			Intents: map[wire.OutPoint]BoardingIntent{},
+		}
+
+		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		_ = assertStateType[*Idle](h)
+	})
+
+	t.Run("nil_tx_error", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+		h.withState(&Idle{})
+
+		intent := h.newTestBoardingIntent()
+		event := h.newBoardingUTXOConfirmedEvent(intent)
+		event.Tx = nil
+
+		_, err := h.sendEvent(event)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "missing transaction")
+	})
+
+	t.Run("invalid_outpoint_index_error", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+		h.withState(&Idle{})
+
+		intent := h.newTestBoardingIntent()
+		event := h.newBoardingUTXOConfirmedEvent(intent)
+		event.Outpoint.Index = 999
+
+		_, err := h.sendEvent(event)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid outpoint index")
+	})
+}
+
+func TestPendingRoundAssemblyState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("additional_confirmation_accumulates", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+
+		existingIntent := h.newTestBoardingIntent()
+		h.withState(&PendingRoundAssembly{
+			Intents: map[wire.OutPoint]BoardingIntent{
+				existingIntent.Outpoint: existingIntent,
+			},
+		})
+
+		newIntent := h.newTestBoardingIntent()
+		event := h.newBoardingUTXOConfirmedEvent(newIntent)
+
+		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		nextState := assertStateType[*PendingRoundAssembly](h)
+		require.Len(t, nextState.Intents, 2)
+	})
+
+	t.Run("registration_requested_transitions", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+
+		intent := h.newTestBoardingIntent()
+		h.withState(&PendingRoundAssembly{
+			Intents: map[wire.OutPoint]BoardingIntent{
+				intent.Outpoint: intent,
+			},
+		})
+
+		intents := []BoardingIntent{intent}
+		event := &RegistrationRequested{Intents: intents}
+
+		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		nextState := assertStateType[*RegistrationSentState](h)
+		require.Len(t, nextState.Intents, 1)
+	})
+
+	t.Run("no_intents_error", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+		h.withState(&PendingRoundAssembly{
+			Intents: map[wire.OutPoint]BoardingIntent{},
+		})
+
+		event := &RegistrationRequested{Intents: []BoardingIntent{}}
+
+		_, err := h.sendEvent(event)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no boarding requests")
+	})
+}
+
+func TestRegistrationSentState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("RoundJoined_transitions", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+
+		intent := h.newTestBoardingIntent()
+		h.withState(&RegistrationSentState{
+			Intents: []BoardingIntent{intent},
+		})
+
+		event := &RoundJoined{RoundID: "test-round-123"}
+
+		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		nextState := assertStateType[*RoundJoinedState](h)
+		require.Equal(t, "test-round-123", nextState.RoundID)
+		require.Len(t, nextState.Intents, 1)
+	})
+}
+
+func TestRoundJoinedState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("CommitmentTxBuilt_transitions", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+
+		intent := h.newTestBoardingIntent()
+		h.withState(&RoundJoinedState{
+			RoundID: "round-001",
+			Intents: []BoardingIntent{intent},
+		})
+
+		vtxtTree, _ := h.newTestVTXOTree(1)
+		commitEvent := h.newCommitmentTxBuiltEvent(
+			"round-001", []BoardingIntent{intent}, vtxtTree,
+		)
+
+		transition, err := h.sendEvent(commitEvent)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		nextState := assertStateType[*CommitmentTxReceivedState](h)
+		require.Equal(t, "round-001", nextState.RoundID)
+		require.NotNil(t, nextState.CommitmentTx)
+		require.True(t, transition.NewEvents.IsSome())
+	})
+}
+
+func TestCommitmentTxReceivedState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("validation_succeeds", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+
+		intent := h.newTestBoardingIntent()
+		vtxtTree := h.newTestVTXOTreeForIntent(intent)
+		commitmentTx := h.newTestCommitmentTx(
+			[]wire.OutPoint{intent.Outpoint},
+		)
+
+		state := &CommitmentTxReceivedState{
+			RoundID:      "round-001",
+			CommitmentTx: commitmentTx,
+			TxID:         commitmentTx.TxHash(),
+			VTXTTree:     vtxtTree,
+			Intents:      []BoardingIntent{intent},
+			ClientTrees:  make(map[SignerKey]*tree.Tree),
+		}
+		h.withState(state)
+
+		event := &CommitmentTxBuilt{
+			CommitmentTxBuiltEvent: CommitmentTxBuiltEvent{
+				RoundID:  "round-001",
+				Tx:       commitmentTx,
+				VTXTTree: vtxtTree,
+			},
+		}
+
+		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		validatedState := assertStateType[*CommitmentTxValidatedState](
+			h,
+		)
+		require.Equal(t, "round-001", validatedState.RoundID)
+		require.NotEmpty(t, validatedState.BoardingInputIndices)
+		assertTransitionEmitsInternalEvent[*GenerateNonces](
+			h, transition,
+		)
+	})
+
+	t.Run("missing_boarding_input_error", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+
+		intent := h.newTestBoardingIntent()
+		vtxtTree := h.newTestVTXOTreeForIntent(intent)
+
+		// Create tx WITHOUT the intent's outpoint.
+		differentOutpoint := h.newTestOutpoint()
+		commitmentTx := h.newTestCommitmentTx(
+			[]wire.OutPoint{differentOutpoint},
+		)
+
+		state := &CommitmentTxReceivedState{
+			RoundID:      "round-001",
+			CommitmentTx: commitmentTx,
+			TxID:         commitmentTx.TxHash(),
+			VTXTTree:     vtxtTree,
+			Intents:      []BoardingIntent{intent},
+			ClientTrees:  make(map[SignerKey]*tree.Tree),
+		}
+		h.withState(state)
+
+		event := &CommitmentTxBuilt{
+			CommitmentTxBuiltEvent: CommitmentTxBuiltEvent{
+				RoundID:  "round-001",
+				Tx:       commitmentTx,
+				VTXTTree: vtxtTree,
+			},
+		}
+
+		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		failedState := assertStateType[*ClientFailedState](h)
+		require.Contains(t, failedState.Reason, "validation failed")
+	})
+}
+
+func TestCommitmentTxValidatedState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("GenerateNonces_transitions", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+		h.setupMockWalletForMuSig2()
+
+		intent := h.newTestBoardingIntent()
+		state := h.newCommitmentTxValidatedState(
+			"round-001", []BoardingIntent{intent},
+		)
+		h.withState(state)
+
+		transition, err := h.sendEvent(&GenerateNonces{})
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		noncesSentState := assertStateType[*NoncesSentState](h)
+		require.Equal(t, "round-001", noncesSentState.RoundID)
+		require.NotNil(t, noncesSentState.Musig2Sessions)
+
+		h.assertOutboxLen(1)
+		h.assertOutboxContainsType("*round.SubmitNoncesRequest")
+	})
+}
+
+func TestNoncesSentState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("NoncesAggregated_transitions", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+		h.setupMockWalletForMuSig2()
+
+		intent := h.newTestBoardingIntent()
+
+		// Build up through actual flow to get real sessions.
+		validatedState := h.newCommitmentTxValidatedState(
+			"round-001", []BoardingIntent{intent},
+		)
+		h.withState(validatedState)
+
+		_, err := h.sendEvent(&GenerateNonces{})
+		require.NoError(t, err)
+		h.clearOutbox()
+
+		noncesSentState := assertStateType[*NoncesSentState](h)
+
+		event := h.newNoncesAggregatedEvent(
+			"round-001", noncesSentState.VTXTTree,
+		)
+
+		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		noncesAggState := assertStateType[*NoncesAggregatedState](h)
+		require.Equal(t, "round-001", noncesAggState.RoundID)
+		assertTransitionEmitsInternalEvent[*GeneratePartialSigs](
+			h, transition,
+		)
+	})
+}
+
+func TestNoncesAggregatedState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("GeneratePartialSigs_transitions", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+		h.setupMockWalletForMuSig2()
+
+		intent := h.newTestBoardingIntent()
+
+		// We build through the full state machine flow to ensure MuSig2
+		// sessions are properly initialized with real nonce state.
+		validatedState := h.newCommitmentTxValidatedState(
+			"round-001", []BoardingIntent{intent},
+		)
+		h.withState(validatedState)
+
+		_, err := h.sendEvent(&GenerateNonces{})
+		require.NoError(t, err)
+		h.clearOutbox()
+
+		noncesSentState := assertStateType[*NoncesSentState](h)
+
+		aggEvent := h.newNoncesAggregatedEvent(
+			"round-001", noncesSentState.VTXTTree,
+		)
+		_, err = h.sendEvent(aggEvent)
+		require.NoError(t, err)
+		h.clearOutbox()
+
+		_ = assertStateType[*NoncesAggregatedState](h)
+
+		transition, err := h.sendEvent(&GeneratePartialSigs{})
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		partialSigsState := assertStateType[*PartialSigsSentState](h)
+		require.Equal(t, "round-001", partialSigsState.RoundID)
+		h.assertOutboxContainsType("*round.SubmitPartialSigRequest")
+	})
+}
+
+func TestPartialSigsSentState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("OperatorSigned_with_real_signatures", func(t *testing.T) {
+		t.Parallel()
+
+		h := newRealSigningTestHarness(t)
+
+		intent := h.newTestBoardingIntentWithTapscript()
+		vtxtTree := h.newTestVTXOTreeForIntent(intent)
+
+		validSigs, err := h.generateValidTreeSignatures(vtxtTree)
+		require.NoError(t, err)
+		require.NotEmpty(t, validSigs)
+
+		commitmentTx := h.newCommitmentTxForIntents(
+			[]BoardingIntent{intent}, vtxtTree,
+		)
+
+		clientTrees := make(map[SignerKey]*tree.Tree)
+		for _, vtxoReq := range intent.VtxoTemplate {
+			signerKey := NewSignerKey(vtxoReq.SigningKey.PubKey)
+			clientTrees[signerKey] = vtxtTree
+		}
+
+		state := &PartialSigsSentState{
+			RoundID:      "round-real-sig-001",
+			CommitmentTx: commitmentTx,
+			VTXTTree:     vtxtTree,
+			Intents:      []BoardingIntent{intent},
+			ClientTrees:  clientTrees,
+			BoardingInputIndices: map[wire.OutPoint]int{
+				intent.Outpoint: 0,
+			},
+			Musig2Sessions: make(map[SignerKey]*tree.SignerSession),
+		}
+
+		h.setupMockWalletForBoardingSigning()
+		h.setupMockRoundStoreForCommit()
+		h.withState(state)
+
+		event := &OperatorSigned{
+			OperatorSignedEvent: OperatorSignedEvent{
+				RoundID:    "round-real-sig-001",
+				Signatures: validSigs,
+			},
+		}
+
+		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		inputSigState := assertStateType[*InputSigSentState](
+			h.boardingTestHarness,
+		)
+		require.Equal(t, "round-real-sig-001", inputSigState.RoundID)
+		require.NotEmpty(t, inputSigState.InputSigs)
+
+		h.assertOutboxContainsType("*round.SubmitForfeitSigRequest")
+		h.assertOutboxContainsType("*round.RegisterConfirmationRequest")
+	})
+
+	t.Run("empty_signatures_error", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+
+		intent := h.newTestBoardingIntent()
+		vtxtTree := h.newTestVTXOTreeForIntent(intent)
+		commitmentTx := h.newTestCommitmentTx(
+			[]wire.OutPoint{intent.Outpoint},
+		)
+
+		state := &PartialSigsSentState{
+			RoundID:      "round-001",
+			CommitmentTx: commitmentTx,
+			VTXTTree:     vtxtTree,
+			Intents:      []BoardingIntent{intent},
+			ClientTrees:  make(map[SignerKey]*tree.Tree),
+			BoardingInputIndices: map[wire.OutPoint]int{
+				intent.Outpoint: 0,
+			},
+		}
+		h.withState(state)
+
+		event := &OperatorSigned{
+			OperatorSignedEvent: OperatorSignedEvent{
+				RoundID:    "round-001",
+				Signatures: [][]byte{},
+			},
+		}
+
+		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		failedState := assertStateType[*ClientFailedState](h)
+		require.Contains(t, failedState.Reason, "signature")
+	})
+
+	t.Run("invalid_signature_format_error", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+
+		intent := h.newTestBoardingIntent()
+		vtxtTree := h.newTestVTXOTreeForIntent(intent)
+		commitmentTx := h.newTestCommitmentTx(
+			[]wire.OutPoint{intent.Outpoint},
+		)
+
+		state := &PartialSigsSentState{
+			RoundID:      "round-001",
+			CommitmentTx: commitmentTx,
+			VTXTTree:     vtxtTree,
+			Intents:      []BoardingIntent{intent},
+			ClientTrees:  make(map[SignerKey]*tree.Tree),
+			BoardingInputIndices: map[wire.OutPoint]int{
+				intent.Outpoint: 0,
+			},
+		}
+		h.withState(state)
+
+		event := &OperatorSigned{
+			OperatorSignedEvent: OperatorSignedEvent{
+				RoundID:    "round-001",
+				Signatures: [][]byte{make([]byte, 10)},
+			},
+		}
+
+		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		failedState := assertStateType[*ClientFailedState](h)
+		require.Contains(t, failedState.Reason, "signature")
+	})
+
+	t.Run("missing_input_index_error", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+
+		intent := h.newTestBoardingIntent()
+		vtxtTree := h.newTestVTXOTreeForIntent(intent)
+		commitmentTx := h.newTestCommitmentTx(
+			[]wire.OutPoint{intent.Outpoint},
+		)
+
+		state := &PartialSigsSentState{
+			RoundID:              "round-001",
+			CommitmentTx:         commitmentTx,
+			VTXTTree:             vtxtTree,
+			Intents:              []BoardingIntent{intent},
+			ClientTrees:          make(map[SignerKey]*tree.Tree),
+			BoardingInputIndices: make(map[wire.OutPoint]int),
+			Musig2Sessions: make(
+				map[SignerKey]*tree.SignerSession,
+			),
+		}
+		h.withState(state)
+
+		validSig := make([]byte, 64)
+		for i := range validSig {
+			validSig[i] = byte(i + 1)
+		}
+
+		event := &OperatorSigned{
+			OperatorSignedEvent: OperatorSignedEvent{
+				RoundID:    "round-001",
+				Signatures: [][]byte{validSig},
+			},
+		}
+
+		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		failedState := assertStateType[*ClientFailedState](h)
+		require.Contains(t, failedState.Reason, "signature")
+	})
+
+	t.Run("too_few_signatures_error", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+
+		intent := h.newTestBoardingIntent()
+		vtxtTree := h.newTestVTXOTreeForIntent(intent)
+		commitmentTx := h.newTestCommitmentTx(
+			[]wire.OutPoint{intent.Outpoint},
+		)
+
+		state := &PartialSigsSentState{
+			RoundID:      "round-001",
+			CommitmentTx: commitmentTx,
+			VTXTTree:     vtxtTree,
+			Intents:      []BoardingIntent{intent},
+			ClientTrees:  make(map[SignerKey]*tree.Tree),
+			BoardingInputIndices: map[wire.OutPoint]int{
+				intent.Outpoint: 0,
+			},
+		}
+		h.withState(state)
+
+		nodeCount := 0
+		_ = vtxtTree.Root.ForEach(func(n *tree.Node) error {
+			nodeCount++
+			return nil
+		})
+
+		if nodeCount > 1 {
+			event := &OperatorSigned{
+				OperatorSignedEvent: OperatorSignedEvent{
+					RoundID:    "round-001",
+					Signatures: [][]byte{make([]byte, 64)},
+				},
+			}
+
+			transition, err := h.sendEvent(event)
+			require.NoError(t, err)
+			require.NotNil(t, transition)
+
+			failedState := assertStateType[*ClientFailedState](h)
+			require.Contains(t, failedState.Reason, "signature")
+		}
+	})
+}
+
+func TestInputSigSentState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("BoardingConfirmed_transitions", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+		h.setupMockVTXOStoreForSave()
+
+		intent := h.newTestBoardingIntent()
+		state := h.newInputSigSentState(
+			"round-001", []BoardingIntent{intent},
+		)
+		h.withState(state)
+
+		event := &BoardingConfirmed{
+			TxID:          state.CommitmentTx.TxHash(),
+			BlockHeight:   101,
+			Confirmations: 6,
+		}
+
+		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		confirmedState := assertStateType[*ConfirmedState](h)
+		require.Equal(t, int32(101), confirmedState.BlockHeight)
+		require.Equal(t, int32(6), confirmedState.Confirmations)
+
+		h.assertOutboxLen(2)
+		h.vtxoStore.AssertCalled(t, "SaveVTXOs", mock.Anything)
+	})
+
+	t.Run("buildClientVTXOs_error", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+
+		vtxtTree, _ := h.newTestVTXOTree(1)
+		intent := h.newTestBoardingIntent()
+
+		// Empty ClientTrees will cause buildClientVTXOs to fail.
+		state := &InputSigSentState{
+			RoundID:     "round-001",
+			VTXTTree:    vtxtTree,
+			Intents:     []BoardingIntent{intent},
+			ClientTrees: make(map[SignerKey]*tree.Tree),
+		}
+		h.withState(state)
+
+		event := &BoardingConfirmed{
+			TxID:          vtxtTree.BatchOutpoint.Hash,
+			BlockHeight:   101,
+			Confirmations: 6,
+		}
+
+		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		failedState := assertStateType[*ClientFailedState](h)
+		require.Contains(t, failedState.Reason, "build client VTXOs")
+	})
+}
+
+func TestConfirmedState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("RoundComplete_transitions_to_idle", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+		h.withState(&ConfirmedState{BlockHeight: 100})
+
+		transition, err := h.sendEvent(&RoundComplete{})
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		_ = assertStateType[*Idle](h)
+	})
+}
+
+func TestClientFailedState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("RecoveryInitiated_transitions", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+
+		intent := h.newTestBoardingIntent()
+		h.withState(&ClientFailedState{
+			Reason:      "round failed",
+			Recoverable: true,
+		})
+
+		event := &RecoveryInitiated{
+			Outpoint: intent.Outpoint,
+			Reason:   "CSV timeout recovery",
+		}
+
+		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		recoveryState := assertStateType[*RecoveryInitiatedState](h)
+		require.Equal(t, intent.Outpoint, recoveryState.Outpoint)
+		require.Equal(t, "CSV timeout recovery", recoveryState.Reason)
+	})
+}
+
+func TestValidateBoardingInputs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil_tx", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+		intent := h.newTestBoardingIntent()
+		intents := []BoardingIntent{intent}
+
+		result, err := validateBoardingInputs(nil, intents)
+
+		require.Error(t, err)
+		require.Nil(t, result)
+		require.Contains(t, err.Error(), "commitment tx is nil")
+	})
+
+	t.Run("empty_intents", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+		tx := h.newTestCommitmentTx(nil)
+
+		result, err := validateBoardingInputs(tx, []BoardingIntent{})
+
+		require.Error(t, err)
+		require.Nil(t, result)
+		require.Contains(t, err.Error(), "no boarding intents")
+	})
+
+	t.Run("missing_outpoint", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+		intent := h.newTestBoardingIntent()
+		differentOutpoint := h.newTestOutpoint()
+		tx := h.newTestCommitmentTx([]wire.OutPoint{differentOutpoint})
+		intents := []BoardingIntent{intent}
+
+		result, err := validateBoardingInputs(tx, intents)
+
+		require.Error(t, err)
+		require.Nil(t, result)
+		require.Contains(t, err.Error(), "not found in commitment tx")
+	})
+
+	t.Run("success_single", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+		intent := h.newTestBoardingIntent()
+		tx := h.newTestCommitmentTx([]wire.OutPoint{intent.Outpoint})
+		intents := []BoardingIntent{intent}
+
+		result, err := validateBoardingInputs(tx, intents)
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Len(t, result, 1)
+
+		idx, found := result[intent.Outpoint]
+		require.True(t, found)
+		require.Equal(t, 0, idx)
+	})
+
+	t.Run("success_multiple", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+		intent1 := h.newTestBoardingIntent()
+		intent2 := h.newTestBoardingIntent()
+		intent3 := h.newTestBoardingIntent()
+
+		tx := h.newTestCommitmentTx([]wire.OutPoint{
+			intent1.Outpoint,
+			intent2.Outpoint,
+			intent3.Outpoint,
+		})
+
+		intents := []BoardingIntent{intent1, intent2, intent3}
+		result, err := validateBoardingInputs(tx, intents)
+
+		require.NoError(t, err)
+		require.Len(t, result, 3)
+		require.Equal(t, 0, result[intent1.Outpoint])
+		require.Equal(t, 1, result[intent2.Outpoint])
+		require.Equal(t, 2, result[intent3.Outpoint])
+	})
+}
+
+func TestNewSignerKey(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid_key", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+		result := NewSignerKey(h.clientPubKey)
+
+		// SignerKey is [33]byte (compressed pubkey).
+		require.Len(t, result, 33)
+		require.Equal(
+			t, h.clientPubKey.SerializeCompressed(), result[:],
+		)
+	})
+
+	t.Run("deterministic", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+		result1 := NewSignerKey(h.clientPubKey)
+		result2 := NewSignerKey(h.clientPubKey)
+
+		require.Equal(t, result1, result2)
+	})
+}
+
+func TestBoardingFlowIdleToPendingToRegistrationSent(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+
+	intent := h.newTestBoardingIntent()
+	intentsMap := map[wire.OutPoint]BoardingIntent{intent.Outpoint: intent}
+	h.withState(&PendingRoundAssembly{Intents: intentsMap})
+
+	// Step 1: Request registration.
+	regEvent := &RegistrationRequested{Intents: []BoardingIntent{intent}}
+	_, err := h.sendEvent(regEvent)
+	require.NoError(t, err)
+
+	regState := assertStateType[*RegistrationSentState](h)
+	require.Len(t, regState.Intents, 1)
+
+	// Step 2: Server accepts.
+	joinEvent := &RoundJoined{RoundID: "round-001"}
+	_, err = h.sendEvent(joinEvent)
+	require.NoError(t, err)
+
+	joinedState := assertStateType[*RoundJoinedState](h)
+	require.Equal(t, "round-001", joinedState.RoundID)
+}
+
+func TestBoardingFlowMultipleIntentsAccumulation(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+	h.withState(&Idle{})
+
+	// We confirm multiple UTXOs to verify that PendingRoundAssembly
+	// correctly accumulates boarding intents as they arrive, rather than
+	// replacing or dropping previous ones.
+	for i := 0; i < 3; i++ {
+		intent := h.newTestBoardingIntent()
+		event := h.newBoardingUTXOConfirmedEvent(intent)
+
+		_, err := h.sendEvent(event)
+		require.NoError(t, err)
+
+		state := assertStateType[*PendingRoundAssembly](h)
+		require.Len(t, state.Intents, i+1)
+	}
+}
+
+func TestBoardingFlowPendingToRoundJoined(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+
+	intent := h.newTestBoardingIntent()
+	intentsMap := map[wire.OutPoint]BoardingIntent{intent.Outpoint: intent}
+	h.withState(&PendingRoundAssembly{Intents: intentsMap})
+
+	// Step 1: PendingRoundAssembly → RegistrationSentState.
+	regEvent := &RegistrationRequested{Intents: []BoardingIntent{intent}}
+	_, err := h.sendEvent(regEvent)
+	require.NoError(t, err)
+
+	regSentState := assertStateType[*RegistrationSentState](h)
+	require.Len(t, regSentState.Intents, 1)
+
+	// Step 2: RegistrationSentState → RoundJoinedState.
+	joinEvent := &RoundJoined{RoundID: "round-integration-001"}
+	_, err = h.sendEvent(joinEvent)
+	require.NoError(t, err)
+
+	joinedState := assertStateType[*RoundJoinedState](h)
+	require.Equal(t, "round-integration-001", joinedState.RoundID)
+}
+
+func TestBoardingFlowRoundJoinedToPartialSigsSent(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+	h.setupMockWalletForMuSig2()
+
+	intent := h.newTestBoardingIntent()
+
+	h.withState(&RoundJoinedState{
+		RoundID: "round-integration-002",
+		Intents: []BoardingIntent{intent},
+	})
+
+	// Step 1: RoundJoined → CommitmentTxReceived.
+	vtxtTree := h.newTestVTXOTreeForIntent(intent)
+	commitEvent := h.newCommitmentTxBuiltEvent(
+		"round-integration-002", []BoardingIntent{intent}, vtxtTree,
+	)
+	_, err := h.sendEvent(commitEvent)
+	require.NoError(t, err)
+
+	ctxReceivedState := assertStateType[*CommitmentTxReceivedState](h)
+	require.NotNil(t, ctxReceivedState.CommitmentTx)
+
+	// Step 2: CommitmentTxReceived → CommitmentTxValidated.
+	_, err = h.sendEvent(&CommitmentTxBuilt{
+		CommitmentTxBuiltEvent: CommitmentTxBuiltEvent{
+			RoundID:  "round-integration-002",
+			Tx:       ctxReceivedState.CommitmentTx,
+			VTXTTree: ctxReceivedState.VTXTTree,
+		},
+	})
+	require.NoError(t, err)
+
+	ctxValidatedState := assertStateType[*CommitmentTxValidatedState](h)
+	require.NotEmpty(t, ctxValidatedState.BoardingInputIndices)
+	h.clearOutbox()
+
+	// Step 3: CommitmentTxValidated → NoncesSent.
+	_, err = h.sendEvent(&GenerateNonces{})
+	require.NoError(t, err)
+
+	noncesSentState := assertStateType[*NoncesSentState](h)
+	require.NotEmpty(t, noncesSentState.Musig2Sessions)
+	h.clearOutbox()
+
+	// Step 4: NoncesSent → NoncesAggregated.
+	aggNoncesEvent := h.newNoncesAggregatedEvent(
+		"round-integration-002", noncesSentState.VTXTTree,
+	)
+	_, err = h.sendEvent(aggNoncesEvent)
+	require.NoError(t, err)
+
+	noncesAggState := assertStateType[*NoncesAggregatedState](h)
+	require.NotEmpty(t, noncesAggState.AggregatedNonces)
+	h.clearOutbox()
+
+	// Step 5: NoncesAggregated → PartialSigsSent.
+	_, err = h.sendEvent(&GeneratePartialSigs{})
+	require.NoError(t, err)
+
+	partialSigsState := assertStateType[*PartialSigsSentState](h)
+	require.Equal(t, "round-integration-002", partialSigsState.RoundID)
+}
+
+func TestBoardingFlowFailureAndRecovery(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+
+	intent := h.newTestBoardingIntent()
+	h.withState(&RoundJoinedState{
+		RoundID: "round-fail-001",
+		Intents: []BoardingIntent{intent},
+	})
+
+	// We inject a failure event to verify the state machine correctly
+	// transitions to ClientFailedState, preserving the failure reason
+	// and recoverability flag for later recovery attempts.
+	_, err := h.sendEvent(&BoardingFailed{
+		Reason:      "operator went offline",
+		Recoverable: true,
+	})
+	require.NoError(t, err)
+
+	failedState := assertStateType[*ClientFailedState](h)
+	require.Equal(t, "operator went offline", failedState.Reason)
+
+	// After failure, we verify recovery can be initiated by transitioning
+	// to RecoveryInitiatedState, which triggers CSV timeout-based fund
+	// recovery.
+	_, err = h.sendEvent(&RecoveryInitiated{
+		Outpoint: intent.Outpoint,
+		Reason:   "CSV timeout recovery",
+	})
+	require.NoError(t, err)
+
+	recoveryState := assertStateType[*RecoveryInitiatedState](h)
+	require.Equal(t, intent.Outpoint, recoveryState.Outpoint)
+}

--- a/round/validation.go
+++ b/round/validation.go
@@ -1,0 +1,162 @@
+//nolint:ll
+package round
+
+import (
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/lightninglabs/darepo-client/lib/scripts"
+	"github.com/lightninglabs/darepo-client/lib/types"
+)
+
+// ValidateBoardingScript validates that a boarding tapscript has the
+// expected structure with collaborative and timeout paths.
+func ValidateBoardingScript(tapscript *waddrmgr.Tapscript,
+	clientKey *btcec.PublicKey, operatorKey *btcec.PublicKey,
+	expectedExitDelay uint32) error {
+
+	if tapscript == nil {
+		return fmt.Errorf("tapscript is nil")
+	}
+
+	// Ensure control block is present for taproot spending.
+	if tapscript.ControlBlock == nil {
+		return fmt.Errorf("tapscript control block is nil")
+	}
+
+	// Verify the internal key exists for taproot construction.
+	if tapscript.ControlBlock.InternalKey == nil {
+		return fmt.Errorf("control block internal key is nil")
+	}
+
+	// Ensure the internal key is unspendable (ARK NUMS key) to force
+	// script path spending only.
+	if !tapscript.ControlBlock.InternalKey.IsEqual(&scripts.ARKNUMSKey) {
+		return fmt.Errorf("internal key is not ARK NUMS key")
+	}
+
+	// For full tree types, verify we have both the collaborative and
+	// timeout script paths by constructing the expected script and comparing.
+	if tapscript.Type == waddrmgr.TapscriptTypeFullTree {
+		if len(tapscript.Leaves) != 2 {
+			return fmt.Errorf("boarding script has %d leaves, "+
+				"expected 2", len(tapscript.Leaves))
+		}
+
+		// Construct the expected boarding tapscript using lib function.
+		// This ensures we validate against the exact script structure
+		// that lib creates.
+		expectedTapscript, err := scripts.VTXOTapScript(
+			clientKey, operatorKey, expectedExitDelay,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to construct expected boarding "+
+				"script: %w", err)
+		}
+
+		if len(expectedTapscript.Leaves) != 2 {
+			return fmt.Errorf("expected tapscript has %d leaves, "+
+				"should be 2", len(expectedTapscript.Leaves))
+		}
+
+		// Compare each leaf script byte-for-byte. The order may vary,
+		// so we check if each actual leaf matches one of the expected leaves.
+		actualLeaves := make(map[string]bool)
+		for _, leaf := range tapscript.Leaves {
+			actualLeaves[string(leaf.Script)] = true
+		}
+
+		for i, expectedLeaf := range expectedTapscript.Leaves {
+			if !actualLeaves[string(expectedLeaf.Script)] {
+				return fmt.Errorf("expected leaf %d script not found "+
+					"in actual boarding script", i)
+			}
+		}
+	}
+
+	return nil
+}
+
+// ValidateBoardingSignature validates a boarding input signature from a
+// client. This verifies the signature is for the collaborative spend path
+// and signs the commitment transaction correctly.
+func ValidateBoardingSignature(commitmentTx *wire.MsgTx,
+	boardingRequest *types.BoardingRequest, signature []byte,
+	inputIndex int) error {
+
+	if commitmentTx == nil {
+		return fmt.Errorf("commitment tx is nil")
+	}
+	if boardingRequest == nil {
+		return fmt.Errorf("boarding request is nil")
+	}
+
+	// Schnorr signatures are always 64 bytes (R || s).
+	if len(signature) != 64 {
+		return fmt.Errorf("invalid signature length: %d, "+
+			"expected 64", len(signature))
+	}
+
+	if inputIndex < 0 || inputIndex >= len(commitmentTx.TxIn) {
+		return fmt.Errorf("input index %d out of range", inputIndex)
+	}
+
+	// Ensure the input being signed actually corresponds to the boarding
+	// UTXO to prevent signature reuse attacks.
+	txIn := commitmentTx.TxIn[inputIndex]
+	outpoint := boardingRequest.Outpoint
+	if !txIn.PreviousOutPoint.Hash.IsEqual(&outpoint.Hash) ||
+		txIn.PreviousOutPoint.Index != outpoint.Index {
+
+		return fmt.Errorf("input %d does not reference boarding "+
+			"UTXO", inputIndex)
+	}
+
+	// TODO: Verify the signature is valid for the collaborative spend
+	// path. This requires:
+	// 1. Computing the sighash for the tapscript spend
+	// 2. Parsing the Schnorr signature
+	// 3. Verifying against the client's public key
+	//
+	// This will be implemented in Phase 2 when we add full signing logic.
+
+	return nil
+}
+
+// ValidateDelayParameters validates the delay parameters for security.
+//
+// SweepDelay MUST be greater than VTXOExitDelay to ensure the operator has
+// time to respond to unilateral exits before the batch expires.
+func ValidateDelayParameters(sweepDelay, vtxoExitDelay uint32) error {
+	// Both delays must be non-zero.
+	if sweepDelay == 0 {
+		return fmt.Errorf("sweep delay is zero")
+	}
+	if vtxoExitDelay == 0 {
+		return fmt.Errorf("VTXO exit delay is zero")
+	}
+
+	// Sweep delay must be greater than VTXO exit delay for security.
+	// This ensures the operator has time to respond to griefing attacks.
+	if sweepDelay <= vtxoExitDelay {
+		return fmt.Errorf("sweep delay (%d) must be greater than "+
+			"VTXO exit delay (%d)", sweepDelay, vtxoExitDelay)
+	}
+
+	// Sanity check: Delays should be reasonable (less than ~1 year).
+	const maxReasonableDelay = 52560 // ~1 year in blocks (10 min blocks)
+	if sweepDelay > maxReasonableDelay {
+		return fmt.Errorf("sweep delay (%d) exceeds maximum "+
+			"reasonable "+
+			"value (%d blocks)", sweepDelay, maxReasonableDelay)
+	}
+	if vtxoExitDelay > maxReasonableDelay {
+		return fmt.Errorf("VTXO exit delay (%d) exceeds maximum "+
+			"reasonable value (%d blocks)", vtxoExitDelay,
+			maxReasonableDelay)
+	}
+
+	return nil
+}

--- a/round/validation_test.go
+++ b/round/validation_test.go
@@ -1,0 +1,493 @@
+package round
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/lightninglabs/darepo-client/lib/scripts"
+	"github.com/lightninglabs/darepo-client/lib/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateDelayParametersValid(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateDelayParameters(1008, 144)
+	require.NoError(t, err)
+}
+
+func TestValidateDelayParametersZeroSweepDelay(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateDelayParameters(0, 144)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "sweep delay is zero")
+}
+
+func TestValidateDelayParametersZeroExitDelay(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateDelayParameters(1008, 0)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "VTXO exit delay is zero")
+}
+
+func TestValidateDelayParametersSweepNotGreaterThanExit(t *testing.T) {
+	t.Parallel()
+
+	// Sweep delay must strictly exceed exit delay to ensure users have time
+	// to respond after the exit path becomes available.
+	err := ValidateDelayParameters(144, 144)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "must be greater than")
+
+	err = ValidateDelayParameters(100, 144)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "must be greater than")
+}
+
+func TestValidateDelayParametersSweepDelayTooLarge(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateDelayParameters(60000, 144)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds maximum reasonable")
+}
+
+func TestValidateDelayParametersExitDelayTooLarge(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateDelayParameters(100000, 60000)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds maximum reasonable")
+}
+
+func TestValidateDelayParametersBoundaryValues(t *testing.T) {
+	t.Parallel()
+
+	// Maximum reasonable delay is 52560 blocks (approximately 1 year).
+	err := ValidateDelayParameters(52560, 52559)
+	require.NoError(t, err)
+
+	err = ValidateDelayParameters(52561, 144)
+	require.Error(t, err)
+}
+
+func TestValidateBoardingSignatureNilCommitmentTx(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+	intent := h.newTestBoardingIntent()
+
+	err := ValidateBoardingSignature(
+		nil, &intent.BoardingRequest, make([]byte, 64), 0,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "commitment tx is nil")
+}
+
+func TestValidateBoardingSignatureNilBoardingRequest(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+	intent := h.newTestBoardingIntent()
+	tx := h.newTestCommitmentTx([]wire.OutPoint{intent.Outpoint})
+
+	err := ValidateBoardingSignature(tx, nil, make([]byte, 64), 0)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "boarding request is nil")
+}
+
+func TestValidateBoardingSignatureInvalidLength(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+	intent := h.newTestBoardingIntent()
+	tx := h.newTestCommitmentTx([]wire.OutPoint{intent.Outpoint})
+
+	// Schnorr signatures must be exactly 64 bytes.
+	err := ValidateBoardingSignature(
+		tx, &intent.BoardingRequest, make([]byte, 32), 0,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid signature length")
+
+	err = ValidateBoardingSignature(
+		tx, &intent.BoardingRequest, make([]byte, 128), 0,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid signature length")
+}
+
+func TestValidateBoardingSignatureInputIndexOutOfRange(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+	intent := h.newTestBoardingIntent()
+	tx := h.newTestCommitmentTx([]wire.OutPoint{intent.Outpoint})
+
+	err := ValidateBoardingSignature(
+		tx, &intent.BoardingRequest, make([]byte, 64), -1,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "input index")
+
+	err = ValidateBoardingSignature(
+		tx, &intent.BoardingRequest, make([]byte, 64), 5,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "out of range")
+}
+
+func TestValidateBoardingSignatureInputMismatch(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+	intent := h.newTestBoardingIntent()
+
+	// Signature must be for the specific boarding UTXO being committed.
+	differentOutpoint := h.newTestOutpoint()
+	tx := h.newTestCommitmentTx([]wire.OutPoint{differentOutpoint})
+
+	err := ValidateBoardingSignature(
+		tx, &intent.BoardingRequest, make([]byte, 64), 0,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not reference boarding UTXO")
+}
+
+func TestValidateBoardingSignatureValid(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+	intent := h.newTestBoardingIntent()
+	tx := h.newTestCommitmentTx([]wire.OutPoint{intent.Outpoint})
+
+	// Signature structure validation only; cryptographic verification is
+	// performed separately in the signing flow.
+	err := ValidateBoardingSignature(
+		tx, &intent.BoardingRequest, make([]byte, 64), 0,
+	)
+	require.NoError(t, err)
+}
+
+func TestValidateBoardingScriptNilTapscript(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+	err := ValidateBoardingScript(
+		nil, h.clientPubKey, h.operatorPubKey, testExitDelay,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "tapscript is nil")
+}
+
+func TestValidateBoardingScriptNilControlBlock(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+	tapscript := &waddrmgr.Tapscript{
+		ControlBlock: nil,
+	}
+
+	err := ValidateBoardingScript(
+		tapscript, h.clientPubKey, h.operatorPubKey, testExitDelay,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "control block is nil")
+}
+
+func TestValidateBoardingScriptNilInternalKey(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+	tapscript := &waddrmgr.Tapscript{
+		ControlBlock: &txscript.ControlBlock{
+			InternalKey: nil,
+		},
+	}
+
+	err := ValidateBoardingScript(
+		tapscript, h.clientPubKey, h.operatorPubKey, testExitDelay,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "internal key is nil")
+}
+
+func TestValidateBoardingScriptWrongInternalKey(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+
+	// Internal key must be the ARK NUMS key to prevent anyone from
+	// spending via the key path, forcing all spends through scripts.
+	_, wrongKey := generateTestKeyPair(t)
+
+	tapscript := &waddrmgr.Tapscript{
+		ControlBlock: &txscript.ControlBlock{
+			InternalKey: wrongKey,
+		},
+	}
+
+	err := ValidateBoardingScript(
+		tapscript, h.clientPubKey, h.operatorPubKey, testExitDelay,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not ARK NUMS key")
+}
+
+func TestValidateBoardingScriptFullTreeWrongLeafCount(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+
+	// Boarding scripts have exactly 2 leaves: operator sweep and client
+	// exit paths.
+	tapscript := &waddrmgr.Tapscript{
+		Type: waddrmgr.TapscriptTypeFullTree,
+		ControlBlock: &txscript.ControlBlock{
+			InternalKey: &scripts.ARKNUMSKey,
+		},
+		Leaves: []txscript.TapLeaf{
+			{Script: []byte{0x01}},
+		},
+	}
+
+	err := ValidateBoardingScript(
+		tapscript, h.clientPubKey, h.operatorPubKey, testExitDelay,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "expected 2")
+}
+
+func TestValidateDelayParametersTableDriven(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name          string
+		sweepDelay    uint32
+		vtxoExitDelay uint32
+		expectError   bool
+		errorMsg      string
+	}{
+		{
+			name:          "valid typical values",
+			sweepDelay:    1008,
+			vtxoExitDelay: 144,
+			expectError:   false,
+		},
+		{
+			name:          "valid minimum difference",
+			sweepDelay:    2,
+			vtxoExitDelay: 1,
+			expectError:   false,
+		},
+		{
+			name:          "valid at boundary",
+			sweepDelay:    52560,
+			vtxoExitDelay: 52559,
+			expectError:   false,
+		},
+		{
+			name:          "zero sweep delay",
+			sweepDelay:    0,
+			vtxoExitDelay: 144,
+			expectError:   true,
+			errorMsg:      "sweep delay is zero",
+		},
+		{
+			name:          "zero exit delay",
+			sweepDelay:    1008,
+			vtxoExitDelay: 0,
+			expectError:   true,
+			errorMsg:      "exit delay is zero",
+		},
+		{
+			name:          "both zero",
+			sweepDelay:    0,
+			vtxoExitDelay: 0,
+			expectError:   true,
+			errorMsg:      "sweep delay is zero",
+		},
+		{
+			name:          "sweep equals exit",
+			sweepDelay:    144,
+			vtxoExitDelay: 144,
+			expectError:   true,
+			errorMsg:      "must be greater than",
+		},
+		{
+			name:          "sweep less than exit",
+			sweepDelay:    100,
+			vtxoExitDelay: 200,
+			expectError:   true,
+			errorMsg:      "must be greater than",
+		},
+		{
+			name:          "sweep exceeds max",
+			sweepDelay:    52561,
+			vtxoExitDelay: 144,
+			expectError:   true,
+			errorMsg:      "exceeds maximum",
+		},
+		{
+			name:          "exit exceeds max",
+			sweepDelay:    100000,
+			vtxoExitDelay: 60000,
+			expectError:   true,
+			errorMsg:      "exceeds maximum",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := ValidateDelayParameters(
+				tc.sweepDelay, tc.vtxoExitDelay,
+			)
+			if tc.expectError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.errorMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateBoardingSignatureTableDriven(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+	intent := h.newTestBoardingIntent()
+
+	testCases := []struct {
+		name        string
+		setupTx     func() *wire.MsgTx
+		request     *types.BoardingRequest
+		sigLen      int
+		inputIndex  int
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "valid signature",
+			setupTx: func() *wire.MsgTx {
+				inputs := []wire.OutPoint{intent.Outpoint}
+				return h.newTestCommitmentTx(inputs)
+			},
+			request:     &intent.BoardingRequest,
+			sigLen:      64,
+			inputIndex:  0,
+			expectError: false,
+		},
+		{
+			name: "nil commitment tx",
+			setupTx: func() *wire.MsgTx {
+				return nil
+			},
+			request:     &intent.BoardingRequest,
+			sigLen:      64,
+			inputIndex:  0,
+			expectError: true,
+			errorMsg:    "commitment tx is nil",
+		},
+		{
+			name: "nil boarding request",
+			setupTx: func() *wire.MsgTx {
+				inputs := []wire.OutPoint{intent.Outpoint}
+				return h.newTestCommitmentTx(inputs)
+			},
+			request:     nil,
+			sigLen:      64,
+			inputIndex:  0,
+			expectError: true,
+			errorMsg:    "boarding request is nil",
+		},
+		{
+			name: "signature too short",
+			setupTx: func() *wire.MsgTx {
+				inputs := []wire.OutPoint{intent.Outpoint}
+				return h.newTestCommitmentTx(inputs)
+			},
+			request:     &intent.BoardingRequest,
+			sigLen:      32,
+			inputIndex:  0,
+			expectError: true,
+			errorMsg:    "invalid signature length",
+		},
+		{
+			name: "signature too long",
+			setupTx: func() *wire.MsgTx {
+				inputs := []wire.OutPoint{intent.Outpoint}
+				return h.newTestCommitmentTx(inputs)
+			},
+			request:     &intent.BoardingRequest,
+			sigLen:      128,
+			inputIndex:  0,
+			expectError: true,
+			errorMsg:    "invalid signature length",
+		},
+		{
+			name: "negative input index",
+			setupTx: func() *wire.MsgTx {
+				inputs := []wire.OutPoint{intent.Outpoint}
+				return h.newTestCommitmentTx(inputs)
+			},
+			request:     &intent.BoardingRequest,
+			sigLen:      64,
+			inputIndex:  -1,
+			expectError: true,
+			errorMsg:    "out of range",
+		},
+		{
+			name: "input index too large",
+			setupTx: func() *wire.MsgTx {
+				inputs := []wire.OutPoint{intent.Outpoint}
+				return h.newTestCommitmentTx(inputs)
+			},
+			request:     &intent.BoardingRequest,
+			sigLen:      64,
+			inputIndex:  10,
+			expectError: true,
+			errorMsg:    "out of range",
+		},
+		{
+			name: "input mismatch",
+			setupTx: func() *wire.MsgTx {
+				differentOutpoint := h.newTestOutpoint()
+				inputs := []wire.OutPoint{differentOutpoint}
+				return h.newTestCommitmentTx(inputs)
+			},
+			request:     &intent.BoardingRequest,
+			sigLen:      64,
+			inputIndex:  0,
+			expectError: true,
+			errorMsg:    "does not reference boarding UTXO",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tx := tc.setupTx()
+			sig := make([]byte, tc.sigLen)
+
+			err := ValidateBoardingSignature(
+				tx, tc.request, sig, tc.inputIndex,
+			)
+			if tc.expectError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.errorMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/vtxo/actor.go
+++ b/vtxo/actor.go
@@ -1,0 +1,275 @@
+package vtxo
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/chainsource"
+	"github.com/lightninglabs/darepo-client/round"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+)
+
+// VTXOActorServiceKey constructs a service key for a VTXO actor based on its
+// outpoint. This enables the round actor to send messages directly to specific
+// VTXO actors without routing through the manager.
+func VTXOActorServiceKey(outpoint wire.OutPoint) actor.ServiceKey[
+	VTXOEvent, VTXOActorResponse,
+] {
+	return actor.NewServiceKey[VTXOEvent, VTXOActorResponse](
+		fmt.Sprintf("vtxo.%s", outpoint.String()),
+	)
+}
+
+// VTXOActorConfig holds configuration for a single VTXO actor.
+type VTXOActorConfig struct {
+	VTXO         *VTXODescriptor
+	Store        VTXOStore
+	Wallet       VTXOWallet
+	ChainSource  actor.ActorRef[chainsource.ChainSourceMsg, chainsource.ChainSourceResp]
+	ChainParams  *chaincfg.Params
+	ExpiryConfig *ExpiryConfig
+	Logger       btclog.Logger
+
+	// RoundActor receives refresh requests and forfeit signatures from this
+	// VTXO actor.
+	RoundActor actor.TellOnlyRef[round.RoundActorMessage]
+
+	// ChainResolver receives expiring notifications for unilateral exit.
+	ChainResolver actor.TellOnlyRef[ExpiringNotification]
+
+	// Manager receives termination notifications for cleanup.
+	Manager actor.TellOnlyRef[ManagerMsg]
+}
+
+// VTXOActor manages the lifecycle of a single VTXO. It processes events using
+// the FSM state machine pattern, subscribes to block epochs for expiry
+// monitoring, and returns outbox messages for the caller to dispatch.
+type VTXOActor struct {
+	cfg   *VTXOActorConfig
+	state VTXOState
+	env   *VTXOEnvironment
+
+	selfRef actor.TellOnlyRef[VTXOEvent]
+}
+
+// NewVTXOActor creates a new VTXO actor with the given configuration.
+func NewVTXOActor(cfg *VTXOActorConfig) *VTXOActor {
+	actorID := fmt.Sprintf("vtxo.%s", cfg.VTXO.Outpoint.String())
+	env := NewVTXOEnvironment(
+		actorID, cfg.Store, cfg.Wallet, cfg.ExpiryConfig, cfg.ChainParams,
+	)
+
+	return &VTXOActor{
+		cfg:   cfg,
+		state: statusToState(cfg.VTXO),
+		env:   env,
+	}
+}
+
+// Start initializes the actor and subscribes to block epochs.
+func (a *VTXOActor) Start(ctx context.Context,
+	selfRef actor.TellOnlyRef[VTXOEvent]) error {
+
+	a.selfRef = selfRef
+
+	// Don't subscribe to epochs if already in a terminal state.
+	if a.state.IsTerminal() {
+		return nil
+	}
+
+	return a.subscribeBlockEpochs(ctx)
+}
+
+// Stop unsubscribes from block epochs.
+func (a *VTXOActor) Stop(ctx context.Context) {
+	a.unsubscribeBlockEpochs(ctx)
+}
+
+// Receive processes incoming events and returns outbox messages for dispatch.
+func (a *VTXOActor) Receive(ctx context.Context,
+	event VTXOEvent) fn.Result[VTXOActorResponse] {
+
+	transition, err := a.state.ProcessEvent(ctx, event, a.env)
+	if err != nil {
+		return fn.Err[VTXOActorResponse](fmt.Errorf("process event: %w", err))
+	}
+
+	priorState := a.state
+
+	// Type assert the next state to VTXOState.
+	nextState, ok := transition.NextState.(VTXOState)
+	if !ok {
+		return fn.Err[VTXOActorResponse](fmt.Errorf(
+			"unexpected state type: %T", transition.NextState,
+		))
+	}
+	a.state = nextState
+
+	// Unsubscribe from block epochs when reaching terminal state.
+	if a.state.IsTerminal() && !priorState.IsTerminal() {
+		a.unsubscribeBlockEpochs(ctx)
+	}
+
+	// Extract outbox messages for caller to dispatch.
+	var outbox []VTXOOutMsg
+	transition.NewEvents.WhenSome(func(emitted VTXOEmittedEvent) {
+		outbox = emitted.Outbox
+	})
+
+	// Process persistence updates immediately.
+	a.processOutbox(ctx, outbox)
+
+	return fn.Ok(VTXOActorResponse{
+		PriorState: priorState,
+		NewState:   a.state,
+		Outbox:     outbox,
+	})
+}
+
+// processOutbox routes outbox messages to their destinations. This includes
+// persistence updates, messages to the round actor, chain resolver, and
+// manager for cleanup.
+func (a *VTXOActor) processOutbox(ctx context.Context, outbox []VTXOOutMsg) {
+	for _, msg := range outbox {
+		switch m := msg.(type) {
+		case *VTXOStatusUpdate:
+			err := a.cfg.Store.UpdateVTXOStatus(ctx, m.Outpoint, m.NewStatus)
+			if err != nil {
+				a.cfg.Logger.ErrorS(ctx, "Failed to update VTXO status", err,
+					slog.String("outpoint", m.Outpoint.String()),
+					slog.String("status", m.NewStatus.String()))
+			}
+
+		case *RefreshRequest:
+			// Route refresh request to round actor.
+			if a.cfg.RoundActor != nil {
+				a.cfg.RoundActor.Tell(ctx, &round.RefreshVTXORequest{
+					VTXOOutpoint: m.VTXOOutpoint,
+					Amount:       m.Amount,
+				})
+				a.cfg.Logger.InfoS(ctx, "Sent refresh request",
+					slog.String("outpoint", m.VTXOOutpoint.String()),
+					slog.String("urgency", m.Urgency.String()))
+			}
+
+		case *ForfeitSignatureSubmission:
+			// Route forfeit signature to round actor.
+			if a.cfg.RoundActor != nil {
+				a.cfg.RoundActor.Tell(ctx, &round.ForfeitSignatureResponse{
+					VTXOOutpoint: m.VTXOOutpoint,
+					RoundID:      m.RoundID,
+					ForfeitTx:    m.ForfeitTx,
+					Signature:    m.Signature,
+				})
+				a.cfg.Logger.InfoS(ctx, "Sent forfeit signature",
+					slog.String("outpoint", m.VTXOOutpoint.String()),
+					slog.String("round_id", m.RoundID))
+			}
+
+		case *ExpiringNotification:
+			// Route to chain resolver for unilateral exit handling.
+			if a.cfg.ChainResolver != nil {
+				a.cfg.ChainResolver.Tell(ctx, *m)
+				a.cfg.Logger.WarnS(ctx, "VTXO sent to chain resolver", nil,
+					slog.String("outpoint", m.VTXO.Outpoint.String()),
+					slog.Int("blocks_remaining", int(m.BlocksRemaining)))
+			}
+
+		case *VTXOTerminatedNotification:
+			// Notify manager to remove this actor from tracking.
+			if a.cfg.Manager != nil {
+				a.cfg.Manager.Tell(ctx, &VTXOTerminatedMsg{
+					Outpoint:   m.VTXOOutpoint,
+					FinalState: m.FinalState,
+					Reason:     m.Reason,
+				})
+			}
+		}
+	}
+}
+
+// subscribeBlockEpochs registers for block notifications with chainsource.
+func (a *VTXOActor) subscribeBlockEpochs(ctx context.Context) error {
+	callerID := fmt.Sprintf("vtxo.%s", a.cfg.VTXO.Outpoint.String())
+
+	epochRef := chainsource.MapBlockEpoch(a.selfRef,
+		func(epoch chainsource.BlockEpoch) VTXOEvent {
+			return &BlockEpochEvent{
+				Height:    epoch.Height,
+				Hash:      epoch.Hash,
+				Timestamp: epoch.Timestamp,
+			}
+		},
+	)
+
+	req := &chainsource.SubscribeBlocksRequest{
+		CallerID:    callerID,
+		NotifyActor: fn.Some(epochRef),
+	}
+
+	future := a.cfg.ChainSource.Ask(ctx, req)
+	result := future.Await(ctx)
+	if result.IsErr() {
+		return fmt.Errorf("subscribe blocks: %w", result.Err())
+	}
+
+	a.cfg.Logger.DebugS(ctx, "Subscribed to block epochs",
+		slog.String("vtxo", a.cfg.VTXO.Outpoint.String()))
+
+	return nil
+}
+
+// unsubscribeBlockEpochs cancels the block epoch subscription.
+func (a *VTXOActor) unsubscribeBlockEpochs(ctx context.Context) {
+	callerID := fmt.Sprintf("vtxo.%s", a.cfg.VTXO.Outpoint.String())
+
+	a.cfg.ChainSource.Tell(ctx, &chainsource.UnsubscribeBlocksRequest{
+		CallerID: callerID,
+	})
+
+	a.cfg.Logger.DebugS(ctx, "Unsubscribed from block epochs",
+		slog.String("vtxo", a.cfg.VTXO.Outpoint.String()))
+}
+
+// CurrentState returns the actor's current FSM state.
+func (a *VTXOActor) CurrentState() VTXOState {
+	return a.state
+}
+
+// VTXOActorResponse is returned from processing an event.
+type VTXOActorResponse struct {
+	PriorState VTXOState
+	NewState   VTXOState
+	Outbox     []VTXOOutMsg
+}
+
+// statusToState converts a persisted VTXOStatus to the appropriate FSM state.
+func statusToState(vtxo *VTXODescriptor) VTXOState {
+	switch vtxo.Status {
+	case VTXOStatusLive:
+		return &LiveState{VTXO: vtxo, LastCheckedHeight: vtxo.CreatedHeight}
+
+	case VTXOStatusRefreshRequested:
+		return &RefreshRequestedState{VTXO: vtxo, RequestedAtHeight: 0}
+
+	case VTXOStatusForfeiting:
+		return &ForfeitingState{VTXO: vtxo, NewRoundID: vtxo.RoundID}
+
+	case VTXOStatusForfeited:
+		return &ForfeitedState{VTXO: vtxo, NewRoundID: vtxo.RoundID}
+
+	case VTXOStatusExpiring:
+		return &ExpiringState{VTXO: vtxo, Reason: "recovered from storage"}
+
+	case VTXOStatusFailed:
+		return &FailedState{VTXO: vtxo, Reason: "recovered from storage"}
+
+	default:
+		return &LiveState{VTXO: vtxo, LastCheckedHeight: vtxo.CreatedHeight}
+	}
+}

--- a/vtxo/events.go
+++ b/vtxo/events.go
@@ -1,0 +1,152 @@
+package vtxo
+
+import (
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/baselib/actor"
+)
+
+// VTXOEvent is a sealed interface for all events that can be processed by the
+// VTXO state machine. The sealed pattern prevents external packages from
+// adding unvalidated event types. Extends actor.Message for actor system
+// compatibility.
+type VTXOEvent interface {
+	actor.Message
+	vtxoEventSealed()
+}
+
+// BlockEpochEvent is received when a new block is connected to the blockchain.
+// This triggers expiry monitoring logic to check if the VTXO needs to be
+// refreshed or escalated to the chain resolver.
+type BlockEpochEvent struct {
+	actor.BaseMessage
+
+	// Height is the block height.
+	Height int32
+
+	// Hash is the block hash.
+	Hash chainhash.Hash
+
+	// Timestamp is the block timestamp from the header.
+	Timestamp int64
+}
+
+func (e *BlockEpochEvent) vtxoEventSealed() {}
+
+// MessageType returns the message type for logging.
+func (e *BlockEpochEvent) MessageType() string { return "BlockEpochEvent" }
+
+// ForfeitRequestEvent is received from the round actor when this VTXO is being
+// forfeited as part of a batch swap. The VTXO actor should sign the forfeit
+// transaction and transition to the forfeiting state.
+//
+// The forfeit transaction structure:
+//   - Input 0: VTXO being forfeited (collaborative spend - client + operator)
+//   - Input 1: Connector output from new commitment tx (operator key spend)
+//   - Output 0: Full VTXO value to operator's forfeit address
+//   - Output 1: Anchor output (zero-value P2A for CPFP)
+type ForfeitRequestEvent struct {
+	actor.BaseMessage
+
+	// RoundID is the new round where the refreshed VTXO will be created.
+	RoundID string
+
+	// ConnectorOutpoint is the connector output from the new commitment tx
+	// that the forfeit tx must spend. This links the forfeit atomically to
+	// the new round.
+	ConnectorOutpoint wire.OutPoint
+
+	// ConnectorPkScript is the scriptPubKey of the connector output.
+	ConnectorPkScript []byte
+
+	// ConnectorAmount is the value of the connector output in satoshis.
+	ConnectorAmount int64
+
+	// ServerForfeitPkScript is the operator's taproot script where the
+	// forfeited VTXO value will be paid.
+	ServerForfeitPkScript []byte
+}
+
+func (e *ForfeitRequestEvent) vtxoEventSealed() {}
+
+// MessageType returns the message type for logging.
+func (e *ForfeitRequestEvent) MessageType() string { return "ForfeitRequestEvent" }
+
+// ForfeitSignedEvent indicates the forfeit transaction has been signed and
+// submitted to the round. This is an internal event triggered after the VTXO
+// actor signs its portion of the forfeit transaction.
+type ForfeitSignedEvent struct {
+	actor.BaseMessage
+
+	// ForfeitTxID is the txid of the forfeit transaction.
+	ForfeitTxID chainhash.Hash
+}
+
+func (e *ForfeitSignedEvent) vtxoEventSealed() {}
+
+// MessageType returns the message type for logging.
+func (e *ForfeitSignedEvent) MessageType() string { return "ForfeitSignedEvent" }
+
+// ForfeitConfirmedEvent indicates the new commitment transaction has been
+// confirmed on-chain, meaning the forfeit is final. The old VTXO is now
+// permanently forfeited and the new VTXO is live.
+type ForfeitConfirmedEvent struct {
+	actor.BaseMessage
+
+	// CommitmentTxID is the new commitment transaction that was confirmed.
+	CommitmentTxID chainhash.Hash
+
+	// BlockHeight is the height at which confirmation occurred.
+	BlockHeight int32
+}
+
+func (e *ForfeitConfirmedEvent) vtxoEventSealed() {}
+
+// MessageType returns the message type for logging.
+func (e *ForfeitConfirmedEvent) MessageType() string { return "ForfeitConfirmedEvent" }
+
+// RefreshAcknowledgedEvent is received when the round actor acknowledges a
+// refresh request. This indicates the VTXO has been queued for inclusion in
+// the next round but the forfeit request hasn't been sent yet.
+type RefreshAcknowledgedEvent struct {
+	actor.BaseMessage
+
+	// RoundID is the round where the refresh will be processed.
+	RoundID string
+}
+
+func (e *RefreshAcknowledgedEvent) vtxoEventSealed() {}
+
+// MessageType returns the message type for logging.
+func (e *RefreshAcknowledgedEvent) MessageType() string { return "RefreshAcknowledgedEvent" }
+
+// VTXOFailedEvent indicates an error occurred during VTXO processing. This
+// transitions the VTXO to the failed state.
+type VTXOFailedEvent struct {
+	actor.BaseMessage
+
+	// Reason is a human-readable description of the failure.
+	Reason string
+
+	// Error is the underlying error, if any.
+	Error error
+
+	// Recoverable indicates whether the failure might be recoverable.
+	Recoverable bool
+}
+
+func (e *VTXOFailedEvent) vtxoEventSealed() {}
+
+// MessageType returns the message type for logging.
+func (e *VTXOFailedEvent) MessageType() string { return "VTXOFailedEvent" }
+
+// ResumeVTXOEvent is sent when resuming a VTXO actor from persisted state.
+// This is used during startup to restore actors from the database.
+type ResumeVTXOEvent struct {
+	actor.BaseMessage
+}
+
+func (e *ResumeVTXOEvent) vtxoEventSealed() {}
+
+// MessageType returns the message type for logging.
+func (e *ResumeVTXOEvent) MessageType() string { return "ResumeVTXOEvent" }

--- a/vtxo/expiry.go
+++ b/vtxo/expiry.go
@@ -1,0 +1,169 @@
+package vtxo
+
+// ExpiryStatus represents the result of an expiry check.
+type ExpiryStatus int
+
+const (
+	// ExpiryStatusSafe indicates the VTXO has plenty of time remaining.
+	ExpiryStatusSafe ExpiryStatus = iota
+
+	// ExpiryStatusNeedsRefresh indicates the VTXO should request refresh.
+	ExpiryStatusNeedsRefresh
+
+	// ExpiryStatusCritical indicates the VTXO must be sent to chain
+	// resolver.
+	ExpiryStatusCritical
+
+	// ExpiryStatusExpired indicates the batch has already expired.
+	ExpiryStatusExpired
+)
+
+// String returns a human-readable representation of the expiry status.
+func (s ExpiryStatus) String() string {
+	switch s {
+	case ExpiryStatusSafe:
+		return "safe"
+	case ExpiryStatusNeedsRefresh:
+		return "needs_refresh"
+	case ExpiryStatusCritical:
+		return "critical"
+	case ExpiryStatusExpired:
+		return "expired"
+	default:
+		return "unknown"
+	}
+}
+
+// ExpiryConfig holds configurable thresholds for VTXO expiry monitoring. These
+// thresholds determine when refresh requests are sent and when VTXOs are
+// escalated to the chain resolver.
+//
+// The dynamic calculation accounts for tree depth (each level requires an
+// additional on-chain transaction for unilateral exit) and CSV delays.
+type ExpiryConfig struct {
+	// RefreshThresholdBlocks is the base number of blocks before batch
+	// expiry at which a refresh request should be sent. The actual
+	// threshold is adjusted based on tree depth.
+	RefreshThresholdBlocks int32
+
+	// CriticalThresholdBlocks is the base number of blocks before batch
+	// expiry at which the VTXO is escalated to the chain resolver for
+	// unilateral exit. Must be less than RefreshThresholdBlocks.
+	CriticalThresholdBlocks int32
+
+	// MinRefreshBuffer is the minimum buffer (blocks) between refresh and
+	// critical thresholds, regardless of other calculations.
+	MinRefreshBuffer int32
+
+	// TreeDepthMultiplier is multiplied by tree depth to calculate the
+	// additional blocks needed for safe unilateral exit. Each tree level
+	// requires broadcasting and confirming an additional transaction.
+	TreeDepthMultiplier int32
+}
+
+// DefaultExpiryConfig returns sensible defaults for expiry configuration.
+// These values provide approximately 1 day of warning for refresh and 6 hours
+// of buffer before critical escalation on mainnet block times.
+func DefaultExpiryConfig() *ExpiryConfig {
+	return &ExpiryConfig{
+		RefreshThresholdBlocks:  144, // ~1 day before batch expiry.
+		CriticalThresholdBlocks: 36,  // ~6 hours before batch expiry.
+		MinRefreshBuffer:        72,  // At least ~12 hours buffer.
+		TreeDepthMultiplier:     6,   // ~1 hour per tree level.
+	}
+}
+
+// CheckExpiry evaluates a VTXO's expiry status given the current block height.
+// It considers both the batch expiry and the tree depth (which affects
+// unilateral exit time).
+//
+// The calculation ensures that:
+//  1. Critical threshold always allows enough time for unilateral exit
+//     (tree depth * multiplier + CSV delay).
+//  2. Refresh threshold is always at least MinRefreshBuffer blocks before
+//     critical.
+func (c *ExpiryConfig) CheckExpiry(
+	vtxo *VTXODescriptor, currentHeight int32,
+) ExpiryStatus {
+
+	blocksRemaining := vtxo.BatchExpiry - currentHeight
+
+	// If batch has already expired, status is expired.
+	if blocksRemaining <= 0 {
+		return ExpiryStatusExpired
+	}
+
+	// Calculate dynamic threshold based on tree depth. Deeper trees need
+	// more time for unilateral exit since each level requires broadcasting
+	// a transaction and waiting for confirmation.
+	treeDepthBuffer := int32(vtxo.TreeDepth) * c.TreeDepthMultiplier
+
+	// Add CSV delay - after the VTXO appears on-chain, we need to wait
+	// for the relative timelock before we can spend via the unilateral
+	// path.
+	csvBuffer := int32(vtxo.RelativeExpiry)
+
+	// Total buffer needed for safe unilateral exit.
+	safeExitBuffer := treeDepthBuffer + csvBuffer
+
+	// Critical threshold: must have enough time for unilateral exit.
+	criticalThreshold := max(c.CriticalThresholdBlocks, safeExitBuffer)
+
+	if blocksRemaining <= criticalThreshold {
+		return ExpiryStatusCritical
+	}
+
+	// Refresh threshold: should refresh well before critical.
+	refreshThreshold := max(
+		c.RefreshThresholdBlocks,
+		criticalThreshold+c.MinRefreshBuffer,
+	)
+
+	if blocksRemaining <= refreshThreshold {
+		return ExpiryStatusNeedsRefresh
+	}
+
+	return ExpiryStatusSafe
+}
+
+// BlocksUntilExpiry returns the number of blocks until batch expiry.
+func BlocksUntilExpiry(vtxo *VTXODescriptor, currentHeight int32) int32 {
+	return vtxo.BatchExpiry - currentHeight
+}
+
+// DetermineRefreshUrgency maps blocks remaining to urgency level.
+func (c *ExpiryConfig) DetermineRefreshUrgency(
+	blocksRemaining int32,
+) RefreshUrgency {
+
+	if blocksRemaining <= c.CriticalThresholdBlocks {
+		return RefreshUrgencyCritical
+	}
+
+	// Elevated if less than half the refresh threshold remaining.
+	if blocksRemaining <= c.RefreshThresholdBlocks/2 {
+		return RefreshUrgencyElevated
+	}
+
+	return RefreshUrgencyNormal
+}
+
+// CalculateCriticalThreshold returns the dynamic critical threshold for a VTXO
+// based on its tree depth and CSV delay.
+func (c *ExpiryConfig) CalculateCriticalThreshold(vtxo *VTXODescriptor) int32 {
+	treeDepthBuffer := int32(vtxo.TreeDepth) * c.TreeDepthMultiplier
+	csvBuffer := int32(vtxo.RelativeExpiry)
+	safeExitBuffer := treeDepthBuffer + csvBuffer
+
+	return max(c.CriticalThresholdBlocks, safeExitBuffer)
+}
+
+// CalculateRefreshThreshold returns the dynamic refresh threshold for a VTXO.
+func (c *ExpiryConfig) CalculateRefreshThreshold(vtxo *VTXODescriptor) int32 {
+	criticalThreshold := c.CalculateCriticalThreshold(vtxo)
+
+	return max(
+		c.RefreshThresholdBlocks,
+		criticalThreshold+c.MinRefreshBuffer,
+	)
+}

--- a/vtxo/fsm_environment.go
+++ b/vtxo/fsm_environment.go
@@ -1,0 +1,50 @@
+package vtxo
+
+import (
+	"github.com/btcsuite/btcd/chaincfg"
+)
+
+// VTXOEnvironment provides the VTXO state machine with access to external
+// systems and storage. This follows the protofsm pattern where the environment
+// contains all dependencies needed for state transitions.
+type VTXOEnvironment struct {
+	// name identifies this FSM instance (typically the VTXO outpoint
+	// string).
+	name string
+
+	// VTXOStore provides persistence for VTXO state.
+	VTXOStore VTXOStore
+
+	// Wallet provides signing capabilities for forfeit transactions.
+	Wallet VTXOWallet
+
+	// ExpiryConfig contains thresholds for expiry monitoring.
+	ExpiryConfig *ExpiryConfig
+
+	// ChainParams are the Bitcoin network parameters.
+	ChainParams *chaincfg.Params
+}
+
+// Name returns the unique identifier for this FSM instance.
+func (e *VTXOEnvironment) Name() string {
+	return e.name
+}
+
+// NewVTXOEnvironment creates a new VTXO environment with the provided
+// dependencies.
+func NewVTXOEnvironment(
+	name string,
+	vtxoStore VTXOStore,
+	wallet VTXOWallet,
+	expiryConfig *ExpiryConfig,
+	chainParams *chaincfg.Params,
+) *VTXOEnvironment {
+
+	return &VTXOEnvironment{
+		name:         name,
+		VTXOStore:    vtxoStore,
+		Wallet:       wallet,
+		ExpiryConfig: expiryConfig,
+		ChainParams:  chainParams,
+	}
+}

--- a/vtxo/interfaces.go
+++ b/vtxo/interfaces.go
@@ -1,0 +1,185 @@
+package vtxo
+
+import (
+	"context"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/lightninglabs/darepo-client/baselib/protofsm"
+	"github.com/lightninglabs/darepo-client/lib/tree"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/keychain"
+)
+
+// VTXOStateTransition is a type alias for the verbose protofsm.StateTransition
+// type used throughout the VTXO FSM. The baselib protofsm uses 3 type
+// parameters: InternalEvent, OutboxEvent, and Env. In our case:
+//   - InternalEvent = VTXOEvent (events that drive the FSM).
+//   - OutboxEvent = VTXOOutMsg (outbox messages emitted by transitions).
+//   - Env = *VTXOEnvironment.
+type VTXOStateTransition = protofsm.StateTransition[
+	VTXOEvent, VTXOOutMsg, *VTXOEnvironment,
+]
+
+// VTXOEmittedEvent is a type alias for the verbose protofsm.EmittedEvent type
+// used when state transitions emit new events or outbox messages.
+type VTXOEmittedEvent = protofsm.EmittedEvent[VTXOEvent, VTXOOutMsg]
+
+// VTXOStateMachine is a type alias for the VTXO FSM.
+type VTXOStateMachine = protofsm.StateMachine[
+	VTXOEvent, VTXOOutMsg, *VTXOEnvironment,
+]
+
+// VTXOStateMachineCfg is a type alias for the VTXO FSM configuration.
+type VTXOStateMachineCfg = protofsm.StateMachineCfg[
+	VTXOEvent, VTXOOutMsg, *VTXOEnvironment,
+]
+
+// VTXOStatus represents the lifecycle state of a VTXO.
+type VTXOStatus int
+
+const (
+	// VTXOStatusLive indicates the VTXO is active and can be spent.
+	VTXOStatusLive VTXOStatus = iota
+
+	// VTXOStatusRefreshRequested indicates a refresh has been requested but
+	// not yet completed via a new round.
+	VTXOStatusRefreshRequested
+
+	// VTXOStatusForfeiting indicates the VTXO is being forfeited in a
+	// round.
+	VTXOStatusForfeiting
+
+	// VTXOStatusForfeited indicates the VTXO has been forfeited
+	// (terminal).
+	VTXOStatusForfeited
+
+	// VTXOStatusExpiring indicates the VTXO is critically close to expiry
+	// and has been sent to the chain resolver (terminal for this actor).
+	VTXOStatusExpiring
+
+	// VTXOStatusFailed indicates an unrecoverable error (terminal).
+	VTXOStatusFailed
+)
+
+// String returns a human-readable representation of the VTXO status.
+func (s VTXOStatus) String() string {
+	switch s {
+	case VTXOStatusLive:
+		return "live"
+	case VTXOStatusRefreshRequested:
+		return "refresh_requested"
+	case VTXOStatusForfeiting:
+		return "forfeiting"
+	case VTXOStatusForfeited:
+		return "forfeited"
+	case VTXOStatusExpiring:
+		return "expiring"
+	case VTXOStatusFailed:
+		return "failed"
+	default:
+		return "unknown"
+	}
+}
+
+// VTXODescriptor contains all information needed to track and spend a VTXO.
+// This is the canonical representation persisted to storage and passed between
+// actors.
+type VTXODescriptor struct {
+	// Outpoint identifies the VTXO's location in the virtual transaction
+	// tree.
+	Outpoint wire.OutPoint
+
+	// Amount is the value of this VTXO in satoshis.
+	Amount btcutil.Amount
+
+	// PkScript is the output script for this VTXO (taproot with
+	// collaborative and timeout spend paths).
+	PkScript []byte
+
+	// ClientKey is the client's key descriptor for this VTXO.
+	ClientKey keychain.KeyDescriptor
+
+	// OperatorKey is the operator's public key for collaborative spends.
+	OperatorKey *btcec.PublicKey
+
+	// TapScript contains the full tapscript structure for this VTXO,
+	// including the internal key and all script paths. This is needed for
+	// signing forfeit transactions via the collaborative spend path.
+	TapScript *waddrmgr.Tapscript
+
+	// TreePath is the extracted path from the commitment transaction output
+	// down to this specific VTXO. Contains only the minimal tree nodes
+	// needed for unilateral exit.
+	TreePath *tree.Tree
+
+	// RoundID identifies which round created this VTXO.
+	RoundID string
+
+	// CommitmentTxID is the txid of the commitment transaction.
+	CommitmentTxID chainhash.Hash
+
+	// BatchExpiry is the absolute block height at which the batch expires
+	// (operator can sweep via the batch-level timelock).
+	BatchExpiry int32
+
+	// RelativeExpiry is the CSV delay for the VTXO's unilateral exit path
+	// (blocks from when VTXO is realized on-chain).
+	RelativeExpiry uint32
+
+	// TreeDepth is the depth of this VTXO in the VTXT (used for expiry
+	// calculation).
+	TreeDepth int
+
+	// CreatedHeight is the block height when this VTXO was created.
+	CreatedHeight int32
+
+	// Status is the current lifecycle status of the VTXO.
+	Status VTXOStatus
+}
+
+// VTXOStore defines the persistence interface for VTXO lifecycle management.
+// The store provides per-VTXO operations since each VTXO has its own actor.
+// The VTXO manager (parent actor) tracks active VTXOs and routes block epochs.
+type VTXOStore interface {
+	// SaveVTXO persists a new VTXO to storage. Called when a VTXO actor is
+	// created. Returns error if a VTXO with the same outpoint already
+	// exists.
+	SaveVTXO(ctx context.Context, vtxo *VTXODescriptor) error
+
+	// GetVTXO retrieves a VTXO by its outpoint. Used for actor recovery on
+	// startup. Returns error if not found.
+	GetVTXO(ctx context.Context, outpoint wire.OutPoint) (
+		*VTXODescriptor, error,
+	)
+
+	// ListLiveVTXOs returns all VTXOs that are not in a terminal state. Used
+	// during startup to recover active VTXO actors after restart.
+	ListLiveVTXOs(ctx context.Context) ([]*VTXODescriptor, error)
+
+	// UpdateVTXOStatus atomically updates a VTXO's status. This is the
+	// primary method for state transitions.
+	UpdateVTXOStatus(
+		ctx context.Context, outpoint wire.OutPoint, status VTXOStatus,
+	) error
+
+	// MarkForfeited marks a VTXO as forfeited and records the forfeit
+	// transaction ID. This is called when the new round's commitment
+	// transaction confirms.
+	MarkForfeited(
+		ctx context.Context, outpoint wire.OutPoint,
+		forfeitTxID chainhash.Hash,
+	) error
+
+	// DeleteVTXO removes a VTXO from storage. Used for cleanup after
+	// terminal states are reached and the VTXO is no longer needed.
+	DeleteVTXO(ctx context.Context, outpoint wire.OutPoint) error
+}
+
+// VTXOWallet defines the signing interface for VTXO operations.
+type VTXOWallet interface {
+	input.Signer
+}

--- a/vtxo/manager.go
+++ b/vtxo/manager.go
@@ -1,0 +1,239 @@
+package vtxo
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/chainsource"
+	"github.com/lightninglabs/darepo-client/round"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+)
+
+// VTXOActorRef is the actor reference type for VTXO actors.
+type VTXOActorRef = actor.ActorRef[VTXOEvent, VTXOActorResponse]
+
+// ManagerConfig holds configuration for the VTXO Manager.
+type ManagerConfig struct {
+	Store        VTXOStore
+	Wallet       VTXOWallet
+	ChainSource  actor.ActorRef[chainsource.ChainSourceMsg, chainsource.ChainSourceResp]
+	ActorSystem  *actor.ActorSystem
+	ChainParams  *chaincfg.Params
+	ExpiryConfig *ExpiryConfig
+	Logger       btclog.Logger
+
+	// RoundActor receives refresh requests and forfeit signatures from VTXOs.
+	// Passed through to spawned VTXO actors.
+	RoundActor actor.TellOnlyRef[round.RoundActorMessage]
+
+	// ChainResolver receives expiring notifications for unilateral exit.
+	// Passed through to spawned VTXO actors.
+	ChainResolver actor.TellOnlyRef[ExpiringNotification]
+}
+
+// Manager coordinates VTXO actor lifecycle - spawning new actors when VTXOs
+// are created and recovering persisted actors on startup. Each VTXO actor
+// manages its own block epoch subscription and communicates directly with the
+// round actor via service keys.
+type Manager struct {
+	cfg *ManagerConfig
+
+	// managerRef is the manager's own actor ref, used for creating mapped
+	// refs that VTXO actors can use to send termination notifications.
+	managerRef actor.TellOnlyRef[ManagerMsg]
+
+	// actors tracks active VTXO actors by outpoint.
+	actors map[wire.OutPoint]VTXOActorRef
+	mu     sync.RWMutex
+}
+
+// NewManager creates a new VTXO Manager.
+func NewManager(cfg *ManagerConfig) *Manager {
+	if cfg.ExpiryConfig == nil {
+		cfg.ExpiryConfig = DefaultExpiryConfig()
+	}
+
+	return &Manager{
+		cfg:    cfg,
+		actors: make(map[wire.OutPoint]VTXOActorRef),
+	}
+}
+
+// Start initializes the manager by recovering persisted VTXOs. The selfRef
+// parameter is the manager's own actor reference, used for VTXO actors to
+// send termination notifications.
+func (m *Manager) Start(ctx context.Context,
+	selfRef actor.TellOnlyRef[ManagerMsg]) error {
+
+	m.managerRef = selfRef
+
+	vtxos, err := m.cfg.Store.ListLiveVTXOs(ctx)
+	if err != nil {
+		return fmt.Errorf("list live vtxos: %w", err)
+	}
+
+	for _, vtxo := range vtxos {
+		if _, err := m.spawnVTXOActor(ctx, vtxo); err != nil {
+			m.cfg.Logger.ErrorS(ctx, "Failed to recover VTXO actor", err,
+				slog.String("outpoint", vtxo.Outpoint.String()))
+			continue
+		}
+
+		m.cfg.Logger.InfoS(ctx, "Recovered VTXO actor",
+			slog.String("outpoint", vtxo.Outpoint.String()),
+			slog.String("status", vtxo.Status.String()))
+	}
+
+	m.cfg.Logger.InfoS(ctx, "VTXO manager started",
+		slog.Int("recovered", len(m.actors)))
+
+	return nil
+}
+
+// Stop gracefully shuts down the manager.
+func (m *Manager) Stop(ctx context.Context) {
+	m.cfg.Logger.InfoS(ctx, "VTXO manager stopped")
+}
+
+// Receive processes incoming messages.
+func (m *Manager) Receive(ctx context.Context,
+	msg ManagerMsg) fn.Result[ManagerResp] {
+
+	switch req := msg.(type) {
+	case *VTXOCreatedMsg:
+		return m.handleVTXOCreated(ctx, req)
+
+	case *VTXOTerminatedMsg:
+		return m.handleVTXOTerminated(ctx, req)
+
+	default:
+		return fn.Err[ManagerResp](fmt.Errorf("unknown message: %T", msg))
+	}
+}
+
+// handleVTXOCreated spawns a new VTXO actor for each created VTXO.
+func (m *Manager) handleVTXOCreated(ctx context.Context,
+	msg *VTXOCreatedMsg) fn.Result[ManagerResp] {
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, clientVTXO := range msg.VTXOs {
+		outpoint := clientVTXO.Outpoint
+
+		if _, exists := m.actors[outpoint]; exists {
+			m.cfg.Logger.WarnS(ctx, "VTXO actor already exists", nil,
+				slog.String("outpoint", outpoint.String()))
+			continue
+		}
+
+		descriptor := clientVTXOToDescriptor(clientVTXO, msg)
+
+		if err := m.cfg.Store.SaveVTXO(ctx, descriptor); err != nil {
+			m.cfg.Logger.ErrorS(ctx, "Failed to save VTXO", err,
+				slog.String("outpoint", outpoint.String()))
+			continue
+		}
+
+		ref, err := m.spawnVTXOActor(ctx, descriptor)
+		if err != nil {
+			m.cfg.Logger.ErrorS(ctx, "Failed to spawn VTXO actor", err,
+				slog.String("outpoint", outpoint.String()))
+			continue
+		}
+
+		m.actors[outpoint] = ref
+
+		m.cfg.Logger.InfoS(ctx, "Spawned VTXO actor",
+			slog.String("outpoint", outpoint.String()),
+			slog.Int64("amount", int64(clientVTXO.Amount)),
+			slog.Int("batch_expiry", int(msg.BatchExpiry)))
+	}
+
+	return fn.Ok[ManagerResp](&VTXOCreatedResp{})
+}
+
+// handleVTXOTerminated removes a VTXO actor from tracking.
+func (m *Manager) handleVTXOTerminated(ctx context.Context,
+	msg *VTXOTerminatedMsg) fn.Result[ManagerResp] {
+
+	m.mu.Lock()
+	delete(m.actors, msg.Outpoint)
+	m.mu.Unlock()
+
+	m.cfg.Logger.InfoS(ctx, "VTXO actor terminated",
+		slog.String("outpoint", msg.Outpoint.String()),
+		slog.String("final_state", msg.FinalState),
+		slog.String("reason", msg.Reason))
+
+	return fn.Ok[ManagerResp](&VTXOTerminatedResp{})
+}
+
+// spawnVTXOActor creates a new VTXO FSM actor.
+func (m *Manager) spawnVTXOActor(ctx context.Context,
+	vtxo *VTXODescriptor) (VTXOActorRef, error) {
+
+	actorID := fmt.Sprintf("vtxo.%s", vtxo.Outpoint.String())
+	serviceKey := VTXOActorServiceKey(vtxo.Outpoint)
+
+	actorCfg := &VTXOActorConfig{
+		VTXO:          vtxo,
+		Store:         m.cfg.Store,
+		Wallet:        m.cfg.Wallet,
+		ChainSource:   m.cfg.ChainSource,
+		ChainParams:   m.cfg.ChainParams,
+		ExpiryConfig:  m.cfg.ExpiryConfig,
+		Logger:        m.cfg.Logger,
+		RoundActor:    m.cfg.RoundActor,
+		ChainResolver: m.cfg.ChainResolver,
+		Manager:       m.managerRef,
+	}
+
+	vtxoActor := NewVTXOActor(actorCfg)
+	ref := serviceKey.Spawn(m.cfg.ActorSystem, actorID, vtxoActor)
+
+	// Start the actor to subscribe to block epochs. ActorRef embeds
+	// TellOnlyRef so we can use it directly.
+	if err := vtxoActor.Start(ctx, ref); err != nil {
+		return ref, fmt.Errorf("start vtxo actor: %w", err)
+	}
+
+	m.actors[vtxo.Outpoint] = ref
+
+	return ref, nil
+}
+
+// clientVTXOToDescriptor converts a round.ClientVTXO to a VTXODescriptor.
+func clientVTXOToDescriptor(cv *round.ClientVTXO,
+	msg *VTXOCreatedMsg) *VTXODescriptor {
+
+	return &VTXODescriptor{
+		Outpoint:       cv.Outpoint,
+		Amount:         cv.Amount,
+		PkScript:       cv.PkScript,
+		ClientKey:      cv.ClientKey,
+		OperatorKey:    cv.OperatorKey,
+		TapScript:      msg.TapScript,
+		TreePath:       cv.TreePath,
+		RoundID:        msg.RoundID,
+		CommitmentTxID: msg.CommitmentTxID,
+		BatchExpiry:    msg.BatchExpiry,
+		RelativeExpiry: cv.Expiry,
+		TreeDepth:      msg.TreeDepth,
+		CreatedHeight:  msg.CreatedHeight,
+		Status:         VTXOStatusLive,
+	}
+}
+
+// ActiveVTXOCount returns the number of active VTXO actors.
+func (m *Manager) ActiveVTXOCount() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return len(m.actors)
+}

--- a/vtxo/messages.go
+++ b/vtxo/messages.go
@@ -1,0 +1,82 @@
+package vtxo
+
+import (
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/round"
+)
+
+// ManagerMsg is the message type accepted by the VTXO Manager actor.
+type ManagerMsg interface {
+	actor.Message
+	managerMsgSealed()
+}
+
+// ManagerResp is the response type returned by the VTXO Manager actor.
+type ManagerResp interface {
+	managerRespSealed()
+}
+
+// VTXOCreatedMsg notifies the manager that new VTXOs have been created by a
+// completed round. The manager spawns a new actor for each VTXO.
+type VTXOCreatedMsg struct {
+	actor.BaseMessage
+
+	// VTXOs are the ClientVTXOs from the completed round.
+	VTXOs []*round.ClientVTXO
+
+	// RoundID identifies the round that created these VTXOs.
+	RoundID string
+
+	// CommitmentTxID is the txid of the commitment transaction.
+	CommitmentTxID chainhash.Hash
+
+	// BatchExpiry is the absolute block height when the batch expires.
+	BatchExpiry int32
+
+	// TreeDepth is the depth of VTXOs in the commitment tree.
+	TreeDepth int
+
+	// CreatedHeight is the block height when the VTXOs were created.
+	CreatedHeight int32
+
+	// TapScript is the tapscript for the VTXOs (shared across batch).
+	TapScript *waddrmgr.Tapscript
+}
+
+func (m *VTXOCreatedMsg) managerMsgSealed() {}
+
+// MessageType returns the message type for logging.
+func (m *VTXOCreatedMsg) MessageType() string { return "VTXOCreatedMsg" }
+
+// VTXOCreatedResp is the response to VTXOCreatedMsg.
+type VTXOCreatedResp struct{}
+
+func (r *VTXOCreatedResp) managerRespSealed() {}
+
+// VTXOTerminatedMsg notifies the manager that a VTXO actor has reached a
+// terminal state and should be removed from tracking.
+type VTXOTerminatedMsg struct {
+	actor.BaseMessage
+
+	// Outpoint identifies the terminated VTXO.
+	Outpoint wire.OutPoint
+
+	// FinalState is the terminal state reached.
+	FinalState string
+
+	// Reason explains why the VTXO terminated.
+	Reason string
+}
+
+func (m *VTXOTerminatedMsg) managerMsgSealed() {}
+
+// MessageType returns the message type for logging.
+func (m *VTXOTerminatedMsg) MessageType() string { return "VTXOTerminatedMsg" }
+
+// VTXOTerminatedResp is the response to VTXOTerminatedMsg.
+type VTXOTerminatedResp struct{}
+
+func (r *VTXOTerminatedResp) managerRespSealed() {}

--- a/vtxo/outbox_messages.go
+++ b/vtxo/outbox_messages.go
@@ -1,0 +1,132 @@
+package vtxo
+
+import (
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/baselib/actor"
+)
+
+// VTXOOutMsg is a sealed interface for messages emitted via the FSM outbox.
+// These messages are sent to other actors (round actor, chain resolver) or
+// used for persistence updates.
+type VTXOOutMsg interface {
+	vtxoOutMsgSealed()
+}
+
+// RefreshUrgency indicates how urgent a refresh request is.
+type RefreshUrgency int
+
+const (
+	// RefreshUrgencyNormal indicates the VTXO has plenty of time remaining.
+	RefreshUrgencyNormal RefreshUrgency = iota
+
+	// RefreshUrgencyElevated indicates the VTXO should be refreshed soon.
+	RefreshUrgencyElevated
+
+	// RefreshUrgencyCritical indicates the VTXO must be refreshed
+	// immediately.
+	RefreshUrgencyCritical
+)
+
+// String returns a human-readable representation of the urgency level.
+func (u RefreshUrgency) String() string {
+	switch u {
+	case RefreshUrgencyNormal:
+		return "normal"
+	case RefreshUrgencyElevated:
+		return "elevated"
+	case RefreshUrgencyCritical:
+		return "critical"
+	default:
+		return "unknown"
+	}
+}
+
+// RefreshRequest is sent to the round actor when a VTXO needs to be refreshed.
+// The round actor should queue this VTXO for inclusion in the next batch swap.
+type RefreshRequest struct {
+	actor.BaseMessage
+
+	// VTXOOutpoint identifies the VTXO to refresh.
+	VTXOOutpoint wire.OutPoint
+
+	// Amount is the VTXO value in satoshis.
+	Amount int64
+
+	// Urgency indicates how urgent the refresh is (based on blocks
+	// remaining until expiry).
+	Urgency RefreshUrgency
+}
+
+func (m *RefreshRequest) vtxoOutMsgSealed() {}
+
+// ExpiringNotification is sent to the chain resolver when a VTXO is critically
+// close to expiry and needs unilateral exit handling. The chain resolver
+// should begin the on-chain unrolling process.
+type ExpiringNotification struct {
+	actor.BaseMessage
+
+	// VTXO is the full descriptor of the expiring VTXO.
+	VTXO *VTXODescriptor
+
+	// BlocksRemaining is how many blocks until batch expiry.
+	BlocksRemaining int32
+
+	// Reason explains why the VTXO is being sent to chain resolver.
+	Reason string
+}
+
+func (m ExpiringNotification) vtxoOutMsgSealed() {}
+
+// MessageType returns the message type for logging.
+func (m ExpiringNotification) MessageType() string { return "ExpiringNotification" }
+
+// ForfeitSignatureSubmission is sent to the round actor with the forfeit
+// transaction signature.
+type ForfeitSignatureSubmission struct {
+	actor.BaseMessage
+
+	// VTXOOutpoint identifies the VTXO being forfeited.
+	VTXOOutpoint wire.OutPoint
+
+	// RoundID is the round where the forfeit is being processed.
+	RoundID string
+
+	// ForfeitTx is the signed forfeit transaction.
+	ForfeitTx *wire.MsgTx
+
+	// Signature is the client's signature for the forfeit tx.
+	Signature []byte
+}
+
+func (m *ForfeitSignatureSubmission) vtxoOutMsgSealed() {}
+
+// VTXOStatusUpdate is a persistence request to update VTXO status. This is
+// emitted on state transitions to keep the database in sync.
+type VTXOStatusUpdate struct {
+	actor.BaseMessage
+
+	// Outpoint identifies the VTXO.
+	Outpoint wire.OutPoint
+
+	// NewStatus is the new status to set.
+	NewStatus VTXOStatus
+}
+
+func (m *VTXOStatusUpdate) vtxoOutMsgSealed() {}
+
+// VTXOTerminatedNotification notifies the VTXO manager that this VTXO actor
+// has reached a terminal state and can be cleaned up.
+type VTXOTerminatedNotification struct {
+	actor.BaseMessage
+
+	// VTXOOutpoint identifies the VTXO.
+	VTXOOutpoint wire.OutPoint
+
+	// FinalState is the terminal state reached.
+	FinalState string
+
+	// Reason explains why the VTXO terminated.
+	Reason string
+}
+
+func (m *VTXOTerminatedNotification) vtxoOutMsgSealed() {}

--- a/vtxo/states.go
+++ b/vtxo/states.go
@@ -1,0 +1,171 @@
+package vtxo
+
+import (
+	"fmt"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/baselib/protofsm"
+)
+
+// VTXOState is a sealed interface for all states in the VTXO state machine.
+// Each state implements ProcessEvent to handle incoming events and return
+// state transitions.
+type VTXOState interface {
+	protofsm.State[VTXOEvent, VTXOOutMsg, *VTXOEnvironment]
+
+	// vtxoStateSealed is an unexported method that prevents external
+	// packages from implementing VTXOState.
+	vtxoStateSealed()
+}
+
+// LiveState is the primary active state. The VTXO is live and can be spent
+// collaboratively with the operator. This state monitors block epochs to
+// detect when the VTXO is approaching expiry.
+type LiveState struct {
+	// VTXO is the descriptor for this VTXO.
+	VTXO *VTXODescriptor
+
+	// LastCheckedHeight is the last block height at which expiry was
+	// checked.
+	LastCheckedHeight int32
+}
+
+// String returns a human-readable state name.
+func (s *LiveState) String() string {
+	return "Live"
+}
+
+// IsTerminal returns false since LiveState is not a terminal state.
+func (s *LiveState) IsTerminal() bool {
+	return false
+}
+
+func (s *LiveState) vtxoStateSealed() {}
+
+// RefreshRequestedState indicates a refresh request has been sent to the round
+// actor. The VTXO is waiting for acknowledgment or a forfeit request to begin
+// the batch swap process.
+type RefreshRequestedState struct {
+	// VTXO is the descriptor for this VTXO.
+	VTXO *VTXODescriptor
+
+	// RequestedAtHeight is the block height when the refresh was requested.
+	RequestedAtHeight int32
+}
+
+// String returns a human-readable state name.
+func (s *RefreshRequestedState) String() string {
+	return "RefreshRequested"
+}
+
+// IsTerminal returns false since RefreshRequestedState is not terminal.
+func (s *RefreshRequestedState) IsTerminal() bool {
+	return false
+}
+
+func (s *RefreshRequestedState) vtxoStateSealed() {}
+
+// ForfeitingState indicates the VTXO is being forfeited in a round. The VTXO
+// actor is waiting for the new commitment transaction to confirm.
+type ForfeitingState struct {
+	// VTXO is the descriptor for this VTXO.
+	VTXO *VTXODescriptor
+
+	// NewRoundID is the round where the refreshed VTXO will be created.
+	NewRoundID string
+
+	// ConnectorOutpoint is the connector from the new commitment tx that
+	// the forfeit tx spends.
+	ConnectorOutpoint wire.OutPoint
+
+	// ForfeitTxID is the txid of the forfeit transaction (set after
+	// signing).
+	ForfeitTxID chainhash.Hash
+}
+
+// String returns a human-readable state name.
+func (s *ForfeitingState) String() string {
+	return "Forfeiting"
+}
+
+// IsTerminal returns false since ForfeitingState is not terminal.
+func (s *ForfeitingState) IsTerminal() bool {
+	return false
+}
+
+func (s *ForfeitingState) vtxoStateSealed() {}
+
+// ForfeitedState is a terminal state indicating the VTXO has been forfeited.
+// The VTXO's value has been transferred to a new VTXO in a new round.
+type ForfeitedState struct {
+	// VTXO is the descriptor for this VTXO.
+	VTXO *VTXODescriptor
+
+	// NewRoundID is the round where the replacement VTXO was created.
+	NewRoundID string
+
+	// CommitmentTxID is the new commitment transaction that was confirmed.
+	CommitmentTxID chainhash.Hash
+}
+
+// String returns a human-readable state name.
+func (s *ForfeitedState) String() string {
+	return "Forfeited"
+}
+
+// IsTerminal returns true since ForfeitedState is a terminal state.
+func (s *ForfeitedState) IsTerminal() bool {
+	return true
+}
+
+func (s *ForfeitedState) vtxoStateSealed() {}
+
+// ExpiringState is a terminal state indicating the VTXO is critically close to
+// expiry and has been sent to the chain resolver for unilateral exit handling.
+type ExpiringState struct {
+	// VTXO is the descriptor for this VTXO.
+	VTXO *VTXODescriptor
+
+	// Reason explains why the VTXO is expiring.
+	Reason string
+}
+
+// String returns a human-readable state name.
+func (s *ExpiringState) String() string {
+	return "Expiring"
+}
+
+// IsTerminal returns true since ExpiringState is a terminal state.
+func (s *ExpiringState) IsTerminal() bool {
+	return true
+}
+
+func (s *ExpiringState) vtxoStateSealed() {}
+
+// FailedState is a terminal state indicating an unrecoverable error occurred.
+type FailedState struct {
+	// VTXO is the descriptor for this VTXO.
+	VTXO *VTXODescriptor
+
+	// Reason is a human-readable description of the failure.
+	Reason string
+
+	// Error is the underlying error, if any.
+	Error error
+
+	// Recoverable indicates whether the failure might be recoverable.
+	Recoverable bool
+}
+
+// String returns a human-readable state name.
+func (s *FailedState) String() string {
+	return fmt.Sprintf("Failed: %s", s.Reason)
+}
+
+// IsTerminal returns true since FailedState is a terminal state.
+func (s *FailedState) IsTerminal() bool {
+	return true
+}
+
+func (s *FailedState) vtxoStateSealed() {}

--- a/vtxo/transitions.go
+++ b/vtxo/transitions.go
@@ -1,0 +1,488 @@
+package vtxo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/tx"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+)
+
+// ProcessEvent handles events in LiveState. The VTXO monitors block epochs for
+// expiry and can receive forfeit requests from the round actor.
+func (s *LiveState) ProcessEvent(
+	ctx context.Context, event VTXOEvent, env *VTXOEnvironment,
+) (*VTXOStateTransition, error) {
+
+	switch evt := event.(type) {
+	case *BlockEpochEvent:
+		return s.handleBlockEpoch(ctx, evt, env)
+
+	case *ForfeitRequestEvent:
+		return s.handleForfeitRequest(ctx, evt, env)
+
+	case *ResumeVTXOEvent:
+		// On resume, stay in LiveState and re-check expiry on next
+		// block.
+		return &VTXOStateTransition{
+			NextState: s,
+		}, nil
+
+	case *VTXOFailedEvent:
+		return &VTXOStateTransition{
+			NextState: &FailedState{
+				VTXO:        s.VTXO,
+				Reason:      evt.Reason,
+				Error:       evt.Error,
+				Recoverable: evt.Recoverable,
+			},
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("live: unexpected event: %T", event)
+	}
+}
+
+// handleBlockEpoch processes a new block notification and checks if the VTXO
+// needs to be refreshed or escalated.
+func (s *LiveState) handleBlockEpoch(
+	_ context.Context, evt *BlockEpochEvent, env *VTXOEnvironment,
+) (*VTXOStateTransition, error) {
+
+	s.LastCheckedHeight = evt.Height
+
+	expiryStatus := env.ExpiryConfig.CheckExpiry(s.VTXO, evt.Height)
+
+	switch expiryStatus {
+	case ExpiryStatusSafe:
+		// Nothing to do, stay in LiveState.
+		return &VTXOStateTransition{
+			NextState: s,
+		}, nil
+
+	case ExpiryStatusNeedsRefresh:
+		// Request refresh from round actor before expiry becomes critical.
+		blocksRemaining := BlocksUntilExpiry(s.VTXO, evt.Height)
+		urgency := env.ExpiryConfig.DetermineRefreshUrgency(
+			blocksRemaining,
+		)
+
+		outbox := []VTXOOutMsg{
+			&RefreshRequest{
+				VTXOOutpoint: s.VTXO.Outpoint,
+				Amount:       int64(s.VTXO.Amount),
+				Urgency:      urgency,
+			},
+			&VTXOStatusUpdate{
+				Outpoint:  s.VTXO.Outpoint,
+				NewStatus: VTXOStatusRefreshRequested,
+			},
+		}
+
+		return &VTXOStateTransition{
+			NextState: &RefreshRequestedState{
+				VTXO:              s.VTXO,
+				RequestedAtHeight: evt.Height,
+			},
+			NewEvents: fn.Some(VTXOEmittedEvent{Outbox: outbox}),
+		}, nil
+
+	case ExpiryStatusCritical:
+		// Escalate to chain resolver for unilateral exit.
+		blocksRemaining := BlocksUntilExpiry(s.VTXO, evt.Height)
+		reason := fmt.Sprintf(
+			"critical expiry: %d blocks remaining", blocksRemaining,
+		)
+
+		outbox := []VTXOOutMsg{
+			&ExpiringNotification{
+				VTXO:            s.VTXO,
+				BlocksRemaining: blocksRemaining,
+				Reason:          "batch expiry imminent",
+			},
+			&VTXOStatusUpdate{
+				Outpoint:  s.VTXO.Outpoint,
+				NewStatus: VTXOStatusExpiring,
+			},
+			&VTXOTerminatedNotification{
+				VTXOOutpoint: s.VTXO.Outpoint,
+				FinalState:   "Expiring",
+				Reason:       "sent to chain resolver",
+			},
+		}
+
+		return &VTXOStateTransition{
+			NextState:  &ExpiringState{VTXO: s.VTXO, Reason: reason},
+			NewEvents: fn.Some(VTXOEmittedEvent{Outbox: outbox}),
+		}, nil
+
+	case ExpiryStatusExpired:
+		// Batch has expired - this should not happen if monitoring
+		// works correctly.
+		return &VTXOStateTransition{
+			NextState: &FailedState{
+				VTXO:        s.VTXO,
+				Reason:      "batch expired before refresh",
+				Recoverable: false,
+			},
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("unknown expiry status: %d", expiryStatus)
+	}
+}
+
+// handleForfeitRequest builds and signs a forfeit transaction when the round
+// actor requests this VTXO be forfeited as part of a batch swap. The forfeit
+// atomically links the old VTXO to a new round via the connector output - if
+// the new commitment tx confirms, the forfeit becomes valid and pays the VTXO
+// value to the operator. This prevents double-spending by ensuring the client
+// cannot claim both the old VTXO and a new one in the fresh round.
+func (s *LiveState) handleForfeitRequest(
+	_ context.Context, evt *ForfeitRequestEvent, env *VTXOEnvironment,
+) (*VTXOStateTransition, error) {
+
+	forfeitTx, err := tx.BuildForfeitTx(
+		&s.VTXO.Outpoint, s.VTXO.Amount,
+		&evt.ConnectorOutpoint, evt.ServerForfeitPkScript,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build forfeit tx: %w", err)
+	}
+
+	// Sign our portion of the collaborative 2-of-2 spend on the VTXO input.
+	// The operator will add their signature to complete the multisig witness.
+	sig, err := signForfeitVTXOInput(s.VTXO, evt, forfeitTx, env)
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign forfeit tx: %w", err)
+	}
+
+	forfeitTxID := forfeitTx.TxHash()
+
+	return &VTXOStateTransition{
+		NextState: &ForfeitingState{
+			VTXO:              s.VTXO,
+			NewRoundID:        evt.RoundID,
+			ConnectorOutpoint: evt.ConnectorOutpoint,
+			ForfeitTxID:       forfeitTxID,
+		},
+		NewEvents: fn.Some(VTXOEmittedEvent{
+			Outbox: []VTXOOutMsg{
+				&ForfeitSignatureSubmission{
+					VTXOOutpoint: s.VTXO.Outpoint,
+					RoundID:      evt.RoundID,
+					ForfeitTx:    forfeitTx,
+					Signature:    sig,
+				},
+				&VTXOStatusUpdate{
+					Outpoint:  s.VTXO.Outpoint,
+					NewStatus: VTXOStatusForfeiting,
+				},
+			},
+		}),
+	}, nil
+}
+
+// signForfeitVTXOInput produces the client's schnorr signature for the VTXO
+// input of a forfeit transaction. The VTXO uses a tapscript with a 2-of-2
+// collaborative spend path, so both client and operator signatures are needed.
+// This function only produces the client's half; the operator adds theirs.
+func signForfeitVTXOInput(vtxo *VTXODescriptor, evt *ForfeitRequestEvent,
+	forfeitTx *wire.MsgTx, env *VTXOEnvironment) ([]byte, error) {
+
+	if vtxo.TapScript == nil {
+		return nil, fmt.Errorf("VTXO tapscript is required for signing")
+	}
+	if env.Wallet == nil {
+		return nil, fmt.Errorf("wallet is required for signing")
+	}
+
+	// Reconstruct the VTXO output to build proper sighash. BIP-341 requires
+	// all prevouts when computing taproot signature hashes.
+	vtxoOutput := &wire.TxOut{
+		Value: int64(vtxo.Amount), PkScript: vtxo.PkScript,
+	}
+	vtxoCtx := &tx.VTXOSpendContext{
+		Outpoint:  vtxo.Outpoint,
+		Output:    vtxoOutput,
+		TapScript: vtxo.TapScript,
+	}
+
+	connectorOutput := &wire.TxOut{
+		Value: evt.ConnectorAmount, PkScript: evt.ConnectorPkScript,
+	}
+	connectorCtx := &tx.ConnectorSpendContext{
+		Outpoint: evt.ConnectorOutpoint,
+		Output:   connectorOutput,
+	}
+
+	prevFetcher, err := tx.NewForfeitPrevOutFetcher(vtxoCtx, connectorCtx)
+	if err != nil {
+		return nil, fmt.Errorf("prevout fetcher: %w", err)
+	}
+
+	sigHashes := txscript.NewTxSigHashes(forfeitTx, prevFetcher)
+
+	// NewVTXOCollabSignDescriptor extracts the collaborative leaf's witness
+	// script and control block from the tapscript, which are needed for
+	// script-path spending.
+	signDesc, _, err := tx.NewVTXOCollabSignDescriptor(
+		vtxoCtx, vtxo.ClientKey, tx.ForfeitVTXOInputIndex,
+		sigHashes, prevFetcher,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("sign descriptor: %w", err)
+	}
+
+	sig, err := env.Wallet.SignOutputRaw(forfeitTx, signDesc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign: %w", err)
+	}
+
+	return sig.Serialize(), nil
+}
+
+// ProcessEvent handles events in RefreshRequestedState. The VTXO is waiting
+// for acknowledgment or a forfeit request from the round actor.
+func (s *RefreshRequestedState) ProcessEvent(
+	ctx context.Context, event VTXOEvent, env *VTXOEnvironment,
+) (*VTXOStateTransition, error) {
+
+	switch evt := event.(type) {
+	case *BlockEpochEvent:
+		// Check if we've hit critical expiry while waiting for refresh.
+		expiryStatus := env.ExpiryConfig.CheckExpiry(s.VTXO, evt.Height)
+
+		if expiryStatus == ExpiryStatusCritical ||
+			expiryStatus == ExpiryStatusExpired {
+
+			blocksRemaining := BlocksUntilExpiry(s.VTXO, evt.Height)
+
+			outbox := []VTXOOutMsg{
+				&ExpiringNotification{
+					VTXO:            s.VTXO,
+					BlocksRemaining: blocksRemaining,
+					Reason:          "refresh not completed in time",
+				},
+				&VTXOStatusUpdate{
+					Outpoint:  s.VTXO.Outpoint,
+					NewStatus: VTXOStatusExpiring,
+				},
+				&VTXOTerminatedNotification{
+					VTXOOutpoint: s.VTXO.Outpoint,
+					FinalState:   "Expiring",
+					Reason:       "refresh timeout",
+				},
+			}
+
+			return &VTXOStateTransition{
+				NextState: &ExpiringState{
+					VTXO:   s.VTXO,
+					Reason: "critical expiry during refresh wait",
+				},
+				NewEvents: fn.Some(VTXOEmittedEvent{Outbox: outbox}),
+			}, nil
+		}
+
+		// Still waiting, stay in this state.
+		return &VTXOStateTransition{
+			NextState: s,
+		}, nil
+
+	case *ForfeitRequestEvent:
+		// Round actor is ready for forfeit. Build and sign the forfeit
+		// tx to transfer this VTXO to the new round.
+		forfeitTx, err := tx.BuildForfeitTx(
+			&s.VTXO.Outpoint, s.VTXO.Amount,
+			&evt.ConnectorOutpoint, evt.ServerForfeitPkScript,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build forfeit tx: %w", err)
+		}
+
+		sig, err := signForfeitVTXOInput(s.VTXO, evt, forfeitTx, env)
+		if err != nil {
+			return nil, fmt.Errorf("failed to sign forfeit tx: %w", err)
+		}
+
+		forfeitTxID := forfeitTx.TxHash()
+
+		return &VTXOStateTransition{
+			NextState: &ForfeitingState{
+				VTXO:              s.VTXO,
+				NewRoundID:        evt.RoundID,
+				ConnectorOutpoint: evt.ConnectorOutpoint,
+				ForfeitTxID:       forfeitTxID,
+			},
+			NewEvents: fn.Some(VTXOEmittedEvent{
+				Outbox: []VTXOOutMsg{
+					&ForfeitSignatureSubmission{
+						VTXOOutpoint: s.VTXO.Outpoint,
+						RoundID:      evt.RoundID,
+						ForfeitTx:    forfeitTx,
+						Signature:    sig,
+					},
+					&VTXOStatusUpdate{
+						Outpoint:  s.VTXO.Outpoint,
+						NewStatus: VTXOStatusForfeiting,
+					},
+				},
+			}),
+		}, nil
+
+	case *RefreshAcknowledgedEvent:
+		// Round actor acknowledged but no forfeit request yet.
+		// Stay in RefreshRequestedState.
+		return &VTXOStateTransition{
+			NextState: s,
+		}, nil
+
+	case *ResumeVTXOEvent:
+		// On resume, stay in this state. The round actor should have
+		// persisted the refresh request.
+		return &VTXOStateTransition{
+			NextState: s,
+		}, nil
+
+	case *VTXOFailedEvent:
+		return &VTXOStateTransition{
+			NextState: &FailedState{
+				VTXO:        s.VTXO,
+				Reason:      evt.Reason,
+				Error:       evt.Error,
+				Recoverable: evt.Recoverable,
+			},
+		}, nil
+
+	default:
+		return nil, fmt.Errorf(
+			"refresh_requested: unexpected event: %T", event,
+		)
+	}
+}
+
+// ProcessEvent handles events in ForfeitingState. The VTXO is being forfeited
+// and waiting for the new commitment transaction to confirm.
+func (s *ForfeitingState) ProcessEvent(
+	ctx context.Context, event VTXOEvent, env *VTXOEnvironment,
+) (*VTXOStateTransition, error) {
+
+	switch evt := event.(type) {
+	case *ForfeitSignedEvent:
+		// Forfeit tx has been signed and submitted. Update the txid
+		// and stay in this state.
+		return &VTXOStateTransition{
+			NextState: &ForfeitingState{
+				VTXO:              s.VTXO,
+				NewRoundID:        s.NewRoundID,
+				ConnectorOutpoint: s.ConnectorOutpoint,
+				ForfeitTxID:       evt.ForfeitTxID,
+			},
+		}, nil
+
+	case *ForfeitConfirmedEvent:
+		// New commitment tx confirmed, forfeit is complete.
+		return &VTXOStateTransition{
+			NextState: &ForfeitedState{
+				VTXO:           s.VTXO,
+				NewRoundID:     s.NewRoundID,
+				CommitmentTxID: evt.CommitmentTxID,
+			},
+			NewEvents: fn.Some(VTXOEmittedEvent{
+				Outbox: []VTXOOutMsg{
+					&VTXOStatusUpdate{
+						Outpoint:  s.VTXO.Outpoint,
+						NewStatus: VTXOStatusForfeited,
+					},
+					&VTXOTerminatedNotification{
+						VTXOOutpoint: s.VTXO.Outpoint,
+						FinalState:   "Forfeited",
+						Reason: fmt.Sprintf(
+							"forfeited in round %s",
+							s.NewRoundID,
+						),
+					},
+				},
+			}),
+		}, nil
+
+	case *BlockEpochEvent:
+		// Check if we've hit expiry while forfeiting.
+		expiryStatus := env.ExpiryConfig.CheckExpiry(s.VTXO, evt.Height)
+
+		if expiryStatus == ExpiryStatusExpired {
+			// This is a serious problem - the batch expired during
+			// forfeit.
+			return &VTXOStateTransition{
+				NextState: &FailedState{
+					VTXO:        s.VTXO,
+					Reason:      "batch expired during forfeit",
+					Recoverable: false,
+				},
+			}, nil
+		}
+
+		// Still waiting for forfeit confirmation.
+		return &VTXOStateTransition{
+			NextState: s,
+		}, nil
+
+	case *ResumeVTXOEvent:
+		// On resume in ForfeitingState, we need to wait for the round
+		// to complete and send ForfeitConfirmedEvent.
+		return &VTXOStateTransition{
+			NextState: s,
+		}, nil
+
+	case *VTXOFailedEvent:
+		return &VTXOStateTransition{
+			NextState: &FailedState{
+				VTXO:        s.VTXO,
+				Reason:      evt.Reason,
+				Error:       evt.Error,
+				Recoverable: evt.Recoverable,
+			},
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("forfeiting: unexpected event: %T", event)
+	}
+}
+
+// ProcessEvent for ForfeitedState. This is a terminal state, so all events
+// result in staying in the same state.
+func (s *ForfeitedState) ProcessEvent(
+	_ context.Context, _ VTXOEvent, _ *VTXOEnvironment,
+) (*VTXOStateTransition, error) {
+
+	// Terminal state: self-loop on all events.
+	return &VTXOStateTransition{
+		NextState: s,
+	}, nil
+}
+
+// ProcessEvent for ExpiringState. This is a terminal state, so all events
+// result in staying in the same state.
+func (s *ExpiringState) ProcessEvent(
+	_ context.Context, _ VTXOEvent, _ *VTXOEnvironment,
+) (*VTXOStateTransition, error) {
+
+	// Terminal state: self-loop on all events.
+	return &VTXOStateTransition{
+		NextState: s,
+	}, nil
+}
+
+// ProcessEvent for FailedState. This is a terminal state, so all events
+// result in staying in the same state.
+func (s *FailedState) ProcessEvent(
+	_ context.Context, _ VTXOEvent, _ *VTXOEnvironment,
+) (*VTXOStateTransition, error) {
+
+	// Terminal state: self-loop on all events.
+	return &VTXOStateTransition{
+		NextState: s,
+	}, nil
+}


### PR DESCRIPTION
In this PR, we start to implement the VTXO actor as sketched out in the issue linked below. 

The VTXO actor is the output of a succesful round. The round actor sends a message to the vtxo factory actor which then spawns a vtxo actor (at this point the details have already been written to disk). 

The VTXO actor+fsm as the following responsibilities:
  * It watches the expiry of the VTXo is manages:
     * Based on the current height, it decides if needs to attempt to refresh the VTXO or actually go to chain. 
     * If it's a refresh it sends a message to the round actor to attempt to join a round. 
     * Otherwise it sends a message to the chain resolver to start to unravel things on chain. 
  * It receives requests to sign a forfeit txn:
     * This may come in response to a refresh message sent to the round, or be triggered by the round itself as it's carrying out a swap. 
      * It'll then take the connector information (at this point the tree is assumed to be validated), signs the forfeit transaction, then shifts states. 

One could argue that the expiry watching could be more centralized. My initial idea was to have the wallet maintain a pqueue of the expiry heights of each VTXO, then trigger the process of refresh or force close. However, after thinking about it more, I felt like it was better to minimize the responsibilities of the wallet, and further encapsulate the key vtxo logic. 

Opening as a draft now. Mainly showing some early work. 

Partially resolves https://github.com/lightninglabs/darepo/issues/19. 