### PR TITLE
darepod: add dual-wallet server, RPC handlers, and SDK-ready modularization [3/5]

### DIFF
--- a/cmd/darepod/main.go
+++ b/cmd/darepod/main.go
@@ -113,6 +113,12 @@ func newRootCmd() *cobra.Command {
 		"daemon gRPC listen address",
 	)
 
+	// Safety flag for mainnet operation.
+	f.Bool("allow-mainnet", cfg.AllowMainnet,
+		"allow the daemon to run on mainnet "+
+			"(required when network=mainnet)",
+	)
+
 	// Bind all flags to viper so Unmarshal populates the config
 	// struct from the combined flag/env/file sources.
 	v.SetEnvPrefix("DAREPOD")

--- a/darepod/config.go
+++ b/darepod/config.go
@@ -105,6 +105,11 @@ type Config struct {
 	// If zero, the default of 2 minutes is used.
 	//nolint:ll
 	ForfeitCollectionTimeout time.Duration `mapstructure:"forfeitcollectiontimeout"`
+
+	// AllowMainnet must be set to true explicitly to run the daemon
+	// on mainnet. This guard prevents accidentally operating on
+	// mainnet during development, since DefaultNetwork is "mainnet".
+	AllowMainnet bool `mapstructure:"allow-mainnet"`
 }
 
 // LndConfig holds connection parameters for the backing lnd node.
@@ -234,6 +239,16 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("unknown network %q", c.Network)
 	}
 
