### PR TITLE
actortest: force outbox publish in delivery poll loops

### DIFF
--- a/internal/actortest/e2e_test.go
+++ b/internal/actortest/e2e_test.go
@@ -393,9 +393,14 @@ func TestOutboxPublisher_DeliversToTarget(t *testing.T) {
 	})
 
 	// Wait for target to receive the increment via OutboxPublisher.
-	eventually(t, 5*time.Second, func() bool {
-		return targetBehavior.Count() == 25
-	})
+	// Use eventuallyWithOutboxPublish to force publish attempts on each
+	// poll iteration, avoiding flakiness when the ticker is delayed under
+	// heavy CI or race-detector load.
+	eventuallyWithOutboxPublish(
+		t, publisher, 5*time.Second, func() bool {
+			return targetBehavior.Count() == 25
+		},
+	)
 
 	require.Equal(t, int64(25), targetBehavior.Count())
 }
@@ -459,15 +464,20 @@ func TestOutboxPublisher_MultiHopForwarding(t *testing.T) {
 		return behaviorA.ForwardCount() == 1
 	})
 
-	// Wait for B to process (receives forward, writes to outbox).
-	eventually(t, 5*time.Second, func() bool {
-		return behaviorB.ForwardCount() == 1
-	})
+	// Wait for B to process (receives forward, writes to outbox). Force
+	// publish attempts to avoid flakiness under race-detector or CI load.
+	eventuallyWithOutboxPublish(
+		t, publisher, 5*time.Second, func() bool {
+			return behaviorB.ForwardCount() == 1
+		},
+	)
 
 	// Wait for C to receive the increment.
-	eventually(t, 5*time.Second, func() bool {
-		return behaviorC.Count() == 100
-	})
+	eventuallyWithOutboxPublish(
+		t, publisher, 5*time.Second, func() bool {
+			return behaviorC.Count() == 100
+		},
+	)
 
 	require.Equal(t, int64(100), behaviorC.Count())
 }
@@ -762,10 +772,13 @@ func TestProperty_OutboxEventuallyDelivers(t *testing.T) {
 		return sourceBehavior.ForwardCount() == 1
 	})
 
-	// Wait for target to receive.
-	eventually(t, 5*time.Second, func() bool {
-		return targetBehavior.Count() == amount
-	})
+	// Wait for target to receive. Force publish attempts on each poll
+	// iteration to avoid flakiness under race-detector or CI load.
+	eventuallyWithOutboxPublish(
+		t, publisher, 5*time.Second, func() bool {
+			return targetBehavior.Count() == amount
+		},
+	)
 
 	require.Equal(t, amount, targetBehavior.Count())
 }


### PR DESCRIPTION
Three outbox-delivery e2e tests (`TestOutboxPublisher_DeliversToTarget`,
`TestOutboxPublisher_MultiHopForwarding`,
`TestProperty_OutboxEventuallyDelivers`) relied solely on the
`OutboxPublisher`'s internal ticker to deliver pending messages during
their `eventually` polling loops. Under heavy CI scheduler pressure or
the race detector, the ticker can be delayed long enough to trip the
timeout and cause a flake.

This commit switches the delivery-wait assertions to use
`eventuallyWithOutboxPublish`, which calls `PublishPending()` on every
poll iteration. This is the same pattern the `DurableAsk` tests already
use, making delivery deterministic regardless of goroutine scheduling
jitter.

Verified with `go test -race -count=50` (150 total runs across the
three tests) — zero failures, zero data races.