### PR TITLE
Part 1: client low-risk follow-ups for integration test migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: sqlc sqlc-check migrate-create migrate-up migrate-down gen
-.PHONY: lint lint-source docker-tools fmt fmt-check tidy-module tidy-module-check schema-check doc-check
+.PHONY: lint lint-source lint-local lint-source-local lint-changed-local local-custom-gcl docker-tools fmt fmt-check tidy-module tidy-module-check schema-check doc-check
 .PHONY: ast-lint ast-grep-fix
 .PHONY: unit unit-cover unit-race check-go-version build install clean release
 .PHONY: build rpc install help clean-networks
@@ -107,6 +107,8 @@ SUBMODULES := $(shell find . -mindepth 2 -name 'go.mod' -not -path './tools/*' -
 ifneq ($(workers),)
 LINT_WORKERS = --concurrency=$(workers)
 endif
+LINT_BASE := $(if $(base),$(base),origin/main)
+LOCAL_CUSTOM_GCL := $(CURDIR)/$(TOOLS_DIR)/custom-gcl
 
 # Docker cache mounting strategy:
 # - CI (GitHub Actions): Use bind mounts to host paths that GA caches persist.
@@ -209,9 +211,60 @@ docker-tools:
 	@$(call print, "Building tools docker image.")
 	docker build -q -t darepo-tools $(TOOLS_DIR)
 
+local-custom-gcl:
+	@mkdir -p $(TOOLS_DIR)
+	@if command -v custom-gcl >/dev/null 2>&1; then \
+		ln -sf "$$(command -v custom-gcl)" "$(LOCAL_CUSTOM_GCL)"; \
+		echo "Using custom-gcl from PATH."; \
+	elif command -v go >/dev/null 2>&1; then \
+		printf '%s\n' \
+			'#!/bin/sh' \
+			'set -e' \
+			'run_golangci() {' \
+			'	exec go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.5 "$$@"' \
+			'}' \
+			'if [ "$$1" = "run" ]; then' \
+			'	shift' \
+			'	tmp="$$(mktemp)"' \
+			'	cfg="$$tmp.yml"' \
+			'	mv "$$tmp" "$$cfg"' \
+			'	trap '\''rm -f "$$cfg"'\'' EXIT' \
+			'	awk '\''{' \
+			'		if ($$0 ~ /^linters-settings:[[:space:]]*$$/) {in_ls=1; print; next}' \
+			'		if (in_ls && $$0 ~ /^  custom:[[:space:]]*$$/) {skip_custom=1; next}' \
+			'		if (skip_custom && $$0 ~ /^  [A-Za-z0-9_-]+:[[:space:]]*$$/) {skip_custom=0}' \
+			'		if (in_ls && $$0 ~ /^[^[:space:]]/) {in_ls=0}' \
+			'		if (skip_custom) {next}' \
+			'		if ($$0 ~ /^[[:space:]]*-[[:space:]]*ll[[:space:]]*$$/) {sub(/ll/, "lll"); print; next}' \
+			'		print $$0' \
+			'	}'\'' .golangci.yml > "$$cfg"' \
+			'	run_golangci run --config "$$cfg" "$$@"' \
+			'fi' \
+			'run_golangci "$$@"' \
+			> "$(LOCAL_CUSTOM_GCL)"; \
+		chmod +x "$(LOCAL_CUSTOM_GCL)"; \
+		echo "custom-gcl not found; using golangci-lint v1.64.5 fallback"; \
+		echo "(custom linter plugin 'll' is disabled in local mode)."; \
+	elif [ -x "$(LOCAL_CUSTOM_GCL)" ]; then \
+		echo "Using local linter binary: $(LOCAL_CUSTOM_GCL)"; \
+	else \
+		echo "error: install go or custom-gcl"; \
+		exit 1; \
+	fi
+
 lint-source: docker-tools
 	@$(call print, "Linting source.")
 	$(DOCKER_TOOLS) custom-gcl run -v --timeout=15m $(LINT_WORKERS)
+
+lint-source-local: local-custom-gcl
+	@$(call print, "Linting source locally (no Docker).")
+	$(LOCAL_CUSTOM_GCL) run -v --timeout=15m $(LINT_WORKERS)
+
+lint-changed-local: local-custom-gcl #? Run static code analysis only for changes against base=<ref> locally (no Docker)
+	@$(call print, "Linting source changes against $(LINT_BASE) locally.")
+	$(LOCAL_CUSTOM_GCL) run -v --timeout=15m $(LINT_WORKERS) \
+		--new-from-merge-base=$(LINT_BASE) \
+		--whole-files
 
 # Globs to exclude generated files from ast-grep.
 AST_GREP_EXCLUDE := --globs '!**/*.pb.go' --globs '!**/*.pb.gw.go' --globs '!**/*.pb.json.go' --globs '!**/db/sqlc/*.go'
@@ -228,6 +281,8 @@ ast-grep-fix: #? Auto-fix ast-grep style issues (requires ast-grep/sg installed)
 	sg scan --update-all $(AST_GREP_EXCLUDE) $(AST_GREP_PATH)
 
 lint: check-go-version check-migration-version lint-source #? Run static code analysis
+
+lint-local: check-go-version check-migration-version lint-source-local #? Run static code analysis locally (no Docker)
 
 fmt: $(GOIMPORTS_BIN) #? Format code and fix imports
 	@$(call print, "Fixing imports.")

--- a/chainbackends/lnd.go
+++ b/chainbackends/lnd.go
@@ -205,11 +205,18 @@ func (b *LNDBackend) RegisterConf(ctx context.Context,
 			err)
 	}
 