+	// Require explicit opt-in for mainnet to prevent accidental
+	// use during development.
+	if c.Network == "mainnet" && !c.AllowMainnet {
+		return fmt.Errorf(
+			"running on mainnet requires " +
+				"--allow-mainnet flag or " +
+				"allow-mainnet=true in config",
+		)
+	}
+
 	// Validate wallet config.
 	if c.Wallet == nil {
 		return fmt.Errorf("wallet config is required")
@@ -314,25 +329,36 @@ func networkToChainParams(network string) (*chaincfg.Params, error) {
 
 // NetworkDir returns the network-scoped data directory (e.g.,
 // ~/.darepod/data/regtest).
-func (c *Config) NetworkDir() string {
-	return filepath.Join(expandTilde(c.DataDir), "data", c.Network)
+func (c *Config) NetworkDir() (string, error) {
+	dataDir, err := expandTilde(c.DataDir)
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(dataDir, "data", c.Network), nil
 }
 
 // LogDir returns the network-scoped log directory.
-func (c *Config) LogDir() string {
-	return filepath.Join(expandTilde(c.DataDir), "logs", c.Network)
+func (c *Config) LogDir() (string, error) {
+	dataDir, err := expandTilde(c.DataDir)
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(dataDir, "logs", c.Network), nil
 }
 
 // expandTilde replaces a leading ~ or ~/ with the user's home
 // directory. For example, "~/.darepod" becomes "/home/user/.darepod".
-func expandTilde(path string) string {
+// It returns an error if the home directory cannot be determined.
+func expandTilde(path string) (string, error) {
 	if len(path) == 0 || path[0] != '~' {
-		return path
+		return path, nil
 	}
 
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return path
+		return "", fmt.Errorf("resolving home directory: %w", err)
 	}
 
 	// Strip the leading "~" and any path separator that follows
@@ -344,5 +370,5 @@ func expandTilde(path string) string {
 		suffix = suffix[1:]
 	}
 
-	return filepath.Join(home, suffix)
+	return filepath.Join(home, suffix), nil
 }

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -83,9 +83,13 @@ func (r *RPCServer) GetInfo(ctx context.Context,
 			// Derive the node identity key from the wallet
 			// keyring using KeyFamilyNodeKey (family 6,
 			// index 0), matching lnd's identity key
-			// derivation path.
-			desc, err := w.DeriveNextKey(
-				ctx, identityKeyFamily,
+			// derivation path. DeriveKey (not
+			// DeriveNextKey) ensures a stable identity.
+			desc, err := w.DeriveKey(
+				ctx, keychain.KeyLocator{
+					Family: identityKeyFamily,
+					Index:  0,
+				},
 			)
 			if err != nil {
 				log.WarnS(ctx,
@@ -519,37 +523,15 @@ func (r *RPCServer) SendVTXO(ctx context.Context,
 		}, nil
 	}
 
-	if !r.server.walletRef.IsSome() {
-		return nil, status.Errorf(codes.Internal,
-			"wallet actor not initialized")
-	}
-
-	// In-round sends are implemented as VTXO refreshes where the
-	// wallet actor selects inputs and submits them to the round
-	// coordinator. The refresh mechanism handles coin selection
-	// and round participation internally.
-	wRef := r.server.walletRef.UnsafeFromSome()
-
-	refreshReq := &wallet.RefreshVTXOsRequest{
-		ForceRefresh: true,
-	}
-	future := wRef.Ask(ctx, refreshReq)
-	result := future.Await(ctx)
-
-	_, err := result.Unpack()
-	if err != nil {
-		return nil, status.Errorf(codes.Internal,
-			"send request failed: %v", err)
-	}
-
-	log.InfoS(ctx, "In-round send submitted",
-		slog.Int64("total_amount_sat", totalAmount),
-		slog.Int("recipient_count", len(req.Recipients)))
-
-	return &daemonrpc.SendVTXOResponse{
-		Status:         "submitted",
-		TotalAmountSat: totalAmount,
-	}, nil
+	// TODO(roasbeef): In-round directed sends are not yet
+	// implemented. The wallet actor's RefreshVTXOsRequest only
+	// supports self-refresh (sending back to self), not directed
+	// transfers to external recipients. Once the round protocol
+	// supports recipient outputs, this handler should build a
+	// proper send request with the validated recipients.
+	return nil, status.Errorf(codes.Unimplemented,
+		"in-round directed sends are not yet implemented; "+
+			"use SendOOR for out-of-round transfers")
 }
 
 // SendOOR initiates an out-of-round transfer directly between the

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -2,9 +2,28 @@ package darepod
 
 import (
 	"context"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"strings"
 
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/build"
 	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/lightninglabs/darepo-client/lib/scripts"
+	oortx "github.com/lightninglabs/darepo-client/lib/tx/oor"
+	"github.com/lightninglabs/darepo-client/lwwallet"
+	"github.com/lightninglabs/darepo-client/oor"
+	"github.com/lightninglabs/darepo-client/vtxo"
+	"github.com/lightninglabs/darepo-client/wallet"
+	"github.com/lightninglabs/lndclient"
+	"github.com/lightningnetwork/lnd/keychain"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // RPCServer implements the daemon's gRPC DaemonService interface.
@@ -27,27 +46,765 @@ func (r *RPCServer) GetInfo(ctx context.Context,
 	_ *daemonrpc.GetInfoRequest) (*daemonrpc.GetInfoResponse, error) {
 
 	resp := &daemonrpc.GetInfoResponse{
-		Version: build.Version(),
-		Commit:  build.CommitHash,
-		Network: r.server.cfg.Network,
+		Version:     build.Version(),
+		Commit:      build.CommitHash,
+		Network:     r.server.cfg.Network,
+		WalletType:  r.server.cfg.Wallet.Type,
+		WalletReady: r.server.isWalletReady(),
 	}
 
 	// Populate lnd fields if connected.
-	if r.server.lnd != nil {
-		resp.LndIdentityPubkey = r.server.lnd.NodePubkey.String()
-		resp.LndAlias = r.server.lnd.NodeAlias
+	r.server.lnd.WhenSome(
+		func(lndSvc *lndclient.GrpcLndServices) {
+			resp.LndIdentityPubkey =
+				lndSvc.NodePubkey.String()
+			resp.LndAlias = lndSvc.NodeAlias
+			resp.IdentityPubkey =
+				lndSvc.NodePubkey.String()
 
-		// Fetch the current best block height from the chain
-		// backend via lnd's ChainKit interface.
-		_, height, err := r.server.lnd.ChainKit.GetBestBlock(ctx)
-		if err != nil {
-			log.WarnS(ctx, "Unable to fetch block height", err)
-		} else {
-			resp.BlockHeight = uint32(height)
-		}
-	}
+			// Fetch the current best block height from
+			// the chain backend via lnd's ChainKit
+			// interface.
+			_, height, err :=
+				lndSvc.ChainKit.GetBestBlock(ctx)
+			if err != nil {
+				log.WarnS(ctx,
+					"Unable to fetch block height",
+					err)
+			} else {
+				resp.BlockHeight = uint32(height)
+			}
+		},
+	)
+
+	// Populate lwwallet fields if the lightweight wallet is active.
+	r.server.lwWallet.WhenSome(
+		func(w *lwwallet.Wallet) {
+			// Derive the node identity key from the wallet
+			// keyring using KeyFamilyNodeKey (family 6,
+			// index 0), matching lnd's identity key
+			// derivation path.
+			desc, err := w.DeriveNextKey(
+				ctx, identityKeyFamily,
+			)
+			if err != nil {
+				log.WarnS(ctx,
+					"Unable to derive identity key",
+					err)
+			} else {
+				resp.IdentityPubkey = fmt.Sprintf(
+					"%x",
+					desc.PubKey.SerializeCompressed(),
+				)
+			}
+
+			// Get block height from the chain backend.
+			if r.server.chainBackend != nil {
+				height, _, err :=
+					r.server.chainBackend.BestBlock(
+						ctx,
+					)
+				if err != nil {
+					log.WarnS(ctx,
+						"Unable to fetch block "+
+							"height", err)
+				} else {
+					resp.BlockHeight = uint32(height)
+				}
+			}
+		},
+	)
 
 	// TODO(roasbeef): populate server connection status from runtime.
 
 	return resp, nil
+}
+
+// requireWalletReady returns a gRPC error if the wallet is not yet
+// ready. Callers use this to gate RPCs that need wallet access.
+func (r *RPCServer) requireWalletReady() error {
+	if !r.server.isWalletReady() {
+		return status.Errorf(codes.FailedPrecondition,
+			"wallet is not ready (create or unlock first)")
+	}
+
+	return nil
+}
+
+// GetBalance returns the current balance of the wallet, broken down
+// by boarding (on-chain) and VTXO (off-chain) balances.
+func (r *RPCServer) GetBalance(ctx context.Context,
+	_ *daemonrpc.GetBalanceRequest) (
+	*daemonrpc.GetBalanceResponse, error) {
+
+	if err := r.requireWalletReady(); err != nil {
+		return nil, err
+	}
+
+	resp := &daemonrpc.GetBalanceResponse{}
+
+	// Fetch boarding balance from the wallet actor via Ask.
+	if r.server.walletRef.IsSome() {
+		wRef := r.server.walletRef.UnsafeFromSome()
+
+		balReq := &wallet.GetBoardingBalanceRequest{}
+		future := wRef.Ask(ctx, balReq)
+		result := future.Await(ctx)
+
+		balResp, err := result.Unpack()
+		if err != nil {
+			log.WarnS(ctx,
+				"Unable to fetch boarding balance",
+				err)
+		} else {
+			br, ok := balResp.(*wallet.GetBoardingBalanceResponse)
+			if ok {
+				resp.BoardingConfirmedSat = int64(
+					br.TotalBalance,
+				)
+			}
+		}
+	}
+
+	// Fetch VTXO balance by summing all live VTXOs.
+	if r.server.vtxoStore != nil {
+		liveVTXOs, err := r.server.vtxoStore.ListLiveVTXOs(
+			ctx,
+		)
+		if err != nil {
+			log.WarnS(ctx,
+				"Unable to fetch VTXO balance", err)
+		} else {
+			var vtxoTotal int64
+			for _, v := range liveVTXOs {
+				vtxoTotal += int64(v.Amount)
+			}
+			resp.VtxoBalanceSat = vtxoTotal
+		}
+	}
+
+	resp.TotalConfirmedSat = resp.BoardingConfirmedSat +
+		resp.VtxoBalanceSat
+
+	return resp, nil
+}
+
+// ListVTXOs returns the set of VTXOs known to the wallet, optionally
+// filtered by status and minimum amount.
+func (r *RPCServer) ListVTXOs(ctx context.Context,
+	req *daemonrpc.ListVTXOsRequest) (
+	*daemonrpc.ListVTXOsResponse, error) {
+
+	if err := r.requireWalletReady(); err != nil {
+		return nil, err
+	}
+
+	if r.server.vtxoStore == nil {
+		return nil, status.Errorf(codes.Internal,
+			"vtxo store not initialized")
+	}
+
+	// Fetch all live VTXOs from the store.
+	liveVTXOs, err := r.server.vtxoStore.ListLiveVTXOs(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"unable to list VTXOs: %v", err)
+	}
+
+	// Apply filters and convert to proto.
+	var protoVTXOs []*daemonrpc.VTXO
+	for _, v := range liveVTXOs {
+		// Filter by status if specified.
+		if req.StatusFilter !=
+			daemonrpc.VTXOStatus_VTXO_STATUS_UNSPECIFIED {
+
+			protoStatus := vtxoStatusToProto(v.Status)
+			if protoStatus != req.StatusFilter {
+				continue
+			}
+		}
+
+		// Filter by minimum amount if specified.
+		if req.MinAmountSat > 0 &&
+			int64(v.Amount) < req.MinAmountSat {
+
+			continue
+		}
+
+		protoVTXOs = append(protoVTXOs,
+			descriptorToProto(v))
+	}
+
+	return &daemonrpc.ListVTXOsResponse{
+		Vtxos: protoVTXOs,
+	}, nil
+}
+
+// vtxoStatusToProto converts a domain VTXOStatus to the proto enum.
+func vtxoStatusToProto(s vtxo.VTXOStatus) daemonrpc.VTXOStatus {
+	switch s {
+	case vtxo.VTXOStatusLive:
+		return daemonrpc.VTXOStatus_VTXO_STATUS_LIVE
+
+	case vtxo.VTXOStatusRefreshRequested:
+		return daemonrpc.VTXOStatus_VTXO_STATUS_REFRESH_REQUESTED
+
+	case vtxo.VTXOStatusForfeiting:
+		return daemonrpc.VTXOStatus_VTXO_STATUS_FORFEITING
+
+	case vtxo.VTXOStatusForfeited:
+		return daemonrpc.VTXOStatus_VTXO_STATUS_FORFEITED
+
+	case vtxo.VTXOStatusSpent:
+		return daemonrpc.VTXOStatus_VTXO_STATUS_SPENT
+
+	case vtxo.VTXOStatusExpiring:
+		return daemonrpc.VTXOStatus_VTXO_STATUS_EXPIRING
+
+	case vtxo.VTXOStatusFailed:
+		return daemonrpc.VTXOStatus_VTXO_STATUS_FAILED
+
+	default:
+		return daemonrpc.VTXOStatus_VTXO_STATUS_UNSPECIFIED
+	}
+}
+
+// descriptorToProto converts a vtxo.Descriptor to the proto VTXO message.
+func descriptorToProto(v *vtxo.Descriptor) *daemonrpc.VTXO {
+	return &daemonrpc.VTXO{
+		Outpoint: fmt.Sprintf(
+			"%s:%d", v.Outpoint.Hash, v.Outpoint.Index,
+		),
+		AmountSat:      int64(v.Amount),
+		Status:         vtxoStatusToProto(v.Status),
+		BatchExpiry:    v.BatchExpiry,
+		RoundId:        v.RoundID,
+		CreatedHeight:  v.CreatedHeight,
+		RelativeExpiry: v.RelativeExpiry,
+		PkScript:       hex.EncodeToString(v.PkScript),
+		CommitmentTxid: v.CommitmentTxID.String(),
+	}
+}
+
+// NewAddress generates a new boarding address that can receive
+// on-chain funds for use in the Ark protocol.
+func (r *RPCServer) NewAddress(ctx context.Context,
+	_ *daemonrpc.NewAddressRequest) (
+	*daemonrpc.NewAddressResponse, error) {
+
+	if err := r.requireWalletReady(); err != nil {
+		return nil, err
+	}
+
+	if !r.server.walletRef.IsSome() {
+		return nil, status.Errorf(codes.Internal,
+			"wallet actor not initialized")
+	}
+
+	wRef := r.server.walletRef.UnsafeFromSome()
+
+	// Fetch operator terms to get the operator key and exit delay
+	// needed for the boarding address tapscript.
+	terms, err := r.server.fetchOperatorTerms(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"unable to fetch operator terms: %v", err)
+	}
+
+	addrReq := &wallet.CreateBoardingAddressRequest{
+		OperatorKey: terms.PubKey,
+		ExitDelay:   terms.BoardingExitDelay,
+	}
+	future := wRef.Ask(ctx, addrReq)
+	result := future.Await(ctx)
+
+	addrResp, err := result.Unpack()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"unable to create boarding address: %v", err)
+	}
+
+	resp, ok := addrResp.(*wallet.CreateBoardingAddressResponse)
+	if !ok {
+		return nil, status.Errorf(codes.Internal,
+			"unexpected response type: %T", addrResp)
+	}
+
+	return &daemonrpc.NewAddressResponse{
+		Address: resp.Address.String(),
+	}, nil
+}
+
+// RefreshVTXOs queues one or more VTXOs for refresh in the next round.
+// This extends their expiry without changing ownership. If the all flag
+// is set, every live VTXO is queued for refresh.
+func (r *RPCServer) RefreshVTXOs(ctx context.Context,
+	req *daemonrpc.RefreshVTXOsRequest) (
+	*daemonrpc.RefreshVTXOsResponse, error) {
+
+	if err := r.requireWalletReady(); err != nil {
+		return nil, err
+	}
+
+	if !r.server.walletRef.IsSome() {
+		return nil, status.Errorf(codes.Internal,
+			"wallet actor not initialized")
+	}
+
+	wRef := r.server.walletRef.UnsafeFromSome()
+
+	// Build the list of target outpoints. If the "all" selection
+	// is set, leave the slice empty so the wallet actor refreshes
+	// everything approaching expiry.
+	var (
+		targets    []wire.OutPoint
+		refreshAll bool
+	)
+
+	switch sel := req.Selection.(type) {
+	case *daemonrpc.RefreshVTXOsRequest_All:
+		refreshAll = sel.All
+
+	case *daemonrpc.RefreshVTXOsRequest_Outpoints:
+		if sel.Outpoints == nil ||
+			len(sel.Outpoints.Outpoints) == 0 {
+
+			return nil, status.Errorf(
+				codes.InvalidArgument,
+				"outpoints list is empty")
+		}
+
+		for _, opStr := range sel.Outpoints.Outpoints {
+			op, err := parseOutpointString(opStr)
+			if err != nil {
+				return nil, status.Errorf(
+					codes.InvalidArgument,
+					"invalid outpoint %q: %v",
+					opStr, err)
+			}
+
+			targets = append(targets, op)
+		}
+
+	default:
+		return nil, status.Errorf(
+			codes.InvalidArgument,
+			"selection is required (outpoints or all)")
+	}
+
+	// For dry_run, validate inputs and return a preview without
+	// actually queuing anything.
+	if req.DryRun {
+		outpointStrs := make([]string, 0, len(targets))
+		for _, op := range targets {
+			outpointStrs = append(outpointStrs,
+				fmt.Sprintf("%s:%d",
+					op.Hash, op.Index))
+		}
+
+		return &daemonrpc.RefreshVTXOsResponse{
+			QueuedOutpoints: outpointStrs,
+			Status:          "preview",
+		}, nil
+	}
+
+	// Send the refresh request to the wallet actor and await its
+	// response.
+	refreshReq := &wallet.RefreshVTXOsRequest{
+		TargetOutpoints: targets,
+		ForceRefresh:    true,
+	}
+	future := wRef.Ask(ctx, refreshReq)
+	result := future.Await(ctx)
+
+	refreshResp, err := result.Unpack()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"refresh request failed: %v", err)
+	}
+
+	resp, ok := refreshResp.(*wallet.RefreshVTXOsResponse)
+	if !ok {
+		return nil, status.Errorf(codes.Internal,
+			"unexpected response type: %T", refreshResp)
+	}
+
+	// Log any per-outpoint errors but don't fail the overall
+	// request.
+	for op, opErr := range resp.Errors {
+		log.WarnS(ctx, "VTXO refresh error", opErr,
+			"outpoint", op.String())
+	}
+
+	// Build the list of outpoints that were successfully queued.
+	queued := make([]string, 0, resp.RefreshingCount)
+	if refreshAll && r.server.vtxoStore != nil {
+		// When refreshing all, list the live VTXOs to
+		// report which ones were actually queued.
+		liveVTXOs, err := r.server.vtxoStore.ListLiveVTXOs(
+			ctx,
+		)
+		if err == nil {
+			for _, v := range liveVTXOs {
+				_, hasErr := resp.Errors[v.Outpoint]
+				if !hasErr {
+					queued = append(queued,
+						fmt.Sprintf("%s:%d",
+							v.Outpoint.Hash,
+							v.Outpoint.Index))
+				}
+			}
+		}
+	} else {
+		for _, op := range targets {
+			if _, hasErr := resp.Errors[op]; !hasErr {
+				queued = append(queued,
+					fmt.Sprintf("%s:%d",
+						op.Hash, op.Index))
+			}
+		}
+	}
+
+	log.InfoS(ctx, "VTXOs queued for refresh",
+		slog.Int("queued_count", len(queued)),
+		slog.Int("error_count", len(resp.Errors)))
+
+	return &daemonrpc.RefreshVTXOsResponse{
+		QueuedOutpoints: queued,
+		Status:          "queued",
+	}, nil
+}
+
+// SendVTXO initiates an in-round transfer by submitting a refresh
+// request with specific recipient outputs to the round coordinator.
+// The transfer completes asynchronously when the next round commits.
+func (r *RPCServer) SendVTXO(ctx context.Context,
+	req *daemonrpc.SendVTXORequest) (
+	*daemonrpc.SendVTXOResponse, error) {
+
+	if err := r.requireWalletReady(); err != nil {
+		return nil, err
+	}
+
+	if len(req.Recipients) == 0 {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"at least one recipient is required")
+	}
+
+	// Validate recipients and compute total amount.
+	var totalAmount int64
+	for i, out := range req.Recipients {
+		if out.GetDestination() == nil {
+			return nil, status.Errorf(
+				codes.InvalidArgument,
+				"recipient %d: destination is "+
+					"required", i)
+		}
+
+		if out.AmountSat <= 0 {
+			return nil, status.Errorf(
+				codes.InvalidArgument,
+				"recipient %d: amount must be "+
+					"positive", i)
+		}
+
+		totalAmount += out.AmountSat
+	}
+
+	// For dry_run, validate inputs and return a preview.
+	if req.DryRun {
+		return &daemonrpc.SendVTXOResponse{
+			Status:         "preview",
+			TotalAmountSat: totalAmount,
+		}, nil
+	}
+
+	if !r.server.walletRef.IsSome() {
+		return nil, status.Errorf(codes.Internal,
+			"wallet actor not initialized")
+	}
+
+	// In-round sends are implemented as VTXO refreshes where the
+	// wallet actor selects inputs and submits them to the round
+	// coordinator. The refresh mechanism handles coin selection
+	// and round participation internally.
+	wRef := r.server.walletRef.UnsafeFromSome()
+
+	refreshReq := &wallet.RefreshVTXOsRequest{
+		ForceRefresh: true,
+	}
+	future := wRef.Ask(ctx, refreshReq)
+	result := future.Await(ctx)
+
+	_, err := result.Unpack()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"send request failed: %v", err)
+	}
+
+	log.InfoS(ctx, "In-round send submitted",
+		slog.Int64("total_amount_sat", totalAmount),
+		slog.Int("recipient_count", len(req.Recipients)))
+
+	return &daemonrpc.SendVTXOResponse{
+		Status:         "submitted",
+		TotalAmountSat: totalAmount,
+	}, nil
+}
+
+// SendOOR initiates an out-of-round transfer directly between the
+// client and operator, without waiting for a round. The transfer
+// completes asynchronously via the OOR protocol.
+func (r *RPCServer) SendOOR(ctx context.Context,
+	req *daemonrpc.SendOORRequest) (
+	*daemonrpc.SendOORResponse, error) {
+
+	if err := r.requireWalletReady(); err != nil {
+		return nil, err
+	}
+
+	if req.Recipient == nil {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"recipient is required")
+	}
+
+	if req.Recipient.AmountSat <= 0 {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"amount must be positive")
+	}
+
+	// Resolve the recipient's pkScript from the destination
+	// oneof.
+	pkScript, err := r.resolveOutputPkScript(
+		req.Recipient,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// For dry_run, validate inputs and return a preview.
+	if req.DryRun {
+		return &daemonrpc.SendOORResponse{
+			Status: "preview",
+		}, nil
+	}
+
+	if r.server.actorSystem == nil {
+		return nil, status.Errorf(codes.Internal,
+			"actor system not initialized")
+	}
+
+	if !r.server.walletRef.IsSome() {
+		return nil, status.Errorf(codes.Internal,
+			"wallet actor not initialized")
+	}
+
+	if r.server.vtxoStore == nil {
+		return nil, status.Errorf(codes.Internal,
+			"VTXO store not initialized")
+	}
+
+	// Fetch operator terms for the checkpoint policy.
+	terms, err := r.server.fetchOperatorTerms(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"unable to fetch operator terms: %v", err)
+	}
+
+	policy := scripts.CheckpointPolicy{
+		OperatorKey: terms.PubKey,
+		CSVDelay:    terms.VTXOExitDelay,
+	}
+
+	// Ask the wallet actor to select and lock VTXOs covering the
+	// send amount. This is atomic: selected VTXOs are locked to
+	// prevent double-spends until the transfer completes or is
+	// cancelled.
+	targetAmt := btcutil.Amount(req.Recipient.AmountSat)
+	wRef := r.server.walletRef.UnsafeFromSome()
+
+	selectReq := &wallet.SelectAndLockVTXOsRequest{
+		TargetAmount: targetAmt,
+	}
+	selectFuture := wRef.Ask(ctx, selectReq)
+	selectResult := selectFuture.Await(ctx)
+
+	selectResp, err := selectResult.Unpack()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"VTXO selection failed: %v", err)
+	}
+
+	locked, ok := selectResp.(*wallet.SelectAndLockVTXOsResponse)
+	if !ok {
+		return nil, status.Errorf(codes.Internal,
+			"unexpected response type: %T", selectResp)
+	}
+
+	// Look up full VTXO descriptors from the store so we can
+	// build the OOR transfer inputs with all required fields
+	// (TapScript, ClientKey, etc.).
+	var selectedInputs []oor.TransferInput
+	for _, sv := range locked.SelectedVTXOs {
+		desc, err := r.server.vtxoStore.GetVTXO(
+			ctx, sv.Outpoint,
+		)
+		if err != nil {
+			// Unlock VTXOs on failure to prevent
+			// leaking locks.
+			r.unlockVTXOs(ctx, locked.SelectedVTXOs)
+
+			return nil, status.Errorf(codes.Internal,
+				"unable to look up VTXO %s: %v",
+				sv.Outpoint, err)
+		}
+
+		selectedInputs = append(selectedInputs,
+			oor.TransferInput{
+				VTXO:            desc,
+				OwnerLeafScript: desc.PkScript,
+			})
+	}
+
+	// Build the recipient output for the OOR transfer.
+	recipients := []oortx.RecipientOutput{{
+		PkScript: pkScript,
+		Value:    targetAmt,
+	}}
+
+	// Resolve the OOR actor via the service key registered in the
+	// actor system's receptionist. This avoids holding a direct
+	// reference and is the canonical way to interact with
+	// service-registered actors.
+	oorKey := oor.NewServiceKey()
+	oorRef := oorKey.Ref(r.server.actorSystem)
+
+	oorReq := &oor.StartTransferRequest{
+		Policy:     policy,
+		Inputs:     selectedInputs,
+		Recipients: recipients,
+	}
+
+	future := oorRef.Ask(ctx, oorReq)
+	oorResult := future.Await(ctx)
+
+	oorResp, err := oorResult.Unpack()
+	if err != nil {
+		// Unlock VTXOs on OOR failure so they can be
+		// reused.
+		r.unlockVTXOs(ctx, locked.SelectedVTXOs)
+
+		return nil, status.Errorf(codes.Internal,
+			"OOR transfer failed: %v", err)
+	}
+
+	resp, ok := oorResp.(*oor.StartTransferResponse)
+	if !ok {
+		return nil, status.Errorf(codes.Internal,
+			"unexpected response type: %T", oorResp)
+	}
+
+	log.InfoS(ctx, "OOR transfer submitted",
+		slog.String("session_id", resp.SessionID.String()),
+		slog.Int64("amount_sat", req.Recipient.AmountSat))
+
+	return &daemonrpc.SendOORResponse{
+		Status:    "submitted",
+		SessionId: resp.SessionID.String(),
+	}, nil
+}
+
+// unlockVTXOs sends an UnlockVTXOsRequest to the wallet actor for the
+// given set of selected VTXOs. This is a fire-and-forget operation used
+// for cleanup when an OOR transfer fails.
+func (r *RPCServer) unlockVTXOs(ctx context.Context,
+	vtxos []wallet.SelectedVTXO) {
+
+	if !r.server.walletRef.IsSome() {
+		return
+	}
+
+	outpoints := make([]wire.OutPoint, 0, len(vtxos))
+	for _, sv := range vtxos {
+		outpoints = append(outpoints, sv.Outpoint)
+	}
+
+	wRef := r.server.walletRef.UnsafeFromSome()
+	wRef.Tell(ctx, &wallet.UnlockVTXOsRequest{
+		Outpoints: outpoints,
+	})
+}
+
+// resolveOutputPkScript derives a pkScript from the Output's
+// destination oneof. It supports address, raw pubkey, and raw
+// pkScript destinations.
+func (r *RPCServer) resolveOutputPkScript(
+	out *daemonrpc.Output) ([]byte, error) {
+
+	switch d := out.Destination.(type) {
+	case *daemonrpc.Output_Address:
+		addr, err := btcutil.DecodeAddress(
+			d.Address, r.server.chainParams,
+		)
+		if err != nil {
+			return nil, status.Errorf(
+				codes.InvalidArgument,
+				"invalid address: %v", err,
+			)
+		}
+
+		pkScript, err := txscript.PayToAddrScript(addr)
+		if err != nil {
+			return nil, status.Errorf(
+				codes.Internal,
+				"unable to derive pkScript: %v",
+				err,
+			)
+		}
+
+		return pkScript, nil
+
+	case *daemonrpc.Output_PkScript:
+		if len(d.PkScript) == 0 {
+			return nil, status.Errorf(
+				codes.InvalidArgument,
+				"pk_script is empty",
+			)
+		}
+
+		return d.PkScript, nil
+
+	default:
+		return nil, status.Errorf(
+			codes.InvalidArgument,
+			"unsupported destination type: %T", d,
+		)
+	}
+}
+
+// parseOutpointString parses a "txid:index" string into a
+// wire.OutPoint.
+func parseOutpointString(s string) (wire.OutPoint, error) {
+	parts := strings.SplitN(s, ":", 2)
+	if len(parts) != 2 {
+		return wire.OutPoint{}, fmt.Errorf(
+			"expected txid:index format")
+	}
+
+	hash, err := chainhash.NewHashFromStr(parts[0])
+	if err != nil {
+		return wire.OutPoint{}, fmt.Errorf(
+			"invalid txid: %w", err)
+	}
+
+	idx, err := strconv.ParseUint(parts[1], 10, 32)
+	if err != nil {
+		return wire.OutPoint{}, fmt.Errorf(
+			"invalid index: %w", err)
+	}
+
+	return wire.OutPoint{
+		Hash:  *hash,
+		Index: uint32(idx),
+	}, nil
 }

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -170,7 +170,8 @@ func (r *RPCServer) GetBalance(ctx context.Context,
 		}
 	}
 
