### PR TITLE
multi: enforce minimum operator fee on client side

### DIFF
--- a/arkrpc/ark.pb.go
+++ b/arkrpc/ark.pb.go
@@ -92,8 +92,12 @@ type GetInfoResponse struct {
 	FeeRate int64 `protobuf:"varint,13,opt,name=fee_rate,json=feeRate,proto3" json:"fee_rate,omitempty"`
 	// The minimum confirmations required on boarding inputs.
 	MinConfirmations uint32 `protobuf:"varint,14,opt,name=min_confirmations,json=minConfirmations,proto3" json:"min_confirmations,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// The minimum operator fee (satoshis) required per join request. The
+	// fee is the difference between total input value and total output
+	// value. Requests below this threshold are rejected.
+	MinOperatorFee int64 `protobuf:"varint,15,opt,name=min_operator_fee,json=minOperatorFee,proto3" json:"min_operator_fee,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *GetInfoResponse) Reset() {
@@ -224,12 +228,19 @@ func (x *GetInfoResponse) GetMinConfirmations() uint32 {
 	return 0
 }
 
+func (x *GetInfoResponse) GetMinOperatorFee() int64 {
+	if x != nil {
+		return x.MinOperatorFee
+	}
+	return 0
+}
+
 var File_ark_proto protoreflect.FileDescriptor
 
 const file_ark_proto_rawDesc = "" +
 	"\n" +
 	"\tark.proto\x12\x06arkrpc\"\x10\n" +
-	"\x0eGetInfoRequest\"\x84\x04\n" +
+	"\x0eGetInfoRequest\"\xae\x04\n" +
 	"\x0fGetInfoResponse\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\tR\aversion\x12\x16\n" +
 	"\x06pubkey\x18\x02 \x01(\fR\x06pubkey\x12\x18\n" +
@@ -247,7 +258,8 @@ const file_ark_proto_rawDesc = "" +
 	"\x13min_boarding_amount\x18\v \x01(\x03R\x11minBoardingAmount\x12.\n" +
 	"\x13max_boarding_amount\x18\f \x01(\x03R\x11maxBoardingAmount\x12\x19\n" +
 	"\bfee_rate\x18\r \x01(\x03R\afeeRate\x12+\n" +
-	"\x11min_confirmations\x18\x0e \x01(\rR\x10minConfirmations2H\n" +
+	"\x11min_confirmations\x18\x0e \x01(\rR\x10minConfirmations\x12(\n" +
+	"\x10min_operator_fee\x18\x0f \x01(\x03R\x0eminOperatorFee2H\n" +
 	"\n" +
 	"ArkService\x12:\n" +
 	"\aGetInfo\x12\x16.arkrpc.GetInfoRequest\x1a\x17.arkrpc.GetInfoResponseB/Z-github.com/lightninglabs/darepo-client/arkrpcb\x06proto3"

--- a/arkrpc/ark.proto
+++ b/arkrpc/ark.proto
@@ -59,4 +59,9 @@ message GetInfoResponse {
 
     // The minimum confirmations required on boarding inputs.
     uint32 min_confirmations = 14;
+
+    // The minimum operator fee (satoshis) required per join request. The
+    // fee is the difference between total input value and total output
+    // value. Requests below this threshold are rejected.
+    int64 min_operator_fee = 15;
 }

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -706,6 +706,7 @@ func (s *Server) fetchOperatorTerms(
 		MinBoardingAmount: btcutil.Amount(resp.MinBoardingAmount),
 		MaxBoardingAmount: btcutil.Amount(resp.MaxBoardingAmount),
 		FeeRate:           btcutil.Amount(resp.FeeRate),
+		MinOperatorFee:    btcutil.Amount(resp.MinOperatorFee),
 		MinConfirmations:  resp.MinConfirmations,
 	}, nil
 }

--- a/lib/types/boarding.go
+++ b/lib/types/boarding.go
@@ -50,6 +50,11 @@ type OperatorTerms struct {
 	// FeeRate reflects the operator's target package feerate (sat/vByte).
 	FeeRate btcutil.Amount
 
+	// MinOperatorFee is the minimum fee (satoshis) the operator
+	// requires per join request. The fee is the difference between
+	// total input value and total output value.
+	MinOperatorFee btcutil.Amount
+
 	// MinConfirmations is the minimum confs required on boarding inputs.
 	MinConfirmations uint32
 }

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -547,6 +547,25 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 		// Calculate the implicit operator fee (inputs - outputs).
 		operatorFee := totalInput - totalOutput
 
