### PR TITLE
darepod: add integration harness prerequisites

### DIFF
--- a/darepod/config.go
+++ b/darepod/config.go
@@ -2,6 +2,7 @@ package darepod
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"time"
@@ -84,6 +85,10 @@ type Config struct {
 	// the list (without a '=') sets the default for unlisted subsystems.
 	// Valid levels: trace, debug, info, warn, error, critical, off.
 	DebugLevel string `mapstructure:"debuglevel"`
+
+	// LogWriter is the sink for daemon log output. When nil, darepod
+	// writes logs to stdout.
+	LogWriter io.Writer
 
 	// Lnd configures the connection to the backing lnd node.
 	Lnd *LndConfig `mapstructure:"lnd"`

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -181,6 +181,9 @@ type Server struct {
 
 	serverConn *grpc.ClientConn
 
+	rpcAddrMu sync.RWMutex
+	rpcAddr   net.Addr
+
 	grpcServer *grpc.Server
 	rpcServer  *RPCServer
 	mailboxMux *mailboxrpc.ServeMux
@@ -217,6 +220,15 @@ func (s *Server) markWalletReady() {
 	s.walletReadyOnce.Do(func() {
 		close(s.walletReady)
 	})
+}
+
+// RPCAddr returns the bound daemon gRPC listener address once startup has
+// progressed far enough to create the listener.
+func (s *Server) RPCAddr() net.Addr {
+	s.rpcAddrMu.RLock()
+	defer s.rpcAddrMu.RUnlock()
+
+	return s.rpcAddr
 }
 
 // RunUntilShutdown starts all subsystems and blocks until the shutdown
@@ -448,9 +460,13 @@ func (s *Server) run(ctx context.Context,
 			s.cfg.RPC.ListenAddr, err)
 	}
 
+	s.rpcAddrMu.Lock()
+	s.rpcAddr = lis.Addr()
+	s.rpcAddrMu.Unlock()
+
 	go func() {
 		log.InfoS(ctx, "gRPC server listening",
-			slog.String("addr", s.cfg.RPC.ListenAddr))
+			slog.String("addr", lis.Addr().String()))
 
 		if err := s.grpcServer.Serve(lis); err != nil {
 			log.ErrorS(ctx, "gRPC server error", err)

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -270,7 +270,12 @@ func (s *Server) run(ctx context.Context,
 	// -------------------------------------------------------
 	// Create a log handler writing to stdout. The SubLoggerManager
 	// manages per-subsystem loggers and supports runtime level changes.
-	logHandler := btclog.NewDefaultHandler(os.Stdout)
+	logWriter := s.cfg.LogWriter
+	if logWriter == nil {
+		logWriter = os.Stdout
+	}
+
+	logHandler := btclog.NewDefaultHandler(logWriter)
 	s.logManager = lndbuild.NewSubLoggerManager(logHandler)
 
 	// Register all package-level loggers with the manager. This

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -84,6 +84,15 @@ const (
 	// events pushed by the server indexer.
 	arkServiceName = "arkrpc.ArkService"
 
+	// indexerProofServerID is the operator identifier currently used by
+	// the daemon indexer service when verifying taproot proof messages.
+	//
+	// This is intentionally decoupled from mailbox transport IDs:
+	// remote mailbox IDs can be per-client routing endpoints (for
+	// auto-registration), while proof server ID is a logical operator
+	// identity shared by all clients.
+	indexerProofServerID = "arkd"
+
 	// MethodIncomingOOR is the routing method name for incoming
 	// OOR transfer notifications pushed by the server indexer.
 	MethodIncomingOOR = "IncomingOOR"
@@ -1657,7 +1666,7 @@ func (s *Server) initRPCClients(ctx context.Context) {
 
 	s.indexer = indexer.New(
 		s.runtime.Unary(), signer,
-		s.cfg.Server.RemoteMailboxID,
+		indexerProofServerID,
 		s.cfg.Server.LocalMailboxID,
 	)
 

--- a/lndbackend/client_wallet.go
+++ b/lndbackend/client_wallet.go
@@ -172,22 +172,9 @@ func (c *ClientWallet) MuSig2CreateSession(
 		slog.Int("num_other_nonces", len(otherNonces)),
 		slog.Bool("has_local_nonces", localNonces != nil))
 
-	// Convert pubkeys to serialized form for lndclient. The
-	// remote signer expects either 33-byte compressed keys
-	// (MuSig2Version040) or 32-byte x-only keys
-	// (MuSig2Version100RC2+). lndclient passes the bytes
-	// through to lnd as-is, so we must match the format to
-	// the version.
-	signerBytes := make([][]byte, len(allSignerPubkeys))
-	for i, pk := range allSignerPubkeys {
-		switch version {
-		case input.MuSig2Version100RC2:
-			signerBytes[i] = schnorr.SerializePubKey(pk)
-
-		default:
-			signerBytes[i] = pk.SerializeCompressed()
-		}
-	}
+	signerBytes := serializeMuSig2SignerPubKeys(
+		version, allSignerPubkeys,
+	)
 
 	var opts []lndclient.MuSig2SessionOpts
 
@@ -229,6 +216,26 @@ func (c *ClientWallet) MuSig2CreateSession(
 		slog.Int("num_signers", len(allSignerPubkeys)))
 
 	return sessionInfo, nil
+}
+
+// serializeMuSig2SignerPubKeys matches lnd's RPC expectations for each
+// MuSig2 draft version. v0.4.0 uses x-only keys while v1.0.0rc2 uses
+// compressed public keys.
+func serializeMuSig2SignerPubKeys(version input.MuSig2Version,
+	allSignerPubkeys []*btcec.PublicKey) [][]byte {
+
+	signerBytes := make([][]byte, len(allSignerPubkeys))
+	for i, pk := range allSignerPubkeys {
+		switch version {
+		case input.MuSig2Version040:
+			signerBytes[i] = schnorr.SerializePubKey(pk)
+
+		default:
+			signerBytes[i] = pk.SerializeCompressed()
+		}
+	}
+
+	return signerBytes
 }
 
 // MuSig2RegisterNonces registers additional public nonces for a

--- a/lndbackend/client_wallet_test.go
+++ b/lndbackend/client_wallet_test.go
@@ -1,0 +1,44 @@
+package lndbackend
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSerializeMuSig2SignerPubKeys(t *testing.T) {
+	t.Parallel()
+
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	pubKey := privKey.PubKey()
+	signers := []*btcec.PublicKey{pubKey}
+
+	t.Run("v040 uses x-only keys", func(t *testing.T) {
+		t.Parallel()
+
+		got := serializeMuSig2SignerPubKeys(
+			input.MuSig2Version040, signers,
+		)
+
+		require.Len(t, got, 1)
+		require.Len(t, got[0], schnorr.PubKeyBytesLen)
+		require.Equal(t, schnorr.SerializePubKey(pubKey), got[0])
+	})
+
+	t.Run("v100rc2 uses compressed keys", func(t *testing.T) {
+		t.Parallel()
+
+		got := serializeMuSig2SignerPubKeys(
+			input.MuSig2Version100RC2, signers,
+		)
+
+		require.Len(t, got, 1)
+		require.Len(t, got[0], btcec.PubKeyBytesLenCompressed)
+		require.Equal(t, pubKey.SerializeCompressed(), got[0])
+	})
+}


### PR DESCRIPTION
## Summary\n- add configurable daemon log writer output selection\n- fix MuSig2 signer key serialization for v1.0.0rc2 in the lnd backend\n- decouple indexer proof server ID from mailbox routing IDs\n- expose the bound RPC listen address for in-process harness discovery\n\n## Why\nThese commits are prerequisites for reliable real-daemon integration tests and should land separately from the routed header-only error envelope fix.\n\n## Testing\n- go test ./darepod/...\n- go test ./lndbackend/...\n