### PR TITLE
lib: refactor tree building to do two phase assembly

### DIFF
--- a/lib/tree/batch.go
+++ b/lib/tree/batch.go
@@ -61,7 +61,16 @@ func NewVTXODescriptor(amount btcutil.Amount, ownerKey *btcec.PublicKey,
 
 // ToLeafDescriptor converts a VTXODescriptor to a generic LeafDescriptor.
 func (v VTXODescriptor) ToLeafDescriptor() LeafDescriptor {
-	return LeafDescriptor(v)
+	pkScript := make([]byte, len(v.PkScript))
+	copy(pkScript, v.PkScript)
+
+	cosignerKey := *v.CoSignerKey
+
+	return LeafDescriptor{
+		PkScript:    pkScript,
+		Amount:      v.Amount,
+		CoSignerKey: &cosignerKey,
+	}
 }
 
 // ConnectorDescriptor defines the specification for a connector tree.
@@ -165,17 +174,12 @@ func (c ConnectorDescriptor) ToLeafDescriptors(
 }
 
 // BuildVTXOTree constructs a complete transaction tree from VTXO descriptors
-// using a BFS (breadth-first search) algorithm. It returns a Tree with all
-// transactions fully constructed and linked.
-func BuildVTXOTree(
-	batchOutpoint wire.OutPoint,
-	batchOutput *wire.TxOut,
-	vtxos []VTXODescriptor,
-	operatorCoSignKey *btcec.PublicKey,
-	sweepKey *btcec.PublicKey,
-	sweepDelay uint32,
-	radix int,
-) (*Tree, error) {
+// using a two-phase approach (structure building + materialization). It returns
+// a Tree with all transactions fully constructed and linked.
+func BuildVTXOTree(batchOutpoint wire.OutPoint, batchOutput *wire.TxOut,
+	vtxos []VTXODescriptor, operatorCoSignKey *btcec.PublicKey,
+	sweepKey *btcec.PublicKey, sweepDelay uint32, radix int) (*Tree,
+	error) {
 
 	// Validate inputs.
 	if err := ValidateVTXODescriptors(vtxos); err != nil {
@@ -223,16 +227,21 @@ func BuildVTXOTree(
 	}
 	sweepTapRoot := sweepTapLeaf.TapHash()
 
-	return NewTree(
-		batchOutpoint, batchOutput, leaves,
-		operatorCoSignKey, sweepTapRoot[:], radix,
-	)
+	// Use BTCTreeAssembler for two-phase tree construction.
+	assembler := NewTreeAssembler(TreeConfig{
+		OperatorKey:        operatorCoSignKey,
+		SweepTapscriptRoot: sweepTapRoot[:],
+		Radix:              radix,
+	})
+
+	return assembler.BuildTree(batchOutpoint, batchOutput, leaves)
 }
 
-// BuildConnectorTree constructs a connector tree from a connector descriptor.
-// Unlike VTXO trees, connector trees have identical leaves (same script, same
-// amount) and are signed only by the operator. This is used for forfeit
-// transaction inputs.
+// BuildConnectorTree constructs a connector tree from a connector descriptor
+// using a two-phase approach (structure building + materialization). Unlike
+// VTXO trees, connector trees have identical leaves (same script, same amount)
+// and are signed only by the operator. This is used for forfeit transaction
+// inputs.
 func BuildConnectorTree(
 	batchOutpoint wire.OutPoint,
 	batchOutput *wire.TxOut,
@@ -257,10 +266,15 @@ func BuildConnectorTree(
 	// Convert to leaf descriptors (creates unique keys for each).
 	leaves := connector.ToLeafDescriptors(operatorKey)
 
-	return NewTree(
-		batchOutpoint, batchOutput, leaves,
-		operatorKey, nil, radix,
-	)
+	// Use the Bitcoin only TreeAssembler for two-phase tree construction.
+	// Connector trees have no sweep script (nil SweepTapscriptRoot).
+	assembler := NewTreeAssembler(TreeConfig{
+		OperatorKey:        operatorKey,
+		SweepTapscriptRoot: nil,
+		Radix:              radix,
+	})
+
+	return assembler.BuildTree(batchOutpoint, batchOutput, leaves)
 }
 
 // BuildBatchOutput computes the pkscript and output amount for a batch output

--- a/lib/tree/batch_test.go
+++ b/lib/tree/batch_test.go
@@ -60,9 +60,15 @@ func TestBuildVTXOTree(t *testing.T) {
 			},
 		}
 
+		// Batch output value should match the sum of VTXO amounts.
+		singleBatchOutput := &wire.TxOut{
+			Value:    5000,
+			PkScript: []byte("batch_script"),
+		}
+
 		tree, err := BuildVTXOTree(
 			batchOutpoint,
-			batchOutput,
+			singleBatchOutput,
 			vtxos,
 			operatorPubKey,
 			sweepPubKey,
@@ -74,7 +80,7 @@ func TestBuildVTXOTree(t *testing.T) {
 
 		// Verify tree context.
 		require.Equal(t, batchOutpoint, tree.BatchOutpoint)
-		require.Equal(t, batchOutput, tree.BatchOutput)
+		require.Equal(t, singleBatchOutput, tree.BatchOutput)
 		require.NotNil(t, tree.SweepTapscriptRoot)
 
 		// Root should be a leaf transaction.
@@ -114,9 +120,16 @@ func TestBuildVTXOTree(t *testing.T) {
 			},
 		}
 
+		// Batch output value should match sum of VTXOs:
+		// 5000 + 3000 = 8000.
+		twoBatchOutput := &wire.TxOut{
+			Value:    8000,
+			PkScript: []byte("batch_script"),
+		}
+
 		tree, err := BuildVTXOTree(
 			batchOutpoint,
-			batchOutput,
+			twoBatchOutput,
 			vtxos,
 			operatorPubKey,
 			sweepPubKey,
@@ -165,6 +178,7 @@ func TestBuildVTXOTree(t *testing.T) {
 
 	t.Run("five VTXO tree with radix 2", func(t *testing.T) {
 		// Create 5 VTXOs with different amounts.
+		// Total: 5000+4000+3000+2000+1000 = 15000
 		vtxos := make([]VTXODescriptor, 5)
 		for i := 0; i < 5; i++ {
 			key, err := btcec.NewPrivateKey()
@@ -180,9 +194,15 @@ func TestBuildVTXOTree(t *testing.T) {
 			}
 		}
 
+		// Batch output should match total VTXO amounts.
+		fiveBatchOutput := &wire.TxOut{
+			Value:    15000,
+			PkScript: []byte("batch_script"),
+		}
+
 		tree, err := BuildVTXOTree(
 			batchOutpoint,
-			batchOutput,
+			fiveBatchOutput,
 			vtxos,
 			operatorPubKey,
 			sweepPubKey,
@@ -281,7 +301,9 @@ func TestBuildVTXOTreeStableSort(t *testing.T) {
 		Hash:  chainhash.HashH([]byte("commitment")),
 		Index: 0,
 	}
-	batchOutput := &wire.TxOut{Value: 10000, PkScript: []byte("batch")}
+
+	// Batch output value must match sum of VTXOs: 3 * 1000 = 3000.
+	batchOutput := &wire.TxOut{Value: 3000, PkScript: []byte("batch")}
 
 	// Create 3 VTXOs with SAME amount but different scripts.
 	// The scripts are intentionally out of lexicographic order.
@@ -368,9 +390,15 @@ func TestBuildConnectorTree(t *testing.T) {
 			Amount:    btcutil.Amount(330),
 		}
 
+		// Batch output must match the connector amount for single leaf.
+		singleBatchOutput := &wire.TxOut{
+			Value:    330,
+			PkScript: []byte("connector_batch_script"),
+		}
+
 		tree, err := BuildConnectorTree(
 			batchOutpoint,
-			batchOutput,
+			singleBatchOutput,
 			connector,
 			operatorPubKey,
 			4, // radix
@@ -401,9 +429,15 @@ func TestBuildConnectorTree(t *testing.T) {
 			Amount:    btcutil.Amount(330),
 		}
 
+		// Batch output = 4 * 330 = 1320.
+		fourBatchOutput := &wire.TxOut{
+			Value:    1320,
+			PkScript: []byte("connector_batch_script"),
+		}
+
 		tree, err := BuildConnectorTree(
 			batchOutpoint,
-			batchOutput,
+			fourBatchOutput,
 			connector,
 			operatorPubKey,
 			4,
@@ -421,7 +455,7 @@ func TestBuildConnectorTree(t *testing.T) {
 			require.True(t, exists, "child %d", i)
 			require.True(t, child.IsLeaf(), "child %d", i)
 
-			// Verify connector output is identical.
+			// Verify connector output is identical (1320/4 = 330).
 			require.Equal(t, int64(330), child.Outputs[0].Value)
 			require.Equal(t, connectorScript,
 				child.Outputs[0].PkScript)
@@ -446,9 +480,15 @@ func TestBuildConnectorTree(t *testing.T) {
 			Amount:    btcutil.Amount(330),
 		}
 
+		// Batch output = 8 * 330 = 2640.
+		eightBatchOutput := &wire.TxOut{
+			Value:    2640,
+			PkScript: []byte("connector_batch_script"),
+		}
+
 		tree, err := BuildConnectorTree(
 			batchOutpoint,
-			batchOutput,
+			eightBatchOutput,
 			connector,
 			operatorPubKey,
 			4,
@@ -479,9 +519,15 @@ func TestBuildConnectorTree(t *testing.T) {
 			Amount:    btcutil.Amount(330),
 		}
 
+		// Batch output = 4 * 330 = 1320.
+		extractBatchOutput := &wire.TxOut{
+			Value:    1320,
+			PkScript: []byte("connector_batch_script"),
+		}
+
 		tree, err := BuildConnectorTree(
 			batchOutpoint,
-			batchOutput,
+			extractBatchOutput,
 			connector,
 			operatorPubKey,
 			2,
@@ -559,9 +605,15 @@ func TestBuildConnectorTree(t *testing.T) {
 			Amount:    btcutil.Amount(330),
 		}
 
+		// Batch output = 4 * 330 = 1320.
+		identicalBatchOutput := &wire.TxOut{
+			Value:    1320,
+			PkScript: []byte("connector_batch_script"),
+		}
+
 		tree, err := BuildConnectorTree(
 			batchOutpoint,
-			batchOutput,
+			identicalBatchOutput,
 			connector,
 			operatorPubKey,
 			2,

--- a/lib/tree/btc_tree_assembler.go
+++ b/lib/tree/btc_tree_assembler.go
@@ -1,0 +1,142 @@
+package tree
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/wire"
+)
+
+const (
+	// DefaultRadix is the default branching factor for tree construction.
+	DefaultRadix = 2
+)
+
+// TreeConfig carries the parameters needed to build a BTC-only tree.
+type TreeConfig struct {
+	// OperatorKey is the operator's public key (included in all cosigner
+	// sets).
+	OperatorKey *btcec.PublicKey
+
+	// SweepTapscriptRoot is the tapscript root used for the sweep script.
+	// This provides the unilateral exit path for tree outputs.
+	SweepTapscriptRoot []byte
+
+	// Radix is the maximum number of children per branch node. If zero,
+	// defaults to 2.
+	Radix int
+
+	// WeightFn determines how leaves are weighted for partitioning.
+	// If nil, defaults to WeightByBtcAmount().
+	WeightFn PartitionWeightFunc
+}
+
+// TreeAssembler builds a BTC-only tree using the two-pass approach:
+// structure building (pass 1) followed by materialization (pass 2).
+type TreeAssembler struct {
+	cfg TreeConfig
+}
+
+// NewTreeAssembler constructs an assembler with the given configuration.
+func NewTreeAssembler(cfg TreeConfig) *TreeAssembler {
+	return &TreeAssembler{cfg: cfg}
+}
+
+// BuildTree assembles a BTC-only tree using a two-pass approach:
+//
+// Pass 1 (bottom-up): Build tree structure from leaf descriptors, computing
+// cosigners at each level. No transactions are built yet.
+//
+// Pass 2 (top-down): Materialize transactions starting from the root, filling
+// in Input, Outputs, and FinalKey as we traverse down the tree.
+//
+// Parameters:
+//   - rootInput: The outpoint being spent by the root transaction
+//   - rootOutput: The output being spent (provides BTC value)
+//   - leaves: Leaf descriptors defining the tree leaves
+//
+// Returns the assembled tree.
+func (a *TreeAssembler) BuildTree(rootInput wire.OutPoint,
+	rootOutput *wire.TxOut, leaves []LeafDescriptor) (*Tree, error) {
+
+	if len(leaves) == 0 {
+		return nil, fmt.Errorf("no leaves supplied")
+	}
+	if rootOutput == nil {
+		return nil, fmt.Errorf("root output cannot be nil")
+	}
+	if a.cfg.OperatorKey == nil {
+		return nil, fmt.Errorf("operator key cannot be nil")
+	}
+	if a.cfg.Radix < DefaultRadix && a.cfg.Radix != 0 {
+		return nil, fmt.Errorf("radix must be at least %d, got %d",
+			DefaultRadix, a.cfg.Radix)
+	}
+
+	// Note: SweepTapscriptRoot can be nil for connector trees which have
+	// no sweep script (they're signed only by the operator).
+
+	// Apply defaults.
+	radix := a.cfg.Radix
+	if radix == 0 {
+		radix = DefaultRadix
+	}
+
+	weightFn := a.cfg.WeightFn
+	if weightFn == nil {
+		weightFn = WeightByBtcAmount()
+	}
+
+	// Pass 1: Build tree structure bottom-up. This determines the tree
+	// shape, partitions leaves into groups, and computes cosigners at
+	// each level.
+	structCfg := StructureConfig{
+		OperatorKey: a.cfg.OperatorKey,
+		Radix:       radix,
+		WeightFn:    weightFn,
+	}
+
+	result, err := BuildStructure(leaves, structCfg)
+	if err != nil {
+		return nil, fmt.Errorf("build tree structure: %w", err)
+	}
+	root := result.Root
+
+	// Sanity check: the sum of all leaf BTC amounts (stored in
+	// root.Amount) must be equal to the root output value.
+	rootValue := btcutil.Amount(rootOutput.Value)
+	if root.Amount != rootValue {
+		return nil, fmt.Errorf("leaf amounts sum (%v) must equal the "+
+			"output value (%v)", root.Amount, rootValue)
+	}
+
+	// Pass 2: Materialize transactions top-down. The BTCMaterializer
+	// uses the leaf scripts map from structure building.
+	leafScriptFn := ScriptLookupFromMap(result.LeafScriptMap)
+	mat := NewBTCMaterializer(
+		a.cfg.OperatorKey, a.cfg.SweepTapscriptRoot, leafScriptFn,
+	)
+
+	// BTC values are now carried by each node's Amount field (set during
+	// structure building), so we only need to provide the root input.
+	matParams := MaterializeParams{
+		Input: rootInput,
+	}
+
+	// Bitcoin-only tree materialization doesn't use the context so we can
+	// just pass background.
+	if err := Materialize(
+		context.Background(), root, matParams, mat,
+	); err != nil {
+		return nil, fmt.Errorf("materialize tree: %w", err)
+	}
+
+	return &Tree{
+		Root:               root,
+		BatchOutpoint:      rootInput,
+		BatchOutput:        rootOutput,
+		SweepTapscriptRoot: a.cfg.SweepTapscriptRoot,
+	}, nil
+}

--- a/lib/tree/btc_tree_assembler_test.go
+++ b/lib/tree/btc_tree_assembler_test.go
@@ -1,0 +1,409 @@
+package tree
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBTCTreeAssemblerBuildTree tests the BTC tree assembler's two-pass
+// construction flow.
+func TestBTCTreeAssemblerBuildTree(t *testing.T) {
+	t.Parallel()
+
+	// Generate test keys.
+	operatorKey := genPubKey(t)
+	sweepKey := genPubKey(t)
+	sweepTapscriptRoot := computeSweepTapscriptRoot(t, sweepKey)
+
+	t.Run("single leaf tree", func(t *testing.T) {
+		t.Parallel()
+
+		// Create a single leaf descriptor.
+		leafKey := genPubKey(t)
+		leafPkScript := genTaprootPkScript(t, leafKey)
+
+		leaves := []LeafDescriptor{{
+			CoSignerKey: leafKey,
+			PkScript:    leafPkScript,
+			Amount:      btcutil.Amount(10000),
+		}}
+
+		// Build tree.
+		assembler := NewTreeAssembler(TreeConfig{
+			OperatorKey:        operatorKey,
+			SweepTapscriptRoot: sweepTapscriptRoot,
+			Radix:              4,
+		})
+
+		rootInput := wire.OutPoint{
+			Hash:  chainhash.HashH([]byte("root-input")),
+			Index: 0,
+		}
+		rootPkScript := genTaprootPkScript(t, operatorKey)
+		rootOutput := wire.NewTxOut(10000, rootPkScript)
+
+		tree, err := assembler.BuildTree(rootInput, rootOutput, leaves)
+		require.NoError(t, err)
+		require.NotNil(t, tree)
+
+		// Verify tree structure.
+		require.NotNil(t, tree.Root)
+		require.True(t, tree.Root.IsLeaf())
+		require.Equal(t, rootInput, tree.BatchOutpoint)
+		require.Equal(t, rootOutput, tree.BatchOutput)
+		require.Equal(t, sweepTapscriptRoot, tree.SweepTapscriptRoot)
+
+		// Verify leaf has outputs set.
+		require.NotNil(t, tree.Root.Outputs)
+		require.Len(t, tree.Root.Outputs, 2) // leaf output + anchor
+
+		// Verify leaf output uses the provided pkscript.
+		require.Equal(t, leafPkScript, tree.Root.Outputs[0].PkScript)
+
+		// Verify final key is set.
+		require.NotNil(t, tree.Root.FinalKey)
+
+		// Verify the tree passes verification.
+		require.NoError(t, tree.Verify())
+	})
+
+	t.Run("multi-leaf tree with branching", func(t *testing.T) {
+		t.Parallel()
+
+		// Create multiple leaves to force branching.
+		var leaves []LeafDescriptor
+		for i := 0; i < 5; i++ {
+			leafKey := genPubKey(t)
+			leaves = append(leaves, LeafDescriptor{
+				CoSignerKey: leafKey,
+				PkScript:    genTaprootPkScript(t, leafKey),
+				Amount:      btcutil.Amount(10000),
+			})
+		}
+
+		assembler := NewTreeAssembler(TreeConfig{
+			OperatorKey:        operatorKey,
+			SweepTapscriptRoot: sweepTapscriptRoot,
+			Radix:              2, // binary tree
+		})
+
+		rootInput := wire.OutPoint{
+			Hash:  chainhash.HashH([]byte("root-input-multi")),
+			Index: 0,
+		}
+		rootPkScript := genTaprootPkScript(t, operatorKey)
+		rootOutput := wire.NewTxOut(50000, rootPkScript)
+
+		tree, err := assembler.BuildTree(rootInput, rootOutput, leaves)
+		require.NoError(t, err)
+		require.NotNil(t, tree)
+
+		// Root should be a branch with children.
+		require.False(t, tree.Root.IsLeaf())
+		require.NotEmpty(t, tree.Root.Children)
+
+		// Verify outputs are set on root.
+		require.NotNil(t, tree.Root.Outputs)
+
+		// Count leaves to verify tree structure.
+		leafCount := 0
+		err = tree.Root.ForEachLeaf(func(n *Node) error {
+			leafCount++
+			// Each leaf should have outputs and final key set.
+			require.NotNil(t, n.Outputs)
+			require.NotNil(t, n.FinalKey)
+
+			return nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, 5, leafCount)
+
+		// Verify the tree passes verification.
+		require.NoError(t, tree.Verify())
+	})
+
+	t.Run("error cases", func(t *testing.T) {
+		t.Parallel()
+
+		assembler := NewTreeAssembler(TreeConfig{
+			OperatorKey:        operatorKey,
+			SweepTapscriptRoot: sweepTapscriptRoot,
+		})
+
+		rootInput := wire.OutPoint{
+			Hash:  chainhash.HashH([]byte("test")),
+			Index: 0,
+		}
+		rootPkScript := genTaprootPkScript(t, operatorKey)
+		rootOutput := wire.NewTxOut(10000, rootPkScript)
+
+		t.Run("empty leaves fails", func(t *testing.T) {
+			_, err := assembler.BuildTree(
+				rootInput, rootOutput, nil,
+			)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "no leaves supplied")
+		})
+
+		t.Run("nil root output fails", func(t *testing.T) {
+			leafKey := genPubKey(t)
+			leaves := []LeafDescriptor{{
+				CoSignerKey: leafKey,
+				PkScript:    genTaprootPkScript(t, leafKey),
+			}}
+			_, err := assembler.BuildTree(rootInput, nil, leaves)
+			require.Error(t, err)
+			require.Contains(
+				t, err.Error(), "root output cannot be nil",
+			)
+		})
+	})
+
+	t.Run("nil operator key fails", func(t *testing.T) {
+		t.Parallel()
+
+		assembler := NewTreeAssembler(TreeConfig{
+			OperatorKey:        nil,
+			SweepTapscriptRoot: sweepTapscriptRoot,
+		})
+
+		rootInput := wire.OutPoint{
+			Hash:  chainhash.HashH([]byte("test")),
+			Index: 0,
+		}
+		rootPkScript := genTaprootPkScript(t, operatorKey)
+		rootOutput := wire.NewTxOut(10000, rootPkScript)
+		leafKey := genPubKey(t)
+		leaves := []LeafDescriptor{{
+			CoSignerKey: leafKey,
+			PkScript:    genTaprootPkScript(t, leafKey),
+		}}
+
+		_, err := assembler.BuildTree(rootInput, rootOutput, leaves)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "operator key cannot be nil")
+	})
+
+	t.Run("nil sweep tapscript root works for connectors", func(t *testing.T) { //nolint:ll
+		t.Parallel()
+
+		// Connector trees don't have sweep scripts, so nil is valid.
+		assembler := NewTreeAssembler(TreeConfig{
+			OperatorKey:        operatorKey,
+			SweepTapscriptRoot: nil,
+			Radix:              4,
+		})
+
+		rootInput := wire.OutPoint{
+			Hash:  chainhash.HashH([]byte("test")),
+			Index: 0,
+		}
+		rootPkScript := genTaprootPkScript(t, operatorKey)
+		rootOutput := wire.NewTxOut(10000, rootPkScript)
+		leafKey := genPubKey(t)
+		leaves := []LeafDescriptor{{
+			CoSignerKey: leafKey,
+			PkScript:    genTaprootPkScript(t, leafKey),
+			Amount:      btcutil.Amount(10000),
+		}}
+
+		tree, err := assembler.BuildTree(rootInput, rootOutput, leaves)
+		require.NoError(t, err)
+		require.NotNil(t, tree)
+
+		// Verify the tree passes verification.
+		require.NoError(t, tree.Verify())
+	})
+
+	t.Run("default radix is applied", func(t *testing.T) {
+		t.Parallel()
+
+		// Create enough leaves to see branching with default radix.
+		var leaves []LeafDescriptor
+		for i := 0; i < 8; i++ {
+			leafKey := genPubKey(t)
+			leaves = append(leaves, LeafDescriptor{
+				CoSignerKey: leafKey,
+				PkScript:    genTaprootPkScript(t, leafKey),
+				Amount:      btcutil.Amount(1000),
+			})
+		}
+
+		// Config with Radix=0 should default to 4.
+		assembler := NewTreeAssembler(TreeConfig{
+			OperatorKey:        operatorKey,
+			SweepTapscriptRoot: sweepTapscriptRoot,
+			Radix:              0,
+		})
+
+		rootInput := wire.OutPoint{
+			Hash:  chainhash.HashH([]byte("default-radix")),
+			Index: 0,
+		}
+		rootPkScript := genTaprootPkScript(t, operatorKey)
+		rootOutput := wire.NewTxOut(8000, rootPkScript)
+
+		tree, err := assembler.BuildTree(rootInput, rootOutput, leaves)
+		require.NoError(t, err)
+		require.NotNil(t, tree)
+
+		// With 8 leaves and radix 4, root should have children.
+		require.False(t, tree.Root.IsLeaf())
+
+		// Verify structure is correct.
+		require.NoError(t, tree.Verify())
+	})
+
+	t.Run("unequal leaf amounts produce correct outputs", func(t *testing.T) { //nolint:ll
+		t.Parallel()
+
+		// Create leaves with different amounts to verify each leaf's
+		// output uses the correct value from its descriptor.
+		amounts := []btcutil.Amount{5000, 15000, 3000, 7000}
+		var leaves []LeafDescriptor
+		leafKeys := make([]*btcec.PublicKey, len(amounts))
+
+		for i, amt := range amounts {
+			leafKey := genPubKey(t)
+			leafKeys[i] = leafKey
+			leaves = append(leaves, LeafDescriptor{
+				CoSignerKey: leafKey,
+				PkScript:    genTaprootPkScript(t, leafKey),
+				Amount:      amt,
+			})
+		}
+
+		assembler := NewTreeAssembler(TreeConfig{
+			OperatorKey:        operatorKey,
+			SweepTapscriptRoot: sweepTapscriptRoot,
+			// Binary tree for predictable structure.
+			Radix: 2,
+		})
+
+		totalAmount := btcutil.Amount(30000)
+		rootInput := wire.OutPoint{
+			Hash:  chainhash.HashH([]byte("unequal-amounts")),
+			Index: 0,
+		}
+		rootPkScript := genTaprootPkScript(t, operatorKey)
+		rootOutput := wire.NewTxOut(int64(totalAmount), rootPkScript)
+
+		tree, err := assembler.BuildTree(rootInput, rootOutput, leaves)
+		require.NoError(t, err)
+		require.NotNil(t, tree)
+
+		// Collect all leaf output amounts.
+		var leafOutputAmounts []btcutil.Amount
+		err = tree.Root.ForEachLeaf(func(n *Node) error {
+			require.NotNil(t, n.Outputs)
+			require.GreaterOrEqual(t, len(n.Outputs), 1)
+
+			// First output is the leaf output (not anchor).
+			leafOutputAmounts = append(
+				leafOutputAmounts,
+				btcutil.Amount(n.Outputs[0].Value),
+			)
+
+			return nil
+		})
+		require.NoError(t, err)
+
+		// Verify we have 4 leaves with outputs.
+		require.Len(t, leafOutputAmounts, 4)
+
+		// Sum of all leaf outputs should equal sum of input amounts.
+		var totalLeafOutput btcutil.Amount
+		for _, amt := range leafOutputAmounts {
+			totalLeafOutput += amt
+		}
+		require.Equal(t, totalAmount, totalLeafOutput)
+
+		// Verify tree structure is valid.
+		require.NoError(t, tree.Verify())
+	})
+
+	t.Run("leaf amounts exceeding root value fails", func(t *testing.T) {
+		t.Parallel()
+
+		// Create leaves whose total exceeds the root output value.
+		leafKey1 := genPubKey(t)
+		leafKey2 := genPubKey(t)
+		leaves := []LeafDescriptor{
+			{
+				CoSignerKey: genPubKey(t),
+				PkScript:    genTaprootPkScript(t, leafKey1),
+				Amount:      btcutil.Amount(10000),
+			},
+			{
+				CoSignerKey: genPubKey(t),
+				PkScript:    genTaprootPkScript(t, leafKey2),
+				Amount:      btcutil.Amount(10000),
+			},
+		}
+
+		assembler := NewTreeAssembler(TreeConfig{
+			OperatorKey:        operatorKey,
+			SweepTapscriptRoot: sweepTapscriptRoot,
+			Radix:              4,
+		})
+
+		rootInput := wire.OutPoint{
+			Hash:  chainhash.HashH([]byte("exceeds-value")),
+			Index: 0,
+		}
+
+		// Root output value (15000) is less than sum of leaf amounts
+		// (20000).
+		rootOutput := wire.NewTxOut(
+			15000, genTaprootPkScript(t, operatorKey),
+		)
+
+		_, err := assembler.BuildTree(rootInput, rootOutput, leaves)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "must equal the output value")
+	})
+}
+
+// genPubKey generates a random public key for testing.
+func genPubKey(t *testing.T) *btcec.PublicKey {
+	t.Helper()
+
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	return privKey.PubKey()
+}
+
+// genTaprootPkScript generates a P2TR script for the given key.
+func genTaprootPkScript(t *testing.T, key *btcec.PublicKey) []byte {
+	t.Helper()
+
+	pkScript, err := txscript.PayToTaprootScript(key)
+	require.NoError(t, err)
+
+	return pkScript
+}
+
+// computeSweepTapscriptRoot computes a tapscript root for a sweep key.
+func computeSweepTapscriptRoot(t *testing.T, sweepKey *btcec.PublicKey) []byte {
+	t.Helper()
+
+	// Create a simple tapscript tree with a single leaf.
+	sweepScript, err := txscript.NewScriptBuilder().
+		AddData(sweepKey.SerializeCompressed()).
+		AddOp(txscript.OP_CHECKSIG).
+		Script()
+	require.NoError(t, err)
+
+	tapLeaf := txscript.NewBaseTapLeaf(sweepScript)
+	tree := txscript.AssembleTaprootScriptTree(tapLeaf)
+	root := tree.RootNode.TapHash()
+
+	return root[:]
+}

--- a/lib/tree/build.go
+++ b/lib/tree/build.go
@@ -1,111 +1,37 @@
 package tree
 
 import (
-	"fmt"
-
-	"github.com/btcsuite/btcd/btcec/v2"
-	"github.com/btcsuite/btcd/wire"
+	"sort"
 )
 
-// workItem represents a unit of work in the tree building queue.
-type workItem struct {
-	input    wire.OutPoint
-	leaves   []LeafDescriptor
-	parent   *Node
-	outIndex uint32
+// PartitionWeightFunc returns the weight used to balance leaves during tree
+// construction. When nil, leaves are partitioned purely by count.
+type PartitionWeightFunc func(LeafDescriptor) int64
+
+// WeightByBtcAmount is a partition function that simply prefers the BTC amount.
+func WeightByBtcAmount() PartitionWeightFunc {
+	return func(l LeafDescriptor) int64 {
+		return int64(l.Amount)
+	}
 }
 
-// buildTreeBFS builds the tree using breadth-first search with a work queue.
-func buildTreeBFS(rootInput wire.OutPoint, leaves []LeafDescriptor,
-	operatorKey *btcec.PublicKey, sweepTapscriptRoot []byte,
-	radix int) (*Node, error) {
+// partitionLeaves divides leaves into balanced groups. When a weight function
+// is provided, groups are balanced by cumulative weight; otherwise, leaves are
+// distributed purely by count (legacy behavior).
+func partitionLeaves(leaves []LeafDescriptor, radix int,
+	weightFn PartitionWeightFunc) [][]LeafDescriptor {
 
-	// Initialize queue with root work item.
-	queue := NewQueue[workItem]()
-	queue.Enqueue(workItem{
-		input:    rootInput,
-		leaves:   leaves,
-		parent:   nil,
-		outIndex: 0,
-	})
-
-	var root *Node
-
-	// Process queue iteratively (BFS).
-	for !queue.IsEmpty() {
-		work, ok := queue.Dequeue()
-		if !ok {
-			return nil, fmt.Errorf("unexpected empty queue")
-		}
-
-		var node *Node
-		var err error
-
-		// Base case: single leaf creates a leaf transaction.
-		if len(work.leaves) == 1 {
-			node, err = NewLeafNode(
-				work.input, work.leaves[0], operatorKey,
-				sweepTapscriptRoot,
-			)
-			if err != nil {
-				return nil, fmt.Errorf("failed to create "+
-					"leaf node: %w", err)
-			}
-		} else {
-			// Partition leaves into balanced groups.
-			groups := partitionLeaves(work.leaves, radix)
-
-			// Create branch transaction.
-			node, err = NewBranchNode(
-				work.input, groups, operatorKey,
-				sweepTapscriptRoot,
-			)
-			if err != nil {
-				return nil, fmt.Errorf("failed to create "+
-					"branch node: %w", err)
-			}
-
-			// Enqueue children for processing.
-			parentTxHash, err := node.TXID()
-			if err != nil {
-				return nil, fmt.Errorf("failed to get "+
-					"parent TXID: %w", err)
-			}
-
-			for i, group := range groups {
-				if len(group) == 0 {
-					continue
-				}
-
-				childInput := wire.OutPoint{
-					Hash:  parentTxHash,
-					Index: uint32(i),
-				}
-
-				queue.Enqueue(workItem{
-					input:    childInput,
-					leaves:   group,
-					parent:   node,
-					outIndex: uint32(i),
-				})
-			}
-		}
-
-		// Link to parent.
-		if work.parent != nil {
-			work.parent.Children[work.outIndex] = node
-		} else {
-			root = node
-		}
+	if weightFn == nil {
+		return partitionLeavesByCount(leaves, radix)
 	}
 
-	return root, nil
+	return partitionLeavesByWeight(leaves, radix, weightFn)
 }
 
-// partitionLeaves divides leaves into balanced groups using round-robin
-// assignment. It ensures even distribution of items across groups to create a
-// balanced tree.
-func partitionLeaves(leaves []LeafDescriptor, radix int) [][]LeafDescriptor {
+// partitionLeavesByCount distributes leaves evenly by count.
+func partitionLeavesByCount(leaves []LeafDescriptor,
+	radix int) [][]LeafDescriptor {
+
 	M := len(leaves)
 
 	if M <= radix {
@@ -161,6 +87,65 @@ func partitionLeaves(leaves []LeafDescriptor, radix int) [][]LeafDescriptor {
 		// Fallback: split in half to guarantee progress.
 		mid := M / 2
 		return [][]LeafDescriptor{leaves[:mid], leaves[mid:]}
+	}
+
+	return nonEmpty
+}
+
+// partitionLeavesByWeight balances groups by cumulative weight using a greedy
+// assignment of sorted leaves.
+func partitionLeavesByWeight(leaves []LeafDescriptor, radix int,
+	weightFn PartitionWeightFunc) [][]LeafDescriptor {
+
+	type weightedLeaf struct {
+		leaf   LeafDescriptor
+		weight int64
+		index  int
+	}
+
+	weighted := make([]weightedLeaf, len(leaves))
+	for i, leaf := range leaves {
+		w := weightFn(leaf)
+		if w < 0 {
+			w = 0
+		}
+		weighted[i] = weightedLeaf{
+			leaf:   leaf,
+			weight: w,
+			index:  i,
+		}
+	}
+
+	sort.SliceStable(weighted, func(i, j int) bool {
+		if weighted[i].weight == weighted[j].weight {
+			return weighted[i].index < weighted[j].index
+		}
+
+		return weighted[i].weight > weighted[j].weight
+	})
+
+	groups := make([][]LeafDescriptor, radix)
+	groupWeights := make([]int64, radix)
+
+	for _, wl := range weighted {
+		// Assign to the group with the smallest cumulative weight.
+		minIdx := 0
+		for i := 1; i < radix; i++ {
+			if groupWeights[i] < groupWeights[minIdx] {
+				minIdx = i
+			}
+		}
+
+		groups[minIdx] = append(groups[minIdx], wl.leaf)
+		groupWeights[minIdx] += wl.weight
+	}
+
+	// Drop empty groups to preserve existing expectations.
+	nonEmpty := make([][]LeafDescriptor, 0, radix)
+	for _, g := range groups {
+		if len(g) > 0 {
+			nonEmpty = append(nonEmpty, g)
+		}
 	}
 
 	return nonEmpty

--- a/lib/tree/build_test.go
+++ b/lib/tree/build_test.go
@@ -34,7 +34,7 @@ func TestPartitionLeaves(t *testing.T) {
 
 		// 3 leaves with radix 5 should create 3 groups of 1 leaf each.
 		leaves := createLeaves(3)
-		groups := partitionLeaves(leaves, 5)
+		groups := partitionLeaves(leaves, 5, nil)
 
 		require.Len(t, groups, 3)
 		for i, group := range groups {
@@ -50,7 +50,7 @@ func TestPartitionLeaves(t *testing.T) {
 
 		// 4 leaves with radix 4 should create 4 groups of 1 leaf each.
 		leaves := createLeaves(4)
-		groups := partitionLeaves(leaves, 4)
+		groups := partitionLeaves(leaves, 4, nil)
 
 		require.Len(t, groups, 4)
 		for i, group := range groups {
@@ -67,7 +67,7 @@ func TestPartitionLeaves(t *testing.T) {
 		// 8 leaves with radix 4 should create 4 groups of 2 leaves
 		// each.
 		leaves := createLeaves(8)
-		groups := partitionLeaves(leaves, 4)
+		groups := partitionLeaves(leaves, 4, nil)
 
 		require.Len(t, groups, 4)
 		for i, group := range groups {
@@ -85,7 +85,7 @@ func TestPartitionLeaves(t *testing.T) {
 		// - 2 groups with 3 leaves (10 % 4 = 2 extra).
 		// - 2 groups with 2 leaves (10 / 4 = 2 base).
 		leaves := createLeaves(10)
-		groups := partitionLeaves(leaves, 4)
+		groups := partitionLeaves(leaves, 4, nil)
 
 		require.Len(t, groups, 4)
 
@@ -114,7 +114,7 @@ func TestPartitionLeaves(t *testing.T) {
 		t.Parallel()
 
 		leaves := createLeaves(1)
-		groups := partitionLeaves(leaves, 4)
+		groups := partitionLeaves(leaves, 4, nil)
 
 		require.Len(t, groups, 1)
 		require.Len(t, groups[0], 1)
@@ -124,7 +124,7 @@ func TestPartitionLeaves(t *testing.T) {
 		t.Parallel()
 
 		leaves := createLeaves(2)
-		groups := partitionLeaves(leaves, 4)
+		groups := partitionLeaves(leaves, 4, nil)
 
 		// Should create 2 groups with 1 leaf each.
 		require.Len(t, groups, 2)
@@ -140,7 +140,7 @@ func TestPartitionLeaves(t *testing.T) {
 		// algorithm should prevent this, the fallback provides defense
 		// in depth.
 		leaves := createLeaves(2)
-		groups := partitionLeaves(leaves, 100)
+		groups := partitionLeaves(leaves, 100, nil)
 
 		// Should have exactly 2 groups (fallback split in half).
 		require.Len(t, groups, 2)
@@ -155,7 +155,7 @@ func TestPartitionLeaves(t *testing.T) {
 		// - Group 0: 4 leaves (7 / 2 = 3 base + 1 extra).
 		// - Group 1: 3 leaves (7 / 2 = 3 base).
 		leaves := createLeaves(7)
-		groups := partitionLeaves(leaves, 2)
+		groups := partitionLeaves(leaves, 2, nil)
 
 		require.Len(t, groups, 2)
 		require.Len(t, groups[0], 4)
@@ -167,7 +167,7 @@ func TestPartitionLeaves(t *testing.T) {
 
 		// 100 leaves with radix 10.
 		leaves := createLeaves(100)
-		groups := partitionLeaves(leaves, 10)
+		groups := partitionLeaves(leaves, 10, nil)
 
 		require.Len(t, groups, 10)
 
@@ -184,7 +184,7 @@ func TestPartitionLeaves(t *testing.T) {
 		t.Parallel()
 
 		leaves := createLeaves(17)
-		groups := partitionLeaves(leaves, 5)
+		groups := partitionLeaves(leaves, 5, nil)
 
 		// Count total leaves across all groups.
 		totalLeaves := 0
@@ -195,9 +195,40 @@ func TestPartitionLeaves(t *testing.T) {
 		require.Equal(t, 17, totalLeaves,
 			"all leaves should be assigned to groups")
 	})
+
+	t.Run("weighted partition prefers heavy leaf alone", func(t *testing.T) { //nolint:ll
+		t.Parallel()
+
+		// Test that weighted partitioning groups leaves by BTC amount.
+		// The heavy leaf (10000 sats) should go to its own group while
+		// the two light leaves (1000 sats each) share the other group,
+		// balancing total weight across groups.
+		leaves := []LeafDescriptor{
+			{
+				PkScript: []byte("heavy"),
+				Amount:   10_000,
+			},
+			{
+				PkScript: []byte("light1"),
+				Amount:   1000,
+			},
+			{
+				PkScript: []byte("light2"),
+				Amount:   1000,
+			},
+		}
+
+		weightFn := WeightByBtcAmount()
+
+		groups := partitionLeaves(leaves, 2, weightFn)
+
+		require.Len(t, groups, 2)
+		require.Len(t, groups[0], 1)
+		require.Len(t, groups[1], 2)
+	})
 }
 
-// TestBuildTreeBFS tests the buildTreeBFS function.
+// TestBuildTreeBFS tests the BTCTreeAssembler.BuildTree function.
 func TestBuildTreeBFS(t *testing.T) {
 	t.Parallel()
 
@@ -234,6 +265,32 @@ func TestBuildTreeBFS(t *testing.T) {
 		return privKey.PubKey()
 	}
 
+	// runBuild is a helper to build a tree using BTCTreeAssembler.
+	runBuild := func(t *testing.T, input wire.OutPoint,
+		leaves []LeafDescriptor, operatorKey *btcec.PublicKey,
+		sweepRoot []byte, radix int,
+		weight PartitionWeightFunc) (*Node, error) {
+
+		assembler := NewTreeAssembler(TreeConfig{
+			OperatorKey:        operatorKey,
+			SweepTapscriptRoot: sweepRoot,
+			Radix:              radix,
+			WeightFn:           weight,
+		})
+
+		rootOutput := &wire.TxOut{
+			Value:    1000 * int64(len(leaves)),
+			PkScript: []byte("root"),
+		}
+
+		tree, err := assembler.BuildTree(input, rootOutput, leaves)
+		if err != nil {
+			return nil, err
+		}
+
+		return tree.Root, nil
+	}
+
 	t.Run("single leaf creates leaf node", func(t *testing.T) {
 		t.Parallel()
 
@@ -242,8 +299,8 @@ func TestBuildTreeBFS(t *testing.T) {
 		input := createTestInput()
 		sweepRoot := make([]byte, 32)
 
-		root, err := buildTreeBFS(
-			input, leaves, operatorKey, sweepRoot, 4,
+		root, err := runBuild(
+			t, input, leaves, operatorKey, sweepRoot, 4, nil,
 		)
 		require.NoError(t, err)
 		require.NotNil(t, root)
@@ -270,8 +327,9 @@ func TestBuildTreeBFS(t *testing.T) {
 			input := createTestInput()
 			sweepRoot := make([]byte, 32)
 
-			root, err := buildTreeBFS(
-				input, leaves, operatorKey, sweepRoot, 4,
+			root, err := runBuild(
+				t, input, leaves, operatorKey, sweepRoot, 4,
+				nil,
 			)
 			require.NoError(t, err)
 			require.NotNil(t, root)
@@ -302,8 +360,9 @@ func TestBuildTreeBFS(t *testing.T) {
 			input := createTestInput()
 			sweepRoot := make([]byte, 32)
 
-			root, err := buildTreeBFS(
-				input, leaves, operatorKey, sweepRoot, 2,
+			root, err := runBuild(
+				t, input, leaves, operatorKey, sweepRoot, 2,
+				nil,
 			)
 			require.NoError(t, err)
 			require.NotNil(t, root)
@@ -358,8 +417,9 @@ func TestBuildTreeBFS(t *testing.T) {
 			input := createTestInput()
 			sweepRoot := make([]byte, 32)
 
-			root, err := buildTreeBFS(
-				input, leaves, operatorKey, sweepRoot, 4,
+			root, err := runBuild(
+				t, input, leaves, operatorKey, sweepRoot, 4,
+				nil,
 			)
 			require.NoError(t, err)
 			require.NotNil(t, root)
@@ -416,8 +476,8 @@ func TestBuildTreeBFS(t *testing.T) {
 		input := createTestInput()
 		sweepRoot := make([]byte, 32)
 
-		root, err := buildTreeBFS(
-			input, leaves, operatorKey, sweepRoot, 4,
+		root, err := runBuild(
+			t, input, leaves, operatorKey, sweepRoot, 4, nil,
 		)
 		require.NoError(t, err)
 		require.NotNil(t, root)
@@ -448,8 +508,8 @@ func TestBuildTreeBFS(t *testing.T) {
 		input := createTestInput()
 		sweepRoot := make([]byte, 32)
 
-		root, err := buildTreeBFS(
-			input, leaves, operatorKey, sweepRoot, 3,
+		root, err := runBuild(
+			t, input, leaves, operatorKey, sweepRoot, 3, nil,
 		)
 		require.NoError(t, err)
 		require.NotNil(t, root)
@@ -467,8 +527,8 @@ func TestBuildTreeBFS(t *testing.T) {
 		input := createTestInput()
 		sweepRoot := make([]byte, 32)
 
-		root, err := buildTreeBFS(
-			input, leaves, operatorKey, sweepRoot, 2,
+		root, err := runBuild(
+			t, input, leaves, operatorKey, sweepRoot, 2, nil,
 		)
 		require.NoError(t, err)
 		require.NotNil(t, root)
@@ -494,8 +554,8 @@ func TestBuildTreeBFS(t *testing.T) {
 		input := createTestInput()
 		sweepRoot := make([]byte, 32)
 
-		root, err := buildTreeBFS(
-			input, leaves, operatorKey, sweepRoot, 10,
+		root, err := runBuild(
+			t, input, leaves, operatorKey, sweepRoot, 10, nil,
 		)
 		require.NoError(t, err)
 		require.NotNil(t, root)
@@ -520,8 +580,8 @@ func TestBuildTreeBFS(t *testing.T) {
 		input := createTestInput()
 		sweepRoot := make([]byte, 32)
 
-		root, err := buildTreeBFS(
-			input, leaves, operatorKey, sweepRoot, 4,
+		root, err := runBuild(
+			t, input, leaves, operatorKey, sweepRoot, 4, nil,
 		)
 		require.NoError(t, err)
 		require.NotNil(t, root)
@@ -548,8 +608,8 @@ func TestBuildTreeBFS(t *testing.T) {
 		input := createTestInput()
 		sweepRoot := make([]byte, 32)
 
-		root, err := buildTreeBFS(
-			input, leaves, operatorKey, sweepRoot, 2,
+		root, err := runBuild(
+			t, input, leaves, operatorKey, sweepRoot, 2, nil,
 		)
 		require.NoError(t, err)
 		require.NotNil(t, root)
@@ -581,8 +641,8 @@ func TestBuildTreeBFS(t *testing.T) {
 		input := createTestInput()
 		sweepRoot := make([]byte, 32)
 
-		root, err := buildTreeBFS(
-			input, leaves, operatorKey, sweepRoot, 4,
+		root, err := runBuild(
+			t, input, leaves, operatorKey, sweepRoot, 4, nil,
 		)
 		require.NoError(t, err)
 		require.NotNil(t, root)
@@ -614,6 +674,33 @@ func TestBuildTreeBFSEdgeCases(t *testing.T) {
 		}
 	}
 
+	// runBuild is a helper to build a tree using BTCTreeAssembler.
+	runBuild := func(t *testing.T, input wire.OutPoint,
+		leaves []LeafDescriptor, operatorKey *btcec.PublicKey,
+		sweepRoot []byte, radix int) (*Node, error) {
+
+		assembler := NewTreeAssembler(TreeConfig{
+			OperatorKey:        operatorKey,
+			SweepTapscriptRoot: sweepRoot,
+			Radix:              radix,
+			// Use the default weight function.
+			WeightFn: nil,
+		})
+
+		// Create a mock root output for the assembler.
+		rootOutput := &wire.TxOut{
+			Value:    1000 * int64(len(leaves)),
+			PkScript: []byte("root"),
+		}
+
+		tree, err := assembler.BuildTree(input, rootOutput, leaves)
+		if err != nil {
+			return nil, err
+		}
+
+		return tree.Root, nil
+	}
+
 	t.Run("nil operator key fails in leaf creation", func(t *testing.T) {
 		t.Parallel()
 
@@ -634,14 +721,12 @@ func TestBuildTreeBFSEdgeCases(t *testing.T) {
 		// creation.
 		leaves = append(leaves, leaves[0])
 
-		_, err := buildTreeBFS(
-			input, leaves, nil, sweepRoot, 4,
-		)
+		_, err := runBuild(t, input, leaves, nil, sweepRoot, 4)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "operator key cannot be nil")
 	})
 
-	t.Run("nil leaf cosigner key fails", func(t *testing.T) {
+	t.Run("nil leaf cosigner key returns error", func(t *testing.T) {
 		t.Parallel()
 
 		leaves := []LeafDescriptor{
@@ -660,9 +745,8 @@ func TestBuildTreeBFSEdgeCases(t *testing.T) {
 		input := createTestInput()
 		sweepRoot := make([]byte, 32)
 
-		_, err := buildTreeBFS(
-			input, leaves, operatorKey, sweepRoot, 4,
-		)
+		// Nil cosigner keys should cause an error during tree building.
+		_, err := runBuild(t, input, leaves, operatorKey, sweepRoot, 4)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "cosigner key cannot be nil")
 	})
@@ -690,8 +774,8 @@ func TestBuildTreeBFSEdgeCases(t *testing.T) {
 
 		// Test with different radix values.
 		for _, radix := range []int{2, 3, 4, 5, 10} {
-			root, err := buildTreeBFS(
-				input, leaves, operatorKey, sweepRoot, radix,
+			root, err := runBuild(
+				t, input, leaves, operatorKey, sweepRoot, radix,
 			)
 			require.NoError(t, err)
 			require.NotNil(t, root)

--- a/lib/tree/materializer_btc.go
+++ b/lib/tree/materializer_btc.go
@@ -1,0 +1,179 @@
+package tree
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/scripts"
+)
+
+// ScriptLookup returns the output script (pkscript) for a leaf node.
+// Returns nil if the node is not a leaf or has no script.
+type ScriptLookup func(node *Node) []byte
+
+// ScriptLookupFromMap creates a ScriptLookup from a map of node
+// pointers to pkscripts. This is the standard way to provide leaf scripts
+// for BTC tree materialization while keeping the shared Node type
+// asset-agnostic and branch nodes untouched.
+func ScriptLookupFromMap(leafScripts map[*Node][]byte) ScriptLookup {
+	return func(node *Node) []byte {
+		if leafScripts == nil {
+			return nil
+		}
+
+		return leafScripts[node]
+	}
+}
+
+// BTCMaterializer builds simple BTC tree transactions. It implements the
+// Materializer interface for BTC-only trees.
+type BTCMaterializer struct {
+	// OperatorKey is the operator's public key.
+	OperatorKey *btcec.PublicKey
+
+	// SweepTapscriptRoot is the tapscript root for the sweep script.
+	SweepTapscriptRoot []byte
+
+	// LeafScriptFn returns the output script for leaf nodes. This is
+	// populated during structure building and used here during
+	// materialization.
+	LeafScriptFn ScriptLookup
+}
+
+// NewBTCMaterializer creates a new BTC materializer. The leafScriptFn
+// parameter provides leaf output scripts populated during structure building.
+func NewBTCMaterializer(operatorKey *btcec.PublicKey,
+	sweepTapscriptRoot []byte,
+	leafScriptFn ScriptLookup) *BTCMaterializer {
+
+	return &BTCMaterializer{
+		OperatorKey:        operatorKey,
+		SweepTapscriptRoot: sweepTapscriptRoot,
+		LeafScriptFn:       leafScriptFn,
+	}
+}
+
+// MaterializeNode fills in transaction data for a single node. For BTC trees,
+// this involves computing the final key and building outputs.
+//
+// NOTE: BTC trees use Node.Amount (set during structure building) for output
+// values.
+func (m *BTCMaterializer) MaterializeNode(_ context.Context, node *Node,
+	params MaterializeParams) (map[uint32]MaterializeParams, error) {
+
+	// Set the input outpoint.
+	node.Input = params.Input
+
+	if node.IsLeaf() {
+		return m.materializeLeaf(node)
+	}
+
+	return m.materializeBranch(node)
+}
+
+// materializeLeaf builds outputs for a leaf node.
+func (m *BTCMaterializer) materializeLeaf(node *Node) (
+	map[uint32]MaterializeParams, error) {
+
+	// Guard against miswired assemblers: LeafScriptFn must be provided.
+	if m.LeafScriptFn == nil {
+		return nil, fmt.Errorf("leaf script lookup function not set")
+	}
+
+	// Compute the final key for this node's input.
+	finalKey, err := ComputeFinalKey(node.CoSigners, m.SweepTapscriptRoot)
+	if err != nil {
+		return nil, fmt.Errorf("compute final key: %w", err)
+	}
+
+	node.FinalKey = finalKey
+
+	// Get leaf PkScript using the lookup function (populated during
+	// structure building).
+	leafPkScript := m.LeafScriptFn(node)
+	if len(leafPkScript) == 0 {
+		return nil, fmt.Errorf("leaf node missing pkscript")
+	}
+
+	// Build outputs: [leaf output, anchor]. Use node.Amount which was set
+	// during structure building from the leaf descriptor. We construct
+	// the leaf output here (pass 2) because the BTC path defers script
+	// attachment to materialization, keeping the shared structure free
+	// of BTC-only fields.
+	node.Outputs = []*wire.TxOut{
+		wire.NewTxOut(int64(node.Amount), leafPkScript),
+		scripts.AnchorOutput(),
+	}
+
+	// Leaves have no children.
+	return nil, nil
+}
+
+// materializeBranch builds outputs for a branch node.
+func (m *BTCMaterializer) materializeBranch(node *Node) (
+	map[uint32]MaterializeParams, error) {
+
+	// Compute the final key for this node's input.
+	finalKey, err := ComputeFinalKey(node.CoSigners, m.SweepTapscriptRoot)
+	if err != nil {
+		return nil, fmt.Errorf("compute final key: %w", err)
+	}
+
+	node.FinalKey = finalKey
+
+	// Build outputs for each child plus anchor.
+	indices := sortedChildIndices(node.Children)
+	outputs := make([]*wire.TxOut, 0, len(indices)+1)
+
+	for _, idx := range indices {
+		child := node.Children[idx]
+
+		// Compute child's output key using their cosigners.
+		childKey, err := ComputeFinalKey(
+			child.CoSigners, m.SweepTapscriptRoot,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("compute child key for "+
+				"index %d: %w", idx, err)
+		}
+
+		pkScript, err := txscript.PayToTaprootScript(childKey)
+		if err != nil {
+			return nil, fmt.Errorf("create pkscript for "+
+				"index %d: %w", idx, err)
+		}
+
+		// Use child.Amount which is the sum of all leaf amounts in
+		// that child's subtree (set during structure building).
+		outputs = append(outputs, wire.NewTxOut(
+			int64(child.Amount), pkScript,
+		))
+	}
+
+	// Add anchor output.
+	outputs = append(outputs, scripts.AnchorOutput())
+
+	node.Outputs = outputs
+
+	// Compute TXID for child inputs.
+	txHash, err := node.TXID()
+	if err != nil {
+		return nil, fmt.Errorf("get parent txid: %w", err)
+	}
+
+	// Build child params.
+	childParams := make(map[uint32]MaterializeParams)
+	for i, idx := range indices {
+		childParams[idx] = MaterializeParams{
+			Input: wire.OutPoint{
+				Hash:  txHash,
+				Index: uint32(i),
+			},
+		}
+	}
+
+	return childParams, nil
+}

--- a/lib/tree/node.go
+++ b/lib/tree/node.go
@@ -10,6 +10,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
@@ -35,6 +36,13 @@ type Node struct {
 	// Children maps output index to child Node.
 	// Empty for leaf nodes.
 	Children map[uint32]*Node
+
+	// Amount is the total BTC value for this node. For leaf nodes, this
+	// is the leaf's BTC amount. For branch nodes, this is the sum of all
+	// descendant leaf amounts (subtree total). This is set during
+	// structure building and used during materialization to determine
+	// output values.
+	Amount btcutil.Amount
 
 	// Signature is the final aggregated MuSig2 signature for the input.
 	// This is populated after signing is complete.

--- a/lib/tree/tree.go
+++ b/lib/tree/tree.go
@@ -40,6 +40,30 @@ func NewTree(rootOutpoint wire.OutPoint, rootOutput *wire.TxOut,
 	leaves []LeafDescriptor, operatorKey *btcec.PublicKey,
 	sweepTapscriptRoot []byte, radix int) (*Tree, error) {
 
+	return NewTreeWithConfig(
+		rootOutpoint, rootOutput, leaves, operatorKey,
+		sweepTapscriptRoot, TreeBuildConfig{
+			Radix: radix,
+		},
+	)
+}
+
+// TreeBuildConfig configures tree construction.
+type TreeBuildConfig struct {
+	// Radix is the branching factor of the tree.
+	Radix int
+
+	// WeightFunc optionally overrides how leaves are balanced into groups.
+	// When nil, leaves are distributed using WeightByBtcAmount().
+	WeightFunc PartitionWeightFunc
+}
+
+// NewTreeWithConfig constructs a transaction tree from the given leaves using
+// the two-pass approach with the provided configuration.
+func NewTreeWithConfig(rootOutpoint wire.OutPoint, rootOutput *wire.TxOut,
+	leaves []LeafDescriptor, operatorKey *btcec.PublicKey,
+	sweepTapscriptRoot []byte, cfg TreeBuildConfig) (*Tree, error) {
+
 	// Validate inputs.
 	if rootOutput == nil {
 		return nil, fmt.Errorf("root output cannot be nil")
@@ -53,26 +77,20 @@ func NewTree(rootOutpoint wire.OutPoint, rootOutput *wire.TxOut,
 		return nil, fmt.Errorf("at least one leaf required")
 	}
 
-	if radix < 2 {
+	if cfg.Radix < 2 {
 		return nil, fmt.Errorf("radix must be at least 2, got %d",
-			radix)
+			cfg.Radix)
 	}
 
-	// Build the tree using BFS.
-	root, err := buildTreeBFS(
-		rootOutpoint, leaves, operatorKey,
-		sweepTapscriptRoot, radix,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to build tree: %w", err)
-	}
-
-	return &Tree{
-		Root:               root,
-		BatchOutpoint:      rootOutpoint,
-		BatchOutput:        rootOutput,
+	// Use BTCTreeAssembler with the two-pass approach.
+	assembler := NewTreeAssembler(TreeConfig{
+		OperatorKey:        operatorKey,
 		SweepTapscriptRoot: sweepTapscriptRoot,
-	}, nil
+		Radix:              cfg.Radix,
+		WeightFn:           cfg.WeightFunc,
+	})
+
+	return assembler.BuildTree(rootOutpoint, rootOutput, leaves)
 }
 
 // ExtractPathForCoSigners extracts the path relevant for one or more cosigners

--- a/lib/tree/tree_materialize.go
+++ b/lib/tree/tree_materialize.go
@@ -1,0 +1,83 @@
+package tree
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/btcsuite/btcd/wire"
+)
+
+// MaterializeParams contains the parameters for materializing a single node.
+type MaterializeParams struct {
+	// Input is the outpoint this node spends.
+	Input wire.OutPoint
+}
+
+// Materializer fills in transaction data for a tree structure. Different
+// implementations handle BTC-only vs Asset trees.
+type Materializer interface {
+	// MaterializeNode fills in Input, Outputs, FinalKey, and OutputsMeta
+	// for a single node. Returns child params for each child index.
+	MaterializeNode(ctx context.Context, node *Node,
+		params MaterializeParams) (map[uint32]MaterializeParams, error)
+}
+
+// materializeItem represents a node and its parameters in the materialization
+// queue. Named to avoid conflict with workItem in build.go.
+type materializeItem struct {
+	node   *Node
+	params MaterializeParams
+}
+
+// Materialize walks the tree top-down iteratively and materializes each node
+// using the provided Materializer. This is pass 2 of the two-pass tree
+// construction.
+//
+// The function uses an explicit stack for depth-first traversal, avoiding
+// recursion to prevent stack overflow for deep trees.
+func Materialize(ctx context.Context, root *Node, rootParams MaterializeParams,
+	mat Materializer) error {
+
+	if root == nil {
+		return nil
+	}
+
+	// Use a stack for depth-first traversal. Parent must be materialized
+	// before children since we need the parent's TXID for child inputs.
+	stack := []materializeItem{{node: root, params: rootParams}}
+
+	for len(stack) > 0 {
+		// Pop from stack.
+		item := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+
+		// Materialize this node.
+		childParams, err := mat.MaterializeNode(
+			ctx, item.node, item.params,
+		)
+		if err != nil {
+			return fmt.Errorf("materialize node: %w", err)
+		}
+
+		// Push children onto stack in reverse order for correct DFS
+		// ordering (so first child is processed first).
+		indices := sortedChildIndices(item.node.Children)
+		for i := len(indices) - 1; i >= 0; i-- {
+			idx := indices[i]
+			child := item.node.Children[idx]
+
+			params, ok := childParams[idx]
+			if !ok {
+				return fmt.Errorf("missing params for child %d",
+					idx)
+			}
+
+			stack = append(stack, materializeItem{
+				node:   child,
+				params: params,
+			})
+		}
+	}
+
+	return nil
+}

--- a/lib/tree/tree_structure.go
+++ b/lib/tree/tree_structure.go
@@ -1,0 +1,165 @@
+package tree
+
+import (
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
+)
+
+// StructureConfig contains configuration for building tree structure.
+type StructureConfig struct {
+	// OperatorKey is the operator's public key (included in all cosigner
+	// sets).
+	OperatorKey *btcec.PublicKey
+
+	// Radix is the maximum number of children per branch node.
+	Radix int
+
+	// WeightFn determines how leaves are weighted for partitioning.
+	// If nil, defaults to WeightByBtcAmount().
+	WeightFn PartitionWeightFunc
+}
+
+// Structure contains the outputs from BuildStructure.
+type Structure struct {
+	// Root is the root node of the tree structure.
+	Root *Node
+
+	// LeafScriptMap maps leaf node pointers to their output scripts
+	// (pkscript). This is populated during structure building and used by
+	// the BTC materializer. We keep BTC leaf data out of Node to keep the
+	// shared structure asset-agnostic and avoid touching branch nodes.
+	LeafScriptMap map[*Node][]byte
+}
+
+// BuildStructure builds the tree structure bottom-up from leaf descriptors.
+// This is pass 1 of the two-pass tree construction. It creates the tree shape,
+// computes cosigners and internal keys - but does NOT build transactions or
+// proofs.
+//
+// The returned Structure contains:
+//   - Root: The root node with CoSigners and Children populated
+//   - LeafScriptMap: Map of leaf nodes to output scripts (for BTC trees only)
+//
+// The following Node fields are NOT set (filled in by Materialize):
+//   - Input (zero outpoint)
+//   - Outputs (nil)
+//   - FinalKey
+//   - Signature
+func BuildStructure(leaves []LeafDescriptor, cfg StructureConfig) (
+	*Structure, error) {
+
+	if len(leaves) == 0 {
+		return nil, nil
+	}
+
+	weightFn := cfg.WeightFn
+	if weightFn == nil {
+		weightFn = WeightByBtcAmount()
+	}
+
+	// Create leaf scripts map for BTC path (maps leaf nodes to pkscripts).
+	leafScripts := make(map[*Node][]byte)
+
+	// Build recursively from leaves up.
+	root, err := buildStructureRecursive(
+		leaves, cfg.OperatorKey, cfg.Radix, weightFn,
+		leafScripts,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Structure{
+		Root:          root,
+		LeafScriptMap: leafScripts,
+	}, nil
+}
+
+// buildStructureRecursive recursively builds the tree structure. For a single
+// leaf, it creates a leaf node. For multiple leaves, it partitions them and
+// creates a branch node with children built recursively.
+func buildStructureRecursive(leaves []LeafDescriptor,
+	operatorKey *btcec.PublicKey, radix int,
+	weightFn PartitionWeightFunc,
+	leafScripts map[*Node][]byte) (*Node, error) {
+
+	// Base case: single leaf becomes a leaf node.
+	if len(leaves) == 1 {
+		return buildLeafStructure(leaves[0], operatorKey, leafScripts)
+	}
+
+	// Partition leaves into groups.
+	groups := partitionLeaves(leaves, radix, weightFn)
+
+	// Build children recursively and collect their cosigners.
+	children := make(map[uint32]*Node, len(groups))
+	allCosigners := []*btcec.PublicKey{operatorKey}
+	var totalBtcAmount btcutil.Amount
+
+	for i, group := range groups {
+		if len(group) == 0 {
+			continue
+		}
+
+		child, err := buildStructureRecursive(
+			group, operatorKey, radix, weightFn, leafScripts,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		children[uint32(i)] = child
+
+		// Collect cosigners from child.
+		allCosigners = append(allCosigners, child.CoSigners...)
+
+		// Sum BTC amounts from children (stored in Node.Amount).
+		totalBtcAmount += child.Amount
+	}
+
+	// Deduplicate cosigners.
+	allCosigners = UniqueCosigners(allCosigners)
+
+	// Create branch node structure.
+	node := &Node{
+		// Input, Outputs, FinalKey left empty - filled by Materialize.
+		CoSigners: allCosigners,
+		Children:  children,
+		Amount:    totalBtcAmount,
+		Signature: nil,
+	}
+
+	return node, nil
+}
+
+// buildLeafStructure creates the structure for a leaf node and populates
+// the leafScripts map (for BTC trees).
+func buildLeafStructure(leaf LeafDescriptor,
+	operatorKey *btcec.PublicKey,
+	leafScripts map[*Node][]byte) (*Node, error) {
+
+	if leaf.CoSignerKey == nil {
+		return nil, fmt.Errorf("leaf cosigner key cannot be nil")
+	}
+
+	// Leaf cosigners: operator + leaf owner.
+	cosigners := []*btcec.PublicKey{operatorKey, leaf.CoSignerKey}
+
+	node := &Node{
+		// Input, Outputs, FinalKey left empty - filled by Materialize.
+		CoSigners: cosigners,
+		Children:  make(map[uint32]*Node),
+		Amount:    leaf.Amount,
+		Signature: nil,
+	}
+
+	// Also store the leaf pkscript in the dedicated map for BTC path.
+	// This keeps BTC and asset concerns separate.
+	if leafScripts != nil && len(leaf.PkScript) > 0 {
+		leafScripts[node] = leaf.PkScript
+	}
+
+	return node, nil
+}

--- a/lib/tree/tree_test.go
+++ b/lib/tree/tree_test.go
@@ -10,6 +10,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// sumLeafAmounts returns the sum of amounts from the provided leaves.
+func sumLeafAmounts(leaves []LeafDescriptor) int64 {
+	var total int64
+	for _, leaf := range leaves {
+		total += int64(leaf.Amount)
+	}
+
+	return total
+}
+
 // TestNewTree tests the NewTree constructor.
 func TestNewTree(t *testing.T) {
 	t.Parallel()
@@ -31,7 +41,7 @@ func TestNewTree(t *testing.T) {
 			Hash:  chainhash.HashH([]byte("batch")),
 			Index: 0,
 		}
-		rootOutput := &wire.TxOut{Value: 10000}
+		rootOutput := &wire.TxOut{Value: sumLeafAmounts(leaves)}
 		sweepRoot := make([]byte, 32)
 
 		tree, err := NewTree(
@@ -68,7 +78,7 @@ func TestNewTree(t *testing.T) {
 			Hash:  chainhash.HashH([]byte("batch")),
 			Index: 0,
 		}
-		rootOutput := &wire.TxOut{Value: 10000}
+		rootOutput := &wire.TxOut{Value: sumLeafAmounts(leaves)}
 		sweepRoot := make([]byte, 32)
 
 		tree, err := NewTree(
@@ -104,7 +114,7 @@ func TestNewTree(t *testing.T) {
 			Hash:  chainhash.HashH([]byte("batch")),
 			Index: 0,
 		}
-		rootOutput := &wire.TxOut{Value: 10000}
+		rootOutput := &wire.TxOut{Value: sumLeafAmounts(leaves)}
 		sweepRoot := make([]byte, 32)
 
 		tree, err := NewTree(
@@ -223,7 +233,7 @@ func TestTreeVerify(t *testing.T) {
 			Hash:  chainhash.HashH([]byte("batch")),
 			Index: 0,
 		}
-		rootOutput := &wire.TxOut{Value: 10000}
+		rootOutput := &wire.TxOut{Value: sumLeafAmounts(leaves)}
 
 		tree, err := NewTree(
 			rootOutpoint, rootOutput, leaves, operatorKey,
@@ -252,7 +262,7 @@ func TestTreeVerify(t *testing.T) {
 			Hash:  chainhash.HashH([]byte("batch")),
 			Index: 0,
 		}
-		rootOutput := &wire.TxOut{Value: 10000}
+		rootOutput := &wire.TxOut{Value: sumLeafAmounts(leaves)}
 
 		tree, err := NewTree(
 			rootOutpoint, rootOutput, leaves, operatorKey,
@@ -300,7 +310,7 @@ func TestTreeExtractPathForCoSigners(t *testing.T) {
 			Hash:  chainhash.HashH([]byte("batch")),
 			Index: 0,
 		}
-		rootOutput := &wire.TxOut{Value: 10000}
+		rootOutput := &wire.TxOut{Value: sumLeafAmounts(leaves)}
 
 		tree, err := NewTree(
 			rootOutpoint, rootOutput, leaves, operatorKey,
@@ -341,8 +351,8 @@ func TestTreeExtractPathForCoSigners(t *testing.T) {
 
 		tree, err := NewTree(
 			wire.OutPoint{Hash: chainhash.HashH([]byte("batch"))},
-			&wire.TxOut{Value: 10000}, leaves, operatorKey,
-			make([]byte, 32), 2,
+			&wire.TxOut{Value: sumLeafAmounts(leaves)}, leaves,
+			operatorKey, make([]byte, 32), 2,
 		)
 		require.NoError(t, err)
 
@@ -380,7 +390,7 @@ func TestTreeExtractPathForCoSigners(t *testing.T) {
 			Hash:  chainhash.HashH([]byte("batch")),
 			Index: 0,
 		}
-		rootOutput := &wire.TxOut{Value: 10000}
+		rootOutput := &wire.TxOut{Value: sumLeafAmounts(leaves)}
 
 		tree, err := NewTree(
 			rootOutpoint, rootOutput, leaves, operatorKey,
@@ -430,7 +440,8 @@ func TestTreeExtractPathForCoSigners(t *testing.T) {
 		}
 
 		tree, err := NewTree(
-			wire.OutPoint{}, &wire.TxOut{Value: 10000}, leaves,
+			wire.OutPoint{},
+			&wire.TxOut{Value: sumLeafAmounts(leaves)}, leaves,
 			operatorKey, make([]byte, 32), 2,
 		)
 		require.NoError(t, err)
@@ -453,7 +464,8 @@ func TestTreeExtractPathForCoSigners(t *testing.T) {
 		}
 
 		tree, err := NewTree(
-			wire.OutPoint{}, &wire.TxOut{Value: 10000}, leaves,
+			wire.OutPoint{},
+			&wire.TxOut{Value: sumLeafAmounts(leaves)}, leaves,
 			operatorKey, make([]byte, 32), 2,
 		)
 		require.NoError(t, err)
@@ -485,8 +497,8 @@ func TestTreeExtractPathForIndices(t *testing.T) {
 
 		tree, err := NewTree(
 			wire.OutPoint{Hash: chainhash.HashH([]byte("batch"))},
-			&wire.TxOut{Value: 10000}, leaves, operatorKey,
-			make([]byte, 32), 2,
+			&wire.TxOut{Value: sumLeafAmounts(leaves)}, leaves,
+			operatorKey, make([]byte, 32), 2,
 		)
 		require.NoError(t, err)
 
@@ -513,7 +525,8 @@ func TestTreeExtractPathForIndices(t *testing.T) {
 		}
 
 		tree, err := NewTree(
-			wire.OutPoint{}, &wire.TxOut{Value: 10000}, leaves,
+			wire.OutPoint{},
+			&wire.TxOut{Value: sumLeafAmounts(leaves)}, leaves,
 			operatorKey, make([]byte, 32), 2,
 		)
 		require.NoError(t, err)
@@ -537,7 +550,8 @@ func TestTreeExtractPathForIndices(t *testing.T) {
 		}
 
 		tree, err := NewTree(
-			wire.OutPoint{}, &wire.TxOut{Value: 10000}, leaves,
+			wire.OutPoint{},
+			&wire.TxOut{Value: sumLeafAmounts(leaves)}, leaves,
 			operatorKey, make([]byte, 32), 2,
 		)
 		require.NoError(t, err)
@@ -564,8 +578,8 @@ func TestTreeExtractPathForIndices(t *testing.T) {
 
 		tree, err := NewTree(
 			wire.OutPoint{Hash: chainhash.HashH([]byte("batch"))},
-			&wire.TxOut{Value: 10000}, leaves, operatorKey,
-			make([]byte, 32), 2,
+			&wire.TxOut{Value: sumLeafAmounts(leaves)}, leaves,
+			operatorKey, make([]byte, 32), 2,
 		)
 		require.NoError(t, err)
 
@@ -597,8 +611,8 @@ func TestVerifyVTXOPath(t *testing.T) {
 
 		tree, err := NewTree(
 			wire.OutPoint{Hash: chainhash.HashH([]byte("batch"))},
-			&wire.TxOut{Value: 10000}, leaves, operatorKey,
-			make([]byte, 32), 2,
+			&wire.TxOut{Value: sumLeafAmounts(leaves)}, leaves,
+			operatorKey, make([]byte, 32), 2,
 		)
 		require.NoError(t, err)
 
@@ -621,8 +635,8 @@ func TestVerifyVTXOPath(t *testing.T) {
 
 		tree, err := NewTree(
 			wire.OutPoint{Hash: chainhash.HashH([]byte("batch"))},
-			&wire.TxOut{Value: 10000}, leaves, operatorKey,
-			make([]byte, 32), 2,
+			&wire.TxOut{Value: sumLeafAmounts(leaves)}, leaves,
+			operatorKey, make([]byte, 32), 2,
 		)
 		require.NoError(t, err)
 
@@ -646,7 +660,8 @@ func TestVerifyVTXOPath(t *testing.T) {
 		}
 
 		tree, err := NewTree(
-			wire.OutPoint{}, &wire.TxOut{Value: 10000}, leaves,
+			wire.OutPoint{},
+			&wire.TxOut{Value: sumLeafAmounts(leaves)}, leaves,
 			operatorKey, make([]byte, 32), 2,
 		)
 		require.NoError(t, err)
@@ -670,7 +685,8 @@ func TestVerifyVTXOPath(t *testing.T) {
 		}
 
 		tree, err := NewTree(
-			wire.OutPoint{}, &wire.TxOut{Value: 10000}, leaves,
+			wire.OutPoint{},
+			&wire.TxOut{Value: sumLeafAmounts(leaves)}, leaves,
 			operatorKey, make([]byte, 32), 2,
 		)
 		require.NoError(t, err)
@@ -694,7 +710,8 @@ func TestVerifyVTXOPath(t *testing.T) {
 		}
 
 		tree, err := NewTree(
-			wire.OutPoint{}, &wire.TxOut{Value: 10000}, leaves,
+			wire.OutPoint{},
+			&wire.TxOut{Value: sumLeafAmounts(leaves)}, leaves,
 			operatorKey, make([]byte, 32), 2,
 		)
 		require.NoError(t, err)
@@ -726,8 +743,8 @@ func TestVerifyVTXOPath(t *testing.T) {
 
 		tree, err := NewTree(
 			wire.OutPoint{Hash: chainhash.HashH([]byte("batch"))},
-			&wire.TxOut{Value: 10000}, leaves, operatorKey,
-			make([]byte, 32), 2,
+			&wire.TxOut{Value: sumLeafAmounts(leaves)}, leaves,
+			operatorKey, make([]byte, 32), 2,
 		)
 		require.NoError(t, err)
 
@@ -758,8 +775,8 @@ func TestSubmitTreeSigs(t *testing.T) {
 
 		tree, err := NewTree(
 			wire.OutPoint{Hash: chainhash.HashH([]byte("batch"))},
-			&wire.TxOut{Value: 10000}, leaves, operatorKey,
-			make([]byte, 32), 2,
+			&wire.TxOut{Value: sumLeafAmounts(leaves)}, leaves,
+			operatorKey, make([]byte, 32), 2,
 		)
 		require.NoError(t, err)
 
@@ -799,7 +816,8 @@ func TestSubmitTreeSigs(t *testing.T) {
 		}
 
 		tree, err := NewTree(
-			wire.OutPoint{}, &wire.TxOut{Value: 10000}, leaves,
+			wire.OutPoint{},
+			&wire.TxOut{Value: sumLeafAmounts(leaves)}, leaves,
 			operatorKey, make([]byte, 32), 2,
 		)
 		require.NoError(t, err)
@@ -825,8 +843,8 @@ func TestSubmitTreeSigs(t *testing.T) {
 
 		tree, err := NewTree(
 			wire.OutPoint{Hash: chainhash.HashH([]byte("batch"))},
-			&wire.TxOut{Value: 10000}, leaves, operatorKey,
-			make([]byte, 32), 2,
+			&wire.TxOut{Value: sumLeafAmounts(leaves)}, leaves,
+			operatorKey, make([]byte, 32), 2,
 		)
 		require.NoError(t, err)
 
@@ -858,7 +876,8 @@ func TestTreeMetrics(t *testing.T) {
 		}
 
 		tree, err := NewTree(
-			wire.OutPoint{}, &wire.TxOut{Value: 10000}, leaves,
+			wire.OutPoint{},
+			&wire.TxOut{Value: sumLeafAmounts(leaves)}, leaves,
 			operatorKey, make([]byte, 32), 2,
 		)
 		require.NoError(t, err)
@@ -883,7 +902,8 @@ func TestTreeMetrics(t *testing.T) {
 		}
 
 		tree, err := NewTree(
-			wire.OutPoint{}, &wire.TxOut{Value: 10000}, leaves,
+			wire.OutPoint{},
+			&wire.TxOut{Value: sumLeafAmounts(leaves)}, leaves,
 			operatorKey, make([]byte, 32), 2,
 		)
 		require.NoError(t, err)
@@ -910,14 +930,16 @@ func TestTreeMetrics(t *testing.T) {
 
 		// Binary tree (radix=2).
 		tree2, err := NewTree(
-			wire.OutPoint{}, &wire.TxOut{Value: 10000}, leaves,
+			wire.OutPoint{},
+			&wire.TxOut{Value: sumLeafAmounts(leaves)}, leaves,
 			operatorKey, make([]byte, 32), 2,
 		)
 		require.NoError(t, err)
 
 		// Quad-tree (radix=4).
 		tree4, err := NewTree(
-			wire.OutPoint{}, &wire.TxOut{Value: 10000}, leaves,
+			wire.OutPoint{},
+			&wire.TxOut{Value: sumLeafAmounts(leaves)}, leaves,
 			operatorKey, make([]byte, 32), 4,
 		)
 		require.NoError(t, err)
@@ -945,7 +967,8 @@ func TestTreePrettyPrint(t *testing.T) {
 		}
 
 		tree, err := NewTree(
-			wire.OutPoint{}, &wire.TxOut{Value: 10000}, leaves,
+			wire.OutPoint{},
+			&wire.TxOut{Value: sumLeafAmounts(leaves)}, leaves,
 			operatorKey, make([]byte, 32), 2,
 		)
 		require.NoError(t, err)


### PR DESCRIPTION
With this commit we refactor the tree building to a two phase approach, where the first phase is the assembly of the tree structure, and the second phase is the materialization of the tree transactions. This allows for easier extension of the tree building process for assets later on while enabling reuse of the existing tree structure assembly logic.

# Asset/BTC Tree Architecture

This document describes the current `lib/tree` design after the two‑pass
refactor. The tree package now supports both BTC‑only trees and asset‑aware
trees while keeping the signing API consistent.

## Overview

Tree construction is split into two passes:

1) **Structure pass** (`PlanStructure`)
   - Inputs: `[]LeafDescriptor`, radix, weight function, operator key.
   - Outputs: `TreeStructure{Root, AssetContext, LeafScriptMap}`.
   - Populates the tree shape (cosigners, children), sets `Node.Amount` to the
     leaf BTC amount and aggregates subtree totals for branches.
   - Asset data is stored in the AssetContext; BTC leaf scripts are stored in
     the `LeafScriptMap`.

2) **Materialization pass** (`Materialize`)
   - Inputs: the root node, root params (`MaterializeParams`), and a materializer.
   - Outputs: each node is filled with its `Input`, `Outputs`, and `FinalKey`.
   - Implementations:
     - `BTCMaterializer`: builds BTC transactions using `Node.Amount` and the `LeafScriptMap`; ignores asset fields.
     - `AssetMaterializer`: builds asset transactions via tapd and uses the AssetContext (proofs, tweaks, metadata).

Signing remains unchanged: `NewTreeSignerSession` takes a tweak lookup (asse trees use `TweakLookupFromAssetContext`; BTC trees pass `nil`).

## Key Data Structures

- `Node`
  - Core fields: `Input`, `Outputs`, `CoSigners`, `Children`, `Amount` (subtree BTC total), `Signature`, `FinalKey`.
  - Asset‑specific state is not stored on `Node`.

- `TreeStructure`
  - `Root`: root node of the structured tree (no outputs yet).
  - `AssetContext`: asset‑only state (asset amounts, proofs, leaf metadata, tweaks); used by the asset materializer and signing tweaks.
  - `LeafScriptMap`: BTC‑only map of leaf node pointers to pkScripts; used by the BTC materializer.

- `MaterializeParams`
  - Common: `Input`.
  - Asset‑only: `ParentProof`, `ParentPlan` (ignored by BTC).

## Assemblers

- `BTCTreeAssembler`
  - `BuildTree(ctx, rootInput, rootOutput, leaves)`:
    - Runs `PlanStructure` with BTC weighting/radix defaults.
    - Sanity checks that the sum of leaf amounts (`root.Amount`) does not exceed `rootOutput.Value`.
    - Materializes with `BTCMaterializer` using `LeafScriptMap`.
    - Returns `*Tree` (no asset context needed for signing).

- `AssetTreeAssembler`
  - `BuildTree(ctx, rootInput, rootPlan, rootProof, rootOutput, leaves, radix)`:
    - Runs `PlanStructure` with asset weighting.
    - Materializes with `AssetMaterializer`, passing the AssetContext.
    - Returns `*Tree` and the AssetContext; callers must keep them paired for
      signing (`TweakLookupFromAssetContext`) and finalization.

## Value Semantics

- BTC amounts:
  - `LeafDescriptor.Amount` is copied to `Node.Amount` at leaves.
  - Branch `Node.Amount` is the sum of descendant leaf amounts.
  - BTC materialization uses these amounts directly; no top‑down splitting.
  - `BTCTreeAssembler` errors if leaf sums exceed the root output value (root may exceed leaf sums if external fees/change are expected).

- Asset data:
  - Stored only in the AssetContext (proofs, asset amounts, labels, funding, tweaks). BTC code does not touch it.

## Signing

- BTC trees: `NewTreeSignerSession` with `tweakLookup=nil`.
- Asset trees: `TweakLookupFromAssetContext(assetCtx)` supplies per‑node tweaks for MuSig2 sessions.

## Compatibility Notes

- `NewTreeWithConfig` now delegates to `BTCTreeAssembler` (BTC path). It uses `context.Background()` internally; use the assemblers directly if you need an explicit context.
- Legacy `buildTreeBFS`/single‑pass construction is superseded by the two‑pass structure/materialize flow.