### PR TITLE
darepod: add seed manager, wallet config, and wallet messages [2/5]

### DIFF
--- a/cmd/darepod/main.go
+++ b/cmd/darepod/main.go
@@ -90,6 +90,24 @@ func newRootCmd() *cobra.Command {
 		"remote server's mailbox identifier",
 	)
 
+	// Wallet backend flags.
+	f.String("wallet.type", cfg.Wallet.Type,
+		"wallet backend type (lnd, lwwallet)",
+	)
+	f.String("wallet.esploraurl", cfg.Wallet.EsploraURL,
+		"esplora REST API URL (required for lwwallet)",
+	)
+	f.Duration("wallet.pollinterval", cfg.Wallet.PollInterval,
+		"chain poll interval for lwwallet backend",
+	)
+	f.Uint32("wallet.recoverywindow", cfg.Wallet.RecoveryWindow,
+		"address recovery look-ahead window for lwwallet",
+	)
+	f.String("wallet.password_file", cfg.Wallet.PasswordFile,
+		"path to file containing wallet password for "+
+			"auto-unlock at startup (lwwallet mode)",
+	)
+
 	// Daemon RPC server flags.
 	f.String("rpc.listenaddr", cfg.RPC.ListenAddr,
 		"daemon gRPC listen address",

--- a/darepod/config.go
+++ b/darepod/config.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/lightninglabs/darepo-client/rpc/roundpb"
 )
 
@@ -44,6 +45,26 @@ const (
 	// deadline for collecting forfeit signatures from VTXO actors
 	// during a round.
 	DefaultForfeitCollectionTimeout = 2 * time.Minute
+
+	// DefaultWalletType is the default wallet backend. The "lwwallet"
+	// backend uses an in-process lightweight wallet backed by
+	// btcwallet and Esplora, requiring no external lnd node.
+	DefaultWalletType = "lwwallet"
+
+	// WalletTypeLnd selects lnd as the wallet backend.
+	WalletTypeLnd = "lnd"
+
+	// WalletTypeLwwallet selects the lightweight in-process wallet
+	// backed by btcwallet and Esplora.
+	WalletTypeLwwallet = "lwwallet"
+
+	// DefaultEsploraPollInterval is the default interval at which the
+	// lwwallet polls the Esplora API for new blocks and transactions.
+	DefaultEsploraPollInterval = 5 * time.Second
+
+	// DefaultRecoveryWindow is the default address look-ahead window
+	// used during lwwallet recovery.
+	DefaultRecoveryWindow = 100
 )
 
 // Config holds all configuration for the darepod daemon.
