### PR TITLE
MailboxRPC 5/7: edge-backed mailboxrpc client

### DIFF
--- a/arkrpc/ark_mailboxrpc.pb.go
+++ b/arkrpc/ark_mailboxrpc.pb.go
@@ -49,13 +49,16 @@ func (c *ArkServiceMailboxClient) GetInfo(ctx context.Context, req *GetInfoReque
 		opt = opts[0]
 	}
 
-	correlationID, _, err := c.C.SendRPC(ctx, "arkrpc.ArkService", "GetInfo", req, opt)
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "arkrpc.ArkService",
+		Method:  "GetInfo",
+	}, req, opt)
 	if err != nil {
 		return nil, err
 	}
 
 	resp := new(GetInfoResponse)
-	if err := c.C.AwaitRPC(ctx, correlationID, resp); err != nil {
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
 		return nil, err
 	}
 

--- a/cmd/protoc-gen-mailboxrpc/internal/gen/generator.go
+++ b/cmd/protoc-gen-mailboxrpc/internal/gen/generator.go
@@ -112,10 +112,14 @@ func buildServiceData(g *protogen.GeneratedFile,
 	const protoPath = "google.golang.org/protobuf/proto"
 
 	data := serviceData{
-		ServiceName:  svc.GoName,
-		ServiceFQN:   serviceFQN,
-		RPCClient:    resolveIdent(g, mailboxrpcPath, "RPCClient"),
-		RPCOptions:   resolveIdent(g, mailboxrpcPath, "RPCOptions"),
+		ServiceName: svc.GoName,
+		ServiceFQN:  serviceFQN,
+		RPCClient:   resolveIdent(g, mailboxrpcPath, "RPCClient"),
+		RPCOptions:  resolveIdent(g, mailboxrpcPath, "RPCOptions"),
+		ServiceMethod: resolveIdent(
+			g, mailboxrpcPath, "ServiceMethod",
+		),
+		SendResult:   resolveIdent(g, mailboxrpcPath, "SendResult"),
 		Router:       resolveIdent(g, mailboxrpcPath, "Router"),
 		Context:      resolveIdent(g, "context", "Context"),
 		ProtoMessage: resolveIdent(g, protoPath, "Message"),

--- a/cmd/protoc-gen-mailboxrpc/internal/gen/templates.go
+++ b/cmd/protoc-gen-mailboxrpc/internal/gen/templates.go
@@ -18,6 +18,14 @@ type serviceData struct {
 	// RPCOptions is the qualified Go identifier for mailboxrpc.RPCOptions.
 	RPCOptions string
 
+	// ServiceMethod is the qualified Go identifier for
+	// mailboxrpc.ServiceMethod.
+	ServiceMethod string
+
+	// SendResult is the qualified Go identifier for
+	// mailboxrpc.SendResult.
+	SendResult string
+
 	// Router is the qualified Go identifier for mailboxrpc.Router.
 	Router string
 
@@ -103,13 +111,16 @@ func (c *{{$.ServiceName}}MailboxClient) {{.Name}}(ctx {{$.Context}}, req *{{.Re
 		opt = opts[0]
 	}
 
-	correlationID, _, err := c.C.SendRPC(ctx, "{{$.ServiceFQN}}", "{{.ProtoName}}", req, opt)
+	result, err := c.C.SendRPC(ctx, {{$.ServiceMethod}}{
+		Service: "{{$.ServiceFQN}}",
+		Method:  "{{.ProtoName}}",
+	}, req, opt)
 	if err != nil {
 		return nil, err
 	}
 
 	resp := new({{.RespType}})
-	if err := c.C.AwaitRPC(ctx, correlationID, resp); err != nil {
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
 		return nil, err
 	}
 

--- a/mailbox/client/client.go
+++ b/mailbox/client/client.go
@@ -1,0 +1,419 @@
+package mailboxclient
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
+	mailboxrpc "github.com/lightninglabs/darepo-client/mailbox/rpc"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+// Client implements mailboxrpc.RPCClient by sending and receiving mailbox
+// envelopes through a mailboxpb.MailboxServiceClient.
+type Client struct {
+	cfg Config
+
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+
+	mu sync.Mutex
+
+	cursor uint64
+
+	pending map[string][]byte
+	waiters map[string][]chan struct{}
+}
+
+// New constructs and starts a mailboxclient.Client.
+func New(cfg Config) (*Client, error) {
+	cfg = applyDefaults(cfg)
+
+	if cfg.Edge == nil {
+		return nil, fmt.Errorf("edge is required")
+	}
+	if cfg.LocalMailboxID == "" {
+		return nil, fmt.Errorf("local mailbox id is required")
+	}
+	if cfg.RemoteMailboxID == "" {
+		return nil, fmt.Errorf("remote mailbox id is required")
+	}
+	if cfg.PullMaxEnvelopes == 0 {
+		return nil, fmt.Errorf("pull max envelopes must be > 0")
+	}
+	if cfg.PullWaitTimeout <= 0 {
+		return nil, fmt.Errorf("pull wait timeout must be > 0")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	c := &Client{
+		cfg: cfg,
+
+		cancel: cancel,
+
+		pending: make(map[string][]byte),
+		waiters: make(map[string][]chan struct{}),
+	}
+
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+		c.run(ctx)
+	}()
+
+	log.InfoS(ctx, "Mailbox client started",
+		slog.String("local_mailbox", cfg.LocalMailboxID),
+		slog.String("remote_mailbox", cfg.RemoteMailboxID))
+
+	return c, nil
+}
+
+// Stop shuts down background polling and unblocks any waiters.
+func (c *Client) Stop() {
+	log.InfoS(context.TODO(), "Stopping mailbox client")
+
+	c.cancel()
+	c.wg.Wait()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for correlationID, waiters := range c.waiters {
+		for _, ch := range waiters {
+			close(ch)
+		}
+
+		delete(c.waiters, correlationID)
+	}
+
+	log.InfoS(context.TODO(), "Mailbox client stopped")
+}
+
+// SendRPC sends a request payload and returns a SendResult containing the
+// correlation id and idempotency key used for the send.
+func (c *Client) SendRPC(ctx context.Context, method mailboxrpc.ServiceMethod,
+	req proto.Message,
+	opts mailboxrpc.RPCOptions) (mailboxrpc.SendResult, error) {
+
+	msgID, err := randomID(16)
+	if err != nil {
+		return mailboxrpc.SendResult{}, err
+	}
+
+	idempotencyKey := opts.IdempotencyKey
+	if idempotencyKey == "" {
+		idempotencyKey, err = randomID(16)
+		if err != nil {
+			return mailboxrpc.SendResult{}, err
+		}
+	}
+
+	correlationID := opts.CorrelationID
+	if correlationID == "" {
+		correlationID = idempotencyKey
+	}
+
+	body, err := anypb.New(req)
+	if err != nil {
+		return mailboxrpc.SendResult{}, err
+	}
+
+	envelope := &mailboxpb.Envelope{
+		ProtocolVersion: c.cfg.ProtocolVersion,
+		MsgId:           msgID,
+		IdempotencyKey:  idempotencyKey,
+		Sender:          c.cfg.LocalMailboxID,
+		Recipient:       c.cfg.RemoteMailboxID,
+		CreatedAtUnixMs: time.Now().UnixMilli(),
+		Headers:         opts.Headers,
+		Body:            body,
+		Rpc: &mailboxpb.RpcMeta{
+			Kind:          mailboxpb.RpcMeta_KIND_REQUEST,
+			Service:       method.Service,
+			Method:        method.Method,
+			CorrelationId: correlationID,
+			ReplyTo:       c.cfg.LocalMailboxID,
+		},
+	}
+
+	resp, err := c.cfg.Edge.Send(ctx, &mailboxpb.SendRequest{
+		Envelope: envelope,
+	})
+	if err != nil {
+		log.WarnS(ctx, "Send failed", err,
+			slog.String("service", method.Service),
+			slog.String("method", method.Method))
+
+		return mailboxrpc.SendResult{}, err
+	}
+
+	if !statusOK(resp.Status) {
+		sendErr := statusError("Send", resp.Status)
+		log.WarnS(ctx, "Send returned non-OK status", sendErr,
+			slog.String("service", method.Service),
+			slog.String("method", method.Method))
+
+		return mailboxrpc.SendResult{}, sendErr
+	}
+
+	log.DebugS(ctx, "Sent RPC request",
+		slog.String("service", method.Service),
+		slog.String("method", method.Method),
+		slog.String("correlation_id", correlationID))
+
+	return mailboxrpc.SendResult{
+		CorrelationID:  correlationID,
+		IdempotencyKey: idempotencyKey,
+	}, nil
+}
+
+// AwaitRPC blocks until a response for correlationID is received.
+func (c *Client) AwaitRPC(ctx context.Context, correlationID string,
+	resp proto.Message) error {
+
+	for {
+		data, ok := c.popPending(correlationID)
+		if ok {
+			return (proto.UnmarshalOptions{
+				DiscardUnknown: true,
+			}).Unmarshal(data, resp)
+		}
+
+		ch := c.addWaiter(correlationID)
+		select {
+		case <-ch:
+		case <-ctx.Done():
+			c.removeWaiter(correlationID, ch)
+			return ctx.Err()
+		}
+	}
+}
+
+// applyDefaults fills unset fields with defaults.
+func applyDefaults(cfg Config) Config {
+	def := DefaultConfig()
+
+	if cfg.PullMaxEnvelopes == 0 {
+		cfg.PullMaxEnvelopes = def.PullMaxEnvelopes
+	}
+	if cfg.PullWaitTimeout == 0 {
+		cfg.PullWaitTimeout = def.PullWaitTimeout
+	}
+
+	return cfg
+}
+
+// run polls Pull and acks envelopes after caching correlated responses.
+func (c *Client) run(ctx context.Context) {
+	log.DebugS(ctx, "Poll loop starting",
+		slog.String("mailbox_id", c.cfg.LocalMailboxID))
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.DebugS(ctx, "Poll loop exiting")
+			return
+
+		default:
+		}
+
+		cursor := c.loadCursor()
+		waitMs := uint32(c.cfg.PullWaitTimeout.Milliseconds())
+
+		resp, err := c.cfg.Edge.Pull(ctx, &mailboxpb.PullRequest{
+			MailboxId:     c.cfg.LocalMailboxID,
+			MaxEnvelopes:  c.cfg.PullMaxEnvelopes,
+			WaitTimeoutMs: waitMs,
+			Cursor:        cursor,
+		})
+		if err != nil {
+			log.WarnS(ctx, "Pull failed, retrying", err)
+			c.sleepRetry(ctx)
+			continue
+		}
+
+		if !statusOK(resp.Status) {
+			log.DebugS(ctx, "Pull returned non-OK status")
+			c.sleepRetry(ctx)
+			continue
+		}
+
+		if len(resp.Envelopes) > 0 {
+			log.DebugS(ctx, "Pulled envelopes",
+				slog.Int("count", len(resp.Envelopes)),
+				slog.Uint64("cursor", cursor),
+				slog.Uint64("next_cursor", resp.NextCursor))
+		}
+
+		for _, env := range resp.Envelopes {
+			c.handleEnvelope(env)
+		}
+
+		if resp.NextCursor > cursor {
+			ackOK := c.ackUpTo(ctx, resp.NextCursor)
+			if ackOK {
+				c.storeCursor(resp.NextCursor)
+				continue
+			}
+
+			log.DebugS(ctx, "AckUpTo failed, retrying",
+				slog.Uint64("cursor", resp.NextCursor))
+
+			c.sleepRetry(ctx)
+		}
+	}
+}
+
+// sleepRetry backs off briefly after a transient pull/ack failure.
+func (c *Client) sleepRetry(ctx context.Context) {
+	timer := time.NewTimer(200 * time.Millisecond)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+	case <-timer.C:
+	}
+}
+
+// ackUpTo calls AckUpTo and returns true on success.
+func (c *Client) ackUpTo(ctx context.Context, cursor uint64) bool {
+	resp, err := c.cfg.Edge.AckUpTo(ctx, &mailboxpb.AckUpToRequest{
+		MailboxId: c.cfg.LocalMailboxID,
+		Cursor:    cursor,
+	})
+	if err != nil {
+		return false
+	}
+
+	return statusOK(resp.Status)
+}
+
+// handleEnvelope caches correlated responses and wakes waiters.
+func (c *Client) handleEnvelope(env *mailboxpb.Envelope) {
+	if env == nil || env.Rpc == nil {
+		return
+	}
+
+	if env.Rpc.Kind != mailboxpb.RpcMeta_KIND_RESPONSE {
+		return
+	}
+
+	correlationID := env.Rpc.CorrelationId
+	if correlationID == "" {
+		return
+	}
+
+	if env.Body == nil {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// If we already have a response for this correlation id, keep the
+	// first response and ignore duplicates.
+	if _, exists := c.pending[correlationID]; !exists {
+		payload := env.Body.Value
+		payloadCopy := make([]byte, len(payload))
+		copy(payloadCopy, payload)
+
+		c.pending[correlationID] = payloadCopy
+
+		log.DebugS(context.TODO(), "Cached response",
+			slog.String("correlation_id", correlationID),
+			slog.Int("payload_bytes", len(payloadCopy)))
+	} else {
+		log.DebugS(context.TODO(), "Ignored duplicate response",
+			slog.String("correlation_id", correlationID))
+	}
+
+	waiters := c.waiters[correlationID]
+	for _, ch := range waiters {
+		close(ch)
+	}
+	delete(c.waiters, correlationID)
+}
+
+// popPending returns and removes a cached response for correlationID.
+func (c *Client) popPending(correlationID string) ([]byte, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	data, ok := c.pending[correlationID]
+	if !ok {
+		return nil, false
+	}
+
+	delete(c.pending, correlationID)
+
+	return data, true
+}
+
+// addWaiter registers a waiter for correlationID and returns its channel.
+func (c *Client) addWaiter(correlationID string) chan struct{} {
+	ch := make(chan struct{})
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.waiters[correlationID] = append(c.waiters[correlationID], ch)
+
+	return ch
+}
+
+// removeWaiter removes a previously registered waiter channel.
+func (c *Client) removeWaiter(correlationID string, ch chan struct{}) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	waiters := c.waiters[correlationID]
+	for i := range waiters {
+		if waiters[i] == ch {
+			waiters[i] = waiters[len(waiters)-1]
+			waiters = waiters[:len(waiters)-1]
+			break
+		}
+	}
+
+	if len(waiters) == 0 {
+		delete(c.waiters, correlationID)
+		return
+	}
+
+	c.waiters[correlationID] = waiters
+}
+
+// loadCursor returns the current pull cursor.
+func (c *Client) loadCursor() uint64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.cursor
+}
+
+// storeCursor sets the pull cursor.
+func (c *Client) storeCursor(cursor uint64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.cursor = cursor
+}
+
+// randomID generates an opaque id backed by crypto/rand.
+func randomID(nbytes int) (string, error) {
+	buf := make([]byte, nbytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(buf), nil
+}
+
+var _ mailboxrpc.RPCClient = (*Client)(nil)

--- a/mailbox/client/client_test.go
+++ b/mailbox/client/client_test.go
@@ -1,0 +1,278 @@
+package mailboxclient_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/lightninglabs/darepo-client/arkrpc"
+	mailboxclient "github.com/lightninglabs/darepo-client/mailbox/client"
+	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
+	mailboxrpc "github.com/lightninglabs/darepo-client/mailbox/rpc"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+// testArkServer implements a tiny mailbox RPC server used by unit tests.
+type testArkServer struct {
+	resp *arkrpc.GetInfoResponse
+}
+
+// GetInfo returns a fixed response for tests.
+func (s *testArkServer) GetInfo(ctx context.Context,
+	req *arkrpc.GetInfoRequest) (*arkrpc.GetInfoResponse, error) {
+
+	_ = ctx
+	_ = req
+
+	return s.resp, nil
+}
+
+// runOperator polls operatorMailboxID and responds to requests using mux.
+func runOperator(ctx context.Context, edge mailboxpb.MailboxServiceClient,
+	operatorMailboxID string, mux *mailboxrpc.ServeMux) error {
+
+	var cursor uint64
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+
+		pull, err := edge.Pull(ctx, &mailboxpb.PullRequest{
+			MailboxId:     operatorMailboxID,
+			MaxEnvelopes:  10,
+			WaitTimeoutMs: 50,
+			Cursor:        cursor,
+		})
+		if err != nil {
+			return err
+		}
+		if pull.Status == nil || !pull.Status.Ok {
+			return fmt.Errorf("operator pull failed")
+		}
+
+		for _, env := range pull.Envelopes {
+			err := handleOperatorEnvelope(
+				ctx, edge, operatorMailboxID, mux, env,
+			)
+			if err != nil {
+				return err
+			}
+		}
+
+		if pull.NextCursor > cursor {
+			ack, err := edge.AckUpTo(ctx, &mailboxpb.AckUpToRequest{
+				MailboxId: operatorMailboxID,
+				Cursor:    pull.NextCursor,
+			})
+			if err != nil {
+				return err
+			}
+			if ack.Status == nil || !ack.Status.Ok {
+				return fmt.Errorf("operator ack failed")
+			}
+
+			cursor = pull.NextCursor
+		}
+	}
+}
+
+// handleOperatorEnvelope serves a request envelope and sends a response.
+func handleOperatorEnvelope(ctx context.Context,
+	edge mailboxpb.MailboxServiceClient, operatorMailboxID string,
+	mux *mailboxrpc.ServeMux, env *mailboxpb.Envelope) error {
+
+	if env == nil || env.Rpc == nil {
+		return nil
+	}
+	if env.Rpc.Kind != mailboxpb.RpcMeta_KIND_REQUEST {
+		return nil
+	}
+
+	if env.Body == nil {
+		return fmt.Errorf("missing request body")
+	}
+
+	resp, err := mux.ServeRPC(ctx, env.Rpc.Service, env.Rpc.Method,
+		env.Body.Value)
+	if err != nil {
+		return err
+	}
+
+	respAny, err := anypb.New(resp)
+	if err != nil {
+		return err
+	}
+
+	replyTo := env.Rpc.ReplyTo
+	if replyTo == "" {
+		return fmt.Errorf("missing reply_to")
+	}
+
+	responseEnv := &mailboxpb.Envelope{
+		ProtocolVersion: env.ProtocolVersion,
+		MsgId:           "resp-" + env.MsgId,
+		Sender:          operatorMailboxID,
+		Recipient:       replyTo,
+		CreatedAtUnixMs: time.Now().UnixMilli(),
+		Body:            respAny,
+		Rpc: &mailboxpb.RpcMeta{
+			Kind:          mailboxpb.RpcMeta_KIND_RESPONSE,
+			Service:       env.Rpc.Service,
+			Method:        env.Rpc.Method,
+			CorrelationId: env.Rpc.CorrelationId,
+		},
+	}
+
+	send, err := edge.Send(ctx, &mailboxpb.SendRequest{
+		Envelope: responseEnv,
+	})
+	if err != nil {
+		return err
+	}
+	if send.Status == nil || !send.Status.Ok {
+		return fmt.Errorf("operator send failed")
+	}
+
+	return nil
+}
+
+// TestClient_GetInfoRoundTrip verifies a basic request/response round trip.
+func TestClient_GetInfoRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	mb := newInMemoryMailbox()
+	edge := &fakeMailboxServiceClient{mb: mb}
+
+	mux := mailboxrpc.NewServeMux()
+	arkrpc.RegisterArkServiceMailboxServer(mux, &testArkServer{
+		resp: &arkrpc.GetInfoResponse{
+			Version:     "v-test",
+			Network:     "regtest",
+			BlockHeight: 123,
+		},
+	})
+
+	operatorCtx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	operatorErr := make(chan error, 1)
+	go func() {
+		operatorErr <- runOperator(operatorCtx, edge, "operator", mux)
+	}()
+
+	cfg := mailboxclient.DefaultConfig()
+	cfg.Edge = edge
+	cfg.LocalMailboxID = "client-1"
+	cfg.RemoteMailboxID = "operator"
+	cfg.ProtocolVersion = 1
+	cfg.PullWaitTimeout = 20 * time.Millisecond
+
+	rpc, err := mailboxclient.New(cfg)
+	require.NoError(t, err)
+	defer rpc.Stop()
+
+	client := arkrpc.NewArkServiceMailboxClient(rpc)
+
+	resp, err := client.GetInfo(t.Context(), &arkrpc.GetInfoRequest{})
+	require.NoError(t, err)
+	require.Equal(t, "v-test", resp.Version)
+	require.Equal(t, "regtest", resp.Network)
+	require.Equal(t, uint32(123), resp.BlockHeight)
+
+	cancel()
+	require.NoError(t, <-operatorErr)
+}
+
+// TestClient_ConcurrentInFlightDoesNotDrop verifies that cursor-based acking
+// does not discard a response for a different in-flight call.
+func TestClient_ConcurrentInFlightDoesNotDrop(t *testing.T) {
+	t.Parallel()
+
+	mb := newInMemoryMailbox()
+	edge := &fakeMailboxServiceClient{mb: mb}
+
+	mux := mailboxrpc.NewServeMux()
+	arkrpc.RegisterArkServiceMailboxServer(mux, &testArkServer{
+		resp: &arkrpc.GetInfoResponse{
+			Version:     "v-test",
+			Network:     "regtest",
+			BlockHeight: 999,
+		},
+	})
+
+	operatorCtx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	operatorErr := make(chan error, 1)
+	go func() {
+		operatorErr <- runOperator(operatorCtx, edge, "operator", mux)
+	}()
+
+	cfg := mailboxclient.DefaultConfig()
+	cfg.Edge = edge
+	cfg.LocalMailboxID = "client-1"
+	cfg.RemoteMailboxID = "operator"
+	cfg.ProtocolVersion = 1
+	cfg.PullWaitTimeout = 20 * time.Millisecond
+
+	rpc, err := mailboxclient.New(cfg)
+	require.NoError(t, err)
+	defer rpc.Stop()
+
+	type result struct {
+		resp *arkrpc.GetInfoResponse
+		err  error
+	}
+
+	call := func(ctx context.Context, correlationID string) result {
+		var out result
+
+		result, err := rpc.SendRPC(
+			ctx,
+			mailboxrpc.ServiceMethod{
+				Service: "arkrpc.ArkService",
+				Method:  "GetInfo",
+			},
+			&arkrpc.GetInfoRequest{},
+			mailboxrpc.RPCOptions{
+				CorrelationID:  correlationID,
+				IdempotencyKey: correlationID,
+			},
+		)
+		if err != nil {
+			out.err = err
+			return out
+		}
+
+		resp := new(arkrpc.GetInfoResponse)
+		err = rpc.AwaitRPC(ctx, result.CorrelationID, resp)
+		out.err = err
+		out.resp = resp
+
+		return out
+	}
+
+	ctx, cancelCalls := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancelCalls()
+
+	ch1 := make(chan result, 1)
+	ch2 := make(chan result, 1)
+	go func() { ch1 <- call(ctx, "corr-1") }()
+	go func() { ch2 <- call(ctx, "corr-2") }()
+
+	r1 := <-ch1
+	r2 := <-ch2
+
+	require.NoError(t, r1.err)
+	require.NoError(t, r2.err)
+	require.Equal(t, uint32(999), r1.resp.BlockHeight)
+	require.Equal(t, uint32(999), r2.resp.BlockHeight)
+
+	cancel()
+	require.NoError(t, <-operatorErr)
+}

