### PR TITLE
serverconn: route header-only unary error responses

### DIFF
--- a/serverconn/connector_test.go
+++ b/serverconn/connector_test.go
@@ -7,10 +7,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/lightninglabs/darepo-client/baselib/actor"
 	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
 	mailboxrpc "github.com/lightninglabs/darepo-client/mailbox/rpc"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -144,6 +147,37 @@ func sendRoutedResponseToMailbox(
 	status := mb.send(env)
 	require.True(t, status.Ok, "send routed response failed: %s",
 		status.Message)
+}
+
+// sendRoutedErrorResponseToMailbox injects a KIND_RESPONSE envelope that
+// carries service/method metadata and a gRPC error encoded in headers, but no
+// response body.
+func sendRoutedErrorResponseToMailbox(
+	t *testing.T, mb *inMemoryMailbox, recipientID, correlationID,
+	service, method string, err error,
+) {
+
+	t.Helper()
+
+	env := &mailboxpb.Envelope{
+		ProtocolVersion: 1,
+		Sender:          "server-1",
+		Recipient:       recipientID,
+		Headers:         mailboxrpc.EncodeErrorHeaders(err),
+		Rpc: &mailboxpb.RpcMeta{
+			Kind:          mailboxpb.RpcMeta_KIND_RESPONSE,
+			CorrelationId: correlationID,
+			Service:       service,
+			Method:        method,
+			ReplyTo:       "server-1",
+		},
+	}
+
+	status := mb.send(env)
+	require.True(
+		t, status.Ok, "send routed error response failed: %s",
+		status.Message,
+	)
 }
 
 // sendEventToMailbox injects a KIND_EVENT envelope into the given mailbox
