### PR TITLE
arkrpc+indexer: structured TreePath proto and OOR recipient event fields

### DIFF
--- a/arkrpc/AGENTS.md
+++ b/arkrpc/AGENTS.md
@@ -3,13 +3,34 @@
 ## Purpose
 
 Server-side gRPC service definitions (ArkService, IndexerService) with generated
-Go stubs. Proto source: `arkrpc/ark.proto`, `arkrpc/indexer.proto`.
+Go stubs, plus hand-written conversion utilities for domain types.
+Proto source: `arkrpc/ark.proto`, `arkrpc/indexer.proto`.
+
+## Key Types
+
+- `TreePath` / `TreePathNode` / `TxOut` — Structured proto messages for the
+  VTXO commitment tree path. Replaces opaque TLV bytes on the wire.
+- `TreePathFromTree` / `TreePathToTree` — Lossless conversion between
+  `tree.Tree` and `arkrpc.TreePath`. Uses deterministic pre-order flattening
+  with sorted child indices.
+- `IncomingOOREvent` — Lightweight notification (wake-up hint). Carries only
+  session_id, pk_script, event_id. Triggers the three-phase receive flow.
+- `OORRecipientEvent` — Phase 1 query response from
+  `ListOORRecipientEventsByScript`. Carries the full Ark PSBT and checkpoint
+  PSBTs that `IncomingOOREvent` intentionally omits.
+- `VTXO` — Phase 2 query response from `ListVTXOsByScripts`. Carries
+  authoritative lineage metadata including the structured `TreePath`.
 
 ## Relationships
 
-- **Depends on**: nothing (proto definitions).
-- **Depended on by**: `indexer`, `darepod`, `serverconn` (uses generated clients).
+- **Depends on**: `lib/tree` (for conversion utilities in `tree_path_convert.go`).
+- **Depended on by**: `indexer`, `darepod`, `serverconn`, `oor` (uses generated
+  clients and conversion helpers).
 
 ## Invariants
 
 - **Never edit generated code** — regenerate via `make rpc`.
+- Conversion round-trip: `TreePathFromTree(t)` → `TreePathToTree(pb)` must
+  reproduce the original tree (excluding derived `FinalKey` fields).
+- Child iteration during flattening is sorted by output index for
+  deterministic serialization.

--- a/arkrpc/CLAUDE.md
+++ b/arkrpc/CLAUDE.md
@@ -3,13 +3,34 @@
 ## Purpose
 
 Server-side gRPC service definitions (ArkService, IndexerService) with generated
-Go stubs. Proto source: `arkrpc/ark.proto`, `arkrpc/indexer.proto`.
+Go stubs, plus hand-written conversion utilities for domain types.
+Proto source: `arkrpc/ark.proto`, `arkrpc/indexer.proto`.
+
+## Key Types
+
+- `TreePath` / `TreePathNode` / `TxOut` — Structured proto messages for the
+  VTXO commitment tree path. Replaces opaque TLV bytes on the wire.
+- `TreePathFromTree` / `TreePathToTree` — Lossless conversion between
+  `tree.Tree` and `arkrpc.TreePath`. Uses deterministic pre-order flattening
+  with sorted child indices.
+- `IncomingOOREvent` — Lightweight notification (wake-up hint). Carries only
+  session_id, pk_script, event_id. Triggers the three-phase receive flow.
+- `OORRecipientEvent` — Phase 1 query response from
+  `ListOORRecipientEventsByScript`. Carries the full Ark PSBT and checkpoint
+  PSBTs that `IncomingOOREvent` intentionally omits.
+- `VTXO` — Phase 2 query response from `ListVTXOsByScripts`. Carries
+  authoritative lineage metadata including the structured `TreePath`.
 
 ## Relationships
 
-- **Depends on**: nothing (proto definitions).
-- **Depended on by**: `indexer`, `darepod`, `serverconn` (uses generated clients).
+- **Depends on**: `lib/tree` (for conversion utilities in `tree_path_convert.go`).
+- **Depended on by**: `indexer`, `darepod`, `serverconn`, `oor` (uses generated
+  clients and conversion helpers).
 
 ## Invariants
 
 - **Never edit generated code** — regenerate via `make rpc`.
+- Conversion round-trip: `TreePathFromTree(t)` → `TreePathToTree(pb)` must
+  reproduce the original tree (excluding derived `FinalKey` fields).
+- Child iteration during flattening is sorted by output index for
+  deterministic serialization.

--- a/arkrpc/indexer.pb.go
+++ b/arkrpc/indexer.pb.go
@@ -687,6 +687,11 @@ func (*UnregisterReceiveScriptResponse) Descriptor() ([]byte, []int) {
 	return file_indexer_proto_rawDescGZIP(), []int{8}
 }
 
