### PR TITLE
serverconn+mailbox: durable unary request path and transport-native queries

### DIFF
--- a/mailbox/conn/response_registry.go
+++ b/mailbox/conn/response_registry.go
@@ -51,6 +51,36 @@ type ResponseRegistry struct {
 	waiterTTL time.Duration
 }
 
+// DeliveryResult reports how DeliverResponse handled a response envelope.
+type DeliveryResult uint8
+
+const (
+	// DeliveryDropped indicates the response could not be stored or
+	// delivered.
+	DeliveryDropped DeliveryResult = iota
+
+	// DeliveryWaiter indicates the response completed an active waiter.
+	DeliveryWaiter
+
+	// DeliveryBuffered indicates the response was buffered because
+	// no waiter was registered yet.
+	DeliveryBuffered
+)
+
+// String returns a human-readable label for the delivery result.
+func (d DeliveryResult) String() string {
+	switch d {
+	case DeliveryDropped:
+		return "dropped"
+	case DeliveryWaiter:
+		return "waiter"
+	case DeliveryBuffered:
+		return "buffered"
+	default:
+		return "unknown"
+	}
+}
+
 // NewResponseRegistry constructs a response registry with stale-state cleanup.
 func NewResponseRegistry(waiterTTL time.Duration) *ResponseRegistry {
 	if waiterTTL <= 0 {
@@ -114,6 +144,14 @@ func (r *ResponseRegistry) RemoveWaiter(id CorrelationID) {
 	}
 }
 
+// RemovePending drops any buffered early response for the correlation ID.
+func (r *ResponseRegistry) RemovePending(id CorrelationID) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	delete(r.pending, id)
+}
+
 // DeliverResponse delivers a response envelope for correlation ID id.
 //
 // If a waiter exists, the promise is completed with the envelope. If a waiter
