### PR TITLE
serverconn: add heartbeat sender for server liveness detection

### DIFF
--- a/round/from_proto_test.go
+++ b/round/from_proto_test.go
@@ -119,10 +119,11 @@ func TestJoinRoundRequestFromProtoPreservesVTXOSigningKey(t *testing.T) {
 	pb := &roundpb.JoinRoundRequest{
 		VtxoRequests: []*roundpb.VTXORequest{
 			{
-				Amount:    1234,
-				PkScript:  []byte{0x51},
-				Expiry:    144,
-				ClientKey: clientPriv.PubKey().SerializeCompressed(),
+				Amount:   1234,
+				PkScript: []byte{0x51},
+				Expiry:   144,
+				ClientKey: clientPriv.PubKey().
+					SerializeCompressed(),
 				OperatorKey: operatorPriv.PubKey().
 					SerializeCompressed(),
 				SigningKey: signingPriv.PubKey().

--- a/serverconn/actor.go
+++ b/serverconn/actor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/lightninglabs/darepo-client/baselib/actor"
@@ -568,6 +569,12 @@ type ServerConnectionActor struct {
 
 	// wg tracks the ingress loop goroutine for clean shutdown.
 	wg sync.WaitGroup
+
+	// lastSendNano stores the UnixNano timestamp of the last
+	// successful outbound Edge.Send. The heartbeat goroutine
+	// checks this to skip sending when real traffic already
+	// proves liveness.
+	lastSendNano atomic.Int64
 }
 
 // NewServerConnectionActor creates a new server connection actor with the
@@ -704,6 +711,8 @@ func (a *ServerConnectionActor) handleSendClientEvent(ctx context.Context,
 			resp.Status.Message, resp.Status.Code,
 		))
 	}
+
+	a.lastSendNano.Store(time.Now().UnixNano())
 
 	return fn.Ok[ServerConnResp](&SendClientEventResponse{
 		Success: true,
@@ -917,6 +926,8 @@ func (a *ServerConnectionActor) handleSendRPCRequest(ctx context.Context,
 		))
 	}
 
+	a.lastSendNano.Store(time.Now().UnixNano())
+
 	return fn.Ok[ServerConnResp](&SendRPCResponse{
 		Success: true,
 	})
@@ -957,9 +968,9 @@ func (a *ServerConnectionActor) deliverResponse(
 }
 
 // StartIngress loads the ack checkpoint from the store and launches the
-// background ingress loop goroutine. If the checkpoint cannot be loaded,
-// an error is returned and the loop is not started — the caller should
-// treat this as a fatal startup failure.
+// background ingress loop and heartbeat goroutines. If the checkpoint
+// cannot be loaded, an error is returned and neither goroutine is
+// started — the caller should treat this as a fatal startup failure.
 func (a *ServerConnectionActor) StartIngress(
 	ctx context.Context,
 ) error {
@@ -971,9 +982,13 @@ func (a *ServerConnectionActor) StartIngress(
 
 	ingressCtx, cancel := context.WithCancel(ctx)
 
-	a.wg.Add(1)
+	a.wg.Add(2)
 	a.cancelCh <- cancel
 	go a.ingressLoop(ingressCtx, state)
+	go func() {
+		defer a.wg.Done()
+		a.startHeartbeat(ingressCtx)
+	}()
 
 	return nil
 }

--- a/serverconn/heartbeat.go
+++ b/serverconn/heartbeat.go
@@ -1,0 +1,114 @@
+package serverconn
+
+import (
+	"context"
+	"encoding/binary"
+	"time"
+
+	mailboxconn "github.com/lightninglabs/darepo-client/mailbox/conn"
+	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
+)
+
+const (
+	// HeartbeatService is the well-known protobuf service name used
+	// for heartbeat envelopes. The server's ingress dispatcher
+	// recognises this service to update the client's liveness
+	// status.
+	HeartbeatService = "clientconn.v1.HeartbeatService"
+
+	// HeartbeatMethod is the RPC method name for heartbeat
+	// envelopes.
+	HeartbeatMethod = "Heartbeat"
+
+	// DefaultHeartbeatInterval is the default interval between
+	// heartbeat sends. The server's default staleness threshold
+	// (60 s) is 2× this interval, giving one missed heartbeat as
+	// grace.
+	DefaultHeartbeatInterval = 30 * time.Second
+)
+
+// startHeartbeat launches a background goroutine that periodically
+// sends a lightweight heartbeat envelope to the server's mailbox. The
+// heartbeat proves to the server that this client is alive even when
+// it has no real traffic to send.
+//
+// The heartbeat is idle-aware: if real outbound traffic (event or RPC)
+// was sent within the current interval, the heartbeat is skipped since
+// the server's ingress loop will already observe activity.
+//
+// The goroutine exits when ctx is cancelled. Errors on individual
+// heartbeat sends are silently ignored — the server will transition
+// the client to offline after its staleness threshold if heartbeats
+// stop arriving.
+func (a *ServerConnectionActor) startHeartbeat(ctx context.Context) {
+	interval := a.cfg.HeartbeatInterval
+	if interval <= 0 {
+		interval = DefaultHeartbeatInterval
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+
+		case <-ticker.C:
+			// Skip the heartbeat if real traffic was sent
+			// recently enough that the server will still
+			// consider us active.
+			lastSend := a.lastSendNano.Load()
+			if lastSend > 0 {
+				elapsed := time.Since(
+					time.Unix(0, lastSend),
+				)
+				if elapsed < interval {
+					continue
+				}
+			}
+
+			a.sendHeartbeat(ctx)
+		}
+	}
+}
+
+// sendHeartbeat sends a single heartbeat envelope to the server. The
+// envelope has no body — the service/method metadata is sufficient for
+// the server to recognise it as a liveness signal.
+func (a *ServerConnectionActor) sendHeartbeat(ctx context.Context) {
+	now := time.Now()
+
+	// Each heartbeat needs a unique MsgId to avoid deduplication
+	// by the mailbox transport. We append the current timestamp
+	// to the seed before hashing.
+	var buf [8]byte
+	binary.BigEndian.PutUint64(buf[:], uint64(now.UnixNano()))
+	msgID := mailboxconn.StableEventMsgID(
+		append([]byte("heartbeat"), buf[:]...),
+	)
+
+	envelope := &mailboxpb.Envelope{
+		ProtocolVersion: a.cfg.ProtocolVersion,
+		MsgId:           msgID,
+		Sender:          a.cfg.LocalMailboxID,
+		Recipient:       a.cfg.RemoteMailboxID,
+		CreatedAtUnixMs: now.UnixMilli(),
+		Rpc: &mailboxpb.RpcMeta{
+			Kind:    mailboxpb.RpcMeta_KIND_EVENT,
+			Service: HeartbeatService,
+			Method:  HeartbeatMethod,
+			ReplyTo: a.cfg.LocalMailboxID,
+		},
+	}
+
+	// Best-effort: log but don't fail. The server will mark us
+	// offline after the staleness threshold if heartbeats stop
+	// arriving.
+	_, err := a.cfg.Edge.Send(ctx, &mailboxpb.SendRequest{
+		Envelope: envelope,
+	})
+	if err != nil {
+		log.WarnS(ctx, "Heartbeat send failed", err)
+	}
+}

--- a/serverconn/types.go
+++ b/serverconn/types.go
@@ -141,6 +141,12 @@ type ConnectorConfig struct {
 	// ResponseWaiterTTL bounds how long a response waiter (or buffered
 	// early response) is retained before stale cleanup.
 	ResponseWaiterTTL time.Duration
+
+	// HeartbeatInterval is the interval between heartbeat sends to
+	// the server. A zero or negative value uses
+	// DefaultHeartbeatInterval (30 s). The server's staleness
+	// threshold should be at least 2× this interval.
+	HeartbeatInterval time.Duration
 }
 
 // DefaultConnectorConfig returns a ConnectorConfig with sensible defaults for

--- a/systest/oor_vtxo_manager_test.go
+++ b/systest/oor_vtxo_manager_test.go
@@ -223,6 +223,30 @@ func driveIncomingOutbox(ctx context.Context, session *oor.ReceiveSession,
 				}
 			}
 
+		case *oor.QueryIncomingMetadataRequest:
+			followUps, err := handler.Handle(
+				ctx, sessionID, typedMsg,
+			)
+			if err != nil {
+				return err
+			}
+
+			for _, followUp := range followUps {
+				fut := session.FSM.AskEvent(ctx, followUp)
+				result := fut.Await(ctx)
+				if result.IsErr() {
+					return result.Err()
+				}
+
+				nextOutbox := result.UnwrapOr(nil)
+				if err := driveIncomingOutbox(
+					ctx, session, handler, sessionID,
+					managerRef, nextOutbox,
+				); err != nil {
+					return err
+				}
+			}
+
 		case *oor.SendIncomingAckRequest:
 			followUps, err := handler.Handle(
 				ctx, sessionID, typedMsg,


### PR DESCRIPTION
## Summary

Previously the server stored VTXOs with only a single cosigner key, so
only the current operator term could reconstruct the collaborative spend
path. After operator key rotation, existing VTXOs became unspendable.

This PR makes each stored VTXO self-contained by persisting:
- **owner key** — client key committed to the VTXO script
- **operator key** — server key for the collaborative spend path
- **exit delay** — CSV delay on the unilateral timeout path
- **operator key locator** — wallet family/index for future signing

The round codec is split into two variants: a registration descriptor
(includes the ephemeral tree signing key for MuSig2) and a stored
descriptor (omits it). Forfeit signing and validation now source all
keys from the VTXO itself rather than from the current environment.

Depends on client PR lightninglabs/darepo-client#208
(`vtxo-owner-cosigner-split`).

## Changes

- `db/rounds_codec.go` — new `serializeStoredVTXODescriptor` /
  `deserializeStoredVTXODescriptor` pair; expanded `SerializeVTXODescriptor`
  with OwnerKey, OperatorKey, ExitDelay, SigningKey fields
- `db/vtxo_store.go` — persist individual key columns + operator key locator
- `db/vtxo_record_store.go` — placeholder values for OOR path (TODO tracked)
- `db/sqlc/migrations/000003_vtxos.up.sql` — replace `cosigner_key` with
  `owner_key`, `operator_key`, `exit_delay`, `operator_key_family`,
  `operator_key_index`
- `rounds/forfeits.go` — forfeit signing reads keys from VTXO descriptor
- `rounds/validation.go` — forfeit validation reads keys from VTXO descriptor
- `rounds/fsm_transitions.go` — `collectVTXOs` stamps operator key descriptor
  on each VTXO at creation time
- `rounds/interfaces.go` — `VTXO` struct gets `OperatorKeyDesc` field

## Testing

```
go test ./db/... ./rounds/... ./batch/... ./batchwatcher/... ./indexer/...
```