### PR TITLE
systest: add new systest framework build on top of existing harness, add wallet boarding tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -222,3 +222,58 @@ jobs:
             **/test-artifacts/
           retention-days: 5
           if-no-files-found: ignore
+
+  ########################
+  # run system integration tests
+  ########################
+  systest:
+    name: Run system tests
+    runs-on: ubuntu-latest
+    strategy:
+      # Allow other tests in the matrix to continue if one fails.
+      fail-fast: false
+      matrix:
+        db_backend:
+          - sqlite
+          - postgres
+
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Clean up runner space
+        uses: ./.github/actions/cleanup-space
+
+      - name: Fetch and rebase on ${{ github.base_ref }}
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/rebase
+
+      - name: Setup go ${{ env.GO_VERSION }}
+        uses: ./.github/actions/setup-go
+        with:
+          go-version: '${{ env.GO_VERSION }}'
+          key-prefix: systest
+
+      - name: Run systest with ${{ matrix.db_backend }}
+        # Run with sudo as harness uses user 0:0 which needs extra permissions
+        # on the github runner in order for docker mounts to work correctly.
+        run: sudo env "PATH=$PATH" "GOPATH=$GOPATH" make systest-verbose db=${{ matrix.db_backend }}
+
+      - name: Fix artifact permissions
+        if: always()
+        run: |
+          # Fix permissions for test artifacts (created in package directories)
+          find . -type d -name "test-artifacts" -exec sudo chown -R "$(id -u):$(id -g)" {} + || true
+          find . -type d -name "test-artifacts" -exec sudo chmod -R a+r {} + || true
+
+      - name: Upload test artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: systest-artifacts-${{ matrix.db_backend }}-${{ github.run_id }}
+          path: |
+            **/test-artifacts/
+          retention-days: 5
+          if-no-files-found: ignore

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ run:
   build-tags:
     - test_postgres
     - test_sqlite
+    - systest
 
 linters-settings:
   custom:

--- a/Makefile
+++ b/Makefile
@@ -280,13 +280,18 @@ unit-race: #? Run unit tests with race detector
 	@$(call print, "Running unit race tests.")
 	env CGO_ENABLED=1 GORACE="history_size=7 halt_on_errors=1" $(UNIT_RACE)
 
-systest: #? Run system integration tests (requires Docker for LND/bitcoind)
-	@$(call print, "Running system integration tests.")
-	$(GOTEST) -tags systest -v ./systest/... -timeout 10m
+# Database backend for systest: sqlite (default) or postgres.
+# Usage: make systest db=postgres
+SYSTEST_DB_TAG := $(if $(filter postgres,$(db)),test_postgres)
+SYSTEST_TAGS := systest $(SYSTEST_DB_TAG)
 
-systest-verbose: #? Run system integration tests with harness stdout logging
-	@$(call print, "Running system integration tests with verbose logging.")
-	$(GOTEST) -tags systest -v ./systest/... -timeout 10m -harness.logstdout
+systest: #? Run system integration tests. Use db=postgres for PostgreSQL.
+	@$(call print, "Running system integration tests (db=$(or $(db),sqlite)).")
+	$(GOTEST) -tags "$(SYSTEST_TAGS)" -v ./systest/... -timeout 10m
+
+systest-verbose: #? Run system integration tests with verbose logging. Use db=postgres for PostgreSQL.
+	@$(call print, "Running system integration tests with verbose logging (db=$(or $(db),sqlite)).")
+	$(GOTEST) -tags "$(SYSTEST_TAGS)" -v ./systest/... -timeout 10m -harness.logstdout
 
 # ============
 # RPC GENERATION

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 .PHONY: ast-lint ast-grep-fix
 .PHONY: unit unit-cover unit-race check-go-version build install clean release
 .PHONY: build rpc install help clean-networks
+.PHONY: systest systest-verbose
 
 # Default target.
 .DEFAULT_GOAL := build
@@ -278,6 +279,14 @@ unit-cover: #? Run unit tests with coverage
 unit-race: #? Run unit tests with race detector
 	@$(call print, "Running unit race tests.")
 	env CGO_ENABLED=1 GORACE="history_size=7 halt_on_errors=1" $(UNIT_RACE)
+
+systest: #? Run system integration tests (requires Docker for LND/bitcoind)
+	@$(call print, "Running system integration tests.")
+	$(GOTEST) -tags systest -v ./systest/... -timeout 10m
+
+systest-verbose: #? Run system integration tests with harness stdout logging
+	@$(call print, "Running system integration tests with verbose logging.")
+	$(GOTEST) -tags systest -v ./systest/... -timeout 10m -harness.logstdout
 
 # ============
 # RPC GENERATION

--- a/chainbackends/doc.go
+++ b/chainbackends/doc.go
@@ -15,10 +15,21 @@
 // # Usage
 //
 // Backends are instantiated and passed to the ChainSource actor during
-// initialization:
+// initialization. For in-process lnd:
 //
-//	backend := chainbackends.NewLNDBackend(notifier, feeEstimator, wallet)
-//	chainSource := chainsource.NewChainSourceActor(backend, system)
+//	backend := chainbackends.NewLNDBackend(
+//		notifier, feeEstimator, broadcaster,
+//	)
+//	chainSource := chainsource.NewChainSourceActor(
+//		backend, system, ctx,
+//	)
+//
+// For remote lnd via lndclient:
+//
+//	backend := chainbackends.NewLNDBackendFromLndClient(lndServices)
+//	chainSource := chainsource.NewChainSourceActor(
+//		backend, system, ctx,
+//	)
 //
 // # Architecture
 //

--- a/chainbackends/lnd.go
+++ b/chainbackends/lnd.go
@@ -10,9 +10,18 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/chainsource"
 	"github.com/lightningnetwork/lnd/chainntnfs"
-	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 )
+
+// TxBroadcaster is a minimal interface for broadcasting transactions. This
+// allows LNDBackend to work with both lnwallet.WalletController (in-process
+// lnd) and lndclient wrappers (remote lnd via gRPC).
+type TxBroadcaster interface {
+	// PublishTransaction broadcasts the given transaction to the network.
+	// The label parameter is optional and may be used for wallet tracking.
+	PublishTransaction(ctx context.Context, tx *wire.MsgTx,
+		label string) error
+}
 
 // LNDBackend implements the chainsource.ChainBackend interface by wrapping
 // lnd's chain notification and fee estimation interfaces. This backend provides
@@ -28,20 +37,20 @@ type LNDBackend struct {
 	// feeEstimator provides fee estimation services from lnd.
 	feeEstimator chainfee.Estimator
 
-	// wallet provides transaction broadcasting capabilities.
-	wallet lnwallet.WalletController
+	// broadcaster provides transaction broadcasting capabilities.
+	broadcaster TxBroadcaster
 }
 
 // NewLNDBackend creates a new LNDBackend instance with the given lnd
 // components. All parameters must be non-nil.
 func NewLNDBackend(notifier chainntnfs.ChainNotifier,
 	feeEstimator chainfee.Estimator,
-	wallet lnwallet.WalletController) *LNDBackend {
+	broadcaster TxBroadcaster) *LNDBackend {
 
 	return &LNDBackend{
 		notifier:     notifier,
 		feeEstimator: feeEstimator,
-		wallet:       wallet,
+		broadcaster:  broadcaster,
 	}
 }
 
@@ -120,12 +129,12 @@ func (b *LNDBackend) TestMempoolAccept(ctx context.Context,
 		"LND backend")
 }
 
