### PR TITLE
oor: simplify outgoing client state

### DIFF
--- a/oor/actor.go
+++ b/oor/actor.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sort"
+	"time"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btclog/v2"
@@ -441,7 +442,7 @@ func (b *oorDurableBehavior) handleStartTransfer(ctx context.Context,
 		return fn.Err[ActorResp](err)
 	}
 
-	err = b.driveOutbox(ctx, session.ID, handle.FSM, outbox)
+	err = b.driveOutbox(ctx, session.ID, handle, outbox)
 	if err != nil {
 		return fn.Err[ActorResp](err)
 	}
@@ -517,6 +518,7 @@ func (b *oorDurableBehavior) handleDriveEvent(ctx context.Context,
 	if err != nil {
 		return fn.Err[ActorResp](err)
 	}
+	handle.clearRetryMetadata()
 
 	if finalizeState != nil {
 		err := b.persistOutgoingPackage(
@@ -534,7 +536,7 @@ func (b *oorDurableBehavior) handleDriveEvent(ctx context.Context,
 
 	b.notifyMaterializedVTXOs(ctx, req.Event)
 
-	err = b.driveOutbox(ctx, req.SessionID, handle.FSM, outbox)
+	err = b.driveOutbox(ctx, req.SessionID, handle, outbox)
 	if err != nil {
 		return fn.Err[ActorResp](err)
 	}
@@ -626,7 +628,7 @@ func (b *oorDurableBehavior) handleResolveIncomingTransfer(
 		return fn.Err[ActorResp](err)
 	}
 
-	err = b.driveOutbox(ctx, req.SessionID, handle.FSM, outbox)
+	err = b.driveOutbox(ctx, req.SessionID, handle, outbox)
 	if err != nil {
 		return fn.Err[ActorResp](err)
 	}
@@ -685,7 +687,7 @@ func (b *oorDurableBehavior) handleIncomingTransfer(ctx context.Context,
 		return err
 	}
 
-	return b.driveOutbox(ctx, session.ID, handle.FSM, outbox)
+	return b.driveOutbox(ctx, session.ID, handle, outbox)
 }
 
 // enrichSubmitAcceptedArkPSBT populates a SubmitAcceptedEvent's ArkPSBT field
@@ -815,8 +817,10 @@ func (b *oorDurableBehavior) handleRestoreSession(ctx context.Context,
 	}
 
 	b.sessions[session.ID] = &sessionHandle{
-		FSM:  session.FSM,
-		kind: sessionKindOutgoing,
+		FSM:         session.FSM,
+		kind:        sessionKindOutgoing,
+		RetryAfter:  req.Snapshot.RetryAfter,
+		RetryReason: req.Snapshot.FailReason,
 	}
 
 	err = b.persistCheckpoint(ctx)
@@ -863,8 +867,14 @@ func (b *oorDurableBehavior) handleResumeSession(ctx context.Context,
 	if err != nil {
 		return fn.Err[ActorResp](err)
 	}
+	handle.clearRetryMetadata()
 
-	err = b.driveOutbox(ctx, req.SessionID, handle.FSM, outbox)
+	err = b.persistCheckpoint(ctx)
+	if err != nil {
+		return fn.Err[ActorResp](err)
+	}
+
+	err = b.driveOutbox(ctx, req.SessionID, handle, outbox)
 	if err != nil {
 		return fn.Err[ActorResp](err)
 	}
@@ -902,6 +912,7 @@ func (b *oorDurableBehavior) handleExportSnapshot(ctx context.Context,
 	if err != nil {
 		return fn.Err[ActorResp](err)
 	}
+	handle.applyRetrySnapshot(snapshot)
 
 	return fn.Ok[ActorResp](&ExportSnapshotResponse{
 		Snapshot: snapshot,
@@ -976,8 +987,10 @@ func (b *oorDurableBehavior) restoreFromCheckpoint(ctx context.Context,
 		}
 
 		b.sessions[session.ID] = &sessionHandle{
-			FSM:  session.FSM,
-			kind: sessionKindOutgoing,
+			FSM:         session.FSM,
+			kind:        sessionKindOutgoing,
+			RetryAfter:  snapshot.RetryAfter,
+			RetryReason: snapshot.FailReason,
 		}
 
 		b.logger(ctx).DebugS(ctx, "Restored session from checkpoint",
@@ -1037,7 +1050,7 @@ func (b *oorDurableBehavior) resumeRestoredSessions(ctx context.Context) error {
 			return err
 		}
 
-		outbox, err := outboxForHandle(handle, state)
+		outbox, err := b.resumeOutboxForHandle(handle, state)
 		if err != nil {
 			return err
 		}
@@ -1047,7 +1060,7 @@ func (b *oorDurableBehavior) resumeRestoredSessions(ctx context.Context) error {
 			slog.String("state", fmt.Sprintf("%T", state)),
 			slog.Int("num_outbox", len(outbox)))
 
-		err = b.driveOutbox(ctx, sessionID, handle.FSM, outbox)
+		err = b.driveOutbox(ctx, sessionID, handle, outbox)
 		if err != nil {
 			return err
 		}
@@ -1180,9 +1193,14 @@ func (b *oorDurableBehavior) sendTransportEvent(ctx context.Context,
 // driveOutbox executes outbox work using the configured handler and feeds any
 // follow-up events back into the FSM.
 func (b *oorDurableBehavior) driveOutbox(ctx context.Context,
-	sessionID SessionID, fsm *StateMachine, outbox []OutboxEvent) error {
+	sessionID SessionID, handle *sessionHandle,
+	outbox []OutboxEvent) error {
 
 	handler := b.cfg.OutboxHandler
+
+	if handle == nil {
+		return fmt.Errorf("session handle must be provided")
+	}
 
 	for _, msg := range outbox {
 		// Transport events (submit, finalize, ack) are Tell'd to
@@ -1201,7 +1219,9 @@ func (b *oorDurableBehavior) driveOutbox(ctx context.Context,
 
 			if _, ok := msg.(*SendIncomingAckRequest); ok {
 				nextOutbox, err := b.askEvent(
-					ctx, fsm, &IncomingAckSentEvent{},
+					ctx,
+					handle.FSM,
+					&IncomingAckSentEvent{},
 				)
 				if err != nil {
 					return err
@@ -1213,7 +1233,7 @@ func (b *oorDurableBehavior) driveOutbox(ctx context.Context,
 				}
 
 				err = b.driveOutbox(
-					ctx, sessionID, fsm, nextOutbox,
+					ctx, sessionID, handle, nextOutbox,
 				)
 				if err != nil {
 					return err
@@ -1254,7 +1274,7 @@ func (b *oorDurableBehavior) driveOutbox(ctx context.Context,
 			b.notifyMaterializedVTXOs(ctx, followUp)
 
 			finalizeState, err := b.captureFinalizeStateForEvent(
-				fsm, followUp,
+				handle.FSM, followUp,
 			)
 			if err != nil {
 				return err
@@ -1263,10 +1283,11 @@ func (b *oorDurableBehavior) driveOutbox(ctx context.Context,
 			// Feed follow-up events into the FSM.
 			// Recursively execute any emitted outbox work.
 			// Stop when none remains.
-			nextOutbox, err := b.askEvent(ctx, fsm, followUp)
+			nextOutbox, err := b.askEvent(ctx, handle.FSM, followUp)
 			if err != nil {
 				return err
 			}
+			handle.applyRetryEvent(followUp)
 
 			if finalizeState != nil {
 				err = b.persistOutgoingPackage(ctx, sessionID,
@@ -1281,7 +1302,7 @@ func (b *oorDurableBehavior) driveOutbox(ctx context.Context,
 				return err
 			}
 
-			err = b.driveOutbox(ctx, sessionID, fsm, nextOutbox)
+			err = b.driveOutbox(ctx, sessionID, handle, nextOutbox)
 			if err != nil {
 				return err
 			}
@@ -1413,6 +1434,7 @@ func (b *oorDurableBehavior) persistCheckpoint(ctx context.Context) error {
 			if err != nil {
 				return err
 			}
+			handle.applyRetrySnapshot(snapshot)
 
 			outgoingSnapshots = append(
 				outgoingSnapshots, snapshot,
@@ -1463,6 +1485,9 @@ type sessionHandle struct {
 	FSM *StateMachine
 
 	kind sessionKind
+
+	RetryAfter  time.Duration
+	RetryReason string
 }
 
 type sessionKind uint8
@@ -1525,6 +1550,87 @@ func outboxForHandle(handle *sessionHandle,
 
 	default:
 		return nil, fmt.Errorf("unknown session kind: %d", handle.kind)
+	}
+}
+
+// applyRetryEvent updates retry metadata based on a follow-up event result.
+func (h *sessionHandle) applyRetryEvent(event Event) {
+	if h == nil {
+		return
+	}
+
+	retryEvent, ok := event.(*OutboxErrorEvent)
+	if !ok || !retryEvent.Retryable {
+		h.clearRetryMetadata()
+		return
+	}
+
+	after := retryEvent.RetryAfter
+	if after == 0 {
+		after = defaultRetryDelay
+	}
+
+	h.RetryAfter = after
+	h.RetryReason = retryEvent.ErrorReason
+}
+
+// clearRetryMetadata removes any pending retry scheduling metadata.
+func (h *sessionHandle) clearRetryMetadata() {
+	if h == nil {
+		return
+	}
+
+	h.RetryAfter = 0
+	h.RetryReason = ""
+}
+
+// applyRetrySnapshot copies retry metadata onto an exported snapshot.
+func (h *sessionHandle) applyRetrySnapshot(snapshot *OutgoingSnapshot) {
+	if h == nil || snapshot == nil || h.RetryAfter == 0 {
+		return
+	}
+
+	snapshot.RetryAfter = h.RetryAfter
+	snapshot.FailReason = h.RetryReason
+}
+
+// resumeOutboxForHandle returns either retry scheduling or the state's
+// natural outbox, depending on whether retry metadata is pending.
+func (b *oorDurableBehavior) resumeOutboxForHandle(
+	handle *sessionHandle, state SessionState,
+) ([]OutboxEvent, error) {
+
+	if handle == nil {
+		return nil, fmt.Errorf("session handle must be provided")
+	}
+
+	switch handle.kind {
+	case sessionKindOutgoing:
+		outgoingState, ok := state.(State)
+		if !ok {
+			return nil, fmt.Errorf(
+				"unexpected outgoing state type: %T",
+				state,
+			)
+		}
+
+		if handle.RetryAfter > 0 {
+			return []OutboxEvent{
+				&ScheduleRetryRequest{
+					After:  handle.RetryAfter,
+					Reason: handle.RetryReason,
+				},
+			}, nil
+		}
+
+		return OutboxForState(outgoingState)
+
+	case sessionKindIncoming:
+		return OutboxForIncomingState(state)
+
+	default:
+		return nil, fmt.Errorf("unknown session kind: %d",
+			handle.kind)
 	}
 }
 

--- a/oor/actor.go
+++ b/oor/actor.go
@@ -729,7 +729,7 @@ func (b *oorDurableBehavior) persistOutgoingPackage(ctx context.Context,
 
 	b.logger(ctx).DebugS(ctx, "Persisting outgoing package",
 		slog.String("session_id", sessionID.String()),
-		slog.Int("num_inputs", len(state.InputOutpoints)),
+		slog.Int("num_inputs", len(state.TransferInputs)),
 		slog.Int("num_checkpoints", len(state.FinalCheckpointPSBTs)))
 
 	err := b.cfg.PackageStore.UpsertPackage(ctx,
@@ -740,9 +740,10 @@ func (b *oorDurableBehavior) persistOutgoingPackage(ctx context.Context,
 		return err
 	}
 
-	for i := range state.InputOutpoints {
+	outpoints := InputOutpoints(state.TransferInputs)
+	for i := range outpoints {
 		err := b.cfg.PackageStore.UpsertBinding(ctx,
-			state.InputOutpoints[i], sessionHash, uint32(i),
+			outpoints[i], sessionHash, uint32(i),
 			PackageLinkKindConsumedInput,
 		)
 		if err != nil {

--- a/oor/actor_drive_event_integration_test.go
+++ b/oor/actor_drive_event_integration_test.go
@@ -19,16 +19,15 @@ import (
 )
 
 const (
-	retryDueTestRetryAfter        = 2 * time.Second
-	retryDueTestEventuallyTimeout = retryDueTestRetryAfter + 2*time.Second
-	retryDueTestEventuallyPoll    = 20 * time.Millisecond
+	resumeTestEventuallyTimeout = 4 * time.Second
+	resumeTestEventuallyPoll    = 20 * time.Millisecond
 )
 
-type retryDueIntegrationHandler struct {
+type resumeIntegrationHandler struct {
 	sawFinalize atomic.Bool
 }
 
-func (h *retryDueIntegrationHandler) Handle(_ context.Context,
+func (h *resumeIntegrationHandler) Handle(_ context.Context,
 	_ SessionID, outbox OutboxEvent) ([]Event, error) {
 
 	switch outbox.(type) {
@@ -41,7 +40,7 @@ func (h *retryDueIntegrationHandler) Handle(_ context.Context,
 	}
 }
 
-var _ OutboxHandler = (*retryDueIntegrationHandler)(nil)
+var _ OutboxHandler = (*resumeIntegrationHandler)(nil)
 
 type mockVTXOManagerRef struct {
 	mu       sync.Mutex
@@ -161,9 +160,10 @@ func testRetryTransferInputs(t *testing.T) []TransferInput {
 		),
 	}
 }
-// TestOORClientActorDriveRetryDueEventDurablePath verifies the retry-due signal
-// can cross the durable actor boundary and re-drive the resumed outbox work.
-func TestOORClientActorDriveRetryDueEventDurablePath(t *testing.T) {
+
+// TestOORClientActorResumeSessionDurablePath verifies ResumeSessionRequest can
+// cross the durable actor boundary and re-drive the resumed outbox work.
+func TestOORClientActorResumeSessionDurablePath(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
@@ -172,7 +172,7 @@ func TestOORClientActorDriveRetryDueEventDurablePath(t *testing.T) {
 	sessionID, err := sessionIDFromArk(ark)
 	require.NoError(t, err)
 
-	resumeSnapshot, err := NewOutgoingSnapshot(
+	snapshot, err := NewOutgoingSnapshot(
 		sessionID,
 		&AwaitingFinalizeAccepted{
 			SessionID:            sessionID,
@@ -183,38 +183,28 @@ func TestOORClientActorDriveRetryDueEventDurablePath(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	retrySnapshot := &OutgoingSnapshot{
-		Version:        2,
-		SessionID:      sessionID,
-		Phase:          OutgoingPhaseRetryBackoff,
-		RetryAfter:     retryDueTestRetryAfter,
-		ResumeSnapshot: resumeSnapshot,
-		FailReason:     "retry later",
-	}
-
-	handler := &retryDueIntegrationHandler{}
+	handler := &resumeIntegrationHandler{}
 	actor := NewOORClientActor(ClientActorCfg{
 		OutboxHandler: handler,
 		DeliveryStore: newTestDeliveryStore(t),
-		ActorID:       "oor-drive-retry-due-durable-path",
+		ActorID:       "oor-resume-session-durable-path",
 	})
 	defer actor.Stop()
 
 	restoreResp := actor.Receive(ctx, &RestoreSessionRequest{
-		Snapshot: retrySnapshot,
+		Snapshot: snapshot,
 	})
 	require.True(t, restoreResp.IsOk())
 
-	driveResp := actor.Receive(ctx, &DriveEventRequest{
+	resumeResp := actor.Receive(ctx, &ResumeSessionRequest{
 		SessionID: sessionID,
-		Event:     &RetryDueEvent{},
 	})
-	require.True(t, driveResp.IsOk())
+	require.True(t, resumeResp.IsOk())
 
 	require.Eventually(
 		t, func() bool {
 			return handler.sawFinalize.Load()
-		}, retryDueTestEventuallyTimeout, retryDueTestEventuallyPoll,
+		}, resumeTestEventuallyTimeout, resumeTestEventuallyPoll,
 	)
 
 	stateResp := actor.Receive(ctx, &GetStateRequest{
@@ -377,78 +367,6 @@ func TestOORDurableBehaviorDriveIncomingHandledReloadsFromStore(
 	require.True(t, ok)
 	require.Len(t, notification.VTXOs, 1)
 	require.Equal(t, desc.Outpoint, notification.VTXOs[0].Outpoint)
-}
-
-// TestOutboxForStateRetryBackoff asserts retry-backoff state emits a
-// schedule-retry request with the expected delay and reason.
-func TestOutboxForStateRetryBackoff(t *testing.T) {
-	t.Parallel()
-
-	outbox, err := OutboxForState(&RetryBackoff{
-		RetryAfter: 3 * time.Second,
-		Reason:     "transport timeout",
-	})
-	require.NoError(t, err)
-	require.Len(t, outbox, 1)
-
-	scheduleMsg, ok := outbox[0].(*ScheduleRetryRequest)
-	require.True(t, ok)
-	require.Equal(t, 3*time.Second, scheduleMsg.After)
-	require.Equal(t, "transport timeout", scheduleMsg.Reason)
-}
-
-// TestRetryBackoffProcessEventRetryDue asserts RetryDueEvent resumes from the
-// stored snapshot and emits finalize outbox work.
-func TestRetryBackoffProcessEventRetryDue(t *testing.T) {
-	t.Parallel()
-
-	ark, checkpoints := testOutboxPSBTPair(t)
-	sessionID, err := sessionIDFromArk(ark)
-	require.NoError(t, err)
-
-	resumeSnapshot, err := NewOutgoingSnapshot(
-		sessionID,
-		&AwaitingFinalizeAccepted{
-			SessionID:            sessionID,
-			ArkPSBT:              ark,
-			FinalCheckpointPSBTs: checkpoints,
-			TransferInputs:       testRetryTransferInputs(t),
-		},
-	)
-	require.NoError(t, err)
-
-	retryState := &RetryBackoff{
-		ResumeSnapshot: resumeSnapshot,
-		RetryAfter:     2 * time.Second,
-		Reason:         "rpc timeout",
-	}
-
-	transition, err := retryState.ProcessEvent(
-		t.Context(), &RetryDueEvent{}, nil,
-	)
-	require.NoError(t, err)
-	require.IsType(t, &AwaitingFinalizeAccepted{}, transition.NextState)
-	require.True(t, transition.NewEvents.IsSome())
-
-	emitted := transition.NewEvents.UnsafeFromSome()
-	require.Len(t, emitted.Outbox, 1)
-	require.IsType(t, &SendFinalizePackageRequest{}, emitted.Outbox[0])
-}
-
-// TestRetryBackoffProcessEventRetryDueRequiresSnapshot asserts retry-due
-// processing fails when no resume snapshot is present.
-func TestRetryBackoffProcessEventRetryDueRequiresSnapshot(t *testing.T) {
-	t.Parallel()
-
-	retryState := &RetryBackoff{
-		RetryAfter: 1 * time.Second,
-	}
-
-	transition, err := retryState.ProcessEvent(
-		t.Context(), &RetryDueEvent{}, nil,
-	)
-	require.Nil(t, transition)
-	require.ErrorContains(t, err, "resume snapshot must be provided")
 }
 
 // TestOORDurableBehaviorHandleResolveIncomingTransferAsync verifies the actor

--- a/oor/actor_drive_event_integration_test.go
+++ b/oor/actor_drive_event_integration_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/arkrpc"
 	"github.com/lightninglabs/darepo-client/lib/tx/psbtutil"
@@ -137,6 +139,28 @@ func buildIncomingResolveResponse(t *testing.T) (
 	}, sessionID, recipient.PkScript, 7
 }
 
+func testRetryTransferInputs(t *testing.T) []TransferInput {
+	t.Helper()
+
+	clientKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	return []TransferInput{
+		newTestTransferInput(
+			t,
+			clientKey,
+			operatorKey.PubKey(),
+			wire.OutPoint{
+				Hash:  [32]byte{0x01},
+				Index: 0,
+			},
+			btcutil.Amount(10_000),
+		),
+	}
+}
 // TestOORClientActorDriveRetryDueEventDurablePath verifies the retry-due signal
 // can cross the durable actor boundary and re-drive the resumed outbox work.
 func TestOORClientActorDriveRetryDueEventDurablePath(t *testing.T) {
@@ -152,9 +176,9 @@ func TestOORClientActorDriveRetryDueEventDurablePath(t *testing.T) {
 		sessionID,
 		&AwaitingFinalizeAccepted{
 			SessionID:            sessionID,
-			InputOutpoints:       []wire.OutPoint{{}},
 			ArkPSBT:              ark,
 			FinalCheckpointPSBTs: checkpoints,
+			TransferInputs:       testRetryTransferInputs(t),
 		},
 	)
 	require.NoError(t, err)
@@ -386,9 +410,9 @@ func TestRetryBackoffProcessEventRetryDue(t *testing.T) {
 		sessionID,
 		&AwaitingFinalizeAccepted{
 			SessionID:            sessionID,
-			InputOutpoints:       []wire.OutPoint{{}},
 			ArkPSBT:              ark,
 			FinalCheckpointPSBTs: checkpoints,
+			TransferInputs:       testRetryTransferInputs(t),
 		},
 	)
 	require.NoError(t, err)

--- a/oor/actor_durable_message.go
+++ b/oor/actor_durable_message.go
@@ -57,7 +57,6 @@ const (
 	eventKindFinalizeAccepted  uint64 = 3
 	eventKindInputsMarkedSpent uint64 = 4
 	eventKindFail              uint64 = 5
-	eventKindRetryDue          uint64 = 6
 	eventKindIncomingTransfer  uint64 = 7
 	eventKindIncomingHandled   uint64 = 8
 	eventKindIncomingAckSent   uint64 = 9
@@ -1021,9 +1020,6 @@ func encodeEventPayload(event Event) ([]byte, error) {
 		eventKind = eventKindFail
 		reason = []byte(evt.Reason)
 
-	case *RetryDueEvent:
-		eventKind = eventKindRetryDue
-
 	case *IncomingTransferEvent:
 		eventKind = eventKindIncomingTransfer
 
@@ -1226,9 +1222,6 @@ func decodeEventPayload(raw []byte) (Event, error) {
 
 	case eventKindFail:
 		return &FailEvent{Reason: string(reason)}, nil
-
-	case eventKindRetryDue:
-		return &RetryDueEvent{}, nil
 
 	case eventKindIncomingTransfer:
 		if len(arkPSBT) == 0 {

--- a/oor/actor_durable_message_test.go
+++ b/oor/actor_durable_message_test.go
@@ -145,27 +145,6 @@ func TestDriveEventRequestRoundTripSubmitAcceptedEvent(t *testing.T) {
 	require.Equal(t, chainhash.Hash(sessionID), decodedTxID)
 }
 
-// TestDriveEventRequestRoundTripRetryDueEvent asserts DriveEventRequest TLV
-// Encode/Decode round-trips RetryDueEvent correctly.
-func TestDriveEventRequestRoundTripRetryDueEvent(t *testing.T) {
-	t.Parallel()
-
-	sessionID := SessionID(chainhash.Hash{3, 3, 3})
-	msg := &DriveEventRequest{
-		SessionID: sessionID,
-		Event:     &RetryDueEvent{},
-	}
-
-	var buf bytes.Buffer
-	require.NoError(t, msg.Encode(&buf))
-
-	decoded := &DriveEventRequest{}
-	require.NoError(t, decoded.Decode(&buf))
-
-	require.Equal(t, sessionID, decoded.SessionID)
-	require.IsType(t, &RetryDueEvent{}, decoded.Event)
-}
-
 // TestDriveEventRequestRoundTripIncomingTransferEvent asserts
 // DriveEventRequest TLV Encode/Decode round-trips IncomingTransferEvent
 // correctly.

--- a/oor/actor_resume_test.go
+++ b/oor/actor_resume_test.go
@@ -2,6 +2,7 @@ package oor
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1004,6 +1005,235 @@ func TestOORClientActorResumeFromSnapshotCoSigned(t *testing.T) {
 // TestOORClientActorDurableRestartAutoResume verifies the durable actor can
 // restore checkpointed sessions and auto-resume pending outbox work after a
 // process restart, without using ExportSnapshot/RestoreSession requests.
+// TestOORClientActorDurableRestartWithRetryMetadata verifies that when a
+// session has pending retry metadata at checkpoint time, a restart schedules a
+// retry timer instead of immediately re-driving the outbox.
+func TestOORClientActorDurableRestartWithRetryMetadata(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	policy := scripts.CheckpointPolicy{
+		OperatorKey: operatorKey.PubKey(),
+		CSVDelay:    10,
+	}
+
+	inputValue := btcutil.Amount(10000)
+
+	clientKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	clientSigner := input.NewMockSigner(
+		[]*btcec.PrivateKey{clientKey}, nil,
+	)
+	operatorSigner := input.NewMockSigner(
+		[]*btcec.PrivateKey{operatorKey}, nil,
+	)
+
+	inputs := []TransferInput{
+		newTestTransferInput(
+			t, clientKey, policy.OperatorKey,
+			wire.OutPoint{
+				Hash:  [32]byte{0x03},
+				Index: 0,
+			},
+			inputValue,
+		),
+	}
+
+	recipients := []oortx.RecipientOutput{
+		{
+			PkScript: newTestTaprootPkScript(
+				t, clientKey.PubKey(),
+			),
+			Value: inputValue,
+		},
+	}
+
+	deliveryStore := newTestDeliveryStore(t)
+
+	const actorID = "oor-restart-retry-metadata"
+
+	// retrySubmitOnceHandler fails the first submit with a retryable
+	// error, then handles ScheduleRetryRequest as a no-op (no timeout
+	// actor). On the second actor instance, it succeeds.
+	handler1 := &retrySubmitOutboxHandler{
+		t:              t,
+		clientSigner:   clientSigner,
+		operatorSigner: operatorSigner,
+	}
+
+	actor1 := NewOORClientActor(ClientActorCfg{
+		OutboxHandler: handler1,
+		DeliveryStore: deliveryStore,
+		ActorID:       actorID,
+	})
+
+	startResp := actor1.Receive(ctx, &StartTransferRequest{
+		Policy:     policy,
+		Inputs:     inputs,
+		Recipients: recipients,
+	})
+	require.True(t, startResp.IsOk())
+
+	startMsg, ok := startResp.UnwrapOr(nil).(*StartTransferResponse)
+	require.True(t, ok)
+
+	// After the retryable error, the session should remain in
+	// AwaitingSubmitAccepted (not RetryBackoff, which no longer
+	// exists).
+	stateResp := actor1.Receive(ctx, &GetStateRequest{
+		SessionID: startMsg.SessionID,
+	})
+	require.True(t, stateResp.IsOk())
+
+	stateMsg, ok := stateResp.UnwrapOr(nil).(*GetStateResponse)
+	require.True(t, ok)
+	require.IsType(t, &AwaitingSubmitAccepted{}, stateMsg.State)
+
+	// Verify retry metadata was persisted to the snapshot by exporting
+	// it.
+	exportResp := actor1.Receive(ctx, &ExportSnapshotRequest{
+		SessionID: startMsg.SessionID,
+	})
+	require.True(t, exportResp.IsOk())
+
+	exportMsg, ok := exportResp.UnwrapOr(nil).(*ExportSnapshotResponse)
+	require.True(t, ok)
+	require.NotZero(t, exportMsg.Snapshot.RetryAfter,
+		"retry metadata should be set on snapshot")
+	require.NotEmpty(t, exportMsg.Snapshot.FailReason,
+		"retry reason should be set on snapshot")
+
+	// Stop actor1 — simulates a crash.
+	actor1.Stop()
+
+	// recordingHandler tracks which outbox events it receives so we can
+	// verify that the restarted actor schedules a retry rather than
+	// immediately re-driving the submit outbox.
+	handler2 := &retryRecordingHandler{
+		t:              t,
+		clientSigner:   clientSigner,
+		operatorSigner: operatorSigner,
+	}
+
+	actor2 := NewOORClientActor(ClientActorCfg{
+		OutboxHandler: handler2,
+		DeliveryStore: deliveryStore,
+		ActorID:       actorID,
+	})
+	defer actor2.Stop()
+
+	// Wait for the restart to process the checkpoint.
+	require.Eventually(t, func() bool {
+		resp := actor2.Receive(ctx, &GetStateRequest{
+			SessionID: startMsg.SessionID,
+		})
+
+		return resp.IsOk()
+	}, 5*time.Second, 50*time.Millisecond)
+
+	// The restarted actor should have emitted ScheduleRetryRequest
+	// (not SendSubmitPackageRequest) because the checkpoint had
+	// RetryAfter > 0.
+	require.True(t, handler2.sawScheduleRetry.Load(),
+		"restart should schedule retry, not drive outbox")
+
+	// Now explicitly resume so the transfer can complete.
+	resumeResp := actor2.Receive(ctx, &ResumeSessionRequest{
+		SessionID: startMsg.SessionID,
+	})
+	require.True(t, resumeResp.IsOk())
+
+	stateResp = actor2.Receive(ctx, &GetStateRequest{
+		SessionID: startMsg.SessionID,
+	})
+	require.True(t, stateResp.IsOk())
+
+	stateMsg, ok = stateResp.UnwrapOr(nil).(*GetStateResponse)
+	require.True(t, ok)
+	require.IsType(t, &Completed{}, stateMsg.State)
+}
+
+// retryRecordingHandler records whether it received a ScheduleRetryRequest
+// and succeeds on all operations. Used to verify restart behavior.
+type retryRecordingHandler struct {
+	t *testing.T
+
+	clientSigner   input.Signer
+	operatorSigner input.Signer
+
+	sawScheduleRetry atomic.Bool
+}
+
+// Handle processes the outbox request and returns follow-up events.
+func (h *retryRecordingHandler) Handle(_ context.Context,
+	sessionID SessionID, outbox OutboxEvent) ([]Event, error) {
+
+	h.t.Helper()
+
+	switch msg := outbox.(type) {
+	case *RequestArkSignatures:
+		err := SignArkPSBT(
+			h.clientSigner, msg.ArkPSBT,
+			msg.CheckpointPSBTs, msg.TransferInputs,
+		)
+		require.NoError(h.t, err)
+
+		return []Event{
+			&ArkSignedEvent{ArkPSBT: msg.ArkPSBT},
+		}, nil
+
+	case *SendSubmitPackageRequest:
+		err := coSignCheckpointPSBTsForTest(
+			h.operatorSigner,
+			msg.TransferInputs,
+			msg.CheckpointPSBTs,
+		)
+		require.NoError(h.t, err)
+
+		return []Event{
+			&SubmitAcceptedEvent{
+				SessionID:               sessionID,
+				ArkPSBT:                 msg.ArkPSBT,
+				CoSignedCheckpointPSBTs: msg.CheckpointPSBTs,
+			},
+		}, nil
+
+	case *RequestCheckpointSignatures:
+		err := SignCheckpointPSBTs(
+			h.clientSigner, msg.TransferInputs,
+			msg.CoSignedCheckpointPSBTs,
+		)
+		require.NoError(h.t, err)
+
+		return []Event{
+			&CheckpointsSignedEvent{
+				FinalCheckpointPSBTs: msg.
+					CoSignedCheckpointPSBTs,
+			},
+		}, nil
+
+	case *SendFinalizePackageRequest:
+		return []Event{&FinalizeAcceptedEvent{}}, nil
+
+	case *MarkInputsSpentRequest:
+		return []Event{&InputsMarkedSpentEvent{}}, nil
+
+	case *ScheduleRetryRequest:
+		h.sawScheduleRetry.Store(true)
+		return nil, nil
+
+	default:
+		return nil, nil
+	}
+}
+
+var _ OutboxHandler = (*retryRecordingHandler)(nil)
+
 func TestOORClientActorDurableRestartAutoResume(t *testing.T) {
 	t.Parallel()
 

--- a/oor/actor_test.go
+++ b/oor/actor_test.go
@@ -402,10 +402,7 @@ func (h *retrySubmitOutboxHandler) Handle(
 	case *ScheduleRetryRequest:
 		_ = msg
 
-		// For unit tests, trigger the retry immediately.
-		return []Event{
-			&RetryDueEvent{},
-		}, nil
+		return nil, nil
 
 	case *RequestCheckpointSignatures:
 		err := SignCheckpointPSBTs(
@@ -442,9 +439,9 @@ func (h *retrySubmitOutboxHandler) Handle(
 
 var _ OutboxHandler = (*retrySubmitOutboxHandler)(nil)
 
-// TestOORClientActorRetryBackoff asserts the client actor can handle a
-// retryable error emitted by the outbox handler and complete after retry.
-func TestOORClientActorRetryBackoff(t *testing.T) {
+// TestOORClientActorRetryResume asserts the client actor can handle a
+// retryable error, persist retry intent, and complete after explicit resume.
+func TestOORClientActorRetryResume(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
@@ -512,6 +509,20 @@ func TestOORClientActorRetryBackoff(t *testing.T) {
 	require.True(t, stateResp.IsOk())
 
 	stateMsg, ok := stateResp.UnwrapOr(nil).(*GetStateResponse)
+	require.True(t, ok)
+	require.IsType(t, &AwaitingSubmitAccepted{}, stateMsg.State)
+
+	resumeResp := actor.Receive(ctx, &ResumeSessionRequest{
+		SessionID: startMsg.SessionID,
+	})
+	require.True(t, resumeResp.IsOk())
+
+	stateResp = actor.Receive(ctx, &GetStateRequest{
+		SessionID: startMsg.SessionID,
+	})
+	require.True(t, stateResp.IsOk())
+
+	stateMsg, ok = stateResp.UnwrapOr(nil).(*GetStateResponse)
 	require.True(t, ok)
 	require.IsType(t, &Completed{}, stateMsg.State)
 }

--- a/oor/events.go
+++ b/oor/events.go
@@ -99,13 +99,6 @@ type InputsMarkedSpentEvent struct{}
 // eventSealed marks this as implementing the sealed Event interface.
 func (e *InputsMarkedSpentEvent) eventSealed() {}
 
-// RetryDueEvent indicates that a previously requested retry backoff timer has
-// elapsed and the session can resume from the stored retry snapshot.
-type RetryDueEvent struct{}
-
-// eventSealed marks this as implementing the sealed Event interface.
-func (e *RetryDueEvent) eventSealed() {}
-
 // FailEvent forces the session to enter a terminal failure state.
 type FailEvent struct {
 	Reason string

--- a/oor/outbox_error_test.go
+++ b/oor/outbox_error_test.go
@@ -63,29 +63,14 @@ func TestHandleOutboxError(t *testing.T) {
 		TransferInputs:  inputs,
 	}
 
-	sessionID, err := sessionIDFromArk(ark)
-	require.NoError(t, err)
-
-	env := &Environment{SessionID: sessionID}
-
 	// Nil event rejected: this is a programmer error and should not be
 	// treated as retryable.
-	_, err = handleOutboxError(env, current, nil)
-	require.Error(t, err)
-
-	// Retryable error requires a valid environment session id. The session
-	// id is used to reconstruct a safe resume snapshot.
-	_, err = handleOutboxError(nil, current, &OutboxErrorEvent{
-		OutboxType:  "x",
-		Retryable:   true,
-		RetryAfter:  0,
-		ErrorReason: "boom",
-	})
+	_, err = handleOutboxError(nil, current, nil)
 	require.Error(t, err)
 
 	// Non-retryable error causes terminal failure. The state machine does
 	// not attempt to guess whether retry is safe.
-	transition, err := handleOutboxError(env, current, &OutboxErrorEvent{
+	transition, err := handleOutboxError(nil, current, &OutboxErrorEvent{
 		OutboxType:  "x",
 		Retryable:   false,
 		ErrorReason: "boom",
@@ -94,20 +79,17 @@ func TestHandleOutboxError(t *testing.T) {
 	require.IsType(t, &Failed{}, transition.NextState)
 	require.True(t, transition.NewEvents.IsNone())
 
-	// Retryable error schedules a retry and snapshots the resume state so
-	// the caller can survive a crash while waiting for the backoff timer.
-	transition, err = handleOutboxError(env, current, &OutboxErrorEvent{
+	// Retryable error keeps the FSM in the current state and emits retry
+	// scheduling. The actor persists retry metadata alongside the real
+	// protocol state.
+	transition, err = handleOutboxError(nil, current, &OutboxErrorEvent{
 		OutboxType:  "x",
 		Retryable:   true,
 		RetryAfter:  0,
 		ErrorReason: "boom",
 	})
 	require.NoError(t, err)
-
-	backoff, ok := transition.NextState.(*RetryBackoff)
-	require.True(t, ok)
-	require.NotNil(t, backoff.ResumeSnapshot)
-	require.Equal(t, 1*time.Second, backoff.RetryAfter)
+	require.Same(t, current, transition.NextState)
 
 	require.True(t, transition.NewEvents.IsSome())
 	emitted := transition.NewEvents.UnwrapOr(EmittedEvent{})
@@ -120,7 +102,8 @@ func TestHandleOutboxError(t *testing.T) {
 }
 
 // TestAwaitingFinalizeAcceptedOutboxError verifies that retryable outbox
-// failures in the finalize-ack wait state transition into RetryBackoff.
+// failures in the finalize-ack wait state stay in the current state while
+// scheduling retry.
 func TestAwaitingFinalizeAcceptedOutboxError(t *testing.T) {
 	t.Parallel()
 
@@ -157,25 +140,21 @@ func TestAwaitingFinalizeAcceptedOutboxError(t *testing.T) {
 	ark, checkpoints, err := buildSubmitPackage(policy, inputs, recipients)
 	require.NoError(t, err)
 
-	sessionID, err := sessionIDFromArk(ark)
-	require.NoError(t, err)
-
 	state := &AwaitingFinalizeAccepted{
-		SessionID:            sessionID,
+		SessionID:            SessionID(ark.UnsignedTx.TxHash()),
 		ArkPSBT:              ark,
 		FinalCheckpointPSBTs: checkpoints,
 		TransferInputs:       inputs,
 	}
 
-	env := &Environment{SessionID: sessionID}
 	transition, err := state.ProcessEvent(t.Context(), &OutboxErrorEvent{
 		OutboxType:  (&SendFinalizePackageRequest{}).outboxType(),
 		Retryable:   true,
 		RetryAfter:  0,
 		ErrorReason: "finalize transport unavailable",
-	}, env)
+	}, nil)
 	require.NoError(t, err)
-	require.IsType(t, &RetryBackoff{}, transition.NextState)
+	require.Same(t, state, transition.NextState)
 
 	emitted := transition.NewEvents.UnwrapOr(EmittedEvent{})
 	require.Len(t, emitted.Outbox, 1)

--- a/oor/outbox_error_test.go
+++ b/oor/outbox_error_test.go
@@ -58,7 +58,6 @@ func TestHandleOutboxError(t *testing.T) {
 	require.NotEmpty(t, checkpoints)
 
 	current := &AwaitingSubmitAccepted{
-		InputOutpoints:  []wire.OutPoint{inputs[0].VTXO.Outpoint},
 		ArkPSBT:         ark,
 		CheckpointPSBTs: checkpoints,
 		TransferInputs:  inputs,
@@ -164,8 +163,8 @@ func TestAwaitingFinalizeAcceptedOutboxError(t *testing.T) {
 	state := &AwaitingFinalizeAccepted{
 		SessionID:            sessionID,
 		ArkPSBT:              ark,
-		InputOutpoints:       []wire.OutPoint{inputs[0].VTXO.Outpoint},
 		FinalCheckpointPSBTs: checkpoints,
+		TransferInputs:       inputs,
 	}
 
 	env := &Environment{SessionID: sessionID}

--- a/oor/outbox_messages.go
+++ b/oor/outbox_messages.go
@@ -397,7 +397,7 @@ func (m *SendIncomingAckRequest) ToProto() fn.Result[proto.Message] {
 	)
 }
 
-// ScheduleRetryRequest asks the runtime to deliver a RetryDueEvent after the
+// ScheduleRetryRequest asks the runtime to resume the session after the
 // requested delay.
 type ScheduleRetryRequest struct {
 	actor.BaseMessage

--- a/oor/outgoing_snapshot.go
+++ b/oor/outgoing_snapshot.go
@@ -38,10 +38,6 @@ const (
 	// and the client is updating its local VTXO persistence state.
 	OutgoingPhaseLocalVTXOUpdate OutgoingPhase = "local_vtxo_update"
 
-	// OutgoingPhaseRetryBackoff indicates the client is waiting to retry a
-	// previously failed outbox request.
-	OutgoingPhaseRetryBackoff OutgoingPhase = "retry_backoff"
-
 	// OutgoingPhaseCompleted indicates the transfer is fully complete.
 	OutgoingPhaseCompleted OutgoingPhase = "completed"
 
@@ -86,14 +82,11 @@ type OutgoingSnapshot struct {
 	// TransferInputs.
 	TransferInputSnapshots []*TransferInputSnapshot
 
-	// RetryAfter is the requested delay in retry backoff phases.
+	// RetryAfter is the requested delay for a pending retry, if any.
 	RetryAfter time.Duration
 
-	// ResumeSnapshot is the snapshot to restore after retry backoff.
-	ResumeSnapshot *OutgoingSnapshot
-
-	// FailReason is the terminal failure reason, when Phase is
-	// Failed.
+	// FailReason is the terminal failure reason when Phase is Failed. When
+	// RetryAfter is non-zero, it carries the pending retry reason.
 	FailReason string
 }
 
@@ -227,17 +220,6 @@ func NewOutgoingSnapshot(sessionID SessionID, state State) (*OutgoingSnapshot,
 	case *Failed:
 		// Failed is terminal. Retrying is not attempted automatically.
 		snap.Phase = OutgoingPhaseFailed
-		snap.FailReason = s.Reason
-
-	case *RetryBackoff:
-		// RetryBackoff wraps another snapshot to support restart-safe
-		// retry.
-		// The intent is:
-		// 1) store the original "resume snapshot" that is safe to retry
-		// 2) store the requested delay and reason for UI/telemetry
-		snap.Phase = OutgoingPhaseRetryBackoff
-		snap.ResumeSnapshot = s.ResumeSnapshot
-		snap.RetryAfter = s.RetryAfter
 		snap.FailReason = s.Reason
 	default:
 		return nil, fmt.Errorf("unsupported outgoing state type: %T",
@@ -398,22 +380,6 @@ func OutgoingStateFromSnapshot(snapshot *OutgoingSnapshot) (State, error) {
 		return &AwaitingLocalVTXOUpdate{
 			SessionID:      snapshot.SessionID,
 			TransferInputs: inputs,
-		}, nil
-
-	case OutgoingPhaseRetryBackoff:
-		if snapshot.ResumeSnapshot == nil {
-			return nil, fmt.Errorf("resume snapshot required")
-		}
-
-		after := snapshot.RetryAfter
-		if after == 0 {
-			after = 1 * time.Second
-		}
-
-		return &RetryBackoff{
-			ResumeSnapshot: snapshot.ResumeSnapshot,
-			RetryAfter:     after,
-			Reason:         snapshot.FailReason,
 		}, nil
 
 	case OutgoingPhaseCompleted:

--- a/oor/outgoing_snapshot.go
+++ b/oor/outgoing_snapshot.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil/psbt"
-	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/baselib/protofsm"
 	"github.com/lightninglabs/darepo-client/lib/tx/psbtutil"
 )
@@ -87,12 +86,6 @@ type OutgoingSnapshot struct {
 	// TransferInputs.
 	TransferInputSnapshots []*TransferInputSnapshot
 
-	// InputOutpoints are the VTXO outpoints consumed by this session.
-	//
-	// This is required to support crash-resilient local persistence
-	// after the server accepts finalize.
-	InputOutpoints []wire.OutPoint
-
 	// RetryAfter is the requested delay in retry backoff phases.
 	RetryAfter time.Duration
 
@@ -144,7 +137,6 @@ func NewOutgoingSnapshot(sessionID SessionID, state State) (*OutgoingSnapshot,
 			return nil, err
 		}
 		snap.TransferInputSnapshots = inputSnaps
-		snap.InputOutpoints = s.InputOutpoints
 
 	case *AwaitingSubmitAccepted:
 		// Snapshot the entire submit package because it is the
@@ -171,7 +163,6 @@ func NewOutgoingSnapshot(sessionID SessionID, state State) (*OutgoingSnapshot,
 		if err != nil {
 			return nil, err
 		}
-		snap.InputOutpoints = s.InputOutpoints
 
 	case *AwaitingCheckpointSignatures:
 		// This is the "point-of-no-return" state from the client's
@@ -196,7 +187,6 @@ func NewOutgoingSnapshot(sessionID SessionID, state State) (*OutgoingSnapshot,
 		if err != nil {
 			return nil, err
 		}
-		snap.InputOutpoints = s.InputOutpoints
 
 	case *AwaitingFinalizeAccepted:
 		// Once finalize is sent, the client should only need the
@@ -214,14 +204,20 @@ func NewOutgoingSnapshot(sessionID SessionID, state State) (*OutgoingSnapshot,
 			return nil, err
 		}
 		snap.CheckpointPSBTs = cps
-		snap.InputOutpoints = s.InputOutpoints
+		err = assignTransferInputSnapshots(snap, s.TransferInputs)
+		if err != nil {
+			return nil, err
+		}
 
 	case *AwaitingLocalVTXOUpdate:
 		// This phase is an off-chain bookkeeping step: after the server
 		// accepts finalize, the local wallet must update local state.
 		// That update reflects that the inputs are spent.
 		snap.Phase = OutgoingPhaseLocalVTXOUpdate
-		snap.InputOutpoints = s.InputOutpoints
+		err := assignTransferInputSnapshots(snap, s.TransferInputs)
+		if err != nil {
+			return nil, err
+		}
 
 	case *Completed:
 		// Completed is a terminal state. There is no outbox implied by
@@ -314,7 +310,6 @@ func OutgoingStateFromSnapshot(snapshot *OutgoingSnapshot) (State, error) {
 		}
 
 		return &AwaitingArkSignatures{
-			InputOutpoints:  snapshot.InputOutpoints,
 			ArkPSBT:         ark,
 			CheckpointPSBTs: cps,
 			TransferInputs:  inputs,
@@ -339,7 +334,6 @@ func OutgoingStateFromSnapshot(snapshot *OutgoingSnapshot) (State, error) {
 		}
 
 		return &AwaitingSubmitAccepted{
-			InputOutpoints:  snapshot.InputOutpoints,
 			ArkPSBT:         ark,
 			CheckpointPSBTs: cps,
 			TransferInputs:  inputs,
@@ -365,7 +359,6 @@ func OutgoingStateFromSnapshot(snapshot *OutgoingSnapshot) (State, error) {
 
 		return &AwaitingCheckpointSignatures{
 			SessionID:               snapshot.SessionID,
-			InputOutpoints:          snapshot.InputOutpoints,
 			ArkPSBT:                 ark,
 			CoSignedCheckpointPSBTs: cps,
 			TransferInputs:          inputs,
@@ -384,21 +377,27 @@ func OutgoingStateFromSnapshot(snapshot *OutgoingSnapshot) (State, error) {
 			return nil, err
 		}
 
+		inputs, err := restoreTransferInputs(snapshot)
+		if err != nil {
+			return nil, err
+		}
+
 		return &AwaitingFinalizeAccepted{
 			SessionID:            snapshot.SessionID,
-			InputOutpoints:       snapshot.InputOutpoints,
 			ArkPSBT:              ark,
 			FinalCheckpointPSBTs: cps,
+			TransferInputs:       inputs,
 		}, nil
 
 	case OutgoingPhaseLocalVTXOUpdate:
-		if len(snapshot.InputOutpoints) == 0 {
-			return nil, fmt.Errorf("input outpoints required")
+		inputs, err := restoreTransferInputs(snapshot)
+		if err != nil {
+			return nil, err
 		}
 
 		return &AwaitingLocalVTXOUpdate{
 			SessionID:      snapshot.SessionID,
-			InputOutpoints: snapshot.InputOutpoints,
+			TransferInputs: inputs,
 		}, nil
 
 	case OutgoingPhaseRetryBackoff:

--- a/oor/outgoing_snapshot_codec.go
+++ b/oor/outgoing_snapshot_codec.go
@@ -24,7 +24,6 @@ const (
 	snapshotCheckpointPSBTsRecordType tlv.Type = 9
 	snapshotTransferInputsRecordType  tlv.Type = 11
 	snapshotRetryAfterNanosRecordType tlv.Type = 15
-	snapshotResumeSnapshotRecordType  tlv.Type = 17
 	snapshotFailReasonRecordType      tlv.Type = 19
 )
 
@@ -223,16 +222,6 @@ func encodeOutgoingSnapshot(snapshot *OutgoingSnapshot) ([]byte, error) {
 	retryAfterNanos := uint64(snapshot.RetryAfter)
 	failReason := []byte(snapshot.FailReason)
 
-	var resumeSnapshot []byte
-	if snapshot.ResumeSnapshot != nil {
-		resumeSnapshot, err = encodeOutgoingSnapshot(
-			snapshot.ResumeSnapshot,
-		)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	version := uint64(snapshot.Version)
 	records := []tlv.Record{
 		tlv.MakePrimitiveRecord(snapshotVersionRecordType, &version),
@@ -249,9 +238,6 @@ func encodeOutgoingSnapshot(snapshot *OutgoingSnapshot) ([]byte, error) {
 		),
 		tlv.MakePrimitiveRecord(
 			snapshotRetryAfterNanosRecordType, &retryAfterNanos,
-		),
-		tlv.MakePrimitiveRecord(
-			snapshotResumeSnapshotRecordType, &resumeSnapshot,
 		),
 		tlv.MakePrimitiveRecord(
 			snapshotFailReasonRecordType, &failReason,
@@ -280,7 +266,6 @@ func decodeOutgoingSnapshot(raw []byte) (*OutgoingSnapshot, error) {
 		checkpointPSBTsRaw []byte
 		inputSnapshotsRaw  []byte
 		retryAfterNanos    uint64
-		resumeSnapshotRaw  []byte
 		failReasonRaw      []byte
 	)
 
@@ -299,9 +284,6 @@ func decodeOutgoingSnapshot(raw []byte) (*OutgoingSnapshot, error) {
 		),
 		tlv.MakePrimitiveRecord(
 			snapshotRetryAfterNanosRecordType, &retryAfterNanos,
-		),
-		tlv.MakePrimitiveRecord(
-			snapshotResumeSnapshotRecordType, &resumeSnapshotRaw,
 		),
 		tlv.MakePrimitiveRecord(
 			snapshotFailReasonRecordType, &failReasonRaw,
@@ -343,14 +325,6 @@ func decodeOutgoingSnapshot(raw []byte) (*OutgoingSnapshot, error) {
 		arkPSBT = nil
 	}
 
-	var resumeSnapshot *OutgoingSnapshot
-	if len(resumeSnapshotRaw) != 0 {
-		resumeSnapshot, err = decodeOutgoingSnapshot(resumeSnapshotRaw)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	decodedVersion, err := decodeUint64ToUint8(version, "snapshot version")
 	if err != nil {
 		return nil, err
@@ -371,7 +345,6 @@ func decodeOutgoingSnapshot(raw []byte) (*OutgoingSnapshot, error) {
 		CheckpointPSBTs:        checkpointPSBTs,
 		TransferInputSnapshots: inputSnapshots,
 		RetryAfter:             decodedRetryAfter,
-		ResumeSnapshot:         resumeSnapshot,
 		FailReason:             string(failReasonRaw),
 	}, nil
 }

--- a/oor/outgoing_snapshot_codec.go
+++ b/oor/outgoing_snapshot_codec.go
@@ -23,7 +23,6 @@ const (
 	snapshotArkPSBTRecordType         tlv.Type = 7
 	snapshotCheckpointPSBTsRecordType tlv.Type = 9
 	snapshotTransferInputsRecordType  tlv.Type = 11
-	snapshotInputOutpointsRecordType  tlv.Type = 13
 	snapshotRetryAfterNanosRecordType tlv.Type = 15
 	snapshotResumeSnapshotRecordType  tlv.Type = 17
 	snapshotFailReasonRecordType      tlv.Type = 19
@@ -221,11 +220,6 @@ func encodeOutgoingSnapshot(snapshot *OutgoingSnapshot) ([]byte, error) {
 		return nil, err
 	}
 
-	outpointsRaw, err := encodeOutpoints(snapshot.InputOutpoints)
-	if err != nil {
-		return nil, err
-	}
-
 	retryAfterNanos := uint64(snapshot.RetryAfter)
 	failReason := []byte(snapshot.FailReason)
 
@@ -252,9 +246,6 @@ func encodeOutgoingSnapshot(snapshot *OutgoingSnapshot) ([]byte, error) {
 		),
 		tlv.MakePrimitiveRecord(
 			snapshotTransferInputsRecordType, &inputSnapshots,
-		),
-		tlv.MakePrimitiveRecord(
-			snapshotInputOutpointsRecordType, &outpointsRaw,
 		),
 		tlv.MakePrimitiveRecord(
 			snapshotRetryAfterNanosRecordType, &retryAfterNanos,
@@ -288,7 +279,6 @@ func decodeOutgoingSnapshot(raw []byte) (*OutgoingSnapshot, error) {
 		arkPSBT            []byte
 		checkpointPSBTsRaw []byte
 		inputSnapshotsRaw  []byte
-		outpointsRaw       []byte
 		retryAfterNanos    uint64
 		resumeSnapshotRaw  []byte
 		failReasonRaw      []byte
@@ -306,9 +296,6 @@ func decodeOutgoingSnapshot(raw []byte) (*OutgoingSnapshot, error) {
 		),
 		tlv.MakePrimitiveRecord(
 			snapshotTransferInputsRecordType, &inputSnapshotsRaw,
-		),
-		tlv.MakePrimitiveRecord(
-			snapshotInputOutpointsRecordType, &outpointsRaw,
 		),
 		tlv.MakePrimitiveRecord(
 			snapshotRetryAfterNanosRecordType, &retryAfterNanos,
@@ -352,14 +339,6 @@ func decodeOutgoingSnapshot(raw []byte) (*OutgoingSnapshot, error) {
 		inputSnapshots = nil
 	}
 
-	outpoints, err := decodeOutpoints(outpointsRaw)
-	if err != nil {
-		return nil, err
-	}
-	if len(outpoints) == 0 {
-		outpoints = nil
-	}
-
 	if len(arkPSBT) == 0 {
 		arkPSBT = nil
 	}
@@ -391,7 +370,6 @@ func decodeOutgoingSnapshot(raw []byte) (*OutgoingSnapshot, error) {
 		ArkPSBT:                arkPSBT,
 		CheckpointPSBTs:        checkpointPSBTs,
 		TransferInputSnapshots: inputSnapshots,
-		InputOutpoints:         outpoints,
 		RetryAfter:             decodedRetryAfter,
 		ResumeSnapshot:         resumeSnapshot,
 		FailReason:             string(failReasonRaw),
@@ -405,25 +383,6 @@ func encodeOutpoints(outpoints []wire.OutPoint) ([]byte, error) {
 	}
 
 	return encodeLengthPrefixedBlobList(blobs)
-}
-
-func decodeOutpoints(raw []byte) ([]wire.OutPoint, error) {
-	blobs, err := decodeLengthPrefixedBlobList(raw)
-	if err != nil {
-		return nil, err
-	}
-
-	outpoints := make([]wire.OutPoint, 0, len(blobs))
-	for i := range blobs {
-		outpoint, err := parseOutPointBytes(blobs[i])
-		if err != nil {
-			return nil, err
-		}
-
-		outpoints = append(outpoints, outpoint)
-	}
-
-	return outpoints, nil
 }
 
 func decodeUint64ToUint8(value uint64, field string) (uint8, error) {

--- a/oor/outgoing_snapshot_codec_test.go
+++ b/oor/outgoing_snapshot_codec_test.go
@@ -36,12 +36,6 @@ func TestOutgoingSnapshotTLVRoundTrip(t *testing.T) {
 				OwnerLeafScript: []byte{0x51},
 			},
 		},
-		InputOutpoints: []wire.OutPoint{
-			{
-				Hash:  chainhash.Hash{12, 13, 14},
-				Index: 15,
-			},
-		},
 		RetryAfter: 3 * time.Second,
 		ResumeSnapshot: &OutgoingSnapshot{
 			Version:   3,
@@ -171,11 +165,6 @@ func encodeSnapshotRawForDecodeTest(version uint64,
 		return nil, err
 	}
 
-	outpointsRaw, err := encodeOutpoints(nil)
-	if err != nil {
-		return nil, err
-	}
-
 	resumeSnapshotRaw := []byte(nil)
 	failReasonRaw := []byte(nil)
 
@@ -191,9 +180,6 @@ func encodeSnapshotRawForDecodeTest(version uint64,
 		),
 		tlv.MakePrimitiveRecord(
 			snapshotTransferInputsRecordType, &inputSnapshotsRaw,
-		),
-		tlv.MakePrimitiveRecord(
-			snapshotInputOutpointsRecordType, &outpointsRaw,
 		),
 		tlv.MakePrimitiveRecord(
 			snapshotRetryAfterNanosRecordType, &retryAfterNanos,

--- a/oor/outgoing_snapshot_codec_test.go
+++ b/oor/outgoing_snapshot_codec_test.go
@@ -37,11 +37,6 @@ func TestOutgoingSnapshotTLVRoundTrip(t *testing.T) {
 			},
 		},
 		RetryAfter: 3 * time.Second,
-		ResumeSnapshot: &OutgoingSnapshot{
-			Version:   3,
-			SessionID: SessionID(chainhash.Hash{16, 17}),
-			Phase:     OutgoingPhaseCompleted,
-		},
 		FailReason: "retry later",
 	}
 
@@ -165,7 +160,6 @@ func encodeSnapshotRawForDecodeTest(version uint64,
 		return nil, err
 	}
 
-	resumeSnapshotRaw := []byte(nil)
 	failReasonRaw := []byte(nil)
 
 	records := []tlv.Record{
@@ -183,9 +177,6 @@ func encodeSnapshotRawForDecodeTest(version uint64,
 		),
 		tlv.MakePrimitiveRecord(
 			snapshotRetryAfterNanosRecordType, &retryAfterNanos,
-		),
-		tlv.MakePrimitiveRecord(
-			snapshotResumeSnapshotRecordType, &resumeSnapshotRaw,
 		),
 		tlv.MakePrimitiveRecord(
 			snapshotFailReasonRecordType, &failReasonRaw,

--- a/oor/outgoing_snapshot_test.go
+++ b/oor/outgoing_snapshot_test.go
@@ -2,6 +2,7 @@ package oor
 
 import (
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
@@ -63,4 +64,81 @@ func TestNewOutgoingSnapshotFinalizeSentMinimality(t *testing.T) {
 	require.NotEmpty(t, snapshot.CheckpointPSBTs)
 	require.NotNil(t, snapshot.TransferInputSnapshots)
 	require.Len(t, snapshot.TransferInputSnapshots, 1)
+}
+
+// TestSnapshotRetryMetadataRoundTrip verifies that RetryAfter and retry
+// reason survive TLV encode/decode. This is essential for restart-safe
+// retry scheduling: the actor persists retry metadata alongside the real
+// protocol state so a restarted actor can schedule a timer instead of
+// immediately re-driving the outbox.
+func TestSnapshotRetryMetadataRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	policy := scripts.CheckpointPolicy{
+		OperatorKey: operatorKey.PubKey(),
+		CSVDelay:    10,
+	}
+
+	const inputValue = btcutil.Amount(10000)
+
+	clientKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	input := newTestTransferInput(
+		t, clientKey, policy.OperatorKey, wire.OutPoint{
+			Hash:  [32]byte{0x02},
+			Index: 0,
+		}, inputValue,
+	)
+
+	recipients := []oortx.RecipientOutput{
+		{
+			PkScript: newTestTaprootPkScript(
+				t, clientKey.PubKey(),
+			),
+			Value: inputValue,
+		},
+	}
+
+	ark, checkpoints, err := buildSubmitPackage(
+		policy, []TransferInput{input}, recipients,
+	)
+	require.NoError(t, err)
+
+	sessionID := SessionID(ark.UnsignedTx.TxHash())
+
+	state := &AwaitingSubmitAccepted{
+		ArkPSBT:         ark,
+		CheckpointPSBTs: checkpoints,
+		TransferInputs:  []TransferInput{input},
+	}
+
+	// Create a snapshot and apply retry metadata (simulating what the
+	// actor does when a retryable outbox error occurs).
+	snapshot, err := NewOutgoingSnapshot(sessionID, state)
+	require.NoError(t, err)
+	require.Equal(t, OutgoingPhaseSubmitSent, snapshot.Phase)
+
+	snapshot.RetryAfter = 3 * time.Second
+	snapshot.FailReason = "temporary transport error"
+
+	// Encode and decode the snapshot to simulate checkpoint
+	// persistence.
+	raw, err := encodeOutgoingSnapshot(snapshot)
+	require.NoError(t, err)
+
+	decoded, err := decodeOutgoingSnapshot(raw)
+	require.NoError(t, err)
+
+	require.Equal(t, OutgoingPhaseSubmitSent, decoded.Phase)
+	require.Equal(t, 3*time.Second, decoded.RetryAfter)
+	require.Equal(t, "temporary transport error", decoded.FailReason)
+
+	// Verify the decoded snapshot can restore the original state.
+	restored, err := OutgoingStateFromSnapshot(decoded)
+	require.NoError(t, err)
+	require.IsType(t, &AwaitingSubmitAccepted{}, restored)
 }

--- a/oor/outgoing_snapshot_test.go
+++ b/oor/outgoing_snapshot_test.go
@@ -50,9 +50,9 @@ func TestNewOutgoingSnapshotFinalizeSentMinimality(t *testing.T) {
 
 	state := &AwaitingFinalizeAccepted{
 		SessionID:            SessionID(ark.UnsignedTx.TxHash()),
-		InputOutpoints:       []wire.OutPoint{input.VTXO.Outpoint},
 		ArkPSBT:              ark,
 		FinalCheckpointPSBTs: checkpoints,
+		TransferInputs:       []TransferInput{input},
 	}
 
 	snapshot, err := NewOutgoingSnapshot(state.SessionID, state)
@@ -61,10 +61,6 @@ func TestNewOutgoingSnapshotFinalizeSentMinimality(t *testing.T) {
 	require.Equal(t, OutgoingPhaseFinalizeSent, snapshot.Phase)
 	require.NotEmpty(t, snapshot.ArkPSBT)
 	require.NotEmpty(t, snapshot.CheckpointPSBTs)
-	require.Equal(t, state.InputOutpoints, snapshot.InputOutpoints)
-
-	// Finalize retries do not require transfer input material, so the
-	// snapshot should not carry those fields in this phase.
-	require.Nil(t, snapshot.TransferInputs)
-	require.Nil(t, snapshot.TransferInputSnapshots)
+	require.NotNil(t, snapshot.TransferInputSnapshots)
+	require.Len(t, snapshot.TransferInputSnapshots, 1)
 }

--- a/oor/resume.go
+++ b/oor/resume.go
@@ -109,13 +109,6 @@ func OutboxForState(state State) ([]OutboxEvent, error) {
 			},
 		}, nil
 
-	case *RetryBackoff:
-		return []OutboxEvent{
-			&ScheduleRetryRequest{
-				After:  s.RetryAfter,
-				Reason: s.Reason,
-			},
-		}, nil
 	case *Completed, *Failed:
 		return nil, nil
 

--- a/oor/resume.go
+++ b/oor/resume.go
@@ -105,7 +105,7 @@ func OutboxForState(state State) ([]OutboxEvent, error) {
 	case *AwaitingLocalVTXOUpdate:
 		return []OutboxEvent{
 			&MarkInputsSpentRequest{
-				Outpoints: s.InputOutpoints,
+				Outpoints: InputOutpoints(s.TransferInputs),
 			},
 		}, nil
 

--- a/oor/retry_callback.go
+++ b/oor/retry_callback.go
@@ -6,11 +6,11 @@ import (
 	"github.com/lightninglabs/darepo-client/timeout"
 )
 
-// NewRetryCallbackRef creates a TellOnlyRef that transforms timeout expiry
-// notifications into OOR actor DriveEventRequest messages containing a
-// RetryDueEvent. The timeout ID is expected to be the hex-encoded session ID
-// (set by SigningOutboxHandler.handleScheduleRetry), which is parsed back
-// into a SessionID for the DriveEventRequest.
+// NewRetryCallbackRef creates a TellOnlyRef that transforms timeout
+// expiry notifications into OOR actor ResumeSessionRequest messages.
+// The timeout ID is expected to be the hex-encoded session ID (set by
+// SigningOutboxHandler.handleScheduleRetry), which is parsed back into
+// a SessionID for the resume request.
 //
 // This bridges the timeout actor's fire-and-forget callback with the OOR
 // actor's durable mailbox, enabling event-driven retry scheduling without
@@ -30,17 +30,14 @@ func NewRetryCallbackRef(
 			)
 			if err != nil {
 				// This should never happen since we control
-				// the timeout ID format. Return a nil-session
-				// drive request that the actor will reject
-				// gracefully.
-				return &DriveEventRequest{
-					Event: &RetryDueEvent{},
-				}
+				// the timeout ID format. Return a
+				// zero-session resume request that the
+				// actor will reject gracefully.
+				return &ResumeSessionRequest{}
 			}
 
-			return &DriveEventRequest{
+			return &ResumeSessionRequest{
 				SessionID: SessionID(*sessionHash),
-				Event:     &RetryDueEvent{},
 			}
 		},
 	)

--- a/oor/signing_outbox_handler.go
+++ b/oor/signing_outbox_handler.go
@@ -21,21 +21,21 @@ import (
 //   - RequestCheckpointSignatures: attaches client-side collaborative VTXO
 //     spend signatures to each checkpoint PSBT via SignCheckpointPSBTs.
 //   - ScheduleRetryRequest: schedules a timer via the timeout actor. When
-//     the timer fires, a DriveEventRequest{Event: &RetryDueEvent{}} is
-//     delivered back to the OOR actor via the CallbackRef.
+//     the timer fires, a ResumeSessionRequest is delivered back to the OOR
+//     actor via the CallbackRef.
 //   - IncomingTransferNotification: informational no-op (logging only).
 type SigningOutboxHandler struct {
 	// Signer signs checkpoint inputs at RequestCheckpointSignatures.
 	Signer input.Signer
 
-	// TimeoutActor schedules retry timers. When nil, retry requests
-	// return a RetryDueEvent immediately (useful for test harnesses).
+	// TimeoutActor schedules retry timers. When nil, retry requests are
+	// treated as no-ops and callers must resume explicitly.
 	TimeoutActor *timeout.Actor
 
 	// CallbackRef receives timeout expiry notifications transformed into
 	// OOR actor messages. This is typically created via
 	// actor.NewMapInputRef to convert *timeout.ExpiredMsg into a
-	// DriveEventRequest targeting the OOR actor.
+	// ResumeSessionRequest targeting the OOR actor.
 	CallbackRef actor.TellOnlyRef[*timeout.ExpiredMsg]
 }
 
@@ -134,16 +134,14 @@ func (h *SigningOutboxHandler) handleCheckpointSignatures(
 
 // handleScheduleRetry schedules a retry timer via the timeout actor. The
 // session ID is encoded as the timeout ID so the expiry callback can
-// reconstruct a DriveEventRequest targeting the correct session. When no
-// timeout actor is configured, a RetryDueEvent is returned immediately for
-// backward compatibility with test harnesses.
+// reconstruct a ResumeSessionRequest targeting the correct session. When no
+// timeout actor is configured, scheduling becomes a no-op and callers must
+// resume explicitly.
 func (h *SigningOutboxHandler) handleScheduleRetry(ctx context.Context,
 	sessionID SessionID, msg *ScheduleRetryRequest) ([]Event, error) {
 
 	if h.TimeoutActor == nil {
-		// No timeout actor configured: emit RetryDueEvent
-		// immediately so tests don't need timer infrastructure.
-		return []Event{&RetryDueEvent{}}, nil
+		return nil, nil
 	}
 
 	if h.CallbackRef == nil {
@@ -152,7 +150,7 @@ func (h *SigningOutboxHandler) handleScheduleRetry(ctx context.Context,
 
 	// Use the session ID hex string as the timeout ID. When the timer
 	// fires, the callback ref's map function parses this back into a
-	// SessionID for the DriveEventRequest.
+	// SessionID for the ResumeSessionRequest.
 	timeoutID := timeout.ID(sessionID.String())
 
 	result := h.TimeoutActor.Receive(ctx, &timeout.ScheduleTimeoutRequest{
@@ -165,7 +163,7 @@ func (h *SigningOutboxHandler) handleScheduleRetry(ctx context.Context,
 			result.Err())
 	}
 
-	// The timeout actor will deliver RetryDueEvent asynchronously
+	// The timeout actor will deliver ResumeSessionRequest asynchronously
 	// via the callback ref when the timer fires.
 	return nil, nil
 }

--- a/oor/states.go
+++ b/oor/states.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil/psbt"
-	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/baselib/protofsm"
 )
 
@@ -38,9 +37,6 @@ func (s *Idle) stateSealed() {}
 // AwaitingArkSignatures indicates the submit package has been built and the
 // client must attach Ark signatures before submit can be sent.
 type AwaitingArkSignatures struct {
-	// InputOutpoints are the VTXO outpoints consumed by this OOR session.
-	InputOutpoints []wire.OutPoint
-
 	// ArkPSBT is the canonical Ark tx PSBT.
 	ArkPSBT *psbt.Packet
 
@@ -71,13 +67,6 @@ type AwaitingSubmitAccepted struct {
 	// AwaitingSubmitAccepted is the crash-sensitive phase where a submit
 	// request may have been sent, while the client has not yet observed
 	// the server's co-sign response.
-
-	// InputOutpoints are the VTXO outpoints consumed by this OOR session.
-	//
-	// The FSM carries these through to the terminal state so it can emit a
-	// crash-resilient local persistence step after the server accepts
-	// finalize.
-	InputOutpoints []wire.OutPoint
 
 	// ArkPSBT is the Ark tx PSBT for this session.
 	ArkPSBT *psbt.Packet
@@ -120,9 +109,6 @@ type AwaitingCheckpointSignatures struct {
 	// SessionID is the stable session identifier (Ark txid).
 	SessionID SessionID
 
-	// InputOutpoints are the VTXO outpoints consumed by this OOR session.
-	InputOutpoints []wire.OutPoint
-
 	// ArkPSBT is the Ark tx PSBT, needed to finalize checkpoint metadata.
 	ArkPSBT *psbt.Packet
 
@@ -162,9 +148,6 @@ type AwaitingFinalizeAccepted struct {
 	// SessionID is the stable session identifier (Ark txid).
 	SessionID SessionID
 
-	// InputOutpoints are the VTXO outpoints consumed by this OOR session.
-	InputOutpoints []wire.OutPoint
-
 	// ArkPSBT is the Ark tx PSBT.
 	ArkPSBT *psbt.Packet
 
@@ -174,6 +157,10 @@ type AwaitingFinalizeAccepted struct {
 	// These are persisted so resume/unilateral-exit paths can reconstruct
 	// checkpoint lineage without depending on a fresh server response.
 	FinalCheckpointPSBTs []*psbt.Packet
+
+	// TransferInputs carry the VTXO descriptors consumed by this session.
+	// The local bookkeeping phase derives spent outpoints from these.
+	TransferInputs []TransferInput
 }
 
 // String returns a human-readable representation of AwaitingFinalizeAccepted.
@@ -234,8 +221,9 @@ type AwaitingLocalVTXOUpdate struct {
 	// SessionID is the stable session identifier (Ark txid).
 	SessionID SessionID
 
-	// InputOutpoints are the VTXO outpoints consumed by this OOR session.
-	InputOutpoints []wire.OutPoint
+	// TransferInputs carry the VTXO descriptors consumed by this session.
+	// The local persistence step derives spent outpoints from these.
+	TransferInputs []TransferInput
 }
 
 // String returns a human-readable representation of AwaitingLocalVTXOUpdate.

--- a/oor/states.go
+++ b/oor/states.go
@@ -1,8 +1,6 @@
 package oor
 
 import (
-	"time"
-
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/lightninglabs/darepo-client/baselib/protofsm"
 )
@@ -176,40 +174,6 @@ func (s *AwaitingFinalizeAccepted) IsTerminal() bool {
 // stateSealed marks AwaitingFinalizeAccepted as implementing the sealed State
 // interface.
 func (s *AwaitingFinalizeAccepted) stateSealed() {}
-
-// RetryBackoff indicates the client should wait before retrying the outbox
-// request implied by ResumeSnapshot.
-//
-// This state is intended to support retry/backoff without requiring durable
-// timers yet: the outbox boundary can implement ScheduleRetryRequest however it
-// wants (immediate in tests, time-based in apps).
-type RetryBackoff struct {
-	// RetryBackoff is a minimal "timer" state that models backoff without
-	// requiring a dedicated scheduler in the FSM runtime. A future durable
-	// actor runtime can replace this by persisting timers and wakeups.
-
-	// ResumeSnapshot captures the state to restore when the retry is due.
-	ResumeSnapshot *OutgoingSnapshot
-
-	// RetryAfter is the requested backoff delay.
-	RetryAfter time.Duration
-
-	// Reason is a human-readable error reason.
-	Reason string
-}
-
-// String returns a human-readable representation of RetryBackoff.
-func (s *RetryBackoff) String() string {
-	return "RetryBackoff"
-}
-
-// IsTerminal returns false as RetryBackoff is not terminal.
-func (s *RetryBackoff) IsTerminal() bool {
-	return false
-}
-
-// stateSealed marks RetryBackoff as implementing the sealed State interface.
-func (s *RetryBackoff) stateSealed() {}
 
 // AwaitingLocalVTXOUpdate indicates the server has accepted the finalize
 // package and the client must update its local VTXO persistence state.

--- a/oor/transfer_inputs.go
+++ b/oor/transfer_inputs.go
@@ -26,6 +26,16 @@ type TransferInput struct {
 	OwnerLeafScript []byte
 }
 
+// InputOutpoints returns the VTXO outpoints for the transfer inputs.
+func InputOutpoints(inputs []TransferInput) []wire.OutPoint {
+	outpoints := make([]wire.OutPoint, 0, len(inputs))
+	for i := range inputs {
+		outpoints = append(outpoints, inputs[i].VTXO.Outpoint)
+	}
+
+	return outpoints
+}
+
 // Validate performs basic structural validation.
 func (i *TransferInput) Validate() error {
 	switch {

--- a/oor/transitions.go
+++ b/oor/transitions.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/lib/scripts"
 	oortx "github.com/lightninglabs/darepo-client/lib/tx/oor"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
@@ -61,16 +60,12 @@ func (s *Idle) ProcessEvent(ctx context.Context, event Event,
 				"provided")
 		}
 
-		inputOutpoints := make([]wire.OutPoint, 0, len(evt.VTXOInputs))
 		for i := range evt.VTXOInputs {
 			if evt.VTXOInputs[i].VTXO == nil {
 				return nil, fmt.Errorf(
 					"checkpoint input vtxo required",
 				)
 			}
-			inputOutpoints = append(
-				inputOutpoints, evt.VTXOInputs[i].VTXO.Outpoint,
-			)
 		}
 
 		// If the FSM environment is already bound to a stable session
@@ -100,7 +95,6 @@ func (s *Idle) ProcessEvent(ctx context.Context, event Event,
 
 		return &StateTransition{
 			NextState: &AwaitingArkSignatures{
-				InputOutpoints:  inputOutpoints,
 				ArkPSBT:         ark,
 				CheckpointPSBTs: checkpoints,
 				TransferInputs:  evt.VTXOInputs,
@@ -167,7 +161,6 @@ func (s *AwaitingArkSignatures) ProcessEvent(ctx context.Context, event Event,
 
 		return &StateTransition{
 			NextState: &AwaitingSubmitAccepted{
-				InputOutpoints:  s.InputOutpoints,
 				ArkPSBT:         evt.ArkPSBT,
 				CheckpointPSBTs: s.CheckpointPSBTs,
 				TransferInputs:  s.TransferInputs,
@@ -243,7 +236,6 @@ func (s *AwaitingSubmitAccepted) ProcessEvent(ctx context.Context, event Event,
 		return &StateTransition{
 			NextState: &AwaitingCheckpointSignatures{
 				SessionID:               evt.SessionID,
-				InputOutpoints:          s.InputOutpoints,
 				ArkPSBT:                 evt.ArkPSBT,
 				CoSignedCheckpointPSBTs: checkpoints,
 				TransferInputs:          s.TransferInputs,
@@ -309,9 +301,9 @@ func (s *AwaitingCheckpointSignatures) ProcessEvent(ctx context.Context,
 		return &StateTransition{
 			NextState: &AwaitingFinalizeAccepted{
 				SessionID:            s.SessionID,
-				InputOutpoints:       s.InputOutpoints,
 				ArkPSBT:              s.ArkPSBT,
 				FinalCheckpointPSBTs: evt.FinalCheckpointPSBTs,
+				TransferInputs:       s.TransferInputs,
 			},
 			NewEvents: fn.Some(EmittedEvent{
 				Outbox: []OutboxEvent{
@@ -360,12 +352,14 @@ func (s *AwaitingFinalizeAccepted) ProcessEvent(ctx context.Context,
 		return &StateTransition{
 			NextState: &AwaitingLocalVTXOUpdate{
 				SessionID:      s.SessionID,
-				InputOutpoints: s.InputOutpoints,
+				TransferInputs: s.TransferInputs,
 			},
 			NewEvents: fn.Some(EmittedEvent{
 				Outbox: []OutboxEvent{
 					&MarkInputsSpentRequest{
-						Outpoints: s.InputOutpoints,
+						Outpoints: InputOutpoints(
+							s.TransferInputs,
+						),
 					},
 				},
 			}),

--- a/oor/transitions.go
+++ b/oor/transitions.go
@@ -409,50 +409,6 @@ func (s *AwaitingLocalVTXOUpdate) ProcessEvent(ctx context.Context,
 	}
 }
 
-// ProcessEvent handles events for RetryBackoff.
-func (s *RetryBackoff) ProcessEvent(ctx context.Context, event Event,
-	env *Environment) (*StateTransition, error) {
-
-	_ = ctx
-	_ = env
-
-	switch evt := event.(type) {
-	case *RetryDueEvent:
-		_ = evt
-
-		if s.ResumeSnapshot == nil {
-			return nil, fmt.Errorf(
-				"resume snapshot must be provided",
-			)
-		}
-
-		nextState, err := OutgoingStateFromSnapshot(s.ResumeSnapshot)
-		if err != nil {
-			return nil, err
-		}
-
-		nextOutbox, err := OutboxForState(nextState)
-		if err != nil {
-			return nil, err
-		}
-
-		return &StateTransition{
-			NextState: nextState,
-			NewEvents: fn.Some(EmittedEvent{
-				Outbox: nextOutbox,
-			}),
-		}, nil
-	case *FailEvent:
-		return &StateTransition{
-			NextState: &Failed{Reason: evt.Reason},
-			NewEvents: fn.None[EmittedEvent](),
-		}, nil
-
-	default:
-		return unexpectedEvent(s), nil
-	}
-}
-
 // ProcessEvent handles events for Completed.
 func (s *Completed) ProcessEvent(ctx context.Context, event Event,
 	env *Environment) (*StateTransition, error) {
@@ -473,8 +429,8 @@ func (s *Failed) ProcessEvent(ctx context.Context, event Event,
 	return unexpectedEvent(s), nil
 }
 
-// handleOutboxError transitions the FSM into a RetryBackoff state if the error
-// is retryable, otherwise returning a terminal failure.
+// handleOutboxError emits retry scheduling for retryable errors while keeping
+// the FSM in the current protocol state.
 func handleOutboxError(env *Environment, current State,
 	evt *OutboxErrorEvent) (*StateTransition, error) {
 
@@ -489,26 +445,13 @@ func handleOutboxError(env *Environment, current State,
 		}, nil
 	}
 
-	if env == nil || env.SessionID == (SessionID{}) {
-		return nil, fmt.Errorf("internal: missing session id")
-	}
-
-	snap, err := NewOutgoingSnapshot(env.SessionID, current)
-	if err != nil {
-		return nil, err
-	}
-
 	after := evt.RetryAfter
 	if after == 0 {
 		after = defaultRetryDelay
 	}
 
 	return &StateTransition{
-		NextState: &RetryBackoff{
-			ResumeSnapshot: snap,
-			RetryAfter:     after,
-			Reason:         evt.ErrorReason,
-		},
+		NextState: current,
 		NewEvents: fn.Some(EmittedEvent{
 			Outbox: []OutboxEvent{
 				&ScheduleRetryRequest{


### PR DESCRIPTION
Simplify the client OOR FSM by removing two sources of unnecessary complexity:

**1. Remove `InputOutpoints`, derive from `TransferInputs` on demand**

`InputOutpoints []wire.OutPoint` was threaded through every non-terminal state struct as a separate field, but it was always a projection of `TransferInputs[i].VTXO.Outpoint`. This added a parallel data path across 5 state structs, the snapshot struct, and the TLV codec.

Now `TransferInputs` is threaded through all states, including `AwaitingFinalizeAccepted` and `AwaitingLocalVTXOUpdate`, which previously dropped it. Outpoints are derived via an `InputOutpoints()` helper where needed. The `InputOutpoints` field and its TLV record type are removed entirely.

**2. Remove `RetryBackoff` state, use timeout actor for retry re-drive**

`RetryBackoff` was a dedicated FSM state that wrapped a full nested `*OutgoingSnapshot` just to model "wait, then re-drive the current state's outbox". This caused recursive TLV encoding of PSBT artifacts, doubling snapshot size during retry, and added a parallel durability/state-restore path on top of the already-durable actor checkpoint.

This is replaced with a simpler model: on retryable `OutboxErrorEvent`, the FSM stays in the current protocol state and emits `ScheduleRetryRequest`. The timeout actor schedules a timer, and the callback sends a `ResumeSessionRequest` which re-drives the outbox for the current state. Optional `RetryAfter` plus retry reason metadata on the `sessionHandle`, persisted to the snapshot, preserves backoff semantics across process restarts.

This removes `RetryBackoff`, `RetryDueEvent`, `ResumeSnapshot`, the recursive snapshot codec path, and `OutgoingPhaseRetryBackoff`.

## Testing

- `make lint`
- `go test ./oor/...`

## Notes

A separate `darepo` OOR timeout investigation is intentionally out of scope for this branch. That timeout is already present on `darepo-client/main` and is not introduced by these two commits.