-	// Fetch VTXO balance by summing all live VTXOs.
+	// Fetch VTXO balance by summing all live VTXOs using the
+	// package-level SumBalance helper.
 	if r.server.vtxoStore != nil {
 		liveVTXOs, err := r.server.vtxoStore.ListLiveVTXOs(
 			ctx,
@@ -179,11 +180,9 @@ func (r *RPCServer) GetBalance(ctx context.Context,
 			log.WarnS(ctx,
 				"Unable to fetch VTXO balance", err)
 		} else {
-			var vtxoTotal int64
-			for _, v := range liveVTXOs {
-				vtxoTotal += int64(v.Amount)
-			}
-			resp.VtxoBalanceSat = vtxoTotal
+			resp.VtxoBalanceSat = int64(
+				vtxo.SumBalance(liveVTXOs),
+			)
 		}
 	}
 
@@ -208,33 +207,54 @@ func (r *RPCServer) ListVTXOs(ctx context.Context,
 			"vtxo store not initialized")
 	}
 
-	// Fetch all live VTXOs from the store.
-	liveVTXOs, err := r.server.vtxoStore.ListLiveVTXOs(ctx)
+	// Fetch VTXOs from the store. When a specific status filter
+	// is provided, query the DB directly for that status so
+	// terminal states (spent, forfeited) are reachable. When
+	// unspecified, return all non-terminal (live) VTXOs.
+	var (
+		dbVTXOs []*vtxo.Descriptor
+		err     error
+	)
+
+	if req.StatusFilter !=
+		daemonrpc.VTXOStatus_VTXO_STATUS_UNSPECIFIED {
+
+		domainStatus, sErr := protoStatusToDomain(
+			req.StatusFilter,
+		)
+		if sErr != nil {
+			return nil, status.Errorf(
+				codes.InvalidArgument,
+				"invalid status filter: %v", sErr,
+			)
+		}
+
+		dbVTXOs, err = r.server.vtxoStore.ListVTXOsByStatus(
+			ctx, domainStatus,
+		)
+	} else {
+		dbVTXOs, err = r.server.vtxoStore.ListLiveVTXOs(ctx)
+	}
+
 	if err != nil {
 		return nil, status.Errorf(codes.Internal,
 			"unable to list VTXOs: %v", err)
 	}
 
-	// Apply filters and convert to proto.
-	var protoVTXOs []*daemonrpc.VTXO
-	for _, v := range liveVTXOs {
-		// Filter by status if specified.
-		if req.StatusFilter !=
-			daemonrpc.VTXOStatus_VTXO_STATUS_UNSPECIFIED {
+	// Apply any remaining in-memory filters (min amount) via
+	// the package-level FilterDescriptors function so this
+	// logic is reusable by a future SDK.
+	filterOpts := vtxo.FilterOptions{
+		MinAmount: btcutil.Amount(req.MinAmountSat),
+	}
 
-			protoStatus := vtxoStatusToProto(v.Status)
-			if protoStatus != req.StatusFilter {
-				continue
-			}
-		}
+	filtered := vtxo.FilterDescriptors(dbVTXOs, filterOpts)
 
-		// Filter by minimum amount if specified.
-		if req.MinAmountSat > 0 &&
-			int64(v.Amount) < req.MinAmountSat {
-
-			continue
-		}
-
+	// Convert to proto.
+	protoVTXOs := make(
+		[]*daemonrpc.VTXO, 0, len(filtered),
+	)
+	for _, v := range filtered {
 		protoVTXOs = append(protoVTXOs,
 			descriptorToProto(v))
 	}
@@ -242,6 +262,40 @@ func (r *RPCServer) ListVTXOs(ctx context.Context,
 	return &daemonrpc.ListVTXOsResponse{
 		Vtxos: protoVTXOs,
 	}, nil
+}
+
+// protoStatusToDomain converts a proto VTXOStatus enum to the domain
+// vtxo.VTXOStatus type for use with vtxo.FilterDescriptors. An error
+// is returned for unknown status values to surface proto/domain drift
+// early rather than silently defaulting.
+func protoStatusToDomain(
+	s daemonrpc.VTXOStatus) (vtxo.VTXOStatus, error) {
+
+	switch s {
+	case daemonrpc.VTXOStatus_VTXO_STATUS_LIVE:
+		return vtxo.VTXOStatusLive, nil
+
+	case daemonrpc.VTXOStatus_VTXO_STATUS_REFRESH_REQUESTED:
+		return vtxo.VTXOStatusRefreshRequested, nil
+
+	case daemonrpc.VTXOStatus_VTXO_STATUS_FORFEITING:
+		return vtxo.VTXOStatusForfeiting, nil
+
+	case daemonrpc.VTXOStatus_VTXO_STATUS_FORFEITED:
+		return vtxo.VTXOStatusForfeited, nil
+
+	case daemonrpc.VTXOStatus_VTXO_STATUS_SPENT:
+		return vtxo.VTXOStatusSpent, nil
+
+	case daemonrpc.VTXOStatus_VTXO_STATUS_EXPIRING:
+		return vtxo.VTXOStatusExpiring, nil
+
+	case daemonrpc.VTXOStatus_VTXO_STATUS_FAILED:
+		return vtxo.VTXOStatusFailed, nil
+
+	default:
+		return 0, fmt.Errorf("unknown VTXO status: %v", s)
+	}
 }
 
 // vtxoStatusToProto converts a domain VTXOStatus to the proto enum.
@@ -623,29 +677,24 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 			"unexpected response type: %T", selectResp)
 	}
 
-	// Look up full VTXO descriptors from the store so we can
-	// build the OOR transfer inputs with all required fields
-	// (TapScript, ClientKey, etc.).
-	var selectedInputs []oor.TransferInput
+	// Look up full VTXO descriptors from the store and build
+	// OOR transfer inputs. This is delegated to a package-level
+	// function so a future SDK can call it directly.
+	outpoints := make(
+		[]wire.OutPoint, 0, len(locked.SelectedVTXOs),
+	)
 	for _, sv := range locked.SelectedVTXOs {
-		desc, err := r.server.vtxoStore.GetVTXO(
-			ctx, sv.Outpoint,
-		)
-		if err != nil {
-			// Unlock VTXOs on failure to prevent
-			// leaking locks.
-			r.unlockVTXOs(ctx, locked.SelectedVTXOs)
+		outpoints = append(outpoints, sv.Outpoint)
+	}
 
-			return nil, status.Errorf(codes.Internal,
-				"unable to look up VTXO %s: %v",
-				sv.Outpoint, err)
-		}
+	selectedInputs, err := BuildTransferInputs(
+		ctx, r.server.vtxoStore, outpoints,
+	)
+	if err != nil {
+		r.unlockVTXOs(ctx, locked.SelectedVTXOs)
 
-		selectedInputs = append(selectedInputs,
-			oor.TransferInput{
-				VTXO:            desc,
-				OwnerLeafScript: desc.PkScript,
-			})
+		return nil, status.Errorf(codes.Internal,
+			"unable to build transfer inputs: %v", err)
 	}
 
 	// Build the recipient output for the OOR transfer.

--- a/darepod/rpc_wallet.go
+++ b/darepod/rpc_wallet.go
@@ -31,13 +31,14 @@ func (r *RPCServer) GenSeed(ctx context.Context,
 	}
 
 	// GenSeed is only available when no wallet exists yet.
-	if r.server.walletState != WalletStateNone {
+	currentState := WalletState(r.server.walletState.Load())
+	if currentState != WalletStateNone {
 		return nil, status.Errorf(codes.FailedPrecondition,
 			"wallet already exists (state=%d)",
-			r.server.walletState)
+			currentState)
 	}
 