@@ -74,6 +95,10 @@ type Config struct {
 	// RPC configures the daemon's own gRPC server that external tools
 	// (CLI, GUI) connect to.
 	RPC *RPCConfig `mapstructure:"rpc"`
+
+	// Wallet configures the wallet backend used for signing, key
+	// derivation, and chain access.
+	Wallet *WalletConfig `mapstructure:"wallet"`
 
 	// ForfeitCollectionTimeout is the maximum wall-clock
 	// duration to wait for forfeit signatures during a round.
@@ -146,6 +171,35 @@ type RPCConfig struct {
 	TLSKeyPath string `mapstructure:"tlskeypath"`
 }
 
+// WalletConfig selects and configures the wallet backend.
+type WalletConfig struct {
+	// Type selects the wallet backend: "lnd" uses a connected lnd
+	// node, "lwwallet" uses an in-process lightweight wallet backed
+	// by btcwallet and Esplora.
+	Type string `mapstructure:"type"`
+
+	// EsploraURL is the base URL of the Esplora REST API used by the
+	// lwwallet backend for chain data. Required when Type is
+	// "lwwallet".
+	EsploraURL string `mapstructure:"esploraurl"`
+
+	// PollInterval controls how often the lwwallet backend polls the
+	// Esplora API for new blocks. If zero,
+	// DefaultEsploraPollInterval is used.
+	PollInterval time.Duration `mapstructure:"pollinterval"`
+
+	// RecoveryWindow is the address look-ahead window used during
+	// lwwallet key recovery. If zero, DefaultRecoveryWindow is used.
+	RecoveryWindow uint32 `mapstructure:"recoverywindow"`
+
+	// PasswordFile is the path to a file containing the wallet
+	// password for auto-unlock at daemon startup. The file contents
+	// are read and trailing newlines are stripped. When set alongside
+	// an existing encrypted seed file, the daemon unlocks the wallet
+	// automatically without requiring an UnlockWallet RPC call.
+	PasswordFile string `mapstructure:"password_file"`
+}
+
 // DefaultConfig returns a Config populated with sensible defaults.
 func DefaultConfig() *Config {
 	return &Config{
@@ -163,6 +217,11 @@ func DefaultConfig() *Config {
 		RPC: &RPCConfig{
 			ListenAddr: DefaultRPCHost,
 		},
+		Wallet: &WalletConfig{
+			Type:           DefaultWalletType,
+			PollInterval:   DefaultEsploraPollInterval,
+			RecoveryWindow: DefaultRecoveryWindow,
+		},
 	}
 }
 
@@ -175,11 +234,38 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("unknown network %q", c.Network)
 	}
 
-	if c.Lnd == nil {
-		return fmt.Errorf("lnd config is required")
+	// Validate wallet config.
+	if c.Wallet == nil {
+		return fmt.Errorf("wallet config is required")
 	}
-	if c.Lnd.Host == "" {
-		return fmt.Errorf("lnd host is required")
+
+	switch c.Wallet.Type {
+	case WalletTypeLnd:
+		// LND backend requires a valid lnd connection config.
+		if c.Lnd == nil {
+			return fmt.Errorf("lnd config is required " +
+				"when wallet.type is lnd")
+		}
+		if c.Lnd.Host == "" {
+			return fmt.Errorf("lnd host is required " +
+				"when wallet.type is lnd")
+		}
+
+	case WalletTypeLwwallet:
+		// Lightweight wallet requires an Esplora URL for
+		// chain data.
+		if c.Wallet.EsploraURL == "" {
+			return fmt.Errorf("wallet.esploraurl is " +
+				"required when wallet.type is " +
+				"lwwallet")
+		}
+
+	default:
+		return fmt.Errorf(
+			"unknown wallet type %q, valid values: "+
+				"lnd, lwwallet",
+			c.Wallet.Type,
+		)
 	}
 
 	if c.Server == nil {
@@ -205,6 +291,25 @@ func (c *Config) Validate() error {
 	}
 
 	return nil
+}
+
+// networkToChainParams maps a network name string to the corresponding
+// btcd chain configuration parameters.
+func networkToChainParams(network string) (*chaincfg.Params, error) {
+	switch network {
+	case "mainnet":
+		return &chaincfg.MainNetParams, nil
+	case "testnet":
+		return &chaincfg.TestNet3Params, nil
+	case "regtest":
+		return &chaincfg.RegressionNetParams, nil
+	case "simnet":
+		return &chaincfg.SimNetParams, nil
+	case "signet":
+		return &chaincfg.SigNetParams, nil
+	default:
+		return nil, fmt.Errorf("unknown network %q", network)
+	}
 }
 
 // NetworkDir returns the network-scoped data directory (e.g.,

--- a/darepod/seed_manager.go
+++ b/darepod/seed_manager.go
@@ -58,11 +58,23 @@ const (
 	minPasswordLen = 8
 )
 
-// GenSeed generates a new aezeed cipher seed and returns its 24-word
-// mnemonic representation. The optional passphrase protects the
-// mnemonic itself (distinct from the wallet password that encrypts the
-// seed at rest).
-func GenSeed(passphrase []byte) (aezeed.Mnemonic, error) {
+// zeroBytes overwrites a byte slice with zeros. This is used to clear
+// sensitive key material from memory after use. The noinline directive
+// prevents the compiler from optimizing away the dead store when the
+// buffer is not read after zeroing.
+//
+//go:noinline
+func zeroBytes(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}
+
+// GenerateSeed generates a new aezeed cipher seed and returns its
+// 24-word mnemonic representation. The optional passphrase protects
+// the mnemonic itself (distinct from the wallet password that encrypts
+// the seed at rest).
+func GenerateSeed(passphrase []byte) (aezeed.Mnemonic, error) {
 	var entropy [aezeed.EntropySize]byte
 
 	if _, err := rand.Read(entropy[:]); err != nil {
@@ -137,9 +149,11 @@ func EncryptSeed(seed [rawSeedLen]byte,
 	if err != nil {
 		return nil, fmt.Errorf("deriving key: %w", err)
 	}
+	defer zeroBytes(key)
 
 	var secretKey [scryptKeyLen]byte
 	copy(secretKey[:], key)
+	defer zeroBytes(secretKey[:])
 
 	// Generate random nonce for secretbox.
 	var nonce [secretboxNonceLen]byte
@@ -197,9 +211,11 @@ func DecryptSeed(ciphertext,
 			"deriving key: %w", err,
 		)
 	}
+	defer zeroBytes(key)
 
 	var secretKey [scryptKeyLen]byte
 	copy(secretKey[:], key)
+	defer zeroBytes(secretKey[:])
 
 	// Decrypt and authenticate.
 	plaintext, ok := secretbox.Open(nil, box, &nonce, &secretKey)
@@ -209,6 +225,7 @@ func DecryptSeed(ciphertext,
 				"corrupted seed file",
 		)
 	}
+	defer zeroBytes(plaintext)
 
 	if len(plaintext) != rawSeedLen {
 		return [rawSeedLen]byte{}, fmt.Errorf(

--- a/darepod/seed_manager.go
+++ b/darepod/seed_manager.go
@@ -1,0 +1,331 @@
+package darepod
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/lightningnetwork/lnd/aezeed"
+	"golang.org/x/crypto/nacl/secretbox"
+	"golang.org/x/crypto/scrypt"
+)
+
+const (
+	// seedFileBaseName is the name of the encrypted seed file stored
+	// in the network data directory.
+	seedFileBaseName = "wallet_seed.enc"
+
+	// seedEnvVar is the environment variable name for providing a
+	// hex-encoded raw seed directly. This bypasses the encrypted
+	// seed file and is intended for development and CI environments.
+	seedEnvVar = "DAREPOD_LWWALLET_SEED"
+
+	// walletPasswordEnvVar is the environment variable name for
+	// providing the wallet password for auto-unlock at daemon
+	// startup.
+	walletPasswordEnvVar = "DAREPOD_WALLET_PASSWORD"
+
+	// scryptN is the CPU/memory cost parameter for scrypt key
+	// derivation. This value balances security against startup
+	// latency.
+	scryptN = 1 << 18
+
+	// scryptR is the block size parameter for scrypt.
+	scryptR = 8
+
+	// scryptP is the parallelism parameter for scrypt.
+	scryptP = 1
+
+	// scryptKeyLen is the derived key length in bytes. We need 32
+	// bytes for the NaCl secretbox key.
+	scryptKeyLen = 32
+
+	// scryptSaltLen is the length of the random salt stored
+	// alongside the ciphertext.
+	scryptSaltLen = 32
+
+	// secretboxNonceLen is the NaCl secretbox nonce length.
+	secretboxNonceLen = 24
+
+	// rawSeedLen is the expected length of the raw HD seed in bytes.
+	rawSeedLen = 32
+
+	// minPasswordLen is the minimum wallet password length in bytes.
+	minPasswordLen = 8
+)
+
+// GenSeed generates a new aezeed cipher seed and returns its 24-word
+// mnemonic representation. The optional passphrase protects the
+// mnemonic itself (distinct from the wallet password that encrypts the
+// seed at rest).
+func GenSeed(passphrase []byte) (aezeed.Mnemonic, error) {
+	var entropy [aezeed.EntropySize]byte
+
+	if _, err := rand.Read(entropy[:]); err != nil {
+		return aezeed.Mnemonic{}, fmt.Errorf(
+			"reading entropy: %w", err,
+		)
+	}
+
+	cipherSeed, err := aezeed.New(
+		aezeed.CipherSeedVersion, &entropy, time.Now(),
+	)
+	if err != nil {
+		return aezeed.Mnemonic{}, fmt.Errorf(
+			"creating cipher seed: %w", err,
+		)
+	}
+
+	mnemonic, err := cipherSeed.ToMnemonic(passphrase)
+	if err != nil {
+		return aezeed.Mnemonic{}, fmt.Errorf(
+			"encoding mnemonic: %w", err,
+		)
+	}
+
+	return mnemonic, nil
+}
+
+// MnemonicToSeed decodes an aezeed mnemonic and extracts the raw
+// 32-byte HD seed from its entropy field. The passphrase must match
+// the one used during mnemonic generation.
+func MnemonicToSeed(mnemonic aezeed.Mnemonic,
+	passphrase []byte) ([rawSeedLen]byte, error) {
+
+	cipherSeed, err := mnemonic.ToCipherSeed(passphrase)
+	if err != nil {
+		return [rawSeedLen]byte{}, fmt.Errorf(
+			"deciphering mnemonic: %w", err,
+		)
+	}
+
+	var seed [rawSeedLen]byte
+	copy(seed[:], cipherSeed.Entropy[:])
+
+	return seed, nil
+}
+
+// EncryptSeed encrypts a raw seed using scrypt for key derivation and
+// NaCl secretbox for authenticated encryption. The returned ciphertext
+// includes the scrypt salt and secretbox nonce as a prefix, so it is
+// self-contained for decryption.
+//
+// Format: salt (32 bytes) || nonce (24 bytes) || ciphertext (variable).
+func EncryptSeed(seed [rawSeedLen]byte,
+	password []byte) ([]byte, error) {
+
+	if len(password) < minPasswordLen {
+		return nil, fmt.Errorf(
+			"password must be at least %d bytes",
+			minPasswordLen,
+		)
+	}
+
+	// Derive encryption key from password via scrypt.
+	salt := make([]byte, scryptSaltLen)
+	if _, err := rand.Read(salt); err != nil {
+		return nil, fmt.Errorf("generating salt: %w", err)
+	}
+
+	key, err := scrypt.Key(
+		password, salt, scryptN, scryptR, scryptP, scryptKeyLen,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("deriving key: %w", err)
+	}
+
+	var secretKey [scryptKeyLen]byte
+	copy(secretKey[:], key)
+
+	// Generate random nonce for secretbox.
+	var nonce [secretboxNonceLen]byte
+	if _, err := rand.Read(nonce[:]); err != nil {
+		return nil, fmt.Errorf("generating nonce: %w", err)
+	}
+
+	// Encrypt the seed. The secretbox Seal function appends the
+	// authenticated ciphertext to the output slice.
+	encrypted := secretbox.Seal(nil, seed[:], &nonce, &secretKey)
+
+	// Assemble the output: salt || nonce || ciphertext.
+	result := make(
+		[]byte, 0,
+		scryptSaltLen+secretboxNonceLen+len(encrypted),
+	)
+	result = append(result, salt...)
+	result = append(result, nonce[:]...)
+	result = append(result, encrypted...)
+
+	return result, nil
+}
+
+// DecryptSeed reverses EncryptSeed: it extracts the salt and nonce
+// from the ciphertext prefix, derives the key via scrypt, and decrypts
+// the seed using NaCl secretbox.
+func DecryptSeed(ciphertext,
+	password []byte) ([rawSeedLen]byte, error) {
+
+	minLen := scryptSaltLen + secretboxNonceLen + secretbox.Overhead +
+		rawSeedLen
+
+	if len(ciphertext) < minLen {
+		return [rawSeedLen]byte{}, fmt.Errorf(
+			"ciphertext too short: got %d, need at least %d",
+			len(ciphertext), minLen,
+		)
+	}
+
+	// Extract salt, nonce, and encrypted payload.
+	salt := ciphertext[:scryptSaltLen]
+	var nonce [secretboxNonceLen]byte
+	copy(
+		nonce[:],
+		ciphertext[scryptSaltLen:scryptSaltLen+secretboxNonceLen],
+	)
+	box := ciphertext[scryptSaltLen+secretboxNonceLen:]
+
+	// Derive the decryption key.
+	key, err := scrypt.Key(
+		password, salt, scryptN, scryptR, scryptP, scryptKeyLen,
+	)
+	if err != nil {
+		return [rawSeedLen]byte{}, fmt.Errorf(
+			"deriving key: %w", err,
+		)
+	}
+
+	var secretKey [scryptKeyLen]byte
+	copy(secretKey[:], key)
+
+	// Decrypt and authenticate.
+	plaintext, ok := secretbox.Open(nil, box, &nonce, &secretKey)
+	if !ok {
+		return [rawSeedLen]byte{}, fmt.Errorf(
+			"decryption failed: wrong password or " +
+				"corrupted seed file",
+		)
+	}
+
+	if len(plaintext) != rawSeedLen {
+		return [rawSeedLen]byte{}, fmt.Errorf(
+			"unexpected seed length: got %d, want %d",
+			len(plaintext), rawSeedLen,
+		)
+	}
+
+	var seed [rawSeedLen]byte
+	copy(seed[:], plaintext)
+
+	return seed, nil
+}
+
+// LoadSeedFromEnv reads a hex-encoded raw seed from the
+// DAREPOD_LWWALLET_SEED environment variable. It returns the seed if
+// the variable is set and valid. It returns (nil, nil) if the variable
+// is not set. It returns an error if the variable is set but invalid.
+func LoadSeedFromEnv() (*[rawSeedLen]byte, error) {
+	hexSeed := os.Getenv(seedEnvVar)
+	if hexSeed == "" {
+		return nil, nil
+	}
+
+	decoded, err := hex.DecodeString(strings.TrimSpace(hexSeed))
+	if err != nil {
+		return nil, fmt.Errorf(
+			"invalid hex seed in %s: %w",
+			seedEnvVar, err,
+		)
+	}
+
+	if len(decoded) != rawSeedLen {
+		return nil, fmt.Errorf(
+			"invalid seed length in %s: got %d, want %d",
+			seedEnvVar, len(decoded), rawSeedLen,
+		)
+	}
+
+	var seed [rawSeedLen]byte
+	copy(seed[:], decoded)
+
+	return &seed, nil
+}
+
+// LoadPasswordFromEnv reads the wallet password from the
+// DAREPOD_WALLET_PASSWORD environment variable.
+func LoadPasswordFromEnv() ([]byte, bool) {
+	pass := os.Getenv(walletPasswordEnvVar)
+	if pass == "" {
+		return nil, false
+	}
+
+	return []byte(pass), true
+}
+
+// LoadPasswordFromFile reads a wallet password from a file, stripping
+// any trailing newline characters.
+func LoadPasswordFromFile(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"reading password file %q: %w", path, err,
+		)
+	}
+
+	// Strip trailing newlines so users can create the file with
+	// echo without worrying about the trailing newline.
+	password := []byte(strings.TrimRight(string(data), "\n\r"))
+
+	return password, nil
+}
+
+// SeedFilePath returns the path to the encrypted seed file within the
+// given network data directory.
+func SeedFilePath(networkDir string) string {
+	return filepath.Join(networkDir, seedFileBaseName)
+}
+
+// SaveEncryptedSeed writes the encrypted seed ciphertext to disk at
+// the given path. The file is created with restrictive permissions
+// (0600) to prevent unauthorized access.
+func SaveEncryptedSeed(path string, ciphertext []byte) error {
+	// Ensure the parent directory exists.
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("creating directory %q: %w", dir, err)
+	}
+
+	if err := os.WriteFile(path, ciphertext, 0600); err != nil {
+		return fmt.Errorf(
+			"writing seed file %q: %w", path, err,
+		)
+	}
+
+	return nil
+}
+
+// LoadEncryptedSeed reads the encrypted seed ciphertext from disk. It
+// returns an error if the file does not exist or cannot be read.
+func LoadEncryptedSeed(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"reading seed file %q: %w", path, err,
+		)
+	}
+
+	return data, nil
+}
+
+// SeedFileExists returns true if an encrypted seed file exists at the
+// expected path within the network data directory.
+func SeedFileExists(networkDir string) bool {
+	path := SeedFilePath(networkDir)
+
+	_, err := os.Stat(path)
+
+	return err == nil
+}

--- a/darepod/seed_manager_test.go
+++ b/darepod/seed_manager_test.go
@@ -1,0 +1,219 @@
+package darepod
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/lightningnetwork/lnd/aezeed"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGenSeedProduces24Words verifies that GenSeed returns a valid
+// 24-word mnemonic.
+func TestGenSeedProduces24Words(t *testing.T) {
+	mnemonic, err := GenerateSeed(nil)
+	require.NoError(t, err)
+
+	for i, word := range mnemonic {
+		require.NotEmpty(t, word, "word %d is empty", i)
+	}
+}
+
+// TestMnemonicToSeedRoundtrip verifies that a mnemonic can be decoded
+// back to the same seed entropy.
+func TestMnemonicToSeedRoundtrip(t *testing.T) {
+	passphrase := []byte("test-passphrase")
+
+	mnemonic, err := GenerateSeed(passphrase)
+	require.NoError(t, err)
+
+	seed, err := MnemonicToSeed(mnemonic, passphrase)
+	require.NoError(t, err)
+	require.NotEqual(t, [rawSeedLen]byte{}, seed)
+
+	// Decode again to verify determinism.
+	seed2, err := MnemonicToSeed(mnemonic, passphrase)
+	require.NoError(t, err)
+	require.Equal(t, seed, seed2)
+}
+
+// TestMnemonicToSeedWrongPassphrase verifies that decoding with the
+// wrong passphrase fails.
+func TestMnemonicToSeedWrongPassphrase(t *testing.T) {
+	mnemonic, err := GenerateSeed([]byte("correct"))
+	require.NoError(t, err)
+
+	_, err = MnemonicToSeed(mnemonic, []byte("wrong"))
+	require.Error(t, err)
+}
+
+// TestEncryptDecryptRoundtrip verifies that a seed survives
+// encrypt-then-decrypt.
+func TestEncryptDecryptRoundtrip(t *testing.T) {
+	password := []byte("a-secure-password")
+
+	// Generate a seed.
+	mnemonic, err := GenerateSeed(nil)
+	require.NoError(t, err)
+
+	seed, err := MnemonicToSeed(mnemonic, nil)
+	require.NoError(t, err)
+
+	// Encrypt.
+	ciphertext, err := EncryptSeed(seed, password)
+	require.NoError(t, err)
+	require.NotEmpty(t, ciphertext)
+
+	// Decrypt.
+	recovered, err := DecryptSeed(ciphertext, password)
+	require.NoError(t, err)
+	require.Equal(t, seed, recovered)
+}
+
+// TestDecryptWrongPassword verifies that decryption with the wrong
+// password fails cleanly.
+func TestDecryptWrongPassword(t *testing.T) {
+	password := []byte("correct-password")
+	var seed [rawSeedLen]byte
+	copy(seed[:], []byte("deterministic-test-seed-value!!!"))
+
+	ciphertext, err := EncryptSeed(seed, password)
+	require.NoError(t, err)
+
+	_, err = DecryptSeed(ciphertext, []byte("wrong-password!!"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "wrong password")
+}
+
+// TestEncryptSeedPasswordTooShort verifies the minimum password length
+// check.
+func TestEncryptSeedPasswordTooShort(t *testing.T) {
+	var seed [rawSeedLen]byte
+
+	_, err := EncryptSeed(seed, []byte("short"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "at least")
+}
+
+// TestSaveLoadEncryptedSeed verifies file I/O for encrypted seeds.
+func TestSaveLoadEncryptedSeed(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test_seed.enc")
+	data := []byte("test-ciphertext-data")
+
+	err := SaveEncryptedSeed(path, data)
+	require.NoError(t, err)
+
+	loaded, err := LoadEncryptedSeed(path)
+	require.NoError(t, err)
+	require.Equal(t, data, loaded)
+
+	// Verify restrictive permissions.
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0600), info.Mode().Perm())
+}
+
+// TestSeedFileExists verifies the existence check.
+func TestSeedFileExists(t *testing.T) {
+	dir := t.TempDir()
+
+	require.False(t, SeedFileExists(dir))
+
+	path := SeedFilePath(dir)
+	err := SaveEncryptedSeed(path, []byte("data"))
+	require.NoError(t, err)
+
+	require.True(t, SeedFileExists(dir))
+}
+
+// TestLoadSeedFromEnv verifies the env var loading path.
+func TestLoadSeedFromEnv(t *testing.T) {
+	// Unset first — should return nil, nil.
+	t.Setenv(seedEnvVar, "")
+	seed, err := LoadSeedFromEnv()
+	require.NoError(t, err)
+	require.Nil(t, seed)
+
+	// Set a valid 32-byte hex seed.
+	hexSeed := "0102030405060708091011121314151617181920212223242526272829303132"
+	t.Setenv(seedEnvVar, hexSeed)
+	seed, err = LoadSeedFromEnv()
+	require.NoError(t, err)
+	require.NotNil(t, seed)
+	require.NotEqual(t, [rawSeedLen]byte{}, *seed)
+
+	// Invalid hex should return an error.
+	t.Setenv(seedEnvVar, "not-hex")
+	_, err = LoadSeedFromEnv()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid hex seed")
+
+	// Wrong length should return an error.
+	t.Setenv(seedEnvVar, "0102030405")
+	_, err = LoadSeedFromEnv()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid seed length")
+}
+
+// TestLoadPasswordFromFile verifies reading passwords from files.
+func TestLoadPasswordFromFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "password.txt")
+
+	// With trailing newline.
+	err := os.WriteFile(path, []byte("my-password\n"), 0600)
+	require.NoError(t, err)
+
+	password, err := LoadPasswordFromFile(path)
+	require.NoError(t, err)
+	require.Equal(t, []byte("my-password"), password)
+
+	// Without trailing newline.
+	err = os.WriteFile(path, []byte("clean-pass"), 0600)
+	require.NoError(t, err)
+
+	password, err = LoadPasswordFromFile(path)
+	require.NoError(t, err)
+	require.Equal(t, []byte("clean-pass"), password)
+}
+
+// TestFullWorkflow exercises the complete create-save-load-unlock flow.
+func TestFullWorkflow(t *testing.T) {
+	dir := t.TempDir()
+	password := []byte("workflow-password")
+	passphrase := []byte("optional-passphrase")
+
+	// Step 1: Generate seed.
+	mnemonic, err := GenerateSeed(passphrase)
+	require.NoError(t, err)
+
+	// Step 2: Derive raw seed from mnemonic.
+	seed, err := MnemonicToSeed(mnemonic, passphrase)
+	require.NoError(t, err)
+
+	// Step 3: Encrypt and save.
+	ciphertext, err := EncryptSeed(seed, password)
+	require.NoError(t, err)
+
+	seedPath := SeedFilePath(dir)
+	err = SaveEncryptedSeed(seedPath, ciphertext)
+	require.NoError(t, err)
+
+	// Step 4: Load and decrypt (simulates daemon restart).
+	loaded, err := LoadEncryptedSeed(seedPath)
+	require.NoError(t, err)
+
+	recovered, err := DecryptSeed(loaded, password)
+	require.NoError(t, err)
+	require.Equal(t, seed, recovered)
+
+	// Verify we can also recover from the mnemonic words directly.
+	var recoveredMnemonic aezeed.Mnemonic
+	copy(recoveredMnemonic[:], mnemonic[:])
+
+	mnemonicSeed, err := MnemonicToSeed(recoveredMnemonic, passphrase)
+	require.NoError(t, err)
+	require.Equal(t, seed, mnemonicSeed)
+}

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/crypto v0.44.0
 	golang.org/x/exp v0.0.0-20251113190631-e25ba8c21ef6
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250324211829-b45e905df463
 	google.golang.org/grpc v1.73.0
