### PR TITLE
chainsource: ignore duplicate broadcast errors

### DIFF
--- a/chainsource/broadcast_errors.go
+++ b/chainsource/broadcast_errors.go
@@ -1,0 +1,89 @@
+package chainsource
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/btcsuite/btcwallet/chain"
+)
+
+var (
+	// ignorableBroadcastSentinels lists sentinel errors that indicate
+	// a broadcast failure can be treated as a success (e.g., already known
+	// or already confirmed).
+	ignorableBroadcastSentinels = []error{
+		chain.ErrInsufficientFee,
+		chain.ErrSameNonWitnessData,
+		chain.ErrTxAlreadyConfirmed,
+		chain.ErrTxAlreadyKnown,
+	}
+
+	// ignorableBroadcastErrs lists error substrings that are expected
+	// to happen when broadcasting the same transaction more than once.
+	//
+	// We treat these errors as non-fatal because callers may legitimately
+	// rebroadcast sweeps (for retry and fee bumping) and some backends
+	// report duplicates or already-confirmed transactions as errors.
+	//
+	// This list is intentionally small and specific. If a backend returns a
+	// new string form, prefer adding a concrete sentinel error check
+	// (errors.Is) where possible, or add the minimal substring required.
+	ignorableBroadcastErrs = []string{
+		// Bitcoind.
+		"txn-already-in-mempool",
+		"already in mempool",
+		"already have transaction",
+
+		// Wallet-layer variants.
+		"output already spent",
+	}
+)
+
+// IsIgnorableBroadcastError returns true if the error is expected to happen
+// when broadcasting the same transaction multiple times.
+func IsIgnorableBroadcastError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	for _, sentinel := range ignorableBroadcastSentinels {
+		if errors.Is(err, sentinel) {
+			return true
+		}
+	}
+
+	errStr := err.Error()
+	for _, substring := range ignorableBroadcastErrs {
+		if strings.Contains(errStr, substring) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// IsIgnorableMempoolRejectReason returns true if the mempool rejection reason
+// indicates the transaction is already known (in mempool or chain).
+func IsIgnorableMempoolRejectReason(reason string) bool {
+	if reason == "" {
+		return false
+	}
+
+	lowerReason := strings.ToLower(reason)
+
+	ignorableSubstrings := []string{
+		strings.ToLower(chain.ErrTxAlreadyKnown.Error()),
+		strings.ToLower(chain.ErrTxAlreadyConfirmed.Error()),
+
+		"already in mempool",
+		"already known",
+	}
+
+	for _, substring := range ignorableSubstrings {
+		if strings.Contains(lowerReason, substring) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/chainsource/broadcast_errors_test.go
+++ b/chainsource/broadcast_errors_test.go
@@ -1,0 +1,85 @@
+package chainsource
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/btcsuite/btcwallet/chain"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIsIgnorableBroadcastError tests error classification for expected
+// re-broadcast failures.
+func TestIsIgnorableBroadcastError(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "insufficient fee sentinel",
+			err:  chain.ErrInsufficientFee,
+			want: true,
+		},
+		{
+			name: "same non-witness data sentinel",
+			err:  chain.ErrSameNonWitnessData,
+			want: true,
+		},
+		{
+			name: "tx already confirmed sentinel",
+			err:  chain.ErrTxAlreadyConfirmed,
+			want: true,
+		},
+		{
+			name: "tx already known sentinel",
+			err:  chain.ErrTxAlreadyKnown,
+			want: true,
+		},
+		{
+			name: "bitcoind already in mempool string",
+			err: errors.New(
+				"sendrawtransaction: txn-already-in-mempool",
+			),
+			want: true,
+		},
+		{
+			name: "unknown error",
+			err:  errors.New("some other error"),
+			want: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want,
+				IsIgnorableBroadcastError(tc.err),
+			)
+		})
+	}
+}
+
+// TestIsIgnorableMempoolRejectReason tests reject reason classification for
+// testmempoolaccept responses.
+func TestIsIgnorableMempoolRejectReason(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, IsIgnorableMempoolRejectReason(""))
+	require.True(t, IsIgnorableMempoolRejectReason(
+		chain.ErrTxAlreadyKnown.Error(),
+	))
+	require.True(t, IsIgnorableMempoolRejectReason(
+		chain.ErrTxAlreadyConfirmed.Error(),
+	))
+	require.True(t, IsIgnorableMempoolRejectReason("txn already known"))
+	require.True(t, IsIgnorableMempoolRejectReason("already in mempool"))
+	require.False(t, IsIgnorableMempoolRejectReason("missing inputs"))
+}