+	// The caller context only scopes registration setup. Keep the delivery
+	// forwarder alive until the registration itself is cancelled so
+	// confirmations are not dropped when the originating actor request
+	// context is released.
+	notifyCtx, cancel := context.WithCancel(context.Background())
+
 	// Create a channel to convert lnd's TxConfirmation to our type.
 	confChan := make(chan *chainsource.TxConfirmation, 1)
 
 	go func() {
 		defer close(confChan)
+		defer cancel()
 		defer event.Cancel()
 
 		select {
@@ -228,14 +235,17 @@ func (b *LNDBackend) RegisterConf(ctx context.Context,
 
 			confChan <- conf
 
-		case <-ctx.Done():
+		case <-notifyCtx.Done():
 			return
 		}
 	}()
 
 	return &chainsource.ConfRegistration{
 		Confirmed: confChan,
-		Cancel:    event.Cancel,
+		Cancel: func() {
+			cancel()
+			event.Cancel()
+		},
 	}, nil
 }
 
@@ -258,12 +268,16 @@ func (b *LNDBackend) RegisterSpend(ctx context.Context,
 		return nil, fmt.Errorf("failed to register spend: %w", err)
 	}
 
+	// Keep spend delivery alive independently of the actor request context.
+	notifyCtx, cancel := context.WithCancel(context.Background())
+
 	// Create a channel to convert lnd's SpendDetail to our type.
 	spendChan := make(chan *chainsource.SpendDetail, 1)
 
 	// Start a goroutine to convert and forward the spend.
 	go func() {
 		defer close(spendChan)
+		defer cancel()
 		defer event.Cancel()
 
 		select {
@@ -283,14 +297,17 @@ func (b *LNDBackend) RegisterSpend(ctx context.Context,
 
 			spendChan <- spend
 
-		case <-ctx.Done():
+		case <-notifyCtx.Done():
 			return
 		}
 	}()
 
 	return &chainsource.SpendRegistration{
-		Spend:  spendChan,
-		Cancel: event.Cancel,
+		Spend: spendChan,
+		Cancel: func() {
+			cancel()
+			event.Cancel()
+		},
 	}, nil
 }
 

