### PR TITLE
baselib: fix flaky ExampleActorStateMachine output race

### DIFF
--- a/baselib/example/example_actors.go
+++ b/baselib/example/example_actors.go
@@ -37,11 +37,23 @@ type ReviewResp struct {
 }
 
 // ReviewServiceBehavior simulates async review process.
-type ReviewServiceBehavior struct{}
+type ReviewServiceBehavior struct {
+	// startProcessing gates review processing in the example so its
+	// section header is always printed before async actor output.
+	startProcessing <-chan struct{}
+}
 
 // Receive processes review requests.
 func (r *ReviewServiceBehavior) Receive(ctx context.Context,
 	msg ReviewMsg) fn.Result[ReviewResp] {
+
+	if r.startProcessing != nil {
+		select {
+		case <-r.startProcessing:
+		case <-ctx.Done():
+			return fn.Err[ReviewResp](ctx.Err())
+		}
+	}
 
 	fmt.Printf("ReviewService: Processing document %s by %s\n",
 		msg.DocumentID, msg.Author)

--- a/baselib/example/example_test.go
+++ b/baselib/example/example_test.go
@@ -15,6 +15,7 @@ import (
 // ReviewService and NotificationService actors.
 func ExampleActorStateMachine() {
 	ctx := context.Background()
+	reviewStart := make(chan struct{}, 1)
 
 	// Create actor system.
 	system := actor.NewActorSystemWithConfig(actor.SystemConfig{
@@ -25,7 +26,9 @@ func ExampleActorStateMachine() {
 	}()
 
 	// Register ReviewService actor.
-	reviewBehavior := &ReviewServiceBehavior{}
+	reviewBehavior := &ReviewServiceBehavior{
+		startProcessing: reviewStart,
+	}
 	actor.RegisterWithSystem(
 		system, "review-service", ReviewServiceKey, reviewBehavior,
 	)
@@ -53,14 +56,18 @@ func ExampleActorStateMachine() {
 
 	// Submit a document for review.
 	fmt.Println("=== Submitting Document ===")
-	resp1 := fsmRef.Ask(ctx, protofsm.ActorMessage[DocEvent]{
-		Event: EventSubmitDocument{
-			DocumentID: "DOC-123",
-			Author:     "Alice",
+	resp1 := fsmRef.Ask(
+		ctx, protofsm.ActorMessage[DocEvent]{
+			Event: EventSubmitDocument{
+				DocumentID: "DOC-123",
+				Author:     "Alice",
+			},
 		},
-	}).Await(ctx)
+	).Await(ctx)
 
 	if resp1.IsErr() {
+		// Release the review worker in error paths so shutdown is clean.
+		reviewStart <- struct{}{}
 		fmt.Printf("Error: %v\n", resp1.Err())
 		return
 	}
@@ -72,13 +79,16 @@ func ExampleActorStateMachine() {
 	// 4. FSM transitions to Approved and emits OutboxNotify
 	// 5. NotificationService receives and processes notification
 	fmt.Println("\n=== Processing Review ===")
+	reviewStart <- struct{}{}
 	time.Sleep(300 * time.Millisecond)
 
 	// Query current state (using StateQuery flag).
 	fmt.Println("\n=== Checking Final State ===")
-	resp2 := fsmRef.Ask(ctx, protofsm.ActorMessage[DocEvent]{
-		StateQuery: true,
-	}).Await(ctx)
+	resp2 := fsmRef.Ask(
+		ctx, protofsm.ActorMessage[DocEvent]{
+			StateQuery: true,
+		},
+	).Await(ctx)
 
 	if resp2.IsOk() {
 		state2, _ := resp2.Unpack()


### PR DESCRIPTION
## Summary
- gate the review actor in `ExampleActorStateMachine` with a start channel
- release the gate only after printing the `=== Processing Review ===` header
- keep actor example output deterministic for Go example output checks

## Why
`ExampleActorStateMachine` was flaky in CI because async review output could race ahead of the processing header, causing output mismatch in both `test_sqlite` and `test_postgres` unit jobs.

## Validation
- `go test ./baselib/example -run ExampleActorStateMachine -count=30`
- `make unit pkg=./baselib/example case=ExampleActorStateMachine tags="test_sqlite" timeout=5m`
- `make unit pkg=./baselib/example case=ExampleActorStateMachine tags="test_postgres" timeout=5m`
- `make unit log="stdlog trace" pkg=./baselib/example case=ExampleActorStateMachine tags="test_sqlite" timeout=5m`
- `make unit log="stdlog trace" pkg=./baselib/example case=ExampleActorStateMachine tags="test_postgres" timeout=5m`
- `make ast-lint pkg=./baselib/example`
- `make lint`
- `make tidy-module-check`
