### PR TITLE
daemonrpc: extend daemon.proto with wallet and VTXO RPCs [1/5]

### DIFF
--- a/daemonrpc/daemon.pb.go
+++ b/daemonrpc/daemon.pb.go
@@ -21,6 +21,85 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// VTXOStatus represents the lifecycle state of a virtual transaction
+// output.
+type VTXOStatus int32
+
+const (
+	// VTXO_STATUS_UNSPECIFIED is the default zero value.
+	VTXOStatus_VTXO_STATUS_UNSPECIFIED VTXOStatus = 0
+	// VTXO_STATUS_LIVE indicates the VTXO is active and spendable.
+	VTXOStatus_VTXO_STATUS_LIVE VTXOStatus = 1
+	// VTXO_STATUS_REFRESH_REQUESTED indicates a refresh has been queued
+	// but the forfeit transaction has not yet been signed.
+	VTXOStatus_VTXO_STATUS_REFRESH_REQUESTED VTXOStatus = 2
+	// VTXO_STATUS_FORFEITING indicates the forfeit transaction has been
+	// signed and the VTXO is awaiting confirmation of the new round.
+	VTXOStatus_VTXO_STATUS_FORFEITING VTXOStatus = 3
+	// VTXO_STATUS_FORFEITED is terminal: the new round confirmed and
+	// this VTXO has been replaced.
+	VTXOStatus_VTXO_STATUS_FORFEITED VTXOStatus = 4
+	// VTXO_STATUS_SPENT is terminal: the VTXO was spent via an
+	// out-of-round transfer.
+	VTXOStatus_VTXO_STATUS_SPENT VTXOStatus = 5
+	// VTXO_STATUS_EXPIRING is terminal: the VTXO is being resolved
+	// on-chain via the unilateral exit path.
+	VTXOStatus_VTXO_STATUS_EXPIRING VTXOStatus = 6
+	// VTXO_STATUS_FAILED is terminal: an unrecoverable error occurred.
+	VTXOStatus_VTXO_STATUS_FAILED VTXOStatus = 7
+)
+
+// Enum value maps for VTXOStatus.
+var (
+	VTXOStatus_name = map[int32]string{
+		0: "VTXO_STATUS_UNSPECIFIED",
+		1: "VTXO_STATUS_LIVE",
+		2: "VTXO_STATUS_REFRESH_REQUESTED",
+		3: "VTXO_STATUS_FORFEITING",
+		4: "VTXO_STATUS_FORFEITED",
+		5: "VTXO_STATUS_SPENT",
+		6: "VTXO_STATUS_EXPIRING",
+		7: "VTXO_STATUS_FAILED",
+	}
+	VTXOStatus_value = map[string]int32{
+		"VTXO_STATUS_UNSPECIFIED":       0,
+		"VTXO_STATUS_LIVE":              1,
+		"VTXO_STATUS_REFRESH_REQUESTED": 2,
+		"VTXO_STATUS_FORFEITING":        3,
+		"VTXO_STATUS_FORFEITED":         4,
+		"VTXO_STATUS_SPENT":             5,
+		"VTXO_STATUS_EXPIRING":          6,
+		"VTXO_STATUS_FAILED":            7,
+	}
+)
+
+func (x VTXOStatus) Enum() *VTXOStatus {
+	p := new(VTXOStatus)
+	*p = x
+	return p
+}
+
+func (x VTXOStatus) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (VTXOStatus) Descriptor() protoreflect.EnumDescriptor {
+	return file_daemon_proto_enumTypes[0].Descriptor()
+}
+
+func (VTXOStatus) Type() protoreflect.EnumType {
+	return &file_daemon_proto_enumTypes[0]
+}
+
+func (x VTXOStatus) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use VTXOStatus.Descriptor instead.
+func (VTXOStatus) EnumDescriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{0}
+}
+
 type GetInfoRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -67,18 +146,27 @@ type GetInfoResponse struct {
 	// etc.).
 	Network string `protobuf:"bytes,3,opt,name=network,proto3" json:"network,omitempty"`
 	// lnd_identity_pubkey is the hex-encoded identity public key of the
-	// connected lnd node.
+	// connected lnd node. Empty in lwwallet mode.
 	LndIdentityPubkey string `protobuf:"bytes,4,opt,name=lnd_identity_pubkey,json=lndIdentityPubkey,proto3" json:"lnd_identity_pubkey,omitempty"`
-	// block_height is the current best block height known to the
-	// connected lnd node.
+	// block_height is the current best block height known to the daemon.
 	BlockHeight uint32 `protobuf:"varint,5,opt,name=block_height,json=blockHeight,proto3" json:"block_height,omitempty"`
 	// server_connected indicates whether the mailbox transport to the ark
 	// operator is active and pulling envelopes.
 	ServerConnected bool `protobuf:"varint,6,opt,name=server_connected,json=serverConnected,proto3" json:"server_connected,omitempty"`
-	// lnd_alias is the alias of the connected lnd node.
-	LndAlias      string `protobuf:"bytes,7,opt,name=lnd_alias,json=lndAlias,proto3" json:"lnd_alias,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// lnd_alias is the alias of the connected lnd node. Empty in lwwallet
+	// mode.
+	LndAlias string `protobuf:"bytes,7,opt,name=lnd_alias,json=lndAlias,proto3" json:"lnd_alias,omitempty"`
+	// wallet_type is the active wallet backend: "lnd" or "lwwallet".
+	WalletType string `protobuf:"bytes,8,opt,name=wallet_type,json=walletType,proto3" json:"wallet_type,omitempty"`
+	// wallet_ready indicates whether the wallet subsystem is initialized
+	// and ready to process requests.
+	WalletReady bool `protobuf:"varint,9,opt,name=wallet_ready,json=walletReady,proto3" json:"wallet_ready,omitempty"`
+	// identity_pubkey is the hex-encoded identity public key derived from
+	// the active wallet backend. In lnd mode this matches
+	// lnd_identity_pubkey.
+	IdentityPubkey string `protobuf:"bytes,10,opt,name=identity_pubkey,json=identityPubkey,proto3" json:"identity_pubkey,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *GetInfoResponse) Reset() {
@@ -160,12 +248,1294 @@ func (x *GetInfoResponse) GetLndAlias() string {
 	return ""
 }
 
+func (x *GetInfoResponse) GetWalletType() string {
+	if x != nil {
+		return x.WalletType
+	}
+	return ""
+}
+
+func (x *GetInfoResponse) GetWalletReady() bool {
+	if x != nil {
+		return x.WalletReady
+	}
+	return false
+}
+
+func (x *GetInfoResponse) GetIdentityPubkey() string {
+	if x != nil {
+		return x.IdentityPubkey
+	}
+	return ""
+}
+
+type GenSeedRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// seed_passphrase is an optional passphrase that protects the aezeed
+	// mnemonic itself. This is distinct from the wallet password that
+	// encrypts the seed at rest on disk.
+	SeedPassphrase []byte `protobuf:"bytes,1,opt,name=seed_passphrase,json=seedPassphrase,proto3" json:"seed_passphrase,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *GenSeedRequest) Reset() {
+	*x = GenSeedRequest{}
+	mi := &file_daemon_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GenSeedRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GenSeedRequest) ProtoMessage() {}
+
+func (x *GenSeedRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GenSeedRequest.ProtoReflect.Descriptor instead.
+func (*GenSeedRequest) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *GenSeedRequest) GetSeedPassphrase() []byte {
+	if x != nil {
+		return x.SeedPassphrase
+	}
+	return nil
+}
+
+type GenSeedResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// mnemonic is the 24-word aezeed mnemonic encoding the generated
+	// seed.
+	Mnemonic []string `protobuf:"bytes,1,rep,name=mnemonic,proto3" json:"mnemonic,omitempty"`
+	// enciphered_seed is the raw enciphered seed bytes for advanced use
+	// cases. Most callers should use the mnemonic field.
+	EncipheredSeed []byte `protobuf:"bytes,2,opt,name=enciphered_seed,json=encipheredSeed,proto3" json:"enciphered_seed,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *GenSeedResponse) Reset() {
+	*x = GenSeedResponse{}
+	mi := &file_daemon_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GenSeedResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GenSeedResponse) ProtoMessage() {}
+
+func (x *GenSeedResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GenSeedResponse.ProtoReflect.Descriptor instead.
+func (*GenSeedResponse) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *GenSeedResponse) GetMnemonic() []string {
+	if x != nil {
+		return x.Mnemonic
+	}
+	return nil
+}
+
+func (x *GenSeedResponse) GetEncipheredSeed() []byte {
+	if x != nil {
+		return x.EncipheredSeed
+	}
+	return nil
+}
+
+type InitWalletRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// mnemonic is the 24-word aezeed mnemonic returned by GenSeed (or
+	// provided for wallet recovery).
+	Mnemonic []string `protobuf:"bytes,1,rep,name=mnemonic,proto3" json:"mnemonic,omitempty"`
+	// wallet_password is the password used to encrypt the seed at rest on
+	// disk. Must be at least 8 bytes.
+	WalletPassword []byte `protobuf:"bytes,2,opt,name=wallet_password,json=walletPassword,proto3" json:"wallet_password,omitempty"`
+	// seed_passphrase is the optional passphrase that was used when
+	// generating the aezeed mnemonic. Must match the value passed to
+	// GenSeed.
+	SeedPassphrase []byte `protobuf:"bytes,3,opt,name=seed_passphrase,json=seedPassphrase,proto3" json:"seed_passphrase,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *InitWalletRequest) Reset() {
+	*x = InitWalletRequest{}
+	mi := &file_daemon_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InitWalletRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InitWalletRequest) ProtoMessage() {}
+
+func (x *InitWalletRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InitWalletRequest.ProtoReflect.Descriptor instead.
+func (*InitWalletRequest) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *InitWalletRequest) GetMnemonic() []string {
+	if x != nil {
+		return x.Mnemonic
+	}
+	return nil
+}
+
+func (x *InitWalletRequest) GetWalletPassword() []byte {
+	if x != nil {
+		return x.WalletPassword
+	}
+	return nil
+}
+
+func (x *InitWalletRequest) GetSeedPassphrase() []byte {
+	if x != nil {
+		return x.SeedPassphrase
+	}
+	return nil
+}
+
+type InitWalletResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// identity_pubkey is the hex-encoded identity public key derived from
+	// the newly created wallet.
+	IdentityPubkey string `protobuf:"bytes,1,opt,name=identity_pubkey,json=identityPubkey,proto3" json:"identity_pubkey,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *InitWalletResponse) Reset() {
+	*x = InitWalletResponse{}
+	mi := &file_daemon_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InitWalletResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InitWalletResponse) ProtoMessage() {}
+
+func (x *InitWalletResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InitWalletResponse.ProtoReflect.Descriptor instead.
+func (*InitWalletResponse) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *InitWalletResponse) GetIdentityPubkey() string {
+	if x != nil {
+		return x.IdentityPubkey
+	}
+	return ""
+}
+
+type UnlockWalletRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// wallet_password is the password used to decrypt the seed stored on
+	// disk.
+	WalletPassword []byte `protobuf:"bytes,1,opt,name=wallet_password,json=walletPassword,proto3" json:"wallet_password,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *UnlockWalletRequest) Reset() {
+	*x = UnlockWalletRequest{}
+	mi := &file_daemon_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UnlockWalletRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UnlockWalletRequest) ProtoMessage() {}
+
+func (x *UnlockWalletRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UnlockWalletRequest.ProtoReflect.Descriptor instead.
+func (*UnlockWalletRequest) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *UnlockWalletRequest) GetWalletPassword() []byte {
+	if x != nil {
+		return x.WalletPassword
+	}
+	return nil
+}
+
+type UnlockWalletResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// identity_pubkey is the hex-encoded identity public key of the
+	// unlocked wallet.
+	IdentityPubkey string `protobuf:"bytes,1,opt,name=identity_pubkey,json=identityPubkey,proto3" json:"identity_pubkey,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *UnlockWalletResponse) Reset() {
+	*x = UnlockWalletResponse{}
+	mi := &file_daemon_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UnlockWalletResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UnlockWalletResponse) ProtoMessage() {}
+
+func (x *UnlockWalletResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UnlockWalletResponse.ProtoReflect.Descriptor instead.
+func (*UnlockWalletResponse) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *UnlockWalletResponse) GetIdentityPubkey() string {
+	if x != nil {
+		return x.IdentityPubkey
+	}
+	return ""
+}
+
+type GetBalanceRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetBalanceRequest) Reset() {
+	*x = GetBalanceRequest{}
+	mi := &file_daemon_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetBalanceRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetBalanceRequest) ProtoMessage() {}
+
+func (x *GetBalanceRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetBalanceRequest.ProtoReflect.Descriptor instead.
+func (*GetBalanceRequest) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{8}
+}
+
+type GetBalanceResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// boarding_confirmed_sat is the total confirmed balance in boarding
+	// addresses (on-chain, waiting to be swept into VTXOs).
+	BoardingConfirmedSat int64 `protobuf:"varint,1,opt,name=boarding_confirmed_sat,json=boardingConfirmedSat,proto3" json:"boarding_confirmed_sat,omitempty"`
+	// boarding_unconfirmed_sat is the total unconfirmed balance in
+	// boarding addresses.
+	BoardingUnconfirmedSat int64 `protobuf:"varint,2,opt,name=boarding_unconfirmed_sat,json=boardingUnconfirmedSat,proto3" json:"boarding_unconfirmed_sat,omitempty"`
+	// vtxo_balance_sat is the total balance held in live (spendable)
+	// VTXOs.
+	VtxoBalanceSat int64 `protobuf:"varint,3,opt,name=vtxo_balance_sat,json=vtxoBalanceSat,proto3" json:"vtxo_balance_sat,omitempty"`
+	// total_confirmed_sat is the sum of all confirmed balances
+	// (boarding_confirmed_sat + vtxo_balance_sat).
+	TotalConfirmedSat int64 `protobuf:"varint,4,opt,name=total_confirmed_sat,json=totalConfirmedSat,proto3" json:"total_confirmed_sat,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *GetBalanceResponse) Reset() {
+	*x = GetBalanceResponse{}
+	mi := &file_daemon_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetBalanceResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetBalanceResponse) ProtoMessage() {}
+
+func (x *GetBalanceResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetBalanceResponse.ProtoReflect.Descriptor instead.
+func (*GetBalanceResponse) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *GetBalanceResponse) GetBoardingConfirmedSat() int64 {
+	if x != nil {
+		return x.BoardingConfirmedSat
+	}
+	return 0
+}
+
+func (x *GetBalanceResponse) GetBoardingUnconfirmedSat() int64 {
+	if x != nil {
+		return x.BoardingUnconfirmedSat
+	}
+	return 0
+}
+
+func (x *GetBalanceResponse) GetVtxoBalanceSat() int64 {
+	if x != nil {
+		return x.VtxoBalanceSat
+	}
+	return 0
+}
+
+func (x *GetBalanceResponse) GetTotalConfirmedSat() int64 {
+	if x != nil {
+		return x.TotalConfirmedSat
+	}
+	return 0
+}
+
+type VTXO struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// outpoint is the VTXO's outpoint in "txid:index" format.
+	Outpoint string `protobuf:"bytes,1,opt,name=outpoint,proto3" json:"outpoint,omitempty"`
+	// amount_sat is the value of this VTXO in satoshis.
+	AmountSat int64 `protobuf:"varint,2,opt,name=amount_sat,json=amountSat,proto3" json:"amount_sat,omitempty"`
+	// status is the current lifecycle state of this VTXO.
+	Status VTXOStatus `protobuf:"varint,3,opt,name=status,proto3,enum=daemonrpc.VTXOStatus" json:"status,omitempty"`
+	// batch_expiry is the absolute block height at which the batch-level
+	// timelock expires.
+	BatchExpiry int32 `protobuf:"varint,4,opt,name=batch_expiry,json=batchExpiry,proto3" json:"batch_expiry,omitempty"`
+	// round_id is the identifier of the round that created this VTXO.
+	RoundId string `protobuf:"bytes,5,opt,name=round_id,json=roundId,proto3" json:"round_id,omitempty"`
+	// created_height is the block height at which this VTXO was created.
+	CreatedHeight int32 `protobuf:"varint,6,opt,name=created_height,json=createdHeight,proto3" json:"created_height,omitempty"`
+	// relative_expiry is the CSV delay (in blocks) for the unilateral
+	// exit path.
+	RelativeExpiry uint32 `protobuf:"varint,7,opt,name=relative_expiry,json=relativeExpiry,proto3" json:"relative_expiry,omitempty"`
+	// pk_script is the hex-encoded taproot output script.
+	PkScript string `protobuf:"bytes,8,opt,name=pk_script,json=pkScript,proto3" json:"pk_script,omitempty"`
+	// commitment_txid is the hex-encoded txid of the on-chain commitment
+	// transaction anchoring this VTXO's tree.
+	CommitmentTxid string `protobuf:"bytes,9,opt,name=commitment_txid,json=commitmentTxid,proto3" json:"commitment_txid,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *VTXO) Reset() {
+	*x = VTXO{}
+	mi := &file_daemon_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *VTXO) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*VTXO) ProtoMessage() {}
+
+func (x *VTXO) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use VTXO.ProtoReflect.Descriptor instead.
+func (*VTXO) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *VTXO) GetOutpoint() string {
+	if x != nil {
+		return x.Outpoint
+	}
+	return ""
+}
+
+func (x *VTXO) GetAmountSat() int64 {
+	if x != nil {
+		return x.AmountSat
+	}
+	return 0
+}
+
+func (x *VTXO) GetStatus() VTXOStatus {
+	if x != nil {
+		return x.Status
+	}
+	return VTXOStatus_VTXO_STATUS_UNSPECIFIED
+}
+
+func (x *VTXO) GetBatchExpiry() int32 {
+	if x != nil {
+		return x.BatchExpiry
+	}
+	return 0
+}
+
+func (x *VTXO) GetRoundId() string {
+	if x != nil {
+		return x.RoundId
+	}
+	return ""
+}
+
+func (x *VTXO) GetCreatedHeight() int32 {
+	if x != nil {
+		return x.CreatedHeight
+	}
+	return 0
+}
+
+func (x *VTXO) GetRelativeExpiry() uint32 {
+	if x != nil {
+		return x.RelativeExpiry
+	}
+	return 0
+}
+
+func (x *VTXO) GetPkScript() string {
+	if x != nil {
+		return x.PkScript
+	}
+	return ""
+}
+
+func (x *VTXO) GetCommitmentTxid() string {
+	if x != nil {
+		return x.CommitmentTxid
+	}
+	return ""
+}
+
+type ListVTXOsRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// status_filter restricts the response to VTXOs matching this status.
+	// If VTXO_STATUS_UNSPECIFIED (default), all statuses are returned.
+	StatusFilter VTXOStatus `protobuf:"varint,1,opt,name=status_filter,json=statusFilter,proto3,enum=daemonrpc.VTXOStatus" json:"status_filter,omitempty"`
+	// min_amount_sat excludes VTXOs below this value.
+	MinAmountSat  int64 `protobuf:"varint,2,opt,name=min_amount_sat,json=minAmountSat,proto3" json:"min_amount_sat,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListVTXOsRequest) Reset() {
+	*x = ListVTXOsRequest{}
+	mi := &file_daemon_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListVTXOsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListVTXOsRequest) ProtoMessage() {}
+
+func (x *ListVTXOsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListVTXOsRequest.ProtoReflect.Descriptor instead.
+func (*ListVTXOsRequest) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *ListVTXOsRequest) GetStatusFilter() VTXOStatus {
+	if x != nil {
+		return x.StatusFilter
+	}
+	return VTXOStatus_VTXO_STATUS_UNSPECIFIED
+}
+
+func (x *ListVTXOsRequest) GetMinAmountSat() int64 {
+	if x != nil {
+		return x.MinAmountSat
+	}
+	return 0
+}
+
+type ListVTXOsResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// vtxos is the list of VTXOs matching the request filters.
+	Vtxos         []*VTXO `protobuf:"bytes,1,rep,name=vtxos,proto3" json:"vtxos,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListVTXOsResponse) Reset() {
+	*x = ListVTXOsResponse{}
+	mi := &file_daemon_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListVTXOsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListVTXOsResponse) ProtoMessage() {}
+
+func (x *ListVTXOsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListVTXOsResponse.ProtoReflect.Descriptor instead.
+func (*ListVTXOsResponse) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *ListVTXOsResponse) GetVtxos() []*VTXO {
+	if x != nil {
+		return x.Vtxos
+	}
+	return nil
+}
+
+type NewAddressRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *NewAddressRequest) Reset() {
+	*x = NewAddressRequest{}
+	mi := &file_daemon_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *NewAddressRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*NewAddressRequest) ProtoMessage() {}
+
+func (x *NewAddressRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use NewAddressRequest.ProtoReflect.Descriptor instead.
+func (*NewAddressRequest) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{13}
+}
+
+type NewAddressResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// address is the bech32m-encoded taproot boarding address.
+	Address       string `protobuf:"bytes,1,opt,name=address,proto3" json:"address,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *NewAddressResponse) Reset() {
+	*x = NewAddressResponse{}
+	mi := &file_daemon_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *NewAddressResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*NewAddressResponse) ProtoMessage() {}
+
+func (x *NewAddressResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use NewAddressResponse.ProtoReflect.Descriptor instead.
+func (*NewAddressResponse) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *NewAddressResponse) GetAddress() string {
+	if x != nil {
+		return x.Address
+	}
+	return ""
+}
+
+// Output describes a single recipient in a send operation.
+type Output struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Destination:
+	//
+	//	*Output_Address
+	//	*Output_Pubkey
+	//	*Output_PkScript
+	Destination isOutput_Destination `protobuf_oneof:"destination"`
+	// amount_sat is the value to send in satoshis.
+	AmountSat     int64 `protobuf:"varint,2,opt,name=amount_sat,json=amountSat,proto3" json:"amount_sat,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Output) Reset() {
+	*x = Output{}
+	mi := &file_daemon_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Output) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Output) ProtoMessage() {}
+
+func (x *Output) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Output.ProtoReflect.Descriptor instead.
+func (*Output) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *Output) GetDestination() isOutput_Destination {
+	if x != nil {
+		return x.Destination
+	}
+	return nil
+}
+
+func (x *Output) GetAddress() string {
+	if x != nil {
+		if x, ok := x.Destination.(*Output_Address); ok {
+			return x.Address
+		}
+	}
+	return ""
+}
+
+func (x *Output) GetPubkey() []byte {
+	if x != nil {
+		if x, ok := x.Destination.(*Output_Pubkey); ok {
+			return x.Pubkey
+		}
+	}
+	return nil
+}
+
+func (x *Output) GetPkScript() []byte {
+	if x != nil {
+		if x, ok := x.Destination.(*Output_PkScript); ok {
+			return x.PkScript
+		}
+	}
+	return nil
+}
+
+func (x *Output) GetAmountSat() int64 {
+	if x != nil {
+		return x.AmountSat
+	}
+	return 0
+}
+
+type isOutput_Destination interface {
+	isOutput_Destination()
+}
+
+type Output_Address struct {
+	// address is the recipient's bech32m-encoded taproot address.
+	Address string `protobuf:"bytes,1,opt,name=address,proto3,oneof"`
+}
+
+type Output_Pubkey struct {
+	// pubkey is the 32-byte x-only public key used to derive a
+	// BIP-86 taproot output.
+	Pubkey []byte `protobuf:"bytes,3,opt,name=pubkey,proto3,oneof"`
+}
+
+type Output_PkScript struct {
+	// pk_script is the raw output script for the recipient.
+	PkScript []byte `protobuf:"bytes,4,opt,name=pk_script,json=pkScript,proto3,oneof"`
+}
+
+func (*Output_Address) isOutput_Destination() {}
+
+func (*Output_Pubkey) isOutput_Destination() {}
+
+func (*Output_PkScript) isOutput_Destination() {}
+
+type SendVTXORequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// recipients is the list of outputs to create in the next round.
+	Recipients []*Output `protobuf:"bytes,1,rep,name=recipients,proto3" json:"recipients,omitempty"`
+	// dry_run validates the request without submitting it to the round
+	// coordinator. When true, the response contains a preview of the
+	// operation.
+	DryRun        bool `protobuf:"varint,2,opt,name=dry_run,json=dryRun,proto3" json:"dry_run,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SendVTXORequest) Reset() {
+	*x = SendVTXORequest{}
+	mi := &file_daemon_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SendVTXORequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SendVTXORequest) ProtoMessage() {}
+
+func (x *SendVTXORequest) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SendVTXORequest.ProtoReflect.Descriptor instead.
+func (*SendVTXORequest) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *SendVTXORequest) GetRecipients() []*Output {
+	if x != nil {
+		return x.Recipients
+	}
+	return nil
+}
+
+func (x *SendVTXORequest) GetDryRun() bool {
+	if x != nil {
+		return x.DryRun
+	}
+	return false
+}
+
+type SendVTXOResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// status is the result: "submitted" on success, "preview" on
+	// dry_run.
+	Status string `protobuf:"bytes,1,opt,name=status,proto3" json:"status,omitempty"`
+	// round_id is the identifier of the round this send was submitted
+	// to. Empty on dry_run.
+	RoundId string `protobuf:"bytes,2,opt,name=round_id,json=roundId,proto3" json:"round_id,omitempty"`
+	// total_amount_sat is the total amount being sent (sum of
+	// recipients).
+	TotalAmountSat int64 `protobuf:"varint,3,opt,name=total_amount_sat,json=totalAmountSat,proto3" json:"total_amount_sat,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *SendVTXOResponse) Reset() {
+	*x = SendVTXOResponse{}
+	mi := &file_daemon_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SendVTXOResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SendVTXOResponse) ProtoMessage() {}
+
+func (x *SendVTXOResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SendVTXOResponse.ProtoReflect.Descriptor instead.
+func (*SendVTXOResponse) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *SendVTXOResponse) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
+func (x *SendVTXOResponse) GetRoundId() string {
+	if x != nil {
+		return x.RoundId
+	}
+	return ""
+}
+
+func (x *SendVTXOResponse) GetTotalAmountSat() int64 {
+	if x != nil {
+		return x.TotalAmountSat
+	}
+	return 0
+}
+
+type SendOORRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// recipient is the output to create via the out-of-round transfer.
+	Recipient *Output `protobuf:"bytes,1,opt,name=recipient,proto3" json:"recipient,omitempty"`
+	// dry_run validates the request without initiating the transfer.
+	DryRun        bool `protobuf:"varint,2,opt,name=dry_run,json=dryRun,proto3" json:"dry_run,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SendOORRequest) Reset() {
+	*x = SendOORRequest{}
+	mi := &file_daemon_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SendOORRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SendOORRequest) ProtoMessage() {}
+
+func (x *SendOORRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SendOORRequest.ProtoReflect.Descriptor instead.
+func (*SendOORRequest) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *SendOORRequest) GetRecipient() *Output {
+	if x != nil {
+		return x.Recipient
+	}
+	return nil
+}
+
+func (x *SendOORRequest) GetDryRun() bool {
+	if x != nil {
+		return x.DryRun
+	}
+	return false
+}
+
+type SendOORResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// status is the result: "submitted" on success, "preview" on
+	// dry_run.
+	Status string `protobuf:"bytes,1,opt,name=status,proto3" json:"status,omitempty"`
+	// session_id is the OOR session identifier. Empty on dry_run.
+	SessionId     string `protobuf:"bytes,2,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SendOORResponse) Reset() {
+	*x = SendOORResponse{}
+	mi := &file_daemon_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SendOORResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SendOORResponse) ProtoMessage() {}
+
+func (x *SendOORResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SendOORResponse.ProtoReflect.Descriptor instead.
+func (*SendOORResponse) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *SendOORResponse) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
+func (x *SendOORResponse) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+// OutpointSelection wraps a list of outpoint strings for use inside a
+// oneof field, since proto3 does not allow repeated fields directly in
+// a oneof.
+type OutpointSelection struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// outpoints lists specific VTXOs in "txid:index" format.
+	Outpoints     []string `protobuf:"bytes,1,rep,name=outpoints,proto3" json:"outpoints,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *OutpointSelection) Reset() {
+	*x = OutpointSelection{}
+	mi := &file_daemon_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *OutpointSelection) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OutpointSelection) ProtoMessage() {}
+
+func (x *OutpointSelection) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use OutpointSelection.ProtoReflect.Descriptor instead.
+func (*OutpointSelection) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *OutpointSelection) GetOutpoints() []string {
+	if x != nil {
+		return x.Outpoints
+	}
+	return nil
+}
+
+type RefreshVTXOsRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Selection:
+	//
+	//	*RefreshVTXOsRequest_Outpoints
+	//	*RefreshVTXOsRequest_All
+	Selection isRefreshVTXOsRequest_Selection `protobuf_oneof:"selection"`
+	// dry_run validates the request without queuing the refresh.
+	DryRun        bool `protobuf:"varint,3,opt,name=dry_run,json=dryRun,proto3" json:"dry_run,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RefreshVTXOsRequest) Reset() {
+	*x = RefreshVTXOsRequest{}
+	mi := &file_daemon_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RefreshVTXOsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RefreshVTXOsRequest) ProtoMessage() {}
+
+func (x *RefreshVTXOsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RefreshVTXOsRequest.ProtoReflect.Descriptor instead.
+func (*RefreshVTXOsRequest) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{21}
+}
+
+func (x *RefreshVTXOsRequest) GetSelection() isRefreshVTXOsRequest_Selection {
+	if x != nil {
+		return x.Selection
+	}
+	return nil
+}
+
+func (x *RefreshVTXOsRequest) GetOutpoints() *OutpointSelection {
+	if x != nil {
+		if x, ok := x.Selection.(*RefreshVTXOsRequest_Outpoints); ok {
+			return x.Outpoints
+		}
+	}
+	return nil
+}
+
+func (x *RefreshVTXOsRequest) GetAll() bool {
+	if x != nil {
+		if x, ok := x.Selection.(*RefreshVTXOsRequest_All); ok {
+			return x.All
+		}
+	}
+	return false
+}
+
+func (x *RefreshVTXOsRequest) GetDryRun() bool {
+	if x != nil {
+		return x.DryRun
+	}
+	return false
+}
+
+type isRefreshVTXOsRequest_Selection interface {
+	isRefreshVTXOsRequest_Selection()
+}
+
+type RefreshVTXOsRequest_Outpoints struct {
+	// outpoints lists specific VTXOs to refresh, in "txid:index"
+	// format.
+	Outpoints *OutpointSelection `protobuf:"bytes,1,opt,name=outpoints,proto3,oneof"`
+}
+
+type RefreshVTXOsRequest_All struct {
+	// all refreshes every live VTXO when true.
+	All bool `protobuf:"varint,2,opt,name=all,proto3,oneof"`
+}
+
+func (*RefreshVTXOsRequest_Outpoints) isRefreshVTXOsRequest_Selection() {}
+
+func (*RefreshVTXOsRequest_All) isRefreshVTXOsRequest_Selection() {}
+
+type RefreshVTXOsResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// queued_outpoints lists the outpoints that were successfully queued
+	// for refresh.
+	QueuedOutpoints []string `protobuf:"bytes,1,rep,name=queued_outpoints,json=queuedOutpoints,proto3" json:"queued_outpoints,omitempty"`
+	// status is the result: "queued" on success, "preview" on dry_run.
+	Status        string `protobuf:"bytes,2,opt,name=status,proto3" json:"status,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RefreshVTXOsResponse) Reset() {
+	*x = RefreshVTXOsResponse{}
+	mi := &file_daemon_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RefreshVTXOsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RefreshVTXOsResponse) ProtoMessage() {}
+
+func (x *RefreshVTXOsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RefreshVTXOsResponse.ProtoReflect.Descriptor instead.
+func (*RefreshVTXOsResponse) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{22}
+}
+
+func (x *RefreshVTXOsResponse) GetQueuedOutpoints() []string {
+	if x != nil {
+		return x.QueuedOutpoints
+	}
+	return nil
+}
+
+func (x *RefreshVTXOsResponse) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
 var File_daemon_proto protoreflect.FileDescriptor
 
 const file_daemon_proto_rawDesc = "" +
 	"\n" +
 	"\fdaemon.proto\x12\tdaemonrpc\"\x10\n" +
-	"\x0eGetInfoRequest\"\xf8\x01\n" +
+	"\x0eGetInfoRequest\"\xe5\x02\n" +
 	"\x0fGetInfoResponse\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\tR\aversion\x12\x16\n" +
 	"\x06commit\x18\x02 \x01(\tR\x06commit\x12\x18\n" +
@@ -173,9 +1543,109 @@ const file_daemon_proto_rawDesc = "" +
 	"\x13lnd_identity_pubkey\x18\x04 \x01(\tR\x11lndIdentityPubkey\x12!\n" +
 	"\fblock_height\x18\x05 \x01(\rR\vblockHeight\x12)\n" +
 	"\x10server_connected\x18\x06 \x01(\bR\x0fserverConnected\x12\x1b\n" +
-	"\tlnd_alias\x18\a \x01(\tR\blndAlias2Q\n" +
+	"\tlnd_alias\x18\a \x01(\tR\blndAlias\x12\x1f\n" +
+	"\vwallet_type\x18\b \x01(\tR\n" +
+	"walletType\x12!\n" +
+	"\fwallet_ready\x18\t \x01(\bR\vwalletReady\x12'\n" +
+	"\x0fidentity_pubkey\x18\n" +
+	" \x01(\tR\x0eidentityPubkey\"9\n" +
+	"\x0eGenSeedRequest\x12'\n" +
+	"\x0fseed_passphrase\x18\x01 \x01(\fR\x0eseedPassphrase\"V\n" +
+	"\x0fGenSeedResponse\x12\x1a\n" +
+	"\bmnemonic\x18\x01 \x03(\tR\bmnemonic\x12'\n" +
+	"\x0fenciphered_seed\x18\x02 \x01(\fR\x0eencipheredSeed\"\x81\x01\n" +
+	"\x11InitWalletRequest\x12\x1a\n" +
+	"\bmnemonic\x18\x01 \x03(\tR\bmnemonic\x12'\n" +
+	"\x0fwallet_password\x18\x02 \x01(\fR\x0ewalletPassword\x12'\n" +
+	"\x0fseed_passphrase\x18\x03 \x01(\fR\x0eseedPassphrase\"=\n" +
+	"\x12InitWalletResponse\x12'\n" +
+	"\x0fidentity_pubkey\x18\x01 \x01(\tR\x0eidentityPubkey\">\n" +
+	"\x13UnlockWalletRequest\x12'\n" +
+	"\x0fwallet_password\x18\x01 \x01(\fR\x0ewalletPassword\"?\n" +
+	"\x14UnlockWalletResponse\x12'\n" +
+	"\x0fidentity_pubkey\x18\x01 \x01(\tR\x0eidentityPubkey\"\x13\n" +
+	"\x11GetBalanceRequest\"\xde\x01\n" +
+	"\x12GetBalanceResponse\x124\n" +
+	"\x16boarding_confirmed_sat\x18\x01 \x01(\x03R\x14boardingConfirmedSat\x128\n" +
+	"\x18boarding_unconfirmed_sat\x18\x02 \x01(\x03R\x16boardingUnconfirmedSat\x12(\n" +
+	"\x10vtxo_balance_sat\x18\x03 \x01(\x03R\x0evtxoBalanceSat\x12.\n" +
+	"\x13total_confirmed_sat\x18\x04 \x01(\x03R\x11totalConfirmedSat\"\xc4\x02\n" +
+	"\x04VTXO\x12\x1a\n" +
+	"\boutpoint\x18\x01 \x01(\tR\boutpoint\x12\x1d\n" +
+	"\n" +
+	"amount_sat\x18\x02 \x01(\x03R\tamountSat\x12-\n" +
+	"\x06status\x18\x03 \x01(\x0e2\x15.daemonrpc.VTXOStatusR\x06status\x12!\n" +
+	"\fbatch_expiry\x18\x04 \x01(\x05R\vbatchExpiry\x12\x19\n" +
+	"\bround_id\x18\x05 \x01(\tR\aroundId\x12%\n" +
+	"\x0ecreated_height\x18\x06 \x01(\x05R\rcreatedHeight\x12'\n" +
+	"\x0frelative_expiry\x18\a \x01(\rR\x0erelativeExpiry\x12\x1b\n" +
+	"\tpk_script\x18\b \x01(\tR\bpkScript\x12'\n" +
+	"\x0fcommitment_txid\x18\t \x01(\tR\x0ecommitmentTxid\"t\n" +
+	"\x10ListVTXOsRequest\x12:\n" +
+	"\rstatus_filter\x18\x01 \x01(\x0e2\x15.daemonrpc.VTXOStatusR\fstatusFilter\x12$\n" +
+	"\x0emin_amount_sat\x18\x02 \x01(\x03R\fminAmountSat\":\n" +
+	"\x11ListVTXOsResponse\x12%\n" +
+	"\x05vtxos\x18\x01 \x03(\v2\x0f.daemonrpc.VTXOR\x05vtxos\"\x13\n" +
+	"\x11NewAddressRequest\".\n" +
+	"\x12NewAddressResponse\x12\x18\n" +
+	"\aaddress\x18\x01 \x01(\tR\aaddress\"\x8b\x01\n" +
+	"\x06Output\x12\x1a\n" +
+	"\aaddress\x18\x01 \x01(\tH\x00R\aaddress\x12\x18\n" +
+	"\x06pubkey\x18\x03 \x01(\fH\x00R\x06pubkey\x12\x1d\n" +
+	"\tpk_script\x18\x04 \x01(\fH\x00R\bpkScript\x12\x1d\n" +
+	"\n" +
+	"amount_sat\x18\x02 \x01(\x03R\tamountSatB\r\n" +
+	"\vdestination\"]\n" +
+	"\x0fSendVTXORequest\x121\n" +
+	"\n" +
+	"recipients\x18\x01 \x03(\v2\x11.daemonrpc.OutputR\n" +
+	"recipients\x12\x17\n" +
+	"\adry_run\x18\x02 \x01(\bR\x06dryRun\"o\n" +
+	"\x10SendVTXOResponse\x12\x16\n" +
+	"\x06status\x18\x01 \x01(\tR\x06status\x12\x19\n" +
+	"\bround_id\x18\x02 \x01(\tR\aroundId\x12(\n" +
+	"\x10total_amount_sat\x18\x03 \x01(\x03R\x0etotalAmountSat\"Z\n" +
+	"\x0eSendOORRequest\x12/\n" +
+	"\trecipient\x18\x01 \x01(\v2\x11.daemonrpc.OutputR\trecipient\x12\x17\n" +
+	"\adry_run\x18\x02 \x01(\bR\x06dryRun\"H\n" +
+	"\x0fSendOORResponse\x12\x16\n" +
+	"\x06status\x18\x01 \x01(\tR\x06status\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x02 \x01(\tR\tsessionId\"1\n" +
+	"\x11OutpointSelection\x12\x1c\n" +
+	"\toutpoints\x18\x01 \x03(\tR\toutpoints\"\x8d\x01\n" +
+	"\x13RefreshVTXOsRequest\x12<\n" +
+	"\toutpoints\x18\x01 \x01(\v2\x1c.daemonrpc.OutpointSelectionH\x00R\toutpoints\x12\x12\n" +
+	"\x03all\x18\x02 \x01(\bH\x00R\x03all\x12\x17\n" +
+	"\adry_run\x18\x03 \x01(\bR\x06dryRunB\v\n" +
+	"\tselection\"Y\n" +
+	"\x14RefreshVTXOsResponse\x12)\n" +
+	"\x10queued_outpoints\x18\x01 \x03(\tR\x0fqueuedOutpoints\x12\x16\n" +
+	"\x06status\x18\x02 \x01(\tR\x06status*\xe2\x01\n" +
+	"\n" +
+	"VTXOStatus\x12\x1b\n" +
+	"\x17VTXO_STATUS_UNSPECIFIED\x10\x00\x12\x14\n" +
+	"\x10VTXO_STATUS_LIVE\x10\x01\x12!\n" +
+	"\x1dVTXO_STATUS_REFRESH_REQUESTED\x10\x02\x12\x1a\n" +
+	"\x16VTXO_STATUS_FORFEITING\x10\x03\x12\x19\n" +
+	"\x15VTXO_STATUS_FORFEITED\x10\x04\x12\x15\n" +
+	"\x11VTXO_STATUS_SPENT\x10\x05\x12\x18\n" +
+	"\x14VTXO_STATUS_EXPIRING\x10\x06\x12\x16\n" +
+	"\x12VTXO_STATUS_FAILED\x10\a2\xe5\x05\n" +
 	"\rDaemonService\x12@\n" +
-	"\aGetInfo\x12\x19.daemonrpc.GetInfoRequest\x1a\x1a.daemonrpc.GetInfoResponseB2Z0github.com/lightninglabs/darepo-client/daemonrpcb\x06proto3"
+	"\aGetInfo\x12\x19.daemonrpc.GetInfoRequest\x1a\x1a.daemonrpc.GetInfoResponse\x12@\n" +
+	"\aGenSeed\x12\x19.daemonrpc.GenSeedRequest\x1a\x1a.daemonrpc.GenSeedResponse\x12I\n" +
+	"\n" +
+	"InitWallet\x12\x1c.daemonrpc.InitWalletRequest\x1a\x1d.daemonrpc.InitWalletResponse\x12O\n" +
+	"\fUnlockWallet\x12\x1e.daemonrpc.UnlockWalletRequest\x1a\x1f.daemonrpc.UnlockWalletResponse\x12I\n" +
+	"\n" +
+	"GetBalance\x12\x1c.daemonrpc.GetBalanceRequest\x1a\x1d.daemonrpc.GetBalanceResponse\x12F\n" +
+	"\tListVTXOs\x12\x1b.daemonrpc.ListVTXOsRequest\x1a\x1c.daemonrpc.ListVTXOsResponse\x12I\n" +
+	"\n" +
+	"NewAddress\x12\x1c.daemonrpc.NewAddressRequest\x1a\x1d.daemonrpc.NewAddressResponse\x12C\n" +
+	"\bSendVTXO\x12\x1a.daemonrpc.SendVTXORequest\x1a\x1b.daemonrpc.SendVTXOResponse\x12@\n" +
+	"\aSendOOR\x12\x19.daemonrpc.SendOORRequest\x1a\x1a.daemonrpc.SendOORResponse\x12O\n" +
+	"\fRefreshVTXOs\x12\x1e.daemonrpc.RefreshVTXOsRequest\x1a\x1f.daemonrpc.RefreshVTXOsResponseB2Z0github.com/lightninglabs/darepo-client/daemonrpcb\x06proto3"
 
 var (
 	file_daemon_proto_rawDescOnce sync.Once
@@ -189,19 +1659,66 @@ func file_daemon_proto_rawDescGZIP() []byte {
 	return file_daemon_proto_rawDescData
 }
 
-var file_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
+var file_daemon_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 23)
 var file_daemon_proto_goTypes = []any{
-	(*GetInfoRequest)(nil),  // 0: daemonrpc.GetInfoRequest
-	(*GetInfoResponse)(nil), // 1: daemonrpc.GetInfoResponse
+	(VTXOStatus)(0),              // 0: daemonrpc.VTXOStatus
+	(*GetInfoRequest)(nil),       // 1: daemonrpc.GetInfoRequest
+	(*GetInfoResponse)(nil),      // 2: daemonrpc.GetInfoResponse
+	(*GenSeedRequest)(nil),       // 3: daemonrpc.GenSeedRequest
+	(*GenSeedResponse)(nil),      // 4: daemonrpc.GenSeedResponse
+	(*InitWalletRequest)(nil),    // 5: daemonrpc.InitWalletRequest
+	(*InitWalletResponse)(nil),   // 6: daemonrpc.InitWalletResponse
+	(*UnlockWalletRequest)(nil),  // 7: daemonrpc.UnlockWalletRequest
+	(*UnlockWalletResponse)(nil), // 8: daemonrpc.UnlockWalletResponse
+	(*GetBalanceRequest)(nil),    // 9: daemonrpc.GetBalanceRequest
+	(*GetBalanceResponse)(nil),   // 10: daemonrpc.GetBalanceResponse
+	(*VTXO)(nil),                 // 11: daemonrpc.VTXO
+	(*ListVTXOsRequest)(nil),     // 12: daemonrpc.ListVTXOsRequest
+	(*ListVTXOsResponse)(nil),    // 13: daemonrpc.ListVTXOsResponse
+	(*NewAddressRequest)(nil),    // 14: daemonrpc.NewAddressRequest
+	(*NewAddressResponse)(nil),   // 15: daemonrpc.NewAddressResponse
+	(*Output)(nil),               // 16: daemonrpc.Output
+	(*SendVTXORequest)(nil),      // 17: daemonrpc.SendVTXORequest
+	(*SendVTXOResponse)(nil),     // 18: daemonrpc.SendVTXOResponse
+	(*SendOORRequest)(nil),       // 19: daemonrpc.SendOORRequest
+	(*SendOORResponse)(nil),      // 20: daemonrpc.SendOORResponse
+	(*OutpointSelection)(nil),    // 21: daemonrpc.OutpointSelection
+	(*RefreshVTXOsRequest)(nil),  // 22: daemonrpc.RefreshVTXOsRequest
+	(*RefreshVTXOsResponse)(nil), // 23: daemonrpc.RefreshVTXOsResponse
 }
 var file_daemon_proto_depIdxs = []int32{
-	0, // 0: daemonrpc.DaemonService.GetInfo:input_type -> daemonrpc.GetInfoRequest
-	1, // 1: daemonrpc.DaemonService.GetInfo:output_type -> daemonrpc.GetInfoResponse
-	1, // [1:2] is the sub-list for method output_type
-	0, // [0:1] is the sub-list for method input_type
-	0, // [0:0] is the sub-list for extension type_name
-	0, // [0:0] is the sub-list for extension extendee
-	0, // [0:0] is the sub-list for field type_name
+	0,  // 0: daemonrpc.VTXO.status:type_name -> daemonrpc.VTXOStatus
+	0,  // 1: daemonrpc.ListVTXOsRequest.status_filter:type_name -> daemonrpc.VTXOStatus
+	11, // 2: daemonrpc.ListVTXOsResponse.vtxos:type_name -> daemonrpc.VTXO
+	16, // 3: daemonrpc.SendVTXORequest.recipients:type_name -> daemonrpc.Output
+	16, // 4: daemonrpc.SendOORRequest.recipient:type_name -> daemonrpc.Output
+	21, // 5: daemonrpc.RefreshVTXOsRequest.outpoints:type_name -> daemonrpc.OutpointSelection
+	1,  // 6: daemonrpc.DaemonService.GetInfo:input_type -> daemonrpc.GetInfoRequest
+	3,  // 7: daemonrpc.DaemonService.GenSeed:input_type -> daemonrpc.GenSeedRequest
+	5,  // 8: daemonrpc.DaemonService.InitWallet:input_type -> daemonrpc.InitWalletRequest
+	7,  // 9: daemonrpc.DaemonService.UnlockWallet:input_type -> daemonrpc.UnlockWalletRequest
+	9,  // 10: daemonrpc.DaemonService.GetBalance:input_type -> daemonrpc.GetBalanceRequest
+	12, // 11: daemonrpc.DaemonService.ListVTXOs:input_type -> daemonrpc.ListVTXOsRequest
+	14, // 12: daemonrpc.DaemonService.NewAddress:input_type -> daemonrpc.NewAddressRequest
+	17, // 13: daemonrpc.DaemonService.SendVTXO:input_type -> daemonrpc.SendVTXORequest
+	19, // 14: daemonrpc.DaemonService.SendOOR:input_type -> daemonrpc.SendOORRequest
+	22, // 15: daemonrpc.DaemonService.RefreshVTXOs:input_type -> daemonrpc.RefreshVTXOsRequest
+	2,  // 16: daemonrpc.DaemonService.GetInfo:output_type -> daemonrpc.GetInfoResponse
+	4,  // 17: daemonrpc.DaemonService.GenSeed:output_type -> daemonrpc.GenSeedResponse
+	6,  // 18: daemonrpc.DaemonService.InitWallet:output_type -> daemonrpc.InitWalletResponse
+	8,  // 19: daemonrpc.DaemonService.UnlockWallet:output_type -> daemonrpc.UnlockWalletResponse
+	10, // 20: daemonrpc.DaemonService.GetBalance:output_type -> daemonrpc.GetBalanceResponse
+	13, // 21: daemonrpc.DaemonService.ListVTXOs:output_type -> daemonrpc.ListVTXOsResponse
+	15, // 22: daemonrpc.DaemonService.NewAddress:output_type -> daemonrpc.NewAddressResponse
+	18, // 23: daemonrpc.DaemonService.SendVTXO:output_type -> daemonrpc.SendVTXOResponse
+	20, // 24: daemonrpc.DaemonService.SendOOR:output_type -> daemonrpc.SendOORResponse
+	23, // 25: daemonrpc.DaemonService.RefreshVTXOs:output_type -> daemonrpc.RefreshVTXOsResponse
+	16, // [16:26] is the sub-list for method output_type
+	6,  // [6:16] is the sub-list for method input_type
+	6,  // [6:6] is the sub-list for extension type_name
+	6,  // [6:6] is the sub-list for extension extendee
+	0,  // [0:6] is the sub-list for field type_name
 }
 
 func init() { file_daemon_proto_init() }
@@ -209,18 +1726,28 @@ func file_daemon_proto_init() {
 	if File_daemon_proto != nil {
 		return
 	}
+	file_daemon_proto_msgTypes[15].OneofWrappers = []any{
+		(*Output_Address)(nil),
+		(*Output_Pubkey)(nil),
+		(*Output_PkScript)(nil),
+	}
+	file_daemon_proto_msgTypes[21].OneofWrappers = []any{
+		(*RefreshVTXOsRequest_Outpoints)(nil),
+		(*RefreshVTXOsRequest_All)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_daemon_proto_rawDesc), len(file_daemon_proto_rawDesc)),
-			NumEnums:      0,
-			NumMessages:   2,
+			NumEnums:      1,
+			NumMessages:   23,
 			NumExtensions: 0,
 			NumServices:   1,
 		},
 		GoTypes:           file_daemon_proto_goTypes,
 		DependencyIndexes: file_daemon_proto_depIdxs,
+		EnumInfos:         file_daemon_proto_enumTypes,
 		MessageInfos:      file_daemon_proto_msgTypes,
 	}.Build()
 	File_daemon_proto = out.File

--- a/daemonrpc/daemon.proto
+++ b/daemonrpc/daemon.proto
@@ -12,6 +12,47 @@ service DaemonService {
     // including version, network, lnd connection state, and server
     // connection state.
     rpc GetInfo (GetInfoRequest) returns (GetInfoResponse);
+
+    // GenSeed generates a new aezeed cipher seed mnemonic. This is the
+    // first step when creating a new lwwallet-backed wallet. The returned
+    // mnemonic must be passed to InitWallet to finalize wallet creation.
+    // Only available in lwwallet mode.
+    rpc GenSeed (GenSeedRequest) returns (GenSeedResponse);
+
+    // InitWallet creates a new wallet from a previously generated aezeed
+    // mnemonic. The wallet is encrypted at rest with the provided
+    // password. Only available in lwwallet mode when no wallet exists.
+    rpc InitWallet (InitWalletRequest) returns (InitWalletResponse);
+
+    // UnlockWallet decrypts an existing wallet seed using the provided
+    // password and starts the wallet subsystem. Only available in
+    // lwwallet mode when the wallet is locked.
+    rpc UnlockWallet (UnlockWalletRequest) returns (UnlockWalletResponse);
+
+    // GetBalance returns the current balance of the wallet, broken down
+    // by boarding (on-chain) and VTXO (off-chain) balances.
+    rpc GetBalance (GetBalanceRequest) returns (GetBalanceResponse);
+
+    // ListVTXOs returns the set of VTXOs known to the wallet, optionally
+    // filtered by status and minimum amount.
+    rpc ListVTXOs (ListVTXOsRequest) returns (ListVTXOsResponse);
+
+    // NewAddress generates a new boarding address that can receive
+    // on-chain funds for use in the Ark protocol.
+    rpc NewAddress (NewAddressRequest) returns (NewAddressResponse);
+
+    // SendVTXO initiates an in-round transfer by submitting a refresh
+    // request to the round coordinator. The transfer completes when the
+    // next round commits.
+    rpc SendVTXO (SendVTXORequest) returns (SendVTXOResponse);
+
+    // SendOOR initiates an out-of-round transfer directly between the
+    // client and operator, without waiting for a round.
+    rpc SendOOR (SendOORRequest) returns (SendOORResponse);
+
+    // RefreshVTXOs queues one or more VTXOs for refresh in the next
+    // round. This extends their expiry without changing ownership.
+    rpc RefreshVTXOs (RefreshVTXOsRequest) returns (RefreshVTXOsResponse);
 }
 
 message GetInfoRequest {
@@ -29,17 +70,277 @@ message GetInfoResponse {
     string network = 3;
 
     // lnd_identity_pubkey is the hex-encoded identity public key of the
-    // connected lnd node.
+    // connected lnd node. Empty in lwwallet mode.
     string lnd_identity_pubkey = 4;
 
-    // block_height is the current best block height known to the
-    // connected lnd node.
+    // block_height is the current best block height known to the daemon.
     uint32 block_height = 5;
 
     // server_connected indicates whether the mailbox transport to the ark
     // operator is active and pulling envelopes.
     bool server_connected = 6;
 
-    // lnd_alias is the alias of the connected lnd node.
+    // lnd_alias is the alias of the connected lnd node. Empty in lwwallet
+    // mode.
     string lnd_alias = 7;
+
+    // wallet_type is the active wallet backend: "lnd" or "lwwallet".
+    string wallet_type = 8;
+
+    // wallet_ready indicates whether the wallet subsystem is initialized
+    // and ready to process requests.
+    bool wallet_ready = 9;
+
+    // identity_pubkey is the hex-encoded identity public key derived from
+    // the active wallet backend. In lnd mode this matches
+    // lnd_identity_pubkey.
+    string identity_pubkey = 10;
+}
+
+message GenSeedRequest {
+    // seed_passphrase is an optional passphrase that protects the aezeed
+    // mnemonic itself. This is distinct from the wallet password that
+    // encrypts the seed at rest on disk.
+    bytes seed_passphrase = 1;
+}
+
+message GenSeedResponse {
+    // mnemonic is the 24-word aezeed mnemonic encoding the generated
+    // seed.
+    repeated string mnemonic = 1;
+
+    // enciphered_seed is the raw enciphered seed bytes for advanced use
+    // cases. Most callers should use the mnemonic field.
+    bytes enciphered_seed = 2;
+}
+
+message InitWalletRequest {
+    // mnemonic is the 24-word aezeed mnemonic returned by GenSeed (or
+    // provided for wallet recovery).
+    repeated string mnemonic = 1;
+
+    // wallet_password is the password used to encrypt the seed at rest on
+    // disk. Must be at least 8 bytes.
+    bytes wallet_password = 2;
+
+    // seed_passphrase is the optional passphrase that was used when
+    // generating the aezeed mnemonic. Must match the value passed to
+    // GenSeed.
+    bytes seed_passphrase = 3;
+}
+
+message InitWalletResponse {
+    // identity_pubkey is the hex-encoded identity public key derived from
+    // the newly created wallet.
+    string identity_pubkey = 1;
+}
+
+message UnlockWalletRequest {
+    // wallet_password is the password used to decrypt the seed stored on
+    // disk.
+    bytes wallet_password = 1;
+}
+
+message UnlockWalletResponse {
+    // identity_pubkey is the hex-encoded identity public key of the
+    // unlocked wallet.
+    string identity_pubkey = 1;
+}
+
+message GetBalanceRequest {
+}
+
+message GetBalanceResponse {
+    // boarding_confirmed_sat is the total confirmed balance in boarding
+    // addresses (on-chain, waiting to be swept into VTXOs).
+    int64 boarding_confirmed_sat = 1;
+
+    // boarding_unconfirmed_sat is the total unconfirmed balance in
+    // boarding addresses.
+    int64 boarding_unconfirmed_sat = 2;
+
+    // vtxo_balance_sat is the total balance held in live (spendable)
+    // VTXOs.
+    int64 vtxo_balance_sat = 3;
+
+    // total_confirmed_sat is the sum of all confirmed balances
+    // (boarding_confirmed_sat + vtxo_balance_sat).
+    int64 total_confirmed_sat = 4;
+}
+
+// VTXOStatus represents the lifecycle state of a virtual transaction
+// output.
+enum VTXOStatus {
+    // VTXO_STATUS_UNSPECIFIED is the default zero value.
+    VTXO_STATUS_UNSPECIFIED = 0;
+
+    // VTXO_STATUS_LIVE indicates the VTXO is active and spendable.
+    VTXO_STATUS_LIVE = 1;
+
+    // VTXO_STATUS_REFRESH_REQUESTED indicates a refresh has been queued
+    // but the forfeit transaction has not yet been signed.
+    VTXO_STATUS_REFRESH_REQUESTED = 2;
+
+    // VTXO_STATUS_FORFEITING indicates the forfeit transaction has been
+    // signed and the VTXO is awaiting confirmation of the new round.
+    VTXO_STATUS_FORFEITING = 3;
+
+    // VTXO_STATUS_FORFEITED is terminal: the new round confirmed and
+    // this VTXO has been replaced.
+    VTXO_STATUS_FORFEITED = 4;
+
+    // VTXO_STATUS_SPENT is terminal: the VTXO was spent via an
+    // out-of-round transfer.
+    VTXO_STATUS_SPENT = 5;
+
+    // VTXO_STATUS_EXPIRING is terminal: the VTXO is being resolved
+    // on-chain via the unilateral exit path.
+    VTXO_STATUS_EXPIRING = 6;
+
+    // VTXO_STATUS_FAILED is terminal: an unrecoverable error occurred.
+    VTXO_STATUS_FAILED = 7;
+}
+
+message VTXO {
+    // outpoint is the VTXO's outpoint in "txid:index" format.
+    string outpoint = 1;
+
+    // amount_sat is the value of this VTXO in satoshis.
+    int64 amount_sat = 2;
+
+    // status is the current lifecycle state of this VTXO.
+    VTXOStatus status = 3;
+
+    // batch_expiry is the absolute block height at which the batch-level
+    // timelock expires.
+    int32 batch_expiry = 4;
+
+    // round_id is the identifier of the round that created this VTXO.
+    string round_id = 5;
+
+    // created_height is the block height at which this VTXO was created.
+    int32 created_height = 6;
+
+    // relative_expiry is the CSV delay (in blocks) for the unilateral
+    // exit path.
+    uint32 relative_expiry = 7;
+
+    // pk_script is the hex-encoded taproot output script.
+    string pk_script = 8;
+
+    // commitment_txid is the hex-encoded txid of the on-chain commitment
+    // transaction anchoring this VTXO's tree.
+    string commitment_txid = 9;
+}
+
+message ListVTXOsRequest {
+    // status_filter restricts the response to VTXOs matching this status.
+    // If VTXO_STATUS_UNSPECIFIED (default), all statuses are returned.
+    VTXOStatus status_filter = 1;
+
+    // min_amount_sat excludes VTXOs below this value.
+    int64 min_amount_sat = 2;
+}
+
+message ListVTXOsResponse {
+    // vtxos is the list of VTXOs matching the request filters.
+    repeated VTXO vtxos = 1;
+}
+
+message NewAddressRequest {
+}
+
+message NewAddressResponse {
+    // address is the bech32m-encoded taproot boarding address.
+    string address = 1;
+}
+
+// Output describes a single recipient in a send operation.
+message Output {
+    oneof destination {
+        // address is the recipient's bech32m-encoded taproot address.
+        string address = 1;
+
+        // pubkey is the 32-byte x-only public key used to derive a
+        // BIP-86 taproot output.
+        bytes pubkey = 3;
+
+        // pk_script is the raw output script for the recipient.
+        bytes pk_script = 4;
+    }
+
+    // amount_sat is the value to send in satoshis.
+    int64 amount_sat = 2;
+}
+
+message SendVTXORequest {
+    // recipients is the list of outputs to create in the next round.
+    repeated Output recipients = 1;
+
+    // dry_run validates the request without submitting it to the round
+    // coordinator. When true, the response contains a preview of the
+    // operation.
+    bool dry_run = 2;
+}
+
+message SendVTXOResponse {
+    // status is the result: "submitted" on success, "preview" on
+    // dry_run.
+    string status = 1;
+
+    // round_id is the identifier of the round this send was submitted
+    // to. Empty on dry_run.
+    string round_id = 2;
+
+    // total_amount_sat is the total amount being sent (sum of
+    // recipients).
+    int64 total_amount_sat = 3;
+}
+
+message SendOORRequest {
+    // recipient is the output to create via the out-of-round transfer.
+    Output recipient = 1;
+
+    // dry_run validates the request without initiating the transfer.
+    bool dry_run = 2;
+}
+
+message SendOORResponse {
+    // status is the result: "submitted" on success, "preview" on
+    // dry_run.
+    string status = 1;
+
+    // session_id is the OOR session identifier. Empty on dry_run.
+    string session_id = 2;
+}
+
+// OutpointSelection wraps a list of outpoint strings for use inside a
+// oneof field, since proto3 does not allow repeated fields directly in
+// a oneof.
+message OutpointSelection {
+    // outpoints lists specific VTXOs in "txid:index" format.
+    repeated string outpoints = 1;
+}
+
+message RefreshVTXOsRequest {
+    oneof selection {
+        // outpoints lists specific VTXOs to refresh, in "txid:index"
+        // format.
+        OutpointSelection outpoints = 1;
+
+        // all refreshes every live VTXO when true.
+        bool all = 2;
+    }
+
+    // dry_run validates the request without queuing the refresh.
+    bool dry_run = 3;
+}
+
+message RefreshVTXOsResponse {
+    // queued_outpoints lists the outpoints that were successfully queued
+    // for refresh.
+    repeated string queued_outpoints = 1;
+
+    // status is the result: "queued" on success, "preview" on dry_run.
+    string status = 2;
 }

--- a/daemonrpc/daemon_grpc.pb.go
+++ b/daemonrpc/daemon_grpc.pb.go
@@ -19,7 +19,16 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	DaemonService_GetInfo_FullMethodName = "/daemonrpc.DaemonService/GetInfo"
+	DaemonService_GetInfo_FullMethodName      = "/daemonrpc.DaemonService/GetInfo"
+	DaemonService_GenSeed_FullMethodName      = "/daemonrpc.DaemonService/GenSeed"
+	DaemonService_InitWallet_FullMethodName   = "/daemonrpc.DaemonService/InitWallet"
+	DaemonService_UnlockWallet_FullMethodName = "/daemonrpc.DaemonService/UnlockWallet"
+	DaemonService_GetBalance_FullMethodName   = "/daemonrpc.DaemonService/GetBalance"
+	DaemonService_ListVTXOs_FullMethodName    = "/daemonrpc.DaemonService/ListVTXOs"
+	DaemonService_NewAddress_FullMethodName   = "/daemonrpc.DaemonService/NewAddress"
+	DaemonService_SendVTXO_FullMethodName     = "/daemonrpc.DaemonService/SendVTXO"
+	DaemonService_SendOOR_FullMethodName      = "/daemonrpc.DaemonService/SendOOR"
+	DaemonService_RefreshVTXOs_FullMethodName = "/daemonrpc.DaemonService/RefreshVTXOs"
 )
 
 // DaemonServiceClient is the client API for DaemonService service.
@@ -34,6 +43,38 @@ type DaemonServiceClient interface {
 	// including version, network, lnd connection state, and server
 	// connection state.
 	GetInfo(ctx context.Context, in *GetInfoRequest, opts ...grpc.CallOption) (*GetInfoResponse, error)
+	// GenSeed generates a new aezeed cipher seed mnemonic. This is the
+	// first step when creating a new lwwallet-backed wallet. The returned
+	// mnemonic must be passed to InitWallet to finalize wallet creation.
+	// Only available in lwwallet mode.
+	GenSeed(ctx context.Context, in *GenSeedRequest, opts ...grpc.CallOption) (*GenSeedResponse, error)
+	// InitWallet creates a new wallet from a previously generated aezeed
+	// mnemonic. The wallet is encrypted at rest with the provided
+	// password. Only available in lwwallet mode when no wallet exists.
+	InitWallet(ctx context.Context, in *InitWalletRequest, opts ...grpc.CallOption) (*InitWalletResponse, error)
+	// UnlockWallet decrypts an existing wallet seed using the provided
+	// password and starts the wallet subsystem. Only available in
+	// lwwallet mode when the wallet is locked.
+	UnlockWallet(ctx context.Context, in *UnlockWalletRequest, opts ...grpc.CallOption) (*UnlockWalletResponse, error)
+	// GetBalance returns the current balance of the wallet, broken down
+	// by boarding (on-chain) and VTXO (off-chain) balances.
+	GetBalance(ctx context.Context, in *GetBalanceRequest, opts ...grpc.CallOption) (*GetBalanceResponse, error)
+	// ListVTXOs returns the set of VTXOs known to the wallet, optionally
+	// filtered by status and minimum amount.
+	ListVTXOs(ctx context.Context, in *ListVTXOsRequest, opts ...grpc.CallOption) (*ListVTXOsResponse, error)
+	// NewAddress generates a new boarding address that can receive
+	// on-chain funds for use in the Ark protocol.
+	NewAddress(ctx context.Context, in *NewAddressRequest, opts ...grpc.CallOption) (*NewAddressResponse, error)
+	// SendVTXO initiates an in-round transfer by submitting a refresh
+	// request to the round coordinator. The transfer completes when the
+	// next round commits.
+	SendVTXO(ctx context.Context, in *SendVTXORequest, opts ...grpc.CallOption) (*SendVTXOResponse, error)
+	// SendOOR initiates an out-of-round transfer directly between the
+	// client and operator, without waiting for a round.
+	SendOOR(ctx context.Context, in *SendOORRequest, opts ...grpc.CallOption) (*SendOORResponse, error)
+	// RefreshVTXOs queues one or more VTXOs for refresh in the next
+	// round. This extends their expiry without changing ownership.
+	RefreshVTXOs(ctx context.Context, in *RefreshVTXOsRequest, opts ...grpc.CallOption) (*RefreshVTXOsResponse, error)
 }
 
 type daemonServiceClient struct {
@@ -54,6 +95,96 @@ func (c *daemonServiceClient) GetInfo(ctx context.Context, in *GetInfoRequest, o
 	return out, nil
 }
 
+func (c *daemonServiceClient) GenSeed(ctx context.Context, in *GenSeedRequest, opts ...grpc.CallOption) (*GenSeedResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GenSeedResponse)
+	err := c.cc.Invoke(ctx, DaemonService_GenSeed_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *daemonServiceClient) InitWallet(ctx context.Context, in *InitWalletRequest, opts ...grpc.CallOption) (*InitWalletResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(InitWalletResponse)
+	err := c.cc.Invoke(ctx, DaemonService_InitWallet_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *daemonServiceClient) UnlockWallet(ctx context.Context, in *UnlockWalletRequest, opts ...grpc.CallOption) (*UnlockWalletResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(UnlockWalletResponse)
+	err := c.cc.Invoke(ctx, DaemonService_UnlockWallet_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *daemonServiceClient) GetBalance(ctx context.Context, in *GetBalanceRequest, opts ...grpc.CallOption) (*GetBalanceResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetBalanceResponse)
+	err := c.cc.Invoke(ctx, DaemonService_GetBalance_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *daemonServiceClient) ListVTXOs(ctx context.Context, in *ListVTXOsRequest, opts ...grpc.CallOption) (*ListVTXOsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListVTXOsResponse)
+	err := c.cc.Invoke(ctx, DaemonService_ListVTXOs_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *daemonServiceClient) NewAddress(ctx context.Context, in *NewAddressRequest, opts ...grpc.CallOption) (*NewAddressResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(NewAddressResponse)
+	err := c.cc.Invoke(ctx, DaemonService_NewAddress_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *daemonServiceClient) SendVTXO(ctx context.Context, in *SendVTXORequest, opts ...grpc.CallOption) (*SendVTXOResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SendVTXOResponse)
+	err := c.cc.Invoke(ctx, DaemonService_SendVTXO_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *daemonServiceClient) SendOOR(ctx context.Context, in *SendOORRequest, opts ...grpc.CallOption) (*SendOORResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SendOORResponse)
+	err := c.cc.Invoke(ctx, DaemonService_SendOOR_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *daemonServiceClient) RefreshVTXOs(ctx context.Context, in *RefreshVTXOsRequest, opts ...grpc.CallOption) (*RefreshVTXOsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(RefreshVTXOsResponse)
+	err := c.cc.Invoke(ctx, DaemonService_RefreshVTXOs_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // DaemonServiceServer is the server API for DaemonService service.
 // All implementations must embed UnimplementedDaemonServiceServer
 // for forward compatibility.
@@ -66,6 +197,38 @@ type DaemonServiceServer interface {
 	// including version, network, lnd connection state, and server
 	// connection state.
 	GetInfo(context.Context, *GetInfoRequest) (*GetInfoResponse, error)
+	// GenSeed generates a new aezeed cipher seed mnemonic. This is the
+	// first step when creating a new lwwallet-backed wallet. The returned
+	// mnemonic must be passed to InitWallet to finalize wallet creation.
+	// Only available in lwwallet mode.
+	GenSeed(context.Context, *GenSeedRequest) (*GenSeedResponse, error)
+	// InitWallet creates a new wallet from a previously generated aezeed
+	// mnemonic. The wallet is encrypted at rest with the provided
+	// password. Only available in lwwallet mode when no wallet exists.
+	InitWallet(context.Context, *InitWalletRequest) (*InitWalletResponse, error)
+	// UnlockWallet decrypts an existing wallet seed using the provided
+	// password and starts the wallet subsystem. Only available in
+	// lwwallet mode when the wallet is locked.
+	UnlockWallet(context.Context, *UnlockWalletRequest) (*UnlockWalletResponse, error)
+	// GetBalance returns the current balance of the wallet, broken down
+	// by boarding (on-chain) and VTXO (off-chain) balances.
+	GetBalance(context.Context, *GetBalanceRequest) (*GetBalanceResponse, error)
+	// ListVTXOs returns the set of VTXOs known to the wallet, optionally
+	// filtered by status and minimum amount.
+	ListVTXOs(context.Context, *ListVTXOsRequest) (*ListVTXOsResponse, error)
+	// NewAddress generates a new boarding address that can receive
+	// on-chain funds for use in the Ark protocol.
+	NewAddress(context.Context, *NewAddressRequest) (*NewAddressResponse, error)
+	// SendVTXO initiates an in-round transfer by submitting a refresh
+	// request to the round coordinator. The transfer completes when the
+	// next round commits.
+	SendVTXO(context.Context, *SendVTXORequest) (*SendVTXOResponse, error)
+	// SendOOR initiates an out-of-round transfer directly between the
+	// client and operator, without waiting for a round.
+	SendOOR(context.Context, *SendOORRequest) (*SendOORResponse, error)
+	// RefreshVTXOs queues one or more VTXOs for refresh in the next
+	// round. This extends their expiry without changing ownership.
+	RefreshVTXOs(context.Context, *RefreshVTXOsRequest) (*RefreshVTXOsResponse, error)
 	mustEmbedUnimplementedDaemonServiceServer()
 }
 
@@ -78,6 +241,33 @@ type UnimplementedDaemonServiceServer struct{}
 
 func (UnimplementedDaemonServiceServer) GetInfo(context.Context, *GetInfoRequest) (*GetInfoResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetInfo not implemented")
+}
+func (UnimplementedDaemonServiceServer) GenSeed(context.Context, *GenSeedRequest) (*GenSeedResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GenSeed not implemented")
+}
+func (UnimplementedDaemonServiceServer) InitWallet(context.Context, *InitWalletRequest) (*InitWalletResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method InitWallet not implemented")
+}
+func (UnimplementedDaemonServiceServer) UnlockWallet(context.Context, *UnlockWalletRequest) (*UnlockWalletResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UnlockWallet not implemented")
+}
+func (UnimplementedDaemonServiceServer) GetBalance(context.Context, *GetBalanceRequest) (*GetBalanceResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetBalance not implemented")
+}
+func (UnimplementedDaemonServiceServer) ListVTXOs(context.Context, *ListVTXOsRequest) (*ListVTXOsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListVTXOs not implemented")
+}
+func (UnimplementedDaemonServiceServer) NewAddress(context.Context, *NewAddressRequest) (*NewAddressResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method NewAddress not implemented")
+}
+func (UnimplementedDaemonServiceServer) SendVTXO(context.Context, *SendVTXORequest) (*SendVTXOResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SendVTXO not implemented")
+}
+func (UnimplementedDaemonServiceServer) SendOOR(context.Context, *SendOORRequest) (*SendOORResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SendOOR not implemented")
+}
+func (UnimplementedDaemonServiceServer) RefreshVTXOs(context.Context, *RefreshVTXOsRequest) (*RefreshVTXOsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method RefreshVTXOs not implemented")
 }
 func (UnimplementedDaemonServiceServer) mustEmbedUnimplementedDaemonServiceServer() {}
 func (UnimplementedDaemonServiceServer) testEmbeddedByValue()                       {}
@@ -118,6 +308,168 @@ func _DaemonService_GetInfo_Handler(srv interface{}, ctx context.Context, dec fu
 	return interceptor(ctx, in, info, handler)
 }
 
+func _DaemonService_GenSeed_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GenSeedRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DaemonServiceServer).GenSeed(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DaemonService_GenSeed_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DaemonServiceServer).GenSeed(ctx, req.(*GenSeedRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DaemonService_InitWallet_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(InitWalletRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DaemonServiceServer).InitWallet(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DaemonService_InitWallet_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DaemonServiceServer).InitWallet(ctx, req.(*InitWalletRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DaemonService_UnlockWallet_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(UnlockWalletRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DaemonServiceServer).UnlockWallet(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DaemonService_UnlockWallet_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DaemonServiceServer).UnlockWallet(ctx, req.(*UnlockWalletRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DaemonService_GetBalance_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetBalanceRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DaemonServiceServer).GetBalance(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DaemonService_GetBalance_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DaemonServiceServer).GetBalance(ctx, req.(*GetBalanceRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DaemonService_ListVTXOs_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListVTXOsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DaemonServiceServer).ListVTXOs(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DaemonService_ListVTXOs_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DaemonServiceServer).ListVTXOs(ctx, req.(*ListVTXOsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DaemonService_NewAddress_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(NewAddressRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DaemonServiceServer).NewAddress(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DaemonService_NewAddress_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DaemonServiceServer).NewAddress(ctx, req.(*NewAddressRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DaemonService_SendVTXO_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SendVTXORequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DaemonServiceServer).SendVTXO(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DaemonService_SendVTXO_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DaemonServiceServer).SendVTXO(ctx, req.(*SendVTXORequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DaemonService_SendOOR_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SendOORRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DaemonServiceServer).SendOOR(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DaemonService_SendOOR_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DaemonServiceServer).SendOOR(ctx, req.(*SendOORRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DaemonService_RefreshVTXOs_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RefreshVTXOsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DaemonServiceServer).RefreshVTXOs(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DaemonService_RefreshVTXOs_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DaemonServiceServer).RefreshVTXOs(ctx, req.(*RefreshVTXOsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // DaemonService_ServiceDesc is the grpc.ServiceDesc for DaemonService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -128,6 +480,42 @@ var DaemonService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetInfo",
 			Handler:    _DaemonService_GetInfo_Handler,
+		},
+		{
+			MethodName: "GenSeed",
+			Handler:    _DaemonService_GenSeed_Handler,
+		},
+		{
+			MethodName: "InitWallet",
+			Handler:    _DaemonService_InitWallet_Handler,
+		},
+		{
+			MethodName: "UnlockWallet",
+			Handler:    _DaemonService_UnlockWallet_Handler,
+		},
+		{
+			MethodName: "GetBalance",
+			Handler:    _DaemonService_GetBalance_Handler,
+		},
+		{
+			MethodName: "ListVTXOs",
+			Handler:    _DaemonService_ListVTXOs_Handler,
+		},
+		{
+			MethodName: "NewAddress",
+			Handler:    _DaemonService_NewAddress_Handler,
+		},
+		{
+			MethodName: "SendVTXO",
+			Handler:    _DaemonService_SendVTXO_Handler,
+		},
+		{
+			MethodName: "SendOOR",
+			Handler:    _DaemonService_SendOOR_Handler,
+		},
+		{
+			MethodName: "RefreshVTXOs",
+			Handler:    _DaemonService_RefreshVTXOs_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/daemonrpc/daemon_mailboxrpc.pb.go
+++ b/daemonrpc/daemon_mailboxrpc.pb.go
@@ -26,6 +26,24 @@ func NewDaemonServiceMailboxClient(c rpc.RPCClient) *DaemonServiceMailboxClient 
 type DaemonServiceMailboxServer interface {
 	// GetInfo handles GetInfo.
 	GetInfo(ctx context.Context, req *GetInfoRequest) (*GetInfoResponse, error)
+	// GenSeed handles GenSeed.
+	GenSeed(ctx context.Context, req *GenSeedRequest) (*GenSeedResponse, error)
+	// InitWallet handles InitWallet.
+	InitWallet(ctx context.Context, req *InitWalletRequest) (*InitWalletResponse, error)
+	// UnlockWallet handles UnlockWallet.
+	UnlockWallet(ctx context.Context, req *UnlockWalletRequest) (*UnlockWalletResponse, error)
+	// GetBalance handles GetBalance.
+	GetBalance(ctx context.Context, req *GetBalanceRequest) (*GetBalanceResponse, error)
+	// ListVTXOs handles ListVTXOs.
+	ListVTXOs(ctx context.Context, req *ListVTXOsRequest) (*ListVTXOsResponse, error)
+	// NewAddress handles NewAddress.
+	NewAddress(ctx context.Context, req *NewAddressRequest) (*NewAddressResponse, error)
+	// SendVTXO handles SendVTXO.
+	SendVTXO(ctx context.Context, req *SendVTXORequest) (*SendVTXOResponse, error)
+	// SendOOR handles SendOOR.
+	SendOOR(ctx context.Context, req *SendOORRequest) (*SendOORResponse, error)
+	// RefreshVTXOs handles RefreshVTXOs.
+	RefreshVTXOs(ctx context.Context, req *RefreshVTXOsRequest) (*RefreshVTXOsResponse, error)
 }
 
 // RegisterDaemonServiceMailboxServer registers handlers for DaemonService.
@@ -39,6 +57,96 @@ func RegisterDaemonServiceMailboxServer(r rpc.Router, impl DaemonServiceMailboxS
 		}
 
 		return impl.GetInfo(ctx, req)
+	})
+	r.Handle("daemonrpc.DaemonService", "GenSeed", func() proto.Message {
+		return &GenSeedRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*GenSeedRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.GenSeed(ctx, req)
+	})
+	r.Handle("daemonrpc.DaemonService", "InitWallet", func() proto.Message {
+		return &InitWalletRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*InitWalletRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.InitWallet(ctx, req)
+	})
+	r.Handle("daemonrpc.DaemonService", "UnlockWallet", func() proto.Message {
+		return &UnlockWalletRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*UnlockWalletRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.UnlockWallet(ctx, req)
+	})
+	r.Handle("daemonrpc.DaemonService", "GetBalance", func() proto.Message {
+		return &GetBalanceRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*GetBalanceRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.GetBalance(ctx, req)
+	})
+	r.Handle("daemonrpc.DaemonService", "ListVTXOs", func() proto.Message {
+		return &ListVTXOsRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*ListVTXOsRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.ListVTXOs(ctx, req)
+	})
+	r.Handle("daemonrpc.DaemonService", "NewAddress", func() proto.Message {
+		return &NewAddressRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*NewAddressRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.NewAddress(ctx, req)
+	})
+	r.Handle("daemonrpc.DaemonService", "SendVTXO", func() proto.Message {
+		return &SendVTXORequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*SendVTXORequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.SendVTXO(ctx, req)
+	})
+	r.Handle("daemonrpc.DaemonService", "SendOOR", func() proto.Message {
+		return &SendOORRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*SendOORRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.SendOOR(ctx, req)
+	})
+	r.Handle("daemonrpc.DaemonService", "RefreshVTXOs", func() proto.Message {
+		return &RefreshVTXOsRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*RefreshVTXOsRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.RefreshVTXOs(ctx, req)
 	})
 }
 
@@ -58,6 +166,213 @@ func (c *DaemonServiceMailboxClient) GetInfo(ctx context.Context, req *GetInfoRe
 	}
 
 	resp := new(GetInfoResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// GenSeed calls the GenSeed RPC.
+func (c *DaemonServiceMailboxClient) GenSeed(ctx context.Context, req *GenSeedRequest, opts ...rpc.RPCOptions) (*GenSeedResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "daemonrpc.DaemonService",
+		Method:  "GenSeed",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(GenSeedResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// InitWallet calls the InitWallet RPC.
+func (c *DaemonServiceMailboxClient) InitWallet(ctx context.Context, req *InitWalletRequest, opts ...rpc.RPCOptions) (*InitWalletResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "daemonrpc.DaemonService",
+		Method:  "InitWallet",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(InitWalletResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// UnlockWallet calls the UnlockWallet RPC.
+func (c *DaemonServiceMailboxClient) UnlockWallet(ctx context.Context, req *UnlockWalletRequest, opts ...rpc.RPCOptions) (*UnlockWalletResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "daemonrpc.DaemonService",
+		Method:  "UnlockWallet",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(UnlockWalletResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// GetBalance calls the GetBalance RPC.
+func (c *DaemonServiceMailboxClient) GetBalance(ctx context.Context, req *GetBalanceRequest, opts ...rpc.RPCOptions) (*GetBalanceResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "daemonrpc.DaemonService",
+		Method:  "GetBalance",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(GetBalanceResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// ListVTXOs calls the ListVTXOs RPC.
+func (c *DaemonServiceMailboxClient) ListVTXOs(ctx context.Context, req *ListVTXOsRequest, opts ...rpc.RPCOptions) (*ListVTXOsResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "daemonrpc.DaemonService",
+		Method:  "ListVTXOs",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(ListVTXOsResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// NewAddress calls the NewAddress RPC.
+func (c *DaemonServiceMailboxClient) NewAddress(ctx context.Context, req *NewAddressRequest, opts ...rpc.RPCOptions) (*NewAddressResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "daemonrpc.DaemonService",
+		Method:  "NewAddress",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(NewAddressResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// SendVTXO calls the SendVTXO RPC.
+func (c *DaemonServiceMailboxClient) SendVTXO(ctx context.Context, req *SendVTXORequest, opts ...rpc.RPCOptions) (*SendVTXOResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "daemonrpc.DaemonService",
+		Method:  "SendVTXO",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(SendVTXOResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// SendOOR calls the SendOOR RPC.
+func (c *DaemonServiceMailboxClient) SendOOR(ctx context.Context, req *SendOORRequest, opts ...rpc.RPCOptions) (*SendOORResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "daemonrpc.DaemonService",
+		Method:  "SendOOR",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(SendOORResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// RefreshVTXOs calls the RefreshVTXOs RPC.
+func (c *DaemonServiceMailboxClient) RefreshVTXOs(ctx context.Context, req *RefreshVTXOsRequest, opts ...rpc.RPCOptions) (*RefreshVTXOsResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "daemonrpc.DaemonService",
+		Method:  "RefreshVTXOs",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(RefreshVTXOsResponse)
 	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
 		return nil, err
 	}

--- a/serverconn/connector_test.go
+++ b/serverconn/connector_test.go
@@ -421,9 +421,13 @@ func TestIngress_PartialDispatch_NoDuplicateRedelivery(t *testing.T) {
 	require.NoError(t, actor.StartIngress(ctx))
 	defer actor.StopIngress()
 
-	// Wait until both envelopes have been fully dispatched.
+	// Wait until the second envelope has been retried (dispatched
+	// twice: once failed, once succeeded).
 	require.Eventually(t, func() bool {
-		return mb.getAckedUpTo("client-1") > 0
+		dispatchCountsMu.Lock()
+		defer dispatchCountsMu.Unlock()
+
+		return dispatchCounts[2] >= 2
 	}, 5*time.Second, 10*time.Millisecond)
 
 	dispatchCountsMu.Lock()


### PR DESCRIPTION
In this PR, we extend the `daemon.proto` service definition with nine new RPCs
covering wallet lifecycle management, balance queries, VTXO operations, and
transfer capabilities. This is part 1 of 5 in the daemon + CLI series.

The wallet lifecycle RPCs (`GenSeed`, `InitWallet`, `UnlockWallet`) enable the
create/unlock flow needed for the `lwwallet` backend where seed management
happens through the daemon rather than through lnd. `GetBalance` and
`NewAddress` expose core wallet functionality. `ListVTXOs` provides filtered
VTXO inventory queries with a `VTXOStatus` enum. The send RPCs (`SendVTXO`,
`SendOOR`, `RefreshVTXOs`) enable in-round transfers, out-of-round transfers,
and VTXO expiry refresh.

`GetInfoResponse` is extended with `wallet_type` and `wallet_ready` fields so
clients can detect the daemon's startup state before issuing wallet-dependent
calls. The `VTXO` message carries outpoint, amount, status, batch expiry, round
ID, and relative expiry fields. `Output` specifies recipients with address and
amount for send operations.

The generated Go stubs (`daemon.pb.go`, `daemon_grpc.pb.go`,
`daemon_mailboxrpc.pb.go`) are regenerated via `make rpc` in a separate commit.

## PR Series

1. **This PR** — Proto definitions + generated stubs
2. Seed manager, wallet config, wallet messages
3. Server dual-wallet refactor + RPC handlers + hardening
4. Agent-first CLI binary (`darepocli`)
5. Schema introspection, MCP server, agent docs