### PR TITLE
docs: update serverconn, mailbox/conn, and oor package docs

### DIFF
--- a/mailbox/conn/AGENTS.md
+++ b/mailbox/conn/AGENTS.md
@@ -1,0 +1,29 @@
+# mailbox/conn
+
+## Purpose
+
+Mailbox connection primitives shared by both `clientconn` and `serverconn`
+for envelope identity, ack state tracking, and unary response correlation.
+
+## Key Types
+
+- `ResponseRegistry` — Maps correlation IDs to unary RPC waiters and early
+  response buffers. `DeliverResponse` returns a tri-state result (`waiter`,
+  `buffered`, `dropped`) so callers can decide whether to fall back to durable
+  route dispatch for responses that arrive with no live waiter.
+- `AckState` — Four-cursor watermark state machine for ingress pull/ack.
+- `WrappedProto` — TLV-serializable wrapper for proto messages.
+- `EnvelopeIdentity` — Stable message ID and idempotency key derivation from
+  payload hash.
+
+## Relationships
+
+- **Depends on**: `mailbox/pb` (envelope proto), `mailbox/rpc` (ServiceMethod).
+- **Depended on by**: `serverconn` (ingress, UnaryFacade), `clientconn` (ingress).
+
+## Invariants
+
+- Response waiters are cleaned up after TTL expiry to prevent memory leaks.
+- Early-buffered responses are consumed exactly once when the waiter arrives.
+- The tri-state delivery result must be checked by the ingress; `buffered` means
+  the response was stored but may need durable dispatch.

--- a/mailbox/conn/CLAUDE.md
+++ b/mailbox/conn/CLAUDE.md
@@ -1,0 +1,29 @@
+# mailbox/conn
+
+## Purpose
+
+Mailbox connection primitives shared by both `clientconn` and `serverconn`
+for envelope identity, ack state tracking, and unary response correlation.
+
+## Key Types
+
+- `ResponseRegistry` — Maps correlation IDs to unary RPC waiters and early
+  response buffers. `DeliverResponse` returns a tri-state result (`waiter`,
+  `buffered`, `dropped`) so callers can decide whether to fall back to durable
+  route dispatch for responses that arrive with no live waiter.
+- `AckState` — Four-cursor watermark state machine for ingress pull/ack.
+- `WrappedProto` — TLV-serializable wrapper for proto messages.
+- `EnvelopeIdentity` — Stable message ID and idempotency key derivation from
+  payload hash.
+
+## Relationships
+
+- **Depends on**: `mailbox/pb` (envelope proto), `mailbox/rpc` (ServiceMethod).
+- **Depended on by**: `serverconn` (ingress, UnaryFacade), `clientconn` (ingress).
+
+## Invariants
+
+- Response waiters are cleaned up after TTL expiry to prevent memory leaks.
+- Early-buffered responses are consumed exactly once when the waiter arrives.
+- The tri-state delivery result must be checked by the ingress; `buffered` means
+  the response was stored but may need durable dispatch.

--- a/oor/AGENTS.md
+++ b/oor/AGENTS.md
@@ -12,9 +12,14 @@ resume semantics.
 - `Environment` — FSM environment providing SessionID and external system access.
 - `OutboxHandler` — Interface for executing FSM outbox requests (RPC, signing, persistence).
 - `SignArkPSBT` — Signs Ark PSBT inputs using the client key on the checkpoint 2-of-2 collab leaf; uses `MultiPrevOutFetcher` for correct BIP-341 sighash across multiple inputs.
-- `ClientActorCfg` — Configuration for OORClientActor (OutboxHandler, ServerConn, PackageStore, DeliveryStore, VTXOManager).
+- `ClientActorCfg` — Configuration for OORClientActor (OutboxHandler, ServerConn, PackageStore, DeliveryStore, VTXOManager, IncomingFetcher).
 - `IncomingVTXOMetadata` — Lineage metadata for incoming OOR VTXOs including `ChainDepth` (OOR checkpoint hop count).
-- `OORClientActor` — Durable actor wrapping per-session state machines.
+- `OORClientActor` — Durable actor wrapping per-session state machines. Handles both outgoing transfers and incoming receive via three-phase async resolution.
+- `ResolveIncomingTransferRequest` — TLV-durable message persisted by the ingress route, resolved asynchronously by the actor via `IncomingFetcher`.
+- `IncomingOORFetcher` — Callback type for querying the indexer for full Ark PSBT data from a lightweight notification hint.
+- `AdaptIncomingOOREvent` / `NewResolveIncomingTransferRequest` — Shared adapters for the notification→query pattern used by both darepod and systest.
+- `NewOutboxHandler` / `OutboxHandlerConfig` — Shared factory for the standard two-layer outbox handler chain (LocalPersistenceOutboxHandler → SigningOutboxHandler).
+- `ReceiveResolving` — FSM state indicating a durable hint is persisted and pending async indexer resolution.
 
 ## Relationships
 
