### PR TITLE
oor: real owner leaf signing and post-commit deferral

### DIFF
--- a/baselib/actor/durable_actor.go
+++ b/baselib/actor/durable_actor.go
@@ -412,8 +412,24 @@ func (a *DurableActor[M, R]) processInTransaction(
 		return
 	}
 
-	// Transaction committed -- now it is safe to complete the
-	// in-memory promise so the caller observes the result.
+	// Transaction committed — flush any post-commit work the
+	// behavior buffered during Receive. This is needed when the
+	// behavior must Tell another durable actor backed by the same
+	// SQLite database: doing so inside the transaction would
+	// deadlock on the write lock.
+	if pch, ok := a.behavior.(PostCommitHandler); ok {
+		if pcErr := pch.FlushPostCommit(ctx); pcErr != nil {
+			log.WarnS(ctx,
+				"Post-commit flush failed "+
+					"(will retry on resume)",
+				pcErr,
+				"actor_id", a.id,
+				"delivery_id", delivery.ID)
+		}
+	}
+
+	// Now it is safe to complete the in-memory promise so the
+	// caller observes the result.
 	if delivery.IsAsk() && delivery.Promise != nil {
 		delivery.Promise.Complete(behaviorResult)
 	}
@@ -433,6 +449,16 @@ func (a *DurableActor[M, R]) processWithoutTransaction(
 
 	// Execute behavior with panic recovery.
 	result := a.executeBehaviorSafely(ctx, delivery)
+
+	// Flush any post-commit work the behavior buffered during
+	// Receive (e.g. transport events to sibling durable actors).
+	// Without a wrapping transaction, flush failures convert the
+	// result to an error so the caller can retry.
+	if pch, ok := a.behavior.(PostCommitHandler); ok {
+		if pcErr := pch.FlushPostCommit(ctx); pcErr != nil {
+			result = fn.Err[R](pcErr)
+		}
+	}
 
 	// For Ask messages, avoid marking as processed until after ack has
 	// succeeded. This prevents a crash between MarkProcessed and Ack from

--- a/baselib/actor/interface.go
+++ b/baselib/actor/interface.go
@@ -156,6 +156,25 @@ type Stoppable interface {
 	OnStop(ctx context.Context) error
 }
 
+// PostCommitHandler is an optional interface that DurableActor behaviors
+// can implement to perform work after the message-processing transaction
+// commits. This is critical for behaviors that need to send messages to
+// other durable actors backed by the same SQLite database — doing so
+// inside the transaction would deadlock because SQLite only allows one
+// concurrent writer.
+//
+// FlushPostCommit is called with a fresh (non-transactional) context
+// after the transaction commits successfully. Errors are logged but do
+// not cause the message to be re-delivered, since the checkpoint was
+// already persisted within the transaction. The behavior should rely on
+// its FSM resume logic to retry any lost post-commit work on restart.
+type PostCommitHandler interface {
+	// FlushPostCommit executes deferred side-effects that were
+	// buffered during Receive but must run outside the database
+	// transaction.
+	FlushPostCommit(ctx context.Context) error
+}
+
 // SystemContext defines the minimal interface for system capabilities needed
 // by actors and service keys. This narrow interface enables dependency
 // injection and unit testing without requiring a full ActorSystem instance.

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
@@ -17,6 +18,7 @@ import (
 	"github.com/lightninglabs/darepo-client/build"
 	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/lightninglabs/darepo-client/lib/scripts"
+	"github.com/lightninglabs/darepo-client/lib/types"
 	oortx "github.com/lightninglabs/darepo-client/lib/tx/oor"
 	"github.com/lightninglabs/darepo-client/lwwallet"
 	"github.com/lightninglabs/darepo-client/oor"
@@ -696,10 +698,18 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 			"amount must be positive")
 	}
 
