### PR TITLE
multi: fix OOR checkpoint collab leaf, real signing, and same-DB tx atomicity

### DIFF
--- a/baselib/AGENTS.md
+++ b/baselib/AGENTS.md
@@ -31,6 +31,7 @@ build on.
 
 - Every actor message must embed `BaseMessage` to satisfy the sealed `Message` interface.
 - Actors registered with system are auto-stopped on `system.Shutdown()`.
+- `DurableMailbox.Send` preserves the sender's DB transaction in the context. Same-DB actors share the tx for atomic enqueue via `ExecTx` joining.
 - Protofsm processes events iteratively; internal events loop until exhausted before returning.
 - `EmittedEvent` separates internal events (routed back to FSM) from outbox events (dispatched externally).
 

--- a/baselib/CLAUDE.md
+++ b/baselib/CLAUDE.md
@@ -31,6 +31,7 @@ build on.
 
 - Every actor message must embed `BaseMessage` to satisfy the sealed `Message` interface.
 - Actors registered with system are auto-stopped on `system.Shutdown()`.
+- `DurableMailbox.Send` preserves the sender's DB transaction in the context. Same-DB actors share the tx for atomic enqueue via `ExecTx` joining.
 - Protofsm processes events iteratively; internal events loop until exhausted before returning.
 - `EmittedEvent` separates internal events (routed back to FSM) from outbox events (dispatched externally).
 

