### PR TITLE
multi: implement in-round SendVTXO directed sends

### DIFF
--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -8,14 +8,18 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/build"
 	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/lightninglabs/darepo-client/lib/actormsg"
 	"github.com/lightninglabs/darepo-client/lib/scripts"
+	"github.com/lightninglabs/darepo-client/lib/tree"
 	oortx "github.com/lightninglabs/darepo-client/lib/tx/oor"
+	"github.com/lightninglabs/darepo-client/lib/types"
 	"github.com/lightninglabs/darepo-client/lwwallet"
 	"github.com/lightninglabs/darepo-client/oor"
 	"github.com/lightninglabs/darepo-client/vtxo"
@@ -569,23 +573,195 @@ func (r *RPCServer) SendVTXO(ctx context.Context,
 		totalAmount += out.AmountSat
 	}
 
-	// For dry_run, validate inputs and return a preview.
+	// Fetch operator terms for VTXO descriptor construction.
+	terms, err := r.server.fetchOperatorTerms(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"unable to fetch operator terms: %v", err)
+	}
+
+	// Convert each recipient Output to a SendRecipient with a
+	// fully-constructed VTXO pkScript.
+	recipients := make(
+		[]actormsg.SendRecipient, 0, len(req.Recipients),
+	)
+	for i, out := range req.Recipients {
+		pkScript, err := r.resolveVTXORecipient(
+			out, terms,
+		)
+		if err != nil {
+			return nil, status.Errorf(
+				codes.InvalidArgument,
+				"recipient %d: %v", i, err,
+			)
+		}
+
+		recipients = append(recipients, actormsg.SendRecipient{
+			PkScript: pkScript,
+			Amount:   out.AmountSat,
+		})
+	}
+
+	// For dry_run, validate inputs and coin selection, then
+	// immediately unlock and return a preview.
 	if req.DryRun {
+		return r.sendVTXODryRun(
+			ctx, totalAmount, recipients,
+		)
+	}
+
+	if !r.server.walletRef.IsSome() {
+		return nil, status.Errorf(codes.Internal,
+			"wallet actor not initialized")
+	}
+
+	wRef := r.server.walletRef.UnsafeFromSome()
+
+	// Ask the wallet to select, lock, and forward the send to the
+	// round actor.
+	sendReq := &wallet.SendVTXOsRequest{
+		Recipients:  recipients,
+		TotalAmount: btcutil.Amount(totalAmount),
+	}
+	future := wRef.Ask(ctx, sendReq)
+	result := future.Await(ctx)
+
+	resp, err := result.Unpack()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"send failed: %v", err)
+	}
+
+	sendResp, ok := resp.(*wallet.SendVTXOsResponse)
+	if !ok {
+		return nil, status.Errorf(codes.Internal,
+			"unexpected response type: %T", resp)
+	}
+
+	log.InfoS(ctx, "In-round send submitted",
+		slog.Int("selected_vtxos", sendResp.SelectedCount),
+		slog.Int64("total_selected",
+			int64(sendResp.TotalSelected)),
+		slog.Int64("change", int64(sendResp.ChangeAmount)),
+		slog.Int64("total_amount", totalAmount))
+
+	return &daemonrpc.SendVTXOResponse{
+		Status:         "submitted",
+		TotalAmountSat: totalAmount,
+	}, nil
+}
+
+// resolveVTXORecipient derives a VTXO pkScript from a recipient Output. For
+// pubkey destinations, a full VTXO descriptor is constructed using the
+// operator's key and exit delay. For pk_script destinations, the raw script
+// is used directly (caller pre-computed the VTXO tapscript). Address
+// destinations are not supported in v1 because we cannot extract a raw key
+// from a tweaked taproot address.
+func (r *RPCServer) resolveVTXORecipient(out *daemonrpc.Output,
+	terms *types.OperatorTerms) ([]byte, error) {
+
+	switch d := out.Destination.(type) {
+	case *daemonrpc.Output_Pubkey:
+		if len(d.Pubkey) != schnorr.PubKeyBytesLen {
+			return nil, fmt.Errorf(
+				"pubkey must be %d bytes (x-only), "+
+					"got %d",
+				schnorr.PubKeyBytesLen, len(d.Pubkey),
+			)
+		}
+
+		recipientKey, err := schnorr.ParsePubKey(d.Pubkey)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"invalid recipient pubkey: %w", err,
+			)
+		}
+
+		desc, err := tree.NewVTXODescriptor(
+			btcutil.Amount(out.AmountSat),
+			recipientKey,
+			terms.PubKey,
+			terms.VTXOExitDelay,
+		)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"build VTXO descriptor: %w", err,
+			)
+		}
+
+		return desc.PkScript, nil
+
+	case *daemonrpc.Output_PkScript:
+		if len(d.PkScript) == 0 {
+			return nil, fmt.Errorf("pk_script is empty")
+		}
+
+		return d.PkScript, nil
+
+	case *daemonrpc.Output_Address:
+		return nil, fmt.Errorf(
+			"address destinations are not supported " +
+				"for in-round sends; use pubkey or " +
+				"pk_script instead",
+		)
+
+	default:
+		return nil, fmt.Errorf(
+			"unsupported destination type: %T", d,
+		)
+	}
+}
+
+// sendVTXODryRun validates coin selection for a send without actually
+// submitting to the round. It selects and locks VTXOs, computes the preview,
+// then immediately unlocks them.
+func (r *RPCServer) sendVTXODryRun(ctx context.Context,
+	totalAmount int64,
+	_ []actormsg.SendRecipient) (
+	*daemonrpc.SendVTXOResponse, error) {
+
+	if !r.server.walletRef.IsSome() {
+		// Without a wallet, return a basic preview.
 		return &daemonrpc.SendVTXOResponse{
 			Status:         "preview",
 			TotalAmountSat: totalAmount,
 		}, nil
 	}
 
-	// TODO(roasbeef): In-round directed sends are not yet
-	// implemented. The wallet actor's RefreshVTXOsRequest only
-	// supports self-refresh (sending back to self), not directed
-	// transfers to external recipients. Once the round protocol
-	// supports recipient outputs, this handler should build a
-	// proper send request with the validated recipients.
-	return nil, status.Errorf(codes.Unimplemented,
-		"in-round directed sends are not yet implemented; "+
-			"use SendOOR for out-of-round transfers")
+	wRef := r.server.walletRef.UnsafeFromSome()
+
+	// Select and lock to validate coin availability.
+	selectReq := &wallet.SelectAndLockVTXOsRequest{
+		TargetAmount: btcutil.Amount(totalAmount),
+	}
+	selectFuture := wRef.Ask(ctx, selectReq)
+	selectResult := selectFuture.Await(ctx)
+
+	selectResp, err := selectResult.Unpack()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"dry-run VTXO selection failed: %v", err)
+	}
+
+	locked, ok := selectResp.(*wallet.SelectAndLockVTXOsResponse)
+	if !ok {
+		return nil, status.Errorf(codes.Internal,
+			"unexpected response type: %T", selectResp)
+	}
+
+	// Immediately unlock the selected VTXOs.
+	if unlockErr := r.unlockVTXOs(
+		ctx, locked.SelectedVTXOs,
+	); unlockErr != nil {
+		log.WarnS(ctx,
+			"Unable to unlock VTXOs after dry-run",
+			unlockErr)
+	}
+
+	return &daemonrpc.SendVTXOResponse{
+		Status:         "preview",
+		TotalAmountSat: totalAmount,
+	}, nil
 }
 
 // SendOOR initiates an out-of-round transfer directly between the

