### PR TITLE
darepod: shutdown actors before chain backend and DB close

### DIFF
--- a/darepod/server.go
+++ b/darepod/server.go
@@ -370,6 +370,19 @@ func (s *Server) run(ctx context.Context,
 	// 3. Initialize the actor system.
 	// -------------------------------------------------------
 	s.actorSystem = actor.NewActorSystem()
+	// Register cleanup from least dependent to most dependent so that the
+	// defer LIFO order tears down components from most dependent to least
+	// dependent: actor system -> chain backend -> DB.
+	defer func() {
+		if s.db != nil {
+			_ = s.db.Close()
+		}
+	}()
+	defer func() {
+		if s.chainBackend != nil {
+			_ = s.chainBackend.Stop()
+		}
+	}()
 	defer func() {
 		shutdownCtx, shutdownCancel := context.WithTimeout(
 			context.Background(), DefaultShutdownTimeout,
@@ -377,6 +390,11 @@ func (s *Server) run(ctx context.Context,
 		defer shutdownCancel()
 
 		_ = s.actorSystem.Shutdown(shutdownCtx)
+	}()
+	defer func() {
+		if s.oorActor != nil {
+			s.oorActor.Stop()
+		}
 	}()
 
 	log.InfoS(ctx, "Actor system initialized")
@@ -395,9 +413,6 @@ func (s *Server) run(ctx context.Context,
 	if err := s.initChainBackend(ctx); err != nil {
 		return err
 	}
-	defer func() {
-		_ = s.chainBackend.Stop()
-	}()
 
 	chainActor := chainsource.NewChainSourceActor(
 		chainsource.ChainSourceConfig{
@@ -418,9 +433,6 @@ func (s *Server) run(ctx context.Context,
 	if err := s.initDatabase(ctx); err != nil {
 		return err
 	}
-	defer func() {
-		_ = s.db.Close()
-	}()
 
 	// Create the VTXO store for RPC queries (ListVTXOs, GetBalance).
 	clk := clock.NewDefaultClock()


### PR DESCRIPTION
## Summary
- fix teardown ordering in `darepod.Server.run` so actor-system shutdown runs before chain-backend stop and DB close
- make cleanup dependency-aware by registering defers in reverse dependency order
- ensure durable actor mailbox loops terminate before backing resources are torn down

## Why
Integration test logs showed repeated mailbox lease warnings during normal shutdown (`sql: database is closed`). The root cause was teardown order: dependent resources could close before actor loops fully exited.

This PR fixes the root cause instead of masking the symptom.

## Testing
- go test ./darepod -count=1
