### PR TITLE
oor: three-phase async receive with durable materialization

### DIFF
--- a/baselib/actor/tx_context.go
+++ b/baselib/actor/tx_context.go
@@ -95,6 +95,13 @@ func WithOutboxID(ctx context.Context, id string) context.Context {
 	return context.WithValue(ctx, outboxIDContextKey{}, id)
 }
 
+// WithoutOutboxID returns a new context with any propagated outbox message ID
+// shadowed. This is used for internal async callbacks so they do not
+// accidentally reuse the caller's CDC deduplication identity.
+func WithoutOutboxID(ctx context.Context) context.Context {
+	return context.WithValue(ctx, outboxIDContextKey{}, "")
+}
+
 // OutboxIDFromContext retrieves the outbox message ID from the context, if
 // present. Returns the ID and true if found, empty string and false otherwise.
 func OutboxIDFromContext(ctx context.Context) (string, bool) {

--- a/baselib/actor/tx_context_test.go
+++ b/baselib/actor/tx_context_test.go
@@ -75,3 +75,28 @@ func TestWithoutTxOnCleanContext(t *testing.T) {
 	require.False(t, ok)
 	require.Nil(t, tx)
 }
+
+// TestWithoutOutboxIDStripsPropagatedID verifies that internal async callbacks
+// can shadow a propagated outbox ID so they don't accidentally reuse CDC
+// deduplication identity from the inbound durable delivery.
+func TestWithoutOutboxIDStripsPropagatedID(t *testing.T) {
+	t.Parallel()
+
+	type customKey struct{}
+
+	ctx := context.WithValue(context.Background(), customKey{}, "preserved")
+	ctx = WithOutboxID(ctx, "outbox-123")
+
+	id, ok := OutboxIDFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, "outbox-123", id)
+
+	stripped := WithoutOutboxID(ctx)
+
+	id, ok = OutboxIDFromContext(stripped)
+	require.False(t, ok)
+	require.Empty(t, id)
+
+	val := stripped.Value(customKey{})
+	require.Equal(t, "preserved", val)
+}

--- a/mailbox/conn/AGENTS.md
+++ b/mailbox/conn/AGENTS.md
@@ -1,0 +1,74 @@
+# mailbox/conn
+
+## Purpose
+
+Reusable mailbox connector primitives shared by client-side and server-side
+connector runtimes. Contains protocol-adjacent building blocks only: typed
+identifiers, deterministic idempotency helpers, ack watermark state machine
+encoding, and the in-memory response waiter registry for unary correlation
+delivery.
+
+## Key Types
+
+- `CorrelationID` — Typed string linking a mailbox KIND_REQUEST to its
+  KIND_RESPONSE. Used as the registry key in `ResponseRegistry`.
+- `IdempotencyKey` — Typed string for server-side semantic deduplication
+  across retries. Stable across retries; differs from `msg_id`.
+- `AckState` — Four-cursor watermark state machine
+  (`PullCursor`, `DispatchCommittedTo`, `AckTarget`, `AckCommittedTo`)
+  that governs safe ack progression. Serialized to/from TLV for checkpoint
+  persistence (checkpoint type `"AckState"`). Invariant:
+  `AckCommittedTo <= DispatchCommittedTo`.
+- `ResponseRegistry` — In-memory waiter registry for unary RPC correlation.
+  Maps `CorrelationID` to `actor.Promise[*mailboxpb.Envelope]`. Supports
+  three scenarios: waiter registered before response, response arrives
+  before waiter (buffered), and stale cleanup via configurable TTL.
+- `DeliveryResult` — Tri-state enum returned by `ResponseRegistry.DeliverResponse`:
+  - `DeliveryWaiter` — Response completed an active in-memory waiter.
+  - `DeliveryBuffered` — Response buffered; no waiter registered yet.
+  - `DeliveryDropped` — Response could not be stored or delivered (nil
+    envelope or proto clone failure).
+  `DeliveryResult` implements `String()` for human-readable logging.
+- `WrappedProto` — TLV bridging type that adapts a `proto.Message` for use
+  as a `tlv.RecordT` field; marshals/unmarshals via `proto.Marshal` /
+  `proto.Unmarshal`.
+- `StableEventMsgID` / `StableEventIdempotencyKey` — Deterministic ID
+  derivation from payload bytes (SHA-256, first 16 bytes, hex-encoded with
+  `"evt-"` / `"idem-"` prefix). Used by durable query types in `serverconn`
+  to auto-derive stable IDs when the caller leaves them empty.
+- `DefaultResponseWaiterTTL` — Default 10-minute TTL for stale waiter and
+  buffered response cleanup.
+- `ErrWaiterExpired` / `ErrWaiterCancelled` — Sentinel errors signaled to
+  blocked `AwaitRPC` callers when a waiter is pruned or explicitly removed.
+
+## Relationships
+
+- **Depends on**: `baselib/actor` (Promise/Future types), `mailbox/pb`
+  (Envelope proto), `lnd/tlv`.
+- **Depended on by**: `serverconn` (uses `AckState`, `ResponseRegistry`,
+  `WrappedProto`, `StableEventMsgID`/`StableEventIdempotencyKey`,
+  `CorrelationID`/`IdempotencyKey`).
+
+## Invariants
+
+- `msg_id` differs on each retry; `idempotency_key` is stable across
+  retries for server deduplication.
+- `AckState` cursors are monotonic and must not decrease during normal
+  operation. `AdvanceDispatch` and `AdvanceAck` enforce this.
+- `ResponseRegistry.DeliverResponse` buffers at most one response per
+  `CorrelationID`; duplicate arrivals before a waiter are ignored (returns
+  `DeliveryBuffered` without overwriting).
+- Stale waiters are completed with `ErrWaiterExpired` (not silently dropped)
+  so blocked callers wake up with a clear error rather than hanging
+  indefinitely.
+- `WrappedProto` callers must use `tlv.NewRecordT` to assign the real TLV
+  type; calling `Record()` directly yields type 0 and would silently conflict
+  with other type-0 records.
+
+## Deep Docs
+
+- [mailbox/conn/doc.go](doc.go) — Package overview.
+- [mailbox/CLAUDE.md](../CLAUDE.md) — Parent package overview.
+- [docs/mailbox_architecture.md](../../docs/mailbox_architecture.md) — Full three-layer mailbox architecture.
+- [docs/RPC_MAILBOX_CONTRACT.md](../../docs/RPC_MAILBOX_CONTRACT.md) — Envelope semantics and ack watermarks.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/mailbox/conn/CLAUDE.md
+++ b/mailbox/conn/CLAUDE.md
@@ -1,0 +1,74 @@
+# mailbox/conn
+
+## Purpose
+
+Reusable mailbox connector primitives shared by client-side and server-side
+connector runtimes. Contains protocol-adjacent building blocks only: typed
+identifiers, deterministic idempotency helpers, ack watermark state machine
+encoding, and the in-memory response waiter registry for unary correlation
+delivery.
+
+## Key Types
+
+- `CorrelationID` — Typed string linking a mailbox KIND_REQUEST to its
+  KIND_RESPONSE. Used as the registry key in `ResponseRegistry`.
+- `IdempotencyKey` — Typed string for server-side semantic deduplication
+  across retries. Stable across retries; differs from `msg_id`.
+- `AckState` — Four-cursor watermark state machine
+  (`PullCursor`, `DispatchCommittedTo`, `AckTarget`, `AckCommittedTo`)
+  that governs safe ack progression. Serialized to/from TLV for checkpoint
+  persistence (checkpoint type `"AckState"`). Invariant:
+  `AckCommittedTo <= DispatchCommittedTo`.
+- `ResponseRegistry` — In-memory waiter registry for unary RPC correlation.
+  Maps `CorrelationID` to `actor.Promise[*mailboxpb.Envelope]`. Supports
+  three scenarios: waiter registered before response, response arrives
+  before waiter (buffered), and stale cleanup via configurable TTL.
+- `DeliveryResult` — Tri-state enum returned by `ResponseRegistry.DeliverResponse`:
+  - `DeliveryWaiter` — Response completed an active in-memory waiter.
+  - `DeliveryBuffered` — Response buffered; no waiter registered yet.
+  - `DeliveryDropped` — Response could not be stored or delivered (nil
+    envelope or proto clone failure).
+  `DeliveryResult` implements `String()` for human-readable logging.
+- `WrappedProto` — TLV bridging type that adapts a `proto.Message` for use
+  as a `tlv.RecordT` field; marshals/unmarshals via `proto.Marshal` /
+  `proto.Unmarshal`.
+- `StableEventMsgID` / `StableEventIdempotencyKey` — Deterministic ID
+  derivation from payload bytes (SHA-256, first 16 bytes, hex-encoded with
+  `"evt-"` / `"idem-"` prefix). Used by durable query types in `serverconn`
+  to auto-derive stable IDs when the caller leaves them empty.
+- `DefaultResponseWaiterTTL` — Default 10-minute TTL for stale waiter and
+  buffered response cleanup.
+- `ErrWaiterExpired` / `ErrWaiterCancelled` — Sentinel errors signaled to
+  blocked `AwaitRPC` callers when a waiter is pruned or explicitly removed.
+
+## Relationships
+
+- **Depends on**: `baselib/actor` (Promise/Future types), `mailbox/pb`
+  (Envelope proto), `lnd/tlv`.
+- **Depended on by**: `serverconn` (uses `AckState`, `ResponseRegistry`,
+  `WrappedProto`, `StableEventMsgID`/`StableEventIdempotencyKey`,
+  `CorrelationID`/`IdempotencyKey`).
+
+## Invariants
+
+- `msg_id` differs on each retry; `idempotency_key` is stable across
+  retries for server deduplication.
+- `AckState` cursors are monotonic and must not decrease during normal
+  operation. `AdvanceDispatch` and `AdvanceAck` enforce this.
+- `ResponseRegistry.DeliverResponse` buffers at most one response per
+  `CorrelationID`; duplicate arrivals before a waiter are ignored (returns
+  `DeliveryBuffered` without overwriting).
+- Stale waiters are completed with `ErrWaiterExpired` (not silently dropped)
+  so blocked callers wake up with a clear error rather than hanging
+  indefinitely.
+- `WrappedProto` callers must use `tlv.NewRecordT` to assign the real TLV
+  type; calling `Record()` directly yields type 0 and would silently conflict
+  with other type-0 records.
+
+## Deep Docs
+
+- [mailbox/conn/doc.go](doc.go) — Package overview.
+- [mailbox/CLAUDE.md](../CLAUDE.md) — Parent package overview.
+- [docs/mailbox_architecture.md](../../docs/mailbox_architecture.md) — Full three-layer mailbox architecture.
+- [docs/RPC_MAILBOX_CONTRACT.md](../../docs/RPC_MAILBOX_CONTRACT.md) — Envelope semantics and ack watermarks.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/oor/AGENTS.md
+++ b/oor/AGENTS.md
@@ -8,26 +8,83 @@ resume semantics.
 
 ## Key Types
 
+### Session Identifiers and FSM Infrastructure
+
 - `SessionID` — Stable session identifier (Ark txid hash in v0).
 - `Environment` — FSM environment providing SessionID and external system access.
 - `OutboxHandler` — Interface for executing FSM outbox requests (RPC, signing, persistence).
 - `SignArkPSBT` — Signs Ark PSBT inputs using the client key on the checkpoint 2-of-2 collab leaf; uses `MultiPrevOutFetcher` for correct BIP-341 sighash across multiple inputs.
 - `ClientActorCfg` — Configuration for OORClientActor (OutboxHandler,
   ServerConn, PackageStore, DeliveryStore, VTXOManager).
-- `IncomingVTXOMetadata` — Lineage metadata for incoming OOR VTXOs including `ChainDepth` (OOR checkpoint hop count).
 - `OORClientActor` — Durable actor wrapping per-session state machines. Handles both outgoing transfers and incoming receive via three-phase async resolution.
-- `ResolveIncomingTransferRequest` — TLV-durable message persisted by the
-  ingress route, resumed via a durable unary indexer query.
-- `QueryIncomingTransferRequest` / `QueryIncomingMetadataRequest` — durable
-  transport outbox events that `oor/actor.go` maps to transport-native
-  durable `serverconn` query messages after commit.
-- `serverconn.SendListOORRecipientEventsByScriptRequest` /
-  `serverconn.SendListVTXOsByScriptsRequest` — durable post-commit transport
-  messages used to resolve incoming hints and authoritative metadata.
-- `AdaptIncomingOOREvent` / `NewResolveIncomingTransferRequest` — Shared adapters for the notification→query pattern used by both darepod and systest.
+
+### Actor Messages (OORDurableMsg / ActorMsg)
+
+- `ResolveIncomingTransferRequest` — TLV-durable actor message (TLV type
+  `0x7016`) persisted by the ingress route. Carries SessionID,
+  RecipientPkScript, and RecipientEventID so the actor can resume
+  phase-1 indexer resolution after a crash.
+- `DriveEventRequest` — Generic actor message that wraps an Event and a
+  SessionID; used to feed FSM events back into a running session from
+  outbox callbacks and durable unary response routes.
+
+### Outbox Events (OutboxEvent)
+
+- `QueryIncomingTransferRequest` — Outbox event emitted after persisting
+  `ReceiveResolving`; actor.go maps this to a
+  `serverconn.SendListOORRecipientEventsByScriptRequest` durable query.
+- `QueryIncomingMetadataRequest` — Outbox event emitted after
+  `IncomingTransferEvent` is processed; actor.go maps this to a
+  `serverconn.SendListVTXOsByScriptsRequest` durable query.
+- `MaterializeIncomingVTXOsRequest` — Outbox event carrying the Ark PSBT,
+  checkpoint PSBTs, recipients, and resolved `MetadataMatches`; sent to
+  the wallet/state layer to persist incoming VTXO records.
+- `SendIncomingAckRequest` — Outbox event that asks the transport layer to
+  ack the incoming transfer to the server.
+
+### Events (Event / ReceiveState)
+
+- `IncomingTransferEvent` — FSM event carrying the full Ark PSBT and
+  checkpoint PSBTs for an incoming transfer; delivered by the phase-1
+  durable unary response route.
+- `IncomingMetadataResolvedEvent` — FSM event delivering authoritative
+  metadata query results back into the receive FSM; delivered by the
+  phase-2 durable unary response route.
+- `IncomingHandledEvent` — FSM event indicating the wallet layer has
+  persisted incoming VTXOs; carries `MaterializedOutpoints` for the
+  durable callback round-trip.
+
+### Incoming Receive FSM States (ReceiveState)
+
+- `ReceiveIdle` — Initial state; no pending incoming transfer.
+- `ReceiveResolving` — Durable hint persisted; waiting for the phase-1
+  indexer query (ListOORRecipientEventsByScript) to return the full Ark
+  package outside the actor transaction.
+- `ReceiveNotified` — Full Ark/checkpoint package received; waiting for
+  local materialization to complete.
+- `ReceiveAwaitingAck` — VTXOs materialized; waiting for ack transport to
+  complete.
+- `ReceiveCompleted` — Terminal success state.
+
+### Shared Adapters and Metadata Types
+
+- `IncomingVTXOMetadata` — Lineage metadata for incoming OOR VTXOs including `ChainDepth` (OOR checkpoint hop count).
+- `IncomingMetadataMatch` — Authoritative metadata for one materialized
+  incoming Ark output, keyed by OutputIndex.
+- `IncomingMetadataMatchesFromResponse` — Filters a
+  `ListVTXOsByScriptsResponse` down to outputs matching the current Ark
+  session and converts them to `[]IncomingMetadataMatch`.
+- `IncomingTransferEventFromResponse` — Validates and converts one
+  `ListOORRecipientEventsByScriptResponse` payload into an
+  `IncomingTransferEvent` for the receive FSM.
+- `NewResolveIncomingTransferRequest` — Converts a lightweight
+  `IncomingOOREvent` notification proto into a
+  `ResolveIncomingTransferRequest`; shared by darepod and systest.
+- `IncomingResolveCorrelationID` / `ParseIncomingResolveCorrelationID` —
+  Stable correlation ID helpers for phase-1 durable queries.
+- `IncomingMetadataCorrelationID` / `ParseIncomingMetadataCorrelationID` —
+  Stable correlation ID helpers for phase-2 durable queries.
 - `NewOutboxHandler` / `OutboxHandlerConfig` — Shared factory for the standard two-layer outbox handler chain (LocalPersistenceOutboxHandler → SigningOutboxHandler).
-- `ReceiveResolving` — FSM state indicating a durable hint is persisted and
-  pending the post-commit unary indexer resolution.
 
 ## Relationships
 
@@ -35,6 +92,7 @@ resume semantics.
 - **Depended on by**: `darepod` (wiring).
 - **Sends**:
   - → `serverconn`: `SendSubmitPackageRequest`, `SendFinalizePackageRequest`, `SendIncomingAckRequest`
+  - → `serverconn` (durable unary, via outbox): `QueryIncomingTransferRequest` → `SendListOORRecipientEventsByScriptRequest`; `QueryIncomingMetadataRequest` → `SendListVTXOsByScriptsRequest`
   - → `db` (via outbox): `MarkInputsSpentRequest`
   - → `wallet`: `MaterializeIncomingVTXOsRequest`
   - → `vtxo` manager: `VTXOsMaterializedNotification` (after incoming VTXOs are durably materialized)

--- a/oor/AGENTS.md
+++ b/oor/AGENTS.md
@@ -12,9 +12,22 @@ resume semantics.
 - `Environment` — FSM environment providing SessionID and external system access.
 - `OutboxHandler` — Interface for executing FSM outbox requests (RPC, signing, persistence).
 - `SignArkPSBT` — Signs Ark PSBT inputs using the client key on the checkpoint 2-of-2 collab leaf; uses `MultiPrevOutFetcher` for correct BIP-341 sighash across multiple inputs.
-- `ClientActorCfg` — Configuration for OORClientActor (OutboxHandler, ServerConn, PackageStore, DeliveryStore, VTXOManager).
+- `ClientActorCfg` — Configuration for OORClientActor (OutboxHandler,
+  ServerConn, PackageStore, DeliveryStore, VTXOManager).
 - `IncomingVTXOMetadata` — Lineage metadata for incoming OOR VTXOs including `ChainDepth` (OOR checkpoint hop count).
-- `OORClientActor` — Durable actor wrapping per-session state machines.
+- `OORClientActor` — Durable actor wrapping per-session state machines. Handles both outgoing transfers and incoming receive via three-phase async resolution.
+- `ResolveIncomingTransferRequest` — TLV-durable message persisted by the
+  ingress route, resumed via a durable unary indexer query.
+- `QueryIncomingTransferRequest` / `QueryIncomingMetadataRequest` — durable
+  transport outbox events that `oor/actor.go` maps to transport-native
+  durable `serverconn` query messages after commit.
+- `serverconn.SendListOORRecipientEventsByScriptRequest` /
+  `serverconn.SendListVTXOsByScriptsRequest` — durable post-commit transport
+  messages used to resolve incoming hints and authoritative metadata.
+- `AdaptIncomingOOREvent` / `NewResolveIncomingTransferRequest` — Shared adapters for the notification→query pattern used by both darepod and systest.
+- `NewOutboxHandler` / `OutboxHandlerConfig` — Shared factory for the standard two-layer outbox handler chain (LocalPersistenceOutboxHandler → SigningOutboxHandler).
+- `ReceiveResolving` — FSM state indicating a durable hint is persisted and
+  pending the post-commit unary indexer resolution.
 
 ## Relationships
 
@@ -26,7 +39,12 @@ resume semantics.
   - → `wallet`: `MaterializeIncomingVTXOsRequest`
   - → `vtxo` manager: `VTXOsMaterializedNotification` (after incoming VTXOs are durably materialized)
 - **Receives**:
-  - ← `serverconn` (via EventRouter): `SubmitAcceptedEvent`, `FinalizeAcceptedEvent`, `IncomingTransferEvent`
+  - ← `serverconn` (via EventRouter): `SubmitAcceptedEvent`, `FinalizeAcceptedEvent`, `ResolveIncomingTransferRequest`
+  - ← `serverconn` durable unary response routes:
+    `DriveEventRequest{IncomingTransferEvent}`,
+    `DriveEventRequest{IncomingMetadataResolvedEvent}`
+  - ← local persistence callback path:
+    `DriveEventRequest{IncomingHandledEvent}`
   - ← API: `StartTransferRequest`, `DriveEventRequest`, `RestoreSessionRequest`, `ResumeSessionRequest`
 
 ## Invariants
@@ -37,6 +55,11 @@ resume semantics.
 - After checkpoint signature, client must resume and obtain byte-identical co-signed PSBTs (deterministic construction).
 - Transport outbox events (submit, finalize, ack) are Tell'd to ServerConn within the actor's DB transaction for atomic enqueue (same-DB tx joining via `ExecTx`).
 - Package persistence tracks finalized outgoing packages and local input bindings for recovery.
+- Incoming receive never performs synchronous unary RPCs inside the durable
+  actor DB transaction. Both incoming-hint resolution and authoritative
+  metadata lookup are emitted as transport-native durable `serverconn`
+  query messages and delivered back as fresh durable messages.
+- `LocalPersistenceOutboxHandler.CallbackRef` receives async materialization results so indexer queries run outside the actor tx, preventing SQLite write-lock starvation.
 
 ## Deep Docs
 

--- a/oor/CLAUDE.md
+++ b/oor/CLAUDE.md
@@ -8,26 +8,83 @@ resume semantics.
 
 ## Key Types
 
+### Session Identifiers and FSM Infrastructure
+
 - `SessionID` — Stable session identifier (Ark txid hash in v0).
 - `Environment` — FSM environment providing SessionID and external system access.
 - `OutboxHandler` — Interface for executing FSM outbox requests (RPC, signing, persistence).
 - `SignArkPSBT` — Signs Ark PSBT inputs using the client key on the checkpoint 2-of-2 collab leaf; uses `MultiPrevOutFetcher` for correct BIP-341 sighash across multiple inputs.
 - `ClientActorCfg` — Configuration for OORClientActor (OutboxHandler,
   ServerConn, PackageStore, DeliveryStore, VTXOManager).
-- `IncomingVTXOMetadata` — Lineage metadata for incoming OOR VTXOs including `ChainDepth` (OOR checkpoint hop count).
 - `OORClientActor` — Durable actor wrapping per-session state machines. Handles both outgoing transfers and incoming receive via three-phase async resolution.
-- `ResolveIncomingTransferRequest` — TLV-durable message persisted by the
-  ingress route, resumed via a durable unary indexer query.
-- `QueryIncomingTransferRequest` / `QueryIncomingMetadataRequest` — durable
-  transport outbox events that `oor/actor.go` maps to transport-native
-  durable `serverconn` query messages after commit.
-- `serverconn.SendListOORRecipientEventsByScriptRequest` /
-  `serverconn.SendListVTXOsByScriptsRequest` — durable post-commit transport
-  messages used to resolve incoming hints and authoritative metadata.
-- `AdaptIncomingOOREvent` / `NewResolveIncomingTransferRequest` — Shared adapters for the notification→query pattern used by both darepod and systest.
+
+### Actor Messages (OORDurableMsg / ActorMsg)
+
+- `ResolveIncomingTransferRequest` — TLV-durable actor message (TLV type
+  `0x7016`) persisted by the ingress route. Carries SessionID,
+  RecipientPkScript, and RecipientEventID so the actor can resume
+  phase-1 indexer resolution after a crash.
+- `DriveEventRequest` — Generic actor message that wraps an Event and a
+  SessionID; used to feed FSM events back into a running session from
+  outbox callbacks and durable unary response routes.
+
+### Outbox Events (OutboxEvent)
+
+- `QueryIncomingTransferRequest` — Outbox event emitted after persisting
+  `ReceiveResolving`; actor.go maps this to a
+  `serverconn.SendListOORRecipientEventsByScriptRequest` durable query.
+- `QueryIncomingMetadataRequest` — Outbox event emitted after
+  `IncomingTransferEvent` is processed; actor.go maps this to a
+  `serverconn.SendListVTXOsByScriptsRequest` durable query.
+- `MaterializeIncomingVTXOsRequest` — Outbox event carrying the Ark PSBT,
+  checkpoint PSBTs, recipients, and resolved `MetadataMatches`; sent to
+  the wallet/state layer to persist incoming VTXO records.
+- `SendIncomingAckRequest` — Outbox event that asks the transport layer to
+  ack the incoming transfer to the server.
+
+### Events (Event / ReceiveState)
+
+- `IncomingTransferEvent` — FSM event carrying the full Ark PSBT and
+  checkpoint PSBTs for an incoming transfer; delivered by the phase-1
+  durable unary response route.
+- `IncomingMetadataResolvedEvent` — FSM event delivering authoritative
+  metadata query results back into the receive FSM; delivered by the
+  phase-2 durable unary response route.
+- `IncomingHandledEvent` — FSM event indicating the wallet layer has
+  persisted incoming VTXOs; carries `MaterializedOutpoints` for the
+  durable callback round-trip.
+
+### Incoming Receive FSM States (ReceiveState)
+
+- `ReceiveIdle` — Initial state; no pending incoming transfer.
+- `ReceiveResolving` — Durable hint persisted; waiting for the phase-1
+  indexer query (ListOORRecipientEventsByScript) to return the full Ark
+  package outside the actor transaction.
+- `ReceiveNotified` — Full Ark/checkpoint package received; waiting for
+  local materialization to complete.
+- `ReceiveAwaitingAck` — VTXOs materialized; waiting for ack transport to
+  complete.
+- `ReceiveCompleted` — Terminal success state.
+
+### Shared Adapters and Metadata Types
+
+- `IncomingVTXOMetadata` — Lineage metadata for incoming OOR VTXOs including `ChainDepth` (OOR checkpoint hop count).
+- `IncomingMetadataMatch` — Authoritative metadata for one materialized
+  incoming Ark output, keyed by OutputIndex.
+- `IncomingMetadataMatchesFromResponse` — Filters a
+  `ListVTXOsByScriptsResponse` down to outputs matching the current Ark
+  session and converts them to `[]IncomingMetadataMatch`.
+- `IncomingTransferEventFromResponse` — Validates and converts one
+  `ListOORRecipientEventsByScriptResponse` payload into an
+  `IncomingTransferEvent` for the receive FSM.
+- `NewResolveIncomingTransferRequest` — Converts a lightweight
+  `IncomingOOREvent` notification proto into a
+  `ResolveIncomingTransferRequest`; shared by darepod and systest.
+- `IncomingResolveCorrelationID` / `ParseIncomingResolveCorrelationID` —
+  Stable correlation ID helpers for phase-1 durable queries.
+- `IncomingMetadataCorrelationID` / `ParseIncomingMetadataCorrelationID` —
+  Stable correlation ID helpers for phase-2 durable queries.
 - `NewOutboxHandler` / `OutboxHandlerConfig` — Shared factory for the standard two-layer outbox handler chain (LocalPersistenceOutboxHandler → SigningOutboxHandler).
-- `ReceiveResolving` — FSM state indicating a durable hint is persisted and
-  pending the post-commit unary indexer resolution.
 
 ## Relationships
 
@@ -35,6 +92,7 @@ resume semantics.
 - **Depended on by**: `darepod` (wiring).
 - **Sends**:
   - → `serverconn`: `SendSubmitPackageRequest`, `SendFinalizePackageRequest`, `SendIncomingAckRequest`
+  - → `serverconn` (durable unary, via outbox): `QueryIncomingTransferRequest` → `SendListOORRecipientEventsByScriptRequest`; `QueryIncomingMetadataRequest` → `SendListVTXOsByScriptsRequest`
   - → `db` (via outbox): `MarkInputsSpentRequest`
   - → `wallet`: `MaterializeIncomingVTXOsRequest`
   - → `vtxo` manager: `VTXOsMaterializedNotification` (after incoming VTXOs are durably materialized)

--- a/oor/CLAUDE.md
+++ b/oor/CLAUDE.md
@@ -12,9 +12,22 @@ resume semantics.
 - `Environment` — FSM environment providing SessionID and external system access.
 - `OutboxHandler` — Interface for executing FSM outbox requests (RPC, signing, persistence).
 - `SignArkPSBT` — Signs Ark PSBT inputs using the client key on the checkpoint 2-of-2 collab leaf; uses `MultiPrevOutFetcher` for correct BIP-341 sighash across multiple inputs.
-- `ClientActorCfg` — Configuration for OORClientActor (OutboxHandler, ServerConn, PackageStore, DeliveryStore, VTXOManager).
+- `ClientActorCfg` — Configuration for OORClientActor (OutboxHandler,
+  ServerConn, PackageStore, DeliveryStore, VTXOManager).
 - `IncomingVTXOMetadata` — Lineage metadata for incoming OOR VTXOs including `ChainDepth` (OOR checkpoint hop count).
-- `OORClientActor` — Durable actor wrapping per-session state machines.
+- `OORClientActor` — Durable actor wrapping per-session state machines. Handles both outgoing transfers and incoming receive via three-phase async resolution.
+- `ResolveIncomingTransferRequest` — TLV-durable message persisted by the
+  ingress route, resumed via a durable unary indexer query.
+- `QueryIncomingTransferRequest` / `QueryIncomingMetadataRequest` — durable
+  transport outbox events that `oor/actor.go` maps to transport-native
+  durable `serverconn` query messages after commit.
+- `serverconn.SendListOORRecipientEventsByScriptRequest` /
+  `serverconn.SendListVTXOsByScriptsRequest` — durable post-commit transport
+  messages used to resolve incoming hints and authoritative metadata.
+- `AdaptIncomingOOREvent` / `NewResolveIncomingTransferRequest` — Shared adapters for the notification→query pattern used by both darepod and systest.
+- `NewOutboxHandler` / `OutboxHandlerConfig` — Shared factory for the standard two-layer outbox handler chain (LocalPersistenceOutboxHandler → SigningOutboxHandler).
+- `ReceiveResolving` — FSM state indicating a durable hint is persisted and
+  pending the post-commit unary indexer resolution.
 
 ## Relationships
 
@@ -26,7 +39,12 @@ resume semantics.
   - → `wallet`: `MaterializeIncomingVTXOsRequest`
   - → `vtxo` manager: `VTXOsMaterializedNotification` (after incoming VTXOs are durably materialized)
 - **Receives**:
-  - ← `serverconn` (via EventRouter): `SubmitAcceptedEvent`, `FinalizeAcceptedEvent`, `IncomingTransferEvent`
+  - ← `serverconn` (via EventRouter): `SubmitAcceptedEvent`, `FinalizeAcceptedEvent`, `ResolveIncomingTransferRequest`
+  - ← `serverconn` durable unary response routes:
+    `DriveEventRequest{IncomingTransferEvent}`,
+    `DriveEventRequest{IncomingMetadataResolvedEvent}`
+  - ← local persistence callback path:
+    `DriveEventRequest{IncomingHandledEvent}`
   - ← API: `StartTransferRequest`, `DriveEventRequest`, `RestoreSessionRequest`, `ResumeSessionRequest`
 
 ## Invariants