--- a/internal/coinselect/coinselect_integration_test.go
+++ b/internal/coinselect/coinselect_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/lightninglabs/darepo-client/lib/actormsg"
 	"github.com/lightninglabs/darepo-client/vtxo"
 	"github.com/lightninglabs/darepo-client/wallet"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/stretchr/testify/require"
 )
 
@@ -329,4 +330,291 @@ func TestSelectWithNoActorSystem(t *testing.T) {
 	require.True(t, result.IsErr())
 	require.Contains(t, result.Err().Error(),
 		"no actor system")
+}
+
+// stubRoundActor captures TriggerVTXOSendMsg messages forwarded by the wallet
+// during in-round send flows. It satisfies the round actor's service key
+// interface (RoundReceivable → RoundActorResp). A channel is used for
+// synchronization since the wallet uses Tell (fire-and-forget) which is
+// processed asynchronously by the actor system.
+type stubRoundActor struct {
+	ch chan *actormsg.TriggerVTXOSendMsg
+}
+
+// newStubRoundActor creates a stub with a buffered channel.
+func newStubRoundActor() *stubRoundActor {
+	return &stubRoundActor{
+		ch: make(chan *actormsg.TriggerVTXOSendMsg, 10),
+	}
+}
+
+// Receive captures TriggerVTXOSendMsg and returns Ok for all messages.
+func (s *stubRoundActor) Receive(_ context.Context,
+	msg actormsg.RoundReceivable) fn.Result[actormsg.RoundActorResp] {
+
+	if sendMsg, ok := msg.(*actormsg.TriggerVTXOSendMsg); ok {
+		s.ch <- sendMsg
+	}
+
+	return fn.Ok[actormsg.RoundActorResp](nil)
+}
+
+// waitForSend blocks until a TriggerVTXOSendMsg is received or the
+// context is cancelled.
+func (s *stubRoundActor) waitForSend(
+	t *testing.T) *actormsg.TriggerVTXOSendMsg {
+
+	t.Helper()
+
+	select {
+	case msg := <-s.ch:
+		return msg
+
+	case <-t.Context().Done():
+		t.Fatal("timed out waiting for TriggerVTXOSendMsg")
+		return nil
+	}
+}
+
+// setupSendVTXOTest creates a minimal actor system with a real VTXO manager,
+// a stub round actor, and a wallet actor wired together via service keys.
+// Returns the wallet actor and the stub round actor for assertions.
+func setupSendVTXOTest(t *testing.T,
+	vtxos []*vtxo.Descriptor) (
+	*wallet.Ark, *stubRoundActor) {
+
+	t.Helper()
+
+	system := actor.NewActorSystem()
+	t.Cleanup(func() {
+		//nolint:usetesting
+		_ = system.Shutdown(context.Background())
+	})
+
+	// Register VTXO manager under the well-known service key.
+	store := &stubVTXOStore{vtxos: vtxos}
+	mgrCfg := &vtxo.ManagerConfig{Store: store}
+	mgrActor := vtxo.NewManager(mgrCfg)
+
+	mgrKey := actormsg.VTXOManagerServiceKey()
+	mgrRef := mgrKey.Spawn(
+		system, actormsg.VTXOManagerServiceKeyName,
+		mgrActor,
+	)
+
+	mgrTellRef := actor.NewMapInputRef[
+		vtxo.ManagerMsg, vtxo.ManagerMsg,
+	](mgrRef, func(m vtxo.ManagerMsg) vtxo.ManagerMsg {
+		return m
+	})
+
+	err := mgrActor.Start(t.Context(), mgrTellRef)
+	require.NoError(t, err)
+
+	store.setReady()
+
+	// Register a stub round actor under the well-known service key
+	// so the wallet can forward TriggerVTXOSendMsg to it.
+	roundStub := newStubRoundActor()
+	roundKey := actormsg.RoundActorServiceKey()
+	roundKey.Spawn(
+		system, actormsg.RoundActorServiceKeyName,
+		roundStub,
+	)
+
+	walletActor := wallet.NewArk(
+		nil, nil, nil, system, btclog.Disabled,
+	)
+
+	return walletActor, roundStub
+}
+
+// TestSendVTXOsIntegration exercises the full wallet→manager→round flow:
+// the wallet selects and locks VTXOs, computes change, and forwards a
+// TriggerVTXOSendMsg to the round actor with the correct forfeit
+// outpoints, recipients, and change amount.
+func TestSendVTXOsIntegration(t *testing.T) {
+	t.Parallel()
+
+	t.Run("sends_with_change", func(t *testing.T) {
+		t.Parallel()
+
+		vtxo1 := makeDescriptor(1, 100_000)
+		vtxo2 := makeDescriptor(2, 50_000)
+
+		w, roundStub := setupSendVTXOTest(
+			t, []*vtxo.Descriptor{vtxo1, vtxo2},
+		)
+		ctx := t.Context()
+
+		// Send 80k to one recipient. Largest-first selects
+		// vtxo1 (100k), leaving 20k change.
+		recipients := []actormsg.SendRecipient{{
+			PkScript: []byte{0x51, 0x20, 0xAA},
+			Amount:   80_000,
+		}}
+
+		result := w.Receive(ctx, &wallet.SendVTXOsRequest{
+			Recipients:  recipients,
+			TotalAmount: 80_000,
+		})
+		require.True(t, result.IsOk(),
+			"send: %v", result.Err())
+
+		resp, err := result.Unpack()
+		require.NoError(t, err)
+
+		//nolint:forcetypeassert
+		sr := resp.(*wallet.SendVTXOsResponse)
+		require.Equal(t, 1, sr.SelectedCount)
+		require.Equal(t,
+			btcutil.Amount(100_000), sr.TotalSelected)
+		require.Equal(t,
+			btcutil.Amount(20_000), sr.ChangeAmount)
+
+		// Verify the round actor received the send message.
+		sendMsg := roundStub.waitForSend(t)
+		require.Len(t, sendMsg.ForfeitOutpoints, 1)
+		require.Equal(t, vtxo1.Outpoint,
+			sendMsg.ForfeitOutpoints[0])
+		require.Len(t, sendMsg.Recipients, 1)
+		require.Equal(t, int64(80_000),
+			sendMsg.Recipients[0].Amount)
+		require.Equal(t, int64(20_000),
+			sendMsg.ChangeAmount)
+	})
+
+	t.Run("sends_exact_amount_no_change", func(t *testing.T) {
+		t.Parallel()
+
+		vtxo1 := makeDescriptor(10, 50_000)
+
+		w, roundStub := setupSendVTXOTest(
+			t, []*vtxo.Descriptor{vtxo1},
+		)
+		ctx := t.Context()
+
+		recipients := []actormsg.SendRecipient{{
+			PkScript: []byte{0x51, 0x20, 0xBB},
+			Amount:   50_000,
+		}}
+
+		result := w.Receive(ctx, &wallet.SendVTXOsRequest{
+			Recipients:  recipients,
+			TotalAmount: 50_000,
+		})
+		require.True(t, result.IsOk(),
+			"send: %v", result.Err())
+
+		resp, err := result.Unpack()
+		require.NoError(t, err)
+
+		//nolint:forcetypeassert
+		sr := resp.(*wallet.SendVTXOsResponse)
+		require.Equal(t, btcutil.Amount(0), sr.ChangeAmount)
+
+		sendMsg := roundStub.waitForSend(t)
+		require.Equal(t, int64(0),
+			sendMsg.ChangeAmount)
+	})
+
+	t.Run("sends_to_multiple_recipients", func(t *testing.T) {
+		t.Parallel()
+
+		vtxo1 := makeDescriptor(20, 200_000)
+
+		w, roundStub := setupSendVTXOTest(
+			t, []*vtxo.Descriptor{vtxo1},
+		)
+		ctx := t.Context()
+
+		recipients := []actormsg.SendRecipient{
+			{
+				PkScript: []byte{0x51, 0x20, 0x01},
+				Amount:   60_000,
+			},
+			{
+				PkScript: []byte{0x51, 0x20, 0x02},
+				Amount:   40_000,
+			},
+		}
+
+		result := w.Receive(ctx, &wallet.SendVTXOsRequest{
+			Recipients:  recipients,
+			TotalAmount: 100_000,
+		})
+		require.True(t, result.IsOk(),
+			"send: %v", result.Err())
+
+		resp, err := result.Unpack()
+		require.NoError(t, err)
+
+		//nolint:forcetypeassert
+		sr := resp.(*wallet.SendVTXOsResponse)
+		require.Equal(t,
+			btcutil.Amount(100_000), sr.ChangeAmount)
+
+		sendMsg := roundStub.waitForSend(t)
+		require.Len(t, sendMsg.Recipients, 2)
+		require.Equal(t, int64(60_000),
+			sendMsg.Recipients[0].Amount)
+		require.Equal(t, int64(40_000),
+			sendMsg.Recipients[1].Amount)
+	})
+
+	t.Run("insufficient_balance", func(t *testing.T) {
+		t.Parallel()
+
+		vtxo1 := makeDescriptor(30, 10_000)
+
+		w, _ := setupSendVTXOTest(
+			t, []*vtxo.Descriptor{vtxo1},
+		)
+		ctx := t.Context()
+
+		recipients := []actormsg.SendRecipient{{
+			PkScript: []byte{0x51, 0x20, 0xCC},
+			Amount:   50_000,
+		}}
+
+		result := w.Receive(ctx, &wallet.SendVTXOsRequest{
+			Recipients:  recipients,
+			TotalAmount: 50_000,
+		})
+		require.True(t, result.IsErr())
+		require.Contains(t, result.Err().Error(),
+			"insufficient")
+	})
+
+	t.Run("locks_vtxos_during_send", func(t *testing.T) {
+		t.Parallel()
+
+		vtxo1 := makeDescriptor(40, 100_000)
+
+		w, _ := setupSendVTXOTest(
+			t, []*vtxo.Descriptor{vtxo1},
+		)
+		ctx := t.Context()
+
+		// First send locks vtxo1.
+		recipients := []actormsg.SendRecipient{{
+			PkScript: []byte{0x51, 0x20, 0xDD},
+			Amount:   50_000,
+		}}
+
+		result := w.Receive(ctx, &wallet.SendVTXOsRequest{
+			Recipients:  recipients,
+			TotalAmount: 50_000,
+		})
+		require.True(t, result.IsOk())
+
+		// Second send should fail since vtxo1 is locked.
+		result = w.Receive(ctx, &wallet.SendVTXOsRequest{
+			Recipients:  recipients,
+			TotalAmount: 50_000,
+		})
+		require.True(t, result.IsErr())
+		require.Contains(t, result.Err().Error(),
+			"insufficient")
+	})
 }