--- a/chainsource/chainsource.go
+++ b/chainsource/chainsource.go
@@ -169,6 +169,69 @@ func (a *ChainSourceActor) handleBroadcastTx(ctx context.Context,
 
 	err := a.cfg.Backend.BroadcastTx(ctx, req.Tx, req.Label)
 	if err != nil {
+		txHash := req.Tx.TxHash()
+
+		// Some backends treat duplicate broadcasts as errors.
+		// If the error
+		// indicates the transaction is already known or confirmed,
+		// treat the broadcast as a success so higher-level retry logic
+		// doesn't increment failure counters.
+		if IsIgnorableBroadcastError(err) {
+			a.logger(ctx).DebugS(ctx,
+				"Broadcast returned ignorable error",
+				slog.String("broadcast_error", err.Error()),
+				slog.String("txid", txHash.String()),
+				slog.String("label", req.Label))
+
+			return fn.Ok[ChainSourceResp](&BroadcastTxResponse{
+				Txid: txHash,
+			})
+		}
+
+		// If supported by the backend, test mempool acceptance as a
+		// best-effort signal that the transaction is already known.
+		// This is useful for backends that return non-standard error
+		// strings
+		// from BroadcastTx but provide a structured reject reason via
+		// testmempoolaccept.
+		accepted, reason, acceptErr := a.cfg.Backend.TestMempoolAccept(
+			ctx, req.Tx,
+		)
+		switch {
+		case acceptErr == nil && accepted:
+			a.logger(ctx).DebugS(ctx,
+				"Broadcast failed but mempool accept succeeded",
+				slog.String("broadcast_error", err.Error()),
+				slog.String("txid", txHash.String()),
+				slog.String("label", req.Label))
+
+			return fn.Ok[ChainSourceResp](&BroadcastTxResponse{
+				Txid: txHash,
+			})
+
+		case acceptErr == nil && IsIgnorableMempoolRejectReason(reason):
+			a.logger(ctx).DebugS(ctx,
+				"Broadcast failed; mempool reject ignorable",
+				slog.String("broadcast_error", err.Error()),
+				slog.String("txid", txHash.String()),
+				slog.String("label", req.Label),
+				slog.String("reject_reason", reason))
+
+			return fn.Ok[ChainSourceResp](&BroadcastTxResponse{
+				Txid: txHash,
+			})
+
+		case acceptErr != nil:
+			a.logger(ctx).DebugS(ctx,
+				"Broadcast failed; mempool accept query failed",
+				slog.String("broadcast_error", err.Error()),
+				slog.String("mempool_accept_error",
+					acceptErr.Error(),
+				),
+				slog.String("txid", txHash.String()),
+				slog.String("label", req.Label))
+		}
+
 		return fn.Err[ChainSourceResp](fmt.Errorf("failed to "+
 			"broadcast transaction: %w", err))
 	}

--- a/chainsource/chainsource_test.go
+++ b/chainsource/chainsource_test.go
@@ -2,12 +2,14 @@ package chainsource
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcwallet/chain"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
 	"github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/stretchr/testify/require"
@@ -60,6 +62,33 @@ func (m *mockBackend) BroadcastTx(ctx context.Context, tx *wire.MsgTx,
 	label string) error {
 
 	return nil
+}
+
+// broadcastErrorBackend is a mock backend that allows injecting broadcast
+// errors and mempool accept behavior while reusing the base mock backend for
+// other operations.
+type broadcastErrorBackend struct {
+	*mockBackend
+
+	broadcastErr error
+
+	mempoolAccepted bool
+	mempoolReason   string
+	mempoolErr      error
+}
+
+// BroadcastTx returns the configured error for testing error handling paths.
+func (b *broadcastErrorBackend) BroadcastTx(ctx context.Context, tx *wire.MsgTx,
+	label string) error {
+
+	return b.broadcastErr
+}
+
+// TestMempoolAccept returns the configured mempool acceptance values.
+func (b *broadcastErrorBackend) TestMempoolAccept(ctx context.Context,
+	tx *wire.MsgTx) (bool, string, error) {
+
+	return b.mempoolAccepted, b.mempoolReason, b.mempoolErr
 }
 
 func (m *mockBackend) RegisterConf(ctx context.Context,
@@ -201,6 +230,143 @@ func TestChainSourceActorBroadcastTx(t *testing.T) {
 	require.True(t, ok)
 	expectedHash := tx.TxHash()
 	require.Equal(t, expectedHash, broadcastResp.Txid)
+}
+
+// TestChainSourceActorBroadcastTxIgnoresRebroadcastErrors tests that broadcast
+// errors expected during re-broadcast are treated as success.
+func TestChainSourceActorBroadcastTxIgnoresRebroadcastErrors(t *testing.T) {
+	t.Parallel()
+
+	baseBackend := newMockBackend()
+	backend := &broadcastErrorBackend{
+		mockBackend: baseBackend,
+
+		broadcastErr: chain.ErrInsufficientFee,
+
+		// If we regress and call TestMempoolAccept on ignorable errors,
+		// the broadcast is treated as a failure,
+		// and this test should fail.
+		mempoolErr: errors.New("should not call testmempoolaccept"),
+	}
+
+	system := actor.NewActorSystem()
+	defer func() { _ = system.Shutdown(t.Context()) }()
+
+	chainSource := NewChainSourceActor(ChainSourceConfig{
+		Backend: backend,
+		System:  system,
+	})
+	ref := ChainSourceKey.Spawn(
+		system, "chainsource-broadcast-ignore", chainSource,
+	)
+
+	ctx := t.Context()
+	tx := wire.NewMsgTx(2)
+	future := ref.Ask(ctx, &BroadcastTxRequest{
+		Tx:    tx,
+		Label: "test-tx",
+	})
+
+	result := future.Await(ctx)
+	require.True(t, result.IsOk())
+
+	resp, err := result.Unpack()
+	require.NoError(t, err)
+	broadcastResp, ok := resp.(*BroadcastTxResponse)
+	require.True(t, ok)
+	require.Equal(t, tx.TxHash(), broadcastResp.Txid)
+}
+
+// TestChainSourceActorBroadcastTxFallsBackToTestMempoolAccept tests that the
+// ChainSourceActor treats a failed broadcast as success if the backend reports
+// that the transaction would be accepted by the mempool.
+func TestChainSourceActorBroadcastTxFallsBackToTestMempoolAccept(t *testing.T) {
+	t.Parallel()
+
+	baseBackend := newMockBackend()
+	backend := &broadcastErrorBackend{
+		mockBackend: baseBackend,
+
+		broadcastErr: errors.New("non-standard backend error"),
+
+		mempoolAccepted: true,
+		mempoolReason:   "",
+		mempoolErr:      nil,
+	}
+
+	system := actor.NewActorSystem()
+	defer func() { _ = system.Shutdown(t.Context()) }()
+
+	chainSource := NewChainSourceActor(ChainSourceConfig{
+		Backend: backend,
+		System:  system,
+	})
+	ref := ChainSourceKey.Spawn(
+		system, "chainsource-broadcast-mempool", chainSource,
+	)
+
+	ctx := t.Context()
+	tx := wire.NewMsgTx(2)
+	future := ref.Ask(ctx, &BroadcastTxRequest{
+		Tx:    tx,
+		Label: "test-tx",
+	})
+
+	result := future.Await(ctx)
+	require.True(t, result.IsOk())
+
+	resp, err := result.Unpack()
+	require.NoError(t, err)
+	broadcastResp, ok := resp.(*BroadcastTxResponse)
+	require.True(t, ok)
+	require.Equal(t, tx.TxHash(), broadcastResp.Txid)
+}
+
+// TestChainSourceActorBroadcastTxFallsBackToIgnorableRejectReason tests that
+// the ChainSourceActor treats a failed broadcast as success if the backend
+// reports an ignorable reject reason from TestMempoolAccept.
+func TestChainSourceActorBroadcastTxFallsBackToIgnorableRejectReason(
+	t *testing.T) {
+
+	t.Parallel()
+
+	baseBackend := newMockBackend()
+	backend := &broadcastErrorBackend{
+		mockBackend: baseBackend,
+
+		broadcastErr: errors.New("non-standard backend error"),
+
+		mempoolAccepted: false,
+		mempoolReason:   "already in mempool",
+		mempoolErr:      nil,
+	}
+
+	system := actor.NewActorSystem()
+	defer func() { _ = system.Shutdown(t.Context()) }()
+
+	chainSource := NewChainSourceActor(ChainSourceConfig{
+		Backend: backend,
+		System:  system,
+	})
+	ref := ChainSourceKey.Spawn(
+		system, "chainsource-broadcast-mempool-reject", chainSource,
+	)
+
+	ctx := t.Context()
+	tx := wire.NewMsgTx(2)
+	future := ref.Ask(ctx, &BroadcastTxRequest{
+		Tx:    tx,
+		Label: "test-tx",
+	})
+
+	result := future.Await(ctx)
+	require.True(t, result.IsOk())
+
+	resp, err := result.Unpack()
+	require.NoError(t, err)
+	broadcastResp, ok := resp.(*BroadcastTxResponse)
+	require.True(t, ok)
+	require.Equal(t, tx.TxHash(), broadcastResp.Txid)
 }
 
 // TestChainSourceActorBestHeight tests best height query through the


### PR DESCRIPTION
Fixes repeated broadcast/rebroadcast flows where the backend returns an error for transactions that are already known (in mempool or chain) or otherwise expected to fail during fee bump / republish attempts.

Changes:
- Add `IsIgnorableBroadcastError` and `IsIgnorableMempoolRejectReason` helpers in `chainsource/`.
- Update `ChainSourceActor.handleBroadcastTx` to treat ignorable broadcast errors as success (returns `BroadcastTxResponse`), and to best-effort fall back to `TestMempoolAccept` for non-standard backend error strings.
- Add unit tests covering both the error classification and the actor behavior.

Testing:
- `make unit pkg=chainsource timeout=5m`
- `make ast-lint pkg=chainsource`