### PR TITLE
lwwallet: add lightweight in-process wallet

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0
 	github.com/btcsuite/btclog/v2 v2.0.1-0.20250728225537-6090e87c6c5b
 	github.com/btcsuite/btcwallet v0.16.17
+	github.com/btcsuite/btcwallet/wtxmgr v1.5.6
 	github.com/golang-migrate/migrate/v4 v4.17.0
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgconn v1.14.3
@@ -55,7 +56,6 @@ require (
 	github.com/btcsuite/btcwallet/wallet/txrules v1.2.2 // indirect
 	github.com/btcsuite/btcwallet/wallet/txsizes v1.2.5 // indirect
 	github.com/btcsuite/btcwallet/walletdb v1.5.1 // indirect
-	github.com/btcsuite/btcwallet/wtxmgr v1.5.6 // indirect
 	github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd // indirect
 	github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792 // indirect
 	github.com/btcsuite/winsvc v1.0.0 // indirect

--- a/lwwallet/boarding_backend.go
+++ b/lwwallet/boarding_backend.go
@@ -1,0 +1,245 @@
+package lwwallet
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"math"
+	"sync"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/lightninglabs/darepo-client/wallet"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/lnwallet/btcwallet"
+)
+
+// BoardingBackendAdapter implements wallet.BoardingBackend by wrapping
+// btcwallet.BtcWallet for key derivation and script import, while
+// using the Esplora API directly for UTXO queries. This is necessary
+// because btcwallet's internal UTXO tracking skips addresses imported
+// under non-default key scopes (like LND's m/1017' scope), so we
+// query Esplora for UTXOs at imported boarding addresses instead.
+type BoardingBackendAdapter struct {
+	btcWallet   *btcwallet.BtcWallet
+	esplora     *EsploraClient
+	chainParams *chaincfg.Params
+
+	// log is the structured logger for this boarding backend
+	// instance.
+	log btclog.Logger
+
+	// chainKeyScope is the key scope used for script imports.
+	// This matches LND's m/1017'/coinType' derivation.
+	chainKeyScope waddrmgr.KeyScope
+
+	// mu protects importedAddrs.
+	mu sync.Mutex
+
+	// importedAddrs tracks addresses imported via ImportTaprootScript.
+	// ListUnspent queries Esplora for UTXOs at each of these
+	// addresses, since btcwallet's internal UTXO tracking skips
+	// non-default scope addresses in its addRelevantTx credit
+	// marking.
+	importedAddrs map[string]btcutil.Address
+}
+
+// NewBoardingBackendAdapter creates a new boarding backend adapter
+// wrapping the given btcwallet instance.
+func NewBoardingBackendAdapter(btcw *btcwallet.BtcWallet,
+	esplora *EsploraClient, chainParams *chaincfg.Params,
+	coinType uint32, logger btclog.Logger) *BoardingBackendAdapter {
+
+	return &BoardingBackendAdapter{
+		btcWallet:   btcw,
+		esplora:     esplora,
+		chainParams: chainParams,
+		log:         logger,
+		chainKeyScope: waddrmgr.KeyScope{
+			Purpose: keychain.BIP0043Purpose,
+			Coin:    coinType,
+		},
+		importedAddrs: make(map[string]btcutil.Address),
+	}
+}
+
+// DeriveNextKey derives the next key in the specified key family. This
+// delegates to btcwallet's keyring which uses the waddrmgr for HD key
+// derivation following the m/1017'/coinType'/family'/0/index path.
+func (b *BoardingBackendAdapter) DeriveNextKey(ctx context.Context,
+	family keychain.KeyFamily) (*keychain.KeyDescriptor, error) {
+
+	keyRing := keychain.NewBtcWalletKeyRing(
+		b.btcWallet.InternalWallet(),
+		b.chainKeyScope.Coin,
+	)
+
+	desc, err := keyRing.DeriveNextKey(family)
+	if err != nil {
+		return nil, fmt.Errorf("derive next key: %w", err)
+	}
+
+	b.log.DebugS(ctx, "Derived next key",
+		slog.Int("family", int(family)),
+		slog.Int("index", int(desc.Index)))
+
+	return &desc, nil
+}
+
+// ImportTaprootScript imports a taproot script into btcwallet and
+// tracks the resulting address for Esplora-based UTXO queries. The
+// import into btcwallet registers the address for chain notifications
+// via NotifyReceived, while the local address tracking enables
+// ListUnspent to query Esplora directly.
+func (b *BoardingBackendAdapter) ImportTaprootScript(
+	ctx context.Context,
+	script *waddrmgr.Tapscript) (btcutil.Address, error) {
+
+	managedAddr, err := b.btcWallet.ImportTaprootScript(
+		b.chainKeyScope, script,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"import taproot script: %w", err,
+		)
+	}
+
+	addr := managedAddr.Address()
+
+	// Track the imported address so ListUnspent can query
+	// Esplora for UTXOs at this address. We use Esplora
+	// directly because btcwallet's addRelevantTx skips credit
+	// marking for non-default scope addresses (1017).
+	b.mu.Lock()
+	b.importedAddrs[addr.String()] = addr
+	b.mu.Unlock()
+
+	b.log.DebugS(ctx,
+		"Imported taproot script via btcwallet",
+		slog.String("address", addr.String()),
+		slog.Int("tracked_addrs", len(b.importedAddrs)))
+
+	return addr, nil
+}
+
+// ListUnspent returns UTXOs at all imported boarding addresses by
+// querying the Esplora API directly. This bypasses btcwallet's
+// internal UTXO tracking, which skips credit marking for addresses
+// in non-default key scopes (like LND's m/1017' scope). For each
+// imported address, Esplora's /address/:addr/utxo endpoint is
+// queried and results are filtered by confirmation count.
+func (b *BoardingBackendAdapter) ListUnspent(ctx context.Context,
+	minConfs, maxConfs int32) ([]*wallet.Utxo, error) {
+
+	// Treat maxConfs of 0 as "no upper bound" so callers that
+	// omit the parameter don't accidentally filter everything.
+	if maxConfs == 0 {
+		maxConfs = math.MaxInt32
+	}
+
+	// Get the current tip height for confirmation calculation.
+	tipHeight, err := b.esplora.GetTipHeight()
+	if err != nil {
+		return nil, fmt.Errorf("get tip height: %w", err)
+	}
+
+	b.mu.Lock()
+	addrs := make(map[string]btcutil.Address, len(b.importedAddrs))
+	for k, v := range b.importedAddrs {
+		addrs[k] = v
+	}
+	b.mu.Unlock()
+
+	var utxos []*wallet.Utxo
+
+	for addrStr, addr := range addrs {
+		esploraUtxos, err := b.esplora.GetAddressUtxos(addrStr)
+		if err != nil {
+			b.log.WarnS(ctx,
+				"Failed to query Esplora for address UTXOs",
+				err,
+				slog.String("address", addrStr))
+
+			continue
+		}
+
+		// Compute the pkScript for this address once, then
+		// reuse it for all UTXOs at this address.
+		pkScript, err := txscript.PayToAddrScript(addr)
+		if err != nil {
+			continue
+		}
+
+		for _, eu := range esploraUtxos {
+			// Compute confirmations from block height.
+			var confs int32
+			if eu.Status.Confirmed {
+				confs = tipHeight -
+					int32(eu.Status.BlockHeight) + 1
+			}
+
+			// Apply confirmation filters.
+			if confs < minConfs || confs > maxConfs {
+				continue
+			}
+
+			txid, err := chainhash.NewHashFromStr(eu.Txid)
+			if err != nil {
+				continue
+			}
+
+			utxos = append(utxos, &wallet.Utxo{
+				Outpoint: wire.OutPoint{
+					Hash:  *txid,
+					Index: eu.Vout,
+				},
+				PkScript:      pkScript,
+				Amount:        btcutil.Amount(eu.Value),
+				Confirmations: confs,
+			})
+		}
+	}
+
+	b.log.DebugS(ctx, "ListUnspent called",
+		slog.Int("min_confs", int(minConfs)),
+		slog.Int("max_confs", int(maxConfs)),
+		slog.Int("tracked_addrs", len(addrs)),
+		slog.Int("utxo_count", len(utxos)))
+
+	return utxos, nil
+}
+
+// GetTransaction returns the full transaction for the given txid.
+// It first attempts to fetch from btcwallet's transaction store,
+// falling back to the Esplora API for transactions not yet indexed
+// by the wallet.
+func (b *BoardingBackendAdapter) GetTransaction(ctx context.Context,
+	txid chainhash.Hash) (*wire.MsgTx, error) {
+
+	// Try btcwallet's transaction store first.
+	tx, err := b.btcWallet.FetchTx(txid)
+	if err == nil && tx != nil {
+		return tx, nil
+	}
+
+	// Fall back to Esplora for transactions not in the wallet DB.
+	b.log.DebugS(ctx,
+		"Transaction not in wallet, falling back to Esplora",
+		slog.String("txid", txid.String()))
+
+	tx, err = b.esplora.GetRawTx(txid)
+	if err != nil {
+		return nil, fmt.Errorf("get transaction: %w", err)
+	}
+
+	return tx, nil
+}
+
+// Compile-time check that BoardingBackendAdapter implements
+// wallet.BoardingBackend.
+var _ wallet.BoardingBackend = (*BoardingBackendAdapter)(nil)

