### PR TITLE
docs: strengthen Go documentation rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
 
 ### Building and Testing
 - `make build` - Compile the project
+- `make tidy-module-check` - Verify module files are tidy
 - `make lint` - Run the linter (must pass before committing)
 - `make fmt` - Format all Go source files
 - `make clean` - Remove build artifacts
@@ -23,11 +24,25 @@
 
 **IMPORTANT**: Editors must be configured with **tab = 8 spaces** for correct formatting.
 
-### Function Comments
-- Every function must have a comment starting with the function name
+### Function and Method Comments
+- **Every function and method** (including unexported ones) must have a comment
+  starting with the function/method name
 - Comments should explain **how/why**, not just what
 - Use literate programming style—comments should be additive and insightful
 - All exported functions need detailed documentation
+
+### GoDoc for Exported Identifiers
+- Any exported identifier (type, const, var, func, method) must have a GoDoc
+  comment that starts with the identifier name.
+- Exported struct fields must have a GoDoc comment (GoDoc style, starting with
+  the field name) and wrapped to 80 columns.
+- All GoDoc-style comments must be wrapped to 80 columns.
+
+### Comments for Non-trivial Code
+- Any non-trivial code blocks (multi-step algorithms, subtle invariants,
+  concurrency/locking, retries/idempotency, tricky encodings) must include
+  explanatory comments that describe the “why” and any invariants.
+- These explanatory comments should also be wrapped to 80 columns.
 
 ### Code Organization and Spacing
 - 80-character line limit (best effort)
@@ -138,6 +153,7 @@ Strive for **near 90% test coverage** where practical.
 ### Before Committing
 **YOU MUST** run tests before every commit:
 
+0. Run module tidy check: `make tidy-module-check`
 1. Run unit tests: `make unit pkg=$pkg case=$case timeout=5m`
 2. Run with debug logs: `make unit log="stdlog trace" pkg=$pkg case=$case`
 3. **Check logs carefully**:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,7 @@
 
 ### Building and Testing
 - `make build` - Compile the project
+- `make tidy-module-check` - Verify module files are tidy
 - `make lint` - Run the linter (must pass before committing)
 - `make fmt` - Format all Go source files
 - `make clean` - Remove build artifacts
@@ -23,11 +24,25 @@
 
 **IMPORTANT**: Editors must be configured with **tab = 8 spaces** for correct formatting.
 
-### Function Comments
-- Every function must have a comment starting with the function name
+### Function and Method Comments
+- **Every function and method** (including unexported ones) must have a comment
+  starting with the function/method name
 - Comments should explain **how/why**, not just what
 - Use literate programming style—comments should be additive and insightful
 - All exported functions need detailed documentation
+
+### GoDoc for Exported Identifiers
+- Any exported identifier (type, const, var, func, method) must have a GoDoc
+  comment that starts with the identifier name.
+- Exported struct fields must have a GoDoc comment (GoDoc style, starting with
+  the field name) and wrapped to 80 columns.
+- All GoDoc-style comments must be wrapped to 80 columns.
+
+### Comments for Non-trivial Code
+- Any non-trivial code blocks (multi-step algorithms, subtle invariants,
+  concurrency/locking, retries/idempotency, tricky encodings) must include
+  explanatory comments that describe the “why” and any invariants.
+- These explanatory comments should also be wrapped to 80 columns.
 
 ### Code Organization and Spacing
 - 80-character line limit (best effort)
@@ -138,6 +153,7 @@ Strive for **near 90% test coverage** where practical.
 ### Before Committing
 **YOU MUST** run tests before every commit:
 
+0. Run module tidy check: `make tidy-module-check`
 1. Run unit tests: `make unit pkg=$pkg case=$case timeout=5m`
 2. Run with debug logs: `make unit log="stdlog trace" pkg=$pkg case=$case`
 3. **Check logs carefully**:


### PR DESCRIPTION
Updates AGENTS.md and CLAUDE.md to strengthen documentation requirements:

- Require GoDoc-style comments for all functions/methods (including unexported).
- Require GoDoc for exported identifiers and exported struct fields, wrapped to 80 columns.
- Require explanatory comments for non-trivial code blocks (also wrapped to 80 columns).
- Add make tidy-module-check to the recommended workflow.
