### PR TITLE
round: unify pool additions via single IntentPackage event

### DIFF
--- a/round/README.md
+++ b/round/README.md
@@ -1,9 +1,17 @@
-# Ark Boarding State Machine
+# Ark Round State Machine
 
-The round package implements the client-side protocol for boarding Bitcoin
-outputs into an Ark virtual UTXO tree through coordinated multi-party rounds.
-Boarding converts on-chain Bitcoin into off-chain VTXOs that enable instant,
-private transfers within the Ark system.
+The round package implements the client-side protocol for participating in Ark
+rounds. Rounds coordinate multiple clients to batch operations into a single
+commitment transaction containing a VTXO tree. The package supports three
+operations:
+
+- **Boarding**: Converting on-chain Bitcoin into off-chain VTXOs by spending
+  boarding UTXOs into the commitment transaction.
+- **Refresh**: Rolling existing VTXOs into a new tree with extended expirations,
+  preventing timeout-based expiry. Old VTXOs are atomically forfeited via
+  connector outputs.
+- **Leave**: Exiting the Ark by converting a VTXO back to an on-chain output
+  included in the commitment transaction.
 
 The architecture strictly separates business logic from side effects. The finite
 state machine (FSM) owns all protocol logic, validation, and state transitions.
@@ -60,23 +68,28 @@ transaction. Once confirmed via `BoardingUTXOConfirmed`, the FSM transitions
 from Idle to PendingRoundAssembly, registering a boarding intent containing
 the address and on-chain UTXO information.
 
-Boarding intents and VTXO requests are managed separately, enabling flexible
-input-output mappings. The FSM collects boarding intents (inputs to spend) and
-VTXO requests (outputs to create) independently:
+Boarding intents, VTXO requests, refresh requests, and leave requests are
+managed separately, enabling flexible input-output mappings. The FSM collects
+them independently as self-loops in PendingRoundAssembly:
 
-- `BoardingUTXOConfirmed` adds a boarding intent to the pending set
+- `BoardingUTXOConfirmed` adds a boarding intent (on-chain input to spend)
 - `VTXORequestsReceived` adds VTXO requests specifying desired output amounts
+- `RefreshVTXORequest` adds a VTXO to be rolled into a new tree (from VTXO
+  actors whose VTXOs are approaching expiry)
+- `LeaveVTXORequest` adds a VTXO to be exited on-chain (from VTXO actors or
+  the wallet when the user wants to offboard)
 
-This separation supports future fan-in (multiple inputs funding one output) and
-fan-out (one input creating multiple outputs) scenarios. The FSM accumulates
-both types as self-loops in PendingRoundAssembly.
+This separation supports fan-in (multiple inputs funding one output) and
+fan-out (one input creating multiple outputs) scenarios, as well as mixed
+rounds containing any combination of boarding, refresh, and leave operations.
+Refresh-only rounds (no boarding inputs) are also supported.
 
 When `RegistrationRequested` is received, the FSM validates that total outputs
 do not exceed inputs, then transitions to RegistrationSentState, emitting a
 `JoinRoundRequest` that aggregates all intents into a single server request.
 The join request carries boarding inputs, VTXO outputs, explicit forfeit
-outpoints, and optional leave outputs. The FSM can also resume existing intents
-on restart via `ResumeBoardingIntents`.
+outpoints, and leave outputs. The FSM can also resume existing intents on
+restart via `ResumeBoardingIntents`.
 
 ### RegistrationSent and RoundJoined States
 
@@ -124,6 +137,26 @@ partial signatures via `SubmitPartialSigRequest`.
 The operator aggregates all partial signatures to produce complete Schnorr
 signatures over every tree branch, making each VTXO spendable through the
 cooperative path.
+
+### ForfeitSignaturesCollecting State
+
+When a round includes refresh or leave requests, the FSM enters
+ForfeitSignaturesCollecting after the operator returns signed tree
+branches. Old VTXOs must be forfeited before boarding inputs are
+released, ensuring atomic replacement.
+
+For each refresh or leave VTXO, the FSM sends a `ForfeitRequestToVTXO`
+outbox message to the corresponding VTXO actor. The VTXO actor builds
+a forfeit transaction spending the old VTXO through a connector output
+tied to the new commitment transaction, signs it, and returns a
+`ForfeitSignatureResponse`.
+
+The FSM tracks expected vs collected forfeits. Once all expected forfeit
+signatures arrive, they are submitted to the server via
+`SubmitVTXOForfeitSigsToServer` and the FSM transitions to
+InputSigSent. If the round has no refresh or leave requests, this state
+is skipped entirely and PartialSigsSent transitions directly to
+InputSigSent.
 
 ### InputSigSent State: The Point of No Return
 
@@ -211,7 +244,10 @@ from depending on external interfaces. The FSM emits side effects as data
 outbox contents and dispatches to appropriate subsystems:
 
 - **Server messages**: `JoinRoundRequest`, `SubmitNoncesRequest`,
-  `SubmitPartialSigRequest`, `SubmitForfeitSigRequest`
+  `SubmitPartialSigRequest`, `SubmitForfeitSigRequest`,
+  `SubmitVTXOForfeitSigsToServer`
+- **VTXO actor messages**: `ForfeitRequestToVTXO`,
+  `ForfeitConfirmedToVTXO`
 - **Chain monitoring**: `RegisterConfirmationRequest`
 - **Wallet notifications**: `VTXOCreatedNotification`, `AddressReceived`
 
@@ -231,6 +267,7 @@ and server during a successful boarding round:
 
 ```mermaid
 sequenceDiagram
+    participant V as VTXO Actors
     participant C as Client FSM
     participant A as Actor
     participant S as Server
@@ -245,6 +282,12 @@ sequenceDiagram
     A->>C: BoardingUTXOConfirmed
     Note over A: User specifies VTXO amounts
     A->>C: VTXORequestsReceived
+    opt Refresh / Leave
+        V->>A: RefreshVTXORequest
+        A->>C: RefreshVTXORequest
+        V->>A: LeaveVTXORequest
+        A->>C: LeaveVTXORequest
+    end
 
     Note over C,B: Round Registration Phase
     A->>C: RegistrationRequested
@@ -270,6 +313,15 @@ sequenceDiagram
     S->>A: OperatorSigned(signatures)
     A->>C: OperatorSigned
 
+    opt Forfeit Signature Collection (refresh/leave)
+        C->>A: ForfeitRequestToVTXO (outbox)
+        A->>V: ForfeitRequestEvent
+        V->>A: ForfeitSignatureResponse
+        A->>C: ForfeitSignatureResponse
+        C->>A: SubmitVTXOForfeitSigsToServer (outbox)
+        A->>S: SubmitVTXOForfeitSigs
+    end
+
     Note over C,B: Boarding Input Signing (Point of No Return)
     Note over C: Validate all tree signatures
     Note over C: Sign boarding inputs
@@ -289,6 +341,8 @@ sequenceDiagram
     Note over C,B: VTXO Creation
     Note over C: Build ClientVTXO descriptors
     C->>A: VTXOCreatedNotification (outbox)
+    C->>A: ForfeitConfirmedToVTXO (outbox)
+    A->>V: ForfeitConfirmedEvent
     Note over C: Transition to Idle
 ```
 
@@ -337,6 +391,8 @@ stateDiagram-v2
     Idle --> PendingRoundAssembly: ResumeBoardingIntents
     PendingRoundAssembly --> PendingRoundAssembly: BoardingUTXOConfirmed
     PendingRoundAssembly --> PendingRoundAssembly: VTXORequestsReceived
+    PendingRoundAssembly --> PendingRoundAssembly: RefreshVTXORequest
+    PendingRoundAssembly --> PendingRoundAssembly: LeaveVTXORequest
     PendingRoundAssembly --> RegistrationSent: RegistrationRequested
     RegistrationSent --> RoundJoined: RoundJoined
     RoundJoined --> CommitmentTxReceived: CommitmentTxBuilt
@@ -344,7 +400,10 @@ stateDiagram-v2
     CommitmentTxValidated --> NoncesSent: GenerateNonces
     NoncesSent --> NoncesAggregated: NoncesAggregated
     NoncesAggregated --> PartialSigsSent: GeneratePartialSigs
-    PartialSigsSent --> InputSigSent: OperatorSigned
+    PartialSigsSent --> ForfeitSignaturesCollecting: OperatorSigned (with forfeits)
+    PartialSigsSent --> InputSigSent: OperatorSigned (no forfeits)
+    ForfeitSignaturesCollecting --> ForfeitSignaturesCollecting: ForfeitSignatureResponse (partial)
+    ForfeitSignaturesCollecting --> InputSigSent: ForfeitSignatureResponse (all collected)
     InputSigSent --> Confirmed: BoardingConfirmed
     Confirmed --> Idle: RoundComplete
 
@@ -356,6 +415,7 @@ stateDiagram-v2
     NoncesSent --> ClientFailed: BoardingFailed
     NoncesAggregated --> ClientFailed: BoardingFailed
     PartialSigsSent --> ClientFailed: BoardingFailed
+    ForfeitSignaturesCollecting --> ClientFailed: BoardingFailed
     InputSigSent --> ClientFailed: BoardingFailed
     InputSigSent --> RecoveryInitiated: RecoveryInitiated
 ```
@@ -364,22 +424,56 @@ The diagram omits internal events for clarity, showing only major transitions
 triggered by external events. Each state may perform significant computation
 (validation, cryptography, checkpoint operations) before transitioning.
 
+## Refresh and Leave Flows
+
+Refresh and leave operations participate in the same round lifecycle as
+boarding, sharing the MuSig2 signing ceremony and commitment transaction. They
+differ in how intents are assembled and how old VTXOs are handled.
+
+### Refresh
+
+When a VTXO approaches its CSV expiry, the VTXO actor sends a
+`RefreshVTXORequest` to the round actor (either automatically or via manual
+`TriggerRefreshEvent`). The round FSM accumulates these in
+`PendingRoundAssembly.RefreshingVTXOs` alongside any boarding intents. During
+registration, refresh requests are included in the `JoinRoundRequest` as
+forfeit outpoints with corresponding new VTXO outputs.
+
+After the operator signs the VTXO tree, the FSM enters
+ForfeitSignaturesCollecting and sends `ForfeitRequestToVTXO` to each VTXO
+actor. The VTXO actor builds a forfeit transaction spending the old VTXO
+through a connector output tied to the new commitment transaction, signs it,
+and returns a `ForfeitSignatureResponse`. This ensures atomic replacement: the
+old VTXO becomes unspendable only when the new commitment transaction
+confirms.
+
+On the VTXO actor side, the flow progresses through `RefreshRequestedState` →
+`ForfeitingState` → `ForfeitedState` as the forfeit is requested, signed, and
+confirmed.
+
+### Leave
+
+Leave follows the same mechanics as refresh, but the output is an on-chain
+destination rather than a new VTXO. The user (or wallet) sends a
+`LeaveVTXORequest`, accumulated in `PendingRoundAssembly.LeavingVTXOs`. During
+commitment transaction validation, the FSM verifies all leave outputs appear
+in the transaction via `validateLeaveOutputs()`.
+
+### Mixed Rounds
+
+A single round can contain any combination of boarding, refresh, and leave
+operations. Refresh-only rounds (no boarding inputs) are supported, allowing
+VTXO rollovers without requiring new on-chain deposits.
+
 ## Future Extensions
 
-The current implementation supports boarding, the entry point for Ark
-participation. Future extensions will add exit paths (unilateral timeout-based
-and cooperative), VTXO transfers between participants, and refresh rounds
-implemented by combining forfeit requests with new VTXO requests
-preventing timeouts by moving VTXOs into new trees with extended expirations.
+Future extensions may add VTXO transfers between participants, requiring their
+own round coordination that potentially reuses portions of the MuSig2 ceremony
+with different validation and output construction. Unilateral exit paths
+(timeout-based) coordinate with the operator but follow distinct state
+progressions without multi-party coordination.
 
-These extensions may introduce additional states or entirely separate FSMs for
-different protocol flows. Exit flows coordinate with the operator but follow
-distinct state progressions (no multi-party coordination required). VTXO
-transfers need their own round coordination, potentially reusing portions of the
-boarding FSM's MuSig2 ceremony with different validation and output
-construction.
-
-The actor's primary/dedicated FSM pattern should extend naturally. Each protocol
-type (boarding, exit, transfer) can maintain a primary FSM for interactive
-phases and spawn dedicated FSMs for monitoring, ensuring responsiveness
-regardless of simultaneous operation count.
+The actor's primary/dedicated FSM pattern extends naturally to these flows.
+Each protocol type can maintain a primary FSM for interactive phases and spawn
+dedicated FSMs for monitoring, ensuring responsiveness regardless of
+simultaneous operation count.

--- a/round/README.md
+++ b/round/README.md
@@ -64,20 +64,26 @@ instance to process additional addresses across different rounds.
 ### PendingRoundAssembly State
 
 After receiving an address, the user funds it by broadcasting a Bitcoin
-transaction. Once confirmed via `BoardingUTXOConfirmed`, the FSM transitions
-from Idle to PendingRoundAssembly, registering a boarding intent containing
-the address and on-chain UTXO information.
+transaction. Once confirmed, the actor builds a `BoardingIntent` and delivers
+it to the FSM via `IntentPackage`. The FSM transitions from Idle to
+PendingRoundAssembly, registering the boarding intent containing the address
+and on-chain UTXO information.
 
-Boarding intents, VTXO requests, refresh requests, and leave requests are
-managed separately, enabling flexible input-output mappings. The FSM collects
-them independently as self-loops in PendingRoundAssembly:
+All pool additions flow through a single `IntentPackage` event, which carries
+four independent pools:
 
-- `BoardingUTXOConfirmed` adds a boarding intent (on-chain input to spend)
-- `VTXORequestsReceived` adds VTXO requests specifying desired output amounts
-- `RefreshVTXORequest` adds a VTXO to be rolled into a new tree (from VTXO
-  actors whose VTXOs are approaching expiry)
-- `LeaveVTXORequest` adds a VTXO to be exited on-chain (from VTXO actors or
-  the wallet when the user wants to offboard)
+- **Boarding** — on-chain inputs to spend (from confirmed boarding UTXOs)
+- **VTXOs** — requested output amounts for new virtual UTXOs
+- **Forfeits** — VTXOs to be rolled into a new tree (from VTXO actors whose
+  VTXOs are approaching expiry)
+- **Leaves** — VTXOs to be exited on-chain (from VTXO actors or the wallet
+  when the user wants to offboard)
+
+The actor translates external messages — `RefreshVTXORequest`,
+`LeaveVTXORequest`, wallet confirmations, and VTXO requests — into an
+`IntentPackage` before sending it to the FSM. This keeps input validation
+and intent construction in the actor layer, while the FSM focuses purely
+on pool accumulation and state management.
 
 This separation supports fan-in (multiple inputs funding one output) and
 fan-out (one input creating multiple outputs) scenarios, as well as mixed
@@ -88,8 +94,7 @@ When `RegistrationRequested` is received, the FSM validates that total outputs
 do not exceed inputs, then transitions to RegistrationSentState, emitting a
 `JoinRoundRequest` that aggregates all intents into a single server request.
 The join request carries boarding inputs, VTXO outputs, explicit forfeit
-outpoints, and leave outputs. The FSM can also resume existing intents on
-restart via `ResumeBoardingIntents`.
+outpoints, and leave outputs.
 
 ### RegistrationSent and RoundJoined States
 
@@ -279,14 +284,14 @@ sequenceDiagram
 
     Note over C,B: Intent Assembly Phase
     B->>A: UTXO confirmed
-    A->>C: BoardingUTXOConfirmed
+    A->>C: IntentPackage(boarding)
     Note over A: User specifies VTXO amounts
-    A->>C: VTXORequestsReceived
+    A->>C: IntentPackage(vtxos)
     opt Refresh / Leave
         V->>A: RefreshVTXORequest
-        A->>C: RefreshVTXORequest
+        A->>C: IntentPackage(forfeit + vtxo)
         V->>A: LeaveVTXORequest
-        A->>C: LeaveVTXORequest
+        A->>C: IntentPackage(forfeit + leave)
     end
 
     Note over C,B: Round Registration Phase
@@ -386,13 +391,8 @@ during checkpoint.
 ```mermaid
 stateDiagram-v2
     [*] --> Idle
