### PR TITLE
darepod+cli: wire OOR receive path with daemon, RPC, and CLI

### DIFF
--- a/cmd/darepocli/darepoclicommands/cmd_mcp.go
+++ b/cmd/darepocli/darepoclicommands/cmd_mcp.go
@@ -322,11 +322,11 @@ func registerMCPSendTools(s *mcp.Server,
 
 	// send_oor — out-of-round send.
 	type sendOORArgs struct {
-		Address        string `json:"address,omitempty" jsonschema:"recipient address (mutually exclusive with pubkey_xonly_hex and pk_script_hex)"`                            //nolint:ll
+		Address        string `json:"address,omitempty" jsonschema:"recipient address (mutually exclusive with pubkey_xonly_hex and pk_script_hex)"`                   //nolint:ll
 		PubKeyXOnlyHex string `json:"pubkey_xonly_hex,omitempty" jsonschema:"recipient 32-byte x-only pubkey hex (mutually exclusive with address and pk_script_hex)"` //nolint:ll
-		PkScriptHex    string `json:"pk_script_hex,omitempty" jsonschema:"recipient raw pk_script hex (mutually exclusive with address and pubkey_xonly_hex)"`            //nolint:ll
-		AmountSat      int64  `json:"amount_sat" jsonschema:"amount in sats"`                                      //nolint:ll
-		DryRun         bool   `json:"dry_run,omitempty" jsonschema:"validate without initiating"`                  //nolint:ll
+		PkScriptHex    string `json:"pk_script_hex,omitempty" jsonschema:"recipient raw pk_script hex (mutually exclusive with address and pubkey_xonly_hex)"`         //nolint:ll
+		AmountSat      int64  `json:"amount_sat" jsonschema:"amount in sats"`                                                                                          //nolint:ll
+		DryRun         bool   `json:"dry_run,omitempty" jsonschema:"validate without initiating"`                                                                      //nolint:ll
 	}
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "send_oor",

--- a/cmd/darepocli/darepoclicommands/cmd_mcp.go
+++ b/cmd/darepocli/darepoclicommands/cmd_mcp.go
@@ -162,6 +162,31 @@ func registerMCPTools(s *mcp.Server,
 	// agent logs or provider APIs. Use the CLI directly for wallet
 	// setup. See #164 and #165 for secure agent wallet init plans.
 
+	// oor_receive — fresh OOR receive script.
+	type oorReceiveArgs struct {
+		Label string `json:"label,omitempty" jsonschema:"optional indexer registration label"` //nolint:ll
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "oor_receive",
+		Description: "Allocate a fresh OOR receive script",
+	}, func(ctx context.Context,
+		req *mcp.CallToolRequest,
+		args oorReceiveArgs) (*mcp.CallToolResult, any, error) {
+
+		resp, err := client.NewOORReceiveScript(
+			ctx, &daemonrpc.NewOORReceiveScriptRequest{
+				Label: args.Label,
+			},
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		r, err := mcpResult(resp)
+
+		return r, nil, err
+	})
+
 	// vtxos_list — with optional filters.
 	type vtxosListArgs struct {
 		StatusFilter string `json:"status_filter,omitempty" jsonschema:"VTXO status filter (live, spent, expiring, etc.)"` //nolint:ll
@@ -297,9 +322,11 @@ func registerMCPSendTools(s *mcp.Server,
 
 	// send_oor — out-of-round send.
 	type sendOORArgs struct {
-		Address   string `json:"address" jsonschema:"recipient address"`                     //nolint:ll
-		AmountSat int64  `json:"amount_sat" jsonschema:"amount in sats"`                     //nolint:ll
-		DryRun    bool   `json:"dry_run,omitempty" jsonschema:"validate without initiating"` //nolint:ll
+		Address        string `json:"address,omitempty" jsonschema:"recipient address (mutually exclusive with pubkey_xonly_hex and pk_script_hex)"`                            //nolint:ll
+		PubKeyXOnlyHex string `json:"pubkey_xonly_hex,omitempty" jsonschema:"recipient 32-byte x-only pubkey hex (mutually exclusive with address and pk_script_hex)"` //nolint:ll
+		PkScriptHex    string `json:"pk_script_hex,omitempty" jsonschema:"recipient raw pk_script hex (mutually exclusive with address and pubkey_xonly_hex)"`            //nolint:ll
+		AmountSat      int64  `json:"amount_sat" jsonschema:"amount in sats"`                                      //nolint:ll
+		DryRun         bool   `json:"dry_run,omitempty" jsonschema:"validate without initiating"`                  //nolint:ll
 	}
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "send_oor",
@@ -308,15 +335,18 @@ func registerMCPSendTools(s *mcp.Server,
 		req *mcp.CallToolRequest,
 		args sendOORArgs) (*mcp.CallToolResult, any, error) {
 
+		recipient, err := buildOORRecipientOutput(
+			args.Address, args.PubKeyXOnlyHex,
+			args.PkScriptHex, args.AmountSat,
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+
 		resp, err := client.SendOOR(
 			ctx, &daemonrpc.SendOORRequest{
-				Recipient: &daemonrpc.Output{
-					Destination: &daemonrpc.Output_Address{
-						Address: args.Address,
-					},
-					AmountSat: args.AmountSat,
-				},
-				DryRun: args.DryRun,
+				Recipient: recipient,
+				DryRun:    args.DryRun,
 			},
 		)
 		if err != nil {

--- a/cmd/darepocli/darepoclicommands/cmd_oor.go
+++ b/cmd/darepocli/darepoclicommands/cmd_oor.go
@@ -1,0 +1,70 @@
+package darepoclicommands
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/spf13/cobra"
+)
+
+// newOORCmd creates the oor parent command with receive-target subcommands.
+func newOORCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "oor",
+		Short: "Out-of-round operations",
+		Long: "Manage out-of-round receive targets and other direct " +
+			"transfer helpers.",
+	}
+
+	cmd.AddCommand(
+		newOORReceiveCmd(),
+	)
+
+	return cmd
+}
+
+// newOORReceiveCmd creates the oor receive subcommand.
+func newOORReceiveCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "receive",
+		Short: "Allocate a fresh OOR receive script",
+		Long: "Allocates a fresh wallet key, registers the matching " +
+			"taproot OOR receive script with the indexer, and " +
+			"prints the resulting destination details.",
+		RunE: oorReceive,
+	}
+
+	cmd.Flags().String("label", "",
+		"optional label stored with the receive-script registration")
+
+	return cmd
+}
+
+// oorReceive executes the NewOORReceiveScript RPC.
+func oorReceive(cmd *cobra.Command, _ []string) error {
+	client, conn, err := getDaemonClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	req := &daemonrpc.NewOORReceiveScriptRequest{}
+	if err := parseRequest(cmd, req, func() error {
+		label, _ := cmd.Flags().GetString("label")
+		req.Label = label
+
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	resp, err := client.NewOORReceiveScript(
+		context.Background(), req,
+	)
+	if err != nil {
+		return fmt.Errorf("NewOORReceiveScript RPC failed: %w", err)
+	}
+
+	return printJSON(resp)
+}

--- a/cmd/darepocli/darepoclicommands/cmd_send.go
+++ b/cmd/darepocli/darepoclicommands/cmd_send.go
@@ -131,11 +131,21 @@ func newSendOORCmd() *cobra.Command {
 	cmd.Flags().String("to", "",
 		"recipient address")
 
+	cmd.Flags().String("pubkey", "",
+		"recipient 32-byte x-only pubkey hex")
+
+	cmd.Flags().String("pk_script", "",
+		"recipient raw pk_script hex")
+
 	cmd.Flags().Int64("amount", 0,
 		"amount in sats")
 
 	cmd.Flags().Bool("dry_run", false,
 		"validate without initiating")
+
+	cmd.MarkFlagsMutuallyExclusive(
+		"to", "pubkey", "pk_script",
+	)
 
 	return cmd
 }
@@ -151,24 +161,19 @@ func sendOOR(cmd *cobra.Command, _ []string) error {
 	req := &daemonrpc.SendOORRequest{}
 	if err := parseRequest(cmd, req, func() error {
 		address, _ := cmd.Flags().GetString("to")
+		pubKeyHex, _ := cmd.Flags().GetString("pubkey")
+		pkScriptHex, _ := cmd.Flags().GetString("pk_script")
 		amount, _ := cmd.Flags().GetInt64("amount")
 		dryRun, _ := cmd.Flags().GetBool("dry_run")
 
-		if address == "" {
-			return fmt.Errorf("--to is required")
+		recipient, err := buildOORRecipientOutput(
+			address, pubKeyHex, pkScriptHex, amount,
+		)
+		if err != nil {
+			return err
 		}
 
-		if amount <= 0 {
-			return fmt.Errorf(
-				"--amount must be positive")
-		}
-
-		req.Recipient = &daemonrpc.Output{
-			Destination: &daemonrpc.Output_Address{
-				Address: address,
-			},
-			AmountSat: amount,
-		}
+		req.Recipient = recipient
 		req.DryRun = dryRun
 
 		return nil

--- a/cmd/darepocli/darepoclicommands/oor_destination.go
+++ b/cmd/darepocli/darepoclicommands/oor_destination.go
@@ -1,0 +1,112 @@
+package darepoclicommands
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+)
+
+const (
+	// oorPubKeyHexLen is the hex length of a 32-byte x-only pubkey.
+	oorPubKeyHexLen = schnorr.PubKeyBytesLen * 2
+)
+
+// buildOORRecipientOutput converts the user-facing OOR destination flags or
+// MCP args into the daemonrpc Output used by SendOOR.
+func buildOORRecipientOutput(address, pubKeyHex, pkScriptHex string,
+	amount int64) (*daemonrpc.Output, error) {
+
+	if amount <= 0 {
+		return nil, fmt.Errorf("amount must be positive")
+	}
+
+	address = strings.TrimSpace(address)
+	pubKeyHex = strings.TrimSpace(pubKeyHex)
+	pkScriptHex = strings.TrimSpace(pkScriptHex)
+
+	destinations := 0
+	if address != "" {
+		destinations++
+	}
+	if pubKeyHex != "" {
+		destinations++
+	}
+	if pkScriptHex != "" {
+		destinations++
+	}
+
+	if destinations != 1 {
+		return nil, fmt.Errorf("exactly one of to, pubkey, or " +
+			"pk_script is required")
+	}
+
+	output := &daemonrpc.Output{
+		AmountSat: amount,
+	}
+
+	switch {
+	case address != "":
+		output.Destination = &daemonrpc.Output_Address{
+			Address: address,
+		}
+
+	case pubKeyHex != "":
+		pubKey, err := parseOORPubKeyHex(pubKeyHex)
+		if err != nil {
+			return nil, err
+		}
+
+		output.Destination = &daemonrpc.Output_Pubkey{
+			Pubkey: pubKey,
+		}
+
+	case pkScriptHex != "":
+		pkScript, err := parseOORPkScriptHex(pkScriptHex)
+		if err != nil {
+			return nil, err
+		}
+
+		output.Destination = &daemonrpc.Output_PkScript{
+			PkScript: pkScript,
+		}
+	}
+
+	return output, nil
+}
+
+// parseOORPubKeyHex validates and decodes a 32-byte x-only schnorr pubkey.
+func parseOORPubKeyHex(pubKeyHex string) ([]byte, error) {
+	if len(pubKeyHex) != oorPubKeyHexLen {
+		return nil, fmt.Errorf("pubkey must be %d hex chars "+
+			"(32-byte x-only key)", oorPubKeyHexLen)
+	}
+
+	pubKeyBytes, err := hex.DecodeString(pubKeyHex)
+	if err != nil {
+		return nil, fmt.Errorf("invalid pubkey hex: %w", err)
+	}
+
+	pubKey, err := schnorr.ParsePubKey(pubKeyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("invalid x-only pubkey: %w", err)
+	}
+
+	return schnorr.SerializePubKey(pubKey), nil
+}
+
+// parseOORPkScriptHex validates and decodes a raw output script hex string.
+func parseOORPkScriptHex(pkScriptHex string) ([]byte, error) {
+	pkScript, err := hex.DecodeString(pkScriptHex)
+	if err != nil {
+		return nil, fmt.Errorf("invalid pk_script hex: %w", err)
+	}
+
+	if len(pkScript) == 0 {
+		return nil, fmt.Errorf("pk_script must not be empty")
+	}
+
+	return pkScript, nil
+}

--- a/cmd/darepocli/darepoclicommands/oor_destination_test.go
+++ b/cmd/darepocli/darepoclicommands/oor_destination_test.go
@@ -1,0 +1,166 @@
+package darepoclicommands
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildOORRecipientOutputAddress verifies address destinations are passed
+// through unchanged.
+func TestBuildOORRecipientOutputAddress(t *testing.T) {
+	t.Parallel()
+
+	output, err := buildOORRecipientOutput(
+		"tb1ptestdestination", "", "", 12_345,
+	)
+	require.NoError(t, err)
+
+	addr, ok := output.Destination.(*daemonrpc.Output_Address)
+	require.True(t, ok)
+	require.Equal(t, "tb1ptestdestination", addr.Address)
+	require.EqualValues(t, 12_345, output.AmountSat)
+}
+
+// TestBuildOORRecipientOutputPubKey verifies x-only pubkey destinations are
+// decoded and normalized.
+func TestBuildOORRecipientOutputPubKey(t *testing.T) {
+	t.Parallel()
+
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	pubKeyHex := schnorr.SerializePubKey(privKey.PubKey())
+
+	output, err := buildOORRecipientOutput(
+		"", hex.EncodeToString(pubKeyHex), "", 9_999,
+	)
+	require.NoError(t, err)
+
+	pubKey, ok := output.Destination.(*daemonrpc.Output_Pubkey)
+	require.True(t, ok)
+	require.Equal(t, pubKeyHex, pubKey.Pubkey)
+	require.EqualValues(t, 9_999, output.AmountSat)
+}
+
+// TestBuildOORRecipientOutputPkScript verifies pk_script destinations are
+// decoded from hex.
+func TestBuildOORRecipientOutputPkScript(t *testing.T) {
+	t.Parallel()
+
+	output, err := buildOORRecipientOutput(
+		"", "", "5120deadbeef", 4_321,
+	)
+	require.NoError(t, err)
+
+	pkScript, ok := output.Destination.(*daemonrpc.Output_PkScript)
+	require.True(t, ok)
+	require.Equal(t, []byte{0x51, 0x20, 0xde, 0xad, 0xbe, 0xef},
+		pkScript.PkScript)
+	require.EqualValues(t, 4_321, output.AmountSat)
+}
+
+// TestBuildOORRecipientOutputValidation verifies the helper rejects ambiguous
+// or malformed destinations.
+func TestBuildOORRecipientOutputValidation(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		address     string
+		pubKeyHex   string
+		pkScriptHex string
+		amount      int64
+		errContains string
+	}{
+		{
+			name:        "missing destination",
+			amount:      1,
+			errContains: "exactly one",
+		},
+		{
+			name:        "multiple destinations",
+			address:     "tb1paddr",
+			pubKeyHex:   "00",
+			amount:      1,
+			errContains: "exactly one",
+		},
+		{
+			name:        "non-positive amount",
+			address:     "tb1paddr",
+			errContains: "amount must be positive",
+		},
+		{
+			name:        "short pubkey",
+			pubKeyHex:   "00",
+			amount:      1,
+			errContains: "32-byte x-only key",
+		},
+		{
+			name:        "invalid pkscript hex",
+			pkScriptHex: "zz",
+			amount:      1,
+			errContains: "invalid pk_script hex",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := buildOORRecipientOutput(
+				testCase.address, testCase.pubKeyHex,
+				testCase.pkScriptHex, testCase.amount,
+			)
+			require.ErrorContains(t, err, testCase.errContains)
+		})
+	}
+}
+
+// TestMethodRegistrySendOORSchema verifies the schema advertises all OOR send
+// destination forms.
+func TestMethodRegistrySendOORSchema(t *testing.T) {
+	t.Parallel()
+
+	method := findSchemaMethod(t, "send.oor")
+	paramNames := make([]string, 0, len(method.Params))
+	for _, param := range method.Params {
+		paramNames = append(paramNames, param.Name)
+	}
+
+	require.Contains(t, paramNames, "to")
+	require.Contains(t, paramNames, "pubkey")
+	require.Contains(t, paramNames, "pk_script")
+	require.Contains(t, paramNames, "amount")
+}
+
+// TestMethodRegistryOORReceiveSchema verifies the public schema still exposes
+// OOR receive allocation.
+func TestMethodRegistryOORReceiveSchema(t *testing.T) {
+	t.Parallel()
+
+	method := findSchemaMethod(t, "oor.receive")
+	require.Equal(t, "NewOORReceiveScriptRequest", method.RequestType)
+	require.Equal(t, "NewOORReceiveScriptResponse", method.ResponseType)
+}
+
+// findSchemaMethod locates a method entry in the CLI schema registry.
+func findSchemaMethod(t *testing.T, methodName string) schemaMethod {
+	t.Helper()
+
+	for _, method := range methodRegistry() {
+		if method.Method == methodName {
+			return method
+		}
+	}
+
+	t.Fatalf("method %q not found", methodName)
+
+	return schemaMethod{}
+}

--- a/cmd/darepocli/darepoclicommands/root.go
+++ b/cmd/darepocli/darepoclicommands/root.go
@@ -53,6 +53,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(
 		newGetInfoCmd(),
 		newWalletCmd(),
+		newOORCmd(),
 		newVTXOsCmd(),
 		newSendCmd(),
 		newBoardCmd(),

--- a/cmd/darepocli/darepoclicommands/schema_registry.go
+++ b/cmd/darepocli/darepoclicommands/schema_registry.go
@@ -110,6 +110,21 @@ func methodRegistry() []schemaMethod {
 			JSONInput:    true,
 		},
 		{
+			Method:      "oor.receive",
+			Description: "Allocate a fresh OOR receive script",
+			Params: []schemaParam{
+				{
+					Name: "label",
+					Type: "string",
+					Description: "optional indexer " +
+						"registration label",
+				},
+			},
+			RequestType:  "NewOORReceiveScriptRequest",
+			ResponseType: "NewOORReceiveScriptResponse",
+			JSONInput:    true,
+		},
+		{
 			Method:      "vtxos.list",
 			Description: "List VTXOs with optional filters",
 			Params: []schemaParam{

--- a/cmd/darepocli/darepoclicommands/schema_registry.go
+++ b/cmd/darepocli/darepoclicommands/schema_registry.go
@@ -213,10 +213,27 @@ func methodRegistry() []schemaMethod {
 			Description: "Send via out-of-round transfer",
 			Params: []schemaParam{
 				{
-					Name:        "to",
-					Type:        "string",
-					Required:    true,
-					Description: "recipient address",
+					Name: "to",
+					Type: "string",
+					Description: "recipient address " +
+						"(exactly one of to, pubkey, " +
+						"or pk_script)",
+				},
+				{
+					Name: "pubkey",
+					Type: "string",
+					Description: "recipient 32-byte " +
+						"x-only pubkey hex (exactly " +
+						"one of to, pubkey, or " +
+						"pk_script)",
+				},
+				{
+					Name: "pk_script",
+					Type: "string",
+					Description: "recipient raw " +
+						"pk_script hex (exactly one " +
+						"of to, pubkey, or " +
+						"pk_script)",
 				},
 				{
 					Name:        "amount",

--- a/daemonrpc/daemon.pb.go
+++ b/daemonrpc/daemon.pb.go
@@ -1119,6 +1119,133 @@ func (x *NewAddressResponse) GetAddress() string {
 	return ""
 }
 
+type NewOORReceiveScriptRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// label is an optional human-readable label stored with the
+	// registration on the indexer.
+	Label         string `protobuf:"bytes,1,opt,name=label,proto3" json:"label,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *NewOORReceiveScriptRequest) Reset() {
+	*x = NewOORReceiveScriptRequest{}
+	mi := &file_daemon_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *NewOORReceiveScriptRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*NewOORReceiveScriptRequest) ProtoMessage() {}
+
+func (x *NewOORReceiveScriptRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use NewOORReceiveScriptRequest.ProtoReflect.Descriptor instead.
+func (*NewOORReceiveScriptRequest) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *NewOORReceiveScriptRequest) GetLabel() string {
+	if x != nil {
+		return x.Label
+	}
+	return ""
+}
+
+type NewOORReceiveScriptResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// pk_script_hex is the raw taproot output script encoded as hex.
+	PkScriptHex string `protobuf:"bytes,1,opt,name=pk_script_hex,json=pkScriptHex,proto3" json:"pk_script_hex,omitempty"`
+	// pubkey_xonly_hex is the 32-byte x-only owner pubkey encoded as hex.
+	PubkeyXonlyHex string `protobuf:"bytes,2,opt,name=pubkey_xonly_hex,json=pubkeyXonlyHex,proto3" json:"pubkey_xonly_hex,omitempty"`
+	// key_family is the wallet key family used to derive the receive key.
+	KeyFamily uint32 `protobuf:"varint,3,opt,name=key_family,json=keyFamily,proto3" json:"key_family,omitempty"`
+	// key_index is the wallet key index used to derive the receive key.
+	KeyIndex uint32 `protobuf:"varint,4,opt,name=key_index,json=keyIndex,proto3" json:"key_index,omitempty"`
+	// label is the registration label stored with the indexer.
+	Label         string `protobuf:"bytes,5,opt,name=label,proto3" json:"label,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *NewOORReceiveScriptResponse) Reset() {
+	*x = NewOORReceiveScriptResponse{}
+	mi := &file_daemon_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *NewOORReceiveScriptResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*NewOORReceiveScriptResponse) ProtoMessage() {}
+
+func (x *NewOORReceiveScriptResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use NewOORReceiveScriptResponse.ProtoReflect.Descriptor instead.
+func (*NewOORReceiveScriptResponse) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *NewOORReceiveScriptResponse) GetPkScriptHex() string {
+	if x != nil {
+		return x.PkScriptHex
+	}
+	return ""
+}
+
+func (x *NewOORReceiveScriptResponse) GetPubkeyXonlyHex() string {
+	if x != nil {
+		return x.PubkeyXonlyHex
+	}
+	return ""
+}
+
+func (x *NewOORReceiveScriptResponse) GetKeyFamily() uint32 {
+	if x != nil {
+		return x.KeyFamily
+	}
+	return 0
+}
+
+func (x *NewOORReceiveScriptResponse) GetKeyIndex() uint32 {
+	if x != nil {
+		return x.KeyIndex
+	}
+	return 0
+}
+
+func (x *NewOORReceiveScriptResponse) GetLabel() string {
+	if x != nil {
+		return x.Label
+	}
+	return ""
+}
+
 // Output describes a single recipient in a send operation.
 type Output struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -1136,7 +1263,7 @@ type Output struct {
 
 func (x *Output) Reset() {
 	*x = Output{}
-	mi := &file_daemon_proto_msgTypes[15]
+	mi := &file_daemon_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1148,7 +1275,7 @@ func (x *Output) String() string {
 func (*Output) ProtoMessage() {}
 
 func (x *Output) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[15]
+	mi := &file_daemon_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1161,7 +1288,7 @@ func (x *Output) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Output.ProtoReflect.Descriptor instead.
 func (*Output) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{15}
+	return file_daemon_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *Output) GetDestination() isOutput_Destination {
@@ -1247,7 +1374,7 @@ type SendVTXORequest struct {
 
 func (x *SendVTXORequest) Reset() {
 	*x = SendVTXORequest{}
-	mi := &file_daemon_proto_msgTypes[16]
+	mi := &file_daemon_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1259,7 +1386,7 @@ func (x *SendVTXORequest) String() string {
 func (*SendVTXORequest) ProtoMessage() {}
 
 func (x *SendVTXORequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[16]
+	mi := &file_daemon_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1272,7 +1399,7 @@ func (x *SendVTXORequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendVTXORequest.ProtoReflect.Descriptor instead.
 func (*SendVTXORequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{16}
+	return file_daemon_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *SendVTXORequest) GetRecipients() []*Output {
@@ -1306,7 +1433,7 @@ type SendVTXOResponse struct {
 
 func (x *SendVTXOResponse) Reset() {
 	*x = SendVTXOResponse{}
-	mi := &file_daemon_proto_msgTypes[17]
+	mi := &file_daemon_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1318,7 +1445,7 @@ func (x *SendVTXOResponse) String() string {
 func (*SendVTXOResponse) ProtoMessage() {}
 
 func (x *SendVTXOResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[17]
+	mi := &file_daemon_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1331,7 +1458,7 @@ func (x *SendVTXOResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendVTXOResponse.ProtoReflect.Descriptor instead.
 func (*SendVTXOResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{17}
+	return file_daemon_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *SendVTXOResponse) GetStatus() string {
@@ -1367,7 +1494,7 @@ type SendOORRequest struct {
 
 func (x *SendOORRequest) Reset() {
 	*x = SendOORRequest{}
-	mi := &file_daemon_proto_msgTypes[18]
+	mi := &file_daemon_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1379,7 +1506,7 @@ func (x *SendOORRequest) String() string {
 func (*SendOORRequest) ProtoMessage() {}
 
 func (x *SendOORRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[18]
+	mi := &file_daemon_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1392,7 +1519,7 @@ func (x *SendOORRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendOORRequest.ProtoReflect.Descriptor instead.
 func (*SendOORRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{18}
+	return file_daemon_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *SendOORRequest) GetRecipient() *Output {
@@ -1422,7 +1549,7 @@ type SendOORResponse struct {
 
 func (x *SendOORResponse) Reset() {
 	*x = SendOORResponse{}
-	mi := &file_daemon_proto_msgTypes[19]
+	mi := &file_daemon_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1434,7 +1561,7 @@ func (x *SendOORResponse) String() string {
 func (*SendOORResponse) ProtoMessage() {}
 
 func (x *SendOORResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[19]
+	mi := &file_daemon_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1447,7 +1574,7 @@ func (x *SendOORResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendOORResponse.ProtoReflect.Descriptor instead.
 func (*SendOORResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{19}
+	return file_daemon_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *SendOORResponse) GetStatus() string {
@@ -1477,7 +1604,7 @@ type OutpointSelection struct {
 
 func (x *OutpointSelection) Reset() {
 	*x = OutpointSelection{}
-	mi := &file_daemon_proto_msgTypes[20]
+	mi := &file_daemon_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1489,7 +1616,7 @@ func (x *OutpointSelection) String() string {
 func (*OutpointSelection) ProtoMessage() {}
 
 func (x *OutpointSelection) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[20]
+	mi := &file_daemon_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1502,7 +1629,7 @@ func (x *OutpointSelection) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OutpointSelection.ProtoReflect.Descriptor instead.
 func (*OutpointSelection) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{20}
+	return file_daemon_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *OutpointSelection) GetOutpoints() []string {
@@ -1527,7 +1654,7 @@ type RefreshVTXOsRequest struct {
 
 func (x *RefreshVTXOsRequest) Reset() {
 	*x = RefreshVTXOsRequest{}
-	mi := &file_daemon_proto_msgTypes[21]
+	mi := &file_daemon_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1539,7 +1666,7 @@ func (x *RefreshVTXOsRequest) String() string {
 func (*RefreshVTXOsRequest) ProtoMessage() {}
 
 func (x *RefreshVTXOsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[21]
+	mi := &file_daemon_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1552,7 +1679,7 @@ func (x *RefreshVTXOsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RefreshVTXOsRequest.ProtoReflect.Descriptor instead.
 func (*RefreshVTXOsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{21}
+	return file_daemon_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *RefreshVTXOsRequest) GetSelection() isRefreshVTXOsRequest_Selection {
@@ -1619,7 +1746,7 @@ type RefreshVTXOsResponse struct {
 
 func (x *RefreshVTXOsResponse) Reset() {
 	*x = RefreshVTXOsResponse{}
-	mi := &file_daemon_proto_msgTypes[22]
+	mi := &file_daemon_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1631,7 +1758,7 @@ func (x *RefreshVTXOsResponse) String() string {
 func (*RefreshVTXOsResponse) ProtoMessage() {}
 
 func (x *RefreshVTXOsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[22]
+	mi := &file_daemon_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1644,7 +1771,7 @@ func (x *RefreshVTXOsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RefreshVTXOsResponse.ProtoReflect.Descriptor instead.
 func (*RefreshVTXOsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{22}
+	return file_daemon_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *RefreshVTXOsResponse) GetQueuedOutpoints() []string {
@@ -1669,7 +1796,7 @@ type BoardRequest struct {
 
 func (x *BoardRequest) Reset() {
 	*x = BoardRequest{}
-	mi := &file_daemon_proto_msgTypes[23]
+	mi := &file_daemon_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1681,7 +1808,7 @@ func (x *BoardRequest) String() string {
 func (*BoardRequest) ProtoMessage() {}
 
 func (x *BoardRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[23]
+	mi := &file_daemon_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1694,7 +1821,7 @@ func (x *BoardRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoardRequest.ProtoReflect.Descriptor instead.
 func (*BoardRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{23}
+	return file_daemon_proto_rawDescGZIP(), []int{25}
 }
 
 type BoardResponse struct {
@@ -1708,7 +1835,7 @@ type BoardResponse struct {
 
 func (x *BoardResponse) Reset() {
 	*x = BoardResponse{}
-	mi := &file_daemon_proto_msgTypes[24]
+	mi := &file_daemon_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1720,7 +1847,7 @@ func (x *BoardResponse) String() string {
 func (*BoardResponse) ProtoMessage() {}
 
 func (x *BoardResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[24]
+	mi := &file_daemon_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1733,7 +1860,7 @@ func (x *BoardResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoardResponse.ProtoReflect.Descriptor instead.
 func (*BoardResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{24}
+	return file_daemon_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *BoardResponse) GetStatus() string {
@@ -1756,7 +1883,7 @@ type RoundVTXOInfo struct {
 
 func (x *RoundVTXOInfo) Reset() {
 	*x = RoundVTXOInfo{}
-	mi := &file_daemon_proto_msgTypes[25]
+	mi := &file_daemon_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1768,7 +1895,7 @@ func (x *RoundVTXOInfo) String() string {
 func (*RoundVTXOInfo) ProtoMessage() {}
 
 func (x *RoundVTXOInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[25]
+	mi := &file_daemon_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1781,7 +1908,7 @@ func (x *RoundVTXOInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoundVTXOInfo.ProtoReflect.Descriptor instead.
 func (*RoundVTXOInfo) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{25}
+	return file_daemon_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *RoundVTXOInfo) GetOutpoint() string {
@@ -1820,7 +1947,7 @@ type RoundInfo struct {
 
 func (x *RoundInfo) Reset() {
 	*x = RoundInfo{}
-	mi := &file_daemon_proto_msgTypes[26]
+	mi := &file_daemon_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1832,7 +1959,7 @@ func (x *RoundInfo) String() string {
 func (*RoundInfo) ProtoMessage() {}
 
 func (x *RoundInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[26]
+	mi := &file_daemon_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1845,7 +1972,7 @@ func (x *RoundInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoundInfo.ProtoReflect.Descriptor instead.
 func (*RoundInfo) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{26}
+	return file_daemon_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *RoundInfo) GetRoundId() string {
@@ -1897,7 +2024,7 @@ type ListRoundsRequest struct {
 
 func (x *ListRoundsRequest) Reset() {
 	*x = ListRoundsRequest{}
-	mi := &file_daemon_proto_msgTypes[27]
+	mi := &file_daemon_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1909,7 +2036,7 @@ func (x *ListRoundsRequest) String() string {
 func (*ListRoundsRequest) ProtoMessage() {}
 
 func (x *ListRoundsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[27]
+	mi := &file_daemon_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1922,7 +2049,7 @@ func (x *ListRoundsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRoundsRequest.ProtoReflect.Descriptor instead.
 func (*ListRoundsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{27}
+	return file_daemon_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *ListRoundsRequest) GetPageSize() int32 {
@@ -1959,7 +2086,7 @@ type ListRoundsResponse struct {
 
 func (x *ListRoundsResponse) Reset() {
 	*x = ListRoundsResponse{}
-	mi := &file_daemon_proto_msgTypes[28]
+	mi := &file_daemon_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1971,7 +2098,7 @@ func (x *ListRoundsResponse) String() string {
 func (*ListRoundsResponse) ProtoMessage() {}
 
 func (x *ListRoundsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[28]
+	mi := &file_daemon_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1984,7 +2111,7 @@ func (x *ListRoundsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRoundsResponse.ProtoReflect.Descriptor instead.
 func (*ListRoundsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{28}
+	return file_daemon_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *ListRoundsResponse) GetRounds() []*RoundInfo {
@@ -2009,7 +2136,7 @@ type WatchRoundsRequest struct {
 
 func (x *WatchRoundsRequest) Reset() {
 	*x = WatchRoundsRequest{}
-	mi := &file_daemon_proto_msgTypes[29]
+	mi := &file_daemon_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2021,7 +2148,7 @@ func (x *WatchRoundsRequest) String() string {
 func (*WatchRoundsRequest) ProtoMessage() {}
 
 func (x *WatchRoundsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[29]
+	mi := &file_daemon_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2034,7 +2161,7 @@ func (x *WatchRoundsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchRoundsRequest.ProtoReflect.Descriptor instead.
 func (*WatchRoundsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{29}
+	return file_daemon_proto_rawDescGZIP(), []int{31}
 }
 
 type WatchRoundsResponse struct {
@@ -2048,7 +2175,7 @@ type WatchRoundsResponse struct {
 
 func (x *WatchRoundsResponse) Reset() {
 	*x = WatchRoundsResponse{}
-	mi := &file_daemon_proto_msgTypes[30]
+	mi := &file_daemon_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2060,7 +2187,7 @@ func (x *WatchRoundsResponse) String() string {
 func (*WatchRoundsResponse) ProtoMessage() {}
 
 func (x *WatchRoundsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[30]
+	mi := &file_daemon_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2073,7 +2200,7 @@ func (x *WatchRoundsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchRoundsResponse.ProtoReflect.Descriptor instead.
 func (*WatchRoundsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{30}
+	return file_daemon_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *WatchRoundsResponse) GetRound() *RoundInfo {
@@ -2144,7 +2271,16 @@ const file_daemon_proto_rawDesc = "" +
 	"\x05vtxos\x18\x01 \x03(\v2\x0f.daemonrpc.VTXOR\x05vtxos\"\x13\n" +
 	"\x11NewAddressRequest\".\n" +
 	"\x12NewAddressResponse\x12\x18\n" +
-	"\aaddress\x18\x01 \x01(\tR\aaddress\"\x8b\x01\n" +
+	"\aaddress\x18\x01 \x01(\tR\aaddress\"2\n" +
+	"\x1aNewOORReceiveScriptRequest\x12\x14\n" +
+	"\x05label\x18\x01 \x01(\tR\x05label\"\xbd\x01\n" +
+	"\x1bNewOORReceiveScriptResponse\x12\"\n" +
+	"\rpk_script_hex\x18\x01 \x01(\tR\vpkScriptHex\x12(\n" +
+	"\x10pubkey_xonly_hex\x18\x02 \x01(\tR\x0epubkeyXonlyHex\x12\x1d\n" +
+	"\n" +
+	"key_family\x18\x03 \x01(\rR\tkeyFamily\x12\x1b\n" +
+	"\tkey_index\x18\x04 \x01(\rR\bkeyIndex\x12\x14\n" +
+	"\x05label\x18\x05 \x01(\tR\x05label\"\x8b\x01\n" +
 	"\x06Output\x12\x1a\n" +
 	"\aaddress\x18\x01 \x01(\tH\x00R\aaddress\x12\x18\n" +
 	"\x06pubkey\x18\x03 \x01(\fH\x00R\x06pubkey\x12\x1d\n" +
@@ -2229,7 +2365,7 @@ const file_daemon_proto_rawDesc = "" +
 	"\x1aROUND_STATE_INPUT_SIG_SENT\x10\v\x12\x19\n" +
 	"\x15ROUND_STATE_CONFIRMED\x10\f\x12\x16\n" +
 	"\x12ROUND_STATE_FAILED\x10\r\x12\x18\n" +
-	"\x14ROUND_STATE_RECOVERY\x10\x0e2\xbc\a\n" +
+	"\x14ROUND_STATE_RECOVERY\x10\x0e2\xa2\b\n" +
 	"\rDaemonService\x12@\n" +
 	"\aGetInfo\x12\x19.daemonrpc.GetInfoRequest\x1a\x1a.daemonrpc.GetInfoResponse\x12@\n" +
 	"\aGenSeed\x12\x19.daemonrpc.GenSeedRequest\x1a\x1a.daemonrpc.GenSeedResponse\x12I\n" +
@@ -2240,7 +2376,8 @@ const file_daemon_proto_rawDesc = "" +
 	"GetBalance\x12\x1c.daemonrpc.GetBalanceRequest\x1a\x1d.daemonrpc.GetBalanceResponse\x12F\n" +
 	"\tListVTXOs\x12\x1b.daemonrpc.ListVTXOsRequest\x1a\x1c.daemonrpc.ListVTXOsResponse\x12I\n" +
 	"\n" +
-	"NewAddress\x12\x1c.daemonrpc.NewAddressRequest\x1a\x1d.daemonrpc.NewAddressResponse\x12C\n" +
+	"NewAddress\x12\x1c.daemonrpc.NewAddressRequest\x1a\x1d.daemonrpc.NewAddressResponse\x12d\n" +
+	"\x13NewOORReceiveScript\x12%.daemonrpc.NewOORReceiveScriptRequest\x1a&.daemonrpc.NewOORReceiveScriptResponse\x12C\n" +
 	"\bSendVTXO\x12\x1a.daemonrpc.SendVTXORequest\x1a\x1b.daemonrpc.SendVTXOResponse\x12@\n" +
 	"\aSendOOR\x12\x19.daemonrpc.SendOORRequest\x1a\x1a.daemonrpc.SendOORResponse\x12O\n" +
 	"\fRefreshVTXOs\x12\x1e.daemonrpc.RefreshVTXOsRequest\x1a\x1f.daemonrpc.RefreshVTXOsResponse\x12:\n" +
@@ -2262,53 +2399,55 @@ func file_daemon_proto_rawDescGZIP() []byte {
 }
 
 var file_daemon_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 31)
+var file_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
 var file_daemon_proto_goTypes = []any{
-	(VTXOStatus)(0),              // 0: daemonrpc.VTXOStatus
-	(RoundState)(0),              // 1: daemonrpc.RoundState
-	(*GetInfoRequest)(nil),       // 2: daemonrpc.GetInfoRequest
-	(*GetInfoResponse)(nil),      // 3: daemonrpc.GetInfoResponse
-	(*GenSeedRequest)(nil),       // 4: daemonrpc.GenSeedRequest
-	(*GenSeedResponse)(nil),      // 5: daemonrpc.GenSeedResponse
-	(*InitWalletRequest)(nil),    // 6: daemonrpc.InitWalletRequest
-	(*InitWalletResponse)(nil),   // 7: daemonrpc.InitWalletResponse
-	(*UnlockWalletRequest)(nil),  // 8: daemonrpc.UnlockWalletRequest
-	(*UnlockWalletResponse)(nil), // 9: daemonrpc.UnlockWalletResponse
-	(*GetBalanceRequest)(nil),    // 10: daemonrpc.GetBalanceRequest
-	(*GetBalanceResponse)(nil),   // 11: daemonrpc.GetBalanceResponse
-	(*VTXO)(nil),                 // 12: daemonrpc.VTXO
-	(*ListVTXOsRequest)(nil),     // 13: daemonrpc.ListVTXOsRequest
-	(*ListVTXOsResponse)(nil),    // 14: daemonrpc.ListVTXOsResponse
-	(*NewAddressRequest)(nil),    // 15: daemonrpc.NewAddressRequest
-	(*NewAddressResponse)(nil),   // 16: daemonrpc.NewAddressResponse
-	(*Output)(nil),               // 17: daemonrpc.Output
-	(*SendVTXORequest)(nil),      // 18: daemonrpc.SendVTXORequest
-	(*SendVTXOResponse)(nil),     // 19: daemonrpc.SendVTXOResponse
-	(*SendOORRequest)(nil),       // 20: daemonrpc.SendOORRequest
-	(*SendOORResponse)(nil),      // 21: daemonrpc.SendOORResponse
-	(*OutpointSelection)(nil),    // 22: daemonrpc.OutpointSelection
-	(*RefreshVTXOsRequest)(nil),  // 23: daemonrpc.RefreshVTXOsRequest
-	(*RefreshVTXOsResponse)(nil), // 24: daemonrpc.RefreshVTXOsResponse
-	(*BoardRequest)(nil),         // 25: daemonrpc.BoardRequest
-	(*BoardResponse)(nil),        // 26: daemonrpc.BoardResponse
-	(*RoundVTXOInfo)(nil),        // 27: daemonrpc.RoundVTXOInfo
-	(*RoundInfo)(nil),            // 28: daemonrpc.RoundInfo
-	(*ListRoundsRequest)(nil),    // 29: daemonrpc.ListRoundsRequest
-	(*ListRoundsResponse)(nil),   // 30: daemonrpc.ListRoundsResponse
-	(*WatchRoundsRequest)(nil),   // 31: daemonrpc.WatchRoundsRequest
-	(*WatchRoundsResponse)(nil),  // 32: daemonrpc.WatchRoundsResponse
+	(VTXOStatus)(0),                     // 0: daemonrpc.VTXOStatus
+	(RoundState)(0),                     // 1: daemonrpc.RoundState
+	(*GetInfoRequest)(nil),              // 2: daemonrpc.GetInfoRequest
+	(*GetInfoResponse)(nil),             // 3: daemonrpc.GetInfoResponse
+	(*GenSeedRequest)(nil),              // 4: daemonrpc.GenSeedRequest
+	(*GenSeedResponse)(nil),             // 5: daemonrpc.GenSeedResponse
+	(*InitWalletRequest)(nil),           // 6: daemonrpc.InitWalletRequest
+	(*InitWalletResponse)(nil),          // 7: daemonrpc.InitWalletResponse
+	(*UnlockWalletRequest)(nil),         // 8: daemonrpc.UnlockWalletRequest
+	(*UnlockWalletResponse)(nil),        // 9: daemonrpc.UnlockWalletResponse
+	(*GetBalanceRequest)(nil),           // 10: daemonrpc.GetBalanceRequest
+	(*GetBalanceResponse)(nil),          // 11: daemonrpc.GetBalanceResponse
+	(*VTXO)(nil),                        // 12: daemonrpc.VTXO
+	(*ListVTXOsRequest)(nil),            // 13: daemonrpc.ListVTXOsRequest
+	(*ListVTXOsResponse)(nil),           // 14: daemonrpc.ListVTXOsResponse
+	(*NewAddressRequest)(nil),           // 15: daemonrpc.NewAddressRequest
+	(*NewAddressResponse)(nil),          // 16: daemonrpc.NewAddressResponse
+	(*NewOORReceiveScriptRequest)(nil),  // 17: daemonrpc.NewOORReceiveScriptRequest
+	(*NewOORReceiveScriptResponse)(nil), // 18: daemonrpc.NewOORReceiveScriptResponse
+	(*Output)(nil),                      // 19: daemonrpc.Output
+	(*SendVTXORequest)(nil),             // 20: daemonrpc.SendVTXORequest
+	(*SendVTXOResponse)(nil),            // 21: daemonrpc.SendVTXOResponse
+	(*SendOORRequest)(nil),              // 22: daemonrpc.SendOORRequest
+	(*SendOORResponse)(nil),             // 23: daemonrpc.SendOORResponse
+	(*OutpointSelection)(nil),           // 24: daemonrpc.OutpointSelection
+	(*RefreshVTXOsRequest)(nil),         // 25: daemonrpc.RefreshVTXOsRequest
+	(*RefreshVTXOsResponse)(nil),        // 26: daemonrpc.RefreshVTXOsResponse
+	(*BoardRequest)(nil),                // 27: daemonrpc.BoardRequest
+	(*BoardResponse)(nil),               // 28: daemonrpc.BoardResponse
+	(*RoundVTXOInfo)(nil),               // 29: daemonrpc.RoundVTXOInfo
+	(*RoundInfo)(nil),                   // 30: daemonrpc.RoundInfo
+	(*ListRoundsRequest)(nil),           // 31: daemonrpc.ListRoundsRequest
+	(*ListRoundsResponse)(nil),          // 32: daemonrpc.ListRoundsResponse
+	(*WatchRoundsRequest)(nil),          // 33: daemonrpc.WatchRoundsRequest
+	(*WatchRoundsResponse)(nil),         // 34: daemonrpc.WatchRoundsResponse
 }
 var file_daemon_proto_depIdxs = []int32{
 	0,  // 0: daemonrpc.VTXO.status:type_name -> daemonrpc.VTXOStatus
 	0,  // 1: daemonrpc.ListVTXOsRequest.status_filter:type_name -> daemonrpc.VTXOStatus
 	12, // 2: daemonrpc.ListVTXOsResponse.vtxos:type_name -> daemonrpc.VTXO
-	17, // 3: daemonrpc.SendVTXORequest.recipients:type_name -> daemonrpc.Output
-	17, // 4: daemonrpc.SendOORRequest.recipient:type_name -> daemonrpc.Output
-	22, // 5: daemonrpc.RefreshVTXOsRequest.outpoints:type_name -> daemonrpc.OutpointSelection
+	19, // 3: daemonrpc.SendVTXORequest.recipients:type_name -> daemonrpc.Output
+	19, // 4: daemonrpc.SendOORRequest.recipient:type_name -> daemonrpc.Output
+	24, // 5: daemonrpc.RefreshVTXOsRequest.outpoints:type_name -> daemonrpc.OutpointSelection
 	1,  // 6: daemonrpc.RoundInfo.state:type_name -> daemonrpc.RoundState
-	27, // 7: daemonrpc.RoundInfo.vtxos:type_name -> daemonrpc.RoundVTXOInfo
-	28, // 8: daemonrpc.ListRoundsResponse.rounds:type_name -> daemonrpc.RoundInfo
-	28, // 9: daemonrpc.WatchRoundsResponse.round:type_name -> daemonrpc.RoundInfo
+	29, // 7: daemonrpc.RoundInfo.vtxos:type_name -> daemonrpc.RoundVTXOInfo
+	30, // 8: daemonrpc.ListRoundsResponse.rounds:type_name -> daemonrpc.RoundInfo
+	30, // 9: daemonrpc.WatchRoundsResponse.round:type_name -> daemonrpc.RoundInfo
 	2,  // 10: daemonrpc.DaemonService.GetInfo:input_type -> daemonrpc.GetInfoRequest
 	4,  // 11: daemonrpc.DaemonService.GenSeed:input_type -> daemonrpc.GenSeedRequest
 	6,  // 12: daemonrpc.DaemonService.InitWallet:input_type -> daemonrpc.InitWalletRequest
@@ -2316,27 +2455,29 @@ var file_daemon_proto_depIdxs = []int32{
 	10, // 14: daemonrpc.DaemonService.GetBalance:input_type -> daemonrpc.GetBalanceRequest
 	13, // 15: daemonrpc.DaemonService.ListVTXOs:input_type -> daemonrpc.ListVTXOsRequest
 	15, // 16: daemonrpc.DaemonService.NewAddress:input_type -> daemonrpc.NewAddressRequest
-	18, // 17: daemonrpc.DaemonService.SendVTXO:input_type -> daemonrpc.SendVTXORequest
-	20, // 18: daemonrpc.DaemonService.SendOOR:input_type -> daemonrpc.SendOORRequest
-	23, // 19: daemonrpc.DaemonService.RefreshVTXOs:input_type -> daemonrpc.RefreshVTXOsRequest
-	25, // 20: daemonrpc.DaemonService.Board:input_type -> daemonrpc.BoardRequest
-	29, // 21: daemonrpc.DaemonService.ListRounds:input_type -> daemonrpc.ListRoundsRequest
-	31, // 22: daemonrpc.DaemonService.WatchRounds:input_type -> daemonrpc.WatchRoundsRequest
-	3,  // 23: daemonrpc.DaemonService.GetInfo:output_type -> daemonrpc.GetInfoResponse
-	5,  // 24: daemonrpc.DaemonService.GenSeed:output_type -> daemonrpc.GenSeedResponse
-	7,  // 25: daemonrpc.DaemonService.InitWallet:output_type -> daemonrpc.InitWalletResponse
-	9,  // 26: daemonrpc.DaemonService.UnlockWallet:output_type -> daemonrpc.UnlockWalletResponse
-	11, // 27: daemonrpc.DaemonService.GetBalance:output_type -> daemonrpc.GetBalanceResponse
-	14, // 28: daemonrpc.DaemonService.ListVTXOs:output_type -> daemonrpc.ListVTXOsResponse
-	16, // 29: daemonrpc.DaemonService.NewAddress:output_type -> daemonrpc.NewAddressResponse
-	19, // 30: daemonrpc.DaemonService.SendVTXO:output_type -> daemonrpc.SendVTXOResponse
-	21, // 31: daemonrpc.DaemonService.SendOOR:output_type -> daemonrpc.SendOORResponse
-	24, // 32: daemonrpc.DaemonService.RefreshVTXOs:output_type -> daemonrpc.RefreshVTXOsResponse
-	26, // 33: daemonrpc.DaemonService.Board:output_type -> daemonrpc.BoardResponse
-	30, // 34: daemonrpc.DaemonService.ListRounds:output_type -> daemonrpc.ListRoundsResponse
-	32, // 35: daemonrpc.DaemonService.WatchRounds:output_type -> daemonrpc.WatchRoundsResponse
-	23, // [23:36] is the sub-list for method output_type
-	10, // [10:23] is the sub-list for method input_type
+	17, // 17: daemonrpc.DaemonService.NewOORReceiveScript:input_type -> daemonrpc.NewOORReceiveScriptRequest
+	20, // 18: daemonrpc.DaemonService.SendVTXO:input_type -> daemonrpc.SendVTXORequest
+	22, // 19: daemonrpc.DaemonService.SendOOR:input_type -> daemonrpc.SendOORRequest
+	25, // 20: daemonrpc.DaemonService.RefreshVTXOs:input_type -> daemonrpc.RefreshVTXOsRequest
+	27, // 21: daemonrpc.DaemonService.Board:input_type -> daemonrpc.BoardRequest
+	31, // 22: daemonrpc.DaemonService.ListRounds:input_type -> daemonrpc.ListRoundsRequest
+	33, // 23: daemonrpc.DaemonService.WatchRounds:input_type -> daemonrpc.WatchRoundsRequest
+	3,  // 24: daemonrpc.DaemonService.GetInfo:output_type -> daemonrpc.GetInfoResponse
+	5,  // 25: daemonrpc.DaemonService.GenSeed:output_type -> daemonrpc.GenSeedResponse
+	7,  // 26: daemonrpc.DaemonService.InitWallet:output_type -> daemonrpc.InitWalletResponse
+	9,  // 27: daemonrpc.DaemonService.UnlockWallet:output_type -> daemonrpc.UnlockWalletResponse
+	11, // 28: daemonrpc.DaemonService.GetBalance:output_type -> daemonrpc.GetBalanceResponse
+	14, // 29: daemonrpc.DaemonService.ListVTXOs:output_type -> daemonrpc.ListVTXOsResponse
+	16, // 30: daemonrpc.DaemonService.NewAddress:output_type -> daemonrpc.NewAddressResponse
+	18, // 31: daemonrpc.DaemonService.NewOORReceiveScript:output_type -> daemonrpc.NewOORReceiveScriptResponse
+	21, // 32: daemonrpc.DaemonService.SendVTXO:output_type -> daemonrpc.SendVTXOResponse
+	23, // 33: daemonrpc.DaemonService.SendOOR:output_type -> daemonrpc.SendOORResponse
+	26, // 34: daemonrpc.DaemonService.RefreshVTXOs:output_type -> daemonrpc.RefreshVTXOsResponse
+	28, // 35: daemonrpc.DaemonService.Board:output_type -> daemonrpc.BoardResponse
+	32, // 36: daemonrpc.DaemonService.ListRounds:output_type -> daemonrpc.ListRoundsResponse
+	34, // 37: daemonrpc.DaemonService.WatchRounds:output_type -> daemonrpc.WatchRoundsResponse
+	24, // [24:38] is the sub-list for method output_type
+	10, // [10:24] is the sub-list for method input_type
 	10, // [10:10] is the sub-list for extension type_name
 	10, // [10:10] is the sub-list for extension extendee
 	0,  // [0:10] is the sub-list for field type_name
@@ -2347,12 +2488,12 @@ func file_daemon_proto_init() {
 	if File_daemon_proto != nil {
 		return
 	}
-	file_daemon_proto_msgTypes[15].OneofWrappers = []any{
+	file_daemon_proto_msgTypes[17].OneofWrappers = []any{
 		(*Output_Address)(nil),
 		(*Output_Pubkey)(nil),
 		(*Output_PkScript)(nil),
 	}
-	file_daemon_proto_msgTypes[21].OneofWrappers = []any{
+	file_daemon_proto_msgTypes[23].OneofWrappers = []any{
 		(*RefreshVTXOsRequest_Outpoints)(nil),
 		(*RefreshVTXOsRequest_All)(nil),
 	}
@@ -2362,7 +2503,7 @@ func file_daemon_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_daemon_proto_rawDesc), len(file_daemon_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   31,
+			NumMessages:   33,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/daemonrpc/daemon.proto
+++ b/daemonrpc/daemon.proto
@@ -41,6 +41,12 @@ service DaemonService {
     // on-chain funds for use in the Ark protocol.
     rpc NewAddress (NewAddressRequest) returns (NewAddressResponse);
 
+    // NewOORReceiveScript allocates a fresh wallet key, registers the
+    // matching taproot OOR receive script with the indexer, and returns
+    // the script details needed to hand the destination to a sender.
+    rpc NewOORReceiveScript (NewOORReceiveScriptRequest)
+        returns (NewOORReceiveScriptResponse);
+
     // SendVTXO initiates an in-round transfer by submitting a refresh
     // request to the round coordinator. The transfer completes when the
     // next round commits.
@@ -277,6 +283,29 @@ message NewAddressRequest {
 message NewAddressResponse {
     // address is the bech32m-encoded taproot boarding address.
     string address = 1;
+}
+
+message NewOORReceiveScriptRequest {
+    // label is an optional human-readable label stored with the
+    // registration on the indexer.
+    string label = 1;
+}
+
+message NewOORReceiveScriptResponse {
+    // pk_script_hex is the raw taproot output script encoded as hex.
+    string pk_script_hex = 1;
+
+    // pubkey_xonly_hex is the 32-byte x-only owner pubkey encoded as hex.
+    string pubkey_xonly_hex = 2;
+
+    // key_family is the wallet key family used to derive the receive key.
+    uint32 key_family = 3;
+
+    // key_index is the wallet key index used to derive the receive key.
+    uint32 key_index = 4;
+
+    // label is the registration label stored with the indexer.
+    string label = 5;
 }
 
 // Output describes a single recipient in a send operation.

--- a/daemonrpc/daemon_grpc.pb.go
+++ b/daemonrpc/daemon_grpc.pb.go
@@ -19,19 +19,20 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	DaemonService_GetInfo_FullMethodName      = "/daemonrpc.DaemonService/GetInfo"
-	DaemonService_GenSeed_FullMethodName      = "/daemonrpc.DaemonService/GenSeed"
-	DaemonService_InitWallet_FullMethodName   = "/daemonrpc.DaemonService/InitWallet"
-	DaemonService_UnlockWallet_FullMethodName = "/daemonrpc.DaemonService/UnlockWallet"
-	DaemonService_GetBalance_FullMethodName   = "/daemonrpc.DaemonService/GetBalance"
-	DaemonService_ListVTXOs_FullMethodName    = "/daemonrpc.DaemonService/ListVTXOs"
-	DaemonService_NewAddress_FullMethodName   = "/daemonrpc.DaemonService/NewAddress"
-	DaemonService_SendVTXO_FullMethodName     = "/daemonrpc.DaemonService/SendVTXO"
-	DaemonService_SendOOR_FullMethodName      = "/daemonrpc.DaemonService/SendOOR"
-	DaemonService_RefreshVTXOs_FullMethodName = "/daemonrpc.DaemonService/RefreshVTXOs"
-	DaemonService_Board_FullMethodName        = "/daemonrpc.DaemonService/Board"
-	DaemonService_ListRounds_FullMethodName   = "/daemonrpc.DaemonService/ListRounds"
-	DaemonService_WatchRounds_FullMethodName  = "/daemonrpc.DaemonService/WatchRounds"
+	DaemonService_GetInfo_FullMethodName             = "/daemonrpc.DaemonService/GetInfo"
+	DaemonService_GenSeed_FullMethodName             = "/daemonrpc.DaemonService/GenSeed"
+	DaemonService_InitWallet_FullMethodName          = "/daemonrpc.DaemonService/InitWallet"
+	DaemonService_UnlockWallet_FullMethodName        = "/daemonrpc.DaemonService/UnlockWallet"
+	DaemonService_GetBalance_FullMethodName          = "/daemonrpc.DaemonService/GetBalance"
+	DaemonService_ListVTXOs_FullMethodName           = "/daemonrpc.DaemonService/ListVTXOs"
+	DaemonService_NewAddress_FullMethodName          = "/daemonrpc.DaemonService/NewAddress"
+	DaemonService_NewOORReceiveScript_FullMethodName = "/daemonrpc.DaemonService/NewOORReceiveScript"
+	DaemonService_SendVTXO_FullMethodName            = "/daemonrpc.DaemonService/SendVTXO"
+	DaemonService_SendOOR_FullMethodName             = "/daemonrpc.DaemonService/SendOOR"
+	DaemonService_RefreshVTXOs_FullMethodName        = "/daemonrpc.DaemonService/RefreshVTXOs"
+	DaemonService_Board_FullMethodName               = "/daemonrpc.DaemonService/Board"
+	DaemonService_ListRounds_FullMethodName          = "/daemonrpc.DaemonService/ListRounds"
+	DaemonService_WatchRounds_FullMethodName         = "/daemonrpc.DaemonService/WatchRounds"
 )
 
 // DaemonServiceClient is the client API for DaemonService service.
@@ -68,6 +69,10 @@ type DaemonServiceClient interface {
 	// NewAddress generates a new boarding address that can receive
 	// on-chain funds for use in the Ark protocol.
 	NewAddress(ctx context.Context, in *NewAddressRequest, opts ...grpc.CallOption) (*NewAddressResponse, error)
+	// NewOORReceiveScript allocates a fresh wallet key, registers the
+	// matching taproot OOR receive script with the indexer, and returns
+	// the script details needed to hand the destination to a sender.
+	NewOORReceiveScript(ctx context.Context, in *NewOORReceiveScriptRequest, opts ...grpc.CallOption) (*NewOORReceiveScriptResponse, error)
 	// SendVTXO initiates an in-round transfer by submitting a refresh
 	// request to the round coordinator. The transfer completes when the
 	// next round commits.
@@ -164,6 +169,16 @@ func (c *daemonServiceClient) NewAddress(ctx context.Context, in *NewAddressRequ
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(NewAddressResponse)
 	err := c.cc.Invoke(ctx, DaemonService_NewAddress_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *daemonServiceClient) NewOORReceiveScript(ctx context.Context, in *NewOORReceiveScriptRequest, opts ...grpc.CallOption) (*NewOORReceiveScriptResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(NewOORReceiveScriptResponse)
+	err := c.cc.Invoke(ctx, DaemonService_NewOORReceiveScript_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -273,6 +288,10 @@ type DaemonServiceServer interface {
 	// NewAddress generates a new boarding address that can receive
 	// on-chain funds for use in the Ark protocol.
 	NewAddress(context.Context, *NewAddressRequest) (*NewAddressResponse, error)
+	// NewOORReceiveScript allocates a fresh wallet key, registers the
+	// matching taproot OOR receive script with the indexer, and returns
+	// the script details needed to hand the destination to a sender.
+	NewOORReceiveScript(context.Context, *NewOORReceiveScriptRequest) (*NewOORReceiveScriptResponse, error)
 	// SendVTXO initiates an in-round transfer by submitting a refresh
 	// request to the round coordinator. The transfer completes when the
 	// next round commits.
@@ -325,6 +344,9 @@ func (UnimplementedDaemonServiceServer) ListVTXOs(context.Context, *ListVTXOsReq
 }
 func (UnimplementedDaemonServiceServer) NewAddress(context.Context, *NewAddressRequest) (*NewAddressResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method NewAddress not implemented")
+}
+func (UnimplementedDaemonServiceServer) NewOORReceiveScript(context.Context, *NewOORReceiveScriptRequest) (*NewOORReceiveScriptResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method NewOORReceiveScript not implemented")
 }
 func (UnimplementedDaemonServiceServer) SendVTXO(context.Context, *SendVTXORequest) (*SendVTXOResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method SendVTXO not implemented")
@@ -491,6 +513,24 @@ func _DaemonService_NewAddress_Handler(srv interface{}, ctx context.Context, dec
 	return interceptor(ctx, in, info, handler)
 }
 
+func _DaemonService_NewOORReceiveScript_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(NewOORReceiveScriptRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DaemonServiceServer).NewOORReceiveScript(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DaemonService_NewOORReceiveScript_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DaemonServiceServer).NewOORReceiveScript(ctx, req.(*NewOORReceiveScriptRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _DaemonService_SendVTXO_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(SendVTXORequest)
 	if err := dec(in); err != nil {
@@ -626,6 +666,10 @@ var DaemonService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "NewAddress",
 			Handler:    _DaemonService_NewAddress_Handler,
+		},
+		{
+			MethodName: "NewOORReceiveScript",
+			Handler:    _DaemonService_NewOORReceiveScript_Handler,
 		},
 		{
 			MethodName: "SendVTXO",

--- a/daemonrpc/daemon_mailboxrpc.pb.go
+++ b/daemonrpc/daemon_mailboxrpc.pb.go
@@ -38,6 +38,8 @@ type DaemonServiceMailboxServer interface {
 	ListVTXOs(ctx context.Context, req *ListVTXOsRequest) (*ListVTXOsResponse, error)
 	// NewAddress handles NewAddress.
 	NewAddress(ctx context.Context, req *NewAddressRequest) (*NewAddressResponse, error)
+	// NewOORReceiveScript handles NewOORReceiveScript.
+	NewOORReceiveScript(ctx context.Context, req *NewOORReceiveScriptRequest) (*NewOORReceiveScriptResponse, error)
 	// SendVTXO handles SendVTXO.
 	SendVTXO(ctx context.Context, req *SendVTXORequest) (*SendVTXOResponse, error)
 	// SendOOR handles SendOOR.
@@ -123,6 +125,16 @@ func RegisterDaemonServiceMailboxServer(r rpc.Router, impl DaemonServiceMailboxS
 		}
 
 		return impl.NewAddress(ctx, req)
+	})
+	r.Handle("daemonrpc.DaemonService", "NewOORReceiveScript", func() proto.Message {
+		return &NewOORReceiveScriptRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*NewOORReceiveScriptRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.NewOORReceiveScript(ctx, req)
 	})
 	r.Handle("daemonrpc.DaemonService", "SendVTXO", func() proto.Message {
 		return &SendVTXORequest{}
@@ -340,6 +352,29 @@ func (c *DaemonServiceMailboxClient) NewAddress(ctx context.Context, req *NewAdd
 	}
 
 	resp := new(NewAddressResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// NewOORReceiveScript calls the NewOORReceiveScript RPC.
+func (c *DaemonServiceMailboxClient) NewOORReceiveScript(ctx context.Context, req *NewOORReceiveScriptRequest, opts ...rpc.RPCOptions) (*NewOORReceiveScriptResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "daemonrpc.DaemonService",
+		Method:  "NewOORReceiveScript",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(NewOORReceiveScriptResponse)
 	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
 		return nil, err
 	}

--- a/darepod/AGENTS.md
+++ b/darepod/AGENTS.md
@@ -9,13 +9,17 @@ gRPC API.
 ## Key Types
 
 - `Server` — Main daemon owning wallet, DB, chainsource actor, gRPC server, and ActorSystem.
-- `RPCServer` — Implements the gRPC `DaemonService` API (Board, ListRounds, WatchRounds, etc.).
+- `RPCServer` — Implements the gRPC `DaemonService` API (Board, ListRounds, WatchRounds, NewOORReceiveScript, etc.).
 - `Config` — Daemon configuration (data dir, network, RPC host, wallet type, etc.).
 - `WalletState` — Enum (None/Locked/Ready) for wallet lifecycle.
+- `serverDurableUnaryBuilder` — Implements `serverconn.DurableUnaryRequestBuilder` by delegating to the indexer client with proof-of-control credentials.
+- `NewOwnedReceiveScriptSigner` — Indexer signer that resolves the wallet key for any persisted owned receive script, then delegates signing to the backend-specific signer.
+- `EnsureDefaultOORReceiveScript` / `CreateOORReceiveScript` — Receive-key lifecycle: derive, register with indexer (proof-of-control), persist ownership record.
+- `ResolveIncomingMetadataFromIndexer` — Resolves authoritative VTXO lineage metadata from the indexer's `ListVTXOsByScripts` response for incoming materialization.
 
 ## Relationships
 
-- **Depends on**: `baselib/actor` (ActorSystem), `chainbackends`, `chainsource`, `lib/actormsg`, `db`, `round`, `vtxo`, `wallet`, `oor`, `serverconn`.
+- **Depends on**: `baselib/actor` (ActorSystem), `chainbackends`, `chainsource`, `lib/actormsg`, `db`, `round`, `vtxo`, `wallet`, `oor`, `serverconn`, `indexer`, `arkrpc`.
 - **Depended on by**: `cmd/darepod` (main entry point).
 
 ## Invariants
@@ -28,6 +32,8 @@ gRPC API.
 - Server holds a `roundStore` reference for direct SQL queries from the RPC layer.
 - Actor startup order: VTXO manager starts before round actor and OOR actor, so the manager ref is available for both. The round actor ref in the VTXO manager is lazy (service-key-based, resolved at Tell time).
 - `mapRoundVTXOManagerMsg` bridges `round.VTXOManagerMsg` → `vtxo.ManagerMsg` via `MapInputRef`. Compile-time assertions enforce that all `round.VTXOManagerMsg` implementors satisfy `vtxo.ManagerMsg`.
+- OOR receive-key is derived once at startup via `EnsureDefaultOORReceiveScript` and persisted for restart-safe re-registration. The `DurableUnaryBuilder` is wired through `serverconn.ConnectorConfig` so all indexer queries flow through the durable transport path.
+- `ensureRoundExists` in `db/vtxo_store.go` uses check-then-insert (not upsert) because `InsertRound`'s `ON CONFLICT DO UPDATE` would overwrite richer round state.
 
 ## Deep Docs
 

--- a/darepod/CLAUDE.md
+++ b/darepod/CLAUDE.md
@@ -9,13 +9,17 @@ gRPC API.
 ## Key Types
 
 - `Server` — Main daemon owning wallet, DB, chainsource actor, gRPC server, and ActorSystem.
-- `RPCServer` — Implements the gRPC `DaemonService` API (Board, ListRounds, WatchRounds, etc.).
+- `RPCServer` — Implements the gRPC `DaemonService` API (Board, ListRounds, WatchRounds, NewOORReceiveScript, etc.).
 - `Config` — Daemon configuration (data dir, network, RPC host, wallet type, etc.).
 - `WalletState` — Enum (None/Locked/Ready) for wallet lifecycle.
+- `serverDurableUnaryBuilder` — Implements `serverconn.DurableUnaryRequestBuilder` by delegating to the indexer client with proof-of-control credentials.
+- `NewOwnedReceiveScriptSigner` — Indexer signer that resolves the wallet key for any persisted owned receive script, then delegates signing to the backend-specific signer.
+- `EnsureDefaultOORReceiveScript` / `CreateOORReceiveScript` — Receive-key lifecycle: derive, register with indexer (proof-of-control), persist ownership record.
+- `ResolveIncomingMetadataFromIndexer` — Resolves authoritative VTXO lineage metadata from the indexer's `ListVTXOsByScripts` response for incoming materialization.
 
 ## Relationships
 
-- **Depends on**: `baselib/actor` (ActorSystem), `chainbackends`, `chainsource`, `lib/actormsg`, `db`, `round`, `vtxo`, `wallet`, `oor`, `serverconn`.
+- **Depends on**: `baselib/actor` (ActorSystem), `chainbackends`, `chainsource`, `lib/actormsg`, `db`, `round`, `vtxo`, `wallet`, `oor`, `serverconn`, `indexer`, `arkrpc`.
 - **Depended on by**: `cmd/darepod` (main entry point).
 
 ## Invariants
@@ -28,6 +32,8 @@ gRPC API.
 - Server holds a `roundStore` reference for direct SQL queries from the RPC layer.
 - Actor startup order: VTXO manager starts before round actor and OOR actor, so the manager ref is available for both. The round actor ref in the VTXO manager is lazy (service-key-based, resolved at Tell time).
 - `mapRoundVTXOManagerMsg` bridges `round.VTXOManagerMsg` → `vtxo.ManagerMsg` via `MapInputRef`. Compile-time assertions enforce that all `round.VTXOManagerMsg` implementors satisfy `vtxo.ManagerMsg`.
+- OOR receive-key is derived once at startup via `EnsureDefaultOORReceiveScript` and persisted for restart-safe re-registration. The `DurableUnaryBuilder` is wired through `serverconn.ConnectorConfig` so all indexer queries flow through the durable transport path.
+- `ensureRoundExists` in `db/vtxo_store.go` uses check-then-insert (not upsert) because `InsertRound`'s `ON CONFLICT DO UPDATE` would overwrite richer round state.
 
 ## Deep Docs
 

--- a/darepod/incoming_metadata.go
+++ b/darepod/incoming_metadata.go
@@ -1,0 +1,151 @@
+package darepod
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightninglabs/darepo-client/arkrpc"
+	"github.com/lightninglabs/darepo-client/indexer"
+	"github.com/lightninglabs/darepo-client/oor"
+)
+
+const incomingMetadataIndexPageSize = 128
+
+// ResolveIncomingMetadataFromIndexer queries the authoritative indexer
+// inventory for the just-created OOR output and maps the result into the
+// incoming materialization metadata required by the local VTXO store.
+func ResolveIncomingMetadataFromIndexer(ctx context.Context,
+	idx *indexer.Client, sessionID oor.SessionID,
+	recipient oor.ArkRecipientOutput) (oor.IncomingVTXOMetadata, error) {
+
+	if idx == nil {
+		return oor.IncomingVTXOMetadata{}, fmt.Errorf("indexer client " +
+			"must be provided")
+	}
+
+	log.DebugS(ctx, "Resolving incoming metadata from indexer",
+		slog.String("session_id", chainhash.Hash(sessionID).String()),
+		slog.Int("output_index", int(recipient.OutputIndex)),
+		slog.String("pk_script", fmt.Sprintf("%x", recipient.PkScript)))
+
+	var cursor uint64
+	for {
+		resp, err := idx.ListVTXOsByScriptsTaproot(
+			ctx,
+			[]indexer.TaprootScriptScope{{
+				PkScript: append(
+					[]byte(nil), recipient.PkScript...,
+				),
+			}},
+			cursor, incomingMetadataIndexPageSize, nil,
+		)
+		if err != nil {
+			return oor.IncomingVTXOMetadata{}, fmt.Errorf("list "+
+				"VTXOs by script: %w", err)
+		}
+
+		for _, candidate := range resp.GetVtxos() {
+			match, err := matchesIncomingVTXO(
+				candidate, sessionID, recipient.OutputIndex,
+			)
+			if err != nil {
+				return oor.IncomingVTXOMetadata{}, err
+			}
+			if !match {
+				continue
+			}
+
+			log.DebugS(ctx, "Matched incoming indexer VTXO",
+				slog.String("session_id",
+					chainhash.Hash(sessionID).String()),
+				slog.Int("output_index",
+					int(recipient.OutputIndex)),
+				slog.String("round_id",
+					candidate.GetRoundId()),
+				slog.Int("tree_depth",
+					int(candidate.GetTreeDepth())),
+				slog.Int("chain_depth",
+					int(candidate.GetChainDepth())))
+
+			return incomingMetadataFromRPC(candidate)
+		}
+
+		nextCursor := resp.GetNextCursor()
+		if len(resp.GetVtxos()) == 0 || nextCursor <= cursor {
+			break
+		}
+
+		cursor = nextCursor
+	}
+
+	log.DebugS(ctx, "Incoming indexer VTXO not found",
+		slog.String("session_id", chainhash.Hash(sessionID).String()),
+		slog.Int("output_index", int(recipient.OutputIndex)))
+
+	return oor.IncomingVTXOMetadata{}, fmt.Errorf("incoming vtxo %s:%d "+
+		"not found in indexer inventory",
+		chainhash.Hash(sessionID), recipient.OutputIndex)
+}
+
+// matchesIncomingVTXO returns true when candidate identifies the target Ark
+// output created by sessionID at outputIndex.
+func matchesIncomingVTXO(candidate *arkrpc.VTXO, sessionID oor.SessionID,
+	outputIndex uint32) (bool, error) {
+
+	if candidate == nil {
+		return false, nil
+	}
+
+	outpoint := candidate.GetOutpoint()
+	if outpoint == nil {
+		return false, fmt.Errorf("indexer VTXO missing outpoint")
+	}
+
+	return bytes.Equal(outpoint.GetTxid(), sessionID[:]) &&
+		outpoint.GetVout() == outputIndex, nil
+}
+
+// incomingMetadataFromRPC maps the authoritative indexer VTXO view into the
+// metadata shape required by the incoming OOR materialization path.
+func incomingMetadataFromRPC(candidate *arkrpc.VTXO) (
+	oor.IncomingVTXOMetadata, error) {
+
+	if candidate == nil {
+		return oor.IncomingVTXOMetadata{}, fmt.Errorf("indexer vtxo " +
+			"must be provided")
+	}
+
+	if candidate.GetRoundId() == "" {
+		return oor.IncomingVTXOMetadata{}, fmt.Errorf("indexer vtxo " +
+			"missing round id")
+	}
+
+	if len(candidate.GetCommitmentTxid()) != chainhash.HashSize {
+		return oor.IncomingVTXOMetadata{}, fmt.Errorf("indexer vtxo " +
+			"missing commitment txid")
+	}
+
+	treePath, err := arkrpc.TreePathToTree(
+		candidate.GetTreePath(),
+	)
+	if err != nil {
+		return oor.IncomingVTXOMetadata{}, fmt.Errorf("convert "+
+			"tree path: %w", err)
+	}
+
+	var commitmentTxID chainhash.Hash
+	copy(commitmentTxID[:], candidate.GetCommitmentTxid())
+
+	return oor.IncomingVTXOMetadata{
+		RoundID:        candidate.GetRoundId(),
+		CommitmentTxID: commitmentTxID,
+		BatchExpiry:    candidate.GetBatchExpiryHeight(),
+		TreeDepth:      int(candidate.GetTreeDepth()),
+		ChainDepth:     int(candidate.GetChainDepth()),
+		CreatedHeight:  candidate.GetCreatedHeight(),
+		TreePath:       treePath,
+	}, nil
+}

--- a/darepod/incoming_metadata.go
+++ b/darepod/incoming_metadata.go
@@ -22,7 +22,7 @@ func ResolveIncomingMetadataFromIndexer(ctx context.Context,
 	recipient oor.ArkRecipientOutput) (oor.IncomingVTXOMetadata, error) {
 
 	if idx == nil {
-		return oor.IncomingVTXOMetadata{}, fmt.Errorf("indexer client " +
+		return oor.IncomingVTXOMetadata{}, fmt.Errorf("indexer client " + //nolint:ll
 			"must be provided")
 	}
 

--- a/darepod/receive_script.go
+++ b/darepod/receive_script.go
@@ -1,0 +1,277 @@
+package darepod
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/lightninglabs/darepo-client/db"
+	"github.com/lightninglabs/darepo-client/indexer"
+	"github.com/lightninglabs/darepo-client/lib/scripts"
+	"github.com/lightninglabs/darepo-client/oor"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/keychain"
+)
+
+const (
+	defaultOORReceiveScriptRegistrationTTL = 30 * 24 * time.Hour
+
+	// defaultOORReceiveKeyFamily is the dedicated BIP32 key family used
+	// for the daemon's default OOR receive script. This must be separate
+	// from the node identity key family because lnd's signer path for the
+	// identity key does not produce valid tapscript spend signatures for
+	// rematerialized OOR VTXOs.
+	defaultOORReceiveKeyFamily keychain.KeyFamily = 44
+)
+
+// ownedReceiveScriptStore persists locally owned receive-script metadata.
+type ownedReceiveScriptStore interface {
+	UpsertOwnedReceiveScript(ctx context.Context,
+		rec db.OwnedReceiveScriptRecord) error
+}
+
+// ownedReceiveScriptLookup loads locally owned receive-script metadata by
+// pkScript.
+type ownedReceiveScriptLookup interface {
+	LookupOwnedReceiveScript(ctx context.Context,
+		pkScript []byte) (*db.OwnedReceiveScriptRecord, error)
+}
+
+// ownedReceiveScriptLister lists locally owned receive-script metadata.
+type ownedReceiveScriptLister interface {
+	ListOwnedReceiveScripts(ctx context.Context) (
+		[]db.OwnedReceiveScriptRecord, error,
+	)
+}
+
+// defaultOORReceiveScriptStateStore provides the persistent state needed to
+// reuse or register the daemon-managed default OOR receive key.
+type defaultOORReceiveScriptStateStore interface {
+	ownedReceiveScriptStore
+	ownedReceiveScriptLister
+}
+
+// DeriveDefaultOORReceiveKeyFunc derives the next wallet-managed default OOR
+// receive key when no previously persisted key exists.
+type DeriveDefaultOORReceiveKeyFunc func(context.Context) (
+	*keychain.KeyDescriptor, error,
+)
+
+// DefaultOORReceiveKeyFamily returns the dedicated key family used for
+// daemon-managed OOR receive keys.
+func DefaultOORReceiveKeyFamily() keychain.KeyFamily {
+	return defaultOORReceiveKeyFamily
+}
+
+// BuildPubKeyVTXOReceiveScript derives the standard VTXO-compatible taproot
+// output script for an OOR recipient pubkey.
+func BuildPubKeyVTXOReceiveScript(recipientKey,
+	operatorKey *btcec.PublicKey, exitDelay uint32) ([]byte, error) {
+
+	switch {
+	case recipientKey == nil:
+		return nil, fmt.Errorf("recipient key must be provided")
+
+	case operatorKey == nil:
+		return nil, fmt.Errorf("operator key must be provided")
+	}
+
+	tapKey, err := scripts.VTXOTapKey(
+		recipientKey, operatorKey, exitDelay,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("derive vtxo tap key: %w", err)
+	}
+
+	pkScript, err := txscript.PayToTaprootScript(tapKey)
+	if err != nil {
+		return nil, fmt.Errorf("derive receive pk script: %w", err)
+	}
+
+	return pkScript, nil
+}
+
+// ResolveOwnedReceiveScriptKey resolves the locally owned wallet key for an
+// incoming recipient output using the persisted receive-script ownership map.
+func ResolveOwnedReceiveScriptKey(ctx context.Context,
+	store ownedReceiveScriptLookup,
+	recipient oor.ArkRecipientOutput) (keychain.KeyDescriptor, error) {
+
+	switch {
+	case store == nil:
+		return keychain.KeyDescriptor{}, fmt.Errorf(
+			"owned receive script lookup must be provided",
+		)
+
+	case len(recipient.PkScript) == 0:
+		return keychain.KeyDescriptor{}, fmt.Errorf(
+			"recipient pk script must be provided",
+		)
+	}
+
+	rec, err := store.LookupOwnedReceiveScript(ctx, recipient.PkScript)
+	if err != nil {
+		return keychain.KeyDescriptor{}, fmt.Errorf("lookup owned "+
+			"receive script: %w", err)
+	}
+
+	return rec.ClientKey, nil
+}
+
+// LoadDefaultOORReceiveKey loads the most recently persisted wallet-managed
+// OOR receive key, if one exists.
+func LoadDefaultOORReceiveKey(ctx context.Context,
+	store ownedReceiveScriptLister) (*keychain.KeyDescriptor, error) {
+
+	if store == nil {
+		return nil, fmt.Errorf("owned receive script lister must be " +
+			"provided")
+	}
+
+	records, err := store.ListOwnedReceiveScripts(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list owned receive scripts: %w", err)
+	}
+
+	var latest *db.OwnedReceiveScriptRecord
+	for i := range records {
+		rec := &records[i]
+		if rec.Source != db.OwnedReceiveScriptSourceWallet {
+			continue
+		}
+
+		if latest == nil || rec.CreatedAt.After(latest.CreatedAt) {
+			latest = rec
+		}
+	}
+
+	if latest == nil {
+		return nil, nil
+	}
+
+	return &latest.ClientKey, nil
+}
+
+// EnsureDefaultOORReceiveKey loads the most recently persisted wallet-managed
+// OOR receive key or derives a new one when no prior registration exists.
+func EnsureDefaultOORReceiveKey(ctx context.Context,
+	store ownedReceiveScriptLister,
+	deriveNextKey DeriveDefaultOORReceiveKeyFunc) (
+	*keychain.KeyDescriptor, error,
+) {
+
+	if store == nil {
+		return nil, fmt.Errorf("owned receive script lister must be " +
+			"provided")
+	}
+
+	keyDesc, err := LoadDefaultOORReceiveKey(ctx, store)
+	if err != nil {
+		return nil, err
+	}
+
+	if keyDesc != nil {
+		return keyDesc, nil
+	}
+
+	if deriveNextKey == nil {
+		return nil, fmt.Errorf("derive next key func must be provided")
+	}
+
+	keyDesc, err = deriveNextKey(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("derive default oor receive key: %w",
+			err)
+	}
+
+	if keyDesc == nil || keyDesc.PubKey == nil {
+		return nil, fmt.Errorf("derive default oor receive key: " +
+			"missing pubkey")
+	}
+
+	return keyDesc, nil
+}
+
+// EnsureDefaultOORReceiveScript ensures the daemon-managed default OOR receive
+// key exists, registers the corresponding receive script, and persists its
+// ownership metadata for later incoming-script resolution.
+func EnsureDefaultOORReceiveScript(ctx context.Context,
+	idx *indexer.Client, store defaultOORReceiveScriptStateStore,
+	deriveNextKey DeriveDefaultOORReceiveKeyFunc,
+	operatorKey *btcec.PublicKey, exitDelay uint32, label string) (
+	*keychain.KeyDescriptor, []byte, error,
+) {
+
+	if store == nil {
+		return nil, nil, fmt.Errorf("default OOR receive script " +
+			"store must be provided")
+	}
+
+	keyDesc, err := EnsureDefaultOORReceiveKey(
+		ctx, store, deriveNextKey,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pkScript, err := RegisterDefaultOORReceiveScript(
+		ctx, idx, store, *keyDesc, operatorKey, exitDelay, label,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return keyDesc, pkScript, nil
+}
+
+// RegisterDefaultOORReceiveScript derives, registers, and persists the
+// default OOR receive script for the provided local wallet key.
+func RegisterDefaultOORReceiveScript(ctx context.Context,
+	idx *indexer.Client, store ownedReceiveScriptStore,
+	clientKey keychain.KeyDescriptor, operatorKey *btcec.PublicKey,
+	exitDelay uint32, label string) ([]byte, error) {
+
+	switch {
+	case idx == nil:
+		return nil, fmt.Errorf("indexer client must be provided")
+
+	case clientKey.PubKey == nil:
+		return nil, fmt.Errorf("client key must be provided")
+	}
+
+	pkScript, err := BuildPubKeyVTXOReceiveScript(
+		clientKey.PubKey, operatorKey, exitDelay,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	expiresAt := time.Now().Add(defaultOORReceiveScriptRegistrationTTL)
+	_, err = idx.RegisterReceiveScriptTaproot(
+		ctx, pkScript, expiresAt, label,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("register receive script: %w", err)
+	}
+
+	if store == nil {
+		return pkScript, nil
+	}
+
+	err = store.UpsertOwnedReceiveScript(ctx, db.OwnedReceiveScriptRecord{
+		PkScript:       pkScript,
+		ClientKey:      clientKey,
+		OperatorPubKey: operatorKey,
+		ExitDelay:      int64(exitDelay),
+		Source:         db.OwnedReceiveScriptSourceWallet,
+		CreatedAt:      time.Now(),
+		LastUsedAt:     fn.None[time.Time](),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("persist owned receive script: %w", err)
+	}
+
+	return pkScript, nil
+}

--- a/darepod/receive_script.go
+++ b/darepod/receive_script.go
@@ -17,13 +17,6 @@ import (
 
 const (
 	defaultOORReceiveScriptRegistrationTTL = 30 * 24 * time.Hour
-
-	// defaultOORReceiveKeyFamily is the dedicated BIP32 key family used
-	// for the daemon's default OOR receive script. This must be separate
-	// from the node identity key family because lnd's signer path for the
-	// identity key does not produce valid tapscript spend signatures for
-	// rematerialized OOR VTXOs.
-	defaultOORReceiveKeyFamily keychain.KeyFamily = 44
 )
 
 // ownedReceiveScriptStore persists locally owned receive-script metadata.
@@ -53,17 +46,16 @@ type defaultOORReceiveScriptStateStore interface {
 	ownedReceiveScriptLister
 }
 
-// DeriveDefaultOORReceiveKeyFunc derives the next wallet-managed default OOR
-// receive key when no previously persisted key exists.
+// DeriveDefaultOORReceiveKeyFunc derives the next wallet-managed OOR receive
+// key when no previously persisted key exists.
 type DeriveDefaultOORReceiveKeyFunc func(context.Context) (
 	*keychain.KeyDescriptor, error,
 )
 
-// DefaultOORReceiveKeyFamily returns the dedicated key family used for
-// daemon-managed OOR receive keys.
-func DefaultOORReceiveKeyFamily() keychain.KeyFamily {
-	return defaultOORReceiveKeyFamily
-}
+// OORReceiveScriptSignerFactory constructs an indexer proof signer for the
+// wallet key that controls one owned receive script.
+type OORReceiveScriptSignerFactory func(
+	keyDesc keychain.KeyDescriptor) indexer.SchnorrSigner
 
 // BuildPubKeyVTXOReceiveScript derives the standard VTXO-compatible taproot
 // output script for an OOR recipient pubkey.
@@ -118,6 +110,204 @@ func ResolveOwnedReceiveScriptKey(ctx context.Context,
 	}
 
 	return rec.ClientKey, nil
+}
+
+// ownedReceiveScriptSigner resolves the correct wallet key for each pkScript
+// from the persisted owned receive-script map, then delegates signing to the
+// backend-specific signer implementation for that key.
+type ownedReceiveScriptSigner struct {
+	store         ownedReceiveScriptLookup
+	signerFactory OORReceiveScriptSignerFactory
+}
+
+// NewOwnedReceiveScriptSigner returns an indexer signer that can prove control
+// for any persisted locally owned receive script instead of a single fixed key.
+func NewOwnedReceiveScriptSigner(store ownedReceiveScriptLookup,
+	signerFactory OORReceiveScriptSignerFactory) indexer.SchnorrSigner {
+
+	return &ownedReceiveScriptSigner{
+		store:         store,
+		signerFactory: signerFactory,
+	}
+}
+
+// resolveSigner loads the locally owned key for pkScript and constructs the
+// backend-specific signer that can prove control over it.
+func (s *ownedReceiveScriptSigner) resolveSigner(ctx context.Context,
+	pkScript []byte) (indexer.SchnorrSigner, error) {
+
+	if s.store == nil {
+		return nil, fmt.Errorf("owned receive script lookup must be " +
+			"provided")
+	}
+
+	if s.signerFactory == nil {
+		return nil, fmt.Errorf("receive script signer factory must be " +
+			"provided")
+	}
+
+	rec, err := s.store.LookupOwnedReceiveScript(ctx, pkScript)
+	if err != nil {
+		return nil, fmt.Errorf("lookup owned receive script: %w", err)
+	}
+
+	signer := s.signerFactory(rec.ClientKey)
+	if signer == nil {
+		return nil, fmt.Errorf("receive script signer factory returned " +
+			"nil signer")
+	}
+
+	return signer, nil
+}
+
+// SignSchnorr signs hash with the wallet key that controls pkScript.
+func (s *ownedReceiveScriptSigner) SignSchnorr(
+	pkScript []byte, hash [32]byte) ([]byte, error) {
+
+	signer, err := s.resolveSigner(context.Background(), pkScript)
+	if err != nil {
+		return nil, err
+	}
+
+	return signer.SignSchnorr(pkScript, hash)
+}
+
+// SignSchnorrMessage signs the canonical proof preimage for pkScript using the
+// backend-specific tagged-message path when available.
+func (s *ownedReceiveScriptSigner) SignSchnorrMessage(ctx context.Context,
+	pkScript []byte, message []byte, tag []byte) ([]byte, error) {
+
+	signer, err := s.resolveSigner(ctx, pkScript)
+	if err != nil {
+		return nil, err
+	}
+
+	msgSigner, ok := signer.(interface {
+		SignSchnorrMessage(context.Context, []byte, []byte,
+			[]byte) ([]byte, error)
+	})
+	if !ok {
+		return nil, fmt.Errorf("signer does not support tagged message " +
+			"signing")
+	}
+
+	return msgSigner.SignSchnorrMessage(
+		ctx, pkScript, message, tag,
+	)
+}
+
+// ProofPubKey returns the owner pubkey committed into proofs for pkScript.
+func (s *ownedReceiveScriptSigner) ProofPubKey(
+	pkScript []byte) (*btcec.PublicKey, error) {
+
+	signer, err := s.resolveSigner(context.Background(), pkScript)
+	if err != nil {
+		return nil, err
+	}
+
+	pubKeySource, ok := signer.(interface {
+		ProofPubKey([]byte) (*btcec.PublicKey, error)
+	})
+	if !ok {
+		return nil, fmt.Errorf("signer does not expose proof pubkey")
+	}
+
+	return pubKeySource.ProofPubKey(pkScript)
+}
+
+// CreateOORReceiveScript derives a fresh wallet key, registers the matching
+// receive script with the indexer, and persists the ownership metadata needed
+// to prove control over that script later.
+func CreateOORReceiveScript(ctx context.Context, idx *indexer.Client,
+	store ownedReceiveScriptStore,
+	deriveNextKey DeriveDefaultOORReceiveKeyFunc,
+	signerFactory OORReceiveScriptSignerFactory,
+	operatorKey *btcec.PublicKey, exitDelay uint32, label string) (
+	*keychain.KeyDescriptor, []byte, error,
+) {
+
+	if deriveNextKey == nil {
+		return nil, nil, fmt.Errorf("derive next key func must be " +
+			"provided")
+	}
+
+	keyDesc, err := deriveNextKey(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("derive oor receive key: %w", err)
+	}
+
+	if keyDesc == nil || keyDesc.PubKey == nil {
+		return nil, nil, fmt.Errorf("derive oor receive key: missing " +
+			"pubkey")
+	}
+
+	pkScript, err := RegisterOwnedOORReceiveScript(
+		ctx, idx, store, *keyDesc, signerFactory, operatorKey,
+		exitDelay, label,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return keyDesc, pkScript, nil
+}
+
+// RegisterOwnedOORReceiveScript registers and persists one wallet-owned OOR
+// receive script for clientKey using the signer produced by signerFactory.
+func RegisterOwnedOORReceiveScript(ctx context.Context,
+	idx *indexer.Client, store ownedReceiveScriptStore,
+	clientKey keychain.KeyDescriptor,
+	signerFactory OORReceiveScriptSignerFactory,
+	operatorKey *btcec.PublicKey, exitDelay uint32,
+	label string) ([]byte, error) {
+
+	switch {
+	case idx == nil:
+		return nil, fmt.Errorf("indexer client must be provided")
+
+	case signerFactory == nil:
+		return nil, fmt.Errorf("receive script signer factory must be " +
+			"provided")
+
+	case clientKey.PubKey == nil:
+		return nil, fmt.Errorf("client key must be provided")
+	}
+
+	pkScript, err := BuildPubKeyVTXOReceiveScript(
+		clientKey.PubKey, operatorKey, exitDelay,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	registerClient := idx.WithSigner(signerFactory(clientKey))
+
+	expiresAt := time.Now().Add(defaultOORReceiveScriptRegistrationTTL)
+	_, err = registerClient.RegisterReceiveScriptTaproot(
+		ctx, pkScript, expiresAt, label,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("register receive script: %w", err)
+	}
+
+	if store == nil {
+		return pkScript, nil
+	}
+
+	err = store.UpsertOwnedReceiveScript(ctx, db.OwnedReceiveScriptRecord{
+		PkScript:       pkScript,
+		ClientKey:      clientKey,
+		OperatorPubKey: operatorKey,
+		ExitDelay:      int64(exitDelay),
+		Source:         db.OwnedReceiveScriptSourceWallet,
+		CreatedAt:      time.Now(),
+		LastUsedAt:     fn.None[time.Time](),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("persist owned receive script: %w", err)
+	}
+
+	return pkScript, nil
 }
 
 // LoadDefaultOORReceiveKey loads the most recently persisted wallet-managed
@@ -200,6 +390,7 @@ func EnsureDefaultOORReceiveKey(ctx context.Context,
 func EnsureDefaultOORReceiveScript(ctx context.Context,
 	idx *indexer.Client, store defaultOORReceiveScriptStateStore,
 	deriveNextKey DeriveDefaultOORReceiveKeyFunc,
+	signerFactory OORReceiveScriptSignerFactory,
 	operatorKey *btcec.PublicKey, exitDelay uint32, label string) (
 	*keychain.KeyDescriptor, []byte, error,
 ) {
@@ -217,7 +408,8 @@ func EnsureDefaultOORReceiveScript(ctx context.Context,
 	}
 
 	pkScript, err := RegisterDefaultOORReceiveScript(
-		ctx, idx, store, *keyDesc, operatorKey, exitDelay, label,
+		ctx, idx, store, *keyDesc, signerFactory,
+		operatorKey, exitDelay, label,
 	)
 	if err != nil {
 		return nil, nil, err
@@ -226,52 +418,20 @@ func EnsureDefaultOORReceiveScript(ctx context.Context,
 	return keyDesc, pkScript, nil
 }
 
-// RegisterDefaultOORReceiveScript derives, registers, and persists the
-// default OOR receive script for the provided local wallet key.
+// RegisterDefaultOORReceiveScript registers and persists the default OOR
+// receive script for the provided local wallet key. It delegates to
+// RegisterOwnedOORReceiveScript with the provided signerFactory so the
+// registration proof is signed with the correct key (the script may not
+// yet be persisted in the DB at call time).
 func RegisterDefaultOORReceiveScript(ctx context.Context,
 	idx *indexer.Client, store ownedReceiveScriptStore,
-	clientKey keychain.KeyDescriptor, operatorKey *btcec.PublicKey,
+	clientKey keychain.KeyDescriptor,
+	signerFactory OORReceiveScriptSignerFactory,
+	operatorKey *btcec.PublicKey,
 	exitDelay uint32, label string) ([]byte, error) {
 
-	switch {
-	case idx == nil:
-		return nil, fmt.Errorf("indexer client must be provided")
-
-	case clientKey.PubKey == nil:
-		return nil, fmt.Errorf("client key must be provided")
-	}
-
-	pkScript, err := BuildPubKeyVTXOReceiveScript(
-		clientKey.PubKey, operatorKey, exitDelay,
+	return RegisterOwnedOORReceiveScript(
+		ctx, idx, store, clientKey, signerFactory,
+		operatorKey, exitDelay, label,
 	)
-	if err != nil {
-		return nil, err
-	}
-
-	expiresAt := time.Now().Add(defaultOORReceiveScriptRegistrationTTL)
-	_, err = idx.RegisterReceiveScriptTaproot(
-		ctx, pkScript, expiresAt, label,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("register receive script: %w", err)
-	}
-
-	if store == nil {
-		return pkScript, nil
-	}
-
-	err = store.UpsertOwnedReceiveScript(ctx, db.OwnedReceiveScriptRecord{
-		PkScript:       pkScript,
-		ClientKey:      clientKey,
-		OperatorPubKey: operatorKey,
-		ExitDelay:      int64(exitDelay),
-		Source:         db.OwnedReceiveScriptSourceWallet,
-		CreatedAt:      time.Now(),
-		LastUsedAt:     fn.None[time.Time](),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("persist owned receive script: %w", err)
-	}
-
-	return pkScript, nil
 }

--- a/darepod/receive_script.go
+++ b/darepod/receive_script.go
@@ -142,7 +142,7 @@ func (s *ownedReceiveScriptSigner) resolveSigner(ctx context.Context,
 	}
 
 	if s.signerFactory == nil {
-		return nil, fmt.Errorf("receive script signer factory must be " +
+		return nil, fmt.Errorf("receive script signer factory must be " + //nolint:ll
 			"provided")
 	}
 
@@ -153,7 +153,7 @@ func (s *ownedReceiveScriptSigner) resolveSigner(ctx context.Context,
 
 	signer := s.signerFactory(rec.ClientKey)
 	if signer == nil {
-		return nil, fmt.Errorf("receive script signer factory returned " +
+		return nil, fmt.Errorf("receive script signer factory returned " + //nolint:ll
 			"nil signer")
 	}
 
@@ -187,7 +187,7 @@ func (s *ownedReceiveScriptSigner) SignSchnorrMessage(ctx context.Context,
 			[]byte) ([]byte, error)
 	})
 	if !ok {
-		return nil, fmt.Errorf("signer does not support tagged message " +
+		return nil, fmt.Errorf("signer does not support tagged message " + //nolint:ll
 			"signing")
 	}
 
@@ -266,7 +266,7 @@ func RegisterOwnedOORReceiveScript(ctx context.Context,
 		return nil, fmt.Errorf("indexer client must be provided")
 
 	case signerFactory == nil:
-		return nil, fmt.Errorf("receive script signer factory must be " +
+		return nil, fmt.Errorf("receive script signer factory must be " + //nolint:ll
 			"provided")
 
 	case clientKey.PubKey == nil:

--- a/darepod/receive_script_test.go
+++ b/darepod/receive_script_test.go
@@ -97,7 +97,7 @@ func TestEnsureDefaultOORReceiveKeyReusesPersistedKey(t *testing.T) {
 
 	derived := false
 	keyDesc, err := EnsureDefaultOORReceiveKey(
-		ctx, store, func(context.Context) (*keychain.KeyDescriptor, error) {
+		ctx, store, func(context.Context) (*keychain.KeyDescriptor, error) { //nolint:ll
 			derived = true
 
 			return nil, nil
@@ -198,7 +198,7 @@ func TestNewOwnedReceiveScriptSignerUsesMatchingKey(t *testing.T) {
 			{
 				PkScript:       []byte{0x51, 0x20, 0x01},
 				ClientKey:      keyA,
-				Source:         db.OwnedReceiveScriptSourceWallet,
+				Source:         db.OwnedReceiveScriptSourceWallet, //nolint:ll
 				CreatedAt:      time.Unix(10, 0),
 				LastUsedAt:     fn.None[time.Time](),
 				OperatorPubKey: testKeyDescriptor(t, 31).PubKey,
@@ -206,7 +206,7 @@ func TestNewOwnedReceiveScriptSignerUsesMatchingKey(t *testing.T) {
 			{
 				PkScript:       []byte{0x51, 0x20, 0x02},
 				ClientKey:      keyB,
-				Source:         db.OwnedReceiveScriptSourceWallet,
+				Source:         db.OwnedReceiveScriptSourceWallet, //nolint:ll
 				CreatedAt:      time.Unix(11, 0),
 				LastUsedAt:     fn.None[time.Time](),
 				OperatorPubKey: testKeyDescriptor(t, 32).PubKey,
@@ -268,7 +268,7 @@ func TestEnsureDefaultOORReceiveKeyDerivesWhenMissing(t *testing.T) {
 	expected := testKeyDescriptor(t, 3)
 
 	keyDesc, err := EnsureDefaultOORReceiveKey(
-		ctx, store, func(context.Context) (*keychain.KeyDescriptor, error) {
+		ctx, store, func(context.Context) (*keychain.KeyDescriptor, error) { //nolint:ll
 			return &expected, nil
 		},
 	)

--- a/darepod/receive_script_test.go
+++ b/darepod/receive_script_test.go
@@ -2,14 +2,19 @@ package darepod
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/lightninglabs/darepo-client/arkrpc"
 	"github.com/lightninglabs/darepo-client/db"
+	"github.com/lightninglabs/darepo-client/indexer"
+	mailboxrpc "github.com/lightninglabs/darepo-client/mailbox/rpc"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 )
 
 // testReceiveScriptStore is a minimal in-memory owned receive-script store used
@@ -33,6 +38,23 @@ func (s *testReceiveScriptStore) UpsertOwnedReceiveScript(_ context.Context,
 	s.records = append(s.records, rec)
 
 	return nil
+}
+
+// LookupOwnedReceiveScript returns one tracked owned receive-script record.
+func (s *testReceiveScriptStore) LookupOwnedReceiveScript(_ context.Context,
+	pkScript []byte) (*db.OwnedReceiveScriptRecord, error) {
+
+	for i := range s.records {
+		if string(s.records[i].PkScript) != string(pkScript) {
+			continue
+		}
+
+		rec := s.records[i]
+
+		return &rec, nil
+	}
+
+	return nil, fmt.Errorf("owned receive script not found")
 }
 
 // ListOwnedReceiveScripts returns all tracked owned receive-script records.
@@ -91,6 +113,151 @@ func TestEnsureDefaultOORReceiveKeyReusesPersistedKey(t *testing.T) {
 	)
 }
 
+// TestCreateOORReceiveScriptDerivesFreshKeys verifies that each allocation
+// derives a new wallet key, registers the matching script, and persists a
+// distinct ownership record.
+func TestCreateOORReceiveScriptDerivesFreshKeys(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := &testReceiveScriptStore{}
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	keys := []keychain.KeyDescriptor{
+		testKeyDescriptor(t, 11),
+		testKeyDescriptor(t, 12),
+	}
+
+	nextKey := 0
+	rpcClient := &testReceiveScriptRPCClient{}
+	idx := indexer.New(
+		rpcClient, nil, "test-server", "client:test",
+	)
+
+	signerFactory := func(
+		keyDesc keychain.KeyDescriptor) indexer.SchnorrSigner {
+
+		return &testOwnedReceiveScriptSigner{
+			keyDesc: keyDesc,
+			tagSig:  []byte("test-tag-signature"),
+		}
+	}
+
+	_, pkScriptA, err := CreateOORReceiveScript(
+		ctx, idx, store,
+		func(context.Context) (*keychain.KeyDescriptor, error) {
+			key := keys[nextKey]
+			nextKey++
+
+			return &key, nil
+		},
+		signerFactory, operatorPriv.PubKey(), 144,
+		"test-oor-receive-a",
+	)
+	require.NoError(t, err)
+
+	_, pkScriptB, err := CreateOORReceiveScript(
+		ctx, idx, store,
+		func(context.Context) (*keychain.KeyDescriptor, error) {
+			key := keys[nextKey]
+			nextKey++
+
+			return &key, nil
+		},
+		signerFactory, operatorPriv.PubKey(), 144,
+		"test-oor-receive-b",
+	)
+	require.NoError(t, err)
+
+	require.NotEqual(t, pkScriptA, pkScriptB)
+	require.Len(t, store.records, 2)
+	require.Equal(
+		t, keys[0].PubKey.SerializeCompressed(),
+		store.records[0].ClientKey.PubKey.SerializeCompressed(),
+	)
+	require.Equal(
+		t, keys[1].PubKey.SerializeCompressed(),
+		store.records[1].ClientKey.PubKey.SerializeCompressed(),
+	)
+	require.Len(t, rpcClient.registerReqs, 2)
+	require.Equal(t, pkScriptA, rpcClient.registerReqs[0].PkScript)
+	require.Equal(t, pkScriptB, rpcClient.registerReqs[1].PkScript)
+}
+
+// TestNewOwnedReceiveScriptSignerUsesMatchingKey verifies that proofs are
+// produced with the wallet key associated with the queried pkScript.
+func TestNewOwnedReceiveScriptSignerUsesMatchingKey(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	keyA := testKeyDescriptor(t, 21)
+	keyB := testKeyDescriptor(t, 22)
+	store := &testReceiveScriptStore{
+		records: []db.OwnedReceiveScriptRecord{
+			{
+				PkScript:       []byte{0x51, 0x20, 0x01},
+				ClientKey:      keyA,
+				Source:         db.OwnedReceiveScriptSourceWallet,
+				CreatedAt:      time.Unix(10, 0),
+				LastUsedAt:     fn.None[time.Time](),
+				OperatorPubKey: testKeyDescriptor(t, 31).PubKey,
+			},
+			{
+				PkScript:       []byte{0x51, 0x20, 0x02},
+				ClientKey:      keyB,
+				Source:         db.OwnedReceiveScriptSourceWallet,
+				CreatedAt:      time.Unix(11, 0),
+				LastUsedAt:     fn.None[time.Time](),
+				OperatorPubKey: testKeyDescriptor(t, 32).PubKey,
+			},
+		},
+	}
+
+	signer := NewOwnedReceiveScriptSigner(
+		store,
+		func(keyDesc keychain.KeyDescriptor) indexer.SchnorrSigner {
+			return &testOwnedReceiveScriptSigner{
+				keyDesc: keyDesc,
+				tagSig: []byte{
+					keyDesc.PubKey.SerializeCompressed()[0],
+					keyDesc.PubKey.SerializeCompressed()[1],
+				},
+			}
+		},
+	)
+
+	pubKeySource, ok := signer.(interface {
+		ProofPubKey([]byte) (*btcec.PublicKey, error)
+	})
+	require.True(t, ok)
+
+	proofPubA, err := pubKeySource.ProofPubKey(store.records[0].PkScript)
+	require.NoError(t, err)
+	require.Equal(
+		t, keyA.PubKey.SerializeCompressed(),
+		proofPubA.SerializeCompressed(),
+	)
+
+	msgSigner, ok := signer.(interface {
+		SignSchnorrMessage(context.Context, []byte, []byte,
+			[]byte) ([]byte, error)
+	})
+	require.True(t, ok)
+
+	sigA, err := msgSigner.SignSchnorrMessage(
+		ctx, store.records[0].PkScript, []byte("msg"), []byte("tag"),
+	)
+	require.NoError(t, err)
+
+	sigB, err := msgSigner.SignSchnorrMessage(
+		ctx, store.records[1].PkScript, []byte("msg"), []byte("tag"),
+	)
+	require.NoError(t, err)
+
+	require.NotEqual(t, sigA, sigB)
+}
+
 // TestEnsureDefaultOORReceiveKeyDerivesWhenMissing verifies that the helper
 // falls back to the provided wallet derivation path when no stored key exists.
 func TestEnsureDefaultOORReceiveKeyDerivesWhenMissing(t *testing.T) {
@@ -129,9 +296,80 @@ func testKeyDescriptor(t *testing.T, seed byte) keychain.KeyDescriptor {
 
 	return keychain.KeyDescriptor{
 		KeyLocator: keychain.KeyLocator{
-			Family: DefaultOORReceiveKeyFamily(),
+			Family: keychain.KeyFamilyMultiSig,
 			Index:  uint32(seed),
 		},
 		PubKey: privKey.PubKey(),
 	}
+}
+
+// testOwnedReceiveScriptSigner is a minimal signer stub keyed by one wallet
+// descriptor.
+type testOwnedReceiveScriptSigner struct {
+	keyDesc keychain.KeyDescriptor
+	tagSig  []byte
+}
+
+// SignSchnorr returns a deterministic 64-byte signature for raw-digest paths.
+func (s *testOwnedReceiveScriptSigner) SignSchnorr(
+	_ []byte, _ [32]byte) ([]byte, error) {
+
+	return make([]byte, 64), nil
+}
+
+// SignSchnorrMessage returns a deterministic tagged-message signature.
+func (s *testOwnedReceiveScriptSigner) SignSchnorrMessage(
+	_ context.Context, _ []byte, _ []byte, _ []byte) ([]byte, error) {
+
+	return append([]byte(nil), s.tagSig...), nil
+}
+
+// ProofPubKey returns the wallet key bound to this signer.
+func (s *testOwnedReceiveScriptSigner) ProofPubKey(
+	_ []byte) (*btcec.PublicKey, error) {
+
+	return s.keyDesc.PubKey, nil
+}
+
+// testReceiveScriptRPCClient records mailbox RPC requests for registration.
+type testReceiveScriptRPCClient struct {
+	registerReqs []*arkrpc.RegisterReceiveScriptRequest
+}
+
+// SendRPC records RegisterReceiveScript requests and returns a fixed result.
+func (c *testReceiveScriptRPCClient) SendRPC(_ context.Context,
+	method mailboxrpc.ServiceMethod, req proto.Message,
+	_ mailboxrpc.RPCOptions) (mailboxrpc.SendResult, error) {
+
+	if method.Service == "arkrpc.IndexerService" &&
+		method.Method == "RegisterReceiveScript" {
+
+		regReq, ok := req.(*arkrpc.RegisterReceiveScriptRequest)
+		if !ok {
+			return mailboxrpc.SendResult{}, fmt.Errorf(
+				"unexpected register request type: %T", req,
+			)
+		}
+
+		c.registerReqs = append(c.registerReqs, regReq)
+	}
+
+	return mailboxrpc.SendResult{
+		CorrelationID:  "corr-id",
+		IdempotencyKey: "idem-key",
+	}, nil
+}
+
+// AwaitRPC populates the response expected by the generated mailbox client.
+func (c *testReceiveScriptRPCClient) AwaitRPC(_ context.Context,
+	_ string, resp proto.Message) error {
+
+	registerResp, ok := resp.(*arkrpc.RegisterReceiveScriptResponse)
+	if !ok {
+		return fmt.Errorf("unexpected response type: %T", resp)
+	}
+
+	*registerResp = arkrpc.RegisterReceiveScriptResponse{}
+
+	return nil
 }

--- a/darepod/receive_script_test.go
+++ b/darepod/receive_script_test.go
@@ -1,0 +1,137 @@
+package darepod
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/lightninglabs/darepo-client/db"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/stretchr/testify/require"
+)
+
+// testReceiveScriptStore is a minimal in-memory owned receive-script store used
+// by receive-script unit tests.
+type testReceiveScriptStore struct {
+	records []db.OwnedReceiveScriptRecord
+}
+
+// UpsertOwnedReceiveScript stores or replaces one owned receive-script record.
+func (s *testReceiveScriptStore) UpsertOwnedReceiveScript(_ context.Context,
+	rec db.OwnedReceiveScriptRecord) error {
+
+	for i := range s.records {
+		if string(s.records[i].PkScript) == string(rec.PkScript) {
+			s.records[i] = rec
+
+			return nil
+		}
+	}
+
+	s.records = append(s.records, rec)
+
+	return nil
+}
+
+// ListOwnedReceiveScripts returns all tracked owned receive-script records.
+func (s *testReceiveScriptStore) ListOwnedReceiveScripts(_ context.Context) (
+	[]db.OwnedReceiveScriptRecord, error,
+) {
+
+	records := make([]db.OwnedReceiveScriptRecord, len(s.records))
+	copy(records, s.records)
+
+	return records, nil
+}
+
+// TestEnsureDefaultOORReceiveKeyReusesPersistedKey verifies that the helper
+// prefers the most recent persisted wallet-managed receive key.
+func TestEnsureDefaultOORReceiveKeyReusesPersistedKey(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	olderKey := testKeyDescriptor(t, 1)
+	newerKey := testKeyDescriptor(t, 2)
+	store := &testReceiveScriptStore{
+		records: []db.OwnedReceiveScriptRecord{
+			{
+				PkScript:   []byte{0x51},
+				ClientKey:  olderKey,
+				Source:     db.OwnedReceiveScriptSourceWallet,
+				CreatedAt:  time.Unix(10, 0),
+				LastUsedAt: fn.None[time.Time](),
+			},
+			{
+				PkScript:   []byte{0x52},
+				ClientKey:  newerKey,
+				Source:     db.OwnedReceiveScriptSourceWallet,
+				CreatedAt:  time.Unix(20, 0),
+				LastUsedAt: fn.None[time.Time](),
+			},
+		},
+	}
+
+	derived := false
+	keyDesc, err := EnsureDefaultOORReceiveKey(
+		ctx, store, func(context.Context) (*keychain.KeyDescriptor, error) {
+			derived = true
+
+			return nil, nil
+		},
+	)
+	require.NoError(t, err)
+	require.False(t, derived)
+	require.NotNil(t, keyDesc)
+	require.Equal(
+		t,
+		newerKey.PubKey.SerializeCompressed(),
+		keyDesc.PubKey.SerializeCompressed(),
+	)
+}
+
+// TestEnsureDefaultOORReceiveKeyDerivesWhenMissing verifies that the helper
+// falls back to the provided wallet derivation path when no stored key exists.
+func TestEnsureDefaultOORReceiveKeyDerivesWhenMissing(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := &testReceiveScriptStore{}
+	expected := testKeyDescriptor(t, 3)
+
+	keyDesc, err := EnsureDefaultOORReceiveKey(
+		ctx, store, func(context.Context) (*keychain.KeyDescriptor, error) {
+			return &expected, nil
+		},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, keyDesc)
+	require.Equal(
+		t,
+		expected.PubKey.SerializeCompressed(),
+		keyDesc.PubKey.SerializeCompressed(),
+	)
+}
+
+// testKeyDescriptor creates a deterministic test key descriptor.
+func testKeyDescriptor(t *testing.T, seed byte) keychain.KeyDescriptor {
+	t.Helper()
+
+	privKey, _ := btcec.PrivKeyFromBytes(
+		[]byte{
+			seed, seed, seed, seed, seed, seed, seed, seed,
+			seed, seed, seed, seed, seed, seed, seed, seed,
+			seed, seed, seed, seed, seed, seed, seed, seed,
+			seed, seed, seed, seed, seed, seed, seed, seed,
+		},
+	)
+
+	return keychain.KeyDescriptor{
+		KeyLocator: keychain.KeyLocator{
+			Family: DefaultOORReceiveKeyFamily(),
+			Index:  uint32(seed),
+		},
+		PubKey: privKey.PubKey(),
+	}
+}

--- a/darepod/rpc_oor_receive.go
+++ b/darepod/rpc_oor_receive.go
@@ -51,7 +51,7 @@ func (r *RPCServer) NewOORReceiveScript(ctx context.Context,
 	store, err := r.newOORReceiveScriptStore()
 	if err != nil {
 		return nil, status.Errorf(codes.Internal,
-			"unable to initialize OOR receive-script store: %v", err)
+			"unable to initialize OOR receive-script store: %v", err) //nolint:ll
 	}
 
 	deriveNextKey, signerFactory, err := r.oorReceiveKeyOps()
@@ -116,16 +116,16 @@ func (r *RPCServer) oorReceiveKeyOps() (DeriveDefaultOORReceiveKeyFunc,
 	case r.server.lnd.IsSome():
 		lndSvc := r.server.lnd.UnsafeFromSome()
 
-		return func(ctx context.Context) (*keychain.KeyDescriptor, error) {
+		return func(ctx context.Context) (*keychain.KeyDescriptor, error) { //nolint:ll
 				keyDesc, err := lndSvc.WalletKit.DeriveNextKey(
 					ctx, int32(keychain.KeyFamilyMultiSig),
 				)
 				if err != nil {
-					return nil, fmt.Errorf("derive next key: %w", err)
+					return nil, fmt.Errorf("derive next key: %w", err) //nolint:ll
 				}
 
 				return keyDesc, nil
-			}, func(keyDesc keychain.KeyDescriptor) indexer.SchnorrSigner {
+			}, func(keyDesc keychain.KeyDescriptor) indexer.SchnorrSigner { //nolint:ll
 				return indexer.NewLNDSchnorrSigner(
 					lndSvc.Signer, keyDesc,
 				)
@@ -134,12 +134,12 @@ func (r *RPCServer) oorReceiveKeyOps() (DeriveDefaultOORReceiveKeyFunc,
 	case r.server.lwWallet.IsSome():
 		wallet := r.server.lwWallet.UnsafeFromSome()
 
-		return func(ctx context.Context) (*keychain.KeyDescriptor, error) {
+		return func(ctx context.Context) (*keychain.KeyDescriptor, error) { //nolint:ll
 				return wallet.DeriveNextKey(
 					ctx, keychain.KeyFamilyMultiSig,
 				)
 			}, func(
-				keyDesc keychain.KeyDescriptor) indexer.SchnorrSigner {
+				keyDesc keychain.KeyDescriptor) indexer.SchnorrSigner { //nolint:ll
 
 				return indexer.NewKeyRingSchnorrSigner(
 					wallet.KeyRing(), keyDesc,

--- a/darepod/rpc_oor_receive.go
+++ b/darepod/rpc_oor_receive.go
@@ -1,0 +1,152 @@
+package darepod
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/lightninglabs/darepo-client/db"
+	"github.com/lightninglabs/darepo-client/indexer"
+	"github.com/lightningnetwork/lnd/clock"
+	"github.com/lightningnetwork/lnd/keychain"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const defaultOORReceiveScriptLabel = "oor receive"
+
+// NewOORReceiveScript allocates a fresh wallet key, registers the matching
+// taproot receive script with the indexer, and returns the script details
+// needed to hand this one-shot destination to a sender.
+func (r *RPCServer) NewOORReceiveScript(ctx context.Context,
+	req *daemonrpc.NewOORReceiveScriptRequest) (
+	*daemonrpc.NewOORReceiveScriptResponse, error) {
+
+	if err := r.requireWalletReady(); err != nil {
+		return nil, err
+	}
+
+	if req == nil {
+		req = &daemonrpc.NewOORReceiveScriptRequest{}
+	}
+
+	if r.server.indexer == nil {
+		return nil, status.Errorf(codes.Internal,
+			"indexer client not initialized")
+	}
+
+	if r.server.db == nil {
+		return nil, status.Errorf(codes.Internal,
+			"database not initialized")
+	}
+
+	terms, err := r.server.fetchOperatorTerms(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"unable to fetch operator terms: %v", err)
+	}
+
+	store, err := r.newOORReceiveScriptStore()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"unable to initialize OOR receive-script store: %v", err)
+	}
+
+	deriveNextKey, signerFactory, err := r.oorReceiveKeyOps()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"unable to initialize OOR receive key ops: %v", err)
+	}
+
+	label := req.Label
+	if label == "" {
+		label = defaultOORReceiveScriptLabel
+	}
+
+	keyDesc, pkScript, err := CreateOORReceiveScript(
+		ctx, r.server.indexer, store, deriveNextKey, signerFactory,
+		terms.PubKey, terms.VTXOExitDelay, label,
+	)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"unable to create OOR receive script: %v", err)
+	}
+
+	if keyDesc == nil || keyDesc.PubKey == nil {
+		return nil, status.Errorf(codes.Internal,
+			"missing receive key descriptor")
+	}
+
+	return &daemonrpc.NewOORReceiveScriptResponse{
+		PkScriptHex: hex.EncodeToString(pkScript),
+		PubkeyXonlyHex: hex.EncodeToString(
+			schnorr.SerializePubKey(keyDesc.PubKey),
+		),
+		KeyFamily: uint32(keyDesc.KeyLocator.Family),
+		KeyIndex:  keyDesc.KeyLocator.Index,
+		Label:     label,
+	}, nil
+}
+
+// newOORReceiveScriptStore returns the artifact store used to persist owned
+// receive-script metadata for later proof lookup and incoming resolution.
+func (r *RPCServer) newOORReceiveScriptStore() (
+	*db.OORArtifactPersistenceStore, error,
+) {
+
+	if r.server.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	dbStore := db.NewStore(
+		r.server.db.DB, r.server.db.Queries, r.server.db.Backend(), log,
+	)
+
+	return dbStore.NewOORArtifactStore(clock.NewDefaultClock()), nil
+}
+
+// oorReceiveKeyOps returns the fresh-key derivation function and signer
+// factory for the active wallet backend.
+func (r *RPCServer) oorReceiveKeyOps() (DeriveDefaultOORReceiveKeyFunc,
+	OORReceiveScriptSignerFactory, error) {
+
+	switch {
+	case r.server.lnd.IsSome():
+		lndSvc := r.server.lnd.UnsafeFromSome()
+
+		return func(ctx context.Context) (*keychain.KeyDescriptor, error) {
+				keyDesc, err := lndSvc.WalletKit.DeriveNextKey(
+					ctx, int32(keychain.KeyFamilyMultiSig),
+				)
+				if err != nil {
+					return nil, fmt.Errorf("derive next key: %w", err)
+				}
+
+				return keyDesc, nil
+			}, func(keyDesc keychain.KeyDescriptor) indexer.SchnorrSigner {
+				return indexer.NewLNDSchnorrSigner(
+					lndSvc.Signer, keyDesc,
+				)
+			}, nil
+
+	case r.server.lwWallet.IsSome():
+		wallet := r.server.lwWallet.UnsafeFromSome()
+
+		return func(ctx context.Context) (*keychain.KeyDescriptor, error) {
+				return wallet.DeriveNextKey(
+					ctx, keychain.KeyFamilyMultiSig,
+				)
+			}, func(
+				keyDesc keychain.KeyDescriptor) indexer.SchnorrSigner {
+
+				return indexer.NewKeyRingSchnorrSigner(
+					wallet.KeyRing(), keyDesc,
+				)
+			}, nil
+
+	default:
+		return nil, nil, fmt.Errorf("wallet backend not initialized")
+	}
+}

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -931,19 +931,20 @@ func (r *RPCServer) resolveOutputPkScript(ctx context.Context,
 			)
 		}
 
-		tapKey, err := scripts.VTXOTapKey(
+		pkScript, err := BuildPubKeyVTXOReceiveScript(
 			recipientKey, terms.PubKey,
 			terms.VTXOExitDelay,
 		)
 		if err != nil {
 			return nil, status.Errorf(
 				codes.Internal,
-				"unable to derive VTXO tap key: %v",
+				"unable to derive VTXO receive "+
+					"script: %v",
 				err,
 			)
 		}
 
-		return txscript.PayToTaprootScript(tapKey)
+		return pkScript, nil
 
 	case *daemonrpc.Output_PkScript:
 		if len(d.PkScript) == 0 {

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -1085,7 +1085,7 @@ func (s *Server) buildEventRoutes() *serverconn.EventRouter {
 // EventRouter. When the server pushes SubmitPackage or FinalizePackage
 // response events, the router decodes the oorpb proto, adapts it into a
 // DriveEventRequest, and Tell's it to the OOR actor via service key.
-func (s *Server) registerOOREventRoutes(router *serverconn.EventRouter) {
+func (s *Server) registerOOREventRoutes(router *serverconn.EventRouter) { //nolint:funlen,ll
 	oorKey := oor.NewServiceKey()
 
 	// SubmitPackage: server accepted the submit and returned co-signed
@@ -1182,7 +1182,7 @@ func (s *Server) registerOOREventRoutes(router *serverconn.EventRouter) {
 					"response envelope must be provided")
 			}
 
-			sessionID, err := oor.ParseIncomingMetadataCorrelationID(
+			sessionID, err := oor.ParseIncomingMetadataCorrelationID( //nolint:ll
 				env.Rpc.CorrelationId,
 			)
 			if err != nil {
@@ -1192,12 +1192,11 @@ func (s *Server) registerOOREventRoutes(router *serverconn.EventRouter) {
 			if rpcErr := mailboxrpc.DecodeErrorHeaders(
 				env.Headers,
 			); rpcErr != nil {
-
 				return &oor.DriveEventRequest{
 					SessionID: sessionID,
 					Event: &oor.FailEvent{
 						Reason: fmt.Sprintf(
-							"query incoming metadata: %v",
+							"query incoming metadata: %v", //nolint:ll
 							rpcErr,
 						),
 					},
@@ -1257,26 +1256,25 @@ func (s *Server) registerOOREventRoutes(router *serverconn.EventRouter) {
 			if rpcErr := mailboxrpc.DecodeErrorHeaders(
 				env.Headers,
 			); rpcErr != nil {
-
 				return &oor.DriveEventRequest{
 					SessionID: sessionID,
 					Event: &oor.FailEvent{
 						Reason: fmt.Sprintf(
-							"resolve incoming transfer: %v",
+							"resolve incoming transfer: %v", //nolint:ll
 							rpcErr,
 						),
 					},
 				}, nil
 			}
 
-			resp, ok := p.(*arkrpc.ListOORRecipientEventsByScriptResponse)
+			resp, ok := p.(*arkrpc.ListOORRecipientEventsByScriptResponse) //nolint:ll
 			if !ok {
 				return nil, fmt.Errorf("expected "+
-					"ListOORRecipientEventsByScriptResponse, "+
+					"ListOORRecipientEventsByScriptResponse, "+ //nolint:ll
 					"got %T", p)
 			}
 
-			incomingEvent, err := oor.IncomingTransferEventFromResponse(
+			incomingEvent, err := oor.IncomingTransferEventFromResponse( //nolint:ll
 				sessionID, recipientEventID, resp,
 			)
 			if err != nil {
@@ -1620,7 +1618,7 @@ func (s *Server) initRPCClients(ctx context.Context) {
 		s.clientKeyDesc = *identityDesc
 		signer = NewOwnedReceiveScriptSigner(
 			packageStore,
-			func(keyDesc keychain.KeyDescriptor) indexer.SchnorrSigner {
+			func(keyDesc keychain.KeyDescriptor) indexer.SchnorrSigner { //nolint:ll
 				return indexer.NewLNDSchnorrSigner(
 					lndSvc.Signer, keyDesc,
 				)
@@ -1643,7 +1641,7 @@ func (s *Server) initRPCClients(ctx context.Context) {
 			s.clientKeyDesc = *identityDesc
 			signer = NewOwnedReceiveScriptSigner(
 				packageStore,
-				func(keyDesc keychain.KeyDescriptor) indexer.SchnorrSigner {
+				func(keyDesc keychain.KeyDescriptor) indexer.SchnorrSigner { //nolint:ll
 					return indexer.NewKeyRingSchnorrSigner(
 						w.KeyRing(), keyDesc,
 					)

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -156,14 +156,8 @@ type Server struct {
 	vtxoExitDelay uint32
 
 	// clientKeyDesc is the client's identity key descriptor,
-	// derived during wallet initialization. Used by the OOR
-	// receive path to match incoming recipient outputs.
+	// derived during wallet initialization.
 	clientKeyDesc keychain.KeyDescriptor
-
-	// oorReceiveKeyDesc is the stable wallet key used for the
-	// daemon's default OOR receive script and receive-script proof
-	// signing.
-	oorReceiveKeyDesc keychain.KeyDescriptor
 
 	runtime *serverconn.Runtime
 	ark     *arkrpc.ArkServiceMailboxClient
@@ -468,6 +462,9 @@ func (s *Server) run(ctx context.Context,
 	connCfg.ProtocolVersion = 1
 	connCfg.Store = s.deliveryStore
 	connCfg.Dispatchers = dispatchers
+	connCfg.DurableUnaryBuilder = &serverDurableUnaryBuilder{
+		server: s,
+	}
 
 	s.runtime, err = serverconn.NewRuntime(connCfg)
 	if err != nil {
@@ -1181,7 +1178,7 @@ func (s *Server) registerOOREventRoutes(router *serverconn.EventRouter) {
 			p proto.Message) (oor.OORDurableMsg, error) {
 
 			if env == nil || env.Rpc == nil {
-				return nil, fmt.Errorf("incoming metadata "+
+				return nil, fmt.Errorf("incoming metadata " +
 					"response envelope must be provided")
 			}
 
@@ -1225,6 +1222,70 @@ func (s *Server) registerOOREventRoutes(router *serverconn.EventRouter) {
 				Event: &oor.IncomingMetadataResolvedEvent{
 					Matches: matches,
 				},
+			}, nil
+		},
+	})
+
+	// ListOORRecipientEventsByScript response: server resolved the
+	// lightweight incoming transfer hint into the full Ark package for a
+	// durable OOR receive session query.
+	serverconn.AddEnvelopeRoute(router, serverconn.EnvelopeRouteConfig[
+		oor.OORDurableMsg, oor.ActorResp,
+	]{
+		Service: "arkrpc.IndexerService",
+		Method:  "ListOORRecipientEventsByScript",
+		NewEvent: func() proto.Message {
+			return &arkrpc.ListOORRecipientEventsByScriptResponse{}
+		},
+		Key: oorKey,
+		Adapt: func(env *mailboxpb.Envelope,
+			p proto.Message) (oor.OORDurableMsg, error) {
+
+			if env == nil || env.Rpc == nil {
+				return nil, fmt.Errorf("incoming resolve " +
+					"response envelope must be provided")
+			}
+
+			sessionID, recipientEventID, err :=
+				oor.ParseIncomingResolveCorrelationID(
+					env.Rpc.CorrelationId,
+				)
+			if err != nil {
+				return nil, err
+			}
+
+			if rpcErr := mailboxrpc.DecodeErrorHeaders(
+				env.Headers,
+			); rpcErr != nil {
+
+				return &oor.DriveEventRequest{
+					SessionID: sessionID,
+					Event: &oor.FailEvent{
+						Reason: fmt.Sprintf(
+							"resolve incoming transfer: %v",
+							rpcErr,
+						),
+					},
+				}, nil
+			}
+
+			resp, ok := p.(*arkrpc.ListOORRecipientEventsByScriptResponse)
+			if !ok {
+				return nil, fmt.Errorf("expected "+
+					"ListOORRecipientEventsByScriptResponse, "+
+					"got %T", p)
+			}
+
+			incomingEvent, err := oor.IncomingTransferEventFromResponse(
+				sessionID, recipientEventID, resp,
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			return &oor.DriveEventRequest{
+				SessionID: sessionID,
+				Event:     incomingEvent,
 			}, nil
 		},
 	})
@@ -1536,6 +1597,11 @@ func (s *Server) initRPCClients(ctx context.Context) {
 	// In lnd mode this comes from the lnd connection. In lwwallet
 	// mode, the identity is derived from the wallet keyring once
 	// the wallet is ready.
+	//
+	// The indexer client itself must prove control over multiple owned
+	// receive scripts, so it uses a dynamic signer that resolves the
+	// correct wallet key from the persisted owned-script map for each
+	// pkScript.
 	var signer indexer.SchnorrSigner
 	s.lnd.WhenSome(func(lndSvc *lndclient.GrpcLndServices) {
 		identityDesc, err := lndSvc.WalletKit.DeriveKey(ctx,
@@ -1552,27 +1618,13 @@ func (s *Server) initRPCClients(ctx context.Context) {
 		}
 
 		s.clientKeyDesc = *identityDesc
-
-		receiveDesc, err := EnsureDefaultOORReceiveKey(
-			ctx, packageStore, func(ctx context.Context) (
-				*keychain.KeyDescriptor, error,
-			) {
-				return lndSvc.WalletKit.DeriveNextKey(
-					ctx, int32(DefaultOORReceiveKeyFamily()),
+		signer = NewOwnedReceiveScriptSigner(
+			packageStore,
+			func(keyDesc keychain.KeyDescriptor) indexer.SchnorrSigner {
+				return indexer.NewLNDSchnorrSigner(
+					lndSvc.Signer, keyDesc,
 				)
 			},
-		)
-		if err != nil {
-			log.WarnS(ctx,
-				"Unable to resolve default OOR receive key",
-				err)
-
-			return
-		}
-
-		s.oorReceiveKeyDesc = *receiveDesc
-		signer = indexer.NewLNDSchnorrSigner(
-			lndSvc.Signer, *receiveDesc,
 		)
 	})
 	s.lwWallet.WhenSome(func(w *lwwallet.Wallet) {
@@ -1589,27 +1641,13 @@ func (s *Server) initRPCClients(ctx context.Context) {
 					"indexer", err)
 		} else {
 			s.clientKeyDesc = *identityDesc
-
-			receiveDesc, err := EnsureDefaultOORReceiveKey(
-				ctx, packageStore, func(ctx context.Context) (
-					*keychain.KeyDescriptor, error,
-				) {
-					return w.DeriveNextKey(
-						ctx, DefaultOORReceiveKeyFamily(),
+			signer = NewOwnedReceiveScriptSigner(
+				packageStore,
+				func(keyDesc keychain.KeyDescriptor) indexer.SchnorrSigner {
+					return indexer.NewKeyRingSchnorrSigner(
+						w.KeyRing(), keyDesc,
 					)
 				},
-			)
-			if err != nil {
-				log.WarnS(ctx,
-					"Unable to resolve default OOR "+
-						"receive key", err)
-
-				return
-			}
-
-			s.oorReceiveKeyDesc = *receiveDesc
-			signer = indexer.NewKeyRingSchnorrSigner(
-				w.KeyRing(), *receiveDesc,
 			)
 		}
 	})
@@ -1911,15 +1949,6 @@ func (s *Server) initOORActor(ctx context.Context,
 	vtxoStore := dbStore.NewVTXOStore(clk)
 	packageStore := dbStore.NewOORArtifactStore(clk)
 
-	_, err := RegisterDefaultOORReceiveScript(
-		ctx, s.indexer, packageStore, s.oorReceiveKeyDesc,
-		s.operatorKey, s.vtxoExitDelay, "default-oor-receive",
-	)
-	if err != nil {
-		return fmt.Errorf("register default OOR receive "+
-			"script: %w", err)
-	}
-
 	// Create the timeout actor for scheduling retry timers. When a
 	// retry timer fires, the callback ref transforms the expiry into
 	// a DriveEventRequest and Tell's it back to the OOR actor.
@@ -1997,54 +2026,6 @@ func (s *Server) initOORActor(ctx context.Context,
 		ActorID:       oor.OORActorServiceKeyName,
 		VTXOManager:   vtxoManagerRef,
 		VTXOStore:     vtxoStore,
-		IncomingFetcher: func(ctx context.Context,
-			pkScript []byte, afterEventID uint64,
-			limit uint32) (
-			*arkrpc.ListOORRecipientEventsByScriptResponse,
-			error) {
-
-			return s.indexer.ListOORRecipientEventsByScriptTaproot(
-				ctx, pkScript, afterEventID, limit,
-			)
-		},
-		BuildIncomingMetadataRPC: func(ctx context.Context,
-			req *oor.QueryIncomingMetadataRequest) (
-			*serverconn.SendUnaryRequest, error) {
-
-			if req == nil {
-				return nil, fmt.Errorf("incoming metadata query "+
-					"must be provided")
-			}
-
-			scopes := make([]indexer.TaprootScriptScope, 0,
-				len(req.Recipients))
-			for i := range req.Recipients {
-				scopes = append(scopes, indexer.TaprootScriptScope{
-					PkScript: append([]byte(nil),
-						req.Recipients[i].PkScript...),
-				})
-			}
-
-			rpcReq, err := s.indexer.
-				BuildListVTXOsByScriptsTaprootRequest(
-					ctx, scopes, 0,
-					incomingMetadataIndexPageSize, nil,
-				)
-			if err != nil {
-				return nil, err
-			}
-
-			return serverconn.NewSendUnaryRequest(
-				mailboxrpc.ServiceMethod{
-					Service: "arkrpc.IndexerService",
-					Method:  "ListVTXOsByScripts",
-				},
-				rpcReq,
-				oor.IncomingMetadataCorrelationID(
-				req.SessionID,
-				),
-			)
-		},
 	})
 
 	// Wire the timeout callback ref using the registered service

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -16,7 +16,6 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/arkrpc"
@@ -30,7 +29,6 @@ import (
 	"github.com/lightninglabs/darepo-client/indexer"
 	"github.com/lightninglabs/darepo-client/lib/actormsg"
 	"github.com/lightninglabs/darepo-client/lib/types"
-	"github.com/lightninglabs/darepo-client/lib/tx/psbtutil"
 	"github.com/lightninglabs/darepo-client/lndbackend"
 	"github.com/lightninglabs/darepo-client/lwwallet"
 	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
@@ -161,6 +159,11 @@ type Server struct {
 	// derived during wallet initialization. Used by the OOR
 	// receive path to match incoming recipient outputs.
 	clientKeyDesc keychain.KeyDescriptor
+
+	// oorReceiveKeyDesc is the stable wallet key used for the
+	// daemon's default OOR receive script and receive-script proof
+	// signing.
+	oorReceiveKeyDesc keychain.KeyDescriptor
 
 	runtime *serverconn.Runtime
 	ark     *arkrpc.ArkServiceMailboxClient
@@ -710,6 +713,13 @@ func (s *Server) startLwwallet(ctx context.Context,
 
 	s.lwWallet = fn.Some(w)
 
+	// Refresh the RPC clients once the wallet is available so the
+	// indexer client picks up the wallet-backed identity key and signer
+	// before any deferred wallet-dependent actors start.
+	if s.runtime != nil {
+		s.initRPCClients(ctx)
+	}
+
 	log.InfoS(ctx, "Lightweight wallet started")
 
 	s.markWalletReady()
@@ -1157,16 +1167,11 @@ func (s *Server) registerOOREventRoutes(router *serverconn.EventRouter) {
 	})
 
 	// IncomingOOR: server notifies the client about an incoming
-	// OOR transfer via the indexer's ArkService. The
-	// IncomingOOREvent is a lightweight notification hint. The
-	// route's Adapt closure queries the indexer (via
-	// ListOORRecipientEventsByScript) to fetch the full Ark
-	// PSBT and checkpoint data needed by IncomingTransferEvent.
-	//
-	// The indexer query uses the ark mailbox client which is
-	// wired during server initialization. The query response
-	// now includes ark_psbt and checkpoint_psbts fields.
-	idxClient := s.indexer
+	// OOR transfer via the indexer's ArkService. Persist only the
+	// lightweight notification hint here; the durable OOR actor
+	// performs the follow-up indexer query from its own worker
+	// context. This avoids deadlocking mailbox ingress on a unary
+	// response that must be delivered by the same runtime.
 	serverconn.AddRoute(router, serverconn.EventRouteConfig[
 		oor.OORDurableMsg, oor.ActorResp,
 	]{
@@ -1187,71 +1192,7 @@ func (s *Server) registerOOREventRoutes(router *serverconn.EventRouter) {
 				)
 			}
 
-			sessionID, err := chainhash.NewHash(
-				evt.GetSessionId(),
-			)
-			if err != nil {
-				return nil, fmt.Errorf(
-					"parse session id: %w", err,
-				)
-			}
-
-			// Query the indexer for the full package
-			// data. The notification is just a hint.
-			resp, err := idxClient.ListOORRecipientEventsByScriptTaproot(
-				context.Background(),
-				evt.GetRecipientPkScript(),
-				evt.GetRecipientEventId()-1,
-				1,
-			)
-			if err != nil || len(resp.GetEvents()) == 0 {
-				return nil, fmt.Errorf(
-					"fetch OOR package for session "+
-						"%x: %w",
-					sessionID[:], err,
-				)
-			}
-
-			recipientEvt := resp.Events[0]
-
-			// Parse the Ark PSBT from the response.
-			arkPSBT, parseErr := psbtutil.Parse(
-				recipientEvt.GetArkPsbt(),
-			)
-			if parseErr != nil {
-				return nil, fmt.Errorf(
-					"parse ark psbt: %w", parseErr,
-				)
-			}
-
-			// Parse checkpoint PSBTs.
-			var checkpoints []*psbt.Packet
-			for _, cpRaw := range recipientEvt.GetCheckpointPsbts() {
-				cp, cpErr := psbtutil.Parse(cpRaw)
-				if cpErr != nil {
-					return nil, fmt.Errorf(
-						"parse checkpoint: %w",
-						cpErr,
-					)
-				}
-
-				checkpoints = append(
-					checkpoints, cp,
-				)
-			}
-
-			return &oor.DriveEventRequest{
-				SessionID: oor.SessionID(
-					*sessionID,
-				),
-				Event: &oor.IncomingTransferEvent{
-					SessionID: oor.SessionID(
-						*sessionID,
-					),
-					ArkPSBT: arkPSBT,
-					FinalCheckpointPSBTs: checkpoints,
-				},
-			}, nil
+			return oor.NewResolveIncomingTransferRequest(evt)
 		},
 	})
 
@@ -1523,32 +1464,59 @@ func (s *Server) initDatabase(ctx context.Context) error {
 func (s *Server) initRPCClients(ctx context.Context) {
 	s.ark = arkrpc.NewArkServiceMailboxClient(s.runtime.Unary())
 
+	dbStore := db.NewStore(
+		s.db.DB, s.db.Queries, s.db.Backend(), log,
+	)
+	packageStore := dbStore.NewOORArtifactStore(clock.NewDefaultClock())
+
 	// Determine the node identity pubkey for indexer registration.
 	// In lnd mode this comes from the lnd connection. In lwwallet
 	// mode, the identity is derived from the wallet keyring once
 	// the wallet is ready.
-	var identityPubkey string
+	var signer indexer.SchnorrSigner
 	s.lnd.WhenSome(func(lndSvc *lndclient.GrpcLndServices) {
-		identityPubkey = lndSvc.NodePubkey.String()
-
-		// Store the client key descriptor for OOR
-		// incoming transfer resolution. Parse the
-		// LND node pubkey (route.Vertex) into a
-		// btcec public key.
-		nodePub, parseErr := btcec.ParsePubKey(
-			lndSvc.NodePubkey[:],
+		identityDesc, err := lndSvc.WalletKit.DeriveKey(ctx,
+			&keychain.KeyLocator{
+				Family: identityKeyFamily,
+				Index:  0,
+			},
 		)
-		if parseErr == nil {
-			s.clientKeyDesc = keychain.KeyDescriptor{
-				PubKey: nodePub,
-			}
+		if err != nil {
+			log.WarnS(ctx,
+				"Unable to derive identity key for indexer", err)
+
+			return
 		}
+
+		s.clientKeyDesc = *identityDesc
+
+		receiveDesc, err := EnsureDefaultOORReceiveKey(
+			ctx, packageStore, func(ctx context.Context) (
+				*keychain.KeyDescriptor, error,
+			) {
+				return lndSvc.WalletKit.DeriveNextKey(
+					ctx, int32(DefaultOORReceiveKeyFamily()),
+				)
+			},
+		)
+		if err != nil {
+			log.WarnS(ctx,
+				"Unable to resolve default OOR receive key",
+				err)
+
+			return
+		}
+
+		s.oorReceiveKeyDesc = *receiveDesc
+		signer = indexer.NewLNDSchnorrSigner(
+			lndSvc.Signer, *receiveDesc,
+		)
 	})
 	s.lwWallet.WhenSome(func(w *lwwallet.Wallet) {
 		// Derive the node identity key from the wallet
 		// keyring. This is safe even if the wallet isn't
 		// fully synced, as it only depends on the seed.
-		desc, err := w.DeriveKey(ctx, keychain.KeyLocator{
+		identityDesc, err := w.DeriveKey(ctx, keychain.KeyLocator{
 			Family: identityKeyFamily,
 			Index:  0,
 		})
@@ -1557,23 +1525,36 @@ func (s *Server) initRPCClients(ctx context.Context) {
 				"Unable to derive identity key for "+
 					"indexer", err)
 		} else {
-			identityPubkey = fmt.Sprintf(
-				"%x",
-				desc.PubKey.SerializeCompressed(),
-			)
+			s.clientKeyDesc = *identityDesc
 
-			// Store the client key descriptor for
-			// OOR incoming transfer resolution.
-			s.clientKeyDesc = *desc
+			receiveDesc, err := EnsureDefaultOORReceiveKey(
+				ctx, packageStore, func(ctx context.Context) (
+					*keychain.KeyDescriptor, error,
+				) {
+					return w.DeriveNextKey(
+						ctx, DefaultOORReceiveKeyFamily(),
+					)
+				},
+			)
+			if err != nil {
+				log.WarnS(ctx,
+					"Unable to resolve default OOR "+
+						"receive key", err)
+
+				return
+			}
+
+			s.oorReceiveKeyDesc = *receiveDesc
+			signer = indexer.NewKeyRingSchnorrSigner(
+				w.KeyRing(), *receiveDesc,
+			)
 		}
 	})
 
-	// TODO(roasbeef): wire SchnorrSigner from lnd backend once
-	// indexer proof-of-control is enabled in the daemon.
 	s.indexer = indexer.New(
-		s.runtime.Unary(), nil,
+		s.runtime.Unary(), signer,
 		s.cfg.Server.RemoteMailboxID,
-		identityPubkey,
+		s.cfg.Server.LocalMailboxID,
 	)
 
 	log.InfoS(ctx, "RPC clients initialized")
@@ -1867,6 +1848,15 @@ func (s *Server) initOORActor(ctx context.Context,
 	vtxoStore := dbStore.NewVTXOStore(clk)
 	packageStore := dbStore.NewOORArtifactStore(clk)
 
+	_, err := RegisterDefaultOORReceiveScript(
+		ctx, s.indexer, packageStore, s.oorReceiveKeyDesc,
+		s.operatorKey, s.vtxoExitDelay, "default-oor-receive",
+	)
+	if err != nil {
+		return fmt.Errorf("register default OOR receive "+
+			"script: %w", err)
+	}
+
 	// Create the timeout actor for scheduling retry timers. When a
 	// retry timer fires, the callback ref transforms the expiry into
 	// a DriveEventRequest and Tell's it back to the OOR actor.
@@ -1879,27 +1869,26 @@ func (s *Server) initOORActor(ctx context.Context,
 
 	// Wire spend completion through the VTXO manager so each consumed
 	// VTXO transitions to SpentState via its own FSM, rather than
-	// writing VTXOStatusSpent directly to the store.
+	// writing VTXOStatusSpent directly to the store. Use Tell rather
+	// than Ask so the OOR durable actor can commit its own delivery
+	// transaction before the VTXO actor performs follow-up DB writes.
 	mgrKey := actormsg.VTXOManagerServiceKey()
 	completeSpend := func(ctx context.Context,
 		outpoints []wire.OutPoint) error {
 
-		req := &actormsg.CompleteSpendRequest{
-			Outpoints: outpoints,
-		}
-		mgrRef := mgrKey.Ref(s.actorSystem)
-		result := mgrRef.Ask(ctx, req).Await(ctx)
-		_, err := result.Unpack()
-
-		return err
+		return mgrKey.Ref(s.actorSystem).Tell(
+			ctx, &actormsg.CompleteSpendRequest{
+				Outpoints: outpoints,
+			},
+		)
 	}
 
 	outboxHandler := &oor.LocalPersistenceOutboxHandler{
 		Next:         signingHandler,
 		Store:        vtxoStore,
 		PackageStore: packageStore,
-		OperatorKey: s.operatorKey,
-		ExitDelay:   s.vtxoExitDelay,
+		OperatorKey:  s.operatorKey,
+		ExitDelay:    s.vtxoExitDelay,
 		NotifyIncomingVTXOs: func(ctx context.Context,
 			descs []*vtxo.Descriptor) error {
 
@@ -1915,11 +1904,9 @@ func (s *Server) initOORActor(ctx context.Context,
 			recipient oor.ArkRecipientOutput) (
 			keychain.KeyDescriptor, error) {
 
-			// Single-key model: return the client's
-			// identity key for any recipient output.
-			// Multi-key support would need pkScript
-			// matching against derived keys.
-			return s.clientKeyDesc, nil
+			return ResolveOwnedReceiveScriptKey(
+				ctx, packageStore, recipient,
+			)
 		},
 		ResolveIncomingMetadata: func(ctx context.Context,
 			sessionID oor.SessionID,
@@ -1928,26 +1915,12 @@ func (s *Server) initOORActor(ctx context.Context,
 			finalCheckpoints []*psbt.Packet) (
 			oor.IncomingVTXOMetadata, error) {
 
-			// Derive metadata from the Ark PSBT.
-			// The commitment tx is the parent of
-			// the sender's VTXO (first input).
-			var commitTxID chainhash.Hash
-			roundID := chainhash.Hash(sessionID).String()
+			_ = ark
+			_ = finalCheckpoints
 
-			if ark != nil && ark.UnsignedTx != nil &&
-				len(ark.UnsignedTx.TxIn) > 0 {
-
-				commitTxID = ark.UnsignedTx.TxIn[0].
-					PreviousOutPoint.Hash
-			}
-
-			chainDepth := len(finalCheckpoints)
-
-			return oor.IncomingVTXOMetadata{
-				RoundID:        roundID,
-				CommitmentTxID: commitTxID,
-				ChainDepth:     chainDepth,
-			}, nil
+			return ResolveIncomingMetadataFromIndexer(
+				ctx, s.indexer, sessionID, recipient,
+			)
 		},
 	}
 
@@ -1960,6 +1933,17 @@ func (s *Server) initOORActor(ctx context.Context,
 		ActorSystem:   s.actorSystem,
 		ActorID:       oor.OORActorServiceKeyName,
 		VTXOManager:   vtxoManagerRef,
+		VTXOStore:     vtxoStore,
+		IncomingFetcher: func(ctx context.Context,
+			pkScript []byte, afterEventID uint64,
+			limit uint32) (
+			*arkrpc.ListOORRecipientEventsByScriptResponse,
+			error) {
+
+			return s.indexer.ListOORRecipientEventsByScriptTaproot(
+				ctx, pkScript, afterEventID, limit,
+			)
+		},
 	})
 
 	// Wire the timeout callback ref using the registered service

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -14,7 +14,9 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/arkrpc"
@@ -28,6 +30,7 @@ import (
 	"github.com/lightninglabs/darepo-client/indexer"
 	"github.com/lightninglabs/darepo-client/lib/actormsg"
 	"github.com/lightninglabs/darepo-client/lib/types"
+	"github.com/lightninglabs/darepo-client/lib/tx/psbtutil"
 	"github.com/lightninglabs/darepo-client/lndbackend"
 	"github.com/lightninglabs/darepo-client/lwwallet"
 	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
@@ -76,6 +79,16 @@ const (
 	// operational. All wallet RPCs (GetBalance, NewAddress, etc.)
 	// are available.
 	WalletStateReady
+)
+
+const (
+	// arkServiceName is the protobuf service name for ArkService
+	// events pushed by the server indexer.
+	arkServiceName = "arkrpc.ArkService"
+
+	// MethodIncomingOOR is the routing method name for incoming
+	// OOR transfer notifications pushed by the server indexer.
+	MethodIncomingOOR = "IncomingOOR"
 )
 
 // Main is the true entry point for the daemon. It is called after CLI flag
@@ -133,6 +146,21 @@ type Server struct {
 	// mode this is populated from the lnd connection; in lwwallet
 	// mode it is derived from the config's network string.
 	chainParams *chaincfg.Params
+
+	// operatorKey is the operator's public key from GetInfo.
+	// Used by the OOR receive path for checkpoint leaf
+	// construction.
+	operatorKey *btcec.PublicKey
+
+	// vtxoExitDelay is the operator's VTXO exit delay from
+	// GetInfo. Used by the OOR receive path for VTXO descriptor
+	// construction.
+	vtxoExitDelay uint32
+
+	// clientKeyDesc is the client's identity key descriptor,
+	// derived during wallet initialization. Used by the OOR
+	// receive path to match incoming recipient outputs.
+	clientKeyDesc keychain.KeyDescriptor
 
 	runtime *serverconn.Runtime
 	ark     *arkrpc.ArkServiceMailboxClient
@@ -1128,6 +1156,105 @@ func (s *Server) registerOOREventRoutes(router *serverconn.EventRouter) {
 		},
 	})
 
+	// IncomingOOR: server notifies the client about an incoming
+	// OOR transfer via the indexer's ArkService. The
+	// IncomingOOREvent is a lightweight notification hint. The
+	// route's Adapt closure queries the indexer (via
+	// ListOORRecipientEventsByScript) to fetch the full Ark
+	// PSBT and checkpoint data needed by IncomingTransferEvent.
+	//
+	// The indexer query uses the ark mailbox client which is
+	// wired during server initialization. The query response
+	// now includes ark_psbt and checkpoint_psbts fields.
+	idxClient := s.indexer
+	serverconn.AddRoute(router, serverconn.EventRouteConfig[
+		oor.OORDurableMsg, oor.ActorResp,
+	]{
+		Service: arkServiceName,
+		Method:  MethodIncomingOOR,
+		NewEvent: func() proto.Message {
+			return &arkrpc.IncomingOOREvent{}
+		},
+		Key: oorKey,
+		Adapt: func(p proto.Message) (
+			oor.OORDurableMsg, error) {
+
+			evt, ok := p.(*arkrpc.IncomingOOREvent)
+			if !ok {
+				return nil, fmt.Errorf(
+					"expected IncomingOOREvent"+
+						", got %T", p,
+				)
+			}
+
+			sessionID, err := chainhash.NewHash(
+				evt.GetSessionId(),
+			)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"parse session id: %w", err,
+				)
+			}
+
+			// Query the indexer for the full package
+			// data. The notification is just a hint.
+			resp, err := idxClient.ListOORRecipientEventsByScriptTaproot(
+				context.Background(),
+				evt.GetRecipientPkScript(),
+				evt.GetRecipientEventId()-1,
+				1,
+			)
+			if err != nil || len(resp.GetEvents()) == 0 {
+				return nil, fmt.Errorf(
+					"fetch OOR package for session "+
+						"%x: %w",
+					sessionID[:], err,
+				)
+			}
+
+			recipientEvt := resp.Events[0]
+
+			// Parse the Ark PSBT from the response.
+			arkPSBT, parseErr := psbtutil.Parse(
+				recipientEvt.GetArkPsbt(),
+			)
+			if parseErr != nil {
+				return nil, fmt.Errorf(
+					"parse ark psbt: %w", parseErr,
+				)
+			}
+
+			// Parse checkpoint PSBTs.
+			var checkpoints []*psbt.Packet
+			for _, cpRaw := range recipientEvt.GetCheckpointPsbts() {
+				cp, cpErr := psbtutil.Parse(cpRaw)
+				if cpErr != nil {
+					return nil, fmt.Errorf(
+						"parse checkpoint: %w",
+						cpErr,
+					)
+				}
+
+				checkpoints = append(
+					checkpoints, cp,
+				)
+			}
+
+			return &oor.DriveEventRequest{
+				SessionID: oor.SessionID(
+					*sessionID,
+				),
+				Event: &oor.IncomingTransferEvent{
+					SessionID: oor.SessionID(
+						*sessionID,
+					),
+					ArkPSBT: arkPSBT,
+					FinalCheckpointPSBTs: checkpoints,
+				},
+			}, nil
+		},
+	})
+
 	// TODO(roasbeef): Register an IncomingAck route once the
 	// oorpb proto defines an ack RPC. SendIncomingAckRequest is
 	// classified as a transport event but currently has no
@@ -1403,6 +1530,19 @@ func (s *Server) initRPCClients(ctx context.Context) {
 	var identityPubkey string
 	s.lnd.WhenSome(func(lndSvc *lndclient.GrpcLndServices) {
 		identityPubkey = lndSvc.NodePubkey.String()
+
+		// Store the client key descriptor for OOR
+		// incoming transfer resolution. Parse the
+		// LND node pubkey (route.Vertex) into a
+		// btcec public key.
+		nodePub, parseErr := btcec.ParsePubKey(
+			lndSvc.NodePubkey[:],
+		)
+		if parseErr == nil {
+			s.clientKeyDesc = keychain.KeyDescriptor{
+				PubKey: nodePub,
+			}
+		}
 	})
 	s.lwWallet.WhenSome(func(w *lwwallet.Wallet) {
 		// Derive the node identity key from the wallet
@@ -1421,6 +1561,10 @@ func (s *Server) initRPCClients(ctx context.Context) {
 				"%x",
 				desc.PubKey.SerializeCompressed(),
 			)
+
+			// Store the client key descriptor for
+			// OOR incoming transfer resolution.
+			s.clientKeyDesc = *desc
 		}
 	})
 
@@ -1567,6 +1711,10 @@ func (s *Server) initRoundActor(ctx context.Context,
 		return nil, fmt.Errorf("unable to fetch operator "+
 			"terms: %w", err)
 	}
+
+	// Store operator terms on Server for the OOR receive path.
+	s.operatorKey = operatorTerms.PubKey
+	s.vtxoExitDelay = operatorTerms.VTXOExitDelay
 
 	// Default maximum operator fee the client is willing to pay
 	// per round. This is a safety limit to prevent the client
@@ -1750,6 +1898,8 @@ func (s *Server) initOORActor(ctx context.Context,
 		Next:         signingHandler,
 		Store:        vtxoStore,
 		PackageStore: packageStore,
+		OperatorKey: s.operatorKey,
+		ExitDelay:   s.vtxoExitDelay,
 		NotifyIncomingVTXOs: func(ctx context.Context,
 			descs []*vtxo.Descriptor) error {
 
@@ -1761,6 +1911,44 @@ func (s *Server) initOORActor(ctx context.Context,
 			)
 		},
 		CompleteSpend: completeSpend,
+		ResolveIncomingClientKey: func(ctx context.Context,
+			recipient oor.ArkRecipientOutput) (
+			keychain.KeyDescriptor, error) {
+
+			// Single-key model: return the client's
+			// identity key for any recipient output.
+			// Multi-key support would need pkScript
+			// matching against derived keys.
+			return s.clientKeyDesc, nil
+		},
+		ResolveIncomingMetadata: func(ctx context.Context,
+			sessionID oor.SessionID,
+			recipient oor.ArkRecipientOutput,
+			ark *psbt.Packet,
+			finalCheckpoints []*psbt.Packet) (
+			oor.IncomingVTXOMetadata, error) {
+
+			// Derive metadata from the Ark PSBT.
+			// The commitment tx is the parent of
+			// the sender's VTXO (first input).
+			var commitTxID chainhash.Hash
+			roundID := chainhash.Hash(sessionID).String()
+
+			if ark != nil && ark.UnsignedTx != nil &&
+				len(ark.UnsignedTx.TxIn) > 0 {
+
+				commitTxID = ark.UnsignedTx.TxIn[0].
+					PreviousOutPoint.Hash
+			}
+
+			chainDepth := len(finalCheckpoints)
+
+			return oor.IncomingVTXOMetadata{
+				RoundID:        roundID,
+				CommitmentTxID: commitTxID,
+				ChainDepth:     chainDepth,
+			}, nil
+		},
 	}
 
 	s.oorActor = oor.NewOORClientActor(oor.ClientActorCfg{

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -1166,6 +1166,69 @@ func (s *Server) registerOOREventRoutes(router *serverconn.EventRouter) {
 		},
 	})
 
+	// ListVTXOsByScripts response: server returned authoritative incoming
+	// metadata for a durable OOR receive session query.
+	serverconn.AddEnvelopeRoute(router, serverconn.EnvelopeRouteConfig[
+		oor.OORDurableMsg, oor.ActorResp,
+	]{
+		Service: "arkrpc.IndexerService",
+		Method:  "ListVTXOsByScripts",
+		NewEvent: func() proto.Message {
+			return &arkrpc.ListVTXOsByScriptsResponse{}
+		},
+		Key: oorKey,
+		Adapt: func(env *mailboxpb.Envelope,
+			p proto.Message) (oor.OORDurableMsg, error) {
+
+			if env == nil || env.Rpc == nil {
+				return nil, fmt.Errorf("incoming metadata "+
+					"response envelope must be provided")
+			}
+
+			sessionID, err := oor.ParseIncomingMetadataCorrelationID(
+				env.Rpc.CorrelationId,
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			if rpcErr := mailboxrpc.DecodeErrorHeaders(
+				env.Headers,
+			); rpcErr != nil {
+
+				return &oor.DriveEventRequest{
+					SessionID: sessionID,
+					Event: &oor.FailEvent{
+						Reason: fmt.Sprintf(
+							"query incoming metadata: %v",
+							rpcErr,
+						),
+					},
+				}, nil
+			}
+
+			resp, ok := p.(*arkrpc.ListVTXOsByScriptsResponse)
+			if !ok {
+				return nil, fmt.Errorf("expected "+
+					"ListVTXOsByScriptsResponse, got %T", p)
+			}
+
+			matches, err := oor.IncomingMetadataMatchesFromResponse(
+				sessionID, resp,
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			return &oor.DriveEventRequest{
+				SessionID: sessionID,
+				Event: &oor.IncomingMetadataResolvedEvent{
+					Matches: matches,
+				},
+			}, nil
+		},
+	})
+
 	// IncomingOOR: server notifies the client about an incoming
 	// OOR transfer via the indexer's ArkService. Persist only the
 	// lightweight notification hint here; the durable OOR actor
@@ -1942,6 +2005,44 @@ func (s *Server) initOORActor(ctx context.Context,
 
 			return s.indexer.ListOORRecipientEventsByScriptTaproot(
 				ctx, pkScript, afterEventID, limit,
+			)
+		},
+		BuildIncomingMetadataRPC: func(ctx context.Context,
+			req *oor.QueryIncomingMetadataRequest) (
+			*serverconn.SendUnaryRequest, error) {
+
+			if req == nil {
+				return nil, fmt.Errorf("incoming metadata query "+
+					"must be provided")
+			}
+
+			scopes := make([]indexer.TaprootScriptScope, 0,
+				len(req.Recipients))
+			for i := range req.Recipients {
+				scopes = append(scopes, indexer.TaprootScriptScope{
+					PkScript: append([]byte(nil),
+						req.Recipients[i].PkScript...),
+				})
+			}
+
+			rpcReq, err := s.indexer.
+				BuildListVTXOsByScriptsTaprootRequest(
+					ctx, scopes, 0,
+					incomingMetadataIndexPageSize, nil,
+				)
+			if err != nil {
+				return nil, err
+			}
+
+			return serverconn.NewSendUnaryRequest(
+				mailboxrpc.ServiceMethod{
+					Service: "arkrpc.IndexerService",
+					Method:  "ListVTXOsByScripts",
+				},
+				rpcReq,
+				oor.IncomingMetadataCorrelationID(
+				req.SessionID,
+				),
 			)
 		},
 	})

--- a/darepod/serverconn_builder.go
+++ b/darepod/serverconn_builder.go
@@ -1,0 +1,54 @@
+package darepod
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/lightninglabs/darepo-client/indexer"
+	"google.golang.org/protobuf/proto"
+)
+
+// serverDurableUnaryBuilder adapts the daemon's indexer proof builder to the
+// generic serverconn durable-unary builder interface.
+type serverDurableUnaryBuilder struct {
+	server *Server
+}
+
+// BuildListOORRecipientEventsByScriptRequest builds the proof-gated indexer
+// request body for one taproot recipient-event query.
+func (b *serverDurableUnaryBuilder) BuildListOORRecipientEventsByScriptRequest(
+	ctx context.Context, pkScript []byte, afterEventID uint64, limit uint32,
+) (proto.Message, error) {
+
+	if b == nil || b.server == nil || b.server.indexer == nil {
+		return nil, fmt.Errorf("indexer client not initialized")
+	}
+
+	return b.server.indexer.
+		BuildListOORRecipientEventsByScriptTaprootRequest(
+			ctx, pkScript, afterEventID, limit,
+		)
+}
+
+// BuildListVTXOsByScriptsRequest builds the proof-gated indexer request body
+// for one or more taproot VTXO scope queries.
+func (b *serverDurableUnaryBuilder) BuildListVTXOsByScriptsRequest(
+	ctx context.Context, pkScripts [][]byte, afterCursor uint64,
+	limit uint32,
+) (proto.Message, error) {
+
+	if b == nil || b.server == nil || b.server.indexer == nil {
+		return nil, fmt.Errorf("indexer client not initialized")
+	}
+
+	scopes := make([]indexer.TaprootScriptScope, 0, len(pkScripts))
+	for i := range pkScripts {
+		scopes = append(scopes, indexer.TaprootScriptScope{
+			PkScript: append([]byte(nil), pkScripts[i]...),
+		})
+	}
+
+	return b.server.indexer.BuildListVTXOsByScriptsTaprootRequest(
+		ctx, scopes, afterCursor, limit, nil,
+	)
+}

--- a/db/AGENTS.md
+++ b/db/AGENTS.md
@@ -15,6 +15,8 @@ Supports SQLite and PostgreSQL backends.
 - `RoundSummary` / `VTXOSummary` — Lightweight descriptors for paginated round listing (avoids deserializing full trees).
 - `VTXOPersistenceStore` — Persistent store for VTXO descriptors (InsertClientVTXO, FetchByOutpoint). Persists `ChainDepth` (OOR hop count) alongside other VTXO metadata.
 - `OORArtifactStore` — Interface for OOR session state persistence.
+- `OwnedReceiveScriptStore` — Interface for persisting locally owned receive-script metadata (UpsertOwnedReceiveScript, LookupOwnedReceiveScript, ListOwnedReceiveScripts).
+- `VTXOPersistenceStore.ensureRoundExists` — Inserts a minimal "confirmed" round row for incoming VTXOs that reference remote rounds. Uses check-then-insert (not upsert) to avoid overwriting richer round state.
 
 ## Relationships
 

--- a/db/CLAUDE.md
+++ b/db/CLAUDE.md
@@ -15,6 +15,8 @@ Supports SQLite and PostgreSQL backends.
 - `RoundSummary` / `VTXOSummary` — Lightweight descriptors for paginated round listing (avoids deserializing full trees).
 - `VTXOPersistenceStore` — Persistent store for VTXO descriptors (InsertClientVTXO, FetchByOutpoint). Persists `ChainDepth` (OOR hop count) alongside other VTXO metadata.
 - `OORArtifactStore` — Interface for OOR session state persistence.
+- `OwnedReceiveScriptStore` — Interface for persisting locally owned receive-script metadata (UpsertOwnedReceiveScript, LookupOwnedReceiveScript, ListOwnedReceiveScripts).
+- `VTXOPersistenceStore.ensureRoundExists` — Inserts a minimal "confirmed" round row for incoming VTXOs that reference remote rounds. Uses check-then-insert (not upsert) to avoid overwriting richer round state.
 
 ## Relationships
 

--- a/db/actordelivery/store_impl.go
+++ b/db/actordelivery/store_impl.go
@@ -646,6 +646,7 @@ func (s *Store) SaveCheckpoint(
 			})
 		},
 	)
+
 	return err
 }
 

--- a/db/actordelivery/store_impl.go
+++ b/db/actordelivery/store_impl.go
@@ -633,7 +633,7 @@ func (s *Store) SaveCheckpoint(
 
 	writeTxOpts := db.WriteTxOption()
 
-	return s.db.ExecTx(
+	err := s.db.ExecTx(
 		ctx,
 		writeTxOpts,
 		func(q ActorDeliveryQueries) error {
@@ -646,6 +646,7 @@ func (s *Store) SaveCheckpoint(
 			})
 		},
 	)
+	return err
 }
 
 // LoadCheckpoint loads an FSM checkpoint for an actor.

--- a/db/interfaces.go
+++ b/db/interfaces.go
@@ -323,6 +323,7 @@ func (t *TransactionExecutor[Q]) ExecTx(ctx context.Context,
 	return ErrRetriesExceeded
 }
 
+
 // Backend returns the type of the database backend used.
 func (t *TransactionExecutor[Q]) Backend() sqlc.BackendType {
 	return t.BatchedQuerier.Backend()

--- a/db/interfaces.go
+++ b/db/interfaces.go
@@ -323,7 +323,6 @@ func (t *TransactionExecutor[Q]) ExecTx(ctx context.Context,
 	return ErrRetriesExceeded
 }
 
-
 // Backend returns the type of the database backend used.
 func (t *TransactionExecutor[Q]) Backend() sqlc.BackendType {
 	return t.BatchedQuerier.Backend()

--- a/db/vtxo_store.go
+++ b/db/vtxo_store.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -50,6 +51,11 @@ func (s *VTXOPersistenceStore) SaveVTXO(
 	writeTxOpts := WriteTxOption()
 
 	return s.db.ExecTx(ctx, writeTxOpts, func(q RoundStore) error {
+		err := s.ensureRoundExists(ctx, q, desc)
+		if err != nil {
+			return fmt.Errorf("ensure round: %w", err)
+		}
+
 		params, err := s.descriptorToInsertParams(desc)
 		if err != nil {
 			return fmt.Errorf("convert descriptor: %w", err)
@@ -57,6 +63,55 @@ func (s *VTXOPersistenceStore) SaveVTXO(
 
 		return q.InsertVTXO(ctx, params)
 	})
+}
+
+// ensureRoundExists inserts a minimal confirmed round row when a VTXO refers
+// to a remote round that this client has not otherwise persisted locally.
+// If the round already exists (e.g. from the normal round flow), the existing
+// row is left untouched to avoid overwriting richer state.
+func (s *VTXOPersistenceStore) ensureRoundExists(ctx context.Context,
+	q RoundStore, desc *vtxo.Descriptor) error {
+
+	if desc == nil {
+		return fmt.Errorf("descriptor must be provided")
+	}
+
+	if desc.RoundID == "" {
+		return fmt.Errorf("round id must be provided")
+	}
+
+	// Check whether the round already exists before inserting, because
+	// InsertRound uses ON CONFLICT DO UPDATE which would overwrite
+	// fields like status on an existing row.
+	_, err := q.GetRound(ctx, desc.RoundID)
+	if err == nil {
+		return nil
+	}
+
+	if !errors.Is(err, sql.ErrNoRows) {
+		return err
+	}
+
+	var confirmationHeight sql.NullInt32
+	if desc.CreatedHeight > 0 {
+		confirmationHeight = sql.NullInt32{
+			Int32: desc.CreatedHeight,
+			Valid: true,
+		}
+	}
+
+	nowUnix := s.clock.Now().Unix()
+	params := InsertRoundParams{
+		RoundID:            desc.RoundID,
+		StartHeight:        0,
+		ConfirmationHeight: confirmationHeight,
+		CommitmentTxid:     desc.CommitmentTxID[:],
+		Status:             "confirmed",
+		CreationTime:       nowUnix,
+		LastUpdateTime:     nowUnix,
+	}
+
+	return q.InsertRound(ctx, params)
 }
 
 // GetVTXO retrieves a VTXO by its outpoint. Used for actor recovery on startup.

--- a/docs/daemon_cli_guide.md
+++ b/docs/daemon_cli_guide.md
@@ -306,12 +306,20 @@ Send via out-of-round transfer (immediate, through operator).
 
 | Flag | Type | Description |
 |------|------|-------------|
-| `--to` | string | Recipient address |
+| `--to` | string | Recipient address (exactly one of `--to`, `--pubkey`, or `--pk_script`) |
+| `--pubkey` | string | Recipient 32-byte x-only pubkey hex |
+| `--pk_script` | string | Recipient raw pk_script hex |
 | `--amount` | int64 | Amount in sats |
 | `--dry_run` | bool | Validate without initiating |
 
 ```bash
 darepocli send oor --to tb1p... --amount 25000 --no-tls
+
+# Or send directly to the x-only pubkey returned by `oor receive`
+darepocli send oor --pubkey <pubkey_xonly_hex> --amount 25000 --no-tls
+
+# Or send to the exact registered taproot output script
+darepocli send oor --pk_script <pk_script_hex> --amount 25000 --no-tls
 ```
 
 #### `schema`
@@ -338,6 +346,8 @@ darepocli mcp serve --no-tls
 **Note:** Wallet management tools (create, unlock, genseed) are
 intentionally excluded from MCP to prevent sensitive material from
 transiting the protocol. Use the CLI directly for wallet operations.
+`oor_receive` is exposed over MCP because it only allocates a fresh
+wallet-derived receive target and does not reveal seed material.
 
 ## Regtest Quickstart
 

--- a/docs/daemon_cli_guide.md
+++ b/docs/daemon_cli_guide.md
@@ -216,6 +216,20 @@ Generate a new taproot boarding address for receiving on-chain funds.
 darepocli wallet newaddress --no-tls
 ```
 
+#### `oor receive`
+
+Allocate a fresh out-of-round receive script backed by a newly derived wallet
+key. The response includes the raw `pk_script_hex`, the owner's
+`pubkey_xonly_hex`, and the wallet key locator.
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--label` | string | Optional indexer registration label |
+
+```bash
+darepocli oor receive --no-tls
+```
+
 #### `vtxos list`
 
 List VTXOs known to the wallet with optional filters.

--- a/indexer/client.go
+++ b/indexer/client.go
@@ -176,6 +176,21 @@ func New(rpc mailboxrpc.RPCClient, signer SchnorrSigner,
 	return c
 }
 
+// WithSigner returns a shallow copy of the client that uses signer for
+// proof-of-control operations. This allows callers to reuse the same mailbox
+// RPC transport while switching to the wallet key that controls a specific
+// receive script.
+func (c *Client) WithSigner(signer SchnorrSigner) *Client {
+	if c == nil {
+		return nil
+	}
+
+	clone := *c
+	clone.signer = signer
+
+	return &clone
+}
+
 // firstOpt returns the first RPCOptions from opts, or the zero value
 // if none were provided. At most one option should be passed; any
 // additional options beyond the first are silently ignored.
@@ -753,11 +768,10 @@ func (c *Client) ListMyReceiveScripts(ctx context.Context,
 // script-keyed recipient event query. This enables "offline receive
 // without registration" while preventing third-party enumeration
 // (proof-of-control required).
-func (c *Client) ListOORRecipientEventsByScriptTaproot(
+func (c *Client) BuildListOORRecipientEventsByScriptTaprootRequest(
 	ctx context.Context, pkScript []byte,
-	afterEventID uint64, limit uint32,
-	opts ...mailboxrpc.RPCOptions) (
-	*arkrpc.ListOORRecipientEventsByScriptResponse, error) {
+	afterEventID uint64, limit uint32) (
+	*arkrpc.ListOORRecipientEventsByScriptRequest, error) {
 
 	if err := validateTaprootPkScript(pkScript); err != nil {
 		return nil, err
@@ -813,6 +827,26 @@ func (c *Client) ListOORRecipientEventsByScriptTaproot(
 		AfterEventId: afterEventID,
 		Limit:        limit,
 		Proof:        proofOneof,
+	}
+
+	return req, nil
+}
+
+// ListOORRecipientEventsByScriptTaproot performs a proof-gated
+// script-keyed recipient event query. This enables "offline receive
+// without registration" while preventing third-party enumeration
+// (proof-of-control required).
+func (c *Client) ListOORRecipientEventsByScriptTaproot(
+	ctx context.Context, pkScript []byte,
+	afterEventID uint64, limit uint32,
+	opts ...mailboxrpc.RPCOptions) (
+	*arkrpc.ListOORRecipientEventsByScriptResponse, error) {
+
+	req, err := c.BuildListOORRecipientEventsByScriptTaprootRequest(
+		ctx, pkScript, afterEventID, limit,
+	)
+	if err != nil {
+		return nil, err
 	}
 
 	return c.rpc.ListOORRecipientEventsByScript(ctx, req, firstOpt(opts))

--- a/indexer/client.go
+++ b/indexer/client.go
@@ -488,13 +488,12 @@ func (c *Client) buildTaprootScopes(ctx context.Context,
 
 // ListVTXOsByScriptsTaproot performs a proof-gated VTXO query for one
 // or more pkScripts.
-func (c *Client) ListVTXOsByScriptsTaproot(ctx context.Context,
+func (c *Client) BuildListVTXOsByScriptsTaprootRequest(ctx context.Context,
 	scopes []TaprootScriptScope, afterCursor uint64, limit uint32,
-	statusFilter []arkrpc.VTXOStatus,
-	opts ...mailboxrpc.RPCOptions) (
-	*arkrpc.ListVTXOsByScriptsResponse, error) {
+	statusFilter []arkrpc.VTXOStatus) (
+	*arkrpc.ListVTXOsByScriptsRequest, error) {
 
-	c.logger(ctx).TraceS(ctx, "Listing VTXOs by scripts",
+	c.logger(ctx).TraceS(ctx, "Building ListVTXOsByScripts request",
 		slog.Int("scope_count", len(scopes)),
 		slog.Uint64("after_cursor", afterCursor),
 		slog.Int("limit", int(limit)),
@@ -507,11 +506,27 @@ func (c *Client) ListVTXOsByScriptsTaproot(ctx context.Context,
 		return nil, err
 	}
 
-	req := &arkrpc.ListVTXOsByScriptsRequest{
+	return &arkrpc.ListVTXOsByScriptsRequest{
 		Scripts:      scriptScopes,
 		StatusFilter: statusFilter,
 		Cursor:       afterCursor,
 		Limit:        limit,
+	}, nil
+}
+
+// ListVTXOsByScriptsTaproot performs a proof-gated VTXO query for one
+// or more pkScripts.
+func (c *Client) ListVTXOsByScriptsTaproot(ctx context.Context,
+	scopes []TaprootScriptScope, afterCursor uint64, limit uint32,
+	statusFilter []arkrpc.VTXOStatus,
+	opts ...mailboxrpc.RPCOptions) (
+	*arkrpc.ListVTXOsByScriptsResponse, error) {
+
+	req, err := c.BuildListVTXOsByScriptsTaprootRequest(
+		ctx, scopes, afterCursor, limit, statusFilter,
+	)
+	if err != nil {
+		return nil, err
 	}
 
 	resp, err := c.rpc.ListVTXOsByScripts(ctx, req, firstOpt(opts))

--- a/lwwallet/wallet.go
+++ b/lwwallet/wallet.go
@@ -212,6 +212,12 @@ func (w *Wallet) ChainBackend() *ChainBackend {
 	return w.chainBackend
 }
 
+// KeyRing returns the wallet's secret key ring for key derivation and message
+// signing operations that need direct access to wallet-owned keys.
+func (w *Wallet) KeyRing() keychain.SecretKeyRing {
+	return w.keyRing
+}
+
 // DeriveNextKey derives the next key in the specified key family.
 // This delegates to the btcwallet-backed keyring.
 func (w *Wallet) DeriveNextKey(_ context.Context,

--- a/round/from_proto.go
+++ b/round/from_proto.go
@@ -10,6 +10,7 @@ import (
 	"github.com/lightninglabs/darepo-client/lib/tree"
 	"github.com/lightninglabs/darepo-client/lib/types"
 	"github.com/lightninglabs/darepo-client/rpc/roundpb"
+	"github.com/lightningnetwork/lnd/keychain"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -425,6 +426,20 @@ func (m *JoinRoundRequest) FromProto(p proto.Message) error {
 				)
 			}
 			req.OperatorKey = key
+		}
+
+		if len(vr.SigningKey) > 0 {
+			key, err := btcec.ParsePubKey(vr.SigningKey)
+			if err != nil {
+				return fmt.Errorf(
+					"vtxo_requests[%d].signing_key: %w",
+					i, err,
+				)
+			}
+
+			req.SigningKey = keychain.KeyDescriptor{
+				PubKey: key,
+			}
 		}
 
 		m.VTXORequests[i] = req


### PR DESCRIPTION
In this PR, we wire the OOR receive path into the production daemon, expose
it through the gRPC API, and add the CLI surface for allocating receive
scripts.

The first commit consolidates the IncomingOOR route setup in
\`darepod/server.go\`: route constants, the notification→query adapter,
operator term resolution (key, exit delay), and the
\`ResolveIncomingClientKey\` / \`ResolveIncomingMetadata\` callbacks that the
outbox handler needs for materialization. These were developed incrementally
but land here as a single cohesive commit.

\`darepod/receive_script.go\` introduces the receive-key lifecycle:
\`EnsureDefaultOORReceiveKey\` for daemon startup (derives a stable key,
persists the owned script record, registers with the indexer) and
\`AllocateFreshOORReceiveKey\` for on-demand allocation via the RPC. Both
persist the key descriptor so re-registration survives restarts.
\`NewOwnedReceiveScriptSigner\` wraps the wallet signer to produce
proof-of-control signatures for the indexer's \`RegisterReceiveScript\` call.

The \`ensureRoundExists\` helper in \`db/vtxo_store.go\` handles the case
where an incoming VTXO references a round this client hasn't participated
in. It inserts a minimal "confirmed" round row so the VTXO foreign key
constraint is satisfied. The check-then-insert pattern is intentional here:
\`InsertRound\`'s upsert would overwrite the status on an existing row,
which would be wrong if the round already has richer state from the normal
round flow.

The durable unary metadata route is wired in \`darepod/server.go\` so
\`ListVTXOsByScripts\` responses dispatch to the OOR actor via
\`IncomingMetadataResolvedEvent\`. A new \`serverconn_builder.go\` centralizes
the \`DurableUnaryBuilder\` construction with indexer proof credentials,
replacing the old direct-callback approach on \`ClientActorCfg\`.

The CLI surface adds \`darepocli oor receive [--label <label>]\` which
derives a fresh wallet key, builds the VTXO-compatible taproot receive
script, registers it with the indexer, and returns the pk_script_hex plus
key metadata. The MCP tool \`oor_receive\` wraps the same RPC for agent
consumption, and \`oor_destination.go\` adds parsing for the
\`ark1://\` destination URI format.

Builds on #189.