### PR TITLE
vtxo: implement FSM for VTXO lifecycle management

### DIFF
--- a/lib/actormsg/interfaces.go
+++ b/lib/actormsg/interfaces.go
@@ -1,0 +1,33 @@
+package actormsg
+
+import "github.com/lightninglabs/darepo-client/baselib/actor"
+
+// VTXOActorMsg is the message type for VTXO actors. Messages sent TO VTXO
+// actors implement this interface via the exported marker method. This enables
+// both round and vtxo packages to use consistent types without import cycles.
+type VTXOActorMsg interface {
+	actor.Message
+	VTXOActorMsg()
+}
+
+// VTXOActorResp is the response type marker for VTXO actors. The concrete
+// vtxo.VTXOActorResponse struct implements this interface. Using an interface
+// here allows both packages to use the same service key type parameters.
+type VTXOActorResp interface {
+	VTXOActorResp()
+}
+
+// RoundReceivable marks messages that can be received by the round actor.
+// round.ClientMsg embeds this interface. Both round-internal messages and
+// messages from other actors (vtxo, wallet) implement this marker.
+type RoundReceivable interface {
+	actor.Message
+	RoundReceivable()
+}
+
+// VTXOManagerMsg is the message type for VTXO manager. Messages sent TO the
+// manager implement this interface via the exported marker method.
+type VTXOManagerMsg interface {
+	actor.Message
+	VTXOManagerMsg()
+}

--- a/lib/actormsg/service_keys.go
+++ b/lib/actormsg/service_keys.go
@@ -1,0 +1,24 @@
+package actormsg
+
+import (
+	"fmt"
+
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/baselib/actor"
+)
+
+// VTXOActorServiceKey returns the service key for looking up a VTXO actor by
+// its outpoint. Both round and vtxo packages use this function to ensure
+// consistent service key types for actor registration and lookup.
+//
+// The service key uses VTXOActorMsg for the message type and VTXOActorResp for
+// the response type. This enables proper type checking by the receptionist
+// during actor registration and lookup.
+func VTXOActorServiceKey(outpoint wire.OutPoint) actor.ServiceKey[
+	VTXOActorMsg, VTXOActorResp,
+] {
+
+	return actor.NewServiceKey[VTXOActorMsg, VTXOActorResp](
+		fmt.Sprintf("vtxo.%s", outpoint.String()),
+	)
+}

--- a/round/vtxo_messages.go
+++ b/round/vtxo_messages.go
@@ -1,0 +1,207 @@
+package round
+
+import (
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/lib/actormsg"
+)
+
+// VTXOActorMsg embeds actormsg.VTXOActorMsg for messages exchanged between
+// VTXO actors and the round actor. This includes both messages FROM VTXO
+// actors (refresh requests, forfeit signatures) and messages TO VTXO actors
+// (forfeit requests, confirmations).
+type VTXOActorMsg interface {
+	actormsg.VTXOActorMsg
+}
+
+// VTXOManagerMsg embeds actormsg.VTXOManagerMsg for messages sent to the VTXO
+// manager. The manager receives notifications about VTXO creation and
+// termination.
+type VTXOManagerMsg interface {
+	actormsg.VTXOManagerMsg
+}
+
+// =============================================================================
+// Messages TO VTXO actors FROM round actor / chainsource
+// =============================================================================
+
+// BlockEpochEvent is received when a new block is connected to the blockchain.
+// This triggers expiry monitoring logic to check if the VTXO needs to be
+// refreshed or escalated to the chain resolver.
+type BlockEpochEvent struct {
+	actor.BaseMessage
+
+	// Height is the block height.
+	Height int32
+
+	// Hash is the block hash.
+	Hash chainhash.Hash
+
+	// Timestamp is the block timestamp from the header.
+	Timestamp int64
+}
+
+// VTXOActorMsg implements actormsg.VTXOActorMsg marker interface.
+func (e *BlockEpochEvent) VTXOActorMsg() {}
+
+// MessageType returns the message type for logging.
+func (e *BlockEpochEvent) MessageType() string { return "BlockEpochEvent" }
+
+// ForfeitRequestEvent is received from the round actor when this VTXO is being
+// forfeited as part of a batch swap. The VTXO actor should sign the forfeit
+// transaction and transition to the forfeiting state.
+//
+// The forfeit transaction structure:
+//   - Input 0: VTXO being forfeited (collaborative spend - client + operator)
+//   - Input 1: Connector output from new commitment tx (operator key spend)
+//   - Output 0: Full VTXO value to operator's forfeit address
+//   - Output 1: Anchor output (zero-value P2A for CPFP)
+type ForfeitRequestEvent struct {
+	actor.BaseMessage
+
+	// RoundID is the new round where the refreshed VTXO will be created.
+	RoundID string
+
+	// ConnectorOutpoint is the connector output from the new commitment tx
+	// that the forfeit tx must spend. This links the forfeit atomically to
+	// the new round.
+	ConnectorOutpoint wire.OutPoint
+
+	// ConnectorPkScript is the scriptPubKey of the connector output.
+	ConnectorPkScript []byte
+
+	// ConnectorAmount is the value of the connector output in satoshis.
+	ConnectorAmount int64
+
+	// ServerForfeitPkScript is the operator's taproot script where the
+	// forfeited VTXO value will be paid.
+	ServerForfeitPkScript []byte
+}
+
+// VTXOActorMsg implements actormsg.VTXOActorMsg marker interface.
+func (e *ForfeitRequestEvent) VTXOActorMsg() {}
+
+// MessageType returns the message type for logging.
+func (e *ForfeitRequestEvent) MessageType() string {
+	return "ForfeitRequestEvent"
+}
+
+// RefreshAcknowledgedEvent is received when the round actor acknowledges a
+// refresh request. This indicates the VTXO has been queued for inclusion in
+// the next round but the forfeit request hasn't been sent yet.
+type RefreshAcknowledgedEvent struct {
+	actor.BaseMessage
+
+	// RoundID is the round where the refresh will be processed.
+	RoundID string
+}
+
+// VTXOActorMsg implements actormsg.VTXOActorMsg marker interface.
+func (e *RefreshAcknowledgedEvent) VTXOActorMsg() {}
+
+// MessageType returns the message type for logging.
+func (e *RefreshAcknowledgedEvent) MessageType() string {
+	return "RefreshAcknowledgedEvent"
+}
+
+// ForfeitConfirmedEvent indicates the new commitment transaction has been
+// confirmed on-chain, meaning the forfeit is final. The old VTXO is now
+// permanently forfeited and the new VTXO is live.
+type ForfeitConfirmedEvent struct {
+	actor.BaseMessage
+
+	// CommitmentTxID is the new commitment transaction that was confirmed.
+	CommitmentTxID chainhash.Hash
+
+	// BlockHeight is the height at which confirmation occurred.
+	BlockHeight int32
+}
+
+// VTXOActorMsg implements actormsg.VTXOActorMsg marker interface.
+func (e *ForfeitConfirmedEvent) VTXOActorMsg() {}
+
+// MessageType returns the message type for logging.
+func (e *ForfeitConfirmedEvent) MessageType() string {
+	return "ForfeitConfirmedEvent"
+}
+
+// =============================================================================
+// Internal VTXO actor events (not sent by round actor)
+// =============================================================================
+
+// ForfeitSignedEvent indicates the forfeit transaction has been signed and
+// submitted to the round. This is an internal event triggered after the VTXO
+// actor signs its portion of the forfeit transaction.
+type ForfeitSignedEvent struct {
+	actor.BaseMessage
+
+	// ForfeitTxID is the txid of the forfeit transaction.
+	ForfeitTxID chainhash.Hash
+}
+
+// VTXOActorMsg implements actormsg.VTXOActorMsg marker interface.
+func (e *ForfeitSignedEvent) VTXOActorMsg() {}
+
+// MessageType returns the message type for logging.
+func (e *ForfeitSignedEvent) MessageType() string {
+	return "ForfeitSignedEvent"
+}
+
+// VTXOFailedEvent indicates an error occurred during VTXO processing. This
+// transitions the VTXO to the failed state.
+type VTXOFailedEvent struct {
+	actor.BaseMessage
+
+	// Reason is a human-readable description of the failure.
+	Reason string
+
+	// Error is the underlying error, if any.
+	Error error
+
+	// Recoverable indicates whether the failure might be recoverable.
+	Recoverable bool
+}
+
+// VTXOActorMsg implements actormsg.VTXOActorMsg marker interface.
+func (e *VTXOFailedEvent) VTXOActorMsg() {}
+
+// MessageType returns the message type for logging.
+func (e *VTXOFailedEvent) MessageType() string { return "VTXOFailedEvent" }
+
+// ResumeVTXOEvent is sent when resuming a VTXO actor from persisted state.
+// This is used during startup to restore actors from the database.
+type ResumeVTXOEvent struct {
+	actor.BaseMessage
+}
+
+// VTXOActorMsg implements actormsg.VTXOActorMsg marker interface.
+func (e *ResumeVTXOEvent) VTXOActorMsg() {}
+
+// MessageType returns the message type for logging.
+func (e *ResumeVTXOEvent) MessageType() string { return "ResumeVTXOEvent" }
+
+// =============================================================================
+// Messages TO VTXO Manager
+// =============================================================================
+
+// VTXOTerminatedMsg notifies the manager that a VTXO actor has reached a
+// terminal state and should be removed from tracking.
+type VTXOTerminatedMsg struct {
+	actor.BaseMessage
+
+	// Outpoint identifies the terminated VTXO.
+	Outpoint wire.OutPoint
+
+	// FinalState is the terminal state reached.
+	FinalState string
+
+	// Reason explains why the VTXO terminated.
+	Reason string
+}
+
+// VTXOManagerMsg implements actormsg.VTXOManagerMsg marker interface.
+func (m *VTXOTerminatedMsg) VTXOManagerMsg() {}
+
+// MessageType returns the message type for logging.
+func (m *VTXOTerminatedMsg) MessageType() string { return "VTXOTerminatedMsg" }

--- a/vtxo/events.go
+++ b/vtxo/events.go
@@ -1,0 +1,152 @@
+package vtxo
+
+import (
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/baselib/actor"
+)
+
+// VTXOEvent is a sealed interface for all events that can be processed by the
+// VTXO state machine. The sealed pattern prevents external packages from
+// adding unvalidated event types. Extends actor.Message for actor system
+// compatibility.
+type VTXOEvent interface {
+	actor.Message
+	vtxoEventSealed()
+}
+
+// BlockEpochEvent is received when a new block is connected to the blockchain.
+// This triggers expiry monitoring logic to check if the VTXO needs to be
+// refreshed or escalated to the chain resolver.
+type BlockEpochEvent struct {
+	actor.BaseMessage
+
+	// Height is the block height.
+	Height int32
+
+	// Hash is the block hash.
+	Hash chainhash.Hash
+
+	// Timestamp is the block timestamp from the header.
+	Timestamp int64
+}
+
+func (e *BlockEpochEvent) vtxoEventSealed() {}
+
+// MessageType returns the message type for logging.
+func (e *BlockEpochEvent) MessageType() string { return "BlockEpochEvent" }
+
+// ForfeitRequestEvent is received from the round actor when this VTXO is being
+// forfeited as part of a batch swap. The VTXO actor should sign the forfeit
+// transaction and transition to the forfeiting state.
+//
+// The forfeit transaction structure:
+//   - Input 0: VTXO being forfeited (collaborative spend - client + operator)
+//   - Input 1: Connector output from new commitment tx (operator key spend)
+//   - Output 0: Full VTXO value to operator's forfeit address
+//   - Output 1: Anchor output (zero-value P2A for CPFP)
+type ForfeitRequestEvent struct {
+	actor.BaseMessage
+
+	// RoundID is the new round where the refreshed VTXO will be created.
+	RoundID string
+
+	// ConnectorOutpoint is the connector output from the new commitment tx
+	// that the forfeit tx must spend. This links the forfeit atomically to
+	// the new round.
+	ConnectorOutpoint wire.OutPoint
+
+	// ConnectorPkScript is the scriptPubKey of the connector output.
+	ConnectorPkScript []byte
+
+	// ConnectorAmount is the value of the connector output in satoshis.
+	ConnectorAmount int64
+
+	// ServerForfeitPkScript is the operator's taproot script where the
+	// forfeited VTXO value will be paid.
+	ServerForfeitPkScript []byte
+}
+
+func (e *ForfeitRequestEvent) vtxoEventSealed() {}
+
+// MessageType returns the message type for logging.
+func (e *ForfeitRequestEvent) MessageType() string { return "ForfeitRequestEvent" }
+
+// ForfeitSignedEvent indicates the forfeit transaction has been signed and
+// submitted to the round. This is an internal event triggered after the VTXO
+// actor signs its portion of the forfeit transaction.
+type ForfeitSignedEvent struct {
+	actor.BaseMessage
+
+	// ForfeitTxID is the txid of the forfeit transaction.
+	ForfeitTxID chainhash.Hash
+}
+
+func (e *ForfeitSignedEvent) vtxoEventSealed() {}
+
+// MessageType returns the message type for logging.
+func (e *ForfeitSignedEvent) MessageType() string { return "ForfeitSignedEvent" }
+
+// ForfeitConfirmedEvent indicates the new commitment transaction has been
+// confirmed on-chain, meaning the forfeit is final. The old VTXO is now
+// permanently forfeited and the new VTXO is live.
+type ForfeitConfirmedEvent struct {
+	actor.BaseMessage
+
+	// CommitmentTxID is the new commitment transaction that was confirmed.
+	CommitmentTxID chainhash.Hash
+
+	// BlockHeight is the height at which confirmation occurred.
+	BlockHeight int32
+}
+
+func (e *ForfeitConfirmedEvent) vtxoEventSealed() {}
+
+// MessageType returns the message type for logging.
+func (e *ForfeitConfirmedEvent) MessageType() string { return "ForfeitConfirmedEvent" }
+
+// RefreshAcknowledgedEvent is received when the round actor acknowledges a
+// refresh request. This indicates the VTXO has been queued for inclusion in
+// the next round but the forfeit request hasn't been sent yet.
+type RefreshAcknowledgedEvent struct {
+	actor.BaseMessage
+
+	// RoundID is the round where the refresh will be processed.
+	RoundID string
+}
+
+func (e *RefreshAcknowledgedEvent) vtxoEventSealed() {}
+
+// MessageType returns the message type for logging.
+func (e *RefreshAcknowledgedEvent) MessageType() string { return "RefreshAcknowledgedEvent" }
+
+// VTXOFailedEvent indicates an error occurred during VTXO processing. This
+// transitions the VTXO to the failed state.
+type VTXOFailedEvent struct {
+	actor.BaseMessage
+
+	// Reason is a human-readable description of the failure.
+	Reason string
+
+	// Error is the underlying error, if any.
+	Error error
+
+	// Recoverable indicates whether the failure might be recoverable.
+	Recoverable bool
+}
+
+func (e *VTXOFailedEvent) vtxoEventSealed() {}
+
+// MessageType returns the message type for logging.
+func (e *VTXOFailedEvent) MessageType() string { return "VTXOFailedEvent" }
+
+// ResumeVTXOEvent is sent when resuming a VTXO actor from persisted state.
+// This is used during startup to restore actors from the database.
+type ResumeVTXOEvent struct {
+	actor.BaseMessage
+}
+
+func (e *ResumeVTXOEvent) vtxoEventSealed() {}
+
+// MessageType returns the message type for logging.
+func (e *ResumeVTXOEvent) MessageType() string { return "ResumeVTXOEvent" }

--- a/vtxo/events.go
+++ b/vtxo/events.go
@@ -1,152 +1,43 @@
 package vtxo
 
 import (
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/wire"
-	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/lib/actormsg"
+	"github.com/lightninglabs/darepo-client/round"
 )
 
-// VTXOEvent is a sealed interface for all events that can be processed by the
-// VTXO state machine. The sealed pattern prevents external packages from
-// adding unvalidated event types. Extends actor.Message for actor system
-// compatibility.
+// VTXOEvent embeds actormsg.VTXOActorMsg for all events that can be processed
+// by the VTXO state machine. Message types are defined in the round package
+// and implement the actormsg.VTXOActorMsg marker interface.
 type VTXOEvent interface {
-	actor.Message
-	vtxoEventSealed()
+	actormsg.VTXOActorMsg
 }
 
