### PR TITLE
mailbox: fix AwaitRPC lost-wakeup flake

### DIFF
--- a/mailbox/client/client.go
+++ b/mailbox/client/client.go
@@ -179,14 +179,15 @@ func (c *Client) AwaitRPC(ctx context.Context, correlationID string,
 	resp proto.Message) error {
 
 	for {
-		data, ok := c.popPending(correlationID)
-		if ok {
-			return (proto.UnmarshalOptions{
+		data, ch, hasPending := c.popPendingOrAddWaiter(correlationID)
+		if hasPending {
+			unmarshal := proto.UnmarshalOptions{
 				DiscardUnknown: true,
-			}).Unmarshal(data, resp)
+			}
+
+			return unmarshal.Unmarshal(data, resp)
 		}
 
-		ch := c.addWaiter(correlationID)
 		select {
 		case <-ch:
 		case <-ctx.Done():
@@ -341,31 +342,25 @@ func (c *Client) handleEnvelope(env *mailboxpb.Envelope) {
 	delete(c.waiters, correlationID)
 }
 
-// popPending returns and removes a cached response for correlationID.
-func (c *Client) popPending(correlationID string) ([]byte, bool) {
+// popPendingOrAddWaiter atomically checks for a pending response and, if one
+// is not present, registers a waiter channel for a future response.
+func (c *Client) popPendingOrAddWaiter(correlationID string) (
+	[]byte, chan struct{}, bool) {
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	data, ok := c.pending[correlationID]
-	if !ok {
-		return nil, false
+	if ok {
+		delete(c.pending, correlationID)
+
+		return data, nil, true
 	}
 
-	delete(c.pending, correlationID)
-
-	return data, true
-}
-
-// addWaiter registers a waiter for correlationID and returns its channel.
-func (c *Client) addWaiter(correlationID string) chan struct{} {
 	ch := make(chan struct{})
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	c.waiters[correlationID] = append(c.waiters[correlationID], ch)
 
-	return ch
+	return nil, ch, false
 }
 
 // removeWaiter removes a previously registered waiter channel.


### PR DESCRIPTION
## Summary
This fixes a flaky timeout in `TestClient_ConcurrentInFlightDoesNotDrop` by
eliminating a lost-wakeup race in `AwaitRPC`.

## Root Cause
`AwaitRPC` previously did these steps separately:
1. Check `pending` for the response.
2. Register a waiter channel.

If a response arrived between steps 1 and 2, `handleEnvelope` would cache
the response and notify the **current** waiter set — which did not yet
include the new waiter. The newly registered waiter would then block until
context timeout.

## Fix
Make the response check and waiter registration atomic under one lock via
`popPendingOrAddWaiter`:
- if pending response exists: return it immediately and skip waiter registration
- otherwise: register waiter before releasing the lock

This removes the race window where notifications can be missed.

## CI Failure
Observed CI failure (PR #79, unit-cover):
- https://github.com/lightninglabs/darepo-client/actions/runs/22197814323/job/64202618296?pr=79

Failure signature:
- `TestClient_ConcurrentInFlightDoesNotDrop`
- `context deadline exceeded`

## Validation
- Reproduced pre-fix flake locally with high repetition.
- Post-fix stress runs passed:
  - `go test ./mailbox/client -run TestClient_ConcurrentInFlightDoesNotDrop -count=20000 -timeout=60m`
  - `go test -covermode=atomic -coverpkg=github.com/lightninglabs/darepo-client/... -tags='dev nolog' ./mailbox/client -run TestClient_ConcurrentInFlightDoesNotDrop -count=1000 -timeout=20m`