### PR TITLE
harness: add LND credential path accessors

### DIFF
--- a/harness/harness.go
+++ b/harness/harness.go
@@ -401,6 +401,18 @@ func (h *Harness) BaseDir() string {
 	return h.artifactsDir
 }
 
+// LndTLSCertPath returns the path to the LND TLS certificate file on the
+// host filesystem.
+func (h *Harness) LndTLSCertPath() string {
+	return h.lndTLSCert
+}
+
+// LndMacaroonPath returns the path to the LND admin macaroon file on the
+// host filesystem.
+func (h *Harness) LndMacaroonPath() string {
+	return h.lndMacaroon
+}
+
 // Start launches bitcoind and lnd containers, initializes lnd, and boots arkd
 // in-process.
 func (h *Harness) Start() {


### PR DESCRIPTION
## Summary
- Add `LndTLSCertPath()` and `LndMacaroonPath()` accessor methods to the test harness
- These expose the previously unexported LND TLS cert and macaroon paths needed by consumers (e.g. arkd harness) that configure services to connect to the harness-managed LND instance

## Test plan
- [ ] Verify `make build` passes
- [ ] Verify existing harness tests still pass