### PR TITLE
multi: use mirror.gcr.io for test images

### DIFF
--- a/db/postgres_fixture.go
+++ b/db/postgres_fixture.go
@@ -18,6 +18,7 @@ const (
 	testPgUser   = "test"
 	testPgPass   = "test"
 	testPgDBName = "test"
+	testPgRepo   = "mirror.gcr.io/library/postgres"
 	PostgresTag  = "15"
 )
 
@@ -44,7 +45,7 @@ func NewTestPgFixture(t testing.TB, expiry time.Duration,
 
 	// Pulls an image, creates a container based on it and runs it.
 	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
-		Repository: "postgres",
+		Repository: testPgRepo,
 		Tag:        PostgresTag,
 		Env: []string{
 			fmt.Sprintf("POSTGRES_USER=%v", testPgUser),

--- a/harness/harness.go
+++ b/harness/harness.go
@@ -290,9 +290,11 @@ func DefaultOptions() Options {
 	}
 
 	return Options{
-		BitcoindImage:       "lightninglabs/bitcoin-core:29",
-		LNDImage:            "lightninglabs/lnd:daily-testing-20260115",
-		TapdImage:           "lightninglabs/taproot-assets:v0.7.0-rc1",
+		BitcoindImage: "mirror.gcr.io/lightninglabs/bitcoin-core:29",
+		LNDImage: "mirror.gcr.io/lightninglabs/lnd:" +
+			"daily-testing-20260115",
+		TapdImage: "mirror.gcr.io/lightninglabs/taproot-assets:" +
+			"v0.7.0-rc1",
 		ArtifactsBaseDir:    artifactsBaseDir,
 		HarnessLogStdOut:    *harnessLogStdOut,
 		AlwaysKeepArtifacts: true,
@@ -1191,7 +1193,7 @@ func (h *Harness) startElectrs() {
 		*dockertest.Resource, error) {
 
 		return h.pool.RunWithOptions(&dockertest.RunOptions{
-			Repository:   "mempool/electrs",
+			Repository:   "mirror.gcr.io/mempool/electrs",
 			Tag:          "latest",
 			Cmd:          cmd,
 			Env:          []string{"RUST_BACKTRACE=1"},
@@ -1276,7 +1278,7 @@ func (h *Harness) startPostgres() {
 		*dockertest.Resource, error) {
 
 		return h.pool.RunWithOptions(&dockertest.RunOptions{
-			Repository: "postgres",
+			Repository: "mirror.gcr.io/library/postgres",
 			Tag:        "16-alpine",
 			Env: []string{
 				"POSTGRES_USER=ark",


### PR DESCRIPTION
## Summary
Switch Docker images used by harness/systest and `test_postgres` fixtures to `mirror.gcr.io`.

## Why
CI intermittently fails with Docker Hub unauthenticated pull rate limits (for
example while starting `electrs`). Using `mirror.gcr.io` reduces direct Docker
Hub pull pressure for these test containers.

## Changes
- `harness/harness.go`
  - Default harness images:
    - `lightninglabs/bitcoin-core:29` -> `mirror.gcr.io/lightninglabs/bitcoin-core:29`
    - `lightninglabs/lnd:daily-testing-20260115` -> `mirror.gcr.io/lightninglabs/lnd:daily-testing-20260115`
    - `lightninglabs/taproot-assets:v0.7.0-rc1` -> `mirror.gcr.io/lightninglabs/taproot-assets:v0.7.0-rc1`
  - Hardcoded container pulls:
    - `mempool/electrs:latest` -> `mirror.gcr.io/mempool/electrs:latest`
    - `postgres:16-alpine` -> `mirror.gcr.io/library/postgres:16-alpine`
- `db/postgres_fixture.go`
  - `postgres:15` -> `mirror.gcr.io/library/postgres:15`

## Validation
- `go test ./harness ./db -run TestNonExistent -count=1`