--- a/lwwallet/chain_backend.go
+++ b/lwwallet/chain_backend.go
@@ -1,0 +1,744 @@
+package lwwallet
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"math"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/chainsource"
+)
+
+// confRegistration tracks a pending confirmation registration within the
+// polling loop.
+type confRegistration struct {
+	// txid is the transaction ID to monitor (nil to match by script).
+	txid *chainhash.Hash
+
+	// pkScript is the output script to watch.
+	pkScript []byte
+
+	// numConfs is the target confirmation count.
+	numConfs uint32
+
+	// heightHint is the earliest block that could contain the tx.
+	heightHint uint32
+
+	// includeBlock requests the full block in the confirmation event.
+	includeBlock bool
+
+	// confChan is the channel to send the confirmation on.
+	confChan chan *chainsource.TxConfirmation
+
+	// cancelCh signals that this registration has been cancelled.
+	cancelCh chan struct{}
+}
+
+// spendRegistration tracks a pending spend registration within the
+// polling loop.
+type spendRegistration struct {
+	// outpoint is the output to monitor for spending.
+	outpoint *wire.OutPoint
+
+	// pkScript is the output script to watch.
+	pkScript []byte
+
+	// heightHint is the earliest block that could contain the spend.
+	heightHint uint32
+
+	// spendChan is the channel to send the spend detail on.
+	spendChan chan *chainsource.SpendDetail
+
+	// cancelCh signals that this registration has been cancelled.
+	cancelCh chan struct{}
+}
+
+// blockRegistration tracks a block epoch subscription.
+type blockRegistration struct {
+	// epochChan is the channel to send new block epochs on.
+	epochChan chan *chainsource.BlockEpoch
+
+	// cancelCh signals that this registration has been cancelled.
+	cancelCh chan struct{}
+}
+
+// ChainBackend implements chainsource.ChainBackend using an Esplora HTTP
+// client with polling-based chain monitoring. The backend periodically
+// polls the Esplora API for new blocks and checks pending confirmation
+// and spend registrations against the current chain state.
+type ChainBackend struct {
+	esplora      *EsploraClient
+	pollInterval time.Duration
+
+	// log is the structured logger for this chain backend instance.
+	log btclog.Logger
+
+	// mu protects bestHeight, bestHash, and the registration maps.
+	// Using a single mutex for the chain tip avoids a race window
+	// where height and hash could be read in an inconsistent state
+	// (e.g. height updated but hash not yet).
+	mu         sync.Mutex
+	bestHeight int32
+	bestHash   chainhash.Hash
+
+	confRegs  map[uint64]*confRegistration
+	spendRegs map[uint64]*spendRegistration
+	blockRegs map[uint64]*blockRegistration
+	nextRegID uint64
+
+	stopCh   chan struct{}
+	stopOnce sync.Once
+	wg       sync.WaitGroup
+}
+
+// NewChainBackend creates a new Esplora-backed chain backend. The
+// pollInterval controls how frequently the backend checks for new blocks
+// and updates to pending registrations.
+func NewChainBackend(esplora *EsploraClient,
+	pollInterval time.Duration,
+	logger btclog.Logger) *ChainBackend {
+
+	return &ChainBackend{
+		esplora:      esplora,
+		pollInterval: pollInterval,
+		log:          logger,
+		confRegs:     make(map[uint64]*confRegistration),
+		spendRegs:    make(map[uint64]*spendRegistration),
+		blockRegs:    make(map[uint64]*blockRegistration),
+		stopCh:       make(chan struct{}),
+	}
+}
+
+// Start initializes the chain backend by fetching the current chain tip
+// and starting the polling loop.
+func (b *ChainBackend) Start() error {
+	// Fetch the initial chain tip. We get height first, then
+	// resolve the hash for that specific height to avoid drift
+	// if a new block arrives between the two HTTP calls.
+	height, err := b.esplora.GetTipHeight()
+	if err != nil {
+		return fmt.Errorf("get initial tip: %w", err)
+	}
+
+	hash, err := b.esplora.GetBlockHashByHeight(height)
+	if err != nil {
+		return fmt.Errorf("get initial hash: %w", err)
+	}
+
+	b.mu.Lock()
+	b.bestHeight = height
+	b.bestHash = hash
+	b.mu.Unlock()
+
+	// Start the polling loop.
+	b.wg.Add(1)
+	go b.pollLoop()
+
+	b.log.InfoS(context.Background(), "Chain backend started",
+		slog.Int("tip_height", int(height)),
+		slog.String("tip_hash", hash.String()))
+
+	return nil
+}
+
+// Stop shuts down the polling loop and cleans up resources. Stop is
+// idempotent and safe to call multiple times; the stop channel is
+// closed exactly once.
+func (b *ChainBackend) Stop() error {
+	b.log.InfoS(context.Background(), "Stopping chain backend")
+
+	b.stopOnce.Do(func() {
+		close(b.stopCh)
+	})
+	b.wg.Wait()
+
+	b.log.InfoS(context.Background(), "Chain backend stopped")
+
+	return nil
+}
+
+// EstimateFee returns the estimated fee rate in satoshis per vbyte for a
+// transaction to confirm within the target number of blocks.
+func (b *ChainBackend) EstimateFee(_ context.Context,
+	targetConf uint32) (btcutil.Amount, error) {
+
+	estimates, err := b.esplora.GetFeeEstimates()
+	if err != nil {
+		return 0, fmt.Errorf("get fee estimates: %w", err)
+	}
+
+	if len(estimates) == 0 {
+		return 0, fmt.Errorf("no fee estimates available")
+	}
+
+	// Find the closest confirmation target in the estimates map.
+	// Esplora returns estimates keyed by confirmation target as strings.
+	var (
+		bestRate   float64
+		bestTarget uint32 = math.MaxUint32
+	)
+
+	for targetStr, rate := range estimates {
+		target, err := strconv.ParseUint(targetStr, 10, 32)
+		if err != nil {
+			continue
+		}
+
+		t := uint32(target)
+
+		// Find the smallest target that is >= our desired target.
+		// If none exists, fall back to the largest available target.
+		if t >= targetConf && t < bestTarget {
+			bestTarget = t
+			bestRate = rate
+		}
+	}
+
+	// If no target >= our desired was found, use the largest available
+	// target (highest confirmation time = lowest fee).
+	if bestTarget == math.MaxUint32 {
+		var maxTarget uint32
+		for targetStr, rate := range estimates {
+			target, err := strconv.ParseUint(
+				targetStr, 10, 32,
+			)
+			if err != nil {
+				continue
+			}
+
+			if uint32(target) > maxTarget {
+				maxTarget = uint32(target)
+				bestRate = rate
+			}
+		}
+	}
+
+	// Ensure at least 1 sat/vB.
+	if bestRate < 1.0 {
+		bestRate = 1.0
+	}
+
+	return btcutil.Amount(math.Ceil(bestRate)), nil
+}
+
+// BestBlock returns the current best block height and hash.
+func (b *ChainBackend) BestBlock(_ context.Context) (int32,
+	chainhash.Hash, error) {
+
+	b.mu.Lock()
+	height := b.bestHeight
+	hash := b.bestHash
+	b.mu.Unlock()
+
+	return height, hash, nil
+}
+
+// TestMempoolAccept is not supported by the Esplora backend. This matches
+// the LND backend behavior.
+func (b *ChainBackend) TestMempoolAccept(_ context.Context,
+	_ *wire.MsgTx) (bool, string, error) {
+
+	return false, "", fmt.Errorf("test mempool accept not supported " +
+		"by Esplora backend")
+}
+
+// BroadcastTx broadcasts a transaction via the Esplora API.
+func (b *ChainBackend) BroadcastTx(_ context.Context,
+	tx *wire.MsgTx, _ string) error {
+
+	_, err := b.esplora.BroadcastTx(tx)
+	if err != nil {
+		return fmt.Errorf("broadcast tx: %w", err)
+	}
+
+	return nil
+}
+
+// RegisterConf registers for confirmation notifications of a transaction.
+func (b *ChainBackend) RegisterConf(ctx context.Context,
+	txid *chainhash.Hash, pkScript []byte, numConfs uint32,
+	heightHint uint32,
+	includeBlock bool) (*chainsource.ConfRegistration, error) {
+
+	confChan := make(chan *chainsource.TxConfirmation, 1)
+	cancelCh := make(chan struct{})
+
+	reg := &confRegistration{
+		txid:         txid,
+		pkScript:     pkScript,
+		numConfs:     numConfs,
+		heightHint:   heightHint,
+		includeBlock: includeBlock,
+		confChan:     confChan,
+		cancelCh:     cancelCh,
+	}
+
+	b.mu.Lock()
+	id := b.nextRegID
+	b.nextRegID++
+	b.confRegs[id] = reg
+	b.mu.Unlock()
+
+	var txidStr string
+	if txid != nil {
+		txidStr = txid.String()
+	}
+
+	b.log.DebugS(ctx, "Registered confirmation watch",
+		slog.Uint64("reg_id", id),
+		slog.String("txid", txidStr),
+		slog.Int("num_confs", int(numConfs)),
+		slog.Int("height_hint", int(heightHint)))
+
+	cancelFn := func() {
+		close(cancelCh)
+
+		b.mu.Lock()
+		delete(b.confRegs, id)
+		b.mu.Unlock()
+	}
+
+	return &chainsource.ConfRegistration{
+		Confirmed: confChan,
+		Cancel:    cancelFn,
+	}, nil
+}
+
+// RegisterSpend registers for spend notifications of a transaction output.
+func (b *ChainBackend) RegisterSpend(ctx context.Context,
+	outpoint *wire.OutPoint, pkScript []byte,
+	heightHint uint32) (*chainsource.SpendRegistration, error) {
+
+	spendChan := make(chan *chainsource.SpendDetail, 1)
+	cancelCh := make(chan struct{})
+
+	reg := &spendRegistration{
+		outpoint:   outpoint,
+		pkScript:   pkScript,
+		heightHint: heightHint,
+		spendChan:  spendChan,
+		cancelCh:   cancelCh,
+	}
+
+	b.mu.Lock()
+	id := b.nextRegID
+	b.nextRegID++
+	b.spendRegs[id] = reg
+	b.mu.Unlock()
+
+	var outpointStr string
+	if outpoint != nil {
+		outpointStr = outpoint.String()
+	}
+
+	b.log.DebugS(ctx, "Registered spend watch",
+		slog.Uint64("reg_id", id),
+		slog.String("outpoint", outpointStr),
+		slog.Int("height_hint", int(heightHint)))
+
+	cancelFn := func() {
+		close(cancelCh)
+
+		b.mu.Lock()
+		delete(b.spendRegs, id)
+		b.mu.Unlock()
+	}
+
+	return &chainsource.SpendRegistration{
+		Spend:  spendChan,
+		Cancel: cancelFn,
+	}, nil
+}
+
+// RegisterBlocks registers for new block notifications.
+func (b *ChainBackend) RegisterBlocks(
+	_ context.Context) (*chainsource.BlockRegistration, error) {
+
+	epochChan := make(chan *chainsource.BlockEpoch, 10)
+	cancelCh := make(chan struct{})
+
+	reg := &blockRegistration{
+		epochChan: epochChan,
+		cancelCh:  cancelCh,
+	}
+
+	b.mu.Lock()
+	id := b.nextRegID
+	b.nextRegID++
+	b.blockRegs[id] = reg
+	b.mu.Unlock()
+
+	cancelFn := func() {
+		close(cancelCh)
+
+		b.mu.Lock()
+		delete(b.blockRegs, id)
+		b.mu.Unlock()
+	}
+
+	return &chainsource.BlockRegistration{
+		Epochs: epochChan,
+		Cancel: cancelFn,
+	}, nil
+}
+
+// pollLoop is the main polling goroutine. It periodically checks for new
+// blocks and processes pending registrations.
+func (b *ChainBackend) pollLoop() {
+	defer b.wg.Done()
+
+	ticker := time.NewTicker(b.pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			b.poll()
+
+		case <-b.stopCh:
+			return
+		}
+	}
+}
+
+// poll performs a single polling iteration: checks for new blocks and
+// processes pending confirmation and spend registrations.
+func (b *ChainBackend) poll() {
+	// Check for new blocks.
+	newHeight, err := b.esplora.GetTipHeight()
+	if err != nil {
+		b.log.WarnS(context.Background(), "Poll tip height failed", err)
+		return
+	}
+
+	b.mu.Lock()
+	oldHeight := b.bestHeight
+	b.mu.Unlock()
+
+	if newHeight <= oldHeight {
+		// No new blocks, but still check registrations in case
+		// of reorgs or newly broadcast transactions.
+		b.checkConfirmations()
+		b.checkSpends()
+		return
+	}
+
+	// Process each new block height.
+	for height := oldHeight + 1; height <= newHeight; height++ {
+		hash, err := b.esplora.GetBlockHashByHeight(height)
+		if err != nil {
+			b.log.WarnS(
+				context.Background(),
+				"Poll block hash failed", err,
+			)
+
+			return
+		}
+
+		// Fetch block metadata for timestamp.
+		blockInfo, err := b.esplora.GetBlockHeader(hash)
+		if err != nil {
+			b.log.WarnS(
+				context.Background(),
+				"Poll block header failed", err,
+			)
+
+			return
+		}
+
+		b.log.DebugS(context.Background(), "New block processed",
+			slog.Int("height", int(height)),
+			slog.String("hash", hash.String()))
+
+		// Notify block subscribers and update the best known
+		// tip atomically under the same lock.
+		epoch := &chainsource.BlockEpoch{
+			Hash:      hash,
+			Height:    height,
+			Timestamp: blockInfo.Timestamp,
+		}
+
+		b.mu.Lock()
+		b.bestHeight = height
+		b.bestHash = hash
+
+		for _, reg := range b.blockRegs {
+			select {
+			case reg.epochChan <- epoch:
+
+			case <-reg.cancelCh:
+
+			default:
+				// Channel full, skip this block for this
+				// subscriber. The subscriber will catch up
+				// on the next poll.
+			}
+		}
+		b.mu.Unlock()
+	}
+
+	// Check registrations after processing new blocks.
+	b.checkConfirmations()
+	b.checkSpends()
+}
+
+// checkConfirmations iterates over all pending confirmation registrations
+// and checks their status via the Esplora API.
+func (b *ChainBackend) checkConfirmations() {
+	b.mu.Lock()
+	regs := make(map[uint64]*confRegistration, len(b.confRegs))
+	for id, reg := range b.confRegs {
+		regs[id] = reg
+	}
+	currentHeight := b.bestHeight
+	b.mu.Unlock()
+
+	for id, reg := range regs {
+		// Skip cancelled registrations.
+		select {
+		case <-reg.cancelCh:
+			continue
+
+		default:
+		}
+
+		conf := b.checkSingleConf(reg, currentHeight)
+		if conf == nil {
+			continue
+		}
+
+		// Send the confirmation.
+		select {
+		case reg.confChan <- conf:
+
+		case <-reg.cancelCh:
+			continue
+		}
+
+		b.log.DebugS(context.Background(),
+			"Confirmation registration fulfilled",
+			slog.Uint64("reg_id", id),
+			slog.Int("block_height",
+				int(conf.BlockHeight)))
+
+		// Remove the fulfilled registration.
+		b.mu.Lock()
+		delete(b.confRegs, id)
+		b.mu.Unlock()
+	}
+}
+
+// checkSpends iterates over all pending spend registrations and checks
+// their status via the Esplora API.
+// checkSingleConf checks whether a single confirmation registration is
+// satisfied. When the registration has a txid, it queries the tx status
+// directly. When the txid is nil, it scans the script's UTXOs to find
+// a confirmed transaction matching the pkScript.
+func (b *ChainBackend) checkSingleConf(reg *confRegistration,
+	currentHeight int32) *chainsource.TxConfirmation {
+
+	if reg.txid != nil {
+		return b.checkConfByTxid(reg, currentHeight)
+	}
+
+	return b.checkConfByScript(reg, currentHeight)
+}
+
+// checkConfByTxid checks confirmation status for a registration that
+// has an explicit txid.
+func (b *ChainBackend) checkConfByTxid(reg *confRegistration,
+	currentHeight int32) *chainsource.TxConfirmation {
+
+	status, err := b.esplora.GetTxStatus(*reg.txid)
+	if err != nil {
+		return nil
+	}
+
+	if !status.Confirmed {
+		return nil
+	}
+
+	// Check if we have enough confirmations.
+	confHeight := int32(status.BlockHeight)
+	confs := currentHeight - confHeight + 1
+	if confs < int32(reg.numConfs) {
+		return nil
+	}
+
+	// Build the confirmation event.
+	blockHash, err := chainhash.NewHashFromStr(status.BlockHash)
+	if err != nil {
+		return nil
+	}
+
+	tx, err := b.esplora.GetRawTx(*reg.txid)
+	if err != nil {
+		return nil
+	}
+
+	conf := &chainsource.TxConfirmation{
+		BlockHash:   blockHash,
+		BlockHeight: status.BlockHeight,
+		Tx:          tx,
+	}
+
+	// Fetch the full block if requested.
+	if reg.includeBlock {
+		block, err := b.esplora.GetRawBlock(*blockHash)
+		if err == nil {
+			conf.Block = block
+		}
+	}
+
+	return conf
+}
+
+// checkConfByScript checks confirmation status by scanning the pkScript's
+// UTXOs for a confirmed transaction. This is used when txid is nil and
+// the caller wants to monitor for any payment to the script.
+func (b *ChainBackend) checkConfByScript(reg *confRegistration,
+	currentHeight int32) *chainsource.TxConfirmation {
+
+	utxos, err := b.esplora.GetScriptUtxos(reg.pkScript)
+	if err != nil {
+		return nil
+	}
+
+	for _, utxo := range utxos {
+		if !utxo.Status.Confirmed {
+			continue
+		}
+
+		confHeight := int32(utxo.Status.BlockHeight)
+		confs := currentHeight - confHeight + 1
+		if confs < int32(reg.numConfs) {
+			continue
+		}
+
+		txid, err := chainhash.NewHashFromStr(utxo.Txid)
+		if err != nil {
+			continue
+		}
+
+		blockHash, err := chainhash.NewHashFromStr(
+			utxo.Status.BlockHash,
+		)
+		if err != nil {
+			continue
+		}
+
+		tx, err := b.esplora.GetRawTx(*txid)
+		if err != nil {
+			continue
+		}
+
+		conf := &chainsource.TxConfirmation{
+			BlockHash:   blockHash,
+			BlockHeight: uint32(utxo.Status.BlockHeight),
+			Tx:          tx,
+		}
+
+		if reg.includeBlock {
+			block, err := b.esplora.GetRawBlock(*blockHash)
+			if err == nil {
+				conf.Block = block
+			}
+		}
+
+		return conf
+	}
+
+	return nil
+}
+
+// checkSpends iterates over all pending spend registrations and checks
+// their status via the Esplora API.
+func (b *ChainBackend) checkSpends() {
+	b.mu.Lock()
+	regs := make(map[uint64]*spendRegistration, len(b.spendRegs))
+	for id, reg := range b.spendRegs {
+		regs[id] = reg
+	}
+	b.mu.Unlock()
+
+	for id, reg := range regs {
+		// Skip cancelled registrations.
+		select {
+		case <-reg.cancelCh:
+			continue
+
+		default:
+		}
+
+		if reg.outpoint == nil {
+			continue
+		}
+
+		outspend, err := b.esplora.GetOutspend(
+			reg.outpoint.Hash, reg.outpoint.Index,
+		)
+		if err != nil {
+			continue
+		}
+
+		if !outspend.Spent {
+			continue
+		}
+
+		if !outspend.Status.Confirmed {
+			continue
+		}
+
+		// Parse the spending transaction ID.
+		spenderHash, err := chainhash.NewHashFromStr(outspend.Txid)
+		if err != nil {
+			continue
+		}
+
+		// Fetch the full spending transaction.
+		spendingTx, err := b.esplora.GetRawTx(*spenderHash)
+		if err != nil {
+			continue
+		}
+
+		detail := &chainsource.SpendDetail{
+			SpentOutPoint:     reg.outpoint,
+			SpenderTxHash:     spenderHash,
+			SpendingTx:        spendingTx,
+			SpenderInputIndex: outspend.Vin,
+			SpendingHeight:    int32(outspend.Status.BlockHeight),
+		}
+
+		// Send the spend detail.
+		select {
+		case reg.spendChan <- detail:
+
+		case <-reg.cancelCh:
+			continue
+		}
+
+		b.log.DebugS(context.Background(),
+			"Spend registration fulfilled",
+			slog.Uint64("reg_id", id),
+			slog.String("outpoint",
+				reg.outpoint.String()),
+			slog.String("spender_txid",
+				spenderHash.String()))
+
+		// Remove the fulfilled registration.
+		b.mu.Lock()
+		delete(b.spendRegs, id)
+		b.mu.Unlock()
+	}
+}
+
+// Compile-time check that ChainBackend implements
+// chainsource.ChainBackend.
+var _ chainsource.ChainBackend = (*ChainBackend)(nil)

