### PR TITLE
lib/tree: clean-up

### DIFF
--- a/lib/tree/node.go
+++ b/lib/tree/node.go
@@ -15,7 +15,14 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/lib/scripts"
 	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/keychain"
 )
+
+// inputIndex is the index of the input being signed in each transaction.
+// Each node tx in a tree has a single input at index 0 which spends the
+// key-spend path of its parent output.
+const inputIndex = 0
 
 // Node represents a single transaction in a virtual transaction tree.
 type Node struct {
@@ -777,13 +784,9 @@ func (n *Node) verifyNodeSignature(
 	}
 
 	// Calculate the signature hash.
-	sigHash, err := txscript.CalcTaprootSignatureHash(
-		txscript.NewTxSigHashes(tx, prevOutFetcher),
-		txscript.SigHashDefault, tx, 0, prevOutFetcher,
-	)
+	sigHash, err := n.SigHash(prevOutFetcher)
 	if err != nil {
-		return fmt.Errorf("failed to calculate signature hash: %w",
-			err)
+		return fmt.Errorf("failed to calculate signature hash: %w", err)
 	}
 
 	// Verify the signature against the cached final key.
@@ -793,6 +796,36 @@ func (n *Node) verifyNodeSignature(
 	}
 
 	return nil
+}
+
+// SigHash computes the signature hash for this node's transaction.
+func (n *Node) SigHash(prevOutFetcher txscript.PrevOutputFetcher) ([]byte,
+	error) {
+
+	// Create the transaction to verify.
+	tx, err := n.ToTx()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create transaction: %w", err)
+	}
+
+	// Calculate the signature hash.
+	return txscript.CalcTaprootSignatureHash(
+		txscript.NewTxSigHashes(tx, prevOutFetcher),
+		txscript.SigHashDefault, tx, inputIndex, prevOutFetcher,
+	)
+}
+
+// NewSignerSession creates a new MuSig2 signing session for this node.
+func (n *Node) NewSignerSession(signerKey *keychain.KeyDescriptor,
+	signer input.MuSig2Signer,
+	sweepTapscriptRoot []byte) (*input.MuSig2SessionInfo, error) {
+
+	return signer.MuSig2CreateSession(
+		input.MuSig2Version100RC2, signerKey.KeyLocator,
+		n.CoSigners, &input.MuSig2Tweaks{
+			TaprootTweak: sweepTapscriptRoot,
+		}, nil, nil,
+	)
 }
 
 // ContainsCosigner checks if a target key is present in the cosigners list.

--- a/lib/tree/signing.go
+++ b/lib/tree/signing.go
@@ -32,8 +32,18 @@ type TxSignerSession struct {
 	sigHash     [32]byte
 }
 
-// NewTxSignerSession creates a new signing session for signing the node's
-// transaction input.
+// NewTxSignerSession creates a new signing session for a single transaction
+// in a virtual transaction tree. The point of the session is to facilitate
+// the MuSig2 signing process for a specific transaction. Each transaction has
+// signs the key-spend path of the previous transaction. The parameters are:
+//
+//   - signer: The MuSig2Signer interface to use creating the session and
+//     signing.
+//   - sweepTapscriptRoot: The tapscript root used for tweaking the keyspend
+//     path.
+//   - signerKey: The key descriptor of the signer.
+//   - fetcher: The PrevOutputFetcher to retrieve the output being spent by this
+//     node's transaction.
 func (n *Node) NewTxSignerSession(signer input.MuSig2Signer,
 	sweepTapscriptRoot []byte, signerKey *keychain.KeyDescriptor,
 	fetcher txscript.PrevOutputFetcher) (*TxSignerSession, error) {
@@ -92,9 +102,11 @@ func (s *TxSignerSession) Sign(cleanup bool) (*musig2.PartialSignature, error) {
 	)
 }
 