+		// Ensure the fee meets the operator's minimum when
+		// boarding inputs are present. The min fee prevents free
+		// UTXO consolidation via boarding; refresh and leave
+		// operations (forfeit-only) are exempt because the
+		// operator already collected a fee when the VTXO was
+		// originally created.
+		minFee := env.OperatorTerms.MinOperatorFee
+		if len(s.Boarding) > 0 && operatorFee < minFee {
+			return failWithNotification(
+				"operator fee below minimum",
+				fmt.Errorf(
+					"operator fee (%d) is below "+
+						"operator minimum (%d)",
+					operatorFee, minFee,
+				),
+				true, fn.None[RoundID](),
+			), nil
+		}
+
 		// Validate that the operator fee is within acceptable limits.
 		if operatorFee > env.MaxOperatorFee {
 			return failWithNotification(

--- a/round/transitions_test.go
+++ b/round/transitions_test.go
@@ -730,6 +730,74 @@ func TestPendingRoundAssemblyState(t *testing.T) {
 		)
 	})
 
+	t.Run("fee_below_operator_minimum_fails", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+
+		// Set a high minimum operator fee (20,000 sats).
+		h.env.OperatorTerms.MinOperatorFee = btcutil.Amount(20000)
+
+		// Create intent with 50,000 sats.
+		intent := h.newTestBoardingIntent()
+		require.Equal(t, btcutil.Amount(50000), intent.ChainInfo.Amount)
+
+		// Create VTXO request for 45,000 sats, implying only
+		// 5,000 sat fee (below 20,000 minimum).
+		vtxoReq := h.newTestVTXORequestForIntent(intent)
+		vtxoReq.Amount = btcutil.Amount(45000)
+
+		h.withState(&PendingRoundAssembly{
+			Boarding: []BoardingIntent{intent},
+			VTXOs:    []types.VTXORequest{vtxoReq},
+		})
+
+		event := &RegistrationRequested{}
+
+		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		failedState := assertStateType[*ClientFailedState](h)
+		require.Contains(
+			t, failedState.Reason,
+			"operator fee below minimum",
+		)
+	})
+
+	t.Run("fee_exactly_at_operator_minimum_succeeds", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+
+		// Set minimum operator fee to 5,000 sats.
+		h.env.OperatorTerms.MinOperatorFee = btcutil.Amount(5000)
+
+		// Create intent with 50,000 sats.
+		intent := h.newTestBoardingIntent()
+		require.Equal(t, btcutil.Amount(50000), intent.ChainInfo.Amount)
+
+		// Create VTXO request for 45,000 sats, implying exactly
+		// 5,000 sat fee (equal to minimum).
+		vtxoReq := h.newTestVTXORequestForIntent(intent)
+		vtxoReq.Amount = btcutil.Amount(45000)
+
+		h.withState(&PendingRoundAssembly{
+			Boarding: []BoardingIntent{intent},
+			VTXOs:    []types.VTXORequest{vtxoReq},
+		})
+
+		event := &RegistrationRequested{}
+
+		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		// Should succeed — fee is exactly at the minimum.
+		nextState := assertStateType[*RegistrationSentState](h)
+		require.Len(t, nextState.Intents.Boarding, 1)
+	})
+
 	t.Run("valid_fee_within_limit_succeeds", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
## Summary

- Add `min_operator_fee` field to `GetInfoResponse` proto so the server can communicate its minimum fee requirement to clients
- Wire the new field through `OperatorTerms` so the client FSM has access to it
- Add client-side validation in the round FSM: reject join attempts where the implicit operator fee (total input - total output) falls below the operator's minimum, failing early with a clear error before sending the `JoinRoundRequest`
- Add unit test covering the below-minimum fee rejection path

Addresses the client-side portion of lightninglabs/darepo#108. Server-side changes in lightninglabs/darepo#122.

## Test plan

- [x] Unit test `fee_below_operator_minimum_fails` verifies early rejection when fee is below minimum
- [x] Existing transition tests continue to pass (no regression)
- [x] `make lint-changed` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)