### PR TITLE
tx: add forfeit transaction structure validation

### DIFF
--- a/lib/tx/forfeit.go
+++ b/lib/tx/forfeit.go
@@ -1,6 +1,7 @@
 package tx
 
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/btcsuite/btcd/btcutil"
@@ -19,6 +20,14 @@ const (
 
 	// ForfeitConnectorInputIndex is the index of the connector input.
 	ForfeitConnectorInputIndex = 1
+
+	// ForfeitPenaltyOutputIndex is the index of the penalty output that
+	// pays to the server's forfeit address.
+	ForfeitPenaltyOutputIndex = 0
+
+	// ForfeitAnchorOutputIndex is the index of the ephemeral anchor output
+	// for fee bumping via CPFP.
+	ForfeitAnchorOutputIndex = 1
 )
 
 // VTXOSpendContext describes the VTXO being spent.
@@ -139,4 +148,102 @@ func NewVTXOCollabSignDescriptor(vtxo *VTXOSpendContext,
 	}
 
 	return signDesc, spendInfo, nil
+}
+
+// ForfeitTxParams contains the expected parameters for validating a forfeit
+// transaction structure. This is used to verify that a forfeit tx built by a
+// VTXO actor matches the expected structure before submitting to the server.
+type ForfeitTxParams struct {
+	// VTXOOutpoint is the expected VTXO input outpoint.
+	VTXOOutpoint wire.OutPoint
+
+	// ConnectorOutpoint is the expected connector input outpoint.
+	ConnectorOutpoint wire.OutPoint
+
+	// ServerForfeitScript is the expected penalty output script.
+	ServerForfeitScript []byte
+
+	// ExpectedAmount is the expected value of the penalty output. If zero,
+	// the amount check is skipped (useful when the caller doesn't know the
+	// exact amount but wants to validate structure).
+	ExpectedAmount btcutil.Amount
+}
+
+// ValidateForfeitTx verifies that the forfeit transaction has the expected
+// structure before signing. This validation is critical because once a VTXO
+// actor signs a forfeit tx, they authorize the operator to claim their funds
+// if they attempt to exit unilaterally. By validating the structure, we ensure
+// the operator cannot construct a malformed transaction that violates the
+// protocol rules.
+//
+// The function checks:
+//   - Exactly 2 inputs: VTXO at index 0, connector at index 1
+//   - Exactly 2 outputs: penalty at index 0, P2A anchor at index 1
+//   - Inputs match expected outpoints
+//   - Penalty output pays to server's forfeit script
+//   - Anchor output is standard P2A with zero value
+func ValidateForfeitTx(forfeitTx *wire.MsgTx, params ForfeitTxParams) error {
+	if forfeitTx == nil {
+		return fmt.Errorf("forfeit tx is nil")
+	}
+
+	// Forfeit tx must have exactly 2 inputs.
+	if len(forfeitTx.TxIn) != 2 {
+		return fmt.Errorf("forfeit tx has %d inputs, expected 2",
+			len(forfeitTx.TxIn))
+	}
+
+	// Verify input 0 is the VTXO.
+	vtxoIn := forfeitTx.TxIn[ForfeitVTXOInputIndex]
+	if vtxoIn.PreviousOutPoint != params.VTXOOutpoint {
+		return fmt.Errorf("forfeit tx input %d is %s, expected VTXO %s",
+			ForfeitVTXOInputIndex, vtxoIn.PreviousOutPoint,
+			params.VTXOOutpoint)
+	}
+
+	// Verify input 1 is the connector.
+	connectorIn := forfeitTx.TxIn[ForfeitConnectorInputIndex]
+	if connectorIn.PreviousOutPoint != params.ConnectorOutpoint {
+		return fmt.Errorf(
+			"forfeit tx input %d is %s, expected connector %s",
+			ForfeitConnectorInputIndex,
+			connectorIn.PreviousOutPoint,
+			params.ConnectorOutpoint,
+		)
+	}
+
+	// Forfeit tx must have exactly 2 outputs (penalty + anchor).
+	if len(forfeitTx.TxOut) != 2 {
+		return fmt.Errorf("forfeit tx has %d outputs, expected 2",
+			len(forfeitTx.TxOut))
+	}
+
+	// Verify penalty output pays to server's forfeit address.
+	penaltyOut := forfeitTx.TxOut[ForfeitPenaltyOutputIndex]
+	if !bytes.Equal(penaltyOut.PkScript, params.ServerForfeitScript) {
+		return fmt.Errorf("forfeit tx output %d does not pay to "+
+			"server forfeit script", ForfeitPenaltyOutputIndex)
+	}
+
+	// Optionally verify the penalty output amount.
+	if params.ExpectedAmount > 0 {
+		if btcutil.Amount(penaltyOut.Value) != params.ExpectedAmount {
+			return fmt.Errorf("forfeit tx penalty output has "+
+				"amount %d, expected %d",
+				penaltyOut.Value, params.ExpectedAmount)
+		}
+	}
+
+	// Verify anchor output is a standard P2A with zero value.
+	anchorOut := forfeitTx.TxOut[ForfeitAnchorOutputIndex]
+	if !bytes.Equal(anchorOut.PkScript, scripts.AnchorPkScript) {
+		return fmt.Errorf("forfeit tx output %d is not a P2A anchor",
+			ForfeitAnchorOutputIndex)
+	}
+	if anchorOut.Value != 0 {
+		return fmt.Errorf("forfeit tx anchor output has non-zero "+
+			"value: %d", anchorOut.Value)
+	}
+
+	return nil
 }