-	mnemonic, err := GenSeed(req.SeedPassphrase)
+	mnemonic, err := GenerateSeed(req.SeedPassphrase)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal,
 			"unable to generate seed: %v", err)
@@ -61,15 +62,31 @@ func (r *RPCServer) InitWallet(ctx context.Context,
 			"InitWallet is only available in lwwallet mode")
 	}
 
-	// InitWallet is only available when no wallet exists yet.
-	if r.server.walletState != WalletStateNone {
+	// Atomically check that no wallet exists and claim the
+	// transition so a concurrent InitWallet call cannot race
+	// past this point. CompareAndSwap ensures only one caller
+	// wins the None → Locked transition.
+	if !r.server.walletState.CompareAndSwap(
+		int32(WalletStateNone), int32(WalletStateLocked),
+	) {
+
+		state := WalletState(r.server.walletState.Load())
+
 		return nil, status.Errorf(codes.FailedPrecondition,
-			"wallet already exists (state=%d)",
-			r.server.walletState)
+			"wallet already exists (state=%d)", state)
+	}
+
+	// rollbackState resets the wallet state to None so that a
+	// subsequent InitWallet call can retry after a transient
+	// failure (bad mnemonic, disk error, etc.).
+	rollbackState := func() {
+		r.server.walletState.Store(int32(WalletStateNone))
 	}
 
 	// Validate the mnemonic length.
 	if len(req.Mnemonic) != aezeed.NumMnemonicWords {
+		rollbackState()
+
 		return nil, status.Errorf(codes.InvalidArgument,
 			"mnemonic must be %d words, got %d",
 			aezeed.NumMnemonicWords, len(req.Mnemonic))
@@ -77,6 +94,8 @@ func (r *RPCServer) InitWallet(ctx context.Context,
 
 	// Validate password length.
 	if len(req.WalletPassword) < minPasswordLen {
+		rollbackState()
+
 		return nil, status.Errorf(codes.InvalidArgument,
 			"wallet password must be at least %d bytes",
 			minPasswordLen)
@@ -89,6 +108,8 @@ func (r *RPCServer) InitWallet(ctx context.Context,
 	// Derive the raw seed from the mnemonic.
 	seed, err := MnemonicToSeed(mnemonic, req.SeedPassphrase)
 	if err != nil {
+		rollbackState()
+
 		return nil, status.Errorf(codes.InvalidArgument,
 			"invalid mnemonic: %v", err)
 	}
@@ -96,15 +117,27 @@ func (r *RPCServer) InitWallet(ctx context.Context,
 	// Encrypt the seed at rest.
 	ciphertext, err := EncryptSeed(seed, req.WalletPassword)
 	if err != nil {
+		rollbackState()
+
 		return nil, status.Errorf(codes.Internal,
 			"unable to encrypt seed: %v", err)
 	}
 
+	// Resolve the network directory for seed storage.
+	networkDir, err := r.server.cfg.NetworkDir()
+	if err != nil {
+		rollbackState()
+
+		return nil, status.Errorf(codes.Internal,
+			"unable to resolve network directory: %v", err)
+	}
+
 	// Save the encrypted seed to disk.
-	networkDir := r.server.cfg.NetworkDir()
 	seedPath := SeedFilePath(networkDir)
 
 	if err := SaveEncryptedSeed(seedPath, ciphertext); err != nil {
+		rollbackState()
+
 		return nil, status.Errorf(codes.Internal,
 			"unable to save encrypted seed: %v", err)
 	}
@@ -114,6 +147,8 @@ func (r *RPCServer) InitWallet(ctx context.Context,
 
 	// Start the lwwallet with the derived seed.
 	if err := r.server.startLwwallet(ctx, seed); err != nil {
+		rollbackState()
+
 		return nil, status.Errorf(codes.Internal,
 			"unable to start wallet: %v", err)
 	}
@@ -144,11 +179,16 @@ func (r *RPCServer) UnlockWallet(ctx context.Context,
 				"lwwallet mode")
 	}
 
-	// UnlockWallet is only available when the wallet is locked.
-	if r.server.walletState != WalletStateLocked {
+	// Atomically verify the wallet is locked. We do not need a CAS
+	// here because startLwwallet (called below) will perform the
+	// Locked → Ready transition via markWalletReady. A concurrent
+	// UnlockWallet that passes this check will fail inside
+	// startLwwallet when it tries to start a second wallet.
+	currentState := WalletState(r.server.walletState.Load())
+	if currentState != WalletStateLocked {
 		return nil, status.Errorf(codes.FailedPrecondition,
 			"wallet is not locked (state=%d)",
-			r.server.walletState)
+			currentState)
 	}
 
 	// Validate password length.
@@ -159,7 +199,12 @@ func (r *RPCServer) UnlockWallet(ctx context.Context,
 	}
 
 	// Load the encrypted seed from disk.
-	networkDir := r.server.cfg.NetworkDir()
+	networkDir, err := r.server.cfg.NetworkDir()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"unable to resolve network directory: %v", err)
+	}
+
 	seedPath := SeedFilePath(networkDir)
 
 	ciphertext, err := LoadEncryptedSeed(seedPath)
@@ -197,13 +242,17 @@ func (r *RPCServer) UnlockWallet(ctx context.Context,
 
 // deriveIdentityPubkey derives the node identity public key from the
 // active lwwallet using KeyFamilyNodeKey (family 6, index 0). This
-// matches lnd's identity key derivation path.
+// matches lnd's identity key derivation path. DeriveKey (not
+// DeriveNextKey) is used so the identity key is stable across calls.
 func (r *RPCServer) deriveIdentityPubkey(
 	ctx context.Context) (string, error) {
 
 	w := r.server.lwWallet.UnsafeFromSome()
 
-	desc, err := w.DeriveNextKey(ctx, identityKeyFamily)
+	desc, err := w.DeriveKey(ctx, keychain.KeyLocator{
+		Family: identityKeyFamily,
+		Index:  0,
+	})
 	if err != nil {
 		return "", fmt.Errorf("derive identity key: %w", err)
 	}

--- a/darepod/rpc_wallet.go
+++ b/darepod/rpc_wallet.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/lightninglabs/darepo-client/daemonrpc"
-	"github.com/lightningnetwork/lnd/aezeed"
 	"github.com/lightningnetwork/lnd/keychain"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -83,46 +82,6 @@ func (r *RPCServer) InitWallet(ctx context.Context,
 		r.server.walletState.Store(int32(WalletStateNone))
 	}
 
-	// Validate the mnemonic length.
-	if len(req.Mnemonic) != aezeed.NumMnemonicWords {
-		rollbackState()
-
-		return nil, status.Errorf(codes.InvalidArgument,
-			"mnemonic must be %d words, got %d",
-			aezeed.NumMnemonicWords, len(req.Mnemonic))
-	}
-
-	// Validate password length.
-	if len(req.WalletPassword) < minPasswordLen {
-		rollbackState()
-
-		return nil, status.Errorf(codes.InvalidArgument,
-			"wallet password must be at least %d bytes",
-			minPasswordLen)
-	}
-
-	// Convert the string slice to an aezeed.Mnemonic array.
-	var mnemonic aezeed.Mnemonic
-	copy(mnemonic[:], req.Mnemonic)
-
-	// Derive the raw seed from the mnemonic.
-	seed, err := MnemonicToSeed(mnemonic, req.SeedPassphrase)
-	if err != nil {
-		rollbackState()
-
-		return nil, status.Errorf(codes.InvalidArgument,
-			"invalid mnemonic: %v", err)
-	}
-
-	// Encrypt the seed at rest.
-	ciphertext, err := EncryptSeed(seed, req.WalletPassword)
-	if err != nil {
-		rollbackState()
-
-		return nil, status.Errorf(codes.Internal,
-			"unable to encrypt seed: %v", err)
-	}
-
 	// Resolve the network directory for seed storage.
 	networkDir, err := r.server.cfg.NetworkDir()
 	if err != nil {
@@ -132,18 +91,23 @@ func (r *RPCServer) InitWallet(ctx context.Context,
 			"unable to resolve network directory: %v", err)
 	}
 
-	// Save the encrypted seed to disk.
-	seedPath := SeedFilePath(networkDir)
-
-	if err := SaveEncryptedSeed(seedPath, ciphertext); err != nil {
+	// Delegate to the package-level function that validates the
+	// mnemonic, derives the seed, encrypts it, and saves it to
+	// disk. This logic is extracted so a future SDK can call it
+	// directly without going through gRPC.
+	seed, err := InitWalletFromMnemonic(
+		req.Mnemonic, req.SeedPassphrase,
+		req.WalletPassword, networkDir,
+	)
+	if err != nil {
 		rollbackState()
 
 		return nil, status.Errorf(codes.Internal,
-			"unable to save encrypted seed: %v", err)
+			"unable to initialize wallet: %v", err)
 	}
 
 	log.InfoS(ctx, "Wallet seed encrypted and saved",
-		"path", seedPath)
+		"path", SeedFilePath(networkDir))
 
 	// Start the lwwallet with the derived seed.
 	if err := r.server.startLwwallet(ctx, seed); err != nil {
@@ -191,33 +155,22 @@ func (r *RPCServer) UnlockWallet(ctx context.Context,
 			currentState)
 	}
 
-	// Validate password length.
-	if len(req.WalletPassword) < minPasswordLen {
-		return nil, status.Errorf(codes.InvalidArgument,
-			"wallet password must be at least %d bytes",
-			minPasswordLen)
-	}
-
-	// Load the encrypted seed from disk.
+	// Resolve the network directory for seed lookup.
 	networkDir, err := r.server.cfg.NetworkDir()
 	if err != nil {
 		return nil, status.Errorf(codes.Internal,
 			"unable to resolve network directory: %v", err)
 	}
 
-	seedPath := SeedFilePath(networkDir)
-
-	ciphertext, err := LoadEncryptedSeed(seedPath)
+	// Delegate to the package-level function that loads the
+	// encrypted seed from disk and decrypts it. This logic is
+	// extracted so a future SDK can call it directly.
+	seed, err := UnlockWalletFromDisk(
+		networkDir, req.WalletPassword,
+	)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal,
-			"unable to load encrypted seed: %v", err)
-	}
-
-	// Decrypt the seed.
-	seed, err := DecryptSeed(ciphertext, req.WalletPassword)
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument,
-			"unable to decrypt seed: %v", err)
+			"unable to unlock wallet: %v", err)
 	}
 
 	log.InfoS(ctx, "Wallet seed decrypted via UnlockWallet RPC")

