### PR TITLE
wallet+round: mark consumed boarding intents adopted at checkpoint

### DIFF
--- a/db/boarding_wallet.go
+++ b/db/boarding_wallet.go
@@ -33,6 +33,8 @@ type IntentHeightFilter = sqlc.ListBoardingIntentsByStatusAndMinHeightParams
 
 // BoardingStore is the interface that groups all boarding-related database
 // queries. This is a subset of sqlc.Querier focused on boarding operations.
+//
+//nolint:interfacebloat
 type BoardingStore interface {
 	InsertBoardingAddress(ctx context.Context, arg NewAddrParams) error
 
@@ -61,6 +63,10 @@ type BoardingStore interface {
 	ListBoardingIntentsByStatusAndMinHeight(
 		ctx context.Context, arg IntentHeightFilter,
 	) ([]BoardingIntentRow, error)
+
+	UpdateBoardingIntentStatus(
+		ctx context.Context, arg sqlc.UpdateBoardingIntentStatusParams,
+	) error
 }
 
 // BatchedBoardingStore combines BoardingStore with transaction support via the
@@ -418,6 +424,94 @@ func (b *BoardingWalletStore) GetIntent(ctx context.Context,
 	})
 
 	return result, err
+}
+
+// MarkBoardingIntentsAdopted marks the provided boarding intent outpoints as
+// adopted in a single transaction. This operation validates expected state and
+// fails fast if any outpoint is missing or already in an unexpected terminal
+// state.
+func (b *BoardingWalletStore) MarkBoardingIntentsAdopted(ctx context.Context,
+	outpoints []wire.OutPoint) (int, error) {
+
+	if len(outpoints) == 0 {
+		return 0, nil
+	}
+
+	adoptedStatus, err := statusToString(wallet.BoardingStatusAdopted)
+	if err != nil {
+		return 0, fmt.Errorf("status to string: %w", err)
+	}
+	nowUnix := b.clock.Now().Unix()
+
+	updated := 0
+	seen := make(map[wire.OutPoint]struct{}, len(outpoints))
+	writeTxOpts := WriteTxOption()
+	err = b.db.ExecTx(ctx, writeTxOpts, func(q BoardingStore) error {
+		for _, outpoint := range outpoints {
+			if _, ok := seen[outpoint]; ok {
+				continue
+			}
+			seen[outpoint] = struct{}{}
+
+			key := BoardingIntentKey{
+				OutpointHash:  outpoint.Hash[:],
+				OutpointIndex: int32(outpoint.Index),
+			}
+			dbIntent, err := q.GetBoardingIntent(ctx, key)
+			if err != nil {
+				return fmt.Errorf(
+					"get boarding intent %s: %w",
+					outpoint.String(), err,
+				)
+			}
+
+			currentStatus, err := stringToStatus(dbIntent.Status)
+			if err != nil {
+				return fmt.Errorf(
+					"parse boarding intent status %q "+
+						"for %s: %w",
+					dbIntent.Status,
+					outpoint.String(), err,
+				)
+			}
+
+			switch currentStatus {
+			case wallet.BoardingStatusAdopted:
+				continue
+
+			case wallet.BoardingStatusConfirmed:
+				update := sqlc.UpdateBoardingIntentStatusParams{
+					OutpointHash:   outpoint.Hash[:],
+					OutpointIndex:  int32(outpoint.Index),
+					Status:         adoptedStatus,
+					LastUpdateTime: nowUnix,
+				}
+				err = q.UpdateBoardingIntentStatus(ctx, update)
+				if err != nil {
+					return fmt.Errorf(
+						"mark boarding intent %s "+
+							"adopted: %w",
+						outpoint.String(), err,
+					)
+				}
+				updated++
+
+			default:
+				return fmt.Errorf(
+					"unexpected boarding intent state "+
+						"for %s: %s",
+					outpoint.String(), dbIntent.Status,
+				)
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	return updated, nil
 }
 
 // LookupIntentByScript returns the stored intent associated with a boarding

--- a/db/boarding_wallet_test.go
+++ b/db/boarding_wallet_test.go
@@ -277,6 +277,110 @@ func TestBoardingIntentLifecycle(t *testing.T) {
 	require.Equal(t, wallet.BoardingStatusAdopted, retrievedIntent.Status)
 }
 
+// TestMarkBoardingIntentsAdopted verifies batch adoption updates execute
+// atomically and only transition expected statuses.
+func TestMarkBoardingIntentsAdopted(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store, _ := newBoardingStoreForTest(t)
+
+	boardingAddr, _ := createTestBoardingAddress(t, 7)
+	err := store.InsertBoardingAddress(ctx, boardingAddr)
+	require.NoError(t, err)
+
+	outpointA := wire.OutPoint{
+		Hash:  chainhash.Hash{0x10},
+		Index: 0,
+	}
+	outpointB := wire.OutPoint{
+		Hash:  chainhash.Hash{0x11},
+		Index: 1,
+	}
+
+	intents := []wallet.BoardingIntent{
+		{
+			Address:  *boardingAddr,
+			Outpoint: outpointA,
+			ChainInfo: wallet.BoardingChainInfo{
+				ConfHeight: 200,
+				ConfHash:   chainhash.Hash{0x21},
+				OutPoint:   outpointA,
+				Amount:     10000,
+			},
+			Status: wallet.BoardingStatusConfirmed,
+		},
+		{
+			Address:  *boardingAddr,
+			Outpoint: outpointB,
+			ChainInfo: wallet.BoardingChainInfo{
+				ConfHeight: 201,
+				ConfHash:   chainhash.Hash{0x22},
+				OutPoint:   outpointB,
+				Amount:     20000,
+			},
+			Status: wallet.BoardingStatusAdopted,
+		},
+	}
+	err = store.InsertBoardingIntents(ctx, intents...)
+	require.NoError(t, err)
+
+	updated, err := store.MarkBoardingIntentsAdopted(ctx, []wire.OutPoint{
+		outpointA, outpointB, outpointA,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, updated)
+
+	adoptedIntents, err := store.FetchBoardingIntentsByStatus(
+		ctx, wallet.BoardingStatusAdopted,
+	)
+	require.NoError(t, err)
+	require.Len(t, adoptedIntents, 2)
+
+	confirmedIntents, err := store.FetchBoardingIntentsByStatus(
+		ctx, wallet.BoardingStatusConfirmed,
+	)
+	require.NoError(t, err)
+	require.Len(t, confirmedIntents, 0)
+}
+
+// TestMarkBoardingIntentsAdoptedUnexpectedState verifies the store rejects
+// invalid transitions instead of silently mutating terminal states.
+func TestMarkBoardingIntentsAdoptedUnexpectedState(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store, _ := newBoardingStoreForTest(t)
+
+	boardingAddr, _ := createTestBoardingAddress(t, 8)
+	err := store.InsertBoardingAddress(ctx, boardingAddr)
+	require.NoError(t, err)
+
+	outpoint := wire.OutPoint{
+		Hash:  chainhash.Hash{0x30},
+		Index: 0,
+	}
+	intent := wallet.BoardingIntent{
+		Address:  *boardingAddr,
+		Outpoint: outpoint,
+		ChainInfo: wallet.BoardingChainInfo{
+			ConfHeight: 300,
+			ConfHash:   chainhash.Hash{0x31},
+			OutPoint:   outpoint,
+			Amount:     50000,
+		},
+		Status: wallet.BoardingStatusSwept,
+	}
+	err = store.InsertBoardingIntents(ctx, intent)
+	require.NoError(t, err)
+
+	_, err = store.MarkBoardingIntentsAdopted(
+		ctx, []wire.OutPoint{outpoint},
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unexpected boarding intent state")
+}
+
 // TestFetchBoardingIntentsByStatus tests filtering intents by status.
 func TestFetchBoardingIntentsByStatus(t *testing.T) {
 	t.Parallel()

--- a/round/actor.go
+++ b/round/actor.go
@@ -1518,6 +1518,16 @@ func (a *RoundClientActor) processOutbox(ctx context.Context,
 					"InputSigSentState, got %T", state)
 			}
 
+			err = a.markBoardingIntentsAdopted(
+				ctx, inputSigState.Intents.Boarding,
+			)
+			if err != nil {
+				return fmt.Errorf(
+					"mark checkpointed boarding intents adopted: %w",
+					err,
+				)
+			}
+
 			// Update round FSM with commitment tx info.
 			txid := inputSigState.CommitmentTx.UnsignedTx.TxHash()
 			roundFSM.TxID = txid
@@ -1624,6 +1634,44 @@ func (a *RoundClientActor) processOutbox(ctx context.Context,
 			)
 		}
 	}
+
+	return nil
+}
+
+// markBoardingIntentsAdopted asks the wallet actor to mark checkpointed
+// boarding intents as adopted so they are no longer counted as spendable
+// confirmed balance.
+func (a *RoundClientActor) markBoardingIntentsAdopted(
+	ctx context.Context, intents []BoardingIntent,
+) error {
+
+	if len(intents) == 0 {
+		return nil
+	}
+
+	outpoints := make([]wire.OutPoint, 0, len(intents))
+	for _, intent := range intents {
+		outpoints = append(outpoints, intent.Outpoint)
+	}
+
+	req := &wallet.MarkBoardingIntentsAdoptedRequest{
+		Outpoints: outpoints,
+	}
+	result := a.cfg.WalletActor.Ask(ctx, req).Await(ctx)
+	if result.IsErr() {
+		return result.Err()
+	}
+
+	resp, _ := result.Unpack()
+	adoptedResp, ok := resp.(*wallet.MarkBoardingIntentsAdoptedResponse)
+	if !ok {
+		return fmt.Errorf(
+			"unexpected wallet response type: %T", resp,
+		)
+	}
+
+	a.log.InfoS(ctx, "Marked checkpointed boarding intents as adopted",
+		slog.Int("count", adoptedResp.UpdatedCount))
 
 	return nil
 }

--- a/round/actor_harness_test.go
+++ b/round/actor_harness_test.go
@@ -3,6 +3,7 @@ package round
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -184,12 +185,17 @@ type mockWalletActorRef struct {
 	// registeredNotifier holds the actor ref provided during registration,
 	// enabling tests to send boarding confirmations.
 	registeredNotifier actor.TellOnlyRef[wallet.BoardingUtxoConfirmedEvent]
+
+	// adoptedOutpoints captures outpoints from
+	// MarkBoardingIntentsAdoptedRequest calls.
+	adoptedOutpoints []wire.OutPoint
 }
 
 func newMockWalletActorRef(t *testing.T) *mockWalletActorRef {
 	return &mockWalletActorRef{
-		t:  t,
-		id: "mock-wallet-actor",
+		t:                t,
+		id:               "mock-wallet-actor",
+		adoptedOutpoints: make([]wire.OutPoint, 0),
 	}
 }
 
@@ -224,7 +230,25 @@ func (m *mockWalletActorRef) Ask(_ context.Context,
 		return newImmediateFuture[wallet.WalletResp](resp)
 	}
 
+	if req, ok := msg.(*wallet.MarkBoardingIntentsAdoptedRequest); ok {
+		m.adoptedOutpoints = append(
+			m.adoptedOutpoints, req.Outpoints...,
+		)
+		resp := &wallet.MarkBoardingIntentsAdoptedResponse{
+			UpdatedCount: len(req.Outpoints),
+		}
+
+		return newImmediateFuture[wallet.WalletResp](resp)
+	}
+
 	return newImmediateFuture[wallet.WalletResp](nil)
+}
+
+func (m *mockWalletActorRef) adoptedRequests() []wire.OutPoint {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return append([]wire.OutPoint(nil), m.adoptedOutpoints...)
 }
 
 // sendBoardingConfirmation simulates a boarding UTXO confirmation from wallet.
@@ -895,6 +919,16 @@ func (h *actorTestHarness) setupRoundInInputSigSentState(
 	roundID RoundID,
 ) *psbt.Packet {
 
+	return h.setupRoundInInputSigSentStateWithIntents(roundID, nil)
+}
+
+// setupRoundInInputSigSentStateWithIntents creates a round FSM in
+// InputSigSentState with the given boarding intents and adds it to the actor's
+// rounds map.
+func (h *actorTestHarness) setupRoundInInputSigSentStateWithIntents(
+	roundID RoundID, intents []BoardingIntent,
+) *psbt.Packet {
+
 	h.t.Helper()
 
 	// Create a unique commitment tx for this round.
@@ -911,6 +945,9 @@ func (h *actorTestHarness) setupRoundInInputSigSentState(
 	initialState := &InputSigSentState{
 		RoundID:      roundID,
 		CommitmentTx: packet,
+		Intents: Intents{
+			Boarding: slices.Clone(intents),
+		},
 	}
 
 	// Create a new FSM starting in InputSigSentState.

--- a/round/actor_test.go
+++ b/round/actor_test.go
@@ -617,10 +617,16 @@ func TestActorProcessOutbox(t *testing.T) {
 		require.Empty(t, h.actor.rounds)
 
 		roundID := testRoundID("checkpointed-round")
+		boardingIntent := h.newTestBoardingIntent()
+		roundIntent := BoardingIntent{
+			BoardingIntent: *boardingIntent,
+		}
 
 		// Set up a round in InputSigSentState, simulating the state
 		// after the round has completed through partial sigs.
-		commitmentTx := h.setupRoundInInputSigSentState(roundID)
+		commitmentTx := h.setupRoundInInputSigSentStateWithIntents(
+			roundID, []BoardingIntent{roundIntent},
+		)
 
 		outbox := []ClientOutMsg{
 			&RoundCheckpointedNotification{
@@ -640,6 +646,10 @@ func TestActorProcessOutbox(t *testing.T) {
 		indexedKeyStr, exists := h.actor.commitmentTxIndex[txid]
 		require.True(t, exists)
 		require.Equal(t, keyStr, indexedKeyStr)
+
+		adopted := h.walletActor.adoptedRequests()
+		require.Len(t, adopted, 1)
+		require.Equal(t, boardingIntent.Outpoint, adopted[0])
 	})
 
 	t.Run("new_boarding_creates_round", func(t *testing.T) {

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -1180,7 +1180,10 @@ func (s *ForfeitSignaturesCollectingState) ProcessEvent(
 		return &ClientStateTransition{
 			NextState: nextState,
 			NewEvents: fn.Some(ClientEmittedEvent{
-				Outbox: append(outboxMsgs, checkpointNotify),
+				Outbox: append(
+					[]ClientOutMsg{checkpointNotify},
+					outboxMsgs...,
+				),
 			}),
 		}, nil
 
@@ -1534,7 +1537,10 @@ func (s *PartialSigsSentState) ProcessEvent(
 		return &ClientStateTransition{
 			NextState: nextState,
 			NewEvents: fn.Some(ClientEmittedEvent{
-				Outbox: append(outboxMsgs, checkpointNotify),
+				Outbox: append(
+					[]ClientOutMsg{checkpointNotify},
+					outboxMsgs...,
+				),
 			}),
 		}, nil
 

--- a/wallet/interfaces.go
+++ b/wallet/interfaces.go
@@ -305,6 +305,8 @@ type BoardingIntent struct {
 
 // BoardingStore defines the storage interface for boarding addresses and
 // intents used by the wallet actor.
+//
+//nolint:interfacebloat
 type BoardingStore interface {
 	// InsertBoardingAddress persists a boarding address when it is first
 	// created. This method is idempotent.
@@ -351,6 +353,12 @@ type BoardingStore interface {
 	// GetIntent retrieves a boarding intent by its outpoint (primary key).
 	GetIntent(ctx context.Context,
 		outpoint wire.OutPoint) (*BoardingIntent, error)
+
+	// MarkBoardingIntentsAdopted marks the provided outpoints as adopted in
+	// a single atomic store operation. Implementations should validate that
+	// intents are in an expected pre-adoption state.
+	MarkBoardingIntentsAdopted(ctx context.Context,
+		outpoints []wire.OutPoint) (int, error)
 
 	// LookupIntentByScript returns the stored intent associated with a
 	// boarding pkScript.

--- a/wallet/messages.go
+++ b/wallet/messages.go
@@ -429,6 +429,41 @@ func (m *CompleteSpendVTXOsResponse) MessageType() string {
 // walletRespSealed implements the sealed WalletResp interface.
 func (m *CompleteSpendVTXOsResponse) walletRespSealed() {}
 
+// MarkBoardingIntentsAdoptedRequest asks the wallet actor to transition the
+// specified boarding intents from Confirmed to Adopted status after a round is
+// checkpointed at point-of-no-return.
+type MarkBoardingIntentsAdoptedRequest struct {
+	actor.BaseMessage
+
+	// Outpoints identifies boarding intents that were consumed by a
+	// checkpointed round and should no longer be counted as spendable.
+	Outpoints []wire.OutPoint
+}
+
+// MessageType returns the message type identifier for logging and debugging.
+func (m *MarkBoardingIntentsAdoptedRequest) MessageType() string {
+	return "MarkBoardingIntentsAdoptedRequest"
+}
+
+// walletMsgSealed implements the sealed WalletMsg interface.
+func (m *MarkBoardingIntentsAdoptedRequest) walletMsgSealed() {}
+
+// MarkBoardingIntentsAdoptedResponse confirms how many intents were updated.
+type MarkBoardingIntentsAdoptedResponse struct {
+	actor.BaseMessage
+
+	// UpdatedCount is the number of boarding intents updated to Adopted.
+	UpdatedCount int
+}
+
+// MessageType returns the message type identifier for logging and debugging.
+func (m *MarkBoardingIntentsAdoptedResponse) MessageType() string {
+	return "MarkBoardingIntentsAdoptedResponse"
+}
+
+// walletRespSealed implements the sealed WalletResp interface.
+func (m *MarkBoardingIntentsAdoptedResponse) walletRespSealed() {}
+
 // LeaveVTXOsRequest triggers leave (offboard) of specified VTXOs. The VTXOs
 // will be forfeited and their value sent to the specified destination output.
 type LeaveVTXOsRequest struct {

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -314,6 +314,9 @@ func (a *Ark) Receive(ctx context.Context,
 	case *CompleteSpendVTXOsRequest:
 		return a.handleCompleteSpendVTXOs(ctx, m)
 
+	case *MarkBoardingIntentsAdoptedRequest:
+		return a.handleMarkBoardingIntentsAdopted(ctx, m)
+
 	default:
 		return fn.Err[WalletResp](
 			fmt.Errorf("unknown message type: %T", msg))
@@ -1046,6 +1049,29 @@ func (a *Ark) handleBoard(ctx context.Context,
 	}
 
 	return fn.Ok[WalletResp](resp)
+}
+
+// handleMarkBoardingIntentsAdopted marks the given boarding intents as
+// adopted. This is invoked by the round actor after checkpointing a round so
+// consumed boarding intents are no longer counted as spendable.
+func (a *Ark) handleMarkBoardingIntentsAdopted(ctx context.Context,
+	req *MarkBoardingIntentsAdoptedRequest) fn.Result[WalletResp] {
+
+	updated, err := a.store.MarkBoardingIntentsAdopted(
+		ctx, req.Outpoints,
+	)
+	if err != nil {
+		return fn.Err[WalletResp](fmt.Errorf(
+			"persist adopted boarding intents: %w", err,
+		))
+	}
+
+	a.logger(ctx).InfoS(ctx, "Marked boarding intents as adopted",
+		slog.Int("count", updated))
+
+	return fn.Ok[WalletResp](&MarkBoardingIntentsAdoptedResponse{
+		UpdatedCount: updated,
+	})
 }
 
 // buildBoardingTxProof fetches the confirmation block and computes a merkle

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -2,6 +2,7 @@ package wallet
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -195,6 +196,14 @@ func (m *MockBoardingStore) GetIntent(ctx context.Context,
 
 	//nolint:forcetypeassert
 	return args.Get(0).(*BoardingIntent), args.Error(1)
+}
+
+func (m *MockBoardingStore) MarkBoardingIntentsAdopted(
+	ctx context.Context, outpoints []wire.OutPoint,
+) (int, error) {
+
+	args := m.Called(ctx, outpoints)
+	return args.Int(0), args.Error(1)
 }
 
 func (m *MockBoardingStore) LookupIntentByScript(ctx context.Context,
@@ -1020,6 +1029,93 @@ func TestGetBoardingBalance(t *testing.T) {
 	// With no intents, balance should be zero.
 	require.Equal(t, btcutil.Amount(0), resp.TotalBalance)
 	require.Equal(t, 0, resp.UtxoCount)
+
+	store.AssertExpectations(t)
+}
+
+// TestMarkBoardingIntentsAdopted verifies that checkpoint notifications from
+// the round actor transition consumed boarding intents out of Confirmed status.
+func TestMarkBoardingIntentsAdopted(t *testing.T) {
+	t.Parallel()
+
+	backend := &MockBoardingBackend{}
+	store := &MockBoardingStore{}
+	epochChan := make(chan chainsource.BlockEpoch, 1)
+	chainSource := newMockChainSourceActor(epochChan)
+
+	walletActor := NewArk(
+		backend, store, nil, chainSource, nil,
+		btclog.Disabled,
+	)
+
+	outpointA := wire.OutPoint{
+		Hash:  chainhash.Hash{0x01},
+		Index: 0,
+	}
+	outpointB := wire.OutPoint{
+		Hash:  chainhash.Hash{0x02},
+		Index: 1,
+	}
+
+	store.On(
+		"MarkBoardingIntentsAdopted", mock.Anything,
+		mock.MatchedBy(func(outpoints []wire.OutPoint) bool {
+			return len(outpoints) == 3 &&
+				outpoints[0] == outpointA &&
+				outpoints[1] == outpointB &&
+				outpoints[2] == outpointA
+		}),
+	).Return(1, nil).Once()
+
+	req := &MarkBoardingIntentsAdoptedRequest{
+		Outpoints: []wire.OutPoint{
+			outpointA, outpointB, outpointA,
+		},
+	}
+	result := walletActor.Receive(t.Context(), req)
+	require.True(t, result.IsOk())
+
+	respVal, _ := result.Unpack()
+
+	//nolint:forcetypeassert
+	resp := respVal.(*MarkBoardingIntentsAdoptedResponse)
+	require.Equal(t, 1, resp.UpdatedCount)
+
+	store.AssertExpectations(t)
+}
+
+// TestMarkBoardingIntentsAdoptedLookupError verifies that an unknown outpoint
+// fails the request and preserves fail-fast behavior.
+func TestMarkBoardingIntentsAdoptedLookupError(t *testing.T) {
+	t.Parallel()
+
+	backend := &MockBoardingBackend{}
+	store := &MockBoardingStore{}
+	epochChan := make(chan chainsource.BlockEpoch, 1)
+	chainSource := newMockChainSourceActor(epochChan)
+
+	walletActor := NewArk(
+		backend, store, nil, chainSource, nil,
+		btclog.Disabled,
+	)
+
+	outpoint := wire.OutPoint{
+		Hash:  chainhash.Hash{0x03},
+		Index: 0,
+	}
+	store.On(
+		"MarkBoardingIntentsAdopted", mock.Anything,
+		[]wire.OutPoint{outpoint},
+	).Return(0, errors.New("unexpected boarding intent state")).Once()
+
+	req := &MarkBoardingIntentsAdoptedRequest{
+		Outpoints: []wire.OutPoint{outpoint},
+	}
+	result := walletActor.Receive(t.Context(), req)
+	require.True(t, result.IsErr())
+	require.Contains(
+		t, result.Err().Error(), "persist adopted boarding intents",
+	)
 
 	store.AssertExpectations(t)
 }


### PR DESCRIPTION
## Summary

This PR fixes a multi-round boarding accounting bug where consumed boarding
intents could remain visible as `confirmed`, causing a later board request to
overcount spendable boarding balance.

The fix now applies the adoption transition through the wallet actor at round
checkpoint time, so boarding intent lifecycle ownership remains in the wallet
layer while still updating promptly once the checkpoint is durable.

## Changes

- Add a wallet actor message pair for checkpoint-time adoption updates.
- Add `MarkBoardingIntentsAdopted` to the wallet store interface.
- Implement `MarkBoardingIntentsAdopted` in the DB store as a single write
  transaction with deduplication and expected-state validation.
- Keep round persistence focused on round-owned tables (remove wallet-table
  status mutation from round store commit logic).
- Have the round actor issue the wallet adoption request during checkpoint
  handling.
- Add coverage in `db`, `wallet`, and `round` tests for transition behavior,
  invariants, and checkpoint propagation.

## Validation

- `go test ./... -count=1`
- `./tools/custom-gcl run --timeout=10m ./wallet ./round ./db`
