### PR TITLE
multi: use actormsg types for round actor service key lookup

### DIFF
--- a/lib/actormsg/interfaces.go
+++ b/lib/actormsg/interfaces.go
@@ -28,6 +28,14 @@ type RoundReceivable interface {
 	RoundReceivable()
 }
 
+// RoundActorResp is the response type marker for round actors. The concrete
+// round.ClientResp struct implements this interface. Using an interface here
+// allows the wallet to look up the round actor without importing the round
+// package (avoiding import cycles).
+type RoundActorResp interface {
+	RoundActorResp()
+}
+
 // VTXOManagerMsg is the message type for VTXO manager. Messages sent TO the
 // manager implement this interface via the exported marker method.
 type VTXOManagerMsg interface {

--- a/lib/actormsg/service_keys.go
+++ b/lib/actormsg/service_keys.go
@@ -22,3 +22,20 @@ func VTXOActorServiceKey(outpoint wire.OutPoint) actor.ServiceKey[
 		fmt.Sprintf("vtxo.%s", outpoint.String()),
 	)
 }
+
+// RoundActorServiceKeyName is the well-known service key name for the round
+// actor. Both the round package (for registration) and wallet package (for
+// lookup) use this constant to ensure they reference the same actor.
+const RoundActorServiceKeyName = "round-client"
+
+// RoundActorServiceKey returns the service key for looking up the round actor.
+// This uses RoundReceivable for the message type so the wallet can look up the
+// round actor without importing the round package (avoiding import cycles).
+//
+// The round package must register the round actor with this key for lookup to
+// work. Use RoundActorServiceKeyName to construct the actor ID for Spawn.
+func RoundActorServiceKey() actor.ServiceKey[RoundReceivable, RoundActorResp] {
+	return actor.NewServiceKey[RoundReceivable, RoundActorResp](
+		RoundActorServiceKeyName,
+	)
+}