--- a/lib/actormsg/interfaces.go
+++ b/lib/actormsg/interfaces.go
@@ -195,6 +195,46 @@ func (m *TriggerVTXORefreshMsg) MessageType() string {
 	return "TriggerVTXORefreshMsg"
 }
 
+// SendRecipient describes a single recipient in an in-round directed send.
+// The PkScript is a fully constructed VTXO taproot output script.
+type SendRecipient struct {
+	// PkScript is the recipient's VTXO output script. This must be a
+	// valid P2TR script constructed via tree.NewVTXODescriptor or
+	// equivalent.
+	PkScript []byte
+
+	// Amount is the value to send to this recipient in satoshis.
+	Amount int64
+}
+
+// TriggerVTXOSendMsg is sent from the wallet actor to the round actor to
+// request an in-round directed send. The wallet has already performed coin
+// selection and locking; this message carries a complete intent package with
+// forfeited VTXOs, recipient outputs, and optional change.
+type TriggerVTXOSendMsg struct {
+	actor.BaseMessage
+
+	// ForfeitOutpoints identifies the VTXOs to forfeit as inputs
+	// (from coin selection).
+	ForfeitOutpoints []wire.OutPoint
+
+	// Recipients describes the recipient outputs to create in the new
+	// round.
+	Recipients []SendRecipient
+
+	// ChangeAmount is the change value in satoshis to return to the
+	// sender as a new self-VTXO. Zero means no change output.
+	ChangeAmount int64
+}
+
+// RoundReceivable implements the RoundReceivable marker interface.
+func (m *TriggerVTXOSendMsg) RoundReceivable() {}
+
+// MessageType returns the message type for logging.
+func (m *TriggerVTXOSendMsg) MessageType() string {
+	return "TriggerVTXOSendMsg"
+}
+
 // TriggerVTXOLeaveMsg is sent from the wallet actor to the round actor to
 // request leave (offboard) of specific VTXOs. The VTXOs will be forfeited and
 // their value sent to the specified destination output.