-// BlockEpochEvent is received when a new block is connected to the blockchain.
-// This triggers expiry monitoring logic to check if the VTXO needs to be
-// refreshed or escalated to the chain resolver.
-type BlockEpochEvent struct {
-	actor.BaseMessage
+// Type aliases for VTXO events. These point to the canonical definitions in
+// the round package, providing ergonomic access without the round. prefix.
+type (
+	// BlockEpochEvent is received when a new block is connected.
+	BlockEpochEvent = round.BlockEpochEvent
 
-	// Height is the block height.
-	Height int32
+	// ForfeitRequestEvent is received from the round actor when this VTXO
+	// is being forfeited as part of a batch swap.
+	ForfeitRequestEvent = round.ForfeitRequestEvent
 
-	// Hash is the block hash.
-	Hash chainhash.Hash
+	// RefreshAcknowledgedEvent is received when the round actor
+	// acknowledges a refresh request.
+	RefreshAcknowledgedEvent = round.RefreshAcknowledgedEvent
 
-	// Timestamp is the block timestamp from the header.
-	Timestamp int64
-}
+	// ForfeitConfirmedEvent indicates the new commitment transaction has
+	// been confirmed on-chain.
+	ForfeitConfirmedEvent = round.ForfeitConfirmedEvent
 
-func (e *BlockEpochEvent) vtxoEventSealed() {}
+	// ForfeitSignedEvent indicates the forfeit transaction has been signed
+	// and submitted to the round.
+	ForfeitSignedEvent = round.ForfeitSignedEvent
 
-// MessageType returns the message type for logging.
-func (e *BlockEpochEvent) MessageType() string { return "BlockEpochEvent" }
+	// VTXOFailedEvent indicates an error occurred during VTXO processing.
+	VTXOFailedEvent = round.VTXOFailedEvent
 
-// ForfeitRequestEvent is received from the round actor when this VTXO is being
-// forfeited as part of a batch swap. The VTXO actor should sign the forfeit
-// transaction and transition to the forfeiting state.
-//
-// The forfeit transaction structure:
-//   - Input 0: VTXO being forfeited (collaborative spend - client + operator)
-//   - Input 1: Connector output from new commitment tx (operator key spend)
-//   - Output 0: Full VTXO value to operator's forfeit address
-//   - Output 1: Anchor output (zero-value P2A for CPFP)
-type ForfeitRequestEvent struct {
-	actor.BaseMessage
-
-	// RoundID is the new round where the refreshed VTXO will be created.
-	RoundID string
-
-	// ConnectorOutpoint is the connector output from the new commitment tx
-	// that the forfeit tx must spend. This links the forfeit atomically to
-	// the new round.
-	ConnectorOutpoint wire.OutPoint
-
-	// ConnectorPkScript is the scriptPubKey of the connector output.
-	ConnectorPkScript []byte
-
-	// ConnectorAmount is the value of the connector output in satoshis.
-	ConnectorAmount int64
-
-	// ServerForfeitPkScript is the operator's taproot script where the
-	// forfeited VTXO value will be paid.
-	ServerForfeitPkScript []byte
-}
-
-func (e *ForfeitRequestEvent) vtxoEventSealed() {}
-
-// MessageType returns the message type for logging.
-func (e *ForfeitRequestEvent) MessageType() string { return "ForfeitRequestEvent" }
-
-// ForfeitSignedEvent indicates the forfeit transaction has been signed and
-// submitted to the round. This is an internal event triggered after the VTXO
-// actor signs its portion of the forfeit transaction.
-type ForfeitSignedEvent struct {
-	actor.BaseMessage
-
-	// ForfeitTxID is the txid of the forfeit transaction.
-	ForfeitTxID chainhash.Hash
-}
-
-func (e *ForfeitSignedEvent) vtxoEventSealed() {}
-
-// MessageType returns the message type for logging.
-func (e *ForfeitSignedEvent) MessageType() string { return "ForfeitSignedEvent" }
-
-// ForfeitConfirmedEvent indicates the new commitment transaction has been
-// confirmed on-chain, meaning the forfeit is final. The old VTXO is now
-// permanently forfeited and the new VTXO is live.
-type ForfeitConfirmedEvent struct {
-	actor.BaseMessage
-
-	// CommitmentTxID is the new commitment transaction that was confirmed.
-	CommitmentTxID chainhash.Hash
-
-	// BlockHeight is the height at which confirmation occurred.
-	BlockHeight int32
-}
-
-func (e *ForfeitConfirmedEvent) vtxoEventSealed() {}
-
-// MessageType returns the message type for logging.
-func (e *ForfeitConfirmedEvent) MessageType() string { return "ForfeitConfirmedEvent" }
-
-// RefreshAcknowledgedEvent is received when the round actor acknowledges a
-// refresh request. This indicates the VTXO has been queued for inclusion in
-// the next round but the forfeit request hasn't been sent yet.
-type RefreshAcknowledgedEvent struct {
-	actor.BaseMessage
-
-	// RoundID is the round where the refresh will be processed.
-	RoundID string
-}
-
-func (e *RefreshAcknowledgedEvent) vtxoEventSealed() {}
-
-// MessageType returns the message type for logging.
-func (e *RefreshAcknowledgedEvent) MessageType() string { return "RefreshAcknowledgedEvent" }
-
-// VTXOFailedEvent indicates an error occurred during VTXO processing. This
-// transitions the VTXO to the failed state.
-type VTXOFailedEvent struct {
-	actor.BaseMessage
-
-	// Reason is a human-readable description of the failure.
-	Reason string
-
-	// Error is the underlying error, if any.
-	Error error
-
-	// Recoverable indicates whether the failure might be recoverable.
-	Recoverable bool
-}
-
-func (e *VTXOFailedEvent) vtxoEventSealed() {}
-
-// MessageType returns the message type for logging.
-func (e *VTXOFailedEvent) MessageType() string { return "VTXOFailedEvent" }
-
-// ResumeVTXOEvent is sent when resuming a VTXO actor from persisted state.
-// This is used during startup to restore actors from the database.
-type ResumeVTXOEvent struct {
-	actor.BaseMessage
-}
-
-func (e *ResumeVTXOEvent) vtxoEventSealed() {}
-
-// MessageType returns the message type for logging.
-func (e *ResumeVTXOEvent) MessageType() string { return "ResumeVTXOEvent" }
+	// ResumeVTXOEvent is sent when resuming a VTXO actor from persisted
+	// state.
+	ResumeVTXOEvent = round.ResumeVTXOEvent
+)

--- a/vtxo/expiry.go
+++ b/vtxo/expiry.go
@@ -1,0 +1,184 @@
+package vtxo
+
+// ExpiryStatus represents the result of an expiry check.
+type ExpiryStatus int
+
+const (
+	// ExpiryStatusSafe indicates the VTXO has plenty of time remaining.
+	ExpiryStatusSafe ExpiryStatus = iota
+
+	// ExpiryStatusNeedsRefresh indicates the VTXO should request refresh.
+	ExpiryStatusNeedsRefresh
+
+	// ExpiryStatusCritical indicates the VTXO must be sent to chain
+	// resolver.
+	ExpiryStatusCritical
+
+	// ExpiryStatusExpired indicates the batch has already expired.
+	ExpiryStatusExpired
+)
+
+// String returns a human-readable representation of the expiry status.
+func (s ExpiryStatus) String() string {
+	switch s {
+	case ExpiryStatusSafe:
+		return "safe"
+	case ExpiryStatusNeedsRefresh:
+		return "needs_refresh"
+	case ExpiryStatusCritical:
+		return "critical"
+	case ExpiryStatusExpired:
+		return "expired"
+	default:
+		return "unknown"
+	}
+}
+
+// ExpiryConfig holds configurable thresholds for VTXO expiry monitoring. These
+// thresholds determine when refresh requests are sent and when VTXOs are
+// escalated to the chain resolver.
+//
+// The dynamic calculation accounts for tree depth (each level requires an
+// additional on-chain transaction for unilateral exit) and CSV delays.
+type ExpiryConfig struct {
+	// RefreshThresholdBlocks is the base number of blocks before batch
+	// expiry at which a refresh request should be sent. The actual
+	// threshold is adjusted based on tree depth.
+	RefreshThresholdBlocks int32
+
+	// CriticalThresholdBlocks is the base number of blocks before batch
+	// expiry at which the VTXO is escalated to the chain resolver for
+	// unilateral exit. Must be less than RefreshThresholdBlocks.
+	CriticalThresholdBlocks int32
+
+	// MinRefreshBuffer is the minimum buffer (blocks) between refresh and
+	// critical thresholds, regardless of other calculations.
+	MinRefreshBuffer int32
+
+	// TreeDepthMultiplier is multiplied by tree depth to calculate the
+	// additional blocks needed for safe unilateral exit. Each tree level
+	// requires broadcasting and confirming an additional transaction.
+	TreeDepthMultiplier int32
+}
+
+// DefaultExpiryConfig returns sensible defaults for expiry configuration.
+// These values provide approximately 1 day of warning for refresh and 6 hours
+// of buffer before critical escalation on mainnet block times.
+func DefaultExpiryConfig() *ExpiryConfig {
+	return &ExpiryConfig{
+		// ~1 day before batch expiry.
+		RefreshThresholdBlocks: 144,
+
+		// ~6 hours before batch expiry.
+		CriticalThresholdBlocks: 36,
+
+		// At least ~12 hours buffer.
+		MinRefreshBuffer: 72,
+
+		// ~1 hour per tree level.
+		TreeDepthMultiplier: 6,
+	}
+}
+
+// CheckExpiry evaluates a VTXO's expiry status given the current block height.
+// It considers both the batch expiry and the tree depth (which affects
+// unilateral exit time).
+//
+// The calculation ensures that:
+//  1. Critical threshold always allows enough time for unilateral exit
+//     (tree depth * multiplier + CSV delay).
+//  2. Refresh threshold is always at least MinRefreshBuffer blocks before
+//     critical.
+func (c *ExpiryConfig) CheckExpiry(
+	vtxo *Descriptor, currentHeight int32,
+) ExpiryStatus {
+
+	blocksRemaining := vtxo.BatchExpiry - currentHeight
+
+	// If batch has already expired, status is expired.
+	if blocksRemaining <= 0 {
+		return ExpiryStatusExpired
+	}
+
+	// Calculate dynamic threshold based on tree depth. Deeper trees need
+	// more time for unilateral exit since each level requires broadcasting
+	// a transaction and waiting for confirmation.
+	treeDepthBuffer := int32(vtxo.TreeDepth) * c.TreeDepthMultiplier
+
+	// Add CSV delay - after the VTXO appears on-chain, we need to wait
+	// for the relative timelock before we can spend via the unilateral
+	// path.
+	csvBuffer := int32(vtxo.RelativeExpiry)
+
+	// Total buffer needed for safe unilateral exit.
+	safeExitBuffer := treeDepthBuffer + csvBuffer
+
+	// Critical threshold: must have enough time for unilateral exit.
+	criticalThreshold := max(c.CriticalThresholdBlocks, safeExitBuffer)
+
+	if blocksRemaining <= criticalThreshold {
+		return ExpiryStatusCritical
+	}
+
+	// Refresh threshold: should refresh well before critical.
+	refreshThreshold := max(
+		c.RefreshThresholdBlocks,
+		criticalThreshold+c.MinRefreshBuffer,
+	)
+
+	if blocksRemaining <= refreshThreshold {
+		return ExpiryStatusNeedsRefresh
+	}
+
+	return ExpiryStatusSafe
+}
+
+// BlocksUntilExpiry returns the number of blocks until batch expiry.
+func BlocksUntilExpiry(vtxo *Descriptor, currentHeight int32) int32 {
+	return vtxo.BatchExpiry - currentHeight
+}
+
+// DetermineRefreshUrgency maps blocks remaining to urgency level using dynamic
+// thresholds based on the VTXO's tree depth and CSV delay. This ensures that
+// VTXOs with deeper trees or larger CSV delays are correctly prioritized since
+// they require more time for unilateral exit.
+func (c *ExpiryConfig) DetermineRefreshUrgency(
+	vtxo *Descriptor, blocksRemaining int32,
+) RefreshUrgency {
+
+	criticalThreshold := c.CalculateCriticalThreshold(vtxo)
+	if blocksRemaining <= criticalThreshold {
+		// This case should ideally not be hit if called after
+		// CheckExpiry, but is kept for robustness.
+		return RefreshUrgencyCritical
+	}
+
+	refreshThreshold := c.CalculateRefreshThreshold(vtxo)
+
+	// Elevated if less than half the dynamic refresh threshold remaining.
+	if blocksRemaining <= refreshThreshold/2 {
+		return RefreshUrgencyElevated
+	}
+
+	return RefreshUrgencyNormal
+}
+
+// CalculateCriticalThreshold returns the dynamic critical threshold for a VTXO
+// based on its tree depth and CSV delay.
+func (c *ExpiryConfig) CalculateCriticalThreshold(vtxo *Descriptor) int32 {
+	treeDepthBuffer := int32(vtxo.TreeDepth) * c.TreeDepthMultiplier
+	csvBuffer := int32(vtxo.RelativeExpiry)
+	safeExitBuffer := treeDepthBuffer + csvBuffer
+
+	return max(c.CriticalThresholdBlocks, safeExitBuffer)
+}
+
+// CalculateRefreshThreshold returns the dynamic refresh threshold for a VTXO.
+func (c *ExpiryConfig) CalculateRefreshThreshold(vtxo *Descriptor) int32 {
+	criticalThreshold := c.CalculateCriticalThreshold(vtxo)
+
+	return max(
+		c.RefreshThresholdBlocks,
+		criticalThreshold+c.MinRefreshBuffer,
+	)
+}

--- a/vtxo/fsm_environment.go
+++ b/vtxo/fsm_environment.go
@@ -1,0 +1,46 @@
+package vtxo
+
+import (
+	"github.com/btcsuite/btcd/chaincfg"
+)
+
+// VTXOEnvironment provides the VTXO state machine with access to external
+// systems and storage. This follows the protofsm pattern where the environment
+// contains all dependencies needed for state transitions.
+type VTXOEnvironment struct {
+	// name identifies this FSM instance (typically the VTXO outpoint
+	// string).
+	name string
+
+	// VTXOStore provides persistence for VTXO state.
+	VTXOStore VTXOStore
+
+	// Wallet provides signing capabilities for forfeit transactions.
+	Wallet VTXOWallet
+
+	// ExpiryConfig contains thresholds for expiry monitoring.
+	ExpiryConfig *ExpiryConfig
+
+	// ChainParams are the Bitcoin network parameters.
+	ChainParams *chaincfg.Params
+}
+
+// Name returns the unique identifier for this FSM instance.
+func (e *VTXOEnvironment) Name() string {
+	return e.name
+}
+
+// NewVTXOEnvironment creates a new VTXO environment with the provided
+// dependencies.
+func NewVTXOEnvironment(name string, vtxoStore VTXOStore, wallet VTXOWallet,
+	expiryConfig *ExpiryConfig,
+	chainParams *chaincfg.Params) *VTXOEnvironment {
+
+	return &VTXOEnvironment{
+		name:         name,
+		VTXOStore:    vtxoStore,
+		Wallet:       wallet,
+		ExpiryConfig: expiryConfig,
+		ChainParams:  chainParams,
+	}
+}

