### PR TITLE
vtxo: implement VTXO actor and manager with round integration

### DIFF
--- a/round/actor_harness_test.go
+++ b/round/actor_harness_test.go
@@ -738,4 +738,4 @@ type unknownClientMsg struct {
 }
 
 func (m *unknownClientMsg) MessageType() string { return "UnknownClientMsg" }
-func (m *unknownClientMsg) clientMsgSealed()    {}
+func (m *unknownClientMsg) RoundReceivable()    {}

--- a/round/actor_messages.go
+++ b/round/actor_messages.go
@@ -5,15 +5,16 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/lib/actormsg"
 	"github.com/lightninglabs/darepo-client/wallet"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 )
 
-// ClientMsg is the sealed interface for all messages that can be sent to a
-// RoundClientActor.
+// ClientMsg embeds actormsg.RoundReceivable for messages that can be sent to a
+// RoundClientActor. Both round-internal messages and messages from other actors
+// (vtxo, wallet) implement the RoundReceivable marker method.
 type ClientMsg interface {
-	actor.Message
-	clientMsgSealed()
+	actormsg.RoundReceivable
 }
 
 // ClientResp is the sealed interface for all response messages from a
@@ -39,7 +40,8 @@ func (m *WalletBoardingConfirmed) MessageType() string {
 	return "WalletBoardingConfirmed"
 }
 
