### PR TITLE
round: purify client FSM via outbox handler

### DIFF
--- a/round/README.md
+++ b/round/README.md
@@ -64,20 +64,26 @@ instance to process additional addresses across different rounds.
 ### PendingRoundAssembly State
 
 After receiving an address, the user funds it by broadcasting a Bitcoin
-transaction. Once confirmed via `BoardingUTXOConfirmed`, the FSM transitions
-from Idle to PendingRoundAssembly, registering a boarding intent containing
-the address and on-chain UTXO information.
+transaction. Once confirmed, the actor builds a `BoardingIntent` and delivers
+it to the FSM via `IntentPackage`. The FSM transitions from Idle to
+PendingRoundAssembly, registering the boarding intent containing the address
+and on-chain UTXO information.
 
-Boarding intents, VTXO requests, refresh requests, and leave requests are
-managed separately, enabling flexible input-output mappings. The FSM collects
-them independently as self-loops in PendingRoundAssembly:
+All pool additions flow through a single `IntentPackage` event, which carries
+four independent pools:
 
-- `BoardingUTXOConfirmed` adds a boarding intent (on-chain input to spend)
-- `VTXORequestsReceived` adds VTXO requests specifying desired output amounts
-- `RefreshVTXORequest` adds a VTXO to be rolled into a new tree (from VTXO
-  actors whose VTXOs are approaching expiry)
-- `LeaveVTXORequest` adds a VTXO to be exited on-chain (from VTXO actors or
-  the wallet when the user wants to offboard)
+- **Boarding** — on-chain inputs to spend (from confirmed boarding UTXOs)
+- **VTXOs** — requested output amounts for new virtual UTXOs
+- **Forfeits** — VTXOs to be rolled into a new tree (from VTXO actors whose
+  VTXOs are approaching expiry)
+- **Leaves** — VTXOs to be exited on-chain (from VTXO actors or the wallet
+  when the user wants to offboard)
+
+The actor translates external messages (`RefreshVTXORequest`,
+`LeaveVTXORequest`, wallet confirmations, VTXO requests) into `IntentPackage`
+before sending to the FSM. This keeps input validation and construction in the
+actor layer, while the FSM focuses purely on pool accumulation and state
+management.
 
 This separation supports fan-in (multiple inputs funding one output) and
 fan-out (one input creating multiple outputs) scenarios, as well as mixed
@@ -88,8 +94,7 @@ When `RegistrationRequested` is received, the FSM validates that total outputs
 do not exceed inputs, then transitions to RegistrationSentState, emitting a
 `JoinRoundRequest` that aggregates all intents into a single server request.
 The join request carries boarding inputs, VTXO outputs, explicit forfeit
-outpoints, and leave outputs. The FSM can also resume existing intents on
-restart via `ResumeBoardingIntents`.
+outpoints, and leave outputs.
 
 ### RegistrationSent and RoundJoined States
 
@@ -279,14 +284,14 @@ sequenceDiagram
 
     Note over C,B: Intent Assembly Phase
     B->>A: UTXO confirmed
-    A->>C: BoardingUTXOConfirmed
+    A->>C: IntentPackage(boarding)
     Note over A: User specifies VTXO amounts
-    A->>C: VTXORequestsReceived
+    A->>C: IntentPackage(vtxos)
     opt Refresh / Leave
         V->>A: RefreshVTXORequest
-        A->>C: RefreshVTXORequest
+        A->>C: IntentPackage(forfeit + vtxo)
         V->>A: LeaveVTXORequest
-        A->>C: LeaveVTXORequest
+        A->>C: IntentPackage(forfeit + leave)
     end
 
     Note over C,B: Round Registration Phase
@@ -386,13 +391,8 @@ during checkpoint.
 ```mermaid
 stateDiagram-v2
     [*] --> Idle
-    Idle --> PendingRoundAssembly: BoardingUTXOConfirmed
-    Idle --> PendingRoundAssembly: VTXORequestsReceived
-    Idle --> PendingRoundAssembly: ResumeBoardingIntents
-    PendingRoundAssembly --> PendingRoundAssembly: BoardingUTXOConfirmed
-    PendingRoundAssembly --> PendingRoundAssembly: VTXORequestsReceived
-    PendingRoundAssembly --> PendingRoundAssembly: RefreshVTXORequest
-    PendingRoundAssembly --> PendingRoundAssembly: LeaveVTXORequest
+    Idle --> PendingRoundAssembly: IntentPackage
+    PendingRoundAssembly --> PendingRoundAssembly: IntentPackage
     PendingRoundAssembly --> RegistrationSent: RegistrationRequested
     RegistrationSent --> RoundJoined: RoundJoined
     RoundJoined --> CommitmentTxReceived: CommitmentTxBuilt
@@ -418,6 +418,7 @@ stateDiagram-v2
     ForfeitSignaturesCollecting --> ClientFailed: BoardingFailed
     InputSigSent --> ClientFailed: BoardingFailed
     InputSigSent --> RecoveryInitiated: RecoveryInitiated
+    ClientFailed --> Idle: IntentPackage (recovery)
 ```
 
 The diagram omits internal events for clarity, showing only major transitions
@@ -434,8 +435,10 @@ differ in how intents are assembled and how old VTXOs are handled.
 
 When a VTXO approaches its CSV expiry, the VTXO actor sends a
 `RefreshVTXORequest` to the round actor (either automatically or via manual
-`TriggerRefreshEvent`). The round FSM accumulates these in
-`PendingRoundAssembly.RefreshingVTXOs` alongside any boarding intents. During
+`TriggerRefreshEvent`). The round actor translates these into an
+`IntentPackage` with a forfeit request and corresponding VTXO output, which
+the FSM accumulates in `PendingRoundAssembly.Forfeits` and
+`PendingRoundAssembly.VTXOs` alongside any boarding intents. During
 registration, refresh requests are included in the `JoinRoundRequest` as
 forfeit outpoints with corresponding new VTXO outputs.
 
@@ -455,7 +458,7 @@ confirmed.
 
 Leave follows the same mechanics as refresh, but the output is an on-chain
 destination rather than a new VTXO. The user (or wallet) sends a
-`LeaveVTXORequest`, accumulated in `PendingRoundAssembly.LeavingVTXOs`. During
+`LeaveVTXORequest`, accumulated in `PendingRoundAssembly.Leaves`. During
 commitment transaction validation, the FSM verifies all leave outputs appear
 in the transaction via `validateLeaveOutputs()`.
 

--- a/round/actor.go
+++ b/round/actor.go
@@ -179,6 +179,11 @@ type RoundClientActor struct {
 	// env is the base FSM environment template containing all dependencies.
 	// Each new round FSM gets a copy with a fresh StartHeight.
 	env *ClientEnvironment
+
+	// outboxHandler processes OutboxRequest messages emitted by the
+	// FSM. The actor's askAndDrive loop routes requests here and
+	// feeds follow-up events back into the FSM.
+	outboxHandler OutboxHandler
 }
 
 // RoundClientConfig houses the configuration for a RoundClientActor.
@@ -294,6 +299,21 @@ func NewRoundClientActor(cfg *RoundClientConfig) fn.Result[*RoundClientActor] {
 	// Wire in the actor height query function so join-auth can anchor
 	// intent validity metadata to the current chain height at signing time.
 	actor.env.QueryBestHeight = actor.queryBestHeight
+
+	// Construct the default in-process outbox handler from the same
+	// dependencies the FSM environment uses. This handler performs
+	// I/O on behalf of FSM OutboxRequest messages.
+	actor.outboxHandler = &InProcessOutboxHandler{
+		RoundStore:             cfg.RoundStore,
+		VTXOStore:              cfg.VTXOStore,
+		Wallet:                 cfg.Wallet,
+		QueryBestHeight:        actor.queryBestHeight,
+		OperatorTerms:          cfg.OperatorTerms,
+		ChainParams:            cfg.ChainParams,
+		MaxOperatorFee:         cfg.MaxOperatorFee,
+		DisableJoinRequestAuth: cfg.DisableJoinRequestAuth,
+		Log:                    actorLog,
+	}
 
 	return fn.Ok(actor)
 }
@@ -583,32 +603,67 @@ func (a *RoundClientActor) registerCommitmentConfirmation(ctx context.Context,
 	}
 }
 
-// askEventAndProcessOutbox sends an event to the FSM and processes any
-// emitted outbox messages. This consolidates a common pattern throughout
-// the actor where FSM events trigger outbox processing.
-func (a *RoundClientActor) askEventAndProcessOutbox(
-	ctx context.Context, fsm *ClientStateMachine, event ClientEvent) error {
+// askAndDrive sends an event to the FSM and processes any emitted
+// outbox messages. OutboxRequest messages are routed through the
+// OutboxHandler, which performs the I/O and returns follow-up events
+// that are fed back into the FSM. Non-request outbox messages go
+// through the existing processOutbox path.
+//
+// The loop drains a breadth-first queue: each handler response may
+// produce new events, which may in turn produce more outbox requests.
+// The loop terminates when the queue is empty.
+func (a *RoundClientActor) askAndDrive(ctx context.Context,
+	fsm *ClientStateMachine, event ClientEvent) error {
 
-	future := fsm.AskEvent(ctx, event)
-	result := future.Await(ctx)
+	queue := []ClientEvent{event}
 
-	events, err := result.Unpack()
-	if err != nil {
-		return err
-	}
+	for len(queue) > 0 {
+		next := queue[0]
+		queue = queue[1:]
 
-	a.log.DebugS(ctx, "askEventAndProcessOutbox: FSM returned outbox events",
-		slog.Int("event_count", len(events)),
-		slog.String("input_event_type", fmt.Sprintf("%T", event)))
+		future := fsm.AskEvent(ctx, next)
+		result := future.Await(ctx)
 
-	if len(events) > 0 {
-		for i, e := range events {
-			a.log.DebugS(ctx, "askEventAndProcessOutbox: outbox event",
-				slog.Int("index", i),
-				slog.String("type", fmt.Sprintf("%T", e)))
+		outbox, err := result.Unpack()
+		if err != nil {
+			return err
 		}
-		if err := a.processOutbox(ctx, events); err != nil {
-			return fmt.Errorf("failed to process outbox: %w", err)
+
+		a.log.DebugS(ctx, "askAndDrive: FSM returned outbox",
+			slog.Int("outbox_count", len(outbox)),
+			slog.String("event_type",
+				fmt.Sprintf("%T", next)))
+
+		// Partition outbox into requests (handler) and regular
+		// messages (processOutbox).
+		var regular []ClientOutMsg
+		for _, msg := range outbox {
+			req, isReq := msg.(OutboxRequest)
+			if !isReq {
+				regular = append(regular, msg)
+				continue
+			}
+
+			// Route through the outbox handler. Follow-up
+			// events re-enter the FSM via the queue.
+			followUps, hErr := a.outboxHandler.Handle(
+				ctx, req,
+			)
+			if hErr != nil {
+				return fmt.Errorf("outbox handler "+
+					"(%T): %w", req, hErr)
+			}
+
+			queue = append(queue, followUps...)
+		}
+
+		if len(regular) > 0 {
+			if err := a.processOutbox(
+				ctx, regular,
+			); err != nil {
+				return fmt.Errorf("process outbox: %w",
+					err)
+			}
 		}
 	}
 
@@ -822,7 +877,7 @@ func (a *RoundClientActor) handleWalletBoardingConfirmed(ctx context.Context,
 	pkg := &IntentPackage{
 		Boarding: []BoardingIntent{intent},
 	}
-	err := a.askEventAndProcessOutbox(ctx, roundFSM.FSM, pkg)
+	err := a.askAndDrive(ctx, roundFSM.FSM, pkg)
 	if err != nil {
 		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 			"FSM error processing boarding confirmation: %w", err))
@@ -881,7 +936,7 @@ func (a *RoundClientActor) handleVTXORequests(ctx context.Context,
 		VTXOs: requests,
 	}
 
-	err := a.askEventAndProcessOutbox(ctx, roundFSM.FSM, pkg)
+	err := a.askAndDrive(ctx, roundFSM.FSM, pkg)
 	if err != nil {
 		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 			"FSM error processing VTXO requests: %w", err,
@@ -923,7 +978,7 @@ func (a *RoundClientActor) handleVTXORequestsReceived(ctx context.Context,
 	pkg := &IntentPackage{
 		VTXOs: req.Requests,
 	}
-	err := a.askEventAndProcessOutbox(ctx, roundFSM.FSM, pkg)
+	err := a.askAndDrive(ctx, roundFSM.FSM, pkg)
 	if err != nil {
 		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 			"FSM error processing VTXO requests: %w", err))
@@ -1003,7 +1058,7 @@ func (a *RoundClientActor) handleRoundJoined(ctx context.Context,
 		slog.Int("num_vtxo", len(event.AcceptedVTXOOutpoints)))
 
 	// Now process the event normally.
-	err := a.askEventAndProcessOutbox(ctx, roundFSM.FSM, event)
+	err := a.askAndDrive(ctx, roundFSM.FSM, event)
 	if err != nil {
 		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 			"FSM error processing RoundJoined: %w", err))
@@ -1079,7 +1134,7 @@ func (a *RoundClientActor) handleServerMessage(ctx context.Context,
 			slog.String("key", roundFSM.Key.KeyString()))
 	}
 
-	err := a.askEventAndProcessOutbox(ctx, roundFSM.FSM, msg.Message)
+	err := a.askAndDrive(ctx, roundFSM.FSM, msg.Message)
 	if err != nil {
 		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 			"FSM error processing server message: %w", err))
@@ -1185,7 +1240,7 @@ func (a *RoundClientActor) handleCancelRound(ctx context.Context,
 		Recoverable: true,
 	}
 
-	err := a.askEventAndProcessOutbox(ctx, targetFSM.FSM, cancelEvent)
+	err := a.askAndDrive(ctx, targetFSM.FSM, cancelEvent)
 	if err != nil {
 		a.log.WarnS(ctx, "Failed to cancel round", err)
 
@@ -1270,7 +1325,7 @@ func (a *RoundClientActor) handleConfirmation(ctx context.Context,
 		Confirmations: int32(event.Confirmations),
 	}
 
-	err := a.askEventAndProcessOutbox(ctx, roundFSM.FSM, confirmEvt)
+	err := a.askAndDrive(ctx, roundFSM.FSM, confirmEvt)
 	if err != nil {
 		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 			"FSM error processing commitment confirmation: %w", err))
@@ -1591,7 +1646,7 @@ func (a *RoundClientActor) handleRefreshVTXORequest(ctx context.Context,
 			buildVTXORequestFromRefresh(req),
 		},
 	}
-	err := a.askEventAndProcessOutbox(ctx, roundFSM.FSM, pkg)
+	err := a.askAndDrive(ctx, roundFSM.FSM, pkg)
 	if err != nil {
 		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 			"FSM error processing refresh package: %w", err,
@@ -1646,7 +1701,7 @@ func (a *RoundClientActor) handleLeaveVTXORequest(ctx context.Context,
 		}},
 		Leaves: []*types.LeaveRequest{{Output: req.Output}},
 	}
-	err := a.askEventAndProcessOutbox(ctx, roundFSM.FSM, pkg)
+	err := a.askAndDrive(ctx, roundFSM.FSM, pkg)
 	if err != nil {
 		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 			"FSM error processing leave package: %w", err,
@@ -1683,7 +1738,7 @@ func (a *RoundClientActor) handleForfeitSignatureResponse(ctx context.Context,
 
 	// Forward to round FSM. The FSM tracks collected signatures and emits
 	// a server message when all expected signatures are collected.
-	err := a.askEventAndProcessOutbox(ctx, roundFSM.FSM, resp)
+	err := a.askAndDrive(ctx, roundFSM.FSM, resp)
 	if err != nil {
 		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 			"FSM error processing forfeit signature: %w", err,

--- a/round/actor.go
+++ b/round/actor.go
@@ -780,6 +780,31 @@ func (a *RoundClientActor) handleWalletBoardingConfirmed(ctx context.Context,
 		slog.Int("amount", int(walletIntent.ChainInfo.Amount)),
 		slog.Int("conf_height", int(walletIntent.ChainInfo.ConfHeight)))
 
+	// Validate chain data that the FSM previously checked.
+	confTx := walletIntent.ChainInfo.ConfTx
+	if confTx == nil {
+		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
+			"boarding confirmation missing tx"))
+	}
+	if int(walletIntent.Outpoint.Index) >= len(confTx.TxOut) {
+		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
+			"invalid outpoint index %d for tx %s",
+			walletIntent.Outpoint.Index,
+			walletIntent.Outpoint.Hash))
+	}
+
+	// Build the boarding request from the wallet intent.
+	boardingReq := types.BoardingRequest{
+		Outpoint:    &walletIntent.Outpoint,
+		ClientKey:   walletIntent.Address.KeyDesc.PubKey,
+		OperatorKey: walletIntent.Address.OperatorKey,
+		ExitDelay:   walletIntent.Address.ExitDelay,
+	}
+	intent := BoardingIntent{
+		BoardingIntent: *walletIntent,
+		Request:        boardingReq,
+	}
+
 	// Find an existing assembling round (Idle or PendingRoundAssembly) or
 	// create a new one. This allows multiple boarding confirmations to
 	// accumulate in the same round.
@@ -793,21 +818,11 @@ func (a *RoundClientActor) handleWalletBoardingConfirmed(ctx context.Context,
 		}
 	}
 
-	// Create the FSM event from the wallet's confirmed intent. Wallet only
-	// notifies after min confs, so we set confirmations to 1. Include the
-	// Address and TxProof for building the Request.
-	confirmEvt := &BoardingUTXOConfirmed{
-		Outpoint:      walletIntent.Outpoint,
-		Address:       walletIntent.Address,
-		BlockHeight:   walletIntent.ChainInfo.ConfHeight,
-		BlockHash:     walletIntent.ChainInfo.ConfHash,
-		Confirmations: int32(a.cfg.OperatorTerms.MinConfirmations),
-		Tx:            walletIntent.ChainInfo.ConfTx,
-		TxProof:       walletIntent.ChainInfo.TxProof,
+	// Send the boarding intent to the FSM as an IntentPackage.
+	pkg := &IntentPackage{
+		Boarding: []BoardingIntent{intent},
 	}
-
-	// Drive the FSM with the confirmation event.
-	err := a.askEventAndProcessOutbox(ctx, roundFSM.FSM, confirmEvt)
+	err := a.askEventAndProcessOutbox(ctx, roundFSM.FSM, pkg)
 	if err != nil {
 		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 			"FSM error processing boarding confirmation: %w", err))
@@ -862,11 +877,11 @@ func (a *RoundClientActor) handleVTXORequests(ctx context.Context,
 		}
 	}
 