--- a/vtxo/harness_test.go
+++ b/vtxo/harness_test.go
@@ -1,0 +1,677 @@
+package vtxo
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/scripts"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// MockVTXOStore implements VTXOStore using mock.Mock for testing.
+type MockVTXOStore struct {
+	mock.Mock
+}
+
+func (m *MockVTXOStore) SaveVTXO(ctx context.Context, vtxo *Descriptor) error {
+	args := m.Called(ctx, vtxo)
+	return args.Error(0)
+}
+
+//nolint:forcetypeassert
+func (m *MockVTXOStore) GetVTXO(ctx context.Context,
+	outpoint wire.OutPoint) (*Descriptor, error) {
+
+	args := m.Called(ctx, outpoint)
+	var vtxo *Descriptor
+	if args.Get(0) != nil {
+		vtxo = args.Get(0).(*Descriptor)
+	}
+
+	return vtxo, args.Error(1)
+}
+
+//nolint:forcetypeassert
+func (m *MockVTXOStore) ListLiveVTXOs(ctx context.Context) (
+	[]*Descriptor, error) {
+
+	args := m.Called(ctx)
+	var vtxos []*Descriptor
+	if args.Get(0) != nil {
+		vtxos = args.Get(0).([]*Descriptor)
+	}
+
+	return vtxos, args.Error(1)
+}
+
+func (m *MockVTXOStore) UpdateVTXOStatus(ctx context.Context,
+	outpoint wire.OutPoint, status VTXOStatus) error {
+
+	args := m.Called(ctx, outpoint, status)
+	return args.Error(0)
+}
+
+func (m *MockVTXOStore) MarkForfeited(ctx context.Context,
+	outpoint wire.OutPoint, forfeitTxID chainhash.Hash) error {
+
+	args := m.Called(ctx, outpoint, forfeitTxID)
+	return args.Error(0)
+}
+
+func (m *MockVTXOStore) DeleteVTXO(ctx context.Context,
+	outpoint wire.OutPoint) error {
+
+	args := m.Called(ctx, outpoint)
+	return args.Error(0)
+}
+
+func (m *MockVTXOStore) MarkForfeiting(ctx context.Context,
+	outpoint wire.OutPoint, roundID string, forfeitTx *wire.MsgTx) error {
+
+	args := m.Called(ctx, outpoint, roundID, forfeitTx)
+	return args.Error(0)
+}
+
+//nolint:forcetypeassert
+func (m *MockVTXOStore) GetForfeitTx(ctx context.Context,
+	outpoint wire.OutPoint) (*wire.MsgTx, error) {
+
+	args := m.Called(ctx, outpoint)
+	var tx *wire.MsgTx
+	if args.Get(0) != nil {
+		tx = args.Get(0).(*wire.MsgTx)
+	}
+
+	return tx, args.Error(1)
+}
+
+// Compile-time check that MockVTXOStore implements VTXOStore.
+var _ VTXOStore = (*MockVTXOStore)(nil)
+
+// MockVTXOWallet implements VTXOWallet using mock.Mock for testing. This
+// includes all methods from input.Signer which embeds input.MuSig2Signer.
+type MockVTXOWallet struct {
+	mock.Mock
+}
+
+//nolint:forcetypeassert
+func (m *MockVTXOWallet) SignOutputRaw(tx *wire.MsgTx,
+	signDesc *input.SignDescriptor) (input.Signature, error) {
+
+	args := m.Called(tx, signDesc)
+	var sig input.Signature
+	if args.Get(0) != nil {
+		sig = args.Get(0).(input.Signature)
+	}
+
+	return sig, args.Error(1)
+}
+
+//nolint:forcetypeassert
+func (m *MockVTXOWallet) ComputeInputScript(tx *wire.MsgTx,
+	signDesc *input.SignDescriptor) (*input.Script, error) {
+
+	args := m.Called(tx, signDesc)
+	var script *input.Script
+	if args.Get(0) != nil {
+		script = args.Get(0).(*input.Script)
+	}
+
+	return script, args.Error(1)
+}
+
+//nolint:forcetypeassert
+func (m *MockVTXOWallet) MuSig2CreateSession(
+	version input.MuSig2Version, keyLoc keychain.KeyLocator,
+	signers []*btcec.PublicKey, tweaks *input.MuSig2Tweaks,
+	otherNonces [][musig2.PubNonceSize]byte,
+	localNonces *musig2.Nonces) (*input.MuSig2SessionInfo, error) {
+
+	args := m.Called(
+		version, keyLoc, signers, tweaks, otherNonces, localNonces,
+	)
+	var info *input.MuSig2SessionInfo
+	if args.Get(0) != nil {
+		info = args.Get(0).(*input.MuSig2SessionInfo)
+	}
+
+	return info, args.Error(1)
+}
+
+func (m *MockVTXOWallet) MuSig2RegisterNonces(
+	sessionID input.MuSig2SessionID,
+	nonces [][musig2.PubNonceSize]byte) (bool, error) {
+
+	args := m.Called(sessionID, nonces)
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *MockVTXOWallet) MuSig2RegisterCombinedNonce(
+	sessionID input.MuSig2SessionID,
+	nonce [musig2.PubNonceSize]byte) error {
+
+	args := m.Called(sessionID, nonce)
+	return args.Error(0)
+}
+
+//nolint:forcetypeassert
+func (m *MockVTXOWallet) MuSig2GetCombinedNonce(
+	sessionID input.MuSig2SessionID) ([musig2.PubNonceSize]byte, error) {
+
+	args := m.Called(sessionID)
+	var nonce [musig2.PubNonceSize]byte
+	if args.Get(0) != nil {
+		nonce = args.Get(0).([musig2.PubNonceSize]byte)
+	}
+
+	return nonce, args.Error(1)
+}
+
+//nolint:forcetypeassert
+func (m *MockVTXOWallet) MuSig2Sign(
+	sessionID input.MuSig2SessionID, message [sha256.Size]byte,
+	cleanup bool) (*musig2.PartialSignature, error) {
+
+	args := m.Called(sessionID, message, cleanup)
+	var sig *musig2.PartialSignature
+	if args.Get(0) != nil {
+		sig = args.Get(0).(*musig2.PartialSignature)
+	}
+
+	return sig, args.Error(1)
+}
+
+//nolint:forcetypeassert
+func (m *MockVTXOWallet) MuSig2CombineSig(
+	sessionID input.MuSig2SessionID,
+	partials []*musig2.PartialSignature) (*schnorr.Signature, bool, error) {
+
+	args := m.Called(sessionID, partials)
+	var sig *schnorr.Signature
+	if args.Get(0) != nil {
+		sig = args.Get(0).(*schnorr.Signature)
+	}
+
+	return sig, args.Bool(1), args.Error(2)
+}
+
+func (m *MockVTXOWallet) MuSig2Cleanup(sessionID input.MuSig2SessionID) error {
+	args := m.Called(sessionID)
+	return args.Error(0)
+}
+
+// Compile-time check that MockVTXOWallet implements VTXOWallet.
+var _ VTXOWallet = (*MockVTXOWallet)(nil)
+
+// vtxoTestHarness provides common test utilities for VTXO FSM testing.
+//
+//nolint:containedctx
+type vtxoTestHarness struct {
+	t      *testing.T
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	// Mocks for FSM dependencies.
+	store  *MockVTXOStore
+	wallet *MockVTXOWallet
+
+	// Environment for FSM.
+	env *VTXOEnvironment
+
+	// Cryptographic keys.
+	clientPrivKey   *btcec.PrivateKey
+	clientPubKey    *btcec.PublicKey
+	operatorPrivKey *btcec.PrivateKey
+	operatorPubKey  *btcec.PublicKey
+
+	// Runtime state tracking.
+	currentState   VTXOState
+	lastTransition *VTXOStateTransition
+	outboxMessages []VTXOOutMsg
+}
+
+// newVTXOTestHarness creates a new test harness with default configuration.
+func newVTXOTestHarness(t *testing.T) *vtxoTestHarness {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	clientPrivKey, clientPubKey := generateTestKeyPair(t)
+	operatorPrivKey, operatorPubKey := generateTestKeyPair(t)
+
+	store := &MockVTXOStore{}
+	wallet := &MockVTXOWallet{}
+
+	env := NewVTXOEnvironment(
+		"test-vtxo",
+		store,
+		wallet,
+		DefaultExpiryConfig(),
+		&chaincfg.RegressionNetParams,
+	)
+
+	h := &vtxoTestHarness{
+		t:               t,
+		ctx:             ctx,
+		cancel:          cancel,
+		store:           store,
+		wallet:          wallet,
+		env:             env,
+		clientPrivKey:   clientPrivKey,
+		clientPubKey:    clientPubKey,
+		operatorPrivKey: operatorPrivKey,
+		operatorPubKey:  operatorPubKey,
+		outboxMessages:  make([]VTXOOutMsg, 0),
+	}
+
+	t.Cleanup(func() {
+		cancel()
+	})
+
+	return h
+}
+
+// withState sets the current state for the harness.
+func (h *vtxoTestHarness) withState(state VTXOState) *vtxoTestHarness {
+	h.currentState = state
+	return h
+}
+
+// withExpiryConfig sets a custom expiry config for testing.
+func (h *vtxoTestHarness) withExpiryConfig(cfg *ExpiryConfig) *vtxoTestHarness {
+	h.env.ExpiryConfig = cfg
+	return h
+}
+
+// sendEvent sends an event to the current state and captures the transition.
+func (h *vtxoTestHarness) sendEvent(
+	event VTXOEvent) (*VTXOStateTransition, error) {
+
+	h.t.Helper()
+
+	transition, err := h.currentState.ProcessEvent(h.ctx, event, h.env)
+	if err != nil {
+		return nil, err
+	}
+
+	h.lastTransition = transition
+
+	if transition != nil {
+		if nextState, ok := transition.NextState.(VTXOState); ok {
+			h.currentState = nextState
+		}
+
+		transition.NewEvents.WhenSome(func(e VTXOEmittedEvent) {
+			h.outboxMessages = append(
+				h.outboxMessages, e.Outbox...,
+			)
+		})
+	}
+
+	return transition, nil
+}
+
+// newTestOutpoint creates a random test outpoint.
+func (h *vtxoTestHarness) newTestOutpoint() wire.OutPoint {
+	h.t.Helper()
+
+	var hash chainhash.Hash
+	_, err := rand.Read(hash[:])
+	require.NoError(h.t, err)
+
+	return wire.OutPoint{Hash: hash, Index: 0}
+}
+
+// newTestDescriptor creates a VTXO descriptor for testing.
+func (h *vtxoTestHarness) newTestDescriptor() *Descriptor {
+	h.t.Helper()
+
+	outpoint := h.newTestOutpoint()
+
+	tapscript, err := scripts.VTXOTapScript(
+		h.clientPubKey, h.operatorPubKey, testExitDelay,
+	)
+	require.NoError(h.t, err)
+
+	return &Descriptor{
+		Outpoint: outpoint,
+		Amount:   btcutil.Amount(50000),
+		ClientKey: keychain.KeyDescriptor{
+			PubKey: h.clientPubKey,
+			KeyLocator: keychain.KeyLocator{
+				Family: keychain.KeyFamilyMultiSig,
+				Index:  0,
+			},
+		},
+		OperatorKey:    h.operatorPubKey,
+		TapScript:      tapscript,
+		BatchExpiry:    int32(testBatchExpiryBlocks),
+		RelativeExpiry: testExitDelay,
+		TreeDepth:      2,
+		CreatedHeight:  100,
+		Status:         VTXOStatusLive,
+	}
+}
+
+// newBlockEpochEvent creates a BlockEpochEvent at the given height.
+func (h *vtxoTestHarness) newBlockEpochEvent(height int32) *BlockEpochEvent {
+	h.t.Helper()
+
+	var hash chainhash.Hash
+	_, err := rand.Read(hash[:])
+	require.NoError(h.t, err)
+
+	return &BlockEpochEvent{
+		Height: height,
+		Hash:   hash,
+	}
+}
+
+// assertCurrentState asserts the current state is of the expected type.
+func assertState[T VTXOState](h *vtxoTestHarness) T {
+	h.t.Helper()
+
+	state, ok := h.currentState.(T)
+	require.True(h.t, ok, "expected state type %T, got %T",
+		*new(T), h.currentState)
+
+	return state
+}
+
+// assertOutboxContains checks if the outbox contains a message of the given
+// type.
+func assertOutboxContains[T VTXOOutMsg](h *vtxoTestHarness) T {
+	h.t.Helper()
+
+	for _, msg := range h.outboxMessages {
+		if typed, ok := msg.(T); ok {
+			return typed
+		}
+	}
+
+	var zero T
+	h.t.Fatalf("outbox does not contain message of type %T", zero)
+
+	return zero
+}
+
+// setupMockWalletForSigning configures the wallet mock to return valid
+// signatures for forfeit tx signing.
+func (h *vtxoTestHarness) setupMockWalletForSigning() {
+	h.t.Helper()
+
+	// Generate a real signature using the client's private key.
+	msgHash := sha256.Sum256([]byte("test-forfeit-sig"))
+	sig, err := schnorr.Sign(h.clientPrivKey, msgHash[:])
+	require.NoError(h.t, err)
+
+	h.wallet.On("SignOutputRaw", mock.Anything, mock.Anything).Return(
+		sig, nil,
+	)
+}
+
+func generateTestKeyPair(t *testing.T) (*btcec.PrivateKey, *btcec.PublicKey) {
+	t.Helper()
+
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	return privKey, privKey.PubKey()
+}
+
+const (
+	// testExitDelay is the CSV delay for tests (~1 day in blocks).
+	testExitDelay = uint32(144)
+
+	// testBatchExpiryBlocks is a mock batch expiry at block 1000.
+	testBatchExpiryBlocks = 1000
+)
+
+// realVTXOSigner wraps LND's MockSigner to provide real cryptographic signing
+// for VTXO forfeit transactions. Despite its name, input.MockSigner performs
+// actual Schnorr signing operations using real private keys.
+type realVTXOSigner struct {
+	*input.MockSigner
+}
+
+// newRealVTXOSigner creates a signer that produces real Schnorr signatures
+// using the provided private key.
+func newRealVTXOSigner(privKey *btcec.PrivateKey) *realVTXOSigner {
+	return &realVTXOSigner{
+		MockSigner: input.NewMockSigner(
+			[]*btcec.PrivateKey{privKey}, nil,
+		),
+	}
+}
+
+// Compile-time check that realVTXOSigner implements VTXOWallet.
+var _ VTXOWallet = (*realVTXOSigner)(nil)
+
+// realVTXOSigningHarness extends vtxoTestHarness with real signing capabilities
+// for testing forfeit signature validity. Unlike mock-based testing, signatures
+// produced here are cryptographically valid and can be verified using
+// txscript.NewEngine.
+//
+//nolint:containedctx
+type realVTXOSigningHarness struct {
+	t      *testing.T
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	// Store mock for FSM dependencies.
+	store *MockVTXOStore
+
+	// Real signers for client and operator.
+	clientSigner   *realVTXOSigner
+	operatorSigner *realVTXOSigner
+
+	// Environment for FSM with real client signer.
+	env *VTXOEnvironment
+
+	// Cryptographic keys.
+	clientPrivKey   *btcec.PrivateKey
+	clientPubKey    *btcec.PublicKey
+	operatorPrivKey *btcec.PrivateKey
+	operatorPubKey  *btcec.PublicKey
+
+	// Runtime state tracking.
+	currentState   VTXOState
+	lastTransition *VTXOStateTransition
+	outboxMessages []VTXOOutMsg
+}
+
+// newRealVTXOSigningHarness creates a test harness with real cryptographic
+// signing for forfeit transactions.
+func newRealVTXOSigningHarness(t *testing.T) *realVTXOSigningHarness {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	clientPrivKey, clientPubKey := generateTestKeyPair(t)
+	operatorPrivKey, operatorPubKey := generateTestKeyPair(t)
+
+	store := &MockVTXOStore{}
+
+	clientSigner := newRealVTXOSigner(clientPrivKey)
+	operatorSigner := newRealVTXOSigner(operatorPrivKey)
+
+	env := NewVTXOEnvironment(
+		"test-vtxo-real-signing",
+		store,
+		clientSigner,
+		DefaultExpiryConfig(),
+		&chaincfg.RegressionNetParams,
+	)
+
+	h := &realVTXOSigningHarness{
+		t:               t,
+		ctx:             ctx,
+		cancel:          cancel,
+		store:           store,
+		clientSigner:    clientSigner,
+		operatorSigner:  operatorSigner,
+		env:             env,
+		clientPrivKey:   clientPrivKey,
+		clientPubKey:    clientPubKey,
+		operatorPrivKey: operatorPrivKey,
+		operatorPubKey:  operatorPubKey,
+		outboxMessages:  make([]VTXOOutMsg, 0),
+	}
+
+	t.Cleanup(func() {
+		cancel()
+	})
+
+	return h
+}
+
+// withState sets the current state for the harness.
+func (h *realVTXOSigningHarness) withState(
+	state VTXOState) *realVTXOSigningHarness {
+
+	h.currentState = state
+	return h
+}
+
+// sendEvent sends an event to the current state and captures the transition.
+func (h *realVTXOSigningHarness) sendEvent(
+	event VTXOEvent) (*VTXOStateTransition, error) {
+
+	h.t.Helper()
+
+	transition, err := h.currentState.ProcessEvent(h.ctx, event, h.env)
+	if err != nil {
+		return nil, err
+	}
+
+	h.lastTransition = transition
+
+	if transition != nil {
+		if nextState, ok := transition.NextState.(VTXOState); ok {
+			h.currentState = nextState
+		}
+
+		transition.NewEvents.WhenSome(func(e VTXOEmittedEvent) {
+			h.outboxMessages = append(
+				h.outboxMessages, e.Outbox...,
+			)
+		})
+	}
+
+	return transition, nil
+}
+
+// newTestOutpoint creates a random test outpoint.
+func (h *realVTXOSigningHarness) newTestOutpoint() wire.OutPoint {
+	h.t.Helper()
+
+	var hash chainhash.Hash
+	_, err := rand.Read(hash[:])
+	require.NoError(h.t, err)
+
+	return wire.OutPoint{Hash: hash, Index: 0}
+}
+
+// newTestDescriptor creates a VTXO descriptor for testing with real tapscript.
+func (h *realVTXOSigningHarness) newTestDescriptor() *Descriptor {
+	h.t.Helper()
+
+	outpoint := h.newTestOutpoint()
+
+	tapscript, err := scripts.VTXOTapScript(
+		h.clientPubKey, h.operatorPubKey, testExitDelay,
+	)
+	require.NoError(h.t, err)
+
+	// Compute the P2TR pkScript for the VTXO output.
+	taprootKey, err := tapscript.TaprootKey()
+	require.NoError(h.t, err)
+
+	pkScript, err := txscript.PayToTaprootScript(taprootKey)
+	require.NoError(h.t, err)
+
+	return &Descriptor{
+		Outpoint: outpoint,
+		Amount:   btcutil.Amount(50000),
+		PkScript: pkScript,
+		ClientKey: keychain.KeyDescriptor{
+			PubKey: h.clientPubKey,
+			KeyLocator: keychain.KeyLocator{
+				Family: keychain.KeyFamilyMultiSig,
+				Index:  0,
+			},
+		},
+		OperatorKey:    h.operatorPubKey,
+		TapScript:      tapscript,
+		BatchExpiry:    int32(testBatchExpiryBlocks),
+		RelativeExpiry: testExitDelay,
+		TreeDepth:      2,
+		CreatedHeight:  100,
+		Status:         VTXOStatusLive,
+	}
+}
+
+// newTestConnectorOutput creates a P2TR connector output for forfeit testing.
+func (h *realVTXOSigningHarness) newTestConnectorOutput() *wire.TxOut {
+	h.t.Helper()
+
+	// Connector is a simple P2TR key-path spend controlled by operator.
+	pkScript, err := txscript.PayToTaprootScript(h.operatorPubKey)
+	require.NoError(h.t, err)
+
+	return &wire.TxOut{
+		Value:    546, // Dust limit.
+		PkScript: pkScript,
+	}
+}
+
+// newServerForfeitScript creates a P2TR script for the server's penalty output.
+func (h *realVTXOSigningHarness) newServerForfeitScript() []byte {
+	h.t.Helper()
+
+	pkScript, err := txscript.PayToTaprootScript(h.operatorPubKey)
+	require.NoError(h.t, err)
+
+	return pkScript
+}
+
+// assertStateReal asserts the current state is of the expected type.
+func assertStateReal[T VTXOState](h *realVTXOSigningHarness) T {
+	h.t.Helper()
+
+	state, ok := h.currentState.(T)
+	require.True(h.t, ok, "expected state type %T, got %T",
+		*new(T), h.currentState)
+
+	return state
+}
+
+// assertOutboxContainsReal checks if the outbox contains a message of the
+// given type.
+func assertOutboxContainsReal[T VTXOOutMsg](h *realVTXOSigningHarness) T {
+	h.t.Helper()
+
+	for _, msg := range h.outboxMessages {
+		if typed, ok := msg.(T); ok {
+			return typed
+		}
+	}
+
+	var zero T
+	h.t.Fatalf("outbox does not contain message of type %T", zero)
+
+	return zero
+}

