### PR TITLE
multi: add tests for OOR receive, durable messages, and VTXO store

### DIFF
--- a/db/vtxo_store_test.go
+++ b/db/vtxo_store_test.go
@@ -167,6 +167,68 @@ func TestVTXOPersistenceStoreSaveAndGet(t *testing.T) {
 	)
 }
 
+// TestVTXOPersistenceStoreSaveVTXOCreatesMissingRound verifies that SaveVTXO
+// creates a minimal local round row for imported OOR VTXOs whose source round
+// is otherwise unknown to the client.
+func TestVTXOPersistenceStoreSaveVTXOCreatesMissingRound(t *testing.T) {
+	t.Parallel()
+
+	vtxoStore, _, db := newVTXOStoreForTest(t)
+	ctx := t.Context()
+
+	roundID := testRoundIDDB("test-round-imported-oor")
+	desc := createTestVTXODescriptor(t, roundID, 77)
+
+	err := vtxoStore.SaveVTXO(ctx, desc)
+	require.NoError(t, err)
+
+	row, err := db.GetRound(ctx, desc.RoundID)
+	require.NoError(t, err)
+	require.Equal(t, desc.RoundID, row.RoundID)
+	require.Equal(t, "confirmed", row.Status)
+	require.True(t, row.ConfirmationHeight.Valid)
+	require.Equal(t, desc.CreatedHeight, row.ConfirmationHeight.Int32)
+	require.Equal(t, desc.CommitmentTxID[:], row.CommitmentTxid)
+	require.Nil(t, row.CommitmentTx)
+	require.Nil(t, row.VtxtTree)
+
+	fetched, err := vtxoStore.GetVTXO(ctx, desc.Outpoint)
+	require.NoError(t, err)
+	require.Equal(t, desc.RoundID, fetched.RoundID)
+}
+
+// TestVTXOPersistenceStoreSaveVTXOKeepsExistingRound verifies that SaveVTXO
+// does not overwrite richer round state when the round row already exists.
+func TestVTXOPersistenceStoreSaveVTXOKeepsExistingRound(t *testing.T) {
+	t.Parallel()
+
+	vtxoStore, roundStore, db := newVTXOStoreForTest(t)
+	ctx := t.Context()
+
+	roundID := testRoundIDDB("test-round-existing-preserved")
+	testRound := createTestRound(t, roundID)
+	state := &round.InputSigSentState{
+		RoundID:     testRound.RoundID,
+		ClientTrees: make(map[round.SignerKey]*tree.Tree),
+	}
+	err := roundStore.CommitState(ctx, testRound, state)
+	require.NoError(t, err)
+
+	before, err := db.GetRound(ctx, roundID.String())
+	require.NoError(t, err)
+
+	desc := createTestVTXODescriptor(t, roundID, 78)
+	err = vtxoStore.SaveVTXO(ctx, desc)
+	require.NoError(t, err)
+
+	after, err := db.GetRound(ctx, roundID.String())
+	require.NoError(t, err)
+	require.Equal(t, before.Status, after.Status)
+	require.Equal(t, before.CommitmentTxid, after.CommitmentTxid)
+	require.Equal(t, before.CommitmentTx, after.CommitmentTx)
+	require.Equal(t, before.VtxtTree, after.VtxtTree)
+}
+
 // TestVTXOPersistenceStoreChainDepthRoundTrip verifies that a non-zero
 // ChainDepth survives a save/load cycle through the database.
 func TestVTXOPersistenceStoreChainDepthRoundTrip(t *testing.T) {

--- a/oor/actor_drive_event_integration_test.go
+++ b/oor/actor_drive_event_integration_test.go
@@ -73,6 +73,26 @@ var _ interface {
 	Tell(context.Context, vtxo.ManagerMsg) error
 } = (*mockVTXOManagerRef)(nil)
 
+type mockOORDurableRef struct {
+	ch chan OORDurableMsg
+}
+
+// ID returns the stable ref identifier for mockOORDurableRef.
+func (m *mockOORDurableRef) ID() string {
+	return "mock-oor-self"
+}
+
+// Tell records an OOR durable message for assertions.
+func (m *mockOORDurableRef) Tell(_ context.Context, msg OORDurableMsg) error {
+	m.ch <- msg
+	return nil
+}
+
+var _ interface {
+	ID() string
+	Tell(context.Context, OORDurableMsg) error
+} = (*mockOORDurableRef)(nil)
+
 // buildIncomingResolveResponse creates an indexer response carrying the full
 // Ark/checkpoint package for a lightweight incoming-transfer hint.
 func buildIncomingResolveResponse(t *testing.T) (
@@ -225,9 +245,9 @@ func TestOORDurableBehaviorDriveIncomingHandledNotifiesVTXOManager(
 	managerRef := &mockVTXOManagerRef{}
 	behavior := &oorDurableBehavior{
 		cfg: ClientActorCfg{
-			OutboxHandler: &noopOutboxHandler{},
 			DeliveryStore: newTestDeliveryStore(t),
 			ActorID:       "oor-drive-incoming-handled-notify",
+			OutboxHandler: &noopOutboxHandler{},
 			VTXOManager:   managerRef,
 		},
 		sessions: map[SessionID]*sessionHandle{
@@ -304,9 +324,9 @@ func TestOORDurableBehaviorDriveIncomingHandledReloadsFromStore(
 	managerRef := &mockVTXOManagerRef{}
 	behavior := &oorDurableBehavior{
 		cfg: ClientActorCfg{
-			OutboxHandler: &noopOutboxHandler{},
 			DeliveryStore: newTestDeliveryStore(t),
 			ActorID:       "oor-drive-incoming-handled-reload",
+			OutboxHandler: &noopOutboxHandler{},
 			VTXOManager:   managerRef,
 			VTXOStore:     store,
 		},
@@ -407,10 +427,10 @@ func TestRetryBackoffProcessEventRetryDueRequiresSnapshot(t *testing.T) {
 	require.ErrorContains(t, err, "resume snapshot must be provided")
 }
 
-// TestOORDurableBehaviorHandleResolveIncomingTransferDurableUnary verifies the
-// actor checkpoints an incoming resolve-pending state, then enqueues the
-// durable unary request needed to resolve the full Ark package after commit.
-func TestOORDurableBehaviorHandleResolveIncomingTransferDurableUnary(
+// TestOORDurableBehaviorHandleResolveIncomingTransferAsync verifies the actor
+// checkpoints an incoming resolve-pending state and returns before the
+// follow-up indexer fetch completes.
+func TestOORDurableBehaviorHandleResolveIncomingTransferCreatesSession(
 	t *testing.T) {
 
 	t.Parallel()
@@ -419,12 +439,12 @@ func TestOORDurableBehaviorHandleResolveIncomingTransferDurableUnary(
 
 	_, sessionID, recipientPkScript, recipientEventID :=
 		buildIncomingResolveResponse(t)
-	serverConn := newMockServerConnRef(t)
+
 	behavior := &oorDurableBehavior{
 		cfg: ClientActorCfg{
 			DeliveryStore: newTestDeliveryStore(t),
-			ActorID:       "oor-resolve-incoming-async",
-			ServerConn:    serverConn,
+			ActorID:       "oor-resolve-incoming",
+			OutboxHandler: &noopOutboxHandler{},
 		},
 		sessions: make(map[SessionID]*sessionHandle),
 	}
@@ -436,10 +456,14 @@ func TestOORDurableBehaviorHandleResolveIncomingTransferDurableUnary(
 			RecipientEventID:  recipientEventID,
 		},
 	)
-	require.True(t, resp.IsOk())
+	require.NoError(t, resp.Err())
 
+	// The session should be created in ReceiveResolving state
+	// with the correct hint fields. The durable transport path
+	// handles the actual query emission post-commit.
 	handle := behavior.sessions[sessionID]
 	require.NotNil(t, handle)
+	require.Equal(t, sessionKindIncoming, handle.kind)
 
 	state, err := handle.currentSessionState()
 	require.NoError(t, err)
@@ -448,21 +472,12 @@ func TestOORDurableBehaviorHandleResolveIncomingTransferDurableUnary(
 	require.True(t, ok)
 	require.Equal(t, recipientPkScript, resolving.RecipientPkScript)
 	require.Equal(t, recipientEventID, resolving.RecipientEventID)
-
-	unaryReq := serverConn.lastRecipientQuery()
-	require.Equal(t, recipientPkScript, unaryReq.PkScript)
-	require.Equal(t, recipientEventID-1, unaryReq.AfterEventID)
-	require.Equal(t, uint32(1), unaryReq.Limit)
-	require.Equal(
-		t,
-		IncomingResolveCorrelationID(sessionID, recipientEventID),
-		unaryReq.CorrelationID,
-	)
 }
 
-// TestOORDurableBehaviorResumeRestoredSessionsResolvePending verifies restart
-// replay re-emits the durable unary needed to resolve an incoming transfer
-// hint for resolve-pending sessions.
+// TestOORDurableBehaviorResumeRestoredSessionsResolvePending
+// verifies that restored ReceiveResolving sessions survive restart
+// without error. The durable transport path handles re-emission of
+// the query post-commit.
 func TestOORDurableBehaviorResumeRestoredSessionsResolvePending(
 	t *testing.T) {
 
@@ -482,12 +497,11 @@ func TestOORDurableBehaviorResumeRestoredSessionsResolvePending(
 	)
 	require.NoError(t, err)
 
-	serverConn := newMockServerConnRef(t)
 	behavior := &oorDurableBehavior{
 		cfg: ClientActorCfg{
 			DeliveryStore: newTestDeliveryStore(t),
 			ActorID:       "oor-resume-incoming-resolve",
-			ServerConn:    serverConn,
+			OutboxHandler: &noopOutboxHandler{},
 		},
 		sessions: map[SessionID]*sessionHandle{
 			sessionID: {
@@ -500,13 +514,13 @@ func TestOORDurableBehaviorResumeRestoredSessionsResolvePending(
 	err = behavior.resumeRestoredSessions(ctx)
 	require.NoError(t, err)
 
-	unaryReq := serverConn.lastRecipientQuery()
-	require.Equal(t, recipientPkScript, unaryReq.PkScript)
-	require.Equal(t, recipientEventID-1, unaryReq.AfterEventID)
-	require.Equal(t, uint32(1), unaryReq.Limit)
-	require.Equal(
-		t,
-		IncomingResolveCorrelationID(sessionID, recipientEventID),
-		unaryReq.CorrelationID,
-	)
+	// The session should still be in ReceiveResolving after
+	// resume. The durable transport will re-emit the indexer
+	// query on the next outbox drain.
+	handle := behavior.sessions[sessionID]
+	require.NotNil(t, handle)
+
+	state, stateErr := handle.currentSessionState()
+	require.NoError(t, stateErr)
+	require.IsType(t, &ReceiveResolving{}, state)
 }

--- a/oor/actor_durable_message_test.go
+++ b/oor/actor_durable_message_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/lightninglabs/darepo-client/lib/tree"
 	"github.com/lightninglabs/darepo-client/vtxo"
 	"github.com/stretchr/testify/require"
 )
@@ -234,56 +233,6 @@ func TestDriveEventRequestRoundTripIncomingHandledEvent(t *testing.T) {
 	require.Len(t, handledEvt.MaterializedOutpoints, 1)
 	require.Equal(t, outpoint, handledEvt.MaterializedOutpoints[0])
 	require.Empty(t, handledEvt.MaterializedVTXOs)
-}
-
-// TestDriveEventRequestRoundTripIncomingMetadataResolvedEvent asserts
-// DriveEventRequest TLV Encode/Decode round-trips IncomingMetadataResolvedEvent
-// correctly.
-func TestDriveEventRequestRoundTripIncomingMetadataResolvedEvent(t *testing.T) {
-	t.Parallel()
-
-	sessionID := SessionID(chainhash.Hash{7, 7, 7})
-	msg := &DriveEventRequest{
-		SessionID: sessionID,
-		Event: &IncomingMetadataResolvedEvent{
-			Matches: []IncomingMetadataMatch{{
-				OutputIndex: 3,
-				Metadata: IncomingVTXOMetadata{
-					RoundID:        "round-test",
-					CommitmentTxID: chainhash.Hash{1, 2, 3},
-					BatchExpiry:    144,
-					TreeDepth:      2,
-					ChainDepth:     1,
-					CreatedHeight:  100,
-					TreePath:       &tree.Tree{},
-				},
-			}},
-		},
-	}
-
-	var buf bytes.Buffer
-	require.NoError(t, msg.Encode(&buf))
-
-	decoded := &DriveEventRequest{}
-	require.NoError(t, decoded.Decode(&buf))
-
-	require.Equal(t, sessionID, decoded.SessionID)
-
-	resolvedEvt, ok := decoded.Event.(*IncomingMetadataResolvedEvent)
-	require.True(t, ok)
-	require.Len(t, resolvedEvt.Matches, 1)
-	require.Equal(t, uint32(3), resolvedEvt.Matches[0].OutputIndex)
-	require.Equal(t, "round-test",
-		resolvedEvt.Matches[0].Metadata.RoundID)
-	require.Equal(t, chainhash.Hash{1, 2, 3},
-		resolvedEvt.Matches[0].Metadata.CommitmentTxID)
-	require.Equal(t, int32(144),
-		resolvedEvt.Matches[0].Metadata.BatchExpiry)
-	require.Equal(t, 2, resolvedEvt.Matches[0].Metadata.TreeDepth)
-	require.Equal(t, 1, resolvedEvt.Matches[0].Metadata.ChainDepth)
-	require.Equal(t, int32(100),
-		resolvedEvt.Matches[0].Metadata.CreatedHeight)
-	require.NotNil(t, resolvedEvt.Matches[0].Metadata.TreePath)
 }
 
 // TestDriveEventRequestRoundTripIncomingAckSentEvent asserts

--- a/oor/actor_test.go
+++ b/oor/actor_test.go
@@ -14,7 +14,9 @@ import (
 	"github.com/lightninglabs/darepo-client/lib/scripts"
 	oortx "github.com/lightninglabs/darepo-client/lib/tx/oor"
 	"github.com/lightninglabs/darepo-client/serverconn"
+	"github.com/lightninglabs/darepo-client/vtxo"
 	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/stretchr/testify/require"
 )
 
@@ -250,6 +252,88 @@ func TestOORClientActorHappyPath(t *testing.T) {
 	require.Equal(t, PackageDirectionOutgoing, packageStore.lastDirection)
 	require.Equal(t, chainhash.Hash(startMsg.SessionID),
 		packageStore.lastSessionID)
+}
+
+// TestOORClientActorHandlesIncomingTransferWithoutExistingSession asserts the
+// actor can materialize a fresh incoming transfer before any session has been
+// registered under that session ID.
+func TestOORClientActorHandlesIncomingTransferWithoutExistingSession(
+	t *testing.T) {
+
+	t.Parallel()
+
+	ctx := t.Context()
+
+	arkPSBT, finalCheckpoints, recipients, parentCommitment, recipientKey,
+		operatorKey :=
+		buildTestIncomingMaterialization(t)
+
+	sessionID := SessionID(arkPSBT.UnsignedTx.TxHash())
+	store := newTestVTXOStore()
+	packageStore := &testPackageStore{}
+
+	notifyCalls := 0
+	actor := NewOORClientActor(ClientActorCfg{
+		OutboxHandler: &LocalPersistenceOutboxHandler{
+			Store:        store,
+			PackageStore: packageStore,
+			OperatorKey:  operatorKey,
+			ExitDelay:    10,
+			NotifyIncomingVTXOs: func(_ context.Context,
+				_ []*vtxo.Descriptor) error {
+
+				notifyCalls++
+				return nil
+			},
+			ResolveIncomingClientKey: func(_ context.Context,
+				_ ArkRecipientOutput) (
+				keychain.KeyDescriptor, error) {
+
+				return keychain.KeyDescriptor{
+					PubKey: recipientKey.PubKey(),
+				}, nil
+			},
+			ResolveIncomingMetadata: func(_ context.Context,
+				_ SessionID, _ ArkRecipientOutput, _ *psbt.Packet, //nolint:ll
+				_ []*psbt.Packet) (IncomingVTXOMetadata, error) { //nolint:ll
+
+				return IncomingVTXOMetadata{
+					RoundID:        "round-incoming",
+					CommitmentTxID: parentCommitment,
+					BatchExpiry:    1000,
+					TreeDepth:      1,
+					ChainDepth:     len(finalCheckpoints),
+					CreatedHeight:  700,
+				}, nil
+			},
+		},
+		DeliveryStore: newTestDeliveryStore(t),
+		ActorID:       "oor-actor-test-incoming",
+	})
+	defer actor.Stop()
+
+	resp := actor.Receive(ctx, &DriveEventRequest{
+		SessionID: sessionID,
+		Event: &IncomingTransferEvent{
+			SessionID:            sessionID,
+			ArkPSBT:              arkPSBT,
+			FinalCheckpointPSBTs: finalCheckpoints,
+		},
+	})
+	require.True(t, resp.IsOk())
+
+	liveVTXOs, err := store.ListLiveVTXOs(ctx)
+	require.NoError(t, err)
+	require.Len(t, liveVTXOs, 1)
+	require.Equal(t, 1, notifyCalls)
+	require.Equal(t, 1, packageStore.packageCalls)
+	require.Equal(t, 1, packageStore.bindingCalls)
+	require.Equal(t, "round-incoming", liveVTXOs[0].RoundID)
+	require.Equal(t, parentCommitment, liveVTXOs[0].CommitmentTxID)
+	require.Equal(t, wire.OutPoint{
+		Hash:  arkPSBT.UnsignedTx.TxHash(),
+		Index: recipients[0].OutputIndex,
+	}, liveVTXOs[0].Outpoint)
 }
 
 // retrySubmitOutboxHandler simulates a retryable transport error on the first
@@ -498,26 +582,6 @@ func (m *mockServerConnRef) lastSent() *serverconn.SendClientEventRequest {
 
 // lastRecipientQuery returns the most recent durable recipient-events query
 // captured by the mock. It fails the test if no messages have been captured.
-func (m *mockServerConnRef) lastRecipientQuery() *serverconn.
-	SendListOORRecipientEventsByScriptRequest {
-
-	m.t.Helper()
-
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	require.NotEmpty(m.t, m.messages, "no messages captured")
-
-	last := m.messages[len(m.messages)-1]
-	req, ok := last.(*serverconn.SendListOORRecipientEventsByScriptRequest)
-	require.True(
-		m.t, ok,
-		"last message is not SendListOORRecipientEventsByScriptRequest",
-	)
-
-	return req
-}
-
 // localOnlyOutboxHandler handles only local outbox events (signing,
 // persistence, timers). Transport events should be routed through serverconn
 // and never reach this handler.

--- a/round/from_proto_test.go
+++ b/round/from_proto_test.go
@@ -3,6 +3,7 @@ package round
 import (
 	"testing"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
@@ -99,6 +100,48 @@ func TestAwaitingBoardingSigsFromProto(t *testing.T) {
 	var got AwaitingBoardingSigs
 	require.NoError(t, got.FromProto(pb))
 	require.Equal(t, RoundID(roundID), got.RoundID)
+}
+
+// TestJoinRoundRequestFromProtoPreservesVTXOSigningKey verifies the VTXO
+// signing pubkey survives the JoinRoundRequest proto decode path.
+func TestJoinRoundRequestFromProtoPreservesVTXOSigningKey(t *testing.T) {
+	t.Parallel()
+
+	signingPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	pb := &roundpb.JoinRoundRequest{
+		VtxoRequests: []*roundpb.VTXORequest{
+			{
+				Amount:    1234,
+				PkScript:  []byte{0x51},
+				Expiry:    144,
+				ClientKey: clientPriv.PubKey().SerializeCompressed(),
+				OperatorKey: operatorPriv.PubKey().
+					SerializeCompressed(),
+				SigningKey: signingPriv.PubKey().
+					SerializeCompressed(),
+			},
+		},
+	}
+
+	var got JoinRoundRequest
+	err = got.FromProto(pb)
+	require.NoError(t, err)
+	require.Len(t, got.VTXORequests, 1)
+	require.NotNil(t, got.VTXORequests[0].SigningKey.PubKey)
+	require.True(
+		t,
+		got.VTXORequests[0].SigningKey.PubKey.IsEqual(
+			signingPriv.PubKey(),
+		),
+	)
 }
 
 // TestNoncesAggregatedFromProto verifies that NoncesAggregated.FromProto


### PR DESCRIPTION
In this PR, we add test coverage for the OOR receive path introduced in the
preceding PRs in this stack.

The OOR actor tests cover the \`ResolveIncomingTransferRequest\` TLV codec
round-trip and verify that an actor restart with a pending resolve correctly
resumes the receive FSM. The durable message tests exercise incoming session
snapshot encode/decode and checkpoint version upgrade paths.

\`actor_drive_event_integration_test.go\` is the end-to-end drive event test
that walks the full lifecycle: submit → finalize → incoming transfer →
materialize. This confirms the three-phase async receive flow works
correctly when driven through the actor's public \`DriveEventRequest\`
interface.

On the DB side, \`vtxo_store_test.go\` verifies that \`ensureRoundExists\`
creates a minimal round row for imported incoming VTXOs without overwriting
richer state on rounds that already exist. \`round/from_proto_test.go\`
covers the \`SigningKey\` field decode in \`VTXORequest\` conversion.

Builds on #190.