@@ -121,10 +159,10 @@ func (r *ResponseRegistry) RemoveWaiter(id CorrelationID) {
 // call still receives it.
 func (r *ResponseRegistry) DeliverResponse(
 	id CorrelationID, env *mailboxpb.Envelope,
-) bool {
+) DeliveryResult {
 
 	if env == nil {
-		return false
+		return DeliveryDropped
 	}
 
 	r.mu.Lock()
@@ -135,16 +173,16 @@ func (r *ResponseRegistry) DeliverResponse(
 	if waiter, ok := r.waiters[id]; ok {
 		waiter.Promise.Complete(fn.Ok(env))
 
-		return true
+		return DeliveryWaiter
 	}
 
 	if _, exists := r.pending[id]; exists {
-		return true
+		return DeliveryBuffered
 	}
 
 	responseCopy, ok := proto.Clone(env).(*mailboxpb.Envelope)
 	if !ok {
-		return false
+		return DeliveryDropped
 	}
 
 	r.pending[id] = &bufferedResponse{
@@ -152,7 +190,7 @@ func (r *ResponseRegistry) DeliverResponse(
 		Created:  time.Now(),
 	}
 
-	return true
+	return DeliveryBuffered
 }
 
 // pruneStaleLocked removes stale waiters and buffered responses. Stale

--- a/mailbox/conn/response_registry_property_test.go
+++ b/mailbox/conn/response_registry_property_test.go
@@ -107,10 +107,10 @@ func TestResponseRegistry_Interleavings_Property(t *testing.T) {
 					rapid.Int().Draw(rt, "msg_rand"),
 				)
 
-				ok := registry.DeliverResponse(
+				result := registry.DeliverResponse(
 					id, &mailboxpb.Envelope{MsgId: msgID},
 				)
-				if !ok {
+				if result == DeliveryDropped {
 					rt.Fatalf("delivery failed")
 				}
 

--- a/mailbox/conn/response_registry_test.go
+++ b/mailbox/conn/response_registry_test.go
@@ -20,7 +20,7 @@ func TestResponseRegistry_DeliverBeforeRegister(t *testing.T) {
 	}
 
 	delivered := registry.DeliverResponse(id, env)
-	require.True(t, delivered)
+	require.Equal(t, DeliveryBuffered, delivered)
 
 	future := registry.RegisterWaiter(id)
 
@@ -41,7 +41,7 @@ func TestResponseRegistry_RegisterThenDeliver(t *testing.T) {
 	delivered := registry.DeliverResponse(id, &mailboxpb.Envelope{
 		MsgId: "msg-2",
 	})
-	require.True(t, delivered)
+	require.Equal(t, DeliveryWaiter, delivered)
 
 	got := future.Await(t.Context()).UnwrapOrFail(t)
 	require.Equal(t, "msg-2", got.MsgId)
@@ -55,9 +55,9 @@ func TestResponseRegistry_TTLPrunesPending(t *testing.T) {
 	registry := NewResponseRegistry(5 * time.Millisecond)
 	id := CorrelationID("corr-3")
 
-	require.True(t, registry.DeliverResponse(id, &mailboxpb.Envelope{
-		MsgId: "stale",
-	}))
+	require.Equal(t, DeliveryBuffered, registry.DeliverResponse(
+		id, &mailboxpb.Envelope{MsgId: "stale"},
+	))
 
 	time.Sleep(20 * time.Millisecond)
 
@@ -114,5 +114,6 @@ func TestResponseRegistry_DeliverNilReturnsFalse(t *testing.T) {
 	t.Parallel()
 
 	registry := NewResponseRegistry(time.Minute)
-	require.False(t, registry.DeliverResponse("any", nil))
+	require.Equal(t, DeliveryDropped, registry.DeliverResponse("any",
+		nil))
 }

--- a/serverconn/AGENTS.md
+++ b/serverconn/AGENTS.md
@@ -10,9 +10,12 @@ background ingress polling with event routing.
 
 - `Runtime` — Main entry point wrapping DurableActor, ServerConnectionActor, and UnaryFacade.
 - `ServerConnectionActor` — Core behavior handling egress messages and the ingress loop.
-- `UnaryFacade` — Implements `mailboxrpc.RPCClient` for generated RPC stubs (low-latency path).
-- `ConnectorConfig` — Wiring configuration (edge address, mailbox IDs, dispatchers, store).
+- `UnaryFacade` — Implements `mailboxrpc.RPCClient` for generated RPC stubs (low-latency path). Also provides `AwaitRPCTimeout` for bounded waits.
+- `ConnectorConfig` — Wiring configuration (edge address, mailbox IDs, dispatchers, store, durable unary builder).
 - `AckState` — Four-cursor watermark state machine (PullCursor, DispatchCommittedTo, AckTarget, AckCommittedTo).
+- `SendUnaryRequest` — Durable typed unary request that becomes a real unary RPC after commit. The response arrives via KIND_RESPONSE and, if no in-memory waiter exists, falls back to durable route dispatch via the EventRouter.
+- `DurableUnaryBuilder` — Proof-gated request-body builder used by transport-native durable query messages.
+- `SendListOORRecipientEventsByScriptRequest` / `SendListVTXOsByScriptsRequest` — transport-native durable indexer query messages emitted by OOR receive.
 
 ## Relationships
 
@@ -21,6 +24,7 @@ background ingress polling with event routing.
 - **Sends (egress → remote mailbox)**:
   - `SendClientEventRequest` (durable): wraps `JoinRoundRequest`, `SubmitNoncesRequest`, `SubmitPartialSigRequest`, `SubmitForfeitSigRequest`
   - `SendRPCRequest` (unary, non-durable): low-latency request-response RPCs
+  - transport-native durable query messages for proof-gated indexer lookups
 - **Routes (ingress → local actors via EventRouter)**:
   - → `round`: `CommitmentTxBuilt`, `NoncesAggregated`, `OperatorSigned`, `RoundJoined`, `BoardingFailed`
   - → `oor`: `SubmitAcceptedEvent`, `FinalizeAcceptedEvent`, `IncomingTransferEvent`
@@ -31,7 +35,8 @@ background ingress polling with event routing.
 ## Invariants
 
 - Ack watermark only advances AFTER durable local dispatch commit (prevents message loss on crash).
-- Unary RPC responses use in-memory registry (no durability); on crash, callers retry with fresh correlation IDs.
+- Unary RPC responses use in-memory registry first; if no waiter exists (crash replay), the ingress falls back to durable EventRouter dispatch. The ResponseRegistry returns a tri-state delivery result (waiter/buffered/dropped) so the ingress knows whether to route durably.
+- `SendClientEventRequest` auto-derives `Service`/`Method` from `Message.ServiceMethod()` when callers leave them empty, preventing silent drops.
 - Idempotency keys are derived from message payload hash; same key on retry enables server deduplication.
 - Ingress loop checkpoints pull cursor and ack state; on restart, resumes from checkpoint.
 

--- a/serverconn/CLAUDE.md
+++ b/serverconn/CLAUDE.md
@@ -10,9 +10,12 @@ background ingress polling with event routing.
 
 - `Runtime` — Main entry point wrapping DurableActor, ServerConnectionActor, and UnaryFacade.
 - `ServerConnectionActor` — Core behavior handling egress messages and the ingress loop.
-- `UnaryFacade` — Implements `mailboxrpc.RPCClient` for generated RPC stubs (low-latency path).
-- `ConnectorConfig` — Wiring configuration (edge address, mailbox IDs, dispatchers, store).
+- `UnaryFacade` — Implements `mailboxrpc.RPCClient` for generated RPC stubs (low-latency path). Also provides `AwaitRPCTimeout` for bounded waits.
+- `ConnectorConfig` — Wiring configuration (edge address, mailbox IDs, dispatchers, store, durable unary builder).
 - `AckState` — Four-cursor watermark state machine (PullCursor, DispatchCommittedTo, AckTarget, AckCommittedTo).
+- `SendUnaryRequest` — Durable typed unary request that becomes a real unary RPC after commit. The response arrives via KIND_RESPONSE and, if no in-memory waiter exists, falls back to durable route dispatch via the EventRouter.
+- `DurableUnaryBuilder` — Proof-gated request-body builder used by transport-native durable query messages.
+- `SendListOORRecipientEventsByScriptRequest` / `SendListVTXOsByScriptsRequest` — transport-native durable indexer query messages emitted by OOR receive.
 
 ## Relationships
 
@@ -21,6 +24,7 @@ background ingress polling with event routing.
 - **Sends (egress → remote mailbox)**:
   - `SendClientEventRequest` (durable): wraps `JoinRoundRequest`, `SubmitNoncesRequest`, `SubmitPartialSigRequest`, `SubmitForfeitSigRequest`
   - `SendRPCRequest` (unary, non-durable): low-latency request-response RPCs
+  - transport-native durable query messages for proof-gated indexer lookups
 - **Routes (ingress → local actors via EventRouter)**:
   - → `round`: `CommitmentTxBuilt`, `NoncesAggregated`, `OperatorSigned`, `RoundJoined`, `BoardingFailed`
   - → `oor`: `SubmitAcceptedEvent`, `FinalizeAcceptedEvent`, `IncomingTransferEvent`
@@ -31,7 +35,8 @@ background ingress polling with event routing.
 ## Invariants
 
 - Ack watermark only advances AFTER durable local dispatch commit (prevents message loss on crash).
-- Unary RPC responses use in-memory registry (no durability); on crash, callers retry with fresh correlation IDs.
+- Unary RPC responses use in-memory registry first; if no waiter exists (crash replay), the ingress falls back to durable EventRouter dispatch. The ResponseRegistry returns a tri-state delivery result (waiter/buffered/dropped) so the ingress knows whether to route durably.
+- `SendClientEventRequest` auto-derives `Service`/`Method` from `Message.ServiceMethod()` when callers leave them empty, preventing silent drops.
 - Idempotency keys are derived from message payload hash; same key on retry enables server deduplication.
 - Ingress loop checkpoints pull cursor and ack state; on restart, resumes from checkpoint.
 

--- a/serverconn/actor.go
+++ b/serverconn/actor.go
@@ -178,6 +178,8 @@ func (m *SendClientEventRequest) Encode(w io.Writer) error {
 		return fmt.Errorf("convert to proto: %w", err)
 	}
 
+	service, method := eventRoutingMetadata(m)
+
 	anyMsg, err := anypb.New(protoMsg)
 	if err != nil {
 		return fmt.Errorf("wrap proto in Any: %w", err)
@@ -215,10 +217,10 @@ func (m *SendClientEventRequest) Encode(w io.Writer) error {
 		idempotencyBytes,
 	)
 	svcRec := tlv.NewPrimitiveRecord[rpcServiceRecordTLV](
-		[]byte(m.Service),
+		[]byte(service),
 	)
 	methodRec := tlv.NewPrimitiveRecord[rpcMethodRecordTLV](
-		[]byte(m.Method),
+		[]byte(method),
 	)
 
 	stream, err := tlv.NewStream(
@@ -493,6 +495,8 @@ func (a *ServerConnectionActor) handleSendClientEvent(ctx context.Context,
 		}
 	}
 
+	service, method := eventRoutingMetadata(req)
+
 	envelope := &mailboxpb.Envelope{
 		ProtocolVersion: a.cfg.ProtocolVersion,
 		MsgId:           msgID,
@@ -503,8 +507,8 @@ func (a *ServerConnectionActor) handleSendClientEvent(ctx context.Context,
 		Body:            body,
 		Rpc: &mailboxpb.RpcMeta{
 			Kind:    mailboxpb.RpcMeta_KIND_EVENT,
-			Service: req.Service,
-			Method:  req.Method,
+			Service: service,
+			Method:  method,
 			ReplyTo: a.cfg.LocalMailboxID,
 		},
 	}
@@ -536,6 +540,36 @@ func (a *ServerConnectionActor) handleSendClientEvent(ctx context.Context,
 	return fn.Ok[ServerConnResp](&SendClientEventResponse{
 		Success: true,
 	})
+}
+
+// eventRoutingMetadata returns the outbound routing metadata persisted on a
+// SendClientEventRequest. When callers leave Service/Method empty, we derive
+// them directly from the wrapped ServerMessage so direct sends remain aligned
+// with the production round-actor outbox path.
+func eventRoutingMetadata(req *SendClientEventRequest) (string, string) {
+	if req == nil {
+		return "", ""
+	}
+
+	if req.Service != "" && req.Method != "" {
+		return req.Service, req.Method
+	}
+
+	if req.Message == nil {
+		return req.Service, req.Method
+	}
+
+	sm := req.Message.ServiceMethod()
+	service := req.Service
+	method := req.Method
+	if service == "" {
+		service = sm.Service
+	}
+	if method == "" {
+		method = sm.Method
+	}
+
+	return service, method
 }
 
 // handleSendRPCRequest sends a pre-built unary RPC envelope via the mailbox

--- a/serverconn/actor.go
+++ b/serverconn/actor.go
@@ -598,13 +598,13 @@ func (a *ServerConnectionActor) Receive(ctx context.Context,
 	case *SendUnaryRequest:
 		return a.handleSendUnaryRequest(ctx, m)
 
-	case *SendListOORRecipientEventsByScriptRequest:
-		return a.handleSendListOORRecipientEventsByScriptRequest(
-			ctx, m,
-		)
+	case DurableUnaryQuery:
+		unary, buildErr := a.buildDurableUnary(ctx, m)
+		if buildErr != nil {
+			return fn.Err[ServerConnResp](buildErr)
+		}
 
-	case *SendListVTXOsByScriptsRequest:
-		return a.handleSendListVTXOsByScriptsRequest(ctx, m)
+		return a.handleSendUnaryRequest(ctx, unary)
 
 	case *SendRPCRequest:
 		return a.handleSendRPCRequest(ctx, m)
@@ -768,151 +768,53 @@ func (a *ServerConnectionActor) handleSendUnaryRequest(ctx context.Context,
 	)
 }
 
-// handleSendListOORRecipientEventsByScriptRequest builds and sends a durable
-// proof-gated indexer unary request for one taproot output script.
-func (a *ServerConnectionActor) handleSendListOORRecipientEventsByScriptRequest(
-	ctx context.Context, req *SendListOORRecipientEventsByScriptRequest,
-) fn.Result[ServerConnResp] {
-
-	if req == nil {
-		return fn.Err[ServerConnResp](fmt.Errorf(
-			"recipient-events query must be provided",
-		))
-	}
+// buildDurableUnary converts a DurableUnaryQuery into a SendUnaryRequest by
+// calling the query's BuildBody with the configured DurableUnaryRequestBuilder.
+// The returned SendUnaryRequest can be passed directly to
+// handleSendUnaryRequest.
+func (a *ServerConnectionActor) buildDurableUnary(ctx context.Context,
+	q DurableUnaryQuery) (*SendUnaryRequest, error) {
 
 	if a.cfg.DurableUnaryBuilder == nil {
-		return fn.Err[ServerConnResp](fmt.Errorf(
+		return nil, fmt.Errorf(
 			"durable unary builder must be provided",
-		))
-	}
-
-	protoReq, err := a.cfg.DurableUnaryBuilder.
-		BuildListOORRecipientEventsByScriptRequest(
-			ctx, req.PkScript, req.AfterEventID, req.Limit,
 		)
-	if err != nil {
-		return fn.Err[ServerConnResp](fmt.Errorf(
-			"build recipient-events request: %w", err,
-		))
 	}
 
-	body, err := anypb.New(protoReq)
-	if err != nil {
-		return fn.Err[ServerConnResp](fmt.Errorf(
-			"wrap recipient-events request in Any: %w", err,
-		))
-	}
-
-	if req.CorrelationID == "" {
-		return fn.Err[ServerConnResp](fmt.Errorf(
-			"recipient-events query requires a " +
-				"correlation ID",
-		))
-	}
-
-	stableBytes, err := encodeRecipientEventsQueryIdentity(
-		req.PkScript, req.AfterEventID, req.Limit,
-		req.CorrelationID,
-	)
-	if err != nil {
-		return fn.Err[ServerConnResp](fmt.Errorf(
-			"encode recipient-events identity: %w", err,
-		))
-	}
-
-	msgID, idempotencyKey := deriveEnvelopeIDs(
-		req.MsgID, req.IdempotencyKey, stableBytes,
-	)
-
-	method := req.ServiceMethod()
-
-	return a.sendUnaryEnvelope(
-		ctx, body, method.Service, method.Method, req.CorrelationID,
-		msgID, idempotencyKey,
-	)
-}
-
-// handleSendListVTXOsByScriptsRequest builds and sends a durable proof-gated
-// indexer unary request for one or more taproot output scripts.
-func (a *ServerConnectionActor) handleSendListVTXOsByScriptsRequest(
-	ctx context.Context, req *SendListVTXOsByScriptsRequest,
-) fn.Result[ServerConnResp] {
-
-	if req == nil {
-		return fn.Err[ServerConnResp](fmt.Errorf(
-			"vtxo query must be provided",
-		))
-	}
-
-	if a.cfg.DurableUnaryBuilder == nil {
-		return fn.Err[ServerConnResp](fmt.Errorf(
-			"durable unary builder must be provided",
-		))
-	}
-
-	if req.CorrelationID == "" {
-		return fn.Err[ServerConnResp](fmt.Errorf(
-			"vtxo query requires a correlation ID",
-		))
-	}
-
-	protoReq, err := a.cfg.DurableUnaryBuilder.
-		BuildListVTXOsByScriptsRequest(
-			ctx, req.PkScripts, req.AfterCursor, req.Limit,
+	if q.QueryCorrelationID() == "" {
+		return nil, fmt.Errorf(
+			"durable unary query requires a correlation ID",
 		)
-	if err != nil {
-		return fn.Err[ServerConnResp](fmt.Errorf(
-			"build vtxo query request: %w", err,
-		))
 	}
 
-	body, err := anypb.New(protoReq)
-	if err != nil {
-		return fn.Err[ServerConnResp](fmt.Errorf(
-			"wrap vtxo query in Any: %w", err,
-		))
-	}
-
-	stableBytes, err := encodeVTXOsByScriptsQueryIdentity(
-		req.PkScripts, req.AfterCursor, req.Limit,
-		req.CorrelationID,
+	body, stableBytes, err := q.BuildBody(
+		ctx, a.cfg.DurableUnaryBuilder,
 	)
 	if err != nil {
-		return fn.Err[ServerConnResp](fmt.Errorf(
-			"encode vtxo query identity: %w", err,
-		))
+		return nil, err
 	}
 
-	msgID, idempotencyKey := deriveEnvelopeIDs(
-		req.MsgID, req.IdempotencyKey, stableBytes,
-	)
-
-	method := req.ServiceMethod()
-
-	return a.sendUnaryEnvelope(
-		ctx, body, method.Service, method.Method, req.CorrelationID,
-		msgID, idempotencyKey,
-	)
-}
-
-// deriveEnvelopeIDs returns the msgID and idempotencyKey to use for a durable
-// unary envelope. Caller-provided values take precedence; if empty, stable
-// deterministic IDs are derived from the identity bytes.
-func deriveEnvelopeIDs(reqMsgID, reqIdempotencyKey string,
-	stableBytes []byte) (string, string) {
-
-	msgID := reqMsgID
+	msgID := q.QueryMsgID()
 	if msgID == "" {
 		msgID = mailboxconn.StableEventMsgID(stableBytes)
 	}
 
-	idempotencyKey := reqIdempotencyKey
+	idempotencyKey := q.QueryIdempotencyKey()
 	if idempotencyKey == "" {
 		idempotencyKey = mailboxconn.
 			StableEventIdempotencyKey(stableBytes)
 	}
 
-	return msgID, idempotencyKey
+	method := q.ServiceMethod()
+
+	return &SendUnaryRequest{
+		Body:           body,
+		Service:        method.Service,
+		Method:         method.Method,
+		CorrelationID:  q.QueryCorrelationID(),
+		MsgID:          msgID,
+		IdempotencyKey: idempotencyKey,
+	}, nil
 }
 
 // sendUnaryEnvelope sends one durable unary request envelope via the mailbox

--- a/serverconn/actor.go
+++ b/serverconn/actor.go
@@ -28,6 +28,10 @@ const (
 	// SendRPCRequestMsgType is the TLV type for outbound unary RPC
 	// envelopes from the unary facade.
 	SendRPCRequestMsgType tlv.Type = 2001
+
+	// SendUnaryRequestMsgType is the TLV type for durable correlated unary
+	// requests where the connector constructs the mailbox envelope.
+	SendUnaryRequestMsgType tlv.Type = 2002
 )
 
 // defaultSendEventTimeout is the timeout for outbound gRPC Edge.Send calls.
@@ -41,6 +45,7 @@ type (
 	idempotencyRecordTLV  = tlv.TlvType4
 	rpcServiceRecordTLV   = tlv.TlvType5
 	rpcMethodRecordTLV    = tlv.TlvType6
+	rpcCorrelationRecordTLV = tlv.TlvType7
 )
 
 // ServerMessage is an interface that client FSM outbox messages must implement
@@ -376,6 +381,158 @@ func (m *SendRPCRequest) Decode(r io.Reader) error {
 // serverConnMsgSealed implements the ServerConnMsg interface seal.
 func (m *SendRPCRequest) serverConnMsgSealed() {}
 
+// SendUnaryRequest wraps a typed unary RPC request for durable delivery via
+// the mailbox edge. Unlike SendRPCRequest, the caller provides the request
+// body and routing metadata rather than a pre-built envelope.
+type SendUnaryRequest struct {
+	actor.BaseMessage
+
+	// Body is the request payload wrapped as Any.
+	Body *anypb.Any
+
+	// MsgID uniquely identifies this send attempt. Retries of the same
+	// persisted request must reuse this ID.
+	MsgID string
+
+	// IdempotencyKey identifies the semantic operation for remote dedupe.
+	IdempotencyKey string
+
+	// Service is the fully-qualified protobuf service name.
+	Service string
+
+	// Method is the RPC method name.
+	Method string
+
+	// CorrelationID links this request to the eventual KIND_RESPONSE.
+	CorrelationID string
+}
+
+// NewSendUnaryRequest constructs a durable unary request from the given proto
+// payload and routing metadata.
+func NewSendUnaryRequest(method mailboxrpc.ServiceMethod, req proto.Message,
+	correlationID string) (*SendUnaryRequest, error) {
+
+	if req == nil {
+		return nil, fmt.Errorf("unary request body must be provided")
+	}
+
+	body, err := anypb.New(req)
+	if err != nil {
+		return nil, fmt.Errorf("wrap unary request in Any: %w", err)
+	}
+
+	return &SendUnaryRequest{
+		Body:          body,
+		Service:       method.Service,
+		Method:        method.Method,
+		CorrelationID: correlationID,
+	}, nil
+}
+
+// MessageType returns a human-readable type name for logging.
+func (m *SendUnaryRequest) MessageType() string {
+	return "SendUnaryRequest"
+}
+
+// TLVType returns the unique TLV type identifier for this message.
+func (m *SendUnaryRequest) TLVType() tlv.Type {
+	return SendUnaryRequestMsgType
+}
+
+// Encode serializes the message to the provided writer.
+func (m *SendUnaryRequest) Encode(w io.Writer) error {
+	body := m.Body
+	if body == nil {
+		return fmt.Errorf("unary request body must be provided")
+	}
+
+	bodyBytes, err := (proto.MarshalOptions{
+		Deterministic: true,
+	}).Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal unary request body: %w", err)
+	}
+
+	msgID := m.MsgID
+	if msgID == "" {
+		msgID = mailboxconn.StableEventMsgID(bodyBytes)
+	}
+
+	idempotencyKey := m.IdempotencyKey
+	if idempotencyKey == "" {
+		idempotencyKey = mailboxconn.
+			StableEventIdempotencyKey(bodyBytes)
+	}
+
+	bodyRec := tlv.NewRecordT[protoPayloadRecordTLV](
+		mailboxconn.WrappedProto[*anypb.Any]{Val: body},
+	)
+	msgIDRec := tlv.NewPrimitiveRecord[msgIDRecordTLV](
+		[]byte(msgID),
+	)
+	idemRec := tlv.NewPrimitiveRecord[idempotencyRecordTLV](
+		[]byte(idempotencyKey),
+	)
+	svcRec := tlv.NewPrimitiveRecord[rpcServiceRecordTLV](
+		[]byte(m.Service),
+	)
+	methodRec := tlv.NewPrimitiveRecord[rpcMethodRecordTLV](
+		[]byte(m.Method),
+	)
+	corrRec := tlv.NewPrimitiveRecord[rpcCorrelationRecordTLV](
+		[]byte(m.CorrelationID),
+	)
+
+	stream, err := tlv.NewStream(
+		bodyRec.Record(), msgIDRec.Record(), idemRec.Record(),
+		svcRec.Record(), methodRec.Record(), corrRec.Record(),
+	)
+	if err != nil {
+		return err
+	}
+
+	return stream.Encode(w)
+}
+
+// Decode deserializes the message from the provided reader.
+func (m *SendUnaryRequest) Decode(r io.Reader) error {
+	bodyRec := tlv.ZeroRecordT[
+		protoPayloadRecordTLV,
+		mailboxconn.WrappedProto[*anypb.Any],
+	]()
+	bodyRec.Val.Val = &anypb.Any{}
+
+	msgIDRec := tlv.ZeroRecordT[msgIDRecordTLV, []byte]()
+	idemRec := tlv.ZeroRecordT[idempotencyRecordTLV, []byte]()
+	svcRec := tlv.ZeroRecordT[rpcServiceRecordTLV, []byte]()
+	methodRec := tlv.ZeroRecordT[rpcMethodRecordTLV, []byte]()
+	corrRec := tlv.ZeroRecordT[rpcCorrelationRecordTLV, []byte]()
+
+	stream, err := tlv.NewStream(
+		bodyRec.Record(), msgIDRec.Record(), idemRec.Record(),
+		svcRec.Record(), methodRec.Record(), corrRec.Record(),
+	)
+	if err != nil {
+		return err
+	}
+
+	if _, err := stream.DecodeWithParsedTypes(r); err != nil {
+		return err
+	}
+
+	m.Body = bodyRec.Val.Val
+	m.MsgID = string(msgIDRec.Val)
+	m.IdempotencyKey = string(idemRec.Val)
+	m.Service = string(svcRec.Val)
+	m.Method = string(methodRec.Val)
+	m.CorrelationID = string(corrRec.Val)
+
+	return nil
+}
+
+// serverConnMsgSealed implements the ServerConnMsg interface seal.
+func (m *SendUnaryRequest) serverConnMsgSealed() {}
+
 // ServerConnectionActor is the unified connector boundary for all mailbox
 // traffic between the client and the remote server. It serves as both:
 //
@@ -437,6 +594,9 @@ func (a *ServerConnectionActor) Receive(ctx context.Context,
 	switch m := msg.(type) {
 	case *SendClientEventRequest:
 		return a.handleSendClientEvent(ctx, m)
+
+	case *SendUnaryRequest:
+		return a.handleSendUnaryRequest(ctx, m)
 
 	case *SendRPCRequest:
 		return a.handleSendRPCRequest(ctx, m)
@@ -542,6 +702,101 @@ func (a *ServerConnectionActor) handleSendClientEvent(ctx context.Context,
 	})
 }
 
+// handleSendUnaryRequest sends a durable correlated unary request via the
+// mailbox edge.
+func (a *ServerConnectionActor) handleSendUnaryRequest(ctx context.Context,
+	req *SendUnaryRequest) fn.Result[ServerConnResp] {
+
+	if req == nil {
+		return fn.Err[ServerConnResp](fmt.Errorf(
+			"unary request must be provided",
+		))
+	}
+
+	if req.Body == nil {
+		return fn.Err[ServerConnResp](fmt.Errorf(
+			"unary request body must be provided",
+		))
+	}
+
+	if req.Service == "" || req.Method == "" {
+		return fn.Err[ServerConnResp](fmt.Errorf(
+			"unary request service and method must be provided",
+		))
+	}
+
+	if req.CorrelationID == "" {
+		return fn.Err[ServerConnResp](fmt.Errorf(
+			"unary request correlation id must be provided",
+		))
+	}
+
+	msgID := req.MsgID
+	idempotencyKey := req.IdempotencyKey
+
+	if msgID == "" || idempotencyKey == "" {
+		bodyBytes, err := (proto.MarshalOptions{
+			Deterministic: true,
+		}).Marshal(req.Body)
+		if err != nil {
+			return fn.Err[ServerConnResp](fmt.Errorf(
+				"marshal unary body: %w", err,
+			))
+		}
+
+		if msgID == "" {
+			msgID = mailboxconn.StableEventMsgID(bodyBytes)
+		}
+
+		if idempotencyKey == "" {
+			idempotencyKey = mailboxconn.
+				StableEventIdempotencyKey(bodyBytes)
+		}
+	}
+
+	envelope := &mailboxpb.Envelope{
+		ProtocolVersion: a.cfg.ProtocolVersion,
+		MsgId:           msgID,
+		IdempotencyKey:  idempotencyKey,
+		Sender:          a.cfg.LocalMailboxID,
+		Recipient:       a.cfg.RemoteMailboxID,
+		CreatedAtUnixMs: time.Now().UnixMilli(),
+		Body:            req.Body,
+		Rpc: &mailboxpb.RpcMeta{
+			Kind:          mailboxpb.RpcMeta_KIND_REQUEST,
+			Service:       req.Service,
+			Method:        req.Method,
+			CorrelationId: req.CorrelationID,
+			ReplyTo:       a.cfg.LocalMailboxID,
+		},
+	}
+
+	sendCtx, sendCancel := context.WithTimeout(
+		context.WithoutCancel(ctx), defaultSendEventTimeout,
+	)
+	defer sendCancel()
+
+	resp, err := a.cfg.Edge.Send(sendCtx, &mailboxpb.SendRequest{
+		Envelope: envelope,
+	})
+	if err != nil {
+		return fn.Err[ServerConnResp](fmt.Errorf(
+			"send unary request: %w", err,
+		))
+	}
+
+	if resp.Status != nil && !resp.Status.Ok {
+		return fn.Err[ServerConnResp](fmt.Errorf(
+			"send unary request: %s (%s)",
+			resp.Status.Message, resp.Status.Code,
+		))
+	}
+
+	return fn.Ok[ServerConnResp](&SendRPCResponse{
+		Success: true,
+	})
+}
+
 // eventRoutingMetadata returns the outbound routing metadata persisted on a
 // SendClientEventRequest. When callers leave Service/Method empty, we derive
 // them directly from the wrapped ServerMessage so direct sends remain aligned
@@ -615,12 +870,19 @@ func (a *ServerConnectionActor) removeWaiter(id CorrelationID) {
 	a.responseRegistry.RemoveWaiter(id)
 }
 
+// removePendingResponse drops any buffered early response for the correlation
+// ID. Durable response dispatchers use this after converting a response into a
+// local actor message so the in-memory unary path cannot consume it later.
+func (a *ServerConnectionActor) removePendingResponse(id CorrelationID) {
+	a.responseRegistry.RemovePending(id)
+}
+
 // deliverResponse looks up a waiter by correlation ID and delivers the
 // envelope. If no waiter exists yet, the response is buffered so a later
 // AwaitRPC call can still observe it.
 func (a *ServerConnectionActor) deliverResponse(
 	id CorrelationID, env *mailboxpb.Envelope,
-) bool {
+) mailboxconn.DeliveryResult {
 
 	return a.responseRegistry.DeliverResponse(id, env)
 }
@@ -680,6 +942,12 @@ func NewServerConnCodec() *actor.MessageCodec {
 			return &SendRPCRequest{}
 		},
 	)
+	codec.MustRegister(
+		SendUnaryRequestMsgType,
+		func() actor.TLVMessage {
+			return &SendUnaryRequest{}
+		},
+	)
 
 	return codec
 }
@@ -687,6 +955,7 @@ func NewServerConnCodec() *actor.MessageCodec {
 // Compile-time interface checks.
 var (
 	_ ServerConnMsg  = (*SendClientEventRequest)(nil)
+	_ ServerConnMsg  = (*SendUnaryRequest)(nil)
 	_ ServerConnMsg  = (*SendRPCRequest)(nil)
 	_ ServerConnResp = (*SendClientEventResponse)(nil)
 	_ ServerConnResp = (*SendRPCResponse)(nil)

--- a/serverconn/actor.go
+++ b/serverconn/actor.go
@@ -39,12 +39,12 @@ const defaultSendEventTimeout = 30 * time.Second
 
 // TLV record type aliases for RecordT-style message field serialization.
 type (
-	protoPayloadRecordTLV = tlv.TlvType1
-	envelopeRecordTLV     = tlv.TlvType2
-	msgIDRecordTLV        = tlv.TlvType3
-	idempotencyRecordTLV  = tlv.TlvType4
-	rpcServiceRecordTLV   = tlv.TlvType5
-	rpcMethodRecordTLV    = tlv.TlvType6
+	protoPayloadRecordTLV   = tlv.TlvType1
+	envelopeRecordTLV       = tlv.TlvType2
+	msgIDRecordTLV          = tlv.TlvType3
+	idempotencyRecordTLV    = tlv.TlvType4
+	rpcServiceRecordTLV     = tlv.TlvType5
+	rpcMethodRecordTLV      = tlv.TlvType6
 	rpcCorrelationRecordTLV = tlv.TlvType7
 )
 
@@ -598,6 +598,14 @@ func (a *ServerConnectionActor) Receive(ctx context.Context,
 	case *SendUnaryRequest:
 		return a.handleSendUnaryRequest(ctx, m)
 
+	case *SendListOORRecipientEventsByScriptRequest:
+		return a.handleSendListOORRecipientEventsByScriptRequest(
+			ctx, m,
+		)
+
+	case *SendListVTXOsByScriptsRequest:
+		return a.handleSendListVTXOsByScriptsRequest(ctx, m)
+
 	case *SendRPCRequest:
 		return a.handleSendRPCRequest(ctx, m)
 
@@ -754,6 +762,165 @@ func (a *ServerConnectionActor) handleSendUnaryRequest(ctx context.Context,
 		}
 	}
 
+	return a.sendUnaryEnvelope(
+		ctx, req.Body, req.Service, req.Method, req.CorrelationID,
+		msgID, idempotencyKey,
+	)
+}
+
+// handleSendListOORRecipientEventsByScriptRequest builds and sends a durable
+// proof-gated indexer unary request for one taproot output script.
+func (a *ServerConnectionActor) handleSendListOORRecipientEventsByScriptRequest(
+	ctx context.Context, req *SendListOORRecipientEventsByScriptRequest,
+) fn.Result[ServerConnResp] {
+
+	if req == nil {
+		return fn.Err[ServerConnResp](fmt.Errorf(
+			"recipient-events query must be provided",
+		))
+	}
+
+	if a.cfg.DurableUnaryBuilder == nil {
+		return fn.Err[ServerConnResp](fmt.Errorf(
+			"durable unary builder must be provided",
+		))
+	}
+
+	protoReq, err := a.cfg.DurableUnaryBuilder.
+		BuildListOORRecipientEventsByScriptRequest(
+			ctx, req.PkScript, req.AfterEventID, req.Limit,
+		)
+	if err != nil {
+		return fn.Err[ServerConnResp](fmt.Errorf(
+			"build recipient-events request: %w", err,
+		))
+	}
+
+	body, err := anypb.New(protoReq)
+	if err != nil {
+		return fn.Err[ServerConnResp](fmt.Errorf(
+			"wrap recipient-events request in Any: %w", err,
+		))
+	}
+
+	if req.CorrelationID == "" {
+		return fn.Err[ServerConnResp](fmt.Errorf(
+			"recipient-events query requires a " +
+				"correlation ID",
+		))
+	}
+
+	stableBytes, err := encodeRecipientEventsQueryIdentity(
+		req.PkScript, req.AfterEventID, req.Limit,
+		req.CorrelationID,
+	)
+	if err != nil {
+		return fn.Err[ServerConnResp](fmt.Errorf(
+			"encode recipient-events identity: %w", err,
+		))
+	}
+
+	msgID, idempotencyKey := deriveEnvelopeIDs(
+		req.MsgID, req.IdempotencyKey, stableBytes,
+	)
+
+	method := req.ServiceMethod()
+
+	return a.sendUnaryEnvelope(
+		ctx, body, method.Service, method.Method, req.CorrelationID,
+		msgID, idempotencyKey,
+	)
+}
+
+// handleSendListVTXOsByScriptsRequest builds and sends a durable proof-gated
+// indexer unary request for one or more taproot output scripts.
+func (a *ServerConnectionActor) handleSendListVTXOsByScriptsRequest(
+	ctx context.Context, req *SendListVTXOsByScriptsRequest,
+) fn.Result[ServerConnResp] {
+
+	if req == nil {
+		return fn.Err[ServerConnResp](fmt.Errorf(
+			"vtxo query must be provided",
+		))
+	}
+
+	if a.cfg.DurableUnaryBuilder == nil {
+		return fn.Err[ServerConnResp](fmt.Errorf(
+			"durable unary builder must be provided",
+		))
+	}
+
+	if req.CorrelationID == "" {
+		return fn.Err[ServerConnResp](fmt.Errorf(
+			"vtxo query requires a correlation ID",
+		))
+	}
+
+	protoReq, err := a.cfg.DurableUnaryBuilder.
+		BuildListVTXOsByScriptsRequest(
+			ctx, req.PkScripts, req.AfterCursor, req.Limit,
+		)
+	if err != nil {
+		return fn.Err[ServerConnResp](fmt.Errorf(
+			"build vtxo query request: %w", err,
+		))
+	}
+
+	body, err := anypb.New(protoReq)
+	if err != nil {
+		return fn.Err[ServerConnResp](fmt.Errorf(
+			"wrap vtxo query in Any: %w", err,
+		))
+	}
+
+	stableBytes, err := encodeVTXOsByScriptsQueryIdentity(
+		req.PkScripts, req.AfterCursor, req.Limit,
+		req.CorrelationID,
+	)
+	if err != nil {
+		return fn.Err[ServerConnResp](fmt.Errorf(
+			"encode vtxo query identity: %w", err,
+		))
+	}
+
+	msgID, idempotencyKey := deriveEnvelopeIDs(
+		req.MsgID, req.IdempotencyKey, stableBytes,
+	)
+
+	method := req.ServiceMethod()
+
+	return a.sendUnaryEnvelope(
+		ctx, body, method.Service, method.Method, req.CorrelationID,
+		msgID, idempotencyKey,
+	)
+}
+
+// deriveEnvelopeIDs returns the msgID and idempotencyKey to use for a durable
+// unary envelope. Caller-provided values take precedence; if empty, stable
+// deterministic IDs are derived from the identity bytes.
+func deriveEnvelopeIDs(reqMsgID, reqIdempotencyKey string,
+	stableBytes []byte) (string, string) {
+
+	msgID := reqMsgID
+	if msgID == "" {
+		msgID = mailboxconn.StableEventMsgID(stableBytes)
+	}
+
+	idempotencyKey := reqIdempotencyKey
+	if idempotencyKey == "" {
+		idempotencyKey = mailboxconn.
+			StableEventIdempotencyKey(stableBytes)
+	}
+
+	return msgID, idempotencyKey
+}
+
+// sendUnaryEnvelope sends one durable unary request envelope via the mailbox
+// edge using the given routing metadata and stable identifiers.
+func (a *ServerConnectionActor) sendUnaryEnvelope(ctx context.Context,
+	body *anypb.Any, service string, method string, correlationID string,
+	msgID string, idempotencyKey string) fn.Result[ServerConnResp] {
+
 	envelope := &mailboxpb.Envelope{
 		ProtocolVersion: a.cfg.ProtocolVersion,
 		MsgId:           msgID,
@@ -761,12 +928,12 @@ func (a *ServerConnectionActor) handleSendUnaryRequest(ctx context.Context,
 		Sender:          a.cfg.LocalMailboxID,
 		Recipient:       a.cfg.RemoteMailboxID,
 		CreatedAtUnixMs: time.Now().UnixMilli(),
-		Body:            req.Body,
+		Body:            body,
 		Rpc: &mailboxpb.RpcMeta{
 			Kind:          mailboxpb.RpcMeta_KIND_REQUEST,
-			Service:       req.Service,
-			Method:        req.Method,
-			CorrelationId: req.CorrelationID,
+			Service:       service,
+			Method:        method,
+			CorrelationId: correlationID,
 			ReplyTo:       a.cfg.LocalMailboxID,
 		},
 	}
@@ -948,6 +1115,18 @@ func NewServerConnCodec() *actor.MessageCodec {
 			return &SendUnaryRequest{}
 		},
 	)
+	codec.MustRegister(
+		SendListOORRecipientEventsByScriptRequestMsgType,
+		func() actor.TLVMessage {
+			return &SendListOORRecipientEventsByScriptRequest{}
+		},
+	)
+	codec.MustRegister(
+		SendListVTXOsByScriptsRequestMsgType,
+		func() actor.TLVMessage {
+			return &SendListVTXOsByScriptsRequest{}
+		},
+	)
 
 	return codec
 }
@@ -957,6 +1136,8 @@ var (
 	_ ServerConnMsg  = (*SendClientEventRequest)(nil)
 	_ ServerConnMsg  = (*SendUnaryRequest)(nil)
 	_ ServerConnMsg  = (*SendRPCRequest)(nil)
+	_ ServerConnMsg  = (*SendListOORRecipientEventsByScriptRequest)(nil)
+	_ ServerConnMsg  = (*SendListVTXOsByScriptsRequest)(nil)
 	_ ServerConnResp = (*SendClientEventResponse)(nil)
 	_ ServerConnResp = (*SendRPCResponse)(nil)
 

--- a/serverconn/actor_tlv_test.go
+++ b/serverconn/actor_tlv_test.go
@@ -386,7 +386,7 @@ func TestServerConnCodec_RoundTrip(t *testing.T) {
 	decodedRecipient, err := codec.Decode(recipientBytes)
 	require.NoError(t, err)
 
-	typedRecipient, ok := decodedRecipient.(*SendListOORRecipientEventsByScriptRequest)
+	typedRecipient, ok := decodedRecipient.(*SendListOORRecipientEventsByScriptRequest) //nolint:ll
 	require.True(t, ok)
 	require.Equal(t, recipientReq.PkScript, typedRecipient.PkScript)
 	require.Equal(

--- a/serverconn/actor_tlv_test.go
+++ b/serverconn/actor_tlv_test.go
@@ -22,9 +22,17 @@ type bytesServerMessage struct {
 	payload []byte
 }
 
-// ServiceMethod returns a zero-value routing key for tests.
+const (
+	testEventService = "test.v1.EventService"
+	testEventMethod  = "PushEvent"
+)
+
+// ServiceMethod returns deterministic routing metadata for tests.
 func (m *bytesServerMessage) ServiceMethod() mailboxrpc.ServiceMethod {
-	return mailboxrpc.ServiceMethod{}
+	return mailboxrpc.ServiceMethod{
+		Service: testEventService,
+		Method:  testEventMethod,
+	}
 }
 
 // ToProto converts the payload to a protobuf wrapper.
@@ -70,6 +78,10 @@ func TestSendClientEventRequest_TLVRoundTrip_DeterministicIDs(t *testing.T) {
 	require.Equal(
 		t, decodedA.IdempotencyKey, decodedB.IdempotencyKey,
 	)
+	require.Equal(t, testEventService, decodedA.Service)
+	require.Equal(t, testEventMethod, decodedA.Method)
+	require.Equal(t, testEventService, decodedB.Service)
+	require.Equal(t, testEventMethod, decodedB.Method)
 
 	protoMsg := decodedA.Message.ToProto().UnwrapOrFail(t)
 	msg, ok := protoMsg.(*wrapperspb.BytesValue)

--- a/serverconn/actor_tlv_test.go
+++ b/serverconn/actor_tlv_test.go
@@ -143,6 +143,40 @@ func TestSendRPCRequest_TLVRoundTrip(t *testing.T) {
 	require.True(t, proto.Equal(original.Envelope, decoded.Envelope))
 }
 
+// TestSendUnaryRequest_TLVRoundTrip verifies durable unary request payload
+// serialization round trips with stable derived identifiers.
+func TestSendUnaryRequest_TLVRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	original, err := NewSendUnaryRequest(
+		mailboxrpc.ServiceMethod{
+			Service: "test.Svc",
+			Method:  "DoThing",
+		},
+		wrapperspb.String("request"),
+		"corr-unary",
+	)
+	require.NoError(t, err)
+
+	var decoded SendUnaryRequest
+	encoded := encodeTLVMessage(t, original)
+
+	require.NoError(
+		t, decoded.Decode(bytes.NewReader(encoded)),
+	)
+
+	require.NotNil(t, decoded.Body)
+	require.NotEmpty(t, decoded.MsgID)
+	require.NotEmpty(t, decoded.IdempotencyKey)
+	require.Equal(t, original.Service, decoded.Service)
+	require.Equal(t, original.Method, decoded.Method)
+	require.Equal(t, original.CorrelationID, decoded.CorrelationID)
+
+	payload := &wrapperspb.StringValue{}
+	require.NoError(t, decoded.Body.UnmarshalTo(payload))
+	require.Equal(t, "request", payload.Value)
+}
+
 // TestServerConnMessageMetadata verifies static message metadata methods.
 func TestServerConnMessageMetadata(t *testing.T) {
 	t.Parallel()
@@ -160,6 +194,11 @@ func TestServerConnMessageMetadata(t *testing.T) {
 	require.Equal(t, "SendRPCRequest", rpcReq.MessageType())
 	require.Equal(t, SendRPCRequestMsgType, rpcReq.TLVType())
 	rpcReq.serverConnMsgSealed()
+
+	unaryReq := &SendUnaryRequest{}
+	require.Equal(t, "SendUnaryRequest", unaryReq.MessageType())
+	require.Equal(t, SendUnaryRequestMsgType, unaryReq.TLVType())
+	unaryReq.serverConnMsgSealed()
 }
 
 // TestRawServerMessage_ToProtoDecodeFailure verifies ToProto returns an error
@@ -230,6 +269,30 @@ func TestServerConnCodec_RoundTrip(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, rpcReq.Envelope.MsgId, typedRPC.Envelope.MsgId)
 	require.Equal(t, rpcReq.Envelope.Sender, typedRPC.Envelope.Sender)
+
+	unaryReq, err := NewSendUnaryRequest(
+		mailboxrpc.ServiceMethod{
+			Service: "test.Svc",
+			Method:  "DoThing",
+		},
+		wrapperspb.String("codec-unary"),
+		"corr-codec-unary",
+	)
+	require.NoError(t, err)
+
+	unaryBytes, err := codec.Encode(unaryReq)
+	require.NoError(t, err)
+
+	decodedUnary, err := codec.Decode(unaryBytes)
+	require.NoError(t, err)
+
+	typedUnary, ok := decodedUnary.(*SendUnaryRequest)
+	require.True(t, ok)
+	require.Equal(t, unaryReq.Service, typedUnary.Service)
+	require.Equal(t, unaryReq.Method, typedUnary.Method)
+	require.Equal(
+		t, unaryReq.CorrelationID, typedUnary.CorrelationID,
+	)
 }
 
 // unknownServerConnMsg is a test-only unsupported message for Receive.

--- a/serverconn/actor_tlv_test.go
+++ b/serverconn/actor_tlv_test.go
@@ -177,6 +177,65 @@ func TestSendUnaryRequest_TLVRoundTrip(t *testing.T) {
 	require.Equal(t, "request", payload.Value)
 }
 
+// TestSendListOORRecipientEventsByScriptRequest_TLVRoundTrip verifies the
+// durable recipient-events query message round-trips through TLV encoding.
+func TestSendListOORRecipientEventsByScriptRequest_TLVRoundTrip(
+	t *testing.T) {
+
+	t.Parallel()
+
+	original := &SendListOORRecipientEventsByScriptRequest{
+		PkScript:      []byte{0x51, 0x20, 0x01},
+		AfterEventID:  7,
+		Limit:         1,
+		CorrelationID: "corr-recipient-query",
+	}
+
+	var decoded SendListOORRecipientEventsByScriptRequest
+	encoded := encodeTLVMessage(t, original)
+
+	require.NoError(
+		t, decoded.Decode(bytes.NewReader(encoded)),
+	)
+
+	require.Equal(t, original.PkScript, decoded.PkScript)
+	require.Equal(t, original.AfterEventID, decoded.AfterEventID)
+	require.Equal(t, original.Limit, decoded.Limit)
+	require.Equal(t, original.CorrelationID, decoded.CorrelationID)
+	require.NotEmpty(t, decoded.MsgID)
+	require.NotEmpty(t, decoded.IdempotencyKey)
+}
+
+// TestSendListVTXOsByScriptsRequest_TLVRoundTrip verifies the durable
+// VTXO-by-scripts query message round-trips through TLV encoding.
+func TestSendListVTXOsByScriptsRequest_TLVRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	original := &SendListVTXOsByScriptsRequest{
+		PkScripts: [][]byte{
+			{0x51, 0x20, 0x01},
+			{0x51, 0x20, 0x02},
+		},
+		AfterCursor:   11,
+		Limit:         128,
+		CorrelationID: "corr-vtxo-query",
+	}
+
+	var decoded SendListVTXOsByScriptsRequest
+	encoded := encodeTLVMessage(t, original)
+
+	require.NoError(
+		t, decoded.Decode(bytes.NewReader(encoded)),
+	)
+
+	require.Equal(t, original.PkScripts, decoded.PkScripts)
+	require.Equal(t, original.AfterCursor, decoded.AfterCursor)
+	require.Equal(t, original.Limit, decoded.Limit)
+	require.Equal(t, original.CorrelationID, decoded.CorrelationID)
+	require.NotEmpty(t, decoded.MsgID)
+	require.NotEmpty(t, decoded.IdempotencyKey)
+}
+
 // TestServerConnMessageMetadata verifies static message metadata methods.
 func TestServerConnMessageMetadata(t *testing.T) {
 	t.Parallel()
@@ -199,6 +258,26 @@ func TestServerConnMessageMetadata(t *testing.T) {
 	require.Equal(t, "SendUnaryRequest", unaryReq.MessageType())
 	require.Equal(t, SendUnaryRequestMsgType, unaryReq.TLVType())
 	unaryReq.serverConnMsgSealed()
+
+	recipientReq := &SendListOORRecipientEventsByScriptRequest{}
+	require.Equal(
+		t, "SendListOORRecipientEventsByScriptRequest",
+		recipientReq.MessageType(),
+	)
+	require.Equal(
+		t, SendListOORRecipientEventsByScriptRequestMsgType,
+		recipientReq.TLVType(),
+	)
+	recipientReq.serverConnMsgSealed()
+
+	vtxoReq := &SendListVTXOsByScriptsRequest{}
+	require.Equal(
+		t, "SendListVTXOsByScriptsRequest", vtxoReq.MessageType(),
+	)
+	require.Equal(
+		t, SendListVTXOsByScriptsRequestMsgType, vtxoReq.TLVType(),
+	)
+	vtxoReq.serverConnMsgSealed()
 }
 
 // TestRawServerMessage_ToProtoDecodeFailure verifies ToProto returns an error
@@ -293,6 +372,47 @@ func TestServerConnCodec_RoundTrip(t *testing.T) {
 	require.Equal(
 		t, unaryReq.CorrelationID, typedUnary.CorrelationID,
 	)
+
+	recipientReq := &SendListOORRecipientEventsByScriptRequest{
+		PkScript:      []byte{0x51, 0x20, 0x04},
+		AfterEventID:  9,
+		Limit:         1,
+		CorrelationID: "corr-codec-recipient",
+	}
+
+	recipientBytes, err := codec.Encode(recipientReq)
+	require.NoError(t, err)
+
+	decodedRecipient, err := codec.Decode(recipientBytes)
+	require.NoError(t, err)
+
+	typedRecipient, ok := decodedRecipient.(*SendListOORRecipientEventsByScriptRequest)
+	require.True(t, ok)
+	require.Equal(t, recipientReq.PkScript, typedRecipient.PkScript)
+	require.Equal(
+		t, recipientReq.CorrelationID, typedRecipient.CorrelationID,
+	)
+
+	vtxoReq := &SendListVTXOsByScriptsRequest{
+		PkScripts: [][]byte{
+			{0x51, 0x20, 0x05},
+			{0x51, 0x20, 0x06},
+		},
+		AfterCursor:   13,
+		Limit:         128,
+		CorrelationID: "corr-codec-vtxo",
+	}
+
+	vtxoBytes, err := codec.Encode(vtxoReq)
+	require.NoError(t, err)
+
+	decodedVTXO, err := codec.Decode(vtxoBytes)
+	require.NoError(t, err)
+
+	typedVTXO, ok := decodedVTXO.(*SendListVTXOsByScriptsRequest)
+	require.True(t, ok)
+	require.Equal(t, vtxoReq.PkScripts, typedVTXO.PkScripts)
+	require.Equal(t, vtxoReq.CorrelationID, typedVTXO.CorrelationID)
 }
 
 // unknownServerConnMsg is a test-only unsupported message for Receive.

--- a/serverconn/connector_test.go
+++ b/serverconn/connector_test.go
@@ -199,10 +199,7 @@ func TestServerConnectionActor_SendListOORRecipientEventsByScriptRequest(
 
 	mb.mu.Lock()
 	require.Len(t, mb.mailboxes["server-1"], 1)
-	env, ok := proto.Clone(
-		mb.mailboxes["server-1"][0],
-	).(*mailboxpb.Envelope)
-	require.True(t, ok)
+	env := proto.Clone(mb.mailboxes["server-1"][0]).(*mailboxpb.Envelope)
 	mb.mu.Unlock()
 
 	require.Equal(

--- a/serverconn/connector_test.go
+++ b/serverconn/connector_test.go
@@ -199,7 +199,10 @@ func TestServerConnectionActor_SendListOORRecipientEventsByScriptRequest(
 
 	mb.mu.Lock()
 	require.Len(t, mb.mailboxes["server-1"], 1)
-	env := proto.Clone(mb.mailboxes["server-1"][0]).(*mailboxpb.Envelope)
+	env, ok := proto.Clone(
+		mb.mailboxes["server-1"][0],
+	).(*mailboxpb.Envelope)
+	require.True(t, ok)
 	mb.mu.Unlock()
 
 	require.Equal(

--- a/serverconn/connector_test.go
+++ b/serverconn/connector_test.go
@@ -21,9 +21,12 @@ type testServerMessage struct {
 	value string
 }
 
-// ServiceMethod returns a zero-value routing key for tests.
+// ServiceMethod returns deterministic routing metadata for tests.
 func (m *testServerMessage) ServiceMethod() mailboxrpc.ServiceMethod {
-	return mailboxrpc.ServiceMethod{}
+	return mailboxrpc.ServiceMethod{
+		Service: testEventService,
+		Method:  testEventMethod,
+	}
 }
 
 // ToProto converts the test message to a protobuf payload.
@@ -364,6 +367,12 @@ func TestEgress_EventRetriesPreserveIdempotencyKey(t *testing.T) {
 	require.Equal(
 		t, envs[0].IdempotencyKey, envs[1].IdempotencyKey,
 	)
+	require.NotNil(t, envs[0].Rpc)
+	require.NotNil(t, envs[1].Rpc)
+	require.Equal(t, testEventService, envs[0].Rpc.Service)
+	require.Equal(t, testEventMethod, envs[0].Rpc.Method)
+	require.Equal(t, testEventService, envs[1].Rpc.Service)
+	require.Equal(t, testEventMethod, envs[1].Rpc.Method)
 }
 
 // TestIngress_PartialDispatch_NoDuplicateRedelivery verifies that when

--- a/serverconn/connector_test.go
+++ b/serverconn/connector_test.go
@@ -2,6 +2,7 @@ package serverconn
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -32,6 +33,31 @@ func (m *testServerMessage) ServiceMethod() mailboxrpc.ServiceMethod {
 // ToProto converts the test message to a protobuf payload.
 func (m *testServerMessage) ToProto() fn.Result[proto.Message] {
 	return fn.Ok[proto.Message](wrapperspb.String(m.value))
+}
+
+// testDurableUnaryBuilder is a minimal builder stub for durable query tests.
+type testDurableUnaryBuilder struct{}
+
+// BuildListOORRecipientEventsByScriptRequest builds a deterministic proto body
+// for recipient-events query tests.
+func (b *testDurableUnaryBuilder) BuildListOORRecipientEventsByScriptRequest(
+	_ context.Context, pkScript []byte, afterEventID uint64, limit uint32,
+) (proto.Message, error) {
+
+	return wrapperspb.String(fmt.Sprintf(
+		"recipient:%x:%d:%d", pkScript, afterEventID, limit,
+	)), nil
+}
+
+// BuildListVTXOsByScriptsRequest builds a deterministic proto body for
+// VTXO-by-scripts query tests.
+func (b *testDurableUnaryBuilder) BuildListVTXOsByScriptsRequest(
+	_ context.Context, pkScripts [][]byte, afterCursor uint64, limit uint32,
+) (proto.Message, error) {
+
+	return wrapperspb.String(fmt.Sprintf(
+		"vtxos:%d:%d:%d", len(pkScripts), afterCursor, limit,
+	)), nil
 }
 
 // newTestConnector builds a ServerConnectionActor with in-memory test
@@ -86,6 +112,40 @@ func sendResponseToMailbox(
 	require.True(t, status.Ok, "send response failed: %s", status.Message)
 }
 
+// sendRoutedResponseToMailbox injects a KIND_RESPONSE envelope that carries
+// service/method metadata so ingress can durably dispatch it when no unary
+// waiter is registered.
+func sendRoutedResponseToMailbox(
+	t *testing.T, mb *inMemoryMailbox, recipientID, correlationID,
+	service, method string, payload []byte,
+) {
+
+	t.Helper()
+
+	body := &anypb.Any{
+		TypeUrl: "test/response",
+		Value:   payload,
+	}
+
+	env := &mailboxpb.Envelope{
+		ProtocolVersion: 1,
+		Sender:          "server-1",
+		Recipient:       recipientID,
+		Body:            body,
+		Rpc: &mailboxpb.RpcMeta{
+			Kind:          mailboxpb.RpcMeta_KIND_RESPONSE,
+			CorrelationId: correlationID,
+			Service:       service,
+			Method:        method,
+			ReplyTo:       "server-1",
+		},
+	}
+
+	status := mb.send(env)
+	require.True(t, status.Ok, "send routed response failed: %s",
+		status.Message)
+}
+
 // sendEventToMailbox injects a KIND_EVENT envelope into the given mailbox
 // addressed to recipientID with the specified service/method.
 func sendEventToMailbox(
@@ -113,6 +173,52 @@ func sendEventToMailbox(
 
 	status := mb.send(env)
 	require.True(t, status.Ok, "send event failed: %s", status.Message)
+}
+
+// TestServerConnectionActor_SendListOORRecipientEventsByScriptRequest verifies
+// the transport-native durable recipient-events query is built and sent as a
+// unary mailbox request with the expected route metadata.
+func TestServerConnectionActor_SendListOORRecipientEventsByScriptRequest(
+	t *testing.T) {
+
+	t.Parallel()
+
+	actor, mb, _ := newTestConnector(t, nil)
+	actor.cfg.DurableUnaryBuilder = &testDurableUnaryBuilder{}
+
+	result := actor.Receive(
+		t.Context(),
+		&SendListOORRecipientEventsByScriptRequest{
+			PkScript:      []byte{0x51, 0x20, 0x01},
+			AfterEventID:  7,
+			Limit:         1,
+			CorrelationID: "corr-recipient",
+		},
+	)
+	require.NoError(t, result.Err())
+
+	mb.mu.Lock()
+	require.Len(t, mb.mailboxes["server-1"], 1)
+	env, ok := proto.Clone(
+		mb.mailboxes["server-1"][0],
+	).(*mailboxpb.Envelope)
+	require.True(t, ok)
+	mb.mu.Unlock()
+
+	require.Equal(
+		t, "arkrpc.IndexerService", env.GetRpc().GetService(),
+	)
+	require.Equal(
+		t, "ListOORRecipientEventsByScript",
+		env.GetRpc().GetMethod(),
+	)
+	require.Equal(
+		t, "corr-recipient", env.GetRpc().GetCorrelationId(),
+	)
+
+	payload := &wrapperspb.StringValue{}
+	require.NoError(t, env.GetBody().UnmarshalTo(payload))
+	require.Equal(t, "recipient:512001:7:1", payload.Value)
 }
 
 // TestIngress_DispatchAndAck verifies that the ingress loop pulls envelopes,
@@ -204,6 +310,52 @@ func TestIngress_ResponseDelivery(t *testing.T) {
 	require.Equal(
 		t, string(corrID), env.Rpc.CorrelationId,
 	)
+}
+
+// TestIngress_ResponseDispatchWithoutWaiter verifies that a KIND_RESPONSE
+// envelope without an in-memory unary waiter falls back to the durable
+// dispatcher map keyed by service and method.
+func TestIngress_ResponseDispatchWithoutWaiter(t *testing.T) {
+	t.Parallel()
+
+	var (
+		dispatched   []*mailboxpb.Envelope
+		dispatchedMu sync.Mutex
+	)
+
+	dispatchers := map[mailboxrpc.ServiceMethod]EnvelopeDispatcher{
+		{Service: "test.Svc", Method: "Unary"}: func(
+			ctx context.Context,
+			env *mailboxpb.Envelope,
+		) error {
+
+			dispatchedMu.Lock()
+			dispatched = append(dispatched, env)
+			dispatchedMu.Unlock()
+
+			return nil
+		},
+	}
+
+	actor, mb, _ := newTestConnector(t, dispatchers)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	require.NoError(t, actor.StartIngress(ctx))
+	defer actor.StopIngress()
+
+	sendRoutedResponseToMailbox(
+		t, mb, "client-1", "corr-routed", "test.Svc", "Unary",
+		[]byte("response-payload"),
+	)
+
+	require.Eventually(t, func() bool {
+		dispatchedMu.Lock()
+		defer dispatchedMu.Unlock()
+
+		return len(dispatched) == 1
+	}, 5*time.Second, 10*time.Millisecond)
 }
 
 // TestIngress_NoAckOnDispatchFailure verifies that when a dispatcher returns

--- a/serverconn/durable_unary_queries.go
+++ b/serverconn/durable_unary_queries.go
@@ -1,0 +1,479 @@
+package serverconn
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	"github.com/lightninglabs/darepo-client/baselib/actor"
+	mailboxconn "github.com/lightninglabs/darepo-client/mailbox/conn"
+	mailboxrpc "github.com/lightninglabs/darepo-client/mailbox/rpc"
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+const (
+	// SendListOORRecipientEventsByScriptRequestMsgType is the TLV type for
+	// durable proof-gated indexer queries that resolve a lightweight incoming
+	// OOR hint into the full recipient-event package.
+	SendListOORRecipientEventsByScriptRequestMsgType tlv.Type = 2003
+
+	// SendListVTXOsByScriptsRequestMsgType is the TLV type for durable
+	// proof-gated indexer queries that resolve authoritative incoming VTXO
+	// metadata by taproot output script.
+	SendListVTXOsByScriptsRequestMsgType tlv.Type = 2004
+)
+
+type (
+	listRecipientPkScriptRecordTLV    = tlv.TlvType1
+	listRecipientAfterEventRecordTLV  = tlv.TlvType2
+	listRecipientLimitRecordTLV       = tlv.TlvType3
+	listRecipientCorrelationRecordTLV = tlv.TlvType4
+	listRecipientMsgIDRecordTLV       = tlv.TlvType5
+	listRecipientIdempotencyRecordTLV = tlv.TlvType6
+	listVTXOsPkScriptsRecordTLV       = tlv.TlvType1
+	listVTXOsAfterCursorRecordTLV     = tlv.TlvType2
+	listVTXOsLimitRecordTLV           = tlv.TlvType3
+	listVTXOsCorrelationRecordTLV     = tlv.TlvType4
+	listVTXOsMsgIDRecordTLV           = tlv.TlvType5
+	listVTXOsIdempotencyRecordTLV     = tlv.TlvType6
+)
+
+// SendListOORRecipientEventsByScriptRequest describes a durable proof-gated
+// indexer unary query for one taproot output script.
+type SendListOORRecipientEventsByScriptRequest struct {
+	actor.BaseMessage
+
+	// PkScript is the taproot output script to query.
+	PkScript []byte
+
+	// AfterEventID is the exclusive lower bound for the recipient-event
+	// stream cursor.
+	AfterEventID uint64
+
+	// Limit is the maximum number of recipient events to return.
+	Limit uint32
+
+	// CorrelationID links this request to the eventual KIND_RESPONSE.
+	CorrelationID string
+
+	// MsgID uniquely identifies this send attempt. Retries of the same
+	// persisted request must reuse this ID.
+	MsgID string
+
+	// IdempotencyKey identifies the semantic operation for remote dedupe.
+	IdempotencyKey string
+}
+
+// MessageType returns a human-readable type name for logging.
+func (m *SendListOORRecipientEventsByScriptRequest) MessageType() string {
+	return "SendListOORRecipientEventsByScriptRequest"
+}
+
+// TLVType returns the unique TLV type identifier for this message.
+func (m *SendListOORRecipientEventsByScriptRequest) TLVType() tlv.Type {
+	return SendListOORRecipientEventsByScriptRequestMsgType
+}
+
+// ServiceMethod returns the fixed mailbox route for this indexer unary.
+func (m *SendListOORRecipientEventsByScriptRequest) ServiceMethod() mailboxrpc.ServiceMethod {
+
+	return mailboxrpc.ServiceMethod{
+		Service: "arkrpc.IndexerService",
+		Method:  "ListOORRecipientEventsByScript",
+	}
+}
+
+// Encode serializes the message to the provided writer.
+func (m *SendListOORRecipientEventsByScriptRequest) Encode(w io.Writer) error {
+	stableBytes, err := encodeRecipientEventsQueryIdentity(
+		m.PkScript, m.AfterEventID, m.Limit, m.CorrelationID,
+	)
+	if err != nil {
+		return err
+	}
+
+	msgID := m.MsgID
+	if msgID == "" {
+		msgID = mailboxconn.StableEventMsgID(stableBytes)
+	}
+
+	idempotencyKey := m.IdempotencyKey
+	if idempotencyKey == "" {
+		idempotencyKey = mailboxconn.
+			StableEventIdempotencyKey(stableBytes)
+	}
+
+	pkScriptRec := tlv.NewPrimitiveRecord[listRecipientPkScriptRecordTLV](
+		m.PkScript,
+	)
+	afterEventRec := tlv.NewPrimitiveRecord[listRecipientAfterEventRecordTLV](
+		m.AfterEventID,
+	)
+	limit := uint64(m.Limit)
+	limitRec := tlv.NewPrimitiveRecord[listRecipientLimitRecordTLV](
+		limit,
+	)
+	correlationRec := tlv.NewPrimitiveRecord[listRecipientCorrelationRecordTLV](
+		[]byte(m.CorrelationID),
+	)
+	msgIDRec := tlv.NewPrimitiveRecord[listRecipientMsgIDRecordTLV](
+		[]byte(msgID),
+	)
+	idempotencyRec := tlv.NewPrimitiveRecord[listRecipientIdempotencyRecordTLV](
+		[]byte(idempotencyKey),
+	)
+
+	stream, err := tlv.NewStream(
+		pkScriptRec.Record(), afterEventRec.Record(),
+		limitRec.Record(), correlationRec.Record(),
+		msgIDRec.Record(), idempotencyRec.Record(),
+	)
+	if err != nil {
+		return err
+	}
+
+	return stream.Encode(w)
+}
+
+// Decode deserializes the message from the provided reader.
+func (m *SendListOORRecipientEventsByScriptRequest) Decode(r io.Reader) error {
+	pkScriptRec := tlv.ZeroRecordT[listRecipientPkScriptRecordTLV, []byte]()
+	afterEventRec := tlv.ZeroRecordT[
+		listRecipientAfterEventRecordTLV,
+		uint64,
+	]()
+	limitRec := tlv.ZeroRecordT[listRecipientLimitRecordTLV, uint64]()
+	correlationRec := tlv.ZeroRecordT[
+		listRecipientCorrelationRecordTLV,
+		[]byte,
+	]()
+	msgIDRec := tlv.ZeroRecordT[listRecipientMsgIDRecordTLV, []byte]()
+	idempotencyRec := tlv.ZeroRecordT[
+		listRecipientIdempotencyRecordTLV,
+		[]byte,
+	]()
+
+	stream, err := tlv.NewStream(
+		pkScriptRec.Record(), afterEventRec.Record(),
+		limitRec.Record(), correlationRec.Record(),
+		msgIDRec.Record(), idempotencyRec.Record(),
+	)
+	if err != nil {
+		return err
+	}
+
+	if _, err := stream.DecodeWithParsedTypes(r); err != nil {
+		return err
+	}
+
+	m.PkScript = append([]byte(nil), pkScriptRec.Val...)
+	m.AfterEventID = afterEventRec.Val
+	if limitRec.Val > uint64(^uint32(0)) {
+		return fmt.Errorf("recipient query limit overflows uint32: %d",
+			limitRec.Val)
+	}
+	m.Limit = uint32(limitRec.Val)
+	m.CorrelationID = string(correlationRec.Val)
+	m.MsgID = string(msgIDRec.Val)
+	m.IdempotencyKey = string(idempotencyRec.Val)
+
+	return nil
+}
+
+// serverConnMsgSealed implements the ServerConnMsg interface seal.
+func (m *SendListOORRecipientEventsByScriptRequest) serverConnMsgSealed() {}
+
+// SendListVTXOsByScriptsRequest describes a durable proof-gated indexer unary
+// query for one or more taproot output scripts.
+type SendListVTXOsByScriptsRequest struct {
+	actor.BaseMessage
+
+	// PkScripts are the taproot output scripts to query.
+	PkScripts [][]byte
+
+	// AfterCursor is the exclusive lower bound for the VTXO query cursor.
+	AfterCursor uint64
+
+	// Limit is the maximum number of VTXOs to return.
+	Limit uint32
+
+	// CorrelationID links this request to the eventual KIND_RESPONSE.
+	CorrelationID string
+
+	// MsgID uniquely identifies this send attempt. Retries of the same
+	// persisted request must reuse this ID.
+	MsgID string
+
+	// IdempotencyKey identifies the semantic operation for remote dedupe.
+	IdempotencyKey string
+}
+
+// MessageType returns a human-readable type name for logging.
+func (m *SendListVTXOsByScriptsRequest) MessageType() string {
+	return "SendListVTXOsByScriptsRequest"
+}
+
+// TLVType returns the unique TLV type identifier for this message.
+func (m *SendListVTXOsByScriptsRequest) TLVType() tlv.Type {
+	return SendListVTXOsByScriptsRequestMsgType
+}
+
+// ServiceMethod returns the fixed mailbox route for this indexer unary.
+func (m *SendListVTXOsByScriptsRequest) ServiceMethod() mailboxrpc.ServiceMethod {
+	return mailboxrpc.ServiceMethod{
+		Service: "arkrpc.IndexerService",
+		Method:  "ListVTXOsByScripts",
+	}
+}
+
+// Encode serializes the message to the provided writer.
+func (m *SendListVTXOsByScriptsRequest) Encode(w io.Writer) error {
+	stableBytes, err := encodeVTXOsByScriptsQueryIdentity(
+		m.PkScripts, m.AfterCursor, m.Limit, m.CorrelationID,
+	)
+	if err != nil {
+		return err
+	}
+
+	msgID := m.MsgID
+	if msgID == "" {
+		msgID = mailboxconn.StableEventMsgID(stableBytes)
+	}
+
+	idempotencyKey := m.IdempotencyKey
+	if idempotencyKey == "" {
+		idempotencyKey = mailboxconn.
+			StableEventIdempotencyKey(stableBytes)
+	}
+
+	pkScriptsRaw, err := encodeLengthPrefixedBlobList(m.PkScripts)
+	if err != nil {
+		return err
+	}
+
+	pkScriptsRec := tlv.NewPrimitiveRecord[listVTXOsPkScriptsRecordTLV](
+		pkScriptsRaw,
+	)
+	afterCursorRec := tlv.NewPrimitiveRecord[listVTXOsAfterCursorRecordTLV](
+		m.AfterCursor,
+	)
+	limit := uint64(m.Limit)
+	limitRec := tlv.NewPrimitiveRecord[listVTXOsLimitRecordTLV](
+		limit,
+	)
+	correlationRec := tlv.NewPrimitiveRecord[listVTXOsCorrelationRecordTLV](
+		[]byte(m.CorrelationID),
+	)
+	msgIDRec := tlv.NewPrimitiveRecord[listVTXOsMsgIDRecordTLV](
+		[]byte(msgID),
+	)
+	idempotencyRec := tlv.NewPrimitiveRecord[listVTXOsIdempotencyRecordTLV](
+		[]byte(idempotencyKey),
+	)
+
+	stream, err := tlv.NewStream(
+		pkScriptsRec.Record(), afterCursorRec.Record(),
+		limitRec.Record(), correlationRec.Record(),
+		msgIDRec.Record(), idempotencyRec.Record(),
+	)
+	if err != nil {
+		return err
+	}
+
+	return stream.Encode(w)
+}
+
+// Decode deserializes the message from the provided reader.
+func (m *SendListVTXOsByScriptsRequest) Decode(r io.Reader) error {
+	pkScriptsRec := tlv.ZeroRecordT[listVTXOsPkScriptsRecordTLV, []byte]()
+	afterCursorRec := tlv.ZeroRecordT[
+		listVTXOsAfterCursorRecordTLV,
+		uint64,
+	]()
+	limitRec := tlv.ZeroRecordT[listVTXOsLimitRecordTLV, uint64]()
+	correlationRec := tlv.ZeroRecordT[
+		listVTXOsCorrelationRecordTLV,
+		[]byte,
+	]()
+	msgIDRec := tlv.ZeroRecordT[listVTXOsMsgIDRecordTLV, []byte]()
+	idempotencyRec := tlv.ZeroRecordT[
+		listVTXOsIdempotencyRecordTLV,
+		[]byte,
+	]()
+
+	stream, err := tlv.NewStream(
+		pkScriptsRec.Record(), afterCursorRec.Record(),
+		limitRec.Record(), correlationRec.Record(),
+		msgIDRec.Record(), idempotencyRec.Record(),
+	)
+	if err != nil {
+		return err
+	}
+
+	if _, err := stream.DecodeWithParsedTypes(r); err != nil {
+		return err
+	}
+
+	pkScripts, err := decodeLengthPrefixedBlobList(pkScriptsRec.Val)
+	if err != nil {
+		return err
+	}
+
+	if limitRec.Val > uint64(^uint32(0)) {
+		return fmt.Errorf("vtxo query limit overflows uint32: %d",
+			limitRec.Val)
+	}
+
+	m.PkScripts = pkScripts
+	m.AfterCursor = afterCursorRec.Val
+	m.Limit = uint32(limitRec.Val)
+	m.CorrelationID = string(correlationRec.Val)
+	m.MsgID = string(msgIDRec.Val)
+	m.IdempotencyKey = string(idempotencyRec.Val)
+
+	return nil
+}
+
+// serverConnMsgSealed implements the ServerConnMsg interface seal.
+func (m *SendListVTXOsByScriptsRequest) serverConnMsgSealed() {}
+
+// encodeRecipientEventsQueryIdentity encodes the stable identity material for
+// a recipient-events query.
+func encodeRecipientEventsQueryIdentity(pkScript []byte, afterEventID uint64,
+	limit uint32, correlationID string) ([]byte, error) {
+
+	var buf bytes.Buffer
+
+	if err := writeLengthPrefixedBlob(&buf, pkScript); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(
+		&buf, binary.BigEndian, afterEventID,
+	); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(
+		&buf, binary.BigEndian, limit,
+	); err != nil {
+		return nil, err
+	}
+	if err := writeLengthPrefixedBlob(
+		&buf, []byte(correlationID),
+	); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// encodeVTXOsByScriptsQueryIdentity encodes the stable identity material for
+// a VTXO-by-scripts query.
+func encodeVTXOsByScriptsQueryIdentity(pkScripts [][]byte,
+	afterCursor uint64, limit uint32,
+	correlationID string) ([]byte, error) {
+
+	var buf bytes.Buffer
+
+	pkScriptsRaw, err := encodeLengthPrefixedBlobList(pkScripts)
+	if err != nil {
+		return nil, err
+	}
+	if err := writeLengthPrefixedBlob(&buf, pkScriptsRaw); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(
+		&buf, binary.BigEndian, afterCursor,
+	); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(
+		&buf, binary.BigEndian, limit,
+	); err != nil {
+		return nil, err
+	}
+	if err := writeLengthPrefixedBlob(
+		&buf, []byte(correlationID),
+	); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// encodeLengthPrefixedBlobList encodes a blob list as a count-prefixed
+// sequence of length-prefixed byte slices.
+func encodeLengthPrefixedBlobList(blobs [][]byte) ([]byte, error) {
+	var buf bytes.Buffer
+
+	count := uint32(len(blobs))
+	if err := binary.Write(
+		&buf, binary.BigEndian, count,
+	); err != nil {
+		return nil, err
+	}
+
+	for i := range blobs {
+		if err := writeLengthPrefixedBlob(&buf, blobs[i]); err != nil {
+			return nil, err
+		}
+	}
+
+	return buf.Bytes(), nil
+}
+
+// decodeLengthPrefixedBlobList decodes a blob list encoded by
+// encodeLengthPrefixedBlobList.
+func decodeLengthPrefixedBlobList(raw []byte) ([][]byte, error) {
+	reader := bytes.NewReader(raw)
+
+	var count uint32
+	if err := binary.Read(
+		reader, binary.BigEndian, &count,
+	); err != nil {
+		return nil, err
+	}
+
+	blobs := make([][]byte, 0, count)
+	for i := uint32(0); i < count; i++ {
+		blob, err := readLengthPrefixedBlob(reader)
+		if err != nil {
+			return nil, err
+		}
+
+		blobs = append(blobs, blob)
+	}
+
+	if reader.Len() != 0 {
+		return nil, fmt.Errorf("unexpected trailing bytes in blob list")
+	}
+
+	return blobs, nil
+}
+
+// writeLengthPrefixedBlob encodes one length-prefixed byte slice.
+func writeLengthPrefixedBlob(w io.Writer, blob []byte) error {
+	size := uint32(len(blob))
+	if err := binary.Write(w, binary.BigEndian, size); err != nil {
+		return err
+	}
+
+	_, err := w.Write(blob)
+
+	return err
+}
+
+// readLengthPrefixedBlob decodes one length-prefixed byte slice.
+func readLengthPrefixedBlob(r *bytes.Reader) ([]byte, error) {
+	var size uint32
+	if err := binary.Read(r, binary.BigEndian, &size); err != nil {
+		return nil, err
+	}
+
+	blob := make([]byte, size)
+	if _, err := io.ReadFull(r, blob); err != nil {
+		return nil, err
+	}
+
+	return blob, nil
+}

--- a/serverconn/durable_unary_queries.go
+++ b/serverconn/durable_unary_queries.go
@@ -2,6 +2,7 @@ package serverconn
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -10,12 +11,14 @@ import (
 	mailboxconn "github.com/lightninglabs/darepo-client/mailbox/conn"
 	mailboxrpc "github.com/lightninglabs/darepo-client/mailbox/rpc"
 	"github.com/lightningnetwork/lnd/tlv"
+	"google.golang.org/protobuf/types/known/anypb"
 )
 
 const (
-	// SendListOORRecipientEventsByScriptRequestMsgType is the TLV type for
-	// durable proof-gated indexer queries that resolve a lightweight incoming
-	// OOR hint into the full recipient-event package.
+	// SendListOORRecipientEventsByScriptRequestMsgType is the TLV
+	// type for durable proof-gated indexer queries that resolve a
+	// lightweight incoming OOR hint into the full recipient-event
+	// package.
 	SendListOORRecipientEventsByScriptRequestMsgType tlv.Type = 2003
 
 	// SendListVTXOsByScriptsRequestMsgType is the TLV type for durable
@@ -76,12 +79,64 @@ func (m *SendListOORRecipientEventsByScriptRequest) TLVType() tlv.Type {
 }
 
 // ServiceMethod returns the fixed mailbox route for this indexer unary.
-func (m *SendListOORRecipientEventsByScriptRequest) ServiceMethod() mailboxrpc.ServiceMethod {
-
+func (m *SendListOORRecipientEventsByScriptRequest) ServiceMethod() mailboxrpc.ServiceMethod { //nolint:ll
 	return mailboxrpc.ServiceMethod{
 		Service: "arkrpc.IndexerService",
 		Method:  "ListOORRecipientEventsByScript",
 	}
+}
+
+// BuildBody constructs the proof-gated proto body and returns
+// stable identity bytes for deterministic ID derivation.
+func (m *SendListOORRecipientEventsByScriptRequest) BuildBody(
+	ctx context.Context,
+	builder DurableUnaryRequestBuilder,
+) (*anypb.Any, []byte, error) {
+
+	protoReq, err := builder.
+		BuildListOORRecipientEventsByScriptRequest(
+			ctx, m.PkScript, m.AfterEventID, m.Limit,
+		)
+	if err != nil {
+		return nil, nil, fmt.Errorf(
+			"build recipient-events request: %w", err,
+		)
+	}
+
+	body, err := anypb.New(protoReq)
+	if err != nil {
+		return nil, nil, fmt.Errorf(
+			"wrap in Any: %w", err,
+		)
+	}
+
+	stable, err := encodeRecipientEventsQueryIdentity(
+		m.PkScript, m.AfterEventID, m.Limit,
+		m.CorrelationID,
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf(
+			"encode identity: %w", err,
+		)
+	}
+
+	return body, stable, nil
+}
+
+// QueryCorrelationID returns the correlation ID.
+func (m *SendListOORRecipientEventsByScriptRequest) QueryCorrelationID() string { //nolint:ll
+	return m.CorrelationID
+}
+
+// QueryMsgID returns the caller-provided msg ID.
+func (m *SendListOORRecipientEventsByScriptRequest) QueryMsgID() string { //nolint:ll
+	return m.MsgID
+}
+
+// QueryIdempotencyKey returns the caller-provided idempotency
+// key.
+func (m *SendListOORRecipientEventsByScriptRequest) QueryIdempotencyKey() string { //nolint:ll
+	return m.IdempotencyKey
 }
 
 // Encode serializes the message to the provided writer.
@@ -107,20 +162,20 @@ func (m *SendListOORRecipientEventsByScriptRequest) Encode(w io.Writer) error {
 	pkScriptRec := tlv.NewPrimitiveRecord[listRecipientPkScriptRecordTLV](
 		m.PkScript,
 	)
-	afterEventRec := tlv.NewPrimitiveRecord[listRecipientAfterEventRecordTLV](
+	afterEventRec := tlv.NewPrimitiveRecord[listRecipientAfterEventRecordTLV]( //nolint:ll
 		m.AfterEventID,
 	)
 	limit := uint64(m.Limit)
 	limitRec := tlv.NewPrimitiveRecord[listRecipientLimitRecordTLV](
 		limit,
 	)
-	correlationRec := tlv.NewPrimitiveRecord[listRecipientCorrelationRecordTLV](
+	correlationRec := tlv.NewPrimitiveRecord[listRecipientCorrelationRecordTLV]( //nolint:ll
 		[]byte(m.CorrelationID),
 	)
 	msgIDRec := tlv.NewPrimitiveRecord[listRecipientMsgIDRecordTLV](
 		[]byte(msgID),
 	)
-	idempotencyRec := tlv.NewPrimitiveRecord[listRecipientIdempotencyRecordTLV](
+	idempotencyRec := tlv.NewPrimitiveRecord[listRecipientIdempotencyRecordTLV]( //nolint:ll
 		[]byte(idempotencyKey),
 	)
 
@@ -220,11 +275,63 @@ func (m *SendListVTXOsByScriptsRequest) TLVType() tlv.Type {
 }
 
 // ServiceMethod returns the fixed mailbox route for this indexer unary.
-func (m *SendListVTXOsByScriptsRequest) ServiceMethod() mailboxrpc.ServiceMethod {
+func (m *SendListVTXOsByScriptsRequest) ServiceMethod() mailboxrpc.ServiceMethod { //nolint:ll
 	return mailboxrpc.ServiceMethod{
 		Service: "arkrpc.IndexerService",
 		Method:  "ListVTXOsByScripts",
 	}
+}
+
+// BuildBody constructs the proof-gated proto body and returns
+// stable identity bytes for deterministic ID derivation.
+func (m *SendListVTXOsByScriptsRequest) BuildBody(
+	ctx context.Context,
+	builder DurableUnaryRequestBuilder,
+) (*anypb.Any, []byte, error) {
+
+	protoReq, err := builder.BuildListVTXOsByScriptsRequest(
+		ctx, m.PkScripts, m.AfterCursor, m.Limit,
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf(
+			"build vtxo query: %w", err,
+		)
+	}
+
+	body, err := anypb.New(protoReq)
+	if err != nil {
+		return nil, nil, fmt.Errorf(
+			"wrap in Any: %w", err,
+		)
+	}
+
+	stable, err := encodeVTXOsByScriptsQueryIdentity(
+		m.PkScripts, m.AfterCursor, m.Limit,
+		m.CorrelationID,
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf(
+			"encode identity: %w", err,
+		)
+	}
+
+	return body, stable, nil
+}
+
+// QueryCorrelationID returns the correlation ID.
+func (m *SendListVTXOsByScriptsRequest) QueryCorrelationID() string {
+	return m.CorrelationID
+}
+
+// QueryMsgID returns the caller-provided msg ID.
+func (m *SendListVTXOsByScriptsRequest) QueryMsgID() string {
+	return m.MsgID
+}
+
+// QueryIdempotencyKey returns the caller-provided idempotency
+// key.
+func (m *SendListVTXOsByScriptsRequest) QueryIdempotencyKey() string {
+	return m.IdempotencyKey
 }
 
 // Encode serializes the message to the provided writer.
@@ -477,3 +584,9 @@ func readLengthPrefixedBlob(r *bytes.Reader) ([]byte, error) {
 
 	return blob, nil
 }
+
+// Compile-time interface checks.
+var (
+	_ DurableUnaryQuery = (*SendListOORRecipientEventsByScriptRequest)(nil)
+	_ DurableUnaryQuery = (*SendListVTXOsByScriptsRequest)(nil)
+)

--- a/serverconn/event_router.go
+++ b/serverconn/event_router.go
@@ -80,81 +80,28 @@ func NewEventRouter(system actor.SystemContext) *EventRouter {
 // AddRoute registers a typed event route with the router. The generic
 // parameters [M, R] must match the ServiceKey's type parameters.
 //
-// AddRoute is a package-level generic function rather than a method because Go
-// does not allow methods with type parameters on non-generic types.
+// AddRoute is a thin wrapper around AddEnvelopeRoute that discards the
+// envelope in the Adapt closure. Use AddRoute when the handler does not need
+// transport metadata from the envelope.
 //
 // Registration is idempotent — re-registering the same (service, method) pair
 // replaces the previous route.
 func AddRoute[M actor.Message, R any](r *EventRouter,
 	cfg EventRouteConfig[M, R]) {
 
-	if cfg.Service == "" {
-		panic("serverconn: empty service name in EventRouteConfig")
-	}
-	if cfg.Method == "" {
-		panic("serverconn: empty method name in EventRouteConfig")
-	}
-	if cfg.NewEvent == nil {
-		panic("serverconn: nil NewEvent in EventRouteConfig")
-	}
-	if cfg.Adapt == nil {
-		panic("serverconn: nil Adapt in EventRouteConfig")
-	}
+	adapt := cfg.Adapt
 
-	// Capture config fields and system in a closure to produce the
-	// type-erased EnvelopeDispatcher. The closure owns the full dispatch
-	// chain: deserialize → adapt → Tell (persist to durable mailbox).
-	system := r.system
-	actorKey := cfg.Key
+	AddEnvelopeRoute(r, EnvelopeRouteConfig[M, R]{
+		Service:  cfg.Service,
+		Method:   cfg.Method,
+		NewEvent: cfg.NewEvent,
+		Key:      cfg.Key,
+		Adapt: func(_ *mailboxpb.Envelope,
+			p proto.Message) (M, error) {
 
-	dispatcher := func(ctx context.Context,
-		env *mailboxpb.Envelope) error {
-
-		if env == nil || env.Body == nil {
-			return fmt.Errorf("nil envelope or body for %s/%s",
-				cfg.Service, cfg.Method)
-		}
-
-		// Deserialize the envelope body. The body is an anypb.Any;
-		// its Value field carries the raw proto bytes of the inner
-		// event message. We unmarshal those bytes directly into the
-		// registered event type for forward-compatible decoding.
-		event := cfg.NewEvent()
-		if event == nil {
-			return fmt.Errorf("nil event prototype for %s/%s",
-				cfg.Service, cfg.Method)
-		}
-
-		if err := (proto.UnmarshalOptions{
-			DiscardUnknown: true,
-		}).Unmarshal(env.Body.Value, event); err != nil {
-			return fmt.Errorf("unmarshal %s/%s event: %w",
-				cfg.Service, cfg.Method, err)
-		}
-
-		// Convert the proto event to the actor's message type.
-		actorMsg, err := cfg.Adapt(event)
-		if err != nil {
-			return fmt.Errorf("adapt %s/%s event: %w",
-				cfg.Service, cfg.Method, err)
-		}
-
-		// Dispatch to the target actor via the service key. Ref
-		// returns a virtual router that load-balances across all
-		// registered actors for this key. Tell persists the message
-		// to the actor's durable mailbox before returning, satisfying
-		// the EnvelopeDispatcher contract of committed delivery.
-		return actorKey.Ref(system).Tell(ctx, actorMsg)
-	}
-
-	serviceMethod := mailboxrpc.ServiceMethod{
-		Service: cfg.Service,
-		Method:  cfg.Method,
-	}
-
-	r.mu.Lock()
-	r.routes[serviceMethod] = dispatcher
-	r.mu.Unlock()
+			return adapt(p)
+		},
+	})
 }
 
 // InboundEventRouteConfig holds parameters for registering an event route
@@ -179,6 +126,91 @@ type InboundEventRouteConfig[M InboundActorMessage, R any] struct {
 	// NewMsg must return a non-nil zero-value M. FromProto is called
 	// on the returned value to populate it from the deserialized event.
 	NewMsg func() M
+}
+
+// EnvelopeRouteConfig holds parameters for registering a typed event route
+// that has access to the full inbound envelope. This extends EventRouteConfig
+// by passing the envelope to the Adapt closure, which allows extracting
+// transport-level metadata that is not part of the proto body.
+type EnvelopeRouteConfig[M actor.Message, R any] struct {
+	// Service is the fully-qualified protobuf service name.
+	Service string
+
+	// Method is the protobuf method name.
+	Method string
+
+	// NewEvent must return a fresh zero-value proto.Message for
+	// the expected request or response type.
+	NewEvent func() proto.Message
+
+	// Key is the ServiceKey for the target actor.
+	Key actor.ServiceKey[M, R]
+
+	// Adapt converts the deserialized proto and envelope metadata into the
+	// actor message type M.
+	Adapt func(*mailboxpb.Envelope, proto.Message) (M, error)
+}
+
+// AddEnvelopeRoute registers a typed event route that receives the full
+// inbound envelope in its Adapt closure. This is useful when handlers need
+// transport metadata like the correlation ID on a unary response envelope.
+func AddEnvelopeRoute[M actor.Message, R any](r *EventRouter,
+	cfg EnvelopeRouteConfig[M, R]) {
+
+	if cfg.Service == "" {
+		panic("serverconn: empty service name in EnvelopeRouteConfig")
+	}
+	if cfg.Method == "" {
+		panic("serverconn: empty method name in EnvelopeRouteConfig")
+	}
+	if cfg.NewEvent == nil {
+		panic("serverconn: nil NewEvent in EnvelopeRouteConfig")
+	}
+	if cfg.Adapt == nil {
+		panic("serverconn: nil Adapt in EnvelopeRouteConfig")
+	}
+
+	system := r.system
+	actorKey := cfg.Key
+
+	dispatcher := func(ctx context.Context,
+		env *mailboxpb.Envelope) error {
+
+		if env == nil || env.Body == nil {
+			return fmt.Errorf("nil envelope or body for %s/%s",
+				cfg.Service, cfg.Method)
+		}
+
+		event := cfg.NewEvent()
+		if event == nil {
+			return fmt.Errorf("nil event prototype for %s/%s",
+				cfg.Service, cfg.Method)
+		}
+
+		if err := (proto.UnmarshalOptions{
+			DiscardUnknown: true,
+		}).Unmarshal(env.Body.Value, event); err != nil {
+			return fmt.Errorf("unmarshal %s/%s event: %w",
+				cfg.Service, cfg.Method, err)
+		}
+
+		actorMsg, err := cfg.Adapt(env, event)
+		if err != nil {
+			return fmt.Errorf("adapt %s/%s event: %w",
+				cfg.Service, cfg.Method, err)
+		}
+
+		return actorKey.Ref(system).Tell(ctx, actorMsg)
+	}
+
+	serviceMethod := mailboxrpc.ServiceMethod{
+		Service: cfg.Service,
+		Method:  cfg.Method,
+	}
+
+	r.mu.Lock()
+	r.routes[serviceMethod] = dispatcher
+	r.mu.Unlock()
 }
 
 // NewEventRoute registers a typed event route for actor message types that

--- a/serverconn/ingress.go
+++ b/serverconn/ingress.go
@@ -3,12 +3,14 @@ package serverconn
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"log/slog"
 	"math"
 	"math/rand/v2"
 	"time"
 
 	"github.com/lightninglabs/darepo-client/baselib/actor"
+	mailboxconn "github.com/lightninglabs/darepo-client/mailbox/conn"
 	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
 	mailboxrpc "github.com/lightninglabs/darepo-client/mailbox/rpc"
 )
@@ -199,9 +201,11 @@ func (a *ServerConnectionActor) pullBatch(
 // dispatchBatch iterates envelopes and routes each one to the correct
 // destination:
 //
-//   - KIND_RESPONSE: delivered to the response registry (unary waiters).
-//   - KIND_REQUEST/KIND_EVENT: dispatched to a local actor via the
-//     configured dispatch table.
+//   - KIND_RESPONSE: delivered to the response registry (unary waiters), or
+//     durably dispatched via the configured dispatch table when no waiter is
+//     registered for the correlation ID.
+//   - KIND_REQUEST/KIND_EVENT: dispatched to a local actor via the configured
+//     dispatch table.
 //
 // On success, returns the exclusive batch-next cursor (one past the last
 // envelope). On partial failure, returns the inclusive event_seq of the
@@ -228,9 +232,11 @@ func (a *ServerConnectionActor) dispatchBatch(
 
 		switch env.Rpc.Kind {
 		case mailboxpb.RpcMeta_KIND_RESPONSE:
-			// Route to response registry for unary RPC waiters.
-			// This is not a durable dispatch — the response is
-			// consumed immediately by the waiting goroutine.
+			// Prefer unary waiters for low-latency RPC
+			// callers. When no in-memory waiter is registered,
+			// fall back to the durable dispatch table so
+			// actor-driven unary flows can treat the response
+			// like any other ingress event.
 			corrID := CorrelationID(env.Rpc.CorrelationId)
 			if corrID == "" {
 				log.WarnS(ctx,
@@ -243,16 +249,39 @@ func (a *ServerConnectionActor) dispatchBatch(
 				continue
 			}
 
-			delivered := a.deliverResponse(corrID, env)
-			if !delivered {
+			delivery := a.deliverResponse(corrID, env)
+			if delivery == mailboxconn.DeliveryWaiter {
+				break
+			}
+
+			svcMethod := mailboxrpc.ServiceMethod{
+				Service: env.Rpc.Service,
+				Method:  env.Rpc.Method,
+			}
+			dispatcher, ok := a.cfg.Dispatchers[svcMethod]
+			if !ok {
 				log.WarnS(ctx,
 					"Failed to deliver response "+
 						"envelope",
 					nil,
+					slog.String("delivery_result",
+						fmt.Sprintf("%d", delivery)),
+					slog.String("service", env.Rpc.Service),
+					slog.String("method", env.Rpc.Method),
 					slog.String("correlation_id",
 						string(corrID)),
 					slog.Uint64("event_seq",
 						env.EventSeq))
+
+				break
+			}
+
+			if err := dispatcher(ctx, env); err != nil {
+				return lastCommitted, err
+			}
+
+			if delivery == mailboxconn.DeliveryBuffered {
+				a.removePendingResponse(corrID)
 			}
 
 		case mailboxpb.RpcMeta_KIND_REQUEST,

--- a/serverconn/types.go
+++ b/serverconn/types.go
@@ -9,6 +9,7 @@ import (
 	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
 	mailboxrpc "github.com/lightninglabs/darepo-client/mailbox/rpc"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
 )
 
 // CorrelationID links a mailbox request to its response.
@@ -51,6 +52,34 @@ type DurableUnaryRequestBuilder interface {
 		pkScripts [][]byte, afterCursor uint64, limit uint32) (
 		proto.Message, error,
 	)
+}
+
+// DurableUnaryQuery is implemented by transport-native durable query messages
+// that persist raw query parameters and need a DurableUnaryRequestBuilder to
+// construct the proof-gated proto body at send time. Implementations are
+// handled generically in Receive by building a SendUnaryRequest on the fly.
+type DurableUnaryQuery interface {
+	ServerConnMsg
+
+	// BuildBody constructs the proto request body and returns stable
+	// identity bytes for deterministic ID derivation.
+	BuildBody(ctx context.Context,
+		builder DurableUnaryRequestBuilder) (
+		body *anypb.Any, stableBytes []byte, err error,
+	)
+
+	// QueryCorrelationID returns the correlation ID for response routing.
+	QueryCorrelationID() string
+
+	// QueryMsgID returns the caller-provided msg ID (empty = auto-derive).
+	QueryMsgID() string
+
+	// QueryIdempotencyKey returns the caller-provided idempotency key
+	// (empty = auto-derive).
+	QueryIdempotencyKey() string
+
+	// ServiceMethod returns the mailbox route for this query.
+	ServiceMethod() mailboxrpc.ServiceMethod
 }
 
 // ConnectorConfig holds all dependencies and tuning knobs for the server

--- a/serverconn/types.go
+++ b/serverconn/types.go
@@ -8,6 +8,7 @@ import (
 	mailboxconn "github.com/lightninglabs/darepo-client/mailbox/conn"
 	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
 	mailboxrpc "github.com/lightninglabs/darepo-client/mailbox/rpc"
+	"google.golang.org/protobuf/proto"
 )
 
 // CorrelationID links a mailbox request to its response.
@@ -30,6 +31,27 @@ const ackStateType = mailboxconn.CheckpointStateType
 type EnvelopeDispatcher func(
 	ctx context.Context, env *mailboxpb.Envelope,
 ) error
+
+// DurableUnaryRequestBuilder constructs proof-gated unary request payloads
+// for durable transport messages that only persist the query spec. The
+// returned proto is wrapped into a mailbox KIND_REQUEST envelope after the
+// durable serverconn mailbox commit completes.
+type DurableUnaryRequestBuilder interface {
+	// BuildListOORRecipientEventsByScriptRequest builds the
+	// ListOORRecipientEventsByScript unary request for the given taproot
+	// output script and monotonic cursor.
+	BuildListOORRecipientEventsByScriptRequest(ctx context.Context,
+		pkScript []byte, afterEventID uint64, limit uint32) (
+		proto.Message, error,
+	)
+
+	// BuildListVTXOsByScriptsRequest builds the ListVTXOsByScripts unary
+	// request for the given taproot output scripts and cursor.
+	BuildListVTXOsByScriptsRequest(ctx context.Context,
+		pkScripts [][]byte, afterCursor uint64, limit uint32) (
+		proto.Message, error,
+	)
+}
 
 // ConnectorConfig holds all dependencies and tuning knobs for the server
 // connection actor. The connector is the single boundary for all mailbox
@@ -65,6 +87,11 @@ type ConnectorConfig struct {
 	// Codec handles TLV serialization of ServerConnMsg types for the
 	// durable actor mailbox.
 	Codec *actor.MessageCodec
+
+	// DurableUnaryBuilder constructs proof-gated unary request bodies for
+	// transport-native durable unary messages such as indexer script-scope
+	// queries. When nil, those message types are rejected.
+	DurableUnaryBuilder DurableUnaryRequestBuilder
 
 	// PullMaxEnvelopes bounds the number of envelopes returned per Pull
 	// call.


### PR DESCRIPTION
In this PR, we add the transport-layer plumbing for durable unary
request/response flows over the mailbox connection. The OOR receive path
needs to issue indexer queries (ListOORRecipientEventsByScript,
ListVTXOsByScripts) from within the durable actor transaction, but those
queries can't block the actor's DB write lock. The solution is a
transport-native durable message pattern: the actor emits a query message
in its outbox, the serverconn transport sends it after commit, and the
response routes back as a fresh durable message.

The first commit updates `ResponseRegistry` in `mailbox/conn` to return a
tri-state `DeliveryResult` (delivered, buffered, unknown) instead of a bare
bool. This lets the ingress layer distinguish "waiter got it" from "nobody
was listening yet" and fall back to durable route dispatch for the latter
case, so OOR metadata replies reach the actor even when the original unary
waiter has been cleaned up after a restart.

`serverconn/actor.go` then gains `SendUnaryRequest` with a bounded wait on
the response registry, plus `SendDurableUnaryRequest` which combines the
unary send with a fallback durable dispatch path. If the response arrives
after the waiter times out (e.g. actor restarted), the ingress routes it
through the normal durable event path instead of dropping it.

The final commit introduces the transport-native durable query messages
themselves: `SendListOORRecipientEventsByScriptRequest` and
`SendListVTXOsByScriptsRequest` in `serverconn/durable_unary_queries.go`.
These are TLV-encoded outbox messages that the serverconn actor processes
after commit, issuing the indexer query and routing the response back to
the OOR actor as a `DriveEventRequest`. The `DurableUnaryBuilder` type
provides a clean factory interface for constructing these from the OOR
actor side.

Builds on #187.