--- a/vtxo/interfaces.go
+++ b/vtxo/interfaces.go
@@ -172,6 +172,19 @@ type VTXOStore interface {
 		ctx context.Context, outpoint wire.OutPoint, status VTXOStatus,
 	) error
 
+	// MarkForfeiting transitions a VTXO to forfeiting state and persists
+	// the signed forfeit transaction for crash recovery. Called when
+	// entering the forfeit flow before the new round's commitment confirms.
+	MarkForfeiting(ctx context.Context, outpoint wire.OutPoint,
+		roundID string, forfeitTx *wire.MsgTx) error
+
+	// GetForfeitTx retrieves the persisted forfeit transaction for a VTXO.
+	// Used during recovery to restore the ForfeitingState with its tx.
+	// Returns nil if no forfeit tx is stored for this outpoint.
+	GetForfeitTx(ctx context.Context, outpoint wire.OutPoint) (
+		*wire.MsgTx, error,
+	)
+
 	// MarkForfeited marks a VTXO as forfeited and records the forfeit
 	// transaction ID. This is called when the new round's commitment
 	// transaction confirms.

--- a/vtxo/interfaces.go
+++ b/vtxo/interfaces.go
@@ -1,0 +1,191 @@
+package vtxo
+
+import (
+	"context"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/lightninglabs/darepo-client/baselib/protofsm"
+	"github.com/lightninglabs/darepo-client/lib/tree"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/keychain"
+)
+
+// VTXOStateTransition is a type alias for the verbose protofsm.StateTransition
+// type used throughout the VTXO FSM. The baselib protofsm uses 3 type
+// parameters: InternalEvent, OutboxEvent, and Env. In our case:
+//   - InternalEvent = VTXOEvent (events that drive the FSM).
+//   - OutboxEvent = VTXOOutMsg (outbox messages emitted by transitions).
+//   - Env = *VTXOEnvironment.
+type VTXOStateTransition = protofsm.StateTransition[
+	VTXOEvent, VTXOOutMsg, *VTXOEnvironment,
+]
+
+// VTXOEmittedEvent is a type alias for the verbose protofsm.EmittedEvent type
+// used when state transitions emit new events or outbox messages.
+type VTXOEmittedEvent = protofsm.EmittedEvent[VTXOEvent, VTXOOutMsg]
+
+// VTXOStateMachine is a type alias for the VTXO FSM.
+type VTXOStateMachine = protofsm.StateMachine[
+	VTXOEvent, VTXOOutMsg, *VTXOEnvironment,
+]
+
+// VTXOStateMachineCfg is a type alias for the VTXO FSM configuration.
+type VTXOStateMachineCfg = protofsm.StateMachineCfg[
+	VTXOEvent, VTXOOutMsg, *VTXOEnvironment,
+]
+
+// VTXOStatus represents the lifecycle state of a VTXO.
+type VTXOStatus int
+
+const (
+	// VTXOStatusLive indicates the VTXO is active and can be spent.
+	VTXOStatusLive VTXOStatus = iota
+
+	// VTXOStatusRefreshRequested indicates a refresh has been requested but
+	// not yet completed via a new round.
+	VTXOStatusRefreshRequested
+
+	// VTXOStatusForfeiting indicates the VTXO is being forfeited in a
+	// round.
+	VTXOStatusForfeiting
+
+	// VTXOStatusForfeited indicates the VTXO has been forfeited
+	// (terminal).
+	VTXOStatusForfeited
+
+	// VTXOStatusSpent indicates the VTXO was spent via an out-of-round
+	// (OOR) transaction (terminal).
+	VTXOStatusSpent
+
+	// VTXOStatusExpiring indicates the VTXO is critically close to expiry
+	// and has been sent to the chain resolver (terminal for this actor).
+	VTXOStatusExpiring
+
+	// VTXOStatusFailed indicates an unrecoverable error (terminal).
+	VTXOStatusFailed
+)
+
+// String returns a human-readable representation of the VTXO status.
+func (s VTXOStatus) String() string {
+	switch s {
+	case VTXOStatusLive:
+		return "live"
+	case VTXOStatusRefreshRequested:
+		return "refresh_requested"
+	case VTXOStatusForfeiting:
+		return "forfeiting"
+	case VTXOStatusForfeited:
+		return "forfeited"
+	case VTXOStatusSpent:
+		return "spent"
+	case VTXOStatusExpiring:
+		return "expiring"
+	case VTXOStatusFailed:
+		return "failed"
+	default:
+		return "unknown"
+	}
+}
+
+// Descriptor contains all information needed to track and spend a VTXO. This
+// is the canonical representation persisted to storage and passed between
+// actors.
+type Descriptor struct {
+	// Outpoint identifies the VTXO's location in the virtual transaction
+	// tree.
+	Outpoint wire.OutPoint
+
+	// Amount is the value of this VTXO in satoshis.
+	Amount btcutil.Amount
+
+	// PkScript is the output script for this VTXO (taproot with
+	// collaborative and timeout spend paths).
+	PkScript []byte
+
+	// ClientKey is the client's key descriptor for this VTXO.
+	ClientKey keychain.KeyDescriptor
+
+	// OperatorKey is the operator's public key for collaborative spends.
+	OperatorKey *btcec.PublicKey
+
+	// TapScript contains the full tapscript structure for this VTXO,
+	// including the internal key and all script paths. This is needed for
+	// signing forfeit transactions via the collaborative spend path.
+	TapScript *waddrmgr.Tapscript
+
+	// TreePath is the extracted path from the commitment transaction output
+	// down to this specific VTXO. Contains only the minimal tree nodes
+	// needed for unilateral exit.
+	TreePath *tree.Tree
+
+	// RoundID identifies which round created this VTXO.
+	RoundID string
+
+	// CommitmentTxID is the txid of the commitment transaction.
+	CommitmentTxID chainhash.Hash
+
+	// BatchExpiry is the absolute block height at which the batch expires
+	// (operator can sweep via the batch-level timelock).
+	BatchExpiry int32
+
+	// RelativeExpiry is the CSV delay for the VTXO's unilateral exit path
+	// (blocks from when VTXO is realized on-chain).
+	RelativeExpiry uint32
+
+	// TreeDepth is the depth of this VTXO in the VTXT (used for expiry
+	// calculation).
+	TreeDepth int
+
+	// CreatedHeight is the block height when this VTXO was created.
+	CreatedHeight int32
+
+	// Status is the current lifecycle status of the VTXO.
+	Status VTXOStatus
+}
+
+// VTXOStore defines the persistence interface for VTXO lifecycle management.
+// The store provides per-VTXO operations since each VTXO has its own actor.
+// The VTXO manager (parent actor) tracks active VTXOs and routes block epochs.
+type VTXOStore interface {
+	// SaveVTXO persists a new VTXO to storage. Called when a VTXO actor is
+	// created. Returns error if a VTXO with the same outpoint already
+	// exists.
+	SaveVTXO(ctx context.Context, vtxo *Descriptor) error
+
+	// GetVTXO retrieves a VTXO by its outpoint. Used for actor recovery on
+	// startup. Returns error if not found.
+	GetVTXO(ctx context.Context, outpoint wire.OutPoint) (
+		*Descriptor, error,
+	)
+
+	// ListLiveVTXOs returns all VTXOs not in a terminal state. Used during
+	// startup to recover active VTXO actors after restart.
+	ListLiveVTXOs(ctx context.Context) ([]*Descriptor, error)
+
+	// UpdateVTXOStatus atomically updates a VTXO's status. This is the
+	// primary method for state transitions.
+	UpdateVTXOStatus(
+		ctx context.Context, outpoint wire.OutPoint, status VTXOStatus,
+	) error
+
+	// MarkForfeited marks a VTXO as forfeited and records the forfeit
+	// transaction ID. This is called when the new round's commitment
+	// transaction confirms.
+	MarkForfeited(
+		ctx context.Context, outpoint wire.OutPoint,
+		forfeitTxID chainhash.Hash,
+	) error
+
+	// DeleteVTXO removes a VTXO from storage. Used for cleanup after
+	// terminal states are reached and the VTXO is no longer needed.
+	DeleteVTXO(ctx context.Context, outpoint wire.OutPoint) error
+}
+
+// VTXOWallet defines the signing interface for VTXO operations.
+type VTXOWallet interface {
+	input.Signer
+}

--- a/vtxo/interfaces.go
+++ b/vtxo/interfaces.go
@@ -10,9 +10,177 @@ import (
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/lightninglabs/darepo-client/baselib/protofsm"
 	"github.com/lightninglabs/darepo-client/lib/tree"
+	"github.com/lightninglabs/darepo-client/round"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
 )
+
+// =============================================================================
+// MESSAGE SPEC
+// =============================================================================
+//
+// This section documents all message types that flow into and out of the VTXO
+// FSM actor. This provides a quick reference similar to a protobuf service
+// definition, showing the complete message surface at a glance.
+//
+// Message flow:
+//
+//	                 ┌──────────┐
+//	 BlockEpochEvent─│          │─RefreshRequest ──▶ Round
+//	                 │          │
+//	 ForfeitRequest ─│ VTXO FSM │─ForfeitSigSubmit ─▶ Round
+//	    (from Round) │          │
+//	                 │          │─ExpiringNotify ───▶ ChainResolver
+//	 ForfeitConfirm ─│          │
+//	    (from Round) │          │─StatusUpdate ─────▶ Persistence
+//	                 │          │
+//	 ResumeVTXOEvent─│          │─TerminatedNotify ─▶ VTXOManager
+//	    (from Mgr)   └──────────┘
+//
+// =============================================================================
+
+// InboundEvent documents an event that flows INTO the FSM from an external
+// source. Used purely for documentation purposes.
+type InboundEvent[E VTXOEvent] struct{}
+
+// OutboundMsg documents a message that flows OUT of the FSM to other actors.
+// Used purely for documentation purposes.
+type OutboundMsg[M VTXOOutMsg] struct{}
+
+// InternalEvent documents an event used within the FSM for internal state
+// transitions. These are typically emitted by one state and consumed by the
+// same or a subsequent state. Used purely for documentation purposes.
+type InternalEvent[E VTXOEvent] struct{}
+
+// MessageSpec documents all message types supported by the VTXO FSM actor.
+// This provides a quick reference showing inbound events (what drives the FSM)
+// and outbound messages (what the FSM emits) at a glance.
+//
+// # Inbound Events
+//
+// Events are received from external actors and drive state transitions:
+//
+//   - BlockEpochEvent: From chain source (via VTXO manager), triggers expiry
+//     checks on each new block.
+//   - ForfeitRequestEvent: From round actor, initiates forfeit signing flow.
+//   - ForfeitConfirmedEvent: From round actor, confirms forfeit completion.
+//   - ResumeVTXOEvent: From VTXO manager, restores state after crash recovery.
+//   - VTXOFailedEvent: From any source, signals unrecoverable failure.
+//
+// # Outbound Messages
+//
+// Messages are emitted via the FSM outbox and routed to target actors:
+//
+//   - RefreshRequest: To round actor, requests VTXO inclusion in next batch.
+//   - ForfeitSignatureSubmission: To round actor, submits signed forfeit tx.
+//   - ExpiringNotification: To chain resolver, escalates critical expiry.
+//   - VTXOStatusUpdate: To persistence layer, updates database state.
+//   - VTXOTerminatedNotification: To VTXO manager, signals actor cleanup.
+//
+// # Internal Events
+//
+//   - ForfeitSignedEvent: Updates ForfeitTxID after signing (currently unused
+//     in production, reserved for round actor acknowledgment flow).
+var MessageSpec = struct {
+	// -----------------------------------------------------------------
+	// INBOUND EVENTS (from external actors → FSM)
+	// -----------------------------------------------------------------
+
+	// BlockEpochEvent is received from the chain source (routed via VTXO
+	// manager) when a new block is connected. Triggers expiry status checks
+	// and may cause state transitions if refresh or critical thresholds are
+	// crossed.
+	//
+	// Source: Chain source → VTXO Manager → VTXO Actor
+	// Handled in: LiveState, RefreshRequestedState, ForfeitingState
+	BlockEpochEvent InboundEvent[*BlockEpochEvent]
+
+	// ForfeitRequestEvent is received from the round actor when this VTXO
+	// has been selected for inclusion in a batch swap. The FSM should sign
+	// the forfeit transaction and submit it back to the round actor.
+	//
+	// Source: Round Actor → VTXO Actor
+	// Handled in: LiveState, RefreshRequestedState
+	ForfeitRequestEvent InboundEvent[*round.ForfeitRequestEvent]
+
+	// ForfeitConfirmedEvent is received from the round actor when the new
+	// commitment transaction has confirmed on-chain. This marks the forfeit
+	// as complete and transitions to terminal ForfeitedState.
+	//
+	// Source: Round Actor → VTXO Actor
+	// Handled in: ForfeitingState
+	ForfeitConfirmedEvent InboundEvent[*round.ForfeitConfirmedEvent]
+
+	// ResumeVTXOEvent is received from the VTXO manager during crash
+	// recovery to restore the FSM to its persisted state.
+	//
+	// Source: VTXO Manager → VTXO Actor
+	// Handled in: All non-terminal states
+	ResumeVTXOEvent InboundEvent[*ResumeVTXOEvent]
+
+	// VTXOFailedEvent signals an unrecoverable error from any source.
+	// Transitions to terminal FailedState.
+	//
+	// Source: Any actor or internal error path
+	// Handled in: All non-terminal states
+	VTXOFailedEvent InboundEvent[*VTXOFailedEvent]
+
+	// -----------------------------------------------------------------
+	// OUTBOUND MESSAGES (FSM → external actors)
+	// -----------------------------------------------------------------
+
+	// RefreshRequest is sent to the round actor when the VTXO's expiry
+	// status crosses the refresh threshold. Requests inclusion in the next
+	// batch swap to extend the VTXO's lifetime.
+	//
+	// Destination: VTXO Actor → Round Actor
+	// Emitted from: LiveState (on ExpiryStatusNeedsRefresh)
+	RefreshRequest OutboundMsg[*RefreshRequest]
+
+	// ForfeitSignatureSubmission is sent to the round actor with the
+	// client's signature on the forfeit transaction. The round actor
+	// combines this with the operator signature and broadcasts.
+	//
+	// Destination: VTXO Actor → Round Actor
+	// Emitted from: LiveState, RefreshRequestedState (on ForfeitRequest)
+	ForfeitSignatureSubmission OutboundMsg[*ForfeitSignatureSubmission]
+
+	// ExpiringNotification is sent to the chain resolver when the VTXO
+	// reaches critical expiry and must begin unilateral exit. This is a
+	// terminal transition for this actor.
+	//
+	// Destination: VTXO Actor → Chain Resolver
+	// Emitted from: LiveState, RefreshRequestedState, ForfeitingState
+	//               (on ExpiryStatusCritical)
+	ExpiringNotification OutboundMsg[*ExpiringNotification]
+
+	// VTXOStatusUpdate is sent to the persistence layer to update the
+	// VTXO's status in the database. Emitted on most state transitions.
+	//
+	// Destination: VTXO Actor → Persistence Layer
+	// Emitted from: All state transitions that change VTXOStatus
+	VTXOStatusUpdate OutboundMsg[*VTXOStatusUpdate]
+
+	// VTXOTerminatedNotification is sent to the VTXO manager when this
+	// actor reaches a terminal state. The manager should clean up the
+	// actor reference.
+	//
+	// Destination: VTXO Actor → VTXO Manager
+	// Emitted from: All terminal state transitions
+	VTXOTerminatedNotification OutboundMsg[*VTXOTerminatedNotification]
+
+	// -----------------------------------------------------------------
+	// INTERNAL EVENTS (within FSM)
+	// -----------------------------------------------------------------
+
+	// ForfeitSignedEvent updates the ForfeitTxID after signing. Currently
+	// reserved for future round actor acknowledgment flow; not emitted in
+	// production code paths.
+	//
+	// Source: Internal (future: Round Actor acknowledgment)
+	// Handled in: ForfeitingState
+	ForfeitSignedEvent InternalEvent[*ForfeitSignedEvent]
+}{}
 
 // VTXOStateTransition is a type alias for the verbose protofsm.StateTransition
 // type used throughout the VTXO FSM. The baselib protofsm uses 3 type

