### PR TITLE
actor: strip sender tx in DurableMailbox.Send

### DIFF
--- a/baselib/actor/durable_mailbox.go
+++ b/baselib/actor/durable_mailbox.go
@@ -107,8 +107,13 @@ func NewDurableMailbox[M TLVMessage, R any](
 // envelope is accepted, the provided context is cancelled, or the actor's
 // context is cancelled.
 //
-// If the context contains a transaction (via WithTx), the message is written
-// within that transaction, enabling atomic outbox writes.
+// The sender's database transaction is intentionally stripped before
+// enqueueing. Mailbox sends cross actor boundaries: the receiver's
+// delivery store must manage its own transaction lifecycle. Inheriting
+// the sender's transaction would either target the wrong database
+// (cross-DB actors) or deadlock for Ask-style calls where the sender
+// blocks on the response but the receiver cannot see the uncommitted
+// message.
 func (m *DurableMailbox[M, R]) Send(ctx context.Context, env envelope[M, R]) bool {
 	m.closeMu.RLock()
 	defer m.closeMu.RUnlock()
@@ -180,7 +185,11 @@ func (m *DurableMailbox[M, R]) Send(ctx context.Context, env envelope[M, R]) boo
 		MaxAttempts:     m.cfg.MaxAttempts,
 	}
 
-	if err := m.cfg.Store.EnqueueMessage(ctx, params); err != nil {
+	// Strip the sender's transaction so the receiver's delivery store
+	// creates its own transaction for the enqueue operation.
+	enqueueCtx := WithoutTx(ctx)
+
+	if err := m.cfg.Store.EnqueueMessage(enqueueCtx, params); err != nil {
 		// Clean up the promise registry entry to prevent unbounded
 		// stale entries from accumulating on repeated enqueue failures.
 		if promiseID != "" {

--- a/baselib/actor/durable_mailbox_test.go
+++ b/baselib/actor/durable_mailbox_test.go
@@ -2,6 +2,7 @@ package actor
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"io"
 	"sync"
@@ -1070,4 +1071,64 @@ func TestDurableMailboxSendWithoutOutboxIDGeneratesFreshID(t *testing.T) {
 		require.Len(t, id, 36,
 			"generated ID should be a UUID (36 chars)")
 	}
+}
+
+// txCapturingStore wraps mockDeliveryStore to capture the context passed to
+// EnqueueMessage for inspection in tests.
+type txCapturingStore struct {
+	*mockDeliveryStore
+	lastCtx context.Context
+}
+
+// EnqueueMessage captures the context before delegating to the underlying
+// mock store.
+func (s *txCapturingStore) EnqueueMessage(ctx context.Context,
+	params EnqueueParams) error {
+
+	s.lastCtx = ctx
+
+	return s.mockDeliveryStore.EnqueueMessage(ctx, params)
+}
+
+// TestDurableMailboxSendStripsSenderTx verifies that Send strips the sender's
+// database transaction from the context before calling EnqueueMessage. This
+// prevents the receiver's delivery store from inheriting the sender's
+// transaction, which would cause cross-DB visibility issues or Ask deadlocks.
+func TestDurableMailboxSendStripsSenderTx(t *testing.T) {
+	t.Parallel()
+
+	store := newMockDeliveryStore()
+	codec := newDurableTestCodec()
+	ctx := context.Background()
+
+	// Wrap the store to capture the context passed to EnqueueMessage.
+	capturing := &txCapturingStore{mockDeliveryStore: store}
+
+	cfg := DefaultDurableMailboxConfig("test-mailbox", capturing, codec)
+	mailbox := NewDurableMailbox[*durableTestMsg, int](ctx, cfg)
+
+	msg := &durableTestMsg{
+		Value:   tlv.NewPrimitiveRecord[tlv.TlvType1](uint64(42)),
+		Payload: tlv.NewPrimitiveRecord[tlv.TlvType2]([]byte("test")),
+	}
+
+	env := envelope[*durableTestMsg, int]{
+		message:   msg,
+		callerCtx: ctx,
+	}
+
+	// Create a context with a transaction attached, simulating a
+	// sender inside an ExecTx closure.
+	sendCtx := WithTx(ctx, (*sql.Tx)(nil))
+	require.True(t, HasTx(sendCtx))
+
+	// Send should succeed.
+	ok := mailbox.Send(sendCtx, env)
+	require.True(t, ok)
+
+	// The context received by EnqueueMessage should NOT carry a tx.
+	require.NotNil(t, capturing.lastCtx,
+		"EnqueueMessage should have been called")
+	require.False(t, HasTx(capturing.lastCtx),
+		"EnqueueMessage context should not carry the sender's tx")
 }

--- a/baselib/actor/tx_context.go
+++ b/baselib/actor/tx_context.go
@@ -51,6 +51,15 @@ func RequireTx(ctx context.Context) (*sql.Tx, error) {
 	return tx, nil
 }
 
+// WithoutTx returns a new context with the database transaction stripped.
+// This is used at actor boundaries (e.g., DurableMailbox.Send) to prevent
+// the sender's transaction from leaking into the receiver's mailbox store.
+// An untyped nil shadows the parent's txContextKey entry so that
+// TxFromContext returns (nil, false).
+func WithoutTx(ctx context.Context) context.Context {
+	return context.WithValue(ctx, txContextKey{}, nil)
+}
+
 // HasTx returns true if the context contains a database transaction.
 func HasTx(ctx context.Context) bool {
 	_, ok := TxFromContext(ctx)

--- a/baselib/actor/tx_context_test.go
+++ b/baselib/actor/tx_context_test.go
@@ -1,0 +1,77 @@
+package actor
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestWithoutTxStripsTransaction verifies that WithoutTx shadows a parent
+// context's transaction entry so that TxFromContext returns (nil, false) and
+// HasTx returns false. This is the core invariant that prevents the sender's
+// transaction from leaking into cross-actor mailbox enqueues.
+func TestWithoutTxStripsTransaction(t *testing.T) {
+	t.Parallel()
+
+	// Start with a context that carries a transaction. A typed nil
+	// *sql.Tx is sufficient: WithTx stores an interface value with
+	// dynamic type *sql.Tx, so HasTx and TxFromContext both report
+	// a transaction is present.
+	ctx := WithTx(context.Background(), (*sql.Tx)(nil))
+	require.True(t, HasTx(ctx),
+		"context should carry a tx after WithTx")
+
+	tx, ok := TxFromContext(ctx)
+	require.True(t, ok, "TxFromContext should return ok=true")
+	require.Nil(t, tx, "tx value should be nil (typed nil)")
+
+	// WithoutTx should shadow the parent's entry with an untyped nil,
+	// causing both HasTx and TxFromContext to report no transaction.
+	stripped := WithoutTx(ctx)
+	require.False(t, HasTx(stripped),
+		"HasTx should return false after WithoutTx")
+
+	tx, ok = TxFromContext(stripped)
+	require.False(t, ok,
+		"TxFromContext should return ok=false after WithoutTx")
+	require.Nil(t, tx)
+}
+
+// TestWithoutTxPreservesOtherValues verifies that WithoutTx only strips the
+// transaction key and leaves other context values intact.
+func TestWithoutTxPreservesOtherValues(t *testing.T) {
+	t.Parallel()
+
+	type customKey struct{}
+
+	ctx := context.WithValue(context.Background(), customKey{}, "preserved")
+	ctx = WithTx(ctx, (*sql.Tx)(nil))
+
+	stripped := WithoutTx(ctx)
+
+	// Transaction should be stripped.
+	require.False(t, HasTx(stripped))
+
+	// Other values should be preserved.
+	val := stripped.Value(customKey{})
+	require.Equal(t, "preserved", val)
+}
+
+// TestWithoutTxOnCleanContext verifies that WithoutTx is safe to call on a
+// context that never had a transaction attached.
+func TestWithoutTxOnCleanContext(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	require.False(t, HasTx(ctx))
+
+	// Stripping a non-existent tx should be a no-op.
+	stripped := WithoutTx(ctx)
+	require.False(t, HasTx(stripped))
+
+	tx, ok := TxFromContext(stripped)
+	require.False(t, ok)
+	require.Nil(t, tx)
+}


### PR DESCRIPTION
## Summary

- Add `WithoutTx()` to the actor package that strips database
  transactions from context at actor boundaries
- Use it in `DurableMailbox.Send()` before `EnqueueMessage()` to
  prevent the sender's transaction from leaking into the receiver's
  mailbox store

## Problem

When a `DurableActor` processes a message inside
`TxAwareActorDeliveryStore.ExecTx`, the context carries the actor's
`*sql.Tx` via `actor.WithTx`. If the behavior calls another actor via
`Ask` (e.g., `server.Receive(ctx, msg)`), the context flows through:

```
DurableMailbox.Send(ctx) → Store.EnqueueMessage(ctx) → TransactionExecutor.ExecTx(ctx)
```

The `TxFromContext` check in `ExecTx` joins the **sender's**
transaction, which causes two issues:

1. **Cross-DB actors**: the message is written to the sender's DB,
   invisible to the receiver's processing goroutine (hang/deadlock)
2. **Same-DB Ask calls**: the sender blocks waiting for a response
   while the receiver cannot see the uncommitted message (deadlock)

## Why this is safe

The outbox atomicity guarantee is **unaffected**:

- The actor's own store operations (FSM state writes, outbox table
  writes) still join the actor's transaction via `TxFromContext`
- Only cross-actor mailbox enqueues are isolated
- This matches the production gRPC boundary where Go context values
  are naturally stripped when crossing process boundaries
- The `OutboxPublisher` already uses a fresh context (`WithOutboxID`
  only, no tx) when delivering messages

## Test plan

- [x] All OOR e2e tests pass (previously hung indefinitely)
- [x] All OOR actor unit tests pass
- [x] All `ExecTx` transaction joining tests pass