@@ -37,6 +55,11 @@ resume semantics.
 - After checkpoint signature, client must resume and obtain byte-identical co-signed PSBTs (deterministic construction).
 - Transport outbox events (submit, finalize, ack) are Tell'd to ServerConn within the actor's DB transaction for atomic enqueue (same-DB tx joining via `ExecTx`).
 - Package persistence tracks finalized outgoing packages and local input bindings for recovery.
+- Incoming receive never performs synchronous unary RPCs inside the durable
+  actor DB transaction. Both incoming-hint resolution and authoritative
+  metadata lookup are emitted as transport-native durable `serverconn`
+  query messages and delivered back as fresh durable messages.
+- `LocalPersistenceOutboxHandler.CallbackRef` receives async materialization results so indexer queries run outside the actor tx, preventing SQLite write-lock starvation.
 
 ## Deep Docs
 

--- a/oor/actor.go
+++ b/oor/actor.go
@@ -2,6 +2,7 @@ package oor
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"log/slog"
 	"sort"
@@ -17,8 +18,8 @@ import (
 )
 
 const (
-	oorCheckpointStateType = "oor.outgoing.sessions"
-	oorCheckpointVersion   = 1
+	oorCheckpointStateType = "oor.sessions"
+	oorCheckpointVersion   = 2
 )
 
 // OutboxHandler executes FSM outbox requests and returns follow-up events.
@@ -69,6 +70,15 @@ type ClientActorCfg struct {
 	// VTXOManager receives notifications after incoming VTXOs are durably
 	// materialized so it can spawn VTXO actors for monitoring.
 	VTXOManager actor.TellOnlyRef[vtxo.ManagerMsg]
+
+	// VTXOStore reloads durably materialized incoming VTXOs by outpoint when
+	// a callback event is restored from the mailbox without in-memory
+	// descriptor attachments.
+	VTXOStore vtxo.VTXOStore
+
+	// IncomingFetcher resolves lightweight incoming OOR notifications into the
+	// full Ark package by querying the indexer from the actor context.
+	IncomingFetcher IncomingOORFetcher
 }
 
 // OORClientActor wraps the outgoing-transfer client FSM in a durable actor
@@ -104,6 +114,12 @@ func newOORActorCodec() *actor.MessageCodec {
 		DriveEventRequestTLVType,
 		func() actor.TLVMessage {
 			return &DriveEventRequest{}
+		},
+	)
+	codec.MustRegister(
+		ResolveIncomingTransferTLVType,
+		func() actor.TLVMessage {
+			return &ResolveIncomingTransferRequest{}
 		},
 	)
 	codec.MustRegister(
@@ -183,6 +199,13 @@ func NewOORClientActor(cfg ClientActorCfg) *OORClientActor {
 	durable := actor.NewDurableActor(durableCfg)
 	actorRef.durable = durable
 	actorRef.ref = durable.Ref()
+	behavior.selfRef = durable.Ref()
+
+	if localHandler, ok := cfg.OutboxHandler.(*LocalPersistenceOutboxHandler); ok {
+		if localHandler.CallbackRef == nil {
+			localHandler.CallbackRef = durable.Ref()
+		}
+	}
 
 	checkpoint, err := cfg.DeliveryStore.LoadCheckpoint(
 		context.Background(), cfg.ActorID,
@@ -288,6 +311,8 @@ type oorDurableBehavior struct {
 	cfg ClientActorCfg
 
 	sessions map[SessionID]*sessionHandle
+
+	selfRef actor.TellOnlyRef[OORDurableMsg]
 }
 
 // logger returns the configured logger or falls back to extracting from
@@ -312,6 +337,9 @@ func (b *oorDurableBehavior) Receive(ctx context.Context,
 
 	case *DriveEventRequest:
 		return b.handleDriveEvent(ctx, m)
+
+	case *ResolveIncomingTransferRequest:
+		return b.handleResolveIncomingTransfer(ctx, m)
 
 	case *GetStateRequest:
 		return b.handleGetState(ctx, m)
@@ -407,7 +435,10 @@ func (b *oorDurableBehavior) handleStartTransfer(ctx context.Context,
 		})
 	}
 
-	handle := &sessionHandle{FSM: session.FSM}
+	handle := &sessionHandle{
+		FSM:  session.FSM,
+		kind: sessionKindOutgoing,
+	}
 	b.sessions[session.ID] = handle
 
 	b.logger(ctx).InfoS(ctx, "OOR session created",
@@ -447,8 +478,18 @@ func (b *oorDurableBehavior) handleDriveEvent(ctx context.Context,
 
 	handle, ok := b.sessions[req.SessionID]
 	if !ok {
-		return fn.Err[ActorResp](fmt.Errorf("unknown session: %s",
-			req.SessionID))
+		incoming, isIncoming := req.Event.(*IncomingTransferEvent)
+		if !isIncoming {
+			return fn.Err[ActorResp](fmt.Errorf("unknown session: %s",
+				req.SessionID))
+		}
+
+		err := b.handleIncomingTransfer(ctx, req.SessionID, incoming)
+		if err != nil {
+			return fn.Err[ActorResp](err)
+		}
+
+		return fn.Ok[ActorResp](&DriveEventResponse{})
 	}
 
 	// If the inbound SubmitAcceptedEvent is missing the ArkPSBT (e.g.,
@@ -499,12 +540,206 @@ func (b *oorDurableBehavior) handleDriveEvent(ctx context.Context,
 		return fn.Err[ActorResp](err)
 	}
 
+	b.notifyMaterializedVTXOs(ctx, req.Event)
+
 	err = b.driveOutbox(ctx, req.SessionID, handle.FSM, outbox)
 	if err != nil {
 		return fn.Err[ActorResp](err)
 	}
 
 	return fn.Ok[ActorResp](&DriveEventResponse{})
+}
+
+// handleResolveIncomingTransfer durably records a lightweight incoming OOR
+// hint, then resolves the full Ark package asynchronously outside the live
+// durable actor transaction.
+func (b *oorDurableBehavior) handleResolveIncomingTransfer(
+	ctx context.Context,
+	req *ResolveIncomingTransferRequest) fn.Result[ActorResp] {
+
+	if req == nil {
+		return fn.Err[ActorResp](fmt.Errorf("request must be provided"))
+	}
+
+	if len(req.RecipientPkScript) == 0 {
+		return fn.Err[ActorResp](fmt.Errorf("recipient pk script must " +
+			"be provided"))
+	}
+
+	b.logger(ctx).DebugS(ctx, "Handling incoming transfer hint",
+		slog.String("session_id", req.SessionID.String()),
+		slog.Uint64("recipient_event_id", req.RecipientEventID),
+		slog.String("recipient_pk_script",
+			hex.EncodeToString(req.RecipientPkScript)))
+
+	handle, ok := b.sessions[req.SessionID]
+	if !ok {
+		session, err := newReceiveSessionWithState(
+			ctx, req.SessionID, &ReceiveResolving{
+				SessionID: req.SessionID,
+				RecipientPkScript: append(
+					[]byte(nil), req.RecipientPkScript...,
+				),
+				RecipientEventID: req.RecipientEventID,
+			},
+		)
+		if err != nil {
+			return fn.Err[ActorResp](err)
+		}
+
+		handle = &sessionHandle{
+			FSM:  session.FSM,
+			kind: sessionKindIncoming,
+		}
+		b.sessions[req.SessionID] = handle
+
+		err = b.persistCheckpoint(ctx)
+		if err != nil {
+			return fn.Err[ActorResp](err)
+		}
+	}
+
+	if handle.kind != sessionKindIncoming {
+		return fn.Err[ActorResp](fmt.Errorf("session %s is not "+
+			"incoming", req.SessionID))
+	}
+
+	state, err := handle.currentSessionState()
+	if err != nil {
+		return fn.Err[ActorResp](err)
+	}
+
+	if _, ok := state.(*ReceiveResolving); !ok {
+		b.logger(ctx).DebugS(ctx, "Ignoring duplicate incoming "+
+			"transfer hint for active session",
+			slog.String("session_id", req.SessionID.String()),
+			slog.String("state", fmt.Sprintf("%T", state)))
+
+		return fn.Ok[ActorResp](&DriveEventResponse{})
+	}
+
+	err = b.scheduleResolveIncomingTransfer(ctx, req)
+	if err != nil {
+		return fn.Err[ActorResp](err)
+	}
+
+	return fn.Ok[ActorResp](&DriveEventResponse{})
+}
+
+// scheduleResolveIncomingTransfer resolves a lightweight incoming OOR hint
+// outside the live actor transaction, then re-drives the actor with either
+// the resolved IncomingTransferEvent or a terminal FailEvent.
+func (b *oorDurableBehavior) scheduleResolveIncomingTransfer(
+	ctx context.Context,
+	req *ResolveIncomingTransferRequest) error {
+
+	if req == nil {
+		return fmt.Errorf("request must be provided")
+	}
+
+	if b.selfRef == nil {
+		return fmt.Errorf("self ref must be configured")
+	}
+
+	opCtx := actor.WithoutOutboxID(
+		actor.WithoutTx(context.WithoutCancel(ctx)),
+	)
+	sessionID := req.SessionID
+	recipientPkScript := append(
+		[]byte(nil), req.RecipientPkScript...,
+	)
+	recipientEventID := req.RecipientEventID
+
+	go func() {
+		incomingEvent, err := ResolveIncomingTransferEvent(
+			opCtx, sessionID, recipientPkScript,
+			recipientEventID, b.cfg.IncomingFetcher,
+		)
+
+		var msg *DriveEventRequest
+		if err != nil {
+			b.logger(opCtx).WarnS(opCtx,
+				"Resolve incoming transfer hint failed", err,
+				slog.String("session_id", sessionID.String()),
+				slog.Uint64("recipient_event_id",
+					recipientEventID))
+
+			msg = &DriveEventRequest{
+				SessionID: sessionID,
+				Event: &FailEvent{
+					Reason: fmt.Sprintf(
+						"resolve incoming transfer: %v", err,
+					),
+				},
+			}
+		} else {
+			b.logger(opCtx).DebugS(opCtx,
+				"Resolved incoming transfer hint",
+				slog.String("session_id", sessionID.String()),
+				slog.Int("num_checkpoints",
+					len(incomingEvent.FinalCheckpointPSBTs)))
+
+			msg = &DriveEventRequest{
+				SessionID: sessionID,
+				Event:     incomingEvent,
+			}
+		}
+
+		tellErr := b.selfRef.Tell(opCtx, msg)
+		if tellErr != nil {
+			b.logger(opCtx).WarnS(opCtx,
+				"Failed to deliver incoming resolve result",
+				tellErr,
+				slog.String("session_id", sessionID.String()))
+		}
+	}()
+
+	return nil
+}
+
+// handleIncomingTransfer drives a new incoming-transfer notification without
+// requiring a pre-existing outgoing session entry.
+//
+// Incoming notifications originate at the transport boundary, so the actor
+// must be able to materialize them the first time it sees the session ID.
+func (b *oorDurableBehavior) handleIncomingTransfer(ctx context.Context,
+	sessionID SessionID, event *IncomingTransferEvent) error {
+
+	if event == nil {
+		return fmt.Errorf("incoming event must be provided")
+	}
+
+	if event.SessionID != (SessionID{}) && event.SessionID != sessionID {
+		return fmt.Errorf("incoming event session id mismatch")
+	}
+
+	b.logger(ctx).DebugS(ctx, "Handling incoming transfer event",
+		slog.String("session_id", sessionID.String()),
+		slog.Int("num_checkpoints", len(event.FinalCheckpointPSBTs)))
+
+	session, outbox, err := DriveIncomingTransferWithCheckpoints(
+		ctx, sessionID, event.ArkPSBT, event.FinalCheckpointPSBTs,
+	)
+	if err != nil {
+		return err
+	}
+
+	b.logger(ctx).DebugS(ctx, "Incoming transfer produced outbox",
+		slog.String("session_id", session.ID.String()),
+		slog.Int("outbox_len", len(outbox)))
+
+	handle := &sessionHandle{
+		FSM:  session.FSM,
+		kind: sessionKindIncoming,
+	}
+	b.sessions[session.ID] = handle
+
+	err = b.persistCheckpoint(ctx)
+	if err != nil {
+		return err
+	}
+
+	return b.driveOutbox(ctx, session.ID, handle.FSM, outbox)
 }
 
 // enrichSubmitAcceptedArkPSBT populates a SubmitAcceptedEvent's ArkPSBT field
@@ -518,7 +753,7 @@ func (b *oorDurableBehavior) enrichSubmitAcceptedArkPSBT(
 	handle *sessionHandle,
 	event *SubmitAcceptedEvent) error {
 
-	state, err := handle.currentState()
+	state, err := handle.currentSessionState()
 	if err != nil {
 		return fmt.Errorf("get current state for ArkPSBT "+
 			"enrichment: %w", err)
@@ -632,7 +867,10 @@ func (b *oorDurableBehavior) handleRestoreSession(ctx context.Context,
 		return fn.Err[ActorResp](err)
 	}
 
-	b.sessions[session.ID] = &sessionHandle{FSM: session.FSM}
+	b.sessions[session.ID] = &sessionHandle{
+		FSM:  session.FSM,
+		kind: sessionKindOutgoing,
+	}
 
 	err = b.persistCheckpoint(ctx)
 	if err != nil {
@@ -665,7 +903,7 @@ func (b *oorDurableBehavior) handleResumeSession(ctx context.Context,
 			req.SessionID))
 	}
 
-	state, err := handle.currentState()
+	state, err := handle.currentSessionState()
 	if err != nil {
 		return fn.Err[ActorResp](err)
 	}
@@ -674,7 +912,28 @@ func (b *oorDurableBehavior) handleResumeSession(ctx context.Context,
 		slog.String("session_id", req.SessionID.String()),
 		slog.String("state", fmt.Sprintf("%T", state)))
 
-	outbox, err := OutboxForState(state)
+	if handle.kind == sessionKindIncoming {
+		if resolving, ok := state.(*ReceiveResolving); ok {
+			err = b.scheduleResolveIncomingTransfer(
+				ctx, &ResolveIncomingTransferRequest{
+					SessionID: req.SessionID,
+					RecipientPkScript: append(
+						[]byte(nil),
+						resolving.RecipientPkScript...,
+					),
+					RecipientEventID: resolving.
+						RecipientEventID,
+				},
+			)
+			if err != nil {
+				return fn.Err[ActorResp](err)
+			}
+
+			return fn.Ok[ActorResp](&ResumeSessionResponse{})
+		}
+	}
+
+	outbox, err := outboxForHandle(handle, state)
 	if err != nil {
 		return fn.Err[ActorResp](err)
 	}
@@ -703,7 +962,12 @@ func (b *oorDurableBehavior) handleExportSnapshot(ctx context.Context,
 			req.SessionID))
 	}
 
-	state, err := handle.currentState()
+	if handle.kind != sessionKindOutgoing {
+		return fn.Err[ActorResp](fmt.Errorf("export snapshot only " +
+			"supports outgoing sessions"))
+	}
+
+	state, err := handle.currentOutgoingState()
 	if err != nil {
 		return fn.Err[ActorResp](err)
 	}
@@ -734,7 +998,7 @@ func (b *oorDurableBehavior) handleGetState(ctx context.Context,
 			req.SessionID))
 	}
 
-	state, err := handle.currentState()
+	state, err := handle.currentSessionState()
 	if err != nil {
 		return fn.Err[ActorResp](err)
 	}
@@ -753,23 +1017,25 @@ func (b *oorDurableBehavior) restoreFromCheckpoint(ctx context.Context,
 		return nil
 	}
 
-	var checkpoint outgoingSessionsCheckpoint
-	checkpoint, err := decodeOutgoingSessionsCheckpoint(raw)
+	checkpoint, err := decodeSessionsCheckpoint(raw)
 	if err != nil {
 		return err
 	}
 
-	if checkpoint.Version != oorCheckpointVersion {
+	if checkpoint.Version < 1 || checkpoint.Version > oorCheckpointVersion {
 		return fmt.Errorf("unknown checkpoint version: %d",
 			checkpoint.Version)
 	}
 
 	b.logger(ctx).InfoS(ctx, "Restoring sessions from checkpoint",
 		slog.Int("checkpoint_version", checkpoint.Version),
-		slog.Int("num_snapshots", len(checkpoint.Snapshots)))
+		slog.Int("num_outgoing_snapshots",
+			len(checkpoint.OutgoingSnapshots)),
+		slog.Int("num_incoming_snapshots",
+			len(checkpoint.IncomingSnapshots)))
 