--- a/vtxo/outbox_messages.go
+++ b/vtxo/outbox_messages.go
@@ -1,0 +1,134 @@
+package vtxo
+
+import (
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/baselib/actor"
+)
+
+// VTXOOutMsg is a sealed interface for messages emitted via the FSM outbox.
+// These messages are sent to other actors (round actor, chain resolver) or
+// used for persistence updates.
+type VTXOOutMsg interface {
+	vtxoOutMsgSealed()
+}
+
+// RefreshUrgency indicates how urgent a refresh request is.
+type RefreshUrgency int
+
+const (
+	// RefreshUrgencyNormal indicates the VTXO has plenty of time remaining.
+	RefreshUrgencyNormal RefreshUrgency = iota
+
+	// RefreshUrgencyElevated indicates the VTXO should be refreshed soon.
+	RefreshUrgencyElevated
+
+	// RefreshUrgencyCritical indicates the VTXO must be refreshed
+	// immediately.
+	RefreshUrgencyCritical
+)
+
+// String returns a human-readable representation of the urgency level.
+func (u RefreshUrgency) String() string {
+	switch u {
+	case RefreshUrgencyNormal:
+		return "normal"
+	case RefreshUrgencyElevated:
+		return "elevated"
+	case RefreshUrgencyCritical:
+		return "critical"
+	default:
+		return "unknown"
+	}
+}
+
+// RefreshRequest is sent to the round actor when a VTXO needs to be refreshed.
+// The round actor should queue this VTXO for inclusion in the next batch swap.
+type RefreshRequest struct {
+	actor.BaseMessage
+
+	// VTXOOutpoint identifies the VTXO to refresh.
+	VTXOOutpoint wire.OutPoint
+
+	// Amount is the VTXO value in satoshis.
+	Amount int64
+
+	// Urgency indicates how urgent the refresh is (based on blocks
+	// remaining until expiry).
+	Urgency RefreshUrgency
+}
+
+func (m *RefreshRequest) vtxoOutMsgSealed() {}
+
+// ExpiringNotification is sent to the chain resolver when a VTXO is critically
+// close to expiry and needs unilateral exit handling. The chain resolver
+// should begin the on-chain unrolling process.
+type ExpiringNotification struct {
+	actor.BaseMessage
+
+	// VTXO is the full descriptor of the expiring VTXO.
+	VTXO *Descriptor
+
+	// BlocksRemaining is how many blocks until batch expiry.
+	BlocksRemaining int32
+
+	// Reason explains why the VTXO is being sent to chain resolver.
+	Reason string
+}
+
+func (m ExpiringNotification) vtxoOutMsgSealed() {}
+
+// MessageType returns the message type for logging.
+func (m ExpiringNotification) MessageType() string {
+	return "ExpiringNotification"
+}
+
+// ForfeitSignatureSubmission is sent to the round actor with the forfeit
+// transaction signature.
+type ForfeitSignatureSubmission struct {
+	actor.BaseMessage
+
+	// VTXOOutpoint identifies the VTXO being forfeited.
+	VTXOOutpoint wire.OutPoint
+
+	// RoundID is the round where the forfeit is being processed.
+	RoundID string
+
+	// ForfeitTx is the signed forfeit transaction.
+	ForfeitTx *wire.MsgTx
+
+	// Signature is the client's signature for the forfeit tx.
+	Signature []byte
+}
+
+func (m *ForfeitSignatureSubmission) vtxoOutMsgSealed() {}
+
+// VTXOStatusUpdate is a persistence request to update VTXO status. This is
+// emitted on state transitions to keep the database in sync.
+type VTXOStatusUpdate struct {
+	actor.BaseMessage
+
+	// Outpoint identifies the VTXO.
+	Outpoint wire.OutPoint
+
+	// NewStatus is the new status to set.
+	NewStatus VTXOStatus
+}
+
+func (m *VTXOStatusUpdate) vtxoOutMsgSealed() {}
+
+// VTXOTerminatedNotification notifies the VTXO manager that this VTXO actor
+// has reached a terminal state and can be cleaned up.
+type VTXOTerminatedNotification struct {
+	actor.BaseMessage
+
+	// VTXOOutpoint identifies the VTXO.
+	VTXOOutpoint wire.OutPoint
+
+	// FinalState is the terminal state reached.
+	FinalState string
+
+	// Reason explains why the VTXO terminated.
+	Reason string
+}
+
+func (m *VTXOTerminatedNotification) vtxoOutMsgSealed() {}

--- a/vtxo/outbox_messages.go
+++ b/vtxo/outbox_messages.go
@@ -112,6 +112,15 @@ type VTXOStatusUpdate struct {
 
 	// NewStatus is the new status to set.
 	NewStatus VTXOStatus
+
+	// RoundID is the round ID for forfeiting state transitions. Empty for
+	// other status updates.
+	RoundID string
+
+	// ForfeitTx is the signed forfeit transaction for forfeiting state
+	// transitions. Nil for other status updates. Persisted for crash
+	// recovery.
+	ForfeitTx *wire.MsgTx
 }
 
 func (m *VTXOStatusUpdate) vtxoOutMsgSealed() {}

--- a/vtxo/states.go
+++ b/vtxo/states.go
@@ -82,6 +82,10 @@ type ForfeitingState struct {
 	// ForfeitTxID is the txid of the forfeit transaction (set after
 	// signing).
 	ForfeitTxID chainhash.Hash
+
+	// ForfeitTx is the signed forfeit transaction. Persisted for crash
+	// recovery so we can re-broadcast if the round doesn't confirm.
+	ForfeitTx *wire.MsgTx
 }
 
 // String returns a human-readable state name.

--- a/vtxo/states.go
+++ b/vtxo/states.go
@@ -1,0 +1,174 @@
+package vtxo
+
+import (
+	"fmt"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/baselib/protofsm"
+)
+
+// VTXOState is a sealed interface for all states in the VTXO state machine.
+// Each state implements ProcessEvent to handle incoming events and return
+// state transitions.
+type VTXOState interface {
+	protofsm.State[VTXOEvent, VTXOOutMsg, *VTXOEnvironment]
+
+	// vtxoStateSealed is an unexported method that prevents external
+	// packages from implementing VTXOState.
+	vtxoStateSealed()
+}
+
+// LiveState is the primary active state. The VTXO is live and can be spent
+// collaboratively with the operator. This state monitors block epochs to
+// detect when the VTXO is approaching expiry.
+type LiveState struct {
+	// VTXO is the descriptor for this VTXO.
+	VTXO *Descriptor
+
+	// LastCheckedHeight is the last block height at which expiry was
+	// checked.
+	LastCheckedHeight int32
+}
+
+// String returns a human-readable state name.
+func (s *LiveState) String() string {
+	return "Live"
+}
+
+// IsTerminal returns false since LiveState is not a terminal state.
+func (s *LiveState) IsTerminal() bool {
+	return false
+}
+
+func (s *LiveState) vtxoStateSealed() {}
+
+// RefreshRequestedState indicates a refresh request has been sent to the round
+// actor. The VTXO is waiting for acknowledgment or a forfeit request to begin
+// the batch swap process.
+type RefreshRequestedState struct {
+	// VTXO is the descriptor for this VTXO.
+	VTXO *Descriptor
+
+	// RequestedAtHeight is the block height when the refresh was requested.
+	RequestedAtHeight int32
+}
+
+// String returns a human-readable state name.
+func (s *RefreshRequestedState) String() string {
+	return "RefreshRequested"
+}
+
+// IsTerminal returns false since RefreshRequestedState is not terminal.
+func (s *RefreshRequestedState) IsTerminal() bool {
+	return false
+}
+
+func (s *RefreshRequestedState) vtxoStateSealed() {}
+
+// ForfeitingState indicates the VTXO is being forfeited in a round. The VTXO
+// actor is waiting for the new commitment transaction to confirm.
+type ForfeitingState struct {
+	// VTXO is the descriptor for this VTXO.
+	VTXO *Descriptor
+
+	// NewRoundID is the round where the refreshed VTXO will be created.
+	NewRoundID string
+
+	// ConnectorOutpoint is the connector from the new commitment tx that
+	// the forfeit tx spends.
+	ConnectorOutpoint wire.OutPoint
+
+	// ForfeitTxID is the txid of the forfeit transaction (set after
+	// signing).
+	ForfeitTxID chainhash.Hash
+}
+
+// String returns a human-readable state name.
+func (s *ForfeitingState) String() string {
+	return "Forfeiting"
+}
+
+// IsTerminal returns false since ForfeitingState is not terminal.
+func (s *ForfeitingState) IsTerminal() bool {
+	return false
+}
+
+func (s *ForfeitingState) vtxoStateSealed() {}
+
+// ForfeitedState is a terminal state indicating the VTXO has been forfeited.
+// The forfeit may have occurred as part of a batch swap (refresh into a new
+// round) or a leave request (withdrawal to an on-chain address).
+type ForfeitedState struct {
+	// VTXO is the descriptor for this VTXO.
+	VTXO *Descriptor
+
+	// NewRoundID is the round where the forfeit was processed. For batch
+	// swaps this contains the replacement VTXO; for leave requests it's
+	// the round that processed the withdrawal.
+	NewRoundID string
+
+	// CommitmentTxID is the new commitment transaction that was confirmed.
+	CommitmentTxID chainhash.Hash
+}
+
+// String returns a human-readable state name.
+func (s *ForfeitedState) String() string {
+	return "Forfeited"
+}
+
+// IsTerminal returns true since ForfeitedState is a terminal state.
+func (s *ForfeitedState) IsTerminal() bool {
+	return true
+}
+
+func (s *ForfeitedState) vtxoStateSealed() {}
+
+// ExpiringState is a terminal state indicating the VTXO is critically close to
+// expiry and has been sent to the chain resolver for unilateral exit handling.
+type ExpiringState struct {
+	// VTXO is the descriptor for this VTXO.
+	VTXO *Descriptor
+
+	// Reason explains why the VTXO is expiring.
+	Reason string
+}
+
+// String returns a human-readable state name.
+func (s *ExpiringState) String() string {
+	return "Expiring"
+}
+
+// IsTerminal returns true since ExpiringState is a terminal state.
+func (s *ExpiringState) IsTerminal() bool {
+	return true
+}
+
+func (s *ExpiringState) vtxoStateSealed() {}
+
+// FailedState is a terminal state indicating an unrecoverable error occurred.
+type FailedState struct {
+	// VTXO is the descriptor for this VTXO.
+	VTXO *Descriptor
+
+	// Reason is a human-readable description of the failure.
+	Reason string
+
+	// Error is the underlying error, if any.
+	Error error
+
+	// Recoverable indicates whether the failure might be recoverable.
+	Recoverable bool
+}
+
+// String returns a human-readable state name.
+func (s *FailedState) String() string {
+	return fmt.Sprintf("Failed: %s", s.Reason)
+}
+
+// IsTerminal returns true since FailedState is a terminal state.
+func (s *FailedState) IsTerminal() bool {
+	return true
+}
+
+func (s *FailedState) vtxoStateSealed() {}