--- a/lwwallet/chain_backend_test.go
+++ b/lwwallet/chain_backend_test.go
@@ -1,0 +1,457 @@
+package lwwallet
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// mockEsploraServer creates a test HTTP server that simulates
+// an Esplora API. The handler is fully customizable via the
+// provided handlerFn.
+func mockEsploraServer(t *testing.T,
+	handlerFn http.HandlerFunc) *httptest.Server {
+
+	t.Helper()
+
+	srv := httptest.NewServer(handlerFn)
+	t.Cleanup(srv.Close)
+
+	return srv
+}
+
+// TestChainBackendStartStop verifies that the chain backend can
+// be started and stopped cleanly.
+func TestChainBackendStartStop(t *testing.T) {
+	t.Parallel()
+
+	srv := mockEsploraServer(
+		t, func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/blocks/tip/height":
+				fmt.Fprint(w, "100")
+
+			case "/block-height/100":
+				h := chainhash.HashH([]byte("test"))
+				fmt.Fprint(w, h.String())
+
+			default:
+				http.Error(
+					w, "not found",
+					http.StatusNotFound,
+				)
+			}
+		},
+	)
+
+	esplora := NewEsploraClient(srv.URL, btclog.Disabled)
+	backend := NewChainBackend(esplora, 50*time.Millisecond, btclog.Disabled)
+
+	err := backend.Start()
+	require.NoError(t, err)
+
+	// Verify BestBlock returns the initial tip.
+	height, hash, err := backend.BestBlock(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, int32(100), height)
+	require.NotEqual(t, chainhash.Hash{}, hash)
+
+	err = backend.Stop()
+	require.NoError(t, err)
+}
+
+// TestChainBackendBlockNotification verifies that new blocks
+// trigger notifications to registered block subscribers.
+func TestChainBackendBlockNotification(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu          sync.Mutex
+		tipHeight   int32 = 100
+		blockHashes       = make(map[int32]chainhash.Hash)
+	)
+
+	// Pre-generate block hashes.
+	for h := int32(100); h <= 103; h++ {
+		blockHashes[h] = chainhash.HashH(
+			[]byte(fmt.Sprintf("block-%d", h)),
+		)
+	}
+
+	srv := mockEsploraServer(
+		t, func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			currentHeight := tipHeight
+			mu.Unlock()
+
+			switch r.URL.Path {
+			case "/blocks/tip/height":
+				fmt.Fprintf(w, "%d", currentHeight)
+
+			case "/blocks/tip/hash":
+				mu.Lock()
+				h := blockHashes[tipHeight]
+				mu.Unlock()
+				fmt.Fprint(w, h.String())
+
+			default:
+				handleBlockReqs(
+					t, w, r, &mu, blockHashes,
+				)
+			}
+		},
+	)
+
+	esplora := NewEsploraClient(srv.URL, btclog.Disabled)
+	backend := NewChainBackend(esplora, 50*time.Millisecond, btclog.Disabled)
+
+	err := backend.Start()
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, backend.Stop())
+	}()
+
+	// Register for blocks.
+	blockReg, err := backend.RegisterBlocks(t.Context())
+	require.NoError(t, err)
+	defer blockReg.Cancel()
+
+	// Advance the tip.
+	mu.Lock()
+	tipHeight = 101
+	mu.Unlock()
+
+	// Wait for the block notification.
+	select {
+	case epoch := <-blockReg.Epochs:
+		require.Equal(t, int32(101), epoch.Height)
+		require.Equal(t, blockHashes[101], epoch.Hash)
+
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for block notification")
+	}
+}
+
+// handleBlockReqs handles /block-height/:height and /block/:hash
+// requests in the mock Esplora server.
+func handleBlockReqs(t *testing.T, w http.ResponseWriter,
+	r *http.Request, mu *sync.Mutex,
+	blockHashes map[int32]chainhash.Hash) {
+
+	t.Helper()
+
+	// Handle /block-height/:height.
+	var height int32
+	if _, err := fmt.Sscanf(
+		r.URL.Path, "/block-height/%d", &height,
+	); err == nil {
+		mu.Lock()
+		h, ok := blockHashes[height]
+		mu.Unlock()
+
+		if ok {
+			fmt.Fprint(w, h.String())
+		} else {
+			http.Error(
+				w, "not found",
+				http.StatusNotFound,
+			)
+		}
+
+		return
+	}
+
+	// Handle /block/:hash (block header).
+	for _, h := range blockHashes {
+		hashStr := h.String()
+		path := "/block/" + hashStr
+		if r.URL.Path == path {
+			resp := esploraBlock{
+				ID:        hashStr,
+				Height:    100,
+				Timestamp: 1700000000,
+			}
+
+			err := json.NewEncoder(w).Encode(resp)
+			require.NoError(t, err)
+
+			return
+		}
+	}
+
+	http.Error(w, "not found", http.StatusNotFound)
+}
+
+// TestChainBackendEstimateFee verifies fee estimation from
+// Esplora data.
+func TestChainBackendEstimateFee(t *testing.T) {
+	t.Parallel()
+
+	srv := mockEsploraServer(
+		t, func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/blocks/tip/height":
+				fmt.Fprint(w, "100")
+
+			case "/block-height/100":
+				h := chainhash.HashH([]byte("test"))
+				fmt.Fprint(w, h.String())
+
+			case "/fee-estimates":
+				estimates := map[string]float64{
+					"1":  25.5,
+					"3":  15.2,
+					"6":  10.1,
+					"25": 5.3,
+				}
+
+				err := json.NewEncoder(w).Encode(
+					estimates,
+				)
+				require.NoError(t, err)
+
+			default:
+				http.Error(
+					w, "not found",
+					http.StatusNotFound,
+				)
+			}
+		},
+	)
+
+	esplora := NewEsploraClient(srv.URL, btclog.Disabled)
+	backend := NewChainBackend(esplora, time.Hour, btclog.Disabled)
+
+	err := backend.Start()
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, backend.Stop())
+	}()
+
+	// Request fee for 3-block target.
+	fee, err := backend.EstimateFee(t.Context(), 3)
+	require.NoError(t, err)
+
+	// Should pick the "3" bucket: 15.2 -> ceil -> 16.
+	require.Equal(t, int64(16), int64(fee))
+
+	// Request fee for 10-block target (should pick "25" bucket
+	// as closest >= target).
+	fee, err = backend.EstimateFee(t.Context(), 10)
+	require.NoError(t, err)
+
+	// Should pick "25" bucket: 5.3 -> ceil -> 6.
+	require.Equal(t, int64(6), int64(fee))
+}
+
+// TestChainBackendTestMempoolAccept verifies that
+// TestMempoolAccept returns an unsupported error.
+func TestChainBackendTestMempoolAccept(t *testing.T) {
+	t.Parallel()
+
+	esplora := NewEsploraClient("http://unused", btclog.Disabled)
+	backend := NewChainBackend(esplora, time.Hour, btclog.Disabled)
+
+	ok, reason, err := backend.TestMempoolAccept(
+		t.Context(), nil,
+	)
+	require.Error(t, err)
+	require.False(t, ok)
+	require.Empty(t, reason)
+	require.Contains(t, err.Error(), "not supported")
+}
+
+// TestChainBackendConfRegistration verifies that confirmation
+// registrations fire when a transaction reaches the target
+// confirmation count.
+func TestChainBackendConfRegistration(t *testing.T) {
+	t.Parallel()
+
+	txid := chainhash.HashH([]byte("test-tx"))
+
+	srv := mockEsploraServer(
+		t, func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/blocks/tip/height":
+				fmt.Fprint(w, "105")
+
+			case "/block-height/105":
+				h := chainhash.HashH(
+					[]byte("block-105"),
+				)
+				fmt.Fprint(w, h.String())
+
+			case "/tx/" + txid.String() + "/status":
+				status := esploraTxStatus{
+					Confirmed:   true,
+					BlockHeight: 100,
+					BlockHash: chainhash.HashH(
+						[]byte("block-100"),
+					).String(),
+				}
+
+				err := json.NewEncoder(w).Encode(
+					status,
+				)
+				require.NoError(t, err)
+
+			case "/tx/" + txid.String() + "/raw":
+				_, err := w.Write(minimalRawTx())
+				require.NoError(t, err)
+
+			default:
+				http.Error(
+					w, "not found",
+					http.StatusNotFound,
+				)
+			}
+		},
+	)
+
+	esplora := NewEsploraClient(srv.URL, btclog.Disabled)
+	backend := NewChainBackend(esplora, 50*time.Millisecond, btclog.Disabled)
+
+	err := backend.Start()
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, backend.Stop())
+	}()
+
+	// Register for 3 confirmations. Tx is at height 100, tip
+	// is 105, so it has 6 confirmations - should fire
+	// immediately.
+	confReg, err := backend.RegisterConf(
+		t.Context(), &txid, nil, 3, 99, false,
+	)
+	require.NoError(t, err)
+	defer confReg.Cancel()
+
+	select {
+	case conf := <-confReg.Confirmed:
+		require.NotNil(t, conf)
+		require.Equal(t, uint32(100), conf.BlockHeight)
+
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for confirmation")
+	}
+}
+
+// TestChainBackendSpendRegistration verifies that spend
+// registrations fire when an output is spent.
+func TestChainBackendSpendRegistration(t *testing.T) {
+	t.Parallel()
+
+	txid := chainhash.HashH([]byte("funding-tx"))
+	spenderTxid := chainhash.HashH([]byte("spending-tx"))
+
+	srv := mockEsploraServer(
+		t, func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/blocks/tip/height":
+				fmt.Fprint(w, "100")
+
+			case "/block-height/100":
+				h := chainhash.HashH(
+					[]byte("block-100"),
+				)
+				fmt.Fprint(w, h.String())
+
+			case "/tx/" + txid.String() + "/outspend/0":
+				outspend := esploraOutspend{
+					Spent: true,
+					Txid:  spenderTxid.String(),
+					Vin:   1,
+					Status: esploraStatus{
+						Confirmed:   true,
+						BlockHeight: 99,
+					},
+				}
+
+				err := json.NewEncoder(w).Encode(
+					outspend,
+				)
+				require.NoError(t, err)
+
+			case "/tx/" + spenderTxid.String() + "/raw":
+				_, err := w.Write(minimalRawTx())
+				require.NoError(t, err)
+
+			default:
+				http.Error(
+					w, "not found",
+					http.StatusNotFound,
+				)
+			}
+		},
+	)
+
+	esplora := NewEsploraClient(srv.URL, btclog.Disabled)
+	backend := NewChainBackend(esplora, 50*time.Millisecond, btclog.Disabled)
+
+	err := backend.Start()
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, backend.Stop())
+	}()
+
+	outpoint := &chainhash.Hash{}
+	copy(outpoint[:], txid[:])
+
+	spendReg, err := backend.RegisterSpend(
+		t.Context(),
+		&wire.OutPoint{Hash: txid, Index: 0},
+		nil, 90,
+	)
+	require.NoError(t, err)
+	defer spendReg.Cancel()
+
+	select {
+	case spend := <-spendReg.Spend:
+		require.NotNil(t, spend)
+		require.Equal(t, uint32(1), spend.SpenderInputIndex)
+		require.Equal(t, int32(99), spend.SpendingHeight)
+
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for spend notification")
+	}
+}
+
+// minimalRawTx returns a minimal valid serialized Bitcoin
+// transaction suitable for testing deserialization.
+func minimalRawTx() []byte {
+	// Version 2, 1 input (coinbase-like), 1 output.
+	return []byte{
+		// Version.
+		0x02, 0x00, 0x00, 0x00,
+		// Input count.
+		0x01,
+		// Previous output hash (32 bytes of zeros).
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		// Previous output index.
+		0x00, 0x00, 0x00, 0x00,
+		// Script length.
+		0x00,
+		// Sequence.
+		0xff, 0xff, 0xff, 0xff,
+		// Output count.
+		0x01,
+		// Value (50000 sats).
+		0x50, 0xc3, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		// Script length + script (OP_TRUE).
+		0x01, 0x51,
+		// Locktime.
+		0x00, 0x00, 0x00, 0x00,
+	}
+}