-// BroadcastTx broadcasts a transaction to the network using lnd's wallet
-// controller.
+// BroadcastTx broadcasts a transaction to the network using the configured
+// broadcaster.
 func (b *LNDBackend) BroadcastTx(ctx context.Context, tx *wire.MsgTx,
 	label string) error {
 
-	err := b.wallet.PublishTransaction(tx, label)
+	err := b.broadcaster.PublishTransaction(ctx, tx, label)
 	if err != nil {
 		return fmt.Errorf("failed to broadcast transaction: %w", err)
 	}

--- a/chainbackends/lndclient_adapters.go
+++ b/chainbackends/lndclient_adapters.go
@@ -1,0 +1,369 @@
+package chainbackends
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/build"
+	"github.com/lightninglabs/lndclient"
+	"github.com/lightningnetwork/lnd/chainntnfs"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
+)
+
+// LndClientTxBroadcaster implements TxBroadcaster using
+// lndclient.WalletKitClient.
+type LndClientTxBroadcaster struct {
+	walletKit lndclient.WalletKitClient
+}
+
+// NewLndClientTxBroadcaster creates a new broadcaster backed by lndclient.
+func NewLndClientTxBroadcaster(
+	walletKit lndclient.WalletKitClient) *LndClientTxBroadcaster {
+
+	return &LndClientTxBroadcaster{
+		walletKit: walletKit,
+	}
+}
+
+// PublishTransaction broadcasts the given transaction to the network via lnd.
+func (b *LndClientTxBroadcaster) PublishTransaction(ctx context.Context,
+	tx *wire.MsgTx, label string) error {
+
+	return b.walletKit.PublishTransaction(ctx, tx, label)
+}
+
+// Ensure LndClientTxBroadcaster implements TxBroadcaster.
+var _ TxBroadcaster = (*LndClientTxBroadcaster)(nil)
+
+// LndClientFeeEstimator implements chainfee.Estimator using lndclient.
+type LndClientFeeEstimator struct {
+	walletKit lndclient.WalletKitClient
+}
+
+// NewLndClientFeeEstimator creates a new fee estimator backed by lndclient.
+func NewLndClientFeeEstimator(
+	walletKit lndclient.WalletKitClient) *LndClientFeeEstimator {
+
+	return &LndClientFeeEstimator{
+		walletKit: walletKit,
+	}
+}
+
+// Start is a no-op for lndclient-backed estimators since the connection is
+// already established.
+func (e *LndClientFeeEstimator) Start() error {
+	return nil
+}
+
+// Stop is a no-op for lndclient-backed estimators.
+func (e *LndClientFeeEstimator) Stop() error {
+	return nil
+}
+
+// EstimateFeePerKW returns the estimated fee rate in satoshis per kilo-weight
+// unit for the given confirmation target.
+func (e *LndClientFeeEstimator) EstimateFeePerKW(
+	numBlocks uint32) (chainfee.SatPerKWeight, error) {
+
+	ctx, cancel := context.WithTimeout(
+		context.Background(), 30*time.Second,
+	)
+	defer cancel()
+	satPerVByte, err := e.walletKit.EstimateFeeRate(
+		ctx, int32(numBlocks),
+	)
+	if err != nil {
+		return 0, fmt.Errorf("estimate fee rate: %w", err)
+	}
+
+	satPerKw := chainfee.SatPerVByte(satPerVByte).FeePerKWeight()
+
+	return satPerKw, nil
+}
+
+// RelayFeePerKW returns the minimum fee rate required for transactions to be
+// relayed. For remote lnd, we return a reasonable default.
+func (e *LndClientFeeEstimator) RelayFeePerKW() chainfee.SatPerKWeight {
+	// Default relay fee of 1 sat/vbyte = 250 sat/kw.
+	return chainfee.SatPerKWeight(250)
+}
+
+// Ensure LndClientFeeEstimator implements chainfee.Estimator.
+var _ chainfee.Estimator = (*LndClientFeeEstimator)(nil)
+
+// LndClientChainNotifierConfig holds configuration for LndClientChainNotifier.
+type LndClientChainNotifierConfig struct {
+	// LND is the lndclient services connection.
+	LND *lndclient.LndServices
+
+	// Log is an optional logger for this notifier. If None, the notifier
+	// falls back to extracting a logger from context via
+	// LoggerFromContext, or uses btclog.Disabled if no logger is found.
+	Log fn.Option[btclog.Logger]
+}
+
+// WithLogger returns a new config with the given logger set.
+func (c LndClientChainNotifierConfig) WithLogger(
+	log btclog.Logger) LndClientChainNotifierConfig {
+
+	c.Log = fn.Some(log)
+
+	return c
+}
+
+// LndClientChainNotifier implements chainntnfs.ChainNotifier using lndclient.
+// This adapter bridges the lndclient.ChainNotifierClient interface to the
+// chainntnfs.ChainNotifier interface expected by LNDBackend.
+type LndClientChainNotifier struct {
+	// cfg holds all notifier configuration including lnd services and
+	// optional logger.
+	cfg LndClientChainNotifierConfig
+}
+
+// NewLndClientChainNotifier creates a new chain notifier backed by lndclient.
+// The config must include LND; use WithLogger() to inject a specific logger.
+func NewLndClientChainNotifier(
+	cfg LndClientChainNotifierConfig) *LndClientChainNotifier {
+
+	return &LndClientChainNotifier{
+		cfg: cfg,
+	}
+}
+
+// logger returns the configured logger or falls back to extracting from
+// context. If no logger is found in either location, returns btclog.Disabled.
+func (n *LndClientChainNotifier) logger(ctx context.Context) btclog.Logger {
+	return n.cfg.Log.UnwrapOr(build.LoggerFromContext(ctx))
+}
+
+// Start is a no-op for lndclient-backed notifiers since the connection is
+// already established.
+func (n *LndClientChainNotifier) Start() error {
+	return nil
+}
+
+// Started returns true since lndclient connections are always ready.
+func (n *LndClientChainNotifier) Started() bool {
+	return true
+}
+
+// Stop is a no-op for lndclient-backed notifiers.
+func (n *LndClientChainNotifier) Stop() error {
+	return nil
+}
+
+// RegisterConfirmationsNtfn registers for confirmation notifications using
+// lndclient's ChainNotifier.
+func (n *LndClientChainNotifier) RegisterConfirmationsNtfn(
+	txid *chainhash.Hash, pkScript []byte, numConfs, heightHint uint32,
+	opts ...chainntnfs.NotifierOption) (*chainntnfs.ConfirmationEvent,
+	error) {
+
+	notifierOpts := chainntnfs.DefaultNotifierOptions()
+	for _, opt := range opts {
+		opt(notifierOpts)
+	}
+
+	var lndOpts []lndclient.NotifierOption
+	if notifierOpts.IncludeBlock {
+		lndOpts = append(lndOpts, lndclient.WithIncludeBlock())
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	chainNotifier := n.cfg.LND.ChainNotifier
+	confChan, errChan, err := chainNotifier.RegisterConfirmationsNtfn(
+		ctx, txid, pkScript, int32(numConfs), int32(heightHint),
+		lndOpts...,
+	)
+	if err != nil {
+		cancel()
+
+		return nil, fmt.Errorf("register confirmations: %w", err)
+	}
+
+	go func() {
+		select {
+		case err, ok := <-errChan:
+			if ok && err != nil {
+				n.logger(ctx).WarnS(
+					ctx, "Conf notification error", err,
+				)
+			}
+
+		case <-ctx.Done():
+		}
+	}()
+
+	return &chainntnfs.ConfirmationEvent{
+		Confirmed: confChan,
+		Cancel:    cancel,
+		Done:      make(chan struct{}, 1),
+	}, nil
+}
+
+// RegisterSpendNtfn registers for spend notifications using lndclient's
+// ChainNotifier.
+func (n *LndClientChainNotifier) RegisterSpendNtfn(
+	outpoint *wire.OutPoint, pkScript []byte,
+	heightHint uint32) (*chainntnfs.SpendEvent, error) {
+
+	ctx, cancel := context.WithCancel(context.Background())
+	spendChan, errChan, err := n.cfg.LND.ChainNotifier.RegisterSpendNtfn(
+		ctx, outpoint, pkScript, int32(heightHint),
+	)
+	if err != nil {
+		cancel()
+
+		return nil, fmt.Errorf("register spend: %w", err)
+	}
+
+	go func() {
+		select {
+		case err, ok := <-errChan:
+			if ok && err != nil {
+				n.logger(ctx).WarnS(
+					ctx, "Spend notification error", err,
+				)
+			}
+
+		case <-ctx.Done():
+		}
+	}()
+
+	return &chainntnfs.SpendEvent{
+		Spend:  spendChan,
+		Reorg:  make(chan struct{}, 1),
+		Done:   make(chan struct{}, 1),
+		Cancel: cancel,
+	}, nil
+}
+
+// RegisterBlockEpochNtfn registers for block epoch notifications using
+// lndclient's ChainNotifier.
+func (n *LndClientChainNotifier) RegisterBlockEpochNtfn(
+	bestBlock *chainntnfs.BlockEpoch) (*chainntnfs.BlockEpochEvent, error) {
+
+	ctx, cancel := context.WithCancel(context.Background())
+	chainNotifier := n.cfg.LND.ChainNotifier
+	heightChan, errChan, err := chainNotifier.RegisterBlockEpochNtfn(ctx)
+	if err != nil {
+		cancel()
+
+		return nil, fmt.Errorf("register block epoch: %w", err)
+	}
+
+	log := n.logger(ctx)
+	log.InfoS(ctx, "Registered for block epoch notifications")
+
+	// Convert height-only channel to full BlockEpoch channel.
+	epochChan := make(chan *chainntnfs.BlockEpoch, 10)
+
+	go func() {
+		defer close(epochChan)
+		defer log.InfoS(ctx, "Block epoch forwarder goroutine exiting")
+
+		for {
+			select {
+			case height, ok := <-heightChan:
+				if !ok {
+					log.InfoS(ctx, "Height channel closed")
+					return
+				}
+
+				log.InfoS(ctx, "Received height from lndclient",
+					slog.Int("height", int(height)))
+
+				// lndclient only provides height, so we need to
+				// fetch the hash via ChainKit.
+				//
+				// TODO(rosabeef): why doesn't lndclient also
+				// give the block height?
+				chainKit := n.cfg.LND.ChainKit
+				blockHash, err := chainKit.GetBlockHash(
+					ctx, int64(height),
+				)
+				if err != nil {
+					log.WarnS(ctx, "Failed to get block hash",
+						err, slog.Int("height", int(height)))
+					continue
+				}
+
+				epoch := &chainntnfs.BlockEpoch{
+					Height: height,
+					Hash:   &blockHash,
+				}
+
+				select {
+				case epochChan <- epoch:
+				case <-ctx.Done():
+					log.InfoS(ctx, "Context cancelled while "+
+						"sending epoch")
+					return
+				}
+
+			case err, ok := <-errChan:
+				if ok && err != nil {
+					log.WarnS(ctx, "Block epoch error", err)
+				}
+
+				return
+
+			case <-ctx.Done():
+				log.InfoS(ctx, "Context cancelled")
+				return
+			}
+		}
+	}()
+
+	return &chainntnfs.BlockEpochEvent{
+		Epochs: epochChan,
+		Cancel: cancel,
+	}, nil
+}
+
+// Ensure LndClientChainNotifier implements chainntnfs.ChainNotifier.
+var _ chainntnfs.ChainNotifier = (*LndClientChainNotifier)(nil)
+
+// LNDBackendFromLndClientConfig holds configuration for creating an LNDBackend
+// from lndclient services.
+type LNDBackendFromLndClientConfig struct {
+	// LND is the lndclient services connection.
+	LND *lndclient.LndServices
+
+	// Log is an optional logger for the backend components. If None, the
+	// backend falls back to extracting a logger from context or uses
+	// btclog.Disabled.
+	Log fn.Option[btclog.Logger]
+}
+
+// WithLogger returns a new config with the given logger set.
+func (c LNDBackendFromLndClientConfig) WithLogger(
+	log btclog.Logger) LNDBackendFromLndClientConfig {
+
+	c.Log = fn.Some(log)
+	return c
+}
+
+// NewLNDBackendFromLndClient creates a new LNDBackend using lndclient
+// services. This is a convenience function for creating a backend from a
+// remote lnd connection. The config must include LND; use WithLogger() to
+// inject a specific logger.
+func NewLNDBackendFromLndClient(cfg LNDBackendFromLndClientConfig) *LNDBackend {
+	// Use explicit struct initialization instead of type cast for safety -
+	// this ensures we don't silently miss fields if the types diverge.
+	//nolint:gosimple
+	notifier := NewLndClientChainNotifier(LndClientChainNotifierConfig{
+		LND: cfg.LND,
+		Log: cfg.Log,
+	})
+	feeEstimator := NewLndClientFeeEstimator(cfg.LND.WalletKit)
+	broadcaster := NewLndClientTxBroadcaster(cfg.LND.WalletKit)
+
+	return NewLNDBackend(notifier, feeEstimator, broadcaster)
+}

--- a/chainbackends/log.go
+++ b/chainbackends/log.go
@@ -1,0 +1,11 @@
+package chainbackends
+
+const (
+	// Subsystem defines the logging subsystem code for the chainbackends
+	// package.
+	Subsystem = "CBKD"
+
+	// LndClientSubsystem defines the logging subsystem code for the
+	// lndclient adapter components.
+	LndClientSubsystem = "LNDC"
+)

--- a/chainsource/block_epoch_actor.go
+++ b/chainsource/block_epoch_actor.go
@@ -3,11 +3,31 @@ package chainsource
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"sync"
 
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
-	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightninglabs/darepo-client/build"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
 )
+
+// BlockEpochConfig holds configuration for BlockEpochActor.
+type BlockEpochConfig struct {
+	// Backend is the blockchain backend used to monitor blocks.
+	Backend ChainBackend
+
+	// Log is an optional logger for this actor instance. If None, the actor
+	// falls back to extracting a logger from context via LoggerFromContext,
+	// or uses btclog.Disabled if no logger is found.
+	Log fn.Option[btclog.Logger]
+}
+
+// WithLogger returns a new config with the given logger set.
+func (c BlockEpochConfig) WithLogger(log btclog.Logger) BlockEpochConfig {
+	c.Log = fn.Some(log)
+	return c
+}
 
 // BlockEpochActor is a single-subscription actor that monitors new blocks and
 // delivers block epoch events. Each instance serves exactly one subscription.