+	// Fetch operator terms early so pubkey destinations can derive
+	// VTXO-compatible pkScripts.
+	terms, err := r.server.fetchOperatorTerms(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"unable to fetch operator terms: %v", err)
+	}
+
 	// Resolve the recipient's pkScript from the destination
 	// oneof.
 	pkScript, err := r.resolveOutputPkScript(
-		req.Recipient,
+		req.Recipient, terms,
 	)
 	if err != nil {
 		return nil, err
@@ -725,13 +735,6 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 	if r.server.vtxoStore == nil {
 		return nil, status.Errorf(codes.Internal,
 			"VTXO store not initialized")
-	}
-
-	// Fetch operator terms for the checkpoint policy.
-	terms, err := r.server.fetchOperatorTerms(ctx)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal,
-			"unable to fetch operator terms: %v", err)
 	}
 
 	policy := scripts.CheckpointPolicy{
@@ -870,9 +873,11 @@ func (r *RPCServer) unlockVTXOs(ctx context.Context,
 
 // resolveOutputPkScript derives a pkScript from the Output's
 // destination oneof. It supports address, raw pubkey, and raw
-// pkScript destinations.
+// pkScript destinations. The operator terms are required for
+// pubkey destinations to build a VTXO-compatible taproot output.
 func (r *RPCServer) resolveOutputPkScript(
-	out *daemonrpc.Output) ([]byte, error) {
+	out *daemonrpc.Output,
+	terms *types.OperatorTerms) ([]byte, error) {
 
 	switch d := out.Destination.(type) {
 	case *daemonrpc.Output_Address:
@@ -896,6 +901,36 @@ func (r *RPCServer) resolveOutputPkScript(
 		}
 
 		return pkScript, nil
+
+	case *daemonrpc.Output_Pubkey:
+		if len(d.Pubkey) == 0 {
+			return nil, status.Errorf(
+				codes.InvalidArgument,
+				"pubkey is empty",
+			)
+		}
+
+		recipientKey, err := schnorr.ParsePubKey(d.Pubkey)
+		if err != nil {
+			return nil, status.Errorf(
+				codes.InvalidArgument,
+				"invalid pubkey: %v", err,
+			)
+		}
+
+		tapKey, err := scripts.VTXOTapKey(
+			recipientKey, terms.PubKey,
+			terms.VTXOExitDelay,
+		)
+		if err != nil {
+			return nil, status.Errorf(
+				codes.Internal,
+				"unable to derive VTXO tap key: %v",
+				err,
+			)
+		}
+
+		return txscript.PayToTaprootScript(tapKey)
 
 	case *daemonrpc.Output_PkScript:
 		if len(d.PkScript) == 0 {

--- a/darepod/wallet_ops.go
+++ b/darepod/wallet_ops.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/scripts"
 	"github.com/lightninglabs/darepo-client/oor"
 	"github.com/lightninglabs/darepo-client/vtxo"
 	"github.com/lightningnetwork/lnd/aezeed"
@@ -121,9 +122,19 @@ func BuildTransferInputs(ctx context.Context,
 			)
 		}
 
+		ownerLeaf, err := scripts.OwnerCheckSigLeaf(
+			desc.ClientKey.PubKey,
+		)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"build owner leaf for %s: %w",
+				op, err,
+			)
+		}
+
 		inputs = append(inputs, oor.TransferInput{
 			VTXO:            desc,
-			OwnerLeafScript: desc.PkScript,
+			OwnerLeafScript: ownerLeaf,
 		})
 	}
 

--- a/lib/scripts/checkpoint_owner.go
+++ b/lib/scripts/checkpoint_owner.go
@@ -1,0 +1,31 @@
+package scripts
+
+import (
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/txscript"
+)
+
+// OwnerCheckSigLeaf builds the single-sig owner leaf script for a checkpoint
+// taproot tree.
+//
+// The resulting script is:
+//
+//	<schnorr_pubkey> OP_CHECKSIG
+//
+// This leaf is spent by the client alone (no operator co-signature) and is
+// used as the collaborative/owner path in the checkpoint output. The operator
+// path uses a CSV-delayed unilateral unroll leaf.
+func OwnerCheckSigLeaf(pubkey *btcec.PublicKey) ([]byte, error) {
+	if pubkey == nil {
+		return nil, fmt.Errorf("pubkey must be provided")
+	}
+
+	builder := txscript.NewScriptBuilder()
+	builder.AddData(schnorr.SerializePubKey(pubkey))
+	builder.AddOp(txscript.OP_CHECKSIG)
+
+	return builder.Script()
+}

--- a/oor/actor.go
+++ b/oor/actor.go
@@ -283,6 +283,19 @@ type oorDurableBehavior struct {
 	cfg ClientActorCfg
 
 	sessions map[SessionID]*sessionHandle
+
+	// pendingTransport collects transport events (submit, finalize,
+	// ack) that must be sent to the serverconn actor AFTER the
+	// database transaction commits. Sending inside the transaction
+	// would deadlock because both actors share the same SQLite
+	// database and SQLite allows only one concurrent writer.
+	pendingTransport []OutboxEvent
+
+	// pendingLocal collects local outbox events that require DB
+	// writes (e.g. MarkInputsSpentRequest) and must be executed
+	// after the durable actor transaction commits to avoid
+	// SQLite write-lock deadlock.
+	pendingLocal []pendingLocalEvent
 }
 
 // logger returns the configured logger or falls back to extracting from
@@ -876,6 +889,32 @@ func (b *oorDurableBehavior) isTransportEvent(msg OutboxEvent) bool {
 	}
 }
 