--- a/round/actor.go
+++ b/round/actor.go
@@ -125,7 +125,7 @@ type RoundClientConfig struct {
 
 	// SelfRef is a reference to this actor for receiving asynchronous
 	// notifications (e.g., confirmations from ChainSource).
-	SelfRef actor.TellOnlyRef[ClientMsg]
+	SelfRef actor.TellOnlyRef[actormsg.RoundReceivable]
 
 	// ChainParams are the Bitcoin network parameters.
 	ChainParams *chaincfg.Params
@@ -418,7 +418,7 @@ func (a *RoundClientActor) registerCommitmentConfirmation(ctx context.Context,
 
 	mappedRef := chainsource.MapConfirmationEvent(
 		a.cfg.SelfRef,
-		func(ce chainsource.ConfirmationEvent) ClientMsg {
+		func(ce chainsource.ConfirmationEvent) actormsg.RoundReceivable {
 			return &ConfirmationEvent{
 				Txid:          ce.Txid,
 				BlockHeight:   ce.BlockHeight,
@@ -533,7 +533,7 @@ func (a *RoundClientActor) Start(ctx context.Context) error {
 	// will notify us when new UTXOs are confirmed.
 	mappedRef := actor.NewMapInputRef(
 		a.cfg.SelfRef,
-		func(evt wallet.BoardingUtxoConfirmedEvent) ClientMsg {
+		func(evt wallet.BoardingUtxoConfirmedEvent) actormsg.RoundReceivable {
 			return &WalletBoardingConfirmed{
 				Intent: evt.BoardingIntent,
 			}
@@ -601,9 +601,11 @@ func (a *RoundClientActor) Start(ctx context.Context) error {
 }
 
 // Receive processes an actor message and returns a response. This is the main
-// entry point for the actor.
+// entry point for the actor. The method uses actormsg types (RoundReceivable
+// and RoundActorResp) so that the wallet can look up the round actor via
+// service key without import cycles.
 func (a *RoundClientActor) Receive(ctx context.Context,
-	msg ClientMsg) fn.Result[ClientResp] {
+	msg actormsg.RoundReceivable) fn.Result[actormsg.RoundActorResp] {
 
 	switch m := msg.(type) {
 	case *WalletBoardingConfirmed:
@@ -634,7 +636,7 @@ func (a *RoundClientActor) Receive(ctx context.Context,
 		return a.handleTriggerVTXORefresh(ctx, m)
 
 	default:
-		return fn.Err[ClientResp](fmt.Errorf(
+		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 			"unknown message type: %T", msg))
 	}
 }
@@ -643,11 +645,11 @@ func (a *RoundClientActor) Receive(ctx context.Context,
 // from the wallet actor. This creates the FSM event and drives the state
 // machine forward. The wallet handles all persistence; we just react.
 func (a *RoundClientActor) handleWalletBoardingConfirmed(ctx context.Context,
-	msg *WalletBoardingConfirmed) fn.Result[ClientResp] {
+	msg *WalletBoardingConfirmed) fn.Result[actormsg.RoundActorResp] {
 
 	walletIntent := msg.Intent
 	if walletIntent == nil {
-		return fn.Err[ClientResp](fmt.Errorf(
+		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 			"wallet boarding confirmed event missing intent"))
 	}
 
@@ -664,7 +666,7 @@ func (a *RoundClientActor) handleWalletBoardingConfirmed(ctx context.Context,
 		var err error
 		roundFSM, err = a.createNewRound(ctx)
 		if err != nil {
-			return fn.Err[ClientResp](fmt.Errorf(
+			return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 				"failed to create round for boarding: %w", err))
 		}
 	}
@@ -685,20 +687,20 @@ func (a *RoundClientActor) handleWalletBoardingConfirmed(ctx context.Context,
 	// Drive the FSM with the confirmation event.
 	err := a.askEventAndProcessOutbox(ctx, roundFSM.FSM, confirmEvt)
 	if err != nil {
-		return fn.Err[ClientResp](fmt.Errorf(
+		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 			"FSM error processing boarding confirmation: %w", err))
 	}
 
-	return fn.Ok[ClientResp](nil)
+	return fn.Ok[actormsg.RoundActorResp](nil)
 }
 
 // handleVTXORequests processes client-submitted VTXO requests and forwards
 // them to an idle round FSM. If no idle round exists, a new one is created.
 func (a *RoundClientActor) handleVTXORequests(ctx context.Context,
-	msg *RegisterVTXORequestsRequest) fn.Result[ClientResp] {
+	msg *RegisterVTXORequestsRequest) fn.Result[actormsg.RoundActorResp] {
 
 	if len(msg.Amounts) == 0 {
-		return fn.Err[ClientResp](fmt.Errorf(
+		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 			"VTXO request amounts are empty",
 		))
 	}
@@ -706,14 +708,14 @@ func (a *RoundClientActor) handleVTXORequests(ctx context.Context,
 	requests := make([]types.VTXORequest, 0, len(msg.Amounts))
 	for i, amount := range msg.Amounts {
 		if amount <= 0 {
-			return fn.Err[ClientResp](fmt.Errorf(
+			return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 				"VTXO amount %d is invalid: %v", i, amount,
 			))
 		}
 
 		req, err := a.buildVTXORequest(ctx, amount)
 		if err != nil {
-			return fn.Err[ClientResp](fmt.Errorf(
+			return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 				"build VTXO request %d: %w", i, err,
 			))
 		}
@@ -732,7 +734,7 @@ func (a *RoundClientActor) handleVTXORequests(ctx context.Context,
 		var err error
 		roundFSM, err = a.createNewRound(ctx)
 		if err != nil {
-			return fn.Err[ClientResp](fmt.Errorf(
+			return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 				"create new round for VTXO requests: %w", err,
 			))
 		}
@@ -744,12 +746,12 @@ func (a *RoundClientActor) handleVTXORequests(ctx context.Context,
 
 	err := a.askEventAndProcessOutbox(ctx, roundFSM.FSM, event)
 	if err != nil {
-		return fn.Err[ClientResp](fmt.Errorf(
+		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 			"FSM error processing VTXO requests: %w", err,
 		))
 	}
 
-	return fn.Ok[ClientResp](&RegisterVTXORequestsResponse{
+	return fn.Ok[actormsg.RoundActorResp](&RegisterVTXORequestsResponse{
 		Success: true,
 	})
 }
@@ -793,7 +795,7 @@ func (a *RoundClientActor) buildVTXORequest(ctx context.Context,
 // pending round, then re-keys the round from its TempRoundKey to the
 // server-assigned RoundID.
 func (a *RoundClientActor) handleRoundJoined(ctx context.Context,
-	event *RoundJoined) fn.Result[ClientResp] {
+	event *RoundJoined) fn.Result[actormsg.RoundActorResp] {
 
 	// Find the pending round by matching outpoints. Currently we only match
 	// boarding outpoints, but this will be extended for VTXO operations
@@ -803,7 +805,7 @@ func (a *RoundClientActor) handleRoundJoined(ctx context.Context,
 		event.AcceptedVTXOOutpoints,
 	)
 	if roundFSM == nil {
-		return fn.Err[ClientResp](fmt.Errorf(
+		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 			"no pending round matches: boarding=%v, vtxo=%v",
 			event.AcceptedBoardingOutpoints,
 			event.AcceptedVTXOOutpoints))
@@ -827,11 +829,11 @@ func (a *RoundClientActor) handleRoundJoined(ctx context.Context,
 	// Now process the event normally.
 	err := a.askEventAndProcessOutbox(ctx, roundFSM.FSM, event)
 	if err != nil {
-		return fn.Err[ClientResp](fmt.Errorf(
+		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 			"FSM error processing RoundJoined: %w", err))
 	}
 
-	return fn.Ok[ClientResp](&ServerMessageResponse{Success: true})
+	return fn.Ok[actormsg.RoundActorResp](&ServerMessageResponse{Success: true})
 }
 
 // extractRoundID returns the RoundID from events that carry one. Returns the
@@ -862,7 +864,7 @@ func extractRoundID(event ClientEvent) (RoundID, bool) {
 // Outbox). The actor routes the message to the appropriate FSM based on the
 // event type and RoundID.
 func (a *RoundClientActor) handleServerMessage(ctx context.Context,
-	msg *ServerMessageNotification) fn.Result[ClientResp] {
+	msg *ServerMessageNotification) fn.Result[actormsg.RoundActorResp] {
 
 	// RoundJoined requires special handling for re-keying.
 	if joined, ok := msg.Message.(*RoundJoined); ok {
@@ -878,7 +880,7 @@ func (a *RoundClientActor) handleServerMessage(ctx context.Context,
 		var exists bool
 		roundFSM, exists = a.rounds[keyStr]
 		if !exists {
-			return fn.Err[ClientResp](fmt.Errorf(
+			return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 				"no round for ID: %s", roundID))
 		}
 
@@ -892,7 +894,7 @@ func (a *RoundClientActor) handleServerMessage(ctx context.Context,
 		// RoundID.
 		roundFSM = a.findPendingRound()
 		if roundFSM == nil {
-			return fn.Err[ClientResp](fmt.Errorf(
+			return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 				"no pending round for event %T", msg.Message))
 		}
 
@@ -903,11 +905,11 @@ func (a *RoundClientActor) handleServerMessage(ctx context.Context,
 
 	err := a.askEventAndProcessOutbox(ctx, roundFSM.FSM, msg.Message)
 	if err != nil {
-		return fn.Err[ClientResp](fmt.Errorf(
+		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 			"FSM error processing server message: %w", err))
 	}
 
-	return fn.Ok[ClientResp](&ServerMessageResponse{
+	return fn.Ok[actormsg.RoundActorResp](&ServerMessageResponse{
 		Success: true,
 	})
 }
@@ -927,7 +929,7 @@ func (a *RoundClientActor) findPendingRound() *RoundFSM {
 // handleGetState returns the current FSM state for monitoring/debugging.
 // This includes all round FSMs (both temp-keyed and RoundID-keyed).
 func (a *RoundClientActor) handleGetState(ctx context.Context,
-	_ *GetClientStateRequest) fn.Result[ClientResp] {
+	_ *GetClientStateRequest) fn.Result[actormsg.RoundActorResp] {
 
 	states := make(map[string]FSMStateInfo)
 
@@ -956,7 +958,7 @@ func (a *RoundClientActor) handleGetState(ctx context.Context,
 		}
 	}
 
-	return fn.Ok[ClientResp](&GetClientStateResponse{
+	return fn.Ok[actormsg.RoundActorResp](&GetClientStateResponse{
 		States: states,
 	})
 }
@@ -965,7 +967,7 @@ func (a *RoundClientActor) handleGetState(ctx context.Context,
 // If a RoundKey is specified in the request, that round is cancelled;
 // otherwise, the first temp-keyed round is cancelled.
 func (a *RoundClientActor) handleCancelRound(ctx context.Context,
-	req *CancelRoundRequest) fn.Result[ClientResp] {
+	req *CancelRoundRequest) fn.Result[actormsg.RoundActorResp] {
 
 	a.log.InfoS(ctx, "Cancelling round participation by user request")
 
@@ -977,7 +979,7 @@ func (a *RoundClientActor) handleCancelRound(ctx context.Context,
 		var exists bool
 		targetFSM, exists = a.rounds[keyStr]
 		if !exists {
-			return fn.Ok[ClientResp](&CancelRoundResponse{
+			return fn.Ok[actormsg.RoundActorResp](&CancelRoundResponse{
 				Success: false,
 				Error:   fmt.Sprintf("no round with key: %s", keyStr),
 			})
@@ -993,7 +995,7 @@ func (a *RoundClientActor) handleCancelRound(ctx context.Context,
 	}
 
 	if targetFSM == nil {
-		return fn.Ok[ClientResp](&CancelRoundResponse{
+		return fn.Ok[actormsg.RoundActorResp](&CancelRoundResponse{
 			Success: false,
 			Error:   "no pending round to cancel",
 		})
@@ -1011,7 +1013,7 @@ func (a *RoundClientActor) handleCancelRound(ctx context.Context,
 	if err != nil {
 		a.log.WarnS(ctx, "Failed to cancel round", err)
 
-		return fn.Ok[ClientResp](&CancelRoundResponse{
+		return fn.Ok[actormsg.RoundActorResp](&CancelRoundResponse{
 			Success: false,
 			Error:   fmt.Sprintf("failed to cancel: %v", err),
 		})
@@ -1023,7 +1025,7 @@ func (a *RoundClientActor) handleCancelRound(ctx context.Context,
 
 	a.log.InfoS(ctx, "Round participation cancelled successfully")
 
-	return fn.Ok[ClientResp](&CancelRoundResponse{
+	return fn.Ok[actormsg.RoundActorResp](&CancelRoundResponse{
 		Success: true,
 	})
 }
@@ -1055,7 +1057,7 @@ func (a *RoundClientActor) onRoundComplete(ctx context.Context, roundID RoundID,
 // Concurrency: The actor framework serializes all messages through Receive(),
 // so no synchronization is needed for rounds map access.
 func (a *RoundClientActor) handleConfirmation(ctx context.Context,
-	event *ConfirmationEvent) fn.Result[ClientResp] {
+	event *ConfirmationEvent) fn.Result[actormsg.RoundActorResp] {
 
 	a.log.InfoS(ctx, "Received commitment transaction confirmation",
 		slog.String("txid", event.Txid.String()),
@@ -1071,13 +1073,13 @@ func (a *RoundClientActor) handleConfirmation(ctx context.Context,
 		a.log.WarnS(ctx, "Commitment tx not in index", nil,
 			slog.String("txid", event.Txid.String()))
 
-		return fn.Ok[ClientResp](nil)
+		return fn.Ok[actormsg.RoundActorResp](nil)
 	}
 
 	// Route to the specific round's FSM.
 	roundFSM, exists := a.rounds[keyStr]
 	if !exists {
-		return fn.Err[ClientResp](fmt.Errorf(
+		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 			"round FSM not found for key %s", keyStr))
 	}
 
@@ -1094,11 +1096,11 @@ func (a *RoundClientActor) handleConfirmation(ctx context.Context,
 
 	err := a.askEventAndProcessOutbox(ctx, roundFSM.FSM, confirmEvt)
 	if err != nil {
-		return fn.Err[ClientResp](fmt.Errorf(
+		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 			"FSM error processing commitment confirmation: %w", err))
 	}
 
-	return fn.Ok[ClientResp](nil)
+	return fn.Ok[actormsg.RoundActorResp](nil)
 }
 
 // processOutbox processes messages emitted by the FSM via Outbox and routes
@@ -1144,7 +1146,7 @@ func (a *RoundClientActor) processOutbox(ctx context.Context,
 			// intermediate actor.
 			mappedRef := chainsource.MapConfirmationEvent(
 				a.cfg.SelfRef,
-				func(ce chainsource.ConfirmationEvent) ClientMsg {
+				func(ce chainsource.ConfirmationEvent) actormsg.RoundReceivable {
 					return &ConfirmationEvent{
 						Txid:          ce.Txid,
 						BlockHeight:   ce.BlockHeight,
@@ -1341,7 +1343,7 @@ func (a *RoundClientActor) processOutbox(ctx context.Context,
 // swap round. The request is forwarded to a pending round FSM which tracks it
 // alongside boarding intents.
 func (a *RoundClientActor) handleRefreshVTXORequest(ctx context.Context,
-	req *RefreshVTXORequest) fn.Result[ClientResp] {
+	req *RefreshVTXORequest) fn.Result[actormsg.RoundActorResp] {
 
 	// Find a pending round or create one if none exists.
 	roundFSM := a.findPendingRound()
@@ -1349,7 +1351,7 @@ func (a *RoundClientActor) handleRefreshVTXORequest(ctx context.Context,
 		var err error
 		roundFSM, err = a.createNewRound(ctx)
 		if err != nil {
-			return fn.Err[ClientResp](fmt.Errorf(
+			return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 				"failed to create round for refresh: %w", err,
 			))
 		}
@@ -1359,7 +1361,7 @@ func (a *RoundClientActor) handleRefreshVTXORequest(ctx context.Context,
 	// state (similar to how it tracks boarding intents).
 	err := a.askEventAndProcessOutbox(ctx, roundFSM.FSM, req)
 	if err != nil {
-		return fn.Err[ClientResp](fmt.Errorf(
+		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 			"FSM error processing refresh request: %w", err,
 		))
 	}
@@ -1377,14 +1379,14 @@ func (a *RoundClientActor) handleRefreshVTXORequest(ctx context.Context,
 		})
 	}
 
-	return fn.Ok[ClientResp](nil)
+	return fn.Ok[actormsg.RoundActorResp](nil)
 }
 
 // handleForfeitSignatureResponse processes a forfeit signature from a VTXO
 // actor. The VTXO actor has signed the forfeit transaction as part of a batch
 // swap round. The signature is forwarded to the round's FSM for tracking.
 func (a *RoundClientActor) handleForfeitSignatureResponse(ctx context.Context,
-	resp *ForfeitSignatureResponse) fn.Result[ClientResp] {
+	resp *ForfeitSignatureResponse) fn.Result[actormsg.RoundActorResp] {
 
 	roundIDStr := resp.RoundID
 
@@ -1396,7 +1398,7 @@ func (a *RoundClientActor) handleForfeitSignatureResponse(ctx context.Context,
 			slog.String("outpoint", resp.VTXOOutpoint.String()),
 			slog.String("round_id", roundIDStr))
 
-		return fn.Err[ClientResp](fmt.Errorf(
+		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 			"unknown round %s for forfeit signature", roundIDStr,
 		))
 	}
@@ -1405,7 +1407,7 @@ func (a *RoundClientActor) handleForfeitSignatureResponse(ctx context.Context,
 	// a server message when all expected signatures are collected.
 	err := a.askEventAndProcessOutbox(ctx, roundFSM.FSM, resp)
 	if err != nil {
-		return fn.Err[ClientResp](fmt.Errorf(
+		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 			"FSM error processing forfeit signature: %w", err,
 		))
 	}
@@ -1414,7 +1416,7 @@ func (a *RoundClientActor) handleForfeitSignatureResponse(ctx context.Context,
 		slog.String("outpoint", resp.VTXOOutpoint.String()),
 		slog.String("round_id", roundIDStr))
 
-	return fn.Ok[ClientResp](nil)
+	return fn.Ok[actormsg.RoundActorResp](nil)
 }
 
 // handleTriggerVTXORefresh processes a refresh trigger request from the wallet
@@ -1422,10 +1424,10 @@ func (a *RoundClientActor) handleForfeitSignatureResponse(ctx context.Context,
 // actor via its service key. The VTXO actor then emits RefreshVTXORequest back
 // to us through its outbox.
 func (a *RoundClientActor) handleTriggerVTXORefresh(ctx context.Context,
-	cmd *actormsg.TriggerVTXORefreshMsg) fn.Result[ClientResp] {
+	cmd *actormsg.TriggerVTXORefreshMsg) fn.Result[actormsg.RoundActorResp] {
 
 	if a.cfg.ActorSystem == nil {
-		return fn.Err[ClientResp](fmt.Errorf(
+		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 			"ActorSystem not configured, cannot trigger VTXO refresh",
 		))
 	}
@@ -1447,5 +1449,5 @@ func (a *RoundClientActor) handleTriggerVTXORefresh(ctx context.Context,
 	a.log.InfoS(ctx, "Triggered VTXO refresh",
 		slog.Int("count", triggeredCount))
 
-	return fn.Ok[ClientResp](nil)
+	return fn.Ok[actormsg.RoundActorResp](nil)
 }

--- a/round/actor_harness_test.go
+++ b/round/actor_harness_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/lightninglabs/darepo-client/baselib/actor"
 	"github.com/lightninglabs/darepo-client/baselib/protofsm"
 	"github.com/lightninglabs/darepo-client/chainsource"
+	"github.com/lightninglabs/darepo-client/lib/actormsg"
 	"github.com/lightninglabs/darepo-client/lib/scripts"
 	"github.com/lightninglabs/darepo-client/lib/types"
 	"github.com/lightninglabs/darepo-client/serverconn"
@@ -236,8 +237,8 @@ func (m *mockWalletActorRef) sendBoardingConfirmation(ctx context.Context,
 type mockSelfRef struct {
 	t        *testing.T
 	id       string
-	messages []ClientMsg
-	msgChan  chan ClientMsg
+	messages []actormsg.RoundReceivable
+	msgChan  chan actormsg.RoundReceivable
 	mu       sync.Mutex
 }
 
@@ -245,8 +246,8 @@ func newMockSelfRef(t *testing.T) *mockSelfRef {
 	return &mockSelfRef{
 		t:        t,
 		id:       "mock-self-ref",
-		messages: make([]ClientMsg, 0),
-		msgChan:  make(chan ClientMsg, 100),
+		messages: make([]actormsg.RoundReceivable, 0),
+		msgChan:  make(chan actormsg.RoundReceivable, 100),
 	}
 }
 
@@ -254,7 +255,7 @@ func (m *mockSelfRef) ID() string {
 	return m.id
 }
 
-func (m *mockSelfRef) Tell(_ context.Context, msg ClientMsg) {
+func (m *mockSelfRef) Tell(_ context.Context, msg actormsg.RoundReceivable) {
 	m.mu.Lock()
 	m.messages = append(m.messages, msg)
 	m.mu.Unlock()
@@ -268,10 +269,14 @@ func (m *mockSelfRef) Tell(_ context.Context, msg ClientMsg) {
 
 // waitForMessage blocks until a message arrives or the timeout expires,
 // enabling synchronous test assertions on asynchronous actor messages.
-func (m *mockSelfRef) waitForMessage(timeout time.Duration) (ClientMsg, bool) {
+func (m *mockSelfRef) waitForMessage(
+	timeout time.Duration,
+) (actormsg.RoundReceivable, bool) {
+
 	select {
 	case msg := <-m.msgChan:
 		return msg, true
+
 	case <-time.After(timeout):
 		return nil, false
 	}
@@ -481,7 +486,10 @@ func (h *actorTestHarness) start() error {
 }
 
 // receive sends a message to the actor and returns the response.
-func (h *actorTestHarness) receive(msg ClientMsg) fn.Result[ClientResp] {
+func (h *actorTestHarness) receive(
+	msg actormsg.RoundReceivable,
+) fn.Result[actormsg.RoundActorResp] {
+
 	return h.actor.Receive(h.ctx, msg)
 }
 

--- a/round/actor_messages.go
+++ b/round/actor_messages.go
@@ -18,10 +18,55 @@ type ClientMsg interface {
 }
 
 // ClientResp is the sealed interface for all response messages from a
-// RoundClientActor.
+// RoundClientActor. It implements actormsg.RoundActorResp to enable service
+// key lookup from the wallet package.
 type ClientResp interface {
 	actor.Message
+	actormsg.RoundActorResp
 	clientRespSealed()
+}
+
+// serviceKeyConfig holds configuration for service key creation.
+type serviceKeyConfig struct {
+	suffix string
+}
+
+// ServiceKeyOption is a functional option for customizing the service key.
+type ServiceKeyOption func(*serviceKeyConfig)
+
+// WithSuffix adds a suffix to the service key name. This is useful in tests
+// with multiple round actors that need unique service keys to avoid collisions.
+func WithSuffix(suffix string) ServiceKeyOption {
+	return func(cfg *serviceKeyConfig) {
+		cfg.suffix = suffix
+	}
+}
+
+// NewServiceKey returns the service key for looking up a round client actor.
+// The service key uses actormsg interface types to match the round actor's
+// Receive signature and ensure compatibility with wallet service key lookups.
+//
+// Use the WithSuffix option in tests to create unique service keys for
+// multi-client scenarios:
+//
+//	key := round.NewServiceKey(round.WithSuffix("-1"))
+func NewServiceKey(
+	opts ...ServiceKeyOption,
+) actor.ServiceKey[actormsg.RoundReceivable, actormsg.RoundActorResp] {
+
+	cfg := &serviceKeyConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	keyName := actormsg.RoundActorServiceKeyName
+	if cfg.suffix != "" {
+		keyName += cfg.suffix
+	}
+
+	return actor.NewServiceKey[actormsg.RoundReceivable, actormsg.RoundActorResp](
+		keyName,
+	)
 }
 
 // WalletBoardingConfirmed wraps a wallet.BoardingUtxoConfirmedEvent to make it
@@ -73,6 +118,9 @@ func (m *ServerMessageResponse) MessageType() string {
 
 func (m *ServerMessageResponse) clientRespSealed() {}
 
+// RoundActorResp implements actormsg.RoundActorResp marker interface.
+func (m *ServerMessageResponse) RoundActorResp() {}
+
 // GetClientStateRequest queries the current client state.
 type GetClientStateRequest struct {
 	actor.BaseMessage
@@ -116,6 +164,9 @@ func (m *GetClientStateResponse) MessageType() string {
 
 func (m *GetClientStateResponse) clientRespSealed() {}
 
+// RoundActorResp implements actormsg.RoundActorResp marker interface.
+func (m *GetClientStateResponse) RoundActorResp() {}
+
 // CancelRoundRequest cancels participation in a round.
 type CancelRoundRequest struct {
 	actor.BaseMessage
@@ -145,6 +196,9 @@ func (m *CancelRoundResponse) MessageType() string {
 }
 
 func (m *CancelRoundResponse) clientRespSealed() {}
+
+// RoundActorResp implements actormsg.RoundActorResp marker interface.
+func (m *CancelRoundResponse) RoundActorResp() {}
 
 // RegisterVTXORequestsRequest informs the FSM of VTXO request amounts to
 // include in the next round registration.
@@ -177,6 +231,9 @@ func (m *RegisterVTXORequestsResponse) MessageType() string {
 
 // clientRespSealed marks this as a client response message.
 func (m *RegisterVTXORequestsResponse) clientRespSealed() {}
+
+// RoundActorResp implements actormsg.RoundActorResp marker interface.
+func (m *RegisterVTXORequestsResponse) RoundActorResp() {}
 
 // ConfirmationEvent wraps a chain confirmation event from ChainSource.
 // This allows the actor to receive confirmation notifications.

--- a/round/actor_messages.go
+++ b/round/actor_messages.go
@@ -64,9 +64,9 @@ func NewServiceKey(
 		keyName += cfg.suffix
 	}
 
-	return actor.NewServiceKey[actormsg.RoundReceivable, actormsg.RoundActorResp](
-		keyName,
-	)
+	return actor.NewServiceKey[
+		actormsg.RoundReceivable, actormsg.RoundActorResp,
+	](keyName)
 }
 
 // WalletBoardingConfirmed wraps a wallet.BoardingUtxoConfirmedEvent to make it

--- a/systest/helpers.go
+++ b/systest/helpers.go
@@ -12,7 +12,6 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
 	"github.com/lightninglabs/darepo-client/chainsource"
-	"github.com/lightninglabs/darepo-client/lib/actormsg"
 	"github.com/lightninglabs/darepo-client/wallet"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/stretchr/testify/require"
@@ -114,7 +113,7 @@ func NewBoardingWalletFixture(t *testing.T) *BoardingWalletFixture {
 	backend := h.NewBoardingBackend()
 	walletActor := wallet.NewArk(
 		backend, h.BoardingStore(), chainSourceRef,
-		fn.None[actor.TellOnlyRef[actormsg.RoundReceivable]](),
+		h.ActorSystem(),
 		h.SubLogger(wallet.Subsystem),
 	)
 

--- a/vtxo/actor.go
+++ b/vtxo/actor.go
@@ -40,8 +40,8 @@ type VTXOActorConfig struct {
 	Logger       btclog.Logger
 
 	// RoundActor receives refresh requests and forfeit signatures from this
-	// VTXO actor.
-	RoundActor actor.TellOnlyRef[round.ClientMsg]
+	// VTXO actor. Uses actormsg.RoundReceivable to avoid import cycles.
+	RoundActor actor.TellOnlyRef[actormsg.RoundReceivable]
 
 	// ChainResolver receives expiring notifications for unilateral exit.
 	ChainResolver actor.TellOnlyRef[ExpiringNotification]

--- a/vtxo/harness_test.go
+++ b/vtxo/harness_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/actormsg"
 	"github.com/lightninglabs/darepo-client/lib/scripts"
-	"github.com/lightninglabs/darepo-client/round"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/stretchr/testify/mock"
@@ -679,17 +679,17 @@ func assertOutboxContainsReal[T VTXOOutMsg](h *realVTXOSigningHarness) T {
 }
 
 // mockRoundActorRef captures messages sent to the round actor for test
-// verification. Implements actor.TellOnlyRef[round.ClientMsg].
+// verification. Implements actor.TellOnlyRef[actormsg.RoundReceivable].
 type mockRoundActorRef struct {
 	t        *testing.T
-	messages []round.ClientMsg
+	messages []actormsg.RoundReceivable
 	mu       sync.Mutex
 }
 
 func newMockRoundActorRef(t *testing.T) *mockRoundActorRef {
 	return &mockRoundActorRef{
 		t:        t,
-		messages: make([]round.ClientMsg, 0),
+		messages: make([]actormsg.RoundReceivable, 0),
 	}
 }
 
@@ -697,17 +697,17 @@ func (m *mockRoundActorRef) ID() string {
 	return "mock-round-actor"
 }
 
-func (m *mockRoundActorRef) Tell(_ context.Context, msg round.ClientMsg) {
+func (m *mockRoundActorRef) Tell(_ context.Context, msg actormsg.RoundReceivable) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.messages = append(m.messages, msg)
 }
 
-func (m *mockRoundActorRef) getMessages() []round.ClientMsg {
+func (m *mockRoundActorRef) getMessages() []actormsg.RoundReceivable {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	result := make([]round.ClientMsg, len(m.messages))
+	result := make([]actormsg.RoundReceivable, len(m.messages))
 	copy(result, m.messages)
 
 	return result

--- a/vtxo/harness_test.go
+++ b/vtxo/harness_test.go
@@ -697,7 +697,10 @@ func (m *mockRoundActorRef) ID() string {
 	return "mock-round-actor"
 }
 
-func (m *mockRoundActorRef) Tell(_ context.Context, msg actormsg.RoundReceivable) {
+func (m *mockRoundActorRef) Tell(
+	_ context.Context, msg actormsg.RoundReceivable,
+) {
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.messages = append(m.messages, msg)

--- a/vtxo/manager.go
+++ b/vtxo/manager.go
@@ -36,8 +36,9 @@ type ManagerConfig struct {
 	Logger       btclog.Logger
 
 	// RoundActor receives refresh requests and forfeit signatures from VTXOs.
-	// Passed through to spawned VTXO actors.
-	RoundActor actor.TellOnlyRef[round.ClientMsg]
+	// Passed through to spawned VTXO actors. Uses actormsg.RoundReceivable to
+	// avoid import cycles.
+	RoundActor actor.TellOnlyRef[actormsg.RoundReceivable]
 
 	// ChainResolver receives expiring notifications for unilateral exit.
 	// Passed through to spawned VTXO actors.

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -58,9 +58,11 @@ type Ark struct {
 	// store persists boarding addresses and intents to the database.
 	store BoardingStore
 
-	// roundActor is a reference to the round actor for forwarding refresh
-	// requests. The round actor handles VTXO actor coordination.
-	roundActor fn.Option[actor.TellOnlyRef[actormsg.RoundReceivable]]
+	// actorSystem is the actor system context for looking up actors by
+	// service key. Used to find the round actor when forwarding refresh
+	// requests. This avoids circular dependencies since we look up the
+	// actor on-demand rather than holding a reference.
+	actorSystem actor.SystemContext
 
 	// chainSource provides block epoch notifications for polling.
 	chainSource actor.ActorRef[
@@ -94,18 +96,19 @@ type Ark struct {
 // NewArk creates a new Ark wallet actor. The logger should already have the
 // subsystem set (e.g., created via handler.SubSystem(wallet.Subsystem)).
 //
-// The roundActor parameter is optional - if provided, refresh requests will be
-// forwarded to the round actor for VTXO actor coordination.
+// The actorSystem parameter enables refresh request forwarding to the round
+// actor via service key lookup. This avoids circular dependencies since we
+// look up the actor on-demand using the well-known RoundActorServiceKey.
 func NewArk(backend BoardingBackend, store BoardingStore,
 	chainSource actor.ActorRef[chainsource.ChainSourceMsg, chainsource.ChainSourceResp],
-	roundActor fn.Option[actor.TellOnlyRef[actormsg.RoundReceivable]],
+	actorSystem actor.SystemContext,
 	log btclog.Logger) *Ark {
 
 	return &Ark{
 		backend:     backend,
 		store:       store,
 		chainSource: chainSource,
-		roundActor:  roundActor,
+		actorSystem: actorSystem,
 		notifiers:   make(map[string]notifierInfo),
 		seenUtxos:   fn.NewSet[UtxoKey](),
 		log:         log,
@@ -535,19 +538,24 @@ func (a *Ark) handleRefreshVTXOs(ctx context.Context,
 
 	a.log.InfoS(ctx, "Received VTXO refresh request",
 		slog.Int("target_count", len(req.TargetOutpoints)),
-		slog.Bool("force_refresh", req.ForceRefresh),
-	)
+		slog.Bool("force_refresh", req.ForceRefresh))
 
-	// Forward to round actor if configured. The round actor looks up VTXO
-	// actors by service key and sends TriggerRefreshEvent to each one.
-	a.roundActor.WhenSome(
-		func(ref actor.TellOnlyRef[actormsg.RoundReceivable]) {
-			ref.Tell(ctx, &actormsg.TriggerVTXORefreshMsg{
-				TargetOutpoints: req.TargetOutpoints,
-				ForceRefresh:    req.ForceRefresh,
-			})
-		},
-	)
+	// Forward to round actor via service key lookup. The round actor looks
+	// up VTXO actors by service key and sends TriggerRefreshEvent to each.
+	if a.actorSystem != nil {
+		serviceKey := actormsg.RoundActorServiceKey()
+		roundRef := serviceKey.Ref(a.actorSystem)
+
+		roundRef.Tell(ctx, &actormsg.TriggerVTXORefreshMsg{
+			TargetOutpoints: req.TargetOutpoints,
+			ForceRefresh:    req.ForceRefresh,
+		})
+
+		a.log.DebugS(ctx, "Forwarded refresh request to round actor")
+	} else {
+		a.log.WarnS(ctx, "Cannot forward refresh: no actor system "+
+			"configured", nil)
+	}
 
 	resp := &RefreshVTXOsResponse{
 		RefreshingCount: len(req.TargetOutpoints),

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
 	"github.com/lightninglabs/darepo-client/chainsource"
-	"github.com/lightninglabs/darepo-client/lib/actormsg"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/stretchr/testify/mock"
@@ -289,8 +288,7 @@ func TestCreateBoardingAddress(t *testing.T) {
 	chainSource := newMockChainSourceActor(epochChan)
 
 	walletActor := NewArk(
-		backend, store, chainSource,
-		fn.None[actor.TellOnlyRef[actormsg.RoundReceivable]](),
+		backend, store, chainSource, nil,
 		btclog.Disabled,
 	)
 
@@ -329,8 +327,7 @@ func TestRegisterNotifier(t *testing.T) {
 	chainSource := newMockChainSourceActor(epochChan)
 
 	walletActor := NewArk(
-		backend, store, chainSource,
-		fn.None[actor.TellOnlyRef[actormsg.RoundReceivable]](),
+		backend, store, chainSource, nil,
 		btclog.Disabled,
 	)
 
@@ -476,8 +473,7 @@ func TestProcessNewUtxo(t *testing.T) {
 	chainSource := newMockChainSourceActor(epochChan)
 
 	walletActor := NewArk(
-		backend, store, chainSource,
-		fn.None[actor.TellOnlyRef[actormsg.RoundReceivable]](),
+		backend, store, chainSource, nil,
 		btclog.Disabled,
 	)
 
@@ -634,8 +630,7 @@ func TestProcessUtxoMinConfFiltering(t *testing.T) {
 	chainSource := newMockChainSourceActor(epochChan)
 
 	walletActor := NewArk(
-		backend, store, chainSource,
-		fn.None[actor.TellOnlyRef[actormsg.RoundReceivable]](),
+		backend, store, chainSource, nil,
 		btclog.Disabled,
 	)
 
@@ -771,8 +766,7 @@ func TestGetActiveBoardingAddresses(t *testing.T) {
 	chainSource := newMockChainSourceActor(epochChan)
 
 	walletActor := NewArk(
-		backend, store, chainSource,
-		fn.None[actor.TellOnlyRef[actormsg.RoundReceivable]](),
+		backend, store, chainSource, nil,
 		btclog.Disabled,
 	)
 
@@ -814,8 +808,7 @@ func TestGetBoardingBalance(t *testing.T) {
 	chainSource := newMockChainSourceActor(epochChan)
 
 	walletActor := NewArk(
-		backend, store, chainSource,
-		fn.None[actor.TellOnlyRef[actormsg.RoundReceivable]](),
+		backend, store, chainSource, nil,
 		btclog.Disabled,
 	)
 
@@ -924,8 +917,7 @@ func TestSendBacklog(t *testing.T) {
 		chainSource := newMockChainSourceActor(epochChan)
 
 		walletActor := NewArk(
-			backend, store, chainSource,
-			fn.None[actor.TellOnlyRef[actormsg.RoundReceivable]](),
+			backend, store, chainSource, nil,
 			btclog.Disabled,
 		)
 
@@ -968,8 +960,7 @@ func TestSendBacklog(t *testing.T) {
 		chainSource := newMockChainSourceActor(epochChan)
 
 		walletActor := NewArk(
-			backend, store, chainSource,
-			fn.None[actor.TellOnlyRef[actormsg.RoundReceivable]](),
+			backend, store, chainSource, nil,
 			btclog.Disabled,
 		)
 
@@ -1018,8 +1009,7 @@ func TestSendBacklog(t *testing.T) {
 		chainSource := newMockChainSourceActor(epochChan)
 
 		walletActor := NewArk(
-			backend, store, chainSource,
-			fn.None[actor.TellOnlyRef[actormsg.RoundReceivable]](),
+			backend, store, chainSource, nil,
 			btclog.Disabled,
 		)
 
@@ -1088,8 +1078,7 @@ func TestSendBacklog(t *testing.T) {
 		chainSource := newMockChainSourceActor(epochChan)
 
 		walletActor := NewArk(
-			backend, store, chainSource,
-			fn.None[actor.TellOnlyRef[actormsg.RoundReceivable]](),
+			backend, store, chainSource, nil,
 			btclog.Disabled,
 		)
 


### PR DESCRIPTION
## Summary

This PR refactors the round actor to use `actormsg` interface types directly in its Receive method signature, enabling service key lookup from the wallet without import cycles. The core problem was Go's generic type invariance: `ActorRef[ClientMsg, ClientResp]` is not assignable to `ActorRef[RoundReceivable, RoundActorResp]` even though ClientMsg embeds RoundReceivable. By changing the round actor to receive the interface types directly, the wallet can now look up the actor using the well-known service key.

The refactoring adds `RoundActorResp` interface and `RoundActorServiceKey()` to the actormsg package, providing a cycle-free path for the wallet to discover and communicate with the round actor. The round package gains a `NewServiceKey()` function with a `WithSuffix` option for test isolation when multiple round actors are needed.

All dependent types were updated to match: the vtxo package's `RoundActor` fields now use `actormsg.RoundReceivable`, and the wallet replaces its explicit `roundActor` field with an `actorSystem` reference for on-demand service key lookup. Test mocks were updated to implement the new interface signatures.

The TestVTXORefreshE2E integration test passes, demonstrating the complete VTXO refresh lifecycle working through the service key lookup mechanism. Unit tests for the round and vtxo packages also pass.