--- a/lib/tx/forfeit_test.go
+++ b/lib/tx/forfeit_test.go
@@ -233,3 +233,320 @@ func nonAnchorOutput(t *testing.T, node *tree.Node) *wire.TxOut {
 
 	return nil
 }
+
+// TestValidateForfeitTx tests the ValidateForfeitTx function with various
+// valid and invalid inputs.
+func TestValidateForfeitTx(t *testing.T) {
+	t.Parallel()
+
+	// Create test fixtures.
+	vtxoOutpoint := wire.OutPoint{
+		Hash:  chainhash.HashH([]byte("vtxo-tx")),
+		Index: 0,
+	}
+	connectorOutpoint := wire.OutPoint{
+		Hash:  chainhash.HashH([]byte("connector-tx")),
+		Index: 1,
+	}
+	serverForfeitScript := []byte{
+		txscript.OP_1, txscript.OP_DATA_32,
+		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+		0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+		0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+		0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20,
+	}
+	vtxoAmount := btcutil.Amount(10000)
+
+	// Build a valid forfeit tx using BuildForfeitTx.
+	validTx, err := tx.BuildForfeitTx(
+		&vtxoOutpoint, vtxoAmount, &connectorOutpoint,
+		serverForfeitScript,
+	)
+	require.NoError(t, err)
+
+	validParams := tx.ForfeitTxParams{
+		VTXOOutpoint:        vtxoOutpoint,
+		ConnectorOutpoint:   connectorOutpoint,
+		ServerForfeitScript: serverForfeitScript,
+	}
+
+	tests := []struct {
+		name        string
+		tx          *wire.MsgTx
+		params      tx.ForfeitTxParams
+		expectError string
+	}{
+		{
+			name:        "valid forfeit tx",
+			tx:          validTx,
+			params:      validParams,
+			expectError: "",
+		},
+		{
+			name:        "nil tx",
+			tx:          nil,
+			params:      validParams,
+			expectError: "forfeit tx is nil",
+		},
+		{
+			name: "wrong number of inputs - too few",
+			tx: func() *wire.MsgTx {
+				tx := wire.NewMsgTx(3)
+				tx.AddTxIn(&wire.TxIn{
+					PreviousOutPoint: vtxoOutpoint,
+				})
+				tx.AddTxOut(&wire.TxOut{
+					Value:    int64(vtxoAmount),
+					PkScript: serverForfeitScript,
+				})
+				tx.AddTxOut(scripts.AnchorOutput())
+
+				return tx
+			}(),
+			params:      validParams,
+			expectError: "has 1 inputs, expected 2",
+		},
+		{
+			name: "wrong number of inputs - too many",
+			tx: func() *wire.MsgTx {
+				tx := wire.NewMsgTx(3)
+				tx.AddTxIn(&wire.TxIn{
+					PreviousOutPoint: vtxoOutpoint,
+				})
+				tx.AddTxIn(&wire.TxIn{
+					PreviousOutPoint: connectorOutpoint,
+				})
+				tx.AddTxIn(&wire.TxIn{
+					PreviousOutPoint: wire.OutPoint{
+						Index: 99,
+					},
+				})
+				tx.AddTxOut(&wire.TxOut{
+					Value:    int64(vtxoAmount),
+					PkScript: serverForfeitScript,
+				})
+				tx.AddTxOut(scripts.AnchorOutput())
+
+				return tx
+			}(),
+			params:      validParams,
+			expectError: "has 3 inputs, expected 2",
+		},
+		{
+			name: "wrong VTXO outpoint",
+			tx:   validTx,
+			params: tx.ForfeitTxParams{
+				VTXOOutpoint: wire.OutPoint{
+					Hash: chainhash.HashH(
+						[]byte("wrong-vtxo"),
+					),
+					Index: 0,
+				},
+				ConnectorOutpoint:   connectorOutpoint,
+				ServerForfeitScript: serverForfeitScript,
+			},
+			expectError: "expected VTXO",
+		},
+		{
+			name: "wrong connector outpoint",
+			tx:   validTx,
+			params: tx.ForfeitTxParams{
+				VTXOOutpoint: vtxoOutpoint,
+				ConnectorOutpoint: wire.OutPoint{
+					Hash: chainhash.HashH(
+						[]byte("wrong-connector"),
+					),
+					Index: 0,
+				},
+				ServerForfeitScript: serverForfeitScript,
+			},
+			expectError: "expected connector",
+		},
+		{
+			name: "wrong number of outputs - too few",
+			tx: func() *wire.MsgTx {
+				tx := wire.NewMsgTx(3)
+				tx.AddTxIn(&wire.TxIn{
+					PreviousOutPoint: vtxoOutpoint,
+				})
+				tx.AddTxIn(&wire.TxIn{
+					PreviousOutPoint: connectorOutpoint,
+				})
+				tx.AddTxOut(&wire.TxOut{
+					Value:    int64(vtxoAmount),
+					PkScript: serverForfeitScript,
+				})
+
+				return tx
+			}(),
+			params:      validParams,
+			expectError: "has 1 outputs, expected 2",
+		},
+		{
+			name: "wrong penalty script",
+			tx: func() *wire.MsgTx {
+				tx := wire.NewMsgTx(3)
+				tx.AddTxIn(&wire.TxIn{
+					PreviousOutPoint: vtxoOutpoint,
+				})
+				tx.AddTxIn(&wire.TxIn{
+					PreviousOutPoint: connectorOutpoint,
+				})
+				tx.AddTxOut(&wire.TxOut{
+					Value: int64(vtxoAmount),
+					PkScript: []byte{
+						0x00, 0x14, 0x01, 0x02,
+					},
+				})
+				tx.AddTxOut(scripts.AnchorOutput())
+
+				return tx
+			}(),
+			params:      validParams,
+			expectError: "does not pay to server forfeit script",
+		},
+		{
+			name: "wrong amount when expected",
+			tx:   validTx,
+			params: tx.ForfeitTxParams{
+				VTXOOutpoint:        vtxoOutpoint,
+				ConnectorOutpoint:   connectorOutpoint,
+				ServerForfeitScript: serverForfeitScript,
+				ExpectedAmount:      btcutil.Amount(99999),
+			},
+			expectError: "penalty output has amount",
+		},
+		{
+			name: "correct amount when expected",
+			tx:   validTx,
+			params: tx.ForfeitTxParams{
+				VTXOOutpoint:        vtxoOutpoint,
+				ConnectorOutpoint:   connectorOutpoint,
+				ServerForfeitScript: serverForfeitScript,
+				ExpectedAmount:      vtxoAmount,
+			},
+			expectError: "",
+		},
+		{
+			name: "non-P2A anchor script",
+			tx: func() *wire.MsgTx {
+				tx := wire.NewMsgTx(3)
+				tx.AddTxIn(&wire.TxIn{
+					PreviousOutPoint: vtxoOutpoint,
+				})
+				tx.AddTxIn(&wire.TxIn{
+					PreviousOutPoint: connectorOutpoint,
+				})
+				tx.AddTxOut(&wire.TxOut{
+					Value:    int64(vtxoAmount),
+					PkScript: serverForfeitScript,
+				})
+				tx.AddTxOut(&wire.TxOut{
+					Value:    0,
+					PkScript: []byte{0x00, 0x14, 0x01},
+				})
+
+				return tx
+			}(),
+			params:      validParams,
+			expectError: "is not a P2A anchor",
+		},
+		{
+			name: "non-zero anchor value",
+			tx: func() *wire.MsgTx {
+				tx := wire.NewMsgTx(3)
+				tx.AddTxIn(&wire.TxIn{
+					PreviousOutPoint: vtxoOutpoint,
+				})
+				tx.AddTxIn(&wire.TxIn{
+					PreviousOutPoint: connectorOutpoint,
+				})
+				tx.AddTxOut(&wire.TxOut{
+					Value:    int64(vtxoAmount),
+					PkScript: serverForfeitScript,
+				})
+				tx.AddTxOut(&wire.TxOut{
+					Value:    1000,
+					PkScript: scripts.AnchorPkScript,
+				})
+
+				return tx
+			}(),
+			params:      validParams,
+			expectError: "anchor output has non-zero value",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tx.ValidateForfeitTx(tc.tx, tc.params)
+
+			if tc.expectError == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectError)
+			}
+		})
+	}
+}
+
+// TestValidateForfeitTxRoundTrip verifies that a forfeit tx built with
+// BuildForfeitTx passes validation.
+func TestValidateForfeitTxRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	// Test with various amounts: dust limit, normal, and larger values.
+	amounts := []btcutil.Amount{
+		btcutil.Amount(546),
+		btcutil.Amount(10000),
+		btcutil.Amount(1000000),
+	}
+
+	for _, amount := range amounts {
+		t.Run(amount.String(), func(t *testing.T) {
+			vtxoOutpoint := wire.OutPoint{
+				Hash:  chainhash.HashH([]byte("vtxo")),
+				Index: 0,
+			}
+			connectorOutpoint := wire.OutPoint{
+				Hash:  chainhash.HashH([]byte("connector")),
+				Index: 0,
+			}
+			serverScript := []byte{
+				txscript.OP_1, txscript.OP_DATA_32,
+				0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+				0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+				0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+				0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20,
+			}
+
+			forfeitTx, err := tx.BuildForfeitTx(
+				&vtxoOutpoint, amount, &connectorOutpoint,
+				serverScript,
+			)
+			require.NoError(t, err)
+
+			// Validate without amount check.
+			err = tx.ValidateForfeitTx(
+				forfeitTx, tx.ForfeitTxParams{
+					VTXOOutpoint:        vtxoOutpoint,
+					ConnectorOutpoint:   connectorOutpoint,
+					ServerForfeitScript: serverScript,
+				},
+			)
+			require.NoError(t, err)
+
+			// Validate with amount check.
+			err = tx.ValidateForfeitTx(
+				forfeitTx, tx.ForfeitTxParams{
+					VTXOOutpoint:        vtxoOutpoint,
+					ConnectorOutpoint:   connectorOutpoint,
+					ServerForfeitScript: serverScript,
+					ExpectedAmount:      amount,
+				},
+			)
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
This PR adds foundational validation logic for forfeit transactions used in the Ark batch swap protocol. The `ValidateForfeitTx` function verifies that a transaction has the correct structure: exactly two inputs (VTXO outpoint at index 0, connector outpoint at index 1) and exactly two outputs (penalty output to operator, ephemeral anchor for fee bumping).

The validation ensures structural correctness before signing, preventing malformed transactions from being processed. It checks that the VTXO and connector outpoints match expected values, the penalty output pays to the operator's script, and the anchor output uses the standard P2A script with zero value.

An optional expected amount can be provided to verify the penalty output value matches. This is useful when the caller knows the exact amount that should be paid (e.g., from protocol parameters). When set to zero, amount validation is skipped.

Comprehensive test coverage includes:
- Valid transaction structure verification  
- Input/output count validation
- Outpoint matching for VTXO and connector
- Penalty script and amount validation
- Anchor output format validation
- Round-trip test with various BTC amounts

This is the first PR in a series implementing VTXO lifecycle management with forfeit flow support.