-    Idle --> PendingRoundAssembly: BoardingUTXOConfirmed
-    Idle --> PendingRoundAssembly: VTXORequestsReceived
-    Idle --> PendingRoundAssembly: ResumeBoardingIntents
-    PendingRoundAssembly --> PendingRoundAssembly: BoardingUTXOConfirmed
-    PendingRoundAssembly --> PendingRoundAssembly: VTXORequestsReceived
-    PendingRoundAssembly --> PendingRoundAssembly: RefreshVTXORequest
-    PendingRoundAssembly --> PendingRoundAssembly: LeaveVTXORequest
+    Idle --> PendingRoundAssembly: IntentPackage
+    PendingRoundAssembly --> PendingRoundAssembly: IntentPackage
     PendingRoundAssembly --> RegistrationSent: RegistrationRequested
     RegistrationSent --> RoundJoined: RoundJoined
     RoundJoined --> CommitmentTxReceived: CommitmentTxBuilt
@@ -418,6 +418,7 @@ stateDiagram-v2
     ForfeitSignaturesCollecting --> ClientFailed: BoardingFailed
     InputSigSent --> ClientFailed: BoardingFailed
     InputSigSent --> RecoveryInitiated: RecoveryInitiated
+    ClientFailed --> Idle: IntentPackage (recovery)
 ```
 
 The diagram omits internal events for clarity, showing only major transitions
@@ -434,8 +435,10 @@ differ in how intents are assembled and how old VTXOs are handled.
 
 When a VTXO approaches its CSV expiry, the VTXO actor sends a
 `RefreshVTXORequest` to the round actor (either automatically or via manual
-`TriggerRefreshEvent`). The round FSM accumulates these in
-`PendingRoundAssembly.RefreshingVTXOs` alongside any boarding intents. During
+`TriggerRefreshEvent`). The round actor translates these into an
+`IntentPackage` with a forfeit request and corresponding VTXO output, which
+the FSM accumulates in `PendingRoundAssembly.Forfeits` and
+`PendingRoundAssembly.VTXOs` alongside any boarding intents. During
 registration, refresh requests are included in the `JoinRoundRequest` as
 forfeit outpoints with corresponding new VTXO outputs.
 
@@ -455,7 +458,7 @@ confirmed.
 
 Leave follows the same mechanics as refresh, but the output is an on-chain
 destination rather than a new VTXO. The user (or wallet) sends a
-`LeaveVTXORequest`, accumulated in `PendingRoundAssembly.LeavingVTXOs`. During
+`LeaveVTXORequest`, accumulated in `PendingRoundAssembly.Leaves`. During
 commitment transaction validation, the FSM verifies all leave outputs appear
 in the transaction via `validateLeaveOutputs()`.
 

--- a/round/actor.go
+++ b/round/actor.go
@@ -780,6 +780,36 @@ func (a *RoundClientActor) handleWalletBoardingConfirmed(ctx context.Context,
 		slog.Int("amount", int(walletIntent.ChainInfo.Amount)),
 		slog.Int("conf_height", int(walletIntent.ChainInfo.ConfHeight)))
 
+	// Validate chain data that the FSM previously checked.
+	confTx := walletIntent.ChainInfo.ConfTx
+	if confTx == nil {
+		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
+			"boarding confirmation missing tx"))
+	}
+	if int(walletIntent.Outpoint.Index) >= len(confTx.TxOut) {
+		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
+			"invalid outpoint index %d for tx %s",
+			walletIntent.Outpoint.Index,
+			walletIntent.Outpoint.Hash))
+	}
+
+	// Build the boarding request from the wallet intent. Chain-level
+	// information (ConfHeight, ConfHash, ConfTx, TxProof, Amount) is
+	// carried through the embedded wallet.BoardingIntent.ChainInfo
+	// and remains available to downstream consumers (e.g.,
+	// buildJoinRoundAuthRequest uses ChainInfo.Amount for BIP-322
+	// proof construction).
+	boardingReq := types.BoardingRequest{
+		Outpoint:    &walletIntent.Outpoint,
+		ClientKey:   walletIntent.Address.KeyDesc.PubKey,
+		OperatorKey: walletIntent.Address.OperatorKey,
+		ExitDelay:   walletIntent.Address.ExitDelay,
+	}
+	intent := BoardingIntent{
+		BoardingIntent: *walletIntent,
+		Request:        boardingReq,
+	}
+
 	// Find an existing assembling round (Idle or PendingRoundAssembly) or
 	// create a new one. This allows multiple boarding confirmations to
 	// accumulate in the same round.
@@ -793,21 +823,11 @@ func (a *RoundClientActor) handleWalletBoardingConfirmed(ctx context.Context,
 		}
 	}
 
-	// Create the FSM event from the wallet's confirmed intent. Wallet only
-	// notifies after min confs, so we set confirmations to 1. Include the
-	// Address and TxProof for building the Request.
-	confirmEvt := &BoardingUTXOConfirmed{
-		Outpoint:      walletIntent.Outpoint,
-		Address:       walletIntent.Address,
-		BlockHeight:   walletIntent.ChainInfo.ConfHeight,
-		BlockHash:     walletIntent.ChainInfo.ConfHash,
-		Confirmations: int32(a.cfg.OperatorTerms.MinConfirmations),
-		Tx:            walletIntent.ChainInfo.ConfTx,
-		TxProof:       walletIntent.ChainInfo.TxProof,
-	}
-
-	// Drive the FSM with the confirmation event.
-	err := a.askEventAndProcessOutbox(ctx, roundFSM.FSM, confirmEvt)
+	// Send the boarding intent to the FSM as an IntentPackage.
+	pkg := &IntentPackage{Intents: Intents{
+		Boarding: []BoardingIntent{intent},
+	}}
+	err := a.askEventAndProcessOutbox(ctx, roundFSM.FSM, pkg)
 	if err != nil {
 		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 			"FSM error processing boarding confirmation: %w", err))
@@ -862,11 +882,11 @@ func (a *RoundClientActor) handleVTXORequests(ctx context.Context,
 		}
 	}
 
-	event := &VTXORequestsReceived{
-		Requests: requests,
-	}
+	pkg := &IntentPackage{Intents: Intents{
+		VTXOs: requests,
+	}}
 
-	err := a.askEventAndProcessOutbox(ctx, roundFSM.FSM, event)
+	err := a.askEventAndProcessOutbox(ctx, roundFSM.FSM, pkg)
 	if err != nil {
 		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 			"FSM error processing VTXO requests: %w", err,
@@ -879,7 +899,7 @@ func (a *RoundClientActor) handleVTXORequests(ctx context.Context,
 }
 
 // handleVTXORequestsReceived forwards pre-built VTXO requests from other
-// actors into the pending round FSM.
+// actors into the pending round FSM via IntentPackage.
 func (a *RoundClientActor) handleVTXORequestsReceived(ctx context.Context,
 	req *VTXORequestsReceived) fn.Result[actormsg.RoundActorResp] {
 
@@ -905,7 +925,10 @@ func (a *RoundClientActor) handleVTXORequestsReceived(ctx context.Context,
 		}
 	}
 
-	err := a.askEventAndProcessOutbox(ctx, roundFSM.FSM, req)
+	pkg := &IntentPackage{Intents: Intents{
+		VTXOs: req.Requests,
+	}}
+	err := a.askEventAndProcessOutbox(ctx, roundFSM.FSM, pkg)
 	if err != nil {
 		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 			"FSM error processing VTXO requests: %w", err))
@@ -1565,14 +1588,14 @@ func (a *RoundClientActor) handleRefreshVTXORequest(ctx context.Context,
 	}
 
 	// Bundle the forfeit input and new VTXO output atomically.
-	pkg := &IntentPackage{
+	pkg := &IntentPackage{Intents: Intents{
 		Forfeits: []types.ForfeitRequest{{
 			VTXOOutpoint: &req.VTXOOutpoint,
 		}},
 		VTXOs: []types.VTXORequest{
 			buildVTXORequestFromRefresh(req),
 		},
-	}
+	}}
 	err := a.askEventAndProcessOutbox(ctx, roundFSM.FSM, pkg)
 	if err != nil {
 		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
@@ -1622,12 +1645,12 @@ func (a *RoundClientActor) handleLeaveVTXORequest(ctx context.Context,
 	}
 
 	// Bundle the forfeit input and leave output atomically.
-	pkg := &IntentPackage{
+	pkg := &IntentPackage{Intents: Intents{
 		Forfeits: []types.ForfeitRequest{{
 			VTXOOutpoint: &req.VTXOOutpoint,
 		}},
 		Leaves: []*types.LeaveRequest{{Output: req.Output}},
-	}
+	}}
 	err := a.askEventAndProcessOutbox(ctx, roundFSM.FSM, pkg)
 	if err != nil {
 		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(

--- a/round/actor.go
+++ b/round/actor.go
@@ -9,6 +9,7 @@ import (
 	"maps"
 	"slices"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg"
@@ -29,6 +30,100 @@ import (
 
 // Compile-time assertion that RoundClientActor implements actor.Stoppable.
 var _ actor.Stoppable = (*RoundClientActor)(nil)
+
+// RefreshVTXORequest is sent from a VTXO actor when its VTXO is approaching
+// expiry and needs to be refreshed in a new round. The round actor should
+// queue this VTXO for inclusion in the next batch swap.
+//
+// This request contains all information needed to build a forfeit request
+// (for the connector tree) and a VTXORequest (for the new VTXO in the VTXT).
+// The same client key is typically reused for the new VTXO.
+//
+// NOTE: This type is an actor message (RoundReceivable), not an FSM event.
+// The actor translates it into an IntentPackage{Forfeits: [1], VTXOs: [1]}.
+type RefreshVTXORequest struct {
+	actor.BaseMessage
+
+	// VTXOOutpoint identifies the VTXO to refresh.
+	VTXOOutpoint wire.OutPoint
+
+	// Amount is the VTXO value in satoshis.
+	Amount int64
+
+	// NewVTXOKey is the client's public key for the new VTXO. This is
+	// typically the same as the old VTXO's key but could be fresh.
+	NewVTXOKey *btcec.PublicKey
+
+	// PkScript is the output script for the new VTXO.
+	PkScript []byte
+
+	// OperatorKey is the operator's public key for the new VTXO.
+	OperatorKey *btcec.PublicKey
+
+	// Expiry is the CSV delay for the new VTXO's unilateral exit path.
+	Expiry uint32
+
+	// SigningKey is the key descriptor for signing the new VTXO's tree.
+	SigningKey keychain.KeyDescriptor
+}
+
+// RoundReceivable implements actormsg.RoundReceivable marker interface.
+func (e *RefreshVTXORequest) RoundReceivable() {}
+
+// MessageType returns the message type for logging.
+func (e *RefreshVTXORequest) MessageType() string {
+	return "RefreshVTXORequest"
+}
+
+// LeaveVTXORequest is sent from a VTXO actor (or wallet) when the user wants
+// to exit the Ark by forfeiting a VTXO and receiving an on-chain output. This
+// is similar to RefreshVTXORequest except the output is on-chain rather than a
+// new VTXO.
+//
+// The leave flow uses the same forfeit mechanism as refresh: the old VTXO is
+// forfeited via a connector output, and the leave output is included directly
+// in the batch transaction.
+//
+// NOTE: This type is an actor message (RoundReceivable), not an FSM event.
+// The actor translates it into an IntentPackage{Forfeits: [1], Leaves: [1]}.
+type LeaveVTXORequest struct {
+	actor.BaseMessage
+
+	// VTXOOutpoint identifies the VTXO to forfeit.
+	VTXOOutpoint wire.OutPoint
+
+	// Amount is the VTXO value in satoshis.
+	Amount int64
+
+	// Output is the on-chain destination output that will be included in
+	// the batch transaction. This contains the value and pkScript for the
+	// leave output.
+	Output *wire.TxOut
+}
+
+// RoundReceivable implements actormsg.RoundReceivable marker interface.
+func (e *LeaveVTXORequest) RoundReceivable() {}
+
+// MessageType returns the message type for logging.
+func (e *LeaveVTXORequest) MessageType() string {
+	return "LeaveVTXORequest"
+}
+
+// buildVTXORequestFromRefresh constructs a types.VTXORequest from a
+// RefreshVTXORequest. The refresh request contains all info needed to create
+// the new VTXO output in the round.
+func buildVTXORequestFromRefresh(
+	req *RefreshVTXORequest) types.VTXORequest {
+
+	return types.VTXORequest{
+		Amount:      btcutil.Amount(req.Amount),
+		PkScript:    req.PkScript,
+		Expiry:      req.Expiry,
+		ClientKey:   req.NewVTXOKey,
+		OperatorKey: req.OperatorKey,
+		SigningKey:  req.SigningKey,
+	}
+}
 
 // RoundFSM wraps a state machine instance for a specific round.
 type RoundFSM struct {

--- a/round/actor.go
+++ b/round/actor.go
@@ -1566,9 +1566,8 @@ func (a *RoundClientActor) handleRefreshVTXORequest(ctx context.Context,
 
 	// Bundle the forfeit input and new VTXO output atomically.
 	pkg := &IntentPackage{
-		Forfeits: []ForfeitIntent{{
-			VTXOOutpoint: req.VTXOOutpoint,
-			Amount:       btcutil.Amount(req.Amount),
+		Forfeits: []types.ForfeitRequest{{
+			VTXOOutpoint: &req.VTXOOutpoint,
 		}},
 		VTXOs: []types.VTXORequest{
 			buildVTXORequestFromRefresh(req),
@@ -1624,11 +1623,10 @@ func (a *RoundClientActor) handleLeaveVTXORequest(ctx context.Context,
 
 	// Bundle the forfeit input and leave output atomically.
 	pkg := &IntentPackage{
-		Forfeits: []ForfeitIntent{{
-			VTXOOutpoint: req.VTXOOutpoint,
-			Amount:       btcutil.Amount(req.Amount),
+		Forfeits: []types.ForfeitRequest{{
+			VTXOOutpoint: &req.VTXOOutpoint,
 		}},
-		Leaves: []*LeaveRequest{{Output: req.Output}},
+		Leaves: []*types.LeaveRequest{{Output: req.Output}},
 	}
 	err := a.askEventAndProcessOutbox(ctx, roundFSM.FSM, pkg)
 	if err != nil {

--- a/round/actor.go
+++ b/round/actor.go
@@ -1452,8 +1452,8 @@ func (a *RoundClientActor) processConfirmationRequest(
 
 // handleRefreshVTXORequest processes a refresh request from a VTXO actor.
 // The VTXO is approaching expiry and needs to be included in the next batch
-// swap round. The request is forwarded to a pending round FSM which tracks it
-// alongside boarding intents.
+// swap round. The actor translates the request into a single IntentPackage
+// containing one forfeit input and one new VTXO output.
 func (a *RoundClientActor) handleRefreshVTXORequest(ctx context.Context,
 	req *RefreshVTXORequest) fn.Result[actormsg.RoundActorResp] {
 
@@ -1469,12 +1469,20 @@ func (a *RoundClientActor) handleRefreshVTXORequest(ctx context.Context,
 		}
 	}
 
-	// Forward to the round FSM. The FSM tracks refreshing VTXOs in its
-	// state (similar to how it tracks boarding intents).
-	err := a.askEventAndProcessOutbox(ctx, roundFSM.FSM, req)
+	// Bundle the forfeit input and new VTXO output atomically.
+	pkg := &IntentPackage{
+		Forfeits: []ForfeitIntent{{
+			VTXOOutpoint: req.VTXOOutpoint,
+			Amount:       btcutil.Amount(req.Amount),
+		}},
+		VTXOs: []types.VTXORequest{
+			buildVTXORequestFromRefresh(req),
+		},
+	}
+	err := a.askEventAndProcessOutbox(ctx, roundFSM.FSM, pkg)
 	if err != nil {
 		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
-			"FSM error processing refresh request: %w", err,
+			"FSM error processing refresh package: %w", err,
 		))
 	}
 
@@ -1502,9 +1510,8 @@ func (a *RoundClientActor) handleRefreshVTXORequest(ctx context.Context,
 }
 
 // handleLeaveVTXORequest processes a leave (offboard) request from a VTXO
-// actor. The VTXO is being exited to an on-chain output. The request is
-// forwarded to a pending round FSM which tracks it alongside boarding intents
-// and refresh requests.
+// actor. The actor translates the request into a single IntentPackage
+// containing one forfeit input and one leave output.
 func (a *RoundClientActor) handleLeaveVTXORequest(ctx context.Context,
 	req *LeaveVTXORequest) fn.Result[actormsg.RoundActorResp] {
 
@@ -1520,12 +1527,18 @@ func (a *RoundClientActor) handleLeaveVTXORequest(ctx context.Context,
 		}
 	}
 
-	// Forward to the round FSM. The FSM tracks leaving VTXOs in its
-	// state (similar to how it tracks boarding intents and refreshes).
-	err := a.askEventAndProcessOutbox(ctx, roundFSM.FSM, req)
+	// Bundle the forfeit input and leave output atomically.
+	pkg := &IntentPackage{
+		Forfeits: []ForfeitIntent{{
+			VTXOOutpoint: req.VTXOOutpoint,
+			Amount:       btcutil.Amount(req.Amount),
+		}},
+		Leaves: []*LeaveRequest{{Output: req.Output}},
+	}
+	err := a.askEventAndProcessOutbox(ctx, roundFSM.FSM, pkg)
 	if err != nil {
 		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
-			"FSM error processing leave request: %w", err,
+			"FSM error processing leave package: %w", err,
 		))
 	}
 

--- a/round/actor_test.go
+++ b/round/actor_test.go
@@ -3,6 +3,7 @@ package round
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -1264,6 +1265,369 @@ func TestVTXOCreatedNotificationForwarding(t *testing.T) {
 		require.Len(t, receivedNotif.VTXOs, 1)
 		require.Equal(
 			t, clientVTXO.Outpoint, receivedNotif.VTXOs[0].Outpoint,
+		)
+	})
+}
+
+// TestActorIntentMapping verifies that the actor correctly maps external
+// messages into IntentPackage events, preserving all fields through the
+// type conversion. These tests exercise the mapping+verification logic
+// that lives in the actor layer.
+func TestActorIntentMapping(t *testing.T) {
+	t.Parallel()
+
+	t.Run("boarding_preserves_chain_info", func(t *testing.T) {
+		t.Parallel()
+
+		h := newActorTestHarness(t)
+		h.setupMockRoundStoreForStart()
+
+		err := h.start()
+		require.NoError(t, err)
+
+		intent := h.newTestBoardingIntent()
+		h.sendWalletConfirmation(intent)
+
+		// Verify the FSM received a complete boarding intent
+		// with chain info preserved through the type hierarchy.
+		states := h.queryState()
+		tempState, exists := h.findTempState(states)
+		require.True(t, exists, "expected temp-keyed FSM")
+
+		assembly, ok := tempState.State.(*PendingRoundAssembly)
+		require.True(t, ok, "expected PendingRoundAssembly")
+		require.Len(t, assembly.Boarding, 1)
+
+		boardingIntent := assembly.Boarding[0]
+
+		// Chain info must be preserved through the embedding.
+		require.Equal(
+			t, intent.ChainInfo.ConfHeight,
+			boardingIntent.ChainInfo.ConfHeight,
+		)
+		require.Equal(
+			t, intent.ChainInfo.Amount,
+			boardingIntent.ChainInfo.Amount,
+		)
+		require.NotNil(t, boardingIntent.ChainInfo.ConfTx)
+
+		// Request fields must be built correctly from the
+		// wallet intent.
+		require.NotNil(t, boardingIntent.Request.Outpoint)
+		require.Equal(
+			t, intent.Outpoint,
+			*boardingIntent.Request.Outpoint,
+		)
+		require.True(
+			t, intent.Address.KeyDesc.PubKey.IsEqual(
+				boardingIntent.Request.ClientKey,
+			),
+		)
+		require.True(
+			t, intent.Address.OperatorKey.IsEqual(
+				boardingIntent.Request.OperatorKey,
+			),
+		)
+		require.Equal(
+			t, intent.Address.ExitDelay,
+			boardingIntent.Request.ExitDelay,
+		)
+	})
+
+	t.Run("boarding_rejects_nil_tx", func(t *testing.T) {
+		t.Parallel()
+
+		h := newActorTestHarness(t)
+		h.setupMockRoundStoreForStart()
+
+		err := h.start()
+		require.NoError(t, err)
+
+		intent := h.newTestBoardingIntent()
+		intent.ChainInfo.ConfTx = nil
+
+		// Nil tx should be caught by actor validation, not
+		// forwarded to the FSM.
+		h.walletActor.sendBoardingConfirmation(h.ctx, intent)
+
+		msg, ok := h.selfRef.waitForMessage(time.Second)
+		require.True(t, ok, "expected self-notification")
+
+		result := h.receive(msg)
+		require.True(t, result.IsErr())
+		require.Contains(
+			t, result.Err().Error(), "missing tx",
+		)
+	})
+
+	t.Run("boarding_rejects_invalid_outpoint_index", func(t *testing.T) {
+		t.Parallel()
+
+		h := newActorTestHarness(t)
+		h.setupMockRoundStoreForStart()
+
+		err := h.start()
+		require.NoError(t, err)
+
+		intent := h.newTestBoardingIntent()
+		intent.Outpoint.Index = 999
+
+		h.walletActor.sendBoardingConfirmation(h.ctx, intent)
+
+		msg, ok := h.selfRef.waitForMessage(time.Second)
+		require.True(t, ok, "expected self-notification")
+
+		result := h.receive(msg)
+		require.True(t, result.IsErr())
+		require.Contains(
+			t, result.Err().Error(), "invalid outpoint",
+		)
+	})
+
+	t.Run("boarding_deduplicates_same_outpoint", func(t *testing.T) {
+		t.Parallel()
+
+		h := newActorTestHarness(t)
+		h.setupMockRoundStoreForStart()
+
+		err := h.start()
+		require.NoError(t, err)
+
+		intent := h.newTestBoardingIntent()
+		h.sendWalletConfirmation(intent)
+		h.sendWalletConfirmation(intent)
+
+		// Second confirmation with same outpoint should be
+		// deduplicated by the FSM.
+		states := h.queryState()
+		tempState, exists := h.findTempState(states)
+		require.True(t, exists)
+
+		assembly, ok := tempState.State.(*PendingRoundAssembly)
+		require.True(t, ok)
+		require.Len(
+			t, assembly.Boarding, 1,
+			"duplicate outpoint should be deduplicated",
+		)
+	})
+
+	t.Run("refresh_maps_to_forfeit_and_vtxo", func(t *testing.T) {
+		t.Parallel()
+
+		h := newActorTestHarness(t)
+		h.setupMockRoundStoreForStart()
+
+		err := h.start()
+		require.NoError(t, err)
+
+		vtxoOutpoint := wire.OutPoint{
+			Hash:  chainhash.HashH([]byte("refresh-vtxo")),
+			Index: 0,
+		}
+		refreshReq := &RefreshVTXORequest{
+			VTXOOutpoint: vtxoOutpoint,
+			Amount:       75000,
+			NewVTXOKey:   h.clientPubKey,
+			PkScript:     []byte{0x51, 0x20},
+			OperatorKey:  h.operatorPubKey,
+			Expiry:       144,
+		}
+
+		result := h.receive(refreshReq)
+		require.True(t, result.IsOk())
+
+		states := h.queryState()
+		tempState, exists := h.findTempState(states)
+		require.True(t, exists)
+
+		assembly, ok := tempState.State.(*PendingRoundAssembly)
+		require.True(t, ok)
+
+		// Verify the forfeit input was mapped correctly.
+		require.Len(t, assembly.Forfeits, 1)
+		require.NotNil(t, assembly.Forfeits[0].VTXOOutpoint)
+		require.Equal(
+			t, vtxoOutpoint,
+			*assembly.Forfeits[0].VTXOOutpoint,
+		)
+
+		// Verify the VTXO output preserves all request fields.
+		require.Len(t, assembly.VTXOs, 1)
+		vtxoReq := assembly.VTXOs[0]
+		require.Equal(
+			t, btcutil.Amount(75000), vtxoReq.Amount,
+		)
+		require.Equal(
+			t, []byte{0x51, 0x20}, vtxoReq.PkScript,
+		)
+		require.Equal(t, uint32(144), vtxoReq.Expiry)
+		require.True(
+			t, h.clientPubKey.IsEqual(vtxoReq.ClientKey),
+		)
+		require.True(
+			t, h.operatorPubKey.IsEqual(vtxoReq.OperatorKey),
+		)
+	})
+
+	t.Run("leave_maps_to_forfeit_and_leave_output", func(t *testing.T) {
+		t.Parallel()
+
+		h := newActorTestHarness(t)
+		h.setupMockRoundStoreForStart()
+
+		err := h.start()
+		require.NoError(t, err)
+
+		vtxoOutpoint := wire.OutPoint{
+			Hash:  chainhash.HashH([]byte("leave-vtxo")),
+			Index: 0,
+		}
+		leaveOutput := &wire.TxOut{
+			Value:    60000,
+			PkScript: []byte{0x00, 0x14, 0x01, 0x02},
+		}
+		leaveReq := &LeaveVTXORequest{
+			VTXOOutpoint: vtxoOutpoint,
+			Amount:       60000,
+			Output:       leaveOutput,
+		}
+
+		result := h.receive(leaveReq)
+		require.True(t, result.IsOk())
+
+		states := h.queryState()
+		tempState, exists := h.findTempState(states)
+		require.True(t, exists)
+
+		assembly, ok := tempState.State.(*PendingRoundAssembly)
+		require.True(t, ok)
+
+		// Verify the forfeit input was mapped correctly.
+		require.Len(t, assembly.Forfeits, 1)
+		require.NotNil(t, assembly.Forfeits[0].VTXOOutpoint)
+		require.Equal(
+			t, vtxoOutpoint,
+			*assembly.Forfeits[0].VTXOOutpoint,
+		)
+
+		// Verify the leave output was mapped correctly.
+		require.Len(t, assembly.Leaves, 1)
+		require.NotNil(t, assembly.Leaves[0].Output)
+		require.Equal(
+			t, leaveOutput.Value,
+			assembly.Leaves[0].Output.Value,
+		)
+		require.Equal(
+			t, leaveOutput.PkScript,
+			assembly.Leaves[0].Output.PkScript,
+		)
+
+		// VTXOs should be empty for a leave.
+		require.Empty(t, assembly.VTXOs)
+	})
+
+	t.Run("mixed_round_accumulates_all_pools", func(t *testing.T) {
+		t.Parallel()
+
+		h := newActorTestHarness(t)
+		h.setupMockRoundStoreForStart()
+
+		err := h.start()
+		require.NoError(t, err)
+
+		// 1. Boarding intent.
+		boardingIntent := h.newTestBoardingIntent()
+		h.sendWalletConfirmation(boardingIntent)
+
+		// 2. VTXO request.
+		h.sendVTXORequests(50000)
+
+		// 3. Refresh request.
+		refreshReq := &RefreshVTXORequest{
+			VTXOOutpoint: wire.OutPoint{
+				Hash:  chainhash.HashH([]byte("ref")),
+				Index: 0,
+			},
+			Amount:      30000,
+			NewVTXOKey:  h.clientPubKey,
+			PkScript:    []byte{0x51, 0x20},
+			OperatorKey: h.operatorPubKey,
+			Expiry:      144,
+		}
+		result := h.receive(refreshReq)
+		require.True(t, result.IsOk())
+
+		// 4. Leave request.
+		leaveReq := &LeaveVTXORequest{
+			VTXOOutpoint: wire.OutPoint{
+				Hash:  chainhash.HashH([]byte("leave")),
+				Index: 0,
+			},
+			Amount: 20000,
+			Output: &wire.TxOut{
+				Value:    20000,
+				PkScript: []byte{0x00, 0x14},
+			},
+		}
+		result = h.receive(leaveReq)
+		require.True(t, result.IsOk())
+
+		// Verify all four pools are populated.
+		states := h.queryState()
+		tempState, exists := h.findTempState(states)
+		require.True(t, exists)
+
+		assembly, ok := tempState.State.(*PendingRoundAssembly)
+		require.True(t, ok)
+
+		require.Len(t, assembly.Boarding, 1)
+		require.Len(t, assembly.VTXOs, 2,
+			"1 explicit VTXO + 1 from refresh")
+		require.Len(t, assembly.Forfeits, 2,
+			"1 from refresh + 1 from leave")
+		require.Len(t, assembly.Leaves, 1)
+	})
+
+	t.Run("duplicate_forfeit_outpoint_deduplicated", func(t *testing.T) {
+		t.Parallel()
+
+		h := newActorTestHarness(t)
+		h.setupMockRoundStoreForStart()
+
+		err := h.start()
+		require.NoError(t, err)
+
+		// Send two refresh requests for the same VTXO.
+		vtxoOutpoint := wire.OutPoint{
+			Hash:  chainhash.HashH([]byte("dup-forfeit")),
+			Index: 0,
+		}
+
+		for i := 0; i < 2; i++ {
+			refreshReq := &RefreshVTXORequest{
+				VTXOOutpoint: vtxoOutpoint,
+				Amount:       50000,
+				NewVTXOKey:   h.clientPubKey,
+				PkScript:     []byte{0x51, 0x20},
+				OperatorKey:  h.operatorPubKey,
+				Expiry:       144,
+			}
+
+			result := h.receive(refreshReq)
+			require.True(t, result.IsOk())
+		}
+
+		states := h.queryState()
+		tempState, exists := h.findTempState(states)
+		require.True(t, exists)
+
+		assembly, ok := tempState.State.(*PendingRoundAssembly)
+		require.True(t, ok)
+
+		// The forfeit should be deduplicated by outpoint.
+		require.Len(
+			t, assembly.Forfeits, 1,
+			"duplicate forfeit outpoint should be deduplicated",
 		)
 	})
 }

--- a/round/actor_test.go
+++ b/round/actor_test.go
@@ -1127,11 +1127,8 @@ func TestHandleRefreshVTXORequest(t *testing.T) {
 		// Verify the forfeit input is tracked.
 		require.Len(t, assembly.Forfeits, 1)
 		require.Equal(
-			t, vtxoOutpoint, assembly.Forfeits[0].VTXOOutpoint,
-		)
-		require.Equal(
-			t, btcutil.Amount(refreshReq.Amount),
-			assembly.Forfeits[0].Amount,
+			t, vtxoOutpoint,
+			*assembly.Forfeits[0].VTXOOutpoint,
 		)
 
 		// Verify the VTXO output request is tracked.
@@ -1184,7 +1181,7 @@ func TestHandleRefreshVTXORequest(t *testing.T) {
 		require.Len(t, assembly.Forfeits, 1)
 		require.Equal(
 			t, vtxoOutpoint,
-			assembly.Forfeits[0].VTXOOutpoint,
+			*assembly.Forfeits[0].VTXOOutpoint,
 		)
 	})
 }

--- a/round/actor_test.go
+++ b/round/actor_test.go
@@ -1124,11 +1124,18 @@ func TestHandleRefreshVTXORequest(t *testing.T) {
 		require.True(t, ok, "expected PendingRoundAssembly, got %T",
 			tempState.State)
 
-		// Verify the refresh request is tracked.
-		require.Contains(t, assembly.RefreshingVTXOs, vtxoOutpoint)
+		// Verify the forfeit input is tracked.
+		require.Len(t, assembly.Forfeits, 1)
 		require.Equal(
-			t, refreshReq, assembly.RefreshingVTXOs[vtxoOutpoint],
+			t, vtxoOutpoint, assembly.Forfeits[0].VTXOOutpoint,
 		)
+		require.Equal(
+			t, btcutil.Amount(refreshReq.Amount),
+			assembly.Forfeits[0].Amount,
+		)
+
+		// Verify the VTXO output request is tracked.
+		require.Len(t, assembly.VTXOs, 1)
 	})
 
 	t.Run("queues_refresh_alongside_boarding_intent", func(t *testing.T) {
@@ -1174,7 +1181,11 @@ func TestHandleRefreshVTXORequest(t *testing.T) {
 		require.True(t, ok, "expected PendingRoundAssembly, got %T",
 			tempState.State)
 		require.Len(t, assembly.Boarding, 1)
-		require.Contains(t, assembly.RefreshingVTXOs, vtxoOutpoint)
+		require.Len(t, assembly.Forfeits, 1)
+		require.Equal(
+			t, vtxoOutpoint,
+			assembly.Forfeits[0].VTXOOutpoint,
+		)
 	})
 }
 

--- a/round/events.go
+++ b/round/events.go
@@ -50,10 +50,10 @@ type ResumeBoardingIntents struct {
 	VTXOs []types.VTXORequest
 
 	// Forfeits contains forfeited VTXOs to resume as inputs.
-	Forfeits []ForfeitIntent
+	Forfeits []types.ForfeitRequest
 
 	// Leaves contains leave requests to resume as outputs.
-	Leaves []*LeaveRequest
+	Leaves []*types.LeaveRequest
 }
 
 // isEmpty returns true if there are no intents of any kind to resume.
@@ -356,14 +356,16 @@ func (e *RoundComplete) clientEventSealed() {}
 //   - Consolidate N-to-1: {Forfeits: [N], VTXOs: [1]}
 //   - Split 1-to-N: {Forfeits: [1], VTXOs: [N]}
 type IntentPackage struct {
-	// Forfeits contains VTXOs being forfeited as round inputs.
-	Forfeits []ForfeitIntent
+	// Forfeits contains VTXOs being forfeited as round inputs. Each
+	// entry carries only the outpoint; the VTXO amount is looked up
+	// from VTXOStore at registration time.
+	Forfeits []types.ForfeitRequest
 
 	// VTXOs contains new VTXO output requests.
 	VTXOs []types.VTXORequest
 
 	// Leaves contains on-chain exit output requests.
-	Leaves []*LeaveRequest
+	Leaves []*types.LeaveRequest
 }
 
 // isEmpty returns true if the package contains no intents.

--- a/round/events.go
+++ b/round/events.go
@@ -49,12 +49,18 @@ type ResumeBoardingIntents struct {
 	// VTXOs contains the collected VTXO requests to include in the next
 	// round.
 	VTXOs []types.VTXORequest
+
+	// Forfeits contains forfeited VTXOs to resume as inputs.
+	Forfeits []ForfeitIntent
+
+	// Leaves contains leave requests to resume as outputs.
+	Leaves []*LeaveRequest
 }
 
-// isEmpty returns true if there are no boarding intents or VTXO requests
-// to resume.
+// isEmpty returns true if there are no intents of any kind to resume.
 func (e *ResumeBoardingIntents) isEmpty() bool {
-	return len(e.Boarding) == 0 && len(e.VTXOs) == 0
+	return len(e.Boarding) == 0 && len(e.VTXOs) == 0 &&
+		len(e.Forfeits) == 0 && len(e.Leaves) == 0
 }
 
 // logAttributes returns a map of attributes for logging purposes.
@@ -62,6 +68,8 @@ func (e *ResumeBoardingIntents) logAttributes() []slog.Attr {
 	return []slog.Attr{
 		slog.Int("boarding_intents", len(e.Boarding)),
 		slog.Int("vtxo_requests", len(e.VTXOs)),
+		slog.Int("forfeits", len(e.Forfeits)),
+		slog.Int("leaves", len(e.Leaves)),
 	}
 }
 
@@ -338,6 +346,36 @@ type RoundComplete struct{}
 
 func (e *RoundComplete) clientEventSealed() {}
 
+// IntentPackage is an atomic bundle of related intents submitted to the FSM
+// as a single event. The FSM unpacks the package and appends each item to its
+// respective pool. All items in a package are accepted together — the upstream
+// caller decides what must travel as a unit.
+//
+// Examples:
+//   - Refresh: {Forfeits: [1], VTXOs: [1]}
+//   - Leave:   {Forfeits: [1], Leaves: [1]}
+//   - Consolidate N-to-1: {Forfeits: [N], VTXOs: [1]}
+//   - Split 1-to-N: {Forfeits: [1], VTXOs: [N]}
+type IntentPackage struct {
+	// Forfeits contains VTXOs being forfeited as round inputs.
+	Forfeits []ForfeitIntent
+
+	// VTXOs contains new VTXO output requests.
+	VTXOs []types.VTXORequest
+
+	// Leaves contains on-chain exit output requests.
+	Leaves []*LeaveRequest
+}
+
+// isEmpty returns true if the package contains no intents.
+func (e *IntentPackage) isEmpty() bool {
+	return len(e.Forfeits) == 0 && len(e.VTXOs) == 0 &&
+		len(e.Leaves) == 0
+}
+
+// clientEventSealed prevents external implementations.
+func (e *IntentPackage) clientEventSealed() {}
+
 // RefreshVTXORequest is sent from a VTXO actor when its VTXO is approaching
 // expiry and needs to be refreshed in a new round. The round actor should
 // queue this VTXO for inclusion in the next batch swap.
@@ -345,6 +383,9 @@ func (e *RoundComplete) clientEventSealed() {}
 // This request contains all information needed to build a forfeit request
 // (for the connector tree) and a VTXORequest (for the new VTXO in the VTXT).
 // The same client key is typically reused for the new VTXO.
+//
+// NOTE: This type is an actor message (RoundReceivable), not an FSM event.
+// The actor translates it into an IntentPackage{Forfeits: [1], VTXOs: [1]}.
 type RefreshVTXORequest struct {
 	actor.BaseMessage
 
@@ -371,8 +412,6 @@ type RefreshVTXORequest struct {
 	SigningKey keychain.KeyDescriptor
 }
 
-func (e *RefreshVTXORequest) clientEventSealed() {}
-
 // RoundReceivable implements actormsg.RoundReceivable marker interface.
 func (e *RefreshVTXORequest) RoundReceivable() {}
 
@@ -389,6 +428,9 @@ func (e *RefreshVTXORequest) MessageType() string {
 // The leave flow uses the same forfeit mechanism as refresh: the old VTXO is
 // forfeited via a connector output, and the leave output is included directly
 // in the batch transaction.
+//
+// NOTE: This type is an actor message (RoundReceivable), not an FSM event.
+// The actor translates it into an IntentPackage{Forfeits: [1], Leaves: [1]}.
 type LeaveVTXORequest struct {
 	actor.BaseMessage
 
@@ -403,9 +445,6 @@ type LeaveVTXORequest struct {
 	// leave output.
 	Output *wire.TxOut
 }
-
-// clientEventSealed prevents external implementations.
-func (e *LeaveVTXORequest) clientEventSealed() {}
 
 // RoundReceivable implements actormsg.RoundReceivable marker interface.
 func (e *LeaveVTXORequest) RoundReceivable() {}

--- a/round/events.go
+++ b/round/events.go
@@ -15,7 +15,6 @@ import (
 	"github.com/lightninglabs/darepo-client/wallet"
 	"github.com/lightninglabs/taproot-assets/proof"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
-	"github.com/lightningnetwork/lnd/keychain"
 )
 
 // ClientEvent is a sealed interface for all events that can be processed by
@@ -375,84 +374,6 @@ func (e *IntentPackage) isEmpty() bool {
 
 // clientEventSealed prevents external implementations.
 func (e *IntentPackage) clientEventSealed() {}
-
-// RefreshVTXORequest is sent from a VTXO actor when its VTXO is approaching
-// expiry and needs to be refreshed in a new round. The round actor should
-// queue this VTXO for inclusion in the next batch swap.
-//
-// This request contains all information needed to build a forfeit request
-// (for the connector tree) and a VTXORequest (for the new VTXO in the VTXT).
-// The same client key is typically reused for the new VTXO.
-//
-// NOTE: This type is an actor message (RoundReceivable), not an FSM event.
-// The actor translates it into an IntentPackage{Forfeits: [1], VTXOs: [1]}.
-type RefreshVTXORequest struct {
-	actor.BaseMessage
-
-	// VTXOOutpoint identifies the VTXO to refresh.
-	VTXOOutpoint wire.OutPoint
-
-	// Amount is the VTXO value in satoshis.
-	Amount int64
-
-	// NewVTXOKey is the client's public key for the new VTXO. This is
-	// typically the same as the old VTXO's key but could be fresh.
-	NewVTXOKey *btcec.PublicKey
-
-	// PkScript is the output script for the new VTXO.
-	PkScript []byte
-
-	// OperatorKey is the operator's public key for the new VTXO.
-	OperatorKey *btcec.PublicKey
-
-	// Expiry is the CSV delay for the new VTXO's unilateral exit path.
-	Expiry uint32
-
-	// SigningKey is the key descriptor for signing the new VTXO's tree.
-	SigningKey keychain.KeyDescriptor
-}
-
-// RoundReceivable implements actormsg.RoundReceivable marker interface.
-func (e *RefreshVTXORequest) RoundReceivable() {}
-
-// MessageType returns the message type for logging.
-func (e *RefreshVTXORequest) MessageType() string {
-	return "RefreshVTXORequest"
-}
-
-// LeaveVTXORequest is sent from a VTXO actor (or wallet) when the user wants
-// to exit the Ark by forfeiting a VTXO and receiving an on-chain output. This
-// is similar to RefreshVTXORequest except the output is on-chain rather than a
-// new VTXO.
-//
-// The leave flow uses the same forfeit mechanism as refresh: the old VTXO is
-// forfeited via a connector output, and the leave output is included directly
-// in the batch transaction.
-//
-// NOTE: This type is an actor message (RoundReceivable), not an FSM event.
-// The actor translates it into an IntentPackage{Forfeits: [1], Leaves: [1]}.
-type LeaveVTXORequest struct {
-	actor.BaseMessage
-
-	// VTXOOutpoint identifies the VTXO to forfeit.
-	VTXOOutpoint wire.OutPoint
-
-	// Amount is the VTXO value in satoshis.
-	Amount int64
-
-	// Output is the on-chain destination output that will be included in
-	// the batch transaction. This contains the value and pkScript for the
-	// leave output.
-	Output *wire.TxOut
-}
-
-// RoundReceivable implements actormsg.RoundReceivable marker interface.
-func (e *LeaveVTXORequest) RoundReceivable() {}
-
-// MessageType returns the message type for logging.
-func (e *LeaveVTXORequest) MessageType() string {
-	return "LeaveVTXORequest"
-}
 
 // ForfeitSignatureResponse is sent from a VTXO actor with its signature for
 // the forfeit transaction. This is the response to a forfeit request during

--- a/round/events.go
+++ b/round/events.go
@@ -12,9 +12,6 @@ import (
 	"github.com/lightninglabs/darepo-client/baselib/actor"
 	"github.com/lightninglabs/darepo-client/lib/tree"
 	"github.com/lightninglabs/darepo-client/lib/types"
-	"github.com/lightninglabs/darepo-client/wallet"
-	"github.com/lightninglabs/taproot-assets/proof"
-	fn "github.com/lightningnetwork/lnd/fn/v2"
 )
 
 // ClientEvent is a sealed interface for all events that can be processed by
@@ -37,79 +34,12 @@ type ClientOutMsg interface {
 	clientOutMsgSealed()
 }
 
-// ResumeBoardingIntents is emitted to instruct the FSM to resume attempting to
-// join a round with previously submitted and confirmed-but-not-adopted
-// intents.
-type ResumeBoardingIntents struct {
-	// Boarding contains the collected boarding intents to include in the
-	// next round.
-	Boarding []BoardingIntent
-
-	// VTXOs contains the collected VTXO requests to include in the next
-	// round.
-	VTXOs []types.VTXORequest
-
-	// Forfeits contains forfeited VTXOs to resume as inputs.
-	Forfeits []types.ForfeitRequest
-
-	// Leaves contains leave requests to resume as outputs.
-	Leaves []*types.LeaveRequest
-}
-
-// isEmpty returns true if there are no intents of any kind to resume.
-func (e *ResumeBoardingIntents) isEmpty() bool {
-	return len(e.Boarding) == 0 && len(e.VTXOs) == 0 &&
-		len(e.Forfeits) == 0 && len(e.Leaves) == 0
-}
-
-// logAttributes returns a map of attributes for logging purposes.
-func (e *ResumeBoardingIntents) logAttributes() []slog.Attr {
-	return []slog.Attr{
-		slog.Int("boarding_intents", len(e.Boarding)),
-		slog.Int("vtxo_requests", len(e.VTXOs)),
-		slog.Int("forfeits", len(e.Forfeits)),
-		slog.Int("leaves", len(e.Leaves)),
-	}
-}
-
-func (e *ResumeBoardingIntents) clientEventSealed() {}
-
-// BoardingUTXOConfirmed is emitted when the boarding UTXO has received
-// sufficient confirmations and is ready to be used for boarding.
-type BoardingUTXOConfirmed struct {
-	// Outpoint identifies the confirmed boarding UTXO.
-	Outpoint wire.OutPoint
-
-	// Address is the boarding address for this UTXO. Contains the keys,
-	// tapscript, and exit delay needed to build the Request.
-	Address wallet.BoardingAddress
-
-	// BlockHeight is the height at which the UTXO was confirmed.
-	BlockHeight int32
-
-	// BlockHash is the hash of the block containing the transaction.
-	BlockHash chainhash.Hash
-
-	// Confirmations is the number of confirmations the UTXO has.
-	Confirmations int32
-
-	// Tx is the confirmed transaction containing the boarding UTXO. This
-	// allows the FSM to extract output details without additional chain
-	// queries.
-	Tx *wire.MsgTx
-
-	// TxProof is the optional SPV proof for this boarding UTXO. Includes
-	// merkle proof, block header, and output construction details. None if
-	// the proof hasn't been constructed yet.
-	TxProof fn.Option[proof.TxProof]
-}
-
-func (e *BoardingUTXOConfirmed) clientEventSealed() {}
-
-// VTXORequestsReceived is emitted when the client submits VTXO requests that
-// should be included in the next round registration. This event can be sent
-// from both internal sources (e.g., wallet) and external actors (e.g., VTXO
-// actor requesting a new VTXO during refresh).
+// VTXORequestsReceived is an actor message carrying pre-built VTXO requests
+// from other actors (e.g., VTXO actor during refresh). The round actor
+// translates it into an IntentPackage before sending to the FSM.
+//
+// NOTE: This is NOT an FSM event — it does not implement clientEventSealed().
+// The actor converts it to IntentPackage{VTXOs: req.Requests}.
 type VTXORequestsReceived struct {
 	actor.BaseMessage
 
@@ -117,9 +47,6 @@ type VTXORequestsReceived struct {
 	// request.
 	Requests []types.VTXORequest
 }
-
-// clientEventSealed prevents external implementations.
-func (e *VTXORequestsReceived) clientEventSealed() {}
 
 // RoundReceivable implements actormsg.RoundReceivable marker interface.
 func (e *VTXORequestsReceived) RoundReceivable() {}
@@ -208,7 +135,8 @@ type ConnectorLeafInfo struct {
 
 	// VTXOAmount is the value of the VTXO being forfeited. The forfeit tx's
 	// penalty output must equal this amount. This field enables validation
-	// that prevents value theft by ensuring the correct amount is forfeited.
+	// that prevents value theft by ensuring the correct amount is
+	// forfeited.
 	VTXOAmount btcutil.Amount
 }
 
@@ -345,33 +273,40 @@ type RoundComplete struct{}
 
 func (e *RoundComplete) clientEventSealed() {}
 
-// IntentPackage is an atomic bundle of related intents submitted to the FSM
-// as a single event. The FSM unpacks the package and appends each item to its
-// respective pool. All items in a package are accepted together — the upstream
-// caller decides what must travel as a unit.
+// IntentPackage is the single FSM event for all pool additions. The actor
+// layer converts raw inputs (boarding confirmations, VTXO requests, refresh
+// requests, leave requests) into processed intents and sends them to the FSM
+// via this unified event. The FSM unpacks the package and appends each item
+// to its respective pool.
+//
+// IntentPackage embeds Intents so that the pool fields (Boarding, VTXOs,
+// Forfeits, Leaves) are defined once and shared between event transport
+// and state storage.
 //
 // Examples:
-//   - Refresh: {Forfeits: [1], VTXOs: [1]}
-//   - Leave:   {Forfeits: [1], Leaves: [1]}
+//   - Boarding:  {Boarding: [1], VTXOs: [1]}
+//   - Refresh:   {Forfeits: [1], VTXOs: [1]}
+//   - Leave:     {Forfeits: [1], Leaves: [1]}
 //   - Consolidate N-to-1: {Forfeits: [N], VTXOs: [1]}
-//   - Split 1-to-N: {Forfeits: [1], VTXOs: [N]}
+//   - Resume:    {Boarding: [N], VTXOs: [M], Forfeits: [K], Leaves: [L]}
 type IntentPackage struct {
-	// Forfeits contains VTXOs being forfeited as round inputs. Each
-	// entry carries only the outpoint; the VTXO amount is looked up
-	// from VTXOStore at registration time.
-	Forfeits []types.ForfeitRequest
-
-	// VTXOs contains new VTXO output requests.
-	VTXOs []types.VTXORequest
-
-	// Leaves contains on-chain exit output requests.
-	Leaves []*types.LeaveRequest
+	Intents
 }
 
 // isEmpty returns true if the package contains no intents.
 func (e *IntentPackage) isEmpty() bool {
-	return len(e.Forfeits) == 0 && len(e.VTXOs) == 0 &&
-		len(e.Leaves) == 0
+	return len(e.Boarding) == 0 && len(e.Forfeits) == 0 &&
+		len(e.VTXOs) == 0 && len(e.Leaves) == 0
+}
+
+// logAttributes returns structured logging attributes for the package.
+func (e *IntentPackage) logAttributes() []slog.Attr {
+	return []slog.Attr{
+		slog.Int("boarding_intents", len(e.Boarding)),
+		slog.Int("vtxo_requests", len(e.VTXOs)),
+		slog.Int("forfeits", len(e.Forfeits)),
+		slog.Int("leaves", len(e.Leaves)),
+	}
 }
 
 // clientEventSealed prevents external implementations.

--- a/round/harness_test.go
+++ b/round/harness_test.go
@@ -607,35 +607,6 @@ func generateTestKeyPair(t *testing.T) (*btcec.PrivateKey, *btcec.PublicKey) {
 	return privKey, privKey.PubKey()
 }
 
-func (h *boardingTestHarness) newBoardingUTXOConfirmedEvent(
-	intent BoardingIntent) *BoardingUTXOConfirmed {
-
-	h.t.Helper()
-
-	// Create a pkScript from the boarding address.
-	pkScript, err := txscript.PayToAddrScript(intent.Address.Address)
-	require.NoError(h.t, err)
-
-	tx := wire.NewMsgTx(2)
-	tx.AddTxOut(&wire.TxOut{
-		Value:    int64(intent.ChainInfo.Amount),
-		PkScript: pkScript,
-	})
-
-	var blockHash chainhash.Hash
-	_, err = rand.Read(blockHash[:])
-	require.NoError(h.t, err)
-
-	return &BoardingUTXOConfirmed{
-		Outpoint:      intent.Outpoint,
-		Address:       intent.Address,
-		BlockHeight:   intent.ChainInfo.ConfHeight,
-		BlockHash:     blockHash,
-		Confirmations: 6,
-		Tx:            tx,
-	}
-}
-
 const (
 	testExitDelay = uint32(144) // 1 day in blocks.
 )

--- a/round/interfaces.go
+++ b/round/interfaces.go
@@ -213,6 +213,18 @@ const (
 	BoardingStatusSwept = wallet.BoardingStatusSwept
 )
 
+// ForfeitIntent captures one VTXO being forfeited as an input to a round.
+// This is decoupled from the output side (VTXO or leave) so the FSM can
+// track forfeit inputs independently, enabling many-to-many operations
+// like consolidation or splitting.
+type ForfeitIntent struct {
+	// VTXOOutpoint identifies the VTXO being forfeited.
+	VTXOOutpoint wire.OutPoint
+
+	// Amount is the value of the forfeited VTXO in satoshis.
+	Amount btcutil.Amount
+}
+
 // Intents captures all the client's intents to be included in a single round
 // join request.
 type Intents struct {
@@ -228,6 +240,11 @@ type Intents struct {
 	// outputs. Each leave forfeits a VTXO and creates an on-chain output
 	// in the batch transaction instead of a new VTXO.
 	Leaves []*LeaveRequest
+
+	// Forfeits contains the VTXOs being forfeited as inputs. Decoupled
+	// from outputs (VTXOs/Leaves) to allow many-to-many operations like
+	// consolidation, splitting, or mixing forfeits with boarding inputs.
+	Forfeits []ForfeitIntent
 }
 
 // Clone creates a copy of the Intents.
@@ -236,6 +253,7 @@ func (i *Intents) Clone() Intents {
 		Boarding: slices.Clone(i.Boarding),
 		VTXOs:    slices.Clone(i.VTXOs),
 		Leaves:   slices.Clone(i.Leaves),
+		Forfeits: slices.Clone(i.Forfeits),
 	}
 }
 

--- a/round/interfaces.go
+++ b/round/interfaces.go
@@ -213,18 +213,6 @@ const (
 	BoardingStatusSwept = wallet.BoardingStatusSwept
 )
 
-// ForfeitIntent captures one VTXO being forfeited as an input to a round.
-// This is decoupled from the output side (VTXO or leave) so the FSM can
-// track forfeit inputs independently, enabling many-to-many operations
-// like consolidation or splitting.
-type ForfeitIntent struct {
-	// VTXOOutpoint identifies the VTXO being forfeited.
-	VTXOOutpoint wire.OutPoint
-
-	// Amount is the value of the forfeited VTXO in satoshis.
-	Amount btcutil.Amount
-}
-
 // Intents captures all the client's intents to be included in a single round
 // join request.
 type Intents struct {
@@ -239,12 +227,12 @@ type Intents struct {
 	// Leaves contains the leave requests for VTXOs being exited to on-chain
 	// outputs. Each leave forfeits a VTXO and creates an on-chain output
 	// in the batch transaction instead of a new VTXO.
-	Leaves []*LeaveRequest
+	Leaves []*types.LeaveRequest
 
-	// Forfeits contains the VTXOs being forfeited as inputs. Decoupled
-	// from outputs (VTXOs/Leaves) to allow many-to-many operations like
-	// consolidation, splitting, or mixing forfeits with boarding inputs.
-	Forfeits []ForfeitIntent
+	// Forfeits contains the VTXOs being forfeited as inputs. Each entry
+	// carries only the outpoint; the VTXO amount is looked up from
+	// VTXOStore at registration time.
+	Forfeits []types.ForfeitRequest
 }
 
 // Clone creates a copy of the Intents.

--- a/round/join_auth.go
+++ b/round/join_auth.go
@@ -87,23 +87,15 @@ func deriveJoinAuthIdentifierKey(ctx context.Context,
 	return *keyDesc, nil
 }
 
-// sortedForfeitRequests returns deterministic forfeit requests for all
-// refreshing and leaving VTXOs. Outpoints are sorted by txid bytes then
-// output index so the resulting list is stable across map iterations.
-func sortedForfeitRequests(refreshing map[wire.OutPoint]*RefreshVTXORequest,
-	leaving map[wire.OutPoint]*LeaveVTXORequest) []*ForfeitRequest {
+// sortedForfeitRequests converts a slice of ForfeitIntent into sorted
+// ForfeitRequest values. Outpoints are sorted by txid bytes then output
+// index so the resulting list is deterministic.
+func sortedForfeitRequests(
+	forfeits []ForfeitIntent) []*ForfeitRequest {
 
-	uniqueOutpoints := make(map[wire.OutPoint]struct{})
-	for outpoint := range refreshing {
-		uniqueOutpoints[outpoint] = struct{}{}
-	}
-	for outpoint := range leaving {
-		uniqueOutpoints[outpoint] = struct{}{}
-	}
-
-	outpoints := make([]wire.OutPoint, 0, len(uniqueOutpoints))
-	for outpoint := range uniqueOutpoints {
-		outpoints = append(outpoints, outpoint)
+	outpoints := make([]wire.OutPoint, 0, len(forfeits))
+	for i := 0; i < len(forfeits); i++ {
+		outpoints = append(outpoints, forfeits[i].VTXOOutpoint)
 	}
 	sortOutPoints(outpoints)
 
@@ -111,29 +103,6 @@ func sortedForfeitRequests(refreshing map[wire.OutPoint]*RefreshVTXORequest,
 	for i := 0; i < len(outpoints); i++ {
 		requests = append(requests, &ForfeitRequest{
 			VTXOOutpoint: outpoints[i],
-		})
-	}
-
-	return requests
-}
-
-// sortedLeaveRequests returns deterministic leave requests for leaving
-// VTXOs. The iteration order is stabilised by sorting outpoints before
-// building the request slice.
-func sortedLeaveRequests(
-	leaving map[wire.OutPoint]*LeaveVTXORequest) []*LeaveRequest {
-
-	outpoints := make([]wire.OutPoint, 0, len(leaving))
-	for outpoint := range leaving {
-		outpoints = append(outpoints, outpoint)
-	}
-	sortOutPoints(outpoints)
-
-	requests := make([]*LeaveRequest, 0, len(outpoints))
-	for i := 0; i < len(outpoints); i++ {
-		request := leaving[outpoints[i]]
-		requests = append(requests, &LeaveRequest{
-			Output: request.Output,
 		})
 	}
 
@@ -156,18 +125,13 @@ func sortOutPoints(outpoints []wire.OutPoint) {
 }
 
 // computeTotalForfeitAmount computes the total value of VTXOs being
-// forfeited via refresh and leave requests. Both contribute input
-// value to the batch transaction.
+// forfeited. These contribute input value to the batch transaction.
 func computeTotalForfeitAmount(
-	refreshing map[wire.OutPoint]*RefreshVTXORequest,
-	leaving map[wire.OutPoint]*LeaveVTXORequest) btcutil.Amount {
+	forfeits []ForfeitIntent) btcutil.Amount {
 
 	var total btcutil.Amount
-	for _, request := range refreshing {
-		total += btcutil.Amount(request.Amount)
-	}
-	for _, request := range leaving {
-		total += btcutil.Amount(request.Amount)
+	for i := 0; i < len(forfeits); i++ {
+		total += forfeits[i].Amount
 	}
 
 	return total

--- a/round/join_auth.go
+++ b/round/join_auth.go
@@ -87,26 +87,39 @@ func deriveJoinAuthIdentifierKey(ctx context.Context,
 	return *keyDesc, nil
 }
 
-// sortedForfeitRequests converts a slice of ForfeitIntent into sorted
-// ForfeitRequest values. Outpoints are sorted by txid bytes then output
-// index so the resulting list is deterministic.
+// sortedForfeitRequests sorts forfeit requests by outpoint (txid bytes
+// then output index) so the resulting list is deterministic. Returns an
+// error if any request has a nil VTXOOutpoint.
 func sortedForfeitRequests(
-	forfeits []ForfeitIntent) []*ForfeitRequest {
+	forfeits []types.ForfeitRequest) ([]*types.ForfeitRequest, error) {
 
+	// Collect and sort the outpoints, validating that none are nil.
 	outpoints := make([]wire.OutPoint, 0, len(forfeits))
 	for i := 0; i < len(forfeits); i++ {
-		outpoints = append(outpoints, forfeits[i].VTXOOutpoint)
+		if forfeits[i].VTXOOutpoint == nil {
+			return nil, fmt.Errorf("forfeit request %d "+
+				"has nil outpoint", i)
+		}
+		outpoints = append(
+			outpoints, *forfeits[i].VTXOOutpoint,
+		)
 	}
 	sortOutPoints(outpoints)
 
-	requests := make([]*ForfeitRequest, 0, len(outpoints))
+	// Build the sorted result with pointer-to-outpoint fields.
+	requests := make(
+		[]*types.ForfeitRequest, 0, len(outpoints),
+	)
 	for i := 0; i < len(outpoints); i++ {
-		requests = append(requests, &ForfeitRequest{
-			VTXOOutpoint: outpoints[i],
-		})
+		op := outpoints[i]
+		requests = append(
+			requests, &types.ForfeitRequest{
+				VTXOOutpoint: &op,
+			},
+		)
 	}
 
-	return requests
+	return requests, nil
 }
 
 // sortOutPoints orders outpoints by txid bytes then output index.
@@ -124,17 +137,29 @@ func sortOutPoints(outpoints []wire.OutPoint) {
 	})
 }
 
-// computeTotalForfeitAmount computes the total value of VTXOs being
-// forfeited. These contribute input value to the batch transaction.
-func computeTotalForfeitAmount(
-	forfeits []ForfeitIntent) btcutil.Amount {
+// computeTotalForfeitAmount looks up each forfeited VTXO's value from
+// the VTXOStore and returns the sum. This replaces the old approach of
+// carrying the amount inside ForfeitIntent — the outpoint is sufficient
+// and the store is the source of truth.
+func computeTotalForfeitAmount(ctx context.Context,
+	store VTXOStore,
+	forfeits []types.ForfeitRequest) (btcutil.Amount, error) {
 
 	var total btcutil.Amount
 	for i := 0; i < len(forfeits); i++ {
-		total += forfeits[i].Amount
+		vtxo, err := store.GetVTXO(
+			ctx, *forfeits[i].VTXOOutpoint,
+		)
+		if err != nil {
+			return 0, fmt.Errorf(
+				"forfeit amount lookup %s: %w",
+				forfeits[i].VTXOOutpoint, err,
+			)
+		}
+		total += vtxo.Amount
 	}
 
-	return total
+	return total, nil
 }
 
 // buildJoinRoundAuth creates the BIP-322 authorization payload for a
@@ -144,8 +169,8 @@ func computeTotalForfeitAmount(
 func buildJoinRoundAuth(ctx context.Context, env *ClientEnvironment,
 	identifierKeyDesc keychain.KeyDescriptor,
 	intents Intents, vtxoReqs []types.VTXORequest,
-	forfeitReqs []*ForfeitRequest,
-	leaveReqs []*LeaveRequest) (*types.JoinRoundAuth, error) {
+	forfeitReqs []*types.ForfeitRequest,
+	leaveReqs []*types.LeaveRequest) (*types.JoinRoundAuth, error) {
 
 	log := env.Log
 	log.InfoS(ctx, "Building join round auth",
@@ -287,11 +312,12 @@ func buildJoinRoundAuth(ctx context.Context, env *ClientEnvironment,
 // buildJoinRoundAuthRequest builds the shared request shape used for
 // canonical message encoding and returns the corresponding signing
 // inputs in the same order.
-func buildJoinRoundAuthRequest(ctx context.Context, env *ClientEnvironment,
-	intents Intents, vtxoReqs []types.VTXORequest,
-	forfeitReqs []*ForfeitRequest,
-	leaveReqs []*LeaveRequest) (*types.JoinRoundRequest, []joinAuthInput,
-	error) {
+func buildJoinRoundAuthRequest(ctx context.Context,
+	env *ClientEnvironment, intents Intents,
+	vtxoReqs []types.VTXORequest,
+	forfeitReqs []*types.ForfeitRequest,
+	leaveReqs []*types.LeaveRequest) (*types.JoinRoundRequest,
+	[]joinAuthInput, error) {
 
 	boardingReqs := make(
 		[]*types.BoardingRequest, 0, len(intents.Boarding),
@@ -331,18 +357,9 @@ func buildJoinRoundAuthRequest(ctx context.Context, env *ClientEnvironment,
 
 	// Each forfeit request contributes a signing input built from
 	// the persisted VTXO data.
-	sharedForfeitReqs := make(
-		[]*types.ForfeitRequest, 0, len(forfeitReqs),
-	)
 	for i := 0; i < len(forfeitReqs); i++ {
 		forfeitReq := forfeitReqs[i]
-		outpoint := forfeitReq.VTXOOutpoint
-
-		sharedForfeitReqs = append(
-			sharedForfeitReqs, &types.ForfeitRequest{
-				VTXOOutpoint: &outpoint,
-			},
-		)
+		outpoint := *forfeitReq.VTXOOutpoint
 
 		vtxo, err := env.VTXOStore.GetVTXO(ctx, outpoint)
 		if err != nil {
@@ -396,19 +413,7 @@ func buildJoinRoundAuthRequest(ctx context.Context, env *ClientEnvironment,
 		})
 	}
 
-	// Convert leave and VTXO requests to their shared types.
-	sharedLeaveReqs := make(
-		[]*types.LeaveRequest, 0, len(leaveReqs),
-	)
-	for i := 0; i < len(leaveReqs); i++ {
-		leaveReq := leaveReqs[i]
-		sharedLeaveReqs = append(
-			sharedLeaveReqs, &types.LeaveRequest{
-				Output: leaveReq.Output,
-			},
-		)
-	}
-
+	// Convert VTXO requests to pointer slice for the shared type.
 	sharedVTXOReqs := make(
 		[]*types.VTXORequest, 0, len(vtxoReqs),
 	)
@@ -421,8 +426,8 @@ func buildJoinRoundAuthRequest(ctx context.Context, env *ClientEnvironment,
 		Identifier:   nil,
 		BoardingReqs: boardingReqs,
 		VTXOReqs:     sharedVTXOReqs,
-		ForfeitReqs:  sharedForfeitReqs,
-		LeaveReqs:    sharedLeaveReqs,
+		ForfeitReqs:  forfeitReqs,
+		LeaveReqs:    leaveReqs,
 	}, signingInputs, nil
 }
 

--- a/round/join_auth_test.go
+++ b/round/join_auth_test.go
@@ -531,8 +531,8 @@ func TestBuildJoinRoundAuthWithForfeit(t *testing.T) {
 		VTXOs:    vtxoReqs,
 	}
 
-	forfeitReqs := []*ForfeitRequest{{
-		VTXOOutpoint: vtxoOutpoint,
+	forfeitReqs := []*types.ForfeitRequest{{
+		VTXOOutpoint: &vtxoOutpoint,
 	}}
 
 	auth, err := buildJoinRoundAuth(
@@ -617,8 +617,8 @@ func TestBuildJoinRoundAuthForfeitOnly(t *testing.T) {
 		VTXOs: vtxoReqs,
 	}
 
-	forfeitReqs := []*ForfeitRequest{{
-		VTXOOutpoint: vtxoOutpoint,
+	forfeitReqs := []*types.ForfeitRequest{{
+		VTXOOutpoint: &vtxoOutpoint,
 	}}
 
 	auth, err := buildJoinRoundAuth(

--- a/round/outbox_messages.go
+++ b/round/outbox_messages.go
@@ -31,13 +31,13 @@ type JoinRoundRequest struct {
 	VTXORequests []types.VTXORequest
 
 	// ForfeitRequests specifies the VTXOs the client wants to forfeit.
-	ForfeitRequests []*ForfeitRequest
+	ForfeitRequests []*types.ForfeitRequest
 
 	// LeaveRequests contains VTXOs being exited to on-chain outputs. Each
 	// leave request specifies only the on-chain destination output. The
 	// server includes these in the batch transaction; any forfeited VTXOs
 	// are listed separately in ForfeitRequests.
-	LeaveRequests []*LeaveRequest
+	LeaveRequests []*types.LeaveRequest
 
 	// RoundID is optional; when empty it instructs the server to assign
 	// a new round. When non-empty, the request is for the specified round.
@@ -46,21 +46,6 @@ type JoinRoundRequest struct {
 	// Auth contains the BIP-322 authorization payload for this
 	// request. Nil when join request auth is disabled (tests).
 	Auth *types.JoinRoundAuth
-}
-
-// ForfeitRequest describes a VTXO that will be forfeited in the round.
-type ForfeitRequest struct {
-	// VTXOOutpoint identifies the VTXO to forfeit.
-	VTXOOutpoint wire.OutPoint
-}
-
-// LeaveRequest describes a leave output to be included in the batch
-// transaction. This represents a client exiting the Ark by forfeiting an
-// existing VTXO and receiving an on-chain output instead of a new VTXO.
-type LeaveRequest struct {
-	// Output is the on-chain destination output. Contains the value and
-	// pkScript for the leave output that will be included in the batch tx.
-	Output *wire.TxOut
 }
 
 func (m *JoinRoundRequest) clientOutMsgSealed() {}

--- a/round/states.go
+++ b/round/states.go
@@ -48,9 +48,9 @@ func (s *Idle) clientStateSealed() {}
 // all intents reach the required confirmations, the FSM transitions to round
 // registration.
 //
-// This state also tracks VTXOs pending refresh or leave. When VTXOs are
-// approaching expiry, they send RefreshVTXORequest to be included in the next
-// round. When a user wants to exit the Ark, they send LeaveVTXORequest.
+// This state tracks four independent pools: boarding inputs, forfeit inputs,
+// VTXO outputs, and leave outputs. The pools are validated at registration
+// time by checking sum(inputs) >= sum(outputs) + fees.
 type PendingRoundAssembly struct {
 	// Boarding contains the collected boarding intents to include in the
 	// next round.
@@ -60,15 +60,13 @@ type PendingRoundAssembly struct {
 	// round.
 	VTXOs []types.VTXORequest
 
-	// RefreshingVTXOs tracks VTXOs waiting to be refreshed in this round.
-	// Keyed by VTXO outpoint. These are accumulated alongside boarding
-	// intents and included in the same round registration.
-	RefreshingVTXOs map[wire.OutPoint]*RefreshVTXORequest
+	// Forfeits tracks VTXOs being forfeited as inputs to this round.
+	// Decoupled from outputs to enable many-to-many operations.
+	Forfeits []ForfeitIntent
 
-	// LeavingVTXOs tracks VTXOs waiting to exit to on-chain outputs. Keyed
-	// by VTXO outpoint. These are accumulated alongside boarding intents
-	// and refresh requests, and included in the same round registration.
-	LeavingVTXOs map[wire.OutPoint]*LeaveVTXORequest
+	// Leaves tracks on-chain exit outputs for this round. Decoupled from
+	// forfeit inputs to enable many-to-many operations.
+	Leaves []*LeaveRequest
 }
 
 func (s *PendingRoundAssembly) String() string {

--- a/round/states.go
+++ b/round/states.go
@@ -457,8 +457,8 @@ func (s *ClientFailedState) String() string {
 }
 
 func (s *ClientFailedState) IsTerminal() bool {
-	// ClientFailedState is NOT terminal - it can recover by accepting the
-	// same events as Idle (BoardingUTXOConfirmed, ResumeBoardingIntents).
+	// ClientFailedState is NOT terminal - it can recover by accepting
+	// IntentPackage events, which transition through Idle.
 	return false
 }
 

--- a/round/states.go
+++ b/round/states.go
@@ -62,11 +62,11 @@ type PendingRoundAssembly struct {
 
 	// Forfeits tracks VTXOs being forfeited as inputs to this round.
 	// Decoupled from outputs to enable many-to-many operations.
-	Forfeits []ForfeitIntent
+	Forfeits []types.ForfeitRequest
 
 	// Leaves tracks on-chain exit outputs for this round. Decoupled from
 	// forfeit inputs to enable many-to-many operations.
-	Leaves []*LeaveRequest
+	Leaves []*types.LeaveRequest
 }
 
 func (s *PendingRoundAssembly) String() string {

--- a/round/transition_table.go
+++ b/round/transition_table.go
@@ -27,24 +27,14 @@ type ClientTransitionTable = protofsm.TransitionTable[
 var BoardingClientTransitions = ClientTransitionTable{
 	MachineName: "BoardingClient",
 	States: []ClientStateTransitions{
-		// Idle: Initial state, waiting for boarding intents.
+		// Idle: Initial state, waiting for intent packages.
 		{
 			FromState: &Idle{},
 			Transitions: []ClientTransitionEntry{
 				{
-					Event:       &ResumeBoardingIntents{},
+					Event:       &IntentPackage{},
 					ToState:     &PendingRoundAssembly{},
-					Description: "Resume monitoring existing intents",
-				},
-				{
-					Event:       &BoardingUTXOConfirmed{},
-					ToState:     &PendingRoundAssembly{},
-					Description: "First UTXO confirmed, start assembly",
-				},
-				{
-					Event:       &VTXORequestsReceived{},
-					ToState:     &PendingRoundAssembly{},
-					Description: "VTXO requests received, start assembly",
+					Description: "Intent package received, start assembly",
 				},
 				{
 					Event:       &BoardingFailed{},
@@ -55,19 +45,14 @@ var BoardingClientTransitions = ClientTransitionTable{
 			},
 		},
 
-		// PendingRoundAssembly: Collecting confirmed boarding intents.
+		// PendingRoundAssembly: Collecting intents for the round.
 		{
 			FromState: &PendingRoundAssembly{},
 			Transitions: []ClientTransitionEntry{
 				{
-					Event:       &BoardingUTXOConfirmed{},
+					Event:       &IntentPackage{},
 					ToState:     &PendingRoundAssembly{},
-					Description: "Additional boarding UTXO confirmed",
-				},
-				{
-					Event:       &VTXORequestsReceived{},
-					ToState:     &PendingRoundAssembly{},
-					Description: "Additional VTXO requests received",
+					Description: "Additional intents received",
 				},
 				{
 					Event:       &RegistrationRequested{},
@@ -262,10 +247,17 @@ var BoardingClientTransitions = ClientTransitionTable{
 			},
 		},
 
-		// ClientFailedState: Terminal failure state.
+		// ClientFailedState: Recoverable failure state. Recovery
+		// transitions to Idle and re-dispatches the IntentPackage,
+		// so the net destination is PendingRoundAssembly.
 		{
 			FromState: &ClientFailedState{},
 			Transitions: []ClientTransitionEntry{
+				{
+					Event:       &IntentPackage{},
+					ToState:     &Idle{},
+					Description: "Recover from failure with new intents",
+				},
 				{
 					Event:       &BoardingFailed{},
 					ToState:     &ClientFailedState{},

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -448,7 +448,16 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 		}
 
 		// Include all forfeited VTXO amounts as inputs.
-		totalInput += computeTotalForfeitAmount(s.Forfeits)
+		forfeitInput, err := computeTotalForfeitAmount(
+			ctx, env.VTXOStore, s.Forfeits,
+		)
+		if err != nil {
+			return failWithNotification(
+				"failed to compute forfeit amount",
+				err, true, fn.None[RoundID](),
+			), nil
+		}
+		totalInput += forfeitInput
 
 		// Include leave amounts as requested on-chain outputs.
 		for i, req := range s.Leaves {
@@ -513,7 +522,13 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 		vtxoReqs := slices.Clone(s.VTXOs)
 
 		// Build forfeit requests from the decoupled forfeit pool.
-		forfeitReqs := sortedForfeitRequests(s.Forfeits)
+		forfeitReqs, err := sortedForfeitRequests(s.Forfeits)
+		if err != nil {
+			return failWithNotification(
+				"invalid forfeit requests",
+				err, true, fn.None[RoundID](),
+			), nil
+		}
 
 		// Leave requests are already in append order.
 		leaveReqs := slices.Clone(s.Leaves)
@@ -714,7 +729,7 @@ func validateBoardingInputs(commitmentTx *wire.MsgTx,
 // commitment transaction with matching values and scripts. This ensures the
 // server has properly included the requested on-chain exit outputs.
 func validateLeaveOutputs(
-	commitmentTx *wire.MsgTx, leaves []*LeaveRequest,
+	commitmentTx *wire.MsgTx, leaves []*types.LeaveRequest,
 ) error {
 
 	if commitmentTx == nil {

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -1675,11 +1675,10 @@ func (s *ConfirmedState) ProcessEvent(_ context.Context, event ClientEvent,
 	}
 }
 
-// ProcessEvent for ClientFailedState. This state is now recoverable and
-// accepts the same events as Idle (BoardingUTXOConfirmed,
-// ResumeBoardingIntents) to allow the FSM to restart the boarding process
-// after a failure. Instead of duplicating the Idle logic, we transition to
-// Idle and forward the event as an internal event for Idle to process.
+// ProcessEvent for ClientFailedState. This state is recoverable and
+// accepts IntentPackage events to restart the boarding process after a
+// failure. Instead of duplicating the Idle logic, we transition to Idle
+// and forward the event as an internal event for Idle to process.
 func (s *ClientFailedState) ProcessEvent(
 	ctx context.Context, event ClientEvent, env *ClientEnvironment,
 ) (*ClientStateTransition, error) {

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -188,6 +188,8 @@ func (s *Idle) ProcessEvent(ctx context.Context, event ClientEvent,
 			NextState: &PendingRoundAssembly{
 				Boarding: slices.Clone(evt.Boarding),
 				VTXOs:    slices.Clone(evt.VTXOs),
+				Forfeits: slices.Clone(evt.Forfeits),
+				Leaves:   slices.Clone(evt.Leaves),
 			},
 		}, nil
 
@@ -277,40 +279,18 @@ func (s *Idle) ProcessEvent(ctx context.Context, event ClientEvent,
 			},
 		}, nil
 
-	case *RefreshVTXORequest:
-		// A VTXO actor requested refresh. Start assembling a round with
-		// this refresh request. Similar to boarding intents, we track
-		// refreshing VTXOs in the PendingRoundAssembly state.
-		//
-		// The refresh request contains all info to build both the
-		// RefreshRequest (forfeit) and VTXORequest (new output).
-		refreshMap := make(map[wire.OutPoint]*RefreshVTXORequest)
-		refreshMap[evt.VTXOOutpoint] = evt
-
-		// Create the VTXORequest for the new VTXO output.
-		vtxoReq := buildVTXORequestFromRefresh(evt)
+	case *IntentPackage:
+		// An atomic bundle of intents was submitted. Start
+		// assembling a round with all items from the package.
+		if evt.isEmpty() {
+			return selfLoop(s), nil
+		}
 
 		return &ClientStateTransition{
 			NextState: &PendingRoundAssembly{
-				Boarding:        nil,
-				VTXOs:           []types.VTXORequest{vtxoReq},
-				RefreshingVTXOs: refreshMap,
-			},
-		}, nil
-
-	case *LeaveVTXORequest:
-		// A VTXO actor (or wallet) requested to exit the Ark. Start
-		// assembling a round with this leave request. Similar to
-		// refresh requests, we track leaving VTXOs in the
-		// PendingRoundAssembly state.
-		leaveMap := make(map[wire.OutPoint]*LeaveVTXORequest)
-		leaveMap[evt.VTXOOutpoint] = evt
-
-		return &ClientStateTransition{
-			NextState: &PendingRoundAssembly{
-				Boarding:     nil,
-				VTXOs:        nil,
-				LeavingVTXOs: leaveMap,
+				Forfeits: slices.Clone(evt.Forfeits),
+				VTXOs:    slices.Clone(evt.VTXOs),
+				Leaves:   slices.Clone(evt.Leaves),
 			},
 		}, nil
 
@@ -409,9 +389,10 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 
 		return &ClientStateTransition{
 			NextState: &PendingRoundAssembly{
-				Boarding:        updatedBoardingIntents,
-				VTXOs:           slices.Clone(s.VTXOs),
-				RefreshingVTXOs: s.RefreshingVTXOs,
+				Boarding: updatedBoardingIntents,
+				VTXOs:    slices.Clone(s.VTXOs),
+				Forfeits: slices.Clone(s.Forfeits),
+				Leaves:   slices.Clone(s.Leaves),
 			},
 		}, nil
 
@@ -427,57 +408,36 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 
 		return &ClientStateTransition{
 			NextState: &PendingRoundAssembly{
-				Boarding:        slices.Clone(s.Boarding),
-				VTXOs:           updatedVTXOIntents,
-				RefreshingVTXOs: maps.Clone(s.RefreshingVTXOs),
+				Boarding: slices.Clone(s.Boarding),
+				VTXOs:    updatedVTXOIntents,
+				Forfeits: slices.Clone(s.Forfeits),
+				Leaves:   slices.Clone(s.Leaves),
 			},
 		}, nil
 
-	case *RefreshVTXORequest:
-		// A VTXO actor requested refresh. Add to our refreshing map.
-		// We stay in this state and accumulate refresh requests.
-		//
-		// Also create a VTXORequest for the new VTXO output.
-		updatedRefreshing := maps.Clone(s.RefreshingVTXOs)
-		if updatedRefreshing == nil {
-			updatedRefreshing = make(
-				map[wire.OutPoint]*RefreshVTXORequest,
-			)
+	case *IntentPackage:
+		// An atomic bundle of intents. Unpack into our pools.
+		if evt.isEmpty() {
+			return selfLoop(s), nil
 		}
-		updatedRefreshing[evt.VTXOOutpoint] = evt
 
-		// Add the VTXORequest for this refresh to the VTXOs list.
-		vtxoReq := buildVTXORequestFromRefresh(evt)
+		updatedForfeits := slices.Clone(s.Forfeits)
+		updatedForfeits = append(
+			updatedForfeits, evt.Forfeits...,
+		)
+
 		updatedVTXOs := slices.Clone(s.VTXOs)
-		updatedVTXOs = append(updatedVTXOs, vtxoReq)
+		updatedVTXOs = append(updatedVTXOs, evt.VTXOs...)
+
+		updatedLeaves := slices.Clone(s.Leaves)
+		updatedLeaves = append(updatedLeaves, evt.Leaves...)
 
 		return &ClientStateTransition{
 			NextState: &PendingRoundAssembly{
-				Boarding:        slices.Clone(s.Boarding),
-				VTXOs:           updatedVTXOs,
-				RefreshingVTXOs: updatedRefreshing,
-				LeavingVTXOs:    maps.Clone(s.LeavingVTXOs),
-			},
-		}, nil
-
-	case *LeaveVTXORequest:
-		// A VTXO actor (or wallet) requested to exit the Ark. Add to
-		// our leaving map. We stay in this state and accumulate leave
-		// requests alongside boarding intents and refresh requests.
-		updatedLeaving := maps.Clone(s.LeavingVTXOs)
-		if updatedLeaving == nil {
-			updatedLeaving = make(
-				map[wire.OutPoint]*LeaveVTXORequest,
-			)
-		}
-		updatedLeaving[evt.VTXOOutpoint] = evt
-
-		return &ClientStateTransition{
-			NextState: &PendingRoundAssembly{
-				Boarding:        slices.Clone(s.Boarding),
-				VTXOs:           slices.Clone(s.VTXOs),
-				RefreshingVTXOs: maps.Clone(s.RefreshingVTXOs),
-				LeavingVTXOs:    updatedLeaving,
+				Boarding: slices.Clone(s.Boarding),
+				VTXOs:    updatedVTXOs,
+				Forfeits: updatedForfeits,
+				Leaves:   updatedLeaves,
 			},
 		}, nil
 
@@ -501,20 +461,16 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 			totalOutput += vtxo.Amount
 		}
 
-		// Include all forfeited VTXO amounts as inputs. These values
-		// come from refresh and leave requests.
-		totalInput += computeTotalForfeitAmount(
-			s.RefreshingVTXOs, s.LeavingVTXOs,
-		)
+		// Include all forfeited VTXO amounts as inputs.
+		totalInput += computeTotalForfeitAmount(s.Forfeits)
 
 		// Include leave amounts as requested on-chain outputs.
-		for _, req := range s.LeavingVTXOs {
+		for i, req := range s.Leaves {
 			if req.Output == nil {
 				return failWithNotification(
 					"leave request has nil output",
-					fmt.Errorf("leave request for %v "+
-						"has nil output",
-						req.VTXOOutpoint),
+					fmt.Errorf("leave request %d "+
+						"has nil output", i),
 					true, fn.None[RoundID](),
 				), nil
 			}
@@ -570,17 +526,11 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 		boardingReqs := fn.Map(s.Boarding, buildBoardingRequest)
 		vtxoReqs := slices.Clone(s.VTXOs)
 
-		// Build forfeit requests for VTXOs being refreshed or exited
-		// on-chain. Forfeits are listed separately from outputs.
-		// Sorted for deterministic ordering across map iterations.
-		forfeitReqs := sortedForfeitRequests(
-			s.RefreshingVTXOs, s.LeavingVTXOs,
-		)
+		// Build forfeit requests from the decoupled forfeit pool.
+		forfeitReqs := sortedForfeitRequests(s.Forfeits)
 
-		// Build leave requests for VTXOs being exited to on-chain
-		// outputs. Each leave forfeits a VTXO and creates an on-chain
-		// output in the batch transaction. Sorted for determinism.
-		leaveReqs := sortedLeaveRequests(s.LeavingVTXOs)
+		// Leave requests are already in append order.
+		leaveReqs := slices.Clone(s.Leaves)
 
 		env.Log.InfoS(ctx, "Sending JoinRoundRequest to server",
 			slog.Int("boarding_requests", len(boardingReqs)),
@@ -588,12 +538,12 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 			slog.Int("forfeit_requests", len(forfeitReqs)),
 			slog.Int("leave_requests", len(leaveReqs)))
 
-		// Build Intents with all VTXOs and leaves for downstream
-		// validation.
+		// Build Intents with all pools for downstream validation.
 		intent := Intents{
 			Boarding: slices.Clone(s.Boarding),
 			VTXOs:    vtxoReqs,
 			Leaves:   leaveReqs,
+			Forfeits: slices.Clone(s.Forfeits),
 		}
 
 		// Derive a fresh identifier key for the join-request
@@ -1949,6 +1899,23 @@ func (s *ClientFailedState) ProcessEvent(
 		// Recovery path: transition to Idle and forward the event
 		// to be processed there. This avoids duplicating the
 		// BoardingUTXOConfirmed handling logic.
+		return &ClientStateTransition{
+			NextState: &Idle{},
+			NewEvents: fn.Some(ClientEmittedEvent{
+				InternalEvent: []ClientEvent{evt},
+			}),
+		}, nil
+
+	case *IntentPackage:
+		if evt.isEmpty() {
+			return selfLoop(s), nil
+		}
+
+		env.Log.InfoS(ctx, "Recovering from failed state with intent package",
+			slog.Int("forfeits", len(evt.Forfeits)),
+			slog.Int("vtxos", len(evt.VTXOs)),
+			slog.Int("leaves", len(evt.Leaves)))
+
 		return &ClientStateTransition{
 			NextState: &Idle{},
 			NewEvents: fn.Some(ClientEmittedEvent{

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -27,20 +27,6 @@ func buildBoardingRequest(intent BoardingIntent) types.BoardingRequest {
 	return intent.Request
 }
 
-// buildVTXORequestFromRefresh constructs a types.VTXORequest from a
-// RefreshVTXORequest. The refresh request contains all info needed to create
-// the new VTXO output in the round.
-func buildVTXORequestFromRefresh(req *RefreshVTXORequest) types.VTXORequest {
-	return types.VTXORequest{
-		Amount:      btcutil.Amount(req.Amount),
-		PkScript:    req.PkScript,
-		Expiry:      req.Expiry,
-		ClientKey:   req.NewVTXOKey,
-		OperatorKey: req.OperatorKey,
-		SigningKey:  req.SigningKey,
-	}
-}
-
 // failWithNotification creates a state transition to ClientFailedState and
 // emits a RoundFailedNotification. This is the standard pattern for handling
 // internal errors without returning an error to the FSM (which would halt it).

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -147,133 +147,25 @@ func signBoardingInputs(wallet ClientWallet, commitmentTx *psbt.Packet,
 	return boardingInputSigs, nil
 }
 
-// ProcessEvent handles the events from the Idle state. In this state, we'll
-// receive boarding UTXO confirmations or resume existing boarding flows.
+// ProcessEvent handles events in the Idle state. The only pool-addition
+// event is IntentPackage — the actor layer converts all raw inputs
+// (boarding confirmations, VTXO requests, refresh/leave) into
+// IntentPackage before sending to the FSM.
 func (s *Idle) ProcessEvent(ctx context.Context, event ClientEvent,
 	env *ClientEnvironment) (*ClientStateTransition, error) {
 
 	switch evt := event.(type) {
-	case *ResumeBoardingIntents:
-		// If for some reason, there aren't any new intents, then we'll
-		// stay in the idle state.
-		if evt.isEmpty() {
-			env.Log.DebugS(ctx, "ResumeBoardingIntents received "+
-				"with no intents")
-
-			return &ClientStateTransition{
-				NextState: s,
-			}, nil
-		}
-
-		env.Log.InfoS(ctx, "Resuming boarding intents",
-			evt.logAttributes())
-
-		// Otherwise, we'll start to assemble a round with the resumed
-		// intents.
-		return &ClientStateTransition{
-			NextState: &PendingRoundAssembly{
-				Boarding: slices.Clone(evt.Boarding),
-				VTXOs:    slices.Clone(evt.VTXOs),
-				Forfeits: slices.Clone(evt.Forfeits),
-				Leaves:   slices.Clone(evt.Leaves),
-			},
-		}, nil
-
-	case *BoardingUTXOConfirmed:
-		env.Log.InfoS(ctx, "Processing boarding UTXO confirmation in Idle state",
-			btclog.Fmt("outpoint", "%v", evt.Outpoint),
-			slog.Int("block_height", int(evt.BlockHeight)))
-
-		// A boarding UTXO was confirmed. The wallet has already
-		// persisted the intent; we just need to create an internal
-		// BoardingIntent and transition to PendingRoundAssembly.
-		if evt.Tx == nil {
-			return failWithNotification(
-				"confirmation event missing transaction",
-				fmt.Errorf("BoardingUTXOConfirmed.Tx is nil"),
-				true, fn.None[RoundID](),
-			), nil
-		}
-
-		// Extract the confirmed output value.
-		if int(evt.Outpoint.Index) >= len(evt.Tx.TxOut) {
-			return failWithNotification(
-				fmt.Sprintf(
-					"invalid outpoint index %d for tx %s",
-					evt.Outpoint.Index, evt.Outpoint.Hash,
-				),
-				fmt.Errorf("outpoint index out of range"),
-				true, fn.None[RoundID](),
-			), nil
-		}
-		confirmedOutput := evt.Tx.TxOut[evt.Outpoint.Index]
-
-		// Create the chain info from the confirmation event, including
-		// the TxProof for SPV verification.
-		chainInfo := BoardingChainInfo{
-			ConfHeight: evt.BlockHeight,
-			ConfHash:   evt.BlockHash,
-			ConfTx:     evt.Tx,
-			OutPoint:   evt.Outpoint,
-			Amount:     btcutil.Amount(confirmedOutput.Value),
-			TxProof:    evt.TxProof,
-		}
-
-		// Create a wallet intent with the full address from the event.
-		walletIntent := WalletBoardingIntent{
-			Address:   evt.Address,
-			Outpoint:  evt.Outpoint,
-			ChainInfo: chainInfo,
-			Status:    BoardingStatusConfirmed,
-		}
-
-		// Build the boarding request from the address. Include the exit
-		// delay so the operator can verify the boarding output script.
-		boardingRequest := types.BoardingRequest{
-			Outpoint:    &evt.Outpoint,
-			ClientKey:   evt.Address.KeyDesc.PubKey,
-			OperatorKey: evt.Address.OperatorKey,
-			ExitDelay:   evt.Address.ExitDelay,
-		}
-
-		// Create a BoardingIntent for the next round.
-		boardingIntent := BoardingIntent{
-			BoardingIntent: walletIntent,
-			Request:        boardingRequest,
-		}
-
-		env.Log.InfoS(ctx, "Transitioning to PendingRoundAssembly",
-			slog.Int("amount", int(chainInfo.Amount)),
-			btclog.Fmt("outpoint", "%v", evt.Outpoint))
-
-		return &ClientStateTransition{
-			NextState: &PendingRoundAssembly{
-				Boarding: []BoardingIntent{boardingIntent},
-				VTXOs:    []types.VTXORequest{},
-			},
-		}, nil
-
-	case *VTXORequestsReceived:
-		env.Log.InfoS(ctx, "Received VTXO requests in Idle state",
-			slog.Int("request_count", len(evt.Requests)))
-
-		// Transition to PendingRoundAssembly with the received VTXO.
-		return &ClientStateTransition{
-			NextState: &PendingRoundAssembly{
-				Boarding: []BoardingIntent{},
-				VTXOs:    slices.Clone(evt.Requests),
-			},
-		}, nil
-
 	case *IntentPackage:
-		// An atomic bundle of intents was submitted. Start
-		// assembling a round with all items from the package.
 		if evt.isEmpty() {
 			return selfLoop(s), nil
 		}
 
+		env.Log.InfoS(ctx, "Starting round assembly from "+
+			"intent package", evt.logAttributes())
+
 		return &ClientStateTransition{
 			NextState: &PendingRoundAssembly{
+				Boarding: slices.Clone(evt.Boarding),
 				Forfeits: slices.Clone(evt.Forfeits),
 				VTXOs:    slices.Clone(evt.VTXOs),
 				Leaves:   slices.Clone(evt.Leaves),
@@ -295,122 +187,56 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 	error) {
 
 	switch evt := event.(type) {
-	// A new boarding UTXO was confirmed. The wallet handles persistence;
-	// we just add to our internal map.
-	case *BoardingUTXOConfirmed:
-		env.Log.InfoS(ctx, "Additional boarding UTXO confirmed during assembly",
-			btclog.Fmt("outpoint", "%v", evt.Outpoint),
-			slog.Int("current_boarding_intent_count", len(s.Boarding)),
-			slog.Int("current_vtxo_intent_count", len(s.VTXOs)))
-
-		if evt.Tx == nil {
-			return failWithNotification(
-				"confirmation event missing transaction",
-				fmt.Errorf("BoardingUTXOConfirmed.Tx is nil"),
-				true, fn.None[RoundID](),
-			), nil
-		}
-
-		// Extract the confirmed output value.
-		if int(evt.Outpoint.Index) >= len(evt.Tx.TxOut) {
-			return failWithNotification(
-				fmt.Sprintf(
-					"invalid outpoint index %d for tx %s",
-					evt.Outpoint.Index, evt.Outpoint.Hash,
-				),
-				fmt.Errorf("outpoint index out of range"),
-				true, fn.None[RoundID](),
-			), nil
-		}
-		confirmedOutput := evt.Tx.TxOut[evt.Outpoint.Index]
-
-		for _, intent := range s.Boarding {
-			if intent.Outpoint != evt.Outpoint {
-				continue
-			}
-
-			env.Log.InfoS(ctx, "Boarding UTXO already present in intents map",
-				btclog.Fmt("outpoint", "%v", evt.Outpoint))
-
-			// Self-loop without adding duplicate intent.
-			return selfLoop(s), nil
-		}
-
-		// Create the chain info from the confirmation event, including
-		// the TxProof for SPV verification.
-		chainInfo := BoardingChainInfo{
-			ConfHeight: evt.BlockHeight,
-			ConfHash:   evt.BlockHash,
-			ConfTx:     evt.Tx,
-			OutPoint:   evt.Outpoint,
-			Amount:     btcutil.Amount(confirmedOutput.Value),
-			TxProof:    evt.TxProof,
-		}
-
-		// Create a wallet intent with the full address from the event.
-		walletIntent := WalletBoardingIntent{
-			Address:   evt.Address,
-			Outpoint:  evt.Outpoint,
-			ChainInfo: chainInfo,
-			Status:    BoardingStatusConfirmed,
-		}
-
-		// Build the boarding request from the address. Include the exit
-		// delay so the operator can verify the boarding output script.
-		boardingRequest := types.BoardingRequest{
-			Outpoint:    &evt.Outpoint,
-			ClientKey:   evt.Address.KeyDesc.PubKey,
-			OperatorKey: evt.Address.OperatorKey,
-			ExitDelay:   evt.Address.ExitDelay,
-		}
-
-		intent := BoardingIntent{
-			BoardingIntent: walletIntent,
-			Request:        boardingRequest,
-		}
-
-		// Add the new intent to our existing set.
-		updatedBoardingIntents := slices.Clone(s.Boarding)
-		updatedBoardingIntents = append(updatedBoardingIntents, intent)
-
-		return &ClientStateTransition{
-			NextState: &PendingRoundAssembly{
-				Boarding: updatedBoardingIntents,
-				VTXOs:    slices.Clone(s.VTXOs),
-				Forfeits: slices.Clone(s.Forfeits),
-				Leaves:   slices.Clone(s.Leaves),
-			},
-		}, nil
-
-	case *VTXORequestsReceived:
-		env.Log.InfoS(ctx, "Additional VTXO requests received during assembly",
-			slog.Int("current_boarding_intent_count", len(s.Boarding)),
-			slog.Int("current_vtxo_intent_count", len(s.VTXOs)),
-			slog.Int("new_request_count", len(evt.Requests)))
-
-		// Add the new VTXO requests to our existing set.
-		updatedVTXOIntents := slices.Clone(s.VTXOs)
-		updatedVTXOIntents = append(updatedVTXOIntents, evt.Requests...)
-
-		return &ClientStateTransition{
-			NextState: &PendingRoundAssembly{
-				Boarding: slices.Clone(s.Boarding),
-				VTXOs:    updatedVTXOIntents,
-				Forfeits: slices.Clone(s.Forfeits),
-				Leaves:   slices.Clone(s.Leaves),
-			},
-		}, nil
-
 	case *IntentPackage:
-		// An atomic bundle of intents. Unpack into our pools.
+		// An atomic bundle of intents. Unpack into our pools,
+		// deduplicating boarding intents by outpoint.
 		if evt.isEmpty() {
 			return selfLoop(s), nil
 		}
 
+		// Build a set of existing boarding outpoints for O(1)
+		// dedup lookups.
+		boardingSeen := fn.NewSet[wire.OutPoint]()
+		for _, b := range s.Boarding {
+			boardingSeen.Add(b.Outpoint)
+		}
+
+		updatedBoarding := slices.Clone(s.Boarding)
+		for _, newIntent := range evt.Boarding {
+			if boardingSeen.Contains(newIntent.Outpoint) {
+				continue
+			}
+
+			boardingSeen.Add(newIntent.Outpoint)
+			updatedBoarding = append(
+				updatedBoarding, newIntent,
+			)
+		}
+
+		// Deduplicate forfeit requests by VTXO outpoint. A VTXO
+		// can only be forfeited once per round.
+		forfeitSeen := fn.NewSet[wire.OutPoint]()
+		for _, f := range s.Forfeits {
+			if f.VTXOOutpoint != nil {
+				forfeitSeen.Add(*f.VTXOOutpoint)
+			}
+		}
+
 		updatedForfeits := slices.Clone(s.Forfeits)
-		updatedForfeits = append(
-			updatedForfeits, evt.Forfeits...,
-		)
+		for _, newForfeit := range evt.Forfeits {
+			if newForfeit.VTXOOutpoint == nil {
+				continue
+			}
+
+			if forfeitSeen.Contains(*newForfeit.VTXOOutpoint) {
+				continue
+			}
+
+			forfeitSeen.Add(*newForfeit.VTXOOutpoint)
+			updatedForfeits = append(
+				updatedForfeits, newForfeit,
+			)
+		}
 
 		updatedVTXOs := slices.Clone(s.VTXOs)
 		updatedVTXOs = append(updatedVTXOs, evt.VTXOs...)
@@ -420,7 +246,7 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 
 		return &ClientStateTransition{
 			NextState: &PendingRoundAssembly{
-				Boarding: slices.Clone(s.Boarding),
+				Boarding: updatedBoarding,
 				VTXOs:    updatedVTXOs,
 				Forfeits: updatedForfeits,
 				Leaves:   updatedLeaves,
@@ -448,7 +274,7 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 		}
 
 		// Include all forfeited VTXO amounts as inputs.
-		forfeitInput, err := computeTotalForfeitAmount(
+		forfeitAmt, err := computeTotalForfeitAmount(
 			ctx, env.VTXOStore, s.Forfeits,
 		)
 		if err != nil {
@@ -457,7 +283,7 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 				err, true, fn.None[RoundID](),
 			), nil
 		}
-		totalInput += forfeitInput
+		totalInput += forfeitAmt
 
 		// Include leave amounts as requested on-chain outputs.
 		for i, req := range s.Leaves {
@@ -1876,46 +1702,14 @@ func (s *ClientFailedState) ProcessEvent(
 			},
 		}, nil
 
-	case *ResumeBoardingIntents:
-		// Recovery path: transition to Idle and forward the event.
-		// If no intents are provided, stay in the current state.
-		if evt.isEmpty() {
-			return selfLoop(s), nil
-		}
-
-		env.Log.InfoS(ctx, "Recovering from failed state with resumed intents",
-			evt.logAttributes())
-
-		return &ClientStateTransition{
-			NextState: &Idle{},
-			NewEvents: fn.Some(ClientEmittedEvent{
-				InternalEvent: []ClientEvent{evt},
-			}),
-		}, nil
-
-	case *BoardingUTXOConfirmed:
-		env.Log.InfoS(ctx, "Recovering from failed state with new boarding confirmation",
-			btclog.Fmt("outpoint", "%v", evt.Outpoint))
-
-		// Recovery path: transition to Idle and forward the event
-		// to be processed there. This avoids duplicating the
-		// BoardingUTXOConfirmed handling logic.
-		return &ClientStateTransition{
-			NextState: &Idle{},
-			NewEvents: fn.Some(ClientEmittedEvent{
-				InternalEvent: []ClientEvent{evt},
-			}),
-		}, nil
-
 	case *IntentPackage:
 		if evt.isEmpty() {
 			return selfLoop(s), nil
 		}
 
-		env.Log.InfoS(ctx, "Recovering from failed state with intent package",
-			slog.Int("forfeits", len(evt.Forfeits)),
-			slog.Int("vtxos", len(evt.VTXOs)),
-			slog.Int("leaves", len(evt.Leaves)))
+		env.Log.InfoS(ctx, "Recovering from failed state "+
+			"with intent package",
+			evt.logAttributes())
 
 		return &ClientStateTransition{
 			NextState: &Idle{},

--- a/round/transitions_test.go
+++ b/round/transitions_test.go
@@ -508,14 +508,16 @@ func TestTerminalStateSelfLoop(t *testing.T) {
 func TestIdleState(t *testing.T) {
 	t.Parallel()
 
-	t.Run("BoardingUTXOConfirmed_to_pending", func(t *testing.T) {
+	t.Run("IntentPackage_boarding_to_pending", func(t *testing.T) {
 		t.Parallel()
 
 		h := newTestHarness(t)
 		h.withState(&Idle{})
 
 		intent := h.newTestBoardingIntent()
-		event := h.newBoardingUTXOConfirmedEvent(intent)
+		event := &IntentPackage{Intents: Intents{
+			Boarding: []BoardingIntent{intent},
+		}}
 
 		transition, err := h.sendEvent(event)
 		require.NoError(t, err)
@@ -525,7 +527,7 @@ func TestIdleState(t *testing.T) {
 		require.Len(t, nextState.Boarding, 1)
 	})
 
-	t.Run("ResumeBoardingIntents_with_intents", func(t *testing.T) {
+	t.Run("IntentPackage_resume_with_intents", func(t *testing.T) {
 		t.Parallel()
 
 		h := newTestHarness(t)
@@ -533,10 +535,10 @@ func TestIdleState(t *testing.T) {
 
 		intent := h.newTestBoardingIntent()
 		vtxoReq := h.newTestVTXORequestForIntent(intent)
-		event := &ResumeBoardingIntents{
+		event := &IntentPackage{Intents: Intents{
 			Boarding: []BoardingIntent{intent},
 			VTXOs:    []types.VTXORequest{vtxoReq},
-		}
+		}}
 
 		transition, err := h.sendEvent(event)
 		require.NoError(t, err)
@@ -546,16 +548,13 @@ func TestIdleState(t *testing.T) {
 		require.Len(t, nextState.Boarding, 1)
 	})
 
-	t.Run("ResumeBoardingIntents_empty_stays_idle", func(t *testing.T) {
+	t.Run("IntentPackage_empty_stays_idle", func(t *testing.T) {
 		t.Parallel()
 
 		h := newTestHarness(t)
 		h.withState(&Idle{})
 
-		event := &ResumeBoardingIntents{
-			Boarding: []BoardingIntent{},
-			VTXOs:    []types.VTXORequest{},
-		}
+		event := &IntentPackage{}
 
 		transition, err := h.sendEvent(event)
 		require.NoError(t, err)
@@ -563,48 +562,12 @@ func TestIdleState(t *testing.T) {
 
 		_ = assertStateType[*Idle](h)
 	})
-
-	t.Run("nil_tx_transitions_to_failed", func(t *testing.T) {
-		t.Parallel()
-
-		h := newTestHarness(t)
-		h.withState(&Idle{})
-
-		intent := h.newTestBoardingIntent()
-		event := h.newBoardingUTXOConfirmedEvent(intent)
-		event.Tx = nil
-
-		transition, err := h.sendEvent(event)
-		require.NoError(t, err)
-		require.NotNil(t, transition)
-
-		failedState := assertStateType[*ClientFailedState](h)
-		require.Contains(t, failedState.Reason, "missing transaction")
-	})
-
-	t.Run("invalid_outpoint_transitions_to_failed", func(t *testing.T) {
-		t.Parallel()
-
-		h := newTestHarness(t)
-		h.withState(&Idle{})
-
-		intent := h.newTestBoardingIntent()
-		event := h.newBoardingUTXOConfirmedEvent(intent)
-		event.Outpoint.Index = 999
-
-		transition, err := h.sendEvent(event)
-		require.NoError(t, err)
-		require.NotNil(t, transition)
-
-		failedState := assertStateType[*ClientFailedState](h)
-		require.Contains(t, failedState.Reason, "invalid outpoint")
-	})
 }
 
 func TestPendingRoundAssemblyState(t *testing.T) {
 	t.Parallel()
 
-	t.Run("additional_confirmation_accumulates", func(t *testing.T) {
+	t.Run("additional_intent_package_accumulates", func(t *testing.T) {
 		t.Parallel()
 
 		h := newTestHarness(t)
@@ -617,7 +580,9 @@ func TestPendingRoundAssemblyState(t *testing.T) {
 		})
 
 		newIntent := h.newTestBoardingIntent()
-		event := h.newBoardingUTXOConfirmedEvent(newIntent)
+		event := &IntentPackage{Intents: Intents{
+			Boarding: []BoardingIntent{newIntent},
+		}}
 
 		transition, err := h.sendEvent(event)
 		require.NoError(t, err)
@@ -1571,12 +1536,15 @@ func TestBoardingFlowMultipleIntentsAccumulation(t *testing.T) {
 	h := newTestHarness(t)
 	h.withState(&Idle{})
 
-	// We confirm multiple UTXOs to verify that PendingRoundAssembly
-	// correctly accumulates boarding intents as they arrive, rather than
-	// replacing or dropping previous ones.
+	// We send multiple intent packages to verify that
+	// PendingRoundAssembly correctly accumulates boarding intents
+	// as they arrive, rather than replacing or dropping previous
+	// ones.
 	for i := 0; i < 3; i++ {
 		intent := h.newTestBoardingIntent()
-		event := h.newBoardingUTXOConfirmedEvent(intent)
+		event := &IntentPackage{Intents: Intents{
+			Boarding: []BoardingIntent{intent},
+		}}
 
 		_, err := h.sendEvent(event)
 		require.NoError(t, err)


### PR DESCRIPTION
## Summary

- **Move actor-only messages** (`RefreshVTXORequest`, `LeaveVTXORequest`,
  `buildVTXORequestFromRefresh`) out of `events.go` into `actor.go`, clarifying
  the boundary between FSM events and actor messages
- **Replace redundant types** — remove `ForfeitIntent` (carried duplicate
  amount), `round.ForfeitRequest`, and `round.LeaveRequest`; use
  `types.ForfeitRequest` and `types.LeaveRequest` directly, eliminating
  conversion loops in join-round authorization
- **Consolidate 4 FSM events into 1** — replace `BoardingUTXOConfirmed`,
  `VTXORequestsReceived`, `ResumeBoardingIntents`, and the existing
  `IntentPackage` with a single `IntentPackage` carrying all four pools
  (boarding, forfeits, VTXOs, leaves). Input validation moves to the actor
  layer where it belongs
- **Update README** to reflect the unified event model

Net result: ~350 fewer lines, one FSM event entry point instead of four,
and forfeit amounts resolved from VTXOStore at registration time rather
than carried through the event chain.

## Test plan

- [x] `make build` passes at each commit
- [x] `make unit pkg=round` passes at each commit
- [x] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)