--- a/chainbackends/lnd_test.go
+++ b/chainbackends/lnd_test.go
@@ -1,0 +1,188 @@
+package chainbackends
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/chainsource"
+	"github.com/lightningnetwork/lnd/chainntnfs"
+	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
+	"github.com/stretchr/testify/require"
+)
+
+type stubNotifier struct {
+	confEvent  *chainntnfs.ConfirmationEvent
+	spendEvent *chainntnfs.SpendEvent
+}
+
+func (n *stubNotifier) RegisterConfirmationsNtfn(
+	_ *chainhash.Hash, _ []byte, _, _ uint32,
+	_ ...chainntnfs.NotifierOption,
+) (*chainntnfs.ConfirmationEvent, error) {
+
+	return n.confEvent, nil
+}
+
+func (n *stubNotifier) RegisterSpendNtfn(
+	_ *wire.OutPoint, _ []byte, _ uint32,
+) (*chainntnfs.SpendEvent, error) {
+
+	return n.spendEvent, nil
+}
+
+func (n *stubNotifier) RegisterBlockEpochNtfn(
+	_ *chainntnfs.BlockEpoch,
+) (*chainntnfs.BlockEpochEvent, error) {
+
+	return &chainntnfs.BlockEpochEvent{
+		Epochs: make(chan *chainntnfs.BlockEpoch),
+		Cancel: func() {},
+	}, nil
+}
+
+func (n *stubNotifier) Start() error { return nil }
+
+func (n *stubNotifier) Started() bool { return true }
+
+func (n *stubNotifier) Stop() error { return nil }
+
+type stubFeeEstimator struct{}
+
+func (s *stubFeeEstimator) EstimateFeePerKW(
+	_ uint32,
+) (chainfee.SatPerKWeight, error) {
+
+	return 0, nil
+}
+
+func (s *stubFeeEstimator) RelayFeePerKW() chainfee.SatPerKWeight {
+	return 0
+}
+
+func (s *stubFeeEstimator) Start() error { return nil }
+
+func (s *stubFeeEstimator) Stop() error { return nil }
+
+type stubBroadcaster struct{}
+
+func (s *stubBroadcaster) PublishTransaction(
+	_ context.Context, _ *wire.MsgTx, _ string,
+) error {
+
+	return nil
+}
+
+func TestRegisterConfSurvivesCallerContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	confChan := make(chan *chainntnfs.TxConfirmation, 1)
+	notifier := &stubNotifier{
+		confEvent: &chainntnfs.ConfirmationEvent{
+			Confirmed: confChan,
+			Cancel:    func() {},
+			Done:      make(chan struct{}),
+		},
+	}
+	backend := NewLNDBackend(
+		notifier, &stubFeeEstimator{}, &stubBroadcaster{},
+	)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	reg, err := backend.RegisterConf(
+		ctx, &chainhash.Hash{1}, []byte{0x51}, 1, 100, false,
+	)
+	require.NoError(t, err)
+
+	cancel()
+
+	expectedHash := chainhash.Hash{2}
+	confChan <- &chainntnfs.TxConfirmation{
+		BlockHash:   &expectedHash,
+		BlockHeight: 123,
+		Tx:          wire.NewMsgTx(2),
+	}
+
+	var got *chainsource.TxConfirmation
+	require.Eventually(t, func() bool {
+		select {
+		case conf, ok := <-reg.Confirmed:
+			if !ok {
+				return false
+			}
+
+			got = conf
+
+			return true
+
+		default:
+			return false
+		}
+	}, testTimeout, pollInterval)
+
+	require.NotNil(t, got)
+	require.Equal(t, uint32(123), got.BlockHeight)
+	require.Equal(t, expectedHash, *got.BlockHash)
+	reg.Cancel()
+}
+
+func TestRegisterSpendSurvivesCallerContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	spendChan := make(chan *chainntnfs.SpendDetail, 1)
+	notifier := &stubNotifier{
+		spendEvent: &chainntnfs.SpendEvent{
+			Spend:  spendChan,
+			Reorg:  make(chan struct{}),
+			Done:   make(chan struct{}),
+			Cancel: func() {},
+		},
+	}
+	backend := NewLNDBackend(
+		notifier, &stubFeeEstimator{}, &stubBroadcaster{},
+	)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	outpoint := &wire.OutPoint{Index: 1}
+	reg, err := backend.RegisterSpend(ctx, outpoint, []byte{0x51}, 100)
+	require.NoError(t, err)
+
+	cancel()
+
+	spenderHash := chainhash.Hash{3}
+	spendChan <- &chainntnfs.SpendDetail{
+		SpentOutPoint:  outpoint,
+		SpenderTxHash:  &spenderHash,
+		SpendingTx:     wire.NewMsgTx(2),
+		SpendingHeight: 144,
+	}
+
+	var got *chainsource.SpendDetail
+	require.Eventually(t, func() bool {
+		select {
+		case spend, ok := <-reg.Spend:
+			if !ok {
+				return false
+			}
+
+			got = spend
+
+			return true
+
+		default:
+			return false
+		}
+	}, testTimeout, pollInterval)
+
+	require.NotNil(t, got)
+	require.Equal(t, int32(144), got.SpendingHeight)
+	require.Equal(t, spenderHash, *got.SpenderTxHash)
+	reg.Cancel()
+}
+
+const (
+	pollInterval = 50 * time.Millisecond
+	testTimeout  = 5 * pollInterval
+)


### PR DESCRIPTION
## Summary
This is Part 1 of the integration-test migration follow-ups on the client side.

It includes two low-risk changes:
- preserve notifier event delivery after request-context cancellation in the LND chain backend
- add non-Docker lint targets (`lint-local`, `lint-source-local`, `lint-changed-local`) with a local `custom-gcl` fallback path

## Commits
- `e5dbdd2` chainbackends: preserve notifier delivery after request context
- `e75143c` build: add non-docker lint targets

## Validation
- `make lint-changed-local base=origin/main workers=2`
- targeted chainbackend tests were previously run when this stack was prepared

## Notes
- This PR is intentionally scoped to low-risk client changes only.
- Server-side integration-test expansion is tracked in a separate Part 1 PR in `darepo`.