@@ -315,6 +349,76 @@ func TestIngress_ResponseDelivery(t *testing.T) {
 // TestIngress_ResponseDispatchWithoutWaiter verifies that a KIND_RESPONSE
 // envelope without an in-memory unary waiter falls back to the durable
 // dispatcher map keyed by service and method.
+// TestIngress_ResponseDispatchHeaderOnlyError verifies that routed response
+// dispatch still reaches EventRouter handlers when the server encodes a gRPC
+// error in headers and intentionally omits the response body.
+func TestIngress_ResponseDispatchHeaderOnlyError(t *testing.T) {
+	t.Parallel()
+
+	mb := newInMemoryMailbox()
+	store := newMemCheckpointStore()
+	system := actor.NewActorSystem()
+
+	greetingKey := actor.NewServiceKey[*helloStartedMsg, struct{}](
+		"greeting-actor",
+	)
+	behavior := &greetingBehavior{
+		received: make(chan *helloStartedMsg, 1),
+	}
+	actor.RegisterWithSystem(system, "greeting-1", greetingKey, behavior)
+
+	router := NewEventRouter(system)
+	AddEnvelopeRoute(
+		router, EnvelopeRouteConfig[*helloStartedMsg, struct{}]{
+			Service: "test.Svc",
+			Method:  "Unary",
+			NewEvent: func() proto.Message {
+				return &wrapperspb.StringValue{}
+			},
+			Key: greetingKey,
+			Adapt: func(env *mailboxpb.Envelope,
+				_ proto.Message) (*helloStartedMsg, error) {
+
+				rpcErr := mailboxrpc.DecodeErrorHeaders(
+					env.GetHeaders(),
+				)
+				if rpcErr == nil {
+					return nil, fmt.Errorf(
+						"expected encoded rpc error",
+					)
+				}
+
+				return &helloStartedMsg{
+					SessionID: rpcErr.Error(),
+				}, nil
+			},
+		},
+	)
+
+	cfg := newTestConnectorConfig(mb, store)
+	cfg.Dispatchers = router.AsDispatcherMap()
+	connector := NewServerConnectionActor(cfg)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	require.NoError(t, connector.StartIngress(ctx))
+	defer connector.StopIngress()
+
+	sendRoutedErrorResponseToMailbox(
+		t, mb, "client-1", "corr-routed", "test.Svc", "Unary",
+		status.Error(codes.Internal, "boom"),
+	)
+
+	select {
+	case msg := <-behavior.received:
+		require.Contains(t, msg.SessionID, "boom")
+
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for routed error response dispatch")
+	}
+}
+
 func TestIngress_ResponseDispatchWithoutWaiter(t *testing.T) {
 	t.Parallel()
 

--- a/serverconn/event_router.go
+++ b/serverconn/event_router.go
@@ -176,22 +176,32 @@ func AddEnvelopeRoute[M actor.Message, R any](r *EventRouter,
 	dispatcher := func(ctx context.Context,
 		env *mailboxpb.Envelope) error {
 
-		if env == nil || env.Body == nil {
-			return fmt.Errorf("nil envelope or body for %s/%s",
+		if env == nil {
+			return fmt.Errorf("nil envelope for %s/%s",
 				cfg.Service, cfg.Method)
 		}
 
-		event := cfg.NewEvent()
-		if event == nil {
-			return fmt.Errorf("nil event prototype for %s/%s",
-				cfg.Service, cfg.Method)
-		}
+		var event proto.Message
+		if env.Body != nil {
+			event = cfg.NewEvent()
+			if event == nil {
+				return fmt.Errorf(
+					"nil event prototype for %s/%s",
+					cfg.Service, cfg.Method,
+				)
+			}
 
-		if err := (proto.UnmarshalOptions{
-			DiscardUnknown: true,
-		}).Unmarshal(env.Body.Value, event); err != nil {
-			return fmt.Errorf("unmarshal %s/%s event: %w",
-				cfg.Service, cfg.Method, err)
+			if err := (proto.UnmarshalOptions{
+				DiscardUnknown: true,
+			}).Unmarshal(
+				env.Body.Value, event,
+			); err != nil {
+				return fmt.Errorf("unmarshal %s/%s event: %w",
+					cfg.Service, cfg.Method, err)
+			}
+		} else if mailboxrpc.DecodeErrorHeaders(env.Headers) == nil {
+			return fmt.Errorf("nil envelope body for %s/%s",
+				cfg.Service, cfg.Method)
 		}
 
 		actorMsg, err := cfg.Adapt(env, event)

--- a/serverconn/event_router.go
+++ b/serverconn/event_router.go
@@ -182,7 +182,18 @@ func AddEnvelopeRoute[M actor.Message, R any](r *EventRouter,
 		}
 
 		var event proto.Message
-		if env.Body != nil {
+		if env.Body == nil {
+			// Header-only unary failures are valid when the server
+			// encodes the gRPC status in the envelope headers.
+			// A nil body without an encoded status is malformed.
+			if mailboxrpc.DecodeErrorHeaders(env.Headers) == nil {
+				return fmt.Errorf(
+					"nil envelope body without encoded "+
+						"error for %s/%s",
+					cfg.Service, cfg.Method,
+				)
+			}
+		} else {
 			event = cfg.NewEvent()
 			if event == nil {
 				return fmt.Errorf(
@@ -199,9 +210,6 @@ func AddEnvelopeRoute[M actor.Message, R any](r *EventRouter,
 				return fmt.Errorf("unmarshal %s/%s event: %w",
 					cfg.Service, cfg.Method, err)
 			}
-		} else if mailboxrpc.DecodeErrorHeaders(env.Headers) == nil {
-			return fmt.Errorf("nil envelope body for %s/%s",
-				cfg.Service, cfg.Method)
 		}
 
 		actorMsg, err := cfg.Adapt(env, event)

--- a/serverconn/event_router_test.go
+++ b/serverconn/event_router_test.go
@@ -1,0 +1,65 @@
+package serverconn
+
+import (
+	"testing"
+
+	"github.com/lightninglabs/darepo-client/baselib/actor"
+	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
+	mailboxrpc "github.com/lightninglabs/darepo-client/mailbox/rpc"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+// TestAddEnvelopeRoute_RejectsNilBodyWithoutEncodedError verifies that
+// AddEnvelopeRoute still fails closed on malformed routed responses that
+// omit both the proto body and the encoded gRPC status headers.
+func TestAddEnvelopeRoute_RejectsNilBodyWithoutEncodedError(
+	t *testing.T,
+) {
+
+	t.Parallel()
+
+	router := NewEventRouter(actor.NewActorSystem())
+	routeKey := actor.NewServiceKey[*helloStartedMsg, struct{}](
+		"test-route",
+	)
+
+	adaptCalled := false
+
+	AddEnvelopeRoute(
+		router, EnvelopeRouteConfig[*helloStartedMsg, struct{}]{
+			Service: "test.Svc",
+			Method:  "Unary",
+			NewEvent: func() proto.Message {
+				return &wrapperspb.StringValue{}
+			},
+			Key: routeKey,
+			Adapt: func(_ *mailboxpb.Envelope,
+				_ proto.Message) (*helloStartedMsg, error) {
+
+				adaptCalled = true
+
+				return &helloStartedMsg{}, nil
+			},
+		},
+	)
+
+	dispatcher := router.AsDispatcherMap()[mailboxrpc.ServiceMethod{
+		Service: "test.Svc",
+		Method:  "Unary",
+	}]
+
+	err := dispatcher(t.Context(), &mailboxpb.Envelope{
+		Rpc: &mailboxpb.RpcMeta{
+			Kind:          mailboxpb.RpcMeta_KIND_RESPONSE,
+			CorrelationId: "corr-1",
+			Service:       "test.Svc",
+			Method:        "Unary",
+		},
+	})
+	require.ErrorContains(
+		t, err, "nil envelope body without encoded error",
+	)
+	require.False(t, adaptCalled)
+}


### PR DESCRIPTION
## Summary
- allow routed KIND_RESPONSE envelopes with nil body when gRPC error headers are present
- keep rejecting malformed envelopes with nil body and no encoded error
- add ingress coverage for routed header-only error responses reaching EventRouter adapters

## Why
OOR receive metadata queries can return mailbox-routed unary failures encoded in headers only. Dropping those envelopes prevented the receive FSM from getting deterministic fail events.

## Testing
- go test ./serverconn -run "TestIngress_ResponseDispatch(HeaderOnlyError|WithoutWaiter)" -count=1