### PR TITLE
docs: add mailbox and serverconn architecture documentation

### DIFF
--- a/docs/mailbox_architecture.md
+++ b/docs/mailbox_architecture.md
@@ -1,0 +1,1020 @@
+# Mailbox Architecture
+
+This document explains the architecture of the RPC-over-mailbox transport, the
+system that enables durable, crash-safe communication between the client and the
+remote server. The mailbox replaces direct gRPC streaming with an at-least-once
+envelope transport that survives process restarts, tolerates intermittent
+connectivity, and unifies unary RPCs and fire-and-forget events under a single
+protocol.
+
+For the protocol-level contract (ordering, idempotency, ack semantics), see
+[`RPC_MAILBOX_CONTRACT.md`](RPC_MAILBOX_CONTRACT.md). For the underlying actor
+durability model, see
+[`durable_actor_architecture.md`](durable_actor_architecture.md).
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [System Layers](#system-layers)
+3. [Envelope and RPC Metadata](#envelope-and-rpc-metadata)
+4. [Layer 1: Mailbox Edge API](#layer-1-mailbox-edge-api)
+5. [Layer 2: RPC Interfaces and Primitives](#layer-2-rpc-interfaces-and-primitives)
+   - [RPCClient and Router Contracts](#rpcclient-and-router-contracts)
+   - [ServeMux: In-Process Routing](#servemux-in-process-routing)
+   - [gRPC Status Encoding](#grpc-status-encoding)
+   - [AckState Watermark Machine](#ackstate-watermark-machine)
+   - [ResponseRegistry: Correlation Waiters](#responseregistry-correlation-waiters)
+   - [EnvelopeIdentity: Deterministic IDs](#envelopeidentity-deterministic-ids)
+   - [WrappedProto: TLV-Proto Bridge](#wrappedproto-tlv-proto-bridge)
+6. [Layer 3: Server Connection Runtime](#layer-3-server-connection-runtime)
+   - [ServerConnectionActor: Dual-Role Connector](#serverconnectionactor-dual-role-connector)
+   - [Egress: Durable Events vs Fast Unary](#egress-durable-events-vs-fast-unary)
+   - [Ingress: Pull-Dispatch-Ack Loop](#ingress-pull-dispatch-ack-loop)
+   - [EventRouter: Typed Dispatch Closures](#eventrouter-typed-dispatch-closures)
+   - [UnaryFacade: Two-Phase Send+Await](#unaryfacade-two-phase-sendawait)
+   - [Runtime: Composition and Lifecycle](#runtime-composition-and-lifecycle)
+7. [Key Data Flows](#key-data-flows)
+   - [Unary RPC Round-Trip](#unary-rpc-round-trip)
+   - [Durable Event Egress](#durable-event-egress)
+   - [Server-Push Event Ingress](#server-push-event-ingress)
+8. [Ack Watermark Invariants](#ack-watermark-invariants)
+9. [Crash Recovery and Restart](#crash-recovery-and-restart)
+10. [Generated Stubs and Code Generation](#generated-stubs-and-code-generation)
+11. [Extension Points](#extension-points)
+
+---
+
+## Overview
+
+Traditional gRPC streaming ties message delivery to TCP connection liveness. If
+the process crashes between receiving a message and processing it, the message is
+lost. If the connection drops, in-flight RPCs fail without retry.
+
+The mailbox transport replaces this with a store-and-forward model. Messages are
+persisted as envelopes in a remote mailbox before the receiver pulls them. The
+receiver acknowledges envelopes only after durable local processing, so crashes
+between pull and ack result in redelivery rather than loss.
+
+This design provides three properties that raw gRPC lacks:
+
+- **Durability**: Envelopes survive sender and receiver restarts.
+- **At-least-once delivery**: Unacked envelopes are redelivered on reconnect.
+- **Unified transport**: Unary RPCs (request-response) and fire-and-forget
+  events (one-way) share the same envelope format and edge API.
+
+The system is organized in three layers. Each layer depends only on the layers
+below it, and each can be tested independently.
+
+```mermaid
+flowchart TB
+    subgraph "Application Code"
+        APP["Round Actor / FSM"]
+        STUB["Generated Stubs<br/>(XxxMailboxClient)"]
+    end
+
+    subgraph "Layer 3: serverconn"
+        RT["Runtime"]
+        DA["DurableActor"]
+        SCA["ServerConnectionActor"]
+        UF["UnaryFacade"]
+        ER["EventRouter"]
+    end
+
+    subgraph "Layer 2: mailbox/rpc + mailbox/conn"
+        RPC["RPCClient / Router"]
+        MUX["ServeMux"]
+        REG["ResponseRegistry"]
+        ACK["AckState"]
+        EID["EnvelopeIdentity"]
+        WP["WrappedProto"]
+    end
+
+    subgraph "Layer 1: mailbox/pb"
+        PROTO["Envelope / RpcMeta"]
+        EDGE["MailboxService<br/>(Send / Pull / AckUpTo)"]
+    end
+
+    APP --> RT
+    STUB --> UF
+    RT --> DA --> SCA
+    RT --> UF
+    SCA --> REG
+    SCA --> ACK
+    SCA --> EDGE
+    UF --> RPC
+    UF --> EDGE
+    ER --> RPC
+    SCA --> WP
+    SCA --> EID
+    MUX --> RPC
+    REG --> PROTO
+    ACK --> PROTO
+```
+
+---
+
+## System Layers
+
+| Layer | Go Packages | Responsibility |
+|-------|-------------|----------------|
+| 1 | `mailbox/pb` | Protobuf definitions: Envelope, RpcMeta, Status, MailboxService edge API. Generated code only. |
+| 2 | `mailbox/rpc`, `mailbox/conn` | Runtime interfaces (`RPCClient`, `Router`, `ServeMux`), connector primitives (ack watermark, response registry, deterministic IDs, TLV-proto bridge). |
+| 3 | `serverconn` | Server connection runtime: `ServerConnectionActor` (egress + ingress), `UnaryFacade`, `EventRouter`, `Runtime` composition. |
+
+Layer 1 is pure proto-generated code. Layer 2 provides the building blocks
+shared by both client-side and server-side connectors. Layer 3 wires everything
+into the client's actor system.
+
+---
+
+## Envelope and RPC Metadata
+
+Every message flowing through the mailbox is wrapped in an `Envelope`. The
+envelope carries metadata for routing, deduplication, and ordering alongside
+a typed protobuf payload.
+
+```mermaid
+classDiagram
+    class Envelope {
+        +uint32 protocol_version
+        +string msg_id
+        +string idempotency_key
+        +string sender
+        +string recipient
+        +int64 created_at_unix_ms
+        +int64 expires_at_unix_ms
+        +string type
+        +map~string,string~ headers
+        +Any body
+        +RpcMeta rpc
+        +uint64 event_seq
+    }
+
+    class RpcMeta {
+        +Kind kind
+        +string service
+        +string method
+        +string correlation_id
+        +string reply_to
+    }
+
+    class Kind {
+        <<enumeration>>
+        KIND_UNSPECIFIED
+        KIND_REQUEST
+        KIND_RESPONSE
+        KIND_EVENT
+    }
+
+    class Status {
+        +bool ok
+        +string code
+        +string message
+        +uint32 min_supported_protocol_version
+        +uint32 server_protocol_version
+        +string upgrade_url
+    }
+
+    Envelope *-- RpcMeta : rpc
+    RpcMeta --> Kind : kind
+```
+
+Key fields:
+
+- **`msg_id`**: Unique per send attempt. Different on each retry.
+- **`idempotency_key`**: Stable per semantic operation. The same across retries
+  of the same logical request, enabling server-side deduplication.
+- **`body`**: A `google.protobuf.Any` carrying the typed protobuf payload.
+  Receivers unmarshal the inner `Value` bytes into the expected message type.
+- **`rpc`**: Optional overlay metadata. When present, the envelope participates
+  in the RPC protocol. The three `Kind` variants are:
+  - `KIND_REQUEST`: A unary RPC request from client to server.
+  - `KIND_RESPONSE`: A unary RPC response from server to client.
+  - `KIND_EVENT`: A fire-and-forget message (either direction).
+- **`event_seq`**: Assigned by the mailbox edge. Defines per-mailbox ordering
+  and serves as the cursor for `Pull` and `AckUpTo` operations.
+- **`headers`**: Extensible key-value metadata. Used for gRPC status transport
+  (see [gRPC Status Encoding](#grpc-status-encoding)).
+
+Source: `mailbox/pb/mailbox.proto`
+
+---
+
+## Layer 1: Mailbox Edge API
+
+The edge API is a standard gRPC service with three RPCs:
+
+```protobuf
+service MailboxService {
+    rpc Send (SendRequest) returns (SendResponse);
+    rpc Pull (PullRequest) returns (PullResponse);
+    rpc AckUpTo (AckUpToRequest) returns (AckUpToResponse);
+}
+```
+
+- **Send**: Appends an envelope to the recipient's mailbox. Returns a `Status`
+  indicating success or failure (including protocol version mismatch).
+- **Pull**: Fetches envelopes from the caller's mailbox starting at a cursor.
+  Supports long-polling via `wait_timeout_ms` to avoid tight loops. Returns the
+  batch and a `next_cursor` (highest `event_seq` + 1).
+- **AckUpTo**: Advances the ack watermark. The server may garbage-collect
+  envelopes with `event_seq < cursor`. Monotonic and idempotent.
+
+The edge API is transport-agnostic from the application's perspective. The
+client connects to it over standard gRPC with TLS. All application-level
+semantics (request-response correlation, idempotency, dispatch routing) are
+handled by the layers above.
+
+Source: `mailbox/pb/mailbox.proto`
+
+---
+
+## Layer 2: RPC Interfaces and Primitives
+
+### RPCClient and Router Contracts
+
+The `mailboxrpc` package defines two interfaces that generated stubs depend on:
+
+```go
+type RPCClient interface {
+    SendRPC(ctx context.Context, method ServiceMethod,
+        req proto.Message, opts RPCOptions) (SendResult, error)
+
+    AwaitRPC(ctx context.Context, correlationID string,
+        resp proto.Message) error
+}
+```
+
+`RPCClient` is the client-side contract. `SendRPC` constructs and sends a
+`KIND_REQUEST` envelope, returning a `SendResult` with the correlation and
+idempotency identifiers. `AwaitRPC` blocks until the ingress loop delivers a
+`KIND_RESPONSE` with the matching correlation ID.
+
+The two-phase design (send, then await) exists so response waiters can be
+pre-registered before the send, preventing a race where a fast server responds
+before the client registers a listener.
+
+```go
+type Router interface {
+    Handle(service string, method string,
+        newReq func() proto.Message, fn HandlerFunc)
+}
+```
+
+`Router` is the server-side contract. `Handle` registers a typed handler for a
+`(service, method)` pair. The generated `RegisterXxxMailboxServer` function
+calls `Handle` once per method.
+
+Supporting types:
+
+- **`ServiceMethod`**: A `(Service, Method)` pair used as a routing key.
+  `Service` is the fully-qualified protobuf service name
+  (e.g., `"arkrpc.v1.RoundService"`). `Method` is the method name
+  (e.g., `"JoinRound"`).
+- **`HandlerFunc`**: `func(context.Context, proto.Message) (proto.Message, error)`.
+  Handlers must be idempotent under the envelope's idempotency key.
+- **`RPCOptions`**: Per-request overrides for idempotency key, correlation ID,
+  and custom headers.
+- **`SendResult`**: Contains `CorrelationID` and `IdempotencyKey` from a
+  successful send.
+
+Source: `mailbox/rpc/interface.go`, `mailbox/rpc/options.go`
+
+### ServeMux: In-Process Routing
+
+`ServeMux` is a concrete implementation of `Router`. It maps `(service, method)`
+pairs to typed handler entries, each containing a request constructor and a
+`HandlerFunc`. `ServeRPC` looks up the handler, creates a fresh request
+message via `newReq()`, unmarshals the raw bytes with `DiscardUnknown: true`
+for forward compatibility, and invokes the handler.
+
+Thread-safe via `sync.RWMutex`. Intended as a small, dependency-free building
+block — it does not handle transport concerns like authentication, retries, or
+persistence.
+
+Source: `mailbox/rpc/mux.go`
+
+### gRPC Status Encoding
+
+Application errors on the server side are transported through envelope headers
+rather than the body. This keeps the response body reserved for successful
+payloads while providing a separate channel for structured errors.
+
+The header key is `mailboxrpc.grpc_status_b64`. The value is a base64-encoded
+`google.rpc.Status` protobuf.
+
+- **`EncodeErrorHeaders(err)`**: Converts any Go error to a gRPC status proto,
+  preserving existing gRPC status codes. Falls back to `codes.Internal` if
+  marshaling fails. Returns `nil` when `err` is `nil`.
+- **`DecodeErrorHeaders(headers)`**: Extracts and reconstructs the gRPC error.
+  Returns `nil` when no error header is present.
+
+On the client side, `AwaitRPC` checks error headers before inspecting the body.
+If an error header exists, it is returned immediately as a gRPC status error.
+
+Source: `mailbox/rpc/grpc_status.go`
+
+### AckState Watermark Machine
+
+The ack watermark tracks four monotonic cursor variables that govern safe ack
+progression:
+
+```go
+type AckState struct {
+    PullCursor          uint64  // Cursor for the next Pull call.
+    DispatchCommittedTo uint64  // Max cursor durably dispatched locally.
+    AckTarget           uint64  // Max cursor that should be acked remotely.
+    AckCommittedTo      uint64  // Last cursor successfully acked remotely.
+}
+```
+
+The critical invariant is:
+
+```
+AckCommittedTo <= DispatchCommittedTo
+```
+
+The system never acks past non-durable local work. If the process crashes after
+dispatch but before ack, envelopes will be redelivered on restart. If the
+process crashes after ack but before local processing, the crash-recovery
+section explains how this is handled.
+
+```mermaid
+stateDiagram-v2
+    direction LR
+
+    state "PullCursor" as PC
+    state "DispatchCommittedTo" as DCT
+    state "AckTarget" as AT
+    state "AckCommittedTo" as ACT
+
+    [*] --> PC : Pull returns batch
+    PC --> DCT : dispatchBatch succeeds
+    DCT --> AT : AdvanceDispatch()
+    AT --> ACT : AckUpTo succeeds + AdvanceAck()
+
+    note right of DCT
+        Invariant: AckCommittedTo <= DispatchCommittedTo
+        Never ack past durable work
+    end note
+```
+
+Three methods drive state transitions:
+
+- **`AdvanceDispatch(nextCursor)`**: Sets `DispatchCommittedTo` to
+  `max(DispatchCommittedTo, nextCursor)` and bumps `AckTarget` to match. Called
+  after `dispatchBatch` successfully persists envelopes to local actor
+  mailboxes.
+- **`AdvanceAck()`**: Sets `AckCommittedTo = AckTarget` and defensively bumps
+  `PullCursor` as a crash-recovery safety net. Called after `AckUpTo` succeeds.
+- **`NeedsAck()`**: Returns `true` when `AckTarget > AckCommittedTo`.
+
+The state is serialized via LND's TLV codec (four `uint64` records) and persisted
+to the checkpoint store after each state change. On restart, `loadCheckpoint`
+restores the state and the ingress loop resumes from `PullCursor`.
+
+Source: `mailbox/conn/ack_state.go`
+
+### ResponseRegistry: Correlation Waiters
+
+The `ResponseRegistry` maps correlation IDs to response waiters and buffers
+early responses that arrive before a waiter is registered.
+
+```mermaid
+sequenceDiagram
+    participant C as Caller (AwaitRPC)
+    participant R as ResponseRegistry
+    participant I as Ingress Loop
+
+    Note over C,I: Normal Flow (waiter before response)
+    C->>R: RegisterWaiter(corrID) → Future
+    I->>R: DeliverResponse(corrID, env)
+    R-->>C: Future completes with envelope
+
+    Note over C,I: Early Response (response before waiter)
+    I->>R: DeliverResponse(corrID, env)
+    R->>R: Buffer response (no waiter yet)
+    C->>R: RegisterWaiter(corrID) → Future
+    R-->>C: Future completes immediately from buffer
+```
+
+Key behaviors:
+
+- **`RegisterWaiter(id)`**: Returns an `actor.Future[*Envelope]`. Idempotent —
+  re-registration returns the same future. If a buffered response exists, the
+  promise is completed immediately.
+- **`DeliverResponse(id, env)`**: Completes the waiter's promise if registered.
+  Otherwise, clones and buffers the envelope for a later `RegisterWaiter`.
+- **`RemoveWaiter(id)`**: Completes the promise with `ErrWaiterCancelled`.
+  Called by `AwaitRPC` on context cancellation or after successful receipt.
+- **Stale cleanup**: Waiters and buffered responses older than `waiterTTL`
+  (default 10 minutes) are pruned on each `RegisterWaiter`/`DeliverResponse`
+  call. Stale waiters receive `ErrWaiterExpired`.
+
+The registry is in-memory only. If the process crashes, callers' contexts are
+cancelled and they retry the RPC. Durability is not needed because the mailbox
+edge retains unacked envelopes for redelivery.
+
+Source: `mailbox/conn/response_registry.go`
+
+### EnvelopeIdentity: Deterministic IDs
+
+For durable egress events (FSM outbox messages), the system derives stable
+identifiers from the payload content:
+
+- **`StableEventMsgID(payload)`**: Returns `"evt-" + SHA256(payload)[:16]` (hex).
+- **`StableEventIdempotencyKey(payload)`**: Returns
+  `"idem-" + SHA256(payload)[:16]` (hex).
+
+When a `SendClientEventRequest` is persisted and later replayed from the
+durable actor mailbox, the same IDs are reproduced from the stored payload.
+This ensures retries carry the same idempotency key, enabling server-side
+deduplication without additional state.
+
+The 16-byte (32 hex character) truncation is sufficient for internal
+deduplication. Collision probability is negligible for the expected message
+volumes.
+
+Source: `mailbox/conn/envelope_identity.go`
+
+### WrappedProto: TLV-Proto Bridge
+
+The durable actor runtime requires all messages to implement the `TLVMessage`
+interface (`TLVType`, `Encode`, `Decode`). Protobuf messages are not TLV
+natively. `WrappedProto[T]` bridges the gap:
+
+```go
+type WrappedProto[T proto.Message] struct {
+    Val T
+}
+```
+
+- **Encode**: Deterministic `proto.Marshal` → write bytes.
+- **Decode**: Read bytes → `proto.Unmarshal` into `Val`.
+- **`Record()`**: Returns a `tlv.Record` using dynamic size/encoder/decoder
+  functions. The placeholder type 0 is overridden when wrapped in
+  `tlv.NewRecordT`.
+
+The caller must pre-set `Val` to a typed zero value before decode so the
+correct concrete type is available for unmarshaling.
+
+Source: `mailbox/conn/proto_record.go`
+
+---
+
+## Layer 3: Server Connection Runtime
+
+### ServerConnectionActor: Dual-Role Connector
+
+The `ServerConnectionActor` is the unified boundary for all mailbox traffic. It
+serves two roles:
+
+1. **Egress actor**: Processes outbound messages from the round actor (FSM
+   events via `SendClientEventRequest`) and the unary facade (RPC requests via
+   `SendRPCRequest`). Backed by a `DurableActor` for crash-safe persistence.
+
+2. **Ingress loop**: A background goroutine that continuously pulls envelopes,
+   dispatches them to local actors or response waiters, and manages the ack
+   watermark.
+
+```mermaid
+flowchart TB
+    subgraph "ServerConnectionActor"
+        direction TB
+
+        subgraph "Egress (DurableActor)"
+            INBOX["Durable Mailbox"]
+            RECV["Receive()"]
+            SEND_EVT["handleSendClientEvent"]
+            SEND_RPC["handleSendRPCRequest"]
+        end
+
+        subgraph "Ingress (Background Loop)"
+            PULL["Edge.Pull"]
+            DISPATCH["dispatchBatch"]
+            ACKR["Edge.AckUpTo"]
+            CKPT["saveCheckpoint"]
+        end
+
+        RR["ResponseRegistry"]
+    end
+
+    ROUND["Round Actor"] -->|"Tell(SendClientEventRequest)"| INBOX
+    INBOX --> RECV
+    RECV --> SEND_EVT
+    RECV --> SEND_RPC
+
+    UF2["UnaryFacade"] -->|"Edge.Send directly"| EDGE2["Edge"]
+    SEND_EVT --> EDGE2
+    SEND_RPC --> EDGE2
+
+    EDGE2 -->|"Pull"| PULL
+    PULL --> DISPATCH
+    DISPATCH -->|"KIND_RESPONSE"| RR
+    DISPATCH -->|"KIND_EVENT"| ACTORS["Local Actors"]
+    DISPATCH --> ACKR --> CKPT
+
+    UF2 -.->|"RegisterWaiter / AwaitRPC"| RR
+```
+
+The actor implements `ActorBehavior[ServerConnMsg, ServerConnResp]`. The
+`Receive` method dispatches by message type:
+
+- `SendClientEventRequest` → `handleSendClientEvent` (converts to proto,
+  builds envelope, calls `Edge.Send`).
+- `SendRPCRequest` → `handleSendRPCRequest` (sends pre-built envelope via
+  `Edge.Send`).
+
+Source: `serverconn/actor.go`
+
+### Egress: Durable Events vs Fast Unary
+
+The system provides two egress paths optimized for different requirements:
+
+```mermaid
+flowchart LR
+    subgraph "Durable Path (FSM Events)"
+        RA["Round Actor"] -->|"Tell()"| DM["DurableActor<br/>Mailbox"]
+        DM -->|"Persists"| DB[(Store)]
+        DM -->|"Receive()"| H1["handleSendClientEvent"]
+        H1 -->|"Edge.Send"| E1["Edge"]
+    end
+
+    subgraph "Fast Path (Unary RPCs)"
+        CALLER["RPC Caller"] -->|"SendRPC()"| UF["UnaryFacade"]
+        UF -->|"Edge.Send directly"| E2["Edge"]
+    end
+```
+
+**Durable event egress** (crash-safe):
+
+1. Round actor calls `DurableActor.Tell(SendClientEventRequest)`.
+2. The request is TLV-encoded and persisted to the durable mailbox.
+3. The durable actor runtime calls `Receive`, which converts the FSM message to
+   proto, derives stable `msg_id` and `idempotency_key` from the payload hash,
+   builds a `KIND_EVENT` envelope, and calls `Edge.Send`.
+4. On crash, the durable mailbox replays the persisted request. The same IDs
+   are derived again, ensuring the server deduplicates the retry.
+
+**Fast unary egress** (low-latency):
+
+1. Caller invokes `UnaryFacade.SendRPC`.
+2. The facade generates random `msg_id` and `idempotency_key` (or uses
+   caller-provided overrides), pre-registers a response waiter, builds a
+   `KIND_REQUEST` envelope, and calls `Edge.Send` directly.
+3. No durable persistence. If the send fails, the caller retries.
+
+The durable path uses the DurableActor's inbox queue, which adds latency but
+survives crashes. The fast path bypasses the inbox for lower latency at the cost
+of no crash durability — appropriate for unary RPCs where the caller can retry.
+
+Source: `serverconn/actor.go`, `serverconn/unary_facade.go`
+
+### Ingress: Pull-Dispatch-Ack Loop
+
+The ingress loop runs as a background goroutine, started by
+`ServerConnectionActor.StartIngress`. It implements the pull-dispatch-ack cycle:
+
+```mermaid
+flowchart TD
+    START["Load Checkpoint"] --> CHECK_ACK{"NeedsAck()?"}
+
+    CHECK_ACK -->|"Yes"| ACK["Edge.AckUpTo(AckTarget)"]
+    ACK -->|"Success"| ADV_ACK["AdvanceAck()"]
+    ADV_ACK --> SAVE1["saveCheckpoint"]
+    SAVE1 --> PULL
+
+    CHECK_ACK -->|"No"| PULL["Edge.Pull(PullCursor)"]
+
+    ACK -->|"Fail"| BACKOFF["sleepBackoff"]
+    SAVE1 -->|"Fail"| BACKOFF
+
+    PULL -->|"Empty"| CHECK_ACK
+    PULL -->|"Fail"| BACKOFF
+    PULL -->|"Batch"| DISPATCH["dispatchBatch()"]
+
+    DISPATCH -->|"Full success"| ADV_DISP["AdvanceDispatch(nextCursor)"]
+    ADV_DISP --> SAVE2["saveCheckpoint"]
+    SAVE2 --> CHECK_ACK
+
+    DISPATCH -->|"Partial fail"| PARTIAL["AdvanceDispatch(lastCommitted+1)"]
+    PARTIAL --> SAVE3["saveCheckpoint"]
+    SAVE3 --> BACKOFF
+
+    BACKOFF --> CHECK_ACK
+```
+
+Each cycle:
+
+1. **Ack phase**: If `NeedsAck()`, call `Edge.AckUpTo(AckTarget)`. On success,
+   `AdvanceAck()` and checkpoint. This frees remote storage for previously
+   dispatched envelopes.
+
+2. **Pull phase**: Call `Edge.Pull(PullCursor, maxEnvelopes, waitTimeout)`.
+   Long-poll returns empty on timeout (no delay needed), or a batch of
+   envelopes with `next_cursor`.
+
+3. **Dispatch phase**: Iterate envelopes. Route each by `RpcMeta.Kind`:
+   - `KIND_RESPONSE`: Deliver to `ResponseRegistry` for unary RPC waiters.
+     Not durable — the response is consumed immediately.
+   - `KIND_REQUEST` / `KIND_EVENT`: Look up the `EnvelopeDispatcher` by
+     `(Service, Method)` in the dispatch table. The dispatcher unmarshals the
+     body, adapts it to an actor message, and calls `Tell` on the target
+     durable actor. A `nil` error means the message is durably persisted.
+
+4. **Advance and checkpoint**: `AdvanceDispatch(nextCursor)` updates the
+   watermark. `saveCheckpoint` persists the state. The loop restarts.
+
+**Partial failure**: If dispatch fails mid-batch (e.g., the target actor's store
+is down), the loop advances state only past the last successfully dispatched
+envelope. The failed envelope will be re-pulled on the next iteration.
+
+**Backoff**: Exponential with jitter on transient failures. Formula:
+`min(base * 2^attempt, max) * uniform(0.5, 1.0)`. Defaults: base 200ms,
+max 30s. Reset to zero on success.
+
+Source: `serverconn/ingress.go`
+
+### EventRouter: Typed Dispatch Closures
+
+The `EventRouter` maps `(service, method)` pairs to `EnvelopeDispatcher`
+closures that route inbound envelopes to durable actor mailboxes.
+
+Two registration APIs:
+
+**Generic `AddRoute[M, R]`** (full control):
+
+```go
+AddRoute(router, EventRouteConfig[M, R]{
+    Service:  "hellotest.v1.HelloService",
+    Method:   "HelloStarted",
+    NewEvent: func() proto.Message { return &hellotestpb.HelloStartedEvent{} },
+    Key:      roundActorKey,
+    Adapt:    func(p proto.Message) (RoundMsg, error) { ... },
+})
+```
+
+The Adapt function converts the deserialized proto to the target actor's message
+type. The closure captures the `ServiceKey` and calls
+`Key.Ref(system).Tell(ctx, msg)`, which persists the message to the actor's
+durable mailbox before returning.
+
+**Convenience `NewEventRoute[M, R]`** (for `InboundActorMessage` types):
+
+```go
+NewEventRoute(router, InboundEventRouteConfig[M, R]{
+    Service:  "hellotest.v1.HelloService",
+    Method:   "HelloStarted",
+    NewEvent: func() proto.Message { return &hellotestpb.HelloStartedEvent{} },
+    Key:      roundActorKey,
+    NewMsg:   func() RoundMsg { return &HelloStartedMsg{} },
+})
+```
+
+Auto-generates the `Adapt` closure by calling `M.FromProto(event)`. The type
+constraint `InboundActorMessage` combines `actor.Message` with
+`InboundServerMessage` (which provides `FromProto`).
+
+At wiring time, callers register all routes, then pass
+`router.AsDispatcherMap()` to `ConnectorConfig.Dispatchers`. The map is a
+shallow copy — safe for concurrent reads.
+
+`AddRoute` is a package-level generic function rather than a method because Go
+does not allow methods with type parameters on non-generic types.
+
+Source: `serverconn/event_router.go`
+
+### UnaryFacade: Two-Phase Send+Await
+
+The `UnaryFacade` implements `mailboxrpc.RPCClient`. Generated client stubs
+call `SendRPC` followed by `AwaitRPC` to perform a complete unary RPC
+round-trip.
+
+**`SendRPC` flow**:
+
+1. Generate random `msg_id` (16 bytes, hex).
+2. Use provided `IdempotencyKey` or generate a random one.
+3. Use provided `CorrelationID` or default to the idempotency key.
+4. Pre-register a response waiter in the `ResponseRegistry` (before sending,
+   to catch fast responses).
+5. Wrap the request proto in `anypb.Any`.
+6. Build a `KIND_REQUEST` envelope with all metadata.
+7. Call `Edge.Send` directly (no actor mailbox, low-latency).
+8. On failure, remove the waiter and return the error.
+9. Return `SendResult{CorrelationID, IdempotencyKey}`.
+
+**`AwaitRPC` flow**:
+
+1. Re-register the waiter (idempotent — returns the same future).
+2. Block on `Future.Await(ctx)`.
+3. When the ingress loop delivers a `KIND_RESPONSE` via
+   `ResponseRegistry.DeliverResponse`, the future completes.
+4. Check error headers first via `DecodeErrorHeaders`. If present, return the
+   gRPC error.
+5. Unmarshal `env.Body.Value` directly into the caller's response proto with
+   `DiscardUnknown: true`. TypeUrl validation is intentionally skipped — the
+   generated stubs always pass the correct concrete type.
+6. Remove the waiter and return.
+
+Source: `serverconn/unary_facade.go`
+
+### Runtime: Composition and Lifecycle
+
+`Runtime` embeds `DurableActor[ServerConnMsg, ServerConnResp]` so it can be
+registered directly with the actor system. `Ref` and `TellRef` are promoted
+without wrapper methods.
+
+```go
+type Runtime struct {
+    *actor.DurableActor[ServerConnMsg, ServerConnResp]
+    connector *ServerConnectionActor
+    unary     *UnaryFacade
+}
+```
+
+**`NewRuntime(cfg)`**: Validates required fields (Edge, Store, mailbox IDs).
+Creates `ServerConnectionActor`, wraps it in a `DurableActor` using
+`DefaultDurableActorConfig`, and creates `UnaryFacade`. The durable actor ID
+is `"serverconn-" + localMailboxID`.
+
+**`Start(ctx)`**: Starts the `DurableActor` (begins processing egress). Starts
+ingress via `connector.StartIngress(ctx)` (loads ack checkpoint, launches
+pull loop). Rolls back the `DurableActor` on ingress failure.
+
+**`Stop()`**: Stops ingress (cancels loop, waits for goroutine exit). Stops the
+`DurableActor`.
+
+**`Unary()`**: Returns the `UnaryFacade` for generated RPC stubs.
+
+**`Connector()`**: Returns the underlying `ServerConnectionActor`.
+
+Source: `serverconn/runtime.go`
+
+---
+
+## Key Data Flows
+
+### Unary RPC Round-Trip
+
+A complete unary RPC from caller through the mailbox and back:
+
+```mermaid
+sequenceDiagram
+    participant C as Caller
+    participant S as Generated Stub
+    participant UF as UnaryFacade
+    participant RR as ResponseRegistry
+    participant E as Edge (gRPC)
+    participant SRV as Server
+    participant IL as Ingress Loop
+
+    C->>S: SayHello(ctx, req)
+    S->>UF: SendRPC(ctx, method, req, opts)
+    UF->>RR: RegisterWaiter(corrID)
+    UF->>E: Send(envelope)
+    E->>SRV: Deliver KIND_REQUEST
+
+    SRV->>SRV: Process request
+    SRV->>E: Send(KIND_RESPONSE, corrID)
+
+    IL->>E: Pull(cursor)
+    E-->>IL: [KIND_RESPONSE envelope]
+    IL->>RR: DeliverResponse(corrID, env)
+
+    S->>UF: AwaitRPC(ctx, corrID, resp)
+    UF->>RR: RegisterWaiter(corrID) [idempotent]
+    RR-->>UF: Future completes
+    UF->>UF: DecodeErrorHeaders / Unmarshal body
+    UF-->>S: resp
+    S-->>C: (resp, nil)
+```
+
+### Durable Event Egress
+
+An FSM event from the round actor through durable persistence to the server:
+
+```mermaid
+sequenceDiagram
+    participant RA as Round Actor
+    participant DM as DurableMailbox
+    participant DB as Store
+    participant SCA as ServerConnectionActor
+    participant E as Edge (gRPC)
+    participant SRV as Server
+
+    RA->>DM: Tell(SendClientEventRequest)
+    DM->>DB: Persist message (TLV)
+    DM->>SCA: Receive(SendClientEventRequest)
+    SCA->>SCA: ToProto() + derive msgID/idempotencyKey
+    SCA->>SCA: Build KIND_EVENT envelope
+    SCA->>E: Send(envelope)
+    E->>SRV: Deliver KIND_EVENT
+
+    Note over DM,DB: On crash, DurableMailbox replays.<br/>Same IDs derived from payload hash.
+```
+
+### Server-Push Event Ingress
+
+A server-pushed event arriving at the client and being routed to a local actor:
+
+```mermaid
+sequenceDiagram
+    participant SRV as Server
+    participant E as Edge (gRPC)
+    participant IL as Ingress Loop
+    participant D as Dispatcher Closure
+    participant TA as Target Actor
+    participant DB as Store
+
+    SRV->>E: Send(KIND_EVENT, service, method)
+    IL->>E: Pull(cursor)
+    E-->>IL: [KIND_EVENT envelope]
+    IL->>D: dispatcher(ctx, env)
+    D->>D: Unmarshal body → proto
+    D->>D: Adapt(proto) → actor message
+    D->>TA: Tell(ctx, actorMsg)
+    TA->>DB: Persist to durable mailbox
+    D-->>IL: nil (committed)
+    IL->>IL: AdvanceDispatch(nextCursor)
+    IL->>E: AckUpTo(cursor)
+    IL->>DB: saveCheckpoint(AckState)
+```
+
+---
+
+## Ack Watermark Invariants
+
+The ack watermark is the critical safety mechanism that prevents message loss.
+The invariant is simple but the consequences of violating it are severe:
+
+> **AckCommittedTo must never exceed DispatchCommittedTo.**
+
+If the system acks an envelope before durably dispatching it, a crash between
+ack and dispatch loses the envelope permanently — the server has already
+garbage-collected it, and the client has no record of it.
+
+Here is a worked crash scenario:
+
+```mermaid
+sequenceDiagram
+    participant IL as Ingress Loop
+    participant DB as Store
+    participant E as Edge
+
+    Note over IL: Pull returns envelopes 5, 6, 7, 8
+
+    IL->>DB: dispatch envelope 5 (Tell → persist)
+    IL->>DB: dispatch envelope 6 (Tell → persist)
+    IL->>DB: dispatch envelope 7 (Tell → persist)
+    IL->>DB: dispatch envelope 8 (Tell → persist)
+    IL->>DB: saveCheckpoint(DispatchCommittedTo=9)
+
+    Note over IL: CRASH before AckUpTo
+
+    Note over IL: Process restarts
+    IL->>DB: loadCheckpoint → AckCommittedTo=5, DispatchCommittedTo=9
+
+    IL->>E: AckUpTo(9)
+    Note over E: Server GCs envelopes 5-8
+    IL->>DB: saveCheckpoint(AckCommittedTo=9)
+    IL->>E: Pull(cursor=9)
+    Note over IL: No data loss: envelopes 5-8 were<br/>durably dispatched before the crash
+```
+
+If the crash had occurred between dispatch of envelope 6 and envelope 7 (before
+the checkpoint), the checkpoint would still reflect the previous state. On
+restart, the loop would re-pull from the old `PullCursor`, re-dispatch
+envelopes 7 and 8 (idempotent via the durable actor's deduplication), and then
+ack up to the new position.
+
+---
+
+## Crash Recovery and Restart
+
+Two recovery paths operate independently on startup:
+
+**Egress recovery** (DurableActor):
+
+The `DurableActor` replays all unacknowledged messages from its persistent
+inbox. For `SendClientEventRequest` messages, the same `msg_id` and
+`idempotency_key` are reproduced from the persisted TLV payload (the IDs are
+derived from the payload hash and stored alongside it). The server deduplicates
+retries using the idempotency key.
+
+**Ingress recovery** (AckState checkpoint):
+
+1. `loadCheckpoint` restores the four-cursor `AckState` from the store.
+2. The ingress loop resumes pulling from `PullCursor`.
+3. If `AckTarget > AckCommittedTo` (ack was pending at crash time), the loop
+   acks first.
+4. Envelopes between `AckCommittedTo` and `PullCursor` may be re-pulled by the
+   server (depending on server-side GC timing). Local dispatchers handle
+   redelivery gracefully via the durable actor's message deduplication.
+
+**Unary RPC recovery**:
+
+Response waiters are in-memory only. On crash, all waiting goroutines' contexts
+are cancelled. Callers retry the RPC, generating new correlation IDs. The
+server processes the retry as a new request (or deduplicates if the caller
+reuses the same idempotency key via `RPCOptions`).
+
+```mermaid
+flowchart TD
+    START["Process Starts"] --> LOAD["loadCheckpoint(AckState)"]
+    LOAD --> DA_START["DurableActor.Start()<br/>(replays egress inbox)"]
+    DA_START --> INGRESS["ingressLoop starts<br/>from PullCursor"]
+
+    INGRESS --> CHECK{"NeedsAck()?"}
+    CHECK -->|"Yes"| CATCH_UP["AckUpTo(AckTarget)<br/>catch up from crash"]
+    CHECK -->|"No"| PULL["Pull(PullCursor)<br/>resume normal operation"]
+    CATCH_UP --> PULL
+```
+
+---
+
+## Generated Stubs and Code Generation
+
+The `protoc-gen-mailboxrpc` plugin generates typed client and server wrappers
+for each protobuf service. The generated code depends only on `mailbox/rpc`
+interfaces, not on `serverconn` or any transport implementation.
+
+**Generated client** (`XxxMailboxClient`):
+
+```go
+type HelloServiceMailboxClient struct {
+    C rpc.RPCClient
+}
+
+func (c *HelloServiceMailboxClient) SayHello(
+    ctx context.Context, req *HelloRequest,
+    opts ...rpc.RPCOptions,
+) (*HelloResponse, error) {
+
+    result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+        Service: "hellotest.v1.HelloService",
+        Method:  "SayHello",
+    }, req, mergeOpts(opts))
+    if err != nil {
+        return nil, err
+    }
+
+    resp := new(HelloResponse)
+    if err := c.C.AwaitRPC(
+        ctx, result.CorrelationID, resp,
+    ); err != nil {
+        return nil, err
+    }
+
+    return resp, nil
+}
+```
+
+**Generated server** (`XxxMailboxServer` + registration):
+
+```go
+type HelloServiceMailboxServer interface {
+    SayHello(context.Context, *HelloRequest) (*HelloResponse, error)
+}
+
+func RegisterHelloServiceMailboxServer(
+    r rpc.Router, impl HelloServiceMailboxServer,
+) {
+    r.Handle("hellotest.v1.HelloService", "SayHello",
+        func() proto.Message { return new(HelloRequest) },
+        func(ctx context.Context, req proto.Message) (
+            proto.Message, error,
+        ) {
+            return impl.SayHello(ctx, req.(*HelloRequest))
+        },
+    )
+}
+```
+
+**Adding a new service**:
+
+1. Define the service in a `.proto` file.
+2. Run `make rpc` to generate Go stubs (including `*_mailboxrpc.pb.go`).
+3. On the client side, create a client with
+   `NewXxxMailboxClient(runtime.Unary())`.
+4. On the server side, implement `XxxMailboxServer` and call
+   `RegisterXxxMailboxServer(mux, impl)`.
+
+---
+
+## Extension Points
+
+**Adding new RPC services**: The system is designed for service proliferation.
+Each new proto service generates independent stubs. No core code changes are
+needed — only registration at wiring time.
+
+**Server-side connector**: The `mailbox/conn` primitives (`AckState`,
+`ResponseRegistry`, `EnvelopeIdentity`, `WrappedProto`) are intentionally
+separated from `serverconn` so a mirror server-side connector can reuse the
+same ack watermark logic, response correlation, and TLV codec without importing
+client-specific code.
+
+**Custom dispatchers**: `EnvelopeDispatcher` is a plain
+`func(context.Context, *Envelope) error` closure. It is not tied to the actor
+system. Callers can implement custom dispatch logic (e.g., logging, metrics,
+routing to non-actor handlers) as long as the contract is upheld: `nil` return
+means the envelope is durably committed.

--- a/mailbox/README.md
+++ b/mailbox/README.md
@@ -1,0 +1,253 @@
+# Mailbox Module
+
+The mailbox module provides the protocol definitions and reusable building
+blocks for RPC-over-mailbox communication. It defines the wire format
+(envelopes), the runtime interfaces that generated stubs depend on, and the
+connector primitives shared by both client-side and server-side runtimes.
+
+For the full architecture covering all three layers, see
+[`docs/mailbox_architecture.md`](../docs/mailbox_architecture.md). For the
+protocol-level contract (ordering, idempotency, ack semantics), see
+[`docs/RPC_MAILBOX_CONTRACT.md`](../docs/RPC_MAILBOX_CONTRACT.md).
+
+## Package Structure
+
+```mermaid
+flowchart TB
+    subgraph "mailbox module"
+        PB["mailbox/pb<br/>Proto definitions"]
+        RPC["mailbox/rpc<br/>RPC interfaces"]
+        CONN["mailbox/conn<br/>Connector primitives"]
+    end
+
+    RPC --> PB
+    CONN --> PB
+
+    GEN["Generated Stubs<br/>(*_mailboxrpc.pb.go)"] --> RPC
+    SC["serverconn<br/>Runtime"] --> RPC
+    SC --> CONN
+    SC --> PB
+```
+
+| Package | Import Path | Responsibility | Key Types |
+|---------|-------------|----------------|-----------|
+| `pb` | `mailbox/pb` | Protobuf definitions and generated gRPC stubs. | `Envelope`, `RpcMeta`, `Status`, `MailboxServiceClient` |
+| `rpc` | `mailbox/rpc` | Runtime interfaces for generated code. In-process routing mux. gRPC error transport. | `RPCClient`, `Router`, `ServeMux`, `HandlerFunc`, `ServiceMethod` |
+| `conn` | `mailbox/conn` | Reusable connector primitives for ack watermarks, response correlation, deterministic IDs, and TLV-proto bridging. | `AckState`, `ResponseRegistry`, `WrappedProto`, `CorrelationID` |
+
+---
+
+## mailbox/pb: Protocol Definitions
+
+Generated from `mailbox.proto`. Contains the wire-format types and the edge
+service definition. Never edit generated code manually — regenerate with
+`make rpc`.
+
+### Envelope
+
+The `Envelope` is the durable unit flowing through the mailbox. Key fields:
+
+| Field | Type | Role |
+|-------|------|------|
+| `msg_id` | `string` | Unique per send attempt. Different on each retry. |
+| `idempotency_key` | `string` | Stable per semantic operation. Same across retries for dedup. |
+| `sender` / `recipient` | `string` | Mailbox identifiers for routing. |
+| `body` | `google.protobuf.Any` | Typed protobuf payload. |
+| `rpc` | `RpcMeta` | Optional RPC overlay (kind, service, method, correlation). |
+| `event_seq` | `uint64` | Server-assigned ordering key. Cursor for Pull/AckUpTo. |
+| `headers` | `map<string,string>` | Extensible metadata (e.g., gRPC error status). |
+
+### RpcMeta
+
+Carries RPC overlay metadata. The `Kind` enum distinguishes:
+
+- `KIND_REQUEST` — Unary RPC request (client → server).
+- `KIND_RESPONSE` — Unary RPC response (server → client).
+- `KIND_EVENT` — Fire-and-forget message (either direction).
+
+### MailboxService
+
+The edge API consumed by connectors:
+
+- **`Send`** — Append an envelope to a recipient's mailbox.
+- **`Pull`** — Long-poll for envelopes starting at a cursor.
+- **`AckUpTo`** — Advance the ack watermark (monotonic, idempotent).
+
+---
+
+## mailbox/rpc: RPC Interfaces and Mux
+
+This package intentionally contains no transport implementation. It provides
+only the narrow contracts needed by generated code so both clients and servers
+can depend on it without pulling in actor or transport dependencies.
+
+### RPCClient
+
+The client-side interface that generated stubs depend on:
+
+```go
+type RPCClient interface {
+    SendRPC(ctx context.Context, method ServiceMethod,
+        req proto.Message, opts RPCOptions) (SendResult, error)
+
+    AwaitRPC(ctx context.Context, correlationID string,
+        resp proto.Message) error
+}
+```
+
+`SendRPC` constructs and sends a `KIND_REQUEST` envelope. `AwaitRPC` blocks
+until the matching `KIND_RESPONSE` arrives. The two-phase design allows
+pre-registering response waiters before sending, preventing races with fast
+servers.
+
+### Router and HandlerFunc
+
+The server-side interface:
+
+```go
+type Router interface {
+    Handle(service string, method string,
+        newReq func() proto.Message, fn HandlerFunc)
+}
+
+type HandlerFunc func(context.Context, proto.Message) (proto.Message, error)
+```
+
+Handlers must be idempotent — the mailbox provides at-least-once delivery.
+
+### ServeMux
+
+Concrete `Router` implementation. Maps `(service, method)` pairs to typed
+handlers. Thread-safe via `sync.RWMutex`. Unmarshals with
+`DiscardUnknown: true` for forward compatibility.
+
+```go
+mux := mailboxrpc.NewServeMux()
+mux.Handle("arkrpc.v1.RoundService", "JoinRound",
+    func() proto.Message { return new(JoinRoundRequest) },
+    func(ctx context.Context, req proto.Message) (proto.Message, error) {
+        return handleJoinRound(ctx, req.(*JoinRoundRequest))
+    },
+)
+```
+
+### gRPC Status Encoding
+
+Server-side errors are transported via envelope headers, keeping the body
+reserved for successful payloads:
+
+- **`EncodeErrorHeaders(err)`** — Converts any error to a gRPC status, encodes
+  as base64 `google.rpc.Status` in the `mailboxrpc.grpc_status_b64` header.
+- **`DecodeErrorHeaders(headers)`** — Reconstructs the gRPC error on the client
+  side. Returns `nil` if no error header is present.
+
+### ServiceMethod and RPCOptions
+
+- **`ServiceMethod{Service, Method}`** — Routing key. Service is the
+  fully-qualified protobuf service name. Method is the method name.
+- **`RPCOptions`** — Per-request overrides for idempotency key, correlation ID,
+  and custom headers.
+- **`SendResult`** — Contains `CorrelationID` and `IdempotencyKey` from a
+  successful send.
+
+---
+
+## mailbox/conn: Connector Primitives
+
+Protocol-adjacent building blocks shared by client-side and server-side
+connector runtimes. Higher-level runtime wiring (actor lifecycle, dispatcher
+tables, transport loops) lives in connector-specific packages like `serverconn`.
+
+### AckState
+
+Tracks four monotonic cursors governing safe ack progression:
+
+```mermaid
+stateDiagram-v2
+    direction LR
+    state "PullCursor" as PC
+    state "DispatchCommittedTo" as DCT
+    state "AckTarget" as AT
+    state "AckCommittedTo" as ACT
+
+    [*] --> PC : Pull returns batch
+    PC --> DCT : Dispatch committed
+    DCT --> AT : AdvanceDispatch()
+    AT --> ACT : AdvanceAck()
+
+    note right of DCT
+        AckCommittedTo <= DispatchCommittedTo
+    end note
+```
+
+| Cursor | Meaning |
+|--------|---------|
+| `PullCursor` | Next cursor for the `Pull` call. |
+| `DispatchCommittedTo` | Max cursor durably committed to local processing. |
+| `AckTarget` | Max cursor that should be acked remotely. |
+| `AckCommittedTo` | Last cursor successfully acked to the remote edge. |
+
+Key methods:
+
+- **`AdvanceDispatch(nextCursor)`** — Updates `DispatchCommittedTo` and
+  `AckTarget`. Called after successful dispatch.
+- **`AdvanceAck()`** — Sets `AckCommittedTo = AckTarget`. Called after
+  `AckUpTo` succeeds.
+- **`NeedsAck()`** — `true` when `AckTarget > AckCommittedTo`.
+- **`Encode`/`Decode`** — TLV serialization for checkpoint persistence.
+
+### ResponseRegistry
+
+In-memory correlation-based response waiters with early-response buffering:
+
+- **`RegisterWaiter(id)`** — Returns `actor.Future[*Envelope]`. Idempotent.
+  Completes immediately from buffer if a response arrived early.
+- **`DeliverResponse(id, env)`** — Completes an existing waiter or buffers the
+  response for late registration.
+- **`RemoveWaiter(id)`** — Cancels a waiter with `ErrWaiterCancelled`.
+- **Stale cleanup** — Waiters and buffered responses older than `waiterTTL`
+  (default 10 min) are pruned automatically.
+
+### EnvelopeIdentity
+
+Deterministic ID derivation from payload bytes:
+
+- **`StableEventMsgID(payload)`** — `"evt-" + SHA256(payload)[:16]` (hex).
+- **`StableEventIdempotencyKey(payload)`** — `"idem-" + SHA256(payload)[:16]`
+  (hex).
+
+Ensures that retries of persisted durable actor messages produce the same IDs,
+enabling server-side deduplication.
+
+### WrappedProto
+
+Adapts `proto.Message` for use in TLV record fields:
+
+```go
+type WrappedProto[T proto.Message] struct {
+    Val T
+}
+```
+
+Encode: deterministic `proto.Marshal` → write bytes.
+Decode: read bytes → `proto.Unmarshal` into `Val`.
+
+The caller must pre-set `Val` to a typed zero value before decode.
+
+### Typed Identifiers
+
+- **`CorrelationID`** — `string` type linking a request to its response.
+- **`IdempotencyKey`** — `string` type for semantic operation deduplication.
+
+---
+
+## See Also
+
+- [`docs/mailbox_architecture.md`](../docs/mailbox_architecture.md) —
+  Comprehensive architecture covering all three layers with diagrams.
+- [`docs/RPC_MAILBOX_CONTRACT.md`](../docs/RPC_MAILBOX_CONTRACT.md) —
+  Protocol-level contract (ordering, idempotency, ack watermark behavior).
+- [`serverconn/README.md`](../serverconn/README.md) — Server connection runtime
+  (egress, ingress, event routing, crash recovery).
+- [`docs/durable_actor_architecture.md`](../docs/durable_actor_architecture.md)
+  — Underlying actor durability model (CDC, leasing, deduplication).

--- a/serverconn/README.md
+++ b/serverconn/README.md
@@ -1,0 +1,367 @@
+# Server Connection Runtime
+
+The `serverconn` package provides the unified connector boundary for all mailbox
+traffic between the client and the remote server. It combines durable egress
+(crash-safe event delivery), low-latency unary RPCs, background ingress polling,
+and typed event routing into a single `Runtime` that integrates with the actor
+system.
+
+For the full three-layer architecture, see
+[`docs/mailbox_architecture.md`](../docs/mailbox_architecture.md). For the
+underlying mailbox primitives, see [`mailbox/README.md`](../mailbox/README.md).
+
+## Architecture
+
+The runtime composes three main components:
+
+```mermaid
+flowchart TB
+    subgraph "Runtime"
+        DA["DurableActor&lt;ServerConnMsg, ServerConnResp&gt;"]
+        SCA["ServerConnectionActor"]
+        UF["UnaryFacade"]
+    end
+
+    DA -->|"wraps"| SCA
+    UF -->|"delegates to"| SCA
+
+    SCA --> RR["ResponseRegistry"]
+    SCA --> EDGE["Edge<br/>(MailboxServiceClient)"]
+
+    CFG["ConnectorConfig"] -.->|"feeds"| RT["NewRuntime(cfg)"]
+
+    ROUND["Round Actor"] -->|"Tell(SendClientEventRequest)"| DA
+    CALLER["RPC Caller / Generated Stub"] -->|"SendRPC / AwaitRPC"| UF
+    ER["EventRouter"] -.->|"AsDispatcherMap()"| CFG
+```
+
+- **`ServerConnectionActor`**: The core behavior. Handles egress messages in
+  `Receive()` and runs the ingress loop as a background goroutine. Owns the
+  in-memory `ResponseRegistry`.
+- **`DurableActor`**: Wraps the actor for crash-safe egress. Persists outbound
+  FSM events to a durable mailbox before processing.
+- **`UnaryFacade`**: Implements `mailboxrpc.RPCClient`. Sends RPCs directly via
+  the edge (low-latency, no durability) and awaits responses through the
+  registry.
+
+## Getting Started
+
+### Creating a Runtime
+
+```go
+cfg := serverconn.DefaultConnectorConfig()
+cfg.Edge = mailboxClient          // MailboxServiceClient (gRPC)
+cfg.LocalMailboxID = "client-1"   // This client's mailbox
+cfg.RemoteMailboxID = "server-1"  // Server's mailbox
+cfg.Store = deliveryStore         // actor.DeliveryStore for persistence
+cfg.Dispatchers = eventRouter.AsDispatcherMap()  // Inbound routing
+
+runtime, err := serverconn.NewRuntime(cfg)
+if err != nil {
+    return err
+}
+```
+
+`NewRuntime` validates required fields, creates the
+`ServerConnectionActor`, wraps it in a `DurableActor` (ID:
+`"serverconn-" + localMailboxID`), and creates the `UnaryFacade`. The
+`Codec` field defaults to `NewServerConnCodec()` if not set.
+
+### Starting and Stopping
+
+```go
+err := runtime.Start(ctx)
+if err != nil {
+    return err  // Ingress checkpoint load failed — fatal.
+}
+defer runtime.Stop()
+```
+
+`Start` launches the DurableActor (begins processing egress inbox) and the
+ingress loop (loads ack checkpoint, starts pulling). `Stop` cancels the ingress
+loop, waits for it to exit, then stops the DurableActor.
+
+## Unary RPC: Using Generated Stubs
+
+Generated mailbox RPC stubs call `SendRPC` + `AwaitRPC` under the hood:
+
+```go
+client := hellotestpb.NewHelloServiceMailboxClient(runtime.Unary())
+
+resp, err := client.SayHello(ctx, &hellotestpb.HelloRequest{
+    Name: "Alice",
+})
+if err != nil {
+    // gRPC status errors are preserved through header transport.
+    return err
+}
+```
+
+```mermaid
+sequenceDiagram
+    participant C as Caller
+    participant S as Generated Stub
+    participant UF as UnaryFacade
+    participant RR as ResponseRegistry
+    participant E as Edge
+    participant SRV as Server
+    participant IL as Ingress Loop
+
+    C->>S: SayHello(ctx, req)
+    S->>UF: SendRPC(method, req)
+    UF->>RR: RegisterWaiter(corrID)
+    UF->>E: Send(KIND_REQUEST envelope)
+    E->>SRV: Deliver request
+
+    SRV->>SRV: Process
+    SRV->>E: Send(KIND_RESPONSE)
+
+    IL->>E: Pull(cursor)
+    E-->>IL: [KIND_RESPONSE]
+    IL->>RR: DeliverResponse(corrID, env)
+    RR-->>UF: Future completes
+
+    S->>UF: AwaitRPC(corrID, resp)
+    UF-->>S: resp
+    S-->>C: (resp, nil)
+```
+
+The send path calls `Edge.Send` directly — no durable mailbox, no actor queue
+roundtrip. This provides low latency for unary RPCs. If the send fails, the
+caller retries (no crash durability needed for unary RPCs).
+
+Error handling: Server-side gRPC errors are encoded in envelope headers as
+base64 `google.rpc.Status`. `AwaitRPC` decodes them before inspecting the body,
+so callers receive standard `status.Error` values.
+
+## Durable Event Egress: Sending FSM Events
+
+FSM outbox messages use the durable egress path for crash safety:
+
+```go
+err := runtime.TellRef().Tell(ctx, &serverconn.SendClientEventRequest{
+    Message: &joinGreetingServerMsg{SessionID: "session-1"},
+})
+```
+
+The `ServerMessage` interface requires a single method:
+
+```go
+type ServerMessage interface {
+    ToProto() proto.Message
+}
+```
+
+The durable egress path:
+
+1. `DurableActor.Tell` persists the `SendClientEventRequest` to the durable
+   mailbox (TLV-encoded).
+2. The actor runtime calls `Receive`, which:
+   - Calls `Message.ToProto()` to get the proto payload.
+   - Wraps it in `anypb.Any`.
+   - Derives `msg_id` and `idempotency_key` from the payload SHA256 hash
+     (via `StableEventMsgID` / `StableEventIdempotencyKey`).
+   - Builds a `KIND_EVENT` envelope and calls `Edge.Send`.
+3. On crash, the durable mailbox replays the persisted request. The same IDs are
+   re-derived from the stored payload, so the server deduplicates the retry.
+
+## Server-Push Events: Receiving and Routing
+
+### Implementing InboundServerMessage
+
+Actor messages that arrive from the server implement `InboundServerMessage`:
+
+```go
+type InboundServerMessage interface {
+    FromProto(proto.Message) error
+}
+```
+
+Combined with `actor.Message`, this forms the `InboundActorMessage` type
+constraint used by `NewEventRoute`:
+
+```go
+type helloStartedMsg struct {
+    actor.BaseMessage
+    SessionID string
+}
+
+func (m *helloStartedMsg) MessageType() string {
+    return "HelloStartedMsg"
+}
+
+func (m *helloStartedMsg) FromProto(p proto.Message) error {
+    ev, ok := p.(*hellotestpb.HelloStartedEvent)
+    if !ok {
+        return fmt.Errorf("unexpected proto type: %T", p)
+    }
+    m.SessionID = ev.SessionId
+    return nil
+}
+```
+
+### Registering Routes with EventRouter
+
+Create an `EventRouter`, register routes for each `(service, method)` pair, then
+pass the dispatcher map to the connector config:
+
+```go
+router := serverconn.NewEventRouter(system)
+
+// Auto-adapt route (for InboundActorMessage types):
+serverconn.NewEventRoute(router, serverconn.InboundEventRouteConfig[
+    *helloStartedMsg, struct{},
+]{
+    Service:  "hellotest.v1.HelloService",
+    Method:   "HelloStarted",
+    NewEvent: func() proto.Message {
+        return &hellotestpb.HelloStartedEvent{}
+    },
+    Key:    greetingActorKey,
+    NewMsg: func() *helloStartedMsg {
+        return &helloStartedMsg{}
+    },
+})
+
+// Manual adapt route (full control):
+serverconn.AddRoute(router, serverconn.EventRouteConfig[RoundMsg, RoundResp]{
+    Service:  "arkrpc.v1.RoundService",
+    Method:   "RoundStarted",
+    NewEvent: func() proto.Message {
+        return &arkrpc.RoundStartedEvent{}
+    },
+    Key: roundActorKey,
+    Adapt: func(p proto.Message) (RoundMsg, error) {
+        return adaptRoundStarted(p)
+    },
+})
+
+// Wire into connector config:
+cfg.Dispatchers = router.AsDispatcherMap()
+```
+
+```mermaid
+flowchart LR
+    E["Edge.Pull"] --> IL["Ingress Loop"]
+    IL -->|"(service, method)"| DM["Dispatchers Map"]
+    DM --> DC["Dispatcher Closure"]
+    DC -->|"Unmarshal body"| PROTO["proto.Message"]
+    DC -->|"Adapt()"| MSG["Actor Message"]
+    DC -->|"Tell()"| TA["Target Durable Actor"]
+    TA --> DB[(Store)]
+```
+
+Each dispatcher closure captures a `ServiceKey`, resolves the actor via the
+Receptionist, and calls `Tell` to durably persist the message. A `nil` return
+means the envelope is committed — the ingress loop can safely advance the ack
+watermark.
+
+## ConnectorConfig Reference
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `Edge` | `MailboxServiceClient` | *required* | gRPC client for the remote mailbox edge. |
+| `LocalMailboxID` | `string` | *required* | This client's mailbox identifier. |
+| `RemoteMailboxID` | `string` | *required* | Remote server's mailbox identifier. |
+| `ProtocolVersion` | `uint32` | `0` | Protocol version stamped on outbound envelopes. |
+| `Dispatchers` | `map[ServiceMethod]EnvelopeDispatcher` | `nil` | Inbound envelope routing table. |
+| `Store` | `actor.DeliveryStore` | *required* | Durability store for inbox, outbox, and checkpoints. |
+| `Codec` | `*actor.MessageCodec` | `NewServerConnCodec()` | TLV codec for ServerConnMsg serialization. |
+| `PullMaxEnvelopes` | `uint32` | `50` | Max envelopes per Pull call. |
+| `PullWaitTimeout` | `time.Duration` | `5s` | Long-poll timeout for Pull. |
+| `RetryBaseDelay` | `time.Duration` | `200ms` | Exponential backoff base for transient failures. |
+| `RetryMaxDelay` | `time.Duration` | `30s` | Backoff cap. |
+| `ResponseWaiterTTL` | `time.Duration` | `10m` | TTL for response waiters and buffered responses. |
+
+Source: `serverconn/types.go`
+
+## Crash Recovery
+
+Two independent recovery paths operate on startup:
+
+```mermaid
+sequenceDiagram
+    participant P as Process
+    participant DB as Store
+    participant DA as DurableActor
+    participant IL as Ingress Loop
+    participant E as Edge
+
+    P->>DB: loadCheckpoint(AckState)
+    P->>DA: Start() — replay egress inbox
+    DA->>DB: Load persisted SendClientEventRequest(s)
+    DA->>DA: Receive() — re-derive same IDs from payload hash
+    DA->>E: Edge.Send (server deduplicates via idempotency key)
+
+    P->>IL: StartIngress(ctx)
+    IL->>E: AckUpTo(AckTarget) — catch up if ack was pending
+    IL->>E: Pull(PullCursor) — resume from last checkpoint
+    Note over IL,E: Re-pulled envelopes dispatched normally.<br/>Durable actors deduplicate via message ID.
+```
+
+**Egress recovery**: The DurableActor replays all unacknowledged
+`SendClientEventRequest` and `SendRPCRequest` messages from its persistent
+inbox. For event messages, the same `msg_id` and `idempotency_key` are
+reproduced from the persisted TLV payload. The server deduplicates.
+
+**Ingress recovery**: `loadCheckpoint` restores the four-cursor `AckState`.
+The loop resumes from `PullCursor`. If an ack was pending at crash time
+(`AckTarget > AckCommittedTo`), it acks first. Re-pulled envelopes are
+dispatched normally — the target durable actors deduplicate via message ID.
+
+**Unary RPC recovery**: Response waiters are in-memory only. On crash, callers'
+contexts are cancelled and they retry the RPC with new correlation IDs.
+
+## Message Types and TLV Encoding
+
+Two message types flow through the durable actor mailbox:
+
+| TLV Type | Message | Description |
+|----------|---------|-------------|
+| `2000` | `SendClientEventRequest` | FSM outbox event. TLV records: proto payload (Any), msg_id, idempotency_key. |
+| `2001` | `SendRPCRequest` | Pre-built unary RPC envelope. TLV record: full Envelope via WrappedProto. |
+
+Both implement `actor.TLVMessage` (`TLVType`, `Encode`, `Decode`).
+`NewServerConnCodec()` returns a `MessageCodec` with both types registered.
+
+## Testing
+
+The package has comprehensive test coverage across several test files:
+
+| File | Focus |
+|------|-------|
+| `e2e_test.go` | Full round-trip: unary RPC, server push events, durable egress, combined flows. |
+| `connector_test.go` | ServerConnectionActor unit tests for egress handling. |
+| `unary_facade_test.go` | UnaryFacade send/await with mocked edge. |
+| `ingress_error_test.go` | Ingress loop error handling and backoff behavior. |
+| `ingress_property_test.go` | Property-based tests for ack watermark invariants. |
+| `actor_tlv_test.go` | TLV encode/decode round-trip for message types. |
+| `restart_replay_test.go` | Crash recovery and egress replay. |
+| `runtime_test.go` | Runtime lifecycle (start, stop, validation). |
+| `testutil_test.go` | In-memory mailbox, checkpoint store, test helpers. |
+
+Run tests:
+
+```bash
+# All serverconn tests:
+make unit pkg=serverconn timeout=5m
+
+# Specific test:
+make unit pkg=serverconn case=TestE2E_UnaryRPC timeout=5m
+
+# With debug logs:
+make unit log="stdlog trace" pkg=serverconn case=TestE2E timeout=5m
+```
+
+## See Also
+
+- [`docs/mailbox_architecture.md`](../docs/mailbox_architecture.md) —
+  Comprehensive architecture covering all three layers with diagrams.
+- [`mailbox/README.md`](../mailbox/README.md) — Mailbox module overview
+  (proto definitions, RPC interfaces, connector primitives).
+- [`docs/RPC_MAILBOX_CONTRACT.md`](../docs/RPC_MAILBOX_CONTRACT.md) —
+  Protocol-level contract (ordering, idempotency, ack semantics).
+- [`docs/durable_actor_architecture.md`](../docs/durable_actor_architecture.md)
+  — Underlying actor durability model (CDC, leasing, deduplication).
+- [`docs/durable_actor_quickstart.md`](../docs/durable_actor_quickstart.md) —
+  Practical guide to implementing durable actors and TLV messages.


### PR DESCRIPTION
In this PR, we add architecture documentation for the mailbox transport
and the `serverconn` runtime that sits on top of it. Up until now the
only written reference was `RPC_MAILBOX_CONTRACT.md`, which covers the
protocol-level contract but doesn't explain how the client-side
implementation is structured, how the pieces wire together, or what
happens on crash recovery. These docs fill that gap for both human
developers and agents working in the codebase.

The main artifact is `docs/mailbox_architecture.md` (~1000 lines), which
walks through the full three-layer stack: the edge API (`mailbox/pb`),
the reusable RPC interfaces and connector primitives (`mailbox/rpc`,
`mailbox/conn`), and the server connection runtime (`serverconn`). It
includes 13 mermaid diagrams covering system topology, the envelope
class hierarchy, ack watermark state progression, the ingress
pull-dispatch-ack loop, dual egress paths (durable vs fast), unary RPC
round-trip sequences, server-push event routing, and crash recovery
flows. The ack watermark section has a worked crash scenario showing
exactly why `AckCommittedTo` must never exceed `DispatchCommittedTo`.

We also add package-level READMEs for `mailbox/` and `serverconn/`. The
mailbox README serves as a navigation hub across the three sub-packages
with annotated type tables and short usage examples. The serverconn
README is more tutorial-oriented: it has complete wiring examples for
creating a `Runtime`, using generated RPC stubs, sending durable FSM
events via `SendClientEventRequest`, and registering `EventRouter`
routes with both the generic `AddRoute` and the convenience
`NewEventRoute` helpers. It also has a `ConnectorConfig` reference
table with defaults and a test file index.

All three docs cross-reference each other and link back to the existing
`RPC_MAILBOX_CONTRACT.md` and `durable_actor_architecture.md`.

See each commit message for a detailed description w.r.t the incremental
changes.