### PR TITLE
harness: extend lnd startup waits for serialized systest

### DIFF
--- a/harness/harness.go
+++ b/harness/harness.go
@@ -61,6 +61,11 @@ const (
 	// readiness, not logic under test.
 	electrsReadyTimeout = 2 * time.Minute
 
+	// lndStartupTimeout is a longer timeout for LND bootstrap and chain
+	// synchronization operations that can take meaningfully longer than the
+	// generic harness timeout under serialized systest load.
+	lndStartupTimeout = 90 * time.Second
+
 	// pollInterval is the interval for polling in require.Eventually
 	// calls. Set to 200ms to balance responsiveness with CPU usage during
 	// test execution. This is used for most polling operations including
@@ -2211,7 +2216,7 @@ func (h *Harness) startLNDInstance(name, dataDir string) *LndInstance {
 
 			return true
 		},
-		defaultTimeout, time.Second,
+		lndStartupTimeout, time.Second,
 		fmt.Sprintf("%s TLS/gRPC not ready", name),
 	)
 
@@ -2271,7 +2276,9 @@ func (h *Harness) initAndWaitLNDInstance(
 		}
 
 		return resp.State == lnrpc.WalletState_SERVER_ACTIVE
-	}, defaultTimeout, time.Second, fmt.Sprintf("%s not active", inst.Name))
+	}, lndStartupTimeout, time.Second,
+		fmt.Sprintf("%s not active", inst.Name),
+	)
 
 	err = h.pool.Retry(func() error {
 		if _, err := os.Stat(inst.Macaroon); err != nil {
@@ -2358,7 +2365,7 @@ func (h *Harness) waitForLNDChainSyncInstance(inst *LndInstance) {
 
 			return sync.SyncedToChain
 		},
-		defaultTimeout, pollInterval,
+		lndStartupTimeout, pollInterval,
 		fmt.Sprintf("%s not synced", inst.Name),
 	)
 }


### PR DESCRIPTION
## Summary
- add a dedicated longer timeout for LND startup and chain-sync waits in the harness
- stop full serialized systest runs from failing when a fresh LND instance is slow but healthy
- keep the change isolated to the LND bootstrap path instead of widening all harness timeouts

## Testing
- go test ./harness -count=1
- docker run --rm -v darepo-go-build-cache:/root/.cache/go-build -v darepo-go-lint-cache:/root/.cache/golangci-lint -v darepo-go-mod-cache:/go/pkg/mod -e GOPATH=/go -v $(pwd):/build darepo-tools custom-gcl run -v --timeout=15m --new-from-merge-base=origin/main --whole-files ./harness
