### PR TITLE
round+db: synchronize client protocol types with server

### DIFF
--- a/db/round_store.go
+++ b/db/round_store.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg"
@@ -150,8 +151,8 @@ func (s *RoundPersistenceStore) CommitState(ctx context.Context,
 			return err
 		}
 
-		// Serialize VTXT tree if present.
-		vtxtTreeBytes, err := serializeVTXTTree(r.VTXTTree)
+		// Serialize VTXO trees if present.
+		vtxtTreeBytes, err := serializeVTXOTreePaths(r.VTXOTreePaths)
 		if err != nil {
 			return err
 		}
@@ -162,7 +163,7 @@ func (s *RoundPersistenceStore) CommitState(ctx context.Context,
 		// we only persist at the "point of no return" after sending
 		// input signatures. Confirmation info is None at this stage.
 		roundParams := InsertRoundParams{
-			RoundID:               r.RoundID,
+			RoundID:               r.RoundID.String(),
 			ConfirmationHeight:    sql.NullInt32{},
 			ConfirmationBlockHash: nil,
 			CommitmentTx:          commitmentTxBytes,
@@ -201,7 +202,7 @@ func (s *RoundPersistenceStore) CommitState(ctx context.Context,
 			for i, intent := range r.BoardingIntents {
 				sig := inputSigState.InputSigs[i]
 				iParams, err := s.domainIntentToRoundParams(
-					r.RoundID, &intent, i, sig,
+					r.RoundID.String(), &intent, i, sig,
 				)
 				if err != nil {
 					return fmt.Errorf(
@@ -218,8 +219,9 @@ func (s *RoundPersistenceStore) CommitState(ctx context.Context,
 
 				// Insert VTXO templates for this intent.
 				for j, vtxoReq := range intent.VtxoTemplate {
+					roundStr := r.RoundID.String()
 					tParams := vtxoRequestToParams(
-						r.RoundID, &intent, j, &vtxoReq,
+						roundStr, &intent, j, &vtxoReq,
 					)
 					err = q.InsertRoundVtxoTemplate(
 						ctx, tParams,
@@ -247,7 +249,7 @@ func (s *RoundPersistenceStore) CommitState(ctx context.Context,
 				}
 
 				treeParams := sqlc.InsertRoundClientTreeParams{
-					RoundID:   r.RoundID,
+					RoundID:   r.RoundID.String(),
 					ClientKey: key[:],
 					TreeData:  treeData,
 				}
@@ -271,7 +273,7 @@ func (s *RoundPersistenceStore) CommitState(ctx context.Context,
 				for _, entry := range txidEntries {
 					p := sqlc.InsertClientTreeTxidParams{
 						Txid:      entry.Txid[:],
-						RoundID:   r.RoundID,
+						RoundID:   r.RoundID.String(),
 						ClientKey: key[:],
 						TreeLevel: int32(
 							entry.TreeLevel,
@@ -298,7 +300,7 @@ func (s *RoundPersistenceStore) CommitState(ctx context.Context,
 // FetchState retrieves a round and its FSM state by round ID. Returns
 // (round, state, err) atomically to ensure consistency.
 func (s *RoundPersistenceStore) FetchState(ctx context.Context,
-	roundID string) (*round.Round, round.ClientState, error) {
+	roundID round.RoundID) (*round.Round, round.ClientState, error) {
 
 	readTxOpts := ReadTxOption()
 
@@ -307,15 +309,18 @@ func (s *RoundPersistenceStore) FetchState(ctx context.Context,
 		resultState round.ClientState
 	)
 
+	// Convert domain RoundID to string for DB query.
+	roundIDStr := roundID.String()
+
 	err := s.db.ExecTx(ctx, readTxOpts, func(q RoundStore) error {
 		// Fetch round row.
-		dbRound, err := q.GetRound(ctx, roundID)
+		dbRound, err := q.GetRound(ctx, roundIDStr)
 		if err != nil {
 			return fmt.Errorf("get round: %w", err)
 		}
 
 		// Fetch boarding intents for this round.
-		dbIntents, err := q.GetRoundBoardingIntents(ctx, roundID)
+		dbIntents, err := q.GetRoundBoardingIntents(ctx, roundIDStr)
 		if err != nil {
 			return fmt.Errorf(
 				"get round boarding intents: %w", err,
@@ -323,7 +328,7 @@ func (s *RoundPersistenceStore) FetchState(ctx context.Context,
 		}
 
 		// Fetch client trees for this round.
-		dbTrees, err := q.GetRoundClientTrees(ctx, roundID)
+		dbTrees, err := q.GetRoundClientTrees(ctx, roundIDStr)
 		if err != nil {
 			return fmt.Errorf("get round client trees: %w", err)
 		}
@@ -439,13 +444,14 @@ func (s *RoundPersistenceStore) ListActiveRounds(
 // FinalizeRound marks a round as complete and archives it. The confInfo
 // contains the block height and hash at which the commitment tx was confirmed.
 func (s *RoundPersistenceStore) FinalizeRound(ctx context.Context,
-	roundID string, txid chainhash.Hash, confInfo round.ConfInfo) error {
+	roundID round.RoundID, txid chainhash.Hash,
+	confInfo round.ConfInfo) error {
 
 	writeTxOpts := WriteTxOption()
 
 	return s.db.ExecTx(ctx, writeTxOpts, func(q RoundStore) error {
 		params := sqlc.FinalizeRoundParams{
-			RoundID:        roundID,
+			RoundID:        roundID.String(),
 			CommitmentTxid: txid[:],
 			ConfirmationHeight: sql.NullInt32{
 				Int32: confInfo.Height,
@@ -570,8 +576,14 @@ func (s *RoundPersistenceStore) dbRoundToDomainRound(ctx context.Context,
 	q RoundStore, dbRound RoundRow,
 	dbIntents []RoundBoardingIntentRow) (*round.Round, error) {
 
+	// Parse the round ID from the database string.
+	roundID, err := round.ParseRoundID(dbRound.RoundID)
+	if err != nil {
+		return nil, fmt.Errorf("parse round ID: %w", err)
+	}
+
 	r := &round.Round{
-		RoundID: dbRound.RoundID,
+		RoundID: roundID,
 	}
 
 	// Populate confirmation info if present.
@@ -600,7 +612,7 @@ func (s *RoundPersistenceStore) dbRoundToDomainRound(ctx context.Context,
 		r.CommitmentTx = fn.Some(packet)
 	}
 
-	// Deserialize VTXT tree if present.
+	// Deserialize VTXO trees if present.
 	if len(dbRound.VtxtTree) > 0 {
 		vtxtTree, err := DeserializeTree(dbRound.VtxtTree)
 		if err != nil {
@@ -609,7 +621,9 @@ func (s *RoundPersistenceStore) dbRoundToDomainRound(ctx context.Context,
 			)
 		}
 
-		r.VTXTTree = fn.Some(vtxtTree)
+		// For now, we store a single tree. Wrap it in a map at index 0.
+		// TODO: Support proper multi-tree serialization format.
+		r.VTXOTreePaths = fn.Some(map[int]*tree.Tree{0: vtxtTree})
 	}
 
 	// Convert boarding intents.
@@ -761,11 +775,17 @@ func (s *RoundPersistenceStore) dbRoundIntentToDomainIntent(ctx context.Context,
 	}
 
 	// Create the round-specific BoardingIntent.
+	// Parse the round ID from the database string.
+	roundID, err := round.ParseRoundID(dbRoundIntent.RoundID)
+	if err != nil {
+		return nil, fmt.Errorf("parse round ID: %w", err)
+	}
+
 	intent := &round.BoardingIntent{
 		BoardingIntent:  baseIntent,
 		BoardingRequest: boardingReq,
 		VtxoTemplate:    vtxoTemplate,
-		RoundID:         fn.Some(dbRoundIntent.RoundID),
+		RoundID:         fn.Some(roundID),
 	}
 
 	return intent, nil
@@ -833,8 +853,14 @@ func (s *RoundPersistenceStore) reconstructInputSigSentState(
 	dbIntents []RoundBoardingIntentRow, dbTrees []RoundClientTreeRow,
 ) (*round.InputSigSentState, error) {
 
+	// Parse the round ID from the database string.
+	roundID, err := round.ParseRoundID(dbRound.RoundID)
+	if err != nil {
+		return nil, fmt.Errorf("parse round ID: %w", err)
+	}
+
 	state := &round.InputSigSentState{
-		RoundID:     dbRound.RoundID,
+		RoundID:     roundID,
 		ClientTrees: make(map[round.SignerKey]*tree.Tree),
 	}
 
@@ -851,7 +877,7 @@ func (s *RoundPersistenceStore) reconstructInputSigSentState(
 		state.CommitmentTx = packet
 	}
 
-	// Deserialize VTXT tree.
+	// Deserialize VTXO trees.
 	if len(dbRound.VtxtTree) > 0 {
 		vtxtTree, err := DeserializeTree(dbRound.VtxtTree)
 		if err != nil {
@@ -860,12 +886,14 @@ func (s *RoundPersistenceStore) reconstructInputSigSentState(
 			)
 		}
 
-		state.VTXTTree = vtxtTree
+		// For now, we store a single tree. Wrap it in a map at index 0.
+		// TODO: Support proper multi-tree serialization format.
+		state.VTXOTreePaths = map[int]*tree.Tree{0: vtxtTree}
 	}
 
-	// Convert boarding intents.
+	// Convert boarding intents and input signatures.
 	intents := make([]round.BoardingIntent, 0, len(dbIntents))
-	inputSigs := make([][]byte, 0, len(dbIntents))
+	inputSigs := make([]*types.BoardingInputSignature, 0, len(dbIntents))
 	for _, dbIntent := range dbIntents {
 		intent, err := s.dbRoundIntentToDomainIntent(ctx, q, dbIntent)
 		if err != nil {
@@ -876,8 +904,32 @@ func (s *RoundPersistenceStore) reconstructInputSigSentState(
 
 		intents = append(intents, *intent)
 
+		// Reconstruct the BoardingInputSignature from stored data.
 		if len(dbIntent.InputSignature) > 0 {
-			inputSigs = append(inputSigs, dbIntent.InputSignature)
+			inputSig := dbIntent.InputSignature
+			sig, err := schnorr.ParseSignature(inputSig)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"parse input signature: %w", err,
+				)
+			}
+
+			var outpoint wire.OutPoint
+			copy(outpoint.Hash[:], dbIntent.OutpointHash)
+			outpoint.Index = uint32(dbIntent.OutpointIndex)
+
+			inputSigs = append(
+				inputSigs,
+				&types.BoardingInputSignature{
+					InputIndex:      int(dbIntent.InputIndex.Int32), //nolint:ll
+					Outpoint:        outpoint,
+					ClientSignature: sig,
+				},
+			)
+		} else {
+			// Missing signature - should not happen for
+			// input_sig_sent state, but handle gracefully.
+			inputSigs = append(inputSigs, nil)
 		}
 	}
 
@@ -905,9 +957,10 @@ func (s *RoundPersistenceStore) reconstructInputSigSentState(
 // parameters for the round_boarding_intents table. The inputSig parameter
 // contains the client's input signature for this boarding intent, which is
 // critical for state recovery after restart.
-func (s *RoundPersistenceStore) domainIntentToRoundParams(roundID string,
-	intent *round.BoardingIntent, inputIndex int,
-	inputSig []byte) (sqlc.InsertRoundBoardingIntentParams, error) {
+func (s *RoundPersistenceStore) domainIntentToRoundParams(
+	roundID string, intent *round.BoardingIntent, inputIndex int,
+	inputSig *types.BoardingInputSignature,
+) (sqlc.InsertRoundBoardingIntentParams, error) {
 
 	// Serialize TxProof if present.
 	var txProofBytes []byte
@@ -940,6 +993,12 @@ func (s *RoundPersistenceStore) domainIntentToRoundParams(roundID string,
 		}
 	}
 
+	// Serialize the input signature if present.
+	var inputSigBytes []byte
+	if inputSig != nil && inputSig.ClientSignature != nil {
+		inputSigBytes = inputSig.ClientSignature.Serialize()
+	}
+
 	return sqlc.InsertRoundBoardingIntentParams{
 		RoundID:        roundID,
 		OutpointHash:   intent.Outpoint.Hash[:],
@@ -949,7 +1008,7 @@ func (s *RoundPersistenceStore) domainIntentToRoundParams(roundID string,
 		ExitDelay:      int32(intent.BoardingRequest.ExitDelay),
 		TxProof:        txProofBytes,
 		InputIndex:     inputIdxVal,
-		InputSignature: inputSig,
+		InputSignature: inputSigBytes,
 	}, nil
 }
 
@@ -1046,9 +1105,9 @@ func (s *RoundPersistenceStore) domainVTXOToInsertParams(
 		treePathBytes = data
 	}
 
-	roundID := ""
-	vtxo.RoundID.WhenSome(func(rid string) {
-		roundID = rid
+	roundIDStr := ""
+	vtxo.RoundID.WhenSome(func(rid round.RoundID) {
+		roundIDStr = rid.String()
 	})
 
 	var operatorPubkey []byte
@@ -1066,7 +1125,7 @@ func (s *RoundPersistenceStore) domainVTXOToInsertParams(
 	return InsertVTXOParams{
 		OutpointHash:    vtxo.Outpoint.Hash[:],
 		OutpointIndex:   int32(vtxo.Outpoint.Index),
-		RoundID:         roundID,
+		RoundID:         roundIDStr,
 		Amount:          int64(vtxo.Amount),
 		PkScript:        vtxo.PkScript,
 		Expiry:          int32(vtxo.Expiry),
@@ -1132,9 +1191,14 @@ func (s *RoundPersistenceStore) dbVTXOToDomainVTXO(
 		treePath = t
 	}
 
-	var roundID fn.Option[string]
+	var roundIDOpt fn.Option[round.RoundID]
 	if dbVTXO.RoundID != "" {
-		roundID = fn.Some(dbVTXO.RoundID)
+		roundID, err := round.ParseRoundID(dbVTXO.RoundID)
+		if err != nil {
+			return nil, fmt.Errorf("parse round ID: %w", err)
+		}
+
+		roundIDOpt = fn.Some(roundID)
 	}
 
 	keyFamily := keychain.KeyFamily(dbVTXO.ClientKeyFamily)
@@ -1153,7 +1217,7 @@ func (s *RoundPersistenceStore) dbVTXOToDomainVTXO(
 		},
 		OperatorKey: operatorPubkey,
 		TreePath:    treePath,
-		RoundID:     roundID,
+		RoundID:     roundIDOpt,
 	}, nil
 }
 
@@ -1178,21 +1242,33 @@ func serializeCommitmentTx(
 	return buf.Bytes(), txid[:], nil
 }
 
-// serializeVTXTTree serializes a VTXT tree if present. Returns the serialized
-// bytes or nil if the Option is None.
-func serializeVTXTTree(treeOpt fn.Option[*tree.Tree]) ([]byte, error) {
-	if !treeOpt.IsSome() {
+// serializeVTXOTreePaths serializes a VTXO tree paths map if present. Returns
+// the serialized bytes or nil if the Option is None.
+func serializeVTXOTreePaths(
+	treesOpt fn.Option[map[int]*tree.Tree],
+) ([]byte, error) {
+
+	if !treesOpt.IsSome() {
 		return nil, nil
 	}
 
-	t := treeOpt.UnwrapOr(nil)
-
-	data, err := SerializeTree(t)
-	if err != nil {
-		return nil, fmt.Errorf("serialize vtxt tree: %w", err)
+	trees := treesOpt.UnwrapOr(nil)
+	if len(trees) == 0 {
+		return nil, nil
 	}
 
-	return data, nil
+	// Serialize as a simple format: for now just take the first tree.
+	// TODO: Support multiple trees with proper serialization format.
+	for _, t := range trees {
+		data, err := SerializeTree(t)
+		if err != nil {
+			return nil, fmt.Errorf("serialize vtxt tree: %w", err)
+		}
+
+		return data, nil
+	}
+
+	return nil, nil
 }
 
 // Compile-time checks that RoundPersistenceStore implements the interfaces.

--- a/db/round_store_test.go
+++ b/db/round_store_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg"
@@ -14,6 +15,7 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btclog/v2"
+	"github.com/google/uuid"
 	"github.com/lightninglabs/darepo-client/db/sqlc"
 	"github.com/lightninglabs/darepo-client/lib/scripts"
 	"github.com/lightninglabs/darepo-client/lib/tree"
@@ -25,6 +27,14 @@ import (
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/stretchr/testify/require"
 )
+
+// testRoundIDDB creates a deterministic RoundID from a string seed for tests.
+func testRoundIDDB(seed string) round.RoundID {
+	h := chainhash.HashH([]byte(seed))
+	id, _ := uuid.FromBytes(h[:16])
+
+	return round.RoundID(id)
+}
 
 // newRoundStoreForTest creates a new RoundPersistenceStore for testing.
 func newRoundStoreForTest(t *testing.T) (*RoundPersistenceStore, *BaseDB) {
@@ -47,7 +57,7 @@ func newRoundStoreForTest(t *testing.T) (*RoundPersistenceStore, *BaseDB) {
 }
 
 // createTestRound creates a test round with minimal data.
-func createTestRound(t *testing.T, roundID string) *round.Round {
+func createTestRound(t *testing.T, roundID round.RoundID) *round.Round {
 	// Create a simple commitment transaction as a PSBT.
 	tx := wire.NewMsgTx(2)
 	tx.AddTxIn(&wire.TxIn{
@@ -91,15 +101,15 @@ func createTestRound(t *testing.T, roundID string) *round.Round {
 	}
 
 	return &round.Round{
-		RoundID:      roundID,
-		CommitmentTx: fn.Some(commitTx),
-		VTXTTree:     fn.Some(vtxtTree),
+		RoundID:       roundID,
+		CommitmentTx:  fn.Some(commitTx),
+		VTXOTreePaths: fn.Some(map[int]*tree.Tree{0: vtxtTree}),
 	}
 }
 
 // createTestClientVTXO creates a test ClientVTXO.
 func createTestClientVTXO(
-	t *testing.T, roundID string, idx int,
+	t *testing.T, roundID round.RoundID, idx int,
 ) *round.ClientVTXO {
 
 	privKey, err := btcec.NewPrivateKey()
@@ -136,7 +146,7 @@ func createTestClientVTXO(
 				Children:  make(map[uint32]*tree.Node),
 			},
 		},
-		RoundID: fn.Some(roundID),
+		RoundID: fn.Some[round.RoundID](roundID),
 	}
 }
 
@@ -148,7 +158,7 @@ func TestRoundStoreCommitAndFetch(t *testing.T) {
 	ctx := t.Context()
 
 	// Create a test round.
-	testRound := createTestRound(t, "test-round-1")
+	testRound := createTestRound(t, testRoundIDDB("test-round-1"))
 
 	// Create a test FSM state.
 	state := &round.InputSigSentState{
@@ -158,8 +168,8 @@ func TestRoundStoreCommitAndFetch(t *testing.T) {
 	testRound.CommitmentTx.WhenSome(func(packet *psbt.Packet) {
 		state.CommitmentTx = packet
 	})
-	testRound.VTXTTree.WhenSome(func(t *tree.Tree) {
-		state.VTXTTree = t
+	testRound.VTXOTreePaths.WhenSome(func(treePaths map[int]*tree.Tree) {
+		state.VTXOTreePaths = treePaths
 	})
 
 	// Commit the state.
@@ -208,7 +218,7 @@ func TestRoundStoreLookupByTxid(t *testing.T) {
 	ctx := t.Context()
 
 	// Create and commit a test round.
-	testRound := createTestRound(t, "test-round-txid")
+	testRound := createTestRound(t, testRoundIDDB("test-round-txid"))
 	state := &round.InputSigSentState{
 		RoundID:     testRound.RoundID,
 		ClientTrees: make(map[round.SignerKey]*tree.Tree),
@@ -239,7 +249,7 @@ func TestRoundStoreListActiveRounds(t *testing.T) {
 
 	// Create and commit multiple rounds.
 	for i := 0; i < 3; i++ {
-		roundID := "test-round-" + string(rune('a'+i))
+		roundID := testRoundIDDB("test-round-" + string(rune('a'+i)))
 		testRound := createTestRound(t, roundID)
 		state := &round.InputSigSentState{
 			RoundID:     testRound.RoundID,
@@ -264,7 +274,7 @@ func TestRoundStoreFinalizeRound(t *testing.T) {
 	ctx := t.Context()
 
 	// Create and commit a test round.
-	testRound := createTestRound(t, "test-round-finalize")
+	testRound := createTestRound(t, testRoundIDDB("test-round-finalize"))
 	state := &round.InputSigSentState{
 		RoundID:     testRound.RoundID,
 		ClientTrees: make(map[round.SignerKey]*tree.Tree),
@@ -312,7 +322,7 @@ func TestVTXOStoreSaveAndList(t *testing.T) {
 	ctx := t.Context()
 
 	// First, create a round to satisfy foreign key constraint.
-	roundID := "test-round-vtxo"
+	roundID := testRoundIDDB("test-round-vtxo")
 	testRound := createTestRound(t, roundID)
 	state := &round.InputSigSentState{
 		RoundID:     testRound.RoundID,
@@ -352,7 +362,7 @@ func TestVTXOStoreGetVTXO(t *testing.T) {
 	ctx := t.Context()
 
 	// First, create a round to satisfy foreign key constraint.
-	roundID := "test-round-get"
+	roundID := testRoundIDDB("test-round-get")
 	testRound := createTestRound(t, roundID)
 	state := &round.InputSigSentState{
 		RoundID:     testRound.RoundID,
@@ -382,7 +392,7 @@ func TestVTXOStoreMarkSpent(t *testing.T) {
 	ctx := t.Context()
 
 	// First, create a round to satisfy foreign key constraint.
-	roundID := "test-round-spent"
+	roundID := testRoundIDDB("test-round-spent")
 	testRound := createTestRound(t, roundID)
 	state := &round.InputSigSentState{
 		RoundID:     testRound.RoundID,
@@ -422,7 +432,7 @@ type boardingIntentFixture struct {
 	roundIntent   round.BoardingIntent
 	outpoint      wire.OutPoint
 	pkScript      []byte
-	inputSig      []byte
+	inputSig      *types.BoardingInputSignature
 	clientTreeKey round.SignerKey
 	clientTree    *tree.Tree
 }
@@ -431,7 +441,7 @@ type boardingIntentFixture struct {
 // all wallet-layer dependencies. The index parameter is used to generate unique
 // keys and outpoints for each fixture.
 func createBoardingIntentFixture(
-	t *testing.T, roundID string, idx int,
+	t *testing.T, roundID round.RoundID, idx int,
 ) *boardingIntentFixture {
 
 	// Create unique keys for this intent.
@@ -544,11 +554,20 @@ func createBoardingIntentFixture(
 		BoardingIntent:  walletIntent,
 		BoardingRequest: boardingRequest,
 		VtxoTemplate:    vtxoTemplates,
-		RoundID:         fn.Some(roundID),
+		RoundID:         fn.Some[round.RoundID](roundID),
 	}
 
-	// Create input signature using bytes.Repeat with unique byte.
-	inputSig := bytes.Repeat([]byte{byte(0xab + idx)}, 64)
+	// Create input signature as a BoardingInputSignature.
+	var sigBytes [64]byte
+	copy(sigBytes[:], bytes.Repeat([]byte{byte(0xab + idx)}, 64))
+	sig, err := schnorr.ParseSignature(sigBytes[:])
+	require.NoError(t, err)
+
+	inputSig := &types.BoardingInputSignature{
+		InputIndex:      idx,
+		Outpoint:        intentOutpoint,
+		ClientSignature: sig,
+	}
 
 	// Create client tree using the actual tree builder with multiple
 	// leaves.
@@ -601,7 +620,7 @@ func TestRoundStoreWithBoardingGroup(t *testing.T) {
 	t.Parallel()
 
 	const numIntents = 2
-	const roundID = "test-round-boarding"
+	roundID := testRoundIDDB("test-round-boarding")
 
 	ctx := t.Context()
 	roundStore, db := newRoundStoreForTest(t)
@@ -641,7 +660,7 @@ func TestRoundStoreWithBoardingGroup(t *testing.T) {
 
 	// Build the round's boarding group from the fixtures.
 	roundIntents := make([]round.BoardingIntent, numIntents)
-	inputSigs := make([][]byte, numIntents)
+	inputSigs := make([]*types.BoardingInputSignature, numIntents)
 	clientTrees := make(map[round.SignerKey]*tree.Tree)
 	for i, f := range fixtures {
 		roundIntents[i] = f.roundIntent
@@ -691,18 +710,18 @@ func TestRoundStoreWithBoardingGroup(t *testing.T) {
 	testRound := &round.Round{
 		RoundID:         roundID,
 		CommitmentTx:    fn.Some(commitTx),
-		VTXTTree:        fn.Some(vtxtTree),
+		VTXOTreePaths:   fn.Some(map[int]*tree.Tree{0: vtxtTree}),
 		BoardingIntents: roundIntents,
 	}
 
 	// Create the FSM state with all intents, signatures, and client trees.
 	state := &round.InputSigSentState{
-		RoundID:      roundID,
-		CommitmentTx: commitTx,
-		VTXTTree:     vtxtTree,
-		Intents:      roundIntents,
-		ClientTrees:  clientTrees,
-		InputSigs:    inputSigs,
+		RoundID:       roundID,
+		CommitmentTx:  commitTx,
+		VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
+		Intents:       roundIntents,
+		ClientTrees:   clientTrees,
+		InputSigs:     inputSigs,
 	}
 
 	// Commit the state.
@@ -773,7 +792,7 @@ func TestRoundStoreWithBoardingGroup(t *testing.T) {
 		// Query the stored txids from the database.
 		storedTxids, err := db.GetClientTreeTxids(
 			ctx, sqlc.GetClientTreeTxidsParams{
-				RoundID:   roundID,
+				RoundID:   roundID.String(),
 				ClientKey: f.clientTreeKey[:],
 			},
 		)
@@ -817,7 +836,7 @@ func TestRoundStoreWithBoardingGroup(t *testing.T) {
 				ctx, expected.Txid[:],
 			)
 			require.NoError(t, err)
-			require.Equal(t, roundID, treeByTxid.RoundID)
+			require.Equal(t, roundID.String(), treeByTxid.RoundID)
 			require.Equal(t, f.clientTreeKey[:],
 				treeByTxid.ClientKey)
 		}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/btcsuite/btclog/v2 v2.0.1-0.20250728225537-6090e87c6c5b
 	github.com/btcsuite/btcwallet v0.16.17
 	github.com/golang-migrate/migrate/v4 v4.17.0
+	github.com/google/uuid v1.6.0
 	github.com/jackc/pgconn v1.14.3
 	github.com/jackc/pgerrcode v0.0.0-20250907135507-afb5586c32a6
 	github.com/jackc/pgx/v5 v5.7.6
@@ -82,7 +83,6 @@ require (
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/btree v1.0.1 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect

--- a/round/actor.go
+++ b/round/actor.go
@@ -28,7 +28,7 @@ type RoundFSM struct {
 	FSM *ClientStateMachine
 
 	// RoundID is the unique identifier for this round.
-	RoundID string
+	RoundID RoundID
 
 	// TxID is the commitment transaction ID for this round.
 	TxID chainhash.Hash
@@ -55,11 +55,11 @@ type RoundClientActor struct {
 
 	// activeRounds tracks concurrent round FSMs awaiting commitment tx
 	// confirmation. Map: RoundID → RoundFSM instance.
-	activeRounds map[string]*RoundFSM
+	activeRounds map[RoundID]*RoundFSM
 
 	// commitmentTxIndex maps commitment transaction IDs to their round IDs
 	// for routing confirmation events. Map: CommitmentTxID → RoundID.
-	commitmentTxIndex map[chainhash.Hash]string
+	commitmentTxIndex map[chainhash.Hash]RoundID
 
 	// env is the FSM environment containing all dependencies.
 	env *ClientEnvironment
@@ -142,8 +142,8 @@ func NewRoundClientActor(cfg *RoundClientConfig) fn.Result[*RoundClientActor] {
 	return fn.Ok(&RoundClientActor{
 		cfg:               cfg,
 		primaryFSM:        &primaryFSM,
-		activeRounds:      make(map[string]*RoundFSM),
-		commitmentTxIndex: make(map[chainhash.Hash]string),
+		activeRounds:      make(map[RoundID]*RoundFSM),
+		commitmentTxIndex: make(map[chainhash.Hash]RoundID),
 		env:               env,
 	})
 }
@@ -152,7 +152,7 @@ func NewRoundClientActor(cfg *RoundClientConfig) fn.Result[*RoundClientActor] {
 // from checkpointed state. Uses FetchState to load both round data and FSM
 // state atomically.
 func (a *RoundClientActor) createRoundFSM(ctx context.Context,
-	roundID string) (*RoundFSM, error) {
+	roundID RoundID) (*RoundFSM, error) {
 
 	round, state, err := a.cfg.RoundStore.FetchState(ctx, roundID)
 	if err != nil {
@@ -381,7 +381,7 @@ func (a *RoundClientActor) handleWalletBoardingConfirmed(ctx context.Context,
 // signaling that a round has been saved to storage and should be migrated to
 // its own FSM instance for independent tracking.
 func (a *RoundClientActor) migrateRoundToActiveFSM(ctx context.Context,
-	roundID string) error {
+	roundID RoundID) error {
 
 	// Check if this round is already in activeRounds (idempotency).
 	if _, exists := a.activeRounds[roundID]; exists {
@@ -404,24 +404,27 @@ func (a *RoundClientActor) migrateRoundToActiveFSM(ctx context.Context,
 	return nil
 }
 
-// extractRoundID returns the RoundID from events that carry one. Returns empty
-// string for events without a RoundID field.
-func extractRoundID(event ClientEvent) string {
+// extractRoundID returns the RoundID from events that carry one. Returns the
+// zero value for events without a RoundID field.
+func extractRoundID(event ClientEvent) (RoundID, bool) {
 	switch e := event.(type) {
 	case *RoundJoined:
-		return e.RoundID
+		return e.RoundID, true
 
 	case *CommitmentTxBuilt:
-		return e.RoundID
+		return e.RoundID, true
 
 	case *NoncesAggregated:
-		return e.RoundID
+		return e.RoundID, true
 
 	case *OperatorSigned:
-		return e.RoundID
+		return e.RoundID, true
+
+	case *AwaitingBoardingSigs:
+		return e.RoundID, true
 
 	default:
-		return ""
+		return RoundID{}, false
 	}
 }
 
@@ -437,8 +440,8 @@ func (a *RoundClientActor) handleServerMessage(ctx context.Context,
 	// Otherwise, use the primaryFSM.
 	targetFSM := a.primaryFSM
 
-	roundID := extractRoundID(msg.Message)
-	if roundID != "" {
+	roundID, hasRoundID := extractRoundID(msg.Message)
+	if hasRoundID {
 		if roundFSM, exists := a.activeRounds[roundID]; exists {
 			targetFSM = roundFSM.FSM
 		}
@@ -479,14 +482,14 @@ func (a *RoundClientActor) handleGetState(_ context.Context,
 	states["primary"] = FSMStateInfo{
 		State:     clientState,
 		IsPrimary: true,
-		RoundID:   "",
+		RoundID:   RoundID{},
 	}
 
 	for roundID, roundFSM := range a.activeRounds {
 		roundState, err := roundFSM.FSM.CurrentState()
 		if err != nil {
 			log.Warnf("Failed to get FSM state for round %s: %v",
-				roundID, err)
+				roundID.String(), err)
 
 			continue
 		}
@@ -494,12 +497,12 @@ func (a *RoundClientActor) handleGetState(_ context.Context,
 		clientState, ok := roundState.(ClientState)
 		if !ok {
 			log.Warnf("Round %s FSM state is not a ClientState: %T",
-				roundID, roundState)
+				roundID.String(), roundState)
 
 			continue
 		}
 
-		states[roundID] = FSMStateInfo{
+		states[roundID.String()] = FSMStateInfo{
 			State:     clientState,
 			IsPrimary: false,
 			RoundID:   roundID,
@@ -538,7 +541,7 @@ func (a *RoundClientActor) handleCancelRound(ctx context.Context,
 
 // onRoundComplete is called when a round finishes successfully. This removes
 // the round from active tracking and archives the round data.
-func (a *RoundClientActor) onRoundComplete(ctx context.Context, roundID string,
+func (a *RoundClientActor) onRoundComplete(ctx context.Context, roundID RoundID,
 	txid chainhash.Hash, confInfo ConfInfo) error {
 
 	delete(a.activeRounds, roundID)

--- a/round/actor_harness_test.go
+++ b/round/actor_harness_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/google/uuid"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
 	"github.com/lightninglabs/darepo-client/chainsource"
 	"github.com/lightninglabs/darepo-client/lib/scripts"
@@ -28,6 +29,17 @@ import (
 
 // confEventNotifier is a type alias for confirmation event notifiers.
 type confEventNotifier = actor.TellOnlyRef[chainsource.ConfirmationEvent]
+
+// testRoundID creates a deterministic RoundID from a string seed for testing.
+// This creates a valid UUID v4 by using the hash of the seed.
+func testRoundID(seed string) RoundID {
+	// Create a deterministic UUID from the seed by using it as namespace
+	// data.
+	h := chainhash.HashH([]byte(seed))
+	id, _ := uuid.FromBytes(h[:16])
+
+	return RoundID(id)
+}
 
 // mockServerConnRef captures all messages sent to the server for test
 // verification, implementing actor.TellOnlyRef[serverconn.ServerConnMsg].
@@ -495,7 +507,7 @@ func (h *actorTestHarness) newTestBoardingIntentWithSuffix(
 
 // simulateRoundJoined injects a RoundJoined server event to the actor,
 // simulating successful round enrollment.
-func (h *actorTestHarness) simulateRoundJoined(roundID string) {
+func (h *actorTestHarness) simulateRoundJoined(roundID RoundID) {
 	h.t.Helper()
 
 	event := &RoundJoined{
@@ -534,12 +546,12 @@ func (h *actorTestHarness) clearServerMessages() {
 
 // newTestRound creates a test Round with a unique commitment transaction,
 // using the roundID in the script to ensure distinct transaction hashes.
-func (h *actorTestHarness) newTestRound(roundID string) *Round {
+func (h *actorTestHarness) newTestRound(roundID RoundID) *Round {
 	h.t.Helper()
 
 	tx := wire.NewMsgTx(2)
 
-	uniqueScript := append([]byte{0x00, 0x14}, []byte(roundID)...)
+	uniqueScript := append([]byte{0x00, 0x14}, []byte(roundID.String())...)
 	tx.AddTxOut(&wire.TxOut{
 		Value:    100000,
 		PkScript: uniqueScript,

--- a/round/actor_messages.go
+++ b/round/actor_messages.go
@@ -88,8 +88,8 @@ type FSMStateInfo struct {
 	// IsPrimary indicates whether this is the primary FSM.
 	IsPrimary bool
 
-	// RoundID is the round ID (empty for primary FSM).
-	RoundID string
+	// RoundID is the round ID (zero value for primary FSM).
+	RoundID RoundID
 }
 
 // GetClientStateResponse returns the current state of all FSMs.

--- a/round/actor_test.go
+++ b/round/actor_test.go
@@ -142,7 +142,8 @@ func TestActorRecovery(t *testing.T) {
 
 		h := newActorTestHarness(t)
 
-		round := h.newTestRound("test-round-001")
+		roundID := testRoundID("test-round-001")
+		round := h.newTestRound(roundID)
 		h.setupMockRoundStoreForRecovery([]*Round{round})
 
 		err := h.start()
@@ -152,9 +153,9 @@ func TestActorRecovery(t *testing.T) {
 		// created a corresponding FSM to resume processing.
 		require.Len(t, h.actor.activeRounds, 1)
 
-		roundFSM, exists := h.actor.activeRounds["test-round-001"]
+		roundFSM, exists := h.actor.activeRounds[roundID]
 		require.True(t, exists, "expected round FSM for test-round-001")
-		require.Equal(t, "test-round-001", roundFSM.RoundID)
+		require.Equal(t, roundID, roundFSM.RoundID)
 
 		// The commitment tx index is used to route confirmation
 		// events to the correct round FSM, so it must be rebuilt
@@ -162,7 +163,7 @@ func TestActorRecovery(t *testing.T) {
 		txid := round.CommitmentTx.UnwrapOrFail(t).UnsignedTx.TxHash()
 		indexedRoundID, exists := h.actor.commitmentTxIndex[txid]
 		require.True(t, exists, "expected commitment tx in index")
-		require.Equal(t, "test-round-001", indexedRoundID)
+		require.Equal(t, roundID, indexedRoundID)
 
 		// The actor must re-register for chain confirmations during
 		// recovery to resume monitoring the commitment transaction.
@@ -178,9 +179,9 @@ func TestActorRecovery(t *testing.T) {
 		h := newActorTestHarness(t)
 
 		rounds := []*Round{
-			h.newTestRound("round-001"),
-			h.newTestRound("round-002"),
-			h.newTestRound("round-003"),
+			h.newTestRound(testRoundID("round-001")),
+			h.newTestRound(testRoundID("round-002")),
+			h.newTestRound(testRoundID("round-003")),
 		}
 		h.setupMockRoundStoreForRecovery(rounds)
 
@@ -212,13 +213,14 @@ func TestActorConfirmation(t *testing.T) {
 
 		h := newActorTestHarness(t)
 
-		round := h.newTestRound("test-round-001")
+		roundID := testRoundID("test-round-001")
+		round := h.newTestRound(roundID)
 		h.setupMockRoundStoreForRecovery([]*Round{round})
 
 		err := h.start()
 		require.NoError(t, err)
 
-		require.Contains(t, h.actor.activeRounds, "test-round-001")
+		require.Contains(t, h.actor.activeRounds, roundID)
 
 		txid := round.CommitmentTx.UnwrapOrFail(t).UnsignedTx.TxHash()
 		h.roundStore.On(
@@ -308,7 +310,7 @@ func TestActorConfirmation(t *testing.T) {
 		// the database but has no active FSM. This represents an
 		// inconsistent state that should be caught and reported as an
 		// error rather than silently ignored.
-		round := h.newTestRound("orphan-round")
+		round := h.newTestRound(testRoundID("orphan-round"))
 		txid := round.CommitmentTx.UnwrapOrFail(t).UnsignedTx.TxHash()
 		h.roundStore.On(
 			"LookupRoundByCommitmentTx", mock.Anything, txid,
@@ -401,16 +403,16 @@ func TestActorProcessOutbox(t *testing.T) {
 
 		h := newActorTestHarness(t)
 
-		round := h.newTestRound("completing-round")
+		roundID := testRoundID("completing-round")
+		round := h.newTestRound(roundID)
 		h.setupMockRoundStoreForRecovery([]*Round{round})
 
 		err := h.start()
 		require.NoError(t, err)
 
-		require.Contains(t, h.actor.activeRounds, "completing-round")
+		require.Contains(t, h.actor.activeRounds, roundID)
 
 		txid := round.CommitmentTx.UnwrapOrFail(t).UnsignedTx.TxHash()
-		roundID := "completing-round"
 		h.roundStore.On(
 			"FinalizeRound", mock.Anything, roundID, txid,
 			mock.Anything,
@@ -422,7 +424,7 @@ func TestActorProcessOutbox(t *testing.T) {
 		}
 		outbox := []ClientOutMsg{
 			&RoundCompletedNotification{
-				RoundID:  "completing-round",
+				RoundID:  roundID,
 				TxID:     txid,
 				ConfInfo: confInfo,
 			},
@@ -435,7 +437,7 @@ func TestActorProcessOutbox(t *testing.T) {
 		// in-memory state, including the FSM and tx index entry, to
 		// prevent memory leaks and avoid routing events to completed
 		// rounds.
-		require.NotContains(t, h.actor.activeRounds, "completing-round")
+		require.NotContains(t, h.actor.activeRounds, roundID)
 
 		_, exists := h.actor.commitmentTxIndex[txid]
 		require.False(t, exists)
@@ -457,18 +459,19 @@ func TestActorProcessOutbox(t *testing.T) {
 
 		require.Empty(t, h.actor.activeRounds)
 
-		round := h.newTestRound("checkpointed-round")
+		roundID := testRoundID("checkpointed-round")
+		round := h.newTestRound(roundID)
 		h.roundStore.On(
-			"FetchState", mock.Anything, "checkpointed-round",
+			"FetchState", mock.Anything, roundID,
 		).Return(
 			round,
-			&InputSigSentState{RoundID: "checkpointed-round"},
+			&InputSigSentState{RoundID: roundID},
 			nil,
 		)
 
 		outbox := []ClientOutMsg{
 			&RoundCheckpointedNotification{
-				RoundID: "checkpointed-round",
+				RoundID: roundID,
 			},
 		}
 
@@ -479,12 +482,12 @@ func TestActorProcessOutbox(t *testing.T) {
 		// migrate the round into an active FSM so it can continue
 		// processing events. This handles the transition from primary
 		// FSM states to dedicated round FSMs.
-		require.Contains(t, h.actor.activeRounds, "checkpointed-round")
+		require.Contains(t, h.actor.activeRounds, roundID)
 
 		txid := round.CommitmentTx.UnwrapOrFail(t).UnsignedTx.TxHash()
 		indexedRoundID, exists := h.actor.commitmentTxIndex[txid]
 		require.True(t, exists)
-		require.Equal(t, "checkpointed-round", indexedRoundID)
+		require.Equal(t, roundID, indexedRoundID)
 	})
 
 	t.Run("vtxo_created", func(t *testing.T) {
@@ -515,23 +518,24 @@ func TestActorProcessOutbox(t *testing.T) {
 		err := h.start()
 		require.NoError(t, err)
 
-		round := h.newTestRound("idempotent-round")
+		roundID := testRoundID("idempotent-round")
+		round := h.newTestRound(roundID)
 		h.roundStore.On(
-			"FetchState", mock.Anything, "idempotent-round",
+			"FetchState", mock.Anything, roundID,
 		).Return(
 			round,
-			&InputSigSentState{RoundID: "idempotent-round"},
+			&InputSigSentState{RoundID: roundID},
 			nil,
 		)
 
-		err = h.actor.migrateRoundToActiveFSM(h.ctx, "idempotent-round")
+		err = h.actor.migrateRoundToActiveFSM(h.ctx, roundID)
 		require.NoError(t, err)
 		require.Len(t, h.actor.activeRounds, 1)
 
 		// Migration must be idempotent to handle duplicate
 		// checkpoint notifications without creating multiple FSMs for
 		// the same round.
-		err = h.actor.migrateRoundToActiveFSM(h.ctx, "idempotent-round")
+		err = h.actor.migrateRoundToActiveFSM(h.ctx, roundID)
 		require.NoError(t, err)
 		require.Len(t, h.actor.activeRounds, 1)
 	})
@@ -566,8 +570,8 @@ func TestActorGetStateWithActiveRounds(t *testing.T) {
 	h := newActorTestHarness(t)
 
 	rounds := []*Round{
-		h.newTestRound("round-001"),
-		h.newTestRound("round-002"),
+		h.newTestRound(testRoundID("round-001")),
+		h.newTestRound(testRoundID("round-002")),
 	}
 	h.setupMockRoundStoreForRecovery(rounds)
 
@@ -585,7 +589,7 @@ func TestActorGetStateWithActiveRounds(t *testing.T) {
 	require.True(t, primaryState.IsPrimary)
 
 	for _, round := range rounds {
-		roundState, exists := states[round.RoundID]
+		roundState, exists := states[round.RoundID.String()]
 		require.True(t, exists, "expected state for %s", round.RoundID)
 		require.False(t, roundState.IsPrimary)
 		require.Equal(t, round.RoundID, roundState.RoundID)
@@ -643,7 +647,7 @@ func TestActorLifecycle(t *testing.T) {
 		h.assertFSMState("RegistrationSentState")
 		h.assertServerMessageSent("SendClientEventRequest")
 
-		roundID := "test-round-001"
+		roundID := testRoundID("test-round-001")
 		h.simulateRoundJoined(roundID)
 		h.assertFSMState("RoundJoinedState")
 	})
@@ -734,7 +738,9 @@ func TestActorServerMessageRouting(t *testing.T) {
 				h.sendWalletConfirmation(intent)
 				h.sendServerMessage(&RegistrationRequested{})
 			},
-			serverEvent:   &RoundJoined{RoundID: "test-round"},
+			serverEvent: &RoundJoined{
+				RoundID: testRoundID("test-round"),
+			},
 			expectedState: "RoundJoinedState",
 			expectOutbox:  false,
 		},

--- a/round/events.go
+++ b/round/events.go
@@ -2,6 +2,7 @@ package round
 
 import (
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
@@ -82,7 +83,8 @@ type RegistrationRequested struct {
 	Intents []BoardingIntent
 
 	// RoundID allows resuming a previously assigned round when rejoining.
-	RoundID string
+	// None for new registrations.
+	RoundID fn.Option[RoundID]
 }
 
 func (e *RegistrationRequested) clientEventSealed() {}
@@ -92,32 +94,33 @@ func (e *RegistrationRequested) clientEventSealed() {}
 // server FSM.
 type RoundJoined struct {
 	// RoundID is the unique identifier for the round.
-	RoundID string
+	RoundID RoundID
 }
 
 func (e *RoundJoined) clientEventSealed() {}
 
 // CommitmentTxBuilt is emitted when the server sends the commitment
-// transaction and VTXT path to the client. This event arrives via the Outbox
+// transaction and VTXT paths to the client. This event arrives via the Outbox
 // from the server FSM after building the transaction that commits all boarding
 // UTXOs.
 type CommitmentTxBuilt struct {
 	// RoundID identifies which round this commitment transaction belongs
 	// to.
-	RoundID string
+	RoundID RoundID
 
 	// Tx is the unsigned commitment transaction as a PSBT. Using PSBT
 	// allows the server to include WitnessUtxo for all inputs, which is
 	// required for correct Taproot sighash computation (BIP341).
 	Tx *psbt.Packet
 
-	// VTXTTree contains the client's extracted sub-tree from the virtual
-	// transaction tree. The server sends only the minimal path containing
-	// the transactions needed to reach this client's VTXO leaves, not the
-	// full tree (which may contain hundreds of transactions for all
-	// participants). This sub-tree is sufficient for the client to verify
-	// their VTXOs and perform unilateral exit if needed.
-	VTXTTree *tree.Tree
+	// VTXOTreePaths maps commitment transaction output indices to the
+	// client's extracted sub-tree from the virtual transaction tree. The
+	// server sends only the minimal paths containing transactions needed to
+	// reach this client's VTXO leaves, not the full tree (which may contain
+	// hundreds of transactions for all participants). Each sub-tree is
+	// sufficient for the client to verify their VTXOs and perform
+	// unilateral exit if needed.
+	VTXOTreePaths map[int]*tree.Tree
 }
 
 func (e *CommitmentTxBuilt) clientEventSealed() {}
@@ -149,12 +152,12 @@ func (e *GenerateNonces) clientEventSealed() {}
 // the next phase of the MuSig2 signing protocol.
 type NoncesAggregated struct {
 	// RoundID identifies which round these aggregated nonces belong to.
-	RoundID string
+	RoundID RoundID
 
-	// AggregatedNonces maps transaction IDs to their aggregated MuSig2
+	// AggNonces maps transaction IDs to their aggregated MuSig2 public
 	// nonces. Each entry corresponds to a transaction in the VTXT that
 	// requires signing.
-	AggregatedNonces map[chainhash.Hash][]byte
+	AggNonces map[tree.TxID]tree.Musig2PubNonce
 }
 
 func (e *NoncesAggregated) clientEventSealed() {}
@@ -180,19 +183,24 @@ func (e *GeneratePartialSigs) clientEventSealed() {}
 // signatures for each transaction in the VTXT.
 type OperatorSigned struct {
 	// RoundID identifies which round these signatures belong to.
-	RoundID string
+	RoundID RoundID
 
-	// Signatures maps transaction IDs to their complete aggregated Schnorr
+	// AggSigs maps transaction IDs to their complete aggregated Schnorr
 	// signatures. Each entry corresponds to a transaction in the VTXT.
-	Signatures map[chainhash.Hash][]byte
-
-	// SignedVTXT optionally contains the fully signed virtual transaction
-	// tree in serialized form. This may be omitted and reconstructed from
-	// the signatures if needed.
-	SignedVTXT []byte
+	AggSigs map[tree.TxID]*schnorr.Signature
 }
 
 func (e *OperatorSigned) clientEventSealed() {}
+
+// AwaitingBoardingSigs is emitted when the server signals it is ready to
+// receive boarding signatures from the client. This occurs after VTXO nonce
+// aggregation and partial signature collection phases complete.
+type AwaitingBoardingSigs struct {
+	// RoundID identifies which round is awaiting boarding signatures.
+	RoundID RoundID
+}
+
+func (e *AwaitingBoardingSigs) clientEventSealed() {}
 
 // BoardingConfirmed is emitted when the commitment transaction has been
 // confirmed on-chain with sufficient confirmations.

--- a/round/harness_test.go
+++ b/round/harness_test.go
@@ -40,7 +40,7 @@ func (m *MockRoundStore) CommitState(ctx context.Context, round *Round,
 
 //nolint:forcetypeassert
 func (m *MockRoundStore) FetchState(ctx context.Context,
-	roundID string) (*Round, ClientState, error) {
+	roundID RoundID) (*Round, ClientState, error) {
 
 	args := m.Called(ctx, roundID)
 
@@ -85,7 +85,7 @@ func (m *MockRoundStore) ListActiveRounds(
 	return rounds, args.Error(1)
 }
 
-func (m *MockRoundStore) FinalizeRound(ctx context.Context, roundID string,
+func (m *MockRoundStore) FinalizeRound(ctx context.Context, roundID RoundID,
 	txid chainhash.Hash, confInfo ConfInfo) error {
 
 	args := m.Called(ctx, roundID, txid, confInfo)
@@ -675,7 +675,7 @@ func (h *boardingTestHarness) newTestVTXOTreeForIntent(
 // with WitnessUtxo populated for all inputs, which is required for correct
 // Taproot sighash computation.
 func (h *boardingTestHarness) newCommitmentTxBuiltEvent(
-	roundID string,
+	roundID RoundID,
 	intents []BoardingIntent,
 	vtxtTree *tree.Tree) *CommitmentTxBuilt {
 
@@ -722,9 +722,9 @@ func (h *boardingTestHarness) newCommitmentTxBuiltEvent(
 	packet.Outputs = pOutputs
 
 	return &CommitmentTxBuilt{
-		RoundID:  roundID,
-		Tx:       packet,
-		VTXTTree: vtxtTree,
+		RoundID:       roundID,
+		Tx:            packet,
+		VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
 	}
 }
 
@@ -732,19 +732,19 @@ func (h *boardingTestHarness) newCommitmentTxBuiltEvent(
 // simulating what the server sends after collecting and combining nonces from
 // all round participants for the MuSig2 signing protocol.
 func (h *boardingTestHarness) newNoncesAggregatedEvent(
-	roundID string, vtxtTree *tree.Tree) *NoncesAggregated {
+	roundID RoundID, vtxtTree *tree.Tree) *NoncesAggregated {
 
 	h.t.Helper()
 
-	aggNonces := make(map[chainhash.Hash][]byte)
+	aggNonces := make(map[tree.TxID]tree.Musig2PubNonce)
 	err := vtxtTree.Root.ForEach(func(node *tree.Node) error {
 		txid, err := node.TXID()
 		if err != nil {
 			return err
 		}
 
-		nonce := make([]byte, musig2.PubNonceSize)
-		_, err = rand.Read(nonce)
+		var nonce tree.Musig2PubNonce
+		_, err = rand.Read(nonce[:])
 		if err != nil {
 			return err
 		}
@@ -756,8 +756,8 @@ func (h *boardingTestHarness) newNoncesAggregatedEvent(
 	require.NoError(h.t, err)
 
 	return &NoncesAggregated{
-		RoundID:          roundID,
-		AggregatedNonces: aggNonces,
+		RoundID:   roundID,
+		AggNonces: aggNonces,
 	}
 }
 
@@ -767,22 +767,28 @@ func (h *boardingTestHarness) newNoncesAggregatedEvent(
 //
 //nolint:unused
 func (h *boardingTestHarness) newOperatorSignedEvent(
-	roundID string, vtxtTree *tree.Tree) *OperatorSigned {
+	roundID RoundID, vtxtTree *tree.Tree) *OperatorSigned {
 
 	h.t.Helper()
 
 	// Build a map of signatures keyed by transaction ID.
-	sigs := make(map[chainhash.Hash][]byte)
+	sigs := make(map[tree.TxID]*schnorr.Signature)
 	err := vtxtTree.Root.ForEach(func(node *tree.Node) error {
 		txid, err := node.TXID()
 		if err != nil {
 			return err
 		}
 
-		sig := make([]byte, schnorr.SignatureSize)
-		_, err = rand.Read(sig)
+		sigBytes := make([]byte, schnorr.SignatureSize)
+		_, err = rand.Read(sigBytes)
 		if err != nil {
 			return err
+		}
+
+		sig, err := schnorr.ParseSignature(sigBytes)
+		if err != nil {
+			// Use a dummy signature for tests.
+			sig = &schnorr.Signature{}
 		}
 
 		sigs[txid] = sig
@@ -792,15 +798,15 @@ func (h *boardingTestHarness) newOperatorSignedEvent(
 	require.NoError(h.t, err)
 
 	return &OperatorSigned{
-		RoundID:    roundID,
-		Signatures: sigs,
+		RoundID: roundID,
+		AggSigs: sigs,
 	}
 }
 
 // newCommitmentTxReceivedState creates a CommitmentTxReceivedState ready for
 // validation testing with a pre-built commitment transaction and VTXT tree.
 func (h *boardingTestHarness) newCommitmentTxReceivedState(
-	roundID string, intents []BoardingIntent) *CommitmentTxReceivedState {
+	roundID RoundID, intents []BoardingIntent) *CommitmentTxReceivedState {
 
 	h.t.Helper()
 
@@ -808,12 +814,12 @@ func (h *boardingTestHarness) newCommitmentTxReceivedState(
 	commitmentTx := h.newTestCommitmentTx(intents)
 
 	return &CommitmentTxReceivedState{
-		RoundID:      roundID,
-		CommitmentTx: commitmentTx,
-		TxID:         commitmentTx.UnsignedTx.TxHash(),
-		VTXTTree:     vtxtTree,
-		Intents:      intents,
-		ClientTrees:  make(map[SignerKey]*tree.Tree),
+		RoundID:       roundID,
+		CommitmentTx:  commitmentTx,
+		TxID:          commitmentTx.UnsignedTx.TxHash(),
+		VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
+		Intents:       intents,
+		ClientTrees:   make(map[SignerKey]*tree.Tree),
 	}
 }
 
@@ -821,7 +827,7 @@ func (h *boardingTestHarness) newCommitmentTxReceivedState(
 // for nonce generation, with boarding input indices pre-mapped for efficient
 // input signature placement during the signing phase.
 func (h *boardingTestHarness) newCommitmentTxValidatedState(
-	roundID string, intents []BoardingIntent) *CommitmentTxValidatedState {
+	roundID RoundID, intents []BoardingIntent) *CommitmentTxValidatedState {
 
 	h.t.Helper()
 
@@ -833,12 +839,27 @@ func (h *boardingTestHarness) newCommitmentTxValidatedState(
 		boardingInputIndices[intent.Outpoint] = i
 	}
 
+	// Populate ClientTrees by extracting sub-trees for each signer key
+	// in the intent's VtxoTemplate. This simulates what happens during
+	// commitment tx validation when ValidatePath is called.
+	clientTrees := make(map[SignerKey]*tree.Tree)
+	for _, intent := range intents {
+		for _, vtxoReq := range intent.VtxoTemplate {
+			signerKey := NewSignerKey(vtxoReq.SigningKey.PubKey)
+
+			// The client tree is a subtree extracted from the VTXT
+			// tree that corresponds to this signer's VTXO. For test
+			// purposes, we use the full tree as the client tree.
+			clientTrees[signerKey] = vtxtTree
+		}
+	}
+
 	return &CommitmentTxValidatedState{
 		RoundID:              roundID,
 		CommitmentTx:         commitmentTx,
-		VTXTTree:             vtxtTree,
+		VTXOTreePaths:        map[int]*tree.Tree{0: vtxtTree},
 		Intents:              intents,
-		ClientTrees:          make(map[SignerKey]*tree.Tree),
+		ClientTrees:          clientTrees,
 		BoardingInputIndices: boardingInputIndices,
 	}
 }
@@ -1009,7 +1030,7 @@ func (h *boardingTestHarness) setupMockVTXOStoreForSave() {
 
 //nolint:unused
 func (h *boardingTestHarness) newNoncesSentState(
-	roundID string, intents []BoardingIntent) *NoncesSentState {
+	roundID RoundID, intents []BoardingIntent) *NoncesSentState {
 
 	h.t.Helper()
 
@@ -1026,7 +1047,7 @@ func (h *boardingTestHarness) newNoncesSentState(
 	return &NoncesSentState{
 		RoundID:              roundID,
 		CommitmentTx:         commitmentTx,
-		VTXTTree:             vtxtTree,
+		VTXOTreePaths:        map[int]*tree.Tree{0: vtxtTree},
 		Intents:              intents,
 		ClientTrees:          make(map[SignerKey]*tree.Tree),
 		Musig2Sessions:       musig2Sessions,
@@ -1036,7 +1057,7 @@ func (h *boardingTestHarness) newNoncesSentState(
 
 //nolint:unused
 func (h *boardingTestHarness) newNoncesAggregatedState(
-	roundID string, intents []BoardingIntent) *NoncesAggregatedState {
+	roundID RoundID, intents []BoardingIntent) *NoncesAggregatedState {
 
 	h.t.Helper()
 
@@ -1048,15 +1069,15 @@ func (h *boardingTestHarness) newNoncesAggregatedState(
 		boardingInputIndices[intent.Outpoint] = i
 	}
 
-	aggNonces := make(map[chainhash.Hash][]byte)
+	aggNonces := make(map[tree.TxID]tree.Musig2PubNonce)
 	err := vtxtTree.Root.ForEach(func(node *tree.Node) error {
 		txid, err := node.TXID()
 		if err != nil {
 			return err
 		}
 
-		nonce := make([]byte, musig2.PubNonceSize)
-		_, err = rand.Read(nonce)
+		var nonce tree.Musig2PubNonce
+		_, err = rand.Read(nonce[:])
 		if err != nil {
 			return err
 		}
@@ -1070,18 +1091,18 @@ func (h *boardingTestHarness) newNoncesAggregatedState(
 	return &NoncesAggregatedState{
 		RoundID:              roundID,
 		CommitmentTx:         commitmentTx,
-		VTXTTree:             vtxtTree,
+		VTXOTreePaths:        map[int]*tree.Tree{0: vtxtTree},
 		Intents:              intents,
 		ClientTrees:          make(map[SignerKey]*tree.Tree),
 		Musig2Sessions:       make(map[SignerKey]*tree.SignerSession),
-		AggregatedNonces:     aggNonces,
+		AggNonces:            aggNonces,
 		BoardingInputIndices: boardingInputIndices,
 	}
 }
 
 //nolint:unused
 func (h *boardingTestHarness) newPartialSigsSentState(
-	roundID string, intents []BoardingIntent) *PartialSigsSentState {
+	roundID RoundID, intents []BoardingIntent) *PartialSigsSentState {
 
 	h.t.Helper()
 
@@ -1096,7 +1117,7 @@ func (h *boardingTestHarness) newPartialSigsSentState(
 	return &PartialSigsSentState{
 		RoundID:              roundID,
 		CommitmentTx:         commitmentTx,
-		VTXTTree:             vtxtTree,
+		VTXOTreePaths:        map[int]*tree.Tree{0: vtxtTree},
 		Intents:              intents,
 		ClientTrees:          make(map[SignerKey]*tree.Tree),
 		Musig2Sessions:       make(map[SignerKey]*tree.SignerSession),
@@ -1105,18 +1126,31 @@ func (h *boardingTestHarness) newPartialSigsSentState(
 }
 
 func (h *boardingTestHarness) newInputSigSentState(
-	roundID string, intents []BoardingIntent) *InputSigSentState {
+	roundID RoundID, intents []BoardingIntent) *InputSigSentState {
 
 	h.t.Helper()
 
 	vtxtTree := h.newTestVTXOTreeForIntent(intents[0])
 	commitmentTx := h.newTestCommitmentTx(intents)
 
-	inputSigs := make([][]byte, len(intents))
-	for i := range inputSigs {
-		inputSigs[i] = make([]byte, schnorr.SignatureSize)
-		_, err := rand.Read(inputSigs[i])
+	inputSigs := make([]*types.BoardingInputSignature, len(intents))
+	for i, intent := range intents {
+		sigBytes := make([]byte, schnorr.SignatureSize)
+		_, err := rand.Read(sigBytes)
 		require.NoError(h.t, err)
+
+		// Parse the random bytes as a signature, or use a dummy if
+		// invalid.
+		sig, err := schnorr.ParseSignature(sigBytes)
+		if err != nil {
+			sig = &schnorr.Signature{}
+		}
+
+		inputSigs[i] = &types.BoardingInputSignature{
+			InputIndex:      i,
+			Outpoint:        intent.Outpoint,
+			ClientSignature: sig,
+		}
 	}
 
 	clientTrees := make(map[SignerKey]*tree.Tree)
@@ -1128,12 +1162,12 @@ func (h *boardingTestHarness) newInputSigSentState(
 	}
 
 	return &InputSigSentState{
-		RoundID:      roundID,
-		CommitmentTx: commitmentTx,
-		VTXTTree:     vtxtTree,
-		Intents:      intents,
-		ClientTrees:  clientTrees,
-		InputSigs:    inputSigs,
+		RoundID:       roundID,
+		CommitmentTx:  commitmentTx,
+		VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
+		Intents:       intents,
+		ClientTrees:   clientTrees,
+		InputSigs:     inputSigs,
 	}
 }
 
@@ -1614,7 +1648,7 @@ func (h *realSigningTestHarness) newCommitmentTxForIntents(
 // 2. Going through the full nonce exchange and signing protocol.
 // 3. Combining partials to produce final Schnorr signatures.
 func (h *realSigningTestHarness) generateValidTreeSignatures(
-	vtxtTree *tree.Tree) (map[chainhash.Hash][]byte, error) {
+	vtxtTree *tree.Tree) (map[tree.TxID]*schnorr.Signature, error) {
 
 	h.t.Helper()
 
@@ -1661,7 +1695,7 @@ func (h *realSigningTestHarness) generateValidTreeSignatures(
 	h.operatorSigner = newRealMuSig2Signer(h.operatorPrivKey)
 
 	// Process each node and build a map of signatures by txid.
-	finalSigs := make(map[chainhash.Hash][]byte, len(nodes))
+	finalSigs := make(map[tree.TxID]*schnorr.Signature, len(nodes))
 	for _, ni := range nodes {
 		sig, sigErr := h.generateSignatureForNode(
 			ni.sigHash, sweepRoot,
@@ -1670,7 +1704,7 @@ func (h *realSigningTestHarness) generateValidTreeSignatures(
 			return nil, fmt.Errorf("failed to sign node %s: %w",
 				ni.txid, sigErr)
 		}
-		finalSigs[ni.txid] = sig.Serialize()
+		finalSigs[ni.txid] = sig
 	}
 
 	return finalSigs, nil

--- a/round/interfaces.go
+++ b/round/interfaces.go
@@ -2,12 +2,15 @@ package round
 
 import (
 	"context"
+	"encoding/hex"
+	"fmt"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/google/uuid"
 	"github.com/lightninglabs/darepo-client/baselib/protofsm"
 	"github.com/lightninglabs/darepo-client/lib/tree"
 	"github.com/lightninglabs/darepo-client/lib/types"
@@ -46,12 +49,48 @@ type ClientStateMachineCfg = protofsm.StateMachineCfg[
 // Musig2PubNonce is an alias for the MuSig2 public nonce type from lib.
 type Musig2PubNonce = tree.Musig2PubNonce
 
-// RoundID is a type alias for round identifiers.
-type RoundID = string
+// RoundID is a unique identifier for rounds, using UUID v7 for time-ordering.
+type RoundID uuid.UUID
+
+// NewRoundID generates a new unique RoundID using cryptographic randomness.
+func NewRoundID() (RoundID, error) {
+	id, err := uuid.NewV7()
+	if err != nil {
+		return RoundID{}, err
+	}
+
+	return RoundID(id), nil
+}
+
+// String returns the full string representation of the RoundID.
+func (id RoundID) String() string {
+	return uuid.UUID(id).String()
+}
+
+// LogPrefix returns a short string representation of the RoundID for logging.
+// It uses the last 4 bytes (32 bits) of the UUIDv7, which are high-entropy
+// random bits.
+func (id RoundID) LogPrefix() string {
+	return fmt.Sprintf("round(%v)", hex.EncodeToString(id[12:16]))
+}
+
+// ParseRoundID parses a RoundID from its string representation.
+func ParseRoundID(s string) (RoundID, error) {
+	id, err := uuid.Parse(s)
+	if err != nil {
+		return RoundID{}, err
+	}
+
+	return RoundID(id), nil
+}
 
 // SignerKey is the 33-byte compressed public key used to identify a signer
 // in MuSig2 sessions and client tree mappings.
 type SignerKey = [33]byte
+
+// SigningKeyHex is an alias for SignerKey, compatible with the server's
+// route.Vertex type which is also a 33-byte compressed public key.
+type SigningKeyHex = SignerKey
 
 // NewSignerKey creates a SignerKey from a public key.
 func NewSignerKey(pk *btcec.PublicKey) SignerKey {
@@ -128,7 +167,7 @@ type BoardingIntent struct {
 
 	// RoundID is the identifier of the round this intent was assigned to.
 	// None until the client joins a round.
-	RoundID fn.Option[string]
+	RoundID fn.Option[RoundID]
 }
 
 // ConfInfo contains chain information about when a round's commitment
@@ -148,7 +187,7 @@ type ConfInfo struct {
 type Round struct {
 	// RoundID is the unique identifier assigned by the server when the
 	// client joins this round.
-	RoundID string
+	RoundID RoundID
 
 	// ConfInfo contains chain information about when the round's commitment
 	// transaction was confirmed. None until the commitment tx is confirmed
@@ -160,12 +199,12 @@ type Round struct {
 	// until the server constructs it.
 	CommitmentTx fn.Option[*psbt.Packet]
 
-	// VTXTTree is the client's extracted sub-tree from the Virtual
-	// Transaction Tree. This contains only the minimal path needed to
-	// reach the client's VTXO leaves, not the full tree. This is ephemeral
-	// and only kept in memory during signing. After confirmation, only
-	// per-VTXO paths are persisted for unilateral exit.
-	VTXTTree fn.Option[*tree.Tree]
+	// VTXOTreePaths maps commitment tx output indices to VTXO tree paths.
+	// Each path contains only the minimal tree needed to reach the client's
+	// VTXO leaves. This is ephemeral and only kept in memory during
+	// signing. After confirmation, only per-VTXO paths are persisted for
+	// unilateral exit.
+	VTXOTreePaths fn.Option[map[int]*tree.Tree]
 
 	// BoardingIntents contains all boarding intents participating in this
 	// round.
@@ -201,7 +240,7 @@ type RoundStore interface {
 	// together to ensure consistency.
 	//
 	// Returns error if round doesn't exist.
-	FetchState(ctx context.Context, roundID string) (
+	FetchState(ctx context.Context, roundID RoundID) (
 		*Round, ClientState, error,
 	)
 
@@ -220,7 +259,7 @@ type RoundStore interface {
 	// contains the block height and hash at which the commitment tx was
 	// confirmed.
 	FinalizeRound(
-		ctx context.Context, roundID string, txid chainhash.Hash,
+		ctx context.Context, roundID RoundID, txid chainhash.Hash,
 		confInfo ConfInfo,
 	) error
 }

--- a/round/outbox_messages.go
+++ b/round/outbox_messages.go
@@ -1,9 +1,12 @@
 package round
 
 import (
+	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/lib/tree"
 	"github.com/lightninglabs/darepo-client/lib/types"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -29,13 +32,13 @@ type SubmitNoncesRequest struct {
 	actor.BaseMessage
 
 	// RoundID identifies the round.
-	RoundID string
+	RoundID RoundID
 
-	// Nonces maps transaction IDs to signing keys to their MuSig2 public
-	// nonces. The outer map is keyed by transaction ID, and the inner map
-	// is keyed by signing key. Each signing key (VTXO) contributes its own
-	// nonce for each transaction in its path.
-	Nonces map[chainhash.Hash]map[SignerKey][]byte
+	// Nonces maps signing keys to their per-transaction MuSig2 public
+	// nonces. The outer map is keyed by signing key (one per VTXO), and
+	// the inner map is keyed by transaction ID. This structure matches
+	// the server's expected format where nonces are grouped by cosigner.
+	Nonces map[SignerKey]map[tree.TxID]tree.Musig2PubNonce
 }
 
 func (m *SubmitNoncesRequest) clientOutMsgSealed() {}
@@ -46,11 +49,13 @@ type SubmitPartialSigRequest struct {
 	actor.BaseMessage
 
 	// RoundID identifies the round.
-	RoundID string
+	RoundID RoundID
 
-	// PartialSigs maps transaction IDs to their MuSig2 partial signatures.
-	// Each entry corresponds to a transaction in the client's VTXT path.
-	PartialSigs map[chainhash.Hash][]byte
+	// Signatures maps signing keys to their per-transaction MuSig2 partial
+	// signatures. The outer map is keyed by signing key (one per VTXO), and
+	// the inner map is keyed by transaction ID. This structure matches the
+	// server's expected format where signatures are grouped by cosigner.
+	Signatures map[SignerKey]map[tree.TxID]*musig2.PartialSignature
 }
 
 func (m *SubmitPartialSigRequest) clientOutMsgSealed() {}
@@ -61,11 +66,12 @@ type SubmitForfeitSigRequest struct {
 	actor.BaseMessage
 
 	// RoundID identifies the round.
-	RoundID string
+	RoundID RoundID
 
-	// ForfeitSigs contains the signature for the boarding UTXO input in the
-	// commitment transaction.
-	ForfeitSigs [][]byte
+	// Signatures contains structured boarding input signatures. Each
+	// signature includes the input index, outpoint, and schnorr signature
+	// for the collaborative tapscript spend path.
+	Signatures []*types.BoardingInputSignature
 }
 
 func (m *SubmitForfeitSigRequest) clientOutMsgSealed() {}
@@ -158,7 +164,7 @@ type RoundCompletedNotification struct {
 	actor.BaseMessage
 
 	// RoundID identifies the completed round.
-	RoundID string
+	RoundID RoundID
 
 	// TxID is the confirmed commitment transaction ID.
 	TxID chainhash.Hash
@@ -178,7 +184,7 @@ type RoundCheckpointedNotification struct {
 	actor.BaseMessage
 
 	// RoundID identifies the checkpointed round to migrate.
-	RoundID string
+	RoundID RoundID
 }
 
 func (m *RoundCheckpointedNotification) clientOutMsgSealed() {}
@@ -190,9 +196,9 @@ func (m *RoundCheckpointedNotification) clientOutMsgSealed() {}
 type RoundFailedNotification struct {
 	actor.BaseMessage
 
-	// RoundID identifies the failed round (if known). Empty if the failure
-	// occurred before a round was assigned.
-	RoundID string
+	// RoundID identifies the failed round. None if the failure occurred
+	// before a round was assigned.
+	RoundID fn.Option[RoundID]
 
 	// Reason is a human-readable description of the failure.
 	Reason string

--- a/round/outbox_messages_test.go
+++ b/round/outbox_messages_test.go
@@ -4,10 +4,23 @@ import (
 	"testing"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/google/uuid"
+	"github.com/lightninglabs/darepo-client/lib/tree"
 	"github.com/lightninglabs/darepo-client/lib/types"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/stretchr/testify/require"
 )
+
+// testRoundIDForMsg creates a deterministic RoundID from a string seed.
+func testRoundIDForMsg(seed string) RoundID {
+	h := chainhash.HashH([]byte(seed))
+	id, _ := uuid.FromBytes(h[:16])
+
+	return RoundID(id)
+}
 
 // TestOutboxMessagesToProto ensures that ToProto() methods compile and return
 // the expected nil placeholders. These placeholders will be replaced with
@@ -39,11 +52,14 @@ func TestOutboxMessagesToProto(t *testing.T) {
 
 		txid := chainhash.HashH([]byte("test-tx"))
 		signerKey := NewSignerKey(pubKey)
+		var nonce tree.Musig2PubNonce
+		copy(nonce[:], []byte{0x01, 0x02})
+
 		msg := &SubmitNoncesRequest{
-			RoundID: "round-001",
-			Nonces: map[chainhash.Hash]map[SignerKey][]byte{
-				txid: {
-					signerKey: {0x01, 0x02},
+			RoundID: testRoundIDForMsg("round-001"),
+			Nonces: map[SignerKey]map[tree.TxID]tree.Musig2PubNonce{
+				signerKey: {
+					txid: nonce,
 				},
 			},
 		}
@@ -56,10 +72,19 @@ func TestOutboxMessagesToProto(t *testing.T) {
 		t.Parallel()
 
 		fakeTxid := chainhash.HashH([]byte("test-tx"))
+		signerKey := NewSignerKey(pubKey)
+
+		// Create a test partial signature.
+		var scalar btcec.ModNScalar
+		scalar.SetInt(12345)
+		partialSig := &musig2.PartialSignature{S: &scalar}
+
 		msg := &SubmitPartialSigRequest{
-			RoundID: "round-001",
-			PartialSigs: map[chainhash.Hash][]byte{
-				fakeTxid: {0x01, 0x02},
+			RoundID: testRoundIDForMsg("round-001"),
+			Signatures: map[SignerKey]map[tree.TxID]*musig2.PartialSignature{ //nolint:ll
+				signerKey: {
+					fakeTxid: partialSig,
+				},
 			},
 		}
 
@@ -71,8 +96,13 @@ func TestOutboxMessagesToProto(t *testing.T) {
 		t.Parallel()
 
 		msg := &SubmitForfeitSigRequest{
-			RoundID:     "round-001",
-			ForfeitSigs: [][]byte{{0xaa, 0xbb}},
+			RoundID: testRoundIDForMsg("round-001"),
+			Signatures: []*types.BoardingInputSignature{
+				{
+					InputIndex: 0,
+					Outpoint:   wire.OutPoint{},
+				},
+			},
 		}
 
 		result := msg.ToProto()
@@ -97,19 +127,22 @@ func TestOutboxMessagesClientOutMsgSealed(t *testing.T) {
 
 	t.Run("SubmitNoncesRequest", func(t *testing.T) {
 		t.Parallel()
-		msg := &SubmitNoncesRequest{RoundID: "round-001"}
+		roundID := testRoundIDForMsg("round-001")
+		msg := &SubmitNoncesRequest{RoundID: roundID}
 		msg.clientOutMsgSealed()
 	})
 
 	t.Run("SubmitPartialSigRequest", func(t *testing.T) {
 		t.Parallel()
-		msg := &SubmitPartialSigRequest{RoundID: "round-001"}
+		roundID := testRoundIDForMsg("round-001")
+		msg := &SubmitPartialSigRequest{RoundID: roundID}
 		msg.clientOutMsgSealed()
 	})
 
 	t.Run("SubmitForfeitSigRequest", func(t *testing.T) {
 		t.Parallel()
-		msg := &SubmitForfeitSigRequest{RoundID: "round-001"}
+		roundID := testRoundIDForMsg("round-001")
+		msg := &SubmitForfeitSigRequest{RoundID: roundID}
 		msg.clientOutMsgSealed()
 	})
 
@@ -134,7 +167,7 @@ func TestOutboxMessagesClientOutMsgSealed(t *testing.T) {
 	t.Run("RoundCompletedNotification", func(t *testing.T) {
 		t.Parallel()
 		msg := &RoundCompletedNotification{
-			RoundID: "round-001",
+			RoundID: testRoundIDForMsg("round-001"),
 			TxID:    txid,
 		}
 		msg.clientOutMsgSealed()
@@ -143,7 +176,7 @@ func TestOutboxMessagesClientOutMsgSealed(t *testing.T) {
 	t.Run("RoundCheckpointedNotification", func(t *testing.T) {
 		t.Parallel()
 		msg := &RoundCheckpointedNotification{
-			RoundID: "round-001",
+			RoundID: testRoundIDForMsg("round-001"),
 		}
 		msg.clientOutMsgSealed()
 	})
@@ -151,7 +184,7 @@ func TestOutboxMessagesClientOutMsgSealed(t *testing.T) {
 	t.Run("RoundFailedNotification", func(t *testing.T) {
 		t.Parallel()
 		msg := &RoundFailedNotification{
-			RoundID:       "round-001",
+			RoundID:       fn.Some(testRoundIDForMsg("round-001")),
 			Reason:        "validation failed",
 			Recoverable:   true,
 			OriginalError: nil,

--- a/round/states.go
+++ b/round/states.go
@@ -8,6 +8,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/baselib/protofsm"
 	"github.com/lightninglabs/darepo-client/lib/tree"
+	"github.com/lightninglabs/darepo-client/lib/types"
 )
 
 // ClientState is a sealed interface for all states in the client round
@@ -84,7 +85,7 @@ func (s *RegistrationSentState) clientStateSealed() {}
 type RoundJoinedState struct {
 	// RoundID is the unique identifier assigned by the server for this
 	// round.
-	RoundID string
+	RoundID RoundID
 
 	// Intents contains all boarding intents participating in this round.
 	Intents []BoardingIntent
@@ -101,10 +102,10 @@ func (s *RoundJoinedState) IsTerminal() bool {
 func (s *RoundJoinedState) clientStateSealed() {}
 
 // CommitmentTxReceivedState indicates the client has received the commitment
-// transaction and VTXT and must now validate them before proceeding.
+// transaction and VTXT paths and must now validate them before proceeding.
 type CommitmentTxReceivedState struct {
 	// RoundID is the unique identifier for this round.
-	RoundID string
+	RoundID RoundID
 
 	// CommitmentTx is the unsigned commitment transaction as a PSBT.
 	CommitmentTx *psbt.Packet
@@ -112,8 +113,8 @@ type CommitmentTxReceivedState struct {
 	// TxID is the transaction ID of the commitment transaction.
 	TxID chainhash.Hash
 
-	// VTXTTree is the virtual transaction tree for this round.
-	VTXTTree *tree.Tree
+	// VTXOTreePaths maps commitment tx output indices to VTXO tree paths.
+	VTXOTreePaths map[int]*tree.Tree
 
 	// Intents contains all boarding intents participating in this round.
 	Intents []BoardingIntent
@@ -137,13 +138,13 @@ func (s *CommitmentTxReceivedState) clientStateSealed() {}
 // and is ready to participate in MuSig2 signing.
 type CommitmentTxValidatedState struct {
 	// RoundID is the unique identifier for this round.
-	RoundID string
+	RoundID RoundID
 
 	// CommitmentTx is the unsigned commitment transaction as a PSBT.
 	CommitmentTx *psbt.Packet
 
-	// VTXTTree is the virtual transaction tree for this round.
-	VTXTTree *tree.Tree
+	// VTXOTreePaths maps commitment tx output indices to VTXO tree paths.
+	VTXOTreePaths map[int]*tree.Tree
 
 	// Intents contains all boarding intents participating in this round.
 	Intents []BoardingIntent
@@ -171,13 +172,13 @@ func (s *CommitmentTxValidatedState) clientStateSealed() {}
 // is waiting for aggregated nonces.
 type NoncesSentState struct {
 	// RoundID is the unique identifier for this round.
-	RoundID string
+	RoundID RoundID
 
 	// CommitmentTx is the unsigned commitment transaction as a PSBT.
 	CommitmentTx *psbt.Packet
 
-	// VTXTTree is the virtual transaction tree for this round.
-	VTXTTree *tree.Tree
+	// VTXOTreePaths maps commitment tx output indices to VTXO tree paths.
+	VTXOTreePaths map[int]*tree.Tree
 
 	// Intents contains all boarding intents participating in this round.
 	Intents []BoardingIntent
@@ -209,13 +210,13 @@ func (s *NoncesSentState) clientStateSealed() {}
 // and is ready to generate partial signatures.
 type NoncesAggregatedState struct {
 	// RoundID is the unique identifier for this round.
-	RoundID string
+	RoundID RoundID
 
 	// CommitmentTx is the unsigned commitment transaction as a PSBT.
 	CommitmentTx *psbt.Packet
 
-	// VTXTTree is the virtual transaction tree for this round.
-	VTXTTree *tree.Tree
+	// VTXOTreePaths maps commitment tx output indices to VTXO tree paths.
+	VTXOTreePaths map[int]*tree.Tree
 
 	// Intents contains all boarding intents participating in this round.
 	Intents []BoardingIntent
@@ -228,8 +229,8 @@ type NoncesAggregatedState struct {
 	// signing session for that VTXO.
 	Musig2Sessions map[SignerKey]*tree.SignerSession
 
-	// AggregatedNonces maps transaction IDs to aggregated MuSig2 nonces.
-	AggregatedNonces map[chainhash.Hash][]byte
+	// AggNonces maps transaction IDs to aggregated MuSig2 public nonces.
+	AggNonces map[tree.TxID]tree.Musig2PubNonce
 
 	// BoardingInputIndices maps each boarding intent's outpoint to its
 	// position in the commitment transaction inputs. Used for signing.
@@ -250,13 +251,13 @@ func (s *NoncesAggregatedState) clientStateSealed() {}
 // to the server and is waiting for the complete VTXT signatures.
 type PartialSigsSentState struct {
 	// RoundID is the unique identifier for this round.
-	RoundID string
+	RoundID RoundID
 
 	// CommitmentTx is the unsigned commitment transaction as a PSBT.
 	CommitmentTx *psbt.Packet
 
-	// VTXTTree is the virtual transaction tree for this round.
-	VTXTTree *tree.Tree
+	// VTXOTreePaths maps commitment tx output indices to VTXO tree paths.
+	VTXOTreePaths map[int]*tree.Tree
 
 	// Intents contains all boarding intents participating in this round.
 	Intents []BoardingIntent
@@ -288,13 +289,13 @@ func (s *PartialSigsSentState) clientStateSealed() {}
 // signature and is waiting for the commitment tx to be broadcast.
 type InputSigSentState struct {
 	// RoundID is the unique identifier for this round.
-	RoundID string
+	RoundID RoundID
 
 	// CommitmentTx is the unsigned commitment transaction as a PSBT.
 	CommitmentTx *psbt.Packet
 
-	// VTXTTree is the virtual transaction tree for this round.
-	VTXTTree *tree.Tree
+	// VTXOTreePaths maps commitment tx output indices to VTXO tree paths.
+	VTXOTreePaths map[int]*tree.Tree
 
 	// Intents contains all boarding intents participating in this round.
 	Intents []BoardingIntent
@@ -304,7 +305,7 @@ type InputSigSentState struct {
 	ClientTrees map[SignerKey]*tree.Tree
 
 	// InputSigs are the Schnorr signatures for the boarding inputs.
-	InputSigs [][]byte
+	InputSigs []*types.BoardingInputSignature
 }
 
 func (s *InputSigSentState) String() string {

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -1,15 +1,14 @@
 package round
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"maps"
 	"slices"
 
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
 	"github.com/btcsuite/btcd/btcutil"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/lib/scripts"
@@ -38,7 +37,7 @@ func buildBoardingRequest(intent BoardingIntent) types.BoardingRequest {
 // emits a RoundFailedNotification. This is the standard pattern for handling
 // internal errors without returning an error to the FSM (which would halt it).
 func failWithNotification(reason string, err error, recoverable bool,
-	roundID string) *ClientStateTransition {
+	roundID fn.Option[RoundID]) *ClientStateTransition {
 
 	return &ClientStateTransition{
 		NextState: &ClientFailedState{
@@ -99,7 +98,7 @@ func (s *Idle) ProcessEvent(_ context.Context, event ClientEvent,
 			return failWithNotification(
 				"confirmation event missing transaction",
 				fmt.Errorf("BoardingUTXOConfirmed.Tx is nil"),
-				true, "",
+				true, fn.None[RoundID](),
 			), nil
 		}
 
@@ -111,7 +110,7 @@ func (s *Idle) ProcessEvent(_ context.Context, event ClientEvent,
 					evt.Outpoint.Index, evt.Outpoint.Hash,
 				),
 				fmt.Errorf("outpoint index out of range"),
-				true, "",
+				true, fn.None[RoundID](),
 			), nil
 		}
 		confirmedOutput := evt.Tx.TxOut[evt.Outpoint.Index]
@@ -162,7 +161,7 @@ func (s *Idle) ProcessEvent(_ context.Context, event ClientEvent,
 			BoardingIntent:  walletIntent,
 			BoardingRequest: boardingRequest,
 			VtxoTemplate:    vtxoTemplate,
-			RoundID:         fn.None[string](),
+			RoundID:         fn.None[RoundID](),
 		}
 
 		intentMap := make(map[wire.OutPoint]BoardingIntent)
@@ -194,7 +193,7 @@ func (s *PendingRoundAssembly) ProcessEvent(
 			return failWithNotification(
 				"confirmation event missing transaction",
 				fmt.Errorf("BoardingUTXOConfirmed.Tx is nil"),
-				true, "",
+				true, fn.None[RoundID](),
 			), nil
 		}
 
@@ -206,7 +205,7 @@ func (s *PendingRoundAssembly) ProcessEvent(
 					evt.Outpoint.Index, evt.Outpoint.Hash,
 				),
 				fmt.Errorf("outpoint index out of range"),
-				true, "",
+				true, fn.None[RoundID](),
 			), nil
 		}
 		confirmedOutput := evt.Tx.TxOut[evt.Outpoint.Index]
@@ -256,7 +255,7 @@ func (s *PendingRoundAssembly) ProcessEvent(
 			BoardingIntent:  walletIntent,
 			BoardingRequest: boardingRequest,
 			VtxoTemplate:    vtxoTemplate,
-			RoundID:         fn.None[string](),
+			RoundID:         fn.None[RoundID](),
 		}
 
 		// Add the newly confirmed intent to our map.
@@ -282,7 +281,7 @@ func (s *PendingRoundAssembly) ProcessEvent(
 			return failWithNotification(
 				"no boarding requests to register",
 				fmt.Errorf("empty boarding requests"),
-				true, "",
+				true, fn.None[RoundID](),
 			), nil
 		}
 
@@ -299,12 +298,12 @@ func (s *PendingRoundAssembly) ProcessEvent(
 			return failWithNotification(
 				"no VTXO requests to register",
 				fmt.Errorf("empty VTXO requests"),
-				true, "",
+				true, fn.None[RoundID](),
 			), nil
 		}
 
-		// With all this extract, we'll now send the JoinRoundRequest
-		// to kick off the singing process.
+		// With all this extracted, we'll now send the JoinRoundRequest
+		// to kick off the signing process.
 		return &ClientStateTransition{
 			NextState: &RegistrationSentState{
 				Intents: intentSlice,
@@ -374,12 +373,12 @@ func (s *RoundJoinedState) ProcessEvent(
 	case *CommitmentTxBuilt:
 		return &ClientStateTransition{
 			NextState: &CommitmentTxReceivedState{
-				RoundID:      evt.RoundID,
-				CommitmentTx: evt.Tx,
-				TxID:         evt.Tx.UnsignedTx.TxHash(),
-				VTXTTree:     evt.VTXTTree,
-				Intents:      slices.Clone(s.Intents),
-				ClientTrees:  make(map[SignerKey]*tree.Tree),
+				RoundID:       evt.RoundID,
+				CommitmentTx:  evt.Tx,
+				TxID:          evt.Tx.UnsignedTx.TxHash(),
+				VTXOTreePaths: evt.VTXOTreePaths,
+				Intents:       slices.Clone(s.Intents),
+				ClientTrees:   make(map[SignerKey]*tree.Tree),
 			},
 			NewEvents: fn.Some(ClientEmittedEvent{
 				InternalEvent: []ClientEvent{evt},
@@ -459,7 +458,7 @@ func (s *CommitmentTxReceivedState) ProcessEvent(
 		clientTrees := make(map[SignerKey]*tree.Tree)
 
 		// Next, we'll make sure that each of the VTXO requests that we
-		// originally requested are actually present in the VTXT tree
+		// originally requested are actually present in the VTXT trees
 		// that the server sent us.
 		vtxoRequests := fn.Map(
 			s.Intents,
@@ -475,11 +474,21 @@ func (s *CommitmentTxReceivedState) ProcessEvent(
 				CoSignerKey: vtxoReq.SigningKey.PubKey,
 			}
 
-			clientTree, err := s.VTXTTree.ValidatePath(
-				vtxoReq.SigningKey.PubKey, expectedLeaf,
-				env.OperatorTerms.PubKey,
-			)
-			if err != nil {
+			// Search through all VTXO trees to find the one
+			// containing this VTXO request.
+			var clientTree *tree.Tree
+			var validateErr error
+			for _, vtxoTree := range s.VTXOTreePaths {
+				clientTree, validateErr = vtxoTree.ValidatePath(
+					vtxoReq.SigningKey.PubKey, expectedLeaf,
+					env.OperatorTerms.PubKey,
+				)
+				if validateErr == nil {
+					// Found the VTXO in this tree.
+					break
+				}
+			}
+			if validateErr != nil {
 				return &ClientStateTransition{
 					NextState: &ClientFailedState{
 						Reason: fmt.Sprintf(
@@ -487,7 +496,24 @@ func (s *CommitmentTxReceivedState) ProcessEvent(
 								"failed for VTXO "+
 								"request %d", i,
 						),
-						Error:       err,
+						Error:       validateErr,
+						Recoverable: false,
+					},
+				}, nil
+			}
+
+			// Ensure we actually found a client tree. This handles the
+			// edge case where VTXOTreePaths is empty.
+			if clientTree == nil {
+				return &ClientStateTransition{
+					NextState: &ClientFailedState{
+						Reason: fmt.Sprintf(
+							"no client tree found "+
+								"for VTXO request %d", i,
+						),
+						Error: fmt.Errorf(
+							"VTXO tree not found",
+						),
 						Recoverable: false,
 					},
 				}, nil
@@ -495,22 +521,27 @@ func (s *CommitmentTxReceivedState) ProcessEvent(
 
 			// Now that we know this VTXO request was properly
 			// included in the tree, we'll store the client-tree
-			// (travesal path from the root to this vtox leaf).
+			// (traversal path from the root to this vtxo leaf).
 			signerKey := NewSignerKey(vtxoReq.SigningKey.PubKey)
 			clientTrees[signerKey] = clientTree
 		}
 
-		// Make sure all anchor outputs are valid in the tree, if they
+		// Make sure all anchor outputs are valid in each tree. If they
 		// aren't we may not be able to go on chain.
-		if err := s.VTXTTree.ValidateAnchors(); err != nil {
-			return &ClientStateTransition{
-				NextState: &ClientFailedState{
-					Reason: "anchor output " +
-						"validation failed",
-					Error:       err,
-					Recoverable: false,
-				},
-			}, nil
+		for outputIdx, vtxoTree := range s.VTXOTreePaths {
+			if err := vtxoTree.ValidateAnchors(); err != nil {
+				return &ClientStateTransition{
+					NextState: &ClientFailedState{
+						Reason: fmt.Sprintf(
+							"anchor output validation "+
+								"failed for output %d",
+							outputIdx,
+						),
+						Error:       err,
+						Recoverable: false,
+					},
+				}, nil
+			}
 		}
 
 		// TODO(roasbeef): for refresh and off boarding, need extra
@@ -525,7 +556,7 @@ func (s *CommitmentTxReceivedState) ProcessEvent(
 			NextState: &CommitmentTxValidatedState{
 				RoundID:              s.RoundID,
 				CommitmentTx:         s.CommitmentTx,
-				VTXTTree:             s.VTXTTree,
+				VTXOTreePaths:        s.VTXOTreePaths,
 				Intents:              slices.Clone(s.Intents),
 				ClientTrees:          clientTrees,
 				BoardingInputIndices: boardingInputIndices,
@@ -557,21 +588,6 @@ func (s *CommitmentTxValidatedState) ProcessEvent(
 
 	switch event.(type) {
 	case *GenerateNonces:
-		// Get sweep tapscript root from the validated tree. This was
-		// set when the operator built the tree.
-		sweepTweak := s.VTXTTree.SweepTapscriptRoot
-
-		// Build the prev output fetcher for signing. The batch output
-		// is needed so the root transaction can look up the output it
-		// spends from the commitment transaction.
-		prevOutFetcher, err := s.VTXTTree.Root.PrevOutputFetcher(
-			s.VTXTTree.BatchOutput,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create prev output "+
-				"fetcher: %w", err)
-		}
-
 		// At this point, all the basic validation checks have passed.
 		// So now we'll generate a musig2 session to create nonces to
 		// sign the VTXO tree. Each VTXO that we created will
@@ -583,12 +599,35 @@ func (s *CommitmentTxValidatedState) ProcessEvent(
 					vtxoReq.SigningKey.PubKey,
 				)
 
+				// Get the client tree for this signer key.
+				// The sweep tweak and batch output are
+				// properties of the tree that were set when
+				// the operator built it.
+				clientTree := s.ClientTrees[signerKey]
+				if clientTree == nil {
+					return nil, fmt.Errorf(
+						"no client tree for signer "+
+							"key %x", signerKey[:],
+					)
+				}
+
+				sweepTweak := clientTree.SweepTapscriptRoot
+				prevOutFetcher, err := clientTree.Root.PrevOutputFetcher( //nolint:ll
+					clientTree.BatchOutput,
+				)
+				if err != nil {
+					return nil, fmt.Errorf("failed to "+
+						"create prev output fetcher "+
+						"for signer %x: %w",
+						signerKey[:], err)
+				}
+
 				// TODO(roasbeef): actually use the interface
 				// in front of this?
 				session, err := tree.NewSignerSession(
 					env.Wallet, &vtxoReq.SigningKey,
 					sweepTweak, prevOutFetcher,
-					s.VTXTTree.Root,
+					clientTree.Root,
 				)
 				if err != nil {
 					return nil, fmt.Errorf("failed to "+
@@ -602,22 +641,14 @@ func (s *CommitmentTxValidatedState) ProcessEvent(
 		}
 
 		// Now that we have all our sessions created, we'll have each
-		// of them generate nonces to use in tree signing. We collect
-		// all nonces into a nested map: txid -> signerKey -> nonce.
-		// Each signing key (VTXO) contributes its own nonce for each
-		// transaction in its path.
-		allNonces := make(map[chainhash.Hash]map[SignerKey][]byte)
+		// of them generate nonces to use in tree signing. The server
+		// expects nonces grouped by signer key first, then by txid.
+		allNonces := make(
+			map[SignerKey]map[tree.TxID]tree.Musig2PubNonce,
+		)
 		for signerKey, session := range musig2Sessions {
 			nonces := session.GetNonces()
-
-			for txid, nonce := range nonces {
-				if allNonces[txid] == nil {
-					allNonces[txid] = make(
-						map[SignerKey][]byte,
-					)
-				}
-				allNonces[txid][signerKey] = nonce[:]
-			}
+			allNonces[signerKey] = nonces
 		}
 
 		// MuSig2 nonces have been generated locally. Send them to the
@@ -631,7 +662,7 @@ func (s *CommitmentTxValidatedState) ProcessEvent(
 			NextState: &NoncesSentState{
 				RoundID:              s.RoundID,
 				CommitmentTx:         s.CommitmentTx,
-				VTXTTree:             s.VTXTTree,
+				VTXOTreePaths:        s.VTXOTreePaths,
 				Intents:              slices.Clone(s.Intents),
 				ClientTrees:          s.ClientTrees,
 				Musig2Sessions:       musig2Sessions,
@@ -664,13 +695,8 @@ func (s *NoncesSentState) ProcessEvent(
 		// The server has already aggregated all participants' nonces
 		// using MuSig2 nonce aggregation.
 		//
-		// Convert the raw bytes to Musig2PubNonce for registration.
-		aggNoncesMap := make(map[tree.TxID]tree.Musig2PubNonce)
-		for txid, nonceBytes := range evt.AggregatedNonces {
-			var nonce tree.Musig2PubNonce
-			copy(nonce[:], nonceBytes)
-			aggNoncesMap[txid] = nonce
-		}
+		// The event now contains properly typed nonces directly.
+		aggNoncesMap := evt.AggNonces
 
 		// With the nonces grouped, we need to register the nonces with
 		// each client session.
@@ -688,11 +714,11 @@ func (s *NoncesSentState) ProcessEvent(
 			NextState: &NoncesAggregatedState{
 				RoundID:              s.RoundID,
 				CommitmentTx:         s.CommitmentTx,
-				VTXTTree:             s.VTXTTree,
+				VTXOTreePaths:        s.VTXOTreePaths,
 				Intents:              slices.Clone(s.Intents),
 				ClientTrees:          s.ClientTrees,
 				Musig2Sessions:       s.Musig2Sessions,
-				AggregatedNonces:     evt.AggregatedNonces,
+				AggNonces:            evt.AggNonces,
 				BoardingInputIndices: s.BoardingInputIndices,
 			},
 			NewEvents: fn.Some(ClientEmittedEvent{
@@ -726,10 +752,13 @@ func (s *NoncesAggregatedState) ProcessEvent(
 	case *GeneratePartialSigs:
 		// At this stage, the nonces have been aggregated for each
 		// client, so now we'll generate and send our partial
-		// signatures.
-		var submitPartialSigs []ClientOutMsg
+		// signatures. The server expects signatures grouped by signer
+		// key first, then by transaction ID.
+		allSignatures := make(
+			map[SignerKey]map[tree.TxID]*musig2.PartialSignature,
+		)
 
-		for _, musig2Session := range s.Musig2Sessions {
+		for signerKey, musig2Session := range s.Musig2Sessions {
 			// Generate partial signatures for all transactions in
 			// our path. The map is keyed by transaction ID.
 			partialSigs, err := musig2Session.Signatures(true)
@@ -738,27 +767,14 @@ func (s *NoncesAggregatedState) ProcessEvent(
 					"partial signatures: %w", err)
 			}
 
-			// Encode each partial signature, preserving the txid
-			// association.
-			partialSigBytes := make(
-				map[chainhash.Hash][]byte, len(partialSigs),
-			)
-			for txid, sig := range partialSigs {
-				var buf bytes.Buffer
-				if err := sig.Encode(&buf); err != nil {
-					return nil, fmt.Errorf("failed to "+
-						"encode partial sig for "+
-						"tx %s: %w", txid, err)
-				}
-				partialSigBytes[txid] = buf.Bytes()
-			}
+			allSignatures[signerKey] = partialSigs
+		}
 
-			submitPartialSigs = append(
-				submitPartialSigs, &SubmitPartialSigRequest{
-					RoundID:     s.RoundID,
-					PartialSigs: partialSigBytes,
-				},
-			)
+		// Create a single message with all signatures grouped by signer
+		// key.
+		submitPartialSigsMsg := &SubmitPartialSigRequest{
+			RoundID:    s.RoundID,
+			Signatures: allSignatures,
 		}
 
 		// Partial MuSig2 signatures have been generated using the
@@ -768,15 +784,14 @@ func (s *NoncesAggregatedState) ProcessEvent(
 			NextState: &PartialSigsSentState{
 				RoundID:              s.RoundID,
 				CommitmentTx:         s.CommitmentTx,
-				VTXTTree:             s.VTXTTree,
+				VTXOTreePaths:        s.VTXOTreePaths,
 				Intents:              slices.Clone(s.Intents),
 				ClientTrees:          s.ClientTrees,
 				Musig2Sessions:       s.Musig2Sessions,
 				BoardingInputIndices: s.BoardingInputIndices,
 			},
-			// TODO(roasbeef): group into a single message?
 			NewEvents: fn.Some(ClientEmittedEvent{
-				Outbox: submitPartialSigs,
+				Outbox: []ClientOutMsg{submitPartialSigsMsg},
 			}),
 		}, nil
 
@@ -797,19 +812,31 @@ func (s *PartialSigsSentState) ProcessEvent(
 		// server after the operator aggregated all partial signatures.
 		//
 		// Now, we'll validate that the aggregated signatures are valid
-		// for the VTXT before proceeding. This prevents the operator
+		// for each VTXT before proceeding. This prevents the operator
 		// from providing invalid signatures that would make our VTXOs
 		// unspendable.
-		err := s.VTXTTree.ValidateAndSubmitSignatures(evt.Signatures)
-		if err != nil {
-			return &ClientStateTransition{
-				NextState: &ClientFailedState{
-					Reason: "VTXT signature " +
-						"validation failed",
-					Error:       err,
-					Recoverable: false,
-				},
-			}, nil
+		//
+		// Convert the typed signatures to raw bytes for validation.
+		sigBytes := make(map[tree.TxID][]byte, len(evt.AggSigs))
+		for txid, sig := range evt.AggSigs {
+			sigBytes[txid] = sig.Serialize()
+		}
+		for outputIdx, vtxoTree := range s.VTXOTreePaths {
+			err := vtxoTree.ValidateAndSubmitSignatures(sigBytes)
+			if err != nil {
+				return &ClientStateTransition{
+					NextState: &ClientFailedState{
+						Reason: fmt.Sprintf(
+							"VTXT signature "+
+								"validation "+
+								"failed: %d",
+							outputIdx,
+						),
+						Error:       err,
+						Recoverable: false,
+					},
+				}, nil
+			}
 		}
 
 		// Now that we know all the signatures are valid, we'll sign
@@ -830,7 +857,8 @@ func (s *PartialSigsSentState) ProcessEvent(
 		prevOutFetcher := txscript.NewMultiPrevOutFetcher(prevOuts)
 		sigHashes := txscript.NewTxSigHashes(tx, prevOutFetcher)
 
-		var boardingSigs []*schnorr.Signature
+		// Build structured boarding input signatures for each intent.
+		var boardingInputSigs []*types.BoardingInputSignature
 		for _, boardingIntent := range s.Intents {
 			outpoint := boardingIntent.BoardingRequest.Outpoint
 			inputIdx, found := s.BoardingInputIndices[*outpoint]
@@ -877,38 +905,41 @@ func (s *PartialSigsSentState) ProcessEvent(
 				return nil, fmt.Errorf("signature is not a " +
 					"schnorr signature")
 			}
-			boardingSigs = append(boardingSigs, schnorrSig)
+
+			// Build the structured boarding input signature.
+			inputSig := &types.BoardingInputSignature{
+				InputIndex:      inputIdx,
+				Outpoint:        *outpoint,
+				ClientSignature: schnorrSig,
+			}
+			boardingInputSigs = append(
+				boardingInputSigs, inputSig,
+			)
 		}
 
-		sigBytes := make([][]byte, len(boardingSigs))
-		for i, sig := range boardingSigs {
-			sigBytes[i] = sig.Serialize()
-		}
-		if len(sigBytes) != len(s.Intents) {
-			return nil, fmt.Errorf("signature count %d != intent "+
-				"count %d", len(sigBytes), len(s.Intents))
+		numSigs := len(boardingInputSigs)
+		if numSigs != len(s.Intents) {
+			return nil, fmt.Errorf("signature count %d != "+
+				"intent count %d", numSigs, len(s.Intents))
 		}
 
-		outboxMsgs := make([]ClientOutMsg, 0, len(sigBytes))
-		for i, intent := range s.Intents {
-			if intent.Address.Address == nil {
-				return nil, fmt.Errorf("intent %d missing "+
-					"boarding address", i)
-			}
-			forfeitSig := &SubmitForfeitSigRequest{
-				RoundID:     s.RoundID,
-				ForfeitSigs: [][]byte{sigBytes[i]},
-			}
-			outboxMsgs = append(outboxMsgs, forfeitSig)
+		// Create a single forfeit signature request with all
+		// signatures.
+		forfeitSigReq := &SubmitForfeitSigRequest{
+			RoundID:    s.RoundID,
+			Signatures: boardingInputSigs,
 		}
 
 		txid := tx.TxHash()
 		callerID := fmt.Sprintf("commitment-%s", txid.String())
-		outboxMsgs = append(outboxMsgs, &RegisterConfirmationRequest{
-			CallerID:    callerID,
-			Txid:        &txid,
-			TargetConfs: env.OperatorTerms.MinConfirmations,
-		})
+		outboxMsgs := []ClientOutMsg{
+			forfeitSigReq,
+			&RegisterConfirmationRequest{
+				CallerID:    callerID,
+				Txid:        &txid,
+				TargetConfs: env.OperatorTerms.MinConfirmations,
+			},
+		}
 
 		// Checkpoint the round state at the "point of no return".
 		// After sending boarding input signatures, the server may
@@ -926,7 +957,7 @@ func (s *PartialSigsSentState) ProcessEvent(
 		round := &Round{
 			RoundID:         s.RoundID,
 			CommitmentTx:    fn.Some(s.CommitmentTx),
-			VTXTTree:        fn.Some(s.VTXTTree),
+			VTXOTreePaths:   fn.Some(s.VTXOTreePaths),
 			BoardingIntents: adoptedIntents,
 		}
 
@@ -934,14 +965,14 @@ func (s *PartialSigsSentState) ProcessEvent(
 		// of no return". The next state is persisted so restart can
 		// recover to InputSigSentState.
 		nextState := &InputSigSentState{
-			RoundID:      s.RoundID,
-			CommitmentTx: s.CommitmentTx,
-			VTXTTree:     s.VTXTTree,
-			Intents:      slices.Clone(s.Intents),
-			ClientTrees:  s.ClientTrees,
-			InputSigs:    sigBytes,
+			RoundID:       s.RoundID,
+			CommitmentTx:  s.CommitmentTx,
+			VTXOTreePaths: s.VTXOTreePaths,
+			Intents:       slices.Clone(s.Intents),
+			ClientTrees:   s.ClientTrees,
+			InputSigs:     boardingInputSigs,
 		}
-		err = env.RoundStore.CommitState(ctx, round, nextState)
+		err := env.RoundStore.CommitState(ctx, round, nextState)
 		if err != nil {
 			return nil, fmt.Errorf("failed to commit round "+
 				"state: %w", err)
@@ -975,16 +1006,16 @@ func (s *PartialSigsSentState) ProcessEvent(
 
 // buildClientVTXOs constructs ClientVTXO instances from the boarding intents
 // and client trees.
-func buildClientVTXOs(intents []BoardingIntent,
-	trees map[SignerKey]*tree.Tree, roundID string) ([]*ClientVTXO, error) {
+func buildClientVTXOs(intents []BoardingIntent, trees map[SignerKey]*tree.Tree,
+	roundID RoundID) ([]*ClientVTXO, error) {
 
 	vtxos := make([]*ClientVTXO, 0)
 	for _, intent := range intents {
 		// Each intent has a VTXO template with one or more requests.
 		for _, req := range intent.VtxoTemplate {
 			signerKey := NewSignerKey(req.SigningKey.PubKey)
-			tree := trees[signerKey]
-			if tree == nil {
+			clientTree := trees[signerKey]
+			if clientTree == nil {
 				return nil, fmt.Errorf("missing client tree " +
 					"for signing key")
 			}
@@ -993,7 +1024,7 @@ func buildClientVTXOs(intents []BoardingIntent,
 			// address.
 			clientKeyDesc := intent.Address.KeyDesc
 
-			leaves := tree.Root.GetLeafNodes()
+			leaves := clientTree.Root.GetLeafNodes()
 
 			for _, leaf := range leaves {
 				outpoint, err := leaf.GetNonAnchorOutpoint()
@@ -1009,7 +1040,7 @@ func buildClientVTXOs(intents []BoardingIntent,
 					Expiry:      req.Expiry,
 					ClientKey:   clientKeyDesc,
 					OperatorKey: req.OperatorKey,
-					TreePath:    tree,
+					TreePath:    clientTree,
 					RoundID:     fn.Some(roundID),
 				})
 			}

--- a/round/transitions_test.go
+++ b/round/transitions_test.go
@@ -3,12 +3,22 @@ package round
 import (
 	"testing"
 
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/google/uuid"
 	"github.com/lightninglabs/darepo-client/lib/tree"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+// testRoundIDTr creates a deterministic RoundID from a string seed for tests.
+func testRoundIDTr(seed string) RoundID {
+	h := chainhash.HashH([]byte(seed))
+	id, _ := uuid.FromBytes(h[:16])
+
+	return RoundID(id)
+}
 
 // TestStateProperties verifies IsTerminal() and String() for all states.
 func TestStateProperties(t *testing.T) {
@@ -129,7 +139,7 @@ func TestUnexpectedEventSelfLoop(t *testing.T) {
 			setup: func(h *boardingTestHarness) ClientState {
 				return &Idle{}
 			},
-			event: &RoundJoined{RoundID: "test"},
+			event: &RoundJoined{RoundID: testRoundIDTr("test")},
 		},
 		{
 			name: "PendingAssembly_self_loops_on_RoundComplete",
@@ -160,83 +170,97 @@ func TestUnexpectedEventSelfLoop(t *testing.T) {
 			setup: func(h *boardingTestHarness) ClientState {
 				intent := h.newTestBoardingIntent()
 				return &RoundJoinedState{
-					RoundID: "round-1",
+					RoundID: testRoundIDTr("round-1"),
 					Intents: []BoardingIntent{intent},
 				}
 			},
-			event: &RoundJoined{RoundID: "another-round"},
+			event: &RoundJoined{RoundID: testRoundIDTr("other")},
 		},
 		{
 			name: "CommitmentTxReceived_self_loops_on_RoundJoined",
 			setup: func(h *boardingTestHarness) ClientState {
 				intent := h.newTestBoardingIntent()
+				roundID := testRoundIDTr("round-001")
 				return h.newCommitmentTxReceivedState(
-					"round-001", []BoardingIntent{intent},
+					roundID, []BoardingIntent{intent},
 				)
 			},
-			event: &RoundJoined{RoundID: "another-round"},
+			event: &RoundJoined{RoundID: testRoundIDTr("other")},
 		},
 		{
 			name: "CommitmentTxValidated_self_loops_on_RoundJoined",
 			setup: func(h *boardingTestHarness) ClientState {
 				intent := h.newTestBoardingIntent()
+				roundID := testRoundIDTr("round-001")
 				return h.newCommitmentTxValidatedState(
-					"round-001", []BoardingIntent{intent},
+					roundID, []BoardingIntent{intent},
 				)
 			},
-			event: &RoundJoined{RoundID: "another-round"},
+			event: &RoundJoined{RoundID: testRoundIDTr("other")},
 		},
 		{
 			name: "NoncesSent_self_loops_on_RoundJoined",
 			setup: func(h *boardingTestHarness) ClientState {
 				vtxtTree, _ := h.newTestVTXOTree(1)
 				intent := h.newTestBoardingIntent()
+				roundID := testRoundIDTr("round-001")
+				trees := map[int]*tree.Tree{0: vtxtTree}
+
 				return &NoncesSentState{
-					RoundID:  "round-001",
-					VTXTTree: vtxtTree,
-					Intents:  []BoardingIntent{intent},
+					RoundID:       roundID,
+					VTXOTreePaths: trees,
+					Intents:       []BoardingIntent{intent},
 				}
 			},
-			event: &RoundJoined{RoundID: "another-round"},
+			event: &RoundJoined{RoundID: testRoundIDTr("other")},
 		},
 		{
 			name: "NoncesAggregated_self_loops_on_RoundJoined",
 			setup: func(h *boardingTestHarness) ClientState {
 				vtxtTree, _ := h.newTestVTXOTree(1)
 				intent := h.newTestBoardingIntent()
+				roundID := testRoundIDTr("round-001")
+				trees := map[int]*tree.Tree{0: vtxtTree}
+
 				return &NoncesAggregatedState{
-					RoundID:  "round-001",
-					VTXTTree: vtxtTree,
-					Intents:  []BoardingIntent{intent},
+					RoundID:       roundID,
+					VTXOTreePaths: trees,
+					Intents:       []BoardingIntent{intent},
 				}
 			},
-			event: &RoundJoined{RoundID: "another-round"},
+			event: &RoundJoined{RoundID: testRoundIDTr("other")},
 		},
 		{
 			name: "PartialSigsSent_self_loops_on_RoundJoined",
 			setup: func(h *boardingTestHarness) ClientState {
 				vtxtTree, _ := h.newTestVTXOTree(1)
 				intent := h.newTestBoardingIntent()
+				roundID := testRoundIDTr("round-001")
+				trees := map[int]*tree.Tree{0: vtxtTree}
+
 				return &PartialSigsSentState{
-					RoundID:  "round-001",
-					VTXTTree: vtxtTree,
-					Intents:  []BoardingIntent{intent},
+					RoundID:       roundID,
+					VTXOTreePaths: trees,
+					Intents:       []BoardingIntent{intent},
 				}
 			},
-			event: &RoundJoined{RoundID: "another-round"},
+			event: &RoundJoined{RoundID: testRoundIDTr("other")},
 		},
 		{
 			name: "InputSigSent_self_loops_on_RoundJoined",
 			setup: func(h *boardingTestHarness) ClientState {
 				vtxtTree, _ := h.newTestVTXOTree(1)
 				intent := h.newTestBoardingIntent()
+				roundID := testRoundIDTr("round-001")
+				trees := map[int]*tree.Tree{0: vtxtTree}
+
 				return &InputSigSentState{
-					RoundID:  "round-001",
-					VTXTTree: vtxtTree,
-					Intents:  []BoardingIntent{intent},
+					RoundID:       roundID,
+					VTXOTreePaths: trees,
+					Intents:       []BoardingIntent{intent},
 				}
 			},
-			event: &RoundJoined{RoundID: "another-round"},
+			event: &RoundJoined{RoundID: testRoundIDTr("other")},
 		},
 		{
 			name: "ClientFailed_self_loops_on_unknown",
@@ -246,7 +270,7 @@ func TestUnexpectedEventSelfLoop(t *testing.T) {
 					Recoverable: true,
 				}
 			},
-			event: &RoundJoined{RoundID: "test"},
+			event: &RoundJoined{RoundID: testRoundIDTr("test")},
 		},
 	}
 
@@ -295,7 +319,7 @@ func TestBoardingFailedTransitions(t *testing.T) {
 			setup: func(h *boardingTestHarness) ClientState {
 				intent := h.newTestBoardingIntent()
 				return &RoundJoinedState{
-					RoundID: "round-001",
+					RoundID: testRoundIDTr("round-001"),
 					Intents: []BoardingIntent{intent},
 				}
 			},
@@ -305,7 +329,8 @@ func TestBoardingFailedTransitions(t *testing.T) {
 			setup: func(h *boardingTestHarness) ClientState {
 				intent := h.newTestBoardingIntent()
 				return h.newCommitmentTxReceivedState(
-					"round-001", []BoardingIntent{intent},
+					testRoundIDTr("round-001"),
+					[]BoardingIntent{intent},
 				)
 			},
 		},
@@ -314,10 +339,13 @@ func TestBoardingFailedTransitions(t *testing.T) {
 			setup: func(h *boardingTestHarness) ClientState {
 				vtxtTree, _ := h.newTestVTXOTree(1)
 				intent := h.newTestBoardingIntent()
+				roundID := testRoundIDTr("round-001")
+				trees := map[int]*tree.Tree{0: vtxtTree}
+
 				return &NoncesSentState{
-					RoundID:  "round-001",
-					VTXTTree: vtxtTree,
-					Intents:  []BoardingIntent{intent},
+					RoundID:       roundID,
+					VTXOTreePaths: trees,
+					Intents:       []BoardingIntent{intent},
 				}
 			},
 		},
@@ -326,10 +354,13 @@ func TestBoardingFailedTransitions(t *testing.T) {
 			setup: func(h *boardingTestHarness) ClientState {
 				vtxtTree, _ := h.newTestVTXOTree(1)
 				intent := h.newTestBoardingIntent()
+				roundID := testRoundIDTr("round-001")
+				trees := map[int]*tree.Tree{0: vtxtTree}
+
 				return &PartialSigsSentState{
-					RoundID:  "round-001",
-					VTXTTree: vtxtTree,
-					Intents:  []BoardingIntent{intent},
+					RoundID:       roundID,
+					VTXOTreePaths: trees,
+					Intents:       []BoardingIntent{intent},
 				}
 			},
 		},
@@ -338,10 +369,13 @@ func TestBoardingFailedTransitions(t *testing.T) {
 			setup: func(h *boardingTestHarness) ClientState {
 				vtxtTree, _ := h.newTestVTXOTree(1)
 				intent := h.newTestBoardingIntent()
+				roundID := testRoundIDTr("round-001")
+				trees := map[int]*tree.Tree{0: vtxtTree}
+
 				return &InputSigSentState{
-					RoundID:  "round-001",
-					VTXTTree: vtxtTree,
-					Intents:  []BoardingIntent{intent},
+					RoundID:       roundID,
+					VTXOTreePaths: trees,
+					Intents:       []BoardingIntent{intent},
 				}
 			},
 		},
@@ -401,7 +435,7 @@ func TestTerminalStateSelfLoop(t *testing.T) {
 			// Terminal states ignore all events and remain in their
 			// current state, preventing further transitions once
 			// boarding reaches a final outcome.
-			event := &RoundJoined{RoundID: "test"}
+			event := &RoundJoined{RoundID: testRoundIDTr("test")}
 			transition, err := h.sendEvent(event)
 			require.NoError(t, err)
 			require.NotNil(t, transition)
@@ -590,14 +624,15 @@ func TestRegistrationSentState(t *testing.T) {
 			Intents: []BoardingIntent{intent},
 		})
 
-		event := &RoundJoined{RoundID: "test-round-123"}
+		event := &RoundJoined{RoundID: testRoundIDTr("test-round-123")}
 
 		transition, err := h.sendEvent(event)
 		require.NoError(t, err)
 		require.NotNil(t, transition)
 
 		nextState := assertStateType[*RoundJoinedState](h)
-		require.Equal(t, "test-round-123", nextState.RoundID)
+		expectedRoundID := testRoundIDTr("test-round-123")
+		require.Equal(t, expectedRoundID, nextState.RoundID)
 		require.Len(t, nextState.Intents, 1)
 	})
 }
@@ -612,13 +647,15 @@ func TestRoundJoinedState(t *testing.T) {
 
 		intent := h.newTestBoardingIntent()
 		h.withState(&RoundJoinedState{
-			RoundID: "round-001",
+			RoundID: testRoundIDTr("round-001"),
 			Intents: []BoardingIntent{intent},
 		})
 
 		vtxtTree, _ := h.newTestVTXOTree(1)
 		commitEvent := h.newCommitmentTxBuiltEvent(
-			"round-001", []BoardingIntent{intent}, vtxtTree,
+			testRoundIDTr("round-001"),
+			[]BoardingIntent{intent},
+			vtxtTree,
 		)
 
 		transition, err := h.sendEvent(commitEvent)
@@ -626,7 +663,7 @@ func TestRoundJoinedState(t *testing.T) {
 		require.NotNil(t, transition)
 
 		nextState := assertStateType[*CommitmentTxReceivedState](h)
-		require.Equal(t, "round-001", nextState.RoundID)
+		require.Equal(t, testRoundIDTr("round-001"), nextState.RoundID)
 		require.NotNil(t, nextState.CommitmentTx)
 		require.True(t, transition.NewEvents.IsSome())
 	})
@@ -646,19 +683,19 @@ func TestCommitmentTxReceivedState(t *testing.T) {
 		commitmentTx := h.newTestCommitmentTx(intents)
 
 		state := &CommitmentTxReceivedState{
-			RoundID:      "round-001",
-			CommitmentTx: commitmentTx,
-			TxID:         commitmentTx.UnsignedTx.TxHash(),
-			VTXTTree:     vtxtTree,
-			Intents:      intents,
-			ClientTrees:  make(map[SignerKey]*tree.Tree),
+			RoundID:       testRoundIDTr("round-001"),
+			CommitmentTx:  commitmentTx,
+			TxID:          commitmentTx.UnsignedTx.TxHash(),
+			VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
+			Intents:       intents,
+			ClientTrees:   make(map[SignerKey]*tree.Tree),
 		}
 		h.withState(state)
 
 		event := &CommitmentTxBuilt{
-			RoundID:  "round-001",
-			Tx:       commitmentTx,
-			VTXTTree: vtxtTree,
+			RoundID:       testRoundIDTr("round-001"),
+			Tx:            commitmentTx,
+			VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
 		}
 
 		transition, err := h.sendEvent(event)
@@ -668,7 +705,8 @@ func TestCommitmentTxReceivedState(t *testing.T) {
 		validatedState := assertStateType[*CommitmentTxValidatedState](
 			h,
 		)
-		require.Equal(t, "round-001", validatedState.RoundID)
+		expectedID := testRoundIDTr("round-001")
+		require.Equal(t, expectedID, validatedState.RoundID)
 		require.NotEmpty(t, validatedState.BoardingInputIndices)
 		assertTransitionEmitsInternalEvent[*GenerateNonces](
 			h, transition,
@@ -690,19 +728,19 @@ func TestCommitmentTxReceivedState(t *testing.T) {
 		commitmentTx := h.newTestCommitmentTx(differentIntents)
 
 		state := &CommitmentTxReceivedState{
-			RoundID:      "round-001",
-			CommitmentTx: commitmentTx,
-			TxID:         commitmentTx.UnsignedTx.TxHash(),
-			VTXTTree:     vtxtTree,
-			Intents:      []BoardingIntent{intent},
-			ClientTrees:  make(map[SignerKey]*tree.Tree),
+			RoundID:       testRoundIDTr("round-001"),
+			CommitmentTx:  commitmentTx,
+			TxID:          commitmentTx.UnsignedTx.TxHash(),
+			VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
+			Intents:       []BoardingIntent{intent},
+			ClientTrees:   make(map[SignerKey]*tree.Tree),
 		}
 		h.withState(state)
 
 		event := &CommitmentTxBuilt{
-			RoundID:  "round-001",
-			Tx:       commitmentTx,
-			VTXTTree: vtxtTree,
+			RoundID:       testRoundIDTr("round-001"),
+			Tx:            commitmentTx,
+			VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
 		}
 
 		transition, err := h.sendEvent(event)
@@ -725,7 +763,8 @@ func TestCommitmentTxValidatedState(t *testing.T) {
 
 		intent := h.newTestBoardingIntent()
 		state := h.newCommitmentTxValidatedState(
-			"round-001", []BoardingIntent{intent},
+			testRoundIDTr("round-001"),
+			[]BoardingIntent{intent},
 		)
 		h.withState(state)
 
@@ -734,7 +773,8 @@ func TestCommitmentTxValidatedState(t *testing.T) {
 		require.NotNil(t, transition)
 
 		noncesSentState := assertStateType[*NoncesSentState](h)
-		require.Equal(t, "round-001", noncesSentState.RoundID)
+		expectedID := testRoundIDTr("round-001")
+		require.Equal(t, expectedID, noncesSentState.RoundID)
 		require.NotNil(t, noncesSentState.Musig2Sessions)
 
 		h.assertOutboxLen(1)
@@ -755,7 +795,8 @@ func TestNoncesSentState(t *testing.T) {
 
 		// Build up through actual flow to get real sessions.
 		validatedState := h.newCommitmentTxValidatedState(
-			"round-001", []BoardingIntent{intent},
+			testRoundIDTr("round-001"),
+			[]BoardingIntent{intent},
 		)
 		h.withState(validatedState)
 
@@ -766,7 +807,8 @@ func TestNoncesSentState(t *testing.T) {
 		noncesSentState := assertStateType[*NoncesSentState](h)
 
 		event := h.newNoncesAggregatedEvent(
-			"round-001", noncesSentState.VTXTTree,
+			testRoundIDTr("round-001"),
+			noncesSentState.VTXOTreePaths[0],
 		)
 
 		transition, err := h.sendEvent(event)
@@ -774,7 +816,8 @@ func TestNoncesSentState(t *testing.T) {
 		require.NotNil(t, transition)
 
 		noncesAggState := assertStateType[*NoncesAggregatedState](h)
-		require.Equal(t, "round-001", noncesAggState.RoundID)
+		expectedID := testRoundIDTr("round-001")
+		require.Equal(t, expectedID, noncesAggState.RoundID)
 		assertTransitionEmitsInternalEvent[*GeneratePartialSigs](
 			h, transition,
 		)
@@ -795,7 +838,8 @@ func TestNoncesAggregatedState(t *testing.T) {
 		// We build through the full state machine flow to ensure MuSig2
 		// sessions are properly initialized with real nonce state.
 		validatedState := h.newCommitmentTxValidatedState(
-			"round-001", []BoardingIntent{intent},
+			testRoundIDTr("round-001"),
+			[]BoardingIntent{intent},
 		)
 		h.withState(validatedState)
 
@@ -806,7 +850,8 @@ func TestNoncesAggregatedState(t *testing.T) {
 		noncesSentState := assertStateType[*NoncesSentState](h)
 
 		aggEvent := h.newNoncesAggregatedEvent(
-			"round-001", noncesSentState.VTXTTree,
+			testRoundIDTr("round-001"),
+			noncesSentState.VTXOTreePaths[0],
 		)
 		_, err = h.sendEvent(aggEvent)
 		require.NoError(t, err)
@@ -819,7 +864,8 @@ func TestNoncesAggregatedState(t *testing.T) {
 		require.NotNil(t, transition)
 
 		partialSigsState := assertStateType[*PartialSigsSentState](h)
-		require.Equal(t, "round-001", partialSigsState.RoundID)
+		expectedID := testRoundIDTr("round-001")
+		require.Equal(t, expectedID, partialSigsState.RoundID)
 		h.assertOutboxContainsType("*round.SubmitPartialSigRequest")
 	})
 }
@@ -850,11 +896,11 @@ func TestPartialSigsSentState(t *testing.T) {
 		}
 
 		state := &PartialSigsSentState{
-			RoundID:      "round-real-sig-001",
-			CommitmentTx: commitmentTx,
-			VTXTTree:     vtxtTree,
-			Intents:      []BoardingIntent{intent},
-			ClientTrees:  clientTrees,
+			RoundID:       testRoundIDTr("round-real-sig-001"),
+			CommitmentTx:  commitmentTx,
+			VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
+			Intents:       []BoardingIntent{intent},
+			ClientTrees:   clientTrees,
 			BoardingInputIndices: map[wire.OutPoint]int{
 				intent.Outpoint: 0,
 			},
@@ -866,8 +912,8 @@ func TestPartialSigsSentState(t *testing.T) {
 		h.withState(state)
 
 		event := &OperatorSigned{
-			RoundID:    "round-real-sig-001",
-			Signatures: validSigs,
+			RoundID: testRoundIDTr("round-real-sig-001"),
+			AggSigs: validSigs,
 		}
 
 		transition, err := h.sendEvent(event)
@@ -877,7 +923,8 @@ func TestPartialSigsSentState(t *testing.T) {
 		inputSigState := assertStateType[*InputSigSentState](
 			h.boardingTestHarness,
 		)
-		require.Equal(t, "round-real-sig-001", inputSigState.RoundID)
+		expectedRoundID := testRoundIDTr("round-real-sig-001")
+		require.Equal(t, expectedRoundID, inputSigState.RoundID)
 		require.NotEmpty(t, inputSigState.InputSigs)
 
 		h.assertOutboxContainsType("*round.SubmitForfeitSigRequest")
@@ -895,11 +942,11 @@ func TestPartialSigsSentState(t *testing.T) {
 		commitmentTx := h.newTestCommitmentTx(intents)
 
 		state := &PartialSigsSentState{
-			RoundID:      "round-001",
-			CommitmentTx: commitmentTx,
-			VTXTTree:     vtxtTree,
-			Intents:      []BoardingIntent{intent},
-			ClientTrees:  make(map[SignerKey]*tree.Tree),
+			RoundID:       testRoundIDTr("round-001"),
+			CommitmentTx:  commitmentTx,
+			VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
+			Intents:       []BoardingIntent{intent},
+			ClientTrees:   make(map[SignerKey]*tree.Tree),
 			BoardingInputIndices: map[wire.OutPoint]int{
 				intent.Outpoint: 0,
 			},
@@ -907,8 +954,8 @@ func TestPartialSigsSentState(t *testing.T) {
 		h.withState(state)
 
 		event := &OperatorSigned{
-			RoundID:    "round-001",
-			Signatures: map[chainhash.Hash][]byte{},
+			RoundID: testRoundIDTr("round-001"),
+			AggSigs: map[tree.TxID]*schnorr.Signature{},
 		}
 
 		transition, err := h.sendEvent(event)
@@ -930,23 +977,23 @@ func TestPartialSigsSentState(t *testing.T) {
 		commitmentTx := h.newTestCommitmentTx(intents)
 
 		state := &PartialSigsSentState{
-			RoundID:      "round-001",
-			CommitmentTx: commitmentTx,
-			VTXTTree:     vtxtTree,
-			Intents:      []BoardingIntent{intent},
-			ClientTrees:  make(map[SignerKey]*tree.Tree),
+			RoundID:       testRoundIDTr("round-001"),
+			CommitmentTx:  commitmentTx,
+			VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
+			Intents:       []BoardingIntent{intent},
+			ClientTrees:   make(map[SignerKey]*tree.Tree),
 			BoardingInputIndices: map[wire.OutPoint]int{
 				intent.Outpoint: 0,
 			},
 		}
 		h.withState(state)
 
-		// Use a fake txid with an invalid signature (too short).
+		// Use a fake txid with a dummy signature.
 		fakeTxid := chainhash.HashH([]byte("fake-tx"))
 		event := &OperatorSigned{
-			RoundID: "round-001",
-			Signatures: map[chainhash.Hash][]byte{
-				fakeTxid: make([]byte, 10),
+			RoundID: testRoundIDTr("round-001"),
+			AggSigs: map[tree.TxID]*schnorr.Signature{
+				fakeTxid: {},
 			},
 		}
 
@@ -969,9 +1016,9 @@ func TestPartialSigsSentState(t *testing.T) {
 		commitmentTx := h.newTestCommitmentTx(intents)
 
 		state := &PartialSigsSentState{
-			RoundID:              "round-001",
+			RoundID:              testRoundIDTr("round-001"),
 			CommitmentTx:         commitmentTx,
-			VTXTTree:             vtxtTree,
+			VTXOTreePaths:        map[int]*tree.Tree{0: vtxtTree},
 			Intents:              []BoardingIntent{intent},
 			ClientTrees:          make(map[SignerKey]*tree.Tree),
 			BoardingInputIndices: make(map[wire.OutPoint]int),
@@ -981,17 +1028,13 @@ func TestPartialSigsSentState(t *testing.T) {
 		}
 		h.withState(state)
 
-		// Create a valid 64-byte signature with a fake txid.
-		validSig := make([]byte, 64)
-		for i := range validSig {
-			validSig[i] = byte(i + 1)
-		}
+		// Create a test signature with a fake txid.
 		fakeTxid := chainhash.HashH([]byte("fake-tx"))
 
 		event := &OperatorSigned{
-			RoundID: "round-001",
-			Signatures: map[chainhash.Hash][]byte{
-				fakeTxid: validSig,
+			RoundID: testRoundIDTr("round-001"),
+			AggSigs: map[tree.TxID]*schnorr.Signature{
+				fakeTxid: {},
 			},
 		}
 
@@ -1014,11 +1057,11 @@ func TestPartialSigsSentState(t *testing.T) {
 		commitmentTx := h.newTestCommitmentTx(intents)
 
 		state := &PartialSigsSentState{
-			RoundID:      "round-001",
-			CommitmentTx: commitmentTx,
-			VTXTTree:     vtxtTree,
-			Intents:      []BoardingIntent{intent},
-			ClientTrees:  make(map[SignerKey]*tree.Tree),
+			RoundID:       testRoundIDTr("round-001"),
+			CommitmentTx:  commitmentTx,
+			VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
+			Intents:       []BoardingIntent{intent},
+			ClientTrees:   make(map[SignerKey]*tree.Tree),
 			BoardingInputIndices: map[wire.OutPoint]int{
 				intent.Outpoint: 0,
 			},
@@ -1035,9 +1078,9 @@ func TestPartialSigsSentState(t *testing.T) {
 			// Only provide one signature when more are needed.
 			fakeTxid := chainhash.HashH([]byte("fake-tx"))
 			event := &OperatorSigned{
-				RoundID: "round-001",
-				Signatures: map[chainhash.Hash][]byte{
-					fakeTxid: make([]byte, 64),
+				RoundID: testRoundIDTr("round-001"),
+				AggSigs: map[tree.TxID]*schnorr.Signature{
+					fakeTxid: {},
 				},
 			}
 
@@ -1062,7 +1105,8 @@ func TestInputSigSentState(t *testing.T) {
 
 		intent := h.newTestBoardingIntent()
 		state := h.newInputSigSentState(
-			"round-001", []BoardingIntent{intent},
+			testRoundIDTr("round-001"),
+			[]BoardingIntent{intent},
 		)
 		h.withState(state)
 
@@ -1099,10 +1143,10 @@ func TestInputSigSentState(t *testing.T) {
 
 		// Empty ClientTrees will cause buildClientVTXOs to fail.
 		state := &InputSigSentState{
-			RoundID:     "round-001",
-			VTXTTree:    vtxtTree,
-			Intents:     []BoardingIntent{intent},
-			ClientTrees: make(map[SignerKey]*tree.Tree),
+			RoundID:       testRoundIDTr("round-001"),
+			VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
+			Intents:       []BoardingIntent{intent},
+			ClientTrees:   make(map[SignerKey]*tree.Tree),
 		}
 		h.withState(state)
 
@@ -1312,12 +1356,12 @@ func TestBoardingFlowIdleToPendingToRegistrationSent(t *testing.T) {
 	require.Len(t, regState.Intents, 1)
 
 	// Step 2: Server accepts.
-	joinEvent := &RoundJoined{RoundID: "round-001"}
+	joinEvent := &RoundJoined{RoundID: testRoundIDTr("round-001")}
 	_, err = h.sendEvent(joinEvent)
 	require.NoError(t, err)
 
 	joinedState := assertStateType[*RoundJoinedState](h)
-	require.Equal(t, "round-001", joinedState.RoundID)
+	require.Equal(t, testRoundIDTr("round-001"), joinedState.RoundID)
 }
 
 func TestBoardingFlowMultipleIntentsAccumulation(t *testing.T) {
@@ -1359,12 +1403,13 @@ func TestBoardingFlowPendingToRoundJoined(t *testing.T) {
 	require.Len(t, regSentState.Intents, 1)
 
 	// Step 2: RegistrationSentState → RoundJoinedState.
-	joinEvent := &RoundJoined{RoundID: "round-integration-001"}
+	integrationRoundID := testRoundIDTr("round-integration-001")
+	joinEvent := &RoundJoined{RoundID: integrationRoundID}
 	_, err = h.sendEvent(joinEvent)
 	require.NoError(t, err)
 
 	joinedState := assertStateType[*RoundJoinedState](h)
-	require.Equal(t, "round-integration-001", joinedState.RoundID)
+	require.Equal(t, integrationRoundID, joinedState.RoundID)
 }
 
 func TestBoardingFlowRoundJoinedToPartialSigsSent(t *testing.T) {
@@ -1376,14 +1421,16 @@ func TestBoardingFlowRoundJoinedToPartialSigsSent(t *testing.T) {
 	intent := h.newTestBoardingIntent()
 
 	h.withState(&RoundJoinedState{
-		RoundID: "round-integration-002",
+		RoundID: testRoundIDTr("round-integration-002"),
 		Intents: []BoardingIntent{intent},
 	})
 
 	// Step 1: RoundJoined → CommitmentTxReceived.
 	vtxtTree := h.newTestVTXOTreeForIntent(intent)
 	commitEvent := h.newCommitmentTxBuiltEvent(
-		"round-integration-002", []BoardingIntent{intent}, vtxtTree,
+		testRoundIDTr("round-integration-002"),
+		[]BoardingIntent{intent},
+		vtxtTree,
 	)
 	_, err := h.sendEvent(commitEvent)
 	require.NoError(t, err)
@@ -1393,9 +1440,9 @@ func TestBoardingFlowRoundJoinedToPartialSigsSent(t *testing.T) {
 
 	// Step 2: CommitmentTxReceived → CommitmentTxValidated.
 	_, err = h.sendEvent(&CommitmentTxBuilt{
-		RoundID:  "round-integration-002",
-		Tx:       ctxReceivedState.CommitmentTx,
-		VTXTTree: ctxReceivedState.VTXTTree,
+		RoundID:       testRoundIDTr("round-integration-002"),
+		Tx:            ctxReceivedState.CommitmentTx,
+		VTXOTreePaths: ctxReceivedState.VTXOTreePaths,
 	})
 	require.NoError(t, err)
 
@@ -1413,13 +1460,14 @@ func TestBoardingFlowRoundJoinedToPartialSigsSent(t *testing.T) {
 
 	// Step 4: NoncesSent → NoncesAggregated.
 	aggNoncesEvent := h.newNoncesAggregatedEvent(
-		"round-integration-002", noncesSentState.VTXTTree,
+		testRoundIDTr("round-integration-002"),
+		noncesSentState.VTXOTreePaths[0],
 	)
 	_, err = h.sendEvent(aggNoncesEvent)
 	require.NoError(t, err)
 
 	noncesAggState := assertStateType[*NoncesAggregatedState](h)
-	require.NotEmpty(t, noncesAggState.AggregatedNonces)
+	require.NotEmpty(t, noncesAggState.AggNonces)
 	h.clearOutbox()
 
 	// Step 5: NoncesAggregated → PartialSigsSent.
@@ -1427,7 +1475,8 @@ func TestBoardingFlowRoundJoinedToPartialSigsSent(t *testing.T) {
 	require.NoError(t, err)
 
 	partialSigsState := assertStateType[*PartialSigsSentState](h)
-	require.Equal(t, "round-integration-002", partialSigsState.RoundID)
+	expectedID := testRoundIDTr("round-integration-002")
+	require.Equal(t, expectedID, partialSigsState.RoundID)
 }
 
 func TestBoardingFlowFailureAndRecovery(t *testing.T) {
@@ -1437,7 +1486,7 @@ func TestBoardingFlowFailureAndRecovery(t *testing.T) {
 
 	intent := h.newTestBoardingIntent()
 	h.withState(&RoundJoinedState{
-		RoundID: "round-fail-001",
+		RoundID: testRoundIDTr("round-fail-001"),
 		Intents: []BoardingIntent{intent},
 	})
 


### PR DESCRIPTION
## Summary

This PR synchronizes the client's protocol types with the server (darepo) to ensure compatibility. The server is the source of truth, and several type mismatches had developed that would prevent successful round participation.

## Protocol Divergence Analysis

The following table summarizes the incompatibilities that existed before this PR:

| Component | Client (Before) | Server (Expected) | Impact |
|-----------|-----------------|-------------------|--------|
| **RoundID** | `type RoundID = string` | `type RoundID uuid.UUID` | Type mismatch at protocol boundary |
| **Nonces map** | `map[TxID]map[SignerKey][]byte` | `map[SignerKey]map[TxID]Musig2PubNonce` | Keys inverted + wrong value type |
| **Partial sigs** | `map[TxID][]byte` | `map[SignerKey]map[TxID]*PartialSignature` | Missing signing key dimension |
| **Boarding sigs** | `[][]byte` | `[]*BoardingInputSignature` | Raw bytes vs structured type |
| **VTXO trees** | `VTXTTree *tree.Tree` | `VTXOTreePaths map[int]*tree.Tree` | Single tree vs map of trees |
| **Agg nonces** | `AggregatedNonces map[Hash][]byte` | `AggNonces map[TxID]Musig2PubNonce` | Field name + typed value |
| **Agg sigs** | `Signatures map[Hash][]byte` | `AggSigs map[TxID]*schnorr.Signature` | Field name + typed value |

## Architecture Changes

### RoundID Type Change

```mermaid
graph LR
    subgraph Before
        A1[RoundID = string] --> B1["''empty string''"]
    end
    subgraph After
        A2[RoundID uuid.UUID] --> B2["uuid.NewV7()"]
        A2 --> C2["id.String()"]
        A2 --> D2["id.LogPrefix()"]
        A2 --> E2["ParseRoundID(s)"]
    end
```

The new RoundID type uses UUIDv7 for time-ordering and provides helper methods for string conversion and logging.

### Nonces Map Structure Inversion

The server expects nonces grouped by cosigner first, then by transaction:

```mermaid
graph TD
    subgraph "Client Before"
        T1[TxID] --> S1[SignerKey]
        S1 --> N1["[]byte nonce"]
    end
    subgraph "Client After (matches Server)"
        S2[SignerKey] --> T2[TxID]
        T2 --> N2[Musig2PubNonce]
    end
```

### Partial Signatures Nesting

Added the missing signing key dimension:

```mermaid
graph TD
    subgraph "Client Before (flat)"
        T1[TxID] --> P1["[]byte sig"]
    end
    subgraph "Client After (nested)"
        S2[SignerKey] --> T2[TxID]
        T2 --> P2["*musig2.PartialSignature"]
    end
```

### Boarding Input Signatures

Changed from raw bytes to structured type with metadata:

```mermaid
graph LR
    subgraph Before
        B1["[][]byte"]
    end
    subgraph After
        B2["[]*BoardingInputSignature"]
        B2 --> I2[InputIndex int]
        B2 --> O2[Outpoint wire.OutPoint]
        B2 --> S2["ClientSignature *schnorr.Signature"]
    end
```

### VTXO Tree Paths

Changed from single tree to map supporting multiple batch outputs:

```mermaid
graph TD
    subgraph Before
        V1["VTXTTree *tree.Tree"]
    end
    subgraph After
        V2["VTXOTreePaths map[int]*tree.Tree"]
        V2 --> |"output 0"| T0["*tree.Tree"]
        V2 --> |"output 1"| T1["*tree.Tree"]
        V2 --> |"output N"| TN["*tree.Tree"]
    end
```

## MuSig2 Signing Flow After Changes

```mermaid
sequenceDiagram
    participant C as Client
    participant S as Server
    
    Note over C,S: Round Registration
    C->>S: JoinRoundRequest
    S->>C: RoundJoined{RoundID: uuid.UUID}
    
    Note over C,S: Commitment Tx Phase
    S->>C: CommitmentTxBuilt{VTXOTreePaths: map[int]*tree.Tree}
    C->>C: Validate paths, populate ClientTrees
    
    Note over C,S: Nonce Exchange
    C->>C: GenerateNonces (per SignerKey)
    C->>S: SubmitNoncesRequest{Nonces: map[SignerKey]map[TxID]Musig2PubNonce}
    S->>C: NoncesAggregated{AggNonces: map[TxID]Musig2PubNonce}
    
    Note over C,S: Partial Signature Exchange
    C->>C: GeneratePartialSigs
    C->>S: SubmitPartialSigRequest{Signatures: map[SignerKey]map[TxID]*PartialSig}
    S->>C: OperatorSigned{AggSigs: map[TxID]*schnorr.Signature}
    
    Note over C,S: Boarding Signature
    S->>C: AwaitingBoardingSigs
    C->>S: SubmitForfeitSigRequest{Signatures: []*BoardingInputSignature}
    S->>C: BoardingConfirmed
```

## Files Changed

**Core types:**
- `round/interfaces.go` - RoundID type, SigningKeyHex alias, Round struct

**Messages:**
- `round/outbox_messages.go` - Client→Server message structs
- `round/events.go` - Server→Client event structs

**FSM:**
- `round/states.go` - State struct definitions
- `round/transitions.go` - ProcessEvent methods

**Actor:**
- `round/actor.go` - Round tracking
- `round/actor_messages.go` - Message handling

**Persistence:**
- `db/round_store.go` - RoundID string conversion at DB boundary

**Tests:**
- `round/*_test.go` - Updated for new types
- `db/round_store_test.go` - Updated for new types

## Test Plan

- [x] All existing unit tests pass (`go test ./...`)
- [x] Build succeeds (`go build ./...`)
- [ ] Integration test with server (requires server-side testing)