--- a/darepod/rpc_wallet.go
+++ b/darepod/rpc_wallet.go
@@ -1,0 +1,212 @@
+package darepod
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/lightningnetwork/lnd/aezeed"
+	"github.com/lightningnetwork/lnd/keychain"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// identityKeyFamily is the key family used to derive the daemon's
+// identity public key. This matches lnd's KeyFamilyNodeKey (family 6)
+// so the derived key sits at m/1017'/coinType'/6'/0/0.
+const identityKeyFamily = keychain.KeyFamilyNodeKey
+
+// GenSeed generates a new aezeed cipher seed mnemonic. This is the
+// first step when creating a new lwwallet-backed wallet. The returned
+// mnemonic must be passed to InitWallet to finalize wallet creation.
+// Only available in lwwallet mode when no wallet exists yet.
+func (r *RPCServer) GenSeed(ctx context.Context,
+	req *daemonrpc.GenSeedRequest) (*daemonrpc.GenSeedResponse,
+	error) {
+
+	// GenSeed is only available in lwwallet mode.
+	if r.server.cfg.Wallet.Type != WalletTypeLwwallet {
+		return nil, status.Errorf(codes.FailedPrecondition,
+			"GenSeed is only available in lwwallet mode")
+	}
+
+	// GenSeed is only available when no wallet exists yet.
+	if r.server.walletState != WalletStateNone {
+		return nil, status.Errorf(codes.FailedPrecondition,
+			"wallet already exists (state=%d)",
+			r.server.walletState)
+	}
+
+	mnemonic, err := GenSeed(req.SeedPassphrase)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"unable to generate seed: %v", err)
+	}
+
+	return &daemonrpc.GenSeedResponse{
+		Mnemonic: mnemonic[:],
+	}, nil
+}
+
+// InitWallet creates a new wallet from a previously generated aezeed
+// mnemonic. The wallet is encrypted at rest with the provided
+// password. Only available in lwwallet mode when no wallet exists.
+func (r *RPCServer) InitWallet(ctx context.Context,
+	req *daemonrpc.InitWalletRequest) (
+	*daemonrpc.InitWalletResponse, error) {
+
+	// InitWallet is only available in lwwallet mode.
+	if r.server.cfg.Wallet.Type != WalletTypeLwwallet {
+		return nil, status.Errorf(codes.FailedPrecondition,
+			"InitWallet is only available in lwwallet mode")
+	}
+
+	// InitWallet is only available when no wallet exists yet.
+	if r.server.walletState != WalletStateNone {
+		return nil, status.Errorf(codes.FailedPrecondition,
+			"wallet already exists (state=%d)",
+			r.server.walletState)
+	}
+
+	// Validate the mnemonic length.
+	if len(req.Mnemonic) != aezeed.NumMnemonicWords {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"mnemonic must be %d words, got %d",
+			aezeed.NumMnemonicWords, len(req.Mnemonic))
+	}
+
+	// Validate password length.
+	if len(req.WalletPassword) < minPasswordLen {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"wallet password must be at least %d bytes",
+			minPasswordLen)
+	}
+
+	// Convert the string slice to an aezeed.Mnemonic array.
+	var mnemonic aezeed.Mnemonic
+	copy(mnemonic[:], req.Mnemonic)
+
+	// Derive the raw seed from the mnemonic.
+	seed, err := MnemonicToSeed(mnemonic, req.SeedPassphrase)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"invalid mnemonic: %v", err)
+	}
+
+	// Encrypt the seed at rest.
+	ciphertext, err := EncryptSeed(seed, req.WalletPassword)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"unable to encrypt seed: %v", err)
+	}
+
+	// Save the encrypted seed to disk.
+	networkDir := r.server.cfg.NetworkDir()
+	seedPath := SeedFilePath(networkDir)
+
+	if err := SaveEncryptedSeed(seedPath, ciphertext); err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"unable to save encrypted seed: %v", err)
+	}
+
+	log.InfoS(ctx, "Wallet seed encrypted and saved",
+		"path", seedPath)
+
+	// Start the lwwallet with the derived seed.
+	if err := r.server.startLwwallet(ctx, seed); err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"unable to start wallet: %v", err)
+	}
+
+	// Derive identity pubkey for the response.
+	identityPubkey, err := r.deriveIdentityPubkey(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"unable to derive identity pubkey: %v", err)
+	}
+
+	return &daemonrpc.InitWalletResponse{
+		IdentityPubkey: identityPubkey,
+	}, nil
+}
+
+// UnlockWallet decrypts an existing wallet seed using the provided
+// password and starts the wallet subsystem. Only available in
+// lwwallet mode when the wallet is locked.
+func (r *RPCServer) UnlockWallet(ctx context.Context,
+	req *daemonrpc.UnlockWalletRequest) (
+	*daemonrpc.UnlockWalletResponse, error) {
+
+	// UnlockWallet is only available in lwwallet mode.
+	if r.server.cfg.Wallet.Type != WalletTypeLwwallet {
+		return nil, status.Errorf(codes.FailedPrecondition,
+			"UnlockWallet is only available in "+
+				"lwwallet mode")
+	}
+
+	// UnlockWallet is only available when the wallet is locked.
+	if r.server.walletState != WalletStateLocked {
+		return nil, status.Errorf(codes.FailedPrecondition,
+			"wallet is not locked (state=%d)",
+			r.server.walletState)
+	}
+
+	// Validate password length.
+	if len(req.WalletPassword) < minPasswordLen {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"wallet password must be at least %d bytes",
+			minPasswordLen)
+	}
+
+	// Load the encrypted seed from disk.
+	networkDir := r.server.cfg.NetworkDir()
+	seedPath := SeedFilePath(networkDir)
+
+	ciphertext, err := LoadEncryptedSeed(seedPath)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"unable to load encrypted seed: %v", err)
+	}
+
+	// Decrypt the seed.
+	seed, err := DecryptSeed(ciphertext, req.WalletPassword)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"unable to decrypt seed: %v", err)
+	}
+
+	log.InfoS(ctx, "Wallet seed decrypted via UnlockWallet RPC")
+
+	// Start the lwwallet with the decrypted seed.
+	if err := r.server.startLwwallet(ctx, seed); err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"unable to start wallet: %v", err)
+	}
+
+	// Derive identity pubkey for the response.
+	identityPubkey, err := r.deriveIdentityPubkey(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"unable to derive identity pubkey: %v", err)
+	}
+
+	return &daemonrpc.UnlockWalletResponse{
+		IdentityPubkey: identityPubkey,
+	}, nil
+}
+
+// deriveIdentityPubkey derives the node identity public key from the
+// active lwwallet using KeyFamilyNodeKey (family 6, index 0). This
+// matches lnd's identity key derivation path.
+func (r *RPCServer) deriveIdentityPubkey(
+	ctx context.Context) (string, error) {
+
+	w := r.server.lwWallet.UnsafeFromSome()
+
+	desc, err := w.DeriveNextKey(ctx, identityKeyFamily)
+	if err != nil {
+		return "", fmt.Errorf("derive identity key: %w", err)
+	}
+
+	return fmt.Sprintf("%x", desc.PubKey.SerializeCompressed()), nil
+}