--- a/vtxo/transitions.go
+++ b/vtxo/transitions.go
@@ -1,0 +1,517 @@
+package vtxo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/tx"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+)
+
+// ProcessEvent handles events in LiveState. The VTXO monitors block epochs for
+// expiry and can receive forfeit requests from the round actor.
+func (s *LiveState) ProcessEvent(
+	ctx context.Context, event VTXOEvent, env *VTXOEnvironment,
+) (*VTXOStateTransition, error) {
+
+	switch evt := event.(type) {
+	case *BlockEpochEvent:
+		return s.handleBlockEpoch(ctx, evt, env)
+
+	case *ForfeitRequestEvent:
+		return s.handleForfeitRequest(ctx, evt, env)
+
+	case *ResumeVTXOEvent:
+		// On resume, stay in LiveState and re-check expiry on next
+		// block.
+		return &VTXOStateTransition{
+			NextState: s,
+		}, nil
+
+	case *VTXOFailedEvent:
+		return &VTXOStateTransition{
+			NextState: &FailedState{
+				VTXO:        s.VTXO,
+				Reason:      evt.Reason,
+				Error:       evt.Error,
+				Recoverable: evt.Recoverable,
+			},
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("live: unexpected event: %T", event)
+	}
+}
+
+// handleBlockEpoch processes a new block notification and checks if the VTXO
+// needs to be refreshed or escalated.
+func (s *LiveState) handleBlockEpoch(
+	_ context.Context, evt *BlockEpochEvent, env *VTXOEnvironment,
+) (*VTXOStateTransition, error) {
+
+	s.LastCheckedHeight = evt.Height
+
+	expiryStatus := env.ExpiryConfig.CheckExpiry(s.VTXO, evt.Height)
+
+	switch expiryStatus {
+	case ExpiryStatusSafe:
+		// Nothing to do, stay in LiveState.
+		return &VTXOStateTransition{
+			NextState: s,
+		}, nil
+
+	case ExpiryStatusNeedsRefresh:
+		// Request refresh before expiry becomes critical.
+		blocksRemaining := BlocksUntilExpiry(s.VTXO, evt.Height)
+		urgency := env.ExpiryConfig.DetermineRefreshUrgency(
+			s.VTXO, blocksRemaining,
+		)
+
+		outbox := []VTXOOutMsg{
+			&RefreshRequest{
+				VTXOOutpoint: s.VTXO.Outpoint,
+				Amount:       int64(s.VTXO.Amount),
+				Urgency:      urgency,
+			},
+			&VTXOStatusUpdate{
+				Outpoint:  s.VTXO.Outpoint,
+				NewStatus: VTXOStatusRefreshRequested,
+			},
+		}
+
+		return &VTXOStateTransition{
+			NextState: &RefreshRequestedState{
+				VTXO:              s.VTXO,
+				RequestedAtHeight: evt.Height,
+			},
+			NewEvents: fn.Some(VTXOEmittedEvent{Outbox: outbox}),
+		}, nil
+
+	case ExpiryStatusCritical:
+		// Escalate to chain resolver for unilateral exit.
+		blocksRemaining := BlocksUntilExpiry(s.VTXO, evt.Height)
+		reason := fmt.Sprintf(
+			"critical expiry: %d blocks remaining", blocksRemaining,
+		)
+
+		outbox := []VTXOOutMsg{
+			&ExpiringNotification{
+				VTXO:            s.VTXO,
+				BlocksRemaining: blocksRemaining,
+				Reason:          "batch expiry imminent",
+			},
+			&VTXOStatusUpdate{
+				Outpoint:  s.VTXO.Outpoint,
+				NewStatus: VTXOStatusExpiring,
+			},
+			&VTXOTerminatedNotification{
+				VTXOOutpoint: s.VTXO.Outpoint,
+				FinalState:   "Expiring",
+				Reason:       "sent to chain resolver",
+			},
+		}
+
+		return &VTXOStateTransition{
+			NextState: &ExpiringState{VTXO: s.VTXO, Reason: reason},
+			NewEvents: fn.Some(VTXOEmittedEvent{Outbox: outbox}),
+		}, nil
+
+	case ExpiryStatusExpired:
+		// Batch has expired - this should not happen if monitoring
+		// works correctly.
+		return &VTXOStateTransition{
+			NextState: &FailedState{
+				VTXO:        s.VTXO,
+				Reason:      "batch expired before refresh",
+				Recoverable: false,
+			},
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("unknown expiry: %d", expiryStatus)
+	}
+}
+
+// handleForfeitRequest builds and signs a forfeit transaction when the round
+// actor requests this VTXO be forfeited as part of a batch swap. The forfeit
+// atomically links the old VTXO to a new round via the connector output - if
+// the new commitment tx confirms, the forfeit becomes valid and pays the VTXO
+// value to the operator. This prevents double-spending by ensuring the client
+// cannot claim both the old VTXO and a new one in the fresh round.
+func (s *LiveState) handleForfeitRequest(
+	_ context.Context, evt *ForfeitRequestEvent, env *VTXOEnvironment,
+) (*VTXOStateTransition, error) {
+
+	forfeitTx, err := tx.BuildForfeitTx(
+		&s.VTXO.Outpoint, s.VTXO.Amount,
+		&evt.ConnectorOutpoint, evt.ServerForfeitPkScript,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build forfeit tx: %w", err)
+	}
+
+	// Sign our portion of the collaborative 2-of-2 spend on the VTXO input.
+	// The operator will complete the multisig witness with their signature.
+	sig, err := signForfeitVTXOInput(s.VTXO, evt, forfeitTx, env)
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign forfeit tx: %w", err)
+	}
+
+	forfeitTxID := forfeitTx.TxHash()
+
+	return &VTXOStateTransition{
+		NextState: &ForfeitingState{
+			VTXO:              s.VTXO,
+			NewRoundID:        evt.RoundID,
+			ConnectorOutpoint: evt.ConnectorOutpoint,
+			ForfeitTxID:       forfeitTxID,
+		},
+		NewEvents: fn.Some(VTXOEmittedEvent{
+			Outbox: []VTXOOutMsg{
+				&ForfeitSignatureSubmission{
+					VTXOOutpoint: s.VTXO.Outpoint,
+					RoundID:      evt.RoundID,
+					ForfeitTx:    forfeitTx,
+					Signature:    sig,
+				},
+				&VTXOStatusUpdate{
+					Outpoint:  s.VTXO.Outpoint,
+					NewStatus: VTXOStatusForfeiting,
+				},
+			},
+		}),
+	}, nil
+}
+
+// signForfeitVTXOInput produces the client's schnorr signature for the VTXO
+// input of a forfeit transaction. The VTXO uses a tapscript with a 2-of-2
+// collaborative spend path, so both client and operator signatures are needed.
+// This function only produces the client's half; the operator adds theirs.
+func signForfeitVTXOInput(vtxo *Descriptor, evt *ForfeitRequestEvent,
+	forfeitTx *wire.MsgTx, env *VTXOEnvironment) ([]byte, error) {
+
+	if vtxo.TapScript == nil {
+		return nil, fmt.Errorf("VTXO tapscript is required for signing")
+	}
+	if env.Wallet == nil {
+		return nil, fmt.Errorf("wallet is required for signing")
+	}
+
+	// Reconstruct the VTXO output to build proper sighash. BIP-341 requires
+	// all prevouts when computing taproot signature hashes.
+	vtxoOutput := &wire.TxOut{
+		Value: int64(vtxo.Amount), PkScript: vtxo.PkScript,
+	}
+	vtxoCtx := &tx.VTXOSpendContext{
+		Outpoint:  vtxo.Outpoint,
+		Output:    vtxoOutput,
+		TapScript: vtxo.TapScript,
+	}
+
+	connectorOutput := &wire.TxOut{
+		Value: evt.ConnectorAmount, PkScript: evt.ConnectorPkScript,
+	}
+	connectorCtx := &tx.ConnectorSpendContext{
+		Outpoint: evt.ConnectorOutpoint,
+		Output:   connectorOutput,
+	}
+
+	prevFetcher, err := tx.NewForfeitPrevOutFetcher(vtxoCtx, connectorCtx)
+	if err != nil {
+		return nil, fmt.Errorf("prevout fetcher: %w", err)
+	}
+
+	sigHashes := txscript.NewTxSigHashes(forfeitTx, prevFetcher)
+
+	// NewVTXOCollabSignDescriptor extracts the collaborative leaf's witness
+	// script and control block from the tapscript, which are needed for
+	// script-path spending.
+	signDesc, _, err := tx.NewVTXOCollabSignDescriptor(
+		vtxoCtx, vtxo.ClientKey, tx.ForfeitVTXOInputIndex,
+		sigHashes, prevFetcher,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("sign descriptor: %w", err)
+	}
+
+	sig, err := env.Wallet.SignOutputRaw(forfeitTx, signDesc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign: %w", err)
+	}
+
+	return sig.Serialize(), nil
+}
+
+// ProcessEvent handles events in RefreshRequestedState. The VTXO is waiting
+// for acknowledgment or a forfeit request from the round actor.
+func (s *RefreshRequestedState) ProcessEvent(
+	ctx context.Context, event VTXOEvent, env *VTXOEnvironment,
+) (*VTXOStateTransition, error) {
+
+	switch evt := event.(type) {
+	case *BlockEpochEvent:
+		// Check if we've hit critical expiry while waiting for refresh.
+		expiryStatus := env.ExpiryConfig.CheckExpiry(s.VTXO, evt.Height)
+
+		if expiryStatus == ExpiryStatusCritical ||
+			expiryStatus == ExpiryStatusExpired {
+
+			blocksRemaining := BlocksUntilExpiry(s.VTXO, evt.Height)
+
+			outbox := []VTXOOutMsg{
+				&ExpiringNotification{
+					VTXO:            s.VTXO,
+					BlocksRemaining: blocksRemaining,
+					Reason:          "refresh timeout",
+				},
+				&VTXOStatusUpdate{
+					Outpoint:  s.VTXO.Outpoint,
+					NewStatus: VTXOStatusExpiring,
+				},
+				&VTXOTerminatedNotification{
+					VTXOOutpoint: s.VTXO.Outpoint,
+					FinalState:   "Expiring",
+					Reason:       "refresh timeout",
+				},
+			}
+
+			return &VTXOStateTransition{
+				NextState: &ExpiringState{
+					VTXO:   s.VTXO,
+					Reason: "critical expiry in refresh",
+				},
+				NewEvents: fn.Some(VTXOEmittedEvent{
+					Outbox: outbox,
+				}),
+			}, nil
+		}
+
+		// Still waiting, stay in this state.
+		return &VTXOStateTransition{
+			NextState: s,
+		}, nil
+
+	case *ForfeitRequestEvent:
+		// Round actor is ready for forfeit. Build and sign the forfeit
+		// tx to transfer this VTXO to the new round.
+		forfeitTx, err := tx.BuildForfeitTx(
+			&s.VTXO.Outpoint, s.VTXO.Amount,
+			&evt.ConnectorOutpoint, evt.ServerForfeitPkScript,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("build forfeit tx: %w", err)
+		}
+
+		sig, err := signForfeitVTXOInput(s.VTXO, evt, forfeitTx, env)
+		if err != nil {
+			return nil, fmt.Errorf("sign forfeit tx: %w", err)
+		}
+
+		forfeitTxID := forfeitTx.TxHash()
+
+		return &VTXOStateTransition{
+			NextState: &ForfeitingState{
+				VTXO:              s.VTXO,
+				NewRoundID:        evt.RoundID,
+				ConnectorOutpoint: evt.ConnectorOutpoint,
+				ForfeitTxID:       forfeitTxID,
+			},
+			NewEvents: fn.Some(VTXOEmittedEvent{
+				Outbox: []VTXOOutMsg{
+					&ForfeitSignatureSubmission{
+						VTXOOutpoint: s.VTXO.Outpoint,
+						RoundID:      evt.RoundID,
+						ForfeitTx:    forfeitTx,
+						Signature:    sig,
+					},
+					&VTXOStatusUpdate{
+						Outpoint:  s.VTXO.Outpoint,
+						NewStatus: VTXOStatusForfeiting,
+					},
+				},
+			}),
+		}, nil
+
+	case *RefreshAcknowledgedEvent:
+		// Round actor acknowledged but no forfeit request yet.
+		// Stay in RefreshRequestedState.
+		return &VTXOStateTransition{
+			NextState: s,
+		}, nil
+
+	case *ResumeVTXOEvent:
+		// On resume, stay in this state. The round actor should have
+		// persisted the refresh request.
+		return &VTXOStateTransition{
+			NextState: s,
+		}, nil
+
+	case *VTXOFailedEvent:
+		return &VTXOStateTransition{
+			NextState: &FailedState{
+				VTXO:        s.VTXO,
+				Reason:      evt.Reason,
+				Error:       evt.Error,
+				Recoverable: evt.Recoverable,
+			},
+		}, nil
+
+	default:
+		return nil, fmt.Errorf(
+			"refresh_requested: unexpected event: %T", event,
+		)
+	}
+}
+
+// ProcessEvent handles events in ForfeitingState. The VTXO is being forfeited
+// and waiting for the new commitment transaction to confirm.
+func (s *ForfeitingState) ProcessEvent(
+	ctx context.Context, event VTXOEvent, env *VTXOEnvironment,
+) (*VTXOStateTransition, error) {
+
+	switch evt := event.(type) {
+	case *ForfeitSignedEvent:
+		// Forfeit tx has been signed and submitted. Update the txid
+		// and stay in this state. Preserve the ForfeitTx for crash
+		// recovery.
+		return &VTXOStateTransition{
+			NextState: &ForfeitingState{
+				VTXO:              s.VTXO,
+				NewRoundID:        s.NewRoundID,
+				ConnectorOutpoint: s.ConnectorOutpoint,
+				ForfeitTxID:       evt.ForfeitTxID,
+				ForfeitTx:         s.ForfeitTx,
+			},
+		}, nil
+
+	case *ForfeitConfirmedEvent:
+		// New commitment tx confirmed, forfeit is complete. Include
+		// the ForfeitTx so the persistence layer can call MarkForfeited
+		// with the txid for audit/recovery purposes.
+		return &VTXOStateTransition{
+			NextState: &ForfeitedState{
+				VTXO:           s.VTXO,
+				NewRoundID:     s.NewRoundID,
+				CommitmentTxID: evt.CommitmentTxID,
+			},
+			NewEvents: fn.Some(VTXOEmittedEvent{
+				Outbox: []VTXOOutMsg{
+					&VTXOStatusUpdate{
+						Outpoint:  s.VTXO.Outpoint,
+						NewStatus: VTXOStatusForfeited,
+						ForfeitTx: s.ForfeitTx,
+					},
+					&VTXOTerminatedNotification{
+						VTXOOutpoint: s.VTXO.Outpoint,
+						FinalState:   "Forfeited",
+						Reason: fmt.Sprintf(
+							"forfeited in round %s",
+							s.NewRoundID,
+						),
+					},
+				},
+			}),
+		}, nil
+
+	case *BlockEpochEvent:
+		// Check if we've hit expiry while forfeiting. If critical, we
+		// must escalate to chain resolver for unilateral exit.
+		expiryStatus := env.ExpiryConfig.CheckExpiry(s.VTXO, evt.Height)
+
+		if expiryStatus == ExpiryStatusCritical ||
+			expiryStatus == ExpiryStatusExpired {
+
+			blocksRemaining := BlocksUntilExpiry(s.VTXO, evt.Height)
+
+			outbox := []VTXOOutMsg{
+				&ExpiringNotification{
+					VTXO:            s.VTXO,
+					BlocksRemaining: blocksRemaining,
+					Reason:          "round stalled",
+				},
+				&VTXOStatusUpdate{
+					Outpoint:  s.VTXO.Outpoint,
+					NewStatus: VTXOStatusExpiring,
+				},
+				&VTXOTerminatedNotification{
+					VTXOOutpoint: s.VTXO.Outpoint,
+					FinalState:   "Expiring",
+					Reason:       "forfeit timeout",
+				},
+			}
+
+			return &VTXOStateTransition{
+				NextState: &ExpiringState{
+					VTXO:   s.VTXO,
+					Reason: "critical expiry in forfeit",
+				},
+				NewEvents: fn.Some(VTXOEmittedEvent{
+					Outbox: outbox,
+				}),
+			}, nil
+		}
+
+		// Still waiting for forfeit confirmation.
+		return &VTXOStateTransition{
+			NextState: s,
+		}, nil
+
+	case *ResumeVTXOEvent:
+		// On resume in ForfeitingState, we need to wait for the round
+		// to complete and send ForfeitConfirmedEvent.
+		return &VTXOStateTransition{
+			NextState: s,
+		}, nil
+
+	case *VTXOFailedEvent:
+		return &VTXOStateTransition{
+			NextState: &FailedState{
+				VTXO:        s.VTXO,
+				Reason:      evt.Reason,
+				Error:       evt.Error,
+				Recoverable: evt.Recoverable,
+			},
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("forfeiting: bad event: %T", event)
+	}
+}
+
+// ProcessEvent for ForfeitedState. This is a terminal state, so all events
+// result in staying in the same state.
+func (s *ForfeitedState) ProcessEvent(
+	_ context.Context, _ VTXOEvent, _ *VTXOEnvironment,
+) (*VTXOStateTransition, error) {
+
+	// Terminal state: self-loop on all events.
+	return &VTXOStateTransition{
+		NextState: s,
+	}, nil
+}
+
+// ProcessEvent for ExpiringState. This is a terminal state, so all events
+// result in staying in the same state.
+func (s *ExpiringState) ProcessEvent(
+	_ context.Context, _ VTXOEvent, _ *VTXOEnvironment,
+) (*VTXOStateTransition, error) {
+
+	// Terminal state: self-loop on all events.
+	return &VTXOStateTransition{
+		NextState: s,
+	}, nil
+}
+
+// ProcessEvent for FailedState. This is a terminal state, so all events
+// result in staying in the same state.
+func (s *FailedState) ProcessEvent(
+	_ context.Context, _ VTXOEvent, _ *VTXOEnvironment,
+) (*VTXOStateTransition, error) {
+
+	// Terminal state: self-loop on all events.
+	return &VTXOStateTransition{
+		NextState: s,
+	}, nil
+}

--- a/vtxo/transitions.go
+++ b/vtxo/transitions.go
@@ -167,6 +167,7 @@ func (s *LiveState) handleForfeitRequest(
 			NewRoundID:        evt.RoundID,
 			ConnectorOutpoint: evt.ConnectorOutpoint,
 			ForfeitTxID:       forfeitTxID,
+			ForfeitTx:         forfeitTx,
 		},
 		NewEvents: fn.Some(VTXOEmittedEvent{
 			Outbox: []VTXOOutMsg{
@@ -179,6 +180,8 @@ func (s *LiveState) handleForfeitRequest(
 				&VTXOStatusUpdate{
 					Outpoint:  s.VTXO.Outpoint,
 					NewStatus: VTXOStatusForfeiting,
+					RoundID:   evt.RoundID,
+					ForfeitTx: forfeitTx,
 				},
 			},
 		}),
@@ -317,6 +320,7 @@ func (s *RefreshRequestedState) ProcessEvent(
 				NewRoundID:        evt.RoundID,
 				ConnectorOutpoint: evt.ConnectorOutpoint,
 				ForfeitTxID:       forfeitTxID,
+				ForfeitTx:         forfeitTx,
 			},
 			NewEvents: fn.Some(VTXOEmittedEvent{
 				Outbox: []VTXOOutMsg{
@@ -329,6 +333,8 @@ func (s *RefreshRequestedState) ProcessEvent(
 					&VTXOStatusUpdate{
 						Outpoint:  s.VTXO.Outpoint,
 						NewStatus: VTXOStatusForfeiting,
+						RoundID:   evt.RoundID,
+						ForfeitTx: forfeitTx,
 					},
 				},
 			}),

--- a/vtxo/transitions_test.go
+++ b/vtxo/transitions_test.go
@@ -1,0 +1,843 @@
+package vtxo
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/scripts"
+	"github.com/lightninglabs/darepo-client/lib/tx"
+	"github.com/lightninglabs/darepo-client/round"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStateProperties verifies basic properties of all states.
+func TestStateProperties(t *testing.T) {
+	t.Parallel()
+
+	h := newVTXOTestHarness(t)
+	vtxo := h.newTestDescriptor()
+
+	tests := []struct {
+		name       string
+		state      VTXOState
+		isTerminal bool
+	}{
+		{
+			name:       "LiveState",
+			state:      &LiveState{VTXO: vtxo},
+			isTerminal: false,
+		},
+		{
+			name:       "RefreshRequestedState",
+			state:      &RefreshRequestedState{VTXO: vtxo},
+			isTerminal: false,
+		},
+		{
+			name:       "ForfeitingState",
+			state:      &ForfeitingState{VTXO: vtxo},
+			isTerminal: false,
+		},
+		{
+			name:       "ForfeitedState",
+			state:      &ForfeitedState{VTXO: vtxo},
+			isTerminal: true,
+		},
+		{
+			name:       "ExpiringState",
+			state:      &ExpiringState{VTXO: vtxo},
+			isTerminal: true,
+		},
+		{
+			name:       "FailedState",
+			state:      &FailedState{VTXO: vtxo, Reason: "test"},
+			isTerminal: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.isTerminal, tc.state.IsTerminal())
+			require.NotEmpty(t, tc.state.String())
+		})
+	}
+}
+
+// TestLiveStateBlockEpochSafe verifies that LiveState stays live when expiry
+// is safe.
+func TestLiveStateBlockEpochSafe(t *testing.T) {
+	t.Parallel()
+
+	h := newVTXOTestHarness(t)
+	vtxo := h.newTestDescriptor()
+	vtxo.BatchExpiry = 1000
+	vtxo.CreatedHeight = 100
+
+	h.withState(&LiveState{
+		VTXO:              vtxo,
+		LastCheckedHeight: 100,
+	})
+
+	// Block height well before expiry - should stay in LiveState.
+	evt := h.newBlockEpochEvent(200)
+	_, err := h.sendEvent(evt)
+	require.NoError(t, err)
+
+	assertState[*LiveState](h)
+	require.Empty(t, h.outboxMessages, "no messages for safe expiry")
+}
+
+// TestLiveStateBlockEpochNeedsRefresh verifies that LiveState transitions to
+// RefreshRequestedState when approaching expiry threshold.
+func TestLiveStateBlockEpochNeedsRefresh(t *testing.T) {
+	t.Parallel()
+
+	h := newVTXOTestHarness(t)
+	vtxo := h.newTestDescriptor()
+	vtxo.BatchExpiry = 1000
+	vtxo.CreatedHeight = 100
+
+	// Configure expiry so we're in the refresh window.
+	h.withExpiryConfig(&ExpiryConfig{
+		RefreshThresholdBlocks:  200,
+		CriticalThresholdBlocks: 50,
+		TreeDepthMultiplier:     1,
+	})
+
+	h.withState(&LiveState{
+		VTXO:              vtxo,
+		LastCheckedHeight: 100,
+	})
+
+	// Block height within refresh threshold (200 blocks before expiry).
+	// BatchExpiry=1000, so at height 850 we're 150 blocks away (< 200).
+	evt := h.newBlockEpochEvent(850)
+
+	// Setup mock for status update.
+	h.store.On(
+		"UpdateVTXOStatus", h.ctx, vtxo.Outpoint,
+		VTXOStatusRefreshRequested,
+	).Return(nil)
+
+	_, err := h.sendEvent(evt)
+	require.NoError(t, err)
+
+	assertState[*RefreshRequestedState](h)
+
+	// Should emit RefreshRequest.
+	assertOutboxContains[*RefreshRequest](h)
+}
+
+// TestLiveStateBlockEpochCritical verifies that LiveState transitions to
+// ExpiringState when critically close to expiry.
+func TestLiveStateBlockEpochCritical(t *testing.T) {
+	t.Parallel()
+
+	h := newVTXOTestHarness(t)
+	vtxo := h.newTestDescriptor()
+	vtxo.BatchExpiry = 1000
+	vtxo.CreatedHeight = 100
+
+	// Configure expiry so we're in critical zone.
+	h.withExpiryConfig(&ExpiryConfig{
+		RefreshThresholdBlocks:  200,
+		CriticalThresholdBlocks: 50,
+		TreeDepthMultiplier:     1,
+	})
+
+	h.withState(&LiveState{
+		VTXO:              vtxo,
+		LastCheckedHeight: 100,
+	})
+
+	// Block height within critical threshold (50 blocks before expiry).
+	// BatchExpiry=1000, so at height 970 we're 30 blocks away (< 50).
+	evt := h.newBlockEpochEvent(970)
+
+	// Setup mock for status update.
+	h.store.On(
+		"UpdateVTXOStatus", h.ctx, vtxo.Outpoint,
+		VTXOStatusExpiring,
+	).Return(nil)
+
+	_, err := h.sendEvent(evt)
+	require.NoError(t, err)
+
+	assertState[*ExpiringState](h)
+
+	// Should emit ExpiringNotification (pointer type).
+	assertOutboxContains[*ExpiringNotification](h)
+}
+
+// TestForfeitRequestFromLiveState verifies that LiveState transitions to
+// ForfeitingState on ForfeitRequest from round actor.
+func TestForfeitRequestFromLiveState(t *testing.T) {
+	t.Parallel()
+
+	h := newVTXOTestHarness(t)
+	vtxo := h.newTestDescriptor()
+
+	h.setupMockWalletForSigning()
+	h.withState(&LiveState{
+		VTXO:              vtxo,
+		LastCheckedHeight: 100,
+	})
+
+	connectorOutpoint := h.newTestOutpoint()
+	evt := &round.ForfeitRequestEvent{
+		RoundID:               "round-123",
+		ConnectorOutpoint:     connectorOutpoint,
+		ConnectorPkScript:     []byte{0x51, 0x20},
+		ConnectorAmount:       546,
+		ServerForfeitPkScript: []byte{0x51, 0x20},
+	}
+
+	// Setup mock for status update.
+	h.store.On(
+		"UpdateVTXOStatus", h.ctx, vtxo.Outpoint, VTXOStatusForfeiting,
+	).Return(nil)
+
+	_, err := h.sendEvent(evt)
+	require.NoError(t, err)
+
+	state := assertState[*ForfeitingState](h)
+	require.Equal(t, "round-123", state.NewRoundID)
+	require.Equal(t, connectorOutpoint, state.ConnectorOutpoint)
+}
+
+// TestForfeitRequestFromRefreshRequested verifies that RefreshRequestedState
+// transitions to ForfeitingState on ForfeitRequest.
+func TestForfeitRequestFromRefreshRequested(t *testing.T) {
+	t.Parallel()
+
+	h := newVTXOTestHarness(t)
+	vtxo := h.newTestDescriptor()
+
+	h.setupMockWalletForSigning()
+	h.withState(&RefreshRequestedState{
+		VTXO:              vtxo,
+		RequestedAtHeight: 800,
+	})
+
+	connectorOutpoint := h.newTestOutpoint()
+	evt := &round.ForfeitRequestEvent{
+		RoundID:               "round-456",
+		ConnectorOutpoint:     connectorOutpoint,
+		ConnectorPkScript:     []byte{0x51, 0x20},
+		ConnectorAmount:       546,
+		ServerForfeitPkScript: []byte{0x51, 0x20},
+	}
+
+	// Setup mock for status update.
+	h.store.On(
+		"UpdateVTXOStatus", h.ctx, vtxo.Outpoint, VTXOStatusForfeiting,
+	).Return(nil)
+
+	_, err := h.sendEvent(evt)
+	require.NoError(t, err)
+
+	state := assertState[*ForfeitingState](h)
+	require.Equal(t, "round-456", state.NewRoundID)
+}
+
+// TestRefreshRequestedCriticalExpiry verifies that RefreshRequestedState
+// transitions to ExpiringState if expiry becomes critical while waiting.
+func TestRefreshRequestedCriticalExpiry(t *testing.T) {
+	t.Parallel()
+
+	h := newVTXOTestHarness(t)
+	vtxo := h.newTestDescriptor()
+	vtxo.BatchExpiry = 1000
+
+	h.withExpiryConfig(&ExpiryConfig{
+		RefreshThresholdBlocks:  200,
+		CriticalThresholdBlocks: 50,
+		TreeDepthMultiplier:     1,
+	})
+
+	h.withState(&RefreshRequestedState{
+		VTXO:              vtxo,
+		RequestedAtHeight: 800,
+	})
+
+	// Block height within critical threshold while waiting for refresh.
+	evt := h.newBlockEpochEvent(970)
+
+	// Setup mock for status update.
+	h.store.On(
+		"UpdateVTXOStatus", h.ctx, vtxo.Outpoint, VTXOStatusExpiring,
+	).Return(nil)
+
+	_, err := h.sendEvent(evt)
+	require.NoError(t, err)
+
+	assertState[*ExpiringState](h)
+}
+
+// TestForfeitingStateConfirmed verifies that ForfeitingState transitions to
+// ForfeitedState on confirmation.
+func TestForfeitingStateConfirmed(t *testing.T) {
+	t.Parallel()
+
+	h := newVTXOTestHarness(t)
+	vtxo := h.newTestDescriptor()
+
+	h.withState(&ForfeitingState{
+		VTXO:              vtxo,
+		NewRoundID:        "round-789",
+		ConnectorOutpoint: h.newTestOutpoint(),
+	})
+
+	var commitmentTxID chainhash.Hash
+	copy(commitmentTxID[:], []byte("commitment-tx-hash"))
+
+	evt := &round.ForfeitConfirmedEvent{
+		CommitmentTxID: commitmentTxID,
+		BlockHeight:    1100,
+	}
+
+	// Setup mock for marking forfeited.
+	h.store.On(
+		"MarkForfeited", h.ctx, vtxo.Outpoint, commitmentTxID,
+	).Return(nil)
+
+	_, err := h.sendEvent(evt)
+	require.NoError(t, err)
+
+	state := assertState[*ForfeitedState](h)
+	require.Equal(t, "round-789", state.NewRoundID)
+	require.Equal(t, commitmentTxID, state.CommitmentTxID)
+
+	// Should emit termination notification.
+	assertOutboxContains[*VTXOTerminatedNotification](h)
+}
+
+// TestTerminalStatesSelfLoop verifies that terminal states self-loop on events.
+func TestTerminalStatesSelfLoop(t *testing.T) {
+	t.Parallel()
+
+	h := newVTXOTestHarness(t)
+	vtxo := h.newTestDescriptor()
+
+	terminalStates := []VTXOState{
+		&ForfeitedState{VTXO: vtxo},
+		&ExpiringState{VTXO: vtxo},
+		&FailedState{VTXO: vtxo, Reason: "test"},
+	}
+
+	for _, state := range terminalStates {
+		t.Run(state.String(), func(t *testing.T) {
+			h.withState(state)
+
+			// Send block epoch - should be no-op.
+			evt := h.newBlockEpochEvent(500)
+			_, err := h.sendEvent(evt)
+			require.NoError(t, err)
+
+			// Should still be in same state.
+			require.True(t, h.currentState.IsTerminal())
+		})
+	}
+}
+
+// TestExpiryStatusDetermination verifies expiry calculation logic.
+// Config: RefreshThreshold=200, CriticalThreshold=50, TreeDepthMultiplier=10
+// Given VTXO: BatchExpiry=1000, TreeDepth=3, RelativeExpiry=144
+// Calculated thresholds:
+//   - Critical = max(50, 3*10+144) = max(50, 174) = 174
+//   - Refresh = max(200, 174+0) = 200 (MinRefreshBuffer defaults to 0)
+func TestExpiryStatusDetermination(t *testing.T) {
+	t.Parallel()
+
+	cfg := &ExpiryConfig{
+		RefreshThresholdBlocks:  200,
+		CriticalThresholdBlocks: 50,
+		TreeDepthMultiplier:     10,
+	}
+
+	vtxo := &Descriptor{
+		Outpoint:       wire.OutPoint{},
+		BatchExpiry:    1000,
+		TreeDepth:      3,
+		RelativeExpiry: 144,
+	}
+
+	tests := []struct {
+		name     string
+		height   int32
+		expected ExpiryStatus
+	}{
+		{
+			name:     "well before refresh threshold",
+			height:   500,
+			expected: ExpiryStatusSafe,
+		},
+		{
+			// Height 810: remaining=190 < 200 (refresh) but > 174
+			// (critical), so NeedsRefresh.
+			name:     "within refresh threshold",
+			height:   810,
+			expected: ExpiryStatusNeedsRefresh,
+		},
+		{
+			// Height 850: remaining=150 < 174 (critical).
+			name:     "within critical threshold",
+			height:   850,
+			expected: ExpiryStatusCritical,
+		},
+		{
+			name:     "past expiry",
+			height:   1001,
+			expected: ExpiryStatusExpired,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			status := cfg.CheckExpiry(vtxo, tc.height)
+			require.Equal(t, tc.expected, status)
+		})
+	}
+}
+
+// TestBlocksUntilExpiry verifies block counting logic.
+func TestBlocksUntilExpiry(t *testing.T) {
+	t.Parallel()
+
+	vtxo := &Descriptor{
+		BatchExpiry: 1000,
+	}
+
+	tests := []struct {
+		name     string
+		height   int32
+		expected int32
+	}{
+		{
+			name:     "500 blocks before",
+			height:   500,
+			expected: 500,
+		},
+		{
+			name:     "at expiry",
+			height:   1000,
+			expected: 0,
+		},
+		{
+			name:     "past expiry",
+			height:   1100,
+			expected: -100,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			blocks := BlocksUntilExpiry(vtxo, tc.height)
+			require.Equal(t, tc.expected, blocks)
+		})
+	}
+}
+
+// TestForfeitRequestRealSigning verifies that the forfeit flow produces
+// valid cryptographic signatures using real signing operations.
+func TestForfeitRequestRealSigning(t *testing.T) {
+	t.Parallel()
+
+	h := newRealVTXOSigningHarness(t)
+	vtxo := h.newTestDescriptor()
+
+	h.withState(&LiveState{
+		VTXO:              vtxo,
+		LastCheckedHeight: 100,
+	})
+
+	connectorOutpoint := h.newTestOutpoint()
+	connectorOutput := h.newTestConnectorOutput()
+	serverForfeitScript := h.newServerForfeitScript()
+
+	evt := &round.ForfeitRequestEvent{
+		RoundID:               "round-real-sig-001",
+		ConnectorOutpoint:     connectorOutpoint,
+		ConnectorPkScript:     connectorOutput.PkScript,
+		ConnectorAmount:       connectorOutput.Value,
+		ServerForfeitPkScript: serverForfeitScript,
+	}
+
+	// Setup mock for status update.
+	h.store.On(
+		"UpdateVTXOStatus", h.ctx, vtxo.Outpoint, VTXOStatusForfeiting,
+	).Return(nil)
+
+	_, err := h.sendEvent(evt)
+	require.NoError(t, err)
+
+	// Verify state transition.
+	state := assertStateReal[*ForfeitingState](h)
+	require.Equal(t, "round-real-sig-001", state.NewRoundID)
+	require.Equal(t, connectorOutpoint, state.ConnectorOutpoint)
+
+	// Get the emitted forfeit signature submission.
+	submission := assertOutboxContainsReal[*ForfeitSignatureSubmission](h)
+
+	// Verify the forfeit tx structure is valid.
+	err = tx.ValidateForfeitTx(submission.ForfeitTx, tx.ForfeitTxParams{
+		VTXOOutpoint:        vtxo.Outpoint,
+		ConnectorOutpoint:   connectorOutpoint,
+		ServerForfeitScript: serverForfeitScript,
+		ExpectedAmount:      vtxo.Amount,
+	})
+	require.NoError(t, err)
+
+	// Verify the signature is non-empty and has valid length (64 bytes for
+	// Schnorr).
+	require.Len(t, submission.Signature, 64, "signature should be 64 bytes")
+}
+
+// TestForfeitingStateCriticalExpiry verifies that ForfeitingState transitions
+// to ExpiringState if critical expiry is reached while waiting for forfeit
+// confirmation.
+func TestForfeitingStateCriticalExpiry(t *testing.T) {
+	t.Parallel()
+
+	h := newVTXOTestHarness(t)
+	vtxo := h.newTestDescriptor()
+	vtxo.BatchExpiry = 1000
+
+	h.withExpiryConfig(&ExpiryConfig{
+		RefreshThresholdBlocks:  200,
+		CriticalThresholdBlocks: 50,
+		TreeDepthMultiplier:     1,
+	})
+
+	forfeitTx := wire.NewMsgTx(2)
+	h.withState(&ForfeitingState{
+		VTXO:              vtxo,
+		NewRoundID:        "round-stalled",
+		ConnectorOutpoint: h.newTestOutpoint(),
+		ForfeitTxID:       forfeitTx.TxHash(),
+		ForfeitTx:         forfeitTx,
+	})
+
+	// Block height within critical threshold while waiting for forfeit
+	// confirmation. Should escalate to chain resolver.
+	evt := h.newBlockEpochEvent(970)
+
+	// Setup mock for status update.
+	h.store.On(
+		"UpdateVTXOStatus", h.ctx, vtxo.Outpoint, VTXOStatusExpiring,
+	).Return(nil)
+
+	_, err := h.sendEvent(evt)
+	require.NoError(t, err)
+
+	assertState[*ExpiringState](h)
+
+	// Should emit ExpiringNotification and VTXOTerminatedNotification.
+	assertOutboxContains[*ExpiringNotification](h)
+	assertOutboxContains[*VTXOTerminatedNotification](h)
+}
+
+// TestForfeitSignedEventPreservesForfeitTx verifies that handling
+// ForfeitSignedEvent preserves the ForfeitTx field for crash recovery.
+func TestForfeitSignedEventPreservesForfeitTx(t *testing.T) {
+	t.Parallel()
+
+	h := newVTXOTestHarness(t)
+	vtxo := h.newTestDescriptor()
+
+	// Create a forfeit tx to track.
+	forfeitTx := wire.NewMsgTx(2)
+	forfeitTx.AddTxIn(&wire.TxIn{})
+	forfeitTx.AddTxOut(&wire.TxOut{Value: 1000})
+
+	var newTxID chainhash.Hash
+	copy(newTxID[:], []byte("updated-forfeit-txid"))
+
+	h.withState(&ForfeitingState{
+		VTXO:              vtxo,
+		NewRoundID:        "round-123",
+		ConnectorOutpoint: h.newTestOutpoint(),
+		ForfeitTxID:       forfeitTx.TxHash(),
+		ForfeitTx:         forfeitTx,
+	})
+
+	// Send ForfeitSignedEvent with a new txid.
+	evt := &ForfeitSignedEvent{
+		ForfeitTxID: newTxID,
+	}
+
+	_, err := h.sendEvent(evt)
+	require.NoError(t, err)
+
+	// Should stay in ForfeitingState.
+	state := assertState[*ForfeitingState](h)
+
+	// ForfeitTx should be preserved for crash recovery.
+	require.NotNil(t, state.ForfeitTx, "ForfeitTx must be preserved")
+	require.Equal(t, forfeitTx, state.ForfeitTx)
+
+	// ForfeitTxID should be updated from the event.
+	require.Equal(t, newTxID, state.ForfeitTxID)
+}
+
+// TestDetermineRefreshUrgencyWithDynamicThresholds verifies that urgency
+// calculation uses dynamic thresholds based on VTXO tree depth and CSV delay.
+func TestDetermineRefreshUrgencyWithDynamicThresholds(t *testing.T) {
+	t.Parallel()
+
+	cfg := &ExpiryConfig{
+		RefreshThresholdBlocks:  200,
+		CriticalThresholdBlocks: 50,
+		MinRefreshBuffer:        72,
+		TreeDepthMultiplier:     10,
+	}
+
+	// VTXO with deep tree and large CSV delay.
+	// Dynamic critical = max(50, 5*10 + 144) = max(50, 194) = 194
+	// Dynamic refresh = max(200, 194 + 72) = 266
+	// Note: For deep VTXOs, there's no "elevated" zone because
+	// critical (194) > half of refresh (133), so we go straight
+	// from normal to critical.
+	deepVTXO := &Descriptor{
+		Outpoint:       wire.OutPoint{},
+		BatchExpiry:    1000,
+		TreeDepth:      5,
+		RelativeExpiry: 144,
+	}
+
+	// VTXO with shallow tree and small CSV delay.
+	// Dynamic critical = max(50, 1*10 + 24) = max(50, 34) = 50
+	// Dynamic refresh = max(200, 50 + 72) = 200
+	// Here we have elevated zone: blocks in (50, 100].
+	shallowVTXO := &Descriptor{
+		Outpoint:       wire.OutPoint{},
+		BatchExpiry:    1000,
+		TreeDepth:      1,
+		RelativeExpiry: 24,
+	}
+
+	tests := []struct {
+		name     string
+		vtxo     *Descriptor
+		blocks   int32
+		expected RefreshUrgency
+	}{
+		{
+			// Deep VTXO: critical=194, blocks=180 < 194.
+			name:     "deep VTXO at critical",
+			vtxo:     deepVTXO,
+			blocks:   180,
+			expected: RefreshUrgencyCritical,
+		},
+		{
+			// For deep VTXO: blocks=200 > critical(194), so not
+			// critical. Half of refresh = 133. Since 200 > 133,
+			// it's normal (no elevated zone for deep VTXOs).
+			name:     "deep VTXO normal near critical",
+			vtxo:     deepVTXO,
+			blocks:   200,
+			expected: RefreshUrgencyNormal,
+		},
+		{
+			// For deep VTXO: blocks=250 > 133 (half of 266).
+			name:     "deep VTXO normal well above",
+			vtxo:     deepVTXO,
+			blocks:   250,
+			expected: RefreshUrgencyNormal,
+		},
+		{
+			// Shallow VTXO: critical=50, blocks=40 < 50.
+			name:     "shallow VTXO at critical",
+			vtxo:     shallowVTXO,
+			blocks:   40,
+			expected: RefreshUrgencyCritical,
+		},
+		{
+			// Shallow VTXO: refresh=200, half=100.
+			// 80 > 50 (not critical) but 80 < 100 (elevated).
+			name:     "shallow VTXO elevated",
+			vtxo:     shallowVTXO,
+			blocks:   80,
+			expected: RefreshUrgencyElevated,
+		},
+		{
+			// For shallow VTXO: blocks=150 > 100 (half of 200).
+			name:     "shallow VTXO normal",
+			vtxo:     shallowVTXO,
+			blocks:   150,
+			expected: RefreshUrgencyNormal,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			urgency := cfg.DetermineRefreshUrgency(
+				tc.vtxo, tc.blocks,
+			)
+			require.Equal(t, tc.expected, urgency)
+		})
+	}
+}
+
+// TestForfeitConfirmedEventIncludesForfeitTx verifies that the
+// ForfeitConfirmedEvent transition includes the ForfeitTx in the status update
+// for persistence.
+func TestForfeitConfirmedEventIncludesForfeitTx(t *testing.T) {
+	t.Parallel()
+
+	h := newVTXOTestHarness(t)
+	vtxo := h.newTestDescriptor()
+
+	// Create a forfeit tx.
+	forfeitTx := wire.NewMsgTx(2)
+	forfeitTx.AddTxIn(&wire.TxIn{})
+	forfeitTx.AddTxOut(&wire.TxOut{Value: 1000})
+
+	h.withState(&ForfeitingState{
+		VTXO:              vtxo,
+		NewRoundID:        "round-789",
+		ConnectorOutpoint: h.newTestOutpoint(),
+		ForfeitTxID:       forfeitTx.TxHash(),
+		ForfeitTx:         forfeitTx,
+	})
+
+	var commitmentTxID chainhash.Hash
+	copy(commitmentTxID[:], []byte("commitment-tx-hash"))
+
+	evt := &ForfeitConfirmedEvent{
+		CommitmentTxID: commitmentTxID,
+		BlockHeight:    1100,
+	}
+
+	// Setup mock for marking forfeited.
+	h.store.On(
+		"MarkForfeited", h.ctx, vtxo.Outpoint, commitmentTxID,
+	).Return(nil)
+
+	_, err := h.sendEvent(evt)
+	require.NoError(t, err)
+
+	// Verify the status update includes ForfeitTx.
+	var statusUpdate *VTXOStatusUpdate
+	for _, msg := range h.outboxMessages {
+		if su, ok := msg.(*VTXOStatusUpdate); ok {
+			statusUpdate = su
+			break
+		}
+	}
+	require.NotNil(t, statusUpdate, "should emit VTXOStatusUpdate")
+	require.NotNil(t, statusUpdate.ForfeitTx,
+		"VTXOStatusUpdate should include ForfeitTx for persistence")
+	require.Equal(t, forfeitTx, statusUpdate.ForfeitTx)
+}
+
+// TestForfeitSignatureValidity verifies that forfeit signatures produced by
+// the VTXO FSM can actually spend the VTXO output when combined with the
+// operator's signature.
+func TestForfeitSignatureValidity(t *testing.T) {
+	t.Parallel()
+
+	h := newRealVTXOSigningHarness(t)
+	vtxo := h.newTestDescriptor()
+
+	h.withState(&LiveState{
+		VTXO:              vtxo,
+		LastCheckedHeight: 100,
+	})
+
+	connectorOutpoint := h.newTestOutpoint()
+	connectorOutput := h.newTestConnectorOutput()
+	serverForfeitScript := h.newServerForfeitScript()
+
+	evt := &round.ForfeitRequestEvent{
+		RoundID:               "round-verify-001",
+		ConnectorOutpoint:     connectorOutpoint,
+		ConnectorPkScript:     connectorOutput.PkScript,
+		ConnectorAmount:       connectorOutput.Value,
+		ServerForfeitPkScript: serverForfeitScript,
+	}
+
+	h.store.On(
+		"UpdateVTXOStatus", h.ctx, vtxo.Outpoint, VTXOStatusForfeiting,
+	).Return(nil)
+
+	_, err := h.sendEvent(evt)
+	require.NoError(t, err)
+
+	submission := assertOutboxContainsReal[*ForfeitSignatureSubmission](h)
+	forfeitTx := submission.ForfeitTx
+
+	// Build the VTXO output for sighash computation.
+	vtxoOutput := &wire.TxOut{
+		Value:    int64(vtxo.Amount),
+		PkScript: vtxo.PkScript,
+	}
+
+	// Create spend contexts for prevout fetcher.
+	vtxoCtx := &tx.VTXOSpendContext{
+		Outpoint:  vtxo.Outpoint,
+		Output:    vtxoOutput,
+		TapScript: vtxo.TapScript,
+	}
+	connectorCtx := &tx.ConnectorSpendContext{
+		Outpoint: connectorOutpoint,
+		Output:   connectorOutput,
+	}
+
+	prevFetcher, err := tx.NewForfeitPrevOutFetcher(vtxoCtx, connectorCtx)
+	require.NoError(t, err)
+
+	sigHashes := txscript.NewTxSigHashes(forfeitTx, prevFetcher)
+
+	// Get the spend info for the collaborative path.
+	spendInfo, err := scripts.NewVTXOSpendInfo(
+		vtxo.TapScript, scripts.VTXOCollabPathLeaf,
+	)
+	require.NoError(t, err)
+
+	// Sign with operator to get second signature.
+	operatorKeyDesc := keychain.KeyDescriptor{
+		PubKey: h.operatorPubKey,
+		KeyLocator: keychain.KeyLocator{
+			Family: keychain.KeyFamilyMultiSig,
+			Index:  0,
+		},
+	}
+
+	operatorSignDesc, _, err := tx.NewVTXOCollabSignDescriptor(
+		vtxoCtx, operatorKeyDesc, tx.ForfeitVTXOInputIndex,
+		sigHashes, prevFetcher,
+	)
+	require.NoError(t, err)
+
+	operatorSig, err := h.operatorSigner.SignOutputRaw(
+		forfeitTx, operatorSignDesc,
+	)
+	require.NoError(t, err)
+
+	// Parse client signature from raw bytes.
+	clientSig, err := schnorr.ParseSignature(submission.Signature)
+	require.NoError(t, err)
+
+	// Build complete witness for collaborative spend.
+	witness, err := scripts.VTXOCollabSpendWitness(
+		clientSig, operatorSig, spendInfo,
+	)
+	require.NoError(t, err)
+
+	forfeitTx.TxIn[tx.ForfeitVTXOInputIndex].Witness = witness
+
+	// Verify the VTXO input can be spent using txscript.NewEngine.
+	engine, err := txscript.NewEngine(
+		vtxoOutput.PkScript, forfeitTx, tx.ForfeitVTXOInputIndex,
+		txscript.StandardVerifyFlags, nil, sigHashes,
+		vtxoOutput.Value, prevFetcher,
+	)
+	require.NoError(t, err)
+
+	err = engine.Execute()
+	require.NoError(t, err, "VTXO input signature verification failed")
+}