+// deferredFollowUps returns the optimistic follow-up events for an
+// outbox event that must be deferred to FlushPostCommit due to DB
+// write conflicts. If the event is not deferred, nil is returned.
+//
+// The follow-up events are fed into the FSM during the transaction
+// so the state transition is persisted atomically, while the actual
+// DB side-effect (e.g. marking inputs spent) runs after commit.
+func (b *oorDurableBehavior) deferredFollowUps(
+	msg OutboxEvent) []Event {
+
+	switch msg.(type) {
+	case *MarkInputsSpentRequest:
+		return []Event{&InputsMarkedSpentEvent{}}
+
+	default:
+		return nil
+	}
+}
+
+// pendingLocalEvent pairs a deferred outbox event with its session ID
+// so FlushPostCommit can route it to the correct handler.
+type pendingLocalEvent struct {
+	sessionID SessionID
+	event     OutboxEvent
+}
+
 // sendTransportEvent wraps the outbox message in a SendClientEventRequest and
 // Tell's it to the serverconn actor for durable delivery to the server.
 func (b *oorDurableBehavior) sendTransportEvent(ctx context.Context,
@@ -918,12 +957,45 @@ func (b *oorDurableBehavior) driveOutbox(ctx context.Context,
 		// asynchronously via DriveEventRequest.
 		if b.isTransportEvent(msg) {
 			//nolint:ll
-			b.logger(ctx).DebugS(ctx, "Sending transport event to server",
+			b.logger(ctx).DebugS(ctx, "Buffering transport event for post-commit send",
 				slog.String("session_id", sessionID.String()),
 				slog.String("event_type", fmt.Sprintf("%T", msg)))
 
-			if err := b.sendTransportEvent(ctx, msg); err != nil {
-				return err
+			b.pendingTransport = append(
+				b.pendingTransport, msg,
+			)
+
+			continue
+		}
+
+		// Local outbox events that require DB writes are
+		// deferred to FlushPostCommit to avoid SQLite
+		// write-lock deadlock with the durable actor tx.
+		// Optimistic follow-up events are fed into the FSM
+		// now so the state transition persists atomically.
+		if followUps := b.deferredFollowUps(msg); followUps != nil {
+			//nolint:ll
+			b.logger(ctx).DebugS(ctx, "Buffering local event for post-commit execution",
+				slog.String("session_id", sessionID.String()),
+				slog.String("event_type", fmt.Sprintf("%T", msg)))
+
+			b.pendingLocal = append(
+				b.pendingLocal, pendingLocalEvent{
+					sessionID: sessionID,
+					event:     msg,
+				},
+			)
+
+			// Feed optimistic follow-ups into the FSM so
+			// it transitions (e.g. to Completed) within
+			// this transaction.
+			for _, followUp := range followUps {
+				_, err := b.askEvent(
+					ctx, fsm, followUp,
+				)
+				if err != nil {
+					return err
+				}
 			}
 
 			continue
@@ -1066,3 +1138,49 @@ type durableBehaviorIface = actor.ActorBehavior[
 ]
 
 var _ durableBehaviorIface = (*oorDurableBehavior)(nil)
+
+// Compile-time check: oorDurableBehavior implements PostCommitHandler
+// so transport events are flushed after the database transaction commits.
+var _ actor.PostCommitHandler = (*oorDurableBehavior)(nil)
+
+// FlushPostCommit sends buffered transport events to the serverconn
+// actor. This runs after the message-processing transaction commits,
+// avoiding a SQLite write-lock deadlock between the OOR and serverconn
+// durable mailboxes.
+//
+// If a send fails, the error is returned and logged by the durable
+// actor framework. The OOR FSM checkpoint was already persisted inside
+// the transaction, so on restart OutboxForState will reconstruct and
+// retry the transport event.
+func (b *oorDurableBehavior) FlushPostCommit(
+	ctx context.Context) error {
+
+	pending := b.pendingTransport
+	b.pendingTransport = nil
+
+	for _, msg := range pending {
+		if err := b.sendTransportEvent(ctx, msg); err != nil {
+			return fmt.Errorf("flush transport event: %w",
+				err)
+		}
+	}
+
+	// Execute deferred local outbox events that require DB writes
+	// outside the durable actor transaction.
+	localPending := b.pendingLocal
+	b.pendingLocal = nil
+
+	handler := b.cfg.OutboxHandler
+	for _, p := range localPending {
+		if handler == nil {
+			continue
+		}
+
+		_, err := handler.Handle(ctx, p.sessionID, p.event)
+		if err != nil {
+			return fmt.Errorf("flush local event: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/oor/actor_resume_test.go
+++ b/oor/actor_resume_test.go
@@ -35,6 +35,12 @@ func (h *pausedFinalizeHandler) Handle(_ context.Context, sessionID SessionID,
 
 	switch msg := outbox.(type) {
 	case *RequestArkSignatures:
+		err := SignArkPSBT(
+			h.clientSigner, msg.ArkPSBT,
+			msg.CheckpointPSBTs, msg.TransferInputs,
+		)
+		require.NoError(h.t, err)
+
 		return []Event{
 			&ArkSignedEvent{
 				ArkPSBT: msg.ArkPSBT,
@@ -114,6 +120,12 @@ func (h *pausedSubmitHandler) Handle(_ context.Context, sessionID SessionID,
 
 	switch msg := outbox.(type) {
 	case *RequestArkSignatures:
+		err := SignArkPSBT(
+			h.clientSigner, msg.ArkPSBT,
+			msg.CheckpointPSBTs, msg.TransferInputs,
+		)
+		require.NoError(h.t, err)
+
 		return []Event{
 			&ArkSignedEvent{
 				ArkPSBT: msg.ArkPSBT,
@@ -196,6 +208,12 @@ func (h *pausedCoSignedHandler) Handle(_ context.Context, sessionID SessionID,
 
 	switch msg := outbox.(type) {
 	case *RequestArkSignatures:
+		err := SignArkPSBT(
+			h.clientSigner, msg.ArkPSBT,
+			msg.CheckpointPSBTs, msg.TransferInputs,
+		)
+		require.NoError(h.t, err)
+
 		return []Event{
 			&ArkSignedEvent{
 				ArkPSBT: msg.ArkPSBT,
@@ -286,6 +304,12 @@ func (h *cosignedButDroppedHandler) Handle(_ context.Context,
 
 	switch msg := outbox.(type) {
 	case *RequestArkSignatures:
+		err := SignArkPSBT(
+			h.clientSigner, msg.ArkPSBT,
+			msg.CheckpointPSBTs, msg.TransferInputs,
+		)
+		require.NoError(h.t, err)
+
 		return []Event{
 			&ArkSignedEvent{
 				ArkPSBT: msg.ArkPSBT,

--- a/oor/actor_test.go
+++ b/oor/actor_test.go
@@ -36,8 +36,12 @@ func (h *testOutboxHandler) Handle(_ context.Context, sessionID SessionID,
 
 	switch msg := outbox.(type) {
 	case *RequestArkSignatures:
-		// Ark signing is modeled as an outbox boundary.
-		// Unit tests treat this as a deterministic pass-through.
+		err := SignArkPSBT(
+			h.clientSigner, msg.ArkPSBT,
+			msg.CheckpointPSBTs, msg.TransferInputs,
+		)
+		require.NoError(h.t, err)
+
 		return []Event{
 			&ArkSignedEvent{
 				ArkPSBT: msg.ArkPSBT,
@@ -256,6 +260,12 @@ func (h *retrySubmitOutboxHandler) Handle(
 
 	switch msg := outbox.(type) {
 	case *RequestArkSignatures:
+		err := SignArkPSBT(
+			h.clientSigner, msg.ArkPSBT,
+			msg.CheckpointPSBTs, msg.TransferInputs,
+		)
+		require.NoError(h.t, err)
+
 		return []Event{
 			&ArkSignedEvent{
 				ArkPSBT: msg.ArkPSBT,
@@ -489,6 +499,12 @@ func (h *localOnlyOutboxHandler) Handle(_ context.Context,
 
 	switch msg := outbox.(type) {
 	case *RequestArkSignatures:
+		err := SignArkPSBT(
+			h.clientSigner, msg.ArkPSBT,
+			msg.CheckpointPSBTs, msg.TransferInputs,
+		)
+		require.NoError(h.t, err)
+
 		return []Event{
 			&ArkSignedEvent{
 				ArkPSBT: msg.ArkPSBT,

--- a/oor/ark_sign.go
+++ b/oor/ark_sign.go
@@ -1,0 +1,180 @@
+package oor
+
+import (
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/tx/psbtutil"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/keychain"
+)
+
+// SignArkPSBT signs the Ark PSBT inputs using the client key on the owner
+// leaf path.
+//
+// Each Ark input spends a checkpoint output. The checkpoint output is a
+// taproot output with an owner leaf (single checksig) and an operator CSV
+// leaf. This function maps each Ark input back to its checkpoint and then to
+// the transfer input that holds the client signing key.
+//
+// The signing pattern follows SignCheckpointPSBTs: for each input, build a
+// taproot script-spend SignDescriptor using the TaprootLeafScript metadata
+// already attached to the Ark PSBT input, then sign and attach the signature.
+func SignArkPSBT(signer input.Signer, arkPSBT *psbt.Packet,
+	checkpointPSBTs []*psbt.Packet,
+	transferInputs []TransferInput) error {
+
+	switch {
+	case signer == nil:
+		return fmt.Errorf("signer must be provided")
+
+	case arkPSBT == nil || arkPSBT.UnsignedTx == nil:
+		return fmt.Errorf("ark psbt must include unsigned tx")
+
+	case len(checkpointPSBTs) == 0:
+		return fmt.Errorf("checkpoint psbts must be provided")
+
+	case len(transferInputs) == 0:
+		return fmt.Errorf("transfer inputs must be provided")
+	}
+
+	// Build a map from checkpoint txid → transfer input index. Each
+	// checkpoint spends exactly one VTXO input (index 0), so we match
+	// via the checkpoint's input prevout.
+	inputByCheckpointTxid, err := buildCheckpointInputMap(
+		checkpointPSBTs, transferInputs,
+	)
+	if err != nil {
+		return err
+	}
+
+	for i := range arkPSBT.UnsignedTx.TxIn {
+		err := signArkPSBTInput(
+			signer, arkPSBT, i, inputByCheckpointTxid,
+		)
+		if err != nil {
+			return fmt.Errorf("sign ark input %d: %w", i, err)
+		}
+	}
+
+	return nil
+}
+
+// checkpointInputEntry pairs a transfer input with its checkpoint txid for
+// Ark input signing.
+type checkpointInputEntry struct {
+	transferInput *TransferInput
+}
+
+// buildCheckpointInputMap creates a lookup from checkpoint txid to the
+// corresponding transfer input.
+func buildCheckpointInputMap(checkpointPSBTs []*psbt.Packet,
+	transferInputs []TransferInput) (
+	map[chainhash.Hash]*checkpointInputEntry, error) {
+
+	if len(checkpointPSBTs) != len(transferInputs) {
+		return nil, fmt.Errorf("checkpoint count %d does not match "+
+			"transfer input count %d",
+			len(checkpointPSBTs), len(transferInputs))
+	}
+
+	result := make(
+		map[chainhash.Hash]*checkpointInputEntry,
+		len(checkpointPSBTs),
+	)
+
+	for i, cp := range checkpointPSBTs {
+		if cp == nil || cp.UnsignedTx == nil {
+			return nil, fmt.Errorf(
+				"checkpoint %d: missing unsigned tx", i,
+			)
+		}
+
+		cpTxid := cp.UnsignedTx.TxHash()
+		result[cpTxid] = &checkpointInputEntry{
+			transferInput: &transferInputs[i],
+		}
+	}
+
+	return result, nil
+}
+
+// signArkPSBTInput signs a single Ark PSBT input using the owner leaf.
+func signArkPSBTInput(signer input.Signer, arkPSBT *psbt.Packet,
+	inputIndex int,
+	inputMap map[chainhash.Hash]*checkpointInputEntry) error {
+
+	prevOut := arkPSBT.UnsignedTx.TxIn[inputIndex].PreviousOutPoint
+	entry, ok := inputMap[prevOut.Hash]
+	if !ok {
+		return fmt.Errorf("no transfer input for checkpoint "+
+			"txid %s", prevOut.Hash)
+	}
+
+	in := entry.transferInput
+	if err := in.Validate(); err != nil {
+		return err
+	}
+
+	pInput := &arkPSBT.Inputs[inputIndex]
+
+	// The TaprootLeafScript metadata was attached during package
+	// construction. Extract the owner leaf script and control block.
+	if len(pInput.TaprootLeafScript) == 0 {
+		return fmt.Errorf("ark input %d: missing tapleaf script",
+			inputIndex)
+	}
+
+	leaf := pInput.TaprootLeafScript[0]
+	ownerLeafScript := leaf.Script
+	controlBlock := leaf.ControlBlock
+
+	// Build the prevout for the checkpoint output being spent.
+	witnessUtxo := pInput.WitnessUtxo
+	if witnessUtxo == nil {
+		return fmt.Errorf("ark input %d: missing witness utxo",
+			inputIndex)
+	}
+
+	prevFetcher := txscript.NewCannedPrevOutputFetcher(
+		witnessUtxo.PkScript, witnessUtxo.Value,
+	)
+	sigHashes := txscript.NewTxSigHashes(
+		arkPSBT.UnsignedTx, prevFetcher,
+	)
+
+	signDesc := &input.SignDescriptor{
+		KeyDesc: keychain.KeyDescriptor{
+			PubKey: in.VTXO.ClientKey.PubKey,
+		},
+		SignMethod: input.TaprootScriptSpendSignMethod,
+		Output: &wire.TxOut{
+			Value:    witnessUtxo.Value,
+			PkScript: witnessUtxo.PkScript,
+		},
+		HashType:          txscript.SigHashDefault,
+		SigHashes:         sigHashes,
+		PrevOutputFetcher: prevFetcher,
+		InputIndex:        inputIndex,
+		WitnessScript:     ownerLeafScript,
+		ControlBlock:      controlBlock,
+	}
+
+	sig, err := signer.SignOutputRaw(arkPSBT.UnsignedTx, signDesc)
+	if err != nil {
+		return fmt.Errorf("sign output: %w", err)
+	}
+
+	sigBytes := sig.Serialize()
+	if len(sigBytes) == 0 {
+		return fmt.Errorf("signer returned empty signature")
+	}
+
+	return psbtutil.AddTaprootScriptSpendSig(
+		pInput, in.VTXO.ClientKey.PubKey,
+		ownerLeafScript, sigBytes, signDesc.HashType,
+	)
+}

--- a/oor/outbox_messages.go
+++ b/oor/outbox_messages.go
@@ -6,10 +6,9 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
-	oortx "github.com/lightninglabs/darepo-client/lib/tx/oor"
-	"github.com/lightninglabs/darepo-client/lib/tx/psbtutil"
 	mailboxrpc "github.com/lightninglabs/darepo-client/mailbox/rpc"
 	"github.com/lightninglabs/darepo-client/rpc/oorpb"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
@@ -23,10 +22,6 @@ const (
 		"oor/"
 )
 
-const (
-	finalizePayloadArkPSBTRecordType     tlv.Type = 1
-	finalizePayloadCheckpointsRecordType tlv.Type = 3
-)
 
 const (
 	retryPayloadAfterNanosRecordType tlv.Type = 1
@@ -59,6 +54,11 @@ type RequestArkSignatures struct {
 
 	// ArkPSBT is the canonical Ark transfer PSBT to sign.
 	ArkPSBT *psbt.Packet
+
+	// CheckpointPSBTs are the unsigned checkpoint PSBTs that correspond
+	// to the Ark inputs. These are needed to map each Ark input back to
+	// the transfer input that provides the client signing key.
+	CheckpointPSBTs []*psbt.Packet
 
 	// TransferInputs carry client signing context needed to authorize Ark
 	// inputs.
@@ -110,19 +110,26 @@ func (m *SendSubmitPackageRequest) ServiceMethod() mailboxrpc.ServiceMethod {
 	}
 }
 
-// ToProto converts SendSubmitPackageRequest to a protobuf message.
+// ToProto converts SendSubmitPackageRequest to the concrete proto type
+// expected by the server-side OOR dispatcher.
 func (m *SendSubmitPackageRequest) ToProto() fn.Result[proto.Message] {
-	payload, err := oortx.MarshalSubmitPackage(&oortx.SubmitPackage{
-		ArkPSBT:         m.ArkPSBT,
-		CheckpointPSBTs: m.CheckpointPSBTs,
-	})
+	descs := make([]oorpb.SigningDescriptor, 0, len(m.TransferInputs))
+	for _, ti := range m.TransferInputs {
+		descs = append(descs, oorpb.SigningDescriptor{
+			Outpoint:  ti.VTXO.Outpoint,
+			OwnerKey:  ti.VTXO.ClientKey.PubKey,
+			ExitDelay: ti.VTXO.RelativeExpiry,
+		})
+	}
+
+	req, err := oorpb.NewSubmitPackageRequest(
+		m.ArkPSBT, m.CheckpointPSBTs, descs,
+	)
 	if err != nil {
 		return fn.Err[proto.Message](err)
 	}
 
-	return fn.Ok[proto.Message](
-		protoEnvelope("SendSubmitPackageRequest", payload),
-	)
+	return fn.Ok[proto.Message](req)
 }
 
 // RequestCheckpointSignatures asks the signing layer to add client signature
@@ -181,18 +188,22 @@ func (m *SendFinalizePackageRequest) ServiceMethod() mailboxrpc.ServiceMethod {
 	}
 }
 
-// ToProto converts SendFinalizePackageRequest to a protobuf message.
+// ToProto converts SendFinalizePackageRequest to the concrete proto type
+// expected by the server-side OOR dispatcher.
 func (m *SendFinalizePackageRequest) ToProto() fn.Result[proto.Message] {
-	payload, err := encodeFinalizePayload(
-		m.ArkPSBT, m.FinalCheckpointPSBTs,
+	sessionID, err := sessionIDFromArk(m.ArkPSBT)
+	if err != nil {
+		return fn.Err[proto.Message](err)
+	}
+
+	req, err := oorpb.NewFinalizePackageRequest(
+		chainhash.Hash(sessionID), m.FinalCheckpointPSBTs,
 	)
 	if err != nil {
 		return fn.Err[proto.Message](err)
 	}
 
-	return fn.Ok[proto.Message](
-		protoEnvelope("SendFinalizePackageRequest", payload),
-	)
+	return fn.Ok[proto.Message](req)
 }
 
 // MarkInputsSpentRequest asks the persistence layer to mark the OOR inputs as
@@ -365,47 +376,6 @@ func protoEnvelope(typeName string, payload []byte) proto.Message {
 	}
 }
 
-func encodeFinalizePayload(ark *psbt.Packet,
-	checkpoints []*psbt.Packet) ([]byte, error) {
-
-	arkRaw, err := psbtutil.Serialize(ark)
-	if err != nil {
-		return nil, err
-	}
-
-	checkpointRaws, err := serializePSBTSlice(checkpoints)
-	if err != nil {
-		return nil, err
-	}
-
-	checkpointPayload, err := encodeLengthPrefixedBlobList(checkpointRaws)
-	if err != nil {
-		return nil, err
-	}
-
-	checkpointPayloadRecord := tlv.MakePrimitiveRecord(
-		finalizePayloadCheckpointsRecordType, &checkpointPayload,
-	)
-
-	records := []tlv.Record{
-		tlv.MakePrimitiveRecord(
-			finalizePayloadArkPSBTRecordType, &arkRaw,
-		),
-		checkpointPayloadRecord,
-	}
-
-	stream, err := tlv.NewStream(records...)
-	if err != nil {
-		return nil, err
-	}
-
-	var buf bytes.Buffer
-	if err := stream.Encode(&buf); err != nil {
-		return nil, err
-	}
-
-	return buf.Bytes(), nil
-}
 func encodeRetryPayload(after time.Duration, reason string) ([]byte, error) {
 	if after < 0 {
 		return nil, fmt.Errorf("retry delay must be non-negative")

--- a/oor/outbox_messages_test.go
+++ b/oor/outbox_messages_test.go
@@ -8,12 +8,13 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/lib/scripts"
+	"github.com/lightninglabs/darepo-client/rpc/oorpb"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
 // TestOutboxToProtoSubmitRequest verifies that a valid submit package
-// outbox request serializes into the expected proto Any envelope.
+// outbox request serializes into the expected proto message.
 func TestOutboxToProtoSubmitRequest(t *testing.T) {
 	t.Parallel()
 
@@ -26,14 +27,8 @@ func TestOutboxToProtoSubmitRequest(t *testing.T) {
 
 	result := msg.ToProto().UnwrapOrFail(t)
 
-	anyMsg, ok := result.(*anypb.Any)
+	_, ok := result.(*oorpb.SubmitPackageRequest)
 	require.True(t, ok)
-	require.Equal(
-		t,
-		oorOutboxProtoTypeURLPrefix+"SendSubmitPackageRequest",
-		anyMsg.TypeUrl,
-	)
-	require.NotEmpty(t, anyMsg.Value)
 }
 
 // TestOutboxToProtoSubmitRequestError verifies that a submit request
@@ -48,8 +43,7 @@ func TestOutboxToProtoSubmitRequestError(t *testing.T) {
 }
 
 // TestOutboxToProtoFinalizeRequest verifies that a valid finalize
-// package outbox request serializes into the expected proto Any
-// envelope.
+// package outbox request serializes into the expected proto message.
 func TestOutboxToProtoFinalizeRequest(t *testing.T) {
 	t.Parallel()
 
@@ -62,14 +56,8 @@ func TestOutboxToProtoFinalizeRequest(t *testing.T) {
 
 	result := msg.ToProto().UnwrapOrFail(t)
 
-	anyMsg, ok := result.(*anypb.Any)
+	_, ok := result.(*oorpb.FinalizePackageRequest)
 	require.True(t, ok)
-	require.Equal(
-		t,
-		oorOutboxProtoTypeURLPrefix+"SendFinalizePackageRequest",
-		anyMsg.TypeUrl,
-	)
-	require.NotEmpty(t, anyMsg.Value)
 }
 
 // TestOutboxToProtoMarkInputsSpentRequest verifies that a mark-inputs-

--- a/oor/resume.go
+++ b/oor/resume.go
@@ -19,8 +19,9 @@ func OutboxForState(state State) ([]OutboxEvent, error) {
 	case *AwaitingArkSignatures:
 		return []OutboxEvent{
 			&RequestArkSignatures{
-				ArkPSBT:        s.ArkPSBT,
-				TransferInputs: s.TransferInputs,
+				ArkPSBT:         s.ArkPSBT,
+				CheckpointPSBTs: s.CheckpointPSBTs,
+				TransferInputs:  s.TransferInputs,
 			},
 		}, nil
 

--- a/oor/session_test.go
+++ b/oor/session_test.go
@@ -77,6 +77,12 @@ func TestSessionHappyPath(t *testing.T) {
 	require.True(t, ok)
 
 	// Step 1: Ark signatures are attached before submit is sent.
+	err = SignArkPSBT(
+		clientSigner, arkSignReq.ArkPSBT,
+		arkSignReq.CheckpointPSBTs, arkSignReq.TransferInputs,
+	)
+	require.NoError(t, err)
+
 	fut := session.FSM.AskEvent(ctx, &ArkSignedEvent{
 		ArkPSBT: arkSignReq.ArkPSBT,
 	})

--- a/oor/signing_outbox_handler.go
+++ b/oor/signing_outbox_handler.go
@@ -16,8 +16,8 @@ import (
 // This handler is intended to be used as the Next delegate inside
 // LocalPersistenceOutboxHandler. It handles the following outbox events:
 //
-//   - RequestArkSignatures: v0 pass-through (no additional local signing
-//     needed beyond deterministic package construction).
+//   - RequestArkSignatures: signs Ark PSBT inputs using the client key on
+//     each checkpoint output's owner leaf via SignArkPSBT.
 //   - RequestCheckpointSignatures: attaches client-side collaborative VTXO
 //     spend signatures to each checkpoint PSBT via SignCheckpointPSBTs.
 //   - ScheduleRetryRequest: schedules a timer via the timeout actor. When
@@ -45,17 +45,12 @@ func (h *SigningOutboxHandler) Handle(ctx context.Context,
 
 	switch msg := outbox.(type) {
 	case *RequestArkSignatures:
-		// v0 does not require extra local Ark signing beyond
-		// deterministic package construction. Forward the Ark
-		// PSBT as-is.
-		log.DebugS(ctx, "Ark signatures requested (v0 pass-through)",
-			slog.String("session_id", sessionID.String()))
+		log.DebugS(ctx, "Ark signatures requested",
+			slog.String("session_id", sessionID.String()),
+			slog.Int("num_inputs",
+				len(msg.ArkPSBT.UnsignedTx.TxIn)))
 
-		return []Event{
-			&ArkSignedEvent{
-				ArkPSBT: msg.ArkPSBT,
-			},
-		}, nil
+		return h.handleArkSignatures(msg)
 
 	case *RequestCheckpointSignatures:
 		log.DebugS(ctx, "Checkpoint signatures requested",
@@ -84,6 +79,30 @@ func (h *SigningOutboxHandler) Handle(ctx context.Context,
 	default:
 		return nil, fmt.Errorf("unhandled outbox event %T", outbox)
 	}
+}
+
+// handleArkSignatures signs the Ark PSBT inputs using the client key on the
+// owner leaf path of each checkpoint output.
+func (h *SigningOutboxHandler) handleArkSignatures(
+	msg *RequestArkSignatures) ([]Event, error) {
+
+	if h.Signer == nil {
+		return nil, fmt.Errorf("signer is required")
+	}
+
+	err := SignArkPSBT(
+		h.Signer, msg.ArkPSBT, msg.CheckpointPSBTs,
+		msg.TransferInputs,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return []Event{
+		&ArkSignedEvent{
+			ArkPSBT: msg.ArkPSBT,
+		},
+	}, nil
 }
 
 // handleCheckpointSignatures attaches client-side collaborative VTXO spend

--- a/oor/test_helpers_test.go
+++ b/oor/test_helpers_test.go
@@ -53,8 +53,18 @@ func newTestTransferInput(t *testing.T, ownerKey *btcec.PrivateKey,
 			TapScript:      tapscript,
 			RelativeExpiry: exitDelay,
 		},
-		OwnerLeafScript: []byte{0x51},
+		OwnerLeafScript: newTestOwnerLeaf(t, ownerKey.PubKey()),
 	}
+}
+
+// newTestOwnerLeaf builds the single-sig owner leaf script for tests.
+func newTestOwnerLeaf(t *testing.T, key *btcec.PublicKey) []byte {
+	t.Helper()
+
+	leaf, err := scripts.OwnerCheckSigLeaf(key)
+	require.NoError(t, err)
+
+	return leaf
 }
 
 // newTestTaprootPkScript returns a valid P2TR pkScript for tests.

--- a/oor/transitions.go
+++ b/oor/transitions.go
@@ -93,8 +93,9 @@ func (s *Idle) ProcessEvent(ctx context.Context, event Event,
 		}
 
 		signReq := &RequestArkSignatures{
-			ArkPSBT:        ark,
-			TransferInputs: evt.VTXOInputs,
+			ArkPSBT:         ark,
+			CheckpointPSBTs: checkpoints,
+			TransferInputs:  evt.VTXOInputs,
 		}
 
 		return &StateTransition{

--- a/serverconn/actor.go
+++ b/serverconn/actor.go
@@ -450,6 +450,8 @@ func (a *ServerConnectionActor) handleSendClientEvent(ctx context.Context,
 
 	protoMsg, err := req.Message.ToProto().Unpack()
 	if err != nil {
+		log.WarnS(ctx, "Failed to convert to proto", err)
+
 		return fn.Err[ServerConnResp](fmt.Errorf(
 			"convert to proto: %w", err,
 		))
@@ -504,7 +506,15 @@ func (a *ServerConnectionActor) handleSendClientEvent(ctx context.Context,
 		},
 	}
 
-	resp, err := a.cfg.Edge.Send(ctx, &mailboxpb.SendRequest{
+	// Use a fresh context for the gRPC call to avoid inheriting
+	// the SQLite transaction context which can cause the gRPC
+	// call to block.
+	sendCtx, sendCancel := context.WithTimeout(
+		context.Background(), 30*time.Second,
+	)
+	defer sendCancel()
+
+	resp, err := a.cfg.Edge.Send(sendCtx, &mailboxpb.SendRequest{
 		Envelope: envelope,
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary

- Add `OwnerCheckSigLeaf` helper that builds a real `<schnorr_pubkey> OP_CHECKSIG` leaf for checkpoint taproot outputs, replacing the OP_TRUE placeholder.
- Implement `SignArkPSBT` which signs Ark transaction inputs using the client key on the owner leaf path. Update `SigningOutboxHandler` to call it.
- Add `PostCommitHandler` interface to the durable actor framework, enabling behaviors to defer side-effects (like Telling sibling actors) until after the DB transaction commits, preventing SQLite write-lock deadlocks.
- Defer transport events (submit, finalize, ack) and DB-writing local events (`MarkInputsSpentRequest`) to `FlushPostCommit` in the OOR client actor. Feed optimistic follow-up events into the FSM within the transaction for atomic state transitions.
- Use background context for `Edge.Send` in serverconn to avoid inheriting closed transaction contexts.
- Add pubkey destination support for OOR sends, deriving VTXO-compatible P2TR outputs from recipient schnorr keys.
- Switch `ToProto` from custom TLV-in-Any envelopes to concrete `oorpb` proto types.

## Test plan

- [x] `go test ./oor/...` passes
- [x] `go test ./baselib/actor/...` passes
- [x] All outbox handler tests updated to use real `SignArkPSBT`
- [x] Outbox message serialization tests updated for oorpb types
- [ ] Integration test via `make arktest case=TestScenarios/oor_send` (requires server-side PR)