--- a/mailbox/client/config.go
+++ b/mailbox/client/config.go
@@ -1,0 +1,38 @@
+package mailboxclient
+
+import (
+	"time"
+
+	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
+)
+
+// Config holds configuration for a mailboxclient.Client.
+type Config struct {
+	// Edge is the gRPC client for the mailbox edge service.
+	Edge mailboxpb.MailboxServiceClient
+
+	// LocalMailboxID is the mailbox id used to receive responses.
+	LocalMailboxID string
+
+	// RemoteMailboxID is the mailbox id used as the recipient for outbound
+	// requests (typically the operator ingress mailbox).
+	RemoteMailboxID string
+
+	// ProtocolVersion is the protocol version set on all outbound
+	// envelopes.
+	ProtocolVersion uint32
+
+	// PullMaxEnvelopes bounds the size of Pull batches.
+	PullMaxEnvelopes uint32
+
+	// PullWaitTimeout controls long-poll behavior.
+	PullWaitTimeout time.Duration
+}
+
+// DefaultConfig returns a Config populated with conservative defaults.
+func DefaultConfig() Config {
+	return Config{
+		PullMaxEnvelopes: 50,
+		PullWaitTimeout:  5 * time.Second,
+	}
+}

--- a/mailbox/client/doc.go
+++ b/mailbox/client/doc.go
@@ -1,0 +1,15 @@
+// Package mailboxclient provides a concrete implementation of the
+// mailboxrpc.RPCClient interface backed by the mailbox edge gRPC API
+// (mailboxpb.MailboxService).
+//
+// The RPC client in this package focuses on:
+//   - encoding requests into mailboxpb.Envelope values,
+//   - receiving correlated responses by long-polling Pull, and
+//   - preventing response loss under cursor-based acking by caching pulled
+//     responses by correlation id before advancing the remote cursor.
+//
+// This package is intentionally small and self-contained so it can be used in
+// both production code and tests. It does not attempt to implement the full
+// “local durability ↔ remote mailbox” connector described in the spec; that
+// integration belongs at a higher layer that has access to a durable store.
+package mailboxclient