--- a/baselib/actor/durable_mailbox.go
+++ b/baselib/actor/durable_mailbox.go
@@ -107,13 +107,12 @@ func NewDurableMailbox[M TLVMessage, R any](
 // envelope is accepted, the provided context is cancelled, or the actor's
 // context is cancelled.
 //
-// The sender's database transaction is intentionally stripped before
-// enqueueing. Mailbox sends cross actor boundaries: the receiver's
-// delivery store must manage its own transaction lifecycle. Inheriting
-// the sender's transaction would either target the wrong database
-// (cross-DB actors) or deadlock for Ask-style calls where the sender
-// blocks on the response but the receiver cannot see the uncommitted
-// message.
+// The sender's database transaction (if any) is preserved in the context
+// passed to EnqueueMessage. When both actors share the same SQLite
+// database, ExecTx in the delivery store joins the outer transaction,
+// making the enqueue atomic with the sender's state change. This
+// eliminates the window where a crash could commit the sender's state
+// but lose the enqueued message.
 func (m *DurableMailbox[M, R]) Send(ctx context.Context, env envelope[M, R]) bool {
 	m.closeMu.RLock()
 	defer m.closeMu.RUnlock()
@@ -185,11 +184,11 @@ func (m *DurableMailbox[M, R]) Send(ctx context.Context, env envelope[M, R]) boo
 		MaxAttempts:     m.cfg.MaxAttempts,
 	}
 
-	// Strip the sender's transaction so the receiver's delivery store
-	// creates its own transaction for the enqueue operation.
-	enqueueCtx := WithoutTx(ctx)
-
-	if err := m.cfg.Store.EnqueueMessage(enqueueCtx, params); err != nil {
+	// Allow the sender's transaction (if any) to flow through so
+	// same-DB actors share the tx and the enqueue is atomic with
+	// the sender's state change. ExecTx in the delivery store
+	// joins the outer tx when one exists in the context.
+	if err := m.cfg.Store.EnqueueMessage(ctx, params); err != nil {
 		// Clean up the promise registry entry to prevent unbounded
 		// stale entries from accumulating on repeated enqueue failures.
 		if promiseID != "" {

--- a/baselib/actor/durable_mailbox_test.go
+++ b/baselib/actor/durable_mailbox_test.go
@@ -1090,11 +1090,11 @@ func (s *txCapturingStore) EnqueueMessage(ctx context.Context,
 	return s.mockDeliveryStore.EnqueueMessage(ctx, params)
 }
 
-// TestDurableMailboxSendStripsSenderTx verifies that Send strips the sender's
-// database transaction from the context before calling EnqueueMessage. This
-// prevents the receiver's delivery store from inheriting the sender's
-// transaction, which would cause cross-DB visibility issues or Ask deadlocks.
-func TestDurableMailboxSendStripsSenderTx(t *testing.T) {
+// TestDurableMailboxSendPreservesSenderTx verifies that Send preserves the
+// sender's database transaction in the context passed to EnqueueMessage.
+// This allows same-DB actors to share the transaction so the enqueue is
+// atomic with the sender's state change.
+func TestDurableMailboxSendPreservesSenderTx(t *testing.T) {
 	t.Parallel()
 
 	store := newMockDeliveryStore()
@@ -1126,9 +1126,10 @@ func TestDurableMailboxSendStripsSenderTx(t *testing.T) {
 	ok := mailbox.Send(sendCtx, env)
 	require.True(t, ok)
 
-	// The context received by EnqueueMessage should NOT carry a tx.
+	// The context received by EnqueueMessage should carry the
+	// sender's tx so same-DB actors share the transaction.
 	require.NotNil(t, capturing.lastCtx,
 		"EnqueueMessage should have been called")
-	require.False(t, HasTx(capturing.lastCtx),
-		"EnqueueMessage context should not carry the sender's tx")
+	require.True(t, HasTx(capturing.lastCtx),
+		"EnqueueMessage context should carry the sender's tx")
 }

--- a/daemonrpc/daemon.pb.go
+++ b/daemonrpc/daemon.pb.go
@@ -1210,8 +1210,10 @@ type Output_Address struct {
 }
 
 type Output_Pubkey struct {
-	// pubkey is the 32-byte x-only public key used to derive a
-	// BIP-86 taproot output.
+	// pubkey is the 32-byte x-only (Schnorr) public key of the
+	// recipient. For OOR sends, this derives a VTXO-compatible
+	// taproot output using the operator's collab key and exit
+	// delay, so the recipient gets a standard Ark VTXO.
 	Pubkey []byte `protobuf:"bytes,3,opt,name=pubkey,proto3,oneof"`
 }
 

--- a/daemonrpc/daemon.proto
+++ b/daemonrpc/daemon.proto
@@ -281,8 +281,10 @@ message Output {
         // address is the recipient's bech32m-encoded taproot address.
         string address = 1;
 
-        // pubkey is the 32-byte x-only public key used to derive a
-        // BIP-86 taproot output.
+        // pubkey is the 32-byte x-only (Schnorr) public key of the
+        // recipient. For OOR sends, this derives a VTXO-compatible
+        // taproot output using the operator's collab key and exit
+        // delay, so the recipient gets a standard Ark VTXO.
         bytes pubkey = 3;
 
         // pk_script is the raw output script for the recipient.

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
@@ -695,15 +696,15 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 	}
 
 	// Resolve the recipient's pkScript from the destination
-	// oneof.
-	pkScript, err := r.resolveOutputPkScript(
-		req.Recipient,
-	)
+	// oneof. Pubkey destinations need operator terms to derive
+	// VTXO-compatible taproot outputs, so we pass a lazy fetcher.
+	pkScript, err := r.resolveOutputPkScript(ctx, req.Recipient)
 	if err != nil {
 		return nil, err
 	}
 
-	// For dry_run, validate inputs and return a preview.
+	// For dry_run, validate inputs and return a preview without
+	// contacting the operator.
 	if req.DryRun {
 		return &daemonrpc.SendOORResponse{
 			Status: "preview",
@@ -868,8 +869,9 @@ func (r *RPCServer) unlockVTXOs(ctx context.Context,
 
 // resolveOutputPkScript derives a pkScript from the Output's
 // destination oneof. It supports address, raw pubkey, and raw
-// pkScript destinations.
-func (r *RPCServer) resolveOutputPkScript(
+// pkScript destinations. For pubkey destinations, operator terms
+// are fetched to derive a VTXO-compatible taproot output.
+func (r *RPCServer) resolveOutputPkScript(ctx context.Context,
 	out *daemonrpc.Output) ([]byte, error) {
 
 	switch d := out.Destination.(type) {
@@ -894,6 +896,51 @@ func (r *RPCServer) resolveOutputPkScript(
 		}
 
 		return pkScript, nil
+
+	case *daemonrpc.Output_Pubkey:
+		if len(d.Pubkey) == 0 {
+			return nil, status.Errorf(
+				codes.InvalidArgument,
+				"pubkey is empty",
+			)
+		}
+
+		recipientKey, err := schnorr.ParsePubKey(d.Pubkey)
+		if err != nil {
+			return nil, status.Errorf(
+				codes.InvalidArgument,
+				"invalid pubkey: %v", err,
+			)
+		}
+
+		// For OOR sends, a pubkey destination creates a
+		// VTXO-compatible taproot output with the operator's
+		// collab key and exit delay (not a simple BIP-86
+		// key-path-only output). This ensures the recipient
+		// gets a standard Ark VTXO they can spend
+		// collaboratively or exit unilaterally.
+		terms, err := r.server.fetchOperatorTerms(ctx)
+		if err != nil {
+			return nil, status.Errorf(
+				codes.Internal,
+				"fetch operator terms for pubkey "+
+					"destination: %v", err,
+			)
+		}
+
+		tapKey, err := scripts.VTXOTapKey(
+			recipientKey, terms.PubKey,
+			terms.VTXOExitDelay,
+		)
+		if err != nil {
+			return nil, status.Errorf(
+				codes.Internal,
+				"unable to derive VTXO tap key: %v",
+				err,
+			)
+		}
+
+		return txscript.PayToTaprootScript(tapKey)
 
 	case *daemonrpc.Output_PkScript:
 		if len(d.PkScript) == 0 {

--- a/darepod/wallet_ops.go
+++ b/darepod/wallet_ops.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/scripts"
 	"github.com/lightninglabs/darepo-client/oor"
 	"github.com/lightninglabs/darepo-client/vtxo"
 	"github.com/lightningnetwork/lnd/aezeed"
@@ -121,9 +122,23 @@ func BuildTransferInputs(ctx context.Context,
 			)
 		}
 
+		// The checkpoint output collab path is a 2-of-2 multisig
+		// between the VTXO owner and the operator, matching the
+		// VTXO's own collaborative spend path. This ensures both
+		// parties must sign the Ark tx that spends the checkpoint.
+		collabLeaf, err := scripts.MultiSigCollabTapLeaf(
+			desc.ClientKey.PubKey, desc.OperatorKey,
+		)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"build collab leaf for %s: %w",
+				op, err,
+			)
+		}
+
 		inputs = append(inputs, oor.TransferInput{
 			VTXO:            desc,
-			OwnerLeafScript: desc.PkScript,
+			OwnerLeafScript: collabLeaf.Script,
 		})
 	}
 

--- a/oor/AGENTS.md
+++ b/oor/AGENTS.md
@@ -11,6 +11,7 @@ resume semantics.
 - `SessionID` — Stable session identifier (Ark txid hash in v0).
 - `Environment` — FSM environment providing SessionID and external system access.
 - `OutboxHandler` — Interface for executing FSM outbox requests (RPC, signing, persistence).
+- `SignArkPSBT` — Signs Ark PSBT inputs using the client key on the checkpoint 2-of-2 collab leaf; uses `MultiPrevOutFetcher` for correct BIP-341 sighash across multiple inputs.
 - `ClientActorCfg` — Configuration for OORClientActor (OutboxHandler, ServerConn, PackageStore, DeliveryStore, VTXOManager).
 - `IncomingVTXOMetadata` — Lineage metadata for incoming OOR VTXOs including `ChainDepth` (OOR checkpoint hop count).
 - `OORClientActor` — Durable actor wrapping per-session state machines.
@@ -30,9 +31,11 @@ resume semantics.
 
 ## Invariants
 
+- Checkpoint output collab path is 2-of-2 `MultiSigCollabTapLeaf(clientKey, operatorKey)`, not single-sig. Both parties must sign the Ark tx that spends checkpoint outputs.
+- At submit time only structural validation runs (`ValidateSubmitPackage`); full script VM validation requires both signatures and runs at finalize.
 - Point-of-no-return: when server co-signs checkpoint transaction(s).
 - After checkpoint signature, client must resume and obtain byte-identical co-signed PSBTs (deterministic construction).
-- Outbox messages from transport layer bypass OutboxHandler and go directly to ServerConn for durable delivery.
+- Transport outbox events (submit, finalize, ack) are Tell'd to ServerConn within the actor's DB transaction for atomic enqueue (same-DB tx joining via `ExecTx`).
 - Package persistence tracks finalized outgoing packages and local input bindings for recovery.
 
 ## Deep Docs

--- a/oor/CLAUDE.md
+++ b/oor/CLAUDE.md
@@ -11,6 +11,7 @@ resume semantics.
 - `SessionID` — Stable session identifier (Ark txid hash in v0).
 - `Environment` — FSM environment providing SessionID and external system access.
 - `OutboxHandler` — Interface for executing FSM outbox requests (RPC, signing, persistence).
+- `SignArkPSBT` — Signs Ark PSBT inputs using the client key on the checkpoint 2-of-2 collab leaf; uses `MultiPrevOutFetcher` for correct BIP-341 sighash across multiple inputs.
 - `ClientActorCfg` — Configuration for OORClientActor (OutboxHandler, ServerConn, PackageStore, DeliveryStore, VTXOManager).
 - `IncomingVTXOMetadata` — Lineage metadata for incoming OOR VTXOs including `ChainDepth` (OOR checkpoint hop count).
 - `OORClientActor` — Durable actor wrapping per-session state machines.
@@ -30,9 +31,11 @@ resume semantics.
 
 ## Invariants
 
+- Checkpoint output collab path is 2-of-2 `MultiSigCollabTapLeaf(clientKey, operatorKey)`, not single-sig. Both parties must sign the Ark tx that spends checkpoint outputs.
+- At submit time only structural validation runs (`ValidateSubmitPackage`); full script VM validation requires both signatures and runs at finalize.
 - Point-of-no-return: when server co-signs checkpoint transaction(s).
 - After checkpoint signature, client must resume and obtain byte-identical co-signed PSBTs (deterministic construction).
-- Outbox messages from transport layer bypass OutboxHandler and go directly to ServerConn for durable delivery.
+- Transport outbox events (submit, finalize, ack) are Tell'd to ServerConn within the actor's DB transaction for atomic enqueue (same-DB tx joining via `ExecTx`).
 - Package persistence tracks finalized outgoing packages and local input bindings for recovery.
 
 ## Deep Docs

--- a/oor/actor_resume_test.go
+++ b/oor/actor_resume_test.go
@@ -35,6 +35,12 @@ func (h *pausedFinalizeHandler) Handle(_ context.Context, sessionID SessionID,
 
 	switch msg := outbox.(type) {
 	case *RequestArkSignatures:
+		err := SignArkPSBT(
+			h.clientSigner, msg.ArkPSBT,
+			msg.CheckpointPSBTs, msg.TransferInputs,
+		)
+		require.NoError(h.t, err)
+
 		return []Event{
 			&ArkSignedEvent{
 				ArkPSBT: msg.ArkPSBT,
@@ -114,6 +120,12 @@ func (h *pausedSubmitHandler) Handle(_ context.Context, sessionID SessionID,
 
 	switch msg := outbox.(type) {
 	case *RequestArkSignatures:
+		err := SignArkPSBT(
+			h.clientSigner, msg.ArkPSBT,
+			msg.CheckpointPSBTs, msg.TransferInputs,
+		)
+		require.NoError(h.t, err)
+
 		return []Event{
 			&ArkSignedEvent{
 				ArkPSBT: msg.ArkPSBT,
@@ -196,6 +208,12 @@ func (h *pausedCoSignedHandler) Handle(_ context.Context, sessionID SessionID,
 
 	switch msg := outbox.(type) {
 	case *RequestArkSignatures:
+		err := SignArkPSBT(
+			h.clientSigner, msg.ArkPSBT,
+			msg.CheckpointPSBTs, msg.TransferInputs,
+		)
+		require.NoError(h.t, err)
+
 		return []Event{
 			&ArkSignedEvent{
 				ArkPSBT: msg.ArkPSBT,
@@ -286,6 +304,12 @@ func (h *cosignedButDroppedHandler) Handle(_ context.Context,
 
 	switch msg := outbox.(type) {
 	case *RequestArkSignatures:
+		err := SignArkPSBT(
+			h.clientSigner, msg.ArkPSBT,
+			msg.CheckpointPSBTs, msg.TransferInputs,
+		)
+		require.NoError(h.t, err)
+
 		return []Event{
 			&ArkSignedEvent{
 				ArkPSBT: msg.ArkPSBT,

--- a/oor/actor_test.go
+++ b/oor/actor_test.go
@@ -36,8 +36,12 @@ func (h *testOutboxHandler) Handle(_ context.Context, sessionID SessionID,
 
 	switch msg := outbox.(type) {
 	case *RequestArkSignatures:
-		// Ark signing is modeled as an outbox boundary.
-		// Unit tests treat this as a deterministic pass-through.
+		err := SignArkPSBT(
+			h.clientSigner, msg.ArkPSBT,
+			msg.CheckpointPSBTs, msg.TransferInputs,
+		)
+		require.NoError(h.t, err)
+
 		return []Event{
 			&ArkSignedEvent{
 				ArkPSBT: msg.ArkPSBT,
@@ -256,6 +260,12 @@ func (h *retrySubmitOutboxHandler) Handle(
 
 	switch msg := outbox.(type) {
 	case *RequestArkSignatures:
+		err := SignArkPSBT(
+			h.clientSigner, msg.ArkPSBT,
+			msg.CheckpointPSBTs, msg.TransferInputs,
+		)
+		require.NoError(h.t, err)
+
 		return []Event{
 			&ArkSignedEvent{
 				ArkPSBT: msg.ArkPSBT,
@@ -489,6 +499,12 @@ func (h *localOnlyOutboxHandler) Handle(_ context.Context,
 
 	switch msg := outbox.(type) {
 	case *RequestArkSignatures:
+		err := SignArkPSBT(
+			h.clientSigner, msg.ArkPSBT,
+			msg.CheckpointPSBTs, msg.TransferInputs,
+		)
+		require.NoError(h.t, err)
+
 		return []Event{
 			&ArkSignedEvent{
 				ArkPSBT: msg.ArkPSBT,

--- a/oor/ark_sign.go
+++ b/oor/ark_sign.go
@@ -1,0 +1,205 @@
+package oor
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/tx/psbtutil"
+	"github.com/lightningnetwork/lnd/input"
+)
+
+// SignArkPSBT signs the Ark PSBT inputs using the client key on the
+// checkpoint collab leaf path.
+//
+// Each Ark input spends a checkpoint output. The checkpoint output is a
+// taproot output with a 2-of-2 collaborative multisig leaf (owner +
+// operator) and an operator CSV leaf. This function provides the client's
+// half of the 2-of-2 signature. The operator provides their half during
+// the submit phase.
+//
+// The signing pattern follows SignCheckpointPSBTs: for each input, build a
+// taproot script-spend SignDescriptor using the TaprootLeafScript metadata
+// already attached to the Ark PSBT input, then sign and attach the signature.
+func SignArkPSBT(signer input.Signer, arkPSBT *psbt.Packet,
+	checkpointPSBTs []*psbt.Packet,
+	transferInputs []TransferInput) error {
+
+	switch {
+	case signer == nil:
+		return fmt.Errorf("signer must be provided")
+
+	case arkPSBT == nil || arkPSBT.UnsignedTx == nil:
+		return fmt.Errorf("ark psbt must include unsigned tx")
+
+	case len(checkpointPSBTs) == 0:
+		return fmt.Errorf("checkpoint psbts must be provided")
+
+	case len(transferInputs) == 0:
+		return fmt.Errorf("transfer inputs must be provided")
+	}
+
+	// Build a map from checkpoint txid → transfer input index. Each
+	// checkpoint spends exactly one VTXO input (index 0), so we match
+	// via the checkpoint's input prevout.
+	inputByCheckpointTxid, err := buildCheckpointInputMap(
+		checkpointPSBTs, transferInputs,
+	)
+	if err != nil {
+		return err
+	}
+
+	for i := range arkPSBT.UnsignedTx.TxIn {
+		err := signArkPSBTInput(
+			signer, arkPSBT, i, inputByCheckpointTxid,
+		)
+		if err != nil {
+			return fmt.Errorf("sign ark input %d: %w", i, err)
+		}
+	}
+
+	return nil
+}
+
+// checkpointInputEntry pairs a transfer input with its checkpoint txid for
+// Ark input signing.
+type checkpointInputEntry struct {
+	transferInput *TransferInput
+}
+
+// buildCheckpointInputMap creates a lookup from checkpoint txid to the
+// corresponding transfer input.
+func buildCheckpointInputMap(checkpointPSBTs []*psbt.Packet,
+	transferInputs []TransferInput) (
+	map[chainhash.Hash]*checkpointInputEntry, error) {
+
+	if len(checkpointPSBTs) != len(transferInputs) {
+		return nil, fmt.Errorf("checkpoint count %d does not match "+
+			"transfer input count %d",
+			len(checkpointPSBTs), len(transferInputs))
+	}
+
+	result := make(
+		map[chainhash.Hash]*checkpointInputEntry,
+		len(checkpointPSBTs),
+	)
+
+	for i, cp := range checkpointPSBTs {
+		if cp == nil || cp.UnsignedTx == nil {
+			return nil, fmt.Errorf(
+				"checkpoint %d: missing unsigned tx", i,
+			)
+		}
+
+		cpTxid := cp.UnsignedTx.TxHash()
+		result[cpTxid] = &checkpointInputEntry{
+			transferInput: &transferInputs[i],
+		}
+	}
+
+	return result, nil
+}
+
+// signArkPSBTInput signs a single Ark PSBT input using the checkpoint
+// collab leaf (2-of-2 multisig between owner and operator).
+func signArkPSBTInput(signer input.Signer, arkPSBT *psbt.Packet,
+	inputIndex int,
+	inputMap map[chainhash.Hash]*checkpointInputEntry) error {
+
+	prevOut := arkPSBT.UnsignedTx.TxIn[inputIndex].PreviousOutPoint
+	entry, ok := inputMap[prevOut.Hash]
+	if !ok {
+		return fmt.Errorf("no transfer input for checkpoint "+
+			"txid %s", prevOut.Hash)
+	}
+
+	in := entry.transferInput
+	if err := in.Validate(); err != nil {
+		return err
+	}
+
+	pInput := &arkPSBT.Inputs[inputIndex]
+
+	// Find the collab leaf by matching against the expected owner
+	// leaf script from the transfer input. Do not assume a fixed
+	// index since additional leaves may be present or the order
+	// may vary.
+	collabLeaf, err := findTapLeafByScript(
+		pInput, in.OwnerLeafScript,
+	)
+	if err != nil {
+		return fmt.Errorf("ark input %d: %w", inputIndex, err)
+	}
+
+	// Build the prevout for the checkpoint output being spent.
+	witnessUtxo := pInput.WitnessUtxo
+	if witnessUtxo == nil {
+		return fmt.Errorf("ark input %d: missing witness utxo",
+			inputIndex)
+	}
+
+	prevFetcher := txscript.NewCannedPrevOutputFetcher(
+		witnessUtxo.PkScript, witnessUtxo.Value,
+	)
+	sigHashes := txscript.NewTxSigHashes(
+		arkPSBT.UnsignedTx, prevFetcher,
+	)
+
+	// Pass the full KeyDescriptor (including KeyLocator) so
+	// signers that require the locator can find the private key.
+	signDesc := &input.SignDescriptor{
+		KeyDesc:       in.VTXO.ClientKey,
+		SignMethod:    input.TaprootScriptSpendSignMethod,
+		Output: &wire.TxOut{
+			Value:    witnessUtxo.Value,
+			PkScript: witnessUtxo.PkScript,
+		},
+		HashType:          txscript.SigHashDefault,
+		SigHashes:         sigHashes,
+		PrevOutputFetcher: prevFetcher,
+		InputIndex:        inputIndex,
+		WitnessScript:     collabLeaf.Script,
+		ControlBlock:      collabLeaf.ControlBlock,
+	}
+
+	sig, err := signer.SignOutputRaw(arkPSBT.UnsignedTx, signDesc)
+	if err != nil {
+		return fmt.Errorf("sign output: %w", err)
+	}
+
+	sigBytes := sig.Serialize()
+	if len(sigBytes) == 0 {
+		return fmt.Errorf("signer returned empty signature")
+	}
+
+	return psbtutil.AddTaprootScriptSpendSig(
+		pInput, in.VTXO.ClientKey.PubKey,
+		collabLeaf.Script, sigBytes, signDesc.HashType,
+	)
+}
+
+// findTapLeafByScript searches the PSBT input's TaprootLeafScript entries
+// for one whose script matches the expected leaf bytes.
+func findTapLeafByScript(pInput *psbt.PInput,
+	expectedScript []byte) (*psbt.TaprootTapLeafScript, error) {
+
+	if len(pInput.TaprootLeafScript) == 0 {
+		return nil, fmt.Errorf("missing tapleaf scripts")
+	}
+
+	for _, leaf := range pInput.TaprootLeafScript {
+		if leaf == nil {
+			continue
+		}
+
+		if bytes.Equal(leaf.Script, expectedScript) {
+			return leaf, nil
+		}
+	}
+
+	return nil, fmt.Errorf("collab leaf script not found in "+
+		"tapleaf entries")
+}

--- a/oor/ark_sign.go
+++ b/oor/ark_sign.go
@@ -91,17 +91,11 @@ func SignArkPSBT(signer input.Signer, arkPSBT *psbt.Packet,
 	return nil
 }
 
-// checkpointInputEntry pairs a transfer input with its checkpoint txid for
-// Ark input signing.
-type checkpointInputEntry struct {
-	transferInput *TransferInput
-}
-
 // buildCheckpointInputMap creates a lookup from checkpoint txid to the
 // corresponding transfer input.
 func buildCheckpointInputMap(checkpointPSBTs []*psbt.Packet,
 	transferInputs []TransferInput) (
-	map[chainhash.Hash]*checkpointInputEntry, error) {
+	map[chainhash.Hash]*TransferInput, error) {
 
 	if len(checkpointPSBTs) != len(transferInputs) {
 		return nil, fmt.Errorf("checkpoint count %d does not match "+
@@ -110,7 +104,7 @@ func buildCheckpointInputMap(checkpointPSBTs []*psbt.Packet,
 	}
 
 	result := make(
-		map[chainhash.Hash]*checkpointInputEntry,
+		map[chainhash.Hash]*TransferInput,
 		len(checkpointPSBTs),
 	)
 
@@ -122,9 +116,7 @@ func buildCheckpointInputMap(checkpointPSBTs []*psbt.Packet,
 		}
 
 		cpTxid := cp.UnsignedTx.TxHash()
-		result[cpTxid] = &checkpointInputEntry{
-			transferInput: &transferInputs[i],
-		}
+		result[cpTxid] = &transferInputs[i]
 	}
 
 	return result, nil
@@ -134,18 +126,16 @@ func buildCheckpointInputMap(checkpointPSBTs []*psbt.Packet,
 // collab leaf (2-of-2 multisig between owner and operator).
 func signArkPSBTInput(signer input.Signer, arkPSBT *psbt.Packet,
 	inputIndex int,
-	inputMap map[chainhash.Hash]*checkpointInputEntry,
+	inputMap map[chainhash.Hash]*TransferInput,
 	prevFetcher txscript.PrevOutputFetcher,
 	sigHashes *txscript.TxSigHashes) error {
 
 	prevOut := arkPSBT.UnsignedTx.TxIn[inputIndex].PreviousOutPoint
-	entry, ok := inputMap[prevOut.Hash]
+	in, ok := inputMap[prevOut.Hash]
 	if !ok {
 		return fmt.Errorf("no transfer input for checkpoint "+
 			"txid %s", prevOut.Hash)
 	}
-
-	in := entry.transferInput
 	if err := in.Validate(); err != nil {
 		return err
 	}

--- a/oor/ark_sign.go
+++ b/oor/ark_sign.go
@@ -52,9 +52,36 @@ func SignArkPSBT(signer input.Signer, arkPSBT *psbt.Packet,
 		return err
 	}
 
+	// Build a complete prevout map from all Ark PSBT inputs.
+	// BIP-341 SigHashDefault commits to ALL prevouts (sha_prevouts,
+	// sha_amounts, sha_scriptpubkeys), so we need a MultiPrevOutFetcher
+	// that returns the correct TxOut for each input. Using
+	// CannedPrevOutputFetcher would produce incorrect sighashes for
+	// multi-input Ark transactions.
+	prevOuts := make(
+		map[wire.OutPoint]*wire.TxOut,
+		len(arkPSBT.UnsignedTx.TxIn),
+	)
+	for i, txIn := range arkPSBT.UnsignedTx.TxIn {
+		wu := arkPSBT.Inputs[i].WitnessUtxo
+		if wu == nil {
+			return fmt.Errorf(
+				"ark input %d: missing witness utxo", i,
+			)
+		}
+
+		prevOuts[txIn.PreviousOutPoint] = wu
+	}
+
+	prevFetcher := txscript.NewMultiPrevOutFetcher(prevOuts)
+	sigHashes := txscript.NewTxSigHashes(
+		arkPSBT.UnsignedTx, prevFetcher,
+	)
+
 	for i := range arkPSBT.UnsignedTx.TxIn {
 		err := signArkPSBTInput(
 			signer, arkPSBT, i, inputByCheckpointTxid,
+			prevFetcher, sigHashes,
 		)
 		if err != nil {
 			return fmt.Errorf("sign ark input %d: %w", i, err)
@@ -107,7 +134,9 @@ func buildCheckpointInputMap(checkpointPSBTs []*psbt.Packet,
 // collab leaf (2-of-2 multisig between owner and operator).
 func signArkPSBTInput(signer input.Signer, arkPSBT *psbt.Packet,
 	inputIndex int,
-	inputMap map[chainhash.Hash]*checkpointInputEntry) error {
+	inputMap map[chainhash.Hash]*checkpointInputEntry,
+	prevFetcher txscript.PrevOutputFetcher,
+	sigHashes *txscript.TxSigHashes) error {
 
 	prevOut := arkPSBT.UnsignedTx.TxIn[inputIndex].PreviousOutPoint
 	entry, ok := inputMap[prevOut.Hash]
@@ -134,19 +163,11 @@ func signArkPSBTInput(signer input.Signer, arkPSBT *psbt.Packet,
 		return fmt.Errorf("ark input %d: %w", inputIndex, err)
 	}
 
-	// Build the prevout for the checkpoint output being spent.
 	witnessUtxo := pInput.WitnessUtxo
 	if witnessUtxo == nil {
 		return fmt.Errorf("ark input %d: missing witness utxo",
 			inputIndex)
 	}
-
-	prevFetcher := txscript.NewCannedPrevOutputFetcher(
-		witnessUtxo.PkScript, witnessUtxo.Value,
-	)
-	sigHashes := txscript.NewTxSigHashes(
-		arkPSBT.UnsignedTx, prevFetcher,
-	)
 
 	// Pass the full KeyDescriptor (including KeyLocator) so
 	// signers that require the locator can find the private key.

--- a/oor/ark_sign.go
+++ b/oor/ark_sign.go
@@ -151,8 +151,8 @@ func signArkPSBTInput(signer input.Signer, arkPSBT *psbt.Packet,
 	// Pass the full KeyDescriptor (including KeyLocator) so
 	// signers that require the locator can find the private key.
 	signDesc := &input.SignDescriptor{
-		KeyDesc:       in.VTXO.ClientKey,
-		SignMethod:    input.TaprootScriptSpendSignMethod,
+		KeyDesc:    in.VTXO.ClientKey,
+		SignMethod: input.TaprootScriptSpendSignMethod,
 		Output: &wire.TxOut{
 			Value:    witnessUtxo.Value,
 			PkScript: witnessUtxo.PkScript,
@@ -200,6 +200,6 @@ func findTapLeafByScript(pInput *psbt.PInput,
 		}
 	}
 
-	return nil, fmt.Errorf("collab leaf script not found in "+
+	return nil, fmt.Errorf("collab leaf script not found in " +
 		"tapleaf entries")
 }

--- a/oor/outbox_messages.go
+++ b/oor/outbox_messages.go
@@ -22,7 +22,6 @@ const (
 		"oor/"
 )
 
-
 const (
 	retryPayloadAfterNanosRecordType tlv.Type = 1
 	retryPayloadReasonRecordType     tlv.Type = 3

--- a/oor/outbox_messages.go
+++ b/oor/outbox_messages.go
@@ -6,10 +6,9 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
-	oortx "github.com/lightninglabs/darepo-client/lib/tx/oor"
-	"github.com/lightninglabs/darepo-client/lib/tx/psbtutil"
 	mailboxrpc "github.com/lightninglabs/darepo-client/mailbox/rpc"
 	"github.com/lightninglabs/darepo-client/rpc/oorpb"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
@@ -23,10 +22,6 @@ const (
 		"oor/"
 )
 
-const (
-	finalizePayloadArkPSBTRecordType     tlv.Type = 1
-	finalizePayloadCheckpointsRecordType tlv.Type = 3
-)
 
 const (
 	retryPayloadAfterNanosRecordType tlv.Type = 1
@@ -59,6 +54,11 @@ type RequestArkSignatures struct {
 
 	// ArkPSBT is the canonical Ark transfer PSBT to sign.
 	ArkPSBT *psbt.Packet
+
+	// CheckpointPSBTs are the unsigned checkpoint PSBTs that correspond
+	// to the Ark inputs. These are needed to map each Ark input back to
+	// the transfer input that provides the client signing key.
+	CheckpointPSBTs []*psbt.Packet
 
 	// TransferInputs carry client signing context needed to authorize Ark
 	// inputs.
@@ -110,19 +110,26 @@ func (m *SendSubmitPackageRequest) ServiceMethod() mailboxrpc.ServiceMethod {
 	}
 }
 
-// ToProto converts SendSubmitPackageRequest to a protobuf message.
+// ToProto converts SendSubmitPackageRequest to the concrete proto type
+// expected by the server-side OOR dispatcher.
 func (m *SendSubmitPackageRequest) ToProto() fn.Result[proto.Message] {
-	payload, err := oortx.MarshalSubmitPackage(&oortx.SubmitPackage{
-		ArkPSBT:         m.ArkPSBT,
-		CheckpointPSBTs: m.CheckpointPSBTs,
-	})
+	descs := make([]oorpb.SigningDescriptor, 0, len(m.TransferInputs))
+	for _, ti := range m.TransferInputs {
+		descs = append(descs, oorpb.SigningDescriptor{
+			Outpoint:  ti.VTXO.Outpoint,
+			OwnerKey:  ti.VTXO.ClientKey.PubKey,
+			ExitDelay: ti.VTXO.RelativeExpiry,
+		})
+	}
+
+	req, err := oorpb.NewSubmitPackageRequest(
+		m.ArkPSBT, m.CheckpointPSBTs, descs,
+	)
 	if err != nil {
 		return fn.Err[proto.Message](err)
 	}
 
-	return fn.Ok[proto.Message](
-		protoEnvelope("SendSubmitPackageRequest", payload),
-	)
+	return fn.Ok[proto.Message](req)
 }
 
 // RequestCheckpointSignatures asks the signing layer to add client signature
@@ -181,18 +188,22 @@ func (m *SendFinalizePackageRequest) ServiceMethod() mailboxrpc.ServiceMethod {
 	}
 }
 
-// ToProto converts SendFinalizePackageRequest to a protobuf message.
+// ToProto converts SendFinalizePackageRequest to the concrete proto type
+// expected by the server-side OOR dispatcher.
 func (m *SendFinalizePackageRequest) ToProto() fn.Result[proto.Message] {
-	payload, err := encodeFinalizePayload(
-		m.ArkPSBT, m.FinalCheckpointPSBTs,
+	sessionID, err := sessionIDFromArk(m.ArkPSBT)
+	if err != nil {
+		return fn.Err[proto.Message](err)
+	}
+
+	req, err := oorpb.NewFinalizePackageRequest(
+		chainhash.Hash(sessionID), m.FinalCheckpointPSBTs,
 	)
 	if err != nil {
 		return fn.Err[proto.Message](err)
 	}
 
-	return fn.Ok[proto.Message](
-		protoEnvelope("SendFinalizePackageRequest", payload),
-	)
+	return fn.Ok[proto.Message](req)
 }
 
 // MarkInputsSpentRequest asks the persistence layer to mark the OOR inputs as
@@ -365,47 +376,6 @@ func protoEnvelope(typeName string, payload []byte) proto.Message {
 	}
 }
 
-func encodeFinalizePayload(ark *psbt.Packet,
-	checkpoints []*psbt.Packet) ([]byte, error) {
-
-	arkRaw, err := psbtutil.Serialize(ark)
-	if err != nil {
-		return nil, err
-	}
-
-	checkpointRaws, err := serializePSBTSlice(checkpoints)
-	if err != nil {
-		return nil, err
-	}
-
-	checkpointPayload, err := encodeLengthPrefixedBlobList(checkpointRaws)
-	if err != nil {
-		return nil, err
-	}
-
-	checkpointPayloadRecord := tlv.MakePrimitiveRecord(
-		finalizePayloadCheckpointsRecordType, &checkpointPayload,
-	)
-
-	records := []tlv.Record{
-		tlv.MakePrimitiveRecord(
-			finalizePayloadArkPSBTRecordType, &arkRaw,
-		),
-		checkpointPayloadRecord,
-	}
-
-	stream, err := tlv.NewStream(records...)
-	if err != nil {
-		return nil, err
-	}
-
-	var buf bytes.Buffer
-	if err := stream.Encode(&buf); err != nil {
-		return nil, err
-	}
-
-	return buf.Bytes(), nil
-}
 func encodeRetryPayload(after time.Duration, reason string) ([]byte, error) {
 	if after < 0 {
 		return nil, fmt.Errorf("retry delay must be non-negative")

--- a/oor/outbox_messages_test.go
+++ b/oor/outbox_messages_test.go
@@ -8,12 +8,13 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/lib/scripts"
+	"github.com/lightninglabs/darepo-client/rpc/oorpb"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
 // TestOutboxToProtoSubmitRequest verifies that a valid submit package
-// outbox request serializes into the expected proto Any envelope.
+// outbox request serializes into the expected proto message.
 func TestOutboxToProtoSubmitRequest(t *testing.T) {
 	t.Parallel()
 
@@ -26,14 +27,8 @@ func TestOutboxToProtoSubmitRequest(t *testing.T) {
 
 	result := msg.ToProto().UnwrapOrFail(t)
 
-	anyMsg, ok := result.(*anypb.Any)
+	_, ok := result.(*oorpb.SubmitPackageRequest)
 	require.True(t, ok)
-	require.Equal(
-		t,
-		oorOutboxProtoTypeURLPrefix+"SendSubmitPackageRequest",
-		anyMsg.TypeUrl,
-	)
-	require.NotEmpty(t, anyMsg.Value)
 }
 
 // TestOutboxToProtoSubmitRequestError verifies that a submit request
@@ -48,8 +43,7 @@ func TestOutboxToProtoSubmitRequestError(t *testing.T) {
 }
 
 // TestOutboxToProtoFinalizeRequest verifies that a valid finalize
-// package outbox request serializes into the expected proto Any
-// envelope.
+// package outbox request serializes into the expected proto message.
 func TestOutboxToProtoFinalizeRequest(t *testing.T) {
 	t.Parallel()
 
@@ -62,14 +56,8 @@ func TestOutboxToProtoFinalizeRequest(t *testing.T) {
 
 	result := msg.ToProto().UnwrapOrFail(t)
 
-	anyMsg, ok := result.(*anypb.Any)
+	_, ok := result.(*oorpb.FinalizePackageRequest)
 	require.True(t, ok)
-	require.Equal(
-		t,
-		oorOutboxProtoTypeURLPrefix+"SendFinalizePackageRequest",
-		anyMsg.TypeUrl,
-	)
-	require.NotEmpty(t, anyMsg.Value)
 }
 
 // TestOutboxToProtoMarkInputsSpentRequest verifies that a mark-inputs-

--- a/oor/resume.go
+++ b/oor/resume.go
@@ -19,8 +19,9 @@ func OutboxForState(state State) ([]OutboxEvent, error) {
 	case *AwaitingArkSignatures:
 		return []OutboxEvent{
 			&RequestArkSignatures{
-				ArkPSBT:        s.ArkPSBT,
-				TransferInputs: s.TransferInputs,
+				ArkPSBT:         s.ArkPSBT,
+				CheckpointPSBTs: s.CheckpointPSBTs,
+				TransferInputs:  s.TransferInputs,
 			},
 		}, nil
 

--- a/oor/session_test.go
+++ b/oor/session_test.go
@@ -159,3 +159,164 @@ func TestSessionHappyPath(t *testing.T) {
 	_, ok = state.(*Completed)
 	require.True(t, ok)
 }
+
+// TestSessionMultiInputHappyPath verifies the outgoing transfer FSM with
+// multiple VTXO inputs. This exercises the multi-input Ark signing path
+// where BIP-341 sighash commits to ALL prevouts, requiring a
+// MultiPrevOutFetcher rather than a CannedPrevOutputFetcher.
+func TestSessionMultiInputHappyPath(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	policy := scripts.CheckpointPolicy{
+		OperatorKey: operatorKey.PubKey(),
+		CSVDelay:    10,
+	}
+
+	// Use two distinct client keys and different amounts to ensure
+	// the sighash computation correctly handles heterogeneous inputs.
+	clientKey1, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	clientKey2, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	clientSigner := input.NewMockSigner(
+		[]*btcec.PrivateKey{clientKey1, clientKey2}, nil,
+	)
+	operatorSigner := input.NewMockSigner(
+		[]*btcec.PrivateKey{operatorKey}, nil,
+	)
+
+	input1Value := btcutil.Amount(10000)
+	input2Value := btcutil.Amount(25000)
+
+	inputs := []TransferInput{
+		newTestTransferInput(
+			t, clientKey1, policy.OperatorKey,
+			wire.OutPoint{
+				Hash:  [32]byte{0x01},
+				Index: 0,
+			},
+			input1Value,
+		),
+		newTestTransferInput(
+			t, clientKey2, policy.OperatorKey,
+			wire.OutPoint{
+				Hash:  [32]byte{0x02},
+				Index: 0,
+			},
+			input2Value,
+		),
+	}
+
+	outputs := []oortx.RecipientOutput{
+		{
+			PkScript: newTestTaprootPkScript(
+				t, clientKey1.PubKey(),
+			),
+			Value: input1Value + input2Value,
+		},
+	}
+
+	session, outbox, err := NewSession(ctx, policy, inputs, outputs)
+	require.NoError(t, err)
+	require.NotNil(t, session)
+	require.Len(t, outbox, 1)
+
+	arkSignReq, ok := outbox[0].(*RequestArkSignatures)
+	require.True(t, ok)
+
+	// The Ark tx should have 2 inputs (one per checkpoint).
+	require.Len(t, arkSignReq.ArkPSBT.UnsignedTx.TxIn, 2,
+		"Ark tx should have one input per VTXO")
+	require.Len(t, arkSignReq.CheckpointPSBTs, 2,
+		"should have one checkpoint per VTXO")
+
+	// Sign the Ark PSBT with the client keys. This exercises the
+	// MultiPrevOutFetcher path for correct BIP-341 sighash
+	// computation across heterogeneous inputs.
+	err = SignArkPSBT(
+		clientSigner, arkSignReq.ArkPSBT,
+		arkSignReq.CheckpointPSBTs, arkSignReq.TransferInputs,
+	)
+	require.NoError(t, err)
+
+	// Verify the signed Ark PSBT has signatures on both inputs.
+	for i, pInput := range arkSignReq.ArkPSBT.Inputs {
+		require.NotEmpty(t, pInput.TaprootScriptSpendSig,
+			"Ark input %d should have a script spend sig", i)
+	}
+
+	// Feed the signed Ark PSBT back into the FSM.
+	fut := session.FSM.AskEvent(ctx, &ArkSignedEvent{
+		ArkPSBT: arkSignReq.ArkPSBT,
+	})
+	result := fut.Await(ctx)
+	require.False(t, result.IsErr(),
+		"ArkSignedEvent should succeed: %v", result.Err())
+
+	submitOutbox := result.UnwrapOr(nil)
+	require.Len(t, submitOutbox, 1)
+	submit, ok := submitOutbox[0].(*SendSubmitPackageRequest)
+	require.True(t, ok)
+	require.Len(t, submit.CheckpointPSBTs, 2)
+
+	// Operator co-signs the checkpoints.
+	err = coSignCheckpointPSBTsForTest(
+		operatorSigner, submit.TransferInputs,
+		submit.CheckpointPSBTs,
+	)
+	require.NoError(t, err)
+
+	// Server accepts submit.
+	fut = session.FSM.AskEvent(ctx, &SubmitAcceptedEvent{
+		SessionID:               session.ID,
+		ArkPSBT:                 submit.ArkPSBT,
+		CoSignedCheckpointPSBTs: submit.CheckpointPSBTs,
+	})
+	result = fut.Await(ctx)
+	require.False(t, result.IsErr())
+
+	signOutbox := result.UnwrapOr(nil)
+	require.Len(t, signOutbox, 1)
+	signReq, ok := signOutbox[0].(*RequestCheckpointSignatures)
+	require.True(t, ok)
+
+	// Client signs checkpoints.
+	err = SignCheckpointPSBTs(
+		clientSigner, signReq.TransferInputs,
+		signReq.CoSignedCheckpointPSBTs,
+	)
+	require.NoError(t, err)
+
+	fut = session.FSM.AskEvent(ctx, &CheckpointsSignedEvent{
+		FinalCheckpointPSBTs: signReq.CoSignedCheckpointPSBTs,
+	})
+	result = fut.Await(ctx)
+	require.False(t, result.IsErr())
+
+	// Finalize.
+	fut = session.FSM.AskEvent(ctx, &FinalizeAcceptedEvent{})
+	result = fut.Await(ctx)
+	require.False(t, result.IsErr())
+
+	markOutbox := result.UnwrapOr(nil)
+	require.Len(t, markOutbox, 1)
+	_, ok = markOutbox[0].(*MarkInputsSpentRequest)
+	require.True(t, ok)
+
+	// Mark spent.
+	fut = session.FSM.AskEvent(ctx, &InputsMarkedSpentEvent{})
+	result = fut.Await(ctx)
+	require.False(t, result.IsErr())
+
+	state, err := session.FSM.CurrentState()
+	require.NoError(t, err)
+	_, ok = state.(*Completed)
+	require.True(t, ok, "FSM should reach Completed state")
+}

--- a/oor/session_test.go
+++ b/oor/session_test.go
@@ -77,6 +77,12 @@ func TestSessionHappyPath(t *testing.T) {
 	require.True(t, ok)
 
 	// Step 1: Ark signatures are attached before submit is sent.
+	err = SignArkPSBT(
+		clientSigner, arkSignReq.ArkPSBT,
+		arkSignReq.CheckpointPSBTs, arkSignReq.TransferInputs,
+	)
+	require.NoError(t, err)
+
 	fut := session.FSM.AskEvent(ctx, &ArkSignedEvent{
 		ArkPSBT: arkSignReq.ArkPSBT,
 	})

--- a/oor/signing_outbox_handler.go
+++ b/oor/signing_outbox_handler.go
@@ -16,8 +16,8 @@ import (
 // This handler is intended to be used as the Next delegate inside
 // LocalPersistenceOutboxHandler. It handles the following outbox events:
 //
-//   - RequestArkSignatures: v0 pass-through (no additional local signing
-//     needed beyond deterministic package construction).
+//   - RequestArkSignatures: signs Ark PSBT inputs using the client key on
+//     each checkpoint output's owner leaf via SignArkPSBT.
 //   - RequestCheckpointSignatures: attaches client-side collaborative VTXO
 //     spend signatures to each checkpoint PSBT via SignCheckpointPSBTs.
 //   - ScheduleRetryRequest: schedules a timer via the timeout actor. When
@@ -45,17 +45,16 @@ func (h *SigningOutboxHandler) Handle(ctx context.Context,
 
 	switch msg := outbox.(type) {
 	case *RequestArkSignatures:
-		// v0 does not require extra local Ark signing beyond
-		// deterministic package construction. Forward the Ark
-		// PSBT as-is.
-		log.DebugS(ctx, "Ark signatures requested (v0 pass-through)",
-			slog.String("session_id", sessionID.String()))
+		numInputs := 0
+		if msg.ArkPSBT != nil && msg.ArkPSBT.UnsignedTx != nil {
+			numInputs = len(msg.ArkPSBT.UnsignedTx.TxIn)
+		}
 
-		return []Event{
-			&ArkSignedEvent{
-				ArkPSBT: msg.ArkPSBT,
-			},
-		}, nil
+		log.DebugS(ctx, "Ark signatures requested",
+			slog.String("session_id", sessionID.String()),
+			slog.Int("num_inputs", numInputs))
+
+		return h.handleArkSignatures(msg)
 
 	case *RequestCheckpointSignatures:
 		log.DebugS(ctx, "Checkpoint signatures requested",
@@ -84,6 +83,30 @@ func (h *SigningOutboxHandler) Handle(ctx context.Context,
 	default:
 		return nil, fmt.Errorf("unhandled outbox event %T", outbox)
 	}
+}
+
+// handleArkSignatures signs the Ark PSBT inputs using the client key on the
+// owner leaf path of each checkpoint output.
+func (h *SigningOutboxHandler) handleArkSignatures(
+	msg *RequestArkSignatures) ([]Event, error) {
+
+	if h.Signer == nil {
+		return nil, fmt.Errorf("signer is required")
+	}
+
+	err := SignArkPSBT(
+		h.Signer, msg.ArkPSBT, msg.CheckpointPSBTs,
+		msg.TransferInputs,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return []Event{
+		&ArkSignedEvent{
+			ArkPSBT: msg.ArkPSBT,
+		},
+	}, nil
 }
 
 // handleCheckpointSignatures attaches client-side collaborative VTXO spend

--- a/oor/test_helpers_test.go
+++ b/oor/test_helpers_test.go
@@ -53,8 +53,24 @@ func newTestTransferInput(t *testing.T, ownerKey *btcec.PrivateKey,
 			TapScript:      tapscript,
 			RelativeExpiry: exitDelay,
 		},
-		OwnerLeafScript: []byte{0x51},
+		OwnerLeafScript: newTestCollabLeaf(
+			t, ownerKey.PubKey(), operatorKey,
+		),
 	}
+}
+
+// newTestCollabLeaf builds the 2-of-2 collaborative multisig leaf script
+// for checkpoint outputs in tests. This matches the protocol spec where
+// the checkpoint collab path requires both owner and operator signatures.
+func newTestCollabLeaf(t *testing.T, ownerKey,
+	operatorKey *btcec.PublicKey) []byte {
+
+	t.Helper()
+
+	leaf, err := scripts.MultiSigCollabTapLeaf(ownerKey, operatorKey)
+	require.NoError(t, err)
+
+	return leaf.Script
 }
 
 // newTestTaprootPkScript returns a valid P2TR pkScript for tests.

--- a/oor/transitions.go
+++ b/oor/transitions.go
@@ -148,7 +148,11 @@ func (s *AwaitingArkSignatures) ProcessEvent(ctx context.Context, event Event,
 			return nil, fmt.Errorf("ark txid mismatch")
 		}
 
-		_, err := oortx.ValidateSubmitPackageSigned(
+		// Validate structural correctness only. Full script VM
+		// validation is not possible here because the Ark tx only
+		// carries the client's half of the 2-of-2 checkpoint collab
+		// signature. The operator adds their half during submit.
+		_, err := oortx.ValidateSubmitPackage(
 			evt.ArkPSBT, s.CheckpointPSBTs,
 		)
 		if err != nil {

--- a/oor/transitions.go
+++ b/oor/transitions.go
@@ -93,8 +93,9 @@ func (s *Idle) ProcessEvent(ctx context.Context, event Event,
 		}
 
 		signReq := &RequestArkSignatures{
-			ArkPSBT:        ark,
-			TransferInputs: evt.VTXOInputs,
+			ArkPSBT:         ark,
+			CheckpointPSBTs: checkpoints,
+			TransferInputs:  evt.VTXOInputs,
 		}
 
 		return &StateTransition{

--- a/serverconn/actor.go
+++ b/serverconn/actor.go
@@ -30,6 +30,9 @@ const (
 	SendRPCRequestMsgType tlv.Type = 2001
 )
 
+// defaultSendEventTimeout is the timeout for outbound gRPC Edge.Send calls.
+const defaultSendEventTimeout = 30 * time.Second
+
 // TLV record type aliases for RecordT-style message field serialization.
 type (
 	protoPayloadRecordTLV = tlv.TlvType1
@@ -450,6 +453,8 @@ func (a *ServerConnectionActor) handleSendClientEvent(ctx context.Context,
 
 	protoMsg, err := req.Message.ToProto().Unpack()
 	if err != nil {
+		log.WarnS(ctx, "Failed to convert to proto", err)
+
 		return fn.Err[ServerConnResp](fmt.Errorf(
 			"convert to proto: %w", err,
 		))
@@ -504,7 +509,15 @@ func (a *ServerConnectionActor) handleSendClientEvent(ctx context.Context,
 		},
 	}
 
-	resp, err := a.cfg.Edge.Send(ctx, &mailboxpb.SendRequest{
+	// Use a detached context for the gRPC call so that parent
+	// cancellation does not abort the outbound send, while
+	// preserving trace/logging context values.
+	sendCtx, sendCancel := context.WithTimeout(
+		context.WithoutCancel(ctx), defaultSendEventTimeout,
+	)
+	defer sendCancel()
+
+	resp, err := a.cfg.Edge.Send(sendCtx, &mailboxpb.SendRequest{
 		Envelope: envelope,
 	})
 	if err != nil {


### PR DESCRIPTION
This PR folds in and corrects several foundational pieces for the OOR
transfer flow, fixing a protocol-level security issue in the checkpoint
collab leaf construction, adding real Ark PSBT signing, and resolving
the same-DB durable actor deadlock at its root.

## Checkpoint collab leaf: 2-of-2, not single-sig

The checkpoint output's collaborative spend path was using a single-sig
`<owner_key> OP_CHECKSIG` leaf (via `OwnerCheckSigLeaf`). Per the
protocol spec (Technical Explainer: OOR Ark and Checkpoint Transactions),
this path **must** be a 2-of-2 multisig between owner and operator:

```
<owner_key> OP_CHECKSIGVERIFY
<operator_key> OP_CHECKSIG
```

Using single-sig would allow the client to create alternative Ark txs
spending the checkpoint output without operator knowledge, breaking the
double-spend protection that checkpoints provide. The fix replaces
`OwnerCheckSigLeaf` with the existing `MultiSigCollabTapLeaf` helper
which already implements the correct 2-of-2 script.

This also required changing the FSM's submit validation from
`ValidateSubmitPackageSigned` (full script VM execution) to
`ValidateSubmitPackage` (structural only), since at submit time only the
client's half of the 2-of-2 signature is present. The operator adds
their half during the submit phase.

## Real Ark PSBT signing

The `SignArkPSBT` function is added to sign Ark tx inputs using the
client key on the checkpoint output's collab leaf. The signing outbox
handler now calls `SignArkPSBT` instead of passing the Ark PSBT through
unsigned.

Fixes from code review:
- Pass full `KeyDescriptor` (including `KeyLocator`) so hardware
  signers can locate the private key
- Search `TaprootLeafScript` entries by matching the expected leaf
  script hash instead of assuming index 0

## Same-DB tx atomicity (WithoutTx removal)

`DurableMailbox.Send()` was calling `WithoutTx(ctx)` to strip the
sender's database transaction before enqueueing messages. On same-DB
actors (all client-side actors share one SQLite DB), this forced
`EnqueueMessage` to open a **new** write transaction while the sender's
write tx was still active. SQLite WAL only allows one writer, causing a
deadlock.

The `WithoutTx` was added as a blanket safety measure for cross-DB
actors, but the root cause was a test setup bug where client and server
shared one DB (fixed in darepo#113). With `TransactionExecutor.ExecTx`
already context-aware (joins the outer tx when one exists), removing
`WithoutTx` gives us atomic cross-actor Tell for free: the enqueue is
committed in the same transaction as the sender's state change.

## Other changes

- `serverconn`: use `context.WithoutCancel` for `Edge.Send` gRPC calls
  to prevent parent cancellation from aborting outbound sends, with a
  `defaultSendEventTimeout` constant
- `darepod`: add `Output_Pubkey` destination for OOR sends, deriving a
  VTXO-compatible P2TR output from a recipient's schnorr key
- `oorpb`: switch `ToProto` from `anypb.Any` envelopes to concrete proto
  types matching the server-side dispatcher

Several commits are adapted from #179, with the critical checkpoint leaf
fix and review feedback addressed.

Fixes #137
Fixes #141