@@ -186,7 +187,6 @@ require (
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.23.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/crypto v0.44.0 // indirect
 	golang.org/x/mod v0.30.0 // indirect
 	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/sync v0.18.0 // indirect

--- a/wallet/messages.go
+++ b/wallet/messages.go
@@ -302,6 +302,99 @@ func (m *RefreshVTXOsResponse) MessageType() string {
 // walletRespSealed implements the sealed WalletResp interface.
 func (m *RefreshVTXOsResponse) walletRespSealed() {}
 
+// SelectAndLockVTXOsRequest asks the wallet actor to select VTXOs covering a
+// target amount and atomically lock them to prevent double-spends. The locked
+// VTXOs are returned as descriptors that the caller can use to build OOR
+// transfer inputs. If the transfer fails, the caller should send an
+// UnlockVTXOsRequest to release the locks.
+type SelectAndLockVTXOsRequest struct {
+	actor.BaseMessage
+
+	// TargetAmount is the minimum total value the selected VTXOs must
+	// cover.
+	TargetAmount btcutil.Amount
+}
+
+// MessageType returns the message type identifier for logging and debugging.
+func (m *SelectAndLockVTXOsRequest) MessageType() string {
+	return "SelectAndLockVTXOsRequest"
+}
+
+// walletMsgSealed implements the sealed WalletMsg interface.
+func (m *SelectAndLockVTXOsRequest) walletMsgSealed() {}
+
+// SelectedVTXO describes a VTXO that was selected and locked for use as
+// a transfer input. This avoids a direct dependency on the vtxo package
+// in the wallet message surface (which would create an import cycle via
+// vtxo → round → wallet).
+type SelectedVTXO struct {
+	// Outpoint is the selected VTXO's outpoint.
+	Outpoint wire.OutPoint
+
+	// Amount is the value of this VTXO in satoshis.
+	Amount btcutil.Amount
+
+	// PkScript is the output script for this VTXO. This also serves
+	// as the owner leaf script for OOR checkpoint construction.
+	PkScript []byte
+}
+
+// SelectAndLockVTXOsResponse returns the VTXOs that were selected and locked.
+type SelectAndLockVTXOsResponse struct {
+	actor.BaseMessage
+
+	// SelectedVTXOs is the set of VTXOs that were locked for this
+	// operation. The caller should use these outpoints to look up
+	// full descriptors from the VTXO store if needed.
+	SelectedVTXOs []SelectedVTXO
+
+	// TotalSelected is the sum of all selected VTXO amounts.
+	TotalSelected btcutil.Amount
+}
+
+// MessageType returns the message type identifier for logging and debugging.
+func (m *SelectAndLockVTXOsResponse) MessageType() string {
+	return "SelectAndLockVTXOsResponse"
+}
+
+// walletRespSealed implements the sealed WalletResp interface.
+func (m *SelectAndLockVTXOsResponse) walletRespSealed() {}
+
+// UnlockVTXOsRequest releases locks on VTXOs that were previously selected
+// via SelectAndLockVTXOsRequest. This is used when an OOR transfer fails
+// or is cancelled, allowing the VTXOs to be used in future operations.
+type UnlockVTXOsRequest struct {
+	actor.BaseMessage
+
+	// Outpoints identifies the VTXOs to unlock.
+	Outpoints []wire.OutPoint
+}
+
+// MessageType returns the message type identifier for logging and debugging.
+func (m *UnlockVTXOsRequest) MessageType() string {
+	return "UnlockVTXOsRequest"
+}
+
+// walletMsgSealed implements the sealed WalletMsg interface.
+func (m *UnlockVTXOsRequest) walletMsgSealed() {}
+
+// UnlockVTXOsResponse confirms that the specified VTXOs were unlocked.
+type UnlockVTXOsResponse struct {
+	actor.BaseMessage
+
+	// UnlockedCount is the number of VTXOs that were successfully
+	// unlocked.
+	UnlockedCount int
+}
+
+// MessageType returns the message type identifier for logging and debugging.
+func (m *UnlockVTXOsResponse) MessageType() string {
+	return "UnlockVTXOsResponse"
+}
+
+// walletRespSealed implements the sealed WalletResp interface.
+func (m *UnlockVTXOsResponse) walletRespSealed() {}
+
 // LeaveVTXOsRequest triggers leave (offboard) of specified VTXOs. The VTXOs
 // will be forfeited and their value sent to the specified destination output.
 type LeaveVTXOsRequest struct {


### PR DESCRIPTION
In this PR, we add the foundational types and configuration needed for the
`lwwallet` backend: the seed manager, wallet configuration, and wallet actor
message types. This is part 2 of 5 in the daemon + CLI series, stacking on
top of #157.

## Seed Manager

The seed manager (`seed_manager.go`) handles aezeed mnemonic generation via
\`GenerateSeed\`, seed-to-mnemonic conversion via \`MnemonicToSeed\`, and seed
encryption/decryption using scrypt for key derivation + NaCl secretbox
(XSalsa20-Poly1305) for authenticated encryption. The on-disk format is
self-contained: \`salt (32B) || nonce (24B) || ciphertext\`.

Helpers for loading seeds and passwords from environment variables
(\`DAREPOD_LWWALLET_SEED\`, \`DAREPOD_WALLET_PASSWORD\`) and files are included
for CI and unattended startup scenarios.

A \`zeroBytes\` helper with \`defer\` calls in \`EncryptSeed\`, \`DecryptSeed\`, and
the plaintext recovery path clears scrypt-derived keys, NaCl secret keys, and
decrypted seed bytes from memory once they're no longer needed.

Unit tests cover the encrypt/decrypt roundtrip, mnemonic generation, and
environment variable loading.

## Wallet Config

\`WalletConfig\` is added to the daemon configuration with fields for wallet type
(\`lnd\` or \`lwwallet\`), esplora URL, poll interval, recovery window, and
password file. Validation enforces that lnd fields are required only when
\`wallet.type=lnd\`, and esplora URL is required when \`wallet.type=lwwallet\`.
The new \`wallet.*\` cobra flags are registered and bound via viper.

## Wallet Actor Messages

New actor message types for VTXO coin selection with locking
(\`SelectAndLockVTXOsRequest\`/\`Response\`, \`UnlockVTXOsRequest\`/\`Response\`) and
\`RefreshVTXOsRequest\`/\`Response\` for triggering VTXO refresh with optional
outpoint filtering, force-refresh, and dry-run support. A \`SelectedVTXO\` struct
carries outpoint, amount, and pkscript without importing the \`vtxo\` package,
avoiding an import cycle.

## PR Series

1. Proto definitions + generated stubs (#157)
2. **This PR** — Seed manager, wallet config, wallet messages
3. Server dual-wallet refactor + RPC handlers + hardening
4. Agent-first CLI binary (\`darepocli\`)
5. Schema introspection, MCP server, agent docs