-func (m *WalletBoardingConfirmed) clientMsgSealed() {}
+// RoundReceivable implements actormsg.RoundReceivable marker interface.
+func (m *WalletBoardingConfirmed) RoundReceivable() {}
 
 // ServerMessageNotification delivers a server FSM outbox message to the client.
 type ServerMessageNotification struct {
@@ -54,7 +56,8 @@ func (m *ServerMessageNotification) MessageType() string {
 	return "ServerMessageNotification"
 }
 
-func (m *ServerMessageNotification) clientMsgSealed() {}
+// RoundReceivable implements actormsg.RoundReceivable marker interface.
+func (m *ServerMessageNotification) RoundReceivable() {}
 
 // ServerMessageResponse acknowledges receipt of a server message.
 type ServerMessageResponse struct {
@@ -79,7 +82,8 @@ func (m *GetClientStateRequest) MessageType() string {
 	return "GetClientStateRequest"
 }
 
-func (m *GetClientStateRequest) clientMsgSealed() {}
+// RoundReceivable implements actormsg.RoundReceivable marker interface.
+func (m *GetClientStateRequest) RoundReceivable() {}
 
 // FSMStateInfo contains information about a single FSM's current state.
 type FSMStateInfo struct {
@@ -125,7 +129,8 @@ func (m *CancelRoundRequest) MessageType() string {
 	return "CancelRoundRequest"
 }
 
-func (m *CancelRoundRequest) clientMsgSealed() {}
+// RoundReceivable implements actormsg.RoundReceivable marker interface.
+func (m *CancelRoundRequest) RoundReceivable() {}
 
 // CancelRoundResponse confirms cancellation.
 type CancelRoundResponse struct {
@@ -154,8 +159,8 @@ func (m *RegisterVTXORequestsRequest) MessageType() string {
 	return "RegisterVTXORequestsRequest"
 }
 
-// clientMsgSealed marks this as a client message.
-func (m *RegisterVTXORequestsRequest) clientMsgSealed() {}
+// RoundReceivable implements actormsg.RoundReceivable marker interface.
+func (m *RegisterVTXORequestsRequest) RoundReceivable() {}
 
 // RegisterVTXORequestsResponse acknowledges the request.
 type RegisterVTXORequestsResponse struct {
@@ -199,11 +204,8 @@ func (m *ConfirmationEvent) MessageType() string {
 	return "ConfirmationEvent"
 }
 
-func (m *ConfirmationEvent) clientMsgSealed() {}
-
-// ============================================================================
-// Server Actor Messages
-// ============================================================================
+// RoundReceivable implements actormsg.RoundReceivable marker interface.
+func (m *ConfirmationEvent) RoundReceivable() {}
 
 // ServerMsg is the sealed interface for all messages that can be sent to a
 // RoundServerActor.

--- a/round/events.go
+++ b/round/events.go
@@ -14,6 +14,7 @@ import (
 	"github.com/lightninglabs/darepo-client/wallet"
 	"github.com/lightninglabs/taproot-assets/proof"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/keychain"
 )
 
 // ClientEvent is a sealed interface for all events that can be processed by
@@ -298,6 +299,10 @@ func (e *RoundComplete) clientEventSealed() {}
 // RefreshVTXORequest is sent from a VTXO actor when its VTXO is approaching
 // expiry and needs to be refreshed in a new round. The round actor should
 // queue this VTXO for inclusion in the next batch swap.
+//
+// This request contains all information needed to build both the server's
+// RefreshRequest (for the connector tree) and a VTXORequest (for the new VTXO
+// in the VTXT). The same client key is typically reused for the new VTXO.
 type RefreshVTXORequest struct {
 	actor.BaseMessage
 
@@ -306,6 +311,22 @@ type RefreshVTXORequest struct {
 
 	// Amount is the VTXO value in satoshis.
 	Amount int64
+
+	// NewVTXOKey is the client's public key for the new VTXO. This is
+	// typically the same as the old VTXO's key but could be fresh.
+	NewVTXOKey *btcec.PublicKey
+
+	// PkScript is the output script for the new VTXO.
+	PkScript []byte
+
+	// OperatorKey is the operator's public key for the new VTXO.
+	OperatorKey *btcec.PublicKey
+
+	// Expiry is the CSV delay for the new VTXO's unilateral exit path.
+	Expiry uint32
+
+	// SigningKey is the key descriptor for signing the new VTXO's tree.
+	SigningKey keychain.KeyDescriptor
 }
 
 func (e *RefreshVTXORequest) clientEventSealed() {}

--- a/round/events.go
+++ b/round/events.go
@@ -330,7 +330,6 @@ type RefreshVTXORequest struct {
 }
 
 func (e *RefreshVTXORequest) clientEventSealed() {}
-func (e *RefreshVTXORequest) clientMsgSealed()   {}
 
 // RoundReceivable implements actormsg.RoundReceivable marker interface.
 func (e *RefreshVTXORequest) RoundReceivable() {}
@@ -360,7 +359,6 @@ type ForfeitSignatureResponse struct {
 }
 
 func (e *ForfeitSignatureResponse) clientEventSealed() {}
-func (e *ForfeitSignatureResponse) clientMsgSealed()   {}
 
 // RoundReceivable implements actormsg.RoundReceivable marker interface.
 func (e *ForfeitSignatureResponse) RoundReceivable() {}

--- a/round/events.go
+++ b/round/events.go
@@ -8,6 +8,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/baselib/actor"
 	"github.com/lightninglabs/darepo-client/lib/tree"
 	"github.com/lightninglabs/darepo-client/lib/types"
 	"github.com/lightninglabs/darepo-client/wallet"
@@ -293,3 +294,57 @@ func (e *RecoveryInitiated) clientEventSealed() {}
 type RoundComplete struct{}
 
 func (e *RoundComplete) clientEventSealed() {}
+
+// RefreshVTXORequest is sent from a VTXO actor when its VTXO is approaching
+// expiry and needs to be refreshed in a new round. The round actor should
+// queue this VTXO for inclusion in the next batch swap.
+type RefreshVTXORequest struct {
+	actor.BaseMessage
+
+	// VTXOOutpoint identifies the VTXO to refresh.
+	VTXOOutpoint wire.OutPoint
+
+	// Amount is the VTXO value in satoshis.
+	Amount int64
+}
+
+func (e *RefreshVTXORequest) clientEventSealed() {}
+func (e *RefreshVTXORequest) clientMsgSealed()   {}
+
+// RoundReceivable implements actormsg.RoundReceivable marker interface.
+func (e *RefreshVTXORequest) RoundReceivable() {}
+
+// MessageType returns the message type for logging.
+func (e *RefreshVTXORequest) MessageType() string {
+	return "RefreshVTXORequest"
+}
+
+// ForfeitSignatureResponse is sent from a VTXO actor with its signature for
+// the forfeit transaction. This is the response to a forfeit request during
+// a batch swap round.
+type ForfeitSignatureResponse struct {
+	actor.BaseMessage
+
+	// VTXOOutpoint identifies the VTXO being forfeited.
+	VTXOOutpoint wire.OutPoint
+
+	// RoundID is the round where the forfeit is being processed.
+	RoundID string
+
+	// ForfeitTx is the built forfeit transaction.
+	ForfeitTx *wire.MsgTx
+
+	// Signature is the client's signature for the forfeit tx.
+	Signature []byte
+}
+
+func (e *ForfeitSignatureResponse) clientEventSealed() {}
+func (e *ForfeitSignatureResponse) clientMsgSealed()   {}
+
+// RoundReceivable implements actormsg.RoundReceivable marker interface.
+func (e *ForfeitSignatureResponse) RoundReceivable() {}
+
+// MessageType returns the message type for logging.
+func (e *ForfeitSignatureResponse) MessageType() string {
+	return "ForfeitSignatureResponse"
+}

--- a/round/outbox_messages.go
+++ b/round/outbox_messages.go
@@ -304,11 +304,6 @@ func (m *VTXOCreatedNotification) clientOutMsgSealed() {}
 // VTXOManagerMsg implements actormsg.VTXOManagerMsg marker interface.
 func (m *VTXOCreatedNotification) VTXOManagerMsg() {}
 
-// MessageType returns the message type for logging.
-func (m *VTXOCreatedNotification) MessageType() string {
-	return "VTXOCreatedNotification"
-}
-
 // RoundCompletedNotification is emitted when a round FSM reaches ConfirmedState
 // which signals the actor to perform cleanup (remove from activeRounds,
 // finalize storage). This replaces the need for manual state inspection via

--- a/round/outbox_messages.go
+++ b/round/outbox_messages.go
@@ -1,8 +1,11 @@
 package round
 
 import (
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
 	"github.com/lightninglabs/darepo-client/lib/tree"
 	"github.com/lightninglabs/darepo-client/lib/types"
@@ -22,6 +25,31 @@ type JoinRoundRequest struct {
 
 	// VTXORequests specifies the VTXOs the client wants to receive.
 	VTXORequests []types.VTXORequest
+
+	// RefreshRequests contains VTXOs being refreshed in this round. Each
+	// refresh request specifies an old VTXO to forfeit and details for the
+	// new VTXO to receive. The server includes these in the connector tree
+	// and expects forfeit signatures before broadcasting.
+	RefreshRequests []*RefreshRequest
+
+	// RoundID is optional; when empty it instructs the server to assign
+	// a new round. When non-empty, the request is for the specified round.
+	RoundID string
+}
+
+// RefreshRequest describes a VTXO being refreshed (forfeited to receive a new
+// VTXO in the current round). The old VTXO will be spent via a forfeit tx that
+// atomically links to the new commitment transaction's connector tree.
+type RefreshRequest struct {
+	// VTXOOutpoint identifies the old VTXO to forfeit.
+	VTXOOutpoint wire.OutPoint
+
+	// Amount is the value of the VTXO in satoshis.
+	Amount btcutil.Amount
+
+	// NewVTXOKey is the client's public key for the new VTXO. This may be
+	// the same as the old VTXO's key or a fresh key for improved privacy.
+	NewVTXOKey *btcec.PublicKey
 }
 
 func (m *JoinRoundRequest) clientOutMsgSealed() {}
@@ -112,6 +140,103 @@ func (m *SubmitForfeitSigRequest) ToProto() proto.Message {
 	return nil
 }
 
+// ForfeitRequestToVTXO is emitted by the FSM when a VTXO must sign a forfeit
+// transaction as part of a batch swap. The round actor routes this message to
+// the VTXO actor via its service key. The VTXO actor should sign the forfeit
+// transaction and respond with ForfeitSignatureResponse.
+//
+// This message contains all information needed to construct and sign the
+// forfeit transaction:
+//   - Connector output from new commitment tx (links forfeit atomically)
+//   - Server's forfeit address (where forfeited value is paid)
+type ForfeitRequestToVTXO struct {
+	actor.BaseMessage
+
+	// VTXOOutpoint identifies the VTXO being forfeited.
+	VTXOOutpoint wire.OutPoint
+
+	// RoundID is the new round where the refreshed VTXO will be created.
+	RoundID string
+
+	// ConnectorOutpoint is the connector output from the new commitment tx
+	// that the forfeit tx must spend. This links the forfeit atomically to
+	// the new round - the forfeit is only valid if the new round confirms.
+	ConnectorOutpoint wire.OutPoint
+
+	// ConnectorPkScript is the scriptPubKey of the connector output.
+	ConnectorPkScript []byte
+
+	// ConnectorAmount is the value of the connector output in satoshis.
+	ConnectorAmount int64
+
+	// ServerForfeitPkScript is the operator's taproot script where the
+	// forfeited VTXO value will be paid.
+	ServerForfeitPkScript []byte
+}
+
+func (m *ForfeitRequestToVTXO) clientOutMsgSealed() {}
+
+// MessageType returns the message type for logging.
+func (m *ForfeitRequestToVTXO) MessageType() string {
+	return "ForfeitRequestToVTXO"
+}
+
+// ForfeitConfirmedToVTXO is emitted by the FSM when the commitment transaction
+// confirms, indicating that the forfeit is final. The round actor routes this
+// to old VTXO actors so they can transition to the terminal Forfeited state.
+type ForfeitConfirmedToVTXO struct {
+	actor.BaseMessage
+
+	// VTXOOutpoint identifies the forfeited VTXO.
+	VTXOOutpoint wire.OutPoint
+
+	// CommitmentTxID is the new commitment transaction that confirmed.
+	CommitmentTxID chainhash.Hash
+
+	// BlockHeight is the height at which confirmation occurred.
+	BlockHeight int32
+}
+
+func (m *ForfeitConfirmedToVTXO) clientOutMsgSealed() {}
+
+// MessageType returns the message type for logging.
+func (m *ForfeitConfirmedToVTXO) MessageType() string {
+	return "ForfeitConfirmedToVTXO"
+}
+
+// SubmitVTXOForfeitSigsToServer is emitted by the FSM after collecting all
+// forfeit signatures from VTXO actors. This message contains the signatures
+// for all VTXOs being refreshed in the round and is sent to the server so it
+// can complete the forfeit transactions.
+type SubmitVTXOForfeitSigsToServer struct {
+	actor.BaseMessage
+
+	// RoundID identifies the round.
+	RoundID string
+
+	// ForfeitSigs maps VTXO outpoints to their forfeit transaction
+	// signatures. Each signature is the client's portion of the 2-of-2
+	// collaborative spend from the VTXO.
+	ForfeitSigs map[wire.OutPoint][]byte
+
+	// ForfeitTxs maps VTXO outpoints to the built forfeit transactions.
+	// The server uses these to broadcast after adding its signature.
+	ForfeitTxs map[wire.OutPoint]*wire.MsgTx
+}
+
+func (m *SubmitVTXOForfeitSigsToServer) clientOutMsgSealed() {}
+
+// MessageType returns the message type for logging.
+func (m *SubmitVTXOForfeitSigsToServer) MessageType() string {
+	return "SubmitVTXOForfeitSigsToServer"
+}
+
+// ToProto converts SubmitVTXOForfeitSigsToServer to a protobuf message.
+// TODO: Implement actual proto conversion once proto definitions are available.
+func (m *SubmitVTXOForfeitSigsToServer) ToProto() proto.Message {
+	return nil
+}
+
 // RegisterConfirmationRequest is emitted by the FSM to request chain monitoring
 // for a transaction. The actor will complete this message with the NotifyActor
 // field before sending to ChainSource.
@@ -144,14 +269,29 @@ type RegisterConfirmationRequest struct {
 
 func (m *RegisterConfirmationRequest) clientOutMsgSealed() {}
 
-// VTXOCreatedNotification notifies higher layers (wallet) that new VTXOs are
-// available after successful boarding. This is emitted once the commitment
-// transaction confirms and includes the full descriptors (with tree paths) so
-// the wallet can resume or unroll on-chain if needed.
+// VTXOCreatedNotification notifies higher layers (wallet, VTXO manager) that
+// new VTXOs are available after successful boarding. This is emitted once the
+// commitment transaction confirms and includes the full descriptors (with tree
+// paths) so the wallet can resume or unroll on-chain if needed.
+//
+// Note: TreeDepth is per-VTXO and derivable from ClientVTXO.TreePath.
 type VTXOCreatedNotification struct {
 	actor.BaseMessage
 
+	// VTXOs are the ClientVTXOs created by this round.
 	VTXOs []*ClientVTXO
+
+	// RoundID identifies the round that created these VTXOs.
+	RoundID string
+
+	// CommitmentTxID is the txid of the confirmed commitment transaction.
+	CommitmentTxID chainhash.Hash
+
+	// BatchExpiry is the absolute block height when the batch expires.
+	BatchExpiry int32
+
+	// CreatedHeight is the block height when the commitment tx confirmed.
+	CreatedHeight int32
 }
 
 // MessageType returns the message type identifier for logging and debugging.
@@ -160,6 +300,14 @@ func (m *VTXOCreatedNotification) MessageType() string {
 }
 
 func (m *VTXOCreatedNotification) clientOutMsgSealed() {}
+
+// VTXOManagerMsg implements actormsg.VTXOManagerMsg marker interface.
+func (m *VTXOCreatedNotification) VTXOManagerMsg() {}
+
+// MessageType returns the message type for logging.
+func (m *VTXOCreatedNotification) MessageType() string {
+	return "VTXOCreatedNotification"
+}
 
 // RoundCompletedNotification is emitted when a round FSM reaches ConfirmedState
 // which signals the actor to perform cleanup (remove from activeRounds,

--- a/vtxo/actor.go
+++ b/vtxo/actor.go
@@ -10,19 +10,19 @@ import (
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
 	"github.com/lightninglabs/darepo-client/chainsource"
+	"github.com/lightninglabs/darepo-client/lib/actormsg"
 	"github.com/lightninglabs/darepo-client/round"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 )
 
-// VTXOActorServiceKey constructs a service key for a VTXO actor based on its
-// outpoint. This enables the round actor to send messages directly to specific
-// VTXO actors without routing through the manager.
+// VTXOActorServiceKey returns the service key for looking up a VTXO actor.
+// This delegates to actormsg.VTXOActorServiceKey to ensure both packages use
+// the same key for registration and lookup, avoiding type mismatches.
 func VTXOActorServiceKey(outpoint wire.OutPoint) actor.ServiceKey[
-	VTXOEvent, VTXOActorResponse,
+	actormsg.VTXOActorMsg, actormsg.VTXOActorResp,
 ] {
-	return actor.NewServiceKey[VTXOEvent, VTXOActorResponse](
-		fmt.Sprintf("vtxo.%s", outpoint.String()),
-	)
+
+	return actormsg.VTXOActorServiceKey(outpoint)
 }
 
 // VTXOActorConfig holds configuration for a single VTXO actor.
@@ -56,11 +56,13 @@ type VTXOActor struct {
 	state VTXOState
 	env   *VTXOEnvironment
 
-	selfRef actor.TellOnlyRef[VTXOEvent]
+	selfRef actor.TellOnlyRef[actormsg.VTXOActorMsg]
 }
 
-// NewVTXOActor creates a new VTXO actor with the given configuration.
-func NewVTXOActor(cfg *VTXOActorConfig) *VTXOActor {
+// NewVTXOActor creates a new VTXO actor with the given configuration. For
+// actors being recovered from storage (e.g., in forfeiting state), this
+// fetches persisted data like the forfeit tx.
+func NewVTXOActor(ctx context.Context, cfg *VTXOActorConfig) *VTXOActor {
 	actorID := fmt.Sprintf("vtxo.%s", cfg.VTXO.Outpoint.String())
 	env := NewVTXOEnvironment(
 		actorID, cfg.Store, cfg.Wallet, cfg.ExpiryConfig,
@@ -69,14 +71,14 @@ func NewVTXOActor(cfg *VTXOActorConfig) *VTXOActor {
 
 	return &VTXOActor{
 		cfg:   cfg,
-		state: statusToState(cfg.VTXO),
+		state: statusToState(ctx, cfg.VTXO, cfg.Store, cfg.Logger),
 		env:   env,
 	}
 }
 
 // Start initializes the actor and subscribes to block epochs.
 func (a *VTXOActor) Start(ctx context.Context,
-	selfRef actor.TellOnlyRef[VTXOEvent]) error {
+	selfRef actor.TellOnlyRef[actormsg.VTXOActorMsg]) error {
 
 	a.selfRef = selfRef
 
@@ -94,12 +96,23 @@ func (a *VTXOActor) Stop(ctx context.Context) {
 }
 
 // Receive processes incoming events and returns outbox messages for dispatch.
+// The return type is actormsg.VTXOActorResp (interface) which VTXOActorResponse
+// implements via the VTXOActorResp() marker method.
 func (a *VTXOActor) Receive(ctx context.Context,
-	event VTXOEvent) fn.Result[VTXOActorResponse] {
+	event actormsg.VTXOActorMsg) fn.Result[actormsg.VTXOActorResp] {
 
-	transition, err := a.state.ProcessEvent(ctx, event, a.env)
+	vtxoEvent, ok := event.(VTXOEvent)
+	if !ok {
+		return fn.Err[actormsg.VTXOActorResp](
+			fmt.Errorf("unexpected event type: %T", event),
+		)
+	}
+
+	transition, err := a.state.ProcessEvent(ctx, vtxoEvent, a.env)
 	if err != nil {
-		return fn.Err[VTXOActorResponse](fmt.Errorf("process event: %w", err))
+		return fn.Err[actormsg.VTXOActorResp](
+			fmt.Errorf("process event: %w", err),
+		)
 	}
 
 	priorState := a.state
@@ -107,7 +120,7 @@ func (a *VTXOActor) Receive(ctx context.Context,
 	// Type assert the next state to VTXOState.
 	nextState, ok := transition.NextState.(VTXOState)
 	if !ok {
-		return fn.Err[VTXOActorResponse](fmt.Errorf(
+		return fn.Err[actormsg.VTXOActorResp](fmt.Errorf(
 			"unexpected state type: %T", transition.NextState,
 		))
 	}
@@ -127,7 +140,7 @@ func (a *VTXOActor) Receive(ctx context.Context,
 	// Process persistence updates immediately.
 	a.processOutbox(ctx, outbox)
 
-	return fn.Ok(VTXOActorResponse{
+	return fn.Ok[actormsg.VTXOActorResp](VTXOActorResponse{
 		PriorState: priorState,
 		NewState:   a.state,
 		Outbox:     outbox,
@@ -141,7 +154,23 @@ func (a *VTXOActor) processOutbox(ctx context.Context, outbox []VTXOOutMsg) {
 	for _, msg := range outbox {
 		switch m := msg.(type) {
 		case *VTXOStatusUpdate:
-			err := a.cfg.Store.UpdateVTXOStatus(ctx, m.Outpoint, m.NewStatus)
+			// For forfeiting status with a forfeit tx, use
+			// MarkForfeiting to persist both status and the signed
+			// tx for crash recovery.
+			var err error
+			isForfeitingWithTx :=
+				m.NewStatus == VTXOStatusForfeiting &&
+					m.ForfeitTx != nil
+
+			if isForfeitingWithTx {
+				err = a.cfg.Store.MarkForfeiting(
+					ctx, m.Outpoint, m.RoundID, m.ForfeitTx,
+				)
+			} else {
+				err = a.cfg.Store.UpdateVTXOStatus(
+					ctx, m.Outpoint, m.NewStatus,
+				)
+			}
 			if err != nil {
 				a.cfg.Logger.ErrorS(ctx,
 					"Failed to update VTXO status", err,
@@ -151,11 +180,20 @@ func (a *VTXOActor) processOutbox(ctx context.Context, outbox []VTXOOutMsg) {
 			}
 
 		case *RefreshRequest:
-			// Route refresh request to round actor.
+			// Route refresh request to round actor. Include all
+			// fields needed to build the server's RefreshRequest
+			// and VTXORequest. We reuse the same client key for the
+			// new VTXO.
 			if a.cfg.RoundActor != nil {
+				vtxo := a.cfg.VTXO
 				a.cfg.RoundActor.Tell(ctx, &round.RefreshVTXORequest{
 					VTXOOutpoint: m.VTXOOutpoint,
 					Amount:       m.Amount,
+					NewVTXOKey:   vtxo.ClientKey.PubKey,
+					PkScript:     vtxo.PkScript,
+					OperatorKey:  vtxo.OperatorKey,
+					Expiry:       vtxo.RelativeExpiry,
+					SigningKey:   vtxo.ClientKey,
 				})
 				a.cfg.Logger.InfoS(ctx, "Sent refresh request",
 					slog.String("outpoint", m.VTXOOutpoint.String()),
@@ -209,7 +247,7 @@ func (a *VTXOActor) subscribeBlockEpochs(ctx context.Context) error {
 	callerID := fmt.Sprintf("vtxo.%s", a.cfg.VTXO.Outpoint.String())
 
 	epochRef := chainsource.MapBlockEpoch(a.selfRef,
-		func(epoch chainsource.BlockEpoch) VTXOEvent {
+		func(epoch chainsource.BlockEpoch) actormsg.VTXOActorMsg {
 			return &BlockEpochEvent{
 				Height:    epoch.Height,
 				Hash:      epoch.Hash,
@@ -259,8 +297,15 @@ type VTXOActorResponse struct {
 	Outbox     []VTXOOutMsg
 }
 
+// VTXOActorResp implements actormsg.VTXOActorResp marker interface.
+func (VTXOActorResponse) VTXOActorResp() {}
+
 // statusToState converts a persisted VTXOStatus to the appropriate FSM state.
-func statusToState(vtxo *Descriptor) VTXOState {
+// For forfeiting state, it fetches the persisted forfeit tx for crash recovery.
+func statusToState(
+	ctx context.Context, vtxo *Descriptor, store VTXOStore, logger btclog.Logger,
+) VTXOState {
+
 	switch vtxo.Status {
 	case VTXOStatusLive:
 		return &LiveState{
@@ -272,7 +317,24 @@ func statusToState(vtxo *Descriptor) VTXOState {
 		return &RefreshRequestedState{VTXO: vtxo, RequestedAtHeight: 0}
 
 	case VTXOStatusForfeiting:
-		return &ForfeitingState{VTXO: vtxo, NewRoundID: vtxo.RoundID}
+		// Fetch the persisted forfeit tx for crash recovery.
+		var forfeitTx *wire.MsgTx
+		if store != nil {
+			tx, err := store.GetForfeitTx(ctx, vtxo.Outpoint)
+			if err != nil && logger != nil {
+				logger.WarnS(
+					ctx, "Could not get forfeit tx", err,
+					slog.String("outpoint", vtxo.Outpoint.String()),
+				)
+			}
+			forfeitTx = tx
+		}
+
+		return &ForfeitingState{
+			VTXO:       vtxo,
+			NewRoundID: vtxo.RoundID,
+			ForfeitTx:  forfeitTx,
+		}
 
 	case VTXOStatusForfeited:
 		return &ForfeitedState{VTXO: vtxo, NewRoundID: vtxo.RoundID}

--- a/vtxo/actor.go
+++ b/vtxo/actor.go
@@ -1,0 +1,298 @@
+package vtxo
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/chainsource"
+	"github.com/lightninglabs/darepo-client/round"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+)
+
+// VTXOActorServiceKey constructs a service key for a VTXO actor based on its
+// outpoint. This enables the round actor to send messages directly to specific
+// VTXO actors without routing through the manager.
+func VTXOActorServiceKey(outpoint wire.OutPoint) actor.ServiceKey[
+	VTXOEvent, VTXOActorResponse,
+] {
+	return actor.NewServiceKey[VTXOEvent, VTXOActorResponse](
+		fmt.Sprintf("vtxo.%s", outpoint.String()),
+	)
+}
+
+// VTXOActorConfig holds configuration for a single VTXO actor.
+type VTXOActorConfig struct {
+	VTXO        *Descriptor
+	Store       VTXOStore
+	Wallet      VTXOWallet
+	ChainSource actor.ActorRef[
+		chainsource.ChainSourceMsg, chainsource.ChainSourceResp,
+	]
+	ChainParams  *chaincfg.Params
+	ExpiryConfig *ExpiryConfig
+	Logger       btclog.Logger
+
+	// RoundActor receives refresh requests and forfeit signatures from this
+	// VTXO actor.
+	RoundActor actor.TellOnlyRef[round.ClientMsg]
+
+	// ChainResolver receives expiring notifications for unilateral exit.
+	ChainResolver actor.TellOnlyRef[ExpiringNotification]
+
+	// Manager receives termination notifications for cleanup.
+	Manager actor.TellOnlyRef[ManagerMsg]
+}
+
+// VTXOActor manages the lifecycle of a single VTXO. It processes events using
+// the FSM state machine pattern, subscribes to block epochs for expiry
+// monitoring, and returns outbox messages for the caller to dispatch.
+type VTXOActor struct {
+	cfg   *VTXOActorConfig
+	state VTXOState
+	env   *VTXOEnvironment
+
+	selfRef actor.TellOnlyRef[VTXOEvent]
+}
+
+// NewVTXOActor creates a new VTXO actor with the given configuration.
+func NewVTXOActor(cfg *VTXOActorConfig) *VTXOActor {
+	actorID := fmt.Sprintf("vtxo.%s", cfg.VTXO.Outpoint.String())
+	env := NewVTXOEnvironment(
+		actorID, cfg.Store, cfg.Wallet, cfg.ExpiryConfig,
+		cfg.ChainParams,
+	)
+
+	return &VTXOActor{
+		cfg:   cfg,
+		state: statusToState(cfg.VTXO),
+		env:   env,
+	}
+}
+
+// Start initializes the actor and subscribes to block epochs.
+func (a *VTXOActor) Start(ctx context.Context,
+	selfRef actor.TellOnlyRef[VTXOEvent]) error {
+
+	a.selfRef = selfRef
+
+	// Don't subscribe to epochs if already in a terminal state.
+	if a.state.IsTerminal() {
+		return nil
+	}
+
+	return a.subscribeBlockEpochs(ctx)
+}
+
+// Stop unsubscribes from block epochs.
+func (a *VTXOActor) Stop(ctx context.Context) {
+	a.unsubscribeBlockEpochs(ctx)
+}
+
+// Receive processes incoming events and returns outbox messages for dispatch.
+func (a *VTXOActor) Receive(ctx context.Context,
+	event VTXOEvent) fn.Result[VTXOActorResponse] {
+
+	transition, err := a.state.ProcessEvent(ctx, event, a.env)
+	if err != nil {
+		return fn.Err[VTXOActorResponse](fmt.Errorf("process event: %w", err))
+	}
+
+	priorState := a.state
+
+	// Type assert the next state to VTXOState.
+	nextState, ok := transition.NextState.(VTXOState)
+	if !ok {
+		return fn.Err[VTXOActorResponse](fmt.Errorf(
+			"unexpected state type: %T", transition.NextState,
+		))
+	}
+	a.state = nextState
+
+	// Unsubscribe from block epochs when reaching terminal state.
+	if a.state.IsTerminal() && !priorState.IsTerminal() {
+		a.unsubscribeBlockEpochs(ctx)
+	}
+
+	// Extract outbox messages for caller to dispatch.
+	var outbox []VTXOOutMsg
+	transition.NewEvents.WhenSome(func(emitted VTXOEmittedEvent) {
+		outbox = emitted.Outbox
+	})
+
+	// Process persistence updates immediately.
+	a.processOutbox(ctx, outbox)
+
+	return fn.Ok(VTXOActorResponse{
+		PriorState: priorState,
+		NewState:   a.state,
+		Outbox:     outbox,
+	})
+}
+
+// processOutbox routes outbox messages to their destinations. This includes
+// persistence updates, messages to the round actor, chain resolver, and
+// manager for cleanup.
+func (a *VTXOActor) processOutbox(ctx context.Context, outbox []VTXOOutMsg) {
+	for _, msg := range outbox {
+		switch m := msg.(type) {
+		case *VTXOStatusUpdate:
+			err := a.cfg.Store.UpdateVTXOStatus(ctx, m.Outpoint, m.NewStatus)
+			if err != nil {
+				a.cfg.Logger.ErrorS(ctx,
+					"Failed to update VTXO status", err,
+					slog.String("outpoint", m.Outpoint.String()),
+					slog.String("status", m.NewStatus.String()),
+				)
+			}
+
+		case *RefreshRequest:
+			// Route refresh request to round actor.
+			if a.cfg.RoundActor != nil {
+				a.cfg.RoundActor.Tell(ctx, &round.RefreshVTXORequest{
+					VTXOOutpoint: m.VTXOOutpoint,
+					Amount:       m.Amount,
+				})
+				a.cfg.Logger.InfoS(ctx, "Sent refresh request",
+					slog.String("outpoint", m.VTXOOutpoint.String()),
+					slog.String("urgency", m.Urgency.String()),
+				)
+			}
+
+		case *ForfeitSignatureSubmission:
+			// Route forfeit signature to round actor.
+			if a.cfg.RoundActor != nil {
+				resp := &round.ForfeitSignatureResponse{
+					VTXOOutpoint: m.VTXOOutpoint,
+					RoundID:      m.RoundID,
+					ForfeitTx:    m.ForfeitTx,
+					Signature:    m.Signature,
+				}
+				a.cfg.RoundActor.Tell(ctx, resp)
+				a.cfg.Logger.InfoS(
+					ctx, "Sent forfeit signature",
+					slog.String("outpoint", m.VTXOOutpoint.String()),
+					slog.String("round_id", m.RoundID),
+				)
+			}
+
+		case *ExpiringNotification:
+			// Route to chain resolver for unilateral exit handling.
+			if a.cfg.ChainResolver != nil {
+				a.cfg.ChainResolver.Tell(ctx, *m)
+				a.cfg.Logger.WarnS(
+					ctx, "VTXO sent to chain resolver", nil,
+					slog.String("outpoint", m.VTXO.Outpoint.String()),
+					slog.Int("blocks_remaining", int(m.BlocksRemaining)),
+				)
+			}
+
+		case *VTXOTerminatedNotification:
+			// Notify manager to remove this actor from tracking.
+			if a.cfg.Manager != nil {
+				a.cfg.Manager.Tell(ctx, &VTXOTerminatedMsg{
+					Outpoint:   m.VTXOOutpoint,
+					FinalState: m.FinalState,
+					Reason:     m.Reason,
+				})
+			}
+		}
+	}
+}
+
+// subscribeBlockEpochs registers for block notifications with chainsource.
+func (a *VTXOActor) subscribeBlockEpochs(ctx context.Context) error {
+	callerID := fmt.Sprintf("vtxo.%s", a.cfg.VTXO.Outpoint.String())
+
+	epochRef := chainsource.MapBlockEpoch(a.selfRef,
+		func(epoch chainsource.BlockEpoch) VTXOEvent {
+			return &BlockEpochEvent{
+				Height:    epoch.Height,
+				Hash:      epoch.Hash,
+				Timestamp: epoch.Timestamp,
+			}
+		},
+	)
+
+	req := &chainsource.SubscribeBlocksRequest{
+		CallerID:    callerID,
+		NotifyActor: fn.Some(epochRef),
+	}
+
+	future := a.cfg.ChainSource.Ask(ctx, req)
+	result := future.Await(ctx)
+	if result.IsErr() {
+		return fmt.Errorf("subscribe blocks: %w", result.Err())
+	}
+
+	a.cfg.Logger.DebugS(ctx, "Subscribed to block epochs",
+		slog.String("vtxo", a.cfg.VTXO.Outpoint.String()))
+
+	return nil
+}
+
+// unsubscribeBlockEpochs cancels the block epoch subscription.
+func (a *VTXOActor) unsubscribeBlockEpochs(ctx context.Context) {
+	callerID := fmt.Sprintf("vtxo.%s", a.cfg.VTXO.Outpoint.String())
+
+	a.cfg.ChainSource.Tell(ctx, &chainsource.UnsubscribeBlocksRequest{
+		CallerID: callerID,
+	})
+
+	a.cfg.Logger.DebugS(ctx, "Unsubscribed from block epochs",
+		slog.String("vtxo", a.cfg.VTXO.Outpoint.String()))
+}
+
+// CurrentState returns the actor's current FSM state.
+func (a *VTXOActor) CurrentState() VTXOState {
+	return a.state
+}
+
+// VTXOActorResponse is returned from processing an event.
+type VTXOActorResponse struct {
+	PriorState VTXOState
+	NewState   VTXOState
+	Outbox     []VTXOOutMsg
+}
+
+// statusToState converts a persisted VTXOStatus to the appropriate FSM state.
+func statusToState(vtxo *Descriptor) VTXOState {
+	switch vtxo.Status {
+	case VTXOStatusLive:
+		return &LiveState{
+			VTXO:              vtxo,
+			LastCheckedHeight: vtxo.CreatedHeight,
+		}
+
+	case VTXOStatusRefreshRequested:
+		return &RefreshRequestedState{VTXO: vtxo, RequestedAtHeight: 0}
+
+	case VTXOStatusForfeiting:
+		return &ForfeitingState{VTXO: vtxo, NewRoundID: vtxo.RoundID}
+
+	case VTXOStatusForfeited:
+		return &ForfeitedState{VTXO: vtxo, NewRoundID: vtxo.RoundID}
+
+	case VTXOStatusExpiring:
+		return &ExpiringState{
+			VTXO:   vtxo,
+			Reason: "recovered from storage",
+		}
+
+	case VTXOStatusFailed:
+		return &FailedState{
+			VTXO:   vtxo,
+			Reason: "recovered from storage",
+		}
+
+	default:
+		return &LiveState{
+			VTXO:              vtxo,
+			LastCheckedHeight: vtxo.CreatedHeight,
+		}
+	}
+}

--- a/vtxo/actor.go
+++ b/vtxo/actor.go
@@ -186,7 +186,7 @@ func (a *VTXOActor) processOutbox(ctx context.Context, outbox []VTXOOutMsg) {
 			// new VTXO.
 			if a.cfg.RoundActor != nil {
 				vtxo := a.cfg.VTXO
-				a.cfg.RoundActor.Tell(ctx, &round.RefreshVTXORequest{
+				req := &round.RefreshVTXORequest{
 					VTXOOutpoint: m.VTXOOutpoint,
 					Amount:       m.Amount,
 					NewVTXOKey:   vtxo.ClientKey.PubKey,
@@ -194,7 +194,8 @@ func (a *VTXOActor) processOutbox(ctx context.Context, outbox []VTXOOutMsg) {
 					OperatorKey:  vtxo.OperatorKey,
 					Expiry:       vtxo.RelativeExpiry,
 					SigningKey:   vtxo.ClientKey,
-				})
+				}
+				a.cfg.RoundActor.Tell(ctx, req)
 				a.cfg.Logger.InfoS(ctx, "Sent refresh request",
 					slog.String("outpoint", m.VTXOOutpoint.String()),
 					slog.String("urgency", m.Urgency.String()),

--- a/vtxo/actor_test.go
+++ b/vtxo/actor_test.go
@@ -1,0 +1,396 @@
+package vtxo
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/round"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProcessOutboxForfeitSignature verifies that ForfeitSignatureSubmission
+// messages in the outbox are routed to the round actor.
+func TestProcessOutboxForfeitSignature(t *testing.T) {
+	t.Parallel()
+
+	h := newVTXOTestHarness(t)
+	vtxo := h.newTestDescriptor()
+
+	roundActor := newMockRoundActorRef(t)
+	actor := &VTXOActor{
+		cfg: &VTXOActorConfig{
+			VTXO:        vtxo,
+			Store:       h.store,
+			Wallet:      h.wallet,
+			ChainParams: &chaincfg.RegressionNetParams,
+			RoundActor:  roundActor,
+			Logger:      btclog.Disabled,
+		},
+		state: &LiveState{VTXO: vtxo},
+		env:   h.env,
+	}
+
+	forfeitTx := wire.NewMsgTx(2)
+	forfeitTx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: vtxo.Outpoint,
+	})
+	forfeitTx.AddTxOut(&wire.TxOut{
+		Value:    int64(vtxo.Amount),
+		PkScript: []byte{0x51, 0x20},
+	})
+
+	outbox := []VTXOOutMsg{
+		&ForfeitSignatureSubmission{
+			VTXOOutpoint: vtxo.Outpoint,
+			RoundID:      "round-123",
+			ForfeitTx:    forfeitTx,
+			Signature:    []byte{0x30, 0x44},
+		},
+	}
+
+	actor.processOutbox(h.ctx, outbox)
+
+	msgs := roundActor.getMessages()
+	require.Len(t, msgs, 1)
+
+	resp, ok := msgs[0].(*round.ForfeitSignatureResponse)
+	require.True(
+		t, ok, "expected ForfeitSignatureResponse, got %T", msgs[0],
+	)
+	require.Equal(t, vtxo.Outpoint, resp.VTXOOutpoint)
+	require.Equal(t, "round-123", resp.RoundID)
+	require.NotNil(t, resp.ForfeitTx)
+	require.Equal(t, []byte{0x30, 0x44}, resp.Signature)
+}
+
+// TestProcessOutboxMarkForfeiting verifies that VTXOStatusUpdate with
+// forfeiting status and a forfeit tx calls MarkForfeiting on the store.
+func TestProcessOutboxMarkForfeiting(t *testing.T) {
+	t.Parallel()
+
+	h := newVTXOTestHarness(t)
+	vtxo := h.newTestDescriptor()
+
+	forfeitTx := wire.NewMsgTx(2)
+	forfeitTx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: vtxo.Outpoint,
+	})
+
+	actor := &VTXOActor{
+		cfg: &VTXOActorConfig{
+			VTXO:        vtxo,
+			Store:       h.store,
+			ChainParams: &chaincfg.RegressionNetParams,
+			Logger:      btclog.Disabled,
+		},
+		state: &LiveState{VTXO: vtxo},
+		env:   h.env,
+	}
+
+	h.store.On(
+		"MarkForfeiting", h.ctx, vtxo.Outpoint, "round-456", forfeitTx,
+	).Return(nil)
+
+	outbox := []VTXOOutMsg{
+		&VTXOStatusUpdate{
+			Outpoint:  vtxo.Outpoint,
+			NewStatus: VTXOStatusForfeiting,
+			RoundID:   "round-456",
+			ForfeitTx: forfeitTx,
+		},
+	}
+
+	actor.processOutbox(h.ctx, outbox)
+
+	h.store.AssertCalled(
+		t, "MarkForfeiting", h.ctx, vtxo.Outpoint,
+		"round-456", forfeitTx,
+	)
+}
+
+// TestProcessOutboxStatusUpdate verifies that VTXOStatusUpdate without a
+// forfeit tx calls UpdateVTXOStatus on the store.
+func TestProcessOutboxStatusUpdate(t *testing.T) {
+	t.Parallel()
+
+	h := newVTXOTestHarness(t)
+	vtxo := h.newTestDescriptor()
+
+	actor := &VTXOActor{
+		cfg: &VTXOActorConfig{
+			VTXO:        vtxo,
+			Store:       h.store,
+			ChainParams: &chaincfg.RegressionNetParams,
+			Logger:      btclog.Disabled,
+		},
+		state: &LiveState{VTXO: vtxo},
+		env:   h.env,
+	}
+
+	h.store.On(
+		"UpdateVTXOStatus", h.ctx, vtxo.Outpoint, VTXOStatusRefreshRequested,
+	).Return(nil)
+
+	outbox := []VTXOOutMsg{
+		&VTXOStatusUpdate{
+			Outpoint:  vtxo.Outpoint,
+			NewStatus: VTXOStatusRefreshRequested,
+		},
+	}
+
+	actor.processOutbox(h.ctx, outbox)
+
+	h.store.AssertCalled(
+		t, "UpdateVTXOStatus", h.ctx, vtxo.Outpoint,
+		VTXOStatusRefreshRequested,
+	)
+}
+
+// TestProcessOutboxRefreshRequest verifies that RefreshRequest messages in the
+// outbox are routed to the round actor with the correct fields populated.
+func TestProcessOutboxRefreshRequest(t *testing.T) {
+	t.Parallel()
+
+	h := newVTXOTestHarness(t)
+	vtxo := h.newTestDescriptor()
+
+	roundActor := newMockRoundActorRef(t)
+	actor := &VTXOActor{
+		cfg: &VTXOActorConfig{
+			VTXO:        vtxo,
+			Store:       h.store,
+			Wallet:      h.wallet,
+			ChainParams: &chaincfg.RegressionNetParams,
+			RoundActor:  roundActor,
+			Logger:      btclog.Disabled,
+		},
+		state: &LiveState{VTXO: vtxo},
+		env:   h.env,
+	}
+
+	outbox := []VTXOOutMsg{
+		&RefreshRequest{
+			VTXOOutpoint: vtxo.Outpoint,
+			Amount:       int64(vtxo.Amount),
+			Urgency:      RefreshUrgencyNormal,
+		},
+	}
+
+	actor.processOutbox(h.ctx, outbox)
+
+	msgs := roundActor.getMessages()
+	require.Len(t, msgs, 1)
+
+	req, ok := msgs[0].(*round.RefreshVTXORequest)
+	require.True(t, ok, "expected RefreshVTXORequest, got %T", msgs[0])
+	require.Equal(t, vtxo.Outpoint, req.VTXOOutpoint)
+	require.Equal(t, int64(vtxo.Amount), req.Amount)
+	require.Equal(t, vtxo.ClientKey.PubKey, req.NewVTXOKey)
+	require.Equal(t, vtxo.OperatorKey, req.OperatorKey)
+	require.Equal(t, vtxo.RelativeExpiry, req.Expiry)
+}
+
+// TestProcessOutboxTerminatedNotification verifies that
+// VTXOTerminatedNotification messages are routed to the manager.
+func TestProcessOutboxTerminatedNotification(t *testing.T) {
+	t.Parallel()
+
+	h := newVTXOTestHarness(t)
+	vtxo := h.newTestDescriptor()
+
+	manager := newMockManagerRef(t)
+	actor := &VTXOActor{
+		cfg: &VTXOActorConfig{
+			VTXO:        vtxo,
+			Store:       h.store,
+			ChainParams: &chaincfg.RegressionNetParams,
+			Manager:     manager,
+			Logger:      btclog.Disabled,
+		},
+		state: &ForfeitedState{VTXO: vtxo},
+		env:   h.env,
+	}
+
+	outbox := []VTXOOutMsg{
+		&VTXOTerminatedNotification{
+			VTXOOutpoint: vtxo.Outpoint,
+			FinalState:   "forfeited",
+			Reason:       "forfeit confirmed",
+		},
+	}
+
+	actor.processOutbox(h.ctx, outbox)
+
+	msgs := manager.getMessages()
+	require.Len(t, msgs, 1)
+
+	termMsg, ok := msgs[0].(*VTXOTerminatedMsg)
+	require.True(t, ok, "expected VTXOTerminatedMsg, got %T", msgs[0])
+	require.Equal(t, vtxo.Outpoint, termMsg.Outpoint)
+	require.Equal(t, "forfeited", termMsg.FinalState)
+	require.Equal(t, "forfeit confirmed", termMsg.Reason)
+}
+
+// TestProcessOutboxExpiringNotification verifies that ExpiringNotification
+// messages are routed to the chain resolver.
+func TestProcessOutboxExpiringNotification(t *testing.T) {
+	t.Parallel()
+
+	h := newVTXOTestHarness(t)
+	vtxo := h.newTestDescriptor()
+
+	chainResolver := newMockChainResolverRef(t)
+	actor := &VTXOActor{
+		cfg: &VTXOActorConfig{
+			VTXO:          vtxo,
+			Store:         h.store,
+			ChainParams:   &chaincfg.RegressionNetParams,
+			ChainResolver: chainResolver,
+			Logger:        btclog.Disabled,
+		},
+		state: &ExpiringState{VTXO: vtxo},
+		env:   h.env,
+	}
+
+	outbox := []VTXOOutMsg{
+		&ExpiringNotification{
+			VTXO:            vtxo,
+			BlocksRemaining: 10,
+			Reason:          "approaching expiry",
+		},
+	}
+
+	actor.processOutbox(h.ctx, outbox)
+
+	msgs := chainResolver.getMessages()
+	require.Len(t, msgs, 1)
+	require.Equal(t, vtxo, msgs[0].VTXO)
+	require.Equal(t, int32(10), msgs[0].BlocksRemaining)
+}
+
+// TestActorRecoveryFromForfeiting verifies that statusToState correctly
+// recovers a ForfeitingState with the persisted forfeit tx.
+func TestActorRecoveryFromForfeiting(t *testing.T) {
+	t.Parallel()
+
+	h := newVTXOTestHarness(t)
+	vtxo := h.newTestDescriptor()
+	vtxo.Status = VTXOStatusForfeiting
+	vtxo.RoundID = "round-789"
+
+	forfeitTx := wire.NewMsgTx(2)
+	forfeitTx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: vtxo.Outpoint,
+	})
+
+	h.store.On("GetForfeitTx", mock.Anything, vtxo.Outpoint).Return(
+		forfeitTx, nil,
+	)
+
+	state := statusToState(h.ctx, vtxo, h.store, btclog.Disabled)
+
+	forfeitingState, ok := state.(*ForfeitingState)
+	require.True(t, ok, "expected ForfeitingState, got %T", state)
+	require.Equal(t, vtxo, forfeitingState.VTXO)
+	require.Equal(t, "round-789", forfeitingState.NewRoundID)
+	require.NotNil(t, forfeitingState.ForfeitTx)
+	require.Equal(t, forfeitTx.TxHash(), forfeitingState.ForfeitTx.TxHash())
+}
+
+// TestActorRecoveryFromForfeitingNoTx verifies statusToState handles the case
+// where no forfeit tx is persisted (crash before MarkForfeiting completed).
+func TestActorRecoveryFromForfeitingNoTx(t *testing.T) {
+	t.Parallel()
+
+	h := newVTXOTestHarness(t)
+	vtxo := h.newTestDescriptor()
+	vtxo.Status = VTXOStatusForfeiting
+	vtxo.RoundID = "round-999"
+
+	h.store.On("GetForfeitTx", mock.Anything, vtxo.Outpoint).Return(
+		nil, nil,
+	)
+
+	state := statusToState(h.ctx, vtxo, h.store, btclog.Disabled)
+
+	forfeitingState, ok := state.(*ForfeitingState)
+	require.True(t, ok, "expected ForfeitingState, got %T", state)
+	require.Equal(t, vtxo, forfeitingState.VTXO)
+	require.Nil(t, forfeitingState.ForfeitTx)
+}
+
+// TestStatusToStateLive verifies statusToState returns LiveState for live
+// VTXOs.
+func TestStatusToStateLive(t *testing.T) {
+	t.Parallel()
+
+	h := newVTXOTestHarness(t)
+	vtxo := h.newTestDescriptor()
+	vtxo.Status = VTXOStatusLive
+	vtxo.CreatedHeight = 500
+
+	state := statusToState(h.ctx, vtxo, h.store, btclog.Disabled)
+
+	liveState, ok := state.(*LiveState)
+	require.True(t, ok, "expected LiveState, got %T", state)
+	require.Equal(t, vtxo, liveState.VTXO)
+	require.Equal(t, int32(500), liveState.LastCheckedHeight)
+}
+
+// TestStatusToStateForfeited verifies statusToState returns ForfeitedState for
+// forfeited VTXOs.
+func TestStatusToStateForfeited(t *testing.T) {
+	t.Parallel()
+
+	h := newVTXOTestHarness(t)
+	vtxo := h.newTestDescriptor()
+	vtxo.Status = VTXOStatusForfeited
+	vtxo.RoundID = "round-final"
+
+	state := statusToState(h.ctx, vtxo, h.store, btclog.Disabled)
+
+	forfeitedState, ok := state.(*ForfeitedState)
+	require.True(t, ok, "expected ForfeitedState, got %T", state)
+	require.Equal(t, vtxo, forfeitedState.VTXO)
+	require.Equal(t, "round-final", forfeitedState.NewRoundID)
+}
+
+// TestManagerGetActiveVTXOCount verifies the Manager returns the correct count
+// of active VTXO actors when queried via GetActiveVTXOCountRequest.
+func TestManagerGetActiveVTXOCount(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	// Create manager with empty actors map.
+	manager := &Manager{
+		actors: make(map[wire.OutPoint]VTXOActorRef),
+	}
+
+	// Test empty state returns zero.
+	result := manager.Receive(ctx, &GetActiveVTXOCountRequest{})
+	resp, err := result.Unpack()
+	require.NoError(t, err)
+
+	countResp, ok := resp.(*GetActiveVTXOCountResponse)
+	require.True(t, ok, "expected GetActiveVTXOCountResponse, got %T", resp)
+	require.Equal(t, 0, countResp.Count)
+
+	// Add some fake entries to simulate active actors. We use nil refs
+	// since we only care about the count.
+	manager.actors[wire.OutPoint{Index: 0}] = nil
+	manager.actors[wire.OutPoint{Index: 1}] = nil
+	manager.actors[wire.OutPoint{Index: 2}] = nil
+
+	// Test returns correct count.
+	result = manager.Receive(ctx, &GetActiveVTXOCountRequest{})
+	resp, err = result.Unpack()
+	require.NoError(t, err)
+
+	countResp, ok = resp.(*GetActiveVTXOCountResponse)
+	require.True(t, ok, "expected GetActiveVTXOCountResponse, got %T", resp)
+	require.Equal(t, 3, countResp.Count)
+}

--- a/vtxo/harness_test.go
+++ b/vtxo/harness_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/sha256"
+	"sync"
 	"testing"
 
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -15,6 +16,7 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/lib/scripts"
+	"github.com/lightninglabs/darepo-client/round"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/stretchr/testify/mock"
@@ -674,4 +676,110 @@ func assertOutboxContainsReal[T VTXOOutMsg](h *realVTXOSigningHarness) T {
 	h.t.Fatalf("outbox does not contain message of type %T", zero)
 
 	return zero
+}
+
+// mockRoundActorRef captures messages sent to the round actor for test
+// verification. Implements actor.TellOnlyRef[round.ClientMsg].
+type mockRoundActorRef struct {
+	t        *testing.T
+	messages []round.ClientMsg
+	mu       sync.Mutex
+}
+
+func newMockRoundActorRef(t *testing.T) *mockRoundActorRef {
+	return &mockRoundActorRef{
+		t:        t,
+		messages: make([]round.ClientMsg, 0),
+	}
+}
+
+func (m *mockRoundActorRef) ID() string {
+	return "mock-round-actor"
+}
+
+func (m *mockRoundActorRef) Tell(_ context.Context, msg round.ClientMsg) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.messages = append(m.messages, msg)
+}
+
+func (m *mockRoundActorRef) getMessages() []round.ClientMsg {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	result := make([]round.ClientMsg, len(m.messages))
+	copy(result, m.messages)
+
+	return result
+}
+
+// mockManagerRef captures messages sent to the manager for test verification.
+type mockManagerRef struct {
+	t        *testing.T
+	messages []ManagerMsg
+	mu       sync.Mutex
+}
+
+func newMockManagerRef(t *testing.T) *mockManagerRef {
+	return &mockManagerRef{
+		t:        t,
+		messages: make([]ManagerMsg, 0),
+	}
+}
+
+func (m *mockManagerRef) ID() string {
+	return "mock-manager"
+}
+
+func (m *mockManagerRef) Tell(_ context.Context, msg ManagerMsg) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.messages = append(m.messages, msg)
+}
+
+func (m *mockManagerRef) getMessages() []ManagerMsg {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	result := make([]ManagerMsg, len(m.messages))
+	copy(result, m.messages)
+
+	return result
+}
+
+// mockChainResolverRef captures expiring notifications for test verification.
+type mockChainResolverRef struct {
+	t        *testing.T
+	messages []ExpiringNotification
+	mu       sync.Mutex
+}
+
+func newMockChainResolverRef(t *testing.T) *mockChainResolverRef {
+	return &mockChainResolverRef{
+		t:        t,
+		messages: make([]ExpiringNotification, 0),
+	}
+}
+
+func (m *mockChainResolverRef) ID() string {
+	return "mock-chain-resolver"
+}
+
+func (m *mockChainResolverRef) Tell(
+	_ context.Context, msg ExpiringNotification,
+) {
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.messages = append(m.messages, msg)
+}
+
+func (m *mockChainResolverRef) getMessages() []ExpiringNotification {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	result := make([]ExpiringNotification, len(m.messages))
+	copy(result, m.messages)
+
+	return result
 }

--- a/vtxo/manager.go
+++ b/vtxo/manager.go
@@ -1,0 +1,250 @@
+package vtxo
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/chainsource"
+	"github.com/lightninglabs/darepo-client/round"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+)
+
+// VTXOActorRef is the actor reference type for VTXO actors.
+type VTXOActorRef = actor.ActorRef[VTXOEvent, VTXOActorResponse]
+
+// ManagerConfig holds configuration for the VTXO Manager.
+type ManagerConfig struct {
+	Store       VTXOStore
+	Wallet      VTXOWallet
+	ChainSource actor.ActorRef[
+		chainsource.ChainSourceMsg, chainsource.ChainSourceResp,
+	]
+	ActorSystem  *actor.ActorSystem
+	ChainParams  *chaincfg.Params
+	ExpiryConfig *ExpiryConfig
+	Logger       btclog.Logger
+
+	// RoundActor receives refresh requests and forfeit signatures from VTXOs.
+	// Passed through to spawned VTXO actors.
+	RoundActor actor.TellOnlyRef[round.ClientMsg]
+
+	// ChainResolver receives expiring notifications for unilateral exit.
+	// Passed through to spawned VTXO actors.
+	ChainResolver actor.TellOnlyRef[ExpiringNotification]
+}
+
+// Manager coordinates VTXO actor lifecycle - spawning new actors when VTXOs
+// are created and recovering persisted actors on startup. Each VTXO actor
+// manages its own block epoch subscription and communicates directly with the
+// round actor via service keys.
+type Manager struct {
+	cfg *ManagerConfig
+
+	// managerRef is the manager's own actor ref, used for creating mapped
+	// refs that VTXO actors can use to send termination notifications.
+	managerRef actor.TellOnlyRef[ManagerMsg]
+
+	// actors tracks active VTXO actors by outpoint.
+	actors map[wire.OutPoint]VTXOActorRef
+}
+
+// NewManager creates a new VTXO Manager.
+func NewManager(cfg *ManagerConfig) *Manager {
+	if cfg.ExpiryConfig == nil {
+		cfg.ExpiryConfig = DefaultExpiryConfig()
+	}
+
+	return &Manager{
+		cfg:    cfg,
+		actors: make(map[wire.OutPoint]VTXOActorRef),
+	}
+}
+
+// Start initializes the manager by recovering persisted VTXOs. The selfRef
+// parameter is the manager's own actor reference, used for VTXO actors to
+// send termination notifications.
+func (m *Manager) Start(ctx context.Context,
+	selfRef actor.TellOnlyRef[ManagerMsg]) error {
+
+	m.managerRef = selfRef
+
+	vtxos, err := m.cfg.Store.ListLiveVTXOs(ctx)
+	if err != nil {
+		return fmt.Errorf("list live vtxos: %w", err)
+	}
+
+	for _, vtxo := range vtxos {
+		ref, err := m.spawnVTXOActor(ctx, vtxo)
+		if err != nil {
+			m.cfg.Logger.ErrorS(
+				ctx, "Failed to recover VTXO actor", err,
+				slog.String("outpoint", vtxo.Outpoint.String()),
+			)
+
+			continue
+		}
+
+		m.actors[vtxo.Outpoint] = ref
+
+		m.cfg.Logger.InfoS(ctx, "Recovered VTXO actor",
+			slog.String("outpoint", vtxo.Outpoint.String()),
+			slog.String("status", vtxo.Status.String()))
+	}
+
+	m.cfg.Logger.InfoS(ctx, "VTXO manager started",
+		slog.Int("recovered", len(m.actors)))
+
+	return nil
+}
+
+// Stop gracefully shuts down the manager.
+func (m *Manager) Stop(ctx context.Context) {
+	m.cfg.Logger.InfoS(ctx, "VTXO manager stopped")
+}
+
+// Receive processes incoming messages.
+func (m *Manager) Receive(ctx context.Context,
+	msg ManagerMsg) fn.Result[ManagerResp] {
+
+	switch req := msg.(type) {
+	case *VTXOCreatedMsg:
+		return m.handleVTXOCreated(ctx, req)
+
+	case *VTXOTerminatedMsg:
+		return m.handleVTXOTerminated(ctx, req)
+
+	case *GetActiveVTXOCountRequest:
+		return fn.Ok[ManagerResp](&GetActiveVTXOCountResponse{
+			Count: len(m.actors),
+		})
+
+	default:
+		return fn.Err[ManagerResp](
+			fmt.Errorf("unknown message: %T", msg),
+		)
+	}
+}
+
+// handleVTXOCreated spawns a new VTXO actor for each created VTXO.
+func (m *Manager) handleVTXOCreated(ctx context.Context,
+	msg *VTXOCreatedMsg) fn.Result[ManagerResp] {
+
+	for _, clientVTXO := range msg.VTXOs {
+		outpoint := clientVTXO.Outpoint
+
+		if _, exists := m.actors[outpoint]; exists {
+			m.cfg.Logger.WarnS(ctx,
+				"VTXO actor already exists", nil,
+				slog.String("outpoint", outpoint.String()),
+			)
+
+			continue
+		}
+
+		descriptor := clientVTXOToDescriptor(clientVTXO, msg)
+
+		if err := m.cfg.Store.SaveVTXO(ctx, descriptor); err != nil {
+			m.cfg.Logger.ErrorS(ctx, "Failed to save VTXO", err,
+				slog.String("outpoint", outpoint.String()),
+			)
+
+			continue
+		}
+
+		ref, err := m.spawnVTXOActor(ctx, descriptor)
+		if err != nil {
+			m.cfg.Logger.ErrorS(ctx,
+				"Failed to spawn VTXO actor", err,
+				slog.String("outpoint", outpoint.String()),
+			)
+
+			continue
+		}
+
+		m.actors[outpoint] = ref
+
+		m.cfg.Logger.InfoS(ctx, "Spawned VTXO actor",
+			slog.String("outpoint", outpoint.String()),
+			slog.Int64("amount", int64(clientVTXO.Amount)),
+			slog.Int("batch_expiry", int(msg.BatchExpiry)))
+	}
+
+	return fn.Ok[ManagerResp](&VTXOCreatedResp{})
+}
+
+// handleVTXOTerminated removes a VTXO actor from tracking.
+func (m *Manager) handleVTXOTerminated(ctx context.Context,
+	msg *VTXOTerminatedMsg) fn.Result[ManagerResp] {
+
+	delete(m.actors, msg.Outpoint)
+
+	m.cfg.Logger.InfoS(ctx, "VTXO actor terminated",
+		slog.String("outpoint", msg.Outpoint.String()),
+		slog.String("final_state", msg.FinalState),
+		slog.String("reason", msg.Reason))
+
+	return fn.Ok[ManagerResp](&VTXOTerminatedResp{})
+}
+
+// spawnVTXOActor creates a new VTXO FSM actor.
+func (m *Manager) spawnVTXOActor(ctx context.Context,
+	vtxo *Descriptor) (VTXOActorRef, error) {
+
+	actorID := fmt.Sprintf("vtxo.%s", vtxo.Outpoint.String())
+	serviceKey := VTXOActorServiceKey(vtxo.Outpoint)
+
+	actorCfg := &VTXOActorConfig{
+		VTXO:          vtxo,
+		Store:         m.cfg.Store,
+		Wallet:        m.cfg.Wallet,
+		ChainSource:   m.cfg.ChainSource,
+		ChainParams:   m.cfg.ChainParams,
+		ExpiryConfig:  m.cfg.ExpiryConfig,
+		Logger:        m.cfg.Logger,
+		RoundActor:    m.cfg.RoundActor,
+		ChainResolver: m.cfg.ChainResolver,
+		Manager:       m.managerRef,
+	}
+
+	vtxoActor := NewVTXOActor(actorCfg)
+	ref := serviceKey.Spawn(m.cfg.ActorSystem, actorID, vtxoActor)
+
+	// Start the actor to subscribe to block epochs. ActorRef embeds
+	// TellOnlyRef so we can use it directly.
+	if err := vtxoActor.Start(ctx, ref); err != nil {
+		// Stop the spawned actor to prevent a zombie actor in the
+		// system.
+		m.cfg.ActorSystem.StopAndRemoveActor(actorID)
+
+		return ref, fmt.Errorf("start vtxo actor: %w", err)
+	}
+
+	return ref, nil
+}
+
+// clientVTXOToDescriptor converts a round.ClientVTXO to a Descriptor.
+func clientVTXOToDescriptor(cv *round.ClientVTXO,
+	msg *VTXOCreatedMsg) *Descriptor {
+
+	return &Descriptor{
+		Outpoint:       cv.Outpoint,
+		Amount:         cv.Amount,
+		PkScript:       cv.PkScript,
+		ClientKey:      cv.ClientKey,
+		OperatorKey:    cv.OperatorKey,
+		TapScript:      msg.TapScript,
+		TreePath:       cv.TreePath,
+		RoundID:        msg.RoundID,
+		CommitmentTxID: msg.CommitmentTxID,
+		BatchExpiry:    msg.BatchExpiry,
+		RelativeExpiry: cv.Expiry,
+		TreeDepth:      msg.TreeDepth,
+		CreatedHeight:  msg.CreatedHeight,
+		Status:         VTXOStatusLive,
+	}
+}

--- a/vtxo/manager.go
+++ b/vtxo/manager.go
@@ -10,12 +10,18 @@ import (
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
 	"github.com/lightninglabs/darepo-client/chainsource"
+	"github.com/lightninglabs/darepo-client/lib/actormsg"
+	"github.com/lightninglabs/darepo-client/lib/scripts"
 	"github.com/lightninglabs/darepo-client/round"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 )
 
-// VTXOActorRef is the actor reference type for VTXO actors.
-type VTXOActorRef = actor.ActorRef[VTXOEvent, VTXOActorResponse]
+// VTXOActorRef is the actor reference type for VTXO actors. Uses
+// actormsg.VTXOActorMsg as the message type to enable both round and vtxo
+// packages to use the same service key for registration and lookup.
+type VTXOActorRef = actor.ActorRef[
+	actormsg.VTXOActorMsg, actormsg.VTXOActorResp,
+]
 
 // ManagerConfig holds configuration for the VTXO Manager.
 type ManagerConfig struct {
@@ -112,10 +118,10 @@ func (m *Manager) Receive(ctx context.Context,
 	msg ManagerMsg) fn.Result[ManagerResp] {
 
 	switch req := msg.(type) {
-	case *VTXOCreatedMsg:
+	case *round.VTXOCreatedNotification:
 		return m.handleVTXOCreated(ctx, req)
 
-	case *VTXOTerminatedMsg:
+	case *round.VTXOTerminatedMsg:
 		return m.handleVTXOTerminated(ctx, req)
 
 	case *GetActiveVTXOCountRequest:
@@ -132,7 +138,7 @@ func (m *Manager) Receive(ctx context.Context,
 
 // handleVTXOCreated spawns a new VTXO actor for each created VTXO.
 func (m *Manager) handleVTXOCreated(ctx context.Context,
-	msg *VTXOCreatedMsg) fn.Result[ManagerResp] {
+	msg *round.VTXOCreatedNotification) fn.Result[ManagerResp] {
 
 	for _, clientVTXO := range msg.VTXOs {
 		outpoint := clientVTXO.Outpoint
@@ -146,7 +152,16 @@ func (m *Manager) handleVTXOCreated(ctx context.Context,
 			continue
 		}
 
-		descriptor := clientVTXOToDescriptor(clientVTXO, msg)
+		result := clientVTXOToDescriptor(clientVTXO, msg)
+		descriptor, err := result.Unpack()
+		if err != nil {
+			m.cfg.Logger.ErrorS(ctx,
+				"Failed to build descriptor", err,
+				slog.String("outpoint", outpoint.String()),
+			)
+
+			continue
+		}
 
 		if err := m.cfg.Store.SaveVTXO(ctx, descriptor); err != nil {
 			m.cfg.Logger.ErrorS(ctx, "Failed to save VTXO", err,
@@ -177,9 +192,10 @@ func (m *Manager) handleVTXOCreated(ctx context.Context,
 	return fn.Ok[ManagerResp](&VTXOCreatedResp{})
 }
 
-// handleVTXOTerminated removes a VTXO actor from tracking.
+// handleVTXOTerminated removes a VTXO actor from tracking when it reaches
+// a terminal state (Forfeited, Failed, etc.).
 func (m *Manager) handleVTXOTerminated(ctx context.Context,
-	msg *VTXOTerminatedMsg) fn.Result[ManagerResp] {
+	msg *round.VTXOTerminatedMsg) fn.Result[ManagerResp] {
 
 	delete(m.actors, msg.Outpoint)
 
@@ -211,7 +227,7 @@ func (m *Manager) spawnVTXOActor(ctx context.Context,
 		Manager:       m.managerRef,
 	}
 
-	vtxoActor := NewVTXOActor(actorCfg)
+	vtxoActor := NewVTXOActor(ctx, actorCfg)
 	ref := serviceKey.Spawn(m.cfg.ActorSystem, actorID, vtxoActor)
 
 	// Start the actor to subscribe to block epochs. ActorRef embeds
@@ -227,24 +243,44 @@ func (m *Manager) spawnVTXOActor(ctx context.Context,
 	return ref, nil
 }
 
-// clientVTXOToDescriptor converts a round.ClientVTXO to a Descriptor.
+// clientVTXOToDescriptor converts a round.ClientVTXO to a Descriptor using
+// metadata from the VTXOCreatedNotification. TreeDepth and TapScript are
+// computed from the VTXO data since each VTXO may be at a different depth.
 func clientVTXOToDescriptor(cv *round.ClientVTXO,
-	msg *VTXOCreatedMsg) *Descriptor {
+	msg *round.VTXOCreatedNotification) fn.Result[*Descriptor] {
 
-	return &Descriptor{
+	// Compute tree depth from the VTXO's path. Each VTXO may be at a
+	// different depth in the commitment tree.
+	var treeDepth int
+	if cv.TreePath != nil {
+		treeDepth = cv.TreePath.Depth()
+	}
+
+	// Construct the TapScript from the client and operator keys. This is
+	// the standard VTXO tapscript with collaborative and timeout paths.
+	tapscript, err := scripts.VTXOTapScript(
+		cv.ClientKey.PubKey, cv.OperatorKey, cv.Expiry,
+	)
+	if err != nil {
+		return fn.Err[*Descriptor](
+			fmt.Errorf("build tapscript: %w", err),
+		)
+	}
+
+	return fn.Ok(&Descriptor{
 		Outpoint:       cv.Outpoint,
 		Amount:         cv.Amount,
 		PkScript:       cv.PkScript,
 		ClientKey:      cv.ClientKey,
 		OperatorKey:    cv.OperatorKey,
-		TapScript:      msg.TapScript,
+		TapScript:      tapscript,
 		TreePath:       cv.TreePath,
 		RoundID:        msg.RoundID,
 		CommitmentTxID: msg.CommitmentTxID,
 		BatchExpiry:    msg.BatchExpiry,
 		RelativeExpiry: cv.Expiry,
-		TreeDepth:      msg.TreeDepth,
+		TreeDepth:      treeDepth,
 		CreatedHeight:  msg.CreatedHeight,
 		Status:         VTXOStatusLive,
-	}
+	})
 }

--- a/vtxo/messages.go
+++ b/vtxo/messages.go
@@ -1,17 +1,15 @@
 package vtxo
 
 import (
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btcwallet/waddrmgr"
-	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/lib/actormsg"
 	"github.com/lightninglabs/darepo-client/round"
 )
 
-// ManagerMsg is the message type accepted by the VTXO Manager actor.
+// ManagerMsg embeds actormsg.VTXOManagerMsg for messages accepted by the VTXO
+// Manager actor. Message types are defined in round/vtxo_messages.go and
+// implement the actormsg.VTXOManagerMsg marker interface.
 type ManagerMsg interface {
-	actor.Message
-	managerMsgSealed()
+	actormsg.VTXOManagerMsg
 }
 
 // ManagerResp is the response type returned by the VTXO Manager actor.
@@ -19,62 +17,13 @@ type ManagerResp interface {
 	managerRespSealed()
 }
 
-// VTXOCreatedMsg notifies the manager that new VTXOs have been created by a
-// completed round. The manager spawns a new actor for each VTXO.
-type VTXOCreatedMsg struct {
-	actor.BaseMessage
+// Type alias for VTXOTerminatedMsg - canonical definition is in round package.
+type VTXOTerminatedMsg = round.VTXOTerminatedMsg
 
-	// VTXOs are the ClientVTXOs from the completed round.
-	VTXOs []*round.ClientVTXO
-
-	// RoundID identifies the round that created these VTXOs.
-	RoundID string
-
-	// CommitmentTxID is the txid of the commitment transaction.
-	CommitmentTxID chainhash.Hash
-
-	// BatchExpiry is the absolute block height when the batch expires.
-	BatchExpiry int32
-
-	// TreeDepth is the depth of VTXOs in the commitment tree.
-	TreeDepth int
-
-	// CreatedHeight is the block height when the VTXOs were created.
-	CreatedHeight int32
-
-	// TapScript is the tapscript for the VTXOs (shared across batch).
-	TapScript *waddrmgr.Tapscript
-}
-
-func (m *VTXOCreatedMsg) managerMsgSealed() {}
-
-// MessageType returns the message type for logging.
-func (m *VTXOCreatedMsg) MessageType() string { return "VTXOCreatedMsg" }
-
-// VTXOCreatedResp is the response to VTXOCreatedMsg.
+// VTXOCreatedResp is the response to VTXOCreatedNotification.
 type VTXOCreatedResp struct{}
 
 func (r *VTXOCreatedResp) managerRespSealed() {}
-
-// VTXOTerminatedMsg notifies the manager that a VTXO actor has reached a
-// terminal state and should be removed from tracking.
-type VTXOTerminatedMsg struct {
-	actor.BaseMessage
-
-	// Outpoint identifies the terminated VTXO.
-	Outpoint wire.OutPoint
-
-	// FinalState is the terminal state reached.
-	FinalState string
-
-	// Reason explains why the VTXO terminated.
-	Reason string
-}
-
-func (m *VTXOTerminatedMsg) managerMsgSealed() {}
-
-// MessageType returns the message type for logging.
-func (m *VTXOTerminatedMsg) MessageType() string { return "VTXOTerminatedMsg" }
 
 // VTXOTerminatedResp is the response to VTXOTerminatedMsg.
 type VTXOTerminatedResp struct{}

--- a/vtxo/messages.go
+++ b/vtxo/messages.go
@@ -1,6 +1,7 @@
 package vtxo
 
 import (
+	"github.com/lightninglabs/darepo-client/baselib/actor"
 	"github.com/lightninglabs/darepo-client/lib/actormsg"
 	"github.com/lightninglabs/darepo-client/round"
 )

--- a/vtxo/messages.go
+++ b/vtxo/messages.go
@@ -1,0 +1,105 @@
+package vtxo
+
+import (
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/round"
+)
+
+// ManagerMsg is the message type accepted by the VTXO Manager actor.
+type ManagerMsg interface {
+	actor.Message
+	managerMsgSealed()
+}
+
+// ManagerResp is the response type returned by the VTXO Manager actor.
+type ManagerResp interface {
+	managerRespSealed()
+}
+
+// VTXOCreatedMsg notifies the manager that new VTXOs have been created by a
+// completed round. The manager spawns a new actor for each VTXO.
+type VTXOCreatedMsg struct {
+	actor.BaseMessage
+
+	// VTXOs are the ClientVTXOs from the completed round.
+	VTXOs []*round.ClientVTXO
+
+	// RoundID identifies the round that created these VTXOs.
+	RoundID string
+
+	// CommitmentTxID is the txid of the commitment transaction.
+	CommitmentTxID chainhash.Hash
+
+	// BatchExpiry is the absolute block height when the batch expires.
+	BatchExpiry int32
+
+	// TreeDepth is the depth of VTXOs in the commitment tree.
+	TreeDepth int
+
+	// CreatedHeight is the block height when the VTXOs were created.
+	CreatedHeight int32
+
+	// TapScript is the tapscript for the VTXOs (shared across batch).
+	TapScript *waddrmgr.Tapscript
+}
+
+func (m *VTXOCreatedMsg) managerMsgSealed() {}
+
+// MessageType returns the message type for logging.
+func (m *VTXOCreatedMsg) MessageType() string { return "VTXOCreatedMsg" }
+
+// VTXOCreatedResp is the response to VTXOCreatedMsg.
+type VTXOCreatedResp struct{}
+
+func (r *VTXOCreatedResp) managerRespSealed() {}
+
+// VTXOTerminatedMsg notifies the manager that a VTXO actor has reached a
+// terminal state and should be removed from tracking.
+type VTXOTerminatedMsg struct {
+	actor.BaseMessage
+
+	// Outpoint identifies the terminated VTXO.
+	Outpoint wire.OutPoint
+
+	// FinalState is the terminal state reached.
+	FinalState string
+
+	// Reason explains why the VTXO terminated.
+	Reason string
+}
+
+func (m *VTXOTerminatedMsg) managerMsgSealed() {}
+
+// MessageType returns the message type for logging.
+func (m *VTXOTerminatedMsg) MessageType() string { return "VTXOTerminatedMsg" }
+
+// VTXOTerminatedResp is the response to VTXOTerminatedMsg.
+type VTXOTerminatedResp struct{}
+
+func (r *VTXOTerminatedResp) managerRespSealed() {}
+
+// GetActiveVTXOCountRequest requests the number of active VTXO actors managed
+// by the VTXO Manager. This goes through the actor message path to avoid
+// requiring synchronization.
+type GetActiveVTXOCountRequest struct {
+	actor.BaseMessage
+}
+
+// MessageType returns the message type identifier.
+func (r *GetActiveVTXOCountRequest) MessageType() string {
+	return "GetActiveVTXOCountRequest"
+}
+
+// VTXOManagerMsg implements actormsg.VTXOManagerMsg marker interface.
+func (r *GetActiveVTXOCountRequest) VTXOManagerMsg() {}
+
+// GetActiveVTXOCountResponse returns the count of active VTXO actors.
+type GetActiveVTXOCountResponse struct {
+	// Count is the number of currently active VTXO actors.
+	Count int
+}
+
+func (r *GetActiveVTXOCountResponse) managerRespSealed() {}


### PR DESCRIPTION
This PR implements the VTXO actor and manager components that bridge the FSM with the actor system. The actor wraps the FSM with a message-based interface, subscribing to block epochs for expiry monitoring and routing outbox messages to their destinations. The manager tracks active VTXO actors, spawning them when VTXOs are created and handling lifecycle notifications.

The VTXO actor processes events through the FSM and dispatches resulting outbox messages:
- `ForfeitSignatureSubmission` → Round actor for batch swap signature aggregation
- `RefreshRequest` → Round actor when VTXO approaches expiry
- `VTXOStatusUpdate` → Store persistence (including `MarkForfeiting()` with forfeit tx)
- `VTXOTerminatedNotification` → Manager for cleanup
- `ExpiringNotification` → Chain resolver for on-chain fallback

The manager maintains a map of outpoint → actor references, using the actor system's service registry for direct addressing. When the round actor needs to send a forfeit request, it looks up the VTXO actor by service key rather than routing through the manager.

This PR also includes necessary round package extensions:
- `RefreshVTXORequest` extended with VTXO descriptor fields (key, script, operator, expiry)
- `VTXOCreatedNotification` extended for manager integration
- `ClientMsg` refactored to use `actormsg.RoundReceivable` marker interface

Actor-level tests verify outbox message routing, store interactions, and crash recovery via `statusToState()` with persisted forfeit transactions.

## Dependencies
- Depends on #69 (vtxo: implement FSM for VTXO lifecycle management)