### PR TITLE
client: low-risk OOR followups stacked on #184

### DIFF
--- a/indexer/memory_sync_cursor_store_test.go
+++ b/indexer/memory_sync_cursor_store_test.go
@@ -1,0 +1,60 @@
+package indexer
+
+import (
+	"context"
+	"sync"
+)
+
+// MemorySyncCursorStore is a test-only in-memory SyncCursorStore
+// implementation used by sync client tests.
+type MemorySyncCursorStore struct {
+	mu      sync.RWMutex
+	cursors map[string]uint64
+}
+
+// NewMemorySyncCursorStore creates a new in-memory sync cursor store for
+// tests.
+func NewMemorySyncCursorStore() *MemorySyncCursorStore {
+	return &MemorySyncCursorStore{
+		cursors: make(map[string]uint64),
+	}
+}
+
+// LoadCursor returns the stored cursor for (namespace, key).
+func (s *MemorySyncCursorStore) LoadCursor(_ context.Context,
+	namespace string, key string) (uint64, error) {
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	namespacedKey := s.namespacedKey(namespace, key)
+
+	return s.cursors[namespacedKey], nil
+}
+
+// SaveCursor stores cursor for (namespace, key) monotonically.
+func (s *MemorySyncCursorStore) SaveCursor(_ context.Context,
+	namespace string, key string, cursor uint64) error {
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	namespacedKey := s.namespacedKey(namespace, key)
+	old := s.cursors[namespacedKey]
+	if cursor < old {
+		return nil
+	}
+
+	s.cursors[namespacedKey] = cursor
+
+	return nil
+}
+
+// namespacedKey returns the canonical map key for (namespace, key).
+func (s *MemorySyncCursorStore) namespacedKey(namespace string,
+	key string) string {
+
+	return namespace + "/" + key
+}
+
+var _ SyncCursorStore = (*MemorySyncCursorStore)(nil)

--- a/indexer/sync_client.go
+++ b/indexer/sync_client.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log/slog"
-	"sync"
 
 	btclog "github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/arkrpc"
@@ -266,57 +265,4 @@ func (c *SyncClient) SyncOORRecipientEventsTaproot(ctx context.Context,
 	}, nil
 }
 
-// MemorySyncCursorStore is an in-memory SyncCursorStore
-// implementation.
-type MemorySyncCursorStore struct {
-	mu      sync.RWMutex
-	cursors map[string]uint64
-}
-
-// NewMemorySyncCursorStore creates a new in-memory sync cursor store.
-func NewMemorySyncCursorStore() *MemorySyncCursorStore {
-	return &MemorySyncCursorStore{
-		cursors: make(map[string]uint64),
-	}
-}
-
-// LoadCursor returns the stored cursor for (namespace, key).
-func (s *MemorySyncCursorStore) LoadCursor(_ context.Context,
-	namespace string, key string) (uint64, error) {
-
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	namespacedKey := s.namespacedKey(namespace, key)
-
-	return s.cursors[namespacedKey], nil
-}
-
-// SaveCursor stores cursor for (namespace, key) monotonically.
-func (s *MemorySyncCursorStore) SaveCursor(_ context.Context,
-	namespace string, key string, cursor uint64) error {
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	namespacedKey := s.namespacedKey(namespace, key)
-	old := s.cursors[namespacedKey]
-	if cursor < old {
-		return nil
-	}
-
-	s.cursors[namespacedKey] = cursor
-
-	return nil
-}
-
-// namespacedKey returns the canonical map key for
-// (namespace, key).
-func (s *MemorySyncCursorStore) namespacedKey(namespace string,
-	key string) string {
-
-	return namespace + "/" + key
-}
-
-var _ SyncCursorStore = (*MemorySyncCursorStore)(nil)
 var _ SyncBackend = (*Client)(nil)