--- a/round/actor.go
+++ b/round/actor.go
@@ -811,6 +811,9 @@ func (a *RoundClientActor) Receive(ctx context.Context,
 	case *actormsg.TriggerVTXOLeaveMsg:
 		return a.handleTriggerVTXOLeave(ctx, m)
 
+	case *actormsg.TriggerVTXOSendMsg:
+		return a.handleTriggerVTXOSend(ctx, m)
+
 	default:
 		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 			"unknown message type: %T", msg))
@@ -1937,4 +1940,146 @@ func (a *RoundClientActor) handleTriggerVTXOLeave(ctx context.Context,
 		slog.Int("count", triggeredCount))
 
 	return fn.Ok[actormsg.RoundActorResp](nil)
+}
+
+// handleTriggerVTXOSend processes a directed in-round send from the wallet
+// actor. The wallet has already selected and locked VTXOs; this handler builds
+// the IntentPackage (forfeits + recipient VTXOs + optional change) and feeds
+// it to the round FSM. It then triggers each forfeited VTXO actor with
+// TriggerSendForfeitEvent so they transition to RefreshRequestedState, ready
+// for forfeit signing when the round provides connector details.
+func (a *RoundClientActor) handleTriggerVTXOSend(ctx context.Context,
+	cmd *actormsg.TriggerVTXOSendMsg) fn.Result[actormsg.RoundActorResp] {
+
+	if a.cfg.ActorSystem == nil {
+		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
+			"ActorSystem not configured, cannot handle send",
+		))
+	}
+
+	// Find a pending round or create one.
+	roundFSM := a.findPendingRound()
+	if roundFSM == nil {
+		var err error
+		roundFSM, err = a.createNewRound(ctx)
+		if err != nil {
+			return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
+				"failed to create round for send: %w", err,
+			))
+		}
+	}
+
+	// Build forfeit requests from the wallet's selected outpoints.
+	forfeits := make(
+		[]types.ForfeitRequest, 0, len(cmd.ForfeitOutpoints),
+	)
+	for i := range cmd.ForfeitOutpoints {
+		forfeits = append(forfeits, types.ForfeitRequest{
+			VTXOOutpoint: &cmd.ForfeitOutpoints[i],
+		})
+	}
+
+	// Build recipient VTXORequests. Each recipient has a pre-computed
+	// pkScript; we derive a local signing key for MuSig2 tree
+	// co-signing.
+	vtxoReqs := make(
+		[]types.VTXORequest, 0,
+		len(cmd.Recipients)+1,
+	)
+	for _, recip := range cmd.Recipients {
+		vReq, err := a.buildSendVTXORequest(
+			ctx, recip.PkScript,
+			btcutil.Amount(recip.Amount),
+		)
+		if err != nil {
+			return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
+				"build recipient VTXO request: %w", err,
+			))
+		}
+
+		vtxoReqs = append(vtxoReqs, *vReq)
+	}
+
+	// If there is change, add a self-VTXO via the standard
+	// buildVTXORequest which derives a fresh key for the sender.
+	if cmd.ChangeAmount > 0 {
+		changeReq, err := a.buildVTXORequest(
+			ctx, btcutil.Amount(cmd.ChangeAmount),
+		)
+		if err != nil {
+			return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
+				"build change VTXO request: %w", err,
+			))
+		}
+
+		vtxoReqs = append(vtxoReqs, *changeReq)
+	}
+
+	// Feed the complete intent package to the round FSM.
+	pkg := &IntentPackage{Intents: Intents{
+		Forfeits: forfeits,
+		VTXOs:    vtxoReqs,
+	}}
+	err := a.askEventAndProcessOutbox(ctx, roundFSM, pkg)
+	if err != nil {
+		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
+			"FSM error processing send package: %w", err,
+		))
+	}
+
+	a.log.InfoS(ctx, "Queued in-round send",
+		slog.Int("forfeits", len(forfeits)),
+		slog.Int("recipients", len(cmd.Recipients)),
+		slog.Int64("change", cmd.ChangeAmount))
+
+	// Trigger each forfeited VTXO actor so it transitions to
+	// RefreshRequestedState for forfeit signing. We use
+	// TriggerSendForfeitEvent which emits only a status update
+	// (no ForfeitRequest outbox) since we already have the intent.
+	for _, outpoint := range cmd.ForfeitOutpoints {
+		serviceKey := actormsg.VTXOActorServiceKey(outpoint)
+		err := serviceKey.Ref(a.cfg.ActorSystem).Tell(
+			ctx, &TriggerSendForfeitEvent{},
+		)
+		if err != nil {
+			a.log.WarnS(ctx,
+				"Failed to send forfeit trigger "+
+					"to VTXO actor",
+				err,
+				slog.String(
+					"outpoint",
+					outpoint.String(),
+				))
+		}
+	}
+
+	return fn.Ok[actormsg.RoundActorResp](nil)
+}
+
+// buildSendVTXORequest constructs a VTXORequest for a send recipient. Unlike
+// buildVTXORequest (which derives the full VTXO descriptor from scratch), this
+// uses a pre-computed pkScript from the recipient. A local signing key is still
+// derived for MuSig2 tree co-signing during round participation.
+func (a *RoundClientActor) buildSendVTXORequest(ctx context.Context,
+	pkScript []byte,
+	amount btcutil.Amount) (*types.VTXORequest, error) {
+
+	keyDesc, err := a.cfg.Wallet.DeriveNextKey(
+		ctx, keychain.KeyFamilyMultiSig,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("derive signing key: %w", err)
+	}
+
+	operatorKey := a.cfg.OperatorTerms.PubKey
+	expiry := a.cfg.OperatorTerms.VTXOExitDelay
+
+	return &types.VTXORequest{
+		Amount:      amount,
+		PkScript:    pkScript,
+		Expiry:      expiry,
+		ClientKey:   keyDesc.PubKey,
+		OperatorKey: operatorKey,
+		SigningKey:  *keyDesc,
+	}, nil
 }

