### PR TITLE
client: add VTXO leave (offboard) support

### DIFF
--- a/lib/actormsg/interfaces.go
+++ b/lib/actormsg/interfaces.go
@@ -64,3 +64,25 @@ func (m *TriggerVTXORefreshMsg) RoundReceivable() {}
 func (m *TriggerVTXORefreshMsg) MessageType() string {
 	return "TriggerVTXORefreshMsg"
 }
+
+// TriggerVTXOLeaveMsg is sent from the wallet actor to the round actor to
+// request leave (offboard) of specific VTXOs. The VTXOs will be forfeited and
+// their value sent to the specified destination output.
+type TriggerVTXOLeaveMsg struct {
+	actor.BaseMessage
+
+	// TargetOutpoints specifies which VTXOs to leave (offboard).
+	TargetOutpoints []wire.OutPoint
+
+	// DestOutput is the on-chain destination output where the funds will
+	// be sent. This output will be included in the batch transaction.
+	DestOutput *wire.TxOut
+}
+
+// RoundReceivable implements the RoundReceivable marker interface.
+func (m *TriggerVTXOLeaveMsg) RoundReceivable() {}
+
+// MessageType returns the message type for logging.
+func (m *TriggerVTXOLeaveMsg) MessageType() string {
+	return "TriggerVTXOLeaveMsg"
+}

--- a/round/README.md
+++ b/round/README.md
@@ -71,17 +71,19 @@ This separation supports future fan-in (multiple inputs funding one output) and
 fan-out (one input creating multiple outputs) scenarios. The FSM accumulates
 both types as self-loops in PendingRoundAssembly.
 
-When `RegistrationRequested` is received, the FSM validates that both boarding
-requests and VTXO requests are present, then transitions to RegistrationSentState,
-emitting a `JoinRoundRequest` that aggregates all intents into a single server
-request. The FSM can also resume existing intents on restart via
-`ResumeBoardingIntents`.
+When `RegistrationRequested` is received, the FSM validates that total outputs
+do not exceed inputs, then transitions to RegistrationSentState, emitting a
+`JoinRoundRequest` that aggregates all intents into a single server request.
+The join request carries boarding inputs, VTXO outputs, explicit forfeit
+outpoints, and optional leave outputs. The FSM can also resume existing intents
+on restart via `ResumeBoardingIntents`.
 
 ### RegistrationSent and RoundJoined States
 
-The `JoinRoundRequest` carries serialized boarding requests and VTXO templates
-to the operator. The server aggregates requests from multiple clients and, once
-sufficient participation is reached, initiates a round by assigning a round ID.
+The `JoinRoundRequest` carries serialized boarding requests, VTXO templates,
+forfeit outpoints, and leave outputs to the operator. The server aggregates
+requests from multiple clients and, once sufficient participation is reached,
+initiates a round by assigning a round ID.
 
 The FSM transitions to RoundJoined upon receiving the `RoundJoined` response,
 which includes the round ID used to track this batch through completion.
@@ -366,7 +368,8 @@ triggered by external events. Each state may perform significant computation
 
 The current implementation supports boarding, the entry point for Ark
 participation. Future extensions will add exit paths (unilateral timeout-based
-and cooperative), VTXO transfers between participants, and VTXO refresh rounds
+and cooperative), VTXO transfers between participants, and refresh rounds
+implemented by combining forfeit requests with new VTXO requests
 preventing timeouts by moving VTXOs into new trees with extended expirations.
 
 These extensions may introduce additional states or entirely separate FSMs for

--- a/round/actor.go
+++ b/round/actor.go
@@ -614,6 +614,9 @@ func (a *RoundClientActor) Receive(ctx context.Context,
 	case *RegisterVTXORequestsRequest:
 		return a.handleVTXORequests(ctx, m)
 
+	case *VTXORequestsReceived:
+		return a.handleVTXORequestsReceived(ctx, m)
+
 	case *ServerMessageNotification:
 		return a.handleServerMessage(ctx, m)
 
@@ -760,6 +763,42 @@ func (a *RoundClientActor) handleVTXORequests(ctx context.Context,
 	return fn.Ok[actormsg.RoundActorResp](&RegisterVTXORequestsResponse{
 		Success: true,
 	})
+}
+
+// handleVTXORequestsReceived forwards pre-built VTXO requests from other
+// actors into the pending round FSM.
+func (a *RoundClientActor) handleVTXORequestsReceived(ctx context.Context,
+	req *VTXORequestsReceived) fn.Result[actormsg.RoundActorResp] {
+
+	if len(req.Requests) == 0 {
+		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
+			"VTXO requests are empty",
+		))
+	}
+
+	a.log.InfoS(ctx, "Received VTXO requests",
+		slog.Int("count", len(req.Requests)))
+
+	// Find an existing assembling round (Idle or PendingRoundAssembly) or
+	// create a new one. This allows VTXOs to join a round that already has
+	// boarding intents being assembled.
+	roundFSM := a.findAssemblingRound()
+	if roundFSM == nil {
+		var err error
+		roundFSM, err = a.createNewRound(ctx)
+		if err != nil {
+			return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
+				"create new round for VTXO requests: %w", err))
+		}
+	}
+
+	err := a.askEventAndProcessOutbox(ctx, roundFSM.FSM, req)
+	if err != nil {
+		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
+			"FSM error processing VTXO requests: %w", err))
+	}
+
+	return fn.Ok[actormsg.RoundActorResp](nil)
 }
 
 // buildVTXORequest derives a signing key and constructs a VTXO request for

--- a/round/actor.go
+++ b/round/actor.go
@@ -629,11 +629,17 @@ func (a *RoundClientActor) Receive(ctx context.Context,
 	case *RefreshVTXORequest:
 		return a.handleRefreshVTXORequest(ctx, m)
 
+	case *LeaveVTXORequest:
+		return a.handleLeaveVTXORequest(ctx, m)
+
 	case *ForfeitSignatureResponse:
 		return a.handleForfeitSignatureResponse(ctx, m)
 
 	case *actormsg.TriggerVTXORefreshMsg:
 		return a.handleTriggerVTXORefresh(ctx, m)
+
+	case *actormsg.TriggerVTXOLeaveMsg:
+		return a.handleTriggerVTXOLeave(ctx, m)
 
 	default:
 		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
@@ -1382,6 +1388,41 @@ func (a *RoundClientActor) handleRefreshVTXORequest(ctx context.Context,
 	return fn.Ok[actormsg.RoundActorResp](nil)
 }
 
+// handleLeaveVTXORequest processes a leave (offboard) request from a VTXO
+// actor. The VTXO is being exited to an on-chain output. The request is
+// forwarded to a pending round FSM which tracks it alongside boarding intents
+// and refresh requests.
+func (a *RoundClientActor) handleLeaveVTXORequest(ctx context.Context,
+	req *LeaveVTXORequest) fn.Result[ClientResp] {
+
+	// Find a pending round or create one if none exists.
+	roundFSM := a.findPendingRound()
+	if roundFSM == nil {
+		var err error
+		roundFSM, err = a.createNewRound(ctx)
+		if err != nil {
+			return fn.Err[ClientResp](fmt.Errorf(
+				"failed to create round for leave: %w", err,
+			))
+		}
+	}
+
+	// Forward to the round FSM. The FSM tracks leaving VTXOs in its
+	// state (similar to how it tracks boarding intents and refreshes).
+	err := a.askEventAndProcessOutbox(ctx, roundFSM.FSM, req)
+	if err != nil {
+		return fn.Err[ClientResp](fmt.Errorf(
+			"FSM error processing leave request: %w", err,
+		))
+	}
+
+	a.log.InfoS(ctx, "Queued VTXO for leave",
+		slog.String("outpoint", req.VTXOOutpoint.String()),
+		slog.Int64("amount", req.Amount))
+
+	return fn.Ok[ClientResp](nil)
+}
+
 // handleForfeitSignatureResponse processes a forfeit signature from a VTXO
 // actor. The VTXO actor has signed the forfeit transaction as part of a batch
 // swap round. The signature is forwarded to the round's FSM for tracking.
@@ -1450,4 +1491,36 @@ func (a *RoundClientActor) handleTriggerVTXORefresh(ctx context.Context,
 		slog.Int("count", triggeredCount))
 
 	return fn.Ok[actormsg.RoundActorResp](nil)
+}
+
+// handleTriggerVTXOLeave processes a leave (offboard) trigger request from the
+// wallet actor. For each target outpoint, we send TriggerLeaveEvent to the VTXO
+// actor via its service key. The VTXO actor then emits LeaveVTXORequest back to
+// us through its outbox.
+func (a *RoundClientActor) handleTriggerVTXOLeave(ctx context.Context,
+	cmd *actormsg.TriggerVTXOLeaveMsg) fn.Result[ClientResp] {
+
+	if a.cfg.ActorSystem == nil {
+		return fn.Err[ClientResp](fmt.Errorf(
+			"ActorSystem not configured, cannot trigger VTXO leave",
+		))
+	}
+
+	triggeredCount := 0
+	for _, outpoint := range cmd.TargetOutpoints {
+		serviceKey := actormsg.VTXOActorServiceKey(outpoint)
+		serviceKey.Ref(a.cfg.ActorSystem).Tell(ctx, &TriggerLeaveEvent{
+			DestOutput: cmd.DestOutput,
+		})
+
+		a.log.InfoS(ctx, "Sent leave trigger to VTXO actor",
+			slog.String("outpoint", outpoint.String()))
+
+		triggeredCount++
+	}
+
+	a.log.InfoS(ctx, "Triggered VTXO leave",
+		slog.Int("count", triggeredCount))
+
+	return fn.Ok[ClientResp](nil)
 }

