### PR TITLE
OOR client 4/4: retry-backoff, outbox error handling, crash-resume tests

### DIFF
--- a/oor/actor.go
+++ b/oor/actor.go
@@ -581,7 +581,9 @@ func (b *oorDurableBehavior) driveOutbox(ctx context.Context,
 		// Outbox handler is the I/O boundary.
 		followUps, err := handler.Handle(ctx, sessionID, msg)
 		if err != nil {
-			return err
+			followUps = []Event{
+				NewOutboxErrorEvent(msg, err),
+			}
 		}
 
 		for _, followUp := range followUps {

--- a/oor/actor_drive_event_integration_test.go
+++ b/oor/actor_drive_event_integration_test.go
@@ -1,0 +1,175 @@
+package oor
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/wire"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	retryDueTestRetryAfter        = 2 * time.Second
+	retryDueTestEventuallyTimeout = 2 * time.Second
+	retryDueTestEventuallyPoll    = 20 * time.Millisecond
+)
+
+type retryDueIntegrationHandler struct {
+	sawFinalize atomic.Bool
+}
+
+func (h *retryDueIntegrationHandler) Handle(_ context.Context,
+	_ SessionID, outbox OutboxEvent) ([]Event, error) {
+
+	switch outbox.(type) {
+	case *SendFinalizePackageRequest:
+		h.sawFinalize.Store(true)
+		return nil, nil
+
+	default:
+		return nil, fmt.Errorf("unexpected outbox event: %T", outbox)
+	}
+}
+
+var _ OutboxHandler = (*retryDueIntegrationHandler)(nil)
+
+// TestOORClientActorDriveRetryDueEventDurablePath verifies the retry-due signal
+// can cross the durable actor boundary and re-drive the resumed outbox work.
+func TestOORClientActorDriveRetryDueEventDurablePath(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	ark, checkpoints := testOutboxPSBTPair(t)
+	sessionID, err := sessionIDFromArk(ark)
+	require.NoError(t, err)
+
+	resumeSnapshot, err := NewOutgoingSnapshot(
+		sessionID,
+		&AwaitingFinalizeAccepted{
+			SessionID:            sessionID,
+			InputOutpoints:       []wire.OutPoint{{}},
+			ArkPSBT:              ark,
+			FinalCheckpointPSBTs: checkpoints,
+		},
+	)
+	require.NoError(t, err)
+
+	retrySnapshot := &OutgoingSnapshot{
+		Version:        2,
+		SessionID:      sessionID,
+		Phase:          OutgoingPhaseRetryBackoff,
+		RetryAfter:     retryDueTestRetryAfter,
+		ResumeSnapshot: resumeSnapshot,
+		FailReason:     "retry later",
+	}
+
+	handler := &retryDueIntegrationHandler{}
+	actor := NewOORClientActor(ClientActorCfg{
+		OutboxHandler: handler,
+		DeliveryStore: newTestDeliveryStore(t),
+		ActorID:       "oor-drive-retry-due-durable-path",
+	})
+	defer actor.Stop()
+
+	restoreResp := actor.Receive(ctx, &RestoreSessionRequest{
+		Snapshot: retrySnapshot,
+	})
+	require.True(t, restoreResp.IsOk())
+
+	driveResp := actor.Receive(ctx, &DriveEventRequest{
+		SessionID: sessionID,
+		Event:     &RetryDueEvent{},
+	})
+	require.True(t, driveResp.IsOk())
+
+	require.Eventually(
+		t, func() bool {
+			return handler.sawFinalize.Load()
+		}, retryDueTestEventuallyTimeout, retryDueTestEventuallyPoll,
+	)
+
+	stateResp := actor.Receive(ctx, &GetStateRequest{
+		SessionID: sessionID,
+	})
+	require.True(t, stateResp.IsOk())
+
+	stateMsg, ok := stateResp.UnwrapOr(nil).(*GetStateResponse)
+	require.True(t, ok)
+	require.IsType(t, &AwaitingFinalizeAccepted{}, stateMsg.State)
+}
+
+// TestOutboxForStateRetryBackoff asserts retry-backoff state emits a
+// schedule-retry request with the expected delay and reason.
+func TestOutboxForStateRetryBackoff(t *testing.T) {
+	t.Parallel()
+
+	outbox, err := OutboxForState(&RetryBackoff{
+		RetryAfter: 3 * time.Second,
+		Reason:     "transport timeout",
+	})
+	require.NoError(t, err)
+	require.Len(t, outbox, 1)
+
+	scheduleMsg, ok := outbox[0].(*ScheduleRetryRequest)
+	require.True(t, ok)
+	require.Equal(t, 3*time.Second, scheduleMsg.After)
+	require.Equal(t, "transport timeout", scheduleMsg.Reason)
+}
+
+// TestRetryBackoffProcessEventRetryDue asserts RetryDueEvent resumes from the
+// stored snapshot and emits finalize outbox work.
+func TestRetryBackoffProcessEventRetryDue(t *testing.T) {
+	t.Parallel()
+
+	ark, checkpoints := testOutboxPSBTPair(t)
+	sessionID, err := sessionIDFromArk(ark)
+	require.NoError(t, err)
+
+	resumeSnapshot, err := NewOutgoingSnapshot(
+		sessionID,
+		&AwaitingFinalizeAccepted{
+			SessionID:            sessionID,
+			InputOutpoints:       []wire.OutPoint{{}},
+			ArkPSBT:              ark,
+			FinalCheckpointPSBTs: checkpoints,
+		},
+	)
+	require.NoError(t, err)
+
+	retryState := &RetryBackoff{
+		ResumeSnapshot: resumeSnapshot,
+		RetryAfter:     2 * time.Second,
+		Reason:         "rpc timeout",
+	}
+
+	transition, err := retryState.ProcessEvent(
+		t.Context(), &RetryDueEvent{}, nil,
+	)
+	require.NoError(t, err)
+	require.IsType(t, &AwaitingFinalizeAccepted{}, transition.NextState)
+	require.True(t, transition.NewEvents.IsSome())
+
+	emitted := transition.NewEvents.UnsafeFromSome()
+	require.Len(t, emitted.Outbox, 1)
+	require.IsType(t, &SendFinalizePackageRequest{}, emitted.Outbox[0])
+}
+
+// TestRetryBackoffProcessEventRetryDueRequiresSnapshot asserts retry-due
+// processing fails when no resume snapshot is present.
+func TestRetryBackoffProcessEventRetryDueRequiresSnapshot(t *testing.T) {
+	t.Parallel()
+
+	retryState := &RetryBackoff{
+		RetryAfter: 1 * time.Second,
+	}
+
+	transition, err := retryState.ProcessEvent(
+		t.Context(), &RetryDueEvent{}, nil,
+	)
+	require.Nil(t, transition)
+	require.ErrorContains(t, err, "resume snapshot must be provided")
+}

--- a/oor/actor_drive_event_integration_test.go
+++ b/oor/actor_drive_event_integration_test.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	retryDueTestRetryAfter        = 2 * time.Second
-	retryDueTestEventuallyTimeout = 2 * time.Second
+	retryDueTestEventuallyTimeout = retryDueTestRetryAfter + 2*time.Second
 	retryDueTestEventuallyPoll    = 20 * time.Millisecond
 )
 

--- a/oor/actor_drive_event_test.go
+++ b/oor/actor_drive_event_test.go
@@ -1,0 +1,129 @@
+package oor
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/scripts"
+	oortx "github.com/lightninglabs/darepo-client/lib/tx/oor"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOORClientActorDriveEventErrors asserts the DriveEventRequest handler
+// rejects malformed inputs.
+func TestOORClientActorDriveEventErrors(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	actor := NewOORClientActor(ClientActorCfg{
+		DeliveryStore: newTestDeliveryStore(t),
+		ActorID:       "oor-drive-event-errors",
+	})
+	defer actor.Stop()
+
+	// DriveEventRequest is an escape hatch for delivering out-of-band
+	// events into a running session.
+	//
+	// These error cases should be rejected early so higher layers don't
+	// accidentally create sessions or mutate state.
+
+	// Nil request is rejected.
+	resp := actor.Receive(ctx, (*DriveEventRequest)(nil))
+	require.True(t, resp.IsErr())
+
+	// Missing event is rejected.
+	resp = actor.Receive(ctx, &DriveEventRequest{
+		SessionID: SessionID{},
+		Event:     nil,
+	})
+	require.True(t, resp.IsErr())
+
+	// Unknown session id is rejected.
+	resp = actor.Receive(ctx, &DriveEventRequest{
+		SessionID: SessionID{1},
+		Event:     &FailEvent{Reason: "boom"},
+	})
+	require.True(t, resp.IsErr())
+}
+
+// TestOORClientActorDriveEventAppliesEvent asserts DriveEventRequest is
+// accepted and routed into the running session FSM.
+func TestOORClientActorDriveEventAppliesEvent(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	// Use a minimal v0 transfer to create a real session, then inject an
+	// event as if it came from an outbox boundary.
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	policy := scripts.CheckpointPolicy{
+		OperatorKey: operatorKey.PubKey(),
+		CSVDelay:    10,
+	}
+
+	inputValue := btcutil.Amount(10_000)
+
+	clientKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	inputs := []TransferInput{
+		newTestTransferInput(
+			t,
+			clientKey,
+			policy.OperatorKey,
+			wire.OutPoint{
+				Hash:  [32]byte{0x01},
+				Index: 0,
+			},
+			inputValue,
+		),
+	}
+
+	recipients := []oortx.RecipientOutput{{
+		PkScript: newTestTaprootPkScript(t, clientKey.PubKey()),
+		Value:    inputValue,
+	}}
+
+	actor := NewOORClientActor(ClientActorCfg{
+		DeliveryStore: newTestDeliveryStore(t),
+		ActorID:       "oor-drive-event-happy",
+	})
+	defer actor.Stop()
+
+	// Start a session; this binds the session id to the Ark txid.
+	startResp := actor.Receive(ctx, &StartTransferRequest{
+		Policy:     policy,
+		Inputs:     inputs,
+		Recipients: recipients,
+	})
+	require.True(t, startResp.IsOk())
+
+	startMsg, ok := startResp.UnwrapOr(nil).(*StartTransferResponse)
+	require.True(t, ok)
+	require.NotEqual(t, SessionID{}, startMsg.SessionID)
+
+	// Drive a terminal event into the session and verify the FSM
+	// transitions.
+	driveResp := actor.Receive(ctx, &DriveEventRequest{
+		SessionID: startMsg.SessionID,
+		Event:     &FailEvent{Reason: "boom"},
+	})
+	require.True(t, driveResp.IsOk())
+
+	// Verify the session moved into terminal failed state.
+	stateResp := actor.Receive(ctx, &GetStateRequest{
+		SessionID: startMsg.SessionID,
+	})
+	require.True(t, stateResp.IsOk())
+
+	stateMsg, ok := stateResp.UnwrapOr(nil).(*GetStateResponse)
+	require.True(t, ok)
+	failedState, ok := stateMsg.State.(*Failed)
+	require.True(t, ok)
+	require.Equal(t, "boom", failedState.Reason)
+}