--- a/internal/actortest/e2e_test.go
+++ b/internal/actortest/e2e_test.go
@@ -172,6 +172,18 @@ func eventuallyWithOutboxPublish(
 // delivery assertions in this test suite.
 const durableAskResponseTimeout = 10 * time.Second
 
+// outboxForwardProcessingTimeout is the timeout budget for waiting on the
+// source actor to durably process a forward request before any outbox delivery
+// assertions. This is intentionally looser than basic actor assertions because
+// these end-to-end tests run with real SQLite persistence and under `-race` in
+// CI.
+const outboxForwardProcessingTimeout = 5 * time.Second
+
+// outboxDeliveryTimeout is the timeout budget for waiting on OutboxPublisher
+// delivery in end-to-end tests. The helper actively triggers publish attempts
+// during this window to reduce scheduler-induced flakiness under `-race`.
+const outboxDeliveryTimeout = 10 * time.Second
+
 // durableCounterRef is a shorthand alias for the generic durable ref used in
 // these end-to-end tests.
 type durableCounterRef = actor.DurableActorRef[CounterMessage, CounterResult]
@@ -388,14 +400,17 @@ func TestOutboxPublisher_DeliversToTarget(t *testing.T) {
 	require.NoError(t, err)
 
 	// Wait for source to process the forward.
-	eventually(t, 2*time.Second, func() bool {
+	eventually(t, outboxForwardProcessingTimeout, func() bool {
 		return sourceBehavior.ForwardCount() == 1
 	})
 
 	// Wait for target to receive the increment via OutboxPublisher.
-	eventually(t, 5*time.Second, func() bool {
-		return targetBehavior.Count() == 25
-	})
+	eventuallyWithOutboxPublish(
+		t, publisher, outboxDeliveryTimeout,
+		func() bool {
+			return targetBehavior.Count() == 25
+		},
+	)
 
 	require.Equal(t, int64(25), targetBehavior.Count())
 }
@@ -455,19 +470,25 @@ func TestOutboxPublisher_MultiHopForwarding(t *testing.T) {
 	require.NoError(t, err)
 
 	// Wait for A to process.
-	eventually(t, 2*time.Second, func() bool {
+	eventually(t, outboxForwardProcessingTimeout, func() bool {
 		return behaviorA.ForwardCount() == 1
 	})
 
 	// Wait for B to process (receives forward, writes to outbox).
-	eventually(t, 5*time.Second, func() bool {
-		return behaviorB.ForwardCount() == 1
-	})
+	eventuallyWithOutboxPublish(
+		t, publisher, outboxDeliveryTimeout,
+		func() bool {
+			return behaviorB.ForwardCount() == 1
+		},
+	)
 
 	// Wait for C to receive the increment.
-	eventually(t, 5*time.Second, func() bool {
-		return behaviorC.Count() == 100
-	})
+	eventuallyWithOutboxPublish(
+		t, publisher, outboxDeliveryTimeout,
+		func() bool {
+			return behaviorC.Count() == 100
+		},
+	)
 
 	require.Equal(t, int64(100), behaviorC.Count())
 }
@@ -758,14 +779,17 @@ func TestProperty_OutboxEventuallyDelivers(t *testing.T) {
 	require.NoError(t, err)
 
 	// Wait for source to process.
-	eventually(t, 2*time.Second, func() bool {
+	eventually(t, outboxForwardProcessingTimeout, func() bool {
 		return sourceBehavior.ForwardCount() == 1
 	})
 
 	// Wait for target to receive.
-	eventually(t, 5*time.Second, func() bool {
-		return targetBehavior.Count() == amount
-	})
+	eventuallyWithOutboxPublish(
+		t, publisher, outboxDeliveryTimeout,
+		func() bool {
+			return targetBehavior.Count() == amount
+		},
+	)
 
 	require.Equal(t, amount, targetBehavior.Count())
 }

--- a/oor/coverage_misc_test.go
+++ b/oor/coverage_misc_test.go
@@ -29,3 +29,50 @@ func TestTerminalStatesIgnoreUnexpectedEvents(t *testing.T) {
 	require.Equal(t, failed, transition.NextState)
 	require.True(t, transition.NewEvents.IsNone())
 }
+
+// TestReceiveStatesIgnoreUnhandledEvents asserts receive FSM states keep their
+// current state and emit no work when fed unrelated late/out-of-order events.
+func TestReceiveStatesIgnoreUnhandledEvents(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name  string
+		state ReceiveState
+		event Event
+	}{
+		{
+			name:  "ReceiveIdle ignores ArkSignedEvent",
+			state: &ReceiveIdle{},
+			event: &ArkSignedEvent{},
+		},
+		{
+			name:  "ReceiveResolving ignores checkpoint event",
+			state: &ReceiveResolving{},
+			event: &CheckpointsSignedEvent{},
+		},
+		{
+			name:  "ReceiveAwaitingAck ignores StartTransferEvent",
+			state: &ReceiveAwaitingAck{},
+			event: &StartTransferEvent{},
+		},
+		{
+			name:  "ReceiveCompleted ignores IncomingHandledEvent",
+			state: &ReceiveCompleted{},
+			event: &IncomingHandledEvent{},
+		},
+	}
+
+	for _, testCase := range testCases {
+		tc := testCase
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := t.Context()
+
+			transition, err := tc.state.ProcessEvent(
+				ctx, tc.event, nil,
+			)
+			require.NoError(t, err)
+			require.Equal(t, tc.state, transition.NextState)
+			require.True(t, transition.NewEvents.IsNone())
+		})
+	}
+}

--- a/oor/doc.go
+++ b/oor/doc.go
@@ -3,16 +3,91 @@ package oor
 // Package oor implements client-side coordination for out-of-round (OOR) Ark
 // transfers.
 //
-// The main goal is to let a client transfer VTXOs to one or more recipients
-// without waiting for a normal round, while still preserving:
-// - deterministic transaction construction for safe retries; and
-// - crash-safe "resume" semantics for mobile clients.
+// The package is built around deterministic state machines and explicit
+// side-effect boundaries so mobile clients can safely survive restarts while
+// still driving OOR transfers to completion.
 //
-// This package is built around a protofsm-based state machine. All I/O and
-// external side effects are modeled as explicit outbox requests that the caller
-// executes (via RPC, in-process adaptors, or other mechanisms) and then feeds
-// back as events.
+// Core goals:
+//   - deterministic transfer package construction (stable Ark txid/session id)
+//   - crash-safe resume based on persisted state + replayed outbox work
+//   - strict separation between pure FSM transitions and effect execution
 //
-// For outgoing transfers, the critical point-of-no-return is when the server
-// has co-signed the checkpoint transaction(s). After that, the client must be
-// able to resume and obtain byte-identical co-signed PSBTs to safely finalize.
+// The FSM emits OutboxEvent values for all I/O (signing, transport, local
+// persistence, retries). The durable actor executes outbox work and feeds the
+// resulting Event back into the FSM.
+//
+// # Outgoing Transfer FSM
+//
+// State flow (happy path):
+//
+//	Idle
+//	  -- StartTransferEvent -->
+//	AwaitingArkSignatures
+//	  -- ArkSignedEvent -->
+//	AwaitingSubmitAccepted
+//	  -- SubmitAcceptedEvent -->
+//	AwaitingCheckpointSignatures
+//	  -- CheckpointsSignedEvent -->
+//	AwaitingFinalizeAccepted
+//	  -- FinalizeAcceptedEvent -->
+//	AwaitingLocalVTXOUpdate
+//	  -- InputsMarkedSpentEvent -->
+//	Completed
+//
+// Outbox work emitted on this path:
+//   - RequestArkSignatures
+//   - SendSubmitPackageRequest
+//   - RequestCheckpointSignatures
+//   - SendFinalizePackageRequest
+//   - MarkInputsSpentRequest
+//
+// Point-of-no-return:
+//   - SubmitAcceptedEvent means the operator has co-signed checkpoint PSBTs.
+//     After this point, resume logic must preserve byte-level consistency for
+//     checkpoint artifacts and session identity.
+//
+// Retry model:
+//   - Retryable OutboxErrorEvent keeps the current state and emits
+//     ScheduleRetryRequest.
+//   - Non-retryable OutboxErrorEvent transitions to Failed.
+//
+// # Incoming Transfer FSM
+//
+// The receive FSM is separate from the sender FSM so incoming notifications
+// can be validated, materialized, and acked independently.
+//
+// State flow (happy path):
+//
+//	ReceiveResolving or ReceiveIdle
+//	  -- IncomingTransferEvent -->
+//	ReceiveNotified
+//	  -- IncomingMetadataResolvedEvent -->
+//	ReceiveNotified (materialization request emitted)
+//	  -- IncomingHandledEvent -->
+//	ReceiveAwaitingAck
+//	  -- IncomingAckSentEvent -->
+//	ReceiveCompleted
+//
+// Outbox work emitted on this path:
+//   - IncomingTransferNotification
+//   - QueryIncomingMetadataRequest
+//   - MaterializeIncomingVTXOsRequest
+//   - SendIncomingAckRequest
+//
+// # Durability And Idempotency Notes
+//
+// Session identity:
+//   - SessionID is derived from Ark txid and validated throughout transitions.
+//
+// Replay safety:
+//   - FSM states intentionally tolerate duplicate and out-of-order
+//     deliveries by ignoring events not handled by the current state.
+//   - Outbox requests should be implemented idempotently because durable replay
+//     can re-emit them after process restart.
+//
+// Local persistence:
+//   - Local spent-marking and incoming materialization are modeled as outbox
+//     work so failures can be retried with the same deterministic state.
+//
+// These properties let callers choose transport/adaptor implementations without
+// weakening crash recovery guarantees.

--- a/oor/outbox_error_test.go
+++ b/oor/outbox_error_test.go
@@ -65,12 +65,12 @@ func TestHandleOutboxError(t *testing.T) {
 
 	// Nil event rejected: this is a programmer error and should not be
 	// treated as retryable.
-	_, err = handleOutboxError(nil, current, nil)
+	_, err = handleOutboxError(current, nil)
 	require.Error(t, err)
 
 	// Non-retryable error causes terminal failure. The state machine does
 	// not attempt to guess whether retry is safe.
-	transition, err := handleOutboxError(nil, current, &OutboxErrorEvent{
+	transition, err := handleOutboxError(current, &OutboxErrorEvent{
 		OutboxType:  "x",
 		Retryable:   false,
 		ErrorReason: "boom",
@@ -82,7 +82,7 @@ func TestHandleOutboxError(t *testing.T) {
 	// Retryable error keeps the FSM in the current state and emits retry
 	// scheduling. The actor persists retry metadata alongside the real
 	// protocol state.
-	transition, err = handleOutboxError(nil, current, &OutboxErrorEvent{
+	transition, err = handleOutboxError(current, &OutboxErrorEvent{
 		OutboxType:  "x",
 		Retryable:   true,
 		RetryAfter:  0,

--- a/oor/receive_transitions.go
+++ b/oor/receive_transitions.go
@@ -278,5 +278,5 @@ func (s *ReceiveAwaitingAck) ProcessEvent(ctx context.Context, event Event,
 			slog.String("event_type", fmt.Sprintf("%T", event)))
 
 		return ignoreReceiveEvent(s, event), nil
-}
+	}
 }

--- a/oor/receive_transitions.go
+++ b/oor/receive_transitions.go
@@ -43,9 +43,10 @@ import (
 //   v
 // ReceiveCompleted
 
-// unexpectedReceiveEvent returns a transition that keeps the current state and
-// emits no outbox work for an unexpected event.
-func unexpectedReceiveEvent(state ReceiveState, event Event) *StateTransition {
+// ignoreReceiveEvent returns a transition that keeps the current state and
+// emits no outbox work for an event that the current receive state does not
+// handle.
+func ignoreReceiveEvent(state ReceiveState, event Event) *StateTransition {
 	_ = event
 
 	return &StateTransition{
@@ -132,7 +133,7 @@ func (s *ReceiveIdle) ProcessEvent(ctx context.Context, event Event,
 			slog.String("state", fmt.Sprintf("%T", s)),
 			slog.String("event_type", fmt.Sprintf("%T", event)))
 
-		return unexpectedReceiveEvent(s, event), nil
+		return ignoreReceiveEvent(s, event), nil
 	}
 }
 
@@ -157,7 +158,7 @@ func (s *ReceiveResolving) ProcessEvent(ctx context.Context, event Event,
 			slog.String("state", fmt.Sprintf("%T", s)),
 			slog.String("event_type", fmt.Sprintf("%T", event)))
 
-		return unexpectedReceiveEvent(s, event), nil
+		return ignoreReceiveEvent(s, event), nil
 	}
 }
 
@@ -227,7 +228,7 @@ func (s *ReceiveNotified) ProcessEvent(ctx context.Context, event Event,
 			slog.String("state", fmt.Sprintf("%T", s)),
 			slog.String("event_type", fmt.Sprintf("%T", event)))
 
-		return unexpectedReceiveEvent(s, event), nil
+		return ignoreReceiveEvent(s, event), nil
 	}
 }
 
@@ -241,7 +242,7 @@ func (s *ReceiveCompleted) ProcessEvent(ctx context.Context, event Event,
 		slog.String("state", fmt.Sprintf("%T", s)),
 		slog.String("event_type", fmt.Sprintf("%T", event)))
 
-	return unexpectedReceiveEvent(s, event), nil
+	return ignoreReceiveEvent(s, event), nil
 }
 
 // ProcessEvent handles events for ReceiveAwaitingAck.
@@ -276,6 +277,6 @@ func (s *ReceiveAwaitingAck) ProcessEvent(ctx context.Context, event Event,
 			slog.String("state", fmt.Sprintf("%T", s)),
 			slog.String("event_type", fmt.Sprintf("%T", event)))
 
-		return unexpectedReceiveEvent(s, event), nil
-	}
+		return ignoreReceiveEvent(s, event), nil
+}
 }

--- a/oor/transitions.go
+++ b/oor/transitions.go
@@ -17,12 +17,12 @@ import (
 // specify an explicit backoff.
 const defaultRetryDelay = 1 * time.Second
 
-// unexpectedEvent returns a transition that stays in the current state and
-// emits no outbox work for an unexpected event.
+// ignoreEvent returns a transition that stays in the current state and emits
+// no outbox work for an event not handled by the current state.
 //
 // This makes the FSM resilient to retries and late deliveries at the actor
 // boundary.
-func unexpectedEvent(state State) *StateTransition {
+func ignoreEvent(state State) *StateTransition {
 	return &StateTransition{
 		NextState: state,
 		NewEvents: fn.None[EmittedEvent](),
@@ -113,7 +113,7 @@ func (s *Idle) ProcessEvent(ctx context.Context, event Event,
 		}, nil
 
 	default:
-		return unexpectedEvent(s), nil
+		return ignoreEvent(s), nil
 	}
 }
 
@@ -182,7 +182,7 @@ func (s *AwaitingArkSignatures) ProcessEvent(ctx context.Context, event Event,
 		}, nil
 
 	default:
-		return unexpectedEvent(s), nil
+		return ignoreEvent(s), nil
 	}
 }
 
@@ -257,7 +257,7 @@ func (s *AwaitingSubmitAccepted) ProcessEvent(ctx context.Context, event Event,
 		}, nil
 
 	default:
-		return unexpectedEvent(s), nil
+		return ignoreEvent(s), nil
 	}
 }
 
@@ -334,7 +334,7 @@ func (s *AwaitingCheckpointSignatures) ProcessEvent(ctx context.Context,
 		}, nil
 
 	default:
-		return unexpectedEvent(s), nil
+		return ignoreEvent(s), nil
 	}
 }
 
@@ -375,7 +375,7 @@ func (s *AwaitingFinalizeAccepted) ProcessEvent(ctx context.Context,
 		}, nil
 
 	default:
-		return unexpectedEvent(s), nil
+		return ignoreEvent(s), nil
 	}
 }
 