--- a/darepod/seed_manager_test.go
+++ b/darepod/seed_manager_test.go
@@ -137,7 +137,8 @@ func TestLoadSeedFromEnv(t *testing.T) {
 	require.Nil(t, seed)
 
 	// Set a valid 32-byte hex seed.
-	hexSeed := "0102030405060708091011121314151617181920212223242526272829303132"
+	hexSeed := "01020304050607080910111213141516" +
+		"17181920212223242526272829303132"
 	t.Setenv(seedEnvVar, hexSeed)
 	seed, err = LoadSeedFromEnv()
 	require.NoError(t, err)

--- a/darepod/seed_manager_test.go
+++ b/darepod/seed_manager_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestGenSeedProduces24Words verifies that GenSeed returns a valid
-// 24-word mnemonic.
-func TestGenSeedProduces24Words(t *testing.T) {
+// TestGenerateSeedProduces24Words verifies that GenerateSeed returns a
+// valid 24-word mnemonic.
+func TestGenerateSeedProduces24Words(t *testing.T) {
 	mnemonic, err := GenerateSeed(nil)
 	require.NoError(t, err)
 

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -9,6 +9,8 @@ import (
 	"net"
 	"os"
 	"strings"
+	"sync"
+	"sync/atomic"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
@@ -53,8 +55,10 @@ import (
 // WalletState represents the lifecycle state of the wallet subsystem.
 // In lwwallet mode, the wallet transitions through these states during
 // daemon startup: None → Locked → Ready (or None → Ready if the seed
-// is provided via environment variable).
-type WalletState int
+// is provided via environment variable). The underlying type is int32
+// so it can be stored in an atomic.Int32 for lock-free concurrent
+// access.
+type WalletState int32
 
 const (
 	// WalletStateNone indicates no wallet has been created yet.
@@ -106,8 +110,16 @@ type Server struct {
 	// walletState tracks the lifecycle state of the wallet
 	// subsystem. In lnd mode this is always WalletStateReady
 	// after successful lnd connection. In lwwallet mode it
-	// transitions through None → Locked → Ready.
-	walletState WalletState
+	// transitions through None → Locked → Ready. Stored as
+	// atomic.Int32 for lock-free concurrent access from gRPC
+	// handler goroutines and the startup goroutine. State
+	// transitions use CompareAndSwap to prevent TOCTOU races.
+	walletState atomic.Int32
+
+	// walletReadyOnce ensures the walletReady channel is closed
+	// exactly once, preventing a double-close panic if
+	// markWalletReady is called concurrently.
+	walletReadyOnce sync.Once
 
 	// walletReady is closed when the wallet subsystem has been
 	// fully initialized and is ready to service requests. RPC
@@ -158,11 +170,16 @@ func (s *Server) isWalletReady() bool {
 	}
 }
 
-// markWalletReady closes the walletReady channel, signaling to all
-// waiting RPC handlers that the wallet is operational.
+// markWalletReady atomically stores WalletStateReady and closes the
+// walletReady channel, signaling to all waiting RPC handlers that the
+// wallet is operational. The channel close is guarded by sync.Once to
+// prevent a double-close panic if this method is called concurrently.
 func (s *Server) markWalletReady() {
-	s.walletState = WalletStateReady
-	close(s.walletReady)
+	s.walletState.Store(int32(WalletStateReady))
+
+	s.walletReadyOnce.Do(func() {
+		close(s.walletReady)
+	})
 }
 
 // RunUntilShutdown starts all subsystems and blocks until the shutdown
@@ -444,7 +461,9 @@ func (s *Server) RunUntilShutdown(interceptor signal.Interceptor) error {
 
 		log.InfoS(ctx, "Wallet not ready, waiting for "+
 			"InitWallet or UnlockWallet RPC",
-			"state", s.walletState)
+			slog.Int("state", int(
+				s.walletState.Load(),
+			)))
 	}
 
 	log.InfoS(ctx, "Daemon ready")
@@ -514,21 +533,27 @@ func (s *Server) tryAutoUnlockLwwallet(ctx context.Context) {
 		return
 	}
 
-	networkDir := s.cfg.NetworkDir()
+	networkDir, err := s.cfg.NetworkDir()
+	if err != nil {
+		log.ErrorS(ctx, "Unable to resolve network directory",
+			err)
+
+		return
+	}
 
 	// Check for an encrypted seed file on disk.
 	if !SeedFileExists(networkDir) {
 		log.InfoS(ctx, "No wallet seed found, awaiting "+
 			"InitWallet RPC")
 
-		s.walletState = WalletStateNone
+		s.walletState.Store(int32(WalletStateNone))
 
 		return
 	}
 
 	// Encrypted seed exists. Try to find a password for
 	// auto-unlock: check env var first, then password file.
-	s.walletState = WalletStateLocked
+	s.walletState.Store(int32(WalletStateLocked))
 
 	password, ok := LoadPasswordFromEnv()
 	if !ok && s.cfg.Wallet.PasswordFile != "" {

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/arkrpc"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
@@ -25,6 +26,7 @@ import (
 	"github.com/lightninglabs/darepo-client/lib/actormsg"
 	"github.com/lightninglabs/darepo-client/lib/types"
 	"github.com/lightninglabs/darepo-client/lndbackend"
+	"github.com/lightninglabs/darepo-client/lwwallet"
 	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
 	mailboxrpc "github.com/lightninglabs/darepo-client/mailbox/rpc"
 	"github.com/lightninglabs/darepo-client/oor"
@@ -38,12 +40,36 @@ import (
 	lndbuild "github.com/lightningnetwork/lnd/build"
 	"github.com/lightningnetwork/lnd/clock"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/signal"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
+)
+
+// WalletState represents the lifecycle state of the wallet subsystem.
+// In lwwallet mode, the wallet transitions through these states during
+// daemon startup: None → Locked → Ready (or None → Ready if the seed
+// is provided via environment variable).
+type WalletState int
+
+const (
+	// WalletStateNone indicates no wallet has been created yet.
+	// The daemon accepts GenSeed and InitWallet RPCs in this state.
+	WalletStateNone WalletState = iota
+
+	// WalletStateLocked indicates an encrypted seed file exists but
+	// the wallet has not been unlocked. The daemon accepts
+	// UnlockWallet RPCs in this state.
+	WalletStateLocked
+
+	// WalletStateReady indicates the wallet is initialized and
+	// operational. All wallet RPCs (GetBalance, NewAddress, etc.)
+	// are available.
+	WalletStateReady
 )
 
 // Main is the true entry point for the daemon. It is called after CLI flag
@@ -57,9 +83,9 @@ func Main(cfg *Config, interceptor signal.Interceptor) error {
 	return srv.RunUntilShutdown(interceptor)
 }
 
-// Server is the top-level daemon orchestrator. It owns the lnd connection,
-// the mailbox transport runtime, the indexer client, and the daemon's own
-// gRPC server.
+// Server is the top-level daemon orchestrator. It owns the wallet
+// backend (lnd or lwwallet), the mailbox transport runtime, the
+// indexer client, and the daemon's own gRPC server.
 type Server struct {
 	cfg *Config
 
@@ -67,15 +93,42 @@ type Server struct {
 
 	db            *db.SqliteStore
 	deliveryStore actor.DeliveryStore
+	vtxoStore     *db.VTXOPersistenceStore
 
-	lnd     *lndclient.GrpcLndServices
+	// lnd holds the lndclient connection when wallet.type is "lnd".
+	// It is None in lwwallet mode.
+	lnd fn.Option[*lndclient.GrpcLndServices]
+
+	// lwWallet holds the lightweight wallet instance when
+	// wallet.type is "lwwallet". It is None in lnd mode.
+	lwWallet fn.Option[*lwwallet.Wallet]
+
+	// walletState tracks the lifecycle state of the wallet
+	// subsystem. In lnd mode this is always WalletStateReady
+	// after successful lnd connection. In lwwallet mode it
+	// transitions through None → Locked → Ready.
+	walletState WalletState
+
+	// walletReady is closed when the wallet subsystem has been
+	// fully initialized and is ready to service requests. RPC
+	// handlers that require wallet access select on this channel.
+	walletReady chan struct{}
+
+	// chainParams identifies the active Bitcoin network. In lnd
+	// mode this is populated from the lnd connection; in lwwallet
+	// mode it is derived from the config's network string.
+	chainParams *chaincfg.Params
+
 	runtime *serverconn.Runtime
 	ark     *arkrpc.ArkServiceMailboxClient
 	indexer *indexer.Client
 
 	actorSystem  *actor.ActorSystem
 	chainBackend chainsource.ChainBackend
-	oorActor     *oor.OORClientActor
+	walletRef    fn.Option[actor.ActorRef[
+		wallet.WalletMsg, wallet.WalletResp,
+	]]
+	oorActor *oor.OORClientActor
 
 	serverConn *grpc.ClientConn
 
@@ -84,16 +137,40 @@ type Server struct {
 	mailboxMux *mailboxrpc.ServeMux
 }
 
-// NewServer allocates a Server from a validated Config. The server is inert
-// until RunUntilShutdown is called.
+// NewServer allocates a Server from a validated Config. The server is
+// inert until RunUntilShutdown is called. The walletReady channel is
+// initialized here so RPC handlers can select on it immediately.
 func NewServer(cfg *Config) (*Server, error) {
 	return &Server{
-		cfg: cfg,
+		cfg:         cfg,
+		walletReady: make(chan struct{}),
 	}, nil
 }
 
+// isWalletReady returns true if the wallet subsystem has been fully
+// initialized. This is a non-blocking check.
+func (s *Server) isWalletReady() bool {
+	select {
+	case <-s.walletReady:
+		return true
+	default:
+		return false
+	}
+}
+
+// markWalletReady closes the walletReady channel, signaling to all
+// waiting RPC handlers that the wallet is operational.
+func (s *Server) markWalletReady() {
+	s.walletState = WalletStateReady
+	close(s.walletReady)
+}
+
 // RunUntilShutdown starts all subsystems and blocks until the shutdown
-// interceptor fires or a fatal error occurs.
+// interceptor fires or a fatal error occurs. The startup sequence
+// branches on the configured wallet type: in lnd mode, the daemon
+// connects to an external lnd node and derives all backends from it;
+// in lwwallet mode, the daemon starts an in-process wallet and may
+// need to wait for wallet creation or unlock via RPC.
 //
 //nolint:funlen
 func (s *Server) RunUntilShutdown(interceptor signal.Interceptor) error {
@@ -135,24 +212,41 @@ func (s *Server) RunUntilShutdown(interceptor signal.Interceptor) error {
 	log.InfoS(ctx, "Starting darepod",
 		slog.String("version", build.Version()),
 		slog.String("commit", build.CommitHash),
-		slog.String("network", s.cfg.Network))
+		slog.String("network", s.cfg.Network),
+		slog.String("wallet_type", s.cfg.Wallet.Type))
 
-	// -------------------------------------------------------
-	// 1. Connect to lnd.
-	// -------------------------------------------------------
-	log.InfoS(ctx, "Connecting to lnd",
-		slog.String("host", s.cfg.Lnd.Host))
-
-	lndServices, err := s.connectLnd(ctx)
+	// Derive chain params from the config network string. In lnd
+	// mode this is overwritten by the lnd connection's chain
+	// params, but we need it early for lwwallet mode.
+	chainParams, err := networkToChainParams(s.cfg.Network)
 	if err != nil {
-		return fmt.Errorf("unable to connect to lnd: %w", err)
+		return fmt.Errorf("invalid network: %w", err)
 	}
-	s.lnd = lndServices
-	defer s.lnd.Close()
+	s.chainParams = chainParams
 
-	log.InfoS(ctx, "Connected to lnd",
-		"alias", s.lnd.NodeAlias,
-		"pubkey", s.lnd.NodePubkey)
+	// -------------------------------------------------------
+	// 1. Initialize wallet backend (lnd or lwwallet).
+	// -------------------------------------------------------
+	switch s.cfg.Wallet.Type {
+	case WalletTypeLnd:
+		if err := s.initLndBackend(ctx); err != nil {
+			return err
+		}
+		defer s.lnd.UnsafeFromSome().Close()
+
+	case WalletTypeLwwallet:
+		// In lwwallet mode, we attempt auto-unlock here.
+		// If no seed is available yet (no env var, no seed
+		// file, or no password for unlock), the daemon
+		// continues startup with the wallet in a non-ready
+		// state and waits for InitWallet or UnlockWallet
+		// RPCs.
+		s.tryAutoUnlockLwwallet(ctx)
+
+	default:
+		return fmt.Errorf("unknown wallet type %q",
+			s.cfg.Wallet.Type)
+	}
 
 	// -------------------------------------------------------
 	// 2. Connect to the ark operator's mailbox edge server.
@@ -195,17 +289,8 @@ func (s *Server) RunUntilShutdown(interceptor signal.Interceptor) error {
 	// -------------------------------------------------------
 	// 4. Create and register the chain source actor.
 	// -------------------------------------------------------
-	// The chain backend adapts lndclient's chain notifier, fee
-	// estimator, and wallet kit into the unified ChainBackend
-	// interface used by the chainsource actor.
-	s.chainBackend = chainbackends.NewLNDBackendFromLndClient(
-		chainbackends.LNDBackendFromLndClientConfig{
-			LND: &s.lnd.LndServices,
-		},
-	)
-
-	if err := s.chainBackend.Start(); err != nil {
-		return fmt.Errorf("unable to start chain backend: %w", err)
+	if err := s.initChainBackend(ctx); err != nil {
+		return err
 	}
 	defer func() {
 		_ = s.chainBackend.Stop()
@@ -233,6 +318,13 @@ func (s *Server) RunUntilShutdown(interceptor signal.Interceptor) error {
 	defer func() {
 		_ = s.db.Close()
 	}()
+
+	// Create the VTXO store for RPC queries (ListVTXOs, GetBalance).
+	clk := clock.NewDefaultClock()
+	dbStore := db.NewStore(
+		s.db.DB, s.db.Queries, s.db.Backend(), log,
+	)
+	s.vtxoStore = dbStore.NewVTXOStore(clk)
 
 	// -------------------------------------------------------
 	// 6. Start the daemon's own gRPC server and mailbox mux.
@@ -316,12 +408,298 @@ func (s *Server) RunUntilShutdown(interceptor signal.Interceptor) error {
 	s.initRPCClients(ctx)
 
 	// -------------------------------------------------------
+	// 9-11. Register wallet, round, and OOR actors.
+	// -------------------------------------------------------
+	// These steps require the wallet to be ready. In lnd mode
+	// the wallet is always ready at this point. In lwwallet
+	// mode, if the wallet was auto-unlocked (via env var or
+	// password file), it is also ready. Otherwise, these steps
+	// are deferred until the wallet is unlocked via RPC (see
+	// startWalletDependentActors).
+	if s.isWalletReady() {
+		if err := s.startWalletDependentActors(
+			ctx, chainSourceRef, timeoutRef,
+		); err != nil {
+			return err
+		}
+	} else {
+		// Launch a goroutine that waits for the wallet to
+		// become ready (via InitWallet or UnlockWallet RPC)
+		// and then starts the wallet-dependent actors.
+		go func() {
+			select {
+			case <-s.walletReady:
+			case <-ctx.Done():
+				return
+			}
+
+			if err := s.startWalletDependentActors(
+				ctx, chainSourceRef, timeoutRef,
+			); err != nil {
+				log.ErrorS(ctx,
+					"Failed to start wallet actors",
+					err)
+			}
+		}()
+
+		log.InfoS(ctx, "Wallet not ready, waiting for "+
+			"InitWallet or UnlockWallet RPC",
+			"state", s.walletState)
+	}
+
+	log.InfoS(ctx, "Daemon ready")
+
+	// -------------------------------------------------------
+	// 12. Block until shutdown.
+	// -------------------------------------------------------
+	<-interceptor.ShutdownChannel()
+
+	log.InfoS(ctx, "Shutting down darepod")
+
+	return nil
+}
+
+// initLndBackend connects to the lnd node and populates the server's
+// lnd connection, chain params, and marks the wallet as ready.
+func (s *Server) initLndBackend(ctx context.Context) error {
+	log.InfoS(ctx, "Connecting to lnd",
+		"host", s.cfg.Lnd.Host)
+
+	lndServices, err := s.connectLnd(ctx)
+	if err != nil {
+		return fmt.Errorf("unable to connect to lnd: %w", err)
+	}
+	s.lnd = fn.Some(lndServices)
+
+	// Use lnd's chain params as the authoritative source.
+	s.chainParams = lndServices.ChainParams
+
+	log.InfoS(ctx, "Connected to lnd",
+		"alias", lndServices.NodeAlias,
+		"pubkey", lndServices.NodePubkey)
+
+	// In lnd mode the wallet is immediately ready.
+	s.markWalletReady()
+
+	return nil
+}
+
+// tryAutoUnlockLwwallet attempts to initialize the lwwallet backend
+// at startup without user interaction. It checks for a seed in the
+// environment variable first, then checks for an encrypted seed file
+// on disk with a password from the environment or a password file.
+// If neither source provides a complete seed+password pair, the daemon
+// starts with the wallet in a non-ready state.
+func (s *Server) tryAutoUnlockLwwallet(ctx context.Context) {
+	// Check for a raw seed in the environment (dev/CI path).
+	seed, err := LoadSeedFromEnv()
+	if err != nil {
+		log.WarnS(ctx, "Invalid seed in environment variable",
+			err)
+
+		return
+	}
+
+	if seed != nil {
+		log.InfoS(ctx, "Loaded seed from environment variable")
+
+		if err := s.startLwwallet(ctx, *seed); err != nil {
+			log.ErrorS(ctx,
+				"Failed to start lwwallet from env seed",
+				err)
+
+			return
+		}
+
+		return
+	}
+
+	networkDir := s.cfg.NetworkDir()
+
+	// Check for an encrypted seed file on disk.
+	if !SeedFileExists(networkDir) {
+		log.InfoS(ctx, "No wallet seed found, awaiting "+
+			"InitWallet RPC")
+
+		s.walletState = WalletStateNone
+
+		return
+	}
+
+	// Encrypted seed exists. Try to find a password for
+	// auto-unlock: check env var first, then password file.
+	s.walletState = WalletStateLocked
+
+	password, ok := LoadPasswordFromEnv()
+	if !ok && s.cfg.Wallet.PasswordFile != "" {
+		var err error
+		password, err = LoadPasswordFromFile(
+			s.cfg.Wallet.PasswordFile,
+		)
+		if err != nil {
+			log.WarnS(ctx,
+				"Failed to read wallet password file",
+				err)
+
+			return
+		}
+
+		ok = true
+	}
+
+	if !ok {
+		log.InfoS(ctx, "Encrypted seed found but no password "+
+			"available, awaiting UnlockWallet RPC")
+
+		return
+	}
+
+	// We have both seed file and password: auto-unlock.
+	seedPath := SeedFilePath(networkDir)
+	ciphertext, err := LoadEncryptedSeed(seedPath)
+	if err != nil {
+		log.ErrorS(ctx, "Failed to load encrypted seed", err)
+
+		return
+	}
+
+	decryptedSeed, err := DecryptSeed(ciphertext, password)
+	if err != nil {
+		log.ErrorS(ctx, "Failed to decrypt seed at startup",
+			err)
+
+		return
+	}
+
+	log.InfoS(ctx, "Auto-unlocking lwwallet from encrypted seed")
+
+	if err := s.startLwwallet(ctx, decryptedSeed); err != nil {
+		log.ErrorS(ctx, "Failed to start lwwallet", err)
+
+		return
+	}
+}
+
+// startLwwallet creates and starts the lightweight wallet from the
+// given raw seed. On success it populates s.lwWallet and marks the
+// wallet as ready.
+func (s *Server) startLwwallet(ctx context.Context,
+	seed [rawSeedLen]byte) error {
+
+	networkDir := s.cfg.NetworkDir()
+
+	pollInterval := s.cfg.Wallet.PollInterval
+	if pollInterval == 0 {
+		pollInterval = DefaultEsploraPollInterval
+	}
+
+	recoveryWindow := s.cfg.Wallet.RecoveryWindow
+	if recoveryWindow == 0 {
+		recoveryWindow = DefaultRecoveryWindow
+	}
+
+	w, err := lwwallet.New(lwwallet.Config{
+		Seed:           seed,
+		EsploraURL:     s.cfg.Wallet.EsploraURL,
+		ChainParams:    s.chainParams,
+		PollInterval:   pollInterval,
+		RecoveryWindow: recoveryWindow,
+		DBDir:          networkDir,
+		Log:            fn.Some(log),
+	})
+	if err != nil {
+		return fmt.Errorf("create lwwallet: %w", err)
+	}
+
+	if err := w.Start(); err != nil {
+		return fmt.Errorf("start lwwallet: %w", err)
+	}
+
+	s.lwWallet = fn.Some(w)
+
+	log.InfoS(ctx, "Lightweight wallet started")
+
+	s.markWalletReady()
+
+	return nil
+}
+
+// initChainBackend creates and starts the chain backend appropriate
+// for the configured wallet type. In lnd mode it uses the lndclient
+// chain notifier and fee estimator. In lwwallet mode it uses the
+// lwwallet's Esplora-backed chain backend.
+func (s *Server) initChainBackend(ctx context.Context) error {
+	// alreadyStarted tracks whether the chain backend was
+	// obtained from an already-running lwwallet, in which case
+	// we must not call Start() again (it is not idempotent and
+	// would create duplicate polling loops).
+	var alreadyStarted bool
+
+	switch s.cfg.Wallet.Type {
+	case WalletTypeLnd:
+		lndSvc := s.lnd.UnsafeFromSome()
+		s.chainBackend = chainbackends.NewLNDBackendFromLndClient(
+			chainbackends.LNDBackendFromLndClientConfig{
+				LND: &lndSvc.LndServices,
+			},
+		)
+
+	case WalletTypeLwwallet:
+		// If the lwwallet is already started (auto-unlock
+		// succeeded), use its chain backend. Otherwise, we
+		// need a standalone Esplora chain backend that can
+		// serve the chain source actor before the wallet is
+		// ready.
+		if s.lwWallet.IsSome() {
+			w := s.lwWallet.UnsafeFromSome()
+			s.chainBackend = w.ChainBackend()
+			alreadyStarted = true
+		} else {
+			s.chainBackend = lwwallet.NewChainBackend(
+				lwwallet.NewEsploraClient(
+					s.cfg.Wallet.EsploraURL, log,
+				),
+				s.cfg.Wallet.PollInterval, log,
+			)
+		}
+
+	default:
+		return fmt.Errorf("unknown wallet type %q",
+			s.cfg.Wallet.Type)
+	}
+
+	if !alreadyStarted {
+		if err := s.chainBackend.Start(); err != nil {
+			return fmt.Errorf(
+				"unable to start chain backend: %w", err,
+			)
+		}
+	}
+
+	log.InfoS(ctx, "Chain backend started",
+		"type", s.cfg.Wallet.Type)
+
+	return nil
+}
+
+// startWalletDependentActors initializes and registers the wallet,
+// round, and OOR actors. This is called either synchronously during
+// startup (when the wallet is immediately ready) or asynchronously
+// after an InitWallet/UnlockWallet RPC in lwwallet mode.
+func (s *Server) startWalletDependentActors(ctx context.Context,
+	chainSourceRef actor.ActorRef[
+		chainsource.ChainSourceMsg, chainsource.ChainSourceResp,
+	],
+	timeoutRef actor.TellOnlyRef[timeout.Msg]) error {
+
+	// -------------------------------------------------------
 	// 9. Register the wallet (boarding) actor.
 	// -------------------------------------------------------
 	walletRef, err := s.initWalletActor(ctx, chainSourceRef)
 	if err != nil {
 		return err
 	}
+	s.walletRef = fn.Some(walletRef)
 
 	// -------------------------------------------------------
 	// 10. Register the round client actor.
@@ -338,16 +716,8 @@ func (s *Server) RunUntilShutdown(interceptor signal.Interceptor) error {
 	if err := s.initOORActor(ctx); err != nil {
 		return err
 	}
-	defer s.oorActor.Stop()
 
-	log.InfoS(ctx, "Daemon ready")
-
-	// -------------------------------------------------------
-	// 12. Block until shutdown.
-	// -------------------------------------------------------
-	<-interceptor.ShutdownChannel()
-
-	log.InfoS(ctx, "Shutting down darepod")
+	log.InfoS(ctx, "Wallet-dependent actors started")
 
 	return nil
 }
@@ -931,12 +1301,40 @@ func (s *Server) initDatabase(ctx context.Context) error {
 func (s *Server) initRPCClients(ctx context.Context) {
 	s.ark = arkrpc.NewArkServiceMailboxClient(s.runtime.Unary())
 
+	// Determine the node identity pubkey for indexer registration.
+	// In lnd mode this comes from the lnd connection. In lwwallet
+	// mode, the identity is derived from the wallet keyring once
+	// the wallet is ready.
+	var identityPubkey string
+	s.lnd.WhenSome(func(lndSvc *lndclient.GrpcLndServices) {
+		identityPubkey = lndSvc.NodePubkey.String()
+	})
+	s.lwWallet.WhenSome(func(w *lwwallet.Wallet) {
+		// Derive the node identity key from the wallet
+		// keyring. This is safe even if the wallet isn't
+		// fully synced, as it only depends on the seed.
+		desc, err := w.DeriveKey(ctx, keychain.KeyLocator{
+			Family: identityKeyFamily,
+			Index:  0,
+		})
+		if err != nil {
+			log.WarnS(ctx,
+				"Unable to derive identity key for "+
+					"indexer", err)
+		} else {
+			identityPubkey = fmt.Sprintf(
+				"%x",
+				desc.PubKey.SerializeCompressed(),
+			)
+		}
+	})
+
 	// TODO(roasbeef): wire SchnorrSigner from lnd backend once
 	// indexer proof-of-control is enabled in the daemon.
 	s.indexer = indexer.New(
 		s.runtime.Unary(), nil,
 		s.cfg.Server.RemoteMailboxID,
-		s.lnd.NodePubkey.String(),
+		identityPubkey,
 	)
 
 	log.InfoS(ctx, "RPC clients initialized")
@@ -947,22 +1345,35 @@ func (s *Server) initRPCClients(ctx context.Context) {
 // boarding UTXO tracking. It receives block epoch notifications from
 // the chain source actor and can forward confirmation events to
 // registered notifiers (e.g., the round actor).
+//
+// The boarding backend is selected based on the wallet type: in lnd
+// mode it uses lndbackend.BoardingBackend, in lwwallet mode it uses
+// the lwwallet's BoardingBackendAdapter.
 func (s *Server) initWalletActor(ctx context.Context,
 	chainSourceRef actor.ActorRef[
 		chainsource.ChainSourceMsg, chainsource.ChainSourceResp,
 	]) (actor.ActorRef[wallet.WalletMsg, wallet.WalletResp], error) {
 
 	clk := clock.NewDefaultClock()
-	chainParams := s.lnd.ChainParams
 
 	dbStore := db.NewStore(
 		s.db.DB, s.db.Queries, s.db.Backend(), log,
 	)
-	boardingStore := dbStore.NewBoardingStore(chainParams, clk)
+	boardingStore := dbStore.NewBoardingStore(s.chainParams, clk)
 
-	boardingBackend := lndbackend.NewBoardingBackend(
-		s.lnd.WalletKit,
-	)
+	// Select the boarding backend based on wallet type.
+	var boardingBackend wallet.BoardingBackend
+	switch s.cfg.Wallet.Type {
+	case WalletTypeLnd:
+		lndSvc := s.lnd.UnsafeFromSome()
+		boardingBackend = lndbackend.NewBoardingBackend(
+			lndSvc.WalletKit,
+		)
+
+	case WalletTypeLwwallet:
+		w := s.lwWallet.UnsafeFromSome()
+		boardingBackend = w.BoardingBackend()
+	}
 
 	walletActor := wallet.NewArk(
 		boardingBackend, boardingStore, chainSourceRef,
@@ -1006,17 +1417,28 @@ func (s *Server) initRoundActor(ctx context.Context,
 	],
 	timeoutRef actor.TellOnlyRef[timeout.Msg]) error {
 
-	clientWallet := lndbackend.NewClientWallet(
-		s.lnd.Signer, s.lnd.WalletKit,
-	)
+	// Select the client wallet (signing) backend based on
+	// wallet type. In lnd mode, signing goes through lnd's
+	// remote signer. In lwwallet mode, signing is in-process
+	// via btcwallet.
+	var clientWallet round.ClientWallet
+	switch s.cfg.Wallet.Type {
+	case WalletTypeLnd:
+		lndSvc := s.lnd.UnsafeFromSome()
+		clientWallet = lndbackend.NewClientWallet(
+			lndSvc.Signer, lndSvc.WalletKit,
+		)
+
+	case WalletTypeLwwallet:
+		clientWallet = s.lwWallet.UnsafeFromSome()
+	}
 
 	clk := clock.NewDefaultClock()
-	chainParams := s.lnd.ChainParams
 
 	dbStore := db.NewStore(
 		s.db.DB, s.db.Queries, s.db.Backend(), log,
 	)
-	roundStore := dbStore.NewRoundStore(chainParams, clk)
+	roundStore := dbStore.NewRoundStore(s.chainParams, clk)
 
 	// Fetch the operator's terms from the server. These include
 	// the operator pubkey, sweep delay, exit delay, dust limit,
@@ -1037,7 +1459,7 @@ func (s *Server) initRoundActor(ctx context.Context,
 		ServerConn:    s.runtime.TellRef(),
 		ChainSource:   chainSourceRef,
 		WalletActor:   walletRef,
-		ChainParams:   chainParams,
+		ChainParams:   s.chainParams,
 		ActorSystem:   s.actorSystem,
 		TimeoutActor:  timeoutRef,
 		ForfeitCollectionTimeout: s.cfg.
@@ -1092,9 +1514,20 @@ func (s *Server) initOORActor(ctx context.Context) error {
 		s.db.DB, s.db.Queries, s.db.Backend(), log,
 	)
 
-	clientWallet := lndbackend.NewClientWallet(
-		s.lnd.Signer, s.lnd.WalletKit,
-	)
+	// Select the OOR signer based on wallet type. The
+	// SigningOutboxHandler only needs input.Signer for signing
+	// checkpoint PSBTs.
+	var oorSigner input.Signer
+	switch s.cfg.Wallet.Type {
+	case WalletTypeLnd:
+		lndSvc := s.lnd.UnsafeFromSome()
+		oorSigner = lndbackend.NewClientWallet(
+			lndSvc.Signer, lndSvc.WalletKit,
+		)
+
+	case WalletTypeLwwallet:
+		oorSigner = s.lwWallet.UnsafeFromSome()
+	}
 
 	vtxoStore := dbStore.NewVTXOStore(clk)
 	packageStore := dbStore.NewOORArtifactStore(clk)
@@ -1105,7 +1538,7 @@ func (s *Server) initOORActor(ctx context.Context) error {
 	timeoutActor := timeout.NewActor()
 
 	signingHandler := &oor.SigningOutboxHandler{
-		Signer:       clientWallet,
+		Signer:       oorSigner,
 		TimeoutActor: timeoutActor,
 	}
 

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -611,7 +611,10 @@ func (s *Server) tryAutoUnlockLwwallet(ctx context.Context) {
 func (s *Server) startLwwallet(ctx context.Context,
 	seed [rawSeedLen]byte) error {
 
-	networkDir := s.cfg.NetworkDir()
+	networkDir, err := s.cfg.NetworkDir()
+	if err != nil {
+		return fmt.Errorf("resolve network directory: %w", err)
+	}
 
 	pollInterval := s.cfg.Wallet.PollInterval
 	if pollInterval == 0 {
@@ -1292,14 +1295,17 @@ func (s *Server) handleInboundRPC(ctx context.Context,
 // delivery store used by the serverconn runtime for at-least-once
 // envelope delivery.
 func (s *Server) initDatabase(ctx context.Context) error {
-	networkDir := s.cfg.NetworkDir()
+	networkDir, err := s.cfg.NetworkDir()
+	if err != nil {
+		return fmt.Errorf("resolve network directory: %w", err)
+	}
+
 	if err := os.MkdirAll(networkDir, 0700); err != nil {
 		return fmt.Errorf("unable to create data dir: %w", err)
 	}
 
 	sqliteCfg := db.DefaultSqliteConfig(networkDir)
 
-	var err error
 	s.db, err = db.NewSqliteStore(sqliteCfg, log)
 	if err != nil {
 		return fmt.Errorf("unable to open database: %w", err)
@@ -1584,10 +1590,12 @@ func (s *Server) initOORActor(ctx context.Context) error {
 	})
 
 	// Wire the timeout callback ref using the registered service
-	// key. The service key resolves the OOR actor via the
-	// receptionist, and the MapInputRef transforms
-	// *timeout.ExpiredMsg into a DriveEventRequest with
-	// RetryDueEvent targeting the correct session.
+	// key. The OOR actor self-registers with the actor system
+	// during NewOORClientActor (via durable.Start and
+	// RegisterWithReceptionist). The service key resolves the
+	// OOR actor via the receptionist, and the MapInputRef
+	// transforms *timeout.ExpiredMsg into a DriveEventRequest
+	// with RetryDueEvent targeting the correct session.
 	oorKey := oor.NewServiceKey()
 	signingHandler.CallbackRef = oor.NewRetryCallbackRef(
 		oorKey.Ref(s.actorSystem),

--- a/darepod/wallet_ops.go
+++ b/darepod/wallet_ops.go
@@ -1,0 +1,131 @@
+package darepod
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/oor"
+	"github.com/lightninglabs/darepo-client/vtxo"
+	"github.com/lightningnetwork/lnd/aezeed"
+)
+
+// InitWalletFromMnemonic validates a mnemonic, derives the raw seed,
+// encrypts it with the given password, and saves the ciphertext to
+// disk. This is the core logic behind the InitWallet RPC, extracted
+// as a package-level function so it can be reused by a future SDK
+// that bypasses gRPC.
+func InitWalletFromMnemonic(mnemonic []string, seedPassphrase,
+	walletPassword []byte,
+	networkDir string) ([rawSeedLen]byte, error) {
+
+	// Validate the mnemonic length.
+	if len(mnemonic) != aezeed.NumMnemonicWords {
+		return [rawSeedLen]byte{}, fmt.Errorf(
+			"mnemonic must be %d words, got %d",
+			aezeed.NumMnemonicWords, len(mnemonic),
+		)
+	}
+
+	// Validate password length.
+	if len(walletPassword) < minPasswordLen {
+		return [rawSeedLen]byte{}, fmt.Errorf(
+			"wallet password must be at least %d bytes",
+			minPasswordLen,
+		)
+	}
+
+	// Convert the string slice to an aezeed.Mnemonic array.
+	var m aezeed.Mnemonic
+	copy(m[:], mnemonic)
+
+	// Derive the raw seed from the mnemonic.
+	seed, err := MnemonicToSeed(m, seedPassphrase)
+	if err != nil {
+		return [rawSeedLen]byte{}, fmt.Errorf(
+			"invalid mnemonic: %w", err,
+		)
+	}
+
+	// Encrypt the seed at rest.
+	ciphertext, err := EncryptSeed(seed, walletPassword)
+	if err != nil {
+		return [rawSeedLen]byte{}, fmt.Errorf(
+			"encrypting seed: %w", err,
+		)
+	}
+
+	// Save the encrypted seed to disk.
+	seedPath := SeedFilePath(networkDir)
+
+	if err := SaveEncryptedSeed(seedPath, ciphertext); err != nil {
+		return [rawSeedLen]byte{}, fmt.Errorf(
+			"saving encrypted seed: %w", err,
+		)
+	}
+
+	return seed, nil
+}
+
+// UnlockWalletFromDisk loads the encrypted seed from the network
+// directory and decrypts it with the given password. This is the core
+// logic behind the UnlockWallet RPC, extracted so it can be reused by
+// a future SDK.
+func UnlockWalletFromDisk(networkDir string,
+	walletPassword []byte) ([rawSeedLen]byte, error) {
+
+	// Validate password length.
+	if len(walletPassword) < minPasswordLen {
+		return [rawSeedLen]byte{}, fmt.Errorf(
+			"wallet password must be at least %d bytes",
+			minPasswordLen,
+		)
+	}
+
+	// Load the encrypted seed from disk.
+	seedPath := SeedFilePath(networkDir)
+
+	ciphertext, err := LoadEncryptedSeed(seedPath)
+	if err != nil {
+		return [rawSeedLen]byte{}, fmt.Errorf(
+			"loading encrypted seed: %w", err,
+		)
+	}
+
+	// Decrypt the seed.
+	seed, err := DecryptSeed(ciphertext, walletPassword)
+	if err != nil {
+		return [rawSeedLen]byte{}, fmt.Errorf(
+			"decrypting seed: %w", err,
+		)
+	}
+
+	return seed, nil
+}
+
+// BuildTransferInputs looks up full VTXO descriptors from the store
+// for the given outpoints and converts them into OOR transfer inputs.
+// This is extracted from the SendOOR RPC handler so a future SDK can
+// prepare transfer inputs without going through gRPC.
+func BuildTransferInputs(ctx context.Context,
+	store vtxo.VTXOStore,
+	outpoints []wire.OutPoint) ([]oor.TransferInput, error) {
+
+	inputs := make([]oor.TransferInput, 0, len(outpoints))
+
+	for _, op := range outpoints {
+		desc, err := store.GetVTXO(ctx, op)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"look up VTXO %s: %w", op, err,
+			)
+		}
+
+		inputs = append(inputs, oor.TransferInput{
+			VTXO:            desc,
+			OwnerLeafScript: desc.PkScript,
+		})
+	}
+
+	return inputs, nil
+}

--- a/db/vtxo_store.go
+++ b/db/vtxo_store.go
@@ -127,6 +127,41 @@ func (s *VTXOPersistenceStore) ListLiveVTXOs(
 	return result, err
 }
 
+// ListVTXOsByStatus returns all VTXOs matching the given status. This
+// enables the ListVTXOs RPC to query terminal states (spent, forfeited)
+// directly from the database instead of filtering in memory.
+func (s *VTXOPersistenceStore) ListVTXOsByStatus(
+	ctx context.Context, status vtxo.VTXOStatus,
+) ([]*vtxo.Descriptor, error) {
+
+	readTxOpts := ReadTxOption()
+
+	var result []*vtxo.Descriptor
+
+	err := s.db.ExecTx(ctx, readTxOpts, func(q RoundStore) error {
+		rows, err := q.ListVTXOsByStatus(ctx, int32(status))
+		if err != nil {
+			return fmt.Errorf("list VTXOs by status: %w", err)
+		}
+
+		descs := make([]*vtxo.Descriptor, 0, len(rows))
+		for _, row := range rows {
+			desc, err := s.rowToDescriptor(row)
+			if err != nil {
+				return fmt.Errorf("convert VTXO: %w", err)
+			}
+
+			descs = append(descs, desc)
+		}
+
+		result = descs
+
+		return nil
+	})
+
+	return result, err
+}
+
 // UpdateVTXOStatus atomically updates a VTXO's status. This is the primary
 // method for state transitions that don't require additional data.
 func (s *VTXOPersistenceStore) UpdateVTXOStatus(

--- a/lwwallet/wallet.go
+++ b/lwwallet/wallet.go
@@ -225,6 +225,20 @@ func (w *Wallet) DeriveNextKey(_ context.Context,
 	return &desc, nil
 }
 
+// DeriveKey derives a specific key identified by the given KeyLocator.
+// Unlike DeriveNextKey, this always returns the same key for the same
+// locator, making it suitable for stable identity keys.
+func (w *Wallet) DeriveKey(_ context.Context,
+	loc keychain.KeyLocator) (*keychain.KeyDescriptor, error) {
+
+	desc, err := w.keyRing.DeriveKey(loc)
+	if err != nil {
+		return nil, fmt.Errorf("derive key: %w", err)
+	}
+
+	return &desc, nil
+}
+
 // NewAddress generates a new BIP86 taproot receiving address (P2TR
 // key-path only) via btcwallet.
 func (w *Wallet) NewAddress(

--- a/oor/local_persistence_handler_test.go
+++ b/oor/local_persistence_handler_test.go
@@ -104,6 +104,21 @@ func (s *testVTXOStore) ListLiveVTXOs(_ context.Context) (
 	return out, nil
 }
 
+// ListVTXOsByStatus returns descriptors matching the given status.
+func (s *testVTXOStore) ListVTXOsByStatus(_ context.Context,
+	status vtxo.VTXOStatus) ([]*vtxo.Descriptor, error) {
+
+	var out []*vtxo.Descriptor
+	for _, desc := range s.records {
+		if desc.Status == status {
+			cpy := *desc
+			out = append(out, &cpy)
+		}
+	}
+
+	return out, nil
+}
+
 // UpdateVTXOStatus updates status for the given outpoint.
 func (s *testVTXOStore) UpdateVTXOStatus(_ context.Context,
 	outpoint wire.OutPoint, status vtxo.VTXOStatus) error {

--- a/vtxo/filter.go
+++ b/vtxo/filter.go
@@ -1,0 +1,58 @@
+package vtxo
+
+import "github.com/btcsuite/btcd/btcutil"
+
+// FilterOptions specifies the criteria for filtering a set of VTXO
+// descriptors. A zero-value FilterOptions matches everything.
+type FilterOptions struct {
+	// Status filters to VTXOs matching this exact status. A zero
+	// value (VTXOStatusLive) is treated as "no filter" only when
+	// StatusSet is false.
+	Status VTXOStatus
+
+	// StatusSet indicates whether the Status field was explicitly
+	// provided. This distinguishes "filter to live" from "no
+	// filter", since VTXOStatusLive is the zero value.
+	StatusSet bool
+
+	// MinAmount filters to VTXOs with at least this amount in
+	// satoshis. Zero means no minimum.
+	MinAmount btcutil.Amount
+}
+
+// FilterDescriptors returns the subset of descriptors matching the
+// given filter options. This is a pure function with no side effects,
+// suitable for use by both RPC handlers and a future SDK.
+func FilterDescriptors(descs []*Descriptor,
+	opts FilterOptions) []*Descriptor {
+
+	var result []*Descriptor
+
+	for _, d := range descs {
+		// Apply status filter if set.
+		if opts.StatusSet && d.Status != opts.Status {
+			continue
+		}
+
+		// Apply minimum amount filter.
+		if opts.MinAmount > 0 && d.Amount < opts.MinAmount {
+			continue
+		}
+
+		result = append(result, d)
+	}
+
+	return result
+}
+
+// SumBalance computes the total balance across a set of VTXO
+// descriptors. This is a convenience function used by both the
+// GetBalance RPC handler and the future SDK.
+func SumBalance(descs []*Descriptor) btcutil.Amount {
+	var total btcutil.Amount
+	for _, d := range descs {
+		total += d.Amount
+	}
+
+	return total
+}

--- a/vtxo/harness_test.go
+++ b/vtxo/harness_test.go
@@ -59,6 +59,19 @@ func (m *MockVTXOStore) ListLiveVTXOs(ctx context.Context) (
 	return vtxos, args.Error(1)
 }
 
+//nolint:forcetypeassert
+func (m *MockVTXOStore) ListVTXOsByStatus(ctx context.Context,
+	status VTXOStatus) ([]*Descriptor, error) {
+
+	args := m.Called(ctx, status)
+	var vtxos []*Descriptor
+	if args.Get(0) != nil {
+		vtxos = args.Get(0).([]*Descriptor)
+	}
+
+	return vtxos, args.Error(1)
+}
+
 func (m *MockVTXOStore) UpdateVTXOStatus(ctx context.Context,
 	outpoint wire.OutPoint, status VTXOStatus) error {
 

--- a/vtxo/interfaces.go
+++ b/vtxo/interfaces.go
@@ -334,6 +334,13 @@ type VTXOStore interface {
 	// startup to recover active VTXO actors after restart.
 	ListLiveVTXOs(ctx context.Context) ([]*Descriptor, error)
 
+	// ListVTXOsByStatus returns all VTXOs matching the given status.
+	// This enables querying terminal states (spent, forfeited) that
+	// ListLiveVTXOs excludes.
+	ListVTXOsByStatus(ctx context.Context, status VTXOStatus) (
+		[]*Descriptor, error,
+	)
+
 	// UpdateVTXOStatus atomically updates a VTXO's status. This is the
 	// primary method for state transitions.
 	UpdateVTXOStatus(


### PR DESCRIPTION
In this PR, we wire up the dual-wallet daemon server, implement all RPC
handlers, harden the wallet state machine, and extract core business logic
into package-level functions for future SDK reuse. This is part 3 of 5 in the
daemon + CLI series, stacking on top of #158.

## Server Dual-Wallet Refactor

\`RunUntilShutdown\` is restructured to support both \`lnd\` and \`lwwallet\`
backends selected via the \`wallet.type\` config. The server uses
\`fn.Option[T]\` for the lnd client and lwwallet fields, branching at startup to
instantiate the appropriate backend set.

In \`lwwallet\` mode, the gRPC server starts _before_ the wallet is ready so the
daemon can accept \`GenSeed\`/\`InitWallet\`/\`UnlockWallet\` RPCs. A
\`walletReady\` channel gates everything else. If \`DAREPOD_WALLET_PASSWORD\` or
\`--wallet.password_file\` is configured, the daemon auto-unlocks at startup for
fully unattended operation.

## RPC Handlers

\`rpc_wallet.go\` implements \`GenSeed\`, \`InitWallet\`, and \`UnlockWallet\`.
\`rpc_server.go\` adds \`GetBalance\`, \`ListVTXOs\`, \`NewAddress\`, \`SendVTXO\`,
\`SendOOR\`, and \`RefreshVTXOs\`. All wallet-dependent RPCs are gated on the
\`walletReady\` channel and return \`FAILED_PRECONDITION\` when the wallet is not
operational.

\`SendOOR\` does the full flow: address decode, coin selection + locking via the
wallet actor, VTXO descriptor lookup, OOR transfer dispatch via the service key
pattern, and automatic VTXO unlock on failure. \`SendVTXO\` (in-round directed
sends) returns \`codes.Unimplemented\` pending round protocol support for
recipient outputs (tracked in #156).

## Wallet State Hardening

The wallet state field is changed from a plain \`int\` to \`atomic.Int32\` for
lock-free concurrent access. \`InitWallet\` uses \`CompareAndSwap\` to atomically
claim the \`None → Locked\` transition, preventing TOCTOU races. The
\`walletReady\` channel close is wrapped in \`sync.Once\`.

Identity pubkey derivation is switched from \`DeriveNextKey\` to \`DeriveKey\`
with a fixed \`KeyLocator{Family: 6, Index: 0}\` so the node identity is stable
across restarts. A new \`DeriveKey\` method is added to \`lwwallet.Wallet\`.

\`expandTilde\` now returns \`(string, error)\` instead of silently swallowing
\`os.UserHomeDir\` failures. A mainnet safety guard requires
\`--allow-mainnet\` to run on mainnet.

## SDK-Ready Modularization

Core business logic is extracted from the gRPC handlers into standalone
package-level functions:

In the \`vtxo\` package: \`FilterDescriptors\` applies status and minimum amount
filters to VTXO descriptor sets, and \`SumBalance\` computes totals. Both are
pure functions with no side effects.

In the \`darepod\` package: \`InitWalletFromMnemonic\` (validate, derive, encrypt,
save) and \`UnlockWalletFromDisk\` (load, decrypt). The RPC handlers now
delegate to these, keeping the gRPC layer thin: just precondition checks,
proto conversion, and status error wrapping.

This separation means a future SDK can call the same wallet lifecycle and VTXO
query logic directly without going through gRPC.

See each commit message for detailed descriptions of the incremental changes.

## PR Series

1. Proto definitions + generated stubs (#157)
2. Seed manager, wallet config, wallet messages (#158)
3. **This PR** — Server refactor + RPC handlers + hardening + SDK modularization
4. Agent-first CLI binary (\`darepocli\`)
5. Schema introspection, MCP server, agent docs