--- a/lwwallet/config.go
+++ b/lwwallet/config.go
@@ -1,0 +1,65 @@
+package lwwallet
+
+import (
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btclog/v2"
+)
+
+// Subsystem defines the logging sub-system code for this package.
+const Subsystem = "LWWL"
+
+// coinTypeForNet returns the BIP44 coin type for the given network.
+// Mainnet uses coin type 0, while all test networks use coin type 1.
+func coinTypeForNet(params *chaincfg.Params) uint32 {
+	switch params.Net {
+	case chaincfg.MainNetParams.Net:
+		return 0
+
+	default:
+		return 1
+	}
+}
+
+// Config holds the configuration for the lightweight wallet.
+type Config struct {
+	// Seed is the 32-byte master seed used for HD key derivation. The
+	// caller is responsible for seed generation, encryption at rest, and
+	// BIP39 mnemonic handling. The wallet only uses the raw seed bytes.
+	Seed [32]byte
+
+	// EsploraURL is the base URL of the Esplora/mempool.space REST API
+	// (e.g. "https://mempool.space/api" or "http://localhost:3000"). The
+	// wallet uses this for all chain data: blocks, transactions, UTXOs,
+	// fee estimates, and broadcasting.
+	EsploraURL string
+
+	// ChainParams identifies the Bitcoin network (mainnet, testnet,
+	// regtest). Used for address encoding and HD derivation paths.
+	ChainParams *chaincfg.Params
+
+	// PollInterval controls how frequently the chain backend polls the
+	// Esplora API for new blocks and registration updates. Shorter
+	// intervals improve responsiveness at the cost of more API requests.
+	// Typical values: 1s for regtest, 10s for mainnet.
+	PollInterval time.Duration
+
+	// RecoveryWindow specifies the address look-ahead for discovering
+	// used addresses during wallet recovery or restart. A value of 0
+	// means no recovery is performed. Typical value: 100 for restart
+	// scenarios where previously derived keys must be rediscovered.
+	RecoveryWindow uint32
+
+	// DBDir is the directory for btcwallet's bbolt database. The
+	// caller owns the lifecycle of this directory: for tests a temp
+	// directory can be created and cleaned up after the wallet stops,
+	// while production callers may use a persistent path.
+	DBDir string
+
+	// Logger is the structured logger for the wallet and all its
+	// sub-components (chain service, chain backend, boarding backend,
+	// Esplora client). If nil, logging is disabled
+	// (btclog.Disabled).
+	Logger btclog.Logger
+}

--- a/lwwallet/doc.go
+++ b/lwwallet/doc.go
@@ -1,0 +1,17 @@
+// Package lwwallet provides a lightweight in-process Bitcoin wallet backed
+// by LND's btcwallet and an Esplora/mempool.space chain backend. It wraps
+// lnwallet/btcwallet.BtcWallet with an Esplora-based chain.Interface,
+// providing a self-contained wallet without an external LND node:
+//
+//   - Full on-chain wallet: HD key management via waddrmgr, UTXO
+//     tracking, address generation, balance queries
+//   - Ark round participation: Schnorr signing, MuSig2 sessions,
+//     boarding address management via btcwallet's signer
+//   - Chain monitoring: block subscriptions, confirmation tracking,
+//     spend detection via Esplora polling
+//
+// The wallet exposes wallet.BoardingBackend (via BoardingBackendAdapter),
+// input.Signer + MuSig2 (via BtcWallet), and chainsource.ChainBackend
+// (via ChainBackend), making it a drop-in replacement for the LND-backed
+// implementations.
+package lwwallet

--- a/lwwallet/esplora.go
+++ b/lwwallet/esplora.go
@@ -1,0 +1,555 @@
+package lwwallet
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btclog/v2"
+)
+
+// EsploraClient is an HTTP REST client for the Esplora/mempool.space API.
+// It provides methods for querying chain state, fetching transactions and
+// UTXOs, estimating fees, and broadcasting transactions. The client is
+// safe for concurrent use.
+type EsploraClient struct {
+	// baseURL is the Esplora API root (e.g. "https://mempool.space/api").
+	baseURL string
+
+	// httpClient is the underlying HTTP client with a configured timeout.
+	httpClient *http.Client
+
+	// log is the structured logger for this Esplora client instance.
+	log btclog.Logger
+}
+
+// NewEsploraClient creates a new Esplora REST API client. The baseURL should
+// point to the API root without a trailing slash (e.g.
+// "https://mempool.space/api").
+func NewEsploraClient(baseURL string,
+	logger btclog.Logger) *EsploraClient {
+
+	return &EsploraClient{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		log: logger,
+	}
+}
+
+// esploraUtxo represents a single UTXO as returned by the Esplora
+// /scripthash/:hash/utxo endpoint.
+type esploraUtxo struct {
+	// Txid is the transaction ID containing this output.
+	Txid string `json:"txid"`
+
+	// Vout is the output index within the transaction.
+	Vout uint32 `json:"vout"`
+
+	// Value is the output value in satoshis.
+	Value int64 `json:"value"`
+
+	// Status contains the confirmation status of the transaction.
+	Status esploraStatus `json:"status"`
+}
+
+// esploraStatus represents the confirmation status of a transaction.
+type esploraStatus struct {
+	// Confirmed indicates whether the transaction is confirmed.
+	Confirmed bool `json:"confirmed"`
+
+	// BlockHeight is the block height where the transaction was confirmed.
+	// Zero if unconfirmed.
+	BlockHeight int64 `json:"block_height"`
+
+	// BlockHash is the hex-encoded block hash. Empty if unconfirmed.
+	BlockHash string `json:"block_hash"`
+}
+
+// esploraTxStatus represents the full status response for a single
+// transaction from the /tx/:txid/status endpoint.
+type esploraTxStatus struct {
+	// Confirmed indicates whether the transaction is confirmed.
+	Confirmed bool `json:"confirmed"`
+
+	// BlockHeight is the confirmation height (0 if unconfirmed).
+	BlockHeight uint32 `json:"block_height"`
+
+	// BlockHash is the hex-encoded confirmation block hash.
+	BlockHash string `json:"block_hash"`
+}
+
+// esploraOutspend represents the response from the
+// /tx/:txid/outspend/:vout endpoint.
+type esploraOutspend struct {
+	// Spent indicates whether the output has been spent.
+	Spent bool `json:"spent"`
+
+	// Txid is the spending transaction ID (empty if unspent).
+	Txid string `json:"txid"`
+
+	// Vin is the input index in the spending transaction.
+	Vin uint32 `json:"vin"`
+
+	// Status contains the confirmation status of the spending
+	// transaction.
+	Status esploraStatus `json:"status"`
+}
+
+// esploraBlock represents the JSON response for a block from the
+// /block/:hash endpoint.
+type esploraBlock struct {
+	// ID is the hex-encoded block hash.
+	ID string `json:"id"`
+
+	// Height is the block height.
+	Height int32 `json:"height"`
+
+	// Timestamp is the block timestamp (unix seconds).
+	Timestamp int64 `json:"timestamp"`
+}
+
+// scriptHashHex computes the Esplora script hash for a pkScript. The hash
+// is SHA256(pkScript) with the bytes reversed and hex-encoded, matching
+// Electrum's script hash format used by Esplora.
+func scriptHashHex(pkScript []byte) string {
+	h := sha256.Sum256(pkScript)
+
+	// Reverse the hash bytes (Electrum convention).
+	for i, j := 0, len(h)-1; i < j; i, j = i+1, j-1 {
+		h[i], h[j] = h[j], h[i]
+	}
+
+	return hex.EncodeToString(h[:])
+}
+
+// GetTipHeight returns the current best block height.
+func (c *EsploraClient) GetTipHeight() (int32, error) {
+	body, err := c.get("/blocks/tip/height")
+	if err != nil {
+		return 0, fmt.Errorf("get tip height: %w", err)
+	}
+
+	height, err := strconv.ParseInt(strings.TrimSpace(string(body)), 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("parse tip height: %w", err)
+	}
+
+	return int32(height), nil
+}
+
+// GetTipHash returns the current best block hash.
+func (c *EsploraClient) GetTipHash() (chainhash.Hash, error) {
+	body, err := c.get("/blocks/tip/hash")
+	if err != nil {
+		return chainhash.Hash{}, fmt.Errorf("get tip hash: %w", err)
+	}
+
+	hash, err := chainhash.NewHashFromStr(strings.TrimSpace(string(body)))
+	if err != nil {
+		return chainhash.Hash{}, fmt.Errorf(
+			"parse tip hash: %w", err,
+		)
+	}
+
+	return *hash, nil
+}
+
+// GetBlockHeader returns block metadata (height, timestamp) for the given
+// block hash.
+func (c *EsploraClient) GetBlockHeader(
+	blockHash chainhash.Hash) (*esploraBlock, error) {
+
+	body, err := c.get("/block/" + blockHash.String())
+	if err != nil {
+		return nil, fmt.Errorf("get block header: %w", err)
+	}
+
+	var block esploraBlock
+	if err := json.Unmarshal(body, &block); err != nil {
+		return nil, fmt.Errorf("parse block header: %w", err)
+	}
+
+	return &block, nil
+}
+
+// GetBlockHashByHeight returns the block hash at the given height.
+func (c *EsploraClient) GetBlockHashByHeight(
+	height int32) (chainhash.Hash, error) {
+
+	body, err := c.get(
+		"/block-height/" + strconv.FormatInt(int64(height), 10),
+	)
+	if err != nil {
+		return chainhash.Hash{}, fmt.Errorf(
+			"get block hash at height %d: %w", height, err,
+		)
+	}
+
+	hash, err := chainhash.NewHashFromStr(strings.TrimSpace(string(body)))
+	if err != nil {
+		return chainhash.Hash{}, fmt.Errorf(
+			"parse block hash: %w", err,
+		)
+	}
+
+	return *hash, nil
+}
+
+// GetRawBlockHeader returns the deserialized 80-byte block header for
+// the given block hash. The Esplora /block/:hash/header endpoint returns
+// the header as a hex-encoded string which we decode and deserialize
+// into a wire.BlockHeader.
+func (c *EsploraClient) GetRawBlockHeader(
+	blockHash chainhash.Hash) (*wire.BlockHeader, error) {
+
+	body, err := c.get(
+		"/block/" + blockHash.String() + "/header",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get raw block header: %w", err)
+	}
+
+	// The response is a hex-encoded 80-byte block header.
+	headerBytes, err := hex.DecodeString(
+		strings.TrimSpace(string(body)),
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"decode block header hex: %w", err,
+		)
+	}
+
+	var header wire.BlockHeader
+	err = header.Deserialize(bytes.NewReader(headerBytes))
+	if err != nil {
+		return nil, fmt.Errorf(
+			"deserialize block header: %w", err,
+		)
+	}
+
+	return &header, nil
+}
+
+// GetRawBlock returns the raw serialized block bytes for the given hash.
+func (c *EsploraClient) GetRawBlock(
+	blockHash chainhash.Hash) (*wire.MsgBlock, error) {
+
+	body, err := c.get("/block/" + blockHash.String() + "/raw")
+	if err != nil {
+		return nil, fmt.Errorf("get raw block: %w", err)
+	}
+
+	var block wire.MsgBlock
+	err = block.Deserialize(bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("deserialize block: %w", err)
+	}
+
+	return &block, nil
+}
+
+// GetScriptUtxos returns all UTXOs for the given pkScript.
+func (c *EsploraClient) GetScriptUtxos(
+	pkScript []byte) ([]esploraUtxo, error) {
+
+	hash := scriptHashHex(pkScript)
+	path := "/scripthash/" + hash + "/utxo"
+	body, err := c.get(path)
+	if err != nil {
+		return nil, fmt.Errorf("get script utxos: %w", err)
+	}
+
+	var utxos []esploraUtxo
+	if err := json.Unmarshal(body, &utxos); err != nil {
+		return nil, fmt.Errorf("parse script utxos: %w", err)
+	}
+
+	// Log raw response when no UTXOs found to aid debugging.
+	if len(utxos) == 0 {
+		c.log.DebugS(context.Background(),
+			"Esplora returned empty UTXO list",
+			slog.String("path", path),
+			slog.String("raw_response",
+				string(body)))
+	}
+
+	return utxos, nil
+}
+
+// GetAddressUtxos returns all UTXOs for the given address string.
+// This uses the /address/:address/utxo endpoint which avoids the need
+// to compute a scripthash. The response format is identical to the
+// scripthash UTXO endpoint.
+func (c *EsploraClient) GetAddressUtxos(
+	address string) ([]esploraUtxo, error) {
+
+	path := "/address/" + address + "/utxo"
+	body, err := c.get(path)
+	if err != nil {
+		return nil, fmt.Errorf("get address utxos: %w", err)
+	}
+
+	var utxos []esploraUtxo
+	if err := json.Unmarshal(body, &utxos); err != nil {
+		return nil, fmt.Errorf("parse address utxos: %w", err)
+	}
+
+	// Log raw response when no UTXOs found to aid debugging.
+	if len(utxos) == 0 {
+		c.log.DebugS(context.Background(),
+			"Esplora address query returned empty",
+			slog.String("path", path),
+			slog.String("raw_response",
+				string(body)))
+	}
+
+	return utxos, nil
+}
+
+// GetTxStatus returns the confirmation status for a transaction.
+func (c *EsploraClient) GetTxStatus(
+	txid chainhash.Hash) (*esploraTxStatus, error) {
+
+	body, err := c.get("/tx/" + txid.String() + "/status")
+	if err != nil {
+		return nil, fmt.Errorf("get tx status: %w", err)
+	}
+
+	var status esploraTxStatus
+	if err := json.Unmarshal(body, &status); err != nil {
+		return nil, fmt.Errorf("parse tx status: %w", err)
+	}
+
+	return &status, nil
+}
+
+// GetRawTx returns the raw serialized transaction bytes for a txid.
+func (c *EsploraClient) GetRawTx(
+	txid chainhash.Hash) (*wire.MsgTx, error) {
+
+	body, err := c.get("/tx/" + txid.String() + "/raw")
+	if err != nil {
+		return nil, fmt.Errorf("get raw tx: %w", err)
+	}
+
+	var tx wire.MsgTx
+	err = tx.Deserialize(bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("deserialize tx: %w", err)
+	}
+
+	return &tx, nil
+}
+
+// BroadcastTx broadcasts a raw transaction to the network. Returns the
+// txid string on success.
+func (c *EsploraClient) BroadcastTx(tx *wire.MsgTx) (string, error) {
+	var buf bytes.Buffer
+	if err := tx.Serialize(&buf); err != nil {
+		return "", fmt.Errorf("serialize tx: %w", err)
+	}
+
+	txHex := hex.EncodeToString(buf.Bytes())
+
+	body, err := c.post("/tx", txHex)
+	if err != nil {
+		return "", fmt.Errorf("broadcast tx: %w", err)
+	}
+
+	return strings.TrimSpace(string(body)), nil
+}
+
+// GetFeeEstimates returns the fee estimates from the Esplora API. The
+// returned map has string keys representing confirmation targets and float64
+// values representing fee rates in sat/vB.
+func (c *EsploraClient) GetFeeEstimates() (map[string]float64, error) {
+	body, err := c.get("/fee-estimates")
+	if err != nil {
+		return nil, fmt.Errorf("get fee estimates: %w", err)
+	}
+
+	var estimates map[string]float64
+	if err := json.Unmarshal(body, &estimates); err != nil {
+		return nil, fmt.Errorf("parse fee estimates: %w", err)
+	}
+
+	return estimates, nil
+}
+
+// GetOutspend returns the spending status of a specific output.
+func (c *EsploraClient) GetOutspend(txid chainhash.Hash,
+	vout uint32) (*esploraOutspend, error) {
+
+	path := fmt.Sprintf(
+		"/tx/%s/outspend/%d", txid.String(), vout,
+	)
+
+	body, err := c.get(path)
+	if err != nil {
+		return nil, fmt.Errorf("get outspend: %w", err)
+	}
+
+	var outspend esploraOutspend
+	if err := json.Unmarshal(body, &outspend); err != nil {
+		return nil, fmt.Errorf("parse outspend: %w", err)
+	}
+
+	return &outspend, nil
+}
+
+// get performs an HTTP GET request and returns the response body.
+func (c *EsploraClient) get(path string) ([]byte, error) {
+	resp, err := c.httpClient.Get(c.baseURL + path)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d: %s",
+			resp.StatusCode, string(body))
+	}
+
+	return body, nil
+}
+
+// TestMempoolAccept validates transactions against mempool policy
+// without broadcasting them. This uses the Esplora POST /txs/test
+// endpoint which proxies to Bitcoin Core's testmempoolaccept RPC.
+func (c *EsploraClient) TestMempoolAccept(
+	txns []*wire.MsgTx,
+	maxFeeRate float64) ([]testMempoolAcceptResult, error) {
+
+	// Serialize each transaction to hex.
+	txHexes := make([]string, 0, len(txns))
+	for _, tx := range txns {
+		var buf bytes.Buffer
+		if err := tx.Serialize(&buf); err != nil {
+			return nil, fmt.Errorf("serialize tx: %w", err)
+		}
+
+		txHexes = append(
+			txHexes, hex.EncodeToString(buf.Bytes()),
+		)
+	}
+
+	jsonBody, err := json.Marshal(txHexes)
+	if err != nil {
+		return nil, fmt.Errorf("marshal tx hexes: %w", err)
+	}
+
+	// Build the URL with optional maxfeerate query parameter.
+	url := c.baseURL + "/txs/test"
+	if maxFeeRate > 0 {
+		url += fmt.Sprintf(
+			"?maxfeerate=%f", maxFeeRate,
+		)
+	}
+
+	resp, err := c.httpClient.Post(
+		url, "application/json",
+		bytes.NewReader(jsonBody),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("test mempool accept: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"read test mempool response: %w", err,
+		)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d: %s",
+			resp.StatusCode, string(respBody))
+	}
+
+	var results []testMempoolAcceptResult
+	if err := json.Unmarshal(respBody, &results); err != nil {
+		return nil, fmt.Errorf(
+			"parse test mempool response: %w", err,
+		)
+	}
+
+	return results, nil
+}
+
+// testMempoolAcceptResult represents the result of testing a single
+// transaction against mempool policy via Bitcoin Core's
+// testmempoolaccept RPC (proxied through Esplora).
+type testMempoolAcceptResult struct {
+	// Txid is the transaction hash.
+	Txid string `json:"txid"`
+
+	// Wtxid is the witness transaction hash.
+	Wtxid string `json:"wtxid"`
+
+	// Allowed indicates whether the transaction would be accepted.
+	Allowed bool `json:"allowed"`
+
+	// Vsize is the virtual transaction size in vbytes.
+	Vsize int32 `json:"vsize"`
+
+	// Fees contains fee information (only when Allowed is true).
+	Fees *testMempoolAcceptFees `json:"fees,omitempty"`
+
+	// RejectReason is the rejection reason (only when Allowed is
+	// false).
+	//nolint:tagliatelle
+	RejectReason string `json:"reject-reason,omitempty"`
+}
+
+// testMempoolAcceptFees contains fee details for accepted
+// transactions.
+type testMempoolAcceptFees struct {
+	// Base is the transaction fee in BTC.
+	Base float64 `json:"base"`
+}
+
+// post performs an HTTP POST request with a text body and returns the
+// response body.
+func (c *EsploraClient) post(path string,
+	body string) ([]byte, error) {
+
+	resp, err := c.httpClient.Post(
+		c.baseURL+path, "text/plain",
+		strings.NewReader(body),
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d: %s",
+			resp.StatusCode, string(respBody))
+	}
+
+	return respBody, nil
+}