@@ -405,7 +405,7 @@ func (s *AwaitingLocalVTXOUpdate) ProcessEvent(ctx context.Context,
 		}, nil
 
 	default:
-		return unexpectedEvent(s), nil
+		return ignoreEvent(s), nil
 	}
 }
 
@@ -416,7 +416,7 @@ func (s *Completed) ProcessEvent(ctx context.Context, event Event,
 	_ = ctx
 	_ = env
 
-	return unexpectedEvent(s), nil
+	return ignoreEvent(s), nil
 }
 
 // ProcessEvent handles events for Failed.
@@ -426,7 +426,7 @@ func (s *Failed) ProcessEvent(ctx context.Context, event Event,
 	_ = ctx
 	_ = env
 
-	return unexpectedEvent(s), nil
+	return ignoreEvent(s), nil
 }
 
 // handleOutboxError emits retry scheduling for retryable errors while keeping

--- a/oor/transitions.go
+++ b/oor/transitions.go
@@ -173,7 +173,7 @@ func (s *AwaitingArkSignatures) ProcessEvent(ctx context.Context, event Event,
 		}, nil
 
 	case *OutboxErrorEvent:
-		return handleOutboxError(env, s, evt)
+		return handleOutboxError(s, evt)
 
 	case *FailEvent:
 		return &StateTransition{
@@ -248,7 +248,7 @@ func (s *AwaitingSubmitAccepted) ProcessEvent(ctx context.Context, event Event,
 		}, nil
 
 	case *OutboxErrorEvent:
-		return handleOutboxError(env, s, evt)
+		return handleOutboxError(s, evt)
 
 	case *FailEvent:
 		return &StateTransition{
@@ -325,7 +325,7 @@ func (s *AwaitingCheckpointSignatures) ProcessEvent(ctx context.Context,
 		}, nil
 
 	case *OutboxErrorEvent:
-		return handleOutboxError(env, s, evt)
+		return handleOutboxError(s, evt)
 
 	case *FailEvent:
 		return &StateTransition{
@@ -366,7 +366,7 @@ func (s *AwaitingFinalizeAccepted) ProcessEvent(ctx context.Context,
 		}, nil
 
 	case *OutboxErrorEvent:
-		return handleOutboxError(env, s, evt)
+		return handleOutboxError(s, evt)
 
 	case *FailEvent:
 		return &StateTransition{
@@ -396,7 +396,7 @@ func (s *AwaitingLocalVTXOUpdate) ProcessEvent(ctx context.Context,
 		}, nil
 
 	case *OutboxErrorEvent:
-		return handleOutboxError(env, s, evt)
+		return handleOutboxError(s, evt)
 
 	case *FailEvent:
 		return &StateTransition{
@@ -431,7 +431,7 @@ func (s *Failed) ProcessEvent(ctx context.Context, event Event,
 
 // handleOutboxError emits retry scheduling for retryable errors while keeping
 // the FSM in the current protocol state.
-func handleOutboxError(env *Environment, current State,
+func handleOutboxError(current State,
 	evt *OutboxErrorEvent) (*StateTransition, error) {
 
 	if evt == nil {

--- a/serverconn/actor.go
+++ b/serverconn/actor.go
@@ -537,9 +537,9 @@ func (m *SendUnaryRequest) serverConnMsgSealed() {}
 // ServerConnectionActor is the unified connector boundary for all mailbox
 // traffic between the client and the remote server. It serves as both:
 //
-//  1. An egress actor: receives outbound messages from the round actor (FSM
-//     events) and unary facade (RPC requests), then sends them via the
-//     mailbox edge.
+//  1. An egress actor: receives outbound messages from durable protocol actors
+//     (for example round and OOR) plus unary facade requests, then sends them
+//     via the mailbox edge.
 //
 //  2. An ingress loop: continuously pulls envelopes from the remote mailbox,
 //     dispatches them to local actors via ServiceKey-based routing, and
@@ -547,7 +547,7 @@ func (m *SendUnaryRequest) serverConnMsgSealed() {}
 //     delivery with crash safety.
 //
 // The actor is backed by a DurableActor for crash-safe egress. Outbound
-// messages from the round actor persist in the durable mailbox before
+// messages from protocol actors persist in the durable mailbox before
 // processing, ensuring no message loss on crashes.
 type ServerConnectionActor struct {
 	// cfg holds all dependencies and tuning knobs for the connector.

--- a/serverconn/connector_test.go
+++ b/serverconn/connector_test.go
@@ -527,6 +527,50 @@ func TestEgress_EventRetriesPreserveIdempotencyKey(t *testing.T) {
 	require.Equal(t, testEventMethod, envs[1].Rpc.Method)
 }
 
+// TestEventRoutingMetadata verifies how SendClientEventRequest route fields are
+// resolved when explicit values and ServerMessage metadata are combined.
+func TestEventRoutingMetadata(t *testing.T) {
+	t.Parallel()
+
+	service, method := eventRoutingMetadata(nil)
+	require.Equal(t, "", service)
+	require.Equal(t, "", method)
+
+	service, method = eventRoutingMetadata(&SendClientEventRequest{
+		Service: "svc.explicit",
+		Method:  "method.explicit",
+		Message: &testServerMessage{value: "ignored"},
+	})
+	require.Equal(t, "svc.explicit", service)
+	require.Equal(t, "method.explicit", method)
+
+	service, method = eventRoutingMetadata(&SendClientEventRequest{
+		Message: &testServerMessage{value: "fallback"},
+	})
+	require.Equal(t, testEventService, service)
+	require.Equal(t, testEventMethod, method)
+
+	service, method = eventRoutingMetadata(&SendClientEventRequest{
+		Service: "svc.partial",
+		Message: &testServerMessage{value: "fill-method"},
+	})
+	require.Equal(t, "svc.partial", service)
+	require.Equal(t, testEventMethod, method)
+
+	service, method = eventRoutingMetadata(&SendClientEventRequest{
+		Method:  "method.partial",
+		Message: &testServerMessage{value: "fill-service"},
+	})
+	require.Equal(t, testEventService, service)
+	require.Equal(t, "method.partial", method)
+
+	service, method = eventRoutingMetadata(&SendClientEventRequest{
+		Service: "svc.only",
+	})
+	require.Equal(t, "svc.only", service)
+	require.Equal(t, "", method)
+}
+
 // TestIngress_PartialDispatch_NoDuplicateRedelivery verifies that when
 // a batch dispatch fails mid-way, the already-dispatched envelopes are
 // not re-dispatched on the next loop iteration. This is a regression test

--- a/serverconn/doc.go
+++ b/serverconn/doc.go
@@ -3,11 +3,11 @@
 //
 // The connector serves as both an egress actor and an ingress loop:
 //
-//   - Egress: Receives outbound messages from the round actor (FSM events) and
-//     the unary facade (RPC requests), then sends them via the mailbox edge.
-//     The actor is backed by a DurableActor for crash-safe egress — outbound
-//     messages from the round actor persist in the durable mailbox before
-//     processing, ensuring no message loss on crashes.
+//   - Egress: Receives outbound messages from round and OOR durable actors, as
+//     well as unary facade calls, then sends them via the mailbox edge. The
+//     actor is backed by a DurableActor for crash-safe egress: outbound actor
+//     messages are durably queued before processing, so crashes do not drop
+//     in-flight mailbox work.
 //
 //   - Ingress: Continuously pulls envelopes from the remote mailbox, dispatches
 //     them to local actors via ServiceKey-based routing, and manages the ack
@@ -43,6 +43,19 @@
 // KIND_RESPONSE envelopes are delivered to in-memory response waiters via the
 // response registry. This is not durable — if the process crashes, callers'
 // contexts are cancelled and they retry.
+//
+// OOR routing is first-class in this dispatch model. Current wiring registers
+// OOR service routes for:
+//   - submit/finalize response adaptation into OOR DriveEvent requests;
+//   - incoming transfer push events from indexer service notifications; and
+//   - durable indexer-query responses used by incoming receive resolution.
+//
+// This means serverconn handles both outgoing OOR protocol traffic and
+// the corresponding ingress callbacks needed to advance the OOR FSM after
+// restart-safe delivery.
+//
+// Note: incoming OOR ack response routing is intentionally absent today because
+// the wire proto does not yet define an ack response RPC.
 //
 // # Unary Facade
 //

--- a/serverconn/restart_replay_test.go
+++ b/serverconn/restart_replay_test.go
@@ -11,6 +11,7 @@ import (
 	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 // failFirstSendEdge wraps the in-memory mailbox edge and fails the first Send
@@ -160,4 +161,88 @@ func TestEgress_RestartReplayPreservesStableIDs(t *testing.T) {
 
 	require.Equal(t, firstMsgID, replayed.MsgId)
 	require.Equal(t, firstIdemKey, replayed.IdempotencyKey)
+}
+
+// TestDurableUnary_RestartReplayPreservesStableIDs verifies a durable unary
+// query replayed after actor restart reuses the same MsgId and
+// IdempotencyKey while preserving route/correlation metadata.
+func TestDurableUnary_RestartReplayPreservesStableIDs(t *testing.T) {
+	t.Parallel()
+
+	mb := newInMemoryMailbox()
+	edge := newFailFirstSendEdge(mb)
+	store := newMemCheckpointStore()
+
+	cfg := newTestConnectorConfig(mb, store)
+	cfg.Edge = edge
+	cfg.Codec = NewServerConnCodec()
+	cfg.DurableUnaryBuilder = &testDurableUnaryBuilder{}
+
+	// First actor instance fails once and leaves the durable unary
+	// send queued for replay.
+	durable1 := newDurableConnectorForTest(cfg, 500*time.Millisecond)
+	durable1.Start()
+
+	err := durable1.TellRef().Tell(
+		t.Context(), &SendListVTXOsByScriptsRequest{
+			PkScripts: [][]byte{
+				{0x51, 0x20, 0x01},
+			},
+			AfterCursor:   11,
+			Limit:         5,
+			CorrelationID: "corr-vtxo-restart",
+		},
+	)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		attempts, _, _ := edge.Snapshot()
+
+		return attempts >= 1
+	}, 5*time.Second, 10*time.Millisecond)
+
+	durable1.Stop()
+
+	attempts, firstMsgID, firstIdemKey := edge.Snapshot()
+	require.Equal(t, 1, attempts)
+	require.NotEmpty(t, firstMsgID)
+	require.NotEmpty(t, firstIdemKey)
+
+	mb.mu.Lock()
+	firstRunEnvs := append(
+		[]*mailboxpb.Envelope(nil), mb.mailboxes["server-1"]...,
+	)
+	mb.mu.Unlock()
+	require.Empty(t, firstRunEnvs)
+
+	// Second actor instance replays from the same durable store and then
+	// succeeds.
+	durable2 := newDurableConnectorForTest(cfg, 20*time.Millisecond)
+	durable2.Start()
+	defer durable2.Stop()
+
+	require.Eventually(t, func() bool {
+		mb.mu.Lock()
+		defer mb.mu.Unlock()
+
+		return len(mb.mailboxes["server-1"]) == 1
+	}, 8*time.Second, 10*time.Millisecond)
+
+	mb.mu.Lock()
+	replayed := mb.mailboxes["server-1"][0]
+	mb.mu.Unlock()
+
+	require.Equal(t, firstMsgID, replayed.MsgId)
+	require.Equal(t, firstIdemKey, replayed.IdempotencyKey)
+	require.Equal(
+		t, "arkrpc.IndexerService",
+		replayed.GetRpc().GetService(),
+	)
+	require.Equal(t, "ListVTXOsByScripts", replayed.GetRpc().GetMethod())
+	require.Equal(t, "corr-vtxo-restart",
+		replayed.GetRpc().GetCorrelationId())
+
+	payload := &wrapperspb.StringValue{}
+	require.NoError(t, replayed.GetBody().UnmarshalTo(payload))
+	require.Equal(t, "vtxos:1:11:5", payload.GetValue())
 }

--- a/serverconn/runtime.go
+++ b/serverconn/runtime.go
@@ -14,9 +14,11 @@ func DurableActorID(localMailboxID string) string {
 }
 
 // Runtime embeds a DurableActor for serverconn egress and wires it together
-// with the ingress loop and unary facade. Because the DurableActor is
-// embedded, Runtime can be registered directly with the actor system — Ref
-// and TellRef are promoted without wrapper methods.
+// with the ingress loop and unary facade. Higher-level protocol actors (round,
+// OOR, and future durable mailbox clients) use TellRef for crash-safe egress.
+//
+// Because the DurableActor is embedded, Runtime can be registered directly
+// with the actor system: Ref and TellRef are promoted without wrapper methods.
 type Runtime struct {
 	*actor.DurableActor[ServerConnMsg, ServerConnResp]
 


### PR DESCRIPTION
## Summary

This PR stacks on top of `oor-simplify-client-state` (PR #184) and batches
additional **low-risk** followups in `darepo-client` only.

Main themes:
- naming/documentation clarity for OOR/serverconn
- targeted test coverage additions for replay/routing/no-op semantics
- test-only cleanup in indexer
- keep the stack lint-clean

## Changes

1. `oor`: rename receive no-op helper for clearer semantics.
2. `oor`: expand package docs with outgoing/incoming transition and durability narrative.
3. `serverconn`: document current OOR routing/coverage.
4. `indexer`: move `MemorySyncCursorStore` into test-only compilation unit.
5. `serverconn`: add restart replay test for durable unary queries.
6. `oor`: rename outgoing no-op helper for consistency (`unexpectedEvent` -> `ignoreEvent`).
7. `serverconn`: add unit coverage for event route metadata fallback semantics.
8. `serverconn`: align actor/runtime comments with current round+OOR usage.
9. `oor`: add receive FSM no-op handling coverage for late/out-of-phase events.

## Why This Is Low Risk

- No protocol-logic rewrites.
- No snapshot schema changes.
- No outbox behavior changes beyond naming/docs/tests.
- Runtime-affecting edits are limited to formatting and line wrapping.
- Most additions are test-only and documentation-only.

## Validation

- `go test ./oor/... ./serverconn/... ./indexer/... ./round/...`
- `make lint`

Both pass on this branch.
