### PR TITLE
round: implement forfeit signature collection in FSM and actor

### DIFF
--- a/lib/tree/node.go
+++ b/lib/tree/node.go
@@ -25,6 +25,12 @@ import (
 // key-spend path of its parent output.
 const inputIndex = 0
 
+// NumLeafOutputs is the number of outputs in a leaf node transaction.
+// Leaf nodes always have exactly 2 outputs:
+//   - For VTXO tree leaves: [VTXO output, anchor output]
+//   - For connector tree leaves: [dust connector output, anchor output]
+const NumLeafOutputs = 2
+
 // Node represents a single transaction in a virtual transaction tree.
 type Node struct {
 	// Input is the single outpoint this transaction spends.

--- a/round/actor.go
+++ b/round/actor.go
@@ -18,6 +18,7 @@ import (
 	"github.com/lightninglabs/darepo-client/baselib/actor"
 	"github.com/lightninglabs/darepo-client/baselib/protofsm"
 	"github.com/lightninglabs/darepo-client/chainsource"
+	"github.com/lightninglabs/darepo-client/lib/actormsg"
 	"github.com/lightninglabs/darepo-client/lib/tree"
 	"github.com/lightninglabs/darepo-client/lib/types"
 	"github.com/lightninglabs/darepo-client/serverconn"
@@ -608,6 +609,12 @@ func (a *RoundClientActor) Receive(ctx context.Context,
 
 	case *ConfirmationEvent:
 		return a.handleConfirmation(ctx, m)
+
+	case *RefreshVTXORequest:
+		return a.handleRefreshVTXORequest(ctx, m)
+
+	case *ForfeitSignatureResponse:
+		return a.handleForfeitSignatureResponse(ctx, m)
 
 	default:
 		return fn.Err[ClientResp](fmt.Errorf(
@@ -1250,6 +1257,46 @@ func (a *RoundClientActor) processOutbox(ctx context.Context,
 				slog.String("reason", m.Reason),
 				slog.Bool("recoverable", m.Recoverable))
 
+		case *ForfeitRequestToVTXO:
+			// Route forfeit request to VTXO actor via service key.
+			// The VTXO actor will sign the forfeit tx and respond
+			// with ForfeitSignatureResponse.
+			if a.cfg.ActorSystem != nil {
+				serviceKey := actormsg.VTXOActorServiceKey(
+					m.VTXOOutpoint,
+				)
+				serviceKey.Ref(a.cfg.ActorSystem).Tell(
+					ctx, &ForfeitRequestEvent{
+						RoundID:               m.RoundID,
+						ConnectorOutpoint:     m.ConnectorOutpoint,
+						ConnectorPkScript:     m.ConnectorPkScript,
+						ConnectorAmount:       m.ConnectorAmount,
+						ServerForfeitPkScript: m.ServerForfeitPkScript,
+					},
+				)
+				log.InfoS(ctx, "Sent forfeit request to VTXO actor",
+					"outpoint", m.VTXOOutpoint.String(),
+					"round_id", m.RoundID)
+			}
+
+		case *ForfeitConfirmedToVTXO:
+			// Notify VTXO actor that forfeit is confirmed. The old
+			// VTXO is now permanently forfeited.
+			if a.cfg.ActorSystem != nil {
+				serviceKey := actormsg.VTXOActorServiceKey(
+					m.VTXOOutpoint,
+				)
+				serviceKey.Ref(a.cfg.ActorSystem).Tell(
+					ctx, &ForfeitConfirmedEvent{
+						CommitmentTxID: m.CommitmentTxID,
+						BlockHeight:    m.BlockHeight,
+					},
+				)
+				log.InfoS(ctx, "Sent forfeit confirmation to VTXO actor",
+					"outpoint", m.VTXOOutpoint.String(),
+					"commitment_txid", m.CommitmentTxID.String())
+			}
+
 		default:
 			// Unknown outbox message type. Log for debugging.
 			a.log.DebugS(ctx, "Ignoring unknown outbox message type",
@@ -1259,4 +1306,85 @@ func (a *RoundClientActor) processOutbox(ctx context.Context,
 	}
 
 	return nil
+}
+
+// handleRefreshVTXORequest processes a refresh request from a VTXO actor.
+// The VTXO is approaching expiry and needs to be included in the next batch
+// swap round. The request is forwarded to a pending round FSM which tracks it
+// alongside boarding intents.
+func (a *RoundClientActor) handleRefreshVTXORequest(ctx context.Context,
+	req *RefreshVTXORequest) fn.Result[ClientResp] {
+
+	// Find a pending round or create one if none exists.
+	roundFSM := a.findPendingRound()
+	if roundFSM == nil {
+		var err error
+		roundFSM, err = a.createNewRound(ctx)
+		if err != nil {
+			return fn.Err[ClientResp](fmt.Errorf(
+				"failed to create round for refresh: %w", err,
+			))
+		}
+	}
+
+	// Forward to the round FSM. The FSM tracks refreshing VTXOs in its
+	// state (similar to how it tracks boarding intents).
+	err := a.askEventAndProcessOutbox(ctx, roundFSM.FSM, req)
+	if err != nil {
+		return fn.Err[ClientResp](fmt.Errorf(
+			"FSM error processing refresh request: %w", err,
+		))
+	}
+
+	a.log.InfoS(ctx, "Queued VTXO for refresh",
+		slog.String("outpoint", req.VTXOOutpoint.String()),
+		slog.Int64("amount", req.Amount))
+
+	// Send acknowledgment back to the VTXO actor using Router pattern.
+	// The RoundID is empty since we haven't assigned it to a round yet.
+	if a.cfg.ActorSystem != nil {
+		serviceKey := actormsg.VTXOActorServiceKey(req.VTXOOutpoint)
+		serviceKey.Ref(a.cfg.ActorSystem).Tell(ctx, &RefreshAcknowledgedEvent{
+			RoundID: "",
+		})
+	}
+
+	return fn.Ok[ClientResp](nil)
+}
+
+// handleForfeitSignatureResponse processes a forfeit signature from a VTXO
+// actor. The VTXO actor has signed the forfeit transaction as part of a batch
+// swap round. The signature is forwarded to the round's FSM for tracking.
+func (a *RoundClientActor) handleForfeitSignatureResponse(ctx context.Context,
+	resp *ForfeitSignatureResponse) fn.Result[ClientResp] {
+
+	roundIDStr := resp.RoundID
+
+	// Look up the round by its RoundID key string.
+	keyStr := RoundKeyStr(roundIDStr)
+	roundFSM, exists := a.rounds[keyStr]
+	if !exists {
+		a.log.WarnS(ctx, "Forfeit signature for unknown round", nil,
+			slog.String("outpoint", resp.VTXOOutpoint.String()),
+			slog.String("round_id", roundIDStr))
+
+		return fn.Err[ClientResp](fmt.Errorf(
+			"unknown round %s for forfeit signature", roundIDStr,
+		))
+	}
+
+	// Forward to round FSM. The FSM tracks collected signatures and emits
+	// a server message when all expected signatures are collected.
+	err := a.askEventAndProcessOutbox(ctx, roundFSM.FSM, resp)
+	if err != nil {
+		return fn.Err[ClientResp](fmt.Errorf(
+			"FSM error processing forfeit signature: %w", err,
+		))
+	}
+
+	a.log.InfoS(ctx, "Collected forfeit signature",
+		slog.String("outpoint", resp.VTXOOutpoint.String()),
+		slog.String("round_id", roundIDStr))
+
+	return fn.Ok[ClientResp](nil)
 }

--- a/round/actor.go
+++ b/round/actor.go
@@ -141,6 +141,11 @@ type RoundClientConfig struct {
 	// avoid import cycle with vtxo package. Optional - if nil,
 	// notifications are not forwarded.
 	VTXOManager actor.TellOnlyRef[actor.Message]
+
+	// ActorSystem enables direct communication with VTXO actors via service
+	// keys. Used to send ForfeitRequestEvent, RefreshAcknowledgedEvent, and
+	// ForfeitConfirmedEvent to specific VTXO actors.
+	ActorSystem *actor.ActorSystem
 }
 
 // NewRoundClientActor creates a new client actor with the provided

--- a/round/events.go
+++ b/round/events.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
@@ -159,9 +160,43 @@ type CommitmentTxBuilt struct {
 	// sufficient for the client to verify their VTXOs and perform
 	// unilateral exit if needed.
 	VTXOTreePaths map[int]*tree.Tree
+
+	// ForfeitMappings maps each VTXO outpoint to its connector leaf info.
+	// This allows VTXO actors to find their connector output and construct
+	// the forfeit transaction. Only set when refresh requests are present.
+	ForfeitMappings map[wire.OutPoint]*ConnectorLeafInfo
+
+	// ServerForfeitPkScript is the operator's taproot script where all
+	// forfeited VTXO values are paid. The forfeit transaction output uses
+	// this script.
+	ServerForfeitPkScript []byte
 }
 
 func (e *CommitmentTxBuilt) clientEventSealed() {}
+
+// ConnectorLeafInfo contains the information needed to construct a forfeit
+// transaction for a specific VTXO. The forfeit tx spends the VTXO and its
+// connector output, paying the VTXO value to the operator's forfeit address.
+type ConnectorLeafInfo struct {
+	// LeafIndex is the position of this connector in the connector tree.
+	LeafIndex int
+
+	// ConnectorOutpoint is the outpoint of the connector output in the
+	// commitment transaction that this forfeit tx must spend.
+	ConnectorOutpoint wire.OutPoint
+
+	// ConnectorPkScript is the scriptPubKey of the connector output.
+	ConnectorPkScript []byte
+
+	// ConnectorAmount is the value of the connector output in satoshis.
+	// Connectors typically have minimal value (dust limit).
+	ConnectorAmount int64
+
+	// VTXOAmount is the value of the VTXO being forfeited. The forfeit tx's
+	// penalty output must equal this amount. This field enables validation
+	// that prevents value theft by ensuring the correct amount is forfeited.
+	VTXOAmount btcutil.Amount
+}
 
 // CommitmentTxValidated is emitted after the client successfully validates
 // the commitment transaction and VTXT path. This is a critical security

--- a/round/events.go
+++ b/round/events.go
@@ -100,8 +100,12 @@ type BoardingUTXOConfirmed struct {
 func (e *BoardingUTXOConfirmed) clientEventSealed() {}
 
 // VTXORequestsReceived is emitted when the client submits VTXO requests that
-// should be included in the next round registration.
+// should be included in the next round registration. This event can be sent
+// from both internal sources (e.g., wallet) and external actors (e.g., VTXO
+// actor requesting a new VTXO during refresh).
 type VTXORequestsReceived struct {
+	actor.BaseMessage
+
 	// Requests are the VTXO requests to include in the next join round
 	// request.
 	Requests []types.VTXORequest
@@ -109,6 +113,14 @@ type VTXORequestsReceived struct {
 
 // clientEventSealed prevents external implementations.
 func (e *VTXORequestsReceived) clientEventSealed() {}
+
+// RoundReceivable implements actormsg.RoundReceivable marker interface.
+func (e *VTXORequestsReceived) RoundReceivable() {}
+
+// MessageType returns the message type for logging.
+func (e *VTXORequestsReceived) MessageType() string {
+	return "VTXORequestsReceived"
+}
 
 // RegistrationRequested is emitted when the FSM is ready to join a round with
 // the currently confirmed set of boarding intents. The actor should treat this

--- a/round/events.go
+++ b/round/events.go
@@ -177,11 +177,6 @@ type CommitmentTxBuilt struct {
 	// This allows VTXO actors to find their connector output and construct
 	// the forfeit transaction. Only set when refresh requests are present.
 	ForfeitMappings map[wire.OutPoint]*ConnectorLeafInfo
-
-	// ServerForfeitPkScript is the operator's taproot script where all
-	// forfeited VTXO values are paid. The forfeit transaction output uses
-	// this script.
-	ServerForfeitPkScript []byte
 }
 
 func (e *CommitmentTxBuilt) clientEventSealed() {}

--- a/round/harness_test.go
+++ b/round/harness_test.go
@@ -336,6 +336,9 @@ func newTestHarness(t *testing.T) *boardingTestHarness {
 	vtxoStore := &MockVTXOStore{}
 	wallet := &MockClientWallet{}
 
+	// Create a test forfeit script (a valid P2TR script).
+	testForfeitScript := []byte{0x51, 0x20}
+
 	terms := &types.OperatorTerms{
 		PubKey:            operatorPubKey,
 		SweepKey:          operatorPubKey,
@@ -345,6 +348,7 @@ func newTestHarness(t *testing.T) *boardingTestHarness {
 		MaxBoardingAmount: 100000000, // 1 BTC.
 		FeeRate:           10,
 		MinConfirmations:  3,
+		ForfeitScript:     testForfeitScript,
 	}
 
 	// Use a mock start height for testing.
@@ -1999,14 +2003,13 @@ func (h *boardingTestHarness) newForfeitCollectingState(
 	}
 
 	return &ForfeitSignaturesCollectingState{
-		RoundID:               roundID,
-		CommitmentTx:          commitmentTx,
-		VTXOTreePaths:         map[int]*tree.Tree{0: vtxtTree},
-		Intents:               intents,
-		ClientTrees:           make(map[SignerKey]*tree.Tree),
-		BoardingInputIndices:  boardingInputIndices,
-		ExpectedForfeits:      expectedForfeits,
-		ServerForfeitPkScript: serverForfeitScript,
+		RoundID:              roundID,
+		CommitmentTx:         commitmentTx,
+		VTXOTreePaths:        map[int]*tree.Tree{0: vtxtTree},
+		Intents:              intents,
+		ClientTrees:          make(map[SignerKey]*tree.Tree),
+		BoardingInputIndices: boardingInputIndices,
+		ExpectedForfeits:     expectedForfeits,
 		CollectedForfeits: make(
 			map[wire.OutPoint]*ForfeitSignatureResponse,
 		),

--- a/round/harness_test.go
+++ b/round/harness_test.go
@@ -1052,7 +1052,6 @@ func (h *boardingTestHarness) setupMockWalletForMuSig2() {
 	).Return(partialSig, nil)
 }
 
-//nolint:unused
 func (h *boardingTestHarness) setupMockWalletForBoardingSigning() {
 	h.t.Helper()
 
@@ -1063,7 +1062,6 @@ func (h *boardingTestHarness) setupMockWalletForBoardingSigning() {
 	)
 }
 
-//nolint:unused
 func (h *boardingTestHarness) setupMockRoundStoreForCheckpoint() {
 	h.t.Helper()
 
@@ -1944,4 +1942,149 @@ func computeTreeNodeSigHash(node *tree.Node, tx *wire.MsgTx,
 	copy(result[:], hashBytes)
 
 	return result, nil
+}
+
+// newTestForfeitTx creates a minimal valid forfeit transaction structure.
+// The forfeit tx has 2 inputs (VTXO + connector) and 2 outputs (penalty +
+// anchor).
+func (h *boardingTestHarness) newTestForfeitTx(
+	vtxoOutpoint, connectorOutpoint wire.OutPoint,
+	serverForfeitScript []byte) *wire.MsgTx {
+
+	h.t.Helper()
+
+	tx := wire.NewMsgTx(2)
+
+	// Input 0: VTXO being forfeited.
+	tx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: vtxoOutpoint,
+	})
+
+	// Input 1: Connector output.
+	tx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: connectorOutpoint,
+	})
+
+	// Output 0: Penalty to server.
+	tx.AddTxOut(&wire.TxOut{
+		Value:    50000,
+		PkScript: serverForfeitScript,
+	})
+
+	// Output 1: Standard P2A anchor (scripts.AnchorPkScript).
+	tx.AddTxOut(&wire.TxOut{
+		Value:    0,
+		PkScript: scripts.AnchorPkScript,
+	})
+
+	return tx
+}
+
+// newForfeitCollectingState creates a ForfeitSignaturesCollectingState with
+// the given parameters for testing forfeit signature collection.
+func (h *boardingTestHarness) newForfeitCollectingState(
+	roundID RoundID,
+	intents Intents,
+	expectedForfeits map[wire.OutPoint]*ConnectorLeafInfo,
+	serverForfeitScript []byte) *ForfeitSignaturesCollectingState {
+
+	h.t.Helper()
+
+	vtxtTree, _ := h.newTestVTXOTree(1)
+	commitmentTx := h.newTestCommitmentTx(intents.Boarding)
+
+	boardingInputIndices := make(map[wire.OutPoint]int)
+	for i, intent := range intents.Boarding {
+		boardingInputIndices[intent.Outpoint] = i
+	}
+
+	return &ForfeitSignaturesCollectingState{
+		RoundID:               roundID,
+		CommitmentTx:          commitmentTx,
+		VTXOTreePaths:         map[int]*tree.Tree{0: vtxtTree},
+		Intents:               intents,
+		ClientTrees:           make(map[SignerKey]*tree.Tree),
+		BoardingInputIndices:  boardingInputIndices,
+		ExpectedForfeits:      expectedForfeits,
+		ServerForfeitPkScript: serverForfeitScript,
+		CollectedForfeits: make(
+			map[wire.OutPoint]*ForfeitSignatureResponse,
+		),
+	}
+}
+
+// newTestCommitmentTxWithInputs creates a test commitment tx with the
+// specified number of inputs. Used for testing refresh-only rounds where there
+// are no boarding inputs.
+func (h *boardingTestHarness) newTestCommitmentTxWithInputs(
+	numInputs int) *psbt.Packet {
+
+	h.t.Helper()
+
+	tx := wire.NewMsgTx(3)
+
+	// Add the specified number of inputs.
+	for i := 0; i < numInputs; i++ {
+		tx.AddTxIn(&wire.TxIn{
+			PreviousOutPoint: h.newTestOutpoint(),
+		})
+	}
+
+	// Add a standard output.
+	tx.AddTxOut(&wire.TxOut{
+		Value:    100000,
+		PkScript: make([]byte, 34),
+	})
+
+	// Add OP_RETURN output.
+	tx.AddTxOut(&wire.TxOut{
+		Value:    0,
+		PkScript: []byte{txscript.OP_TRUE, txscript.OP_RETURN},
+	})
+
+	packet, err := psbt.NewFromUnsignedTx(tx)
+	require.NoError(h.t, err)
+
+	return packet
+}
+
+// newMinimalVTXOTree creates a minimal valid VTXO tree for testing. This is
+// used for refresh-only rounds where we need a valid tree structure but don't
+// have specific VTXO requests from boarding intents.
+func (h *boardingTestHarness) newMinimalVTXOTree() *tree.Tree {
+	h.t.Helper()
+
+	// Create a minimal tree with one leaf.
+	const leafAmount = btcutil.Amount(50000)
+
+	vtxoScript, err := txscript.PayToTaprootScript(h.clientPubKey)
+	require.NoError(h.t, err)
+
+	leaves := []tree.LeafDescriptor{
+		{
+			PkScript:    vtxoScript,
+			Amount:      leafAmount,
+			CoSignerKey: h.clientPubKey,
+		},
+	}
+
+	batchOutpoint := h.newTestOutpoint()
+
+	batchPkScript, err := txscript.PayToTaprootScript(h.operatorPubKey)
+	require.NoError(h.t, err)
+
+	batchOutput := &wire.TxOut{
+		Value:    int64(leafAmount),
+		PkScript: batchPkScript,
+	}
+
+	sweepRoot := sha256.Sum256([]byte("test-sweep-root"))
+
+	vtxtTree, err := tree.NewTree(
+		batchOutpoint, batchOutput, leaves,
+		h.operatorPubKey, sweepRoot[:], 2,
+	)
+	require.NoError(h.t, err)
+
+	return vtxtTree
 }

--- a/round/interfaces.go
+++ b/round/interfaces.go
@@ -224,16 +224,21 @@ type Intents struct {
 	// TODO(roasbeef): add auxleaf for tap here.
 	VTXOs []types.VTXORequest
 
+	// Refreshes contains the refresh requests for VTXOs being forfeited.
+	// Each refresh consumes input value but doesn't automatically create
+	// output - the actual outputs are specified via VTXOs or Leave.
+	Refreshes []*RefreshRequest
+
 	// Future extensions:
-	// Forfeits requests
 	// Leave requests
 }
 
 // Clone creates a copy of the Intents.
 func (i *Intents) Clone() Intents {
 	return Intents{
-		Boarding: slices.Clone(i.Boarding),
-		VTXOs:    slices.Clone(i.VTXOs),
+		Boarding:  slices.Clone(i.Boarding),
+		VTXOs:     slices.Clone(i.VTXOs),
+		Refreshes: slices.Clone(i.Refreshes),
 	}
 }
 

--- a/round/states.go
+++ b/round/states.go
@@ -173,10 +173,6 @@ type CommitmentTxValidatedState struct {
 	// refresh rounds. Empty for boarding-only rounds. Carried forward
 	// through MuSig2 signing states until forfeit collection.
 	ForfeitMappings map[wire.OutPoint]*ConnectorLeafInfo
-
-	// ServerForfeitPkScript is the operator's forfeit address for refresh
-	// rounds. Empty for boarding-only rounds.
-	ServerForfeitPkScript []byte
 }
 
 func (s *CommitmentTxValidatedState) String() string {
@@ -227,9 +223,6 @@ type ForfeitSignaturesCollectingState struct {
 	// CollectedForfeits maps VTXO outpoints to their forfeit responses.
 	// When len(CollectedForfeits) == len(ExpectedForfeits), we proceed.
 	CollectedForfeits map[wire.OutPoint]*ForfeitSignatureResponse
-
-	// ServerForfeitPkScript is the operator's forfeit address.
-	ServerForfeitPkScript []byte
 }
 
 func (s *ForfeitSignaturesCollectingState) String() string {
@@ -273,9 +266,6 @@ type NoncesSentState struct {
 	// refresh rounds. Carried forward until forfeit collection after
 	// VTXO tree signing.
 	ForfeitMappings map[wire.OutPoint]*ConnectorLeafInfo
-
-	// ServerForfeitPkScript is the operator's forfeit address.
-	ServerForfeitPkScript []byte
 }
 
 func (s *NoncesSentState) String() string {
@@ -322,9 +312,6 @@ type NoncesAggregatedState struct {
 	// refresh rounds. Carried forward until forfeit collection after
 	// VTXO tree signing.
 	ForfeitMappings map[wire.OutPoint]*ConnectorLeafInfo
-
-	// ServerForfeitPkScript is the operator's forfeit address.
-	ServerForfeitPkScript []byte
 }
 
 func (s *NoncesAggregatedState) String() string {
@@ -368,9 +355,6 @@ type PartialSigsSentState struct {
 	// refresh rounds. After VTXO tree signature validation, if non-empty,
 	// transitions to ForfeitSignaturesCollectingState.
 	ForfeitMappings map[wire.OutPoint]*ConnectorLeafInfo
-
-	// ServerForfeitPkScript is the operator's forfeit address.
-	ServerForfeitPkScript []byte
 }
 
 func (s *PartialSigsSentState) String() string {

--- a/round/states.go
+++ b/round/states.go
@@ -47,6 +47,9 @@ func (s *Idle) clientStateSealed() {}
 // on-chain outpoint for efficient lookup when confirmation events arrive. Once
 // all intents reach the required confirmations, the FSM transitions to round
 // registration.
+//
+// This state also tracks VTXOs pending refresh. When VTXOs are approaching
+// expiry, they send RefreshVTXORequest to be included in the next round.
 type PendingRoundAssembly struct {
 	// Boarding contains the collected boarding intents to include in the
 	// next round.
@@ -55,6 +58,11 @@ type PendingRoundAssembly struct {
 	// VTXOs contains the collected VTXO requests to include in the next
 	// round.
 	VTXOs []types.VTXORequest
+
+	// RefreshingVTXOs tracks VTXOs waiting to be refreshed in this round.
+	// Keyed by VTXO outpoint. These are accumulated alongside boarding
+	// intents and included in the same round registration.
+	RefreshingVTXOs map[wire.OutPoint]*RefreshVTXORequest
 }
 
 func (s *PendingRoundAssembly) String() string {
@@ -160,6 +168,15 @@ type CommitmentTxValidatedState struct {
 	// BoardingInputIndices maps each boarding intent's outpoint to its
 	// position in the commitment transaction inputs. Used for signing.
 	BoardingInputIndices map[wire.OutPoint]int
+
+	// ForfeitMappings maps VTXO outpoints to their connector info for
+	// refresh rounds. Empty for boarding-only rounds. Carried forward
+	// through MuSig2 signing states until forfeit collection.
+	ForfeitMappings map[wire.OutPoint]*ConnectorLeafInfo
+
+	// ServerForfeitPkScript is the operator's forfeit address for refresh
+	// rounds. Empty for boarding-only rounds.
+	ServerForfeitPkScript []byte
 }
 
 func (s *CommitmentTxValidatedState) String() string {
@@ -171,6 +188,59 @@ func (s *CommitmentTxValidatedState) IsTerminal() bool {
 }
 
 func (s *CommitmentTxValidatedState) clientStateSealed() {}
+
+// ForfeitSignaturesCollectingState indicates the client is waiting for forfeit
+// signatures from VTXO actors after completing VTXO tree signing. This state
+// is entered when the round includes refresh or leave requests (VTXOs being
+// rolled over or exited). The FSM waits until all expected forfeit signatures
+// are collected, then submits them to the server and transitions to boarding
+// input signing.
+//
+// The forfeit flow ensures atomic refresh: old VTXOs are forfeited (locked to
+// the new commitment tx via connectors) before new VTXOs become valid. This
+// prevents double-spending while preserving client custody.
+type ForfeitSignaturesCollectingState struct {
+	// RoundID is the unique identifier for this round.
+	RoundID RoundID
+
+	// CommitmentTx is the unsigned commitment transaction as a PSBT.
+	CommitmentTx *psbt.Packet
+
+	// VTXOTreePaths maps commitment tx output indices to VTXO tree paths.
+	VTXOTreePaths map[int]*tree.Tree
+
+	// Intents contains all the client's intents for this round.
+	Intents Intents
+
+	// ClientTrees maps signer keys (compressed pubkeys) to the client's
+	// extracted sub-tree for that VTXO.
+	ClientTrees map[SignerKey]*tree.Tree
+
+	// BoardingInputIndices maps each boarding intent's outpoint to its
+	// position in the commitment transaction inputs. Used for signing.
+	BoardingInputIndices map[wire.OutPoint]int
+
+	// ExpectedForfeits maps VTXO outpoints to their connector info. These
+	// are the VTXOs we're waiting for forfeit signatures from.
+	ExpectedForfeits map[wire.OutPoint]*ConnectorLeafInfo
+
+	// CollectedForfeits maps VTXO outpoints to their forfeit responses.
+	// When len(CollectedForfeits) == len(ExpectedForfeits), we proceed.
+	CollectedForfeits map[wire.OutPoint]*ForfeitSignatureResponse
+
+	// ServerForfeitPkScript is the operator's forfeit address.
+	ServerForfeitPkScript []byte
+}
+
+func (s *ForfeitSignaturesCollectingState) String() string {
+	return "ForfeitSignaturesCollecting"
+}
+
+func (s *ForfeitSignaturesCollectingState) IsTerminal() bool {
+	return false
+}
+
+func (s *ForfeitSignaturesCollectingState) clientStateSealed() {}
 
 // NoncesSentState indicates the client has sent nonces to the server and
 // is waiting for aggregated nonces.
@@ -198,6 +268,14 @@ type NoncesSentState struct {
 	// BoardingInputIndices maps each boarding intent's outpoint to its
 	// position in the commitment transaction inputs. Used for signing.
 	BoardingInputIndices map[wire.OutPoint]int
+
+	// ForfeitMappings maps VTXO outpoints to their connector info for
+	// refresh rounds. Carried forward until forfeit collection after
+	// VTXO tree signing.
+	ForfeitMappings map[wire.OutPoint]*ConnectorLeafInfo
+
+	// ServerForfeitPkScript is the operator's forfeit address.
+	ServerForfeitPkScript []byte
 }
 
 func (s *NoncesSentState) String() string {
@@ -239,6 +317,14 @@ type NoncesAggregatedState struct {
 	// BoardingInputIndices maps each boarding intent's outpoint to its
 	// position in the commitment transaction inputs. Used for signing.
 	BoardingInputIndices map[wire.OutPoint]int
+
+	// ForfeitMappings maps VTXO outpoints to their connector info for
+	// refresh rounds. Carried forward until forfeit collection after
+	// VTXO tree signing.
+	ForfeitMappings map[wire.OutPoint]*ConnectorLeafInfo
+
+	// ServerForfeitPkScript is the operator's forfeit address.
+	ServerForfeitPkScript []byte
 }
 
 func (s *NoncesAggregatedState) String() string {
@@ -277,6 +363,14 @@ type PartialSigsSentState struct {
 	// BoardingInputIndices maps each boarding intent's outpoint to its
 	// position in the commitment transaction inputs. Used for signing.
 	BoardingInputIndices map[wire.OutPoint]int
+
+	// ForfeitMappings maps VTXO outpoints to their connector info for
+	// refresh rounds. After VTXO tree signature validation, if non-empty,
+	// transitions to ForfeitSignaturesCollectingState.
+	ForfeitMappings map[wire.OutPoint]*ConnectorLeafInfo
+
+	// ServerForfeitPkScript is the operator's forfeit address.
+	ServerForfeitPkScript []byte
 }
 
 func (s *PartialSigsSentState) String() string {
@@ -310,6 +404,11 @@ type InputSigSentState struct {
 
 	// InputSigs are the Schnorr signatures for the boarding inputs.
 	InputSigs []*types.BoardingInputSignature
+
+	// ForfeitedVTXOs contains outpoints of VTXOs being refreshed. When the
+	// round confirms, ForfeitConfirmedToVTXO messages are emitted for each
+	// so old VTXO actors can transition to the Forfeited terminal state.
+	ForfeitedVTXOs []wire.OutPoint
 }
 
 func (s *InputSigSentState) String() string {

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -793,14 +793,13 @@ func (s *CommitmentTxReceivedState) ProcessEvent(
 		// VTXOs are properly signed.
 		return &ClientStateTransition{
 			NextState: &CommitmentTxValidatedState{
-				RoundID:               s.RoundID,
-				CommitmentTx:          s.CommitmentTx,
-				VTXOTreePaths:         s.VTXOTreePaths,
-				Intents:               s.Intents.Clone(),
-				ClientTrees:           clientTrees,
-				BoardingInputIndices:  boardingInputIndices,
-				ForfeitMappings:       evt.ForfeitMappings,
-				ServerForfeitPkScript: evt.ServerForfeitPkScript,
+				RoundID:              s.RoundID,
+				CommitmentTx:         s.CommitmentTx,
+				VTXOTreePaths:        s.VTXOTreePaths,
+				Intents:              s.Intents.Clone(),
+				ClientTrees:          clientTrees,
+				BoardingInputIndices: boardingInputIndices,
+				ForfeitMappings:      evt.ForfeitMappings,
 			},
 			NewEvents: fn.Some(ClientEmittedEvent{
 				InternalEvent: []ClientEvent{&GenerateNonces{}},
@@ -909,15 +908,14 @@ func (s *CommitmentTxValidatedState) ProcessEvent(
 
 		return &ClientStateTransition{
 			NextState: &NoncesSentState{
-				RoundID:               s.RoundID,
-				CommitmentTx:          s.CommitmentTx,
-				VTXOTreePaths:         s.VTXOTreePaths,
-				Intents:               s.Intents.Clone(),
-				ClientTrees:           s.ClientTrees,
-				Musig2Sessions:        musig2Sessions,
-				BoardingInputIndices:  s.BoardingInputIndices,
-				ForfeitMappings:       s.ForfeitMappings,
-				ServerForfeitPkScript: s.ServerForfeitPkScript,
+				RoundID:              s.RoundID,
+				CommitmentTx:         s.CommitmentTx,
+				VTXOTreePaths:        s.VTXOTreePaths,
+				Intents:              s.Intents.Clone(),
+				ClientTrees:          s.ClientTrees,
+				Musig2Sessions:       musig2Sessions,
+				BoardingInputIndices: s.BoardingInputIndices,
+				ForfeitMappings:      s.ForfeitMappings,
 			},
 			NewEvents: fn.Some(ClientEmittedEvent{
 				Outbox: []ClientOutMsg{nonceMsg},
@@ -955,7 +953,7 @@ func (s *ForfeitSignaturesCollectingState) ProcessEvent(
 		params := tx.ForfeitTxParams{
 			VTXOOutpoint:        evt.VTXOOutpoint,
 			ConnectorOutpoint:   connectorInfo.ConnectorOutpoint,
-			ServerForfeitScript: s.ServerForfeitPkScript,
+			ServerForfeitScript: env.OperatorTerms.ForfeitScript,
 			ExpectedAmount:      connectorInfo.VTXOAmount,
 		}
 		err := tx.ValidateForfeitTx(evt.ForfeitTx, params)
@@ -983,15 +981,14 @@ func (s *ForfeitSignaturesCollectingState) ProcessEvent(
 			return &ClientStateTransition{
 				//nolint:ll
 				NextState: &ForfeitSignaturesCollectingState{
-					RoundID:               s.RoundID,
-					CommitmentTx:          s.CommitmentTx,
-					VTXOTreePaths:         s.VTXOTreePaths,
-					Intents:               s.Intents.Clone(),
-					ClientTrees:           s.ClientTrees,
-					BoardingInputIndices:  s.BoardingInputIndices,
-					ExpectedForfeits:      s.ExpectedForfeits,
-					CollectedForfeits:     updatedForfeits,
-					ServerForfeitPkScript: s.ServerForfeitPkScript,
+					RoundID:              s.RoundID,
+					CommitmentTx:         s.CommitmentTx,
+					VTXOTreePaths:        s.VTXOTreePaths,
+					Intents:              s.Intents.Clone(),
+					ClientTrees:          s.ClientTrees,
+					BoardingInputIndices: s.BoardingInputIndices,
+					ExpectedForfeits:     s.ExpectedForfeits,
+					CollectedForfeits:    updatedForfeits,
 				},
 			}, nil
 		}
@@ -1148,16 +1145,15 @@ func (s *NoncesSentState) ProcessEvent(
 
 		return &ClientStateTransition{
 			NextState: &NoncesAggregatedState{
-				RoundID:               s.RoundID,
-				CommitmentTx:          s.CommitmentTx,
-				VTXOTreePaths:         s.VTXOTreePaths,
-				Intents:               s.Intents.Clone(),
-				ClientTrees:           s.ClientTrees,
-				Musig2Sessions:        s.Musig2Sessions,
-				AggNonces:             evt.AggNonces,
-				BoardingInputIndices:  s.BoardingInputIndices,
-				ForfeitMappings:       s.ForfeitMappings,
-				ServerForfeitPkScript: s.ServerForfeitPkScript,
+				RoundID:              s.RoundID,
+				CommitmentTx:         s.CommitmentTx,
+				VTXOTreePaths:        s.VTXOTreePaths,
+				Intents:              s.Intents.Clone(),
+				ClientTrees:          s.ClientTrees,
+				Musig2Sessions:       s.Musig2Sessions,
+				AggNonces:            evt.AggNonces,
+				BoardingInputIndices: s.BoardingInputIndices,
+				ForfeitMappings:      s.ForfeitMappings,
 			},
 			NewEvents: fn.Some(ClientEmittedEvent{
 				InternalEvent: []ClientEvent{
@@ -1228,15 +1224,14 @@ func (s *NoncesAggregatedState) ProcessEvent(
 		// aggregation.
 		return &ClientStateTransition{
 			NextState: &PartialSigsSentState{
-				RoundID:               s.RoundID,
-				CommitmentTx:          s.CommitmentTx,
-				VTXOTreePaths:         s.VTXOTreePaths,
-				Intents:               s.Intents.Clone(),
-				ClientTrees:           s.ClientTrees,
-				Musig2Sessions:        s.Musig2Sessions,
-				BoardingInputIndices:  s.BoardingInputIndices,
-				ForfeitMappings:       s.ForfeitMappings,
-				ServerForfeitPkScript: s.ServerForfeitPkScript,
+				RoundID:              s.RoundID,
+				CommitmentTx:         s.CommitmentTx,
+				VTXOTreePaths:        s.VTXOTreePaths,
+				Intents:              s.Intents.Clone(),
+				ClientTrees:          s.ClientTrees,
+				Musig2Sessions:       s.Musig2Sessions,
+				BoardingInputIndices: s.BoardingInputIndices,
+				ForfeitMappings:      s.ForfeitMappings,
 			},
 			NewEvents: fn.Some(ClientEmittedEvent{
 				Outbox: []ClientOutMsg{submitPartialSigsMsg},
@@ -1431,7 +1426,8 @@ func (s *PartialSigsSentState) transitionToForfeitCollection(
 	ctx context.Context, env *ClientEnvironment,
 ) (*ClientStateTransition, error) {
 
-	// Build forfeit request messages for each VTXO being refreshed.
+	// Build forfeit request messages for each VTXO being refreshed. The
+	// forfeit script is a static operator property from OperatorTerms.
 	var outbox []ClientOutMsg
 	for vtxoOutpoint, info := range s.ForfeitMappings {
 		msg := &ForfeitRequestToVTXO{
@@ -1440,7 +1436,7 @@ func (s *PartialSigsSentState) transitionToForfeitCollection(
 			ConnectorOutpoint:     info.ConnectorOutpoint,
 			ConnectorPkScript:     info.ConnectorPkScript,
 			ConnectorAmount:       info.ConnectorAmount,
-			ServerForfeitPkScript: s.ServerForfeitPkScript,
+			ServerForfeitPkScript: env.OperatorTerms.ForfeitScript,
 		}
 		outbox = append(outbox, msg)
 	}
@@ -1456,15 +1452,14 @@ func (s *PartialSigsSentState) transitionToForfeitCollection(
 
 	return &ClientStateTransition{
 		NextState: &ForfeitSignaturesCollectingState{
-			RoundID:               s.RoundID,
-			CommitmentTx:          s.CommitmentTx,
-			VTXOTreePaths:         s.VTXOTreePaths,
-			Intents:               s.Intents.Clone(),
-			ClientTrees:           s.ClientTrees,
-			ExpectedForfeits:      s.ForfeitMappings,
-			CollectedForfeits:     collectedForfeits,
-			BoardingInputIndices:  s.BoardingInputIndices,
-			ServerForfeitPkScript: s.ServerForfeitPkScript,
+			RoundID:              s.RoundID,
+			CommitmentTx:         s.CommitmentTx,
+			VTXOTreePaths:        s.VTXOTreePaths,
+			Intents:              s.Intents.Clone(),
+			ClientTrees:          s.ClientTrees,
+			ExpectedForfeits:     s.ForfeitMappings,
+			CollectedForfeits:    collectedForfeits,
+			BoardingInputIndices: s.BoardingInputIndices,
 		},
 		NewEvents: fn.Some(ClientEmittedEvent{
 			Outbox: outbox,

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"maps"
 	"slices"
 
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
@@ -14,6 +15,7 @@ import (
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/lib/scripts"
 	"github.com/lightninglabs/darepo-client/lib/tree"
+	"github.com/lightninglabs/darepo-client/lib/tx"
 	"github.com/lightninglabs/darepo-client/lib/types"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 )
@@ -174,6 +176,21 @@ func (s *Idle) ProcessEvent(ctx context.Context, event ClientEvent,
 			},
 		}, nil
 
+	case *RefreshVTXORequest:
+		// A VTXO actor requested refresh. Start assembling a round with
+		// this refresh request. Similar to boarding intents, we track
+		// refreshing VTXOs in the PendingRoundAssembly state.
+		refreshMap := make(map[wire.OutPoint]*RefreshVTXORequest)
+		refreshMap[evt.VTXOOutpoint] = evt
+
+		return &ClientStateTransition{
+			NextState: &PendingRoundAssembly{
+				Boarding:        nil,
+				VTXOs:           nil,
+				RefreshingVTXOs: refreshMap,
+			},
+		}, nil
+
 	default:
 		// Self-loop on unknown events - do not halt the FSM.
 		return selfLoop(s), nil
@@ -182,6 +199,8 @@ func (s *Idle) ProcessEvent(ctx context.Context, event ClientEvent,
 
 // ProcessEvent for PendingRoundAssembly tracks confirmed boarding intents and
 // transitions to registration once all are ready.
+//
+//nolint:funlen
 func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 	event ClientEvent, env *ClientEnvironment) (*ClientStateTransition,
 	error) {
@@ -267,8 +286,9 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 
 		return &ClientStateTransition{
 			NextState: &PendingRoundAssembly{
-				Boarding: updatedBoardingIntents,
-				VTXOs:    slices.Clone(s.VTXOs),
+				Boarding:        updatedBoardingIntents,
+				VTXOs:           slices.Clone(s.VTXOs),
+				RefreshingVTXOs: s.RefreshingVTXOs,
 			},
 		}, nil
 
@@ -284,8 +304,28 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 
 		return &ClientStateTransition{
 			NextState: &PendingRoundAssembly{
-				Boarding: slices.Clone(s.Boarding),
-				VTXOs:    updatedVTXOIntents,
+				Boarding:        slices.Clone(s.Boarding),
+				VTXOs:           updatedVTXOIntents,
+				RefreshingVTXOs: maps.Clone(s.RefreshingVTXOs),
+			},
+		}, nil
+
+	case *RefreshVTXORequest:
+		// A VTXO actor requested refresh. Add to our refreshing map.
+		// We stay in this state and accumulate refresh requests.
+		updatedRefreshing := maps.Clone(s.RefreshingVTXOs)
+		if updatedRefreshing == nil {
+			updatedRefreshing = make(
+				map[wire.OutPoint]*RefreshVTXORequest,
+			)
+		}
+		updatedRefreshing[evt.VTXOOutpoint] = evt
+
+		return &ClientStateTransition{
+			NextState: &PendingRoundAssembly{
+				Boarding:        slices.Clone(s.Boarding),
+				VTXOs:           slices.Clone(s.VTXOs),
+				RefreshingVTXOs: updatedRefreshing,
 			},
 		}, nil
 
@@ -297,11 +337,6 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 			slog.Int("boarding_intent_count", len(s.Boarding)),
 			slog.Int("vtxo_intent_count", len(s.VTXOs)))
 
-		intent := Intents{
-			Boarding: slices.Clone(s.Boarding),
-			VTXOs:    slices.Clone(s.VTXOs),
-		}
-
 		// Calculate total input amount from all boarding intents.
 		var totalInput btcutil.Amount
 		for _, boarding := range s.Boarding {
@@ -312,6 +347,13 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 		var totalOutput btcutil.Amount
 		for _, vtxo := range s.VTXOs {
 			totalOutput += vtxo.Amount
+		}
+
+		// Include refresh amounts in inputs only. The forfeited VTXO
+		// value contributes to totalInput. Outputs are determined by
+		// VTXOReqs and LeaveReqs (not assumed 1:1 with refresh).
+		for _, req := range s.RefreshingVTXOs {
+			totalInput += btcutil.Amount(req.Amount)
 		}
 
 		// Validate that we have outputs to create.
@@ -362,9 +404,30 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 		boardingReqs := fn.Map(s.Boarding, buildBoardingRequest)
 		vtxoReqs := slices.Clone(s.VTXOs)
 
+		// Build refresh requests for VTXOs being refreshed. The actual
+		// VTXO outputs are specified via VTXOReqs (not assumed 1:1).
+		numRefresh := len(s.RefreshingVTXOs)
+		refreshReqs := make([]*RefreshRequest, 0, numRefresh)
+		for _, req := range s.RefreshingVTXOs {
+			refreshReqs = append(refreshReqs, &RefreshRequest{
+				VTXOOutpoint: req.VTXOOutpoint,
+				Amount:       btcutil.Amount(req.Amount),
+				NewVTXOKey:   req.NewVTXOKey,
+			})
+		}
+
 		env.Log.InfoS(ctx, "Sending JoinRoundRequest to server",
 			slog.Int("boarding_requests", len(boardingReqs)),
-			slog.Int("vtxo_requests", len(vtxoReqs)))
+			slog.Int("vtxo_requests", len(vtxoReqs)),
+			slog.Int("refresh_requests", len(refreshReqs)))
+
+		// Build Intents with all VTXOs and refreshes for downstream
+		// validation.
+		intent := Intents{
+			Boarding:  slices.Clone(s.Boarding),
+			VTXOs:     vtxoReqs,
+			Refreshes: refreshReqs,
+		}
 
 		// With all this extracted, we'll now send the JoinRoundRequest
 		// to kick off the signing process.
@@ -377,6 +440,7 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 					&JoinRoundRequest{
 						BoardingRequests: boardingReqs,
 						VTXORequests:     vtxoReqs,
+						RefreshRequests:  refreshReqs,
 					},
 				},
 			}),
@@ -519,23 +583,29 @@ func (s *CommitmentTxReceivedState) ProcessEvent(
 			slog.Int("boarding_intent_count", len(s.Intents.Boarding)),
 			slog.Int("vtxo_intent_count", len(s.Intents.VTXOs)))
 
-		// First, well make sure that all boarding UTXOs are present
-		// in the round transaction and build the outpoint-to-index map.
-		boardingInputIndices, err := validateBoardingInputs(
-			s.CommitmentTx.UnsignedTx, s.Intents.Boarding,
-		)
-		if err != nil {
-			env.Log.WarnS(ctx, "Commitment tx validation failed", err,
-				slog.String("round_id", s.RoundID.String()))
+		// Validate boarding inputs if we have any boarding intents.
+		// Refresh-only rounds have no boarding inputs to validate.
+		var boardingInputIndices map[wire.OutPoint]int
+		if len(s.Intents.Boarding) > 0 {
+			var err error
+			boardingInputIndices, err = validateBoardingInputs(
+				s.CommitmentTx.UnsignedTx, s.Intents.Boarding,
+			)
+			if err != nil {
+				env.Log.WarnS(ctx, "Commitment tx validation failed", err,
+					slog.String("round_id", s.RoundID.String()))
 
-			return &ClientStateTransition{
-				NextState: &ClientFailedState{
-					Reason: "commitment tx " +
-						"validation failed",
-					Error:       err,
-					Recoverable: true,
-				},
-			}, nil
+				return &ClientStateTransition{
+					NextState: &ClientFailedState{
+						Reason: "commitment tx " +
+							"validation failed",
+						Error:       err,
+						Recoverable: true,
+					},
+				}, nil
+			}
+		} else {
+			boardingInputIndices = make(map[wire.OutPoint]int)
 		}
 
 		env.Log.DebugS(ctx, "Validated boarding inputs in commitment tx",
@@ -624,27 +694,26 @@ func (s *CommitmentTxReceivedState) ProcessEvent(
 			}
 		}
 
-		// TODO(roasbeef): for refresh and off boarding, need extra
-		// validation for:
-		//   * connector tree
-		//   * outputs on commit, etc
-
 		env.Log.InfoS(ctx, "Commitment transaction validated successfully",
 			slog.String("round_id", s.RoundID.String()),
 			slog.Int("client_trees", len(clientTrees)),
 			slog.Int("vtxo_tree_count", len(s.VTXOTreePaths)))
 
-		// We'll now transition to the CommitmentTxValidatedState, and
-		// emit an internal generate nonces event so we can propagate
-		// the state.
+		// Proceed to nonce generation. Forfeit mappings (if any) are
+		// carried forward through the MuSig2 signing states. Forfeit
+		// signatures are collected AFTER VTXO tree signing is complete,
+		// ensuring clients only forfeit old VTXOs after verifying new
+		// VTXOs are properly signed.
 		return &ClientStateTransition{
 			NextState: &CommitmentTxValidatedState{
-				RoundID:              s.RoundID,
-				CommitmentTx:         s.CommitmentTx,
-				VTXOTreePaths:        s.VTXOTreePaths,
-				Intents:              s.Intents.Clone(),
-				ClientTrees:          clientTrees,
-				BoardingInputIndices: boardingInputIndices,
+				RoundID:               s.RoundID,
+				CommitmentTx:          s.CommitmentTx,
+				VTXOTreePaths:         s.VTXOTreePaths,
+				Intents:               s.Intents.Clone(),
+				ClientTrees:           clientTrees,
+				BoardingInputIndices:  boardingInputIndices,
+				ForfeitMappings:       evt.ForfeitMappings,
+				ServerForfeitPkScript: evt.ServerForfeitPkScript,
 			},
 			NewEvents: fn.Some(ClientEmittedEvent{
 				InternalEvent: []ClientEvent{&GenerateNonces{}},
@@ -753,17 +822,262 @@ func (s *CommitmentTxValidatedState) ProcessEvent(
 
 		return &ClientStateTransition{
 			NextState: &NoncesSentState{
-				RoundID:              s.RoundID,
-				CommitmentTx:         s.CommitmentTx,
-				VTXOTreePaths:        s.VTXOTreePaths,
-				Intents:              s.Intents.Clone(),
-				ClientTrees:          s.ClientTrees,
-				Musig2Sessions:       musig2Sessions,
-				BoardingInputIndices: s.BoardingInputIndices,
+				RoundID:               s.RoundID,
+				CommitmentTx:          s.CommitmentTx,
+				VTXOTreePaths:         s.VTXOTreePaths,
+				Intents:               s.Intents.Clone(),
+				ClientTrees:           s.ClientTrees,
+				Musig2Sessions:        musig2Sessions,
+				BoardingInputIndices:  s.BoardingInputIndices,
+				ForfeitMappings:       s.ForfeitMappings,
+				ServerForfeitPkScript: s.ServerForfeitPkScript,
 			},
 			NewEvents: fn.Some(ClientEmittedEvent{
 				Outbox: []ClientOutMsg{nonceMsg},
 			}),
+		}, nil
+
+	default:
+		// Self-loop on unknown events - do not halt the FSM.
+		return selfLoop(s), nil
+	}
+}
+
+// ProcessEvent for ForfeitSignaturesCollectingState. This state handles the
+// collection of forfeit signatures from VTXO actors after VTXO tree signing
+// is complete. Each VTXO actor signs its forfeit transaction and sends a
+// ForfeitSignatureResponse. Once all expected signatures are collected, we
+// sign boarding inputs, submit all signatures to the server, and transition
+// to InputSigSentState.
+//
+//nolint:funlen
+func (s *ForfeitSignaturesCollectingState) ProcessEvent(
+	ctx context.Context, event ClientEvent, env *ClientEnvironment,
+) (*ClientStateTransition, error) {
+
+	switch evt := event.(type) {
+	case *ForfeitSignatureResponse:
+		// Validate this is a response we're expecting.
+		connectorInfo, expected := s.ExpectedForfeits[evt.VTXOOutpoint]
+		if !expected {
+			return nil, fmt.Errorf("unexpected forfeit signature "+
+				"for VTXO %s", evt.VTXOOutpoint)
+		}
+
+		// Validate the forfeit transaction structure using lib/tx. The
+		// VTXOAmount check ensures the penalty output equals the
+		// forfeited VTXO value, preventing value theft.
+		params := tx.ForfeitTxParams{
+			VTXOOutpoint:        evt.VTXOOutpoint,
+			ConnectorOutpoint:   connectorInfo.ConnectorOutpoint,
+			ServerForfeitScript: s.ServerForfeitPkScript,
+			ExpectedAmount:      connectorInfo.VTXOAmount,
+		}
+		err := tx.ValidateForfeitTx(evt.ForfeitTx, params)
+		if err != nil {
+			return nil, fmt.Errorf("invalid forfeit tx for VTXO "+
+				"%s: %w", evt.VTXOOutpoint, err)
+		}
+
+		// Check for duplicate response.
+		_, already := s.CollectedForfeits[evt.VTXOOutpoint]
+		if already {
+			// Already have this signature, ignore duplicate.
+			return &ClientStateTransition{NextState: s}, nil
+		}
+
+		// Add to collected signatures in an immutable way. FSM states
+		// should be treated as immutable to prevent side effects.
+		updatedForfeits := maps.Clone(s.CollectedForfeits)
+		updatedForfeits[evt.VTXOOutpoint] = evt
+
+		// Check if all forfeit signatures have been collected.
+		if len(updatedForfeits) < len(s.ExpectedForfeits) {
+			// Still waiting for more signatures - return new state
+			// with explicit struct to ensure immutability.
+			return &ClientStateTransition{
+				//nolint:ll
+				NextState: &ForfeitSignaturesCollectingState{
+					RoundID:               s.RoundID,
+					CommitmentTx:          s.CommitmentTx,
+					VTXOTreePaths:         s.VTXOTreePaths,
+					Intents:               s.Intents.Clone(),
+					ClientTrees:           s.ClientTrees,
+					BoardingInputIndices:  s.BoardingInputIndices,
+					ExpectedForfeits:      s.ExpectedForfeits,
+					CollectedForfeits:     updatedForfeits,
+					ServerForfeitPkScript: s.ServerForfeitPkScript,
+				},
+			}, nil
+		}
+
+		// All forfeit signatures collected! Build the submission.
+		forfeitSigs := make(map[wire.OutPoint][]byte)
+		forfeitTxs := make(map[wire.OutPoint]*wire.MsgTx)
+		forfeitedVTXOs := make([]wire.OutPoint, 0, len(updatedForfeits))
+		for outpoint, resp := range updatedForfeits {
+			forfeitSigs[outpoint] = resp.Signature
+			forfeitTxs[outpoint] = resp.ForfeitTx
+			forfeitedVTXOs = append(forfeitedVTXOs, outpoint)
+		}
+
+		env.Log.InfoS(ctx, "All forfeit signatures collected, signing boarding inputs",
+			slog.String("round_id", s.RoundID.String()),
+			slog.Int("forfeit_count", len(forfeitedVTXOs)),
+			slog.Int("boarding_intent_count", len(s.Intents.Boarding)))
+
+		// Now sign boarding inputs. Build PrevOutputFetcher from PSBT.
+		commitTx := s.CommitmentTx.UnsignedTx
+		prevOuts := make(map[wire.OutPoint]*wire.TxOut)
+		for i, pIn := range s.CommitmentTx.Inputs {
+			if pIn.WitnessUtxo == nil {
+				return nil, fmt.Errorf("PSBT input %d missing "+
+					"WitnessUtxo", i)
+			}
+			outpoint := commitTx.TxIn[i].PreviousOutPoint
+			prevOuts[outpoint] = pIn.WitnessUtxo
+		}
+		prevOutFetcher := txscript.NewMultiPrevOutFetcher(prevOuts)
+		sigHashes := txscript.NewTxSigHashes(commitTx, prevOutFetcher)
+
+		// Build boarding input signatures.
+		var boardingInputSigs []*types.BoardingInputSignature
+		for _, boardingIntent := range s.Intents.Boarding {
+			outpoint := boardingIntent.Request.Outpoint
+			inputIdx, found := s.BoardingInputIndices[*outpoint]
+			if !found {
+				return nil, fmt.Errorf("no input index "+
+					"found for boarding outpoint %s",
+					outpoint)
+			}
+
+			spendInfo, err := scripts.NewVTXOSpendInfo(
+				boardingIntent.Address.Tapscript,
+				scripts.VTXOCollabPathLeaf,
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			chainInfo := boardingIntent.ChainInfo
+			addr := boardingIntent.Address.Address
+			amt := chainInfo.Amount
+
+			pkScript, err := txscript.PayToAddrScript(addr)
+			if err != nil {
+				return nil, fmt.Errorf("pay to addr script: %w",
+					err)
+			}
+
+			output := &wire.TxOut{
+				Value:    int64(amt),
+				PkScript: pkScript,
+			}
+
+			signature, err := scripts.SignVTXOCollabInput(
+				env.Wallet, commitTx, inputIdx, spendInfo,
+				&boardingIntent.Address.KeyDesc, output,
+				sigHashes, prevOutFetcher,
+			)
+			if err != nil {
+				return nil, fmt.Errorf("failed to sign "+
+					"boarding input %d: %w", inputIdx, err)
+			}
+
+			schnorrSig, ok := signature.(*schnorr.Signature)
+			if !ok {
+				return nil, fmt.Errorf("signature is not a " +
+					"schnorr signature")
+			}
+
+			inputSig := &types.BoardingInputSignature{
+				InputIndex:      inputIdx,
+				Outpoint:        *outpoint,
+				ClientSignature: schnorrSig,
+			}
+			boardingInputSigs = append(boardingInputSigs, inputSig)
+		}
+
+		// Build outbox messages.
+		txid := commitTx.TxHash()
+		callerID := fmt.Sprintf("commitment-%s", txid.String())
+
+		var pkScript []byte
+		if len(commitTx.TxOut) > 0 {
+			pkScript = commitTx.TxOut[0].PkScript
+		}
+
+		outboxMsgs := []ClientOutMsg{
+			&SubmitVTXOForfeitSigsToServer{
+				RoundID:     s.RoundID.String(),
+				ForfeitSigs: forfeitSigs,
+				ForfeitTxs:  forfeitTxs,
+			},
+			&SubmitForfeitSigRequest{
+				RoundID:    s.RoundID,
+				Signatures: boardingInputSigs,
+			},
+			&RegisterConfirmationRequest{
+				CallerID:    callerID,
+				Txid:        &txid,
+				PkScript:    pkScript,
+				TargetConfs: env.OperatorTerms.MinConfirmations,
+				HeightHint:  env.StartHeight,
+			},
+		}
+
+		// Checkpoint round state.
+		intents := s.Intents.Clone()
+		for i := range intents.Boarding {
+			intents.Boarding[i].Status = BoardingStatusAdopted
+		}
+		round := &Round{
+			RoundID:       s.RoundID,
+			StartHeight:   env.StartHeight,
+			CommitmentTx:  fn.Some(s.CommitmentTx),
+			VTXOTreePaths: fn.Some(s.VTXOTreePaths),
+			Intents:       intents,
+		}
+
+		nextState := &InputSigSentState{
+			RoundID:        s.RoundID,
+			CommitmentTx:   s.CommitmentTx,
+			VTXOTreePaths:  s.VTXOTreePaths,
+			Intents:        s.Intents.Clone(),
+			ClientTrees:    s.ClientTrees,
+			InputSigs:      boardingInputSigs,
+			ForfeitedVTXOs: forfeitedVTXOs,
+		}
+
+		err = env.RoundStore.CommitState(ctx, round, nextState)
+		if err != nil {
+			return nil, fmt.Errorf("failed to commit round "+
+				"state: %w", err)
+		}
+
+		env.Log.InfoS(ctx, "Round state checkpointed with forfeit signatures",
+			slog.String("round_id", s.RoundID.String()),
+			slog.Int("boarding_sig_count", len(boardingInputSigs)),
+			slog.Int("forfeit_sig_count", len(forfeitSigs)))
+
+		checkpointNotify := &RoundCheckpointedNotification{
+			RoundID: s.RoundID,
+		}
+
+		return &ClientStateTransition{
+			NextState: nextState,
+			NewEvents: fn.Some(ClientEmittedEvent{
+				Outbox: append(outboxMsgs, checkpointNotify),
+			}),
+		}, nil
+
+	case *BoardingFailed:
+		return &ClientStateTransition{
+			NextState: &ClientFailedState{
+				Reason:      evt.Reason,
+				Error:       evt.Error,
+				Recoverable: evt.Recoverable,
+			},
 		}, nil
 
 	default:
@@ -812,14 +1126,16 @@ func (s *NoncesSentState) ProcessEvent(
 
 		return &ClientStateTransition{
 			NextState: &NoncesAggregatedState{
-				RoundID:              s.RoundID,
-				CommitmentTx:         s.CommitmentTx,
-				VTXOTreePaths:        s.VTXOTreePaths,
-				Intents:              s.Intents.Clone(),
-				ClientTrees:          s.ClientTrees,
-				Musig2Sessions:       s.Musig2Sessions,
-				AggNonces:            evt.AggNonces,
-				BoardingInputIndices: s.BoardingInputIndices,
+				RoundID:               s.RoundID,
+				CommitmentTx:          s.CommitmentTx,
+				VTXOTreePaths:         s.VTXOTreePaths,
+				Intents:               s.Intents.Clone(),
+				ClientTrees:           s.ClientTrees,
+				Musig2Sessions:        s.Musig2Sessions,
+				AggNonces:             evt.AggNonces,
+				BoardingInputIndices:  s.BoardingInputIndices,
+				ForfeitMappings:       s.ForfeitMappings,
+				ServerForfeitPkScript: s.ServerForfeitPkScript,
 			},
 			NewEvents: fn.Some(ClientEmittedEvent{
 				InternalEvent: []ClientEvent{
@@ -890,13 +1206,15 @@ func (s *NoncesAggregatedState) ProcessEvent(
 		// aggregation.
 		return &ClientStateTransition{
 			NextState: &PartialSigsSentState{
-				RoundID:              s.RoundID,
-				CommitmentTx:         s.CommitmentTx,
-				VTXOTreePaths:        s.VTXOTreePaths,
-				Intents:              s.Intents.Clone(),
-				ClientTrees:          s.ClientTrees,
-				Musig2Sessions:       s.Musig2Sessions,
-				BoardingInputIndices: s.BoardingInputIndices,
+				RoundID:               s.RoundID,
+				CommitmentTx:          s.CommitmentTx,
+				VTXOTreePaths:         s.VTXOTreePaths,
+				Intents:               s.Intents.Clone(),
+				ClientTrees:           s.ClientTrees,
+				Musig2Sessions:        s.Musig2Sessions,
+				BoardingInputIndices:  s.BoardingInputIndices,
+				ForfeitMappings:       s.ForfeitMappings,
+				ServerForfeitPkScript: s.ServerForfeitPkScript,
 			},
 			NewEvents: fn.Some(ClientEmittedEvent{
 				Outbox: []ClientOutMsg{submitPartialSigsMsg},
@@ -953,13 +1271,24 @@ func (s *PartialSigsSentState) ProcessEvent(
 			}
 		}
 
-		env.Log.InfoS(ctx, "Validated aggregated signatures, signing boarding inputs",
+		env.Log.InfoS(ctx, "Validated aggregated signatures",
+			slog.String("round_id", s.RoundID.String()),
+			slog.Int("forfeit_mapping_count", len(s.ForfeitMappings)))
+
+		// VTXO tree signatures validated. Now check if this round
+		// includes refresh requests. If so, we need to collect forfeit
+		// signatures from VTXO actors before signing boarding inputs.
+		// This ensures clients only forfeit old VTXOs after verifying
+		// their new VTXOs are properly signed.
+		if len(s.ForfeitMappings) > 0 {
+			return s.transitionToForfeitCollection(ctx, env)
+		}
+
+		// No refresh requests - proceed to sign boarding inputs.
+		env.Log.InfoS(ctx, "Signing boarding inputs",
 			slog.String("round_id", s.RoundID.String()),
 			slog.Int("boarding_intent_count", len(s.Intents.Boarding)))
 
-		// Now that we know all the signatures are valid, we'll sign
-		// off on each of our boarding inputs sent to the server.
-		//
 		// Build a PrevOutputFetcher from ALL PSBT inputs. Taproot
 		// sighash (BIP341) requires prevout info for all inputs.
 		tx := s.CommitmentTx.UnsignedTx
@@ -1110,7 +1439,8 @@ func (s *PartialSigsSentState) ProcessEvent(
 
 		// Checkpoint round data + FSM state atomically at the "point
 		// of no return". The next state is persisted so restart can
-		// recover to InputSigSentState.
+		// recover to InputSigSentState. For boarding-only rounds,
+		// ForfeitedVTXOs is nil.
 		nextState := &InputSigSentState{
 			RoundID:       s.RoundID,
 			CommitmentTx:  s.CommitmentTx,
@@ -1152,6 +1482,54 @@ func (s *PartialSigsSentState) ProcessEvent(
 		// Self-loop on unknown events - do not halt the FSM.
 		return selfLoop(s), nil
 	}
+}
+
+// transitionToForfeitCollection builds the transition to
+// ForfeitSignaturesCollectingState for refresh rounds. This helper is extracted
+// to keep ProcessEvent under the line length limit.
+func (s *PartialSigsSentState) transitionToForfeitCollection(
+	ctx context.Context, env *ClientEnvironment,
+) (*ClientStateTransition, error) {
+
+	// Build forfeit request messages for each VTXO being refreshed.
+	var outbox []ClientOutMsg
+	for vtxoOutpoint, info := range s.ForfeitMappings {
+		msg := &ForfeitRequestToVTXO{
+			VTXOOutpoint:          vtxoOutpoint,
+			RoundID:               s.RoundID.String(),
+			ConnectorOutpoint:     info.ConnectorOutpoint,
+			ConnectorPkScript:     info.ConnectorPkScript,
+			ConnectorAmount:       info.ConnectorAmount,
+			ServerForfeitPkScript: s.ServerForfeitPkScript,
+		}
+		outbox = append(outbox, msg)
+	}
+
+	env.Log.InfoS(ctx, "Transitioning to forfeit collection",
+		slog.String("round_id", s.RoundID.String()),
+		slog.Int("forfeit_count", len(s.ForfeitMappings)))
+
+	// Transition to forfeit collection state. After collecting all forfeit
+	// signatures, that state will sign boarding inputs and transition to
+	// InputSigSent.
+	collectedForfeits := make(map[wire.OutPoint]*ForfeitSignatureResponse)
+
+	return &ClientStateTransition{
+		NextState: &ForfeitSignaturesCollectingState{
+			RoundID:               s.RoundID,
+			CommitmentTx:          s.CommitmentTx,
+			VTXOTreePaths:         s.VTXOTreePaths,
+			Intents:               s.Intents.Clone(),
+			ClientTrees:           s.ClientTrees,
+			ExpectedForfeits:      s.ForfeitMappings,
+			CollectedForfeits:     collectedForfeits,
+			BoardingInputIndices:  s.BoardingInputIndices,
+			ServerForfeitPkScript: s.ServerForfeitPkScript,
+		},
+		NewEvents: fn.Some(ClientEmittedEvent{
+			Outbox: outbox,
+		}),
+	}, nil
 }
 
 // buildClientVTXOs constructs ClientVTXO instances from the intents and client
@@ -1252,6 +1630,37 @@ func (s *InputSigSentState) ProcessEvent(
 			BlockHash: evt.BlockHash,
 		}
 
+		// Compute batch expiry as absolute block height.
+		sweepDelay := int32(env.OperatorTerms.SweepDelay)
+		batchExpiry := evt.BlockHeight + sweepDelay
+
+		// Build outbox messages starting with standard notifications.
+		outbox := []ClientOutMsg{
+			&VTXOCreatedNotification{
+				VTXOs:          vtxos,
+				RoundID:        s.RoundID.String(),
+				CommitmentTxID: evt.TxID,
+				BatchExpiry:    batchExpiry,
+				CreatedHeight:  evt.BlockHeight,
+			},
+			&RoundCompletedNotification{
+				RoundID:  s.RoundID,
+				TxID:     evt.TxID,
+				ConfInfo: confInfo,
+			},
+		}
+
+		// If this round included refresh requests, notify the old VTXO
+		// actors that their forfeit is now confirmed. This allows them
+		// to transition to the terminal Forfeited state.
+		for _, vtxoOutpoint := range s.ForfeitedVTXOs {
+			outbox = append(outbox, &ForfeitConfirmedToVTXO{
+				VTXOOutpoint:   vtxoOutpoint,
+				CommitmentTxID: evt.TxID,
+				BlockHeight:    evt.BlockHeight,
+			})
+		}
+
 		return &ClientStateTransition{
 			NextState: &ConfirmedState{
 				TxID:          evt.TxID,
@@ -1261,14 +1670,7 @@ func (s *InputSigSentState) ProcessEvent(
 				VTXOs:         vtxos,
 			},
 			NewEvents: fn.Some(ClientEmittedEvent{
-				Outbox: []ClientOutMsg{
-					&VTXOCreatedNotification{VTXOs: vtxos},
-					&RoundCompletedNotification{
-						RoundID:  s.RoundID,
-						TxID:     evt.TxID,
-						ConfInfo: confInfo,
-					},
-				},
+				Outbox: outbox,
 			}),
 		}, nil
 

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -10,6 +10,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btclog/v2"
@@ -58,6 +59,92 @@ func selfLoop(state ClientState) *ClientStateTransition {
 	return &ClientStateTransition{
 		NextState: state,
 	}
+}
+
+// signBoardingInputs signs all boarding inputs for a commitment transaction.
+// This builds the PrevOutputFetcher, sigHashes, and generates Schnorr
+// signatures for each boarding intent's input.
+func signBoardingInputs(wallet ClientWallet, commitmentTx *psbt.Packet,
+	intents Intents, boardingInputIndices map[wire.OutPoint]int,
+) ([]*types.BoardingInputSignature, error) {
+
+	tx := commitmentTx.UnsignedTx
+
+	// Build a PrevOutputFetcher from ALL PSBT inputs. Taproot sighash
+	// (BIP341) requires prevout info for all inputs.
+	prevOuts := make(map[wire.OutPoint]*wire.TxOut)
+	for i, pIn := range commitmentTx.Inputs {
+		if pIn.WitnessUtxo == nil {
+			return nil, fmt.Errorf("PSBT input %d missing "+
+				"WitnessUtxo", i)
+		}
+		outpoint := tx.TxIn[i].PreviousOutPoint
+		prevOuts[outpoint] = pIn.WitnessUtxo
+	}
+	prevOutFetcher := txscript.NewMultiPrevOutFetcher(prevOuts)
+	sigHashes := txscript.NewTxSigHashes(tx, prevOutFetcher)
+
+	// Build structured boarding input signatures for each intent.
+	var boardingInputSigs []*types.BoardingInputSignature
+	for _, boardingIntent := range intents.Boarding {
+		outpoint := boardingIntent.Request.Outpoint
+		inputIdx, found := boardingInputIndices[*outpoint]
+		if !found {
+			return nil, fmt.Errorf("no input index "+
+				"found for boarding outpoint %s",
+				outpoint)
+		}
+
+		spendInfo, err := scripts.NewVTXOSpendInfo(
+			boardingIntent.Address.Tapscript,
+			scripts.VTXOCollabPathLeaf,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		chainInfo := boardingIntent.ChainInfo
+		addr := boardingIntent.Address.Address
+		amt := chainInfo.Amount
+
+		// Use PayToAddrScript to get the full pkScript with OP_1
+		// OP_PUSHBYTES_32 prefix for P2TR addresses. ScriptAddress()
+		// only returns the 32-byte witness program.
+		pkScript, err := txscript.PayToAddrScript(addr)
+		if err != nil {
+			return nil, fmt.Errorf("pay to addr script: %w", err)
+		}
+
+		output := &wire.TxOut{
+			Value:    int64(amt),
+			PkScript: pkScript,
+		}
+
+		signature, err := scripts.SignVTXOCollabInput(
+			wallet, tx, inputIdx, spendInfo,
+			&boardingIntent.Address.KeyDesc, output,
+			sigHashes, prevOutFetcher,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to sign "+
+				"boarding input %d: %w", inputIdx, err)
+		}
+
+		schnorrSig, ok := signature.(*schnorr.Signature)
+		if !ok {
+			return nil, fmt.Errorf("signature is not a " +
+				"schnorr signature")
+		}
+
+		inputSig := &types.BoardingInputSignature{
+			InputIndex:      inputIdx,
+			Outpoint:        *outpoint,
+			ClientSignature: schnorrSig,
+		}
+		boardingInputSigs = append(boardingInputSigs, inputSig)
+	}
+
+	return boardingInputSigs, nil
 }
 
 // ProcessEvent handles the events from the Idle state. In this state, we'll
@@ -849,8 +936,6 @@ func (s *CommitmentTxValidatedState) ProcessEvent(
 // ForfeitSignatureResponse. Once all expected signatures are collected, we
 // sign boarding inputs, submit all signatures to the server, and transition
 // to InputSigSentState.
-//
-//nolint:funlen
 func (s *ForfeitSignaturesCollectingState) ProcessEvent(
 	ctx context.Context, event ClientEvent, env *ClientEnvironment,
 ) (*ClientStateTransition, error) {
@@ -926,85 +1011,22 @@ func (s *ForfeitSignaturesCollectingState) ProcessEvent(
 			slog.Int("forfeit_count", len(forfeitedVTXOs)),
 			slog.Int("boarding_intent_count", len(s.Intents.Boarding)))
 
-		// Now sign boarding inputs. Build PrevOutputFetcher from PSBT.
-		commitTx := s.CommitmentTx.UnsignedTx
-		prevOuts := make(map[wire.OutPoint]*wire.TxOut)
-		for i, pIn := range s.CommitmentTx.Inputs {
-			if pIn.WitnessUtxo == nil {
-				return nil, fmt.Errorf("PSBT input %d missing "+
-					"WitnessUtxo", i)
-			}
-			outpoint := commitTx.TxIn[i].PreviousOutPoint
-			prevOuts[outpoint] = pIn.WitnessUtxo
-		}
-		prevOutFetcher := txscript.NewMultiPrevOutFetcher(prevOuts)
-		sigHashes := txscript.NewTxSigHashes(commitTx, prevOutFetcher)
-
-		// Build boarding input signatures.
-		var boardingInputSigs []*types.BoardingInputSignature
-		for _, boardingIntent := range s.Intents.Boarding {
-			outpoint := boardingIntent.Request.Outpoint
-			inputIdx, found := s.BoardingInputIndices[*outpoint]
-			if !found {
-				return nil, fmt.Errorf("no input index "+
-					"found for boarding outpoint %s",
-					outpoint)
-			}
-
-			spendInfo, err := scripts.NewVTXOSpendInfo(
-				boardingIntent.Address.Tapscript,
-				scripts.VTXOCollabPathLeaf,
-			)
-			if err != nil {
-				return nil, err
-			}
-
-			chainInfo := boardingIntent.ChainInfo
-			addr := boardingIntent.Address.Address
-			amt := chainInfo.Amount
-
-			pkScript, err := txscript.PayToAddrScript(addr)
-			if err != nil {
-				return nil, fmt.Errorf("pay to addr script: %w",
-					err)
-			}
-
-			output := &wire.TxOut{
-				Value:    int64(amt),
-				PkScript: pkScript,
-			}
-
-			signature, err := scripts.SignVTXOCollabInput(
-				env.Wallet, commitTx, inputIdx, spendInfo,
-				&boardingIntent.Address.KeyDesc, output,
-				sigHashes, prevOutFetcher,
-			)
-			if err != nil {
-				return nil, fmt.Errorf("failed to sign "+
-					"boarding input %d: %w", inputIdx, err)
-			}
-
-			schnorrSig, ok := signature.(*schnorr.Signature)
-			if !ok {
-				return nil, fmt.Errorf("signature is not a " +
-					"schnorr signature")
-			}
-
-			inputSig := &types.BoardingInputSignature{
-				InputIndex:      inputIdx,
-				Outpoint:        *outpoint,
-				ClientSignature: schnorrSig,
-			}
-			boardingInputSigs = append(boardingInputSigs, inputSig)
+		// Sign all boarding inputs using the shared helper.
+		boardingInputSigs, err := signBoardingInputs(
+			env.Wallet, s.CommitmentTx, s.Intents,
+			s.BoardingInputIndices,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("sign boarding inputs: %w", err)
 		}
 
 		// Build outbox messages.
-		txid := commitTx.TxHash()
+		txid := s.CommitmentTx.UnsignedTx.TxHash()
 		callerID := fmt.Sprintf("commitment-%s", txid.String())
 
 		var pkScript []byte
-		if len(commitTx.TxOut) > 0 {
-			pkScript = commitTx.TxOut[0].PkScript
+		if len(s.CommitmentTx.UnsignedTx.TxOut) > 0 {
+			pkScript = s.CommitmentTx.UnsignedTx.TxOut[0].PkScript
 		}
 
 		outboxMsgs := []ClientOutMsg{
@@ -1228,8 +1250,6 @@ func (s *NoncesAggregatedState) ProcessEvent(
 }
 
 // ProcessEvent for PartialSigsSentState.
-//
-//nolint:funlen
 func (s *PartialSigsSentState) ProcessEvent(
 	ctx context.Context, event ClientEvent, env *ClientEnvironment,
 ) (*ClientStateTransition, error) {
@@ -1289,94 +1309,13 @@ func (s *PartialSigsSentState) ProcessEvent(
 			slog.String("round_id", s.RoundID.String()),
 			slog.Int("boarding_intent_count", len(s.Intents.Boarding)))
 
-		// Build a PrevOutputFetcher from ALL PSBT inputs. Taproot
-		// sighash (BIP341) requires prevout info for all inputs.
-		tx := s.CommitmentTx.UnsignedTx
-		prevOuts := make(map[wire.OutPoint]*wire.TxOut)
-		for i, pIn := range s.CommitmentTx.Inputs {
-			if pIn.WitnessUtxo == nil {
-				return nil, fmt.Errorf("PSBT input %d missing "+
-					"WitnessUtxo", i)
-			}
-			outpoint := tx.TxIn[i].PreviousOutPoint
-			prevOuts[outpoint] = pIn.WitnessUtxo
-		}
-		prevOutFetcher := txscript.NewMultiPrevOutFetcher(prevOuts)
-		sigHashes := txscript.NewTxSigHashes(tx, prevOutFetcher)
-
-		// Build structured boarding input signatures for each intent.
-		var boardingInputSigs []*types.BoardingInputSignature
-		for _, boardingIntent := range s.Intents.Boarding {
-			outpoint := boardingIntent.Request.Outpoint
-			inputIdx, found := s.BoardingInputIndices[*outpoint]
-			if !found {
-				return nil, fmt.Errorf("no input index "+
-					"found for boarding outpoint %s",
-					outpoint)
-			}
-
-			spendInfo, err := scripts.NewVTXOSpendInfo(
-				boardingIntent.Address.Tapscript,
-				scripts.VTXOCollabPathLeaf,
-			)
-			if err != nil {
-				return nil, err
-			}
-
-			// Access chain info directly from the embedded wallet
-			// intent.
-			chainInfo := boardingIntent.ChainInfo
-			addr := boardingIntent.Address.Address
-			amt := chainInfo.Amount
-
-			// Use PayToAddrScript to get the full pkScript with
-			// OP_1 OP_PUSHBYTES_32 prefix for P2TR addresses.
-			// ScriptAddress() only returns the 32-byte witness.
-			pkScript, err := txscript.PayToAddrScript(addr)
-			if err != nil {
-				return nil, fmt.Errorf("pay to addr script: %w",
-					err)
-			}
-
-			// Create the TxOut for the boarding output.
-			output := &wire.TxOut{
-				Value:    int64(amt),
-				PkScript: pkScript,
-			}
-
-			signature, err := scripts.SignVTXOCollabInput(
-				env.Wallet, tx, inputIdx, spendInfo,
-				&boardingIntent.Address.KeyDesc, output,
-				sigHashes, prevOutFetcher,
-			)
-			if err != nil {
-				return nil, fmt.Errorf("failed to sign "+
-					"boarding input %d: %w", inputIdx, err)
-			}
-
-			// Convert input.Signature to *schnorr.Signature.
-			schnorrSig, ok := signature.(*schnorr.Signature)
-			if !ok {
-				return nil, fmt.Errorf("signature is not a " +
-					"schnorr signature")
-			}
-
-			// Build the structured boarding input signature.
-			inputSig := &types.BoardingInputSignature{
-				InputIndex:      inputIdx,
-				Outpoint:        *outpoint,
-				ClientSignature: schnorrSig,
-			}
-			boardingInputSigs = append(
-				boardingInputSigs, inputSig,
-			)
-		}
-
-		numSigs := len(boardingInputSigs)
-		numIntents := len(s.Intents.Boarding)
-		if numSigs != numIntents {
-			return nil, fmt.Errorf("signature count %d != "+
-				"intent count %d", numSigs, numIntents)
+		// Sign all boarding inputs using the shared helper.
+		boardingInputSigs, err := signBoardingInputs(
+			env.Wallet, s.CommitmentTx, s.Intents,
+			s.BoardingInputIndices,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("sign boarding inputs: %w", err)
 		}
 
 		// Create a single forfeit signature request with all
@@ -1386,20 +1325,21 @@ func (s *PartialSigsSentState) ProcessEvent(
 			Signatures: boardingInputSigs,
 		}
 
-		txid := tx.TxHash()
+		txid := s.CommitmentTx.UnsignedTx.TxHash()
 		callerID := fmt.Sprintf("commitment-%s", txid.String())
 
 		// Get pkScript from the first output for LND confirmation
 		// tracking.
+		commitTx := s.CommitmentTx.UnsignedTx
 		var pkScript []byte
-		if len(tx.TxOut) > 0 {
-			pkScript = tx.TxOut[0].PkScript
+		if len(commitTx.TxOut) > 0 {
+			pkScript = commitTx.TxOut[0].PkScript
 		}
 
 		env.Log.InfoS(ctx, "Building RegisterConfirmationRequest",
 			slog.String("round_id", s.RoundID.String()),
 			slog.String("txid", txid.String()),
-			slog.Int("num_outputs", len(tx.TxOut)),
+			slog.Int("num_outputs", len(commitTx.TxOut)),
 			slog.Int("pkscript_len", len(pkScript)),
 			slog.Int("target_confs", int(env.OperatorTerms.MinConfirmations)))
 
@@ -1449,7 +1389,7 @@ func (s *PartialSigsSentState) ProcessEvent(
 			ClientTrees:   s.ClientTrees,
 			InputSigs:     boardingInputSigs,
 		}
-		err := env.RoundStore.CommitState(ctx, round, nextState)
+		err = env.RoundStore.CommitState(ctx, round, nextState)
 		if err != nil {
 			return nil, fmt.Errorf("failed to commit round "+
 				"state: %w", err)

--- a/round/transitions_test.go
+++ b/round/transitions_test.go
@@ -2085,7 +2085,6 @@ func TestForfeitMappingsCarriedThroughSigningStates(t *testing.T) {
 	intent := h.newTestBoardingIntent()
 	vtxoOutpoint := h.newTestOutpoint()
 	connectorOutpoint := h.newTestOutpoint()
-	serverForfeitScript := []byte{0x51, 0x20}
 
 	// Build forfeit mappings for a refresh round.
 	forfeitMappings := map[wire.OutPoint]*ConnectorLeafInfo{
@@ -2104,7 +2103,6 @@ func TestForfeitMappingsCarriedThroughSigningStates(t *testing.T) {
 		roundID, []BoardingIntent{intent},
 	)
 	validatedState.ForfeitMappings = forfeitMappings
-	validatedState.ServerForfeitPkScript = serverForfeitScript
 	h.withState(validatedState)
 
 	// Generate nonces.

--- a/round/transitions_test.go
+++ b/round/transitions_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/google/uuid"
+	"github.com/lightninglabs/darepo-client/lib/scripts"
 	"github.com/lightninglabs/darepo-client/lib/tree"
 	"github.com/lightninglabs/darepo-client/lib/types"
 	"github.com/stretchr/testify/mock"
@@ -1723,4 +1724,589 @@ func TestBoardingFlowFailureAndRecovery(t *testing.T) {
 
 	recoveryState := assertStateType[*RecoveryInitiatedState](h)
 	require.Equal(t, intent.Outpoint, recoveryState.Outpoint)
+}
+
+// TestForfeitSignaturesCollectingState tests the forfeit signature collection
+// flow which is used when VTXOs are being refreshed in a batch swap round.
+func TestForfeitSignaturesCollectingState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("single_forfeit_collection", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+		h.setupMockWalletForBoardingSigning()
+		h.setupMockRoundStoreForCheckpoint()
+
+		intent := h.newTestBoardingIntent()
+		vtxoOutpoint := h.newTestOutpoint()
+		connectorOutpoint := h.newTestOutpoint()
+		serverForfeitScript := []byte{0x51, 0x20}
+
+		// Build a valid forfeit tx structure for validation.
+		forfeitTx := h.newTestForfeitTx(
+			vtxoOutpoint, connectorOutpoint, serverForfeitScript,
+		)
+
+		roundID := testRoundIDTr("round-forfeit-001")
+		state := h.newForfeitCollectingState(
+			roundID,
+			Intents{Boarding: []BoardingIntent{intent}},
+			map[wire.OutPoint]*ConnectorLeafInfo{
+				vtxoOutpoint: {
+					LeafIndex:         0,
+					ConnectorOutpoint: connectorOutpoint,
+					ConnectorPkScript: []byte{0x51, 0x20},
+					ConnectorAmount:   546,
+					VTXOAmount:        50000,
+				},
+			},
+			serverForfeitScript,
+		)
+		h.withState(state)
+
+		// Send forfeit signature response.
+		event := &ForfeitSignatureResponse{
+			VTXOOutpoint: vtxoOutpoint,
+			RoundID:      roundID.String(),
+			ForfeitTx:    forfeitTx,
+			Signature:    make([]byte, 64),
+		}
+
+		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		// Should transition to InputSigSentState. In the new flow,
+		// forfeit collection happens AFTER VTXO tree signing, so
+		// completing forfeits goes directly to InputSigSentState.
+		inputSigState := assertStateType[*InputSigSentState](h)
+		require.Equal(t, roundID, inputSigState.RoundID)
+		require.Len(t, inputSigState.ForfeitedVTXOs, 1)
+		require.Equal(t, vtxoOutpoint, inputSigState.ForfeitedVTXOs[0])
+
+		// Should emit SubmitVTXOForfeitSigsToServer and
+		// SubmitForfeitSigRequest (boarding input signatures).
+		forfeitType := "*round.SubmitVTXOForfeitSigsToServer"
+		h.assertOutboxContainsType(forfeitType)
+		h.assertOutboxContainsType("*round.SubmitForfeitSigRequest")
+	})
+
+	t.Run("multiple_forfeits_wait_for_all", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+		h.setupMockWalletForBoardingSigning()
+		h.setupMockRoundStoreForCheckpoint()
+
+		intent := h.newTestBoardingIntent()
+		vtxoOutpoint1 := h.newTestOutpoint()
+		vtxoOutpoint2 := h.newTestOutpoint()
+		connectorOutpoint1 := h.newTestOutpoint()
+		connectorOutpoint2 := h.newTestOutpoint()
+		serverForfeitScript := []byte{0x51, 0x20}
+
+		roundID := testRoundIDTr("round-forfeit-002")
+		state := h.newForfeitCollectingState(
+			roundID,
+			Intents{Boarding: []BoardingIntent{intent}},
+			map[wire.OutPoint]*ConnectorLeafInfo{
+				vtxoOutpoint1: {
+					LeafIndex:         0,
+					ConnectorOutpoint: connectorOutpoint1,
+					ConnectorPkScript: []byte{0x51, 0x20},
+					ConnectorAmount:   546,
+					VTXOAmount:        50000,
+				},
+				vtxoOutpoint2: {
+					LeafIndex:         1,
+					ConnectorOutpoint: connectorOutpoint2,
+					ConnectorPkScript: []byte{0x51, 0x20},
+					ConnectorAmount:   546,
+					VTXOAmount:        50000,
+				},
+			},
+			serverForfeitScript,
+		)
+		h.withState(state)
+
+		// Send first forfeit - should stay in state.
+		forfeitTx1 := h.newTestForfeitTx(
+			vtxoOutpoint1, connectorOutpoint1, serverForfeitScript,
+		)
+		event1 := &ForfeitSignatureResponse{
+			VTXOOutpoint: vtxoOutpoint1,
+			RoundID:      roundID.String(),
+			ForfeitTx:    forfeitTx1,
+			Signature:    make([]byte, 64),
+		}
+
+		_, err := h.sendEvent(event1)
+		require.NoError(t, err)
+
+		// Should still be in ForfeitSignaturesCollectingState.
+		//nolint:ll
+		collectingState := assertStateType[*ForfeitSignaturesCollectingState](h)
+		require.Len(t, collectingState.CollectedForfeits, 1)
+
+		// Send second forfeit - should transition.
+		forfeitTx2 := h.newTestForfeitTx(
+			vtxoOutpoint2, connectorOutpoint2, serverForfeitScript,
+		)
+		event2 := &ForfeitSignatureResponse{
+			VTXOOutpoint: vtxoOutpoint2,
+			RoundID:      roundID.String(),
+			ForfeitTx:    forfeitTx2,
+			Signature:    make([]byte, 64),
+		}
+
+		transition, err := h.sendEvent(event2)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		// Now should transition to InputSigSentState.
+		inputSigState := assertStateType[*InputSigSentState](h)
+		require.Len(t, inputSigState.ForfeitedVTXOs, 2)
+	})
+
+	t.Run("duplicate_forfeit_ignored", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+
+		intent := h.newTestBoardingIntent()
+		vtxoOutpoint := h.newTestOutpoint()
+		connectorOutpoint := h.newTestOutpoint()
+		serverForfeitScript := []byte{0x51, 0x20}
+
+		// We need 2 expected forfeits to stay in state after first.
+		vtxoOutpoint2 := h.newTestOutpoint()
+		connectorOutpoint2 := h.newTestOutpoint()
+
+		roundID := testRoundIDTr("round-forfeit-003")
+		state := h.newForfeitCollectingState(
+			roundID,
+			Intents{Boarding: []BoardingIntent{intent}},
+			map[wire.OutPoint]*ConnectorLeafInfo{
+				vtxoOutpoint: {
+					LeafIndex:         0,
+					ConnectorOutpoint: connectorOutpoint,
+					ConnectorPkScript: []byte{0x51, 0x20},
+					ConnectorAmount:   546,
+					VTXOAmount:        50000,
+				},
+				vtxoOutpoint2: {
+					LeafIndex:         1,
+					ConnectorOutpoint: connectorOutpoint2,
+					ConnectorPkScript: []byte{0x51, 0x20},
+					ConnectorAmount:   546,
+					VTXOAmount:        50000,
+				},
+			},
+			serverForfeitScript,
+		)
+		h.withState(state)
+
+		forfeitTx := h.newTestForfeitTx(
+			vtxoOutpoint, connectorOutpoint, serverForfeitScript,
+		)
+		event := &ForfeitSignatureResponse{
+			VTXOOutpoint: vtxoOutpoint,
+			RoundID:      roundID.String(),
+			ForfeitTx:    forfeitTx,
+			Signature:    make([]byte, 64),
+		}
+
+		// First response.
+		_, err := h.sendEvent(event)
+		require.NoError(t, err)
+
+		//nolint:ll
+		collectingState := assertStateType[*ForfeitSignaturesCollectingState](h)
+		require.Len(t, collectingState.CollectedForfeits, 1)
+
+		// Duplicate response - should be ignored.
+		_, err = h.sendEvent(event)
+		require.NoError(t, err)
+
+		//nolint:ll
+		collectingState = assertStateType[*ForfeitSignaturesCollectingState](h)
+		require.Len(t, collectingState.CollectedForfeits, 1)
+	})
+
+	t.Run("unexpected_forfeit_error", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+
+		intent := h.newTestBoardingIntent()
+		vtxoOutpoint := h.newTestOutpoint()
+		connectorOutpoint := h.newTestOutpoint()
+		serverForfeitScript := []byte{0x51, 0x20}
+
+		roundID := testRoundIDTr("round-forfeit-004")
+		state := h.newForfeitCollectingState(
+			roundID,
+			Intents{Boarding: []BoardingIntent{intent}},
+			map[wire.OutPoint]*ConnectorLeafInfo{
+				vtxoOutpoint: {
+					LeafIndex:         0,
+					ConnectorOutpoint: connectorOutpoint,
+					ConnectorPkScript: []byte{0x51, 0x20},
+					ConnectorAmount:   546,
+					VTXOAmount:        50000,
+				},
+			},
+			serverForfeitScript,
+		)
+		h.withState(state)
+
+		// Send forfeit for unknown VTXO.
+		unknownOutpoint := h.newTestOutpoint()
+		event := &ForfeitSignatureResponse{
+			VTXOOutpoint: unknownOutpoint,
+			RoundID:      roundID.String(),
+			Signature:    make([]byte, 64),
+		}
+
+		_, err := h.sendEvent(event)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unexpected forfeit")
+	})
+
+	t.Run("boarding_failed_transitions", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+
+		intent := h.newTestBoardingIntent()
+		vtxoOutpoint := h.newTestOutpoint()
+		connectorOutpoint := h.newTestOutpoint()
+
+		roundID := testRoundIDTr("round-forfeit-005")
+		state := h.newForfeitCollectingState(
+			roundID,
+			Intents{Boarding: []BoardingIntent{intent}},
+			map[wire.OutPoint]*ConnectorLeafInfo{
+				vtxoOutpoint: {
+					LeafIndex:         0,
+					ConnectorOutpoint: connectorOutpoint,
+					ConnectorPkScript: []byte{0x51, 0x20},
+					ConnectorAmount:   546,
+					VTXOAmount:        50000,
+				},
+			},
+			[]byte{0x51, 0x20},
+		)
+		h.withState(state)
+
+		event := &BoardingFailed{
+			Reason:      "server disconnected",
+			Recoverable: true,
+		}
+
+		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		failedState := assertStateType[*ClientFailedState](h)
+		require.Equal(t, "server disconnected", failedState.Reason)
+		require.True(t, failedState.Recoverable)
+	})
+
+	t.Run("forfeit_amount_mismatch_fails", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+
+		intent := h.newTestBoardingIntent()
+		vtxoOutpoint := h.newTestOutpoint()
+		connectorOutpoint := h.newTestOutpoint()
+		serverForfeitScript := []byte{0x51, 0x20}
+
+		// Create forfeit tx with 40000 sats (mismatch).
+		forfeitTx := wire.NewMsgTx(2)
+		forfeitTx.AddTxIn(&wire.TxIn{
+			PreviousOutPoint: vtxoOutpoint,
+		})
+		forfeitTx.AddTxIn(&wire.TxIn{
+			PreviousOutPoint: connectorOutpoint,
+		})
+		forfeitTx.AddTxOut(&wire.TxOut{
+			Value:    40000, // Wrong amount - expected 50000.
+			PkScript: serverForfeitScript,
+		})
+		forfeitTx.AddTxOut(&wire.TxOut{
+			Value:    0,
+			PkScript: scripts.AnchorPkScript,
+		})
+
+		// Create state expecting 50000 sats.
+		roundID := testRoundIDTr("round-forfeit-amount")
+		state := h.newForfeitCollectingState(
+			roundID,
+			Intents{Boarding: []BoardingIntent{intent}},
+			map[wire.OutPoint]*ConnectorLeafInfo{
+				vtxoOutpoint: {
+					LeafIndex:         0,
+					ConnectorOutpoint: connectorOutpoint,
+					ConnectorPkScript: []byte{0x51, 0x20},
+					ConnectorAmount:   546,
+					VTXOAmount:        50000,
+				},
+			},
+			serverForfeitScript,
+		)
+		h.withState(state)
+
+		event := &ForfeitSignatureResponse{
+			VTXOOutpoint: vtxoOutpoint,
+			RoundID:      roundID.String(),
+			ForfeitTx:    forfeitTx,
+			Signature:    make([]byte, 64),
+		}
+
+		_, err := h.sendEvent(event)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "forfeit tx penalty output")
+		require.Contains(t, err.Error(), "amount")
+	})
+}
+
+// TestForfeitMappingsCarriedThroughSigningStates verifies that ForfeitMappings
+// is carried through NoncesSent, NoncesAggregated, and PartialSigsSent states
+// so that forfeit signature collection can happen after VTXO tree signing.
+func TestForfeitMappingsCarriedThroughSigningStates(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+	h.setupMockWalletForMuSig2()
+
+	intent := h.newTestBoardingIntent()
+	vtxoOutpoint := h.newTestOutpoint()
+	connectorOutpoint := h.newTestOutpoint()
+	serverForfeitScript := []byte{0x51, 0x20}
+
+	// Build forfeit mappings for a refresh round.
+	forfeitMappings := map[wire.OutPoint]*ConnectorLeafInfo{
+		vtxoOutpoint: {
+			LeafIndex:         0,
+			ConnectorOutpoint: connectorOutpoint,
+			ConnectorPkScript: []byte{0x51, 0x20},
+			ConnectorAmount:   546,
+			VTXOAmount:        50000,
+		},
+	}
+
+	// Start from CommitmentTxValidatedState with ForfeitMappings populated.
+	roundID := testRoundID("round-carry-001")
+	validatedState := h.newCommitmentTxValidatedState(
+		roundID, []BoardingIntent{intent},
+	)
+	validatedState.ForfeitMappings = forfeitMappings
+	validatedState.ServerForfeitPkScript = serverForfeitScript
+	h.withState(validatedState)
+
+	// Generate nonces.
+	_, err := h.sendEvent(&GenerateNonces{})
+	require.NoError(t, err)
+	h.clearOutbox()
+
+	// Check NoncesSentState has ForfeitMappings.
+	noncesSentState := assertStateType[*NoncesSentState](h)
+	require.Len(t, noncesSentState.ForfeitMappings, 1)
+	require.Contains(t, noncesSentState.ForfeitMappings, vtxoOutpoint)
+
+	// Send aggregated nonces.
+	aggEvent := h.newNoncesAggregatedEvent(
+		roundID, noncesSentState.VTXOTreePaths[0],
+	)
+	_, err = h.sendEvent(aggEvent)
+	require.NoError(t, err)
+	h.clearOutbox()
+
+	// Check NoncesAggregatedState has ForfeitMappings.
+	noncesAggState := assertStateType[*NoncesAggregatedState](h)
+	require.Len(t, noncesAggState.ForfeitMappings, 1)
+	require.Contains(t, noncesAggState.ForfeitMappings, vtxoOutpoint)
+}
+
+// TestInputSigSentStateEmitsForfeitConfirmed verifies that when
+// BoardingConfirmed is received in InputSigSentState, ForfeitConfirmedToVTXO
+// messages are emitted for all forfeited VTXOs.
+func TestInputSigSentStateEmitsForfeitConfirmed(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+	h.setupMockVTXOStoreForSave()
+
+	intent := h.newTestBoardingIntent()
+	vtxoOutpoint1 := h.newTestOutpoint()
+	vtxoOutpoint2 := h.newTestOutpoint()
+
+	roundID := testRoundID("round-forfeit-confirm")
+	state := h.newInputSigSentState(roundID, []BoardingIntent{intent})
+	state.ForfeitedVTXOs = []wire.OutPoint{vtxoOutpoint1, vtxoOutpoint2}
+	h.withState(state)
+
+	event := &BoardingConfirmed{
+		TxID:          state.CommitmentTx.UnsignedTx.TxHash(),
+		BlockHeight:   101,
+		Confirmations: 6,
+	}
+
+	_, err := h.sendEvent(event)
+	require.NoError(t, err)
+
+	_ = assertStateType[*ConfirmedState](h)
+
+	// Should emit ForfeitConfirmedToVTXO for each forfeited VTXO.
+	forfeitConfirmCount := 0
+	for _, msg := range h.outboxMessages {
+		if forfeitMsg, ok := msg.(*ForfeitConfirmedToVTXO); ok {
+			forfeitConfirmCount++
+			require.Equal(t, int32(101), forfeitMsg.BlockHeight)
+		}
+	}
+	require.Equal(t, 2, forfeitConfirmCount)
+}
+
+// TestStatePropertiesForfeitState verifies ForfeitSignaturesCollectingState
+// properties.
+func TestStatePropertiesForfeitState(t *testing.T) {
+	t.Parallel()
+
+	state := &ForfeitSignaturesCollectingState{
+		RoundID: testRoundID("round-001"),
+	}
+
+	require.False(t, state.IsTerminal())
+	require.Equal(t, "ForfeitSignaturesCollecting", state.String())
+}
+
+// TestForfeitCollectionStateImmutability verifies that when a forfeit
+// signature response is received, the FSM creates a new state object rather
+// than mutating the existing one. This is important for FSM correctness.
+func TestForfeitCollectionStateImmutability(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+
+	intent := h.newTestBoardingIntent()
+	vtxoOutpoint1 := h.newTestOutpoint()
+	vtxoOutpoint2 := h.newTestOutpoint()
+	connectorOutpoint1 := h.newTestOutpoint()
+	connectorOutpoint2 := h.newTestOutpoint()
+	serverForfeitScript := []byte{0x51, 0x20}
+
+	roundID := testRoundIDTr("round-immut-001")
+	state := h.newForfeitCollectingState(
+		roundID,
+		Intents{Boarding: []BoardingIntent{intent}},
+		map[wire.OutPoint]*ConnectorLeafInfo{
+			vtxoOutpoint1: {
+				LeafIndex:         0,
+				ConnectorOutpoint: connectorOutpoint1,
+				ConnectorPkScript: []byte{0x51, 0x20},
+				ConnectorAmount:   546,
+				VTXOAmount:        50000,
+			},
+			vtxoOutpoint2: {
+				LeafIndex:         1,
+				ConnectorOutpoint: connectorOutpoint2,
+				ConnectorPkScript: []byte{0x51, 0x20},
+				ConnectorAmount:   546,
+				VTXOAmount:        50000,
+			},
+		},
+		serverForfeitScript,
+	)
+
+	// Save original state's CollectedForfeits map reference.
+	originalMap := state.CollectedForfeits
+	originalMapLen := len(originalMap)
+	h.withState(state)
+
+	// Send first forfeit - should NOT mutate original state's map.
+	forfeitTx1 := h.newTestForfeitTx(
+		vtxoOutpoint1, connectorOutpoint1, serverForfeitScript,
+	)
+	event1 := &ForfeitSignatureResponse{
+		VTXOOutpoint: vtxoOutpoint1,
+		RoundID:      "round-immut-001",
+		ForfeitTx:    forfeitTx1,
+		Signature:    make([]byte, 64),
+	}
+
+	_, err := h.sendEvent(event1)
+	require.NoError(t, err)
+
+	// The ORIGINAL state's map should NOT have been modified.
+	require.Len(
+		t, originalMap, originalMapLen,
+		"original state's CollectedForfeits map was mutated",
+	)
+
+	// The NEW state should have the collected forfeit.
+	newState := assertStateType[*ForfeitSignaturesCollectingState](h)
+	require.Len(t, newState.CollectedForfeits, 1)
+
+	// Verify the new state is a different object by checking it has the
+	// updated forfeit while the original doesn't.
+	_, hasInNew := newState.CollectedForfeits[vtxoOutpoint1]
+	require.True(t, hasInNew, "new state should have the forfeit")
+
+	_, hasInOriginal := originalMap[vtxoOutpoint1]
+	require.False(t, hasInOriginal, "original map should not have forfeit")
+}
+
+// TestRefreshOnlyRoundValidation verifies that rounds containing only refresh
+// requests (no boarding intents) can successfully pass commitment validation.
+func TestRefreshOnlyRoundValidation(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+
+	// Create a state with NO boarding intents (refresh-only round).
+	emptyIntents := Intents{Boarding: []BoardingIntent{}}
+	roundID := testRoundIDTr("round-refresh-001")
+
+	// Create a minimal commitment tx with no boarding inputs.
+	commitmentTx := h.newTestCommitmentTxWithInputs(0)
+
+	// Create a VTXT tree. For refresh-only rounds, this would contain
+	// VTXOs for the refreshed amounts, but we need a minimal valid tree.
+	vtxtTree := h.newMinimalVTXOTree()
+
+	state := &CommitmentTxReceivedState{
+		RoundID:       roundID,
+		CommitmentTx:  commitmentTx,
+		TxID:          commitmentTx.UnsignedTx.TxHash(),
+		VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
+		Intents:       emptyIntents,
+		ClientTrees:   make(map[SignerKey]*tree.Tree),
+	}
+	h.withState(state)
+
+	// No forfeit mappings for this simple test - just validating the
+	// round can proceed without boarding intents.
+	event := &CommitmentTxBuilt{
+		RoundID:       roundID,
+		Tx:            commitmentTx,
+		VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
+	}
+
+	transition, err := h.sendEvent(event)
+	require.NoError(t, err)
+	require.NotNil(t, transition)
+
+	// Should transition to CommitmentTxValidatedState, not fail.
+	validatedState := assertStateType[*CommitmentTxValidatedState](h)
+	require.Equal(t, roundID, validatedState.RoundID)
+
+	// BoardingInputIndices should be empty (no boarding inputs).
+	require.Empty(t, validatedState.BoardingInputIndices)
+
+	// Should emit GenerateNonces internal event.
+	assertTransitionEmitsInternalEvent[*GenerateNonces](h, transition)
 }

--- a/vtxo/actor.go
+++ b/vtxo/actor.go
@@ -5,12 +5,14 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
 	"github.com/lightninglabs/darepo-client/chainsource"
 	"github.com/lightninglabs/darepo-client/lib/actormsg"
+	"github.com/lightninglabs/darepo-client/lib/types"
 	"github.com/lightninglabs/darepo-client/round"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 )
@@ -180,13 +182,16 @@ func (a *VTXOActor) processOutbox(ctx context.Context, outbox []VTXOOutMsg) {
 			}
 
 		case *RefreshRequest:
-			// Route refresh request to round actor. Include all
-			// fields needed to build the server's RefreshRequest
-			// and VTXORequest. We reuse the same client key for the
-			// new VTXO.
+			// Route refresh request to round actor. This tells
+			// the round to include this VTXO in the forfeit flow.
+			// We also send a separate VTXORequest to explicitly
+			// request a new VTXO for the refreshed value (refresh
+			// no longer automatically creates a replacement VTXO).
 			if a.cfg.RoundActor != nil {
 				vtxo := a.cfg.VTXO
-				req := &round.RefreshVTXORequest{
+
+				// Send the refresh request for forfeit flow.
+				refreshReq := &round.RefreshVTXORequest{
 					VTXOOutpoint: m.VTXOOutpoint,
 					Amount:       m.Amount,
 					NewVTXOKey:   vtxo.ClientKey.PubKey,
@@ -195,10 +200,33 @@ func (a *VTXOActor) processOutbox(ctx context.Context, outbox []VTXOOutMsg) {
 					Expiry:       vtxo.RelativeExpiry,
 					SigningKey:   vtxo.ClientKey,
 				}
-				a.cfg.RoundActor.Tell(ctx, req)
-				a.cfg.Logger.InfoS(ctx, "Sent refresh request",
-					slog.String("outpoint", m.VTXOOutpoint.String()),
-					slog.String("urgency", m.Urgency.String()),
+				a.cfg.RoundActor.Tell(ctx, refreshReq)
+
+				// Also send a VTXORequest to request the new
+				// VTXO output for this refresh.
+				amt := btcutil.Amount(m.Amount)
+				vtxoReq := &round.VTXORequestsReceived{
+					Requests: []types.VTXORequest{{
+						Amount:   amt,
+						PkScript: vtxo.PkScript,
+						Expiry:   vtxo.RelativeExpiry,
+						ClientKey: vtxo.ClientKey.
+							PubKey,
+						OperatorKey: vtxo.OperatorKey,
+						SigningKey:  vtxo.ClientKey,
+					}},
+				}
+				a.cfg.RoundActor.Tell(ctx, vtxoReq)
+
+				a.cfg.Logger.InfoS(
+					ctx, "Sent refresh and VTXO request",
+					slog.String(
+						"outpoint",
+						m.VTXOOutpoint.String(),
+					),
+					slog.String(
+						"urgency", m.Urgency.String(),
+					),
 				)
 			}
 

--- a/vtxo/actor_test.go
+++ b/vtxo/actor_test.go
@@ -150,7 +150,9 @@ func TestProcessOutboxStatusUpdate(t *testing.T) {
 }
 
 // TestProcessOutboxRefreshRequest verifies that RefreshRequest messages in the
-// outbox are routed to the round actor with the correct fields populated.
+// outbox are routed to the round actor with the correct fields populated. Since
+// refresh is decoupled from VTXO creation, both a RefreshVTXORequest and a
+// VTXORequestsReceived message should be sent.
 func TestProcessOutboxRefreshRequest(t *testing.T) {
 	t.Parallel()
 
@@ -181,16 +183,33 @@ func TestProcessOutboxRefreshRequest(t *testing.T) {
 
 	actor.processOutbox(h.ctx, outbox)
 
+	// Should send both a RefreshVTXORequest and a VTXORequestsReceived.
 	msgs := roundActor.getMessages()
-	require.Len(t, msgs, 1)
+	require.Len(t, msgs, 2)
 
-	req, ok := msgs[0].(*round.RefreshVTXORequest)
+	// First message should be the refresh request.
+	refreshReq, ok := msgs[0].(*round.RefreshVTXORequest)
 	require.True(t, ok, "expected RefreshVTXORequest, got %T", msgs[0])
-	require.Equal(t, vtxo.Outpoint, req.VTXOOutpoint)
-	require.Equal(t, int64(vtxo.Amount), req.Amount)
-	require.Equal(t, vtxo.ClientKey.PubKey, req.NewVTXOKey)
-	require.Equal(t, vtxo.OperatorKey, req.OperatorKey)
-	require.Equal(t, vtxo.RelativeExpiry, req.Expiry)
+	require.Equal(t, vtxo.Outpoint, refreshReq.VTXOOutpoint)
+	require.Equal(t, int64(vtxo.Amount), refreshReq.Amount)
+	require.Equal(t, vtxo.ClientKey.PubKey, refreshReq.NewVTXOKey)
+	require.Equal(t, vtxo.OperatorKey, refreshReq.OperatorKey)
+	require.Equal(t, vtxo.RelativeExpiry, refreshReq.Expiry)
+
+	// Second message should be the VTXO request for the new VTXO.
+	vtxoReqMsg, ok := msgs[1].(*round.VTXORequestsReceived)
+	require.True(t, ok, "expected VTXORequestsReceived, got %T", msgs[1])
+	require.Len(t, vtxoReqMsg.Requests, 1)
+
+	vtxoReq := vtxoReqMsg.Requests[0]
+	require.Equal(t, vtxo.Amount, vtxoReq.Amount)
+	require.Equal(t, vtxo.PkScript, vtxoReq.PkScript)
+	require.Equal(t, vtxo.RelativeExpiry, vtxoReq.Expiry)
+	require.Equal(t, vtxo.ClientKey.PubKey, vtxoReq.ClientKey)
+	require.Equal(t, vtxo.OperatorKey, vtxoReq.OperatorKey)
+	require.Equal(
+		t, vtxo.ClientKey.KeyLocator, vtxoReq.SigningKey.KeyLocator,
+	)
 }
 
 // TestProcessOutboxTerminatedNotification verifies that


### PR DESCRIPTION
This PR extends the round FSM and actor to support batch swap forfeit flow, where existing VTXOs are forfeited to create new VTXOs in a commitment transaction.

The FSM gains `ForfeitSignaturesCollectingState` for coordinating signature collection from participating VTXOs. When the commitment transaction contains a connector tree and forfeit mappings, the FSM transitions to this state after receiving the commitment. Each participating VTXO actor signs its forfeit transaction and sends a `ForfeitSignatureResponse`, which the FSM collects until all expected signatures are received.

The round actor adds handlers for VTXO actor messages:
- `handleRefreshVTXORequest`: Processes refresh requests from expiring VTXOs and sends acknowledgement
- `handleForfeitSignatureResponse`: Routes signatures to the appropriate round's FSM
- `processOutbox` extensions: `ForfeitRequestToVTXO` sends forfeit requests via service key lookup, `ForfeitConfirmedToVTXO` notifies VTXOs of on-chain confirmation, `VTXOCreatedNotification` is forwarded to the VTXO manager

`CommitmentTxBuilt` event now includes connector tree structure and forfeit mappings that link each VTXO to its connector leaf. The `validateConnectorTree()` function verifies the tree structure matches the commitment transaction outputs before signing.

Comprehensive tests verify the forfeit flow transitions, connector tree validation, and integration between round and VTXO actors.

## Dependencies
- Depends on #70 (vtxo: implement VTXO actor and manager with round integration)