--- a/round/actor_test.go
+++ b/round/actor_test.go
@@ -5,11 +5,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
 	"github.com/lightninglabs/darepo-client/internal/testutils"
+	"github.com/lightninglabs/darepo-client/lib/actormsg"
 	"github.com/lightninglabs/darepo-client/lib/tree"
 	"github.com/lightninglabs/darepo-client/lib/types"
 	"github.com/lightninglabs/darepo-client/timeout"
@@ -1938,5 +1940,198 @@ func TestActorIntentMapping(t *testing.T) {
 			t, assembly.Forfeits, 1,
 			"duplicate forfeit outpoint should be deduplicated",
 		)
+	})
+}
+
+// TestHandleTriggerVTXOSend verifies that TriggerVTXOSendMsg from the wallet
+// is processed into a correct IntentPackage with forfeits, recipient VTXOs,
+// and optional change.
+func TestHandleTriggerVTXOSend(t *testing.T) {
+	t.Parallel()
+
+	t.Run("errors_without_actor_system", func(t *testing.T) {
+		t.Parallel()
+
+		h := newActorTestHarness(t)
+		h.setupMockRoundStoreForStart()
+
+		err := h.start()
+		require.NoError(t, err)
+
+		// The default harness has no ActorSystem, so the handler
+		// should return an error.
+		sendMsg := &actormsg.TriggerVTXOSendMsg{
+			ForfeitOutpoints: []wire.OutPoint{{
+				Hash:  chainhash.HashH([]byte("vtxo-1")),
+				Index: 0,
+			}},
+			Recipients: []actormsg.SendRecipient{{
+				PkScript: []byte{0x51, 0x20},
+				Amount:   50000,
+			}},
+			ChangeAmount: 0,
+		}
+
+		result := h.receive(sendMsg)
+		require.True(t, result.IsErr(),
+			"expected error without ActorSystem")
+	})
+
+	t.Run("queues_send_with_recipients_and_change",
+		func(t *testing.T) {
+			t.Parallel()
+
+			h := newActorTestHarness(t)
+			h.setupMockRoundStoreForStart()
+
+			// Wire up an actor system so the handler can
+			// derive keys and trigger VTXO actors.
+			system := actor.NewActorSystem()
+			t.Cleanup(func() {
+				_ = system.Shutdown(t.Context())
+			})
+			h.actor.cfg.ActorSystem = system
+
+			// Mock DeriveNextKey for recipient and change
+			// VTXO requests (KeyFamilyMultiSig).
+			signingKey, err := btcec.NewPrivateKey()
+			require.NoError(t, err)
+
+			h.wallet.On(
+				"DeriveNextKey", mock.Anything,
+				keychain.KeyFamilyMultiSig,
+			).Return(&keychain.KeyDescriptor{
+				PubKey: signingKey.PubKey(),
+			}, nil)
+
+			err = h.start()
+			require.NoError(t, err)
+
+			vtxo1 := wire.OutPoint{
+				Hash:  chainhash.HashH([]byte("send-1")),
+				Index: 0,
+			}
+			vtxo2 := wire.OutPoint{
+				Hash:  chainhash.HashH([]byte("send-2")),
+				Index: 1,
+			}
+
+			sendMsg := &actormsg.TriggerVTXOSendMsg{
+				ForfeitOutpoints: []wire.OutPoint{
+					vtxo1, vtxo2,
+				},
+				Recipients: []actormsg.SendRecipient{{
+					PkScript: []byte{
+						0x51, 0x20, 0x01,
+					},
+					Amount: 40000,
+				}, {
+					PkScript: []byte{
+						0x51, 0x20, 0x02,
+					},
+					Amount: 30000,
+				}},
+				ChangeAmount: 5000,
+			}
+
+			result := h.receive(sendMsg)
+			require.True(t, result.IsOk(),
+				"expected Ok, got: %v", result.Err())
+
+			// Verify the FSM has the intent package.
+			states := h.queryState()
+			tempState, exists := h.findTempState(states)
+			require.True(t, exists,
+				"expected temp-keyed FSM state")
+
+			assembly, ok := tempState.State.(*PendingRoundAssembly)
+			require.True(t, ok,
+				"expected PendingRoundAssembly, got %T",
+				tempState.State)
+
+			// Two forfeit inputs.
+			require.Len(t, assembly.Forfeits, 2)
+			require.Equal(t, vtxo1,
+				*assembly.Forfeits[0].VTXOOutpoint)
+			require.Equal(t, vtxo2,
+				*assembly.Forfeits[1].VTXOOutpoint)
+
+			// Two recipient VTXOs + one change VTXO = 3.
+			require.Len(t, assembly.VTXOs, 3,
+				"expected 2 recipients + 1 change")
+
+			// First two are recipients with their pkScripts.
+			require.Equal(t,
+				btcutil.Amount(40000),
+				assembly.VTXOs[0].Amount)
+			require.Equal(t,
+				btcutil.Amount(30000),
+				assembly.VTXOs[1].Amount)
+
+			// Third is change.
+			require.Equal(t,
+				btcutil.Amount(5000),
+				assembly.VTXOs[2].Amount)
+		},
+	)
+
+	t.Run("queues_send_without_change", func(t *testing.T) {
+		t.Parallel()
+
+		h := newActorTestHarness(t)
+		h.setupMockRoundStoreForStart()
+
+		system := actor.NewActorSystem()
+		t.Cleanup(func() {
+			_ = system.Shutdown(t.Context())
+		})
+		h.actor.cfg.ActorSystem = system
+
+		signingKey, err := btcec.NewPrivateKey()
+		require.NoError(t, err)
+
+		h.wallet.On(
+			"DeriveNextKey", mock.Anything,
+			keychain.KeyFamilyMultiSig,
+		).Return(&keychain.KeyDescriptor{
+			PubKey: signingKey.PubKey(),
+		}, nil)
+
+		err = h.start()
+		require.NoError(t, err)
+
+		sendMsg := &actormsg.TriggerVTXOSendMsg{
+			ForfeitOutpoints: []wire.OutPoint{{
+				Hash: chainhash.HashH(
+					[]byte("exact-send"),
+				),
+				Index: 0,
+			}},
+			Recipients: []actormsg.SendRecipient{{
+				PkScript: []byte{0x51, 0x20},
+				Amount:   50000,
+			}},
+			ChangeAmount: 0,
+		}
+
+		result := h.receive(sendMsg)
+		require.True(t, result.IsOk(),
+			"expected Ok, got: %v", result.Err())
+
+		states := h.queryState()
+		tempState, exists := h.findTempState(states)
+		require.True(t, exists)
+
+		assembly, ok := tempState.State.(*PendingRoundAssembly)
+		require.True(t, ok)
+
+		require.Len(t, assembly.Forfeits, 1)
+
+		// Only 1 recipient, no change.
+		require.Len(t, assembly.VTXOs, 1,
+			"expected 1 recipient, no change")
+		require.Equal(t,
+			btcutil.Amount(50000),
+			assembly.VTXOs[0].Amount)
 	})
 }