--- a/mailbox/client/errors.go
+++ b/mailbox/client/errors.go
@@ -1,0 +1,39 @@
+package mailboxclient
+
+import (
+	"fmt"
+
+	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
+)
+
+// StatusError wraps a mailboxpb.Status failure.
+type StatusError struct {
+	// Op is the mailbox operation that failed (Send, Pull, AckUpTo).
+	Op string
+
+	// Status is the status returned by the mailbox edge.
+	Status *mailboxpb.Status
+}
+
+// Error returns a human-readable description of the error.
+func (e *StatusError) Error() string {
+	if e == nil || e.Status == nil {
+		return "mailbox status error"
+	}
+
+	return fmt.Sprintf("%s failed: %s (%s)", e.Op, e.Status.Message,
+		e.Status.Code)
+}
+
+// statusOK returns true when status indicates success.
+func statusOK(status *mailboxpb.Status) bool {
+	return status != nil && status.Ok
+}
+
+// statusError constructs a StatusError for a failed mailbox response.
+func statusError(op string, status *mailboxpb.Status) error {
+	return &StatusError{
+		Op:     op,
+		Status: status,
+	}
+}

--- a/mailbox/client/inmemory_test.go
+++ b/mailbox/client/inmemory_test.go
@@ -1,0 +1,242 @@
+package mailboxclient_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
+)
+
+// inMemoryMailbox is a minimal in-memory implementation of the MailboxService
+// semantics needed for unit tests.
+type inMemoryMailbox struct {
+	mu sync.Mutex
+
+	nextSeq uint64
+
+	// mailboxes stores all envelopes by mailbox id.
+	mailboxes map[string][]*mailboxpb.Envelope
+
+	// ackedUpTo stores the ack watermark (event_seq < ackedUpTo are acked).
+	ackedUpTo map[string]uint64
+
+	notify chan struct{}
+}
+
+// newInMemoryMailbox constructs an empty mailbox edge.
+func newInMemoryMailbox() *inMemoryMailbox {
+	mb := &inMemoryMailbox{
+		nextSeq:   1,
+		mailboxes: make(map[string][]*mailboxpb.Envelope),
+		ackedUpTo: make(map[string]uint64),
+		notify:    make(chan struct{}),
+	}
+
+	return mb
+}
+
+// send enqueues envelope into recipient mailbox and assigns an event_seq.
+func (m *inMemoryMailbox) send(envelope *mailboxpb.Envelope) *mailboxpb.Status {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if envelope == nil {
+		return &mailboxpb.Status{
+			Ok:      false,
+			Code:    "INVALID_ARGUMENT",
+			Message: "missing envelope",
+		}
+	}
+
+	envCopy, ok := cloneEnvelope(envelope)
+	if !ok {
+		return &mailboxpb.Status{
+			Ok:      false,
+			Code:    "INVALID_ARGUMENT",
+			Message: "unexpected envelope type",
+		}
+	}
+	envCopy.EventSeq = m.nextSeq
+	m.nextSeq++
+
+	recipient := envCopy.Recipient
+	m.mailboxes[recipient] = append(m.mailboxes[recipient], envCopy)
+
+	close(m.notify)
+	m.notify = make(chan struct{})
+
+	return okStatus()
+}
+
+// pull returns envelopes with event_seq >= cursor and not acked.
+func (m *inMemoryMailbox) pull(ctx context.Context, mailboxID string,
+	cursor uint64, maxEnvelopes uint32,
+	wait time.Duration) ([]*mailboxpb.Envelope, uint64, *mailboxpb.Status) {
+
+	deadline := time.Now().Add(wait)
+
+	for {
+		m.mu.Lock()
+		envs, next := m.pullLocked(mailboxID, cursor, maxEnvelopes)
+		if len(envs) > 0 || wait == 0 {
+			m.mu.Unlock()
+			return envs, next, okStatus()
+		}
+
+		notify := m.notify
+		m.mu.Unlock()
+
+		now := time.Now()
+		if !now.Before(deadline) {
+			return nil, cursor, okStatus()
+		}
+
+		remaining := deadline.Sub(now)
+		timer := time.NewTimer(remaining)
+		select {
+		case <-notify:
+		case <-timer.C:
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, cursor, okStatus()
+		}
+		timer.Stop()
+	}
+}
+
+// pullLocked assumes m.mu is held.
+func (m *inMemoryMailbox) pullLocked(mailboxID string, cursor uint64,
+	maxEnvelopes uint32) ([]*mailboxpb.Envelope, uint64) {
+
+	acked := m.ackedUpTo[mailboxID]
+
+	var result []*mailboxpb.Envelope
+	var maxSeq uint64
+
+	for _, env := range m.mailboxes[mailboxID] {
+		if env.EventSeq < acked {
+			continue
+		}
+		if env.EventSeq < cursor {
+			continue
+		}
+
+		clone, ok := cloneEnvelope(env)
+		if !ok {
+			continue
+		}
+
+		result = append(result, clone)
+		if env.EventSeq > maxSeq {
+			maxSeq = env.EventSeq
+		}
+
+		if uint32(len(result)) >= maxEnvelopes {
+			break
+		}
+	}
+
+	if len(result) == 0 {
+		return nil, cursor
+	}
+
+	return result, maxSeq + 1
+}
+
+// ackUpTo advances the ack cursor.
+func (m *inMemoryMailbox) ackUpTo(mailboxID string,
+	cursor uint64) *mailboxpb.Status {
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if cursor > m.ackedUpTo[mailboxID] {
+		m.ackedUpTo[mailboxID] = cursor
+	}
+
+	return okStatus()
+}
+
+// cloneEnvelope makes a deep copy of env and returns false if proto.Clone does
+// not return the expected type.
+func cloneEnvelope(env *mailboxpb.Envelope) (*mailboxpb.Envelope, bool) {
+	clone := proto.Clone(env)
+	typed, ok := clone.(*mailboxpb.Envelope)
+	if !ok {
+		return nil, false
+	}
+
+	return typed, true
+}
+
+// okStatus returns a successful mailbox status.
+func okStatus() *mailboxpb.Status {
+	return &mailboxpb.Status{Ok: true}
+}
+
+// fakeMailboxServiceClient adapts the in-memory edge to MailboxServiceClient.
+type fakeMailboxServiceClient struct {
+	mb *inMemoryMailbox
+}
+
+// Send implements mailboxpb.MailboxServiceClient.
+func (c *fakeMailboxServiceClient) Send(
+	ctx context.Context,
+	in *mailboxpb.SendRequest,
+	_ ...grpc.CallOption,
+) (*mailboxpb.SendResponse, error) {
+
+	_ = ctx
+
+	if in == nil {
+		return nil, fmt.Errorf("nil request")
+	}
+
+	status := c.mb.send(in.Envelope)
+
+	return &mailboxpb.SendResponse{Status: status}, nil
+}
+
+// Pull implements mailboxpb.MailboxServiceClient.
+func (c *fakeMailboxServiceClient) Pull(
+	ctx context.Context,
+	in *mailboxpb.PullRequest,
+	_ ...grpc.CallOption,
+) (*mailboxpb.PullResponse, error) {
+
+	if in == nil {
+		return nil, fmt.Errorf("nil request")
+	}
+
+	wait := time.Duration(in.WaitTimeoutMs) * time.Millisecond
+
+	envs, next, status := c.mb.pull(
+		ctx, in.MailboxId, in.Cursor, in.MaxEnvelopes, wait,
+	)
+
+	return &mailboxpb.PullResponse{
+		Status:     status,
+		Envelopes:  envs,
+		NextCursor: next,
+	}, nil
+}
+
+// AckUpTo implements mailboxpb.MailboxServiceClient.
+func (c *fakeMailboxServiceClient) AckUpTo(ctx context.Context,
+	in *mailboxpb.AckUpToRequest, _ ...grpc.CallOption) (
+	*mailboxpb.AckUpToResponse, error) {
+
+	_ = ctx
+
+	if in == nil {
+		return nil, fmt.Errorf("nil request")
+	}
+
+	status := c.mb.ackUpTo(in.MailboxId, in.Cursor)
+
+	return &mailboxpb.AckUpToResponse{Status: status}, nil
+}