### PR DESCRIPTION
This PR implements a finite state machine for managing VTXO lifecycle in the Ark protocol client. The FSM tracks VTXOs through their various states from creation through expiry or forfeiture, enabling proper coordination during batch swaps.

The core states include: `LiveState` (active VTXO), `RefreshingState` (awaiting refresh), `ForfeitingState` (forfeit tx signed, awaiting confirmation), `RefreshedState` (replaced by new VTXO), `ForfeitedState` (forfeit confirmed), `ExpiringState` (approaching expiry), and `ExpiredState` (past expiry window). Each state defines valid transitions based on events like block epochs, forfeit requests, and refresh completions.

The expiry monitoring logic tracks block heights relative to VTXO creation, calculating remaining blocks until expiry. When thresholds are crossed (configurable warning/critical levels), the FSM emits refresh requests or escalates to on-chain resolution. This ensures VTXOs are proactively refreshed before the operator can unilaterally claim them.

For crash recovery, the `ForfeitingState` persists the signed forfeit transaction via `MarkForfeiting()`. On restart, `statusToState()` reconstructs the state with the persisted forfeit tx, allowing the actor to resume monitoring for on-chain confirmation without re-signing.

This PR also includes `lib/actormsg` (shared message interfaces for cross-package actor communication) and `round/vtxo_messages.go` (VTXO actor message types) which define the event types consumed by the FSM. Comprehensive test coverage verifies state transitions, expiry calculations, and forfeit flow behavior.

## Dependencies
- Depends on #68 (tx: add forfeit transaction structure validation)