+// ListOORRecipientEventsByScriptRequest is Phase 1 of the three-phase
+// incoming OOR receive flow. After a lightweight IncomingOOREvent
+// notification wakes the client, the client issues this query to fetch
+// the full OOR package data (Ark PSBT + checkpoint PSBTs) needed to
+// construct IncomingTransferEvent in the OOR FSM.
 type ListOORRecipientEventsByScriptRequest struct {
 	state        protoimpl.MessageState `protogen:"open.v1"`
 	PkScript     []byte                 `protobuf:"bytes,1,opt,name=pk_script,json=pkScript,proto3" json:"pk_script,omitempty"`
@@ -847,6 +852,9 @@ func (x *ListOORRecipientEventsByScriptResponse) GetNextCursor() uint64 {
 	return 0
 }
 
+// OORRecipientEvent is returned by ListOORRecipientEventsByScript (Phase 1
+// query response). It carries the full Ark PSBT and checkpoint data that
+// the lightweight IncomingOOREvent notification intentionally omits.
 type OORRecipientEvent struct {
 	state             protoimpl.MessageState `protogen:"open.v1"`
 	RecipientPkScript []byte                 `protobuf:"bytes,1,opt,name=recipient_pk_script,json=recipientPkScript,proto3" json:"recipient_pk_script,omitempty"`
@@ -854,8 +862,16 @@ type OORRecipientEvent struct {
 	SessionId         []byte                 `protobuf:"bytes,3,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
 	OutputIndex       uint32                 `protobuf:"varint,4,opt,name=output_index,json=outputIndex,proto3" json:"output_index,omitempty"`
 	Value             uint64                 `protobuf:"varint,5,opt,name=value,proto3" json:"value,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	// ark_psbt is the serialized Ark PSBT for this OOR session. The
+	// client needs this to materialize the received VTXO via the
+	// IncomingTransferEvent in the OOR FSM.
+	ArkPsbt []byte `protobuf:"bytes,6,opt,name=ark_psbt,json=arkPsbt,proto3" json:"ark_psbt,omitempty"`
+	// checkpoint_psbts are the finalized checkpoint PSBTs for the
+	// session. These provide lineage and unroll proof data for the
+	// materialized VTXO.
+	CheckpointPsbts [][]byte `protobuf:"bytes,7,rep,name=checkpoint_psbts,json=checkpointPsbts,proto3" json:"checkpoint_psbts,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *OORRecipientEvent) Reset() {
@@ -923,9 +939,37 @@ func (x *OORRecipientEvent) GetValue() uint64 {
 	return 0
 }
 
-// IncomingOOREvent is delivered as a mailbox EVENT envelope. It is
-// intentionally bounded and acts as a durable hint that a wallet should fetch
-// full OOR proof material via wallet-scoped queries if needed.
+func (x *OORRecipientEvent) GetArkPsbt() []byte {
+	if x != nil {
+		return x.ArkPsbt
+	}
+	return nil
+}
+
+func (x *OORRecipientEvent) GetCheckpointPsbts() [][]byte {
+	if x != nil {
+		return x.CheckpointPsbts
+	}
+	return nil
+}
+
+// IncomingOOREvent is a lightweight notification delivered as a mailbox EVENT
+// envelope. It acts as a durable wake-up hint that triggers the three-phase
+// incoming receive flow:
+//
+//	Phase 0 (notification): IncomingOOREvent arrives with session_id,
+//	  pk_script, and event_id. No PSBTs or metadata; just enough to
+//	  identify the transfer and persist a durable resolve request.
+//
+//	Phase 1 (package query): Client issues ListOORRecipientEventsByScript
+//	  to fetch the full Ark PSBT + checkpoint PSBTs from the indexer.
+//
+//	Phase 2 (metadata query): Client issues ListVTXOsByScripts to fetch
+//	  authoritative VTXO lineage metadata (round_id, commitment_txid,
+//	  tree_path, batch_expiry, chain_depth) for materialization.
+//
+// Each phase boundary is a durable message, so the flow survives actor
+// restarts without re-issuing queries or losing state.
 type IncomingOOREvent struct {
 	state             protoimpl.MessageState `protogen:"open.v1"`
 	RecipientPkScript []byte                 `protobuf:"bytes,1,opt,name=recipient_pk_script,json=recipientPkScript,proto3" json:"recipient_pk_script,omitempty"`
@@ -1057,6 +1101,233 @@ func (x *OutPoint) GetVout() uint32 {
 	return 0
 }
 
+// TxOut represents a Bitcoin transaction output.
+type TxOut struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// value is the output amount in satoshis.
+	Value int64 `protobuf:"varint,1,opt,name=value,proto3" json:"value,omitempty"`
+	// pk_script is the output script (scriptPubKey).
+	PkScript      []byte `protobuf:"bytes,2,opt,name=pk_script,json=pkScript,proto3" json:"pk_script,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TxOut) Reset() {
+	*x = TxOut{}
+	mi := &file_indexer_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TxOut) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TxOut) ProtoMessage() {}
+
+func (x *TxOut) ProtoReflect() protoreflect.Message {
+	mi := &file_indexer_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TxOut.ProtoReflect.Descriptor instead.
+func (*TxOut) Descriptor() ([]byte, []int) {
+	return file_indexer_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *TxOut) GetValue() int64 {
+	if x != nil {
+		return x.Value
+	}
+	return 0
+}
+
+func (x *TxOut) GetPkScript() []byte {
+	if x != nil {
+		return x.PkScript
+	}
+	return nil
+}
+
+// TreePathNode represents a single node in a VTXO tree path. Each node
+// corresponds to one transaction in the commitment lineage from root to leaf.
+type TreePathNode struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// input is the outpoint this transaction spends.
+	Input *OutPoint `protobuf:"bytes,1,opt,name=input,proto3" json:"input,omitempty"`
+	// outputs are all the outputs created by this transaction.
+	Outputs []*TxOut `protobuf:"bytes,2,rep,name=outputs,proto3" json:"outputs,omitempty"`
+	// co_signers are the compressed public keys (33 bytes each) that must
+	// participate in MuSig2 signing for this node's input.
+	CoSigners [][]byte `protobuf:"bytes,3,rep,name=co_signers,json=coSigners,proto3" json:"co_signers,omitempty"`
+	// children maps output index to the index of the child TreePathNode in
+	// the parent TreePath's flattened nodes array.
+	Children map[uint32]uint32 `protobuf:"bytes,4,rep,name=children,proto3" json:"children,omitempty" protobuf_key:"varint,1,opt,name=key" protobuf_val:"varint,2,opt,name=value"`
+	// amount is the total BTC value (satoshis) for this node.
+	Amount int64 `protobuf:"varint,5,opt,name=amount,proto3" json:"amount,omitempty"`
+	// signature is the final aggregated MuSig2 schnorr signature (64 bytes)
+	// for the input. Empty if unsigned.
+	Signature     []byte `protobuf:"bytes,6,opt,name=signature,proto3" json:"signature,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TreePathNode) Reset() {
+	*x = TreePathNode{}
+	mi := &file_indexer_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TreePathNode) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TreePathNode) ProtoMessage() {}
+
+func (x *TreePathNode) ProtoReflect() protoreflect.Message {
+	mi := &file_indexer_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TreePathNode.ProtoReflect.Descriptor instead.
+func (*TreePathNode) Descriptor() ([]byte, []int) {
+	return file_indexer_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *TreePathNode) GetInput() *OutPoint {
+	if x != nil {
+		return x.Input
+	}
+	return nil
+}
+
+func (x *TreePathNode) GetOutputs() []*TxOut {
+	if x != nil {
+		return x.Outputs
+	}
+	return nil
+}
+
+func (x *TreePathNode) GetCoSigners() [][]byte {
+	if x != nil {
+		return x.CoSigners
+	}
+	return nil
+}
+
+func (x *TreePathNode) GetChildren() map[uint32]uint32 {
+	if x != nil {
+		return x.Children
+	}
+	return nil
+}
+
+func (x *TreePathNode) GetAmount() int64 {
+	if x != nil {
+		return x.Amount
+	}
+	return 0
+}
+
+func (x *TreePathNode) GetSignature() []byte {
+	if x != nil {
+		return x.Signature
+	}
+	return nil
+}
+
+// TreePath is the minimal extracted VTXO tree path from root to a client's
+// leaf, required for unilateral exit of the underlying commitment lineage.
+type TreePath struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// nodes is the pre-order flattened list of tree nodes. Index 0 is the
+	// root.
+	Nodes []*TreePathNode `protobuf:"bytes,1,rep,name=nodes,proto3" json:"nodes,omitempty"`
+	// batch_outpoint is the outpoint in the commitment transaction that the
+	// root transaction spends.
+	BatchOutpoint *OutPoint `protobuf:"bytes,2,opt,name=batch_outpoint,json=batchOutpoint,proto3" json:"batch_outpoint,omitempty"`
+	// batch_output is the actual output at batch_outpoint.
+	BatchOutput *TxOut `protobuf:"bytes,3,opt,name=batch_output,json=batchOutput,proto3" json:"batch_output,omitempty"`
+	// sweep_tapscript_root is the tapscript root hash for tweaking branch
+	// outputs. Empty for connector trees.
+	SweepTapscriptRoot []byte `protobuf:"bytes,4,opt,name=sweep_tapscript_root,json=sweepTapscriptRoot,proto3" json:"sweep_tapscript_root,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *TreePath) Reset() {
+	*x = TreePath{}
+	mi := &file_indexer_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TreePath) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TreePath) ProtoMessage() {}
+
+func (x *TreePath) ProtoReflect() protoreflect.Message {
+	mi := &file_indexer_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TreePath.ProtoReflect.Descriptor instead.
+func (*TreePath) Descriptor() ([]byte, []int) {
+	return file_indexer_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *TreePath) GetNodes() []*TreePathNode {
+	if x != nil {
+		return x.Nodes
+	}
+	return nil
+}
+
+func (x *TreePath) GetBatchOutpoint() *OutPoint {
+	if x != nil {
+		return x.BatchOutpoint
+	}
+	return nil
+}
+
+func (x *TreePath) GetBatchOutput() *TxOut {
+	if x != nil {
+		return x.BatchOutput
+	}
+	return nil
+}
+
+func (x *TreePath) GetSweepTapscriptRoot() []byte {
+	if x != nil {
+		return x.SweepTapscriptRoot
+	}
+	return nil
+}
+
 // ScriptScope selects a pkScript and carries a proof-of-control for that
 // script.
 //
@@ -1080,7 +1351,7 @@ type ScriptScope struct {
 
 func (x *ScriptScope) Reset() {
 	*x = ScriptScope{}
-	mi := &file_indexer_proto_msgTypes[14]
+	mi := &file_indexer_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1092,7 +1363,7 @@ func (x *ScriptScope) String() string {
 func (*ScriptScope) ProtoMessage() {}
 
 func (x *ScriptScope) ProtoReflect() protoreflect.Message {
-	mi := &file_indexer_proto_msgTypes[14]
+	mi := &file_indexer_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1105,7 +1376,7 @@ func (x *ScriptScope) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ScriptScope.ProtoReflect.Descriptor instead.
 func (*ScriptScope) Descriptor() ([]byte, []int) {
-	return file_indexer_proto_rawDescGZIP(), []int{14}
+	return file_indexer_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *ScriptScope) GetPkScript() []byte {
@@ -1195,14 +1466,17 @@ type VTXO struct {
 	// chain_depth is the number of OOR checkpoint hops between this VTXO
 	// and the most recent on-chain commitment. Round-created VTXOs have
 	// chain_depth 0.
-	ChainDepth    uint32 `protobuf:"varint,15,opt,name=chain_depth,json=chainDepth,proto3" json:"chain_depth,omitempty"`
+	ChainDepth uint32 `protobuf:"varint,15,opt,name=chain_depth,json=chainDepth,proto3" json:"chain_depth,omitempty"`
+	// tree_path is the extracted VTXO tree path required for unilateral exit
+	// of this VTXO's underlying commitment lineage.
+	TreePath      *TreePath `protobuf:"bytes,16,opt,name=tree_path,json=treePath,proto3" json:"tree_path,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *VTXO) Reset() {
 	*x = VTXO{}
-	mi := &file_indexer_proto_msgTypes[15]
+	mi := &file_indexer_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1214,7 +1488,7 @@ func (x *VTXO) String() string {
 func (*VTXO) ProtoMessage() {}
 
 func (x *VTXO) ProtoReflect() protoreflect.Message {
-	mi := &file_indexer_proto_msgTypes[15]
+	mi := &file_indexer_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1227,7 +1501,7 @@ func (x *VTXO) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VTXO.ProtoReflect.Descriptor instead.
 func (*VTXO) Descriptor() ([]byte, []int) {
-	return file_indexer_proto_rawDescGZIP(), []int{15}
+	return file_indexer_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *VTXO) GetOutpoint() *OutPoint {
@@ -1335,6 +1609,13 @@ func (x *VTXO) GetChainDepth() uint32 {
 	return 0
 }
 
+func (x *VTXO) GetTreePath() *TreePath {
+	if x != nil {
+		return x.TreePath
+	}
+	return nil
+}
+
 type ListVTXOsByScriptsRequest struct {
 	state   protoimpl.MessageState `protogen:"open.v1"`
 	Scripts []*ScriptScope         `protobuf:"bytes,1,rep,name=scripts,proto3" json:"scripts,omitempty"`
@@ -1351,7 +1632,7 @@ type ListVTXOsByScriptsRequest struct {
 
 func (x *ListVTXOsByScriptsRequest) Reset() {
 	*x = ListVTXOsByScriptsRequest{}
-	mi := &file_indexer_proto_msgTypes[16]
+	mi := &file_indexer_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1363,7 +1644,7 @@ func (x *ListVTXOsByScriptsRequest) String() string {
 func (*ListVTXOsByScriptsRequest) ProtoMessage() {}
 
 func (x *ListVTXOsByScriptsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_indexer_proto_msgTypes[16]
+	mi := &file_indexer_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1376,7 +1657,7 @@ func (x *ListVTXOsByScriptsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListVTXOsByScriptsRequest.ProtoReflect.Descriptor instead.
 func (*ListVTXOsByScriptsRequest) Descriptor() ([]byte, []int) {
-	return file_indexer_proto_rawDescGZIP(), []int{16}
+	return file_indexer_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *ListVTXOsByScriptsRequest) GetScripts() []*ScriptScope {
@@ -1417,7 +1698,7 @@ type ListVTXOsByScriptsResponse struct {
 
 func (x *ListVTXOsByScriptsResponse) Reset() {
 	*x = ListVTXOsByScriptsResponse{}
-	mi := &file_indexer_proto_msgTypes[17]
+	mi := &file_indexer_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1429,7 +1710,7 @@ func (x *ListVTXOsByScriptsResponse) String() string {
 func (*ListVTXOsByScriptsResponse) ProtoMessage() {}
 
 func (x *ListVTXOsByScriptsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_indexer_proto_msgTypes[17]
+	mi := &file_indexer_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1442,7 +1723,7 @@ func (x *ListVTXOsByScriptsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListVTXOsByScriptsResponse.ProtoReflect.Descriptor instead.
 func (*ListVTXOsByScriptsResponse) Descriptor() ([]byte, []int) {
-	return file_indexer_proto_rawDescGZIP(), []int{17}
+	return file_indexer_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *ListVTXOsByScriptsResponse) GetVtxos() []*VTXO {
@@ -1478,7 +1759,7 @@ type TreeNode struct {
 
 func (x *TreeNode) Reset() {
 	*x = TreeNode{}
-	mi := &file_indexer_proto_msgTypes[18]
+	mi := &file_indexer_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1490,7 +1771,7 @@ func (x *TreeNode) String() string {
 func (*TreeNode) ProtoMessage() {}
 
 func (x *TreeNode) ProtoReflect() protoreflect.Message {
-	mi := &file_indexer_proto_msgTypes[18]
+	mi := &file_indexer_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1503,7 +1784,7 @@ func (x *TreeNode) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TreeNode.ProtoReflect.Descriptor instead.
 func (*TreeNode) Descriptor() ([]byte, []int) {
-	return file_indexer_proto_rawDescGZIP(), []int{18}
+	return file_indexer_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *TreeNode) GetTxid() []byte {
@@ -1549,7 +1830,7 @@ type TreeEdge struct {
 
 func (x *TreeEdge) Reset() {
 	*x = TreeEdge{}
-	mi := &file_indexer_proto_msgTypes[19]
+	mi := &file_indexer_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1561,7 +1842,7 @@ func (x *TreeEdge) String() string {
 func (*TreeEdge) ProtoMessage() {}
 
 func (x *TreeEdge) ProtoReflect() protoreflect.Message {
-	mi := &file_indexer_proto_msgTypes[19]
+	mi := &file_indexer_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1574,7 +1855,7 @@ func (x *TreeEdge) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TreeEdge.ProtoReflect.Descriptor instead.
 func (*TreeEdge) Descriptor() ([]byte, []int) {
-	return file_indexer_proto_rawDescGZIP(), []int{19}
+	return file_indexer_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *TreeEdge) GetParentTxid() []byte {
@@ -1610,7 +1891,7 @@ type GetSubtreeByScriptsRequest struct {
 
 func (x *GetSubtreeByScriptsRequest) Reset() {
 	*x = GetSubtreeByScriptsRequest{}
-	mi := &file_indexer_proto_msgTypes[20]
+	mi := &file_indexer_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1622,7 +1903,7 @@ func (x *GetSubtreeByScriptsRequest) String() string {
 func (*GetSubtreeByScriptsRequest) ProtoMessage() {}
 
 func (x *GetSubtreeByScriptsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_indexer_proto_msgTypes[20]
+	mi := &file_indexer_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1635,7 +1916,7 @@ func (x *GetSubtreeByScriptsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSubtreeByScriptsRequest.ProtoReflect.Descriptor instead.
 func (*GetSubtreeByScriptsRequest) Descriptor() ([]byte, []int) {
-	return file_indexer_proto_rawDescGZIP(), []int{20}
+	return file_indexer_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *GetSubtreeByScriptsRequest) GetScripts() []*ScriptScope {
@@ -1666,7 +1947,7 @@ type GetSubtreeByScriptsResponse struct {
 
 func (x *GetSubtreeByScriptsResponse) Reset() {
 	*x = GetSubtreeByScriptsResponse{}
-	mi := &file_indexer_proto_msgTypes[21]
+	mi := &file_indexer_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1678,7 +1959,7 @@ func (x *GetSubtreeByScriptsResponse) String() string {
 func (*GetSubtreeByScriptsResponse) ProtoMessage() {}
 
 func (x *GetSubtreeByScriptsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_indexer_proto_msgTypes[21]
+	mi := &file_indexer_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1691,7 +1972,7 @@ func (x *GetSubtreeByScriptsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSubtreeByScriptsResponse.ProtoReflect.Descriptor instead.
 func (*GetSubtreeByScriptsResponse) Descriptor() ([]byte, []int) {
-	return file_indexer_proto_rawDescGZIP(), []int{21}
+	return file_indexer_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *GetSubtreeByScriptsResponse) GetVtxos() []*VTXO {
@@ -1730,7 +2011,7 @@ type VTXOEvent struct {
 
 func (x *VTXOEvent) Reset() {
 	*x = VTXOEvent{}
-	mi := &file_indexer_proto_msgTypes[22]
+	mi := &file_indexer_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1742,7 +2023,7 @@ func (x *VTXOEvent) String() string {
 func (*VTXOEvent) ProtoMessage() {}
 
 func (x *VTXOEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_indexer_proto_msgTypes[22]
+	mi := &file_indexer_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1755,7 +2036,7 @@ func (x *VTXOEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VTXOEvent.ProtoReflect.Descriptor instead.
 func (*VTXOEvent) Descriptor() ([]byte, []int) {
-	return file_indexer_proto_rawDescGZIP(), []int{22}
+	return file_indexer_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *VTXOEvent) GetEventId() uint64 {
@@ -1806,7 +2087,7 @@ type ListVTXOEventsByScriptsRequest struct {
 
 func (x *ListVTXOEventsByScriptsRequest) Reset() {
 	*x = ListVTXOEventsByScriptsRequest{}
-	mi := &file_indexer_proto_msgTypes[23]
+	mi := &file_indexer_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1818,7 +2099,7 @@ func (x *ListVTXOEventsByScriptsRequest) String() string {
 func (*ListVTXOEventsByScriptsRequest) ProtoMessage() {}
 
 func (x *ListVTXOEventsByScriptsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_indexer_proto_msgTypes[23]
+	mi := &file_indexer_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1831,7 +2112,7 @@ func (x *ListVTXOEventsByScriptsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListVTXOEventsByScriptsRequest.ProtoReflect.Descriptor instead.
 func (*ListVTXOEventsByScriptsRequest) Descriptor() ([]byte, []int) {
-	return file_indexer_proto_rawDescGZIP(), []int{23}
+	return file_indexer_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *ListVTXOEventsByScriptsRequest) GetScripts() []*ScriptScope {
@@ -1865,7 +2146,7 @@ type ListVTXOEventsByScriptsResponse struct {
 
 func (x *ListVTXOEventsByScriptsResponse) Reset() {
 	*x = ListVTXOEventsByScriptsResponse{}
-	mi := &file_indexer_proto_msgTypes[24]
+	mi := &file_indexer_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1877,7 +2158,7 @@ func (x *ListVTXOEventsByScriptsResponse) String() string {
 func (*ListVTXOEventsByScriptsResponse) ProtoMessage() {}
 
 func (x *ListVTXOEventsByScriptsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_indexer_proto_msgTypes[24]
+	mi := &file_indexer_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1890,7 +2171,7 @@ func (x *ListVTXOEventsByScriptsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListVTXOEventsByScriptsResponse.ProtoReflect.Descriptor instead.
 func (*ListVTXOEventsByScriptsResponse) Descriptor() ([]byte, []int) {
-	return file_indexer_proto_rawDescGZIP(), []int{24}
+	return file_indexer_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *ListVTXOEventsByScriptsResponse) GetEvents() []*VTXOEvent {
@@ -1921,7 +2202,7 @@ type IncomingVTXOEvent struct {
 
 func (x *IncomingVTXOEvent) Reset() {
 	*x = IncomingVTXOEvent{}
-	mi := &file_indexer_proto_msgTypes[25]
+	mi := &file_indexer_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1933,7 +2214,7 @@ func (x *IncomingVTXOEvent) String() string {
 func (*IncomingVTXOEvent) ProtoMessage() {}
 
 func (x *IncomingVTXOEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_indexer_proto_msgTypes[25]
+	mi := &file_indexer_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1946,7 +2227,7 @@ func (x *IncomingVTXOEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IncomingVTXOEvent.ProtoReflect.Descriptor instead.
 func (*IncomingVTXOEvent) Descriptor() ([]byte, []int) {
-	return file_indexer_proto_rawDescGZIP(), []int{25}
+	return file_indexer_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *IncomingVTXOEvent) GetEventId() uint64 {
@@ -2022,14 +2303,16 @@ const file_indexer_proto_rawDesc = "" +
 	"&ListOORRecipientEventsByScriptResponse\x121\n" +
 	"\x06events\x18\x01 \x03(\v2\x19.arkrpc.OORRecipientEventR\x06events\x12\x1f\n" +
 	"\vnext_cursor\x18\x02 \x01(\x04R\n" +
-	"nextCursor\"\xb6\x01\n" +
+	"nextCursor\"\xfc\x01\n" +
 	"\x11OORRecipientEvent\x12.\n" +
 	"\x13recipient_pk_script\x18\x01 \x01(\fR\x11recipientPkScript\x12\x19\n" +
 	"\bevent_id\x18\x02 \x01(\x04R\aeventId\x12\x1d\n" +
 	"\n" +
 	"session_id\x18\x03 \x01(\fR\tsessionId\x12!\n" +
 	"\foutput_index\x18\x04 \x01(\rR\voutputIndex\x12\x14\n" +
-	"\x05value\x18\x05 \x01(\x04R\x05value\"\xc8\x01\n" +
+	"\x05value\x18\x05 \x01(\x04R\x05value\x12\x19\n" +
+	"\bark_psbt\x18\x06 \x01(\fR\aarkPsbt\x12)\n" +
+	"\x10checkpoint_psbts\x18\a \x03(\fR\x0fcheckpointPsbts\"\xc8\x01\n" +
 	"\x10IncomingOOREvent\x12.\n" +
 	"\x13recipient_pk_script\x18\x01 \x01(\fR\x11recipientPkScript\x12,\n" +
 	"\x12recipient_event_id\x18\x02 \x01(\x04R\x10recipientEventId\x12\x1d\n" +
@@ -2039,13 +2322,32 @@ const file_indexer_proto_rawDesc = "" +
 	"\x05value\x18\x05 \x01(\x04R\x05value\"2\n" +
 	"\bOutPoint\x12\x12\n" +
 	"\x04txid\x18\x01 \x01(\fR\x04txid\x12\x12\n" +
-	"\x04vout\x18\x02 \x01(\rR\x04vout\"\xaa\x01\n" +
+	"\x04vout\x18\x02 \x01(\rR\x04vout\":\n" +
+	"\x05TxOut\x12\x14\n" +
+	"\x05value\x18\x01 \x01(\x03R\x05value\x12\x1b\n" +
+	"\tpk_script\x18\x02 \x01(\fR\bpkScript\"\xb1\x02\n" +
+	"\fTreePathNode\x12&\n" +
+	"\x05input\x18\x01 \x01(\v2\x10.arkrpc.OutPointR\x05input\x12'\n" +
+	"\aoutputs\x18\x02 \x03(\v2\r.arkrpc.TxOutR\aoutputs\x12\x1d\n" +
+	"\n" +
+	"co_signers\x18\x03 \x03(\fR\tcoSigners\x12>\n" +
+	"\bchildren\x18\x04 \x03(\v2\".arkrpc.TreePathNode.ChildrenEntryR\bchildren\x12\x16\n" +
+	"\x06amount\x18\x05 \x01(\x03R\x06amount\x12\x1c\n" +
+	"\tsignature\x18\x06 \x01(\fR\tsignature\x1a;\n" +
+	"\rChildrenEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\rR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\rR\x05value:\x028\x01\"\xd3\x01\n" +
+	"\bTreePath\x12*\n" +
+	"\x05nodes\x18\x01 \x03(\v2\x14.arkrpc.TreePathNodeR\x05nodes\x127\n" +
+	"\x0ebatch_outpoint\x18\x02 \x01(\v2\x10.arkrpc.OutPointR\rbatchOutpoint\x120\n" +
+	"\fbatch_output\x18\x03 \x01(\v2\r.arkrpc.TxOutR\vbatchOutput\x120\n" +
+	"\x14sweep_tapscript_root\x18\x04 \x01(\fR\x12sweepTapscriptRoot\"\xaa\x01\n" +
 	"\vScriptScope\x12\x1b\n" +
 	"\tpk_script\x18\x01 \x01(\fR\bpkScript\x12F\n" +
 	"\x0ftaproot_schnorr\x18\n" +
 	" \x01(\v2\x1b.arkrpc.TaprootSchnorrProofH\x00R\x0etaprootSchnorr\x12-\n" +
 	"\x06bip322\x18\v \x01(\v2\x13.arkrpc.BIP322ProofH\x00R\x06bip322B\a\n" +
-	"\x05proof\"\xc4\x04\n" +
+	"\x05proof\"\xf3\x04\n" +
 	"\x04VTXO\x12,\n" +
 	"\boutpoint\x18\x01 \x01(\v2\x10.arkrpc.OutPointR\boutpoint\x12\x1b\n" +
 	"\tvalue_sat\x18\x02 \x01(\x04R\bvalueSat\x12\x1b\n" +
@@ -2065,7 +2367,8 @@ const file_indexer_proto_rawDesc = "" +
 	"oorArkPsbt\x12;\n" +
 	"\x1aoor_final_checkpoint_psbts\x18\x0e \x03(\fR\x17oorFinalCheckpointPsbts\x12\x1f\n" +
 	"\vchain_depth\x18\x0f \x01(\rR\n" +
-	"chainDepth\"\xb1\x01\n" +
+	"chainDepth\x12-\n" +
+	"\ttree_path\x18\x10 \x01(\v2\x10.arkrpc.TreePathR\btreePath\"\xb1\x01\n" +
 	"\x19ListVTXOsByScriptsRequest\x12-\n" +
 	"\ascripts\x18\x01 \x03(\v2\x13.arkrpc.ScriptScopeR\ascripts\x127\n" +
 	"\rstatus_filter\x18\x02 \x03(\x0e2\x12.arkrpc.VTXOStatusR\fstatusFilter\x12\x16\n" +
@@ -2151,7 +2454,7 @@ func file_indexer_proto_rawDescGZIP() []byte {
 }
 
 var file_indexer_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_indexer_proto_msgTypes = make([]protoimpl.MessageInfo, 26)
+var file_indexer_proto_msgTypes = make([]protoimpl.MessageInfo, 30)
 var file_indexer_proto_goTypes = []any{
 	(VTXOStatus)(0),                                // 0: arkrpc.VTXOStatus
 	(VTXOEventType)(0),                             // 1: arkrpc.VTXOEventType
@@ -2169,18 +2472,22 @@ var file_indexer_proto_goTypes = []any{
 	(*OORRecipientEvent)(nil),                      // 13: arkrpc.OORRecipientEvent
 	(*IncomingOOREvent)(nil),                       // 14: arkrpc.IncomingOOREvent
 	(*OutPoint)(nil),                               // 15: arkrpc.OutPoint
-	(*ScriptScope)(nil),                            // 16: arkrpc.ScriptScope
-	(*VTXO)(nil),                                   // 17: arkrpc.VTXO
-	(*ListVTXOsByScriptsRequest)(nil),              // 18: arkrpc.ListVTXOsByScriptsRequest
-	(*ListVTXOsByScriptsResponse)(nil),             // 19: arkrpc.ListVTXOsByScriptsResponse
-	(*TreeNode)(nil),                               // 20: arkrpc.TreeNode
-	(*TreeEdge)(nil),                               // 21: arkrpc.TreeEdge
-	(*GetSubtreeByScriptsRequest)(nil),             // 22: arkrpc.GetSubtreeByScriptsRequest
-	(*GetSubtreeByScriptsResponse)(nil),            // 23: arkrpc.GetSubtreeByScriptsResponse
-	(*VTXOEvent)(nil),                              // 24: arkrpc.VTXOEvent
-	(*ListVTXOEventsByScriptsRequest)(nil),         // 25: arkrpc.ListVTXOEventsByScriptsRequest
-	(*ListVTXOEventsByScriptsResponse)(nil),        // 26: arkrpc.ListVTXOEventsByScriptsResponse
-	(*IncomingVTXOEvent)(nil),                      // 27: arkrpc.IncomingVTXOEvent
+	(*TxOut)(nil),                                  // 16: arkrpc.TxOut
+	(*TreePathNode)(nil),                           // 17: arkrpc.TreePathNode
+	(*TreePath)(nil),                               // 18: arkrpc.TreePath
+	(*ScriptScope)(nil),                            // 19: arkrpc.ScriptScope
+	(*VTXO)(nil),                                   // 20: arkrpc.VTXO
+	(*ListVTXOsByScriptsRequest)(nil),              // 21: arkrpc.ListVTXOsByScriptsRequest
+	(*ListVTXOsByScriptsResponse)(nil),             // 22: arkrpc.ListVTXOsByScriptsResponse
+	(*TreeNode)(nil),                               // 23: arkrpc.TreeNode
+	(*TreeEdge)(nil),                               // 24: arkrpc.TreeEdge
+	(*GetSubtreeByScriptsRequest)(nil),             // 25: arkrpc.GetSubtreeByScriptsRequest
+	(*GetSubtreeByScriptsResponse)(nil),            // 26: arkrpc.GetSubtreeByScriptsResponse
+	(*VTXOEvent)(nil),                              // 27: arkrpc.VTXOEvent
+	(*ListVTXOEventsByScriptsRequest)(nil),         // 28: arkrpc.ListVTXOEventsByScriptsRequest
+	(*ListVTXOEventsByScriptsResponse)(nil),        // 29: arkrpc.ListVTXOEventsByScriptsResponse
+	(*IncomingVTXOEvent)(nil),                      // 30: arkrpc.IncomingVTXOEvent
+	nil,                                            // 31: arkrpc.TreePathNode.ChildrenEntry
 }
 var file_indexer_proto_depIdxs = []int32{
 	3,  // 0: arkrpc.RegisterReceiveScriptRequest.taproot_schnorr:type_name -> arkrpc.TaprootSchnorrProof
@@ -2191,45 +2498,52 @@ var file_indexer_proto_depIdxs = []int32{
 	3,  // 5: arkrpc.ListOORRecipientEventsByScriptRequest.taproot_schnorr:type_name -> arkrpc.TaprootSchnorrProof
 	4,  // 6: arkrpc.ListOORRecipientEventsByScriptRequest.bip322:type_name -> arkrpc.BIP322Proof
 	13, // 7: arkrpc.ListOORRecipientEventsByScriptResponse.events:type_name -> arkrpc.OORRecipientEvent
-	3,  // 8: arkrpc.ScriptScope.taproot_schnorr:type_name -> arkrpc.TaprootSchnorrProof
-	4,  // 9: arkrpc.ScriptScope.bip322:type_name -> arkrpc.BIP322Proof
-	15, // 10: arkrpc.VTXO.outpoint:type_name -> arkrpc.OutPoint
-	0,  // 11: arkrpc.VTXO.status:type_name -> arkrpc.VTXOStatus
-	16, // 12: arkrpc.ListVTXOsByScriptsRequest.scripts:type_name -> arkrpc.ScriptScope
-	0,  // 13: arkrpc.ListVTXOsByScriptsRequest.status_filter:type_name -> arkrpc.VTXOStatus
-	17, // 14: arkrpc.ListVTXOsByScriptsResponse.vtxos:type_name -> arkrpc.VTXO
-	15, // 15: arkrpc.TreeNode.input:type_name -> arkrpc.OutPoint
-	16, // 16: arkrpc.GetSubtreeByScriptsRequest.scripts:type_name -> arkrpc.ScriptScope
-	17, // 17: arkrpc.GetSubtreeByScriptsResponse.vtxos:type_name -> arkrpc.VTXO
-	20, // 18: arkrpc.GetSubtreeByScriptsResponse.nodes:type_name -> arkrpc.TreeNode
-	21, // 19: arkrpc.GetSubtreeByScriptsResponse.edges:type_name -> arkrpc.TreeEdge
-	1,  // 20: arkrpc.VTXOEvent.type:type_name -> arkrpc.VTXOEventType
-	15, // 21: arkrpc.VTXOEvent.outpoint:type_name -> arkrpc.OutPoint
-	0,  // 22: arkrpc.VTXOEvent.status:type_name -> arkrpc.VTXOStatus
-	16, // 23: arkrpc.ListVTXOEventsByScriptsRequest.scripts:type_name -> arkrpc.ScriptScope
-	24, // 24: arkrpc.ListVTXOEventsByScriptsResponse.events:type_name -> arkrpc.VTXOEvent
-	1,  // 25: arkrpc.IncomingVTXOEvent.type:type_name -> arkrpc.VTXOEventType
-	15, // 26: arkrpc.IncomingVTXOEvent.outpoint:type_name -> arkrpc.OutPoint
-	0,  // 27: arkrpc.IncomingVTXOEvent.status:type_name -> arkrpc.VTXOStatus
-	2,  // 28: arkrpc.IndexerService.RegisterReceiveScript:input_type -> arkrpc.RegisterReceiveScriptRequest
-	7,  // 29: arkrpc.IndexerService.ListMyReceiveScripts:input_type -> arkrpc.ListMyReceiveScriptsRequest
-	6,  // 30: arkrpc.IndexerService.UnregisterReceiveScript:input_type -> arkrpc.UnregisterReceiveScriptRequest
-	11, // 31: arkrpc.IndexerService.ListOORRecipientEventsByScript:input_type -> arkrpc.ListOORRecipientEventsByScriptRequest
-	18, // 32: arkrpc.IndexerService.ListVTXOsByScripts:input_type -> arkrpc.ListVTXOsByScriptsRequest
-	22, // 33: arkrpc.IndexerService.GetSubtreeByScripts:input_type -> arkrpc.GetSubtreeByScriptsRequest
-	25, // 34: arkrpc.IndexerService.ListVTXOEventsByScripts:input_type -> arkrpc.ListVTXOEventsByScriptsRequest
-	5,  // 35: arkrpc.IndexerService.RegisterReceiveScript:output_type -> arkrpc.RegisterReceiveScriptResponse
-	8,  // 36: arkrpc.IndexerService.ListMyReceiveScripts:output_type -> arkrpc.ListMyReceiveScriptsResponse
-	10, // 37: arkrpc.IndexerService.UnregisterReceiveScript:output_type -> arkrpc.UnregisterReceiveScriptResponse
-	12, // 38: arkrpc.IndexerService.ListOORRecipientEventsByScript:output_type -> arkrpc.ListOORRecipientEventsByScriptResponse
-	19, // 39: arkrpc.IndexerService.ListVTXOsByScripts:output_type -> arkrpc.ListVTXOsByScriptsResponse
-	23, // 40: arkrpc.IndexerService.GetSubtreeByScripts:output_type -> arkrpc.GetSubtreeByScriptsResponse
-	26, // 41: arkrpc.IndexerService.ListVTXOEventsByScripts:output_type -> arkrpc.ListVTXOEventsByScriptsResponse
-	35, // [35:42] is the sub-list for method output_type
-	28, // [28:35] is the sub-list for method input_type
-	28, // [28:28] is the sub-list for extension type_name
-	28, // [28:28] is the sub-list for extension extendee
-	0,  // [0:28] is the sub-list for field type_name
+	15, // 8: arkrpc.TreePathNode.input:type_name -> arkrpc.OutPoint
+	16, // 9: arkrpc.TreePathNode.outputs:type_name -> arkrpc.TxOut
+	31, // 10: arkrpc.TreePathNode.children:type_name -> arkrpc.TreePathNode.ChildrenEntry
+	17, // 11: arkrpc.TreePath.nodes:type_name -> arkrpc.TreePathNode
+	15, // 12: arkrpc.TreePath.batch_outpoint:type_name -> arkrpc.OutPoint
+	16, // 13: arkrpc.TreePath.batch_output:type_name -> arkrpc.TxOut
+	3,  // 14: arkrpc.ScriptScope.taproot_schnorr:type_name -> arkrpc.TaprootSchnorrProof
+	4,  // 15: arkrpc.ScriptScope.bip322:type_name -> arkrpc.BIP322Proof
+	15, // 16: arkrpc.VTXO.outpoint:type_name -> arkrpc.OutPoint
+	0,  // 17: arkrpc.VTXO.status:type_name -> arkrpc.VTXOStatus
+	18, // 18: arkrpc.VTXO.tree_path:type_name -> arkrpc.TreePath
+	19, // 19: arkrpc.ListVTXOsByScriptsRequest.scripts:type_name -> arkrpc.ScriptScope
+	0,  // 20: arkrpc.ListVTXOsByScriptsRequest.status_filter:type_name -> arkrpc.VTXOStatus
+	20, // 21: arkrpc.ListVTXOsByScriptsResponse.vtxos:type_name -> arkrpc.VTXO
+	15, // 22: arkrpc.TreeNode.input:type_name -> arkrpc.OutPoint
+	19, // 23: arkrpc.GetSubtreeByScriptsRequest.scripts:type_name -> arkrpc.ScriptScope
+	20, // 24: arkrpc.GetSubtreeByScriptsResponse.vtxos:type_name -> arkrpc.VTXO
+	23, // 25: arkrpc.GetSubtreeByScriptsResponse.nodes:type_name -> arkrpc.TreeNode
+	24, // 26: arkrpc.GetSubtreeByScriptsResponse.edges:type_name -> arkrpc.TreeEdge
+	1,  // 27: arkrpc.VTXOEvent.type:type_name -> arkrpc.VTXOEventType
+	15, // 28: arkrpc.VTXOEvent.outpoint:type_name -> arkrpc.OutPoint
+	0,  // 29: arkrpc.VTXOEvent.status:type_name -> arkrpc.VTXOStatus
+	19, // 30: arkrpc.ListVTXOEventsByScriptsRequest.scripts:type_name -> arkrpc.ScriptScope
+	27, // 31: arkrpc.ListVTXOEventsByScriptsResponse.events:type_name -> arkrpc.VTXOEvent
+	1,  // 32: arkrpc.IncomingVTXOEvent.type:type_name -> arkrpc.VTXOEventType
+	15, // 33: arkrpc.IncomingVTXOEvent.outpoint:type_name -> arkrpc.OutPoint
+	0,  // 34: arkrpc.IncomingVTXOEvent.status:type_name -> arkrpc.VTXOStatus
+	2,  // 35: arkrpc.IndexerService.RegisterReceiveScript:input_type -> arkrpc.RegisterReceiveScriptRequest
+	7,  // 36: arkrpc.IndexerService.ListMyReceiveScripts:input_type -> arkrpc.ListMyReceiveScriptsRequest
+	6,  // 37: arkrpc.IndexerService.UnregisterReceiveScript:input_type -> arkrpc.UnregisterReceiveScriptRequest
+	11, // 38: arkrpc.IndexerService.ListOORRecipientEventsByScript:input_type -> arkrpc.ListOORRecipientEventsByScriptRequest
+	21, // 39: arkrpc.IndexerService.ListVTXOsByScripts:input_type -> arkrpc.ListVTXOsByScriptsRequest
+	25, // 40: arkrpc.IndexerService.GetSubtreeByScripts:input_type -> arkrpc.GetSubtreeByScriptsRequest
+	28, // 41: arkrpc.IndexerService.ListVTXOEventsByScripts:input_type -> arkrpc.ListVTXOEventsByScriptsRequest
+	5,  // 42: arkrpc.IndexerService.RegisterReceiveScript:output_type -> arkrpc.RegisterReceiveScriptResponse
+	8,  // 43: arkrpc.IndexerService.ListMyReceiveScripts:output_type -> arkrpc.ListMyReceiveScriptsResponse
+	10, // 44: arkrpc.IndexerService.UnregisterReceiveScript:output_type -> arkrpc.UnregisterReceiveScriptResponse
+	12, // 45: arkrpc.IndexerService.ListOORRecipientEventsByScript:output_type -> arkrpc.ListOORRecipientEventsByScriptResponse
+	22, // 46: arkrpc.IndexerService.ListVTXOsByScripts:output_type -> arkrpc.ListVTXOsByScriptsResponse
+	26, // 47: arkrpc.IndexerService.GetSubtreeByScripts:output_type -> arkrpc.GetSubtreeByScriptsResponse
+	29, // 48: arkrpc.IndexerService.ListVTXOEventsByScripts:output_type -> arkrpc.ListVTXOEventsByScriptsResponse
+	42, // [42:49] is the sub-list for method output_type
+	35, // [35:42] is the sub-list for method input_type
+	35, // [35:35] is the sub-list for extension type_name
+	35, // [35:35] is the sub-list for extension extendee
+	0,  // [0:35] is the sub-list for field type_name
 }
 
 func init() { file_indexer_proto_init() }
@@ -2249,7 +2563,7 @@ func file_indexer_proto_init() {
 		(*ListOORRecipientEventsByScriptRequest_TaprootSchnorr)(nil),
 		(*ListOORRecipientEventsByScriptRequest_Bip322)(nil),
 	}
-	file_indexer_proto_msgTypes[14].OneofWrappers = []any{
+	file_indexer_proto_msgTypes[17].OneofWrappers = []any{
 		(*ScriptScope_TaprootSchnorr)(nil),
 		(*ScriptScope_Bip322)(nil),
 	}
@@ -2259,7 +2573,7 @@ func file_indexer_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_indexer_proto_rawDesc), len(file_indexer_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   26,
+			NumMessages:   30,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/arkrpc/indexer.proto
+++ b/arkrpc/indexer.proto
@@ -130,6 +130,11 @@ message RegisteredReceiveScript {
 message UnregisterReceiveScriptResponse {
 }
 
+// ListOORRecipientEventsByScriptRequest is Phase 1 of the three-phase
+// incoming OOR receive flow. After a lightweight IncomingOOREvent
+// notification wakes the client, the client issues this query to fetch
+// the full OOR package data (Ark PSBT + checkpoint PSBTs) needed to
+// construct IncomingTransferEvent in the OOR FSM.
 message ListOORRecipientEventsByScriptRequest {
     bytes pk_script = 1;
     uint64 after_event_id = 2;
@@ -146,17 +151,44 @@ message ListOORRecipientEventsByScriptResponse {
     uint64 next_cursor = 2;
 }
 
+// OORRecipientEvent is returned by ListOORRecipientEventsByScript (Phase 1
+// query response). It carries the full Ark PSBT and checkpoint data that
+// the lightweight IncomingOOREvent notification intentionally omits.
 message OORRecipientEvent {
     bytes recipient_pk_script = 1;
     uint64 event_id = 2;
     bytes session_id = 3;
     uint32 output_index = 4;
     uint64 value = 5;
+
+    // ark_psbt is the serialized Ark PSBT for this OOR session. The
+    // client needs this to materialize the received VTXO via the
+    // IncomingTransferEvent in the OOR FSM.
+    bytes ark_psbt = 6;
+
+    // checkpoint_psbts are the finalized checkpoint PSBTs for the
+    // session. These provide lineage and unroll proof data for the
+    // materialized VTXO.
+    repeated bytes checkpoint_psbts = 7;
 }
 
-// IncomingOOREvent is delivered as a mailbox EVENT envelope. It is
-// intentionally bounded and acts as a durable hint that a wallet should fetch
-// full OOR proof material via wallet-scoped queries if needed.
+// IncomingOOREvent is a lightweight notification delivered as a mailbox EVENT
+// envelope. It acts as a durable wake-up hint that triggers the three-phase
+// incoming receive flow:
+//
+//   Phase 0 (notification): IncomingOOREvent arrives with session_id,
+//     pk_script, and event_id. No PSBTs or metadata; just enough to
+//     identify the transfer and persist a durable resolve request.
+//
+//   Phase 1 (package query): Client issues ListOORRecipientEventsByScript
+//     to fetch the full Ark PSBT + checkpoint PSBTs from the indexer.
+//
+//   Phase 2 (metadata query): Client issues ListVTXOsByScripts to fetch
+//     authoritative VTXO lineage metadata (round_id, commitment_txid,
+//     tree_path, batch_expiry, chain_depth) for materialization.
+//
+// Each phase boundary is a durable message, so the flow survives actor
+// restarts without re-issuing queries or losing state.
 message IncomingOOREvent {
     bytes recipient_pk_script = 1;
     uint64 recipient_event_id = 2;
@@ -171,6 +203,59 @@ message IncomingOOREvent {
 message OutPoint {
     bytes txid = 1;
     uint32 vout = 2;
+}
+
+// TxOut represents a Bitcoin transaction output.
+message TxOut {
+    // value is the output amount in satoshis.
+    int64 value = 1;
+
+    // pk_script is the output script (scriptPubKey).
+    bytes pk_script = 2;
+}
+
+// TreePathNode represents a single node in a VTXO tree path. Each node
+// corresponds to one transaction in the commitment lineage from root to leaf.
+message TreePathNode {
+    // input is the outpoint this transaction spends.
+    OutPoint input = 1;
+
+    // outputs are all the outputs created by this transaction.
+    repeated TxOut outputs = 2;
+
+    // co_signers are the compressed public keys (33 bytes each) that must
+    // participate in MuSig2 signing for this node's input.
+    repeated bytes co_signers = 3;
+
+    // children maps output index to the index of the child TreePathNode in
+    // the parent TreePath's flattened nodes array.
+    map<uint32, uint32> children = 4;
+
+    // amount is the total BTC value (satoshis) for this node.
+    int64 amount = 5;
+
+    // signature is the final aggregated MuSig2 schnorr signature (64 bytes)
+    // for the input. Empty if unsigned.
+    bytes signature = 6;
+}
+
+// TreePath is the minimal extracted VTXO tree path from root to a client's
+// leaf, required for unilateral exit of the underlying commitment lineage.
+message TreePath {
+    // nodes is the pre-order flattened list of tree nodes. Index 0 is the
+    // root.
+    repeated TreePathNode nodes = 1;
+
+    // batch_outpoint is the outpoint in the commitment transaction that the
+    // root transaction spends.
+    OutPoint batch_outpoint = 2;
+
+    // batch_output is the actual output at batch_outpoint.
+    TxOut batch_output = 3;
+
+    // sweep_tapscript_root is the tapscript root hash for tweaking branch
+    // outputs. Empty for connector trees.
+    bytes sweep_tapscript_root = 4;
 }
 
 // ScriptScope selects a pkScript and carries a proof-of-control for that
@@ -278,6 +363,10 @@ message VTXO {
     // and the most recent on-chain commitment. Round-created VTXOs have
     // chain_depth 0.
     uint32 chain_depth = 15;
+
+    // tree_path is the extracted VTXO tree path required for unilateral exit
+    // of this VTXO's underlying commitment lineage.
+    TreePath tree_path = 16;
 }
 
 message ListVTXOsByScriptsRequest {

--- a/arkrpc/tree_path_convert.go
+++ b/arkrpc/tree_path_convert.go
@@ -1,0 +1,286 @@
+package arkrpc
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/tree"
+)
+
+// TreePathFromTree converts a tree.Tree (typically an extracted path) into its
+// proto TreePath representation by flattening the recursive node structure
+// into a pre-order indexed slice.
+func TreePathFromTree(t *tree.Tree) (*TreePath, error) {
+	if t == nil {
+		return nil, nil
+	}
+
+	// Flatten nodes in pre-order.
+	var nodes []*TreePathNode
+	nodeIndex := make(map[*tree.Node]uint32)
+	if err := flattenTreePathNode(
+		t.Root, &nodes, nodeIndex,
+	); err != nil {
+		return nil, err
+	}
+
+	return &TreePath{
+		Nodes:              nodes,
+		BatchOutpoint:      outpointToProto(t.BatchOutpoint),
+		BatchOutput:        txOutToProto(t.BatchOutput),
+		SweepTapscriptRoot: t.SweepTapscriptRoot,
+	}, nil
+}
+
+// TreePathToTree converts a proto TreePath back to a tree.Tree by
+// reconstructing the recursive node structure from the flattened nodes.
+func TreePathToTree(tp *TreePath) (*tree.Tree, error) {
+	if tp == nil {
+		return nil, nil
+	}
+
+	if len(tp.Nodes) == 0 {
+		return nil, fmt.Errorf("empty tree path nodes")
+	}
+
+	// Convert all proto nodes to Go nodes.
+	goNodes := make([]*tree.Node, len(tp.Nodes))
+	for i, pn := range tp.Nodes {
+		node, err := treePathNodeFromProto(pn)
+		if err != nil {
+			return nil, fmt.Errorf("node[%d]: %w", i, err)
+		}
+		goNodes[i] = node
+	}
+
+	// Wire up children references with pre-order invariant.
+	for i, pn := range tp.Nodes {
+		for outIdx, childIdx := range pn.Children {
+			if childIdx <= uint32(i) {
+				return nil, fmt.Errorf(
+					"node[%d] child index %d must "+
+						"be > parent index "+
+						"(cycle or back-reference)",
+					i, childIdx,
+				)
+			}
+
+			if int(childIdx) >= len(goNodes) {
+				return nil, fmt.Errorf(
+					"node[%d] child index %d out "+
+						"of range", i, childIdx,
+				)
+			}
+
+			if int(outIdx) >= len(goNodes[i].Outputs) {
+				return nil, fmt.Errorf(
+					"node[%d] child output index "+
+						"%d out of range (node "+
+						"has %d outputs)",
+					i, outIdx,
+					len(goNodes[i].Outputs),
+				)
+			}
+
+			goNodes[i].Children[outIdx] = goNodes[childIdx]
+		}
+	}
+
+	batchOP, err := outpointFromProto(tp.BatchOutpoint)
+	if err != nil {
+		return nil, fmt.Errorf("batch outpoint: %w", err)
+	}
+
+	batchOut, err := txOutFromProto(tp.BatchOutput)
+	if err != nil {
+		return nil, fmt.Errorf("batch output: %w", err)
+	}
+
+	return &tree.Tree{
+		Root:               goNodes[0],
+		BatchOutpoint:      batchOP,
+		BatchOutput:        batchOut,
+		SweepTapscriptRoot: tp.SweepTapscriptRoot,
+	}, nil
+}
+
+// flattenTreePathNode recursively flattens a tree node into the nodes slice
+// in pre-order.
+func flattenTreePathNode(n *tree.Node, nodes *[]*TreePathNode,
+	index map[*tree.Node]uint32) error {
+
+	if n == nil {
+		return nil
+	}
+
+	myIdx := uint32(len(*nodes))
+	index[n] = myIdx
+
+	// Convert outputs.
+	outputs := make([]*TxOut, len(n.Outputs))
+	for i, out := range n.Outputs {
+		outputs[i] = txOutToProto(out)
+	}
+
+	// Convert co-signers.
+	coSigners := make([][]byte, len(n.CoSigners))
+	for i, pk := range n.CoSigners {
+		coSigners[i] = pk.SerializeCompressed()
+	}
+
+	protoNode := &TreePathNode{
+		Input:     outpointToProto(n.Input),
+		Outputs:   outputs,
+		CoSigners: coSigners,
+		Children:  make(map[uint32]uint32),
+		Amount:    int64(n.Amount),
+		Signature: schnorrSigToBytes(n.Signature),
+	}
+
+	*nodes = append(*nodes, protoNode)
+
+	// Recurse into children in deterministic order so the
+	// flattened output is stable across runs.
+	childIndices := make([]uint32, 0, len(n.Children))
+	for outIdx := range n.Children {
+		childIndices = append(childIndices, outIdx)
+	}
+	sort.Slice(childIndices, func(i, j int) bool {
+		return childIndices[i] < childIndices[j]
+	})
+
+	for _, outIdx := range childIndices {
+		child := n.Children[outIdx]
+		if err := flattenTreePathNode(
+			child, nodes, index,
+		); err != nil {
+			return err
+		}
+
+		protoNode.Children[outIdx] = index[child]
+	}
+
+	return nil
+}
+
+// treePathNodeFromProto converts a single proto TreePathNode to a tree.Node.
+func treePathNodeFromProto(pn *TreePathNode) (*tree.Node, error) {
+	input, err := outpointFromProto(pn.Input)
+	if err != nil {
+		return nil, fmt.Errorf("input: %w", err)
+	}
+
+	// Convert outputs.
+	outputs := make([]*wire.TxOut, len(pn.Outputs))
+	for i, out := range pn.Outputs {
+		txOut, err := txOutFromProto(out)
+		if err != nil {
+			return nil, fmt.Errorf("output[%d]: %w", i, err)
+		}
+		outputs[i] = txOut
+	}
+
+	// Convert co-signers.
+	coSigners := make([]*btcec.PublicKey, len(pn.CoSigners))
+	for i, pkBytes := range pn.CoSigners {
+		pk, err := btcec.ParsePubKey(pkBytes)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"co_signer[%d]: %w", i, err,
+			)
+		}
+		coSigners[i] = pk
+	}
+
+	var sig *schnorr.Signature
+	if len(pn.Signature) > 0 {
+		sig, err = schnorr.ParseSignature(pn.Signature)
+		if err != nil {
+			return nil, fmt.Errorf("signature: %w", err)
+		}
+	}
+
+	return &tree.Node{
+		Input:     input,
+		Outputs:   outputs,
+		CoSigners: coSigners,
+		Children:  make(map[uint32]*tree.Node),
+		Amount:    btcutil.Amount(pn.Amount),
+		Signature: sig,
+	}, nil
+}
+
+// outpointToProto converts a wire.OutPoint to a proto OutPoint.
+func outpointToProto(op wire.OutPoint) *OutPoint {
+	hash := op.Hash[:]
+
+	return &OutPoint{
+		Txid: append([]byte(nil), hash...),
+		Vout: op.Index,
+	}
+}
+
+// outpointFromProto converts a proto OutPoint to a wire.OutPoint.
+func outpointFromProto(op *OutPoint) (wire.OutPoint, error) {
+	if op == nil {
+		return wire.OutPoint{}, fmt.Errorf("nil outpoint")
+	}
+
+	if len(op.Txid) != chainhash.HashSize {
+		return wire.OutPoint{}, fmt.Errorf(
+			"invalid txid length %d", len(op.Txid),
+		)
+	}
+
+	var hash chainhash.Hash
+	copy(hash[:], op.Txid)
+
+	return wire.OutPoint{
+		Hash:  hash,
+		Index: op.Vout,
+	}, nil
+}
+
+// txOutToProto converts a wire.TxOut to a proto TxOut.
+func txOutToProto(out *wire.TxOut) *TxOut {
+	if out == nil {
+		return nil
+	}
+
+	return &TxOut{
+		Value:    out.Value,
+		PkScript: append([]byte(nil), out.PkScript...),
+	}
+}
+
+// txOutFromProto converts a proto TxOut to a wire.TxOut.
+func txOutFromProto(out *TxOut) (*wire.TxOut, error) {
+	if out == nil {
+		return nil, nil
+	}
+
+	if out.Value < 0 {
+		return nil, fmt.Errorf(
+			"negative output value %d", out.Value,
+		)
+	}
+
+	return &wire.TxOut{
+		Value:    out.Value,
+		PkScript: append([]byte(nil), out.PkScript...),
+	}, nil
+}
+
+// schnorrSigToBytes serializes a schnorr signature to bytes.
+func schnorrSigToBytes(sig *schnorr.Signature) []byte {
+	if sig == nil {
+		return nil
+	}
+
+	return sig.Serialize()
+}

--- a/arkrpc/tree_path_convert_test.go
+++ b/arkrpc/tree_path_convert_test.go
@@ -1,0 +1,306 @@
+package arkrpc
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/tree"
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+// ---------------------------------------------------------------------------
+// Rapid generators
+// ---------------------------------------------------------------------------
+
+func genHash(t *rapid.T) chainhash.Hash {
+	var h chainhash.Hash
+	b := rapid.SliceOfN(rapid.Byte(), 32, 32).Draw(t, "hash")
+	copy(h[:], b)
+
+	return h
+}
+
+func genOutpoint(t *rapid.T) wire.OutPoint {
+	return wire.OutPoint{
+		Hash:  genHash(t),
+		Index: rapid.Uint32().Draw(t, "index"),
+	}
+}
+
+func genTxOut(t *rapid.T) *wire.TxOut {
+	scriptLen := rapid.IntRange(1, 100).Draw(t, "script_len")
+	script := rapid.SliceOfN(
+		rapid.Byte(), scriptLen, scriptLen,
+	).Draw(t, "pk_script")
+
+	maxSats := int64(21_000_000_00000000)
+	value := rapid.Int64Range(0, maxSats).Draw(t, "value")
+
+	return &wire.TxOut{
+		Value:    value,
+		PkScript: script,
+	}
+}
+
+func genPubKey(t *rapid.T) *btcec.PublicKey {
+	privBytes := rapid.SliceOfN(
+		rapid.Byte(), 32, 32,
+	).Draw(t, "priv_key")
+	privKey, _ := btcec.PrivKeyFromBytes(privBytes)
+	if privKey == nil {
+		privKey, _ = btcec.NewPrivateKey()
+	}
+
+	return privKey.PubKey()
+}
+
+func genSignature(t *rapid.T) *schnorr.Signature {
+	privBytes := rapid.SliceOfN(
+		rapid.Byte(), 32, 32,
+	).Draw(t, "sig_pk")
+	privKey, _ := btcec.PrivKeyFromBytes(privBytes)
+	if privKey == nil {
+		privKey, _ = btcec.NewPrivateKey()
+	}
+
+	msgBytes := rapid.SliceOfN(
+		rapid.Byte(), 32, 32,
+	).Draw(t, "sig_msg")
+	var msg [32]byte
+	copy(msg[:], msgBytes)
+
+	sig, err := schnorr.Sign(privKey, msg[:])
+	if err != nil {
+		privKey, _ = btcec.NewPrivateKey()
+		sig, _ = schnorr.Sign(privKey, msg[:])
+	}
+
+	return sig
+}
+
+// genNode generates a random tree.Node with bounded depth.
+func genNode(t *rapid.T, depth int) *tree.Node {
+	maxChildren := 0
+	if depth > 0 {
+		maxChildren = rapid.IntRange(0, 2).Draw(
+			t, "max_children",
+		)
+	}
+
+	numOutputs := rapid.IntRange(1, 4).Draw(t, "num_outputs")
+	outputs := make([]*wire.TxOut, numOutputs)
+	for i := range outputs {
+		outputs[i] = genTxOut(t)
+	}
+
+	numCoSigners := rapid.IntRange(0, 3).Draw(t, "num_cosigners")
+	coSigners := make([]*btcec.PublicKey, numCoSigners)
+	for i := range coSigners {
+		coSigners[i] = genPubKey(t)
+	}
+
+	var sig *schnorr.Signature
+	if rapid.Bool().Draw(t, "has_sig") {
+		sig = genSignature(t)
+	}
+
+	maxSats := int64(21_000_000_00000000)
+	amount := btcutil.Amount(
+		rapid.Int64Range(0, maxSats).Draw(t, "amount"),
+	)
+
+	children := make(map[uint32]*tree.Node)
+	for i := 0; i < maxChildren; i++ {
+		idx := rapid.Uint32Range(
+			0, uint32(numOutputs-1),
+		).Draw(t, "child_idx")
+		children[idx] = genNode(t, depth-1)
+	}
+
+	return &tree.Node{
+		Input:     genOutpoint(t),
+		Outputs:   outputs,
+		CoSigners: coSigners,
+		Children:  children,
+		Amount:    amount,
+		Signature: sig,
+	}
+}
+
+// genTree generates a random tree.Tree with a root and up to 3 levels
+// of children.
+func genTree(t *rapid.T) *tree.Tree {
+	var batchOutput *wire.TxOut
+	if rapid.Bool().Draw(t, "has_batch_output") {
+		batchOutput = genTxOut(t)
+	}
+
+	sweepLen := rapid.IntRange(0, 32).Draw(t, "sweep_len")
+	var sweepRoot []byte
+	if sweepLen > 0 {
+		sweepRoot = rapid.SliceOfN(
+			rapid.Byte(), sweepLen, sweepLen,
+		).Draw(t, "sweep_root")
+	}
+
+	return &tree.Tree{
+		Root:               genNode(t, 3),
+		BatchOutpoint:      genOutpoint(t),
+		BatchOutput:        batchOutput,
+		SweepTapscriptRoot: sweepRoot,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Assertion helpers
+// ---------------------------------------------------------------------------
+
+// clearFinalKeys recursively clears the FinalKey field on all nodes in a
+// tree, since the proto representation does not carry it.
+func clearFinalKeys(n *tree.Node) {
+	if n == nil {
+		return
+	}
+
+	n.FinalKey = nil
+
+	for _, child := range n.Children {
+		clearFinalKeys(child)
+	}
+}
+
+// assertTreeEqual compares two trees structurally, checking all fields
+// that survive proto round-trip.
+func assertTreeEqual(t testing.TB, a, b *tree.Tree) {
+	t.Helper()
+
+	require.Equal(t, a.BatchOutpoint, b.BatchOutpoint)
+	require.Equal(t, a.SweepTapscriptRoot, b.SweepTapscriptRoot)
+
+	if a.BatchOutput == nil {
+		require.Nil(t, b.BatchOutput)
+	} else {
+		require.NotNil(t, b.BatchOutput)
+		require.Equal(t, a.BatchOutput.Value, b.BatchOutput.Value)
+		require.Equal(
+			t, a.BatchOutput.PkScript, b.BatchOutput.PkScript,
+		)
+	}
+
+	assertNodeEqual(t, a.Root, b.Root)
+}
+
+// assertNodeEqual recursively compares two tree nodes.
+func assertNodeEqual(t testing.TB, a, b *tree.Node) {
+	t.Helper()
+
+	require.Equal(t, a.Input, b.Input)
+	require.Equal(t, a.Amount, b.Amount)
+	require.Equal(t, len(a.Outputs), len(b.Outputs))
+
+	for i := range a.Outputs {
+		require.Equal(t, a.Outputs[i].Value, b.Outputs[i].Value)
+		require.Equal(
+			t, a.Outputs[i].PkScript, b.Outputs[i].PkScript,
+		)
+	}
+
+	require.Equal(t, len(a.CoSigners), len(b.CoSigners))
+	for i := range a.CoSigners {
+		require.Equal(
+			t,
+			a.CoSigners[i].SerializeCompressed(),
+			b.CoSigners[i].SerializeCompressed(),
+		)
+	}
+
+	if a.Signature == nil {
+		require.Nil(t, b.Signature)
+	} else {
+		require.NotNil(t, b.Signature)
+		require.Equal(
+			t, a.Signature.Serialize(), b.Signature.Serialize(),
+		)
+	}
+
+	require.Equal(t, len(a.Children), len(b.Children))
+	for idx, childA := range a.Children {
+		childB, ok := b.Children[idx]
+		require.True(t, ok, "missing child at index %d", idx)
+		assertNodeEqual(t, childA, childB)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Property tests
+// ---------------------------------------------------------------------------
+
+// TestTreePathProtoRoundTrip verifies that any tree.Tree survives a
+// round-trip through TreePathFromTree → TreePathToTree. FinalKey is
+// excluded from comparison since the proto does not carry it.
+func TestTreePathProtoRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(rt *rapid.T) {
+		original := genTree(rt)
+		pb, err := TreePathFromTree(original)
+		require.NoError(t, err)
+
+		got, err := TreePathToTree(pb)
+		require.NoError(t, err)
+
+		// FinalKey is derived from CoSigners + SweepTapscriptRoot,
+		// not carried in the proto. Clear on both sides.
+		clearFinalKeys(original.Root)
+		clearFinalKeys(got.Root)
+		assertTreeEqual(t, original, got)
+	})
+}
+
+// TestTreePathProtoNil verifies nil handling in tree path conversion.
+func TestTreePathProtoNil(t *testing.T) {
+	t.Parallel()
+
+	pb, err := TreePathFromTree(nil)
+	require.NoError(t, err)
+	require.Nil(t, pb)
+
+	got, err := TreePathToTree(nil)
+	require.NoError(t, err)
+	require.Nil(t, got)
+}
+
+// TestTreePathOutpointRoundTrip verifies that outpoint conversion
+// between wire.OutPoint and arkrpc.OutPoint is lossless.
+func TestTreePathOutpointRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(rt *rapid.T) {
+		op := genOutpoint(rt)
+		pb := outpointToProto(op)
+
+		got, err := outpointFromProto(pb)
+		require.NoError(t, err)
+		require.Equal(t, op, got)
+	})
+}
+
+// TestTreePathTxOutRoundTrip verifies that TxOut conversion is lossless.
+func TestTreePathTxOutRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(rt *rapid.T) {
+		out := genTxOut(rt)
+		pb := txOutToProto(out)
+		got, err := txOutFromProto(pb)
+		require.NoError(t, err)
+
+		require.Equal(t, out.Value, got.Value)
+		require.Equal(t, out.PkScript, got.PkScript)
+	})
+}

--- a/indexer/AGENTS.md
+++ b/indexer/AGENTS.md
@@ -2,10 +2,21 @@
 
 ## Purpose
 
-Server indexing client for receive script registration, wrapping
-`arkrpc.IndexerServiceMailboxClient` with BIP-340 Schnorr signature proofs.
+Server indexing client for receive script registration and VTXO queries,
+wrapping `arkrpc.IndexerServiceMailboxClient` with BIP-340 Schnorr signature
+proofs for proof-of-control.
+
+## Key Types
+
+- `Client` — Wraps the mailbox RPC client with automatic proof-of-control
+  signing. `WithSigner` returns a shallow copy using a different signer.
+- `SchnorrSigner` — Interface for signing proof-of-control messages.
+  Implementations: `PrivKeySchnorrSigner` (raw key), `LNDSchnorrSigner`
+  (LND wallet), `KeyRingSchnorrSigner` (btcwallet keyring).
+- `ProofPubKey` — Returns the owner pubkey used in proof construction.
+  Added to `SchnorrSigner` implementations for receive script ownership.
 
 ## Relationships
 
 - **Depends on**: `arkrpc` (IndexerService stubs), `serverconn` (mailbox transport).
-- **Depended on by**: `darepod` (wiring).
+- **Depended on by**: `darepod` (wiring, receive script registration, metadata queries).

--- a/indexer/CLAUDE.md
+++ b/indexer/CLAUDE.md
@@ -2,10 +2,21 @@
 
 ## Purpose
 
-Server indexing client for receive script registration, wrapping
-`arkrpc.IndexerServiceMailboxClient` with BIP-340 Schnorr signature proofs.
+Server indexing client for receive script registration and VTXO queries,
+wrapping `arkrpc.IndexerServiceMailboxClient` with BIP-340 Schnorr signature
+proofs for proof-of-control.
+
+## Key Types
+
+- `Client` — Wraps the mailbox RPC client with automatic proof-of-control
+  signing. `WithSigner` returns a shallow copy using a different signer.
+- `SchnorrSigner` — Interface for signing proof-of-control messages.
+  Implementations: `PrivKeySchnorrSigner` (raw key), `LNDSchnorrSigner`
+  (LND wallet), `KeyRingSchnorrSigner` (btcwallet keyring).
+- `ProofPubKey` — Returns the owner pubkey used in proof construction.
+  Added to `SchnorrSigner` implementations for receive script ownership.
 
 ## Relationships
 
 - **Depends on**: `arkrpc` (IndexerService stubs), `serverconn` (mailbox transport).
-- **Depended on by**: `darepod` (wiring).
+- **Depended on by**: `darepod` (wiring, receive script registration, metadata queries).

--- a/indexer/client.go
+++ b/indexer/client.go
@@ -149,6 +149,11 @@ const (
 	// proofTLVTypePurpose identifies the purpose string for
 	// script-scope proofs.
 	proofTLVTypePurpose tlv.Type = 9
+
+	// proofTLVTypeOwnerPubKey identifies the compressed owner pubkey used
+	// to prove control over supported standardized receive scripts such as
+	// VTXO tapscripts.
+	proofTLVTypeOwnerPubKey tlv.Type = 10
 )
 
 // New creates an Indexer client wrapper. The signer is used for all
@@ -161,12 +166,14 @@ func New(rpc mailboxrpc.RPCClient, signer SchnorrSigner,
 		slog.String("server_id", serverID),
 		slog.String("principal", principal))
 
-	return &Client{
+	c := &Client{
 		rpc:       arkrpc.NewIndexerServiceMailboxClient(rpc),
 		signer:    signer,
 		serverID:  serverID,
 		principal: principal,
 	}
+
+	return c
 }
 
 // firstOpt returns the first RPCOptions from opts, or the zero value
@@ -190,13 +197,24 @@ func encodeProofTLV(msgType, serverID, principal, purpose string,
 	pkScript, nonce []byte,
 	issuedAt, expiresAt uint64) ([]byte, error) {
 
+	return encodeProofTLVWithOwner(
+		msgType, serverID, principal, purpose, pkScript, nil,
+		nonce, issuedAt, expiresAt,
+	)
+}
+
+// encodeProofTLVWithOwner encodes a proof message to its canonical TLV byte
+// representation and optionally commits to the script owner pubkey.
+func encodeProofTLVWithOwner(msgType, serverID, principal, purpose string,
+	pkScript, ownerPubKey, nonce []byte,
+	issuedAt, expiresAt uint64) ([]byte, error) {
+
 	proofTypeBytes := []byte(msgType)
 	version := uint32(registrationMessageVersion)
 	serverIDBytes := []byte(serverID)
 	principalBytes := []byte(principal)
 	purposeBytes := []byte(purpose)
-
-	tlvStream, err := tlv.NewStream(
+	records := []tlv.Record{
 		tlv.MakeDynamicRecord(
 			proofTLVTypeType, &proofTypeBytes,
 			tlv.SizeVarBytes(&proofTypeBytes),
@@ -236,7 +254,16 @@ func encodeProofTLV(msgType, serverID, principal, purpose string,
 			tlv.SizeVarBytes(&purposeBytes),
 			tlv.EVarBytes, tlv.DVarBytes,
 		),
-	)
+	}
+	if len(ownerPubKey) > 0 {
+		records = append(records, tlv.MakeDynamicRecord(
+			proofTLVTypeOwnerPubKey, &ownerPubKey,
+			tlv.SizeVarBytes(&ownerPubKey),
+			tlv.EVarBytes, tlv.DVarBytes,
+		))
+	}
+
+	tlvStream, err := tlv.NewStream(records...)
 	if err != nil {
 		return nil, fmt.Errorf("build TLV stream: %w", err)
 	}
@@ -261,6 +288,19 @@ type SchnorrSigner interface {
 	SignSchnorr(pkScript []byte, hash [32]byte) ([]byte, error)
 }
 
+// schnorrMessageSigner signs the canonical proof preimage with the requested
+// tag applied inside the signer.
+type schnorrMessageSigner interface {
+	SignSchnorrMessage(ctx context.Context, pkScript []byte,
+		message []byte, tag []byte) ([]byte, error)
+}
+
+// schnorrProofPubKeySource returns the owner pubkey that should be committed
+// into proofs for the given script.
+type schnorrProofPubKeySource interface {
+	ProofPubKey(pkScript []byte) (*btcec.PublicKey, error)
+}
+
 // PrivKeySchnorrSigner wraps a single btcec.PrivateKey to satisfy
 // SchnorrSigner. It ignores pkScript since it always signs with the
 // same key. Suitable for tests and single-key setups.
@@ -282,6 +322,17 @@ func (s *PrivKeySchnorrSigner) SignSchnorr(
 	return sig.Serialize(), nil
 }
 
+// ProofPubKey returns the public key corresponding to the wrapped private key.
+func (s *PrivKeySchnorrSigner) ProofPubKey(
+	_ []byte) (*btcec.PublicKey, error) {
+
+	if s.Key == nil {
+		return nil, fmt.Errorf("private key not configured")
+	}
+
+	return s.Key.PubKey(), nil
+}
+
 // proofTag returns the BIP-340 tagged hash domain separator for indexer
 // proof signatures. A fresh slice is returned each call to prevent
 // accidental mutation. This must match the server-side ProofTagHash
@@ -290,12 +341,43 @@ func proofTag() []byte {
 	return []byte("darepo/indexer/v1")
 }
 
-// schnorrSigOverMessage returns a 64-byte schnorr signature over a
-// BIP-340 tagged hash of the message. The tag provides domain separation
-// so indexer proof signatures cannot be replayed in other protocols.
-// The pkScript identifies which key the signer should use.
-func schnorrSigOverMessage(message []byte, pkScript []byte,
+// proofOwnerPubKey returns the compressed owner pubkey to include in the
+// signed TLV proof when the signer can identify it.
+func proofOwnerPubKey(pkScript []byte,
 	signer SchnorrSigner) ([]byte, error) {
+
+	pubKeySource, ok := signer.(schnorrProofPubKeySource)
+	if !ok {
+		return nil, nil
+	}
+
+	pubKey, err := pubKeySource.ProofPubKey(pkScript)
+	if err != nil {
+		return nil, err
+	}
+	if pubKey == nil {
+		return nil, nil
+	}
+
+	return pubKey.SerializeCompressed(), nil
+}
+
+// schnorrSigOverMessage returns a 64-byte schnorr signature over a
+// BIP-340 tagged hash of the message. The tag provides domain separation so
+// indexer proof signatures cannot be replayed in other protocols. The
+// pkScript identifies which key the signer should use.
+func schnorrSigOverMessage(ctx context.Context, message []byte,
+	pkScript []byte, signer SchnorrSigner) ([]byte, error) {
+
+	if signer == nil {
+		return nil, fmt.Errorf("schnorr signer not configured")
+	}
+
+	if messageSigner, ok := signer.(schnorrMessageSigner); ok {
+		return messageSigner.SignSchnorrMessage(
+			ctx, pkScript, message, proofTag(),
+		)
+	}
 
 	msgHash := chainhash.TaggedHash(proofTag(), message)
 
@@ -332,10 +414,8 @@ type TaprootScriptScope struct {
 
 // newTaprootScope builds a ScriptScope proto with a TLV-encoded
 // script-scope proof signed via the client's signer.
-func (c *Client) newTaprootScope(
-	pkScript []byte,
-	purpose string,
-) (*arkrpc.ScriptScope, error) {
+func (c *Client) newTaprootScope(ctx context.Context, pkScript []byte,
+	purpose string) (*arkrpc.ScriptScope, error) {
 
 	if err := validateTaprootPkScript(pkScript); err != nil {
 		return nil, err
@@ -346,15 +426,20 @@ func (c *Client) newTaprootScope(
 
 	now := time.Now()
 	expiresAt := now.Add(offlineReceiveProofTTL)
+	ownerPubKey, err := proofOwnerPubKey(pkScript, c.signer)
+	if err != nil {
+		return nil, err
+	}
 
 	nonce, err := randomNonce(registrationNonceBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	msgBytes, err := encodeProofTLV(
+	msgBytes, err := encodeProofTLVWithOwner(
 		scriptScopeMessageType,
-		c.serverID, c.principal, purpose, pkScript, nonce,
+		c.serverID, c.principal, purpose, pkScript, ownerPubKey,
+		nonce,
 		uint64(now.Unix()), uint64(expiresAt.Unix()),
 	)
 	if err != nil {
@@ -362,7 +447,7 @@ func (c *Client) newTaprootScope(
 	}
 
 	sig64, err := schnorrSigOverMessage(
-		msgBytes, pkScript, c.signer,
+		ctx, msgBytes, pkScript, c.signer,
 	)
 	if err != nil {
 		return nil, err
@@ -382,14 +467,14 @@ func (c *Client) newTaprootScope(
 // buildTaprootScopes converts a slice of TaprootScriptScope into
 // proto ScriptScope messages, constructing a signed proof for each
 // entry under the given purpose.
-func (c *Client) buildTaprootScopes(
-	scopes []TaprootScriptScope, purpose string,
-) ([]*arkrpc.ScriptScope, error) {
+func (c *Client) buildTaprootScopes(ctx context.Context,
+	scopes []TaprootScriptScope,
+	purpose string) ([]*arkrpc.ScriptScope, error) {
 
 	out := make([]*arkrpc.ScriptScope, 0, len(scopes))
 	for _, scope := range scopes {
 		ss, err := c.newTaprootScope(
-			scope.PkScript, purpose,
+			ctx, scope.PkScript, purpose,
 		)
 		if err != nil {
 			return nil, err
@@ -416,7 +501,7 @@ func (c *Client) ListVTXOsByScriptsTaproot(ctx context.Context,
 		slog.Int("status_filter_count", len(statusFilter)))
 
 	scriptScopes, err := c.buildTaprootScopes(
-		scopes, purposeListVTXOsByScripts,
+		ctx, scopes, purposeListVTXOsByScripts,
 	)
 	if err != nil {
 		return nil, err
@@ -429,7 +514,12 @@ func (c *Client) ListVTXOsByScriptsTaproot(ctx context.Context,
 		Limit:        limit,
 	}
 
-	return c.rpc.ListVTXOsByScripts(ctx, req, firstOpt(opts))
+	resp, err := c.rpc.ListVTXOsByScripts(ctx, req, firstOpt(opts))
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
 }
 
 // GetSubtreeByScriptsTaproot performs a proof-gated subtree query for
@@ -444,7 +534,7 @@ func (c *Client) GetSubtreeByScriptsTaproot(ctx context.Context,
 		slog.Bool("include_internal_nodes", includeInternalNodes))
 
 	scriptScopes, err := c.buildTaprootScopes(
-		scopes, purposeGetSubtreeByScripts,
+		ctx, scopes, purposeGetSubtreeByScripts,
 	)
 	if err != nil {
 		return nil, err
@@ -471,7 +561,7 @@ func (c *Client) ListVTXOEventsByScriptsTaproot(ctx context.Context,
 		slog.Int("limit", int(limit)))
 
 	scriptScopes, err := c.buildTaprootScopes(
-		scopes, purposeListVTXOEventsByScripts,
+		ctx, scopes, purposeListVTXOEventsByScripts,
 	)
 	if err != nil {
 		return nil, err
@@ -513,6 +603,12 @@ func (c *Client) RegisterReceiveScriptTaproot(ctx context.Context,
 		)
 	}
 
+	proofExpiresAt := now.Add(offlineReceiveProofTTL)
+	ownerPubKey, err := proofOwnerPubKey(pkScript, c.signer)
+	if err != nil {
+		return nil, err
+	}
+
 	// A zero time means "use server default", so we leave the
 	// field at 0 rather than casting time.Time{}.Unix() which
 	// would wrap to a huge uint64. We derive the safe value
@@ -528,18 +624,19 @@ func (c *Client) RegisterReceiveScriptTaproot(ctx context.Context,
 		return nil, err
 	}
 
-	msgBytes, err := encodeProofTLV(
+	msgBytes, err := encodeProofTLVWithOwner(
 		registrationMessageType,
 		c.serverID, c.principal,
-		purposeRegisterReceiveScript, pkScript, nonce,
-		uint64(now.Unix()), uint64(expiresAt.Unix()),
+		purposeRegisterReceiveScript, pkScript, ownerPubKey,
+		nonce,
+		uint64(now.Unix()), uint64(proofExpiresAt.Unix()),
 	)
 	if err != nil {
 		return nil, err
 	}
 
 	sig64, err := schnorrSigOverMessage(
-		msgBytes, pkScript, c.signer,
+		ctx, msgBytes, pkScript, c.signer,
 	)
 	if err != nil {
 		return nil, err
@@ -579,16 +676,21 @@ func (c *Client) UnregisterReceiveScript(ctx context.Context,
 
 	now := time.Now()
 	expiresAt := now.Add(offlineReceiveProofTTL)
+	ownerPubKey, err := proofOwnerPubKey(pkScript, c.signer)
+	if err != nil {
+		return nil, err
+	}
 
 	nonce, err := randomNonce(registrationNonceBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	msgBytes, err := encodeProofTLV(
+	msgBytes, err := encodeProofTLVWithOwner(
 		registrationMessageType,
 		c.serverID, c.principal,
-		purposeUnregisterReceiveScript, pkScript, nonce,
+		purposeUnregisterReceiveScript, pkScript, ownerPubKey,
+		nonce,
 		uint64(now.Unix()), uint64(expiresAt.Unix()),
 	)
 	if err != nil {
@@ -596,7 +698,7 @@ func (c *Client) UnregisterReceiveScript(ctx context.Context,
 	}
 
 	sig64, err := schnorrSigOverMessage(
-		msgBytes, pkScript, c.signer,
+		ctx, msgBytes, pkScript, c.signer,
 	)
 	if err != nil {
 		return nil, err
@@ -648,16 +750,20 @@ func (c *Client) ListOORRecipientEventsByScriptTaproot(
 
 	now := time.Now()
 	expiresAt := now.Add(offlineReceiveProofTTL)
+	ownerPubKey, err := proofOwnerPubKey(pkScript, c.signer)
+	if err != nil {
+		return nil, err
+	}
 
 	nonce, err := randomNonce(registrationNonceBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	msgBytes, err := encodeProofTLV(
+	msgBytes, err := encodeProofTLVWithOwner(
 		scriptScopeMessageType,
 		c.serverID, c.principal,
-		purposeOORRecipientEvents, pkScript,
+		purposeOORRecipientEvents, pkScript, ownerPubKey,
 		nonce, uint64(now.Unix()),
 		uint64(expiresAt.Unix()),
 	)
@@ -666,7 +772,7 @@ func (c *Client) ListOORRecipientEventsByScriptTaproot(
 	}
 
 	sig64, err := schnorrSigOverMessage(
-		msgBytes, pkScript, c.signer,
+		ctx, msgBytes, pkScript, c.signer,
 	)
 	if err != nil {
 		return nil, err

--- a/indexer/client_test.go
+++ b/indexer/client_test.go
@@ -2,13 +2,19 @@ package indexer
 
 import (
 	"bytes"
+	"context"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightninglabs/darepo-client/arkrpc"
+	mailboxrpc "github.com/lightninglabs/darepo-client/mailbox/rpc"
 	"github.com/lightningnetwork/lnd/tlv"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 )
 
 // TestEncodeProofTLVRoundTrip encodes a proof and decodes it via a TLV
@@ -169,7 +175,9 @@ func TestSchnorrSigOverMessageSignVerify(t *testing.T) {
 	msg := []byte("test proof message content")
 
 	signer := &PrivKeySchnorrSigner{Key: priv}
-	sig64, err := schnorrSigOverMessage(msg, nil, signer)
+	sig64, err := schnorrSigOverMessage(
+		context.Background(), msg, nil, signer,
+	)
 	require.NoError(t, err)
 	require.Len(t, sig64, 64)
 
@@ -194,10 +202,14 @@ func TestSchnorrSigOverMessageDeterministic(t *testing.T) {
 	msg := []byte("deterministic signing test")
 
 	signer := &PrivKeySchnorrSigner{Key: priv}
-	sig1, err := schnorrSigOverMessage(msg, nil, signer)
+	sig1, err := schnorrSigOverMessage(
+		context.Background(), msg, nil, signer,
+	)
 	require.NoError(t, err)
 
-	sig2, err := schnorrSigOverMessage(msg, nil, signer)
+	sig2, err := schnorrSigOverMessage(
+		context.Background(), msg, nil, signer,
+	)
 	require.NoError(t, err)
 
 	require.Equal(t, sig1, sig2)
@@ -217,7 +229,9 @@ func TestSchnorrSigOverMessageWrongKeyFails(t *testing.T) {
 	msg := []byte("wrong key test")
 
 	signer1 := &PrivKeySchnorrSigner{Key: priv1}
-	sig64, err := schnorrSigOverMessage(msg, nil, signer1)
+	sig64, err := schnorrSigOverMessage(
+		context.Background(), msg, nil, signer1,
+	)
 	require.NoError(t, err)
 
 	// Parse and verify against the wrong key.
@@ -228,6 +242,99 @@ func TestSchnorrSigOverMessageWrongKeyFails(t *testing.T) {
 	wrongPub := priv2.PubKey()
 	require.False(t, sig.Verify(msgHash[:], wrongPub),
 		"signature must not verify with wrong key")
+}
+
+// TestSchnorrSigOverMessageUsesMessageSigner verifies that the helper prefers
+// the tagged-message signing path when it is available.
+func TestSchnorrSigOverMessageUsesMessageSigner(t *testing.T) {
+	t.Parallel()
+
+	signer := &testMessageSchnorrSigner{
+		result: []byte("message-signed"),
+	}
+	msg := []byte("message signer path")
+	pkScript := []byte{0x51, 0x20, 0x01}
+
+	sig, err := schnorrSigOverMessage(
+		context.Background(), msg, pkScript, signer,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []byte("message-signed"), sig)
+	require.Equal(t, msg, signer.message)
+	require.Equal(t, pkScript, signer.pkScript)
+	require.Equal(t, proofTag(), signer.tag)
+	require.False(t, signer.rawCalled)
+}
+
+// TestRegisterReceiveScriptTaprootUsesShortLivedProof verifies that the
+// registration proof TTL remains short even when the registration retention
+// window is much longer.
+func TestRegisterReceiveScriptTaprootUsesShortLivedProof(t *testing.T) {
+	t.Parallel()
+
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	pkScript := append(
+		[]byte{0x51, 0x20},
+		privKey.PubKey().SerializeCompressed()[1:]...,
+	)
+
+	rpcClient := &recordingRPCClient{}
+	client := New(
+		rpcClient, &PrivKeySchnorrSigner{Key: privKey},
+		"test-server", "client:test",
+	)
+
+	registrationExpiry := time.Now().Add(30 * 24 * time.Hour)
+	_, err = client.RegisterReceiveScriptTaproot(
+		t.Context(), pkScript, registrationExpiry, "oor receive",
+	)
+	require.NoError(t, err)
+
+	req := rpcClient.lastRegisterReceiveScriptRequest(t)
+	require.Equal(
+		t, uint64(registrationExpiry.Unix()), req.ExpiresAtUnixS,
+	)
+
+	decoded := decodeProofTLVBytes(
+		t, req.GetTaprootSchnorr().GetMessage(),
+	)
+	require.Equal(t, purposeRegisterReceiveScript, decoded.purpose)
+	require.Equal(t, uint64(registrationExpiry.Unix()), req.ExpiresAtUnixS)
+	require.NotEqual(t, req.ExpiresAtUnixS, decoded.expiresAt)
+	require.Equal(
+		t, uint64(offlineReceiveProofTTL/time.Second),
+		decoded.expiresAt-decoded.issuedAt,
+	)
+}
+
+type testMessageSchnorrSigner struct {
+	result    []byte
+	message   []byte
+	pkScript  []byte
+	tag       []byte
+	rawCalled bool
+}
+
+// SignSchnorr records an unexpected raw-digest call.
+func (s *testMessageSchnorrSigner) SignSchnorr(
+	_ []byte, _ [32]byte) ([]byte, error) {
+
+	s.rawCalled = true
+
+	return nil, nil
+}
+
+// SignSchnorrMessage records the canonical inputs passed by the helper.
+func (s *testMessageSchnorrSigner) SignSchnorrMessage(_ context.Context,
+	pkScript []byte, message []byte, tag []byte) ([]byte, error) {
+
+	s.message = append([]byte(nil), message...)
+	s.pkScript = append([]byte(nil), pkScript...)
+	s.tag = append([]byte(nil), tag...)
+
+	return append([]byte(nil), s.result...), nil
 }
 
 // TestValidateTaprootPkScript uses a table-driven approach to verify
@@ -339,4 +446,47 @@ func TestProofTagImmutable(t *testing.T) {
 	tag2 := proofTag()
 	require.Equal(t, original, tag2,
 		"mutating one proofTag() return must not affect the next")
+}
+
+type recordingRPCClient struct {
+	mu      sync.Mutex
+	lastReq proto.Message
+}
+
+// SendRPC records the last request and returns a static correlation pair.
+func (r *recordingRPCClient) SendRPC(_ context.Context,
+	_ mailboxrpc.ServiceMethod, req proto.Message,
+	_ mailboxrpc.RPCOptions) (mailboxrpc.SendResult, error) {
+
+	r.mu.Lock()
+	r.lastReq = proto.Clone(req)
+	r.mu.Unlock()
+
+	return mailboxrpc.SendResult{
+		CorrelationID:  "corr-1",
+		IdempotencyKey: "idemp-1",
+	}, nil
+}
+
+// AwaitRPC completes successfully with the zero-value response.
+func (r *recordingRPCClient) AwaitRPC(_ context.Context, _ string,
+	_ proto.Message) error {
+
+	return nil
+}
+
+// lastRegisterReceiveScriptRequest returns the last recorded registration
+// request.
+func (r *recordingRPCClient) lastRegisterReceiveScriptRequest(
+	t *testing.T) *arkrpc.RegisterReceiveScriptRequest {
+
+	t.Helper()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	req, ok := r.lastReq.(*arkrpc.RegisterReceiveScriptRequest)
+	require.True(t, ok)
+
+	return req
 }

--- a/indexer/client_test.go
+++ b/indexer/client_test.go
@@ -176,7 +176,7 @@ func TestSchnorrSigOverMessageSignVerify(t *testing.T) {
 
 	signer := &PrivKeySchnorrSigner{Key: priv}
 	sig64, err := schnorrSigOverMessage(
-		context.Background(), msg, nil, signer,
+		t.Context(), msg, nil, signer,
 	)
 	require.NoError(t, err)
 	require.Len(t, sig64, 64)
@@ -203,12 +203,12 @@ func TestSchnorrSigOverMessageDeterministic(t *testing.T) {
 
 	signer := &PrivKeySchnorrSigner{Key: priv}
 	sig1, err := schnorrSigOverMessage(
-		context.Background(), msg, nil, signer,
+		t.Context(), msg, nil, signer,
 	)
 	require.NoError(t, err)
 
 	sig2, err := schnorrSigOverMessage(
-		context.Background(), msg, nil, signer,
+		t.Context(), msg, nil, signer,
 	)
 	require.NoError(t, err)
 
@@ -230,7 +230,7 @@ func TestSchnorrSigOverMessageWrongKeyFails(t *testing.T) {
 
 	signer1 := &PrivKeySchnorrSigner{Key: priv1}
 	sig64, err := schnorrSigOverMessage(
-		context.Background(), msg, nil, signer1,
+		t.Context(), msg, nil, signer1,
 	)
 	require.NoError(t, err)
 
@@ -256,7 +256,7 @@ func TestSchnorrSigOverMessageUsesMessageSigner(t *testing.T) {
 	pkScript := []byte{0x51, 0x20, 0x01}
 
 	sig, err := schnorrSigOverMessage(
-		context.Background(), msg, pkScript, signer,
+		t.Context(), msg, pkScript, signer,
 	)
 	require.NoError(t, err)
 	require.Equal(t, []byte("message-signed"), sig)

--- a/indexer/security_audit_test.go
+++ b/indexer/security_audit_test.go
@@ -55,7 +55,9 @@ func TestH1_CrossPurposeProofReplay(t *testing.T) {
 	require.NoError(t, err)
 
 	signer := &PrivKeySchnorrSigner{Key: privKey}
-	sig64, err := schnorrSigOverMessage(msgBytes, pkScript, signer)
+	sig64, err := schnorrSigOverMessage(
+		context.Background(), msgBytes, pkScript, signer,
+	)
 	require.NoError(t, err)
 
 	// The attacker now takes the (msgBytes, sig64) pair -- which was
@@ -90,8 +92,9 @@ func TestH1_CrossPurposeProofReplay(t *testing.T) {
 }
 
 // TestH2_RegistrationExpiryMismatch demonstrates that the proto-level
-// ExpiresAtUnixS and the TLV-signed expiresAt can diverge if the caller
-// provides a different value.
+// ExpiresAtUnixS and the TLV-signed expiresAt intentionally diverge for
+// registrations with long retention, and that tampering the outer field widens
+// that divergence further.
 func TestH2_RegistrationExpiryMismatch(t *testing.T) {
 	t.Parallel()
 
@@ -107,13 +110,12 @@ func TestH2_RegistrationExpiryMismatch(t *testing.T) {
 	serverID := "test-server"
 	principal := "client:test"
 
-	// The caller wants the registration to expire in 1 hour.
+	// The caller wants the registration to remain registered for 1 hour.
 	callerExpiry := time.Now().Add(1 * time.Hour)
 
-	// But the TLV proof is signed with the client's own timestamp
-	// logic. In RegisterReceiveScriptTaproot, the proof's expiresAt
-	// is uint64(expiresAt.Unix()) where expiresAt = the caller arg.
-	// The proto also carries ExpiresAtUnixS = uint64(expiresAt.Unix()).
+	// The real client signs the TLV proof with a short replay window while
+	// the outer request keeps the longer registration-retention deadline.
+	proofExpiry := time.Now().Add(offlineReceiveProofTTL)
 	//
 	// Now consider: an attacker intercepts the wire proto and modifies
 	// the outer ExpiresAtUnixS to a much later time.
@@ -125,12 +127,14 @@ func TestH2_RegistrationExpiryMismatch(t *testing.T) {
 		registrationMessageType,
 		serverID, principal,
 		purposeRegisterReceiveScript, pkScript, nonce,
-		uint64(now.Unix()), uint64(callerExpiry.Unix()),
+		uint64(now.Unix()), uint64(proofExpiry.Unix()),
 	)
 	require.NoError(t, err)
 
 	signer := &PrivKeySchnorrSigner{Key: privKey}
-	sig64, err := schnorrSigOverMessage(msgBytes, pkScript, signer)
+	sig64, err := schnorrSigOverMessage(
+		context.Background(), msgBytes, pkScript, signer,
+	)
 	require.NoError(t, err)
 
 	// Build the registration request as the honest client would.
@@ -154,9 +158,8 @@ func TestH2_RegistrationExpiryMismatch(t *testing.T) {
 		callerExpiry.Add(365 * 24 * time.Hour).Unix(),
 	)
 
-	// The signature is still valid -- it signed the TLV payload
-	// which has the original expiresAt. But the request-level
-	// ExpiresAtUnixS is now 1 year later.
+	// The signature is still valid because it covers the TLV payload
+	// only. The request-level ExpiresAtUnixS is now 1 year later.
 	tlvExpiry := decodeProofTLVBytes(t, msgBytes).expiresAt
 
 	require.NotEqual(t, tamperedReq.ExpiresAtUnixS, tlvExpiry,
@@ -228,7 +231,9 @@ func TestM1_ProofReplayWithinTTL(t *testing.T) {
 	require.NoError(t, err)
 
 	signer := &PrivKeySchnorrSigner{Key: privKey}
-	sig64, err := schnorrSigOverMessage(msgBytes, pkScript, signer)
+	sig64, err := schnorrSigOverMessage(
+		context.Background(), msgBytes, pkScript, signer,
+	)
 	require.NoError(t, err)
 
 	// Replay the exact same proof 100 times. Each is
@@ -579,7 +584,9 @@ func TestH4_CrossTypeProofConfusion(t *testing.T) {
 	require.NoError(t, err)
 
 	signer := &PrivKeySchnorrSigner{Key: privKey}
-	regSig, err := schnorrSigOverMessage(regMsg, pkScript, signer)
+	regSig, err := schnorrSigOverMessage(
+		context.Background(), regMsg, pkScript, signer,
+	)
 	require.NoError(t, err)
 
 	// Package the registration proof into a ScriptScope envelope
@@ -650,7 +657,7 @@ func TestM5_PkScriptEnvelopeMismatch(t *testing.T) {
 
 	signer := &PrivKeySchnorrSigner{Key: privKey}
 	sig64, err := schnorrSigOverMessage(
-		msgBytes, ownedScript, signer,
+		context.Background(), msgBytes, ownedScript, signer,
 	)
 	require.NoError(t, err)
 
@@ -687,15 +694,16 @@ func TestM5_PkScriptEnvelopeMismatch(t *testing.T) {
 
 // decodedProof holds all fields decoded from a proof TLV message.
 type decodedProof struct {
-	proofType string
-	version   uint32
-	serverID  string
-	principal string
-	pkScript  []byte
-	issuedAt  uint64
-	expiresAt uint64
-	nonce     []byte
-	purpose   string
+	proofType   string
+	version     uint32
+	serverID    string
+	principal   string
+	pkScript    []byte
+	ownerPubKey []byte
+	issuedAt    uint64
+	expiresAt   uint64
+	nonce       []byte
+	purpose     string
 
 	// hasPurpose indicates whether the purpose field was present
 	// in the TLV stream.
@@ -716,6 +724,7 @@ func decodeProofTLVBytes(
 		serverIDBytes  []byte
 		principalBytes []byte
 		pkScript       []byte
+		ownerPubKey    []byte
 		issuedAt       uint64
 		expiresAt      uint64
 		nonce          []byte
@@ -762,6 +771,11 @@ func decodeProofTLVBytes(
 			tlv.SizeVarBytes(&purposeBytes),
 			tlv.EVarBytes, tlv.DVarBytes,
 		),
+		tlv.MakeDynamicRecord(
+			proofTLVTypeOwnerPubKey, &ownerPubKey,
+			tlv.SizeVarBytes(&ownerPubKey),
+			tlv.EVarBytes, tlv.DVarBytes,
+		),
 	)
 	require.NoError(t, err)
 
@@ -772,16 +786,17 @@ func decodeProofTLVBytes(
 	_, hasPurpose := parsedTypes[proofTLVTypePurpose]
 
 	return decodedProof{
-		proofType:  string(proofType),
-		version:    version,
-		serverID:   string(serverIDBytes),
-		principal:  string(principalBytes),
-		pkScript:   pkScript,
-		issuedAt:   issuedAt,
-		expiresAt:  expiresAt,
-		nonce:      nonce,
-		purpose:    string(purposeBytes),
-		hasPurpose: hasPurpose,
+		proofType:   string(proofType),
+		version:     version,
+		serverID:    string(serverIDBytes),
+		principal:   string(principalBytes),
+		pkScript:    pkScript,
+		ownerPubKey: ownerPubKey,
+		issuedAt:    issuedAt,
+		expiresAt:   expiresAt,
+		nonce:       nonce,
+		purpose:     string(purposeBytes),
+		hasPurpose:  hasPurpose,
 	}
 }
 
@@ -795,6 +810,7 @@ func extractPurposeFromTLVSafe(msg []byte) string {
 		serverIDBytes  []byte
 		principalBytes []byte
 		pkScript       []byte
+		ownerPubKey    []byte
 		issuedAt       uint64
 		expiresAt      uint64
 		nonce          []byte
@@ -839,6 +855,11 @@ func extractPurposeFromTLVSafe(msg []byte) string {
 		tlv.MakeDynamicRecord(
 			proofTLVTypePurpose, &purposeBytes,
 			tlv.SizeVarBytes(&purposeBytes),
+			tlv.EVarBytes, tlv.DVarBytes,
+		),
+		tlv.MakeDynamicRecord(
+			proofTLVTypeOwnerPubKey, &ownerPubKey,
+			tlv.SizeVarBytes(&ownerPubKey),
 			tlv.EVarBytes, tlv.DVarBytes,
 		),
 	)

--- a/indexer/security_audit_test.go
+++ b/indexer/security_audit_test.go
@@ -56,7 +56,7 @@ func TestH1_CrossPurposeProofReplay(t *testing.T) {
 
 	signer := &PrivKeySchnorrSigner{Key: privKey}
 	sig64, err := schnorrSigOverMessage(
-		context.Background(), msgBytes, pkScript, signer,
+		t.Context(), msgBytes, pkScript, signer,
 	)
 	require.NoError(t, err)
 
@@ -133,7 +133,7 @@ func TestH2_RegistrationExpiryMismatch(t *testing.T) {
 
 	signer := &PrivKeySchnorrSigner{Key: privKey}
 	sig64, err := schnorrSigOverMessage(
-		context.Background(), msgBytes, pkScript, signer,
+		t.Context(), msgBytes, pkScript, signer,
 	)
 	require.NoError(t, err)
 
@@ -232,7 +232,7 @@ func TestM1_ProofReplayWithinTTL(t *testing.T) {
 
 	signer := &PrivKeySchnorrSigner{Key: privKey}
 	sig64, err := schnorrSigOverMessage(
-		context.Background(), msgBytes, pkScript, signer,
+		t.Context(), msgBytes, pkScript, signer,
 	)
 	require.NoError(t, err)
 
@@ -585,7 +585,7 @@ func TestH4_CrossTypeProofConfusion(t *testing.T) {
 
 	signer := &PrivKeySchnorrSigner{Key: privKey}
 	regSig, err := schnorrSigOverMessage(
-		context.Background(), regMsg, pkScript, signer,
+		t.Context(), regMsg, pkScript, signer,
 	)
 	require.NoError(t, err)
 
@@ -657,7 +657,7 @@ func TestM5_PkScriptEnvelopeMismatch(t *testing.T) {
 
 	signer := &PrivKeySchnorrSigner{Key: privKey}
 	sig64, err := schnorrSigOverMessage(
-		context.Background(), msgBytes, ownedScript, signer,
+		t.Context(), msgBytes, ownedScript, signer,
 	)
 	require.NoError(t, err)
 

--- a/indexer/signer_adapters.go
+++ b/indexer/signer_adapters.go
@@ -1,0 +1,172 @@
+package indexer
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/lightninglabs/lndclient"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/lnrpc/signrpc"
+)
+
+// KeyRingSchnorrSigner adapts a keychain.SecretKeyRing to SchnorrSigner for a
+// fixed key descriptor.
+type KeyRingSchnorrSigner struct {
+	keyRing keychain.SecretKeyRing
+	keyDesc keychain.KeyDescriptor
+}
+
+// NewKeyRingSchnorrSigner creates a Schnorr signer backed by a local secret
+// key ring.
+func NewKeyRingSchnorrSigner(keyRing keychain.SecretKeyRing,
+	keyDesc keychain.KeyDescriptor) *KeyRingSchnorrSigner {
+
+	return &KeyRingSchnorrSigner{
+		keyRing: keyRing,
+		keyDesc: keyDesc,
+	}
+}
+
+// SignSchnorr signs the provided 32-byte digest with the configured key.
+func (s *KeyRingSchnorrSigner) SignSchnorr(
+	_ []byte, hash [32]byte) ([]byte, error) {
+
+	if s.keyRing == nil {
+		return nil, fmt.Errorf("secret key ring not configured")
+	}
+
+	privKey, err := s.keyRing.DerivePrivKey(s.keyDesc)
+	if err != nil {
+		return nil, fmt.Errorf("derive private key: %w", err)
+	}
+
+	sig, err := schnorr.Sign(privKey, hash[:])
+	if err != nil {
+		return nil, fmt.Errorf("sign digest: %w", err)
+	}
+
+	return sig.Serialize(), nil
+}
+
+// ProofPubKey returns the configured owner pubkey.
+func (s *KeyRingSchnorrSigner) ProofPubKey(
+	_ []byte) (*btcec.PublicKey, error) {
+
+	if s.keyDesc.PubKey == nil {
+		return nil, fmt.Errorf("key descriptor pubkey not configured")
+	}
+
+	return s.keyDesc.PubKey, nil
+}
+
+// SignSchnorrMessage signs the canonical proof preimage using the key ring's
+// tagged-hash Schnorr signing path.
+func (s *KeyRingSchnorrSigner) SignSchnorrMessage(ctx context.Context,
+	_ []byte, message []byte, tag []byte) ([]byte, error) {
+
+	_ = ctx
+
+	if s.keyRing == nil {
+		return nil, fmt.Errorf("secret key ring not configured")
+	}
+
+	sig, err := s.keyRing.SignMessageSchnorr(
+		s.keyDesc.KeyLocator, message, false, nil, tag,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("sign tagged message: %w", err)
+	}
+
+	return sig.Serialize(), nil
+}
+
+// LNDSchnorrSigner adapts lnd's signrpc client to SchnorrSigner for a
+// fixed key descriptor. When TapTweak is set, signatures are produced
+// with the tweaked key (taproot output key) rather than the raw
+// internal key.
+type LNDSchnorrSigner struct {
+	signer  lndclient.SignerClient
+	keyDesc keychain.KeyDescriptor
+
+	// TapTweak is the tapscript merkle root used to tweak the
+	// internal key into the taproot output key. When nil, the
+	// raw internal key is used (keyspend-only P2TR). When set,
+	// signatures verify against P2TR(internalKey, tapTweak).
+	TapTweak []byte
+}
+
+// NewLNDSchnorrSigner creates a Schnorr signer backed by lnd signrpc.
+func NewLNDSchnorrSigner(signer lndclient.SignerClient,
+	keyDesc keychain.KeyDescriptor) *LNDSchnorrSigner {
+
+	return &LNDSchnorrSigner{
+		signer:  signer,
+		keyDesc: keyDesc,
+	}
+}
+
+// WithTapTweak returns a copy of the signer with the given tapscript
+// merkle root tweak. The resulting signer produces signatures that
+// verify against the tweaked taproot output key.
+func (s *LNDSchnorrSigner) WithTapTweak(
+	tweak []byte) *LNDSchnorrSigner {
+
+	return &LNDSchnorrSigner{
+		signer:   s.signer,
+		keyDesc:  s.keyDesc,
+		TapTweak: tweak,
+	}
+}
+
+// SignSchnorr returns an error because lnd's signrpc does not expose a raw
+// digest Schnorr signing RPC for arbitrary prehashed messages.
+func (s *LNDSchnorrSigner) SignSchnorr(
+	_ []byte, _ [32]byte) ([]byte, error) {
+
+	return nil, fmt.Errorf("raw digest schnorr signing is not supported " +
+		"by lnd signrpc")
+}
+
+// ProofPubKey returns the configured owner pubkey.
+func (s *LNDSchnorrSigner) ProofPubKey(
+	_ []byte) (*btcec.PublicKey, error) {
+
+	if s.keyDesc.PubKey == nil {
+		return nil, fmt.Errorf("key descriptor pubkey not configured")
+	}
+
+	return s.keyDesc.PubKey, nil
+}
+
+// SignSchnorrMessage signs the canonical proof preimage using lnd's tagged
+// message Schnorr signing RPC.
+func (s *LNDSchnorrSigner) SignSchnorrMessage(ctx context.Context,
+	_ []byte, message []byte, tag []byte) ([]byte, error) {
+
+	if s.signer == nil {
+		return nil, fmt.Errorf("lnd signer client not configured")
+	}
+
+	sig, err := s.signer.SignMessage(
+		ctx, message, s.keyDesc.KeyLocator,
+		lndclient.SignSchnorr(s.TapTweak),
+		withSchnorrTag(tag),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("sign tagged message via lnd: %w", err)
+	}
+
+	return sig, nil
+}
+
+// withSchnorrTag applies a BIP-340 tag to lnd's SignMessage request.
+func withSchnorrTag(tag []byte) lndclient.SignMessageOption {
+	return func(req *signrpc.SignMessageReq) {
+		req.Tag = tag
+	}
+}
+
+var _ SchnorrSigner = (*KeyRingSchnorrSigner)(nil)
+var _ SchnorrSigner = (*LNDSchnorrSigner)(nil)

--- a/rpc/roundpb/convert.go
+++ b/rpc/roundpb/convert.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -293,8 +294,18 @@ func flattenNode(n *tree.Node, nodes *[]*TreeNode,
 
 	*nodes = append(*nodes, protoNode)
 
-	// Recurse into children.
-	for outIdx, child := range n.Children {
+	// Recurse into children in deterministic order so the
+	// flattened output is stable across runs.
+	childIndices := make([]uint32, 0, len(n.Children))
+	for outIdx := range n.Children {
+		childIndices = append(childIndices, outIdx)
+	}
+	sort.Slice(childIndices, func(i, j int) bool {
+		return childIndices[i] < childIndices[j]
+	})
+
+	for _, outIdx := range childIndices {
+		child := n.Children[outIdx]
 		if err := flattenNode(
 			child, nodes, index,
 		); err != nil {


### PR DESCRIPTION
In this PR, we extend the indexer proto surface with the fields needed for
client-side OOR receive. The `OORRecipientEvent` message gains `ark_psbt`
(field 6) and `checkpoint_psbts` (field 7) so the client can construct
`IncomingTransferEvent` from a single indexer query rather than requiring a
separate package-fetch RPC.

We also replace the opaque `bytes tree_path_tlv` field on the `VTXO` message
with a structured `TreePath` proto (field 16). The new `TreePath`, `TreePathNode`,
and `TxOut` messages in `indexer.proto` mirror the `tree.Tree` domain type,
giving the wire format proper field-level visibility instead of hiding the
commitment lineage behind an opaque TLV blob. The conversion utilities live in
`arkrpc/tree_path_convert.go` with property-based round-trip tests (via
`pgregory.net/rapid`) confirming lossless `tree.Tree` ↔ `arkrpc.TreePath`
conversion across 100 random trees per test case.

The second commit adds owner-pubkey TLV proof support to the indexer client.
`RegisterReceiveScript` now attaches a proof-of-control signature so the
server can verify the caller actually owns the receive script being
registered. `NewOwnedReceiveScriptSigner` and the `ProofPubKey` adapter in
`indexer/signer_adapters.go` handle the signing plumbing.

See each commit message for a detailed description w.r.t the incremental
changes.