--- a/mailbox/client/log.go
+++ b/mailbox/client/log.go
@@ -1,0 +1,24 @@
+package mailboxclient
+
+import "github.com/btcsuite/btclog/v2"
+
+// Subsystem defines the logging code for this subsystem.
+const Subsystem = "MBXC"
+
+// log is a logger that is initialized with no output filters. This means the
+// package will not perform any logging by default until the caller requests
+// it.
+var log = btclog.Disabled
+
+// DisableLog disables all library log output. Logging output is disabled by
+// default until UseLogger is called.
+func DisableLog() {
+	UseLogger(btclog.Disabled)
+}
+
+// UseLogger uses a specified Logger to output package logging info. This
+// should be used in preference to SetLogWriter if the caller is also using
+// btclog.
+func UseLogger(logger btclog.Logger) {
+	log = logger
+}

--- a/mailbox/rpc/interface.go
+++ b/mailbox/rpc/interface.go
@@ -33,17 +33,38 @@ type Router interface {
 		fn HandlerFunc)
 }
 
+// ServiceMethod identifies an RPC endpoint by its fully-qualified protobuf
+// service name and method name.
+type ServiceMethod struct {
+	// Service is the fully-qualified protobuf service name
+	// (e.g., "arkrpc.ArkService").
+	Service string
+
+	// Method is the protobuf method name (e.g., "GetInfo").
+	Method string
+}
+
+// SendResult holds the identifiers returned by a successful SendRPC call.
+type SendResult struct {
+	// CorrelationID uniquely identifies the request-response pair so the
+	// caller can match it with a subsequent AwaitRPC call.
+	CorrelationID string
+
+	// IdempotencyKey identifies the semantic operation for deduplication
+	// by the remote mailbox.
+	IdempotencyKey string
+}
+
 // RPCClient sends RPC-over-mailbox requests and awaits correlated responses.
 //
 // Implementations are expected to ensure concurrent in-flight calls are safe
 // under cursor-based acking by demultiplexing pulled responses by correlation
 // id before advancing any cursor.
 type RPCClient interface {
-	// SendRPC sends a request payload and returns the correlation id and
-	// idempotency key used for the send.
-	SendRPC(ctx context.Context, service string, method string,
-		req proto.Message, opts RPCOptions) (correlationID string,
-		idempotencyKey string, err error)
+	// SendRPC sends a request payload and returns a SendResult containing
+	// the correlation id and idempotency key used for the send.
+	SendRPC(ctx context.Context, method ServiceMethod,
+		req proto.Message, opts RPCOptions) (SendResult, error)
 
 	// AwaitRPC blocks until a response for correlationID is received.
 	//


### PR DESCRIPTION
Adds `mailboxclient.Client`, a concrete `mailboxrpc.RPCClient` implementation
backed by the mailbox edge gRPC API (`mailboxpb.MailboxService`: Send/Pull/AckUpTo).

Key behaviors:
- Encodes requests into `mailboxpb.Envelope` with `google.protobuf.Any` payloads.
- Long-polls `Pull` for responses.
- Caches pulled responses by correlation id before advancing the ack cursor
  (prevents response loss with concurrent in-flight RPCs).

Stack order:
- Base: #48
- Depends on: #88 (router), #86 (contract/codegen)