-// SignerSession manages signing for all transactions in a client's path.
-// It automatically extracts the signer's path and creates TxSignerSession for
-// each transaction in that path.
+// SignerSession manages signing for all transactions in a client's path in a
+// tree for a given signing key. It automatically extracts the signer's path
+// and creates TxSignerSession for each transaction in that path. If a client
+// has multiple vtxo's in the tree, they will have a SignerSession for each
+// vtxo's signing key.
 type SignerSession struct {
 	// signerKey is the key descriptor for the signer.
 	signerKey *keychain.KeyDescriptor
@@ -133,6 +145,8 @@ func NewSignerSession(signer input.MuSig2Signer,
 	// Create signing sessions for each transaction in the path.
 	txs := make(map[TxID]*TxSignerSession)
 
+	// For each transaction in the signer's path, create a TxSignerSession
+	// which will help facilitate MuSig2 signing for that transaction.
 	err := signerPath.ForEach(func(node *Node) error {
 		tx, err := node.ToTx()
 		if err != nil {
@@ -167,6 +181,8 @@ func (s *SignerSession) PubKey() *btcec.PublicKey {
 }
 
 // GetNonces returns nonces for all transactions in the signer's path.
+// This is used after all signers have shared their public nonces and the
+// aggregated nonce has been computed for each transaction.
 func (s *SignerSession) GetNonces() (map[TxID]Musig2PubNonce, error) {
 	nonces := make(map[TxID]Musig2PubNonce, len(s.txs))
 	for txid, txSession := range s.txs {
@@ -206,6 +222,8 @@ func (s *SignerSession) RegisterAggNonces(
 
 // Signatures generates partial signatures for all transactions in the signer's
 // path. If cleanup is true, the signing sessions are cleaned up after signing.
+// This is used in the second round of MuSig2 signing where each signer
+// generates their partial signatures.
 func (s *SignerSession) Signatures(cleanup bool) (
 	map[TxID]*musig2.PartialSignature, error) {
 

--- a/lib/tree/signing.go
+++ b/lib/tree/signing.go
@@ -81,8 +81,8 @@ func (n *Node) NewTxSignerSession(signer input.MuSig2Signer,
 }
 
 // GetNonce returns the public nonce for this signing session.
-func (s *TxSignerSession) GetNonce() (Musig2PubNonce, error) {
-	return s.signSession.PublicNonce, nil
+func (s *TxSignerSession) GetNonce() Musig2PubNonce {
+	return s.signSession.PublicNonce
 }
 
 // RegisterAggNonce registers the aggregated nonce for this signing session.
@@ -183,19 +183,13 @@ func (s *SignerSession) PubKey() *btcec.PublicKey {
 // GetNonces returns nonces for all transactions in the signer's path.
 // This is used after all signers have shared their public nonces and the
 // aggregated nonce has been computed for each transaction.
-func (s *SignerSession) GetNonces() (map[TxID]Musig2PubNonce, error) {
+func (s *SignerSession) GetNonces() map[TxID]Musig2PubNonce {
 	nonces := make(map[TxID]Musig2PubNonce, len(s.txs))
 	for txid, txSession := range s.txs {
-		nonce, err := txSession.GetNonce()
-		if err != nil {
-			return nil, fmt.Errorf("failed to get nonce for "+
-				"tx %s: %w", txid, err)
-		}
-
-		nonces[txid] = nonce
+		nonces[txid] = txSession.GetNonce()
 	}
 
-	return nonces, nil
+	return nonces
 }
 
 // RegisterAggNonces registers the aggregated nonce for each transaction in the

--- a/lib/tree/signing.go
+++ b/lib/tree/signing.go
@@ -47,25 +47,16 @@ func (n *Node) NewTxSignerSession(signer input.MuSig2Signer,
 		return nil, fmt.Errorf("signer key cannot be nil")
 	}
 
-	tx, err := n.ToTx()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create tx: %w", err)
-	}
-
 	// Calculate signature hash.
-	message, err := txscript.CalcTaprootSignatureHash(
-		txscript.NewTxSigHashes(tx, fetcher),
-		txscript.SigHashDefault, tx, 0, fetcher,
-	)
+	sigHash, err := n.SigHash(fetcher)
 	if err != nil {
-		return nil, fmt.Errorf("failed to calculate signature hash: %w",
-			err)
+		return nil, fmt.Errorf("failed to calculate sig hash: %w", err)
 	}
 
-	// Create MuSig2 session.
-	musigSession, err := signer.MuSig2CreateSession(
-		input.MuSig2Version100RC2, signerKey.KeyLocator, n.CoSigners,
-		&input.MuSig2Tweaks{TaprootTweak: sweepTapscriptRoot}, nil, nil,
+	// Create MuSig2 session for signing the transaction input via the
+	// keyspend path.
+	musigSession, err := n.NewSignerSession(
+		signerKey, signer, sweepTapscriptRoot,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create MuSig2 session: %w",
@@ -75,7 +66,7 @@ func (n *Node) NewTxSignerSession(signer input.MuSig2Signer,
 	return &TxSignerSession{
 		signer:      signer,
 		signSession: musigSession,
-		sigHash:     [32]byte(message),
+		sigHash:     [32]byte(sigHash),
 	}, nil
 }
 

--- a/lib/tree/signing.go
+++ b/lib/tree/signing.go
@@ -7,7 +7,6 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
-	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
 )
@@ -33,10 +32,10 @@ type TxSignerSession struct {
 	sigHash     [32]byte
 }
 
-// NewTxSignerSession creates a new signing session for a single transaction.
-func NewTxSignerSession(signer input.MuSig2Signer,
-	sweepTapscriptRoot []byte, cosigners []*btcec.PublicKey,
-	signerKey *keychain.KeyDescriptor, tx *wire.MsgTx,
+// NewTxSignerSession creates a new signing session for signing the node's
+// transaction input.
+func (n *Node) NewTxSignerSession(signer input.MuSig2Signer,
+	sweepTapscriptRoot []byte, signerKey *keychain.KeyDescriptor,
 	fetcher txscript.PrevOutputFetcher) (*TxSignerSession, error) {
 
 	// Validate inputs.
@@ -48,12 +47,9 @@ func NewTxSignerSession(signer input.MuSig2Signer,
 		return nil, fmt.Errorf("signer key cannot be nil")
 	}
 
-	if len(cosigners) == 0 {
-		return nil, fmt.Errorf("cosigners cannot be empty")
-	}
-
-	if tx == nil {
-		return nil, fmt.Errorf("transaction cannot be nil")
+	tx, err := n.ToTx()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create tx: %w", err)
 	}
 
 	// Calculate signature hash.
@@ -68,10 +64,8 @@ func NewTxSignerSession(signer input.MuSig2Signer,
 
 	// Create MuSig2 session.
 	musigSession, err := signer.MuSig2CreateSession(
-		input.MuSig2Version100RC2, signerKey.KeyLocator,
-		cosigners, &input.MuSig2Tweaks{
-			TaprootTweak: sweepTapscriptRoot,
-		}, nil, nil,
+		input.MuSig2Version100RC2, signerKey.KeyLocator, n.CoSigners,
+		&input.MuSig2Tweaks{TaprootTweak: sweepTapscriptRoot}, nil, nil,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create MuSig2 session: %w",
@@ -154,9 +148,8 @@ func NewSignerSession(signer input.MuSig2Signer,
 			return fmt.Errorf("failed to create tx: %w", err)
 		}
 
-		session, err := NewTxSignerSession(
-			signer, sweepTapscriptRoot, node.CoSigners,
-			signerKey, tx, prevOuts,
+		session, err := node.NewTxSignerSession(
+			signer, sweepTapscriptRoot, signerKey, prevOuts,
 		)
 		if err != nil {
 			return fmt.Errorf("failed to create tx session: %w",

--- a/lib/tree/signing.go
+++ b/lib/tree/signing.go
@@ -5,11 +5,17 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
 )
+
+// TxID is a type alias for chainhash.Hash, used as a key for maps that index
+// by transaction ID. Using the raw hash type instead of strings improves type
+// safety and avoids unnecessary string conversions.
+type TxID = chainhash.Hash
 
 // Musig2PubNonce is a public nonce for MuSig2 signing.
 type Musig2PubNonce [musig2.PubNonceSize]byte
@@ -109,7 +115,7 @@ type SignerSession struct {
 	signerKey *keychain.KeyDescriptor
 
 	// txs maps transaction IDs to their signing sessions.
-	txs map[string]*TxSignerSession
+	txs map[TxID]*TxSignerSession
 }
 
 // NewSignerSession creates a new signing session for a tree. It
@@ -140,7 +146,7 @@ func NewSignerSession(signer input.MuSig2Signer,
 	}
 
 	// Create signing sessions for each transaction in the path.
-	txs := make(map[string]*TxSignerSession)
+	txs := make(map[TxID]*TxSignerSession)
 
 	err := signerPath.ForEach(func(node *Node) error {
 		tx, err := node.ToTx()
@@ -157,7 +163,7 @@ func NewSignerSession(signer input.MuSig2Signer,
 				err)
 		}
 
-		txs[tx.TxHash().String()] = session
+		txs[tx.TxHash()] = session
 
 		return nil
 	})
@@ -177,10 +183,8 @@ func (s *SignerSession) PubKey() *btcec.PublicKey {
 }
 
 // GetNonces returns nonces for all transactions in the signer's path.
-func (s *SignerSession) GetNonces() (
-	map[string]Musig2PubNonce, error) {
-
-	nonces := make(map[string]Musig2PubNonce, len(s.txs))
+func (s *SignerSession) GetNonces() (map[TxID]Musig2PubNonce, error) {
+	nonces := make(map[TxID]Musig2PubNonce, len(s.txs))
 	for txid, txSession := range s.txs {
 		nonce, err := txSession.GetNonce()
 		if err != nil {
@@ -197,7 +201,7 @@ func (s *SignerSession) GetNonces() (
 // RegisterAggNonces registers the aggregated nonce for each transaction in the
 // signer's path.
 func (s *SignerSession) RegisterAggNonces(
-	nonceSet map[string]Musig2PubNonce) error {
+	nonceSet map[TxID]Musig2PubNonce) error {
 
 	for txid, txSession := range s.txs {
 		nonce, ok := nonceSet[txid]
@@ -219,9 +223,9 @@ func (s *SignerSession) RegisterAggNonces(
 // Signatures generates partial signatures for all transactions in the signer's
 // path. If cleanup is true, the signing sessions are cleaned up after signing.
 func (s *SignerSession) Signatures(cleanup bool) (
-	map[string]*musig2.PartialSignature, error) {
+	map[TxID]*musig2.PartialSignature, error) {
 
-	sigs := make(map[string]*musig2.PartialSignature, len(s.txs))
+	sigs := make(map[TxID]*musig2.PartialSignature, len(s.txs))
 	for txid, txSession := range s.txs {
 		sig, err := txSession.Sign(cleanup)
 		if err != nil {

--- a/lib/tree/signing_test.go
+++ b/lib/tree/signing_test.go
@@ -240,16 +240,8 @@ func TestTxSignerSession(t *testing.T) {
 		cosigners := []*btcec.PublicKey{pubKey, otherKey}
 		sweepRoot := make([]byte, 32)
 
-		// Create a simple transaction.
-		tx := wire.NewMsgTx(3)
-		tx.AddTxIn(&wire.TxIn{
-			PreviousOutPoint: wire.OutPoint{
-				Hash:  chainhash.HashH([]byte("prev")),
-				Index: 0,
-			},
-			Sequence: wire.MaxTxInSequenceNum,
-		})
-		tx.AddTxOut(&wire.TxOut{Value: 1000})
+		// Create a node with the cosigners.
+		node := createSimpleLeaf("test", 1000, cosigners)
 
 		// Create fetcher.
 		prevOut := &wire.TxOut{Value: 2000}
@@ -257,8 +249,8 @@ func TestTxSignerSession(t *testing.T) {
 			prevOut.PkScript, prevOut.Value,
 		)
 
-		session, err := NewTxSignerSession(
-			signer, sweepRoot, cosigners, keyDesc, tx, fetcher,
+		session, err := node.NewTxSignerSession(
+			signer, sweepRoot, keyDesc, fetcher,
 		)
 		require.NoError(t, err)
 		require.NotNil(t, session)
@@ -282,23 +274,16 @@ func TestTxSignerSession(t *testing.T) {
 		cosigners := []*btcec.PublicKey{pubKey, otherKey}
 		sweepRoot := make([]byte, 32)
 
-		tx := wire.NewMsgTx(3)
-		tx.AddTxIn(&wire.TxIn{
-			PreviousOutPoint: wire.OutPoint{
-				Hash:  chainhash.HashH([]byte("prev")),
-				Index: 0,
-			},
-			Sequence: wire.MaxTxInSequenceNum,
-		})
-		tx.AddTxOut(&wire.TxOut{Value: 1000})
+		// Create a node with the cosigners.
+		node := createSimpleLeaf("test", 1000, cosigners)
 
 		prevOut := &wire.TxOut{Value: 2000}
 		fetcher := txscript.NewCannedPrevOutputFetcher(
 			prevOut.PkScript, prevOut.Value,
 		)
 
-		session, err := NewTxSignerSession(
-			signer, sweepRoot, cosigners, keyDesc, tx, fetcher,
+		session, err := node.NewTxSignerSession(
+			signer, sweepRoot, keyDesc, fetcher,
 		)
 		require.NoError(t, err)
 
@@ -338,15 +323,8 @@ func TestTxSignerSession(t *testing.T) {
 		cosigners := []*btcec.PublicKey{pubKey1, pubKey2}
 		sweepRoot := make([]byte, 32)
 
-		tx := wire.NewMsgTx(3)
-		tx.AddTxIn(&wire.TxIn{
-			PreviousOutPoint: wire.OutPoint{
-				Hash:  chainhash.HashH([]byte("prev")),
-				Index: 0,
-			},
-			Sequence: wire.MaxTxInSequenceNum,
-		})
-		tx.AddTxOut(&wire.TxOut{Value: 1000})
+		// Create a node with the cosigners.
+		node := createSimpleLeaf("test", 1000, cosigners)
 
 		prevOut := &wire.TxOut{Value: 2000}
 		fetcher := txscript.NewCannedPrevOutputFetcher(
@@ -354,13 +332,13 @@ func TestTxSignerSession(t *testing.T) {
 		)
 
 		// Create sessions for both signers.
-		session1, err := NewTxSignerSession(
-			signer1, sweepRoot, cosigners, keyDesc1, tx, fetcher,
+		session1, err := node.NewTxSignerSession(
+			signer1, sweepRoot, keyDesc1, fetcher,
 		)
 		require.NoError(t, err)
 
-		session2, err := NewTxSignerSession(
-			signer2, sweepRoot, cosigners, keyDesc2, tx, fetcher,
+		session2, err := node.NewTxSignerSession(
+			signer2, sweepRoot, keyDesc2, fetcher,
 		)
 		require.NoError(t, err)
 
@@ -408,15 +386,8 @@ func TestTxSignerSession(t *testing.T) {
 		cosigners := []*btcec.PublicKey{pubKey}
 		sweepRoot := make([]byte, 32)
 
-		tx := wire.NewMsgTx(3)
-		tx.AddTxIn(&wire.TxIn{
-			PreviousOutPoint: wire.OutPoint{
-				Hash:  chainhash.HashH([]byte("prev")),
-				Index: 0,
-			},
-			Sequence: wire.MaxTxInSequenceNum,
-		})
-		tx.AddTxOut(&wire.TxOut{Value: 1000, PkScript: []byte("out")})
+		// Create a node with the cosigners.
+		node := createSimpleLeaf("test", 1000, cosigners)
 
 		prevOut := &wire.TxOut{
 			Value:    2000,
@@ -426,9 +397,13 @@ func TestTxSignerSession(t *testing.T) {
 			prevOut.PkScript, prevOut.Value,
 		)
 
-		session, err := NewTxSignerSession(
-			signer, sweepRoot, cosigners, keyDesc, tx, fetcher,
+		session, err := node.NewTxSignerSession(
+			signer, sweepRoot, keyDesc, fetcher,
 		)
+		require.NoError(t, err)
+
+		// Get the tx that the node generates internally.
+		tx, err := node.ToTx()
 		require.NoError(t, err)
 
 		// Calculate expected signature hash manually.
@@ -850,30 +825,23 @@ func TestTxSignerSessionSecurityNote(t *testing.T) {
 		cosigners := []*btcec.PublicKey{pubKey, otherKey}
 		sweepRoot := make([]byte, 32)
 
-		tx := wire.NewMsgTx(3)
-		tx.AddTxIn(&wire.TxIn{
-			PreviousOutPoint: wire.OutPoint{
-				Hash:  chainhash.HashH([]byte("prev")),
-				Index: 0,
-			},
-			Sequence: wire.MaxTxInSequenceNum,
-		})
-		tx.AddTxOut(&wire.TxOut{Value: 1000})
+		// Create a node with the cosigners.
+		node := createSimpleLeaf("test", 1000, cosigners)
 
 		prevOut := &wire.TxOut{Value: 2000}
 		fetcher := txscript.NewCannedPrevOutputFetcher(
 			prevOut.PkScript, prevOut.Value,
 		)
 
-		// Create two sessions for same tx (in real usage this is
+		// Create two sessions for same node (in real usage this is
 		// unsafe!).
-		session1, err := NewTxSignerSession(
-			signer, sweepRoot, cosigners, keyDesc, tx, fetcher,
+		session1, err := node.NewTxSignerSession(
+			signer, sweepRoot, keyDesc, fetcher,
 		)
 		require.NoError(t, err)
 
-		session2, err := NewTxSignerSession(
-			signer, sweepRoot, cosigners, keyDesc, tx, fetcher,
+		session2, err := node.NewTxSignerSession(
+			signer, sweepRoot, keyDesc, fetcher,
 		)
 		require.NoError(t, err)
 

--- a/lib/tree/signing_test.go
+++ b/lib/tree/signing_test.go
@@ -560,7 +560,7 @@ func TestSignerSession(t *testing.T) {
 
 		// Verify nonce exists for the leaf tx.
 		leafTXID, _ := leaf.TXID()
-		nonce, exists := nonces[leafTXID.String()]
+		nonce, exists := nonces[leafTXID]
 		require.True(t, exists)
 		require.NotEqual(t, Musig2PubNonce{}, nonce)
 	})
@@ -605,13 +605,13 @@ func TestSignerSession(t *testing.T) {
 			// Aggregate nonces and register for all txs.
 			leafTXID, _ := leaf.TXID()
 			aggNonce, err := musig2.AggregateNonces([][66]byte{
-				nonces[leafTXID.String()],
+				nonces[leafTXID],
 				otherNonces.PubNonce,
 			})
 			require.NoError(t, err)
 
-			aggNonceSet := map[string]Musig2PubNonce{
-				leafTXID.String(): aggNonce,
+			aggNonceSet := map[TxID]Musig2PubNonce{
+				leafTXID: aggNonce,
 			}
 
 			err = session.RegisterAggNonces(aggNonceSet)
@@ -660,20 +660,19 @@ func TestSignerSession(t *testing.T) {
 
 		// Aggregate and register nonces.
 		leafTXID, _ := leaf.TXID()
-		txidStr := leafTXID.String()
 
 		aggNonce, err := musig2.AggregateNonces([][66]byte{
-			nonces1[txidStr], nonces2[txidStr],
+			nonces1[leafTXID], nonces2[leafTXID],
 		})
 		require.NoError(t, err)
 
-		err = session1.RegisterAggNonces(map[string]Musig2PubNonce{
-			txidStr: aggNonce,
+		err = session1.RegisterAggNonces(map[TxID]Musig2PubNonce{
+			leafTXID: aggNonce,
 		})
 		require.NoError(t, err)
 
-		err = session2.RegisterAggNonces(map[string]Musig2PubNonce{
-			txidStr: aggNonce,
+		err = session2.RegisterAggNonces(map[TxID]Musig2PubNonce{
+			leafTXID: aggNonce,
 		})
 		require.NoError(t, err)
 
@@ -681,12 +680,12 @@ func TestSignerSession(t *testing.T) {
 		sigs1, err := session1.Signatures(true)
 		require.NoError(t, err)
 		require.Len(t, sigs1, 1)
-		require.NotNil(t, sigs1[txidStr])
+		require.NotNil(t, sigs1[leafTXID])
 
 		sigs2, err := session2.Signatures(true)
 		require.NoError(t, err)
 		require.Len(t, sigs2, 1)
-		require.NotNil(t, sigs2[txidStr])
+		require.NotNil(t, sigs2[leafTXID])
 	})
 
 	t.Run("RegisterAggNonces fails if tx not found", func(t *testing.T) {
@@ -712,8 +711,9 @@ func TestSignerSession(t *testing.T) {
 
 		// Register aggregated nonce for non-existent tx.
 		var nonce Musig2PubNonce
-		err = session.RegisterAggNonces(map[string]Musig2PubNonce{
-			"non_existent_txid": nonce,
+		nonExistentTxID := chainhash.HashH([]byte("non_existent"))
+		err = session.RegisterAggNonces(map[TxID]Musig2PubNonce{
+			nonExistentTxID: nonce,
 		})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "aggregated nonce for tx")
@@ -783,8 +783,8 @@ func TestSignerSessionMultiTx(t *testing.T) {
 		rootTx, _ := root.ToTx()
 		leaf1Tx, _ := leaf1.ToTx()
 
-		_, hasRoot := nonces[rootTx.TxHash().String()]
-		_, hasLeaf1 := nonces[leaf1Tx.TxHash().String()]
+		_, hasRoot := nonces[rootTx.TxHash()]
+		_, hasLeaf1 := nonces[leaf1Tx.TxHash()]
 
 		require.True(t, hasRoot)
 		require.True(t, hasLeaf1)
@@ -819,7 +819,7 @@ func TestSignerSessionMultiTx(t *testing.T) {
 		require.Len(t, nonces, 1)
 
 		leafTXID, _ := leaf.TXID()
-		_, exists := nonces[leafTXID.String()]
+		_, exists := nonces[leafTXID]
 		require.True(t, exists)
 	})
 }
@@ -969,16 +969,15 @@ func TestFullSigningFlow(t *testing.T) {
 			require.NoError(t, err)
 
 			leafTXID, _ := leaf.TXID()
-			txidStr := leafTXID.String()
 
 			// Phase 2: Aggregate and register nonces.
 			aggNonce, err := musig2.AggregateNonces([][66]byte{
-				nonces1[txidStr], nonces2[txidStr],
+				nonces1[leafTXID], nonces2[leafTXID],
 			})
 			require.NoError(t, err)
 
-			aggNonceSet := map[string]Musig2PubNonce{
-				txidStr: aggNonce,
+			aggNonceSet := map[TxID]Musig2PubNonce{
+				leafTXID: aggNonce,
 			}
 			err = session1.RegisterAggNonces(aggNonceSet)
 			require.NoError(t, err)
@@ -990,12 +989,12 @@ func TestFullSigningFlow(t *testing.T) {
 			partialSigs1, err := session1.Signatures(true)
 			require.NoError(t, err)
 			require.Len(t, partialSigs1, 1)
-			require.NotNil(t, partialSigs1[txidStr])
+			require.NotNil(t, partialSigs1[leafTXID])
 
 			partialSigs2, err := session2.Signatures(true)
 			require.NoError(t, err)
 			require.Len(t, partialSigs2, 1)
-			require.NotNil(t, partialSigs2[txidStr])
+			require.NotNil(t, partialSigs2[leafTXID])
 
 			// Note: In production, a coordinator would combine
 			// these partial signatures. For this test, we verify
@@ -1087,7 +1086,7 @@ func TestFullSigningFlow(t *testing.T) {
 			require.Len(t, nonces2, 3)
 
 			// Aggregate nonces for all 3 transactions.
-			aggNonceSet := make(map[string]Musig2PubNonce)
+			aggNonceSet := make(map[TxID]Musig2PubNonce)
 			for txid := range nonces1 {
 				aggNonce, err := musig2.AggregateNonces(
 					[][66]byte{

--- a/lib/tree/signing_test.go
+++ b/lib/tree/signing_test.go
@@ -256,8 +256,7 @@ func TestTxSignerSession(t *testing.T) {
 		require.NotNil(t, session)
 
 		// Should be able to get nonce.
-		nonce, err := session.GetNonce()
-		require.NoError(t, err)
+		nonce := session.GetNonce()
 		require.NotEqual(t, Musig2PubNonce{}, nonce)
 	})
 
@@ -288,8 +287,7 @@ func TestTxSignerSession(t *testing.T) {
 		require.NoError(t, err)
 
 		// Get own nonce.
-		ownNonce, err := session.GetNonce()
-		require.NoError(t, err)
+		ownNonce := session.GetNonce()
 
 		// Create other participant's nonce (must be valid EC point).
 		otherPrivKey, _ := createTestKey(t)
@@ -343,11 +341,8 @@ func TestTxSignerSession(t *testing.T) {
 		require.NoError(t, err)
 
 		// Exchange nonces.
-		nonce1, err := session1.GetNonce()
-		require.NoError(t, err)
-
-		nonce2, err := session2.GetNonce()
-		require.NoError(t, err)
+		nonce1 := session1.GetNonce()
+		nonce2 := session2.GetNonce()
 
 		// Aggregate nonces.
 		aggNonce, err := musig2.AggregateNonces([][66]byte{
@@ -529,8 +524,7 @@ func TestSignerSession(t *testing.T) {
 		require.NoError(t, err)
 
 		// Get nonces.
-		nonces, err := session.GetNonces()
-		require.NoError(t, err)
+		nonces := session.GetNonces()
 		require.Len(t, nonces, 1)
 
 		// Verify nonce exists for the leaf tx.
@@ -566,8 +560,7 @@ func TestSignerSession(t *testing.T) {
 			require.NoError(t, err)
 
 			// Get nonces from this session.
-			nonces, err := session.GetNonces()
-			require.NoError(t, err)
+			nonces := session.GetNonces()
 
 			// Create other participant's nonce (must be valid EC
 			// point).
@@ -627,11 +620,8 @@ func TestSignerSession(t *testing.T) {
 		require.NoError(t, err)
 
 		// Exchange nonces.
-		nonces1, err := session1.GetNonces()
-		require.NoError(t, err)
-
-		nonces2, err := session2.GetNonces()
-		require.NoError(t, err)
+		nonces1 := session1.GetNonces()
+		nonces2 := session2.GetNonces()
 
 		// Aggregate and register nonces.
 		leafTXID, _ := leaf.TXID()
@@ -750,8 +740,7 @@ func TestSignerSessionMultiTx(t *testing.T) {
 		require.Len(t, session.txs, 2)
 
 		// Get nonces for all txs.
-		nonces, err := session.GetNonces()
-		require.NoError(t, err)
+		nonces := session.GetNonces()
 		require.Len(t, nonces, 2)
 
 		// Should have nonce for root and leaf1.
@@ -789,8 +778,7 @@ func TestSignerSessionMultiTx(t *testing.T) {
 		// Should have exactly 1 tx (the leaf).
 		require.Len(t, session.txs, 1)
 
-		nonces, err := session.GetNonces()
-		require.NoError(t, err)
+		nonces := session.GetNonces()
 		require.Len(t, nonces, 1)
 
 		leafTXID, _ := leaf.TXID()
@@ -846,8 +834,8 @@ func TestTxSignerSessionSecurityNote(t *testing.T) {
 		require.NoError(t, err)
 
 		// Nonces should be different (proves fresh generation).
-		nonce1, _ := session1.GetNonce()
-		nonce2, _ := session2.GetNonce()
+		nonce1 := session1.GetNonce()
+		nonce2 := session2.GetNonce()
 
 		require.NotEqual(t, nonce1, nonce2,
 			"Sessions should generate unique nonces")
@@ -930,11 +918,8 @@ func TestFullSigningFlow(t *testing.T) {
 			require.NoError(t, err)
 
 			// Phase 1: Exchange nonces.
-			nonces1, err := session1.GetNonces()
-			require.NoError(t, err)
-
-			nonces2, err := session2.GetNonces()
-			require.NoError(t, err)
+			nonces1 := session1.GetNonces()
+			nonces2 := session2.GetNonces()
 
 			leafTXID, _ := leaf.TXID()
 
@@ -1045,12 +1030,10 @@ func TestFullSigningFlow(t *testing.T) {
 			require.Len(t, session2.txs, 3)
 
 			// Exchange nonces.
-			nonces1, err := session1.GetNonces()
-			require.NoError(t, err)
+			nonces1 := session1.GetNonces()
 			require.Len(t, nonces1, 3)
 
-			nonces2, err := session2.GetNonces()
-			require.NoError(t, err)
+			nonces2 := session2.GetNonces()
 			require.Len(t, nonces2, 3)
 
 			// Aggregate nonces for all 3 transactions.

--- a/lib/tree/tree.go
+++ b/lib/tree/tree.go
@@ -230,7 +230,7 @@ func (t *Tree) VerifySigned() error {
 // SubmitTreeSigs stores signatures in the tree nodes. This method does NOT
 // validate the signatures cryptographically - it only stores them. Use
 // VerifySigned after calling this method to validate signatures.
-func (t *Tree) SubmitTreeSigs(sigs map[string]*schnorr.Signature) error {
+func (t *Tree) SubmitTreeSigs(sigs map[TxID]*schnorr.Signature) error {
 	if sigs == nil {
 		return fmt.Errorf("signatures map cannot be nil")
 	}
@@ -241,7 +241,7 @@ func (t *Tree) SubmitTreeSigs(sigs map[string]*schnorr.Signature) error {
 			return fmt.Errorf("failed to get TXID: %w", err)
 		}
 
-		sig, exists := sigs[txid.String()]
+		sig, exists := sigs[txid]
 		if !exists {
 			return fmt.Errorf("signature not found for "+
 				"transaction %s", txid.String())

--- a/lib/tree/tree_test.go
+++ b/lib/tree/tree_test.go
@@ -764,10 +764,10 @@ func TestSubmitTreeSigs(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create signatures for all transactions.
-		sigs := make(map[string]*schnorr.Signature)
+		sigs := make(map[TxID]*schnorr.Signature)
 		for node := range tree.Root.NodesIter() {
 			txid, _ := node.TXID()
-			sigs[txid.String()] = createTestSignature(t)
+			sigs[txid] = createTestSignature(t)
 		}
 
 		// Initially no signatures.
@@ -831,7 +831,7 @@ func TestSubmitTreeSigs(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create signatures for only some transactions.
-		sigs := make(map[string]*schnorr.Signature)
+		sigs := make(map[TxID]*schnorr.Signature)
 		// Leave one transaction without signature.
 
 		err = tree.SubmitTreeSigs(sigs)


### PR DESCRIPTION
No logic changes here. Just a bit of clean-up in preparation for writing the server-side signing coordinator. 