--- a/round/vtxo_messages.go
+++ b/round/vtxo_messages.go
@@ -219,6 +219,24 @@ func (e *TriggerLeaveEvent) VTXOActorMsg() {}
 // MessageType returns the message type for logging.
 func (e *TriggerLeaveEvent) MessageType() string { return "TriggerLeaveEvent" }
 
+// TriggerSendForfeitEvent is sent to a VTXO actor to prepare it for forfeit
+// signing as part of an in-round directed send. Unlike TriggerRefreshEvent,
+// this does NOT emit a ForfeitRequest outbox message because the round actor
+// already has the complete IntentPackage from TriggerVTXOSendMsg. The VTXO
+// actor only needs to transition to RefreshRequestedState so it is ready to
+// sign the forfeit transaction when the round provides connector details.
+type TriggerSendForfeitEvent struct {
+	actor.BaseMessage
+}
+
+// VTXOActorMsg implements actormsg.VTXOActorMsg marker interface.
+func (e *TriggerSendForfeitEvent) VTXOActorMsg() {}
+
+// MessageType returns the message type for logging.
+func (e *TriggerSendForfeitEvent) MessageType() string {
+	return "TriggerSendForfeitEvent"
+}
+
 // =============================================================================
 // Messages TO VTXO Manager
 // =============================================================================

--- a/vtxo/events.go
+++ b/vtxo/events.go
@@ -48,4 +48,9 @@ type (
 	// request. The VTXO will be forfeited and the value sent to the
 	// specified destination output.
 	TriggerLeaveEvent = round.TriggerLeaveEvent
+
+	// TriggerSendForfeitEvent is sent to prepare a VTXO for forfeit
+	// signing as part of an in-round directed send. Transitions to
+	// RefreshRequestedState without emitting a ForfeitRequest outbox.
+	TriggerSendForfeitEvent = round.TriggerSendForfeitEvent
 )

