### PR TITLE
OOR client 3b/4: PSBT script-spend validation + operator sig verification

### DIFF
--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -70,7 +70,7 @@ type Querier interface {
 	// ListLiveVTXOs returns all VTXOs that are not in a terminal state.
 	// Terminal states are: Forfeited (3), Spent (4), Expiring (5), Failed (6).
 	// This is used during startup to recover active VTXO actors.
-	// Also filter on spent = FALSE to handle VTXOs marked spent via the legacy
+	// Also filter on spent = FALSE to handle VTXOs marked spent via the earlier
 	// flag before the status field was introduced.
 	ListLiveVTXOs(ctx context.Context) ([]Vtxo, error)
 	ListRoundsByStatus(ctx context.Context, status string) ([]Round, error)

--- a/db/sqlc/queries/vtxo.sql
+++ b/db/sqlc/queries/vtxo.sql
@@ -12,7 +12,7 @@ ORDER BY creation_time DESC;
 -- ListLiveVTXOs returns all VTXOs that are not in a terminal state.
 -- Terminal states are: Forfeited (3), Spent (4), Expiring (5), Failed (6).
 -- This is used during startup to recover active VTXO actors.
--- Also filter on spent = FALSE to handle VTXOs marked spent via the legacy
+-- Also filter on spent = FALSE to handle VTXOs marked spent via the earlier
 -- flag before the status field was introduced.
 SELECT * FROM vtxos
 WHERE status < 3 AND spent = FALSE

--- a/db/sqlc/vtxo.sql.go
+++ b/db/sqlc/vtxo.sql.go
@@ -96,7 +96,7 @@ ORDER BY creation_time DESC
 // ListLiveVTXOs returns all VTXOs that are not in a terminal state.
 // Terminal states are: Forfeited (3), Spent (4), Expiring (5), Failed (6).
 // This is used during startup to recover active VTXO actors.
-// Also filter on spent = FALSE to handle VTXOs marked spent via the legacy
+// Also filter on spent = FALSE to handle VTXOs marked spent via the earlier
 // flag before the status field was introduced.
 func (q *Queries) ListLiveVTXOs(ctx context.Context) ([]Vtxo, error) {
 	rows, err := q.db.QueryContext(ctx, ListLiveVTXOs)

--- a/lib/tree/build.go
+++ b/lib/tree/build.go
@@ -17,7 +17,7 @@ func WeightByBtcAmount() PartitionWeightFunc {
 
 // partitionLeaves divides leaves into balanced groups. When a weight function
 // is provided, groups are balanced by cumulative weight; otherwise, leaves are
-// distributed purely by count (legacy behavior).
+// distributed purely by count.
 func partitionLeaves(leaves []LeafDescriptor, radix int,
 	weightFn PartitionWeightFunc) [][]LeafDescriptor {
 

--- a/lib/tx/oor/submit_signature_validate.go
+++ b/lib/tx/oor/submit_signature_validate.go
@@ -1,0 +1,335 @@
+package oor
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/scripts"
+)
+
+// ValidateSubmitPackageSigned validates a v0 OOR submit package including
+// signature correctness and script VM execution for the Ark PSBT.
+//
+// This performs structural validation and then executes the tapscript VM for
+// each Ark input using the witness data embedded in the PSBT.
+func ValidateSubmitPackageSigned(ark *psbt.Packet,
+	checkpoints []*psbt.Packet) (*ValidatedSubmitPackage, error) {
+
+	validated, err := ValidateSubmitPackage(ark, checkpoints)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := validatePSBTSpends(ark, "ark"); err != nil {
+		return nil, err
+	}
+
+	return validated, nil
+}
+
+// ValidateFinalizePackageSigned validates a v0 OOR finalize package including
+// signature correctness and script VM execution for checkpoint PSBTs.
+//
+// This builds the final witness stacks for the checkpoints and executes the
+// script VM to confirm the finalized package is spendable on-chain.
+func ValidateFinalizePackageSigned(ark *psbt.Packet,
+	finalCheckpoints []*psbt.Packet) error {
+
+	if err := ValidateFinalizePackage(ark, finalCheckpoints); err != nil {
+		return err
+	}
+
+	for i, checkpoint := range finalCheckpoints {
+		if err := validatePSBTSpends(checkpoint, fmt.Sprintf(
+			"final checkpoint %d", i,
+		)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validatePSBTSpends constructs witnesses from PSBT metadata and executes the
+// script VM for each input, returning an annotated error on the first failure.
+func validatePSBTSpends(pkt *psbt.Packet, label string) error {
+	switch {
+	case pkt == nil || pkt.UnsignedTx == nil:
+		return fmt.Errorf("%s psbt must include unsigned tx", label)
+	case len(pkt.Inputs) != len(pkt.UnsignedTx.TxIn):
+		return fmt.Errorf("%s psbt input count mismatch", label)
+	}
+
+	tx := pkt.UnsignedTx.Copy()
+
+	prevOuts := make(map[wire.OutPoint]*wire.TxOut, len(tx.TxIn))
+	for i, txIn := range tx.TxIn {
+		in := pkt.Inputs[i]
+		if in.WitnessUtxo == nil {
+			return fmt.Errorf("%s input %d missing witness utxo",
+				label, i)
+		}
+
+		prevOuts[txIn.PreviousOutPoint] = in.WitnessUtxo
+
+		tapTreeEncoded, err := GetTapTreePSBTInput(in)
+		if err != nil {
+			return fmt.Errorf("%s input %d: get tap tree: %w",
+				label, i, err)
+		}
+
+		witness, err := buildTaprootWitness(in, tapTreeEncoded)
+		if err != nil {
+			return fmt.Errorf("%s input %d: %w", label, i,
+				err)
+		}
+
+		txIn.Witness = witness
+	}
+
+	prevFetcher := txscript.NewMultiPrevOutFetcher(prevOuts)
+	sigHashes := txscript.NewTxSigHashes(tx, prevFetcher)
+
+	for i, txIn := range tx.TxIn {
+		prevOut := prevFetcher.FetchPrevOutput(
+			txIn.PreviousOutPoint,
+		)
+		if prevOut == nil {
+			return fmt.Errorf("%s input %d missing prevout",
+				label, i)
+		}
+
+		engine, err := txscript.NewEngine(
+			prevOut.PkScript, tx, i,
+			txscript.StandardVerifyFlags, nil, sigHashes,
+			prevOut.Value, prevFetcher,
+		)
+		if err != nil {
+			return fmt.Errorf("%s input %d: create script "+
+				"engine: %w", label, i, err)
+		}
+
+		if err := engine.Execute(); err != nil {
+			return fmt.Errorf("%s input %d: script validation "+
+				"failed: %w", label, i, err)
+		}
+	}
+
+	return nil
+}
+
+// buildTaprootWitness constructs the witness stack for a taproot input using
+// any finalized witness, key spend signature, or script spend signature data
+// available in the PSBT.
+func buildTaprootWitness(in psbt.PInput,
+	tapTreeEncoded []byte) (wire.TxWitness, error) {
+
+	if len(in.FinalScriptWitness) > 0 {
+		return parseFinalWitness(in.FinalScriptWitness)
+	}
+
+	if len(in.TaprootKeySpendSig) > 0 {
+		return wire.TxWitness{
+			appendTaprootSigHash(
+				in.TaprootKeySpendSig, in.SighashType,
+			),
+		}, nil
+	}
+
+	if len(in.TaprootScriptSpendSig) > 0 {
+		targetLeafHash := in.TaprootScriptSpendSig[0].LeafHash
+		for i := range in.TaprootScriptSpendSig {
+			sig := in.TaprootScriptSpendSig[i]
+			if sig == nil {
+				return nil, fmt.Errorf(
+					"nil taproot signature",
+				)
+			}
+
+			if !bytes.Equal(sig.LeafHash, targetLeafHash) {
+				return nil, fmt.Errorf("taproot script " +
+					"signatures reference multiple " +
+					"leaf hashes")
+			}
+		}
+
+		leafScript, err := findTaprootLeafScript(
+			in, targetLeafHash, tapTreeEncoded,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		witness := make(wire.TxWitness, 0,
+			len(in.TaprootScriptSpendSig)+2,
+		)
+		for i := range in.TaprootScriptSpendSig {
+			sig := in.TaprootScriptSpendSig[i]
+			witness = append(
+				witness,
+				appendTaprootSigHash(
+					sig.Signature, sig.SigHash,
+				),
+			)
+		}
+
+		witness = append(witness, leafScript.Script)
+		witness = append(witness, leafScript.ControlBlock)
+
+		return witness, nil
+	}
+
+	if len(in.TaprootLeafScript) == 1 {
+		leaf := in.TaprootLeafScript[0]
+		if leaf == nil {
+			return nil, fmt.Errorf("taproot leaf script " +
+				"missing")
+		}
+
+		return wire.TxWitness{
+			leaf.Script,
+			leaf.ControlBlock,
+		}, nil
+	}
+
+	return nil, fmt.Errorf("missing taproot signature or " +
+		"leaf script")
+}
+
+// findTaprootLeafScript locates the tapleaf script and control block for the
+// given leaf hash, searching PSBT metadata first and falling back to encoded
+// tap tree data if needed.
+func findTaprootLeafScript(in psbt.PInput, leafHash []byte,
+	tapTreeEncoded []byte) (*psbt.TaprootTapLeafScript, error) {
+
+	if len(leafHash) != chainhash.HashSize {
+		return nil, fmt.Errorf("invalid leaf hash size")
+	}
+
+	for i := range in.TaprootLeafScript {
+		leaf := in.TaprootLeafScript[i]
+		if leaf == nil {
+			continue
+		}
+
+		hash := txscript.NewTapLeaf(
+			leaf.LeafVersion, leaf.Script,
+		).TapHash()
+		if bytes.Equal(hash[:], leafHash) {
+			return leaf, nil
+		}
+	}
+
+	if len(tapTreeEncoded) == 0 {
+		return nil, fmt.Errorf("taproot leaf script not found")
+	}
+
+	target := chainhash.Hash{}
+	copy(target[:], leafHash)
+
+	leafScript, err := tapLeafFromEncodedTree(
+		tapTreeEncoded, target,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return leafScript, nil
+}
+
+// tapLeafFromEncodedTree reconstructs a TaprootTapLeafScript from encoded tap
+// tree data by locating the target leaf and deriving its control block.
+func tapLeafFromEncodedTree(encoded []byte,
+	target chainhash.Hash) (*psbt.TaprootTapLeafScript, error) {
+
+	leafScripts, err := DecodeTapTree(encoded)
+	if err != nil {
+		return nil, fmt.Errorf("decode tap tree: %w", err)
+	}
+
+	tapLeaves := make([]txscript.TapLeaf, 0, len(leafScripts))
+	for _, script := range leafScripts {
+		tapLeaves = append(
+			tapLeaves, txscript.NewBaseTapLeaf(script),
+		)
+	}
+
+	tree := txscript.AssembleTaprootScriptTree(tapLeaves...)
+	index, ok := tree.LeafProofIndex[target]
+	if !ok {
+		return nil, fmt.Errorf("leaf not found in tap tree")
+	}
+
+	proof := tree.LeafMerkleProofs[index]
+	control := proof.ToControlBlock(&scripts.ARKNUMSKey)
+	controlBytes, err := control.ToBytes()
+	if err != nil {
+		return nil, fmt.Errorf("encode control block: %w",
+			err)
+	}
+
+	return &psbt.TaprootTapLeafScript{
+		ControlBlock: controlBytes,
+		Script:       proof.TapLeaf.Script,
+		LeafVersion:  proof.TapLeaf.LeafVersion,
+	}, nil
+}
+
+// BuildTaprootTapLeafScript constructs a TaprootTapLeafScript for the target
+// leaf script using the encoded tap tree data.
+//
+// This is used by v0 OOR to attach the owner leaf path to Ark inputs so submit
+// validation and finalize signing can bind to the correct tapscript leaf.
+func BuildTaprootTapLeafScript(encoded []byte,
+	leafScript []byte) (*psbt.TaprootTapLeafScript, error) {
+
+	if len(leafScript) == 0 {
+		return nil, fmt.Errorf("leaf script must be provided")
+	}
+
+	target := txscript.NewBaseTapLeaf(leafScript).TapHash()
+
+	return tapLeafFromEncodedTree(encoded, target)
+}
+
+// appendTaprootSigHash appends a non-default sighash byte to a schnorr
+// signature for witness construction.
+func appendTaprootSigHash(sig []byte,
+	sigHash txscript.SigHashType) []byte {
+
+	out := append([]byte(nil), sig...)
+	if sigHash == txscript.SigHashDefault {
+		return out
+	}
+
+	return append(out, byte(sigHash))
+}
+
+// parseFinalWitness deserializes a raw final witness stack from PSBT metadata.
+func parseFinalWitness(raw []byte) (wire.TxWitness, error) {
+	witnessReader := bytes.NewReader(raw)
+	witCount, err := wire.ReadVarInt(witnessReader, 0)
+	if err != nil {
+		return nil, fmt.Errorf("read witness count: %w", err)
+	}
+
+	witness := make(wire.TxWitness, witCount)
+	for i := uint64(0); i < witCount; i++ {
+		item, err := wire.ReadVarBytes(
+			witnessReader, 0, txscript.MaxScriptSize,
+			"witness",
+		)
+		if err != nil {
+			return nil, fmt.Errorf("read witness item: %w",
+				err)
+		}
+
+		witness[i] = item
+	}
+
+	return witness, nil
+}

--- a/lib/tx/oor/submit_signature_validate.go
+++ b/lib/tx/oor/submit_signature_validate.go
@@ -2,6 +2,7 @@ package oor
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 
 	"github.com/btcsuite/btcd/btcutil/psbt"
@@ -78,8 +79,16 @@ func validatePSBTSpends(pkt *psbt.Packet, label string) error {
 
 		tapTreeEncoded, err := GetTapTreePSBTInput(in)
 		if err != nil {
-			return fmt.Errorf("%s input %d: get tap tree: %w",
-				label, i, err)
+			// The full tap tree is optional when the witness has
+			// enough data (for example FinalScriptWitness or a
+			// TaprootLeafScript path).
+			// Keep malformed tree metadata as hard errors.
+			if !errors.Is(err, ErrTapTreeNotFound) {
+				return fmt.Errorf(
+					"%s input %d: get tap tree: %w",
+					label, i, err,
+				)
+			}
 		}
 
 		witness, err := buildTaprootWitness(in, tapTreeEncoded)

--- a/lib/tx/oor/submit_signature_validate_test.go
+++ b/lib/tx/oor/submit_signature_validate_test.go
@@ -1,0 +1,118 @@
+package oor
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/scripts"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateSubmitPackageSignedHappyPath asserts a signed submit package
+// with valid tapscript data passes full validation.
+func TestValidateSubmitPackageSignedHappyPath(t *testing.T) {
+	t.Parallel()
+
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	policy := scripts.CheckpointPolicy{
+		OperatorKey: operatorKey.PubKey(),
+		CSVDelay:    10,
+	}
+
+	ownerLeafScript := []byte{txscript.OP_TRUE}
+	checkpointRes, err := BuildCheckpointPSBT(policy, CheckpointInput{
+		SpentVTXO: SpentVTXORef{
+			Outpoint: wire.OutPoint{
+				Hash:  [32]byte{1},
+				Index: 0,
+			},
+			Output: &wire.TxOut{
+				Value:    5000,
+				PkScript: randomP2TRScript(t),
+			},
+		},
+		OwnerLeafScript: ownerLeafScript,
+	})
+	require.NoError(t, err)
+
+	arkPSBT, err := BuildArkPSBT([]CheckpointOutput{{
+		Txid:           checkpointRes.PSBT.UnsignedTx.TxHash(),
+		Output:         checkpointRes.PSBT.UnsignedTx.TxOut[0],
+		TapTreeEncoded: checkpointRes.TapTreeEncoded,
+	}}, []RecipientOutput{{
+		PkScript: randomP2TRScript(t),
+		Value:    btcutil.Amount(5000),
+	}})
+	require.NoError(t, err)
+
+	leaf, err := BuildTaprootTapLeafScript(
+		checkpointRes.TapTreeEncoded, ownerLeafScript,
+	)
+	require.NoError(t, err)
+	arkPSBT.Inputs[0].TaprootLeafScript =
+		[]*psbt.TaprootTapLeafScript{leaf}
+
+	_, err = ValidateSubmitPackageSigned(
+		arkPSBT, []*psbt.Packet{checkpointRes.PSBT},
+	)
+	require.NoError(t, err)
+}
+
+// TestValidateSubmitPackageSignedRejectsBadControlBlock asserts a tampered
+// control block fails full validation.
+func TestValidateSubmitPackageSignedRejectsBadControlBlock(t *testing.T) {
+	t.Parallel()
+
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	policy := scripts.CheckpointPolicy{
+		OperatorKey: operatorKey.PubKey(),
+		CSVDelay:    10,
+	}
+
+	ownerLeafScript := []byte{txscript.OP_TRUE}
+	checkpointRes, err := BuildCheckpointPSBT(policy, CheckpointInput{
+		SpentVTXO: SpentVTXORef{
+			Outpoint: wire.OutPoint{
+				Hash:  [32]byte{2},
+				Index: 0,
+			},
+			Output: &wire.TxOut{
+				Value:    5000,
+				PkScript: randomP2TRScript(t),
+			},
+		},
+		OwnerLeafScript: ownerLeafScript,
+	})
+	require.NoError(t, err)
+
+	arkPSBT, err := BuildArkPSBT([]CheckpointOutput{{
+		Txid:           checkpointRes.PSBT.UnsignedTx.TxHash(),
+		Output:         checkpointRes.PSBT.UnsignedTx.TxOut[0],
+		TapTreeEncoded: checkpointRes.TapTreeEncoded,
+	}}, []RecipientOutput{{
+		PkScript: randomP2TRScript(t),
+		Value:    btcutil.Amount(5000),
+	}})
+	require.NoError(t, err)
+
+	leaf, err := BuildTaprootTapLeafScript(
+		checkpointRes.TapTreeEncoded, ownerLeafScript,
+	)
+	require.NoError(t, err)
+	leaf.ControlBlock[0] ^= 0x01
+	arkPSBT.Inputs[0].TaprootLeafScript =
+		[]*psbt.TaprootTapLeafScript{leaf}
+
+	_, err = ValidateSubmitPackageSigned(
+		arkPSBT, []*psbt.Packet{checkpointRes.PSBT},
+	)
+	require.Error(t, err)
+}

--- a/lib/tx/oor/submit_signature_validate_test.go
+++ b/lib/tx/oor/submit_signature_validate_test.go
@@ -1,6 +1,8 @@
 package oor
 
 import (
+	"bytes"
+	"crypto/sha256"
 	"testing"
 
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -115,4 +117,185 @@ func TestValidateSubmitPackageSignedRejectsBadControlBlock(t *testing.T) {
 		arkPSBT, []*psbt.Packet{checkpointRes.PSBT},
 	)
 	require.Error(t, err)
+}
+
+// TestValidateFinalizePackageSignedAllowsMissingInputTapTree asserts finalize
+// signed validation accepts checkpoint inputs without taptree unknown metadata
+// when FinalScriptWitness is present and spendable.
+func TestValidateFinalizePackageSignedAllowsMissingInputTapTree(t *testing.T) {
+	t.Parallel()
+
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	policy := scripts.CheckpointPolicy{
+		OperatorKey: operatorKey.PubKey(),
+		CSVDelay:    10,
+	}
+
+	checkpointRes, err := BuildCheckpointPSBT(policy, CheckpointInput{
+		SpentVTXO: SpentVTXORef{
+			Outpoint: wire.OutPoint{
+				Hash:  [32]byte{3},
+				Index: 0,
+			},
+			Output: &wire.TxOut{
+				Value:    5000,
+				PkScript: p2WSHTrueScript(),
+			},
+		},
+		OwnerLeafScript: []byte{txscript.OP_TRUE},
+	})
+	require.NoError(t, err)
+
+	finalWitness, err := encodeFinalWitness(
+		wire.TxWitness{[]byte{txscript.OP_TRUE}},
+	)
+	require.NoError(t, err)
+	checkpointRes.PSBT.Inputs[0].FinalScriptWitness = finalWitness
+	checkpointRes.PSBT.Inputs[0].Unknowns = nil
+
+	arkPSBT, err := BuildArkPSBT([]CheckpointOutput{{
+		Txid:           checkpointRes.PSBT.UnsignedTx.TxHash(),
+		Output:         checkpointRes.PSBT.UnsignedTx.TxOut[0],
+		TapTreeEncoded: checkpointRes.TapTreeEncoded,
+	}}, []RecipientOutput{{
+		PkScript: randomP2TRScript(t),
+		Value:    btcutil.Amount(5000),
+	}})
+	require.NoError(t, err)
+
+	err = ValidateFinalizePackageSigned(
+		arkPSBT, []*psbt.Packet{checkpointRes.PSBT},
+	)
+	require.NoError(t, err)
+}
+
+// TestValidateFinalizeSignedRejectsMalformedInputTapTree asserts
+// malformed taptree input metadata remains a hard validation error.
+func TestValidateFinalizeSignedRejectsMalformedInputTapTree(t *testing.T) {
+	t.Parallel()
+
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	policy := scripts.CheckpointPolicy{
+		OperatorKey: operatorKey.PubKey(),
+		CSVDelay:    10,
+	}
+
+	checkpointRes, err := BuildCheckpointPSBT(policy, CheckpointInput{
+		SpentVTXO: SpentVTXORef{
+			Outpoint: wire.OutPoint{
+				Hash:  [32]byte{4},
+				Index: 0,
+			},
+			Output: &wire.TxOut{
+				Value:    5000,
+				PkScript: p2WSHTrueScript(),
+			},
+		},
+		OwnerLeafScript: []byte{txscript.OP_TRUE},
+	})
+	require.NoError(t, err)
+
+	finalWitness, err := encodeFinalWitness(
+		wire.TxWitness{[]byte{txscript.OP_TRUE}},
+	)
+	require.NoError(t, err)
+	checkpointRes.PSBT.Inputs[0].FinalScriptWitness = finalWitness
+	checkpointRes.PSBT.Inputs[0].Unknowns = []*psbt.Unknown{
+		{
+			Key:   append([]byte(nil), TapTreePSBTKey...),
+			Value: []byte{0x01},
+		},
+		{
+			Key:   append([]byte(nil), TapTreePSBTKey...),
+			Value: []byte{0x02},
+		},
+	}
+
+	arkPSBT, err := BuildArkPSBT([]CheckpointOutput{{
+		Txid:           checkpointRes.PSBT.UnsignedTx.TxHash(),
+		Output:         checkpointRes.PSBT.UnsignedTx.TxOut[0],
+		TapTreeEncoded: checkpointRes.TapTreeEncoded,
+	}}, []RecipientOutput{{
+		PkScript: randomP2TRScript(t),
+		Value:    btcutil.Amount(5000),
+	}})
+	require.NoError(t, err)
+
+	err = ValidateFinalizePackageSigned(
+		arkPSBT, []*psbt.Packet{checkpointRes.PSBT},
+	)
+	require.ErrorContains(t, err, "multiple tap tree entries found")
+}
+
+// TestValidateSubmitSignedRejectsMissingArkInputTapTree asserts submit
+// signed validation still enforces required Ark-input taptree metadata.
+func TestValidateSubmitSignedRejectsMissingArkInputTapTree(t *testing.T) {
+	t.Parallel()
+
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	policy := scripts.CheckpointPolicy{
+		OperatorKey: operatorKey.PubKey(),
+		CSVDelay:    10,
+	}
+
+	checkpointRes, err := BuildCheckpointPSBT(policy, CheckpointInput{
+		SpentVTXO: SpentVTXORef{
+			Outpoint: wire.OutPoint{
+				Hash:  [32]byte{5},
+				Index: 0,
+			},
+			Output: &wire.TxOut{
+				Value:    5000,
+				PkScript: randomP2TRScript(t),
+			},
+		},
+		OwnerLeafScript: []byte{txscript.OP_TRUE},
+	})
+	require.NoError(t, err)
+
+	arkPSBT, err := BuildArkPSBT([]CheckpointOutput{{
+		Txid:           checkpointRes.PSBT.UnsignedTx.TxHash(),
+		Output:         checkpointRes.PSBT.UnsignedTx.TxOut[0],
+		TapTreeEncoded: checkpointRes.TapTreeEncoded,
+	}}, []RecipientOutput{{
+		PkScript: randomP2TRScript(t),
+		Value:    btcutil.Amount(5000),
+	}})
+	require.NoError(t, err)
+
+	arkPSBT.Inputs[0].Unknowns = nil
+
+	_, err = ValidateSubmitPackageSigned(
+		arkPSBT, []*psbt.Packet{checkpointRes.PSBT},
+	)
+	require.ErrorContains(t, err, "missing tap tree metadata")
+}
+
+func p2WSHTrueScript() []byte {
+	scriptHash := sha256.Sum256([]byte{txscript.OP_TRUE})
+	return append([]byte{txscript.OP_0, 0x20}, scriptHash[:]...)
+}
+
+func encodeFinalWitness(wit wire.TxWitness) ([]byte, error) {
+	var b bytes.Buffer
+
+	err := wire.WriteVarInt(&b, 0, uint64(len(wit)))
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range wit {
+		err = wire.WriteVarBytes(&b, 0, wit[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return b.Bytes(), nil
 }

--- a/lib/tx/oor/taptree.go
+++ b/lib/tx/oor/taptree.go
@@ -2,6 +2,7 @@ package oor
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 
 	"github.com/btcsuite/btcd/btcutil/psbt"
@@ -22,6 +23,10 @@ var (
 	// A future version should consider namespacing this (for example,
 	// `ark/taptree`) to reduce collision risk with other PSBT extensions.
 	TapTreePSBTKey = []byte("taptree")
+
+	// ErrTapTreeNotFound indicates that a PSBT input does not include
+	// TapTreePSBTKey metadata.
+	ErrTapTreeNotFound = errors.New("tap tree not found")
 )
 
 // EncodeTapTree encodes a set of tapscript leaves into a single byte blob.
@@ -97,7 +102,7 @@ func GetTapTreePSBTInput(input psbt.PInput) ([]byte, error) {
 	}
 
 	if !found {
-		return nil, fmt.Errorf("tap tree not found")
+		return nil, ErrTapTreeNotFound
 	}
 
 	return tapTreeValue, nil

--- a/oor/actor_resume_test.go
+++ b/oor/actor_resume_test.go
@@ -21,7 +21,8 @@ import (
 type pausedFinalizeHandler struct {
 	t *testing.T
 
-	clientSigner input.Signer
+	clientSigner   input.Signer
+	operatorSigner input.Signer
 
 	finalizePaused bool
 }
@@ -36,6 +37,13 @@ func (h *pausedFinalizeHandler) Handle(_ context.Context, sessionID SessionID,
 	case *SendSubmitPackageRequest:
 		txid := msg.ArkPSBT.UnsignedTx.TxHash()
 		require.Equal(h.t, SessionID(txid), sessionID)
+
+		err := coSignCheckpointPSBTsForTest(
+			h.operatorSigner,
+			msg.TransferInputs,
+			msg.CheckpointPSBTs,
+		)
+		require.NoError(h.t, err)
 
 		return []Event{
 			&SubmitAcceptedEvent{
@@ -81,7 +89,8 @@ var _ OutboxHandler = (*pausedFinalizeHandler)(nil)
 type pausedSubmitHandler struct {
 	t *testing.T
 
-	clientSigner input.Signer
+	clientSigner   input.Signer
+	operatorSigner input.Signer
 
 	submitPaused bool
 }
@@ -96,6 +105,13 @@ func (h *pausedSubmitHandler) Handle(_ context.Context, sessionID SessionID,
 	case *SendSubmitPackageRequest:
 		txid := msg.ArkPSBT.UnsignedTx.TxHash()
 		require.Equal(h.t, SessionID(txid), sessionID)
+
+		err := coSignCheckpointPSBTsForTest(
+			h.operatorSigner,
+			msg.TransferInputs,
+			msg.CheckpointPSBTs,
+		)
+		require.NoError(h.t, err)
 
 		if !h.submitPaused {
 			h.submitPaused = true
@@ -144,7 +160,8 @@ var _ OutboxHandler = (*pausedSubmitHandler)(nil)
 type pausedCoSignedHandler struct {
 	t *testing.T
 
-	clientSigner input.Signer
+	clientSigner   input.Signer
+	operatorSigner input.Signer
 
 	signPaused bool
 }
@@ -159,6 +176,13 @@ func (h *pausedCoSignedHandler) Handle(_ context.Context, sessionID SessionID,
 	case *SendSubmitPackageRequest:
 		txid := msg.ArkPSBT.UnsignedTx.TxHash()
 		require.Equal(h.t, SessionID(txid), sessionID)
+
+		err := coSignCheckpointPSBTsForTest(
+			h.operatorSigner,
+			msg.TransferInputs,
+			msg.CheckpointPSBTs,
+		)
+		require.NoError(h.t, err)
 
 		return []Event{
 			&SubmitAcceptedEvent{
@@ -210,7 +234,8 @@ var _ OutboxHandler = (*pausedCoSignedHandler)(nil)
 type cosignedButDroppedHandler struct {
 	t *testing.T
 
-	clientSigner input.Signer
+	clientSigner   input.Signer
+	operatorSigner input.Signer
 
 	firstSubmitDropped bool
 
@@ -230,6 +255,13 @@ func (h *cosignedButDroppedHandler) Handle(_ context.Context,
 	case *SendSubmitPackageRequest:
 		txid := msg.ArkPSBT.UnsignedTx.TxHash()
 		require.Equal(h.t, SessionID(txid), sessionID)
+
+		err := coSignCheckpointPSBTsForTest(
+			h.operatorSigner,
+			msg.TransferInputs,
+			msg.CheckpointPSBTs,
+		)
+		require.NoError(h.t, err)
 
 		arkRaw, err := psbtutil.Serialize(msg.ArkPSBT)
 		require.NoError(h.t, err)
@@ -320,6 +352,9 @@ func TestOORClientActorResumeFromSnapshot(t *testing.T) {
 	require.NoError(t, err)
 
 	clientSigner := input.NewMockSigner([]*btcec.PrivateKey{clientKey}, nil)
+	operatorSigner := input.NewMockSigner(
+		[]*btcec.PrivateKey{operatorKey}, nil,
+	)
 
 	inputs := []TransferInput{
 		newTestTransferInput(
@@ -342,8 +377,9 @@ func TestOORClientActorResumeFromSnapshot(t *testing.T) {
 	deliveryStore := newTestDeliveryStore(t)
 
 	handler := &pausedFinalizeHandler{
-		t:            t,
-		clientSigner: clientSigner,
+		t:              t,
+		clientSigner:   clientSigner,
+		operatorSigner: operatorSigner,
 	}
 
 	actor1 := NewOORClientActor(ClientActorCfg{
@@ -437,6 +473,9 @@ func TestOORClientActorResumeAfterServerCoSigned(t *testing.T) {
 	require.NoError(t, err)
 
 	clientSigner := input.NewMockSigner([]*btcec.PrivateKey{clientKey}, nil)
+	operatorSigner := input.NewMockSigner(
+		[]*btcec.PrivateKey{operatorKey}, nil,
+	)
 
 	inputs := []TransferInput{
 		newTestTransferInput(
@@ -458,8 +497,9 @@ func TestOORClientActorResumeAfterServerCoSigned(t *testing.T) {
 
 	deliveryStore := newTestDeliveryStore(t)
 	handler := &cosignedButDroppedHandler{
-		t:            t,
-		clientSigner: clientSigner,
+		t:              t,
+		clientSigner:   clientSigner,
+		operatorSigner: operatorSigner,
 	}
 
 	actor1 := NewOORClientActor(ClientActorCfg{
@@ -554,6 +594,9 @@ func TestOORClientActorResumeFromSnapshotSubmitSent(t *testing.T) {
 	require.NoError(t, err)
 
 	clientSigner := input.NewMockSigner([]*btcec.PrivateKey{clientKey}, nil)
+	operatorSigner := input.NewMockSigner(
+		[]*btcec.PrivateKey{operatorKey}, nil,
+	)
 
 	inputs := []TransferInput{
 		newTestTransferInput(
@@ -575,8 +618,9 @@ func TestOORClientActorResumeFromSnapshotSubmitSent(t *testing.T) {
 
 	deliveryStore := newTestDeliveryStore(t)
 	handler := &pausedSubmitHandler{
-		t:            t,
-		clientSigner: clientSigner,
+		t:              t,
+		clientSigner:   clientSigner,
+		operatorSigner: operatorSigner,
 	}
 
 	actor1 := NewOORClientActor(ClientActorCfg{
@@ -667,6 +711,9 @@ func TestOORClientActorResumeFromSnapshotCoSigned(t *testing.T) {
 	require.NoError(t, err)
 
 	clientSigner := input.NewMockSigner([]*btcec.PrivateKey{clientKey}, nil)
+	operatorSigner := input.NewMockSigner(
+		[]*btcec.PrivateKey{operatorKey}, nil,
+	)
 
 	inputs := []TransferInput{
 		newTestTransferInput(
@@ -688,8 +735,9 @@ func TestOORClientActorResumeFromSnapshotCoSigned(t *testing.T) {
 
 	deliveryStore := newTestDeliveryStore(t)
 	handler := &pausedCoSignedHandler{
-		t:            t,
-		clientSigner: clientSigner,
+		t:              t,
+		clientSigner:   clientSigner,
+		operatorSigner: operatorSigner,
 	}
 
 	actor1 := NewOORClientActor(ClientActorCfg{
@@ -780,6 +828,9 @@ func TestOORClientActorDurableRestartAutoResume(t *testing.T) {
 	require.NoError(t, err)
 
 	clientSigner := input.NewMockSigner([]*btcec.PrivateKey{clientKey}, nil)
+	operatorSigner := input.NewMockSigner(
+		[]*btcec.PrivateKey{operatorKey}, nil,
+	)
 
 	inputs := []TransferInput{
 		newTestTransferInput(
@@ -801,8 +852,9 @@ func TestOORClientActorDurableRestartAutoResume(t *testing.T) {
 
 	deliveryStore := newTestDeliveryStore(t)
 	handler := &pausedFinalizeHandler{
-		t:            t,
-		clientSigner: clientSigner,
+		t:              t,
+		clientSigner:   clientSigner,
+		operatorSigner: operatorSigner,
 	}
 
 	const actorID = "oor-durable-restart-actor"

--- a/oor/actor_test.go
+++ b/oor/actor_test.go
@@ -19,7 +19,8 @@ import (
 type testOutboxHandler struct {
 	t *testing.T
 
-	clientSigner input.Signer
+	clientSigner   input.Signer
+	operatorSigner input.Signer
 }
 
 // Handle processes the outbox request and returns follow-up events.
@@ -32,6 +33,13 @@ func (h *testOutboxHandler) Handle(_ context.Context, sessionID SessionID,
 	case *SendSubmitPackageRequest:
 		txid := msg.ArkPSBT.UnsignedTx.TxHash()
 		require.Equal(h.t, SessionID(txid), sessionID)
+
+		err := coSignCheckpointPSBTsForTest(
+			h.operatorSigner,
+			msg.TransferInputs,
+			msg.CheckpointPSBTs,
+		)
+		require.NoError(h.t, err)
 
 		return []Event{
 			&SubmitAcceptedEvent{
@@ -90,6 +98,9 @@ func TestOORClientActorHappyPath(t *testing.T) {
 	require.NoError(t, err)
 
 	clientSigner := input.NewMockSigner([]*btcec.PrivateKey{clientKey}, nil)
+	operatorSigner := input.NewMockSigner(
+		[]*btcec.PrivateKey{operatorKey}, nil,
+	)
 
 	inputs := []TransferInput{
 		newTestTransferInput(
@@ -111,8 +122,9 @@ func TestOORClientActorHappyPath(t *testing.T) {
 
 	actor := NewOORClientActor(ClientActorCfg{
 		OutboxHandler: &testOutboxHandler{
-			t:            t,
-			clientSigner: clientSigner,
+			t:              t,
+			clientSigner:   clientSigner,
+			operatorSigner: operatorSigner,
 		},
 		DeliveryStore: newTestDeliveryStore(t),
 		ActorID:       "oor-actor-test-happy",

--- a/oor/checkpoint_sign.go
+++ b/oor/checkpoint_sign.go
@@ -1,22 +1,28 @@
 package oor
 
 import (
+	"bytes"
 	"fmt"
 
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/lib/tx"
 	"github.com/lightninglabs/darepo-client/lib/tx/psbtutil"
 	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/keychain"
 )
 
 // SignCheckpointPSBTs attaches the client-side collaborative VTXO spend
 // signatures to each checkpoint PSBT.
 //
 // Each checkpoint PSBT is expected to spend exactly one VTXO (input index 0).
-// The TransferInput slice is expected to match the checkpoint PSBT slice
-// 1:1.
+// The TransferInput slice is expected to match the checkpoint PSBT slice 1:1.
+// Before client signing, the operator signature is verified to preserve
+// custody: clients only sign once the operator has committed its half of the
+// collaborative spend path.
 func SignCheckpointPSBTs(signer input.Signer, inputs []TransferInput,
 	checkpoints []*psbt.Packet) error {
 
@@ -35,11 +41,276 @@ func SignCheckpointPSBTs(signer input.Signer, inputs []TransferInput,
 			"count %d", len(inputs), len(checkpoints))
 	}
 
+	// Before the client adds its own signature material, verify the
+	// server/operator signature that was attached at submit acceptance.
+	// This preserves custody: we only proceed once the
+	// collaborative spend is already cryptographically valid from
+	// the operator side.
+	err := validateOperatorCheckpointSignatures(inputs, checkpoints)
+	if err != nil {
+		return err
+	}
+
 	for i := range inputs {
-		err := signCheckpointPSBT(signer, &inputs[i], checkpoints[i])
+		err = signCheckpointPSBT(signer, &inputs[i], checkpoints[i])
 		if err != nil {
 			return fmt.Errorf("sign checkpoint %d: %w", i, err)
 		}
+	}
+
+	return nil
+}
+
+// validateOperatorCheckpointSignatures verifies each checkpoint includes a
+// valid operator collaborative-path signature before client signing begins.
+//
+// This ensures the checkpoint witness UTXO matches the expected VTXO data and
+// that the operator signature correctly spends the collaborative leaf.
+func validateOperatorCheckpointSignatures(inputs []TransferInput,
+	checkpoints []*psbt.Packet) error {
+
+	inputByOutpoint := make(map[wire.OutPoint]*TransferInput, len(inputs))
+	for i := range inputs {
+		in := &inputs[i]
+		if in == nil || in.VTXO == nil {
+			return fmt.Errorf("transfer input must include vtxo")
+		}
+
+		err := in.Validate()
+		if err != nil {
+			return err
+		}
+
+		inputByOutpoint[in.VTXO.Outpoint] = in
+	}
+
+	for i := range checkpoints {
+		checkpoint := checkpoints[i]
+		if checkpoint == nil || checkpoint.UnsignedTx == nil {
+			return fmt.Errorf(
+				"checkpoint psbt must include unsigned tx",
+			)
+		}
+
+		if len(checkpoint.UnsignedTx.TxIn) != 1 ||
+			len(checkpoint.Inputs) != 1 {
+
+			return fmt.Errorf(
+				"checkpoint must have exactly one input",
+			)
+		}
+
+		prevOutpoint := checkpoint.UnsignedTx.TxIn[0].PreviousOutPoint
+		in := inputByOutpoint[prevOutpoint]
+		if in == nil {
+			return fmt.Errorf(
+				"unknown checkpoint input outpoint %s",
+				prevOutpoint,
+			)
+		}
+
+		err := validateSingleOperatorCheckpointSignature(
+			in, checkpoint,
+		)
+		if err != nil {
+			return fmt.Errorf("checkpoint %d: %w", i, err)
+		}
+	}
+
+	return nil
+}
+
+// validateSingleOperatorCheckpointSignature verifies one checkpoint contains a
+// valid operator collaborative-path script-spend signature.
+func validateSingleOperatorCheckpointSignature(in *TransferInput,
+	checkpoint *psbt.Packet) error {
+
+	vtxo := in.VTXO
+	if vtxo == nil || vtxo.OperatorKey == nil {
+		return fmt.Errorf("operator key must be provided")
+	}
+
+	prevOut := checkpoint.Inputs[0].WitnessUtxo
+	if prevOut == nil {
+		return fmt.Errorf("checkpoint must include witness utxo")
+	}
+
+	if prevOut.Value != int64(vtxo.Amount) {
+		return fmt.Errorf("checkpoint witness utxo value mismatch")
+	}
+
+	if !bytes.Equal(prevOut.PkScript, vtxo.PkScript) {
+		return fmt.Errorf("checkpoint witness utxo script mismatch")
+	}
+
+	prevFetcher := txscript.NewCannedPrevOutputFetcher(
+		prevOut.PkScript, prevOut.Value,
+	)
+	sigHashes := txscript.NewTxSigHashes(
+		checkpoint.UnsignedTx, prevFetcher,
+	)
+
+	signDesc, spendInfo, err := tx.NewVTXOCollabSignDescriptor(
+		&tx.VTXOSpendContext{
+			Outpoint:  vtxo.Outpoint,
+			Output:    prevOut,
+			TapScript: vtxo.TapScript,
+		},
+		keychain.KeyDescriptor{PubKey: vtxo.OperatorKey},
+		0,
+		sigHashes,
+		prevFetcher,
+	)
+	if err != nil {
+		return err
+	}
+
+	err = requireTapLeafScript(
+		&checkpoint.Inputs[0],
+		spendInfo.WitnessScript,
+		spendInfo.ControlBlock,
+	)
+	if err != nil {
+		return err
+	}
+
+	sigRec, err := findTaprootScriptSpendSig(
+		&checkpoint.Inputs[0], vtxo.OperatorKey,
+		spendInfo.WitnessScript,
+	)
+	if err != nil {
+		return err
+	}
+
+	return verifyTaprootScriptSpendSig(
+		checkpoint.UnsignedTx, signDesc.InputIndex, prevFetcher,
+		spendInfo.WitnessScript, sigRec,
+	)
+}
+
+// requireTapLeafScript asserts the PSBT input includes the expected tapleaf
+// script and control block for the collaborative spend path.
+func requireTapLeafScript(in *psbt.PInput, leafScript,
+	controlBlock []byte) error {
+
+	if in == nil {
+		return fmt.Errorf("psbt input must be provided")
+	}
+
+	for i := range in.TaprootLeafScript {
+		leaf := in.TaprootLeafScript[i]
+		if leaf == nil {
+			continue
+		}
+
+		if bytes.Equal(leaf.Script, leafScript) &&
+			bytes.Equal(leaf.ControlBlock, controlBlock) {
+
+			return nil
+		}
+	}
+
+	return fmt.Errorf("checkpoint missing collaborative tap leaf")
+}
+
+// findTaprootScriptSpendSig locates a taproot script spend signature for the
+// given pubkey and leaf script within a PSBT input.
+func findTaprootScriptSpendSig(in *psbt.PInput, pubKey *btcec.PublicKey,
+	leafScript []byte) (*psbt.TaprootScriptSpendSig, error) {
+
+	if in == nil {
+		return nil, fmt.Errorf("psbt input must be provided")
+	}
+
+	if pubKey == nil {
+		return nil, fmt.Errorf("pubkey must be provided")
+	}
+
+	leafHash := txscript.NewBaseTapLeaf(leafScript).TapHash()
+	leafHashBytes := leafHash[:]
+	wantPub := schnorr.SerializePubKey(pubKey)
+
+	for i := range in.TaprootScriptSpendSig {
+		sigRec := in.TaprootScriptSpendSig[i]
+		if sigRec == nil {
+			continue
+		}
+
+		if !bytes.Equal(sigRec.XOnlyPubKey, wantPub) {
+			continue
+		}
+
+		if !bytes.Equal(sigRec.LeafHash, leafHashBytes) {
+			continue
+		}
+
+		return sigRec, nil
+	}
+
+	return nil, fmt.Errorf("missing taproot script spend signature")
+}
+
+// parseTaprootScriptSpendSigBytes parses a schnorr signature that may include
+// an appended sighash byte, enforcing the expected sighash type.
+func parseTaprootScriptSpendSigBytes(raw []byte,
+	sigHash txscript.SigHashType) (*schnorr.Signature, error) {
+
+	switch {
+	case len(raw) == schnorr.SignatureSize:
+		return schnorr.ParseSignature(raw)
+
+	case len(raw) == schnorr.SignatureSize+1 &&
+		raw[len(raw)-1] == byte(sigHash):
+		return schnorr.ParseSignature(raw[:schnorr.SignatureSize])
+
+	default:
+		return nil, fmt.Errorf(
+			"invalid schnorr signature size: %d", len(raw),
+		)
+	}
+}
+
+// verifyTaprootScriptSpendSig verifies a taproot script spend signature against
+// the provided transaction, prevout data, and leaf script.
+func verifyTaprootScriptSpendSig(tx *wire.MsgTx, inputIndex int,
+	prevFetcher txscript.PrevOutputFetcher, leafScript []byte,
+	sigRec *psbt.TaprootScriptSpendSig) error {
+
+	if tx == nil {
+		return fmt.Errorf("tx must be provided")
+	}
+
+	if sigRec == nil {
+		return fmt.Errorf("signature must be provided")
+	}
+
+	sig, err := parseTaprootScriptSpendSigBytes(
+		sigRec.Signature, sigRec.SigHash,
+	)
+	if err != nil {
+		return err
+	}
+
+	pubKey, err := schnorr.ParsePubKey(sigRec.XOnlyPubKey)
+	if err != nil {
+		return fmt.Errorf("parse pubkey: %w", err)
+	}
+
+	sigHashes := txscript.NewTxSigHashes(tx, prevFetcher)
+	sigHash, err := txscript.CalcTapscriptSignaturehash(
+		sigHashes,
+		sigRec.SigHash,
+		tx,
+		inputIndex,
+		prevFetcher,
+		txscript.NewBaseTapLeaf(leafScript),
+	)
+	if err != nil {
+		return fmt.Errorf("calculate tapscript sighash: %w", err)
+	}
+
+	if !sig.Verify(sigHash, pubKey) {
+		return fmt.Errorf("invalid taproot script signature")
 	}
 
 	return nil

--- a/oor/checkpoint_sign_testhelpers_test.go
+++ b/oor/checkpoint_sign_testhelpers_test.go
@@ -1,0 +1,139 @@
+package oor
+
+import (
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/tx"
+	"github.com/lightninglabs/darepo-client/lib/tx/psbtutil"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/keychain"
+)
+
+// coSignCheckpointPSBTsForTest attaches operator collaborative signatures to
+// checkpoint PSBTs. Tests use this to model submit-accepted artifacts returned
+// by the server.
+func coSignCheckpointPSBTsForTest(signer input.Signer, inputs []TransferInput,
+	checkpoints []*psbt.Packet) error {
+
+	if signer == nil {
+		return fmt.Errorf("signer must be provided")
+	}
+
+	if len(inputs) == 0 {
+		return fmt.Errorf("transfer inputs must be provided")
+	}
+
+	if len(checkpoints) == 0 {
+		return fmt.Errorf("checkpoint psbts must be provided")
+	}
+
+	inputByOutpoint := make(map[wire.OutPoint]*TransferInput, len(inputs))
+	for i := range inputs {
+		in := &inputs[i]
+		if in == nil || in.VTXO == nil {
+			return fmt.Errorf("transfer input must include vtxo")
+		}
+
+		err := in.Validate()
+		if err != nil {
+			return err
+		}
+
+		inputByOutpoint[in.VTXO.Outpoint] = in
+	}
+
+	for i := range checkpoints {
+		checkpoint := checkpoints[i]
+		if checkpoint == nil || checkpoint.UnsignedTx == nil {
+			return fmt.Errorf(
+				"checkpoint psbt must include unsigned tx",
+			)
+		}
+
+		if len(checkpoint.UnsignedTx.TxIn) != 1 ||
+			len(checkpoint.Inputs) != 1 {
+
+			return fmt.Errorf(
+				"checkpoint must have exactly one input",
+			)
+		}
+
+		prevOutpoint := checkpoint.UnsignedTx.TxIn[0].PreviousOutPoint
+		in := inputByOutpoint[prevOutpoint]
+		if in == nil {
+			return fmt.Errorf(
+				"unknown checkpoint input outpoint %s",
+				prevOutpoint,
+			)
+		}
+
+		vtxo := in.VTXO
+		if vtxo == nil || vtxo.OperatorKey == nil {
+			return fmt.Errorf("operator key must be provided")
+		}
+
+		prevOut := checkpoint.Inputs[0].WitnessUtxo
+		if prevOut == nil {
+			return fmt.Errorf(
+				"checkpoint must include witness utxo",
+			)
+		}
+
+		prevFetcher := txscript.NewCannedPrevOutputFetcher(
+			prevOut.PkScript, prevOut.Value,
+		)
+		sigHashes := txscript.NewTxSigHashes(
+			checkpoint.UnsignedTx, prevFetcher,
+		)
+
+		signDesc, spendInfo, err := tx.NewVTXOCollabSignDescriptor(
+			&tx.VTXOSpendContext{
+				Outpoint:  vtxo.Outpoint,
+				Output:    prevOut,
+				TapScript: vtxo.TapScript,
+			},
+			keychain.KeyDescriptor{PubKey: vtxo.OperatorKey},
+			0,
+			sigHashes,
+			prevFetcher,
+		)
+		if err != nil {
+			return err
+		}
+
+		sig, err := signer.SignOutputRaw(
+			checkpoint.UnsignedTx, signDesc,
+		)
+		if err != nil {
+			return err
+		}
+
+		sigBytes := sig.Serialize()
+		if len(sigBytes) == 0 {
+			return fmt.Errorf("signer returned empty signature")
+		}
+
+		input := &checkpoint.Inputs[0]
+
+		err = psbtutil.AddTapLeafScript(input, spendInfo)
+		if err != nil {
+			return err
+		}
+
+		err = psbtutil.AddTaprootScriptSpendSig(
+			input,
+			vtxo.OperatorKey,
+			spendInfo.WitnessScript,
+			sigBytes,
+			signDesc.HashType,
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/oor/checkpoint_sign_validation_test.go
+++ b/oor/checkpoint_sign_validation_test.go
@@ -1,0 +1,109 @@
+package oor
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/scripts"
+	oortx "github.com/lightninglabs/darepo-client/lib/tx/oor"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/stretchr/testify/require"
+)
+
+// buildCheckpointForSignValidationTest constructs a checkpoint PSBT for a
+// single transfer input to use in operator-signature validation tests.
+func buildCheckpointForSignValidationTest(t *testing.T,
+	in TransferInput) *psbt.Packet {
+
+	t.Helper()
+
+	require.NotNil(t, in.VTXO)
+
+	policy := scripts.CheckpointPolicy{
+		OperatorKey: in.VTXO.OperatorKey,
+		CSVDelay:    in.VTXO.RelativeExpiry,
+	}
+
+	res, err := oortx.BuildCheckpointPSBT(policy, oortx.CheckpointInput{
+		SpentVTXO: oortx.SpentVTXORef{
+			Outpoint: in.VTXO.Outpoint,
+			Output: &wire.TxOut{
+				Value:    int64(in.VTXO.Amount),
+				PkScript: in.VTXO.PkScript,
+			},
+		},
+		OwnerLeafScript: in.OwnerLeafScript,
+	})
+	require.NoError(t, err)
+
+	return res.PSBT
+}
+
+// TestSignCheckpointPSBTsRejectsMissingOperatorSignature asserts client
+// signing refuses checkpoints without operator signatures.
+func TestSignCheckpointPSBTsRejectsMissingOperatorSignature(t *testing.T) {
+	t.Parallel()
+
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	clientKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	clientSigner := input.NewMockSigner([]*btcec.PrivateKey{clientKey}, nil)
+
+	in := newTestTransferInput(
+		t, clientKey, operatorKey.PubKey(),
+		wire.OutPoint{Hash: [32]byte{0x01}, Index: 0},
+		btcutil.Amount(50_000),
+	)
+	checkpoint := buildCheckpointForSignValidationTest(t, in)
+
+	err = SignCheckpointPSBTs(
+		clientSigner, []TransferInput{in}, []*psbt.Packet{checkpoint},
+	)
+	require.ErrorContains(
+		t, err, "checkpoint missing collaborative tap leaf",
+	)
+}
+
+// TestSignCheckpointPSBTsRejectsInvalidOperatorSignature asserts client
+// signing refuses checkpoints with invalid operator signatures.
+func TestSignCheckpointPSBTsRejectsInvalidOperatorSignature(t *testing.T) {
+	t.Parallel()
+
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	clientKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	clientSigner := input.NewMockSigner([]*btcec.PrivateKey{clientKey}, nil)
+	operatorSigner := input.NewMockSigner(
+		[]*btcec.PrivateKey{operatorKey}, nil,
+	)
+
+	in := newTestTransferInput(
+		t, clientKey, operatorKey.PubKey(),
+		wire.OutPoint{Hash: [32]byte{0x02}, Index: 0},
+		btcutil.Amount(50_000),
+	)
+	checkpoint := buildCheckpointForSignValidationTest(t, in)
+
+	err = coSignCheckpointPSBTsForTest(
+		operatorSigner, []TransferInput{in}, []*psbt.Packet{checkpoint},
+	)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, checkpoint.Inputs[0].TaprootScriptSpendSig)
+	operatorSig := checkpoint.Inputs[0].TaprootScriptSpendSig[0]
+	require.NotNil(t, operatorSig)
+	require.NotEmpty(t, operatorSig.Signature)
+	operatorSig.Signature[0] ^= 0x01
+
+	err = SignCheckpointPSBTs(
+		clientSigner, []TransferInput{in}, []*psbt.Packet{checkpoint},
+	)
+	require.ErrorContains(t, err, "invalid taproot script signature")
+}

--- a/oor/session_test.go
+++ b/oor/session_test.go
@@ -33,6 +33,9 @@ func TestSessionHappyPath(t *testing.T) {
 	require.NoError(t, err)
 
 	clientSigner := input.NewMockSigner([]*btcec.PrivateKey{clientKey}, nil)
+	operatorSigner := input.NewMockSigner(
+		[]*btcec.PrivateKey{operatorKey}, nil,
+	)
 
 	inputs := []TransferInput{
 		newTestTransferInput(
@@ -62,6 +65,11 @@ func TestSessionHappyPath(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, submit.ArkPSBT)
 	require.NotEmpty(t, submit.CheckpointPSBTs)
+
+	err = coSignCheckpointPSBTsForTest(
+		operatorSigner, submit.TransferInputs, submit.CheckpointPSBTs,
+	)
+	require.NoError(t, err)
 
 	state, err := session.FSM.CurrentState()
 	require.NoError(t, err)

--- a/oor/transitions.go
+++ b/oor/transitions.go
@@ -213,7 +213,7 @@ func (s *AwaitingCheckpointSignatures) ProcessEvent(ctx context.Context,
 		}
 
 		// Validate finalize package before emitting request.
-		err = oortx.ValidateFinalizePackage(
+		err = oortx.ValidateFinalizePackageSigned(
 			s.ArkPSBT, evt.FinalCheckpointPSBTs,
 		)
 		if err != nil {


### PR DESCRIPTION
## Motivation

After split-3 lands the client-side OOR actor with outgoing and incoming FSMs, the validation helpers (`ValidateSubmitPackage`, `ValidateFinalizePackage`) only perform structural checks: canonical ordering, checkpoint-to-Ark input matching, and witness UTXO consistency. A structurally valid package could still be unspendable if the taproot witnesses are missing, malformed, or signed with the wrong key.

More critically, the client has no defense against a malicious operator: `SignCheckpointPSBTs` would attach the client's collaborative-leaf signature without verifying that the operator had already committed a valid signature on the same leaf.

This PR closes both gaps before split-4 layers retry-backoff and recovery semantics on top.

## What this PR adds

### PSBT script-spend validation library (`lib/tx/oor/`)

`ValidateSubmitPackageSigned` and `ValidateFinalizePackageSigned` go beyond structural PSBT checks: they reconstruct taproot witnesses from PSBT tap-tree metadata and execute the Bitcoin script VM (`txscript.NewEngine`) against each checkpoint input, proving on-chain spendability rather than just well-formedness. This library is also used by the server-side validation.

### Operator signature verification (`oor/checkpoint_sign.go`)

`validateOperatorCheckpointSignatures` is called inside `SignCheckpointPSBTs` before the client attaches its own signature. For each checkpoint input it locates the operator's taproot script-spend signature via the tap-leaf hash, parses the schnorr signature bytes, recomputes the tapscript sighash, and verifies it against the operator public key.

This enforces the custody invariant: **the client never co-signs unless the operator's collaborative-leaf schnorr signature is already valid and verifiable.**

### FSM integration + test alignment

- `AwaitingCheckpointSignatures` now calls `ValidateFinalizePackageSigned` (was `ValidateFinalizePackage`) so finalized checkpoint PSBTs are script-VM-verified before the client emits the finalize request.
- All test outbox handlers updated to produce real operator co-signatures via `coSignCheckpointPSBTsForTest`, replacing previous placeholder witnesses.

## Commits

```
951ab38 oor: add PSBT script-spend validation library
3ac5d85 oor: validate operator sigs before client co-sign
9efc30d oor: wire signed validation and align test signatures
```