### PR TITLE
multi: decouple vtxo requests from intents

### DIFF
--- a/db/boarding_wallet_test.go
+++ b/db/boarding_wallet_test.go
@@ -210,7 +210,7 @@ func TestBoardingIntentLifecycle(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a test boarding intent in confirmed status.
-	// (Intents are only created after on-chain confirmation.)
+	// (BoardingIntents are only created after on-chain confirmation.)
 	outpoint := wire.OutPoint{
 		Hash:  chainhash.Hash{0xaa, 0xbb},
 		Index: 0,

--- a/db/round_persistence.md
+++ b/db/round_persistence.md
@@ -26,8 +26,8 @@ The round persistence schema consists of seven tables:
    in that round, storing BoardingRequest fields relationally and input
    signatures.
 
-4. **round_vtxo_templates**: Stores VTXO requests (VTXORequest) for each
-   boarding intent. One intent can request multiple VTXOs (1:N relationship).
+4. **round_vtxo_requests**: Stores VTXO requests (VTXORequest) for the round,
+   keyed by request index.
 
 5. **round_client_trees**: Stores per-client extracted tree paths for
    reconstructing sweep transactions if needed.
@@ -47,7 +47,7 @@ erDiagram
     rounds ||--o{ round_client_trees : "contains"
     rounds ||--o{ vtxos : "produces"
     boarding_intents ||--o{ round_boarding_intents : "references"
-    round_boarding_intents ||--o{ round_vtxo_templates : "contains"
+    rounds ||--o{ round_vtxo_requests : "contains"
     round_client_trees ||--o{ client_tree_txids : "indexes"
 
     round_statuses {
@@ -78,11 +78,9 @@ erDiagram
         BLOB input_signature
     }
 
-    round_vtxo_templates {
+    round_vtxo_requests {
         TEXT round_id "PK, FK"
-        BLOB outpoint_hash "PK, FK"
-        INTEGER outpoint_index "PK, FK"
-        INTEGER template_index "PK"
+        INTEGER request_index "PK"
         BIGINT amount
         BLOB pk_script
         INTEGER expiry

--- a/db/round_store.go
+++ b/db/round_store.go
@@ -220,24 +220,31 @@ func (s *RoundPersistenceStore) CommitState(ctx context.Context,
 						"insert round intent: %w", err,
 					)
 				}
+			}
+		}
 
-				// Insert VTXO templates for this intent.
-				for j, vtxoReq := range intent.VtxoTemplate {
-					roundStr := r.RoundID.String()
-					tParams := vtxoRequestToParams(
-						roundStr, &intent, j, &vtxoReq,
-					)
-					err = q.InsertRoundVtxoTemplate(
-						ctx, tParams,
-					)
-					if err != nil {
-						return fmt.Errorf(
-							"insert vtxo "+
-								"template: %w",
-							err,
-						)
-					}
-				}
+		// Insert VTXO templates for this round. For now, we couple
+		// VTXOs to boarding intents 1:1 by index at the DB level.
+		// TODO: Decouple VTXOs from intents in storage.
+		vtxos := inputSigState.Intents.VTXOs
+		if len(vtxos) != len(r.BoardingIntents) {
+			return fmt.Errorf(
+				"mismatch between vtxos (%d) and "+
+					"boarding intents (%d)",
+				len(vtxos), len(r.BoardingIntents),
+			)
+		}
+		for i, vtxoReq := range vtxos {
+			intent := &r.BoardingIntents[i]
+			roundStr := r.RoundID.String()
+			tParams := vtxoRequestToParams(
+				roundStr, intent, i, &vtxoReq,
+			)
+			err = q.InsertRoundVtxoTemplate(ctx, tParams)
+			if err != nil {
+				return fmt.Errorf(
+					"insert vtxo template: %w", err,
+				)
 			}
 		}
 
@@ -803,30 +810,9 @@ func (s *RoundPersistenceStore) dbRoundIntentToDomainIntent(ctx context.Context,
 		TxProof:     txProofOpt,
 	}
 
-	// Fetch and reconstruct VtxoTemplate from relational data.
-	templateParams := sqlc.GetRoundVtxoTemplatesParams{
-		RoundID:       dbRoundIntent.RoundID,
-		OutpointHash:  dbRoundIntent.OutpointHash,
-		OutpointIndex: dbRoundIntent.OutpointIndex,
-	}
-	dbTemplates, err := q.GetRoundVtxoTemplates(ctx, templateParams)
-	if err != nil {
-		return nil, fmt.Errorf("get vtxo templates: %w", err)
-	}
-
-	vtxoTemplate := make([]types.VTXORequest, 0, len(dbTemplates))
-	for _, t := range dbTemplates {
-		vtxoReq, err := dbTemplateToVTXORequest(t)
-		if err != nil {
-			return nil, fmt.Errorf("convert vtxo template: %w", err)
-		}
-		vtxoTemplate = append(vtxoTemplate, *vtxoReq)
-	}
-
 	intent := &round.BoardingIntent{
 		BoardingIntent:  baseIntent,
 		BoardingRequest: boardingReq,
-		VtxoTemplate:    vtxoTemplate,
 	}
 
 	return intent, nil
@@ -932,8 +918,10 @@ func (s *RoundPersistenceStore) reconstructInputSigSentState(
 		state.VTXOTreePaths = map[int]*tree.Tree{0: vtxtTree}
 	}
 
-	// Convert boarding intents and input signatures.
+	// Convert boarding intents, VTXO templates, and input signatures.
+	// VTXOs are coupled 1:1 to boarding intents by index at the DB level.
 	intents := make([]round.BoardingIntent, 0, len(dbIntents))
+	vtxos := make([]types.VTXORequest, 0, len(dbIntents))
 	inputSigs := make([]*types.BoardingInputSignature, 0, len(dbIntents))
 	for _, dbIntent := range dbIntents {
 		intent, err := s.dbRoundIntentToDomainIntent(ctx, q, dbIntent)
@@ -944,6 +932,26 @@ func (s *RoundPersistenceStore) reconstructInputSigSentState(
 		}
 
 		intents = append(intents, *intent)
+
+		// Fetch VTXO template for this intent.
+		templateParams := sqlc.GetRoundVtxoTemplatesParams{
+			RoundID:       dbIntent.RoundID,
+			OutpointHash:  dbIntent.OutpointHash,
+			OutpointIndex: dbIntent.OutpointIndex,
+		}
+		dbTemplates, err := q.GetRoundVtxoTemplates(ctx, templateParams)
+		if err != nil {
+			return nil, fmt.Errorf("get vtxo templates: %w", err)
+		}
+		for _, t := range dbTemplates {
+			vtxoReq, err := dbTemplateToVTXORequest(t)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"convert vtxo template: %w", err,
+				)
+			}
+			vtxos = append(vtxos, *vtxoReq)
+		}
 
 		// Reconstruct the BoardingInputSignature from stored data.
 		if len(dbIntent.InputSignature) > 0 {
@@ -974,7 +982,10 @@ func (s *RoundPersistenceStore) reconstructInputSigSentState(
 		}
 	}
 
-	state.Intents = intents
+	state.Intents = round.Intents{
+		Boarding: intents,
+		VTXOs:    vtxos,
+	}
 	state.InputSigs = inputSigs
 
 	// Deserialize client trees.
@@ -1054,7 +1065,8 @@ func (s *RoundPersistenceStore) domainIntentToRoundParams(
 }
 
 // vtxoRequestToParams converts a types.VTXORequest to sqlc insert parameters
-// for the round_vtxo_templates table.
+// for the round_vtxo_templates table. The intent parameter provides the
+// outpoint used to associate the VTXO template with a boarding intent.
 func vtxoRequestToParams(roundID string, intent *round.BoardingIntent,
 	templateIndex int,
 	req *types.VTXORequest) sqlc.InsertRoundVtxoTemplateParams {

--- a/db/round_store.go
+++ b/db/round_store.go
@@ -775,7 +775,7 @@ func (s *RoundPersistenceStore) dbRoundIntentToDomainIntent(ctx context.Context,
 		Status:    status,
 	}
 
-	// Reconstruct BoardingRequest from relational columns.
+	// Reconstruct Request from relational columns.
 	var clientKey, operatorKey *btcec.PublicKey
 	if len(dbRoundIntent.ClientKey) > 0 {
 		clientKey, err = btcec.ParsePubKey(dbRoundIntent.ClientKey)
@@ -811,8 +811,8 @@ func (s *RoundPersistenceStore) dbRoundIntentToDomainIntent(ctx context.Context,
 	}
 
 	intent := &round.BoardingIntent{
-		BoardingIntent:  baseIntent,
-		BoardingRequest: boardingReq,
+		BoardingIntent: baseIntent,
+		Request:        boardingReq,
 	}
 
 	return intent, nil
@@ -1016,8 +1016,8 @@ func (s *RoundPersistenceStore) domainIntentToRoundParams(
 
 	// Serialize TxProof if present.
 	var txProofBytes []byte
-	if intent.BoardingRequest.TxProof.IsSome() {
-		p := intent.BoardingRequest.TxProof.UnsafeFromSome()
+	if intent.Request.TxProof.IsSome() {
+		p := intent.Request.TxProof.UnsafeFromSome()
 		data, err := SerializeTxProof(&p)
 		if err != nil {
 			return sqlc.InsertRoundBoardingIntentParams{},
@@ -1028,12 +1028,12 @@ func (s *RoundPersistenceStore) domainIntentToRoundParams(
 
 	// Serialize public keys.
 	var clientKey, operatorKey []byte
-	if intent.BoardingRequest.ClientKey != nil {
-		clientPk := intent.BoardingRequest.ClientKey
+	if intent.Request.ClientKey != nil {
+		clientPk := intent.Request.ClientKey
 		clientKey = clientPk.SerializeCompressed()
 	}
-	if intent.BoardingRequest.OperatorKey != nil {
-		opPk := intent.BoardingRequest.OperatorKey
+	if intent.Request.OperatorKey != nil {
+		opPk := intent.Request.OperatorKey
 		operatorKey = opPk.SerializeCompressed()
 	}
 
@@ -1057,7 +1057,7 @@ func (s *RoundPersistenceStore) domainIntentToRoundParams(
 		OutpointIndex:  int32(intent.Outpoint.Index),
 		ClientKey:      clientKey,
 		OperatorKey:    operatorKey,
-		ExitDelay:      int32(intent.BoardingRequest.ExitDelay),
+		ExitDelay:      int32(intent.Request.ExitDelay),
 		TxProof:        txProofBytes,
 		InputIndex:     inputIdxVal,
 		InputSignature: inputSigBytes,

--- a/db/round_store.go
+++ b/db/round_store.go
@@ -823,18 +823,10 @@ func (s *RoundPersistenceStore) dbRoundIntentToDomainIntent(ctx context.Context,
 		vtxoTemplate = append(vtxoTemplate, *vtxoReq)
 	}
 
-	// Create the round-specific BoardingIntent.
-	// Parse the round ID from the database string.
-	roundID, err := round.ParseRoundID(dbRoundIntent.RoundID)
-	if err != nil {
-		return nil, fmt.Errorf("parse round ID: %w", err)
-	}
-
 	intent := &round.BoardingIntent{
 		BoardingIntent:  baseIntent,
 		BoardingRequest: boardingReq,
 		VtxoTemplate:    vtxoTemplate,
-		RoundID:         fn.Some(roundID),
 	}
 
 	return intent, nil

--- a/db/round_store.go
+++ b/db/round_store.go
@@ -192,8 +192,8 @@ func (s *RoundPersistenceStore) CommitState(ctx context.Context,
 		}
 
 		// Insert boarding intents for this round.
-		if len(r.BoardingIntents) > 0 {
-			numIntents := len(r.BoardingIntents)
+		if len(r.Intents.Boarding) > 0 {
+			numIntents := len(r.Intents.Boarding)
 			numSigs := len(inputSigState.InputSigs)
 			if numIntents != numSigs {
 				return fmt.Errorf(
@@ -203,7 +203,7 @@ func (s *RoundPersistenceStore) CommitState(ctx context.Context,
 				)
 			}
 
-			for i, intent := range r.BoardingIntents {
+			for i, intent := range r.Intents.Boarding {
 				sig := inputSigState.InputSigs[i]
 				iParams, err := s.domainIntentToRoundParams(
 					r.RoundID.String(), &intent, i, sig,
@@ -226,16 +226,16 @@ func (s *RoundPersistenceStore) CommitState(ctx context.Context,
 		// Insert VTXO templates for this round. For now, we couple
 		// VTXOs to boarding intents 1:1 by index at the DB level.
 		// TODO: Decouple VTXOs from intents in storage.
-		vtxos := inputSigState.Intents.VTXOs
-		if len(vtxos) != len(r.BoardingIntents) {
+		vtxos := r.Intents.VTXOs
+		if len(vtxos) != len(r.Intents.Boarding) {
 			return fmt.Errorf(
 				"mismatch between vtxos (%d) and "+
 					"boarding intents (%d)",
-				len(vtxos), len(r.BoardingIntents),
+				len(vtxos), len(r.Intents.Boarding),
 			)
 		}
 		for i, vtxoReq := range vtxos {
-			intent := &r.BoardingIntents[i]
+			intent := &r.Intents.Boarding[i]
 			roundStr := r.RoundID.String()
 			tParams := vtxoRequestToParams(
 				roundStr, intent, i, &vtxoReq,
@@ -698,7 +698,7 @@ func (s *RoundPersistenceStore) dbRoundToDomainRound(ctx context.Context,
 			intents = append(intents, *intent)
 		}
 
-		r.BoardingIntents = intents
+		r.Intents.Boarding = intents
 	}
 
 	return r, nil

--- a/db/round_store.go
+++ b/db/round_store.go
@@ -28,7 +28,7 @@ type (
 	RoundRow               = sqlc.Round
 	RoundBoardingIntentRow = sqlc.RoundBoardingIntent
 	RoundClientTreeRow     = sqlc.RoundClientTree
-	RoundVtxoTemplateRow   = sqlc.RoundVtxoTemplate
+	RoundVtxoRequestRow    = sqlc.RoundVtxoRequest
 	VTXORow                = sqlc.Vtxo
 	InsertRoundParams      = sqlc.InsertRoundParams
 	InsertVTXOParams       = sqlc.InsertVTXOParams
@@ -66,13 +66,13 @@ type RoundStore interface {
 		ctx context.Context, roundID string,
 	) ([]RoundBoardingIntentRow, error)
 
-	InsertRoundVtxoTemplate(
-		ctx context.Context, arg sqlc.InsertRoundVtxoTemplateParams,
+	InsertRoundVtxoRequest(
+		ctx context.Context, arg sqlc.InsertRoundVtxoRequestParams,
 	) error
 
-	GetRoundVtxoTemplates(
-		ctx context.Context, arg sqlc.GetRoundVtxoTemplatesParams,
-	) ([]RoundVtxoTemplateRow, error)
+	GetRoundVtxoRequests(
+		ctx context.Context, roundID string,
+	) ([]RoundVtxoRequestRow, error)
 
 	InsertRoundClientTree(
 		ctx context.Context, arg sqlc.InsertRoundClientTreeParams,
@@ -223,27 +223,15 @@ func (s *RoundPersistenceStore) CommitState(ctx context.Context,
 			}
 		}
 
-		// Insert VTXO templates for this round. For now, we couple
-		// VTXOs to boarding intents 1:1 by index at the DB level.
-		// TODO: Decouple VTXOs from intents in storage.
-		vtxos := r.Intents.VTXOs
-		if len(vtxos) != len(r.Intents.Boarding) {
-			return fmt.Errorf(
-				"mismatch between vtxos (%d) and "+
-					"boarding intents (%d)",
-				len(vtxos), len(r.Intents.Boarding),
+		// Insert VTXO requests for this round.
+		for i, vtxoReq := range r.Intents.VTXOs {
+			reqParams := vtxoRequestToRoundParams(
+				r.RoundID.String(), i, &vtxoReq,
 			)
-		}
-		for i, vtxoReq := range vtxos {
-			intent := &r.Intents.Boarding[i]
-			roundStr := r.RoundID.String()
-			tParams := vtxoRequestToParams(
-				roundStr, intent, i, &vtxoReq,
-			)
-			err = q.InsertRoundVtxoTemplate(ctx, tParams)
+			err = q.InsertRoundVtxoRequest(ctx, reqParams)
 			if err != nil {
 				return fmt.Errorf(
-					"insert vtxo template: %w", err,
+					"insert vtxo request: %w", err,
 				)
 			}
 		}
@@ -918,10 +906,25 @@ func (s *RoundPersistenceStore) reconstructInputSigSentState(
 		state.VTXOTreePaths = map[int]*tree.Tree{0: vtxtTree}
 	}
 
-	// Convert boarding intents, VTXO templates, and input signatures.
-	// VTXOs are coupled 1:1 to boarding intents by index at the DB level.
+	// Fetch VTXO requests for this round.
+	dbVtxoReqs, err := q.GetRoundVtxoRequests(ctx, dbRound.RoundID)
+	if err != nil {
+		return nil, fmt.Errorf("get round vtxo requests: %w", err)
+	}
+
+	vtxos := make([]types.VTXORequest, 0, len(dbVtxoReqs))
+	for _, dbReq := range dbVtxoReqs {
+		req, err := dbVtxoRequestRowToVTXORequest(dbReq)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"convert round vtxo request: %w", err,
+			)
+		}
+		vtxos = append(vtxos, *req)
+	}
+
+	// Convert boarding intents and input signatures.
 	intents := make([]round.BoardingIntent, 0, len(dbIntents))
-	vtxos := make([]types.VTXORequest, 0, len(dbIntents))
 	inputSigs := make([]*types.BoardingInputSignature, 0, len(dbIntents))
 	for _, dbIntent := range dbIntents {
 		intent, err := s.dbRoundIntentToDomainIntent(ctx, q, dbIntent)
@@ -932,26 +935,6 @@ func (s *RoundPersistenceStore) reconstructInputSigSentState(
 		}
 
 		intents = append(intents, *intent)
-
-		// Fetch VTXO template for this intent.
-		templateParams := sqlc.GetRoundVtxoTemplatesParams{
-			RoundID:       dbIntent.RoundID,
-			OutpointHash:  dbIntent.OutpointHash,
-			OutpointIndex: dbIntent.OutpointIndex,
-		}
-		dbTemplates, err := q.GetRoundVtxoTemplates(ctx, templateParams)
-		if err != nil {
-			return nil, fmt.Errorf("get vtxo templates: %w", err)
-		}
-		for _, t := range dbTemplates {
-			vtxoReq, err := dbTemplateToVTXORequest(t)
-			if err != nil {
-				return nil, fmt.Errorf(
-					"convert vtxo template: %w", err,
-				)
-			}
-			vtxos = append(vtxos, *vtxoReq)
-		}
 
 		// Reconstruct the BoardingInputSignature from stored data.
 		if len(dbIntent.InputSignature) > 0 {
@@ -1064,12 +1047,10 @@ func (s *RoundPersistenceStore) domainIntentToRoundParams(
 	}, nil
 }
 
-// vtxoRequestToParams converts a types.VTXORequest to sqlc insert parameters
-// for the round_vtxo_templates table. The intent parameter provides the
-// outpoint used to associate the VTXO template with a boarding intent.
-func vtxoRequestToParams(roundID string, intent *round.BoardingIntent,
-	templateIndex int,
-	req *types.VTXORequest) sqlc.InsertRoundVtxoTemplateParams {
+// vtxoRequestToRoundParams converts a types.VTXORequest to sqlc insert
+// parameters for the round_vtxo_requests table.
+func vtxoRequestToRoundParams(roundID string, requestIndex int,
+	req *types.VTXORequest) sqlc.InsertRoundVtxoRequestParams {
 
 	var clientPubkey, operatorPubkey, signingPubkey []byte
 	if req.ClientKey != nil {
@@ -1082,11 +1063,9 @@ func vtxoRequestToParams(roundID string, intent *round.BoardingIntent,
 		signingPubkey = req.SigningKey.PubKey.SerializeCompressed()
 	}
 
-	return sqlc.InsertRoundVtxoTemplateParams{
+	return sqlc.InsertRoundVtxoRequestParams{
 		RoundID:          roundID,
-		OutpointHash:     intent.Outpoint.Hash[:],
-		OutpointIndex:    int32(intent.Outpoint.Index),
-		TemplateIndex:    int32(templateIndex),
+		RequestIndex:     int32(requestIndex),
 		Amount:           int64(req.Amount),
 		PkScript:         req.PkScript,
 		Expiry:           int32(req.Expiry),
@@ -1098,9 +1077,9 @@ func vtxoRequestToParams(roundID string, intent *round.BoardingIntent,
 	}
 }
 
-// dbTemplateToVTXORequest converts a database template row to a VTXORequest.
-func dbTemplateToVTXORequest(
-	t RoundVtxoTemplateRow) (*types.VTXORequest, error) {
+// dbVtxoRequestRowToVTXORequest converts a database row to a VTXORequest.
+func dbVtxoRequestRowToVTXORequest(
+	t RoundVtxoRequestRow) (*types.VTXORequest, error) {
 
 	var clientKey, operatorKey, signingPubkey *btcec.PublicKey
 	var err error

--- a/db/round_store_test.go
+++ b/db/round_store_test.go
@@ -619,8 +619,8 @@ func createBoardingIntentFixture(
 	}
 
 	roundIntent := round.BoardingIntent{
-		BoardingIntent:  walletIntent,
-		BoardingRequest: boardingRequest,
+		BoardingIntent: walletIntent,
+		Request:        boardingRequest,
 	}
 
 	// Create input signature as a BoardingInputSignature.

--- a/db/round_store_test.go
+++ b/db/round_store_test.go
@@ -498,6 +498,7 @@ type boardingIntentFixture struct {
 	boardingAddr  *wallet.BoardingAddress
 	walletIntent  wallet.BoardingIntent
 	roundIntent   round.BoardingIntent
+	vtxoTemplates []types.VTXORequest
 	outpoint      wire.OutPoint
 	pkScript      []byte
 	inputSig      *types.BoardingInputSignature
@@ -591,25 +592,24 @@ func createBoardingIntentFixture(
 		Status: wallet.BoardingStatusConfirmed,
 	}
 
-	// Create multiple VTXO templates per intent.
-	vtxoTemplates := make([]types.VTXORequest, 2)
-	for j := 0; j < 2; j++ {
-		signingKey := keychain.KeyDescriptor{
-			PubKey: clientPubKey,
-			KeyLocator: keychain.KeyLocator{
-				Family: keychain.KeyFamily(43),
-				Index:  uint32(idx*10 + j),
-			},
-		}
-		vtxoTemplates[j] = types.VTXORequest{
-			Amount:      btcutil.Amount(45000 * (j + 1)),
-			PkScript:    pkScript,
-			Expiry:      exitDelay,
-			ClientKey:   clientPubKey,
-			OperatorKey: operatorPubKey,
-			SigningKey:  signingKey,
-		}
+	// Create VTXO template for this intent (1:1 coupling at DB level for
+	// now). TODO: Support multiple VTXOs per intent when we decouple
+	// storage.
+	signingKey := keychain.KeyDescriptor{
+		PubKey: clientPubKey,
+		KeyLocator: keychain.KeyLocator{
+			Family: keychain.KeyFamily(43),
+			Index:  uint32(idx * 10),
+		},
 	}
+	vtxoTemplates := []types.VTXORequest{{
+		Amount:      btcutil.Amount(90000),
+		PkScript:    pkScript,
+		Expiry:      exitDelay,
+		ClientKey:   clientPubKey,
+		OperatorKey: operatorPubKey,
+		SigningKey:  signingKey,
+	}}
 
 	boardingRequest := types.BoardingRequest{
 		Outpoint:    &intentOutpoint,
@@ -621,7 +621,6 @@ func createBoardingIntentFixture(
 	roundIntent := round.BoardingIntent{
 		BoardingIntent:  walletIntent,
 		BoardingRequest: boardingRequest,
-		VtxoTemplate:    vtxoTemplates,
 	}
 
 	// Create input signature as a BoardingInputSignature.
@@ -636,8 +635,8 @@ func createBoardingIntentFixture(
 		ClientSignature: sig,
 	}
 
-	// Create client tree using the actual tree builder with multiple
-	// leaves.
+	// Create client tree using the actual tree builder (1 leaf per intent
+	// to match 1:1 VTXO coupling).
 	clientTreeKey := round.NewSignerKey(clientPubKey)
 	rootOutpoint := wire.OutPoint{
 		Hash:  chainhash.Hash{0xc1, 0x1e, byte(idx)},
@@ -650,12 +649,7 @@ func createBoardingIntentFixture(
 	leaves := []tree.LeafDescriptor{
 		{
 			PkScript:    pkScript,
-			Amount:      btcutil.Amount(45000 * (idx + 1)),
-			CoSignerKey: clientPubKey,
-		},
-		{
-			PkScript:    pkScript,
-			Amount:      btcutil.Amount(45000 * (idx + 1)),
+			Amount:      btcutil.Amount(90000 * (idx + 1)),
 			CoSignerKey: clientPubKey,
 		},
 	}
@@ -670,6 +664,7 @@ func createBoardingIntentFixture(
 		boardingAddr:  boardingAddr,
 		walletIntent:  walletIntent,
 		roundIntent:   roundIntent,
+		vtxoTemplates: vtxoTemplates,
 		outpoint:      intentOutpoint,
 		pkScript:      pkScript,
 		inputSig:      inputSig,
@@ -727,10 +722,12 @@ func TestRoundStoreWithBoardingGroup(t *testing.T) {
 
 	// Build the round's boarding group from the fixtures.
 	roundIntents := make([]round.BoardingIntent, numIntents)
+	allVtxos := make([]types.VTXORequest, 0, numIntents)
 	inputSigs := make([]*types.BoardingInputSignature, numIntents)
 	clientTrees := make(map[round.SignerKey]*tree.Tree)
 	for i, f := range fixtures {
 		roundIntents[i] = f.roundIntent
+		allVtxos = append(allVtxos, f.vtxoTemplates...)
 		inputSigs[i] = f.inputSig
 		clientTrees[f.clientTreeKey] = f.clientTree
 	}
@@ -755,12 +752,12 @@ func TestRoundStoreWithBoardingGroup(t *testing.T) {
 		Index: 0,
 	}
 	vtxtTreeOutput := &wire.TxOut{
-		Value:    180000,
+		Value:    90000,
 		PkScript: fixtures[0].pkScript,
 	}
-	vtxtLeaves := make([]tree.LeafDescriptor, 0, numIntents*2)
+	vtxtLeaves := make([]tree.LeafDescriptor, 0, numIntents)
 	for _, f := range fixtures {
-		for range f.roundIntent.VtxoTemplate {
+		for range f.vtxoTemplates {
 			vtxtLeaves = append(vtxtLeaves, tree.LeafDescriptor{
 				PkScript:    f.pkScript,
 				Amount:      45000,
@@ -786,9 +783,12 @@ func TestRoundStoreWithBoardingGroup(t *testing.T) {
 		RoundID:       roundID,
 		CommitmentTx:  commitTx,
 		VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
-		Intents:       roundIntents,
-		ClientTrees:   clientTrees,
-		InputSigs:     inputSigs,
+		Intents: round.Intents{
+			Boarding: roundIntents,
+			VTXOs:    allVtxos,
+		},
+		ClientTrees: clientTrees,
+		InputSigs:   inputSigs,
 	}
 
 	// Commit the state.
@@ -812,15 +812,15 @@ func TestRoundStoreWithBoardingGroup(t *testing.T) {
 	for i, f := range fixtures {
 		fetchedIntent := fetchedRound.BoardingIntents[i]
 		require.Equal(t, f.outpoint, fetchedIntent.Outpoint)
-
-		// Verify VTXO templates were persisted.
-		require.Len(t, fetchedIntent.VtxoTemplate, 2)
 	}
 
 	// Verify FSM state type.
 	inputSigState, ok := fetchedState.(*round.InputSigSentState)
 	require.True(t, ok)
 	require.Equal(t, roundID, inputSigState.RoundID)
+
+	// Verify VTXO templates were persisted (1 per intent for now).
+	require.Len(t, inputSigState.Intents.VTXOs, numIntents)
 
 	// Verify all input signatures were persisted and recovered.
 	require.Len(t, inputSigState.InputSigs, numIntents)
@@ -843,8 +843,8 @@ func TestRoundStoreWithBoardingGroup(t *testing.T) {
 
 		// Verify tree structure was preserved. The number of outputs
 		// should match: one per leaf group + 1 anchor output (P2A).
-		// Each fixture creates 2 leaves in the client tree.
-		numLeaves := 2
+		// Each fixture creates 1 leaf (1:1 coupling).
+		numLeaves := 1
 		expectedOutputs := numLeaves + 1
 		require.Len(t, fetchedTree.Root.Outputs, expectedOutputs)
 	}

--- a/db/round_store_test.go
+++ b/db/round_store_test.go
@@ -673,6 +673,179 @@ func createBoardingIntentFixture(
 	}
 }
 
+// TestRoundStoreDecoupledVTXOStorage verifies that VTXO requests are stored
+// independently from boarding intents. This allows fan-out (1 input creating
+// multiple outputs) and fan-in (multiple inputs funding 1 output) scenarios.
+// The test creates 2 boarding intents but 3 VTXO requests to verify the counts
+// are independent.
+func TestRoundStoreDecoupledVTXOStorage(t *testing.T) {
+	t.Parallel()
+
+	const numIntents = 2
+	const numVTXORequests = 3
+
+	roundID := testRoundIDDB("test-round-decoupled-vtxo")
+
+	ctx := t.Context()
+	roundStore, db := newRoundStoreForTest(t)
+
+	// Set up boarding store for FK constraints.
+	boardingDB := NewTransactionExecutor(
+		db,
+		func(tx *sql.Tx) BoardingStore {
+			return db.WithTx(tx)
+		},
+		btclog.Disabled,
+	)
+	boardingStore := NewBoardingWalletStore(
+		boardingDB, &chaincfg.RegressionNetParams,
+		clock.NewDefaultClock(),
+	)
+
+	// Create 2 boarding intent fixtures.
+	fixtures := make([]*boardingIntentFixture, numIntents)
+	for i := 0; i < numIntents; i++ {
+		fixtures[i] = createBoardingIntentFixture(t, roundID, i)
+
+		err := boardingStore.InsertBoardingAddress(
+			ctx, fixtures[i].boardingAddr,
+		)
+		require.NoError(t, err)
+
+		err = boardingStore.InsertBoardingIntents(
+			ctx, fixtures[i].walletIntent,
+		)
+		require.NoError(t, err)
+	}
+
+	// Build boarding intents from fixtures.
+	roundIntents := make([]round.BoardingIntent, numIntents)
+	inputSigs := make([]*types.BoardingInputSignature, numIntents)
+	clientTrees := make(map[round.SignerKey]*tree.Tree)
+	for i, f := range fixtures {
+		roundIntents[i] = f.roundIntent
+		inputSigs[i] = f.inputSig
+		clientTrees[f.clientTreeKey] = f.clientTree
+	}
+
+	// Create 3 VTXO requests (more than boarding intents) to test
+	// decoupled storage.
+	allVtxos := make([]types.VTXORequest, numVTXORequests)
+	for i := 0; i < numVTXORequests; i++ {
+		privKey, err := btcec.NewPrivateKey()
+		require.NoError(t, err)
+		operatorKey, err := btcec.NewPrivateKey()
+		require.NoError(t, err)
+
+		signingKey := keychain.KeyDescriptor{
+			PubKey: privKey.PubKey(),
+			KeyLocator: keychain.KeyLocator{
+				Family: keychain.KeyFamily(50),
+				Index:  uint32(i),
+			},
+		}
+
+		allVtxos[i] = types.VTXORequest{
+			Amount:      btcutil.Amount(30000 * (i + 1)),
+			PkScript:    fixtures[0].pkScript,
+			Expiry:      144,
+			ClientKey:   privKey.PubKey(),
+			OperatorKey: operatorKey.PubKey(),
+			SigningKey:  signingKey,
+		}
+	}
+
+	// Create commitment tx with inputs from all boarding intents.
+	tx := wire.NewMsgTx(2)
+	for _, f := range fixtures {
+		tx.AddTxIn(&wire.TxIn{
+			PreviousOutPoint: f.outpoint,
+		})
+	}
+	tx.AddTxOut(&wire.TxOut{
+		Value:    180000,
+		PkScript: fixtures[0].pkScript,
+	})
+	commitTx, err := psbt.NewFromUnsignedTx(tx)
+	require.NoError(t, err)
+
+	// Create VTXT tree. The output value must equal sum of leaf amounts
+	// (30000 + 60000 + 90000 = 180000).
+	vtxtTreeOutpoint := wire.OutPoint{
+		Hash:  chainhash.Hash{0x02},
+		Index: 0,
+	}
+	vtxtTreeOutput := &wire.TxOut{
+		Value:    180000,
+		PkScript: fixtures[0].pkScript,
+	}
+	vtxtLeaves := make([]tree.LeafDescriptor, numVTXORequests)
+	for i := 0; i < numVTXORequests; i++ {
+		vtxtLeaves[i] = tree.LeafDescriptor{
+			PkScript:    fixtures[0].pkScript,
+			Amount:      btcutil.Amount(30000 * (i + 1)),
+			CoSignerKey: allVtxos[i].ClientKey,
+		}
+	}
+	vtxtTree, err := tree.NewTree(
+		vtxtTreeOutpoint, vtxtTreeOutput, vtxtLeaves,
+		fixtures[0].operatorKey, nil, 2,
+	)
+	require.NoError(t, err)
+
+	testRound := &round.Round{
+		RoundID:       roundID,
+		CommitmentTx:  fn.Some(commitTx),
+		VTXOTreePaths: fn.Some(map[int]*tree.Tree{0: vtxtTree}),
+		Intents: round.Intents{
+			Boarding: roundIntents,
+			VTXOs:    allVtxos,
+		},
+	}
+
+	state := &round.InputSigSentState{
+		RoundID:       roundID,
+		CommitmentTx:  commitTx,
+		VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
+		Intents: round.Intents{
+			Boarding: roundIntents,
+			VTXOs:    allVtxos,
+		},
+		ClientTrees: clientTrees,
+		InputSigs:   inputSigs,
+	}
+
+	// Commit state.
+	err = roundStore.CommitState(ctx, testRound, state)
+	require.NoError(t, err)
+
+	// Fetch and verify.
+	fetchedRound, fetchedState, err := roundStore.FetchState(ctx, roundID)
+	require.NoError(t, err)
+
+	// Verify boarding intents count.
+	require.Len(
+		t, fetchedRound.Intents.Boarding, numIntents,
+		"expected %d boarding intents", numIntents,
+	)
+
+	// Verify VTXO requests count is different from intents.
+	inputSigState, ok := fetchedState.(*round.InputSigSentState)
+	require.True(t, ok)
+	require.Len(
+		t, inputSigState.Intents.VTXOs, numVTXORequests,
+		"expected %d VTXO requests (decoupled from %d intents)",
+		numVTXORequests, numIntents,
+	)
+
+	// Verify VTXO amounts were preserved correctly.
+	for i, vtxo := range inputSigState.Intents.VTXOs {
+		expectedAmount := btcutil.Amount(30000 * (i + 1))
+		require.Equal(t, expectedAmount, vtxo.Amount,
+			"VTXO %d amount mismatch", i)
+	}
+}
+
 // TestRoundStoreWithBoardingGroup verifies that rounds with boarding intents
 // can be persisted and recovered correctly. This is critical because boarding
 // intents link on-chain UTXOs to virtual transaction outputs - losing this

--- a/db/round_store_test.go
+++ b/db/round_store_test.go
@@ -772,10 +772,13 @@ func TestRoundStoreWithBoardingGroup(t *testing.T) {
 	require.NoError(t, err)
 
 	testRound := &round.Round{
-		RoundID:         roundID,
-		CommitmentTx:    fn.Some(commitTx),
-		VTXOTreePaths:   fn.Some(map[int]*tree.Tree{0: vtxtTree}),
-		BoardingIntents: roundIntents,
+		RoundID:       roundID,
+		CommitmentTx:  fn.Some(commitTx),
+		VTXOTreePaths: fn.Some(map[int]*tree.Tree{0: vtxtTree}),
+		Intents: round.Intents{
+			Boarding: roundIntents,
+			VTXOs:    allVtxos,
+		},
 	}
 
 	// Create the FSM state with all intents, signatures, and client trees.
@@ -808,9 +811,9 @@ func TestRoundStoreWithBoardingGroup(t *testing.T) {
 	require.True(t, fetchedRound.ConfInfo.IsNone())
 
 	// Verify boarding intents were persisted with all intents.
-	require.Len(t, fetchedRound.BoardingIntents, numIntents)
+	require.Len(t, fetchedRound.Intents.Boarding, numIntents)
 	for i, f := range fixtures {
-		fetchedIntent := fetchedRound.BoardingIntents[i]
+		fetchedIntent := fetchedRound.Intents.Boarding[i]
 		require.Equal(t, f.outpoint, fetchedIntent.Outpoint)
 	}
 

--- a/db/round_store_test.go
+++ b/db/round_store_test.go
@@ -622,7 +622,6 @@ func createBoardingIntentFixture(
 		BoardingIntent:  walletIntent,
 		BoardingRequest: boardingRequest,
 		VtxoTemplate:    vtxoTemplates,
-		RoundID:         fn.Some[round.RoundID](roundID),
 	}
 
 	// Create input signature as a BoardingInputSignature.

--- a/db/sqlc/migrations/000003_round_tables.down.sql
+++ b/db/sqlc/migrations/000003_round_tables.down.sql
@@ -8,7 +8,7 @@ DROP TABLE IF EXISTS vtxos;
 
 DROP TABLE IF EXISTS round_client_trees;
 
-DROP TABLE IF EXISTS round_vtxo_templates;
+DROP TABLE IF EXISTS round_vtxo_requests;
 
 DROP INDEX IF EXISTS idx_round_boarding_intents_round_id;
 DROP TABLE IF EXISTS round_boarding_intents;

--- a/db/sqlc/migrations/000003_round_tables.up.sql
+++ b/db/sqlc/migrations/000003_round_tables.up.sql
@@ -117,17 +117,14 @@ CREATE TABLE IF NOT EXISTS round_boarding_intents (
 CREATE INDEX IF NOT EXISTS idx_round_boarding_intents_round_id
     ON round_boarding_intents(round_id);
 
--- Round VTXO templates table.
--- Stores requested VTXOs for each boarding intent.
--- One boarding intent can request multiple VTXOs (1:N relationship).
-CREATE TABLE IF NOT EXISTS round_vtxo_templates (
-    -- Composite FK to round_boarding_intents.
+-- Round VTXO requests table.
+-- Stores VTXO requests for the round.
+CREATE TABLE IF NOT EXISTS round_vtxo_requests (
+    -- round_id links to the parent round.
     round_id TEXT NOT NULL,
-    outpoint_hash BLOB NOT NULL,
-    outpoint_index INTEGER NOT NULL,
 
-    -- template_index is the order of this VTXO within the request.
-    template_index INTEGER NOT NULL,
+    -- request_index preserves request order.
+    request_index INTEGER NOT NULL,
 
     -- VTXORequest.Amount - value in satoshis.
     amount BIGINT NOT NULL,
@@ -153,10 +150,8 @@ CREATE TABLE IF NOT EXISTS round_vtxo_templates (
     -- VTXORequest.SigningKey.PubKey - 33-byte compressed public key.
     signing_pubkey BLOB NOT NULL,
 
-    PRIMARY KEY (round_id, outpoint_hash, outpoint_index, template_index),
-    FOREIGN KEY (round_id, outpoint_hash, outpoint_index)
-        REFERENCES round_boarding_intents(round_id, outpoint_hash, outpoint_index)
-        ON DELETE CASCADE
+    PRIMARY KEY (round_id, request_index),
+    FOREIGN KEY (round_id) REFERENCES rounds(round_id) ON DELETE CASCADE
 );
 
 -- Client trees table.

--- a/db/sqlc/models.go
+++ b/db/sqlc/models.go
@@ -88,11 +88,9 @@ type RoundStatus struct {
 	StatusName string
 }
 
-type RoundVtxoTemplate struct {
+type RoundVtxoRequest struct {
 	RoundID          string
-	OutpointHash     []byte
-	OutpointIndex    int32
-	TemplateIndex    int32
+	RequestIndex     int32
 	Amount           int64
 	PkScript         []byte
 	Expiry           int32

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -13,7 +13,6 @@ type Querier interface {
 	CountUnspentVTXOs(ctx context.Context) (int64, error)
 	DeleteClientTreeTxids(ctx context.Context, arg DeleteClientTreeTxidsParams) error
 	FinalizeRound(ctx context.Context, arg FinalizeRoundParams) error
-	GetAllRoundVtxoTemplates(ctx context.Context, roundID string) ([]RoundVtxoTemplate, error)
 	GetBoardingAddress(ctx context.Context, pkScript []byte) (BoardingAddress, error)
 	GetBoardingIntent(ctx context.Context, arg GetBoardingIntentParams) (BoardingIntent, error)
 	GetChainInfo(ctx context.Context, chainName string) (ChainInfo, error)
@@ -25,7 +24,7 @@ type Querier interface {
 	GetRoundByCommitmentTxid(ctx context.Context, commitmentTxid []byte) (Round, error)
 	GetRoundClientTree(ctx context.Context, arg GetRoundClientTreeParams) (RoundClientTree, error)
 	GetRoundClientTrees(ctx context.Context, roundID string) ([]RoundClientTree, error)
-	GetRoundVtxoTemplates(ctx context.Context, arg GetRoundVtxoTemplatesParams) ([]RoundVtxoTemplate, error)
+	GetRoundVtxoRequests(ctx context.Context, roundID string) ([]RoundVtxoRequest, error)
 	GetVTXO(ctx context.Context, arg GetVTXOParams) (Vtxo, error)
 	// Boarding address queries.
 	InsertBoardingAddress(ctx context.Context, arg InsertBoardingAddressParams) error
@@ -39,8 +38,8 @@ type Querier interface {
 	InsertRoundBoardingIntent(ctx context.Context, arg InsertRoundBoardingIntentParams) error
 	// Client trees queries.
 	InsertRoundClientTree(ctx context.Context, arg InsertRoundClientTreeParams) error
-	// Round VTXO templates queries.
-	InsertRoundVtxoTemplate(ctx context.Context, arg InsertRoundVtxoTemplateParams) error
+	// Round VTXO request queries.
+	InsertRoundVtxoRequest(ctx context.Context, arg InsertRoundVtxoRequestParams) error
 	// VTXO queries.
 	InsertVTXO(ctx context.Context, arg InsertVTXOParams) error
 	ListActiveRounds(ctx context.Context) ([]Round, error)

--- a/db/sqlc/queries/round.sql
+++ b/db/sqlc/queries/round.sql
@@ -60,25 +60,19 @@ UPDATE round_boarding_intents
 SET input_signature = $4, input_index = $5
 WHERE round_id = $1 AND outpoint_hash = $2 AND outpoint_index = $3;
 
--- Round VTXO templates queries.
+-- Round VTXO request queries.
 
--- name: InsertRoundVtxoTemplate :exec
-INSERT INTO round_vtxo_templates (
-    round_id, outpoint_hash, outpoint_index, template_index, amount, pk_script,
-    expiry, client_pubkey, operator_pubkey, signing_key_family, signing_key_index,
-    signing_pubkey
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
-ON CONFLICT (round_id, outpoint_hash, outpoint_index, template_index) DO NOTHING;
+-- name: InsertRoundVtxoRequest :exec
+INSERT INTO round_vtxo_requests (
+    round_id, request_index, amount, pk_script, expiry, client_pubkey,
+    operator_pubkey, signing_key_family, signing_key_index, signing_pubkey
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+    ON CONFLICT (round_id, request_index) DO NOTHING;
 
--- name: GetRoundVtxoTemplates :many
-SELECT * FROM round_vtxo_templates
-WHERE round_id = $1 AND outpoint_hash = $2 AND outpoint_index = $3
-ORDER BY template_index ASC;
-
--- name: GetAllRoundVtxoTemplates :many
-SELECT * FROM round_vtxo_templates
+-- name: GetRoundVtxoRequests :many
+SELECT * FROM round_vtxo_requests
 WHERE round_id = $1
-ORDER BY outpoint_hash, outpoint_index, template_index ASC;
+ORDER BY request_index ASC;
 
 -- Client trees queries.
 

--- a/db/sqlc/round.sql.go
+++ b/db/sqlc/round.sql.go
@@ -64,48 +64,6 @@ func (q *Queries) FinalizeRound(ctx context.Context, arg FinalizeRoundParams) er
 	return err
 }
 
-const GetAllRoundVtxoTemplates = `-- name: GetAllRoundVtxoTemplates :many
-SELECT round_id, outpoint_hash, outpoint_index, template_index, amount, pk_script, expiry, client_pubkey, operator_pubkey, signing_key_family, signing_key_index, signing_pubkey FROM round_vtxo_templates
-WHERE round_id = $1
-ORDER BY outpoint_hash, outpoint_index, template_index ASC
-`
-
-func (q *Queries) GetAllRoundVtxoTemplates(ctx context.Context, roundID string) ([]RoundVtxoTemplate, error) {
-	rows, err := q.db.QueryContext(ctx, GetAllRoundVtxoTemplates, roundID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []RoundVtxoTemplate
-	for rows.Next() {
-		var i RoundVtxoTemplate
-		if err := rows.Scan(
-			&i.RoundID,
-			&i.OutpointHash,
-			&i.OutpointIndex,
-			&i.TemplateIndex,
-			&i.Amount,
-			&i.PkScript,
-			&i.Expiry,
-			&i.ClientPubkey,
-			&i.OperatorPubkey,
-			&i.SigningKeyFamily,
-			&i.SigningKeyIndex,
-			&i.SigningPubkey,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const GetClientTreeByTxid = `-- name: GetClientTreeByTxid :one
 SELECT t.round_id, t.client_key, t.tree_data FROM round_client_trees t
 JOIN client_tree_txids idx ON t.round_id = idx.round_id AND t.client_key = idx.client_key
@@ -301,32 +259,24 @@ func (q *Queries) GetRoundClientTrees(ctx context.Context, roundID string) ([]Ro
 	return items, nil
 }
 
-const GetRoundVtxoTemplates = `-- name: GetRoundVtxoTemplates :many
-SELECT round_id, outpoint_hash, outpoint_index, template_index, amount, pk_script, expiry, client_pubkey, operator_pubkey, signing_key_family, signing_key_index, signing_pubkey FROM round_vtxo_templates
-WHERE round_id = $1 AND outpoint_hash = $2 AND outpoint_index = $3
-ORDER BY template_index ASC
+const GetRoundVtxoRequests = `-- name: GetRoundVtxoRequests :many
+SELECT round_id, request_index, amount, pk_script, expiry, client_pubkey, operator_pubkey, signing_key_family, signing_key_index, signing_pubkey FROM round_vtxo_requests
+WHERE round_id = $1
+ORDER BY request_index ASC
 `
 
-type GetRoundVtxoTemplatesParams struct {
-	RoundID       string
-	OutpointHash  []byte
-	OutpointIndex int32
-}
-
-func (q *Queries) GetRoundVtxoTemplates(ctx context.Context, arg GetRoundVtxoTemplatesParams) ([]RoundVtxoTemplate, error) {
-	rows, err := q.db.QueryContext(ctx, GetRoundVtxoTemplates, arg.RoundID, arg.OutpointHash, arg.OutpointIndex)
+func (q *Queries) GetRoundVtxoRequests(ctx context.Context, roundID string) ([]RoundVtxoRequest, error) {
+	rows, err := q.db.QueryContext(ctx, GetRoundVtxoRequests, roundID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []RoundVtxoTemplate
+	var items []RoundVtxoRequest
 	for rows.Next() {
-		var i RoundVtxoTemplate
+		var i RoundVtxoRequest
 		if err := rows.Scan(
 			&i.RoundID,
-			&i.OutpointHash,
-			&i.OutpointIndex,
-			&i.TemplateIndex,
+			&i.RequestIndex,
 			&i.Amount,
 			&i.PkScript,
 			&i.Expiry,
@@ -514,21 +464,18 @@ func (q *Queries) InsertRoundClientTree(ctx context.Context, arg InsertRoundClie
 	return err
 }
 
-const InsertRoundVtxoTemplate = `-- name: InsertRoundVtxoTemplate :exec
+const InsertRoundVtxoRequest = `-- name: InsertRoundVtxoRequest :exec
 
-INSERT INTO round_vtxo_templates (
-    round_id, outpoint_hash, outpoint_index, template_index, amount, pk_script,
-    expiry, client_pubkey, operator_pubkey, signing_key_family, signing_key_index,
-    signing_pubkey
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
-ON CONFLICT (round_id, outpoint_hash, outpoint_index, template_index) DO NOTHING
+INSERT INTO round_vtxo_requests (
+    round_id, request_index, amount, pk_script, expiry, client_pubkey,
+    operator_pubkey, signing_key_family, signing_key_index, signing_pubkey
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+    ON CONFLICT (round_id, request_index) DO NOTHING
 `
 
-type InsertRoundVtxoTemplateParams struct {
+type InsertRoundVtxoRequestParams struct {
 	RoundID          string
-	OutpointHash     []byte
-	OutpointIndex    int32
-	TemplateIndex    int32
+	RequestIndex     int32
 	Amount           int64
 	PkScript         []byte
 	Expiry           int32
@@ -539,13 +486,11 @@ type InsertRoundVtxoTemplateParams struct {
 	SigningPubkey    []byte
 }
 
-// Round VTXO templates queries.
-func (q *Queries) InsertRoundVtxoTemplate(ctx context.Context, arg InsertRoundVtxoTemplateParams) error {
-	_, err := q.db.ExecContext(ctx, InsertRoundVtxoTemplate,
+// Round VTXO request queries.
+func (q *Queries) InsertRoundVtxoRequest(ctx context.Context, arg InsertRoundVtxoRequestParams) error {
+	_, err := q.db.ExecContext(ctx, InsertRoundVtxoRequest,
 		arg.RoundID,
-		arg.OutpointHash,
-		arg.OutpointIndex,
-		arg.TemplateIndex,
+		arg.RequestIndex,
 		arg.Amount,
 		arg.PkScript,
 		arg.Expiry,

--- a/db/sqlc/schemas/generated_schema.sql
+++ b/db/sqlc/schemas/generated_schema.sql
@@ -204,14 +204,12 @@ CREATE TABLE round_statuses (
     status_name TEXT UNIQUE NOT NULL
 );
 
-CREATE TABLE round_vtxo_templates (
-    -- Composite FK to round_boarding_intents.
+CREATE TABLE round_vtxo_requests (
+    -- round_id links to the parent round.
     round_id TEXT NOT NULL,
-    outpoint_hash BLOB NOT NULL,
-    outpoint_index INTEGER NOT NULL,
 
-    -- template_index is the order of this VTXO within the request.
-    template_index INTEGER NOT NULL,
+    -- request_index preserves request order.
+    request_index INTEGER NOT NULL,
 
     -- VTXORequest.Amount - value in satoshis.
     amount BIGINT NOT NULL,
@@ -237,10 +235,8 @@ CREATE TABLE round_vtxo_templates (
     -- VTXORequest.SigningKey.PubKey - 33-byte compressed public key.
     signing_pubkey BLOB NOT NULL,
 
-    PRIMARY KEY (round_id, outpoint_hash, outpoint_index, template_index),
-    FOREIGN KEY (round_id, outpoint_hash, outpoint_index)
-        REFERENCES round_boarding_intents(round_id, outpoint_hash, outpoint_index)
-        ON DELETE CASCADE
+    PRIMARY KEY (round_id, request_index),
+    FOREIGN KEY (round_id) REFERENCES rounds(round_id) ON DELETE CASCADE
 );
 
 CREATE TABLE rounds (

--- a/round/README.md
+++ b/round/README.md
@@ -58,13 +58,24 @@ instance to process additional addresses across different rounds.
 After receiving an address, the user funds it by broadcasting a Bitcoin
 transaction. Once confirmed via `BoardingUTXOConfirmed`, the FSM transitions
 from Idle to PendingRoundAssembly, registering a boarding intent containing
-the address, on-chain UTXO, and VTXO template (amount, expiry, keys).
+the address and on-chain UTXO information.
 
-The FSM accumulates multiple intents, handling additional `BoardingUTXOConfirmed`
-events as a self-loop. When `RegistrationRequested` is received, it transitions
-to RegistrationSentState, emitting a `JoinRoundRequest` that aggregates all
-intents into a single server request. The FSM can also resume existing intents
-on restart via `ResumeBoardingIntents`.
+Boarding intents and VTXO requests are managed separately, enabling flexible
+input-output mappings. The FSM collects boarding intents (inputs to spend) and
+VTXO requests (outputs to create) independently:
+
+- `BoardingUTXOConfirmed` adds a boarding intent to the pending set
+- `VTXORequestsReceived` adds VTXO requests specifying desired output amounts
+
+This separation supports future fan-in (multiple inputs funding one output) and
+fan-out (one input creating multiple outputs) scenarios. The FSM accumulates
+both types as self-loops in PendingRoundAssembly.
+
+When `RegistrationRequested` is received, the FSM validates that both boarding
+requests and VTXO requests are present, then transitions to RegistrationSentState,
+emitting a `JoinRoundRequest` that aggregates all intents into a single server
+request. The FSM can also resume existing intents on restart via
+`ResumeBoardingIntents`.
 
 ### RegistrationSent and RoundJoined States
 
@@ -227,9 +238,14 @@ sequenceDiagram
     C->>A: AddressReceived (outbox)
     A->>C: User: Wallet deposits to address
 
-    Note over C,B: Intent Registration Phase
+    Note over C,B: Intent Assembly Phase
     B->>A: UTXO confirmed
     A->>C: BoardingUTXOConfirmed
+    Note over A: User specifies VTXO amounts
+    A->>C: VTXORequestsReceived
+
+    Note over C,B: Round Registration Phase
+    A->>C: RegistrationRequested
     C->>A: JoinRoundRequest (outbox)
     A->>S: JoinRound
     S->>A: RoundJoined(roundID)
@@ -278,6 +294,8 @@ Key observations:
 
 - All server-bound messages flow through the outbox, never directly from FSM
 - The actor routes outbox messages to appropriate destinations based on type
+- Boarding intents and VTXO requests are collected separately during the
+  assembly phase, enabling flexible input-output relationships
 - Internal validation (tree extraction, signature verification, descriptor
   building) happens within state transitions, invisible to external systems
 - The checkpoint before sending boarding input signatures is critical for
@@ -313,8 +331,10 @@ during checkpoint.
 stateDiagram-v2
     [*] --> Idle
     Idle --> PendingRoundAssembly: BoardingUTXOConfirmed
+    Idle --> PendingRoundAssembly: VTXORequestsReceived
     Idle --> PendingRoundAssembly: ResumeBoardingIntents
     PendingRoundAssembly --> PendingRoundAssembly: BoardingUTXOConfirmed
+    PendingRoundAssembly --> PendingRoundAssembly: VTXORequestsReceived
     PendingRoundAssembly --> RegistrationSent: RegistrationRequested
     RegistrationSent --> RoundJoined: RoundJoined
     RoundJoined --> CommitmentTxReceived: CommitmentTxBuilt

--- a/round/actor.go
+++ b/round/actor.go
@@ -313,23 +313,6 @@ func (a *RoundClientActor) createNewRound(ctx context.Context) (*RoundFSM, error
 	return roundFSM, nil
 }
 
-// findIdleRound finds an existing round FSM that is in Idle state and can
-// accept new boarding intents. Returns nil if no idle round exists.
-func (a *RoundClientActor) findIdleRound() *RoundFSM {
-	for _, roundFSM := range a.rounds {
-		state, err := roundFSM.FSM.CurrentState()
-		if err != nil {
-			continue
-		}
-
-		if _, ok := state.(*Idle); ok {
-			return roundFSM
-		}
-	}
-
-	return nil
-}
-
 // findAssemblingRound finds a round that is currently assembling intents.
 // It prioritizes PendingRoundAssembly (which already has boarding inputs)
 // over Idle rounds. This ensures VTXOs are attached to rounds that have

--- a/round/actor.go
+++ b/round/actor.go
@@ -127,6 +127,11 @@ type RoundClientConfig struct {
 	// ChainParams are the Bitcoin network parameters.
 	ChainParams *chaincfg.Params
 
+	// MaxOperatorFee is the maximum fee the client is willing to pay per
+	// round. This limits the difference between total boarding input amounts
+	// and total VTXO output amounts.
+	MaxOperatorFee btcutil.Amount
+
 	// VTXOManager receives VTXO creation notifications after rounds
 	// complete. The round actor forwards VTXOCreatedNotification messages
 	// to spawn VTXO actors for newly created VTXOs. Uses actor.Message to
@@ -152,12 +157,13 @@ func NewRoundClientActor(cfg *RoundClientConfig) fn.Result[*RoundClientActor] {
 	// (e.g., lib.NewTreeSignerSession, signing helpers). StartHeight is set
 	// to 0 here and will be set per-round when FSMs are created.
 	env := &ClientEnvironment{
-		RoundStore:    cfg.RoundStore,
-		VTXOStore:     cfg.VTXOStore,
-		Wallet:        cfg.Wallet,
-		OperatorTerms: cfg.OperatorTerms,
-		ChainParams:   cfg.ChainParams,
-		Log:           actorLog,
+		RoundStore:     cfg.RoundStore,
+		VTXOStore:      cfg.VTXOStore,
+		Wallet:         cfg.Wallet,
+		OperatorTerms:  cfg.OperatorTerms,
+		ChainParams:    cfg.ChainParams,
+		MaxOperatorFee: cfg.MaxOperatorFee,
+		Log:            actorLog,
 	}
 
 	if err := ValidateDelayParameters(
@@ -219,13 +225,14 @@ func (a *RoundClientActor) createRoundFSMFromDB(ctx context.Context,
 	fsmLogger := a.log.WithPrefix(fsmPrefix)
 
 	env := &ClientEnvironment{
-		RoundStore:    a.cfg.RoundStore,
-		VTXOStore:     a.cfg.VTXOStore,
-		Wallet:        a.cfg.Wallet,
-		OperatorTerms: a.cfg.OperatorTerms,
-		ChainParams:   a.cfg.ChainParams,
-		Log:           fsmLogger,
-		StartHeight:   startHeight,
+		RoundStore:     a.cfg.RoundStore,
+		VTXOStore:      a.cfg.VTXOStore,
+		Wallet:         a.cfg.Wallet,
+		OperatorTerms:  a.cfg.OperatorTerms,
+		ChainParams:    a.cfg.ChainParams,
+		MaxOperatorFee: a.cfg.MaxOperatorFee,
+		Log:            fsmLogger,
+		StartHeight:    startHeight,
 	}
 	fsmCfg := ClientStateMachineCfg{
 		Logger:        fsmLogger,
@@ -273,13 +280,14 @@ func (a *RoundClientActor) createNewRound(ctx context.Context) (*RoundFSM, error
 	fsmLogger := a.log.WithPrefix(fsmPrefix)
 
 	env := &ClientEnvironment{
-		RoundStore:    a.cfg.RoundStore,
-		VTXOStore:     a.cfg.VTXOStore,
-		Wallet:        a.cfg.Wallet,
-		OperatorTerms: a.cfg.OperatorTerms,
-		ChainParams:   a.cfg.ChainParams,
-		Log:           fsmLogger,
-		StartHeight:   startHeight,
+		RoundStore:     a.cfg.RoundStore,
+		VTXOStore:      a.cfg.VTXOStore,
+		Wallet:         a.cfg.Wallet,
+		OperatorTerms:  a.cfg.OperatorTerms,
+		ChainParams:    a.cfg.ChainParams,
+		MaxOperatorFee: a.cfg.MaxOperatorFee,
+		Log:            fsmLogger,
+		StartHeight:    startHeight,
 	}
 	fsmCfg := ClientStateMachineCfg{
 		Logger:        fsmLogger,
@@ -635,8 +643,10 @@ func (a *RoundClientActor) handleWalletBoardingConfirmed(ctx context.Context,
 		slog.Int("amount", int(walletIntent.ChainInfo.Amount)),
 		slog.Int("conf_height", int(walletIntent.ChainInfo.ConfHeight)))
 
-	// Find an existing Idle round or create a new one.
-	roundFSM := a.findIdleRound()
+	// Find an existing assembling round (Idle or PendingRoundAssembly) or
+	// create a new one. This allows multiple boarding confirmations to
+	// accumulate in the same round.
+	roundFSM := a.findAssemblingRound()
 	if roundFSM == nil {
 		var err error
 		roundFSM, err = a.createNewRound(ctx)

--- a/round/actor.go
+++ b/round/actor.go
@@ -610,7 +610,7 @@ func (a *RoundClientActor) handleWalletBoardingConfirmed(ctx context.Context,
 
 	// Create the FSM event from the wallet's confirmed intent. Wallet only
 	// notifies after min confs, so we set confirmations to 1. Include the
-	// Address and TxProof for building the BoardingRequest.
+	// Address and TxProof for building the Request.
 	confirmEvt := &BoardingUTXOConfirmed{
 		Outpoint:      walletIntent.Outpoint,
 		Address:       walletIntent.Address,

--- a/round/actor.go
+++ b/round/actor.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -15,10 +16,12 @@ import (
 	"github.com/lightninglabs/darepo-client/baselib/actor"
 	"github.com/lightninglabs/darepo-client/baselib/protofsm"
 	"github.com/lightninglabs/darepo-client/chainsource"
+	"github.com/lightninglabs/darepo-client/lib/tree"
 	"github.com/lightninglabs/darepo-client/lib/types"
 	"github.com/lightninglabs/darepo-client/serverconn"
 	"github.com/lightninglabs/darepo-client/wallet"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/keychain"
 )
 
 // Compile-time assertion that RoundClientActor implements actor.Stoppable.
@@ -319,6 +322,38 @@ func (a *RoundClientActor) findIdleRound() *RoundFSM {
 	return nil
 }
 
+// findAssemblingRound finds a round that is currently assembling intents.
+// It prioritizes PendingRoundAssembly (which already has boarding inputs)
+// over Idle rounds. This ensures VTXOs are attached to rounds that have
+// inputs, preventing registration failures from empty input sets.
+func (a *RoundClientActor) findAssemblingRound() *RoundFSM {
+	// First pass: prefer rounds that already have boarding intents.
+	for _, roundFSM := range a.rounds {
+		state, err := roundFSM.FSM.CurrentState()
+		if err != nil {
+			continue
+		}
+
+		if _, ok := state.(*PendingRoundAssembly); ok {
+			return roundFSM
+		}
+	}
+
+	// Second pass: fall back to idle rounds.
+	for _, roundFSM := range a.rounds {
+		state, err := roundFSM.FSM.CurrentState()
+		if err != nil {
+			continue
+		}
+
+		if _, ok := state.(*Idle); ok {
+			return roundFSM
+		}
+	}
+
+	return nil
+}
+
 // findRoundByOutpoints finds a pending round (in RegistrationSentState) whose
 // inputs match the given outpoints. Used to correlate RoundJoined responses to
 // the correct pending round when multiple rounds are in-flight concurrently.
@@ -344,7 +379,7 @@ func (a *RoundClientActor) findRoundByOutpoints(
 		}
 
 		// Check if this round's intents match the boarding outpoints.
-		if a.intentsMatchOutpoints(regState.Intents, boardingSet) {
+		if a.intentsMatchOutpoints(regState.Intents.Boarding, boardingSet) {
 			return roundFSM
 		}
 	}
@@ -562,6 +597,9 @@ func (a *RoundClientActor) Receive(ctx context.Context,
 	case *WalletBoardingConfirmed:
 		return a.handleWalletBoardingConfirmed(ctx, m)
 
+	case *RegisterVTXORequestsRequest:
+		return a.handleVTXORequests(ctx, m)
+
 	case *ServerMessageNotification:
 		return a.handleServerMessage(ctx, m)
 
@@ -629,6 +667,102 @@ func (a *RoundClientActor) handleWalletBoardingConfirmed(ctx context.Context,
 	}
 
 	return fn.Ok[ClientResp](nil)
+}
+
+// handleVTXORequests processes client-submitted VTXO requests and forwards
+// them to an idle round FSM. If no idle round exists, a new one is created.
+func (a *RoundClientActor) handleVTXORequests(ctx context.Context,
+	msg *RegisterVTXORequestsRequest) fn.Result[ClientResp] {
+
+	if len(msg.Amounts) == 0 {
+		return fn.Err[ClientResp](fmt.Errorf(
+			"VTXO request amounts are empty",
+		))
+	}
+
+	requests := make([]types.VTXORequest, 0, len(msg.Amounts))
+	for i, amount := range msg.Amounts {
+		if amount <= 0 {
+			return fn.Err[ClientResp](fmt.Errorf(
+				"VTXO amount %d is invalid: %v", i, amount,
+			))
+		}
+
+		req, err := a.buildVTXORequest(ctx, amount)
+		if err != nil {
+			return fn.Err[ClientResp](fmt.Errorf(
+				"build VTXO request %d: %w", i, err,
+			))
+		}
+
+		requests = append(requests, *req)
+	}
+
+	a.log.InfoS(ctx, "Received VTXO requests",
+		slog.Int("count", len(requests)))
+
+	// Find an existing assembling round (Idle or PendingRoundAssembly) or
+	// create a new one. This allows VTXOs to join a round that already has
+	// boarding intents being assembled.
+	roundFSM := a.findAssemblingRound()
+	if roundFSM == nil {
+		var err error
+		roundFSM, err = a.createNewRound(ctx)
+		if err != nil {
+			return fn.Err[ClientResp](fmt.Errorf(
+				"create new round for VTXO requests: %w", err,
+			))
+		}
+	}
+
+	event := &VTXORequestsReceived{
+		Requests: requests,
+	}
+
+	err := a.askEventAndProcessOutbox(ctx, roundFSM.FSM, event)
+	if err != nil {
+		return fn.Err[ClientResp](fmt.Errorf(
+			"FSM error processing VTXO requests: %w", err,
+		))
+	}
+
+	return fn.Ok[ClientResp](&RegisterVTXORequestsResponse{
+		Success: true,
+	})
+}
+
+// buildVTXORequest derives a signing key and constructs a VTXO request for
+// the provided amount.
+func (a *RoundClientActor) buildVTXORequest(ctx context.Context,
+	amount btcutil.Amount) (*types.VTXORequest, error) {
+
+	keyDesc, err := a.cfg.Wallet.DeriveNextKey(
+		ctx, keychain.KeyFamilyMultiSig,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("derive signing key: %w", err)
+	}
+
+	operatorKey := a.cfg.OperatorTerms.PubKey
+	expiry := a.cfg.OperatorTerms.VTXOExitDelay
+	desc, err := tree.NewVTXODescriptor(
+		amount, keyDesc.PubKey, operatorKey, expiry,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("build VTXO descriptor for amount %v, "+
+			"client %x, operator %x, expiry %d: %w",
+			amount, keyDesc.PubKey.SerializeCompressed(),
+			operatorKey.SerializeCompressed(), expiry, err)
+	}
+
+	return &types.VTXORequest{
+		Amount:      amount,
+		PkScript:    desc.PkScript,
+		Expiry:      expiry,
+		ClientKey:   keyDesc.PubKey,
+		OperatorKey: operatorKey,
+		SigningKey:  *keyDesc,
+	}, nil
 }
 
 // handleRoundJoined handles the RoundJoined event which requires special

--- a/round/actor_harness_test.go
+++ b/round/actor_harness_test.go
@@ -366,17 +366,23 @@ func newActorTestHarness(t *testing.T) *actorTestHarness {
 		MinConfirmations:  1,
 	}
 
+	// Default max operator fee for tests: 100,000 sats (0.001 BTC).
+	// This is generous to avoid test brittleness when multiple intents
+	// are used.
+	const defaultMaxOperatorFee = btcutil.Amount(100000)
+
 	cfg := &RoundClientConfig{
-		Name:          "test-round-actor",
-		Wallet:        walletMock,
-		RoundStore:    roundStore,
-		VTXOStore:     vtxoStore,
-		OperatorTerms: operatorTerms,
-		ServerConn:    serverConn,
-		ChainSource:   chainSource,
-		WalletActor:   walletActor,
-		SelfRef:       selfRef,
-		ChainParams:   &chaincfg.MainNetParams,
+		Name:           "test-round-actor",
+		Wallet:         walletMock,
+		RoundStore:     roundStore,
+		VTXOStore:      vtxoStore,
+		OperatorTerms:  operatorTerms,
+		ServerConn:     serverConn,
+		ChainSource:    chainSource,
+		WalletActor:    walletActor,
+		SelfRef:        selfRef,
+		ChainParams:    &chaincfg.MainNetParams,
+		MaxOperatorFee: defaultMaxOperatorFee,
 	}
 
 	actorResult := NewRoundClientActor(cfg)
@@ -582,8 +588,15 @@ func (h *actorTestHarness) assertFSMState(expectedStateType string) {
 	// No matching state found, print what we have for debugging.
 	var foundStates []string
 	for key, stateInfo := range states {
-		foundStates = append(foundStates, fmt.Sprintf("%s=%T",
-			key, stateInfo.State))
+		stateStr := fmt.Sprintf("%s=%T", key, stateInfo.State)
+
+		// Print additional info for ClientFailedState.
+		if failedState, ok := stateInfo.State.(*ClientFailedState); ok {
+			stateStr = fmt.Sprintf("%s (reason=%q, err=%v)",
+				stateStr, failedState.Reason, failedState.Error)
+		}
+
+		foundStates = append(foundStates, stateStr)
 	}
 	h.t.Fatalf("expected state containing %q, got: %v",
 		expectedStateType, foundStates)

--- a/round/actor_harness_test.go
+++ b/round/actor_harness_test.go
@@ -602,6 +602,34 @@ func (h *actorTestHarness) clearServerMessages() {
 	h.serverConn.clearMessages()
 }
 
+// sendVTXORequests sends VTXO request amounts to the actor. This sets up the
+// mock wallet to return key descriptors for each amount, then sends a
+// RegisterVTXORequestsRequest message.
+func (h *actorTestHarness) sendVTXORequests(amounts ...btcutil.Amount) {
+	h.t.Helper()
+
+	// Setup mock to return a key descriptor for each DeriveNextKey call.
+	for i := range amounts {
+		keyDesc := &keychain.KeyDescriptor{
+			PubKey: h.clientPubKey,
+			KeyLocator: keychain.KeyLocator{
+				Family: keychain.KeyFamilyMultiSig,
+				Index:  uint32(i),
+			},
+		}
+		h.wallet.On(
+			"DeriveNextKey", mock.Anything,
+			keychain.KeyFamilyMultiSig,
+		).Return(keyDesc, nil).Once()
+	}
+
+	msg := &RegisterVTXORequestsRequest{Amounts: amounts}
+	result := h.receive(msg)
+	require.True(
+		h.t, result.IsOk(), "actor receive failed: %v", result.Err(),
+	)
+}
+
 // newTestRound creates a test Round with a unique commitment transaction,
 // using the roundID in the script to ensure distinct transaction hashes.
 func (h *actorTestHarness) newTestRound(roundID RoundID) *Round {

--- a/round/actor_messages.go
+++ b/round/actor_messages.go
@@ -5,7 +5,6 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
-	"github.com/lightninglabs/darepo-client/lib/types"
 	"github.com/lightninglabs/darepo-client/wallet"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 )
@@ -141,35 +140,6 @@ func (m *CancelRoundResponse) MessageType() string {
 }
 
 func (m *CancelRoundResponse) clientRespSealed() {}
-
-// RegisterBoardingIntentRequest informs the FSM that the wallet has funded or
-// will fund a specific boarding address so confirmations should be tracked.
-type RegisterBoardingIntentRequest struct {
-	actor.BaseMessage
-
-	Address      *BoardingAddress
-	VTXORequests []*types.VTXORequest
-}
-
-func (m *RegisterBoardingIntentRequest) MessageType() string {
-	return "RegisterBoardingIntentRequest"
-}
-
-func (m *RegisterBoardingIntentRequest) clientMsgSealed() {}
-
-// RegisterBoardingIntentResponse acknowledges the request.
-type RegisterBoardingIntentResponse struct {
-	actor.BaseMessage
-
-	Success bool
-	Error   string
-}
-
-func (m *RegisterBoardingIntentResponse) MessageType() string {
-	return "RegisterBoardingIntentResponse"
-}
-
-func (m *RegisterBoardingIntentResponse) clientRespSealed() {}
 
 // RegisterVTXORequestsRequest informs the FSM of VTXO request amounts to
 // include in the next round registration.

--- a/round/actor_messages.go
+++ b/round/actor_messages.go
@@ -1,6 +1,7 @@
 package round
 
 import (
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
@@ -169,6 +170,38 @@ func (m *RegisterBoardingIntentResponse) MessageType() string {
 }
 
 func (m *RegisterBoardingIntentResponse) clientRespSealed() {}
+
+// RegisterVTXORequestsRequest informs the FSM of VTXO request amounts to
+// include in the next round registration.
+type RegisterVTXORequestsRequest struct {
+	actor.BaseMessage
+
+	Amounts []btcutil.Amount
+}
+
+// MessageType returns the message type name.
+func (m *RegisterVTXORequestsRequest) MessageType() string {
+	return "RegisterVTXORequestsRequest"
+}
+
+// clientMsgSealed marks this as a client message.
+func (m *RegisterVTXORequestsRequest) clientMsgSealed() {}
+
+// RegisterVTXORequestsResponse acknowledges the request.
+type RegisterVTXORequestsResponse struct {
+	actor.BaseMessage
+
+	Success bool
+	Error   string
+}
+
+// MessageType returns the message type name.
+func (m *RegisterVTXORequestsResponse) MessageType() string {
+	return "RegisterVTXORequestsResponse"
+}
+
+// clientRespSealed marks this as a client response message.
+func (m *RegisterVTXORequestsResponse) clientRespSealed() {}
 
 // ConfirmationEvent wraps a chain confirmation event from ChainSource.
 // This allows the actor to receive confirmation notifications.

--- a/round/actor_test.go
+++ b/round/actor_test.go
@@ -4,11 +4,14 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/tree"
 	"github.com/lightninglabs/darepo-client/lib/types"
 	"github.com/lightninglabs/darepo-client/wallet"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -75,6 +78,7 @@ func TestActorStart(t *testing.T) {
 
 		intent := h.newTestBoardingIntent()
 		h.sendWalletConfirmation(intent)
+		h.sendVTXORequests(50000)
 		h.sendServerMessage(&RegistrationRequested{})
 
 		// When the server signals registration is requested, the
@@ -139,6 +143,70 @@ func TestActorStart(t *testing.T) {
 		// After cancel, the round is removed from rounds map.
 		states := h.queryState()
 		require.Empty(t, states, "round should be removed after cancel")
+	})
+
+	t.Run("registers_vtxo_requests_from_amounts", func(t *testing.T) {
+		t.Parallel()
+
+		h := newActorTestHarness(t)
+		h.setupMockRoundStoreForStart()
+
+		err := h.start()
+		require.NoError(t, err)
+
+		signingKey := &keychain.KeyDescriptor{
+			PubKey: h.clientPubKey,
+			KeyLocator: keychain.KeyLocator{
+				Family: keychain.KeyFamilyMultiSig,
+				Index:  0,
+			},
+		}
+
+		h.wallet.On(
+			"DeriveNextKey", mock.Anything,
+			keychain.KeyFamilyMultiSig,
+		).Return(signingKey, nil).Once()
+
+		amount := btcutil.Amount(50000)
+		msg := &RegisterVTXORequestsRequest{
+			Amounts: []btcutil.Amount{amount},
+		}
+
+		result := h.receive(msg)
+		require.True(t, result.IsOk())
+
+		resp, _ := result.Unpack()
+		registerResp, ok := resp.(*RegisterVTXORequestsResponse)
+		require.True(t, ok)
+		require.True(t, registerResp.Success)
+
+		states := h.queryState()
+		require.Len(t, states, 1, "expected one FSM")
+
+		// Find the temp-keyed round.
+		tempState, found := h.findTempState(states)
+		require.True(t, found, "expected temp-keyed FSM state")
+
+		assembly, ok := tempState.State.(*PendingRoundAssembly)
+		require.True(
+			t, ok, "expected PendingRoundAssembly, got %T",
+			tempState.State,
+		)
+		require.Len(t, assembly.VTXOs, 1)
+
+		expectedDesc, err := tree.NewVTXODescriptor(
+			amount, signingKey.PubKey, h.operatorPubKey,
+			h.operatorTerms.VTXOExitDelay,
+		)
+		require.NoError(t, err)
+
+		req := assembly.VTXOs[0]
+		require.Equal(t, amount, req.Amount)
+		require.Equal(t, expectedDesc.PkScript, req.PkScript)
+		require.Equal(t, h.operatorTerms.VTXOExitDelay, req.Expiry)
+		require.True(t, req.ClientKey.IsEqual(signingKey.PubKey))
+		require.True(t, req.OperatorKey.IsEqual(h.operatorPubKey))
+		require.Equal(t, *signingKey, req.SigningKey)
 	})
 }
 
@@ -716,6 +784,9 @@ func TestActorLifecycle(t *testing.T) {
 		h.sendWalletConfirmation(intent)
 		h.assertFSMState("PendingRoundAssembly")
 
+		// Send VTXO requests before registration.
+		h.sendVTXORequests(50000)
+
 		h.clearServerMessages()
 		h.sendServerMessage(&RegistrationRequested{})
 		h.assertFSMState("RegistrationSentState")
@@ -746,6 +817,9 @@ func TestActorLifecycle(t *testing.T) {
 		h.sendWalletConfirmation(intent2)
 		h.assertFSMState("PendingRoundAssembly")
 
+		// Send VTXO requests before registration.
+		h.sendVTXORequests(50000)
+
 		h.clearServerMessages()
 		h.sendServerMessage(&RegistrationRequested{})
 		h.assertFSMState("RegistrationSentState")
@@ -763,6 +837,7 @@ func TestActorLifecycle(t *testing.T) {
 
 		intent := h.newTestBoardingIntent()
 		h.sendWalletConfirmation(intent)
+		h.sendVTXORequests(50000)
 		h.sendServerMessage(&RegistrationRequested{})
 		h.assertFSMState("RegistrationSentState")
 
@@ -788,7 +863,9 @@ func TestActorLifecycle(t *testing.T) {
 		intent1 := h.newTestBoardingIntentWithSuffix("-first")
 		h.sendWalletConfirmation(intent1)
 
-		// Advance round 1 to RegistrationSentState.
+		// Add VTXO requests and advance to RegistrationSentState (new
+		// transitions require both boarding AND VTXO requests).
+		h.sendVTXORequests(50000)
 		h.sendServerMessage(&RegistrationRequested{})
 
 		// Verify we have one round in RegistrationSentState.
@@ -901,6 +978,7 @@ func TestActorServerMessageRouting(t *testing.T) {
 				require.NoError(h.t, h.start())
 				intent := h.newTestBoardingIntent()
 				h.sendWalletConfirmation(intent)
+				h.sendVTXORequests(50000)
 
 				return intent
 			},
@@ -921,6 +999,7 @@ func TestActorServerMessageRouting(t *testing.T) {
 				require.NoError(h.t, h.start())
 				intent := h.newTestBoardingIntent()
 				h.sendWalletConfirmation(intent)
+				h.sendVTXORequests(50000)
 				h.sendServerMessage(&RegistrationRequested{})
 
 				return intent
@@ -936,7 +1015,7 @@ func TestActorServerMessageRouting(t *testing.T) {
 						continue
 					}
 
-					for _, i := range rs.Intents {
+					for _, i := range rs.Intents.Boarding {
 						outpoints = append(
 							outpoints, i.Outpoint,
 						)

--- a/round/events.go
+++ b/round/events.go
@@ -71,7 +71,7 @@ type BoardingUTXOConfirmed struct {
 	Outpoint wire.OutPoint
 
 	// Address is the boarding address for this UTXO. Contains the keys,
-	// tapscript, and exit delay needed to build the BoardingRequest.
+	// tapscript, and exit delay needed to build the Request.
 	Address wallet.BoardingAddress
 
 	// BlockHeight is the height at which the UTXO was confirmed.

--- a/round/events.go
+++ b/round/events.go
@@ -1,12 +1,15 @@
 package round
 
 import (
+	"log/slog"
+
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/lib/tree"
+	"github.com/lightninglabs/darepo-client/lib/types"
 	"github.com/lightninglabs/darepo-client/wallet"
 	"github.com/lightninglabs/taproot-assets/proof"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
@@ -32,14 +35,31 @@ type ClientOutMsg interface {
 	clientOutMsgSealed()
 }
 
-// ResumeBoardingIntents is emitted to instruct the FSM to resume monitoring
-// boarding intents that were in progress. The intents are provided as a
-// parameter (pre-filtered by the actor) rather than fetched from storage.
+// ResumeBoardingIntents is emitted to instruct the FSM to resume attempting to
+// join a round with previously submitted and confirmed-but-not-adopted
+// intents.
 type ResumeBoardingIntents struct {
-	// Intents are the boarding intents to resume, keyed by their outpoint.
-	// These are pre-filtered to include only Confirmed-but-not-Adopted
-	// intents.
-	Intents map[wire.OutPoint]BoardingIntent
+	// Boarding contains the collected boarding intents to include in the
+	// next round.
+	Boarding []BoardingIntent
+
+	// VTXOs contains the collected VTXO requests to include in the next
+	// round.
+	VTXOs []types.VTXORequest
+}
+
+// isEmpty returns true if there are no boarding intents or VTXO requests
+// to resume.
+func (e *ResumeBoardingIntents) isEmpty() bool {
+	return len(e.Boarding) == 0 && len(e.VTXOs) == 0
+}
+
+// logAttributes returns a map of attributes for logging purposes.
+func (e *ResumeBoardingIntents) logAttributes() []slog.Attr {
+	return []slog.Attr{
+		slog.Int("boarding_intents", len(e.Boarding)),
+		slog.Int("vtxo_requests", len(e.VTXOs)),
+	}
 }
 
 func (e *ResumeBoardingIntents) clientEventSealed() {}

--- a/round/events.go
+++ b/round/events.go
@@ -96,6 +96,17 @@ type BoardingUTXOConfirmed struct {
 
 func (e *BoardingUTXOConfirmed) clientEventSealed() {}
 
+// VTXORequestsReceived is emitted when the client submits VTXO requests that
+// should be included in the next round registration.
+type VTXORequestsReceived struct {
+	// Requests are the VTXO requests to include in the next join round
+	// request.
+	Requests []types.VTXORequest
+}
+
+// clientEventSealed prevents external implementations.
+func (e *VTXORequestsReceived) clientEventSealed() {}
+
 // RegistrationRequested is emitted when the FSM is ready to join a round with
 // the currently confirmed set of boarding intents. The actor should treat this
 // as a batch request containing every confirmed intent.

--- a/round/events.go
+++ b/round/events.go
@@ -79,13 +79,7 @@ func (e *BoardingUTXOConfirmed) clientEventSealed() {}
 // RegistrationRequested is emitted when the FSM is ready to join a round with
 // the currently confirmed set of boarding intents. The actor should treat this
 // as a batch request containing every confirmed intent.
-type RegistrationRequested struct {
-	Intents []BoardingIntent
-
-	// RoundID allows resuming a previously assigned round when rejoining.
-	// None for new registrations.
-	RoundID fn.Option[RoundID]
-}
+type RegistrationRequested struct{}
 
 func (e *RegistrationRequested) clientEventSealed() {}
 

--- a/round/fsm_environment.go
+++ b/round/fsm_environment.go
@@ -1,6 +1,7 @@
 package round
 
 import (
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/lib/types"
@@ -30,6 +31,12 @@ type ClientEnvironment struct {
 	// ChainParams are the Bitcoin network parameters.
 	ChainParams *chaincfg.Params
 
+	// MaxOperatorFee is the maximum fee the client is willing to pay to
+	// the operator per round. This is the difference between total input
+	// (boarding) amounts and total output (VTXO) amounts. If the fee would
+	// exceed this limit, registration is rejected.
+	MaxOperatorFee btcutil.Amount
+
 	// Log is the logger for FSM transitions and operations.
 	Log btclog.Logger
 
@@ -51,16 +58,17 @@ func (e *ClientEnvironment) Name() string {
 // when the FSM is created, used as a HeightHint for confirmation registration.
 func NewClientEnvironment(roundStore RoundStore, vtxoStore VTXOStore,
 	wallet ClientWallet, terms *types.OperatorTerms,
-	chainParams *chaincfg.Params, logger btclog.Logger,
-	startHeight uint32) *ClientEnvironment {
+	chainParams *chaincfg.Params, maxOperatorFee btcutil.Amount,
+	logger btclog.Logger, startHeight uint32) *ClientEnvironment {
 
 	return &ClientEnvironment{
-		RoundStore:    roundStore,
-		VTXOStore:     vtxoStore,
-		Wallet:        wallet,
-		OperatorTerms: terms,
-		ChainParams:   chainParams,
-		Log:           logger,
-		StartHeight:   startHeight,
+		RoundStore:     roundStore,
+		VTXOStore:      vtxoStore,
+		Wallet:         wallet,
+		OperatorTerms:  terms,
+		ChainParams:    chainParams,
+		MaxOperatorFee: maxOperatorFee,
+		Log:            logger,
+		StartHeight:    startHeight,
 	}
 }

--- a/round/harness_test.go
+++ b/round/harness_test.go
@@ -480,7 +480,7 @@ func (h *boardingTestHarness) newTestBoardingIntent() BoardingIntent {
 			},
 			Status: wallet.BoardingStatusConfirmed,
 		},
-		BoardingRequest: types.BoardingRequest{
+		Request: types.BoardingRequest{
 			Outpoint:    &outpoint,
 			ClientKey:   h.clientPubKey,
 			OperatorKey: h.operatorPubKey,
@@ -1091,9 +1091,9 @@ func (h *boardingTestHarness) newNoncesSentState(
 	musig2Sessions := make(map[SignerKey]*tree.SignerSession)
 
 	return &NoncesSentState{
-		RoundID:              roundID,
-		CommitmentTx:         commitmentTx,
-		VTXOTreePaths:        map[int]*tree.Tree{0: vtxtTree},
+		RoundID:       roundID,
+		CommitmentTx:  commitmentTx,
+		VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
 		Intents: Intents{
 			Boarding: intents,
 			VTXOs:    vtxoReqs,
@@ -1146,9 +1146,9 @@ func (h *boardingTestHarness) newNoncesAggregatedState(
 	require.NoError(h.t, err)
 
 	return &NoncesAggregatedState{
-		RoundID:              roundID,
-		CommitmentTx:         commitmentTx,
-		VTXOTreePaths:        map[int]*tree.Tree{0: vtxtTree},
+		RoundID:       roundID,
+		CommitmentTx:  commitmentTx,
+		VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
 		Intents: Intents{
 			Boarding: intents,
 			VTXOs:    vtxoReqs,
@@ -1183,9 +1183,9 @@ func (h *boardingTestHarness) newPartialSigsSentState(
 	}
 
 	return &PartialSigsSentState{
-		RoundID:              roundID,
-		CommitmentTx:         commitmentTx,
-		VTXOTreePaths:        map[int]*tree.Tree{0: vtxtTree},
+		RoundID:       roundID,
+		CommitmentTx:  commitmentTx,
+		VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
 		Intents: Intents{
 			Boarding: intents,
 			VTXOs:    vtxoReqs,
@@ -1650,7 +1650,7 @@ func (h *realSigningTestHarness) newTestBoardingIntentWithTapscript() BoardingIn
 			},
 			Status: wallet.BoardingStatusConfirmed,
 		},
-		BoardingRequest: types.BoardingRequest{
+		Request: types.BoardingRequest{
 			Outpoint:    &outpoint,
 			ClientKey:   h.clientPubKey,
 			OperatorKey: h.operatorPubKey,

--- a/round/harness_test.go
+++ b/round/harness_test.go
@@ -350,10 +350,15 @@ func newTestHarness(t *testing.T) *boardingTestHarness {
 	// Use a mock start height for testing.
 	const testStartHeight uint32 = 100
 
+	// Default max operator fee for tests: 100,000 sats (0.001 BTC).
+	// This is generous to avoid test brittleness when multiple intents
+	// are used.
+	const defaultMaxOperatorFee = btcutil.Amount(100000)
+
 	env := NewClientEnvironment(
 		roundStore, vtxoStore, wallet, terms,
-		&chaincfg.RegressionNetParams, btclog.Disabled,
-		testStartHeight,
+		&chaincfg.RegressionNetParams, defaultMaxOperatorFee,
+		btclog.Disabled, testStartHeight,
 	)
 
 	h := &boardingTestHarness{

--- a/round/harness_test.go
+++ b/round/harness_test.go
@@ -151,6 +151,20 @@ type MockClientWallet struct {
 }
 
 //nolint:forcetypeassert
+func (m *MockClientWallet) DeriveNextKey(ctx context.Context,
+	family keychain.KeyFamily) (*keychain.KeyDescriptor, error) {
+
+	args := m.Called(ctx, family)
+
+	var keyDesc *keychain.KeyDescriptor
+	if args.Get(0) != nil {
+		keyDesc = args.Get(0).(*keychain.KeyDescriptor)
+	}
+
+	return keyDesc, args.Error(1)
+}
+
+//nolint:forcetypeassert
 func (m *MockClientWallet) MuSig2CreateSession(
 	version input.MuSig2Version,
 	keyLoc keychain.KeyLocator,

--- a/round/harness_test.go
+++ b/round/harness_test.go
@@ -469,17 +469,6 @@ func (h *boardingTestHarness) newTestBoardingIntent() BoardingIntent {
 	outpoint := h.newTestOutpoint()
 	address := h.newTestBoardingAddress()
 
-	pkScript, err := txscript.PayToTaprootScript(h.clientPubKey)
-	require.NoError(h.t, err)
-
-	signingKey := keychain.KeyDescriptor{
-		PubKey: h.clientPubKey,
-		KeyLocator: keychain.KeyLocator{
-			Family: keychain.KeyFamilyMultiSig,
-			Index:  0,
-		},
-	}
-
 	return BoardingIntent{
 		BoardingIntent: wallet.BoardingIntent{
 			Address:  address,
@@ -496,16 +485,35 @@ func (h *boardingTestHarness) newTestBoardingIntent() BoardingIntent {
 			ClientKey:   h.clientPubKey,
 			OperatorKey: h.operatorPubKey,
 		},
-		VtxoTemplate: []types.VTXORequest{
-			{
-				Amount:      50000,
-				PkScript:    pkScript,
-				Expiry:      testExitDelay,
-				ClientKey:   h.clientPubKey,
-				OperatorKey: h.operatorPubKey,
-				SigningKey:  signingKey,
-			},
+	}
+}
+
+// newTestVTXORequestForIntent creates a VTXORequest that corresponds to a
+// boarding intent. This is what the client would request as output for their
+// boarding input.
+func (h *boardingTestHarness) newTestVTXORequestForIntent(
+	intent BoardingIntent) types.VTXORequest {
+
+	h.t.Helper()
+
+	pkScript, err := txscript.PayToTaprootScript(h.clientPubKey)
+	require.NoError(h.t, err)
+
+	signingKey := keychain.KeyDescriptor{
+		PubKey: h.clientPubKey,
+		KeyLocator: keychain.KeyLocator{
+			Family: keychain.KeyFamilyMultiSig,
+			Index:  0,
 		},
+	}
+
+	return types.VTXORequest{
+		Amount:      intent.ChainInfo.Amount,
+		PkScript:    pkScript,
+		Expiry:      testExitDelay,
+		ClientKey:   h.clientPubKey,
+		OperatorKey: h.operatorPubKey,
+		SigningKey:  signingKey,
 	}
 }
 
@@ -568,14 +576,18 @@ func (h *boardingTestHarness) newBoardingUTXOConfirmedEvent(
 
 	h.t.Helper()
 
+	// Create a pkScript from the boarding address.
+	pkScript, err := txscript.PayToAddrScript(intent.Address.Address)
+	require.NoError(h.t, err)
+
 	tx := wire.NewMsgTx(2)
 	tx.AddTxOut(&wire.TxOut{
-		Value:    int64(intent.VtxoTemplate[0].Amount),
-		PkScript: intent.VtxoTemplate[0].PkScript,
+		Value:    int64(intent.ChainInfo.Amount),
+		PkScript: pkScript,
 	})
 
 	var blockHash chainhash.Hash
-	_, err := rand.Read(blockHash[:])
+	_, err = rand.Read(blockHash[:])
 	require.NoError(h.t, err)
 
 	return &BoardingUTXOConfirmed{
@@ -636,21 +648,22 @@ func (h *boardingTestHarness) newTestVTXOTree(
 	return vtxtTree, leaves
 }
 
-// newTestVTXOTreeForIntent creates a VTXT tree configured for a specific
-// boarding intent, deriving leaves from the intent's VTXO template to ensure
-// amounts and keys match what the client expects to receive.
-func (h *boardingTestHarness) newTestVTXOTreeForIntent(
-	intent BoardingIntent) *tree.Tree {
+// newTestVTXOTreeForIntents creates a VTXT tree configured for the given VTXO
+// requests, with total amount calculated from the VTXOs.
+func (h *boardingTestHarness) newTestVTXOTreeForIntents(
+	vtxoReqs []types.VTXORequest) *tree.Tree {
 
 	h.t.Helper()
 
-	leaves := make([]tree.LeafDescriptor, len(intent.VtxoTemplate))
-	for i, vtxoReq := range intent.VtxoTemplate {
+	var totalAmount btcutil.Amount
+	leaves := make([]tree.LeafDescriptor, len(vtxoReqs))
+	for i, vtxoReq := range vtxoReqs {
 		leaves[i] = tree.LeafDescriptor{
 			PkScript:    vtxoReq.PkScript,
 			Amount:      vtxoReq.Amount,
 			CoSignerKey: h.clientPubKey,
 		}
+		totalAmount += vtxoReq.Amount
 	}
 
 	batchOutpoint := h.newTestOutpoint()
@@ -659,7 +672,7 @@ func (h *boardingTestHarness) newTestVTXOTreeForIntent(
 	require.NoError(h.t, err)
 
 	batchOutput := &wire.TxOut{
-		Value:    int64(intent.ChainInfo.Amount),
+		Value:    int64(totalAmount),
 		PkScript: batchPkScript,
 	}
 
@@ -815,7 +828,15 @@ func (h *boardingTestHarness) newCommitmentTxReceivedState(
 
 	h.t.Helper()
 
-	vtxtTree := h.newTestVTXOTreeForIntent(intents[0])
+	// Generate VTXO requests from intents.
+	vtxoReqs := make([]types.VTXORequest, len(intents))
+	var totalAmount btcutil.Amount
+	for i, intent := range intents {
+		vtxoReqs[i] = h.newTestVTXORequestForIntent(intent)
+		totalAmount += intent.ChainInfo.Amount
+	}
+
+	vtxtTree := h.newTestVTXOTreeForIntents(vtxoReqs)
 	commitmentTx := h.newTestCommitmentTx(intents)
 
 	return &CommitmentTxReceivedState{
@@ -823,8 +844,11 @@ func (h *boardingTestHarness) newCommitmentTxReceivedState(
 		CommitmentTx:  commitmentTx,
 		TxID:          commitmentTx.UnsignedTx.TxHash(),
 		VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
-		Intents:       intents,
-		ClientTrees:   make(map[SignerKey]*tree.Tree),
+		Intents: Intents{
+			Boarding: intents,
+			VTXOs:    vtxoReqs,
+		},
+		ClientTrees: make(map[SignerKey]*tree.Tree),
 	}
 }
 
@@ -836,7 +860,15 @@ func (h *boardingTestHarness) newCommitmentTxValidatedState(
 
 	h.t.Helper()
 
-	vtxtTree := h.newTestVTXOTreeForIntent(intents[0])
+	// Generate VTXO requests from intents.
+	vtxoReqs := make([]types.VTXORequest, len(intents))
+	var totalAmount btcutil.Amount
+	for i, intent := range intents {
+		vtxoReqs[i] = h.newTestVTXORequestForIntent(intent)
+		totalAmount += intent.ChainInfo.Amount
+	}
+
+	vtxtTree := h.newTestVTXOTreeForIntents(vtxoReqs)
 	commitmentTx := h.newTestCommitmentTx(intents)
 
 	boardingInputIndices := make(map[wire.OutPoint]int)
@@ -845,25 +877,26 @@ func (h *boardingTestHarness) newCommitmentTxValidatedState(
 	}
 
 	// Populate ClientTrees by extracting sub-trees for each signer key
-	// in the intent's VtxoTemplate. This simulates what happens during
-	// commitment tx validation when ValidatePath is called.
+	// in the VTXOs. This simulates what happens during commitment tx
+	// validation when ValidatePath is called.
 	clientTrees := make(map[SignerKey]*tree.Tree)
-	for _, intent := range intents {
-		for _, vtxoReq := range intent.VtxoTemplate {
-			signerKey := NewSignerKey(vtxoReq.SigningKey.PubKey)
+	for _, vtxoReq := range vtxoReqs {
+		signerKey := NewSignerKey(vtxoReq.SigningKey.PubKey)
 
-			// The client tree is a subtree extracted from the VTXT
-			// tree that corresponds to this signer's VTXO. For test
-			// purposes, we use the full tree as the client tree.
-			clientTrees[signerKey] = vtxtTree
-		}
+		// The client tree is a subtree extracted from the VTXT
+		// tree that corresponds to this signer's VTXO. For test
+		// purposes, we use the full tree as the client tree.
+		clientTrees[signerKey] = vtxtTree
 	}
 
 	return &CommitmentTxValidatedState{
-		RoundID:              roundID,
-		CommitmentTx:         commitmentTx,
-		VTXOTreePaths:        map[int]*tree.Tree{0: vtxtTree},
-		Intents:              intents,
+		RoundID:       roundID,
+		CommitmentTx:  commitmentTx,
+		VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
+		Intents: Intents{
+			Boarding: intents,
+			VTXOs:    vtxoReqs,
+		},
 		ClientTrees:          clientTrees,
 		BoardingInputIndices: boardingInputIndices,
 	}
@@ -1039,7 +1072,15 @@ func (h *boardingTestHarness) newNoncesSentState(
 
 	h.t.Helper()
 
-	vtxtTree := h.newTestVTXOTreeForIntent(intents[0])
+	// Generate VTXO requests from intents.
+	vtxoReqs := make([]types.VTXORequest, len(intents))
+	var totalAmount btcutil.Amount
+	for i, intent := range intents {
+		vtxoReqs[i] = h.newTestVTXORequestForIntent(intent)
+		totalAmount += intent.ChainInfo.Amount
+	}
+
+	vtxtTree := h.newTestVTXOTreeForIntents(vtxoReqs)
 	commitmentTx := h.newTestCommitmentTx(intents)
 
 	boardingInputIndices := make(map[wire.OutPoint]int)
@@ -1053,7 +1094,10 @@ func (h *boardingTestHarness) newNoncesSentState(
 		RoundID:              roundID,
 		CommitmentTx:         commitmentTx,
 		VTXOTreePaths:        map[int]*tree.Tree{0: vtxtTree},
-		Intents:              intents,
+		Intents: Intents{
+			Boarding: intents,
+			VTXOs:    vtxoReqs,
+		},
 		ClientTrees:          make(map[SignerKey]*tree.Tree),
 		Musig2Sessions:       musig2Sessions,
 		BoardingInputIndices: boardingInputIndices,
@@ -1066,7 +1110,15 @@ func (h *boardingTestHarness) newNoncesAggregatedState(
 
 	h.t.Helper()
 
-	vtxtTree := h.newTestVTXOTreeForIntent(intents[0])
+	// Generate VTXO requests from intents.
+	vtxoReqs := make([]types.VTXORequest, len(intents))
+	var totalAmount btcutil.Amount
+	for i, intent := range intents {
+		vtxoReqs[i] = h.newTestVTXORequestForIntent(intent)
+		totalAmount += intent.ChainInfo.Amount
+	}
+
+	vtxtTree := h.newTestVTXOTreeForIntents(vtxoReqs)
 	commitmentTx := h.newTestCommitmentTx(intents)
 
 	boardingInputIndices := make(map[wire.OutPoint]int)
@@ -1097,7 +1149,10 @@ func (h *boardingTestHarness) newNoncesAggregatedState(
 		RoundID:              roundID,
 		CommitmentTx:         commitmentTx,
 		VTXOTreePaths:        map[int]*tree.Tree{0: vtxtTree},
-		Intents:              intents,
+		Intents: Intents{
+			Boarding: intents,
+			VTXOs:    vtxoReqs,
+		},
 		ClientTrees:          make(map[SignerKey]*tree.Tree),
 		Musig2Sessions:       make(map[SignerKey]*tree.SignerSession),
 		AggNonces:            aggNonces,
@@ -1111,7 +1166,15 @@ func (h *boardingTestHarness) newPartialSigsSentState(
 
 	h.t.Helper()
 
-	vtxtTree := h.newTestVTXOTreeForIntent(intents[0])
+	// Generate VTXO requests from intents.
+	vtxoReqs := make([]types.VTXORequest, len(intents))
+	var totalAmount btcutil.Amount
+	for i, intent := range intents {
+		vtxoReqs[i] = h.newTestVTXORequestForIntent(intent)
+		totalAmount += intent.ChainInfo.Amount
+	}
+
+	vtxtTree := h.newTestVTXOTreeForIntents(vtxoReqs)
 	commitmentTx := h.newTestCommitmentTx(intents)
 
 	boardingInputIndices := make(map[wire.OutPoint]int)
@@ -1123,7 +1186,10 @@ func (h *boardingTestHarness) newPartialSigsSentState(
 		RoundID:              roundID,
 		CommitmentTx:         commitmentTx,
 		VTXOTreePaths:        map[int]*tree.Tree{0: vtxtTree},
-		BoardingIntents:      intents,
+		Intents: Intents{
+			Boarding: intents,
+			VTXOs:    vtxoReqs,
+		},
 		ClientTrees:          make(map[SignerKey]*tree.Tree),
 		Musig2Sessions:       make(map[SignerKey]*tree.SignerSession),
 		BoardingInputIndices: boardingInputIndices,
@@ -1135,7 +1201,15 @@ func (h *boardingTestHarness) newInputSigSentState(
 
 	h.t.Helper()
 
-	vtxtTree := h.newTestVTXOTreeForIntent(intents[0])
+	// Generate VTXO requests from intents.
+	vtxoReqs := make([]types.VTXORequest, len(intents))
+	var totalAmount btcutil.Amount
+	for i, intent := range intents {
+		vtxoReqs[i] = h.newTestVTXORequestForIntent(intent)
+		totalAmount += intent.ChainInfo.Amount
+	}
+
+	vtxtTree := h.newTestVTXOTreeForIntents(vtxoReqs)
 	commitmentTx := h.newTestCommitmentTx(intents)
 
 	inputSigs := make([]*types.BoardingInputSignature, len(intents))
@@ -1159,20 +1233,21 @@ func (h *boardingTestHarness) newInputSigSentState(
 	}
 
 	clientTrees := make(map[SignerKey]*tree.Tree)
-	for _, intent := range intents {
-		for _, vtxoReq := range intent.VtxoTemplate {
-			signerKey := NewSignerKey(vtxoReq.SigningKey.PubKey)
-			clientTrees[signerKey] = vtxtTree
-		}
+	for _, vtxoReq := range vtxoReqs {
+		signerKey := NewSignerKey(vtxoReq.SigningKey.PubKey)
+		clientTrees[signerKey] = vtxtTree
 	}
 
 	return &InputSigSentState{
 		RoundID:       roundID,
 		CommitmentTx:  commitmentTx,
 		VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
-		Intents:       intents,
-		ClientTrees:   clientTrees,
-		InputSigs:     inputSigs,
+		Intents: Intents{
+			Boarding: intents,
+			VTXOs:    vtxoReqs,
+		},
+		ClientTrees: clientTrees,
+		InputSigs:   inputSigs,
 	}
 }
 
@@ -1564,10 +1639,6 @@ func (h *realSigningTestHarness) newTestBoardingIntentWithTapscript() BoardingIn
 		ExitDelay:   testExitDelay,
 	}
 
-	// Create the P2TR pkScript for the VTXO template output.
-	pkScript, err := txscript.PayToTaprootScript(h.clientPubKey)
-	require.NoError(h.t, err)
-
 	return BoardingIntent{
 		BoardingIntent: wallet.BoardingIntent{
 			Address:  boardingAddr,
@@ -1583,16 +1654,6 @@ func (h *realSigningTestHarness) newTestBoardingIntentWithTapscript() BoardingIn
 			Outpoint:    &outpoint,
 			ClientKey:   h.clientPubKey,
 			OperatorKey: h.operatorPubKey,
-		},
-		VtxoTemplate: []types.VTXORequest{
-			{
-				Amount:      50000,
-				PkScript:    pkScript,
-				Expiry:      testExitDelay,
-				ClientKey:   h.clientPubKey,
-				OperatorKey: h.operatorPubKey,
-				SigningKey:  signingKey,
-			},
 		},
 	}
 }

--- a/round/harness_test.go
+++ b/round/harness_test.go
@@ -1123,7 +1123,7 @@ func (h *boardingTestHarness) newPartialSigsSentState(
 		RoundID:              roundID,
 		CommitmentTx:         commitmentTx,
 		VTXOTreePaths:        map[int]*tree.Tree{0: vtxtTree},
-		Intents:              intents,
+		BoardingIntents:      intents,
 		ClientTrees:          make(map[SignerKey]*tree.Tree),
 		Musig2Sessions:       make(map[SignerKey]*tree.SignerSession),
 		BoardingInputIndices: boardingInputIndices,

--- a/round/interfaces.go
+++ b/round/interfaces.go
@@ -245,9 +245,9 @@ type BoardingIntent struct {
 	// Address, Outpoint, ChainInfo, and Status.
 	wallet.BoardingIntent
 
-	// BoardingRequest is the original boarding request details. It targets
+	// Request is the original boarding request details. It targets
 	// a boarding address by outpoint and includes additional metadata.
-	BoardingRequest types.BoardingRequest
+	Request types.BoardingRequest
 }
 
 // ConfInfo contains chain information about when a round's commitment

--- a/round/interfaces.go
+++ b/round/interfaces.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"slices"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
@@ -212,6 +213,30 @@ const (
 	BoardingStatusSwept = wallet.BoardingStatusSwept
 )
 
+// Intents captures all the client's intents to be included in a single round
+// join request.
+type Intents struct {
+	// Boarding contains all boarding intents to include in the round.
+	Boarding []BoardingIntent
+
+	// VTXOs is the templates for the VTXO(s) requested in the round.
+	//
+	// TODO(roasbeef): add auxleaf for tap here.
+	VTXOs []types.VTXORequest
+
+	// Future extensions:
+	// Forfeits requests
+	// Leave requests
+}
+
+// Clone creates a copy of the Intents.
+func (i *Intents) Clone() Intents {
+	return Intents{
+		Boarding: slices.Clone(i.Boarding),
+		VTXOs:    slices.Clone(i.VTXOs),
+	}
+}
+
 // BoardingIntent captures one confirmed boarding input plus its requested VTXO
 // outputs. This type embeds the wallet's BoardingIntent and adds round-specific
 // fields for tracking VTXO templates and round assignment.
@@ -223,12 +248,6 @@ type BoardingIntent struct {
 	// BoardingRequest is the original boarding request details. It targets
 	// a boarding address by outpoint and includes additional metadata.
 	BoardingRequest types.BoardingRequest
-
-	// VtxoTemplate is the template for the VTXO(s) requested as part of
-	// boarding.
-	//
-	// TODO(roasbeef): add auxleaf for tap here.
-	VtxoTemplate []types.VTXORequest
 }
 
 // ConfInfo contains chain information about when a round's commitment

--- a/round/interfaces.go
+++ b/round/interfaces.go
@@ -413,4 +413,9 @@ type VTXOStore interface {
 // embed Signer here.
 type ClientWallet interface {
 	input.Signer
+
+	// DeriveNextKey derives the next key in the specified key family for
+	// use as a VTXO signing key.
+	DeriveNextKey(ctx context.Context,
+		family keychain.KeyFamily) (*keychain.KeyDescriptor, error)
 }

--- a/round/interfaces.go
+++ b/round/interfaces.go
@@ -229,10 +229,6 @@ type BoardingIntent struct {
 	//
 	// TODO(roasbeef): add auxleaf for tap here.
 	VtxoTemplate []types.VTXORequest
-
-	// RoundID is the identifier of the round this intent was assigned to.
-	// None until the client joins a round.
-	RoundID fn.Option[RoundID]
 }
 
 // ConfInfo contains chain information about when a round's commitment

--- a/round/interfaces.go
+++ b/round/interfaces.go
@@ -292,9 +292,8 @@ type Round struct {
 	// unilateral exit.
 	VTXOTreePaths fn.Option[map[int]*tree.Tree]
 
-	// BoardingIntents contains all boarding intents participating in this
-	// round.
-	BoardingIntents []BoardingIntent
+	// Intents contains all intents participating in this round.
+	Intents Intents
 
 	// Future extensions:
 	// Refreshes []*RefreshIntent

--- a/round/states.go
+++ b/round/states.go
@@ -48,9 +48,13 @@ func (s *Idle) clientStateSealed() {}
 // all intents reach the required confirmations, the FSM transitions to round
 // registration.
 type PendingRoundAssembly struct {
-	// Intents maps outpoint to boarding intent. Only intents with on-chain
-	// UTXOs (i.e., ChainInfo.OutPoint set) are included in this map.
-	Intents map[wire.OutPoint]BoardingIntent
+	// Boarding contains the collected boarding intents to include in the
+	// next round.
+	Boarding []BoardingIntent
+
+	// VTXOs contains the collected VTXO requests to include in the next
+	// round.
+	VTXOs []types.VTXORequest
 }
 
 func (s *PendingRoundAssembly) String() string {
@@ -66,8 +70,8 @@ func (s *PendingRoundAssembly) clientStateSealed() {}
 // RegistrationSentState indicates the client has sent a JoinRoundRequest
 // to the server and is waiting for confirmation.
 type RegistrationSentState struct {
-	// Intents contains all boarding intents being registered in this round.
-	Intents []BoardingIntent
+	// Intents contains all the client's intents for this round.
+	Intents Intents
 }
 
 func (s *RegistrationSentState) String() string {
@@ -87,8 +91,8 @@ type RoundJoinedState struct {
 	// round.
 	RoundID RoundID
 
-	// Intents contains all boarding intents participating in this round.
-	Intents []BoardingIntent
+	// Intents contains all intents participating in this round.
+	Intents Intents
 }
 
 func (s *RoundJoinedState) String() string {
@@ -116,8 +120,8 @@ type CommitmentTxReceivedState struct {
 	// VTXOTreePaths maps commitment tx output indices to VTXO tree paths.
 	VTXOTreePaths map[int]*tree.Tree
 
-	// Intents contains all boarding intents participating in this round.
-	Intents []BoardingIntent
+	// Intents contains all the client's intents for this round.
+	Intents Intents
 
 	// ClientTrees maps signer keys (compressed pubkeys) to the client's
 	// extracted sub-tree for that VTXO.
@@ -146,8 +150,8 @@ type CommitmentTxValidatedState struct {
 	// VTXOTreePaths maps commitment tx output indices to VTXO tree paths.
 	VTXOTreePaths map[int]*tree.Tree
 
-	// Intents contains all boarding intents participating in this round.
-	Intents []BoardingIntent
+	// Intents contains all the client's intents for this round.
+	Intents Intents
 
 	// ClientTrees maps signer keys (compressed pubkeys) to the client's
 	// extracted sub-tree for that VTXO.
@@ -180,8 +184,8 @@ type NoncesSentState struct {
 	// VTXOTreePaths maps commitment tx output indices to VTXO tree paths.
 	VTXOTreePaths map[int]*tree.Tree
 
-	// Intents contains all boarding intents participating in this round.
-	Intents []BoardingIntent
+	// Intents contains all the client's intents for this round.
+	Intents Intents
 
 	// ClientTrees maps signer keys (compressed pubkeys) to the client's
 	// extracted sub-tree for that VTXO.
@@ -218,8 +222,8 @@ type NoncesAggregatedState struct {
 	// VTXOTreePaths maps commitment tx output indices to VTXO tree paths.
 	VTXOTreePaths map[int]*tree.Tree
 
-	// Intents contains all boarding intents participating in this round.
-	Intents []BoardingIntent
+	// Intents contains all the client's intents for this round.
+	Intents Intents
 
 	// ClientTrees maps signer keys (compressed pubkeys) to the client's
 	// extracted sub-tree for that VTXO.
@@ -259,9 +263,8 @@ type PartialSigsSentState struct {
 	// VTXOTreePaths maps commitment tx output indices to VTXO tree paths.
 	VTXOTreePaths map[int]*tree.Tree
 
-	// BoardingIntents contains all boarding intents participating in this
-	// round.
-	BoardingIntents []BoardingIntent
+	// Intents contains all the client's intents for this round.
+	Intents Intents
 
 	// ClientTrees maps signer keys (compressed pubkeys) to the client's
 	// extracted sub-tree for that VTXO.
@@ -298,8 +301,8 @@ type InputSigSentState struct {
 	// VTXOTreePaths maps commitment tx output indices to VTXO tree paths.
 	VTXOTreePaths map[int]*tree.Tree
 
-	// Intents contains all boarding intents participating in this round.
-	Intents []BoardingIntent
+	// Intents contains all the client's intents for this round.
+	Intents Intents
 
 	// ClientTrees maps signer keys (compressed pubkeys) to the client's
 	// extracted sub-tree for that VTXO.

--- a/round/states.go
+++ b/round/states.go
@@ -259,8 +259,9 @@ type PartialSigsSentState struct {
 	// VTXOTreePaths maps commitment tx output indices to VTXO tree paths.
 	VTXOTreePaths map[int]*tree.Tree
 
-	// Intents contains all boarding intents participating in this round.
-	Intents []BoardingIntent
+	// BoardingIntents contains all boarding intents participating in this
+	// round.
+	BoardingIntents []BoardingIntent
 
 	// ClientTrees maps signer keys (compressed pubkeys) to the client's
 	// extracted sub-tree for that VTXO.

--- a/round/transition_table.go
+++ b/round/transition_table.go
@@ -62,7 +62,7 @@ var BoardingClientTransitions = ClientTransitionTable{
 				{
 					Event:       &RegistrationRequested{},
 					ToState:     &RegistrationSentState{},
-					Description: "Intents confirmed, register with server",
+					Description: "BoardingIntents confirmed, register with server",
 					EmitsOutbox: []ClientOutMsg{&JoinRoundRequest{}},
 				},
 				{

--- a/round/transition_table.go
+++ b/round/transition_table.go
@@ -42,6 +42,11 @@ var BoardingClientTransitions = ClientTransitionTable{
 					Description: "First UTXO confirmed, start assembly",
 				},
 				{
+					Event:       &VTXORequestsReceived{},
+					ToState:     &PendingRoundAssembly{},
+					Description: "VTXO requests received, start assembly",
+				},
+				{
 					Event:       &BoardingFailed{},
 					ToState:     &ClientFailedState{},
 					Description: "Boarding failed before any progress",
@@ -60,9 +65,14 @@ var BoardingClientTransitions = ClientTransitionTable{
 					Description: "Additional boarding UTXO confirmed",
 				},
 				{
+					Event:       &VTXORequestsReceived{},
+					ToState:     &PendingRoundAssembly{},
+					Description: "Additional VTXO requests received",
+				},
+				{
 					Event:       &RegistrationRequested{},
 					ToState:     &RegistrationSentState{},
-					Description: "BoardingIntents confirmed, register with server",
+					Description: "Intents confirmed, register with server",
 					EmitsOutbox: []ClientOutMsg{&JoinRoundRequest{}},
 				},
 				{

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -298,30 +298,65 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 			VTXOs:    slices.Clone(s.VTXOs),
 		}
 
-		// TODO(elle): should be able to remove the checks below and
-		// only need to check that total input and output amounts are
-		// sane.
+		// Calculate total input amount from all boarding intents.
+		var totalInput btcutil.Amount
+		for _, boarding := range s.Boarding {
+			totalInput += boarding.ChainInfo.Amount
+		}
+
+		// Calculate total output amount from all VTXO requests.
+		var totalOutput btcutil.Amount
+		for _, vtxo := range s.VTXOs {
+			totalOutput += vtxo.Amount
+		}
+
+		// Validate that we have outputs to create.
+		if totalOutput == 0 {
+			return failWithNotification(
+				"no VTXO output amount",
+				fmt.Errorf("total VTXO output is zero"),
+				true, fn.None[RoundID](),
+			), nil
+		}
+
+		// Validate that outputs don't exceed inputs.
+		if totalOutput > totalInput {
+			return failWithNotification(
+				"outputs exceed inputs",
+				fmt.Errorf(
+					"total output (%d) exceeds total "+
+						"input (%d)",
+					totalOutput, totalInput,
+				),
+				true, fn.None[RoundID](),
+			), nil
+		}
+
+		// Calculate the implicit operator fee (inputs - outputs).
+		operatorFee := totalInput - totalOutput
+
+		// Validate that the operator fee is within acceptable limits.
+		if operatorFee > env.MaxOperatorFee {
+			return failWithNotification(
+				"operator fee exceeds limit",
+				fmt.Errorf(
+					"operator fee (%d) exceeds max "+
+						"allowed (%d)",
+					operatorFee, env.MaxOperatorFee,
+				),
+				true, fn.None[RoundID](),
+			), nil
+		}
+
+		env.Log.InfoS(ctx, "Amount validation passed",
+			btclog.Fmt("total_input", "%v", totalInput),
+			btclog.Fmt("total_output", "%v", totalOutput),
+			btclog.Fmt("operator_fee", "%v", operatorFee))
 
 		// Extract the set of values from the intent map, as we don't
 		// need to track them by outpoint any longer.
 		boardingReqs := fn.Map(s.Boarding, buildBoardingRequest)
-		if len(boardingReqs) == 0 {
-			return failWithNotification(
-				"no boarding requests to register",
-				fmt.Errorf("empty boarding requests"),
-				true, fn.None[RoundID](),
-			), nil
-		}
-
-		// Next, we'll extract all the VTXO requests.
 		vtxoReqs := slices.Clone(s.VTXOs)
-		if len(vtxoReqs) == 0 {
-			return failWithNotification(
-				"no VTXO requests to register",
-				fmt.Errorf("empty VTXO requests"),
-				true, fn.None[RoundID](),
-			), nil
-		}
 
 		env.Log.InfoS(ctx, "Sending JoinRoundRequest to server",
 			slog.Int("boarding_requests", len(boardingReqs)),

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"maps"
 	"slices"
 
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
@@ -20,19 +19,9 @@ import (
 )
 
 // buildBoardingRequest constructs a types.BoardingRequest from a
-// BoardingIntent. This pulls together the outpoint, keys, and exit delay from
-// the embedded wallet intent and address, along with the TxProof from
-// ChainInfo if present.
+// BoardingIntent.
 func buildBoardingRequest(intent BoardingIntent) types.BoardingRequest {
-	addr := intent.Address
-
-	return types.BoardingRequest{
-		Outpoint:    &intent.Outpoint,
-		ClientKey:   addr.KeyDesc.PubKey,
-		OperatorKey: addr.OperatorKey,
-		ExitDelay:   addr.ExitDelay,
-		TxProof:     intent.ChainInfo.TxProof,
-	}
+	return intent.BoardingRequest
 }
 
 // failWithNotification creates a state transition to ClientFailedState and
@@ -78,8 +67,9 @@ func (s *Idle) ProcessEvent(ctx context.Context, event ClientEvent,
 	case *ResumeBoardingIntents:
 		// If for some reason, there aren't any new intents, then we'll
 		// stay in the idle state.
-		if len(evt.Intents) == 0 {
-			env.Log.DebugS(ctx, "ResumeBoardingIntents received with no intents")
+		if evt.isEmpty() {
+			env.Log.DebugS(ctx, "ResumeBoardingIntents received "+
+				"with no intents")
 
 			return &ClientStateTransition{
 				NextState: s,
@@ -87,13 +77,14 @@ func (s *Idle) ProcessEvent(ctx context.Context, event ClientEvent,
 		}
 
 		env.Log.InfoS(ctx, "Resuming boarding intents",
-			slog.Int("intent_count", len(evt.Intents)))
+			evt.logAttributes())
 
 		// Otherwise, we'll start to assemble a round with the resumed
 		// intents.
 		return &ClientStateTransition{
 			NextState: &PendingRoundAssembly{
-				Intents: evt.Intents,
+				Boarding: slices.Clone(evt.Boarding),
+				VTXOs:    slices.Clone(evt.VTXOs),
 			},
 		}, nil
 
@@ -154,28 +145,27 @@ func (s *Idle) ProcessEvent(ctx context.Context, event ClientEvent,
 
 		// Build the VTXO template from the boarding address info. The
 		// client wants a single VTXO with the full confirmed amount.
-		vtxoTemplate := []types.VTXORequest{
-			{
-				Amount: btcutil.Amount(
-					confirmedOutput.Value,
-				),
-				PkScript:    confirmedOutput.PkScript,
-				ClientKey:   evt.Address.KeyDesc.PubKey,
-				OperatorKey: evt.Address.OperatorKey,
-				Expiry:      evt.Address.ExitDelay,
-				SigningKey:  evt.Address.KeyDesc,
-			},
+		//
+		// TODO(elle): support fan-out and fan-in by separating this
+		// direct link between boarding UTXO and VTXO request.
+		// Also: vtxo info should not be directly derived from boarding
+		// info.
+		vtxoIntent := types.VTXORequest{
+			Amount: btcutil.Amount(
+				confirmedOutput.Value,
+			),
+			PkScript:    confirmedOutput.PkScript,
+			ClientKey:   evt.Address.KeyDesc.PubKey,
+			OperatorKey: evt.Address.OperatorKey,
+			Expiry:      evt.Address.ExitDelay,
+			SigningKey:  evt.Address.KeyDesc,
 		}
 
-		// Create the round's BoardingIntent.
-		intent := BoardingIntent{
+		// Create a BoardingIntent for the next round.
+		boardingIntent := BoardingIntent{
 			BoardingIntent:  walletIntent,
 			BoardingRequest: boardingRequest,
-			VtxoTemplate:    vtxoTemplate,
 		}
-
-		intentMap := make(map[wire.OutPoint]BoardingIntent)
-		intentMap[evt.Outpoint] = intent
 
 		env.Log.InfoS(ctx, "Transitioning to PendingRoundAssembly",
 			slog.Int("amount", int(chainInfo.Amount)),
@@ -183,7 +173,8 @@ func (s *Idle) ProcessEvent(ctx context.Context, event ClientEvent,
 
 		return &ClientStateTransition{
 			NextState: &PendingRoundAssembly{
-				Intents: intentMap,
+				Boarding: []BoardingIntent{boardingIntent},
+				VTXOs:    []types.VTXORequest{vtxoIntent},
 			},
 		}, nil
 
@@ -195,9 +186,9 @@ func (s *Idle) ProcessEvent(ctx context.Context, event ClientEvent,
 
 // ProcessEvent for PendingRoundAssembly tracks confirmed boarding intents and
 // transitions to registration once all are ready.
-func (s *PendingRoundAssembly) ProcessEvent(
-	ctx context.Context, event ClientEvent, env *ClientEnvironment,
-) (*ClientStateTransition, error) {
+func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
+	event ClientEvent, env *ClientEnvironment) (*ClientStateTransition,
+	error) {
 
 	switch evt := event.(type) {
 	// A new boarding UTXO was confirmed. The wallet handles persistence;
@@ -205,7 +196,9 @@ func (s *PendingRoundAssembly) ProcessEvent(
 	case *BoardingUTXOConfirmed:
 		env.Log.InfoS(ctx, "Additional boarding UTXO confirmed during assembly",
 			btclog.Fmt("outpoint", "%v", evt.Outpoint),
-			slog.Int("current_intent_count", len(s.Intents)))
+			slog.Int("current_boarding_intent_count", len(s.Boarding)),
+			slog.Int("current_vtxo_intent_count", len(s.VTXOs)))
+
 		if evt.Tx == nil {
 			return failWithNotification(
 				"confirmation event missing transaction",
@@ -226,6 +219,18 @@ func (s *PendingRoundAssembly) ProcessEvent(
 			), nil
 		}
 		confirmedOutput := evt.Tx.TxOut[evt.Outpoint.Index]
+
+		for _, intent := range s.Boarding {
+			if intent.Outpoint != evt.Outpoint {
+				continue
+			}
+
+			env.Log.InfoS(ctx, "Boarding UTXO already present in intents map",
+				btclog.Fmt("outpoint", "%v", evt.Outpoint))
+
+			// Self-loop without adding duplicate intent.
+			return selfLoop(s), nil
+		}
 
 		// Create the chain info from the confirmation event, including
 		// the TxProof for SPV verification.
@@ -255,32 +260,34 @@ func (s *PendingRoundAssembly) ProcessEvent(
 
 		// Build the VTXO template from the boarding address info. The
 		// client wants a single VTXO with the full confirmed amount.
-		vtxoTemplate := []types.VTXORequest{
-			{
-				Amount: btcutil.Amount(
-					confirmedOutput.Value,
-				),
-				PkScript:    confirmedOutput.PkScript,
-				ClientKey:   evt.Address.KeyDesc.PubKey,
-				OperatorKey: evt.Address.OperatorKey,
-				Expiry:      evt.Address.ExitDelay,
-				SigningKey:  evt.Address.KeyDesc,
-			},
+		vtxoIntent := types.VTXORequest{
+			Amount: btcutil.Amount(
+				confirmedOutput.Value,
+			),
+			PkScript:    confirmedOutput.PkScript,
+			ClientKey:   evt.Address.KeyDesc.PubKey,
+			OperatorKey: evt.Address.OperatorKey,
+			Expiry:      evt.Address.ExitDelay,
+			SigningKey:  evt.Address.KeyDesc,
 		}
 
 		intent := BoardingIntent{
 			BoardingIntent:  walletIntent,
 			BoardingRequest: boardingRequest,
-			VtxoTemplate:    vtxoTemplate,
 		}
 
-		// Add the newly confirmed intent to our map.
-		updatedIntents := maps.Clone(s.Intents)
-		updatedIntents[evt.Outpoint] = intent
+		// Add the new intent to our existing set.
+		updatedBoardingIntents := slices.Clone(s.Boarding)
+		updatedBoardingIntents = append(updatedBoardingIntents, intent)
+
+		// Also add the new VTXO intent.
+		updatedVTXOIntents := slices.Clone(s.VTXOs)
+		updatedVTXOIntents = append(updatedVTXOIntents, vtxoIntent)
 
 		return &ClientStateTransition{
 			NextState: &PendingRoundAssembly{
-				Intents: updatedIntents,
+				Boarding: updatedBoardingIntents,
+				VTXOs:    updatedVTXOIntents,
 			},
 		}, nil
 
@@ -289,13 +296,21 @@ func (s *PendingRoundAssembly) ProcessEvent(
 	// transition to the next phase.
 	case *RegistrationRequested:
 		env.Log.InfoS(ctx, "Registration requested, preparing to join round",
-			slog.Int("intent_count", len(s.Intents)))
+			slog.Int("boarding_intent_count", len(s.Boarding)),
+			slog.Int("vtxo_intent_count", len(s.VTXOs)))
+
+		intent := Intents{
+			Boarding: slices.Clone(s.Boarding),
+			VTXOs:    slices.Clone(s.VTXOs),
+		}
+
+		// TODO(elle): should be able to remove the checks below and
+		// only need to check that total input and output amounts are
+		// sane.
 
 		// Extract the set of values from the intent map, as we don't
 		// need to track them by outpoint any longer.
-		//
-		intentSlice := slices.Collect(maps.Values(s.Intents))
-		boardingReqs := fn.Map(intentSlice, buildBoardingRequest)
+		boardingReqs := fn.Map(s.Boarding, buildBoardingRequest)
 		if len(boardingReqs) == 0 {
 			return failWithNotification(
 				"no boarding requests to register",
@@ -304,15 +319,8 @@ func (s *PendingRoundAssembly) ProcessEvent(
 			), nil
 		}
 
-		// Next, we'll extract all the VTXO templates from the set of
-		// nested intents.
-		vtxoReqLists := fn.Map(
-			intentSlice,
-			func(intent BoardingIntent) []types.VTXORequest {
-				return intent.VtxoTemplate
-			},
-		)
-		vtxoReqs := fn.Flatten(vtxoReqLists)
+		// Next, we'll extract all the VTXO requests.
+		vtxoReqs := slices.Clone(s.VTXOs)
 		if len(vtxoReqs) == 0 {
 			return failWithNotification(
 				"no VTXO requests to register",
@@ -329,7 +337,7 @@ func (s *PendingRoundAssembly) ProcessEvent(
 		// to kick off the signing process.
 		return &ClientStateTransition{
 			NextState: &RegistrationSentState{
-				Intents: intentSlice,
+				Intents: intent,
 			},
 			NewEvents: fn.Some(ClientEmittedEvent{
 				Outbox: []ClientOutMsg{
@@ -365,12 +373,13 @@ func (s *RegistrationSentState) ProcessEvent(
 	case *RoundJoined:
 		env.Log.InfoS(ctx, "Successfully joined round",
 			slog.String("round_id", evt.RoundID.String()),
-			slog.Int("intent_count", len(s.Intents)))
+			slog.Int("boarding_intent_count", len(s.Intents.Boarding)),
+			slog.Int("vtxo_intent_count", len(s.Intents.VTXOs)))
 
 		return &ClientStateTransition{
 			NextState: &RoundJoinedState{
 				RoundID: evt.RoundID,
-				Intents: slices.Clone(s.Intents),
+				Intents: s.Intents.Clone(),
 			},
 		}, nil
 
@@ -410,7 +419,7 @@ func (s *RoundJoinedState) ProcessEvent(
 				CommitmentTx:  evt.Tx,
 				TxID:          txid,
 				VTXOTreePaths: evt.VTXOTreePaths,
-				Intents:       slices.Clone(s.Intents),
+				Intents:       s.Intents.Clone(),
 				ClientTrees:   make(map[SignerKey]*tree.Tree),
 			},
 			NewEvents: fn.Some(ClientEmittedEvent{
@@ -474,12 +483,13 @@ func (s *CommitmentTxReceivedState) ProcessEvent(
 	case *CommitmentTxBuilt:
 		env.Log.InfoS(ctx, "Validating commitment transaction",
 			slog.String("round_id", s.RoundID.String()),
-			slog.Int("intent_count", len(s.Intents)))
+			slog.Int("boarding_intent_count", len(s.Intents.Boarding)),
+			slog.Int("vtxo_intent_count", len(s.Intents.VTXOs)))
 
 		// First, well make sure that all boarding UTXOs are present
 		// in the round transaction and build the outpoint-to-index map.
 		boardingInputIndices, err := validateBoardingInputs(
-			s.CommitmentTx.UnsignedTx, s.Intents,
+			s.CommitmentTx.UnsignedTx, s.Intents.Boarding,
 		)
 		if err != nil {
 			env.Log.WarnS(ctx, "Commitment tx validation failed", err,
@@ -503,13 +513,7 @@ func (s *CommitmentTxReceivedState) ProcessEvent(
 		// Next, we'll make sure that each of the VTXO requests that we
 		// originally requested are actually present in the VTXT trees
 		// that the server sent us.
-		vtxoRequests := fn.Map(
-			s.Intents,
-			func(intent BoardingIntent) []types.VTXORequest {
-				return intent.VtxoTemplate
-			},
-		)
-		for i, vtxoReq := range fn.Flatten(vtxoRequests) {
+		for i, vtxoReq := range s.Intents.VTXOs {
 			// Convert VTXORequest to LeafDescriptor for validation.
 			expectedLeaf := tree.LeafDescriptor{
 				Amount:      vtxoReq.Amount,
@@ -605,7 +609,7 @@ func (s *CommitmentTxReceivedState) ProcessEvent(
 				RoundID:              s.RoundID,
 				CommitmentTx:         s.CommitmentTx,
 				VTXOTreePaths:        s.VTXOTreePaths,
-				Intents:              slices.Clone(s.Intents),
+				Intents:              s.Intents.Clone(),
 				ClientTrees:          clientTrees,
 				BoardingInputIndices: boardingInputIndices,
 			},
@@ -638,58 +642,57 @@ func (s *CommitmentTxValidatedState) ProcessEvent(
 	case *GenerateNonces:
 		env.Log.InfoS(ctx, "Generating MuSig2 nonces for VTXO tree signing",
 			slog.String("round_id", s.RoundID.String()),
-			slog.Int("intent_count", len(s.Intents)))
+			slog.Int("boarding_intent_count", len(s.Intents.Boarding)),
+			slog.Int("vtxo_intent_count", len(s.Intents.VTXOs)))
 
 		// At this point, all the basic validation checks have passed.
 		// So now we'll generate a musig2 session to create nonces to
 		// sign the VTXO tree. Each VTXO that we created will
 		// effectively be a new musig session.
 		musig2Sessions := make(map[SignerKey]*tree.SignerSession)
-		for _, boardingIntent := range s.Intents {
-			for _, vtxoReq := range boardingIntent.VtxoTemplate {
-				signerKey := NewSignerKey(
-					vtxoReq.SigningKey.PubKey,
+		for _, vtxoReq := range s.Intents.VTXOs {
+			signerKey := NewSignerKey(
+				vtxoReq.SigningKey.PubKey,
+			)
+
+			// Get the client tree for this signer key.
+			// The sweep tweak and batch output are
+			// properties of the tree that were set when
+			// the operator built it.
+			clientTree := s.ClientTrees[signerKey]
+			if clientTree == nil {
+				return nil, fmt.Errorf(
+					"no client tree for signer "+
+						"key %x", signerKey[:],
 				)
-
-				// Get the client tree for this signer key.
-				// The sweep tweak and batch output are
-				// properties of the tree that were set when
-				// the operator built it.
-				clientTree := s.ClientTrees[signerKey]
-				if clientTree == nil {
-					return nil, fmt.Errorf(
-						"no client tree for signer "+
-							"key %x", signerKey[:],
-					)
-				}
-
-				sweepTweak := clientTree.SweepTapscriptRoot
-				prevOutFetcher, err := clientTree.Root.PrevOutputFetcher( //nolint:ll
-					clientTree.BatchOutput,
-				)
-				if err != nil {
-					return nil, fmt.Errorf("failed to "+
-						"create prev output fetcher "+
-						"for signer %x: %w",
-						signerKey[:], err)
-				}
-
-				// TODO(roasbeef): actually use the interface
-				// in front of this?
-				session, err := tree.NewSignerSession(
-					env.Wallet, &vtxoReq.SigningKey,
-					sweepTweak, prevOutFetcher,
-					clientTree.Root,
-				)
-				if err != nil {
-					return nil, fmt.Errorf("failed to "+
-						"create signing session for "+
-						"client %x: %w",
-						signerKey[:], err)
-				}
-
-				musig2Sessions[signerKey] = session
 			}
+
+			sweepTweak := clientTree.SweepTapscriptRoot
+			batchOut := clientTree.BatchOutput
+			root := clientTree.Root
+			prevOutFetcher, err := root.PrevOutputFetcher(batchOut)
+			if err != nil {
+				return nil, fmt.Errorf("failed to "+
+					"create prev output fetcher "+
+					"for signer %x: %w",
+					signerKey[:], err)
+			}
+
+			// TODO(roasbeef): actually use the interface
+			// in front of this?
+			session, err := tree.NewSignerSession(
+				env.Wallet, &vtxoReq.SigningKey,
+				sweepTweak, prevOutFetcher,
+				clientTree.Root,
+			)
+			if err != nil {
+				return nil, fmt.Errorf("failed to "+
+					"create signing session for "+
+					"client %x: %w",
+					signerKey[:], err)
+			}
+
+			musig2Sessions[signerKey] = session
 		}
 
 		// Now that we have all our sessions created, we'll have each
@@ -720,7 +723,7 @@ func (s *CommitmentTxValidatedState) ProcessEvent(
 				RoundID:              s.RoundID,
 				CommitmentTx:         s.CommitmentTx,
 				VTXOTreePaths:        s.VTXOTreePaths,
-				Intents:              slices.Clone(s.Intents),
+				Intents:              s.Intents.Clone(),
 				ClientTrees:          s.ClientTrees,
 				Musig2Sessions:       musig2Sessions,
 				BoardingInputIndices: s.BoardingInputIndices,
@@ -779,7 +782,7 @@ func (s *NoncesSentState) ProcessEvent(
 				RoundID:              s.RoundID,
 				CommitmentTx:         s.CommitmentTx,
 				VTXOTreePaths:        s.VTXOTreePaths,
-				Intents:              slices.Clone(s.Intents),
+				Intents:              s.Intents.Clone(),
 				ClientTrees:          s.ClientTrees,
 				Musig2Sessions:       s.Musig2Sessions,
 				AggNonces:            evt.AggNonces,
@@ -857,7 +860,7 @@ func (s *NoncesAggregatedState) ProcessEvent(
 				RoundID:              s.RoundID,
 				CommitmentTx:         s.CommitmentTx,
 				VTXOTreePaths:        s.VTXOTreePaths,
-				BoardingIntents:      slices.Clone(s.Intents),
+				Intents:              s.Intents.Clone(),
 				ClientTrees:          s.ClientTrees,
 				Musig2Sessions:       s.Musig2Sessions,
 				BoardingInputIndices: s.BoardingInputIndices,
@@ -919,7 +922,7 @@ func (s *PartialSigsSentState) ProcessEvent(
 
 		env.Log.InfoS(ctx, "Validated aggregated signatures, signing boarding inputs",
 			slog.String("round_id", s.RoundID.String()),
-			slog.Int("intent_count", len(s.BoardingIntents)))
+			slog.Int("boarding_intent_count", len(s.Intents.Boarding)))
 
 		// Now that we know all the signatures are valid, we'll sign
 		// off on each of our boarding inputs sent to the server.
@@ -941,7 +944,7 @@ func (s *PartialSigsSentState) ProcessEvent(
 
 		// Build structured boarding input signatures for each intent.
 		var boardingInputSigs []*types.BoardingInputSignature
-		for _, boardingIntent := range s.BoardingIntents {
+		for _, boardingIntent := range s.Intents.Boarding {
 			outpoint := boardingIntent.BoardingRequest.Outpoint
 			inputIdx, found := s.BoardingInputIndices[*outpoint]
 			if !found {
@@ -1008,9 +1011,10 @@ func (s *PartialSigsSentState) ProcessEvent(
 		}
 
 		numSigs := len(boardingInputSigs)
-		if numSigs != len(s.BoardingIntents) {
+		numIntents := len(s.Intents.Boarding)
+		if numSigs != numIntents {
 			return nil, fmt.Errorf("signature count %d != "+
-				"intent count %d", numSigs, len(s.BoardingIntents))
+				"intent count %d", numSigs, numIntents)
 		}
 
 		// Create a single forfeit signature request with all
@@ -1055,8 +1059,9 @@ func (s *PartialSigsSentState) ProcessEvent(
 		//
 		// Mark all intents as Adopted (frozen in this round) and set
 		// their RoundID, then save them alongside the round.
-		adoptedIntents := make([]BoardingIntent, len(s.BoardingIntents))
-		for i, intent := range s.BoardingIntents {
+		numBoardingIntents := len(s.Intents.Boarding)
+		adoptedIntents := make([]BoardingIntent, numBoardingIntents)
+		for i, intent := range s.Intents.Boarding {
 			intent.Status = BoardingStatusAdopted
 			adoptedIntents[i] = intent
 		}
@@ -1079,7 +1084,7 @@ func (s *PartialSigsSentState) ProcessEvent(
 			RoundID:       s.RoundID,
 			CommitmentTx:  s.CommitmentTx,
 			VTXOTreePaths: s.VTXOTreePaths,
-			Intents:       slices.Clone(s.BoardingIntents),
+			Intents:       s.Intents.Clone(),
 			ClientTrees:   s.ClientTrees,
 			InputSigs:     boardingInputSigs,
 		}
@@ -1118,46 +1123,39 @@ func (s *PartialSigsSentState) ProcessEvent(
 	}
 }
 
-// buildClientVTXOs constructs ClientVTXO instances from the boarding intents
-// and client trees.
-func buildClientVTXOs(intents []BoardingIntent, trees map[SignerKey]*tree.Tree,
+// buildClientVTXOs constructs ClientVTXO instances from the intents and client
+// trees.
+func buildClientVTXOs(intents Intents, trees map[SignerKey]*tree.Tree,
 	roundID RoundID) ([]*ClientVTXO, error) {
 
 	vtxos := make([]*ClientVTXO, 0)
-	for _, intent := range intents {
-		// Each intent has a VTXO template with one or more requests.
-		for _, req := range intent.VtxoTemplate {
-			signerKey := NewSignerKey(req.SigningKey.PubKey)
-			clientTree := trees[signerKey]
-			if clientTree == nil {
-				return nil, fmt.Errorf("missing client tree " +
-					"for signing key")
+	for _, req := range intents.VTXOs {
+		signerKey := NewSignerKey(req.SigningKey.PubKey)
+		clientTree := trees[signerKey]
+		if clientTree == nil {
+			return nil, fmt.Errorf("missing client tree " +
+				"for signing key")
+		}
+
+		leaves := clientTree.Root.GetLeafNodes()
+
+		for _, leaf := range leaves {
+			outpoint, err := leaf.GetNonAnchorOutpoint()
+			if err != nil {
+				return nil, fmt.Errorf("failed to "+
+					"derive VTXO outpoint: %w", err)
 			}
 
-			// Use the key descriptor from the intent's boarding
-			// address.
-			clientKeyDesc := intent.Address.KeyDesc
-
-			leaves := clientTree.Root.GetLeafNodes()
-
-			for _, leaf := range leaves {
-				outpoint, err := leaf.GetNonAnchorOutpoint()
-				if err != nil {
-					return nil, fmt.Errorf("failed to "+
-						"derive VTXO outpoint: %w", err)
-				}
-
-				vtxos = append(vtxos, &ClientVTXO{
-					Outpoint:    *outpoint,
-					Amount:      req.Amount,
-					PkScript:    req.PkScript,
-					Expiry:      req.Expiry,
-					ClientKey:   clientKeyDesc,
-					OperatorKey: req.OperatorKey,
-					TreePath:    clientTree,
-					RoundID:     fn.Some(roundID),
-				})
-			}
+			vtxos = append(vtxos, &ClientVTXO{
+				Outpoint:    *outpoint,
+				Amount:      req.Amount,
+				PkScript:    req.PkScript,
+				Expiry:      req.Expiry,
+				ClientKey:   req.SigningKey,
+				OperatorKey: req.OperatorKey,
+				TreePath:    clientTree,
+				RoundID:     fn.Some(roundID),
+			})
 		}
 	}
 
@@ -1302,12 +1300,12 @@ func (s *ClientFailedState) ProcessEvent(
 	case *ResumeBoardingIntents:
 		// Recovery path: transition to Idle and forward the event.
 		// If no intents are provided, stay in the current state.
-		if len(evt.Intents) == 0 {
+		if evt.isEmpty() {
 			return selfLoop(s), nil
 		}
 
 		env.Log.InfoS(ctx, "Recovering from failed state with resumed intents",
-			slog.Int("intent_count", len(evt.Intents)))
+			evt.logAttributes())
 
 		return &ClientStateTransition{
 			NextState: &Idle{},

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -143,24 +143,6 @@ func (s *Idle) ProcessEvent(ctx context.Context, event ClientEvent,
 			OperatorKey: evt.Address.OperatorKey,
 		}
 
-		// Build the VTXO template from the boarding address info. The
-		// client wants a single VTXO with the full confirmed amount.
-		//
-		// TODO(elle): support fan-out and fan-in by separating this
-		// direct link between boarding UTXO and VTXO request.
-		// Also: vtxo info should not be directly derived from boarding
-		// info.
-		vtxoIntent := types.VTXORequest{
-			Amount: btcutil.Amount(
-				confirmedOutput.Value,
-			),
-			PkScript:    confirmedOutput.PkScript,
-			ClientKey:   evt.Address.KeyDesc.PubKey,
-			OperatorKey: evt.Address.OperatorKey,
-			Expiry:      evt.Address.ExitDelay,
-			SigningKey:  evt.Address.KeyDesc,
-		}
-
 		// Create a BoardingIntent for the next round.
 		boardingIntent := BoardingIntent{
 			BoardingIntent: walletIntent,
@@ -174,7 +156,19 @@ func (s *Idle) ProcessEvent(ctx context.Context, event ClientEvent,
 		return &ClientStateTransition{
 			NextState: &PendingRoundAssembly{
 				Boarding: []BoardingIntent{boardingIntent},
-				VTXOs:    []types.VTXORequest{vtxoIntent},
+				VTXOs:    []types.VTXORequest{},
+			},
+		}, nil
+
+	case *VTXORequestsReceived:
+		env.Log.InfoS(ctx, "Received VTXO requests in Idle state",
+			slog.Int("request_count", len(evt.Requests)))
+
+		// Transition to PendingRoundAssembly with the received VTXO.
+		return &ClientStateTransition{
+			NextState: &PendingRoundAssembly{
+				Boarding: []BoardingIntent{},
+				VTXOs:    slices.Clone(evt.Requests),
 			},
 		}, nil
 
@@ -258,19 +252,6 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 			OperatorKey: evt.Address.OperatorKey,
 		}
 
-		// Build the VTXO template from the boarding address info. The
-		// client wants a single VTXO with the full confirmed amount.
-		vtxoIntent := types.VTXORequest{
-			Amount: btcutil.Amount(
-				confirmedOutput.Value,
-			),
-			PkScript:    confirmedOutput.PkScript,
-			ClientKey:   evt.Address.KeyDesc.PubKey,
-			OperatorKey: evt.Address.OperatorKey,
-			Expiry:      evt.Address.ExitDelay,
-			SigningKey:  evt.Address.KeyDesc,
-		}
-
 		intent := BoardingIntent{
 			BoardingIntent: walletIntent,
 			Request:        boardingRequest,
@@ -280,13 +261,26 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 		updatedBoardingIntents := slices.Clone(s.Boarding)
 		updatedBoardingIntents = append(updatedBoardingIntents, intent)
 
-		// Also add the new VTXO intent.
-		updatedVTXOIntents := slices.Clone(s.VTXOs)
-		updatedVTXOIntents = append(updatedVTXOIntents, vtxoIntent)
-
 		return &ClientStateTransition{
 			NextState: &PendingRoundAssembly{
 				Boarding: updatedBoardingIntents,
+				VTXOs:    slices.Clone(s.VTXOs),
+			},
+		}, nil
+
+	case *VTXORequestsReceived:
+		env.Log.InfoS(ctx, "Additional VTXO requests received during assembly",
+			slog.Int("current_boarding_intent_count", len(s.Boarding)),
+			slog.Int("current_vtxo_intent_count", len(s.VTXOs)),
+			slog.Int("new_request_count", len(evt.Requests)))
+
+		// Add the new VTXO requests to our existing set.
+		updatedVTXOIntents := slices.Clone(s.VTXOs)
+		updatedVTXOIntents = append(updatedVTXOIntents, evt.Requests...)
+
+		return &ClientStateTransition{
+			NextState: &PendingRoundAssembly{
+				Boarding: slices.Clone(s.Boarding),
 				VTXOs:    updatedVTXOIntents,
 			},
 		}, nil

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -136,11 +136,13 @@ func (s *Idle) ProcessEvent(ctx context.Context, event ClientEvent,
 			Status:    BoardingStatusConfirmed,
 		}
 
-		// Build the boarding request from the address.
+		// Build the boarding request from the address. Include the exit
+		// delay so the operator can verify the boarding output script.
 		boardingRequest := types.BoardingRequest{
 			Outpoint:    &evt.Outpoint,
 			ClientKey:   evt.Address.KeyDesc.PubKey,
 			OperatorKey: evt.Address.OperatorKey,
+			ExitDelay:   evt.Address.ExitDelay,
 		}
 
 		// Create a BoardingIntent for the next round.
@@ -245,11 +247,13 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 			Status:    BoardingStatusConfirmed,
 		}
 
-		// Build the boarding request from the address.
+		// Build the boarding request from the address. Include the exit
+		// delay so the operator can verify the boarding output script.
 		boardingRequest := types.BoardingRequest{
 			Outpoint:    &evt.Outpoint,
 			ClientKey:   evt.Address.KeyDesc.PubKey,
 			OperatorKey: evt.Address.OperatorKey,
+			ExitDelay:   evt.Address.ExitDelay,
 		}
 
 		intent := BoardingIntent{

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -857,7 +857,7 @@ func (s *NoncesAggregatedState) ProcessEvent(
 				RoundID:              s.RoundID,
 				CommitmentTx:         s.CommitmentTx,
 				VTXOTreePaths:        s.VTXOTreePaths,
-				Intents:              slices.Clone(s.Intents),
+				BoardingIntents:      slices.Clone(s.Intents),
 				ClientTrees:          s.ClientTrees,
 				Musig2Sessions:       s.Musig2Sessions,
 				BoardingInputIndices: s.BoardingInputIndices,
@@ -919,7 +919,7 @@ func (s *PartialSigsSentState) ProcessEvent(
 
 		env.Log.InfoS(ctx, "Validated aggregated signatures, signing boarding inputs",
 			slog.String("round_id", s.RoundID.String()),
-			slog.Int("intent_count", len(s.Intents)))
+			slog.Int("intent_count", len(s.BoardingIntents)))
 
 		// Now that we know all the signatures are valid, we'll sign
 		// off on each of our boarding inputs sent to the server.
@@ -941,7 +941,7 @@ func (s *PartialSigsSentState) ProcessEvent(
 
 		// Build structured boarding input signatures for each intent.
 		var boardingInputSigs []*types.BoardingInputSignature
-		for _, boardingIntent := range s.Intents {
+		for _, boardingIntent := range s.BoardingIntents {
 			outpoint := boardingIntent.BoardingRequest.Outpoint
 			inputIdx, found := s.BoardingInputIndices[*outpoint]
 			if !found {
@@ -1008,9 +1008,9 @@ func (s *PartialSigsSentState) ProcessEvent(
 		}
 
 		numSigs := len(boardingInputSigs)
-		if numSigs != len(s.Intents) {
+		if numSigs != len(s.BoardingIntents) {
 			return nil, fmt.Errorf("signature count %d != "+
-				"intent count %d", numSigs, len(s.Intents))
+				"intent count %d", numSigs, len(s.BoardingIntents))
 		}
 
 		// Create a single forfeit signature request with all
@@ -1055,8 +1055,8 @@ func (s *PartialSigsSentState) ProcessEvent(
 		//
 		// Mark all intents as Adopted (frozen in this round) and set
 		// their RoundID, then save them alongside the round.
-		adoptedIntents := make([]BoardingIntent, len(s.Intents))
-		for i, intent := range s.Intents {
+		adoptedIntents := make([]BoardingIntent, len(s.BoardingIntents))
+		for i, intent := range s.BoardingIntents {
 			intent.Status = BoardingStatusAdopted
 			adoptedIntents[i] = intent
 		}
@@ -1079,7 +1079,7 @@ func (s *PartialSigsSentState) ProcessEvent(
 			RoundID:       s.RoundID,
 			CommitmentTx:  s.CommitmentTx,
 			VTXOTreePaths: s.VTXOTreePaths,
-			Intents:       slices.Clone(s.Intents),
+			Intents:       slices.Clone(s.BoardingIntents),
 			ClientTrees:   s.ClientTrees,
 			InputSigs:     boardingInputSigs,
 		}

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -172,7 +172,6 @@ func (s *Idle) ProcessEvent(ctx context.Context, event ClientEvent,
 			BoardingIntent:  walletIntent,
 			BoardingRequest: boardingRequest,
 			VtxoTemplate:    vtxoTemplate,
-			RoundID:         fn.None[RoundID](),
 		}
 
 		intentMap := make(map[wire.OutPoint]BoardingIntent)
@@ -273,7 +272,6 @@ func (s *PendingRoundAssembly) ProcessEvent(
 			BoardingIntent:  walletIntent,
 			BoardingRequest: boardingRequest,
 			VtxoTemplate:    vtxoTemplate,
-			RoundID:         fn.None[RoundID](),
 		}
 
 		// Add the newly confirmed intent to our map.
@@ -1060,7 +1058,6 @@ func (s *PartialSigsSentState) ProcessEvent(
 		adoptedIntents := make([]BoardingIntent, len(s.Intents))
 		for i, intent := range s.Intents {
 			intent.Status = BoardingStatusAdopted
-			intent.RoundID = fn.Some(s.RoundID)
 			adoptedIntents[i] = intent
 		}
 		round := &Round{

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -21,7 +21,7 @@ import (
 // buildBoardingRequest constructs a types.BoardingRequest from a
 // BoardingIntent.
 func buildBoardingRequest(intent BoardingIntent) types.BoardingRequest {
-	return intent.BoardingRequest
+	return intent.Request
 }
 
 // failWithNotification creates a state transition to ClientFailedState and
@@ -163,8 +163,8 @@ func (s *Idle) ProcessEvent(ctx context.Context, event ClientEvent,
 
 		// Create a BoardingIntent for the next round.
 		boardingIntent := BoardingIntent{
-			BoardingIntent:  walletIntent,
-			BoardingRequest: boardingRequest,
+			BoardingIntent: walletIntent,
+			Request:        boardingRequest,
 		}
 
 		env.Log.InfoS(ctx, "Transitioning to PendingRoundAssembly",
@@ -272,8 +272,8 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 		}
 
 		intent := BoardingIntent{
-			BoardingIntent:  walletIntent,
-			BoardingRequest: boardingRequest,
+			BoardingIntent: walletIntent,
+			Request:        boardingRequest,
 		}
 
 		// Add the new intent to our existing set.
@@ -462,7 +462,7 @@ func validateBoardingInputs(commitmentTx *wire.MsgTx,
 
 	// Validate all intent outpoints are present in the commitment tx.
 	for _, intent := range intents {
-		outpoint := intent.BoardingRequest.Outpoint
+		outpoint := intent.Request.Outpoint
 		if _, found := outpointToIdx[*outpoint]; !found {
 			return nil, fmt.Errorf("boarding UTXO %s not found "+
 				"in commitment tx", outpoint)
@@ -945,7 +945,7 @@ func (s *PartialSigsSentState) ProcessEvent(
 		// Build structured boarding input signatures for each intent.
 		var boardingInputSigs []*types.BoardingInputSignature
 		for _, boardingIntent := range s.Intents.Boarding {
-			outpoint := boardingIntent.BoardingRequest.Outpoint
+			outpoint := boardingIntent.Request.Outpoint
 			inputIdx, found := s.BoardingInputIndices[*outpoint]
 			if !found {
 				return nil, fmt.Errorf("no input index "+

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -1057,20 +1057,18 @@ func (s *PartialSigsSentState) ProcessEvent(
 		// broadcast the commitment transaction. We must persist all
 		// round data to enable recovery if the client restarts.
 		//
-		// Mark all intents as Adopted (frozen in this round) and set
-		// their RoundID, then save them alongside the round.
-		numBoardingIntents := len(s.Intents.Boarding)
-		adoptedIntents := make([]BoardingIntent, numBoardingIntents)
-		for i, intent := range s.Intents.Boarding {
-			intent.Status = BoardingStatusAdopted
-			adoptedIntents[i] = intent
+		// Mark all intents as Adopted (frozen in this round) and then
+		// save them alongside the round.
+		intents := s.Intents.Clone()
+		for i := range intents.Boarding {
+			intents.Boarding[i].Status = BoardingStatusAdopted
 		}
 		round := &Round{
-			RoundID:         s.RoundID,
-			StartHeight:     env.StartHeight,
-			CommitmentTx:    fn.Some(s.CommitmentTx),
-			VTXOTreePaths:   fn.Some(s.VTXOTreePaths),
-			BoardingIntents: adoptedIntents,
+			RoundID:       s.RoundID,
+			StartHeight:   env.StartHeight,
+			CommitmentTx:  fn.Some(s.CommitmentTx),
+			VTXOTreePaths: fn.Some(s.VTXOTreePaths),
+			Intents:       intents,
 		}
 
 		env.Log.InfoS(ctx, "Signed boarding inputs, checkpointing round state",

--- a/round/transitions_test.go
+++ b/round/transitions_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/google/uuid"
@@ -661,8 +662,101 @@ func TestPendingRoundAssemblyState(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, transition)
 
+		// With no VTXOs, total output is zero which fails validation.
 		failedState := assertStateType[*ClientFailedState](h)
-		require.Contains(t, failedState.Reason, "no boarding requests")
+		require.Contains(t, failedState.Reason, "no VTXO output amount")
+	})
+
+	t.Run("output_exceeds_input_fails", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+
+		// Create intent with 50,000 sats.
+		intent := h.newTestBoardingIntent()
+		require.Equal(t, btcutil.Amount(50000), intent.ChainInfo.Amount)
+
+		// Create VTXO request for 60,000 sats (more than input).
+		vtxoReq := h.newTestVTXORequestForIntent(intent)
+		vtxoReq.Amount = btcutil.Amount(60000)
+
+		h.withState(&PendingRoundAssembly{
+			Boarding: []BoardingIntent{intent},
+			VTXOs:    []types.VTXORequest{vtxoReq},
+		})
+
+		event := &RegistrationRequested{}
+
+		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		failedState := assertStateType[*ClientFailedState](h)
+		require.Contains(t, failedState.Reason, "outputs exceed inputs")
+	})
+
+	t.Run("fee_exceeds_max_fails", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+
+		// Set a low max operator fee (1,000 sats).
+		h.env.MaxOperatorFee = btcutil.Amount(1000)
+
+		// Create intent with 50,000 sats.
+		intent := h.newTestBoardingIntent()
+		require.Equal(t, btcutil.Amount(50000), intent.ChainInfo.Amount)
+
+		// Create VTXO request for 40,000 sats, implying 10,000 sat fee.
+		vtxoReq := h.newTestVTXORequestForIntent(intent)
+		vtxoReq.Amount = btcutil.Amount(40000)
+
+		h.withState(&PendingRoundAssembly{
+			Boarding: []BoardingIntent{intent},
+			VTXOs:    []types.VTXORequest{vtxoReq},
+		})
+
+		event := &RegistrationRequested{}
+
+		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		failedState := assertStateType[*ClientFailedState](h)
+		require.Contains(
+			t, failedState.Reason, "operator fee exceeds limit",
+		)
+	})
+
+	t.Run("valid_fee_within_limit_succeeds", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+
+		// Set max operator fee (10,000 sats).
+		h.env.MaxOperatorFee = btcutil.Amount(10000)
+
+		// Create intent with 50,000 sats.
+		intent := h.newTestBoardingIntent()
+
+		// Create VTXO request for 45,000 sats, implying 5,000 sat fee.
+		vtxoReq := h.newTestVTXORequestForIntent(intent)
+		vtxoReq.Amount = btcutil.Amount(45000)
+
+		h.withState(&PendingRoundAssembly{
+			Boarding: []BoardingIntent{intent},
+			VTXOs:    []types.VTXORequest{vtxoReq},
+		})
+
+		event := &RegistrationRequested{}
+
+		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		// Should succeed and transition to RegistrationSentState.
+		nextState := assertStateType[*RegistrationSentState](h)
+		require.Len(t, nextState.Intents.Boarding, 1)
 	})
 }
 

--- a/round/transitions_test.go
+++ b/round/transitions_test.go
@@ -581,8 +581,7 @@ func TestPendingRoundAssemblyState(t *testing.T) {
 			},
 		})
 
-		intents := []BoardingIntent{intent}
-		event := &RegistrationRequested{Intents: intents}
+		event := &RegistrationRequested{}
 
 		transition, err := h.sendEvent(event)
 		require.NoError(t, err)
@@ -600,7 +599,7 @@ func TestPendingRoundAssemblyState(t *testing.T) {
 			Intents: map[wire.OutPoint]BoardingIntent{},
 		})
 
-		event := &RegistrationRequested{Intents: []BoardingIntent{}}
+		event := &RegistrationRequested{}
 
 		transition, err := h.sendEvent(event)
 		require.NoError(t, err)
@@ -1348,7 +1347,7 @@ func TestBoardingFlowIdleToPendingToRegistrationSent(t *testing.T) {
 	h.withState(&PendingRoundAssembly{Intents: intentsMap})
 
 	// Step 1: Request registration.
-	regEvent := &RegistrationRequested{Intents: []BoardingIntent{intent}}
+	regEvent := &RegistrationRequested{}
 	_, err := h.sendEvent(regEvent)
 	require.NoError(t, err)
 
@@ -1395,7 +1394,7 @@ func TestBoardingFlowPendingToRoundJoined(t *testing.T) {
 	h.withState(&PendingRoundAssembly{Intents: intentsMap})
 
 	// Step 1: PendingRoundAssembly → RegistrationSentState.
-	regEvent := &RegistrationRequested{Intents: []BoardingIntent{intent}}
+	regEvent := &RegistrationRequested{}
 	_, err := h.sendEvent(regEvent)
 	require.NoError(t, err)
 

--- a/round/transitions_test.go
+++ b/round/transitions_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/google/uuid"
 	"github.com/lightninglabs/darepo-client/lib/tree"
+	"github.com/lightninglabs/darepo-client/lib/types"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -145,12 +146,11 @@ func TestUnexpectedEventSelfLoop(t *testing.T) {
 			name: "PendingAssembly_self_loops_on_RoundComplete",
 			setup: func(h *boardingTestHarness) ClientState {
 				intent := h.newTestBoardingIntent()
-				intents := map[wire.OutPoint]BoardingIntent{
-					intent.Outpoint: intent,
-				}
+				vtxoReq := h.newTestVTXORequestForIntent(intent)
 
 				return &PendingRoundAssembly{
-					Intents: intents,
+					Boarding: []BoardingIntent{intent},
+					VTXOs:    []types.VTXORequest{vtxoReq},
 				}
 			},
 			event: &RoundComplete{},
@@ -159,9 +159,13 @@ func TestUnexpectedEventSelfLoop(t *testing.T) {
 			name: "RegSent_self_loops_on_BoardingConfirmed",
 			setup: func(h *boardingTestHarness) ClientState {
 				intent := h.newTestBoardingIntent()
-				return &RegistrationSentState{
-					Intents: []BoardingIntent{intent},
+				vtxoReq := h.newTestVTXORequestForIntent(intent)
+				intents := Intents{
+					Boarding: []BoardingIntent{intent},
+					VTXOs:    []types.VTXORequest{vtxoReq},
 				}
+
+				return &RegistrationSentState{Intents: intents}
 			},
 			event: &BoardingConfirmed{},
 		},
@@ -169,9 +173,15 @@ func TestUnexpectedEventSelfLoop(t *testing.T) {
 			name: "RoundJoined_self_loops_on_duplicate_RoundJoined",
 			setup: func(h *boardingTestHarness) ClientState {
 				intent := h.newTestBoardingIntent()
+				vtxoReq := h.newTestVTXORequestForIntent(intent)
+				intents := Intents{
+					Boarding: []BoardingIntent{intent},
+					VTXOs:    []types.VTXORequest{vtxoReq},
+				}
+
 				return &RoundJoinedState{
 					RoundID: testRoundIDTr("round-1"),
-					Intents: []BoardingIntent{intent},
+					Intents: intents,
 				}
 			},
 			event: &RoundJoined{RoundID: testRoundIDTr("other")},
@@ -203,13 +213,18 @@ func TestUnexpectedEventSelfLoop(t *testing.T) {
 			setup: func(h *boardingTestHarness) ClientState {
 				vtxtTree, _ := h.newTestVTXOTree(1)
 				intent := h.newTestBoardingIntent()
+				vtxoReq := h.newTestVTXORequestForIntent(intent)
 				roundID := testRoundIDTr("round-001")
 				trees := map[int]*tree.Tree{0: vtxtTree}
+				intents := Intents{
+					Boarding: []BoardingIntent{intent},
+					VTXOs:    []types.VTXORequest{vtxoReq},
+				}
 
 				return &NoncesSentState{
 					RoundID:       roundID,
 					VTXOTreePaths: trees,
-					Intents:       []BoardingIntent{intent},
+					Intents:       intents,
 				}
 			},
 			event: &RoundJoined{RoundID: testRoundIDTr("other")},
@@ -219,13 +234,18 @@ func TestUnexpectedEventSelfLoop(t *testing.T) {
 			setup: func(h *boardingTestHarness) ClientState {
 				vtxtTree, _ := h.newTestVTXOTree(1)
 				intent := h.newTestBoardingIntent()
+				vtxoReq := h.newTestVTXORequestForIntent(intent)
 				roundID := testRoundIDTr("round-001")
 				trees := map[int]*tree.Tree{0: vtxtTree}
+				intents := Intents{
+					Boarding: []BoardingIntent{intent},
+					VTXOs:    []types.VTXORequest{vtxoReq},
+				}
 
 				return &NoncesAggregatedState{
 					RoundID:       roundID,
 					VTXOTreePaths: trees,
-					Intents:       []BoardingIntent{intent},
+					Intents:       intents,
 				}
 			},
 			event: &RoundJoined{RoundID: testRoundIDTr("other")},
@@ -235,13 +255,18 @@ func TestUnexpectedEventSelfLoop(t *testing.T) {
 			setup: func(h *boardingTestHarness) ClientState {
 				vtxtTree, _ := h.newTestVTXOTree(1)
 				intent := h.newTestBoardingIntent()
+				vtxoReq := h.newTestVTXORequestForIntent(intent)
 				roundID := testRoundIDTr("round-001")
 				trees := map[int]*tree.Tree{0: vtxtTree}
+				intents := Intents{
+					Boarding: []BoardingIntent{intent},
+					VTXOs:    []types.VTXORequest{vtxoReq},
+				}
 
 				return &PartialSigsSentState{
-					RoundID:         roundID,
-					VTXOTreePaths:   trees,
-					BoardingIntents: []BoardingIntent{intent},
+					RoundID:       roundID,
+					VTXOTreePaths: trees,
+					Intents:       intents,
 				}
 			},
 			event: &RoundJoined{RoundID: testRoundIDTr("other")},
@@ -251,13 +276,18 @@ func TestUnexpectedEventSelfLoop(t *testing.T) {
 			setup: func(h *boardingTestHarness) ClientState {
 				vtxtTree, _ := h.newTestVTXOTree(1)
 				intent := h.newTestBoardingIntent()
+				vtxoReq := h.newTestVTXORequestForIntent(intent)
 				roundID := testRoundIDTr("round-001")
 				trees := map[int]*tree.Tree{0: vtxtTree}
+				intents := Intents{
+					Boarding: []BoardingIntent{intent},
+					VTXOs:    []types.VTXORequest{vtxoReq},
+				}
 
 				return &InputSigSentState{
 					RoundID:       roundID,
 					VTXOTreePaths: trees,
-					Intents:       []BoardingIntent{intent},
+					Intents:       intents,
 				}
 			},
 			event: &RoundJoined{RoundID: testRoundIDTr("other")},
@@ -309,18 +339,28 @@ func TestBoardingFailedTransitions(t *testing.T) {
 			name: "RegistrationSentState",
 			setup: func(h *boardingTestHarness) ClientState {
 				intent := h.newTestBoardingIntent()
-				return &RegistrationSentState{
-					Intents: []BoardingIntent{intent},
+				vtxoReq := h.newTestVTXORequestForIntent(intent)
+				intents := Intents{
+					Boarding: []BoardingIntent{intent},
+					VTXOs:    []types.VTXORequest{vtxoReq},
 				}
+
+				return &RegistrationSentState{Intents: intents}
 			},
 		},
 		{
 			name: "RoundJoinedState",
 			setup: func(h *boardingTestHarness) ClientState {
 				intent := h.newTestBoardingIntent()
+				vtxoReq := h.newTestVTXORequestForIntent(intent)
+				intents := Intents{
+					Boarding: []BoardingIntent{intent},
+					VTXOs:    []types.VTXORequest{vtxoReq},
+				}
+
 				return &RoundJoinedState{
 					RoundID: testRoundIDTr("round-001"),
-					Intents: []BoardingIntent{intent},
+					Intents: intents,
 				}
 			},
 		},
@@ -339,13 +379,18 @@ func TestBoardingFailedTransitions(t *testing.T) {
 			setup: func(h *boardingTestHarness) ClientState {
 				vtxtTree, _ := h.newTestVTXOTree(1)
 				intent := h.newTestBoardingIntent()
+				vtxoReq := h.newTestVTXORequestForIntent(intent)
 				roundID := testRoundIDTr("round-001")
 				trees := map[int]*tree.Tree{0: vtxtTree}
+				intents := Intents{
+					Boarding: []BoardingIntent{intent},
+					VTXOs:    []types.VTXORequest{vtxoReq},
+				}
 
 				return &NoncesSentState{
 					RoundID:       roundID,
 					VTXOTreePaths: trees,
-					Intents:       []BoardingIntent{intent},
+					Intents:       intents,
 				}
 			},
 		},
@@ -354,13 +399,18 @@ func TestBoardingFailedTransitions(t *testing.T) {
 			setup: func(h *boardingTestHarness) ClientState {
 				vtxtTree, _ := h.newTestVTXOTree(1)
 				intent := h.newTestBoardingIntent()
+				vtxoReq := h.newTestVTXORequestForIntent(intent)
 				roundID := testRoundIDTr("round-001")
 				trees := map[int]*tree.Tree{0: vtxtTree}
+				intents := Intents{
+					Boarding: []BoardingIntent{intent},
+					VTXOs:    []types.VTXORequest{vtxoReq},
+				}
 
 				return &PartialSigsSentState{
-					RoundID:         roundID,
-					VTXOTreePaths:   trees,
-					BoardingIntents: []BoardingIntent{intent},
+					RoundID:       roundID,
+					VTXOTreePaths: trees,
+					Intents:       intents,
 				}
 			},
 		},
@@ -369,13 +419,18 @@ func TestBoardingFailedTransitions(t *testing.T) {
 			setup: func(h *boardingTestHarness) ClientState {
 				vtxtTree, _ := h.newTestVTXOTree(1)
 				intent := h.newTestBoardingIntent()
+				vtxoReq := h.newTestVTXORequestForIntent(intent)
 				roundID := testRoundIDTr("round-001")
 				trees := map[int]*tree.Tree{0: vtxtTree}
+				intents := Intents{
+					Boarding: []BoardingIntent{intent},
+					VTXOs:    []types.VTXORequest{vtxoReq},
+				}
 
 				return &InputSigSentState{
 					RoundID:       roundID,
 					VTXOTreePaths: trees,
-					Intents:       []BoardingIntent{intent},
+					Intents:       intents,
 				}
 			},
 		},
@@ -464,8 +519,7 @@ func TestIdleState(t *testing.T) {
 		require.NotNil(t, transition)
 
 		nextState := assertStateType[*PendingRoundAssembly](h)
-		require.Len(t, nextState.Intents, 1)
-		require.Contains(t, nextState.Intents, intent.Outpoint)
+		require.Len(t, nextState.Boarding, 1)
 	})
 
 	t.Run("ResumeBoardingIntents_with_intents", func(t *testing.T) {
@@ -475,10 +529,10 @@ func TestIdleState(t *testing.T) {
 		h.withState(&Idle{})
 
 		intent := h.newTestBoardingIntent()
+		vtxoReq := h.newTestVTXORequestForIntent(intent)
 		event := &ResumeBoardingIntents{
-			Intents: map[wire.OutPoint]BoardingIntent{
-				intent.Outpoint: intent,
-			},
+			Boarding: []BoardingIntent{intent},
+			VTXOs:    []types.VTXORequest{vtxoReq},
 		}
 
 		transition, err := h.sendEvent(event)
@@ -486,7 +540,7 @@ func TestIdleState(t *testing.T) {
 		require.NotNil(t, transition)
 
 		nextState := assertStateType[*PendingRoundAssembly](h)
-		require.Len(t, nextState.Intents, 1)
+		require.Len(t, nextState.Boarding, 1)
 	})
 
 	t.Run("ResumeBoardingIntents_empty_stays_idle", func(t *testing.T) {
@@ -496,7 +550,8 @@ func TestIdleState(t *testing.T) {
 		h.withState(&Idle{})
 
 		event := &ResumeBoardingIntents{
-			Intents: map[wire.OutPoint]BoardingIntent{},
+			Boarding: []BoardingIntent{},
+			VTXOs:    []types.VTXORequest{},
 		}
 
 		transition, err := h.sendEvent(event)
@@ -552,10 +607,10 @@ func TestPendingRoundAssemblyState(t *testing.T) {
 		h := newTestHarness(t)
 
 		existingIntent := h.newTestBoardingIntent()
+		existingVtxoReq := h.newTestVTXORequestForIntent(existingIntent)
 		h.withState(&PendingRoundAssembly{
-			Intents: map[wire.OutPoint]BoardingIntent{
-				existingIntent.Outpoint: existingIntent,
-			},
+			Boarding: []BoardingIntent{existingIntent},
+			VTXOs:    []types.VTXORequest{existingVtxoReq},
 		})
 
 		newIntent := h.newTestBoardingIntent()
@@ -566,7 +621,7 @@ func TestPendingRoundAssemblyState(t *testing.T) {
 		require.NotNil(t, transition)
 
 		nextState := assertStateType[*PendingRoundAssembly](h)
-		require.Len(t, nextState.Intents, 2)
+		require.Len(t, nextState.Boarding, 2)
 	})
 
 	t.Run("registration_requested_transitions", func(t *testing.T) {
@@ -575,10 +630,10 @@ func TestPendingRoundAssemblyState(t *testing.T) {
 		h := newTestHarness(t)
 
 		intent := h.newTestBoardingIntent()
+		vtxoReq := h.newTestVTXORequestForIntent(intent)
 		h.withState(&PendingRoundAssembly{
-			Intents: map[wire.OutPoint]BoardingIntent{
-				intent.Outpoint: intent,
-			},
+			Boarding: []BoardingIntent{intent},
+			VTXOs:    []types.VTXORequest{vtxoReq},
 		})
 
 		event := &RegistrationRequested{}
@@ -588,7 +643,7 @@ func TestPendingRoundAssemblyState(t *testing.T) {
 		require.NotNil(t, transition)
 
 		nextState := assertStateType[*RegistrationSentState](h)
-		require.Len(t, nextState.Intents, 1)
+		require.Len(t, nextState.Intents.Boarding, 1)
 	})
 
 	t.Run("no_intents_transitions_to_failed", func(t *testing.T) {
@@ -596,7 +651,8 @@ func TestPendingRoundAssemblyState(t *testing.T) {
 
 		h := newTestHarness(t)
 		h.withState(&PendingRoundAssembly{
-			Intents: map[wire.OutPoint]BoardingIntent{},
+			Boarding: []BoardingIntent{},
+			VTXOs:    []types.VTXORequest{},
 		})
 
 		event := &RegistrationRequested{}
@@ -619,8 +675,12 @@ func TestRegistrationSentState(t *testing.T) {
 		h := newTestHarness(t)
 
 		intent := h.newTestBoardingIntent()
+		vtxoReq := h.newTestVTXORequestForIntent(intent)
 		h.withState(&RegistrationSentState{
-			Intents: []BoardingIntent{intent},
+			Intents: Intents{
+				Boarding: []BoardingIntent{intent},
+				VTXOs:    []types.VTXORequest{vtxoReq},
+			},
 		})
 
 		event := &RoundJoined{RoundID: testRoundIDTr("test-round-123")}
@@ -632,7 +692,7 @@ func TestRegistrationSentState(t *testing.T) {
 		nextState := assertStateType[*RoundJoinedState](h)
 		expectedRoundID := testRoundIDTr("test-round-123")
 		require.Equal(t, expectedRoundID, nextState.RoundID)
-		require.Len(t, nextState.Intents, 1)
+		require.Len(t, nextState.Intents.Boarding, 1)
 	})
 }
 
@@ -645,9 +705,13 @@ func TestRoundJoinedState(t *testing.T) {
 		h := newTestHarness(t)
 
 		intent := h.newTestBoardingIntent()
+		vtxoReq := h.newTestVTXORequestForIntent(intent)
 		h.withState(&RoundJoinedState{
 			RoundID: testRoundIDTr("round-001"),
-			Intents: []BoardingIntent{intent},
+			Intents: Intents{
+				Boarding: []BoardingIntent{intent},
+				VTXOs:    []types.VTXORequest{vtxoReq},
+			},
 		})
 
 		vtxtTree, _ := h.newTestVTXOTree(1)
@@ -677,8 +741,10 @@ func TestCommitmentTxReceivedState(t *testing.T) {
 		h := newTestHarness(t)
 
 		intent := h.newTestBoardingIntent()
+		vtxoReq := h.newTestVTXORequestForIntent(intent)
 		intents := []BoardingIntent{intent}
-		vtxtTree := h.newTestVTXOTreeForIntent(intent)
+		vtxos := []types.VTXORequest{vtxoReq}
+		vtxtTree := h.newTestVTXOTreeForIntents(vtxos)
 		commitmentTx := h.newTestCommitmentTx(intents)
 
 		state := &CommitmentTxReceivedState{
@@ -686,7 +752,7 @@ func TestCommitmentTxReceivedState(t *testing.T) {
 			CommitmentTx:  commitmentTx,
 			TxID:          commitmentTx.UnsignedTx.TxHash(),
 			VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
-			Intents:       intents,
+			Intents:       Intents{Boarding: intents, VTXOs: vtxos},
 			ClientTrees:   make(map[SignerKey]*tree.Tree),
 		}
 		h.withState(state)
@@ -718,7 +784,9 @@ func TestCommitmentTxReceivedState(t *testing.T) {
 		h := newTestHarness(t)
 
 		intent := h.newTestBoardingIntent()
-		vtxtTree := h.newTestVTXOTreeForIntent(intent)
+		vtxoReq := h.newTestVTXORequestForIntent(intent)
+		vtxos := []types.VTXORequest{vtxoReq}
+		vtxtTree := h.newTestVTXOTreeForIntents(vtxos)
 
 		// Create tx WITHOUT the intent's outpoint. Create a fake intent
 		// with a different outpoint for the commitment tx.
@@ -731,8 +799,11 @@ func TestCommitmentTxReceivedState(t *testing.T) {
 			CommitmentTx:  commitmentTx,
 			TxID:          commitmentTx.UnsignedTx.TxHash(),
 			VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
-			Intents:       []BoardingIntent{intent},
-			ClientTrees:   make(map[SignerKey]*tree.Tree),
+			Intents: Intents{
+				Boarding: []BoardingIntent{intent},
+				VTXOs:    []types.VTXORequest{vtxoReq},
+			},
+			ClientTrees: make(map[SignerKey]*tree.Tree),
 		}
 		h.withState(state)
 
@@ -878,7 +949,10 @@ func TestPartialSigsSentState(t *testing.T) {
 		h := newRealSigningTestHarness(t)
 
 		intent := h.newTestBoardingIntentWithTapscript()
-		vtxtTree := h.newTestVTXOTreeForIntent(intent)
+		vtxoReq := h.newTestVTXORequestForIntent(intent)
+		vtxtTree := h.newTestVTXOTreeForIntents(
+			[]types.VTXORequest{vtxoReq},
+		)
 
 		validSigs, err := h.generateValidTreeSignatures(vtxtTree)
 		require.NoError(t, err)
@@ -889,17 +963,18 @@ func TestPartialSigsSentState(t *testing.T) {
 		)
 
 		clientTrees := make(map[SignerKey]*tree.Tree)
-		for _, vtxoReq := range intent.VtxoTemplate {
-			signerKey := NewSignerKey(vtxoReq.SigningKey.PubKey)
-			clientTrees[signerKey] = vtxtTree
-		}
+		signerKey := NewSignerKey(vtxoReq.SigningKey.PubKey)
+		clientTrees[signerKey] = vtxtTree
 
 		state := &PartialSigsSentState{
-			RoundID:         testRoundIDTr("round-real-sig-001"),
-			CommitmentTx:    commitmentTx,
-			VTXOTreePaths:   map[int]*tree.Tree{0: vtxtTree},
-			BoardingIntents: []BoardingIntent{intent},
-			ClientTrees:     clientTrees,
+			RoundID:       testRoundIDTr("round-real-sig-001"),
+			CommitmentTx:  commitmentTx,
+			VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
+			Intents: Intents{
+				Boarding: []BoardingIntent{intent},
+				VTXOs:    []types.VTXORequest{vtxoReq},
+			},
+			ClientTrees: clientTrees,
 			BoardingInputIndices: map[wire.OutPoint]int{
 				intent.Outpoint: 0,
 			},
@@ -936,16 +1011,22 @@ func TestPartialSigsSentState(t *testing.T) {
 		h := newTestHarness(t)
 
 		intent := h.newTestBoardingIntent()
-		vtxtTree := h.newTestVTXOTreeForIntent(intent)
+		vtxoReq := h.newTestVTXORequestForIntent(intent)
+		vtxtTree := h.newTestVTXOTreeForIntents(
+			[]types.VTXORequest{vtxoReq},
+		)
 		intents := []BoardingIntent{intent}
 		commitmentTx := h.newTestCommitmentTx(intents)
 
 		state := &PartialSigsSentState{
-			RoundID:         testRoundIDTr("round-001"),
-			CommitmentTx:    commitmentTx,
-			VTXOTreePaths:   map[int]*tree.Tree{0: vtxtTree},
-			BoardingIntents: []BoardingIntent{intent},
-			ClientTrees:     make(map[SignerKey]*tree.Tree),
+			RoundID:       testRoundIDTr("round-001"),
+			CommitmentTx:  commitmentTx,
+			VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
+			Intents: Intents{
+				Boarding: []BoardingIntent{intent},
+				VTXOs:    []types.VTXORequest{vtxoReq},
+			},
+			ClientTrees: make(map[SignerKey]*tree.Tree),
 			BoardingInputIndices: map[wire.OutPoint]int{
 				intent.Outpoint: 0,
 			},
@@ -971,16 +1052,22 @@ func TestPartialSigsSentState(t *testing.T) {
 		h := newTestHarness(t)
 
 		intent := h.newTestBoardingIntent()
-		vtxtTree := h.newTestVTXOTreeForIntent(intent)
+		vtxoReq := h.newTestVTXORequestForIntent(intent)
+		vtxtTree := h.newTestVTXOTreeForIntents(
+			[]types.VTXORequest{vtxoReq},
+		)
 		intents := []BoardingIntent{intent}
 		commitmentTx := h.newTestCommitmentTx(intents)
 
 		state := &PartialSigsSentState{
-			RoundID:         testRoundIDTr("round-001"),
-			CommitmentTx:    commitmentTx,
-			VTXOTreePaths:   map[int]*tree.Tree{0: vtxtTree},
-			BoardingIntents: []BoardingIntent{intent},
-			ClientTrees:     make(map[SignerKey]*tree.Tree),
+			RoundID:       testRoundIDTr("round-001"),
+			CommitmentTx:  commitmentTx,
+			VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
+			Intents: Intents{
+				Boarding: []BoardingIntent{intent},
+				VTXOs:    []types.VTXORequest{vtxoReq},
+			},
+			ClientTrees: make(map[SignerKey]*tree.Tree),
 			BoardingInputIndices: map[wire.OutPoint]int{
 				intent.Outpoint: 0,
 			},
@@ -1010,15 +1097,21 @@ func TestPartialSigsSentState(t *testing.T) {
 		h := newTestHarness(t)
 
 		intent := h.newTestBoardingIntent()
-		vtxtTree := h.newTestVTXOTreeForIntent(intent)
+		vtxoReq := h.newTestVTXORequestForIntent(intent)
+		vtxtTree := h.newTestVTXOTreeForIntents(
+			[]types.VTXORequest{vtxoReq},
+		)
 		intents := []BoardingIntent{intent}
 		commitmentTx := h.newTestCommitmentTx(intents)
 
 		state := &PartialSigsSentState{
-			RoundID:              testRoundIDTr("round-001"),
-			CommitmentTx:         commitmentTx,
-			VTXOTreePaths:        map[int]*tree.Tree{0: vtxtTree},
-			BoardingIntents:      []BoardingIntent{intent},
+			RoundID:       testRoundIDTr("round-001"),
+			CommitmentTx:  commitmentTx,
+			VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
+			Intents: Intents{
+				Boarding: []BoardingIntent{intent},
+				VTXOs:    []types.VTXORequest{vtxoReq},
+			},
 			ClientTrees:          make(map[SignerKey]*tree.Tree),
 			BoardingInputIndices: make(map[wire.OutPoint]int),
 			Musig2Sessions: make(
@@ -1051,16 +1144,22 @@ func TestPartialSigsSentState(t *testing.T) {
 		h := newTestHarness(t)
 
 		intent := h.newTestBoardingIntent()
-		vtxtTree := h.newTestVTXOTreeForIntent(intent)
+		vtxoReq := h.newTestVTXORequestForIntent(intent)
+		vtxtTree := h.newTestVTXOTreeForIntents(
+			[]types.VTXORequest{vtxoReq},
+		)
 		intents := []BoardingIntent{intent}
 		commitmentTx := h.newTestCommitmentTx(intents)
 
 		state := &PartialSigsSentState{
-			RoundID:         testRoundIDTr("round-001"),
-			CommitmentTx:    commitmentTx,
-			VTXOTreePaths:   map[int]*tree.Tree{0: vtxtTree},
-			BoardingIntents: []BoardingIntent{intent},
-			ClientTrees:     make(map[SignerKey]*tree.Tree),
+			RoundID:       testRoundIDTr("round-001"),
+			CommitmentTx:  commitmentTx,
+			VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
+			Intents: Intents{
+				Boarding: []BoardingIntent{intent},
+				VTXOs:    []types.VTXORequest{vtxoReq},
+			},
+			ClientTrees: make(map[SignerKey]*tree.Tree),
 			BoardingInputIndices: map[wire.OutPoint]int{
 				intent.Outpoint: 0,
 			},
@@ -1139,13 +1238,17 @@ func TestInputSigSentState(t *testing.T) {
 
 		vtxtTree, _ := h.newTestVTXOTree(1)
 		intent := h.newTestBoardingIntent()
+		vtxoReq := h.newTestVTXORequestForIntent(intent)
 
 		// Empty ClientTrees will cause buildClientVTXOs to fail.
 		state := &InputSigSentState{
 			RoundID:       testRoundIDTr("round-001"),
 			VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
-			Intents:       []BoardingIntent{intent},
-			ClientTrees:   make(map[SignerKey]*tree.Tree),
+			Intents: Intents{
+				Boarding: []BoardingIntent{intent},
+				VTXOs:    []types.VTXORequest{vtxoReq},
+			},
+			ClientTrees: make(map[SignerKey]*tree.Tree),
 		}
 		h.withState(state)
 
@@ -1343,8 +1446,11 @@ func TestBoardingFlowIdleToPendingToRegistrationSent(t *testing.T) {
 	h := newTestHarness(t)
 
 	intent := h.newTestBoardingIntent()
-	intentsMap := map[wire.OutPoint]BoardingIntent{intent.Outpoint: intent}
-	h.withState(&PendingRoundAssembly{Intents: intentsMap})
+	vtxoReq := h.newTestVTXORequestForIntent(intent)
+	h.withState(&PendingRoundAssembly{
+		Boarding: []BoardingIntent{intent},
+		VTXOs:    []types.VTXORequest{vtxoReq},
+	})
 
 	// Step 1: Request registration.
 	regEvent := &RegistrationRequested{}
@@ -1352,7 +1458,7 @@ func TestBoardingFlowIdleToPendingToRegistrationSent(t *testing.T) {
 	require.NoError(t, err)
 
 	regState := assertStateType[*RegistrationSentState](h)
-	require.Len(t, regState.Intents, 1)
+	require.Len(t, regState.Intents.Boarding, 1)
 
 	// Step 2: Server accepts.
 	joinEvent := &RoundJoined{RoundID: testRoundIDTr("round-001")}
@@ -1380,7 +1486,7 @@ func TestBoardingFlowMultipleIntentsAccumulation(t *testing.T) {
 		require.NoError(t, err)
 
 		state := assertStateType[*PendingRoundAssembly](h)
-		require.Len(t, state.Intents, i+1)
+		require.Len(t, state.Boarding, i+1)
 	}
 }
 
@@ -1390,8 +1496,11 @@ func TestBoardingFlowPendingToRoundJoined(t *testing.T) {
 	h := newTestHarness(t)
 
 	intent := h.newTestBoardingIntent()
-	intentsMap := map[wire.OutPoint]BoardingIntent{intent.Outpoint: intent}
-	h.withState(&PendingRoundAssembly{Intents: intentsMap})
+	vtxoReq := h.newTestVTXORequestForIntent(intent)
+	h.withState(&PendingRoundAssembly{
+		Boarding: []BoardingIntent{intent},
+		VTXOs:    []types.VTXORequest{vtxoReq},
+	})
 
 	// Step 1: PendingRoundAssembly → RegistrationSentState.
 	regEvent := &RegistrationRequested{}
@@ -1399,7 +1508,7 @@ func TestBoardingFlowPendingToRoundJoined(t *testing.T) {
 	require.NoError(t, err)
 
 	regSentState := assertStateType[*RegistrationSentState](h)
-	require.Len(t, regSentState.Intents, 1)
+	require.Len(t, regSentState.Intents.Boarding, 1)
 
 	// Step 2: RegistrationSentState → RoundJoinedState.
 	integrationRoundID := testRoundIDTr("round-integration-001")
@@ -1418,14 +1527,18 @@ func TestBoardingFlowRoundJoinedToPartialSigsSent(t *testing.T) {
 	h.setupMockWalletForMuSig2()
 
 	intent := h.newTestBoardingIntent()
+	vtxoReq := h.newTestVTXORequestForIntent(intent)
 
 	h.withState(&RoundJoinedState{
 		RoundID: testRoundIDTr("round-integration-002"),
-		Intents: []BoardingIntent{intent},
+		Intents: Intents{
+			Boarding: []BoardingIntent{intent},
+			VTXOs:    []types.VTXORequest{vtxoReq},
+		},
 	})
 
 	// Step 1: RoundJoined → CommitmentTxReceived.
-	vtxtTree := h.newTestVTXOTreeForIntent(intent)
+	vtxtTree := h.newTestVTXOTreeForIntents([]types.VTXORequest{vtxoReq})
 	commitEvent := h.newCommitmentTxBuiltEvent(
 		testRoundIDTr("round-integration-002"),
 		[]BoardingIntent{intent},
@@ -1484,9 +1597,13 @@ func TestBoardingFlowFailureAndRecovery(t *testing.T) {
 	h := newTestHarness(t)
 
 	intent := h.newTestBoardingIntent()
+	vtxoReq := h.newTestVTXORequestForIntent(intent)
 	h.withState(&RoundJoinedState{
 		RoundID: testRoundIDTr("round-fail-001"),
-		Intents: []BoardingIntent{intent},
+		Intents: Intents{
+			Boarding: []BoardingIntent{intent},
+			VTXOs:    []types.VTXORequest{vtxoReq},
+		},
 	})
 
 	// We inject a failure event to verify the state machine correctly

--- a/round/transitions_test.go
+++ b/round/transitions_test.go
@@ -239,9 +239,9 @@ func TestUnexpectedEventSelfLoop(t *testing.T) {
 				trees := map[int]*tree.Tree{0: vtxtTree}
 
 				return &PartialSigsSentState{
-					RoundID:       roundID,
-					VTXOTreePaths: trees,
-					Intents:       []BoardingIntent{intent},
+					RoundID:         roundID,
+					VTXOTreePaths:   trees,
+					BoardingIntents: []BoardingIntent{intent},
 				}
 			},
 			event: &RoundJoined{RoundID: testRoundIDTr("other")},
@@ -358,9 +358,9 @@ func TestBoardingFailedTransitions(t *testing.T) {
 				trees := map[int]*tree.Tree{0: vtxtTree}
 
 				return &PartialSigsSentState{
-					RoundID:       roundID,
-					VTXOTreePaths: trees,
-					Intents:       []BoardingIntent{intent},
+					RoundID:         roundID,
+					VTXOTreePaths:   trees,
+					BoardingIntents: []BoardingIntent{intent},
 				}
 			},
 		},
@@ -896,11 +896,11 @@ func TestPartialSigsSentState(t *testing.T) {
 		}
 
 		state := &PartialSigsSentState{
-			RoundID:       testRoundIDTr("round-real-sig-001"),
-			CommitmentTx:  commitmentTx,
-			VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
-			Intents:       []BoardingIntent{intent},
-			ClientTrees:   clientTrees,
+			RoundID:         testRoundIDTr("round-real-sig-001"),
+			CommitmentTx:    commitmentTx,
+			VTXOTreePaths:   map[int]*tree.Tree{0: vtxtTree},
+			BoardingIntents: []BoardingIntent{intent},
+			ClientTrees:     clientTrees,
 			BoardingInputIndices: map[wire.OutPoint]int{
 				intent.Outpoint: 0,
 			},
@@ -942,11 +942,11 @@ func TestPartialSigsSentState(t *testing.T) {
 		commitmentTx := h.newTestCommitmentTx(intents)
 
 		state := &PartialSigsSentState{
-			RoundID:       testRoundIDTr("round-001"),
-			CommitmentTx:  commitmentTx,
-			VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
-			Intents:       []BoardingIntent{intent},
-			ClientTrees:   make(map[SignerKey]*tree.Tree),
+			RoundID:         testRoundIDTr("round-001"),
+			CommitmentTx:    commitmentTx,
+			VTXOTreePaths:   map[int]*tree.Tree{0: vtxtTree},
+			BoardingIntents: []BoardingIntent{intent},
+			ClientTrees:     make(map[SignerKey]*tree.Tree),
 			BoardingInputIndices: map[wire.OutPoint]int{
 				intent.Outpoint: 0,
 			},
@@ -977,11 +977,11 @@ func TestPartialSigsSentState(t *testing.T) {
 		commitmentTx := h.newTestCommitmentTx(intents)
 
 		state := &PartialSigsSentState{
-			RoundID:       testRoundIDTr("round-001"),
-			CommitmentTx:  commitmentTx,
-			VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
-			Intents:       []BoardingIntent{intent},
-			ClientTrees:   make(map[SignerKey]*tree.Tree),
+			RoundID:         testRoundIDTr("round-001"),
+			CommitmentTx:    commitmentTx,
+			VTXOTreePaths:   map[int]*tree.Tree{0: vtxtTree},
+			BoardingIntents: []BoardingIntent{intent},
+			ClientTrees:     make(map[SignerKey]*tree.Tree),
 			BoardingInputIndices: map[wire.OutPoint]int{
 				intent.Outpoint: 0,
 			},
@@ -1019,7 +1019,7 @@ func TestPartialSigsSentState(t *testing.T) {
 			RoundID:              testRoundIDTr("round-001"),
 			CommitmentTx:         commitmentTx,
 			VTXOTreePaths:        map[int]*tree.Tree{0: vtxtTree},
-			Intents:              []BoardingIntent{intent},
+			BoardingIntents:      []BoardingIntent{intent},
 			ClientTrees:          make(map[SignerKey]*tree.Tree),
 			BoardingInputIndices: make(map[wire.OutPoint]int),
 			Musig2Sessions: make(
@@ -1057,11 +1057,11 @@ func TestPartialSigsSentState(t *testing.T) {
 		commitmentTx := h.newTestCommitmentTx(intents)
 
 		state := &PartialSigsSentState{
-			RoundID:       testRoundIDTr("round-001"),
-			CommitmentTx:  commitmentTx,
-			VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
-			Intents:       []BoardingIntent{intent},
-			ClientTrees:   make(map[SignerKey]*tree.Tree),
+			RoundID:         testRoundIDTr("round-001"),
+			CommitmentTx:    commitmentTx,
+			VTXOTreePaths:   map[int]*tree.Tree{0: vtxtTree},
+			BoardingIntents: []BoardingIntent{intent},
+			ClientTrees:     make(map[SignerKey]*tree.Tree),
 			BoardingInputIndices: map[wire.OutPoint]int{
 				intent.Outpoint: 0,
 			},


### PR DESCRIPTION
This commit fundamentally changes how VTXO requests relate to boarding intents, enabling flexible M:N mappings instead of the previous 1:N constraint.

The schema locked each VTXO request to a specific boarding intent via a foreign key constraint:

    round_vtxo_templates (
        round_id, outpoint_hash, outpoint_index, template_index,
        FOREIGN KEY (round_id, outpoint_hash, outpoint_index)
            REFERENCES round_boarding_intents
    )

This enforced a rigid 1:N relationship where one boarding intent could produce multiple VTXOs, but multiple boarding intents could NOT be combined to produce a single VTXO.

VTXO requests are now first-class citizens of the round, tied directly to the round rather than to individual intents:

    round_vtxo_requests (
        round_id, request_index,
        FOREIGN KEY (round_id) REFERENCES rounds
    )

This enables flexible M:N mappings:
- Fan-in: Multiple boarding intents can contribute UTXOs to fund a single VTXO output
- Fan-out: One boarding intent can still produce multiple VTXOs
- Any combination: The round FSM can now optimize tree construction by grouping inputs and outputs independently

The decoupling allows the round FSM to collect all inputs and all requested outputs separately, then pair them optimally during tree construction rather than being constrained by the intent-request relationship.


Fixes https://github.com/lightninglabs/darepo-client/issues/59