@@ -26,7 +31,8 @@ resume semantics.
   - → `wallet`: `MaterializeIncomingVTXOsRequest`
   - → `vtxo` manager: `VTXOsMaterializedNotification` (after incoming VTXOs are durably materialized)
 - **Receives**:
-  - ← `serverconn` (via EventRouter): `SubmitAcceptedEvent`, `FinalizeAcceptedEvent`, `IncomingTransferEvent`
+  - ← `serverconn` (via EventRouter): `SubmitAcceptedEvent`, `FinalizeAcceptedEvent`, `ResolveIncomingTransferRequest`
+  - ← self (async callback via `CallbackRef`): `DriveEventRequest{IncomingTransferEvent}`, `DriveEventRequest{IncomingHandledEvent}`
   - ← API: `StartTransferRequest`, `DriveEventRequest`, `RestoreSessionRequest`, `ResumeSessionRequest`
 
 ## Invariants
@@ -37,6 +43,8 @@ resume semantics.
 - After checkpoint signature, client must resume and obtain byte-identical co-signed PSBTs (deterministic construction).
 - Transport outbox events (submit, finalize, ack) are Tell'd to ServerConn within the actor's DB transaction for atomic enqueue (same-DB tx joining via `ExecTx`).
 - Package persistence tracks finalized outgoing packages and local input bindings for recovery.
+- Incoming receive never performs synchronous unary RPCs inside the durable actor DB transaction. All indexer queries are scheduled asynchronously and delivered back as fresh durable messages.
+- `LocalPersistenceOutboxHandler.CallbackRef` receives async materialization results so indexer queries run outside the actor tx, preventing SQLite write-lock starvation.
 
 ## Deep Docs
 

--- a/oor/CLAUDE.md
+++ b/oor/CLAUDE.md
@@ -12,9 +12,14 @@ resume semantics.
 - `Environment` — FSM environment providing SessionID and external system access.
 - `OutboxHandler` — Interface for executing FSM outbox requests (RPC, signing, persistence).
 - `SignArkPSBT` — Signs Ark PSBT inputs using the client key on the checkpoint 2-of-2 collab leaf; uses `MultiPrevOutFetcher` for correct BIP-341 sighash across multiple inputs.
-- `ClientActorCfg` — Configuration for OORClientActor (OutboxHandler, ServerConn, PackageStore, DeliveryStore, VTXOManager).
+- `ClientActorCfg` — Configuration for OORClientActor (OutboxHandler, ServerConn, PackageStore, DeliveryStore, VTXOManager, IncomingFetcher).
 - `IncomingVTXOMetadata` — Lineage metadata for incoming OOR VTXOs including `ChainDepth` (OOR checkpoint hop count).
-- `OORClientActor` — Durable actor wrapping per-session state machines.
+- `OORClientActor` — Durable actor wrapping per-session state machines. Handles both outgoing transfers and incoming receive via three-phase async resolution.
+- `ResolveIncomingTransferRequest` — TLV-durable message persisted by the ingress route, resolved asynchronously by the actor via `IncomingFetcher`.
+- `IncomingOORFetcher` — Callback type for querying the indexer for full Ark PSBT data from a lightweight notification hint.
+- `AdaptIncomingOOREvent` / `NewResolveIncomingTransferRequest` — Shared adapters for the notification→query pattern used by both darepod and systest.
+- `NewOutboxHandler` / `OutboxHandlerConfig` — Shared factory for the standard two-layer outbox handler chain (LocalPersistenceOutboxHandler → SigningOutboxHandler).
+- `ReceiveResolving` — FSM state indicating a durable hint is persisted and pending async indexer resolution.
 
 ## Relationships
 
@@ -26,7 +31,8 @@ resume semantics.
   - → `wallet`: `MaterializeIncomingVTXOsRequest`
   - → `vtxo` manager: `VTXOsMaterializedNotification` (after incoming VTXOs are durably materialized)
 - **Receives**:
-  - ← `serverconn` (via EventRouter): `SubmitAcceptedEvent`, `FinalizeAcceptedEvent`, `IncomingTransferEvent`
+  - ← `serverconn` (via EventRouter): `SubmitAcceptedEvent`, `FinalizeAcceptedEvent`, `ResolveIncomingTransferRequest`
+  - ← self (async callback via `CallbackRef`): `DriveEventRequest{IncomingTransferEvent}`, `DriveEventRequest{IncomingHandledEvent}`
   - ← API: `StartTransferRequest`, `DriveEventRequest`, `RestoreSessionRequest`, `ResumeSessionRequest`
 
 ## Invariants
@@ -37,6 +43,8 @@ resume semantics.
 - After checkpoint signature, client must resume and obtain byte-identical co-signed PSBTs (deterministic construction).
 - Transport outbox events (submit, finalize, ack) are Tell'd to ServerConn within the actor's DB transaction for atomic enqueue (same-DB tx joining via `ExecTx`).
 - Package persistence tracks finalized outgoing packages and local input bindings for recovery.
