### PR TITLE
baselib/actor: Make tx failure test deterministic

### DIFF
--- a/baselib/actor/durable_actor_test.go
+++ b/baselib/actor/durable_actor_test.go
@@ -569,9 +569,6 @@ func TestDurableActorTransactionFailure(t *testing.T) {
 	cfg.PollInterval = 10 * time.Millisecond
 	actor := NewDurableActor(cfg)
 
-	actor.Start()
-	defer actor.Stop()
-
 	msg := &actorTestMsg{
 		Value: tlv.NewPrimitiveRecord[tlv.TlvType1](uint64(42)),
 	}
@@ -580,12 +577,17 @@ func TestDurableActorTransactionFailure(t *testing.T) {
 	err := actor.Ref().Tell(ctx, msg)
 	require.NoError(t, err)
 
-	// Verify message was enqueued.
+	// Verify message was enqueued before starting the actor to avoid races
+	// where the consumer goroutine processes/dead-letters the message before
+	// this assertion runs.
 	store.mu.Lock()
 	initialCount := len(store.messages)
 	store.mu.Unlock()
 	t.Logf("After Tell: %d messages in store", initialCount)
 	require.Equal(t, 1, initialCount, "message should be enqueued")
+
+	actor.Start()
+	defer actor.Stop()
 
 	// Wait for first transaction to be attempted.
 	require.Eventually(t, func() bool {


### PR DESCRIPTION
## Summary
This change makes `TestDurableActorTransactionFailure` deterministic by
asserting enqueue semantics before starting the actor processing loop.

## Flake Analysis
Observed failure:
```
--- FAIL: TestDurableActorTransactionFailure (0.00s)
    durable_actor_test.go:587: After Tell: 0 messages in store
    durable_actor_test.go:588: 
        	Error Trace:	/home/runner/work/darepo/darepo/client/baselib/actor/durable_actor_test.go:588
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 0
        	Test:       	TestDurableActorTransactionFailure
        	Messages:   	message should be enqueued
FAIL
```

### Why it flakes
The test previously did:

1. `actor.Start()`
2. `Tell(...)`
3. immediate assertion `len(store.messages) == 1`

That assertion races with the running consumer goroutine. In this test,
`txShouldFail=true`, so delivery processing repeatedly nacks and can quickly
reach dead-letter/delete before the assertion runs.

In the mock store used by this test, `NackMessage` clears the lease and does
not enforce `retryAfter` scheduling, so retries can happen immediately. This
amplifies the race window under faster CI scheduling.

## Why this fix is correct
The intent of this test is to verify that `Tell` enqueues successfully.

The fix changes ordering to:

1. `Tell(...)`
2. assert `len(store.messages) == 1`
3. `actor.Start()`
4. keep existing assertions that tx failure path executes and triggers nack

This removes concurrent consumption from the enqueue assertion while preserving
validation of the transaction-failure/nack behavior once processing starts.

## Testing
Ran the following locally:

- `make unit pkg=baselib/actor case=TestDurableActorTransactionFailure timeout=5m`
- `make unit log="stdlog trace" pkg=baselib/actor case=TestDurableActorTransactionFailure`
- `make lint`
- `go test ./baselib/actor -run TestDurableActorTransactionFailure -count=200`
- `go test ./baselib/actor -run TestDurableActorTransactionFailure -count=100 -covermode=atomic -coverpkg=github.com/lightninglabs/darepo-client/...`
- `go test ./baselib/actor -run TestDurableActor -count=10`