--- a/lwwallet/esplora_chain.go
+++ b/lwwallet/esplora_chain.go
@@ -1,0 +1,832 @@
+package lwwallet
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/btcsuite/btcd/btcjson"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/btcsuite/btcwallet/chain"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wtxmgr"
+)
+
+// EsploraChainService implements btcwallet's chain.Interface using the
+// Esplora REST API. It provides the blockchain access layer that
+// btcwallet needs for wallet synchronization, block notifications, and
+// transaction broadcasting. The service polls Esplora for new blocks
+// at a configurable interval and forwards BlockConnected notifications
+// to btcwallet via the Notifications() channel.
+type EsploraChainService struct {
+	esplora      *EsploraClient
+	pollInterval time.Duration
+
+	// log is the structured logger for this chain service instance.
+	log btclog.Logger
+
+	// notifications is the channel for sending chain events to
+	// btcwallet's wallet syncer. btcwallet reads from this channel
+	// in its handleChainNotifications goroutine.
+	notifications chan interface{}
+
+	// mu protects watchedAddrs and bestBlock.
+	mu sync.Mutex
+
+	// watchedAddrs holds addresses registered via NotifyReceived.
+	// These are used during block processing to detect relevant
+	// transactions for RelevantTx notifications.
+	watchedAddrs map[string]btcutil.Address
+
+	// bestBlock caches the current chain tip, updated by the poll
+	// loop on each new block.
+	bestBlock waddrmgr.BlockStamp
+
+	quit chan struct{}
+	wg   sync.WaitGroup
+}
+
+// NewEsploraChainService creates a new chain.Interface backed by the
+// Esplora REST API. The pollInterval controls how frequently the
+// service checks for new blocks.
+func NewEsploraChainService(esplora *EsploraClient,
+	pollInterval time.Duration,
+	logger btclog.Logger) *EsploraChainService {
+
+	return &EsploraChainService{
+		esplora:       esplora,
+		pollInterval:  pollInterval,
+		log:           logger,
+		notifications: make(chan interface{}, 100),
+		watchedAddrs:  make(map[string]btcutil.Address),
+		quit:          make(chan struct{}),
+	}
+}
+
+// Start fetches the initial chain tip and starts the polling goroutine
+// that sends BlockConnected notifications to btcwallet.
+func (s *EsploraChainService) Start() error {
+	// Fetch the initial chain tip so BlockStamp() returns correct
+	// values immediately. We get height first, then resolve the
+	// hash for that specific height to avoid drift if a new block
+	// arrives between the two HTTP calls.
+	tipHeight, err := s.esplora.GetTipHeight()
+	if err != nil {
+		return fmt.Errorf("get initial tip height: %w", err)
+	}
+
+	tipHash, err := s.esplora.GetBlockHashByHeight(tipHeight)
+	if err != nil {
+		return fmt.Errorf("get initial tip hash: %w", err)
+	}
+
+	tipHeader, err := s.esplora.GetBlockHeader(tipHash)
+	if err != nil {
+		return fmt.Errorf("get initial tip header: %w", err)
+	}
+
+	s.mu.Lock()
+	s.bestBlock = waddrmgr.BlockStamp{
+		Height:    tipHeight,
+		Hash:      tipHash,
+		Timestamp: time.Unix(tipHeader.Timestamp, 0),
+	}
+	s.mu.Unlock()
+
+	// Send ClientConnected so btcwallet knows the chain backend
+	// is ready.
+	s.notifications <- chain.ClientConnected{}
+
+	s.wg.Add(1)
+	go s.pollLoop()
+
+	s.log.InfoS(context.Background(), "Esplora chain service started",
+		slog.Int("tip_height", int(tipHeight)),
+		slog.String("tip_hash", tipHash.String()))
+
+	return nil
+}
+
+// Stop signals the polling goroutine to exit.
+func (s *EsploraChainService) Stop() {
+	select {
+	case <-s.quit:
+		// Already stopped.
+		return
+
+	default:
+		s.log.InfoS(context.Background(),
+			"Stopping Esplora chain service")
+
+		close(s.quit)
+	}
+}
+
+// WaitForShutdown blocks until the polling goroutine has exited.
+func (s *EsploraChainService) WaitForShutdown() {
+	s.wg.Wait()
+}
+
+// GetBestBlock returns the hash and height of the current best block.
+// Height is fetched first, then the hash is resolved for that specific
+// height to avoid returning mismatched values if a new block arrives
+// between the two HTTP calls.
+func (s *EsploraChainService) GetBestBlock() (
+	*chainhash.Hash, int32, error) {
+
+	height, err := s.esplora.GetTipHeight()
+	if err != nil {
+		return nil, 0, fmt.Errorf(
+			"get best block height: %w", err,
+		)
+	}
+
+	hash, err := s.esplora.GetBlockHashByHeight(height)
+	if err != nil {
+		return nil, 0, fmt.Errorf("get best block hash: %w", err)
+	}
+
+	return &hash, height, nil
+}
+
+// GetBlock returns the full deserialized block for the given hash.
+func (s *EsploraChainService) GetBlock(
+	hash *chainhash.Hash) (*wire.MsgBlock, error) {
+
+	return s.esplora.GetRawBlock(*hash)
+}
+
+// GetBlockHash returns the block hash at the given height. The height
+// is int64 to match the chain.Interface signature.
+func (s *EsploraChainService) GetBlockHash(
+	height int64) (*chainhash.Hash, error) {
+
+	hash, err := s.esplora.GetBlockHashByHeight(int32(height))
+	if err != nil {
+		return nil, err
+	}
+
+	return &hash, nil
+}
+
+// GetBlockHeader returns the deserialized block header for the given
+// hash. This calls the Esplora /block/:hash/header endpoint.
+func (s *EsploraChainService) GetBlockHeader(
+	hash *chainhash.Hash) (*wire.BlockHeader, error) {
+
+	return s.esplora.GetRawBlockHeader(*hash)
+}
+
+// IsCurrent returns true because the Esplora backend is assumed to
+// always be synced with the network.
+func (s *EsploraChainService) IsCurrent() bool {
+	return true
+}
+
+// FilterBlocks scans a batch of blocks for transactions relevant to
+// the provided addresses and watched outpoints. For each block in the
+// request, the full block is fetched and every transaction is checked
+// for outputs matching external/internal addresses and inputs spending
+// watched outpoints. Returns the first block containing any match.
+func (s *EsploraChainService) FilterBlocks(
+	req *chain.FilterBlocksRequest) (
+	*chain.FilterBlocksResponse, error) {
+
+	// Build a pkScript lookup table from the address sets so we
+	// can efficiently match transaction outputs.
+	addrScripts := make(map[string]addressMatch)
+
+	for scopedIdx, addr := range req.ExternalAddrs {
+		pkScript, err := txscript.PayToAddrScript(addr)
+		if err != nil {
+			continue
+		}
+
+		addrScripts[string(pkScript)] = addressMatch{
+			scope:    scopedIdx.Scope,
+			index:    scopedIdx.Index,
+			external: true,
+		}
+	}
+
+	for scopedIdx, addr := range req.InternalAddrs {
+		pkScript, err := txscript.PayToAddrScript(addr)
+		if err != nil {
+			continue
+		}
+
+		addrScripts[string(pkScript)] = addressMatch{
+			scope:    scopedIdx.Scope,
+			index:    scopedIdx.Index,
+			external: false,
+		}
+	}
+
+	for batchIdx, blockMeta := range req.Blocks {
+		block, err := s.esplora.GetRawBlock(blockMeta.Hash)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"get block %s: %w",
+				blockMeta.Hash, err,
+			)
+		}
+
+		resp := s.filterBlock(
+			block, blockMeta, uint32(batchIdx),
+			addrScripts, req.WatchedOutPoints,
+		)
+
+		if resp != nil {
+			return resp, nil
+		}
+	}
+
+	return nil, nil
+}
+
+// addressMatch pairs an address's key scope and index with whether
+// it is external or internal. This is used to populate the
+// FoundExternalAddrs / FoundInternalAddrs maps in the filter response.
+type addressMatch struct {
+	scope    waddrmgr.KeyScope
+	index    uint32
+	external bool
+}
+
+// filterBlock checks a single block for transactions matching the
+// given address scripts or watched outpoints. Returns nil if no
+// matches are found.
+func (s *EsploraChainService) filterBlock(
+	block *wire.MsgBlock, meta wtxmgr.BlockMeta,
+	batchIdx uint32, addrScripts map[string]addressMatch,
+	watchedOPs map[wire.OutPoint]btcutil.Address,
+) *chain.FilterBlocksResponse {
+
+	var (
+		foundExternal = make(
+			map[waddrmgr.KeyScope]map[uint32]struct{},
+		)
+		foundInternal = make(
+			map[waddrmgr.KeyScope]map[uint32]struct{},
+		)
+		foundOutpoints = make(
+			map[wire.OutPoint]btcutil.Address,
+		)
+		relevantTxns []*wire.MsgTx
+	)
+
+	matched := false
+
+	for _, tx := range block.Transactions {
+		txMatched := false
+
+		// Check outputs against watched addresses.
+		for _, txOut := range tx.TxOut {
+			match, ok := addrScripts[string(txOut.PkScript)]
+			if !ok {
+				continue
+			}
+
+			txMatched = true
+
+			if match.external {
+				if foundExternal[match.scope] == nil {
+					foundExternal[match.scope] =
+						make(map[uint32]struct{})
+				}
+
+				foundExternal[match.scope][match.index] =
+					struct{}{}
+			} else {
+				if foundInternal[match.scope] == nil {
+					foundInternal[match.scope] =
+						make(map[uint32]struct{})
+				}
+
+				foundInternal[match.scope][match.index] =
+					struct{}{}
+			}
+		}
+
+		// Check inputs against watched outpoints.
+		for _, txIn := range tx.TxIn {
+			addr, ok := watchedOPs[txIn.PreviousOutPoint]
+			if !ok {
+				continue
+			}
+
+			txMatched = true
+			foundOutpoints[txIn.PreviousOutPoint] = addr
+		}
+
+		if txMatched {
+			matched = true
+			relevantTxns = append(relevantTxns, tx)
+		}
+	}
+
+	if !matched {
+		return nil
+	}
+
+	return &chain.FilterBlocksResponse{
+		BatchIndex:         batchIdx,
+		BlockMeta:          meta,
+		FoundExternalAddrs: foundExternal,
+		FoundInternalAddrs: foundInternal,
+		FoundOutPoints:     foundOutpoints,
+		RelevantTxns:       relevantTxns,
+	}
+}
+
+// BlockStamp returns the cached best block stamp. This is updated by
+// the polling loop whenever a new block is detected.
+func (s *EsploraChainService) BlockStamp() (
+	*waddrmgr.BlockStamp, error) {
+
+	s.mu.Lock()
+	stamp := s.bestBlock
+	s.mu.Unlock()
+
+	return &stamp, nil
+}
+
+// SendRawTransaction broadcasts a signed transaction to the network
+// via the Esplora API. The allowHighFees parameter is ignored since
+// Esplora does not support fee-rate validation before broadcast.
+func (s *EsploraChainService) SendRawTransaction(tx *wire.MsgTx,
+	allowHighFees bool) (*chainhash.Hash, error) {
+
+	_, err := s.esplora.BroadcastTx(tx)
+	if err != nil {
+		return nil, fmt.Errorf("broadcast tx: %w", err)
+	}
+
+	txHash := tx.TxHash()
+
+	return &txHash, nil
+}
+
+// Rescan walks the chain from the block identified by startHash
+// forward to the current tip, checking each block for transactions
+// that match the given addresses or outpoints.
+//
+// Block data is fetched synchronously, but notifications are flushed
+// to the notification channel in a background goroutine. This avoids
+// a deadlock with btcwallet's handleChainNotifications: during initial
+// sync, handleChainNotifications blocks on the rescan result (via
+// rescanWithTarget → SubmitRescan), while Rescan tries to send
+// FilteredBlockConnected notifications to the same channel that
+// handleChainNotifications reads from. If the channel buffer fills,
+// both sides block permanently. Sending notifications asynchronously
+// lets Rescan return immediately, unblocking handleChainNotifications
+// to drain the queued notifications.
+func (s *EsploraChainService) Rescan(startHash *chainhash.Hash,
+	addrs []btcutil.Address,
+	outpoints map[wire.OutPoint]btcutil.Address) error {
+
+	// Build the pkScript lookup from addresses.
+	addrScripts := make(map[string]struct{})
+	for _, addr := range addrs {
+		pkScript, err := txscript.PayToAddrScript(addr)
+		if err != nil {
+			continue
+		}
+
+		addrScripts[string(pkScript)] = struct{}{}
+	}
+
+	// Look up the starting block height.
+	startBlock, err := s.esplora.GetBlockHeader(*startHash)
+	if err != nil {
+		return fmt.Errorf("get start block header: %w", err)
+	}
+
+	startHeight := startBlock.Height
+
+	// Get the current chain tip.
+	tipHeight, err := s.esplora.GetTipHeight()
+	if err != nil {
+		return fmt.Errorf("get tip height for rescan: %w", err)
+	}
+
+	s.log.InfoS(context.Background(), "Starting chain rescan",
+		slog.Int("start_height", int(startHeight)),
+		slog.Int("tip_height", int(tipHeight)),
+		slog.Int("watched_addrs", len(addrs)),
+		slog.Int("watched_outpoints", len(outpoints)))
+
+	// Collect all notifications first, then flush them
+	// asynchronously. See method doc for deadlock rationale.
+	var pending []interface{}
+
+	// Walk each block from start to tip.
+	for height := startHeight; height <= tipHeight; height++ {
+		blockHash, err := s.esplora.GetBlockHashByHeight(height)
+		if err != nil {
+			return fmt.Errorf(
+				"get block hash at %d: %w", height, err,
+			)
+		}
+
+		block, err := s.esplora.GetRawBlock(blockHash)
+		if err != nil {
+			return fmt.Errorf(
+				"get block at %d: %w", height, err,
+			)
+		}
+
+		blockHeader, err := s.esplora.GetBlockHeader(blockHash)
+		if err != nil {
+			return fmt.Errorf(
+				"get block header at %d: %w", height, err,
+			)
+		}
+
+		blockMeta := wtxmgr.BlockMeta{
+			Block: wtxmgr.Block{
+				Hash:   blockHash,
+				Height: height,
+			},
+			Time: time.Unix(blockHeader.Timestamp, 0),
+		}
+
+		// Filter transactions in this block.
+		var relevantTxs []*wtxmgr.TxRecord
+		for _, tx := range block.Transactions {
+			if !s.txMatchesRescan(
+				tx, addrScripts, outpoints,
+			) {
+
+				continue
+			}
+
+			rec, err := wtxmgr.NewTxRecordFromMsgTx(
+				tx, blockMeta.Time,
+			)
+			if err != nil {
+				continue
+			}
+
+			relevantTxs = append(relevantTxs, rec)
+		}
+
+		// Queue FilteredBlockConnected so btcwallet processes
+		// any relevant transactions via addRelevantTx.
+		pending = append(pending,
+			chain.FilteredBlockConnected{
+				Block:       &blockMeta,
+				RelevantTxs: relevantTxs,
+			},
+		)
+
+		// Queue BlockConnected so btcwallet advances its
+		// sync height via connectBlock → SetSyncedTo.
+		// This must follow FilteredBlockConnected so that
+		// relevant transactions are recorded before the
+		// sync height advances past them.
+		pending = append(pending,
+			chain.BlockConnected(blockMeta),
+		)
+	}
+
+	s.log.InfoS(context.Background(), "Chain rescan complete",
+		slog.Int("tip_height", int(tipHeight)),
+		slog.Int("pending_notifications", len(pending)))
+
+	// Flush collected notifications in a background goroutine
+	// so this function returns without blocking on channel
+	// capacity.
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+
+		for _, n := range pending {
+			select {
+			case s.notifications <- n:
+
+			case <-s.quit:
+				return
+			}
+		}
+	}()
+
+	return nil
+}
+
+// txMatchesRescan checks whether a transaction matches any of the
+// rescan criteria (address scripts or watched outpoints).
+func (s *EsploraChainService) txMatchesRescan(tx *wire.MsgTx,
+	addrScripts map[string]struct{},
+	outpoints map[wire.OutPoint]btcutil.Address) bool {
+
+	// Check outputs against watched address scripts.
+	for _, txOut := range tx.TxOut {
+		if _, ok := addrScripts[string(txOut.PkScript)]; ok {
+			return true
+		}
+	}
+
+	// Check inputs against watched outpoints.
+	for _, txIn := range tx.TxIn {
+		if _, ok := outpoints[txIn.PreviousOutPoint]; ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+// NotifyReceived registers addresses for transaction notifications.
+// When a new block arrives and contains a transaction paying to one of
+// these addresses, a RelevantTx notification is sent. btcwallet calls
+// this for each new address it generates (NewAddress,
+// ImportTaprootScript, etc.) so the chain backend can include
+// transactions to those addresses in FilteredBlockConnected
+// notifications.
+func (s *EsploraChainService) NotifyReceived(
+	addrs []btcutil.Address) error {
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, addr := range addrs {
+		s.watchedAddrs[addr.String()] = addr
+	}
+
+	s.log.DebugS(context.Background(),
+		"Registered addresses for notifications",
+		slog.Int("new_addrs", len(addrs)),
+		slog.Int("total_watched", len(s.watchedAddrs)))
+
+	return nil
+}
+
+// NotifyBlocks is a no-op because the polling loop always sends
+// BlockConnected notifications for new blocks.
+func (s *EsploraChainService) NotifyBlocks() error {
+	return nil
+}
+
+// Notifications returns the read-only channel that btcwallet uses to
+// receive chain events (BlockConnected, FilteredBlockConnected,
+// RelevantTx, RescanProgress, RescanFinished, ClientConnected).
+func (s *EsploraChainService) Notifications() <-chan interface{} {
+	return s.notifications
+}
+
+// BackEnd returns the name of this chain backend implementation.
+func (s *EsploraChainService) BackEnd() string {
+	return "esplora"
+}
+
+// TestMempoolAccept validates transactions against mempool policy
+// without broadcasting them. This uses the Esplora POST /txs/test
+// endpoint which proxies to Bitcoin Core's testmempoolaccept RPC.
+func (s *EsploraChainService) TestMempoolAccept(
+	txns []*wire.MsgTx,
+	maxFeeRate float64) ([]*btcjson.TestMempoolAcceptResult, error) {
+
+	esploraResults, err := s.esplora.TestMempoolAccept(
+		txns, maxFeeRate,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert from Esplora response format to btcjson format.
+	results := make(
+		[]*btcjson.TestMempoolAcceptResult, len(esploraResults),
+	)
+	for i, r := range esploraResults {
+		result := &btcjson.TestMempoolAcceptResult{
+			Txid:         r.Txid,
+			Wtxid:        r.Wtxid,
+			Allowed:      r.Allowed,
+			Vsize:        r.Vsize,
+			RejectReason: r.RejectReason,
+		}
+
+		if r.Fees != nil {
+			result.Fees = &btcjson.TestMempoolAcceptFees{
+				Base: r.Fees.Base,
+			}
+		}
+
+		results[i] = result
+	}
+
+	return results, nil
+}
+
+// MapRPCErr passes through errors unchanged since the Esplora backend
+// does not use RPC error codes.
+func (s *EsploraChainService) MapRPCErr(err error) error {
+	return err
+}
+
+// pollLoop periodically checks for new blocks and sends
+// BlockConnected notifications to btcwallet. The loop runs until
+// Stop() is called.
+func (s *EsploraChainService) pollLoop() {
+	defer s.wg.Done()
+
+	ticker := time.NewTicker(s.pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			s.pollForBlocks()
+
+		case <-s.quit:
+			return
+		}
+	}
+}
+
+// pollForBlocks checks for new blocks since the last known tip and
+// sends FilteredBlockConnected and BlockConnected notifications for
+// each new block. FilteredBlockConnected carries relevant transactions
+// (matching watched addresses) so btcwallet can track UTXOs, while
+// BlockConnected updates the wallet's sync height.
+func (s *EsploraChainService) pollForBlocks() {
+	newHeight, err := s.esplora.GetTipHeight()
+	if err != nil {
+		s.log.WarnS(context.Background(),
+			"Chain service poll tip height failed", err)
+
+		return
+	}
+
+	s.mu.Lock()
+	oldHeight := s.bestBlock.Height
+	s.mu.Unlock()
+
+	if newHeight <= oldHeight {
+		return
+	}
+
+	s.log.DebugS(context.Background(),
+		"New blocks detected",
+		slog.Int("old_height", int(oldHeight)),
+		slog.Int("new_height", int(newHeight)))
+
+	// Process each new block in order.
+	for height := oldHeight + 1; height <= newHeight; height++ {
+		blockHash, err := s.esplora.GetBlockHashByHeight(height)
+		if err != nil {
+			s.log.WarnS(context.Background(),
+				"Chain service poll block hash failed",
+				err)
+
+			return
+		}
+
+		blockInfo, err := s.esplora.GetBlockHeader(blockHash)
+		if err != nil {
+			s.log.WarnS(context.Background(),
+				"Chain service poll block info failed",
+				err)
+
+			return
+		}
+
+		blockMeta := wtxmgr.BlockMeta{
+			Block: wtxmgr.Block{
+				Hash:   blockHash,
+				Height: height,
+			},
+			Time: time.Unix(blockInfo.Timestamp, 0),
+		}
+
+		// Build pkScript lookup from currently watched addresses
+		// so we can detect relevant transactions in this block.
+		s.mu.Lock()
+		watchedScripts := make(map[string]struct{},
+			len(s.watchedAddrs))
+		for _, addr := range s.watchedAddrs {
+			pkScript, err := txscript.PayToAddrScript(addr)
+			if err != nil {
+				continue
+			}
+
+			watchedScripts[string(pkScript)] = struct{}{}
+		}
+		s.mu.Unlock()
+
+		// Filter block for relevant transactions if we have
+		// any watched addresses. This requires fetching the
+		// full block from Esplora.
+		var relevantTxs []*wtxmgr.TxRecord
+		if len(watchedScripts) > 0 {
+			block, err := s.esplora.GetRawBlock(blockHash)
+			if err != nil {
+				s.log.WarnS(context.Background(),
+					"Chain service poll block "+
+						"fetch failed", err)
+
+				return
+			}
+
+			relevantTxs = s.filterBlockTxs(
+				block, watchedScripts,
+				blockMeta.Time,
+			)
+		}
+
+		// Send FilteredBlockConnected with relevant
+		// transactions so btcwallet processes them via
+		// addRelevantTx. This is how btcwallet learns about
+		// transactions paying to wallet-owned addresses.
+		//
+		// We use select with quit to prevent blocking
+		// indefinitely if the channel is full during initial
+		// sync (when handleChainNotifications is busy with
+		// syncWithChain/recovery).
+		select {
+		case s.notifications <- chain.FilteredBlockConnected{
+			Block:       &blockMeta,
+			RelevantTxs: relevantTxs,
+		}:
+
+		case <-s.quit:
+			return
+		}
+
+		// Send BlockConnected to update btcwallet's sync
+		// height. FilteredBlockConnected only processes
+		// transactions but does not update the sync height.
+		select {
+		case s.notifications <- chain.BlockConnected(
+			blockMeta,
+		):
+
+		case <-s.quit:
+			return
+		}
+
+		// Update the cached best block.
+		s.mu.Lock()
+		s.bestBlock = waddrmgr.BlockStamp{
+			Height:    height,
+			Hash:      blockHash,
+			Timestamp: blockMeta.Time,
+		}
+		s.mu.Unlock()
+	}
+}
+
+// filterBlockTxs checks all transactions in the block against the
+// watched pkScripts and returns TxRecords for matching transactions.
+func (s *EsploraChainService) filterBlockTxs(block *wire.MsgBlock,
+	watchedScripts map[string]struct{},
+	blockTime time.Time) []*wtxmgr.TxRecord {
+
+	var records []*wtxmgr.TxRecord
+
+	for _, tx := range block.Transactions {
+		if !s.txMatchesScripts(tx, watchedScripts) {
+			continue
+		}
+
+		rec, err := wtxmgr.NewTxRecordFromMsgTx(tx, blockTime)
+		if err != nil {
+			continue
+		}
+
+		txHash := tx.TxHash()
+		s.log.DebugS(context.Background(),
+			"Found relevant transaction in block",
+			slog.String("txid", txHash.String()),
+			slog.Int("num_outputs", len(tx.TxOut)))
+
+		records = append(records, rec)
+	}
+
+	return records
+}
+
+// txMatchesScripts checks whether any transaction output pays to one
+// of the watched pkScripts.
+func (s *EsploraChainService) txMatchesScripts(tx *wire.MsgTx,
+	watchedScripts map[string]struct{}) bool {
+
+	for _, txOut := range tx.TxOut {
+		if _, ok := watchedScripts[string(txOut.PkScript)]; ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Compile-time check that EsploraChainService implements
+// chain.Interface.
+var _ chain.Interface = (*EsploraChainService)(nil)

--- a/lwwallet/esplora_test.go
+++ b/lwwallet/esplora_test.go
@@ -1,0 +1,331 @@
+package lwwallet
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestScriptHashHex verifies the Esplora script hash computation matches
+// the expected Electrum-style reversed SHA256 hex encoding.
+func TestScriptHashHex(t *testing.T) {
+	t.Parallel()
+
+	// Use a known pkScript and verify the hash matches the expected
+	// Electrum script hash format.
+	pkScript, err := hex.DecodeString(
+		"76a91489abcdefabbaabbaabbaabbaabbaabbaabbaabba88ac",
+	)
+	require.NoError(t, err)
+
+	hash := scriptHashHex(pkScript)
+
+	// The hash should be 64 hex characters (32 bytes).
+	require.Len(t, hash, 64)
+
+	// Verify it's valid hex.
+	_, err = hex.DecodeString(hash)
+	require.NoError(t, err)
+}
+
+// TestEsploraGetTipHeight verifies that GetTipHeight correctly parses the
+// API response.
+func TestEsploraGetTipHeight(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, "/blocks/tip/height", r.URL.Path)
+
+			_, err := w.Write([]byte("850123"))
+			require.NoError(t, err)
+		}),
+	)
+	defer srv.Close()
+
+	client := NewEsploraClient(srv.URL, btclog.Disabled)
+	height, err := client.GetTipHeight()
+	require.NoError(t, err)
+	require.Equal(t, int32(850123), height)
+}
+
+// TestEsploraGetTipHash verifies that GetTipHash correctly parses a block
+// hash response.
+func TestEsploraGetTipHash(t *testing.T) {
+	t.Parallel()
+
+	hashStr := "000000000019d6689c085ae165831e934ff763ae46" +
+		"a2a6c172b3f1b60a8ce26f"
+
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, "/blocks/tip/hash", r.URL.Path)
+
+			_, err := w.Write([]byte(hashStr))
+			require.NoError(t, err)
+		}),
+	)
+	defer srv.Close()
+
+	client := NewEsploraClient(srv.URL, btclog.Disabled)
+	hash, err := client.GetTipHash()
+	require.NoError(t, err)
+	require.Equal(t, hashStr, hash.String())
+}
+
+// TestEsploraGetBlockHashByHeight verifies hash-by-height lookup.
+func TestEsploraGetBlockHashByHeight(t *testing.T) {
+	t.Parallel()
+
+	hashStr := "000000000019d6689c085ae165831e934ff763ae46" +
+		"a2a6c172b3f1b60a8ce26f"
+
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, "/block-height/100", r.URL.Path)
+
+			_, err := w.Write([]byte(hashStr))
+			require.NoError(t, err)
+		}),
+	)
+	defer srv.Close()
+
+	client := NewEsploraClient(srv.URL, btclog.Disabled)
+	hash, err := client.GetBlockHashByHeight(100)
+	require.NoError(t, err)
+	require.Equal(t, hashStr, hash.String())
+}
+
+// TestEsploraGetBlockHeader verifies block header JSON parsing.
+func TestEsploraGetBlockHeader(t *testing.T) {
+	t.Parallel()
+
+	blockHash, err := chainhash.NewHashFromStr(
+		"000000000019d6689c085ae165831e934ff763ae46" +
+			"a2a6c172b3f1b60a8ce26f",
+	)
+	require.NoError(t, err)
+
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			resp := esploraBlock{
+				ID:        blockHash.String(),
+				Height:    100,
+				Timestamp: 1231006505,
+			}
+
+			err := json.NewEncoder(w).Encode(resp)
+			require.NoError(t, err)
+		}),
+	)
+	defer srv.Close()
+
+	client := NewEsploraClient(srv.URL, btclog.Disabled)
+	block, err := client.GetBlockHeader(*blockHash)
+	require.NoError(t, err)
+	require.Equal(t, int32(100), block.Height)
+	require.Equal(t, int64(1231006505), block.Timestamp)
+}
+
+// TestEsploraGetScriptUtxos verifies UTXO listing by script hash.
+func TestEsploraGetScriptUtxos(t *testing.T) {
+	t.Parallel()
+
+	pkScript := []byte{0x51, 0x20, 0x01, 0x02, 0x03}
+
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Verify the path contains the correct script hash.
+			expectedHash := scriptHashHex(pkScript)
+			expectedPath := "/scripthash/" + expectedHash +
+				"/utxo"
+			require.Equal(t, expectedPath, r.URL.Path)
+
+			utxos := []esploraUtxo{
+				{
+					Txid:  "aabb",
+					Vout:  0,
+					Value: 100000,
+					Status: esploraStatus{
+						Confirmed:   true,
+						BlockHeight: 500,
+					},
+				},
+				{
+					Txid:  "ccdd",
+					Vout:  1,
+					Value: 200000,
+					Status: esploraStatus{
+						Confirmed: false,
+					},
+				},
+			}
+
+			err := json.NewEncoder(w).Encode(utxos)
+			require.NoError(t, err)
+		}),
+	)
+	defer srv.Close()
+
+	client := NewEsploraClient(srv.URL, btclog.Disabled)
+	utxos, err := client.GetScriptUtxos(pkScript)
+	require.NoError(t, err)
+	require.Len(t, utxos, 2)
+	require.Equal(t, int64(100000), utxos[0].Value)
+	require.True(t, utxos[0].Status.Confirmed)
+	require.Equal(t, int64(200000), utxos[1].Value)
+	require.False(t, utxos[1].Status.Confirmed)
+}
+
+// TestEsploraGetTxStatus verifies transaction status parsing.
+func TestEsploraGetTxStatus(t *testing.T) {
+	t.Parallel()
+
+	txid, err := chainhash.NewHashFromStr(
+		"0000000000000000000000000000000000000000000000" +
+			"000000000000000001",
+	)
+	require.NoError(t, err)
+
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			status := esploraTxStatus{
+				Confirmed:   true,
+				BlockHeight: 750000,
+				BlockHash:   "deadbeef",
+			}
+
+			err := json.NewEncoder(w).Encode(status)
+			require.NoError(t, err)
+		}),
+	)
+	defer srv.Close()
+
+	client := NewEsploraClient(srv.URL, btclog.Disabled)
+	status, err := client.GetTxStatus(*txid)
+	require.NoError(t, err)
+	require.True(t, status.Confirmed)
+	require.Equal(t, uint32(750000), status.BlockHeight)
+}
+
+// TestEsploraGetFeeEstimates verifies fee estimate parsing.
+func TestEsploraGetFeeEstimates(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, "/fee-estimates", r.URL.Path)
+
+			estimates := map[string]float64{
+				"1":  25.0,
+				"3":  15.0,
+				"6":  10.0,
+				"25": 5.0,
+			}
+
+			err := json.NewEncoder(w).Encode(estimates)
+			require.NoError(t, err)
+		}),
+	)
+	defer srv.Close()
+
+	client := NewEsploraClient(srv.URL, btclog.Disabled)
+	estimates, err := client.GetFeeEstimates()
+	require.NoError(t, err)
+	require.Equal(t, 25.0, estimates["1"])
+	require.Equal(t, 5.0, estimates["25"])
+}
+
+// TestEsploraGetOutspend verifies outspend status parsing.
+func TestEsploraGetOutspend(t *testing.T) {
+	t.Parallel()
+
+	txid, err := chainhash.NewHashFromStr(
+		"0000000000000000000000000000000000000000000000" +
+			"000000000000000001",
+	)
+	require.NoError(t, err)
+
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			outspend := esploraOutspend{
+				Spent: true,
+				Txid:  "abcd1234",
+				Vin:   0,
+				Status: esploraStatus{
+					Confirmed:   true,
+					BlockHeight: 800000,
+				},
+			}
+
+			err := json.NewEncoder(w).Encode(outspend)
+			require.NoError(t, err)
+		}),
+	)
+	defer srv.Close()
+
+	client := NewEsploraClient(srv.URL, btclog.Disabled)
+	outspend, err := client.GetOutspend(*txid, 0)
+	require.NoError(t, err)
+	require.True(t, outspend.Spent)
+	require.Equal(t, "abcd1234", outspend.Txid)
+}
+
+// TestEsploraBroadcastTx verifies transaction broadcasting.
+func TestEsploraBroadcastTx(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, http.MethodPost, r.Method)
+			require.Equal(t, "/tx", r.URL.Path)
+
+			// Return a fake txid.
+			_, err := w.Write([]byte("aabbccdd"))
+			require.NoError(t, err)
+		}),
+	)
+	defer srv.Close()
+
+	// Build a minimal valid transaction for serialization.
+	tx := wire.NewMsgTx(2)
+	tx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{
+			Hash:  chainhash.Hash{},
+			Index: 0,
+		},
+	})
+	tx.AddTxOut(&wire.TxOut{
+		Value:    50000,
+		PkScript: []byte{0x51, 0x20},
+	})
+
+	client := NewEsploraClient(srv.URL, btclog.Disabled)
+	txid, err := client.BroadcastTx(tx)
+	require.NoError(t, err)
+	require.Equal(t, "aabbccdd", txid)
+}
+
+// TestEsploraHTTPError verifies that non-200 responses produce an error.
+func TestEsploraHTTPError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "not found", http.StatusNotFound)
+		}),
+	)
+	defer srv.Close()
+
+	client := NewEsploraClient(srv.URL, btclog.Disabled)
+	_, err := client.GetTipHeight()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "404")
+}

