### PR TITLE
vtxo+wallet: implement VTXO coin selection with atomic locking

### DIFF
--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -760,8 +760,8 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 }
 
 // unlockVTXOs sends an UnlockVTXOsRequest to the wallet actor for the
-// given set of selected VTXOs. This is used for cleanup when an OOR
-// transfer fails.
+// given set of selected VTXOs. This is used for cleanup when a transfer
+// (OOR or in-round) fails.
 func (r *RPCServer) unlockVTXOs(ctx context.Context,
 	vtxos []wallet.SelectedVTXO) error {
 

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -37,6 +37,7 @@ import (
 	"github.com/lightninglabs/darepo-client/rpc/roundpb"
 	"github.com/lightninglabs/darepo-client/serverconn"
 	"github.com/lightninglabs/darepo-client/timeout"
+	"github.com/lightninglabs/darepo-client/vtxo"
 	"github.com/lightninglabs/darepo-client/wallet"
 	"github.com/lightninglabs/lndclient"
 	lndbuild "github.com/lightningnetwork/lnd/build"
@@ -1523,7 +1524,108 @@ func (s *Server) initRoundActor(ctx context.Context,
 
 	log.InfoS(ctx, "Round actor registered and started")
 
+	// Create and register the VTXO manager. The manager needs the
+	// round actor ref so spawned VTXO actors can send refresh and
+	// forfeit messages back to the round. We create it after the
+	// round actor so the ref is available.
+	vtxoMgrRef, err := s.initVTXOManager(
+		ctx, clientWallet, chainSourceRef, roundRef,
+	)
+	if err != nil {
+		return fmt.Errorf("unable to init vtxo "+
+			"manager: %w", err)
+	}
+
+	// Wire the VTXO manager into the round actor so
+	// VTXOCreatedNotification messages are forwarded to spawn
+	// VTXO actors after rounds complete.
+	roundCfg.VTXOManager = vtxoMgrRef
+
 	return nil
+}
+
+// initVTXOManager creates, registers, and starts the VTXO manager actor.
+// The manager spawns individual VTXO actors for each live VTXO and
+// maintains an in-memory lock set for coin selection. It is registered
+// under the well-known VTXOManagerServiceKey so the wallet actor can
+// find it via service key lookup for lock/unlock operations.
+func (s *Server) initVTXOManager(ctx context.Context,
+	clientWallet vtxo.VTXOWallet,
+	chainSourceRef actor.ActorRef[
+		chainsource.ChainSourceMsg, chainsource.ChainSourceResp,
+	],
+	roundRef actor.ActorRef[
+		actormsg.RoundReceivable, actormsg.RoundActorResp,
+	]) (actor.TellOnlyRef[actor.Message], error) {
+
+	clk := clock.NewDefaultClock()
+	dbStore := db.NewStore(
+		s.db.DB, s.db.Queries, s.db.Backend(), log,
+	)
+	vtxoStore := dbStore.NewVTXOStore(clk)
+
+	mgrCfg := &vtxo.ManagerConfig{
+		Store:       vtxoStore,
+		Wallet:      clientWallet,
+		ChainSource: chainSourceRef,
+		ActorSystem: s.actorSystem,
+		ChainParams: s.chainParams,
+		Log:         fn.Some[btclog.Logger](log),
+		RoundActor:  roundRef,
+
+		// ChainResolver is nil until unilateral exit is
+		// implemented.
+		ChainResolver: nil,
+	}
+
+	mgrActor := vtxo.NewManager(mgrCfg)
+
+	// Register under the well-known service key so the wallet
+	// actor can discover it for lock/unlock via Ask.
+	mgrKey := actormsg.VTXOManagerServiceKey()
+	mgrRef := mgrKey.Spawn(
+		s.actorSystem, actormsg.VTXOManagerServiceKeyName,
+		mgrActor,
+	)
+
+	// Create a TellOnlyRef for the manager itself so VTXO actors
+	// can send termination notifications back.
+	mgrTellRef := actor.NewMapInputRef[
+		vtxo.ManagerMsg, vtxo.ManagerMsg,
+	](mgrRef, func(m vtxo.ManagerMsg) vtxo.ManagerMsg {
+		return m
+	})
+
+	// Start the manager, which recovers persisted live VTXOs.
+	if err := mgrActor.Start(ctx, mgrTellRef); err != nil {
+		return nil, fmt.Errorf("unable to start vtxo "+
+			"manager: %w", err)
+	}
+
+	log.InfoS(ctx, "VTXO manager registered and started")
+
+	// Create a MapInputRef adapter so the round actor can send
+	// actor.Message to the manager (VTXOCreatedNotification).
+	// The round config expects TellOnlyRef[actor.Message] to
+	// avoid import cycles with the vtxo package.
+	vtxoMgrMappedRef := actor.NewMapInputRef[
+		actor.Message, vtxo.ManagerMsg,
+	](mgrRef, func(m actor.Message) vtxo.ManagerMsg {
+		msg, ok := m.(vtxo.ManagerMsg)
+		if !ok {
+			log.WarnS(ctx,
+				"Dropping unexpected vtxo "+
+					"manager message",
+				fmt.Errorf("type: %T", m),
+			)
+
+			return nil
+		}
+
+		return msg
+	})
+
+	return vtxoMgrMappedRef, nil
 }
 
 // initOORActor creates and starts the OOR (out-of-round) client actor.

--- a/internal/coinselect/coinselect_integration_test.go
+++ b/internal/coinselect/coinselect_integration_test.go
@@ -1,0 +1,332 @@
+package coinselect
+
+import (
+	"context"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/lib/actormsg"
+	"github.com/lightninglabs/darepo-client/vtxo"
+	"github.com/lightninglabs/darepo-client/wallet"
+	"github.com/stretchr/testify/require"
+)
+
+// stubVTXOStore implements vtxo.VTXOStore with only ListLiveVTXOs
+// returning real data. All other methods are no-op stubs that satisfy
+// the interface but are never called during coin selection tests.
+//
+// The ready flag controls when VTXOs become visible. During
+// Manager.Start the store returns an empty list (so no VTXO actors
+// are spawned), then after calling setReady the full list is returned
+// for coin selection queries.
+type stubVTXOStore struct {
+	vtxos []*vtxo.Descriptor
+	ready bool
+}
+
+// setReady makes the test VTXOs visible to ListLiveVTXOs.
+func (s *stubVTXOStore) setReady() { s.ready = true }
+
+// ListLiveVTXOs returns the pre-configured test VTXOs only after
+// setReady has been called.
+func (s *stubVTXOStore) ListLiveVTXOs(context.Context) (
+	[]*vtxo.Descriptor, error) {
+
+	if !s.ready {
+		return nil, nil
+	}
+
+	return s.vtxos, nil
+}
+
+// SaveVTXO is unused in coin selection tests.
+func (s *stubVTXOStore) SaveVTXO(context.Context,
+	*vtxo.Descriptor) error {
+
+	return nil
+}
+
+// GetVTXO is unused in coin selection tests.
+func (s *stubVTXOStore) GetVTXO(context.Context,
+	wire.OutPoint) (*vtxo.Descriptor, error) {
+
+	return nil, nil
+}
+
+// ListVTXOsByStatus is unused in coin selection tests.
+func (s *stubVTXOStore) ListVTXOsByStatus(context.Context,
+	vtxo.VTXOStatus) ([]*vtxo.Descriptor, error) {
+
+	return nil, nil
+}
+
+// UpdateVTXOStatus is unused in coin selection tests.
+func (s *stubVTXOStore) UpdateVTXOStatus(context.Context,
+	wire.OutPoint, vtxo.VTXOStatus) error {
+
+	return nil
+}
+
+// MarkForfeiting is unused in coin selection tests.
+func (s *stubVTXOStore) MarkForfeiting(context.Context,
+	wire.OutPoint, string, *wire.MsgTx) error {
+
+	return nil
+}
+
+// GetForfeitTx is unused in coin selection tests.
+func (s *stubVTXOStore) GetForfeitTx(context.Context,
+	wire.OutPoint) (*wire.MsgTx, error) {
+
+	return nil, nil
+}
+
+// MarkForfeited is unused in coin selection tests.
+func (s *stubVTXOStore) MarkForfeited(context.Context,
+	wire.OutPoint, chainhash.Hash) error {
+
+	return nil
+}
+
+// DeleteVTXO is unused in coin selection tests.
+func (s *stubVTXOStore) DeleteVTXO(context.Context,
+	wire.OutPoint) error {
+
+	return nil
+}
+
+// Compile-time check that stubVTXOStore satisfies the interface.
+var _ vtxo.VTXOStore = (*stubVTXOStore)(nil)
+
+// makeDescriptor creates a minimal VTXO descriptor for tests.
+func makeDescriptor(idx uint32,
+	amount btcutil.Amount) *vtxo.Descriptor {
+
+	return &vtxo.Descriptor{
+		Outpoint: wire.OutPoint{
+			Hash:  chainhash.Hash{byte(idx)},
+			Index: idx,
+		},
+		Amount:   amount,
+		PkScript: []byte{0x51, 0x20, byte(idx)},
+		Status:   vtxo.VTXOStatusLive,
+	}
+}
+
+// setupCoinSelectionTest creates a minimal actor system with a real VTXO
+// manager and wallet actor wired together via the well-known service key.
+// The VTXO manager uses a stub store pre-loaded with the given
+// descriptors. Returns the wallet actor for sending requests.
+func setupCoinSelectionTest(t *testing.T,
+	vtxos []*vtxo.Descriptor) *wallet.Ark {
+
+	t.Helper()
+
+	system := actor.NewActorSystem()
+	t.Cleanup(func() {
+		//nolint:usetesting
+		_ = system.Shutdown(context.Background())
+	})
+
+	store := &stubVTXOStore{vtxos: vtxos}
+	mgrCfg := &vtxo.ManagerConfig{
+		Store: store,
+	}
+	mgrActor := vtxo.NewManager(mgrCfg)
+
+	// Register under the well-known service key so the wallet
+	// actor can discover it.
+	mgrKey := actormsg.VTXOManagerServiceKey()
+	mgrRef := mgrKey.Spawn(
+		system, actormsg.VTXOManagerServiceKeyName,
+		mgrActor,
+	)
+
+	// Create a TellOnlyRef for the manager's self-reference
+	// (needed by Start for VTXO actor termination notifications).
+	mgrTellRef := actor.NewMapInputRef[
+		vtxo.ManagerMsg, vtxo.ManagerMsg,
+	](mgrRef, func(m vtxo.ManagerMsg) vtxo.ManagerMsg {
+		return m
+	})
+
+	err := mgrActor.Start(t.Context(), mgrTellRef)
+	require.NoError(t, err)
+
+	// Make VTXOs visible now that Start has completed without
+	// trying to spawn actors for them.
+	store.setReady()
+
+	// Create a minimal wallet actor with only the actor system
+	// wired in. The boarding backend, store, and chain source are
+	// not used during coin selection.
+	walletActor := wallet.NewArk(
+		nil, nil, nil, system, btclog.Disabled,
+	)
+
+	return walletActor
+}
+
+// TestSelectAndLockIntegration exercises the full wallet→manager flow:
+// service key lookup, listing available VTXOs, coin selection, and
+// locking via the VTXO manager.
+func TestSelectAndLockIntegration(t *testing.T) {
+	t.Parallel()
+
+	vtxo1 := makeDescriptor(1, 50_000)
+	vtxo2 := makeDescriptor(2, 100_000)
+	vtxo3 := makeDescriptor(3, 25_000)
+
+	w := setupCoinSelectionTest(
+		t, []*vtxo.Descriptor{vtxo1, vtxo2, vtxo3},
+	)
+	ctx := t.Context()
+
+	// Select VTXOs covering 60k. Largest-first should pick vtxo2
+	// (100k) alone.
+	result := w.Receive(ctx, &wallet.SelectAndLockVTXOsRequest{
+		TargetAmount: 60_000,
+	})
+	require.True(t, result.IsOk(), "select: %v", result.Err())
+
+	resp, err := result.Unpack()
+	require.NoError(t, err)
+
+	//nolint:forcetypeassert
+	sr := resp.(*wallet.SelectAndLockVTXOsResponse)
+	require.Len(t, sr.SelectedVTXOs, 1)
+	require.Equal(t, vtxo2.Outpoint,
+		sr.SelectedVTXOs[0].Outpoint)
+	require.Equal(t, btcutil.Amount(100_000), sr.TotalSelected)
+}
+
+// TestSelectExcludesLockedVTXOs verifies that a second selection does
+// not return VTXOs locked by the first.
+func TestSelectExcludesLockedVTXOs(t *testing.T) {
+	t.Parallel()
+
+	vtxo1 := makeDescriptor(1, 50_000)
+	vtxo2 := makeDescriptor(2, 100_000)
+	vtxo3 := makeDescriptor(3, 25_000)
+
+	w := setupCoinSelectionTest(
+		t, []*vtxo.Descriptor{vtxo1, vtxo2, vtxo3},
+	)
+	ctx := t.Context()
+
+	// First selection locks vtxo2 (100k covers 60k).
+	result := w.Receive(ctx, &wallet.SelectAndLockVTXOsRequest{
+		TargetAmount: 60_000,
+	})
+	require.True(t, result.IsOk())
+
+	// Second selection for 40k must skip vtxo2 (locked) and pick
+	// vtxo1 (50k).
+	result = w.Receive(ctx, &wallet.SelectAndLockVTXOsRequest{
+		TargetAmount: 40_000,
+	})
+	require.True(t, result.IsOk())
+
+	resp, err := result.Unpack()
+	require.NoError(t, err)
+
+	//nolint:forcetypeassert
+	sr := resp.(*wallet.SelectAndLockVTXOsResponse)
+	require.Len(t, sr.SelectedVTXOs, 1)
+	require.Equal(t, vtxo1.Outpoint,
+		sr.SelectedVTXOs[0].Outpoint)
+}
+
+// TestSelectInsufficientAfterLock verifies that selecting more than the
+// available (unlocked) balance returns an error.
+func TestSelectInsufficientAfterLock(t *testing.T) {
+	t.Parallel()
+
+	vtxo1 := makeDescriptor(1, 50_000)
+
+	w := setupCoinSelectionTest(
+		t, []*vtxo.Descriptor{vtxo1},
+	)
+	ctx := t.Context()
+
+	// Lock the only VTXO.
+	result := w.Receive(ctx, &wallet.SelectAndLockVTXOsRequest{
+		TargetAmount: 50_000,
+	})
+	require.True(t, result.IsOk())
+
+	// Nothing left — should fail.
+	result = w.Receive(ctx, &wallet.SelectAndLockVTXOsRequest{
+		TargetAmount: 1_000,
+	})
+	require.True(t, result.IsErr())
+	require.Contains(t, result.Err().Error(),
+		"insufficient VTXO balance")
+}
+
+// TestUnlockRestoresAvailability verifies that unlocking VTXOs makes
+// them available for subsequent coin selection.
+func TestUnlockRestoresAvailability(t *testing.T) {
+	t.Parallel()
+
+	vtxo1 := makeDescriptor(1, 80_000)
+
+	w := setupCoinSelectionTest(
+		t, []*vtxo.Descriptor{vtxo1},
+	)
+	ctx := t.Context()
+
+	// Select and lock vtxo1.
+	result := w.Receive(ctx, &wallet.SelectAndLockVTXOsRequest{
+		TargetAmount: 50_000,
+	})
+	require.True(t, result.IsOk())
+
+	// Unlock vtxo1.
+	unlockResult := w.Receive(ctx, &wallet.UnlockVTXOsRequest{
+		Outpoints: []wire.OutPoint{vtxo1.Outpoint},
+	})
+	require.True(t, unlockResult.IsOk())
+
+	resp, err := unlockResult.Unpack()
+	require.NoError(t, err)
+
+	//nolint:forcetypeassert
+	unlockResp := resp.(*wallet.UnlockVTXOsResponse)
+	require.Equal(t, 1, unlockResp.UnlockedCount)
+
+	// vtxo1 should be available again.
+	result = w.Receive(ctx, &wallet.SelectAndLockVTXOsRequest{
+		TargetAmount: 50_000,
+	})
+	require.True(t, result.IsOk(), "re-select: %v",
+		result.Err())
+
+	selectResp, err := result.Unpack()
+	require.NoError(t, err)
+
+	//nolint:forcetypeassert
+	sr := selectResp.(*wallet.SelectAndLockVTXOsResponse)
+	require.Len(t, sr.SelectedVTXOs, 1)
+	require.Equal(t, vtxo1.Outpoint,
+		sr.SelectedVTXOs[0].Outpoint)
+}
+
+// TestSelectWithNoActorSystem verifies the wallet returns a clear error
+// when no actor system is configured.
+func TestSelectWithNoActorSystem(t *testing.T) {
+	t.Parallel()
+
+	w := wallet.NewArk(nil, nil, nil, nil, btclog.Disabled)
+
+	result := w.Receive(t.Context(),
+		&wallet.SelectAndLockVTXOsRequest{TargetAmount: 1_000})
+
+	require.True(t, result.IsErr())
+	require.Contains(t, result.Err().Error(),
+		"no actor system")
+}

--- a/lib/actormsg/interfaces.go
+++ b/lib/actormsg/interfaces.go
@@ -43,6 +43,136 @@ type VTXOManagerMsg interface {
 	VTXOManagerMsg()
 }
 
+// VTXOManagerResp is the response type marker for the VTXO manager actor.
+// Using an interface here allows the wallet to look up and Ask the VTXO
+// manager without importing the vtxo package (avoiding import cycles).
+type VTXOManagerResp interface {
+	VTXOManagerResp()
+}
+
+// AvailableVTXO describes a live, unlocked VTXO available for coin selection.
+// This lightweight type avoids requiring callers to import the vtxo package.
+type AvailableVTXO struct {
+	// Outpoint is the VTXO's outpoint.
+	Outpoint wire.OutPoint
+
+	// Amount is the value of this VTXO in satoshis.
+	Amount int64
+
+	// PkScript is the output script for this VTXO.
+	PkScript []byte
+}
+
+// ListAvailableVTXOsRequest asks the VTXO manager for all live VTXOs that
+// are not currently locked. The wallet actor uses this to run coin selection
+// against the set of spendable VTXOs.
+type ListAvailableVTXOsRequest struct {
+	actor.BaseMessage
+}
+
+// VTXOManagerMsg implements the VTXOManagerMsg marker interface.
+func (m *ListAvailableVTXOsRequest) VTXOManagerMsg() {}
+
+// MessageType returns the message type for logging.
+func (m *ListAvailableVTXOsRequest) MessageType() string {
+	return "ListAvailableVTXOsRequest"
+}
+
+// ListAvailableVTXOsResponse returns the set of live, unlocked VTXOs.
+type ListAvailableVTXOsResponse struct {
+	// Available is the set of VTXOs that are live and not locked.
+	Available []AvailableVTXO
+}
+
+// VTXOManagerResp implements the VTXOManagerResp marker interface.
+func (m *ListAvailableVTXOsResponse) VTXOManagerResp() {}
+
+// SelectAndLockVTXOsRequest asks the VTXO manager to atomically select and
+// lock a set of live VTXOs that cover the target amount. This avoids a race
+// between separate list and lock requests.
+type SelectAndLockVTXOsRequest struct {
+	actor.BaseMessage
+
+	// TargetAmount is the minimum total value the selected VTXOs must
+	// cover, in satoshis.
+	TargetAmount int64
+}
+
+// VTXOManagerMsg implements the VTXOManagerMsg marker interface.
+func (m *SelectAndLockVTXOsRequest) VTXOManagerMsg() {}
+
+// MessageType returns the message type for logging.
+func (m *SelectAndLockVTXOsRequest) MessageType() string {
+	return "SelectAndLockVTXOsRequest"
+}
+
+// SelectAndLockVTXOsResponse returns the VTXOs that were selected and locked
+// by the manager.
+type SelectAndLockVTXOsResponse struct {
+	// Selected is the set of VTXOs that were selected and locked.
+	Selected []AvailableVTXO
+
+	// TotalSelected is the sum of all selected VTXO amounts in satoshis.
+	TotalSelected int64
+}
+
+// VTXOManagerResp implements the VTXOManagerResp marker interface.
+func (m *SelectAndLockVTXOsResponse) VTXOManagerResp() {}
+
+// LockVTXOsRequest asks the VTXO manager to mark the given outpoints as
+// locked. Locked VTXOs are excluded from future ListAvailableVTXOs results
+// until explicitly unlocked.
+type LockVTXOsRequest struct {
+	actor.BaseMessage
+
+	// Outpoints identifies the VTXOs to lock.
+	Outpoints []wire.OutPoint
+}
+
+// VTXOManagerMsg implements the VTXOManagerMsg marker interface.
+func (m *LockVTXOsRequest) VTXOManagerMsg() {}
+
+// MessageType returns the message type for logging.
+func (m *LockVTXOsRequest) MessageType() string {
+	return "LockVTXOsRequest"
+}
+
+// LockVTXOsResponse confirms that the specified VTXOs were locked.
+type LockVTXOsResponse struct {
+	// LockedCount is the number of VTXOs that were newly locked.
+	LockedCount int
+}
+
+// VTXOManagerResp implements the VTXOManagerResp marker interface.
+func (m *LockVTXOsResponse) VTXOManagerResp() {}
+
+// UnlockVTXOsRequest asks the VTXO manager to release locks on the given
+// outpoints. This is used when a transfer or round participation fails or
+// is cancelled, allowing the VTXOs to be selected again.
+type UnlockVTXOsRequest struct {
+	actor.BaseMessage
+
+	// Outpoints identifies the VTXOs to unlock.
+	Outpoints []wire.OutPoint
+}
+
+// VTXOManagerMsg implements the VTXOManagerMsg marker interface.
+func (m *UnlockVTXOsRequest) VTXOManagerMsg() {}
+
+// MessageType returns the message type for logging.
+func (m *UnlockVTXOsRequest) MessageType() string {
+	return "UnlockVTXOsRequest"
+}
+
+// UnlockVTXOsResponse confirms that the specified VTXOs were unlocked.
+type UnlockVTXOsResponse struct {
+	// UnlockedCount is the number of VTXOs that were actually unlocked.
+	UnlockedCount int
+}
+
+// VTXOManagerResp implements the VTXOManagerResp marker interface.
+func (m *UnlockVTXOsResponse) VTXOManagerResp() {}
+
 // TriggerVTXORefreshMsg is sent from the wallet actor to the round actor to
 // request refresh of specific VTXOs. Defined in actormsg to avoid import cycle
 // between wallet and round packages.

--- a/lib/actormsg/service_keys.go
+++ b/lib/actormsg/service_keys.go
@@ -23,6 +23,23 @@ func VTXOActorServiceKey(outpoint wire.OutPoint) actor.ServiceKey[
 	)
 }
 
+// VTXOManagerServiceKeyName is the well-known service key name for the VTXO
+// manager actor. Both the vtxo package (for registration) and wallet package
+// (for lookup) use this constant to ensure they reference the same actor.
+const VTXOManagerServiceKeyName = "vtxo-manager"
+
+// VTXOManagerServiceKey returns the service key for looking up the VTXO
+// manager actor. This uses VTXOManagerMsg for the message type so the wallet
+// can look up the manager without importing the vtxo package.
+func VTXOManagerServiceKey() actor.ServiceKey[
+	VTXOManagerMsg, VTXOManagerResp,
+] {
+
+	return actor.NewServiceKey[VTXOManagerMsg, VTXOManagerResp](
+		VTXOManagerServiceKeyName,
+	)
+}
+
 // RoundActorServiceKeyName is the well-known service key name for the round
 // actor. Both the round package (for registration) and wallet package (for
 // lookup) use this constant to ensure they reference the same actor.

--- a/vtxo/manager.go
+++ b/vtxo/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sort"
 
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/wire"
@@ -54,6 +55,11 @@ type ManagerConfig struct {
 // are created and recovering persisted actors on startup. Each VTXO actor
 // manages its own block epoch subscription and communicates directly with the
 // round actor via service keys.
+//
+// The manager also maintains an in-memory set of locked outpoints for coin
+// selection. Locked VTXOs are excluded from availability queries to prevent
+// double-spends across concurrent transfers or round participations. Locks
+// are transient and cleared on daemon restart.
 type Manager struct {
 	cfg *ManagerConfig
 
@@ -63,6 +69,12 @@ type Manager struct {
 
 	// actors tracks active VTXO actors by outpoint.
 	actors map[wire.OutPoint]VTXOActorRef
+
+	// lockedOutpoints tracks VTXOs that are currently reserved for
+	// in-flight operations (transfers, round participation). These
+	// are excluded from ListAvailableVTXOs results until explicitly
+	// unlocked.
+	lockedOutpoints fn.Set[wire.OutPoint]
 }
 
 // NewManager creates a new VTXO Manager.
@@ -72,8 +84,9 @@ func NewManager(cfg *ManagerConfig) *Manager {
 	}
 
 	return &Manager{
-		cfg:    cfg,
-		actors: make(map[wire.OutPoint]VTXOActorRef),
+		cfg:             cfg,
+		actors:          make(map[wire.OutPoint]VTXOActorRef),
+		lockedOutpoints: fn.NewSet[wire.OutPoint](),
 	}
 }
 
@@ -140,6 +153,18 @@ func (m *Manager) Receive(ctx context.Context,
 		return fn.Ok[ManagerResp](&GetActiveVTXOCountResponse{
 			Count: len(m.actors),
 		})
+
+	case *actormsg.ListAvailableVTXOsRequest:
+		return m.handleListAvailable(ctx)
+
+	case *actormsg.SelectAndLockVTXOsRequest:
+		return m.handleSelectAndLockVTXOs(ctx, req)
+
+	case *actormsg.LockVTXOsRequest:
+		return m.handleLockVTXOs(ctx, req)
+
+	case *actormsg.UnlockVTXOsRequest:
+		return m.handleUnlockVTXOs(ctx, req)
 
 	default:
 		return fn.Err[ManagerResp](
@@ -210,6 +235,7 @@ func (m *Manager) handleVTXOTerminated(ctx context.Context,
 	msg *round.VTXOTerminatedMsg) fn.Result[ManagerResp] {
 
 	delete(m.actors, msg.Outpoint)
+	m.lockedOutpoints.Remove(msg.Outpoint)
 
 	m.logger(ctx).InfoS(ctx, "VTXO actor terminated",
 		slog.String("outpoint", msg.Outpoint.String()),
@@ -217,6 +243,174 @@ func (m *Manager) handleVTXOTerminated(ctx context.Context,
 		slog.String("reason", msg.Reason))
 
 	return fn.Ok[ManagerResp](&VTXOTerminatedResp{})
+}
+
+// handleListAvailable returns all live VTXOs that are not currently locked.
+// This queries the store for live VTXOs and filters out any that appear in
+// the locked outpoints set.
+func (m *Manager) handleListAvailable(
+	ctx context.Context) fn.Result[ManagerResp] {
+
+	available, err := m.listAvailableVTXOs(ctx)
+	if err != nil {
+		return fn.Err[ManagerResp](
+			err,
+		)
+	}
+
+	m.logger(ctx).DebugS(ctx, "Listed available VTXOs",
+		slog.Int("available", len(available)),
+		slog.Int("locked", int(m.lockedOutpoints.Size())),
+	)
+
+	return fn.Ok[ManagerResp](&actormsg.ListAvailableVTXOsResponse{
+		Available: available,
+	})
+}
+
+// handleSelectAndLockVTXOs atomically selects and locks a set of VTXOs that
+// cover the target amount. Because selection and mutation happen within one
+// manager message, callers do not race with separate list+lock steps.
+func (m *Manager) handleSelectAndLockVTXOs(ctx context.Context,
+	req *actormsg.SelectAndLockVTXOsRequest) fn.Result[ManagerResp] {
+
+	if req.TargetAmount <= 0 {
+		return fn.Err[ManagerResp](fmt.Errorf(
+			"target amount must be positive, got %d",
+			req.TargetAmount,
+		))
+	}
+
+	available, err := m.listAvailableVTXOs(ctx)
+	if err != nil {
+		return fn.Err[ManagerResp](err)
+	}
+
+	selected, total, err := selectCoinsLargestFirst(
+		available, req.TargetAmount,
+	)
+	if err != nil {
+		return fn.Err[ManagerResp](err)
+	}
+
+	for _, v := range selected {
+		m.lockedOutpoints.Add(v.Outpoint)
+	}
+
+	m.logger(ctx).InfoS(ctx, "Selected and locked VTXOs",
+		slog.Int("selected", len(selected)),
+		slog.Int64("target", req.TargetAmount),
+		slog.Int64("total", total),
+		slog.Int("total_locked", int(m.lockedOutpoints.Size())),
+	)
+
+	return fn.Ok[ManagerResp](&actormsg.SelectAndLockVTXOsResponse{
+		Selected:      selected,
+		TotalSelected: total,
+	})
+}
+
+// handleLockVTXOs adds the given outpoints to the locked set.
+func (m *Manager) handleLockVTXOs(ctx context.Context,
+	req *actormsg.LockVTXOsRequest) fn.Result[ManagerResp] {
+
+	var locked int
+	for _, op := range req.Outpoints {
+		if !m.lockedOutpoints.Contains(op) {
+			m.lockedOutpoints.Add(op)
+			locked++
+		}
+	}
+
+	m.logger(ctx).InfoS(ctx, "Locked VTXOs",
+		slog.Int("requested", len(req.Outpoints)),
+		slog.Int("newly_locked", locked),
+		slog.Int("total_locked", int(m.lockedOutpoints.Size())))
+
+	return fn.Ok[ManagerResp](&actormsg.LockVTXOsResponse{
+		LockedCount: locked,
+	})
+}
+
+// handleUnlockVTXOs removes the given outpoints from the locked set.
+func (m *Manager) handleUnlockVTXOs(ctx context.Context,
+	req *actormsg.UnlockVTXOsRequest) fn.Result[ManagerResp] {
+
+	var unlocked int
+	for _, op := range req.Outpoints {
+		if m.lockedOutpoints.Contains(op) {
+			m.lockedOutpoints.Remove(op)
+			unlocked++
+		}
+	}
+
+	m.logger(ctx).InfoS(ctx, "Unlocked VTXOs",
+		slog.Int("requested", len(req.Outpoints)),
+		slog.Int("unlocked", unlocked),
+		slog.Int("total_locked", int(m.lockedOutpoints.Size())))
+
+	return fn.Ok[ManagerResp](&actormsg.UnlockVTXOsResponse{
+		UnlockedCount: unlocked,
+	})
+}
+
+// listAvailableVTXOs returns the live VTXOs that are not currently locked.
+func (m *Manager) listAvailableVTXOs(
+	ctx context.Context) ([]actormsg.AvailableVTXO, error) {
+
+	liveVTXOs, err := m.cfg.Store.ListLiveVTXOs(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list live vtxos: %w", err)
+	}
+
+	available := make(
+		[]actormsg.AvailableVTXO, 0, len(liveVTXOs),
+	)
+	for _, v := range liveVTXOs {
+		if m.lockedOutpoints.Contains(v.Outpoint) {
+			continue
+		}
+
+		available = append(available, actormsg.AvailableVTXO{
+			Outpoint: v.Outpoint,
+			Amount:   int64(v.Amount),
+			PkScript: v.PkScript,
+		})
+	}
+
+	return available, nil
+}
+
+// selectCoinsLargestFirst selects VTXOs using a largest-first strategy.
+// It sorts available VTXOs by descending amount and greedily picks until
+// the target amount is covered. This minimizes the number of inputs.
+func selectCoinsLargestFirst(available []actormsg.AvailableVTXO,
+	target int64) ([]actormsg.AvailableVTXO, int64, error) {
+
+	sorted := make([]actormsg.AvailableVTXO, len(available))
+	copy(sorted, available)
+
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Amount > sorted[j].Amount
+	})
+
+	var (
+		selected []actormsg.AvailableVTXO
+		total    int64
+	)
+	for _, v := range sorted {
+		selected = append(selected, v)
+		total += v.Amount
+
+		if total >= target {
+			return selected, total, nil
+		}
+	}
+
+	return nil, 0, fmt.Errorf(
+		"insufficient VTXO balance: have %d, need %d",
+		total, target,
+	)
 }
 
 // spawnVTXOActor creates a new VTXO FSM actor.

--- a/vtxo/manager_lock_test.go
+++ b/vtxo/manager_lock_test.go
@@ -1,0 +1,384 @@
+package vtxo
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/actormsg"
+	"github.com/stretchr/testify/require"
+)
+
+// makeTestDescriptor creates a minimal VTXO descriptor for manager tests.
+func makeTestDescriptor(idx uint32, amount btcutil.Amount) *Descriptor {
+	return &Descriptor{
+		Outpoint: wire.OutPoint{
+			Hash:  chainhash.Hash{byte(idx)},
+			Index: idx,
+		},
+		Amount:   amount,
+		PkScript: []byte{0x51, 0x20, byte(idx)},
+		Status:   VTXOStatusLive,
+	}
+}
+
+// TestManagerListAvailable verifies that ListAvailableVTXOsRequest returns
+// live VTXOs excluding locked ones.
+func TestManagerListAvailable(t *testing.T) {
+	t.Parallel()
+
+	vtxo1 := makeTestDescriptor(1, 50_000)
+	vtxo2 := makeTestDescriptor(2, 100_000)
+	vtxo3 := makeTestDescriptor(3, 25_000)
+
+	store := &MockVTXOStore{}
+	store.On(
+		"ListLiveVTXOs", t.Context(),
+	).Return([]*Descriptor{vtxo1, vtxo2, vtxo3}, nil)
+
+	mgr := NewManager(&ManagerConfig{Store: store})
+
+	ctx := t.Context()
+
+	// All three should be available initially.
+	result := mgr.Receive(ctx, &actormsg.ListAvailableVTXOsRequest{})
+	require.True(t, result.IsOk())
+
+	resp, ok := result.Unpack()
+	require.NoError(t, ok)
+
+	//nolint:forcetypeassert
+	listResp := resp.(*actormsg.ListAvailableVTXOsResponse)
+	require.Len(t, listResp.Available, 3)
+
+	// Lock vtxo2.
+	lockResult := mgr.Receive(ctx, &actormsg.LockVTXOsRequest{
+		Outpoints: []wire.OutPoint{vtxo2.Outpoint},
+	})
+	require.True(t, lockResult.IsOk())
+
+	// Now only 2 should be available.
+	result = mgr.Receive(ctx, &actormsg.ListAvailableVTXOsRequest{})
+	require.True(t, result.IsOk())
+
+	resp, ok = result.Unpack()
+	require.NoError(t, ok)
+
+	//nolint:forcetypeassert
+	listResp = resp.(*actormsg.ListAvailableVTXOsResponse)
+	require.Len(t, listResp.Available, 2)
+
+	// Verify vtxo2 is not in the available list.
+	for _, av := range listResp.Available {
+		require.NotEqual(t, vtxo2.Outpoint, av.Outpoint)
+	}
+}
+
+// TestManagerLockVTXOs verifies that locking outpoints adds them to the
+// locked set and reports the correct count.
+func TestManagerLockVTXOs(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager(&ManagerConfig{})
+	ctx := t.Context()
+
+	op1 := wire.OutPoint{Hash: chainhash.Hash{1}, Index: 0}
+	op2 := wire.OutPoint{Hash: chainhash.Hash{2}, Index: 0}
+
+	// Lock two outpoints.
+	result := mgr.Receive(ctx, &actormsg.LockVTXOsRequest{
+		Outpoints: []wire.OutPoint{op1, op2},
+	})
+	require.True(t, result.IsOk())
+
+	resp, err := result.Unpack()
+	require.NoError(t, err)
+
+	//nolint:forcetypeassert
+	lockResp := resp.(*actormsg.LockVTXOsResponse)
+	require.Equal(t, 2, lockResp.LockedCount)
+
+	// Locking the same outpoints again should report 0 newly locked.
+	result = mgr.Receive(ctx, &actormsg.LockVTXOsRequest{
+		Outpoints: []wire.OutPoint{op1},
+	})
+	require.True(t, result.IsOk())
+
+	resp, err = result.Unpack()
+	require.NoError(t, err)
+
+	//nolint:forcetypeassert
+	lockResp = resp.(*actormsg.LockVTXOsResponse)
+	require.Equal(t, 0, lockResp.LockedCount)
+}
+
+// TestManagerSelectAndLockVTXOs verifies the manager atomically selects and
+// locks VTXOs in a single request.
+func TestManagerSelectAndLockVTXOs(t *testing.T) {
+	t.Parallel()
+
+	vtxo1 := makeTestDescriptor(1, 50_000)
+	vtxo2 := makeTestDescriptor(2, 100_000)
+	vtxo3 := makeTestDescriptor(3, 25_000)
+
+	store := &MockVTXOStore{}
+	store.On(
+		"ListLiveVTXOs", t.Context(),
+	).Return([]*Descriptor{vtxo1, vtxo2, vtxo3}, nil)
+
+	mgr := NewManager(&ManagerConfig{Store: store})
+	ctx := t.Context()
+
+	result := mgr.Receive(ctx, &actormsg.SelectAndLockVTXOsRequest{
+		TargetAmount: 60_000,
+	})
+	require.True(t, result.IsOk())
+
+	resp, err := result.Unpack()
+	require.NoError(t, err)
+
+	//nolint:forcetypeassert
+	selectResp := resp.(*actormsg.SelectAndLockVTXOsResponse)
+	require.Len(t, selectResp.Selected, 1)
+	require.Equal(t, vtxo2.Outpoint, selectResp.Selected[0].Outpoint)
+	require.EqualValues(t, 100_000, selectResp.TotalSelected)
+	require.True(t, mgr.lockedOutpoints.Contains(vtxo2.Outpoint))
+
+	listResult := mgr.Receive(ctx, &actormsg.ListAvailableVTXOsRequest{})
+	require.True(t, listResult.IsOk())
+
+	listRespAny, err := listResult.Unpack()
+	require.NoError(t, err)
+
+	//nolint:forcetypeassert
+	listResp := listRespAny.(*actormsg.ListAvailableVTXOsResponse)
+	require.Len(t, listResp.Available, 2)
+	for _, av := range listResp.Available {
+		require.NotEqual(t, vtxo2.Outpoint, av.Outpoint)
+	}
+}
+
+// TestManagerSelectAndLockRejectsZeroTarget verifies that a zero or
+// negative target amount returns an error without locking anything.
+func TestManagerSelectAndLockRejectsZeroTarget(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager(&ManagerConfig{})
+	ctx := t.Context()
+
+	result := mgr.Receive(ctx, &actormsg.SelectAndLockVTXOsRequest{
+		TargetAmount: 0,
+	})
+	require.True(t, result.IsErr())
+	require.Contains(t, result.Err().Error(),
+		"target amount must be positive")
+
+	result = mgr.Receive(ctx, &actormsg.SelectAndLockVTXOsRequest{
+		TargetAmount: -100,
+	})
+	require.True(t, result.IsErr())
+	require.Contains(t, result.Err().Error(),
+		"target amount must be positive")
+}
+
+// TestManagerUnlockVTXOs verifies that unlocking removes outpoints from
+// the locked set.
+func TestManagerUnlockVTXOs(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager(&ManagerConfig{})
+	ctx := t.Context()
+
+	op1 := wire.OutPoint{Hash: chainhash.Hash{1}, Index: 0}
+	op2 := wire.OutPoint{Hash: chainhash.Hash{2}, Index: 0}
+
+	// Lock two, then unlock one.
+	mgr.Receive(ctx, &actormsg.LockVTXOsRequest{
+		Outpoints: []wire.OutPoint{op1, op2},
+	})
+
+	result := mgr.Receive(ctx, &actormsg.UnlockVTXOsRequest{
+		Outpoints: []wire.OutPoint{op1},
+	})
+	require.True(t, result.IsOk())
+
+	resp, err := result.Unpack()
+	require.NoError(t, err)
+
+	//nolint:forcetypeassert
+	unlockResp := resp.(*actormsg.UnlockVTXOsResponse)
+	require.Equal(t, 1, unlockResp.UnlockedCount)
+
+	// op1 should be gone from locked set, op2 still there.
+	require.False(t, mgr.lockedOutpoints.Contains(op1))
+	require.True(t, mgr.lockedOutpoints.Contains(op2))
+}
+
+// TestManagerUnlockNonexistent verifies that unlocking an outpoint that
+// was not locked reports 0 unlocked.
+func TestManagerUnlockNonexistent(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager(&ManagerConfig{})
+	ctx := t.Context()
+
+	op := wire.OutPoint{Hash: chainhash.Hash{99}, Index: 0}
+
+	result := mgr.Receive(ctx, &actormsg.UnlockVTXOsRequest{
+		Outpoints: []wire.OutPoint{op},
+	})
+	require.True(t, result.IsOk())
+
+	resp, err := result.Unpack()
+	require.NoError(t, err)
+
+	//nolint:forcetypeassert
+	unlockResp := resp.(*actormsg.UnlockVTXOsResponse)
+	require.Equal(t, 0, unlockResp.UnlockedCount)
+}
+
+// TestManagerTerminatedUnlocks verifies that a terminated VTXO is
+// automatically removed from the locked set.
+func TestManagerTerminatedUnlocks(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager(&ManagerConfig{})
+	ctx := t.Context()
+
+	op := wire.OutPoint{Hash: chainhash.Hash{1}, Index: 0}
+
+	// Lock the outpoint.
+	mgr.Receive(ctx, &actormsg.LockVTXOsRequest{
+		Outpoints: []wire.OutPoint{op},
+	})
+	require.True(t, mgr.lockedOutpoints.Contains(op))
+
+	// Simulate VTXO termination. We need to add a tracking entry
+	// first so delete(m.actors, ...) doesn't panic.
+	mgr.actors[op] = nil
+
+	mgr.Receive(ctx, &VTXOTerminatedMsg{
+		Outpoint:   op,
+		FinalState: "forfeited",
+		Reason:     "test",
+	})
+
+	// Should be automatically unlocked.
+	require.False(t, mgr.lockedOutpoints.Contains(op))
+}
+
+// TestManagerListAvailableFields verifies that the AvailableVTXO fields
+// are correctly populated from the descriptor.
+func TestManagerListAvailableFields(t *testing.T) {
+	t.Parallel()
+
+	vtxo := makeTestDescriptor(7, 42_000)
+
+	store := &MockVTXOStore{}
+	store.On(
+		"ListLiveVTXOs", t.Context(),
+	).Return([]*Descriptor{vtxo}, nil)
+
+	mgr := NewManager(&ManagerConfig{Store: store})
+	ctx := t.Context()
+
+	result := mgr.Receive(ctx, &actormsg.ListAvailableVTXOsRequest{})
+	resp, err := result.Unpack()
+	require.NoError(t, err)
+
+	//nolint:forcetypeassert
+	listResp := resp.(*actormsg.ListAvailableVTXOsResponse)
+	require.Len(t, listResp.Available, 1)
+
+	av := listResp.Available[0]
+	require.Equal(t, vtxo.Outpoint, av.Outpoint)
+	require.Equal(t, int64(42_000), av.Amount)
+	require.Equal(t, vtxo.PkScript, av.PkScript)
+}
+
+// TestManagerGetActiveCountStillWorks verifies the pre-existing message
+// still works after the ManagerResp interface change.
+func TestManagerGetActiveCountStillWorks(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager(&ManagerConfig{})
+	ctx := t.Context()
+
+	result := mgr.Receive(ctx, &GetActiveVTXOCountRequest{})
+	require.True(t, result.IsOk())
+
+	resp, err := result.Unpack()
+	require.NoError(t, err)
+
+	//nolint:forcetypeassert
+	countResp := resp.(*GetActiveVTXOCountResponse)
+	require.Equal(t, 0, countResp.Count)
+}
+
+// TestManagerLockedVTXOsExcludedFromNextSelection simulates two sequential
+// coin selection calls. The first call locks some VTXOs; the second call
+// should only see the remaining unlocked VTXOs, preventing double-spends.
+func TestManagerLockedVTXOsExcludedFromNextSelection(t *testing.T) {
+	t.Parallel()
+
+	vtxo1 := makeTestDescriptor(1, 50_000)
+	vtxo2 := makeTestDescriptor(2, 30_000)
+	vtxo3 := makeTestDescriptor(3, 20_000)
+
+	store := &MockVTXOStore{}
+	store.On(
+		"ListLiveVTXOs", t.Context(),
+	).Return([]*Descriptor{vtxo1, vtxo2, vtxo3}, nil)
+
+	mgr := NewManager(&ManagerConfig{Store: store})
+	ctx := t.Context()
+
+	// First selection: lock vtxo1 and vtxo2 (simulating a 70k send).
+	lockResult := mgr.Receive(ctx, &actormsg.LockVTXOsRequest{
+		Outpoints: []wire.OutPoint{
+			vtxo1.Outpoint, vtxo2.Outpoint,
+		},
+	})
+	require.True(t, lockResult.IsOk())
+
+	// Second selection: list available should only return vtxo3.
+	listResult := mgr.Receive(
+		ctx, &actormsg.ListAvailableVTXOsRequest{},
+	)
+	resp, err := listResult.Unpack()
+	require.NoError(t, err)
+
+	//nolint:forcetypeassert
+	listResp := resp.(*actormsg.ListAvailableVTXOsResponse)
+	require.Len(t, listResp.Available, 1)
+	require.Equal(t, vtxo3.Outpoint, listResp.Available[0].Outpoint)
+
+	// Unlock the first selection (simulating transfer failure).
+	unlockResult := mgr.Receive(ctx, &actormsg.UnlockVTXOsRequest{
+		Outpoints: []wire.OutPoint{
+			vtxo1.Outpoint, vtxo2.Outpoint,
+		},
+	})
+	require.True(t, unlockResult.IsOk())
+
+	// All three should be available again.
+	listResult = mgr.Receive(
+		ctx, &actormsg.ListAvailableVTXOsRequest{},
+	)
+	resp, err = listResult.Unpack()
+	require.NoError(t, err)
+
+	//nolint:forcetypeassert
+	listResp = resp.(*actormsg.ListAvailableVTXOsResponse)
+	require.Len(t, listResp.Available, 3)
+}
+
+// Compile-time check that response types satisfy ManagerResp.
+var _ ManagerResp = (*actormsg.ListAvailableVTXOsResponse)(nil)
+var _ ManagerResp = (*actormsg.SelectAndLockVTXOsResponse)(nil)
+var _ ManagerResp = (*actormsg.LockVTXOsResponse)(nil)
+var _ ManagerResp = (*actormsg.UnlockVTXOsResponse)(nil)
+var _ ManagerResp = (*VTXOCreatedResp)(nil)
+var _ ManagerResp = (*VTXOTerminatedResp)(nil)
+var _ ManagerResp = (*GetActiveVTXOCountResponse)(nil)

--- a/vtxo/messages.go
+++ b/vtxo/messages.go
@@ -6,20 +6,16 @@ import (
 	"github.com/lightninglabs/darepo-client/round"
 )
 
-// ManagerMsg embeds actormsg.VTXOManagerMsg for messages accepted by the VTXO
-// Manager actor. Message types are defined in round/vtxo_messages.go and
-// implement the actormsg.VTXOManagerMsg marker interface.
-type ManagerMsg interface {
-	actormsg.VTXOManagerMsg
-}
+// ManagerMsg is the message type for the VTXO Manager actor. This is a type
+// alias for actormsg.VTXOManagerMsg so the manager can be registered with
+// the well-known VTXOManagerServiceKey and looked up by the wallet actor
+// without import cycles.
+type ManagerMsg = actormsg.VTXOManagerMsg
 
-// ManagerResp embeds actormsg.VTXOManagerResp for responses returned by the
-// VTXO Manager actor. Response types defined in actormsg (for cross-package
-// use) and in this package both satisfy this interface via the exported
-// VTXOManagerResp() marker method.
-type ManagerResp interface {
-	actormsg.VTXOManagerResp
-}
+// ManagerResp is the response type for the VTXO Manager actor. This is a
+// type alias for actormsg.VTXOManagerResp so responses from the manager
+// can be received by the wallet actor via the service key lookup.
+type ManagerResp = actormsg.VTXOManagerResp
 
 // Type alias for VTXOTerminatedMsg - canonical definition is in round package.
 type VTXOTerminatedMsg = round.VTXOTerminatedMsg

--- a/vtxo/messages.go
+++ b/vtxo/messages.go
@@ -13,9 +13,12 @@ type ManagerMsg interface {
 	actormsg.VTXOManagerMsg
 }
 
-// ManagerResp is the response type returned by the VTXO Manager actor.
+// ManagerResp embeds actormsg.VTXOManagerResp for responses returned by the
+// VTXO Manager actor. Response types defined in actormsg (for cross-package
+// use) and in this package both satisfy this interface via the exported
+// VTXOManagerResp() marker method.
 type ManagerResp interface {
-	managerRespSealed()
+	actormsg.VTXOManagerResp
 }
 
 // Type alias for VTXOTerminatedMsg - canonical definition is in round package.
@@ -24,12 +27,14 @@ type VTXOTerminatedMsg = round.VTXOTerminatedMsg
 // VTXOCreatedResp is the response to VTXOCreatedNotification.
 type VTXOCreatedResp struct{}
 
-func (r *VTXOCreatedResp) managerRespSealed() {}
+// VTXOManagerResp implements the actormsg.VTXOManagerResp marker interface.
+func (r *VTXOCreatedResp) VTXOManagerResp() {}
 
 // VTXOTerminatedResp is the response to VTXOTerminatedMsg.
 type VTXOTerminatedResp struct{}
 
-func (r *VTXOTerminatedResp) managerRespSealed() {}
+// VTXOManagerResp implements the actormsg.VTXOManagerResp marker interface.
+func (r *VTXOTerminatedResp) VTXOManagerResp() {}
 
 // GetActiveVTXOCountRequest requests the number of active VTXO actors managed
 // by the VTXO Manager. This goes through the actor message path to avoid
@@ -52,4 +57,5 @@ type GetActiveVTXOCountResponse struct {
 	Count int
 }
 
-func (r *GetActiveVTXOCountResponse) managerRespSealed() {}
+// VTXOManagerResp implements the actormsg.VTXOManagerResp marker interface.
+func (r *GetActiveVTXOCountResponse) VTXOManagerResp() {}

--- a/wallet/messages.go
+++ b/wallet/messages.go
@@ -304,9 +304,10 @@ func (m *RefreshVTXOsResponse) walletRespSealed() {}
 
 // SelectAndLockVTXOsRequest asks the wallet actor to select VTXOs covering a
 // target amount and atomically lock them to prevent double-spends. The locked
-// VTXOs are returned as descriptors that the caller can use to build OOR
-// transfer inputs. If the transfer fails, the caller should send an
-// UnlockVTXOsRequest to release the locks.
+// VTXOs are returned as lightweight descriptors that the caller can use to
+// build transfer inputs for OOR sends or in-round directed transfers. If the
+// operation fails, the caller should send an UnlockVTXOsRequest to release
+// the locks.
 type SelectAndLockVTXOsRequest struct {
 	actor.BaseMessage
 
@@ -323,10 +324,10 @@ func (m *SelectAndLockVTXOsRequest) MessageType() string {
 // walletMsgSealed implements the sealed WalletMsg interface.
 func (m *SelectAndLockVTXOsRequest) walletMsgSealed() {}
 
-// SelectedVTXO describes a VTXO that was selected and locked for use as
-// a transfer input. This avoids a direct dependency on the vtxo package
-// in the wallet message surface (which would create an import cycle via
-// vtxo → round → wallet).
+// SelectedVTXO describes a VTXO that was selected and locked for use as a
+// transfer input (OOR or in-round). This avoids a direct dependency on the
+// vtxo package in the wallet message surface (which would create an import
+// cycle via vtxo → round → wallet).
 type SelectedVTXO struct {
 	// Outpoint is the selected VTXO's outpoint.
 	Outpoint wire.OutPoint
@@ -334,8 +335,7 @@ type SelectedVTXO struct {
 	// Amount is the value of this VTXO in satoshis.
 	Amount btcutil.Amount
 
-	// PkScript is the output script for this VTXO. This also serves
-	// as the owner leaf script for OOR checkpoint construction.
+	// PkScript is the output script for this VTXO.
 	PkScript []byte
 }
 
@@ -361,8 +361,8 @@ func (m *SelectAndLockVTXOsResponse) MessageType() string {
 func (m *SelectAndLockVTXOsResponse) walletRespSealed() {}
 
 // UnlockVTXOsRequest releases locks on VTXOs that were previously selected
-// via SelectAndLockVTXOsRequest. This is used when an OOR transfer fails
-// or is cancelled, allowing the VTXOs to be used in future operations.
+// via SelectAndLockVTXOsRequest. This is used when a transfer or round
+// participation fails or is cancelled, allowing the VTXOs to be reused.
 type UnlockVTXOsRequest struct {
 	actor.BaseMessage
 

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -280,6 +280,12 @@ func (a *Ark) Receive(ctx context.Context,
 	case *LeaveVTXOsRequest:
 		return a.handleLeaveVTXOs(ctx, m)
 
+	case *SelectAndLockVTXOsRequest:
+		return a.handleSelectAndLockVTXOs(ctx, m)
+
+	case *UnlockVTXOsRequest:
+		return a.handleUnlockVTXOs(ctx, m)
+
 	default:
 		return fn.Err[WalletResp](
 			fmt.Errorf("unknown message type: %T", msg))
@@ -711,6 +717,115 @@ func (a *Ark) handleLeaveVTXOs(ctx context.Context,
 	}
 
 	return fn.Ok[WalletResp](resp)
+}
+
+// handleSelectAndLockVTXOs forwards a single atomic select+lock request to the
+// VTXO manager, then adapts the manager response to the wallet message
+// surface.
+func (a *Ark) handleSelectAndLockVTXOs(ctx context.Context,
+	req *SelectAndLockVTXOsRequest) fn.Result[WalletResp] {
+
+	if a.actorSystem == nil {
+		return fn.Err[WalletResp](
+			fmt.Errorf("no actor system for VTXO selection"),
+		)
+	}
+
+	// Ask the VTXO manager to select and lock in a single actor message.
+	mgrKey := actormsg.VTXOManagerServiceKey()
+	mgrRef := mgrKey.Ref(a.actorSystem)
+
+	future := mgrRef.Ask(ctx, &actormsg.SelectAndLockVTXOsRequest{
+		TargetAmount: int64(req.TargetAmount),
+	})
+	result := future.Await(ctx)
+
+	resp, err := result.Unpack()
+	if err != nil {
+		return fn.Err[WalletResp](
+			fmt.Errorf("select and lock vtxos: %w", err),
+		)
+	}
+
+	selectResp, ok := resp.(*actormsg.SelectAndLockVTXOsResponse)
+	if !ok {
+		return fn.Err[WalletResp](fmt.Errorf(
+			"unexpected select response type: %T", resp,
+		))
+	}
+
+	selected := make([]SelectedVTXO, 0, len(selectResp.Selected))
+	for _, v := range selectResp.Selected {
+		selected = append(selected, SelectedVTXO{
+			Outpoint: v.Outpoint,
+			Amount:   btcutil.Amount(v.Amount),
+			PkScript: v.PkScript,
+		})
+	}
+
+	total := btcutil.Amount(selectResp.TotalSelected)
+	if total < req.TargetAmount {
+		return fn.Err[WalletResp](fmt.Errorf(
+			"manager returned insufficient "+
+				"selection: have %d, need %d",
+			total, req.TargetAmount,
+		))
+	}
+
+	a.logger(ctx).InfoS(ctx, "Selected and locked VTXOs",
+		slog.Int("selected", len(selected)),
+		slog.Int64("target", int64(req.TargetAmount)),
+		slog.Int64("total", int64(total)))
+
+	respMsg := &SelectAndLockVTXOsResponse{
+		SelectedVTXOs: selected,
+		TotalSelected: total,
+	}
+
+	return fn.Ok[WalletResp](respMsg)
+}
+
+// handleUnlockVTXOs forwards an unlock request to the VTXO manager to
+// release previously locked outpoints.
+func (a *Ark) handleUnlockVTXOs(ctx context.Context,
+	req *UnlockVTXOsRequest) fn.Result[WalletResp] {
+
+	if a.actorSystem == nil {
+		return fn.Err[WalletResp](
+			fmt.Errorf("no actor system for VTXO unlock"),
+		)
+	}
+
+	mgrKey := actormsg.VTXOManagerServiceKey()
+	mgrRef := mgrKey.Ref(a.actorSystem)
+
+	future := mgrRef.Ask(
+		ctx, &actormsg.UnlockVTXOsRequest{
+			Outpoints: req.Outpoints,
+		},
+	)
+	result := future.Await(ctx)
+
+	resp, err := result.Unpack()
+	if err != nil {
+		return fn.Err[WalletResp](
+			fmt.Errorf("unlock vtxos: %w", err),
+		)
+	}
+
+	unlockResp, ok := resp.(*actormsg.UnlockVTXOsResponse)
+	if !ok {
+		return fn.Err[WalletResp](fmt.Errorf(
+			"unexpected unlock response type: %T", resp,
+		))
+	}
+
+	a.logger(ctx).InfoS(ctx, "Unlocked VTXOs",
+		slog.Int("unlocked", unlockResp.UnlockedCount))
+
+	return fn.Ok[WalletResp](&UnlockVTXOsResponse{
+		UnlockedCount: unlockResp.UnlockedCount,
+	})
 }
 
 // buildBoardingTapscript constructs a 2-of-2 tapscript with CSV timeout for


### PR DESCRIPTION
## VTXO coin selection + locking for transfers

Closes https://github.com/lightninglabs/darepo-client/issues/150

Implements full VTXO coin selection with in-memory locking to prevent
double-spends across concurrent OOR sends and in-round directed
transfers. The wallet actor selects VTXOs using a largest-first
strategy and delegates lock management to the VTXO manager via the
actor system's service key pattern.

### Architecture

Locking lives in the **VTXO manager** rather than the wallet because:

- The manager owns VTXO lifecycle (spawn, terminate, status tracking)
- Auto-unlock on termination is a natural fit
- Actor serialization (`Receive`) eliminates explicit synchronization
- The wallet avoids the `wallet → vtxo → round → wallet` import cycle
  by discovering the manager through the well-known
  `VTXOManagerServiceKey`

### Select & Lock Flow

Selection and locking happen in a **single atomic manager message**
(`SelectAndLockVTXOsRequest`) — no race window between list and lock.

```
┌────────┐  SelectAndLockVTXOsRequest(target)
│ Caller │─────────────────────────────────────►┌────────────────┐
│(RPC/   │                                      │  Wallet Actor  │
│ Round) │                                      └───────┬────────┘
└────────┘                                              │
            ① Ask: SelectAndLockVTXOsRequest            │
               (service key lookup)                     ▼
                                          ┌─────────────────────────┐
                                          │      VTXO Manager       │
                                          │  (single Receive call)  │
                                          │                         │
                                          │  ListLiveVTXOs()        │
                                          │  filter locked outpoints│
                                          │  selectCoinsLargestFirst│
                                          │  lockedOutpoints.Add()  │
                                          └─────────────────────────┘
            ② SelectAndLockVTXOsResponse                │
               { Selected, TotalSelected } ◄────────────┘
                        │
                        ▼
            ③ Wallet adapts to SelectedVTXO list
               and returns to caller
```

### Unlock Flow (failure / cancellation)

```
┌────────┐  UnlockVTXOsRequest(outpoints)
│ Caller │─────────────────────────────────────►┌────────────────┐
└────────┘                                      │  Wallet Actor  │
                                                └───────┬────────┘
            Forwards to VTXO manager via service key    │
                                                        ▼
                                                ┌───────────────┐
            lockedOutpoints.Remove(op) ─────────│ VTXO Manager  │
                                                └───────────────┘
            VTXOs available for next selection
```

### Auto-Unlock on Termination

```
  VTXO actor terminates (spent / forfeited / expired)
              │
              ▼
  VTXOTerminatedMsg ────────────────────────────┌───────────────┐
                                                │ VTXO Manager  │
  handleVTXOTerminated:                         │               │
    delete from actors map                      │  auto-unlock  │
    lockedOutpoints.Remove(op) ◄────────────────└───────────────┘
```

### Double-Spend Prevention

Locked VTXOs are invisible to subsequent selections. Two concurrent
callers requesting 50k each will never receive the same VTXO:

```
Caller A: SelectAndLock(50k) → gets vtxo1(60k), locks it
Caller B: SelectAndLock(50k) → vtxo1 filtered out, gets vtxo2(55k)
```

All access is serialized through the manager's `Receive` — no explicit
mutex needed.

### Design Notes

- **Locks are transient** (in-memory `fn.Set`): cleared on daemon
  restart. After restart there are no in-flight transfers, so nothing
  needs to stay locked.
- **Largest-first selection** minimizes input count. The pure function
  sorts a copy to avoid mutating the caller's slice.
- **`ManagerMsg` / `ManagerResp` are type aliases** (not embedding
  interfaces) so Go generics treat them as identical to
  `actormsg.VTXOManagerMsg` / `actormsg.VTXOManagerResp` — required for
  `RegisterWithSystem` to accept the service key's type parameters.
- **TTL-based lock expiry** (mentioned in issue) is deferred: auto-unlock
  on termination + transient locks cover the practical cases.