--- a/vtxo/transitions.go
+++ b/vtxo/transitions.go
@@ -30,6 +30,9 @@ func (s *LiveState) ProcessEvent(
 	case *TriggerLeaveEvent:
 		return s.handleTriggerLeave(ctx, evt, env)
 
+	case *TriggerSendForfeitEvent:
+		return s.handleTriggerSendForfeit(ctx, evt, env)
+
 	case *ResumeVTXOEvent:
 		// On resume, stay in LiveState and re-check expiry on next
 		// block.
@@ -209,6 +212,31 @@ func (s *LiveState) handleTriggerRefresh(
 		NextState: &RefreshRequestedState{
 			VTXO: s.VTXO,
 			// Manual trigger, no height context.
+			RequestedAtHeight: 0,
+		},
+		NewEvents: fn.Some(VTXOEmittedEvent{Outbox: outbox}),
+	}, nil
+}
+
+// handleTriggerSendForfeit handles a send forfeit trigger from the round actor.
+// This transitions the VTXO to RefreshRequestedState with only a status update
+// outbox (no ForfeitRequest), because the round actor already has the complete
+// IntentPackage from the wallet's TriggerVTXOSendMsg.
+func (s *LiveState) handleTriggerSendForfeit(
+	_ context.Context, _ *TriggerSendForfeitEvent, _ *VTXOEnvironment,
+) (*VTXOStateTransition, error) {
+
+	outbox := []VTXOOutMsg{
+		&VTXOStatusUpdate{
+			Outpoint:  s.VTXO.Outpoint,
+			NewStatus: VTXOStatusRefreshRequested,
+		},
+	}
+
+	return &VTXOStateTransition{
+		NextState: &RefreshRequestedState{
+			VTXO: s.VTXO,
+			// Send-triggered, no height context.
 			RequestedAtHeight: 0,
 		},
 		NewEvents: fn.Some(VTXOEmittedEvent{Outbox: outbox}),

--- a/vtxo/transitions_test.go
+++ b/vtxo/transitions_test.go
@@ -737,6 +737,109 @@ func TestForfeitConfirmedEventIncludesForfeitTx(t *testing.T) {
 }
 
 // TestForfeitSignatureValidity verifies that forfeit signatures produced by
+// TestLiveStateTriggerSendForfeit verifies that a TriggerSendForfeitEvent
+// transitions a LiveState VTXO to RefreshRequestedState with only a
+// VTXOStatusUpdate outbox (no ForfeitRequest, since the round actor already
+// has the IntentPackage from the wallet's TriggerVTXOSendMsg).
+func TestLiveStateTriggerSendForfeit(t *testing.T) {
+	t.Parallel()
+
+	h := newVTXOTestHarness(t)
+	vtxo := h.newTestDescriptor()
+
+	h.withState(&LiveState{
+		VTXO:              vtxo,
+		LastCheckedHeight: 100,
+	})
+
+	evt := &round.TriggerSendForfeitEvent{}
+
+	// Mock the status update that the outbox handler will invoke.
+	h.store.On(
+		"UpdateVTXOStatus", h.ctx, vtxo.Outpoint,
+		VTXOStatusRefreshRequested,
+	).Return(nil)
+
+	_, err := h.sendEvent(evt)
+	require.NoError(t, err)
+
+	// Verify state transition to RefreshRequestedState.
+	state := assertState[*RefreshRequestedState](h)
+	require.Equal(t, vtxo, state.VTXO)
+	require.Equal(t, int32(0), state.RequestedAtHeight,
+		"send-triggered should have no height context")
+
+	// Verify outbox contains VTXOStatusUpdate but NOT ForfeitRequest.
+	// This is the key difference from TriggerRefreshEvent.
+	assertOutboxContains[*VTXOStatusUpdate](h)
+
+	for _, msg := range h.outboxMessages {
+		_, isForfeit := msg.(*ForfeitRequest)
+		require.False(t, isForfeit,
+			"send forfeit should not emit ForfeitRequest")
+	}
+}
+
+// TestLiveStateTriggerSendForfeitThenForfeitRequest verifies the full flow:
+// TriggerSendForfeitEvent transitions to RefreshRequestedState, and a
+// subsequent ForfeitRequestEvent transitions to ForfeitingState with proper
+// forfeit signing.
+func TestLiveStateTriggerSendForfeitThenForfeitRequest(t *testing.T) {
+	t.Parallel()
+
+	h := newVTXOTestHarness(t)
+	vtxo := h.newTestDescriptor()
+
+	h.withState(&LiveState{
+		VTXO:              vtxo,
+		LastCheckedHeight: 100,
+	})
+
+	// Set up the wallet mock for signing.
+	h.setupMockWalletForSigning()
+
+	h.store.On(
+		"UpdateVTXOStatus", h.ctx, vtxo.Outpoint,
+		VTXOStatusRefreshRequested,
+	).Return(nil)
+
+	// Step 1: Send TriggerSendForfeitEvent.
+	_, err := h.sendEvent(&round.TriggerSendForfeitEvent{})
+	require.NoError(t, err)
+
+	assertState[*RefreshRequestedState](h)
+
+	// Clear outbox to isolate step 2 messages.
+	h.outboxMessages = h.outboxMessages[:0]
+
+	// Step 2: Send ForfeitRequestEvent from the round actor.
+	connectorOutpoint := h.newTestOutpoint()
+
+	h.store.On(
+		"UpdateVTXOStatus", h.ctx, vtxo.Outpoint,
+		VTXOStatusForfeiting,
+	).Return(nil)
+
+	forfeitEvt := &round.ForfeitRequestEvent{
+		RoundID:               "round-send-001",
+		ConnectorOutpoint:     connectorOutpoint,
+		ConnectorPkScript:     []byte{0x51, 0x20},
+		ConnectorAmount:       1000,
+		ServerForfeitPkScript: []byte{0x51, 0x20},
+	}
+
+	_, err = h.sendEvent(forfeitEvt)
+	require.NoError(t, err)
+
+	// Verify transition to ForfeitingState with proper fields.
+	fState := assertState[*ForfeitingState](h)
+	require.Equal(t, "round-send-001", fState.NewRoundID)
+	require.Equal(t, connectorOutpoint, fState.ConnectorOutpoint)
+
+	// Verify forfeit signature was submitted.
+	assertOutboxContains[*ForfeitSignatureSubmission](h)
+}
+
 // the VTXO FSM can actually spend the VTXO output when combined with the
 // operator's signature.
 func TestForfeitSignatureValidity(t *testing.T) {

--- a/wallet/messages.go
+++ b/wallet/messages.go
@@ -6,6 +6,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
 	"github.com/lightninglabs/darepo-client/chainsource"
+	"github.com/lightninglabs/darepo-client/lib/actormsg"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 )
 
@@ -394,6 +395,52 @@ func (m *UnlockVTXOsResponse) MessageType() string {
 
 // walletRespSealed implements the sealed WalletResp interface.
 func (m *UnlockVTXOsResponse) walletRespSealed() {}
+
+// SendVTXOsRequest asks the wallet actor to perform an in-round directed send.
+// The wallet selects and locks VTXOs covering TotalAmount, then builds and
+// forwards a TriggerVTXOSendMsg to the round actor with the selected forfeit
+// inputs, recipient outputs, and change.
+type SendVTXOsRequest struct {
+	actor.BaseMessage
+
+	// Recipients describes the destination outputs. Each entry contains
+	// a fully constructed VTXO pkScript and amount.
+	Recipients []actormsg.SendRecipient
+
+	// TotalAmount is the sum of all recipient amounts. The wallet uses
+	// this as the coin selection target.
+	TotalAmount btcutil.Amount
+}
+
+// MessageType returns the message type identifier for logging and debugging.
+func (m *SendVTXOsRequest) MessageType() string {
+	return "SendVTXOsRequest"
+}
+
+// walletMsgSealed implements the sealed WalletMsg interface.
+func (m *SendVTXOsRequest) walletMsgSealed() {}
+
+// SendVTXOsResponse indicates the result of the send request.
+type SendVTXOsResponse struct {
+	actor.BaseMessage
+
+	// SelectedCount is the number of VTXOs selected as forfeit inputs.
+	SelectedCount int
+
+	// TotalSelected is the sum of all selected VTXO amounts.
+	TotalSelected btcutil.Amount
+
+	// ChangeAmount is the change returned to the sender (0 = no change).
+	ChangeAmount btcutil.Amount
+}
+
+// MessageType returns the message type identifier for logging and debugging.
+func (m *SendVTXOsResponse) MessageType() string {
+	return "SendVTXOsResponse"
+}
+
+// walletRespSealed implements the sealed WalletResp interface.
+func (m *SendVTXOsResponse) walletRespSealed() {}
 
 // LeaveVTXOsRequest triggers leave (offboard) of specified VTXOs. The VTXOs
 // will be forfeited and their value sent to the specified destination output.

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -286,6 +286,9 @@ func (a *Ark) Receive(ctx context.Context,
 	case *UnlockVTXOsRequest:
 		return a.handleUnlockVTXOs(ctx, m)
 
+	case *SendVTXOsRequest:
+		return a.handleSendVTXOs(ctx, m)
+
 	default:
 		return fn.Err[WalletResp](
 			fmt.Errorf("unknown message type: %T", msg))
@@ -825,6 +828,105 @@ func (a *Ark) handleUnlockVTXOs(ctx context.Context,
 
 	return fn.Ok[WalletResp](&UnlockVTXOsResponse{
 		UnlockedCount: unlockResp.UnlockedCount,
+	})
+}
+
+// handleSendVTXOs orchestrates an in-round directed send. It asks the VTXO
+// manager to select and lock VTXOs covering the send amount, computes change,
+// then forwards a TriggerVTXOSendMsg to the round actor. On failure the
+// selected VTXOs are unlocked to avoid leaving stale locks.
+func (a *Ark) handleSendVTXOs(ctx context.Context,
+	req *SendVTXOsRequest) fn.Result[WalletResp] {
+
+	if a.actorSystem == nil {
+		return fn.Err[WalletResp](
+			fmt.Errorf("no actor system for VTXO send"),
+		)
+	}
+
+	// Ask the VTXO manager to select and lock VTXOs covering the total
+	// send amount.
+	mgrKey := actormsg.VTXOManagerServiceKey()
+	mgrRef := mgrKey.Ref(a.actorSystem)
+
+	future := mgrRef.Ask(ctx, &actormsg.SelectAndLockVTXOsRequest{
+		TargetAmount: int64(req.TotalAmount),
+	})
+	result := future.Await(ctx)
+
+	resp, err := result.Unpack()
+	if err != nil {
+		return fn.Err[WalletResp](
+			fmt.Errorf("select and lock for send: %w", err),
+		)
+	}
+
+	selectResp, ok := resp.(*actormsg.SelectAndLockVTXOsResponse)
+	if !ok {
+		return fn.Err[WalletResp](fmt.Errorf(
+			"unexpected select response type: %T", resp,
+		))
+	}
+
+	totalSelected := btcutil.Amount(selectResp.TotalSelected)
+	if totalSelected < req.TotalAmount {
+		return fn.Err[WalletResp](fmt.Errorf(
+			"insufficient selection: have %d, need %d",
+			totalSelected, req.TotalAmount,
+		))
+	}
+
+	// Compute change and build the forfeit outpoints list.
+	changeAmount := totalSelected - req.TotalAmount
+	forfeitOutpoints := make(
+		[]wire.OutPoint, 0, len(selectResp.Selected),
+	)
+	for _, v := range selectResp.Selected {
+		forfeitOutpoints = append(forfeitOutpoints, v.Outpoint)
+	}
+
+	// Forward the complete intent to the round actor.
+	serviceKey := actormsg.RoundActorServiceKey()
+	roundRef := serviceKey.Ref(a.actorSystem)
+
+	err = roundRef.Tell(ctx, &actormsg.TriggerVTXOSendMsg{
+		ForfeitOutpoints: forfeitOutpoints,
+		Recipients:       req.Recipients,
+		ChangeAmount:     int64(changeAmount),
+	})
+	if err != nil {
+		// On Tell failure, unlock the VTXOs to avoid stale locks.
+		a.logger(ctx).WarnS(ctx,
+			"Failed to forward send to round actor, "+
+				"unlocking VTXOs", err)
+
+		unlockFuture := mgrRef.Ask(
+			ctx, &actormsg.UnlockVTXOsRequest{
+				Outpoints: forfeitOutpoints,
+			},
+		)
+		unlockResult := unlockFuture.Await(ctx)
+		if unlockResult.IsErr() {
+			a.logger(ctx).WarnS(ctx,
+				"Failed to unlock VTXOs after send "+
+					"failure", unlockResult.Err())
+		}
+
+		return fn.Err[WalletResp](
+			fmt.Errorf("forward send to round actor: %w", err),
+		)
+	}
+
+	a.logger(ctx).InfoS(ctx, "Forwarded VTXO send to round actor",
+		slog.Int("selected", len(selectResp.Selected)),
+		slog.Int64("total_selected", int64(totalSelected)),
+		slog.Int64("change", int64(changeAmount)),
+		slog.Int("recipients", len(req.Recipients)))
+
+	return fn.Ok[WalletResp](&SendVTXOsResponse{
+		SelectedCount: len(selectResp.Selected),
+		TotalSelected: totalSelected,
+		ChangeAmount:  changeAmount,
 	})
 }
 


### PR DESCRIPTION
## Summary

Implements a first-class in-round send API, completing the `SendVTXO`
RPC that was previously stubbed as `codes.Unimplemented`.

Closes https://github.com/lightninglabs/darepo-client/issues/156 (takes
a different approach — wallet-orchestrated flow rather than round-driven).

Depends on #168.

## Approach

**Wallet orchestrates the send flow**: `SendVTXO RPC → wallet (coin
select + lock) → wallet sends complete intent to round actor`. The round
actor receives a fully assembled package rather than having to coordinate
coin selection itself.

### Key design decisions

1. **TriggerSendForfeitEvent vs TriggerRefreshEvent**: A new VTXO actor
   event avoids the `ForfeitRequest → RefreshVTXORequest` round-trip
   that refresh uses. The round actor already has the IntentPackage from
   the wallet; VTXO actors just need to be in `RefreshRequestedState`
   for forfeit signing.

2. **Recipient key format**: v1 supports `pubkey` (32-byte x-only →
   full VTXO descriptor) and `pk_script` (pre-computed tapscript)
   destinations. `address` destinations need an Ark-specific address
   format (future work).

3. **Change handling**: `changeAmount = totalSelected - totalAmount`. If
   > 0, a change VTXORequest is added via the existing `buildVTXORequest`
   (self-VTXO with fresh key derivation).

### Data flow

```
RPC SendVTXO
  → resolve recipients to VTXO pkScripts
  → wallet.SendVTXOsRequest (Ask)
    → VTXO manager: SelectAndLockVTXOs
    → compute change
    → round actor: TriggerVTXOSendMsg (Tell)
      → build IntentPackage (forfeits + recipient VTXOs + change)
      → feed to round FSM
      → trigger each VTXO actor: TriggerSendForfeitEvent
        → transition to RefreshRequestedState (no ForfeitRequest outbox)
        → ready for forfeit signing when round provides connectors
```

## Files changed

| File | What |
|------|------|
| `lib/actormsg/interfaces.go` | `SendRecipient`, `TriggerVTXOSendMsg` |
| `wallet/messages.go` | `SendVTXOsRequest`, `SendVTXOsResponse` |
| `wallet/wallet.go` | `handleSendVTXOs` handler + `Receive()` case |
| `round/vtxo_messages.go` | `TriggerSendForfeitEvent` |
| `vtxo/events.go` | Type alias for `TriggerSendForfeitEvent` |
| `vtxo/transitions.go` | `handleTriggerSendForfeit` in `LiveState` |
| `round/actor.go` | `handleTriggerVTXOSend` + `buildSendVTXORequest` |
| `darepod/rpc_server.go` | Complete `SendVTXO` handler |

## Test plan

- [x] `make build` compiles
- [x] `make lint` passes
- [x] VTXO transition unit tests (`TestLiveStateTriggerSendForfeit`,
  `TestLiveStateTriggerSendForfeitThenForfeitRequest`)
- [x] Round actor unit tests (`TestHandleTriggerVTXOSend` — error
  without actor system, send with recipients + change, send without
  change)
- [x] Integration tests (`TestSendVTXOsIntegration` — full
  wallet→manager→round flow with real actor system: send with change,
  exact amount, multiple recipients, insufficient balance, lock
  exclusion)