+- Incoming receive never performs synchronous unary RPCs inside the durable actor DB transaction. All indexer queries are scheduled asynchronously and delivered back as fresh durable messages.
+- `LocalPersistenceOutboxHandler.CallbackRef` receives async materialization results so indexer queries run outside the actor tx, preventing SQLite write-lock starvation.
 
 ## Deep Docs
 

--- a/serverconn/AGENTS.md
+++ b/serverconn/AGENTS.md
@@ -10,9 +10,10 @@ background ingress polling with event routing.
 
 - `Runtime` — Main entry point wrapping DurableActor, ServerConnectionActor, and UnaryFacade.
 - `ServerConnectionActor` — Core behavior handling egress messages and the ingress loop.
-- `UnaryFacade` — Implements `mailboxrpc.RPCClient` for generated RPC stubs (low-latency path).
+- `UnaryFacade` — Implements `mailboxrpc.RPCClient` for generated RPC stubs (low-latency path). Also provides `AwaitRPCTimeout` for bounded waits.
 - `ConnectorConfig` — Wiring configuration (edge address, mailbox IDs, dispatchers, store).
 - `AckState` — Four-cursor watermark state machine (PullCursor, DispatchCommittedTo, AckTarget, AckCommittedTo).
+- `SendUnaryRequest` — Durable typed unary request that becomes a real unary RPC after commit. The response arrives via KIND_RESPONSE and, if no in-memory waiter exists, falls back to durable route dispatch via the EventRouter.
 
 ## Relationships
 
@@ -31,7 +32,8 @@ background ingress polling with event routing.
 ## Invariants
 
 - Ack watermark only advances AFTER durable local dispatch commit (prevents message loss on crash).
-- Unary RPC responses use in-memory registry (no durability); on crash, callers retry with fresh correlation IDs.
+- Unary RPC responses use in-memory registry first; if no waiter exists (crash replay), the ingress falls back to durable EventRouter dispatch. The ResponseRegistry returns a tri-state delivery result (waiter/buffered/dropped) so the ingress knows whether to route durably.
+- `SendClientEventRequest` auto-derives `Service`/`Method` from `Message.ServiceMethod()` when callers leave them empty, preventing silent drops.
 - Idempotency keys are derived from message payload hash; same key on retry enables server deduplication.
 - Ingress loop checkpoints pull cursor and ack state; on restart, resumes from checkpoint.
 

--- a/serverconn/CLAUDE.md
+++ b/serverconn/CLAUDE.md
@@ -10,9 +10,10 @@ background ingress polling with event routing.
 
 - `Runtime` — Main entry point wrapping DurableActor, ServerConnectionActor, and UnaryFacade.
 - `ServerConnectionActor` — Core behavior handling egress messages and the ingress loop.
-- `UnaryFacade` — Implements `mailboxrpc.RPCClient` for generated RPC stubs (low-latency path).
+- `UnaryFacade` — Implements `mailboxrpc.RPCClient` for generated RPC stubs (low-latency path). Also provides `AwaitRPCTimeout` for bounded waits.
 - `ConnectorConfig` — Wiring configuration (edge address, mailbox IDs, dispatchers, store).
 - `AckState` — Four-cursor watermark state machine (PullCursor, DispatchCommittedTo, AckTarget, AckCommittedTo).
+- `SendUnaryRequest` — Durable typed unary request that becomes a real unary RPC after commit. The response arrives via KIND_RESPONSE and, if no in-memory waiter exists, falls back to durable route dispatch via the EventRouter.
 
 ## Relationships
 
@@ -31,7 +32,8 @@ background ingress polling with event routing.
 ## Invariants
 
 - Ack watermark only advances AFTER durable local dispatch commit (prevents message loss on crash).
-- Unary RPC responses use in-memory registry (no durability); on crash, callers retry with fresh correlation IDs.
+- Unary RPC responses use in-memory registry first; if no waiter exists (crash replay), the ingress falls back to durable EventRouter dispatch. The ResponseRegistry returns a tri-state delivery result (waiter/buffered/dropped) so the ingress knows whether to route durably.
+- `SendClientEventRequest` auto-derives `Service`/`Method` from `Message.ServiceMethod()` when callers leave them empty, preventing silent drops.
 - Idempotency keys are derived from message payload hash; same key on retry enables server deduplication.
 - Ingress loop checkpoints pull cursor and ack state; on restart, resumes from checkpoint.
 


### PR DESCRIPTION
In this PR, we update the per-package documentation to reflect the OOR
receive path changes. The serverconn and oor CLAUDE.md/AGENTS.md files get
new key types, relationship entries, and invariant notes for the durable
unary query pattern and three-phase async receive flow. We also add
CLAUDE.md and AGENTS.md for the mailbox/conn package which was previously
undocumented.