### PR TITLE
vtxo: remove duplicate VTXORequest in refresh outbox

### DIFF
--- a/vtxo/actor.go
+++ b/vtxo/actor.go
@@ -11,7 +11,6 @@ import (
 	"github.com/lightninglabs/darepo-client/baselib/actor"
 	"github.com/lightninglabs/darepo-client/chainsource"
 	"github.com/lightninglabs/darepo-client/lib/actormsg"
-	"github.com/lightninglabs/darepo-client/lib/types"
 	"github.com/lightninglabs/darepo-client/round"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 )
@@ -213,13 +212,16 @@ func (a *VTXOActor) processOutbox(ctx context.Context, outbox []VTXOOutMsg) {
 		case *ForfeitRequest:
 			// Route forfeit request to round actor. This tells
 			// the round to include this VTXO in the forfeit flow.
-			// We also send a separate VTXORequest to explicitly
-			// request a new VTXO for the refreshed value (refresh
-			// no longer automatically creates a replacement VTXO).
+			// The round FSM's RefreshVTXORequest handler creates
+			// the corresponding VTXORequest for the new output via
+			// buildVTXORequestFromRefresh, so we only need to send
+			// the refresh request here.
 			if a.cfg.RoundActor != nil {
 				vtxo := a.cfg.VTXO
 
 				// Send the refresh request for forfeit flow.
+				// The FSM adds both the forfeit input and the
+				// new VTXO output from this single message.
 				refreshReq := &round.RefreshVTXORequest{
 					VTXOOutpoint: m.VTXOOutpoint,
 					Amount:       int64(vtxo.Amount),
@@ -231,23 +233,8 @@ func (a *VTXOActor) processOutbox(ctx context.Context, outbox []VTXOOutMsg) {
 				}
 				a.cfg.RoundActor.Tell(ctx, refreshReq)
 
-				// Also send a VTXORequest to request the new
-				// VTXO output for this refresh.
-				vtxoReq := &round.VTXORequestsReceived{
-					Requests: []types.VTXORequest{{
-						Amount:   vtxo.Amount,
-						PkScript: vtxo.PkScript,
-						Expiry:   vtxo.RelativeExpiry,
-						ClientKey: vtxo.ClientKey.
-							PubKey,
-						OperatorKey: vtxo.OperatorKey,
-						SigningKey:  vtxo.ClientKey,
-					}},
-				}
-				a.cfg.RoundActor.Tell(ctx, vtxoReq)
-
 				a.cfg.Logger.InfoS(
-					ctx, "Sent refresh forfeit and request",
+					ctx, "Sent refresh request to round",
 					slog.String("outpoint", m.VTXOOutpoint.String()),
 				)
 			}

--- a/vtxo/actor_test.go
+++ b/vtxo/actor_test.go
@@ -152,9 +152,10 @@ func TestProcessOutboxStatusUpdate(t *testing.T) {
 }
 
 // TestProcessOutboxForfeitRequest verifies that ForfeitRequest messages in the
-// outbox are routed to the round actor with the correct fields populated. Since
-// refresh is decoupled from VTXO creation, both a RefreshVTXORequest and a
-// VTXORequestsReceived message should be sent.
+// outbox are routed to the round actor as a single RefreshVTXORequest with
+// the correct fields populated. The round FSM handles creating the
+// corresponding VTXORequest for the new output via buildVTXORequestFromRefresh,
+// so only one message is sent.
 func TestProcessOutboxForfeitRequest(t *testing.T) {
 	t.Parallel()
 
@@ -183,11 +184,11 @@ func TestProcessOutboxForfeitRequest(t *testing.T) {
 
 	actor.processOutbox(h.ctx, outbox)
 
-	// Should send both a RefreshVTXORequest and a VTXORequestsReceived.
+	// Should send a single RefreshVTXORequest. The round FSM creates the
+	// VTXORequest for the new output internally.
 	msgs := roundActor.getMessages()
-	require.Len(t, msgs, 2)
+	require.Len(t, msgs, 1)
 
-	// First message should be the refresh request.
 	refreshReq, ok := msgs[0].(*round.RefreshVTXORequest)
 	require.True(t, ok, "expected RefreshVTXORequest, got %T", msgs[0])
 	require.Equal(t, vtxo.Outpoint, refreshReq.VTXOOutpoint)
@@ -195,21 +196,8 @@ func TestProcessOutboxForfeitRequest(t *testing.T) {
 	require.Equal(t, vtxo.ClientKey.PubKey, refreshReq.NewVTXOKey)
 	require.Equal(t, vtxo.OperatorKey, refreshReq.OperatorKey)
 	require.Equal(t, vtxo.RelativeExpiry, refreshReq.Expiry)
-
-	// Second message should be the VTXO request for the new VTXO.
-	vtxoReqMsg, ok := msgs[1].(*round.VTXORequestsReceived)
-	require.True(t, ok, "expected VTXORequestsReceived, got %T", msgs[1])
-	require.Len(t, vtxoReqMsg.Requests, 1)
-
-	vtxoReq := vtxoReqMsg.Requests[0]
-	require.Equal(t, vtxo.Amount, vtxoReq.Amount)
-	require.Equal(t, vtxo.PkScript, vtxoReq.PkScript)
-	require.Equal(t, vtxo.RelativeExpiry, vtxoReq.Expiry)
-	require.Equal(t, vtxo.ClientKey.PubKey, vtxoReq.ClientKey)
-	require.Equal(t, vtxo.OperatorKey, vtxoReq.OperatorKey)
-	require.Equal(
-		t, vtxo.ClientKey.KeyLocator, vtxoReq.SigningKey.KeyLocator,
-	)
+	require.Equal(t, vtxo.PkScript, refreshReq.PkScript)
+	require.Equal(t, vtxo.ClientKey, refreshReq.SigningKey)
 }
 
 // TestProcessOutboxTerminatedNotification verifies that


### PR DESCRIPTION
The VTXO actor's outbox processing for ForfeitRequest was sending two messages to the round actor: a RefreshVTXORequest and a separate VTXORequestsReceived. The round FSM's RefreshVTXORequest handler already creates the corresponding VTXORequest internally via buildVTXORequestFromRefresh, so the explicit VTXORequestsReceived was a duplicate. This caused the FSM to track two VTXO output requests against a single forfeit input, failing validation with "outputs exceed inputs" during round registration.

The fix removes the duplicate VTXORequestsReceived Tell from the VTXO actor's processOutbox handler. The RefreshVTXORequest message alone carries all the information the round FSM needs to track both the forfeit input and the new VTXO output.

The unit test TestProcessOutboxForfeitRequest is updated to expect a single RefreshVTXORequest message instead of two messages. Additional field assertions for PkScript and SigningKey are included to ensure the refresh request carries complete VTXO metadata.

This was caught by the TestVTXORefreshE2E system test which exercises the full refresh lifecycle: boarding, VTXO creation, refresh trigger, forfeit signing, and confirmation. With the fix, all 13 system tests pass.