--- a/lwwallet/wallet.go
+++ b/lwwallet/wallet.go
@@ -1,0 +1,298 @@
+package lwwallet
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightningnetwork/lnd/blockcache"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/lnwallet"
+	"github.com/lightningnetwork/lnd/lnwallet/btcwallet"
+)
+
+// defaultBlockCacheSize is the number of blocks to cache in memory.
+// This prevents redundant block fetches during wallet sync.
+const defaultBlockCacheSize uint64 = 20
+
+// walletPassphrase is the default passphrase for the wallet DB.
+var walletPassphrase = []byte("lwwallet")
+
+// Wallet is a lightweight in-process Bitcoin wallet backed by LND's
+// btcwallet implementation and an Esplora chain backend. It provides
+// full on-chain wallet capabilities (receive, balance, key derivation,
+// signing, MuSig2) plus Ark protocol participation (boarding address
+// management, chain monitoring).
+//
+// The wallet wraps a btcwallet.BtcWallet instance which handles key
+// management via waddrmgr, UTXO tracking, and transaction signing.
+// Chain data is fetched from Esplora via the EsploraChainService
+// (implementing btcwallet's chain.Interface) and the existing
+// ChainBackend (implementing chainsource.ChainBackend for actors).
+//
+// The wallet exposes sub-interfaces via accessor methods:
+//   - BoardingBackend() returns the wallet.BoardingBackend adapter
+//   - Signer() returns the input.Signer implementation
+//   - ChainBackend() returns the chainsource.ChainBackend for actors
+//   - KeyRing() returns the keychain.SecretKeyRing for key operations
+type Wallet struct {
+	// Signer is the input.Signer implementation backed by
+	// btcwallet. This supports Schnorr signing, taproot
+	// key/script-path signing, and MuSig2 sessions. Embedding
+	// this (together with DeriveNextKey) means Wallet directly
+	// satisfies round.ClientWallet.
+	input.Signer
+
+	// btcWallet is the LND btcwallet instance that provides key
+	// management, signing, UTXO tracking, and address generation.
+	btcWallet *btcwallet.BtcWallet
+
+	// chainSvc implements btcwallet's chain.Interface, feeding
+	// block notifications to btcwallet for wallet sync.
+	chainSvc *EsploraChainService
+
+	// esplora is the Esplora REST API client shared by chain
+	// service and chain backend.
+	esplora *EsploraClient
+
+	// chainBackend implements chainsource.ChainBackend for the
+	// actor system (confirmation/spend/block registrations).
+	chainBackend *ChainBackend
+
+	// boardingBackend wraps btcwallet to provide the
+	// wallet.BoardingBackend interface for Ark boarding.
+	boardingBackend *BoardingBackendAdapter
+
+	// keyRing provides keychain.SecretKeyRing backed by btcwallet's
+	// waddrmgr for HD key derivation.
+	keyRing keychain.SecretKeyRing
+
+	// chainParams identifies the Bitcoin network.
+	chainParams *chaincfg.Params
+
+	// log is the structured logger for this wallet instance.
+	log btclog.Logger
+}
+
+// New creates a new lightweight wallet from the given configuration.
+// The caller must provide a DBDir for btcwallet's bbolt database and
+// is responsible for managing the directory's lifecycle (creation
+// before calling New, cleanup after Stop if desired).
+func New(cfg Config) (*Wallet, error) {
+	// Use the configured logger, falling back to disabled logging
+	// if none was provided.
+	walletLog := cfg.Logger
+	if walletLog == nil {
+		walletLog = btclog.Disabled
+	}
+
+	esplora := NewEsploraClient(cfg.EsploraURL, walletLog)
+
+	// The EsploraChainService implements btcwallet's chain.Interface
+	// and feeds block notifications to btcwallet for wallet sync.
+	chainSvc := NewEsploraChainService(
+		esplora, cfg.PollInterval, walletLog,
+	)
+
+	// The ChainBackend implements chainsource.ChainBackend for the
+	// actor system (confirmation/spend/block registrations).
+	chainBackend := NewChainBackend(
+		esplora, cfg.PollInterval, walletLog,
+	)
+
+	coinType := coinTypeForNet(cfg.ChainParams)
+	blockCache := blockcache.NewBlockCache(defaultBlockCacheSize)
+
+	btcw, err := btcwallet.New(btcwallet.Config{
+		PrivatePass:    walletPassphrase,
+		PublicPass:     walletPassphrase,
+		HdSeed:         cfg.Seed[:],
+		ChainSource:    chainSvc,
+		NetParams:      cfg.ChainParams,
+		CoinType:       coinType,
+		RecoveryWindow: cfg.RecoveryWindow,
+		LoaderOptions: []btcwallet.LoaderOption{
+			btcwallet.LoaderWithLocalWalletDB(
+				cfg.DBDir, false, 60*time.Second,
+			),
+		},
+	}, blockCache)
+	if err != nil {
+		return nil, fmt.Errorf("create btcwallet: %w", err)
+	}
+
+	// Create the keyring from btcwallet's internal wallet. This
+	// provides HD key derivation using the same m/1017'/coinType'
+	// scope as LND.
+	keyRing := keychain.NewBtcWalletKeyRing(
+		btcw.InternalWallet(), coinType,
+	)
+
+	boardingBackend := NewBoardingBackendAdapter(
+		btcw, esplora, cfg.ChainParams, coinType, walletLog,
+	)
+
+	walletLog.InfoS(context.Background(), "Lightweight wallet created",
+		slog.String("db_dir", cfg.DBDir),
+		slog.Uint64("coin_type", uint64(coinType)))
+
+	return &Wallet{
+		Signer:          btcw,
+		btcWallet:       btcw,
+		chainSvc:        chainSvc,
+		esplora:         esplora,
+		chainBackend:    chainBackend,
+		boardingBackend: boardingBackend,
+		keyRing:         keyRing,
+		chainParams:     cfg.ChainParams,
+		log:             walletLog,
+	}, nil
+}
+
+// Start initializes the wallet by starting btcwallet (which
+// internally starts the EsploraChainService and syncs the wallet)
+// and the chainsource ChainBackend.
+func (w *Wallet) Start() error {
+	// btcWallet.Start() unlocks the wallet, creates key scopes,
+	// starts the chain service, and begins wallet synchronization.
+	if err := w.btcWallet.Start(); err != nil {
+		return fmt.Errorf("start btcwallet: %w", err)
+	}
+
+	// Start the chainsource ChainBackend used by the actor system.
+	// This is separate from the chain service used by btcwallet.
+	if err := w.chainBackend.Start(); err != nil {
+		return fmt.Errorf("start chain backend: %w", err)
+	}
+
+	w.log.InfoS(context.Background(), "Lightweight wallet started")
+
+	return nil
+}
+
+// Stop shuts down the wallet, chain service, and chain backend. We
+// wait for the chain service goroutine to fully exit before
+// returning to avoid racing with btcwallet's internal writes.
+func (w *Wallet) Stop() {
+	w.log.InfoS(context.Background(), "Stopping lightweight wallet")
+
+	_ = w.btcWallet.Stop()
+	w.chainSvc.WaitForShutdown()
+	_ = w.chainBackend.Stop()
+
+	w.log.InfoS(context.Background(), "Lightweight wallet stopped")
+}
+
+// BoardingBackend returns the wallet.BoardingBackend adapter that
+// wraps btcwallet for Ark boarding address management.
+func (w *Wallet) BoardingBackend() *BoardingBackendAdapter {
+	return w.boardingBackend
+}
+
+// ChainBackend returns the chainsource.ChainBackend used by the
+// actor system for confirmation, spend, and block registrations.
+func (w *Wallet) ChainBackend() *ChainBackend {
+	return w.chainBackend
+}
+
+// DeriveNextKey derives the next key in the specified key family.
+// This delegates to the btcwallet-backed keyring.
+func (w *Wallet) DeriveNextKey(_ context.Context,
+	family keychain.KeyFamily) (*keychain.KeyDescriptor, error) {
+
+	desc, err := w.keyRing.DeriveNextKey(family)
+	if err != nil {
+		return nil, fmt.Errorf("derive next key: %w", err)
+	}
+
+	return &desc, nil
+}
+
+// NewAddress generates a new BIP86 taproot receiving address (P2TR
+// key-path only) via btcwallet.
+func (w *Wallet) NewAddress(
+	ctx context.Context) (btcutil.Address, error) {
+
+	addr, err := w.btcWallet.NewAddress(
+		lnwallet.TaprootPubkey, false,
+		lnwallet.DefaultAccountName,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	w.log.DebugS(ctx, "Generated new P2TR address",
+		slog.String("address", addr.String()))
+
+	return addr, nil
+}
+
+// Balance returns the confirmed and unconfirmed balance across all
+// wallet-managed addresses. Confirmed balance requires at least 1
+// confirmation.
+func (w *Wallet) Balance(
+	ctx context.Context) (btcutil.Amount, btcutil.Amount, error) {
+
+	// Log sync state for debugging. The sync height determines
+	// whether confirmed transactions are counted.
+	syncedTo := w.btcWallet.InternalWallet().SyncedTo()
+	chainSynced := w.btcWallet.InternalWallet().ChainSynced()
+	w.log.DebugS(ctx, "Checking wallet balance",
+		slog.Int("sync_height", int(syncedTo.Height)),
+		slog.String("sync_hash", syncedTo.Hash.String()),
+		slog.Bool("chain_synced", chainSynced))
+
+	confirmed, err := w.btcWallet.ConfirmedBalance(1, "")
+	if err != nil {
+		return 0, 0, fmt.Errorf("get confirmed balance: %w", err)
+	}
+
+	// Total includes unconfirmed (0-conf) outputs.
+	total, err := w.btcWallet.ConfirmedBalance(
+		0, "",
+	)
+	if err != nil {
+		return 0, 0, fmt.Errorf("get total balance: %w", err)
+	}
+
+	unconfirmed := total - confirmed
+
+	w.log.DebugS(ctx, "Wallet balance result",
+		slog.Int64("confirmed_sats", int64(confirmed)),
+		slog.Int64("unconfirmed_sats", int64(unconfirmed)),
+		slog.Int64("total_sats", int64(total)))
+
+	return confirmed, unconfirmed, nil
+}
+
+// InternalWallet returns the underlying btcwallet instance for
+// advanced operations not exposed through the Wallet API.
+func (w *Wallet) InternalWallet() *btcwallet.BtcWallet {
+	return w.btcWallet
+}
+
+// ConfirmedBalance returns the confirmed balance with the specified
+// minimum confirmations. This is a convenience wrapper around
+// btcwallet's ConfirmedBalance.
+func (w *Wallet) ConfirmedBalance(
+	minConfs int32) (btcutil.Amount, error) {
+
+	return w.btcWallet.ConfirmedBalance(minConfs, "")
+}
+
+// ListUnspentWitness returns all unspent witness outputs with
+// confirmations in the given range. This delegates to btcwallet's
+// ListUnspentWitness which returns P2WKH, P2TR, and nested P2SH
+// outputs.
+func (w *Wallet) ListUnspentWitness(minConfs,
+	maxConfs int32) ([]*lnwallet.Utxo, error) {
+
+	return w.btcWallet.ListUnspentWitness(
+		minConfs, maxConfs, "",
+	)
+}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -147,6 +147,31 @@ func (a *Ark) Start(ctx context.Context,
 	a.log.InfoS(ctx, "Loaded boarding addresses from database",
 		slog.Int("count", len(addresses)))
 
+	// Re-import each persisted boarding address into the boarding
+	// backend. For in-memory backends (lwwallet), this restores
+	// tracked scripts lost on restart. For persistent backends
+	// (LND), the script may already exist and the import will
+	// return a benign "already exists" error which we log and
+	// skip since the backend is already tracking the address.
+	for _, addr := range addresses {
+		_, err := a.backend.ImportTaprootScript(
+			ctx, addr.Tapscript,
+		)
+		if err != nil {
+			// The import may fail if the backend already
+			// tracks this script (e.g., LND persists
+			// imports internally and returns "already
+			// exists"). This is expected during restart
+			// recovery so we log and continue.
+			a.log.DebugS(ctx,
+				"Boarding address re-import skipped",
+				slog.String("address",
+					addr.Address.String()),
+				slog.String("reason",
+					err.Error()))
+		}
+	}
+
 	// Load just the outpoints of existing intents to populate seenUtxos.
 	// This is more efficient than loading full intents since we only need
 	// the outpoints to avoid duplicate notifications.


### PR DESCRIPTION
## Summary

- Add new `lwwallet` package providing a lightweight, in-process Bitcoin wallet that replaces the LND dependency on the client side
- Implements `wallet.BoardingBackend`, `round.ClientWallet` (`input.Signer` + `input.MuSig2Signer`), and `chainsource.ChainBackend` as drop-in replacements for LND-backed implementations
- Uses LND-compatible HD keyring (`m/1017'/coinType'/family'/0/index`) and Esplora/mempool.space for chain data

### Components

| File | Purpose |
|------|---------|
| `keyring.go` | HD key derivation compatible with LND's BIP43 purpose 1017 |
| `signer.go` | `input.Signer` implementation (Schnorr, key-path, script-path) |
| `musig2.go` | `input.MuSig2Signer` with in-memory session management |
| `esplora.go` | HTTP client for Esplora/mempool.space REST API |
| `chain_backend.go` | `chainsource.ChainBackend` via Esplora polling |
| `boarding_backend.go` | `wallet.BoardingBackend` with taproot script imports |
| `coin_select.go` | Largest-first greedy coin selection for P2TR |
| `wallet.go` | Top-level wallet: addresses, UTXOs, SendCoins, Balance |
| `config.go` / `doc.go` | Configuration and package documentation |

### Test coverage

44 unit tests covering keyring derivation, coin selection, MuSig2 sessions, Esplora client mocking, chain backend registrations, and signer operations.

## Test plan

- [ ] `go test ./lwwallet/...` -- all 44 unit tests pass
- [ ] `go build ./...` -- clean compile
- [ ] `make lint` -- linter passes
- [ ] Integration: systest PR in darepo runs all E2E tests with both LND and lwwallet backends