--- a/oor/actor_durable_message.go
+++ b/oor/actor_durable_message.go
@@ -72,6 +72,7 @@ const (
 	eventKindFinalizeAccepted  uint64 = 3
 	eventKindInputsMarkedSpent uint64 = 4
 	eventKindFail              uint64 = 5
+	eventKindRetryDue          uint64 = 6
 )
 
 const (
@@ -964,6 +965,9 @@ func encodeEventPayload(event Event) ([]byte, error) {
 		eventKind = eventKindFail
 		reason = []byte(evt.Reason)
 
+	case *RetryDueEvent:
+		eventKind = eventKindRetryDue
+
 	default:
 		return nil, fmt.Errorf("unsupported event type: %T", event)
 	}
@@ -1083,6 +1087,9 @@ func decodeEventPayload(raw []byte) (Event, error) {
 
 	case eventKindFail:
 		return &FailEvent{Reason: string(reason)}, nil
+
+	case eventKindRetryDue:
+		return &RetryDueEvent{}, nil
 
 	default:
 		return nil, fmt.Errorf("unknown event kind: %d", eventKind)

--- a/oor/actor_durable_message.go
+++ b/oor/actor_durable_message.go
@@ -263,6 +263,12 @@ func durableCommandFromActorMsg(msg ActorMsg) (*durableActorCommandMessage,
 		}, nil
 
 	case *DriveEventRequest:
+		if req == nil {
+			return nil, fmt.Errorf(
+				"drive event request must be provided",
+			)
+		}
+
 		raw, err := encodeDriveEventRequestPayload(
 			req.SessionID, req.Event,
 		)

--- a/oor/actor_durable_message_test.go
+++ b/oor/actor_durable_message_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestStartTransferPayloadTLVRoundTrip asserts start-transfer payload TLV
+// encoding/decoding preserves all fields.
 func TestStartTransferPayloadTLVRoundTrip(t *testing.T) {
 	t.Parallel()
 
@@ -50,6 +52,8 @@ func TestStartTransferPayloadTLVRoundTrip(t *testing.T) {
 	require.Equal(t, payload.Inputs[0], decoded.Inputs[0])
 }
 
+// TestSessionPayloadTLVRoundTrip asserts session payload TLV encoding/decoding
+// preserves the session identifier.
 func TestSessionPayloadTLVRoundTrip(t *testing.T) {
 	t.Parallel()
 
@@ -62,6 +66,8 @@ func TestSessionPayloadTLVRoundTrip(t *testing.T) {
 	require.Equal(t, id, decoded)
 }
 
+// TestDecodeLengthPrefixedBlobListRejectsTrailingBytes asserts decode rejects
+// payloads with trailing bytes.
 func TestDecodeLengthPrefixedBlobListRejectsTrailingBytes(t *testing.T) {
 	t.Parallel()
 
@@ -75,6 +81,8 @@ func TestDecodeLengthPrefixedBlobListRejectsTrailingBytes(t *testing.T) {
 	require.ErrorContains(t, err, "trailing payload bytes")
 }
 
+// TestDriveEventCommandRoundTripFailEvent asserts durable encoding/decoding
+// round-trips FailEvent drive-event commands.
 func TestDriveEventCommandRoundTripFailEvent(t *testing.T) {
 	t.Parallel()
 
@@ -102,6 +110,8 @@ func TestDriveEventCommandRoundTripFailEvent(t *testing.T) {
 	require.Equal(t, "transport timeout", failEvt.Reason)
 }
 
+// TestDriveEventCommandRoundTripSubmitAcceptedEvent asserts durable
+// encoding/decoding round-trips SubmitAcceptedEvent drive-event commands.
 func TestDriveEventCommandRoundTripSubmitAcceptedEvent(t *testing.T) {
 	t.Parallel()
 
@@ -137,4 +147,39 @@ func TestDriveEventCommandRoundTripSubmitAcceptedEvent(t *testing.T) {
 
 	decodedTxID := submitEvt.ArkPSBT.UnsignedTx.TxHash()
 	require.Equal(t, chainhash.Hash(sessionID), decodedTxID)
+}
+
+// TestDriveEventCommandRoundTripRetryDueEvent asserts durable
+// encoding/decoding round-trips RetryDueEvent drive-event commands.
+func TestDriveEventCommandRoundTripRetryDueEvent(t *testing.T) {
+	t.Parallel()
+
+	sessionID := SessionID(chainhash.Hash{3, 3, 3})
+	msg := &DriveEventRequest{
+		SessionID: sessionID,
+		Event:     &RetryDueEvent{},
+	}
+
+	cmd, err := durableCommandFromActorMsg(msg)
+	require.NoError(t, err)
+	require.Equal(t, oorCommandDriveEvent, cmd.Command)
+
+	decoded, err := actorMsgFromDurableCommand(cmd)
+	require.NoError(t, err)
+
+	decodedReq, ok := decoded.(*DriveEventRequest)
+	require.True(t, ok)
+	require.Equal(t, sessionID, decodedReq.SessionID)
+	require.IsType(t, &RetryDueEvent{}, decodedReq.Event)
+}
+
+// TestDriveEventPayloadRequiresEvent asserts drive-event payload encoding
+// rejects nil events.
+func TestDriveEventPayloadRequiresEvent(t *testing.T) {
+	t.Parallel()
+
+	_, err := encodeDriveEventRequestPayload(
+		SessionID(chainhash.Hash{1, 2, 3}), nil,
+	)
+	require.ErrorContains(t, err, "event must be provided")
 }

--- a/oor/actor_resume_test.go
+++ b/oor/actor_resume_test.go
@@ -77,6 +77,10 @@ func (h *pausedFinalizeHandler) Handle(_ context.Context, sessionID SessionID,
 			&FinalizeAcceptedEvent{},
 		}, nil
 
+	case *MarkInputsSpentRequest:
+		_ = msg
+		return []Event{&InputsMarkedSpentEvent{}}, nil
+
 	default:
 		return nil, nil
 	}
@@ -146,6 +150,10 @@ func (h *pausedSubmitHandler) Handle(_ context.Context, sessionID SessionID,
 		return []Event{
 			&FinalizeAcceptedEvent{},
 		}, nil
+
+	case *MarkInputsSpentRequest:
+		_ = msg
+		return []Event{&InputsMarkedSpentEvent{}}, nil
 
 	default:
 		return nil, nil
@@ -217,6 +225,10 @@ func (h *pausedCoSignedHandler) Handle(_ context.Context, sessionID SessionID,
 		return []Event{
 			&FinalizeAcceptedEvent{},
 		}, nil
+
+	case *MarkInputsSpentRequest:
+		_ = msg
+		return []Event{&InputsMarkedSpentEvent{}}, nil
 
 	default:
 		return nil, nil
@@ -324,6 +336,10 @@ func (h *cosignedButDroppedHandler) Handle(_ context.Context,
 			&FinalizeAcceptedEvent{},
 		}, nil
 
+	case *MarkInputsSpentRequest:
+		_ = msg
+		return []Event{&InputsMarkedSpentEvent{}}, nil
+
 	default:
 		return nil, nil
 	}
@@ -338,6 +354,9 @@ func TestOORClientActorResumeFromSnapshot(t *testing.T) {
 
 	ctx := t.Context()
 
+	// Build a deterministic transfer with a mocked client signer. The
+	// outbox handler will pause on finalize to simulate a transport/UI
+	// interruption that requires an explicit resume.
 	operatorKey, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
 
@@ -382,6 +401,8 @@ func TestOORClientActorResumeFromSnapshot(t *testing.T) {
 		operatorSigner: operatorSigner,
 	}
 
+	// Start a session and drive it until finalize is sent (but "dropped"
+	// by the outbox handler).
 	actor1 := NewOORClientActor(ClientActorCfg{
 		OutboxHandler: handler,
 		DeliveryStore: deliveryStore,
@@ -409,6 +430,11 @@ func TestOORClientActorResumeFromSnapshot(t *testing.T) {
 
 	require.IsType(t, &AwaitingFinalizeAccepted{}, stateMsg.State)
 
+	// Export a portable snapshot, then create a new actor and restore from
+	// it to simulate an app restart.
+	//
+	// The key property is that the snapshot contains enough information to
+	// re-emit the outbox work implied by the state (idempotently).
 	exportResp := actor1.Receive(ctx, &ExportSnapshotRequest{
 		SessionID: startMsg.SessionID,
 	})
@@ -459,6 +485,13 @@ func TestOORClientActorResumeAfterServerCoSigned(t *testing.T) {
 
 	ctx := t.Context()
 
+	// This test covers the "point of no return" edge:
+	//
+	// - The server has accepted the submit package and co-signed it.
+	// - The client did not receive SubmitAcceptedEvent.
+	//
+	// On resume, the client must send the exact same submit bytes and the
+	// server must return the same co-signed artifacts.
 	operatorKey, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
 
@@ -557,6 +590,104 @@ func TestOORClientActorResumeAfterServerCoSigned(t *testing.T) {
 
 	restoreMsg, ok := restoreResp.UnwrapOr(nil).(*RestoreSessionResponse)
 	require.True(t, ok)
+
+	resumeResp := actor2.Receive(ctx, &ResumeSessionRequest{
+		SessionID: restoreMsg.SessionID,
+	})
+	require.True(t, resumeResp.IsOk())
+
+	finalStateResp := actor2.Receive(ctx, &GetStateRequest{
+		SessionID: restoreMsg.SessionID,
+	})
+	require.True(t, finalStateResp.IsOk())
+
+	finalStateMsg, ok := finalStateResp.UnwrapOr(nil).(*GetStateResponse)
+	require.True(t, ok)
+	require.IsType(t, &Completed{}, finalStateMsg.State)
+}
+
+// TestOORClientActorResumeAfterServerCoSignedFromStore verifies the client can
+// resume after a crash using only the persisted snapshot (no explicit export)
+// even if the server already co-signed but the submit response was dropped.
+func TestOORClientActorResumeAfterServerCoSignedFromStore(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	policy := scripts.CheckpointPolicy{
+		OperatorKey: operatorKey.PubKey(),
+		CSVDelay:    10,
+	}
+
+	inputValue := btcutil.Amount(10000)
+
+	clientKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	clientSigner := input.NewMockSigner([]*btcec.PrivateKey{clientKey}, nil)
+
+	inputs := []TransferInput{
+		newTestTransferInput(
+			t, clientKey, policy.OperatorKey,
+			wire.OutPoint{
+				Hash:  [32]byte{0x01},
+				Index: 0,
+			},
+			inputValue,
+		),
+	}
+
+	recipients := []oortx.RecipientOutput{
+		{
+			PkScript: newTestTaprootPkScript(t, clientKey.PubKey()),
+			Value:    inputValue,
+		},
+	}
+
+	store := NewInMemoryOutgoingSessionStore()
+	handler := &cosignedButDroppedHandler{
+		t:            t,
+		clientSigner: clientSigner,
+	}
+
+	actor1 := NewOORClientActor(ClientActorCfg{
+		OutboxHandler: handler,
+		SessionStore:  store,
+	})
+
+	startResp := actor1.Receive(ctx, &StartTransferRequest{
+		Policy:     policy,
+		Inputs:     inputs,
+		Recipients: recipients,
+	})
+	require.True(t, startResp.IsOk())
+
+	startMsg, ok := startResp.UnwrapOr(nil).(*StartTransferResponse)
+	require.True(t, ok)
+
+	// Simulate a crash by constructing a new actor and restoring from the
+	// persisted snapshot.
+	persistedSnap, err := store.GetOutgoing(ctx, startMsg.SessionID)
+	require.NoError(t, err)
+	require.NotNil(t, persistedSnap)
+	require.Equal(t, OutgoingPhaseSubmitSent, persistedSnap.Phase)
+
+	actor2 := NewOORClientActor(ClientActorCfg{
+		OutboxHandler: handler,
+		SessionStore:  store,
+	})
+
+	restoreResp := actor2.Receive(ctx, &RestoreSessionRequest{
+		Snapshot: persistedSnap,
+	})
+	require.True(t, restoreResp.IsOk())
+
+	restoreMsg, ok := restoreResp.UnwrapOr(nil).(*RestoreSessionResponse)
+	require.True(t, ok)
+	require.Equal(t, startMsg.SessionID, restoreMsg.SessionID)
 
 	resumeResp := actor2.Receive(ctx, &ResumeSessionRequest{
 		SessionID: restoreMsg.SessionID,

--- a/oor/actor_resume_test.go
+++ b/oor/actor_resume_test.go
@@ -34,6 +34,13 @@ func (h *pausedFinalizeHandler) Handle(_ context.Context, sessionID SessionID,
 	h.t.Helper()
 
 	switch msg := outbox.(type) {
+	case *RequestArkSignatures:
+		return []Event{
+			&ArkSignedEvent{
+				ArkPSBT: msg.ArkPSBT,
+			},
+		}, nil
+
 	case *SendSubmitPackageRequest:
 		txid := msg.ArkPSBT.UnsignedTx.TxHash()
 		require.Equal(h.t, SessionID(txid), sessionID)
@@ -106,6 +113,13 @@ func (h *pausedSubmitHandler) Handle(_ context.Context, sessionID SessionID,
 	h.t.Helper()
 
 	switch msg := outbox.(type) {
+	case *RequestArkSignatures:
+		return []Event{
+			&ArkSignedEvent{
+				ArkPSBT: msg.ArkPSBT,
+			},
+		}, nil
+
 	case *SendSubmitPackageRequest:
 		txid := msg.ArkPSBT.UnsignedTx.TxHash()
 		require.Equal(h.t, SessionID(txid), sessionID)
@@ -181,6 +195,13 @@ func (h *pausedCoSignedHandler) Handle(_ context.Context, sessionID SessionID,
 	h.t.Helper()
 
 	switch msg := outbox.(type) {
+	case *RequestArkSignatures:
+		return []Event{
+			&ArkSignedEvent{
+				ArkPSBT: msg.ArkPSBT,
+			},
+		}, nil
+
 	case *SendSubmitPackageRequest:
 		txid := msg.ArkPSBT.UnsignedTx.TxHash()
 		require.Equal(h.t, SessionID(txid), sessionID)
@@ -264,6 +285,13 @@ func (h *cosignedButDroppedHandler) Handle(_ context.Context,
 	h.t.Helper()
 
 	switch msg := outbox.(type) {
+	case *RequestArkSignatures:
+		return []Event{
+			&ArkSignedEvent{
+				ArkPSBT: msg.ArkPSBT,
+			},
+		}, nil
+
 	case *SendSubmitPackageRequest:
 		txid := msg.ArkPSBT.UnsignedTx.TxHash()
 		require.Equal(h.t, SessionID(txid), sessionID)
@@ -647,16 +675,20 @@ func TestOORClientActorResumeAfterServerCoSignedFromStore(t *testing.T) {
 		},
 	}
 
-	store := NewInMemoryOutgoingSessionStore()
+	deliveryStore := newTestDeliveryStore(t)
 	handler := &cosignedButDroppedHandler{
 		t:            t,
 		clientSigner: clientSigner,
 	}
 
+	const actorID = "oor-resume-cosigned-from-store-actor"
+
 	actor1 := NewOORClientActor(ClientActorCfg{
 		OutboxHandler: handler,
-		SessionStore:  store,
+		DeliveryStore: deliveryStore,
+		ActorID:       actorID,
 	})
+	defer actor1.Stop()
 
 	startResp := actor1.Receive(ctx, &StartTransferRequest{
 		Policy:     policy,
@@ -668,40 +700,44 @@ func TestOORClientActorResumeAfterServerCoSignedFromStore(t *testing.T) {
 	startMsg, ok := startResp.UnwrapOr(nil).(*StartTransferResponse)
 	require.True(t, ok)
 
-	// Simulate a crash by constructing a new actor and restoring from the
-	// persisted snapshot.
-	persistedSnap, err := store.GetOutgoing(ctx, startMsg.SessionID)
-	require.NoError(t, err)
-	require.NotNil(t, persistedSnap)
-	require.Equal(t, OutgoingPhaseSubmitSent, persistedSnap.Phase)
+	// At this point the server has co-signed but the response was dropped,
+	// so the client should still be waiting for submit acceptance.
+	stateResp := actor1.Receive(ctx, &GetStateRequest{
+		SessionID: startMsg.SessionID,
+	})
+	require.True(t, stateResp.IsOk())
+
+	stateMsg, ok := stateResp.UnwrapOr(nil).(*GetStateResponse)
+	require.True(t, ok)
+	require.IsType(t, &AwaitingSubmitAccepted{}, stateMsg.State)
+
+	actor1.Stop()
 
 	actor2 := NewOORClientActor(ClientActorCfg{
 		OutboxHandler: handler,
-		SessionStore:  store,
+		DeliveryStore: deliveryStore,
+		ActorID:       actorID,
 	})
+	defer actor2.Stop()
 
-	restoreResp := actor2.Receive(ctx, &RestoreSessionRequest{
-		Snapshot: persistedSnap,
-	})
-	require.True(t, restoreResp.IsOk())
+	require.Eventually(t, func() bool {
+		finalStateResp := actor2.Receive(ctx, &GetStateRequest{
+			SessionID: startMsg.SessionID,
+		})
+		if finalStateResp.IsErr() {
+			return false
+		}
 
-	restoreMsg, ok := restoreResp.UnwrapOr(nil).(*RestoreSessionResponse)
-	require.True(t, ok)
-	require.Equal(t, startMsg.SessionID, restoreMsg.SessionID)
+		respMsg := finalStateResp.UnwrapOr(nil)
+		finalStateMsg, ok := respMsg.(*GetStateResponse)
+		if !ok {
+			return false
+		}
 
-	resumeResp := actor2.Receive(ctx, &ResumeSessionRequest{
-		SessionID: restoreMsg.SessionID,
-	})
-	require.True(t, resumeResp.IsOk())
+		_, ok = finalStateMsg.State.(*Completed)
 
-	finalStateResp := actor2.Receive(ctx, &GetStateRequest{
-		SessionID: restoreMsg.SessionID,
-	})
-	require.True(t, finalStateResp.IsOk())
-
-	finalStateMsg, ok := finalStateResp.UnwrapOr(nil).(*GetStateResponse)
-	require.True(t, ok)
-	require.IsType(t, &Completed{}, finalStateMsg.State)
+		return ok
+	}, 5*time.Second, 50*time.Millisecond)
 }
 
 // TestOORClientActorResumeFromSnapshotSubmitSent verifies the client can resume
@@ -1037,8 +1073,11 @@ func TestOORClientActorDurableRestartAutoResume(t *testing.T) {
 			return false
 		}
 
-		_, ok = got.State.(*AwaitingLocalVTXOUpdate)
-
-		return ok
+		switch got.State.(type) {
+		case *AwaitingLocalVTXOUpdate, *Completed:
+			return true
+		default:
+			return false
+		}
 	}, 5*time.Second, 50*time.Millisecond)
 }

--- a/oor/actor_resume_test.go
+++ b/oor/actor_resume_test.go
@@ -448,7 +448,7 @@ func TestOORClientActorResumeFromSnapshot(t *testing.T) {
 
 	finalStateMsg, ok := finalStateResp.UnwrapOr(nil).(*GetStateResponse)
 	require.True(t, ok)
-	require.IsType(t, &AwaitingLocalVTXOUpdate{}, finalStateMsg.State)
+	require.IsType(t, &Completed{}, finalStateMsg.State)
 }
 
 // TestOORClientActorResumeAfterServerCoSigned verifies the client can resume
@@ -570,7 +570,7 @@ func TestOORClientActorResumeAfterServerCoSigned(t *testing.T) {
 
 	finalStateMsg, ok := finalStateResp.UnwrapOr(nil).(*GetStateResponse)
 	require.True(t, ok)
-	require.IsType(t, &AwaitingLocalVTXOUpdate{}, finalStateMsg.State)
+	require.IsType(t, &Completed{}, finalStateMsg.State)
 }
 
 // TestOORClientActorResumeFromSnapshotSubmitSent verifies the client can resume
@@ -686,7 +686,7 @@ func TestOORClientActorResumeFromSnapshotSubmitSent(t *testing.T) {
 
 	finalStateMsg, ok := finalStateResp.UnwrapOr(nil).(*GetStateResponse)
 	require.True(t, ok)
-	require.IsType(t, &AwaitingLocalVTXOUpdate{}, finalStateMsg.State)
+	require.IsType(t, &Completed{}, finalStateMsg.State)
 }
 
 // TestOORClientActorResumeFromSnapshotCoSigned verifies the client can resume
@@ -803,7 +803,7 @@ func TestOORClientActorResumeFromSnapshotCoSigned(t *testing.T) {
 
 	finalStateMsg, ok := finalStateResp.UnwrapOr(nil).(*GetStateResponse)
 	require.True(t, ok)
-	require.IsType(t, &AwaitingLocalVTXOUpdate{}, finalStateMsg.State)
+	require.IsType(t, &Completed{}, finalStateMsg.State)
 }
 
 // TestOORClientActorDurableRestartAutoResume verifies the durable actor can

--- a/oor/actor_resume_test.go
+++ b/oor/actor_resume_test.go
@@ -656,6 +656,9 @@ func TestOORClientActorResumeAfterServerCoSignedFromStore(t *testing.T) {
 	require.NoError(t, err)
 
 	clientSigner := input.NewMockSigner([]*btcec.PrivateKey{clientKey}, nil)
+	operatorSigner := input.NewMockSigner(
+		[]*btcec.PrivateKey{operatorKey}, nil,
+	)
 
 	inputs := []TransferInput{
 		newTestTransferInput(
@@ -677,8 +680,9 @@ func TestOORClientActorResumeAfterServerCoSignedFromStore(t *testing.T) {
 
 	deliveryStore := newTestDeliveryStore(t)
 	handler := &cosignedButDroppedHandler{
-		t:            t,
-		clientSigner: clientSigner,
+		t:              t,
+		clientSigner:   clientSigner,
+		operatorSigner: operatorSigner,
 	}
 
 	const actorID = "oor-resume-cosigned-from-store-actor"

--- a/oor/actor_test.go
+++ b/oor/actor_test.go
@@ -52,6 +52,7 @@ func (h *testOutboxHandler) Handle(_ context.Context, sessionID SessionID,
 			msg.CheckpointPSBTs,
 		)
 		require.NoError(h.t, err)
+
 		return []Event{
 			&SubmitAcceptedEvent{
 				SessionID:               sessionID,
@@ -197,7 +198,8 @@ func TestOORClientActorHappyPath(t *testing.T) {
 type retrySubmitOutboxHandler struct {
 	t *testing.T
 
-	clientSigner input.Signer
+	clientSigner   input.Signer
+	operatorSigner input.Signer
 
 	submitAttempts int
 }
@@ -232,6 +234,13 @@ func (h *retrySubmitOutboxHandler) Handle(
 
 		txid := msg.ArkPSBT.UnsignedTx.TxHash()
 		require.Equal(h.t, SessionID(txid), sessionID)
+
+		err := coSignCheckpointPSBTsForTest(
+			h.operatorSigner,
+			msg.TransferInputs,
+			msg.CheckpointPSBTs,
+		)
+		require.NoError(h.t, err)
 
 		return []Event{
 			&SubmitAcceptedEvent{
@@ -304,6 +313,9 @@ func TestOORClientActorRetryBackoff(t *testing.T) {
 	require.NoError(t, err)
 
 	clientSigner := input.NewMockSigner([]*btcec.PrivateKey{clientKey}, nil)
+	operatorSigner := input.NewMockSigner(
+		[]*btcec.PrivateKey{operatorKey}, nil,
+	)
 
 	inputs := []TransferInput{
 		newTestTransferInput(
@@ -325,8 +337,9 @@ func TestOORClientActorRetryBackoff(t *testing.T) {
 
 	actor := NewOORClientActor(ClientActorCfg{
 		OutboxHandler: &retrySubmitOutboxHandler{
-			t:            t,
-			clientSigner: clientSigner,
+			t:              t,
+			clientSigner:   clientSigner,
+			operatorSigner: operatorSigner,
 		},
 		DeliveryStore: newTestDeliveryStore(t),
 		ActorID:       "oor-actor-retry-backoff",

--- a/oor/actor_test.go
+++ b/oor/actor_test.go
@@ -31,6 +31,15 @@ func (h *testOutboxHandler) Handle(_ context.Context, sessionID SessionID,
 	h.t.Helper()
 
 	switch msg := outbox.(type) {
+	case *RequestArkSignatures:
+		// Ark signing is modeled as an outbox boundary.
+		// Unit tests treat this as a deterministic pass-through.
+		return []Event{
+			&ArkSignedEvent{
+				ArkPSBT: msg.ArkPSBT,
+			},
+		}, nil
+
 	case *SendSubmitPackageRequest:
 		// The session ID is defined as the Ark txid, which means the
 		// client can reconstruct it deterministically from PSBT bytes.
@@ -84,8 +93,9 @@ func (h *testOutboxHandler) Handle(_ context.Context, sessionID SessionID,
 		}, nil
 
 	case *MarkInputsSpentRequest:
-		// Outgoing OOR transfers are off-chain. Once finalize is accepted,
-		// the local wallet must persist that its inputs are spent.
+		// Outgoing OOR transfers are off-chain.
+		// Once finalize is accepted, the local wallet must record
+		// that its inputs are spent.
 		_ = msg
 		return []Event{
 			&InputsMarkedSpentEvent{},
@@ -202,6 +212,13 @@ func (h *retrySubmitOutboxHandler) Handle(
 	h.t.Helper()
 
 	switch msg := outbox.(type) {
+	case *RequestArkSignatures:
+		return []Event{
+			&ArkSignedEvent{
+				ArkPSBT: msg.ArkPSBT,
+			},
+		}, nil
+
 	case *SendSubmitPackageRequest:
 		h.submitAttempts++
 
@@ -311,7 +328,10 @@ func TestOORClientActorRetryBackoff(t *testing.T) {
 			t:            t,
 			clientSigner: clientSigner,
 		},
+		DeliveryStore: newTestDeliveryStore(t),
+		ActorID:       "oor-actor-retry-backoff",
 	})
+	defer actor.Stop()
 
 	startResp := actor.Receive(ctx, &StartTransferRequest{
 		Policy:     policy,

--- a/oor/actor_test.go
+++ b/oor/actor_test.go
@@ -2,6 +2,7 @@ package oor
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -31,6 +32,8 @@ func (h *testOutboxHandler) Handle(_ context.Context, sessionID SessionID,
 
 	switch msg := outbox.(type) {
 	case *SendSubmitPackageRequest:
+		// The session ID is defined as the Ark txid, which means the
+		// client can reconstruct it deterministically from PSBT bytes.
 		txid := msg.ArkPSBT.UnsignedTx.TxHash()
 		require.Equal(h.t, SessionID(txid), sessionID)
 
@@ -40,7 +43,6 @@ func (h *testOutboxHandler) Handle(_ context.Context, sessionID SessionID,
 			msg.CheckpointPSBTs,
 		)
 		require.NoError(h.t, err)
-
 		return []Event{
 			&SubmitAcceptedEvent{
 				SessionID:               sessionID,
@@ -50,12 +52,19 @@ func (h *testOutboxHandler) Handle(_ context.Context, sessionID SessionID,
 		}, nil
 
 	case *RequestCheckpointSignatures:
+		// This simulates wallet-side signing.
+		//
+		// The FSM is expected to request that the application/wallet
+		// layer attaches client signatures to the (server co-signed)
+		// checkpoint PSBTs.
 		err := SignCheckpointPSBTs(
 			h.clientSigner, msg.TransferInputs,
 			msg.CoSignedCheckpointPSBTs,
 		)
 		require.NoError(h.t, err)
 
+		// After signing, we emit the event that drives the FSM into the
+		// finalize step.
 		finalCheckpoints := msg.CoSignedCheckpointPSBTs
 
 		return []Event{
@@ -65,9 +74,21 @@ func (h *testOutboxHandler) Handle(_ context.Context, sessionID SessionID,
 		}, nil
 
 	case *SendFinalizePackageRequest:
+		// Finalize is the last transport step: after this point, the
+		// server is expected to persist the transfer's VTXO set update.
+		//
+		// In unit tests we model this as unconditional acceptance.
 		_ = msg
 		return []Event{
 			&FinalizeAcceptedEvent{},
+		}, nil
+
+	case *MarkInputsSpentRequest:
+		// Outgoing OOR transfers are off-chain. Once finalize is accepted,
+		// the local wallet must persist that its inputs are spent.
+		_ = msg
+		return []Event{
+			&InputsMarkedSpentEvent{},
 		}, nil
 
 	default:
@@ -84,6 +105,8 @@ func TestOORClientActorHappyPath(t *testing.T) {
 
 	ctx := t.Context()
 
+	// This is a pure unit test: we use mock keys and a mock signer so the
+	// test is deterministic and does not require an external wallet.
 	operatorKey, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
 
@@ -120,6 +143,10 @@ func TestOORClientActorHappyPath(t *testing.T) {
 		},
 	}
 
+	// The actor wrapper is responsible for:
+	// - creating a per-session FSM instance
+	// - delivering outbox work to an application-provided handler
+	// - driving follow-up events back into the FSM
 	actor := NewOORClientActor(ClientActorCfg{
 		OutboxHandler: &testOutboxHandler{
 			t:              t,
@@ -142,6 +169,9 @@ func TestOORClientActorHappyPath(t *testing.T) {
 	require.True(t, ok)
 	require.NotEqual(t, SessionID{}, startMsg.SessionID)
 
+	// Verify the session reached a terminal state without requiring any
+	// explicit "drive" calls by the test: outbox ↔ event feedback should
+	// be sufficient for the happy path.
 	stateResp := actor.Receive(ctx, &GetStateRequest{
 		SessionID: startMsg.SessionID,
 	})
@@ -149,5 +179,156 @@ func TestOORClientActorHappyPath(t *testing.T) {
 
 	stateMsg, ok := stateResp.UnwrapOr(nil).(*GetStateResponse)
 	require.True(t, ok)
-	require.IsType(t, &AwaitingLocalVTXOUpdate{}, stateMsg.State)
+	require.IsType(t, &Completed{}, stateMsg.State)
+}
+
+// retrySubmitOutboxHandler simulates a retryable transport error on the first
+// submit attempt and verifies the FSM can back off and retry.
+type retrySubmitOutboxHandler struct {
+	t *testing.T
+
+	clientSigner input.Signer
+
+	submitAttempts int
+}
+
+// Handle processes the outbox request and returns follow-up events.
+func (h *retrySubmitOutboxHandler) Handle(
+	_ context.Context,
+	sessionID SessionID,
+	outbox OutboxEvent,
+) ([]Event, error) {
+
+	h.t.Helper()
+
+	switch msg := outbox.(type) {
+	case *SendSubmitPackageRequest:
+		h.submitAttempts++
+
+		// First attempt fails with a retryable error.
+		if h.submitAttempts == 1 {
+			return nil, NewRetryableOutboxError(
+				fmt.Errorf("temporary transport error"),
+				0,
+			)
+		}
+
+		txid := msg.ArkPSBT.UnsignedTx.TxHash()
+		require.Equal(h.t, SessionID(txid), sessionID)
+
+		return []Event{
+			&SubmitAcceptedEvent{
+				SessionID:               sessionID,
+				ArkPSBT:                 msg.ArkPSBT,
+				CoSignedCheckpointPSBTs: msg.CheckpointPSBTs,
+			},
+		}, nil
+
+	case *ScheduleRetryRequest:
+		_ = msg
+
+		// For unit tests, trigger the retry immediately.
+		return []Event{
+			&RetryDueEvent{},
+		}, nil
+
+	case *RequestCheckpointSignatures:
+		err := SignCheckpointPSBTs(
+			h.clientSigner, msg.TransferInputs,
+			msg.CoSignedCheckpointPSBTs,
+		)
+		require.NoError(h.t, err)
+
+		return []Event{
+			&CheckpointsSignedEvent{
+				FinalCheckpointPSBTs: msg.
+					CoSignedCheckpointPSBTs,
+			},
+		}, nil
+
+	case *SendFinalizePackageRequest:
+		_ = msg
+
+		return []Event{
+			&FinalizeAcceptedEvent{},
+		}, nil
+
+	case *MarkInputsSpentRequest:
+		_ = msg
+		return []Event{
+			&InputsMarkedSpentEvent{},
+		}, nil
+
+	default:
+		return nil, nil
+	}
+}
+
+var _ OutboxHandler = (*retrySubmitOutboxHandler)(nil)
+
+// TestOORClientActorRetryBackoff asserts the client actor can handle a
+// retryable error emitted by the outbox handler and complete after retry.
+func TestOORClientActorRetryBackoff(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	policy := scripts.CheckpointPolicy{
+		OperatorKey: operatorKey.PubKey(),
+		CSVDelay:    10,
+	}
+
+	inputValue := btcutil.Amount(10000)
+
+	clientKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	clientSigner := input.NewMockSigner([]*btcec.PrivateKey{clientKey}, nil)
+
+	inputs := []TransferInput{
+		newTestTransferInput(
+			t, clientKey, policy.OperatorKey,
+			wire.OutPoint{
+				Hash:  [32]byte{0x02},
+				Index: 0,
+			},
+			inputValue,
+		),
+	}
+
+	recipients := []oortx.RecipientOutput{
+		{
+			PkScript: newTestTaprootPkScript(t, clientKey.PubKey()),
+			Value:    inputValue,
+		},
+	}
+
+	actor := NewOORClientActor(ClientActorCfg{
+		OutboxHandler: &retrySubmitOutboxHandler{
+			t:            t,
+			clientSigner: clientSigner,
+		},
+	})
+
+	startResp := actor.Receive(ctx, &StartTransferRequest{
+		Policy:     policy,
+		Inputs:     inputs,
+		Recipients: recipients,
+	})
+	require.True(t, startResp.IsOk())
+
+	startMsg, ok := startResp.UnwrapOr(nil).(*StartTransferResponse)
+	require.True(t, ok)
+
+	stateResp := actor.Receive(ctx, &GetStateRequest{
+		SessionID: startMsg.SessionID,
+	})
+	require.True(t, stateResp.IsOk())
+
+	stateMsg, ok := stateResp.UnwrapOr(nil).(*GetStateResponse)
+	require.True(t, ok)
+	require.IsType(t, &Completed{}, stateMsg.State)
 }

--- a/oor/coverage_misc_test.go
+++ b/oor/coverage_misc_test.go
@@ -1,0 +1,31 @@
+package oor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestTerminalStatesIgnoreUnexpectedEvents asserts terminal states ignore
+// late/unexpected deliveries and remain unchanged.
+func TestTerminalStatesIgnoreUnexpectedEvents(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	completed := &Completed{}
+	transition, err := completed.ProcessEvent(
+		ctx, &FailEvent{Reason: "late"}, nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, completed, transition.NextState)
+	require.True(t, transition.NewEvents.IsNone())
+
+	failed := &Failed{Reason: "boom"}
+	transition, err = failed.ProcessEvent(
+		ctx, &FailEvent{Reason: "late"}, nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, failed, transition.NextState)
+	require.True(t, transition.NewEvents.IsNone())
+}

--- a/oor/events.go
+++ b/oor/events.go
@@ -95,6 +95,13 @@ type InputsMarkedSpentEvent struct{}
 // eventSealed marks this as implementing the sealed Event interface.
 func (e *InputsMarkedSpentEvent) eventSealed() {}
 
+// RetryDueEvent indicates that a previously requested retry backoff timer has
+// elapsed and the session can resume from the stored retry snapshot.
+type RetryDueEvent struct{}
+
+// eventSealed marks this as implementing the sealed Event interface.
+func (e *RetryDueEvent) eventSealed() {}
+
 // FailEvent forces the session to enter a terminal failure state.
 type FailEvent struct {
 	Reason string

--- a/oor/events.go
+++ b/oor/events.go
@@ -1,6 +1,8 @@
 package oor
 
 import (
+	"time"
+
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/lightninglabs/darepo-client/lib/scripts"
 	oortx "github.com/lightninglabs/darepo-client/lib/tx/oor"
@@ -110,6 +112,24 @@ type FailEvent struct {
 // eventSealed marks this as implementing the sealed Event interface.
 func (e *FailEvent) eventSealed() {}
 
+// OutboxErrorEvent notifies the FSM that a side effect request failed.
+//
+// The actor boundary is responsible for deciding whether the error is
+// retryable and for populating RetryAfter appropriately.
+//
+// Encoding retry semantics as an event (rather than returning a special Go
+// error) keeps the FSM deterministic and keeps all "should we retry" policy in
+// one place: the state transition logic.
+type OutboxErrorEvent struct {
+	OutboxType  string
+	Retryable   bool
+	RetryAfter  time.Duration
+	ErrorReason string
+}
+
+// eventSealed marks this as implementing the sealed Event interface.
+func (e *OutboxErrorEvent) eventSealed() {}
+
 // IncomingTransferEvent notifies the client about an incoming OOR transfer.
 //
 // This event is intended to be delivered by some higher layer (RPC push,
@@ -148,3 +168,10 @@ type IncomingHandledEvent struct{}
 
 // eventSealed marks this as implementing the sealed Event interface.
 func (e *IncomingHandledEvent) eventSealed() {}
+
+// IncomingAckSentEvent indicates the server ack has been sent for this
+// incoming transfer session.
+type IncomingAckSentEvent struct{}
+
+// eventSealed marks this as implementing the sealed Event interface.
+func (e *IncomingAckSentEvent) eventSealed() {}

--- a/oor/incoming_vtxo.go
+++ b/oor/incoming_vtxo.go
@@ -7,13 +7,39 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/lib/scripts"
+	"github.com/lightninglabs/darepo-client/lib/tree"
 	"github.com/lightninglabs/darepo-client/lib/tx/arktx"
 	"github.com/lightninglabs/darepo-client/vtxo"
 	"github.com/lightningnetwork/lnd/keychain"
 )
+
+// IncomingVTXOMetadata carries authoritative lineage/expiry metadata for an
+// incoming OOR VTXO. The receive path must not invent synthetic placeholders
+// for these fields because they drive expiry logic and unilateral-exit lineage.
+type IncomingVTXOMetadata struct {
+	// RoundID identifies the round lineage this VTXO belongs to.
+	RoundID string
+
+	// CommitmentTxID is the commitment transaction anchoring this VTXO
+	// lineage.
+	CommitmentTxID chainhash.Hash
+
+	// BatchExpiry is the absolute batch expiry height.
+	BatchExpiry int32
+
+	// TreeDepth is the VTXO depth in the commitment tree.
+	TreeDepth int
+
+	// CreatedHeight is the block height at which the VTXO was created.
+	CreatedHeight int32
+
+	// TreePath is the minimal inclusion path used for unilateral exit.
+	TreePath *tree.Tree
+}
 
 // IncomingVTXOConfig describes how to materialize an Ark tx output into a
 // spendable local VTXO descriptor.
@@ -34,6 +60,9 @@ type IncomingVTXOConfig struct {
 	// ExitDelay is the unilateral CSV delay used by the timeout spend
 	// path.
 	ExitDelay uint32
+
+	// Metadata carries authoritative lineage and expiry attributes.
+	Metadata IncomingVTXOMetadata
 }
 
 // BuildIncomingVTXODescriptor constructs a VTXO descriptor for a recipient
@@ -54,6 +83,13 @@ func BuildIncomingVTXODescriptor(ark *psbt.Packet,
 
 	case cfg.OperatorKey == nil:
 		return nil, fmt.Errorf("operator key must be provided")
+
+	case cfg.Metadata.RoundID == "":
+		return nil, fmt.Errorf("round id must be provided")
+	}
+
+	if cfg.Metadata.CommitmentTxID == (chainhash.Hash{}) {
+		return nil, fmt.Errorf("commitment tx id must be provided")
 	}
 
 	err := arktx.ValidateCanonicalPSBT(ark)
@@ -109,9 +145,13 @@ func BuildIncomingVTXODescriptor(ark *psbt.Packet,
 		ClientKey:      cfg.ClientKey,
 		OperatorKey:    cfg.OperatorKey,
 		TapScript:      tapscript,
-		RoundID:        fmt.Sprintf("oor:%s", arkTxid),
-		CommitmentTxID: arkTxid,
+		TreePath:       cfg.Metadata.TreePath,
+		RoundID:        cfg.Metadata.RoundID,
+		CommitmentTxID: cfg.Metadata.CommitmentTxID,
+		BatchExpiry:    cfg.Metadata.BatchExpiry,
 		RelativeExpiry: cfg.ExitDelay,
+		TreeDepth:      cfg.Metadata.TreeDepth,
+		CreatedHeight:  cfg.Metadata.CreatedHeight,
 		Status:         vtxo.VTXOStatusLive,
 	}, nil
 }

--- a/oor/local_persistence_handler.go
+++ b/oor/local_persistence_handler.go
@@ -67,8 +67,8 @@ type LocalPersistenceOutboxHandler struct {
 	// incoming recipient output.
 	ResolveIncomingClientKey IncomingClientKeyResolver
 
-	// ResolveIncomingMetadata resolves authoritative lineage/expiry metadata
-	// for each incoming recipient output.
+	// ResolveIncomingMetadata resolves authoritative lineage/expiry
+	// metadata for each incoming recipient output.
 	ResolveIncomingMetadata IncomingMetadataResolver
 }
 
@@ -128,7 +128,8 @@ func (h *LocalPersistenceOutboxHandler) handleMarkInputsSpent(
 // handleMaterializeIncoming persists recipient VTXOs for an incoming transfer
 // before the receive FSM acknowledges the transfer to the server.
 func (h *LocalPersistenceOutboxHandler) handleMaterializeIncoming(
-	ctx context.Context, msg *MaterializeIncomingVTXOsRequest) ([]Event, error) {
+	ctx context.Context,
+	msg *MaterializeIncomingVTXOsRequest) ([]Event, error) {
 
 	if h.Store == nil {
 		return nil, fmt.Errorf("vtxo store must be provided")
@@ -139,11 +140,15 @@ func (h *LocalPersistenceOutboxHandler) handleMaterializeIncoming(
 	}
 
 	if h.ResolveIncomingClientKey == nil {
-		return nil, fmt.Errorf("incoming client key resolver must be provided")
+		return nil, fmt.Errorf(
+			"incoming client key resolver must be provided",
+		)
 	}
 
 	if h.ResolveIncomingMetadata == nil {
-		return nil, fmt.Errorf("incoming metadata resolver must be provided")
+		return nil, fmt.Errorf(
+			"incoming metadata resolver must be provided",
+		)
 	}
 
 	if len(msg.Recipients) == 0 {
@@ -192,9 +197,9 @@ func (h *LocalPersistenceOutboxHandler) handleMaterializeIncoming(
 			continue
 		}
 
-		// SaveVTXO may fail for duplicates on retry/restart paths. Treat that
-		// case as idempotent only if the already-persisted descriptor matches
-		// the materialized recipient output.
+		// SaveVTXO may fail for duplicates on retry/restart paths.
+		// Treat that case as idempotent only if the already-persisted
+		// descriptor matches the materialized recipient output.
 		existing, getErr := h.Store.GetVTXO(ctx, desc.Outpoint)
 		if getErr != nil || existing == nil {
 			return nil, err
@@ -242,4 +247,3 @@ func (h *LocalPersistenceOutboxHandler) handleIncomingAck(
 }
 
 var _ OutboxHandler = (*LocalPersistenceOutboxHandler)(nil)
-

--- a/oor/local_persistence_handler.go
+++ b/oor/local_persistence_handler.go
@@ -1,0 +1,245 @@
+package oor
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/lightninglabs/darepo-client/vtxo"
+	"github.com/lightningnetwork/lnd/keychain"
+)
+
+var (
+	// ErrIncomingRecipientNotOwned signals that a recipient output does not
+	// belong to this wallet and should be ignored by incoming
+	// materialization.
+	ErrIncomingRecipientNotOwned = errors.New(
+		"incoming recipient not owned by wallet",
+	)
+)
+
+// IsIncomingRecipientNotOwned reports whether err indicates an incoming
+// recipient that should be skipped during materialization.
+func IsIncomingRecipientNotOwned(err error) bool {
+	return errors.Is(err, ErrIncomingRecipientNotOwned)
+}
+
+// IncomingClientKeyResolver resolves the local client key for a recipient
+// output being materialized from an incoming transfer.
+type IncomingClientKeyResolver func(ctx context.Context,
+	recipient ArkRecipientOutput) (keychain.KeyDescriptor, error)
+
+// IncomingMetadataResolver resolves authoritative lineage and expiry metadata
+// for a recipient output being materialized from an incoming transfer.
+type IncomingMetadataResolver func(ctx context.Context, sessionID SessionID,
+	recipient ArkRecipientOutput, ark *psbt.Packet,
+	finalCheckpoints []*psbt.Packet) (IncomingVTXOMetadata, error)
+
+// LocalPersistenceOutboxHandler implements the persistence-related outbox
+// requests emitted by the OOR FSM.
+//
+// This exists as a small convenience for callers: an application can wrap its
+// transport/signing outbox implementation with this handler to get consistent,
+// restart-safe local VTXO state updates.
+//
+// Incoming transfer materialization requires wallet-specific key and lineage
+// resolution. Those remain explicit callouts via resolver callbacks on this
+// handler.
+type LocalPersistenceOutboxHandler struct {
+	// Next is the delegate handler that executes non-persistence outbox
+	// requests.
+	Next OutboxHandler
+
+	// Store is the VTXO store to update.
+	Store vtxo.VTXOStore
+
+	// OperatorKey is the operator key used to reconstruct incoming VTXO
+	// tapscripts.
+	OperatorKey *btcec.PublicKey
+
+	// ExitDelay is the unilateral CSV delay for incoming VTXO descriptors.
+	ExitDelay uint32
+
+	// ResolveIncomingClientKey resolves the local client key for each
+	// incoming recipient output.
+	ResolveIncomingClientKey IncomingClientKeyResolver
+
+	// ResolveIncomingMetadata resolves authoritative lineage/expiry metadata
+	// for each incoming recipient output.
+	ResolveIncomingMetadata IncomingMetadataResolver
+}
+
+// Handle executes the outbox request and returns follow-up events.
+func (h *LocalPersistenceOutboxHandler) Handle(ctx context.Context,
+	sessionID SessionID, outbox OutboxEvent) ([]Event, error) {
+
+	_ = sessionID
+
+	if h == nil {
+		return nil, fmt.Errorf("handler must be provided")
+	}
+
+	switch msg := outbox.(type) {
+	case *MarkInputsSpentRequest:
+		return h.handleMarkInputsSpent(ctx, msg)
+
+	case *MaterializeIncomingVTXOsRequest:
+		return h.handleMaterializeIncoming(ctx, msg)
+
+	case *SendIncomingAckRequest:
+		return h.handleIncomingAck(ctx, sessionID, msg)
+
+	default:
+		if h.Next == nil {
+			return nil, nil
+		}
+
+		return h.Next.Handle(ctx, sessionID, outbox)
+	}
+}
+
+// handleMarkInputsSpent updates local VTXO state for outgoing transfer inputs.
+func (h *LocalPersistenceOutboxHandler) handleMarkInputsSpent(
+	ctx context.Context, msg *MarkInputsSpentRequest) ([]Event, error) {
+
+	if h.Store == nil {
+		return nil, fmt.Errorf("vtxo store must be provided")
+	}
+
+	if len(msg.Outpoints) == 0 {
+		return nil, fmt.Errorf("outpoints must be provided")
+	}
+
+	for i := range msg.Outpoints {
+		err := h.Store.UpdateVTXOStatus(
+			ctx, msg.Outpoints[i], vtxo.VTXOStatusSpent,
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return []Event{&InputsMarkedSpentEvent{}}, nil
+}
+
+// handleMaterializeIncoming persists recipient VTXOs for an incoming transfer
+// before the receive FSM acknowledges the transfer to the server.
+func (h *LocalPersistenceOutboxHandler) handleMaterializeIncoming(
+	ctx context.Context, msg *MaterializeIncomingVTXOsRequest) ([]Event, error) {
+
+	if h.Store == nil {
+		return nil, fmt.Errorf("vtxo store must be provided")
+	}
+
+	if h.OperatorKey == nil {
+		return nil, fmt.Errorf("operator key must be provided")
+	}
+
+	if h.ResolveIncomingClientKey == nil {
+		return nil, fmt.Errorf("incoming client key resolver must be provided")
+	}
+
+	if h.ResolveIncomingMetadata == nil {
+		return nil, fmt.Errorf("incoming metadata resolver must be provided")
+	}
+
+	if len(msg.Recipients) == 0 {
+		return nil, fmt.Errorf("incoming recipients must be provided")
+	}
+
+	ownedRecipients := 0
+
+	for i := range msg.Recipients {
+		recipient := msg.Recipients[i]
+
+		clientKey, err := h.ResolveIncomingClientKey(ctx, recipient)
+		if err != nil {
+			if IsIncomingRecipientNotOwned(err) {
+				continue
+			}
+
+			return nil, err
+		}
+
+		ownedRecipients++
+
+		metadata, err := h.ResolveIncomingMetadata(
+			ctx, msg.SessionID, recipient, msg.ArkPSBT,
+			msg.FinalCheckpointPSBTs,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		desc, err := BuildIncomingVTXODescriptor(msg.ArkPSBT,
+			IncomingVTXOConfig{
+				OutputIndex: recipient.OutputIndex,
+				ClientKey:   clientKey,
+				OperatorKey: h.OperatorKey,
+				ExitDelay:   h.ExitDelay,
+				Metadata:    metadata,
+			},
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		err = h.Store.SaveVTXO(ctx, desc)
+		if err == nil {
+			continue
+		}
+
+		// SaveVTXO may fail for duplicates on retry/restart paths. Treat that
+		// case as idempotent only if the already-persisted descriptor matches
+		// the materialized recipient output.
+		existing, getErr := h.Store.GetVTXO(ctx, desc.Outpoint)
+		if getErr != nil || existing == nil {
+			return nil, err
+		}
+
+		if existing.Amount != desc.Amount {
+			return nil, err
+		}
+
+		if !bytes.Equal(existing.PkScript, desc.PkScript) {
+			return nil, err
+		}
+	}
+
+	if ownedRecipients == 0 {
+		return nil, fmt.Errorf("incoming transfer contains no " +
+			"wallet-owned recipients")
+	}
+
+	return []Event{&IncomingHandledEvent{}}, nil
+}
+
+// handleIncomingAck forwards the ack request to the transport boundary (if
+// configured) and emits IncomingAckSentEvent on success.
+func (h *LocalPersistenceOutboxHandler) handleIncomingAck(
+	ctx context.Context, sessionID SessionID,
+	msg *SendIncomingAckRequest) ([]Event, error) {
+
+	if msg == nil {
+		return nil, fmt.Errorf("incoming ack request must be provided")
+	}
+
+	if h.Next == nil {
+		return []Event{&IncomingAckSentEvent{}}, nil
+	}
+
+	followUps, err := h.Next.Handle(ctx, sessionID, msg)
+	if err != nil {
+		return nil, err
+	}
+
+	followUps = append(followUps, &IncomingAckSentEvent{})
+
+	return followUps, nil
+}
+
+var _ OutboxHandler = (*LocalPersistenceOutboxHandler)(nil)
+

--- a/oor/local_persistence_handler_test.go
+++ b/oor/local_persistence_handler_test.go
@@ -1,0 +1,429 @@
+package oor
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/scripts"
+	oortx "github.com/lightninglabs/darepo-client/lib/tx/oor"
+	"github.com/lightninglabs/darepo-client/vtxo"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/stretchr/testify/require"
+)
+
+// testVTXOStore is a minimal in-memory vtxo.VTXOStore used by handler tests.
+type testVTXOStore struct {
+	records map[wire.OutPoint]*vtxo.Descriptor
+}
+
+// newTestVTXOStore creates a new testVTXOStore.
+func newTestVTXOStore() *testVTXOStore {
+	return &testVTXOStore{
+		records: make(map[wire.OutPoint]*vtxo.Descriptor),
+	}
+}
+
+// SaveVTXO persists a descriptor unless it already exists.
+func (s *testVTXOStore) SaveVTXO(_ context.Context,
+	desc *vtxo.Descriptor) error {
+
+	if desc == nil {
+		return fmt.Errorf("descriptor must be provided")
+	}
+
+	if _, ok := s.records[desc.Outpoint]; ok {
+		return fmt.Errorf("duplicate vtxo")
+	}
+
+	cpy := *desc
+	s.records[desc.Outpoint] = &cpy
+
+	return nil
+}
+
+// GetVTXO returns a descriptor by outpoint.
+func (s *testVTXOStore) GetVTXO(_ context.Context,
+	outpoint wire.OutPoint) (*vtxo.Descriptor, error) {
+
+	desc, ok := s.records[outpoint]
+	if !ok {
+		return nil, fmt.Errorf("not found")
+	}
+
+	cpy := *desc
+
+	return &cpy, nil
+}
+
+// ListLiveVTXOs returns all stored descriptors.
+func (s *testVTXOStore) ListLiveVTXOs(_ context.Context) (
+	[]*vtxo.Descriptor, error) {
+
+	out := make([]*vtxo.Descriptor, 0, len(s.records))
+	for _, desc := range s.records {
+		cpy := *desc
+		out = append(out, &cpy)
+	}
+
+	return out, nil
+}
+
+// UpdateVTXOStatus updates status for the given outpoint.
+func (s *testVTXOStore) UpdateVTXOStatus(_ context.Context,
+	outpoint wire.OutPoint, status vtxo.VTXOStatus) error {
+
+	desc, ok := s.records[outpoint]
+	if !ok {
+		return fmt.Errorf("not found")
+	}
+
+	desc.Status = status
+
+	return nil
+}
+
+// MarkForfeiting is unused by these tests.
+func (s *testVTXOStore) MarkForfeiting(_ context.Context,
+	_ wire.OutPoint, _ string, _ *wire.MsgTx) error {
+
+	return nil
+}
+
+// GetForfeitTx is unused by these tests.
+func (s *testVTXOStore) GetForfeitTx(_ context.Context,
+	_ wire.OutPoint) (*wire.MsgTx, error) {
+
+	return nil, nil
+}
+
+// MarkForfeited is unused by these tests.
+func (s *testVTXOStore) MarkForfeited(_ context.Context,
+	_ wire.OutPoint, _ chainhash.Hash) error {
+
+	return nil
+}
+
+// DeleteVTXO removes an outpoint from the test store.
+func (s *testVTXOStore) DeleteVTXO(_ context.Context,
+	outpoint wire.OutPoint) error {
+
+	delete(s.records, outpoint)
+	return nil
+}
+
+// TestLocalPersistenceOutboxHandlerMaterializeIncoming asserts incoming
+// materialization persists recipient VTXOs and emits IncomingHandledEvent.
+func TestLocalPersistenceOutboxHandlerMaterializeIncoming(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	arkPSBT, recipients, parentCommitment, recipientKey, operatorKey :=
+		buildTestIncomingMaterialization(t)
+
+	sessionID := SessionID(arkPSBT.UnsignedTx.TxHash())
+	store := newTestVTXOStore()
+
+	handler := &LocalPersistenceOutboxHandler{
+		Store:       store,
+		OperatorKey: operatorKey,
+		ExitDelay:   10,
+		ResolveIncomingClientKey: func(ctx context.Context,
+			recipient ArkRecipientOutput) (
+			keychain.KeyDescriptor, error) {
+
+			_ = ctx
+			_ = recipient
+
+			return keychain.KeyDescriptor{
+				PubKey: recipientKey.PubKey(),
+			}, nil
+		},
+		ResolveIncomingMetadata: func(ctx context.Context,
+			sessionID SessionID, recipient ArkRecipientOutput,
+			ark *psbt.Packet,
+			finalCheckpoints []*psbt.Packet) (
+			IncomingVTXOMetadata, error) {
+
+			_ = ctx
+			_ = sessionID
+			_ = recipient
+			_ = ark
+			_ = finalCheckpoints
+
+			return IncomingVTXOMetadata{
+				RoundID:        "round-incoming",
+				CommitmentTxID: parentCommitment,
+				BatchExpiry:    1000,
+				TreeDepth:      1,
+				CreatedHeight:  700,
+			}, nil
+		},
+	}
+
+	req := &MaterializeIncomingVTXOsRequest{
+		SessionID:  sessionID,
+		ArkPSBT:    arkPSBT,
+		Recipients: recipients,
+	}
+
+	events, err := handler.Handle(ctx, sessionID, req)
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	require.IsType(t, &IncomingHandledEvent{}, events[0])
+
+	desc, err := store.GetVTXO(ctx, wire.OutPoint{
+		Hash:  arkPSBT.UnsignedTx.TxHash(),
+		Index: recipients[0].OutputIndex,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "round-incoming", desc.RoundID)
+	require.Equal(t, parentCommitment, desc.CommitmentTxID)
+	require.EqualValues(t, 1000, desc.BatchExpiry)
+	require.EqualValues(t, 1, desc.TreeDepth)
+	require.EqualValues(t, 700, desc.CreatedHeight)
+
+	// Re-materialization should be idempotent.
+	events, err = handler.Handle(ctx, sessionID, req)
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	require.IsType(t, &IncomingHandledEvent{}, events[0])
+}
+
+// TestLocalPersistenceOutboxHandlerMaterializeIncomingSkipsNotOwned asserts
+// non-owned recipients are skipped while owned recipients are materialized.
+func TestLocalPersistenceOutboxHandlerMaterializeIncomingSkipsNotOwned(
+	t *testing.T) {
+
+	t.Parallel()
+
+	ctx := t.Context()
+
+	arkPSBT, recipients, parentCommitment, recipientKey, operatorKey :=
+		buildTestIncomingMaterialization(t)
+
+	anchorIndex := uint32(len(arkPSBT.UnsignedTx.TxOut) - 1)
+	recipients = append(recipients, ArkRecipientOutput{
+		OutputIndex: anchorIndex,
+		Value:       0,
+		PkScript:    arkPSBT.UnsignedTx.TxOut[anchorIndex].PkScript,
+	})
+
+	sessionID := SessionID(arkPSBT.UnsignedTx.TxHash())
+	store := newTestVTXOStore()
+
+	metadataCalls := 0
+	handler := &LocalPersistenceOutboxHandler{
+		Store:       store,
+		OperatorKey: operatorKey,
+		ExitDelay:   10,
+		ResolveIncomingClientKey: func(ctx context.Context,
+			recipient ArkRecipientOutput) (
+			keychain.KeyDescriptor, error) {
+
+			_ = ctx
+
+			if recipient.OutputIndex == anchorIndex {
+				return keychain.KeyDescriptor{},
+					ErrIncomingRecipientNotOwned
+			}
+
+			return keychain.KeyDescriptor{
+				PubKey: recipientKey.PubKey(),
+			}, nil
+		},
+		ResolveIncomingMetadata: func(ctx context.Context,
+			sessionID SessionID, recipient ArkRecipientOutput,
+			ark *psbt.Packet,
+			finalCheckpoints []*psbt.Packet) (
+			IncomingVTXOMetadata, error) {
+
+			_ = ctx
+			_ = sessionID
+			_ = recipient
+			_ = ark
+			_ = finalCheckpoints
+
+			metadataCalls++
+
+			return IncomingVTXOMetadata{
+				RoundID:        "round-incoming",
+				CommitmentTxID: parentCommitment,
+				BatchExpiry:    1000,
+				TreeDepth:      1,
+				CreatedHeight:  700,
+			}, nil
+		},
+	}
+
+	req := &MaterializeIncomingVTXOsRequest{
+		SessionID:  sessionID,
+		ArkPSBT:    arkPSBT,
+		Recipients: recipients,
+	}
+	events, err := handler.Handle(ctx, sessionID, req)
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	require.IsType(t, &IncomingHandledEvent{}, events[0])
+	require.Equal(t, 1, metadataCalls)
+
+	live, err := store.ListLiveVTXOs(ctx)
+	require.NoError(t, err)
+	require.Len(t, live, 1)
+	require.EqualValues(
+		t, recipients[0].OutputIndex, live[0].Outpoint.Index,
+	)
+}
+
+// TestLocalPersistenceOutboxHandlerMaterializeIncomingRequiresOwned asserts the
+// handler fails fast if no incoming recipient belongs to this wallet.
+func TestLocalPersistenceOutboxHandlerMaterializeIncomingRequiresOwned(
+	t *testing.T) {
+
+	t.Parallel()
+
+	ctx := t.Context()
+
+	arkPSBT, recipients, _, _, operatorKey :=
+		buildTestIncomingMaterialization(t)
+	sessionID := SessionID(arkPSBT.UnsignedTx.TxHash())
+	store := newTestVTXOStore()
+
+	handler := &LocalPersistenceOutboxHandler{
+		Store:       store,
+		OperatorKey: operatorKey,
+		ExitDelay:   10,
+		ResolveIncomingClientKey: func(ctx context.Context,
+			recipient ArkRecipientOutput) (
+			keychain.KeyDescriptor, error) {
+
+			_ = ctx
+			_ = recipient
+
+			return keychain.KeyDescriptor{},
+				ErrIncomingRecipientNotOwned
+		},
+		ResolveIncomingMetadata: func(ctx context.Context,
+			sessionID SessionID, recipient ArkRecipientOutput,
+			ark *psbt.Packet,
+			finalCheckpoints []*psbt.Packet) (
+			IncomingVTXOMetadata, error) {
+
+			_ = ctx
+			_ = sessionID
+			_ = recipient
+			_ = ark
+			_ = finalCheckpoints
+
+			return IncomingVTXOMetadata{},
+				fmt.Errorf("metadata should not be resolved")
+		},
+	}
+
+	req := &MaterializeIncomingVTXOsRequest{
+		SessionID:  sessionID,
+		ArkPSBT:    arkPSBT,
+		Recipients: recipients,
+	}
+	events, err := handler.Handle(ctx, sessionID, req)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "no wallet-owned recipients")
+	require.Empty(t, events)
+}
+
+// TestLocalPersistenceOutboxHandlerIncomingAck asserts incoming ack requests
+// emit IncomingAckSentEvent.
+func TestLocalPersistenceOutboxHandlerIncomingAck(t *testing.T) {
+	t.Parallel()
+
+	handler := &LocalPersistenceOutboxHandler{}
+	events, err := handler.Handle(
+		t.Context(), SessionID{}, &SendIncomingAckRequest{},
+	)
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	require.IsType(t, &IncomingAckSentEvent{}, events[0])
+}
+
+// buildTestIncomingMaterialization returns a canonical Ark PSBT and its
+// recipient list for incoming materialization tests.
+func buildTestIncomingMaterialization(t *testing.T) (*psbt.Packet,
+	[]ArkRecipientOutput, chainhash.Hash, *btcec.PrivateKey,
+	*btcec.PublicKey) {
+
+	t.Helper()
+
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	policy := scripts.CheckpointPolicy{
+		OperatorKey: operatorKey.PubKey(),
+		CSVDelay:    10,
+	}
+
+	recipientKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	inputValue := btcutil.Amount(10000)
+	inputs := []oortx.CheckpointInput{
+		{
+			SpentVTXO: oortx.SpentVTXORef{
+				Outpoint: wire.OutPoint{
+					Hash:  [32]byte{0x11},
+					Index: 0,
+				},
+				Output: &wire.TxOut{
+					Value: int64(inputValue),
+					PkScript: newTestTaprootPkScript(
+						t, operatorKey.PubKey(),
+					),
+				},
+			},
+			OwnerLeafScript: []byte{0x51},
+		},
+	}
+
+	vtxoTapKey, err := scripts.VTXOTapKey(
+		recipientKey.PubKey(), policy.OperatorKey, 10,
+	)
+	require.NoError(t, err)
+
+	recipientPkScript, err := txscript.PayToTaprootScript(vtxoTapKey)
+	require.NoError(t, err)
+
+	outputs := []oortx.RecipientOutput{
+		{
+			PkScript: recipientPkScript,
+			Value:    inputValue,
+		},
+	}
+
+	cp, err := oortx.BuildCheckpointPSBT(policy, inputs[0])
+	require.NoError(t, err)
+
+	arkPSBT, err := oortx.BuildArkPSBT(
+		[]oortx.CheckpointOutput{
+			{
+				Txid:           cp.PSBT.UnsignedTx.TxHash(),
+				Output:         cp.PSBT.UnsignedTx.TxOut[0],
+				TapTreeEncoded: cp.TapTreeEncoded,
+			},
+		},
+		outputs,
+	)
+	require.NoError(t, err)
+
+	recipients, err := ExtractArkRecipients(arkPSBT)
+	require.NoError(t, err)
+
+	return arkPSBT, recipients,
+		inputs[0].SpentVTXO.Outpoint.Hash, recipientKey,
+		operatorKey.PubKey()
+}

--- a/oor/outbox_error_test.go
+++ b/oor/outbox_error_test.go
@@ -1,0 +1,187 @@
+package oor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/scripts"
+	oortx "github.com/lightninglabs/darepo-client/lib/tx/oor"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHandleOutboxError asserts retry and failure transitions are derived
+// deterministically from outbox error events.
+func TestHandleOutboxError(t *testing.T) {
+	t.Parallel()
+
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	// Build a minimal, deterministic transfer package. We validate outbox
+	// error handling independently of any transport: the important part is
+	// that the current state contains enough information to retry safely
+	// (or to fail terminally in a deterministic way).
+	policy := scripts.CheckpointPolicy{
+		OperatorKey: operatorKey.PubKey(),
+		CSVDelay:    10,
+	}
+
+	inputValue := btcutil.Amount(10_000)
+
+	clientKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	inputs := []TransferInput{
+		newTestTransferInput(
+			t,
+			clientKey,
+			policy.OperatorKey,
+			wire.OutPoint{
+				Hash:  [32]byte{0x01},
+				Index: 0,
+			},
+			inputValue,
+		),
+	}
+
+	recipients := []oortx.RecipientOutput{{
+		PkScript: newTestTaprootPkScript(t, clientKey.PubKey()),
+		Value:    inputValue,
+	}}
+
+	ark, checkpoints, err := buildSubmitPackage(policy, inputs, recipients)
+	require.NoError(t, err)
+	require.NotNil(t, ark)
+	require.NotEmpty(t, checkpoints)
+
+	current := &AwaitingSubmitAccepted{
+		InputOutpoints:  []wire.OutPoint{inputs[0].VTXO.Outpoint},
+		ArkPSBT:         ark,
+		CheckpointPSBTs: checkpoints,
+		TransferInputs:  inputs,
+	}
+
+	sessionID, err := sessionIDFromArk(ark)
+	require.NoError(t, err)
+
+	env := &Environment{SessionID: sessionID}
+
+	// Nil event rejected: this is a programmer error and should not be
+	// treated as retryable.
+	_, err = handleOutboxError(env, current, nil)
+	require.Error(t, err)
+
+	// Retryable error requires a valid environment session id. The session
+	// id is used to reconstruct a safe resume snapshot.
+	_, err = handleOutboxError(nil, current, &OutboxErrorEvent{
+		OutboxType:  "x",
+		Retryable:   true,
+		RetryAfter:  0,
+		ErrorReason: "boom",
+	})
+	require.Error(t, err)
+
+	// Non-retryable error causes terminal failure. The state machine does
+	// not attempt to guess whether retry is safe.
+	transition, err := handleOutboxError(env, current, &OutboxErrorEvent{
+		OutboxType:  "x",
+		Retryable:   false,
+		ErrorReason: "boom",
+	})
+	require.NoError(t, err)
+	require.IsType(t, &Failed{}, transition.NextState)
+	require.True(t, transition.NewEvents.IsNone())
+
+	// Retryable error schedules a retry and snapshots the resume state so
+	// the caller can survive a crash while waiting for the backoff timer.
+	transition, err = handleOutboxError(env, current, &OutboxErrorEvent{
+		OutboxType:  "x",
+		Retryable:   true,
+		RetryAfter:  0,
+		ErrorReason: "boom",
+	})
+	require.NoError(t, err)
+
+	backoff, ok := transition.NextState.(*RetryBackoff)
+	require.True(t, ok)
+	require.NotNil(t, backoff.ResumeSnapshot)
+	require.Equal(t, 1*time.Second, backoff.RetryAfter)
+
+	require.True(t, transition.NewEvents.IsSome())
+	emitted := transition.NewEvents.UnwrapOr(EmittedEvent{})
+	require.Len(t, emitted.Outbox, 1)
+
+	schedule, ok := emitted.Outbox[0].(*ScheduleRetryRequest)
+	require.True(t, ok)
+	require.Equal(t, 1*time.Second, schedule.After)
+	require.Equal(t, "boom", schedule.Reason)
+}
+
+// TestAwaitingFinalizeAcceptedOutboxError verifies that retryable outbox
+// failures in the finalize-ack wait state transition into RetryBackoff.
+func TestAwaitingFinalizeAcceptedOutboxError(t *testing.T) {
+	t.Parallel()
+
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	policy := scripts.CheckpointPolicy{
+		OperatorKey: operatorKey.PubKey(),
+		CSVDelay:    10,
+	}
+
+	inputValue := btcutil.Amount(10_000)
+	clientKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	inputs := []TransferInput{
+		newTestTransferInput(
+			t,
+			clientKey,
+			policy.OperatorKey,
+			wire.OutPoint{
+				Hash:  [32]byte{0x11},
+				Index: 1,
+			},
+			inputValue,
+		),
+	}
+
+	recipients := []oortx.RecipientOutput{{
+		PkScript: newTestTaprootPkScript(t, clientKey.PubKey()),
+		Value:    inputValue,
+	}}
+
+	ark, checkpoints, err := buildSubmitPackage(policy, inputs, recipients)
+	require.NoError(t, err)
+
+	sessionID, err := sessionIDFromArk(ark)
+	require.NoError(t, err)
+
+	state := &AwaitingFinalizeAccepted{
+		SessionID:            sessionID,
+		ArkPSBT:              ark,
+		InputOutpoints:       []wire.OutPoint{inputs[0].VTXO.Outpoint},
+		FinalCheckpointPSBTs: checkpoints,
+	}
+
+	env := &Environment{SessionID: sessionID}
+	transition, err := state.ProcessEvent(t.Context(), &OutboxErrorEvent{
+		OutboxType:  (&SendFinalizePackageRequest{}).outboxType(),
+		Retryable:   true,
+		RetryAfter:  0,
+		ErrorReason: "finalize transport unavailable",
+	}, env)
+	require.NoError(t, err)
+	require.IsType(t, &RetryBackoff{}, transition.NextState)
+
+	emitted := transition.NewEvents.UnwrapOr(EmittedEvent{})
+	require.Len(t, emitted.Outbox, 1)
+
+	schedule, ok := emitted.Outbox[0].(*ScheduleRetryRequest)
+	require.True(t, ok)
+	require.Equal(t, defaultRetryDelay, schedule.After)
+}

--- a/oor/outbox_handler_func.go
+++ b/oor/outbox_handler_func.go
@@ -1,0 +1,18 @@
+package oor
+
+import (
+	"context"
+)
+
+// OutboxHandlerFunc adapts a function to the OutboxHandler interface.
+type OutboxHandlerFunc func(ctx context.Context, sessionID SessionID,
+	outbox OutboxEvent) ([]Event, error)
+
+// Handle implements OutboxHandler by calling the underlying function.
+func (f OutboxHandlerFunc) Handle(ctx context.Context, sessionID SessionID,
+	outbox OutboxEvent) ([]Event, error) {
+
+	return f(ctx, sessionID, outbox)
+}
+
+var _ OutboxHandler = (OutboxHandlerFunc)(nil)

--- a/oor/outbox_messages.go
+++ b/oor/outbox_messages.go
@@ -46,12 +46,37 @@ type OutboxEvent interface {
 	outboxSealed()
 }
 
+// RequestArkSignatures asks the signing layer to attach client signature
+// material for Ark inputs before submit.
+//
+// This is the explicit boundary where the client signs the Ark PSBT. The
+// resulting signed Ark PSBT is then forwarded in SendSubmitPackageRequest.
+type RequestArkSignatures struct {
+	actor.BaseMessage
+
+	// ArkPSBT is the canonical Ark transfer PSBT to sign.
+	ArkPSBT *psbt.Packet
+
+	// TransferInputs carry client signing context needed to authorize Ark
+	// inputs.
+	TransferInputs []TransferInput
+}
+
+// outboxType returns a stable identifier for this outbox message.
+func (m *RequestArkSignatures) outboxType() string {
+	return "RequestArkSignatures"
+}
+
+// outboxSealed marks this as implementing the sealed OutboxEvent interface.
+func (m *RequestArkSignatures) outboxSealed() {}
+
 // SendSubmitPackageRequest asks the transport layer to send the submit package
 // (Ark PSBT + checkpoint PSBTs) to the server.
 type SendSubmitPackageRequest struct {
 	actor.BaseMessage
 
-	// ArkPSBT is the canonical unsigned Ark transfer PSBT.
+	// ArkPSBT is the canonical Ark transfer PSBT with client signature
+	// material already attached for submit.
 	ArkPSBT *psbt.Packet
 
 	// CheckpointPSBTs are unsigned checkpoint PSBTs for the submit phase.
@@ -223,6 +248,10 @@ type MaterializeIncomingVTXOsRequest struct {
 	// ArkPSBT is the canonical Ark tx PSBT.
 	ArkPSBT *psbt.Packet
 
+	// FinalCheckpointPSBTs are the finalized checkpoint packages associated
+	// with this Ark transfer.
+	FinalCheckpointPSBTs []*psbt.Packet
+
 	// Recipients are the non-anchor recipient outputs in the Ark tx.
 	Recipients []ArkRecipientOutput
 }
@@ -347,7 +376,6 @@ func encodeFinalizePayload(ark *psbt.Packet,
 
 	return buf.Bytes(), nil
 }
-
 func encodeRetryPayload(after time.Duration, reason string) ([]byte, error) {
 	if after < 0 {
 		return nil, fmt.Errorf("retry delay must be non-negative")

--- a/oor/outbox_messages.go
+++ b/oor/outbox_messages.go
@@ -2,6 +2,8 @@ package oor
 
 import (
 	"bytes"
+	"fmt"
+	"time"
 
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/wire"
@@ -21,6 +23,11 @@ const (
 const (
 	finalizePayloadArkPSBTRecordType     tlv.Type = 1
 	finalizePayloadCheckpointsRecordType tlv.Type = 3
+)
+
+const (
+	retryPayloadAfterNanosRecordType tlv.Type = 1
+	retryPayloadReasonRecordType     tlv.Type = 3
 )
 
 // OutboxEvent is a sealed interface for side-effect requests emitted by the
@@ -258,6 +265,33 @@ func (m *SendIncomingAckRequest) ToProto() proto.Message {
 	return protoEnvelope("SendIncomingAckRequest", payload)
 }
 
+// ScheduleRetryRequest asks the runtime to deliver a RetryDueEvent after the
+// requested delay.
+type ScheduleRetryRequest struct {
+	actor.BaseMessage
+
+	After  time.Duration
+	Reason string
+}
+
+// outboxType returns a stable identifier for this outbox message.
+func (m *ScheduleRetryRequest) outboxType() string {
+	return "ScheduleRetryRequest"
+}
+
+// outboxSealed marks this as implementing the sealed OutboxEvent interface.
+func (m *ScheduleRetryRequest) outboxSealed() {}
+
+// ToProto converts ScheduleRetryRequest to a protobuf message.
+func (m *ScheduleRetryRequest) ToProto() proto.Message {
+	payload, err := encodeRetryPayload(m.After, m.Reason)
+	if err != nil {
+		return protoErrorEnvelope("ScheduleRetryRequest", err)
+	}
+
+	return protoEnvelope("ScheduleRetryRequest", payload)
+}
+
 func protoEnvelope(typeName string, payload []byte) proto.Message {
 	return &anypb.Any{
 		TypeUrl: oorOutboxProtoTypeURLPrefix + typeName,
@@ -299,6 +333,36 @@ func encodeFinalizePayload(ark *psbt.Packet,
 			finalizePayloadArkPSBTRecordType, &arkRaw,
 		),
 		checkpointPayloadRecord,
+	}
+
+	stream, err := tlv.NewStream(records...)
+	if err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	if err := stream.Encode(&buf); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func encodeRetryPayload(after time.Duration, reason string) ([]byte, error) {
+	if after < 0 {
+		return nil, fmt.Errorf("retry delay must be non-negative")
+	}
+
+	afterNanos := uint64(after)
+	reasonBytes := []byte(reason)
+
+	records := []tlv.Record{
+		tlv.MakePrimitiveRecord(
+			retryPayloadAfterNanosRecordType, &afterNanos,
+		),
+		tlv.MakePrimitiveRecord(
+			retryPayloadReasonRecordType, &reasonBytes,
+		),
 	}
 
 	stream, err := tlv.NewStream(records...)

--- a/oor/outbox_messages_test.go
+++ b/oor/outbox_messages_test.go
@@ -2,6 +2,7 @@ package oor
 
 import (
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -124,6 +125,53 @@ func TestOutboxToProtoSendIncomingAckRequest(t *testing.T) {
 	require.Equal(
 		t,
 		oorOutboxProtoTypeURLPrefix+"SendIncomingAckRequest",
+		anyMsg.TypeUrl,
+	)
+	require.NotEmpty(t, anyMsg.Value)
+}
+
+// TestOutboxToProtoScheduleRetryRequest verifies that a schedule-retry
+// outbox request serializes into the expected proto Any envelope.
+func TestOutboxToProtoScheduleRetryRequest(t *testing.T) {
+	t.Parallel()
+
+	msg := &ScheduleRetryRequest{
+		After:  2 * time.Second,
+		Reason: "transport timeout",
+	}
+
+	protoMsg := msg.ToProto()
+	require.IsType(t, &anypb.Any{}, protoMsg)
+
+	anyMsg, ok := protoMsg.(*anypb.Any)
+	require.True(t, ok)
+	require.Equal(
+		t,
+		oorOutboxProtoTypeURLPrefix+"ScheduleRetryRequest",
+		anyMsg.TypeUrl,
+	)
+	require.NotEmpty(t, anyMsg.Value)
+}
+
+// TestOutboxToProtoScheduleRetryRequestNegativeDelay verifies that a
+// schedule-retry request with a negative delay produces an error-typed
+// proto envelope.
+func TestOutboxToProtoScheduleRetryRequestNegativeDelay(t *testing.T) {
+	t.Parallel()
+
+	msg := &ScheduleRetryRequest{
+		After:  -1 * time.Second,
+		Reason: "transport timeout",
+	}
+
+	protoMsg := msg.ToProto()
+	require.IsType(t, &anypb.Any{}, protoMsg)
+
+	anyMsg, ok := protoMsg.(*anypb.Any)
+	require.True(t, ok)
+	require.Equal(
+		t,
+		oorOutboxProtoTypeURLPrefix+"ScheduleRetryRequest.error",
 		anyMsg.TypeUrl,
 	)
 	require.NotEmpty(t, anyMsg.Value)

--- a/oor/outgoing_snapshot.go
+++ b/oor/outgoing_snapshot.go
@@ -123,8 +123,8 @@ func NewOutgoingSnapshot(sessionID SessionID, state State) (*OutgoingSnapshot,
 
 	switch s := state.(type) {
 	case *AwaitingArkSignatures:
-		// Snapshot the deterministic submit package before submit is sent so
-		// resume can re-drive Ark signing without rebuilding artifacts.
+		// Snapshot deterministic submit artifacts before submit.
+		// This lets resume re-drive Ark signing without rebuilding.
 		snap.Phase = OutgoingPhaseArkSignRequested
 
 		ark, err := psbtutil.Serialize(s.ArkPSBT)
@@ -218,8 +218,8 @@ func NewOutgoingSnapshot(sessionID SessionID, state State) (*OutgoingSnapshot,
 
 	case *AwaitingLocalVTXOUpdate:
 		// This phase is an off-chain bookkeeping step: after the server
-		// accepts finalize, the local wallet must update its VTXO store to
-		// reflect that the inputs are spent.
+		// accepts finalize, the local wallet must update local state.
+		// That update reflects that the inputs are spent.
 		snap.Phase = OutgoingPhaseLocalVTXOUpdate
 		snap.InputOutpoints = s.InputOutpoints
 

--- a/oor/outgoing_snapshot.go
+++ b/oor/outgoing_snapshot.go
@@ -3,6 +3,7 @@ package oor
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/wire"
@@ -17,6 +18,11 @@ import (
 type OutgoingPhase string
 
 const (
+	// OutgoingPhaseArkSignRequested indicates the submit package has been
+	// built and the client must attach Ark signatures before submit can be
+	// sent.
+	OutgoingPhaseArkSignRequested OutgoingPhase = "ark_sign_requested"
+
 	// OutgoingPhaseSubmitSent indicates the client has built the submit
 	// package and is waiting for the server to accept/co-sign it.
 	OutgoingPhaseSubmitSent OutgoingPhase = "submit_sent"
@@ -29,9 +35,13 @@ const (
 	// checkpoints and is awaiting server acknowledgement.
 	OutgoingPhaseFinalizeSent OutgoingPhase = "finalize_sent"
 
-	// OutgoingPhaseLocalVTXOUpdate indicates finalize was accepted, but the
-	// client still needs to update local VTXO state.
+	// OutgoingPhaseLocalVTXOUpdate indicates the server accepted finalize
+	// and the client is updating its local VTXO persistence state.
 	OutgoingPhaseLocalVTXOUpdate OutgoingPhase = "local_vtxo_update"
+
+	// OutgoingPhaseRetryBackoff indicates the client is waiting to retry a
+	// previously failed outbox request.
+	OutgoingPhaseRetryBackoff OutgoingPhase = "retry_backoff"
 
 	// OutgoingPhaseCompleted indicates the transfer is fully complete.
 	OutgoingPhaseCompleted OutgoingPhase = "completed"
@@ -77,9 +87,17 @@ type OutgoingSnapshot struct {
 	// TransferInputs.
 	TransferInputSnapshots []*TransferInputSnapshot
 
-	// InputOutpoints are the VTXO inputs consumed by this transfer
-	// session.
+	// InputOutpoints are the VTXO outpoints consumed by this session.
+	//
+	// This is required to support crash-resilient local persistence
+	// after the server accepts finalize.
 	InputOutpoints []wire.OutPoint
+
+	// RetryAfter is the requested delay in retry backoff phases.
+	RetryAfter time.Duration
+
+	// ResumeSnapshot is the snapshot to restore after retry backoff.
+	ResumeSnapshot *OutgoingSnapshot
 
 	// FailReason is the terminal failure reason, when Phase is
 	// Failed.
@@ -99,11 +117,35 @@ func NewOutgoingSnapshot(sessionID SessionID, state State) (*OutgoingSnapshot,
 	}
 
 	snap := &OutgoingSnapshot{
-		Version:   2,
+		Version:   3,
 		SessionID: sessionID,
 	}
 
 	switch s := state.(type) {
+	case *AwaitingArkSignatures:
+		// Snapshot the deterministic submit package before submit is sent so
+		// resume can re-drive Ark signing without rebuilding artifacts.
+		snap.Phase = OutgoingPhaseArkSignRequested
+
+		ark, err := psbtutil.Serialize(s.ArkPSBT)
+		if err != nil {
+			return nil, err
+		}
+		snap.ArkPSBT = ark
+
+		cps, err := serializePSBTSlice(s.CheckpointPSBTs)
+		if err != nil {
+			return nil, err
+		}
+		snap.CheckpointPSBTs = cps
+		snap.TransferInputs = s.TransferInputs
+		inputSnaps, err := snapshotTransferInputs(s.TransferInputs)
+		if err != nil {
+			return nil, err
+		}
+		snap.TransferInputSnapshots = inputSnaps
+		snap.InputOutpoints = s.InputOutpoints
+
 	case *AwaitingSubmitAccepted:
 		// Snapshot the entire submit package because it is the
 		// canonical v0 payload, and the natural unit for idempotence.
@@ -129,6 +171,7 @@ func NewOutgoingSnapshot(sessionID SessionID, state State) (*OutgoingSnapshot,
 		if err != nil {
 			return nil, err
 		}
+		snap.InputOutpoints = s.InputOutpoints
 
 	case *AwaitingCheckpointSignatures:
 		// This is the "point-of-no-return" state from the client's
@@ -153,6 +196,7 @@ func NewOutgoingSnapshot(sessionID SessionID, state State) (*OutgoingSnapshot,
 		if err != nil {
 			return nil, err
 		}
+		snap.InputOutpoints = s.InputOutpoints
 
 	case *AwaitingFinalizeAccepted:
 		// Once finalize is sent, the client should only need the
@@ -173,6 +217,9 @@ func NewOutgoingSnapshot(sessionID SessionID, state State) (*OutgoingSnapshot,
 		snap.InputOutpoints = s.InputOutpoints
 
 	case *AwaitingLocalVTXOUpdate:
+		// This phase is an off-chain bookkeeping step: after the server
+		// accepts finalize, the local wallet must update its VTXO store to
+		// reflect that the inputs are spent.
 		snap.Phase = OutgoingPhaseLocalVTXOUpdate
 		snap.InputOutpoints = s.InputOutpoints
 
@@ -186,6 +233,16 @@ func NewOutgoingSnapshot(sessionID SessionID, state State) (*OutgoingSnapshot,
 		snap.Phase = OutgoingPhaseFailed
 		snap.FailReason = s.Reason
 
+	case *RetryBackoff:
+		// RetryBackoff wraps another snapshot to support restart-safe
+		// retry.
+		// The intent is:
+		// 1) store the original "resume snapshot" that is safe to retry
+		// 2) store the requested delay and reason for UI/telemetry
+		snap.Phase = OutgoingPhaseRetryBackoff
+		snap.ResumeSnapshot = s.ResumeSnapshot
+		snap.RetryAfter = s.RetryAfter
+		snap.FailReason = s.Reason
 	default:
 		return nil, fmt.Errorf("unsupported outgoing state type: %T",
 			state)
@@ -237,6 +294,30 @@ func OutgoingStateFromSnapshot(snapshot *OutgoingSnapshot) (State, error) {
 	}
 
 	switch snapshot.Phase {
+	case OutgoingPhaseArkSignRequested:
+		ark, cps, err := parseOutgoingPSBTs(snapshot.ArkPSBT,
+			snapshot.CheckpointPSBTs)
+		if err != nil {
+			return nil, err
+		}
+
+		err = requireSessionIDMatchesArk(snapshot.SessionID, ark)
+		if err != nil {
+			return nil, err
+		}
+
+		inputs, err := restoreTransferInputs(snapshot)
+		if err != nil {
+			return nil, err
+		}
+
+		return &AwaitingArkSignatures{
+			InputOutpoints:  snapshot.InputOutpoints,
+			ArkPSBT:         ark,
+			CheckpointPSBTs: cps,
+			TransferInputs:  inputs,
+		}, nil
+
 	case OutgoingPhaseSubmitSent:
 		ark, cps, err := parseOutgoingPSBTs(
 			snapshot.ArkPSBT, snapshot.CheckpointPSBTs,
@@ -256,6 +337,7 @@ func OutgoingStateFromSnapshot(snapshot *OutgoingSnapshot) (State, error) {
 		}
 
 		return &AwaitingSubmitAccepted{
+			InputOutpoints:  snapshot.InputOutpoints,
 			ArkPSBT:         ark,
 			CheckpointPSBTs: cps,
 			TransferInputs:  inputs,
@@ -281,6 +363,7 @@ func OutgoingStateFromSnapshot(snapshot *OutgoingSnapshot) (State, error) {
 
 		return &AwaitingCheckpointSignatures{
 			SessionID:               snapshot.SessionID,
+			InputOutpoints:          snapshot.InputOutpoints,
 			ArkPSBT:                 ark,
 			CoSignedCheckpointPSBTs: cps,
 			TransferInputs:          inputs,
@@ -307,9 +390,29 @@ func OutgoingStateFromSnapshot(snapshot *OutgoingSnapshot) (State, error) {
 		}, nil
 
 	case OutgoingPhaseLocalVTXOUpdate:
+		if len(snapshot.InputOutpoints) == 0 {
+			return nil, fmt.Errorf("input outpoints required")
+		}
+
 		return &AwaitingLocalVTXOUpdate{
 			SessionID:      snapshot.SessionID,
 			InputOutpoints: snapshot.InputOutpoints,
+		}, nil
+
+	case OutgoingPhaseRetryBackoff:
+		if snapshot.ResumeSnapshot == nil {
+			return nil, fmt.Errorf("resume snapshot required")
+		}
+
+		after := snapshot.RetryAfter
+		if after == 0 {
+			after = 1 * time.Second
+		}
+
+		return &RetryBackoff{
+			ResumeSnapshot: snapshot.ResumeSnapshot,
+			RetryAfter:     after,
+			Reason:         snapshot.FailReason,
 		}, nil
 
 	case OutgoingPhaseCompleted:

--- a/oor/outgoing_snapshot_codec.go
+++ b/oor/outgoing_snapshot_codec.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"math"
+	"time"
 
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/tlv"
@@ -22,6 +23,8 @@ const (
 	snapshotCheckpointPSBTsRecordType tlv.Type = 9
 	snapshotTransferInputsRecordType  tlv.Type = 11
 	snapshotInputOutpointsRecordType  tlv.Type = 13
+	snapshotRetryAfterNanosRecordType tlv.Type = 15
+	snapshotResumeSnapshotRecordType  tlv.Type = 17
 	snapshotFailReasonRecordType      tlv.Type = 19
 )
 
@@ -142,7 +145,18 @@ func encodeOutgoingSnapshot(snapshot *OutgoingSnapshot) ([]byte, error) {
 		return nil, err
 	}
 
+	retryAfterNanos := uint64(snapshot.RetryAfter)
 	failReason := []byte(snapshot.FailReason)
+
+	var resumeSnapshot []byte
+	if snapshot.ResumeSnapshot != nil {
+		resumeSnapshot, err = encodeOutgoingSnapshot(
+			snapshot.ResumeSnapshot,
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	version := uint64(snapshot.Version)
 	records := []tlv.Record{
@@ -160,6 +174,12 @@ func encodeOutgoingSnapshot(snapshot *OutgoingSnapshot) ([]byte, error) {
 		),
 		tlv.MakePrimitiveRecord(
 			snapshotInputOutpointsRecordType, &outpointsRaw,
+		),
+		tlv.MakePrimitiveRecord(
+			snapshotRetryAfterNanosRecordType, &retryAfterNanos,
+		),
+		tlv.MakePrimitiveRecord(
+			snapshotResumeSnapshotRecordType, &resumeSnapshot,
 		),
 		tlv.MakePrimitiveRecord(
 			snapshotFailReasonRecordType, &failReason,
@@ -188,6 +208,8 @@ func decodeOutgoingSnapshot(raw []byte) (*OutgoingSnapshot, error) {
 		checkpointPSBTsRaw []byte
 		inputSnapshotsRaw  []byte
 		outpointsRaw       []byte
+		retryAfterNanos    uint64
+		resumeSnapshotRaw  []byte
 		failReasonRaw      []byte
 	)
 
@@ -206,6 +228,12 @@ func decodeOutgoingSnapshot(raw []byte) (*OutgoingSnapshot, error) {
 		),
 		tlv.MakePrimitiveRecord(
 			snapshotInputOutpointsRecordType, &outpointsRaw,
+		),
+		tlv.MakePrimitiveRecord(
+			snapshotRetryAfterNanosRecordType, &retryAfterNanos,
+		),
+		tlv.MakePrimitiveRecord(
+			snapshotResumeSnapshotRecordType, &resumeSnapshotRaw,
 		),
 		tlv.MakePrimitiveRecord(
 			snapshotFailReasonRecordType, &failReasonRaw,
@@ -255,7 +283,22 @@ func decodeOutgoingSnapshot(raw []byte) (*OutgoingSnapshot, error) {
 		arkPSBT = nil
 	}
 
+	var resumeSnapshot *OutgoingSnapshot
+	if len(resumeSnapshotRaw) != 0 {
+		resumeSnapshot, err = decodeOutgoingSnapshot(resumeSnapshotRaw)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	decodedVersion, err := decodeUint64ToUint8(version, "snapshot version")
+	if err != nil {
+		return nil, err
+	}
+
+	decodedRetryAfter, err := decodeUint64ToDuration(
+		retryAfterNanos, "snapshot retry_after nanos",
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -268,6 +311,8 @@ func decodeOutgoingSnapshot(raw []byte) (*OutgoingSnapshot, error) {
 		CheckpointPSBTs:        checkpointPSBTs,
 		TransferInputSnapshots: inputSnapshots,
 		InputOutpoints:         outpoints,
+		RetryAfter:             decodedRetryAfter,
+		ResumeSnapshot:         resumeSnapshot,
 		FailReason:             string(failReasonRaw),
 	}, nil
 }
@@ -315,4 +360,14 @@ func decodeUint64ToInt(value uint64, field string) (int, error) {
 	}
 
 	return int(value), nil
+}
+
+func decodeUint64ToDuration(value uint64, field string) (time.Duration, error) {
+	if value > math.MaxInt64 {
+		return 0, fmt.Errorf(
+			"%s overflows time.Duration: %d", field, value,
+		)
+	}
+
+	return time.Duration(int64(value)), nil
 }

--- a/oor/outgoing_snapshot_codec_test.go
+++ b/oor/outgoing_snapshot_codec_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"math"
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
@@ -40,6 +41,12 @@ func TestOutgoingSnapshotTLVRoundTrip(t *testing.T) {
 				Hash:  chainhash.Hash{12, 13, 14},
 				Index: 15,
 			},
+		},
+		RetryAfter: 3 * time.Second,
+		ResumeSnapshot: &OutgoingSnapshot{
+			Version:   3,
+			SessionID: SessionID(chainhash.Hash{16, 17}),
+			Phase:     OutgoingPhaseCompleted,
 		},
 		FailReason: "retry later",
 	}
@@ -101,12 +108,26 @@ func TestDecodeOutgoingSnapshotRejectsVersionOverflow(t *testing.T) {
 	t.Parallel()
 
 	raw, err := encodeSnapshotRawForDecodeTest(
-		uint64(math.MaxUint8) + 1,
+		uint64(math.MaxUint8)+1, 0,
 	)
 	require.NoError(t, err)
 
 	_, err = decodeOutgoingSnapshot(raw)
 	require.ErrorContains(t, err, "snapshot version overflows uint8")
+}
+
+func TestDecodeOutgoingSnapshotRejectsRetryAfterOverflow(t *testing.T) {
+	t.Parallel()
+
+	raw, err := encodeSnapshotRawForDecodeTest(
+		2, uint64(math.MaxInt64)+1,
+	)
+	require.NoError(t, err)
+
+	_, err = decodeOutgoingSnapshot(raw)
+	require.ErrorContains(
+		t, err, "snapshot retry_after nanos overflows time.Duration",
+	)
 }
 
 func TestDecodeOutgoingCheckpointRejectsVersionOverflow(t *testing.T) {
@@ -133,7 +154,9 @@ func TestDecodeOutgoingCheckpointRejectsVersionOverflow(t *testing.T) {
 	require.ErrorContains(t, err, "checkpoint version overflows int")
 }
 
-func encodeSnapshotRawForDecodeTest(version uint64) ([]byte, error) {
+func encodeSnapshotRawForDecodeTest(version uint64,
+	retryAfterNanos uint64) ([]byte, error) {
+
 	sessionBytes := sessionIDBytes(SessionID(chainhash.Hash{1}))
 	phaseBytes := []byte(OutgoingPhaseCompleted)
 	arkPSBT := []byte(nil)
@@ -153,6 +176,7 @@ func encodeSnapshotRawForDecodeTest(version uint64) ([]byte, error) {
 		return nil, err
 	}
 
+	resumeSnapshotRaw := []byte(nil)
 	failReasonRaw := []byte(nil)
 
 	records := []tlv.Record{
@@ -170,6 +194,12 @@ func encodeSnapshotRawForDecodeTest(version uint64) ([]byte, error) {
 		),
 		tlv.MakePrimitiveRecord(
 			snapshotInputOutpointsRecordType, &outpointsRaw,
+		),
+		tlv.MakePrimitiveRecord(
+			snapshotRetryAfterNanosRecordType, &retryAfterNanos,
+		),
+		tlv.MakePrimitiveRecord(
+			snapshotResumeSnapshotRecordType, &resumeSnapshotRaw,
 		),
 		tlv.MakePrimitiveRecord(
 			snapshotFailReasonRecordType, &failReasonRaw,

--- a/oor/receive_session.go
+++ b/oor/receive_session.go
@@ -21,6 +21,10 @@ type ReceiveSession struct {
 //
 // The caller should drive the returned FSM by sending an IncomingTransferEvent
 // (or by using DriveIncomingTransfer).
+//
+// Ownership checks are intentionally deferred to the incoming materialization
+// boundary (LocalPersistenceOutboxHandler + resolver callbacks), where wallet
+// key ownership is available.
 func NewReceiveSession(ctx context.Context, ark *psbt.Packet,
 	sessionID SessionID) (*ReceiveSession, error) {
 
@@ -58,14 +62,26 @@ func NewReceiveSession(ctx context.Context, ark *psbt.Packet,
 func DriveIncomingTransfer(ctx context.Context, sessionID SessionID,
 	ark *psbt.Packet) (*ReceiveSession, []OutboxEvent, error) {
 
+	return DriveIncomingTransferWithCheckpoints(
+		ctx, sessionID, ark, nil,
+	)
+}
+
+// DriveIncomingTransferWithCheckpoints is DriveIncomingTransfer with optional
+// finalized checkpoints attached to the incoming event.
+func DriveIncomingTransferWithCheckpoints(ctx context.Context,
+	sessionID SessionID, ark *psbt.Packet,
+	finalCheckpoints []*psbt.Packet) (*ReceiveSession, []OutboxEvent, error) {
+
 	sess, err := NewReceiveSession(ctx, ark, sessionID)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	fut := sess.FSM.AskEvent(ctx, &IncomingTransferEvent{
-		SessionID: sessionID,
-		ArkPSBT:   ark,
+		SessionID:            sessionID,
+		ArkPSBT:              ark,
+		FinalCheckpointPSBTs: finalCheckpoints,
 	})
 
 	result := fut.Await(ctx)

--- a/oor/receive_session.go
+++ b/oor/receive_session.go
@@ -71,7 +71,8 @@ func DriveIncomingTransfer(ctx context.Context, sessionID SessionID,
 // finalized checkpoints attached to the incoming event.
 func DriveIncomingTransferWithCheckpoints(ctx context.Context,
 	sessionID SessionID, ark *psbt.Packet,
-	finalCheckpoints []*psbt.Packet) (*ReceiveSession, []OutboxEvent, error) {
+	finalCheckpoints []*psbt.Packet) (
+	*ReceiveSession, []OutboxEvent, error) {
 
 	sess, err := NewReceiveSession(ctx, ark, sessionID)
 	if err != nil {

--- a/oor/receive_session_test.go
+++ b/oor/receive_session_test.go
@@ -14,10 +14,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestReceiveSessionNotifiesAndAcks verifies the incoming-transfer FSM emits
-// notification, materialization and ack outbox messages for a canonical Ark
-// transfer.
-func TestReceiveSessionNotifiesAndAcks(t *testing.T) {
+// TestReceiveSessionNotifiesThenMaterializes verifies the incoming-transfer FSM
+// emits notification/materialization first, deferring ack until after incoming
+// materialization is confirmed.
+func TestReceiveSessionNotifiesThenMaterializes(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
@@ -29,7 +29,7 @@ func TestReceiveSessionNotifiesAndAcks(t *testing.T) {
 	// session:
 	// - emits an application-facing notification
 	// - requests recipient materialization into local VTXO state
-	// - requests an ack back to the server (transport boundary)
+	// Ack is emitted only after materialization is confirmed.
 	operatorKey, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
 
@@ -102,7 +102,7 @@ func TestReceiveSessionNotifiesAndAcks(t *testing.T) {
 
 	_, outbox, err := DriveIncomingTransfer(ctx, sessionID, arkPSBT)
 	require.NoError(t, err)
-	require.Len(t, outbox, 3)
+	require.Len(t, outbox, 2)
 
 	_, ok := outbox[0].(*IncomingTransferNotification)
 	require.True(t, ok)
@@ -110,9 +110,7 @@ func TestReceiveSessionNotifiesAndAcks(t *testing.T) {
 	materializeMsg, ok := outbox[1].(*MaterializeIncomingVTXOsRequest)
 	require.True(t, ok)
 	require.NotEmpty(t, materializeMsg.Recipients)
-
-	_, ok = outbox[2].(*SendIncomingAckRequest)
-	require.True(t, ok)
+	parentCommitment := inputs[0].SpentVTXO.Outpoint.Hash
 
 	desc, err := BuildIncomingVTXODescriptor(materializeMsg.ArkPSBT,
 		IncomingVTXOConfig{
@@ -122,10 +120,48 @@ func TestReceiveSessionNotifiesAndAcks(t *testing.T) {
 			},
 			OperatorKey: policy.OperatorKey,
 			ExitDelay:   exitDelay,
+			Metadata: IncomingVTXOMetadata{
+				CommitmentTxID: parentCommitment,
+				RoundID:        "round-test",
+				BatchExpiry:    100,
+				TreeDepth:      1,
+				CreatedHeight:  50,
+			},
 		},
 	)
 	require.NoError(t, err)
 	require.Equal(t, recipientPkScript, desc.PkScript)
 	require.Equal(t, inputValue, desc.Amount)
 	require.Equal(t, vtxo.VTXOStatusLive, desc.Status)
+}
+
+// TestReceiveSessionAcksAfterHandled asserts ack is emitted only after the
+// application confirms materialization completion.
+func TestReceiveSessionAcksAfterHandled(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	arkPSBT, _, _, _, _ := buildTestIncomingMaterialization(t)
+	sessionID := SessionID(arkPSBT.UnsignedTx.TxHash())
+
+	sess, outbox, err := DriveIncomingTransfer(ctx, sessionID, arkPSBT)
+	require.NoError(t, err)
+	require.Len(t, outbox, 2)
+
+	fut := sess.FSM.AskEvent(ctx, &IncomingHandledEvent{})
+	result := fut.Await(ctx)
+	require.False(t, result.IsErr())
+
+	ackOutbox := result.UnwrapOr(nil)
+	require.Len(t, ackOutbox, 1)
+	require.IsType(t, &SendIncomingAckRequest{}, ackOutbox[0])
+
+	fut = sess.FSM.AskEvent(ctx, &IncomingAckSentEvent{})
+	result = fut.Await(ctx)
+	require.False(t, result.IsErr())
+
+	finalState, err := sess.FSM.CurrentState()
+	require.NoError(t, err)
+	require.IsType(t, &ReceiveCompleted{}, finalState)
 }

--- a/oor/receive_states.go
+++ b/oor/receive_states.go
@@ -52,6 +52,25 @@ func (s *ReceiveNotified) IsTerminal() bool {
 // receiveStateSealed marks ReceiveNotified as implementing ReceiveState.
 func (s *ReceiveNotified) receiveStateSealed() {}
 
+// ReceiveAwaitingAck indicates incoming VTXOs were materialized locally and the
+// client is waiting for ack transport completion.
+type ReceiveAwaitingAck struct {
+	SessionID SessionID
+}
+
+// String returns a human-readable representation of ReceiveAwaitingAck.
+func (s *ReceiveAwaitingAck) String() string {
+	return "ReceiveAwaitingAck"
+}
+
+// IsTerminal returns false as ReceiveAwaitingAck is not terminal.
+func (s *ReceiveAwaitingAck) IsTerminal() bool {
+	return false
+}
+
+// receiveStateSealed marks ReceiveAwaitingAck as implementing ReceiveState.
+func (s *ReceiveAwaitingAck) receiveStateSealed() {}
+
 // ReceiveCompleted is the terminal success state for an incoming transfer.
 type ReceiveCompleted struct{}
 

--- a/oor/receive_transitions.go
+++ b/oor/receive_transitions.go
@@ -90,8 +90,11 @@ func (s *ReceiveIdle) ProcessEvent(ctx context.Context, event Event,
 
 		// The outbox is intentionally ordered:
 		//   1) notify the app/UI so it can show the transfer;
-		//   2) materialize incoming VTXOs into local state; and
-		//   3) ack receipt to the server (best-effort, idempotent).
+		//   2) materialize incoming VTXOs into local state.
+		//
+		// Ack is emitted only after the application confirms incoming
+		// handling to avoid acknowledging transfers that were not
+		// durably materialized yet.
 		return &StateTransition{
 			NextState: &ReceiveNotified{
 				SessionID: evt.SessionID,
@@ -105,12 +108,11 @@ func (s *ReceiveIdle) ProcessEvent(ctx context.Context, event Event,
 						Recipients: recipients,
 					},
 					&MaterializeIncomingVTXOsRequest{
-						SessionID:  evt.SessionID,
-						ArkPSBT:    evt.ArkPSBT,
-						Recipients: recipients,
-					},
-					&SendIncomingAckRequest{
 						SessionID: evt.SessionID,
+						ArkPSBT:   evt.ArkPSBT,
+						FinalCheckpointPSBTs: evt.
+							FinalCheckpointPSBTs,
+						Recipients: recipients,
 					},
 				},
 			}),
@@ -137,12 +139,21 @@ func (s *ReceiveNotified) ProcessEvent(ctx context.Context, event Event,
 	switch evt := event.(type) {
 	case *IncomingHandledEvent:
 		// The application signals it has processed the notification.
-		// Wallet state has been updated (materialization complete).
+		// Wallet state has been updated (materialization complete), so
+		// we can now ack to the server.
 		_ = evt
 
 		return &StateTransition{
-			NextState: &ReceiveCompleted{},
-			NewEvents: fn.None[EmittedEvent](),
+			NextState: &ReceiveAwaitingAck{
+				SessionID: s.SessionID,
+			},
+			NewEvents: fn.Some(EmittedEvent{
+				Outbox: []OutboxEvent{
+					&SendIncomingAckRequest{
+						SessionID: s.SessionID,
+					},
+				},
+			}),
 		}, nil
 
 	case *FailEvent:
@@ -164,4 +175,31 @@ func (s *ReceiveCompleted) ProcessEvent(ctx context.Context, event Event,
 	_ = env
 
 	return unexpectedReceiveEvent(s, event), nil
+}
+
+// ProcessEvent handles events for ReceiveAwaitingAck.
+func (s *ReceiveAwaitingAck) ProcessEvent(ctx context.Context, event Event,
+	env *Environment) (*StateTransition, error) {
+
+	_ = ctx
+	_ = env
+
+	switch evt := event.(type) {
+	case *IncomingAckSentEvent:
+		_ = evt
+
+		return &StateTransition{
+			NextState: &ReceiveCompleted{},
+			NewEvents: fn.None[EmittedEvent](),
+		}, nil
+
+	case *FailEvent:
+		return &StateTransition{
+			NextState: &Failed{Reason: evt.Reason},
+			NewEvents: fn.None[EmittedEvent](),
+		}, nil
+
+	default:
+		return unexpectedReceiveEvent(s, event), nil
+	}
 }

--- a/oor/resume.go
+++ b/oor/resume.go
@@ -9,14 +9,21 @@ import (
 //
 // This is used to support explicit retry/resume logic: after a restart, the app
 // can either rely on durable-actor restart handling or explicitly call
-// ResumeSessionRequest to re-send the submit/finalize request (or re-request
-// checkpoint signing).
+// submit/finalize request (or re-request signing steps).
 func OutboxForState(state State) ([]OutboxEvent, error) {
 	if state == nil {
 		return nil, fmt.Errorf("state must be provided")
 	}
 
 	switch s := state.(type) {
+	case *AwaitingArkSignatures:
+		return []OutboxEvent{
+			&RequestArkSignatures{
+				ArkPSBT:        s.ArkPSBT,
+				TransferInputs: s.TransferInputs,
+			},
+		}, nil
+
 	case *AwaitingSubmitAccepted:
 		return []OutboxEvent{
 			&SendSubmitPackageRequest{
@@ -58,7 +65,6 @@ func OutboxForState(state State) ([]OutboxEvent, error) {
 				Reason: s.Reason,
 			},
 		}, nil
-
 	case *Completed, *Failed:
 		return nil, nil
 

--- a/oor/resume.go
+++ b/oor/resume.go
@@ -51,6 +51,14 @@ func OutboxForState(state State) ([]OutboxEvent, error) {
 			},
 		}, nil
 
+	case *RetryBackoff:
+		return []OutboxEvent{
+			&ScheduleRetryRequest{
+				After:  s.RetryAfter,
+				Reason: s.Reason,
+			},
+		}, nil
+
 	case *Completed, *Failed:
 		return nil, nil
 

--- a/oor/retry.go
+++ b/oor/retry.go
@@ -1,0 +1,85 @@
+package oor
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// RetryableOutboxError wraps an error and marks it as retryable.
+//
+// The actor wrapper interprets this to mean it should feed an OutboxErrorEvent
+// into the FSM with Retryable=true rather than failing the call.
+type RetryableOutboxError struct {
+	Err        error
+	RetryAfter time.Duration
+}
+
+// Error returns the string representation of the wrapped error.
+func (e *RetryableOutboxError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+
+	if e.Err == nil {
+		return "retryable outbox error"
+	}
+
+	return fmt.Sprintf("retryable outbox error: %v", e.Err)
+}
+
+// Unwrap returns the wrapped error.
+func (e *RetryableOutboxError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+
+	return e.Err
+}
+
+// NewRetryableOutboxError creates a RetryableOutboxError wrapper.
+func NewRetryableOutboxError(err error, retryAfter time.Duration) error {
+	if err == nil {
+		return &RetryableOutboxError{
+			Err:        fmt.Errorf("unknown error"),
+			RetryAfter: retryAfter,
+		}
+	}
+
+	return &RetryableOutboxError{
+		Err:        err,
+		RetryAfter: retryAfter,
+	}
+}
+
+// NewOutboxErrorEvent converts an outbox execution error into an FSM event.
+func NewOutboxErrorEvent(outbox OutboxEvent, err error) *OutboxErrorEvent {
+	outboxType := ""
+	if outbox != nil {
+		outboxType = outbox.outboxType()
+	}
+
+	// The retry behavior is encoded in the event rather than by returning a
+	// different Go error type from the actor. This keeps the actor boundary
+	// simple: every outbox failure maps to a deterministic event, and the
+	// FSM decides whether to back off or fail terminally.
+	retryAfter, retryable := retryableOutboxParams(err)
+
+	return &OutboxErrorEvent{
+		OutboxType:  outboxType,
+		Retryable:   retryable,
+		RetryAfter:  retryAfter,
+		ErrorReason: err.Error(),
+	}
+}
+
+// retryableOutboxParams returns the retry delay and whether the error is
+// retryable.
+func retryableOutboxParams(err error) (time.Duration, bool) {
+	var retryErr *RetryableOutboxError
+	if errors.As(err, &retryErr) {
+		return retryErr.RetryAfter, true
+	}
+
+	return 0, false
+}

--- a/oor/session.go
+++ b/oor/session.go
@@ -63,13 +63,20 @@ func NewSession(ctx context.Context, policy scripts.CheckpointPolicy,
 		return nil, nil, err
 	}
 
-	awaitingSubmit, ok := currentState.(*AwaitingSubmitAccepted)
-	if !ok {
+	var arkPSBT *psbt.Packet
+	switch s := currentState.(type) {
+	case *AwaitingArkSignatures:
+		arkPSBT = s.ArkPSBT
+
+	case *AwaitingSubmitAccepted:
+		arkPSBT = s.ArkPSBT
+
+	default:
 		return nil, nil, fmt.Errorf("unexpected start state: %T",
 			currentState)
 	}
 
-	sessionID, err := sessionIDFromArk(awaitingSubmit.ArkPSBT)
+	sessionID, err := sessionIDFromArk(arkPSBT)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/oor/session_test.go
+++ b/oor/session_test.go
@@ -71,11 +71,6 @@ func TestSessionHappyPath(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, arkSignReq.ArkPSBT)
 
-	err = coSignCheckpointPSBTsForTest(
-		operatorSigner, submit.TransferInputs, submit.CheckpointPSBTs,
-	)
-	require.NoError(t, err)
-
 	state, err := session.FSM.CurrentState()
 	require.NoError(t, err)
 	_, ok = state.(*AwaitingArkSignatures)
@@ -94,6 +89,11 @@ func TestSessionHappyPath(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, submit.ArkPSBT)
 	require.NotEmpty(t, submit.CheckpointPSBTs)
+
+	err = coSignCheckpointPSBTsForTest(
+		operatorSigner, submit.TransferInputs, submit.CheckpointPSBTs,
+	)
+	require.NoError(t, err)
 
 	// Step 2: Server accepts submit and returns co-signed checkpoints.
 	fut = session.FSM.AskEvent(ctx, &SubmitAcceptedEvent{

--- a/oor/session_test.go
+++ b/oor/session_test.go
@@ -62,14 +62,14 @@ func TestSessionHappyPath(t *testing.T) {
 	require.NotNil(t, session)
 	require.NotEmpty(t, outbox)
 
-	// Creating a new session always emits a submit outbox message. The FSM
-	// itself never calls the network; the caller must perform the side
-	// effect and then feed the result back as an event.
+	// Creating a new session first emits an Ark-sign outbox request.
+	// The FSM itself never calls the signer/network.
+	// The caller must perform the side effect and then feed the result
+	// back as an event.
 	require.Len(t, outbox, 1)
-	submit, ok := outbox[0].(*SendSubmitPackageRequest)
+	arkSignReq, ok := outbox[0].(*RequestArkSignatures)
 	require.True(t, ok)
-	require.NotNil(t, submit.ArkPSBT)
-	require.NotEmpty(t, submit.CheckpointPSBTs)
+	require.NotNil(t, arkSignReq.ArkPSBT)
 
 	err = coSignCheckpointPSBTsForTest(
 		operatorSigner, submit.TransferInputs, submit.CheckpointPSBTs,
@@ -78,25 +78,39 @@ func TestSessionHappyPath(t *testing.T) {
 
 	state, err := session.FSM.CurrentState()
 	require.NoError(t, err)
-	_, ok = state.(*AwaitingSubmitAccepted)
+	_, ok = state.(*AwaitingArkSignatures)
 	require.True(t, ok)
 
-	// Step 1: Server accepts submit and returns co-signed checkpoints.
-	fut := session.FSM.AskEvent(ctx, &SubmitAcceptedEvent{
-		SessionID:               session.ID,
-		ArkPSBT:                 submit.ArkPSBT,
-		CoSignedCheckpointPSBTs: submit.CheckpointPSBTs,
+	// Step 1: Ark signatures are attached before submit is sent.
+	fut := session.FSM.AskEvent(ctx, &ArkSignedEvent{
+		ArkPSBT: arkSignReq.ArkPSBT,
 	})
 	result := fut.Await(ctx)
 	require.False(t, result.IsErr())
 
 	submitOutbox := result.UnwrapOr(nil)
 	require.Len(t, submitOutbox, 1)
-	signReq, ok := submitOutbox[0].(*RequestCheckpointSignatures)
+	submit, ok := submitOutbox[0].(*SendSubmitPackageRequest)
+	require.True(t, ok)
+	require.NotNil(t, submit.ArkPSBT)
+	require.NotEmpty(t, submit.CheckpointPSBTs)
+
+	// Step 2: Server accepts submit and returns co-signed checkpoints.
+	fut = session.FSM.AskEvent(ctx, &SubmitAcceptedEvent{
+		SessionID:               session.ID,
+		ArkPSBT:                 submit.ArkPSBT,
+		CoSignedCheckpointPSBTs: submit.CheckpointPSBTs,
+	})
+	result = fut.Await(ctx)
+	require.False(t, result.IsErr())
+
+	signOutbox := result.UnwrapOr(nil)
+	require.Len(t, signOutbox, 1)
+	signReq, ok := signOutbox[0].(*RequestCheckpointSignatures)
 	require.True(t, ok)
 	require.NotEmpty(t, signReq.TransferInputs)
 
-	// Step 2: Wallet attaches client signatures to checkpoints.
+	// Step 3: Wallet attaches client signatures to checkpoints.
 	//
 	// This is the local signing boundary: no network calls are required,
 	// but the signing implementation is still modeled as a side effect
@@ -118,7 +132,7 @@ func TestSessionHappyPath(t *testing.T) {
 	_, ok = finalizeOutbox[0].(*SendFinalizePackageRequest)
 	require.True(t, ok)
 
-	// Step 3: Server accepts finalize and updates VTXO set.
+	// Step 4: Server accepts finalize and updates VTXO set.
 	fut = session.FSM.AskEvent(ctx, &FinalizeAcceptedEvent{})
 	result = fut.Await(ctx)
 	require.False(t, result.IsErr())
@@ -128,7 +142,7 @@ func TestSessionHappyPath(t *testing.T) {
 	_, ok = markOutbox[0].(*MarkInputsSpentRequest)
 	require.True(t, ok)
 
-	// Step 4: Client persists that inputs are spent.
+	// Step 5: Client persists that inputs are spent.
 	fut = session.FSM.AskEvent(ctx, &InputsMarkedSpentEvent{})
 	result = fut.Await(ctx)
 	require.False(t, result.IsErr())

--- a/oor/session_test.go
+++ b/oor/session_test.go
@@ -14,6 +14,8 @@ import (
 
 // TestSessionHappyPath exercises the outgoing transfer FSM without the actor
 // wrapper.
+//
+// It asserts the canonical v0 phase progression and final terminal state.
 func TestSessionHappyPath(t *testing.T) {
 	t.Parallel()
 
@@ -60,6 +62,9 @@ func TestSessionHappyPath(t *testing.T) {
 	require.NotNil(t, session)
 	require.NotEmpty(t, outbox)
 
+	// Creating a new session always emits a submit outbox message. The FSM
+	// itself never calls the network; the caller must perform the side
+	// effect and then feed the result back as an event.
 	require.Len(t, outbox, 1)
 	submit, ok := outbox[0].(*SendSubmitPackageRequest)
 	require.True(t, ok)
@@ -92,6 +97,10 @@ func TestSessionHappyPath(t *testing.T) {
 	require.NotEmpty(t, signReq.TransferInputs)
 
 	// Step 2: Wallet attaches client signatures to checkpoints.
+	//
+	// This is the local signing boundary: no network calls are required,
+	// but the signing implementation is still modeled as a side effect
+	// outside the FSM for determinism and testability.
 	err = SignCheckpointPSBTs(
 		clientSigner, signReq.TransferInputs,
 		signReq.CoSignedCheckpointPSBTs,

--- a/oor/states.go
+++ b/oor/states.go
@@ -1,6 +1,8 @@
 package oor
 
 import (
+	"time"
+
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/baselib/protofsm"
@@ -140,6 +142,40 @@ type AwaitingFinalizeAccepted struct {
 	// server.
 	FinalCheckpointPSBTs []*psbt.Packet
 }
+
+// RetryBackoff indicates the client should wait before retrying the outbox
+// request implied by ResumeSnapshot.
+//
+// This state is intended to support retry/backoff without requiring durable
+// timers yet: the outbox boundary can implement ScheduleRetryRequest however it
+// wants (immediate in tests, time-based in apps).
+type RetryBackoff struct {
+	// RetryBackoff is a minimal "timer" state that models backoff without
+	// requiring a dedicated scheduler in the FSM runtime. A future durable
+	// actor runtime can replace this by persisting timers and wakeups.
+
+	// ResumeSnapshot captures the state to restore when the retry is due.
+	ResumeSnapshot *OutgoingSnapshot
+
+	// RetryAfter is the requested backoff delay.
+	RetryAfter time.Duration
+
+	// Reason is a human-readable error reason.
+	Reason string
+}
+
+// String returns a human-readable representation of RetryBackoff.
+func (s *RetryBackoff) String() string {
+	return "RetryBackoff"
+}
+
+// IsTerminal returns false as RetryBackoff is not terminal.
+func (s *RetryBackoff) IsTerminal() bool {
+	return false
+}
+
+// stateSealed marks RetryBackoff as implementing the sealed State interface.
+func (s *RetryBackoff) stateSealed() {}
 
 // String returns a human-readable representation of AwaitingFinalizeAccepted.
 func (s *AwaitingFinalizeAccepted) String() string {

--- a/oor/states.go
+++ b/oor/states.go
@@ -35,6 +35,36 @@ func (s *Idle) IsTerminal() bool {
 // stateSealed marks Idle as implementing the sealed State interface.
 func (s *Idle) stateSealed() {}
 
+// AwaitingArkSignatures indicates the submit package has been built and the
+// client must attach Ark signatures before submit can be sent.
+type AwaitingArkSignatures struct {
+	// InputOutpoints are the VTXO outpoints consumed by this OOR session.
+	InputOutpoints []wire.OutPoint
+
+	// ArkPSBT is the canonical Ark tx PSBT.
+	ArkPSBT *psbt.Packet
+
+	// CheckpointPSBTs are unsigned checkpoint PSBTs for the submit phase.
+	CheckpointPSBTs []*psbt.Packet
+
+	// TransferInputs carry client-side signing context.
+	TransferInputs []TransferInput
+}
+
+// String returns a human-readable representation of AwaitingArkSignatures.
+func (s *AwaitingArkSignatures) String() string {
+	return "AwaitingArkSignatures"
+}
+
+// IsTerminal returns false as AwaitingArkSignatures is not terminal.
+func (s *AwaitingArkSignatures) IsTerminal() bool {
+	return false
+}
+
+// stateSealed marks AwaitingArkSignatures as implementing the sealed State
+// interface.
+func (s *AwaitingArkSignatures) stateSealed() {}
+
 // AwaitingSubmitAccepted is reached after the client has built a submit
 // package and emitted an outbox request to send it to the server.
 type AwaitingSubmitAccepted struct {
@@ -140,8 +170,25 @@ type AwaitingFinalizeAccepted struct {
 
 	// FinalCheckpointPSBTs are the final checkpoint PSBTs sent to the
 	// server.
+	//
+	// These are persisted so resume/unilateral-exit paths can reconstruct
+	// checkpoint lineage without depending on a fresh server response.
 	FinalCheckpointPSBTs []*psbt.Packet
 }
+
+// String returns a human-readable representation of AwaitingFinalizeAccepted.
+func (s *AwaitingFinalizeAccepted) String() string {
+	return "AwaitingFinalizeAccepted"
+}
+
+// IsTerminal returns false as AwaitingFinalizeAccepted is not terminal.
+func (s *AwaitingFinalizeAccepted) IsTerminal() bool {
+	return false
+}
+
+// stateSealed marks AwaitingFinalizeAccepted as implementing the sealed State
+// interface.
+func (s *AwaitingFinalizeAccepted) stateSealed() {}
 
 // RetryBackoff indicates the client should wait before retrying the outbox
 // request implied by ResumeSnapshot.
@@ -176,20 +223,6 @@ func (s *RetryBackoff) IsTerminal() bool {
 
 // stateSealed marks RetryBackoff as implementing the sealed State interface.
 func (s *RetryBackoff) stateSealed() {}
-
-// String returns a human-readable representation of AwaitingFinalizeAccepted.
-func (s *AwaitingFinalizeAccepted) String() string {
-	return "AwaitingFinalizeAccepted"
-}
-
-// IsTerminal returns false as AwaitingFinalizeAccepted is not terminal.
-func (s *AwaitingFinalizeAccepted) IsTerminal() bool {
-	return false
-}
-
-// stateSealed marks AwaitingFinalizeAccepted as implementing the sealed State
-// interface.
-func (s *AwaitingFinalizeAccepted) stateSealed() {}
 
 // AwaitingLocalVTXOUpdate indicates the server has accepted the finalize
 // package and the client must update its local VTXO persistence state.

--- a/oor/transitions.go
+++ b/oor/transitions.go
@@ -320,6 +320,32 @@ func (s *RetryBackoff) ProcessEvent(ctx context.Context,
 	_ = env
 
 	switch evt := event.(type) {
+	case *RetryDueEvent:
+		_ = evt
+
+		if s.ResumeSnapshot == nil {
+			return nil, fmt.Errorf(
+				"resume snapshot must be provided",
+			)
+		}
+
+		nextState, err := OutgoingStateFromSnapshot(s.ResumeSnapshot)
+		if err != nil {
+			return nil, err
+		}
+
+		nextOutbox, err := OutboxForState(nextState)
+		if err != nil {
+			return nil, err
+		}
+
+		return &StateTransition{
+			NextState: nextState,
+			NewEvents: fn.Some(EmittedEvent{
+				Outbox: nextOutbox,
+			}),
+		}, nil
+
 	case *FailEvent:
 		return &StateTransition{
 			NextState: &Failed{Reason: evt.Reason},

--- a/oor/transitions.go
+++ b/oor/transitions.go
@@ -213,7 +213,7 @@ func (s *AwaitingCheckpointSignatures) ProcessEvent(ctx context.Context,
 		}
 
 		// Validate finalize package before emitting request.
-		err = oortx.ValidateFinalizePackageSigned(
+		err = oortx.ValidateFinalizePackage(
 			s.ArkPSBT, evt.FinalCheckpointPSBTs,
 		)
 		if err != nil {
@@ -299,51 +299,6 @@ func (s *AwaitingLocalVTXOUpdate) ProcessEvent(ctx context.Context,
 		return &StateTransition{
 			NextState: &Completed{},
 			NewEvents: fn.None[EmittedEvent](),
-		}, nil
-
-	case *FailEvent:
-		return &StateTransition{
-			NextState: &Failed{Reason: evt.Reason},
-			NewEvents: fn.None[EmittedEvent](),
-		}, nil
-
-	default:
-		return unexpectedEvent(s, event), nil
-	}
-}
-
-// ProcessEvent handles events for RetryBackoff.
-func (s *RetryBackoff) ProcessEvent(ctx context.Context,
-	event Event, env *Environment) (*StateTransition, error) {
-
-	_ = ctx
-	_ = env
-
-	switch evt := event.(type) {
-	case *RetryDueEvent:
-		_ = evt
-
-		if s.ResumeSnapshot == nil {
-			return nil, fmt.Errorf(
-				"resume snapshot must be provided",
-			)
-		}
-
-		nextState, err := OutgoingStateFromSnapshot(s.ResumeSnapshot)
-		if err != nil {
-			return nil, err
-		}
-
-		nextOutbox, err := OutboxForState(nextState)
-		if err != nil {
-			return nil, err
-		}
-
-		return &StateTransition{
-			NextState: nextState,
-			NewEvents: fn.Some(EmittedEvent{
-				Outbox: nextOutbox,
-			}),
 		}, nil
 
 	case *FailEvent:

--- a/oor/transitions.go
+++ b/oor/transitions.go
@@ -312,6 +312,25 @@ func (s *AwaitingLocalVTXOUpdate) ProcessEvent(ctx context.Context,
 	}
 }
 
+// ProcessEvent handles events for RetryBackoff.
+func (s *RetryBackoff) ProcessEvent(ctx context.Context,
+	event Event, env *Environment) (*StateTransition, error) {
+
+	_ = ctx
+	_ = env
+
+	switch evt := event.(type) {
+	case *FailEvent:
+		return &StateTransition{
+			NextState: &Failed{Reason: evt.Reason},
+			NewEvents: fn.None[EmittedEvent](),
+		}, nil
+
+	default:
+		return unexpectedEvent(s, event), nil
+	}
+}
+
 // ProcessEvent handles events for Completed.
 func (s *Completed) ProcessEvent(ctx context.Context, event Event,
 	env *Environment) (*StateTransition, error) {

--- a/oor/transitions.go
+++ b/oor/transitions.go
@@ -1,24 +1,29 @@
 package oor
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/lib/scripts"
 	oortx "github.com/lightninglabs/darepo-client/lib/tx/oor"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 )
 
+// defaultRetryDelay is used when an outbox error is retryable but does not
+// specify an explicit backoff.
+const defaultRetryDelay = 1 * time.Second
+
 // unexpectedEvent returns a transition that stays in the current state and
 // emits no outbox work for an unexpected event.
 //
 // This makes the FSM resilient to retries and late deliveries at the actor
 // boundary.
-func unexpectedEvent(state State, event Event) *StateTransition {
-	_ = event
-
+func unexpectedEvent(state State) *StateTransition {
 	return &StateTransition{
 		NextState: state,
 		NewEvents: fn.None[EmittedEvent](),
@@ -37,7 +42,7 @@ func (s *Idle) ProcessEvent(ctx context.Context, event Event,
 		// - checkpoint txs convert VTXOs into checkpoints
 		// - an Ark tx spends checkpoints and pays recipients
 		//
-		// The Ark txid is the stable session identifier.
+		// The Ark txid is the stable v0 session identifier.
 		ark, checkpoints, err := buildSubmitPackage(
 			evt.Policy,
 			evt.VTXOInputs,
@@ -68,10 +73,13 @@ func (s *Idle) ProcessEvent(ctx context.Context, event Event,
 			)
 		}
 
-		// If the environment is already bound to a stable session id,
-		// verify the derived Ark txid matches. A mismatch indicates
-		// non-determinism in the builder or inconsistent state
-		// reconstruction.
+		// If the FSM environment is already bound to a stable session
+		// id (for example via `NewSessionFromSnapshot`), verify the
+		// derived Ark txid matches.
+		//
+		// A mismatch here is a correctness bug. It implies either:
+		// - non-deterministic tx building; or
+		// - inconsistent input/recipient reconstruction from state.
 		if env != nil && env.SessionID != (SessionID{}) {
 			sessionID, err := sessionIDFromArk(ark)
 			if err != nil {
@@ -84,14 +92,13 @@ func (s *Idle) ProcessEvent(ctx context.Context, event Event,
 			}
 		}
 
-		submitReq := &SendSubmitPackageRequest{
-			ArkPSBT:         ark,
-			CheckpointPSBTs: checkpoints,
-			TransferInputs:  evt.VTXOInputs,
+		signReq := &RequestArkSignatures{
+			ArkPSBT:        ark,
+			TransferInputs: evt.VTXOInputs,
 		}
 
 		return &StateTransition{
-			NextState: &AwaitingSubmitAccepted{
+			NextState: &AwaitingArkSignatures{
 				InputOutpoints:  inputOutpoints,
 				ArkPSBT:         ark,
 				CheckpointPSBTs: checkpoints,
@@ -99,7 +106,7 @@ func (s *Idle) ProcessEvent(ctx context.Context, event Event,
 			},
 			NewEvents: fn.Some(EmittedEvent{
 				Outbox: []OutboxEvent{
-					submitReq,
+					signReq,
 				},
 			}),
 		}, nil
@@ -111,7 +118,73 @@ func (s *Idle) ProcessEvent(ctx context.Context, event Event,
 		}, nil
 
 	default:
-		return unexpectedEvent(s, event), nil
+		return unexpectedEvent(s), nil
+	}
+}
+
+// ProcessEvent handles events for AwaitingArkSignatures.
+func (s *AwaitingArkSignatures) ProcessEvent(ctx context.Context, event Event,
+	env *Environment) (*StateTransition, error) {
+
+	_ = ctx
+	_ = env
+
+	switch evt := event.(type) {
+	case *ArkSignedEvent:
+		if evt.ArkPSBT == nil || evt.ArkPSBT.UnsignedTx == nil {
+			return nil, fmt.Errorf(
+				"signed ark psbt must be provided",
+			)
+		}
+
+		if s.ArkPSBT == nil || s.ArkPSBT.UnsignedTx == nil {
+			return nil, fmt.Errorf("internal: missing ark psbt")
+		}
+
+		originalTxid := s.ArkPSBT.UnsignedTx.TxHash()
+		signedTxid := evt.ArkPSBT.UnsignedTx.TxHash()
+		if signedTxid != originalTxid {
+			return nil, fmt.Errorf("ark txid mismatch")
+		}
+
+		_, err := oortx.ValidateSubmitPackageSigned(
+			evt.ArkPSBT, s.CheckpointPSBTs,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		submitReq := &SendSubmitPackageRequest{
+			ArkPSBT:         evt.ArkPSBT,
+			CheckpointPSBTs: s.CheckpointPSBTs,
+			TransferInputs:  s.TransferInputs,
+		}
+
+		return &StateTransition{
+			NextState: &AwaitingSubmitAccepted{
+				InputOutpoints:  s.InputOutpoints,
+				ArkPSBT:         evt.ArkPSBT,
+				CheckpointPSBTs: s.CheckpointPSBTs,
+				TransferInputs:  s.TransferInputs,
+			},
+			NewEvents: fn.Some(EmittedEvent{
+				Outbox: []OutboxEvent{
+					submitReq,
+				},
+			}),
+		}, nil
+
+	case *OutboxErrorEvent:
+		return handleOutboxError(env, s, evt)
+
+	case *FailEvent:
+		return &StateTransition{
+			NextState: &Failed{Reason: evt.Reason},
+			NewEvents: fn.None[EmittedEvent](),
+		}, nil
+
+	default:
+		return unexpectedEvent(s), nil
 	}
 }
 
@@ -154,7 +227,8 @@ func (s *AwaitingSubmitAccepted) ProcessEvent(ctx context.Context, event Event,
 		checkpoints := evt.CoSignedCheckpointPSBTs
 
 		// Signature material is produced outside the FSM.
-		// Ask the outbox boundary to finalize checkpoints.
+		// Ask the outbox boundary to attach client checkpoint
+		// signatures.
 		signReq := &RequestCheckpointSignatures{
 			ArkPSBT:                 evt.ArkPSBT,
 			CoSignedCheckpointPSBTs: evt.CoSignedCheckpointPSBTs,
@@ -176,6 +250,9 @@ func (s *AwaitingSubmitAccepted) ProcessEvent(ctx context.Context, event Event,
 			}),
 		}, nil
 
+	case *OutboxErrorEvent:
+		return handleOutboxError(env, s, evt)
+
 	case *FailEvent:
 		return &StateTransition{
 			NextState: &Failed{Reason: evt.Reason},
@@ -183,7 +260,7 @@ func (s *AwaitingSubmitAccepted) ProcessEvent(ctx context.Context, event Event,
 		}, nil
 
 	default:
-		return unexpectedEvent(s, event), nil
+		return unexpectedEvent(s), nil
 	}
 }
 
@@ -196,6 +273,10 @@ func (s *AwaitingCheckpointSignatures) ProcessEvent(ctx context.Context,
 
 	switch evt := event.(type) {
 	case *CheckpointsSignedEvent:
+		// The client has signed the checkpoint PSBTs (owner leaf).
+		//
+		// Next it binds finalize metadata to the Ark PSBT and submits
+		// the finalize package.
 		if s.ArkPSBT == nil {
 			return nil, fmt.Errorf("internal: missing ark psbt")
 		}
@@ -213,7 +294,7 @@ func (s *AwaitingCheckpointSignatures) ProcessEvent(ctx context.Context,
 		}
 
 		// Validate finalize package before emitting request.
-		err = oortx.ValidateFinalizePackage(
+		err = oortx.ValidateFinalizePackageSigned(
 			s.ArkPSBT, evt.FinalCheckpointPSBTs,
 		)
 		if err != nil {
@@ -229,6 +310,14 @@ func (s *AwaitingCheckpointSignatures) ProcessEvent(ctx context.Context,
 			},
 			NewEvents: fn.Some(EmittedEvent{
 				Outbox: []OutboxEvent{
+					// Finalize is a pure "ack" boundary
+					// in v0.
+					//
+					// Retry and resume after crash is safe
+					// because the package is deterministic.
+					//
+					// The server should handle duplicates
+					// idempotently.
 					&SendFinalizePackageRequest{
 						ArkPSBT: s.ArkPSBT,
 						FinalCheckpointPSBTs: evt.
@@ -238,6 +327,9 @@ func (s *AwaitingCheckpointSignatures) ProcessEvent(ctx context.Context,
 			}),
 		}, nil
 
+	case *OutboxErrorEvent:
+		return handleOutboxError(env, s, evt)
+
 	case *FailEvent:
 		return &StateTransition{
 			NextState: &Failed{Reason: evt.Reason},
@@ -245,7 +337,7 @@ func (s *AwaitingCheckpointSignatures) ProcessEvent(ctx context.Context,
 		}, nil
 
 	default:
-		return unexpectedEvent(s, event), nil
+		return unexpectedEvent(s), nil
 	}
 }
 
@@ -274,6 +366,9 @@ func (s *AwaitingFinalizeAccepted) ProcessEvent(ctx context.Context,
 			}),
 		}, nil
 
+	case *OutboxErrorEvent:
+		return handleOutboxError(env, s, evt)
+
 	case *FailEvent:
 		return &StateTransition{
 			NextState: &Failed{Reason: evt.Reason},
@@ -281,7 +376,7 @@ func (s *AwaitingFinalizeAccepted) ProcessEvent(ctx context.Context,
 		}, nil
 
 	default:
-		return unexpectedEvent(s, event), nil
+		return unexpectedEvent(s), nil
 	}
 }
 
@@ -301,6 +396,9 @@ func (s *AwaitingLocalVTXOUpdate) ProcessEvent(ctx context.Context,
 			NewEvents: fn.None[EmittedEvent](),
 		}, nil
 
+	case *OutboxErrorEvent:
+		return handleOutboxError(env, s, evt)
+
 	case *FailEvent:
 		return &StateTransition{
 			NextState: &Failed{Reason: evt.Reason},
@@ -308,7 +406,51 @@ func (s *AwaitingLocalVTXOUpdate) ProcessEvent(ctx context.Context,
 		}, nil
 
 	default:
-		return unexpectedEvent(s, event), nil
+		return unexpectedEvent(s), nil
+	}
+}
+
+// ProcessEvent handles events for RetryBackoff.
+func (s *RetryBackoff) ProcessEvent(ctx context.Context, event Event,
+	env *Environment) (*StateTransition, error) {
+
+	_ = ctx
+	_ = env
+
+	switch evt := event.(type) {
+	case *RetryDueEvent:
+		_ = evt
+
+		if s.ResumeSnapshot == nil {
+			return nil, fmt.Errorf(
+				"resume snapshot must be provided",
+			)
+		}
+
+		nextState, err := OutgoingStateFromSnapshot(s.ResumeSnapshot)
+		if err != nil {
+			return nil, err
+		}
+
+		nextOutbox, err := OutboxForState(nextState)
+		if err != nil {
+			return nil, err
+		}
+
+		return &StateTransition{
+			NextState: nextState,
+			NewEvents: fn.Some(EmittedEvent{
+				Outbox: nextOutbox,
+			}),
+		}, nil
+	case *FailEvent:
+		return &StateTransition{
+			NextState: &Failed{Reason: evt.Reason},
+			NewEvents: fn.None[EmittedEvent](),
+		}, nil
+
+	default:
+		return unexpectedEvent(s), nil
 	}
 }
 
@@ -319,7 +461,7 @@ func (s *Completed) ProcessEvent(ctx context.Context, event Event,
 	_ = ctx
 	_ = env
 
-	return unexpectedEvent(s, event), nil
+	return unexpectedEvent(s), nil
 }
 
 // ProcessEvent handles events for Failed.
@@ -329,7 +471,54 @@ func (s *Failed) ProcessEvent(ctx context.Context, event Event,
 	_ = ctx
 	_ = env
 
-	return unexpectedEvent(s, event), nil
+	return unexpectedEvent(s), nil
+}
+
+// handleOutboxError transitions the FSM into a RetryBackoff state if the error
+// is retryable, otherwise returning a terminal failure.
+func handleOutboxError(env *Environment, current State,
+	evt *OutboxErrorEvent) (*StateTransition, error) {
+
+	if evt == nil {
+		return nil, fmt.Errorf("outbox error event must be provided")
+	}
+
+	if !evt.Retryable {
+		return &StateTransition{
+			NextState: &Failed{Reason: evt.ErrorReason},
+			NewEvents: fn.None[EmittedEvent](),
+		}, nil
+	}
+
+	if env == nil || env.SessionID == (SessionID{}) {
+		return nil, fmt.Errorf("internal: missing session id")
+	}
+
+	snap, err := NewOutgoingSnapshot(env.SessionID, current)
+	if err != nil {
+		return nil, err
+	}
+
+	after := evt.RetryAfter
+	if after == 0 {
+		after = defaultRetryDelay
+	}
+
+	return &StateTransition{
+		NextState: &RetryBackoff{
+			ResumeSnapshot: snap,
+			RetryAfter:     after,
+			Reason:         evt.ErrorReason,
+		},
+		NewEvents: fn.Some(EmittedEvent{
+			Outbox: []OutboxEvent{
+				&ScheduleRetryRequest{
+					After:  after,
+					Reason: evt.ErrorReason,
+				},
+			},
+		}),
+	}, nil
 }
 
 // buildSubmitPackage constructs a v0 OOR submit package using the shared
@@ -344,6 +533,10 @@ func buildSubmitPackage(policy scripts.CheckpointPolicy,
 
 	checkpoints := make([]*psbt.Packet, 0, len(inputs))
 	checkpointOuts := make([]oortx.CheckpointOutput, 0, len(inputs))
+	checkpointByTxid := make(map[chainhash.Hash]struct {
+		tapTreeEncoded []byte
+		ownerLeaf      []byte
+	}, len(inputs))
 
 	for i := range inputs {
 		checkpointInput, err := inputs[i].CheckpointInput()
@@ -360,16 +553,19 @@ func buildSubmitPackage(policy scripts.CheckpointPolicy,
 
 		checkpoints = append(checkpoints, result.PSBT)
 
-		txid := result.PSBT.UnsignedTx.TxHash()
-		cpOut := result.PSBT.UnsignedTx.TxOut[0]
+		checkpointOut, err := result.ToCheckpointOutput()
+		if err != nil {
+			return nil, nil, err
+		}
 
-		checkpointOuts = append(checkpointOuts,
-			oortx.CheckpointOutput{
-				Txid:           txid,
-				Output:         cpOut,
-				TapTreeEncoded: result.TapTreeEncoded,
-			},
-		)
+		checkpointOuts = append(checkpointOuts, checkpointOut)
+		checkpointByTxid[checkpointOut.Txid] = struct {
+			tapTreeEncoded []byte
+			ownerLeaf      []byte
+		}{
+			tapTreeEncoded: result.TapTreeEncoded,
+			ownerLeaf:      inputs[i].OwnerLeafScript,
+		}
 	}
 
 	ark, err := oortx.BuildArkPSBT(checkpointOuts, outputs)
@@ -377,5 +573,49 @@ func buildSubmitPackage(policy scripts.CheckpointPolicy,
 		return nil, nil, err
 	}
 
+	for i := range ark.UnsignedTx.TxIn {
+		prevOut := ark.UnsignedTx.TxIn[i].PreviousOutPoint
+		meta, ok := checkpointByTxid[prevOut.Hash]
+		if !ok {
+			return nil, nil, fmt.Errorf("missing checkpoint for "+
+				"ark input %d", i)
+		}
+
+		leaf, err := oortx.BuildTaprootTapLeafScript(
+			meta.tapTreeEncoded, meta.ownerLeaf,
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		addTaprootLeafScript(&ark.Inputs[i], leaf)
+	}
+
 	return ark, checkpoints, nil
+}
+
+// addTaprootLeafScript ensures the PSBT input carries the tapleaf script and
+// control block used by the owner leaf path, avoiding duplicate inserts.
+func addTaprootLeafScript(in *psbt.PInput,
+	leaf *psbt.TaprootTapLeafScript) {
+
+	if in == nil || leaf == nil {
+		return
+	}
+
+	for i := range in.TaprootLeafScript {
+		existing := in.TaprootLeafScript[i]
+		if existing == nil {
+			continue
+		}
+
+		if bytes.Equal(existing.ControlBlock, leaf.ControlBlock) &&
+			bytes.Equal(existing.Script, leaf.Script) &&
+			existing.LeafVersion == leaf.LeafVersion {
+
+			return
+		}
+	}
+
+	in.TaprootLeafScript = append(in.TaprootLeafScript, leaf)
 }


### PR DESCRIPTION
## Context

Final client PR in the OOR stack. Split 3 (#79) made the actor durable with TLV codecs and signing context. Split 3b (#119) added operator signature validation. This split adds **retry-backoff runtime behavior** so transient outbox failures don't drop sessions, and adds crash-resume test coverage for the co-sign window.

## What changes

### Retry-backoff FSM state
`RetryBackoff` is introduced as an explicit outgoing FSM state that stores a resume snapshot, retry delay, and failure reason. Snapshot restore and resume logic can represent retry intent without losing session progress after a restart.

### Retry transitions and scheduling
Retry progression is driven through the durable actor boundary with explicit `RetryDueEvent` and `ScheduleRetryRequest` messages. `OutboxForState` emits the expected retry scheduling request for restored sessions so restart replay stays consistent with the normal runtime path.

### Outbox error handling
Retryable outbox failures are routed through retry-backoff states and durable events. Non-retryable errors terminate the session. This classification happens at the actor level so the FSM stays pure.

### Crash-resume and edge-case tests
- Actor resume test simulating a crash after server co-sign but before the client observes submit acceptance. Restores from persisted state, re-drives the outbox, and asserts stable package behavior through completion.
- Targeted unit tests for DriveEvent handling, late/terminal event behavior, and retryable vs non-retryable outbox error transitions.

## Storage model

This split extends split 3's replay behavior — it does not add a new durability backend.

| Concern | Storage/Boundary | Trigger |
|---|---|---|
| Retry scheduling intent | `ScheduleRetryRequest` outbox event | retryable outbox error |
| Crash/restart replay | durable mailbox + TLV checkpoint | actor restart |

The retry delay and resume snapshot are captured inside the `RetryBackoff` FSM state and persisted through the existing `OutgoingSnapshot` → checkpoint TLV path from split 3.

## Commits

1. **oor: add retry-backoff state for snapshot restore path**
2. **oor: wire retry-backoff transitions for outgoing snapshots**
3. **oor: make retry-backoff resumable**
4. **oor: add retry-backoff flow and outbox error handling**
5. **oor: add crash-resume test for co-sign**
6. **test: cover OOR actor/FSM edge cases**
7. **oor: reconcile split4 with split3 validation base**

## Not included

- Full transport RPC integration beyond typed envelopes.
- System-level restart/retry integration tests (unit/in-process focus here).

## Stack

Parent: #119 · Final split in the client OOR stack.