### PR TITLE
oor: production-identical OOR receive path with async materialization

### DIFF
--- a/arkrpc/indexer.pb.go
+++ b/arkrpc/indexer.pb.go
@@ -854,8 +854,16 @@ type OORRecipientEvent struct {
 	SessionId         []byte                 `protobuf:"bytes,3,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
 	OutputIndex       uint32                 `protobuf:"varint,4,opt,name=output_index,json=outputIndex,proto3" json:"output_index,omitempty"`
 	Value             uint64                 `protobuf:"varint,5,opt,name=value,proto3" json:"value,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	// ark_psbt is the serialized Ark PSBT for this OOR session. The
+	// client needs this to materialize the received VTXO via the
+	// IncomingTransferEvent in the OOR FSM.
+	ArkPsbt []byte `protobuf:"bytes,6,opt,name=ark_psbt,json=arkPsbt,proto3" json:"ark_psbt,omitempty"`
+	// checkpoint_psbts are the finalized checkpoint PSBTs for the
+	// session. These provide lineage and unroll proof data for the
+	// materialized VTXO.
+	CheckpointPsbts [][]byte `protobuf:"bytes,7,rep,name=checkpoint_psbts,json=checkpointPsbts,proto3" json:"checkpoint_psbts,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *OORRecipientEvent) Reset() {
@@ -921,6 +929,20 @@ func (x *OORRecipientEvent) GetValue() uint64 {
 		return x.Value
 	}
 	return 0
+}
+
+func (x *OORRecipientEvent) GetArkPsbt() []byte {
+	if x != nil {
+		return x.ArkPsbt
+	}
+	return nil
+}
+
+func (x *OORRecipientEvent) GetCheckpointPsbts() [][]byte {
+	if x != nil {
+		return x.CheckpointPsbts
+	}
+	return nil
 }
 
 // IncomingOOREvent is delivered as a mailbox EVENT envelope. It is
@@ -2022,14 +2044,16 @@ const file_indexer_proto_rawDesc = "" +
 	"&ListOORRecipientEventsByScriptResponse\x121\n" +
 	"\x06events\x18\x01 \x03(\v2\x19.arkrpc.OORRecipientEventR\x06events\x12\x1f\n" +
 	"\vnext_cursor\x18\x02 \x01(\x04R\n" +
-	"nextCursor\"\xb6\x01\n" +
+	"nextCursor\"\xfc\x01\n" +
 	"\x11OORRecipientEvent\x12.\n" +
 	"\x13recipient_pk_script\x18\x01 \x01(\fR\x11recipientPkScript\x12\x19\n" +
 	"\bevent_id\x18\x02 \x01(\x04R\aeventId\x12\x1d\n" +
 	"\n" +
 	"session_id\x18\x03 \x01(\fR\tsessionId\x12!\n" +
 	"\foutput_index\x18\x04 \x01(\rR\voutputIndex\x12\x14\n" +
-	"\x05value\x18\x05 \x01(\x04R\x05value\"\xc8\x01\n" +
+	"\x05value\x18\x05 \x01(\x04R\x05value\x12\x19\n" +
+	"\bark_psbt\x18\x06 \x01(\fR\aarkPsbt\x12)\n" +
+	"\x10checkpoint_psbts\x18\a \x03(\fR\x0fcheckpointPsbts\"\xc8\x01\n" +
 	"\x10IncomingOOREvent\x12.\n" +
 	"\x13recipient_pk_script\x18\x01 \x01(\fR\x11recipientPkScript\x12,\n" +
 	"\x12recipient_event_id\x18\x02 \x01(\x04R\x10recipientEventId\x12\x1d\n" +

--- a/arkrpc/indexer.pb.go
+++ b/arkrpc/indexer.pb.go
@@ -1217,7 +1217,10 @@ type VTXO struct {
 	// chain_depth is the number of OOR checkpoint hops between this VTXO
 	// and the most recent on-chain commitment. Round-created VTXOs have
 	// chain_depth 0.
-	ChainDepth    uint32 `protobuf:"varint,15,opt,name=chain_depth,json=chainDepth,proto3" json:"chain_depth,omitempty"`
+	ChainDepth uint32 `protobuf:"varint,15,opt,name=chain_depth,json=chainDepth,proto3" json:"chain_depth,omitempty"`
+	// tree_path_tlv is the TLV-encoded extracted tree.Tree path required for
+	// unilateral exit of this VTXO's underlying commitment lineage.
+	TreePathTlv   []byte `protobuf:"bytes,16,opt,name=tree_path_tlv,json=treePathTlv,proto3" json:"tree_path_tlv,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1355,6 +1358,13 @@ func (x *VTXO) GetChainDepth() uint32 {
 		return x.ChainDepth
 	}
 	return 0
+}
+
+func (x *VTXO) GetTreePathTlv() []byte {
+	if x != nil {
+		return x.TreePathTlv
+	}
+	return nil
 }
 
 type ListVTXOsByScriptsRequest struct {
@@ -2069,7 +2079,7 @@ const file_indexer_proto_rawDesc = "" +
 	"\x0ftaproot_schnorr\x18\n" +
 	" \x01(\v2\x1b.arkrpc.TaprootSchnorrProofH\x00R\x0etaprootSchnorr\x12-\n" +
 	"\x06bip322\x18\v \x01(\v2\x13.arkrpc.BIP322ProofH\x00R\x06bip322B\a\n" +
-	"\x05proof\"\xc4\x04\n" +
+	"\x05proof\"\xe8\x04\n" +
 	"\x04VTXO\x12,\n" +
 	"\boutpoint\x18\x01 \x01(\v2\x10.arkrpc.OutPointR\boutpoint\x12\x1b\n" +
 	"\tvalue_sat\x18\x02 \x01(\x04R\bvalueSat\x12\x1b\n" +
@@ -2089,7 +2099,8 @@ const file_indexer_proto_rawDesc = "" +
 	"oorArkPsbt\x12;\n" +
 	"\x1aoor_final_checkpoint_psbts\x18\x0e \x03(\fR\x17oorFinalCheckpointPsbts\x12\x1f\n" +
 	"\vchain_depth\x18\x0f \x01(\rR\n" +
-	"chainDepth\"\xb1\x01\n" +
+	"chainDepth\x12\"\n" +
+	"\rtree_path_tlv\x18\x10 \x01(\fR\vtreePathTlv\"\xb1\x01\n" +
 	"\x19ListVTXOsByScriptsRequest\x12-\n" +
 	"\ascripts\x18\x01 \x03(\v2\x13.arkrpc.ScriptScopeR\ascripts\x127\n" +
 	"\rstatus_filter\x18\x02 \x03(\x0e2\x12.arkrpc.VTXOStatusR\fstatusFilter\x12\x16\n" +

--- a/arkrpc/indexer.proto
+++ b/arkrpc/indexer.proto
@@ -152,6 +152,16 @@ message OORRecipientEvent {
     bytes session_id = 3;
     uint32 output_index = 4;
     uint64 value = 5;
+
+    // ark_psbt is the serialized Ark PSBT for this OOR session. The
+    // client needs this to materialize the received VTXO via the
+    // IncomingTransferEvent in the OOR FSM.
+    bytes ark_psbt = 6;
+
+    // checkpoint_psbts are the finalized checkpoint PSBTs for the
+    // session. These provide lineage and unroll proof data for the
+    // materialized VTXO.
+    repeated bytes checkpoint_psbts = 7;
 }
 
 // IncomingOOREvent is delivered as a mailbox EVENT envelope. It is

--- a/arkrpc/indexer.proto
+++ b/arkrpc/indexer.proto
@@ -288,6 +288,10 @@ message VTXO {
     // and the most recent on-chain commitment. Round-created VTXOs have
     // chain_depth 0.
     uint32 chain_depth = 15;
+
+    // tree_path_tlv is the TLV-encoded extracted tree.Tree path required for
+    // unilateral exit of this VTXO's underlying commitment lineage.
+    bytes tree_path_tlv = 16;
 }
 
 message ListVTXOsByScriptsRequest {

--- a/baselib/actor/tx_context.go
+++ b/baselib/actor/tx_context.go
@@ -95,6 +95,13 @@ func WithOutboxID(ctx context.Context, id string) context.Context {
 	return context.WithValue(ctx, outboxIDContextKey{}, id)
 }
 
+// WithoutOutboxID returns a new context with any propagated outbox message ID
+// shadowed. This is used for internal async callbacks so they do not
+// accidentally reuse the caller's CDC deduplication identity.
+func WithoutOutboxID(ctx context.Context) context.Context {
+	return context.WithValue(ctx, outboxIDContextKey{}, "")
+}
+
 // OutboxIDFromContext retrieves the outbox message ID from the context, if
 // present. Returns the ID and true if found, empty string and false otherwise.
 func OutboxIDFromContext(ctx context.Context) (string, bool) {

--- a/baselib/actor/tx_context_test.go
+++ b/baselib/actor/tx_context_test.go
@@ -75,3 +75,28 @@ func TestWithoutTxOnCleanContext(t *testing.T) {
 	require.False(t, ok)
 	require.Nil(t, tx)
 }
+
+// TestWithoutOutboxIDStripsPropagatedID verifies that internal async callbacks
+// can shadow a propagated outbox ID so they don't accidentally reuse CDC
+// deduplication identity from the inbound durable delivery.
+func TestWithoutOutboxIDStripsPropagatedID(t *testing.T) {
+	t.Parallel()
+
+	type customKey struct{}
+
+	ctx := context.WithValue(context.Background(), customKey{}, "preserved")
+	ctx = WithOutboxID(ctx, "outbox-123")
+
+	id, ok := OutboxIDFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, "outbox-123", id)
+
+	stripped := WithoutOutboxID(ctx)
+
+	id, ok = OutboxIDFromContext(stripped)
+	require.False(t, ok)
+	require.Empty(t, id)
+
+	val := stripped.Value(customKey{})
+	require.Equal(t, "preserved", val)
+}

--- a/cmd/darepocli/darepoclicommands/cmd_mcp.go
+++ b/cmd/darepocli/darepoclicommands/cmd_mcp.go
@@ -162,6 +162,31 @@ func registerMCPTools(s *mcp.Server,
 	// agent logs or provider APIs. Use the CLI directly for wallet
 	// setup. See #164 and #165 for secure agent wallet init plans.
 
+	// oor_receive — fresh OOR receive script.
+	type oorReceiveArgs struct {
+		Label string `json:"label,omitempty" jsonschema:"optional indexer registration label"` //nolint:ll
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "oor_receive",
+		Description: "Allocate a fresh OOR receive script",
+	}, func(ctx context.Context,
+		req *mcp.CallToolRequest,
+		args oorReceiveArgs) (*mcp.CallToolResult, any, error) {
+
+		resp, err := client.NewOORReceiveScript(
+			ctx, &daemonrpc.NewOORReceiveScriptRequest{
+				Label: args.Label,
+			},
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		r, err := mcpResult(resp)
+
+		return r, nil, err
+	})
+
 	// vtxos_list — with optional filters.
 	type vtxosListArgs struct {
 		StatusFilter string `json:"status_filter,omitempty" jsonschema:"VTXO status filter (live, spent, expiring, etc.)"` //nolint:ll
@@ -297,9 +322,11 @@ func registerMCPSendTools(s *mcp.Server,
 
 	// send_oor — out-of-round send.
 	type sendOORArgs struct {
-		Address   string `json:"address" jsonschema:"recipient address"`                     //nolint:ll
-		AmountSat int64  `json:"amount_sat" jsonschema:"amount in sats"`                     //nolint:ll
-		DryRun    bool   `json:"dry_run,omitempty" jsonschema:"validate without initiating"` //nolint:ll
+		Address        string `json:"address,omitempty" jsonschema:"recipient address"`                            //nolint:ll
+		PubKeyXOnlyHex string `json:"pubkey_xonly_hex,omitempty" jsonschema:"recipient 32-byte x-only pubkey hex"` //nolint:ll
+		PkScriptHex    string `json:"pk_script_hex,omitempty" jsonschema:"recipient raw pk_script hex"`            //nolint:ll
+		AmountSat      int64  `json:"amount_sat" jsonschema:"amount in sats"`                                      //nolint:ll
+		DryRun         bool   `json:"dry_run,omitempty" jsonschema:"validate without initiating"`                  //nolint:ll
 	}
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "send_oor",
@@ -308,15 +335,18 @@ func registerMCPSendTools(s *mcp.Server,
 		req *mcp.CallToolRequest,
 		args sendOORArgs) (*mcp.CallToolResult, any, error) {
 
+		recipient, err := buildOORRecipientOutput(
+			args.Address, args.PubKeyXOnlyHex,
+			args.PkScriptHex, args.AmountSat,
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+
 		resp, err := client.SendOOR(
 			ctx, &daemonrpc.SendOORRequest{
-				Recipient: &daemonrpc.Output{
-					Destination: &daemonrpc.Output_Address{
-						Address: args.Address,
-					},
-					AmountSat: args.AmountSat,
-				},
-				DryRun: args.DryRun,
+				Recipient: recipient,
+				DryRun:    args.DryRun,
 			},
 		)
 		if err != nil {

--- a/cmd/darepocli/darepoclicommands/cmd_oor.go
+++ b/cmd/darepocli/darepoclicommands/cmd_oor.go
@@ -1,0 +1,70 @@
+package darepoclicommands
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/spf13/cobra"
+)
+
+// newOORCmd creates the oor parent command with receive-target subcommands.
+func newOORCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "oor",
+		Short: "Out-of-round operations",
+		Long: "Manage out-of-round receive targets and other direct " +
+			"transfer helpers.",
+	}
+
+	cmd.AddCommand(
+		newOORReceiveCmd(),
+	)
+
+	return cmd
+}
+
+// newOORReceiveCmd creates the oor receive subcommand.
+func newOORReceiveCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "receive",
+		Short: "Allocate a fresh OOR receive script",
+		Long: "Allocates a fresh wallet key, registers the matching " +
+			"taproot OOR receive script with the indexer, and " +
+			"prints the resulting destination details.",
+		RunE: oorReceive,
+	}
+
+	cmd.Flags().String("label", "",
+		"optional label stored with the receive-script registration")
+
+	return cmd
+}
+
+// oorReceive executes the NewOORReceiveScript RPC.
+func oorReceive(cmd *cobra.Command, _ []string) error {
+	client, conn, err := getDaemonClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	req := &daemonrpc.NewOORReceiveScriptRequest{}
+	if err := parseRequest(cmd, req, func() error {
+		label, _ := cmd.Flags().GetString("label")
+		req.Label = label
+
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	resp, err := client.NewOORReceiveScript(
+		context.Background(), req,
+	)
+	if err != nil {
+		return fmt.Errorf("NewOORReceiveScript RPC failed: %w", err)
+	}
+
+	return printJSON(resp)
+}

--- a/cmd/darepocli/darepoclicommands/cmd_send.go
+++ b/cmd/darepocli/darepoclicommands/cmd_send.go
@@ -131,11 +131,21 @@ func newSendOORCmd() *cobra.Command {
 	cmd.Flags().String("to", "",
 		"recipient address")
 
+	cmd.Flags().String("pubkey", "",
+		"recipient 32-byte x-only pubkey hex")
+
+	cmd.Flags().String("pk_script", "",
+		"recipient raw pk_script hex")
+
 	cmd.Flags().Int64("amount", 0,
 		"amount in sats")
 
 	cmd.Flags().Bool("dry_run", false,
 		"validate without initiating")
+
+	cmd.MarkFlagsMutuallyExclusive(
+		"to", "pubkey", "pk_script",
+	)
 
 	return cmd
 }
@@ -151,24 +161,19 @@ func sendOOR(cmd *cobra.Command, _ []string) error {
 	req := &daemonrpc.SendOORRequest{}
 	if err := parseRequest(cmd, req, func() error {
 		address, _ := cmd.Flags().GetString("to")
+		pubKeyHex, _ := cmd.Flags().GetString("pubkey")
+		pkScriptHex, _ := cmd.Flags().GetString("pk_script")
 		amount, _ := cmd.Flags().GetInt64("amount")
 		dryRun, _ := cmd.Flags().GetBool("dry_run")
 
-		if address == "" {
-			return fmt.Errorf("--to is required")
+		recipient, err := buildOORRecipientOutput(
+			address, pubKeyHex, pkScriptHex, amount,
+		)
+		if err != nil {
+			return err
 		}
 
-		if amount <= 0 {
-			return fmt.Errorf(
-				"--amount must be positive")
-		}
-
-		req.Recipient = &daemonrpc.Output{
-			Destination: &daemonrpc.Output_Address{
-				Address: address,
-			},
-			AmountSat: amount,
-		}
+		req.Recipient = recipient
 		req.DryRun = dryRun
 
 		return nil

--- a/cmd/darepocli/darepoclicommands/oor_destination.go
+++ b/cmd/darepocli/darepoclicommands/oor_destination.go
@@ -1,0 +1,112 @@
+package darepoclicommands
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+)
+
+const (
+	// oorPubKeyHexLen is the hex length of a 32-byte x-only pubkey.
+	oorPubKeyHexLen = schnorr.PubKeyBytesLen * 2
+)
+
+// buildOORRecipientOutput converts the user-facing OOR destination flags or
+// MCP args into the daemonrpc Output used by SendOOR.
+func buildOORRecipientOutput(address, pubKeyHex, pkScriptHex string,
+	amount int64) (*daemonrpc.Output, error) {
+
+	if amount <= 0 {
+		return nil, fmt.Errorf("amount must be positive")
+	}
+
+	address = strings.TrimSpace(address)
+	pubKeyHex = strings.TrimSpace(pubKeyHex)
+	pkScriptHex = strings.TrimSpace(pkScriptHex)
+
+	destinations := 0
+	if address != "" {
+		destinations++
+	}
+	if pubKeyHex != "" {
+		destinations++
+	}
+	if pkScriptHex != "" {
+		destinations++
+	}
+
+	if destinations != 1 {
+		return nil, fmt.Errorf("exactly one of to, pubkey, or " +
+			"pk_script is required")
+	}
+
+	output := &daemonrpc.Output{
+		AmountSat: amount,
+	}
+
+	switch {
+	case address != "":
+		output.Destination = &daemonrpc.Output_Address{
+			Address: address,
+		}
+
+	case pubKeyHex != "":
+		pubKey, err := parseOORPubKeyHex(pubKeyHex)
+		if err != nil {
+			return nil, err
+		}
+
+		output.Destination = &daemonrpc.Output_Pubkey{
+			Pubkey: pubKey,
+		}
+
+	case pkScriptHex != "":
+		pkScript, err := parseOORPkScriptHex(pkScriptHex)
+		if err != nil {
+			return nil, err
+		}
+
+		output.Destination = &daemonrpc.Output_PkScript{
+			PkScript: pkScript,
+		}
+	}
+
+	return output, nil
+}
+
+// parseOORPubKeyHex validates and decodes a 32-byte x-only schnorr pubkey.
+func parseOORPubKeyHex(pubKeyHex string) ([]byte, error) {
+	if len(pubKeyHex) != oorPubKeyHexLen {
+		return nil, fmt.Errorf("pubkey must be %d hex chars "+
+			"(32-byte x-only key)", oorPubKeyHexLen)
+	}
+
+	pubKeyBytes, err := hex.DecodeString(pubKeyHex)
+	if err != nil {
+		return nil, fmt.Errorf("invalid pubkey hex: %w", err)
+	}
+
+	pubKey, err := schnorr.ParsePubKey(pubKeyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("invalid x-only pubkey: %w", err)
+	}
+
+	return schnorr.SerializePubKey(pubKey), nil
+}
+
+// parseOORPkScriptHex validates and decodes a raw output script hex string.
+func parseOORPkScriptHex(pkScriptHex string) ([]byte, error) {
+	pkScript, err := hex.DecodeString(pkScriptHex)
+	if err != nil {
+		return nil, fmt.Errorf("invalid pk_script hex: %w", err)
+	}
+
+	if len(pkScript) == 0 {
+		return nil, fmt.Errorf("pk_script must not be empty")
+	}
+
+	return pkScript, nil
+}

--- a/cmd/darepocli/darepoclicommands/oor_destination_test.go
+++ b/cmd/darepocli/darepoclicommands/oor_destination_test.go
@@ -1,0 +1,166 @@
+package darepoclicommands
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildOORRecipientOutputAddress verifies address destinations are passed
+// through unchanged.
+func TestBuildOORRecipientOutputAddress(t *testing.T) {
+	t.Parallel()
+
+	output, err := buildOORRecipientOutput(
+		"tb1ptestdestination", "", "", 12_345,
+	)
+	require.NoError(t, err)
+
+	addr, ok := output.Destination.(*daemonrpc.Output_Address)
+	require.True(t, ok)
+	require.Equal(t, "tb1ptestdestination", addr.Address)
+	require.EqualValues(t, 12_345, output.AmountSat)
+}
+
+// TestBuildOORRecipientOutputPubKey verifies x-only pubkey destinations are
+// decoded and normalized.
+func TestBuildOORRecipientOutputPubKey(t *testing.T) {
+	t.Parallel()
+
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	pubKeyHex := schnorr.SerializePubKey(privKey.PubKey())
+
+	output, err := buildOORRecipientOutput(
+		"", hex.EncodeToString(pubKeyHex), "", 9_999,
+	)
+	require.NoError(t, err)
+
+	pubKey, ok := output.Destination.(*daemonrpc.Output_Pubkey)
+	require.True(t, ok)
+	require.Equal(t, pubKeyHex, pubKey.Pubkey)
+	require.EqualValues(t, 9_999, output.AmountSat)
+}
+
+// TestBuildOORRecipientOutputPkScript verifies pk_script destinations are
+// decoded from hex.
+func TestBuildOORRecipientOutputPkScript(t *testing.T) {
+	t.Parallel()
+
+	output, err := buildOORRecipientOutput(
+		"", "", "5120deadbeef", 4_321,
+	)
+	require.NoError(t, err)
+
+	pkScript, ok := output.Destination.(*daemonrpc.Output_PkScript)
+	require.True(t, ok)
+	require.Equal(t, []byte{0x51, 0x20, 0xde, 0xad, 0xbe, 0xef},
+		pkScript.PkScript)
+	require.EqualValues(t, 4_321, output.AmountSat)
+}
+
+// TestBuildOORRecipientOutputValidation verifies the helper rejects ambiguous
+// or malformed destinations.
+func TestBuildOORRecipientOutputValidation(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		address     string
+		pubKeyHex   string
+		pkScriptHex string
+		amount      int64
+		errContains string
+	}{
+		{
+			name:        "missing destination",
+			amount:      1,
+			errContains: "exactly one",
+		},
+		{
+			name:        "multiple destinations",
+			address:     "tb1paddr",
+			pubKeyHex:   "00",
+			amount:      1,
+			errContains: "exactly one",
+		},
+		{
+			name:        "non-positive amount",
+			address:     "tb1paddr",
+			errContains: "amount must be positive",
+		},
+		{
+			name:        "short pubkey",
+			pubKeyHex:   "00",
+			amount:      1,
+			errContains: "32-byte x-only key",
+		},
+		{
+			name:        "invalid pkscript hex",
+			pkScriptHex: "zz",
+			amount:      1,
+			errContains: "invalid pk_script hex",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := buildOORRecipientOutput(
+				testCase.address, testCase.pubKeyHex,
+				testCase.pkScriptHex, testCase.amount,
+			)
+			require.ErrorContains(t, err, testCase.errContains)
+		})
+	}
+}
+
+// TestMethodRegistrySendOORSchema verifies the schema advertises all OOR send
+// destination forms.
+func TestMethodRegistrySendOORSchema(t *testing.T) {
+	t.Parallel()
+
+	method := findSchemaMethod(t, "send.oor")
+	paramNames := make([]string, 0, len(method.Params))
+	for _, param := range method.Params {
+		paramNames = append(paramNames, param.Name)
+	}
+
+	require.Contains(t, paramNames, "to")
+	require.Contains(t, paramNames, "pubkey")
+	require.Contains(t, paramNames, "pk_script")
+	require.Contains(t, paramNames, "amount")
+}
+
+// TestMethodRegistryOORReceiveSchema verifies the public schema still exposes
+// OOR receive allocation.
+func TestMethodRegistryOORReceiveSchema(t *testing.T) {
+	t.Parallel()
+
+	method := findSchemaMethod(t, "oor.receive")
+	require.Equal(t, "NewOORReceiveScriptRequest", method.RequestType)
+	require.Equal(t, "NewOORReceiveScriptResponse", method.ResponseType)
+}
+
+// findSchemaMethod locates a method entry in the CLI schema registry.
+func findSchemaMethod(t *testing.T, methodName string) schemaMethod {
+	t.Helper()
+
+	for _, method := range methodRegistry() {
+		if method.Method == methodName {
+			return method
+		}
+	}
+
+	t.Fatalf("method %q not found", methodName)
+
+	return schemaMethod{}
+}

--- a/cmd/darepocli/darepoclicommands/root.go
+++ b/cmd/darepocli/darepoclicommands/root.go
@@ -53,6 +53,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(
 		newGetInfoCmd(),
 		newWalletCmd(),
+		newOORCmd(),
 		newVTXOsCmd(),
 		newSendCmd(),
 		newBoardCmd(),

--- a/cmd/darepocli/darepoclicommands/schema_registry.go
+++ b/cmd/darepocli/darepoclicommands/schema_registry.go
@@ -110,6 +110,21 @@ func methodRegistry() []schemaMethod {
 			JSONInput:    true,
 		},
 		{
+			Method:      "oor.receive",
+			Description: "Allocate a fresh OOR receive script",
+			Params: []schemaParam{
+				{
+					Name: "label",
+					Type: "string",
+					Description: "optional indexer " +
+						"registration label",
+				},
+			},
+			RequestType:  "NewOORReceiveScriptRequest",
+			ResponseType: "NewOORReceiveScriptResponse",
+			JSONInput:    true,
+		},
+		{
 			Method:      "vtxos.list",
 			Description: "List VTXOs with optional filters",
 			Params: []schemaParam{

--- a/cmd/darepocli/darepoclicommands/schema_registry.go
+++ b/cmd/darepocli/darepoclicommands/schema_registry.go
@@ -213,10 +213,27 @@ func methodRegistry() []schemaMethod {
 			Description: "Send via out-of-round transfer",
 			Params: []schemaParam{
 				{
-					Name:        "to",
-					Type:        "string",
-					Required:    true,
-					Description: "recipient address",
+					Name: "to",
+					Type: "string",
+					Description: "recipient address " +
+						"(exactly one of to, pubkey, " +
+						"or pk_script)",
+				},
+				{
+					Name: "pubkey",
+					Type: "string",
+					Description: "recipient 32-byte " +
+						"x-only pubkey hex (exactly " +
+						"one of to, pubkey, or " +
+						"pk_script)",
+				},
+				{
+					Name: "pk_script",
+					Type: "string",
+					Description: "recipient raw " +
+						"pk_script hex (exactly one " +
+						"of to, pubkey, or " +
+						"pk_script)",
 				},
 				{
 					Name:        "amount",

--- a/daemonrpc/daemon.pb.go
+++ b/daemonrpc/daemon.pb.go
@@ -1119,6 +1119,133 @@ func (x *NewAddressResponse) GetAddress() string {
 	return ""
 }
 
+type NewOORReceiveScriptRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// label is an optional human-readable label stored with the
+	// registration on the indexer.
+	Label         string `protobuf:"bytes,1,opt,name=label,proto3" json:"label,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *NewOORReceiveScriptRequest) Reset() {
+	*x = NewOORReceiveScriptRequest{}
+	mi := &file_daemon_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *NewOORReceiveScriptRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*NewOORReceiveScriptRequest) ProtoMessage() {}
+
+func (x *NewOORReceiveScriptRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use NewOORReceiveScriptRequest.ProtoReflect.Descriptor instead.
+func (*NewOORReceiveScriptRequest) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *NewOORReceiveScriptRequest) GetLabel() string {
+	if x != nil {
+		return x.Label
+	}
+	return ""
+}
+
+type NewOORReceiveScriptResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// pk_script_hex is the raw taproot output script encoded as hex.
+	PkScriptHex string `protobuf:"bytes,1,opt,name=pk_script_hex,json=pkScriptHex,proto3" json:"pk_script_hex,omitempty"`
+	// pubkey_xonly_hex is the 32-byte x-only owner pubkey encoded as hex.
+	PubkeyXonlyHex string `protobuf:"bytes,2,opt,name=pubkey_xonly_hex,json=pubkeyXonlyHex,proto3" json:"pubkey_xonly_hex,omitempty"`
+	// key_family is the wallet key family used to derive the receive key.
+	KeyFamily uint32 `protobuf:"varint,3,opt,name=key_family,json=keyFamily,proto3" json:"key_family,omitempty"`
+	// key_index is the wallet key index used to derive the receive key.
+	KeyIndex uint32 `protobuf:"varint,4,opt,name=key_index,json=keyIndex,proto3" json:"key_index,omitempty"`
+	// label is the registration label stored with the indexer.
+	Label         string `protobuf:"bytes,5,opt,name=label,proto3" json:"label,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *NewOORReceiveScriptResponse) Reset() {
+	*x = NewOORReceiveScriptResponse{}
+	mi := &file_daemon_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *NewOORReceiveScriptResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*NewOORReceiveScriptResponse) ProtoMessage() {}
+
+func (x *NewOORReceiveScriptResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use NewOORReceiveScriptResponse.ProtoReflect.Descriptor instead.
+func (*NewOORReceiveScriptResponse) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *NewOORReceiveScriptResponse) GetPkScriptHex() string {
+	if x != nil {
+		return x.PkScriptHex
+	}
+	return ""
+}
+
+func (x *NewOORReceiveScriptResponse) GetPubkeyXonlyHex() string {
+	if x != nil {
+		return x.PubkeyXonlyHex
+	}
+	return ""
+}
+
+func (x *NewOORReceiveScriptResponse) GetKeyFamily() uint32 {
+	if x != nil {
+		return x.KeyFamily
+	}
+	return 0
+}
+
+func (x *NewOORReceiveScriptResponse) GetKeyIndex() uint32 {
+	if x != nil {
+		return x.KeyIndex
+	}
+	return 0
+}
+
+func (x *NewOORReceiveScriptResponse) GetLabel() string {
+	if x != nil {
+		return x.Label
+	}
+	return ""
+}
+
 // Output describes a single recipient in a send operation.
 type Output struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -1136,7 +1263,7 @@ type Output struct {
 
 func (x *Output) Reset() {
 	*x = Output{}
-	mi := &file_daemon_proto_msgTypes[15]
+	mi := &file_daemon_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1148,7 +1275,7 @@ func (x *Output) String() string {
 func (*Output) ProtoMessage() {}
 
 func (x *Output) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[15]
+	mi := &file_daemon_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1161,7 +1288,7 @@ func (x *Output) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Output.ProtoReflect.Descriptor instead.
 func (*Output) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{15}
+	return file_daemon_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *Output) GetDestination() isOutput_Destination {
@@ -1247,7 +1374,7 @@ type SendVTXORequest struct {
 
 func (x *SendVTXORequest) Reset() {
 	*x = SendVTXORequest{}
-	mi := &file_daemon_proto_msgTypes[16]
+	mi := &file_daemon_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1259,7 +1386,7 @@ func (x *SendVTXORequest) String() string {
 func (*SendVTXORequest) ProtoMessage() {}
 
 func (x *SendVTXORequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[16]
+	mi := &file_daemon_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1272,7 +1399,7 @@ func (x *SendVTXORequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendVTXORequest.ProtoReflect.Descriptor instead.
 func (*SendVTXORequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{16}
+	return file_daemon_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *SendVTXORequest) GetRecipients() []*Output {
@@ -1306,7 +1433,7 @@ type SendVTXOResponse struct {
 
 func (x *SendVTXOResponse) Reset() {
 	*x = SendVTXOResponse{}
-	mi := &file_daemon_proto_msgTypes[17]
+	mi := &file_daemon_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1318,7 +1445,7 @@ func (x *SendVTXOResponse) String() string {
 func (*SendVTXOResponse) ProtoMessage() {}
 
 func (x *SendVTXOResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[17]
+	mi := &file_daemon_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1331,7 +1458,7 @@ func (x *SendVTXOResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendVTXOResponse.ProtoReflect.Descriptor instead.
 func (*SendVTXOResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{17}
+	return file_daemon_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *SendVTXOResponse) GetStatus() string {
@@ -1367,7 +1494,7 @@ type SendOORRequest struct {
 
 func (x *SendOORRequest) Reset() {
 	*x = SendOORRequest{}
-	mi := &file_daemon_proto_msgTypes[18]
+	mi := &file_daemon_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1379,7 +1506,7 @@ func (x *SendOORRequest) String() string {
 func (*SendOORRequest) ProtoMessage() {}
 
 func (x *SendOORRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[18]
+	mi := &file_daemon_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1392,7 +1519,7 @@ func (x *SendOORRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendOORRequest.ProtoReflect.Descriptor instead.
 func (*SendOORRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{18}
+	return file_daemon_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *SendOORRequest) GetRecipient() *Output {
@@ -1422,7 +1549,7 @@ type SendOORResponse struct {
 
 func (x *SendOORResponse) Reset() {
 	*x = SendOORResponse{}
-	mi := &file_daemon_proto_msgTypes[19]
+	mi := &file_daemon_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1434,7 +1561,7 @@ func (x *SendOORResponse) String() string {
 func (*SendOORResponse) ProtoMessage() {}
 
 func (x *SendOORResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[19]
+	mi := &file_daemon_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1447,7 +1574,7 @@ func (x *SendOORResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendOORResponse.ProtoReflect.Descriptor instead.
 func (*SendOORResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{19}
+	return file_daemon_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *SendOORResponse) GetStatus() string {
@@ -1477,7 +1604,7 @@ type OutpointSelection struct {
 
 func (x *OutpointSelection) Reset() {
 	*x = OutpointSelection{}
-	mi := &file_daemon_proto_msgTypes[20]
+	mi := &file_daemon_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1489,7 +1616,7 @@ func (x *OutpointSelection) String() string {
 func (*OutpointSelection) ProtoMessage() {}
 
 func (x *OutpointSelection) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[20]
+	mi := &file_daemon_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1502,7 +1629,7 @@ func (x *OutpointSelection) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OutpointSelection.ProtoReflect.Descriptor instead.
 func (*OutpointSelection) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{20}
+	return file_daemon_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *OutpointSelection) GetOutpoints() []string {
@@ -1527,7 +1654,7 @@ type RefreshVTXOsRequest struct {
 
 func (x *RefreshVTXOsRequest) Reset() {
 	*x = RefreshVTXOsRequest{}
-	mi := &file_daemon_proto_msgTypes[21]
+	mi := &file_daemon_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1539,7 +1666,7 @@ func (x *RefreshVTXOsRequest) String() string {
 func (*RefreshVTXOsRequest) ProtoMessage() {}
 
 func (x *RefreshVTXOsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[21]
+	mi := &file_daemon_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1552,7 +1679,7 @@ func (x *RefreshVTXOsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RefreshVTXOsRequest.ProtoReflect.Descriptor instead.
 func (*RefreshVTXOsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{21}
+	return file_daemon_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *RefreshVTXOsRequest) GetSelection() isRefreshVTXOsRequest_Selection {
@@ -1619,7 +1746,7 @@ type RefreshVTXOsResponse struct {
 
 func (x *RefreshVTXOsResponse) Reset() {
 	*x = RefreshVTXOsResponse{}
-	mi := &file_daemon_proto_msgTypes[22]
+	mi := &file_daemon_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1631,7 +1758,7 @@ func (x *RefreshVTXOsResponse) String() string {
 func (*RefreshVTXOsResponse) ProtoMessage() {}
 
 func (x *RefreshVTXOsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[22]
+	mi := &file_daemon_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1644,7 +1771,7 @@ func (x *RefreshVTXOsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RefreshVTXOsResponse.ProtoReflect.Descriptor instead.
 func (*RefreshVTXOsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{22}
+	return file_daemon_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *RefreshVTXOsResponse) GetQueuedOutpoints() []string {
@@ -1669,7 +1796,7 @@ type BoardRequest struct {
 
 func (x *BoardRequest) Reset() {
 	*x = BoardRequest{}
-	mi := &file_daemon_proto_msgTypes[23]
+	mi := &file_daemon_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1681,7 +1808,7 @@ func (x *BoardRequest) String() string {
 func (*BoardRequest) ProtoMessage() {}
 
 func (x *BoardRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[23]
+	mi := &file_daemon_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1694,7 +1821,7 @@ func (x *BoardRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoardRequest.ProtoReflect.Descriptor instead.
 func (*BoardRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{23}
+	return file_daemon_proto_rawDescGZIP(), []int{25}
 }
 
 type BoardResponse struct {
@@ -1708,7 +1835,7 @@ type BoardResponse struct {
 
 func (x *BoardResponse) Reset() {
 	*x = BoardResponse{}
-	mi := &file_daemon_proto_msgTypes[24]
+	mi := &file_daemon_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1720,7 +1847,7 @@ func (x *BoardResponse) String() string {
 func (*BoardResponse) ProtoMessage() {}
 
 func (x *BoardResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[24]
+	mi := &file_daemon_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1733,7 +1860,7 @@ func (x *BoardResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoardResponse.ProtoReflect.Descriptor instead.
 func (*BoardResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{24}
+	return file_daemon_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *BoardResponse) GetStatus() string {
@@ -1756,7 +1883,7 @@ type RoundVTXOInfo struct {
 
 func (x *RoundVTXOInfo) Reset() {
 	*x = RoundVTXOInfo{}
-	mi := &file_daemon_proto_msgTypes[25]
+	mi := &file_daemon_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1768,7 +1895,7 @@ func (x *RoundVTXOInfo) String() string {
 func (*RoundVTXOInfo) ProtoMessage() {}
 
 func (x *RoundVTXOInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[25]
+	mi := &file_daemon_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1781,7 +1908,7 @@ func (x *RoundVTXOInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoundVTXOInfo.ProtoReflect.Descriptor instead.
 func (*RoundVTXOInfo) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{25}
+	return file_daemon_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *RoundVTXOInfo) GetOutpoint() string {
@@ -1820,7 +1947,7 @@ type RoundInfo struct {
 
 func (x *RoundInfo) Reset() {
 	*x = RoundInfo{}
-	mi := &file_daemon_proto_msgTypes[26]
+	mi := &file_daemon_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1832,7 +1959,7 @@ func (x *RoundInfo) String() string {
 func (*RoundInfo) ProtoMessage() {}
 
 func (x *RoundInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[26]
+	mi := &file_daemon_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1845,7 +1972,7 @@ func (x *RoundInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoundInfo.ProtoReflect.Descriptor instead.
 func (*RoundInfo) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{26}
+	return file_daemon_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *RoundInfo) GetRoundId() string {
@@ -1897,7 +2024,7 @@ type ListRoundsRequest struct {
 
 func (x *ListRoundsRequest) Reset() {
 	*x = ListRoundsRequest{}
-	mi := &file_daemon_proto_msgTypes[27]
+	mi := &file_daemon_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1909,7 +2036,7 @@ func (x *ListRoundsRequest) String() string {
 func (*ListRoundsRequest) ProtoMessage() {}
 
 func (x *ListRoundsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[27]
+	mi := &file_daemon_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1922,7 +2049,7 @@ func (x *ListRoundsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRoundsRequest.ProtoReflect.Descriptor instead.
 func (*ListRoundsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{27}
+	return file_daemon_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *ListRoundsRequest) GetPageSize() int32 {
@@ -1959,7 +2086,7 @@ type ListRoundsResponse struct {
 
 func (x *ListRoundsResponse) Reset() {
 	*x = ListRoundsResponse{}
-	mi := &file_daemon_proto_msgTypes[28]
+	mi := &file_daemon_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1971,7 +2098,7 @@ func (x *ListRoundsResponse) String() string {
 func (*ListRoundsResponse) ProtoMessage() {}
 
 func (x *ListRoundsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[28]
+	mi := &file_daemon_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1984,7 +2111,7 @@ func (x *ListRoundsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRoundsResponse.ProtoReflect.Descriptor instead.
 func (*ListRoundsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{28}
+	return file_daemon_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *ListRoundsResponse) GetRounds() []*RoundInfo {
@@ -2009,7 +2136,7 @@ type WatchRoundsRequest struct {
 
 func (x *WatchRoundsRequest) Reset() {
 	*x = WatchRoundsRequest{}
-	mi := &file_daemon_proto_msgTypes[29]
+	mi := &file_daemon_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2021,7 +2148,7 @@ func (x *WatchRoundsRequest) String() string {
 func (*WatchRoundsRequest) ProtoMessage() {}
 
 func (x *WatchRoundsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[29]
+	mi := &file_daemon_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2034,7 +2161,7 @@ func (x *WatchRoundsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchRoundsRequest.ProtoReflect.Descriptor instead.
 func (*WatchRoundsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{29}
+	return file_daemon_proto_rawDescGZIP(), []int{31}
 }
 
 type WatchRoundsResponse struct {
@@ -2048,7 +2175,7 @@ type WatchRoundsResponse struct {
 
 func (x *WatchRoundsResponse) Reset() {
 	*x = WatchRoundsResponse{}
-	mi := &file_daemon_proto_msgTypes[30]
+	mi := &file_daemon_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2060,7 +2187,7 @@ func (x *WatchRoundsResponse) String() string {
 func (*WatchRoundsResponse) ProtoMessage() {}
 
 func (x *WatchRoundsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[30]
+	mi := &file_daemon_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2073,7 +2200,7 @@ func (x *WatchRoundsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchRoundsResponse.ProtoReflect.Descriptor instead.
 func (*WatchRoundsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{30}
+	return file_daemon_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *WatchRoundsResponse) GetRound() *RoundInfo {
@@ -2144,7 +2271,16 @@ const file_daemon_proto_rawDesc = "" +
 	"\x05vtxos\x18\x01 \x03(\v2\x0f.daemonrpc.VTXOR\x05vtxos\"\x13\n" +
 	"\x11NewAddressRequest\".\n" +
 	"\x12NewAddressResponse\x12\x18\n" +
-	"\aaddress\x18\x01 \x01(\tR\aaddress\"\x8b\x01\n" +
+	"\aaddress\x18\x01 \x01(\tR\aaddress\"2\n" +
+	"\x1aNewOORReceiveScriptRequest\x12\x14\n" +
+	"\x05label\x18\x01 \x01(\tR\x05label\"\xbd\x01\n" +
+	"\x1bNewOORReceiveScriptResponse\x12\"\n" +
+	"\rpk_script_hex\x18\x01 \x01(\tR\vpkScriptHex\x12(\n" +
+	"\x10pubkey_xonly_hex\x18\x02 \x01(\tR\x0epubkeyXonlyHex\x12\x1d\n" +
+	"\n" +
+	"key_family\x18\x03 \x01(\rR\tkeyFamily\x12\x1b\n" +
+	"\tkey_index\x18\x04 \x01(\rR\bkeyIndex\x12\x14\n" +
+	"\x05label\x18\x05 \x01(\tR\x05label\"\x8b\x01\n" +
 	"\x06Output\x12\x1a\n" +
 	"\aaddress\x18\x01 \x01(\tH\x00R\aaddress\x12\x18\n" +
 	"\x06pubkey\x18\x03 \x01(\fH\x00R\x06pubkey\x12\x1d\n" +
@@ -2229,7 +2365,7 @@ const file_daemon_proto_rawDesc = "" +
 	"\x1aROUND_STATE_INPUT_SIG_SENT\x10\v\x12\x19\n" +
 	"\x15ROUND_STATE_CONFIRMED\x10\f\x12\x16\n" +
 	"\x12ROUND_STATE_FAILED\x10\r\x12\x18\n" +
-	"\x14ROUND_STATE_RECOVERY\x10\x0e2\xbc\a\n" +
+	"\x14ROUND_STATE_RECOVERY\x10\x0e2\xa2\b\n" +
 	"\rDaemonService\x12@\n" +
 	"\aGetInfo\x12\x19.daemonrpc.GetInfoRequest\x1a\x1a.daemonrpc.GetInfoResponse\x12@\n" +
 	"\aGenSeed\x12\x19.daemonrpc.GenSeedRequest\x1a\x1a.daemonrpc.GenSeedResponse\x12I\n" +
@@ -2240,7 +2376,8 @@ const file_daemon_proto_rawDesc = "" +
 	"GetBalance\x12\x1c.daemonrpc.GetBalanceRequest\x1a\x1d.daemonrpc.GetBalanceResponse\x12F\n" +
 	"\tListVTXOs\x12\x1b.daemonrpc.ListVTXOsRequest\x1a\x1c.daemonrpc.ListVTXOsResponse\x12I\n" +
 	"\n" +
-	"NewAddress\x12\x1c.daemonrpc.NewAddressRequest\x1a\x1d.daemonrpc.NewAddressResponse\x12C\n" +
+	"NewAddress\x12\x1c.daemonrpc.NewAddressRequest\x1a\x1d.daemonrpc.NewAddressResponse\x12d\n" +
+	"\x13NewOORReceiveScript\x12%.daemonrpc.NewOORReceiveScriptRequest\x1a&.daemonrpc.NewOORReceiveScriptResponse\x12C\n" +
 	"\bSendVTXO\x12\x1a.daemonrpc.SendVTXORequest\x1a\x1b.daemonrpc.SendVTXOResponse\x12@\n" +
 	"\aSendOOR\x12\x19.daemonrpc.SendOORRequest\x1a\x1a.daemonrpc.SendOORResponse\x12O\n" +
 	"\fRefreshVTXOs\x12\x1e.daemonrpc.RefreshVTXOsRequest\x1a\x1f.daemonrpc.RefreshVTXOsResponse\x12:\n" +
@@ -2262,53 +2399,55 @@ func file_daemon_proto_rawDescGZIP() []byte {
 }
 
 var file_daemon_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 31)
+var file_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
 var file_daemon_proto_goTypes = []any{
-	(VTXOStatus)(0),              // 0: daemonrpc.VTXOStatus
-	(RoundState)(0),              // 1: daemonrpc.RoundState
-	(*GetInfoRequest)(nil),       // 2: daemonrpc.GetInfoRequest
-	(*GetInfoResponse)(nil),      // 3: daemonrpc.GetInfoResponse
-	(*GenSeedRequest)(nil),       // 4: daemonrpc.GenSeedRequest
-	(*GenSeedResponse)(nil),      // 5: daemonrpc.GenSeedResponse
-	(*InitWalletRequest)(nil),    // 6: daemonrpc.InitWalletRequest
-	(*InitWalletResponse)(nil),   // 7: daemonrpc.InitWalletResponse
-	(*UnlockWalletRequest)(nil),  // 8: daemonrpc.UnlockWalletRequest
-	(*UnlockWalletResponse)(nil), // 9: daemonrpc.UnlockWalletResponse
-	(*GetBalanceRequest)(nil),    // 10: daemonrpc.GetBalanceRequest
-	(*GetBalanceResponse)(nil),   // 11: daemonrpc.GetBalanceResponse
-	(*VTXO)(nil),                 // 12: daemonrpc.VTXO
-	(*ListVTXOsRequest)(nil),     // 13: daemonrpc.ListVTXOsRequest
-	(*ListVTXOsResponse)(nil),    // 14: daemonrpc.ListVTXOsResponse
-	(*NewAddressRequest)(nil),    // 15: daemonrpc.NewAddressRequest
-	(*NewAddressResponse)(nil),   // 16: daemonrpc.NewAddressResponse
-	(*Output)(nil),               // 17: daemonrpc.Output
-	(*SendVTXORequest)(nil),      // 18: daemonrpc.SendVTXORequest
-	(*SendVTXOResponse)(nil),     // 19: daemonrpc.SendVTXOResponse
-	(*SendOORRequest)(nil),       // 20: daemonrpc.SendOORRequest
-	(*SendOORResponse)(nil),      // 21: daemonrpc.SendOORResponse
-	(*OutpointSelection)(nil),    // 22: daemonrpc.OutpointSelection
-	(*RefreshVTXOsRequest)(nil),  // 23: daemonrpc.RefreshVTXOsRequest
-	(*RefreshVTXOsResponse)(nil), // 24: daemonrpc.RefreshVTXOsResponse
-	(*BoardRequest)(nil),         // 25: daemonrpc.BoardRequest
-	(*BoardResponse)(nil),        // 26: daemonrpc.BoardResponse
-	(*RoundVTXOInfo)(nil),        // 27: daemonrpc.RoundVTXOInfo
-	(*RoundInfo)(nil),            // 28: daemonrpc.RoundInfo
-	(*ListRoundsRequest)(nil),    // 29: daemonrpc.ListRoundsRequest
-	(*ListRoundsResponse)(nil),   // 30: daemonrpc.ListRoundsResponse
-	(*WatchRoundsRequest)(nil),   // 31: daemonrpc.WatchRoundsRequest
-	(*WatchRoundsResponse)(nil),  // 32: daemonrpc.WatchRoundsResponse
+	(VTXOStatus)(0),                     // 0: daemonrpc.VTXOStatus
+	(RoundState)(0),                     // 1: daemonrpc.RoundState
+	(*GetInfoRequest)(nil),              // 2: daemonrpc.GetInfoRequest
+	(*GetInfoResponse)(nil),             // 3: daemonrpc.GetInfoResponse
+	(*GenSeedRequest)(nil),              // 4: daemonrpc.GenSeedRequest
+	(*GenSeedResponse)(nil),             // 5: daemonrpc.GenSeedResponse
+	(*InitWalletRequest)(nil),           // 6: daemonrpc.InitWalletRequest
+	(*InitWalletResponse)(nil),          // 7: daemonrpc.InitWalletResponse
+	(*UnlockWalletRequest)(nil),         // 8: daemonrpc.UnlockWalletRequest
+	(*UnlockWalletResponse)(nil),        // 9: daemonrpc.UnlockWalletResponse
+	(*GetBalanceRequest)(nil),           // 10: daemonrpc.GetBalanceRequest
+	(*GetBalanceResponse)(nil),          // 11: daemonrpc.GetBalanceResponse
+	(*VTXO)(nil),                        // 12: daemonrpc.VTXO
+	(*ListVTXOsRequest)(nil),            // 13: daemonrpc.ListVTXOsRequest
+	(*ListVTXOsResponse)(nil),           // 14: daemonrpc.ListVTXOsResponse
+	(*NewAddressRequest)(nil),           // 15: daemonrpc.NewAddressRequest
+	(*NewAddressResponse)(nil),          // 16: daemonrpc.NewAddressResponse
+	(*NewOORReceiveScriptRequest)(nil),  // 17: daemonrpc.NewOORReceiveScriptRequest
+	(*NewOORReceiveScriptResponse)(nil), // 18: daemonrpc.NewOORReceiveScriptResponse
+	(*Output)(nil),                      // 19: daemonrpc.Output
+	(*SendVTXORequest)(nil),             // 20: daemonrpc.SendVTXORequest
+	(*SendVTXOResponse)(nil),            // 21: daemonrpc.SendVTXOResponse
+	(*SendOORRequest)(nil),              // 22: daemonrpc.SendOORRequest
+	(*SendOORResponse)(nil),             // 23: daemonrpc.SendOORResponse
+	(*OutpointSelection)(nil),           // 24: daemonrpc.OutpointSelection
+	(*RefreshVTXOsRequest)(nil),         // 25: daemonrpc.RefreshVTXOsRequest
+	(*RefreshVTXOsResponse)(nil),        // 26: daemonrpc.RefreshVTXOsResponse
+	(*BoardRequest)(nil),                // 27: daemonrpc.BoardRequest
+	(*BoardResponse)(nil),               // 28: daemonrpc.BoardResponse
+	(*RoundVTXOInfo)(nil),               // 29: daemonrpc.RoundVTXOInfo
+	(*RoundInfo)(nil),                   // 30: daemonrpc.RoundInfo
+	(*ListRoundsRequest)(nil),           // 31: daemonrpc.ListRoundsRequest
+	(*ListRoundsResponse)(nil),          // 32: daemonrpc.ListRoundsResponse
+	(*WatchRoundsRequest)(nil),          // 33: daemonrpc.WatchRoundsRequest
+	(*WatchRoundsResponse)(nil),         // 34: daemonrpc.WatchRoundsResponse
 }
 var file_daemon_proto_depIdxs = []int32{
 	0,  // 0: daemonrpc.VTXO.status:type_name -> daemonrpc.VTXOStatus
 	0,  // 1: daemonrpc.ListVTXOsRequest.status_filter:type_name -> daemonrpc.VTXOStatus
 	12, // 2: daemonrpc.ListVTXOsResponse.vtxos:type_name -> daemonrpc.VTXO
-	17, // 3: daemonrpc.SendVTXORequest.recipients:type_name -> daemonrpc.Output
-	17, // 4: daemonrpc.SendOORRequest.recipient:type_name -> daemonrpc.Output
-	22, // 5: daemonrpc.RefreshVTXOsRequest.outpoints:type_name -> daemonrpc.OutpointSelection
+	19, // 3: daemonrpc.SendVTXORequest.recipients:type_name -> daemonrpc.Output
+	19, // 4: daemonrpc.SendOORRequest.recipient:type_name -> daemonrpc.Output
+	24, // 5: daemonrpc.RefreshVTXOsRequest.outpoints:type_name -> daemonrpc.OutpointSelection
 	1,  // 6: daemonrpc.RoundInfo.state:type_name -> daemonrpc.RoundState
-	27, // 7: daemonrpc.RoundInfo.vtxos:type_name -> daemonrpc.RoundVTXOInfo
-	28, // 8: daemonrpc.ListRoundsResponse.rounds:type_name -> daemonrpc.RoundInfo
-	28, // 9: daemonrpc.WatchRoundsResponse.round:type_name -> daemonrpc.RoundInfo
+	29, // 7: daemonrpc.RoundInfo.vtxos:type_name -> daemonrpc.RoundVTXOInfo
+	30, // 8: daemonrpc.ListRoundsResponse.rounds:type_name -> daemonrpc.RoundInfo
+	30, // 9: daemonrpc.WatchRoundsResponse.round:type_name -> daemonrpc.RoundInfo
 	2,  // 10: daemonrpc.DaemonService.GetInfo:input_type -> daemonrpc.GetInfoRequest
 	4,  // 11: daemonrpc.DaemonService.GenSeed:input_type -> daemonrpc.GenSeedRequest
 	6,  // 12: daemonrpc.DaemonService.InitWallet:input_type -> daemonrpc.InitWalletRequest
@@ -2316,27 +2455,29 @@ var file_daemon_proto_depIdxs = []int32{
 	10, // 14: daemonrpc.DaemonService.GetBalance:input_type -> daemonrpc.GetBalanceRequest
 	13, // 15: daemonrpc.DaemonService.ListVTXOs:input_type -> daemonrpc.ListVTXOsRequest
 	15, // 16: daemonrpc.DaemonService.NewAddress:input_type -> daemonrpc.NewAddressRequest
-	18, // 17: daemonrpc.DaemonService.SendVTXO:input_type -> daemonrpc.SendVTXORequest
-	20, // 18: daemonrpc.DaemonService.SendOOR:input_type -> daemonrpc.SendOORRequest
-	23, // 19: daemonrpc.DaemonService.RefreshVTXOs:input_type -> daemonrpc.RefreshVTXOsRequest
-	25, // 20: daemonrpc.DaemonService.Board:input_type -> daemonrpc.BoardRequest
-	29, // 21: daemonrpc.DaemonService.ListRounds:input_type -> daemonrpc.ListRoundsRequest
-	31, // 22: daemonrpc.DaemonService.WatchRounds:input_type -> daemonrpc.WatchRoundsRequest
-	3,  // 23: daemonrpc.DaemonService.GetInfo:output_type -> daemonrpc.GetInfoResponse
-	5,  // 24: daemonrpc.DaemonService.GenSeed:output_type -> daemonrpc.GenSeedResponse
-	7,  // 25: daemonrpc.DaemonService.InitWallet:output_type -> daemonrpc.InitWalletResponse
-	9,  // 26: daemonrpc.DaemonService.UnlockWallet:output_type -> daemonrpc.UnlockWalletResponse
-	11, // 27: daemonrpc.DaemonService.GetBalance:output_type -> daemonrpc.GetBalanceResponse
-	14, // 28: daemonrpc.DaemonService.ListVTXOs:output_type -> daemonrpc.ListVTXOsResponse
-	16, // 29: daemonrpc.DaemonService.NewAddress:output_type -> daemonrpc.NewAddressResponse
-	19, // 30: daemonrpc.DaemonService.SendVTXO:output_type -> daemonrpc.SendVTXOResponse
-	21, // 31: daemonrpc.DaemonService.SendOOR:output_type -> daemonrpc.SendOORResponse
-	24, // 32: daemonrpc.DaemonService.RefreshVTXOs:output_type -> daemonrpc.RefreshVTXOsResponse
-	26, // 33: daemonrpc.DaemonService.Board:output_type -> daemonrpc.BoardResponse
-	30, // 34: daemonrpc.DaemonService.ListRounds:output_type -> daemonrpc.ListRoundsResponse
-	32, // 35: daemonrpc.DaemonService.WatchRounds:output_type -> daemonrpc.WatchRoundsResponse
-	23, // [23:36] is the sub-list for method output_type
-	10, // [10:23] is the sub-list for method input_type
+	17, // 17: daemonrpc.DaemonService.NewOORReceiveScript:input_type -> daemonrpc.NewOORReceiveScriptRequest
+	20, // 18: daemonrpc.DaemonService.SendVTXO:input_type -> daemonrpc.SendVTXORequest
+	22, // 19: daemonrpc.DaemonService.SendOOR:input_type -> daemonrpc.SendOORRequest
+	25, // 20: daemonrpc.DaemonService.RefreshVTXOs:input_type -> daemonrpc.RefreshVTXOsRequest
+	27, // 21: daemonrpc.DaemonService.Board:input_type -> daemonrpc.BoardRequest
+	31, // 22: daemonrpc.DaemonService.ListRounds:input_type -> daemonrpc.ListRoundsRequest
+	33, // 23: daemonrpc.DaemonService.WatchRounds:input_type -> daemonrpc.WatchRoundsRequest
+	3,  // 24: daemonrpc.DaemonService.GetInfo:output_type -> daemonrpc.GetInfoResponse
+	5,  // 25: daemonrpc.DaemonService.GenSeed:output_type -> daemonrpc.GenSeedResponse
+	7,  // 26: daemonrpc.DaemonService.InitWallet:output_type -> daemonrpc.InitWalletResponse
+	9,  // 27: daemonrpc.DaemonService.UnlockWallet:output_type -> daemonrpc.UnlockWalletResponse
+	11, // 28: daemonrpc.DaemonService.GetBalance:output_type -> daemonrpc.GetBalanceResponse
+	14, // 29: daemonrpc.DaemonService.ListVTXOs:output_type -> daemonrpc.ListVTXOsResponse
+	16, // 30: daemonrpc.DaemonService.NewAddress:output_type -> daemonrpc.NewAddressResponse
+	18, // 31: daemonrpc.DaemonService.NewOORReceiveScript:output_type -> daemonrpc.NewOORReceiveScriptResponse
+	21, // 32: daemonrpc.DaemonService.SendVTXO:output_type -> daemonrpc.SendVTXOResponse
+	23, // 33: daemonrpc.DaemonService.SendOOR:output_type -> daemonrpc.SendOORResponse
+	26, // 34: daemonrpc.DaemonService.RefreshVTXOs:output_type -> daemonrpc.RefreshVTXOsResponse
+	28, // 35: daemonrpc.DaemonService.Board:output_type -> daemonrpc.BoardResponse
+	32, // 36: daemonrpc.DaemonService.ListRounds:output_type -> daemonrpc.ListRoundsResponse
+	34, // 37: daemonrpc.DaemonService.WatchRounds:output_type -> daemonrpc.WatchRoundsResponse
+	24, // [24:38] is the sub-list for method output_type
+	10, // [10:24] is the sub-list for method input_type
 	10, // [10:10] is the sub-list for extension type_name
 	10, // [10:10] is the sub-list for extension extendee
 	0,  // [0:10] is the sub-list for field type_name
@@ -2347,12 +2488,12 @@ func file_daemon_proto_init() {
 	if File_daemon_proto != nil {
 		return
 	}
-	file_daemon_proto_msgTypes[15].OneofWrappers = []any{
+	file_daemon_proto_msgTypes[17].OneofWrappers = []any{
 		(*Output_Address)(nil),
 		(*Output_Pubkey)(nil),
 		(*Output_PkScript)(nil),
 	}
-	file_daemon_proto_msgTypes[21].OneofWrappers = []any{
+	file_daemon_proto_msgTypes[23].OneofWrappers = []any{
 		(*RefreshVTXOsRequest_Outpoints)(nil),
 		(*RefreshVTXOsRequest_All)(nil),
 	}
@@ -2362,7 +2503,7 @@ func file_daemon_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_daemon_proto_rawDesc), len(file_daemon_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   31,
+			NumMessages:   33,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/daemonrpc/daemon.proto
+++ b/daemonrpc/daemon.proto
@@ -41,6 +41,12 @@ service DaemonService {
     // on-chain funds for use in the Ark protocol.
     rpc NewAddress (NewAddressRequest) returns (NewAddressResponse);
 
+    // NewOORReceiveScript allocates a fresh wallet key, registers the
+    // matching taproot OOR receive script with the indexer, and returns
+    // the script details needed to hand the destination to a sender.
+    rpc NewOORReceiveScript (NewOORReceiveScriptRequest)
+        returns (NewOORReceiveScriptResponse);
+
     // SendVTXO initiates an in-round transfer by submitting a refresh
     // request to the round coordinator. The transfer completes when the
     // next round commits.
@@ -277,6 +283,29 @@ message NewAddressRequest {
 message NewAddressResponse {
     // address is the bech32m-encoded taproot boarding address.
     string address = 1;
+}
+
+message NewOORReceiveScriptRequest {
+    // label is an optional human-readable label stored with the
+    // registration on the indexer.
+    string label = 1;
+}
+
+message NewOORReceiveScriptResponse {
+    // pk_script_hex is the raw taproot output script encoded as hex.
+    string pk_script_hex = 1;
+
+    // pubkey_xonly_hex is the 32-byte x-only owner pubkey encoded as hex.
+    string pubkey_xonly_hex = 2;
+
+    // key_family is the wallet key family used to derive the receive key.
+    uint32 key_family = 3;
+
+    // key_index is the wallet key index used to derive the receive key.
+    uint32 key_index = 4;
+
+    // label is the registration label stored with the indexer.
+    string label = 5;
 }
 
 // Output describes a single recipient in a send operation.

--- a/daemonrpc/daemon_grpc.pb.go
+++ b/daemonrpc/daemon_grpc.pb.go
@@ -19,19 +19,20 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	DaemonService_GetInfo_FullMethodName      = "/daemonrpc.DaemonService/GetInfo"
-	DaemonService_GenSeed_FullMethodName      = "/daemonrpc.DaemonService/GenSeed"
-	DaemonService_InitWallet_FullMethodName   = "/daemonrpc.DaemonService/InitWallet"
-	DaemonService_UnlockWallet_FullMethodName = "/daemonrpc.DaemonService/UnlockWallet"
-	DaemonService_GetBalance_FullMethodName   = "/daemonrpc.DaemonService/GetBalance"
-	DaemonService_ListVTXOs_FullMethodName    = "/daemonrpc.DaemonService/ListVTXOs"
-	DaemonService_NewAddress_FullMethodName   = "/daemonrpc.DaemonService/NewAddress"
-	DaemonService_SendVTXO_FullMethodName     = "/daemonrpc.DaemonService/SendVTXO"
-	DaemonService_SendOOR_FullMethodName      = "/daemonrpc.DaemonService/SendOOR"
-	DaemonService_RefreshVTXOs_FullMethodName = "/daemonrpc.DaemonService/RefreshVTXOs"
-	DaemonService_Board_FullMethodName        = "/daemonrpc.DaemonService/Board"
-	DaemonService_ListRounds_FullMethodName   = "/daemonrpc.DaemonService/ListRounds"
-	DaemonService_WatchRounds_FullMethodName  = "/daemonrpc.DaemonService/WatchRounds"
+	DaemonService_GetInfo_FullMethodName             = "/daemonrpc.DaemonService/GetInfo"
+	DaemonService_GenSeed_FullMethodName             = "/daemonrpc.DaemonService/GenSeed"
+	DaemonService_InitWallet_FullMethodName          = "/daemonrpc.DaemonService/InitWallet"
+	DaemonService_UnlockWallet_FullMethodName        = "/daemonrpc.DaemonService/UnlockWallet"
+	DaemonService_GetBalance_FullMethodName          = "/daemonrpc.DaemonService/GetBalance"
+	DaemonService_ListVTXOs_FullMethodName           = "/daemonrpc.DaemonService/ListVTXOs"
+	DaemonService_NewAddress_FullMethodName          = "/daemonrpc.DaemonService/NewAddress"
+	DaemonService_NewOORReceiveScript_FullMethodName = "/daemonrpc.DaemonService/NewOORReceiveScript"
+	DaemonService_SendVTXO_FullMethodName            = "/daemonrpc.DaemonService/SendVTXO"
+	DaemonService_SendOOR_FullMethodName             = "/daemonrpc.DaemonService/SendOOR"
+	DaemonService_RefreshVTXOs_FullMethodName        = "/daemonrpc.DaemonService/RefreshVTXOs"
+	DaemonService_Board_FullMethodName               = "/daemonrpc.DaemonService/Board"
+	DaemonService_ListRounds_FullMethodName          = "/daemonrpc.DaemonService/ListRounds"
+	DaemonService_WatchRounds_FullMethodName         = "/daemonrpc.DaemonService/WatchRounds"
 )
 
 // DaemonServiceClient is the client API for DaemonService service.
@@ -68,6 +69,10 @@ type DaemonServiceClient interface {
 	// NewAddress generates a new boarding address that can receive
 	// on-chain funds for use in the Ark protocol.
 	NewAddress(ctx context.Context, in *NewAddressRequest, opts ...grpc.CallOption) (*NewAddressResponse, error)
+	// NewOORReceiveScript allocates a fresh wallet key, registers the
+	// matching taproot OOR receive script with the indexer, and returns
+	// the script details needed to hand the destination to a sender.
+	NewOORReceiveScript(ctx context.Context, in *NewOORReceiveScriptRequest, opts ...grpc.CallOption) (*NewOORReceiveScriptResponse, error)
 	// SendVTXO initiates an in-round transfer by submitting a refresh
 	// request to the round coordinator. The transfer completes when the
 	// next round commits.
@@ -164,6 +169,16 @@ func (c *daemonServiceClient) NewAddress(ctx context.Context, in *NewAddressRequ
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(NewAddressResponse)
 	err := c.cc.Invoke(ctx, DaemonService_NewAddress_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *daemonServiceClient) NewOORReceiveScript(ctx context.Context, in *NewOORReceiveScriptRequest, opts ...grpc.CallOption) (*NewOORReceiveScriptResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(NewOORReceiveScriptResponse)
+	err := c.cc.Invoke(ctx, DaemonService_NewOORReceiveScript_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -273,6 +288,10 @@ type DaemonServiceServer interface {
 	// NewAddress generates a new boarding address that can receive
 	// on-chain funds for use in the Ark protocol.
 	NewAddress(context.Context, *NewAddressRequest) (*NewAddressResponse, error)
+	// NewOORReceiveScript allocates a fresh wallet key, registers the
+	// matching taproot OOR receive script with the indexer, and returns
+	// the script details needed to hand the destination to a sender.
+	NewOORReceiveScript(context.Context, *NewOORReceiveScriptRequest) (*NewOORReceiveScriptResponse, error)
 	// SendVTXO initiates an in-round transfer by submitting a refresh
 	// request to the round coordinator. The transfer completes when the
 	// next round commits.
@@ -325,6 +344,9 @@ func (UnimplementedDaemonServiceServer) ListVTXOs(context.Context, *ListVTXOsReq
 }
 func (UnimplementedDaemonServiceServer) NewAddress(context.Context, *NewAddressRequest) (*NewAddressResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method NewAddress not implemented")
+}
+func (UnimplementedDaemonServiceServer) NewOORReceiveScript(context.Context, *NewOORReceiveScriptRequest) (*NewOORReceiveScriptResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method NewOORReceiveScript not implemented")
 }
 func (UnimplementedDaemonServiceServer) SendVTXO(context.Context, *SendVTXORequest) (*SendVTXOResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method SendVTXO not implemented")
@@ -491,6 +513,24 @@ func _DaemonService_NewAddress_Handler(srv interface{}, ctx context.Context, dec
 	return interceptor(ctx, in, info, handler)
 }
 
+func _DaemonService_NewOORReceiveScript_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(NewOORReceiveScriptRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DaemonServiceServer).NewOORReceiveScript(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DaemonService_NewOORReceiveScript_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DaemonServiceServer).NewOORReceiveScript(ctx, req.(*NewOORReceiveScriptRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _DaemonService_SendVTXO_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(SendVTXORequest)
 	if err := dec(in); err != nil {
@@ -626,6 +666,10 @@ var DaemonService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "NewAddress",
 			Handler:    _DaemonService_NewAddress_Handler,
+		},
+		{
+			MethodName: "NewOORReceiveScript",
+			Handler:    _DaemonService_NewOORReceiveScript_Handler,
 		},
 		{
 			MethodName: "SendVTXO",

--- a/daemonrpc/daemon_mailboxrpc.pb.go
+++ b/daemonrpc/daemon_mailboxrpc.pb.go
@@ -38,6 +38,8 @@ type DaemonServiceMailboxServer interface {
 	ListVTXOs(ctx context.Context, req *ListVTXOsRequest) (*ListVTXOsResponse, error)
 	// NewAddress handles NewAddress.
 	NewAddress(ctx context.Context, req *NewAddressRequest) (*NewAddressResponse, error)
+	// NewOORReceiveScript handles NewOORReceiveScript.
+	NewOORReceiveScript(ctx context.Context, req *NewOORReceiveScriptRequest) (*NewOORReceiveScriptResponse, error)
 	// SendVTXO handles SendVTXO.
 	SendVTXO(ctx context.Context, req *SendVTXORequest) (*SendVTXOResponse, error)
 	// SendOOR handles SendOOR.
@@ -123,6 +125,16 @@ func RegisterDaemonServiceMailboxServer(r rpc.Router, impl DaemonServiceMailboxS
 		}
 
 		return impl.NewAddress(ctx, req)
+	})
+	r.Handle("daemonrpc.DaemonService", "NewOORReceiveScript", func() proto.Message {
+		return &NewOORReceiveScriptRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*NewOORReceiveScriptRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.NewOORReceiveScript(ctx, req)
 	})
 	r.Handle("daemonrpc.DaemonService", "SendVTXO", func() proto.Message {
 		return &SendVTXORequest{}
@@ -340,6 +352,29 @@ func (c *DaemonServiceMailboxClient) NewAddress(ctx context.Context, req *NewAdd
 	}
 
 	resp := new(NewAddressResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// NewOORReceiveScript calls the NewOORReceiveScript RPC.
+func (c *DaemonServiceMailboxClient) NewOORReceiveScript(ctx context.Context, req *NewOORReceiveScriptRequest, opts ...rpc.RPCOptions) (*NewOORReceiveScriptResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "daemonrpc.DaemonService",
+		Method:  "NewOORReceiveScript",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(NewOORReceiveScriptResponse)
 	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
 		return nil, err
 	}

--- a/darepod/incoming_metadata.go
+++ b/darepod/incoming_metadata.go
@@ -1,0 +1,152 @@
+package darepod
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightninglabs/darepo-client/arkrpc"
+	clientdb "github.com/lightninglabs/darepo-client/db"
+	"github.com/lightninglabs/darepo-client/indexer"
+	"github.com/lightninglabs/darepo-client/oor"
+)
+
+const incomingMetadataIndexPageSize = 128
+
+// ResolveIncomingMetadataFromIndexer queries the authoritative indexer
+// inventory for the just-created OOR output and maps the result into the
+// incoming materialization metadata required by the local VTXO store.
+func ResolveIncomingMetadataFromIndexer(ctx context.Context,
+	idx *indexer.Client, sessionID oor.SessionID,
+	recipient oor.ArkRecipientOutput) (oor.IncomingVTXOMetadata, error) {
+
+	if idx == nil {
+		return oor.IncomingVTXOMetadata{}, fmt.Errorf("indexer client " +
+			"must be provided")
+	}
+
+	log.DebugS(ctx, "Resolving incoming metadata from indexer",
+		slog.String("session_id", chainhash.Hash(sessionID).String()),
+		slog.Int("output_index", int(recipient.OutputIndex)),
+		slog.String("pk_script", fmt.Sprintf("%x", recipient.PkScript)))
+
+	var cursor uint64
+	for {
+		resp, err := idx.ListVTXOsByScriptsTaproot(
+			ctx,
+			[]indexer.TaprootScriptScope{{
+				PkScript: append(
+					[]byte(nil), recipient.PkScript...,
+				),
+			}},
+			cursor, incomingMetadataIndexPageSize, nil,
+		)
+		if err != nil {
+			return oor.IncomingVTXOMetadata{}, fmt.Errorf("list "+
+				"VTXOs by script: %w", err)
+		}
+
+		for _, candidate := range resp.GetVtxos() {
+			match, err := matchesIncomingVTXO(
+				candidate, sessionID, recipient.OutputIndex,
+			)
+			if err != nil {
+				return oor.IncomingVTXOMetadata{}, err
+			}
+			if !match {
+				continue
+			}
+
+			log.DebugS(ctx, "Matched incoming indexer VTXO",
+				slog.String("session_id",
+					chainhash.Hash(sessionID).String()),
+				slog.Int("output_index",
+					int(recipient.OutputIndex)),
+				slog.String("round_id",
+					candidate.GetRoundId()),
+				slog.Int("tree_depth",
+					int(candidate.GetTreeDepth())),
+				slog.Int("chain_depth",
+					int(candidate.GetChainDepth())))
+
+			return incomingMetadataFromRPC(candidate)
+		}
+
+		nextCursor := resp.GetNextCursor()
+		if len(resp.GetVtxos()) == 0 || nextCursor <= cursor {
+			break
+		}
+
+		cursor = nextCursor
+	}
+
+	log.DebugS(ctx, "Incoming indexer VTXO not found",
+		slog.String("session_id", chainhash.Hash(sessionID).String()),
+		slog.Int("output_index", int(recipient.OutputIndex)))
+
+	return oor.IncomingVTXOMetadata{}, fmt.Errorf("incoming vtxo %s:%d "+
+		"not found in indexer inventory",
+		chainhash.Hash(sessionID), recipient.OutputIndex)
+}
+
+// matchesIncomingVTXO returns true when candidate identifies the target Ark
+// output created by sessionID at outputIndex.
+func matchesIncomingVTXO(candidate *arkrpc.VTXO, sessionID oor.SessionID,
+	outputIndex uint32) (bool, error) {
+
+	if candidate == nil {
+		return false, nil
+	}
+
+	outpoint := candidate.GetOutpoint()
+	if outpoint == nil {
+		return false, fmt.Errorf("indexer VTXO missing outpoint")
+	}
+
+	return bytes.Equal(outpoint.GetTxid(), sessionID[:]) &&
+		outpoint.GetVout() == outputIndex, nil
+}
+
+// incomingMetadataFromRPC maps the authoritative indexer VTXO view into the
+// metadata shape required by the incoming OOR materialization path.
+func incomingMetadataFromRPC(candidate *arkrpc.VTXO) (
+	oor.IncomingVTXOMetadata, error) {
+
+	if candidate == nil {
+		return oor.IncomingVTXOMetadata{}, fmt.Errorf("indexer vtxo " +
+			"must be provided")
+	}
+
+	if candidate.GetRoundId() == "" {
+		return oor.IncomingVTXOMetadata{}, fmt.Errorf("indexer vtxo " +
+			"missing round id")
+	}
+
+	if len(candidate.GetCommitmentTxid()) != chainhash.HashSize {
+		return oor.IncomingVTXOMetadata{}, fmt.Errorf("indexer vtxo " +
+			"missing commitment txid")
+	}
+
+	treePath, err := clientdb.DeserializeTree(
+		candidate.GetTreePathTlv(),
+	)
+	if err != nil {
+		return oor.IncomingVTXOMetadata{}, fmt.Errorf("deserialize "+
+			"tree path: %w", err)
+	}
+
+	var commitmentTxID chainhash.Hash
+	copy(commitmentTxID[:], candidate.GetCommitmentTxid())
+
+	return oor.IncomingVTXOMetadata{
+		RoundID:        candidate.GetRoundId(),
+		CommitmentTxID: commitmentTxID,
+		BatchExpiry:    candidate.GetBatchExpiryHeight(),
+		TreeDepth:      int(candidate.GetTreeDepth()),
+		ChainDepth:     int(candidate.GetChainDepth()),
+		CreatedHeight:  candidate.GetCreatedHeight(),
+		TreePath:       treePath,
+	}, nil
+}

--- a/darepod/receive_script.go
+++ b/darepod/receive_script.go
@@ -17,13 +17,6 @@ import (
 
 const (
 	defaultOORReceiveScriptRegistrationTTL = 30 * 24 * time.Hour
-
-	// defaultOORReceiveKeyFamily is the dedicated BIP32 key family used
-	// for the daemon's default OOR receive script. This must be separate
-	// from the node identity key family because lnd's signer path for the
-	// identity key does not produce valid tapscript spend signatures for
-	// rematerialized OOR VTXOs.
-	defaultOORReceiveKeyFamily keychain.KeyFamily = 44
 )
 
 // ownedReceiveScriptStore persists locally owned receive-script metadata.
@@ -53,17 +46,16 @@ type defaultOORReceiveScriptStateStore interface {
 	ownedReceiveScriptLister
 }
 
-// DeriveDefaultOORReceiveKeyFunc derives the next wallet-managed default OOR
-// receive key when no previously persisted key exists.
+// DeriveDefaultOORReceiveKeyFunc derives the next wallet-managed OOR receive
+// key when no previously persisted key exists.
 type DeriveDefaultOORReceiveKeyFunc func(context.Context) (
 	*keychain.KeyDescriptor, error,
 )
 
-// DefaultOORReceiveKeyFamily returns the dedicated key family used for
-// daemon-managed OOR receive keys.
-func DefaultOORReceiveKeyFamily() keychain.KeyFamily {
-	return defaultOORReceiveKeyFamily
-}
+// OORReceiveScriptSignerFactory constructs an indexer proof signer for the
+// wallet key that controls one owned receive script.
+type OORReceiveScriptSignerFactory func(
+	keyDesc keychain.KeyDescriptor) indexer.SchnorrSigner
 
 // BuildPubKeyVTXOReceiveScript derives the standard VTXO-compatible taproot
 // output script for an OOR recipient pubkey.
@@ -118,6 +110,207 @@ func ResolveOwnedReceiveScriptKey(ctx context.Context,
 	}
 
 	return rec.ClientKey, nil
+}
+
+// ownedReceiveScriptSigner resolves the correct wallet key for each pkScript
+// from the persisted owned receive-script map, then delegates signing to the
+// backend-specific signer implementation for that key.
+type ownedReceiveScriptSigner struct {
+	store         ownedReceiveScriptLookup
+	signerFactory OORReceiveScriptSignerFactory
+}
+
+// NewOwnedReceiveScriptSigner returns an indexer signer that can prove control
+// for any persisted locally owned receive script instead of a single fixed key.
+func NewOwnedReceiveScriptSigner(store ownedReceiveScriptLookup,
+	signerFactory OORReceiveScriptSignerFactory) indexer.SchnorrSigner {
+
+	return &ownedReceiveScriptSigner{
+		store:         store,
+		signerFactory: signerFactory,
+	}
+}
+
+// resolveSigner loads the locally owned key for pkScript and constructs the
+// backend-specific signer that can prove control over it.
+func (s *ownedReceiveScriptSigner) resolveSigner(ctx context.Context,
+	pkScript []byte) (indexer.SchnorrSigner, error) {
+
+	if s.store == nil {
+		return nil, fmt.Errorf("owned receive script lookup must be " +
+			"provided")
+	}
+
+	if s.signerFactory == nil {
+		return nil, fmt.Errorf("receive script signer factory must be " +
+			"provided")
+	}
+
+	rec, err := s.store.LookupOwnedReceiveScript(ctx, pkScript)
+	if err != nil {
+		return nil, fmt.Errorf("lookup owned receive script: %w", err)
+	}
+
+	signer := s.signerFactory(rec.ClientKey)
+	if signer == nil {
+		return nil, fmt.Errorf("receive script signer factory returned " +
+			"nil signer")
+	}
+
+	return signer, nil
+}
+
+// SignSchnorr signs hash with the wallet key that controls pkScript.
+func (s *ownedReceiveScriptSigner) SignSchnorr(
+	pkScript []byte, hash [32]byte) ([]byte, error) {
+
+	signer, err := s.resolveSigner(context.Background(), pkScript)
+	if err != nil {
+		return nil, err
+	}
+
+	return signer.SignSchnorr(pkScript, hash)
+}
+
+// SignSchnorrMessage signs the canonical proof preimage for pkScript using the
+// backend-specific tagged-message path when available.
+func (s *ownedReceiveScriptSigner) SignSchnorrMessage(ctx context.Context,
+	pkScript []byte, message []byte, tag []byte) ([]byte, error) {
+
+	signer, err := s.resolveSigner(ctx, pkScript)
+	if err != nil {
+		return nil, err
+	}
+
+	msgSigner, ok := signer.(interface {
+		SignSchnorrMessage(context.Context, []byte, []byte,
+			[]byte) ([]byte, error)
+	})
+	if !ok {
+		return nil, fmt.Errorf("signer does not support tagged message " +
+			"signing")
+	}
+
+	return msgSigner.SignSchnorrMessage(
+		ctx, pkScript, message, tag,
+	)
+}
+
+// ProofPubKey returns the owner pubkey committed into proofs for pkScript.
+func (s *ownedReceiveScriptSigner) ProofPubKey(
+	pkScript []byte) (*btcec.PublicKey, error) {
+
+	signer, err := s.resolveSigner(context.Background(), pkScript)
+	if err != nil {
+		return nil, err
+	}
+
+	pubKeySource, ok := signer.(interface {
+		ProofPubKey([]byte) (*btcec.PublicKey, error)
+	})
+	if !ok {
+		return nil, fmt.Errorf("signer does not expose proof pubkey")
+	}
+
+	return pubKeySource.ProofPubKey(pkScript)
+}
+
+// CreateOORReceiveScript derives a fresh wallet key, registers the matching
+// receive script with the indexer, and persists the ownership metadata needed
+// to prove control over that script later.
+func CreateOORReceiveScript(ctx context.Context, idx *indexer.Client,
+	store ownedReceiveScriptStore,
+	deriveNextKey DeriveDefaultOORReceiveKeyFunc,
+	signerFactory OORReceiveScriptSignerFactory,
+	operatorKey *btcec.PublicKey, exitDelay uint32, label string) (
+	*keychain.KeyDescriptor, []byte, error,
+) {
+
+	if deriveNextKey == nil {
+		return nil, nil, fmt.Errorf("derive next key func must be " +
+			"provided")
+	}
+
+	keyDesc, err := deriveNextKey(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("derive oor receive key: %w", err)
+	}
+
+	if keyDesc == nil || keyDesc.PubKey == nil {
+		return nil, nil, fmt.Errorf("derive oor receive key: missing " +
+			"pubkey")
+	}
+
+	pkScript, err := RegisterOwnedOORReceiveScript(
+		ctx, idx, store, *keyDesc, signerFactory, operatorKey,
+		exitDelay, label,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return keyDesc, pkScript, nil
+}
+
+// RegisterOwnedOORReceiveScript registers and persists one wallet-owned OOR
+// receive script for clientKey using the signer produced by signerFactory.
+func RegisterOwnedOORReceiveScript(ctx context.Context,
+	idx *indexer.Client, store ownedReceiveScriptStore,
+	clientKey keychain.KeyDescriptor,
+	signerFactory OORReceiveScriptSignerFactory,
+	operatorKey *btcec.PublicKey, exitDelay uint32,
+	label string) ([]byte, error) {
+
+	switch {
+	case idx == nil:
+		return nil, fmt.Errorf("indexer client must be provided")
+
+	case signerFactory == nil:
+		return nil, fmt.Errorf("receive script signer factory must be " +
+			"provided")
+
+	case clientKey.PubKey == nil:
+		return nil, fmt.Errorf("client key must be provided")
+	}
+
+	pkScript, err := BuildPubKeyVTXOReceiveScript(
+		clientKey.PubKey, operatorKey, exitDelay,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	registerClient := idx.WithSigner(signerFactory(clientKey))
+	if registerClient == nil {
+		return nil, fmt.Errorf("indexer client must be provided")
+	}
+
+	expiresAt := time.Now().Add(defaultOORReceiveScriptRegistrationTTL)
+	_, err = registerClient.RegisterReceiveScriptTaproot(
+		ctx, pkScript, expiresAt, label,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("register receive script: %w", err)
+	}
+
+	if store == nil {
+		return pkScript, nil
+	}
+
+	err = store.UpsertOwnedReceiveScript(ctx, db.OwnedReceiveScriptRecord{
+		PkScript:       pkScript,
+		ClientKey:      clientKey,
+		OperatorPubKey: operatorKey,
+		ExitDelay:      int64(exitDelay),
+		Source:         db.OwnedReceiveScriptSourceWallet,
+		CreatedAt:      time.Now(),
+		LastUsedAt:     fn.None[time.Time](),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("persist owned receive script: %w", err)
+	}
+
+	return pkScript, nil
 }
 
 // LoadDefaultOORReceiveKey loads the most recently persisted wallet-managed

--- a/darepod/receive_script.go
+++ b/darepod/receive_script.go
@@ -1,0 +1,277 @@
+package darepod
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/lightninglabs/darepo-client/db"
+	"github.com/lightninglabs/darepo-client/indexer"
+	"github.com/lightninglabs/darepo-client/lib/scripts"
+	"github.com/lightninglabs/darepo-client/oor"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/keychain"
+)
+
+const (
+	defaultOORReceiveScriptRegistrationTTL = 30 * 24 * time.Hour
+
+	// defaultOORReceiveKeyFamily is the dedicated BIP32 key family used
+	// for the daemon's default OOR receive script. This must be separate
+	// from the node identity key family because lnd's signer path for the
+	// identity key does not produce valid tapscript spend signatures for
+	// rematerialized OOR VTXOs.
+	defaultOORReceiveKeyFamily keychain.KeyFamily = 44
+)
+
+// ownedReceiveScriptStore persists locally owned receive-script metadata.
+type ownedReceiveScriptStore interface {
+	UpsertOwnedReceiveScript(ctx context.Context,
+		rec db.OwnedReceiveScriptRecord) error
+}
+
+// ownedReceiveScriptLookup loads locally owned receive-script metadata by
+// pkScript.
+type ownedReceiveScriptLookup interface {
+	LookupOwnedReceiveScript(ctx context.Context,
+		pkScript []byte) (*db.OwnedReceiveScriptRecord, error)
+}
+
+// ownedReceiveScriptLister lists locally owned receive-script metadata.
+type ownedReceiveScriptLister interface {
+	ListOwnedReceiveScripts(ctx context.Context) (
+		[]db.OwnedReceiveScriptRecord, error,
+	)
+}
+
+// defaultOORReceiveScriptStateStore provides the persistent state needed to
+// reuse or register the daemon-managed default OOR receive key.
+type defaultOORReceiveScriptStateStore interface {
+	ownedReceiveScriptStore
+	ownedReceiveScriptLister
+}
+
+// DeriveDefaultOORReceiveKeyFunc derives the next wallet-managed default OOR
+// receive key when no previously persisted key exists.
+type DeriveDefaultOORReceiveKeyFunc func(context.Context) (
+	*keychain.KeyDescriptor, error,
+)
+
+// DefaultOORReceiveKeyFamily returns the dedicated key family used for
+// daemon-managed OOR receive keys.
+func DefaultOORReceiveKeyFamily() keychain.KeyFamily {
+	return defaultOORReceiveKeyFamily
+}
+
+// BuildPubKeyVTXOReceiveScript derives the standard VTXO-compatible taproot
+// output script for an OOR recipient pubkey.
+func BuildPubKeyVTXOReceiveScript(recipientKey,
+	operatorKey *btcec.PublicKey, exitDelay uint32) ([]byte, error) {
+
+	switch {
+	case recipientKey == nil:
+		return nil, fmt.Errorf("recipient key must be provided")
+
+	case operatorKey == nil:
+		return nil, fmt.Errorf("operator key must be provided")
+	}
+
+	tapKey, err := scripts.VTXOTapKey(
+		recipientKey, operatorKey, exitDelay,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("derive vtxo tap key: %w", err)
+	}
+
+	pkScript, err := txscript.PayToTaprootScript(tapKey)
+	if err != nil {
+		return nil, fmt.Errorf("derive receive pk script: %w", err)
+	}
+
+	return pkScript, nil
+}
+
+// ResolveOwnedReceiveScriptKey resolves the locally owned wallet key for an
+// incoming recipient output using the persisted receive-script ownership map.
+func ResolveOwnedReceiveScriptKey(ctx context.Context,
+	store ownedReceiveScriptLookup,
+	recipient oor.ArkRecipientOutput) (keychain.KeyDescriptor, error) {
+
+	switch {
+	case store == nil:
+		return keychain.KeyDescriptor{}, fmt.Errorf(
+			"owned receive script lookup must be provided",
+		)
+
+	case len(recipient.PkScript) == 0:
+		return keychain.KeyDescriptor{}, fmt.Errorf(
+			"recipient pk script must be provided",
+		)
+	}
+
+	rec, err := store.LookupOwnedReceiveScript(ctx, recipient.PkScript)
+	if err != nil {
+		return keychain.KeyDescriptor{}, fmt.Errorf("lookup owned "+
+			"receive script: %w", err)
+	}
+
+	return rec.ClientKey, nil
+}
+
+// LoadDefaultOORReceiveKey loads the most recently persisted wallet-managed
+// OOR receive key, if one exists.
+func LoadDefaultOORReceiveKey(ctx context.Context,
+	store ownedReceiveScriptLister) (*keychain.KeyDescriptor, error) {
+
+	if store == nil {
+		return nil, fmt.Errorf("owned receive script lister must be " +
+			"provided")
+	}
+
+	records, err := store.ListOwnedReceiveScripts(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list owned receive scripts: %w", err)
+	}
+
+	var latest *db.OwnedReceiveScriptRecord
+	for i := range records {
+		rec := &records[i]
+		if rec.Source != db.OwnedReceiveScriptSourceWallet {
+			continue
+		}
+
+		if latest == nil || rec.CreatedAt.After(latest.CreatedAt) {
+			latest = rec
+		}
+	}
+
+	if latest == nil {
+		return nil, nil
+	}
+
+	return &latest.ClientKey, nil
+}
+
+// EnsureDefaultOORReceiveKey loads the most recently persisted wallet-managed
+// OOR receive key or derives a new one when no prior registration exists.
+func EnsureDefaultOORReceiveKey(ctx context.Context,
+	store ownedReceiveScriptLister,
+	deriveNextKey DeriveDefaultOORReceiveKeyFunc) (
+	*keychain.KeyDescriptor, error,
+) {
+
+	if store == nil {
+		return nil, fmt.Errorf("owned receive script lister must be " +
+			"provided")
+	}
+
+	keyDesc, err := LoadDefaultOORReceiveKey(ctx, store)
+	if err != nil {
+		return nil, err
+	}
+
+	if keyDesc != nil {
+		return keyDesc, nil
+	}
+
+	if deriveNextKey == nil {
+		return nil, fmt.Errorf("derive next key func must be provided")
+	}
+
+	keyDesc, err = deriveNextKey(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("derive default oor receive key: %w",
+			err)
+	}
+
+	if keyDesc == nil || keyDesc.PubKey == nil {
+		return nil, fmt.Errorf("derive default oor receive key: " +
+			"missing pubkey")
+	}
+
+	return keyDesc, nil
+}
+
+// EnsureDefaultOORReceiveScript ensures the daemon-managed default OOR receive
+// key exists, registers the corresponding receive script, and persists its
+// ownership metadata for later incoming-script resolution.
+func EnsureDefaultOORReceiveScript(ctx context.Context,
+	idx *indexer.Client, store defaultOORReceiveScriptStateStore,
+	deriveNextKey DeriveDefaultOORReceiveKeyFunc,
+	operatorKey *btcec.PublicKey, exitDelay uint32, label string) (
+	*keychain.KeyDescriptor, []byte, error,
+) {
+
+	if store == nil {
+		return nil, nil, fmt.Errorf("default OOR receive script " +
+			"store must be provided")
+	}
+
+	keyDesc, err := EnsureDefaultOORReceiveKey(
+		ctx, store, deriveNextKey,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pkScript, err := RegisterDefaultOORReceiveScript(
+		ctx, idx, store, *keyDesc, operatorKey, exitDelay, label,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return keyDesc, pkScript, nil
+}
+
+// RegisterDefaultOORReceiveScript derives, registers, and persists the
+// default OOR receive script for the provided local wallet key.
+func RegisterDefaultOORReceiveScript(ctx context.Context,
+	idx *indexer.Client, store ownedReceiveScriptStore,
+	clientKey keychain.KeyDescriptor, operatorKey *btcec.PublicKey,
+	exitDelay uint32, label string) ([]byte, error) {
+
+	switch {
+	case idx == nil:
+		return nil, fmt.Errorf("indexer client must be provided")
+
+	case clientKey.PubKey == nil:
+		return nil, fmt.Errorf("client key must be provided")
+	}
+
+	pkScript, err := BuildPubKeyVTXOReceiveScript(
+		clientKey.PubKey, operatorKey, exitDelay,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	expiresAt := time.Now().Add(defaultOORReceiveScriptRegistrationTTL)
+	_, err = idx.RegisterReceiveScriptTaproot(
+		ctx, pkScript, expiresAt, label,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("register receive script: %w", err)
+	}
+
+	if store == nil {
+		return pkScript, nil
+	}
+
+	err = store.UpsertOwnedReceiveScript(ctx, db.OwnedReceiveScriptRecord{
+		PkScript:       pkScript,
+		ClientKey:      clientKey,
+		OperatorPubKey: operatorKey,
+		ExitDelay:      int64(exitDelay),
+		Source:         db.OwnedReceiveScriptSourceWallet,
+		CreatedAt:      time.Now(),
+		LastUsedAt:     fn.None[time.Time](),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("persist owned receive script: %w", err)
+	}
+
+	return pkScript, nil
+}

--- a/darepod/receive_script_test.go
+++ b/darepod/receive_script_test.go
@@ -2,14 +2,19 @@ package darepod
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/lightninglabs/darepo-client/arkrpc"
 	"github.com/lightninglabs/darepo-client/db"
+	"github.com/lightninglabs/darepo-client/indexer"
+	mailboxrpc "github.com/lightninglabs/darepo-client/mailbox/rpc"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 )
 
 // testReceiveScriptStore is a minimal in-memory owned receive-script store used
@@ -33,6 +38,23 @@ func (s *testReceiveScriptStore) UpsertOwnedReceiveScript(_ context.Context,
 	s.records = append(s.records, rec)
 
 	return nil
+}
+
+// LookupOwnedReceiveScript returns one tracked owned receive-script record.
+func (s *testReceiveScriptStore) LookupOwnedReceiveScript(_ context.Context,
+	pkScript []byte) (*db.OwnedReceiveScriptRecord, error) {
+
+	for i := range s.records {
+		if string(s.records[i].PkScript) != string(pkScript) {
+			continue
+		}
+
+		rec := s.records[i]
+
+		return &rec, nil
+	}
+
+	return nil, fmt.Errorf("owned receive script not found")
 }
 
 // ListOwnedReceiveScripts returns all tracked owned receive-script records.
@@ -91,6 +113,151 @@ func TestEnsureDefaultOORReceiveKeyReusesPersistedKey(t *testing.T) {
 	)
 }
 
+// TestCreateOORReceiveScriptDerivesFreshKeys verifies that each allocation
+// derives a new wallet key, registers the matching script, and persists a
+// distinct ownership record.
+func TestCreateOORReceiveScriptDerivesFreshKeys(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := &testReceiveScriptStore{}
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	keys := []keychain.KeyDescriptor{
+		testKeyDescriptor(t, 11),
+		testKeyDescriptor(t, 12),
+	}
+
+	nextKey := 0
+	rpcClient := &testReceiveScriptRPCClient{}
+	idx := indexer.New(
+		rpcClient, nil, "test-server", "client:test",
+	)
+
+	signerFactory := func(
+		keyDesc keychain.KeyDescriptor) indexer.SchnorrSigner {
+
+		return &testOwnedReceiveScriptSigner{
+			keyDesc: keyDesc,
+			tagSig:  []byte("test-tag-signature"),
+		}
+	}
+
+	_, pkScriptA, err := CreateOORReceiveScript(
+		ctx, idx, store,
+		func(context.Context) (*keychain.KeyDescriptor, error) {
+			key := keys[nextKey]
+			nextKey++
+
+			return &key, nil
+		},
+		signerFactory, operatorPriv.PubKey(), 144,
+		"test-oor-receive-a",
+	)
+	require.NoError(t, err)
+
+	_, pkScriptB, err := CreateOORReceiveScript(
+		ctx, idx, store,
+		func(context.Context) (*keychain.KeyDescriptor, error) {
+			key := keys[nextKey]
+			nextKey++
+
+			return &key, nil
+		},
+		signerFactory, operatorPriv.PubKey(), 144,
+		"test-oor-receive-b",
+	)
+	require.NoError(t, err)
+
+	require.NotEqual(t, pkScriptA, pkScriptB)
+	require.Len(t, store.records, 2)
+	require.Equal(
+		t, keys[0].PubKey.SerializeCompressed(),
+		store.records[0].ClientKey.PubKey.SerializeCompressed(),
+	)
+	require.Equal(
+		t, keys[1].PubKey.SerializeCompressed(),
+		store.records[1].ClientKey.PubKey.SerializeCompressed(),
+	)
+	require.Len(t, rpcClient.registerReqs, 2)
+	require.Equal(t, pkScriptA, rpcClient.registerReqs[0].PkScript)
+	require.Equal(t, pkScriptB, rpcClient.registerReqs[1].PkScript)
+}
+
+// TestNewOwnedReceiveScriptSignerUsesMatchingKey verifies that proofs are
+// produced with the wallet key associated with the queried pkScript.
+func TestNewOwnedReceiveScriptSignerUsesMatchingKey(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	keyA := testKeyDescriptor(t, 21)
+	keyB := testKeyDescriptor(t, 22)
+	store := &testReceiveScriptStore{
+		records: []db.OwnedReceiveScriptRecord{
+			{
+				PkScript:       []byte{0x51, 0x20, 0x01},
+				ClientKey:      keyA,
+				Source:         db.OwnedReceiveScriptSourceWallet,
+				CreatedAt:      time.Unix(10, 0),
+				LastUsedAt:     fn.None[time.Time](),
+				OperatorPubKey: testKeyDescriptor(t, 31).PubKey,
+			},
+			{
+				PkScript:       []byte{0x51, 0x20, 0x02},
+				ClientKey:      keyB,
+				Source:         db.OwnedReceiveScriptSourceWallet,
+				CreatedAt:      time.Unix(11, 0),
+				LastUsedAt:     fn.None[time.Time](),
+				OperatorPubKey: testKeyDescriptor(t, 32).PubKey,
+			},
+		},
+	}
+
+	signer := NewOwnedReceiveScriptSigner(
+		store,
+		func(keyDesc keychain.KeyDescriptor) indexer.SchnorrSigner {
+			return &testOwnedReceiveScriptSigner{
+				keyDesc: keyDesc,
+				tagSig: []byte{
+					keyDesc.PubKey.SerializeCompressed()[0],
+					keyDesc.PubKey.SerializeCompressed()[1],
+				},
+			}
+		},
+	)
+
+	pubKeySource, ok := signer.(interface {
+		ProofPubKey([]byte) (*btcec.PublicKey, error)
+	})
+	require.True(t, ok)
+
+	proofPubA, err := pubKeySource.ProofPubKey(store.records[0].PkScript)
+	require.NoError(t, err)
+	require.Equal(
+		t, keyA.PubKey.SerializeCompressed(),
+		proofPubA.SerializeCompressed(),
+	)
+
+	msgSigner, ok := signer.(interface {
+		SignSchnorrMessage(context.Context, []byte, []byte,
+			[]byte) ([]byte, error)
+	})
+	require.True(t, ok)
+
+	sigA, err := msgSigner.SignSchnorrMessage(
+		ctx, store.records[0].PkScript, []byte("msg"), []byte("tag"),
+	)
+	require.NoError(t, err)
+
+	sigB, err := msgSigner.SignSchnorrMessage(
+		ctx, store.records[1].PkScript, []byte("msg"), []byte("tag"),
+	)
+	require.NoError(t, err)
+
+	require.NotEqual(t, sigA, sigB)
+}
+
 // TestEnsureDefaultOORReceiveKeyDerivesWhenMissing verifies that the helper
 // falls back to the provided wallet derivation path when no stored key exists.
 func TestEnsureDefaultOORReceiveKeyDerivesWhenMissing(t *testing.T) {
@@ -129,9 +296,80 @@ func testKeyDescriptor(t *testing.T, seed byte) keychain.KeyDescriptor {
 
 	return keychain.KeyDescriptor{
 		KeyLocator: keychain.KeyLocator{
-			Family: DefaultOORReceiveKeyFamily(),
+			Family: keychain.KeyFamilyMultiSig,
 			Index:  uint32(seed),
 		},
 		PubKey: privKey.PubKey(),
 	}
+}
+
+// testOwnedReceiveScriptSigner is a minimal signer stub keyed by one wallet
+// descriptor.
+type testOwnedReceiveScriptSigner struct {
+	keyDesc keychain.KeyDescriptor
+	tagSig  []byte
+}
+
+// SignSchnorr returns a deterministic 64-byte signature for raw-digest paths.
+func (s *testOwnedReceiveScriptSigner) SignSchnorr(
+	_ []byte, _ [32]byte) ([]byte, error) {
+
+	return make([]byte, 64), nil
+}
+
+// SignSchnorrMessage returns a deterministic tagged-message signature.
+func (s *testOwnedReceiveScriptSigner) SignSchnorrMessage(
+	_ context.Context, _ []byte, _ []byte, _ []byte) ([]byte, error) {
+
+	return append([]byte(nil), s.tagSig...), nil
+}
+
+// ProofPubKey returns the wallet key bound to this signer.
+func (s *testOwnedReceiveScriptSigner) ProofPubKey(
+	_ []byte) (*btcec.PublicKey, error) {
+
+	return s.keyDesc.PubKey, nil
+}
+
+// testReceiveScriptRPCClient records mailbox RPC requests for registration.
+type testReceiveScriptRPCClient struct {
+	registerReqs []*arkrpc.RegisterReceiveScriptRequest
+}
+
+// SendRPC records RegisterReceiveScript requests and returns a fixed result.
+func (c *testReceiveScriptRPCClient) SendRPC(_ context.Context,
+	method mailboxrpc.ServiceMethod, req proto.Message,
+	_ mailboxrpc.RPCOptions) (mailboxrpc.SendResult, error) {
+
+	if method.Service == "arkrpc.IndexerService" &&
+		method.Method == "RegisterReceiveScript" {
+
+		regReq, ok := req.(*arkrpc.RegisterReceiveScriptRequest)
+		if !ok {
+			return mailboxrpc.SendResult{}, fmt.Errorf(
+				"unexpected register request type: %T", req,
+			)
+		}
+
+		c.registerReqs = append(c.registerReqs, regReq)
+	}
+
+	return mailboxrpc.SendResult{
+		CorrelationID:  "corr-id",
+		IdempotencyKey: "idem-key",
+	}, nil
+}
+
+// AwaitRPC populates the response expected by the generated mailbox client.
+func (c *testReceiveScriptRPCClient) AwaitRPC(_ context.Context,
+	_ string, resp proto.Message) error {
+
+	registerResp, ok := resp.(*arkrpc.RegisterReceiveScriptResponse)
+	if !ok {
+		return fmt.Errorf("unexpected response type: %T", resp)
+	}
+
+	*registerResp = arkrpc.RegisterReceiveScriptResponse{}
+
+	return nil
 }

--- a/darepod/receive_script_test.go
+++ b/darepod/receive_script_test.go
@@ -1,0 +1,137 @@
+package darepod
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/lightninglabs/darepo-client/db"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/stretchr/testify/require"
+)
+
+// testReceiveScriptStore is a minimal in-memory owned receive-script store used
+// by receive-script unit tests.
+type testReceiveScriptStore struct {
+	records []db.OwnedReceiveScriptRecord
+}
+
+// UpsertOwnedReceiveScript stores or replaces one owned receive-script record.
+func (s *testReceiveScriptStore) UpsertOwnedReceiveScript(_ context.Context,
+	rec db.OwnedReceiveScriptRecord) error {
+
+	for i := range s.records {
+		if string(s.records[i].PkScript) == string(rec.PkScript) {
+			s.records[i] = rec
+
+			return nil
+		}
+	}
+
+	s.records = append(s.records, rec)
+
+	return nil
+}
+
+// ListOwnedReceiveScripts returns all tracked owned receive-script records.
+func (s *testReceiveScriptStore) ListOwnedReceiveScripts(_ context.Context) (
+	[]db.OwnedReceiveScriptRecord, error,
+) {
+
+	records := make([]db.OwnedReceiveScriptRecord, len(s.records))
+	copy(records, s.records)
+
+	return records, nil
+}
+
+// TestEnsureDefaultOORReceiveKeyReusesPersistedKey verifies that the helper
+// prefers the most recent persisted wallet-managed receive key.
+func TestEnsureDefaultOORReceiveKeyReusesPersistedKey(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	olderKey := testKeyDescriptor(t, 1)
+	newerKey := testKeyDescriptor(t, 2)
+	store := &testReceiveScriptStore{
+		records: []db.OwnedReceiveScriptRecord{
+			{
+				PkScript:   []byte{0x51},
+				ClientKey:  olderKey,
+				Source:     db.OwnedReceiveScriptSourceWallet,
+				CreatedAt:  time.Unix(10, 0),
+				LastUsedAt: fn.None[time.Time](),
+			},
+			{
+				PkScript:   []byte{0x52},
+				ClientKey:  newerKey,
+				Source:     db.OwnedReceiveScriptSourceWallet,
+				CreatedAt:  time.Unix(20, 0),
+				LastUsedAt: fn.None[time.Time](),
+			},
+		},
+	}
+
+	derived := false
+	keyDesc, err := EnsureDefaultOORReceiveKey(
+		ctx, store, func(context.Context) (*keychain.KeyDescriptor, error) {
+			derived = true
+
+			return nil, nil
+		},
+	)
+	require.NoError(t, err)
+	require.False(t, derived)
+	require.NotNil(t, keyDesc)
+	require.Equal(
+		t,
+		newerKey.PubKey.SerializeCompressed(),
+		keyDesc.PubKey.SerializeCompressed(),
+	)
+}
+
+// TestEnsureDefaultOORReceiveKeyDerivesWhenMissing verifies that the helper
+// falls back to the provided wallet derivation path when no stored key exists.
+func TestEnsureDefaultOORReceiveKeyDerivesWhenMissing(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := &testReceiveScriptStore{}
+	expected := testKeyDescriptor(t, 3)
+
+	keyDesc, err := EnsureDefaultOORReceiveKey(
+		ctx, store, func(context.Context) (*keychain.KeyDescriptor, error) {
+			return &expected, nil
+		},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, keyDesc)
+	require.Equal(
+		t,
+		expected.PubKey.SerializeCompressed(),
+		keyDesc.PubKey.SerializeCompressed(),
+	)
+}
+
+// testKeyDescriptor creates a deterministic test key descriptor.
+func testKeyDescriptor(t *testing.T, seed byte) keychain.KeyDescriptor {
+	t.Helper()
+
+	privKey, _ := btcec.PrivKeyFromBytes(
+		[]byte{
+			seed, seed, seed, seed, seed, seed, seed, seed,
+			seed, seed, seed, seed, seed, seed, seed, seed,
+			seed, seed, seed, seed, seed, seed, seed, seed,
+			seed, seed, seed, seed, seed, seed, seed, seed,
+		},
+	)
+
+	return keychain.KeyDescriptor{
+		KeyLocator: keychain.KeyLocator{
+			Family: DefaultOORReceiveKeyFamily(),
+			Index:  uint32(seed),
+		},
+		PubKey: privKey.PubKey(),
+	}
+}

--- a/darepod/rpc_oor_receive.go
+++ b/darepod/rpc_oor_receive.go
@@ -1,0 +1,152 @@
+package darepod
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/lightninglabs/darepo-client/db"
+	"github.com/lightninglabs/darepo-client/indexer"
+	"github.com/lightningnetwork/lnd/clock"
+	"github.com/lightningnetwork/lnd/keychain"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const defaultOORReceiveScriptLabel = "oor receive"
+
+// NewOORReceiveScript allocates a fresh wallet key, registers the matching
+// taproot receive script with the indexer, and returns the script details
+// needed to hand this one-shot destination to a sender.
+func (r *RPCServer) NewOORReceiveScript(ctx context.Context,
+	req *daemonrpc.NewOORReceiveScriptRequest) (
+	*daemonrpc.NewOORReceiveScriptResponse, error) {
+
+	if err := r.requireWalletReady(); err != nil {
+		return nil, err
+	}
+
+	if req == nil {
+		req = &daemonrpc.NewOORReceiveScriptRequest{}
+	}
+
+	if r.server.indexer == nil {
+		return nil, status.Errorf(codes.Internal,
+			"indexer client not initialized")
+	}
+
+	if r.server.db == nil {
+		return nil, status.Errorf(codes.Internal,
+			"database not initialized")
+	}
+
+	terms, err := r.server.fetchOperatorTerms(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"unable to fetch operator terms: %v", err)
+	}
+
+	store, err := r.newOORReceiveScriptStore()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"unable to initialize OOR receive-script store: %v", err)
+	}
+
+	deriveNextKey, signerFactory, err := r.oorReceiveKeyOps()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"unable to initialize OOR receive key ops: %v", err)
+	}
+
+	label := req.Label
+	if label == "" {
+		label = defaultOORReceiveScriptLabel
+	}
+
+	keyDesc, pkScript, err := CreateOORReceiveScript(
+		ctx, r.server.indexer, store, deriveNextKey, signerFactory,
+		terms.PubKey, terms.VTXOExitDelay, label,
+	)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"unable to create OOR receive script: %v", err)
+	}
+
+	if keyDesc == nil || keyDesc.PubKey == nil {
+		return nil, status.Errorf(codes.Internal,
+			"missing receive key descriptor")
+	}
+
+	return &daemonrpc.NewOORReceiveScriptResponse{
+		PkScriptHex: hex.EncodeToString(pkScript),
+		PubkeyXonlyHex: hex.EncodeToString(
+			schnorr.SerializePubKey(keyDesc.PubKey),
+		),
+		KeyFamily: uint32(keyDesc.KeyLocator.Family),
+		KeyIndex:  keyDesc.KeyLocator.Index,
+		Label:     label,
+	}, nil
+}
+
+// newOORReceiveScriptStore returns the artifact store used to persist owned
+// receive-script metadata for later proof lookup and incoming resolution.
+func (r *RPCServer) newOORReceiveScriptStore() (
+	*db.OORArtifactPersistenceStore, error,
+) {
+
+	if r.server.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	dbStore := db.NewStore(
+		r.server.db.DB, r.server.db.Queries, r.server.db.Backend(), log,
+	)
+
+	return dbStore.NewOORArtifactStore(clock.NewDefaultClock()), nil
+}
+
+// oorReceiveKeyOps returns the fresh-key derivation function and signer
+// factory for the active wallet backend.
+func (r *RPCServer) oorReceiveKeyOps() (DeriveDefaultOORReceiveKeyFunc,
+	OORReceiveScriptSignerFactory, error) {
+
+	switch {
+	case r.server.lnd.IsSome():
+		lndSvc := r.server.lnd.UnsafeFromSome()
+
+		return func(ctx context.Context) (*keychain.KeyDescriptor, error) {
+				keyDesc, err := lndSvc.WalletKit.DeriveNextKey(
+					ctx, int32(keychain.KeyFamilyMultiSig),
+				)
+				if err != nil {
+					return nil, fmt.Errorf("derive next key: %w", err)
+				}
+
+				return keyDesc, nil
+			}, func(keyDesc keychain.KeyDescriptor) indexer.SchnorrSigner {
+				return indexer.NewLNDSchnorrSigner(
+					lndSvc.Signer, keyDesc,
+				)
+			}, nil
+
+	case r.server.lwWallet.IsSome():
+		wallet := r.server.lwWallet.UnsafeFromSome()
+
+		return func(ctx context.Context) (*keychain.KeyDescriptor, error) {
+				return wallet.DeriveNextKey(
+					ctx, keychain.KeyFamilyMultiSig,
+				)
+			}, func(
+				keyDesc keychain.KeyDescriptor) indexer.SchnorrSigner {
+
+				return indexer.NewKeyRingSchnorrSigner(
+					wallet.KeyRing(), keyDesc,
+				)
+			}, nil
+
+	default:
+		return nil, nil, fmt.Errorf("wallet backend not initialized")
+	}
+}

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -931,19 +931,20 @@ func (r *RPCServer) resolveOutputPkScript(ctx context.Context,
 			)
 		}
 
-		tapKey, err := scripts.VTXOTapKey(
+		pkScript, err := BuildPubKeyVTXOReceiveScript(
 			recipientKey, terms.PubKey,
 			terms.VTXOExitDelay,
 		)
 		if err != nil {
 			return nil, status.Errorf(
 				codes.Internal,
-				"unable to derive VTXO tap key: %v",
+				"unable to derive VTXO receive "+
+					"script: %v",
 				err,
 			)
 		}
 
-		return txscript.PayToTaprootScript(tapKey)
+		return pkScript, nil
 
 	case *daemonrpc.Output_PkScript:
 		if len(d.PkScript) == 0 {

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -1928,12 +1928,25 @@ func (s *Server) initOORActor(ctx context.Context,
 			finalCheckpoints []*psbt.Packet) (
 			oor.IncomingVTXOMetadata, error) {
 
-			// Derive chain depth from checkpoint
-			// count. Each OOR hop adds one checkpoint.
+			// Derive metadata from the Ark PSBT.
+			// The commitment tx is the parent of
+			// the sender's VTXO (first input).
+			var commitTxID chainhash.Hash
+			roundID := chainhash.Hash(sessionID).String()
+
+			if ark != nil && ark.UnsignedTx != nil &&
+				len(ark.UnsignedTx.TxIn) > 0 {
+
+				commitTxID = ark.UnsignedTx.TxIn[0].
+					PreviousOutPoint.Hash
+			}
+
 			chainDepth := len(finalCheckpoints)
 
 			return oor.IncomingVTXOMetadata{
-				ChainDepth: chainDepth,
+				RoundID:        roundID,
+				CommitmentTxID: commitTxID,
+				ChainDepth:     chainDepth,
 			}, nil
 		},
 	}

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -1862,6 +1862,9 @@ func (s *Server) initOORActor(ctx context.Context,
 		Next:         signingHandler,
 		Store:        vtxoStore,
 		PackageStore: packageStore,
+		// TODO(roasbeef): populate OperatorKey and ExitDelay
+		// from the operator terms once key derivation stores
+		// them on the Server struct.
 		NotifyIncomingVTXOs: func(ctx context.Context,
 			descs []*vtxo.Descriptor) error {
 
@@ -1873,6 +1876,9 @@ func (s *Server) initOORActor(ctx context.Context,
 			)
 		},
 		CompleteSpend: completeSpend,
+		// TODO(roasbeef): wire ResolveIncomingClientKey and
+		// ResolveIncomingMetadata once the operator terms
+		// and client key descriptor are stored on Server.
 	}
 
 	s.oorActor = oor.NewOORClientActor(oor.ClientActorCfg{

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -147,6 +147,21 @@ type Server struct {
 	// mode it is derived from the config's network string.
 	chainParams *chaincfg.Params
 
+	// operatorKey is the operator's public key from GetInfo.
+	// Used by the OOR receive path for checkpoint leaf
+	// construction.
+	operatorKey *btcec.PublicKey
+
+	// vtxoExitDelay is the operator's VTXO exit delay from
+	// GetInfo. Used by the OOR receive path for VTXO descriptor
+	// construction.
+	vtxoExitDelay uint32
+
+	// clientKeyDesc is the client's identity key descriptor,
+	// derived during wallet initialization. Used by the OOR
+	// receive path to match incoming recipient outputs.
+	clientKeyDesc keychain.KeyDescriptor
+
 	runtime *serverconn.Runtime
 	ark     *arkrpc.ArkServiceMailboxClient
 	indexer *indexer.Client
@@ -1515,6 +1530,19 @@ func (s *Server) initRPCClients(ctx context.Context) {
 	var identityPubkey string
 	s.lnd.WhenSome(func(lndSvc *lndclient.GrpcLndServices) {
 		identityPubkey = lndSvc.NodePubkey.String()
+
+		// Store the client key descriptor for OOR
+		// incoming transfer resolution. Parse the
+		// LND node pubkey (route.Vertex) into a
+		// btcec public key.
+		nodePub, parseErr := btcec.ParsePubKey(
+			lndSvc.NodePubkey[:],
+		)
+		if parseErr == nil {
+			s.clientKeyDesc = keychain.KeyDescriptor{
+				PubKey: nodePub,
+			}
+		}
 	})
 	s.lwWallet.WhenSome(func(w *lwwallet.Wallet) {
 		// Derive the node identity key from the wallet
@@ -1533,6 +1561,10 @@ func (s *Server) initRPCClients(ctx context.Context) {
 				"%x",
 				desc.PubKey.SerializeCompressed(),
 			)
+
+			// Store the client key descriptor for
+			// OOR incoming transfer resolution.
+			s.clientKeyDesc = *desc
 		}
 	})
 
@@ -1679,6 +1711,10 @@ func (s *Server) initRoundActor(ctx context.Context,
 		return nil, fmt.Errorf("unable to fetch operator "+
 			"terms: %w", err)
 	}
+
+	// Store operator terms on Server for the OOR receive path.
+	s.operatorKey = operatorTerms.PubKey
+	s.vtxoExitDelay = operatorTerms.VTXOExitDelay
 
 	// Default maximum operator fee the client is willing to pay
 	// per round. This is a safety limit to prevent the client
@@ -1862,9 +1898,8 @@ func (s *Server) initOORActor(ctx context.Context,
 		Next:         signingHandler,
 		Store:        vtxoStore,
 		PackageStore: packageStore,
-		// TODO(roasbeef): populate OperatorKey and ExitDelay
-		// from the operator terms once key derivation stores
-		// them on the Server struct.
+		OperatorKey: s.operatorKey,
+		ExitDelay:   s.vtxoExitDelay,
 		NotifyIncomingVTXOs: func(ctx context.Context,
 			descs []*vtxo.Descriptor) error {
 
@@ -1876,9 +1911,31 @@ func (s *Server) initOORActor(ctx context.Context,
 			)
 		},
 		CompleteSpend: completeSpend,
-		// TODO(roasbeef): wire ResolveIncomingClientKey and
-		// ResolveIncomingMetadata once the operator terms
-		// and client key descriptor are stored on Server.
+		ResolveIncomingClientKey: func(ctx context.Context,
+			recipient oor.ArkRecipientOutput) (
+			keychain.KeyDescriptor, error) {
+
+			// Single-key model: return the client's
+			// identity key for any recipient output.
+			// Multi-key support would need pkScript
+			// matching against derived keys.
+			return s.clientKeyDesc, nil
+		},
+		ResolveIncomingMetadata: func(ctx context.Context,
+			sessionID oor.SessionID,
+			recipient oor.ArkRecipientOutput,
+			ark *psbt.Packet,
+			finalCheckpoints []*psbt.Packet) (
+			oor.IncomingVTXOMetadata, error) {
+
+			// Derive chain depth from checkpoint
+			// count. Each OOR hop adds one checkpoint.
+			chainDepth := len(finalCheckpoints)
+
+			return oor.IncomingVTXOMetadata{
+				ChainDepth: chainDepth,
+			}, nil
+		},
 	}
 
 	s.oorActor = oor.NewOORClientActor(oor.ClientActorCfg{

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -14,7 +14,9 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/arkrpc"
@@ -28,6 +30,7 @@ import (
 	"github.com/lightninglabs/darepo-client/indexer"
 	"github.com/lightninglabs/darepo-client/lib/actormsg"
 	"github.com/lightninglabs/darepo-client/lib/types"
+	"github.com/lightninglabs/darepo-client/lib/tx/psbtutil"
 	"github.com/lightninglabs/darepo-client/lndbackend"
 	"github.com/lightninglabs/darepo-client/lwwallet"
 	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
@@ -1140,21 +1143,102 @@ func (s *Server) registerOOREventRoutes(router *serverconn.EventRouter) {
 
 	// IncomingOOR: server notifies the client about an incoming
 	// OOR transfer via the indexer's ArkService. The
-	// IncomingOOREvent is a lightweight notification hint — the
-	// client needs to fetch the full Ark PSBT and checkpoint
-	// data from the server to materialize the received VTXO.
+	// IncomingOOREvent is a lightweight notification hint. The
+	// route's Adapt closure queries the indexer (via
+	// ListOORRecipientEventsByScript) to fetch the full Ark
+	// PSBT and checkpoint data needed by IncomingTransferEvent.
 	//
-	// For now, we construct a DriveEventRequest with the session
-	// ID. The IncomingTransferEvent currently requires ArkPSBT
-	// and FinalCheckpointPSBTs which must be resolved separately
-	// (e.g., via a wallet-scoped query to the indexer).
-	//
-	// TODO(roasbeef): Add full Ark PSBT resolution from the
-	// indexer's recipient event store before dispatching to the
-	// OOR FSM.
-	_ = oorKey
-	_ = arkServiceName
-	_ = MethodIncomingOOR
+	// The indexer query uses the ark mailbox client which is
+	// wired during server initialization. The query response
+	// now includes ark_psbt and checkpoint_psbts fields.
+	idxClient := s.indexer
+	serverconn.AddRoute(router, serverconn.EventRouteConfig[
+		oor.OORDurableMsg, oor.ActorResp,
+	]{
+		Service: arkServiceName,
+		Method:  MethodIncomingOOR,
+		NewEvent: func() proto.Message {
+			return &arkrpc.IncomingOOREvent{}
+		},
+		Key: oorKey,
+		Adapt: func(p proto.Message) (
+			oor.OORDurableMsg, error) {
+
+			evt, ok := p.(*arkrpc.IncomingOOREvent)
+			if !ok {
+				return nil, fmt.Errorf(
+					"expected IncomingOOREvent"+
+						", got %T", p,
+				)
+			}
+
+			sessionID, err := chainhash.NewHash(
+				evt.GetSessionId(),
+			)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"parse session id: %w", err,
+				)
+			}
+
+			// Query the indexer for the full package
+			// data. The notification is just a hint.
+			resp, err := idxClient.ListOORRecipientEventsByScriptTaproot(
+				context.Background(),
+				evt.GetRecipientPkScript(),
+				evt.GetRecipientEventId()-1,
+				1,
+			)
+			if err != nil || len(resp.GetEvents()) == 0 {
+				return nil, fmt.Errorf(
+					"fetch OOR package for session "+
+						"%x: %w",
+					sessionID[:], err,
+				)
+			}
+
+			recipientEvt := resp.Events[0]
+
+			// Parse the Ark PSBT from the response.
+			arkPSBT, parseErr := psbtutil.Parse(
+				recipientEvt.GetArkPsbt(),
+			)
+			if parseErr != nil {
+				return nil, fmt.Errorf(
+					"parse ark psbt: %w", parseErr,
+				)
+			}
+
+			// Parse checkpoint PSBTs.
+			var checkpoints []*psbt.Packet
+			for _, cpRaw := range recipientEvt.GetCheckpointPsbts() {
+				cp, cpErr := psbtutil.Parse(cpRaw)
+				if cpErr != nil {
+					return nil, fmt.Errorf(
+						"parse checkpoint: %w",
+						cpErr,
+					)
+				}
+
+				checkpoints = append(
+					checkpoints, cp,
+				)
+			}
+
+			return &oor.DriveEventRequest{
+				SessionID: oor.SessionID(
+					*sessionID,
+				),
+				Event: &oor.IncomingTransferEvent{
+					SessionID: oor.SessionID(
+						*sessionID,
+					),
+					ArkPSBT: arkPSBT,
+					FinalCheckpointPSBTs: checkpoints,
+				},
+			}, nil
+		},
+	})
 
 	// TODO(roasbeef): Register an IncomingAck route once the
 	// oorpb proto defines an ack RPC. SendIncomingAckRequest is

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -156,14 +156,8 @@ type Server struct {
 	vtxoExitDelay uint32
 
 	// clientKeyDesc is the client's identity key descriptor,
-	// derived during wallet initialization. Used by the OOR
-	// receive path to match incoming recipient outputs.
+	// derived during wallet initialization.
 	clientKeyDesc keychain.KeyDescriptor
-
-	// oorReceiveKeyDesc is the stable wallet key used for the
-	// daemon's default OOR receive script and receive-script proof
-	// signing.
-	oorReceiveKeyDesc keychain.KeyDescriptor
 
 	runtime *serverconn.Runtime
 	ark     *arkrpc.ArkServiceMailboxClient
@@ -468,6 +462,9 @@ func (s *Server) run(ctx context.Context,
 	connCfg.ProtocolVersion = 1
 	connCfg.Store = s.deliveryStore
 	connCfg.Dispatchers = dispatchers
+	connCfg.DurableUnaryBuilder = &serverDurableUnaryBuilder{
+		server: s,
+	}
 
 	s.runtime, err = serverconn.NewRuntime(connCfg)
 	if err != nil {
@@ -1181,7 +1178,7 @@ func (s *Server) registerOOREventRoutes(router *serverconn.EventRouter) {
 			p proto.Message) (oor.OORDurableMsg, error) {
 
 			if env == nil || env.Rpc == nil {
-				return nil, fmt.Errorf("incoming metadata "+
+				return nil, fmt.Errorf("incoming metadata " +
 					"response envelope must be provided")
 			}
 
@@ -1225,6 +1222,70 @@ func (s *Server) registerOOREventRoutes(router *serverconn.EventRouter) {
 				Event: &oor.IncomingMetadataResolvedEvent{
 					Matches: matches,
 				},
+			}, nil
+		},
+	})
+
+	// ListOORRecipientEventsByScript response: server resolved the
+	// lightweight incoming transfer hint into the full Ark package for a
+	// durable OOR receive session query.
+	serverconn.AddEnvelopeRoute(router, serverconn.EnvelopeRouteConfig[
+		oor.OORDurableMsg, oor.ActorResp,
+	]{
+		Service: "arkrpc.IndexerService",
+		Method:  "ListOORRecipientEventsByScript",
+		NewEvent: func() proto.Message {
+			return &arkrpc.ListOORRecipientEventsByScriptResponse{}
+		},
+		Key: oorKey,
+		Adapt: func(env *mailboxpb.Envelope,
+			p proto.Message) (oor.OORDurableMsg, error) {
+
+			if env == nil || env.Rpc == nil {
+				return nil, fmt.Errorf("incoming resolve " +
+					"response envelope must be provided")
+			}
+
+			sessionID, recipientEventID, err :=
+				oor.ParseIncomingResolveCorrelationID(
+					env.Rpc.CorrelationId,
+				)
+			if err != nil {
+				return nil, err
+			}
+
+			if rpcErr := mailboxrpc.DecodeErrorHeaders(
+				env.Headers,
+			); rpcErr != nil {
+
+				return &oor.DriveEventRequest{
+					SessionID: sessionID,
+					Event: &oor.FailEvent{
+						Reason: fmt.Sprintf(
+							"resolve incoming transfer: %v",
+							rpcErr,
+						),
+					},
+				}, nil
+			}
+
+			resp, ok := p.(*arkrpc.ListOORRecipientEventsByScriptResponse)
+			if !ok {
+				return nil, fmt.Errorf("expected "+
+					"ListOORRecipientEventsByScriptResponse, "+
+					"got %T", p)
+			}
+
+			incomingEvent, err := oor.IncomingTransferEventFromResponse(
+				sessionID, recipientEventID, resp,
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			return &oor.DriveEventRequest{
+				SessionID: sessionID,
+				Event:     incomingEvent,
 			}, nil
 		},
 	})
@@ -1536,6 +1597,11 @@ func (s *Server) initRPCClients(ctx context.Context) {
 	// In lnd mode this comes from the lnd connection. In lwwallet
 	// mode, the identity is derived from the wallet keyring once
 	// the wallet is ready.
+	//
+	// The indexer client itself must prove control over multiple owned
+	// receive scripts, so it uses a dynamic signer that resolves the
+	// correct wallet key from the persisted owned-script map for each
+	// pkScript.
 	var signer indexer.SchnorrSigner
 	s.lnd.WhenSome(func(lndSvc *lndclient.GrpcLndServices) {
 		identityDesc, err := lndSvc.WalletKit.DeriveKey(ctx,
@@ -1552,27 +1618,13 @@ func (s *Server) initRPCClients(ctx context.Context) {
 		}
 
 		s.clientKeyDesc = *identityDesc
-
-		receiveDesc, err := EnsureDefaultOORReceiveKey(
-			ctx, packageStore, func(ctx context.Context) (
-				*keychain.KeyDescriptor, error,
-			) {
-				return lndSvc.WalletKit.DeriveNextKey(
-					ctx, int32(DefaultOORReceiveKeyFamily()),
+		signer = NewOwnedReceiveScriptSigner(
+			packageStore,
+			func(keyDesc keychain.KeyDescriptor) indexer.SchnorrSigner {
+				return indexer.NewLNDSchnorrSigner(
+					lndSvc.Signer, keyDesc,
 				)
 			},
-		)
-		if err != nil {
-			log.WarnS(ctx,
-				"Unable to resolve default OOR receive key",
-				err)
-
-			return
-		}
-
-		s.oorReceiveKeyDesc = *receiveDesc
-		signer = indexer.NewLNDSchnorrSigner(
-			lndSvc.Signer, *receiveDesc,
 		)
 	})
 	s.lwWallet.WhenSome(func(w *lwwallet.Wallet) {
@@ -1589,27 +1641,13 @@ func (s *Server) initRPCClients(ctx context.Context) {
 					"indexer", err)
 		} else {
 			s.clientKeyDesc = *identityDesc
-
-			receiveDesc, err := EnsureDefaultOORReceiveKey(
-				ctx, packageStore, func(ctx context.Context) (
-					*keychain.KeyDescriptor, error,
-				) {
-					return w.DeriveNextKey(
-						ctx, DefaultOORReceiveKeyFamily(),
+			signer = NewOwnedReceiveScriptSigner(
+				packageStore,
+				func(keyDesc keychain.KeyDescriptor) indexer.SchnorrSigner {
+					return indexer.NewKeyRingSchnorrSigner(
+						w.KeyRing(), keyDesc,
 					)
 				},
-			)
-			if err != nil {
-				log.WarnS(ctx,
-					"Unable to resolve default OOR "+
-						"receive key", err)
-
-				return
-			}
-
-			s.oorReceiveKeyDesc = *receiveDesc
-			signer = indexer.NewKeyRingSchnorrSigner(
-				w.KeyRing(), *receiveDesc,
 			)
 		}
 	})
@@ -1911,15 +1949,6 @@ func (s *Server) initOORActor(ctx context.Context,
 	vtxoStore := dbStore.NewVTXOStore(clk)
 	packageStore := dbStore.NewOORArtifactStore(clk)
 
-	_, err := RegisterDefaultOORReceiveScript(
-		ctx, s.indexer, packageStore, s.oorReceiveKeyDesc,
-		s.operatorKey, s.vtxoExitDelay, "default-oor-receive",
-	)
-	if err != nil {
-		return fmt.Errorf("register default OOR receive "+
-			"script: %w", err)
-	}
-
 	// Create the timeout actor for scheduling retry timers. When a
 	// retry timer fires, the callback ref transforms the expiry into
 	// a DriveEventRequest and Tell's it back to the OOR actor.
@@ -1997,54 +2026,6 @@ func (s *Server) initOORActor(ctx context.Context,
 		ActorID:       oor.OORActorServiceKeyName,
 		VTXOManager:   vtxoManagerRef,
 		VTXOStore:     vtxoStore,
-		IncomingFetcher: func(ctx context.Context,
-			pkScript []byte, afterEventID uint64,
-			limit uint32) (
-			*arkrpc.ListOORRecipientEventsByScriptResponse,
-			error) {
-
-			return s.indexer.ListOORRecipientEventsByScriptTaproot(
-				ctx, pkScript, afterEventID, limit,
-			)
-		},
-		BuildIncomingMetadataRPC: func(ctx context.Context,
-			req *oor.QueryIncomingMetadataRequest) (
-			*serverconn.SendUnaryRequest, error) {
-
-			if req == nil {
-				return nil, fmt.Errorf("incoming metadata query "+
-					"must be provided")
-			}
-
-			scopes := make([]indexer.TaprootScriptScope, 0,
-				len(req.Recipients))
-			for i := range req.Recipients {
-				scopes = append(scopes, indexer.TaprootScriptScope{
-					PkScript: append([]byte(nil),
-						req.Recipients[i].PkScript...),
-				})
-			}
-
-			rpcReq, err := s.indexer.
-				BuildListVTXOsByScriptsTaprootRequest(
-					ctx, scopes, 0,
-					incomingMetadataIndexPageSize, nil,
-				)
-			if err != nil {
-				return nil, err
-			}
-
-			return serverconn.NewSendUnaryRequest(
-				mailboxrpc.ServiceMethod{
-					Service: "arkrpc.IndexerService",
-					Method:  "ListVTXOsByScripts",
-				},
-				rpcReq,
-				oor.IncomingMetadataCorrelationID(
-				req.SessionID,
-				),
-			)
-		},
 	})
 
 	// Wire the timeout callback ref using the registered service

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -78,6 +78,16 @@ const (
 	WalletStateReady
 )
 
+const (
+	// arkServiceName is the protobuf service name for ArkService
+	// events pushed by the server indexer.
+	arkServiceName = "arkrpc.ArkService"
+
+	// MethodIncomingOOR is the routing method name for incoming
+	// OOR transfer notifications pushed by the server indexer.
+	MethodIncomingOOR = "IncomingOOR"
+)
+
 // Main is the true entry point for the daemon. It is called after CLI flag
 // parsing, config validation, and signal interception are complete.
 func Main(cfg *Config, interceptor signal.Interceptor) error {
@@ -1127,6 +1137,24 @@ func (s *Server) registerOOREventRoutes(router *serverconn.EventRouter) {
 			}, nil
 		},
 	})
+
+	// IncomingOOR: server notifies the client about an incoming
+	// OOR transfer via the indexer's ArkService. The
+	// IncomingOOREvent is a lightweight notification hint — the
+	// client needs to fetch the full Ark PSBT and checkpoint
+	// data from the server to materialize the received VTXO.
+	//
+	// For now, we construct a DriveEventRequest with the session
+	// ID. The IncomingTransferEvent currently requires ArkPSBT
+	// and FinalCheckpointPSBTs which must be resolved separately
+	// (e.g., via a wallet-scoped query to the indexer).
+	//
+	// TODO(roasbeef): Add full Ark PSBT resolution from the
+	// indexer's recipient event store before dispatching to the
+	// OOR FSM.
+	_ = oorKey
+	_ = arkServiceName
+	_ = MethodIncomingOOR
 
 	// TODO(roasbeef): Register an IncomingAck route once the
 	// oorpb proto defines an ack RPC. SendIncomingAckRequest is

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -16,7 +16,6 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/arkrpc"
@@ -30,7 +29,6 @@ import (
 	"github.com/lightninglabs/darepo-client/indexer"
 	"github.com/lightninglabs/darepo-client/lib/actormsg"
 	"github.com/lightninglabs/darepo-client/lib/types"
-	"github.com/lightninglabs/darepo-client/lib/tx/psbtutil"
 	"github.com/lightninglabs/darepo-client/lndbackend"
 	"github.com/lightninglabs/darepo-client/lwwallet"
 	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
@@ -161,6 +159,11 @@ type Server struct {
 	// derived during wallet initialization. Used by the OOR
 	// receive path to match incoming recipient outputs.
 	clientKeyDesc keychain.KeyDescriptor
+
+	// oorReceiveKeyDesc is the stable wallet key used for the
+	// daemon's default OOR receive script and receive-script proof
+	// signing.
+	oorReceiveKeyDesc keychain.KeyDescriptor
 
 	runtime *serverconn.Runtime
 	ark     *arkrpc.ArkServiceMailboxClient
@@ -710,6 +713,13 @@ func (s *Server) startLwwallet(ctx context.Context,
 
 	s.lwWallet = fn.Some(w)
 
+	// Refresh the RPC clients once the wallet is available so the
+	// indexer client picks up the wallet-backed identity key and signer
+	// before any deferred wallet-dependent actors start.
+	if s.runtime != nil {
+		s.initRPCClients(ctx)
+	}
+
 	log.InfoS(ctx, "Lightweight wallet started")
 
 	s.markWalletReady()
@@ -1157,16 +1167,11 @@ func (s *Server) registerOOREventRoutes(router *serverconn.EventRouter) {
 	})
 
 	// IncomingOOR: server notifies the client about an incoming
-	// OOR transfer via the indexer's ArkService. The
-	// IncomingOOREvent is a lightweight notification hint. The
-	// route's Adapt closure queries the indexer (via
-	// ListOORRecipientEventsByScript) to fetch the full Ark
-	// PSBT and checkpoint data needed by IncomingTransferEvent.
-	//
-	// The indexer query uses the ark mailbox client which is
-	// wired during server initialization. The query response
-	// now includes ark_psbt and checkpoint_psbts fields.
-	idxClient := s.indexer
+	// OOR transfer via the indexer's ArkService. Persist only the
+	// lightweight notification hint here; the durable OOR actor
+	// performs the follow-up indexer query from its own worker
+	// context. This avoids deadlocking mailbox ingress on a unary
+	// response that must be delivered by the same runtime.
 	serverconn.AddRoute(router, serverconn.EventRouteConfig[
 		oor.OORDurableMsg, oor.ActorResp,
 	]{
@@ -1187,71 +1192,7 @@ func (s *Server) registerOOREventRoutes(router *serverconn.EventRouter) {
 				)
 			}
 
-			sessionID, err := chainhash.NewHash(
-				evt.GetSessionId(),
-			)
-			if err != nil {
-				return nil, fmt.Errorf(
-					"parse session id: %w", err,
-				)
-			}
-
-			// Query the indexer for the full package
-			// data. The notification is just a hint.
-			resp, err := idxClient.ListOORRecipientEventsByScriptTaproot(
-				context.Background(),
-				evt.GetRecipientPkScript(),
-				evt.GetRecipientEventId()-1,
-				1,
-			)
-			if err != nil || len(resp.GetEvents()) == 0 {
-				return nil, fmt.Errorf(
-					"fetch OOR package for session "+
-						"%x: %w",
-					sessionID[:], err,
-				)
-			}
-
-			recipientEvt := resp.Events[0]
-
-			// Parse the Ark PSBT from the response.
-			arkPSBT, parseErr := psbtutil.Parse(
-				recipientEvt.GetArkPsbt(),
-			)
-			if parseErr != nil {
-				return nil, fmt.Errorf(
-					"parse ark psbt: %w", parseErr,
-				)
-			}
-
-			// Parse checkpoint PSBTs.
-			var checkpoints []*psbt.Packet
-			for _, cpRaw := range recipientEvt.GetCheckpointPsbts() {
-				cp, cpErr := psbtutil.Parse(cpRaw)
-				if cpErr != nil {
-					return nil, fmt.Errorf(
-						"parse checkpoint: %w",
-						cpErr,
-					)
-				}
-
-				checkpoints = append(
-					checkpoints, cp,
-				)
-			}
-
-			return &oor.DriveEventRequest{
-				SessionID: oor.SessionID(
-					*sessionID,
-				),
-				Event: &oor.IncomingTransferEvent{
-					SessionID: oor.SessionID(
-						*sessionID,
-					),
-					ArkPSBT: arkPSBT,
-					FinalCheckpointPSBTs: checkpoints,
-				},
-			}, nil
+			return oor.NewResolveIncomingTransferRequest(evt)
 		},
 	})
 
@@ -1523,32 +1464,59 @@ func (s *Server) initDatabase(ctx context.Context) error {
 func (s *Server) initRPCClients(ctx context.Context) {
 	s.ark = arkrpc.NewArkServiceMailboxClient(s.runtime.Unary())
 
+	dbStore := db.NewStore(
+		s.db.DB, s.db.Queries, s.db.Backend(), log,
+	)
+	packageStore := dbStore.NewOORArtifactStore(clock.NewDefaultClock())
+
 	// Determine the node identity pubkey for indexer registration.
 	// In lnd mode this comes from the lnd connection. In lwwallet
 	// mode, the identity is derived from the wallet keyring once
 	// the wallet is ready.
-	var identityPubkey string
+	var signer indexer.SchnorrSigner
 	s.lnd.WhenSome(func(lndSvc *lndclient.GrpcLndServices) {
-		identityPubkey = lndSvc.NodePubkey.String()
-
-		// Store the client key descriptor for OOR
-		// incoming transfer resolution. Parse the
-		// LND node pubkey (route.Vertex) into a
-		// btcec public key.
-		nodePub, parseErr := btcec.ParsePubKey(
-			lndSvc.NodePubkey[:],
+		identityDesc, err := lndSvc.WalletKit.DeriveKey(ctx,
+			&keychain.KeyLocator{
+				Family: identityKeyFamily,
+				Index:  0,
+			},
 		)
-		if parseErr == nil {
-			s.clientKeyDesc = keychain.KeyDescriptor{
-				PubKey: nodePub,
-			}
+		if err != nil {
+			log.WarnS(ctx,
+				"Unable to derive identity key for indexer", err)
+
+			return
 		}
+
+		s.clientKeyDesc = *identityDesc
+
+		receiveDesc, err := EnsureDefaultOORReceiveKey(
+			ctx, packageStore, func(ctx context.Context) (
+				*keychain.KeyDescriptor, error,
+			) {
+				return lndSvc.WalletKit.DeriveNextKey(
+					ctx, int32(DefaultOORReceiveKeyFamily()),
+				)
+			},
+		)
+		if err != nil {
+			log.WarnS(ctx,
+				"Unable to resolve default OOR receive key",
+				err)
+
+			return
+		}
+
+		s.oorReceiveKeyDesc = *receiveDesc
+		signer = indexer.NewLNDSchnorrSigner(
+			lndSvc.Signer, *receiveDesc,
+		)
 	})
 	s.lwWallet.WhenSome(func(w *lwwallet.Wallet) {
 		// Derive the node identity key from the wallet
 		// keyring. This is safe even if the wallet isn't
 		// fully synced, as it only depends on the seed.
-		desc, err := w.DeriveKey(ctx, keychain.KeyLocator{
+		identityDesc, err := w.DeriveKey(ctx, keychain.KeyLocator{
 			Family: identityKeyFamily,
 			Index:  0,
 		})
@@ -1557,23 +1525,36 @@ func (s *Server) initRPCClients(ctx context.Context) {
 				"Unable to derive identity key for "+
 					"indexer", err)
 		} else {
-			identityPubkey = fmt.Sprintf(
-				"%x",
-				desc.PubKey.SerializeCompressed(),
-			)
+			s.clientKeyDesc = *identityDesc
 
-			// Store the client key descriptor for
-			// OOR incoming transfer resolution.
-			s.clientKeyDesc = *desc
+			receiveDesc, err := EnsureDefaultOORReceiveKey(
+				ctx, packageStore, func(ctx context.Context) (
+					*keychain.KeyDescriptor, error,
+				) {
+					return w.DeriveNextKey(
+						ctx, DefaultOORReceiveKeyFamily(),
+					)
+				},
+			)
+			if err != nil {
+				log.WarnS(ctx,
+					"Unable to resolve default OOR "+
+						"receive key", err)
+
+				return
+			}
+
+			s.oorReceiveKeyDesc = *receiveDesc
+			signer = indexer.NewKeyRingSchnorrSigner(
+				w.KeyRing(), *receiveDesc,
+			)
 		}
 	})
 
-	// TODO(roasbeef): wire SchnorrSigner from lnd backend once
-	// indexer proof-of-control is enabled in the daemon.
 	s.indexer = indexer.New(
-		s.runtime.Unary(), nil,
+		s.runtime.Unary(), signer,
 		s.cfg.Server.RemoteMailboxID,
-		identityPubkey,
+		s.cfg.Server.LocalMailboxID,
 	)
 
 	log.InfoS(ctx, "RPC clients initialized")
@@ -1867,6 +1848,15 @@ func (s *Server) initOORActor(ctx context.Context,
 	vtxoStore := dbStore.NewVTXOStore(clk)
 	packageStore := dbStore.NewOORArtifactStore(clk)
 
+	_, err := RegisterDefaultOORReceiveScript(
+		ctx, s.indexer, packageStore, s.oorReceiveKeyDesc,
+		s.operatorKey, s.vtxoExitDelay, "default-oor-receive",
+	)
+	if err != nil {
+		return fmt.Errorf("register default OOR receive "+
+			"script: %w", err)
+	}
+
 	// Create the timeout actor for scheduling retry timers. When a
 	// retry timer fires, the callback ref transforms the expiry into
 	// a DriveEventRequest and Tell's it back to the OOR actor.
@@ -1879,27 +1869,26 @@ func (s *Server) initOORActor(ctx context.Context,
 
 	// Wire spend completion through the VTXO manager so each consumed
 	// VTXO transitions to SpentState via its own FSM, rather than
-	// writing VTXOStatusSpent directly to the store.
+	// writing VTXOStatusSpent directly to the store. Use Tell rather
+	// than Ask so the OOR durable actor can commit its own delivery
+	// transaction before the VTXO actor performs follow-up DB writes.
 	mgrKey := actormsg.VTXOManagerServiceKey()
 	completeSpend := func(ctx context.Context,
 		outpoints []wire.OutPoint) error {
 
-		req := &actormsg.CompleteSpendRequest{
-			Outpoints: outpoints,
-		}
-		mgrRef := mgrKey.Ref(s.actorSystem)
-		result := mgrRef.Ask(ctx, req).Await(ctx)
-		_, err := result.Unpack()
-
-		return err
+		return mgrKey.Ref(s.actorSystem).Tell(
+			ctx, &actormsg.CompleteSpendRequest{
+				Outpoints: outpoints,
+			},
+		)
 	}
 
 	outboxHandler := &oor.LocalPersistenceOutboxHandler{
 		Next:         signingHandler,
 		Store:        vtxoStore,
 		PackageStore: packageStore,
-		OperatorKey: s.operatorKey,
-		ExitDelay:   s.vtxoExitDelay,
+		OperatorKey:  s.operatorKey,
+		ExitDelay:    s.vtxoExitDelay,
 		NotifyIncomingVTXOs: func(ctx context.Context,
 			descs []*vtxo.Descriptor) error {
 
@@ -1915,11 +1904,9 @@ func (s *Server) initOORActor(ctx context.Context,
 			recipient oor.ArkRecipientOutput) (
 			keychain.KeyDescriptor, error) {
 
-			// Single-key model: return the client's
-			// identity key for any recipient output.
-			// Multi-key support would need pkScript
-			// matching against derived keys.
-			return s.clientKeyDesc, nil
+			return ResolveOwnedReceiveScriptKey(
+				ctx, packageStore, recipient,
+			)
 		},
 		ResolveIncomingMetadata: func(ctx context.Context,
 			sessionID oor.SessionID,
@@ -1928,26 +1915,12 @@ func (s *Server) initOORActor(ctx context.Context,
 			finalCheckpoints []*psbt.Packet) (
 			oor.IncomingVTXOMetadata, error) {
 
-			// Derive metadata from the Ark PSBT.
-			// The commitment tx is the parent of
-			// the sender's VTXO (first input).
-			var commitTxID chainhash.Hash
-			roundID := chainhash.Hash(sessionID).String()
+			_ = ark
+			_ = finalCheckpoints
 
-			if ark != nil && ark.UnsignedTx != nil &&
-				len(ark.UnsignedTx.TxIn) > 0 {
-
-				commitTxID = ark.UnsignedTx.TxIn[0].
-					PreviousOutPoint.Hash
-			}
-
-			chainDepth := len(finalCheckpoints)
-
-			return oor.IncomingVTXOMetadata{
-				RoundID:        roundID,
-				CommitmentTxID: commitTxID,
-				ChainDepth:     chainDepth,
-			}, nil
+			return ResolveIncomingMetadataFromIndexer(
+				ctx, s.indexer, sessionID, recipient,
+			)
 		},
 	}
 
@@ -1960,6 +1933,17 @@ func (s *Server) initOORActor(ctx context.Context,
 		ActorSystem:   s.actorSystem,
 		ActorID:       oor.OORActorServiceKeyName,
 		VTXOManager:   vtxoManagerRef,
+		VTXOStore:     vtxoStore,
+		IncomingFetcher: func(ctx context.Context,
+			pkScript []byte, afterEventID uint64,
+			limit uint32) (
+			*arkrpc.ListOORRecipientEventsByScriptResponse,
+			error) {
+
+			return s.indexer.ListOORRecipientEventsByScriptTaproot(
+				ctx, pkScript, afterEventID, limit,
+			)
+		},
 	})
 
 	// Wire the timeout callback ref using the registered service

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -1166,6 +1166,69 @@ func (s *Server) registerOOREventRoutes(router *serverconn.EventRouter) {
 		},
 	})
 
+	// ListVTXOsByScripts response: server returned authoritative incoming
+	// metadata for a durable OOR receive session query.
+	serverconn.AddEnvelopeRoute(router, serverconn.EnvelopeRouteConfig[
+		oor.OORDurableMsg, oor.ActorResp,
+	]{
+		Service: "arkrpc.IndexerService",
+		Method:  "ListVTXOsByScripts",
+		NewEvent: func() proto.Message {
+			return &arkrpc.ListVTXOsByScriptsResponse{}
+		},
+		Key: oorKey,
+		Adapt: func(env *mailboxpb.Envelope,
+			p proto.Message) (oor.OORDurableMsg, error) {
+
+			if env == nil || env.Rpc == nil {
+				return nil, fmt.Errorf("incoming metadata "+
+					"response envelope must be provided")
+			}
+
+			sessionID, err := oor.ParseIncomingMetadataCorrelationID(
+				env.Rpc.CorrelationId,
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			if rpcErr := mailboxrpc.DecodeErrorHeaders(
+				env.Headers,
+			); rpcErr != nil {
+
+				return &oor.DriveEventRequest{
+					SessionID: sessionID,
+					Event: &oor.FailEvent{
+						Reason: fmt.Sprintf(
+							"query incoming metadata: %v",
+							rpcErr,
+						),
+					},
+				}, nil
+			}
+
+			resp, ok := p.(*arkrpc.ListVTXOsByScriptsResponse)
+			if !ok {
+				return nil, fmt.Errorf("expected "+
+					"ListVTXOsByScriptsResponse, got %T", p)
+			}
+
+			matches, err := oor.IncomingMetadataMatchesFromResponse(
+				sessionID, resp,
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			return &oor.DriveEventRequest{
+				SessionID: sessionID,
+				Event: &oor.IncomingMetadataResolvedEvent{
+					Matches: matches,
+				},
+			}, nil
+		},
+	})
+
 	// IncomingOOR: server notifies the client about an incoming
 	// OOR transfer via the indexer's ArkService. Persist only the
 	// lightweight notification hint here; the durable OOR actor
@@ -1942,6 +2005,44 @@ func (s *Server) initOORActor(ctx context.Context,
 
 			return s.indexer.ListOORRecipientEventsByScriptTaproot(
 				ctx, pkScript, afterEventID, limit,
+			)
+		},
+		BuildIncomingMetadataRPC: func(ctx context.Context,
+			req *oor.QueryIncomingMetadataRequest) (
+			*serverconn.SendUnaryRequest, error) {
+
+			if req == nil {
+				return nil, fmt.Errorf("incoming metadata query "+
+					"must be provided")
+			}
+
+			scopes := make([]indexer.TaprootScriptScope, 0,
+				len(req.Recipients))
+			for i := range req.Recipients {
+				scopes = append(scopes, indexer.TaprootScriptScope{
+					PkScript: append([]byte(nil),
+						req.Recipients[i].PkScript...),
+				})
+			}
+
+			rpcReq, err := s.indexer.
+				BuildListVTXOsByScriptsTaprootRequest(
+					ctx, scopes, 0,
+					incomingMetadataIndexPageSize, nil,
+				)
+			if err != nil {
+				return nil, err
+			}
+
+			return serverconn.NewSendUnaryRequest(
+				mailboxrpc.ServiceMethod{
+					Service: "arkrpc.IndexerService",
+					Method:  "ListVTXOsByScripts",
+				},
+				rpcReq,
+				oor.IncomingMetadataCorrelationID(
+				req.SessionID,
+				),
 			)
 		},
 	})

--- a/darepod/serverconn_builder.go
+++ b/darepod/serverconn_builder.go
@@ -1,0 +1,54 @@
+package darepod
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/lightninglabs/darepo-client/indexer"
+	"google.golang.org/protobuf/proto"
+)
+
+// serverDurableUnaryBuilder adapts the daemon's indexer proof builder to the
+// generic serverconn durable-unary builder interface.
+type serverDurableUnaryBuilder struct {
+	server *Server
+}
+
+// BuildListOORRecipientEventsByScriptRequest builds the proof-gated indexer
+// request body for one taproot recipient-event query.
+func (b *serverDurableUnaryBuilder) BuildListOORRecipientEventsByScriptRequest(
+	ctx context.Context, pkScript []byte, afterEventID uint64, limit uint32,
+) (proto.Message, error) {
+
+	if b == nil || b.server == nil || b.server.indexer == nil {
+		return nil, fmt.Errorf("indexer client not initialized")
+	}
+
+	return b.server.indexer.
+		BuildListOORRecipientEventsByScriptTaprootRequest(
+			ctx, pkScript, afterEventID, limit,
+		)
+}
+
+// BuildListVTXOsByScriptsRequest builds the proof-gated indexer request body
+// for one or more taproot VTXO scope queries.
+func (b *serverDurableUnaryBuilder) BuildListVTXOsByScriptsRequest(
+	ctx context.Context, pkScripts [][]byte, afterCursor uint64,
+	limit uint32,
+) (proto.Message, error) {
+
+	if b == nil || b.server == nil || b.server.indexer == nil {
+		return nil, fmt.Errorf("indexer client not initialized")
+	}
+
+	scopes := make([]indexer.TaprootScriptScope, 0, len(pkScripts))
+	for i := range pkScripts {
+		scopes = append(scopes, indexer.TaprootScriptScope{
+			PkScript: append([]byte(nil), pkScripts[i]...),
+		})
+	}
+
+	return b.server.indexer.BuildListVTXOsByScriptsTaprootRequest(
+		ctx, scopes, afterCursor, limit, nil,
+	)
+}

--- a/db/actordelivery/store_impl.go
+++ b/db/actordelivery/store_impl.go
@@ -633,7 +633,7 @@ func (s *Store) SaveCheckpoint(
 
 	writeTxOpts := db.WriteTxOption()
 
-	return s.db.ExecTx(
+	err := s.db.ExecTx(
 		ctx,
 		writeTxOpts,
 		func(q ActorDeliveryQueries) error {
@@ -646,6 +646,7 @@ func (s *Store) SaveCheckpoint(
 			})
 		},
 	)
+	return err
 }
 
 // LoadCheckpoint loads an FSM checkpoint for an actor.

--- a/db/interfaces.go
+++ b/db/interfaces.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"math"
 	prand "math/rand"
+	"path/filepath"
+	"runtime"
 	"time"
 
 	"github.com/btcsuite/btclog/v2"
@@ -247,6 +249,8 @@ func (t *TransactionExecutor[Q]) ExecTx(ctx context.Context,
 		return txBody(t.createQuery(tx))
 	}
 
+	callerFile, callerLine, callerFunc := txRetryCaller()
+
 	waitBeforeRetry := func(attemptNumber int) {
 		retryDelay := t.opts.randRetryDelay(attemptNumber)
 
@@ -256,6 +260,9 @@ func (t *TransactionExecutor[Q]) ExecTx(ctx context.Context,
 				"deadlock error",
 			"attempt_number", attemptNumber,
 			"delay", retryDelay,
+			"caller_file", callerFile,
+			"caller_line", callerLine,
+			"caller_func", callerFunc,
 		)
 
 		// Before we try again, we'll wait with a random backoff based
@@ -321,6 +328,43 @@ func (t *TransactionExecutor[Q]) ExecTx(ctx context.Context,
 	// If we get to this point, then we weren't able to successfully commit
 	// a tx given the max number of retries.
 	return ErrRetriesExceeded
+}
+
+// txRetryCaller returns the first caller above the db transaction helpers so
+// retry logs can identify which store method is contending on the database.
+func txRetryCaller() (string, int, string) {
+	pcs := make([]uintptr, 16)
+	n := runtime.Callers(2, pcs)
+	if n == 0 {
+		return "unknown", 0, "unknown"
+	}
+
+	frames := runtime.CallersFrames(pcs[:n])
+
+	for {
+		frame, more := frames.Next()
+
+		// Skip frames inside the db transaction helper itself.
+		if filepath.Base(frame.File) == "interfaces.go" &&
+			filepath.Base(filepath.Dir(frame.File)) == "db" {
+
+			if !more {
+				break
+			}
+
+			continue
+		}
+
+		if frame.Function != "" {
+			return filepath.Base(frame.File), frame.Line, frame.Function
+		}
+
+		if !more {
+			break
+		}
+	}
+
+	return "unknown", 0, "unknown"
 }
 
 // Backend returns the type of the database backend used.

--- a/db/vtxo_store.go
+++ b/db/vtxo_store.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -50,6 +51,11 @@ func (s *VTXOPersistenceStore) SaveVTXO(
 	writeTxOpts := WriteTxOption()
 
 	return s.db.ExecTx(ctx, writeTxOpts, func(q RoundStore) error {
+		err := s.ensureRoundExists(ctx, q, desc)
+		if err != nil {
+			return fmt.Errorf("ensure round: %w", err)
+		}
+
 		params, err := s.descriptorToInsertParams(desc)
 		if err != nil {
 			return fmt.Errorf("convert descriptor: %w", err)
@@ -57,6 +63,50 @@ func (s *VTXOPersistenceStore) SaveVTXO(
 
 		return q.InsertVTXO(ctx, params)
 	})
+}
+
+// ensureRoundExists inserts a minimal confirmed round row when a VTXO refers
+// to a remote round that this client has not otherwise persisted locally.
+func (s *VTXOPersistenceStore) ensureRoundExists(ctx context.Context,
+	q RoundStore, desc *vtxo.Descriptor) error {
+
+	if desc == nil {
+		return fmt.Errorf("descriptor must be provided")
+	}
+
+	if desc.RoundID == "" {
+		return fmt.Errorf("round id must be provided")
+	}
+
+	_, err := q.GetRound(ctx, desc.RoundID)
+	switch {
+	case err == nil:
+		return nil
+
+	case !errors.Is(err, sql.ErrNoRows):
+		return err
+	}
+
+	var confirmationHeight sql.NullInt32
+	if desc.CreatedHeight > 0 {
+		confirmationHeight = sql.NullInt32{
+			Int32: desc.CreatedHeight,
+			Valid: true,
+		}
+	}
+
+	nowUnix := s.clock.Now().Unix()
+	params := InsertRoundParams{
+		RoundID:            desc.RoundID,
+		StartHeight:        0,
+		ConfirmationHeight: confirmationHeight,
+		CommitmentTxid:     desc.CommitmentTxID[:],
+		Status:             "confirmed",
+		CreationTime:       nowUnix,
+		LastUpdateTime:     nowUnix,
+	}
+
+	return q.InsertRound(ctx, params)
 }
 
 // GetVTXO retrieves a VTXO by its outpoint. Used for actor recovery on startup.

--- a/db/vtxo_store_test.go
+++ b/db/vtxo_store_test.go
@@ -167,6 +167,68 @@ func TestVTXOPersistenceStoreSaveAndGet(t *testing.T) {
 	)
 }
 
+// TestVTXOPersistenceStoreSaveVTXOCreatesMissingRound verifies that SaveVTXO
+// creates a minimal local round row for imported OOR VTXOs whose source round
+// is otherwise unknown to the client.
+func TestVTXOPersistenceStoreSaveVTXOCreatesMissingRound(t *testing.T) {
+	t.Parallel()
+
+	vtxoStore, _, db := newVTXOStoreForTest(t)
+	ctx := t.Context()
+
+	roundID := testRoundIDDB("test-round-imported-oor")
+	desc := createTestVTXODescriptor(t, roundID, 77)
+
+	err := vtxoStore.SaveVTXO(ctx, desc)
+	require.NoError(t, err)
+
+	row, err := db.GetRound(ctx, desc.RoundID)
+	require.NoError(t, err)
+	require.Equal(t, desc.RoundID, row.RoundID)
+	require.Equal(t, "confirmed", row.Status)
+	require.True(t, row.ConfirmationHeight.Valid)
+	require.Equal(t, desc.CreatedHeight, row.ConfirmationHeight.Int32)
+	require.Equal(t, desc.CommitmentTxID[:], row.CommitmentTxid)
+	require.Nil(t, row.CommitmentTx)
+	require.Nil(t, row.VtxtTree)
+
+	fetched, err := vtxoStore.GetVTXO(ctx, desc.Outpoint)
+	require.NoError(t, err)
+	require.Equal(t, desc.RoundID, fetched.RoundID)
+}
+
+// TestVTXOPersistenceStoreSaveVTXOKeepsExistingRound verifies that SaveVTXO
+// does not overwrite richer round state when the round row already exists.
+func TestVTXOPersistenceStoreSaveVTXOKeepsExistingRound(t *testing.T) {
+	t.Parallel()
+
+	vtxoStore, roundStore, db := newVTXOStoreForTest(t)
+	ctx := t.Context()
+
+	roundID := testRoundIDDB("test-round-existing-preserved")
+	testRound := createTestRound(t, roundID)
+	state := &round.InputSigSentState{
+		RoundID:     testRound.RoundID,
+		ClientTrees: make(map[round.SignerKey]*tree.Tree),
+	}
+	err := roundStore.CommitState(ctx, testRound, state)
+	require.NoError(t, err)
+
+	before, err := db.GetRound(ctx, roundID.String())
+	require.NoError(t, err)
+
+	desc := createTestVTXODescriptor(t, roundID, 78)
+	err = vtxoStore.SaveVTXO(ctx, desc)
+	require.NoError(t, err)
+
+	after, err := db.GetRound(ctx, roundID.String())
+	require.NoError(t, err)
+	require.Equal(t, before.Status, after.Status)
+	require.Equal(t, before.CommitmentTxid, after.CommitmentTxid)
+	require.Equal(t, before.CommitmentTx, after.CommitmentTx)
+	require.Equal(t, before.VtxtTree, after.VtxtTree)
+}
+
 // TestVTXOPersistenceStoreChainDepthRoundTrip verifies that a non-zero
 // ChainDepth survives a save/load cycle through the database.
 func TestVTXOPersistenceStoreChainDepthRoundTrip(t *testing.T) {

--- a/docs/daemon_cli_guide.md
+++ b/docs/daemon_cli_guide.md
@@ -306,12 +306,20 @@ Send via out-of-round transfer (immediate, through operator).
 
 | Flag | Type | Description |
 |------|------|-------------|
-| `--to` | string | Recipient address |
+| `--to` | string | Recipient address (exactly one of `--to`, `--pubkey`, or `--pk_script`) |
+| `--pubkey` | string | Recipient 32-byte x-only pubkey hex |
+| `--pk_script` | string | Recipient raw pk_script hex |
 | `--amount` | int64 | Amount in sats |
 | `--dry_run` | bool | Validate without initiating |
 
 ```bash
 darepocli send oor --to tb1p... --amount 25000 --no-tls
+
+# Or send directly to the x-only pubkey returned by `oor receive`
+darepocli send oor --pubkey <pubkey_xonly_hex> --amount 25000 --no-tls
+
+# Or send to the exact registered taproot output script
+darepocli send oor --pk_script <pk_script_hex> --amount 25000 --no-tls
 ```
 
 #### `schema`
@@ -338,6 +346,8 @@ darepocli mcp serve --no-tls
 **Note:** Wallet management tools (create, unlock, genseed) are
 intentionally excluded from MCP to prevent sensitive material from
 transiting the protocol. Use the CLI directly for wallet operations.
+`oor_receive` is exposed over MCP because it only allocates a fresh
+wallet-derived receive target and does not reveal seed material.
 
 ## Regtest Quickstart
 

--- a/docs/daemon_cli_guide.md
+++ b/docs/daemon_cli_guide.md
@@ -216,6 +216,20 @@ Generate a new taproot boarding address for receiving on-chain funds.
 darepocli wallet newaddress --no-tls
 ```
 
+#### `oor receive`
+
+Allocate a fresh out-of-round receive script backed by a newly derived wallet
+key. The response includes the raw `pk_script_hex`, the owner's
+`pubkey_xonly_hex`, and the wallet key locator.
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--label` | string | Optional indexer registration label |
+
+```bash
+darepocli oor receive --no-tls
+```
+
 #### `vtxos list`
 
 List VTXOs known to the wallet with optional filters.

--- a/indexer/client.go
+++ b/indexer/client.go
@@ -176,6 +176,21 @@ func New(rpc mailboxrpc.RPCClient, signer SchnorrSigner,
 	return c
 }
 
+// WithSigner returns a shallow copy of the client that uses signer for
+// proof-of-control operations. This allows callers to reuse the same mailbox
+// RPC transport while switching to the wallet key that controls a specific
+// receive script.
+func (c *Client) WithSigner(signer SchnorrSigner) *Client {
+	if c == nil {
+		return nil
+	}
+
+	clone := *c
+	clone.signer = signer
+
+	return &clone
+}
+
 // firstOpt returns the first RPCOptions from opts, or the zero value
 // if none were provided. At most one option should be passed; any
 // additional options beyond the first are silently ignored.
@@ -753,11 +768,10 @@ func (c *Client) ListMyReceiveScripts(ctx context.Context,
 // script-keyed recipient event query. This enables "offline receive
 // without registration" while preventing third-party enumeration
 // (proof-of-control required).
-func (c *Client) ListOORRecipientEventsByScriptTaproot(
+func (c *Client) BuildListOORRecipientEventsByScriptTaprootRequest(
 	ctx context.Context, pkScript []byte,
-	afterEventID uint64, limit uint32,
-	opts ...mailboxrpc.RPCOptions) (
-	*arkrpc.ListOORRecipientEventsByScriptResponse, error) {
+	afterEventID uint64, limit uint32) (
+	*arkrpc.ListOORRecipientEventsByScriptRequest, error) {
 
 	if err := validateTaprootPkScript(pkScript); err != nil {
 		return nil, err
@@ -813,6 +827,26 @@ func (c *Client) ListOORRecipientEventsByScriptTaproot(
 		AfterEventId: afterEventID,
 		Limit:        limit,
 		Proof:        proofOneof,
+	}
+
+	return req, nil
+}
+
+// ListOORRecipientEventsByScriptTaproot performs a proof-gated
+// script-keyed recipient event query. This enables "offline receive
+// without registration" while preventing third-party enumeration
+// (proof-of-control required).
+func (c *Client) ListOORRecipientEventsByScriptTaproot(
+	ctx context.Context, pkScript []byte,
+	afterEventID uint64, limit uint32,
+	opts ...mailboxrpc.RPCOptions) (
+	*arkrpc.ListOORRecipientEventsByScriptResponse, error) {
+
+	req, err := c.BuildListOORRecipientEventsByScriptTaprootRequest(
+		ctx, pkScript, afterEventID, limit,
+	)
+	if err != nil {
+		return nil, err
 	}
 
 	return c.rpc.ListOORRecipientEventsByScript(ctx, req, firstOpt(opts))

--- a/indexer/client.go
+++ b/indexer/client.go
@@ -149,6 +149,11 @@ const (
 	// proofTLVTypePurpose identifies the purpose string for
 	// script-scope proofs.
 	proofTLVTypePurpose tlv.Type = 9
+
+	// proofTLVTypeOwnerPubKey identifies the compressed owner pubkey used
+	// to prove control over supported standardized receive scripts such as
+	// VTXO tapscripts.
+	proofTLVTypeOwnerPubKey tlv.Type = 10
 )
 
 // New creates an Indexer client wrapper. The signer is used for all
@@ -161,12 +166,14 @@ func New(rpc mailboxrpc.RPCClient, signer SchnorrSigner,
 		slog.String("server_id", serverID),
 		slog.String("principal", principal))
 
-	return &Client{
+	c := &Client{
 		rpc:       arkrpc.NewIndexerServiceMailboxClient(rpc),
 		signer:    signer,
 		serverID:  serverID,
 		principal: principal,
 	}
+
+	return c
 }
 
 // firstOpt returns the first RPCOptions from opts, or the zero value
@@ -190,13 +197,24 @@ func encodeProofTLV(msgType, serverID, principal, purpose string,
 	pkScript, nonce []byte,
 	issuedAt, expiresAt uint64) ([]byte, error) {
 
+	return encodeProofTLVWithOwner(
+		msgType, serverID, principal, purpose, pkScript, nil,
+		nonce, issuedAt, expiresAt,
+	)
+}
+
+// encodeProofTLVWithOwner encodes a proof message to its canonical TLV byte
+// representation and optionally commits to the script owner pubkey.
+func encodeProofTLVWithOwner(msgType, serverID, principal, purpose string,
+	pkScript, ownerPubKey, nonce []byte,
+	issuedAt, expiresAt uint64) ([]byte, error) {
+
 	proofTypeBytes := []byte(msgType)
 	version := uint32(registrationMessageVersion)
 	serverIDBytes := []byte(serverID)
 	principalBytes := []byte(principal)
 	purposeBytes := []byte(purpose)
-
-	tlvStream, err := tlv.NewStream(
+	records := []tlv.Record{
 		tlv.MakeDynamicRecord(
 			proofTLVTypeType, &proofTypeBytes,
 			tlv.SizeVarBytes(&proofTypeBytes),
@@ -236,7 +254,16 @@ func encodeProofTLV(msgType, serverID, principal, purpose string,
 			tlv.SizeVarBytes(&purposeBytes),
 			tlv.EVarBytes, tlv.DVarBytes,
 		),
-	)
+	}
+	if len(ownerPubKey) > 0 {
+		records = append(records, tlv.MakeDynamicRecord(
+			proofTLVTypeOwnerPubKey, &ownerPubKey,
+			tlv.SizeVarBytes(&ownerPubKey),
+			tlv.EVarBytes, tlv.DVarBytes,
+		))
+	}
+
+	tlvStream, err := tlv.NewStream(records...)
 	if err != nil {
 		return nil, fmt.Errorf("build TLV stream: %w", err)
 	}
@@ -261,6 +288,19 @@ type SchnorrSigner interface {
 	SignSchnorr(pkScript []byte, hash [32]byte) ([]byte, error)
 }
 
+// schnorrMessageSigner signs the canonical proof preimage with the requested
+// tag applied inside the signer.
+type schnorrMessageSigner interface {
+	SignSchnorrMessage(ctx context.Context, pkScript []byte,
+		message []byte, tag []byte) ([]byte, error)
+}
+
+// schnorrProofPubKeySource returns the owner pubkey that should be committed
+// into proofs for the given script.
+type schnorrProofPubKeySource interface {
+	ProofPubKey(pkScript []byte) (*btcec.PublicKey, error)
+}
+
 // PrivKeySchnorrSigner wraps a single btcec.PrivateKey to satisfy
 // SchnorrSigner. It ignores pkScript since it always signs with the
 // same key. Suitable for tests and single-key setups.
@@ -282,6 +322,17 @@ func (s *PrivKeySchnorrSigner) SignSchnorr(
 	return sig.Serialize(), nil
 }
 
+// ProofPubKey returns the public key corresponding to the wrapped private key.
+func (s *PrivKeySchnorrSigner) ProofPubKey(
+	_ []byte) (*btcec.PublicKey, error) {
+
+	if s.Key == nil {
+		return nil, fmt.Errorf("private key not configured")
+	}
+
+	return s.Key.PubKey(), nil
+}
+
 // proofTag returns the BIP-340 tagged hash domain separator for indexer
 // proof signatures. A fresh slice is returned each call to prevent
 // accidental mutation. This must match the server-side ProofTagHash
@@ -290,12 +341,43 @@ func proofTag() []byte {
 	return []byte("darepo/indexer/v1")
 }
 
-// schnorrSigOverMessage returns a 64-byte schnorr signature over a
-// BIP-340 tagged hash of the message. The tag provides domain separation
-// so indexer proof signatures cannot be replayed in other protocols.
-// The pkScript identifies which key the signer should use.
-func schnorrSigOverMessage(message []byte, pkScript []byte,
+// proofOwnerPubKey returns the compressed owner pubkey to include in the
+// signed TLV proof when the signer can identify it.
+func proofOwnerPubKey(pkScript []byte,
 	signer SchnorrSigner) ([]byte, error) {
+
+	pubKeySource, ok := signer.(schnorrProofPubKeySource)
+	if !ok {
+		return nil, nil
+	}
+
+	pubKey, err := pubKeySource.ProofPubKey(pkScript)
+	if err != nil {
+		return nil, err
+	}
+	if pubKey == nil {
+		return nil, nil
+	}
+
+	return pubKey.SerializeCompressed(), nil
+}
+
+// schnorrSigOverMessage returns a 64-byte schnorr signature over a
+// BIP-340 tagged hash of the message. The tag provides domain separation so
+// indexer proof signatures cannot be replayed in other protocols. The
+// pkScript identifies which key the signer should use.
+func schnorrSigOverMessage(ctx context.Context, message []byte,
+	pkScript []byte, signer SchnorrSigner) ([]byte, error) {
+
+	if signer == nil {
+		return nil, fmt.Errorf("schnorr signer not configured")
+	}
+
+	if messageSigner, ok := signer.(schnorrMessageSigner); ok {
+		return messageSigner.SignSchnorrMessage(
+			ctx, pkScript, message, proofTag(),
+		)
+	}
 
 	msgHash := chainhash.TaggedHash(proofTag(), message)
 
@@ -332,10 +414,8 @@ type TaprootScriptScope struct {
 
 // newTaprootScope builds a ScriptScope proto with a TLV-encoded
 // script-scope proof signed via the client's signer.
-func (c *Client) newTaprootScope(
-	pkScript []byte,
-	purpose string,
-) (*arkrpc.ScriptScope, error) {
+func (c *Client) newTaprootScope(ctx context.Context, pkScript []byte,
+	purpose string) (*arkrpc.ScriptScope, error) {
 
 	if err := validateTaprootPkScript(pkScript); err != nil {
 		return nil, err
@@ -346,15 +426,20 @@ func (c *Client) newTaprootScope(
 
 	now := time.Now()
 	expiresAt := now.Add(offlineReceiveProofTTL)
+	ownerPubKey, err := proofOwnerPubKey(pkScript, c.signer)
+	if err != nil {
+		return nil, err
+	}
 
 	nonce, err := randomNonce(registrationNonceBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	msgBytes, err := encodeProofTLV(
+	msgBytes, err := encodeProofTLVWithOwner(
 		scriptScopeMessageType,
-		c.serverID, c.principal, purpose, pkScript, nonce,
+		c.serverID, c.principal, purpose, pkScript, ownerPubKey,
+		nonce,
 		uint64(now.Unix()), uint64(expiresAt.Unix()),
 	)
 	if err != nil {
@@ -362,7 +447,7 @@ func (c *Client) newTaprootScope(
 	}
 
 	sig64, err := schnorrSigOverMessage(
-		msgBytes, pkScript, c.signer,
+		ctx, msgBytes, pkScript, c.signer,
 	)
 	if err != nil {
 		return nil, err
@@ -382,14 +467,14 @@ func (c *Client) newTaprootScope(
 // buildTaprootScopes converts a slice of TaprootScriptScope into
 // proto ScriptScope messages, constructing a signed proof for each
 // entry under the given purpose.
-func (c *Client) buildTaprootScopes(
-	scopes []TaprootScriptScope, purpose string,
-) ([]*arkrpc.ScriptScope, error) {
+func (c *Client) buildTaprootScopes(ctx context.Context,
+	scopes []TaprootScriptScope,
+	purpose string) ([]*arkrpc.ScriptScope, error) {
 
 	out := make([]*arkrpc.ScriptScope, 0, len(scopes))
 	for _, scope := range scopes {
 		ss, err := c.newTaprootScope(
-			scope.PkScript, purpose,
+			ctx, scope.PkScript, purpose,
 		)
 		if err != nil {
 			return nil, err
@@ -416,7 +501,7 @@ func (c *Client) ListVTXOsByScriptsTaproot(ctx context.Context,
 		slog.Int("status_filter_count", len(statusFilter)))
 
 	scriptScopes, err := c.buildTaprootScopes(
-		scopes, purposeListVTXOsByScripts,
+		ctx, scopes, purposeListVTXOsByScripts,
 	)
 	if err != nil {
 		return nil, err
@@ -429,7 +514,12 @@ func (c *Client) ListVTXOsByScriptsTaproot(ctx context.Context,
 		Limit:        limit,
 	}
 
-	return c.rpc.ListVTXOsByScripts(ctx, req, firstOpt(opts))
+	resp, err := c.rpc.ListVTXOsByScripts(ctx, req, firstOpt(opts))
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
 }
 
 // GetSubtreeByScriptsTaproot performs a proof-gated subtree query for
@@ -444,7 +534,7 @@ func (c *Client) GetSubtreeByScriptsTaproot(ctx context.Context,
 		slog.Bool("include_internal_nodes", includeInternalNodes))
 
 	scriptScopes, err := c.buildTaprootScopes(
-		scopes, purposeGetSubtreeByScripts,
+		ctx, scopes, purposeGetSubtreeByScripts,
 	)
 	if err != nil {
 		return nil, err
@@ -471,7 +561,7 @@ func (c *Client) ListVTXOEventsByScriptsTaproot(ctx context.Context,
 		slog.Int("limit", int(limit)))
 
 	scriptScopes, err := c.buildTaprootScopes(
-		scopes, purposeListVTXOEventsByScripts,
+		ctx, scopes, purposeListVTXOEventsByScripts,
 	)
 	if err != nil {
 		return nil, err
@@ -513,6 +603,12 @@ func (c *Client) RegisterReceiveScriptTaproot(ctx context.Context,
 		)
 	}
 
+	proofExpiresAt := now.Add(offlineReceiveProofTTL)
+	ownerPubKey, err := proofOwnerPubKey(pkScript, c.signer)
+	if err != nil {
+		return nil, err
+	}
+
 	// A zero time means "use server default", so we leave the
 	// field at 0 rather than casting time.Time{}.Unix() which
 	// would wrap to a huge uint64. We derive the safe value
@@ -528,18 +624,19 @@ func (c *Client) RegisterReceiveScriptTaproot(ctx context.Context,
 		return nil, err
 	}
 
-	msgBytes, err := encodeProofTLV(
+	msgBytes, err := encodeProofTLVWithOwner(
 		registrationMessageType,
 		c.serverID, c.principal,
-		purposeRegisterReceiveScript, pkScript, nonce,
-		uint64(now.Unix()), uint64(expiresAt.Unix()),
+		purposeRegisterReceiveScript, pkScript, ownerPubKey,
+		nonce,
+		uint64(now.Unix()), uint64(proofExpiresAt.Unix()),
 	)
 	if err != nil {
 		return nil, err
 	}
 
 	sig64, err := schnorrSigOverMessage(
-		msgBytes, pkScript, c.signer,
+		ctx, msgBytes, pkScript, c.signer,
 	)
 	if err != nil {
 		return nil, err
@@ -579,16 +676,21 @@ func (c *Client) UnregisterReceiveScript(ctx context.Context,
 
 	now := time.Now()
 	expiresAt := now.Add(offlineReceiveProofTTL)
+	ownerPubKey, err := proofOwnerPubKey(pkScript, c.signer)
+	if err != nil {
+		return nil, err
+	}
 
 	nonce, err := randomNonce(registrationNonceBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	msgBytes, err := encodeProofTLV(
+	msgBytes, err := encodeProofTLVWithOwner(
 		registrationMessageType,
 		c.serverID, c.principal,
-		purposeUnregisterReceiveScript, pkScript, nonce,
+		purposeUnregisterReceiveScript, pkScript, ownerPubKey,
+		nonce,
 		uint64(now.Unix()), uint64(expiresAt.Unix()),
 	)
 	if err != nil {
@@ -596,7 +698,7 @@ func (c *Client) UnregisterReceiveScript(ctx context.Context,
 	}
 
 	sig64, err := schnorrSigOverMessage(
-		msgBytes, pkScript, c.signer,
+		ctx, msgBytes, pkScript, c.signer,
 	)
 	if err != nil {
 		return nil, err
@@ -648,16 +750,20 @@ func (c *Client) ListOORRecipientEventsByScriptTaproot(
 
 	now := time.Now()
 	expiresAt := now.Add(offlineReceiveProofTTL)
+	ownerPubKey, err := proofOwnerPubKey(pkScript, c.signer)
+	if err != nil {
+		return nil, err
+	}
 
 	nonce, err := randomNonce(registrationNonceBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	msgBytes, err := encodeProofTLV(
+	msgBytes, err := encodeProofTLVWithOwner(
 		scriptScopeMessageType,
 		c.serverID, c.principal,
-		purposeOORRecipientEvents, pkScript,
+		purposeOORRecipientEvents, pkScript, ownerPubKey,
 		nonce, uint64(now.Unix()),
 		uint64(expiresAt.Unix()),
 	)
@@ -666,7 +772,7 @@ func (c *Client) ListOORRecipientEventsByScriptTaproot(
 	}
 
 	sig64, err := schnorrSigOverMessage(
-		msgBytes, pkScript, c.signer,
+		ctx, msgBytes, pkScript, c.signer,
 	)
 	if err != nil {
 		return nil, err

--- a/indexer/client.go
+++ b/indexer/client.go
@@ -488,13 +488,12 @@ func (c *Client) buildTaprootScopes(ctx context.Context,
 
 // ListVTXOsByScriptsTaproot performs a proof-gated VTXO query for one
 // or more pkScripts.
-func (c *Client) ListVTXOsByScriptsTaproot(ctx context.Context,
+func (c *Client) BuildListVTXOsByScriptsTaprootRequest(ctx context.Context,
 	scopes []TaprootScriptScope, afterCursor uint64, limit uint32,
-	statusFilter []arkrpc.VTXOStatus,
-	opts ...mailboxrpc.RPCOptions) (
-	*arkrpc.ListVTXOsByScriptsResponse, error) {
+	statusFilter []arkrpc.VTXOStatus) (
+	*arkrpc.ListVTXOsByScriptsRequest, error) {
 
-	c.logger(ctx).TraceS(ctx, "Listing VTXOs by scripts",
+	c.logger(ctx).TraceS(ctx, "Building ListVTXOsByScripts request",
 		slog.Int("scope_count", len(scopes)),
 		slog.Uint64("after_cursor", afterCursor),
 		slog.Int("limit", int(limit)),
@@ -507,11 +506,27 @@ func (c *Client) ListVTXOsByScriptsTaproot(ctx context.Context,
 		return nil, err
 	}
 
-	req := &arkrpc.ListVTXOsByScriptsRequest{
+	return &arkrpc.ListVTXOsByScriptsRequest{
 		Scripts:      scriptScopes,
 		StatusFilter: statusFilter,
 		Cursor:       afterCursor,
 		Limit:        limit,
+	}, nil
+}
+
+// ListVTXOsByScriptsTaproot performs a proof-gated VTXO query for one
+// or more pkScripts.
+func (c *Client) ListVTXOsByScriptsTaproot(ctx context.Context,
+	scopes []TaprootScriptScope, afterCursor uint64, limit uint32,
+	statusFilter []arkrpc.VTXOStatus,
+	opts ...mailboxrpc.RPCOptions) (
+	*arkrpc.ListVTXOsByScriptsResponse, error) {
+
+	req, err := c.BuildListVTXOsByScriptsTaprootRequest(
+		ctx, scopes, afterCursor, limit, statusFilter,
+	)
+	if err != nil {
+		return nil, err
 	}
 
 	resp, err := c.rpc.ListVTXOsByScripts(ctx, req, firstOpt(opts))

--- a/indexer/client_test.go
+++ b/indexer/client_test.go
@@ -2,13 +2,19 @@ package indexer
 
 import (
 	"bytes"
+	"context"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightninglabs/darepo-client/arkrpc"
+	mailboxrpc "github.com/lightninglabs/darepo-client/mailbox/rpc"
 	"github.com/lightningnetwork/lnd/tlv"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 )
 
 // TestEncodeProofTLVRoundTrip encodes a proof and decodes it via a TLV
@@ -169,7 +175,9 @@ func TestSchnorrSigOverMessageSignVerify(t *testing.T) {
 	msg := []byte("test proof message content")
 
 	signer := &PrivKeySchnorrSigner{Key: priv}
-	sig64, err := schnorrSigOverMessage(msg, nil, signer)
+	sig64, err := schnorrSigOverMessage(
+		context.Background(), msg, nil, signer,
+	)
 	require.NoError(t, err)
 	require.Len(t, sig64, 64)
 
@@ -194,10 +202,14 @@ func TestSchnorrSigOverMessageDeterministic(t *testing.T) {
 	msg := []byte("deterministic signing test")
 
 	signer := &PrivKeySchnorrSigner{Key: priv}
-	sig1, err := schnorrSigOverMessage(msg, nil, signer)
+	sig1, err := schnorrSigOverMessage(
+		context.Background(), msg, nil, signer,
+	)
 	require.NoError(t, err)
 
-	sig2, err := schnorrSigOverMessage(msg, nil, signer)
+	sig2, err := schnorrSigOverMessage(
+		context.Background(), msg, nil, signer,
+	)
 	require.NoError(t, err)
 
 	require.Equal(t, sig1, sig2)
@@ -217,7 +229,9 @@ func TestSchnorrSigOverMessageWrongKeyFails(t *testing.T) {
 	msg := []byte("wrong key test")
 
 	signer1 := &PrivKeySchnorrSigner{Key: priv1}
-	sig64, err := schnorrSigOverMessage(msg, nil, signer1)
+	sig64, err := schnorrSigOverMessage(
+		context.Background(), msg, nil, signer1,
+	)
 	require.NoError(t, err)
 
 	// Parse and verify against the wrong key.
@@ -228,6 +242,99 @@ func TestSchnorrSigOverMessageWrongKeyFails(t *testing.T) {
 	wrongPub := priv2.PubKey()
 	require.False(t, sig.Verify(msgHash[:], wrongPub),
 		"signature must not verify with wrong key")
+}
+
+// TestSchnorrSigOverMessageUsesMessageSigner verifies that the helper prefers
+// the tagged-message signing path when it is available.
+func TestSchnorrSigOverMessageUsesMessageSigner(t *testing.T) {
+	t.Parallel()
+
+	signer := &testMessageSchnorrSigner{
+		result: []byte("message-signed"),
+	}
+	msg := []byte("message signer path")
+	pkScript := []byte{0x51, 0x20, 0x01}
+
+	sig, err := schnorrSigOverMessage(
+		context.Background(), msg, pkScript, signer,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []byte("message-signed"), sig)
+	require.Equal(t, msg, signer.message)
+	require.Equal(t, pkScript, signer.pkScript)
+	require.Equal(t, proofTag(), signer.tag)
+	require.False(t, signer.rawCalled)
+}
+
+// TestRegisterReceiveScriptTaprootUsesShortLivedProof verifies that the
+// registration proof TTL remains short even when the registration retention
+// window is much longer.
+func TestRegisterReceiveScriptTaprootUsesShortLivedProof(t *testing.T) {
+	t.Parallel()
+
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	pkScript := append(
+		[]byte{0x51, 0x20},
+		privKey.PubKey().SerializeCompressed()[1:]...,
+	)
+
+	rpcClient := &recordingRPCClient{}
+	client := New(
+		rpcClient, &PrivKeySchnorrSigner{Key: privKey},
+		"test-server", "client:test",
+	)
+
+	registrationExpiry := time.Now().Add(30 * 24 * time.Hour)
+	_, err = client.RegisterReceiveScriptTaproot(
+		t.Context(), pkScript, registrationExpiry, "oor receive",
+	)
+	require.NoError(t, err)
+
+	req := rpcClient.lastRegisterReceiveScriptRequest(t)
+	require.Equal(
+		t, uint64(registrationExpiry.Unix()), req.ExpiresAtUnixS,
+	)
+
+	decoded := decodeProofTLVBytes(
+		t, req.GetTaprootSchnorr().GetMessage(),
+	)
+	require.Equal(t, purposeRegisterReceiveScript, decoded.purpose)
+	require.Equal(t, uint64(registrationExpiry.Unix()), req.ExpiresAtUnixS)
+	require.NotEqual(t, req.ExpiresAtUnixS, decoded.expiresAt)
+	require.Equal(
+		t, uint64(offlineReceiveProofTTL/time.Second),
+		decoded.expiresAt-decoded.issuedAt,
+	)
+}
+
+type testMessageSchnorrSigner struct {
+	result    []byte
+	message   []byte
+	pkScript  []byte
+	tag       []byte
+	rawCalled bool
+}
+
+// SignSchnorr records an unexpected raw-digest call.
+func (s *testMessageSchnorrSigner) SignSchnorr(
+	_ []byte, _ [32]byte) ([]byte, error) {
+
+	s.rawCalled = true
+
+	return nil, nil
+}
+
+// SignSchnorrMessage records the canonical inputs passed by the helper.
+func (s *testMessageSchnorrSigner) SignSchnorrMessage(_ context.Context,
+	pkScript []byte, message []byte, tag []byte) ([]byte, error) {
+
+	s.message = append([]byte(nil), message...)
+	s.pkScript = append([]byte(nil), pkScript...)
+	s.tag = append([]byte(nil), tag...)
+
+	return append([]byte(nil), s.result...), nil
 }
 
 // TestValidateTaprootPkScript uses a table-driven approach to verify
@@ -339,4 +446,47 @@ func TestProofTagImmutable(t *testing.T) {
 	tag2 := proofTag()
 	require.Equal(t, original, tag2,
 		"mutating one proofTag() return must not affect the next")
+}
+
+type recordingRPCClient struct {
+	mu      sync.Mutex
+	lastReq proto.Message
+}
+
+// SendRPC records the last request and returns a static correlation pair.
+func (r *recordingRPCClient) SendRPC(_ context.Context,
+	_ mailboxrpc.ServiceMethod, req proto.Message,
+	_ mailboxrpc.RPCOptions) (mailboxrpc.SendResult, error) {
+
+	r.mu.Lock()
+	r.lastReq = proto.Clone(req)
+	r.mu.Unlock()
+
+	return mailboxrpc.SendResult{
+		CorrelationID:  "corr-1",
+		IdempotencyKey: "idemp-1",
+	}, nil
+}
+
+// AwaitRPC completes successfully with the zero-value response.
+func (r *recordingRPCClient) AwaitRPC(_ context.Context, _ string,
+	_ proto.Message) error {
+
+	return nil
+}
+
+// lastRegisterReceiveScriptRequest returns the last recorded registration
+// request.
+func (r *recordingRPCClient) lastRegisterReceiveScriptRequest(
+	t *testing.T) *arkrpc.RegisterReceiveScriptRequest {
+
+	t.Helper()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	req, ok := r.lastReq.(*arkrpc.RegisterReceiveScriptRequest)
+	require.True(t, ok)
+
+	return req
 }

--- a/indexer/security_audit_test.go
+++ b/indexer/security_audit_test.go
@@ -55,7 +55,9 @@ func TestH1_CrossPurposeProofReplay(t *testing.T) {
 	require.NoError(t, err)
 
 	signer := &PrivKeySchnorrSigner{Key: privKey}
-	sig64, err := schnorrSigOverMessage(msgBytes, pkScript, signer)
+	sig64, err := schnorrSigOverMessage(
+		context.Background(), msgBytes, pkScript, signer,
+	)
 	require.NoError(t, err)
 
 	// The attacker now takes the (msgBytes, sig64) pair -- which was
@@ -90,8 +92,9 @@ func TestH1_CrossPurposeProofReplay(t *testing.T) {
 }
 
 // TestH2_RegistrationExpiryMismatch demonstrates that the proto-level
-// ExpiresAtUnixS and the TLV-signed expiresAt can diverge if the caller
-// provides a different value.
+// ExpiresAtUnixS and the TLV-signed expiresAt intentionally diverge for
+// registrations with long retention, and that tampering the outer field widens
+// that divergence further.
 func TestH2_RegistrationExpiryMismatch(t *testing.T) {
 	t.Parallel()
 
@@ -107,13 +110,12 @@ func TestH2_RegistrationExpiryMismatch(t *testing.T) {
 	serverID := "test-server"
 	principal := "client:test"
 
-	// The caller wants the registration to expire in 1 hour.
+	// The caller wants the registration to remain registered for 1 hour.
 	callerExpiry := time.Now().Add(1 * time.Hour)
 
-	// But the TLV proof is signed with the client's own timestamp
-	// logic. In RegisterReceiveScriptTaproot, the proof's expiresAt
-	// is uint64(expiresAt.Unix()) where expiresAt = the caller arg.
-	// The proto also carries ExpiresAtUnixS = uint64(expiresAt.Unix()).
+	// The real client signs the TLV proof with a short replay window while
+	// the outer request keeps the longer registration-retention deadline.
+	proofExpiry := time.Now().Add(offlineReceiveProofTTL)
 	//
 	// Now consider: an attacker intercepts the wire proto and modifies
 	// the outer ExpiresAtUnixS to a much later time.
@@ -125,12 +127,14 @@ func TestH2_RegistrationExpiryMismatch(t *testing.T) {
 		registrationMessageType,
 		serverID, principal,
 		purposeRegisterReceiveScript, pkScript, nonce,
-		uint64(now.Unix()), uint64(callerExpiry.Unix()),
+		uint64(now.Unix()), uint64(proofExpiry.Unix()),
 	)
 	require.NoError(t, err)
 
 	signer := &PrivKeySchnorrSigner{Key: privKey}
-	sig64, err := schnorrSigOverMessage(msgBytes, pkScript, signer)
+	sig64, err := schnorrSigOverMessage(
+		context.Background(), msgBytes, pkScript, signer,
+	)
 	require.NoError(t, err)
 
 	// Build the registration request as the honest client would.
@@ -154,9 +158,8 @@ func TestH2_RegistrationExpiryMismatch(t *testing.T) {
 		callerExpiry.Add(365 * 24 * time.Hour).Unix(),
 	)
 
-	// The signature is still valid -- it signed the TLV payload
-	// which has the original expiresAt. But the request-level
-	// ExpiresAtUnixS is now 1 year later.
+	// The signature is still valid because it covers the TLV payload
+	// only. The request-level ExpiresAtUnixS is now 1 year later.
 	tlvExpiry := decodeProofTLVBytes(t, msgBytes).expiresAt
 
 	require.NotEqual(t, tamperedReq.ExpiresAtUnixS, tlvExpiry,
@@ -228,7 +231,9 @@ func TestM1_ProofReplayWithinTTL(t *testing.T) {
 	require.NoError(t, err)
 
 	signer := &PrivKeySchnorrSigner{Key: privKey}
-	sig64, err := schnorrSigOverMessage(msgBytes, pkScript, signer)
+	sig64, err := schnorrSigOverMessage(
+		context.Background(), msgBytes, pkScript, signer,
+	)
 	require.NoError(t, err)
 
 	// Replay the exact same proof 100 times. Each is
@@ -579,7 +584,9 @@ func TestH4_CrossTypeProofConfusion(t *testing.T) {
 	require.NoError(t, err)
 
 	signer := &PrivKeySchnorrSigner{Key: privKey}
-	regSig, err := schnorrSigOverMessage(regMsg, pkScript, signer)
+	regSig, err := schnorrSigOverMessage(
+		context.Background(), regMsg, pkScript, signer,
+	)
 	require.NoError(t, err)
 
 	// Package the registration proof into a ScriptScope envelope
@@ -650,7 +657,7 @@ func TestM5_PkScriptEnvelopeMismatch(t *testing.T) {
 
 	signer := &PrivKeySchnorrSigner{Key: privKey}
 	sig64, err := schnorrSigOverMessage(
-		msgBytes, ownedScript, signer,
+		context.Background(), msgBytes, ownedScript, signer,
 	)
 	require.NoError(t, err)
 
@@ -687,15 +694,16 @@ func TestM5_PkScriptEnvelopeMismatch(t *testing.T) {
 
 // decodedProof holds all fields decoded from a proof TLV message.
 type decodedProof struct {
-	proofType string
-	version   uint32
-	serverID  string
-	principal string
-	pkScript  []byte
-	issuedAt  uint64
-	expiresAt uint64
-	nonce     []byte
-	purpose   string
+	proofType   string
+	version     uint32
+	serverID    string
+	principal   string
+	pkScript    []byte
+	ownerPubKey []byte
+	issuedAt    uint64
+	expiresAt   uint64
+	nonce       []byte
+	purpose     string
 
 	// hasPurpose indicates whether the purpose field was present
 	// in the TLV stream.
@@ -716,6 +724,7 @@ func decodeProofTLVBytes(
 		serverIDBytes  []byte
 		principalBytes []byte
 		pkScript       []byte
+		ownerPubKey    []byte
 		issuedAt       uint64
 		expiresAt      uint64
 		nonce          []byte
@@ -762,6 +771,11 @@ func decodeProofTLVBytes(
 			tlv.SizeVarBytes(&purposeBytes),
 			tlv.EVarBytes, tlv.DVarBytes,
 		),
+		tlv.MakeDynamicRecord(
+			proofTLVTypeOwnerPubKey, &ownerPubKey,
+			tlv.SizeVarBytes(&ownerPubKey),
+			tlv.EVarBytes, tlv.DVarBytes,
+		),
 	)
 	require.NoError(t, err)
 
@@ -772,16 +786,17 @@ func decodeProofTLVBytes(
 	_, hasPurpose := parsedTypes[proofTLVTypePurpose]
 
 	return decodedProof{
-		proofType:  string(proofType),
-		version:    version,
-		serverID:   string(serverIDBytes),
-		principal:  string(principalBytes),
-		pkScript:   pkScript,
-		issuedAt:   issuedAt,
-		expiresAt:  expiresAt,
-		nonce:      nonce,
-		purpose:    string(purposeBytes),
-		hasPurpose: hasPurpose,
+		proofType:   string(proofType),
+		version:     version,
+		serverID:    string(serverIDBytes),
+		principal:   string(principalBytes),
+		pkScript:    pkScript,
+		ownerPubKey: ownerPubKey,
+		issuedAt:    issuedAt,
+		expiresAt:   expiresAt,
+		nonce:       nonce,
+		purpose:     string(purposeBytes),
+		hasPurpose:  hasPurpose,
 	}
 }
 
@@ -795,6 +810,7 @@ func extractPurposeFromTLVSafe(msg []byte) string {
 		serverIDBytes  []byte
 		principalBytes []byte
 		pkScript       []byte
+		ownerPubKey    []byte
 		issuedAt       uint64
 		expiresAt      uint64
 		nonce          []byte
@@ -839,6 +855,11 @@ func extractPurposeFromTLVSafe(msg []byte) string {
 		tlv.MakeDynamicRecord(
 			proofTLVTypePurpose, &purposeBytes,
 			tlv.SizeVarBytes(&purposeBytes),
+			tlv.EVarBytes, tlv.DVarBytes,
+		),
+		tlv.MakeDynamicRecord(
+			proofTLVTypeOwnerPubKey, &ownerPubKey,
+			tlv.SizeVarBytes(&ownerPubKey),
 			tlv.EVarBytes, tlv.DVarBytes,
 		),
 	)

--- a/indexer/signer_adapters.go
+++ b/indexer/signer_adapters.go
@@ -1,0 +1,172 @@
+package indexer
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/lightninglabs/lndclient"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/lnrpc/signrpc"
+)
+
+// KeyRingSchnorrSigner adapts a keychain.SecretKeyRing to SchnorrSigner for a
+// fixed key descriptor.
+type KeyRingSchnorrSigner struct {
+	keyRing keychain.SecretKeyRing
+	keyDesc keychain.KeyDescriptor
+}
+
+// NewKeyRingSchnorrSigner creates a Schnorr signer backed by a local secret
+// key ring.
+func NewKeyRingSchnorrSigner(keyRing keychain.SecretKeyRing,
+	keyDesc keychain.KeyDescriptor) *KeyRingSchnorrSigner {
+
+	return &KeyRingSchnorrSigner{
+		keyRing: keyRing,
+		keyDesc: keyDesc,
+	}
+}
+
+// SignSchnorr signs the provided 32-byte digest with the configured key.
+func (s *KeyRingSchnorrSigner) SignSchnorr(
+	_ []byte, hash [32]byte) ([]byte, error) {
+
+	if s.keyRing == nil {
+		return nil, fmt.Errorf("secret key ring not configured")
+	}
+
+	privKey, err := s.keyRing.DerivePrivKey(s.keyDesc)
+	if err != nil {
+		return nil, fmt.Errorf("derive private key: %w", err)
+	}
+
+	sig, err := schnorr.Sign(privKey, hash[:])
+	if err != nil {
+		return nil, fmt.Errorf("sign digest: %w", err)
+	}
+
+	return sig.Serialize(), nil
+}
+
+// ProofPubKey returns the configured owner pubkey.
+func (s *KeyRingSchnorrSigner) ProofPubKey(
+	_ []byte) (*btcec.PublicKey, error) {
+
+	if s.keyDesc.PubKey == nil {
+		return nil, fmt.Errorf("key descriptor pubkey not configured")
+	}
+
+	return s.keyDesc.PubKey, nil
+}
+
+// SignSchnorrMessage signs the canonical proof preimage using the key ring's
+// tagged-hash Schnorr signing path.
+func (s *KeyRingSchnorrSigner) SignSchnorrMessage(ctx context.Context,
+	_ []byte, message []byte, tag []byte) ([]byte, error) {
+
+	_ = ctx
+
+	if s.keyRing == nil {
+		return nil, fmt.Errorf("secret key ring not configured")
+	}
+
+	sig, err := s.keyRing.SignMessageSchnorr(
+		s.keyDesc.KeyLocator, message, false, nil, tag,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("sign tagged message: %w", err)
+	}
+
+	return sig.Serialize(), nil
+}
+
+// LNDSchnorrSigner adapts lnd's signrpc client to SchnorrSigner for a
+// fixed key descriptor. When TapTweak is set, signatures are produced
+// with the tweaked key (taproot output key) rather than the raw
+// internal key.
+type LNDSchnorrSigner struct {
+	signer  lndclient.SignerClient
+	keyDesc keychain.KeyDescriptor
+
+	// TapTweak is the tapscript merkle root used to tweak the
+	// internal key into the taproot output key. When nil, the
+	// raw internal key is used (keyspend-only P2TR). When set,
+	// signatures verify against P2TR(internalKey, tapTweak).
+	TapTweak []byte
+}
+
+// NewLNDSchnorrSigner creates a Schnorr signer backed by lnd signrpc.
+func NewLNDSchnorrSigner(signer lndclient.SignerClient,
+	keyDesc keychain.KeyDescriptor) *LNDSchnorrSigner {
+
+	return &LNDSchnorrSigner{
+		signer:  signer,
+		keyDesc: keyDesc,
+	}
+}
+
+// WithTapTweak returns a copy of the signer with the given tapscript
+// merkle root tweak. The resulting signer produces signatures that
+// verify against the tweaked taproot output key.
+func (s *LNDSchnorrSigner) WithTapTweak(
+	tweak []byte) *LNDSchnorrSigner {
+
+	return &LNDSchnorrSigner{
+		signer:   s.signer,
+		keyDesc:  s.keyDesc,
+		TapTweak: tweak,
+	}
+}
+
+// SignSchnorr returns an error because lnd's signrpc does not expose a raw
+// digest Schnorr signing RPC for arbitrary prehashed messages.
+func (s *LNDSchnorrSigner) SignSchnorr(
+	_ []byte, _ [32]byte) ([]byte, error) {
+
+	return nil, fmt.Errorf("raw digest schnorr signing is not supported " +
+		"by lnd signrpc")
+}
+
+// ProofPubKey returns the configured owner pubkey.
+func (s *LNDSchnorrSigner) ProofPubKey(
+	_ []byte) (*btcec.PublicKey, error) {
+
+	if s.keyDesc.PubKey == nil {
+		return nil, fmt.Errorf("key descriptor pubkey not configured")
+	}
+
+	return s.keyDesc.PubKey, nil
+}
+
+// SignSchnorrMessage signs the canonical proof preimage using lnd's tagged
+// message Schnorr signing RPC.
+func (s *LNDSchnorrSigner) SignSchnorrMessage(ctx context.Context,
+	_ []byte, message []byte, tag []byte) ([]byte, error) {
+
+	if s.signer == nil {
+		return nil, fmt.Errorf("lnd signer client not configured")
+	}
+
+	sig, err := s.signer.SignMessage(
+		ctx, message, s.keyDesc.KeyLocator,
+		lndclient.SignSchnorr(s.TapTweak),
+		withSchnorrTag(tag),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("sign tagged message via lnd: %w", err)
+	}
+
+	return sig, nil
+}
+
+// withSchnorrTag applies a BIP-340 tag to lnd's SignMessage request.
+func withSchnorrTag(tag []byte) lndclient.SignMessageOption {
+	return func(req *signrpc.SignMessageReq) {
+		req.Tag = tag
+	}
+}
+
+var _ SchnorrSigner = (*KeyRingSchnorrSigner)(nil)
+var _ SchnorrSigner = (*LNDSchnorrSigner)(nil)

--- a/lwwallet/wallet.go
+++ b/lwwallet/wallet.go
@@ -212,6 +212,12 @@ func (w *Wallet) ChainBackend() *ChainBackend {
 	return w.chainBackend
 }
 
+// KeyRing returns the wallet's secret key ring for key derivation and message
+// signing operations that need direct access to wallet-owned keys.
+func (w *Wallet) KeyRing() keychain.SecretKeyRing {
+	return w.keyRing
+}
+
 // DeriveNextKey derives the next key in the specified key family.
 // This delegates to the btcwallet-backed keyring.
 func (w *Wallet) DeriveNextKey(_ context.Context,

--- a/mailbox/conn/AGENTS.md
+++ b/mailbox/conn/AGENTS.md
@@ -1,0 +1,29 @@
+# mailbox/conn
+
+## Purpose
+
+Mailbox connection primitives shared by both `clientconn` and `serverconn`
+for envelope identity, ack state tracking, and unary response correlation.
+
+## Key Types
+
+- `ResponseRegistry` — Maps correlation IDs to unary RPC waiters and early
+  response buffers. `DeliverResponse` returns a tri-state result (`waiter`,
+  `buffered`, `dropped`) so callers can decide whether to fall back to durable
+  route dispatch for responses that arrive with no live waiter.
+- `AckState` — Four-cursor watermark state machine for ingress pull/ack.
+- `WrappedProto` — TLV-serializable wrapper for proto messages.
+- `EnvelopeIdentity` — Stable message ID and idempotency key derivation from
+  payload hash.
+
+## Relationships
+
+- **Depends on**: `mailbox/pb` (envelope proto), `mailbox/rpc` (ServiceMethod).
+- **Depended on by**: `serverconn` (ingress, UnaryFacade), `clientconn` (ingress).
+
+## Invariants
+
+- Response waiters are cleaned up after TTL expiry to prevent memory leaks.
+- Early-buffered responses are consumed exactly once when the waiter arrives.
+- The tri-state delivery result must be checked by the ingress; `buffered` means
+  the response was stored but may need durable dispatch.

--- a/mailbox/conn/CLAUDE.md
+++ b/mailbox/conn/CLAUDE.md
@@ -1,0 +1,29 @@
+# mailbox/conn
+
+## Purpose
+
+Mailbox connection primitives shared by both `clientconn` and `serverconn`
+for envelope identity, ack state tracking, and unary response correlation.
+
+## Key Types
+
+- `ResponseRegistry` — Maps correlation IDs to unary RPC waiters and early
+  response buffers. `DeliverResponse` returns a tri-state result (`waiter`,
+  `buffered`, `dropped`) so callers can decide whether to fall back to durable
+  route dispatch for responses that arrive with no live waiter.
+- `AckState` — Four-cursor watermark state machine for ingress pull/ack.
+- `WrappedProto` — TLV-serializable wrapper for proto messages.
+- `EnvelopeIdentity` — Stable message ID and idempotency key derivation from
+  payload hash.
+
+## Relationships
+
+- **Depends on**: `mailbox/pb` (envelope proto), `mailbox/rpc` (ServiceMethod).
+- **Depended on by**: `serverconn` (ingress, UnaryFacade), `clientconn` (ingress).
+
+## Invariants
+
+- Response waiters are cleaned up after TTL expiry to prevent memory leaks.
+- Early-buffered responses are consumed exactly once when the waiter arrives.
+- The tri-state delivery result must be checked by the ingress; `buffered` means
+  the response was stored but may need durable dispatch.

--- a/mailbox/conn/response_registry.go
+++ b/mailbox/conn/response_registry.go
@@ -51,6 +51,22 @@ type ResponseRegistry struct {
 	waiterTTL time.Duration
 }
 
+// DeliveryResult reports how DeliverResponse handled a response envelope.
+type DeliveryResult uint8
+
+const (
+	// DeliveryDropped indicates the response could not be stored or
+	// delivered.
+	DeliveryDropped DeliveryResult = iota
+
+	// DeliveryWaiter indicates the response completed an active waiter.
+	DeliveryWaiter
+
+	// DeliveryBuffered indicates the response was buffered because no waiter
+	// was registered yet.
+	DeliveryBuffered
+)
+
 // NewResponseRegistry constructs a response registry with stale-state cleanup.
 func NewResponseRegistry(waiterTTL time.Duration) *ResponseRegistry {
 	if waiterTTL <= 0 {
@@ -114,6 +130,14 @@ func (r *ResponseRegistry) RemoveWaiter(id CorrelationID) {
 	}
 }
 
+// RemovePending drops any buffered early response for the correlation ID.
+func (r *ResponseRegistry) RemovePending(id CorrelationID) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	delete(r.pending, id)
+}
+
 // DeliverResponse delivers a response envelope for correlation ID id.
 //
 // If a waiter exists, the promise is completed with the envelope. If a waiter
@@ -121,10 +145,10 @@ func (r *ResponseRegistry) RemoveWaiter(id CorrelationID) {
 // call still receives it.
 func (r *ResponseRegistry) DeliverResponse(
 	id CorrelationID, env *mailboxpb.Envelope,
-) bool {
+) DeliveryResult {
 
 	if env == nil {
-		return false
+		return DeliveryDropped
 	}
 
 	r.mu.Lock()
@@ -135,16 +159,16 @@ func (r *ResponseRegistry) DeliverResponse(
 	if waiter, ok := r.waiters[id]; ok {
 		waiter.Promise.Complete(fn.Ok(env))
 
-		return true
+		return DeliveryWaiter
 	}
 
 	if _, exists := r.pending[id]; exists {
-		return true
+		return DeliveryBuffered
 	}
 
 	responseCopy, ok := proto.Clone(env).(*mailboxpb.Envelope)
 	if !ok {
-		return false
+		return DeliveryDropped
 	}
 
 	r.pending[id] = &bufferedResponse{
@@ -152,7 +176,7 @@ func (r *ResponseRegistry) DeliverResponse(
 		Created:  time.Now(),
 	}
 
-	return true
+	return DeliveryBuffered
 }
 
 // pruneStaleLocked removes stale waiters and buffered responses. Stale

--- a/mailbox/conn/response_registry_property_test.go
+++ b/mailbox/conn/response_registry_property_test.go
@@ -107,10 +107,10 @@ func TestResponseRegistry_Interleavings_Property(t *testing.T) {
 					rapid.Int().Draw(rt, "msg_rand"),
 				)
 
-				ok := registry.DeliverResponse(
+				result := registry.DeliverResponse(
 					id, &mailboxpb.Envelope{MsgId: msgID},
 				)
-				if !ok {
+				if result == DeliveryDropped {
 					rt.Fatalf("delivery failed")
 				}
 

--- a/mailbox/conn/response_registry_test.go
+++ b/mailbox/conn/response_registry_test.go
@@ -20,7 +20,7 @@ func TestResponseRegistry_DeliverBeforeRegister(t *testing.T) {
 	}
 
 	delivered := registry.DeliverResponse(id, env)
-	require.True(t, delivered)
+	require.Equal(t, DeliveryBuffered, delivered)
 
 	future := registry.RegisterWaiter(id)
 
@@ -41,7 +41,7 @@ func TestResponseRegistry_RegisterThenDeliver(t *testing.T) {
 	delivered := registry.DeliverResponse(id, &mailboxpb.Envelope{
 		MsgId: "msg-2",
 	})
-	require.True(t, delivered)
+	require.Equal(t, DeliveryWaiter, delivered)
 
 	got := future.Await(t.Context()).UnwrapOrFail(t)
 	require.Equal(t, "msg-2", got.MsgId)
@@ -55,9 +55,9 @@ func TestResponseRegistry_TTLPrunesPending(t *testing.T) {
 	registry := NewResponseRegistry(5 * time.Millisecond)
 	id := CorrelationID("corr-3")
 
-	require.True(t, registry.DeliverResponse(id, &mailboxpb.Envelope{
-		MsgId: "stale",
-	}))
+	require.Equal(t, DeliveryBuffered, registry.DeliverResponse(
+		id, &mailboxpb.Envelope{MsgId: "stale"},
+	))
 
 	time.Sleep(20 * time.Millisecond)
 
@@ -114,5 +114,6 @@ func TestResponseRegistry_DeliverNilReturnsFalse(t *testing.T) {
 	t.Parallel()
 
 	registry := NewResponseRegistry(time.Minute)
-	require.False(t, registry.DeliverResponse("any", nil))
+	require.Equal(t, DeliveryDropped, registry.DeliverResponse("any",
+		nil))
 }

--- a/oor/AGENTS.md
+++ b/oor/AGENTS.md
@@ -12,14 +12,22 @@ resume semantics.
 - `Environment` — FSM environment providing SessionID and external system access.
 - `OutboxHandler` — Interface for executing FSM outbox requests (RPC, signing, persistence).
 - `SignArkPSBT` — Signs Ark PSBT inputs using the client key on the checkpoint 2-of-2 collab leaf; uses `MultiPrevOutFetcher` for correct BIP-341 sighash across multiple inputs.
-- `ClientActorCfg` — Configuration for OORClientActor (OutboxHandler, ServerConn, PackageStore, DeliveryStore, VTXOManager, IncomingFetcher).
+- `ClientActorCfg` — Configuration for OORClientActor (OutboxHandler,
+  ServerConn, PackageStore, DeliveryStore, VTXOManager).
 - `IncomingVTXOMetadata` — Lineage metadata for incoming OOR VTXOs including `ChainDepth` (OOR checkpoint hop count).
 - `OORClientActor` — Durable actor wrapping per-session state machines. Handles both outgoing transfers and incoming receive via three-phase async resolution.
-- `ResolveIncomingTransferRequest` — TLV-durable message persisted by the ingress route, resolved asynchronously by the actor via `IncomingFetcher`.
-- `IncomingOORFetcher` — Callback type for querying the indexer for full Ark PSBT data from a lightweight notification hint.
+- `ResolveIncomingTransferRequest` — TLV-durable message persisted by the
+  ingress route, resumed via a durable unary indexer query.
+- `QueryIncomingTransferRequest` / `QueryIncomingMetadataRequest` — durable
+  transport outbox events that `oor/actor.go` maps to transport-native
+  durable `serverconn` query messages after commit.
+- `serverconn.SendListOORRecipientEventsByScriptRequest` /
+  `serverconn.SendListVTXOsByScriptsRequest` — durable post-commit transport
+  messages used to resolve incoming hints and authoritative metadata.
 - `AdaptIncomingOOREvent` / `NewResolveIncomingTransferRequest` — Shared adapters for the notification→query pattern used by both darepod and systest.
 - `NewOutboxHandler` / `OutboxHandlerConfig` — Shared factory for the standard two-layer outbox handler chain (LocalPersistenceOutboxHandler → SigningOutboxHandler).
-- `ReceiveResolving` — FSM state indicating a durable hint is persisted and pending async indexer resolution.
+- `ReceiveResolving` — FSM state indicating a durable hint is persisted and
+  pending the post-commit unary indexer resolution.
 
 ## Relationships
 
@@ -32,7 +40,11 @@ resume semantics.
   - → `vtxo` manager: `VTXOsMaterializedNotification` (after incoming VTXOs are durably materialized)
 - **Receives**:
   - ← `serverconn` (via EventRouter): `SubmitAcceptedEvent`, `FinalizeAcceptedEvent`, `ResolveIncomingTransferRequest`
-  - ← self (async callback via `CallbackRef`): `DriveEventRequest{IncomingTransferEvent}`, `DriveEventRequest{IncomingHandledEvent}`
+  - ← `serverconn` durable unary response routes:
+    `DriveEventRequest{IncomingTransferEvent}`,
+    `DriveEventRequest{IncomingMetadataResolvedEvent}`
+  - ← local persistence callback path:
+    `DriveEventRequest{IncomingHandledEvent}`
   - ← API: `StartTransferRequest`, `DriveEventRequest`, `RestoreSessionRequest`, `ResumeSessionRequest`
 
 ## Invariants
@@ -43,7 +55,10 @@ resume semantics.
 - After checkpoint signature, client must resume and obtain byte-identical co-signed PSBTs (deterministic construction).
 - Transport outbox events (submit, finalize, ack) are Tell'd to ServerConn within the actor's DB transaction for atomic enqueue (same-DB tx joining via `ExecTx`).
 - Package persistence tracks finalized outgoing packages and local input bindings for recovery.
-- Incoming receive never performs synchronous unary RPCs inside the durable actor DB transaction. All indexer queries are scheduled asynchronously and delivered back as fresh durable messages.
+- Incoming receive never performs synchronous unary RPCs inside the durable
+  actor DB transaction. Both incoming-hint resolution and authoritative
+  metadata lookup are emitted as transport-native durable `serverconn`
+  query messages and delivered back as fresh durable messages.
 - `LocalPersistenceOutboxHandler.CallbackRef` receives async materialization results so indexer queries run outside the actor tx, preventing SQLite write-lock starvation.
 
 ## Deep Docs

--- a/oor/AGENTS.md
+++ b/oor/AGENTS.md
@@ -12,9 +12,14 @@ resume semantics.
 - `Environment` — FSM environment providing SessionID and external system access.
 - `OutboxHandler` — Interface for executing FSM outbox requests (RPC, signing, persistence).
 - `SignArkPSBT` — Signs Ark PSBT inputs using the client key on the checkpoint 2-of-2 collab leaf; uses `MultiPrevOutFetcher` for correct BIP-341 sighash across multiple inputs.
-- `ClientActorCfg` — Configuration for OORClientActor (OutboxHandler, ServerConn, PackageStore, DeliveryStore, VTXOManager).
+- `ClientActorCfg` — Configuration for OORClientActor (OutboxHandler, ServerConn, PackageStore, DeliveryStore, VTXOManager, IncomingFetcher).
 - `IncomingVTXOMetadata` — Lineage metadata for incoming OOR VTXOs including `ChainDepth` (OOR checkpoint hop count).
-- `OORClientActor` — Durable actor wrapping per-session state machines.
+- `OORClientActor` — Durable actor wrapping per-session state machines. Handles both outgoing transfers and incoming receive via three-phase async resolution.
+- `ResolveIncomingTransferRequest` — TLV-durable message persisted by the ingress route, resolved asynchronously by the actor via `IncomingFetcher`.
+- `IncomingOORFetcher` — Callback type for querying the indexer for full Ark PSBT data from a lightweight notification hint.
+- `AdaptIncomingOOREvent` / `NewResolveIncomingTransferRequest` — Shared adapters for the notification→query pattern used by both darepod and systest.
+- `NewOutboxHandler` / `OutboxHandlerConfig` — Shared factory for the standard two-layer outbox handler chain (LocalPersistenceOutboxHandler → SigningOutboxHandler).
+- `ReceiveResolving` — FSM state indicating a durable hint is persisted and pending async indexer resolution.
 
 ## Relationships
 
@@ -26,7 +31,8 @@ resume semantics.
   - → `wallet`: `MaterializeIncomingVTXOsRequest`
   - → `vtxo` manager: `VTXOsMaterializedNotification` (after incoming VTXOs are durably materialized)
 - **Receives**:
-  - ← `serverconn` (via EventRouter): `SubmitAcceptedEvent`, `FinalizeAcceptedEvent`, `IncomingTransferEvent`
+  - ← `serverconn` (via EventRouter): `SubmitAcceptedEvent`, `FinalizeAcceptedEvent`, `ResolveIncomingTransferRequest`
+  - ← self (async callback via `CallbackRef`): `DriveEventRequest{IncomingTransferEvent}`, `DriveEventRequest{IncomingHandledEvent}`
   - ← API: `StartTransferRequest`, `DriveEventRequest`, `RestoreSessionRequest`, `ResumeSessionRequest`
 
 ## Invariants
@@ -37,6 +43,8 @@ resume semantics.
 - After checkpoint signature, client must resume and obtain byte-identical co-signed PSBTs (deterministic construction).
 - Transport outbox events (submit, finalize, ack) are Tell'd to ServerConn within the actor's DB transaction for atomic enqueue (same-DB tx joining via `ExecTx`).
 - Package persistence tracks finalized outgoing packages and local input bindings for recovery.
+- Incoming receive never performs synchronous unary RPCs inside the durable actor DB transaction. All indexer queries are scheduled asynchronously and delivered back as fresh durable messages.
+- `LocalPersistenceOutboxHandler.CallbackRef` receives async materialization results so indexer queries run outside the actor tx, preventing SQLite write-lock starvation.
 
 ## Deep Docs
 

--- a/oor/CLAUDE.md
+++ b/oor/CLAUDE.md
@@ -12,14 +12,22 @@ resume semantics.
 - `Environment` — FSM environment providing SessionID and external system access.
 - `OutboxHandler` — Interface for executing FSM outbox requests (RPC, signing, persistence).
 - `SignArkPSBT` — Signs Ark PSBT inputs using the client key on the checkpoint 2-of-2 collab leaf; uses `MultiPrevOutFetcher` for correct BIP-341 sighash across multiple inputs.
-- `ClientActorCfg` — Configuration for OORClientActor (OutboxHandler, ServerConn, PackageStore, DeliveryStore, VTXOManager, IncomingFetcher).
+- `ClientActorCfg` — Configuration for OORClientActor (OutboxHandler,
+  ServerConn, PackageStore, DeliveryStore, VTXOManager).
 - `IncomingVTXOMetadata` — Lineage metadata for incoming OOR VTXOs including `ChainDepth` (OOR checkpoint hop count).
 - `OORClientActor` — Durable actor wrapping per-session state machines. Handles both outgoing transfers and incoming receive via three-phase async resolution.
-- `ResolveIncomingTransferRequest` — TLV-durable message persisted by the ingress route, resolved asynchronously by the actor via `IncomingFetcher`.
-- `IncomingOORFetcher` — Callback type for querying the indexer for full Ark PSBT data from a lightweight notification hint.
+- `ResolveIncomingTransferRequest` — TLV-durable message persisted by the
+  ingress route, resumed via a durable unary indexer query.
+- `QueryIncomingTransferRequest` / `QueryIncomingMetadataRequest` — durable
+  transport outbox events that `oor/actor.go` maps to transport-native
+  durable `serverconn` query messages after commit.
+- `serverconn.SendListOORRecipientEventsByScriptRequest` /
+  `serverconn.SendListVTXOsByScriptsRequest` — durable post-commit transport
+  messages used to resolve incoming hints and authoritative metadata.
 - `AdaptIncomingOOREvent` / `NewResolveIncomingTransferRequest` — Shared adapters for the notification→query pattern used by both darepod and systest.
 - `NewOutboxHandler` / `OutboxHandlerConfig` — Shared factory for the standard two-layer outbox handler chain (LocalPersistenceOutboxHandler → SigningOutboxHandler).
-- `ReceiveResolving` — FSM state indicating a durable hint is persisted and pending async indexer resolution.
+- `ReceiveResolving` — FSM state indicating a durable hint is persisted and
+  pending the post-commit unary indexer resolution.
 
 ## Relationships
 
@@ -32,7 +40,11 @@ resume semantics.
   - → `vtxo` manager: `VTXOsMaterializedNotification` (after incoming VTXOs are durably materialized)
 - **Receives**:
   - ← `serverconn` (via EventRouter): `SubmitAcceptedEvent`, `FinalizeAcceptedEvent`, `ResolveIncomingTransferRequest`
-  - ← self (async callback via `CallbackRef`): `DriveEventRequest{IncomingTransferEvent}`, `DriveEventRequest{IncomingHandledEvent}`
+  - ← `serverconn` durable unary response routes:
+    `DriveEventRequest{IncomingTransferEvent}`,
+    `DriveEventRequest{IncomingMetadataResolvedEvent}`
+  - ← local persistence callback path:
+    `DriveEventRequest{IncomingHandledEvent}`
   - ← API: `StartTransferRequest`, `DriveEventRequest`, `RestoreSessionRequest`, `ResumeSessionRequest`
 
 ## Invariants
@@ -43,7 +55,10 @@ resume semantics.
 - After checkpoint signature, client must resume and obtain byte-identical co-signed PSBTs (deterministic construction).
 - Transport outbox events (submit, finalize, ack) are Tell'd to ServerConn within the actor's DB transaction for atomic enqueue (same-DB tx joining via `ExecTx`).
 - Package persistence tracks finalized outgoing packages and local input bindings for recovery.
-- Incoming receive never performs synchronous unary RPCs inside the durable actor DB transaction. All indexer queries are scheduled asynchronously and delivered back as fresh durable messages.
+- Incoming receive never performs synchronous unary RPCs inside the durable
+  actor DB transaction. Both incoming-hint resolution and authoritative
+  metadata lookup are emitted as transport-native durable `serverconn`
+  query messages and delivered back as fresh durable messages.
 - `LocalPersistenceOutboxHandler.CallbackRef` receives async materialization results so indexer queries run outside the actor tx, preventing SQLite write-lock starvation.
 
 ## Deep Docs

--- a/oor/CLAUDE.md
+++ b/oor/CLAUDE.md
@@ -12,9 +12,14 @@ resume semantics.
 - `Environment` — FSM environment providing SessionID and external system access.
 - `OutboxHandler` — Interface for executing FSM outbox requests (RPC, signing, persistence).
 - `SignArkPSBT` — Signs Ark PSBT inputs using the client key on the checkpoint 2-of-2 collab leaf; uses `MultiPrevOutFetcher` for correct BIP-341 sighash across multiple inputs.
-- `ClientActorCfg` — Configuration for OORClientActor (OutboxHandler, ServerConn, PackageStore, DeliveryStore, VTXOManager).
+- `ClientActorCfg` — Configuration for OORClientActor (OutboxHandler, ServerConn, PackageStore, DeliveryStore, VTXOManager, IncomingFetcher).
 - `IncomingVTXOMetadata` — Lineage metadata for incoming OOR VTXOs including `ChainDepth` (OOR checkpoint hop count).
-- `OORClientActor` — Durable actor wrapping per-session state machines.
+- `OORClientActor` — Durable actor wrapping per-session state machines. Handles both outgoing transfers and incoming receive via three-phase async resolution.
+- `ResolveIncomingTransferRequest` — TLV-durable message persisted by the ingress route, resolved asynchronously by the actor via `IncomingFetcher`.
+- `IncomingOORFetcher` — Callback type for querying the indexer for full Ark PSBT data from a lightweight notification hint.
+- `AdaptIncomingOOREvent` / `NewResolveIncomingTransferRequest` — Shared adapters for the notification→query pattern used by both darepod and systest.
+- `NewOutboxHandler` / `OutboxHandlerConfig` — Shared factory for the standard two-layer outbox handler chain (LocalPersistenceOutboxHandler → SigningOutboxHandler).
+- `ReceiveResolving` — FSM state indicating a durable hint is persisted and pending async indexer resolution.
 
 ## Relationships
 
@@ -26,7 +31,8 @@ resume semantics.
   - → `wallet`: `MaterializeIncomingVTXOsRequest`
   - → `vtxo` manager: `VTXOsMaterializedNotification` (after incoming VTXOs are durably materialized)
 - **Receives**:
-  - ← `serverconn` (via EventRouter): `SubmitAcceptedEvent`, `FinalizeAcceptedEvent`, `IncomingTransferEvent`
+  - ← `serverconn` (via EventRouter): `SubmitAcceptedEvent`, `FinalizeAcceptedEvent`, `ResolveIncomingTransferRequest`
+  - ← self (async callback via `CallbackRef`): `DriveEventRequest{IncomingTransferEvent}`, `DriveEventRequest{IncomingHandledEvent}`
   - ← API: `StartTransferRequest`, `DriveEventRequest`, `RestoreSessionRequest`, `ResumeSessionRequest`
 
 ## Invariants
@@ -37,6 +43,8 @@ resume semantics.
 - After checkpoint signature, client must resume and obtain byte-identical co-signed PSBTs (deterministic construction).
 - Transport outbox events (submit, finalize, ack) are Tell'd to ServerConn within the actor's DB transaction for atomic enqueue (same-DB tx joining via `ExecTx`).
 - Package persistence tracks finalized outgoing packages and local input bindings for recovery.
+- Incoming receive never performs synchronous unary RPCs inside the durable actor DB transaction. All indexer queries are scheduled asynchronously and delivered back as fresh durable messages.
+- `LocalPersistenceOutboxHandler.CallbackRef` receives async materialization results so indexer queries run outside the actor tx, preventing SQLite write-lock starvation.
 
 ## Deep Docs
 

--- a/oor/actor.go
+++ b/oor/actor.go
@@ -2,6 +2,7 @@ package oor
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"log/slog"
 	"sort"
@@ -17,8 +18,8 @@ import (
 )
 
 const (
-	oorCheckpointStateType = "oor.outgoing.sessions"
-	oorCheckpointVersion   = 1
+	oorCheckpointStateType = "oor.sessions"
+	oorCheckpointVersion   = 2
 )
 
 // OutboxHandler executes FSM outbox requests and returns follow-up events.
@@ -69,6 +70,15 @@ type ClientActorCfg struct {
 	// VTXOManager receives notifications after incoming VTXOs are durably
 	// materialized so it can spawn VTXO actors for monitoring.
 	VTXOManager actor.TellOnlyRef[vtxo.ManagerMsg]
+
+	// VTXOStore reloads durably materialized incoming VTXOs by outpoint when
+	// a callback event is restored from the mailbox without in-memory
+	// descriptor attachments.
+	VTXOStore vtxo.VTXOStore
+
+	// IncomingFetcher resolves lightweight incoming OOR notifications into the
+	// full Ark package by querying the indexer from the actor context.
+	IncomingFetcher IncomingOORFetcher
 }
 
 // OORClientActor wraps the outgoing-transfer client FSM in a durable actor
@@ -104,6 +114,12 @@ func newOORActorCodec() *actor.MessageCodec {
 		DriveEventRequestTLVType,
 		func() actor.TLVMessage {
 			return &DriveEventRequest{}
+		},
+	)
+	codec.MustRegister(
+		ResolveIncomingTransferTLVType,
+		func() actor.TLVMessage {
+			return &ResolveIncomingTransferRequest{}
 		},
 	)
 	codec.MustRegister(
@@ -183,6 +199,13 @@ func NewOORClientActor(cfg ClientActorCfg) *OORClientActor {
 	durable := actor.NewDurableActor(durableCfg)
 	actorRef.durable = durable
 	actorRef.ref = durable.Ref()
+	behavior.selfRef = durable.Ref()
+
+	if localHandler, ok := cfg.OutboxHandler.(*LocalPersistenceOutboxHandler); ok {
+		if localHandler.CallbackRef == nil {
+			localHandler.CallbackRef = durable.Ref()
+		}
+	}
 
 	checkpoint, err := cfg.DeliveryStore.LoadCheckpoint(
 		context.Background(), cfg.ActorID,
@@ -288,6 +311,8 @@ type oorDurableBehavior struct {
 	cfg ClientActorCfg
 
 	sessions map[SessionID]*sessionHandle
+
+	selfRef actor.TellOnlyRef[OORDurableMsg]
 }
 
 // logger returns the configured logger or falls back to extracting from
@@ -312,6 +337,9 @@ func (b *oorDurableBehavior) Receive(ctx context.Context,
 
 	case *DriveEventRequest:
 		return b.handleDriveEvent(ctx, m)
+
+	case *ResolveIncomingTransferRequest:
+		return b.handleResolveIncomingTransfer(ctx, m)
 
 	case *GetStateRequest:
 		return b.handleGetState(ctx, m)
@@ -407,7 +435,10 @@ func (b *oorDurableBehavior) handleStartTransfer(ctx context.Context,
 		})
 	}
 
-	handle := &sessionHandle{FSM: session.FSM}
+	handle := &sessionHandle{
+		FSM:  session.FSM,
+		kind: sessionKindOutgoing,
+	}
 	b.sessions[session.ID] = handle
 
 	b.logger(ctx).InfoS(ctx, "OOR session created",
@@ -447,8 +478,18 @@ func (b *oorDurableBehavior) handleDriveEvent(ctx context.Context,
 
 	handle, ok := b.sessions[req.SessionID]
 	if !ok {
-		return fn.Err[ActorResp](fmt.Errorf("unknown session: %s",
-			req.SessionID))
+		incoming, isIncoming := req.Event.(*IncomingTransferEvent)
+		if !isIncoming {
+			return fn.Err[ActorResp](fmt.Errorf("unknown session: %s",
+				req.SessionID))
+		}
+
+		err := b.handleIncomingTransfer(ctx, req.SessionID, incoming)
+		if err != nil {
+			return fn.Err[ActorResp](err)
+		}
+
+		return fn.Ok[ActorResp](&DriveEventResponse{})
 	}
 
 	// If the inbound SubmitAcceptedEvent is missing the ArkPSBT (e.g.,
@@ -499,12 +540,206 @@ func (b *oorDurableBehavior) handleDriveEvent(ctx context.Context,
 		return fn.Err[ActorResp](err)
 	}
 
+	b.notifyMaterializedVTXOs(ctx, req.Event)
+
 	err = b.driveOutbox(ctx, req.SessionID, handle.FSM, outbox)
 	if err != nil {
 		return fn.Err[ActorResp](err)
 	}
 
 	return fn.Ok[ActorResp](&DriveEventResponse{})
+}
+
+// handleResolveIncomingTransfer durably records a lightweight incoming OOR
+// hint, then resolves the full Ark package asynchronously outside the live
+// durable actor transaction.
+func (b *oorDurableBehavior) handleResolveIncomingTransfer(
+	ctx context.Context,
+	req *ResolveIncomingTransferRequest) fn.Result[ActorResp] {
+
+	if req == nil {
+		return fn.Err[ActorResp](fmt.Errorf("request must be provided"))
+	}
+
+	if len(req.RecipientPkScript) == 0 {
+		return fn.Err[ActorResp](fmt.Errorf("recipient pk script must " +
+			"be provided"))
+	}
+
+	b.logger(ctx).DebugS(ctx, "Handling incoming transfer hint",
+		slog.String("session_id", req.SessionID.String()),
+		slog.Uint64("recipient_event_id", req.RecipientEventID),
+		slog.String("recipient_pk_script",
+			hex.EncodeToString(req.RecipientPkScript)))
+
+	handle, ok := b.sessions[req.SessionID]
+	if !ok {
+		session, err := newReceiveSessionWithState(
+			ctx, req.SessionID, &ReceiveResolving{
+				SessionID: req.SessionID,
+				RecipientPkScript: append(
+					[]byte(nil), req.RecipientPkScript...,
+				),
+				RecipientEventID: req.RecipientEventID,
+			},
+		)
+		if err != nil {
+			return fn.Err[ActorResp](err)
+		}
+
+		handle = &sessionHandle{
+			FSM:  session.FSM,
+			kind: sessionKindIncoming,
+		}
+		b.sessions[req.SessionID] = handle
+
+		err = b.persistCheckpoint(ctx)
+		if err != nil {
+			return fn.Err[ActorResp](err)
+		}
+	}
+
+	if handle.kind != sessionKindIncoming {
+		return fn.Err[ActorResp](fmt.Errorf("session %s is not "+
+			"incoming", req.SessionID))
+	}
+
+	state, err := handle.currentSessionState()
+	if err != nil {
+		return fn.Err[ActorResp](err)
+	}
+
+	if _, ok := state.(*ReceiveResolving); !ok {
+		b.logger(ctx).DebugS(ctx, "Ignoring duplicate incoming "+
+			"transfer hint for active session",
+			slog.String("session_id", req.SessionID.String()),
+			slog.String("state", fmt.Sprintf("%T", state)))
+
+		return fn.Ok[ActorResp](&DriveEventResponse{})
+	}
+
+	err = b.scheduleResolveIncomingTransfer(ctx, req)
+	if err != nil {
+		return fn.Err[ActorResp](err)
+	}
+
+	return fn.Ok[ActorResp](&DriveEventResponse{})
+}
+
+// scheduleResolveIncomingTransfer resolves a lightweight incoming OOR hint
+// outside the live actor transaction, then re-drives the actor with either
+// the resolved IncomingTransferEvent or a terminal FailEvent.
+func (b *oorDurableBehavior) scheduleResolveIncomingTransfer(
+	ctx context.Context,
+	req *ResolveIncomingTransferRequest) error {
+
+	if req == nil {
+		return fmt.Errorf("request must be provided")
+	}
+
+	if b.selfRef == nil {
+		return fmt.Errorf("self ref must be configured")
+	}
+
+	opCtx := actor.WithoutOutboxID(
+		actor.WithoutTx(context.WithoutCancel(ctx)),
+	)
+	sessionID := req.SessionID
+	recipientPkScript := append(
+		[]byte(nil), req.RecipientPkScript...,
+	)
+	recipientEventID := req.RecipientEventID
+
+	go func() {
+		incomingEvent, err := ResolveIncomingTransferEvent(
+			opCtx, sessionID, recipientPkScript,
+			recipientEventID, b.cfg.IncomingFetcher,
+		)
+
+		var msg *DriveEventRequest
+		if err != nil {
+			b.logger(opCtx).WarnS(opCtx,
+				"Resolve incoming transfer hint failed", err,
+				slog.String("session_id", sessionID.String()),
+				slog.Uint64("recipient_event_id",
+					recipientEventID))
+
+			msg = &DriveEventRequest{
+				SessionID: sessionID,
+				Event: &FailEvent{
+					Reason: fmt.Sprintf(
+						"resolve incoming transfer: %v", err,
+					),
+				},
+			}
+		} else {
+			b.logger(opCtx).DebugS(opCtx,
+				"Resolved incoming transfer hint",
+				slog.String("session_id", sessionID.String()),
+				slog.Int("num_checkpoints",
+					len(incomingEvent.FinalCheckpointPSBTs)))
+
+			msg = &DriveEventRequest{
+				SessionID: sessionID,
+				Event:     incomingEvent,
+			}
+		}
+
+		tellErr := b.selfRef.Tell(opCtx, msg)
+		if tellErr != nil {
+			b.logger(opCtx).WarnS(opCtx,
+				"Failed to deliver incoming resolve result",
+				tellErr,
+				slog.String("session_id", sessionID.String()))
+		}
+	}()
+
+	return nil
+}
+
+// handleIncomingTransfer drives a new incoming-transfer notification without
+// requiring a pre-existing outgoing session entry.
+//
+// Incoming notifications originate at the transport boundary, so the actor
+// must be able to materialize them the first time it sees the session ID.
+func (b *oorDurableBehavior) handleIncomingTransfer(ctx context.Context,
+	sessionID SessionID, event *IncomingTransferEvent) error {
+
+	if event == nil {
+		return fmt.Errorf("incoming event must be provided")
+	}
+
+	if event.SessionID != (SessionID{}) && event.SessionID != sessionID {
+		return fmt.Errorf("incoming event session id mismatch")
+	}
+
+	b.logger(ctx).DebugS(ctx, "Handling incoming transfer event",
+		slog.String("session_id", sessionID.String()),
+		slog.Int("num_checkpoints", len(event.FinalCheckpointPSBTs)))
+
+	session, outbox, err := DriveIncomingTransferWithCheckpoints(
+		ctx, sessionID, event.ArkPSBT, event.FinalCheckpointPSBTs,
+	)
+	if err != nil {
+		return err
+	}
+
+	b.logger(ctx).DebugS(ctx, "Incoming transfer produced outbox",
+		slog.String("session_id", session.ID.String()),
+		slog.Int("outbox_len", len(outbox)))
+
+	handle := &sessionHandle{
+		FSM:  session.FSM,
+		kind: sessionKindIncoming,
+	}
+	b.sessions[session.ID] = handle
+
+	err = b.persistCheckpoint(ctx)
+	if err != nil {
+		return err
+	}
+
+	return b.driveOutbox(ctx, session.ID, handle.FSM, outbox)
 }
 
 // enrichSubmitAcceptedArkPSBT populates a SubmitAcceptedEvent's ArkPSBT field
@@ -518,7 +753,7 @@ func (b *oorDurableBehavior) enrichSubmitAcceptedArkPSBT(
 	handle *sessionHandle,
 	event *SubmitAcceptedEvent) error {
 
-	state, err := handle.currentState()
+	state, err := handle.currentSessionState()
 	if err != nil {
 		return fmt.Errorf("get current state for ArkPSBT "+
 			"enrichment: %w", err)
@@ -632,7 +867,10 @@ func (b *oorDurableBehavior) handleRestoreSession(ctx context.Context,
 		return fn.Err[ActorResp](err)
 	}
 
-	b.sessions[session.ID] = &sessionHandle{FSM: session.FSM}
+	b.sessions[session.ID] = &sessionHandle{
+		FSM:  session.FSM,
+		kind: sessionKindOutgoing,
+	}
 
 	err = b.persistCheckpoint(ctx)
 	if err != nil {
@@ -665,7 +903,7 @@ func (b *oorDurableBehavior) handleResumeSession(ctx context.Context,
 			req.SessionID))
 	}
 
-	state, err := handle.currentState()
+	state, err := handle.currentSessionState()
 	if err != nil {
 		return fn.Err[ActorResp](err)
 	}
@@ -674,7 +912,28 @@ func (b *oorDurableBehavior) handleResumeSession(ctx context.Context,
 		slog.String("session_id", req.SessionID.String()),
 		slog.String("state", fmt.Sprintf("%T", state)))
 
-	outbox, err := OutboxForState(state)
+	if handle.kind == sessionKindIncoming {
+		if resolving, ok := state.(*ReceiveResolving); ok {
+			err = b.scheduleResolveIncomingTransfer(
+				ctx, &ResolveIncomingTransferRequest{
+					SessionID: req.SessionID,
+					RecipientPkScript: append(
+						[]byte(nil),
+						resolving.RecipientPkScript...,
+					),
+					RecipientEventID: resolving.
+						RecipientEventID,
+				},
+			)
+			if err != nil {
+				return fn.Err[ActorResp](err)
+			}
+
+			return fn.Ok[ActorResp](&ResumeSessionResponse{})
+		}
+	}
+
+	outbox, err := outboxForHandle(handle, state)
 	if err != nil {
 		return fn.Err[ActorResp](err)
 	}
@@ -703,7 +962,12 @@ func (b *oorDurableBehavior) handleExportSnapshot(ctx context.Context,
 			req.SessionID))
 	}
 
-	state, err := handle.currentState()
+	if handle.kind != sessionKindOutgoing {
+		return fn.Err[ActorResp](fmt.Errorf("export snapshot only " +
+			"supports outgoing sessions"))
+	}
+
+	state, err := handle.currentOutgoingState()
 	if err != nil {
 		return fn.Err[ActorResp](err)
 	}
@@ -734,7 +998,7 @@ func (b *oorDurableBehavior) handleGetState(ctx context.Context,
 			req.SessionID))
 	}
 
-	state, err := handle.currentState()
+	state, err := handle.currentSessionState()
 	if err != nil {
 		return fn.Err[ActorResp](err)
 	}
@@ -753,23 +1017,25 @@ func (b *oorDurableBehavior) restoreFromCheckpoint(ctx context.Context,
 		return nil
 	}
 
-	var checkpoint outgoingSessionsCheckpoint
-	checkpoint, err := decodeOutgoingSessionsCheckpoint(raw)
+	checkpoint, err := decodeSessionsCheckpoint(raw)
 	if err != nil {
 		return err
 	}
 
-	if checkpoint.Version != oorCheckpointVersion {
+	if checkpoint.Version < 1 || checkpoint.Version > oorCheckpointVersion {
 		return fmt.Errorf("unknown checkpoint version: %d",
 			checkpoint.Version)
 	}
 
 	b.logger(ctx).InfoS(ctx, "Restoring sessions from checkpoint",
 		slog.Int("checkpoint_version", checkpoint.Version),
-		slog.Int("num_snapshots", len(checkpoint.Snapshots)))
+		slog.Int("num_outgoing_snapshots",
+			len(checkpoint.OutgoingSnapshots)),
+		slog.Int("num_incoming_snapshots",
+			len(checkpoint.IncomingSnapshots)))
 
-	for i := range checkpoint.Snapshots {
-		snapshot := checkpoint.Snapshots[i]
+	for i := range checkpoint.OutgoingSnapshots {
+		snapshot := checkpoint.OutgoingSnapshots[i]
 
 		if _, exists := b.sessions[snapshot.SessionID]; exists {
 			return fmt.Errorf(
@@ -783,9 +1049,37 @@ func (b *oorDurableBehavior) restoreFromCheckpoint(ctx context.Context,
 			return err
 		}
 
-		b.sessions[session.ID] = &sessionHandle{FSM: session.FSM}
+		b.sessions[session.ID] = &sessionHandle{
+			FSM:  session.FSM,
+			kind: sessionKindOutgoing,
+		}
 
 		b.logger(ctx).DebugS(ctx, "Restored session from checkpoint",
+			slog.String("session_id", session.ID.String()))
+	}
+
+	for i := range checkpoint.IncomingSnapshots {
+		snapshot := checkpoint.IncomingSnapshots[i]
+
+		if _, exists := b.sessions[snapshot.SessionID]; exists {
+			return fmt.Errorf(
+				"duplicate session id in checkpoint: %s",
+				snapshot.SessionID,
+			)
+		}
+
+		session, err := NewReceiveSessionFromSnapshot(ctx, snapshot)
+		if err != nil {
+			return err
+		}
+
+		b.sessions[session.ID] = &sessionHandle{
+			FSM:  session.FSM,
+			kind: sessionKindIncoming,
+		}
+
+		b.logger(ctx).DebugS(ctx, "Restored incoming session "+
+			"from checkpoint",
 			slog.String("session_id", session.ID.String()))
 	}
 
@@ -812,12 +1106,40 @@ func (b *oorDurableBehavior) resumeRestoredSessions(ctx context.Context) error {
 		sessionID := sessionIDs[i]
 		handle := b.sessions[sessionID]
 
-		state, err := handle.currentState()
+		state, err := handle.currentSessionState()
 		if err != nil {
 			return err
 		}
 
-		outbox, err := OutboxForState(state)
+		if handle.kind == sessionKindIncoming {
+			if resolving, ok := state.(*ReceiveResolving); ok {
+				b.logger(ctx).DebugS(ctx, "Resuming restored "+
+					"incoming resolve",
+					slog.String("session_id",
+						sessionID.String()),
+					slog.String("state",
+						fmt.Sprintf("%T", state)))
+
+				err = b.scheduleResolveIncomingTransfer(
+					ctx, &ResolveIncomingTransferRequest{
+						SessionID: sessionID,
+						RecipientPkScript: append(
+							[]byte(nil),
+							resolving.RecipientPkScript...,
+						),
+						RecipientEventID: resolving.
+							RecipientEventID,
+					},
+				)
+				if err != nil {
+					return err
+				}
+
+				continue
+			}
+		}
+
+		outbox, err := outboxForHandle(handle, state)
 		if err != nil {
 			return err
 		}
@@ -931,6 +1253,27 @@ func (b *oorDurableBehavior) driveOutbox(ctx context.Context,
 				return err
 			}
 
+			if _, ok := msg.(*SendIncomingAckRequest); ok {
+				nextOutbox, err := b.askEvent(
+					ctx, fsm, &IncomingAckSentEvent{},
+				)
+				if err != nil {
+					return err
+				}
+
+				err = b.persistCheckpoint(ctx)
+				if err != nil {
+					return err
+				}
+
+				err = b.driveOutbox(
+					ctx, sessionID, fsm, nextOutbox,
+				)
+				if err != nil {
+					return err
+				}
+			}
+
 			continue
 		}
 
@@ -1005,7 +1348,7 @@ func (b *oorDurableBehavior) notifyMaterializedVTXOs(ctx context.Context,
 	followUp Event) {
 
 	handled, ok := followUp.(*IncomingHandledEvent)
-	if !ok || len(handled.MaterializedVTXOs) == 0 {
+	if !ok {
 		return
 	}
 
@@ -1013,17 +1356,65 @@ func (b *oorDurableBehavior) notifyMaterializedVTXOs(ctx context.Context,
 		return
 	}
 
+	descs := handled.MaterializedVTXOs
+	if len(descs) == 0 {
+		descs = b.loadMaterializedVTXOs(ctx, handled)
+	}
+
+	if len(descs) == 0 {
+		return
+	}
+
 	notification := &vtxo.VTXOsMaterializedNotification{
-		VTXOs: handled.MaterializedVTXOs,
+		VTXOs: descs,
 	}
 
 	if err := b.cfg.VTXOManager.Tell(ctx, notification); err != nil {
 		b.logger(ctx).WarnS(
 			ctx, "Failed to notify VTXO manager of "+
 				"materialized incoming VTXOs", err,
-			slog.Int("num_vtxos",
-				len(handled.MaterializedVTXOs)))
+			slog.Int("num_vtxos", len(descs)))
 	}
+}
+
+// loadMaterializedVTXOs reloads persisted incoming VTXO descriptors for a
+// callback event that only round-tripped outpoint identifiers through the
+// durable mailbox.
+func (b *oorDurableBehavior) loadMaterializedVTXOs(ctx context.Context,
+	handled *IncomingHandledEvent) []*vtxo.Descriptor {
+
+	if handled == nil || len(handled.MaterializedOutpoints) == 0 {
+		return nil
+	}
+
+	if b.cfg.VTXOStore == nil {
+		b.logger(ctx).WarnS(
+			ctx, "Missing VTXO store for incoming callback reload",
+			nil,
+			slog.Int("num_outpoints",
+				len(handled.MaterializedOutpoints)))
+
+		return nil
+	}
+
+	descs := make([]*vtxo.Descriptor, 0,
+		len(handled.MaterializedOutpoints))
+
+	for _, outpoint := range handled.MaterializedOutpoints {
+		desc, err := b.cfg.VTXOStore.GetVTXO(ctx, outpoint)
+		if err != nil {
+			b.logger(ctx).WarnS(
+				ctx, "Failed to reload materialized incoming "+
+					"VTXO for manager notification", err,
+				slog.String("outpoint", outpoint.String()))
+
+			continue
+		}
+
+		descs = append(descs, desc)
+	}
+
+	return descs
 }
 
 // persistCheckpoint snapshots every active session into a single TLV
@@ -1042,27 +1433,62 @@ func (b *oorDurableBehavior) persistCheckpoint(ctx context.Context) error {
 		return sessionIDs[i].String() < sessionIDs[j].String()
 	})
 
-	snapshots := make([]*OutgoingSnapshot, 0, len(sessionIDs))
+	outgoingSnapshots := make(
+		[]*OutgoingSnapshot, 0, len(sessionIDs),
+	)
+	incomingSnapshots := make(
+		[]*IncomingSnapshot, 0, len(sessionIDs),
+	)
 	for i := range sessionIDs {
 		sessionID := sessionIDs[i]
 		handle := b.sessions[sessionID]
 
-		state, err := handle.currentState()
+		state, err := handle.currentSessionState()
 		if err != nil {
 			return err
 		}
 
-		snapshot, err := NewOutgoingSnapshot(sessionID, state)
-		if err != nil {
-			return err
-		}
+		switch handle.kind {
+		case sessionKindOutgoing:
+			outgoingState, ok := state.(State)
+			if !ok {
+				return fmt.Errorf("unexpected outgoing state "+
+					"type: %T", state)
+			}
 
-		snapshots = append(snapshots, snapshot)
+			snapshot, err := NewOutgoingSnapshot(
+				sessionID, outgoingState,
+			)
+			if err != nil {
+				return err
+			}
+
+			outgoingSnapshots = append(
+				outgoingSnapshots, snapshot,
+			)
+
+		case sessionKindIncoming:
+			snapshot, err := NewIncomingSnapshot(
+				sessionID, state,
+			)
+			if err != nil {
+				return err
+			}
+
+			incomingSnapshots = append(
+				incomingSnapshots, snapshot,
+			)
+
+		default:
+			return fmt.Errorf("unknown session kind: %d",
+				handle.kind)
+		}
 	}
 
-	raw, err := encodeOutgoingSessionsCheckpoint(outgoingSessionsCheckpoint{
-		Version:   oorCheckpointVersion,
-		Snapshots: snapshots,
+	raw, err := encodeSessionsCheckpoint(sessionsCheckpoint{
+		Version:           oorCheckpointVersion,
+		OutgoingSnapshots: outgoingSnapshots,
+		IncomingSnapshots: incomingSnapshots,
 	})
 	if err != nil {
 		return err
@@ -1084,21 +1510,72 @@ type outgoingSessionsCheckpoint struct {
 // sessionHandle ties a session ID to its running state machine instance.
 type sessionHandle struct {
 	FSM *StateMachine
+
+	kind sessionKind
 }
 
-// currentState returns the current concrete OOR session state.
-func (h *sessionHandle) currentState() (State, error) {
+type sessionKind uint8
+
+const (
+	sessionKindOutgoing sessionKind = iota + 1
+	sessionKindIncoming
+)
+
+// currentSessionState returns the current concrete OOR session state.
+func (h *sessionHandle) currentSessionState() (SessionState, error) {
 	current, err := h.FSM.CurrentState()
 	if err != nil {
 		return nil, err
 	}
 
-	state, ok := current.(State)
+	state, ok := current.(SessionState)
 	if !ok {
 		return nil, fmt.Errorf("unexpected state type: %T", current)
 	}
 
 	return state, nil
+}
+
+// currentOutgoingState returns the current outgoing session state.
+func (h *sessionHandle) currentOutgoingState() (State, error) {
+	state, err := h.currentSessionState()
+	if err != nil {
+		return nil, err
+	}
+
+	outgoingState, ok := state.(State)
+	if !ok {
+		return nil, fmt.Errorf("unexpected outgoing state type: %T",
+			state)
+	}
+
+	return outgoingState, nil
+}
+
+// outboxForHandle returns the outbox implied by the handle's current state.
+func outboxForHandle(handle *sessionHandle,
+	state SessionState) ([]OutboxEvent, error) {
+
+	if handle == nil {
+		return nil, fmt.Errorf("session handle must be provided")
+	}
+
+	switch handle.kind {
+	case sessionKindOutgoing:
+		outgoingState, ok := state.(State)
+		if !ok {
+			return nil, fmt.Errorf("unexpected outgoing state type: %T",
+				state)
+		}
+
+		return OutboxForState(outgoingState)
+
+	case sessionKindIncoming:
+		return OutboxForIncomingState(state)
+
+	default:
+		return nil, fmt.Errorf("unknown session kind: %d", handle.kind)
+	}
 }
 
 type durableBehaviorIface = actor.ActorBehavior[

--- a/oor/actor.go
+++ b/oor/actor.go
@@ -20,6 +20,10 @@ import (
 const (
 	oorCheckpointStateType = "oor.sessions"
 	oorCheckpointVersion   = 2
+
+	// incomingMetadataQueryLimit is the default page size for durable
+	// ListVTXOsByScripts lookups used by the receive FSM.
+	incomingMetadataQueryLimit uint32 = 128
 )
 
 // OutboxHandler executes FSM outbox requests and returns follow-up events.
@@ -32,11 +36,6 @@ type OutboxHandler interface {
 	Handle(ctx context.Context, sessionID SessionID,
 		outbox OutboxEvent) ([]Event, error)
 }
-
-// IncomingMetadataRPCBuilder builds a durable serverconn unary request for the
-// authoritative incoming metadata query emitted by the receive FSM.
-type IncomingMetadataRPCBuilder func(ctx context.Context,
-	req *QueryIncomingMetadataRequest) (*serverconn.SendUnaryRequest, error)
 
 // ClientActorCfg configures the OORClientActor.
 type ClientActorCfg struct {
@@ -80,14 +79,6 @@ type ClientActorCfg struct {
 	// a callback event is restored from the mailbox without in-memory
 	// descriptor attachments.
 	VTXOStore vtxo.VTXOStore
-
-	// IncomingFetcher resolves lightweight incoming OOR notifications into the
-	// full Ark package by querying the indexer from the actor context.
-	IncomingFetcher IncomingOORFetcher
-
-	// BuildIncomingMetadataRPC constructs the durable serverconn unary request
-	// used to resolve authoritative incoming VTXO metadata after commit.
-	BuildIncomingMetadataRPC IncomingMetadataRPCBuilder
 }
 
 // OORClientActor wraps the outgoing-transfer client FSM in a durable actor
@@ -208,7 +199,6 @@ func NewOORClientActor(cfg ClientActorCfg) *OORClientActor {
 	durable := actor.NewDurableActor(durableCfg)
 	actorRef.durable = durable
 	actorRef.ref = durable.Ref()
-	behavior.selfRef = durable.Ref()
 
 	checkpoint, err := cfg.DeliveryStore.LoadCheckpoint(
 		context.Background(), cfg.ActorID,
@@ -314,8 +304,6 @@ type oorDurableBehavior struct {
 	cfg ClientActorCfg
 
 	sessions map[SessionID]*sessionHandle
-
-	selfRef actor.TellOnlyRef[OORDurableMsg]
 }
 
 // logger returns the configured logger or falls back to extracting from
@@ -554,8 +542,8 @@ func (b *oorDurableBehavior) handleDriveEvent(ctx context.Context,
 }
 
 // handleResolveIncomingTransfer durably records a lightweight incoming OOR
-// hint, then resolves the full Ark package asynchronously outside the live
-// durable actor transaction.
+// hint, then emits the transport query needed to resolve the full Ark package
+// after the checkpoint commits.
 func (b *oorDurableBehavior) handleResolveIncomingTransfer(
 	ctx context.Context,
 	req *ResolveIncomingTransferRequest) fn.Result[ActorResp] {
@@ -575,6 +563,7 @@ func (b *oorDurableBehavior) handleResolveIncomingTransfer(
 		slog.String("recipient_pk_script",
 			hex.EncodeToString(req.RecipientPkScript)))
 
+	created := false
 	handle, ok := b.sessions[req.SessionID]
 	if !ok {
 		session, err := newReceiveSessionWithState(
@@ -595,6 +584,7 @@ func (b *oorDurableBehavior) handleResolveIncomingTransfer(
 			kind: sessionKindIncoming,
 		}
 		b.sessions[req.SessionID] = handle
+		created = true
 
 		err = b.persistCheckpoint(ctx)
 		if err != nil {
@@ -621,83 +611,25 @@ func (b *oorDurableBehavior) handleResolveIncomingTransfer(
 		return fn.Ok[ActorResp](&DriveEventResponse{})
 	}
 
-	err = b.scheduleResolveIncomingTransfer(ctx, req)
+	if !created {
+		b.logger(ctx).DebugS(ctx, "Ignoring duplicate incoming "+
+			"resolve request for pending session",
+			slog.String("session_id", req.SessionID.String()))
+
+		return fn.Ok[ActorResp](&DriveEventResponse{})
+	}
+
+	outbox, err := outboxForHandle(handle, state)
+	if err != nil {
+		return fn.Err[ActorResp](err)
+	}
+
+	err = b.driveOutbox(ctx, req.SessionID, handle.FSM, outbox)
 	if err != nil {
 		return fn.Err[ActorResp](err)
 	}
 
 	return fn.Ok[ActorResp](&DriveEventResponse{})
-}
-
-// scheduleResolveIncomingTransfer resolves a lightweight incoming OOR hint
-// outside the live actor transaction, then re-drives the actor with either
-// the resolved IncomingTransferEvent or a terminal FailEvent.
-func (b *oorDurableBehavior) scheduleResolveIncomingTransfer(
-	ctx context.Context,
-	req *ResolveIncomingTransferRequest) error {
-
-	if req == nil {
-		return fmt.Errorf("request must be provided")
-	}
-
-	if b.selfRef == nil {
-		return fmt.Errorf("self ref must be configured")
-	}
-
-	opCtx := actor.WithoutOutboxID(
-		actor.WithoutTx(context.WithoutCancel(ctx)),
-	)
-	sessionID := req.SessionID
-	recipientPkScript := append(
-		[]byte(nil), req.RecipientPkScript...,
-	)
-	recipientEventID := req.RecipientEventID
-
-	go func() {
-		incomingEvent, err := ResolveIncomingTransferEvent(
-			opCtx, sessionID, recipientPkScript,
-			recipientEventID, b.cfg.IncomingFetcher,
-		)
-
-		var msg *DriveEventRequest
-		if err != nil {
-			b.logger(opCtx).WarnS(opCtx,
-				"Resolve incoming transfer hint failed", err,
-				slog.String("session_id", sessionID.String()),
-				slog.Uint64("recipient_event_id",
-					recipientEventID))
-
-			msg = &DriveEventRequest{
-				SessionID: sessionID,
-				Event: &FailEvent{
-					Reason: fmt.Sprintf(
-						"resolve incoming transfer: %v", err,
-					),
-				},
-			}
-		} else {
-			b.logger(opCtx).DebugS(opCtx,
-				"Resolved incoming transfer hint",
-				slog.String("session_id", sessionID.String()),
-				slog.Int("num_checkpoints",
-					len(incomingEvent.FinalCheckpointPSBTs)))
-
-			msg = &DriveEventRequest{
-				SessionID: sessionID,
-				Event:     incomingEvent,
-			}
-		}
-
-		tellErr := b.selfRef.Tell(opCtx, msg)
-		if tellErr != nil {
-			b.logger(opCtx).WarnS(opCtx,
-				"Failed to deliver incoming resolve result",
-				tellErr,
-				slog.String("session_id", sessionID.String()))
-		}
-	}()
-
-	return nil
 }
 
 // handleIncomingTransfer drives a new incoming-transfer notification without
@@ -915,27 +847,6 @@ func (b *oorDurableBehavior) handleResumeSession(ctx context.Context,
 		slog.String("session_id", req.SessionID.String()),
 		slog.String("state", fmt.Sprintf("%T", state)))
 
-	if handle.kind == sessionKindIncoming {
-		if resolving, ok := state.(*ReceiveResolving); ok {
-			err = b.scheduleResolveIncomingTransfer(
-				ctx, &ResolveIncomingTransferRequest{
-					SessionID: req.SessionID,
-					RecipientPkScript: append(
-						[]byte(nil),
-						resolving.RecipientPkScript...,
-					),
-					RecipientEventID: resolving.
-						RecipientEventID,
-				},
-			)
-			if err != nil {
-				return fn.Err[ActorResp](err)
-			}
-
-			return fn.Ok[ActorResp](&ResumeSessionResponse{})
-		}
-	}
-
 	outbox, err := outboxForHandle(handle, state)
 	if err != nil {
 		return fn.Err[ActorResp](err)
@@ -1114,34 +1025,6 @@ func (b *oorDurableBehavior) resumeRestoredSessions(ctx context.Context) error {
 			return err
 		}
 
-		if handle.kind == sessionKindIncoming {
-			if resolving, ok := state.(*ReceiveResolving); ok {
-				b.logger(ctx).DebugS(ctx, "Resuming restored "+
-					"incoming resolve",
-					slog.String("session_id",
-						sessionID.String()),
-					slog.String("state",
-						fmt.Sprintf("%T", state)))
-
-				err = b.scheduleResolveIncomingTransfer(
-					ctx, &ResolveIncomingTransferRequest{
-						SessionID: sessionID,
-						RecipientPkScript: append(
-							[]byte(nil),
-							resolving.RecipientPkScript...,
-						),
-						RecipientEventID: resolving.
-							RecipientEventID,
-					},
-				)
-				if err != nil {
-					return err
-				}
-
-				continue
-			}
-		}
-
 		outbox, err := outboxForHandle(handle, state)
 		if err != nil {
 			return err
@@ -1197,7 +1080,8 @@ func (b *oorDurableBehavior) isTransportEvent(msg OutboxEvent) bool {
 
 	switch msg.(type) {
 	case *SendSubmitPackageRequest, *SendFinalizePackageRequest,
-		*SendIncomingAckRequest, *QueryIncomingMetadataRequest:
+		*SendIncomingAckRequest, *QueryIncomingTransferRequest,
+		*QueryIncomingMetadataRequest:
 
 		return true
 
@@ -1212,18 +1096,45 @@ func (b *oorDurableBehavior) sendTransportEvent(ctx context.Context,
 	msg OutboxEvent) error {
 
 	serverMsg, ok := msg.(serverconn.ServerMessage)
-	if queryReq, isQuery := msg.(*QueryIncomingMetadataRequest); isQuery {
-		if b.cfg.BuildIncomingMetadataRPC == nil {
-			return fmt.Errorf("incoming metadata rpc builder must be " +
-				"provided")
+	switch queryReq := msg.(type) {
+	case *QueryIncomingTransferRequest:
+		afterEventID := uint64(0)
+		if queryReq.RecipientEventID > 0 {
+			afterEventID = queryReq.RecipientEventID - 1
 		}
 
-		sendReq, err := b.cfg.BuildIncomingMetadataRPC(
-			ctx, queryReq,
-		)
-		if err != nil {
-			return fmt.Errorf("build incoming metadata rpc: %w",
-				err)
+		sendReq := &serverconn.SendListOORRecipientEventsByScriptRequest{
+			PkScript: append(
+				[]byte(nil), queryReq.RecipientPkScript...,
+			),
+			AfterEventID: afterEventID,
+			Limit:        1,
+			CorrelationID: IncomingResolveCorrelationID(
+				queryReq.SessionID, queryReq.RecipientEventID,
+			),
+		}
+
+		if err := b.cfg.ServerConn.Tell(ctx, sendReq); err != nil {
+			return fmt.Errorf("send incoming resolve query to "+
+				"server: %w", err)
+		}
+
+		return nil
+
+	case *QueryIncomingMetadataRequest:
+		pkScripts := make([][]byte, 0, len(queryReq.Recipients))
+		for i := range queryReq.Recipients {
+			pkScripts = append(pkScripts, append(
+				[]byte(nil), queryReq.Recipients[i].PkScript...,
+			))
+		}
+
+		sendReq := &serverconn.SendListVTXOsByScriptsRequest{
+			PkScripts: pkScripts,
+			Limit:     incomingMetadataQueryLimit,
+			CorrelationID: IncomingMetadataCorrelationID(
+				queryReq.SessionID,
+			),
 		}
 
 		if err := b.cfg.ServerConn.Tell(ctx, sendReq); err != nil {
@@ -1259,9 +1170,6 @@ func (b *oorDurableBehavior) driveOutbox(ctx context.Context,
 	sessionID SessionID, fsm *StateMachine, outbox []OutboxEvent) error {
 
 	handler := b.cfg.OutboxHandler
-	if handler == nil {
-		return nil
-	}
 
 	for _, msg := range outbox {
 		// Transport events (submit, finalize, ack) are Tell'd to
@@ -1305,6 +1213,11 @@ func (b *oorDurableBehavior) driveOutbox(ctx context.Context,
 		b.logger(ctx).DebugS(ctx, "Handling local outbox event",
 			slog.String("session_id", sessionID.String()),
 			slog.String("event_type", fmt.Sprintf("%T", msg)))
+
+		if handler == nil {
+			return fmt.Errorf("outbox handler must be provided for " +
+				"local events")
+		}
 
 		// Local events (signing, persistence, timers) continue
 		// through the outbox handler.

--- a/oor/actor.go
+++ b/oor/actor.go
@@ -33,6 +33,11 @@ type OutboxHandler interface {
 		outbox OutboxEvent) ([]Event, error)
 }
 
+// IncomingMetadataRPCBuilder builds a durable serverconn unary request for the
+// authoritative incoming metadata query emitted by the receive FSM.
+type IncomingMetadataRPCBuilder func(ctx context.Context,
+	req *QueryIncomingMetadataRequest) (*serverconn.SendUnaryRequest, error)
+
 // ClientActorCfg configures the OORClientActor.
 type ClientActorCfg struct {
 	// Log is an optional logger for this actor instance. If None, the
@@ -79,6 +84,10 @@ type ClientActorCfg struct {
 	// IncomingFetcher resolves lightweight incoming OOR notifications into the
 	// full Ark package by querying the indexer from the actor context.
 	IncomingFetcher IncomingOORFetcher
+
+	// BuildIncomingMetadataRPC constructs the durable serverconn unary request
+	// used to resolve authoritative incoming VTXO metadata after commit.
+	BuildIncomingMetadataRPC IncomingMetadataRPCBuilder
 }
 
 // OORClientActor wraps the outgoing-transfer client FSM in a durable actor
@@ -200,12 +209,6 @@ func NewOORClientActor(cfg ClientActorCfg) *OORClientActor {
 	actorRef.durable = durable
 	actorRef.ref = durable.Ref()
 	behavior.selfRef = durable.Ref()
-
-	if localHandler, ok := cfg.OutboxHandler.(*LocalPersistenceOutboxHandler); ok {
-		if localHandler.CallbackRef == nil {
-			localHandler.CallbackRef = durable.Ref()
-		}
-	}
 
 	checkpoint, err := cfg.DeliveryStore.LoadCheckpoint(
 		context.Background(), cfg.ActorID,
@@ -1194,7 +1197,7 @@ func (b *oorDurableBehavior) isTransportEvent(msg OutboxEvent) bool {
 
 	switch msg.(type) {
 	case *SendSubmitPackageRequest, *SendFinalizePackageRequest,
-		*SendIncomingAckRequest:
+		*SendIncomingAckRequest, *QueryIncomingMetadataRequest:
 
 		return true
 
@@ -1209,6 +1212,28 @@ func (b *oorDurableBehavior) sendTransportEvent(ctx context.Context,
 	msg OutboxEvent) error {
 
 	serverMsg, ok := msg.(serverconn.ServerMessage)
+	if queryReq, isQuery := msg.(*QueryIncomingMetadataRequest); isQuery {
+		if b.cfg.BuildIncomingMetadataRPC == nil {
+			return fmt.Errorf("incoming metadata rpc builder must be " +
+				"provided")
+		}
+
+		sendReq, err := b.cfg.BuildIncomingMetadataRPC(
+			ctx, queryReq,
+		)
+		if err != nil {
+			return fmt.Errorf("build incoming metadata rpc: %w",
+				err)
+		}
+
+		if err := b.cfg.ServerConn.Tell(ctx, sendReq); err != nil {
+			return fmt.Errorf("send metadata query to server: %w",
+				err)
+		}
+
+		return nil
+	}
+
 	if !ok {
 		return fmt.Errorf("transport event %T does not implement "+
 			"ServerMessage", msg)

--- a/oor/actor_drive_event_integration_test.go
+++ b/oor/actor_drive_event_integration_test.go
@@ -73,26 +73,6 @@ var _ interface {
 	Tell(context.Context, vtxo.ManagerMsg) error
 } = (*mockVTXOManagerRef)(nil)
 
-type mockOORDurableRef struct {
-	ch chan OORDurableMsg
-}
-
-// ID returns the stable ref identifier for mockOORDurableRef.
-func (m *mockOORDurableRef) ID() string {
-	return "mock-oor-self"
-}
-
-// Tell records an OOR durable message for assertions.
-func (m *mockOORDurableRef) Tell(_ context.Context, msg OORDurableMsg) error {
-	m.ch <- msg
-	return nil
-}
-
-var _ interface {
-	ID() string
-	Tell(context.Context, OORDurableMsg) error
-} = (*mockOORDurableRef)(nil)
-
 // buildIncomingResolveResponse creates an indexer response carrying the full
 // Ark/checkpoint package for a lightweight incoming-transfer hint.
 func buildIncomingResolveResponse(t *testing.T) (
@@ -245,6 +225,7 @@ func TestOORDurableBehaviorDriveIncomingHandledNotifiesVTXOManager(
 	managerRef := &mockVTXOManagerRef{}
 	behavior := &oorDurableBehavior{
 		cfg: ClientActorCfg{
+			OutboxHandler: &noopOutboxHandler{},
 			DeliveryStore: newTestDeliveryStore(t),
 			ActorID:       "oor-drive-incoming-handled-notify",
 			VTXOManager:   managerRef,
@@ -323,6 +304,7 @@ func TestOORDurableBehaviorDriveIncomingHandledReloadsFromStore(
 	managerRef := &mockVTXOManagerRef{}
 	behavior := &oorDurableBehavior{
 		cfg: ClientActorCfg{
+			OutboxHandler: &noopOutboxHandler{},
 			DeliveryStore: newTestDeliveryStore(t),
 			ActorID:       "oor-drive-incoming-handled-reload",
 			VTXOManager:   managerRef,
@@ -425,41 +407,26 @@ func TestRetryBackoffProcessEventRetryDueRequiresSnapshot(t *testing.T) {
 	require.ErrorContains(t, err, "resume snapshot must be provided")
 }
 
-// TestOORDurableBehaviorHandleResolveIncomingTransferAsync verifies the actor
-// checkpoints an incoming resolve-pending state and returns before the
-// follow-up indexer fetch completes.
-func TestOORDurableBehaviorHandleResolveIncomingTransferAsync(
+// TestOORDurableBehaviorHandleResolveIncomingTransferDurableUnary verifies the
+// actor checkpoints an incoming resolve-pending state, then enqueues the
+// durable unary request needed to resolve the full Ark package after commit.
+func TestOORDurableBehaviorHandleResolveIncomingTransferDurableUnary(
 	t *testing.T) {
 
 	t.Parallel()
 
 	ctx := t.Context()
 
-	response, sessionID, recipientPkScript, recipientEventID :=
+	_, sessionID, recipientPkScript, recipientEventID :=
 		buildIncomingResolveResponse(t)
-
-	fetchStarted := make(chan struct{}, 1)
-	unblockFetch := make(chan struct{})
-	callbackRef := &mockOORDurableRef{
-		ch: make(chan OORDurableMsg, 1),
-	}
+	serverConn := newMockServerConnRef(t)
 	behavior := &oorDurableBehavior{
 		cfg: ClientActorCfg{
 			DeliveryStore: newTestDeliveryStore(t),
 			ActorID:       "oor-resolve-incoming-async",
-			IncomingFetcher: func(_ context.Context, _ []byte,
-				_ uint64, _ uint32) (
-				*arkrpc.ListOORRecipientEventsByScriptResponse,
-				error) {
-
-				fetchStarted <- struct{}{}
-				<-unblockFetch
-
-				return response, nil
-			},
+			ServerConn:    serverConn,
 		},
 		sessions: make(map[SessionID]*sessionHandle),
-		selfRef:  callbackRef,
 	}
 
 	resp := behavior.handleResolveIncomingTransfer(
@@ -482,38 +449,20 @@ func TestOORDurableBehaviorHandleResolveIncomingTransferAsync(
 	require.Equal(t, recipientPkScript, resolving.RecipientPkScript)
 	require.Equal(t, recipientEventID, resolving.RecipientEventID)
 
-	select {
-	case <-fetchStarted:
-	case <-time.After(time.Second):
-		t.Fatal("fetch did not start")
-	}
-
-	select {
-	case msg := <-callbackRef.ch:
-		t.Fatalf("unexpected callback before fetch unblocked: %T", msg)
-	default:
-	}
-
-	close(unblockFetch)
-
-	var callbackMsg OORDurableMsg
-	require.Eventually(t, func() bool {
-		select {
-		case callbackMsg = <-callbackRef.ch:
-			return true
-		default:
-			return false
-		}
-	}, time.Second, 10*time.Millisecond)
-
-	driveReq, ok := callbackMsg.(*DriveEventRequest)
-	require.True(t, ok)
-	require.Equal(t, sessionID, driveReq.SessionID)
-	require.IsType(t, &IncomingTransferEvent{}, driveReq.Event)
+	unaryReq := serverConn.lastRecipientQuery()
+	require.Equal(t, recipientPkScript, unaryReq.PkScript)
+	require.Equal(t, recipientEventID-1, unaryReq.AfterEventID)
+	require.Equal(t, uint32(1), unaryReq.Limit)
+	require.Equal(
+		t,
+		IncomingResolveCorrelationID(sessionID, recipientEventID),
+		unaryReq.CorrelationID,
+	)
 }
 
 // TestOORDurableBehaviorResumeRestoredSessionsResolvePending verifies restart
-// replay re-schedules incoming-hint resolution for resolve-pending sessions.
+// replay re-emits the durable unary needed to resolve an incoming transfer
+// hint for resolve-pending sessions.
 func TestOORDurableBehaviorResumeRestoredSessionsResolvePending(
 	t *testing.T) {
 
@@ -521,7 +470,7 @@ func TestOORDurableBehaviorResumeRestoredSessionsResolvePending(
 
 	ctx := t.Context()
 
-	response, sessionID, recipientPkScript, recipientEventID :=
+	_, sessionID, recipientPkScript, recipientEventID :=
 		buildIncomingResolveResponse(t)
 
 	session, err := newReceiveSessionWithState(
@@ -533,23 +482,12 @@ func TestOORDurableBehaviorResumeRestoredSessionsResolvePending(
 	)
 	require.NoError(t, err)
 
-	unblockFetch := make(chan struct{})
-	callbackRef := &mockOORDurableRef{
-		ch: make(chan OORDurableMsg, 1),
-	}
+	serverConn := newMockServerConnRef(t)
 	behavior := &oorDurableBehavior{
 		cfg: ClientActorCfg{
 			DeliveryStore: newTestDeliveryStore(t),
 			ActorID:       "oor-resume-incoming-resolve",
-			IncomingFetcher: func(_ context.Context, _ []byte,
-				_ uint64, _ uint32) (
-				*arkrpc.ListOORRecipientEventsByScriptResponse,
-				error) {
-
-				<-unblockFetch
-
-				return response, nil
-			},
+			ServerConn:    serverConn,
 		},
 		sessions: map[SessionID]*sessionHandle{
 			sessionID: {
@@ -557,26 +495,18 @@ func TestOORDurableBehaviorResumeRestoredSessionsResolvePending(
 				kind: sessionKindIncoming,
 			},
 		},
-		selfRef: callbackRef,
 	}
 
 	err = behavior.resumeRestoredSessions(ctx)
 	require.NoError(t, err)
 
-	close(unblockFetch)
-
-	var callbackMsg OORDurableMsg
-	require.Eventually(t, func() bool {
-		select {
-		case callbackMsg = <-callbackRef.ch:
-			return true
-		default:
-			return false
-		}
-	}, time.Second, 10*time.Millisecond)
-
-	driveReq, ok := callbackMsg.(*DriveEventRequest)
-	require.True(t, ok)
-	require.Equal(t, sessionID, driveReq.SessionID)
-	require.IsType(t, &IncomingTransferEvent{}, driveReq.Event)
+	unaryReq := serverConn.lastRecipientQuery()
+	require.Equal(t, recipientPkScript, unaryReq.PkScript)
+	require.Equal(t, recipientEventID-1, unaryReq.AfterEventID)
+	require.Equal(t, uint32(1), unaryReq.Limit)
+	require.Equal(
+		t,
+		IncomingResolveCorrelationID(sessionID, recipientEventID),
+		unaryReq.CorrelationID,
+	)
 }

--- a/oor/actor_drive_event_integration_test.go
+++ b/oor/actor_drive_event_integration_test.go
@@ -3,11 +3,16 @@ package oor
 import (
 	"context"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/arkrpc"
+	"github.com/lightninglabs/darepo-client/lib/tx/psbtutil"
+	"github.com/lightninglabs/darepo-client/vtxo"
+	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,6 +40,102 @@ func (h *retryDueIntegrationHandler) Handle(_ context.Context,
 }
 
 var _ OutboxHandler = (*retryDueIntegrationHandler)(nil)
+
+type mockVTXOManagerRef struct {
+	mu       sync.Mutex
+	messages []vtxo.ManagerMsg
+}
+
+func (m *mockVTXOManagerRef) ID() string {
+	return "mock-vtxo-manager"
+}
+
+func (m *mockVTXOManagerRef) Tell(_ context.Context,
+	msg vtxo.ManagerMsg) error {
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.messages = append(m.messages, msg)
+
+	return nil
+}
+
+func (m *mockVTXOManagerRef) sent() []vtxo.ManagerMsg {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return append([]vtxo.ManagerMsg(nil), m.messages...)
+}
+
+var _ interface {
+	ID() string
+	Tell(context.Context, vtxo.ManagerMsg) error
+} = (*mockVTXOManagerRef)(nil)
+
+type mockOORDurableRef struct {
+	ch chan OORDurableMsg
+}
+
+// ID returns the stable ref identifier for mockOORDurableRef.
+func (m *mockOORDurableRef) ID() string {
+	return "mock-oor-self"
+}
+
+// Tell records an OOR durable message for assertions.
+func (m *mockOORDurableRef) Tell(_ context.Context, msg OORDurableMsg) error {
+	m.ch <- msg
+	return nil
+}
+
+var _ interface {
+	ID() string
+	Tell(context.Context, OORDurableMsg) error
+} = (*mockOORDurableRef)(nil)
+
+// buildIncomingResolveResponse creates an indexer response carrying the full
+// Ark/checkpoint package for a lightweight incoming-transfer hint.
+func buildIncomingResolveResponse(t *testing.T) (
+	*arkrpc.ListOORRecipientEventsByScriptResponse,
+	SessionID, []byte, uint64,
+) {
+
+	t.Helper()
+
+	arkPSBT, finalCheckpoints, recipients, _, _, _ :=
+		buildTestIncomingMaterialization(t)
+
+	arkRaw, err := psbtutil.Serialize(arkPSBT)
+	require.NoError(t, err)
+
+	checkpointRaws := make([][]byte, 0, len(finalCheckpoints))
+	for _, checkpoint := range finalCheckpoints {
+		checkpointRaw, checkpointErr := psbtutil.Serialize(
+			checkpoint,
+		)
+		require.NoError(t, checkpointErr)
+
+		checkpointRaws = append(checkpointRaws, checkpointRaw)
+	}
+
+	sessionID := SessionID(arkPSBT.UnsignedTx.TxHash())
+	recipient := recipients[0]
+
+	return &arkrpc.ListOORRecipientEventsByScriptResponse{
+		Events: []*arkrpc.OORRecipientEvent{
+			{
+				RecipientPkScript: recipient.PkScript,
+				EventId:           7,
+				SessionId:         sessionID[:],
+				OutputIndex:       recipient.OutputIndex,
+				Value:             uint64(recipient.Value),
+				ArkPsbt:           arkRaw,
+				CheckpointPsbts:   checkpointRaws,
+			},
+		},
+		NextCursor: 8,
+	}, sessionID, recipient.PkScript, 7
+}
 
 // TestOORClientActorDriveRetryDueEventDurablePath verifies the retry-due signal
 // can cross the durable actor boundary and re-drive the resumed outbox work.
@@ -100,6 +201,156 @@ func TestOORClientActorDriveRetryDueEventDurablePath(t *testing.T) {
 	stateMsg, ok := stateResp.UnwrapOr(nil).(*GetStateResponse)
 	require.True(t, ok)
 	require.IsType(t, &AwaitingFinalizeAccepted{}, stateMsg.State)
+}
+
+// TestOORDurableBehaviorDriveIncomingHandledNotifiesVTXOManager verifies the
+// DriveEventRequest path forwards materialized incoming VTXOs to the manager
+// after the receive-state transition is durably checkpointed.
+func TestOORDurableBehaviorDriveIncomingHandledNotifiesVTXOManager(
+	t *testing.T) {
+
+	t.Parallel()
+
+	ctx := t.Context()
+
+	arkPSBT, finalCheckpoints, recipients, parentCommitment, recipientKey,
+		operatorKey := buildTestIncomingMaterialization(t)
+
+	sessionID := SessionID(arkPSBT.UnsignedTx.TxHash())
+	session, _, err := DriveIncomingTransferWithCheckpoints(
+		ctx, sessionID, arkPSBT, finalCheckpoints,
+	)
+	require.NoError(t, err)
+
+	desc, err := BuildIncomingVTXODescriptor(
+		arkPSBT, IncomingVTXOConfig{
+			OutputIndex: recipients[0].OutputIndex,
+			ClientKey: keychain.KeyDescriptor{
+				PubKey: recipientKey.PubKey(),
+			},
+			OperatorKey: operatorKey,
+			ExitDelay:   10,
+			Metadata: IncomingVTXOMetadata{
+				RoundID:        "round-incoming",
+				CommitmentTxID: parentCommitment,
+				BatchExpiry:    1000,
+				TreeDepth:      1,
+				ChainDepth:     len(finalCheckpoints),
+				CreatedHeight:  700,
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	managerRef := &mockVTXOManagerRef{}
+	behavior := &oorDurableBehavior{
+		cfg: ClientActorCfg{
+			DeliveryStore: newTestDeliveryStore(t),
+			ActorID:       "oor-drive-incoming-handled-notify",
+			VTXOManager:   managerRef,
+		},
+		sessions: map[SessionID]*sessionHandle{
+			sessionID: {
+				FSM:  session.FSM,
+				kind: sessionKindIncoming,
+			},
+		},
+	}
+
+	resp := behavior.handleDriveEvent(ctx, &DriveEventRequest{
+		SessionID: sessionID,
+		Event: &IncomingHandledEvent{
+			MaterializedVTXOs: []*vtxo.Descriptor{desc},
+		},
+	})
+	require.True(t, resp.IsOk())
+
+	sent := managerRef.sent()
+	require.Len(t, sent, 1)
+
+	notification, ok := sent[0].(*vtxo.VTXOsMaterializedNotification)
+	require.True(t, ok)
+	require.Len(t, notification.VTXOs, 1)
+	require.Equal(t, desc.Outpoint, notification.VTXOs[0].Outpoint)
+
+	state, err := session.FSM.CurrentState()
+	require.NoError(t, err)
+	require.IsType(t, &ReceiveAwaitingAck{}, state)
+}
+
+// TestOORDurableBehaviorDriveIncomingHandledReloadsFromStore verifies the
+// durable callback path can reload incoming VTXOs by outpoint after the event
+// round-trips through the mailbox without attached descriptors.
+func TestOORDurableBehaviorDriveIncomingHandledReloadsFromStore(
+	t *testing.T) {
+
+	t.Parallel()
+
+	ctx := t.Context()
+
+	arkPSBT, finalCheckpoints, recipients, parentCommitment, recipientKey,
+		operatorKey := buildTestIncomingMaterialization(t)
+
+	sessionID := SessionID(arkPSBT.UnsignedTx.TxHash())
+	session, _, err := DriveIncomingTransferWithCheckpoints(
+		ctx, sessionID, arkPSBT, finalCheckpoints,
+	)
+	require.NoError(t, err)
+
+	desc, err := BuildIncomingVTXODescriptor(
+		arkPSBT, IncomingVTXOConfig{
+			OutputIndex: recipients[0].OutputIndex,
+			ClientKey: keychain.KeyDescriptor{
+				PubKey: recipientKey.PubKey(),
+			},
+			OperatorKey: operatorKey,
+			ExitDelay:   10,
+			Metadata: IncomingVTXOMetadata{
+				RoundID:        "round-incoming",
+				CommitmentTxID: parentCommitment,
+				BatchExpiry:    1000,
+				TreeDepth:      1,
+				ChainDepth:     len(finalCheckpoints),
+				CreatedHeight:  700,
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	store := newTestVTXOStore()
+	require.NoError(t, store.SaveVTXO(ctx, desc))
+
+	managerRef := &mockVTXOManagerRef{}
+	behavior := &oorDurableBehavior{
+		cfg: ClientActorCfg{
+			DeliveryStore: newTestDeliveryStore(t),
+			ActorID:       "oor-drive-incoming-handled-reload",
+			VTXOManager:   managerRef,
+			VTXOStore:     store,
+		},
+		sessions: map[SessionID]*sessionHandle{
+			sessionID: {
+				FSM:  session.FSM,
+				kind: sessionKindIncoming,
+			},
+		},
+	}
+
+	resp := behavior.handleDriveEvent(ctx, &DriveEventRequest{
+		SessionID: sessionID,
+		Event: &IncomingHandledEvent{
+			MaterializedOutpoints: []wire.OutPoint{desc.Outpoint},
+		},
+	})
+	require.True(t, resp.IsOk())
+
+	sent := managerRef.sent()
+	require.Len(t, sent, 1)
+
+	notification, ok := sent[0].(*vtxo.VTXOsMaterializedNotification)
+	require.True(t, ok)
+	require.Len(t, notification.VTXOs, 1)
+	require.Equal(t, desc.Outpoint, notification.VTXOs[0].Outpoint)
 }
 
 // TestOutboxForStateRetryBackoff asserts retry-backoff state emits a
@@ -172,4 +423,160 @@ func TestRetryBackoffProcessEventRetryDueRequiresSnapshot(t *testing.T) {
 	)
 	require.Nil(t, transition)
 	require.ErrorContains(t, err, "resume snapshot must be provided")
+}
+
+// TestOORDurableBehaviorHandleResolveIncomingTransferAsync verifies the actor
+// checkpoints an incoming resolve-pending state and returns before the
+// follow-up indexer fetch completes.
+func TestOORDurableBehaviorHandleResolveIncomingTransferAsync(
+	t *testing.T) {
+
+	t.Parallel()
+
+	ctx := t.Context()
+
+	response, sessionID, recipientPkScript, recipientEventID :=
+		buildIncomingResolveResponse(t)
+
+	fetchStarted := make(chan struct{}, 1)
+	unblockFetch := make(chan struct{})
+	callbackRef := &mockOORDurableRef{
+		ch: make(chan OORDurableMsg, 1),
+	}
+	behavior := &oorDurableBehavior{
+		cfg: ClientActorCfg{
+			DeliveryStore: newTestDeliveryStore(t),
+			ActorID:       "oor-resolve-incoming-async",
+			IncomingFetcher: func(_ context.Context, _ []byte,
+				_ uint64, _ uint32) (
+				*arkrpc.ListOORRecipientEventsByScriptResponse,
+				error) {
+
+				fetchStarted <- struct{}{}
+				<-unblockFetch
+
+				return response, nil
+			},
+		},
+		sessions: make(map[SessionID]*sessionHandle),
+		selfRef:  callbackRef,
+	}
+
+	resp := behavior.handleResolveIncomingTransfer(
+		ctx, &ResolveIncomingTransferRequest{
+			SessionID:         sessionID,
+			RecipientPkScript: recipientPkScript,
+			RecipientEventID:  recipientEventID,
+		},
+	)
+	require.True(t, resp.IsOk())
+
+	handle := behavior.sessions[sessionID]
+	require.NotNil(t, handle)
+
+	state, err := handle.currentSessionState()
+	require.NoError(t, err)
+
+	resolving, ok := state.(*ReceiveResolving)
+	require.True(t, ok)
+	require.Equal(t, recipientPkScript, resolving.RecipientPkScript)
+	require.Equal(t, recipientEventID, resolving.RecipientEventID)
+
+	select {
+	case <-fetchStarted:
+	case <-time.After(time.Second):
+		t.Fatal("fetch did not start")
+	}
+
+	select {
+	case msg := <-callbackRef.ch:
+		t.Fatalf("unexpected callback before fetch unblocked: %T", msg)
+	default:
+	}
+
+	close(unblockFetch)
+
+	var callbackMsg OORDurableMsg
+	require.Eventually(t, func() bool {
+		select {
+		case callbackMsg = <-callbackRef.ch:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+
+	driveReq, ok := callbackMsg.(*DriveEventRequest)
+	require.True(t, ok)
+	require.Equal(t, sessionID, driveReq.SessionID)
+	require.IsType(t, &IncomingTransferEvent{}, driveReq.Event)
+}
+
+// TestOORDurableBehaviorResumeRestoredSessionsResolvePending verifies restart
+// replay re-schedules incoming-hint resolution for resolve-pending sessions.
+func TestOORDurableBehaviorResumeRestoredSessionsResolvePending(
+	t *testing.T) {
+
+	t.Parallel()
+
+	ctx := t.Context()
+
+	response, sessionID, recipientPkScript, recipientEventID :=
+		buildIncomingResolveResponse(t)
+
+	session, err := newReceiveSessionWithState(
+		ctx, sessionID, &ReceiveResolving{
+			SessionID:         sessionID,
+			RecipientPkScript: recipientPkScript,
+			RecipientEventID:  recipientEventID,
+		},
+	)
+	require.NoError(t, err)
+
+	unblockFetch := make(chan struct{})
+	callbackRef := &mockOORDurableRef{
+		ch: make(chan OORDurableMsg, 1),
+	}
+	behavior := &oorDurableBehavior{
+		cfg: ClientActorCfg{
+			DeliveryStore: newTestDeliveryStore(t),
+			ActorID:       "oor-resume-incoming-resolve",
+			IncomingFetcher: func(_ context.Context, _ []byte,
+				_ uint64, _ uint32) (
+				*arkrpc.ListOORRecipientEventsByScriptResponse,
+				error) {
+
+				<-unblockFetch
+
+				return response, nil
+			},
+		},
+		sessions: map[SessionID]*sessionHandle{
+			sessionID: {
+				FSM:  session.FSM,
+				kind: sessionKindIncoming,
+			},
+		},
+		selfRef: callbackRef,
+	}
+
+	err = behavior.resumeRestoredSessions(ctx)
+	require.NoError(t, err)
+
+	close(unblockFetch)
+
+	var callbackMsg OORDurableMsg
+	require.Eventually(t, func() bool {
+		select {
+		case callbackMsg = <-callbackRef.ch:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+
+	driveReq, ok := callbackMsg.(*DriveEventRequest)
+	require.True(t, ok)
+	require.Equal(t, sessionID, driveReq.SessionID)
+	require.IsType(t, &IncomingTransferEvent{}, driveReq.Event)
 }

--- a/oor/actor_drive_event_test.go
+++ b/oor/actor_drive_event_test.go
@@ -90,6 +90,7 @@ func TestOORClientActorDriveEventAppliesEvent(t *testing.T) {
 	}}
 
 	actor := NewOORClientActor(ClientActorCfg{
+		OutboxHandler: &noopOutboxHandler{},
 		DeliveryStore: newTestDeliveryStore(t),
 		ActorID:       "oor-drive-event-happy",
 	})

--- a/oor/actor_durable_message.go
+++ b/oor/actor_durable_message.go
@@ -10,6 +10,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+	clientdb "github.com/lightninglabs/darepo-client/db"
 	"github.com/lightninglabs/darepo-client/lib/tx/psbtutil"
 	"github.com/lightningnetwork/lnd/tlv"
 )
@@ -47,6 +48,7 @@ const (
 	eventPayloadCheckpointPSBTsRecordType tlv.Type = 7
 	eventPayloadReasonRecordType          tlv.Type = 9
 	eventPayloadOutpointsRecordType       tlv.Type = 11
+	eventPayloadMetadataMatchesRecordType tlv.Type = 13
 )
 
 const (
@@ -59,6 +61,7 @@ const (
 	eventKindIncomingTransfer  uint64 = 7
 	eventKindIncomingHandled   uint64 = 8
 	eventKindIncomingAckSent   uint64 = 9
+	eventKindIncomingMetadata  uint64 = 10
 )
 
 const (
@@ -75,6 +78,17 @@ const (
 const (
 	recipientPkScriptRecordType tlv.Type = 1
 	recipientValueSatRecordType tlv.Type = 2
+)
+
+const (
+	incomingMetadataMatchOutputIndexRecordType   tlv.Type = 1
+	incomingMetadataMatchRoundIDRecordType       tlv.Type = 3
+	incomingMetadataMatchCommitmentTxIDRecordType tlv.Type = 5
+	incomingMetadataMatchBatchExpiryRecordType   tlv.Type = 7
+	incomingMetadataMatchTreeDepthRecordType     tlv.Type = 9
+	incomingMetadataMatchChainDepthRecordType    tlv.Type = 11
+	incomingMetadataMatchCreatedHeightRecordType tlv.Type = 13
+	incomingMetadataMatchTreePathRecordType      tlv.Type = 15
 )
 
 type startTransferPayload struct {
@@ -242,6 +256,209 @@ func decodeOutPointList(raw []byte) ([]wire.OutPoint, error) {
 	}
 
 	return outpoints, nil
+}
+
+func encodeIncomingMetadataMatches(matches []IncomingMetadataMatch) ([]byte,
+	error) {
+
+	blobs := make([][]byte, 0, len(matches))
+	for i := range matches {
+		raw, err := encodeIncomingMetadataMatch(matches[i])
+		if err != nil {
+			return nil, err
+		}
+
+		blobs = append(blobs, raw)
+	}
+
+	return encodeLengthPrefixedBlobList(blobs)
+}
+
+func decodeIncomingMetadataMatches(raw []byte) ([]IncomingMetadataMatch, error) {
+	blobs, err := decodeLengthPrefixedBlobList(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	matches := make([]IncomingMetadataMatch, 0, len(blobs))
+	for i := range blobs {
+		match, err := decodeIncomingMetadataMatch(blobs[i])
+		if err != nil {
+			return nil, err
+		}
+
+		matches = append(matches, match)
+	}
+
+	return matches, nil
+}
+
+func encodeIncomingMetadataMatch(match IncomingMetadataMatch) ([]byte, error) {
+	outputIndex := match.OutputIndex
+	roundID := []byte(match.Metadata.RoundID)
+	commitmentTxID := match.Metadata.CommitmentTxID[:]
+	batchExpiry := uint32(match.Metadata.BatchExpiry)
+	treeDepth := uint32(match.Metadata.TreeDepth)
+	chainDepth := uint32(match.Metadata.ChainDepth)
+	createdHeight := uint32(match.Metadata.CreatedHeight)
+
+	treePath, err := clientdb.SerializeTree(match.Metadata.TreePath)
+	if err != nil {
+		return nil, err
+	}
+
+	records := []tlv.Record{
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchOutputIndexRecordType,
+			&outputIndex,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchRoundIDRecordType, &roundID,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchCommitmentTxIDRecordType,
+			&commitmentTxID,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchBatchExpiryRecordType,
+			&batchExpiry,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchTreeDepthRecordType, &treeDepth,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchChainDepthRecordType,
+			&chainDepth,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchCreatedHeightRecordType,
+			&createdHeight,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchTreePathRecordType, &treePath,
+		),
+	}
+
+	stream, err := tlv.NewStream(records...)
+	if err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	if err := stream.Encode(&buf); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func decodeIncomingMetadataMatch(raw []byte) (IncomingMetadataMatch, error) {
+	var (
+		outputIndex   uint32
+		roundID       []byte
+		commitmentTxID []byte
+		batchExpiry   uint32
+		treeDepth     uint32
+		chainDepth    uint32
+		createdHeight uint32
+		treePath      []byte
+	)
+
+	records := []tlv.Record{
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchOutputIndexRecordType,
+			&outputIndex,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchRoundIDRecordType, &roundID,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchCommitmentTxIDRecordType,
+			&commitmentTxID,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchBatchExpiryRecordType,
+			&batchExpiry,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchTreeDepthRecordType, &treeDepth,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchChainDepthRecordType,
+			&chainDepth,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchCreatedHeightRecordType,
+			&createdHeight,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchTreePathRecordType, &treePath,
+		),
+	}
+
+	stream, err := tlv.NewStream(records...)
+	if err != nil {
+		return IncomingMetadataMatch{}, err
+	}
+
+	reader := bytes.NewReader(raw)
+	if _, err := stream.DecodeWithParsedTypes(reader); err != nil {
+		return IncomingMetadataMatch{}, err
+	}
+
+	if len(commitmentTxID) != chainhash.HashSize {
+		return IncomingMetadataMatch{}, fmt.Errorf("incoming metadata "+
+			"commitment txid must be provided")
+	}
+
+	decodedBatchExpiry, err := uint32ToInt32(
+		batchExpiry, "incoming batch expiry",
+	)
+	if err != nil {
+		return IncomingMetadataMatch{}, err
+	}
+
+	decodedTreeDepth, err := uint32ToInt32(
+		treeDepth, "incoming tree depth",
+	)
+	if err != nil {
+		return IncomingMetadataMatch{}, err
+	}
+
+	decodedChainDepth, err := uint32ToInt32(
+		chainDepth, "incoming chain depth",
+	)
+	if err != nil {
+		return IncomingMetadataMatch{}, err
+	}
+
+	decodedCreatedHeight, err := uint32ToInt32(
+		createdHeight, "incoming created height",
+	)
+	if err != nil {
+		return IncomingMetadataMatch{}, err
+	}
+
+	decodedTreePath, err := clientdb.DeserializeTree(treePath)
+	if err != nil {
+		return IncomingMetadataMatch{}, err
+	}
+
+	var decodedCommitmentTxID chainhash.Hash
+	copy(decodedCommitmentTxID[:], commitmentTxID)
+
+	return IncomingMetadataMatch{
+		OutputIndex: outputIndex,
+		Metadata: IncomingVTXOMetadata{
+			RoundID:        string(roundID),
+			CommitmentTxID: decodedCommitmentTxID,
+			BatchExpiry:    decodedBatchExpiry,
+			TreeDepth:      int(decodedTreeDepth),
+			ChainDepth:     int(decodedChainDepth),
+			CreatedHeight:  decodedCreatedHeight,
+			TreePath:       decodedTreePath,
+		},
+	}, nil
 }
 
 func encodeRecipientPayload(payload recipientPayload) ([]byte, error) {
@@ -733,6 +950,7 @@ func encodeEventPayload(event Event) ([]byte, error) {
 		checkpointPSBT  []byte
 		reason          []byte
 		outpointPayload []byte
+		metadataPayload []byte
 		err             error
 	)
 
@@ -836,6 +1054,16 @@ func encodeEventPayload(event Event) ([]byte, error) {
 			return nil, err
 		}
 
+	case *IncomingMetadataResolvedEvent:
+		eventKind = eventKindIncomingMetadata
+
+		metadataPayload, err = encodeIncomingMetadataMatches(
+			evt.Matches,
+		)
+		if err != nil {
+			return nil, err
+		}
+
 	case *IncomingAckSentEvent:
 		eventKind = eventKindIncomingAckSent
 
@@ -857,6 +1085,9 @@ func encodeEventPayload(event Event) ([]byte, error) {
 		tlv.MakePrimitiveRecord(eventPayloadReasonRecordType, &reason),
 		tlv.MakePrimitiveRecord(
 			eventPayloadOutpointsRecordType, &outpointPayload,
+		),
+		tlv.MakePrimitiveRecord(
+			eventPayloadMetadataMatchesRecordType, &metadataPayload,
 		),
 	}
 
@@ -881,6 +1112,7 @@ func decodeEventPayload(raw []byte) (Event, error) {
 		checkpointPSBT  []byte
 		reason          []byte
 		outpointPayload []byte
+		metadataPayload []byte
 	)
 
 	records := []tlv.Record{
@@ -897,6 +1129,9 @@ func decodeEventPayload(raw []byte) (Event, error) {
 		tlv.MakePrimitiveRecord(eventPayloadReasonRecordType, &reason),
 		tlv.MakePrimitiveRecord(
 			eventPayloadOutpointsRecordType, &outpointPayload,
+		),
+		tlv.MakePrimitiveRecord(
+			eventPayloadMetadataMatchesRecordType, &metadataPayload,
 		),
 	}
 
@@ -1012,6 +1247,18 @@ func decodeEventPayload(raw []byte) (Event, error) {
 
 		return &IncomingHandledEvent{
 			MaterializedOutpoints: outpoints,
+		}, nil
+
+	case eventKindIncomingMetadata:
+		matches, err := decodeIncomingMetadataMatches(
+			metadataPayload,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		return &IncomingMetadataResolvedEvent{
+			Matches: matches,
 		}, nil
 
 	case eventKindIncomingAckSent:

--- a/oor/actor_durable_message.go
+++ b/oor/actor_durable_message.go
@@ -26,6 +26,12 @@ const (
 )
 
 const (
+	resolveIncomingPayloadSessionIDRecordType tlv.Type = 1
+	resolveIncomingPayloadPkScriptRecordType  tlv.Type = 2
+	resolveIncomingPayloadEventIDRecordType   tlv.Type = 3
+)
+
+const (
 	restorePayloadSnapshotRecordType tlv.Type = 1
 )
 
@@ -40,6 +46,7 @@ const (
 	eventPayloadArkPSBTRecordType         tlv.Type = 5
 	eventPayloadCheckpointPSBTsRecordType tlv.Type = 7
 	eventPayloadReasonRecordType          tlv.Type = 9
+	eventPayloadOutpointsRecordType       tlv.Type = 11
 )
 
 const (
@@ -49,6 +56,9 @@ const (
 	eventKindInputsMarkedSpent uint64 = 4
 	eventKindFail              uint64 = 5
 	eventKindRetryDue          uint64 = 6
+	eventKindIncomingTransfer  uint64 = 7
+	eventKindIncomingHandled   uint64 = 8
+	eventKindIncomingAckSent   uint64 = 9
 )
 
 const (
@@ -203,6 +213,35 @@ func decodeRecipientPayloads(raw []byte) ([]recipientPayload, error) {
 	}
 
 	return payloads, nil
+}
+
+func encodeOutPointList(outpoints []wire.OutPoint) ([]byte, error) {
+	blobs := make([][]byte, 0, len(outpoints))
+
+	for _, outpoint := range outpoints {
+		blobs = append(blobs, outPointBytes(outpoint))
+	}
+
+	return encodeLengthPrefixedBlobList(blobs)
+}
+
+func decodeOutPointList(raw []byte) ([]wire.OutPoint, error) {
+	blobs, err := decodeLengthPrefixedBlobList(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	outpoints := make([]wire.OutPoint, 0, len(blobs))
+	for _, blob := range blobs {
+		outpoint, err := parseOutPointBytes(blob)
+		if err != nil {
+			return nil, err
+		}
+
+		outpoints = append(outpoints, outpoint)
+	}
+
+	return outpoints, nil
 }
 
 func encodeRecipientPayload(payload recipientPayload) ([]byte, error) {
@@ -479,6 +518,79 @@ func decodeSessionPayload(raw []byte) (SessionID, error) {
 	return parseSessionID(sessionBytes)
 }
 
+func encodeResolveIncomingTransferPayload(sessionID SessionID,
+	recipientPkScript []byte, recipientEventID uint64) ([]byte, error) {
+
+	sessionBytes := sessionIDBytes(sessionID)
+	pkScript := recipientPkScript
+	eventID := recipientEventID
+
+	records := []tlv.Record{
+		tlv.MakePrimitiveRecord(
+			resolveIncomingPayloadSessionIDRecordType, &sessionBytes,
+		),
+		tlv.MakePrimitiveRecord(
+			resolveIncomingPayloadPkScriptRecordType, &pkScript,
+		),
+		tlv.MakePrimitiveRecord(
+			resolveIncomingPayloadEventIDRecordType, &eventID,
+		),
+	}
+
+	stream, err := tlv.NewStream(records...)
+	if err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	if err := stream.Encode(&buf); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func decodeResolveIncomingTransferPayload(raw []byte) (SessionID, []byte,
+	uint64, error) {
+
+	var (
+		sessionBytes      []byte
+		recipientPkScript []byte
+		recipientEventID  uint64
+	)
+
+	records := []tlv.Record{
+		tlv.MakePrimitiveRecord(
+			resolveIncomingPayloadSessionIDRecordType, &sessionBytes,
+		),
+		tlv.MakePrimitiveRecord(
+			resolveIncomingPayloadPkScriptRecordType,
+			&recipientPkScript,
+		),
+		tlv.MakePrimitiveRecord(
+			resolveIncomingPayloadEventIDRecordType,
+			&recipientEventID,
+		),
+	}
+
+	stream, err := tlv.NewStream(records...)
+	if err != nil {
+		return SessionID{}, nil, 0, err
+	}
+
+	reader := bytes.NewReader(raw)
+	if _, err := stream.DecodeWithParsedTypes(reader); err != nil {
+		return SessionID{}, nil, 0, err
+	}
+
+	sessionID, err := parseSessionID(sessionBytes)
+	if err != nil {
+		return SessionID{}, nil, 0, err
+	}
+
+	return sessionID, recipientPkScript, recipientEventID, nil
+}
+
 func encodeRestoreSnapshotPayload(snapshot *OutgoingSnapshot) ([]byte, error) {
 	snapshotRaw, err := encodeOutgoingSnapshot(snapshot)
 	if err != nil {
@@ -602,6 +714,10 @@ func decodeDriveEventRequestPayload(raw []byte) (SessionID, Event, error) {
 		return SessionID{}, nil, err
 	}
 
+	if incoming, ok := event.(*IncomingTransferEvent); ok {
+		incoming.SessionID = sessionID
+	}
+
 	// Validation of SubmitAcceptedEvent identity is deferred to the
 	// processing layer (handleDriveEvent), not the deserialization
 	// layer. See encodeDriveEventRequestPayload for rationale.
@@ -611,12 +727,13 @@ func decodeDriveEventRequestPayload(raw []byte) (SessionID, Event, error) {
 
 func encodeEventPayload(event Event) ([]byte, error) {
 	var (
-		eventKind      uint64
-		submitSession  []byte
-		arkPSBT        []byte
-		checkpointPSBT []byte
-		reason         []byte
-		err            error
+		eventKind       uint64
+		submitSession   []byte
+		arkPSBT         []byte
+		checkpointPSBT  []byte
+		reason          []byte
+		outpointPayload []byte
+		err             error
 	)
 
 	switch evt := event.(type) {
@@ -670,6 +787,58 @@ func encodeEventPayload(event Event) ([]byte, error) {
 	case *RetryDueEvent:
 		eventKind = eventKindRetryDue
 
+	case *IncomingTransferEvent:
+		eventKind = eventKindIncomingTransfer
+
+		if evt.ArkPSBT == nil {
+			return nil, fmt.Errorf(
+				"incoming transfer event ark psbt must be provided",
+			)
+		}
+
+		arkPSBT, err = psbtutil.Serialize(evt.ArkPSBT)
+		if err != nil {
+			return nil, err
+		}
+
+		checkpoints, err := serializePSBTSlice(
+			evt.FinalCheckpointPSBTs,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		checkpointPSBT, err = encodeLengthPrefixedBlobList(
+			checkpoints,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+	case *IncomingHandledEvent:
+		eventKind = eventKindIncomingHandled
+
+		outpoints := evt.MaterializedOutpoints
+		if len(outpoints) == 0 && len(evt.MaterializedVTXOs) > 0 {
+			outpoints = make([]wire.OutPoint, 0,
+				len(evt.MaterializedVTXOs))
+			for _, desc := range evt.MaterializedVTXOs {
+				if desc == nil {
+					continue
+				}
+
+				outpoints = append(outpoints, desc.Outpoint)
+			}
+		}
+
+		outpointPayload, err = encodeOutPointList(outpoints)
+		if err != nil {
+			return nil, err
+		}
+
+	case *IncomingAckSentEvent:
+		eventKind = eventKindIncomingAckSent
+
 	default:
 		return nil, fmt.Errorf("unsupported event type: %T", event)
 	}
@@ -686,6 +855,9 @@ func encodeEventPayload(event Event) ([]byte, error) {
 			eventPayloadCheckpointPSBTsRecordType, &checkpointPSBT,
 		),
 		tlv.MakePrimitiveRecord(eventPayloadReasonRecordType, &reason),
+		tlv.MakePrimitiveRecord(
+			eventPayloadOutpointsRecordType, &outpointPayload,
+		),
 	}
 
 	stream, err := tlv.NewStream(records...)
@@ -703,11 +875,12 @@ func encodeEventPayload(event Event) ([]byte, error) {
 
 func decodeEventPayload(raw []byte) (Event, error) {
 	var (
-		eventKind      uint64
-		submitSession  []byte
-		arkPSBT        []byte
-		checkpointPSBT []byte
-		reason         []byte
+		eventKind       uint64
+		submitSession   []byte
+		arkPSBT         []byte
+		checkpointPSBT  []byte
+		reason          []byte
+		outpointPayload []byte
 	)
 
 	records := []tlv.Record{
@@ -722,6 +895,9 @@ func decodeEventPayload(raw []byte) (Event, error) {
 			eventPayloadCheckpointPSBTsRecordType, &checkpointPSBT,
 		),
 		tlv.MakePrimitiveRecord(eventPayloadReasonRecordType, &reason),
+		tlv.MakePrimitiveRecord(
+			eventPayloadOutpointsRecordType, &outpointPayload,
+		),
 	}
 
 	stream, err := tlv.NewStream(records...)
@@ -798,6 +974,48 @@ func decodeEventPayload(raw []byte) (Event, error) {
 
 	case eventKindRetryDue:
 		return &RetryDueEvent{}, nil
+
+	case eventKindIncomingTransfer:
+		if len(arkPSBT) == 0 {
+			return nil, fmt.Errorf(
+				"incoming transfer event ark psbt must be provided",
+			)
+		}
+
+		ark, err := psbtutil.Parse(arkPSBT)
+		if err != nil {
+			return nil, err
+		}
+
+		checkpointRaw, err := decodeLengthPrefixedBlobList(
+			checkpointPSBT,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		checkpoints, err := parsePSBTSlice(checkpointRaw)
+		if err != nil {
+			return nil, err
+		}
+
+		return &IncomingTransferEvent{
+			ArkPSBT:              ark,
+			FinalCheckpointPSBTs: checkpoints,
+		}, nil
+
+	case eventKindIncomingHandled:
+		outpoints, err := decodeOutPointList(outpointPayload)
+		if err != nil {
+			return nil, err
+		}
+
+		return &IncomingHandledEvent{
+			MaterializedOutpoints: outpoints,
+		}, nil
+
+	case eventKindIncomingAckSent:
+		return &IncomingAckSentEvent{}, nil
 
 	default:
 		return nil, fmt.Errorf("unknown event kind: %d", eventKind)

--- a/oor/actor_durable_message_test.go
+++ b/oor/actor_durable_message_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/vtxo"
 	"github.com/stretchr/testify/require"
 )
 
@@ -163,6 +164,121 @@ func TestDriveEventRequestRoundTripRetryDueEvent(t *testing.T) {
 
 	require.Equal(t, sessionID, decoded.SessionID)
 	require.IsType(t, &RetryDueEvent{}, decoded.Event)
+}
+
+// TestDriveEventRequestRoundTripIncomingTransferEvent asserts
+// DriveEventRequest TLV Encode/Decode round-trips IncomingTransferEvent
+// correctly.
+func TestDriveEventRequestRoundTripIncomingTransferEvent(t *testing.T) {
+	t.Parallel()
+
+	arkPSBT, checkpoints, _, _, _, _ :=
+		buildTestIncomingMaterialization(t)
+
+	sessionID := SessionID(arkPSBT.UnsignedTx.TxHash())
+	msg := &DriveEventRequest{
+		SessionID: sessionID,
+		Event: &IncomingTransferEvent{
+			SessionID:            sessionID,
+			ArkPSBT:              arkPSBT,
+			FinalCheckpointPSBTs: checkpoints,
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, msg.Encode(&buf))
+
+	decoded := &DriveEventRequest{}
+	require.NoError(t, decoded.Decode(&buf))
+
+	require.Equal(t, sessionID, decoded.SessionID)
+
+	incomingEvt, ok := decoded.Event.(*IncomingTransferEvent)
+	require.True(t, ok)
+	require.Equal(t, sessionID, incomingEvt.SessionID)
+	require.NotNil(t, incomingEvt.ArkPSBT)
+	require.Len(t, incomingEvt.FinalCheckpointPSBTs, len(checkpoints))
+}
+
+// TestDriveEventRequestRoundTripIncomingHandledEvent asserts
+// DriveEventRequest TLV Encode/Decode round-trips IncomingHandledEvent
+// correctly using durable outpoint identifiers.
+func TestDriveEventRequestRoundTripIncomingHandledEvent(t *testing.T) {
+	t.Parallel()
+
+	sessionID := SessionID(chainhash.Hash{8, 8, 8})
+	outpoint := wire.OutPoint{
+		Hash:  chainhash.Hash{9, 9, 9},
+		Index: 2,
+	}
+	msg := &DriveEventRequest{
+		SessionID: sessionID,
+		Event: &IncomingHandledEvent{
+			MaterializedVTXOs: []*vtxo.Descriptor{{
+				Outpoint: outpoint,
+			}},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, msg.Encode(&buf))
+
+	decoded := &DriveEventRequest{}
+	require.NoError(t, decoded.Decode(&buf))
+
+	require.Equal(t, sessionID, decoded.SessionID)
+
+	handledEvt, ok := decoded.Event.(*IncomingHandledEvent)
+	require.True(t, ok)
+	require.Len(t, handledEvt.MaterializedOutpoints, 1)
+	require.Equal(t, outpoint, handledEvt.MaterializedOutpoints[0])
+	require.Empty(t, handledEvt.MaterializedVTXOs)
+}
+
+// TestDriveEventRequestRoundTripIncomingAckSentEvent asserts
+// DriveEventRequest TLV Encode/Decode round-trips IncomingAckSentEvent
+// correctly.
+func TestDriveEventRequestRoundTripIncomingAckSentEvent(t *testing.T) {
+	t.Parallel()
+
+	sessionID := SessionID(chainhash.Hash{6, 6, 6})
+	msg := &DriveEventRequest{
+		SessionID: sessionID,
+		Event:     &IncomingAckSentEvent{},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, msg.Encode(&buf))
+
+	decoded := &DriveEventRequest{}
+	require.NoError(t, decoded.Decode(&buf))
+
+	require.Equal(t, sessionID, decoded.SessionID)
+	require.IsType(t, &IncomingAckSentEvent{}, decoded.Event)
+}
+
+// TestResolveIncomingTransferRequestRoundTrip asserts
+// ResolveIncomingTransferRequest TLV Encode/Decode round-trips the incoming
+// notification hint fields correctly.
+func TestResolveIncomingTransferRequestRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	sessionID := SessionID(chainhash.Hash{4, 5, 6})
+	msg := &ResolveIncomingTransferRequest{
+		SessionID:         sessionID,
+		RecipientPkScript: []byte{0x51, 0x20, 0x01, 0x02},
+		RecipientEventID:  7,
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, msg.Encode(&buf))
+
+	decoded := &ResolveIncomingTransferRequest{}
+	require.NoError(t, decoded.Decode(&buf))
+
+	require.Equal(t, sessionID, decoded.SessionID)
+	require.Equal(t, msg.RecipientPkScript, decoded.RecipientPkScript)
+	require.Equal(t, msg.RecipientEventID, decoded.RecipientEventID)
 }
 
 // TestDriveEventPayloadRequiresEvent asserts drive-event payload encoding

--- a/oor/actor_durable_message_test.go
+++ b/oor/actor_durable_message_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/tree"
 	"github.com/lightninglabs/darepo-client/vtxo"
 	"github.com/stretchr/testify/require"
 )
@@ -233,6 +234,56 @@ func TestDriveEventRequestRoundTripIncomingHandledEvent(t *testing.T) {
 	require.Len(t, handledEvt.MaterializedOutpoints, 1)
 	require.Equal(t, outpoint, handledEvt.MaterializedOutpoints[0])
 	require.Empty(t, handledEvt.MaterializedVTXOs)
+}
+
+// TestDriveEventRequestRoundTripIncomingMetadataResolvedEvent asserts
+// DriveEventRequest TLV Encode/Decode round-trips IncomingMetadataResolvedEvent
+// correctly.
+func TestDriveEventRequestRoundTripIncomingMetadataResolvedEvent(t *testing.T) {
+	t.Parallel()
+
+	sessionID := SessionID(chainhash.Hash{7, 7, 7})
+	msg := &DriveEventRequest{
+		SessionID: sessionID,
+		Event: &IncomingMetadataResolvedEvent{
+			Matches: []IncomingMetadataMatch{{
+				OutputIndex: 3,
+				Metadata: IncomingVTXOMetadata{
+					RoundID:        "round-test",
+					CommitmentTxID: chainhash.Hash{1, 2, 3},
+					BatchExpiry:    144,
+					TreeDepth:      2,
+					ChainDepth:     1,
+					CreatedHeight:  100,
+					TreePath:       &tree.Tree{},
+				},
+			}},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, msg.Encode(&buf))
+
+	decoded := &DriveEventRequest{}
+	require.NoError(t, decoded.Decode(&buf))
+
+	require.Equal(t, sessionID, decoded.SessionID)
+
+	resolvedEvt, ok := decoded.Event.(*IncomingMetadataResolvedEvent)
+	require.True(t, ok)
+	require.Len(t, resolvedEvt.Matches, 1)
+	require.Equal(t, uint32(3), resolvedEvt.Matches[0].OutputIndex)
+	require.Equal(t, "round-test",
+		resolvedEvt.Matches[0].Metadata.RoundID)
+	require.Equal(t, chainhash.Hash{1, 2, 3},
+		resolvedEvt.Matches[0].Metadata.CommitmentTxID)
+	require.Equal(t, int32(144),
+		resolvedEvt.Matches[0].Metadata.BatchExpiry)
+	require.Equal(t, 2, resolvedEvt.Matches[0].Metadata.TreeDepth)
+	require.Equal(t, 1, resolvedEvt.Matches[0].Metadata.ChainDepth)
+	require.Equal(t, int32(100),
+		resolvedEvt.Matches[0].Metadata.CreatedHeight)
+	require.NotNil(t, resolvedEvt.Matches[0].Metadata.TreePath)
 }
 
 // TestDriveEventRequestRoundTripIncomingAckSentEvent asserts

--- a/oor/actor_messages.go
+++ b/oor/actor_messages.go
@@ -31,12 +31,13 @@ func NewServiceKey() actor.ServiceKey[OORDurableMsg, ActorResp] {
 // identifier used for durable mailbox serialization. The 0x7xxx range avoids
 // collisions with the actor framework's reserved types.
 const (
-	StartTransferRequestTLVType  tlv.Type = 0x7010
-	DriveEventRequestTLVType     tlv.Type = 0x7011
-	GetStateRequestTLVType       tlv.Type = 0x7012
-	RestoreSessionRequestTLVType tlv.Type = 0x7013
-	ResumeSessionRequestTLVType  tlv.Type = 0x7014
-	ExportSnapshotRequestTLVType tlv.Type = 0x7015
+	StartTransferRequestTLVType    tlv.Type = 0x7010
+	DriveEventRequestTLVType       tlv.Type = 0x7011
+	GetStateRequestTLVType         tlv.Type = 0x7012
+	RestoreSessionRequestTLVType   tlv.Type = 0x7013
+	ResumeSessionRequestTLVType    tlv.Type = 0x7014
+	ExportSnapshotRequestTLVType   tlv.Type = 0x7015
+	ResolveIncomingTransferTLVType tlv.Type = 0x7016
 )
 
 // OORDurableMsg is the message constraint for the OOR durable actor mailbox.
@@ -277,6 +278,82 @@ func (m *DriveEventResponse) MessageType() string {
 // actorRespSealed marks this as implementing the sealed ActorResp interface.
 func (m *DriveEventResponse) actorRespSealed() {}
 
+// ResolveIncomingTransferRequest asks the actor to durably record a
+// lightweight incoming OOR notification and then resolve the full Ark package
+// asynchronously outside the live actor transaction.
+//
+// The serverconn dispatcher persists only the lightweight hint into the durable
+// OOR mailbox. The actor checkpoints a resolve-pending receive state first,
+// then performs the follow-up unary RPC on a detached callback path so restart
+// can safely re-drive the work.
+type ResolveIncomingTransferRequest struct {
+	actor.BaseMessage
+
+	// SessionID identifies the incoming transfer session.
+	SessionID SessionID
+
+	// RecipientPkScript is the registered receive script that matched the
+	// incoming OOR output.
+	RecipientPkScript []byte
+
+	// RecipientEventID is the monotonic per-script event ID for the incoming
+	// recipient event. The actor uses this as the cursor hint when querying the
+	// indexer for the full Ark PSBT payload.
+	RecipientEventID uint64
+}
+
+// MessageType returns the type of this message.
+func (m *ResolveIncomingTransferRequest) MessageType() string {
+	return "ResolveIncomingTransferRequest"
+}
+
+// actorMsgSealed marks this as implementing the sealed ActorMsg interface.
+func (m *ResolveIncomingTransferRequest) actorMsgSealed() {}
+
+// TLVType returns the unique TLV type identifier for this message.
+func (m *ResolveIncomingTransferRequest) TLVType() tlv.Type {
+	return ResolveIncomingTransferTLVType
+}
+
+// Encode serializes the message to the provided writer.
+func (m *ResolveIncomingTransferRequest) Encode(w io.Writer) error {
+	if m == nil {
+		return fmt.Errorf("resolve incoming transfer request must " +
+			"be provided")
+	}
+
+	raw, err := encodeResolveIncomingTransferPayload(
+		m.SessionID, m.RecipientPkScript, m.RecipientEventID,
+	)
+	if err != nil {
+		return err
+	}
+
+	_, err = w.Write(raw)
+
+	return err
+}
+
+// Decode deserializes the message from the provided reader.
+func (m *ResolveIncomingTransferRequest) Decode(r io.Reader) error {
+	raw, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+
+	sessionID, recipientPkScript, recipientEventID, err :=
+		decodeResolveIncomingTransferPayload(raw)
+	if err != nil {
+		return err
+	}
+
+	m.SessionID = sessionID
+	m.RecipientPkScript = recipientPkScript
+	m.RecipientEventID = recipientEventID
+
+	return nil
+}
+
 // GetStateRequest asks the actor for the current state of a session.
 type GetStateRequest struct {
 	actor.BaseMessage
@@ -332,7 +409,7 @@ type GetStateResponse struct {
 	actor.BaseMessage
 
 	// State is the current session state machine state.
-	State State
+	State SessionState
 }
 
 // MessageType returns the type of this message.

--- a/oor/actor_test.go
+++ b/oor/actor_test.go
@@ -922,6 +922,7 @@ func TestIsTransportEventClassification(t *testing.T) {
 		&SendSubmitPackageRequest{},
 		&SendFinalizePackageRequest{},
 		&SendIncomingAckRequest{},
+		&QueryIncomingMetadataRequest{},
 	}
 	for _, evt := range transportEvents {
 		require.True(

--- a/oor/actor_test.go
+++ b/oor/actor_test.go
@@ -14,7 +14,9 @@ import (
 	"github.com/lightninglabs/darepo-client/lib/scripts"
 	oortx "github.com/lightninglabs/darepo-client/lib/tx/oor"
 	"github.com/lightninglabs/darepo-client/serverconn"
+	"github.com/lightninglabs/darepo-client/vtxo"
 	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/stretchr/testify/require"
 )
 
@@ -236,6 +238,88 @@ func TestOORClientActorHappyPath(t *testing.T) {
 	require.Equal(t, PackageDirectionOutgoing, packageStore.lastDirection)
 	require.Equal(t, chainhash.Hash(startMsg.SessionID),
 		packageStore.lastSessionID)
+}
+
+// TestOORClientActorHandlesIncomingTransferWithoutExistingSession asserts the
+// actor can materialize a fresh incoming transfer before any session has been
+// registered under that session ID.
+func TestOORClientActorHandlesIncomingTransferWithoutExistingSession(
+	t *testing.T) {
+
+	t.Parallel()
+
+	ctx := t.Context()
+
+	arkPSBT, finalCheckpoints, recipients, parentCommitment, recipientKey,
+		operatorKey :=
+		buildTestIncomingMaterialization(t)
+
+	sessionID := SessionID(arkPSBT.UnsignedTx.TxHash())
+	store := newTestVTXOStore()
+	packageStore := &testPackageStore{}
+
+	notifyCalls := 0
+	actor := NewOORClientActor(ClientActorCfg{
+		OutboxHandler: &LocalPersistenceOutboxHandler{
+			Store:        store,
+			PackageStore: packageStore,
+			OperatorKey:  operatorKey,
+			ExitDelay:    10,
+			NotifyIncomingVTXOs: func(_ context.Context,
+				_ []*vtxo.Descriptor) error {
+
+				notifyCalls++
+				return nil
+			},
+			ResolveIncomingClientKey: func(_ context.Context,
+				_ ArkRecipientOutput) (
+				keychain.KeyDescriptor, error) {
+
+				return keychain.KeyDescriptor{
+					PubKey: recipientKey.PubKey(),
+				}, nil
+			},
+			ResolveIncomingMetadata: func(_ context.Context,
+				_ SessionID, _ ArkRecipientOutput, _ *psbt.Packet,
+				_ []*psbt.Packet) (IncomingVTXOMetadata, error) {
+
+				return IncomingVTXOMetadata{
+					RoundID:        "round-incoming",
+					CommitmentTxID: parentCommitment,
+					BatchExpiry:    1000,
+					TreeDepth:      1,
+					ChainDepth:     len(finalCheckpoints),
+					CreatedHeight:  700,
+				}, nil
+			},
+		},
+		DeliveryStore: newTestDeliveryStore(t),
+		ActorID:       "oor-actor-test-incoming",
+	})
+	defer actor.Stop()
+
+	resp := actor.Receive(ctx, &DriveEventRequest{
+		SessionID: sessionID,
+		Event: &IncomingTransferEvent{
+			SessionID:            sessionID,
+			ArkPSBT:              arkPSBT,
+			FinalCheckpointPSBTs: finalCheckpoints,
+		},
+	})
+	require.True(t, resp.IsOk())
+
+	liveVTXOs, err := store.ListLiveVTXOs(ctx)
+	require.NoError(t, err)
+	require.Len(t, liveVTXOs, 1)
+	require.Equal(t, 1, notifyCalls)
+	require.Equal(t, 1, packageStore.packageCalls)
+	require.Equal(t, 1, packageStore.bindingCalls)
+	require.Equal(t, "round-incoming", liveVTXOs[0].RoundID)
+	require.Equal(t, parentCommitment, liveVTXOs[0].CommitmentTxID)
+	require.Equal(t, wire.OutPoint{
+		Hash:  arkPSBT.UnsignedTx.TxHash(),
+		Index: recipients[0].OutputIndex,
+	}, liveVTXOs[0].Outpoint)
 }
 
 // retrySubmitOutboxHandler simulates a retryable transport error on the first

--- a/oor/actor_test.go
+++ b/oor/actor_test.go
@@ -119,6 +119,20 @@ func (h *testOutboxHandler) Handle(_ context.Context, sessionID SessionID,
 
 var _ OutboxHandler = (*testOutboxHandler)(nil)
 
+// noopOutboxHandler acknowledges local outbox events without producing any
+// follow-up events. Tests use this when they only need the actor plumbing,
+// not full wallet/server side effects.
+type noopOutboxHandler struct{}
+
+// Handle implements OutboxHandler.
+func (h *noopOutboxHandler) Handle(_ context.Context, _ SessionID,
+	_ OutboxEvent) ([]Event, error) {
+
+	return nil, nil
+}
+
+var _ OutboxHandler = (*noopOutboxHandler)(nil)
+
 // testOutgoingPackageStore records package persistence calls for assertions.
 type testOutgoingPackageStore struct {
 	packageCalls int
@@ -566,6 +580,50 @@ func (m *mockServerConnRef) lastSent() *serverconn.SendClientEventRequest {
 	return req
 }
 
+// lastRecipientQuery returns the most recent durable recipient-events query
+// captured by the mock. It fails the test if no messages have been captured.
+func (m *mockServerConnRef) lastRecipientQuery() *serverconn.
+	SendListOORRecipientEventsByScriptRequest {
+
+	m.t.Helper()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	require.NotEmpty(m.t, m.messages, "no messages captured")
+
+	last := m.messages[len(m.messages)-1]
+	req, ok := last.(*serverconn.SendListOORRecipientEventsByScriptRequest)
+	require.True(
+		m.t, ok,
+		"last message is not SendListOORRecipientEventsByScriptRequest",
+	)
+
+	return req
+}
+
+// lastVTXOQuery returns the most recent durable ListVTXOsByScripts query
+// captured by the mock. It fails the test if no messages have been captured.
+func (m *mockServerConnRef) lastVTXOQuery() *serverconn.
+	SendListVTXOsByScriptsRequest {
+
+	m.t.Helper()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	require.NotEmpty(m.t, m.messages, "no messages captured")
+
+	last := m.messages[len(m.messages)-1]
+	req, ok := last.(*serverconn.SendListVTXOsByScriptsRequest)
+	require.True(
+		m.t, ok,
+		"last message is not SendListVTXOsByScriptsRequest",
+	)
+
+	return req
+}
+
 // localOnlyOutboxHandler handles only local outbox events (signing,
 // persistence, timers). Transport events should be routed through serverconn
 // and never reach this handler.
@@ -922,6 +980,7 @@ func TestIsTransportEventClassification(t *testing.T) {
 		&SendSubmitPackageRequest{},
 		&SendFinalizePackageRequest{},
 		&SendIncomingAckRequest{},
+		&QueryIncomingTransferRequest{},
 		&QueryIncomingMetadataRequest{},
 	}
 	for _, evt := range transportEvents {

--- a/oor/checkpoint_sign.go
+++ b/oor/checkpoint_sign.go
@@ -392,8 +392,29 @@ func signCheckpointPSBT(signer input.Signer, in *TransferInput,
 		return err
 	}
 
-	return psbtutil.AddTaprootScriptSpendSig(
+	err = psbtutil.AddTaprootScriptSpendSig(
 		&checkpoint.Inputs[0], in.VTXO.ClientKey.PubKey,
 		spendInfo.WitnessScript, sigBytes, signDesc.HashType,
 	)
+	if err != nil {
+		return err
+	}
+
+	sigRec, err := findTaprootScriptSpendSig(
+		&checkpoint.Inputs[0], in.VTXO.ClientKey.PubKey,
+		spendInfo.WitnessScript,
+	)
+	if err != nil {
+		return err
+	}
+
+	err = verifyTaprootScriptSpendSig(
+		checkpoint.UnsignedTx, signDesc.InputIndex, prevFetcher,
+		spendInfo.WitnessScript, sigRec,
+	)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/oor/events.go
+++ b/oor/events.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/lib/scripts"
 	oortx "github.com/lightninglabs/darepo-client/lib/tx/oor"
 	"github.com/lightninglabs/darepo-client/vtxo"
@@ -172,6 +173,11 @@ type IncomingHandledEvent struct {
 	// persisted during materialization. The OOR actor forwards these
 	// to the VTXO manager so it can spawn monitoring actors.
 	MaterializedVTXOs []*vtxo.Descriptor
+
+	// MaterializedOutpoints identifies the persisted VTXOs by outpoint so
+	// durable callback delivery can round-trip the event without embedding
+	// the full descriptor payload in the mailbox record.
+	MaterializedOutpoints []wire.OutPoint
 }
 
 // eventSealed marks this as implementing the sealed Event interface.

--- a/oor/incoming_adapter.go
+++ b/oor/incoming_adapter.go
@@ -16,21 +16,11 @@ type IncomingOORFetcher func(ctx context.Context,
 	pkScript []byte, afterEventID uint64,
 	limit uint32) (*arkrpc.ListOORRecipientEventsByScriptResponse, error)
 
-// AdaptIncomingOOREvent converts a lightweight IncomingOOREvent
-// notification into a DriveEventRequest by querying the indexer for
-// the full Ark PSBT and checkpoint data.
-//
-// This function implements the notification→query pattern:
-//  1. Parse session ID from the notification
-//  2. Query indexer for the OOR recipient event with Ark PSBT
-//  3. Parse Ark PSBT and checkpoint PSBTs from the response
-//  4. Construct IncomingTransferEvent with full data
-//
-// It is used by both the production darepod route handler and the
-// systest route handler to ensure identical behavior.
-func AdaptIncomingOOREvent(ctx context.Context,
-	evt *arkrpc.IncomingOOREvent,
-	fetcher IncomingOORFetcher) (*DriveEventRequest, error) {
+// NewResolveIncomingTransferRequest converts a lightweight IncomingOOREvent
+// notification into a durable actor request that can be persisted without
+// blocking mailbox ingress on a follow-up indexer query.
+func NewResolveIncomingTransferRequest(evt *arkrpc.IncomingOOREvent) (
+	*ResolveIncomingTransferRequest, error) {
 
 	if evt == nil {
 		return nil, fmt.Errorf("nil IncomingOOREvent")
@@ -41,14 +31,26 @@ func AdaptIncomingOOREvent(ctx context.Context,
 		return nil, fmt.Errorf("parse session id: %w", err)
 	}
 
-	// Query the indexer for the full package data. The
-	// notification is just a hint — the query returns the Ark
-	// PSBT and checkpoint PSBTs.
+	return &ResolveIncomingTransferRequest{
+		SessionID:         SessionID(*sessionID),
+		RecipientPkScript: append([]byte(nil), evt.GetRecipientPkScript()...),
+		RecipientEventID:  evt.GetRecipientEventId(),
+	}, nil
+}
+
+// ResolveIncomingTransferEvent queries the indexer for full OOR package data
+// given a durable incoming-transfer hint and returns the complete incoming
+// transfer event for the receive FSM.
+func ResolveIncomingTransferEvent(ctx context.Context, sessionID SessionID,
+	recipientPkScript []byte, recipientEventID uint64,
+	fetcher IncomingOORFetcher) (*IncomingTransferEvent, error) {
+
+	if fetcher == nil {
+		return nil, fmt.Errorf("incoming OOR fetcher not configured")
+	}
+
 	resp, err := fetcher(
-		ctx,
-		evt.GetRecipientPkScript(),
-		evt.GetRecipientEventId()-1,
-		1,
+		ctx, recipientPkScript, recipientEventID-1, 1,
 	)
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -85,12 +87,44 @@ func AdaptIncomingOOREvent(ctx context.Context,
 		checkpoints = append(checkpoints, cp)
 	}
 
+	return &IncomingTransferEvent{
+		SessionID:            sessionID,
+		ArkPSBT:              arkPSBT,
+		FinalCheckpointPSBTs: checkpoints,
+	}, nil
+}
+
+// AdaptIncomingOOREvent converts a lightweight IncomingOOREvent
+// notification into a DriveEventRequest by querying the indexer for
+// the full Ark PSBT and checkpoint data.
+//
+// This function implements the notification→query pattern:
+//  1. Parse session ID from the notification
+//  2. Query indexer for the OOR recipient event with Ark PSBT
+//  3. Parse Ark PSBT and checkpoint PSBTs from the response
+//  4. Construct IncomingTransferEvent with full data
+//
+// It is used by both the production darepod route handler and the
+// systest route handler to ensure identical behavior.
+func AdaptIncomingOOREvent(ctx context.Context,
+	evt *arkrpc.IncomingOOREvent,
+	fetcher IncomingOORFetcher) (*DriveEventRequest, error) {
+
+	req, err := NewResolveIncomingTransferRequest(evt)
+	if err != nil {
+		return nil, err
+	}
+
+	incomingEvent, err := ResolveIncomingTransferEvent(
+		ctx, req.SessionID, req.RecipientPkScript,
+		req.RecipientEventID, fetcher,
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	return &DriveEventRequest{
-		SessionID: SessionID(*sessionID),
-		Event: &IncomingTransferEvent{
-			SessionID:            SessionID(*sessionID),
-			ArkPSBT:              arkPSBT,
-			FinalCheckpointPSBTs: checkpoints,
-		},
+		SessionID: req.SessionID,
+		Event:     incomingEvent,
 	}, nil
 }

--- a/oor/incoming_adapter.go
+++ b/oor/incoming_adapter.go
@@ -1,8 +1,9 @@
 package oor
 
 import (
-	"context"
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -10,11 +11,7 @@ import (
 	"github.com/lightninglabs/darepo-client/lib/tx/psbtutil"
 )
 
-// IncomingOORFetcher queries the indexer for full OOR package data
-// given a lightweight notification hint.
-type IncomingOORFetcher func(ctx context.Context,
-	pkScript []byte, afterEventID uint64,
-	limit uint32) (*arkrpc.ListOORRecipientEventsByScriptResponse, error)
+const incomingResolveCorrelationPrefix = "oor-incoming-resolve:"
 
 // NewResolveIncomingTransferRequest converts a lightweight IncomingOOREvent
 // notification into a durable actor request that can be persisted without
@@ -38,50 +35,100 @@ func NewResolveIncomingTransferRequest(evt *arkrpc.IncomingOOREvent) (
 	}, nil
 }
 
-// ResolveIncomingTransferEvent queries the indexer for full OOR package data
-// given a durable incoming-transfer hint and returns the complete incoming
-// transfer event for the receive FSM.
-func ResolveIncomingTransferEvent(ctx context.Context, sessionID SessionID,
-	recipientPkScript []byte, recipientEventID uint64,
-	fetcher IncomingOORFetcher) (*IncomingTransferEvent, error) {
+// IncomingResolveCorrelationID returns the stable unary correlation ID used
+// for durable incoming-transfer resolution queries for the given session and
+// recipient event.
+func IncomingResolveCorrelationID(sessionID SessionID,
+	recipientEventID uint64) string {
 
-	if fetcher == nil {
-		return nil, fmt.Errorf("incoming OOR fetcher not configured")
+	return incomingResolveCorrelationPrefix +
+		chainhash.Hash(sessionID).String() + ":" +
+		strconv.FormatUint(recipientEventID, 10)
+}
+
+// ParseIncomingResolveCorrelationID decodes a durable incoming-transfer
+// resolution query correlation ID back into the OOR session ID and recipient
+// event ID.
+func ParseIncomingResolveCorrelationID(correlationID string) (
+	SessionID, uint64, error) {
+
+	if len(correlationID) <= len(incomingResolveCorrelationPrefix) ||
+		correlationID[:len(incomingResolveCorrelationPrefix)] !=
+			incomingResolveCorrelationPrefix {
+
+		return SessionID{}, 0, fmt.Errorf("unexpected incoming resolve "+
+			"correlation id: %q", correlationID)
 	}
 
-	resp, err := fetcher(
-		ctx, recipientPkScript, recipientEventID-1, 1,
-	)
+	suffix := correlationID[len(incomingResolveCorrelationPrefix):]
+	parts := strings.SplitN(suffix, ":", 2)
+	if len(parts) != 2 {
+		return SessionID{}, 0, fmt.Errorf("unexpected incoming resolve "+
+			"correlation id payload: %q", suffix)
+	}
+
+	hash, err := chainhash.NewHashFromStr(parts[0])
 	if err != nil {
-		return nil, fmt.Errorf(
-			"fetch OOR package for session %x: %w",
-			sessionID[:], err,
-		)
+		return SessionID{}, 0, fmt.Errorf("parse incoming resolve "+
+			"session id: %w", err)
+	}
+
+	recipientEventID, err := strconv.ParseUint(parts[1], 10, 64)
+	if err != nil {
+		return SessionID{}, 0, fmt.Errorf("parse incoming resolve "+
+			"event id: %w", err)
+	}
+
+	return SessionID(*hash), recipientEventID, nil
+}
+
+// IncomingTransferEventFromResponse validates and converts one
+// ListOORRecipientEventsByScriptResponse payload into the complete incoming
+// transfer event expected by the receive FSM.
+func IncomingTransferEventFromResponse(sessionID SessionID,
+	recipientEventID uint64,
+	resp *arkrpc.ListOORRecipientEventsByScriptResponse) (
+	*IncomingTransferEvent, error) {
+
+	if resp == nil {
+		return nil, fmt.Errorf("incoming transfer response must be " +
+			"provided")
 	}
 
 	if len(resp.GetEvents()) == 0 {
-		return nil, fmt.Errorf(
-			"no events found for session %x",
-			sessionID[:],
-		)
+		return nil, fmt.Errorf("no events found for session %x",
+			sessionID[:])
 	}
 
 	recipientEvt := resp.Events[0]
+	if recipientEvt == nil {
+		return nil, fmt.Errorf("incoming transfer event must be provided")
+	}
 
-	// Parse the Ark PSBT from the query response.
+	if recipientEvt.GetEventId() != recipientEventID {
+		return nil, fmt.Errorf("unexpected recipient event id: got %d, "+
+			"want %d", recipientEvt.GetEventId(), recipientEventID)
+	}
+
+	eventSessionID, err := chainhash.NewHash(recipientEvt.GetSessionId())
+	if err != nil {
+		return nil, fmt.Errorf("parse event session id: %w", err)
+	}
+	if SessionID(*eventSessionID) != sessionID {
+		return nil, fmt.Errorf("incoming transfer session mismatch")
+	}
+
 	arkPSBT, err := psbtutil.Parse(recipientEvt.GetArkPsbt())
 	if err != nil {
 		return nil, fmt.Errorf("parse ark psbt: %w", err)
 	}
 
-	// Parse checkpoint PSBTs.
-	var checkpoints []*psbt.Packet
+	checkpoints := make([]*psbt.Packet, 0,
+		len(recipientEvt.GetCheckpointPsbts()))
 	for _, cpRaw := range recipientEvt.GetCheckpointPsbts() {
 		cp, cpErr := psbtutil.Parse(cpRaw)
 		if cpErr != nil {
-			return nil, fmt.Errorf(
-				"parse checkpoint: %w", cpErr,
-			)
+			return nil, fmt.Errorf("parse checkpoint: %w", cpErr)
 		}
 
 		checkpoints = append(checkpoints, cp)
@@ -91,40 +138,5 @@ func ResolveIncomingTransferEvent(ctx context.Context, sessionID SessionID,
 		SessionID:            sessionID,
 		ArkPSBT:              arkPSBT,
 		FinalCheckpointPSBTs: checkpoints,
-	}, nil
-}
-
-// AdaptIncomingOOREvent converts a lightweight IncomingOOREvent
-// notification into a DriveEventRequest by querying the indexer for
-// the full Ark PSBT and checkpoint data.
-//
-// This function implements the notification→query pattern:
-//  1. Parse session ID from the notification
-//  2. Query indexer for the OOR recipient event with Ark PSBT
-//  3. Parse Ark PSBT and checkpoint PSBTs from the response
-//  4. Construct IncomingTransferEvent with full data
-//
-// It is used by both the production darepod route handler and the
-// systest route handler to ensure identical behavior.
-func AdaptIncomingOOREvent(ctx context.Context,
-	evt *arkrpc.IncomingOOREvent,
-	fetcher IncomingOORFetcher) (*DriveEventRequest, error) {
-
-	req, err := NewResolveIncomingTransferRequest(evt)
-	if err != nil {
-		return nil, err
-	}
-
-	incomingEvent, err := ResolveIncomingTransferEvent(
-		ctx, req.SessionID, req.RecipientPkScript,
-		req.RecipientEventID, fetcher,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	return &DriveEventRequest{
-		SessionID: req.SessionID,
-		Event:     incomingEvent,
 	}, nil
 }

--- a/oor/incoming_adapter.go
+++ b/oor/incoming_adapter.go
@@ -1,0 +1,96 @@
+package oor
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightninglabs/darepo-client/arkrpc"
+	"github.com/lightninglabs/darepo-client/lib/tx/psbtutil"
+)
+
+// IncomingOORFetcher queries the indexer for full OOR package data
+// given a lightweight notification hint.
+type IncomingOORFetcher func(ctx context.Context,
+	pkScript []byte, afterEventID uint64,
+	limit uint32) (*arkrpc.ListOORRecipientEventsByScriptResponse, error)
+
+// AdaptIncomingOOREvent converts a lightweight IncomingOOREvent
+// notification into a DriveEventRequest by querying the indexer for
+// the full Ark PSBT and checkpoint data.
+//
+// This function implements the notification→query pattern:
+//  1. Parse session ID from the notification
+//  2. Query indexer for the OOR recipient event with Ark PSBT
+//  3. Parse Ark PSBT and checkpoint PSBTs from the response
+//  4. Construct IncomingTransferEvent with full data
+//
+// It is used by both the production darepod route handler and the
+// systest route handler to ensure identical behavior.
+func AdaptIncomingOOREvent(ctx context.Context,
+	evt *arkrpc.IncomingOOREvent,
+	fetcher IncomingOORFetcher) (*DriveEventRequest, error) {
+
+	if evt == nil {
+		return nil, fmt.Errorf("nil IncomingOOREvent")
+	}
+
+	sessionID, err := chainhash.NewHash(evt.GetSessionId())
+	if err != nil {
+		return nil, fmt.Errorf("parse session id: %w", err)
+	}
+
+	// Query the indexer for the full package data. The
+	// notification is just a hint — the query returns the Ark
+	// PSBT and checkpoint PSBTs.
+	resp, err := fetcher(
+		ctx,
+		evt.GetRecipientPkScript(),
+		evt.GetRecipientEventId()-1,
+		1,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"fetch OOR package for session %x: %w",
+			sessionID[:], err,
+		)
+	}
+
+	if len(resp.GetEvents()) == 0 {
+		return nil, fmt.Errorf(
+			"no events found for session %x",
+			sessionID[:],
+		)
+	}
+
+	recipientEvt := resp.Events[0]
+
+	// Parse the Ark PSBT from the query response.
+	arkPSBT, err := psbtutil.Parse(recipientEvt.GetArkPsbt())
+	if err != nil {
+		return nil, fmt.Errorf("parse ark psbt: %w", err)
+	}
+
+	// Parse checkpoint PSBTs.
+	var checkpoints []*psbt.Packet
+	for _, cpRaw := range recipientEvt.GetCheckpointPsbts() {
+		cp, cpErr := psbtutil.Parse(cpRaw)
+		if cpErr != nil {
+			return nil, fmt.Errorf(
+				"parse checkpoint: %w", cpErr,
+			)
+		}
+
+		checkpoints = append(checkpoints, cp)
+	}
+
+	return &DriveEventRequest{
+		SessionID: SessionID(*sessionID),
+		Event: &IncomingTransferEvent{
+			SessionID:            SessionID(*sessionID),
+			ArkPSBT:              arkPSBT,
+			FinalCheckpointPSBTs: checkpoints,
+		},
+	}, nil
+}

--- a/oor/incoming_metadata_query.go
+++ b/oor/incoming_metadata_query.go
@@ -1,0 +1,151 @@
+package oor
+
+import (
+	"fmt"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightninglabs/darepo-client/arkrpc"
+	clientdb "github.com/lightninglabs/darepo-client/db"
+)
+
+const incomingMetadataCorrelationPrefix = "oor-incoming-metadata:"
+
+// IncomingMetadataMatch carries authoritative metadata for one materialized
+// incoming Ark output.
+type IncomingMetadataMatch struct {
+	// OutputIndex identifies the Ark output this metadata belongs to.
+	OutputIndex uint32
+
+	// Metadata carries the authoritative lineage and expiry data.
+	Metadata IncomingVTXOMetadata
+}
+
+// IncomingMetadataResolvedEvent delivers the authoritative incoming metadata
+// query result back into the receive FSM.
+type IncomingMetadataResolvedEvent struct {
+	// Matches contains metadata keyed by Ark output index for the current
+	// incoming transfer session.
+	Matches []IncomingMetadataMatch
+}
+
+// eventSealed marks this as implementing the sealed Event interface.
+func (e *IncomingMetadataResolvedEvent) eventSealed() {}
+
+// IncomingMetadataCorrelationID returns the stable unary correlation ID used
+// for durable incoming metadata queries for the given session.
+func IncomingMetadataCorrelationID(sessionID SessionID) string {
+	return incomingMetadataCorrelationPrefix +
+		chainhash.Hash(sessionID).String()
+}
+
+// ParseIncomingMetadataCorrelationID decodes a durable incoming metadata query
+// correlation ID back into the OOR session ID.
+func ParseIncomingMetadataCorrelationID(correlationID string) (
+	SessionID, error) {
+
+	if len(correlationID) <= len(incomingMetadataCorrelationPrefix) ||
+		correlationID[:len(incomingMetadataCorrelationPrefix)] !=
+			incomingMetadataCorrelationPrefix {
+
+		return SessionID{}, fmt.Errorf("unexpected incoming metadata "+
+			"correlation id: %q", correlationID)
+	}
+
+	hash, err := chainhash.NewHashFromStr(
+		correlationID[len(incomingMetadataCorrelationPrefix):],
+	)
+	if err != nil {
+		return SessionID{}, fmt.Errorf("parse incoming metadata "+
+			"session id: %w", err)
+	}
+
+	return SessionID(*hash), nil
+}
+
+// IncomingMetadataMatchesFromResponse filters an indexer
+// ListVTXOsByScriptsResponse down to the entries created by the given Ark
+// session and converts them into the local incoming metadata shape.
+func IncomingMetadataMatchesFromResponse(sessionID SessionID,
+	resp *arkrpc.ListVTXOsByScriptsResponse) ([]IncomingMetadataMatch, error) {
+
+	if resp == nil {
+		return nil, fmt.Errorf("incoming metadata response must be provided")
+	}
+
+	matches := make([]IncomingMetadataMatch, 0, len(resp.GetVtxos()))
+	for _, candidate := range resp.GetVtxos() {
+		if candidate == nil {
+			continue
+		}
+
+		outpoint := candidate.GetOutpoint()
+		if outpoint == nil {
+			return nil, fmt.Errorf("indexer vtxo missing outpoint")
+		}
+
+		if !matchesIncomingVTXO(sessionID, outpoint.GetTxid()) {
+			continue
+		}
+
+		metadata, err := incomingMetadataFromRPC(candidate)
+		if err != nil {
+			return nil, err
+		}
+
+		matches = append(matches, IncomingMetadataMatch{
+			OutputIndex: outpoint.GetVout(),
+			Metadata:    metadata,
+		})
+	}
+
+	return matches, nil
+}
+
+// matchesIncomingVTXO reports whether the candidate txid belongs to the
+// current Ark session.
+func matchesIncomingVTXO(sessionID SessionID, txid []byte) bool {
+	return len(txid) == chainhash.HashSize &&
+		string(txid) == string(sessionID[:])
+}
+
+// incomingMetadataFromRPC maps the authoritative indexer VTXO view into the
+// metadata shape required by the incoming OOR materialization path.
+func incomingMetadataFromRPC(candidate *arkrpc.VTXO) (
+	IncomingVTXOMetadata, error) {
+
+	if candidate == nil {
+		return IncomingVTXOMetadata{}, fmt.Errorf("indexer vtxo " +
+			"must be provided")
+	}
+
+	if candidate.GetRoundId() == "" {
+		return IncomingVTXOMetadata{}, fmt.Errorf("indexer vtxo " +
+			"missing round id")
+	}
+
+	if len(candidate.GetCommitmentTxid()) != chainhash.HashSize {
+		return IncomingVTXOMetadata{}, fmt.Errorf("indexer vtxo " +
+			"missing commitment txid")
+	}
+
+	treePath, err := clientdb.DeserializeTree(
+		candidate.GetTreePathTlv(),
+	)
+	if err != nil {
+		return IncomingVTXOMetadata{}, fmt.Errorf("deserialize "+
+			"tree path: %w", err)
+	}
+
+	var commitmentTxID chainhash.Hash
+	copy(commitmentTxID[:], candidate.GetCommitmentTxid())
+
+	return IncomingVTXOMetadata{
+		RoundID:        candidate.GetRoundId(),
+		CommitmentTxID: commitmentTxID,
+		BatchExpiry:    candidate.GetBatchExpiryHeight(),
+		TreeDepth:      int(candidate.GetTreeDepth()),
+		ChainDepth:     int(candidate.GetChainDepth()),
+		CreatedHeight:  candidate.GetCreatedHeight(),
+		TreePath:       treePath,
+	}, nil
+}

--- a/oor/interfaces.go
+++ b/oor/interfaces.go
@@ -18,6 +18,10 @@ type StateTransition = protofsm.StateTransition[
 // when state transitions emit new events or outbox messages.
 type EmittedEvent = protofsm.EmittedEvent[Event, OutboxEvent]
 
+// SessionState is the common protofsm state interface implemented by both the
+// outgoing and incoming OOR session state machines.
+type SessionState = protofsm.State[Event, OutboxEvent, *Environment]
+
 // StateMachine is a type alias for the OOR client transfer FSM.
 type StateMachine = protofsm.StateMachine[
 	Event, OutboxEvent, *Environment,

--- a/oor/local_persistence_handler.go
+++ b/oor/local_persistence_handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/baselib/actor"
 	"github.com/lightninglabs/darepo-client/vtxo"
 	"github.com/lightningnetwork/lnd/keychain"
 )
@@ -44,10 +45,10 @@ type IncomingMetadataResolver func(ctx context.Context, sessionID SessionID,
 	recipient ArkRecipientOutput, ark *psbt.Packet,
 	finalCheckpoints []*psbt.Packet) (IncomingVTXOMetadata, error)
 
-// SpendCompleter finalizes an OOR spend by routing the completion through the
-// VTXO manager so each VTXO actor transitions to SpentState via its own FSM.
-// This replaces the previous direct-store-write pattern and ensures the VTXO
-// actor remains the single source of truth for availability state.
+// SpendCompleter enqueues OOR spend completion through the VTXO manager so
+// each VTXO actor transitions to SpentState via its own FSM. Implementations
+// should avoid blocking on downstream DB writes because the OOR durable actor
+// may already be running inside a transaction.
 type SpendCompleter func(ctx context.Context,
 	outpoints []wire.OutPoint) error
 
@@ -99,10 +100,15 @@ type LocalPersistenceOutboxHandler struct {
 	// received OOR VTXOs are actively monitored.
 	NotifyIncomingVTXOs IncomingVTXONotifier
 
-	// CompleteSpend routes OOR spend completion through the VTXO manager
-	// so each consumed VTXO transitions to SpentState via its own FSM.
-	// When nil, the handler falls back to direct store writes for
-	// backwards compatibility during migration.
+	// CallbackRef receives async materialization results so the handler can
+	// resume the durable actor with a fresh DriveEventRequest after the
+	// blocking indexer lookup finishes outside the actor transaction.
+	CallbackRef actor.TellOnlyRef[OORDurableMsg]
+
+	// CompleteSpend enqueues OOR spend completion through the VTXO
+	// manager so each consumed VTXO transitions to SpentState via its
+	// own FSM. When nil, the handler falls back to direct store writes
+	// for backwards compatibility during migration.
 	CompleteSpend SpendCompleter
 }
 
@@ -140,10 +146,10 @@ func (h *LocalPersistenceOutboxHandler) Handle(ctx context.Context,
 
 // handleMarkInputsSpent completes the OOR spend for consumed VTXO inputs.
 //
-// When CompleteSpend is configured, the handler routes completion through the
-// VTXO manager so each VTXO actor transitions to SpentState via its own FSM.
-// This ensures the VTXO actor remains the single source of truth for
-// availability state.
+// When CompleteSpend is configured, the handler enqueues completion through
+// the VTXO manager so each VTXO actor transitions to SpentState via its own
+// FSM. This keeps the VTXO actor as the source of truth for availability
+// state without blocking the OOR durable actor on nested write transactions.
 //
 // When CompleteSpend is nil, the handler falls back to direct store writes
 // for backwards compatibility during migration.
@@ -197,35 +203,115 @@ func (h *LocalPersistenceOutboxHandler) handleMaterializeIncoming(
 	ctx context.Context,
 	msg *MaterializeIncomingVTXOsRequest) ([]Event, error) {
 
+	err := h.validateMaterializeIncoming(ctx, msg)
+	if err != nil {
+		return nil, err
+	}
+
+	if hasActorDBTx(ctx) {
+		return h.scheduleMaterializeIncoming(ctx, msg)
+	}
+
+	return h.materializeIncoming(ctx, msg, true)
+}
+
+// validateMaterializeIncoming verifies the dependencies needed to materialize
+// an incoming transfer.
+func (h *LocalPersistenceOutboxHandler) validateMaterializeIncoming(
+	ctx context.Context, msg *MaterializeIncomingVTXOsRequest) error {
+
+	if msg == nil {
+		return fmt.Errorf("materialize request must be provided")
+	}
+
 	if h.Store == nil {
-		return nil, fmt.Errorf("vtxo store must be provided")
+		return fmt.Errorf("vtxo store must be provided")
 	}
 
 	if h.OperatorKey == nil {
-		return nil, fmt.Errorf("operator key must be provided")
+		return fmt.Errorf("operator key must be provided")
 	}
 
 	if h.ResolveIncomingClientKey == nil {
-		return nil, fmt.Errorf(
+		return fmt.Errorf(
 			"incoming client key resolver must be provided",
 		)
 	}
 
 	if h.ResolveIncomingMetadata == nil {
-		return nil, fmt.Errorf(
+		return fmt.Errorf(
 			"incoming metadata resolver must be provided",
 		)
 	}
 
-	if h.NotifyIncomingVTXOs == nil {
-		return nil, fmt.Errorf(
+	if hasActorDBTx(ctx) && h.CallbackRef == nil {
+		return fmt.Errorf(
+			"incoming materialization callback ref must be " +
+				"provided",
+		)
+	}
+
+	if h.NotifyIncomingVTXOs == nil &&
+		!hasActorDBTx(ctx) && h.CallbackRef == nil {
+
+		return fmt.Errorf(
 			"incoming VTXO notifier must be provided",
 		)
 	}
 
 	if len(msg.Recipients) == 0 {
-		return nil, fmt.Errorf("incoming recipients must be provided")
+		return fmt.Errorf("incoming recipients must be provided")
 	}
+
+	return nil
+}
+
+// scheduleMaterializeIncoming moves the incoming materialization work off the
+// durable actor transaction and delivers the result back as a fresh actor
+// event once the blocking indexer query completes.
+func (h *LocalPersistenceOutboxHandler) scheduleMaterializeIncoming(
+	ctx context.Context,
+	msg *MaterializeIncomingVTXOsRequest) ([]Event, error) {
+
+	if msg == nil {
+		return nil, fmt.Errorf("materialize request must be provided")
+	}
+
+	opCtx := actor.WithoutOutboxID(
+		actor.WithoutTx(context.WithoutCancel(ctx)),
+	)
+
+	go func() {
+		followUps, err := h.materializeIncoming(opCtx, msg, false)
+		if err != nil {
+			followUps = []Event{&FailEvent{
+				Reason: fmt.Sprintf("materialize incoming: %v", err),
+			}}
+		}
+
+		for _, followUp := range followUps {
+			tellErr := h.CallbackRef.Tell(opCtx, &DriveEventRequest{
+				SessionID: msg.SessionID,
+				Event:     followUp,
+			})
+			if tellErr != nil {
+				log.WarnS(opCtx, "Failed to deliver incoming "+
+					"materialization result", tellErr,
+					slog.String("session_id",
+						msg.SessionID.String()))
+			}
+		}
+	}()
+
+	return nil, nil
+}
+
+// materializeIncoming persists recipient VTXOs for an incoming transfer and
+// optionally notifies the VTXO manager directly when the caller is not
+// resuming the durable actor with a follow-up event.
+func (h *LocalPersistenceOutboxHandler) materializeIncoming(
+	ctx context.Context, msg *MaterializeIncomingVTXOsRequest,
+	notifyIncoming bool) ([]Event, error) {
 
 	log.InfoS(ctx, "Materializing incoming VTXOs",
 		slog.String("session_id", msg.SessionID.String()),
@@ -233,6 +319,7 @@ func (h *LocalPersistenceOutboxHandler) handleMaterializeIncoming(
 
 	ownedRecipients := 0
 	materializedVTXOs := make([]*vtxo.Descriptor, 0, len(msg.Recipients))
+	materializedOutpoints := make([]wire.OutPoint, 0, len(msg.Recipients))
 	sessionIDHash := chainhash.Hash(msg.SessionID)
 
 	if h.PackageStore != nil {
@@ -247,7 +334,6 @@ func (h *LocalPersistenceOutboxHandler) handleMaterializeIncoming(
 
 	for i := range msg.Recipients {
 		recipient := msg.Recipients[i]
-
 		clientKey, err := h.ResolveIncomingClientKey(ctx, recipient)
 		if err != nil {
 			if IsIncomingRecipientNotOwned(err) {
@@ -264,8 +350,23 @@ func (h *LocalPersistenceOutboxHandler) handleMaterializeIncoming(
 			msg.FinalCheckpointPSBTs,
 		)
 		if err != nil {
+			log.DebugS(ctx, "Incoming metadata resolution failed",
+				slog.String("session_id", msg.SessionID.String()),
+				slog.Int("output_index",
+					int(recipient.OutputIndex)),
+				slog.String("pk_script",
+					fmt.Sprintf("%x", recipient.PkScript)),
+				slog.String("err", err.Error()))
+
 			return nil, err
 		}
+
+		log.DebugS(ctx, "Resolved incoming metadata",
+			slog.String("session_id", msg.SessionID.String()),
+			slog.Int("output_index", int(recipient.OutputIndex)),
+			slog.String("round_id", metadata.RoundID),
+			slog.Int("tree_depth", metadata.TreeDepth),
+			slog.Int("chain_depth", metadata.ChainDepth))
 
 		desc, err := BuildIncomingVTXODescriptor(msg.ArkPSBT,
 			IncomingVTXOConfig{
@@ -303,6 +404,9 @@ func (h *LocalPersistenceOutboxHandler) handleMaterializeIncoming(
 		}
 
 		materializedVTXOs = append(materializedVTXOs, desc)
+		materializedOutpoints = append(
+			materializedOutpoints, desc.Outpoint,
+		)
 
 		if h.PackageStore != nil {
 			err := h.PackageStore.UpsertBinding(
@@ -326,16 +430,32 @@ func (h *LocalPersistenceOutboxHandler) handleMaterializeIncoming(
 		slog.Int("owned_recipients", ownedRecipients),
 		slog.Int("materialized_vtxos", len(materializedVTXOs)))
 
-	// Notify the VTXO manager so newly received OOR VTXOs are
-	// actively monitored for expiry and spend.
-	err := h.NotifyIncomingVTXOs(ctx, materializedVTXOs)
-	if err != nil {
-		return nil, err
+	// When the durable actor will receive an IncomingHandledEvent follow-up,
+	// defer notification to that actor path so the manager only sees the
+	// materialization once.
+	if notifyIncoming {
+		// Notify the VTXO manager so newly received OOR VTXOs are
+		// actively monitored for expiry and spend.
+		err := h.NotifyIncomingVTXOs(
+			ctx, materializedVTXOs,
+		)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return []Event{&IncomingHandledEvent{
-		MaterializedVTXOs: materializedVTXOs,
+		MaterializedVTXOs:     materializedVTXOs,
+		MaterializedOutpoints: materializedOutpoints,
 	}}, nil
+}
+
+// hasActorDBTx reports whether the current context is already scoped to a
+// durable actor database transaction.
+func hasActorDBTx(ctx context.Context) bool {
+	_, ok := actor.TxFromContext(ctx)
+
+	return ok
 }
 
 // handleIncomingAck forwards the ack request to the transport boundary (if

--- a/oor/local_persistence_handler.go
+++ b/oor/local_persistence_handler.go
@@ -97,13 +97,9 @@ type LocalPersistenceOutboxHandler struct {
 
 	// NotifyIncomingVTXOs is invoked after incoming VTXOs are persisted.
 	// Production wiring should use this to notify the VTXO manager so newly
-	// received OOR VTXOs are actively monitored.
+	// received OOR VTXOs are actively monitored when the handler is used
+	// outside the OOR durable actor.
 	NotifyIncomingVTXOs IncomingVTXONotifier
-
-	// CallbackRef receives async materialization results so the handler can
-	// resume the durable actor with a fresh DriveEventRequest after the
-	// blocking indexer lookup finishes outside the actor transaction.
-	CallbackRef actor.TellOnlyRef[OORDurableMsg]
 
 	// CompleteSpend enqueues OOR spend completion through the VTXO
 	// manager so each consumed VTXO transitions to SpentState via its
@@ -128,6 +124,9 @@ func (h *LocalPersistenceOutboxHandler) Handle(ctx context.Context,
 	switch msg := outbox.(type) {
 	case *MarkInputsSpentRequest:
 		return h.handleMarkInputsSpent(ctx, msg)
+
+	case *QueryIncomingMetadataRequest:
+		return h.handleQueryIncomingMetadata(ctx, msg)
 
 	case *MaterializeIncomingVTXOsRequest:
 		return h.handleMaterializeIncoming(ctx, msg)
@@ -208,11 +207,7 @@ func (h *LocalPersistenceOutboxHandler) handleMaterializeIncoming(
 		return nil, err
 	}
 
-	if hasActorDBTx(ctx) {
-		return h.scheduleMaterializeIncoming(ctx, msg)
-	}
-
-	return h.materializeIncoming(ctx, msg, true)
+	return h.materializeIncoming(ctx, msg, !hasActorDBTx(ctx))
 }
 
 // validateMaterializeIncoming verifies the dependencies needed to materialize
@@ -238,21 +233,7 @@ func (h *LocalPersistenceOutboxHandler) validateMaterializeIncoming(
 		)
 	}
 
-	if h.ResolveIncomingMetadata == nil {
-		return fmt.Errorf(
-			"incoming metadata resolver must be provided",
-		)
-	}
-
-	if hasActorDBTx(ctx) && h.CallbackRef == nil {
-		return fmt.Errorf(
-			"incoming materialization callback ref must be " +
-				"provided",
-		)
-	}
-
-	if h.NotifyIncomingVTXOs == nil &&
-		!hasActorDBTx(ctx) && h.CallbackRef == nil {
+	if h.NotifyIncomingVTXOs == nil && !hasActorDBTx(ctx) {
 
 		return fmt.Errorf(
 			"incoming VTXO notifier must be provided",
@@ -266,44 +247,57 @@ func (h *LocalPersistenceOutboxHandler) validateMaterializeIncoming(
 	return nil
 }
 
-// scheduleMaterializeIncoming moves the incoming materialization work off the
-// durable actor transaction and delivers the result back as a fresh actor
-// event once the blocking indexer query completes.
-func (h *LocalPersistenceOutboxHandler) scheduleMaterializeIncoming(
+// handleQueryIncomingMetadata resolves authoritative metadata for owned
+// recipients when the OOR actor is running without the durable serverconn
+// request/response path.
+func (h *LocalPersistenceOutboxHandler) handleQueryIncomingMetadata(
 	ctx context.Context,
-	msg *MaterializeIncomingVTXOsRequest) ([]Event, error) {
+	msg *QueryIncomingMetadataRequest) ([]Event, error) {
 
 	if msg == nil {
-		return nil, fmt.Errorf("materialize request must be provided")
+		return nil, fmt.Errorf("incoming metadata query must be provided")
 	}
 
-	opCtx := actor.WithoutOutboxID(
-		actor.WithoutTx(context.WithoutCancel(ctx)),
-	)
+	if h.ResolveIncomingClientKey == nil {
+		return nil, fmt.Errorf("incoming client key resolver must be " +
+			"provided")
+	}
 
-	go func() {
-		followUps, err := h.materializeIncoming(opCtx, msg, false)
+	if h.ResolveIncomingMetadata == nil {
+		return nil, fmt.Errorf("incoming metadata resolver must be " +
+			"provided")
+	}
+
+	matches := make([]IncomingMetadataMatch, 0, len(msg.Recipients))
+	for i := range msg.Recipients {
+		recipient := msg.Recipients[i]
+
+		_, err := h.ResolveIncomingClientKey(ctx, recipient)
 		if err != nil {
-			followUps = []Event{&FailEvent{
-				Reason: fmt.Sprintf("materialize incoming: %v", err),
-			}}
-		}
-
-		for _, followUp := range followUps {
-			tellErr := h.CallbackRef.Tell(opCtx, &DriveEventRequest{
-				SessionID: msg.SessionID,
-				Event:     followUp,
-			})
-			if tellErr != nil {
-				log.WarnS(opCtx, "Failed to deliver incoming "+
-					"materialization result", tellErr,
-					slog.String("session_id",
-						msg.SessionID.String()))
+			if IsIncomingRecipientNotOwned(err) {
+				continue
 			}
-		}
-	}()
 
-	return nil, nil
+			return nil, err
+		}
+
+		metadata, err := h.ResolveIncomingMetadata(
+			ctx, msg.SessionID, recipient, msg.ArkPSBT,
+			msg.FinalCheckpointPSBTs,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		matches = append(matches, IncomingMetadataMatch{
+			OutputIndex: recipient.OutputIndex,
+			Metadata:    metadata,
+		})
+	}
+
+	return []Event{&IncomingMetadataResolvedEvent{
+		Matches: matches,
+	}}, nil
 }
 
 // materializeIncoming persists recipient VTXOs for an incoming transfer and
@@ -321,6 +315,13 @@ func (h *LocalPersistenceOutboxHandler) materializeIncoming(
 	materializedVTXOs := make([]*vtxo.Descriptor, 0, len(msg.Recipients))
 	materializedOutpoints := make([]wire.OutPoint, 0, len(msg.Recipients))
 	sessionIDHash := chainhash.Hash(msg.SessionID)
+	metadataByOutput := make(map[uint32]IncomingVTXOMetadata,
+		len(msg.MetadataMatches))
+
+	for i := range msg.MetadataMatches {
+		match := msg.MetadataMatches[i]
+		metadataByOutput[match.OutputIndex] = match.Metadata
+	}
 
 	if h.PackageStore != nil {
 		err := h.PackageStore.UpsertPackage(ctx,
@@ -345,20 +346,23 @@ func (h *LocalPersistenceOutboxHandler) materializeIncoming(
 
 		ownedRecipients++
 
-		metadata, err := h.ResolveIncomingMetadata(
-			ctx, msg.SessionID, recipient, msg.ArkPSBT,
-			msg.FinalCheckpointPSBTs,
-		)
-		if err != nil {
-			log.DebugS(ctx, "Incoming metadata resolution failed",
-				slog.String("session_id", msg.SessionID.String()),
-				slog.Int("output_index",
-					int(recipient.OutputIndex)),
-				slog.String("pk_script",
-					fmt.Sprintf("%x", recipient.PkScript)),
-				slog.String("err", err.Error()))
+		metadata, ok := metadataByOutput[recipient.OutputIndex]
+		if !ok && h.ResolveIncomingMetadata != nil &&
+			!hasActorDBTx(ctx) {
 
-			return nil, err
+			metadata, err = h.ResolveIncomingMetadata(
+				ctx, msg.SessionID, recipient, msg.ArkPSBT,
+				msg.FinalCheckpointPSBTs,
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			ok = true
+		}
+		if !ok {
+			return nil, fmt.Errorf("incoming metadata missing for "+
+				"wallet-owned output %d", recipient.OutputIndex)
 		}
 
 		log.DebugS(ctx, "Resolved incoming metadata",

--- a/oor/outbox_factory.go
+++ b/oor/outbox_factory.go
@@ -1,0 +1,81 @@
+package oor
+
+import (
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/lightninglabs/darepo-client/timeout"
+	"github.com/lightninglabs/darepo-client/vtxo"
+	"github.com/lightningnetwork/lnd/input"
+)
+
+// OutboxHandlerConfig contains the parameters for constructing the
+// standard OOR outbox handler chain:
+//
+//	LocalPersistenceOutboxHandler → SigningOutboxHandler
+//
+// This config is used by both the production darepod server and
+// the systest harness to ensure identical outbox handling.
+type OutboxHandlerConfig struct {
+	// Signer signs checkpoint and Ark PSBTs.
+	Signer input.Signer
+
+	// Store provides VTXO lifecycle persistence.
+	Store vtxo.VTXOStore
+
+	// PackageStore persists finalized OOR package artifacts.
+	PackageStore PackagePersistence
+
+	// OperatorKey is the operator's public key for checkpoint
+	// leaf construction.
+	OperatorKey *btcec.PublicKey
+
+	// ExitDelay is the VTXO exit CSV delay.
+	ExitDelay uint32
+
+	// TimeoutActor schedules retry timers. When nil, retry
+	// requests return RetryDueEvent immediately.
+	TimeoutActor *timeout.Actor
+
+	// NotifyIncomingVTXOs is called after incoming VTXOs are
+	// durably materialized.
+	NotifyIncomingVTXOs IncomingVTXONotifier
+
+	// CompleteSpend routes OOR spend completion through the
+	// VTXO manager.
+	CompleteSpend SpendCompleter
+
+	// ResolveIncomingClientKey resolves the wallet key for each
+	// incoming recipient output.
+	ResolveIncomingClientKey IncomingClientKeyResolver
+
+	// ResolveIncomingMetadata resolves lineage metadata for
+	// incoming VTXOs.
+	ResolveIncomingMetadata IncomingMetadataResolver
+}
+
+// NewOutboxHandler constructs the standard two-layer outbox handler
+// chain from the given configuration. The returned handler processes
+// all outbox events: signing, persistence, transport, and incoming
+// materialization.
+//
+// Both the production darepod and systest should call this function
+// to ensure identical outbox handling.
+func NewOutboxHandler(
+	cfg OutboxHandlerConfig) *LocalPersistenceOutboxHandler {
+
+	signingHandler := &SigningOutboxHandler{
+		Signer:       cfg.Signer,
+		TimeoutActor: cfg.TimeoutActor,
+	}
+
+	return &LocalPersistenceOutboxHandler{
+		Next:                    signingHandler,
+		Store:                   cfg.Store,
+		PackageStore:            cfg.PackageStore,
+		OperatorKey:             cfg.OperatorKey,
+		ExitDelay:               cfg.ExitDelay,
+		NotifyIncomingVTXOs:     cfg.NotifyIncomingVTXOs,
+		CompleteSpend:           cfg.CompleteSpend,
+		ResolveIncomingClientKey: cfg.ResolveIncomingClientKey,
+		ResolveIncomingMetadata: cfg.ResolveIncomingMetadata,
+	}
+}

--- a/oor/outbox_messages.go
+++ b/oor/outbox_messages.go
@@ -266,6 +266,32 @@ func (m *IncomingTransferNotification) outboxType() string {
 // outboxSealed marks this as implementing the sealed OutboxEvent interface.
 func (m *IncomingTransferNotification) outboxSealed() {}
 
+// QueryIncomingTransferRequest asks the transport layer to resolve a
+// lightweight incoming OOR hint into the full Ark/checkpoint package for this
+// session.
+type QueryIncomingTransferRequest struct {
+	actor.BaseMessage
+
+	// SessionID identifies the incoming transfer session.
+	SessionID SessionID
+
+	// RecipientPkScript identifies the locally controlled output that the
+	// server notified us about.
+	RecipientPkScript []byte
+
+	// RecipientEventID identifies the authoritative recipient event row to
+	// resolve from the indexer.
+	RecipientEventID uint64
+}
+
+// outboxType returns a stable identifier for this outbox message.
+func (m *QueryIncomingTransferRequest) outboxType() string {
+	return "QueryIncomingTransferRequest"
+}
+
+// outboxSealed marks this as implementing the sealed OutboxEvent interface.
+func (m *QueryIncomingTransferRequest) outboxSealed() {}
+
 // QueryIncomingMetadataRequest asks the transport layer to query the
 // authoritative indexer inventory for the incoming Ark outputs referenced by
 // this session.

--- a/oor/outbox_messages.go
+++ b/oor/outbox_messages.go
@@ -266,6 +266,34 @@ func (m *IncomingTransferNotification) outboxType() string {
 // outboxSealed marks this as implementing the sealed OutboxEvent interface.
 func (m *IncomingTransferNotification) outboxSealed() {}
 
+// QueryIncomingMetadataRequest asks the transport layer to query the
+// authoritative indexer inventory for the incoming Ark outputs referenced by
+// this session.
+type QueryIncomingMetadataRequest struct {
+	actor.BaseMessage
+
+	// SessionID identifies the incoming transfer session.
+	SessionID SessionID
+
+	// ArkPSBT is the canonical Ark tx PSBT.
+	ArkPSBT *psbt.Packet
+
+	// FinalCheckpointPSBTs are the finalized checkpoint packages associated
+	// with this Ark transfer.
+	FinalCheckpointPSBTs []*psbt.Packet
+
+	// Recipients are the non-anchor recipient outputs in the Ark tx.
+	Recipients []ArkRecipientOutput
+}
+
+// outboxType returns a stable identifier for this outbox message.
+func (m *QueryIncomingMetadataRequest) outboxType() string {
+	return "QueryIncomingMetadataRequest"
+}
+
+// outboxSealed marks this as implementing the sealed OutboxEvent interface.
+func (m *QueryIncomingMetadataRequest) outboxSealed() {}
+
 // MaterializeIncomingVTXOsRequest asks the wallet/state layer to materialize
 // the incoming transfer into local VTXO records.
 //
@@ -289,6 +317,10 @@ type MaterializeIncomingVTXOsRequest struct {
 
 	// Recipients are the non-anchor recipient outputs in the Ark tx.
 	Recipients []ArkRecipientOutput
+
+	// MetadataMatches carries the authoritative lineage metadata resolved for
+	// the current Ark outputs.
+	MetadataMatches []IncomingMetadataMatch
 }
 
 // outboxType returns a stable identifier for this outbox message.

--- a/oor/outgoing_snapshot_codec.go
+++ b/oor/outgoing_snapshot_codec.go
@@ -11,8 +11,9 @@ import (
 )
 
 const (
-	checkpointVersionRecordType   tlv.Type = 1
-	checkpointSnapshotsRecordType tlv.Type = 3
+	checkpointVersionRecordType           tlv.Type = 1
+	checkpointSnapshotsRecordType         tlv.Type = 3
+	checkpointIncomingSnapshotsRecordType tlv.Type = 5
 )
 
 const (
@@ -28,20 +29,45 @@ const (
 	snapshotFailReasonRecordType      tlv.Type = 19
 )
 
-func encodeOutgoingSessionsCheckpoint(
-	checkpoint outgoingSessionsCheckpoint) ([]byte, error) {
+type sessionsCheckpoint struct {
+	Version           int
+	OutgoingSnapshots []*OutgoingSnapshot
+	IncomingSnapshots []*IncomingSnapshot
+}
 
-	snapshotBlobs := make([][]byte, 0, len(checkpoint.Snapshots))
-	for i := range checkpoint.Snapshots {
-		raw, err := encodeOutgoingSnapshot(checkpoint.Snapshots[i])
+func encodeSessionsCheckpoint(
+	checkpoint sessionsCheckpoint) ([]byte, error) {
+
+	outgoingBlobs := make([][]byte, 0, len(checkpoint.OutgoingSnapshots))
+	for i := range checkpoint.OutgoingSnapshots {
+		raw, err := encodeOutgoingSnapshot(
+			checkpoint.OutgoingSnapshots[i],
+		)
 		if err != nil {
 			return nil, err
 		}
 
-		snapshotBlobs = append(snapshotBlobs, raw)
+		outgoingBlobs = append(outgoingBlobs, raw)
 	}
 
-	snapshotsRaw, err := encodeLengthPrefixedBlobList(snapshotBlobs)
+	outgoingRaw, err := encodeLengthPrefixedBlobList(outgoingBlobs)
+	if err != nil {
+		return nil, err
+	}
+
+	incomingBlobs := make([][]byte, 0, len(checkpoint.IncomingSnapshots))
+	for i := range checkpoint.IncomingSnapshots {
+		raw, err := encodeIncomingSnapshot(
+			checkpoint.IncomingSnapshots[i],
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		incomingBlobs = append(incomingBlobs, raw)
+	}
+
+	incomingRaw, err := encodeLengthPrefixedBlobList(incomingBlobs)
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +76,10 @@ func encodeOutgoingSessionsCheckpoint(
 	records := []tlv.Record{
 		tlv.MakePrimitiveRecord(checkpointVersionRecordType, &version),
 		tlv.MakePrimitiveRecord(
-			checkpointSnapshotsRecordType, &snapshotsRaw,
+			checkpointSnapshotsRecordType, &outgoingRaw,
+		),
+		tlv.MakePrimitiveRecord(
+			checkpointIncomingSnapshotsRecordType, &incomingRaw,
 		),
 	}
 
@@ -67,54 +96,108 @@ func encodeOutgoingSessionsCheckpoint(
 	return buf.Bytes(), nil
 }
 
-func decodeOutgoingSessionsCheckpoint(
-	raw []byte) (outgoingSessionsCheckpoint, error) {
+func decodeSessionsCheckpoint(raw []byte) (sessionsCheckpoint, error) {
 
 	var (
-		version      uint64
-		snapshotsRaw []byte
+		version     uint64
+		outgoingRaw []byte
+		incomingRaw []byte
 	)
 
 	records := []tlv.Record{
 		tlv.MakePrimitiveRecord(checkpointVersionRecordType, &version),
 		tlv.MakePrimitiveRecord(
-			checkpointSnapshotsRecordType, &snapshotsRaw,
+			checkpointSnapshotsRecordType, &outgoingRaw,
+		),
+		tlv.MakePrimitiveRecord(
+			checkpointIncomingSnapshotsRecordType, &incomingRaw,
 		),
 	}
 
 	stream, err := tlv.NewStream(records...)
 	if err != nil {
-		return outgoingSessionsCheckpoint{}, err
+		return sessionsCheckpoint{}, err
 	}
 
 	reader := bytes.NewReader(raw)
 	if _, err := stream.DecodeWithParsedTypes(reader); err != nil {
-		return outgoingSessionsCheckpoint{}, err
+		return sessionsCheckpoint{}, err
 	}
 
-	snapshotBlobs, err := decodeLengthPrefixedBlobList(snapshotsRaw)
+	outgoingBlobs, err := decodeLengthPrefixedBlobList(outgoingRaw)
 	if err != nil {
-		return outgoingSessionsCheckpoint{}, err
+		return sessionsCheckpoint{}, err
 	}
 
-	snapshots := make([]*OutgoingSnapshot, 0, len(snapshotBlobs))
-	for i := range snapshotBlobs {
-		snapshot, err := decodeOutgoingSnapshot(snapshotBlobs[i])
+	outgoingSnapshots := make([]*OutgoingSnapshot, 0,
+		len(outgoingBlobs))
+	for i := range outgoingBlobs {
+		snapshot, err := decodeOutgoingSnapshot(outgoingBlobs[i])
 		if err != nil {
-			return outgoingSessionsCheckpoint{}, err
+			return sessionsCheckpoint{}, err
 		}
 
-		snapshots = append(snapshots, snapshot)
+		outgoingSnapshots = append(outgoingSnapshots, snapshot)
+	}
+
+	incomingSnapshots := make([]*IncomingSnapshot, 0,
+		0)
+	if len(incomingRaw) != 0 {
+		incomingBlobs, err := decodeLengthPrefixedBlobList(
+			incomingRaw,
+		)
+		if err != nil {
+			return sessionsCheckpoint{}, err
+		}
+
+		incomingSnapshots = make([]*IncomingSnapshot, 0,
+			len(incomingBlobs))
+		for i := range incomingBlobs {
+			snapshot, err := decodeIncomingSnapshot(
+				incomingBlobs[i],
+			)
+			if err != nil {
+				return sessionsCheckpoint{}, err
+			}
+
+			incomingSnapshots = append(
+				incomingSnapshots, snapshot,
+			)
+		}
 	}
 
 	decodedVersion, err := decodeUint64ToInt(version, "checkpoint version")
+	if err != nil {
+		return sessionsCheckpoint{}, err
+	}
+
+	return sessionsCheckpoint{
+		Version:           decodedVersion,
+		OutgoingSnapshots: outgoingSnapshots,
+		IncomingSnapshots: incomingSnapshots,
+	}, nil
+}
+
+func encodeOutgoingSessionsCheckpoint(
+	checkpoint outgoingSessionsCheckpoint) ([]byte, error) {
+
+	return encodeSessionsCheckpoint(sessionsCheckpoint{
+		Version:           checkpoint.Version,
+		OutgoingSnapshots: checkpoint.Snapshots,
+	})
+}
+
+func decodeOutgoingSessionsCheckpoint(
+	raw []byte) (outgoingSessionsCheckpoint, error) {
+
+	checkpoint, err := decodeSessionsCheckpoint(raw)
 	if err != nil {
 		return outgoingSessionsCheckpoint{}, err
 	}
 
 	return outgoingSessionsCheckpoint{
-		Version:   decodedVersion,
-		Snapshots: snapshots,
+		Version:   checkpoint.Version,
+		Snapshots: checkpoint.OutgoingSnapshots,
 	}, nil
 }
 

--- a/oor/receive_session.go
+++ b/oor/receive_session.go
@@ -40,12 +40,30 @@ func NewReceiveSession(ctx context.Context, ark *psbt.Packet,
 	log.InfoS(ctx, "Creating receive session",
 		slog.String("session_id", sessionID.String()))
 
+	return newReceiveSessionWithState(
+		ctx, sessionID, &ReceiveIdle{},
+	)
+}
+
+// newReceiveSessionWithState creates an incoming-transfer FSM session with
+// the provided initial receive state.
+func newReceiveSessionWithState(ctx context.Context, sessionID SessionID,
+	state SessionState) (*ReceiveSession, error) {
+
+	if sessionID == (SessionID{}) {
+		return nil, fmt.Errorf("session id must be provided")
+	}
+
+	if state == nil {
+		return nil, fmt.Errorf("state must be provided")
+	}
+
 	env := &Environment{SessionID: sessionID}
 
 	fsmCfg := StateMachineCfg{
 		Logger:        log.WithPrefix(sessionID.LogPrefix()),
 		ErrorReporter: newContextErrorReporter(ctx, sessionID.LogPrefix()),
-		InitialState:  &ReceiveIdle{},
+		InitialState:  state,
 		Env:           env,
 	}
 

--- a/oor/receive_session_test.go
+++ b/oor/receive_session_test.go
@@ -14,10 +14,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestReceiveSessionNotifiesThenMaterializes verifies the incoming-transfer FSM
-// emits notification/materialization first, deferring ack until after incoming
-// materialization is confirmed.
-func TestReceiveSessionNotifiesThenMaterializes(t *testing.T) {
+// TestReceiveSessionNotifiesThenQueriesMetadata verifies the incoming-transfer
+// FSM emits notification and metadata-query outbox work first, deferring ack
+// until local materialization is confirmed.
+func TestReceiveSessionNotifiesThenQueriesMetadata(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
@@ -28,7 +28,7 @@ func TestReceiveSessionNotifiesThenMaterializes(t *testing.T) {
 	// (checkpoint input -> recipients + anchor), then verify the receive
 	// session:
 	// - emits an application-facing notification
-	// - requests recipient materialization into local VTXO state
+	// - requests authoritative incoming metadata
 	// Ack is emitted only after materialization is confirmed.
 	operatorKey, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
@@ -107,14 +107,14 @@ func TestReceiveSessionNotifiesThenMaterializes(t *testing.T) {
 	_, ok := outbox[0].(*IncomingTransferNotification)
 	require.True(t, ok)
 
-	materializeMsg, ok := outbox[1].(*MaterializeIncomingVTXOsRequest)
+	queryMsg, ok := outbox[1].(*QueryIncomingMetadataRequest)
 	require.True(t, ok)
-	require.NotEmpty(t, materializeMsg.Recipients)
+	require.NotEmpty(t, queryMsg.Recipients)
 	parentCommitment := inputs[0].SpentVTXO.Outpoint.Hash
 
-	desc, err := BuildIncomingVTXODescriptor(materializeMsg.ArkPSBT,
+	desc, err := BuildIncomingVTXODescriptor(queryMsg.ArkPSBT,
 		IncomingVTXOConfig{
-			OutputIndex: materializeMsg.Recipients[0].OutputIndex,
+			OutputIndex: queryMsg.Recipients[0].OutputIndex,
 			ClientKey: keychain.KeyDescriptor{
 				PubKey: recipientKey.PubKey(),
 			},
@@ -149,8 +149,24 @@ func TestReceiveSessionAcksAfterHandled(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, outbox, 2)
 
-	fut := sess.FSM.AskEvent(ctx, &IncomingHandledEvent{})
+	fut := sess.FSM.AskEvent(ctx, &IncomingMetadataResolvedEvent{
+		Matches: []IncomingMetadataMatch{{
+			OutputIndex: 0,
+			Metadata: IncomingVTXOMetadata{
+				RoundID: "round-test",
+			},
+		}},
+	})
 	result := fut.Await(ctx)
+	require.False(t, result.IsErr())
+
+	materializeOutbox := result.UnwrapOr(nil)
+	require.Len(t, materializeOutbox, 1)
+	require.IsType(t, &MaterializeIncomingVTXOsRequest{},
+		materializeOutbox[0])
+
+	fut = sess.FSM.AskEvent(ctx, &IncomingHandledEvent{})
+	result = fut.Await(ctx)
 	require.False(t, result.IsErr())
 
 	ackOutbox := result.UnwrapOr(nil)

--- a/oor/receive_snapshot.go
+++ b/oor/receive_snapshot.go
@@ -1,0 +1,397 @@
+package oor
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/lightninglabs/darepo-client/lib/tx/psbtutil"
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+const (
+	incomingSnapshotVersionRecordType         tlv.Type = 1
+	incomingSnapshotSessionIDRecordType       tlv.Type = 3
+	incomingSnapshotPhaseRecordType           tlv.Type = 5
+	incomingSnapshotArkPSBTRecordType         tlv.Type = 7
+	incomingSnapshotCheckpointPSBTsRecordType tlv.Type = 9
+	incomingSnapshotFailReasonRecordType      tlv.Type = 11
+	incomingSnapshotRecipientPkScriptType     tlv.Type = 13
+	incomingSnapshotRecipientEventIDType      tlv.Type = 15
+)
+
+// IncomingPhase identifies the coarse stage of an incoming OOR receive
+// session.
+type IncomingPhase string
+
+const (
+	// IncomingPhaseResolvePending indicates the client durably recorded
+	// an incoming-hint notification and still needs to resolve the full
+	// Ark/checkpoint package outside the actor transaction.
+	IncomingPhaseResolvePending IncomingPhase = "resolve_pending"
+
+	// IncomingPhaseMaterializePending indicates the incoming transfer has
+	// been validated and notified locally, and the wallet materialization
+	// step still needs to run.
+	IncomingPhaseMaterializePending IncomingPhase = "materialize_pending"
+
+	// IncomingPhaseAckPending indicates the incoming VTXOs were
+	// durably materialized and the client still needs to enqueue the
+	// best-effort ack to the server.
+	IncomingPhaseAckPending IncomingPhase = "ack_pending"
+
+	// IncomingPhaseCompleted indicates the incoming transfer finished.
+	IncomingPhaseCompleted IncomingPhase = "completed"
+
+	// IncomingPhaseFailed indicates the incoming transfer entered a
+	// terminal failure state.
+	IncomingPhaseFailed IncomingPhase = "failed"
+)
+
+// IncomingSnapshot is the durable checkpoint shape for incoming OOR receive
+// sessions.
+type IncomingSnapshot struct {
+	// Version is the snapshot version.
+	Version uint8
+
+	// SessionID is the stable Ark txid for the incoming transfer.
+	SessionID SessionID
+
+	// Phase is the coarse incoming receive phase.
+	Phase IncomingPhase
+
+	// ArkPSBT is the canonical Ark transfer PSBT.
+	ArkPSBT []byte
+
+	// CheckpointPSBTs are the finalized checkpoint PSBTs associated with the
+	// incoming transfer when the phase needs them.
+	CheckpointPSBTs [][]byte
+
+	// FailReason is the terminal failure reason, when Phase is Failed.
+	FailReason string
+
+	// RecipientPkScript is the persisted hint used while the incoming
+	// package still needs resolution.
+	RecipientPkScript []byte
+
+	// RecipientEventID is the per-script cursor hint paired with
+	// RecipientPkScript during resolve-pending restart.
+	RecipientEventID uint64
+}
+
+// NewIncomingSnapshot exports an incoming receive session state into a
+// checkpoint snapshot.
+func NewIncomingSnapshot(sessionID SessionID,
+	state SessionState) (*IncomingSnapshot, error) {
+
+	if sessionID == (SessionID{}) {
+		return nil, fmt.Errorf("session id must be provided")
+	}
+
+	if state == nil {
+		return nil, fmt.Errorf("state must be provided")
+	}
+
+	snap := &IncomingSnapshot{
+		Version:   1,
+		SessionID: sessionID,
+	}
+
+	switch s := state.(type) {
+	case *ReceiveResolving:
+		snap.Phase = IncomingPhaseResolvePending
+		snap.RecipientPkScript = append(
+			[]byte(nil), s.RecipientPkScript...,
+		)
+		snap.RecipientEventID = s.RecipientEventID
+
+	case *ReceiveNotified:
+		ark, err := psbtutil.Serialize(s.ArkPSBT)
+		if err != nil {
+			return nil, err
+		}
+
+		checkpoints, err := serializePSBTSlice(
+			s.FinalCheckpointPSBTs,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		snap.Phase = IncomingPhaseMaterializePending
+		snap.ArkPSBT = ark
+		snap.CheckpointPSBTs = checkpoints
+
+	case *ReceiveAwaitingAck:
+		snap.Phase = IncomingPhaseAckPending
+
+	case *ReceiveCompleted:
+		snap.Phase = IncomingPhaseCompleted
+
+	case *Failed:
+		snap.Phase = IncomingPhaseFailed
+		snap.FailReason = s.Reason
+
+	default:
+		return nil, fmt.Errorf("unsupported incoming state type: %T",
+			state)
+	}
+
+	return snap, nil
+}
+
+// NewReceiveSessionFromSnapshot restores an incoming receive session from a
+// durable snapshot.
+func NewReceiveSessionFromSnapshot(ctx context.Context,
+	snapshot *IncomingSnapshot) (*ReceiveSession, error) {
+
+	if snapshot == nil {
+		return nil, fmt.Errorf("snapshot must be provided")
+	}
+
+	state, err := IncomingStateFromSnapshot(snapshot)
+	if err != nil {
+		return nil, err
+	}
+
+	return newReceiveSessionWithState(
+		ctx, snapshot.SessionID, state,
+	)
+}
+
+// IncomingStateFromSnapshot converts an incoming receive snapshot into the
+// corresponding concrete state.
+func IncomingStateFromSnapshot(snapshot *IncomingSnapshot) (SessionState,
+	error) {
+
+	if snapshot == nil {
+		return nil, fmt.Errorf("snapshot must be provided")
+	}
+
+	if snapshot.SessionID == (SessionID{}) {
+		return nil, fmt.Errorf("session id must be provided")
+	}
+
+	if snapshot.Version == 0 {
+		return nil, fmt.Errorf("snapshot version must be provided")
+	}
+
+	switch snapshot.Phase {
+	case IncomingPhaseResolvePending:
+		return &ReceiveResolving{
+			SessionID: snapshot.SessionID,
+			RecipientPkScript: append(
+				[]byte(nil), snapshot.RecipientPkScript...,
+			),
+			RecipientEventID: snapshot.RecipientEventID,
+		}, nil
+
+	case IncomingPhaseMaterializePending:
+		ark, checkpoints, err := parseIncomingPSBTs(
+			snapshot.ArkPSBT, snapshot.CheckpointPSBTs,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		err = requireSessionIDMatchesArk(snapshot.SessionID, ark)
+		if err != nil {
+			return nil, err
+		}
+
+		return &ReceiveNotified{
+			SessionID:            snapshot.SessionID,
+			ArkPSBT:              ark,
+			FinalCheckpointPSBTs: checkpoints,
+		}, nil
+
+	case IncomingPhaseAckPending:
+		return &ReceiveAwaitingAck{
+			SessionID: snapshot.SessionID,
+		}, nil
+
+	case IncomingPhaseCompleted:
+		return &ReceiveCompleted{}, nil
+
+	case IncomingPhaseFailed:
+		return &Failed{Reason: snapshot.FailReason}, nil
+
+	default:
+		return nil, fmt.Errorf("unknown incoming phase: %s",
+			snapshot.Phase)
+	}
+}
+
+// encodeIncomingSnapshot serializes an incoming snapshot into TLV bytes.
+func encodeIncomingSnapshot(snapshot *IncomingSnapshot) ([]byte, error) {
+	if snapshot == nil {
+		return nil, fmt.Errorf("snapshot must be provided")
+	}
+
+	sessionBytes := sessionIDBytes(snapshot.SessionID)
+	phaseBytes := []byte(snapshot.Phase)
+	arkPSBT := snapshot.ArkPSBT
+	checkpoints, err := encodeLengthPrefixedBlobList(
+		snapshot.CheckpointPSBTs,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	failReason := []byte(snapshot.FailReason)
+	recipientPkScript := snapshot.RecipientPkScript
+	recipientEventID := snapshot.RecipientEventID
+	version := uint64(snapshot.Version)
+
+	records := []tlv.Record{
+		tlv.MakePrimitiveRecord(
+			incomingSnapshotVersionRecordType, &version,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingSnapshotSessionIDRecordType, &sessionBytes,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingSnapshotPhaseRecordType, &phaseBytes,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingSnapshotArkPSBTRecordType, &arkPSBT,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingSnapshotCheckpointPSBTsRecordType,
+			&checkpoints,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingSnapshotFailReasonRecordType, &failReason,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingSnapshotRecipientPkScriptType,
+			&recipientPkScript,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingSnapshotRecipientEventIDType,
+			&recipientEventID,
+		),
+	}
+
+	stream, err := tlv.NewStream(records...)
+	if err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	if err := stream.Encode(&buf); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// decodeIncomingSnapshot deserializes an incoming snapshot from TLV bytes.
+func decodeIncomingSnapshot(raw []byte) (*IncomingSnapshot, error) {
+	var (
+		version           uint64
+		sessionBytes      []byte
+		phaseBytes        []byte
+		arkPSBT           []byte
+		checkpointsRaw    []byte
+		failReasonRaw     []byte
+		recipientPkScript []byte
+		recipientEventID  uint64
+	)
+
+	records := []tlv.Record{
+		tlv.MakePrimitiveRecord(
+			incomingSnapshotVersionRecordType, &version,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingSnapshotSessionIDRecordType, &sessionBytes,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingSnapshotPhaseRecordType, &phaseBytes,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingSnapshotArkPSBTRecordType, &arkPSBT,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingSnapshotCheckpointPSBTsRecordType,
+			&checkpointsRaw,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingSnapshotFailReasonRecordType, &failReasonRaw,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingSnapshotRecipientPkScriptType,
+			&recipientPkScript,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingSnapshotRecipientEventIDType,
+			&recipientEventID,
+		),
+	}
+
+	stream, err := tlv.NewStream(records...)
+	if err != nil {
+		return nil, err
+	}
+
+	reader := bytes.NewReader(raw)
+	if _, err := stream.DecodeWithParsedTypes(reader); err != nil {
+		return nil, err
+	}
+
+	sessionID, err := parseSessionID(sessionBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	checkpoints, err := decodeLengthPrefixedBlobList(checkpointsRaw)
+	if err != nil {
+		return nil, err
+	}
+	if len(checkpoints) == 0 {
+		checkpoints = nil
+	}
+
+	if len(arkPSBT) == 0 {
+		arkPSBT = nil
+	}
+
+	decodedVersion, err := decodeUint64ToUint8(
+		version, "incoming snapshot version",
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &IncomingSnapshot{
+		Version:         decodedVersion,
+		SessionID:       sessionID,
+		Phase:           IncomingPhase(phaseBytes),
+		ArkPSBT:         arkPSBT,
+		CheckpointPSBTs: checkpoints,
+		FailReason:      string(failReasonRaw),
+		RecipientPkScript: append(
+			[]byte(nil), recipientPkScript...,
+		),
+		RecipientEventID: recipientEventID,
+	}, nil
+}
+
+// parseIncomingPSBTs parses the Ark and checkpoint PSBTs stored in an incoming
+// snapshot.
+func parseIncomingPSBTs(arkRaw []byte, checkpointRaws [][]byte) (
+	*psbt.Packet, []*psbt.Packet, error) {
+
+	ark, err := psbtutil.Parse(arkRaw)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	checkpoints, err := parsePSBTSlice(checkpointRaws)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return ark, checkpoints, nil
+}

--- a/oor/receive_snapshot.go
+++ b/oor/receive_snapshot.go
@@ -32,8 +32,8 @@ const (
 	IncomingPhaseResolvePending IncomingPhase = "resolve_pending"
 
 	// IncomingPhaseMaterializePending indicates the incoming transfer has
-	// been validated and notified locally, and the wallet materialization
-	// step still needs to run.
+	// been validated and notified locally, and the authoritative metadata
+	// lookup/materialization work still needs to run.
 	IncomingPhaseMaterializePending IncomingPhase = "materialize_pending"
 
 	// IncomingPhaseAckPending indicates the incoming VTXOs were

--- a/oor/receive_states.go
+++ b/oor/receive_states.go
@@ -15,6 +15,30 @@ type ReceiveState interface {
 	receiveStateSealed()
 }
 
+// ReceiveResolving indicates the client durably recorded a lightweight
+// incoming-transfer hint and still needs to fetch the full Ark/checkpoint
+// package outside the live durable actor transaction.
+type ReceiveResolving struct {
+	SessionID SessionID
+
+	RecipientPkScript []byte
+
+	RecipientEventID uint64
+}
+
+// String returns a human-readable representation of ReceiveResolving.
+func (s *ReceiveResolving) String() string {
+	return "ReceiveResolving"
+}
+
+// IsTerminal returns false as ReceiveResolving is not terminal.
+func (s *ReceiveResolving) IsTerminal() bool {
+	return false
+}
+
+// receiveStateSealed marks ReceiveResolving as implementing ReceiveState.
+func (s *ReceiveResolving) receiveStateSealed() {}
+
 // ReceiveIdle is the initial state for handling incoming transfers.
 type ReceiveIdle struct{}
 
@@ -32,11 +56,13 @@ func (s *ReceiveIdle) IsTerminal() bool {
 func (s *ReceiveIdle) receiveStateSealed() {}
 
 // ReceiveNotified indicates the client has validated and surfaced an incoming
-// transfer and is waiting to ack it.
+// transfer and is waiting for local materialization to finish.
 type ReceiveNotified struct {
 	SessionID SessionID
 
 	ArkPSBT *psbt.Packet
+
+	FinalCheckpointPSBTs []*psbt.Packet
 }
 
 // String returns a human-readable representation of ReceiveNotified.

--- a/oor/receive_transitions.go
+++ b/oor/receive_transitions.go
@@ -10,22 +10,33 @@ import (
 
 // Incoming transfer receive flow (human-readable):
 //
-// IncomingTransferEvent (delivered by transport; server believes we are a
-// recipient)
+// ResolveIncomingTransferRequest (delivered by transport as a lightweight
+// hint)
 //   |
 //   v
-// ReceiveIdle
+// ReceiveResolving
+//   - async indexer fetch outside the actor tx
+//   - callback re-enters with IncomingTransferEvent
+//   |
+//   v
+// IncomingTransferEvent
+//   |
+//   v
+// ReceiveIdle / ReceiveResolving
 //   - structural checks (SessionID/txid consistency)
 //   - canonical Ark PSBT validation (stable recipient extraction)
 //   - extract recipients (for UI summary and wallet materialization)
 //   emits outbox (in order):
 //   1) IncomingTransferNotification: app/UI summary of the transfer
 //   2) MaterializeIncomingVTXOsRequest: wallet/state update (filter + persist)
-//   3) SendIncomingAckRequest: best-effort ack to server
 //   |
 //   v
 // ReceiveNotified
-//   - waits for IncomingHandledEvent (app confirms it processed the transfer)
+//   - waits for IncomingHandledEvent after async materialization completes
+//   |
+//   v
+// ReceiveAwaitingAck
+//   - emits SendIncomingAckRequest after durable materialization succeeds
 //   |
 //   v
 // ReceiveCompleted
@@ -41,6 +52,63 @@ func unexpectedReceiveEvent(state ReceiveState, event Event) *StateTransition {
 	}
 }
 
+// transitionIncomingTransfer validates and applies a fully resolved incoming
+// transfer event, moving the receive FSM into the notified/materialize phase.
+func transitionIncomingTransfer(
+	evt *IncomingTransferEvent) (*StateTransition, error) {
+
+	if evt.ArkPSBT == nil || evt.ArkPSBT.UnsignedTx == nil {
+		return nil, fmt.Errorf("ark psbt must be provided")
+	}
+
+	if evt.SessionID == (SessionID{}) {
+		return nil, fmt.Errorf("session id must be provided")
+	}
+
+	txid := evt.ArkPSBT.UnsignedTx.TxHash()
+	if SessionID(txid) != evt.SessionID {
+		return nil, fmt.Errorf("ark txid mismatch")
+	}
+
+	// Canonical ordering checks prevent subtle malleability in how the
+	// recipients are extracted and displayed.
+	err := arktx.ValidateCanonicalPSBT(evt.ArkPSBT)
+	if err != nil {
+		return nil, err
+	}
+
+	// The FSM intentionally does not decide which outputs belong to the
+	// local wallet. Ownership lives behind the materialization boundary.
+	recipients, err := ExtractArkRecipients(evt.ArkPSBT)
+	if err != nil {
+		return nil, err
+	}
+
+	return &StateTransition{
+		NextState: &ReceiveNotified{
+			SessionID:            evt.SessionID,
+			ArkPSBT:              evt.ArkPSBT,
+			FinalCheckpointPSBTs: evt.FinalCheckpointPSBTs,
+		},
+		NewEvents: fn.Some(EmittedEvent{
+			Outbox: []OutboxEvent{
+				&IncomingTransferNotification{
+					SessionID:  evt.SessionID,
+					ArkPSBT:    evt.ArkPSBT,
+					Recipients: recipients,
+				},
+				&MaterializeIncomingVTXOsRequest{
+					SessionID: evt.SessionID,
+					ArkPSBT:   evt.ArkPSBT,
+					FinalCheckpointPSBTs: evt.
+						FinalCheckpointPSBTs,
+					Recipients: recipients,
+				},
+			},
+		}),
+	}, nil
+}
+
 // ProcessEvent handles events for ReceiveIdle.
 func (s *ReceiveIdle) ProcessEvent(ctx context.Context, event Event,
 	env *Environment) (*StateTransition, error) {
@@ -50,73 +118,29 @@ func (s *ReceiveIdle) ProcessEvent(ctx context.Context, event Event,
 
 	switch evt := event.(type) {
 	case *IncomingTransferEvent:
-		// Basic sanity checks: we only accept an incoming transfer
-		// notification if it is self-consistent (Ark txid matches
-		// SessionID) and structurally valid.
-		if evt.ArkPSBT == nil || evt.ArkPSBT.UnsignedTx == nil {
-			return nil, fmt.Errorf("ark psbt must be provided")
-		}
+		return transitionIncomingTransfer(evt)
 
-		if evt.SessionID == (SessionID{}) {
-			return nil, fmt.Errorf("session id must be provided")
-		}
-
-		txid := evt.ArkPSBT.UnsignedTx.TxHash()
-		if SessionID(txid) != evt.SessionID {
-			return nil, fmt.Errorf("ark txid mismatch")
-		}
-
-		// Canonical ordering checks prevent subtle malleability in how
-		// the recipients are extracted and displayed.
-		//
-		// The goal is that all parties derive identical semantics from
-		// identical bytes.
-		err := arktx.ValidateCanonicalPSBT(evt.ArkPSBT)
-		if err != nil {
-			return nil, err
-		}
-
-		// Extract recipients and surface the notification to the
-		// application layer.
-		//
-		// Note: the FSM intentionally does not decide which of these
-		// outputs belong to the local wallet. That check depends on
-		// local wallet keys and policy, so it lives behind the outbox
-		// boundary in the materialization step.
-		recipients, err := ExtractArkRecipients(evt.ArkPSBT)
-		if err != nil {
-			return nil, err
-		}
-
-		// The outbox is intentionally ordered:
-		//   1) notify the app/UI so it can show the transfer;
-		//   2) materialize incoming VTXOs into local state.
-		//
-		// Ack is emitted only after the application confirms incoming
-		// handling to avoid acknowledging transfers that were not
-		// durably materialized yet.
+	case *FailEvent:
 		return &StateTransition{
-			NextState: &ReceiveNotified{
-				SessionID: evt.SessionID,
-				ArkPSBT:   evt.ArkPSBT,
-			},
-			NewEvents: fn.Some(EmittedEvent{
-				Outbox: []OutboxEvent{
-					&IncomingTransferNotification{
-						SessionID:  evt.SessionID,
-						ArkPSBT:    evt.ArkPSBT,
-						Recipients: recipients,
-					},
-					&MaterializeIncomingVTXOsRequest{
-						SessionID: evt.SessionID,
-						ArkPSBT:   evt.ArkPSBT,
-						FinalCheckpointPSBTs: evt.
-							FinalCheckpointPSBTs,
-						Recipients: recipients,
-					},
-				},
-			}),
+			NextState: &Failed{Reason: evt.Reason},
+			NewEvents: fn.None[EmittedEvent](),
 		}, nil
+
+	default:
+		return unexpectedReceiveEvent(s, event), nil
+	}
+}
+
+// ProcessEvent handles events for ReceiveResolving.
+func (s *ReceiveResolving) ProcessEvent(ctx context.Context, event Event,
+	env *Environment) (*StateTransition, error) {
+
+	_ = ctx
+	_ = env
+
+	switch evt := event.(type) {
+	case *IncomingTransferEvent:
+		return transitionIncomingTransfer(evt)
 
 	case *FailEvent:
 		return &StateTransition{
@@ -139,8 +163,8 @@ func (s *ReceiveNotified) ProcessEvent(ctx context.Context, event Event,
 	switch evt := event.(type) {
 	case *IncomingHandledEvent:
 		// The application signals it has processed the notification.
-		// Wallet state has been updated (materialization complete), so
-		// we can now ack to the server.
+		// Wallet state has been updated (materialization complete), so we
+		// can now ack to the server.
 		_ = evt
 
 		return &StateTransition{
@@ -154,6 +178,12 @@ func (s *ReceiveNotified) ProcessEvent(ctx context.Context, event Event,
 					},
 				},
 			}),
+		}, nil
+
+	case *OutboxErrorEvent:
+		return &StateTransition{
+			NextState: &Failed{Reason: evt.ErrorReason},
+			NewEvents: fn.None[EmittedEvent](),
 		}, nil
 
 	case *FailEvent:
@@ -190,6 +220,12 @@ func (s *ReceiveAwaitingAck) ProcessEvent(ctx context.Context, event Event,
 
 		return &StateTransition{
 			NextState: &ReceiveCompleted{},
+			NewEvents: fn.None[EmittedEvent](),
+		}, nil
+
+	case *OutboxErrorEvent:
+		return &StateTransition{
+			NextState: &Failed{Reason: evt.ErrorReason},
 			NewEvents: fn.None[EmittedEvent](),
 		}, nil
 

--- a/oor/receive_transitions.go
+++ b/oor/receive_transitions.go
@@ -28,11 +28,12 @@ import (
 //   - extract recipients (for UI summary and wallet materialization)
 //   emits outbox (in order):
 //   1) IncomingTransferNotification: app/UI summary of the transfer
-//   2) MaterializeIncomingVTXOsRequest: wallet/state update (filter + persist)
+//   2) QueryIncomingMetadataRequest: authoritative indexer metadata lookup
 //   |
 //   v
 // ReceiveNotified
-//   - waits for IncomingHandledEvent after async materialization completes
+//   - waits for IncomingMetadataResolvedEvent then emits local materialization
+//   - waits for IncomingHandledEvent after local materialization completes
 //   |
 //   v
 // ReceiveAwaitingAck
@@ -97,12 +98,11 @@ func transitionIncomingTransfer(
 					ArkPSBT:    evt.ArkPSBT,
 					Recipients: recipients,
 				},
-				&MaterializeIncomingVTXOsRequest{
-					SessionID: evt.SessionID,
-					ArkPSBT:   evt.ArkPSBT,
-					FinalCheckpointPSBTs: evt.
-						FinalCheckpointPSBTs,
-					Recipients: recipients,
+				&QueryIncomingMetadataRequest{
+					SessionID:            evt.SessionID,
+					ArkPSBT:              evt.ArkPSBT,
+					FinalCheckpointPSBTs: evt.FinalCheckpointPSBTs,
+					Recipients:           recipients,
 				},
 			},
 		}),
@@ -161,6 +161,28 @@ func (s *ReceiveNotified) ProcessEvent(ctx context.Context, event Event,
 	_ = env
 
 	switch evt := event.(type) {
+	case *IncomingMetadataResolvedEvent:
+		recipients, err := ExtractArkRecipients(s.ArkPSBT)
+		if err != nil {
+			return nil, err
+		}
+
+		return &StateTransition{
+			NextState: s,
+			NewEvents: fn.Some(EmittedEvent{
+				Outbox: []OutboxEvent{
+					&MaterializeIncomingVTXOsRequest{
+						SessionID: s.SessionID,
+						ArkPSBT:   s.ArkPSBT,
+						FinalCheckpointPSBTs: s.
+							FinalCheckpointPSBTs,
+						Recipients: recipients,
+						MetadataMatches: evt.Matches,
+					},
+				},
+			}),
+		}, nil
+
 	case *IncomingHandledEvent:
 		// The application signals it has processed the notification.
 		// Wallet state has been updated (materialization complete), so we

--- a/oor/resume.go
+++ b/oor/resume.go
@@ -4,6 +4,48 @@ import (
 	"fmt"
 )
 
+// OutboxForIncomingState returns the outbox implied by the current incoming
+// receive state.
+func OutboxForIncomingState(state SessionState) ([]OutboxEvent, error) {
+	if state == nil {
+		return nil, fmt.Errorf("state must be provided")
+	}
+
+	switch s := state.(type) {
+	case *ReceiveResolving:
+		return nil, nil
+
+	case *ReceiveNotified:
+		recipients, err := ExtractArkRecipients(s.ArkPSBT)
+		if err != nil {
+			return nil, err
+		}
+
+		return []OutboxEvent{
+			&MaterializeIncomingVTXOsRequest{
+				SessionID:            s.SessionID,
+				ArkPSBT:              s.ArkPSBT,
+				FinalCheckpointPSBTs: s.FinalCheckpointPSBTs,
+				Recipients:           recipients,
+			},
+		}, nil
+
+	case *ReceiveAwaitingAck:
+		return []OutboxEvent{
+			&SendIncomingAckRequest{
+				SessionID: s.SessionID,
+			},
+		}, nil
+
+	case *ReceiveCompleted, *Failed:
+		return nil, nil
+
+	default:
+		return nil, fmt.Errorf("unsupported incoming state type: %T",
+			state)
+	}
+}
+
 // OutboxForState returns the outbox request implied by the current outgoing
 // session state.
 //

--- a/oor/resume.go
+++ b/oor/resume.go
@@ -13,7 +13,15 @@ func OutboxForIncomingState(state SessionState) ([]OutboxEvent, error) {
 
 	switch s := state.(type) {
 	case *ReceiveResolving:
-		return nil, nil
+		return []OutboxEvent{
+			&QueryIncomingTransferRequest{
+				SessionID: s.SessionID,
+				RecipientPkScript: append(
+					[]byte(nil), s.RecipientPkScript...,
+				),
+				RecipientEventID: s.RecipientEventID,
+			},
+		}, nil
 
 	case *ReceiveNotified:
 		recipients, err := ExtractArkRecipients(s.ArkPSBT)

--- a/oor/resume.go
+++ b/oor/resume.go
@@ -22,7 +22,7 @@ func OutboxForIncomingState(state SessionState) ([]OutboxEvent, error) {
 		}
 
 		return []OutboxEvent{
-			&MaterializeIncomingVTXOsRequest{
+			&QueryIncomingMetadataRequest{
 				SessionID:            s.SessionID,
 				ArkPSBT:              s.ArkPSBT,
 				FinalCheckpointPSBTs: s.FinalCheckpointPSBTs,

--- a/round/from_proto.go
+++ b/round/from_proto.go
@@ -10,6 +10,7 @@ import (
 	"github.com/lightninglabs/darepo-client/lib/tree"
 	"github.com/lightninglabs/darepo-client/lib/types"
 	"github.com/lightninglabs/darepo-client/rpc/roundpb"
+	"github.com/lightningnetwork/lnd/keychain"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -425,6 +426,20 @@ func (m *JoinRoundRequest) FromProto(p proto.Message) error {
 				)
 			}
 			req.OperatorKey = key
+		}
+
+		if len(vr.SigningKey) > 0 {
+			key, err := btcec.ParsePubKey(vr.SigningKey)
+			if err != nil {
+				return fmt.Errorf(
+					"vtxo_requests[%d].signing_key: %w",
+					i, err,
+				)
+			}
+
+			req.SigningKey = keychain.KeyDescriptor{
+				PubKey: key,
+			}
 		}
 
 		m.VTXORequests[i] = req

--- a/round/from_proto_test.go
+++ b/round/from_proto_test.go
@@ -3,6 +3,7 @@ package round
 import (
 	"testing"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
@@ -99,6 +100,48 @@ func TestAwaitingBoardingSigsFromProto(t *testing.T) {
 	var got AwaitingBoardingSigs
 	require.NoError(t, got.FromProto(pb))
 	require.Equal(t, RoundID(roundID), got.RoundID)
+}
+
+// TestJoinRoundRequestFromProtoPreservesVTXOSigningKey verifies the VTXO
+// signing pubkey survives the JoinRoundRequest proto decode path.
+func TestJoinRoundRequestFromProtoPreservesVTXOSigningKey(t *testing.T) {
+	t.Parallel()
+
+	signingPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	pb := &roundpb.JoinRoundRequest{
+		VtxoRequests: []*roundpb.VTXORequest{
+			{
+				Amount:    1234,
+				PkScript:  []byte{0x51},
+				Expiry:    144,
+				ClientKey: clientPriv.PubKey().SerializeCompressed(),
+				OperatorKey: operatorPriv.PubKey().
+					SerializeCompressed(),
+				SigningKey: signingPriv.PubKey().
+					SerializeCompressed(),
+			},
+		},
+	}
+
+	var got JoinRoundRequest
+	err = got.FromProto(pb)
+	require.NoError(t, err)
+	require.Len(t, got.VTXORequests, 1)
+	require.NotNil(t, got.VTXORequests[0].SigningKey.PubKey)
+	require.True(
+		t,
+		got.VTXORequests[0].SigningKey.PubKey.IsEqual(
+			signingPriv.PubKey(),
+		),
+	)
 }
 
 // TestNoncesAggregatedFromProto verifies that NoncesAggregated.FromProto

--- a/serverconn/AGENTS.md
+++ b/serverconn/AGENTS.md
@@ -11,9 +11,11 @@ background ingress polling with event routing.
 - `Runtime` — Main entry point wrapping DurableActor, ServerConnectionActor, and UnaryFacade.
 - `ServerConnectionActor` — Core behavior handling egress messages and the ingress loop.
 - `UnaryFacade` — Implements `mailboxrpc.RPCClient` for generated RPC stubs (low-latency path). Also provides `AwaitRPCTimeout` for bounded waits.
-- `ConnectorConfig` — Wiring configuration (edge address, mailbox IDs, dispatchers, store).
+- `ConnectorConfig` — Wiring configuration (edge address, mailbox IDs, dispatchers, store, durable unary builder).
 - `AckState` — Four-cursor watermark state machine (PullCursor, DispatchCommittedTo, AckTarget, AckCommittedTo).
 - `SendUnaryRequest` — Durable typed unary request that becomes a real unary RPC after commit. The response arrives via KIND_RESPONSE and, if no in-memory waiter exists, falls back to durable route dispatch via the EventRouter.
+- `DurableUnaryBuilder` — Proof-gated request-body builder used by transport-native durable query messages.
+- `SendListOORRecipientEventsByScriptRequest` / `SendListVTXOsByScriptsRequest` — transport-native durable indexer query messages emitted by OOR receive.
 
 ## Relationships
 
@@ -22,6 +24,7 @@ background ingress polling with event routing.
 - **Sends (egress → remote mailbox)**:
   - `SendClientEventRequest` (durable): wraps `JoinRoundRequest`, `SubmitNoncesRequest`, `SubmitPartialSigRequest`, `SubmitForfeitSigRequest`
   - `SendRPCRequest` (unary, non-durable): low-latency request-response RPCs
+  - transport-native durable query messages for proof-gated indexer lookups
 - **Routes (ingress → local actors via EventRouter)**:
   - → `round`: `CommitmentTxBuilt`, `NoncesAggregated`, `OperatorSigned`, `RoundJoined`, `BoardingFailed`
   - → `oor`: `SubmitAcceptedEvent`, `FinalizeAcceptedEvent`, `IncomingTransferEvent`

--- a/serverconn/AGENTS.md
+++ b/serverconn/AGENTS.md
@@ -10,9 +10,10 @@ background ingress polling with event routing.
 
 - `Runtime` — Main entry point wrapping DurableActor, ServerConnectionActor, and UnaryFacade.
 - `ServerConnectionActor` — Core behavior handling egress messages and the ingress loop.
-- `UnaryFacade` — Implements `mailboxrpc.RPCClient` for generated RPC stubs (low-latency path).
+- `UnaryFacade` — Implements `mailboxrpc.RPCClient` for generated RPC stubs (low-latency path). Also provides `AwaitRPCTimeout` for bounded waits.
 - `ConnectorConfig` — Wiring configuration (edge address, mailbox IDs, dispatchers, store).
 - `AckState` — Four-cursor watermark state machine (PullCursor, DispatchCommittedTo, AckTarget, AckCommittedTo).
+- `SendUnaryRequest` — Durable typed unary request that becomes a real unary RPC after commit. The response arrives via KIND_RESPONSE and, if no in-memory waiter exists, falls back to durable route dispatch via the EventRouter.
 
 ## Relationships
 
@@ -31,7 +32,8 @@ background ingress polling with event routing.
 ## Invariants
 
 - Ack watermark only advances AFTER durable local dispatch commit (prevents message loss on crash).
-- Unary RPC responses use in-memory registry (no durability); on crash, callers retry with fresh correlation IDs.
+- Unary RPC responses use in-memory registry first; if no waiter exists (crash replay), the ingress falls back to durable EventRouter dispatch. The ResponseRegistry returns a tri-state delivery result (waiter/buffered/dropped) so the ingress knows whether to route durably.
+- `SendClientEventRequest` auto-derives `Service`/`Method` from `Message.ServiceMethod()` when callers leave them empty, preventing silent drops.
 - Idempotency keys are derived from message payload hash; same key on retry enables server deduplication.
 - Ingress loop checkpoints pull cursor and ack state; on restart, resumes from checkpoint.
 

--- a/serverconn/CLAUDE.md
+++ b/serverconn/CLAUDE.md
@@ -11,9 +11,11 @@ background ingress polling with event routing.
 - `Runtime` — Main entry point wrapping DurableActor, ServerConnectionActor, and UnaryFacade.
 - `ServerConnectionActor` — Core behavior handling egress messages and the ingress loop.
 - `UnaryFacade` — Implements `mailboxrpc.RPCClient` for generated RPC stubs (low-latency path). Also provides `AwaitRPCTimeout` for bounded waits.
-- `ConnectorConfig` — Wiring configuration (edge address, mailbox IDs, dispatchers, store).
+- `ConnectorConfig` — Wiring configuration (edge address, mailbox IDs, dispatchers, store, durable unary builder).
 - `AckState` — Four-cursor watermark state machine (PullCursor, DispatchCommittedTo, AckTarget, AckCommittedTo).
 - `SendUnaryRequest` — Durable typed unary request that becomes a real unary RPC after commit. The response arrives via KIND_RESPONSE and, if no in-memory waiter exists, falls back to durable route dispatch via the EventRouter.
+- `DurableUnaryBuilder` — Proof-gated request-body builder used by transport-native durable query messages.
+- `SendListOORRecipientEventsByScriptRequest` / `SendListVTXOsByScriptsRequest` — transport-native durable indexer query messages emitted by OOR receive.
 
 ## Relationships
 
@@ -22,6 +24,7 @@ background ingress polling with event routing.
 - **Sends (egress → remote mailbox)**:
   - `SendClientEventRequest` (durable): wraps `JoinRoundRequest`, `SubmitNoncesRequest`, `SubmitPartialSigRequest`, `SubmitForfeitSigRequest`
   - `SendRPCRequest` (unary, non-durable): low-latency request-response RPCs
+  - transport-native durable query messages for proof-gated indexer lookups
 - **Routes (ingress → local actors via EventRouter)**:
   - → `round`: `CommitmentTxBuilt`, `NoncesAggregated`, `OperatorSigned`, `RoundJoined`, `BoardingFailed`
   - → `oor`: `SubmitAcceptedEvent`, `FinalizeAcceptedEvent`, `IncomingTransferEvent`

--- a/serverconn/CLAUDE.md
+++ b/serverconn/CLAUDE.md
@@ -10,9 +10,10 @@ background ingress polling with event routing.
 
 - `Runtime` — Main entry point wrapping DurableActor, ServerConnectionActor, and UnaryFacade.
 - `ServerConnectionActor` — Core behavior handling egress messages and the ingress loop.
-- `UnaryFacade` — Implements `mailboxrpc.RPCClient` for generated RPC stubs (low-latency path).
+- `UnaryFacade` — Implements `mailboxrpc.RPCClient` for generated RPC stubs (low-latency path). Also provides `AwaitRPCTimeout` for bounded waits.
 - `ConnectorConfig` — Wiring configuration (edge address, mailbox IDs, dispatchers, store).
 - `AckState` — Four-cursor watermark state machine (PullCursor, DispatchCommittedTo, AckTarget, AckCommittedTo).
+- `SendUnaryRequest` — Durable typed unary request that becomes a real unary RPC after commit. The response arrives via KIND_RESPONSE and, if no in-memory waiter exists, falls back to durable route dispatch via the EventRouter.
 
 ## Relationships
 
@@ -31,7 +32,8 @@ background ingress polling with event routing.
 ## Invariants
 
 - Ack watermark only advances AFTER durable local dispatch commit (prevents message loss on crash).
-- Unary RPC responses use in-memory registry (no durability); on crash, callers retry with fresh correlation IDs.
+- Unary RPC responses use in-memory registry first; if no waiter exists (crash replay), the ingress falls back to durable EventRouter dispatch. The ResponseRegistry returns a tri-state delivery result (waiter/buffered/dropped) so the ingress knows whether to route durably.
+- `SendClientEventRequest` auto-derives `Service`/`Method` from `Message.ServiceMethod()` when callers leave them empty, preventing silent drops.
 - Idempotency keys are derived from message payload hash; same key on retry enables server deduplication.
 - Ingress loop checkpoints pull cursor and ack state; on restart, resumes from checkpoint.
 

--- a/serverconn/actor.go
+++ b/serverconn/actor.go
@@ -178,6 +178,8 @@ func (m *SendClientEventRequest) Encode(w io.Writer) error {
 		return fmt.Errorf("convert to proto: %w", err)
 	}
 
+	service, method := eventRoutingMetadata(m)
+
 	anyMsg, err := anypb.New(protoMsg)
 	if err != nil {
 		return fmt.Errorf("wrap proto in Any: %w", err)
@@ -215,10 +217,10 @@ func (m *SendClientEventRequest) Encode(w io.Writer) error {
 		idempotencyBytes,
 	)
 	svcRec := tlv.NewPrimitiveRecord[rpcServiceRecordTLV](
-		[]byte(m.Service),
+		[]byte(service),
 	)
 	methodRec := tlv.NewPrimitiveRecord[rpcMethodRecordTLV](
-		[]byte(m.Method),
+		[]byte(method),
 	)
 
 	stream, err := tlv.NewStream(
@@ -493,6 +495,8 @@ func (a *ServerConnectionActor) handleSendClientEvent(ctx context.Context,
 		}
 	}
 
+	service, method := eventRoutingMetadata(req)
+
 	envelope := &mailboxpb.Envelope{
 		ProtocolVersion: a.cfg.ProtocolVersion,
 		MsgId:           msgID,
@@ -503,8 +507,8 @@ func (a *ServerConnectionActor) handleSendClientEvent(ctx context.Context,
 		Body:            body,
 		Rpc: &mailboxpb.RpcMeta{
 			Kind:    mailboxpb.RpcMeta_KIND_EVENT,
-			Service: req.Service,
-			Method:  req.Method,
+			Service: service,
+			Method:  method,
 			ReplyTo: a.cfg.LocalMailboxID,
 		},
 	}
@@ -536,6 +540,36 @@ func (a *ServerConnectionActor) handleSendClientEvent(ctx context.Context,
 	return fn.Ok[ServerConnResp](&SendClientEventResponse{
 		Success: true,
 	})
+}
+
+// eventRoutingMetadata returns the outbound routing metadata persisted on a
+// SendClientEventRequest. When callers leave Service/Method empty, we derive
+// them directly from the wrapped ServerMessage so direct sends remain aligned
+// with the production round-actor outbox path.
+func eventRoutingMetadata(req *SendClientEventRequest) (string, string) {
+	if req == nil {
+		return "", ""
+	}
+
+	if req.Service != "" && req.Method != "" {
+		return req.Service, req.Method
+	}
+
+	if req.Message == nil {
+		return req.Service, req.Method
+	}
+
+	sm := req.Message.ServiceMethod()
+	service := req.Service
+	method := req.Method
+	if service == "" {
+		service = sm.Service
+	}
+	if method == "" {
+		method = sm.Method
+	}
+
+	return service, method
 }
 
 // handleSendRPCRequest sends a pre-built unary RPC envelope via the mailbox

--- a/serverconn/actor.go
+++ b/serverconn/actor.go
@@ -28,6 +28,10 @@ const (
 	// SendRPCRequestMsgType is the TLV type for outbound unary RPC
 	// envelopes from the unary facade.
 	SendRPCRequestMsgType tlv.Type = 2001
+
+	// SendUnaryRequestMsgType is the TLV type for durable correlated unary
+	// requests where the connector constructs the mailbox envelope.
+	SendUnaryRequestMsgType tlv.Type = 2002
 )
 
 // defaultSendEventTimeout is the timeout for outbound gRPC Edge.Send calls.
@@ -41,6 +45,7 @@ type (
 	idempotencyRecordTLV  = tlv.TlvType4
 	rpcServiceRecordTLV   = tlv.TlvType5
 	rpcMethodRecordTLV    = tlv.TlvType6
+	rpcCorrelationRecordTLV = tlv.TlvType7
 )
 
 // ServerMessage is an interface that client FSM outbox messages must implement
@@ -376,6 +381,158 @@ func (m *SendRPCRequest) Decode(r io.Reader) error {
 // serverConnMsgSealed implements the ServerConnMsg interface seal.
 func (m *SendRPCRequest) serverConnMsgSealed() {}
 
+// SendUnaryRequest wraps a typed unary RPC request for durable delivery via
+// the mailbox edge. Unlike SendRPCRequest, the caller provides the request
+// body and routing metadata rather than a pre-built envelope.
+type SendUnaryRequest struct {
+	actor.BaseMessage
+
+	// Body is the request payload wrapped as Any.
+	Body *anypb.Any
+
+	// MsgID uniquely identifies this send attempt. Retries of the same
+	// persisted request must reuse this ID.
+	MsgID string
+
+	// IdempotencyKey identifies the semantic operation for remote dedupe.
+	IdempotencyKey string
+
+	// Service is the fully-qualified protobuf service name.
+	Service string
+
+	// Method is the RPC method name.
+	Method string
+
+	// CorrelationID links this request to the eventual KIND_RESPONSE.
+	CorrelationID string
+}
+
+// NewSendUnaryRequest constructs a durable unary request from the given proto
+// payload and routing metadata.
+func NewSendUnaryRequest(method mailboxrpc.ServiceMethod, req proto.Message,
+	correlationID string) (*SendUnaryRequest, error) {
+
+	if req == nil {
+		return nil, fmt.Errorf("unary request body must be provided")
+	}
+
+	body, err := anypb.New(req)
+	if err != nil {
+		return nil, fmt.Errorf("wrap unary request in Any: %w", err)
+	}
+
+	return &SendUnaryRequest{
+		Body:          body,
+		Service:       method.Service,
+		Method:        method.Method,
+		CorrelationID: correlationID,
+	}, nil
+}
+
+// MessageType returns a human-readable type name for logging.
+func (m *SendUnaryRequest) MessageType() string {
+	return "SendUnaryRequest"
+}
+
+// TLVType returns the unique TLV type identifier for this message.
+func (m *SendUnaryRequest) TLVType() tlv.Type {
+	return SendUnaryRequestMsgType
+}
+
+// Encode serializes the message to the provided writer.
+func (m *SendUnaryRequest) Encode(w io.Writer) error {
+	body := m.Body
+	if body == nil {
+		return fmt.Errorf("unary request body must be provided")
+	}
+
+	bodyBytes, err := (proto.MarshalOptions{
+		Deterministic: true,
+	}).Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal unary request body: %w", err)
+	}
+
+	msgID := m.MsgID
+	if msgID == "" {
+		msgID = mailboxconn.StableEventMsgID(bodyBytes)
+	}
+
+	idempotencyKey := m.IdempotencyKey
+	if idempotencyKey == "" {
+		idempotencyKey = mailboxconn.
+			StableEventIdempotencyKey(bodyBytes)
+	}
+
+	bodyRec := tlv.NewRecordT[protoPayloadRecordTLV](
+		mailboxconn.WrappedProto[*anypb.Any]{Val: body},
+	)
+	msgIDRec := tlv.NewPrimitiveRecord[msgIDRecordTLV](
+		[]byte(msgID),
+	)
+	idemRec := tlv.NewPrimitiveRecord[idempotencyRecordTLV](
+		[]byte(idempotencyKey),
+	)
+	svcRec := tlv.NewPrimitiveRecord[rpcServiceRecordTLV](
+		[]byte(m.Service),
+	)
+	methodRec := tlv.NewPrimitiveRecord[rpcMethodRecordTLV](
+		[]byte(m.Method),
+	)
+	corrRec := tlv.NewPrimitiveRecord[rpcCorrelationRecordTLV](
+		[]byte(m.CorrelationID),
+	)
+
+	stream, err := tlv.NewStream(
+		bodyRec.Record(), msgIDRec.Record(), idemRec.Record(),
+		svcRec.Record(), methodRec.Record(), corrRec.Record(),
+	)
+	if err != nil {
+		return err
+	}
+
+	return stream.Encode(w)
+}
+
+// Decode deserializes the message from the provided reader.
+func (m *SendUnaryRequest) Decode(r io.Reader) error {
+	bodyRec := tlv.ZeroRecordT[
+		protoPayloadRecordTLV,
+		mailboxconn.WrappedProto[*anypb.Any],
+	]()
+	bodyRec.Val.Val = &anypb.Any{}
+
+	msgIDRec := tlv.ZeroRecordT[msgIDRecordTLV, []byte]()
+	idemRec := tlv.ZeroRecordT[idempotencyRecordTLV, []byte]()
+	svcRec := tlv.ZeroRecordT[rpcServiceRecordTLV, []byte]()
+	methodRec := tlv.ZeroRecordT[rpcMethodRecordTLV, []byte]()
+	corrRec := tlv.ZeroRecordT[rpcCorrelationRecordTLV, []byte]()
+
+	stream, err := tlv.NewStream(
+		bodyRec.Record(), msgIDRec.Record(), idemRec.Record(),
+		svcRec.Record(), methodRec.Record(), corrRec.Record(),
+	)
+	if err != nil {
+		return err
+	}
+
+	if _, err := stream.DecodeWithParsedTypes(r); err != nil {
+		return err
+	}
+
+	m.Body = bodyRec.Val.Val
+	m.MsgID = string(msgIDRec.Val)
+	m.IdempotencyKey = string(idemRec.Val)
+	m.Service = string(svcRec.Val)
+	m.Method = string(methodRec.Val)
+	m.CorrelationID = string(corrRec.Val)
+
+	return nil
+}
+
+// serverConnMsgSealed implements the ServerConnMsg interface seal.
+func (m *SendUnaryRequest) serverConnMsgSealed() {}
+
 // ServerConnectionActor is the unified connector boundary for all mailbox
 // traffic between the client and the remote server. It serves as both:
 //
@@ -437,6 +594,9 @@ func (a *ServerConnectionActor) Receive(ctx context.Context,
 	switch m := msg.(type) {
 	case *SendClientEventRequest:
 		return a.handleSendClientEvent(ctx, m)
+
+	case *SendUnaryRequest:
+		return a.handleSendUnaryRequest(ctx, m)
 
 	case *SendRPCRequest:
 		return a.handleSendRPCRequest(ctx, m)
@@ -542,6 +702,101 @@ func (a *ServerConnectionActor) handleSendClientEvent(ctx context.Context,
 	})
 }
 
+// handleSendUnaryRequest sends a durable correlated unary request via the
+// mailbox edge.
+func (a *ServerConnectionActor) handleSendUnaryRequest(ctx context.Context,
+	req *SendUnaryRequest) fn.Result[ServerConnResp] {
+
+	if req == nil {
+		return fn.Err[ServerConnResp](fmt.Errorf(
+			"unary request must be provided",
+		))
+	}
+
+	if req.Body == nil {
+		return fn.Err[ServerConnResp](fmt.Errorf(
+			"unary request body must be provided",
+		))
+	}
+
+	if req.Service == "" || req.Method == "" {
+		return fn.Err[ServerConnResp](fmt.Errorf(
+			"unary request service and method must be provided",
+		))
+	}
+
+	if req.CorrelationID == "" {
+		return fn.Err[ServerConnResp](fmt.Errorf(
+			"unary request correlation id must be provided",
+		))
+	}
+
+	msgID := req.MsgID
+	idempotencyKey := req.IdempotencyKey
+
+	if msgID == "" || idempotencyKey == "" {
+		bodyBytes, err := (proto.MarshalOptions{
+			Deterministic: true,
+		}).Marshal(req.Body)
+		if err != nil {
+			return fn.Err[ServerConnResp](fmt.Errorf(
+				"marshal unary body: %w", err,
+			))
+		}
+
+		if msgID == "" {
+			msgID = mailboxconn.StableEventMsgID(bodyBytes)
+		}
+
+		if idempotencyKey == "" {
+			idempotencyKey = mailboxconn.
+				StableEventIdempotencyKey(bodyBytes)
+		}
+	}
+
+	envelope := &mailboxpb.Envelope{
+		ProtocolVersion: a.cfg.ProtocolVersion,
+		MsgId:           msgID,
+		IdempotencyKey:  idempotencyKey,
+		Sender:          a.cfg.LocalMailboxID,
+		Recipient:       a.cfg.RemoteMailboxID,
+		CreatedAtUnixMs: time.Now().UnixMilli(),
+		Body:            req.Body,
+		Rpc: &mailboxpb.RpcMeta{
+			Kind:          mailboxpb.RpcMeta_KIND_REQUEST,
+			Service:       req.Service,
+			Method:        req.Method,
+			CorrelationId: req.CorrelationID,
+			ReplyTo:       a.cfg.LocalMailboxID,
+		},
+	}
+
+	sendCtx, sendCancel := context.WithTimeout(
+		context.WithoutCancel(ctx), defaultSendEventTimeout,
+	)
+	defer sendCancel()
+
+	resp, err := a.cfg.Edge.Send(sendCtx, &mailboxpb.SendRequest{
+		Envelope: envelope,
+	})
+	if err != nil {
+		return fn.Err[ServerConnResp](fmt.Errorf(
+			"send unary request: %w", err,
+		))
+	}
+
+	if resp.Status != nil && !resp.Status.Ok {
+		return fn.Err[ServerConnResp](fmt.Errorf(
+			"send unary request: %s (%s)",
+			resp.Status.Message, resp.Status.Code,
+		))
+	}
+
+	return fn.Ok[ServerConnResp](&SendRPCResponse{
+		Success: true,
+	})
+}
+
 // eventRoutingMetadata returns the outbound routing metadata persisted on a
 // SendClientEventRequest. When callers leave Service/Method empty, we derive
 // them directly from the wrapped ServerMessage so direct sends remain aligned
@@ -615,12 +870,19 @@ func (a *ServerConnectionActor) removeWaiter(id CorrelationID) {
 	a.responseRegistry.RemoveWaiter(id)
 }
 
+// removePendingResponse drops any buffered early response for the correlation
+// ID. Durable response dispatchers use this after converting a response into a
+// local actor message so the in-memory unary path cannot consume it later.
+func (a *ServerConnectionActor) removePendingResponse(id CorrelationID) {
+	a.responseRegistry.RemovePending(id)
+}
+
 // deliverResponse looks up a waiter by correlation ID and delivers the
 // envelope. If no waiter exists yet, the response is buffered so a later
 // AwaitRPC call can still observe it.
 func (a *ServerConnectionActor) deliverResponse(
 	id CorrelationID, env *mailboxpb.Envelope,
-) bool {
+) mailboxconn.DeliveryResult {
 
 	return a.responseRegistry.DeliverResponse(id, env)
 }
@@ -680,6 +942,12 @@ func NewServerConnCodec() *actor.MessageCodec {
 			return &SendRPCRequest{}
 		},
 	)
+	codec.MustRegister(
+		SendUnaryRequestMsgType,
+		func() actor.TLVMessage {
+			return &SendUnaryRequest{}
+		},
+	)
 
 	return codec
 }
@@ -687,6 +955,7 @@ func NewServerConnCodec() *actor.MessageCodec {
 // Compile-time interface checks.
 var (
 	_ ServerConnMsg  = (*SendClientEventRequest)(nil)
+	_ ServerConnMsg  = (*SendUnaryRequest)(nil)
 	_ ServerConnMsg  = (*SendRPCRequest)(nil)
 	_ ServerConnResp = (*SendClientEventResponse)(nil)
 	_ ServerConnResp = (*SendRPCResponse)(nil)

--- a/serverconn/actor.go
+++ b/serverconn/actor.go
@@ -39,12 +39,12 @@ const defaultSendEventTimeout = 30 * time.Second
 
 // TLV record type aliases for RecordT-style message field serialization.
 type (
-	protoPayloadRecordTLV = tlv.TlvType1
-	envelopeRecordTLV     = tlv.TlvType2
-	msgIDRecordTLV        = tlv.TlvType3
-	idempotencyRecordTLV  = tlv.TlvType4
-	rpcServiceRecordTLV   = tlv.TlvType5
-	rpcMethodRecordTLV    = tlv.TlvType6
+	protoPayloadRecordTLV   = tlv.TlvType1
+	envelopeRecordTLV       = tlv.TlvType2
+	msgIDRecordTLV          = tlv.TlvType3
+	idempotencyRecordTLV    = tlv.TlvType4
+	rpcServiceRecordTLV     = tlv.TlvType5
+	rpcMethodRecordTLV      = tlv.TlvType6
 	rpcCorrelationRecordTLV = tlv.TlvType7
 )
 
@@ -598,6 +598,14 @@ func (a *ServerConnectionActor) Receive(ctx context.Context,
 	case *SendUnaryRequest:
 		return a.handleSendUnaryRequest(ctx, m)
 
+	case *SendListOORRecipientEventsByScriptRequest:
+		return a.handleSendListOORRecipientEventsByScriptRequest(
+			ctx, m,
+		)
+
+	case *SendListVTXOsByScriptsRequest:
+		return a.handleSendListVTXOsByScriptsRequest(ctx, m)
+
 	case *SendRPCRequest:
 		return a.handleSendRPCRequest(ctx, m)
 
@@ -754,6 +762,146 @@ func (a *ServerConnectionActor) handleSendUnaryRequest(ctx context.Context,
 		}
 	}
 
+	return a.sendUnaryEnvelope(
+		ctx, req.Body, req.Service, req.Method, req.CorrelationID,
+		msgID, idempotencyKey,
+	)
+}
+
+// handleSendListOORRecipientEventsByScriptRequest builds and sends a durable
+// proof-gated indexer unary request for one taproot output script.
+func (a *ServerConnectionActor) handleSendListOORRecipientEventsByScriptRequest(
+	ctx context.Context, req *SendListOORRecipientEventsByScriptRequest,
+) fn.Result[ServerConnResp] {
+
+	if req == nil {
+		return fn.Err[ServerConnResp](fmt.Errorf(
+			"recipient-events query must be provided",
+		))
+	}
+
+	if a.cfg.DurableUnaryBuilder == nil {
+		return fn.Err[ServerConnResp](fmt.Errorf(
+			"durable unary builder must be provided",
+		))
+	}
+
+	protoReq, err := a.cfg.DurableUnaryBuilder.
+		BuildListOORRecipientEventsByScriptRequest(
+			ctx, req.PkScript, req.AfterEventID, req.Limit,
+		)
+	if err != nil {
+		return fn.Err[ServerConnResp](fmt.Errorf(
+			"build recipient-events request: %w", err,
+		))
+	}
+
+	body, err := anypb.New(protoReq)
+	if err != nil {
+		return fn.Err[ServerConnResp](fmt.Errorf(
+			"wrap recipient-events request in Any: %w", err,
+		))
+	}
+
+	stableBytes, err := encodeRecipientEventsQueryIdentity(
+		req.PkScript, req.AfterEventID, req.Limit,
+		req.CorrelationID,
+	)
+	if err != nil {
+		return fn.Err[ServerConnResp](fmt.Errorf(
+			"encode recipient-events identity: %w", err,
+		))
+	}
+
+	msgID := req.MsgID
+	if msgID == "" {
+		msgID = mailboxconn.StableEventMsgID(stableBytes)
+	}
+
+	idempotencyKey := req.IdempotencyKey
+	if idempotencyKey == "" {
+		idempotencyKey = mailboxconn.
+			StableEventIdempotencyKey(stableBytes)
+	}
+
+	method := req.ServiceMethod()
+
+	return a.sendUnaryEnvelope(
+		ctx, body, method.Service, method.Method, req.CorrelationID,
+		msgID, idempotencyKey,
+	)
+}
+
+// handleSendListVTXOsByScriptsRequest builds and sends a durable proof-gated
+// indexer unary request for one or more taproot output scripts.
+func (a *ServerConnectionActor) handleSendListVTXOsByScriptsRequest(
+	ctx context.Context, req *SendListVTXOsByScriptsRequest,
+) fn.Result[ServerConnResp] {
+
+	if req == nil {
+		return fn.Err[ServerConnResp](fmt.Errorf(
+			"vtxo query must be provided",
+		))
+	}
+
+	if a.cfg.DurableUnaryBuilder == nil {
+		return fn.Err[ServerConnResp](fmt.Errorf(
+			"durable unary builder must be provided",
+		))
+	}
+
+	protoReq, err := a.cfg.DurableUnaryBuilder.
+		BuildListVTXOsByScriptsRequest(
+			ctx, req.PkScripts, req.AfterCursor, req.Limit,
+		)
+	if err != nil {
+		return fn.Err[ServerConnResp](fmt.Errorf(
+			"build vtxo query request: %w", err,
+		))
+	}
+
+	body, err := anypb.New(protoReq)
+	if err != nil {
+		return fn.Err[ServerConnResp](fmt.Errorf(
+			"wrap vtxo query in Any: %w", err,
+		))
+	}
+
+	stableBytes, err := encodeVTXOsByScriptsQueryIdentity(
+		req.PkScripts, req.AfterCursor, req.Limit,
+		req.CorrelationID,
+	)
+	if err != nil {
+		return fn.Err[ServerConnResp](fmt.Errorf(
+			"encode vtxo query identity: %w", err,
+		))
+	}
+
+	msgID := req.MsgID
+	if msgID == "" {
+		msgID = mailboxconn.StableEventMsgID(stableBytes)
+	}
+
+	idempotencyKey := req.IdempotencyKey
+	if idempotencyKey == "" {
+		idempotencyKey = mailboxconn.
+			StableEventIdempotencyKey(stableBytes)
+	}
+
+	method := req.ServiceMethod()
+
+	return a.sendUnaryEnvelope(
+		ctx, body, method.Service, method.Method, req.CorrelationID,
+		msgID, idempotencyKey,
+	)
+}
+
+// sendUnaryEnvelope sends one durable unary request envelope via the mailbox
+// edge using the given routing metadata and stable identifiers.
+func (a *ServerConnectionActor) sendUnaryEnvelope(ctx context.Context,
+	body *anypb.Any, service string, method string, correlationID string,
+	msgID string, idempotencyKey string) fn.Result[ServerConnResp] {
+
 	envelope := &mailboxpb.Envelope{
 		ProtocolVersion: a.cfg.ProtocolVersion,
 		MsgId:           msgID,
@@ -761,12 +909,12 @@ func (a *ServerConnectionActor) handleSendUnaryRequest(ctx context.Context,
 		Sender:          a.cfg.LocalMailboxID,
 		Recipient:       a.cfg.RemoteMailboxID,
 		CreatedAtUnixMs: time.Now().UnixMilli(),
-		Body:            req.Body,
+		Body:            body,
 		Rpc: &mailboxpb.RpcMeta{
 			Kind:          mailboxpb.RpcMeta_KIND_REQUEST,
-			Service:       req.Service,
-			Method:        req.Method,
-			CorrelationId: req.CorrelationID,
+			Service:       service,
+			Method:        method,
+			CorrelationId: correlationID,
 			ReplyTo:       a.cfg.LocalMailboxID,
 		},
 	}
@@ -948,6 +1096,18 @@ func NewServerConnCodec() *actor.MessageCodec {
 			return &SendUnaryRequest{}
 		},
 	)
+	codec.MustRegister(
+		SendListOORRecipientEventsByScriptRequestMsgType,
+		func() actor.TLVMessage {
+			return &SendListOORRecipientEventsByScriptRequest{}
+		},
+	)
+	codec.MustRegister(
+		SendListVTXOsByScriptsRequestMsgType,
+		func() actor.TLVMessage {
+			return &SendListVTXOsByScriptsRequest{}
+		},
+	)
 
 	return codec
 }
@@ -957,6 +1117,8 @@ var (
 	_ ServerConnMsg  = (*SendClientEventRequest)(nil)
 	_ ServerConnMsg  = (*SendUnaryRequest)(nil)
 	_ ServerConnMsg  = (*SendRPCRequest)(nil)
+	_ ServerConnMsg  = (*SendListOORRecipientEventsByScriptRequest)(nil)
+	_ ServerConnMsg  = (*SendListVTXOsByScriptsRequest)(nil)
 	_ ServerConnResp = (*SendClientEventResponse)(nil)
 	_ ServerConnResp = (*SendRPCResponse)(nil)
 

--- a/serverconn/actor_tlv_test.go
+++ b/serverconn/actor_tlv_test.go
@@ -22,9 +22,17 @@ type bytesServerMessage struct {
 	payload []byte
 }
 
-// ServiceMethod returns a zero-value routing key for tests.
+const (
+	testEventService = "test.v1.EventService"
+	testEventMethod  = "PushEvent"
+)
+
+// ServiceMethod returns deterministic routing metadata for tests.
 func (m *bytesServerMessage) ServiceMethod() mailboxrpc.ServiceMethod {
-	return mailboxrpc.ServiceMethod{}
+	return mailboxrpc.ServiceMethod{
+		Service: testEventService,
+		Method:  testEventMethod,
+	}
 }
 
 // ToProto converts the payload to a protobuf wrapper.
@@ -70,6 +78,10 @@ func TestSendClientEventRequest_TLVRoundTrip_DeterministicIDs(t *testing.T) {
 	require.Equal(
 		t, decodedA.IdempotencyKey, decodedB.IdempotencyKey,
 	)
+	require.Equal(t, testEventService, decodedA.Service)
+	require.Equal(t, testEventMethod, decodedA.Method)
+	require.Equal(t, testEventService, decodedB.Service)
+	require.Equal(t, testEventMethod, decodedB.Method)
 
 	protoMsg := decodedA.Message.ToProto().UnwrapOrFail(t)
 	msg, ok := protoMsg.(*wrapperspb.BytesValue)

--- a/serverconn/actor_tlv_test.go
+++ b/serverconn/actor_tlv_test.go
@@ -143,6 +143,40 @@ func TestSendRPCRequest_TLVRoundTrip(t *testing.T) {
 	require.True(t, proto.Equal(original.Envelope, decoded.Envelope))
 }
 
+// TestSendUnaryRequest_TLVRoundTrip verifies durable unary request payload
+// serialization round trips with stable derived identifiers.
+func TestSendUnaryRequest_TLVRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	original, err := NewSendUnaryRequest(
+		mailboxrpc.ServiceMethod{
+			Service: "test.Svc",
+			Method:  "DoThing",
+		},
+		wrapperspb.String("request"),
+		"corr-unary",
+	)
+	require.NoError(t, err)
+
+	var decoded SendUnaryRequest
+	encoded := encodeTLVMessage(t, original)
+
+	require.NoError(
+		t, decoded.Decode(bytes.NewReader(encoded)),
+	)
+
+	require.NotNil(t, decoded.Body)
+	require.NotEmpty(t, decoded.MsgID)
+	require.NotEmpty(t, decoded.IdempotencyKey)
+	require.Equal(t, original.Service, decoded.Service)
+	require.Equal(t, original.Method, decoded.Method)
+	require.Equal(t, original.CorrelationID, decoded.CorrelationID)
+
+	payload := &wrapperspb.StringValue{}
+	require.NoError(t, decoded.Body.UnmarshalTo(payload))
+	require.Equal(t, "request", payload.Value)
+}
+
 // TestServerConnMessageMetadata verifies static message metadata methods.
 func TestServerConnMessageMetadata(t *testing.T) {
 	t.Parallel()
@@ -160,6 +194,11 @@ func TestServerConnMessageMetadata(t *testing.T) {
 	require.Equal(t, "SendRPCRequest", rpcReq.MessageType())
 	require.Equal(t, SendRPCRequestMsgType, rpcReq.TLVType())
 	rpcReq.serverConnMsgSealed()
+
+	unaryReq := &SendUnaryRequest{}
+	require.Equal(t, "SendUnaryRequest", unaryReq.MessageType())
+	require.Equal(t, SendUnaryRequestMsgType, unaryReq.TLVType())
+	unaryReq.serverConnMsgSealed()
 }
 
 // TestRawServerMessage_ToProtoDecodeFailure verifies ToProto returns an error
@@ -230,6 +269,30 @@ func TestServerConnCodec_RoundTrip(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, rpcReq.Envelope.MsgId, typedRPC.Envelope.MsgId)
 	require.Equal(t, rpcReq.Envelope.Sender, typedRPC.Envelope.Sender)
+
+	unaryReq, err := NewSendUnaryRequest(
+		mailboxrpc.ServiceMethod{
+			Service: "test.Svc",
+			Method:  "DoThing",
+		},
+		wrapperspb.String("codec-unary"),
+		"corr-codec-unary",
+	)
+	require.NoError(t, err)
+
+	unaryBytes, err := codec.Encode(unaryReq)
+	require.NoError(t, err)
+
+	decodedUnary, err := codec.Decode(unaryBytes)
+	require.NoError(t, err)
+
+	typedUnary, ok := decodedUnary.(*SendUnaryRequest)
+	require.True(t, ok)
+	require.Equal(t, unaryReq.Service, typedUnary.Service)
+	require.Equal(t, unaryReq.Method, typedUnary.Method)
+	require.Equal(
+		t, unaryReq.CorrelationID, typedUnary.CorrelationID,
+	)
 }
 
 // unknownServerConnMsg is a test-only unsupported message for Receive.

--- a/serverconn/actor_tlv_test.go
+++ b/serverconn/actor_tlv_test.go
@@ -177,6 +177,65 @@ func TestSendUnaryRequest_TLVRoundTrip(t *testing.T) {
 	require.Equal(t, "request", payload.Value)
 }
 
+// TestSendListOORRecipientEventsByScriptRequest_TLVRoundTrip verifies the
+// durable recipient-events query message round-trips through TLV encoding.
+func TestSendListOORRecipientEventsByScriptRequest_TLVRoundTrip(
+	t *testing.T) {
+
+	t.Parallel()
+
+	original := &SendListOORRecipientEventsByScriptRequest{
+		PkScript:      []byte{0x51, 0x20, 0x01},
+		AfterEventID:  7,
+		Limit:         1,
+		CorrelationID: "corr-recipient-query",
+	}
+
+	var decoded SendListOORRecipientEventsByScriptRequest
+	encoded := encodeTLVMessage(t, original)
+
+	require.NoError(
+		t, decoded.Decode(bytes.NewReader(encoded)),
+	)
+
+	require.Equal(t, original.PkScript, decoded.PkScript)
+	require.Equal(t, original.AfterEventID, decoded.AfterEventID)
+	require.Equal(t, original.Limit, decoded.Limit)
+	require.Equal(t, original.CorrelationID, decoded.CorrelationID)
+	require.NotEmpty(t, decoded.MsgID)
+	require.NotEmpty(t, decoded.IdempotencyKey)
+}
+
+// TestSendListVTXOsByScriptsRequest_TLVRoundTrip verifies the durable
+// VTXO-by-scripts query message round-trips through TLV encoding.
+func TestSendListVTXOsByScriptsRequest_TLVRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	original := &SendListVTXOsByScriptsRequest{
+		PkScripts: [][]byte{
+			{0x51, 0x20, 0x01},
+			{0x51, 0x20, 0x02},
+		},
+		AfterCursor:   11,
+		Limit:         128,
+		CorrelationID: "corr-vtxo-query",
+	}
+
+	var decoded SendListVTXOsByScriptsRequest
+	encoded := encodeTLVMessage(t, original)
+
+	require.NoError(
+		t, decoded.Decode(bytes.NewReader(encoded)),
+	)
+
+	require.Equal(t, original.PkScripts, decoded.PkScripts)
+	require.Equal(t, original.AfterCursor, decoded.AfterCursor)
+	require.Equal(t, original.Limit, decoded.Limit)
+	require.Equal(t, original.CorrelationID, decoded.CorrelationID)
+	require.NotEmpty(t, decoded.MsgID)
+	require.NotEmpty(t, decoded.IdempotencyKey)
+}
+
 // TestServerConnMessageMetadata verifies static message metadata methods.
 func TestServerConnMessageMetadata(t *testing.T) {
 	t.Parallel()
@@ -199,6 +258,26 @@ func TestServerConnMessageMetadata(t *testing.T) {
 	require.Equal(t, "SendUnaryRequest", unaryReq.MessageType())
 	require.Equal(t, SendUnaryRequestMsgType, unaryReq.TLVType())
 	unaryReq.serverConnMsgSealed()
+
+	recipientReq := &SendListOORRecipientEventsByScriptRequest{}
+	require.Equal(
+		t, "SendListOORRecipientEventsByScriptRequest",
+		recipientReq.MessageType(),
+	)
+	require.Equal(
+		t, SendListOORRecipientEventsByScriptRequestMsgType,
+		recipientReq.TLVType(),
+	)
+	recipientReq.serverConnMsgSealed()
+
+	vtxoReq := &SendListVTXOsByScriptsRequest{}
+	require.Equal(
+		t, "SendListVTXOsByScriptsRequest", vtxoReq.MessageType(),
+	)
+	require.Equal(
+		t, SendListVTXOsByScriptsRequestMsgType, vtxoReq.TLVType(),
+	)
+	vtxoReq.serverConnMsgSealed()
 }
 
 // TestRawServerMessage_ToProtoDecodeFailure verifies ToProto returns an error
@@ -293,6 +372,47 @@ func TestServerConnCodec_RoundTrip(t *testing.T) {
 	require.Equal(
 		t, unaryReq.CorrelationID, typedUnary.CorrelationID,
 	)
+
+	recipientReq := &SendListOORRecipientEventsByScriptRequest{
+		PkScript:      []byte{0x51, 0x20, 0x04},
+		AfterEventID:  9,
+		Limit:         1,
+		CorrelationID: "corr-codec-recipient",
+	}
+
+	recipientBytes, err := codec.Encode(recipientReq)
+	require.NoError(t, err)
+
+	decodedRecipient, err := codec.Decode(recipientBytes)
+	require.NoError(t, err)
+
+	typedRecipient, ok := decodedRecipient.(*SendListOORRecipientEventsByScriptRequest)
+	require.True(t, ok)
+	require.Equal(t, recipientReq.PkScript, typedRecipient.PkScript)
+	require.Equal(
+		t, recipientReq.CorrelationID, typedRecipient.CorrelationID,
+	)
+
+	vtxoReq := &SendListVTXOsByScriptsRequest{
+		PkScripts: [][]byte{
+			{0x51, 0x20, 0x05},
+			{0x51, 0x20, 0x06},
+		},
+		AfterCursor:   13,
+		Limit:         128,
+		CorrelationID: "corr-codec-vtxo",
+	}
+
+	vtxoBytes, err := codec.Encode(vtxoReq)
+	require.NoError(t, err)
+
+	decodedVTXO, err := codec.Decode(vtxoBytes)
+	require.NoError(t, err)
+
+	typedVTXO, ok := decodedVTXO.(*SendListVTXOsByScriptsRequest)
+	require.True(t, ok)
+	require.Equal(t, vtxoReq.PkScripts, typedVTXO.PkScripts)
+	require.Equal(t, vtxoReq.CorrelationID, typedVTXO.CorrelationID)
 }
 
 // unknownServerConnMsg is a test-only unsupported message for Receive.

--- a/serverconn/connector_test.go
+++ b/serverconn/connector_test.go
@@ -86,6 +86,40 @@ func sendResponseToMailbox(
 	require.True(t, status.Ok, "send response failed: %s", status.Message)
 }
 
+// sendRoutedResponseToMailbox injects a KIND_RESPONSE envelope that carries
+// service/method metadata so ingress can durably dispatch it when no unary
+// waiter is registered.
+func sendRoutedResponseToMailbox(
+	t *testing.T, mb *inMemoryMailbox, recipientID, correlationID,
+	service, method string, payload []byte,
+) {
+
+	t.Helper()
+
+	body := &anypb.Any{
+		TypeUrl: "test/response",
+		Value:   payload,
+	}
+
+	env := &mailboxpb.Envelope{
+		ProtocolVersion: 1,
+		Sender:          "server-1",
+		Recipient:       recipientID,
+		Body:            body,
+		Rpc: &mailboxpb.RpcMeta{
+			Kind:          mailboxpb.RpcMeta_KIND_RESPONSE,
+			CorrelationId: correlationID,
+			Service:       service,
+			Method:        method,
+			ReplyTo:       "server-1",
+		},
+	}
+
+	status := mb.send(env)
+	require.True(t, status.Ok, "send routed response failed: %s",
+		status.Message)
+}
+
 // sendEventToMailbox injects a KIND_EVENT envelope into the given mailbox
 // addressed to recipientID with the specified service/method.
 func sendEventToMailbox(
@@ -204,6 +238,52 @@ func TestIngress_ResponseDelivery(t *testing.T) {
 	require.Equal(
 		t, string(corrID), env.Rpc.CorrelationId,
 	)
+}
+
+// TestIngress_ResponseDispatchWithoutWaiter verifies that a KIND_RESPONSE
+// envelope without an in-memory unary waiter falls back to the durable
+// dispatcher map keyed by service and method.
+func TestIngress_ResponseDispatchWithoutWaiter(t *testing.T) {
+	t.Parallel()
+
+	var (
+		dispatched   []*mailboxpb.Envelope
+		dispatchedMu sync.Mutex
+	)
+
+	dispatchers := map[mailboxrpc.ServiceMethod]EnvelopeDispatcher{
+		{Service: "test.Svc", Method: "Unary"}: func(
+			ctx context.Context,
+			env *mailboxpb.Envelope,
+		) error {
+
+			dispatchedMu.Lock()
+			dispatched = append(dispatched, env)
+			dispatchedMu.Unlock()
+
+			return nil
+		},
+	}
+
+	actor, mb, _ := newTestConnector(t, dispatchers)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	require.NoError(t, actor.StartIngress(ctx))
+	defer actor.StopIngress()
+
+	sendRoutedResponseToMailbox(
+		t, mb, "client-1", "corr-routed", "test.Svc", "Unary",
+		[]byte("response-payload"),
+	)
+
+	require.Eventually(t, func() bool {
+		dispatchedMu.Lock()
+		defer dispatchedMu.Unlock()
+
+		return len(dispatched) == 1
+	}, 5*time.Second, 10*time.Millisecond)
 }
 
 // TestIngress_NoAckOnDispatchFailure verifies that when a dispatcher returns

--- a/serverconn/connector_test.go
+++ b/serverconn/connector_test.go
@@ -2,6 +2,7 @@ package serverconn
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -32,6 +33,31 @@ func (m *testServerMessage) ServiceMethod() mailboxrpc.ServiceMethod {
 // ToProto converts the test message to a protobuf payload.
 func (m *testServerMessage) ToProto() fn.Result[proto.Message] {
 	return fn.Ok[proto.Message](wrapperspb.String(m.value))
+}
+
+// testDurableUnaryBuilder is a minimal builder stub for durable query tests.
+type testDurableUnaryBuilder struct{}
+
+// BuildListOORRecipientEventsByScriptRequest builds a deterministic proto body
+// for recipient-events query tests.
+func (b *testDurableUnaryBuilder) BuildListOORRecipientEventsByScriptRequest(
+	_ context.Context, pkScript []byte, afterEventID uint64, limit uint32,
+) (proto.Message, error) {
+
+	return wrapperspb.String(fmt.Sprintf(
+		"recipient:%x:%d:%d", pkScript, afterEventID, limit,
+	)), nil
+}
+
+// BuildListVTXOsByScriptsRequest builds a deterministic proto body for
+// VTXO-by-scripts query tests.
+func (b *testDurableUnaryBuilder) BuildListVTXOsByScriptsRequest(
+	_ context.Context, pkScripts [][]byte, afterCursor uint64, limit uint32,
+) (proto.Message, error) {
+
+	return wrapperspb.String(fmt.Sprintf(
+		"vtxos:%d:%d:%d", len(pkScripts), afterCursor, limit,
+	)), nil
 }
 
 // newTestConnector builds a ServerConnectionActor with in-memory test
@@ -147,6 +173,49 @@ func sendEventToMailbox(
 
 	status := mb.send(env)
 	require.True(t, status.Ok, "send event failed: %s", status.Message)
+}
+
+// TestServerConnectionActor_SendListOORRecipientEventsByScriptRequest verifies
+// the transport-native durable recipient-events query is built and sent as a
+// unary mailbox request with the expected route metadata.
+func TestServerConnectionActor_SendListOORRecipientEventsByScriptRequest(
+	t *testing.T) {
+
+	t.Parallel()
+
+	actor, mb, _ := newTestConnector(t, nil)
+	actor.cfg.DurableUnaryBuilder = &testDurableUnaryBuilder{}
+
+	result := actor.Receive(
+		t.Context(),
+		&SendListOORRecipientEventsByScriptRequest{
+			PkScript:      []byte{0x51, 0x20, 0x01},
+			AfterEventID:  7,
+			Limit:         1,
+			CorrelationID: "corr-recipient",
+		},
+	)
+	require.NoError(t, result.Err())
+
+	mb.mu.Lock()
+	require.Len(t, mb.mailboxes["server-1"], 1)
+	env := proto.Clone(mb.mailboxes["server-1"][0]).(*mailboxpb.Envelope)
+	mb.mu.Unlock()
+
+	require.Equal(
+		t, "arkrpc.IndexerService", env.GetRpc().GetService(),
+	)
+	require.Equal(
+		t, "ListOORRecipientEventsByScript",
+		env.GetRpc().GetMethod(),
+	)
+	require.Equal(
+		t, "corr-recipient", env.GetRpc().GetCorrelationId(),
+	)
+
+	payload := &wrapperspb.StringValue{}
+	require.NoError(t, env.GetBody().UnmarshalTo(payload))
+	require.Equal(t, "recipient:512001:7:1", payload.Value)
 }
 
 // TestIngress_DispatchAndAck verifies that the ingress loop pulls envelopes,

--- a/serverconn/connector_test.go
+++ b/serverconn/connector_test.go
@@ -21,9 +21,12 @@ type testServerMessage struct {
 	value string
 }
 
-// ServiceMethod returns a zero-value routing key for tests.
+// ServiceMethod returns deterministic routing metadata for tests.
 func (m *testServerMessage) ServiceMethod() mailboxrpc.ServiceMethod {
-	return mailboxrpc.ServiceMethod{}
+	return mailboxrpc.ServiceMethod{
+		Service: testEventService,
+		Method:  testEventMethod,
+	}
 }
 
 // ToProto converts the test message to a protobuf payload.
@@ -364,6 +367,12 @@ func TestEgress_EventRetriesPreserveIdempotencyKey(t *testing.T) {
 	require.Equal(
 		t, envs[0].IdempotencyKey, envs[1].IdempotencyKey,
 	)
+	require.NotNil(t, envs[0].Rpc)
+	require.NotNil(t, envs[1].Rpc)
+	require.Equal(t, testEventService, envs[0].Rpc.Service)
+	require.Equal(t, testEventMethod, envs[0].Rpc.Method)
+	require.Equal(t, testEventService, envs[1].Rpc.Service)
+	require.Equal(t, testEventMethod, envs[1].Rpc.Method)
 }
 
 // TestIngress_PartialDispatch_NoDuplicateRedelivery verifies that when

--- a/serverconn/durable_unary_queries.go
+++ b/serverconn/durable_unary_queries.go
@@ -1,0 +1,479 @@
+package serverconn
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	"github.com/lightninglabs/darepo-client/baselib/actor"
+	mailboxconn "github.com/lightninglabs/darepo-client/mailbox/conn"
+	mailboxrpc "github.com/lightninglabs/darepo-client/mailbox/rpc"
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+const (
+	// SendListOORRecipientEventsByScriptRequestMsgType is the TLV type for
+	// durable proof-gated indexer queries that resolve a lightweight incoming
+	// OOR hint into the full recipient-event package.
+	SendListOORRecipientEventsByScriptRequestMsgType tlv.Type = 2003
+
+	// SendListVTXOsByScriptsRequestMsgType is the TLV type for durable
+	// proof-gated indexer queries that resolve authoritative incoming VTXO
+	// metadata by taproot output script.
+	SendListVTXOsByScriptsRequestMsgType tlv.Type = 2004
+)
+
+type (
+	listRecipientPkScriptRecordTLV    = tlv.TlvType1
+	listRecipientAfterEventRecordTLV  = tlv.TlvType2
+	listRecipientLimitRecordTLV       = tlv.TlvType3
+	listRecipientCorrelationRecordTLV = tlv.TlvType4
+	listRecipientMsgIDRecordTLV       = tlv.TlvType5
+	listRecipientIdempotencyRecordTLV = tlv.TlvType6
+	listVTXOsPkScriptsRecordTLV       = tlv.TlvType1
+	listVTXOsAfterCursorRecordTLV     = tlv.TlvType2
+	listVTXOsLimitRecordTLV           = tlv.TlvType3
+	listVTXOsCorrelationRecordTLV     = tlv.TlvType4
+	listVTXOsMsgIDRecordTLV           = tlv.TlvType5
+	listVTXOsIdempotencyRecordTLV     = tlv.TlvType6
+)
+
+// SendListOORRecipientEventsByScriptRequest describes a durable proof-gated
+// indexer unary query for one taproot output script.
+type SendListOORRecipientEventsByScriptRequest struct {
+	actor.BaseMessage
+
+	// PkScript is the taproot output script to query.
+	PkScript []byte
+
+	// AfterEventID is the exclusive lower bound for the recipient-event
+	// stream cursor.
+	AfterEventID uint64
+
+	// Limit is the maximum number of recipient events to return.
+	Limit uint32
+
+	// CorrelationID links this request to the eventual KIND_RESPONSE.
+	CorrelationID string
+
+	// MsgID uniquely identifies this send attempt. Retries of the same
+	// persisted request must reuse this ID.
+	MsgID string
+
+	// IdempotencyKey identifies the semantic operation for remote dedupe.
+	IdempotencyKey string
+}
+
+// MessageType returns a human-readable type name for logging.
+func (m *SendListOORRecipientEventsByScriptRequest) MessageType() string {
+	return "SendListOORRecipientEventsByScriptRequest"
+}
+
+// TLVType returns the unique TLV type identifier for this message.
+func (m *SendListOORRecipientEventsByScriptRequest) TLVType() tlv.Type {
+	return SendListOORRecipientEventsByScriptRequestMsgType
+}
+
+// ServiceMethod returns the fixed mailbox route for this indexer unary.
+func (m *SendListOORRecipientEventsByScriptRequest) ServiceMethod() mailboxrpc.ServiceMethod {
+
+	return mailboxrpc.ServiceMethod{
+		Service: "arkrpc.IndexerService",
+		Method:  "ListOORRecipientEventsByScript",
+	}
+}
+
+// Encode serializes the message to the provided writer.
+func (m *SendListOORRecipientEventsByScriptRequest) Encode(w io.Writer) error {
+	stableBytes, err := encodeRecipientEventsQueryIdentity(
+		m.PkScript, m.AfterEventID, m.Limit, m.CorrelationID,
+	)
+	if err != nil {
+		return err
+	}
+
+	msgID := m.MsgID
+	if msgID == "" {
+		msgID = mailboxconn.StableEventMsgID(stableBytes)
+	}
+
+	idempotencyKey := m.IdempotencyKey
+	if idempotencyKey == "" {
+		idempotencyKey = mailboxconn.
+			StableEventIdempotencyKey(stableBytes)
+	}
+
+	pkScriptRec := tlv.NewPrimitiveRecord[listRecipientPkScriptRecordTLV](
+		m.PkScript,
+	)
+	afterEventRec := tlv.NewPrimitiveRecord[listRecipientAfterEventRecordTLV](
+		m.AfterEventID,
+	)
+	limit := uint64(m.Limit)
+	limitRec := tlv.NewPrimitiveRecord[listRecipientLimitRecordTLV](
+		limit,
+	)
+	correlationRec := tlv.NewPrimitiveRecord[listRecipientCorrelationRecordTLV](
+		[]byte(m.CorrelationID),
+	)
+	msgIDRec := tlv.NewPrimitiveRecord[listRecipientMsgIDRecordTLV](
+		[]byte(msgID),
+	)
+	idempotencyRec := tlv.NewPrimitiveRecord[listRecipientIdempotencyRecordTLV](
+		[]byte(idempotencyKey),
+	)
+
+	stream, err := tlv.NewStream(
+		pkScriptRec.Record(), afterEventRec.Record(),
+		limitRec.Record(), correlationRec.Record(),
+		msgIDRec.Record(), idempotencyRec.Record(),
+	)
+	if err != nil {
+		return err
+	}
+
+	return stream.Encode(w)
+}
+
+// Decode deserializes the message from the provided reader.
+func (m *SendListOORRecipientEventsByScriptRequest) Decode(r io.Reader) error {
+	pkScriptRec := tlv.ZeroRecordT[listRecipientPkScriptRecordTLV, []byte]()
+	afterEventRec := tlv.ZeroRecordT[
+		listRecipientAfterEventRecordTLV,
+		uint64,
+	]()
+	limitRec := tlv.ZeroRecordT[listRecipientLimitRecordTLV, uint64]()
+	correlationRec := tlv.ZeroRecordT[
+		listRecipientCorrelationRecordTLV,
+		[]byte,
+	]()
+	msgIDRec := tlv.ZeroRecordT[listRecipientMsgIDRecordTLV, []byte]()
+	idempotencyRec := tlv.ZeroRecordT[
+		listRecipientIdempotencyRecordTLV,
+		[]byte,
+	]()
+
+	stream, err := tlv.NewStream(
+		pkScriptRec.Record(), afterEventRec.Record(),
+		limitRec.Record(), correlationRec.Record(),
+		msgIDRec.Record(), idempotencyRec.Record(),
+	)
+	if err != nil {
+		return err
+	}
+
+	if _, err := stream.DecodeWithParsedTypes(r); err != nil {
+		return err
+	}
+
+	m.PkScript = append([]byte(nil), pkScriptRec.Val...)
+	m.AfterEventID = afterEventRec.Val
+	if limitRec.Val > uint64(^uint32(0)) {
+		return fmt.Errorf("recipient query limit overflows uint32: %d",
+			limitRec.Val)
+	}
+	m.Limit = uint32(limitRec.Val)
+	m.CorrelationID = string(correlationRec.Val)
+	m.MsgID = string(msgIDRec.Val)
+	m.IdempotencyKey = string(idempotencyRec.Val)
+
+	return nil
+}
+
+// serverConnMsgSealed implements the ServerConnMsg interface seal.
+func (m *SendListOORRecipientEventsByScriptRequest) serverConnMsgSealed() {}
+
+// SendListVTXOsByScriptsRequest describes a durable proof-gated indexer unary
+// query for one or more taproot output scripts.
+type SendListVTXOsByScriptsRequest struct {
+	actor.BaseMessage
+
+	// PkScripts are the taproot output scripts to query.
+	PkScripts [][]byte
+
+	// AfterCursor is the exclusive lower bound for the VTXO query cursor.
+	AfterCursor uint64
+
+	// Limit is the maximum number of VTXOs to return.
+	Limit uint32
+
+	// CorrelationID links this request to the eventual KIND_RESPONSE.
+	CorrelationID string
+
+	// MsgID uniquely identifies this send attempt. Retries of the same
+	// persisted request must reuse this ID.
+	MsgID string
+
+	// IdempotencyKey identifies the semantic operation for remote dedupe.
+	IdempotencyKey string
+}
+
+// MessageType returns a human-readable type name for logging.
+func (m *SendListVTXOsByScriptsRequest) MessageType() string {
+	return "SendListVTXOsByScriptsRequest"
+}
+
+// TLVType returns the unique TLV type identifier for this message.
+func (m *SendListVTXOsByScriptsRequest) TLVType() tlv.Type {
+	return SendListVTXOsByScriptsRequestMsgType
+}
+
+// ServiceMethod returns the fixed mailbox route for this indexer unary.
+func (m *SendListVTXOsByScriptsRequest) ServiceMethod() mailboxrpc.ServiceMethod {
+	return mailboxrpc.ServiceMethod{
+		Service: "arkrpc.IndexerService",
+		Method:  "ListVTXOsByScripts",
+	}
+}
+
+// Encode serializes the message to the provided writer.
+func (m *SendListVTXOsByScriptsRequest) Encode(w io.Writer) error {
+	stableBytes, err := encodeVTXOsByScriptsQueryIdentity(
+		m.PkScripts, m.AfterCursor, m.Limit, m.CorrelationID,
+	)
+	if err != nil {
+		return err
+	}
+
+	msgID := m.MsgID
+	if msgID == "" {
+		msgID = mailboxconn.StableEventMsgID(stableBytes)
+	}
+
+	idempotencyKey := m.IdempotencyKey
+	if idempotencyKey == "" {
+		idempotencyKey = mailboxconn.
+			StableEventIdempotencyKey(stableBytes)
+	}
+
+	pkScriptsRaw, err := encodeLengthPrefixedBlobList(m.PkScripts)
+	if err != nil {
+		return err
+	}
+
+	pkScriptsRec := tlv.NewPrimitiveRecord[listVTXOsPkScriptsRecordTLV](
+		pkScriptsRaw,
+	)
+	afterCursorRec := tlv.NewPrimitiveRecord[listVTXOsAfterCursorRecordTLV](
+		m.AfterCursor,
+	)
+	limit := uint64(m.Limit)
+	limitRec := tlv.NewPrimitiveRecord[listVTXOsLimitRecordTLV](
+		limit,
+	)
+	correlationRec := tlv.NewPrimitiveRecord[listVTXOsCorrelationRecordTLV](
+		[]byte(m.CorrelationID),
+	)
+	msgIDRec := tlv.NewPrimitiveRecord[listVTXOsMsgIDRecordTLV](
+		[]byte(msgID),
+	)
+	idempotencyRec := tlv.NewPrimitiveRecord[listVTXOsIdempotencyRecordTLV](
+		[]byte(idempotencyKey),
+	)
+
+	stream, err := tlv.NewStream(
+		pkScriptsRec.Record(), afterCursorRec.Record(),
+		limitRec.Record(), correlationRec.Record(),
+		msgIDRec.Record(), idempotencyRec.Record(),
+	)
+	if err != nil {
+		return err
+	}
+
+	return stream.Encode(w)
+}
+
+// Decode deserializes the message from the provided reader.
+func (m *SendListVTXOsByScriptsRequest) Decode(r io.Reader) error {
+	pkScriptsRec := tlv.ZeroRecordT[listVTXOsPkScriptsRecordTLV, []byte]()
+	afterCursorRec := tlv.ZeroRecordT[
+		listVTXOsAfterCursorRecordTLV,
+		uint64,
+	]()
+	limitRec := tlv.ZeroRecordT[listVTXOsLimitRecordTLV, uint64]()
+	correlationRec := tlv.ZeroRecordT[
+		listVTXOsCorrelationRecordTLV,
+		[]byte,
+	]()
+	msgIDRec := tlv.ZeroRecordT[listVTXOsMsgIDRecordTLV, []byte]()
+	idempotencyRec := tlv.ZeroRecordT[
+		listVTXOsIdempotencyRecordTLV,
+		[]byte,
+	]()
+
+	stream, err := tlv.NewStream(
+		pkScriptsRec.Record(), afterCursorRec.Record(),
+		limitRec.Record(), correlationRec.Record(),
+		msgIDRec.Record(), idempotencyRec.Record(),
+	)
+	if err != nil {
+		return err
+	}
+
+	if _, err := stream.DecodeWithParsedTypes(r); err != nil {
+		return err
+	}
+
+	pkScripts, err := decodeLengthPrefixedBlobList(pkScriptsRec.Val)
+	if err != nil {
+		return err
+	}
+
+	if limitRec.Val > uint64(^uint32(0)) {
+		return fmt.Errorf("vtxo query limit overflows uint32: %d",
+			limitRec.Val)
+	}
+
+	m.PkScripts = pkScripts
+	m.AfterCursor = afterCursorRec.Val
+	m.Limit = uint32(limitRec.Val)
+	m.CorrelationID = string(correlationRec.Val)
+	m.MsgID = string(msgIDRec.Val)
+	m.IdempotencyKey = string(idempotencyRec.Val)
+
+	return nil
+}
+
+// serverConnMsgSealed implements the ServerConnMsg interface seal.
+func (m *SendListVTXOsByScriptsRequest) serverConnMsgSealed() {}
+
+// encodeRecipientEventsQueryIdentity encodes the stable identity material for
+// a recipient-events query.
+func encodeRecipientEventsQueryIdentity(pkScript []byte, afterEventID uint64,
+	limit uint32, correlationID string) ([]byte, error) {
+
+	var buf bytes.Buffer
+
+	if err := writeLengthPrefixedBlob(&buf, pkScript); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(
+		&buf, binary.BigEndian, afterEventID,
+	); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(
+		&buf, binary.BigEndian, limit,
+	); err != nil {
+		return nil, err
+	}
+	if err := writeLengthPrefixedBlob(
+		&buf, []byte(correlationID),
+	); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// encodeVTXOsByScriptsQueryIdentity encodes the stable identity material for
+// a VTXO-by-scripts query.
+func encodeVTXOsByScriptsQueryIdentity(pkScripts [][]byte,
+	afterCursor uint64, limit uint32,
+	correlationID string) ([]byte, error) {
+
+	var buf bytes.Buffer
+
+	pkScriptsRaw, err := encodeLengthPrefixedBlobList(pkScripts)
+	if err != nil {
+		return nil, err
+	}
+	if err := writeLengthPrefixedBlob(&buf, pkScriptsRaw); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(
+		&buf, binary.BigEndian, afterCursor,
+	); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(
+		&buf, binary.BigEndian, limit,
+	); err != nil {
+		return nil, err
+	}
+	if err := writeLengthPrefixedBlob(
+		&buf, []byte(correlationID),
+	); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// encodeLengthPrefixedBlobList encodes a blob list as a count-prefixed
+// sequence of length-prefixed byte slices.
+func encodeLengthPrefixedBlobList(blobs [][]byte) ([]byte, error) {
+	var buf bytes.Buffer
+
+	count := uint32(len(blobs))
+	if err := binary.Write(
+		&buf, binary.BigEndian, count,
+	); err != nil {
+		return nil, err
+	}
+
+	for i := range blobs {
+		if err := writeLengthPrefixedBlob(&buf, blobs[i]); err != nil {
+			return nil, err
+		}
+	}
+
+	return buf.Bytes(), nil
+}
+
+// decodeLengthPrefixedBlobList decodes a blob list encoded by
+// encodeLengthPrefixedBlobList.
+func decodeLengthPrefixedBlobList(raw []byte) ([][]byte, error) {
+	reader := bytes.NewReader(raw)
+
+	var count uint32
+	if err := binary.Read(
+		reader, binary.BigEndian, &count,
+	); err != nil {
+		return nil, err
+	}
+
+	blobs := make([][]byte, 0, count)
+	for i := uint32(0); i < count; i++ {
+		blob, err := readLengthPrefixedBlob(reader)
+		if err != nil {
+			return nil, err
+		}
+
+		blobs = append(blobs, blob)
+	}
+
+	if reader.Len() != 0 {
+		return nil, fmt.Errorf("unexpected trailing bytes in blob list")
+	}
+
+	return blobs, nil
+}
+
+// writeLengthPrefixedBlob encodes one length-prefixed byte slice.
+func writeLengthPrefixedBlob(w io.Writer, blob []byte) error {
+	size := uint32(len(blob))
+	if err := binary.Write(w, binary.BigEndian, size); err != nil {
+		return err
+	}
+
+	_, err := w.Write(blob)
+
+	return err
+}
+
+// readLengthPrefixedBlob decodes one length-prefixed byte slice.
+func readLengthPrefixedBlob(r *bytes.Reader) ([]byte, error) {
+	var size uint32
+	if err := binary.Read(r, binary.BigEndian, &size); err != nil {
+		return nil, err
+	}
+
+	blob := make([]byte, size)
+	if _, err := io.ReadFull(r, blob); err != nil {
+		return nil, err
+	}
+
+	return blob, nil
+}

--- a/serverconn/event_router.go
+++ b/serverconn/event_router.go
@@ -80,81 +80,28 @@ func NewEventRouter(system actor.SystemContext) *EventRouter {
 // AddRoute registers a typed event route with the router. The generic
 // parameters [M, R] must match the ServiceKey's type parameters.
 //
-// AddRoute is a package-level generic function rather than a method because Go
-// does not allow methods with type parameters on non-generic types.
+// AddRoute is a thin wrapper around AddEnvelopeRoute that discards the
+// envelope in the Adapt closure. Use AddRoute when the handler does not need
+// transport metadata from the envelope.
 //
 // Registration is idempotent — re-registering the same (service, method) pair
 // replaces the previous route.
 func AddRoute[M actor.Message, R any](r *EventRouter,
 	cfg EventRouteConfig[M, R]) {
 
-	if cfg.Service == "" {
-		panic("serverconn: empty service name in EventRouteConfig")
-	}
-	if cfg.Method == "" {
-		panic("serverconn: empty method name in EventRouteConfig")
-	}
-	if cfg.NewEvent == nil {
-		panic("serverconn: nil NewEvent in EventRouteConfig")
-	}
-	if cfg.Adapt == nil {
-		panic("serverconn: nil Adapt in EventRouteConfig")
-	}
+	adapt := cfg.Adapt
 
-	// Capture config fields and system in a closure to produce the
-	// type-erased EnvelopeDispatcher. The closure owns the full dispatch
-	// chain: deserialize → adapt → Tell (persist to durable mailbox).
-	system := r.system
-	actorKey := cfg.Key
+	AddEnvelopeRoute(r, EnvelopeRouteConfig[M, R]{
+		Service:  cfg.Service,
+		Method:   cfg.Method,
+		NewEvent: cfg.NewEvent,
+		Key:      cfg.Key,
+		Adapt: func(_ *mailboxpb.Envelope,
+			p proto.Message) (M, error) {
 
-	dispatcher := func(ctx context.Context,
-		env *mailboxpb.Envelope) error {
-
-		if env == nil || env.Body == nil {
-			return fmt.Errorf("nil envelope or body for %s/%s",
-				cfg.Service, cfg.Method)
-		}
-
-		// Deserialize the envelope body. The body is an anypb.Any;
-		// its Value field carries the raw proto bytes of the inner
-		// event message. We unmarshal those bytes directly into the
-		// registered event type for forward-compatible decoding.
-		event := cfg.NewEvent()
-		if event == nil {
-			return fmt.Errorf("nil event prototype for %s/%s",
-				cfg.Service, cfg.Method)
-		}
-
-		if err := (proto.UnmarshalOptions{
-			DiscardUnknown: true,
-		}).Unmarshal(env.Body.Value, event); err != nil {
-			return fmt.Errorf("unmarshal %s/%s event: %w",
-				cfg.Service, cfg.Method, err)
-		}
-
-		// Convert the proto event to the actor's message type.
-		actorMsg, err := cfg.Adapt(event)
-		if err != nil {
-			return fmt.Errorf("adapt %s/%s event: %w",
-				cfg.Service, cfg.Method, err)
-		}
-
-		// Dispatch to the target actor via the service key. Ref
-		// returns a virtual router that load-balances across all
-		// registered actors for this key. Tell persists the message
-		// to the actor's durable mailbox before returning, satisfying
-		// the EnvelopeDispatcher contract of committed delivery.
-		return actorKey.Ref(system).Tell(ctx, actorMsg)
-	}
-
-	serviceMethod := mailboxrpc.ServiceMethod{
-		Service: cfg.Service,
-		Method:  cfg.Method,
-	}
-
-	r.mu.Lock()
-	r.routes[serviceMethod] = dispatcher
-	r.mu.Unlock()
+			return adapt(p)
+		},
+	})
 }
 
 // InboundEventRouteConfig holds parameters for registering an event route
@@ -179,6 +126,91 @@ type InboundEventRouteConfig[M InboundActorMessage, R any] struct {
 	// NewMsg must return a non-nil zero-value M. FromProto is called
 	// on the returned value to populate it from the deserialized event.
 	NewMsg func() M
+}
+
+// EnvelopeRouteConfig holds parameters for registering a typed event route
+// that has access to the full inbound envelope. This extends EventRouteConfig
+// by passing the envelope to the Adapt closure, which allows extracting
+// transport-level metadata that is not part of the proto body.
+type EnvelopeRouteConfig[M actor.Message, R any] struct {
+	// Service is the fully-qualified protobuf service name.
+	Service string
+
+	// Method is the protobuf method name.
+	Method string
+
+	// NewEvent must return a fresh zero-value proto.Message for the expected
+	// request or response type.
+	NewEvent func() proto.Message
+
+	// Key is the ServiceKey for the target actor.
+	Key actor.ServiceKey[M, R]
+
+	// Adapt converts the deserialized proto and envelope metadata into the
+	// actor message type M.
+	Adapt func(*mailboxpb.Envelope, proto.Message) (M, error)
+}
+
+// AddEnvelopeRoute registers a typed event route that receives the full
+// inbound envelope in its Adapt closure. This is useful when handlers need
+// transport metadata like the correlation ID on a unary response envelope.
+func AddEnvelopeRoute[M actor.Message, R any](r *EventRouter,
+	cfg EnvelopeRouteConfig[M, R]) {
+
+	if cfg.Service == "" {
+		panic("serverconn: empty service name in EnvelopeRouteConfig")
+	}
+	if cfg.Method == "" {
+		panic("serverconn: empty method name in EnvelopeRouteConfig")
+	}
+	if cfg.NewEvent == nil {
+		panic("serverconn: nil NewEvent in EnvelopeRouteConfig")
+	}
+	if cfg.Adapt == nil {
+		panic("serverconn: nil Adapt in EnvelopeRouteConfig")
+	}
+
+	system := r.system
+	actorKey := cfg.Key
+
+	dispatcher := func(ctx context.Context,
+		env *mailboxpb.Envelope) error {
+
+		if env == nil || env.Body == nil {
+			return fmt.Errorf("nil envelope or body for %s/%s",
+				cfg.Service, cfg.Method)
+		}
+
+		event := cfg.NewEvent()
+		if event == nil {
+			return fmt.Errorf("nil event prototype for %s/%s",
+				cfg.Service, cfg.Method)
+		}
+
+		if err := (proto.UnmarshalOptions{
+			DiscardUnknown: true,
+		}).Unmarshal(env.Body.Value, event); err != nil {
+			return fmt.Errorf("unmarshal %s/%s event: %w",
+				cfg.Service, cfg.Method, err)
+		}
+
+		actorMsg, err := cfg.Adapt(env, event)
+		if err != nil {
+			return fmt.Errorf("adapt %s/%s event: %w",
+				cfg.Service, cfg.Method, err)
+		}
+
+		return actorKey.Ref(system).Tell(ctx, actorMsg)
+	}
+
+	serviceMethod := mailboxrpc.ServiceMethod{
+		Service: cfg.Service,
+		Method:  cfg.Method,
+	}
+
+	r.mu.Lock()
+	r.routes[serviceMethod] = dispatcher
+	r.mu.Unlock()
 }
 
 // NewEventRoute registers a typed event route for actor message types that

--- a/serverconn/ingress.go
+++ b/serverconn/ingress.go
@@ -3,12 +3,14 @@ package serverconn
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"log/slog"
 	"math"
 	"math/rand/v2"
 	"time"
 
 	"github.com/lightninglabs/darepo-client/baselib/actor"
+	mailboxconn "github.com/lightninglabs/darepo-client/mailbox/conn"
 	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
 	mailboxrpc "github.com/lightninglabs/darepo-client/mailbox/rpc"
 )
@@ -199,9 +201,11 @@ func (a *ServerConnectionActor) pullBatch(
 // dispatchBatch iterates envelopes and routes each one to the correct
 // destination:
 //
-//   - KIND_RESPONSE: delivered to the response registry (unary waiters).
-//   - KIND_REQUEST/KIND_EVENT: dispatched to a local actor via the
-//     configured dispatch table.
+//   - KIND_RESPONSE: delivered to the response registry (unary waiters), or
+//     durably dispatched via the configured dispatch table when no waiter is
+//     registered for the correlation ID.
+//   - KIND_REQUEST/KIND_EVENT: dispatched to a local actor via the configured
+//     dispatch table.
 //
 // On success, returns the exclusive batch-next cursor (one past the last
 // envelope). On partial failure, returns the inclusive event_seq of the
@@ -228,9 +232,10 @@ func (a *ServerConnectionActor) dispatchBatch(
 
 		switch env.Rpc.Kind {
 		case mailboxpb.RpcMeta_KIND_RESPONSE:
-			// Route to response registry for unary RPC waiters.
-			// This is not a durable dispatch — the response is
-			// consumed immediately by the waiting goroutine.
+			// Prefer unary waiters for low-latency RPC callers. When no
+			// in-memory waiter is registered, fall back to the durable
+			// dispatch table so actor-driven unary flows can treat the
+			// response like any other ingress event.
 			corrID := CorrelationID(env.Rpc.CorrelationId)
 			if corrID == "" {
 				log.WarnS(ctx,
@@ -243,16 +248,38 @@ func (a *ServerConnectionActor) dispatchBatch(
 				continue
 			}
 
-			delivered := a.deliverResponse(corrID, env)
-			if !delivered {
+			delivery := a.deliverResponse(corrID, env)
+			if delivery == mailboxconn.DeliveryWaiter {
+				break
+			}
+
+			dispatcher, ok := a.cfg.Dispatchers[mailboxrpc.ServiceMethod{
+				Service: env.Rpc.Service,
+				Method:  env.Rpc.Method,
+			}]
+			if !ok {
 				log.WarnS(ctx,
 					"Failed to deliver response "+
 						"envelope",
 					nil,
+					slog.String("delivery_result",
+						fmt.Sprintf("%d", delivery)),
+					slog.String("service", env.Rpc.Service),
+					slog.String("method", env.Rpc.Method),
 					slog.String("correlation_id",
 						string(corrID)),
 					slog.Uint64("event_seq",
 						env.EventSeq))
+
+				break
+			}
+
+			if err := dispatcher(ctx, env); err != nil {
+				return lastCommitted, err
+			}
+
+			if delivery == mailboxconn.DeliveryBuffered {
+				a.removePendingResponse(corrID)
 			}
 
 		case mailboxpb.RpcMeta_KIND_REQUEST,

--- a/serverconn/types.go
+++ b/serverconn/types.go
@@ -8,6 +8,7 @@ import (
 	mailboxconn "github.com/lightninglabs/darepo-client/mailbox/conn"
 	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
 	mailboxrpc "github.com/lightninglabs/darepo-client/mailbox/rpc"
+	"google.golang.org/protobuf/proto"
 )
 
 // CorrelationID links a mailbox request to its response.
@@ -30,6 +31,27 @@ const ackStateType = mailboxconn.CheckpointStateType
 type EnvelopeDispatcher func(
 	ctx context.Context, env *mailboxpb.Envelope,
 ) error
+
+// DurableUnaryRequestBuilder constructs proof-gated unary request payloads
+// for durable transport messages that only persist the query spec. The
+// returned proto is wrapped into a mailbox KIND_REQUEST envelope after the
+// durable serverconn mailbox commit completes.
+type DurableUnaryRequestBuilder interface {
+	// BuildListOORRecipientEventsByScriptRequest builds the
+	// ListOORRecipientEventsByScript unary request for the given taproot
+	// output script and monotonic cursor.
+	BuildListOORRecipientEventsByScriptRequest(ctx context.Context,
+		pkScript []byte, afterEventID uint64, limit uint32) (
+		proto.Message, error,
+	)
+
+	// BuildListVTXOsByScriptsRequest builds the ListVTXOsByScripts unary
+	// request for the given taproot output scripts and cursor.
+	BuildListVTXOsByScriptsRequest(ctx context.Context,
+		pkScripts [][]byte, afterCursor uint64, limit uint32) (
+		proto.Message, error,
+	)
+}
 
 // ConnectorConfig holds all dependencies and tuning knobs for the server
 // connection actor. The connector is the single boundary for all mailbox
@@ -65,6 +87,11 @@ type ConnectorConfig struct {
 	// Codec handles TLV serialization of ServerConnMsg types for the
 	// durable actor mailbox.
 	Codec *actor.MessageCodec
+
+	// DurableUnaryBuilder constructs proof-gated unary request bodies for
+	// transport-native durable unary messages such as indexer script-scope
+	// queries. When nil, those message types are rejected.
+	DurableUnaryBuilder DurableUnaryRequestBuilder
 
 	// PullMaxEnvelopes bounds the number of envelopes returned per Pull
 	// call.


### PR DESCRIPTION
## Summary

This PR implements the full production OOR incoming transfer receive
path with crash-safe async materialization. The changes enable clients
to receive OOR transfers through production connectors (serverconn +
mailbox) without SQLite write-lock starvation or ingress deadlocks.

## Detailed Fix Catalogue

See the [OOR fixes analysis gist](https://gist.github.com/Roasbeef/360a155ad12bcd8565cbe88c1d845bf3)
for the full 20-fix catalogue with production applicability matrix.

## Key Changes

### Three-Phase Async Receive (oor/actor.go, oor/receive_*)
- Phase 1: Route persists lightweight ResolveIncomingTransferRequest (TLV durable)
- Phase 2: Actor resolves via IncomingFetcher outside DB tx (no lock contention)
- Phase 3: Actor drives receive FSM → async MaterializeIncomingVTXOs → callback

### Owner-Pubkey TLV Proof (indexer/client.go, indexer/signer_adapters.go)
- VTXO tapscripts use NUMS internal key — client can't sign output-key proof
- New TLV field carries owner pubkey; server reconstructs + verifies

### Async Materialization (oor/local_persistence_handler.go)
- Detects actor DB tx via hasActorDBTx(ctx)
- Schedules indexer queries in background goroutine
- CallbackRef delivers result as fresh DriveEventRequest

### Production Daemon Wiring (darepod/server.go)
- EnsureDefaultOORReceiveKey centralized for daemon + systest
- IncomingFetcher, CallbackRef, operator terms all wired
- SendClientEventRequest auto-derives ServiceMethod

## Test Plan

- [x] `go test ./oor -count=1` — all OOR unit tests
- [x] `go test ./darepod ./indexer ./oor -count=1` — integration
- [x] `go test ./serverconn -count=1` — connector tests
- [x] Full systest suite (417s, zero failures)