@@ -16,8 +36,9 @@ import (
 // iteration, and Actor mode for asynchronous event delivery to a registered
 // actor. Each actor creates its own backend registration (no sharing).
 type BlockEpochActor struct {
-	// backend is the blockchain backend used to monitor blocks.
-	backend ChainBackend
+	// cfg holds all actor configuration including backend and optional
+	// logger.
+	cfg BlockEpochConfig
 
 	// notifyActor is used in Actor mode to send events. None in Iterator
 	// mode.
@@ -30,7 +51,8 @@ type BlockEpochActor struct {
 	// registration is the backend registration for this actor.
 	registration *BlockRegistration
 
-	// ctx is the actor's context, cancelled when the actor stops.
+	// ctx is the actor's internal context for cancellation, created from
+	// context.Background() to ensure it outlives any request context.
 	//nolint:containedctx
 	ctx context.Context
 
@@ -48,18 +70,24 @@ type BlockEpochActor struct {
 }
 
 // NewBlockEpochActor creates a new BlockEpochActor instance with the given
-// backend and parent context. The actor waits for a SubscribeBlocksRequest
-// message to begin monitoring.
-func NewBlockEpochActor(backend ChainBackend,
-	parentCtx context.Context) *BlockEpochActor {
-
-	ctx, cancel := context.WithCancel(parentCtx)
+// configuration. The config must include Backend; use WithLogger() to inject
+// a specific logger.
+func NewBlockEpochActor(cfg BlockEpochConfig) *BlockEpochActor {
+	// Use background context for internal cancellation since the actor
+	// needs to outlive any request context. Logger is passed via config.
+	ctx, cancel := context.WithCancel(context.Background())
 
 	return &BlockEpochActor{
-		backend: backend,
-		ctx:     ctx,
-		cancel:  cancel,
+		cfg:    cfg,
+		ctx:    ctx,
+		cancel: cancel,
 	}
+}
+
+// logger returns the configured logger or falls back to extracting from
+// context. If no logger is found in either location, returns btclog.Disabled.
+func (a *BlockEpochActor) logger(ctx context.Context) btclog.Logger {
+	return a.cfg.Log.UnwrapOr(build.LoggerFromContext(ctx))
 }
 
 // Receive processes incoming messages for the BlockEpochActor.
@@ -149,7 +177,7 @@ func (a *BlockEpochActor) handleSubscribeBlocks(actorCtx context.Context,
 	// Register with the backend to receive block notifications. We do this
 	// before starting the goroutine so we can return an error to the
 	// caller if registration fails.
-	registration, err := a.backend.RegisterBlocks(a.ctx)
+	registration, err := a.cfg.Backend.RegisterBlocks(a.ctx)
 	if err != nil {
 		return fn.Err[EpochResp](fmt.Errorf(
 			"failed to register for blocks: %w", err))
@@ -168,8 +196,12 @@ func (a *BlockEpochActor) handleSubscribeBlocks(actorCtx context.Context,
 func (a *BlockEpochActor) monitorBlocks() {
 	defer a.wg.Done()
 
+	log := a.logger(a.ctx)
+	log.InfoS(a.ctx, "BlockEpochActor monitoring started")
+
 	// Make sure we clean up the registration on exit.
 	defer func() {
+		log.InfoS(a.ctx, "BlockEpochActor monitoring stopped")
 		if a.registration != nil {
 			a.registration.Cancel()
 		}
@@ -179,8 +211,12 @@ func (a *BlockEpochActor) monitorBlocks() {
 		select {
 		case epoch, ok := <-a.registration.Epochs:
 			if !ok {
+				log.InfoS(a.ctx, "Block epoch channel closed")
 				return
 			}
+
+			log.InfoS(a.ctx, "Received block from backend",
+				slog.Int("height", int(epoch.Height)))
 
 			// Forward the block epoch from the backend.
 			blockEpoch := BlockEpoch{
@@ -200,6 +236,9 @@ func (a *BlockEpochActor) monitorBlocks() {
 			} else {
 				// Otherwise, this is actor mode, so we'll
 				// deliver in the block epoch via a Tell.
+				log.InfoS(a.ctx, "Forwarding block to notify actor",
+					slog.Int("height", int(blockEpoch.Height)))
+
 				notifyRef := func(
 					ref actor.TellOnlyRef[BlockEpoch],
 				) {
@@ -210,6 +249,7 @@ func (a *BlockEpochActor) monitorBlocks() {
 			}
 
 		case <-a.ctx.Done():
+			log.InfoS(a.ctx, "BlockEpochActor context cancelled")
 			return
 		}
 	}

--- a/chainsource/chainsource.go
+++ b/chainsource/chainsource.go
@@ -6,8 +6,10 @@ import (
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
-	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightninglabs/darepo-client/build"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
 )
 
 const (
@@ -17,6 +19,27 @@ const (
 	epochChannelSize = 10
 )
 
+// ChainSourceConfig holds configuration for ChainSourceActor.
+type ChainSourceConfig struct {
+	// Backend is the blockchain backend used for all chain operations.
+	Backend ChainBackend
+
+	// System is the actor system for spawning sub-actors.
+	System *actor.ActorSystem
+
+	// Log is an optional logger for this actor instance. If None, the actor
+	// falls back to extracting a logger from context via LoggerFromContext,
+	// or uses btclog.Disabled if no logger is found.
+	Log fn.Option[btclog.Logger]
+}
+
+// WithLogger returns a new config with the given logger set.
+func (c ChainSourceConfig) WithLogger(log btclog.Logger) ChainSourceConfig {
+	c.Log = fn.Some(log)
+
+	return c
+}
+
 // ChainSourceActor is a stateless factory actor that provides blockchain
 // interface functionality. It handles direct queries (fee estimation, best
 // height, mempool testing, transaction broadcasting) and spawns dedicated
@@ -25,22 +48,24 @@ const (
 // Each monitoring request spawns a new dedicated actor with a unique service
 // key, enabling deterministic cancellation and eliminating shared state.
 type ChainSourceActor struct {
-	// backend is the blockchain backend used for all chain operations.
-	backend ChainBackend
-
-	// system is the actor system for spawning sub-actors.
-	system *actor.ActorSystem
+	// cfg holds all actor configuration including backend, system, and
+	// optional logger.
+	cfg ChainSourceConfig
 }
 
 // NewChainSourceActor creates a new ChainSourceActor instance with the given
-// backend and actor system.
-func NewChainSourceActor(backend ChainBackend,
-	system *actor.ActorSystem) *ChainSourceActor {
-
+// configuration. The config must include Backend and System; use WithLogger()
+// to inject a specific logger.
+func NewChainSourceActor(cfg ChainSourceConfig) *ChainSourceActor {
 	return &ChainSourceActor{
-		backend: backend,
-		system:  system,
+		cfg: cfg,
 	}
+}
+
+// logger returns the configured logger or falls back to extracting from
+// context. If no logger is found in either location, returns btclog.Disabled.
+func (a *ChainSourceActor) logger(ctx context.Context) btclog.Logger {
+	return a.cfg.Log.UnwrapOr(build.LoggerFromContext(ctx))
 }
 
 // Receive processes incoming messages for the ChainSourceActor. This handles
@@ -90,7 +115,7 @@ func (a *ChainSourceActor) Receive(actorCtx context.Context,
 func (a *ChainSourceActor) handleFeeEstimate(ctx context.Context,
 	req *FeeEstimateRequest) fn.Result[ChainSourceResp] {
 
-	feeRate, err := a.backend.EstimateFee(ctx, req.TargetConf)
+	feeRate, err := a.cfg.Backend.EstimateFee(ctx, req.TargetConf)
 	if err != nil {
 		return fn.Err[ChainSourceResp](fmt.Errorf("failed to "+
 			"estimate fee: %w", err))
@@ -106,7 +131,7 @@ func (a *ChainSourceActor) handleFeeEstimate(ctx context.Context,
 func (a *ChainSourceActor) handleBestHeight(ctx context.Context,
 	req *BestHeightRequest) fn.Result[ChainSourceResp] {
 
-	height, hash, err := a.backend.BestBlock(ctx)
+	height, hash, err := a.cfg.Backend.BestBlock(ctx)
 	if err != nil {
 		return fn.Err[ChainSourceResp](fmt.Errorf("failed to get "+
 			"best height: %w", err))
@@ -124,7 +149,7 @@ func (a *ChainSourceActor) handleBestHeight(ctx context.Context,
 func (a *ChainSourceActor) handleTestMempoolAccept(ctx context.Context,
 	req *TestMempoolAcceptRequest) fn.Result[ChainSourceResp] {
 
-	accepted, reason, err := a.backend.TestMempoolAccept(ctx, req.Tx)
+	accepted, reason, err := a.cfg.Backend.TestMempoolAccept(ctx, req.Tx)
 	if err != nil {
 		return fn.Err[ChainSourceResp](fmt.Errorf("failed to test "+
 			"mempool accept: %w", err))
@@ -141,7 +166,7 @@ func (a *ChainSourceActor) handleTestMempoolAccept(ctx context.Context,
 func (a *ChainSourceActor) handleBroadcastTx(ctx context.Context,
 	req *BroadcastTxRequest) fn.Result[ChainSourceResp] {
 
-	err := a.backend.BroadcastTx(ctx, req.Tx, req.Label)
+	err := a.cfg.Backend.BroadcastTx(ctx, req.Tx, req.Label)
 	if err != nil {
 		return fn.Err[ChainSourceResp](fmt.Errorf("failed to "+
 			"broadcast transaction: %w", err))
@@ -175,8 +200,12 @@ func (a *ChainSourceActor) handleRegisterConf(ctx context.Context,
 		req.CallerID, keyPart, req.TargetConfs,
 	)
 
-	confActor := NewConfActor(a.backend, context.Background())
-	actorRef := serviceKey.Spawn(a.system, actorID, confActor)
+	confCfg := ConfActorConfig{
+		Backend: a.cfg.Backend,
+		Log:     fn.Some(a.logger(ctx)),
+	}
+	confActor := NewConfActor(confCfg)
+	actorRef := serviceKey.Spawn(a.cfg.System, actorID, confActor)
 
 	// We block on this as we want to know if the subscription could be
 	// created or not, so we can notify the caller.
@@ -204,8 +233,12 @@ func (a *ChainSourceActor) handleRegisterSpend(ctx context.Context,
 		req.CallerID, keyPart,
 	)
 
-	spendActor := NewSpendActor(a.backend, context.Background())
-	actorRef := serviceKey.Spawn(a.system, actorID, spendActor)
+	spendCfg := SpendActorConfig{
+		Backend: a.cfg.Backend,
+		Log:     fn.Some(a.logger(ctx)),
+	}
+	spendActor := NewSpendActor(spendCfg)
+	actorRef := serviceKey.Spawn(a.cfg.System, actorID, spendActor)
 
 	// We block on this as we want to know if the subscription could be
 	// created or not, so we can notify the caller.
@@ -222,8 +255,13 @@ func (a *ChainSourceActor) handleSubscribeBlocks(ctx context.Context,
 	actorID := fmt.Sprintf("epoch.%s", req.CallerID)
 	serviceKey := epochActorServiceKey(req.CallerID)
 
-	epochActor := NewBlockEpochActor(a.backend, context.Background())
-	actorRef := serviceKey.Spawn(a.system, actorID, epochActor)
+	// Pass the backend and logger to the sub-actor via config.
+	epochCfg := BlockEpochConfig{
+		Backend: a.cfg.Backend,
+		Log:     fn.Some(a.logger(ctx)),
+	}
+	epochActor := NewBlockEpochActor(epochCfg)
+	actorRef := serviceKey.Spawn(a.cfg.System, actorID, epochActor)
 
 	return convertSubActorResult(
 		actorRef.Ask(ctx, req).Await(ctx), "subscribe blocks",
@@ -297,15 +335,16 @@ func (a *ChainSourceActor) handleUnsubscribeBlocks(ctx context.Context,
 func unregisterByServiceKey[Req, Resp actor.Message](
 	a *ChainSourceActor, serviceKey actor.ServiceKey[Req, Resp]) {
 
-	refs := actor.FindInReceptionist(a.system.Receptionist(), serviceKey)
+	receptionist := a.cfg.System.Receptionist()
+	refs := actor.FindInReceptionist(receptionist, serviceKey)
 	for _, ref := range refs {
 		// Unregister from receptionist.
-		serviceKey.Unregister(a.system, ref)
+		serviceKey.Unregister(a.cfg.System, ref)
 
 		// Stop the actor to prevent goroutine leak. The actor continues
 		// running even after being unregistered from the receptionist,
 		// so we must explicitly stop it.
-		a.system.StopAndRemoveActor(ref.ID())
+		a.cfg.System.StopAndRemoveActor(ref.ID())
 	}
 }
 

--- a/chainsource/chainsource_errors_test.go
+++ b/chainsource/chainsource_errors_test.go
@@ -18,7 +18,7 @@ func TestConfActorValidationErrors(t *testing.T) {
 
 	backend := newMockBackend()
 	ctx := t.Context()
-	confActor := NewConfActor(backend, ctx)
+	confActor := NewConfActor(ConfActorConfig{Backend: backend})
 	defer confActor.Stop()
 
 	testCases := []struct {
@@ -66,7 +66,7 @@ func TestSpendActorValidationErrors(t *testing.T) {
 
 	backend := newMockBackend()
 	ctx := t.Context()
-	spendActor := NewSpendActor(backend, ctx)
+	spendActor := NewSpendActor(SpendActorConfig{Backend: backend})
 	defer spendActor.Stop()
 
 	testCases := []struct {
@@ -163,7 +163,10 @@ func TestChainSourceActorBackendErrors(t *testing.T) {
 	system := actor.NewActorSystem()
 	defer func() { _ = system.Shutdown(t.Context()) }()
 
-	chainSource := NewChainSourceActor(backend, system)
+	chainSource := NewChainSourceActor(ChainSourceConfig{
+		Backend: backend,
+		System:  system,
+	})
 	ref := ChainSourceKey.Spawn(system, "test-chainsource", chainSource)
 
 	ctx := t.Context()
@@ -210,7 +213,7 @@ func TestConfActorBackendError(t *testing.T) {
 	testErr := errors.New("backend error")
 	backend := &errorBackend{err: testErr}
 	ctx := t.Context()
-	confActor := NewConfActor(backend, ctx)
+	confActor := NewConfActor(ConfActorConfig{Backend: backend})
 	defer confActor.Stop()
 
 	result := confActor.Receive(ctx, &RegisterConfRequest{
@@ -236,7 +239,7 @@ func TestSpendActorBackendError(t *testing.T) {
 	testErr := errors.New("backend error")
 	backend := &errorBackend{err: testErr}
 	ctx := t.Context()
-	spendActor := NewSpendActor(backend, ctx)
+	spendActor := NewSpendActor(SpendActorConfig{Backend: backend})
 	defer spendActor.Stop()
 
 	result := spendActor.Receive(ctx, &RegisterSpendRequest{
@@ -263,7 +266,7 @@ func TestBlockEpochActorBackendError(t *testing.T) {
 	testErr := errors.New("backend error")
 	backend := &errorBackend{err: testErr}
 	ctx := t.Context()
-	epochActor := NewBlockEpochActor(backend, ctx)
+	epochActor := NewBlockEpochActor(BlockEpochConfig{Backend: backend})
 	defer epochActor.Stop()
 
 	result := epochActor.Receive(ctx, &SubscribeBlocksRequest{
@@ -289,7 +292,7 @@ func TestConfActorDuplicateSubscription(t *testing.T) {
 
 	backend := newMockBackend()
 	ctx := t.Context()
-	confActor := NewConfActor(backend, ctx)
+	confActor := NewConfActor(ConfActorConfig{Backend: backend})
 	defer confActor.Stop()
 
 	result1 := confActor.Receive(ctx, &RegisterConfRequest{
@@ -321,7 +324,7 @@ func TestSpendActorDuplicateSubscription(t *testing.T) {
 
 	backend := newMockBackend()
 	ctx := t.Context()
-	spendActor := NewSpendActor(backend, ctx)
+	spendActor := NewSpendActor(SpendActorConfig{Backend: backend})
 	defer spendActor.Stop()
 
 	result1 := spendActor.Receive(ctx, &RegisterSpendRequest{
@@ -351,7 +354,7 @@ func TestBlockEpochActorDuplicateSubscription(t *testing.T) {
 
 	backend := newMockBackend()
 	ctx := t.Context()
-	epochActor := NewBlockEpochActor(backend, ctx)
+	epochActor := NewBlockEpochActor(BlockEpochConfig{Backend: backend})
 	defer epochActor.Stop()
 
 	result1 := epochActor.Receive(ctx, &SubscribeBlocksRequest{

--- a/chainsource/chainsource_test.go
+++ b/chainsource/chainsource_test.go
@@ -117,7 +117,10 @@ func TestChainSourceActorFeeEstimate(t *testing.T) {
 	system := actor.NewActorSystem()
 	defer func() { _ = system.Shutdown(t.Context()) }()
 
-	chainSource := NewChainSourceActor(backend, system)
+	chainSource := NewChainSourceActor(ChainSourceConfig{
+		Backend: backend,
+		System:  system,
+	})
 	ref := ChainSourceKey.Spawn(
 		system, "chainsource-1", chainSource,
 	)
@@ -144,7 +147,10 @@ func TestChainSourceActorTestMempoolAccept(t *testing.T) {
 	system := actor.NewActorSystem()
 	defer func() { _ = system.Shutdown(t.Context()) }()
 
-	chainSource := NewChainSourceActor(backend, system)
+	chainSource := NewChainSourceActor(ChainSourceConfig{
+		Backend: backend,
+		System:  system,
+	})
 	ref := ChainSourceKey.Spawn(system, "chainsource-mempool", chainSource)
 
 	ctx := t.Context()
@@ -171,7 +177,10 @@ func TestChainSourceActorBroadcastTx(t *testing.T) {
 	system := actor.NewActorSystem()
 	defer func() { _ = system.Shutdown(t.Context()) }()
 
-	chainSource := NewChainSourceActor(backend, system)
+	chainSource := NewChainSourceActor(ChainSourceConfig{
+		Backend: backend,
+		System:  system,
+	})
 	ref := ChainSourceKey.Spawn(
 		system, "chainsource-broadcast", chainSource,
 	)
@@ -203,7 +212,10 @@ func TestChainSourceActorBestHeight(t *testing.T) {
 	system := actor.NewActorSystem()
 	defer func() { _ = system.Shutdown(t.Context()) }()
 
-	chainSource := NewChainSourceActor(backend, system)
+	chainSource := NewChainSourceActor(ChainSourceConfig{
+		Backend: backend,
+		System:  system,
+	})
 	ref := ChainSourceKey.Spawn(
 		system, "chainsource-1", chainSource,
 	)
@@ -231,7 +243,10 @@ func TestChainSourceActorRegisterConf(t *testing.T) {
 	system := actor.NewActorSystem()
 	defer func() { _ = system.Shutdown(t.Context()) }()
 
-	chainSource := NewChainSourceActor(backend, system)
+	chainSource := NewChainSourceActor(ChainSourceConfig{
+		Backend: backend,
+		System:  system,
+	})
 	ref := ChainSourceKey.Spawn(system, "chainsource-conf", chainSource)
 
 	ctx := t.Context()
@@ -283,7 +298,10 @@ func TestChainSourceActorRegisterSpend(t *testing.T) {
 	system := actor.NewActorSystem()
 	defer func() { _ = system.Shutdown(t.Context()) }()
 
-	chainSource := NewChainSourceActor(backend, system)
+	chainSource := NewChainSourceActor(ChainSourceConfig{
+		Backend: backend,
+		System:  system,
+	})
 	ref := ChainSourceKey.Spawn(system, "chainsource-spend", chainSource)
 
 	ctx := t.Context()
@@ -333,7 +351,10 @@ func TestChainSourceActorUnregisterConf(t *testing.T) {
 	system := actor.NewActorSystem()
 	defer func() { _ = system.Shutdown(t.Context()) }()
 
-	chainSource := NewChainSourceActor(backend, system)
+	chainSource := NewChainSourceActor(ChainSourceConfig{
+		Backend: backend,
+		System:  system,
+	})
 	ref := ChainSourceKey.Spawn(
 		system, "chainsource-unreg-conf", chainSource,
 	)
@@ -376,7 +397,10 @@ func TestChainSourceActorUnregisterSpend(t *testing.T) {
 	system := actor.NewActorSystem()
 	defer func() { _ = system.Shutdown(t.Context()) }()
 
-	chainSource := NewChainSourceActor(backend, system)
+	chainSource := NewChainSourceActor(ChainSourceConfig{
+		Backend: backend,
+		System:  system,
+	})
 	ref := ChainSourceKey.Spawn(
 		system, "chainsource-unreg-spend", chainSource,
 	)
@@ -417,7 +441,10 @@ func TestChainSourceActorUnsubscribeBlocks(t *testing.T) {
 	system := actor.NewActorSystem()
 	defer func() { _ = system.Shutdown(t.Context()) }()
 
-	chainSource := NewChainSourceActor(backend, system)
+	chainSource := NewChainSourceActor(ChainSourceConfig{
+		Backend: backend,
+		System:  system,
+	})
 	ref := ChainSourceKey.Spawn(
 		system, "chainsource-unsub-blocks", chainSource,
 	)
@@ -453,7 +480,10 @@ func TestChainSourceActorSubscribeBlocks(t *testing.T) {
 	system := actor.NewActorSystem()
 	defer func() { _ = system.Shutdown(t.Context()) }()
 
-	chainSource := NewChainSourceActor(backend, system)
+	chainSource := NewChainSourceActor(ChainSourceConfig{
+		Backend: backend,
+		System:  system,
+	})
 	ref := ChainSourceKey.Spawn(system, "chainsource-epoch", chainSource)
 
 	ctx := t.Context()
@@ -500,7 +530,7 @@ func TestConfActorFutureMode(t *testing.T) {
 	backend := newMockBackend()
 
 	ctx := t.Context()
-	confActor := NewConfActor(backend, ctx)
+	confActor := NewConfActor(ConfActorConfig{Backend: backend})
 	defer confActor.Stop()
 
 	txHash := chainhash.Hash{}
@@ -548,7 +578,7 @@ func TestConfActorNotifyMode(t *testing.T) {
 
 	backend := newMockBackend()
 	ctx := t.Context()
-	confActor := NewConfActor(backend, ctx)
+	confActor := NewConfActor(ConfActorConfig{Backend: backend})
 	defer confActor.Stop()
 
 	txHash := chainhash.Hash{}
@@ -598,7 +628,7 @@ func TestConfActorHandlesNilTx(t *testing.T) {
 
 	backend := newMockBackend()
 	ctx := t.Context()
-	confActor := NewConfActor(backend, ctx)
+	confActor := NewConfActor(ConfActorConfig{Backend: backend})
 	defer confActor.Stop()
 
 	//nolint:ll
@@ -644,7 +674,7 @@ func TestConfActorHandlesClosedChannel(t *testing.T) {
 
 	backend := newMockBackend()
 	ctx := t.Context()
-	confActor := NewConfActor(backend, ctx)
+	confActor := NewConfActor(ConfActorConfig{Backend: backend})
 	defer confActor.Stop()
 
 	txHash := chainhash.Hash{}
@@ -678,7 +708,7 @@ func TestSpendActorFutureMode(t *testing.T) {
 	backend := newMockBackend()
 
 	ctx := t.Context()
-	spendActor := NewSpendActor(backend, ctx)
+	spendActor := NewSpendActor(SpendActorConfig{Backend: backend})
 	defer spendActor.Stop()
 
 	txHash := chainhash.Hash{}
@@ -726,7 +756,7 @@ func TestSpendActorNotifyMode(t *testing.T) {
 
 	backend := newMockBackend()
 	ctx := t.Context()
-	spendActor := NewSpendActor(backend, ctx)
+	spendActor := NewSpendActor(SpendActorConfig{Backend: backend})
 	defer spendActor.Stop()
 
 	txHash := chainhash.Hash{}
@@ -774,7 +804,7 @@ func TestSpendActorHandlesMissingTxHash(t *testing.T) {
 
 	backend := newMockBackend()
 	ctx := t.Context()
-	spendActor := NewSpendActor(backend, ctx)
+	spendActor := NewSpendActor(SpendActorConfig{Backend: backend})
 	defer spendActor.Stop()
 
 	outpoint := &wire.OutPoint{Hash: chainhash.Hash{}, Index: 0}
@@ -818,7 +848,7 @@ func TestSpendActorHandlesClosedChannel(t *testing.T) {
 
 	backend := newMockBackend()
 	ctx := t.Context()
-	spendActor := NewSpendActor(backend, ctx)
+	spendActor := NewSpendActor(SpendActorConfig{Backend: backend})
 	defer spendActor.Stop()
 
 	outpoint := &wire.OutPoint{Hash: chainhash.Hash{}, Index: 0}
@@ -851,7 +881,7 @@ func TestBlockEpochActorNotifyMode(t *testing.T) {
 
 	backend := newMockBackend()
 	ctx := t.Context()
-	epochActor := NewBlockEpochActor(backend, ctx)
+	epochActor := NewBlockEpochActor(BlockEpochConfig{Backend: backend})
 	defer epochActor.Stop()
 
 	notifier := actor.NewChannelTellOnlyRef[BlockEpoch]("test-notify", 10)
@@ -894,7 +924,7 @@ func TestBlockEpochActorIteratorMode(t *testing.T) {
 	backend := newMockBackend()
 
 	ctx := t.Context()
-	epochActor := NewBlockEpochActor(backend, ctx)
+	epochActor := NewBlockEpochActor(BlockEpochConfig{Backend: backend})
 	defer epochActor.Stop()
 
 	result := epochActor.Receive(ctx, &SubscribeBlocksRequest{
@@ -948,7 +978,7 @@ func TestBlockEpochActorIteratorCancel(t *testing.T) {
 
 	backend := newMockBackend()
 	ctx := t.Context()
-	epochActor := NewBlockEpochActor(backend, ctx)
+	epochActor := NewBlockEpochActor(BlockEpochConfig{Backend: backend})
 	defer epochActor.Stop()
 
 	// Subscription that stops after the first block.
@@ -996,7 +1026,7 @@ func TestBlockEpochActorIteratorCancel(t *testing.T) {
 	// Second subscription requires a new actor (each actor serves exactly
 	// one subscription). This tests explicit Cancel() without consuming
 	// blocks.
-	epochActor2 := NewBlockEpochActor(backend, ctx)
+	epochActor2 := NewBlockEpochActor(BlockEpochConfig{Backend: backend})
 	defer epochActor2.Stop()
 
 	result2 := epochActor2.Receive(ctx, &SubscribeBlocksRequest{
@@ -1206,7 +1236,8 @@ func TestConfActorIncludeBlock(t *testing.T) {
 
 			ctx := t.Context()
 			backend := newMockBackend()
-			confActor := NewConfActor(backend, ctx)
+			cfg := ConfActorConfig{Backend: backend}
+			confActor := NewConfActor(cfg)
 
 			// Send a register conf request directly into the
 			// actor.

--- a/chainsource/conf_actor.go
+++ b/chainsource/conf_actor.go
@@ -6,9 +6,27 @@ import (
 	"sync"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
-	"github.com/lightningnetwork/lnd/fn/v2"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
 )
+
+// ConfActorConfig holds configuration for ConfActor.
+type ConfActorConfig struct {
+	// Backend is the blockchain backend used to monitor confirmations.
+	Backend ChainBackend
+
+	// Log is an optional logger for this actor instance. If None, the actor
+	// falls back to extracting a logger from context via LoggerFromContext,
+	// or uses btclog.Disabled if no logger is found.
+	Log fn.Option[btclog.Logger]
+}
+
+// WithLogger returns a new config with the given logger set.
+func (c ConfActorConfig) WithLogger(log btclog.Logger) ConfActorConfig {
+	c.Log = fn.Some(log)
+	return c
+}
 
 // ConfActor is a single-subscription actor that monitors transaction
 // confirmations and delivers an event when the transaction reaches its target
@@ -18,8 +36,9 @@ import (
 // Actor mode for asynchronous event delivery. The actor exits after delivering
 // the confirmation event.
 type ConfActor struct {
-	// backend is the blockchain backend used to monitor confirmations.
-	backend ChainBackend
+	// cfg holds all actor configuration including backend and optional
+	// logger.
+	cfg ConfActorConfig
 
 	// txid is the transaction ID being monitored.
 	txid *chainhash.Hash
@@ -48,7 +67,8 @@ type ConfActor struct {
 	// registration is the backend registration for this watch.
 	registration *ConfRegistration
 
-	// ctx is the actor's context, cancelled when the actor stops.
+	// ctx is the actor's internal context for cancellation, created from
+	// context.Background() to ensure it outlives any request context.
 	//nolint:containedctx
 	ctx context.Context
 
@@ -59,16 +79,18 @@ type ConfActor struct {
 	wg sync.WaitGroup
 }
 
-// NewConfActor creates a new ConfActor instance with the given backend and
-// parent context. The actor waits for a RegisterConfRequest message to begin
-// monitoring.
-func NewConfActor(backend ChainBackend, parentCtx context.Context) *ConfActor {
-	ctx, cancel := context.WithCancel(parentCtx)
+// NewConfActor creates a new ConfActor instance with the given configuration.
+// The config must include Backend; use WithLogger() to inject a specific
+// logger.
+func NewConfActor(cfg ConfActorConfig) *ConfActor {
+	// Use background context for internal cancellation since the actor
+	// needs to outlive any request context. Logger is passed via config.
+	ctx, cancel := context.WithCancel(context.Background())
 
 	return &ConfActor{
-		backend: backend,
-		ctx:     ctx,
-		cancel:  cancel,
+		cfg:    cfg,
+		ctx:    ctx,
+		cancel: cancel,
 	}
 }
 
@@ -128,7 +150,7 @@ func (a *ConfActor) handleRegisterConf(actorCtx context.Context,
 	// Register with the backend to receive confirmation notifications. We
 	// do this before starting the goroutine so we can return an error to
 	// the caller if registration fails.
-	registration, err := a.backend.RegisterConf(
+	registration, err := a.cfg.Backend.RegisterConf(
 		a.ctx, a.txid, a.pkScript, a.targetConfs, a.heightHint,
 		a.includeBlock,
 	)

--- a/chainsource/log.go
+++ b/chainsource/log.go
@@ -1,0 +1,19 @@
+package chainsource
+
+const (
+	// Subsystem defines the logging subsystem code for the chainsource
+	// package.
+	Subsystem = "CSRC"
+
+	// ConfSubsystem defines the logging subsystem code for confirmation
+	// monitoring actors.
+	ConfSubsystem = "CONF"
+
+	// SpendSubsystem defines the logging subsystem code for spend
+	// monitoring actors.
+	SpendSubsystem = "SPND"
+
+	// EpochSubsystem defines the logging subsystem code for block epoch
+	// monitoring actors.
+	EpochSubsystem = "EPCH"
+)

--- a/chainsource/spend_actor.go
+++ b/chainsource/spend_actor.go
@@ -8,9 +8,27 @@ import (
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
-	"github.com/lightningnetwork/lnd/fn/v2"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
 )
+
+// SpendActorConfig holds configuration for SpendActor.
+type SpendActorConfig struct {
+	// Backend is the blockchain backend used to monitor spends.
+	Backend ChainBackend
+
+	// Log is an optional logger for this actor instance. If None, the actor
+	// falls back to extracting a logger from context via LoggerFromContext,
+	// or uses btclog.Disabled if no logger is found.
+	Log fn.Option[btclog.Logger]
+}
+
+// WithLogger returns a new config with the given logger set.
+func (c SpendActorConfig) WithLogger(log btclog.Logger) SpendActorConfig {
+	c.Log = fn.Some(log)
+	return c
+}
 
 // SpendActor is a single-subscription actor that monitors outpoint spends and
 // delivers events when outputs are consumed by confirmed transactions. Each
@@ -20,8 +38,9 @@ import (
 // (exits after first event), and Actor mode for asynchronous event delivery
 // (continues monitoring for re-orgs).
 type SpendActor struct {
-	// backend is the blockchain backend used to monitor spends.
-	backend ChainBackend
+	// cfg holds all actor configuration including backend and optional
+	// logger.
+	cfg SpendActorConfig
 
 	// outpoint is the output being monitored.
 	outpoint *wire.OutPoint
@@ -43,7 +62,8 @@ type SpendActor struct {
 	// registration is the backend registration for this watch.
 	registration *SpendRegistration
 
-	// ctx is the actor's context, cancelled when the actor stops.
+	// ctx is the actor's internal context for cancellation, created from
+	// context.Background() to ensure it outlives any request context.
 	//nolint:containedctx
 	ctx context.Context
 
@@ -54,18 +74,18 @@ type SpendActor struct {
 	wg sync.WaitGroup
 }
 
-// NewSpendActor creates a new SpendActor instance with the given backend and
-// parent context. The actor waits for a RegisterSpendRequest message to begin
-// monitoring.
-func NewSpendActor(backend ChainBackend,
-	parentCtx context.Context) *SpendActor {
-
-	ctx, cancel := context.WithCancel(parentCtx)
+// NewSpendActor creates a new SpendActor instance with the given configuration.
+// The config must include Backend; use WithLogger() to inject a specific
+// logger.
+func NewSpendActor(cfg SpendActorConfig) *SpendActor {
+	// Use background context for internal cancellation since the actor
+	// needs to outlive any request context. Logger is passed via config.
+	ctx, cancel := context.WithCancel(context.Background())
 
 	return &SpendActor{
-		backend: backend,
-		ctx:     ctx,
-		cancel:  cancel,
+		cfg:    cfg,
+		ctx:    ctx,
+		cancel: cancel,
 	}
 }
 
@@ -121,7 +141,7 @@ func (a *SpendActor) handleRegisterSpend(actorCtx context.Context,
 	// Register with the backend to receive spend notifications. We do this
 	// before starting the goroutine so we can return an error to the
 	// caller if registration fails.
-	registration, err := a.backend.RegisterSpend(
+	registration, err := a.cfg.Backend.RegisterSpend(
 		a.ctx, a.outpoint, a.pkScript, a.heightHint,
 	)
 	if err != nil {

--- a/lnd_boarding_wallet.go
+++ b/lnd_boarding_wallet.go
@@ -1,90 +1,17 @@
 package main
 
 import (
-	"context"
-	"fmt"
-
-	"github.com/btcsuite/btcd/btcutil"
-	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btcwallet/waddrmgr"
-	"github.com/lightninglabs/darepo-client/wallet"
+	"github.com/lightninglabs/darepo-client/lndbackend"
 	"github.com/lightninglabs/lndclient"
-	"github.com/lightningnetwork/lnd/keychain"
 )
 
-// LndBoardingBackend implements the wallet.BoardingBackend interface by
-// wrapping an lndclient.WalletKitClient. This provides the concrete
-// integration with an LND node for boarding address management.
-type LndBoardingBackend struct {
-	// walletKit is the LND wallet kit client used for key derivation,
-	// script import, and UTXO enumeration.
-	walletKit lndclient.WalletKitClient
-}
+// LndBoardingBackend is an alias for lndbackend.BoardingBackend for backwards
+// compatibility in the main package.
+type LndBoardingBackend = lndbackend.BoardingBackend
 
 // NewLndBoardingBackend creates a new LND boarding backend.
 func NewLndBoardingBackend(
-	walletKit lndclient.WalletKitClient,
-) *LndBoardingBackend {
+	walletKit lndclient.WalletKitClient) *LndBoardingBackend {
 
-	return &LndBoardingBackend{
-		walletKit: walletKit,
-	}
+	return lndbackend.NewBoardingBackend(walletKit)
 }
-
-// DeriveNextKey derives the next key in the specified key family using LND's
-// key derivation infrastructure.
-func (l *LndBoardingBackend) DeriveNextKey(ctx context.Context,
-	family keychain.KeyFamily) (*keychain.KeyDescriptor, error) {
-
-	keyDesc, err := l.walletKit.DeriveNextKey(ctx, int32(family))
-	if err != nil {
-		return nil, fmt.Errorf("derive next key: %w", err)
-	}
-
-	return keyDesc, nil
-}
-
-// ImportTaprootScript imports a taproot script into the LND wallet. After
-// import, LND will track UTXOs paying to this script.
-func (l *LndBoardingBackend) ImportTaprootScript(ctx context.Context,
-	script *waddrmgr.Tapscript) (btcutil.Address, error) {
-
-	addr, err := l.walletKit.ImportTaprootScript(ctx, script)
-	if err != nil {
-		return nil, fmt.Errorf("import taproot script: %w", err)
-	}
-
-	return addr, nil
-}
-
-// ListUnspent returns all UTXOs known to the LND wallet with confirmation
-// counts between minConfs and maxConfs. Converts from lnwallet.Utxo to the
-// wallet package's Utxo type.
-func (l *LndBoardingBackend) ListUnspent(ctx context.Context, minConfs,
-	maxConfs int32) ([]*wallet.Utxo, error) {
-
-	lndUtxos, err := l.walletKit.ListUnspent(ctx, minConfs, maxConfs)
-	if err != nil {
-		return nil, fmt.Errorf("list unspent: %w", err)
-	}
-
-	utxos := make([]*wallet.Utxo, 0, len(lndUtxos))
-	for _, lndUtxo := range lndUtxos {
-		utxo := &wallet.Utxo{
-			Outpoint: wire.OutPoint{
-				Hash:  lndUtxo.OutPoint.Hash,
-				Index: lndUtxo.OutPoint.Index,
-			},
-			PkScript:      lndUtxo.PkScript,
-			Amount:        lndUtxo.Value,
-			Confirmations: int32(lndUtxo.Confirmations),
-		}
-
-		utxos = append(utxos, utxo)
-	}
-
-	return utxos, nil
-}
-
-// Compile-time check that LndBoardingBackend implements BoardingBackend.
-var _ wallet.BoardingBackend = (*LndBoardingBackend)(nil)

--- a/lndbackend/boarding_backend.go
+++ b/lndbackend/boarding_backend.go
@@ -1,0 +1,91 @@
+// Package lndbackend provides lndclient-backed implementations of wallet
+// interfaces for connecting to remote LND nodes.
+package lndbackend
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/lightninglabs/darepo-client/wallet"
+	"github.com/lightninglabs/lndclient"
+	"github.com/lightningnetwork/lnd/keychain"
+)
+
+// BoardingBackend implements the wallet.BoardingBackend interface by
+// wrapping an lndclient.WalletKitClient. This provides the concrete
+// integration with an LND node for boarding address management.
+type BoardingBackend struct {
+	// walletKit is the LND wallet kit client used for key derivation,
+	// script import, and UTXO enumeration.
+	walletKit lndclient.WalletKitClient
+}
+
+// NewBoardingBackend creates a new LND boarding backend.
+func NewBoardingBackend(
+	walletKit lndclient.WalletKitClient) *BoardingBackend {
+
+	return &BoardingBackend{
+		walletKit: walletKit,
+	}
+}
+
+// DeriveNextKey derives the next key in the specified key family using LND's
+// key derivation infrastructure.
+func (l *BoardingBackend) DeriveNextKey(ctx context.Context,
+	family keychain.KeyFamily) (*keychain.KeyDescriptor, error) {
+
+	keyDesc, err := l.walletKit.DeriveNextKey(ctx, int32(family))
+	if err != nil {
+		return nil, fmt.Errorf("derive next key: %w", err)
+	}
+
+	return keyDesc, nil
+}
+
+// ImportTaprootScript imports a taproot script into the LND wallet. After
+// import, LND will track UTXOs paying to this script.
+func (l *BoardingBackend) ImportTaprootScript(ctx context.Context,
+	script *waddrmgr.Tapscript) (btcutil.Address, error) {
+
+	addr, err := l.walletKit.ImportTaprootScript(ctx, script)
+	if err != nil {
+		return nil, fmt.Errorf("import taproot script: %w", err)
+	}
+
+	return addr, nil
+}
+
+// ListUnspent returns all UTXOs known to the LND wallet with confirmation
+// counts between minConfs and maxConfs. Converts from lnwallet.Utxo to the
+// wallet package's Utxo type.
+func (l *BoardingBackend) ListUnspent(ctx context.Context, minConfs,
+	maxConfs int32) ([]*wallet.Utxo, error) {
+
+	lndUtxos, err := l.walletKit.ListUnspent(ctx, minConfs, maxConfs)
+	if err != nil {
+		return nil, fmt.Errorf("list unspent: %w", err)
+	}
+
+	utxos := make([]*wallet.Utxo, 0, len(lndUtxos))
+	for _, lndUtxo := range lndUtxos {
+		utxo := &wallet.Utxo{
+			Outpoint: wire.OutPoint{
+				Hash:  lndUtxo.OutPoint.Hash,
+				Index: lndUtxo.OutPoint.Index,
+			},
+			PkScript:      lndUtxo.PkScript,
+			Amount:        lndUtxo.Value,
+			Confirmations: int32(lndUtxo.Confirmations),
+		}
+
+		utxos = append(utxos, utxo)
+	}
+
+	return utxos, nil
+}
+
+// Compile-time check that BoardingBackend implements wallet.BoardingBackend.
+var _ wallet.BoardingBackend = (*BoardingBackend)(nil)

--- a/systest/boarding_wallet_test.go
+++ b/systest/boarding_wallet_test.go
@@ -1,0 +1,245 @@
+//go:build systest
+
+package systest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/wallet"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBoardingWalletIntentPersistence tests that when a boarding address
+// receives funds, the BoardingIntent is persisted with full fidelity. This
+// verifies address creation, funding detection, and complete data integrity.
+func TestBoardingWalletIntentPersistence(t *testing.T) {
+	f := NewBoardingWalletFixture(t)
+
+	// Create address and verify it's stored correctly.
+	addrResp := f.CreateBoardingAddress(144)
+	addresses := f.GetActiveAddresses()
+	require.Len(t, addresses, 1)
+
+	storedAddr := addresses[addrResp.Address.String()]
+	require.NotNil(t, storedAddr)
+	f.AssertAddressStored(storedAddr)
+
+	// Fund it and wait for detection.
+	fundAmount := btcutil.Amount(btcutil.SatoshiPerBitcoin / 4)
+	f.FundAddress(addrResp.Address.String(), fundAmount)
+	f.WaitForBalance(30 * time.Second)
+
+	// Verify intent is stored with full fidelity.
+	intent := f.AssertIntentStored(storedAddr, fundAmount)
+
+	t.Logf("Intent stored: outpoint=%s, height=%d, amount=%d",
+		intent.Outpoint.String(), intent.ChainInfo.ConfHeight,
+		intent.ChainInfo.Amount)
+}
+
+// TestBoardingWalletBacklogNotifications tests both backlog delivery (for
+// historical UTXOs) and real-time notifications (for new UTXOs). This
+// verifies the BacklogHeight parameter works correctly.
+func TestBoardingWalletBacklogNotifications(t *testing.T) {
+	f := NewBoardingWalletFixture(t)
+	ctx := f.Context()
+
+	// First, create and fund address BEFORE registering any notifier.
+	addr1 := f.CreateBoardingAddress(144)
+	amount1 := btcutil.Amount(btcutil.SatoshiPerBitcoin / 2)
+	f.FundAddress(addr1.Address.String(), amount1)
+	f.WaitForBalance(30 * time.Second)
+
+	// With the address created, verify that it actually exists.
+	intents, err := f.Store().FetchBoardingIntentsByStatus(
+		ctx, wallet.BoardingStatusConfirmed,
+	)
+	require.NoError(t, err)
+	require.Len(t, intents, 1)
+	backlogHeight := intents[0].ChainInfo.ConfHeight
+
+	// Next, register with BacklogHeight to receive historical event.
+	notifyCh := f.RegisterNotifierWithBacklog("backlog-test", backlogHeight)
+
+	// We should receive backlog notification for already-confirmed UTXO.
+	select {
+	case event := <-notifyCh:
+		t.Logf("Backlog notification: height=%d, addr=%s",
+			event.ChainInfo.ConfHeight,
+			event.Address.Address.String())
+
+		require.Equal(
+			t, addr1.Address.String(),
+			event.Address.Address.String(),
+		)
+		require.Equal(t, backlogHeight, event.ChainInfo.ConfHeight)
+
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for backlog notification")
+	}
+
+	// Now we'll create second address and fund it, this should result in
+	// us getting yet another notification.
+	addr2 := f.CreateBoardingAddress(288)
+	amount2 := btcutil.Amount(btcutil.SatoshiPerBitcoin / 4)
+	f.FundAddress(addr2.Address.String(), amount2)
+
+	// Should receive real-time notification for new UTXO.
+	select {
+	case event := <-notifyCh:
+		t.Logf(
+			"Real-time notification: height=%d, addr=%s",
+			event.ChainInfo.ConfHeight,
+			event.Address.Address.String(),
+		)
+
+		require.Equal(
+			t, addr2.Address.String(),
+			event.Address.Address.String(),
+		)
+
+	case <-time.After(30 * time.Second):
+		t.Fatal("timeout waiting for real-time notification")
+	}
+
+	// Verify both intents exist with correct details.
+	balance := f.GetBalance()
+	require.Equal(t, 2, balance.UtxoCount)
+
+	f.UnregisterNotifier("backlog-test")
+}
+
+// TestBoardingWalletAddressReuse tests that multiple credits to the SAME
+// boarding address are correctly tracked as separate intents.
+func TestBoardingWalletAddressReuse(t *testing.T) {
+	f := NewBoardingWalletFixture(t)
+	ctx := f.Context()
+
+	// Register notifier to capture all events.
+	notifyCh := f.RegisterNotifier("reuse-notifier")
+
+	// Now, create a single boarding address.
+	addrResp := f.CreateBoardingAddress(144)
+	addr := addrResp.Address.String()
+	addresses := f.GetActiveAddresses()
+	storedAddr := addresses[addr]
+	f.AssertAddressStored(storedAddr)
+
+	// Send some funds to it.
+	amount1 := btcutil.Amount(btcutil.SatoshiPerBitcoin / 4)
+	f.FundAddress(addr, amount1)
+
+	var firstOutpoint wire.OutPoint
+	select {
+	case event := <-notifyCh:
+		t.Logf("First UTXO: %s, amount=%d", event.Outpoint.String(),
+			event.ChainInfo.Amount)
+
+		require.Equal(t, addr, event.Address.Address.String())
+		firstOutpoint = event.Outpoint
+
+	case <-time.After(30 * time.Second):
+		t.Fatal("timeout waiting for first notification")
+	}
+
+	// Send second credit to SAME address.
+	amount2 := btcutil.Amount(btcutil.SatoshiPerBitcoin / 2)
+	f.FundAddress(addr, amount2)
+
+	select {
+	case event := <-notifyCh:
+		t.Logf("Second UTXO: %s, amount=%d", event.Outpoint.String(),
+			event.ChainInfo.Amount)
+		require.Equal(t, addr, event.Address.Address.String())
+		require.NotEqual(t, firstOutpoint, event.Outpoint,
+			"should be different outpoint")
+
+	case <-time.After(30 * time.Second):
+		t.Fatal("timeout waiting for second notification")
+	}
+
+	// Verify two separate intents exist for the same address.
+	intents, err := f.Store().FetchBoardingIntentsByStatus(
+		ctx, wallet.BoardingStatusConfirmed,
+	)
+	require.NoError(t, err)
+	require.Len(t, intents, 2, "should have 2 intents for reused address")
+
+	// Both reference the same address but have different outpoints.
+	require.Equal(
+		t, intents[0].Address.Address.String(),
+		intents[1].Address.Address.String(),
+	)
+	require.NotEqual(t, intents[0].Outpoint, intents[1].Outpoint)
+
+	// Balance should be sum of both.
+	balance := f.GetBalance()
+	require.InDelta(
+		t, int64(amount1+amount2), int64(balance.TotalBalance), 20000,
+	)
+	require.Equal(t, 2, balance.UtxoCount)
+
+	f.UnregisterNotifier("reuse-notifier")
+}
+
+// TestBoardingWalletMultipleAddresses tests creating and funding multiple
+// addresses with different exit delays, verifying each is stored correctly.
+func TestBoardingWalletMultipleAddresses(t *testing.T) {
+	f := NewBoardingWalletFixture(t)
+	ctx := f.Context()
+
+	// Create 3 addresses with different exit delays.
+	addr1 := f.CreateBoardingAddress(144)
+	addr2 := f.CreateBoardingAddress(288)
+	addr3 := f.CreateBoardingAddress(432)
+
+	// Verify all addresses are stored with correct details.
+	addresses := f.GetActiveAddresses()
+	require.Len(t, addresses, 3)
+	for _, addr := range addresses {
+		f.AssertAddressStored(addr)
+	}
+
+	// Fund each address with different amounts.
+	amounts := []btcutil.Amount{
+		btcutil.Amount(btcutil.SatoshiPerBitcoin / 4),
+		btcutil.Amount(btcutil.SatoshiPerBitcoin / 2),
+		btcutil.Amount(btcutil.SatoshiPerBitcoin / 8),
+	}
+
+	f.FundAddress(addr1.Address.String(), amounts[0])
+	f.FundAddress(addr2.Address.String(), amounts[1])
+	f.FundAddress(addr3.Address.String(), amounts[2])
+
+	// Wait for all UTXOs to be detected.
+	require.Eventually(t, func() bool {
+		return f.GetBalance().UtxoCount == 3
+	}, 60*time.Second, 500*time.Millisecond)
+
+	// Verify all intents are persisted with correct exit delays.
+	intents, err := f.Store().FetchBoardingIntentsByStatus(
+		ctx, wallet.BoardingStatusConfirmed,
+	)
+	require.NoError(t, err)
+	require.Len(t, intents, 3)
+
+	exitDelays := make(map[string]uint32)
+	for _, intent := range intents {
+		addrStr := intent.Address.Address.String()
+		exitDelays[addrStr] = intent.Address.ExitDelay
+	}
+
+	require.Equal(t, uint32(144), exitDelays[addr1.Address.String()])
+	require.Equal(t, uint32(288), exitDelays[addr2.Address.String()])
+	require.Equal(t, uint32(432), exitDelays[addr3.Address.String()])
+
+	// Verify total balance.
+	balance := f.GetBalance()
+	expectedTotal := amounts[0] + amounts[1] + amounts[2]
+	require.InDelta(
+		t, int64(expectedTotal), int64(balance.TotalBalance), 30000,
+	)
+}

--- a/systest/boarding_wallet_test.go
+++ b/systest/boarding_wallet_test.go
@@ -16,6 +16,8 @@ import (
 // receives funds, the BoardingIntent is persisted with full fidelity. This
 // verifies address creation, funding detection, and complete data integrity.
 func TestBoardingWalletIntentPersistence(t *testing.T) {
+	ParallelN(t)
+
 	f := NewBoardingWalletFixture(t)
 
 	// Create address and verify it's stored correctly.
@@ -44,6 +46,8 @@ func TestBoardingWalletIntentPersistence(t *testing.T) {
 // historical UTXOs) and real-time notifications (for new UTXOs). This
 // verifies the BacklogHeight parameter works correctly.
 func TestBoardingWalletBacklogNotifications(t *testing.T) {
+	ParallelN(t)
+
 	f := NewBoardingWalletFixture(t)
 	ctx := f.Context()
 
@@ -115,6 +119,8 @@ func TestBoardingWalletBacklogNotifications(t *testing.T) {
 // TestBoardingWalletAddressReuse tests that multiple credits to the SAME
 // boarding address are correctly tracked as separate intents.
 func TestBoardingWalletAddressReuse(t *testing.T) {
+	ParallelN(t)
+
 	f := NewBoardingWalletFixture(t)
 	ctx := f.Context()
 
@@ -188,6 +194,8 @@ func TestBoardingWalletAddressReuse(t *testing.T) {
 // TestBoardingWalletMultipleAddresses tests creating and funding multiple
 // addresses with different exit delays, verifying each is stored correctly.
 func TestBoardingWalletMultipleAddresses(t *testing.T) {
+	ParallelN(t)
+
 	f := NewBoardingWalletFixture(t)
 	ctx := f.Context()
 

--- a/systest/helpers.go
+++ b/systest/helpers.go
@@ -1,0 +1,419 @@
+//go:build systest
+
+package systest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/chainsource"
+	"github.com/lightninglabs/darepo-client/wallet"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// NotificationReceiver is a simple actor that forwards
+// BoardingUtxoConfirmedEvent to a channel for test verification.
+type NotificationReceiver struct {
+	ch chan<- wallet.BoardingUtxoConfirmedEvent
+}
+
+// NewNotificationReceiver creates a new notification receiver actor.
+func NewNotificationReceiver(
+	ch chan<- wallet.BoardingUtxoConfirmedEvent) *NotificationReceiver {
+
+	return &NotificationReceiver{ch: ch}
+}
+
+// Receive implements the actor.ActorBehavior interface.
+func (n *NotificationReceiver) Receive(ctx context.Context,
+	msg wallet.BoardingUtxoConfirmedEvent) fn.Result[fn.Unit] {
+
+	select {
+	case n.ch <- msg:
+	case <-ctx.Done():
+	}
+
+	return fn.Ok(fn.Unit{})
+}
+
+// GenerateOperatorKey creates a test operator public key.
+func GenerateOperatorKey(t *testing.T) *btcec.PublicKey {
+	t.Helper()
+
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	return privKey.PubKey()
+}
+
+// SpawnNotificationReceiver creates and spawns a notification receiver actor
+// that forwards events to the provided channel.
+func SpawnNotificationReceiver(t *testing.T, h *SysTestHarness,
+	ch chan wallet.BoardingUtxoConfirmedEvent,
+) actor.TellOnlyRef[wallet.BoardingUtxoConfirmedEvent] {
+
+	t.Helper()
+
+	receiver := NewNotificationReceiver(ch)
+
+	// Create a service key for the notification receiver.
+	key := actor.NewServiceKey[wallet.BoardingUtxoConfirmedEvent, fn.Unit](
+		"notification-receiver",
+	)
+	ref := actor.RegisterWithSystem(
+		h.ActorSystem(), "notification-receiver", key, receiver,
+	)
+
+	// Return as TellOnlyRef since we only need Tell capability.
+	// ActorRef implements TellOnlyRef, so the interface conversion is
+	// automatic.
+	return ref
+}
+
+// BoardingWalletFixture holds the common components for boarding wallet tests.
+// It encapsulates the harness, chain source, wallet actor, and wallet
+// reference so tests can focus on test logic rather than setup boilerplate.
+type BoardingWalletFixture struct {
+	// T is the test instance.
+	T *testing.T
+
+	// Harness is the systest harness with Docker infrastructure.
+	Harness *SysTestHarness
+
+	// ChainSource is the chain source actor reference.
+	ChainSource actor.ActorRef[
+		chainsource.ChainSourceMsg, chainsource.ChainSourceResp,
+	]
+
+	// WalletActor is the underlying wallet actor instance.
+	WalletActor *wallet.Ark
+
+	// Wallet is the wallet actor reference for sending messages.
+	Wallet actor.ActorRef[wallet.WalletMsg, wallet.WalletResp]
+}
+
+// NewBoardingWalletFixture creates a complete boarding wallet test fixture. It
+// sets up the harness, chain source actor, boarding backend, wallet actor, and
+// starts everything. The caller only needs to write test logic.
+func NewBoardingWalletFixture(t *testing.T) *BoardingWalletFixture {
+	t.Helper()
+
+	h := NewSysTestHarness(t)
+	ctx := h.Context()
+
+	// Create and start the chain source actor, along with the wallet and
+	// all its deps.
+	chainSourceRef := h.NewChainSourceActor()
+	backend := h.NewBoardingBackend()
+	walletActor := wallet.NewArk(
+		backend, h.BoardingStore(), chainSourceRef,
+		h.SubLogger(wallet.Subsystem),
+	)
+
+	// Next, we'll make a service key for tha wallet, then register it with
+	// the system to obtain its ref.
+	walletKey := actor.NewServiceKey[wallet.WalletMsg, wallet.WalletResp](
+		"boarding-wallet",
+	)
+	walletRef := actor.RegisterWithSystem(
+		h.ActorSystem(), "boarding-wallet", walletKey, walletActor,
+	)
+
+	// Now that the wallet has been registered with the system, we'll start
+	// it so it can perform its start up duties.
+	err := walletActor.Start(ctx, walletRef)
+	require.NoError(t, err)
+
+	return &BoardingWalletFixture{
+		T:           t,
+		Harness:     h,
+		ChainSource: chainSourceRef,
+		WalletActor: walletActor,
+		Wallet:      walletRef,
+	}
+}
+
+// Context returns the test context from the harness.
+func (f *BoardingWalletFixture) Context() context.Context {
+	return f.Harness.Context()
+}
+
+// CreateBoardingAddress creates a new boarding address with the given exit
+// delay. Returns the address string.
+func (f *BoardingWalletFixture) CreateBoardingAddress(
+	exitDelay uint32) *wallet.CreateBoardingAddressResponse {
+
+	f.T.Helper()
+
+	operatorKey := GenerateOperatorKey(f.T)
+	req := &wallet.CreateBoardingAddressRequest{
+		OperatorKey: operatorKey,
+		ExitDelay:   exitDelay,
+	}
+
+	future := f.Wallet.Ask(f.Context(), req)
+	result := future.Await(f.Context())
+	require.True(
+		f.T, result.IsOk(), "create address failed: %v", result.Err(),
+	)
+
+	respVal, err := result.Unpack()
+	require.NoError(f.T, err)
+
+	resp, ok := respVal.(*wallet.CreateBoardingAddressResponse)
+	require.True(f.T, ok, "unexpected response type: %T", respVal)
+
+	f.T.Logf("Created boarding address: %s", resp.Address.String())
+
+	return resp
+}
+
+// FundAddress sends the specified amount to the given address and mines a
+// block to confirm it.
+func (f *BoardingWalletFixture) FundAddress(
+	addr string, amount btcutil.Amount,
+) {
+
+	f.T.Helper()
+
+	f.Harness.Harness.Faucet(addr, amount)
+
+	f.T.Logf("Sent %d satoshis to %s", amount, addr)
+
+	f.Harness.Harness.Generate(1)
+	f.Harness.WaitForLNDSync()
+
+	f.T.Log("Mined 1 block")
+}
+
+// GetBalance queries and returns the current boarding balance.
+//
+//nolint:ll
+func (f *BoardingWalletFixture) GetBalance() *wallet.GetBoardingBalanceResponse {
+	f.T.Helper()
+
+	req := &wallet.GetBoardingBalanceRequest{}
+	future := f.Wallet.Ask(f.Context(), req)
+	result := future.Await(f.Context())
+	require.True(f.T, result.IsOk(), "get balance failed: %v", result.Err())
+
+	respVal, err := result.Unpack()
+	require.NoError(f.T, err)
+
+	resp, ok := respVal.(*wallet.GetBoardingBalanceResponse)
+	require.True(f.T, ok, "unexpected response type: %T", respVal)
+
+	return resp
+}
+
+// WaitForBalance waits until the wallet has a positive balance.
+func (f *BoardingWalletFixture) WaitForBalance(timeout time.Duration) {
+	f.T.Helper()
+
+	require.Eventually(f.T, func() bool {
+		bal := f.GetBalance()
+		f.T.Logf("Current balance: %d satoshis, UTXO count: %d",
+			bal.TotalBalance, bal.UtxoCount)
+
+		return bal.TotalBalance > 0
+	}, timeout, 500*time.Millisecond, "wallet did not recognize balance")
+}
+
+// GetActiveAddresses returns all active boarding addresses as a map keyed by
+// address string for efficient lookups.
+//
+//nolint:ll
+func (f *BoardingWalletFixture) GetActiveAddresses() map[string]*wallet.BoardingAddress {
+	f.T.Helper()
+
+	req := &wallet.GetActiveBoardingAddressesRequest{}
+	future := f.Wallet.Ask(f.Context(), req)
+	result := future.Await(f.Context())
+	require.True(f.T, result.IsOk())
+
+	respVal, err := result.Unpack()
+	require.NoError(f.T, err)
+
+	resp, ok := respVal.(*wallet.GetActiveBoardingAddressesResponse)
+	require.True(f.T, ok, "unexpected response type: %T", respVal)
+
+	// Convert to map for efficient lookups.
+	addrMap := make(map[string]*wallet.BoardingAddress, len(resp.Addresses))
+	for _, addr := range resp.Addresses {
+		addrMap[addr.Address.String()] = addr
+	}
+
+	return addrMap
+}
+
+// RegisterNotifier registers a notification receiver and returns the channel
+// to receive events on.
+func (f *BoardingWalletFixture) RegisterNotifier(
+	notifierID string) <-chan wallet.BoardingUtxoConfirmedEvent {
+
+	f.T.Helper()
+
+	notifyCh := make(chan wallet.BoardingUtxoConfirmedEvent, 1)
+	notifyRef := SpawnNotificationReceiver(f.T, f.Harness, notifyCh)
+
+	req := &wallet.RegisterConfirmationNotifierRequest{
+		NotifierID:    notifierID,
+		NotifyActor:   notifyRef,
+		BacklogHeight: fn.None[int32](),
+	}
+
+	future := f.Wallet.Ask(f.Context(), req)
+	result := future.Await(f.Context())
+	require.True(
+		f.T, result.IsOk(), "register notifier failed: %v",
+		result.Err(),
+	)
+
+	f.T.Logf("Registered confirmation notifier: %s", notifierID)
+
+	return notifyCh
+}
+
+// UnregisterNotifier unregisters a notification receiver.
+func (f *BoardingWalletFixture) UnregisterNotifier(notifierID string) {
+	f.T.Helper()
+
+	req := &wallet.UnregisterConfirmationNotifierRequest{
+		NotifierID: notifierID,
+	}
+
+	future := f.Wallet.Ask(f.Context(), req)
+	result := future.Await(f.Context())
+	require.True(
+		f.T, result.IsOk(), "unregister notifier failed: %v",
+		result.Err(),
+	)
+
+	f.T.Logf("Unregistered confirmation notifier: %s", notifierID)
+}
+
+// Store returns the underlying BoardingStore for direct queries in tests.
+func (f *BoardingWalletFixture) Store() wallet.BoardingStore {
+	return f.Harness.BoardingStore()
+}
+
+// AssertAddressStored verifies a boarding address is correctly persisted with
+// full fidelity. It compares the stored address against the expected values.
+func (f *BoardingWalletFixture) AssertAddressStored(
+	expected *wallet.BoardingAddress) {
+
+	f.T.Helper()
+
+	addresses := f.GetActiveAddresses()
+
+	// Look up by address string.
+	found, ok := addresses[expected.Address.String()]
+	require.True(f.T, ok, "address %s not found in store",
+		expected.Address.String())
+
+	// Verify all fields.
+	require.Equal(f.T, expected.ExitDelay, found.ExitDelay)
+	require.True(f.T, expected.OperatorKey.IsEqual(found.OperatorKey),
+		"operator key mismatch")
+	require.Equal(f.T, expected.KeyDesc.KeyLocator.Family,
+		found.KeyDesc.KeyLocator.Family)
+	require.Equal(f.T, expected.KeyDesc.KeyLocator.Index,
+		found.KeyDesc.KeyLocator.Index)
+	require.True(f.T, expected.KeyDesc.PubKey.IsEqual(found.KeyDesc.PubKey),
+		"client pubkey mismatch")
+	require.NotNil(
+		f.T, found.Tapscript, "tapscript should be reconstructed",
+	)
+}
+
+// AssertIntentStored verifies a boarding intent is correctly persisted with
+// full fidelity, including address details, chain info, and status.
+func (f *BoardingWalletFixture) AssertIntentStored(
+	expectedAddr *wallet.BoardingAddress,
+	expectedAmount btcutil.Amount) *wallet.BoardingIntent {
+
+	f.T.Helper()
+
+	ctx := f.Context()
+	intents, err := f.Store().FetchBoardingIntentsByStatus(
+		ctx, wallet.BoardingStatusConfirmed,
+	)
+	require.NoError(f.T, err)
+
+	var found *wallet.BoardingIntent
+	for i := range intents {
+		if intents[i].Address.Address.String() ==
+			expectedAddr.Address.String() {
+
+			found = &intents[i]
+
+			break
+		}
+	}
+
+	require.NotNil(f.T, found, "intent for address %s not found",
+		expectedAddr.Address.String())
+
+	// Verify address fidelity within intent.
+	require.Equal(f.T, expectedAddr.ExitDelay, found.Address.ExitDelay)
+	require.True(
+		f.T,
+		expectedAddr.OperatorKey.IsEqual(found.Address.OperatorKey),
+	)
+	require.True(
+		f.T,
+		expectedAddr.KeyDesc.PubKey.IsEqual(
+			found.Address.KeyDesc.PubKey,
+		),
+	)
+
+	// Verify all the chain information is correct.
+	require.Equal(f.T, wallet.BoardingStatusConfirmed, found.Status)
+	require.Greater(f.T, found.ChainInfo.ConfHeight, int32(0))
+	require.NotZero(f.T, found.ChainInfo.ConfHash)
+	require.NotEqual(f.T, wire.OutPoint{}, found.Outpoint)
+	require.Equal(f.T, found.Outpoint, found.ChainInfo.OutPoint)
+
+	// Verify amount (with tolerance for fees).
+	require.InDelta(
+		f.T, int64(expectedAmount), int64(found.ChainInfo.Amount),
+		10000,
+	)
+
+	return found
+}
+
+// RegisterNotifierWithBacklog registers a notification receiver with backlog
+// delivery from the specified height.
+func (f *BoardingWalletFixture) RegisterNotifierWithBacklog(
+	notifierID string,
+	fromHeight int32) <-chan wallet.BoardingUtxoConfirmedEvent {
+
+	f.T.Helper()
+
+	notifyCh := make(chan wallet.BoardingUtxoConfirmedEvent, 10)
+	notifyRef := SpawnNotificationReceiver(f.T, f.Harness, notifyCh)
+
+	req := &wallet.RegisterConfirmationNotifierRequest{
+		NotifierID:    notifierID,
+		NotifyActor:   notifyRef,
+		BacklogHeight: fn.Some(fromHeight),
+	}
+
+	future := f.Wallet.Ask(f.Context(), req)
+	result := future.Await(f.Context())
+	require.True(
+		f.T, result.IsOk(), "register notifier failed: %v",
+		result.Err(),
+	)
+
+	f.T.Logf("Registered notifier with backlog from height %d", fromHeight)
+
+	return notifyCh
+}

--- a/systest/log.go
+++ b/systest/log.go
@@ -1,0 +1,8 @@
+//go:build systest
+
+package systest
+
+const (
+	// Subsystem is the log subsystem code for the systest harness.
+	Subsystem = "TEST"
+)

--- a/systest/main_test.go
+++ b/systest/main_test.go
@@ -1,0 +1,59 @@
+//go:build systest
+
+package systest
+
+import (
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/lightninglabs/darepo-client/harness"
+)
+
+var (
+	// sharedHarness is the shared Docker harness for all systests.
+	sharedHarness *harness.Harness
+
+	// harnessOnce ensures the harness is only started once.
+	harnessOnce sync.Once
+
+	// harnessStarted tracks whether the harness was ever started.
+	harnessStarted bool
+)
+
+// TestMain is the entry point for the systest suite. It manages the shared
+// harness lifecycle - the harness is started lazily on the first test that
+// needs it, and stopped after all tests complete.
+func TestMain(m *testing.M) {
+	// Run all tests.
+	code := m.Run()
+
+	// Stop the harness after all tests complete (if it was started).
+	if harnessStarted && sharedHarness != nil {
+		sharedHarness.Stop()
+	}
+
+	os.Exit(code)
+}
+
+// GetSharedHarness returns the shared harness, starting it lazily on first
+// call. The harness is started using the first test's T for logging but
+// cleanup is handled by TestMain, not t.Cleanup.
+func GetSharedHarness(t *testing.T) *harness.Harness {
+	t.Helper()
+
+	harnessOnce.Do(func() {
+		opts := harness.DefaultOptions()
+		opts.StartTapd = false // Don't need tapd for boarding tests.
+		opts.GroupName = "systest"
+
+		sharedHarness = harness.NewHarness(t, &opts)
+		sharedHarness.Start()
+		harnessStarted = true
+
+		// NOTE: We intentionally do NOT register t.Cleanup here
+		// since TestMain handles harness cleanup after all tests.
+	})
+
+	return sharedHarness
+}

--- a/systest/main_test.go
+++ b/systest/main_test.go
@@ -3,57 +3,44 @@
 package systest
 
 import (
+	"flag"
 	"os"
-	"sync"
 	"testing"
-
-	"github.com/lightninglabs/darepo-client/harness"
 )
 
 var (
-	// sharedHarness is the shared Docker harness for all systests.
-	sharedHarness *harness.Harness
+	// testParallelism controls how many systest tests can run in parallel.
+	// Each systest spawns its own Docker harness (bitcoind, lnd, etc.)
+	// which can be resource-intensive.
+	testParallelism = flag.Int(
+		"test.parallelism", 4,
+		"maximum number of systest tests to run in parallel",
+	)
 
-	// harnessOnce ensures the harness is only started once.
-	harnessOnce sync.Once
-
-	// harnessStarted tracks whether the harness was ever started.
-	harnessStarted bool
+	// testParallelismSem is a semaphore channel to limit parallel test
+	// execution based on testParallelism flag.
+	testParallelismSem chan struct{}
 )
 
-// TestMain is the entry point for the systest suite. It manages the shared
-// harness lifecycle - the harness is started lazily on the first test that
-// needs it, and stopped after all tests complete.
-func TestMain(m *testing.M) {
-	// Run all tests.
-	code := m.Run()
-
-	// Stop the harness after all tests complete (if it was started).
-	if harnessStarted && sharedHarness != nil {
-		sharedHarness.Stop()
-	}
-
-	os.Exit(code)
-}
-
-// GetSharedHarness returns the shared harness, starting it lazily on first
-// call. The harness is started using the first test's T for logging but
-// cleanup is handled by TestMain, not t.Cleanup.
-func GetSharedHarness(t *testing.T) *harness.Harness {
+// ParallelN acquires a slot from the parallelism semaphore and marks the test
+// as parallel. This allows controlling how many resource-intensive systest
+// tests run concurrently via the -test.parallelism flag.
+func ParallelN(t *testing.T) {
 	t.Helper()
 
-	harnessOnce.Do(func() {
-		opts := harness.DefaultOptions()
-		opts.StartTapd = false // Don't need tapd for boarding tests.
-		opts.GroupName = "systest"
+	t.Parallel()
 
-		sharedHarness = harness.NewHarness(t, &opts)
-		sharedHarness.Start()
-		harnessStarted = true
-
-		// NOTE: We intentionally do NOT register t.Cleanup here
-		// since TestMain handles harness cleanup after all tests.
+	testParallelismSem <- struct{}{}
+	t.Cleanup(func() {
+		<-testParallelismSem
 	})
+}
 
-	return sharedHarness
+// TestMain is the entry point for the systest suite. It handles flag parsing
+// and initializes the parallelism semaphore.
+func TestMain(m *testing.M) {
+	flag.Parse()
+	testParallelismSem = make(chan struct{}, *testParallelism)
+
+	os.Exit(m.Run())
 }

--- a/systest/systest.go
+++ b/systest/systest.go
@@ -1,0 +1,227 @@
+//go:build systest
+
+// Package systest provides end-to-end system testing infrastructure for the
+// boarding wallet and related actors. Tests use real LND nodes on regtest via
+// Docker, with per-test isolation of actor systems and databases.
+package systest
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/build"
+	"github.com/lightninglabs/darepo-client/chainbackends"
+	"github.com/lightninglabs/darepo-client/chainsource"
+	"github.com/lightninglabs/darepo-client/db"
+	"github.com/lightninglabs/darepo-client/harness"
+	"github.com/lightninglabs/darepo-client/lndbackend"
+	"github.com/lightninglabs/darepo-client/wallet"
+	"github.com/lightningnetwork/lnd/clock"
+	"github.com/stretchr/testify/require"
+)
+
+// SysTestHarness wraps harness.Harness with per-test actor system and database.
+// The underlying Docker infrastructure (bitcoind, lnd) is shared across tests,
+// but each test gets its own isolated ActorSystem and database.
+type SysTestHarness struct {
+	// Harness is the shared Docker harness for all systests.
+	Harness *harness.Harness
+
+	t *testing.T
+
+	//nolint:containedctx
+	ctx         context.Context
+	cancel      context.CancelFunc
+	actorSystem *actor.ActorSystem
+	store       *db.BoardingWalletStore
+	chainParams *chaincfg.Params
+
+	// logHandler is the shared log handler for creating subsystem loggers.
+	logHandler *btclog.DefaultHandler
+
+	// log is the root logger for general logging.
+	log btclog.Logger
+
+	// cleanup holds functions to run on Close.
+	cleanup []func()
+}
+
+// NewSysTestHarness creates a new test harness for a specific test. It uses
+// the shared Docker infrastructure but creates isolated actor system and
+// database resources.
+func NewSysTestHarness(t *testing.T) *SysTestHarness {
+	t.Helper()
+
+	shared := GetSharedHarness(t)
+	baseCtx, cancel := context.WithCancel(t.Context())
+
+	// Create a log handler for creating subsystem-specific loggers.
+	// Each subsystem gets its own logger created via handler.SubSystem()
+	// which produces proper lnd-style log output: [INF] SUBSYS: message.
+	logHandler := btclog.NewDefaultHandler(os.Stdout)
+	logHandler.SetLevel(btclog.LevelInfo)
+
+	// Create a root logger for general test harness logging.
+	rootLog := btclog.NewSLogger(logHandler.SubSystem(Subsystem))
+	rootLog.SetLevel(btclog.LevelInfo)
+
+	// Attach the root logger to the context for downstream use.
+	ctx := build.ContextWithLogger(baseCtx, rootLog)
+
+	// Create per-test actor system.
+	actorSystem := actor.NewActorSystem()
+
+	// Create per-test in-memory SQLite database.
+	sqlDB := db.NewTestDB(t)
+
+	// Create the transaction executor for the boarding store. We use the
+	// sqlDB directly since it implements DatabaseBackend which extends
+	// BatchedQuerier.
+	boardingDB := db.NewTransactionExecutor(
+		sqlDB,
+		func(tx *sql.Tx) db.BoardingStore {
+			return sqlDB.WithTx(tx)
+		},
+		rootLog,
+	)
+
+	// Create the boarding wallet store with the transaction executor.
+	store := db.NewBoardingWalletStore(
+		boardingDB, &chaincfg.RegressionNetParams,
+		clock.NewDefaultClock(),
+	)
+
+	h := &SysTestHarness{
+		Harness:     shared,
+		t:           t,
+		ctx:         ctx,
+		cancel:      cancel,
+		actorSystem: actorSystem,
+		store:       store,
+		chainParams: &chaincfg.RegressionNetParams,
+		logHandler:  logHandler,
+		log:         rootLog,
+	}
+
+	// Register cleanup.
+	t.Cleanup(func() {
+		h.Close()
+	})
+
+	return h
+}
+
+// Context returns the test context.
+func (h *SysTestHarness) Context() context.Context {
+	return h.ctx
+}
+
+// ActorSystem returns the per-test actor system.
+func (h *SysTestHarness) ActorSystem() *actor.ActorSystem {
+	return h.actorSystem
+}
+
+// BoardingStore returns the per-test boarding store.
+func (h *SysTestHarness) BoardingStore() wallet.BoardingStore {
+	return h.store
+}
+
+// ChainParams returns the chain parameters (regtest).
+func (h *SysTestHarness) ChainParams() *chaincfg.Params {
+	return h.chainParams
+}
+
+// Logger returns the test logger.
+func (h *SysTestHarness) Logger() btclog.Logger {
+	return h.log
+}
+
+// SubLogger creates a new logger for the given subsystem. The returned logger
+// formats output as [INF] SUBSYS: message, matching lnd's log format.
+func (h *SysTestHarness) SubLogger(subsystem string) btclog.Logger {
+	log := btclog.NewSLogger(h.logHandler.SubSystem(subsystem))
+	log.SetLevel(btclog.LevelInfo)
+
+	return log
+}
+
+// NewBoardingBackend creates a new BoardingBackend connected to the shared LND.
+func (h *SysTestHarness) NewBoardingBackend() wallet.BoardingBackend {
+	return lndbackend.NewBoardingBackend(h.Harness.LND.WalletKit)
+}
+
+// NewChainBackend creates a new ChainBackend connected to the shared LND.
+// The subsystem logger is passed via config to enable proper logging.
+func (h *SysTestHarness) NewChainBackend() chainsource.ChainBackend {
+	return chainbackends.NewLNDBackendFromLndClient(
+		chainbackends.LNDBackendFromLndClientConfig{
+			LND: h.Harness.LND,
+		}.WithLogger(h.SubLogger(chainbackends.LndClientSubsystem)),
+	)
+}
+
+// NewChainSourceActor creates and spawns a ChainSourceActor using the shared
+// LND connection and per-test actor system.
+func (h *SysTestHarness) NewChainSourceActor() actor.ActorRef[
+	chainsource.ChainSourceMsg, chainsource.ChainSourceResp] {
+
+	backend := h.NewChainBackend()
+	require.NoError(h.t, backend.Start())
+
+	h.cleanup = append(h.cleanup, func() {
+		_ = backend.Stop()
+	})
+
+	// Pass the backend, system, and logger via config. The actor and its
+	// spawned sub-actors will use subsystem-specific loggers.
+	chainSourceActor := chainsource.NewChainSourceActor(
+		chainsource.ChainSourceConfig{
+			Backend: backend,
+			System:  h.actorSystem,
+		}.WithLogger(h.SubLogger(chainsource.Subsystem)),
+	)
+
+	chainSourceRef := actor.RegisterWithSystem(
+		h.actorSystem, "chain-source",
+		actor.NewServiceKey[
+			chainsource.ChainSourceMsg, chainsource.ChainSourceResp,
+		]("chain-source"),
+		chainSourceActor,
+	)
+
+	return chainSourceRef
+}
+
+// Close cleans up the per-test resources.
+func (h *SysTestHarness) Close() {
+	// Run cleanup functions in reverse order.
+	for i := len(h.cleanup) - 1; i >= 0; i-- {
+		h.cleanup[i]()
+	}
+
+	h.cancel()
+
+	// Shutdown actor system with timeout.
+	shutdownCtx, cancel := context.WithTimeout(
+		context.Background(), DefaultTimeout,
+	)
+	defer cancel()
+
+	_ = h.actorSystem.Shutdown(shutdownCtx)
+}
+
+// WaitForLNDSync waits for the shared LND to sync to chain after mining.
+func (h *SysTestHarness) WaitForLNDSync() {
+	h.Harness.WaitForLNDChainSync()
+}
+
+const (
+	// DefaultTimeout is the default timeout for various operations.
+	DefaultTimeout = 30 * time.Second
+)

--- a/systest/systest.go
+++ b/systest/systest.go
@@ -27,10 +27,11 @@ import (
 )
 
 // SysTestHarness wraps harness.Harness with per-test actor system and database.
-// The underlying Docker infrastructure (bitcoind, lnd) is shared across tests,
-// but each test gets its own isolated ActorSystem and database.
+// Each test gets its own isolated Docker infrastructure, ActorSystem, and
+// database. Use ParallelN(t) to run tests in parallel with controlled
+// concurrency.
 type SysTestHarness struct {
-	// Harness is the shared Docker harness for all systests.
+	// Harness is the per-test Docker harness.
 	Harness *harness.Harness
 
 	t *testing.T
@@ -52,13 +53,22 @@ type SysTestHarness struct {
 	cleanup []func()
 }
 
-// NewSysTestHarness creates a new test harness for a specific test. It uses
-// the shared Docker infrastructure but creates isolated actor system and
-// database resources.
+// NewSysTestHarness creates a new test harness for a specific test. Each test
+// gets its own Docker infrastructure (bitcoind, lnd), actor system, and
+// database for full isolation. Call ParallelN(t) before this to enable
+// parallel execution with controlled concurrency.
 func NewSysTestHarness(t *testing.T) *SysTestHarness {
 	t.Helper()
 
-	shared := GetSharedHarness(t)
+	// Create per-test Docker harness. We don't need tapd for boarding.
+	opts := harness.DefaultOptions()
+	opts.StartTapd = false
+	opts.GroupName = t.Name()
+
+	dockerHarness := harness.NewHarness(t, &opts)
+	t.Cleanup(dockerHarness.Stop)
+	dockerHarness.Start()
+
 	baseCtx, cancel := context.WithCancel(t.Context())
 
 	// Create a log handler for creating subsystem-specific loggers.
@@ -97,8 +107,8 @@ func NewSysTestHarness(t *testing.T) *SysTestHarness {
 		clock.NewDefaultClock(),
 	)
 
-	h := &SysTestHarness{
-		Harness:     shared,
+	sth := &SysTestHarness{
+		Harness:     dockerHarness,
 		t:           t,
 		ctx:         ctx,
 		cancel:      cancel,
@@ -111,10 +121,10 @@ func NewSysTestHarness(t *testing.T) *SysTestHarness {
 
 	// Register cleanup.
 	t.Cleanup(func() {
-		h.Close()
+		sth.Close()
 	})
 
-	return h
+	return sth
 }
 
 // Context returns the test context.

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -28,6 +28,9 @@ const (
 	// MaxConfsForListUnspent is the maximum confirmations parameter for
 	// ListUnspent queries.
 	MaxConfsForListUnspent = 9999999
+
+	// Subsystem is the log subsystem code for the boarding wallet actor.
+	Subsystem = "ARKW"
 )
 
 // notifierInfo holds the configuration for a registered confirmation notifier.
@@ -73,7 +76,8 @@ type Ark struct {
 	log btclog.Logger
 }
 
-// NewArk creates a new Ark wallet actor.
+// NewArk creates a new Ark wallet actor. The logger should already have the
+// subsystem set (e.g., created via handler.SubSystem(wallet.Subsystem)).
 func NewArk(backend BoardingBackend, store BoardingStore,
 	chainSource actor.ActorRef[chainsource.ChainSourceMsg, chainsource.ChainSourceResp],
 	log btclog.Logger) *Ark {
@@ -353,7 +357,7 @@ func (a *Ark) handleUnregisterNotifier(ctx context.Context,
 func (a *Ark) handleBlockEpoch(ctx context.Context,
 	epoch chainsource.BlockEpoch) fn.Result[WalletResp] {
 
-	a.log.DebugS(ctx, "Processing new block",
+	a.log.InfoS(ctx, "Processing new block epoch",
 		slog.Int("height", int(epoch.Height)))
 
 	// A new block just arrived, we'll now poll ListUnspent for any new
@@ -369,6 +373,10 @@ func (a *Ark) handleBlockEpoch(ctx context.Context,
 		// again on the next block.
 		return fn.Ok[WalletResp](nil)
 	}
+
+	a.log.InfoS(ctx, "ListUnspent returned UTXOs",
+		slog.Int("height", int(epoch.Height)),
+		slog.Int("utxo_count", len(utxos)))
 
 	// For Each UTXO, we'll check if it's new and belongs to a fresh
 	// boarding intent, dispatching notifications if needed.

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -72,6 +72,15 @@ type Ark struct {
 	// wg tracks background goroutines spawned by the wallet actor.
 	wg sync.WaitGroup
 
+	// ctx is the wallet's internal context, cancelled on shutdown. Used for
+	// background goroutines that should respect wallet lifecycle.
+	//
+	//nolint:containedctx
+	ctx context.Context
+
+	// cancel cancels the internal context on shutdown.
+	cancel context.CancelFunc
+
 	// log is the logger for this actor.
 	log btclog.Logger
 }
@@ -97,6 +106,10 @@ func NewArk(backend BoardingBackend, store BoardingStore,
 // notifications from the chainsource actor.
 func (a *Ark) Start(ctx context.Context,
 	selfRef actor.TellOnlyRef[WalletMsg]) error {
+
+	// Create an internal context for background goroutines that outlive
+	// request contexts but should respect wallet shutdown.
+	a.ctx, a.cancel = context.WithCancel(context.Background())
 
 	// Load existing addresses from database to populate seenUtxos for
 	// restart recovery.
@@ -154,6 +167,11 @@ func (a *Ark) Start(ctx context.Context,
 // notifications and waiting for any in-flight backlog deliveries to complete.
 func (a *Ark) Stop(ctx context.Context) {
 	a.log.InfoS(ctx, "Stopping boarding wallet actor")
+
+	// Cancel the internal context to signal background goroutines to stop.
+	if a.cancel != nil {
+		a.cancel()
+	}
 
 	a.chainSource.Tell(ctx, &chainsource.UnsubscribeBlocksRequest{
 		CallerID: "boarding-wallet",
@@ -320,10 +338,12 @@ func (a *Ark) handleRegisterNotifier(ctx context.Context,
 	)
 
 	// If a backlog is needed, send it asynchronously so we don't block
-	// the registration response.
+	// the registration response. We use the wallet's internal context since
+	// the request context will be cancelled after Ask returns, but we still
+	// want the backlog goroutine to respect wallet shutdown.
 	req.BacklogHeight.WhenSome(func(height int32) {
 		a.wg.Go(func() {
-			a.sendBacklog(ctx, req.NotifyActor, height)
+			a.sendBacklog(a.ctx, req.NotifyActor, height)
 		})
 	})
 


### PR DESCRIPTION
In this PR, we add a new `systest` framework built on top of the existing harness. It wraps the harness with an active actor system, and some other useful utilities. 

Along the way we fix some subtle bugs related to cotnexts (deciding when to make a new one vs pass on the parent context). 

We also revamp the way logging is set up for the actors, going back to the old style of relying primarily on a logger passed in as config. We then supplement that as needed with a logger passed in via a context. 

Finally we update CI to run the new systests using both postgres and sqlite.