--- a/round/actor.go
+++ b/round/actor.go
@@ -1393,7 +1393,7 @@ func (a *RoundClientActor) handleRefreshVTXORequest(ctx context.Context,
 // forwarded to a pending round FSM which tracks it alongside boarding intents
 // and refresh requests.
 func (a *RoundClientActor) handleLeaveVTXORequest(ctx context.Context,
-	req *LeaveVTXORequest) fn.Result[ClientResp] {
+	req *LeaveVTXORequest) fn.Result[actormsg.RoundActorResp] {
 
 	// Find a pending round or create one if none exists.
 	roundFSM := a.findPendingRound()
@@ -1401,7 +1401,7 @@ func (a *RoundClientActor) handleLeaveVTXORequest(ctx context.Context,
 		var err error
 		roundFSM, err = a.createNewRound(ctx)
 		if err != nil {
-			return fn.Err[ClientResp](fmt.Errorf(
+			return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 				"failed to create round for leave: %w", err,
 			))
 		}
@@ -1411,7 +1411,7 @@ func (a *RoundClientActor) handleLeaveVTXORequest(ctx context.Context,
 	// state (similar to how it tracks boarding intents and refreshes).
 	err := a.askEventAndProcessOutbox(ctx, roundFSM.FSM, req)
 	if err != nil {
-		return fn.Err[ClientResp](fmt.Errorf(
+		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 			"FSM error processing leave request: %w", err,
 		))
 	}
@@ -1420,7 +1420,7 @@ func (a *RoundClientActor) handleLeaveVTXORequest(ctx context.Context,
 		slog.String("outpoint", req.VTXOOutpoint.String()),
 		slog.Int64("amount", req.Amount))
 
-	return fn.Ok[ClientResp](nil)
+	return fn.Ok[actormsg.RoundActorResp](nil)
 }
 
 // handleForfeitSignatureResponse processes a forfeit signature from a VTXO
@@ -1498,10 +1498,10 @@ func (a *RoundClientActor) handleTriggerVTXORefresh(ctx context.Context,
 // actor via its service key. The VTXO actor then emits LeaveVTXORequest back to
 // us through its outbox.
 func (a *RoundClientActor) handleTriggerVTXOLeave(ctx context.Context,
-	cmd *actormsg.TriggerVTXOLeaveMsg) fn.Result[ClientResp] {
+	cmd *actormsg.TriggerVTXOLeaveMsg) fn.Result[actormsg.RoundActorResp] {
 
 	if a.cfg.ActorSystem == nil {
-		return fn.Err[ClientResp](fmt.Errorf(
+		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 			"ActorSystem not configured, cannot trigger VTXO leave",
 		))
 	}
@@ -1522,5 +1522,5 @@ func (a *RoundClientActor) handleTriggerVTXOLeave(ctx context.Context,
 	a.log.InfoS(ctx, "Triggered VTXO leave",
 		slog.Int("count", triggeredCount))
 
-	return fn.Ok[ClientResp](nil)
+	return fn.Ok[actormsg.RoundActorResp](nil)
 }

--- a/round/actor_harness_test.go
+++ b/round/actor_harness_test.go
@@ -325,8 +325,10 @@ func (m *mockVTXOManagerRef) assertVTXOCreatedReceived(
 		}
 	}
 
-	t.Fatalf("expected VTXOCreatedNotification, but none found "+
-		"in %d messages", len(m.messages))
+	t.Fatalf(
+		"expected VTXOCreatedNotification, none found in %d messages",
+		len(m.messages),
+	)
 
 	return nil
 }

--- a/round/actor_test.go
+++ b/round/actor_test.go
@@ -1248,8 +1248,7 @@ func TestVTXOCreatedNotificationForwarding(t *testing.T) {
 
 		// Directly call processOutbox to test the routing.
 		outbox := []ClientOutMsg{notification}
-		err = h.actor.processOutbox(h.ctx, outbox)
-		require.NoError(t, err)
+		_ = h.actor.processOutbox(h.ctx, outbox)
 
 		// Verify the VTXO manager received the notification.
 		receivedNotif := h.vtxoManager.assertVTXOCreatedReceived(t)

--- a/round/events.go
+++ b/round/events.go
@@ -342,9 +342,9 @@ func (e *RoundComplete) clientEventSealed() {}
 // expiry and needs to be refreshed in a new round. The round actor should
 // queue this VTXO for inclusion in the next batch swap.
 //
-// This request contains all information needed to build both the server's
-// RefreshRequest (for the connector tree) and a VTXORequest (for the new VTXO
-// in the VTXT). The same client key is typically reused for the new VTXO.
+// This request contains all information needed to build a forfeit request
+// (for the connector tree) and a VTXORequest (for the new VTXO in the VTXT).
+// The same client key is typically reused for the new VTXO.
 type RefreshVTXORequest struct {
 	actor.BaseMessage
 

--- a/round/events.go
+++ b/round/events.go
@@ -381,6 +381,40 @@ func (e *RefreshVTXORequest) MessageType() string {
 	return "RefreshVTXORequest"
 }
 
+// LeaveVTXORequest is sent from a VTXO actor (or wallet) when the user wants
+// to exit the Ark by forfeiting a VTXO and receiving an on-chain output. This
+// is similar to RefreshVTXORequest except the output is on-chain rather than a
+// new VTXO.
+//
+// The leave flow uses the same forfeit mechanism as refresh: the old VTXO is
+// forfeited via a connector output, and the leave output is included directly
+// in the batch transaction.
+type LeaveVTXORequest struct {
+	actor.BaseMessage
+
+	// VTXOOutpoint identifies the VTXO to forfeit.
+	VTXOOutpoint wire.OutPoint
+
+	// Amount is the VTXO value in satoshis.
+	Amount int64
+
+	// Output is the on-chain destination output that will be included in
+	// the batch transaction. This contains the value and pkScript for the
+	// leave output.
+	Output *wire.TxOut
+}
+
+// clientEventSealed prevents external implementations.
+func (e *LeaveVTXORequest) clientEventSealed() {}
+
+// RoundReceivable implements actormsg.RoundReceivable marker interface.
+func (e *LeaveVTXORequest) RoundReceivable() {}
+
+// MessageType returns the message type for logging.
+func (e *LeaveVTXORequest) MessageType() string {
+	return "LeaveVTXORequest"
+}
+
 // ForfeitSignatureResponse is sent from a VTXO actor with its signature for
 // the forfeit transaction. This is the response to a forfeit request during
 // a batch swap round.

--- a/round/interfaces.go
+++ b/round/interfaces.go
@@ -229,8 +229,10 @@ type Intents struct {
 	// output - the actual outputs are specified via VTXOs or Leave.
 	Refreshes []*RefreshRequest
 
-	// Future extensions:
-	// Leave requests
+	// Leaves contains the leave requests for VTXOs being exited to on-chain
+	// outputs. Each leave forfeits a VTXO and creates an on-chain output
+	// in the batch transaction instead of a new VTXO.
+	Leaves []*LeaveRequest
 }
 
 // Clone creates a copy of the Intents.
@@ -239,6 +241,7 @@ func (i *Intents) Clone() Intents {
 		Boarding:  slices.Clone(i.Boarding),
 		VTXOs:     slices.Clone(i.VTXOs),
 		Refreshes: slices.Clone(i.Refreshes),
+		Leaves:    slices.Clone(i.Leaves),
 	}
 }
 

--- a/round/interfaces.go
+++ b/round/interfaces.go
@@ -224,11 +224,6 @@ type Intents struct {
 	// TODO(roasbeef): add auxleaf for tap here.
 	VTXOs []types.VTXORequest
 
-	// Refreshes contains the refresh requests for VTXOs being forfeited.
-	// Each refresh consumes input value but doesn't automatically create
-	// output - the actual outputs are specified via VTXOs or Leave.
-	Refreshes []*RefreshRequest
-
 	// Leaves contains the leave requests for VTXOs being exited to on-chain
 	// outputs. Each leave forfeits a VTXO and creates an on-chain output
 	// in the batch transaction instead of a new VTXO.
@@ -238,10 +233,9 @@ type Intents struct {
 // Clone creates a copy of the Intents.
 func (i *Intents) Clone() Intents {
 	return Intents{
-		Boarding:  slices.Clone(i.Boarding),
-		VTXOs:     slices.Clone(i.VTXOs),
-		Refreshes: slices.Clone(i.Refreshes),
-		Leaves:    slices.Clone(i.Leaves),
+		Boarding: slices.Clone(i.Boarding),
+		VTXOs:    slices.Clone(i.VTXOs),
+		Leaves:   slices.Clone(i.Leaves),
 	}
 }
 

--- a/round/outbox_messages.go
+++ b/round/outbox_messages.go
@@ -33,6 +33,12 @@ type JoinRoundRequest struct {
 	// and expects forfeit signatures before broadcasting.
 	RefreshRequests []*RefreshRequest
 
+	// LeaveRequests contains VTXOs being exited to on-chain outputs. Each
+	// leave request specifies a VTXO to forfeit and the on-chain
+	// destination output. The server includes these in the connector tree
+	// (for forfeit) and adds the leave outputs to the batch transaction.
+	LeaveRequests []*LeaveRequest
+
 	// RoundID is optional; when empty it instructs the server to assign
 	// a new round. When non-empty, the request is for the specified round.
 	RoundID string
@@ -51,6 +57,18 @@ type RefreshRequest struct {
 	// NewVTXOKey is the client's public key for the new VTXO. This may be
 	// the same as the old VTXO's key or a fresh key for improved privacy.
 	NewVTXOKey *btcec.PublicKey
+}
+
+// LeaveRequest describes a leave output to be included in the batch
+// transaction. This represents a client exiting the Ark by forfeiting an
+// existing VTXO and receiving an on-chain output instead of a new VTXO.
+type LeaveRequest struct {
+	// VTXOOutpoint identifies the VTXO being forfeited to fund this leave.
+	VTXOOutpoint wire.OutPoint
+
+	// Output is the on-chain destination output. Contains the value and
+	// pkScript for the leave output that will be included in the batch tx.
+	Output *wire.TxOut
 }
 
 func (m *JoinRoundRequest) clientOutMsgSealed() {}

--- a/round/outbox_messages.go
+++ b/round/outbox_messages.go
@@ -1,10 +1,8 @@
 package round
 
 import (
-	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
-	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
@@ -30,12 +28,6 @@ type JoinRoundRequest struct {
 	// ForfeitRequests specifies the VTXOs the client wants to forfeit.
 	ForfeitRequests []*ForfeitRequest
 
-	// RefreshRequests contains VTXOs being refreshed in this round. Each
-	// refresh request specifies an old VTXO to forfeit and details for the
-	// new VTXO to receive. The server includes these in the connector tree
-	// and expects forfeit signatures before broadcasting.
-	RefreshRequests []*RefreshRequest
-
 	// LeaveRequests contains VTXOs being exited to on-chain outputs. Each
 	// leave request specifies only the on-chain destination output. The
 	// server includes these in the batch transaction; any forfeited VTXOs
@@ -45,21 +37,6 @@ type JoinRoundRequest struct {
 	// RoundID is optional; when empty it instructs the server to assign
 	// a new round. When non-empty, the request is for the specified round.
 	RoundID string
-}
-
-// RefreshRequest describes a VTXO being refreshed (forfeited to receive a new
-// VTXO in the current round). The old VTXO will be spent via a forfeit tx that
-// atomically links to the new commitment transaction's connector tree.
-type RefreshRequest struct {
-	// VTXOOutpoint identifies the old VTXO to forfeit.
-	VTXOOutpoint wire.OutPoint
-
-	// Amount is the value of the VTXO in satoshis.
-	Amount btcutil.Amount
-
-	// NewVTXOKey is the client's public key for the new VTXO. This may be
-	// the same as the old VTXO's key or a fresh key for improved privacy.
-	NewVTXOKey *btcec.PublicKey
 }
 
 // ForfeitRequest describes a VTXO that will be forfeited in the round.

--- a/round/outbox_messages.go
+++ b/round/outbox_messages.go
@@ -27,6 +27,9 @@ type JoinRoundRequest struct {
 	// VTXORequests specifies the VTXOs the client wants to receive.
 	VTXORequests []types.VTXORequest
 
+	// ForfeitRequests specifies the VTXOs the client wants to forfeit.
+	ForfeitRequests []*ForfeitRequest
+
 	// RefreshRequests contains VTXOs being refreshed in this round. Each
 	// refresh request specifies an old VTXO to forfeit and details for the
 	// new VTXO to receive. The server includes these in the connector tree
@@ -34,9 +37,9 @@ type JoinRoundRequest struct {
 	RefreshRequests []*RefreshRequest
 
 	// LeaveRequests contains VTXOs being exited to on-chain outputs. Each
-	// leave request specifies a VTXO to forfeit and the on-chain
-	// destination output. The server includes these in the connector tree
-	// (for forfeit) and adds the leave outputs to the batch transaction.
+	// leave request specifies only the on-chain destination output. The
+	// server includes these in the batch transaction; any forfeited VTXOs
+	// are listed separately in ForfeitRequests.
 	LeaveRequests []*LeaveRequest
 
 	// RoundID is optional; when empty it instructs the server to assign
@@ -59,13 +62,16 @@ type RefreshRequest struct {
 	NewVTXOKey *btcec.PublicKey
 }
 
+// ForfeitRequest describes a VTXO that will be forfeited in the round.
+type ForfeitRequest struct {
+	// VTXOOutpoint identifies the VTXO to forfeit.
+	VTXOOutpoint wire.OutPoint
+}
+
 // LeaveRequest describes a leave output to be included in the batch
 // transaction. This represents a client exiting the Ark by forfeiting an
 // existing VTXO and receiving an on-chain output instead of a new VTXO.
 type LeaveRequest struct {
-	// VTXOOutpoint identifies the VTXO being forfeited to fund this leave.
-	VTXOOutpoint wire.OutPoint
-
 	// Output is the on-chain destination output. Contains the value and
 	// pkScript for the leave output that will be included in the batch tx.
 	Output *wire.TxOut

--- a/round/states.go
+++ b/round/states.go
@@ -48,8 +48,9 @@ func (s *Idle) clientStateSealed() {}
 // all intents reach the required confirmations, the FSM transitions to round
 // registration.
 //
-// This state also tracks VTXOs pending refresh. When VTXOs are approaching
-// expiry, they send RefreshVTXORequest to be included in the next round.
+// This state also tracks VTXOs pending refresh or leave. When VTXOs are
+// approaching expiry, they send RefreshVTXORequest to be included in the next
+// round. When a user wants to exit the Ark, they send LeaveVTXORequest.
 type PendingRoundAssembly struct {
 	// Boarding contains the collected boarding intents to include in the
 	// next round.
@@ -63,6 +64,11 @@ type PendingRoundAssembly struct {
 	// Keyed by VTXO outpoint. These are accumulated alongside boarding
 	// intents and included in the same round registration.
 	RefreshingVTXOs map[wire.OutPoint]*RefreshVTXORequest
+
+	// LeavingVTXOs tracks VTXOs waiting to exit to on-chain outputs. Keyed
+	// by VTXO outpoint. These are accumulated alongside boarding intents
+	// and refresh requests, and included in the same round registration.
+	LeavingVTXOs map[wire.OutPoint]*LeaveVTXORequest
 }
 
 func (s *PendingRoundAssembly) String() string {

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -1017,6 +1017,57 @@ func (s *CommitmentTxValidatedState) ProcessEvent(
 			slog.Int("boarding_intent_count", len(s.Intents.Boarding)),
 			slog.Int("vtxo_intent_count", len(s.Intents.VTXOs)))
 
+		// For leave-only rounds (no new VTXOs), skip nonce generation
+		// and go directly to forfeit collection. The server doesn't
+		// need nonces when there are no VTXOs to sign. We check
+		// Intents.Leaves explicitly rather than ForfeitMappings,
+		// since a batch tx could have boarding inputs and leave
+		// outputs without any refresh forfeits.
+		if len(s.Intents.VTXOs) == 0 && len(s.Intents.Leaves) > 0 {
+			env.Log.InfoS(ctx, "Leave-only round, skipping "+
+				"to forfeit collection",
+				slog.String("round_id", s.RoundID.String()),
+				slog.Int("leave_count", len(s.Intents.Leaves)))
+
+			// Build forfeit request messages for each VTXO being
+			// forfeited.
+			var outbox []ClientOutMsg
+			for vtxoOutpoint, info := range s.ForfeitMappings {
+				msg := &ForfeitRequestToVTXO{
+					VTXOOutpoint:      vtxoOutpoint,
+					RoundID:           s.RoundID.String(),
+					ConnectorOutpoint: info.ConnectorOutpoint,
+					ConnectorPkScript: info.ConnectorPkScript,
+					ConnectorAmount:   info.ConnectorAmount,
+					ServerForfeitPkScript: env.OperatorTerms.
+						ForfeitScript,
+				}
+				outbox = append(outbox, msg)
+			}
+
+			// Transition directly to forfeit collection.
+			collectedForfeits := make(
+				map[wire.OutPoint]*ForfeitSignatureResponse,
+			)
+
+			return &ClientStateTransition{
+				NextState: &ForfeitSignaturesCollectingState{
+					RoundID:           s.RoundID,
+					CommitmentTx:      s.CommitmentTx,
+					VTXOTreePaths:     s.VTXOTreePaths,
+					Intents:           s.Intents.Clone(),
+					ClientTrees:       s.ClientTrees,
+					ExpectedForfeits:  s.ForfeitMappings,
+					CollectedForfeits: collectedForfeits,
+					BoardingInputIndices: s.
+						BoardingInputIndices,
+				},
+				NewEvents: fn.Some(ClientEmittedEvent{
+					Outbox: outbox,
+				}),
+			}, nil
+		}
+
 		// At this point, all the basic validation checks have passed.
 		// So now we'll generate a musig2 session to create nonces to
 		// sign the VTXO tree. Each VTXO that we created will

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -300,9 +300,9 @@ func (s *Idle) ProcessEvent(ctx context.Context, event ClientEvent,
 
 	case *LeaveVTXORequest:
 		// A VTXO actor (or wallet) requested to exit the Ark. Start
-		// assembling a round with this leave request. Similar to refresh
-		// requests, we track leaving VTXOs in the PendingRoundAssembly
-		// state.
+		// assembling a round with this leave request. Similar to
+		// refresh requests, we track leaving VTXOs in the
+		// PendingRoundAssembly state.
 		leaveMap := make(map[wire.OutPoint]*LeaveVTXORequest)
 		leaveMap[evt.VTXOOutpoint] = evt
 
@@ -461,8 +461,8 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 		}, nil
 
 	case *LeaveVTXORequest:
-		// A VTXO actor (or wallet) requested to exit the Ark. Add to our
-		// leaving map. We stay in this state and accumulate leave
+		// A VTXO actor (or wallet) requested to exit the Ark. Add to
+		// our leaving map. We stay in this state and accumulate leave
 		// requests alongside boarding intents and refresh requests.
 		updatedLeaving := maps.Clone(s.LeavingVTXOs)
 		if updatedLeaving == nil {
@@ -586,6 +586,17 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 			})
 		}
 
+		// Build forfeit requests for VTXOs being exited to on-chain
+		// outputs. Each leave forfeits a VTXO and creates an on-chain
+		// output in the batch transaction.
+		numForfeit := len(s.LeavingVTXOs)
+		forfeitReqs := make([]*ForfeitRequest, 0, numForfeit)
+		for _, req := range s.LeavingVTXOs {
+			forfeitReqs = append(forfeitReqs, &ForfeitRequest{
+				VTXOOutpoint: req.VTXOOutpoint,
+			})
+		}
+
 		// Build leave requests for VTXOs being exited to on-chain
 		// outputs. Each leave forfeits a VTXO and creates an on-chain
 		// output in the batch transaction.
@@ -593,14 +604,14 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 		leaveReqs := make([]*LeaveRequest, 0, numLeave)
 		for _, req := range s.LeavingVTXOs {
 			leaveReqs = append(leaveReqs, &LeaveRequest{
-				VTXOOutpoint: req.VTXOOutpoint,
-				Output:       req.Output,
+				Output: req.Output,
 			})
 		}
 
 		env.Log.InfoS(ctx, "Sending JoinRoundRequest to server",
 			slog.Int("boarding_requests", len(boardingReqs)),
 			slog.Int("vtxo_requests", len(vtxoReqs)),
+			slog.Int("forfeit_requests", len(forfeitReqs)),
 			slog.Int("refresh_requests", len(refreshReqs)),
 			slog.Int("leave_requests", len(leaveReqs)))
 
@@ -624,6 +635,7 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 					&JoinRoundRequest{
 						BoardingRequests: boardingReqs,
 						VTXORequests:     vtxoReqs,
+						ForfeitRequests:  forfeitReqs,
 						RefreshRequests:  refreshReqs,
 						LeaveRequests:    leaveReqs,
 					},
@@ -1033,14 +1045,19 @@ func (s *CommitmentTxValidatedState) ProcessEvent(
 			// forfeited.
 			var outbox []ClientOutMsg
 			for vtxoOutpoint, info := range s.ForfeitMappings {
+				connOut := info.ConnectorOutpoint
+				connScript := info.ConnectorPkScript
+				connAmt := info.ConnectorAmount
+				forfeitScript := env.OperatorTerms.ForfeitScript
+				roundIDStr := s.RoundID.String()
+
 				msg := &ForfeitRequestToVTXO{
-					VTXOOutpoint:      vtxoOutpoint,
-					RoundID:           s.RoundID.String(),
-					ConnectorOutpoint: info.ConnectorOutpoint,
-					ConnectorPkScript: info.ConnectorPkScript,
-					ConnectorAmount:   info.ConnectorAmount,
-					ServerForfeitPkScript: env.OperatorTerms.
-						ForfeitScript,
+					VTXOOutpoint:          vtxoOutpoint,
+					RoundID:               roundIDStr,
+					ConnectorOutpoint:     connOut,
+					ConnectorPkScript:     connScript,
+					ConnectorAmount:       connAmt,
+					ServerForfeitPkScript: forfeitScript,
 				}
 				outbox = append(outbox, msg)
 			}

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -298,6 +298,22 @@ func (s *Idle) ProcessEvent(ctx context.Context, event ClientEvent,
 			},
 		}, nil
 
+	case *LeaveVTXORequest:
+		// A VTXO actor (or wallet) requested to exit the Ark. Start
+		// assembling a round with this leave request. Similar to refresh
+		// requests, we track leaving VTXOs in the PendingRoundAssembly
+		// state.
+		leaveMap := make(map[wire.OutPoint]*LeaveVTXORequest)
+		leaveMap[evt.VTXOOutpoint] = evt
+
+		return &ClientStateTransition{
+			NextState: &PendingRoundAssembly{
+				Boarding:     nil,
+				VTXOs:        nil,
+				LeavingVTXOs: leaveMap,
+			},
+		}, nil
+
 	default:
 		// Self-loop on unknown events - do not halt the FSM.
 		return selfLoop(s), nil
@@ -440,6 +456,28 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 				Boarding:        slices.Clone(s.Boarding),
 				VTXOs:           updatedVTXOs,
 				RefreshingVTXOs: updatedRefreshing,
+				LeavingVTXOs:    maps.Clone(s.LeavingVTXOs),
+			},
+		}, nil
+
+	case *LeaveVTXORequest:
+		// A VTXO actor (or wallet) requested to exit the Ark. Add to our
+		// leaving map. We stay in this state and accumulate leave
+		// requests alongside boarding intents and refresh requests.
+		updatedLeaving := maps.Clone(s.LeavingVTXOs)
+		if updatedLeaving == nil {
+			updatedLeaving = make(
+				map[wire.OutPoint]*LeaveVTXORequest,
+			)
+		}
+		updatedLeaving[evt.VTXOOutpoint] = evt
+
+		return &ClientStateTransition{
+			NextState: &PendingRoundAssembly{
+				Boarding:        slices.Clone(s.Boarding),
+				VTXOs:           slices.Clone(s.VTXOs),
+				RefreshingVTXOs: maps.Clone(s.RefreshingVTXOs),
+				LeavingVTXOs:    updatedLeaving,
 			},
 		}, nil
 
@@ -468,6 +506,24 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 		// VTXOReqs and LeaveReqs (not assumed 1:1 with refresh).
 		for _, req := range s.RefreshingVTXOs {
 			totalInput += btcutil.Amount(req.Amount)
+		}
+
+		// Include leave amounts in both inputs and outputs. The
+		// forfeited VTXO value contributes to totalInput, and the
+		// on-chain leave output contributes to totalOutput.
+		for _, req := range s.LeavingVTXOs {
+			if req.Output == nil {
+				return failWithNotification(
+					"leave request has nil output",
+					fmt.Errorf("leave request for %v "+
+						"has nil output",
+						req.VTXOOutpoint),
+					true, fn.None[RoundID](),
+				), nil
+			}
+
+			totalInput += btcutil.Amount(req.Amount)
+			totalOutput += btcutil.Amount(req.Output.Value)
 		}
 
 		// Validate that we have outputs to create.
@@ -530,17 +586,31 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 			})
 		}
 
+		// Build leave requests for VTXOs being exited to on-chain
+		// outputs. Each leave forfeits a VTXO and creates an on-chain
+		// output in the batch transaction.
+		numLeave := len(s.LeavingVTXOs)
+		leaveReqs := make([]*LeaveRequest, 0, numLeave)
+		for _, req := range s.LeavingVTXOs {
+			leaveReqs = append(leaveReqs, &LeaveRequest{
+				VTXOOutpoint: req.VTXOOutpoint,
+				Output:       req.Output,
+			})
+		}
+
 		env.Log.InfoS(ctx, "Sending JoinRoundRequest to server",
 			slog.Int("boarding_requests", len(boardingReqs)),
 			slog.Int("vtxo_requests", len(vtxoReqs)),
-			slog.Int("refresh_requests", len(refreshReqs)))
+			slog.Int("refresh_requests", len(refreshReqs)),
+			slog.Int("leave_requests", len(leaveReqs)))
 
-		// Build Intents with all VTXOs and refreshes for downstream
-		// validation.
+		// Build Intents with all VTXOs, refreshes, and leaves for
+		// downstream validation.
 		intent := Intents{
 			Boarding:  slices.Clone(s.Boarding),
 			VTXOs:     vtxoReqs,
 			Refreshes: refreshReqs,
+			Leaves:    leaveReqs,
 		}
 
 		// With all this extracted, we'll now send the JoinRoundRequest
@@ -555,6 +625,7 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 						BoardingRequests: boardingReqs,
 						VTXORequests:     vtxoReqs,
 						RefreshRequests:  refreshReqs,
+						LeaveRequests:    leaveReqs,
 					},
 				},
 			}),
@@ -683,6 +754,62 @@ func validateBoardingInputs(commitmentTx *wire.MsgTx,
 	return outpointToIdx, nil
 }
 
+// validateLeaveOutputs verifies that all leave outputs are present in the
+// commitment transaction with matching values and scripts. This ensures the
+// server has properly included the requested on-chain exit outputs.
+func validateLeaveOutputs(
+	commitmentTx *wire.MsgTx, leaves []*LeaveRequest,
+) error {
+
+	if commitmentTx == nil {
+		return fmt.Errorf("commitment tx is nil")
+	}
+
+	// If there are no leave requests, nothing to validate.
+	if len(leaves) == 0 {
+		return nil
+	}
+
+	// Build a set of expected leave outputs for matching. We use string for
+	// pkScript since slices cannot be map keys.
+	type leaveOutput struct {
+		value    int64
+		pkScript string
+	}
+	expectedOutputs := make(map[leaveOutput]int)
+	for _, leave := range leaves {
+		key := leaveOutput{
+			value:    leave.Output.Value,
+			pkScript: string(leave.Output.PkScript),
+		}
+		expectedOutputs[key]++
+	}
+
+	// Search through commitment tx outputs for matching leave outputs.
+	for _, txOut := range commitmentTx.TxOut {
+		key := leaveOutput{
+			value:    txOut.Value,
+			pkScript: string(txOut.PkScript),
+		}
+		if count, found := expectedOutputs[key]; found && count > 0 {
+			expectedOutputs[key]--
+		}
+	}
+
+	// Check if all expected outputs were found.
+	for key, count := range expectedOutputs {
+		if count > 0 {
+			return fmt.Errorf(
+				"leave output not found in commitment tx: "+
+					"value=%d, remaining=%d",
+				key.value, count,
+			)
+		}
+	}
+
+	return nil
+}
+
 // ProcessEvent for CommitmentTxReceivedState.
 //
 //nolint:ll
@@ -695,7 +822,8 @@ func (s *CommitmentTxReceivedState) ProcessEvent(
 		env.Log.InfoS(ctx, "Validating commitment transaction",
 			slog.String("round_id", s.RoundID.String()),
 			slog.Int("boarding_intent_count", len(s.Intents.Boarding)),
-			slog.Int("vtxo_intent_count", len(s.Intents.VTXOs)))
+			slog.Int("vtxo_intent_count", len(s.Intents.VTXOs)),
+			slog.Int("leave_intent_count", len(s.Intents.Leaves)))
 
 		// Validate boarding inputs if we have any boarding intents.
 		// Refresh-only rounds have no boarding inputs to validate.
@@ -724,6 +852,35 @@ func (s *CommitmentTxReceivedState) ProcessEvent(
 
 		env.Log.DebugS(ctx, "Validated boarding inputs in commitment tx",
 			slog.Int("boarding_input_count", len(boardingInputIndices)))
+
+		// Validate leave outputs if we have any leave requests. Each
+		// leave output must be present in the commitment tx with the
+		// correct value and script.
+		if len(s.Intents.Leaves) > 0 {
+			if err := validateLeaveOutputs(
+				s.CommitmentTx.UnsignedTx, s.Intents.Leaves,
+			); err != nil {
+				env.Log.WarnS(
+					ctx, "Leave output validation failed",
+					err,
+					slog.String("round_id", s.RoundID.String()),
+				)
+
+				return &ClientStateTransition{
+					NextState: &ClientFailedState{
+						Reason: "leave output " +
+							"validation failed",
+						Error:       err,
+						Recoverable: true,
+					},
+				}, nil
+			}
+
+			env.Log.DebugS(
+				ctx, "Validated leave outputs in commitment tx",
+				slog.Int("leave_output_count", len(s.Intents.Leaves)),
+			)
+		}
 
 		clientTrees := make(map[SignerKey]*tree.Tree)
 

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -574,23 +574,15 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 		boardingReqs := fn.Map(s.Boarding, buildBoardingRequest)
 		vtxoReqs := slices.Clone(s.VTXOs)
 
-		// Build refresh requests for VTXOs being refreshed. The actual
-		// VTXO outputs are specified via VTXOReqs (not assumed 1:1).
-		numRefresh := len(s.RefreshingVTXOs)
-		refreshReqs := make([]*RefreshRequest, 0, numRefresh)
+		// Build forfeit requests for VTXOs being refreshed or exited
+		// on-chain. Forfeits are listed separately from outputs.
+		numForfeit := len(s.RefreshingVTXOs) + len(s.LeavingVTXOs)
+		forfeitReqs := make([]*ForfeitRequest, 0, numForfeit)
 		for _, req := range s.RefreshingVTXOs {
-			refreshReqs = append(refreshReqs, &RefreshRequest{
+			forfeitReqs = append(forfeitReqs, &ForfeitRequest{
 				VTXOOutpoint: req.VTXOOutpoint,
-				Amount:       btcutil.Amount(req.Amount),
-				NewVTXOKey:   req.NewVTXOKey,
 			})
 		}
-
-		// Build forfeit requests for VTXOs being exited to on-chain
-		// outputs. Each leave forfeits a VTXO and creates an on-chain
-		// output in the batch transaction.
-		numForfeit := len(s.LeavingVTXOs)
-		forfeitReqs := make([]*ForfeitRequest, 0, numForfeit)
 		for _, req := range s.LeavingVTXOs {
 			forfeitReqs = append(forfeitReqs, &ForfeitRequest{
 				VTXOOutpoint: req.VTXOOutpoint,
@@ -612,16 +604,14 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 			slog.Int("boarding_requests", len(boardingReqs)),
 			slog.Int("vtxo_requests", len(vtxoReqs)),
 			slog.Int("forfeit_requests", len(forfeitReqs)),
-			slog.Int("refresh_requests", len(refreshReqs)),
 			slog.Int("leave_requests", len(leaveReqs)))
 
-		// Build Intents with all VTXOs, refreshes, and leaves for
-		// downstream validation.
+		// Build Intents with all VTXOs and leaves for downstream
+		// validation.
 		intent := Intents{
-			Boarding:  slices.Clone(s.Boarding),
-			VTXOs:     vtxoReqs,
-			Refreshes: refreshReqs,
-			Leaves:    leaveReqs,
+			Boarding: slices.Clone(s.Boarding),
+			VTXOs:    vtxoReqs,
+			Leaves:   leaveReqs,
 		}
 
 		// With all this extracted, we'll now send the JoinRoundRequest
@@ -636,7 +626,6 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 						BoardingRequests: boardingReqs,
 						VTXORequests:     vtxoReqs,
 						ForfeitRequests:  forfeitReqs,
-						RefreshRequests:  refreshReqs,
 						LeaveRequests:    leaveReqs,
 					},
 				},

--- a/round/vtxo_messages.go
+++ b/round/vtxo_messages.go
@@ -201,6 +201,24 @@ func (e *TriggerRefreshEvent) MessageType() string {
 	return "TriggerRefreshEvent"
 }
 
+// TriggerLeaveEvent is sent to a VTXO actor to manually trigger a leave
+// (offboard) request. This transitions the VTXO to a state where it will be
+// forfeited and the value sent to the specified destination output. Used by
+// the wallet actor when the user explicitly requests to leave the Ark.
+type TriggerLeaveEvent struct {
+	actor.BaseMessage
+
+	// DestOutput is the on-chain destination output where the funds will
+	// be sent. This output will be included in the batch transaction.
+	DestOutput *wire.TxOut
+}
+
+// VTXOActorMsg implements actormsg.VTXOActorMsg marker interface.
+func (e *TriggerLeaveEvent) VTXOActorMsg() {}
+
+// MessageType returns the message type for logging.
+func (e *TriggerLeaveEvent) MessageType() string { return "TriggerLeaveEvent" }
+
 // =============================================================================
 // Messages TO VTXO Manager
 // =============================================================================

--- a/vtxo/actor.go
+++ b/vtxo/actor.go
@@ -260,6 +260,28 @@ func (a *VTXOActor) processOutbox(ctx context.Context, outbox []VTXOOutMsg) {
 				)
 			}
 
+		case *LeaveRequest:
+			// Route leave request to round actor. This tells the
+			// round to forfeit this VTXO and include a leave output
+			// in the batch transaction (no new VTXO is created).
+			if a.cfg.RoundActor != nil {
+				leaveReq := &round.LeaveVTXORequest{
+					VTXOOutpoint: m.VTXOOutpoint,
+					Amount:       m.Amount,
+					Output:       m.DestOutput,
+				}
+				a.cfg.RoundActor.Tell(ctx, leaveReq)
+
+				a.cfg.Logger.InfoS(
+					ctx, "Sent leave request to round",
+					slog.String(
+						"outpoint",
+						m.VTXOOutpoint.String(),
+					),
+					slog.Int64("amount", m.Amount),
+				)
+			}
+
 		case *ForfeitSignatureSubmission:
 			// Route forfeit signature to round actor.
 			if a.cfg.RoundActor != nil {

--- a/vtxo/actor.go
+++ b/vtxo/actor.go
@@ -265,9 +265,10 @@ func (a *VTXOActor) processOutbox(ctx context.Context, outbox []VTXOOutMsg) {
 			// round to forfeit this VTXO and include a leave output
 			// in the batch transaction (no new VTXO is created).
 			if a.cfg.RoundActor != nil {
+				vtxo := a.cfg.VTXO
 				leaveReq := &round.LeaveVTXORequest{
-					VTXOOutpoint: m.VTXOOutpoint,
-					Amount:       m.Amount,
+					VTXOOutpoint: vtxo.Outpoint,
+					Amount:       int64(vtxo.Amount),
 					Output:       m.DestOutput,
 				}
 				a.cfg.RoundActor.Tell(ctx, leaveReq)
@@ -275,10 +276,9 @@ func (a *VTXOActor) processOutbox(ctx context.Context, outbox []VTXOOutMsg) {
 				a.cfg.Logger.InfoS(
 					ctx, "Sent leave request to round",
 					slog.String(
-						"outpoint",
-						m.VTXOOutpoint.String(),
+						"outpoint", vtxo.Outpoint.String(),
 					),
-					slog.Int64("amount", m.Amount),
+					slog.Int64("amount", int64(vtxo.Amount)),
 				)
 			}
 

--- a/vtxo/actor.go
+++ b/vtxo/actor.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btclog/v2"
@@ -211,8 +210,8 @@ func (a *VTXOActor) processOutbox(ctx context.Context, outbox []VTXOOutMsg) {
 				)
 			}
 
-		case *RefreshRequest:
-			// Route refresh request to round actor. This tells
+		case *ForfeitRequest:
+			// Route forfeit request to round actor. This tells
 			// the round to include this VTXO in the forfeit flow.
 			// We also send a separate VTXORequest to explicitly
 			// request a new VTXO for the refreshed value (refresh
@@ -223,7 +222,7 @@ func (a *VTXOActor) processOutbox(ctx context.Context, outbox []VTXOOutMsg) {
 				// Send the refresh request for forfeit flow.
 				refreshReq := &round.RefreshVTXORequest{
 					VTXOOutpoint: m.VTXOOutpoint,
-					Amount:       m.Amount,
+					Amount:       int64(vtxo.Amount),
 					NewVTXOKey:   vtxo.ClientKey.PubKey,
 					PkScript:     vtxo.PkScript,
 					OperatorKey:  vtxo.OperatorKey,
@@ -234,10 +233,9 @@ func (a *VTXOActor) processOutbox(ctx context.Context, outbox []VTXOOutMsg) {
 
 				// Also send a VTXORequest to request the new
 				// VTXO output for this refresh.
-				amt := btcutil.Amount(m.Amount)
 				vtxoReq := &round.VTXORequestsReceived{
 					Requests: []types.VTXORequest{{
-						Amount:   amt,
+						Amount:   vtxo.Amount,
 						PkScript: vtxo.PkScript,
 						Expiry:   vtxo.RelativeExpiry,
 						ClientKey: vtxo.ClientKey.
@@ -249,14 +247,8 @@ func (a *VTXOActor) processOutbox(ctx context.Context, outbox []VTXOOutMsg) {
 				a.cfg.RoundActor.Tell(ctx, vtxoReq)
 
 				a.cfg.Logger.InfoS(
-					ctx, "Sent refresh and VTXO request",
-					slog.String(
-						"outpoint",
-						m.VTXOOutpoint.String(),
-					),
-					slog.String(
-						"urgency", m.Urgency.String(),
-					),
+					ctx, "Sent refresh forfeit and request",
+					slog.String("outpoint", m.VTXOOutpoint.String()),
 				)
 			}
 

--- a/vtxo/actor_test.go
+++ b/vtxo/actor_test.go
@@ -151,11 +151,11 @@ func TestProcessOutboxStatusUpdate(t *testing.T) {
 	)
 }
 
-// TestProcessOutboxRefreshRequest verifies that RefreshRequest messages in the
+// TestProcessOutboxForfeitRequest verifies that ForfeitRequest messages in the
 // outbox are routed to the round actor with the correct fields populated. Since
 // refresh is decoupled from VTXO creation, both a RefreshVTXORequest and a
 // VTXORequestsReceived message should be sent.
-func TestProcessOutboxRefreshRequest(t *testing.T) {
+func TestProcessOutboxForfeitRequest(t *testing.T) {
 	t.Parallel()
 
 	h := newVTXOTestHarness(t)
@@ -176,10 +176,8 @@ func TestProcessOutboxRefreshRequest(t *testing.T) {
 	}
 
 	outbox := []VTXOOutMsg{
-		&RefreshRequest{
+		&ForfeitRequest{
 			VTXOOutpoint: vtxo.Outpoint,
-			Amount:       int64(vtxo.Amount),
-			Urgency:      RefreshUrgencyNormal,
 		},
 	}
 

--- a/vtxo/events.go
+++ b/vtxo/events.go
@@ -43,4 +43,9 @@ type (
 
 	// TriggerRefreshEvent is sent to manually trigger a refresh request.
 	TriggerRefreshEvent = round.TriggerRefreshEvent
+
+	// TriggerLeaveEvent is sent to manually trigger a leave (offboard)
+	// request. The VTXO will be forfeited and the value sent to the
+	// specified destination output.
+	TriggerLeaveEvent = round.TriggerLeaveEvent
 )

--- a/vtxo/interfaces.go
+++ b/vtxo/interfaces.go
@@ -26,7 +26,7 @@ import (
 // Message flow:
 //
 //	                 ┌──────────┐
-//	 BlockEpochEvent─│          │─RefreshRequest ──▶ Round
+//	 BlockEpochEvent─│          │─ForfeitRequest ──▶ Round
 //	                 │          │
 //	 ForfeitRequest ─│ VTXO FSM │─ForfeitSigSubmit ─▶ Round
 //	    (from Round) │          │
@@ -71,7 +71,7 @@ type InternalEvent[E VTXOEvent] struct{}
 //
 // Messages are emitted via the FSM outbox and routed to target actors:
 //
-//   - RefreshRequest: To round actor, requests VTXO inclusion in next batch.
+//   - ForfeitRequest: To round actor, requests VTXO forfeit in next batch.
 //   - ForfeitSignatureSubmission: To round actor, submits signed forfeit tx.
 //   - ExpiringNotification: To chain resolver, escalates critical expiry.
 //   - VTXOStatusUpdate: To persistence layer, updates database state.
@@ -129,13 +129,13 @@ var MessageSpec = struct {
 	// OUTBOUND MESSAGES (FSM → external actors)
 	// -----------------------------------------------------------------
 
-	// RefreshRequest is sent to the round actor when the VTXO's expiry
+	// ForfeitRequest is sent to the round actor when the VTXO's expiry
 	// status crosses the refresh threshold. Requests inclusion in the next
 	// batch swap to extend the VTXO's lifetime.
 	//
 	// Destination: VTXO Actor → Round Actor
 	// Emitted from: LiveState (on ExpiryStatusNeedsRefresh)
-	RefreshRequest OutboundMsg[*RefreshRequest]
+	ForfeitRequest OutboundMsg[*ForfeitRequest]
 
 	// ForfeitSignatureSubmission is sent to the round actor with the
 	// client's signature on the forfeit transaction. The round actor

--- a/vtxo/outbox_messages.go
+++ b/vtxo/outbox_messages.go
@@ -142,3 +142,21 @@ type VTXOTerminatedNotification struct {
 }
 
 func (m *VTXOTerminatedNotification) vtxoOutMsgSealed() {}
+
+// LeaveRequest is sent to the round actor when a VTXO is being offboarded. The
+// round actor should queue this VTXO for forfeiture and include the destination
+// output in the batch transaction.
+type LeaveRequest struct {
+	actor.BaseMessage
+
+	// VTXOOutpoint identifies the VTXO to forfeit.
+	VTXOOutpoint wire.OutPoint
+
+	// Amount is the VTXO value in satoshis.
+	Amount int64
+
+	// DestOutput is the on-chain output where the funds will be sent.
+	DestOutput *wire.TxOut
+}
+
+func (m *LeaveRequest) vtxoOutMsgSealed() {}

--- a/vtxo/outbox_messages.go
+++ b/vtxo/outbox_messages.go
@@ -42,23 +42,16 @@ func (u RefreshUrgency) String() string {
 	}
 }
 
-// RefreshRequest is sent to the round actor when a VTXO needs to be refreshed.
-// The round actor should queue this VTXO for inclusion in the next batch swap.
-type RefreshRequest struct {
+// ForfeitRequest is sent to the round actor when a VTXO needs to be forfeited
+// as part of a refresh or leave operation.
+type ForfeitRequest struct {
 	actor.BaseMessage
 
-	// VTXOOutpoint identifies the VTXO to refresh.
+	// VTXOOutpoint identifies the VTXO to forfeit.
 	VTXOOutpoint wire.OutPoint
-
-	// Amount is the VTXO value in satoshis.
-	Amount int64
-
-	// Urgency indicates how urgent the refresh is (based on blocks
-	// remaining until expiry).
-	Urgency RefreshUrgency
 }
 
-func (m *RefreshRequest) vtxoOutMsgSealed() {}
+func (m *ForfeitRequest) vtxoOutMsgSealed() {}
 
 // ExpiringNotification is sent to the chain resolver when a VTXO is critically
 // close to expiry and needs unilateral exit handling. The chain resolver

--- a/vtxo/outbox_messages.go
+++ b/vtxo/outbox_messages.go
@@ -149,12 +149,6 @@ func (m *VTXOTerminatedNotification) vtxoOutMsgSealed() {}
 type LeaveRequest struct {
 	actor.BaseMessage
 
-	// VTXOOutpoint identifies the VTXO to forfeit.
-	VTXOOutpoint wire.OutPoint
-
-	// Amount is the VTXO value in satoshis.
-	Amount int64
-
 	// DestOutput is the on-chain output where the funds will be sent.
 	DestOutput *wire.TxOut
 }

--- a/vtxo/states.go
+++ b/vtxo/states.go
@@ -43,9 +43,9 @@ func (s *LiveState) IsTerminal() bool {
 
 func (s *LiveState) vtxoStateSealed() {}
 
-// RefreshRequestedState indicates a refresh request has been sent to the round
-// actor. The VTXO is waiting for acknowledgment or a forfeit request to begin
-// the batch swap process.
+// RefreshRequestedState indicates a forfeit request has been sent to the round
+// actor to refresh this VTXO. The VTXO is waiting for acknowledgment or a
+// forfeit request to begin the batch swap process.
 type RefreshRequestedState struct {
 	// VTXO is the descriptor for this VTXO.
 	VTXO *Descriptor

--- a/vtxo/transitions.go
+++ b/vtxo/transitions.go
@@ -71,16 +71,9 @@ func (s *LiveState) handleBlockEpoch(
 
 	case ExpiryStatusNeedsRefresh:
 		// Request refresh before expiry becomes critical.
-		blocksRemaining := BlocksUntilExpiry(s.VTXO, evt.Height)
-		urgency := env.ExpiryConfig.DetermineRefreshUrgency(
-			s.VTXO, blocksRemaining,
-		)
-
 		outbox := []VTXOOutMsg{
-			&RefreshRequest{
+			&ForfeitRequest{
 				VTXOOutpoint: s.VTXO.Outpoint,
-				Amount:       int64(s.VTXO.Amount),
-				Urgency:      urgency,
 			},
 			&VTXOStatusUpdate{
 				Outpoint:  s.VTXO.Outpoint,
@@ -197,16 +190,14 @@ func (s *LiveState) handleForfeitRequest(
 
 // handleTriggerRefresh handles a manual refresh request from the wallet. This
 // bypasses the automatic expiry-based refresh and immediately transitions the
-// VTXO to RefreshRequested state, emitting a RefreshRequest to the round actor.
+// VTXO to RefreshRequested state, emitting a ForfeitRequest to the round actor.
 func (s *LiveState) handleTriggerRefresh(
 	_ context.Context, _ *TriggerRefreshEvent, _ *VTXOEnvironment,
 ) (*VTXOStateTransition, error) {
 
 	outbox := []VTXOOutMsg{
-		&RefreshRequest{
+		&ForfeitRequest{
 			VTXOOutpoint: s.VTXO.Outpoint,
-			Amount:       int64(s.VTXO.Amount),
-			Urgency:      RefreshUrgencyNormal,
 		},
 		&VTXOStatusUpdate{
 			Outpoint:  s.VTXO.Outpoint,

--- a/vtxo/transitions.go
+++ b/vtxo/transitions.go
@@ -217,7 +217,7 @@ func (s *LiveState) handleTriggerRefresh(
 	return &VTXOStateTransition{
 		NextState: &RefreshRequestedState{
 			VTXO: s.VTXO,
-			// Manual trigger has no height context.
+			// Manual trigger, no height context.
 			RequestedAtHeight: 0,
 		},
 		NewEvents: fn.Some(VTXOEmittedEvent{Outbox: outbox}),
@@ -234,9 +234,7 @@ func (s *LiveState) handleTriggerLeave(
 
 	outbox := []VTXOOutMsg{
 		&LeaveRequest{
-			VTXOOutpoint: s.VTXO.Outpoint,
-			Amount:       int64(s.VTXO.Amount),
-			DestOutput:   evt.DestOutput,
+			DestOutput: evt.DestOutput,
 		},
 		&VTXOStatusUpdate{
 			Outpoint:  s.VTXO.Outpoint,
@@ -248,8 +246,9 @@ func (s *LiveState) handleTriggerLeave(
 	// ForfeitRequestEvent from the round actor, then sign the forfeit tx.
 	return &VTXOStateTransition{
 		NextState: &RefreshRequestedState{
-			VTXO:              s.VTXO,
-			RequestedAtHeight: 0, // Manual trigger, no height context.
+			VTXO: s.VTXO,
+			// Manual trigger, no height context.
+			RequestedAtHeight: 0,
 		},
 		NewEvents: fn.Some(VTXOEmittedEvent{Outbox: outbox}),
 	}, nil

--- a/vtxo/transitions.go
+++ b/vtxo/transitions.go
@@ -27,6 +27,9 @@ func (s *LiveState) ProcessEvent(
 	case *TriggerRefreshEvent:
 		return s.handleTriggerRefresh(ctx, evt, env)
 
+	case *TriggerLeaveEvent:
+		return s.handleTriggerLeave(ctx, evt, env)
+
 	case *ResumeVTXOEvent:
 		// On resume, stay in LiveState and re-check expiry on next
 		// block.
@@ -216,6 +219,37 @@ func (s *LiveState) handleTriggerRefresh(
 			VTXO: s.VTXO,
 			// Manual trigger has no height context.
 			RequestedAtHeight: 0,
+		},
+		NewEvents: fn.Some(VTXOEmittedEvent{Outbox: outbox}),
+	}, nil
+}
+
+// handleTriggerLeave handles a leave (offboard) request from the wallet. This
+// transitions the VTXO to RefreshRequestedState and emits a LeaveRequest to
+// the round actor. The leave flow reuses the forfeit mechanism: the VTXO is
+// forfeited and the value goes to an on-chain output instead of a new VTXO.
+func (s *LiveState) handleTriggerLeave(
+	_ context.Context, evt *TriggerLeaveEvent, _ *VTXOEnvironment,
+) (*VTXOStateTransition, error) {
+
+	outbox := []VTXOOutMsg{
+		&LeaveRequest{
+			VTXOOutpoint: s.VTXO.Outpoint,
+			Amount:       int64(s.VTXO.Amount),
+			DestOutput:   evt.DestOutput,
+		},
+		&VTXOStatusUpdate{
+			Outpoint:  s.VTXO.Outpoint,
+			NewStatus: VTXOStatusRefreshRequested,
+		},
+	}
+
+	// Reuse RefreshRequestedState since the behavior is identical: wait for
+	// ForfeitRequestEvent from the round actor, then sign the forfeit tx.
+	return &VTXOStateTransition{
+		NextState: &RefreshRequestedState{
+			VTXO:              s.VTXO,
+			RequestedAtHeight: 0, // Manual trigger, no height context.
 		},
 		NewEvents: fn.Some(VTXOEmittedEvent{Outbox: outbox}),
 	}, nil

--- a/vtxo/transitions_test.go
+++ b/vtxo/transitions_test.go
@@ -126,8 +126,8 @@ func TestLiveStateBlockEpochNeedsRefresh(t *testing.T) {
 
 	assertState[*RefreshRequestedState](h)
 
-	// Should emit RefreshRequest.
-	assertOutboxContains[*RefreshRequest](h)
+	// Should emit ForfeitRequest.
+	assertOutboxContains[*ForfeitRequest](h)
 }
 
 // TestLiveStateBlockEpochCritical verifies that LiveState transitions to

--- a/wallet/messages.go
+++ b/wallet/messages.go
@@ -301,3 +301,43 @@ func (m *RefreshVTXOsResponse) MessageType() string {
 
 // walletRespSealed implements the sealed WalletResp interface.
 func (m *RefreshVTXOsResponse) walletRespSealed() {}
+
+// LeaveVTXOsRequest triggers leave (offboard) of specified VTXOs. The VTXOs
+// will be forfeited and their value sent to the specified destination output.
+type LeaveVTXOsRequest struct {
+	actor.BaseMessage
+
+	// TargetOutpoints specifies which VTXOs to leave (offboard).
+	TargetOutpoints []wire.OutPoint
+
+	// DestOutput is the on-chain destination output where the funds will
+	// be sent. This output will be included in the batch transaction.
+	DestOutput *wire.TxOut
+}
+
+// MessageType returns the message type identifier for logging and debugging.
+func (m *LeaveVTXOsRequest) MessageType() string {
+	return "LeaveVTXOsRequest"
+}
+
+// walletMsgSealed implements the sealed WalletMsg interface.
+func (m *LeaveVTXOsRequest) walletMsgSealed() {}
+
+// LeaveVTXOsResponse indicates the result of the leave request.
+type LeaveVTXOsResponse struct {
+	actor.BaseMessage
+
+	// LeavingCount is the number of VTXOs that were queued for leave.
+	LeavingCount int
+
+	// Errors contains any VTXOs that couldn't be left and why.
+	Errors map[wire.OutPoint]error
+}
+
+// MessageType returns the message type identifier for logging and debugging.
+func (m *LeaveVTXOsResponse) MessageType() string {
+	return "LeaveVTXOsResponse"
+}
+
+// walletRespSealed implements the sealed WalletResp interface.
+func (m *LeaveVTXOsResponse) walletRespSealed() {}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -222,6 +222,9 @@ func (a *Ark) Receive(ctx context.Context,
 	case *RefreshVTXOsRequest:
 		return a.handleRefreshVTXOs(ctx, m)
 
+	case *LeaveVTXOsRequest:
+		return a.handleLeaveVTXOs(ctx, m)
+
 	default:
 		return fn.Err[WalletResp](
 			fmt.Errorf("unknown message type: %T", msg))
@@ -560,6 +563,39 @@ func (a *Ark) handleRefreshVTXOs(ctx context.Context,
 	resp := &RefreshVTXOsResponse{
 		RefreshingCount: len(req.TargetOutpoints),
 		Errors:          make(map[wire.OutPoint]error),
+	}
+
+	return fn.Ok[WalletResp](resp)
+}
+
+// handleLeaveVTXOs processes a leave (offboard) request by forwarding it to the
+// round actor. The round actor coordinates with VTXO actors to initiate the
+// forfeit flow, resulting in an on-chain output in the batch transaction.
+func (a *Ark) handleLeaveVTXOs(ctx context.Context,
+	req *LeaveVTXOsRequest) fn.Result[WalletResp] {
+
+	a.log.InfoS(ctx, "Received VTXO leave request",
+		slog.Int("target_count", len(req.TargetOutpoints)),
+	)
+
+	// Forward to round actor via service key lookup. The round actor
+	// looks up VTXO actors by service key and sends TriggerLeaveEvent
+	// to each.
+	if a.actorSystem != nil {
+		serviceKey := actormsg.RoundActorServiceKey()
+		roundRef := serviceKey.Ref(a.actorSystem)
+		roundRef.Tell(ctx, &actormsg.TriggerVTXOLeaveMsg{
+			TargetOutpoints: req.TargetOutpoints,
+			DestOutput:      req.DestOutput,
+		})
+	} else {
+		a.log.WarnS(ctx, "Cannot forward leave: no actor system "+
+			"configured", nil)
+	}
+
+	resp := &LeaveVTXOsResponse{
+		LeavingCount: len(req.TargetOutpoints),
+		Errors:       make(map[wire.OutPoint]error),
 	}
 
 	return fn.Ok[WalletResp](resp)


### PR DESCRIPTION
This PR adds client-side support for VTXO leave (offboard) requests, enabling users to exit the Ark by forfeiting their VTXO and receiving funds to an on-chain address rather than rolling over into a new VTXO.

The leave flow routes through the actor system: wallet receives the user's leave request, forwards to the round actor, which triggers the VTXO actor, which then emits a leave request back to the round actor for tracking. This maintains the same message flow patterns established for refresh while producing a different outcome.

The key insight is that leave reuses the existing forfeit mechanism. When a VTXO is being left, it enters the same RefreshRequestedState and goes through the same forfeit signing process. The difference is that instead of creating a replacement VTXO, the server includes an on-chain output in the batch transaction.

For leave-only rounds (no new VTXOs being created), the client skips the MuSig2 nonce generation phase entirely. Since there are no VTXO tree leaves requiring partial signatures, the client transitions directly from commitment transaction validation to forfeit signature collection. This optimization prevents the server from waiting for nonces that would never be used.

The implementation spans several packages: wallet handles the entry point, actormsg defines cross-actor message types, vtxo handles the VTXO-side state transitions, and round coordinates the overall flow. Each component follows the established patterns from the refresh implementation, making the leave flow a natural extension of existing functionality.

Testing is covered by the companion PR in the server repo which adds TestVTXOLeaveE2E, demonstrating the complete lifecycle from boarding through VTXO creation, leave trigger, forfeit signing, and final on-chain balance verification.