-	for i := range checkpoint.Snapshots {
-		snapshot := checkpoint.Snapshots[i]
+	for i := range checkpoint.OutgoingSnapshots {
+		snapshot := checkpoint.OutgoingSnapshots[i]
 
 		if _, exists := b.sessions[snapshot.SessionID]; exists {
 			return fmt.Errorf(
@@ -783,9 +1049,37 @@ func (b *oorDurableBehavior) restoreFromCheckpoint(ctx context.Context,
 			return err
 		}
 
-		b.sessions[session.ID] = &sessionHandle{FSM: session.FSM}
+		b.sessions[session.ID] = &sessionHandle{
+			FSM:  session.FSM,
+			kind: sessionKindOutgoing,
+		}
 
 		b.logger(ctx).DebugS(ctx, "Restored session from checkpoint",
+			slog.String("session_id", session.ID.String()))
+	}
+
+	for i := range checkpoint.IncomingSnapshots {
+		snapshot := checkpoint.IncomingSnapshots[i]
+
+		if _, exists := b.sessions[snapshot.SessionID]; exists {
+			return fmt.Errorf(
+				"duplicate session id in checkpoint: %s",
+				snapshot.SessionID,
+			)
+		}
+
+		session, err := NewReceiveSessionFromSnapshot(ctx, snapshot)
+		if err != nil {
+			return err
+		}
+
+		b.sessions[session.ID] = &sessionHandle{
+			FSM:  session.FSM,
+			kind: sessionKindIncoming,
+		}
+
+		b.logger(ctx).DebugS(ctx, "Restored incoming session "+
+			"from checkpoint",
 			slog.String("session_id", session.ID.String()))
 	}
 
@@ -812,12 +1106,40 @@ func (b *oorDurableBehavior) resumeRestoredSessions(ctx context.Context) error {
 		sessionID := sessionIDs[i]
 		handle := b.sessions[sessionID]
 
-		state, err := handle.currentState()
+		state, err := handle.currentSessionState()
 		if err != nil {
 			return err
 		}
 
-		outbox, err := OutboxForState(state)
+		if handle.kind == sessionKindIncoming {
+			if resolving, ok := state.(*ReceiveResolving); ok {
+				b.logger(ctx).DebugS(ctx, "Resuming restored "+
+					"incoming resolve",
+					slog.String("session_id",
+						sessionID.String()),
+					slog.String("state",
+						fmt.Sprintf("%T", state)))
+
+				err = b.scheduleResolveIncomingTransfer(
+					ctx, &ResolveIncomingTransferRequest{
+						SessionID: sessionID,
+						RecipientPkScript: append(
+							[]byte(nil),
+							resolving.RecipientPkScript...,
+						),
+						RecipientEventID: resolving.
+							RecipientEventID,
+					},
+				)
+				if err != nil {
+					return err
+				}
+
+				continue
+			}
+		}
+
+		outbox, err := outboxForHandle(handle, state)
 		if err != nil {
 			return err
 		}
@@ -931,6 +1253,27 @@ func (b *oorDurableBehavior) driveOutbox(ctx context.Context,
 				return err
 			}
 
+			if _, ok := msg.(*SendIncomingAckRequest); ok {
+				nextOutbox, err := b.askEvent(
+					ctx, fsm, &IncomingAckSentEvent{},
+				)
+				if err != nil {
+					return err
+				}
+
+				err = b.persistCheckpoint(ctx)
+				if err != nil {
+					return err
+				}
+
+				err = b.driveOutbox(
+					ctx, sessionID, fsm, nextOutbox,
+				)
+				if err != nil {
+					return err
+				}
+			}
+
 			continue
 		}
 
@@ -1005,7 +1348,7 @@ func (b *oorDurableBehavior) notifyMaterializedVTXOs(ctx context.Context,
 	followUp Event) {
 
 	handled, ok := followUp.(*IncomingHandledEvent)
-	if !ok || len(handled.MaterializedVTXOs) == 0 {
+	if !ok {
 		return
 	}
 
@@ -1013,17 +1356,65 @@ func (b *oorDurableBehavior) notifyMaterializedVTXOs(ctx context.Context,
 		return
 	}
 
+	descs := handled.MaterializedVTXOs
+	if len(descs) == 0 {
+		descs = b.loadMaterializedVTXOs(ctx, handled)
+	}
+
+	if len(descs) == 0 {
+		return
+	}
+
 	notification := &vtxo.VTXOsMaterializedNotification{
-		VTXOs: handled.MaterializedVTXOs,
+		VTXOs: descs,
 	}
 
 	if err := b.cfg.VTXOManager.Tell(ctx, notification); err != nil {
 		b.logger(ctx).WarnS(
 			ctx, "Failed to notify VTXO manager of "+
 				"materialized incoming VTXOs", err,
-			slog.Int("num_vtxos",
-				len(handled.MaterializedVTXOs)))
+			slog.Int("num_vtxos", len(descs)))
 	}
+}
+
+// loadMaterializedVTXOs reloads persisted incoming VTXO descriptors for a
+// callback event that only round-tripped outpoint identifiers through the
+// durable mailbox.
+func (b *oorDurableBehavior) loadMaterializedVTXOs(ctx context.Context,
+	handled *IncomingHandledEvent) []*vtxo.Descriptor {
+
+	if handled == nil || len(handled.MaterializedOutpoints) == 0 {
+		return nil
+	}
+
+	if b.cfg.VTXOStore == nil {
+		b.logger(ctx).WarnS(
+			ctx, "Missing VTXO store for incoming callback reload",
+			nil, //nolint:ll
+			slog.Int("num_outpoints",
+				len(handled.MaterializedOutpoints)))
+
+		return nil
+	}
+
+	descs := make([]*vtxo.Descriptor, 0,
+		len(handled.MaterializedOutpoints))
+
+	for _, outpoint := range handled.MaterializedOutpoints {
+		desc, err := b.cfg.VTXOStore.GetVTXO(ctx, outpoint)
+		if err != nil {
+			b.logger(ctx).WarnS(
+				ctx, "Failed to reload materialized incoming "+
+					"VTXO for manager notification", err,
+				slog.String("outpoint", outpoint.String()))
+
+			continue
+		}
+
+		descs = append(descs, desc)
+	}
+
+	return descs
 }
 
 // persistCheckpoint snapshots every active session into a single TLV
@@ -1042,27 +1433,62 @@ func (b *oorDurableBehavior) persistCheckpoint(ctx context.Context) error {
 		return sessionIDs[i].String() < sessionIDs[j].String()
 	})
 
-	snapshots := make([]*OutgoingSnapshot, 0, len(sessionIDs))
+	outgoingSnapshots := make(
+		[]*OutgoingSnapshot, 0, len(sessionIDs),
+	)
+	incomingSnapshots := make(
+		[]*IncomingSnapshot, 0, len(sessionIDs),
+	)
 	for i := range sessionIDs {
 		sessionID := sessionIDs[i]
 		handle := b.sessions[sessionID]
 
-		state, err := handle.currentState()
+		state, err := handle.currentSessionState()
 		if err != nil {
 			return err
 		}
 
-		snapshot, err := NewOutgoingSnapshot(sessionID, state)
-		if err != nil {
-			return err
-		}
+		switch handle.kind {
+		case sessionKindOutgoing:
+			outgoingState, ok := state.(State)
+			if !ok {
+				return fmt.Errorf("unexpected outgoing state "+
+					"type: %T", state)
+			}
 
-		snapshots = append(snapshots, snapshot)
+			snapshot, err := NewOutgoingSnapshot(
+				sessionID, outgoingState,
+			)
+			if err != nil {
+				return err
+			}
+
+			outgoingSnapshots = append(
+				outgoingSnapshots, snapshot,
+			)
+
+		case sessionKindIncoming:
+			snapshot, err := NewIncomingSnapshot(
+				sessionID, state,
+			)
+			if err != nil {
+				return err
+			}
+
+			incomingSnapshots = append(
+				incomingSnapshots, snapshot,
+			)
+
+		default:
+			return fmt.Errorf("unknown session kind: %d",
+				handle.kind)
+		}
 	}
 
-	raw, err := encodeOutgoingSessionsCheckpoint(outgoingSessionsCheckpoint{
-		Version:   oorCheckpointVersion,
-		Snapshots: snapshots,
+	raw, err := encodeSessionsCheckpoint(sessionsCheckpoint{
+		Version:           oorCheckpointVersion,
+		OutgoingSnapshots: outgoingSnapshots,
+		IncomingSnapshots: incomingSnapshots,
 	})
 	if err != nil {
 		return err
@@ -1084,21 +1510,72 @@ type outgoingSessionsCheckpoint struct {
 // sessionHandle ties a session ID to its running state machine instance.
 type sessionHandle struct {
 	FSM *StateMachine
+
+	kind sessionKind
 }
 
-// currentState returns the current concrete OOR session state.
-func (h *sessionHandle) currentState() (State, error) {
+type sessionKind uint8
+
+const (
+	sessionKindOutgoing sessionKind = iota + 1
+	sessionKindIncoming
+)
+
+// currentSessionState returns the current concrete OOR session state.
+func (h *sessionHandle) currentSessionState() (SessionState, error) {
 	current, err := h.FSM.CurrentState()
 	if err != nil {
 		return nil, err
 	}
 
-	state, ok := current.(State)
+	state, ok := current.(SessionState)
 	if !ok {
 		return nil, fmt.Errorf("unexpected state type: %T", current)
 	}
 
 	return state, nil
+}
+
+// currentOutgoingState returns the current outgoing session state.
+func (h *sessionHandle) currentOutgoingState() (State, error) {
+	state, err := h.currentSessionState()
+	if err != nil {
+		return nil, err
+	}
+
+	outgoingState, ok := state.(State)
+	if !ok {
+		return nil, fmt.Errorf("unexpected outgoing state type: %T",
+			state)
+	}
+
+	return outgoingState, nil
+}
+
+// outboxForHandle returns the outbox implied by the handle's current state.
+func outboxForHandle(handle *sessionHandle,
+	state SessionState) ([]OutboxEvent, error) {
+
+	if handle == nil {
+		return nil, fmt.Errorf("session handle must be provided")
+	}
+
+	switch handle.kind {
+	case sessionKindOutgoing:
+		outgoingState, ok := state.(State)
+		if !ok {
+			return nil, fmt.Errorf("unexpected outgoing state type: %T",
+				state)
+		}
+
+		return OutboxForState(outgoingState)
+
+	case sessionKindIncoming:
+		return OutboxForIncomingState(state)
+
+	default:
+		return nil, fmt.Errorf("unknown session kind: %d", handle.kind)
+	}
 }
 
 type durableBehaviorIface = actor.ActorBehavior[

--- a/oor/actor.go
+++ b/oor/actor.go
@@ -75,9 +75,9 @@ type ClientActorCfg struct {
 	// materialized so it can spawn VTXO actors for monitoring.
 	VTXOManager actor.TellOnlyRef[vtxo.ManagerMsg]
 
-	// VTXOStore reloads durably materialized incoming VTXOs by outpoint when
-	// a callback event is restored from the mailbox without in-memory
-	// descriptor attachments.
+	// VTXOStore reloads durably materialized incoming VTXOs
+	// by outpoint when a callback event is restored from the
+	// mailbox without in-memory descriptor attachments.
 	VTXOStore vtxo.VTXOStore
 }
 
@@ -471,8 +471,9 @@ func (b *oorDurableBehavior) handleDriveEvent(ctx context.Context,
 	if !ok {
 		incoming, isIncoming := req.Event.(*IncomingTransferEvent)
 		if !isIncoming {
-			return fn.Err[ActorResp](fmt.Errorf("unknown session: %s",
-				req.SessionID))
+			return fn.Err[ActorResp](fmt.Errorf(
+				"unknown session: %s", req.SessionID,
+			))
 		}
 
 		err := b.handleIncomingTransfer(ctx, req.SessionID, incoming)
@@ -553,8 +554,9 @@ func (b *oorDurableBehavior) handleResolveIncomingTransfer(
 	}
 
 	if len(req.RecipientPkScript) == 0 {
-		return fn.Err[ActorResp](fmt.Errorf("recipient pk script must " +
-			"be provided"))
+		return fn.Err[ActorResp](fmt.Errorf(
+			"recipient pk script must be provided",
+		))
 	}
 
 	b.logger(ctx).DebugS(ctx, "Handling incoming transfer hint",
@@ -1103,6 +1105,7 @@ func (b *oorDurableBehavior) sendTransportEvent(ctx context.Context,
 			afterEventID = queryReq.RecipientEventID - 1
 		}
 
+		//nolint:ll
 		sendReq := &serverconn.SendListOORRecipientEventsByScriptRequest{
 			PkScript: append(
 				[]byte(nil), queryReq.RecipientPkScript...,
@@ -1215,8 +1218,8 @@ func (b *oorDurableBehavior) driveOutbox(ctx context.Context,
 			slog.String("event_type", fmt.Sprintf("%T", msg)))
 
 		if handler == nil {
-			return fmt.Errorf("outbox handler must be provided for " +
-				"local events")
+			return fmt.Errorf("outbox handler must " +
+				"be provided for local events")
 		}
 
 		// Local events (signing, persistence, timers) continue
@@ -1328,7 +1331,7 @@ func (b *oorDurableBehavior) loadMaterializedVTXOs(ctx context.Context,
 	if b.cfg.VTXOStore == nil {
 		b.logger(ctx).WarnS(
 			ctx, "Missing VTXO store for incoming callback reload",
-			nil, //nolint:ll
+			nil,
 			slog.Int("num_outpoints",
 				len(handled.MaterializedOutpoints)))
 
@@ -1466,12 +1469,7 @@ func (h *sessionHandle) currentSessionState() (SessionState, error) {
 		return nil, err
 	}
 
-	state, ok := current.(SessionState)
-	if !ok {
-		return nil, fmt.Errorf("unexpected state type: %T", current)
-	}
-
-	return state, nil
+	return current, nil
 }
 
 // currentOutgoingState returns the current outgoing session state.
@@ -1483,8 +1481,10 @@ func (h *sessionHandle) currentOutgoingState() (State, error) {
 
 	outgoingState, ok := state.(State)
 	if !ok {
-		return nil, fmt.Errorf("unexpected outgoing state type: %T",
-			state)
+		return nil, fmt.Errorf(
+			"unexpected outgoing state type: %T",
+			state,
+		)
 	}
 
 	return outgoingState, nil
@@ -1502,8 +1502,10 @@ func outboxForHandle(handle *sessionHandle,
 	case sessionKindOutgoing:
 		outgoingState, ok := state.(State)
 		if !ok {
-			return nil, fmt.Errorf("unexpected outgoing state type: %T",
-				state)
+			return nil, fmt.Errorf(
+				"unexpected outgoing state type: %T",
+				state,
+			)
 		}
 
 		return OutboxForState(outgoingState)

--- a/oor/actor.go
+++ b/oor/actor.go
@@ -20,6 +20,10 @@ import (
 const (
 	oorCheckpointStateType = "oor.sessions"
 	oorCheckpointVersion   = 2
+
+	// incomingMetadataQueryLimit is the default page size for durable
+	// ListVTXOsByScripts lookups used by the receive FSM.
+	incomingMetadataQueryLimit uint32 = 128
 )
 
 // OutboxHandler executes FSM outbox requests and returns follow-up events.
@@ -32,11 +36,6 @@ type OutboxHandler interface {
 	Handle(ctx context.Context, sessionID SessionID,
 		outbox OutboxEvent) ([]Event, error)
 }
-
-// IncomingMetadataRPCBuilder builds a durable serverconn unary request for the
-// authoritative incoming metadata query emitted by the receive FSM.
-type IncomingMetadataRPCBuilder func(ctx context.Context,
-	req *QueryIncomingMetadataRequest) (*serverconn.SendUnaryRequest, error)
 
 // ClientActorCfg configures the OORClientActor.
 type ClientActorCfg struct {
@@ -80,14 +79,6 @@ type ClientActorCfg struct {
 	// a callback event is restored from the mailbox without in-memory
 	// descriptor attachments.
 	VTXOStore vtxo.VTXOStore
-
-	// IncomingFetcher resolves lightweight incoming OOR notifications into the
-	// full Ark package by querying the indexer from the actor context.
-	IncomingFetcher IncomingOORFetcher
-
-	// BuildIncomingMetadataRPC constructs the durable serverconn unary request
-	// used to resolve authoritative incoming VTXO metadata after commit.
-	BuildIncomingMetadataRPC IncomingMetadataRPCBuilder
 }
 
 // OORClientActor wraps the outgoing-transfer client FSM in a durable actor
@@ -208,7 +199,6 @@ func NewOORClientActor(cfg ClientActorCfg) *OORClientActor {
 	durable := actor.NewDurableActor(durableCfg)
 	actorRef.durable = durable
 	actorRef.ref = durable.Ref()
-	behavior.selfRef = durable.Ref()
 
 	checkpoint, err := cfg.DeliveryStore.LoadCheckpoint(
 		context.Background(), cfg.ActorID,
@@ -314,8 +304,6 @@ type oorDurableBehavior struct {
 	cfg ClientActorCfg
 
 	sessions map[SessionID]*sessionHandle
-
-	selfRef actor.TellOnlyRef[OORDurableMsg]
 }
 
 // logger returns the configured logger or falls back to extracting from
@@ -554,8 +542,8 @@ func (b *oorDurableBehavior) handleDriveEvent(ctx context.Context,
 }
 
 // handleResolveIncomingTransfer durably records a lightweight incoming OOR
-// hint, then resolves the full Ark package asynchronously outside the live
-// durable actor transaction.
+// hint, then emits the transport query needed to resolve the full Ark package
+// after the checkpoint commits.
 func (b *oorDurableBehavior) handleResolveIncomingTransfer(
 	ctx context.Context,
 	req *ResolveIncomingTransferRequest) fn.Result[ActorResp] {
@@ -575,6 +563,7 @@ func (b *oorDurableBehavior) handleResolveIncomingTransfer(
 		slog.String("recipient_pk_script",
 			hex.EncodeToString(req.RecipientPkScript)))
 
+	created := false
 	handle, ok := b.sessions[req.SessionID]
 	if !ok {
 		session, err := newReceiveSessionWithState(
@@ -595,6 +584,7 @@ func (b *oorDurableBehavior) handleResolveIncomingTransfer(
 			kind: sessionKindIncoming,
 		}
 		b.sessions[req.SessionID] = handle
+		created = true
 
 		err = b.persistCheckpoint(ctx)
 		if err != nil {
@@ -621,83 +611,25 @@ func (b *oorDurableBehavior) handleResolveIncomingTransfer(
 		return fn.Ok[ActorResp](&DriveEventResponse{})
 	}
 
-	err = b.scheduleResolveIncomingTransfer(ctx, req)
+	if !created {
+		b.logger(ctx).DebugS(ctx, "Ignoring duplicate incoming "+
+			"resolve request for pending session",
+			slog.String("session_id", req.SessionID.String()))
+
+		return fn.Ok[ActorResp](&DriveEventResponse{})
+	}
+
+	outbox, err := outboxForHandle(handle, state)
+	if err != nil {
+		return fn.Err[ActorResp](err)
+	}
+
+	err = b.driveOutbox(ctx, req.SessionID, handle.FSM, outbox)
 	if err != nil {
 		return fn.Err[ActorResp](err)
 	}
 
 	return fn.Ok[ActorResp](&DriveEventResponse{})
-}
-
-// scheduleResolveIncomingTransfer resolves a lightweight incoming OOR hint
-// outside the live actor transaction, then re-drives the actor with either
-// the resolved IncomingTransferEvent or a terminal FailEvent.
-func (b *oorDurableBehavior) scheduleResolveIncomingTransfer(
-	ctx context.Context,
-	req *ResolveIncomingTransferRequest) error {
-
-	if req == nil {
-		return fmt.Errorf("request must be provided")
-	}
-
-	if b.selfRef == nil {
-		return fmt.Errorf("self ref must be configured")
-	}
-
-	opCtx := actor.WithoutOutboxID(
-		actor.WithoutTx(context.WithoutCancel(ctx)),
-	)
-	sessionID := req.SessionID
-	recipientPkScript := append(
-		[]byte(nil), req.RecipientPkScript...,
-	)
-	recipientEventID := req.RecipientEventID
-
-	go func() {
-		incomingEvent, err := ResolveIncomingTransferEvent(
-			opCtx, sessionID, recipientPkScript,
-			recipientEventID, b.cfg.IncomingFetcher,
-		)
-
-		var msg *DriveEventRequest
-		if err != nil {
-			b.logger(opCtx).WarnS(opCtx,
-				"Resolve incoming transfer hint failed", err,
-				slog.String("session_id", sessionID.String()),
-				slog.Uint64("recipient_event_id",
-					recipientEventID))
-
-			msg = &DriveEventRequest{
-				SessionID: sessionID,
-				Event: &FailEvent{
-					Reason: fmt.Sprintf(
-						"resolve incoming transfer: %v", err,
-					),
-				},
-			}
-		} else {
-			b.logger(opCtx).DebugS(opCtx,
-				"Resolved incoming transfer hint",
-				slog.String("session_id", sessionID.String()),
-				slog.Int("num_checkpoints",
-					len(incomingEvent.FinalCheckpointPSBTs)))
-
-			msg = &DriveEventRequest{
-				SessionID: sessionID,
-				Event:     incomingEvent,
-			}
-		}
-
-		tellErr := b.selfRef.Tell(opCtx, msg)
-		if tellErr != nil {
-			b.logger(opCtx).WarnS(opCtx,
-				"Failed to deliver incoming resolve result",
-				tellErr,
-				slog.String("session_id", sessionID.String()))
-		}
-	}()
-
-	return nil
 }
 
 // handleIncomingTransfer drives a new incoming-transfer notification without
@@ -915,27 +847,6 @@ func (b *oorDurableBehavior) handleResumeSession(ctx context.Context,
 		slog.String("session_id", req.SessionID.String()),
 		slog.String("state", fmt.Sprintf("%T", state)))
 
-	if handle.kind == sessionKindIncoming {
-		if resolving, ok := state.(*ReceiveResolving); ok {
-			err = b.scheduleResolveIncomingTransfer(
-				ctx, &ResolveIncomingTransferRequest{
-					SessionID: req.SessionID,
-					RecipientPkScript: append(
-						[]byte(nil),
-						resolving.RecipientPkScript...,
-					),
-					RecipientEventID: resolving.
-						RecipientEventID,
-				},
-			)
-			if err != nil {
-				return fn.Err[ActorResp](err)
-			}
-
-			return fn.Ok[ActorResp](&ResumeSessionResponse{})
-		}
-	}
-
 	outbox, err := outboxForHandle(handle, state)
 	if err != nil {
 		return fn.Err[ActorResp](err)
@@ -1114,34 +1025,6 @@ func (b *oorDurableBehavior) resumeRestoredSessions(ctx context.Context) error {
 			return err
 		}
 
-		if handle.kind == sessionKindIncoming {
-			if resolving, ok := state.(*ReceiveResolving); ok {
-				b.logger(ctx).DebugS(ctx, "Resuming restored "+
-					"incoming resolve",
-					slog.String("session_id",
-						sessionID.String()),
-					slog.String("state",
-						fmt.Sprintf("%T", state)))
-
-				err = b.scheduleResolveIncomingTransfer(
-					ctx, &ResolveIncomingTransferRequest{
-						SessionID: sessionID,
-						RecipientPkScript: append(
-							[]byte(nil),
-							resolving.RecipientPkScript...,
-						),
-						RecipientEventID: resolving.
-							RecipientEventID,
-					},
-				)
-				if err != nil {
-					return err
-				}
-
-				continue
-			}
-		}
-
 		outbox, err := outboxForHandle(handle, state)
 		if err != nil {
 			return err
@@ -1197,7 +1080,8 @@ func (b *oorDurableBehavior) isTransportEvent(msg OutboxEvent) bool {
 
 	switch msg.(type) {
 	case *SendSubmitPackageRequest, *SendFinalizePackageRequest,
-		*SendIncomingAckRequest, *QueryIncomingMetadataRequest:
+		*SendIncomingAckRequest, *QueryIncomingTransferRequest,
+		*QueryIncomingMetadataRequest:
 
 		return true
 
@@ -1212,18 +1096,45 @@ func (b *oorDurableBehavior) sendTransportEvent(ctx context.Context,
 	msg OutboxEvent) error {
 
 	serverMsg, ok := msg.(serverconn.ServerMessage)
-	if queryReq, isQuery := msg.(*QueryIncomingMetadataRequest); isQuery {
-		if b.cfg.BuildIncomingMetadataRPC == nil {
-			return fmt.Errorf("incoming metadata rpc builder must be " +
-				"provided")
+	switch queryReq := msg.(type) {
+	case *QueryIncomingTransferRequest:
+		afterEventID := uint64(0)
+		if queryReq.RecipientEventID > 0 {
+			afterEventID = queryReq.RecipientEventID - 1
 		}
 
-		sendReq, err := b.cfg.BuildIncomingMetadataRPC(
-			ctx, queryReq,
-		)
-		if err != nil {
-			return fmt.Errorf("build incoming metadata rpc: %w",
-				err)
+		sendReq := &serverconn.SendListOORRecipientEventsByScriptRequest{
+			PkScript: append(
+				[]byte(nil), queryReq.RecipientPkScript...,
+			),
+			AfterEventID: afterEventID,
+			Limit:        1,
+			CorrelationID: IncomingResolveCorrelationID(
+				queryReq.SessionID, queryReq.RecipientEventID,
+			),
+		}
+
+		if err := b.cfg.ServerConn.Tell(ctx, sendReq); err != nil {
+			return fmt.Errorf("send incoming resolve query to "+
+				"server: %w", err)
+		}
+
+		return nil
+
+	case *QueryIncomingMetadataRequest:
+		pkScripts := make([][]byte, 0, len(queryReq.Recipients))
+		for i := range queryReq.Recipients {
+			pkScripts = append(pkScripts, append(
+				[]byte(nil), queryReq.Recipients[i].PkScript...,
+			))
+		}
+
+		sendReq := &serverconn.SendListVTXOsByScriptsRequest{
+			PkScripts: pkScripts,
+			Limit:     incomingMetadataQueryLimit,
+			CorrelationID: IncomingMetadataCorrelationID(
+				queryReq.SessionID,
+			),
 		}
 
 		if err := b.cfg.ServerConn.Tell(ctx, sendReq); err != nil {
@@ -1259,9 +1170,6 @@ func (b *oorDurableBehavior) driveOutbox(ctx context.Context,
 	sessionID SessionID, fsm *StateMachine, outbox []OutboxEvent) error {
 
 	handler := b.cfg.OutboxHandler
-	if handler == nil {
-		return nil
-	}
 
 	for _, msg := range outbox {
 		// Transport events (submit, finalize, ack) are Tell'd to
@@ -1305,6 +1213,11 @@ func (b *oorDurableBehavior) driveOutbox(ctx context.Context,
 		b.logger(ctx).DebugS(ctx, "Handling local outbox event",
 			slog.String("session_id", sessionID.String()),
 			slog.String("event_type", fmt.Sprintf("%T", msg)))
+
+		if handler == nil {
+			return fmt.Errorf("outbox handler must be provided for " +
+				"local events")
+		}
 
 		// Local events (signing, persistence, timers) continue
 		// through the outbox handler.

--- a/oor/actor.go
+++ b/oor/actor.go
@@ -646,6 +646,15 @@ func (b *oorDurableBehavior) handleIncomingTransfer(ctx context.Context,
 		return fmt.Errorf("incoming event must be provided")
 	}
 
+	// Reject if a session with this ID already exists in any
+	// kind (outgoing or incoming). A malicious server could
+	// push an IncomingTransferEvent with a known outgoing txid
+	// to create a shadow session that blocks outgoing restore.
+	if _, exists := b.sessions[sessionID]; exists {
+		return fmt.Errorf("session %s already exists, "+
+			"rejecting incoming transfer", sessionID)
+	}
+
 	if event.SessionID != (SessionID{}) && event.SessionID != sessionID {
 		return fmt.Errorf("incoming event session id mismatch")
 	}

--- a/oor/actor.go
+++ b/oor/actor.go
@@ -33,6 +33,11 @@ type OutboxHandler interface {
 		outbox OutboxEvent) ([]Event, error)
 }
 
+// IncomingMetadataRPCBuilder builds a durable serverconn unary request for the
+// authoritative incoming metadata query emitted by the receive FSM.
+type IncomingMetadataRPCBuilder func(ctx context.Context,
+	req *QueryIncomingMetadataRequest) (*serverconn.SendUnaryRequest, error)
+
 // ClientActorCfg configures the OORClientActor.
 type ClientActorCfg struct {
 	// Log is an optional logger for this actor instance. If None, the
@@ -79,6 +84,10 @@ type ClientActorCfg struct {
 	// IncomingFetcher resolves lightweight incoming OOR notifications into the
 	// full Ark package by querying the indexer from the actor context.
 	IncomingFetcher IncomingOORFetcher
+
+	// BuildIncomingMetadataRPC constructs the durable serverconn unary request
+	// used to resolve authoritative incoming VTXO metadata after commit.
+	BuildIncomingMetadataRPC IncomingMetadataRPCBuilder
 }
 
 // OORClientActor wraps the outgoing-transfer client FSM in a durable actor
@@ -200,12 +209,6 @@ func NewOORClientActor(cfg ClientActorCfg) *OORClientActor {
 	actorRef.durable = durable
 	actorRef.ref = durable.Ref()
 	behavior.selfRef = durable.Ref()
-
-	if localHandler, ok := cfg.OutboxHandler.(*LocalPersistenceOutboxHandler); ok {
-		if localHandler.CallbackRef == nil {
-			localHandler.CallbackRef = durable.Ref()
-		}
-	}
 
 	checkpoint, err := cfg.DeliveryStore.LoadCheckpoint(
 		context.Background(), cfg.ActorID,
@@ -1194,7 +1197,7 @@ func (b *oorDurableBehavior) isTransportEvent(msg OutboxEvent) bool {
 
 	switch msg.(type) {
 	case *SendSubmitPackageRequest, *SendFinalizePackageRequest,
-		*SendIncomingAckRequest:
+		*SendIncomingAckRequest, *QueryIncomingMetadataRequest:
 
 		return true
 
@@ -1209,6 +1212,28 @@ func (b *oorDurableBehavior) sendTransportEvent(ctx context.Context,
 	msg OutboxEvent) error {
 
 	serverMsg, ok := msg.(serverconn.ServerMessage)
+	if queryReq, isQuery := msg.(*QueryIncomingMetadataRequest); isQuery {
+		if b.cfg.BuildIncomingMetadataRPC == nil {
+			return fmt.Errorf("incoming metadata rpc builder must be " +
+				"provided")
+		}
+
+		sendReq, err := b.cfg.BuildIncomingMetadataRPC(
+			ctx, queryReq,
+		)
+		if err != nil {
+			return fmt.Errorf("build incoming metadata rpc: %w",
+				err)
+		}
+
+		if err := b.cfg.ServerConn.Tell(ctx, sendReq); err != nil {
+			return fmt.Errorf("send metadata query to server: %w",
+				err)
+		}
+
+		return nil
+	}
+
 	if !ok {
 		return fmt.Errorf("transport event %T does not implement "+
 			"ServerMessage", msg)

--- a/oor/actor_drive_event_integration_test.go
+++ b/oor/actor_drive_event_integration_test.go
@@ -3,11 +3,16 @@ package oor
 import (
 	"context"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/arkrpc"
+	"github.com/lightninglabs/darepo-client/lib/tx/psbtutil"
+	"github.com/lightninglabs/darepo-client/vtxo"
+	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,6 +40,82 @@ func (h *retryDueIntegrationHandler) Handle(_ context.Context,
 }
 
 var _ OutboxHandler = (*retryDueIntegrationHandler)(nil)
+
+type mockVTXOManagerRef struct {
+	mu       sync.Mutex
+	messages []vtxo.ManagerMsg
+}
+
+func (m *mockVTXOManagerRef) ID() string {
+	return "mock-vtxo-manager"
+}
+
+func (m *mockVTXOManagerRef) Tell(_ context.Context,
+	msg vtxo.ManagerMsg) error {
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.messages = append(m.messages, msg)
+
+	return nil
+}
+
+func (m *mockVTXOManagerRef) sent() []vtxo.ManagerMsg {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return append([]vtxo.ManagerMsg(nil), m.messages...)
+}
+
+var _ interface {
+	ID() string
+	Tell(context.Context, vtxo.ManagerMsg) error
+} = (*mockVTXOManagerRef)(nil)
+
+// buildIncomingResolveResponse creates an indexer response carrying the full
+// Ark/checkpoint package for a lightweight incoming-transfer hint.
+func buildIncomingResolveResponse(t *testing.T) (
+	*arkrpc.ListOORRecipientEventsByScriptResponse,
+	SessionID, []byte, uint64,
+) {
+
+	t.Helper()
+
+	arkPSBT, finalCheckpoints, recipients, _, _, _ :=
+		buildTestIncomingMaterialization(t)
+
+	arkRaw, err := psbtutil.Serialize(arkPSBT)
+	require.NoError(t, err)
+
+	checkpointRaws := make([][]byte, 0, len(finalCheckpoints))
+	for _, checkpoint := range finalCheckpoints {
+		checkpointRaw, checkpointErr := psbtutil.Serialize(
+			checkpoint,
+		)
+		require.NoError(t, checkpointErr)
+
+		checkpointRaws = append(checkpointRaws, checkpointRaw)
+	}
+
+	sessionID := SessionID(arkPSBT.UnsignedTx.TxHash())
+	recipient := recipients[0]
+
+	return &arkrpc.ListOORRecipientEventsByScriptResponse{
+		Events: []*arkrpc.OORRecipientEvent{
+			{
+				RecipientPkScript: recipient.PkScript,
+				EventId:           7,
+				SessionId:         sessionID[:],
+				OutputIndex:       recipient.OutputIndex,
+				Value:             uint64(recipient.Value),
+				ArkPsbt:           arkRaw,
+				CheckpointPsbts:   checkpointRaws,
+			},
+		},
+		NextCursor: 8,
+	}, sessionID, recipient.PkScript, 7
+}
 
 // TestOORClientActorDriveRetryDueEventDurablePath verifies the retry-due signal
 // can cross the durable actor boundary and re-drive the resumed outbox work.
@@ -100,6 +181,158 @@ func TestOORClientActorDriveRetryDueEventDurablePath(t *testing.T) {
 	stateMsg, ok := stateResp.UnwrapOr(nil).(*GetStateResponse)
 	require.True(t, ok)
 	require.IsType(t, &AwaitingFinalizeAccepted{}, stateMsg.State)
+}
+
+// TestOORDurableBehaviorDriveIncomingHandledNotifiesVTXOManager verifies the
+// DriveEventRequest path forwards materialized incoming VTXOs to the manager
+// after the receive-state transition is durably checkpointed.
+func TestOORDurableBehaviorDriveIncomingHandledNotifiesVTXOManager(
+	t *testing.T) {
+
+	t.Parallel()
+
+	ctx := t.Context()
+
+	arkPSBT, finalCheckpoints, recipients, parentCommitment, recipientKey,
+		operatorKey := buildTestIncomingMaterialization(t)
+
+	sessionID := SessionID(arkPSBT.UnsignedTx.TxHash())
+	session, _, err := DriveIncomingTransferWithCheckpoints(
+		ctx, sessionID, arkPSBT, finalCheckpoints,
+	)
+	require.NoError(t, err)
+
+	desc, err := BuildIncomingVTXODescriptor(
+		arkPSBT, IncomingVTXOConfig{
+			OutputIndex: recipients[0].OutputIndex,
+			ClientKey: keychain.KeyDescriptor{
+				PubKey: recipientKey.PubKey(),
+			},
+			OperatorKey: operatorKey,
+			ExitDelay:   10,
+			Metadata: IncomingVTXOMetadata{
+				RoundID:        "round-incoming",
+				CommitmentTxID: parentCommitment,
+				BatchExpiry:    1000,
+				TreeDepth:      1,
+				ChainDepth:     len(finalCheckpoints),
+				CreatedHeight:  700,
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	managerRef := &mockVTXOManagerRef{}
+	behavior := &oorDurableBehavior{
+		cfg: ClientActorCfg{
+			OutboxHandler: &noopOutboxHandler{},
+			DeliveryStore: newTestDeliveryStore(t),
+			ActorID:       "oor-drive-incoming-handled-notify",
+			VTXOManager:   managerRef,
+		},
+		sessions: map[SessionID]*sessionHandle{
+			sessionID: {
+				FSM:  session.FSM,
+				kind: sessionKindIncoming,
+			},
+		},
+	}
+
+	resp := behavior.handleDriveEvent(ctx, &DriveEventRequest{
+		SessionID: sessionID,
+		Event: &IncomingHandledEvent{
+			MaterializedVTXOs: []*vtxo.Descriptor{desc},
+		},
+	})
+	require.True(t, resp.IsOk())
+
+	sent := managerRef.sent()
+	require.Len(t, sent, 1)
+
+	notification, ok := sent[0].(*vtxo.VTXOsMaterializedNotification)
+	require.True(t, ok)
+	require.Len(t, notification.VTXOs, 1)
+	require.Equal(t, desc.Outpoint, notification.VTXOs[0].Outpoint)
+
+	state, err := session.FSM.CurrentState()
+	require.NoError(t, err)
+	require.IsType(t, &ReceiveAwaitingAck{}, state)
+}
+
+// TestOORDurableBehaviorDriveIncomingHandledReloadsFromStore verifies the
+// durable callback path can reload incoming VTXOs by outpoint after the event
+// round-trips through the mailbox without attached descriptors.
+func TestOORDurableBehaviorDriveIncomingHandledReloadsFromStore(
+	t *testing.T) {
+
+	t.Parallel()
+
+	ctx := t.Context()
+
+	arkPSBT, finalCheckpoints, recipients, parentCommitment, recipientKey,
+		operatorKey := buildTestIncomingMaterialization(t)
+
+	sessionID := SessionID(arkPSBT.UnsignedTx.TxHash())
+	session, _, err := DriveIncomingTransferWithCheckpoints(
+		ctx, sessionID, arkPSBT, finalCheckpoints,
+	)
+	require.NoError(t, err)
+
+	desc, err := BuildIncomingVTXODescriptor(
+		arkPSBT, IncomingVTXOConfig{
+			OutputIndex: recipients[0].OutputIndex,
+			ClientKey: keychain.KeyDescriptor{
+				PubKey: recipientKey.PubKey(),
+			},
+			OperatorKey: operatorKey,
+			ExitDelay:   10,
+			Metadata: IncomingVTXOMetadata{
+				RoundID:        "round-incoming",
+				CommitmentTxID: parentCommitment,
+				BatchExpiry:    1000,
+				TreeDepth:      1,
+				ChainDepth:     len(finalCheckpoints),
+				CreatedHeight:  700,
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	store := newTestVTXOStore()
+	require.NoError(t, store.SaveVTXO(ctx, desc))
+
+	managerRef := &mockVTXOManagerRef{}
+	behavior := &oorDurableBehavior{
+		cfg: ClientActorCfg{
+			OutboxHandler: &noopOutboxHandler{},
+			DeliveryStore: newTestDeliveryStore(t),
+			ActorID:       "oor-drive-incoming-handled-reload",
+			VTXOManager:   managerRef,
+			VTXOStore:     store,
+		},
+		sessions: map[SessionID]*sessionHandle{
+			sessionID: {
+				FSM:  session.FSM,
+				kind: sessionKindIncoming,
+			},
+		},
+	}
+
+	resp := behavior.handleDriveEvent(ctx, &DriveEventRequest{
+		SessionID: sessionID,
+		Event: &IncomingHandledEvent{
+			MaterializedOutpoints: []wire.OutPoint{desc.Outpoint},
+		},
+	})
+	require.True(t, resp.IsOk())
+
+	sent := managerRef.sent()
+	require.Len(t, sent, 1)
+
+	notification, ok := sent[0].(*vtxo.VTXOsMaterializedNotification)
+	require.True(t, ok)
+	require.Len(t, notification.VTXOs, 1)
+	require.Equal(t, desc.Outpoint, notification.VTXOs[0].Outpoint)
 }
 
 // TestOutboxForStateRetryBackoff asserts retry-backoff state emits a
@@ -172,4 +405,108 @@ func TestRetryBackoffProcessEventRetryDueRequiresSnapshot(t *testing.T) {
 	)
 	require.Nil(t, transition)
 	require.ErrorContains(t, err, "resume snapshot must be provided")
+}
+
+// TestOORDurableBehaviorHandleResolveIncomingTransferDurableUnary verifies the
+// actor checkpoints an incoming resolve-pending state, then enqueues the
+// durable unary request needed to resolve the full Ark package after commit.
+func TestOORDurableBehaviorHandleResolveIncomingTransferDurableUnary(
+	t *testing.T) {
+
+	t.Parallel()
+
+	ctx := t.Context()
+
+	_, sessionID, recipientPkScript, recipientEventID :=
+		buildIncomingResolveResponse(t)
+	serverConn := newMockServerConnRef(t)
+	behavior := &oorDurableBehavior{
+		cfg: ClientActorCfg{
+			DeliveryStore: newTestDeliveryStore(t),
+			ActorID:       "oor-resolve-incoming-async",
+			ServerConn:    serverConn,
+		},
+		sessions: make(map[SessionID]*sessionHandle),
+	}
+
+	resp := behavior.handleResolveIncomingTransfer(
+		ctx, &ResolveIncomingTransferRequest{
+			SessionID:         sessionID,
+			RecipientPkScript: recipientPkScript,
+			RecipientEventID:  recipientEventID,
+		},
+	)
+	require.True(t, resp.IsOk())
+
+	handle := behavior.sessions[sessionID]
+	require.NotNil(t, handle)
+
+	state, err := handle.currentSessionState()
+	require.NoError(t, err)
+
+	resolving, ok := state.(*ReceiveResolving)
+	require.True(t, ok)
+	require.Equal(t, recipientPkScript, resolving.RecipientPkScript)
+	require.Equal(t, recipientEventID, resolving.RecipientEventID)
+
+	unaryReq := serverConn.lastRecipientQuery()
+	require.Equal(t, recipientPkScript, unaryReq.PkScript)
+	require.Equal(t, recipientEventID-1, unaryReq.AfterEventID)
+	require.Equal(t, uint32(1), unaryReq.Limit)
+	require.Equal(
+		t,
+		IncomingResolveCorrelationID(sessionID, recipientEventID),
+		unaryReq.CorrelationID,
+	)
+}
+
+// TestOORDurableBehaviorResumeRestoredSessionsResolvePending verifies restart
+// replay re-emits the durable unary needed to resolve an incoming transfer
+// hint for resolve-pending sessions.
+func TestOORDurableBehaviorResumeRestoredSessionsResolvePending(
+	t *testing.T) {
+
+	t.Parallel()
+
+	ctx := t.Context()
+
+	_, sessionID, recipientPkScript, recipientEventID :=
+		buildIncomingResolveResponse(t)
+
+	session, err := newReceiveSessionWithState(
+		ctx, sessionID, &ReceiveResolving{
+			SessionID:         sessionID,
+			RecipientPkScript: recipientPkScript,
+			RecipientEventID:  recipientEventID,
+		},
+	)
+	require.NoError(t, err)
+
+	serverConn := newMockServerConnRef(t)
+	behavior := &oorDurableBehavior{
+		cfg: ClientActorCfg{
+			DeliveryStore: newTestDeliveryStore(t),
+			ActorID:       "oor-resume-incoming-resolve",
+			ServerConn:    serverConn,
+		},
+		sessions: map[SessionID]*sessionHandle{
+			sessionID: {
+				FSM:  session.FSM,
+				kind: sessionKindIncoming,
+			},
+		},
+	}
+
+	err = behavior.resumeRestoredSessions(ctx)
+	require.NoError(t, err)
+
+	unaryReq := serverConn.lastRecipientQuery()
+	require.Equal(t, recipientPkScript, unaryReq.PkScript)
+	require.Equal(t, recipientEventID-1, unaryReq.AfterEventID)
+	require.Equal(t, uint32(1), unaryReq.Limit)
+	require.Equal(
+		t,
+		IncomingResolveCorrelationID(sessionID, recipientEventID),
+		unaryReq.CorrelationID,
+	)
 }

--- a/oor/actor_drive_event_test.go
+++ b/oor/actor_drive_event_test.go
@@ -90,6 +90,7 @@ func TestOORClientActorDriveEventAppliesEvent(t *testing.T) {
 	}}
 
 	actor := NewOORClientActor(ClientActorCfg{
+		OutboxHandler: &noopOutboxHandler{},
 		DeliveryStore: newTestDeliveryStore(t),
 		ActorID:       "oor-drive-event-happy",
 	})

--- a/oor/actor_durable_message.go
+++ b/oor/actor_durable_message.go
@@ -81,14 +81,14 @@ const (
 )
 
 const (
-	incomingMetadataMatchOutputIndexRecordType   tlv.Type = 1
-	incomingMetadataMatchRoundIDRecordType       tlv.Type = 3
+	incomingMetadataMatchOutputIndexRecordType    tlv.Type = 1
+	incomingMetadataMatchRoundIDRecordType        tlv.Type = 3
 	incomingMetadataMatchCommitmentTxIDRecordType tlv.Type = 5
-	incomingMetadataMatchBatchExpiryRecordType   tlv.Type = 7
-	incomingMetadataMatchTreeDepthRecordType     tlv.Type = 9
-	incomingMetadataMatchChainDepthRecordType    tlv.Type = 11
-	incomingMetadataMatchCreatedHeightRecordType tlv.Type = 13
-	incomingMetadataMatchTreePathRecordType      tlv.Type = 15
+	incomingMetadataMatchBatchExpiryRecordType    tlv.Type = 7
+	incomingMetadataMatchTreeDepthRecordType      tlv.Type = 9
+	incomingMetadataMatchChainDepthRecordType     tlv.Type = 11
+	incomingMetadataMatchCreatedHeightRecordType  tlv.Type = 13
+	incomingMetadataMatchTreePathRecordType       tlv.Type = 15
 )
 
 type startTransferPayload struct {
@@ -274,7 +274,9 @@ func encodeIncomingMetadataMatches(matches []IncomingMetadataMatch) ([]byte,
 	return encodeLengthPrefixedBlobList(blobs)
 }
 
-func decodeIncomingMetadataMatches(raw []byte) ([]IncomingMetadataMatch, error) {
+func decodeIncomingMetadataMatches(
+	raw []byte) ([]IncomingMetadataMatch, error) {
+
 	blobs, err := decodeLengthPrefixedBlobList(raw)
 	if err != nil {
 		return nil, err
@@ -354,14 +356,14 @@ func encodeIncomingMetadataMatch(match IncomingMetadataMatch) ([]byte, error) {
 
 func decodeIncomingMetadataMatch(raw []byte) (IncomingMetadataMatch, error) {
 	var (
-		outputIndex   uint32
-		roundID       []byte
+		outputIndex    uint32
+		roundID        []byte
 		commitmentTxID []byte
-		batchExpiry   uint32
-		treeDepth     uint32
-		chainDepth    uint32
-		createdHeight uint32
-		treePath      []byte
+		batchExpiry    uint32
+		treeDepth      uint32
+		chainDepth     uint32
+		createdHeight  uint32
+		treePath       []byte
 	)
 
 	records := []tlv.Record{
@@ -407,8 +409,10 @@ func decodeIncomingMetadataMatch(raw []byte) (IncomingMetadataMatch, error) {
 	}
 
 	if len(commitmentTxID) != chainhash.HashSize {
-		return IncomingMetadataMatch{}, fmt.Errorf("incoming metadata "+
-			"commitment txid must be provided")
+		return IncomingMetadataMatch{}, fmt.Errorf(
+			"incoming metadata commitment txid " +
+				"must be provided",
+		)
 	}
 
 	decodedBatchExpiry, err := uint32ToInt32(
@@ -744,7 +748,8 @@ func encodeResolveIncomingTransferPayload(sessionID SessionID,
 
 	records := []tlv.Record{
 		tlv.MakePrimitiveRecord(
-			resolveIncomingPayloadSessionIDRecordType, &sessionBytes,
+			resolveIncomingPayloadSessionIDRecordType,
+			&sessionBytes,
 		),
 		tlv.MakePrimitiveRecord(
 			resolveIncomingPayloadPkScriptRecordType, &pkScript,
@@ -778,7 +783,8 @@ func decodeResolveIncomingTransferPayload(raw []byte) (SessionID, []byte,
 
 	records := []tlv.Record{
 		tlv.MakePrimitiveRecord(
-			resolveIncomingPayloadSessionIDRecordType, &sessionBytes,
+			resolveIncomingPayloadSessionIDRecordType,
+			&sessionBytes,
 		),
 		tlv.MakePrimitiveRecord(
 			resolveIncomingPayloadPkScriptRecordType,
@@ -1010,7 +1016,8 @@ func encodeEventPayload(event Event) ([]byte, error) {
 
 		if evt.ArkPSBT == nil {
 			return nil, fmt.Errorf(
-				"incoming transfer event ark psbt must be provided",
+				"incoming transfer event " +
+					"ark psbt must be provided",
 			)
 		}
 
@@ -1213,7 +1220,8 @@ func decodeEventPayload(raw []byte) (Event, error) {
 	case eventKindIncomingTransfer:
 		if len(arkPSBT) == 0 {
 			return nil, fmt.Errorf(
-				"incoming transfer event ark psbt must be provided",
+				"incoming transfer event " +
+					"ark psbt must be provided",
 			)
 		}
 

--- a/oor/actor_durable_message.go
+++ b/oor/actor_durable_message.go
@@ -10,6 +10,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+	clientdb "github.com/lightninglabs/darepo-client/db"
 	"github.com/lightninglabs/darepo-client/lib/tx/psbtutil"
 	"github.com/lightningnetwork/lnd/tlv"
 )
@@ -47,6 +48,7 @@ const (
 	eventPayloadCheckpointPSBTsRecordType tlv.Type = 7
 	eventPayloadReasonRecordType          tlv.Type = 9
 	eventPayloadOutpointsRecordType       tlv.Type = 11
+	eventPayloadMetadataMatchesRecordType tlv.Type = 13
 )
 
 const (
@@ -59,6 +61,7 @@ const (
 	eventKindIncomingTransfer  uint64 = 7
 	eventKindIncomingHandled   uint64 = 8
 	eventKindIncomingAckSent   uint64 = 9
+	eventKindIncomingMetadata  uint64 = 10
 )
 
 const (
@@ -75,6 +78,17 @@ const (
 const (
 	recipientPkScriptRecordType tlv.Type = 1
 	recipientValueSatRecordType tlv.Type = 2
+)
+
+const (
+	incomingMetadataMatchOutputIndexRecordType   tlv.Type = 1
+	incomingMetadataMatchRoundIDRecordType       tlv.Type = 3
+	incomingMetadataMatchCommitmentTxIDRecordType tlv.Type = 5
+	incomingMetadataMatchBatchExpiryRecordType   tlv.Type = 7
+	incomingMetadataMatchTreeDepthRecordType     tlv.Type = 9
+	incomingMetadataMatchChainDepthRecordType    tlv.Type = 11
+	incomingMetadataMatchCreatedHeightRecordType tlv.Type = 13
+	incomingMetadataMatchTreePathRecordType      tlv.Type = 15
 )
 
 type startTransferPayload struct {
@@ -242,6 +256,209 @@ func decodeOutPointList(raw []byte) ([]wire.OutPoint, error) {
 	}
 
 	return outpoints, nil
+}
+
+func encodeIncomingMetadataMatches(matches []IncomingMetadataMatch) ([]byte,
+	error) {
+
+	blobs := make([][]byte, 0, len(matches))
+	for i := range matches {
+		raw, err := encodeIncomingMetadataMatch(matches[i])
+		if err != nil {
+			return nil, err
+		}
+
+		blobs = append(blobs, raw)
+	}
+
+	return encodeLengthPrefixedBlobList(blobs)
+}
+
+func decodeIncomingMetadataMatches(raw []byte) ([]IncomingMetadataMatch, error) {
+	blobs, err := decodeLengthPrefixedBlobList(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	matches := make([]IncomingMetadataMatch, 0, len(blobs))
+	for i := range blobs {
+		match, err := decodeIncomingMetadataMatch(blobs[i])
+		if err != nil {
+			return nil, err
+		}
+
+		matches = append(matches, match)
+	}
+
+	return matches, nil
+}
+
+func encodeIncomingMetadataMatch(match IncomingMetadataMatch) ([]byte, error) {
+	outputIndex := match.OutputIndex
+	roundID := []byte(match.Metadata.RoundID)
+	commitmentTxID := match.Metadata.CommitmentTxID[:]
+	batchExpiry := uint32(match.Metadata.BatchExpiry)
+	treeDepth := uint32(match.Metadata.TreeDepth)
+	chainDepth := uint32(match.Metadata.ChainDepth)
+	createdHeight := uint32(match.Metadata.CreatedHeight)
+
+	treePath, err := clientdb.SerializeTree(match.Metadata.TreePath)
+	if err != nil {
+		return nil, err
+	}
+
+	records := []tlv.Record{
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchOutputIndexRecordType,
+			&outputIndex,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchRoundIDRecordType, &roundID,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchCommitmentTxIDRecordType,
+			&commitmentTxID,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchBatchExpiryRecordType,
+			&batchExpiry,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchTreeDepthRecordType, &treeDepth,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchChainDepthRecordType,
+			&chainDepth,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchCreatedHeightRecordType,
+			&createdHeight,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchTreePathRecordType, &treePath,
+		),
+	}
+
+	stream, err := tlv.NewStream(records...)
+	if err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	if err := stream.Encode(&buf); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func decodeIncomingMetadataMatch(raw []byte) (IncomingMetadataMatch, error) {
+	var (
+		outputIndex   uint32
+		roundID       []byte
+		commitmentTxID []byte
+		batchExpiry   uint32
+		treeDepth     uint32
+		chainDepth    uint32
+		createdHeight uint32
+		treePath      []byte
+	)
+
+	records := []tlv.Record{
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchOutputIndexRecordType,
+			&outputIndex,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchRoundIDRecordType, &roundID,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchCommitmentTxIDRecordType,
+			&commitmentTxID,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchBatchExpiryRecordType,
+			&batchExpiry,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchTreeDepthRecordType, &treeDepth,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchChainDepthRecordType,
+			&chainDepth,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchCreatedHeightRecordType,
+			&createdHeight,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchTreePathRecordType, &treePath,
+		),
+	}
+
+	stream, err := tlv.NewStream(records...)
+	if err != nil {
+		return IncomingMetadataMatch{}, err
+	}
+
+	reader := bytes.NewReader(raw)
+	if _, err := stream.DecodeWithParsedTypes(reader); err != nil {
+		return IncomingMetadataMatch{}, err
+	}
+
+	if len(commitmentTxID) != chainhash.HashSize {
+		return IncomingMetadataMatch{}, fmt.Errorf("incoming metadata "+
+			"commitment txid must be provided")
+	}
+
+	decodedBatchExpiry, err := uint32ToInt32(
+		batchExpiry, "incoming batch expiry",
+	)
+	if err != nil {
+		return IncomingMetadataMatch{}, err
+	}
+
+	decodedTreeDepth, err := uint32ToInt32(
+		treeDepth, "incoming tree depth",
+	)
+	if err != nil {
+		return IncomingMetadataMatch{}, err
+	}
+
+	decodedChainDepth, err := uint32ToInt32(
+		chainDepth, "incoming chain depth",
+	)
+	if err != nil {
+		return IncomingMetadataMatch{}, err
+	}
+
+	decodedCreatedHeight, err := uint32ToInt32(
+		createdHeight, "incoming created height",
+	)
+	if err != nil {
+		return IncomingMetadataMatch{}, err
+	}
+
+	decodedTreePath, err := clientdb.DeserializeTree(treePath)
+	if err != nil {
+		return IncomingMetadataMatch{}, err
+	}
+
+	var decodedCommitmentTxID chainhash.Hash
+	copy(decodedCommitmentTxID[:], commitmentTxID)
+
+	return IncomingMetadataMatch{
+		OutputIndex: outputIndex,
+		Metadata: IncomingVTXOMetadata{
+			RoundID:        string(roundID),
+			CommitmentTxID: decodedCommitmentTxID,
+			BatchExpiry:    decodedBatchExpiry,
+			TreeDepth:      int(decodedTreeDepth),
+			ChainDepth:     int(decodedChainDepth),
+			CreatedHeight:  decodedCreatedHeight,
+			TreePath:       decodedTreePath,
+		},
+	}, nil
 }
 
 func encodeRecipientPayload(payload recipientPayload) ([]byte, error) {
@@ -733,6 +950,7 @@ func encodeEventPayload(event Event) ([]byte, error) {
 		checkpointPSBT  []byte
 		reason          []byte
 		outpointPayload []byte
+		metadataPayload []byte
 		err             error
 	)
 
@@ -836,6 +1054,16 @@ func encodeEventPayload(event Event) ([]byte, error) {
 			return nil, err
 		}
 
+	case *IncomingMetadataResolvedEvent:
+		eventKind = eventKindIncomingMetadata
+
+		metadataPayload, err = encodeIncomingMetadataMatches(
+			evt.Matches,
+		)
+		if err != nil {
+			return nil, err
+		}
+
 	case *IncomingAckSentEvent:
 		eventKind = eventKindIncomingAckSent
 
@@ -857,6 +1085,9 @@ func encodeEventPayload(event Event) ([]byte, error) {
 		tlv.MakePrimitiveRecord(eventPayloadReasonRecordType, &reason),
 		tlv.MakePrimitiveRecord(
 			eventPayloadOutpointsRecordType, &outpointPayload,
+		),
+		tlv.MakePrimitiveRecord(
+			eventPayloadMetadataMatchesRecordType, &metadataPayload,
 		),
 	}
 
@@ -881,6 +1112,7 @@ func decodeEventPayload(raw []byte) (Event, error) {
 		checkpointPSBT  []byte
 		reason          []byte
 		outpointPayload []byte
+		metadataPayload []byte
 	)
 
 	records := []tlv.Record{
@@ -897,6 +1129,9 @@ func decodeEventPayload(raw []byte) (Event, error) {
 		tlv.MakePrimitiveRecord(eventPayloadReasonRecordType, &reason),
 		tlv.MakePrimitiveRecord(
 			eventPayloadOutpointsRecordType, &outpointPayload,
+		),
+		tlv.MakePrimitiveRecord(
+			eventPayloadMetadataMatchesRecordType, &metadataPayload,
 		),
 	}
 
@@ -1012,6 +1247,18 @@ func decodeEventPayload(raw []byte) (Event, error) {
 
 		return &IncomingHandledEvent{
 			MaterializedOutpoints: outpoints,
+		}, nil
+
+	case eventKindIncomingMetadata:
+		matches, err := decodeIncomingMetadataMatches(
+			metadataPayload,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		return &IncomingMetadataResolvedEvent{
+			Matches: matches,
 		}, nil
 
 	case eventKindIncomingAckSent:

--- a/oor/actor_durable_message.go
+++ b/oor/actor_durable_message.go
@@ -26,6 +26,12 @@ const (
 )
 
 const (
+	resolveIncomingPayloadSessionIDRecordType tlv.Type = 1
+	resolveIncomingPayloadPkScriptRecordType  tlv.Type = 2
+	resolveIncomingPayloadEventIDRecordType   tlv.Type = 3
+)
+
+const (
 	restorePayloadSnapshotRecordType tlv.Type = 1
 )
 
@@ -40,6 +46,7 @@ const (
 	eventPayloadArkPSBTRecordType         tlv.Type = 5
 	eventPayloadCheckpointPSBTsRecordType tlv.Type = 7
 	eventPayloadReasonRecordType          tlv.Type = 9
+	eventPayloadOutpointsRecordType       tlv.Type = 11
 )
 
 const (
@@ -49,6 +56,9 @@ const (
 	eventKindInputsMarkedSpent uint64 = 4
 	eventKindFail              uint64 = 5
 	eventKindRetryDue          uint64 = 6
+	eventKindIncomingTransfer  uint64 = 7
+	eventKindIncomingHandled   uint64 = 8
+	eventKindIncomingAckSent   uint64 = 9
 )
 
 const (
@@ -203,6 +213,35 @@ func decodeRecipientPayloads(raw []byte) ([]recipientPayload, error) {
 	}
 
 	return payloads, nil
+}
+
+func encodeOutPointList(outpoints []wire.OutPoint) ([]byte, error) {
+	blobs := make([][]byte, 0, len(outpoints))
+
+	for _, outpoint := range outpoints {
+		blobs = append(blobs, outPointBytes(outpoint))
+	}
+
+	return encodeLengthPrefixedBlobList(blobs)
+}
+
+func decodeOutPointList(raw []byte) ([]wire.OutPoint, error) {
+	blobs, err := decodeLengthPrefixedBlobList(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	outpoints := make([]wire.OutPoint, 0, len(blobs))
+	for _, blob := range blobs {
+		outpoint, err := parseOutPointBytes(blob)
+		if err != nil {
+			return nil, err
+		}
+
+		outpoints = append(outpoints, outpoint)
+	}
+
+	return outpoints, nil
 }
 
 func encodeRecipientPayload(payload recipientPayload) ([]byte, error) {
@@ -479,6 +518,79 @@ func decodeSessionPayload(raw []byte) (SessionID, error) {
 	return parseSessionID(sessionBytes)
 }
 
+func encodeResolveIncomingTransferPayload(sessionID SessionID,
+	recipientPkScript []byte, recipientEventID uint64) ([]byte, error) {
+
+	sessionBytes := sessionIDBytes(sessionID)
+	pkScript := recipientPkScript
+	eventID := recipientEventID
+
+	records := []tlv.Record{
+		tlv.MakePrimitiveRecord(
+			resolveIncomingPayloadSessionIDRecordType, &sessionBytes,
+		),
+		tlv.MakePrimitiveRecord(
+			resolveIncomingPayloadPkScriptRecordType, &pkScript,
+		),
+		tlv.MakePrimitiveRecord(
+			resolveIncomingPayloadEventIDRecordType, &eventID,
+		),
+	}
+
+	stream, err := tlv.NewStream(records...)
+	if err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	if err := stream.Encode(&buf); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func decodeResolveIncomingTransferPayload(raw []byte) (SessionID, []byte,
+	uint64, error) {
+
+	var (
+		sessionBytes      []byte
+		recipientPkScript []byte
+		recipientEventID  uint64
+	)
+
+	records := []tlv.Record{
+		tlv.MakePrimitiveRecord(
+			resolveIncomingPayloadSessionIDRecordType, &sessionBytes,
+		),
+		tlv.MakePrimitiveRecord(
+			resolveIncomingPayloadPkScriptRecordType,
+			&recipientPkScript,
+		),
+		tlv.MakePrimitiveRecord(
+			resolveIncomingPayloadEventIDRecordType,
+			&recipientEventID,
+		),
+	}
+
+	stream, err := tlv.NewStream(records...)
+	if err != nil {
+		return SessionID{}, nil, 0, err
+	}
+
+	reader := bytes.NewReader(raw)
+	if _, err := stream.DecodeWithParsedTypes(reader); err != nil {
+		return SessionID{}, nil, 0, err
+	}
+
+	sessionID, err := parseSessionID(sessionBytes)
+	if err != nil {
+		return SessionID{}, nil, 0, err
+	}
+
+	return sessionID, recipientPkScript, recipientEventID, nil
+}
+
 func encodeRestoreSnapshotPayload(snapshot *OutgoingSnapshot) ([]byte, error) {
 	snapshotRaw, err := encodeOutgoingSnapshot(snapshot)
 	if err != nil {
@@ -602,6 +714,10 @@ func decodeDriveEventRequestPayload(raw []byte) (SessionID, Event, error) {
 		return SessionID{}, nil, err
 	}
 
+	if incoming, ok := event.(*IncomingTransferEvent); ok {
+		incoming.SessionID = sessionID
+	}
+
 	// Validation of SubmitAcceptedEvent identity is deferred to the
 	// processing layer (handleDriveEvent), not the deserialization
 	// layer. See encodeDriveEventRequestPayload for rationale.
@@ -611,12 +727,13 @@ func decodeDriveEventRequestPayload(raw []byte) (SessionID, Event, error) {
 
 func encodeEventPayload(event Event) ([]byte, error) {
 	var (
-		eventKind      uint64
-		submitSession  []byte
-		arkPSBT        []byte
-		checkpointPSBT []byte
-		reason         []byte
-		err            error
+		eventKind       uint64
+		submitSession   []byte
+		arkPSBT         []byte
+		checkpointPSBT  []byte
+		reason          []byte
+		outpointPayload []byte
+		err             error
 	)
 
 	switch evt := event.(type) {
@@ -670,6 +787,58 @@ func encodeEventPayload(event Event) ([]byte, error) {
 	case *RetryDueEvent:
 		eventKind = eventKindRetryDue
 
+	case *IncomingTransferEvent:
+		eventKind = eventKindIncomingTransfer
+
+		if evt.ArkPSBT == nil {
+			return nil, fmt.Errorf(
+				"incoming transfer event ark psbt must be provided",
+			)
+		}
+
+		arkPSBT, err = psbtutil.Serialize(evt.ArkPSBT)
+		if err != nil {
+			return nil, err
+		}
+
+		checkpoints, err := serializePSBTSlice(
+			evt.FinalCheckpointPSBTs,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		checkpointPSBT, err = encodeLengthPrefixedBlobList(
+			checkpoints,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+	case *IncomingHandledEvent:
+		eventKind = eventKindIncomingHandled
+
+		outpoints := evt.MaterializedOutpoints
+		if len(outpoints) == 0 && len(evt.MaterializedVTXOs) > 0 {
+			outpoints = make([]wire.OutPoint, 0,
+				len(evt.MaterializedVTXOs))
+			for _, desc := range evt.MaterializedVTXOs {
+				if desc == nil {
+					continue
+				}
+
+				outpoints = append(outpoints, desc.Outpoint)
+			}
+		}
+
+		outpointPayload, err = encodeOutPointList(outpoints)
+		if err != nil {
+			return nil, err
+		}
+
+	case *IncomingAckSentEvent:
+		eventKind = eventKindIncomingAckSent
+
 	default:
 		return nil, fmt.Errorf("unsupported event type: %T", event)
 	}
@@ -686,6 +855,9 @@ func encodeEventPayload(event Event) ([]byte, error) {
 			eventPayloadCheckpointPSBTsRecordType, &checkpointPSBT,
 		),
 		tlv.MakePrimitiveRecord(eventPayloadReasonRecordType, &reason),
+		tlv.MakePrimitiveRecord(
+			eventPayloadOutpointsRecordType, &outpointPayload,
+		),
 	}
 
 	stream, err := tlv.NewStream(records...)
@@ -703,11 +875,12 @@ func encodeEventPayload(event Event) ([]byte, error) {
 
 func decodeEventPayload(raw []byte) (Event, error) {
 	var (
-		eventKind      uint64
-		submitSession  []byte
-		arkPSBT        []byte
-		checkpointPSBT []byte
-		reason         []byte
+		eventKind       uint64
+		submitSession   []byte
+		arkPSBT         []byte
+		checkpointPSBT  []byte
+		reason          []byte
+		outpointPayload []byte
 	)
 
 	records := []tlv.Record{
@@ -722,6 +895,9 @@ func decodeEventPayload(raw []byte) (Event, error) {
 			eventPayloadCheckpointPSBTsRecordType, &checkpointPSBT,
 		),
 		tlv.MakePrimitiveRecord(eventPayloadReasonRecordType, &reason),
+		tlv.MakePrimitiveRecord(
+			eventPayloadOutpointsRecordType, &outpointPayload,
+		),
 	}
 
 	stream, err := tlv.NewStream(records...)
@@ -798,6 +974,48 @@ func decodeEventPayload(raw []byte) (Event, error) {
 
 	case eventKindRetryDue:
 		return &RetryDueEvent{}, nil
+
+	case eventKindIncomingTransfer:
+		if len(arkPSBT) == 0 {
+			return nil, fmt.Errorf(
+				"incoming transfer event ark psbt must be provided",
+			)
+		}
+
+		ark, err := psbtutil.Parse(arkPSBT)
+		if err != nil {
+			return nil, err
+		}
+
+		checkpointRaw, err := decodeLengthPrefixedBlobList(
+			checkpointPSBT,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		checkpoints, err := parsePSBTSlice(checkpointRaw)
+		if err != nil {
+			return nil, err
+		}
+
+		return &IncomingTransferEvent{
+			ArkPSBT:              ark,
+			FinalCheckpointPSBTs: checkpoints,
+		}, nil
+
+	case eventKindIncomingHandled:
+		outpoints, err := decodeOutPointList(outpointPayload)
+		if err != nil {
+			return nil, err
+		}
+
+		return &IncomingHandledEvent{
+			MaterializedOutpoints: outpoints,
+		}, nil
+
+	case eventKindIncomingAckSent:
+		return &IncomingAckSentEvent{}, nil
 
 	default:
 		return nil, fmt.Errorf("unknown event kind: %d", eventKind)

--- a/oor/actor_durable_message.go
+++ b/oor/actor_durable_message.go
@@ -811,6 +811,19 @@ func decodeResolveIncomingTransferPayload(raw []byte) (SessionID, []byte,
 		return SessionID{}, nil, 0, err
 	}
 
+	// TODO(oor-receive): The maxPkScriptLen limit guards against
+	// unbounded allocations from a corrupted or malicious TLV payload.
+	// Standard Bitcoin pk_scripts are well under 10 000 bytes; raise
+	// this constant via a tracked issue if a new script type requires
+	// a longer encoding.
+	const maxPkScriptLen = 10_000
+	if len(recipientPkScript) > maxPkScriptLen {
+		return SessionID{}, nil, 0, fmt.Errorf(
+			"recipient pk_script length %d exceeds limit %d",
+			len(recipientPkScript), maxPkScriptLen,
+		)
+	}
+
 	return sessionID, recipientPkScript, recipientEventID, nil
 }
 
@@ -1362,6 +1375,19 @@ func decodeLengthPrefixedBlobList(raw []byte) ([][]byte, error) {
 	count, err := tlv.ReadVarInt(reader, &scratch)
 	if err != nil {
 		return nil, err
+	}
+
+	// TODO(oor-receive): The maxBlobListCount limit is a pragmatic
+	// upper bound to prevent unbounded slice allocation from a
+	// malformed or malicious TLV payload. Raise this constant via a
+	// tracked issue if any blob-list field legitimately needs more
+	// entries.
+	const maxBlobListCount = 10_000
+	if count > maxBlobListCount {
+		return nil, fmt.Errorf(
+			"blob list count %d exceeds limit %d",
+			count, maxBlobListCount,
+		)
 	}
 
 	blobs := make([][]byte, 0, count)

--- a/oor/actor_durable_message_test.go
+++ b/oor/actor_durable_message_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/tree"
+	"github.com/lightninglabs/darepo-client/vtxo"
 	"github.com/stretchr/testify/require"
 )
 
@@ -163,6 +165,171 @@ func TestDriveEventRequestRoundTripRetryDueEvent(t *testing.T) {
 
 	require.Equal(t, sessionID, decoded.SessionID)
 	require.IsType(t, &RetryDueEvent{}, decoded.Event)
+}
+
+// TestDriveEventRequestRoundTripIncomingTransferEvent asserts
+// DriveEventRequest TLV Encode/Decode round-trips IncomingTransferEvent
+// correctly.
+func TestDriveEventRequestRoundTripIncomingTransferEvent(t *testing.T) {
+	t.Parallel()
+
+	arkPSBT, checkpoints, _, _, _, _ :=
+		buildTestIncomingMaterialization(t)
+
+	sessionID := SessionID(arkPSBT.UnsignedTx.TxHash())
+	msg := &DriveEventRequest{
+		SessionID: sessionID,
+		Event: &IncomingTransferEvent{
+			SessionID:            sessionID,
+			ArkPSBT:              arkPSBT,
+			FinalCheckpointPSBTs: checkpoints,
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, msg.Encode(&buf))
+
+	decoded := &DriveEventRequest{}
+	require.NoError(t, decoded.Decode(&buf))
+
+	require.Equal(t, sessionID, decoded.SessionID)
+
+	incomingEvt, ok := decoded.Event.(*IncomingTransferEvent)
+	require.True(t, ok)
+	require.Equal(t, sessionID, incomingEvt.SessionID)
+	require.NotNil(t, incomingEvt.ArkPSBT)
+	require.Len(t, incomingEvt.FinalCheckpointPSBTs, len(checkpoints))
+}
+
+// TestDriveEventRequestRoundTripIncomingHandledEvent asserts
+// DriveEventRequest TLV Encode/Decode round-trips IncomingHandledEvent
+// correctly using durable outpoint identifiers.
+func TestDriveEventRequestRoundTripIncomingHandledEvent(t *testing.T) {
+	t.Parallel()
+
+	sessionID := SessionID(chainhash.Hash{8, 8, 8})
+	outpoint := wire.OutPoint{
+		Hash:  chainhash.Hash{9, 9, 9},
+		Index: 2,
+	}
+	msg := &DriveEventRequest{
+		SessionID: sessionID,
+		Event: &IncomingHandledEvent{
+			MaterializedVTXOs: []*vtxo.Descriptor{{
+				Outpoint: outpoint,
+			}},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, msg.Encode(&buf))
+
+	decoded := &DriveEventRequest{}
+	require.NoError(t, decoded.Decode(&buf))
+
+	require.Equal(t, sessionID, decoded.SessionID)
+
+	handledEvt, ok := decoded.Event.(*IncomingHandledEvent)
+	require.True(t, ok)
+	require.Len(t, handledEvt.MaterializedOutpoints, 1)
+	require.Equal(t, outpoint, handledEvt.MaterializedOutpoints[0])
+	require.Empty(t, handledEvt.MaterializedVTXOs)
+}
+
+// TestDriveEventRequestRoundTripIncomingMetadataResolvedEvent asserts
+// DriveEventRequest TLV Encode/Decode round-trips IncomingMetadataResolvedEvent
+// correctly.
+func TestDriveEventRequestRoundTripIncomingMetadataResolvedEvent(t *testing.T) {
+	t.Parallel()
+
+	sessionID := SessionID(chainhash.Hash{7, 7, 7})
+	msg := &DriveEventRequest{
+		SessionID: sessionID,
+		Event: &IncomingMetadataResolvedEvent{
+			Matches: []IncomingMetadataMatch{{
+				OutputIndex: 3,
+				Metadata: IncomingVTXOMetadata{
+					RoundID:        "round-test",
+					CommitmentTxID: chainhash.Hash{1, 2, 3},
+					BatchExpiry:    144,
+					TreeDepth:      2,
+					ChainDepth:     1,
+					CreatedHeight:  100,
+					TreePath:       &tree.Tree{},
+				},
+			}},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, msg.Encode(&buf))
+
+	decoded := &DriveEventRequest{}
+	require.NoError(t, decoded.Decode(&buf))
+
+	require.Equal(t, sessionID, decoded.SessionID)
+
+	resolvedEvt, ok := decoded.Event.(*IncomingMetadataResolvedEvent)
+	require.True(t, ok)
+	require.Len(t, resolvedEvt.Matches, 1)
+	require.Equal(t, uint32(3), resolvedEvt.Matches[0].OutputIndex)
+	require.Equal(t, "round-test",
+		resolvedEvt.Matches[0].Metadata.RoundID)
+	require.Equal(t, chainhash.Hash{1, 2, 3},
+		resolvedEvt.Matches[0].Metadata.CommitmentTxID)
+	require.Equal(t, int32(144),
+		resolvedEvt.Matches[0].Metadata.BatchExpiry)
+	require.Equal(t, 2, resolvedEvt.Matches[0].Metadata.TreeDepth)
+	require.Equal(t, 1, resolvedEvt.Matches[0].Metadata.ChainDepth)
+	require.Equal(t, int32(100),
+		resolvedEvt.Matches[0].Metadata.CreatedHeight)
+	require.NotNil(t, resolvedEvt.Matches[0].Metadata.TreePath)
+}
+
+// TestDriveEventRequestRoundTripIncomingAckSentEvent asserts
+// DriveEventRequest TLV Encode/Decode round-trips IncomingAckSentEvent
+// correctly.
+func TestDriveEventRequestRoundTripIncomingAckSentEvent(t *testing.T) {
+	t.Parallel()
+
+	sessionID := SessionID(chainhash.Hash{6, 6, 6})
+	msg := &DriveEventRequest{
+		SessionID: sessionID,
+		Event:     &IncomingAckSentEvent{},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, msg.Encode(&buf))
+
+	decoded := &DriveEventRequest{}
+	require.NoError(t, decoded.Decode(&buf))
+
+	require.Equal(t, sessionID, decoded.SessionID)
+	require.IsType(t, &IncomingAckSentEvent{}, decoded.Event)
+}
+
+// TestResolveIncomingTransferRequestRoundTrip asserts
+// ResolveIncomingTransferRequest TLV Encode/Decode round-trips the incoming
+// notification hint fields correctly.
+func TestResolveIncomingTransferRequestRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	sessionID := SessionID(chainhash.Hash{4, 5, 6})
+	msg := &ResolveIncomingTransferRequest{
+		SessionID:         sessionID,
+		RecipientPkScript: []byte{0x51, 0x20, 0x01, 0x02},
+		RecipientEventID:  7,
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, msg.Encode(&buf))
+
+	decoded := &ResolveIncomingTransferRequest{}
+	require.NoError(t, decoded.Decode(&buf))
+
+	require.Equal(t, sessionID, decoded.SessionID)
+	require.Equal(t, msg.RecipientPkScript, decoded.RecipientPkScript)
+	require.Equal(t, msg.RecipientEventID, decoded.RecipientEventID)
 }
 
 // TestDriveEventPayloadRequiresEvent asserts drive-event payload encoding

--- a/oor/actor_messages.go
+++ b/oor/actor_messages.go
@@ -296,9 +296,10 @@ type ResolveIncomingTransferRequest struct {
 	// incoming OOR output.
 	RecipientPkScript []byte
 
-	// RecipientEventID is the monotonic per-script event ID for the incoming
-	// recipient event. The actor uses this as the cursor hint when querying the
-	// indexer for the full Ark PSBT payload.
+	// RecipientEventID is the monotonic per-script event ID
+	// for the incoming recipient event. The actor uses this as
+	// the cursor hint when querying the indexer for the full
+	// Ark PSBT payload.
 	RecipientEventID uint64
 }
 

--- a/oor/actor_messages.go
+++ b/oor/actor_messages.go
@@ -31,12 +31,13 @@ func NewServiceKey() actor.ServiceKey[OORDurableMsg, ActorResp] {
 // identifier used for durable mailbox serialization. The 0x7xxx range avoids
 // collisions with the actor framework's reserved types.
 const (
-	StartTransferRequestTLVType  tlv.Type = 0x7010
-	DriveEventRequestTLVType     tlv.Type = 0x7011
-	GetStateRequestTLVType       tlv.Type = 0x7012
-	RestoreSessionRequestTLVType tlv.Type = 0x7013
-	ResumeSessionRequestTLVType  tlv.Type = 0x7014
-	ExportSnapshotRequestTLVType tlv.Type = 0x7015
+	StartTransferRequestTLVType    tlv.Type = 0x7010
+	DriveEventRequestTLVType       tlv.Type = 0x7011
+	GetStateRequestTLVType         tlv.Type = 0x7012
+	RestoreSessionRequestTLVType   tlv.Type = 0x7013
+	ResumeSessionRequestTLVType    tlv.Type = 0x7014
+	ExportSnapshotRequestTLVType   tlv.Type = 0x7015
+	ResolveIncomingTransferTLVType tlv.Type = 0x7016
 )
 
 // OORDurableMsg is the message constraint for the OOR durable actor mailbox.
@@ -277,6 +278,82 @@ func (m *DriveEventResponse) MessageType() string {
 // actorRespSealed marks this as implementing the sealed ActorResp interface.
 func (m *DriveEventResponse) actorRespSealed() {}
 
+// ResolveIncomingTransferRequest asks the actor to durably record a
+// lightweight incoming OOR notification and then resolve the full Ark package
+// asynchronously outside the live actor transaction.
+//
+// The serverconn dispatcher persists only the lightweight hint into the durable
+// OOR mailbox. The actor checkpoints a resolve-pending receive state first,
+// then performs the follow-up unary RPC on a detached callback path so restart
+// can safely re-drive the work.
+type ResolveIncomingTransferRequest struct {
+	actor.BaseMessage
+
+	// SessionID identifies the incoming transfer session.
+	SessionID SessionID
+
+	// RecipientPkScript is the registered receive script that matched the
+	// incoming OOR output.
+	RecipientPkScript []byte
+
+	// RecipientEventID is the monotonic per-script event ID for the incoming
+	// recipient event. The actor uses this as the cursor hint when querying the
+	// indexer for the full Ark PSBT payload.
+	RecipientEventID uint64
+}
+
+// MessageType returns the type of this message.
+func (m *ResolveIncomingTransferRequest) MessageType() string {
+	return "ResolveIncomingTransferRequest"
+}
+
+// actorMsgSealed marks this as implementing the sealed ActorMsg interface.
+func (m *ResolveIncomingTransferRequest) actorMsgSealed() {}
+
+// TLVType returns the unique TLV type identifier for this message.
+func (m *ResolveIncomingTransferRequest) TLVType() tlv.Type {
+	return ResolveIncomingTransferTLVType
+}
+
+// Encode serializes the message to the provided writer.
+func (m *ResolveIncomingTransferRequest) Encode(w io.Writer) error {
+	if m == nil {
+		return fmt.Errorf("resolve incoming transfer request must " +
+			"be provided")
+	}
+
+	raw, err := encodeResolveIncomingTransferPayload(
+		m.SessionID, m.RecipientPkScript, m.RecipientEventID,
+	)
+	if err != nil {
+		return err
+	}
+
+	_, err = w.Write(raw)
+
+	return err
+}
+
+// Decode deserializes the message from the provided reader.
+func (m *ResolveIncomingTransferRequest) Decode(r io.Reader) error {
+	raw, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+
+	sessionID, recipientPkScript, recipientEventID, err :=
+		decodeResolveIncomingTransferPayload(raw)
+	if err != nil {
+		return err
+	}
+
+	m.SessionID = sessionID
+	m.RecipientPkScript = recipientPkScript
+	m.RecipientEventID = recipientEventID
+
+	return nil
+}
+
 // GetStateRequest asks the actor for the current state of a session.
 type GetStateRequest struct {
 	actor.BaseMessage
@@ -332,7 +409,7 @@ type GetStateResponse struct {
 	actor.BaseMessage
 
 	// State is the current session state machine state.
-	State State
+	State SessionState
 }
 
 // MessageType returns the type of this message.

--- a/oor/actor_test.go
+++ b/oor/actor_test.go
@@ -117,6 +117,20 @@ func (h *testOutboxHandler) Handle(_ context.Context, sessionID SessionID,
 
 var _ OutboxHandler = (*testOutboxHandler)(nil)
 
+// noopOutboxHandler acknowledges local outbox events without producing any
+// follow-up events. Tests use this when they only need the actor plumbing,
+// not full wallet/server side effects.
+type noopOutboxHandler struct{}
+
+// Handle implements OutboxHandler.
+func (h *noopOutboxHandler) Handle(_ context.Context, _ SessionID,
+	_ OutboxEvent) ([]Event, error) {
+
+	return nil, nil
+}
+
+var _ OutboxHandler = (*noopOutboxHandler)(nil)
+
 // testOutgoingPackageStore records package persistence calls for assertions.
 type testOutgoingPackageStore struct {
 	packageCalls int
@@ -482,6 +496,50 @@ func (m *mockServerConnRef) lastSent() *serverconn.SendClientEventRequest {
 	return req
 }
 
+// lastRecipientQuery returns the most recent durable recipient-events query
+// captured by the mock. It fails the test if no messages have been captured.
+func (m *mockServerConnRef) lastRecipientQuery() *serverconn.
+	SendListOORRecipientEventsByScriptRequest {
+
+	m.t.Helper()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	require.NotEmpty(m.t, m.messages, "no messages captured")
+
+	last := m.messages[len(m.messages)-1]
+	req, ok := last.(*serverconn.SendListOORRecipientEventsByScriptRequest)
+	require.True(
+		m.t, ok,
+		"last message is not SendListOORRecipientEventsByScriptRequest",
+	)
+
+	return req
+}
+
+// lastVTXOQuery returns the most recent durable ListVTXOsByScripts query
+// captured by the mock. It fails the test if no messages have been captured.
+func (m *mockServerConnRef) lastVTXOQuery() *serverconn.
+	SendListVTXOsByScriptsRequest {
+
+	m.t.Helper()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	require.NotEmpty(m.t, m.messages, "no messages captured")
+
+	last := m.messages[len(m.messages)-1]
+	req, ok := last.(*serverconn.SendListVTXOsByScriptsRequest)
+	require.True(
+		m.t, ok,
+		"last message is not SendListVTXOsByScriptsRequest",
+	)
+
+	return req
+}
+
 // localOnlyOutboxHandler handles only local outbox events (signing,
 // persistence, timers). Transport events should be routed through serverconn
 // and never reach this handler.
@@ -838,6 +896,7 @@ func TestIsTransportEventClassification(t *testing.T) {
 		&SendSubmitPackageRequest{},
 		&SendFinalizePackageRequest{},
 		&SendIncomingAckRequest{},
+		&QueryIncomingTransferRequest{},
 		&QueryIncomingMetadataRequest{},
 	}
 	for _, evt := range transportEvents {

--- a/oor/actor_test.go
+++ b/oor/actor_test.go
@@ -838,6 +838,7 @@ func TestIsTransportEventClassification(t *testing.T) {
 		&SendSubmitPackageRequest{},
 		&SendFinalizePackageRequest{},
 		&SendIncomingAckRequest{},
+		&QueryIncomingMetadataRequest{},
 	}
 	for _, evt := range transportEvents {
 		require.True(

--- a/oor/actor_test.go
+++ b/oor/actor_test.go
@@ -518,28 +518,6 @@ func (m *mockServerConnRef) lastRecipientQuery() *serverconn.
 	return req
 }
 
-// lastVTXOQuery returns the most recent durable ListVTXOsByScripts query
-// captured by the mock. It fails the test if no messages have been captured.
-func (m *mockServerConnRef) lastVTXOQuery() *serverconn.
-	SendListVTXOsByScriptsRequest {
-
-	m.t.Helper()
-
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	require.NotEmpty(m.t, m.messages, "no messages captured")
-
-	last := m.messages[len(m.messages)-1]
-	req, ok := last.(*serverconn.SendListVTXOsByScriptsRequest)
-	require.True(
-		m.t, ok,
-		"last message is not SendListVTXOsByScriptsRequest",
-	)
-
-	return req
-}
-
 // localOnlyOutboxHandler handles only local outbox events (signing,
 // persistence, timers). Transport events should be routed through serverconn
 // and never reach this handler.

--- a/oor/checkpoint_sign.go
+++ b/oor/checkpoint_sign.go
@@ -392,8 +392,29 @@ func signCheckpointPSBT(signer input.Signer, in *TransferInput,
 		return err
 	}
 
-	return psbtutil.AddTaprootScriptSpendSig(
+	err = psbtutil.AddTaprootScriptSpendSig(
 		&checkpoint.Inputs[0], in.VTXO.ClientKey.PubKey,
 		spendInfo.WitnessScript, sigBytes, signDesc.HashType,
 	)
+	if err != nil {
+		return err
+	}
+
+	sigRec, err := findTaprootScriptSpendSig(
+		&checkpoint.Inputs[0], in.VTXO.ClientKey.PubKey,
+		spendInfo.WitnessScript,
+	)
+	if err != nil {
+		return err
+	}
+
+	err = verifyTaprootScriptSpendSig(
+		checkpoint.UnsignedTx, signDesc.InputIndex, prevFetcher,
+		spendInfo.WitnessScript, sigRec,
+	)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/oor/events.go
+++ b/oor/events.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/lib/scripts"
 	oortx "github.com/lightninglabs/darepo-client/lib/tx/oor"
 	"github.com/lightninglabs/darepo-client/vtxo"
@@ -172,6 +173,11 @@ type IncomingHandledEvent struct {
 	// persisted during materialization. The OOR actor forwards these
 	// to the VTXO manager so it can spawn monitoring actors.
 	MaterializedVTXOs []*vtxo.Descriptor
+
+	// MaterializedOutpoints identifies the persisted VTXOs by outpoint so
+	// durable callback delivery can round-trip the event without embedding
+	// the full descriptor payload in the mailbox record.
+	MaterializedOutpoints []wire.OutPoint
 }
 
 // eventSealed marks this as implementing the sealed Event interface.

--- a/oor/incoming_adapter.go
+++ b/oor/incoming_adapter.go
@@ -29,9 +29,11 @@ func NewResolveIncomingTransferRequest(evt *arkrpc.IncomingOOREvent) (
 	}
 
 	return &ResolveIncomingTransferRequest{
-		SessionID:         SessionID(*sessionID),
-		RecipientPkScript: append([]byte(nil), evt.GetRecipientPkScript()...),
-		RecipientEventID:  evt.GetRecipientEventId(),
+		SessionID: SessionID(*sessionID),
+		RecipientPkScript: append(
+			[]byte(nil), evt.GetRecipientPkScript()...,
+		),
+		RecipientEventID: evt.GetRecipientEventId(),
 	}, nil
 }
 
@@ -56,15 +58,19 @@ func ParseIncomingResolveCorrelationID(correlationID string) (
 		correlationID[:len(incomingResolveCorrelationPrefix)] !=
 			incomingResolveCorrelationPrefix {
 
-		return SessionID{}, 0, fmt.Errorf("unexpected incoming resolve "+
-			"correlation id: %q", correlationID)
+		return SessionID{}, 0, fmt.Errorf(
+			"unexpected incoming resolve "+
+				"correlation id: %q", correlationID,
+		)
 	}
 
 	suffix := correlationID[len(incomingResolveCorrelationPrefix):]
 	parts := strings.SplitN(suffix, ":", 2)
 	if len(parts) != 2 {
-		return SessionID{}, 0, fmt.Errorf("unexpected incoming resolve "+
-			"correlation id payload: %q", suffix)
+		return SessionID{}, 0, fmt.Errorf(
+			"unexpected incoming resolve "+
+				"correlation id payload: %q", suffix,
+		)
 	}
 
 	hash, err := chainhash.NewHashFromStr(parts[0])
@@ -96,18 +102,23 @@ func IncomingTransferEventFromResponse(sessionID SessionID,
 	}
 
 	if len(resp.GetEvents()) == 0 {
-		return nil, fmt.Errorf("no events found for session %x",
+		return nil, fmt.Errorf("no events found for session %x", //nolint:ll
 			sessionID[:])
 	}
 
 	recipientEvt := resp.Events[0]
 	if recipientEvt == nil {
-		return nil, fmt.Errorf("incoming transfer event must be provided")
+		return nil, fmt.Errorf(
+			"incoming transfer event must be provided",
+		)
 	}
 
 	if recipientEvt.GetEventId() != recipientEventID {
-		return nil, fmt.Errorf("unexpected recipient event id: got %d, "+
-			"want %d", recipientEvt.GetEventId(), recipientEventID)
+		return nil, fmt.Errorf(
+			"unexpected recipient event id: "+
+				"got %d, want %d",
+			recipientEvt.GetEventId(), recipientEventID,
+		)
 	}
 
 	eventSessionID, err := chainhash.NewHash(recipientEvt.GetSessionId())

--- a/oor/incoming_adapter.go
+++ b/oor/incoming_adapter.go
@@ -16,21 +16,11 @@ type IncomingOORFetcher func(ctx context.Context,
 	pkScript []byte, afterEventID uint64,
 	limit uint32) (*arkrpc.ListOORRecipientEventsByScriptResponse, error)
 
-// AdaptIncomingOOREvent converts a lightweight IncomingOOREvent
-// notification into a DriveEventRequest by querying the indexer for
-// the full Ark PSBT and checkpoint data.
-//
-// This function implements the notification→query pattern:
-//  1. Parse session ID from the notification
-//  2. Query indexer for the OOR recipient event with Ark PSBT
-//  3. Parse Ark PSBT and checkpoint PSBTs from the response
-//  4. Construct IncomingTransferEvent with full data
-//
-// It is used by both the production darepod route handler and the
-// systest route handler to ensure identical behavior.
-func AdaptIncomingOOREvent(ctx context.Context,
-	evt *arkrpc.IncomingOOREvent,
-	fetcher IncomingOORFetcher) (*DriveEventRequest, error) {
+// NewResolveIncomingTransferRequest converts a lightweight IncomingOOREvent
+// notification into a durable actor request that can be persisted without
+// blocking mailbox ingress on a follow-up indexer query.
+func NewResolveIncomingTransferRequest(evt *arkrpc.IncomingOOREvent) (
+	*ResolveIncomingTransferRequest, error) {
 
 	if evt == nil {
 		return nil, fmt.Errorf("nil IncomingOOREvent")
@@ -41,14 +31,26 @@ func AdaptIncomingOOREvent(ctx context.Context,
 		return nil, fmt.Errorf("parse session id: %w", err)
 	}
 
-	// Query the indexer for the full package data. The
-	// notification is just a hint — the query returns the Ark
-	// PSBT and checkpoint PSBTs.
+	return &ResolveIncomingTransferRequest{
+		SessionID:         SessionID(*sessionID),
+		RecipientPkScript: append([]byte(nil), evt.GetRecipientPkScript()...),
+		RecipientEventID:  evt.GetRecipientEventId(),
+	}, nil
+}
+
+// ResolveIncomingTransferEvent queries the indexer for full OOR package data
+// given a durable incoming-transfer hint and returns the complete incoming
+// transfer event for the receive FSM.
+func ResolveIncomingTransferEvent(ctx context.Context, sessionID SessionID,
+	recipientPkScript []byte, recipientEventID uint64,
+	fetcher IncomingOORFetcher) (*IncomingTransferEvent, error) {
+
+	if fetcher == nil {
+		return nil, fmt.Errorf("incoming OOR fetcher not configured")
+	}
+
 	resp, err := fetcher(
-		ctx,
-		evt.GetRecipientPkScript(),
-		evt.GetRecipientEventId()-1,
-		1,
+		ctx, recipientPkScript, recipientEventID-1, 1,
 	)
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -85,12 +87,44 @@ func AdaptIncomingOOREvent(ctx context.Context,
 		checkpoints = append(checkpoints, cp)
 	}
 
+	return &IncomingTransferEvent{
+		SessionID:            sessionID,
+		ArkPSBT:              arkPSBT,
+		FinalCheckpointPSBTs: checkpoints,
+	}, nil
+}
+
+// AdaptIncomingOOREvent converts a lightweight IncomingOOREvent
+// notification into a DriveEventRequest by querying the indexer for
+// the full Ark PSBT and checkpoint data.
+//
+// This function implements the notification→query pattern:
+//  1. Parse session ID from the notification
+//  2. Query indexer for the OOR recipient event with Ark PSBT
+//  3. Parse Ark PSBT and checkpoint PSBTs from the response
+//  4. Construct IncomingTransferEvent with full data
+//
+// It is used by both the production darepod route handler and the
+// systest route handler to ensure identical behavior.
+func AdaptIncomingOOREvent(ctx context.Context,
+	evt *arkrpc.IncomingOOREvent,
+	fetcher IncomingOORFetcher) (*DriveEventRequest, error) {
+
+	req, err := NewResolveIncomingTransferRequest(evt)
+	if err != nil {
+		return nil, err
+	}
+
+	incomingEvent, err := ResolveIncomingTransferEvent(
+		ctx, req.SessionID, req.RecipientPkScript,
+		req.RecipientEventID, fetcher,
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	return &DriveEventRequest{
-		SessionID: SessionID(*sessionID),
-		Event: &IncomingTransferEvent{
-			SessionID:            SessionID(*sessionID),
-			ArkPSBT:              arkPSBT,
-			FinalCheckpointPSBTs: checkpoints,
-		},
+		SessionID: req.SessionID,
+		Event:     incomingEvent,
 	}, nil
 }

--- a/oor/incoming_adapter.go
+++ b/oor/incoming_adapter.go
@@ -134,6 +134,19 @@ func IncomingTransferEventFromResponse(sessionID SessionID,
 		return nil, fmt.Errorf("parse ark psbt: %w", err)
 	}
 
+	// TODO(oor-receive): The maxCheckpointPSBTs limit is a pragmatic
+	// upper bound for the OOR checkpoint chain depth. If the protocol
+	// ever allows deeper chains this constant should be raised via a
+	// tracked issue rather than silently increasing memory exposure.
+	const maxCheckpointPSBTs = 64
+	if len(recipientEvt.GetCheckpointPsbts()) > maxCheckpointPSBTs { //nolint:ll
+		return nil, fmt.Errorf(
+			"checkpoint count %d exceeds limit %d",
+			len(recipientEvt.GetCheckpointPsbts()),
+			maxCheckpointPSBTs,
+		)
+	}
+
 	checkpoints := make([]*psbt.Packet, 0,
 		len(recipientEvt.GetCheckpointPsbts()))
 	for _, cpRaw := range recipientEvt.GetCheckpointPsbts() {

--- a/oor/incoming_adapter.go
+++ b/oor/incoming_adapter.go
@@ -1,8 +1,9 @@
 package oor
 
 import (
-	"context"
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -10,11 +11,7 @@ import (
 	"github.com/lightninglabs/darepo-client/lib/tx/psbtutil"
 )
 
-// IncomingOORFetcher queries the indexer for full OOR package data
-// given a lightweight notification hint.
-type IncomingOORFetcher func(ctx context.Context,
-	pkScript []byte, afterEventID uint64,
-	limit uint32) (*arkrpc.ListOORRecipientEventsByScriptResponse, error)
+const incomingResolveCorrelationPrefix = "oor-incoming-resolve:"
 
 // NewResolveIncomingTransferRequest converts a lightweight IncomingOOREvent
 // notification into a durable actor request that can be persisted without
@@ -38,50 +35,100 @@ func NewResolveIncomingTransferRequest(evt *arkrpc.IncomingOOREvent) (
 	}, nil
 }
 
-// ResolveIncomingTransferEvent queries the indexer for full OOR package data
-// given a durable incoming-transfer hint and returns the complete incoming
-// transfer event for the receive FSM.
-func ResolveIncomingTransferEvent(ctx context.Context, sessionID SessionID,
-	recipientPkScript []byte, recipientEventID uint64,
-	fetcher IncomingOORFetcher) (*IncomingTransferEvent, error) {
+// IncomingResolveCorrelationID returns the stable unary correlation ID used
+// for durable incoming-transfer resolution queries for the given session and
+// recipient event.
+func IncomingResolveCorrelationID(sessionID SessionID,
+	recipientEventID uint64) string {
 
-	if fetcher == nil {
-		return nil, fmt.Errorf("incoming OOR fetcher not configured")
+	return incomingResolveCorrelationPrefix +
+		chainhash.Hash(sessionID).String() + ":" +
+		strconv.FormatUint(recipientEventID, 10)
+}
+
+// ParseIncomingResolveCorrelationID decodes a durable incoming-transfer
+// resolution query correlation ID back into the OOR session ID and recipient
+// event ID.
+func ParseIncomingResolveCorrelationID(correlationID string) (
+	SessionID, uint64, error) {
+
+	if len(correlationID) <= len(incomingResolveCorrelationPrefix) ||
+		correlationID[:len(incomingResolveCorrelationPrefix)] !=
+			incomingResolveCorrelationPrefix {
+
+		return SessionID{}, 0, fmt.Errorf("unexpected incoming resolve "+
+			"correlation id: %q", correlationID)
 	}
 
-	resp, err := fetcher(
-		ctx, recipientPkScript, recipientEventID-1, 1,
-	)
+	suffix := correlationID[len(incomingResolveCorrelationPrefix):]
+	parts := strings.SplitN(suffix, ":", 2)
+	if len(parts) != 2 {
+		return SessionID{}, 0, fmt.Errorf("unexpected incoming resolve "+
+			"correlation id payload: %q", suffix)
+	}
+
+	hash, err := chainhash.NewHashFromStr(parts[0])
 	if err != nil {
-		return nil, fmt.Errorf(
-			"fetch OOR package for session %x: %w",
-			sessionID[:], err,
-		)
+		return SessionID{}, 0, fmt.Errorf("parse incoming resolve "+
+			"session id: %w", err)
+	}
+
+	recipientEventID, err := strconv.ParseUint(parts[1], 10, 64)
+	if err != nil {
+		return SessionID{}, 0, fmt.Errorf("parse incoming resolve "+
+			"event id: %w", err)
+	}
+
+	return SessionID(*hash), recipientEventID, nil
+}
+
+// IncomingTransferEventFromResponse validates and converts one
+// ListOORRecipientEventsByScriptResponse payload into the complete incoming
+// transfer event expected by the receive FSM.
+func IncomingTransferEventFromResponse(sessionID SessionID,
+	recipientEventID uint64,
+	resp *arkrpc.ListOORRecipientEventsByScriptResponse) (
+	*IncomingTransferEvent, error) {
+
+	if resp == nil {
+		return nil, fmt.Errorf("incoming transfer response must be " +
+			"provided")
 	}
 
 	if len(resp.GetEvents()) == 0 {
-		return nil, fmt.Errorf(
-			"no events found for session %x",
-			sessionID[:],
-		)
+		return nil, fmt.Errorf("no events found for session %x",
+			sessionID[:])
 	}
 
 	recipientEvt := resp.Events[0]
+	if recipientEvt == nil {
+		return nil, fmt.Errorf("incoming transfer event must be provided")
+	}
 
-	// Parse the Ark PSBT from the query response.
+	if recipientEvt.GetEventId() != recipientEventID {
+		return nil, fmt.Errorf("unexpected recipient event id: got %d, "+
+			"want %d", recipientEvt.GetEventId(), recipientEventID)
+	}
+
+	eventSessionID, err := chainhash.NewHash(recipientEvt.GetSessionId())
+	if err != nil {
+		return nil, fmt.Errorf("parse event session id: %w", err)
+	}
+	if SessionID(*eventSessionID) != sessionID {
+		return nil, fmt.Errorf("incoming transfer session mismatch")
+	}
+
 	arkPSBT, err := psbtutil.Parse(recipientEvt.GetArkPsbt())
 	if err != nil {
 		return nil, fmt.Errorf("parse ark psbt: %w", err)
 	}
 
-	// Parse checkpoint PSBTs.
-	var checkpoints []*psbt.Packet
+	checkpoints := make([]*psbt.Packet, 0,
+		len(recipientEvt.GetCheckpointPsbts()))
 	for _, cpRaw := range recipientEvt.GetCheckpointPsbts() {
 		cp, cpErr := psbtutil.Parse(cpRaw)
 		if cpErr != nil {
-			return nil, fmt.Errorf(
-				"parse checkpoint: %w", cpErr,
-			)
+			return nil, fmt.Errorf("parse checkpoint: %w", cpErr)
 		}
 
 		checkpoints = append(checkpoints, cp)
@@ -91,40 +138,5 @@ func ResolveIncomingTransferEvent(ctx context.Context, sessionID SessionID,
 		SessionID:            sessionID,
 		ArkPSBT:              arkPSBT,
 		FinalCheckpointPSBTs: checkpoints,
-	}, nil
-}
-
-// AdaptIncomingOOREvent converts a lightweight IncomingOOREvent
-// notification into a DriveEventRequest by querying the indexer for
-// the full Ark PSBT and checkpoint data.
-//
-// This function implements the notification→query pattern:
-//  1. Parse session ID from the notification
-//  2. Query indexer for the OOR recipient event with Ark PSBT
-//  3. Parse Ark PSBT and checkpoint PSBTs from the response
-//  4. Construct IncomingTransferEvent with full data
-//
-// It is used by both the production darepod route handler and the
-// systest route handler to ensure identical behavior.
-func AdaptIncomingOOREvent(ctx context.Context,
-	evt *arkrpc.IncomingOOREvent,
-	fetcher IncomingOORFetcher) (*DriveEventRequest, error) {
-
-	req, err := NewResolveIncomingTransferRequest(evt)
-	if err != nil {
-		return nil, err
-	}
-
-	incomingEvent, err := ResolveIncomingTransferEvent(
-		ctx, req.SessionID, req.RecipientPkScript,
-		req.RecipientEventID, fetcher,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	return &DriveEventRequest{
-		SessionID: req.SessionID,
-		Event:     incomingEvent,
 	}, nil
 }

--- a/oor/incoming_adapter.go
+++ b/oor/incoming_adapter.go
@@ -1,0 +1,96 @@
+package oor
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightninglabs/darepo-client/arkrpc"
+	"github.com/lightninglabs/darepo-client/lib/tx/psbtutil"
+)
+
+// IncomingOORFetcher queries the indexer for full OOR package data
+// given a lightweight notification hint.
+type IncomingOORFetcher func(ctx context.Context,
+	pkScript []byte, afterEventID uint64,
+	limit uint32) (*arkrpc.ListOORRecipientEventsByScriptResponse, error)
+
+// AdaptIncomingOOREvent converts a lightweight IncomingOOREvent
+// notification into a DriveEventRequest by querying the indexer for
+// the full Ark PSBT and checkpoint data.
+//
+// This function implements the notification→query pattern:
+//  1. Parse session ID from the notification
+//  2. Query indexer for the OOR recipient event with Ark PSBT
+//  3. Parse Ark PSBT and checkpoint PSBTs from the response
+//  4. Construct IncomingTransferEvent with full data
+//
+// It is used by both the production darepod route handler and the
+// systest route handler to ensure identical behavior.
+func AdaptIncomingOOREvent(ctx context.Context,
+	evt *arkrpc.IncomingOOREvent,
+	fetcher IncomingOORFetcher) (*DriveEventRequest, error) {
+
+	if evt == nil {
+		return nil, fmt.Errorf("nil IncomingOOREvent")
+	}
+
+	sessionID, err := chainhash.NewHash(evt.GetSessionId())
+	if err != nil {
+		return nil, fmt.Errorf("parse session id: %w", err)
+	}
+
+	// Query the indexer for the full package data. The
+	// notification is just a hint — the query returns the Ark
+	// PSBT and checkpoint PSBTs.
+	resp, err := fetcher(
+		ctx,
+		evt.GetRecipientPkScript(),
+		evt.GetRecipientEventId()-1,
+		1,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"fetch OOR package for session %x: %w",
+			sessionID[:], err,
+		)
+	}
+
+	if len(resp.GetEvents()) == 0 {
+		return nil, fmt.Errorf(
+			"no events found for session %x",
+			sessionID[:],
+		)
+	}
+
+	recipientEvt := resp.Events[0]
+
+	// Parse the Ark PSBT from the query response.
+	arkPSBT, err := psbtutil.Parse(recipientEvt.GetArkPsbt())
+	if err != nil {
+		return nil, fmt.Errorf("parse ark psbt: %w", err)
+	}
+
+	// Parse checkpoint PSBTs.
+	var checkpoints []*psbt.Packet
+	for _, cpRaw := range recipientEvt.GetCheckpointPsbts() {
+		cp, cpErr := psbtutil.Parse(cpRaw)
+		if cpErr != nil {
+			return nil, fmt.Errorf(
+				"parse checkpoint: %w", cpErr,
+			)
+		}
+
+		checkpoints = append(checkpoints, cp)
+	}
+
+	return &DriveEventRequest{
+		SessionID: SessionID(*sessionID),
+		Event: &IncomingTransferEvent{
+			SessionID:            SessionID(*sessionID),
+			ArkPSBT:              arkPSBT,
+			FinalCheckpointPSBTs: checkpoints,
+		},
+	}, nil
+}

--- a/oor/incoming_metadata_query.go
+++ b/oor/incoming_metadata_query.go
@@ -1,0 +1,150 @@
+package oor
+
+import (
+	"fmt"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightninglabs/darepo-client/arkrpc"
+)
+
+const incomingMetadataCorrelationPrefix = "oor-incoming-metadata:"
+
+// IncomingMetadataMatch carries authoritative metadata for one materialized
+// incoming Ark output.
+type IncomingMetadataMatch struct {
+	// OutputIndex identifies the Ark output this metadata belongs to.
+	OutputIndex uint32
+
+	// Metadata carries the authoritative lineage and expiry data.
+	Metadata IncomingVTXOMetadata
+}
+
+// IncomingMetadataResolvedEvent delivers the authoritative incoming metadata
+// query result back into the receive FSM.
+type IncomingMetadataResolvedEvent struct {
+	// Matches contains metadata keyed by Ark output index for the current
+	// incoming transfer session.
+	Matches []IncomingMetadataMatch
+}
+
+// eventSealed marks this as implementing the sealed Event interface.
+func (e *IncomingMetadataResolvedEvent) eventSealed() {}
+
+// IncomingMetadataCorrelationID returns the stable unary correlation ID used
+// for durable incoming metadata queries for the given session.
+func IncomingMetadataCorrelationID(sessionID SessionID) string {
+	return incomingMetadataCorrelationPrefix +
+		chainhash.Hash(sessionID).String()
+}
+
+// ParseIncomingMetadataCorrelationID decodes a durable incoming metadata query
+// correlation ID back into the OOR session ID.
+func ParseIncomingMetadataCorrelationID(correlationID string) (
+	SessionID, error) {
+
+	if len(correlationID) <= len(incomingMetadataCorrelationPrefix) ||
+		correlationID[:len(incomingMetadataCorrelationPrefix)] !=
+			incomingMetadataCorrelationPrefix {
+
+		return SessionID{}, fmt.Errorf("unexpected incoming metadata "+
+			"correlation id: %q", correlationID)
+	}
+
+	hash, err := chainhash.NewHashFromStr(
+		correlationID[len(incomingMetadataCorrelationPrefix):],
+	)
+	if err != nil {
+		return SessionID{}, fmt.Errorf("parse incoming metadata "+
+			"session id: %w", err)
+	}
+
+	return SessionID(*hash), nil
+}
+
+// IncomingMetadataMatchesFromResponse filters an indexer
+// ListVTXOsByScriptsResponse down to the entries created by the given Ark
+// session and converts them into the local incoming metadata shape.
+func IncomingMetadataMatchesFromResponse(sessionID SessionID,
+	resp *arkrpc.ListVTXOsByScriptsResponse) ([]IncomingMetadataMatch, error) {
+
+	if resp == nil {
+		return nil, fmt.Errorf("incoming metadata response must be provided")
+	}
+
+	matches := make([]IncomingMetadataMatch, 0, len(resp.GetVtxos()))
+	for _, candidate := range resp.GetVtxos() {
+		if candidate == nil {
+			continue
+		}
+
+		outpoint := candidate.GetOutpoint()
+		if outpoint == nil {
+			return nil, fmt.Errorf("indexer vtxo missing outpoint")
+		}
+
+		if !matchesIncomingVTXO(sessionID, outpoint.GetTxid()) {
+			continue
+		}
+
+		metadata, err := incomingMetadataFromRPC(candidate)
+		if err != nil {
+			return nil, err
+		}
+
+		matches = append(matches, IncomingMetadataMatch{
+			OutputIndex: outpoint.GetVout(),
+			Metadata:    metadata,
+		})
+	}
+
+	return matches, nil
+}
+
+// matchesIncomingVTXO reports whether the candidate txid belongs to the
+// current Ark session.
+func matchesIncomingVTXO(sessionID SessionID, txid []byte) bool {
+	return len(txid) == chainhash.HashSize &&
+		string(txid) == string(sessionID[:])
+}
+
+// incomingMetadataFromRPC maps the authoritative indexer VTXO view into the
+// metadata shape required by the incoming OOR materialization path.
+func incomingMetadataFromRPC(candidate *arkrpc.VTXO) (
+	IncomingVTXOMetadata, error) {
+
+	if candidate == nil {
+		return IncomingVTXOMetadata{}, fmt.Errorf("indexer vtxo " +
+			"must be provided")
+	}
+
+	if candidate.GetRoundId() == "" {
+		return IncomingVTXOMetadata{}, fmt.Errorf("indexer vtxo " +
+			"missing round id")
+	}
+
+	if len(candidate.GetCommitmentTxid()) != chainhash.HashSize {
+		return IncomingVTXOMetadata{}, fmt.Errorf("indexer vtxo " +
+			"missing commitment txid")
+	}
+
+	treePath, err := arkrpc.TreePathToTree(
+		candidate.GetTreePath(),
+	)
+	if err != nil {
+		return IncomingVTXOMetadata{}, fmt.Errorf("convert "+
+			"tree path: %w", err)
+	}
+
+	var commitmentTxID chainhash.Hash
+	copy(commitmentTxID[:], candidate.GetCommitmentTxid())
+
+	return IncomingVTXOMetadata{
+		RoundID:        candidate.GetRoundId(),
+		CommitmentTxID: commitmentTxID,
+		BatchExpiry:    candidate.GetBatchExpiryHeight(),
+		TreeDepth:      int(candidate.GetTreeDepth()),
+		ChainDepth:     int(candidate.GetChainDepth()),
+		CreatedHeight:  candidate.GetCreatedHeight(),
+		TreePath:       treePath,
+	}, nil
+}

--- a/oor/incoming_metadata_query.go
+++ b/oor/incoming_metadata_query.go
@@ -1,6 +1,7 @@
 package oor
 
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -75,6 +76,12 @@ func IncomingMetadataMatchesFromResponse(
 		)
 	}
 
+	// TODO(oor-receive): The maxIncomingMetadataMatches limit guards
+	// against unbounded allocations from a malicious or misconfigured
+	// indexer response. Raise this constant via a tracked issue if the
+	// protocol ever allows more outputs per incoming transfer.
+	const maxIncomingMetadataMatches = 128
+
 	matches := make([]IncomingMetadataMatch, 0, len(resp.GetVtxos()))
 	for _, candidate := range resp.GetVtxos() {
 		if candidate == nil {
@@ -99,6 +106,14 @@ func IncomingMetadataMatchesFromResponse(
 			OutputIndex: outpoint.GetVout(),
 			Metadata:    metadata,
 		})
+
+		if len(matches) > maxIncomingMetadataMatches {
+			return nil, fmt.Errorf(
+				"incoming metadata match count "+
+					"exceeds limit %d",
+				maxIncomingMetadataMatches,
+			)
+		}
 	}
 
 	return matches, nil
@@ -107,8 +122,7 @@ func IncomingMetadataMatchesFromResponse(
 // matchesIncomingVTXO reports whether the candidate txid belongs to the
 // current Ark session.
 func matchesIncomingVTXO(sessionID SessionID, txid []byte) bool {
-	return len(txid) == chainhash.HashSize &&
-		string(txid) == string(sessionID[:])
+	return bytes.Equal(txid, sessionID[:])
 }
 
 // incomingMetadataFromRPC maps the authoritative indexer VTXO view into the

--- a/oor/incoming_metadata_query.go
+++ b/oor/incoming_metadata_query.go
@@ -64,11 +64,15 @@ func ParseIncomingMetadataCorrelationID(correlationID string) (
 // IncomingMetadataMatchesFromResponse filters an indexer
 // ListVTXOsByScriptsResponse down to the entries created by the given Ark
 // session and converts them into the local incoming metadata shape.
-func IncomingMetadataMatchesFromResponse(sessionID SessionID,
-	resp *arkrpc.ListVTXOsByScriptsResponse) ([]IncomingMetadataMatch, error) {
+func IncomingMetadataMatchesFromResponse(
+	sessionID SessionID,
+	resp *arkrpc.ListVTXOsByScriptsResponse,
+) ([]IncomingMetadataMatch, error) {
 
 	if resp == nil {
-		return nil, fmt.Errorf("incoming metadata response must be provided")
+		return nil, fmt.Errorf(
+			"incoming metadata response must be provided",
+		)
 	}
 
 	matches := make([]IncomingMetadataMatch, 0, len(resp.GetVtxos()))

--- a/oor/interfaces.go
+++ b/oor/interfaces.go
@@ -18,6 +18,10 @@ type StateTransition = protofsm.StateTransition[
 // when state transitions emit new events or outbox messages.
 type EmittedEvent = protofsm.EmittedEvent[Event, OutboxEvent]
 
+// SessionState is the common protofsm state interface implemented by both the
+// outgoing and incoming OOR session state machines.
+type SessionState = protofsm.State[Event, OutboxEvent, *Environment]
+
 // StateMachine is a type alias for the OOR client transfer FSM.
 type StateMachine = protofsm.StateMachine[
 	Event, OutboxEvent, *Environment,

--- a/oor/local_persistence_handler.go
+++ b/oor/local_persistence_handler.go
@@ -379,6 +379,12 @@ func (h *LocalPersistenceOutboxHandler) materializeIncoming(
 			slog.Int("tree_depth", metadata.TreeDepth),
 			slog.Int("chain_depth", metadata.ChainDepth))
 
+		// TODO(oor-receive): Use per-round operator key from
+		// indexer metadata instead of the startup-cached
+		// OperatorKey. If the operator rotates keys, VTXOs
+		// materialized with the stale key will have an incorrect
+		// collab tapscript leaf, locking funds until the
+		// unilateral exit delay expires.
 		desc, err := BuildIncomingVTXODescriptor(msg.ArkPSBT,
 			IncomingVTXOConfig{
 				OutputIndex: recipient.OutputIndex,

--- a/oor/local_persistence_handler.go
+++ b/oor/local_persistence_handler.go
@@ -234,7 +234,6 @@ func (h *LocalPersistenceOutboxHandler) validateMaterializeIncoming(
 	}
 
 	if h.NotifyIncomingVTXOs == nil && !hasActorDBTx(ctx) {
-
 		return fmt.Errorf(
 			"incoming VTXO notifier must be provided",
 		)
@@ -255,7 +254,9 @@ func (h *LocalPersistenceOutboxHandler) handleQueryIncomingMetadata(
 	msg *QueryIncomingMetadataRequest) ([]Event, error) {
 
 	if msg == nil {
-		return nil, fmt.Errorf("incoming metadata query must be provided")
+		return nil, fmt.Errorf(
+			"incoming metadata query must be provided",
+		)
 	}
 
 	if h.ResolveIncomingClientKey == nil {
@@ -440,8 +441,9 @@ func (h *LocalPersistenceOutboxHandler) materializeIncoming(
 		slog.Int("owned_recipients", ownedRecipients),
 		slog.Int("materialized_vtxos", len(materializedVTXOs)))
 
-	// When the durable actor will receive an IncomingHandledEvent follow-up,
-	// defer notification to that actor path so the manager only sees the
+	// When the durable actor will receive an
+	// IncomingHandledEvent follow-up, defer notification to
+	// that actor path so the manager only sees the
 	// materialization once.
 	if notifyIncoming {
 		// Notify the VTXO manager so newly received OOR VTXOs are

--- a/oor/local_persistence_handler.go
+++ b/oor/local_persistence_handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/baselib/actor"
 	"github.com/lightninglabs/darepo-client/vtxo"
 	"github.com/lightningnetwork/lnd/keychain"
 )
@@ -44,10 +45,10 @@ type IncomingMetadataResolver func(ctx context.Context, sessionID SessionID,
 	recipient ArkRecipientOutput, ark *psbt.Packet,
 	finalCheckpoints []*psbt.Packet) (IncomingVTXOMetadata, error)
 
-// SpendCompleter finalizes an OOR spend by routing the completion through the
-// VTXO manager so each VTXO actor transitions to SpentState via its own FSM.
-// This replaces the previous direct-store-write pattern and ensures the VTXO
-// actor remains the single source of truth for availability state.
+// SpendCompleter enqueues OOR spend completion through the VTXO manager so
+// each VTXO actor transitions to SpentState via its own FSM. Implementations
+// should avoid blocking on downstream DB writes because the OOR durable actor
+// may already be running inside a transaction.
 type SpendCompleter func(ctx context.Context,
 	outpoints []wire.OutPoint) error
 
@@ -96,13 +97,14 @@ type LocalPersistenceOutboxHandler struct {
 
 	// NotifyIncomingVTXOs is invoked after incoming VTXOs are persisted.
 	// Production wiring should use this to notify the VTXO manager so newly
-	// received OOR VTXOs are actively monitored.
+	// received OOR VTXOs are actively monitored when the handler is used
+	// outside the OOR durable actor.
 	NotifyIncomingVTXOs IncomingVTXONotifier
 
-	// CompleteSpend routes OOR spend completion through the VTXO manager
-	// so each consumed VTXO transitions to SpentState via its own FSM.
-	// When nil, the handler falls back to direct store writes for
-	// backwards compatibility during migration.
+	// CompleteSpend enqueues OOR spend completion through the VTXO
+	// manager so each consumed VTXO transitions to SpentState via its
+	// own FSM. When nil, the handler falls back to direct store writes
+	// for backwards compatibility during migration.
 	CompleteSpend SpendCompleter
 }
 
@@ -123,6 +125,9 @@ func (h *LocalPersistenceOutboxHandler) Handle(ctx context.Context,
 	case *MarkInputsSpentRequest:
 		return h.handleMarkInputsSpent(ctx, msg)
 
+	case *QueryIncomingMetadataRequest:
+		return h.handleQueryIncomingMetadata(ctx, msg)
+
 	case *MaterializeIncomingVTXOsRequest:
 		return h.handleMaterializeIncoming(ctx, msg)
 
@@ -140,10 +145,10 @@ func (h *LocalPersistenceOutboxHandler) Handle(ctx context.Context,
 
 // handleMarkInputsSpent completes the OOR spend for consumed VTXO inputs.
 //
-// When CompleteSpend is configured, the handler routes completion through the
-// VTXO manager so each VTXO actor transitions to SpentState via its own FSM.
-// This ensures the VTXO actor remains the single source of truth for
-// availability state.
+// When CompleteSpend is configured, the handler enqueues completion through
+// the VTXO manager so each VTXO actor transitions to SpentState via its own
+// FSM. This keeps the VTXO actor as the source of truth for availability
+// state without blocking the OOR durable actor on nested write transactions.
 //
 // When CompleteSpend is nil, the handler falls back to direct store writes
 // for backwards compatibility during migration.
@@ -197,35 +202,110 @@ func (h *LocalPersistenceOutboxHandler) handleMaterializeIncoming(
 	ctx context.Context,
 	msg *MaterializeIncomingVTXOsRequest) ([]Event, error) {
 
+	err := h.validateMaterializeIncoming(ctx, msg)
+	if err != nil {
+		return nil, err
+	}
+
+	return h.materializeIncoming(ctx, msg, !hasActorDBTx(ctx))
+}
+
+// validateMaterializeIncoming verifies the dependencies needed to materialize
+// an incoming transfer.
+func (h *LocalPersistenceOutboxHandler) validateMaterializeIncoming(
+	ctx context.Context, msg *MaterializeIncomingVTXOsRequest) error {
+
+	if msg == nil {
+		return fmt.Errorf("materialize request must be provided")
+	}
+
 	if h.Store == nil {
-		return nil, fmt.Errorf("vtxo store must be provided")
+		return fmt.Errorf("vtxo store must be provided")
 	}
 
 	if h.OperatorKey == nil {
-		return nil, fmt.Errorf("operator key must be provided")
+		return fmt.Errorf("operator key must be provided")
 	}
 
 	if h.ResolveIncomingClientKey == nil {
-		return nil, fmt.Errorf(
+		return fmt.Errorf(
 			"incoming client key resolver must be provided",
 		)
 	}
 
-	if h.ResolveIncomingMetadata == nil {
-		return nil, fmt.Errorf(
-			"incoming metadata resolver must be provided",
-		)
-	}
+	if h.NotifyIncomingVTXOs == nil && !hasActorDBTx(ctx) {
 
-	if h.NotifyIncomingVTXOs == nil {
-		return nil, fmt.Errorf(
+		return fmt.Errorf(
 			"incoming VTXO notifier must be provided",
 		)
 	}
 
 	if len(msg.Recipients) == 0 {
-		return nil, fmt.Errorf("incoming recipients must be provided")
+		return fmt.Errorf("incoming recipients must be provided")
 	}
+
+	return nil
+}
+
+// handleQueryIncomingMetadata resolves authoritative metadata for owned
+// recipients when the OOR actor is running without the durable serverconn
+// request/response path.
+func (h *LocalPersistenceOutboxHandler) handleQueryIncomingMetadata(
+	ctx context.Context,
+	msg *QueryIncomingMetadataRequest) ([]Event, error) {
+
+	if msg == nil {
+		return nil, fmt.Errorf("incoming metadata query must be provided")
+	}
+
+	if h.ResolveIncomingClientKey == nil {
+		return nil, fmt.Errorf("incoming client key resolver must be " +
+			"provided")
+	}
+
+	if h.ResolveIncomingMetadata == nil {
+		return nil, fmt.Errorf("incoming metadata resolver must be " +
+			"provided")
+	}
+
+	matches := make([]IncomingMetadataMatch, 0, len(msg.Recipients))
+	for i := range msg.Recipients {
+		recipient := msg.Recipients[i]
+
+		_, err := h.ResolveIncomingClientKey(ctx, recipient)
+		if err != nil {
+			if IsIncomingRecipientNotOwned(err) {
+				continue
+			}
+
+			return nil, err
+		}
+
+		metadata, err := h.ResolveIncomingMetadata(
+			ctx, msg.SessionID, recipient, msg.ArkPSBT,
+			msg.FinalCheckpointPSBTs,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		matches = append(matches, IncomingMetadataMatch{
+			OutputIndex: recipient.OutputIndex,
+			Metadata:    metadata,
+		})
+	}
+
+	return []Event{&IncomingMetadataResolvedEvent{
+		Matches: matches,
+	}}, nil
+}
+
+// materializeIncoming persists recipient VTXOs for an incoming transfer and
+// optionally notifies the VTXO manager directly when the caller is not
+// resuming the durable actor with a follow-up event.
+func (h *LocalPersistenceOutboxHandler) materializeIncoming(
+	ctx context.Context, msg *MaterializeIncomingVTXOsRequest,
+	notifyIncoming bool) ([]Event, error) {
 
 	log.InfoS(ctx, "Materializing incoming VTXOs",
 		slog.String("session_id", msg.SessionID.String()),
@@ -233,7 +313,15 @@ func (h *LocalPersistenceOutboxHandler) handleMaterializeIncoming(
 
 	ownedRecipients := 0
 	materializedVTXOs := make([]*vtxo.Descriptor, 0, len(msg.Recipients))
+	materializedOutpoints := make([]wire.OutPoint, 0, len(msg.Recipients))
 	sessionIDHash := chainhash.Hash(msg.SessionID)
+	metadataByOutput := make(map[uint32]IncomingVTXOMetadata,
+		len(msg.MetadataMatches))
+
+	for i := range msg.MetadataMatches {
+		match := msg.MetadataMatches[i]
+		metadataByOutput[match.OutputIndex] = match.Metadata
+	}
 
 	if h.PackageStore != nil {
 		err := h.PackageStore.UpsertPackage(ctx,
@@ -247,7 +335,6 @@ func (h *LocalPersistenceOutboxHandler) handleMaterializeIncoming(
 
 	for i := range msg.Recipients {
 		recipient := msg.Recipients[i]
-
 		clientKey, err := h.ResolveIncomingClientKey(ctx, recipient)
 		if err != nil {
 			if IsIncomingRecipientNotOwned(err) {
@@ -259,13 +346,37 @@ func (h *LocalPersistenceOutboxHandler) handleMaterializeIncoming(
 
 		ownedRecipients++
 
-		metadata, err := h.ResolveIncomingMetadata(
-			ctx, msg.SessionID, recipient, msg.ArkPSBT,
-			msg.FinalCheckpointPSBTs,
-		)
-		if err != nil {
-			return nil, err
+		metadata, ok := metadataByOutput[recipient.OutputIndex]
+
+		// Legacy synchronous path for callers outside the durable
+		// actor transaction (e.g. systest, non-actor consumers).
+		// Production durable actors pre-resolve metadata via the
+		// async QueryIncomingMetadataRequest path, so this branch
+		// is never reached inside an actor DB tx.
+		if !ok && h.ResolveIncomingMetadata != nil &&
+			!hasActorDBTx(ctx) {
+
+			metadata, err = h.ResolveIncomingMetadata(
+				ctx, msg.SessionID, recipient, msg.ArkPSBT,
+				msg.FinalCheckpointPSBTs,
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			ok = true
 		}
+		if !ok {
+			return nil, fmt.Errorf("incoming metadata missing for "+
+				"wallet-owned output %d", recipient.OutputIndex)
+		}
+
+		log.DebugS(ctx, "Resolved incoming metadata",
+			slog.String("session_id", msg.SessionID.String()),
+			slog.Int("output_index", int(recipient.OutputIndex)),
+			slog.String("round_id", metadata.RoundID),
+			slog.Int("tree_depth", metadata.TreeDepth),
+			slog.Int("chain_depth", metadata.ChainDepth))
 
 		desc, err := BuildIncomingVTXODescriptor(msg.ArkPSBT,
 			IncomingVTXOConfig{
@@ -303,6 +414,9 @@ func (h *LocalPersistenceOutboxHandler) handleMaterializeIncoming(
 		}
 
 		materializedVTXOs = append(materializedVTXOs, desc)
+		materializedOutpoints = append(
+			materializedOutpoints, desc.Outpoint,
+		)
 
 		if h.PackageStore != nil {
 			err := h.PackageStore.UpsertBinding(
@@ -326,16 +440,32 @@ func (h *LocalPersistenceOutboxHandler) handleMaterializeIncoming(
 		slog.Int("owned_recipients", ownedRecipients),
 		slog.Int("materialized_vtxos", len(materializedVTXOs)))
 
-	// Notify the VTXO manager so newly received OOR VTXOs are
-	// actively monitored for expiry and spend.
-	err := h.NotifyIncomingVTXOs(ctx, materializedVTXOs)
-	if err != nil {
-		return nil, err
+	// When the durable actor will receive an IncomingHandledEvent follow-up,
+	// defer notification to that actor path so the manager only sees the
+	// materialization once.
+	if notifyIncoming {
+		// Notify the VTXO manager so newly received OOR VTXOs are
+		// actively monitored for expiry and spend.
+		err := h.NotifyIncomingVTXOs(
+			ctx, materializedVTXOs,
+		)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return []Event{&IncomingHandledEvent{
-		MaterializedVTXOs: materializedVTXOs,
+		MaterializedVTXOs:     materializedVTXOs,
+		MaterializedOutpoints: materializedOutpoints,
 	}}, nil
+}
+
+// hasActorDBTx reports whether the current context is already scoped to a
+// durable actor database transaction.
+func hasActorDBTx(ctx context.Context) bool {
+	_, ok := actor.TxFromContext(ctx)
+
+	return ok
 }
 
 // handleIncomingAck forwards the ack request to the transport boundary (if

--- a/oor/outbox_factory.go
+++ b/oor/outbox_factory.go
@@ -1,0 +1,81 @@
+package oor
+
+import (
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/lightninglabs/darepo-client/timeout"
+	"github.com/lightninglabs/darepo-client/vtxo"
+	"github.com/lightningnetwork/lnd/input"
+)
+
+// OutboxHandlerConfig contains the parameters for constructing the
+// standard OOR outbox handler chain:
+//
+//	LocalPersistenceOutboxHandler → SigningOutboxHandler
+//
+// This config is used by both the production darepod server and
+// the systest harness to ensure identical outbox handling.
+type OutboxHandlerConfig struct {
+	// Signer signs checkpoint and Ark PSBTs.
+	Signer input.Signer
+
+	// Store provides VTXO lifecycle persistence.
+	Store vtxo.VTXOStore
+
+	// PackageStore persists finalized OOR package artifacts.
+	PackageStore PackagePersistence
+
+	// OperatorKey is the operator's public key for checkpoint
+	// leaf construction.
+	OperatorKey *btcec.PublicKey
+
+	// ExitDelay is the VTXO exit CSV delay.
+	ExitDelay uint32
+
+	// TimeoutActor schedules retry timers. When nil, retry
+	// requests return RetryDueEvent immediately.
+	TimeoutActor *timeout.Actor
+
+	// NotifyIncomingVTXOs is called after incoming VTXOs are
+	// durably materialized.
+	NotifyIncomingVTXOs IncomingVTXONotifier
+
+	// CompleteSpend routes OOR spend completion through the
+	// VTXO manager.
+	CompleteSpend SpendCompleter
+
+	// ResolveIncomingClientKey resolves the wallet key for each
+	// incoming recipient output.
+	ResolveIncomingClientKey IncomingClientKeyResolver
+
+	// ResolveIncomingMetadata resolves lineage metadata for
+	// incoming VTXOs.
+	ResolveIncomingMetadata IncomingMetadataResolver
+}
+
+// NewOutboxHandler constructs the standard two-layer outbox handler
+// chain from the given configuration. The returned handler processes
+// all outbox events: signing, persistence, transport, and incoming
+// materialization.
+//
+// Both the production darepod and systest should call this function
+// to ensure identical outbox handling.
+func NewOutboxHandler(
+	cfg OutboxHandlerConfig) *LocalPersistenceOutboxHandler {
+
+	signingHandler := &SigningOutboxHandler{
+		Signer:       cfg.Signer,
+		TimeoutActor: cfg.TimeoutActor,
+	}
+
+	return &LocalPersistenceOutboxHandler{
+		Next:                    signingHandler,
+		Store:                   cfg.Store,
+		PackageStore:            cfg.PackageStore,
+		OperatorKey:             cfg.OperatorKey,
+		ExitDelay:               cfg.ExitDelay,
+		NotifyIncomingVTXOs:     cfg.NotifyIncomingVTXOs,
+		CompleteSpend:           cfg.CompleteSpend,
+		ResolveIncomingClientKey: cfg.ResolveIncomingClientKey,
+		ResolveIncomingMetadata: cfg.ResolveIncomingMetadata,
+	}
+}

--- a/oor/outbox_factory.go
+++ b/oor/outbox_factory.go
@@ -68,14 +68,14 @@ func NewOutboxHandler(
 	}
 
 	return &LocalPersistenceOutboxHandler{
-		Next:                    signingHandler,
-		Store:                   cfg.Store,
-		PackageStore:            cfg.PackageStore,
-		OperatorKey:             cfg.OperatorKey,
-		ExitDelay:               cfg.ExitDelay,
-		NotifyIncomingVTXOs:     cfg.NotifyIncomingVTXOs,
-		CompleteSpend:           cfg.CompleteSpend,
+		Next:                     signingHandler,
+		Store:                    cfg.Store,
+		PackageStore:             cfg.PackageStore,
+		OperatorKey:              cfg.OperatorKey,
+		ExitDelay:                cfg.ExitDelay,
+		NotifyIncomingVTXOs:      cfg.NotifyIncomingVTXOs,
+		CompleteSpend:            cfg.CompleteSpend,
 		ResolveIncomingClientKey: cfg.ResolveIncomingClientKey,
-		ResolveIncomingMetadata: cfg.ResolveIncomingMetadata,
+		ResolveIncomingMetadata:  cfg.ResolveIncomingMetadata,
 	}
 }

--- a/oor/outbox_messages.go
+++ b/oor/outbox_messages.go
@@ -344,8 +344,8 @@ type MaterializeIncomingVTXOsRequest struct {
 	// Recipients are the non-anchor recipient outputs in the Ark tx.
 	Recipients []ArkRecipientOutput
 
-	// MetadataMatches carries the authoritative lineage metadata resolved for
-	// the current Ark outputs.
+	// MetadataMatches carries the authoritative lineage
+	// metadata resolved for the current Ark outputs.
 	MetadataMatches []IncomingMetadataMatch
 }
 

--- a/oor/outbox_messages.go
+++ b/oor/outbox_messages.go
@@ -266,6 +266,32 @@ func (m *IncomingTransferNotification) outboxType() string {
 // outboxSealed marks this as implementing the sealed OutboxEvent interface.
 func (m *IncomingTransferNotification) outboxSealed() {}
 
+// QueryIncomingTransferRequest asks the transport layer to resolve a
+// lightweight incoming OOR hint into the full Ark/checkpoint package for this
+// session.
+type QueryIncomingTransferRequest struct {
+	actor.BaseMessage
+
+	// SessionID identifies the incoming transfer session.
+	SessionID SessionID
+
+	// RecipientPkScript identifies the locally controlled output that the
+	// server notified us about.
+	RecipientPkScript []byte
+
+	// RecipientEventID identifies the authoritative recipient event row to
+	// resolve from the indexer.
+	RecipientEventID uint64
+}
+
+// outboxType returns a stable identifier for this outbox message.
+func (m *QueryIncomingTransferRequest) outboxType() string {
+	return "QueryIncomingTransferRequest"
+}
+
+// outboxSealed marks this as implementing the sealed OutboxEvent interface.
+func (m *QueryIncomingTransferRequest) outboxSealed() {}
+
 // QueryIncomingMetadataRequest asks the transport layer to query the
 // authoritative indexer inventory for the incoming Ark outputs referenced by
 // this session.

--- a/oor/outbox_messages.go
+++ b/oor/outbox_messages.go
@@ -266,6 +266,34 @@ func (m *IncomingTransferNotification) outboxType() string {
 // outboxSealed marks this as implementing the sealed OutboxEvent interface.
 func (m *IncomingTransferNotification) outboxSealed() {}
 
+// QueryIncomingMetadataRequest asks the transport layer to query the
+// authoritative indexer inventory for the incoming Ark outputs referenced by
+// this session.
+type QueryIncomingMetadataRequest struct {
+	actor.BaseMessage
+
+	// SessionID identifies the incoming transfer session.
+	SessionID SessionID
+
+	// ArkPSBT is the canonical Ark tx PSBT.
+	ArkPSBT *psbt.Packet
+
+	// FinalCheckpointPSBTs are the finalized checkpoint packages associated
+	// with this Ark transfer.
+	FinalCheckpointPSBTs []*psbt.Packet
+
+	// Recipients are the non-anchor recipient outputs in the Ark tx.
+	Recipients []ArkRecipientOutput
+}
+
+// outboxType returns a stable identifier for this outbox message.
+func (m *QueryIncomingMetadataRequest) outboxType() string {
+	return "QueryIncomingMetadataRequest"
+}
+
+// outboxSealed marks this as implementing the sealed OutboxEvent interface.
+func (m *QueryIncomingMetadataRequest) outboxSealed() {}
+
 // MaterializeIncomingVTXOsRequest asks the wallet/state layer to materialize
 // the incoming transfer into local VTXO records.
 //
@@ -289,6 +317,10 @@ type MaterializeIncomingVTXOsRequest struct {
 
 	// Recipients are the non-anchor recipient outputs in the Ark tx.
 	Recipients []ArkRecipientOutput
+
+	// MetadataMatches carries the authoritative lineage metadata resolved for
+	// the current Ark outputs.
+	MetadataMatches []IncomingMetadataMatch
 }
 
 // outboxType returns a stable identifier for this outbox message.

--- a/oor/outgoing_snapshot.go
+++ b/oor/outgoing_snapshot.go
@@ -267,10 +267,12 @@ func NewSessionFromSnapshot(ctx context.Context,
 	env := &Environment{SessionID: snapshot.SessionID}
 
 	fsmCfg := StateMachineCfg{
-		Logger:        log.WithPrefix(snapshot.SessionID.LogPrefix()),
-		ErrorReporter: newContextErrorReporter(ctx, snapshot.SessionID.LogPrefix()),
-		InitialState:  state,
-		Env:           env,
+		Logger: log.WithPrefix(snapshot.SessionID.LogPrefix()),
+		ErrorReporter: newContextErrorReporter(
+			ctx, snapshot.SessionID.LogPrefix(),
+		),
+		InitialState: state,
+		Env:          env,
 	}
 
 	sm := protofsm.NewStateMachine(fsmCfg)

--- a/oor/outgoing_snapshot_codec.go
+++ b/oor/outgoing_snapshot_codec.go
@@ -11,8 +11,9 @@ import (
 )
 
 const (
-	checkpointVersionRecordType   tlv.Type = 1
-	checkpointSnapshotsRecordType tlv.Type = 3
+	checkpointVersionRecordType           tlv.Type = 1
+	checkpointSnapshotsRecordType         tlv.Type = 3
+	checkpointIncomingSnapshotsRecordType tlv.Type = 5
 )
 
 const (
@@ -28,20 +29,45 @@ const (
 	snapshotFailReasonRecordType      tlv.Type = 19
 )
 
-func encodeOutgoingSessionsCheckpoint(
-	checkpoint outgoingSessionsCheckpoint) ([]byte, error) {
+type sessionsCheckpoint struct {
+	Version           int
+	OutgoingSnapshots []*OutgoingSnapshot
+	IncomingSnapshots []*IncomingSnapshot
+}
 
-	snapshotBlobs := make([][]byte, 0, len(checkpoint.Snapshots))
-	for i := range checkpoint.Snapshots {
-		raw, err := encodeOutgoingSnapshot(checkpoint.Snapshots[i])
+func encodeSessionsCheckpoint(
+	checkpoint sessionsCheckpoint) ([]byte, error) {
+
+	outgoingBlobs := make([][]byte, 0, len(checkpoint.OutgoingSnapshots))
+	for i := range checkpoint.OutgoingSnapshots {
+		raw, err := encodeOutgoingSnapshot(
+			checkpoint.OutgoingSnapshots[i],
+		)
 		if err != nil {
 			return nil, err
 		}
 
-		snapshotBlobs = append(snapshotBlobs, raw)
+		outgoingBlobs = append(outgoingBlobs, raw)
 	}
 
-	snapshotsRaw, err := encodeLengthPrefixedBlobList(snapshotBlobs)
+	outgoingRaw, err := encodeLengthPrefixedBlobList(outgoingBlobs)
+	if err != nil {
+		return nil, err
+	}
+
+	incomingBlobs := make([][]byte, 0, len(checkpoint.IncomingSnapshots))
+	for i := range checkpoint.IncomingSnapshots {
+		raw, err := encodeIncomingSnapshot(
+			checkpoint.IncomingSnapshots[i],
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		incomingBlobs = append(incomingBlobs, raw)
+	}
+
+	incomingRaw, err := encodeLengthPrefixedBlobList(incomingBlobs)
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +76,10 @@ func encodeOutgoingSessionsCheckpoint(
 	records := []tlv.Record{
 		tlv.MakePrimitiveRecord(checkpointVersionRecordType, &version),
 		tlv.MakePrimitiveRecord(
-			checkpointSnapshotsRecordType, &snapshotsRaw,
+			checkpointSnapshotsRecordType, &outgoingRaw,
+		),
+		tlv.MakePrimitiveRecord(
+			checkpointIncomingSnapshotsRecordType, &incomingRaw,
 		),
 	}
 
@@ -67,54 +96,108 @@ func encodeOutgoingSessionsCheckpoint(
 	return buf.Bytes(), nil
 }
 
-func decodeOutgoingSessionsCheckpoint(
-	raw []byte) (outgoingSessionsCheckpoint, error) {
+func decodeSessionsCheckpoint(raw []byte) (sessionsCheckpoint, error) {
 
 	var (
-		version      uint64
-		snapshotsRaw []byte
+		version     uint64
+		outgoingRaw []byte
+		incomingRaw []byte
 	)
 
 	records := []tlv.Record{
 		tlv.MakePrimitiveRecord(checkpointVersionRecordType, &version),
 		tlv.MakePrimitiveRecord(
-			checkpointSnapshotsRecordType, &snapshotsRaw,
+			checkpointSnapshotsRecordType, &outgoingRaw,
+		),
+		tlv.MakePrimitiveRecord(
+			checkpointIncomingSnapshotsRecordType, &incomingRaw,
 		),
 	}
 
 	stream, err := tlv.NewStream(records...)
 	if err != nil {
-		return outgoingSessionsCheckpoint{}, err
+		return sessionsCheckpoint{}, err
 	}
 
 	reader := bytes.NewReader(raw)
 	if _, err := stream.DecodeWithParsedTypes(reader); err != nil {
-		return outgoingSessionsCheckpoint{}, err
+		return sessionsCheckpoint{}, err
 	}
 
-	snapshotBlobs, err := decodeLengthPrefixedBlobList(snapshotsRaw)
+	outgoingBlobs, err := decodeLengthPrefixedBlobList(outgoingRaw)
 	if err != nil {
-		return outgoingSessionsCheckpoint{}, err
+		return sessionsCheckpoint{}, err
 	}
 
-	snapshots := make([]*OutgoingSnapshot, 0, len(snapshotBlobs))
-	for i := range snapshotBlobs {
-		snapshot, err := decodeOutgoingSnapshot(snapshotBlobs[i])
+	outgoingSnapshots := make([]*OutgoingSnapshot, 0,
+		len(outgoingBlobs))
+	for i := range outgoingBlobs {
+		snapshot, err := decodeOutgoingSnapshot(outgoingBlobs[i])
 		if err != nil {
-			return outgoingSessionsCheckpoint{}, err
+			return sessionsCheckpoint{}, err
 		}
 
-		snapshots = append(snapshots, snapshot)
+		outgoingSnapshots = append(outgoingSnapshots, snapshot)
+	}
+
+	incomingSnapshots := make([]*IncomingSnapshot, 0,
+		0)
+	if len(incomingRaw) != 0 {
+		incomingBlobs, err := decodeLengthPrefixedBlobList(
+			incomingRaw,
+		)
+		if err != nil {
+			return sessionsCheckpoint{}, err
+		}
+
+		incomingSnapshots = make([]*IncomingSnapshot, 0,
+			len(incomingBlobs))
+		for i := range incomingBlobs {
+			snapshot, err := decodeIncomingSnapshot(
+				incomingBlobs[i],
+			)
+			if err != nil {
+				return sessionsCheckpoint{}, err
+			}
+
+			incomingSnapshots = append(
+				incomingSnapshots, snapshot,
+			)
+		}
 	}
 
 	decodedVersion, err := decodeUint64ToInt(version, "checkpoint version")
+	if err != nil {
+		return sessionsCheckpoint{}, err
+	}
+
+	return sessionsCheckpoint{
+		Version:           decodedVersion,
+		OutgoingSnapshots: outgoingSnapshots,
+		IncomingSnapshots: incomingSnapshots,
+	}, nil
+}
+
+func encodeOutgoingSessionsCheckpoint(
+	checkpoint outgoingSessionsCheckpoint) ([]byte, error) {
+
+	return encodeSessionsCheckpoint(sessionsCheckpoint{
+		Version:           checkpoint.Version,
+		OutgoingSnapshots: checkpoint.Snapshots,
+	})
+}
+
+func decodeOutgoingSessionsCheckpoint(
+	raw []byte) (outgoingSessionsCheckpoint, error) {
+
+	checkpoint, err := decodeSessionsCheckpoint(raw)
 	if err != nil {
 		return outgoingSessionsCheckpoint{}, err
 	}
 
 	return outgoingSessionsCheckpoint{
-		Version:   decodedVersion,
-		Snapshots: snapshots,
+		Version:   checkpoint.Version,
+		Snapshots: checkpoint.OutgoingSnapshots,
 	}, nil
 }
 

--- a/oor/outgoing_snapshot_codec.go
+++ b/oor/outgoing_snapshot_codec.go
@@ -97,7 +97,6 @@ func encodeSessionsCheckpoint(
 }
 
 func decodeSessionsCheckpoint(raw []byte) (sessionsCheckpoint, error) {
-
 	var (
 		version     uint64
 		outgoingRaw []byte
@@ -140,8 +139,7 @@ func decodeSessionsCheckpoint(raw []byte) (sessionsCheckpoint, error) {
 		outgoingSnapshots = append(outgoingSnapshots, snapshot)
 	}
 
-	incomingSnapshots := make([]*IncomingSnapshot, 0,
-		0)
+	incomingSnapshots := make([]*IncomingSnapshot, 0)
 	if len(incomingRaw) != 0 {
 		incomingBlobs, err := decodeLengthPrefixedBlobList(
 			incomingRaw,

--- a/oor/receive_session.go
+++ b/oor/receive_session.go
@@ -40,12 +40,30 @@ func NewReceiveSession(ctx context.Context, ark *psbt.Packet,
 	log.InfoS(ctx, "Creating receive session",
 		slog.String("session_id", sessionID.String()))
 
+	return newReceiveSessionWithState(
+		ctx, sessionID, &ReceiveIdle{},
+	)
+}
+
+// newReceiveSessionWithState creates an incoming-transfer FSM session with
+// the provided initial receive state.
+func newReceiveSessionWithState(ctx context.Context, sessionID SessionID,
+	state SessionState) (*ReceiveSession, error) {
+
+	if sessionID == (SessionID{}) {
+		return nil, fmt.Errorf("session id must be provided")
+	}
+
+	if state == nil {
+		return nil, fmt.Errorf("state must be provided")
+	}
+
 	env := &Environment{SessionID: sessionID}
 
 	fsmCfg := StateMachineCfg{
 		Logger:        log.WithPrefix(sessionID.LogPrefix()),
 		ErrorReporter: newContextErrorReporter(ctx, sessionID.LogPrefix()),
-		InitialState:  &ReceiveIdle{},
+		InitialState:  state,
 		Env:           env,
 	}
 

--- a/oor/receive_session.go
+++ b/oor/receive_session.go
@@ -61,10 +61,12 @@ func newReceiveSessionWithState(ctx context.Context, sessionID SessionID,
 	env := &Environment{SessionID: sessionID}
 
 	fsmCfg := StateMachineCfg{
-		Logger:        log.WithPrefix(sessionID.LogPrefix()),
-		ErrorReporter: newContextErrorReporter(ctx, sessionID.LogPrefix()),
-		InitialState:  state,
-		Env:           env,
+		Logger: log.WithPrefix(sessionID.LogPrefix()),
+		ErrorReporter: newContextErrorReporter(
+			ctx, sessionID.LogPrefix(),
+		),
+		InitialState: state,
+		Env:          env,
 	}
 
 	sm := protofsm.NewStateMachine(fsmCfg)

--- a/oor/receive_session_test.go
+++ b/oor/receive_session_test.go
@@ -14,10 +14,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestReceiveSessionNotifiesThenMaterializes verifies the incoming-transfer FSM
-// emits notification/materialization first, deferring ack until after incoming
-// materialization is confirmed.
-func TestReceiveSessionNotifiesThenMaterializes(t *testing.T) {
+// TestReceiveSessionNotifiesThenQueriesMetadata verifies the incoming-transfer
+// FSM emits notification and metadata-query outbox work first, deferring ack
+// until local materialization is confirmed.
+func TestReceiveSessionNotifiesThenQueriesMetadata(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
@@ -28,7 +28,7 @@ func TestReceiveSessionNotifiesThenMaterializes(t *testing.T) {
 	// (checkpoint input -> recipients + anchor), then verify the receive
 	// session:
 	// - emits an application-facing notification
-	// - requests recipient materialization into local VTXO state
+	// - requests authoritative incoming metadata
 	// Ack is emitted only after materialization is confirmed.
 	operatorKey, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
@@ -107,14 +107,14 @@ func TestReceiveSessionNotifiesThenMaterializes(t *testing.T) {
 	_, ok := outbox[0].(*IncomingTransferNotification)
 	require.True(t, ok)
 
-	materializeMsg, ok := outbox[1].(*MaterializeIncomingVTXOsRequest)
+	queryMsg, ok := outbox[1].(*QueryIncomingMetadataRequest)
 	require.True(t, ok)
-	require.NotEmpty(t, materializeMsg.Recipients)
+	require.NotEmpty(t, queryMsg.Recipients)
 	parentCommitment := inputs[0].SpentVTXO.Outpoint.Hash
 
-	desc, err := BuildIncomingVTXODescriptor(materializeMsg.ArkPSBT,
+	desc, err := BuildIncomingVTXODescriptor(queryMsg.ArkPSBT,
 		IncomingVTXOConfig{
-			OutputIndex: materializeMsg.Recipients[0].OutputIndex,
+			OutputIndex: queryMsg.Recipients[0].OutputIndex,
 			ClientKey: keychain.KeyDescriptor{
 				PubKey: recipientKey.PubKey(),
 			},
@@ -149,8 +149,24 @@ func TestReceiveSessionAcksAfterHandled(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, outbox, 2)
 
-	fut := sess.FSM.AskEvent(ctx, &IncomingHandledEvent{})
+	fut := sess.FSM.AskEvent(ctx, &IncomingMetadataResolvedEvent{
+		Matches: []IncomingMetadataMatch{{
+			OutputIndex: 0,
+			Metadata: IncomingVTXOMetadata{
+				RoundID: "round-test",
+			},
+		}},
+	})
 	result := fut.Await(ctx)
+	require.False(t, result.IsErr())
+
+	materializeOutbox := result.UnwrapOr(nil)
+	require.Len(t, materializeOutbox, 1)
+	require.IsType(t, &MaterializeIncomingVTXOsRequest{},
+		materializeOutbox[0])
+
+	fut = sess.FSM.AskEvent(ctx, &IncomingHandledEvent{})
+	result = fut.Await(ctx)
 	require.False(t, result.IsErr())
 
 	ackOutbox := result.UnwrapOr(nil)

--- a/oor/receive_snapshot.go
+++ b/oor/receive_snapshot.go
@@ -1,0 +1,397 @@
+package oor
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/lightninglabs/darepo-client/lib/tx/psbtutil"
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+const (
+	incomingSnapshotVersionRecordType         tlv.Type = 1
+	incomingSnapshotSessionIDRecordType       tlv.Type = 3
+	incomingSnapshotPhaseRecordType           tlv.Type = 5
+	incomingSnapshotArkPSBTRecordType         tlv.Type = 7
+	incomingSnapshotCheckpointPSBTsRecordType tlv.Type = 9
+	incomingSnapshotFailReasonRecordType      tlv.Type = 11
+	incomingSnapshotRecipientPkScriptType     tlv.Type = 13
+	incomingSnapshotRecipientEventIDType      tlv.Type = 15
+)
+
+// IncomingPhase identifies the coarse stage of an incoming OOR receive
+// session.
+type IncomingPhase string
+
+const (
+	// IncomingPhaseResolvePending indicates the client durably recorded
+	// an incoming-hint notification and still needs to resolve the full
+	// Ark/checkpoint package outside the actor transaction.
+	IncomingPhaseResolvePending IncomingPhase = "resolve_pending"
+
+	// IncomingPhaseMaterializePending indicates the incoming transfer has
+	// been validated and notified locally, and the wallet materialization
+	// step still needs to run.
+	IncomingPhaseMaterializePending IncomingPhase = "materialize_pending"
+
+	// IncomingPhaseAckPending indicates the incoming VTXOs were
+	// durably materialized and the client still needs to enqueue the
+	// best-effort ack to the server.
+	IncomingPhaseAckPending IncomingPhase = "ack_pending"
+
+	// IncomingPhaseCompleted indicates the incoming transfer finished.
+	IncomingPhaseCompleted IncomingPhase = "completed"
+
+	// IncomingPhaseFailed indicates the incoming transfer entered a
+	// terminal failure state.
+	IncomingPhaseFailed IncomingPhase = "failed"
+)
+
+// IncomingSnapshot is the durable checkpoint shape for incoming OOR receive
+// sessions.
+type IncomingSnapshot struct {
+	// Version is the snapshot version.
+	Version uint8
+
+	// SessionID is the stable Ark txid for the incoming transfer.
+	SessionID SessionID
+
+	// Phase is the coarse incoming receive phase.
+	Phase IncomingPhase
+
+	// ArkPSBT is the canonical Ark transfer PSBT.
+	ArkPSBT []byte
+
+	// CheckpointPSBTs are the finalized checkpoint PSBTs associated with the
+	// incoming transfer when the phase needs them.
+	CheckpointPSBTs [][]byte
+
+	// FailReason is the terminal failure reason, when Phase is Failed.
+	FailReason string
+
+	// RecipientPkScript is the persisted hint used while the incoming
+	// package still needs resolution.
+	RecipientPkScript []byte
+
+	// RecipientEventID is the per-script cursor hint paired with
+	// RecipientPkScript during resolve-pending restart.
+	RecipientEventID uint64
+}
+
+// NewIncomingSnapshot exports an incoming receive session state into a
+// checkpoint snapshot.
+func NewIncomingSnapshot(sessionID SessionID,
+	state SessionState) (*IncomingSnapshot, error) {
+
+	if sessionID == (SessionID{}) {
+		return nil, fmt.Errorf("session id must be provided")
+	}
+
+	if state == nil {
+		return nil, fmt.Errorf("state must be provided")
+	}
+
+	snap := &IncomingSnapshot{
+		Version:   1,
+		SessionID: sessionID,
+	}
+
+	switch s := state.(type) {
+	case *ReceiveResolving:
+		snap.Phase = IncomingPhaseResolvePending
+		snap.RecipientPkScript = append(
+			[]byte(nil), s.RecipientPkScript...,
+		)
+		snap.RecipientEventID = s.RecipientEventID
+
+	case *ReceiveNotified:
+		ark, err := psbtutil.Serialize(s.ArkPSBT)
+		if err != nil {
+			return nil, err
+		}
+
+		checkpoints, err := serializePSBTSlice(
+			s.FinalCheckpointPSBTs,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		snap.Phase = IncomingPhaseMaterializePending
+		snap.ArkPSBT = ark
+		snap.CheckpointPSBTs = checkpoints
+
+	case *ReceiveAwaitingAck:
+		snap.Phase = IncomingPhaseAckPending
+
+	case *ReceiveCompleted:
+		snap.Phase = IncomingPhaseCompleted
+
+	case *Failed:
+		snap.Phase = IncomingPhaseFailed
+		snap.FailReason = s.Reason
+
+	default:
+		return nil, fmt.Errorf("unsupported incoming state type: %T",
+			state)
+	}
+
+	return snap, nil
+}
+
+// NewReceiveSessionFromSnapshot restores an incoming receive session from a
+// durable snapshot.
+func NewReceiveSessionFromSnapshot(ctx context.Context,
+	snapshot *IncomingSnapshot) (*ReceiveSession, error) {
+
+	if snapshot == nil {
+		return nil, fmt.Errorf("snapshot must be provided")
+	}
+
+	state, err := IncomingStateFromSnapshot(snapshot)
+	if err != nil {
+		return nil, err
+	}
+
+	return newReceiveSessionWithState(
+		ctx, snapshot.SessionID, state,
+	)
+}
+
+// IncomingStateFromSnapshot converts an incoming receive snapshot into the
+// corresponding concrete state.
+func IncomingStateFromSnapshot(snapshot *IncomingSnapshot) (SessionState,
+	error) {
+
+	if snapshot == nil {
+		return nil, fmt.Errorf("snapshot must be provided")
+	}
+
+	if snapshot.SessionID == (SessionID{}) {
+		return nil, fmt.Errorf("session id must be provided")
+	}
+
+	if snapshot.Version == 0 {
+		return nil, fmt.Errorf("snapshot version must be provided")
+	}
+
+	switch snapshot.Phase {
+	case IncomingPhaseResolvePending:
+		return &ReceiveResolving{
+			SessionID: snapshot.SessionID,
+			RecipientPkScript: append(
+				[]byte(nil), snapshot.RecipientPkScript...,
+			),
+			RecipientEventID: snapshot.RecipientEventID,
+		}, nil
+
+	case IncomingPhaseMaterializePending:
+		ark, checkpoints, err := parseIncomingPSBTs(
+			snapshot.ArkPSBT, snapshot.CheckpointPSBTs,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		err = requireSessionIDMatchesArk(snapshot.SessionID, ark)
+		if err != nil {
+			return nil, err
+		}
+
+		return &ReceiveNotified{
+			SessionID:            snapshot.SessionID,
+			ArkPSBT:              ark,
+			FinalCheckpointPSBTs: checkpoints,
+		}, nil
+
+	case IncomingPhaseAckPending:
+		return &ReceiveAwaitingAck{
+			SessionID: snapshot.SessionID,
+		}, nil
+
+	case IncomingPhaseCompleted:
+		return &ReceiveCompleted{}, nil
+
+	case IncomingPhaseFailed:
+		return &Failed{Reason: snapshot.FailReason}, nil
+
+	default:
+		return nil, fmt.Errorf("unknown incoming phase: %s",
+			snapshot.Phase)
+	}
+}
+
+// encodeIncomingSnapshot serializes an incoming snapshot into TLV bytes.
+func encodeIncomingSnapshot(snapshot *IncomingSnapshot) ([]byte, error) {
+	if snapshot == nil {
+		return nil, fmt.Errorf("snapshot must be provided")
+	}
+
+	sessionBytes := sessionIDBytes(snapshot.SessionID)
+	phaseBytes := []byte(snapshot.Phase)
+	arkPSBT := snapshot.ArkPSBT
+	checkpoints, err := encodeLengthPrefixedBlobList(
+		snapshot.CheckpointPSBTs,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	failReason := []byte(snapshot.FailReason)
+	recipientPkScript := snapshot.RecipientPkScript
+	recipientEventID := snapshot.RecipientEventID
+	version := uint64(snapshot.Version)
+
+	records := []tlv.Record{
+		tlv.MakePrimitiveRecord(
+			incomingSnapshotVersionRecordType, &version,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingSnapshotSessionIDRecordType, &sessionBytes,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingSnapshotPhaseRecordType, &phaseBytes,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingSnapshotArkPSBTRecordType, &arkPSBT,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingSnapshotCheckpointPSBTsRecordType,
+			&checkpoints,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingSnapshotFailReasonRecordType, &failReason,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingSnapshotRecipientPkScriptType,
+			&recipientPkScript,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingSnapshotRecipientEventIDType,
+			&recipientEventID,
+		),
+	}
+
+	stream, err := tlv.NewStream(records...)
+	if err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	if err := stream.Encode(&buf); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// decodeIncomingSnapshot deserializes an incoming snapshot from TLV bytes.
+func decodeIncomingSnapshot(raw []byte) (*IncomingSnapshot, error) {
+	var (
+		version           uint64
+		sessionBytes      []byte
+		phaseBytes        []byte
+		arkPSBT           []byte
+		checkpointsRaw    []byte
+		failReasonRaw     []byte
+		recipientPkScript []byte
+		recipientEventID  uint64
+	)
+
+	records := []tlv.Record{
+		tlv.MakePrimitiveRecord(
+			incomingSnapshotVersionRecordType, &version,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingSnapshotSessionIDRecordType, &sessionBytes,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingSnapshotPhaseRecordType, &phaseBytes,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingSnapshotArkPSBTRecordType, &arkPSBT,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingSnapshotCheckpointPSBTsRecordType,
+			&checkpointsRaw,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingSnapshotFailReasonRecordType, &failReasonRaw,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingSnapshotRecipientPkScriptType,
+			&recipientPkScript,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingSnapshotRecipientEventIDType,
+			&recipientEventID,
+		),
+	}
+
+	stream, err := tlv.NewStream(records...)
+	if err != nil {
+		return nil, err
+	}
+
+	reader := bytes.NewReader(raw)
+	if _, err := stream.DecodeWithParsedTypes(reader); err != nil {
+		return nil, err
+	}
+
+	sessionID, err := parseSessionID(sessionBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	checkpoints, err := decodeLengthPrefixedBlobList(checkpointsRaw)
+	if err != nil {
+		return nil, err
+	}
+	if len(checkpoints) == 0 {
+		checkpoints = nil
+	}
+
+	if len(arkPSBT) == 0 {
+		arkPSBT = nil
+	}
+
+	decodedVersion, err := decodeUint64ToUint8(
+		version, "incoming snapshot version",
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &IncomingSnapshot{
+		Version:         decodedVersion,
+		SessionID:       sessionID,
+		Phase:           IncomingPhase(phaseBytes),
+		ArkPSBT:         arkPSBT,
+		CheckpointPSBTs: checkpoints,
+		FailReason:      string(failReasonRaw),
+		RecipientPkScript: append(
+			[]byte(nil), recipientPkScript...,
+		),
+		RecipientEventID: recipientEventID,
+	}, nil
+}
+
+// parseIncomingPSBTs parses the Ark and checkpoint PSBTs stored in an incoming
+// snapshot.
+func parseIncomingPSBTs(arkRaw []byte, checkpointRaws [][]byte) (
+	*psbt.Packet, []*psbt.Packet, error) {
+
+	ark, err := psbtutil.Parse(arkRaw)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	checkpoints, err := parsePSBTSlice(checkpointRaws)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return ark, checkpoints, nil
+}

--- a/oor/receive_snapshot.go
+++ b/oor/receive_snapshot.go
@@ -32,8 +32,8 @@ const (
 	IncomingPhaseResolvePending IncomingPhase = "resolve_pending"
 
 	// IncomingPhaseMaterializePending indicates the incoming transfer has
-	// been validated and notified locally, and the wallet materialization
-	// step still needs to run.
+	// been validated and notified locally, and the authoritative metadata
+	// lookup/materialization work still needs to run.
 	IncomingPhaseMaterializePending IncomingPhase = "materialize_pending"
 
 	// IncomingPhaseAckPending indicates the incoming VTXOs were

--- a/oor/receive_snapshot.go
+++ b/oor/receive_snapshot.go
@@ -64,8 +64,9 @@ type IncomingSnapshot struct {
 	// ArkPSBT is the canonical Ark transfer PSBT.
 	ArkPSBT []byte
 
-	// CheckpointPSBTs are the finalized checkpoint PSBTs associated with the
-	// incoming transfer when the phase needs them.
+	// CheckpointPSBTs are the finalized checkpoint PSBTs
+	// associated with the incoming transfer when the phase
+	// needs them.
 	CheckpointPSBTs [][]byte
 
 	// FailReason is the terminal failure reason, when Phase is Failed.

--- a/oor/receive_states.go
+++ b/oor/receive_states.go
@@ -15,6 +15,30 @@ type ReceiveState interface {
 	receiveStateSealed()
 }
 
+// ReceiveResolving indicates the client durably recorded a lightweight
+// incoming-transfer hint and still needs to fetch the full Ark/checkpoint
+// package outside the live durable actor transaction.
+type ReceiveResolving struct {
+	SessionID SessionID
+
+	RecipientPkScript []byte
+
+	RecipientEventID uint64
+}
+
+// String returns a human-readable representation of ReceiveResolving.
+func (s *ReceiveResolving) String() string {
+	return "ReceiveResolving"
+}
+
+// IsTerminal returns false as ReceiveResolving is not terminal.
+func (s *ReceiveResolving) IsTerminal() bool {
+	return false
+}
+
+// receiveStateSealed marks ReceiveResolving as implementing ReceiveState.
+func (s *ReceiveResolving) receiveStateSealed() {}
+
 // ReceiveIdle is the initial state for handling incoming transfers.
 type ReceiveIdle struct{}
 
@@ -32,11 +56,13 @@ func (s *ReceiveIdle) IsTerminal() bool {
 func (s *ReceiveIdle) receiveStateSealed() {}
 
 // ReceiveNotified indicates the client has validated and surfaced an incoming
-// transfer and is waiting to ack it.
+// transfer and is waiting for local materialization to finish.
 type ReceiveNotified struct {
 	SessionID SessionID
 
 	ArkPSBT *psbt.Packet
+
+	FinalCheckpointPSBTs []*psbt.Packet
 }
 
 // String returns a human-readable representation of ReceiveNotified.

--- a/oor/receive_transitions.go
+++ b/oor/receive_transitions.go
@@ -3,6 +3,7 @@ package oor
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	"github.com/lightninglabs/darepo-client/lib/tx/arktx"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
@@ -101,8 +102,8 @@ func transitionIncomingTransfer(
 				&QueryIncomingMetadataRequest{
 					SessionID: evt.SessionID,
 					ArkPSBT:   evt.ArkPSBT,
-					FinalCheckpointPSBTs: evt. //nolint:ll
-									FinalCheckpointPSBTs, //nolint:ll
+					FinalCheckpointPSBTs: evt.
+						FinalCheckpointPSBTs, //nolint:ll
 					Recipients: recipients,
 				},
 			},
@@ -114,7 +115,6 @@ func transitionIncomingTransfer(
 func (s *ReceiveIdle) ProcessEvent(ctx context.Context, event Event,
 	env *Environment) (*StateTransition, error) {
 
-	_ = ctx
 	_ = env
 
 	switch evt := event.(type) {
@@ -128,6 +128,10 @@ func (s *ReceiveIdle) ProcessEvent(ctx context.Context, event Event,
 		}, nil
 
 	default:
+		log.WarnS(ctx, "Unexpected event in receive FSM", nil,
+			slog.String("state", fmt.Sprintf("%T", s)),
+			slog.String("event_type", fmt.Sprintf("%T", event)))
+
 		return unexpectedReceiveEvent(s, event), nil
 	}
 }
@@ -136,7 +140,6 @@ func (s *ReceiveIdle) ProcessEvent(ctx context.Context, event Event,
 func (s *ReceiveResolving) ProcessEvent(ctx context.Context, event Event,
 	env *Environment) (*StateTransition, error) {
 
-	_ = ctx
 	_ = env
 
 	switch evt := event.(type) {
@@ -150,6 +153,10 @@ func (s *ReceiveResolving) ProcessEvent(ctx context.Context, event Event,
 		}, nil
 
 	default:
+		log.WarnS(ctx, "Unexpected event in receive FSM", nil,
+			slog.String("state", fmt.Sprintf("%T", s)),
+			slog.String("event_type", fmt.Sprintf("%T", event)))
+
 		return unexpectedReceiveEvent(s, event), nil
 	}
 }
@@ -158,7 +165,6 @@ func (s *ReceiveResolving) ProcessEvent(ctx context.Context, event Event,
 func (s *ReceiveNotified) ProcessEvent(ctx context.Context, event Event,
 	env *Environment) (*StateTransition, error) {
 
-	_ = ctx
 	_ = env
 
 	switch evt := event.(type) {
@@ -217,6 +223,10 @@ func (s *ReceiveNotified) ProcessEvent(ctx context.Context, event Event,
 		}, nil
 
 	default:
+		log.WarnS(ctx, "Unexpected event in receive FSM", nil,
+			slog.String("state", fmt.Sprintf("%T", s)),
+			slog.String("event_type", fmt.Sprintf("%T", event)))
+
 		return unexpectedReceiveEvent(s, event), nil
 	}
 }
@@ -225,8 +235,11 @@ func (s *ReceiveNotified) ProcessEvent(ctx context.Context, event Event,
 func (s *ReceiveCompleted) ProcessEvent(ctx context.Context, event Event,
 	env *Environment) (*StateTransition, error) {
 
-	_ = ctx
 	_ = env
+
+	log.WarnS(ctx, "Unexpected event in receive FSM", nil,
+		slog.String("state", fmt.Sprintf("%T", s)),
+		slog.String("event_type", fmt.Sprintf("%T", event)))
 
 	return unexpectedReceiveEvent(s, event), nil
 }
@@ -235,7 +248,6 @@ func (s *ReceiveCompleted) ProcessEvent(ctx context.Context, event Event,
 func (s *ReceiveAwaitingAck) ProcessEvent(ctx context.Context, event Event,
 	env *Environment) (*StateTransition, error) {
 
-	_ = ctx
 	_ = env
 
 	switch evt := event.(type) {
@@ -260,6 +272,10 @@ func (s *ReceiveAwaitingAck) ProcessEvent(ctx context.Context, event Event,
 		}, nil
 
 	default:
+		log.WarnS(ctx, "Unexpected event in receive FSM", nil,
+			slog.String("state", fmt.Sprintf("%T", s)),
+			slog.String("event_type", fmt.Sprintf("%T", event)))
+
 		return unexpectedReceiveEvent(s, event), nil
 	}
 }

--- a/oor/receive_transitions.go
+++ b/oor/receive_transitions.go
@@ -10,22 +10,33 @@ import (
 
 // Incoming transfer receive flow (human-readable):
 //
-// IncomingTransferEvent (delivered by transport; server believes we are a
-// recipient)
+// ResolveIncomingTransferRequest (delivered by transport as a lightweight
+// hint)
 //   |
 //   v
-// ReceiveIdle
+// ReceiveResolving
+//   - async indexer fetch outside the actor tx
+//   - callback re-enters with IncomingTransferEvent
+//   |
+//   v
+// IncomingTransferEvent
+//   |
+//   v
+// ReceiveIdle / ReceiveResolving
 //   - structural checks (SessionID/txid consistency)
 //   - canonical Ark PSBT validation (stable recipient extraction)
 //   - extract recipients (for UI summary and wallet materialization)
 //   emits outbox (in order):
 //   1) IncomingTransferNotification: app/UI summary of the transfer
 //   2) MaterializeIncomingVTXOsRequest: wallet/state update (filter + persist)
-//   3) SendIncomingAckRequest: best-effort ack to server
 //   |
 //   v
 // ReceiveNotified
-//   - waits for IncomingHandledEvent (app confirms it processed the transfer)
+//   - waits for IncomingHandledEvent after async materialization completes
+//   |
+//   v
+// ReceiveAwaitingAck
+//   - emits SendIncomingAckRequest after durable materialization succeeds
 //   |
 //   v
 // ReceiveCompleted
@@ -41,6 +52,63 @@ func unexpectedReceiveEvent(state ReceiveState, event Event) *StateTransition {
 	}
 }
 
+// transitionIncomingTransfer validates and applies a fully resolved incoming
+// transfer event, moving the receive FSM into the notified/materialize phase.
+func transitionIncomingTransfer(
+	evt *IncomingTransferEvent) (*StateTransition, error) {
+
+	if evt.ArkPSBT == nil || evt.ArkPSBT.UnsignedTx == nil {
+		return nil, fmt.Errorf("ark psbt must be provided")
+	}
+
+	if evt.SessionID == (SessionID{}) {
+		return nil, fmt.Errorf("session id must be provided")
+	}
+
+	txid := evt.ArkPSBT.UnsignedTx.TxHash()
+	if SessionID(txid) != evt.SessionID {
+		return nil, fmt.Errorf("ark txid mismatch")
+	}
+
+	// Canonical ordering checks prevent subtle malleability in how the
+	// recipients are extracted and displayed.
+	err := arktx.ValidateCanonicalPSBT(evt.ArkPSBT)
+	if err != nil {
+		return nil, err
+	}
+
+	// The FSM intentionally does not decide which outputs belong to the
+	// local wallet. Ownership lives behind the materialization boundary.
+	recipients, err := ExtractArkRecipients(evt.ArkPSBT)
+	if err != nil {
+		return nil, err
+	}
+
+	return &StateTransition{
+		NextState: &ReceiveNotified{
+			SessionID:            evt.SessionID,
+			ArkPSBT:              evt.ArkPSBT,
+			FinalCheckpointPSBTs: evt.FinalCheckpointPSBTs,
+		},
+		NewEvents: fn.Some(EmittedEvent{
+			Outbox: []OutboxEvent{
+				&IncomingTransferNotification{
+					SessionID:  evt.SessionID,
+					ArkPSBT:    evt.ArkPSBT,
+					Recipients: recipients,
+				},
+				&MaterializeIncomingVTXOsRequest{
+					SessionID: evt.SessionID,
+					ArkPSBT:   evt.ArkPSBT,
+					FinalCheckpointPSBTs: evt.
+						FinalCheckpointPSBTs,
+					Recipients: recipients,
+				},
+			},
+		}),
+	}, nil
+}
+
 // ProcessEvent handles events for ReceiveIdle.
 func (s *ReceiveIdle) ProcessEvent(ctx context.Context, event Event,
 	env *Environment) (*StateTransition, error) {
@@ -50,73 +118,29 @@ func (s *ReceiveIdle) ProcessEvent(ctx context.Context, event Event,
 
 	switch evt := event.(type) {
 	case *IncomingTransferEvent:
-		// Basic sanity checks: we only accept an incoming transfer
-		// notification if it is self-consistent (Ark txid matches
-		// SessionID) and structurally valid.
-		if evt.ArkPSBT == nil || evt.ArkPSBT.UnsignedTx == nil {
-			return nil, fmt.Errorf("ark psbt must be provided")
-		}
+		return transitionIncomingTransfer(evt)
 
-		if evt.SessionID == (SessionID{}) {
-			return nil, fmt.Errorf("session id must be provided")
-		}
-
-		txid := evt.ArkPSBT.UnsignedTx.TxHash()
-		if SessionID(txid) != evt.SessionID {
-			return nil, fmt.Errorf("ark txid mismatch")
-		}
-
-		// Canonical ordering checks prevent subtle malleability in how
-		// the recipients are extracted and displayed.
-		//
-		// The goal is that all parties derive identical semantics from
-		// identical bytes.
-		err := arktx.ValidateCanonicalPSBT(evt.ArkPSBT)
-		if err != nil {
-			return nil, err
-		}
-
-		// Extract recipients and surface the notification to the
-		// application layer.
-		//
-		// Note: the FSM intentionally does not decide which of these
-		// outputs belong to the local wallet. That check depends on
-		// local wallet keys and policy, so it lives behind the outbox
-		// boundary in the materialization step.
-		recipients, err := ExtractArkRecipients(evt.ArkPSBT)
-		if err != nil {
-			return nil, err
-		}
-
-		// The outbox is intentionally ordered:
-		//   1) notify the app/UI so it can show the transfer;
-		//   2) materialize incoming VTXOs into local state.
-		//
-		// Ack is emitted only after the application confirms incoming
-		// handling to avoid acknowledging transfers that were not
-		// durably materialized yet.
+	case *FailEvent:
 		return &StateTransition{
-			NextState: &ReceiveNotified{
-				SessionID: evt.SessionID,
-				ArkPSBT:   evt.ArkPSBT,
-			},
-			NewEvents: fn.Some(EmittedEvent{
-				Outbox: []OutboxEvent{
-					&IncomingTransferNotification{
-						SessionID:  evt.SessionID,
-						ArkPSBT:    evt.ArkPSBT,
-						Recipients: recipients,
-					},
-					&MaterializeIncomingVTXOsRequest{
-						SessionID: evt.SessionID,
-						ArkPSBT:   evt.ArkPSBT,
-						FinalCheckpointPSBTs: evt.
-							FinalCheckpointPSBTs,
-						Recipients: recipients,
-					},
-				},
-			}),
+			NextState: &Failed{Reason: evt.Reason},
+			NewEvents: fn.None[EmittedEvent](),
 		}, nil
+
+	default:
+		return unexpectedReceiveEvent(s, event), nil
+	}
+}
+
+// ProcessEvent handles events for ReceiveResolving.
+func (s *ReceiveResolving) ProcessEvent(ctx context.Context, event Event,
+	env *Environment) (*StateTransition, error) {
+
+	_ = ctx
+	_ = env
+
+	switch evt := event.(type) {
+	case *IncomingTransferEvent:
+		return transitionIncomingTransfer(evt)
 
 	case *FailEvent:
 		return &StateTransition{
@@ -139,8 +163,8 @@ func (s *ReceiveNotified) ProcessEvent(ctx context.Context, event Event,
 	switch evt := event.(type) {
 	case *IncomingHandledEvent:
 		// The application signals it has processed the notification.
-		// Wallet state has been updated (materialization complete), so
-		// we can now ack to the server.
+		// Wallet state has been updated (materialization complete), so we
+		// can now ack to the server.
 		_ = evt
 
 		return &StateTransition{
@@ -154,6 +178,12 @@ func (s *ReceiveNotified) ProcessEvent(ctx context.Context, event Event,
 					},
 				},
 			}),
+		}, nil
+
+	case *OutboxErrorEvent:
+		return &StateTransition{
+			NextState: &Failed{Reason: evt.ErrorReason},
+			NewEvents: fn.None[EmittedEvent](),
 		}, nil
 
 	case *FailEvent:
@@ -190,6 +220,12 @@ func (s *ReceiveAwaitingAck) ProcessEvent(ctx context.Context, event Event,
 
 		return &StateTransition{
 			NextState: &ReceiveCompleted{},
+			NewEvents: fn.None[EmittedEvent](),
+		}, nil
+
+	case *OutboxErrorEvent:
+		return &StateTransition{
+			NextState: &Failed{Reason: evt.ErrorReason},
 			NewEvents: fn.None[EmittedEvent](),
 		}, nil
 

--- a/oor/receive_transitions.go
+++ b/oor/receive_transitions.go
@@ -99,10 +99,11 @@ func transitionIncomingTransfer(
 					Recipients: recipients,
 				},
 				&QueryIncomingMetadataRequest{
-					SessionID:            evt.SessionID,
-					ArkPSBT:              evt.ArkPSBT,
-					FinalCheckpointPSBTs: evt.FinalCheckpointPSBTs,
-					Recipients:           recipients,
+					SessionID: evt.SessionID,
+					ArkPSBT:   evt.ArkPSBT,
+					FinalCheckpointPSBTs: evt. //nolint:ll
+									FinalCheckpointPSBTs, //nolint:ll
+					Recipients: recipients,
 				},
 			},
 		}),
@@ -176,7 +177,7 @@ func (s *ReceiveNotified) ProcessEvent(ctx context.Context, event Event,
 						ArkPSBT:   s.ArkPSBT,
 						FinalCheckpointPSBTs: s.
 							FinalCheckpointPSBTs,
-						Recipients: recipients,
+						Recipients:      recipients,
 						MetadataMatches: evt.Matches,
 					},
 				},
@@ -184,9 +185,10 @@ func (s *ReceiveNotified) ProcessEvent(ctx context.Context, event Event,
 		}, nil
 
 	case *IncomingHandledEvent:
-		// The application signals it has processed the notification.
-		// Wallet state has been updated (materialization complete), so we
-		// can now ack to the server.
+		// The application signals it has processed the
+		// notification. Wallet state has been updated
+		// (materialization complete), so we can now ack to the
+		// server.
 		_ = evt
 
 		return &StateTransition{

--- a/oor/receive_transitions.go
+++ b/oor/receive_transitions.go
@@ -28,11 +28,12 @@ import (
 //   - extract recipients (for UI summary and wallet materialization)
 //   emits outbox (in order):
 //   1) IncomingTransferNotification: app/UI summary of the transfer
-//   2) MaterializeIncomingVTXOsRequest: wallet/state update (filter + persist)
+//   2) QueryIncomingMetadataRequest: authoritative indexer metadata lookup
 //   |
 //   v
 // ReceiveNotified
-//   - waits for IncomingHandledEvent after async materialization completes
+//   - waits for IncomingMetadataResolvedEvent then emits local materialization
+//   - waits for IncomingHandledEvent after local materialization completes
 //   |
 //   v
 // ReceiveAwaitingAck
@@ -97,12 +98,11 @@ func transitionIncomingTransfer(
 					ArkPSBT:    evt.ArkPSBT,
 					Recipients: recipients,
 				},
-				&MaterializeIncomingVTXOsRequest{
-					SessionID: evt.SessionID,
-					ArkPSBT:   evt.ArkPSBT,
-					FinalCheckpointPSBTs: evt.
-						FinalCheckpointPSBTs,
-					Recipients: recipients,
+				&QueryIncomingMetadataRequest{
+					SessionID:            evt.SessionID,
+					ArkPSBT:              evt.ArkPSBT,
+					FinalCheckpointPSBTs: evt.FinalCheckpointPSBTs,
+					Recipients:           recipients,
 				},
 			},
 		}),
@@ -161,6 +161,28 @@ func (s *ReceiveNotified) ProcessEvent(ctx context.Context, event Event,
 	_ = env
 
 	switch evt := event.(type) {
+	case *IncomingMetadataResolvedEvent:
+		recipients, err := ExtractArkRecipients(s.ArkPSBT)
+		if err != nil {
+			return nil, err
+		}
+
+		return &StateTransition{
+			NextState: s,
+			NewEvents: fn.Some(EmittedEvent{
+				Outbox: []OutboxEvent{
+					&MaterializeIncomingVTXOsRequest{
+						SessionID: s.SessionID,
+						ArkPSBT:   s.ArkPSBT,
+						FinalCheckpointPSBTs: s.
+							FinalCheckpointPSBTs,
+						Recipients: recipients,
+						MetadataMatches: evt.Matches,
+					},
+				},
+			}),
+		}, nil
+
 	case *IncomingHandledEvent:
 		// The application signals it has processed the notification.
 		// Wallet state has been updated (materialization complete), so we

--- a/oor/resume.go
+++ b/oor/resume.go
@@ -4,6 +4,48 @@ import (
 	"fmt"
 )
 
+// OutboxForIncomingState returns the outbox implied by the current incoming
+// receive state.
+func OutboxForIncomingState(state SessionState) ([]OutboxEvent, error) {
+	if state == nil {
+		return nil, fmt.Errorf("state must be provided")
+	}
+
+	switch s := state.(type) {
+	case *ReceiveResolving:
+		return nil, nil
+
+	case *ReceiveNotified:
+		recipients, err := ExtractArkRecipients(s.ArkPSBT)
+		if err != nil {
+			return nil, err
+		}
+
+		return []OutboxEvent{
+			&MaterializeIncomingVTXOsRequest{
+				SessionID:            s.SessionID,
+				ArkPSBT:              s.ArkPSBT,
+				FinalCheckpointPSBTs: s.FinalCheckpointPSBTs,
+				Recipients:           recipients,
+			},
+		}, nil
+
+	case *ReceiveAwaitingAck:
+		return []OutboxEvent{
+			&SendIncomingAckRequest{
+				SessionID: s.SessionID,
+			},
+		}, nil
+
+	case *ReceiveCompleted, *Failed:
+		return nil, nil
+
+	default:
+		return nil, fmt.Errorf("unsupported incoming state type: %T",
+			state)
+	}
+}
+
 // OutboxForState returns the outbox request implied by the current outgoing
 // session state.
 //

--- a/oor/resume.go
+++ b/oor/resume.go
@@ -13,7 +13,15 @@ func OutboxForIncomingState(state SessionState) ([]OutboxEvent, error) {
 
 	switch s := state.(type) {
 	case *ReceiveResolving:
-		return nil, nil
+		return []OutboxEvent{
+			&QueryIncomingTransferRequest{
+				SessionID: s.SessionID,
+				RecipientPkScript: append(
+					[]byte(nil), s.RecipientPkScript...,
+				),
+				RecipientEventID: s.RecipientEventID,
+			},
+		}, nil
 
 	case *ReceiveNotified:
 		recipients, err := ExtractArkRecipients(s.ArkPSBT)

--- a/oor/resume.go
+++ b/oor/resume.go
@@ -22,7 +22,7 @@ func OutboxForIncomingState(state SessionState) ([]OutboxEvent, error) {
 		}
 
 		return []OutboxEvent{
-			&MaterializeIncomingVTXOsRequest{
+			&QueryIncomingMetadataRequest{
 				SessionID:            s.SessionID,
 				ArkPSBT:              s.ArkPSBT,
 				FinalCheckpointPSBTs: s.FinalCheckpointPSBTs,

--- a/oor/session.go
+++ b/oor/session.go
@@ -44,10 +44,12 @@ func NewSession(ctx context.Context, policy scripts.CheckpointPolicy,
 	startupID := SessionID{}
 
 	fsmCfg := StateMachineCfg{
-		Logger:        log.WithPrefix(startupID.LogPrefix()),
-		ErrorReporter: newContextErrorReporter(ctx, startupID.LogPrefix()),
-		InitialState:  &Idle{},
-		Env:           env,
+		Logger: log.WithPrefix(startupID.LogPrefix()),
+		ErrorReporter: newContextErrorReporter(
+			ctx, startupID.LogPrefix(),
+		),
+		InitialState: &Idle{},
+		Env:          env,
 	}
 
 	sm := protofsm.NewStateMachine(fsmCfg)

--- a/serverconn/AGENTS.md
+++ b/serverconn/AGENTS.md
@@ -9,13 +9,15 @@ background ingress polling with event routing.
 ## Key Types
 
 - `Runtime` — Main entry point wrapping DurableActor, ServerConnectionActor, and UnaryFacade.
-- `ServerConnectionActor` — Core behavior handling egress messages and the ingress loop.
+- `ServerConnectionActor` — Core behavior handling egress messages and the ingress loop. Dispatches `DurableUnaryQuery` values generically via `buildDurableUnary`.
 - `UnaryFacade` — Implements `mailboxrpc.RPCClient` for generated RPC stubs (low-latency path). Also provides `AwaitRPCTimeout` for bounded waits.
-- `ConnectorConfig` — Wiring configuration (edge address, mailbox IDs, dispatchers, store, durable unary builder).
+- `ConnectorConfig` — Wiring configuration (edge address, mailbox IDs, dispatchers, store, durable unary builder). The `DurableUnaryBuilder` field must be set to handle `DurableUnaryQuery` message types; otherwise those messages are rejected.
 - `AckState` — Four-cursor watermark state machine (PullCursor, DispatchCommittedTo, AckTarget, AckCommittedTo).
 - `SendUnaryRequest` — Durable typed unary request that becomes a real unary RPC after commit. The response arrives via KIND_RESPONSE and, if no in-memory waiter exists, falls back to durable route dispatch via the EventRouter.
-- `DurableUnaryBuilder` — Proof-gated request-body builder used by transport-native durable query messages.
-- `SendListOORRecipientEventsByScriptRequest` / `SendListVTXOsByScriptsRequest` — transport-native durable indexer query messages emitted by OOR receive.
+- `DurableUnaryRequestBuilder` — Interface for proof-gated request-body construction. Implementations build the actual proto request (e.g., with signed proofs) at send time, not at persist time. The interface is provided via `ConnectorConfig.DurableUnaryBuilder`.
+- `DurableUnaryQuery` — Interface implemented by transport-native durable query messages that persist raw query parameters (not a full proto). The `ServerConnectionActor` matches any `DurableUnaryQuery` generically in its `Receive` loop and calls `buildDurableUnary` to construct a `SendUnaryRequest` on the fly, using `BuildBody`, `QueryCorrelationID`, `QueryMsgID`, `QueryIdempotencyKey`, and `ServiceMethod`.
+- `SendListOORRecipientEventsByScriptRequest` — TLV-durable (type `2003`) indexer query message for phase-1 OOR receive resolution. Persists PkScript, AfterEventID, Limit, and CorrelationID; the proof-gated proto body is built at send time by `DurableUnaryRequestBuilder.BuildListOORRecipientEventsByScriptRequest`.
+- `SendListVTXOsByScriptsRequest` — TLV-durable (type `2004`) indexer query message for phase-2 OOR metadata resolution. Persists PkScripts (count-prefixed, length-prefixed list), AfterCursor, Limit, and CorrelationID; the proof-gated proto body is built by `DurableUnaryRequestBuilder.BuildListVTXOsByScriptsRequest`.
 
 ## Relationships
 
@@ -39,6 +41,8 @@ background ingress polling with event routing.
 - `SendClientEventRequest` auto-derives `Service`/`Method` from `Message.ServiceMethod()` when callers leave them empty, preventing silent drops.
 - Idempotency keys are derived from message payload hash; same key on retry enables server deduplication.
 - Ingress loop checkpoints pull cursor and ack state; on restart, resumes from checkpoint.
+- `DurableUnaryQuery` values are handled generically in `ServerConnectionActor.Receive` via `buildDurableUnary`: the query is converted to a `SendUnaryRequest` using the configured `DurableUnaryRequestBuilder`. Adding a new durable indexer query type requires only implementing `DurableUnaryQuery` — no new `Receive` case is needed.
+- `DurableUnaryQuery` implementations must produce stable identity bytes in `BuildBody` so that `MsgID` and `IdempotencyKey` are deterministic across restarts (auto-derived via `mailboxconn.StableEventMsgID` / `StableEventIdempotencyKey` when the caller leaves them empty).
 
 ## Deep Docs
 

--- a/serverconn/CLAUDE.md
+++ b/serverconn/CLAUDE.md
@@ -9,13 +9,15 @@ background ingress polling with event routing.
 ## Key Types
 
 - `Runtime` — Main entry point wrapping DurableActor, ServerConnectionActor, and UnaryFacade.
-- `ServerConnectionActor` — Core behavior handling egress messages and the ingress loop.
+- `ServerConnectionActor` — Core behavior handling egress messages and the ingress loop. Dispatches `DurableUnaryQuery` values generically via `buildDurableUnary`.
 - `UnaryFacade` — Implements `mailboxrpc.RPCClient` for generated RPC stubs (low-latency path). Also provides `AwaitRPCTimeout` for bounded waits.
-- `ConnectorConfig` — Wiring configuration (edge address, mailbox IDs, dispatchers, store, durable unary builder).
+- `ConnectorConfig` — Wiring configuration (edge address, mailbox IDs, dispatchers, store, durable unary builder). The `DurableUnaryBuilder` field must be set to handle `DurableUnaryQuery` message types; otherwise those messages are rejected.
 - `AckState` — Four-cursor watermark state machine (PullCursor, DispatchCommittedTo, AckTarget, AckCommittedTo).
 - `SendUnaryRequest` — Durable typed unary request that becomes a real unary RPC after commit. The response arrives via KIND_RESPONSE and, if no in-memory waiter exists, falls back to durable route dispatch via the EventRouter.
-- `DurableUnaryBuilder` — Proof-gated request-body builder used by transport-native durable query messages.
-- `SendListOORRecipientEventsByScriptRequest` / `SendListVTXOsByScriptsRequest` — transport-native durable indexer query messages emitted by OOR receive.
+- `DurableUnaryRequestBuilder` — Interface for proof-gated request-body construction. Implementations build the actual proto request (e.g., with signed proofs) at send time, not at persist time. The interface is provided via `ConnectorConfig.DurableUnaryBuilder`.
+- `DurableUnaryQuery` — Interface implemented by transport-native durable query messages that persist raw query parameters (not a full proto). The `ServerConnectionActor` matches any `DurableUnaryQuery` generically in its `Receive` loop and calls `buildDurableUnary` to construct a `SendUnaryRequest` on the fly, using `BuildBody`, `QueryCorrelationID`, `QueryMsgID`, `QueryIdempotencyKey`, and `ServiceMethod`.
+- `SendListOORRecipientEventsByScriptRequest` — TLV-durable (type `2003`) indexer query message for phase-1 OOR receive resolution. Persists PkScript, AfterEventID, Limit, and CorrelationID; the proof-gated proto body is built at send time by `DurableUnaryRequestBuilder.BuildListOORRecipientEventsByScriptRequest`.
+- `SendListVTXOsByScriptsRequest` — TLV-durable (type `2004`) indexer query message for phase-2 OOR metadata resolution. Persists PkScripts (count-prefixed, length-prefixed list), AfterCursor, Limit, and CorrelationID; the proof-gated proto body is built by `DurableUnaryRequestBuilder.BuildListVTXOsByScriptsRequest`.
 
 ## Relationships
 
@@ -39,6 +41,8 @@ background ingress polling with event routing.
 - `SendClientEventRequest` auto-derives `Service`/`Method` from `Message.ServiceMethod()` when callers leave them empty, preventing silent drops.
 - Idempotency keys are derived from message payload hash; same key on retry enables server deduplication.
 - Ingress loop checkpoints pull cursor and ack state; on restart, resumes from checkpoint.
+- `DurableUnaryQuery` values are handled generically in `ServerConnectionActor.Receive` via `buildDurableUnary`: the query is converted to a `SendUnaryRequest` using the configured `DurableUnaryRequestBuilder`. Adding a new durable indexer query type requires only implementing `DurableUnaryQuery` — no new `Receive` case is needed.
+- `DurableUnaryQuery` implementations must produce stable identity bytes in `BuildBody` so that `MsgID` and `IdempotencyKey` are deterministic across restarts (auto-derived via `mailboxconn.StableEventMsgID` / `StableEventIdempotencyKey` when the caller leaves them empty).
 
 ## Deep Docs
 


### PR DESCRIPTION
In this PR, we add the core OOR receive FSM logic that allows a client to
accept incoming out-of-round transfers. The receive path follows a
three-phase async pattern where each phase boundary is a durable message,
so the entire flow survives actor restarts without re-issuing queries or
losing state.

The three phases are:

1. **ReceiveResolving**: the actor persists a lightweight
   `ResolveIncomingTransferRequest` hint (session ID, pk_script, event ID)
   and emits a transport-native durable query to fetch the full OOR package
   from the indexer. No inline RPC inside the actor transaction.

2. **ReceiveMetadataResolving**: after the package data arrives, the actor
   emits a second durable query (`ListVTXOsByScripts`) to fetch
   authoritative VTXO lineage metadata (round ID, commitment txid, tree
   path, batch expiry, chain depth) from the indexer's inventory.

3. **ReceiveMaterializing**: with full metadata in hand, the actor calls
   `BuildIncomingVTXODescriptor` to construct the local VTXO record and
   persists it through the wallet's materialization path.

`AdaptIncomingOOREvent` in `incoming_adapter.go` is the shared entry point
for converting a lightweight `IncomingOOREvent` notification into a durable
`ResolveIncomingTransferRequest`. Both the production daemon and the systest
harness use this same adapter.

The `LocalPersistenceOutboxHandler` is extended with async materialization
support. Rather than issuing the metadata query synchronously inside the
actor's DB transaction (which would starve SQLite's single-writer lock),
the handler emits a `QueryIncomingMetadataRequest` outbox message that the
transport resolves post-commit. The response arrives as a fresh
`IncomingMetadataResolvedEvent` and drives the final materialization step.

We also add `NewOutboxHandler` as a shared factory in `outbox_factory.go`
for constructing the standard two-layer outbox handler chain
(LocalPersistenceOutboxHandler → SigningOutboxHandler), and a collaborative
leaf validation check in `checkpoint_sign.go` that verifies the 2-of-2
multisig structure before signing checkpoint outputs.

Builds on #188.