-	event := &VTXORequestsReceived{
-		Requests: requests,
+	pkg := &IntentPackage{
+		VTXOs: requests,
 	}
 
-	err := a.askEventAndProcessOutbox(ctx, roundFSM.FSM, event)
+	err := a.askEventAndProcessOutbox(ctx, roundFSM.FSM, pkg)
 	if err != nil {
 		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 			"FSM error processing VTXO requests: %w", err,
@@ -879,7 +894,7 @@ func (a *RoundClientActor) handleVTXORequests(ctx context.Context,
 }
 
 // handleVTXORequestsReceived forwards pre-built VTXO requests from other
-// actors into the pending round FSM.
+// actors into the pending round FSM via IntentPackage.
 func (a *RoundClientActor) handleVTXORequestsReceived(ctx context.Context,
 	req *VTXORequestsReceived) fn.Result[actormsg.RoundActorResp] {
 
@@ -905,7 +920,10 @@ func (a *RoundClientActor) handleVTXORequestsReceived(ctx context.Context,
 		}
 	}
 
-	err := a.askEventAndProcessOutbox(ctx, roundFSM.FSM, req)
+	pkg := &IntentPackage{
+		VTXOs: req.Requests,
+	}
+	err := a.askEventAndProcessOutbox(ctx, roundFSM.FSM, pkg)
 	if err != nil {
 		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 			"FSM error processing VTXO requests: %w", err))

--- a/round/actor.go
+++ b/round/actor.go
@@ -264,19 +264,13 @@ func NewRoundClientActor(cfg *RoundClientConfig) fn.Result[*RoundClientActor] {
 		actorLog = log
 	}
 
-	// Create base FSM environment template with direct interface
-	// assignments. The FSM will call lib functions directly when needed
-	// (e.g., lib.NewTreeSignerSession, signing helpers). StartHeight is set
-	// to 0 here and will be set per-round when FSMs are created.
+	// Create base FSM environment template with read-only config.
+	// All I/O (persistence, signing, key derivation) is handled by
+	// the OutboxHandler. StartHeight is set to 0 here and will be
+	// set per-round when FSMs are created.
 	env := &ClientEnvironment{
-		RoundStore:             cfg.RoundStore,
-		VTXOStore:              cfg.VTXOStore,
-		Wallet:                 cfg.Wallet,
-		OperatorTerms:          cfg.OperatorTerms,
-		ChainParams:            cfg.ChainParams,
-		MaxOperatorFee:         cfg.MaxOperatorFee,
-		Log:                    actorLog,
-		DisableJoinRequestAuth: cfg.DisableJoinRequestAuth,
+		OperatorTerms: cfg.OperatorTerms,
+		Log:           actorLog,
 	}
 
 	if err := ValidateDelayParameters(
@@ -295,21 +289,14 @@ func NewRoundClientActor(cfg *RoundClientConfig) fn.Result[*RoundClientActor] {
 		env:               env,
 	}
 
-	// The base env is used as a template for per-round FSM environments.
-	// Wire in the actor height query function so join-auth can anchor
-	// intent validity metadata to the current chain height at signing time.
-	actor.env.QueryBestHeight = actor.queryBestHeight
-
-	// Construct the default in-process outbox handler from the same
-	// dependencies the FSM environment uses. This handler performs
-	// I/O on behalf of FSM OutboxRequest messages.
+	// Construct the default in-process outbox handler with all I/O
+	// dependencies. The handler performs persistence, signing, and
+	// key derivation on behalf of FSM OutboxRequest messages.
 	actor.outboxHandler = &InProcessOutboxHandler{
 		RoundStore:             cfg.RoundStore,
 		VTXOStore:              cfg.VTXOStore,
 		Wallet:                 cfg.Wallet,
 		QueryBestHeight:        actor.queryBestHeight,
-		OperatorTerms:          cfg.OperatorTerms,
-		ChainParams:            cfg.ChainParams,
 		MaxOperatorFee:         cfg.MaxOperatorFee,
 		DisableJoinRequestAuth: cfg.DisableJoinRequestAuth,
 		Log:                    actorLog,
@@ -359,18 +346,9 @@ func (a *RoundClientActor) createRoundFSMFromDB(ctx context.Context,
 	fsmPrefix := roundID.LogPrefix()
 	fsmLogger := a.log.WithPrefix(fsmPrefix)
 
-	env := &ClientEnvironment{
-		RoundStore:             a.cfg.RoundStore,
-		VTXOStore:              a.cfg.VTXOStore,
-		Wallet:                 a.cfg.Wallet,
-		OperatorTerms:          a.cfg.OperatorTerms,
-		ChainParams:            a.cfg.ChainParams,
-		MaxOperatorFee:         a.cfg.MaxOperatorFee,
-		Log:                    fsmLogger,
-		StartHeight:            startHeight,
-		QueryBestHeight:        a.queryBestHeight,
-		DisableJoinRequestAuth: a.cfg.DisableJoinRequestAuth,
-	}
+	env := NewClientEnvironment(
+		a.cfg.OperatorTerms, fsmLogger, startHeight,
+	)
 	fsmCfg := ClientStateMachineCfg{
 		Logger:        fsmLogger,
 		ErrorReporter: newContextErrorReporter(ctx, fsmPrefix),
@@ -416,18 +394,9 @@ func (a *RoundClientActor) createNewRound(ctx context.Context) (*RoundFSM, error
 	fsmPrefix := tempKey.LogPrefix()
 	fsmLogger := a.log.WithPrefix(fsmPrefix)
 
-	env := &ClientEnvironment{
-		RoundStore:             a.cfg.RoundStore,
-		VTXOStore:              a.cfg.VTXOStore,
-		Wallet:                 a.cfg.Wallet,
-		OperatorTerms:          a.cfg.OperatorTerms,
-		ChainParams:            a.cfg.ChainParams,
-		MaxOperatorFee:         a.cfg.MaxOperatorFee,
-		Log:                    fsmLogger,
-		StartHeight:            startHeight,
-		QueryBestHeight:        a.queryBestHeight,
-		DisableJoinRequestAuth: a.cfg.DisableJoinRequestAuth,
-	}
+	env := NewClientEnvironment(
+		a.cfg.OperatorTerms, fsmLogger, startHeight,
+	)
 	fsmCfg := ClientStateMachineCfg{
 		Logger:        fsmLogger,
 		ErrorReporter: newContextErrorReporter(ctx, fsmPrefix),

--- a/round/events.go
+++ b/round/events.go
@@ -378,3 +378,22 @@ type SaveVTXOsFailed struct {
 }
 
 func (e *SaveVTXOsFailed) clientEventSealed() {}
+
+// SignBoardingInputsSucceeded is the follow-up event returned by the
+// outbox handler after signing all boarding inputs in the commitment
+// transaction.
+type SignBoardingInputsSucceeded struct {
+	// InputSigs are the signed boarding input signatures.
+	InputSigs []*types.BoardingInputSignature
+}
+
+func (e *SignBoardingInputsSucceeded) clientEventSealed() {}
+
+// SignBoardingInputsFailed is the follow-up event returned by the
+// outbox handler when boarding input signing fails.
+type SignBoardingInputsFailed struct {
+	// Error is the underlying signing error.
+	Error error
+}
+
+func (e *SignBoardingInputsFailed) clientEventSealed() {}

--- a/round/events.go
+++ b/round/events.go
@@ -349,6 +349,21 @@ func (e *ForfeitSignatureResponse) MessageType() string {
 	return "ForfeitSignatureResponse"
 }
 
+// CommitRoundStateSucceeded is the follow-up event returned by the
+// outbox handler after RoundStore.CommitState completes successfully.
+type CommitRoundStateSucceeded struct{}
+
+func (e *CommitRoundStateSucceeded) clientEventSealed() {}
+
+// CommitRoundStateFailed is the follow-up event returned by the outbox
+// handler when RoundStore.CommitState fails.
+type CommitRoundStateFailed struct {
+	// Error is the underlying persistence error.
+	Error error
+}
+
+func (e *CommitRoundStateFailed) clientEventSealed() {}
+
 // SaveVTXOsSucceeded is the follow-up event returned by the outbox
 // handler after VTXOStore.SaveVTXOs completes successfully.
 type SaveVTXOsSucceeded struct{}

--- a/round/events.go
+++ b/round/events.go
@@ -348,3 +348,18 @@ func (e *ForfeitSignatureResponse) RoundReceivable() {}
 func (e *ForfeitSignatureResponse) MessageType() string {
 	return "ForfeitSignatureResponse"
 }
+
+// SaveVTXOsSucceeded is the follow-up event returned by the outbox
+// handler after VTXOStore.SaveVTXOs completes successfully.
+type SaveVTXOsSucceeded struct{}
+
+func (e *SaveVTXOsSucceeded) clientEventSealed() {}
+
+// SaveVTXOsFailed is the follow-up event returned by the outbox
+// handler when VTXOStore.SaveVTXOs fails.
+type SaveVTXOsFailed struct {
+	// Error is the underlying persistence error.
+	Error error
+}
+
+func (e *SaveVTXOsFailed) clientEventSealed() {}

--- a/round/events.go
+++ b/round/events.go
@@ -12,9 +12,6 @@ import (
 	"github.com/lightninglabs/darepo-client/baselib/actor"
 	"github.com/lightninglabs/darepo-client/lib/tree"
 	"github.com/lightninglabs/darepo-client/lib/types"
-	"github.com/lightninglabs/darepo-client/wallet"
-	"github.com/lightninglabs/taproot-assets/proof"
-	fn "github.com/lightningnetwork/lnd/fn/v2"
 )
 
 // ClientEvent is a sealed interface for all events that can be processed by
@@ -37,79 +34,12 @@ type ClientOutMsg interface {
 	clientOutMsgSealed()
 }
 
-// ResumeBoardingIntents is emitted to instruct the FSM to resume attempting to
-// join a round with previously submitted and confirmed-but-not-adopted
-// intents.
-type ResumeBoardingIntents struct {
-	// Boarding contains the collected boarding intents to include in the
-	// next round.
-	Boarding []BoardingIntent
-
-	// VTXOs contains the collected VTXO requests to include in the next
-	// round.
-	VTXOs []types.VTXORequest
-
-	// Forfeits contains forfeited VTXOs to resume as inputs.
-	Forfeits []types.ForfeitRequest
-
-	// Leaves contains leave requests to resume as outputs.
-	Leaves []*types.LeaveRequest
-}
-
-// isEmpty returns true if there are no intents of any kind to resume.
-func (e *ResumeBoardingIntents) isEmpty() bool {
-	return len(e.Boarding) == 0 && len(e.VTXOs) == 0 &&
-		len(e.Forfeits) == 0 && len(e.Leaves) == 0
-}
-
-// logAttributes returns a map of attributes for logging purposes.
-func (e *ResumeBoardingIntents) logAttributes() []slog.Attr {
-	return []slog.Attr{
-		slog.Int("boarding_intents", len(e.Boarding)),
-		slog.Int("vtxo_requests", len(e.VTXOs)),
-		slog.Int("forfeits", len(e.Forfeits)),
-		slog.Int("leaves", len(e.Leaves)),
-	}
-}
-
-func (e *ResumeBoardingIntents) clientEventSealed() {}
-
-// BoardingUTXOConfirmed is emitted when the boarding UTXO has received
-// sufficient confirmations and is ready to be used for boarding.
-type BoardingUTXOConfirmed struct {
-	// Outpoint identifies the confirmed boarding UTXO.
-	Outpoint wire.OutPoint
-
-	// Address is the boarding address for this UTXO. Contains the keys,
-	// tapscript, and exit delay needed to build the Request.
-	Address wallet.BoardingAddress
-
-	// BlockHeight is the height at which the UTXO was confirmed.
-	BlockHeight int32
-
-	// BlockHash is the hash of the block containing the transaction.
-	BlockHash chainhash.Hash
-
-	// Confirmations is the number of confirmations the UTXO has.
-	Confirmations int32
-
-	// Tx is the confirmed transaction containing the boarding UTXO. This
-	// allows the FSM to extract output details without additional chain
-	// queries.
-	Tx *wire.MsgTx
-
-	// TxProof is the optional SPV proof for this boarding UTXO. Includes
-	// merkle proof, block header, and output construction details. None if
-	// the proof hasn't been constructed yet.
-	TxProof fn.Option[proof.TxProof]
-}
-
-func (e *BoardingUTXOConfirmed) clientEventSealed() {}
-
-// VTXORequestsReceived is emitted when the client submits VTXO requests that
-// should be included in the next round registration. This event can be sent
-// from both internal sources (e.g., wallet) and external actors (e.g., VTXO
-// actor requesting a new VTXO during refresh).
+// VTXORequestsReceived is an actor message carrying pre-built VTXO requests
+// from other actors (e.g., VTXO actor during refresh). The round actor
+// translates it into an IntentPackage before sending to the FSM.
+//
+// NOTE: This is NOT an FSM event — it does not implement clientEventSealed().
+// The actor converts it to IntentPackage{VTXOs: req.Requests}.
 type VTXORequestsReceived struct {
 	actor.BaseMessage
 
@@ -117,9 +47,6 @@ type VTXORequestsReceived struct {
 	// request.
 	Requests []types.VTXORequest
 }
-
-// clientEventSealed prevents external implementations.
-func (e *VTXORequestsReceived) clientEventSealed() {}
 
 // RoundReceivable implements actormsg.RoundReceivable marker interface.
 func (e *VTXORequestsReceived) RoundReceivable() {}
@@ -208,7 +135,8 @@ type ConnectorLeafInfo struct {
 
 	// VTXOAmount is the value of the VTXO being forfeited. The forfeit tx's
 	// penalty output must equal this amount. This field enables validation
-	// that prevents value theft by ensuring the correct amount is forfeited.
+	// that prevents value theft by ensuring the correct amount is
+	// forfeited.
 	VTXOAmount btcutil.Amount
 }
 
@@ -345,17 +273,22 @@ type RoundComplete struct{}
 
 func (e *RoundComplete) clientEventSealed() {}
 
-// IntentPackage is an atomic bundle of related intents submitted to the FSM
-// as a single event. The FSM unpacks the package and appends each item to its
-// respective pool. All items in a package are accepted together — the upstream
-// caller decides what must travel as a unit.
+// IntentPackage is the single FSM event for all pool additions. The actor
+// layer converts raw inputs (boarding confirmations, VTXO requests, refresh
+// requests, leave requests) into processed intents and sends them to the FSM
+// via this unified event. The FSM unpacks the package and appends each item
+// to its respective pool.
 //
 // Examples:
-//   - Refresh: {Forfeits: [1], VTXOs: [1]}
-//   - Leave:   {Forfeits: [1], Leaves: [1]}
+//   - Boarding:  {Boarding: [1], VTXOs: [1]}
+//   - Refresh:   {Forfeits: [1], VTXOs: [1]}
+//   - Leave:     {Forfeits: [1], Leaves: [1]}
 //   - Consolidate N-to-1: {Forfeits: [N], VTXOs: [1]}
-//   - Split 1-to-N: {Forfeits: [1], VTXOs: [N]}
+//   - Resume:    {Boarding: [N], VTXOs: [M], Forfeits: [K], Leaves: [L]}
 type IntentPackage struct {
+	// Boarding contains confirmed boarding intents to add to the pool.
+	Boarding []BoardingIntent
+
 	// Forfeits contains VTXOs being forfeited as round inputs. Each
 	// entry carries only the outpoint; the VTXO amount is looked up
 	// from VTXOStore at registration time.
@@ -370,8 +303,18 @@ type IntentPackage struct {
 
 // isEmpty returns true if the package contains no intents.
 func (e *IntentPackage) isEmpty() bool {
-	return len(e.Forfeits) == 0 && len(e.VTXOs) == 0 &&
-		len(e.Leaves) == 0
+	return len(e.Boarding) == 0 && len(e.Forfeits) == 0 &&
+		len(e.VTXOs) == 0 && len(e.Leaves) == 0
+}
+
+// logAttributes returns structured logging attributes for the package.
+func (e *IntentPackage) logAttributes() []slog.Attr {
+	return []slog.Attr{
+		slog.Int("boarding_intents", len(e.Boarding)),
+		slog.Int("vtxo_requests", len(e.VTXOs)),
+		slog.Int("forfeits", len(e.Forfeits)),
+		slog.Int("leaves", len(e.Leaves)),
+	}
 }
 
 // clientEventSealed prevents external implementations.

--- a/round/events.go
+++ b/round/events.go
@@ -397,3 +397,28 @@ type SignBoardingInputsFailed struct {
 }
 
 func (e *SignBoardingInputsFailed) clientEventSealed() {}
+
+// BuildRegistrationSucceeded is the follow-up event returned by the
+// outbox handler after successfully building the JoinRoundRequest.
+type BuildRegistrationSucceeded struct {
+	// JoinReq is the fully constructed join round request ready
+	// for the server.
+	JoinReq *JoinRoundRequest
+
+	// Intents are the validated intents for downstream use.
+	Intents Intents
+}
+
+func (e *BuildRegistrationSucceeded) clientEventSealed() {}
+
+// BuildRegistrationFailed is the follow-up event returned by the
+// outbox handler when registration building fails.
+type BuildRegistrationFailed struct {
+	// Error is the underlying error.
+	Error error
+
+	// Recoverable indicates whether the client can retry.
+	Recoverable bool
+}
+
+func (e *BuildRegistrationFailed) clientEventSealed() {}

--- a/round/events.go
+++ b/round/events.go
@@ -422,3 +422,26 @@ type BuildRegistrationFailed struct {
 }
 
 func (e *BuildRegistrationFailed) clientEventSealed() {}
+
+// CreateSigningSessionsSucceeded is the follow-up event returned by
+// the outbox handler after successfully creating MuSig2 signing
+// sessions for all VTXOs and collecting their nonces.
+type CreateSigningSessionsSucceeded struct {
+	// Sessions maps signer keys to their MuSig2 signing sessions.
+	Sessions map[SignerKey]*tree.SignerSession
+
+	// AllNonces maps signer keys to per-transaction MuSig2 public
+	// nonces from the created sessions.
+	AllNonces map[SignerKey]map[tree.TxID]tree.Musig2PubNonce
+}
+
+func (e *CreateSigningSessionsSucceeded) clientEventSealed() {}
+
+// CreateSigningSessionsFailed is the follow-up event returned by the
+// outbox handler when MuSig2 session creation fails.
+type CreateSigningSessionsFailed struct {
+	// Error is the underlying session creation error.
+	Error error
+}
+
+func (e *CreateSigningSessionsFailed) clientEventSealed() {}

--- a/round/fsm_environment.go
+++ b/round/fsm_environment.go
@@ -1,62 +1,29 @@
 package round
 
 import (
-	"context"
-
-	"github.com/btcsuite/btcd/btcutil"
-	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/lib/types"
 )
 
-// ClientEnvironment provides the client round interaction state machine with
-// access to external systems and storage. This follows the protofsm pattern
-// where the environment contains all dependencies needed for state transitions.
-//
-// Note: Boarding address and intent persistence is handled by the wallet actor.
-// The FSM only needs RoundStore for round checkpointing.
+// ClientEnvironment provides the client round interaction state machine
+// with read-only configuration for state transitions. All I/O side
+// effects (persistence, signing, key derivation) are handled by the
+// OutboxHandler, keeping the FSM pure and testable.
 type ClientEnvironment struct {
-	// RoundStore provides persistence for round coordination and
-	// checkpointing.
-	RoundStore RoundStore
-
-	// VTXOStore provides persistence for off-chain balance.
-	VTXOStore VTXOStore
-
-	// Wallet provides signing capabilities for round participation.
-	Wallet ClientWallet
-
-	// OperatorTerms contains the operator's parameters including sweep
-	// keys, fee targets, confirmation thresholds, and amount limits.
+	// OperatorTerms contains the operator's parameters including
+	// sweep keys, fee targets, confirmation thresholds, and amount
+	// limits.
 	OperatorTerms *types.OperatorTerms
-
-	// ChainParams are the Bitcoin network parameters.
-	ChainParams *chaincfg.Params
-
-	// MaxOperatorFee is the maximum fee the client is willing to pay to
-	// the operator per round. This is the difference between total input
-	// (boarding) amounts and total output (VTXO) amounts. If the fee would
-	// exceed this limit, registration is rejected.
-	MaxOperatorFee btcutil.Amount
 
 	// Log is the logger for FSM transitions and operations.
 	Log btclog.Logger
 
-	// StartHeight is the block height when the FSM was created. This is
-	// used as a HeightHint for confirmation registration, ensuring the
-	// chain backend scans from the correct starting point. This avoids
-	// missing confirmations if the transaction was broadcast before the
-	// registration request is processed.
+	// StartHeight is the block height when the FSM was created.
+	// This is used as a HeightHint for confirmation registration,
+	// ensuring the chain backend scans from the correct starting
+	// point. This avoids missing confirmations if the transaction
+	// was broadcast before the registration request is processed.
 	StartHeight uint32
-
-	// QueryBestHeight returns the current chain tip height. Join-auth uses
-	// this to anchor intent validity metadata at signing time.
-	QueryBestHeight func(context.Context) (uint32, error)
-
-	// DisableJoinRequestAuth skips BIP-322 join authorization
-	// generation. This should only be set in focused unit tests
-	// that exercise FSM mechanics without real signing.
-	DisableJoinRequestAuth bool
 }
 
 // Name returns the unique identifier for this FSM instance.
@@ -64,26 +31,17 @@ func (e *ClientEnvironment) Name() string {
 	return "round_fsm"
 }
 
-// NewClientEnvironment creates a new client environment with the provided
-// dependencies. The startHeight parameter should be the current block height
-// when the FSM is created, used as a HeightHint for confirmation
-// registration. The queryBestHeight callback is used by join-auth to fetch
-// signing-time chain tip height for intent validity anchoring.
-func NewClientEnvironment(roundStore RoundStore, vtxoStore VTXOStore,
-	wallet ClientWallet, terms *types.OperatorTerms,
-	chainParams *chaincfg.Params, maxOperatorFee btcutil.Amount,
-	logger btclog.Logger, startHeight uint32,
-	queryBestHeight func(context.Context) (uint32, error)) *ClientEnvironment {
+// NewClientEnvironment creates a new client environment with the
+// provided read-only configuration. All I/O dependencies (stores,
+// wallet, height queries) are handled by the OutboxHandler and are
+// not part of the FSM environment.
+func NewClientEnvironment(terms *types.OperatorTerms,
+	logger btclog.Logger,
+	startHeight uint32) *ClientEnvironment {
 
 	return &ClientEnvironment{
-		RoundStore:      roundStore,
-		VTXOStore:       vtxoStore,
-		Wallet:          wallet,
-		OperatorTerms:   terms,
-		ChainParams:     chainParams,
-		MaxOperatorFee:  maxOperatorFee,
-		Log:             logger,
-		StartHeight:     startHeight,
-		QueryBestHeight: queryBestHeight,
+		OperatorTerms: terms,
+		Log:           logger,
+		StartHeight:   startHeight,
 	}
 }

--- a/round/harness_test.go
+++ b/round/harness_test.go
@@ -1040,16 +1040,6 @@ func (h *boardingTestHarness) setupMockWalletForMuSig2() {
 	).Return(partialSig, nil)
 }
 
-func (h *boardingTestHarness) setupMockWalletForBoardingSigning() {
-	h.t.Helper()
-
-	sig := &schnorr.Signature{}
-
-	h.wallet.On("SignOutputRaw", mock.Anything, mock.Anything).Return(
-		sig, nil,
-	)
-}
-
 //nolint:unused
 func (h *boardingTestHarness) newNoncesSentState(
 	roundID RoundID, intents []BoardingIntent) *NoncesSentState {
@@ -1555,21 +1545,6 @@ func newRealSigningTestHarness(t *testing.T) *realSigningTestHarness {
 		clientSigner:        newRealMuSig2Signer(base.clientPrivKey),
 		operatorSigner:      newRealMuSig2Signer(base.operatorPrivKey),
 	}
-}
-
-// setupMockWalletForBoardingSigning configures the wallet mock to return valid
-// Schnorr signatures for boarding inputs, using the client's real private key
-// to ensure signature correctness.
-func (h *realSigningTestHarness) setupMockWalletForBoardingSigning() {
-	h.t.Helper()
-
-	msgHash := sha256.Sum256([]byte("test-boarding-sig"))
-	sig, err := schnorr.Sign(h.clientPrivKey, msgHash[:])
-	require.NoError(h.t, err)
-
-	h.wallet.On("SignOutputRaw", mock.Anything, mock.Anything).Return(
-		sig, nil,
-	)
 }
 
 // newTestBoardingIntentWithTapscript creates a boarding intent with real

--- a/round/harness_test.go
+++ b/round/harness_test.go
@@ -1050,27 +1050,6 @@ func (h *boardingTestHarness) setupMockWalletForBoardingSigning() {
 	)
 }
 
-func (h *boardingTestHarness) setupMockRoundStoreForCheckpoint() {
-	h.t.Helper()
-
-	h.roundStore.On(
-		"CommitState",
-		mock.Anything, // ctx
-		mock.Anything, // round
-		mock.Anything, // state
-	).Return(nil)
-}
-
-func (h *boardingTestHarness) setupMockVTXOStoreForSave() {
-	h.t.Helper()
-
-	h.vtxoStore.On(
-		"SaveVTXOs",
-		mock.Anything, // ctx
-		mock.Anything, // vtxos
-	).Return(nil)
-}
-
 //nolint:unused
 func (h *boardingTestHarness) newNoncesSentState(
 	roundID RoundID, intents []BoardingIntent) *NoncesSentState {
@@ -1591,14 +1570,6 @@ func (h *realSigningTestHarness) setupMockWalletForBoardingSigning() {
 	h.wallet.On("SignOutputRaw", mock.Anything, mock.Anything).Return(
 		sig, nil,
 	)
-}
-
-func (h *realSigningTestHarness) setupMockRoundStoreForCommit() {
-	h.t.Helper()
-
-	h.roundStore.On(
-		"CommitState", mock.Anything, mock.Anything, mock.Anything,
-	).Return(nil)
 }
 
 // newTestBoardingIntentWithTapscript creates a boarding intent with real

--- a/round/harness_test.go
+++ b/round/harness_test.go
@@ -1040,6 +1040,72 @@ func (h *boardingTestHarness) setupMockWalletForMuSig2() {
 	).Return(partialSig, nil)
 }
 
+// feedSigningSessionsSuccess simulates the outbox handler creating
+// MuSig2 signing sessions. It asserts the FSM is in
+// AwaitingSigningSessionsState, extracts the CreateSigningSessionsReq
+// from the outbox, creates real sessions using the mock wallet, and
+// sends CreateSigningSessionsSucceeded back to the FSM. Returns the
+// resulting NoncesSentState.
+func (h *boardingTestHarness) feedSigningSessionsSuccess() *NoncesSentState {
+	h.t.Helper()
+
+	_ = assertStateType[*AwaitingSigningSessionsState](h)
+
+	// Extract the request from outbox.
+	require.NotEmpty(h.t, h.outboxMessages)
+	var req *CreateSigningSessionsReq
+	for _, msg := range h.outboxMessages {
+		if r, ok := msg.(*CreateSigningSessionsReq); ok {
+			req = r
+
+			break
+		}
+	}
+	require.NotNil(h.t, req)
+
+	// Create real sessions using the mock wallet, same as the
+	// handler would.
+	sessions := make(map[SignerKey]*tree.SignerSession)
+	allNonces := make(
+		map[SignerKey]map[tree.TxID]tree.Musig2PubNonce,
+	)
+
+	for _, vtxoReq := range req.VTXORequests {
+		signerKey := NewSignerKey(vtxoReq.SigningKey.PubKey)
+		clientTree := req.ClientTrees[signerKey]
+		require.NotNil(h.t, clientTree)
+
+		sweepTweak := clientTree.SweepTapscriptRoot
+		batchOut := clientTree.BatchOutput
+		root := clientTree.Root
+
+		prevOutFetcher, err := root.PrevOutputFetcher(
+			batchOut,
+		)
+		require.NoError(h.t, err)
+
+		session, err := tree.NewSignerSession(
+			h.wallet, &vtxoReq.SigningKey,
+			sweepTweak, prevOutFetcher,
+			clientTree.Root,
+		)
+		require.NoError(h.t, err)
+
+		sessions[signerKey] = session
+		allNonces[signerKey] = session.GetNonces()
+	}
+
+	h.clearOutbox()
+
+	_, err := h.sendEvent(&CreateSigningSessionsSucceeded{
+		Sessions:  sessions,
+		AllNonces: allNonces,
+	})
+	require.NoError(h.t, err)
+
+	return assertStateType[*NoncesSentState](h)
+}
+
 //nolint:unused
 func (h *boardingTestHarness) newNoncesSentState(
 	roundID RoundID, intents []BoardingIntent) *NoncesSentState {

--- a/round/harness_test.go
+++ b/round/harness_test.go
@@ -354,17 +354,9 @@ func newTestHarness(t *testing.T) *boardingTestHarness {
 	// Use a mock start height for testing.
 	const testStartHeight uint32 = 100
 
-	// Default max operator fee for tests: 100,000 sats (0.001 BTC).
-	// This is generous to avoid test brittleness when multiple intents
-	// are used.
-	const defaultMaxOperatorFee = btcutil.Amount(100000)
-
 	env := NewClientEnvironment(
-		roundStore, vtxoStore, wallet, terms,
-		&chaincfg.RegressionNetParams, defaultMaxOperatorFee,
-		btclog.Disabled, testStartHeight, nil,
+		terms, btclog.Disabled, testStartHeight,
 	)
-	env.DisableJoinRequestAuth = true
 
 	// The join-round transition always derives a fresh identifier key,
 	// so wire up a default mock that returns a valid key descriptor.

--- a/round/harness_test.go
+++ b/round/harness_test.go
@@ -607,35 +607,6 @@ func generateTestKeyPair(t *testing.T) (*btcec.PrivateKey, *btcec.PublicKey) {
 	return privKey, privKey.PubKey()
 }
 
-func (h *boardingTestHarness) newBoardingUTXOConfirmedEvent(
-	intent BoardingIntent) *BoardingUTXOConfirmed {
-
-	h.t.Helper()
-
-	// Create a pkScript from the boarding address.
-	pkScript, err := txscript.PayToAddrScript(intent.Address.Address)
-	require.NoError(h.t, err)
-
-	tx := wire.NewMsgTx(2)
-	tx.AddTxOut(&wire.TxOut{
-		Value:    int64(intent.ChainInfo.Amount),
-		PkScript: pkScript,
-	})
-
-	var blockHash chainhash.Hash
-	_, err = rand.Read(blockHash[:])
-	require.NoError(h.t, err)
-
-	return &BoardingUTXOConfirmed{
-		Outpoint:      intent.Outpoint,
-		Address:       intent.Address,
-		BlockHeight:   intent.ChainInfo.ConfHeight,
-		BlockHash:     blockHash,
-		Confirmations: 6,
-		Tx:            tx,
-	}
-}
-
 const (
 	testExitDelay = uint32(144) // 1 day in blocks.
 )

--- a/round/join_auth.go
+++ b/round/join_auth.go
@@ -162,17 +162,35 @@ func computeTotalForfeitAmount(ctx context.Context,
 	return total, nil
 }
 
+// joinAuthDeps carries the dependencies needed by BIP-322 join-round
+// authorization functions. These were previously accessed via
+// *ClientEnvironment but are now passed explicitly from the outbox
+// handler, keeping the FSM environment free of I/O dependencies.
+type joinAuthDeps struct {
+	// Wallet provides signing and key derivation.
+	Wallet ClientWallet
+
+	// VTXOStore provides VTXO lookups for forfeit proof inputs.
+	VTXOStore VTXOStore
+
+	// QueryBestHeight returns the current chain tip height.
+	QueryBestHeight func(context.Context) (uint32, error)
+
+	// Log is the logger for join-auth operations.
+	Log btclog.Logger
+}
+
 // buildJoinRoundAuth creates the BIP-322 authorization payload for a
 // JoinRoundRequest. The identifier key must already be derived; this
 // function builds the canonical message, constructs proof-of-funds
 // inputs, and signs everything.
-func buildJoinRoundAuth(ctx context.Context, env *ClientEnvironment,
+func buildJoinRoundAuth(ctx context.Context, deps *joinAuthDeps,
 	identifierKeyDesc keychain.KeyDescriptor,
 	intents Intents, vtxoReqs []types.VTXORequest,
 	forfeitReqs []*types.ForfeitRequest,
 	leaveReqs []*types.LeaveRequest) (*types.JoinRoundAuth, error) {
 
-	log := env.Log
+	log := deps.Log
 	log.InfoS(ctx, "Building join round auth",
 		slog.Int("boarding_intent_count", len(intents.Boarding)),
 		slog.Int("vtxo_request_count", len(vtxoReqs)),
@@ -185,7 +203,7 @@ func buildJoinRoundAuth(ctx context.Context, env *ClientEnvironment,
 	// signing inputs carry the per-UTXO data (prevout, key,
 	// tapscript) needed to produce proof-of-funds witnesses.
 	joinReq, signingInputs, err := buildJoinRoundAuthRequest(
-		ctx, env, intents, vtxoReqs, forfeitReqs, leaveReqs,
+		ctx, deps, intents, vtxoReqs, forfeitReqs, leaveReqs,
 	)
 	if err != nil {
 		return nil, err
@@ -234,7 +252,7 @@ func buildJoinRoundAuth(ctx context.Context, env *ClientEnvironment,
 
 	// Query the chain tip at signing time and use that height as the
 	// lower bound for this auth intent.
-	validFrom, err := joinAuthValidFrom(ctx, env)
+	validFrom, err := joinAuthValidFrom(ctx, deps)
 	if err != nil {
 		return nil, err
 	}
@@ -264,7 +282,7 @@ func buildJoinRoundAuth(ctx context.Context, env *ClientEnvironment,
 		intentMessage,
 		messageChallenge,
 		&joinRoundBIP322Signer{
-			wallet:            env.Wallet,
+			wallet:            deps.Wallet,
 			identifierKeyDesc: identifierKeyDesc,
 			signingInputs:     signingInputs,
 			log:               log,
@@ -313,7 +331,7 @@ func buildJoinRoundAuth(ctx context.Context, env *ClientEnvironment,
 // canonical message encoding and returns the corresponding signing
 // inputs in the same order.
 func buildJoinRoundAuthRequest(ctx context.Context,
-	env *ClientEnvironment, intents Intents,
+	deps *joinAuthDeps, intents Intents,
 	vtxoReqs []types.VTXORequest,
 	forfeitReqs []*types.ForfeitRequest,
 	leaveReqs []*types.LeaveRequest) (*types.JoinRoundRequest,
@@ -361,7 +379,7 @@ func buildJoinRoundAuthRequest(ctx context.Context,
 		forfeitReq := forfeitReqs[i]
 		outpoint := *forfeitReq.VTXOOutpoint
 
-		vtxo, err := env.VTXOStore.GetVTXO(ctx, outpoint)
+		vtxo, err := deps.VTXOStore.GetVTXO(ctx, outpoint)
 		if err != nil {
 			return nil, nil, fmt.Errorf(
 				"forfeit auth input %s: %w",
@@ -633,19 +651,20 @@ func signJoinAuthMessageInput(wallet ClientWallet,
 // joinAuthValidFrom queries the current best height used as the lower
 // bound in join-auth intent validity metadata.
 func joinAuthValidFrom(ctx context.Context,
-	env *ClientEnvironment) (uint32, error) {
+	deps *joinAuthDeps) (uint32, error) {
 
-	if env == nil {
-		return 0, fmt.Errorf("client environment must be provided")
+	if deps == nil {
+		return 0, fmt.Errorf("join auth deps must be provided")
 	}
 
-	if env.QueryBestHeight == nil {
+	if deps.QueryBestHeight == nil {
 		return 0, fmt.Errorf(
-			"join auth valid-from query function must be provided",
+			"join auth valid-from query function " +
+				"must be provided",
 		)
 	}
 
-	height, err := env.QueryBestHeight(ctx)
+	height, err := deps.QueryBestHeight(ctx)
 	if err != nil {
 		return 0, fmt.Errorf(
 			"query join auth valid-from height: %w", err,

--- a/round/join_auth_test.go
+++ b/round/join_auth_test.go
@@ -132,9 +132,9 @@ type joinAuthTestFixture struct {
 	operatorPrivKey   *btcec.PrivateKey
 	identifierPrivKey *btcec.PrivateKey
 
-	// Signing wallet and environment.
+	// Signing wallet and join-auth dependencies.
 	wallet        *realSchnorrWallet
-	env           *ClientEnvironment
+	deps          *joinAuthDeps
 	signingHeight uint32
 }
 
@@ -162,11 +162,9 @@ func newJoinAuthTestFixture(t *testing.T) *joinAuthTestFixture {
 		testSigningHeight uint32 = 125
 	)
 
-	env := &ClientEnvironment{
-		Wallet:      signingWallet,
-		ChainParams: &chaincfg.RegressionNetParams,
-		Log:         btclog.Disabled,
-		StartHeight: testStartHeight,
+	deps := &joinAuthDeps{
+		Wallet: signingWallet,
+		Log:    btclog.Disabled,
 		QueryBestHeight: func(_ context.Context) (uint32, error) {
 			return testSigningHeight, nil
 		},
@@ -178,7 +176,7 @@ func newJoinAuthTestFixture(t *testing.T) *joinAuthTestFixture {
 		operatorPrivKey:   operatorPrivKey,
 		identifierPrivKey: identifierPrivKey,
 		wallet:            signingWallet,
-		env:               env,
+		deps:              deps,
 		signingHeight:     testSigningHeight,
 	}
 }
@@ -352,7 +350,7 @@ func TestBuildJoinRoundAuthBoardingOnly(t *testing.T) {
 	}
 
 	auth, err := buildJoinRoundAuth(
-		f.ctx, f.env, f.identifierKeyDesc(),
+		f.ctx, f.deps, f.identifierKeyDesc(),
 		intents, vtxoReqs, nil, nil,
 	)
 	require.NoError(t, err)
@@ -413,7 +411,7 @@ func TestBuildJoinRoundAuthRejectsTamperedSig(t *testing.T) {
 	}
 
 	auth, err := buildJoinRoundAuth(
-		f.ctx, f.env, f.identifierKeyDesc(),
+		f.ctx, f.deps, f.identifierKeyDesc(),
 		intents, vtxoReqs, nil, nil,
 	)
 	require.NoError(t, err)
@@ -477,7 +475,7 @@ func TestBuildJoinRoundAuthWithForfeit(t *testing.T) {
 
 	// Set up the VTXO store mock for forfeit lookups.
 	vtxoStore := &MockVTXOStore{}
-	f.env.VTXOStore = vtxoStore
+	f.deps.VTXOStore = vtxoStore
 
 	// Create a boarding intent.
 	boardingAmount := btcutil.Amount(50000)
@@ -536,7 +534,7 @@ func TestBuildJoinRoundAuthWithForfeit(t *testing.T) {
 	}}
 
 	auth, err := buildJoinRoundAuth(
-		f.ctx, f.env, f.identifierKeyDesc(),
+		f.ctx, f.deps, f.identifierKeyDesc(),
 		intents, vtxoReqs, forfeitReqs, nil,
 	)
 	require.NoError(t, err)
@@ -571,7 +569,7 @@ func TestBuildJoinRoundAuthForfeitOnly(t *testing.T) {
 	f := newJoinAuthTestFixture(t)
 
 	vtxoStore := &MockVTXOStore{}
-	f.env.VTXOStore = vtxoStore
+	f.deps.VTXOStore = vtxoStore
 
 	vtxoExpiry := uint32(288)
 	vtxoOutpoint := wire.OutPoint{
@@ -622,7 +620,7 @@ func TestBuildJoinRoundAuthForfeitOnly(t *testing.T) {
 	}}
 
 	auth, err := buildJoinRoundAuth(
-		f.ctx, f.env, f.identifierKeyDesc(),
+		f.ctx, f.deps, f.identifierKeyDesc(),
 		intents, vtxoReqs, forfeitReqs, nil,
 	)
 	require.NoError(t, err)
@@ -654,7 +652,7 @@ func TestBuildJoinRoundAuthRejectsNoInputs(t *testing.T) {
 	}
 
 	_, err := buildJoinRoundAuth(
-		f.ctx, f.env, f.identifierKeyDesc(),
+		f.ctx, f.deps, f.identifierKeyDesc(),
 		intents, vtxoReqs, nil, nil,
 	)
 	require.Error(t, err)
@@ -668,7 +666,7 @@ func TestBuildJoinRoundAuthRejectsMissingValidFromQuery(t *testing.T) {
 	t.Parallel()
 
 	f := newJoinAuthTestFixture(t)
-	f.env.QueryBestHeight = nil
+	f.deps.QueryBestHeight = nil
 
 	boardingAmount := btcutil.Amount(50000)
 	intent := f.newBoardingIntent(t, boardingAmount)
@@ -682,7 +680,7 @@ func TestBuildJoinRoundAuthRejectsMissingValidFromQuery(t *testing.T) {
 	}
 
 	_, err := buildJoinRoundAuth(
-		f.ctx, f.env, f.identifierKeyDesc(),
+		f.ctx, f.deps, f.identifierKeyDesc(),
 		intents, vtxoReqs, nil, nil,
 	)
 	require.Error(t, err)

--- a/round/outbox_handler.go
+++ b/round/outbox_handler.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/lib/types"
 )
@@ -97,6 +99,25 @@ type CommitRoundStateReq struct {
 
 func (r *CommitRoundStateReq) clientOutMsgSealed()  {}
 func (r *CommitRoundStateReq) outboxRequestSealed() {}
+
+// SignBoardingInputsReq requests signing of all boarding inputs in the
+// commitment transaction. The handler calls signBoardingInputs with
+// the Wallet and returns SignBoardingInputsSucceeded or
+// SignBoardingInputsFailed.
+type SignBoardingInputsReq struct {
+	// CommitmentTx is the PSBT containing the boarding inputs.
+	CommitmentTx *psbt.Packet
+
+	// Intents are the round intents containing boarding info.
+	Intents Intents
+
+	// BoardingInputIndices maps each boarding outpoint to its
+	// position in the commitment tx inputs.
+	BoardingInputIndices map[wire.OutPoint]int
+}
+
+func (r *SignBoardingInputsReq) clientOutMsgSealed()  {}
+func (r *SignBoardingInputsReq) outboxRequestSealed() {}
 
 // Compile-time assertion that InProcessOutboxHandler implements
 // OutboxHandler.

--- a/round/outbox_handler.go
+++ b/round/outbox_handler.go
@@ -80,8 +80,23 @@ type SaveVTXOsReq struct {
 	VTXOs []*ClientVTXO
 }
 
-func (r *SaveVTXOsReq) clientOutMsgSealed()   {}
-func (r *SaveVTXOsReq) outboxRequestSealed()  {}
+func (r *SaveVTXOsReq) clientOutMsgSealed()  {}
+func (r *SaveVTXOsReq) outboxRequestSealed() {}
+
+// CommitRoundStateReq requests atomic persistence of round data and
+// FSM state at the "point of no return". The handler calls
+// RoundStore.CommitState and returns CommitRoundStateSucceeded or
+// CommitRoundStateFailed.
+type CommitRoundStateReq struct {
+	// Round is the round data to persist.
+	Round *Round
+
+	// State is the FSM state to persist alongside the round.
+	State ClientState
+}
+
+func (r *CommitRoundStateReq) clientOutMsgSealed()  {}
+func (r *CommitRoundStateReq) outboxRequestSealed() {}
 
 // Compile-time assertion that InProcessOutboxHandler implements
 // OutboxHandler.

--- a/round/outbox_handler.go
+++ b/round/outbox_handler.go
@@ -3,6 +3,8 @@ package round
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"slices"
 
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil"
@@ -164,6 +166,9 @@ func (h *InProcessOutboxHandler) Handle(ctx context.Context,
 	case *SignBoardingInputsReq:
 		return h.handleSignBoardingInputs(ctx, req)
 
+	case *BuildRegistrationReq:
+		return h.handleBuildRegistration(ctx, req)
+
 	default:
 		return nil, fmt.Errorf("unhandled outbox request "+
 			"type: %T", msg)
@@ -220,6 +225,221 @@ func (h *InProcessOutboxHandler) handleSignBoardingInputs(
 
 	return []ClientEvent{
 		&SignBoardingInputsSucceeded{InputSigs: sigs},
+	}, nil
+}
+
+// handleBuildRegistration performs all I/O needed to construct a
+// JoinRoundRequest: forfeit amount lookups, amount validation, key
+// derivation, and BIP-322 authorization signing. Returns
+// BuildRegistrationSucceeded with the complete request or
+// BuildRegistrationFailed if any step fails.
+//
+//nolint:funlen
+func (h *InProcessOutboxHandler) handleBuildRegistration(
+	ctx context.Context,
+	req *BuildRegistrationReq) ([]ClientEvent, error) {
+
+	// Calculate total input amount from all boarding intents.
+	var totalInput btcutil.Amount
+	for _, boarding := range req.Boarding {
+		totalInput += boarding.ChainInfo.Amount
+	}
+
+	// Include all forfeited VTXO amounts as inputs. This
+	// requires VTXOStore lookups to resolve each outpoint to
+	// its persisted amount.
+	forfeitAmt, err := computeTotalForfeitAmount(
+		ctx, h.VTXOStore, req.Forfeits,
+	)
+	if err != nil {
+		return []ClientEvent{
+			&BuildRegistrationFailed{
+				Error: fmt.Errorf(
+					"compute forfeit amount: %w",
+					err,
+				),
+				Recoverable: true,
+			},
+		}, nil
+	}
+	totalInput += forfeitAmt
+
+	// Calculate total output amount from all VTXO requests.
+	var totalOutput btcutil.Amount
+	for _, vtxo := range req.VTXOs {
+		totalOutput += vtxo.Amount
+	}
+
+	// Include leave amounts as requested on-chain outputs.
+	for i, leaveReq := range req.Leaves {
+		if leaveReq.Output == nil {
+			return []ClientEvent{
+				&BuildRegistrationFailed{
+					Error: fmt.Errorf(
+						"leave request %d has "+
+							"nil output", i,
+					),
+					Recoverable: true,
+				},
+			}, nil
+		}
+
+		totalOutput += btcutil.Amount(
+			leaveReq.Output.Value,
+		)
+	}
+
+	// Validate that we have outputs to create.
+	if totalOutput == 0 {
+		return []ClientEvent{
+			&BuildRegistrationFailed{
+				Error: fmt.Errorf(
+					"total VTXO output is zero",
+				),
+				Recoverable: true,
+			},
+		}, nil
+	}
+
+	// Validate that outputs don't exceed inputs.
+	if totalOutput > totalInput {
+		return []ClientEvent{
+			&BuildRegistrationFailed{
+				Error: fmt.Errorf(
+					"total output (%d) exceeds "+
+						"total input (%d)",
+					totalOutput, totalInput,
+				),
+				Recoverable: true,
+			},
+		}, nil
+	}
+
+	// Calculate the implicit operator fee (inputs - outputs)
+	// and validate it's within acceptable limits.
+	operatorFee := totalInput - totalOutput
+	if operatorFee > h.MaxOperatorFee {
+		return []ClientEvent{
+			&BuildRegistrationFailed{
+				Error: fmt.Errorf(
+					"operator fee (%d) exceeds "+
+						"max allowed (%d)",
+					operatorFee,
+					h.MaxOperatorFee,
+				),
+				Recoverable: true,
+			},
+		}, nil
+	}
+
+	h.Log.InfoS(ctx, "Amount validation passed",
+		btclog.Fmt("total_input", "%v", totalInput),
+		btclog.Fmt("total_output", "%v", totalOutput),
+		btclog.Fmt("operator_fee", "%v", operatorFee))
+
+	// Build boarding requests from intents.
+	boardingReqs := make(
+		[]types.BoardingRequest, 0, len(req.Boarding),
+	)
+	for _, intent := range req.Boarding {
+		boardingReqs = append(boardingReqs, intent.Request)
+	}
+
+	vtxoReqs := slices.Clone(req.VTXOs)
+
+	// Build sorted forfeit requests from the decoupled pool.
+	forfeitReqs, err := sortedForfeitRequests(req.Forfeits)
+	if err != nil {
+		return []ClientEvent{
+			&BuildRegistrationFailed{
+				Error:       err,
+				Recoverable: true,
+			},
+		}, nil
+	}
+
+	leaveReqs := slices.Clone(req.Leaves)
+
+	// Build Intents with all pools for downstream validation.
+	intents := Intents{
+		Boarding: slices.Clone(req.Boarding),
+		VTXOs:    vtxoReqs,
+		Leaves:   leaveReqs,
+		Forfeits: slices.Clone(req.Forfeits),
+	}
+
+	// Derive a fresh identifier key for the join-request
+	// authorization challenge.
+	identifierKeyDesc, err := deriveJoinAuthIdentifierKey(
+		ctx, h.Wallet,
+	)
+	if err != nil {
+		return []ClientEvent{
+			&BuildRegistrationFailed{
+				Error: fmt.Errorf(
+					"derive join auth identifier: %w",
+					err,
+				),
+				Recoverable: true,
+			},
+		}, nil
+	}
+
+	idPub := identifierKeyDesc.PubKey
+
+	// When auth is enabled, produce a BIP-322 proof that binds
+	// the request contents to the identifier key. The functions
+	// in join_auth.go take *ClientEnvironment, so we construct
+	// a temporary env from handler fields.
+	var joinAuth *types.JoinRoundAuth
+	if !h.DisableJoinRequestAuth {
+		env := &ClientEnvironment{
+			VTXOStore:       h.VTXOStore,
+			Wallet:          h.Wallet,
+			QueryBestHeight: h.QueryBestHeight,
+			Log:             h.Log,
+			OperatorTerms:   h.OperatorTerms,
+			ChainParams:     h.ChainParams,
+		}
+
+		auth, err := buildJoinRoundAuth(
+			ctx, env, identifierKeyDesc, intents,
+			vtxoReqs, forfeitReqs, leaveReqs,
+		)
+		if err != nil {
+			return []ClientEvent{
+				&BuildRegistrationFailed{
+					Error: fmt.Errorf(
+						"join auth: %w", err,
+					),
+					Recoverable: true,
+				},
+			}, nil
+		}
+
+		joinAuth = auth
+	}
+
+	h.Log.InfoS(ctx, "Registration built",
+		slog.Int("boarding_requests", len(boardingReqs)),
+		slog.Int("vtxo_requests", len(vtxoReqs)),
+		slog.Int("forfeit_requests", len(forfeitReqs)),
+		slog.Int("leave_requests", len(leaveReqs)))
+
+	joinReq := &JoinRoundRequest{
+		BoardingRequests: boardingReqs,
+		VTXORequests:     vtxoReqs,
+		ForfeitRequests:  forfeitReqs,
+		LeaveRequests:    leaveReqs,
+		Identifier:       idPub,
+		Auth:             joinAuth,
+	}
+
+	return []ClientEvent{
+		&BuildRegistrationSucceeded{
+			JoinReq: joinReq,
+			Intents: intents,
+		},
 	}, nil
 }
 

--- a/round/outbox_handler.go
+++ b/round/outbox_handler.go
@@ -111,6 +111,9 @@ func (h *InProcessOutboxHandler) Handle(ctx context.Context,
 	case *SaveVTXOsReq:
 		return h.handleSaveVTXOs(ctx, req)
 
+	case *CommitRoundStateReq:
+		return h.handleCommitRoundState(ctx, req)
+
 	default:
 		return nil, fmt.Errorf("unhandled outbox request "+
 			"type: %T", msg)
@@ -129,4 +132,21 @@ func (h *InProcessOutboxHandler) handleSaveVTXOs(ctx context.Context,
 	}
 
 	return []ClientEvent{&SaveVTXOsSucceeded{}}, nil
+}
+
+// handleCommitRoundState persists round data and FSM state atomically
+// via RoundStore.CommitState.
+func (h *InProcessOutboxHandler) handleCommitRoundState(
+	ctx context.Context,
+	req *CommitRoundStateReq) ([]ClientEvent, error) {
+
+	if err := h.RoundStore.CommitState(
+		ctx, req.Round, req.State,
+	); err != nil {
+		return []ClientEvent{
+			&CommitRoundStateFailed{Error: err},
+		}, nil
+	}
+
+	return []ClientEvent{&CommitRoundStateSucceeded{}}, nil
 }

--- a/round/outbox_handler.go
+++ b/round/outbox_handler.go
@@ -103,6 +103,29 @@ type CommitRoundStateReq struct {
 func (r *CommitRoundStateReq) clientOutMsgSealed()  {}
 func (r *CommitRoundStateReq) outboxRequestSealed() {}
 
+// BuildRegistrationReq requests construction of the JoinRoundRequest
+// including forfeit amount computation, amount validation, key
+// derivation, and BIP-322 authorization. The handler performs all
+// I/O (VTXOStore lookups, Wallet key derivation, Wallet signing,
+// QueryBestHeight) and returns BuildRegistrationSucceeded or
+// BuildRegistrationFailed.
+type BuildRegistrationReq struct {
+	// Boarding are the confirmed boarding intents.
+	Boarding []BoardingIntent
+
+	// VTXOs are the VTXO output requests.
+	VTXOs []types.VTXORequest
+
+	// Forfeits are the forfeit input requests.
+	Forfeits []types.ForfeitRequest
+
+	// Leaves are the on-chain exit output requests.
+	Leaves []*types.LeaveRequest
+}
+
+func (r *BuildRegistrationReq) clientOutMsgSealed()  {}
+func (r *BuildRegistrationReq) outboxRequestSealed() {}
+
 // SignBoardingInputsReq requests signing of all boarding inputs in the
 // commitment transaction. The handler calls signBoardingInputs with
 // the Wallet and returns SignBoardingInputsSucceeded or

--- a/round/outbox_handler.go
+++ b/round/outbox_handler.go
@@ -187,6 +187,9 @@ func (h *InProcessOutboxHandler) Handle(ctx context.Context,
 	case *BuildRegistrationReq:
 		return h.handleBuildRegistration(ctx, req)
 
+	case *CreateSigningSessionsReq:
+		return h.handleCreateSigningSessions(ctx, req)
+
 	default:
 		return nil, fmt.Errorf("unhandled outbox request "+
 			"type: %T", msg)
@@ -457,6 +460,94 @@ func (h *InProcessOutboxHandler) handleBuildRegistration(
 		&BuildRegistrationSucceeded{
 			JoinReq: joinReq,
 			Intents: intents,
+		},
+	}, nil
+}
+
+// handleCreateSigningSessions creates MuSig2 signing sessions for
+// each VTXO using the Wallet, collects nonces from each session, and
+// returns CreateSigningSessionsSucceeded or
+// CreateSigningSessionsFailed.
+func (h *InProcessOutboxHandler) handleCreateSigningSessions(
+	_ context.Context,
+	req *CreateSigningSessionsReq) ([]ClientEvent, error) {
+
+	musig2Sessions := make(map[SignerKey]*tree.SignerSession)
+
+	for _, vtxoReq := range req.VTXORequests {
+		signerKey := NewSignerKey(
+			vtxoReq.SigningKey.PubKey,
+		)
+
+		// Get the client tree for this signer key. The sweep
+		// tweak and batch output are properties of the tree
+		// that were set when the operator built it.
+		clientTree := req.ClientTrees[signerKey]
+		if clientTree == nil {
+			return []ClientEvent{
+				&CreateSigningSessionsFailed{
+					Error: fmt.Errorf(
+						"no client tree for "+
+							"signer key %x",
+						signerKey[:],
+					),
+				},
+			}, nil
+		}
+
+		sweepTweak := clientTree.SweepTapscriptRoot
+		batchOut := clientTree.BatchOutput
+		root := clientTree.Root
+
+		prevOutFetcher, err := root.PrevOutputFetcher(
+			batchOut,
+		)
+		if err != nil {
+			return []ClientEvent{
+				&CreateSigningSessionsFailed{
+					Error: fmt.Errorf(
+						"prev output fetcher "+
+							"for signer %x: %w",
+						signerKey[:], err,
+					),
+				},
+			}, nil
+		}
+
+		session, err := tree.NewSignerSession(
+			h.Wallet, &vtxoReq.SigningKey,
+			sweepTweak, prevOutFetcher,
+			clientTree.Root,
+		)
+		if err != nil {
+			return []ClientEvent{
+				&CreateSigningSessionsFailed{
+					Error: fmt.Errorf(
+						"create signing session "+
+							"for signer %x: %w",
+						signerKey[:], err,
+					),
+				},
+			}, nil
+		}
+
+		musig2Sessions[signerKey] = session
+	}
+
+	// Collect nonces from each session. The server expects
+	// nonces grouped by signer key first, then by txid.
+	allNonces := make(
+		map[SignerKey]map[tree.TxID]tree.Musig2PubNonce,
+	)
+	for signerKey, session := range musig2Sessions {
+		nonces := session.GetNonces()
+		allNonces[signerKey] = nonces
+	}
+
+	return []ClientEvent{
+		&CreateSigningSessionsSucceeded{
+			Sessions:  musig2Sessions,
+			AllNonces: allNonces,
 		},
 	}, nil
 }

--- a/round/outbox_handler.go
+++ b/round/outbox_handler.go
@@ -1,0 +1,88 @@
+package round
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/lib/types"
+)
+
+// OutboxRequest is a sealed marker interface for outbox messages that
+// represent I/O side-effect requests. These are emitted by FSM
+// transitions and handled by the OutboxHandler, which performs the
+// actual I/O and returns follow-up ClientEvents to feed back into the
+// FSM. Non-request outbox messages (server messages, notifications)
+// continue through the existing processOutbox path.
+type OutboxRequest interface {
+	ClientOutMsg
+
+	// outboxRequestSealed prevents external implementations,
+	// ensuring only this package can define request types.
+	outboxRequestSealed()
+}
+
+// OutboxHandler processes OutboxRequest messages emitted by the FSM.
+// Each request represents an I/O side effect (persistence, signing,
+// key derivation) that was previously performed inline during state
+// transitions. The handler performs the I/O and returns follow-up
+// ClientEvent(s) that the event pump feeds back into the FSM.
+type OutboxHandler interface {
+	// Handle processes an OutboxRequest and returns zero or more
+	// follow-up events. The caller feeds these events back into the
+	// FSM via the askAndDrive event pump. An error return indicates
+	// a fatal handler failure.
+	Handle(ctx context.Context,
+		msg OutboxRequest) ([]ClientEvent, error)
+}
+
+// InProcessOutboxHandler performs I/O side effects in the same process
+// using the provided stores and wallet. This is the default handler
+// wired by the actor; tests may substitute a mock.
+type InProcessOutboxHandler struct {
+	// RoundStore provides round checkpoint persistence.
+	RoundStore RoundStore
+
+	// VTXOStore provides VTXO persistence and lookup.
+	VTXOStore VTXOStore
+
+	// Wallet provides signing and key derivation.
+	Wallet ClientWallet
+
+	// QueryBestHeight returns the current chain tip height.
+	QueryBestHeight func(context.Context) (uint32, error)
+
+	// OperatorTerms contains the operator's parameters.
+	OperatorTerms *types.OperatorTerms
+
+	// ChainParams are the Bitcoin network parameters.
+	ChainParams *chaincfg.Params
+
+	// MaxOperatorFee is the maximum acceptable operator fee.
+	MaxOperatorFee btcutil.Amount
+
+	// DisableJoinRequestAuth skips BIP-322 join authorization in
+	// tests.
+	DisableJoinRequestAuth bool
+
+	// Log is the logger for handler operations.
+	Log btclog.Logger
+}
+
+// Compile-time assertion that InProcessOutboxHandler implements
+// OutboxHandler.
+var _ OutboxHandler = (*InProcessOutboxHandler)(nil)
+
+// Handle dispatches an OutboxRequest to the appropriate handler
+// method. Unrecognized request types return an error.
+func (h *InProcessOutboxHandler) Handle(ctx context.Context,
+	msg OutboxRequest) ([]ClientEvent, error) {
+
+	switch msg.(type) {
+	default:
+		return nil, fmt.Errorf("unhandled outbox request "+
+			"type: %T", msg)
+	}
+}

--- a/round/outbox_handler.go
+++ b/round/outbox_handler.go
@@ -92,9 +92,26 @@ var _ OutboxHandler = (*InProcessOutboxHandler)(nil)
 func (h *InProcessOutboxHandler) Handle(ctx context.Context,
 	msg OutboxRequest) ([]ClientEvent, error) {
 
-	switch msg.(type) {
+	switch req := msg.(type) {
+	case *SaveVTXOsReq:
+		return h.handleSaveVTXOs(ctx, req)
+
 	default:
 		return nil, fmt.Errorf("unhandled outbox request "+
 			"type: %T", msg)
 	}
+}
+
+// handleSaveVTXOs persists VTXOs via VTXOStore and returns the
+// appropriate follow-up event.
+func (h *InProcessOutboxHandler) handleSaveVTXOs(ctx context.Context,
+	req *SaveVTXOsReq) ([]ClientEvent, error) {
+
+	if err := h.VTXOStore.SaveVTXOs(ctx, req.VTXOs); err != nil {
+		return []ClientEvent{
+			&SaveVTXOsFailed{Error: err},
+		}, nil
+	}
+
+	return []ClientEvent{&SaveVTXOsSucceeded{}}, nil
 }

--- a/round/outbox_handler.go
+++ b/round/outbox_handler.go
@@ -71,6 +71,18 @@ type InProcessOutboxHandler struct {
 	Log btclog.Logger
 }
 
+// SaveVTXOsReq requests persistence of newly created VTXOs after a
+// round's commitment transaction confirms. The handler calls
+// VTXOStore.SaveVTXOs and returns SaveVTXOsSucceeded or
+// SaveVTXOsFailed.
+type SaveVTXOsReq struct {
+	// VTXOs are the client VTXOs to persist.
+	VTXOs []*ClientVTXO
+}
+
+func (r *SaveVTXOsReq) clientOutMsgSealed()   {}
+func (r *SaveVTXOsReq) outboxRequestSealed()  {}
+
 // Compile-time assertion that InProcessOutboxHandler implements
 // OutboxHandler.
 var _ OutboxHandler = (*InProcessOutboxHandler)(nil)

--- a/round/outbox_handler.go
+++ b/round/outbox_handler.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/lib/scripts"
 	"github.com/lightninglabs/darepo-client/lib/types"
 )
 
@@ -135,6 +138,9 @@ func (h *InProcessOutboxHandler) Handle(ctx context.Context,
 	case *CommitRoundStateReq:
 		return h.handleCommitRoundState(ctx, req)
 
+	case *SignBoardingInputsReq:
+		return h.handleSignBoardingInputs(ctx, req)
+
 	default:
 		return nil, fmt.Errorf("unhandled outbox request "+
 			"type: %T", msg)
@@ -170,4 +176,120 @@ func (h *InProcessOutboxHandler) handleCommitRoundState(
 	}
 
 	return []ClientEvent{&CommitRoundStateSucceeded{}}, nil
+}
+
+// handleSignBoardingInputs signs all boarding inputs in the
+// commitment transaction using the wallet and returns the
+// appropriate follow-up event.
+func (h *InProcessOutboxHandler) handleSignBoardingInputs(
+	_ context.Context,
+	req *SignBoardingInputsReq) ([]ClientEvent, error) {
+
+	sigs, err := signBoardingInputs(
+		h.Wallet, req.CommitmentTx, req.Intents,
+		req.BoardingInputIndices,
+	)
+	if err != nil {
+		return []ClientEvent{
+			&SignBoardingInputsFailed{Error: err},
+		}, nil
+	}
+
+	return []ClientEvent{
+		&SignBoardingInputsSucceeded{InputSigs: sigs},
+	}, nil
+}
+
+// signBoardingInputs signs all boarding inputs for a commitment
+// transaction. It builds the PrevOutputFetcher, sigHashes, and
+// generates Schnorr signatures for each boarding intent's input.
+func signBoardingInputs(wallet ClientWallet,
+	commitmentTx *psbt.Packet, intents Intents,
+	boardingInputIndices map[wire.OutPoint]int,
+) ([]*types.BoardingInputSignature, error) {
+
+	tx := commitmentTx.UnsignedTx
+
+	// Build a PrevOutputFetcher from ALL PSBT inputs. Taproot
+	// sighash (BIP341) requires prevout info for all inputs.
+	prevOuts := make(map[wire.OutPoint]*wire.TxOut)
+	for i, pIn := range commitmentTx.Inputs {
+		if pIn.WitnessUtxo == nil {
+			return nil, fmt.Errorf("PSBT input %d "+
+				"missing WitnessUtxo", i)
+		}
+		outpoint := tx.TxIn[i].PreviousOutPoint
+		prevOuts[outpoint] = pIn.WitnessUtxo
+	}
+	prevOutFetcher := txscript.NewMultiPrevOutFetcher(prevOuts)
+	sigHashes := txscript.NewTxSigHashes(tx, prevOutFetcher)
+
+	// Build structured boarding input signatures for each
+	// intent.
+	var boardingInputSigs []*types.BoardingInputSignature
+	for _, boardingIntent := range intents.Boarding {
+		outpoint := boardingIntent.Request.Outpoint
+		inputIdx, found := boardingInputIndices[*outpoint]
+		if !found {
+			return nil, fmt.Errorf("no input index "+
+				"found for boarding outpoint %s",
+				outpoint)
+		}
+
+		spendInfo, err := scripts.NewVTXOSpendInfo(
+			boardingIntent.Address.Tapscript,
+			scripts.VTXOCollabPathLeaf,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		chainInfo := boardingIntent.ChainInfo
+		addr := boardingIntent.Address.Address
+		amt := chainInfo.Amount
+
+		// Use PayToAddrScript to get the full pkScript
+		// with OP_1 OP_PUSHBYTES_32 prefix for P2TR
+		// addresses. ScriptAddress() only returns the
+		// 32-byte witness program.
+		pkScript, err := txscript.PayToAddrScript(addr)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"pay to addr script: %w", err,
+			)
+		}
+
+		output := &wire.TxOut{
+			Value:    int64(amt),
+			PkScript: pkScript,
+		}
+
+		signature, err := scripts.SignVTXOCollabInput(
+			wallet, tx, inputIdx, spendInfo,
+			&boardingIntent.Address.KeyDesc, output,
+			sigHashes, prevOutFetcher,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to sign "+
+				"boarding input %d: %w",
+				inputIdx, err)
+		}
+
+		schnorrSig, ok := signature.(*schnorr.Signature)
+		if !ok {
+			return nil, fmt.Errorf("signature is not " +
+				"a schnorr signature")
+		}
+
+		inputSig := &types.BoardingInputSignature{
+			InputIndex:      inputIdx,
+			Outpoint:        *outpoint,
+			ClientSignature: schnorrSig,
+		}
+		boardingInputSigs = append(
+			boardingInputSigs, inputSig,
+		)
+	}
+
+	return boardingInputSigs, nil
 }

--- a/round/outbox_handler.go
+++ b/round/outbox_handler.go
@@ -9,7 +9,6 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/psbt"
-	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btclog/v2"
@@ -61,12 +60,6 @@ type InProcessOutboxHandler struct {
 
 	// QueryBestHeight returns the current chain tip height.
 	QueryBestHeight func(context.Context) (uint32, error)
-
-	// OperatorTerms contains the operator's parameters.
-	OperatorTerms *types.OperatorTerms
-
-	// ChainParams are the Bitcoin network parameters.
-	ChainParams *chaincfg.Params
 
 	// MaxOperatorFee is the maximum acceptable operator fee.
 	MaxOperatorFee btcutil.Amount
@@ -409,22 +402,18 @@ func (h *InProcessOutboxHandler) handleBuildRegistration(
 	idPub := identifierKeyDesc.PubKey
 
 	// When auth is enabled, produce a BIP-322 proof that binds
-	// the request contents to the identifier key. The functions
-	// in join_auth.go take *ClientEnvironment, so we construct
-	// a temporary env from handler fields.
+	// the request contents to the identifier key.
 	var joinAuth *types.JoinRoundAuth
 	if !h.DisableJoinRequestAuth {
-		env := &ClientEnvironment{
-			VTXOStore:       h.VTXOStore,
+		deps := &joinAuthDeps{
 			Wallet:          h.Wallet,
+			VTXOStore:       h.VTXOStore,
 			QueryBestHeight: h.QueryBestHeight,
 			Log:             h.Log,
-			OperatorTerms:   h.OperatorTerms,
-			ChainParams:     h.ChainParams,
 		}
 
 		auth, err := buildJoinRoundAuth(
-			ctx, env, identifierKeyDesc, intents,
+			ctx, deps, identifierKeyDesc, intents,
 			vtxoReqs, forfeitReqs, leaveReqs,
 		)
 		if err != nil {

--- a/round/outbox_handler.go
+++ b/round/outbox_handler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/lib/scripts"
+	"github.com/lightninglabs/darepo-client/lib/tree"
 	"github.com/lightninglabs/darepo-client/lib/types"
 )
 
@@ -127,6 +128,23 @@ type BuildRegistrationReq struct {
 
 func (r *BuildRegistrationReq) clientOutMsgSealed()  {}
 func (r *BuildRegistrationReq) outboxRequestSealed() {}
+
+// CreateSigningSessionsReq requests creation of MuSig2 signing
+// sessions for each VTXO in the round. The handler calls
+// tree.NewSignerSession per VTXO using the Wallet, collects nonces,
+// and returns CreateSigningSessionsSucceeded or
+// CreateSigningSessionsFailed.
+type CreateSigningSessionsReq struct {
+	// VTXORequests are the VTXO requests needing signing sessions.
+	VTXORequests []types.VTXORequest
+
+	// ClientTrees maps signer keys to the client's extracted
+	// sub-tree for each VTXO.
+	ClientTrees map[SignerKey]*tree.Tree
+}
+
+func (r *CreateSigningSessionsReq) clientOutMsgSealed()  {}
+func (r *CreateSigningSessionsReq) outboxRequestSealed() {}
 
 // SignBoardingInputsReq requests signing of all boarding inputs in the
 // commitment transaction. The handler calls signBoardingInputs with

--- a/round/states.go
+++ b/round/states.go
@@ -410,6 +410,59 @@ func (s *InputSigSentState) IsTerminal() bool {
 
 func (s *InputSigSentState) clientStateSealed() {}
 
+// AwaitingBoardingSignaturesState is an intermediate state between
+// operator signing (or forfeit collection) and round checkpointing.
+// The FSM has validated VTXO tree signatures and emitted a
+// SignBoardingInputsReq; it is now waiting for the outbox handler
+// to produce boarding input signatures. On success, the FSM builds
+// the Round object and transitions to AwaitingRoundCheckpointState
+// with a CommitRoundStateReq; on failure, the error is fatal.
+type AwaitingBoardingSignaturesState struct {
+	// RoundID is the unique identifier for this round.
+	RoundID RoundID
+
+	// CommitmentTx is the unsigned commitment transaction as a
+	// PSBT.
+	CommitmentTx *psbt.Packet
+
+	// VTXOTreePaths maps commitment tx output indices to VTXO tree
+	// paths.
+	VTXOTreePaths map[int]*tree.Tree
+
+	// Intents contains all the client's intents for this round.
+	Intents Intents
+
+	// ClientTrees maps signer keys to the client's extracted
+	// sub-tree for that VTXO.
+	ClientTrees map[SignerKey]*tree.Tree
+
+	// BoardingInputIndices maps each boarding intent's outpoint to
+	// its position in the commitment transaction inputs.
+	BoardingInputIndices map[wire.OutPoint]int
+
+	// ForfeitedVTXOs contains outpoints of VTXOs being refreshed.
+	// Nil for boarding-only rounds.
+	ForfeitedVTXOs []wire.OutPoint
+
+	// ForfeitSigs maps VTXO outpoints to their forfeit transaction
+	// signatures. Nil for boarding-only rounds.
+	ForfeitSigs map[wire.OutPoint]*schnorr.Signature
+
+	// ForfeitTxs maps VTXO outpoints to the built forfeit
+	// transactions. Nil for boarding-only rounds.
+	ForfeitTxs map[wire.OutPoint]*wire.MsgTx
+}
+
+func (s *AwaitingBoardingSignaturesState) String() string {
+	return "AwaitingBoardingSignatures"
+}
+
+func (s *AwaitingBoardingSignaturesState) IsTerminal() bool {
+	return false
+}
+
+func (s *AwaitingBoardingSignaturesState) clientStateSealed() {}
+
 // AwaitingRoundCheckpointState is an intermediate state between
 // boarding/forfeit signing and InputSigSent. The FSM has prepared all
 // signatures and emitted a CommitRoundStateReq; it is now waiting for

--- a/round/states.go
+++ b/round/states.go
@@ -409,6 +409,42 @@ func (s *InputSigSentState) IsTerminal() bool {
 
 func (s *InputSigSentState) clientStateSealed() {}
 
+// AwaitingSaveVTXOsState is an intermediate state between InputSigSent
+// and Confirmed. The FSM has built the client VTXOs and emitted a
+// SaveVTXOsReq; it is now waiting for the outbox handler to persist
+// them. On success, the FSM transitions to ConfirmedState with
+// notifications; on failure, it transitions to ClientFailedState.
+type AwaitingSaveVTXOsState struct {
+	// RoundID is the unique identifier for this round.
+	RoundID RoundID
+
+	// VTXOs are the built client VTXOs pending persistence.
+	VTXOs []*ClientVTXO
+
+	// ConfEvent is the BoardingConfirmed event that triggered this
+	// state. Carried forward so the FSM can build ConfirmedState
+	// with the confirmation details after save succeeds.
+	ConfEvent *BoardingConfirmed
+
+	// ForfeitedVTXOs contains outpoints of VTXOs being refreshed.
+	// Carried forward for ForfeitConfirmedToVTXO notifications.
+	ForfeitedVTXOs []wire.OutPoint
+
+	// Intents contains all the client's intents for this round.
+	// Needed for computing batch expiry via OperatorTerms.
+	Intents Intents
+}
+
+func (s *AwaitingSaveVTXOsState) String() string {
+	return "AwaitingSaveVTXOs"
+}
+
+func (s *AwaitingSaveVTXOsState) IsTerminal() bool {
+	return false
+}
+
+func (s *AwaitingSaveVTXOsState) clientStateSealed() {}
+
 // ConfirmedState is a terminal state indicating the boarding process has
 // completed successfully. The client now owns VTXOs.
 type ConfirmedState struct {

--- a/round/states.go
+++ b/round/states.go
@@ -80,6 +80,35 @@ func (s *PendingRoundAssembly) IsTerminal() bool {
 
 func (s *PendingRoundAssembly) clientStateSealed() {}
 
+// AwaitingRegistrationBuildState is an intermediate state between
+// PendingRoundAssembly and RegistrationSent. The FSM has validated
+// structural requirements and emitted a BuildRegistrationReq; it is
+// now waiting for the outbox handler to build the JoinRoundRequest
+// (which involves VTXOStore lookups, key derivation, and signing).
+type AwaitingRegistrationBuildState struct {
+	// Boarding are the confirmed boarding intents.
+	Boarding []BoardingIntent
+
+	// VTXOs are the VTXO output requests.
+	VTXOs []types.VTXORequest
+
+	// Forfeits are the forfeit input requests.
+	Forfeits []types.ForfeitRequest
+
+	// Leaves are the on-chain exit output requests.
+	Leaves []*types.LeaveRequest
+}
+
+func (s *AwaitingRegistrationBuildState) String() string {
+	return "AwaitingRegistrationBuild"
+}
+
+func (s *AwaitingRegistrationBuildState) IsTerminal() bool {
+	return false
+}
+
+func (s *AwaitingRegistrationBuildState) clientStateSealed() {}
+
 // RegistrationSentState indicates the client has sent a JoinRoundRequest
 // to the server and is waiting for confirmation.
 type RegistrationSentState struct {

--- a/round/states.go
+++ b/round/states.go
@@ -457,8 +457,8 @@ func (s *ClientFailedState) String() string {
 }
 
 func (s *ClientFailedState) IsTerminal() bool {
-	// ClientFailedState is NOT terminal - it can recover by accepting the
-	// same events as Idle (BoardingUTXOConfirmed, ResumeBoardingIntents).
+	// ClientFailedState is NOT terminal - it can recover by accepting
+	// IntentPackage events, which transition through Idle.
 	return false
 }
 

--- a/round/states.go
+++ b/round/states.go
@@ -3,6 +3,7 @@ package round
 import (
 	"fmt"
 
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
@@ -408,6 +409,59 @@ func (s *InputSigSentState) IsTerminal() bool {
 }
 
 func (s *InputSigSentState) clientStateSealed() {}
+
+// AwaitingRoundCheckpointState is an intermediate state between
+// boarding/forfeit signing and InputSigSent. The FSM has prepared all
+// signatures and emitted a CommitRoundStateReq; it is now waiting for
+// the outbox handler to persist the round checkpoint. On success, the
+// FSM transitions to InputSigSentState and emits server submission
+// messages; on failure, the error is fatal.
+type AwaitingRoundCheckpointState struct {
+	// RoundID is the unique identifier for this round.
+	RoundID RoundID
+
+	// CommitmentTx is the unsigned commitment transaction as a PSBT.
+	CommitmentTx *psbt.Packet
+
+	// VTXOTreePaths maps commitment tx output indices to VTXO tree
+	// paths.
+	VTXOTreePaths map[int]*tree.Tree
+
+	// Intents contains all the client's intents for this round.
+	Intents Intents
+
+	// ClientTrees maps signer keys to the client's extracted
+	// sub-tree for that VTXO.
+	ClientTrees map[SignerKey]*tree.Tree
+
+	// BoardingInputIndices maps each boarding intent's outpoint to
+	// its position in the commitment transaction inputs.
+	BoardingInputIndices map[wire.OutPoint]int
+
+	// InputSigs are the Schnorr signatures for the boarding inputs.
+	InputSigs []*types.BoardingInputSignature
+
+	// ForfeitedVTXOs contains outpoints of VTXOs being refreshed.
+	ForfeitedVTXOs []wire.OutPoint
+
+	// ForfeitSigs maps VTXO outpoints to their forfeit transaction
+	// signatures. Nil for boarding-only rounds.
+	ForfeitSigs map[wire.OutPoint]*schnorr.Signature
+
+	// ForfeitTxs maps VTXO outpoints to the built forfeit
+	// transactions. Nil for boarding-only rounds.
+	ForfeitTxs map[wire.OutPoint]*wire.MsgTx
+}
+
+func (s *AwaitingRoundCheckpointState) String() string {
+	return "AwaitingRoundCheckpoint"
+}
+
+func (s *AwaitingRoundCheckpointState) IsTerminal() bool {
+	return false
+}
+
+func (s *AwaitingRoundCheckpointState) clientStateSealed() {}
 
 // AwaitingSaveVTXOsState is an intermediate state between InputSigSent
 // and Confirmed. The FSM has built the client VTXOs and emitted a

--- a/round/states.go
+++ b/round/states.go
@@ -219,6 +219,51 @@ func (s *CommitmentTxValidatedState) IsTerminal() bool {
 
 func (s *CommitmentTxValidatedState) clientStateSealed() {}
 
+// AwaitingSigningSessionsState is an intermediate state between
+// CommitmentTxValidated and NoncesSent. The FSM has validated the
+// commitment tx and VTXO tree, and emitted a CreateSigningSessionsReq.
+// It is now waiting for the outbox handler to create MuSig2 signing
+// sessions using the Wallet. On success, the FSM transitions to
+// NoncesSentState with the nonce submission in the outbox; on failure,
+// the error is fatal.
+type AwaitingSigningSessionsState struct {
+	// RoundID is the unique identifier for this round.
+	RoundID RoundID
+
+	// CommitmentTx is the unsigned commitment transaction as a
+	// PSBT.
+	CommitmentTx *psbt.Packet
+
+	// VTXOTreePaths maps commitment tx output indices to VTXO tree
+	// paths.
+	VTXOTreePaths map[int]*tree.Tree
+
+	// Intents contains all the client's intents for this round.
+	Intents Intents
+
+	// ClientTrees maps signer keys to the client's extracted
+	// sub-tree for each VTXO.
+	ClientTrees map[SignerKey]*tree.Tree
+
+	// BoardingInputIndices maps each boarding intent's outpoint to
+	// its position in the commitment transaction inputs.
+	BoardingInputIndices map[wire.OutPoint]int
+
+	// ForfeitMappings maps VTXO outpoints to their connector info
+	// for refresh rounds. Carried forward through signing states.
+	ForfeitMappings map[wire.OutPoint]*ConnectorLeafInfo
+}
+
+func (s *AwaitingSigningSessionsState) String() string {
+	return "AwaitingSigningSessions"
+}
+
+func (s *AwaitingSigningSessionsState) IsTerminal() bool {
+	return false
+}
+
+func (s *AwaitingSigningSessionsState) clientStateSealed() {}
+
 // ForfeitSignaturesCollectingState indicates the client is waiting for forfeit
 // signatures from VTXO actors after completing VTXO tree signing. This state
 // is entered when the round includes refresh or leave requests (VTXOs being

--- a/round/transition_table.go
+++ b/round/transition_table.go
@@ -210,13 +210,11 @@ var BoardingClientTransitions = ClientTransitionTable{
 			Transitions: []ClientTransitionEntry{
 				{
 					Event:       &BoardingConfirmed{},
-					ToState:     &ConfirmedState{},
-					Description: "Commitment tx confirmed, complete",
+					ToState:     &AwaitingSaveVTXOsState{},
+					Description: "Commitment tx confirmed, saving VTXOs",
 					EmitsOutbox: []ClientOutMsg{
-						&VTXOCreatedNotification{},
-						&RoundCompletedNotification{},
+						&SaveVTXOsReq{},
 					},
-					IsTerminal: true,
 				},
 				{
 					Event:       &BoardingFailed{},
@@ -228,6 +226,29 @@ var BoardingClientTransitions = ClientTransitionTable{
 					Event:       &RecoveryInitiated{},
 					ToState:     &RecoveryInitiatedState{},
 					Description: "CSV timeout, recovering funds",
+					IsTerminal:  true,
+				},
+			},
+		},
+
+		// AwaitingSaveVTXOsState: Waiting for VTXO persistence.
+		{
+			FromState: &AwaitingSaveVTXOsState{},
+			Transitions: []ClientTransitionEntry{
+				{
+					Event:       &SaveVTXOsSucceeded{},
+					ToState:     &ConfirmedState{},
+					Description: "VTXOs saved, round complete",
+					EmitsOutbox: []ClientOutMsg{
+						&VTXOCreatedNotification{},
+						&RoundCompletedNotification{},
+					},
+					IsTerminal: true,
+				},
+				{
+					Event:       &SaveVTXOsFailed{},
+					ToState:     &ClientFailedState{},
+					Description: "VTXO persistence failed",
 					IsTerminal:  true,
 				},
 			},

--- a/round/transition_table.go
+++ b/round/transition_table.go
@@ -188,11 +188,12 @@ var BoardingClientTransitions = ClientTransitionTable{
 			FromState: &PartialSigsSentState{},
 			Transitions: []ClientTransitionEntry{
 				{
-					Event:       &OperatorSigned{},
-					ToState:     &AwaitingRoundCheckpointState{},
-					Description: "Received VTXT sigs, checkpointing",
+					Event:   &OperatorSigned{},
+					ToState: &AwaitingBoardingSignaturesState{},
+					Description: "Received VTXT sigs, " +
+						"signing boarding inputs",
 					EmitsOutbox: []ClientOutMsg{
-						&CommitRoundStateReq{},
+						&SignBoardingInputsReq{},
 					},
 				},
 				{
@@ -200,6 +201,28 @@ var BoardingClientTransitions = ClientTransitionTable{
 					ToState:     &ClientFailedState{},
 					Description: "Operator signing failed",
 					IsTerminal:  true,
+				},
+			},
+		},
+
+		// AwaitingBoardingSignaturesState: Waiting for boarding
+		// input signing.
+		{
+			FromState: &AwaitingBoardingSignaturesState{},
+			Transitions: []ClientTransitionEntry{
+				{
+					Event:   &SignBoardingInputsSucceeded{},
+					ToState: &AwaitingRoundCheckpointState{},
+					Description: "Boarding inputs signed," +
+						" checkpointing",
+					EmitsOutbox: []ClientOutMsg{
+						&CommitRoundStateReq{},
+					},
+				},
+				{
+					Event:       &SignBoardingInputsFailed{},
+					ToState:     nil,
+					Description: "Boarding signing failed (fatal)",
 				},
 			},
 		},

--- a/round/transition_table.go
+++ b/round/transition_table.go
@@ -56,14 +56,34 @@ var BoardingClientTransitions = ClientTransitionTable{
 				},
 				{
 					Event:       &RegistrationRequested{},
-					ToState:     &RegistrationSentState{},
-					Description: "Intents confirmed, register with server",
-					EmitsOutbox: []ClientOutMsg{&JoinRoundRequest{}},
+					ToState:     &AwaitingRegistrationBuildState{},
+					Description: "Intents confirmed, building registration",
+					EmitsOutbox: []ClientOutMsg{&BuildRegistrationReq{}},
 				},
 				{
 					Event:       &BoardingFailed{},
 					ToState:     &ClientFailedState{},
 					Description: "Boarding failed during assembly",
+					IsTerminal:  true,
+				},
+			},
+		},
+
+		// AwaitingRegistrationBuildState: Waiting for registration
+		// build to complete.
+		{
+			FromState: &AwaitingRegistrationBuildState{},
+			Transitions: []ClientTransitionEntry{
+				{
+					Event:       &BuildRegistrationSucceeded{},
+					ToState:     &RegistrationSentState{},
+					Description: "Registration built, sending to server",
+					EmitsOutbox: []ClientOutMsg{&JoinRoundRequest{}},
+				},
+				{
+					Event:       &BuildRegistrationFailed{},
+					ToState:     &ClientFailedState{},
+					Description: "Registration build failed",
 					IsTerminal:  true,
 				},
 			},

--- a/round/transition_table.go
+++ b/round/transition_table.go
@@ -143,16 +143,17 @@ var BoardingClientTransitions = ClientTransitionTable{
 			},
 		},
 
-		// CommitmentTxValidatedState: Generate and send nonces.
+		// CommitmentTxValidatedState: Emit signing session
+		// creation or go to forfeit collection (leave-only).
 		{
 			FromState: &CommitmentTxValidatedState{},
 			Transitions: []ClientTransitionEntry{
 				{
 					Event:       &GenerateNonces{},
-					ToState:     &NoncesSentState{},
-					Description: "Generated nonces, sending to server",
+					ToState:     &AwaitingSigningSessionsState{},
+					Description: "Creating signing sessions",
 					EmitsOutbox: []ClientOutMsg{
-						&SubmitNoncesRequest{},
+						&CreateSigningSessionsReq{},
 					},
 				},
 				{
@@ -160,6 +161,27 @@ var BoardingClientTransitions = ClientTransitionTable{
 					ToState:     &ClientFailedState{},
 					Description: "Nonce generation failed",
 					IsTerminal:  true,
+				},
+			},
+		},
+
+		// AwaitingSigningSessionsState: Waiting for MuSig2
+		// session creation.
+		{
+			FromState: &AwaitingSigningSessionsState{},
+			Transitions: []ClientTransitionEntry{
+				{
+					Event:       &CreateSigningSessionsSucceeded{},
+					ToState:     &NoncesSentState{},
+					Description: "Sessions created, sending nonces",
+					EmitsOutbox: []ClientOutMsg{
+						&SubmitNoncesRequest{},
+					},
+				},
+				{
+					Event:       &CreateSigningSessionsFailed{},
+					ToState:     nil,
+					Description: "Session creation failed (fatal)",
 				},
 			},
 		},

--- a/round/transition_table.go
+++ b/round/transition_table.go
@@ -189,10 +189,10 @@ var BoardingClientTransitions = ClientTransitionTable{
 			Transitions: []ClientTransitionEntry{
 				{
 					Event:       &OperatorSigned{},
-					ToState:     &InputSigSentState{},
-					Description: "Received VTXT sigs, sending input sig",
+					ToState:     &AwaitingRoundCheckpointState{},
+					Description: "Received VTXT sigs, checkpointing",
 					EmitsOutbox: []ClientOutMsg{
-						&SubmitForfeitSigRequest{},
+						&CommitRoundStateReq{},
 					},
 				},
 				{
@@ -200,6 +200,28 @@ var BoardingClientTransitions = ClientTransitionTable{
 					ToState:     &ClientFailedState{},
 					Description: "Operator signing failed",
 					IsTerminal:  true,
+				},
+			},
+		},
+
+		// AwaitingRoundCheckpointState: Waiting for round persistence.
+		{
+			FromState: &AwaitingRoundCheckpointState{},
+			Transitions: []ClientTransitionEntry{
+				{
+					Event:       &CommitRoundStateSucceeded{},
+					ToState:     &InputSigSentState{},
+					Description: "Checkpoint saved, sending sigs",
+					EmitsOutbox: []ClientOutMsg{
+						&SubmitForfeitSigRequest{},
+						&RegisterConfirmationRequest{},
+						&RoundCheckpointedNotification{},
+					},
+				},
+				{
+					Event:       &CommitRoundStateFailed{},
+					ToState:     nil,
+					Description: "Checkpoint failed (fatal)",
 				},
 			},
 		},

--- a/round/transition_table.go
+++ b/round/transition_table.go
@@ -27,24 +27,14 @@ type ClientTransitionTable = protofsm.TransitionTable[
 var BoardingClientTransitions = ClientTransitionTable{
 	MachineName: "BoardingClient",
 	States: []ClientStateTransitions{
-		// Idle: Initial state, waiting for boarding intents.
+		// Idle: Initial state, waiting for intent packages.
 		{
 			FromState: &Idle{},
 			Transitions: []ClientTransitionEntry{
 				{
-					Event:       &ResumeBoardingIntents{},
+					Event:       &IntentPackage{},
 					ToState:     &PendingRoundAssembly{},
-					Description: "Resume monitoring existing intents",
-				},
-				{
-					Event:       &BoardingUTXOConfirmed{},
-					ToState:     &PendingRoundAssembly{},
-					Description: "First UTXO confirmed, start assembly",
-				},
-				{
-					Event:       &VTXORequestsReceived{},
-					ToState:     &PendingRoundAssembly{},
-					Description: "VTXO requests received, start assembly",
+					Description: "Intent package received, start assembly",
 				},
 				{
 					Event:       &BoardingFailed{},
@@ -55,19 +45,14 @@ var BoardingClientTransitions = ClientTransitionTable{
 			},
 		},
 
-		// PendingRoundAssembly: Collecting confirmed boarding intents.
+		// PendingRoundAssembly: Collecting intents for the round.
 		{
 			FromState: &PendingRoundAssembly{},
 			Transitions: []ClientTransitionEntry{
 				{
-					Event:       &BoardingUTXOConfirmed{},
+					Event:       &IntentPackage{},
 					ToState:     &PendingRoundAssembly{},
-					Description: "Additional boarding UTXO confirmed",
-				},
-				{
-					Event:       &VTXORequestsReceived{},
-					ToState:     &PendingRoundAssembly{},
-					Description: "Additional VTXO requests received",
+					Description: "Additional intents received",
 				},
 				{
 					Event:       &RegistrationRequested{},
@@ -262,10 +247,17 @@ var BoardingClientTransitions = ClientTransitionTable{
 			},
 		},
 
-		// ClientFailedState: Terminal failure state.
+		// ClientFailedState: Recoverable failure state. Recovery
+		// transitions to Idle and re-dispatches the IntentPackage,
+		// so the net destination is PendingRoundAssembly.
 		{
 			FromState: &ClientFailedState{},
 			Transitions: []ClientTransitionEntry{
+				{
+					Event:       &IntentPackage{},
+					ToState:     &Idle{},
+					Description: "Recover from failure with new intents",
+				},
 				{
 					Event:       &BoardingFailed{},
 					ToState:     &ClientFailedState{},

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -1580,71 +1580,104 @@ func (s *InputSigSentState) ProcessEvent(
 			}, nil
 		}
 
-		env.Log.InfoS(ctx, "Built client VTXOs from confirmed transaction",
+		env.Log.InfoS(ctx, "Built client VTXOs, requesting persistence",
 			slog.String("round_id", s.RoundID.String()),
 			slog.Int("vtxo_count", len(vtxos)))
 
-		// Persist VTXOs with their extracted tree paths for future
-		// spending.
-		if err := env.VTXOStore.SaveVTXOs(ctx, vtxos); err != nil {
-			return nil, fmt.Errorf("failed to save VTXOs: %w", err)
-		}
+		// Emit SaveVTXOsReq for the outbox handler to persist
+		// the VTXOs. The FSM transitions to an awaiting state
+		// until the handler responds with success or failure.
+		return &ClientStateTransition{
+			NextState: &AwaitingSaveVTXOsState{
+				RoundID:        s.RoundID,
+				VTXOs:          vtxos,
+				ConfEvent:      evt,
+				ForfeitedVTXOs: s.ForfeitedVTXOs,
+				Intents:        s.Intents.Clone(),
+			},
+			NewEvents: fn.Some(ClientEmittedEvent{
+				Outbox: []ClientOutMsg{
+					&SaveVTXOsReq{VTXOs: vtxos},
+				},
+			}),
+		}, nil
 
-		env.Log.InfoS(ctx, "Saved VTXOs to store, round complete",
+	default:
+		// Self-loop on unknown events - do not halt the FSM.
+		return selfLoop(s), nil
+	}
+}
+
+// ProcessEvent for AwaitingSaveVTXOsState. Handles the outbox handler
+// response after VTXO persistence is attempted.
+func (s *AwaitingSaveVTXOsState) ProcessEvent(
+	ctx context.Context, event ClientEvent, env *ClientEnvironment,
+) (*ClientStateTransition, error) {
+
+	switch evt := event.(type) {
+	case *SaveVTXOsSucceeded:
+		env.Log.InfoS(ctx, "VTXOs saved, round complete",
 			slog.String("round_id", s.RoundID.String()),
-			slog.Int("vtxo_count", len(vtxos)))
+			slog.Int("vtxo_count", len(s.VTXOs)))
 
+		confEvt := s.ConfEvent
 		confInfo := ConfInfo{
-			Height:    evt.BlockHeight,
-			BlockHash: evt.BlockHash,
+			Height:    confEvt.BlockHeight,
+			BlockHash: confEvt.BlockHash,
 		}
 
 		// Compute batch expiry as absolute block height.
 		sweepDelay := int32(env.OperatorTerms.SweepDelay)
-		batchExpiry := evt.BlockHeight + sweepDelay
+		batchExpiry := confEvt.BlockHeight + sweepDelay
 
-		// Build outbox messages starting with standard notifications.
+		// Build outbox messages starting with standard
+		// notifications.
 		outbox := []ClientOutMsg{
 			&VTXOCreatedNotification{
-				VTXOs:          vtxos,
+				VTXOs:          s.VTXOs,
 				RoundID:        s.RoundID.String(),
-				CommitmentTxID: evt.TxID,
+				CommitmentTxID: confEvt.TxID,
 				BatchExpiry:    batchExpiry,
-				CreatedHeight:  evt.BlockHeight,
+				CreatedHeight:  confEvt.BlockHeight,
 			},
 			&RoundCompletedNotification{
 				RoundID:  s.RoundID,
-				TxID:     evt.TxID,
+				TxID:     confEvt.TxID,
 				ConfInfo: confInfo,
 			},
 		}
 
-		// If this round included refresh requests, notify the old VTXO
-		// actors that their forfeit is now confirmed. This allows them
-		// to transition to the terminal Forfeited state.
+		// If this round included refresh requests, notify old
+		// VTXO actors that their forfeit is confirmed.
 		for _, vtxoOutpoint := range s.ForfeitedVTXOs {
-			outbox = append(outbox, &ForfeitConfirmedToVTXO{
-				VTXOOutpoint:   vtxoOutpoint,
-				CommitmentTxID: evt.TxID,
-				BlockHeight:    evt.BlockHeight,
-			})
+			outbox = append(outbox,
+				&ForfeitConfirmedToVTXO{
+					VTXOOutpoint:   vtxoOutpoint,
+					CommitmentTxID: confEvt.TxID,
+					BlockHeight:    confEvt.BlockHeight,
+				})
 		}
 
 		return &ClientStateTransition{
 			NextState: &ConfirmedState{
-				TxID:          evt.TxID,
-				BlockHeight:   evt.BlockHeight,
-				BlockHash:     evt.BlockHash,
-				Confirmations: evt.Confirmations,
-				VTXOs:         vtxos,
+				TxID:          confEvt.TxID,
+				BlockHeight:   confEvt.BlockHeight,
+				BlockHash:     confEvt.BlockHash,
+				Confirmations: confEvt.Confirmations,
+				VTXOs:         s.VTXOs,
 			},
 			NewEvents: fn.Some(ClientEmittedEvent{
 				Outbox: outbox,
 			}),
 		}, nil
 
+	case *SaveVTXOsFailed:
+		return failWithNotification(
+			"failed to save VTXOs", evt.Error,
+			false, fn.Some(s.RoundID),
+		), nil
+
 	default:
-		// Self-loop on unknown events - do not halt the FSM.
 		return selfLoop(s), nil
 	}
 }

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -147,133 +147,25 @@ func signBoardingInputs(wallet ClientWallet, commitmentTx *psbt.Packet,
 	return boardingInputSigs, nil
 }
 
-// ProcessEvent handles the events from the Idle state. In this state, we'll
-// receive boarding UTXO confirmations or resume existing boarding flows.
+// ProcessEvent handles events in the Idle state. The only pool-addition
+// event is IntentPackage — the actor layer converts all raw inputs
+// (boarding confirmations, VTXO requests, refresh/leave) into
+// IntentPackage before sending to the FSM.
 func (s *Idle) ProcessEvent(ctx context.Context, event ClientEvent,
 	env *ClientEnvironment) (*ClientStateTransition, error) {
 
 	switch evt := event.(type) {
-	case *ResumeBoardingIntents:
-		// If for some reason, there aren't any new intents, then we'll
-		// stay in the idle state.
-		if evt.isEmpty() {
-			env.Log.DebugS(ctx, "ResumeBoardingIntents received "+
-				"with no intents")
-
-			return &ClientStateTransition{
-				NextState: s,
-			}, nil
-		}
-
-		env.Log.InfoS(ctx, "Resuming boarding intents",
-			evt.logAttributes())
-
-		// Otherwise, we'll start to assemble a round with the resumed
-		// intents.
-		return &ClientStateTransition{
-			NextState: &PendingRoundAssembly{
-				Boarding: slices.Clone(evt.Boarding),
-				VTXOs:    slices.Clone(evt.VTXOs),
-				Forfeits: slices.Clone(evt.Forfeits),
-				Leaves:   slices.Clone(evt.Leaves),
-			},
-		}, nil
-
-	case *BoardingUTXOConfirmed:
-		env.Log.InfoS(ctx, "Processing boarding UTXO confirmation in Idle state",
-			btclog.Fmt("outpoint", "%v", evt.Outpoint),
-			slog.Int("block_height", int(evt.BlockHeight)))
-
-		// A boarding UTXO was confirmed. The wallet has already
-		// persisted the intent; we just need to create an internal
-		// BoardingIntent and transition to PendingRoundAssembly.
-		if evt.Tx == nil {
-			return failWithNotification(
-				"confirmation event missing transaction",
-				fmt.Errorf("BoardingUTXOConfirmed.Tx is nil"),
-				true, fn.None[RoundID](),
-			), nil
-		}
-
-		// Extract the confirmed output value.
-		if int(evt.Outpoint.Index) >= len(evt.Tx.TxOut) {
-			return failWithNotification(
-				fmt.Sprintf(
-					"invalid outpoint index %d for tx %s",
-					evt.Outpoint.Index, evt.Outpoint.Hash,
-				),
-				fmt.Errorf("outpoint index out of range"),
-				true, fn.None[RoundID](),
-			), nil
-		}
-		confirmedOutput := evt.Tx.TxOut[evt.Outpoint.Index]
-
-		// Create the chain info from the confirmation event, including
-		// the TxProof for SPV verification.
-		chainInfo := BoardingChainInfo{
-			ConfHeight: evt.BlockHeight,
-			ConfHash:   evt.BlockHash,
-			ConfTx:     evt.Tx,
-			OutPoint:   evt.Outpoint,
-			Amount:     btcutil.Amount(confirmedOutput.Value),
-			TxProof:    evt.TxProof,
-		}
-
-		// Create a wallet intent with the full address from the event.
-		walletIntent := WalletBoardingIntent{
-			Address:   evt.Address,
-			Outpoint:  evt.Outpoint,
-			ChainInfo: chainInfo,
-			Status:    BoardingStatusConfirmed,
-		}
-
-		// Build the boarding request from the address. Include the exit
-		// delay so the operator can verify the boarding output script.
-		boardingRequest := types.BoardingRequest{
-			Outpoint:    &evt.Outpoint,
-			ClientKey:   evt.Address.KeyDesc.PubKey,
-			OperatorKey: evt.Address.OperatorKey,
-			ExitDelay:   evt.Address.ExitDelay,
-		}
-
-		// Create a BoardingIntent for the next round.
-		boardingIntent := BoardingIntent{
-			BoardingIntent: walletIntent,
-			Request:        boardingRequest,
-		}
-
-		env.Log.InfoS(ctx, "Transitioning to PendingRoundAssembly",
-			slog.Int("amount", int(chainInfo.Amount)),
-			btclog.Fmt("outpoint", "%v", evt.Outpoint))
-
-		return &ClientStateTransition{
-			NextState: &PendingRoundAssembly{
-				Boarding: []BoardingIntent{boardingIntent},
-				VTXOs:    []types.VTXORequest{},
-			},
-		}, nil
-
-	case *VTXORequestsReceived:
-		env.Log.InfoS(ctx, "Received VTXO requests in Idle state",
-			slog.Int("request_count", len(evt.Requests)))
-
-		// Transition to PendingRoundAssembly with the received VTXO.
-		return &ClientStateTransition{
-			NextState: &PendingRoundAssembly{
-				Boarding: []BoardingIntent{},
-				VTXOs:    slices.Clone(evt.Requests),
-			},
-		}, nil
-
 	case *IntentPackage:
-		// An atomic bundle of intents was submitted. Start
-		// assembling a round with all items from the package.
 		if evt.isEmpty() {
 			return selfLoop(s), nil
 		}
 
+		env.Log.InfoS(ctx, "Starting round assembly from "+
+			"intent package", evt.logAttributes())
+
 		return &ClientStateTransition{
 			NextState: &PendingRoundAssembly{
+				Boarding: slices.Clone(evt.Boarding),
 				Forfeits: slices.Clone(evt.Forfeits),
 				VTXOs:    slices.Clone(evt.VTXOs),
 				Leaves:   slices.Clone(evt.Leaves),
@@ -295,122 +187,53 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 	error) {
 
 	switch evt := event.(type) {
-	// A new boarding UTXO was confirmed. The wallet handles persistence;
-	// we just add to our internal map.
-	case *BoardingUTXOConfirmed:
-		env.Log.InfoS(ctx, "Additional boarding UTXO confirmed during assembly",
-			btclog.Fmt("outpoint", "%v", evt.Outpoint),
-			slog.Int("current_boarding_intent_count", len(s.Boarding)),
-			slog.Int("current_vtxo_intent_count", len(s.VTXOs)))
-
-		if evt.Tx == nil {
-			return failWithNotification(
-				"confirmation event missing transaction",
-				fmt.Errorf("BoardingUTXOConfirmed.Tx is nil"),
-				true, fn.None[RoundID](),
-			), nil
-		}
-
-		// Extract the confirmed output value.
-		if int(evt.Outpoint.Index) >= len(evt.Tx.TxOut) {
-			return failWithNotification(
-				fmt.Sprintf(
-					"invalid outpoint index %d for tx %s",
-					evt.Outpoint.Index, evt.Outpoint.Hash,
-				),
-				fmt.Errorf("outpoint index out of range"),
-				true, fn.None[RoundID](),
-			), nil
-		}
-		confirmedOutput := evt.Tx.TxOut[evt.Outpoint.Index]
-
-		for _, intent := range s.Boarding {
-			if intent.Outpoint != evt.Outpoint {
-				continue
-			}
-
-			env.Log.InfoS(ctx, "Boarding UTXO already present in intents map",
-				btclog.Fmt("outpoint", "%v", evt.Outpoint))
-
-			// Self-loop without adding duplicate intent.
-			return selfLoop(s), nil
-		}
-
-		// Create the chain info from the confirmation event, including
-		// the TxProof for SPV verification.
-		chainInfo := BoardingChainInfo{
-			ConfHeight: evt.BlockHeight,
-			ConfHash:   evt.BlockHash,
-			ConfTx:     evt.Tx,
-			OutPoint:   evt.Outpoint,
-			Amount:     btcutil.Amount(confirmedOutput.Value),
-			TxProof:    evt.TxProof,
-		}
-
-		// Create a wallet intent with the full address from the event.
-		walletIntent := WalletBoardingIntent{
-			Address:   evt.Address,
-			Outpoint:  evt.Outpoint,
-			ChainInfo: chainInfo,
-			Status:    BoardingStatusConfirmed,
-		}
-
-		// Build the boarding request from the address. Include the exit
-		// delay so the operator can verify the boarding output script.
-		boardingRequest := types.BoardingRequest{
-			Outpoint:    &evt.Outpoint,
-			ClientKey:   evt.Address.KeyDesc.PubKey,
-			OperatorKey: evt.Address.OperatorKey,
-			ExitDelay:   evt.Address.ExitDelay,
-		}
-
-		intent := BoardingIntent{
-			BoardingIntent: walletIntent,
-			Request:        boardingRequest,
-		}
-
-		// Add the new intent to our existing set.
-		updatedBoardingIntents := slices.Clone(s.Boarding)
-		updatedBoardingIntents = append(updatedBoardingIntents, intent)
-
-		return &ClientStateTransition{
-			NextState: &PendingRoundAssembly{
-				Boarding: updatedBoardingIntents,
-				VTXOs:    slices.Clone(s.VTXOs),
-				Forfeits: slices.Clone(s.Forfeits),
-				Leaves:   slices.Clone(s.Leaves),
-			},
-		}, nil
-
-	case *VTXORequestsReceived:
-		env.Log.InfoS(ctx, "Additional VTXO requests received during assembly",
-			slog.Int("current_boarding_intent_count", len(s.Boarding)),
-			slog.Int("current_vtxo_intent_count", len(s.VTXOs)),
-			slog.Int("new_request_count", len(evt.Requests)))
-
-		// Add the new VTXO requests to our existing set.
-		updatedVTXOIntents := slices.Clone(s.VTXOs)
-		updatedVTXOIntents = append(updatedVTXOIntents, evt.Requests...)
-
-		return &ClientStateTransition{
-			NextState: &PendingRoundAssembly{
-				Boarding: slices.Clone(s.Boarding),
-				VTXOs:    updatedVTXOIntents,
-				Forfeits: slices.Clone(s.Forfeits),
-				Leaves:   slices.Clone(s.Leaves),
-			},
-		}, nil
-
 	case *IntentPackage:
-		// An atomic bundle of intents. Unpack into our pools.
+		// An atomic bundle of intents. Unpack into our pools,
+		// deduplicating boarding intents by outpoint.
 		if evt.isEmpty() {
 			return selfLoop(s), nil
 		}
 
+		// Deduplicate boarding intents by outpoint.
+		updatedBoarding := slices.Clone(s.Boarding)
+		for _, newIntent := range evt.Boarding {
+			dup := slices.ContainsFunc(
+				updatedBoarding,
+				func(b BoardingIntent) bool {
+					return b.Outpoint ==
+						newIntent.Outpoint
+				},
+			)
+			if !dup {
+				updatedBoarding = append(
+					updatedBoarding, newIntent,
+				)
+			}
+		}
+
+		// Deduplicate forfeit requests by VTXO outpoint. A VTXO
+		// can only be forfeited once per round.
 		updatedForfeits := slices.Clone(s.Forfeits)
-		updatedForfeits = append(
-			updatedForfeits, evt.Forfeits...,
-		)
+		for _, newForfeit := range evt.Forfeits {
+			dup := slices.ContainsFunc(
+				updatedForfeits,
+				func(f types.ForfeitRequest) bool {
+					if f.VTXOOutpoint == nil ||
+						newForfeit.VTXOOutpoint == nil {
+
+						return false
+					}
+
+					return *f.VTXOOutpoint ==
+						*newForfeit.VTXOOutpoint
+				},
+			)
+			if !dup {
+				updatedForfeits = append(
+					updatedForfeits, newForfeit,
+				)
+			}
+		}
 
 		updatedVTXOs := slices.Clone(s.VTXOs)
 		updatedVTXOs = append(updatedVTXOs, evt.VTXOs...)
@@ -420,7 +243,7 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 
 		return &ClientStateTransition{
 			NextState: &PendingRoundAssembly{
-				Boarding: slices.Clone(s.Boarding),
+				Boarding: updatedBoarding,
 				VTXOs:    updatedVTXOs,
 				Forfeits: updatedForfeits,
 				Leaves:   updatedLeaves,
@@ -448,7 +271,7 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 		}
 
 		// Include all forfeited VTXO amounts as inputs.
-		forfeitInput, err := computeTotalForfeitAmount(
+		forfeitAmt, err := computeTotalForfeitAmount(
 			ctx, env.VTXOStore, s.Forfeits,
 		)
 		if err != nil {
@@ -457,7 +280,7 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 				err, true, fn.None[RoundID](),
 			), nil
 		}
-		totalInput += forfeitInput
+		totalInput += forfeitAmt
 
 		// Include leave amounts as requested on-chain outputs.
 		for i, req := range s.Leaves {
@@ -1876,46 +1699,14 @@ func (s *ClientFailedState) ProcessEvent(
 			},
 		}, nil
 
-	case *ResumeBoardingIntents:
-		// Recovery path: transition to Idle and forward the event.
-		// If no intents are provided, stay in the current state.
-		if evt.isEmpty() {
-			return selfLoop(s), nil
-		}
-
-		env.Log.InfoS(ctx, "Recovering from failed state with resumed intents",
-			evt.logAttributes())
-
-		return &ClientStateTransition{
-			NextState: &Idle{},
-			NewEvents: fn.Some(ClientEmittedEvent{
-				InternalEvent: []ClientEvent{evt},
-			}),
-		}, nil
-
-	case *BoardingUTXOConfirmed:
-		env.Log.InfoS(ctx, "Recovering from failed state with new boarding confirmation",
-			btclog.Fmt("outpoint", "%v", evt.Outpoint))
-
-		// Recovery path: transition to Idle and forward the event
-		// to be processed there. This avoids duplicating the
-		// BoardingUTXOConfirmed handling logic.
-		return &ClientStateTransition{
-			NextState: &Idle{},
-			NewEvents: fn.Some(ClientEmittedEvent{
-				InternalEvent: []ClientEvent{evt},
-			}),
-		}, nil
-
 	case *IntentPackage:
 		if evt.isEmpty() {
 			return selfLoop(s), nil
 		}
 
-		env.Log.InfoS(ctx, "Recovering from failed state with intent package",
-			slog.Int("forfeits", len(evt.Forfeits)),
-			slog.Int("vtxos", len(evt.VTXOs)),
-			slog.Int("leaves", len(evt.Leaves)))
+		env.Log.InfoS(ctx, "Recovering from failed state "+
+			"with intent package",
+			evt.logAttributes())
 
 		return &ClientStateTransition{
 			NextState: &Idle{},

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -663,97 +663,84 @@ func (s *CommitmentTxValidatedState) ProcessEvent(
 			}, nil
 		}
 
-		// At this point, all the basic validation checks have passed.
-		// So now we'll generate a musig2 session to create nonces to
-		// sign the VTXO tree. Each VTXO that we created will
-		// effectively be a new musig session.
-		musig2Sessions := make(map[SignerKey]*tree.SignerSession)
-		for _, vtxoReq := range s.Intents.VTXOs {
-			signerKey := NewSignerKey(
-				vtxoReq.SigningKey.PubKey,
-			)
-
-			// Get the client tree for this signer key.
-			// The sweep tweak and batch output are
-			// properties of the tree that were set when
-			// the operator built it.
-			clientTree := s.ClientTrees[signerKey]
-			if clientTree == nil {
-				return nil, fmt.Errorf(
-					"no client tree for signer "+
-						"key %x", signerKey[:],
-				)
-			}
-
-			sweepTweak := clientTree.SweepTapscriptRoot
-			batchOut := clientTree.BatchOutput
-			root := clientTree.Root
-			prevOutFetcher, err := root.PrevOutputFetcher(batchOut)
-			if err != nil {
-				return nil, fmt.Errorf("failed to "+
-					"create prev output fetcher "+
-					"for signer %x: %w",
-					signerKey[:], err)
-			}
-
-			// TODO(roasbeef): actually use the interface
-			// in front of this?
-			session, err := tree.NewSignerSession(
-				env.Wallet, &vtxoReq.SigningKey,
-				sweepTweak, prevOutFetcher,
-				clientTree.Root,
-			)
-			if err != nil {
-				return nil, fmt.Errorf("failed to "+
-					"create signing session for "+
-					"client %x: %w",
-					signerKey[:], err)
-			}
-
-			musig2Sessions[signerKey] = session
-		}
-
-		// Now that we have all our sessions created, we'll have each
-		// of them generate nonces to use in tree signing. The server
-		// expects nonces grouped by signer key first, then by txid.
-		allNonces := make(
-			map[SignerKey]map[tree.TxID]tree.Musig2PubNonce,
-		)
-		for signerKey, session := range musig2Sessions {
-			nonces := session.GetNonces()
-			allNonces[signerKey] = nonces
-		}
-
-		env.Log.InfoS(ctx, "Generated MuSig2 nonces, sending to server",
-			slog.String("round_id", s.RoundID.String()),
-			slog.Int("session_count", len(musig2Sessions)),
-			slog.Int("signer_key_count", len(allNonces)))
-
-		// MuSig2 nonces have been generated locally. Send them to the
-		// server to participate in the aggregated nonce computation.
-		nonceMsg := &SubmitNoncesRequest{
-			RoundID: s.RoundID,
-			Nonces:  allNonces,
-		}
-
+		// Emit CreateSigningSessionsReq for the outbox handler
+		// to create MuSig2 signing sessions per VTXO using the
+		// Wallet. The handler returns sessions and nonces.
 		return &ClientStateTransition{
-			NextState: &NoncesSentState{
+			NextState: &AwaitingSigningSessionsState{
 				RoundID:              s.RoundID,
 				CommitmentTx:         s.CommitmentTx,
 				VTXOTreePaths:        s.VTXOTreePaths,
 				Intents:              s.Intents.Clone(),
 				ClientTrees:          s.ClientTrees,
-				Musig2Sessions:       musig2Sessions,
 				BoardingInputIndices: s.BoardingInputIndices,
 				ForfeitMappings:      s.ForfeitMappings,
+			},
+			NewEvents: fn.Some(ClientEmittedEvent{
+				Outbox: []ClientOutMsg{
+					&CreateSigningSessionsReq{
+						VTXORequests: slices.Clone(
+							s.Intents.VTXOs,
+						),
+						ClientTrees: maps.Clone(
+							s.ClientTrees,
+						),
+					},
+				},
+			}),
+		}, nil
+
+	default:
+		// Self-loop on unknown events - do not halt the FSM.
+		return selfLoop(s), nil
+	}
+}
+
+// ProcessEvent for AwaitingSigningSessionsState handles the outbox
+// handler response after creating MuSig2 signing sessions. On success,
+// transitions to NoncesSentState with nonces in the outbox; on
+// failure, the error is fatal.
+func (s *AwaitingSigningSessionsState) ProcessEvent(
+	ctx context.Context, event ClientEvent, env *ClientEnvironment,
+) (*ClientStateTransition, error) {
+
+	switch evt := event.(type) {
+	case *CreateSigningSessionsSucceeded:
+		env.Log.InfoS(ctx, "Signing sessions created, "+
+			"sending nonces to server",
+			slog.String("round_id", s.RoundID.String()),
+			slog.Int("session_count", len(evt.Sessions)),
+			slog.Int("signer_key_count", len(evt.AllNonces)))
+
+		nonceMsg := &SubmitNoncesRequest{
+			RoundID: s.RoundID,
+			Nonces:  evt.AllNonces,
+		}
+
+		return &ClientStateTransition{
+			NextState: &NoncesSentState{
+				RoundID:        s.RoundID,
+				CommitmentTx:   s.CommitmentTx,
+				VTXOTreePaths:  s.VTXOTreePaths,
+				Intents:        s.Intents.Clone(),
+				ClientTrees:    s.ClientTrees,
+				Musig2Sessions: evt.Sessions,
+				BoardingInputIndices: s.
+					BoardingInputIndices,
+				ForfeitMappings: s.ForfeitMappings,
 			},
 			NewEvents: fn.Some(ClientEmittedEvent{
 				Outbox: []ClientOutMsg{nonceMsg},
 			}),
 		}, nil
 
+	case *CreateSigningSessionsFailed:
+		return nil, fmt.Errorf(
+			"signing session creation failed: %w",
+			evt.Error,
+		)
+
 	default:
-		// Self-loop on unknown events - do not halt the FSM.
 		return selfLoop(s), nil
 	}
 }

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
-	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/lib/tree"
@@ -17,12 +16,6 @@ import (
 	"github.com/lightninglabs/darepo-client/lib/types"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 )
-
-// buildBoardingRequest constructs a types.BoardingRequest from a
-// BoardingIntent.
-func buildBoardingRequest(intent BoardingIntent) types.BoardingRequest {
-	return intent.Request
-}
 
 // failWithNotification creates a state transition to ClientFailedState and
 // emits a RoundFailedNotification. This is the standard pattern for handling
@@ -161,176 +154,35 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 			},
 		}, nil
 
-	// It's time to register our confirmed boarding UTXOs for the next
-	// round. We'll send a message to the server using our outbox, then
-	// transition to the next phase.
+	// It's time to register our confirmed boarding UTXOs for the
+	// next round. Emit BuildRegistrationReq for the outbox handler
+	// to perform I/O (forfeit amount lookup, key derivation,
+	// BIP-322 signing) and build the JoinRoundRequest.
 	case *RegistrationRequested:
-		env.Log.InfoS(ctx, "Registration requested, preparing to join round",
+		env.Log.InfoS(ctx, "Registration requested, delegating to handler",
 			slog.Int("boarding_intent_count", len(s.Boarding)),
-			slog.Int("vtxo_intent_count", len(s.VTXOs)))
+			slog.Int("vtxo_intent_count", len(s.VTXOs)),
+			slog.Int("forfeit_count", len(s.Forfeits)),
+			slog.Int("leave_count", len(s.Leaves)))
 
-		// Calculate total input amount from all boarding intents.
-		var totalInput btcutil.Amount
-		for _, boarding := range s.Boarding {
-			totalInput += boarding.ChainInfo.Amount
-		}
-
-		// Calculate total output amount from all VTXO requests.
-		var totalOutput btcutil.Amount
-		for _, vtxo := range s.VTXOs {
-			totalOutput += vtxo.Amount
-		}
-
-		// Include all forfeited VTXO amounts as inputs.
-		forfeitAmt, err := computeTotalForfeitAmount(
-			ctx, env.VTXOStore, s.Forfeits,
-		)
-		if err != nil {
-			return failWithNotification(
-				"failed to compute forfeit amount",
-				err, true, fn.None[RoundID](),
-			), nil
-		}
-		totalInput += forfeitAmt
-
-		// Include leave amounts as requested on-chain outputs.
-		for i, req := range s.Leaves {
-			if req.Output == nil {
-				return failWithNotification(
-					"leave request has nil output",
-					fmt.Errorf("leave request %d "+
-						"has nil output", i),
-					true, fn.None[RoundID](),
-				), nil
-			}
-
-			totalOutput += btcutil.Amount(req.Output.Value)
-		}
-
-		// Validate that we have outputs to create.
-		if totalOutput == 0 {
-			return failWithNotification(
-				"no VTXO output amount",
-				fmt.Errorf("total VTXO output is zero"),
-				true, fn.None[RoundID](),
-			), nil
-		}
-
-		// Validate that outputs don't exceed inputs.
-		if totalOutput > totalInput {
-			return failWithNotification(
-				"outputs exceed inputs",
-				fmt.Errorf(
-					"total output (%d) exceeds total "+
-						"input (%d)",
-					totalOutput, totalInput,
-				),
-				true, fn.None[RoundID](),
-			), nil
-		}
-
-		// Calculate the implicit operator fee (inputs - outputs).
-		operatorFee := totalInput - totalOutput
-
-		// Validate that the operator fee is within acceptable limits.
-		if operatorFee > env.MaxOperatorFee {
-			return failWithNotification(
-				"operator fee exceeds limit",
-				fmt.Errorf(
-					"operator fee (%d) exceeds max "+
-						"allowed (%d)",
-					operatorFee, env.MaxOperatorFee,
-				),
-				true, fn.None[RoundID](),
-			), nil
-		}
-
-		env.Log.InfoS(ctx, "Amount validation passed",
-			btclog.Fmt("total_input", "%v", totalInput),
-			btclog.Fmt("total_output", "%v", totalOutput),
-			btclog.Fmt("operator_fee", "%v", operatorFee))
-
-		// Extract the set of values from the intent map, as we don't
-		// need to track them by outpoint any longer.
-		boardingReqs := fn.Map(s.Boarding, buildBoardingRequest)
-		vtxoReqs := slices.Clone(s.VTXOs)
-
-		// Build forfeit requests from the decoupled forfeit pool.
-		forfeitReqs, err := sortedForfeitRequests(s.Forfeits)
-		if err != nil {
-			return failWithNotification(
-				"invalid forfeit requests",
-				err, true, fn.None[RoundID](),
-			), nil
-		}
-
-		// Leave requests are already in append order.
-		leaveReqs := slices.Clone(s.Leaves)
-
-		env.Log.InfoS(ctx, "Sending JoinRoundRequest to server",
-			slog.Int("boarding_requests", len(boardingReqs)),
-			slog.Int("vtxo_requests", len(vtxoReqs)),
-			slog.Int("forfeit_requests", len(forfeitReqs)),
-			slog.Int("leave_requests", len(leaveReqs)))
-
-		// Build Intents with all pools for downstream validation.
-		intent := Intents{
-			Boarding: slices.Clone(s.Boarding),
-			VTXOs:    vtxoReqs,
-			Leaves:   leaveReqs,
-			Forfeits: slices.Clone(s.Forfeits),
-		}
-
-		// Derive a fresh identifier key for the join-request
-		// authorization challenge.
-		identifierKeyDesc, err := deriveJoinAuthIdentifierKey(
-			ctx, env.Wallet,
-		)
-		if err != nil {
-			return failWithNotification(
-				"failed to derive join auth identifier",
-				err, true, fn.None[RoundID](),
-			), nil
-		}
-
-		idPub := identifierKeyDesc.PubKey
-
-		// When auth is enabled, produce a BIP-322 proof that
-		// binds the request contents to the identifier key.
-		var joinAuth *types.JoinRoundAuth
-		if !env.DisableJoinRequestAuth {
-			auth, err := buildJoinRoundAuth(
-				ctx, env, identifierKeyDesc, intent, vtxoReqs,
-				forfeitReqs, leaveReqs,
-			)
-			if err != nil {
-				return failWithNotification(
-					"failed to build round auth",
-					fmt.Errorf(
-						"join auth: %w", err,
-					),
-					true, fn.None[RoundID](),
-				), nil
-			}
-
-			joinAuth = auth
-		}
-
-		// With all this extracted, we'll now send the
-		// JoinRoundRequest to kick off the signing process.
 		return &ClientStateTransition{
-			NextState: &RegistrationSentState{
-				Intents: intent,
+			NextState: &AwaitingRegistrationBuildState{
+				Boarding: slices.Clone(s.Boarding),
+				VTXOs:    slices.Clone(s.VTXOs),
+				Forfeits: slices.Clone(s.Forfeits),
+				Leaves:   slices.Clone(s.Leaves),
 			},
 			NewEvents: fn.Some(ClientEmittedEvent{
 				Outbox: []ClientOutMsg{
-					&JoinRoundRequest{
-						BoardingRequests: boardingReqs,
-						VTXORequests:     vtxoReqs,
-						ForfeitRequests:  forfeitReqs,
-						LeaveRequests:    leaveReqs,
-						Identifier:       idPub,
-						Auth:             joinAuth,
+					&BuildRegistrationReq{
+						Boarding: slices.Clone(
+							s.Boarding,
+						),
+						VTXOs: slices.Clone(s.VTXOs),
+						Forfeits: slices.Clone(
+							s.Forfeits,
+						),
+						Leaves: slices.Clone(s.Leaves),
 					},
 				},
 			}),
@@ -347,6 +199,39 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 
 	default:
 		// Self-loop on unknown events - do not halt the FSM.
+		return selfLoop(s), nil
+	}
+}
+
+// ProcessEvent for AwaitingRegistrationBuildState handles the outbox
+// handler response after building the JoinRoundRequest. On success,
+// transitions to RegistrationSentState with the JoinRoundRequest
+// in the outbox; on failure, transitions to ClientFailedState.
+func (s *AwaitingRegistrationBuildState) ProcessEvent(
+	ctx context.Context, event ClientEvent, env *ClientEnvironment,
+) (*ClientStateTransition, error) {
+
+	switch evt := event.(type) {
+	case *BuildRegistrationSucceeded:
+		env.Log.InfoS(ctx, "Registration built, sending to server")
+
+		return &ClientStateTransition{
+			NextState: &RegistrationSentState{
+				Intents: evt.Intents,
+			},
+			NewEvents: fn.Some(ClientEmittedEvent{
+				Outbox: []ClientOutMsg{evt.JoinReq},
+			}),
+		}, nil
+
+	case *BuildRegistrationFailed:
+		return failWithNotification(
+			"registration build failed",
+			evt.Error, evt.Recoverable,
+			fn.None[RoundID](),
+		), nil
+
+	default:
 		return selfLoop(s), nil
 	}
 }

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -10,11 +10,8 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
 	"github.com/btcsuite/btcd/btcutil"
-	"github.com/btcsuite/btcd/btcutil/psbt"
-	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btclog/v2"
-	"github.com/lightninglabs/darepo-client/lib/scripts"
 	"github.com/lightninglabs/darepo-client/lib/tree"
 	"github.com/lightninglabs/darepo-client/lib/tx"
 	"github.com/lightninglabs/darepo-client/lib/types"
@@ -59,92 +56,6 @@ func selfLoop(state ClientState) *ClientStateTransition {
 	return &ClientStateTransition{
 		NextState: state,
 	}
-}
-
-// signBoardingInputs signs all boarding inputs for a commitment transaction.
-// This builds the PrevOutputFetcher, sigHashes, and generates Schnorr
-// signatures for each boarding intent's input.
-func signBoardingInputs(wallet ClientWallet, commitmentTx *psbt.Packet,
-	intents Intents, boardingInputIndices map[wire.OutPoint]int,
-) ([]*types.BoardingInputSignature, error) {
-
-	tx := commitmentTx.UnsignedTx
-
-	// Build a PrevOutputFetcher from ALL PSBT inputs. Taproot sighash
-	// (BIP341) requires prevout info for all inputs.
-	prevOuts := make(map[wire.OutPoint]*wire.TxOut)
-	for i, pIn := range commitmentTx.Inputs {
-		if pIn.WitnessUtxo == nil {
-			return nil, fmt.Errorf("PSBT input %d missing "+
-				"WitnessUtxo", i)
-		}
-		outpoint := tx.TxIn[i].PreviousOutPoint
-		prevOuts[outpoint] = pIn.WitnessUtxo
-	}
-	prevOutFetcher := txscript.NewMultiPrevOutFetcher(prevOuts)
-	sigHashes := txscript.NewTxSigHashes(tx, prevOutFetcher)
-
-	// Build structured boarding input signatures for each intent.
-	var boardingInputSigs []*types.BoardingInputSignature
-	for _, boardingIntent := range intents.Boarding {
-		outpoint := boardingIntent.Request.Outpoint
-		inputIdx, found := boardingInputIndices[*outpoint]
-		if !found {
-			return nil, fmt.Errorf("no input index "+
-				"found for boarding outpoint %s",
-				outpoint)
-		}
-
-		spendInfo, err := scripts.NewVTXOSpendInfo(
-			boardingIntent.Address.Tapscript,
-			scripts.VTXOCollabPathLeaf,
-		)
-		if err != nil {
-			return nil, err
-		}
-
-		chainInfo := boardingIntent.ChainInfo
-		addr := boardingIntent.Address.Address
-		amt := chainInfo.Amount
-
-		// Use PayToAddrScript to get the full pkScript with OP_1
-		// OP_PUSHBYTES_32 prefix for P2TR addresses. ScriptAddress()
-		// only returns the 32-byte witness program.
-		pkScript, err := txscript.PayToAddrScript(addr)
-		if err != nil {
-			return nil, fmt.Errorf("pay to addr script: %w", err)
-		}
-
-		output := &wire.TxOut{
-			Value:    int64(amt),
-			PkScript: pkScript,
-		}
-
-		signature, err := scripts.SignVTXOCollabInput(
-			wallet, tx, inputIdx, spendInfo,
-			&boardingIntent.Address.KeyDesc, output,
-			sigHashes, prevOutFetcher,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("failed to sign "+
-				"boarding input %d: %w", inputIdx, err)
-		}
-
-		schnorrSig, ok := signature.(*schnorr.Signature)
-		if !ok {
-			return nil, fmt.Errorf("signature is not a " +
-				"schnorr signature")
-		}
-
-		inputSig := &types.BoardingInputSignature{
-			InputIndex:      inputIdx,
-			Outpoint:        *outpoint,
-			ClientSignature: schnorrSig,
-		}
-		boardingInputSigs = append(boardingInputSigs, inputSig)
-	}
-
-	return boardingInputSigs, nil
 }
 
 // ProcessEvent handles events in the Idle state. The only pool-addition
@@ -1038,68 +949,34 @@ func (s *ForfeitSignaturesCollectingState) ProcessEvent(
 			forfeitedVTXOs = append(forfeitedVTXOs, outpoint)
 		}
 
-		env.Log.InfoS(ctx, "All forfeit signatures collected, signing boarding inputs",
+		env.Log.InfoS(ctx, "All forfeit signatures collected, requesting boarding signing",
 			slog.String("round_id", s.RoundID.String()),
 			slog.Int("forfeit_count", len(forfeitedVTXOs)),
-			slog.Int("boarding_intent_count", len(s.Intents.Boarding)))
+			slog.Int("boarding_intent_count",
+				len(s.Intents.Boarding)))
 
-		// Sign all boarding inputs using the shared helper.
-		boardingInputSigs, err := signBoardingInputs(
-			env.Wallet, s.CommitmentTx, s.Intents,
-			s.BoardingInputIndices,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("sign boarding inputs: %w", err)
-		}
-
-		// Build the Round object for checkpointing.
-		intents := s.Intents.Clone()
-		for i := range intents.Boarding {
-			intents.Boarding[i].Status = BoardingStatusAdopted
-		}
-		round := &Round{
-			RoundID:       s.RoundID,
-			StartHeight:   env.StartHeight,
-			CommitmentTx:  fn.Some(s.CommitmentTx),
-			VTXOTreePaths: fn.Some(s.VTXOTreePaths),
-			Intents:       intents,
-		}
-
-		checkpointState := &InputSigSentState{
-			RoundID:        s.RoundID,
-			CommitmentTx:   s.CommitmentTx,
-			VTXOTreePaths:  s.VTXOTreePaths,
-			Intents:        s.Intents.Clone(),
-			ClientTrees:    s.ClientTrees,
-			InputSigs:      boardingInputSigs,
-			ForfeitedVTXOs: forfeitedVTXOs,
-		}
-
-		env.Log.InfoS(ctx, "Signed boarding inputs, requesting checkpoint",
-			slog.String("round_id", s.RoundID.String()),
-			slog.Int("boarding_sig_count", len(boardingInputSigs)),
-			slog.Int("forfeit_sig_count", len(forfeitSigs)))
-
-		// Emit CommitRoundStateReq for the outbox handler to
-		// persist the round checkpoint.
+		// Emit SignBoardingInputsReq for the outbox handler
+		// to sign the boarding inputs. Carry forfeit data
+		// forward so the checkpoint state can include it.
 		return &ClientStateTransition{
-			NextState: &AwaitingRoundCheckpointState{
+			NextState: &AwaitingBoardingSignaturesState{
 				RoundID:              s.RoundID,
 				CommitmentTx:         s.CommitmentTx,
 				VTXOTreePaths:        s.VTXOTreePaths,
 				Intents:              s.Intents.Clone(),
 				ClientTrees:          s.ClientTrees,
 				BoardingInputIndices: s.BoardingInputIndices,
-				InputSigs:            boardingInputSigs,
 				ForfeitedVTXOs:       forfeitedVTXOs,
 				ForfeitSigs:          forfeitSigs,
 				ForfeitTxs:           forfeitTxs,
 			},
 			NewEvents: fn.Some(ClientEmittedEvent{
 				Outbox: []ClientOutMsg{
-					&CommitRoundStateReq{
-						Round: round,
-						State: checkpointState,
+					&SignBoardingInputsReq{
+						CommitmentTx: s.CommitmentTx,
+						Intents:      s.Intents.Clone(),
+						BoardingInputIndices: s.
+							BoardingInputIndices,
 					},
 				},
 			}),
@@ -1314,66 +1191,29 @@ func (s *PartialSigsSentState) ProcessEvent(
 			return s.transitionToForfeitCollection(ctx, env)
 		}
 
-		// No refresh requests - proceed to sign boarding inputs.
-		env.Log.InfoS(ctx, "Signing boarding inputs",
+		// No refresh requests - emit SignBoardingInputsReq for
+		// the outbox handler to sign the boarding inputs.
+		env.Log.InfoS(ctx, "Requesting boarding input signing",
 			slog.String("round_id", s.RoundID.String()),
-			slog.Int("boarding_intent_count", len(s.Intents.Boarding)))
+			slog.Int("boarding_intent_count",
+				len(s.Intents.Boarding)))
 
-		// Sign all boarding inputs using the shared helper.
-		boardingInputSigs, err := signBoardingInputs(
-			env.Wallet, s.CommitmentTx, s.Intents,
-			s.BoardingInputIndices,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("sign boarding inputs: %w", err)
-		}
-
-		// Build the Round object for checkpointing. Mark all
-		// intents as Adopted (frozen in this round).
-		intents := s.Intents.Clone()
-		for i := range intents.Boarding {
-			intents.Boarding[i].Status = BoardingStatusAdopted
-		}
-		round := &Round{
-			RoundID:       s.RoundID,
-			StartHeight:   env.StartHeight,
-			CommitmentTx:  fn.Some(s.CommitmentTx),
-			VTXOTreePaths: fn.Some(s.VTXOTreePaths),
-			Intents:       intents,
-		}
-
-		// Build the next state for the checkpoint.
-		checkpointState := &InputSigSentState{
-			RoundID:       s.RoundID,
-			CommitmentTx:  s.CommitmentTx,
-			VTXOTreePaths: s.VTXOTreePaths,
-			Intents:       s.Intents.Clone(),
-			ClientTrees:   s.ClientTrees,
-			InputSigs:     boardingInputSigs,
-		}
-
-		env.Log.InfoS(ctx, "Signed boarding inputs, requesting checkpoint",
-			slog.String("round_id", s.RoundID.String()),
-			slog.Int("boarding_sig_count", len(boardingInputSigs)))
-
-		// Emit CommitRoundStateReq for the outbox handler to
-		// persist the round checkpoint. The FSM transitions to
-		// an awaiting state until the handler responds.
 		return &ClientStateTransition{
-			NextState: &AwaitingRoundCheckpointState{
+			NextState: &AwaitingBoardingSignaturesState{
 				RoundID:              s.RoundID,
 				CommitmentTx:         s.CommitmentTx,
 				VTXOTreePaths:        s.VTXOTreePaths,
 				Intents:              s.Intents.Clone(),
 				ClientTrees:          s.ClientTrees,
 				BoardingInputIndices: s.BoardingInputIndices,
-				InputSigs:            boardingInputSigs,
 			},
 			NewEvents: fn.Some(ClientEmittedEvent{
 				Outbox: []ClientOutMsg{
-					&CommitRoundStateReq{
-						Round: round,
-						State: checkpointState,
+					&SignBoardingInputsReq{
+						CommitmentTx: s.CommitmentTx,
+						Intents:      s.Intents.Clone(),
+						BoardingInputIndices: s.
+							BoardingInputIndices,
 					},
 				},
 			}),
@@ -1481,6 +1321,82 @@ func buildClientVTXOs(intents Intents, trees map[SignerKey]*tree.Tree,
 }
 
 // ProcessEvent for AwaitingRoundCheckpointState. Handles the outbox
+// ProcessEvent for AwaitingBoardingSignaturesState handles the outbox
+// handler response after boarding input signing is attempted. On
+// success, builds the Round object and emits CommitRoundStateReq to
+// persist the checkpoint, transitioning to
+// AwaitingRoundCheckpointState.
+func (s *AwaitingBoardingSignaturesState) ProcessEvent(
+	ctx context.Context, event ClientEvent, env *ClientEnvironment,
+) (*ClientStateTransition, error) {
+
+	switch evt := event.(type) {
+	case *SignBoardingInputsSucceeded:
+		env.Log.InfoS(ctx, "Boarding inputs signed, requesting checkpoint",
+			slog.String("round_id", s.RoundID.String()),
+			slog.Int("boarding_sig_count",
+				len(evt.InputSigs)))
+
+		// Build the Round object for checkpointing. Mark all
+		// intents as Adopted (frozen in this round).
+		intents := s.Intents.Clone()
+		for i := range intents.Boarding {
+			intents.Boarding[i].Status =
+				BoardingStatusAdopted
+		}
+		round := &Round{
+			RoundID:       s.RoundID,
+			StartHeight:   env.StartHeight,
+			CommitmentTx:  fn.Some(s.CommitmentTx),
+			VTXOTreePaths: fn.Some(s.VTXOTreePaths),
+			Intents:       intents,
+		}
+
+		// Build the state that the checkpoint will persist.
+		checkpointState := &InputSigSentState{
+			RoundID:        s.RoundID,
+			CommitmentTx:   s.CommitmentTx,
+			VTXOTreePaths:  s.VTXOTreePaths,
+			Intents:        s.Intents.Clone(),
+			ClientTrees:    s.ClientTrees,
+			InputSigs:      evt.InputSigs,
+			ForfeitedVTXOs: s.ForfeitedVTXOs,
+		}
+
+		return &ClientStateTransition{
+			NextState: &AwaitingRoundCheckpointState{
+				RoundID:       s.RoundID,
+				CommitmentTx:  s.CommitmentTx,
+				VTXOTreePaths: s.VTXOTreePaths,
+				Intents:       s.Intents.Clone(),
+				ClientTrees:   s.ClientTrees,
+				BoardingInputIndices: s.
+					BoardingInputIndices,
+				InputSigs:      evt.InputSigs,
+				ForfeitedVTXOs: s.ForfeitedVTXOs,
+				ForfeitSigs:    s.ForfeitSigs,
+				ForfeitTxs:     s.ForfeitTxs,
+			},
+			NewEvents: fn.Some(ClientEmittedEvent{
+				Outbox: []ClientOutMsg{
+					&CommitRoundStateReq{
+						Round: round,
+						State: checkpointState,
+					},
+				},
+			}),
+		}, nil
+
+	case *SignBoardingInputsFailed:
+		return nil, fmt.Errorf("failed to sign boarding "+
+			"inputs: %w", evt.Error)
+
+	default:
+		return selfLoop(s), nil
+	}
+}
+
+// ProcessEvent for AwaitingRoundCheckpointState handles the outbox
 // handler response after round checkpoint persistence is attempted.
 // On success, transitions to InputSigSentState and emits server
 // submission messages (forfeit sigs, boarding sigs, confirmation

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -1027,7 +1027,8 @@ func (s *ForfeitSignaturesCollectingState) ProcessEvent(
 			}, nil
 		}
 
-		// All forfeit signatures collected! Build the submission.
+		// All forfeit signatures collected! Build the submission
+		// maps from the collected responses.
 		forfeitSigs := make(map[wire.OutPoint]*schnorr.Signature)
 		forfeitTxs := make(map[wire.OutPoint]*wire.MsgTx)
 		forfeitedVTXOs := make([]wire.OutPoint, 0, len(updatedForfeits))
@@ -1051,35 +1052,7 @@ func (s *ForfeitSignaturesCollectingState) ProcessEvent(
 			return nil, fmt.Errorf("sign boarding inputs: %w", err)
 		}
 
-		// Build outbox messages.
-		txid := s.CommitmentTx.UnsignedTx.TxHash()
-		callerID := fmt.Sprintf("commitment-%s", txid.String())
-
-		var pkScript []byte
-		if len(s.CommitmentTx.UnsignedTx.TxOut) > 0 {
-			pkScript = s.CommitmentTx.UnsignedTx.TxOut[0].PkScript
-		}
-
-		outboxMsgs := []ClientOutMsg{
-			&SubmitVTXOForfeitSigsToServer{
-				RoundID:     s.RoundID,
-				ForfeitSigs: forfeitSigs,
-				ForfeitTxs:  forfeitTxs,
-			},
-			&SubmitForfeitSigRequest{
-				RoundID:    s.RoundID,
-				Signatures: boardingInputSigs,
-			},
-			&RegisterConfirmationRequest{
-				CallerID:    callerID,
-				Txid:        &txid,
-				PkScript:    pkScript,
-				TargetConfs: env.OperatorTerms.MinConfirmations,
-				HeightHint:  env.StartHeight,
-			},
-		}
-
-		// Checkpoint round state.
+		// Build the Round object for checkpointing.
 		intents := s.Intents.Clone()
 		for i := range intents.Boarding {
 			intents.Boarding[i].Status = BoardingStatusAdopted
@@ -1092,7 +1065,7 @@ func (s *ForfeitSignaturesCollectingState) ProcessEvent(
 			Intents:       intents,
 		}
 
-		nextState := &InputSigSentState{
+		checkpointState := &InputSigSentState{
 			RoundID:        s.RoundID,
 			CommitmentTx:   s.CommitmentTx,
 			VTXOTreePaths:  s.VTXOTreePaths,
@@ -1102,25 +1075,33 @@ func (s *ForfeitSignaturesCollectingState) ProcessEvent(
 			ForfeitedVTXOs: forfeitedVTXOs,
 		}
 
-		err = env.RoundStore.CommitState(ctx, round, nextState)
-		if err != nil {
-			return nil, fmt.Errorf("failed to commit round "+
-				"state: %w", err)
-		}
-
-		env.Log.InfoS(ctx, "Round state checkpointed with forfeit signatures",
+		env.Log.InfoS(ctx, "Signed boarding inputs, requesting checkpoint",
 			slog.String("round_id", s.RoundID.String()),
 			slog.Int("boarding_sig_count", len(boardingInputSigs)),
 			slog.Int("forfeit_sig_count", len(forfeitSigs)))
 
-		checkpointNotify := &RoundCheckpointedNotification{
-			RoundID: s.RoundID,
-		}
-
+		// Emit CommitRoundStateReq for the outbox handler to
+		// persist the round checkpoint.
 		return &ClientStateTransition{
-			NextState: nextState,
+			NextState: &AwaitingRoundCheckpointState{
+				RoundID:              s.RoundID,
+				CommitmentTx:         s.CommitmentTx,
+				VTXOTreePaths:        s.VTXOTreePaths,
+				Intents:              s.Intents.Clone(),
+				ClientTrees:          s.ClientTrees,
+				BoardingInputIndices: s.BoardingInputIndices,
+				InputSigs:            boardingInputSigs,
+				ForfeitedVTXOs:       forfeitedVTXOs,
+				ForfeitSigs:          forfeitSigs,
+				ForfeitTxs:           forfeitTxs,
+			},
 			NewEvents: fn.Some(ClientEmittedEvent{
-				Outbox: append(outboxMsgs, checkpointNotify),
+				Outbox: []ClientOutMsg{
+					&CommitRoundStateReq{
+						Round: round,
+						State: checkpointState,
+					},
+				},
 			}),
 		}, nil
 
@@ -1347,49 +1328,8 @@ func (s *PartialSigsSentState) ProcessEvent(
 			return nil, fmt.Errorf("sign boarding inputs: %w", err)
 		}
 
-		// Create a single forfeit signature request with all
-		// signatures.
-		forfeitSigReq := &SubmitForfeitSigRequest{
-			RoundID:    s.RoundID,
-			Signatures: boardingInputSigs,
-		}
-
-		txid := s.CommitmentTx.UnsignedTx.TxHash()
-		callerID := fmt.Sprintf("commitment-%s", txid.String())
-
-		// Get pkScript from the first output for LND confirmation
-		// tracking.
-		commitTx := s.CommitmentTx.UnsignedTx
-		var pkScript []byte
-		if len(commitTx.TxOut) > 0 {
-			pkScript = commitTx.TxOut[0].PkScript
-		}
-
-		env.Log.InfoS(ctx, "Building RegisterConfirmationRequest",
-			slog.String("round_id", s.RoundID.String()),
-			slog.String("txid", txid.String()),
-			slog.Int("num_outputs", len(commitTx.TxOut)),
-			slog.Int("pkscript_len", len(pkScript)),
-			slog.Int("target_confs", int(env.OperatorTerms.MinConfirmations)))
-
-		outboxMsgs := []ClientOutMsg{
-			forfeitSigReq,
-			&RegisterConfirmationRequest{
-				CallerID:    callerID,
-				Txid:        &txid,
-				PkScript:    pkScript,
-				TargetConfs: env.OperatorTerms.MinConfirmations,
-				HeightHint:  env.StartHeight,
-			},
-		}
-
-		// Checkpoint the round state at the "point of no return".
-		// After sending boarding input signatures, the server may
-		// broadcast the commitment transaction. We must persist all
-		// round data to enable recovery if the client restarts.
-		//
-		// Mark all intents as Adopted (frozen in this round) and then
-		// save them alongside the round.
+		// Build the Round object for checkpointing. Mark all
+		// intents as Adopted (frozen in this round).
 		intents := s.Intents.Clone()
 		for i := range intents.Boarding {
 			intents.Boarding[i].Status = BoardingStatusAdopted
@@ -1402,15 +1342,8 @@ func (s *PartialSigsSentState) ProcessEvent(
 			Intents:       intents,
 		}
 
-		env.Log.InfoS(ctx, "Signed boarding inputs, checkpointing round state",
-			slog.String("round_id", s.RoundID.String()),
-			slog.Int("boarding_sig_count", len(boardingInputSigs)))
-
-		// Checkpoint round data + FSM state atomically at the "point
-		// of no return". The next state is persisted so restart can
-		// recover to InputSigSentState. For boarding-only rounds,
-		// ForfeitedVTXOs is nil.
-		nextState := &InputSigSentState{
+		// Build the next state for the checkpoint.
+		checkpointState := &InputSigSentState{
 			RoundID:       s.RoundID,
 			CommitmentTx:  s.CommitmentTx,
 			VTXOTreePaths: s.VTXOTreePaths,
@@ -1418,24 +1351,31 @@ func (s *PartialSigsSentState) ProcessEvent(
 			ClientTrees:   s.ClientTrees,
 			InputSigs:     boardingInputSigs,
 		}
-		err = env.RoundStore.CommitState(ctx, round, nextState)
-		if err != nil {
-			return nil, fmt.Errorf("failed to commit round "+
-				"state: %w", err)
-		}
 
-		env.Log.InfoS(ctx, "Round state checkpointed at point of no return",
+		env.Log.InfoS(ctx, "Signed boarding inputs, requesting checkpoint",
 			slog.String("round_id", s.RoundID.String()),
-			slog.String("commitment_txid", txid.String()))
+			slog.Int("boarding_sig_count", len(boardingInputSigs)))
 
-		checkpointNotify := &RoundCheckpointedNotification{
-			RoundID: s.RoundID,
-		}
-
+		// Emit CommitRoundStateReq for the outbox handler to
+		// persist the round checkpoint. The FSM transitions to
+		// an awaiting state until the handler responds.
 		return &ClientStateTransition{
-			NextState: nextState,
+			NextState: &AwaitingRoundCheckpointState{
+				RoundID:              s.RoundID,
+				CommitmentTx:         s.CommitmentTx,
+				VTXOTreePaths:        s.VTXOTreePaths,
+				Intents:              s.Intents.Clone(),
+				ClientTrees:          s.ClientTrees,
+				BoardingInputIndices: s.BoardingInputIndices,
+				InputSigs:            boardingInputSigs,
+			},
 			NewEvents: fn.Some(ClientEmittedEvent{
-				Outbox: append(outboxMsgs, checkpointNotify),
+				Outbox: []ClientOutMsg{
+					&CommitRoundStateReq{
+						Round: round,
+						State: checkpointState,
+					},
+				},
 			}),
 		}, nil
 
@@ -1538,6 +1478,85 @@ func buildClientVTXOs(intents Intents, trees map[SignerKey]*tree.Tree,
 	}
 
 	return vtxos, nil
+}
+
+// ProcessEvent for AwaitingRoundCheckpointState. Handles the outbox
+// handler response after round checkpoint persistence is attempted.
+// On success, transitions to InputSigSentState and emits server
+// submission messages (forfeit sigs, boarding sigs, confirmation
+// registration, checkpoint notification).
+func (s *AwaitingRoundCheckpointState) ProcessEvent(
+	ctx context.Context, event ClientEvent, env *ClientEnvironment,
+) (*ClientStateTransition, error) {
+
+	switch evt := event.(type) {
+	case *CommitRoundStateSucceeded:
+		env.Log.InfoS(ctx, "Round state checkpointed",
+			slog.String("round_id", s.RoundID.String()))
+
+		// Build the server submission outbox messages.
+		txid := s.CommitmentTx.UnsignedTx.TxHash()
+		callerID := fmt.Sprintf("commitment-%s", txid.String())
+
+		var pkScript []byte
+		if len(s.CommitmentTx.UnsignedTx.TxOut) > 0 {
+			pkScript = s.CommitmentTx.UnsignedTx.
+				TxOut[0].PkScript
+		}
+
+		var outbox []ClientOutMsg
+
+		// If forfeit sigs are present (refresh round), submit
+		// them to the server.
+		if len(s.ForfeitSigs) > 0 {
+			outbox = append(outbox,
+				&SubmitVTXOForfeitSigsToServer{
+					RoundID:     s.RoundID,
+					ForfeitSigs: s.ForfeitSigs,
+					ForfeitTxs:  s.ForfeitTxs,
+				})
+		}
+
+		outbox = append(outbox,
+			&SubmitForfeitSigRequest{
+				RoundID:    s.RoundID,
+				Signatures: s.InputSigs,
+			},
+			&RegisterConfirmationRequest{
+				CallerID: callerID,
+				Txid:     &txid,
+				PkScript: pkScript,
+				TargetConfs: env.OperatorTerms.
+					MinConfirmations,
+				HeightHint: env.StartHeight,
+			},
+			&RoundCheckpointedNotification{
+				RoundID: s.RoundID,
+			},
+		)
+
+		return &ClientStateTransition{
+			NextState: &InputSigSentState{
+				RoundID:        s.RoundID,
+				CommitmentTx:   s.CommitmentTx,
+				VTXOTreePaths:  s.VTXOTreePaths,
+				Intents:        s.Intents.Clone(),
+				ClientTrees:    s.ClientTrees,
+				InputSigs:      s.InputSigs,
+				ForfeitedVTXOs: s.ForfeitedVTXOs,
+			},
+			NewEvents: fn.Some(ClientEmittedEvent{
+				Outbox: outbox,
+			}),
+		}, nil
+
+	case *CommitRoundStateFailed:
+		return nil, fmt.Errorf("failed to commit round "+
+			"state: %w", evt.Error)
+
+	default:
+		return selfLoop(s), nil
+	}
 }
 
 // ProcessEvent for InputSigSentState.

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -1672,11 +1672,10 @@ func (s *ConfirmedState) ProcessEvent(_ context.Context, event ClientEvent,
 	}
 }
 
-// ProcessEvent for ClientFailedState. This state is now recoverable and
-// accepts the same events as Idle (BoardingUTXOConfirmed,
-// ResumeBoardingIntents) to allow the FSM to restart the boarding process
-// after a failure. Instead of duplicating the Idle logic, we transition to
-// Idle and forward the event as an internal event for Idle to process.
+// ProcessEvent for ClientFailedState. This state is recoverable and
+// accepts IntentPackage events to restart the boarding process after a
+// failure. Instead of duplicating the Idle logic, we transition to Idle
+// and forward the event as an internal event for Idle to process.
 func (s *ClientFailedState) ProcessEvent(
 	ctx context.Context, event ClientEvent, env *ClientEnvironment,
 ) (*ClientStateTransition, error) {

--- a/round/transitions_test.go
+++ b/round/transitions_test.go
@@ -1,10 +1,10 @@
 package round
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
-	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/google/uuid"
@@ -123,6 +123,11 @@ func TestStateProperties(t *testing.T) {
 				"AwaitingSaveVTXOs",
 				&AwaitingSaveVTXOsState{},
 				"AwaitingSaveVTXOs",
+			},
+			{
+				"AwaitingRegistrationBuild",
+				&AwaitingRegistrationBuildState{},
+				"AwaitingRegistrationBuild",
 			},
 			{
 				"ClientFailed",
@@ -606,6 +611,11 @@ func TestPendingRoundAssemblyState(t *testing.T) {
 		require.Len(t, nextState.Boarding, 2)
 	})
 
+	// Tests below use the two-hop pattern. RegistrationRequested
+	// now delegates I/O to the outbox handler and transitions to
+	// AwaitingRegistrationBuildState. The handler response
+	// (BuildRegistrationSucceeded/Failed) drives the next hop.
+
 	t.Run("registration_requested_transitions", func(t *testing.T) {
 		t.Parallel()
 
@@ -618,9 +628,41 @@ func TestPendingRoundAssemblyState(t *testing.T) {
 			VTXOs:    []types.VTXORequest{vtxoReq},
 		})
 
+		// Hop 1: RegistrationRequested →
+		// AwaitingRegistrationBuildState + BuildRegistrationReq.
 		event := &RegistrationRequested{}
-
 		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		awaitState := assertStateType[*AwaitingRegistrationBuildState](h) //nolint:ll
+		require.Len(t, awaitState.Boarding, 1)
+		require.Len(t, awaitState.VTXOs, 1)
+
+		require.Len(t, h.outboxMessages, 1)
+		_, ok := h.outboxMessages[0].(*BuildRegistrationReq)
+		require.True(t, ok)
+
+		// Hop 2: BuildRegistrationSucceeded →
+		// RegistrationSentState.
+		h.outboxMessages = nil
+		joinReq := &JoinRoundRequest{
+			BoardingRequests: []types.BoardingRequest{
+				intent.Request,
+			},
+			VTXORequests: []types.VTXORequest{vtxoReq},
+		}
+		intents := Intents{
+			Boarding: []BoardingIntent{intent},
+			VTXOs:    []types.VTXORequest{vtxoReq},
+		}
+
+		transition, err = h.sendEvent(
+			&BuildRegistrationSucceeded{
+				JoinReq: joinReq,
+				Intents: intents,
+			},
+		)
 		require.NoError(t, err)
 		require.NotNil(t, transition)
 
@@ -628,116 +670,34 @@ func TestPendingRoundAssemblyState(t *testing.T) {
 		require.Len(t, nextState.Intents.Boarding, 1)
 	})
 
-	t.Run("no_intents_transitions_to_failed", func(t *testing.T) {
+	t.Run("build_registration_failed_transitions", func(t *testing.T) {
 		t.Parallel()
 
 		h := newTestHarness(t)
-		h.withState(&PendingRoundAssembly{
+
+		// Start in AwaitingRegistrationBuildState directly
+		// to test the failure path.
+		h.withState(&AwaitingRegistrationBuildState{
 			Boarding: []BoardingIntent{},
 			VTXOs:    []types.VTXORequest{},
 		})
 
-		event := &RegistrationRequested{}
-
-		transition, err := h.sendEvent(event)
-		require.NoError(t, err)
-		require.NotNil(t, transition)
-
-		// With no VTXOs, total output is zero which fails validation.
-		failedState := assertStateType[*ClientFailedState](h)
-		require.Contains(t, failedState.Reason, "no VTXO output amount")
-	})
-
-	t.Run("output_exceeds_input_fails", func(t *testing.T) {
-		t.Parallel()
-
-		h := newTestHarness(t)
-
-		// Create intent with 50,000 sats.
-		intent := h.newTestBoardingIntent()
-		require.Equal(t, btcutil.Amount(50000), intent.ChainInfo.Amount)
-
-		// Create VTXO request for 60,000 sats (more than input).
-		vtxoReq := h.newTestVTXORequestForIntent(intent)
-		vtxoReq.Amount = btcutil.Amount(60000)
-
-		h.withState(&PendingRoundAssembly{
-			Boarding: []BoardingIntent{intent},
-			VTXOs:    []types.VTXORequest{vtxoReq},
-		})
-
-		event := &RegistrationRequested{}
-
-		transition, err := h.sendEvent(event)
-		require.NoError(t, err)
-		require.NotNil(t, transition)
-
-		failedState := assertStateType[*ClientFailedState](h)
-		require.Contains(t, failedState.Reason, "outputs exceed inputs")
-	})
-
-	t.Run("fee_exceeds_max_fails", func(t *testing.T) {
-		t.Parallel()
-
-		h := newTestHarness(t)
-
-		// Set a low max operator fee (1,000 sats).
-		h.env.MaxOperatorFee = btcutil.Amount(1000)
-
-		// Create intent with 50,000 sats.
-		intent := h.newTestBoardingIntent()
-		require.Equal(t, btcutil.Amount(50000), intent.ChainInfo.Amount)
-
-		// Create VTXO request for 40,000 sats, implying 10,000 sat fee.
-		vtxoReq := h.newTestVTXORequestForIntent(intent)
-		vtxoReq.Amount = btcutil.Amount(40000)
-
-		h.withState(&PendingRoundAssembly{
-			Boarding: []BoardingIntent{intent},
-			VTXOs:    []types.VTXORequest{vtxoReq},
-		})
-
-		event := &RegistrationRequested{}
-
-		transition, err := h.sendEvent(event)
+		transition, err := h.sendEvent(
+			&BuildRegistrationFailed{
+				Error: fmt.Errorf(
+					"total VTXO output is zero",
+				),
+				Recoverable: true,
+			},
+		)
 		require.NoError(t, err)
 		require.NotNil(t, transition)
 
 		failedState := assertStateType[*ClientFailedState](h)
 		require.Contains(
-			t, failedState.Reason, "operator fee exceeds limit",
+			t, failedState.Reason,
+			"registration build failed",
 		)
-	})
-
-	t.Run("valid_fee_within_limit_succeeds", func(t *testing.T) {
-		t.Parallel()
-
-		h := newTestHarness(t)
-
-		// Set max operator fee (10,000 sats).
-		h.env.MaxOperatorFee = btcutil.Amount(10000)
-
-		// Create intent with 50,000 sats.
-		intent := h.newTestBoardingIntent()
-
-		// Create VTXO request for 45,000 sats, implying 5,000 sat fee.
-		vtxoReq := h.newTestVTXORequestForIntent(intent)
-		vtxoReq.Amount = btcutil.Amount(45000)
-
-		h.withState(&PendingRoundAssembly{
-			Boarding: []BoardingIntent{intent},
-			VTXOs:    []types.VTXORequest{vtxoReq},
-		})
-
-		event := &RegistrationRequested{}
-
-		transition, err := h.sendEvent(event)
-		require.NoError(t, err)
-		require.NotNil(t, transition)
-
-		// Should succeed and transition to RegistrationSentState.
-		nextState := assertStateType[*RegistrationSentState](h)
-		require.Len(t, nextState.Intents.Boarding, 1)
 	})
 }
 
@@ -1589,15 +1549,34 @@ func TestBoardingFlowIdleToPendingToRegistrationSent(t *testing.T) {
 		VTXOs:    []types.VTXORequest{vtxoReq},
 	})
 
-	// Step 1: Request registration.
+	// Step 1: Request registration → AwaitingRegistrationBuild.
 	regEvent := &RegistrationRequested{}
 	_, err := h.sendEvent(regEvent)
+	require.NoError(t, err)
+
+	assertStateType[*AwaitingRegistrationBuildState](h) //nolint:ll
+	h.outboxMessages = nil
+
+	// Step 2: Handler builds → RegistrationSentState.
+	intents := Intents{
+		Boarding: []BoardingIntent{intent},
+		VTXOs:    []types.VTXORequest{vtxoReq},
+	}
+	_, err = h.sendEvent(&BuildRegistrationSucceeded{
+		JoinReq: &JoinRoundRequest{
+			BoardingRequests: []types.BoardingRequest{
+				intent.Request,
+			},
+			VTXORequests: []types.VTXORequest{vtxoReq},
+		},
+		Intents: intents,
+	})
 	require.NoError(t, err)
 
 	regState := assertStateType[*RegistrationSentState](h)
 	require.Len(t, regState.Intents.Boarding, 1)
 
-	// Step 2: Server accepts.
+	// Step 3: Server accepts.
 	joinEvent := &RoundJoined{RoundID: testRoundIDTr("round-001")}
 	_, err = h.sendEvent(joinEvent)
 	require.NoError(t, err)
@@ -1642,15 +1621,36 @@ func TestBoardingFlowPendingToRoundJoined(t *testing.T) {
 		VTXOs:    []types.VTXORequest{vtxoReq},
 	})
 
-	// Step 1: PendingRoundAssembly → RegistrationSentState.
+	// Step 1: PendingRoundAssembly →
+	// AwaitingRegistrationBuildState.
 	regEvent := &RegistrationRequested{}
 	_, err := h.sendEvent(regEvent)
+	require.NoError(t, err)
+
+	assertStateType[*AwaitingRegistrationBuildState](h) //nolint:ll
+	h.outboxMessages = nil
+
+	// Step 2: BuildRegistrationSucceeded →
+	// RegistrationSentState.
+	intents := Intents{
+		Boarding: []BoardingIntent{intent},
+		VTXOs:    []types.VTXORequest{vtxoReq},
+	}
+	_, err = h.sendEvent(&BuildRegistrationSucceeded{
+		JoinReq: &JoinRoundRequest{
+			BoardingRequests: []types.BoardingRequest{
+				intent.Request,
+			},
+			VTXORequests: []types.VTXORequest{vtxoReq},
+		},
+		Intents: intents,
+	})
 	require.NoError(t, err)
 
 	regSentState := assertStateType[*RegistrationSentState](h)
 	require.Len(t, regSentState.Intents.Boarding, 1)
 
-	// Step 2: RegistrationSentState → RoundJoinedState.
+	// Step 3: RegistrationSentState → RoundJoinedState.
 	integrationRoundID := testRoundIDTr("round-integration-001")
 	joinEvent := &RoundJoined{RoundID: integrationRoundID}
 	_, err = h.sendEvent(joinEvent)

--- a/round/transitions_test.go
+++ b/round/transitions_test.go
@@ -110,6 +110,11 @@ func TestStateProperties(t *testing.T) {
 				"InputSigSent",
 			},
 			{
+				"AwaitingBoardingSignatures",
+				&AwaitingBoardingSignaturesState{},
+				"AwaitingBoardingSignatures",
+			},
+			{
 				"AwaitingRoundCheckpoint",
 				&AwaitingRoundCheckpointState{},
 				"AwaitingRoundCheckpoint",
@@ -1051,7 +1056,6 @@ func TestPartialSigsSentState(t *testing.T) {
 			Musig2Sessions: make(map[SignerKey]*tree.SignerSession),
 		}
 
-		h.setupMockWalletForBoardingSigning()
 		h.withState(state)
 
 		event := &OperatorSigned{
@@ -1059,16 +1063,40 @@ func TestPartialSigsSentState(t *testing.T) {
 			AggSigs: validSigs,
 		}
 
+		expectedRoundID := testRoundIDTr("round-real-sig-001")
+
 		// Hop 1: OperatorSigned →
-		// AwaitingRoundCheckpointState with
-		// CommitRoundStateReq in outbox.
+		// AwaitingBoardingSignaturesState with
+		// SignBoardingInputsReq in outbox.
 		transition, err := h.sendEvent(event)
 		require.NoError(t, err)
 		require.NotNil(t, transition)
 
 		//nolint:ll
+		boardingSigState := assertStateType[*AwaitingBoardingSignaturesState](h.boardingTestHarness)
+		require.Equal(
+			t, expectedRoundID, boardingSigState.RoundID,
+		)
+		h.assertOutboxContainsType(
+			"*round.SignBoardingInputsReq",
+		)
+		h.clearOutbox()
+
+		// Hop 2: SignBoardingInputsSucceeded →
+		// AwaitingRoundCheckpointState with
+		// CommitRoundStateReq in outbox.
+		transition, err = h.sendEvent(
+			&SignBoardingInputsSucceeded{
+				InputSigs: []*types.BoardingInputSignature{
+					{InputIndex: 0},
+				},
+			},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		//nolint:ll
 		checkpointState := assertStateType[*AwaitingRoundCheckpointState](h.boardingTestHarness)
-		expectedRoundID := testRoundIDTr("round-real-sig-001")
 		require.Equal(
 			t, expectedRoundID, checkpointState.RoundID,
 		)
@@ -1078,7 +1106,7 @@ func TestPartialSigsSentState(t *testing.T) {
 		)
 		h.clearOutbox()
 
-		// Hop 2: CommitRoundStateSucceeded →
+		// Hop 3: CommitRoundStateSucceeded →
 		// InputSigSentState.
 		transition, err = h.sendEvent(
 			&CommitRoundStateSucceeded{},
@@ -1752,7 +1780,6 @@ func TestForfeitSignaturesCollectingState(t *testing.T) {
 		t.Parallel()
 
 		h := newTestHarness(t)
-		h.setupMockWalletForBoardingSigning()
 
 		intent := h.newTestBoardingIntent()
 		vtxoOutpoint := h.newTestOutpoint()
@@ -1791,26 +1818,46 @@ func TestForfeitSignaturesCollectingState(t *testing.T) {
 		}
 
 		// Hop 1: ForfeitSignatureResponse →
-		// AwaitingRoundCheckpointState with
-		// CommitRoundStateReq in outbox.
+		// AwaitingBoardingSignaturesState with
+		// SignBoardingInputsReq in outbox.
 		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		//nolint:ll
+		boardingSigState := assertStateType[*AwaitingBoardingSignaturesState](h)
+		require.Equal(t, roundID, boardingSigState.RoundID)
+		require.Len(t, boardingSigState.ForfeitedVTXOs, 1)
+		require.Equal(
+			t, vtxoOutpoint,
+			boardingSigState.ForfeitedVTXOs[0],
+		)
+		h.assertOutboxContainsType(
+			"*round.SignBoardingInputsReq",
+		)
+		h.clearOutbox()
+
+		// Hop 2: SignBoardingInputsSucceeded →
+		// AwaitingRoundCheckpointState.
+		transition, err = h.sendEvent(
+			&SignBoardingInputsSucceeded{
+				InputSigs: []*types.BoardingInputSignature{
+					{InputIndex: 0},
+				},
+			},
+		)
 		require.NoError(t, err)
 		require.NotNil(t, transition)
 
 		//nolint:ll
 		checkpointState := assertStateType[*AwaitingRoundCheckpointState](h)
 		require.Equal(t, roundID, checkpointState.RoundID)
-		require.Len(t, checkpointState.ForfeitedVTXOs, 1)
-		require.Equal(
-			t, vtxoOutpoint,
-			checkpointState.ForfeitedVTXOs[0],
-		)
 		h.assertOutboxContainsType(
 			"*round.CommitRoundStateReq",
 		)
 		h.clearOutbox()
 
-		// Hop 2: CommitRoundStateSucceeded →
+		// Hop 3: CommitRoundStateSucceeded →
 		// InputSigSentState.
 		transition, err = h.sendEvent(
 			&CommitRoundStateSucceeded{},
@@ -1835,7 +1882,6 @@ func TestForfeitSignaturesCollectingState(t *testing.T) {
 		t.Parallel()
 
 		h := newTestHarness(t)
-		h.setupMockWalletForBoardingSigning()
 
 		intent := h.newTestBoardingIntent()
 		vtxoOutpoint1 := h.newTestOutpoint()
@@ -1901,20 +1947,38 @@ func TestForfeitSignaturesCollectingState(t *testing.T) {
 		}
 
 		// Hop 1: Second forfeit →
-		// AwaitingRoundCheckpointState.
+		// AwaitingBoardingSignaturesState.
 		transition, err := h.sendEvent(event2)
 		require.NoError(t, err)
 		require.NotNil(t, transition)
 
 		//nolint:ll
-		checkpointState := assertStateType[*AwaitingRoundCheckpointState](h)
-		require.Len(t, checkpointState.ForfeitedVTXOs, 2)
+		boardingSigState := assertStateType[*AwaitingBoardingSignaturesState](h)
+		require.Len(t, boardingSigState.ForfeitedVTXOs, 2)
+		h.assertOutboxContainsType(
+			"*round.SignBoardingInputsReq",
+		)
+		h.clearOutbox()
+
+		// Hop 2: SignBoardingInputsSucceeded →
+		// AwaitingRoundCheckpointState.
+		transition, err = h.sendEvent(
+			&SignBoardingInputsSucceeded{
+				InputSigs: []*types.BoardingInputSignature{
+					{InputIndex: 0},
+				},
+			},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		_ = assertStateType[*AwaitingRoundCheckpointState](h)
 		h.assertOutboxContainsType(
 			"*round.CommitRoundStateReq",
 		)
 		h.clearOutbox()
 
-		// Hop 2: CommitRoundStateSucceeded →
+		// Hop 3: CommitRoundStateSucceeded →
 		// InputSigSentState.
 		transition, err = h.sendEvent(
 			&CommitRoundStateSucceeded{},

--- a/round/transitions_test.go
+++ b/round/transitions_test.go
@@ -130,6 +130,11 @@ func TestStateProperties(t *testing.T) {
 				"AwaitingRegistrationBuild",
 			},
 			{
+				"AwaitingSigningSessions",
+				&AwaitingSigningSessionsState{},
+				"AwaitingSigningSessions",
+			},
+			{
 				"ClientFailed",
 				&ClientFailedState{Reason: "test"},
 				"ClientFailed: test",
@@ -313,6 +318,26 @@ func TestUnexpectedEventSelfLoop(t *testing.T) {
 				}
 			},
 			event: &RoundJoined{RoundID: testRoundIDTr("other")},
+		},
+		{
+			name: "AwaitingRegistrationBuild_self_loops",
+			setup: func(h *boardingTestHarness) ClientState {
+				return &AwaitingRegistrationBuildState{}
+			},
+			event: &RoundJoined{
+				RoundID: testRoundIDTr("test"),
+			},
+		},
+		{
+			name: "AwaitingSigningSessions_self_loops",
+			setup: func(h *boardingTestHarness) ClientState {
+				return &AwaitingSigningSessionsState{
+					RoundID: testRoundIDTr("round-001"),
+				}
+			},
+			event: &RoundJoined{
+				RoundID: testRoundIDTr("other"),
+			},
 		},
 		{
 			name: "ClientFailed_self_loops_on_unknown",
@@ -873,17 +898,31 @@ func TestCommitmentTxValidatedState(t *testing.T) {
 		)
 		h.withState(state)
 
+		// Hop 1: GenerateNonces →
+		// AwaitingSigningSessionsState +
+		// CreateSigningSessionsReq.
 		transition, err := h.sendEvent(&GenerateNonces{})
 		require.NoError(t, err)
 		require.NotNil(t, transition)
 
-		noncesSentState := assertStateType[*NoncesSentState](h)
+		awaitState := assertStateType[*AwaitingSigningSessionsState](h) //nolint:ll
 		expectedID := testRoundIDTr("round-001")
+		require.Equal(t, expectedID, awaitState.RoundID)
+
+		h.assertOutboxContainsType(
+			"*round.CreateSigningSessionsReq",
+		)
+
+		// Hop 2: CreateSigningSessionsSucceeded →
+		// NoncesSentState.
+		noncesSentState := h.feedSigningSessionsSuccess()
 		require.Equal(t, expectedID, noncesSentState.RoundID)
 		require.NotNil(t, noncesSentState.Musig2Sessions)
 
 		h.assertOutboxLen(1)
-		h.assertOutboxContainsType("*round.SubmitNoncesRequest")
+		h.assertOutboxContainsType(
+			"*round.SubmitNoncesRequest",
+		)
 	})
 }
 
@@ -907,9 +946,10 @@ func TestNoncesSentState(t *testing.T) {
 
 		_, err := h.sendEvent(&GenerateNonces{})
 		require.NoError(t, err)
-		h.clearOutbox()
 
-		noncesSentState := assertStateType[*NoncesSentState](h)
+		// Hop through signing session creation.
+		noncesSentState := h.feedSigningSessionsSuccess()
+		h.clearOutbox()
 
 		event := h.newNoncesAggregatedEvent(
 			testRoundIDTr("round-001"),
@@ -920,7 +960,7 @@ func TestNoncesSentState(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, transition)
 
-		noncesAggState := assertStateType[*NoncesAggregatedState](h)
+		noncesAggState := assertStateType[*NoncesAggregatedState](h) //nolint:ll
 		expectedID := testRoundIDTr("round-001")
 		require.Equal(t, expectedID, noncesAggState.RoundID)
 		assertTransitionEmitsInternalEvent[*GeneratePartialSigs](
@@ -940,8 +980,8 @@ func TestNoncesAggregatedState(t *testing.T) {
 
 		intent := h.newTestBoardingIntent()
 
-		// We build through the full state machine flow to ensure MuSig2
-		// sessions are properly initialized with real nonce state.
+		// Build through the full state machine flow to ensure
+		// MuSig2 sessions are properly initialized.
 		validatedState := h.newCommitmentTxValidatedState(
 			testRoundIDTr("round-001"),
 			[]BoardingIntent{intent},
@@ -950,9 +990,10 @@ func TestNoncesAggregatedState(t *testing.T) {
 
 		_, err := h.sendEvent(&GenerateNonces{})
 		require.NoError(t, err)
-		h.clearOutbox()
 
-		noncesSentState := assertStateType[*NoncesSentState](h)
+		// Hop through signing session creation.
+		noncesSentState := h.feedSigningSessionsSuccess()
+		h.clearOutbox()
 
 		aggEvent := h.newNoncesAggregatedEvent(
 			testRoundIDTr("round-001"),
@@ -968,10 +1009,12 @@ func TestNoncesAggregatedState(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, transition)
 
-		partialSigsState := assertStateType[*PartialSigsSentState](h)
+		partialSigsState := assertStateType[*PartialSigsSentState](h) //nolint:ll
 		expectedID := testRoundIDTr("round-001")
 		require.Equal(t, expectedID, partialSigsState.RoundID)
-		h.assertOutboxContainsType("*round.SubmitPartialSigRequest")
+		h.assertOutboxContainsType(
+			"*round.SubmitPartialSigRequest",
+		)
 	})
 }
 
@@ -1702,11 +1745,12 @@ func TestBoardingFlowRoundJoinedToPartialSigsSent(t *testing.T) {
 	require.NotEmpty(t, ctxValidatedState.BoardingInputIndices)
 	h.clearOutbox()
 
-	// Step 3: CommitmentTxValidated → NoncesSent.
+	// Step 3: CommitmentTxValidated →
+	// AwaitingSigningSessions → NoncesSent.
 	_, err = h.sendEvent(&GenerateNonces{})
 	require.NoError(t, err)
 
-	noncesSentState := assertStateType[*NoncesSentState](h)
+	noncesSentState := h.feedSigningSessionsSuccess()
 	require.NotEmpty(t, noncesSentState.Musig2Sessions)
 	h.clearOutbox()
 
@@ -2229,13 +2273,14 @@ func TestForfeitMappingsCarriedThroughSigningStates(t *testing.T) {
 	validatedState.ForfeitMappings = forfeitMappings
 	h.withState(validatedState)
 
-	// Generate nonces.
+	// Generate nonces and hop through signing sessions.
 	_, err := h.sendEvent(&GenerateNonces{})
 	require.NoError(t, err)
+
+	noncesSentState := h.feedSigningSessionsSuccess()
 	h.clearOutbox()
 
 	// Check NoncesSentState has ForfeitMappings.
-	noncesSentState := assertStateType[*NoncesSentState](h)
 	require.Len(t, noncesSentState.ForfeitMappings, 1)
 	require.Contains(t, noncesSentState.ForfeitMappings, vtxoOutpoint)
 

--- a/round/transitions_test.go
+++ b/round/transitions_test.go
@@ -110,6 +110,11 @@ func TestStateProperties(t *testing.T) {
 				"InputSigSent",
 			},
 			{
+				"AwaitingRoundCheckpoint",
+				&AwaitingRoundCheckpointState{},
+				"AwaitingRoundCheckpoint",
+			},
+			{
 				"AwaitingSaveVTXOs",
 				&AwaitingSaveVTXOsState{},
 				"AwaitingSaveVTXOs",
@@ -1047,7 +1052,6 @@ func TestPartialSigsSentState(t *testing.T) {
 		}
 
 		h.setupMockWalletForBoardingSigning()
-		h.setupMockRoundStoreForCommit()
 		h.withState(state)
 
 		event := &OperatorSigned{
@@ -1055,19 +1059,47 @@ func TestPartialSigsSentState(t *testing.T) {
 			AggSigs: validSigs,
 		}
 
+		// Hop 1: OperatorSigned →
+		// AwaitingRoundCheckpointState with
+		// CommitRoundStateReq in outbox.
 		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		//nolint:ll
+		checkpointState := assertStateType[*AwaitingRoundCheckpointState](h.boardingTestHarness)
+		expectedRoundID := testRoundIDTr("round-real-sig-001")
+		require.Equal(
+			t, expectedRoundID, checkpointState.RoundID,
+		)
+		require.NotEmpty(t, checkpointState.InputSigs)
+		h.assertOutboxContainsType(
+			"*round.CommitRoundStateReq",
+		)
+		h.clearOutbox()
+
+		// Hop 2: CommitRoundStateSucceeded →
+		// InputSigSentState.
+		transition, err = h.sendEvent(
+			&CommitRoundStateSucceeded{},
+		)
 		require.NoError(t, err)
 		require.NotNil(t, transition)
 
 		inputSigState := assertStateType[*InputSigSentState](
 			h.boardingTestHarness,
 		)
-		expectedRoundID := testRoundIDTr("round-real-sig-001")
-		require.Equal(t, expectedRoundID, inputSigState.RoundID)
+		require.Equal(
+			t, expectedRoundID, inputSigState.RoundID,
+		)
 		require.NotEmpty(t, inputSigState.InputSigs)
 
-		h.assertOutboxContainsType("*round.SubmitForfeitSigRequest")
-		h.assertOutboxContainsType("*round.RegisterConfirmationRequest")
+		h.assertOutboxContainsType(
+			"*round.SubmitForfeitSigRequest",
+		)
+		h.assertOutboxContainsType(
+			"*round.RegisterConfirmationRequest",
+		)
 	})
 
 	t.Run("empty_signatures_error", func(t *testing.T) {
@@ -1721,7 +1753,6 @@ func TestForfeitSignaturesCollectingState(t *testing.T) {
 
 		h := newTestHarness(t)
 		h.setupMockWalletForBoardingSigning()
-		h.setupMockRoundStoreForCheckpoint()
 
 		intent := h.newTestBoardingIntent()
 		vtxoOutpoint := h.newTestOutpoint()
@@ -1759,23 +1790,45 @@ func TestForfeitSignaturesCollectingState(t *testing.T) {
 			Signature:    sig,
 		}
 
+		// Hop 1: ForfeitSignatureResponse →
+		// AwaitingRoundCheckpointState with
+		// CommitRoundStateReq in outbox.
 		transition, err := h.sendEvent(event)
 		require.NoError(t, err)
 		require.NotNil(t, transition)
 
-		// Should transition to InputSigSentState. In the new flow,
-		// forfeit collection happens AFTER VTXO tree signing, so
-		// completing forfeits goes directly to InputSigSentState.
+		//nolint:ll
+		checkpointState := assertStateType[*AwaitingRoundCheckpointState](h)
+		require.Equal(t, roundID, checkpointState.RoundID)
+		require.Len(t, checkpointState.ForfeitedVTXOs, 1)
+		require.Equal(
+			t, vtxoOutpoint,
+			checkpointState.ForfeitedVTXOs[0],
+		)
+		h.assertOutboxContainsType(
+			"*round.CommitRoundStateReq",
+		)
+		h.clearOutbox()
+
+		// Hop 2: CommitRoundStateSucceeded →
+		// InputSigSentState.
+		transition, err = h.sendEvent(
+			&CommitRoundStateSucceeded{},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
 		inputSigState := assertStateType[*InputSigSentState](h)
 		require.Equal(t, roundID, inputSigState.RoundID)
 		require.Len(t, inputSigState.ForfeitedVTXOs, 1)
-		require.Equal(t, vtxoOutpoint, inputSigState.ForfeitedVTXOs[0])
 
 		// Should emit SubmitVTXOForfeitSigsToServer and
 		// SubmitForfeitSigRequest (boarding input signatures).
 		forfeitType := "*round.SubmitVTXOForfeitSigsToServer"
 		h.assertOutboxContainsType(forfeitType)
-		h.assertOutboxContainsType("*round.SubmitForfeitSigRequest")
+		h.assertOutboxContainsType(
+			"*round.SubmitForfeitSigRequest",
+		)
 	})
 
 	t.Run("multiple_forfeits_wait_for_all", func(t *testing.T) {
@@ -1783,7 +1836,6 @@ func TestForfeitSignaturesCollectingState(t *testing.T) {
 
 		h := newTestHarness(t)
 		h.setupMockWalletForBoardingSigning()
-		h.setupMockRoundStoreForCheckpoint()
 
 		intent := h.newTestBoardingIntent()
 		vtxoOutpoint1 := h.newTestOutpoint()
@@ -1848,11 +1900,28 @@ func TestForfeitSignaturesCollectingState(t *testing.T) {
 			Signature:    sig2,
 		}
 
+		// Hop 1: Second forfeit →
+		// AwaitingRoundCheckpointState.
 		transition, err := h.sendEvent(event2)
 		require.NoError(t, err)
 		require.NotNil(t, transition)
 
-		// Now should transition to InputSigSentState.
+		//nolint:ll
+		checkpointState := assertStateType[*AwaitingRoundCheckpointState](h)
+		require.Len(t, checkpointState.ForfeitedVTXOs, 2)
+		h.assertOutboxContainsType(
+			"*round.CommitRoundStateReq",
+		)
+		h.clearOutbox()
+
+		// Hop 2: CommitRoundStateSucceeded →
+		// InputSigSentState.
+		transition, err = h.sendEvent(
+			&CommitRoundStateSucceeded{},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
 		inputSigState := assertStateType[*InputSigSentState](h)
 		require.Len(t, inputSigState.ForfeitedVTXOs, 2)
 	})

--- a/round/transitions_test.go
+++ b/round/transitions_test.go
@@ -508,14 +508,16 @@ func TestTerminalStateSelfLoop(t *testing.T) {
 func TestIdleState(t *testing.T) {
 	t.Parallel()
 
-	t.Run("BoardingUTXOConfirmed_to_pending", func(t *testing.T) {
+	t.Run("IntentPackage_boarding_to_pending", func(t *testing.T) {
 		t.Parallel()
 
 		h := newTestHarness(t)
 		h.withState(&Idle{})
 
 		intent := h.newTestBoardingIntent()
-		event := h.newBoardingUTXOConfirmedEvent(intent)
+		event := &IntentPackage{
+			Boarding: []BoardingIntent{intent},
+		}
 
 		transition, err := h.sendEvent(event)
 		require.NoError(t, err)
@@ -525,7 +527,7 @@ func TestIdleState(t *testing.T) {
 		require.Len(t, nextState.Boarding, 1)
 	})
 
-	t.Run("ResumeBoardingIntents_with_intents", func(t *testing.T) {
+	t.Run("IntentPackage_resume_with_intents", func(t *testing.T) {
 		t.Parallel()
 
 		h := newTestHarness(t)
@@ -533,7 +535,7 @@ func TestIdleState(t *testing.T) {
 
 		intent := h.newTestBoardingIntent()
 		vtxoReq := h.newTestVTXORequestForIntent(intent)
-		event := &ResumeBoardingIntents{
+		event := &IntentPackage{
 			Boarding: []BoardingIntent{intent},
 			VTXOs:    []types.VTXORequest{vtxoReq},
 		}
@@ -546,16 +548,13 @@ func TestIdleState(t *testing.T) {
 		require.Len(t, nextState.Boarding, 1)
 	})
 
-	t.Run("ResumeBoardingIntents_empty_stays_idle", func(t *testing.T) {
+	t.Run("IntentPackage_empty_stays_idle", func(t *testing.T) {
 		t.Parallel()
 
 		h := newTestHarness(t)
 		h.withState(&Idle{})
 
-		event := &ResumeBoardingIntents{
-			Boarding: []BoardingIntent{},
-			VTXOs:    []types.VTXORequest{},
-		}
+		event := &IntentPackage{}
 
 		transition, err := h.sendEvent(event)
 		require.NoError(t, err)
@@ -563,48 +562,12 @@ func TestIdleState(t *testing.T) {
 
 		_ = assertStateType[*Idle](h)
 	})
-
-	t.Run("nil_tx_transitions_to_failed", func(t *testing.T) {
-		t.Parallel()
-
-		h := newTestHarness(t)
-		h.withState(&Idle{})
-
-		intent := h.newTestBoardingIntent()
-		event := h.newBoardingUTXOConfirmedEvent(intent)
-		event.Tx = nil
-
-		transition, err := h.sendEvent(event)
-		require.NoError(t, err)
-		require.NotNil(t, transition)
-
-		failedState := assertStateType[*ClientFailedState](h)
-		require.Contains(t, failedState.Reason, "missing transaction")
-	})
-
-	t.Run("invalid_outpoint_transitions_to_failed", func(t *testing.T) {
-		t.Parallel()
-
-		h := newTestHarness(t)
-		h.withState(&Idle{})
-
-		intent := h.newTestBoardingIntent()
-		event := h.newBoardingUTXOConfirmedEvent(intent)
-		event.Outpoint.Index = 999
-
-		transition, err := h.sendEvent(event)
-		require.NoError(t, err)
-		require.NotNil(t, transition)
-
-		failedState := assertStateType[*ClientFailedState](h)
-		require.Contains(t, failedState.Reason, "invalid outpoint")
-	})
 }
 
 func TestPendingRoundAssemblyState(t *testing.T) {
 	t.Parallel()
 
-	t.Run("additional_confirmation_accumulates", func(t *testing.T) {
+	t.Run("additional_intent_package_accumulates", func(t *testing.T) {
 		t.Parallel()
 
 		h := newTestHarness(t)
@@ -617,7 +580,9 @@ func TestPendingRoundAssemblyState(t *testing.T) {
 		})
 
 		newIntent := h.newTestBoardingIntent()
-		event := h.newBoardingUTXOConfirmedEvent(newIntent)
+		event := &IntentPackage{
+			Boarding: []BoardingIntent{newIntent},
+		}
 
 		transition, err := h.sendEvent(event)
 		require.NoError(t, err)
@@ -1571,12 +1536,15 @@ func TestBoardingFlowMultipleIntentsAccumulation(t *testing.T) {
 	h := newTestHarness(t)
 	h.withState(&Idle{})
 
-	// We confirm multiple UTXOs to verify that PendingRoundAssembly
-	// correctly accumulates boarding intents as they arrive, rather than
-	// replacing or dropping previous ones.
+	// We send multiple intent packages to verify that
+	// PendingRoundAssembly correctly accumulates boarding intents
+	// as they arrive, rather than replacing or dropping previous
+	// ones.
 	for i := 0; i < 3; i++ {
 		intent := h.newTestBoardingIntent()
-		event := h.newBoardingUTXOConfirmedEvent(intent)
+		event := &IntentPackage{
+			Boarding: []BoardingIntent{intent},
+		}
 
 		_, err := h.sendEvent(event)
 		require.NoError(t, err)

--- a/round/transitions_test.go
+++ b/round/transitions_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/lightninglabs/darepo-client/lib/scripts"
 	"github.com/lightninglabs/darepo-client/lib/tree"
 	"github.com/lightninglabs/darepo-client/lib/types"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -109,6 +108,11 @@ func TestStateProperties(t *testing.T) {
 			{
 				"InputSigSent", &InputSigSentState{},
 				"InputSigSent",
+			},
+			{
+				"AwaitingSaveVTXOs",
+				&AwaitingSaveVTXOsState{},
+				"AwaitingSaveVTXOs",
 			},
 			{
 				"ClientFailed",
@@ -1260,7 +1264,6 @@ func TestInputSigSentState(t *testing.T) {
 		t.Parallel()
 
 		h := newTestHarness(t)
-		h.setupMockVTXOStoreForSave()
 
 		intent := h.newTestBoardingIntent()
 		state := h.newInputSigSentState(
@@ -1277,7 +1280,21 @@ func TestInputSigSentState(t *testing.T) {
 			Confirmations: 6,
 		}
 
+		// Hop 1: BoardingConfirmed → AwaitingSaveVTXOsState
+		// with SaveVTXOsReq in outbox.
 		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		awaitState := assertStateType[*AwaitingSaveVTXOsState](h)
+		require.NotEmpty(t, awaitState.VTXOs)
+		h.assertOutboxLen(1)
+		require.IsType(t, &SaveVTXOsReq{},
+			h.outboxMessages[0])
+		h.clearOutbox()
+
+		// Hop 2: SaveVTXOsSucceeded → ConfirmedState.
+		transition, err = h.sendEvent(&SaveVTXOsSucceeded{})
 		require.NoError(t, err)
 		require.NotNil(t, transition)
 
@@ -1286,10 +1303,9 @@ func TestInputSigSentState(t *testing.T) {
 		require.Equal(t, blockHash, confirmedState.BlockHash)
 		require.Equal(t, int32(6), confirmedState.Confirmations)
 
+		// Outbox should have VTXOCreated + RoundCompleted
+		// notifications.
 		h.assertOutboxLen(2)
-		h.vtxoStore.AssertCalled(
-			t, "SaveVTXOs", mock.Anything, mock.Anything,
-		)
 	})
 
 	t.Run("buildClientVTXOs_error", func(t *testing.T) {
@@ -2111,7 +2127,6 @@ func TestInputSigSentStateEmitsForfeitConfirmed(t *testing.T) {
 	t.Parallel()
 
 	h := newTestHarness(t)
-	h.setupMockVTXOStoreForSave()
 
 	intent := h.newTestBoardingIntent()
 	vtxoOutpoint1 := h.newTestOutpoint()
@@ -2128,9 +2143,15 @@ func TestInputSigSentStateEmitsForfeitConfirmed(t *testing.T) {
 		Confirmations: 6,
 	}
 
+	// Hop 1: BoardingConfirmed → AwaitingSaveVTXOsState.
 	_, err := h.sendEvent(event)
 	require.NoError(t, err)
+	_ = assertStateType[*AwaitingSaveVTXOsState](h)
+	h.clearOutbox()
 
+	// Hop 2: SaveVTXOsSucceeded → ConfirmedState.
+	_, err = h.sendEvent(&SaveVTXOsSucceeded{})
+	require.NoError(t, err)
 	_ = assertStateType[*ConfirmedState](h)
 
 	// Should emit ForfeitConfirmedToVTXO for each forfeited VTXO.


### PR DESCRIPTION
## Summary

Extracts all 7 I/O call sites from client round FSM state transitions
into the outbox handler pattern, matching the server-side approach in
[darepo#118](https://github.com/lightninglabs/darepo/pull/118).

The FSM now emits `OutboxRequest` messages describing side effects.
The actor's `askAndDrive` event pump routes them through an
`OutboxHandler` which performs the actual I/O and returns follow-up
`ClientEvent`s fed back into the FSM.

After migration, `ClientEnvironment` is stripped down to read-only
config (`OperatorTerms`, `Log`, `StartHeight`) — no stores, wallet,
or height queries are accessed during state transitions.

### I/O sites extracted

| Phase | State | I/O Call | New Request Type |
|-------|-------|----------|------------------|
| 1 | `InputSigSentState` | `VTXOStore.SaveVTXOs` | `SaveVTXOsReq` |
| 2 | `PartialSigsSentState` / `ForfeitSignaturesCollectingState` | `RoundStore.CommitState` | `CommitRoundStateReq` |
| 3 | `PartialSigsSentState` / `ForfeitSignaturesCollectingState` | `signBoardingInputs(Wallet)` | `SignBoardingInputsReq` |
| 4 | `PendingRoundAssembly` | `VTXOStore.GetVTXO`, `Wallet.DeriveNextKey`, `Wallet` signing, `QueryBestHeight` | `BuildRegistrationReq` |
| 5 | `CommitmentTxValidatedState` | `tree.NewSignerSession(Wallet)` | `CreateSigningSessionsReq` |

### New intermediate states

- `AwaitingSaveVTXOsState` — waiting for VTXO persistence
- `AwaitingRoundCheckpointState` — waiting for round checkpoint persistence
- `AwaitingBoardingSignaturesState` — waiting for boarding input signing
- `AwaitingRegistrationBuildState` — waiting for registration I/O
- `AwaitingSigningSessionsState` — waiting for MuSig2 session creation

### Commit structure

Each phase follows a two-commit pattern: types first (new states,
events, request types), then behavior (FSM changes, handler impl,
test updates). Final commit strips `ClientEnvironment` of all I/O
fields.

## Test plan

- [x] `make unit pkg=round` passes after each commit
- [x] `go build ./...` compiles after each commit
- [x] `go vet ./round/...` clean after each commit
- [ ] `make lint` (deferred to review)
- [ ] `make itest` on full integration suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)