### PR TITLE
multi: split VTXO descriptors from tree signers

### DIFF
--- a/darepod/server.go
+++ b/darepod/server.go
@@ -1756,7 +1756,7 @@ func (s *Server) initWalletActor(ctx context.Context,
 			Amount:      desc.Amount,
 			PkScript:    desc.PkScript,
 			Expiry:      desc.RelativeExpiry,
-			ClientKey:   desc.ClientKey,
+			OwnerKey:    desc.OwnerKey,
 			OperatorKey: desc.OperatorKey,
 		}, nil
 	})

--- a/darepod/wallet_ops.go
+++ b/darepod/wallet_ops.go
@@ -127,7 +127,7 @@ func BuildTransferInputs(ctx context.Context,
 		// VTXO's own collaborative spend path. This ensures both
 		// parties must sign the Ark tx that spends the checkpoint.
 		collabLeaf, err := scripts.MultiSigCollabTapLeaf(
-			desc.ClientKey.PubKey, desc.OperatorKey,
+			desc.OwnerKey.PubKey, desc.OperatorKey,
 		)
 		if err != nil {
 			return nil, fmt.Errorf(

--- a/db/actordelivery/sqlc/models.go
+++ b/db/actordelivery/sqlc/models.go
@@ -221,6 +221,9 @@ type RoundVtxoRequest struct {
 	PkScript         []byte
 	Expiry           int32
 	ClientPubkey     []byte
+	ClientKeyFamily  int32
+	ClientKeyIndex   int32
+	OwnsClientKey    bool
 	OperatorPubkey   []byte
 	SigningKeyFamily int32
 	SigningKeyIndex  int32

--- a/db/round_store.go
+++ b/db/round_store.go
@@ -1083,8 +1083,8 @@ func vtxoRequestToRoundParams(roundID string, requestIndex int,
 	req *types.VTXORequest) sqlc.InsertRoundVtxoRequestParams {
 
 	var clientPubkey, operatorPubkey, signingPubkey []byte
-	if req.ClientKey != nil {
-		clientPubkey = req.ClientKey.SerializeCompressed()
+	if req.ClientKey.PubKey != nil {
+		clientPubkey = req.ClientKey.PubKey.SerializeCompressed()
 	}
 	if req.OperatorKey != nil {
 		operatorPubkey = req.OperatorKey.SerializeCompressed()
@@ -1100,6 +1100,9 @@ func vtxoRequestToRoundParams(roundID string, requestIndex int,
 		PkScript:         req.PkScript,
 		Expiry:           int32(req.Expiry),
 		ClientPubkey:     clientPubkey,
+		ClientKeyFamily:  int32(req.ClientKey.KeyLocator.Family),
+		ClientKeyIndex:   int32(req.ClientKey.KeyLocator.Index),
+		OwnsClientKey:    req.OwnsClientKey,
 		OperatorPubkey:   operatorPubkey,
 		SigningKeyFamily: int32(req.SigningKey.KeyLocator.Family),
 		SigningKeyIndex:  int32(req.SigningKey.KeyLocator.Index),
@@ -1134,11 +1137,18 @@ func dbVtxoRequestRowToVTXORequest(
 	}
 
 	return &types.VTXORequest{
-		Amount:      btcutil.Amount(t.Amount),
-		PkScript:    t.PkScript,
-		Expiry:      uint32(t.Expiry),
-		ClientKey:   clientKey,
-		OperatorKey: operatorKey,
+		Amount:   btcutil.Amount(t.Amount),
+		PkScript: t.PkScript,
+		Expiry:   uint32(t.Expiry),
+		ClientKey: keychain.KeyDescriptor{
+			PubKey: clientKey,
+			KeyLocator: keychain.KeyLocator{
+				Family: keychain.KeyFamily(t.ClientKeyFamily),
+				Index:  uint32(t.ClientKeyIndex),
+			},
+		},
+		OwnsClientKey: t.OwnsClientKey,
+		OperatorKey:   operatorKey,
 		SigningKey: keychain.KeyDescriptor{
 			PubKey: signingPubkey,
 			KeyLocator: keychain.KeyLocator{

--- a/db/round_store.go
+++ b/db/round_store.go
@@ -942,9 +942,9 @@ func (s *RoundPersistenceStore) reconstructInputSigSentState(
 		return nil, fmt.Errorf("get round vtxo requests: %w", err)
 	}
 
-	vtxos := make([]types.VTXORequest, 0, len(dbVtxoReqs))
+	vtxos := make([]round.RoundVTXORequest, 0, len(dbVtxoReqs))
 	for _, dbReq := range dbVtxoReqs {
-		req, err := dbVtxoRequestRowToVTXORequest(dbReq)
+		req, err := dbVtxoRequestRowToRoundVTXORequest(dbReq)
 		if err != nil {
 			return nil, fmt.Errorf(
 				"convert round vtxo request: %w", err,
@@ -1077,14 +1077,14 @@ func (s *RoundPersistenceStore) domainIntentToRoundParams(
 	}, nil
 }
 
-// vtxoRequestToRoundParams converts a types.VTXORequest to sqlc insert
+// vtxoRequestToRoundParams converts a RoundVTXORequest to sqlc insert
 // parameters for the round_vtxo_requests table.
 func vtxoRequestToRoundParams(roundID string, requestIndex int,
-	req *types.VTXORequest) sqlc.InsertRoundVtxoRequestParams {
+	req *round.RoundVTXORequest) sqlc.InsertRoundVtxoRequestParams {
 
 	var clientPubkey, operatorPubkey, signingPubkey []byte
-	if req.ClientKey.PubKey != nil {
-		clientPubkey = req.ClientKey.PubKey.SerializeCompressed()
+	if req.OwnerKey.PubKey != nil {
+		clientPubkey = req.OwnerKey.PubKey.SerializeCompressed()
 	}
 	if req.OperatorKey != nil {
 		operatorPubkey = req.OperatorKey.SerializeCompressed()
@@ -1100,9 +1100,9 @@ func vtxoRequestToRoundParams(roundID string, requestIndex int,
 		PkScript:         req.PkScript,
 		Expiry:           int32(req.Expiry),
 		ClientPubkey:     clientPubkey,
-		ClientKeyFamily:  int32(req.ClientKey.KeyLocator.Family),
-		ClientKeyIndex:   int32(req.ClientKey.KeyLocator.Index),
-		OwnsClientKey:    req.OwnsClientKey,
+		ClientKeyFamily:  int32(req.OwnerKey.KeyLocator.Family),
+		ClientKeyIndex:   int32(req.OwnerKey.KeyLocator.Index),
+		OwnsClientKey:    req.IsOwner,
 		OperatorPubkey:   operatorPubkey,
 		SigningKeyFamily: int32(req.SigningKey.KeyLocator.Family),
 		SigningKeyIndex:  int32(req.SigningKey.KeyLocator.Index),
@@ -1110,9 +1110,10 @@ func vtxoRequestToRoundParams(roundID string, requestIndex int,
 	}
 }
 
-// dbVtxoRequestRowToVTXORequest converts a database row to a VTXORequest.
-func dbVtxoRequestRowToVTXORequest(
-	t RoundVtxoRequestRow) (*types.VTXORequest, error) {
+// dbVtxoRequestRowToRoundVTXORequest converts a database row to a
+// RoundVTXORequest.
+func dbVtxoRequestRowToRoundVTXORequest(
+	t RoundVtxoRequestRow) (*round.RoundVTXORequest, error) {
 
 	var clientKey, operatorKey, signingPubkey *btcec.PublicKey
 	var err error
@@ -1136,24 +1137,30 @@ func dbVtxoRequestRowToVTXORequest(
 		}
 	}
 
-	return &types.VTXORequest{
-		Amount:   btcutil.Amount(t.Amount),
-		PkScript: t.PkScript,
-		Expiry:   uint32(t.Expiry),
-		ClientKey: keychain.KeyDescriptor{
-			PubKey: clientKey,
-			KeyLocator: keychain.KeyLocator{
-				Family: keychain.KeyFamily(t.ClientKeyFamily),
-				Index:  uint32(t.ClientKeyIndex),
+	return &round.RoundVTXORequest{
+		VTXOIntent: round.VTXOIntent{
+			Amount:   btcutil.Amount(t.Amount),
+			PkScript: t.PkScript,
+			Expiry:   uint32(t.Expiry),
+			OwnerKey: keychain.KeyDescriptor{
+				PubKey: clientKey,
+				KeyLocator: keychain.KeyLocator{
+					Family: keychain.KeyFamily(
+						t.ClientKeyFamily,
+					),
+					Index: uint32(t.ClientKeyIndex),
+				},
 			},
+			IsOwner:     t.OwnsClientKey,
+			OperatorKey: operatorKey,
 		},
-		OwnsClientKey: t.OwnsClientKey,
-		OperatorKey:   operatorKey,
 		SigningKey: keychain.KeyDescriptor{
 			PubKey: signingPubkey,
 			KeyLocator: keychain.KeyLocator{
-				Family: keychain.KeyFamily(t.SigningKeyFamily),
-				Index:  uint32(t.SigningKeyIndex),
+				Family: keychain.KeyFamily(
+					t.SigningKeyFamily,
+				),
+				Index: uint32(t.SigningKeyIndex),
 			},
 		},
 	}, nil
@@ -1188,8 +1195,8 @@ func (s *RoundPersistenceStore) domainVTXOToInsertParams(
 	}
 
 	var clientPubkey []byte
-	if vtxo.ClientKey.PubKey != nil {
-		clientPubkey = vtxo.ClientKey.PubKey.SerializeCompressed()
+	if vtxo.OwnerKey.PubKey != nil {
+		clientPubkey = vtxo.OwnerKey.PubKey.SerializeCompressed()
 	}
 
 	nowUnix := s.clock.Now().Unix()
@@ -1201,8 +1208,8 @@ func (s *RoundPersistenceStore) domainVTXOToInsertParams(
 		Amount:          int64(vtxo.Amount),
 		PkScript:        vtxo.PkScript,
 		Expiry:          int32(vtxo.Expiry),
-		ClientKeyFamily: int32(vtxo.ClientKey.Family),
-		ClientKeyIndex:  int32(vtxo.ClientKey.Index),
+		ClientKeyFamily: int32(vtxo.OwnerKey.Family),
+		ClientKeyIndex:  int32(vtxo.OwnerKey.Index),
 		ClientPubkey:    clientPubkey,
 		OperatorPubkey:  operatorPubkey,
 		TreePath:        treePathBytes,
@@ -1291,7 +1298,7 @@ func (s *RoundPersistenceStore) dbVTXOToDomainVTXO(
 		Amount:   btcutil.Amount(dbVTXO.Amount),
 		PkScript: dbVTXO.PkScript,
 		Expiry:   uint32(dbVTXO.Expiry),
-		ClientKey: keychain.KeyDescriptor{
+		OwnerKey: keychain.KeyDescriptor{
 			PubKey: clientPubkey,
 			KeyLocator: keychain.KeyLocator{
 				Family: keyFamily,

--- a/db/round_store_test.go
+++ b/db/round_store_test.go
@@ -130,7 +130,7 @@ func createTestClientVTXO(
 		Amount:   btcutil.Amount(100000 * (idx + 1)),
 		PkScript: []byte{0x51, 0x20, byte(idx)},
 		Expiry:   144,
-		ClientKey: keychain.KeyDescriptor{
+		OwnerKey: keychain.KeyDescriptor{
 			PubKey: privKey.PubKey(),
 			KeyLocator: keychain.KeyLocator{
 				Family: keychain.KeyFamily(0),
@@ -417,7 +417,7 @@ func TestVTXOStoreSaveAndList(t *testing.T) {
 	// Verify amounts.
 	for _, vtxo := range listedVTXOs {
 		require.NotZero(t, vtxo.Amount)
-		require.NotNil(t, vtxo.ClientKey.PubKey)
+		require.NotNil(t, vtxo.OwnerKey.PubKey)
 		require.NotNil(t, vtxo.OperatorKey)
 	}
 }
@@ -498,7 +498,7 @@ type boardingIntentFixture struct {
 	boardingAddr  *wallet.BoardingAddress
 	walletIntent  wallet.BoardingIntent
 	roundIntent   round.BoardingIntent
-	vtxoTemplates []types.VTXORequest
+	vtxoTemplates []round.RoundVTXORequest
 	outpoint      wire.OutPoint
 	pkScript      []byte
 	inputSig      *types.BoardingInputSignature
@@ -602,20 +602,22 @@ func createBoardingIntentFixture(
 			Index:  uint32(idx * 10),
 		},
 	}
-	vtxoTemplates := []types.VTXORequest{{
-		Amount:   btcutil.Amount(90000),
-		PkScript: pkScript,
-		Expiry:   exitDelay,
-		ClientKey: keychain.KeyDescriptor{
-			PubKey: clientPubKey,
-			KeyLocator: keychain.KeyLocator{
-				Family: types.VTXOOwnerKeyFamily,
-				Index:  uint32(idx * 10),
+	vtxoTemplates := []round.RoundVTXORequest{{
+		VTXOIntent: round.VTXOIntent{
+			Amount:   btcutil.Amount(90000),
+			PkScript: pkScript,
+			Expiry:   exitDelay,
+			OwnerKey: keychain.KeyDescriptor{
+				PubKey: clientPubKey,
+				KeyLocator: keychain.KeyLocator{
+					Family: types.VTXOOwnerKeyFamily,
+					Index:  uint32(idx * 10),
+				},
 			},
+			IsOwner:     true,
+			OperatorKey: operatorPubKey,
 		},
-		OwnsClientKey: true,
-		OperatorKey:   operatorPubKey,
-		SigningKey:    signingKey,
+		SigningKey: signingKey,
 	}}
 
 	boardingRequest := types.BoardingRequest{
@@ -655,9 +657,9 @@ func createBoardingIntentFixture(
 	}
 	leaves := []tree.LeafDescriptor{
 		{
-			PkScript:    pkScript,
-			Amount:      btcutil.Amount(90000 * (idx + 1)),
-			CoSignerKey: clientPubKey,
+			PkScript:   pkScript,
+			Amount:     btcutil.Amount(90000 * (idx + 1)),
+			SigningKey: clientPubKey,
 		},
 	}
 	clientTree, err := tree.NewTree(
@@ -737,7 +739,7 @@ func TestRoundStoreDecoupledVTXOStorage(t *testing.T) {
 
 	// Create 3 VTXO requests (more than boarding intents) to test
 	// decoupled storage.
-	allVtxos := make([]types.VTXORequest, numVTXORequests)
+	allVtxos := make([]round.RoundVTXORequest, numVTXORequests)
 	for i := 0; i < numVTXORequests; i++ {
 		privKey, err := btcec.NewPrivateKey()
 		require.NoError(t, err)
@@ -752,20 +754,23 @@ func TestRoundStoreDecoupledVTXOStorage(t *testing.T) {
 			},
 		}
 
-		allVtxos[i] = types.VTXORequest{
-			Amount:   btcutil.Amount(30000 * (i + 1)),
-			PkScript: fixtures[0].pkScript,
-			Expiry:   144,
-			ClientKey: keychain.KeyDescriptor{
-				PubKey: privKey.PubKey(),
-				KeyLocator: keychain.KeyLocator{
-					Family: types.VTXOOwnerKeyFamily,
-					Index:  uint32(i),
+		allVtxos[i] = round.RoundVTXORequest{
+			VTXOIntent: round.VTXOIntent{
+				Amount:   btcutil.Amount(30000 * (i + 1)),
+				PkScript: fixtures[0].pkScript,
+				Expiry:   144,
+				OwnerKey: keychain.KeyDescriptor{
+					PubKey: privKey.PubKey(),
+					KeyLocator: keychain.KeyLocator{
+						Family: types.
+							VTXOOwnerKeyFamily,
+						Index: uint32(i),
+					},
 				},
+				IsOwner:     true,
+				OperatorKey: operatorKey.PubKey(),
 			},
-			OwnsClientKey: true,
-			OperatorKey:   operatorKey.PubKey(),
-			SigningKey:    signingKey,
+			SigningKey: signingKey,
 		}
 	}
 
@@ -796,9 +801,9 @@ func TestRoundStoreDecoupledVTXOStorage(t *testing.T) {
 	vtxtLeaves := make([]tree.LeafDescriptor, numVTXORequests)
 	for i := 0; i < numVTXORequests; i++ {
 		vtxtLeaves[i] = tree.LeafDescriptor{
-			PkScript:    fixtures[0].pkScript,
-			Amount:      btcutil.Amount(30000 * (i + 1)),
-			CoSignerKey: allVtxos[i].SigningKey.PubKey,
+			PkScript:   fixtures[0].pkScript,
+			Amount:     btcutil.Amount(30000 * (i + 1)),
+			SigningKey: allVtxos[i].SigningKey.PubKey,
 		}
 	}
 	vtxtTree, err := tree.NewTree(
@@ -1028,7 +1033,7 @@ func TestRoundStoreWithBoardingGroup(t *testing.T) {
 
 	// Build the round's boarding group from the fixtures.
 	roundIntents := make([]round.BoardingIntent, numIntents)
-	allVtxos := make([]types.VTXORequest, 0, numIntents)
+	allVtxos := make([]round.RoundVTXORequest, 0, numIntents)
 	inputSigs := make([]*types.BoardingInputSignature, numIntents)
 	clientTrees := make(map[round.SignerKey]*tree.Tree)
 	for i, f := range fixtures {
@@ -1065,9 +1070,9 @@ func TestRoundStoreWithBoardingGroup(t *testing.T) {
 	for _, f := range fixtures {
 		for range f.vtxoTemplates {
 			vtxtLeaves = append(vtxtLeaves, tree.LeafDescriptor{
-				PkScript:    f.pkScript,
-				Amount:      45000,
-				CoSignerKey: f.clientPubKey,
+				PkScript:   f.pkScript,
+				Amount:     45000,
+				SigningKey: f.clientPubKey,
 			})
 		}
 	}

--- a/db/round_store_test.go
+++ b/db/round_store_test.go
@@ -603,12 +603,19 @@ func createBoardingIntentFixture(
 		},
 	}
 	vtxoTemplates := []types.VTXORequest{{
-		Amount:      btcutil.Amount(90000),
-		PkScript:    pkScript,
-		Expiry:      exitDelay,
-		ClientKey:   clientPubKey,
-		OperatorKey: operatorPubKey,
-		SigningKey:  signingKey,
+		Amount:   btcutil.Amount(90000),
+		PkScript: pkScript,
+		Expiry:   exitDelay,
+		ClientKey: keychain.KeyDescriptor{
+			PubKey: clientPubKey,
+			KeyLocator: keychain.KeyLocator{
+				Family: types.VTXOOwnerKeyFamily,
+				Index:  uint32(idx * 10),
+			},
+		},
+		OwnsClientKey: true,
+		OperatorKey:   operatorPubKey,
+		SigningKey:    signingKey,
 	}}
 
 	boardingRequest := types.BoardingRequest{
@@ -746,12 +753,19 @@ func TestRoundStoreDecoupledVTXOStorage(t *testing.T) {
 		}
 
 		allVtxos[i] = types.VTXORequest{
-			Amount:      btcutil.Amount(30000 * (i + 1)),
-			PkScript:    fixtures[0].pkScript,
-			Expiry:      144,
-			ClientKey:   privKey.PubKey(),
-			OperatorKey: operatorKey.PubKey(),
-			SigningKey:  signingKey,
+			Amount:   btcutil.Amount(30000 * (i + 1)),
+			PkScript: fixtures[0].pkScript,
+			Expiry:   144,
+			ClientKey: keychain.KeyDescriptor{
+				PubKey: privKey.PubKey(),
+				KeyLocator: keychain.KeyLocator{
+					Family: types.VTXOOwnerKeyFamily,
+					Index:  uint32(i),
+				},
+			},
+			OwnsClientKey: true,
+			OperatorKey:   operatorKey.PubKey(),
+			SigningKey:    signingKey,
 		}
 	}
 
@@ -784,7 +798,7 @@ func TestRoundStoreDecoupledVTXOStorage(t *testing.T) {
 		vtxtLeaves[i] = tree.LeafDescriptor{
 			PkScript:    fixtures[0].pkScript,
 			Amount:      btcutil.Amount(30000 * (i + 1)),
-			CoSignerKey: allVtxos[i].ClientKey,
+			CoSignerKey: allVtxos[i].SigningKey.PubKey,
 		}
 	}
 	vtxtTree, err := tree.NewTree(

--- a/db/sqlc/migrations/000003_round_tables.up.sql
+++ b/db/sqlc/migrations/000003_round_tables.up.sql
@@ -138,6 +138,16 @@ CREATE TABLE IF NOT EXISTS round_vtxo_requests (
     -- VTXORequest.ClientKey - 33-byte compressed public key.
     client_pubkey BLOB NOT NULL,
 
+    -- VTXORequest.ClientKey.KeyLocator.Family
+    client_key_family INTEGER NOT NULL,
+
+    -- VTXORequest.ClientKey.KeyLocator.Index
+    client_key_index INTEGER NOT NULL,
+
+    -- OwnsClientKey records whether the local client controls the VTXO owner
+    -- key and should materialize this VTXO locally after confirmation.
+    owns_client_key BOOLEAN NOT NULL DEFAULT FALSE,
+
     -- VTXORequest.OperatorKey - 33-byte compressed public key.
     operator_pubkey BLOB NOT NULL,
 

--- a/db/sqlc/models.go
+++ b/db/sqlc/models.go
@@ -154,6 +154,9 @@ type RoundVtxoRequest struct {
 	PkScript         []byte
 	Expiry           int32
 	ClientPubkey     []byte
+	ClientKeyFamily  int32
+	ClientKeyIndex   int32
+	OwnsClientKey    bool
 	OperatorPubkey   []byte
 	SigningKeyFamily int32
 	SigningKeyIndex  int32

--- a/db/sqlc/queries/round.sql
+++ b/db/sqlc/queries/round.sql
@@ -73,8 +73,9 @@ WHERE round_id = $1 AND outpoint_hash = $2 AND outpoint_index = $3;
 -- name: InsertRoundVtxoRequest :exec
 INSERT INTO round_vtxo_requests (
     round_id, request_index, amount, pk_script, expiry, client_pubkey,
-    operator_pubkey, signing_key_family, signing_key_index, signing_pubkey
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+    client_key_family, client_key_index, owns_client_key, operator_pubkey,
+    signing_key_family, signing_key_index, signing_pubkey
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
     ON CONFLICT (round_id, request_index) DO NOTHING;
 
 -- name: GetRoundVtxoRequests :many

--- a/db/sqlc/round.sql.go
+++ b/db/sqlc/round.sql.go
@@ -262,7 +262,7 @@ func (q *Queries) GetRoundClientTrees(ctx context.Context, roundID string) ([]Ro
 }
 
 const GetRoundVtxoRequests = `-- name: GetRoundVtxoRequests :many
-SELECT round_id, request_index, amount, pk_script, expiry, client_pubkey, operator_pubkey, signing_key_family, signing_key_index, signing_pubkey FROM round_vtxo_requests
+SELECT round_id, request_index, amount, pk_script, expiry, client_pubkey, client_key_family, client_key_index, owns_client_key, operator_pubkey, signing_key_family, signing_key_index, signing_pubkey FROM round_vtxo_requests
 WHERE round_id = $1
 ORDER BY request_index ASC
 `
@@ -283,6 +283,9 @@ func (q *Queries) GetRoundVtxoRequests(ctx context.Context, roundID string) ([]R
 			&i.PkScript,
 			&i.Expiry,
 			&i.ClientPubkey,
+			&i.ClientKeyFamily,
+			&i.ClientKeyIndex,
+			&i.OwnsClientKey,
 			&i.OperatorPubkey,
 			&i.SigningKeyFamily,
 			&i.SigningKeyIndex,
@@ -481,8 +484,9 @@ const InsertRoundVtxoRequest = `-- name: InsertRoundVtxoRequest :exec
 
 INSERT INTO round_vtxo_requests (
     round_id, request_index, amount, pk_script, expiry, client_pubkey,
-    operator_pubkey, signing_key_family, signing_key_index, signing_pubkey
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+    client_key_family, client_key_index, owns_client_key, operator_pubkey,
+    signing_key_family, signing_key_index, signing_pubkey
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
     ON CONFLICT (round_id, request_index) DO NOTHING
 `
 
@@ -493,6 +497,9 @@ type InsertRoundVtxoRequestParams struct {
 	PkScript         []byte
 	Expiry           int32
 	ClientPubkey     []byte
+	ClientKeyFamily  int32
+	ClientKeyIndex   int32
+	OwnsClientKey    bool
 	OperatorPubkey   []byte
 	SigningKeyFamily int32
 	SigningKeyIndex  int32
@@ -508,6 +515,9 @@ func (q *Queries) InsertRoundVtxoRequest(ctx context.Context, arg InsertRoundVtx
 		arg.PkScript,
 		arg.Expiry,
 		arg.ClientPubkey,
+		arg.ClientKeyFamily,
+		arg.ClientKeyIndex,
+		arg.OwnsClientKey,
 		arg.OperatorPubkey,
 		arg.SigningKeyFamily,
 		arg.SigningKeyIndex,

--- a/db/sqlc/schemas/generated_schema.sql
+++ b/db/sqlc/schemas/generated_schema.sql
@@ -615,6 +615,16 @@ CREATE TABLE round_vtxo_requests (
     -- VTXORequest.ClientKey - 33-byte compressed public key.
     client_pubkey BLOB NOT NULL,
 
+    -- VTXORequest.ClientKey.KeyLocator.Family
+    client_key_family INTEGER NOT NULL,
+
+    -- VTXORequest.ClientKey.KeyLocator.Index
+    client_key_index INTEGER NOT NULL,
+
+    -- OwnsClientKey records whether the local client controls the VTXO owner
+    -- key and should materialize this VTXO locally after confirmation.
+    owns_client_key BOOLEAN NOT NULL DEFAULT FALSE,
+
     -- VTXORequest.OperatorKey - 33-byte compressed public key.
     operator_pubkey BLOB NOT NULL,
 

--- a/db/vtxo_store.go
+++ b/db/vtxo_store.go
@@ -385,8 +385,8 @@ func (s *VTXOPersistenceStore) descriptorToInsertParams(
 	}
 
 	var clientPubkey []byte
-	if desc.ClientKey.PubKey != nil {
-		clientPubkey = desc.ClientKey.PubKey.SerializeCompressed()
+	if desc.OwnerKey.PubKey != nil {
+		clientPubkey = desc.OwnerKey.PubKey.SerializeCompressed()
 	}
 
 	nowUnix := s.clock.Now().Unix()
@@ -398,8 +398,8 @@ func (s *VTXOPersistenceStore) descriptorToInsertParams(
 		Amount:          int64(desc.Amount),
 		PkScript:        desc.PkScript,
 		Expiry:          int32(desc.RelativeExpiry),
-		ClientKeyFamily: int32(desc.ClientKey.Family),
-		ClientKeyIndex:  int32(desc.ClientKey.Index),
+		ClientKeyFamily: int32(desc.OwnerKey.Family),
+		ClientKeyIndex:  int32(desc.OwnerKey.Index),
 		ClientPubkey:    clientPubkey,
 		OperatorPubkey:  operatorPubkey,
 		TreePath:        treePathBytes,
@@ -488,7 +488,7 @@ func (s *VTXOPersistenceStore) rowToDescriptor(
 		Outpoint: outpoint,
 		Amount:   btcutil.Amount(row.Amount),
 		PkScript: row.PkScript,
-		ClientKey: keychain.KeyDescriptor{
+		OwnerKey: keychain.KeyDescriptor{
 			PubKey: clientPubkey,
 			KeyLocator: keychain.KeyLocator{
 				Family: keyFamily,

--- a/db/vtxo_store_test.go
+++ b/db/vtxo_store_test.go
@@ -99,7 +99,7 @@ func createTestVTXODescriptor(
 		Outpoint: outpoint,
 		Amount:   btcutil.Amount(100000 * (idx + 1)),
 		PkScript: []byte{0x51, 0x20, byte(idx)},
-		ClientKey: keychain.KeyDescriptor{
+		OwnerKey: keychain.KeyDescriptor{
 			PubKey: privKey.PubKey(),
 			KeyLocator: keychain.KeyLocator{
 				Family: keychain.KeyFamily(0),
@@ -155,10 +155,10 @@ func TestVTXOPersistenceStoreSaveAndGet(t *testing.T) {
 	require.Equal(t, desc.Status, fetched.Status)
 
 	// Verify keys.
-	require.NotNil(t, fetched.ClientKey.PubKey)
+	require.NotNil(t, fetched.OwnerKey.PubKey)
 	require.NotNil(t, fetched.OperatorKey)
-	require.Equal(t, desc.ClientKey.Family, fetched.ClientKey.Family)
-	require.Equal(t, desc.ClientKey.Index, fetched.ClientKey.Index)
+	require.Equal(t, desc.OwnerKey.Family, fetched.OwnerKey.Family)
+	require.Equal(t, desc.OwnerKey.Index, fetched.OwnerKey.Index)
 
 	// Verify tree path was persisted.
 	require.NotNil(t, fetched.TreePath)
@@ -782,7 +782,7 @@ func TestVTXOPersistenceStoreMetadataUpdate(t *testing.T) {
 		Amount:      desc.Amount,
 		PkScript:    desc.PkScript,
 		Expiry:      desc.RelativeExpiry,
-		ClientKey:   desc.ClientKey,
+		OwnerKey:    desc.OwnerKey,
 		OperatorKey: desc.OperatorKey,
 		TreePath:    desc.TreePath,
 		RoundID:     fn.Some(roundID),

--- a/lib/tree/batch.go
+++ b/lib/tree/batch.go
@@ -26,8 +26,11 @@ type VTXODescriptor struct {
 	// Amount is the value of this VTXO in satoshis.
 	Amount btcutil.Amount
 
-	// CoSignerKey is the public key of the VTXO owner who must co-sign
-	// along with the operator to spend this VTXO collaboratively.
+	// OwnerKey is the public key committed to the VTXO output script.
+	OwnerKey *btcec.PublicKey
+
+	// CoSignerKey is the MuSig2 tree co-signer key used during tree
+	// signing. This is distinct from the owner key.
 	CoSignerKey *btcec.PublicKey
 }
 
@@ -55,7 +58,8 @@ func NewVTXODescriptor(amount btcutil.Amount, ownerKey *btcec.PublicKey,
 	return &VTXODescriptor{
 		PkScript:    pkScript,
 		Amount:      amount,
-		CoSignerKey: ownerKey,
+		OwnerKey:    ownerKey,
+		CoSignerKey: cosignerKey,
 	}, nil
 }
 

--- a/lib/tree/batch.go
+++ b/lib/tree/batch.go
@@ -16,7 +16,10 @@ import (
 	"github.com/lightninglabs/darepo-client/lib/scripts"
 )
 
-// VTXODescriptor defines the complete specification for a single VTXO leaf.
+// VTXODescriptor defines the specification for a single VTXO in a round's
+// transaction tree. It carries both the VTXO output metadata (owner key,
+// operator key, exit delay) and the ephemeral signing key used for MuSig2
+// tree construction.
 type VTXODescriptor struct {
 	// PkScript is the P2TR script for the VTXO output. This is typically
 	// generated using scripts.VTXOTapKey which creates a taproot script
@@ -26,23 +29,32 @@ type VTXODescriptor struct {
 	// Amount is the value of this VTXO in satoshis.
 	Amount btcutil.Amount
 
+	// ExitDelay is the CSV delay committed to the unilateral timeout path
+	// of the VTXO output.
+	ExitDelay uint32
+
 	// OwnerKey is the public key committed to the VTXO output script.
 	OwnerKey *btcec.PublicKey
 
-	// CoSignerKey is the MuSig2 tree co-signer key used during tree
-	// signing. This is distinct from the owner key.
-	CoSignerKey *btcec.PublicKey
+	// OperatorKey is the collaborative spend cosigner committed to the
+	// VTXO output script.
+	OperatorKey *btcec.PublicKey
+
+	// SigningKey is the MuSig2 tree signing key used during round tree
+	// construction. This is distinct from the owner key and operator
+	// key, is ephemeral per round, and must not be reused.
+	SigningKey *btcec.PublicKey
 }
 
 // NewVTXODescriptor constructs a VTXODescriptor by building the VTXO taproot
-// script using the scripts package. This is a convenience helper for clients to
-// easily create VTXO descriptors for tree construction.
+// script using the scripts package and combining it with the signing key for
+// tree construction.
 func NewVTXODescriptor(amount btcutil.Amount, ownerKey *btcec.PublicKey,
-	cosignerKey *btcec.PublicKey, exitDelay uint32) (*VTXODescriptor,
-	error) {
+	operatorKey *btcec.PublicKey, signingKey *btcec.PublicKey,
+	exitDelay uint32) (*VTXODescriptor, error) {
 
 	// Use scripts package to compute the VTXO output key.
-	outputKey, err := scripts.VTXOTapKey(ownerKey, cosignerKey, exitDelay)
+	outputKey, err := scripts.VTXOTapKey(ownerKey, operatorKey, exitDelay)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compute VTXO tap key: %w",
 			err)
@@ -58,22 +70,25 @@ func NewVTXODescriptor(amount btcutil.Amount, ownerKey *btcec.PublicKey,
 	return &VTXODescriptor{
 		PkScript:    pkScript,
 		Amount:      amount,
+		ExitDelay:   exitDelay,
 		OwnerKey:    ownerKey,
-		CoSignerKey: cosignerKey,
+		OperatorKey: operatorKey,
+		SigningKey:  signingKey,
 	}, nil
 }
 
-// ToLeafDescriptor converts a VTXODescriptor to a generic LeafDescriptor.
+// ToLeafDescriptor converts a VTXODescriptor to a generic LeafDescriptor
+// for tree construction.
 func (v VTXODescriptor) ToLeafDescriptor() LeafDescriptor {
 	pkScript := make([]byte, len(v.PkScript))
 	copy(pkScript, v.PkScript)
 
-	cosignerKey := *v.CoSignerKey
+	signingKey := *v.SigningKey
 
 	return LeafDescriptor{
-		PkScript:    pkScript,
-		Amount:      v.Amount,
-		CoSignerKey: &cosignerKey,
+		PkScript:   pkScript,
+		Amount:     v.Amount,
+		SigningKey: &signingKey,
 	}
 }
 
@@ -116,16 +131,16 @@ func ValidateVTXODescriptors(vtxos []VTXODescriptor) error {
 				"VTXO %d has invalid taproot script", i,
 			)
 		}
-		if vtxo.CoSignerKey == nil {
-			return fmt.Errorf("VTXO %d has nil co-signer key", i)
+		if vtxo.SigningKey == nil {
+			return fmt.Errorf("VTXO %d has nil signing key", i)
 		}
 
 		keyStr := hex.EncodeToString(
-			schnorr.SerializePubKey(vtxo.CoSignerKey),
+			schnorr.SerializePubKey(vtxo.SigningKey),
 		)
 		if _, exists := seen[keyStr]; exists {
 			return fmt.Errorf(
-				"VTXO %d has duplicate co-signer key", i,
+				"VTXO %d has duplicate signing key", i,
 			)
 		}
 		seen[keyStr] = struct{}{}
@@ -160,7 +175,7 @@ func ValidateConnectorDescriptor(conn ConnectorDescriptor) error {
 }
 
 // ToLeafDescriptors expands a connector descriptor into identical leaves using
-// the provided operator key as cosigner.
+// the provided operator key as signer.
 func (c ConnectorDescriptor) ToLeafDescriptors(
 	operatorKey *btcec.PublicKey,
 ) []LeafDescriptor {
@@ -168,9 +183,9 @@ func (c ConnectorDescriptor) ToLeafDescriptors(
 	leaves := make([]LeafDescriptor, c.NumLeaves)
 	for i := 0; i < c.NumLeaves; i++ {
 		leaves[i] = LeafDescriptor{
-			PkScript:    c.PkScript,
-			Amount:      c.Amount,
-			CoSignerKey: operatorKey,
+			PkScript:   c.PkScript,
+			Amount:     c.Amount,
+			SigningKey: operatorKey,
 		}
 	}
 
@@ -319,7 +334,7 @@ func BuildBatchOutput(vtxos []VTXODescriptor,
 	}
 	sweepTapRoot := sweepTapLeaf.TapHash()
 
-	// Collect unique cosigners (operator + all client cosigners).
+	// Collect unique signers (operator + all client tree signers).
 	signers := []*btcec.PublicKey{operatorMuSigKey}
 	seenSigners := make(map[string]struct{})
 	operatorKeyStr := hex.EncodeToString(
@@ -328,9 +343,15 @@ func BuildBatchOutput(vtxos []VTXODescriptor,
 	seenSigners[operatorKeyStr] = struct{}{}
 
 	var totalAmount btcutil.Amount
-	for _, vtxo := range vtxos {
+	for i, vtxo := range vtxos {
 		if vtxo.Amount < 0 {
 			return nil, fmt.Errorf("vtxo amount cannot be negative")
+		}
+
+		if vtxo.SigningKey == nil {
+			return nil, fmt.Errorf(
+				"VTXO %d has nil signing key", i,
+			)
 		}
 
 		// Check overflow before adding.
@@ -341,17 +362,17 @@ func BuildBatchOutput(vtxos []VTXODescriptor,
 
 		totalAmount += vtxo.Amount
 
-		// Add cosigner if not already seen.
+		// Add signer if not already seen.
 		keyStr := hex.EncodeToString(
-			schnorr.SerializePubKey(vtxo.CoSignerKey),
+			schnorr.SerializePubKey(vtxo.SigningKey),
 		)
 		if _, seen := seenSigners[keyStr]; !seen {
 			seenSigners[keyStr] = struct{}{}
-			signers = append(signers, vtxo.CoSignerKey)
+			signers = append(signers, vtxo.SigningKey)
 		}
 	}
 
-	// Aggregate cosigner keys and tweak with sweep tapscript root.
+	// Aggregate signer keys and tweak with sweep tapscript root.
 	aggKey, _, _, err := musig2.AggregateKeys(
 		signers, true,
 		musig2.WithTaprootKeyTweak(sweepTapRoot[:]),

--- a/lib/tree/batch_test.go
+++ b/lib/tree/batch_test.go
@@ -54,9 +54,9 @@ func TestBuildVTXOTree(t *testing.T) {
 
 		vtxos := []VTXODescriptor{
 			{
-				PkScript:    vtxoScript,
-				Amount:      btcutil.Amount(5000),
-				CoSignerKey: user1PubKey,
+				PkScript:   vtxoScript,
+				Amount:     btcutil.Amount(5000),
+				SigningKey: user1PubKey,
 			},
 		}
 
@@ -109,14 +109,14 @@ func TestBuildVTXOTree(t *testing.T) {
 
 		vtxos := []VTXODescriptor{
 			{
-				PkScript:    vtxo1Script,
-				Amount:      btcutil.Amount(5000),
-				CoSignerKey: user1PubKey,
+				PkScript:   vtxo1Script,
+				Amount:     btcutil.Amount(5000),
+				SigningKey: user1PubKey,
 			},
 			{
-				PkScript:    vtxo2Script,
-				Amount:      btcutil.Amount(3000),
-				CoSignerKey: user2PubKey,
+				PkScript:   vtxo2Script,
+				Amount:     btcutil.Amount(3000),
+				SigningKey: user2PubKey,
 			},
 		}
 
@@ -188,9 +188,9 @@ func TestBuildVTXOTree(t *testing.T) {
 			require.NoError(t, err)
 
 			vtxos[i] = VTXODescriptor{
-				PkScript:    script,
-				Amount:      btcutil.Amount(1000 * (5 - i)),
-				CoSignerKey: key.PubKey(),
+				PkScript:   script,
+				Amount:     btcutil.Amount(1000 * (5 - i)),
+				SigningKey: key.PubKey(),
 			}
 		}
 
@@ -238,9 +238,9 @@ func TestBuildVTXOTree(t *testing.T) {
 		require.NoError(t, err)
 
 		validVTXO := VTXODescriptor{
-			PkScript:    vtxoScript,
-			Amount:      btcutil.Amount(1000),
-			CoSignerKey: user1PubKey,
+			PkScript:   vtxoScript,
+			Amount:     btcutil.Amount(1000),
+			SigningKey: user1PubKey,
 		}
 
 		t.Run("empty VTXOs fails", func(t *testing.T) {
@@ -321,9 +321,9 @@ func TestBuildVTXOTreeStableSort(t *testing.T) {
 	coSigner3, _ := testutils.CreateKey(103)
 
 	vtxos := []VTXODescriptor{
-		{PkScript: script3, Amount: 1000, CoSignerKey: coSigner3},
-		{PkScript: script1, Amount: 1000, CoSignerKey: coSigner1},
-		{PkScript: script2, Amount: 1000, CoSignerKey: coSigner2},
+		{PkScript: script3, Amount: 1000, SigningKey: coSigner3},
+		{PkScript: script1, Amount: 1000, SigningKey: coSigner1},
+		{PkScript: script2, Amount: 1000, SigningKey: coSigner2},
 	}
 
 	// Build tree multiple times - should be identical.
@@ -656,9 +656,9 @@ func TestBuildBatchOutput(t *testing.T) {
 	t.Run("single VTXO", func(t *testing.T) {
 		vtxos := []VTXODescriptor{
 			{
-				PkScript:    user1Script,
-				Amount:      btcutil.Amount(5000),
-				CoSignerKey: user1Key,
+				PkScript:   user1Script,
+				Amount:     btcutil.Amount(5000),
+				SigningKey: user1Key,
 			},
 		}
 
@@ -678,14 +678,14 @@ func TestBuildBatchOutput(t *testing.T) {
 	t.Run("multiple VTXOs", func(t *testing.T) {
 		vtxos := []VTXODescriptor{
 			{
-				PkScript:    user1Script,
-				Amount:      btcutil.Amount(5000),
-				CoSignerKey: user1Key,
+				PkScript:   user1Script,
+				Amount:     btcutil.Amount(5000),
+				SigningKey: user1Key,
 			},
 			{
-				PkScript:    user2Script,
-				Amount:      btcutil.Amount(3000),
-				CoSignerKey: user2Key,
+				PkScript:   user2Script,
+				Amount:     btcutil.Amount(3000),
+				SigningKey: user2Key,
 			},
 		}
 
@@ -706,14 +706,14 @@ func TestBuildBatchOutput(t *testing.T) {
 		// Same user has 2 VTXOs.
 		vtxos := []VTXODescriptor{
 			{
-				PkScript:    user1Script,
-				Amount:      btcutil.Amount(2000),
-				CoSignerKey: user1Key,
+				PkScript:   user1Script,
+				Amount:     btcutil.Amount(2000),
+				SigningKey: user1Key,
 			},
 			{
-				PkScript:    user1Script,
-				Amount:      btcutil.Amount(3000),
-				CoSignerKey: user1Key, // Same key!
+				PkScript:   user1Script,
+				Amount:     btcutil.Amount(3000),
+				SigningKey: user1Key, // Same key!
 			},
 		}
 
@@ -729,9 +729,9 @@ func TestBuildBatchOutput(t *testing.T) {
 
 	t.Run("error cases", func(t *testing.T) {
 		validVTXO := VTXODescriptor{
-			PkScript:    user1Script,
-			Amount:      btcutil.Amount(1000),
-			CoSignerKey: user1Key,
+			PkScript:   user1Script,
+			Amount:     btcutil.Amount(1000),
+			SigningKey: user1Key,
 		}
 
 		t.Run("empty VTXOs fails", func(t *testing.T) {
@@ -857,9 +857,9 @@ func TestValidateVTXODescriptors(t *testing.T) {
 	t.Run("valid single VTXO", func(t *testing.T) {
 		vtxos := []VTXODescriptor{
 			{
-				PkScript:    validTaprootScript,
-				Amount:      btcutil.Amount(10000),
-				CoSignerKey: key1Pub,
+				PkScript:   validTaprootScript,
+				Amount:     btcutil.Amount(10000),
+				SigningKey: key1Pub,
 			},
 		}
 
@@ -876,19 +876,19 @@ func TestValidateVTXODescriptors(t *testing.T) {
 
 		vtxos := []VTXODescriptor{
 			{
-				PkScript:    validTaprootScript,
-				Amount:      btcutil.Amount(10000),
-				CoSignerKey: key1Pub,
+				PkScript:   validTaprootScript,
+				Amount:     btcutil.Amount(10000),
+				SigningKey: key1Pub,
 			},
 			{
-				PkScript:    script2,
-				Amount:      btcutil.Amount(20000),
-				CoSignerKey: key2Pub,
+				PkScript:   script2,
+				Amount:     btcutil.Amount(20000),
+				SigningKey: key2Pub,
 			},
 			{
-				PkScript:    script3,
-				Amount:      btcutil.Amount(30000),
-				CoSignerKey: key3Pub,
+				PkScript:   script3,
+				Amount:     btcutil.Amount(30000),
+				SigningKey: key3Pub,
 			},
 		}
 
@@ -911,9 +911,9 @@ func TestValidateVTXODescriptors(t *testing.T) {
 	t.Run("zero amount fails", func(t *testing.T) {
 		vtxos := []VTXODescriptor{
 			{
-				PkScript:    validTaprootScript,
-				Amount:      btcutil.Amount(0),
-				CoSignerKey: key1Pub,
+				PkScript:   validTaprootScript,
+				Amount:     btcutil.Amount(0),
+				SigningKey: key1Pub,
 			},
 		}
 
@@ -925,9 +925,9 @@ func TestValidateVTXODescriptors(t *testing.T) {
 	t.Run("negative amount fails", func(t *testing.T) {
 		vtxos := []VTXODescriptor{
 			{
-				PkScript:    validTaprootScript,
-				Amount:      btcutil.Amount(-1000),
-				CoSignerKey: key1Pub,
+				PkScript:   validTaprootScript,
+				Amount:     btcutil.Amount(-1000),
+				SigningKey: key1Pub,
 			},
 		}
 
@@ -939,9 +939,9 @@ func TestValidateVTXODescriptors(t *testing.T) {
 	t.Run("empty PkScript fails", func(t *testing.T) {
 		vtxos := []VTXODescriptor{
 			{
-				PkScript:    []byte{},
-				Amount:      btcutil.Amount(10000),
-				CoSignerKey: key1Pub,
+				PkScript:   []byte{},
+				Amount:     btcutil.Amount(10000),
+				SigningKey: key1Pub,
 			},
 		}
 
@@ -953,9 +953,9 @@ func TestValidateVTXODescriptors(t *testing.T) {
 	t.Run("nil PkScript fails", func(t *testing.T) {
 		vtxos := []VTXODescriptor{
 			{
-				PkScript:    nil,
-				Amount:      btcutil.Amount(10000),
-				CoSignerKey: key1Pub,
+				PkScript:   nil,
+				Amount:     btcutil.Amount(10000),
+				SigningKey: key1Pub,
 			},
 		}
 
@@ -975,9 +975,9 @@ func TestValidateVTXODescriptors(t *testing.T) {
 
 		vtxos := []VTXODescriptor{
 			{
-				PkScript:    p2wpkhScript,
-				Amount:      btcutil.Amount(10000),
-				CoSignerKey: key1Pub,
+				PkScript:   p2wpkhScript,
+				Amount:     btcutil.Amount(10000),
+				SigningKey: key1Pub,
 			},
 		}
 
@@ -986,40 +986,40 @@ func TestValidateVTXODescriptors(t *testing.T) {
 		require.Contains(t, err.Error(), "invalid taproot script")
 	})
 
-	t.Run("nil co-signer key fails", func(t *testing.T) {
+	t.Run("nil signing key fails", func(t *testing.T) {
 		vtxos := []VTXODescriptor{
 			{
-				PkScript:    validTaprootScript,
-				Amount:      btcutil.Amount(10000),
-				CoSignerKey: nil,
+				PkScript:   validTaprootScript,
+				Amount:     btcutil.Amount(10000),
+				SigningKey: nil,
 			},
 		}
 
 		err := ValidateVTXODescriptors(vtxos)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "nil co-signer key")
+		require.Contains(t, err.Error(), "nil signing key")
 	})
 
-	t.Run("duplicate co-signer keys fail", func(t *testing.T) {
+	t.Run("duplicate signing keys fail", func(t *testing.T) {
 		script2, err := txscript.PayToTaprootScript(key2Pub)
 		require.NoError(t, err)
 
 		vtxos := []VTXODescriptor{
 			{
-				PkScript:    validTaprootScript,
-				Amount:      btcutil.Amount(10000),
-				CoSignerKey: key1Pub,
+				PkScript:   validTaprootScript,
+				Amount:     btcutil.Amount(10000),
+				SigningKey: key1Pub,
 			},
 			{
-				PkScript:    script2,
-				Amount:      btcutil.Amount(20000),
-				CoSignerKey: key1Pub, // Duplicate!
+				PkScript:   script2,
+				Amount:     btcutil.Amount(20000),
+				SigningKey: key1Pub, // Duplicate!
 			},
 		}
 
 		err = ValidateVTXODescriptors(vtxos)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "duplicate co-signer key")
+		require.Contains(t, err.Error(), "duplicate signing key")
 	})
 
 	t.Run("duplicate detection multiple VTXOs", func(t *testing.T) {
@@ -1031,25 +1031,25 @@ func TestValidateVTXODescriptors(t *testing.T) {
 
 		vtxos := []VTXODescriptor{
 			{
-				PkScript:    validTaprootScript,
-				Amount:      btcutil.Amount(10000),
-				CoSignerKey: key1Pub,
+				PkScript:   validTaprootScript,
+				Amount:     btcutil.Amount(10000),
+				SigningKey: key1Pub,
 			},
 			{
-				PkScript:    script2,
-				Amount:      btcutil.Amount(20000),
-				CoSignerKey: key2Pub,
+				PkScript:   script2,
+				Amount:     btcutil.Amount(20000),
+				SigningKey: key2Pub,
 			},
 			{
-				PkScript:    script3,
-				Amount:      btcutil.Amount(30000),
-				CoSignerKey: key2Pub, // Duplicate of second!
+				PkScript:   script3,
+				Amount:     btcutil.Amount(30000),
+				SigningKey: key2Pub, // Duplicate of second!
 			},
 		}
 
 		err = ValidateVTXODescriptors(vtxos)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "duplicate co-signer key")
+		require.Contains(t, err.Error(), "duplicate signing key")
 	})
 }
 
@@ -1163,6 +1163,7 @@ func TestMakeVTXODescriptor(t *testing.T) {
 			btcutil.Amount(5000),
 			timeoutKey,
 			cosignerKey,
+			nil,
 			144, // exit delay
 		)
 		require.NoError(t, err)
@@ -1171,24 +1172,37 @@ func TestMakeVTXODescriptor(t *testing.T) {
 		// Verify descriptor fields.
 		require.Equal(t, btcutil.Amount(5000), desc.Amount)
 		require.Equal(t, timeoutKey, desc.OwnerKey)
-		require.Equal(t, cosignerKey, desc.CoSignerKey)
+		require.Equal(t, cosignerKey, desc.OperatorKey)
+		require.Nil(t, desc.SigningKey)
 
 		// Verify PkScript is valid taproot.
 		require.NotEmpty(t, desc.PkScript)
 		require.True(t, txscript.IsPayToTaproot(desc.PkScript))
 
-		// Verify descriptor passes validation.
-		err = ValidateVTXODescriptors([]VTXODescriptor{*desc})
+		// Verify the round descriptor passes tree-building validation.
+		roundDesc, err := NewVTXODescriptor(
+			btcutil.Amount(5000),
+			timeoutKey,
+			cosignerKey,
+			timeoutKey,
+			144,
+		)
+		require.NoError(t, err)
+
+		err = ValidateVTXODescriptors([]VTXODescriptor{*roundDesc})
 		require.NoError(t, err)
 	})
 
 	t.Run("integrates with scripts package", func(t *testing.T) {
-		// Create multiple VTXOs with different tree cosigner keys.
+		operatorKey, _ := testutils.CreateKey(50)
+
+		// Create multiple VTXOs with different tree signing keys.
 		owner1, _ := testutils.CreateKey(10)
 		signingKey1, _ := testutils.CreateKey(20)
 		desc1, err := NewVTXODescriptor(
 			btcutil.Amount(1000),
 			owner1,
+			operatorKey,
 			signingKey1,
 			144,
 		)
@@ -1199,12 +1213,13 @@ func TestMakeVTXODescriptor(t *testing.T) {
 		desc2, err := NewVTXODescriptor(
 			btcutil.Amount(2000),
 			owner2,
+			operatorKey,
 			signingKey2,
 			144,
 		)
 		require.NoError(t, err)
 
-		// Both should be valid and have unique cosigners.
+		// Both should be valid and have unique signing keys.
 		err = ValidateVTXODescriptors([]VTXODescriptor{*desc1, *desc2})
 		require.NoError(t, err)
 	})

--- a/lib/tree/batch_test.go
+++ b/lib/tree/batch_test.go
@@ -1170,7 +1170,8 @@ func TestMakeVTXODescriptor(t *testing.T) {
 
 		// Verify descriptor fields.
 		require.Equal(t, btcutil.Amount(5000), desc.Amount)
-		require.Equal(t, timeoutKey, desc.CoSignerKey)
+		require.Equal(t, timeoutKey, desc.OwnerKey)
+		require.Equal(t, cosignerKey, desc.CoSignerKey)
 
 		// Verify PkScript is valid taproot.
 		require.NotEmpty(t, desc.PkScript)
@@ -1182,22 +1183,23 @@ func TestMakeVTXODescriptor(t *testing.T) {
 	})
 
 	t.Run("integrates with scripts package", func(t *testing.T) {
-		// Create multiple VTXOs with different cosigner keys.
-		cosigner1, _ := testutils.CreateKey(10)
-		operator, _ := testutils.CreateKey(20)
+		// Create multiple VTXOs with different tree cosigner keys.
+		owner1, _ := testutils.CreateKey(10)
+		signingKey1, _ := testutils.CreateKey(20)
 		desc1, err := NewVTXODescriptor(
 			btcutil.Amount(1000),
-			cosigner1,
-			operator,
+			owner1,
+			signingKey1,
 			144,
 		)
 		require.NoError(t, err)
 
-		cosigner2, _ := testutils.CreateKey(20)
+		owner2, _ := testutils.CreateKey(30)
+		signingKey2, _ := testutils.CreateKey(40)
 		desc2, err := NewVTXODescriptor(
 			btcutil.Amount(2000),
-			cosigner2,
-			operator,
+			owner2,
+			signingKey2,
 			144,
 		)
 		require.NoError(t, err)

--- a/lib/tree/btc_tree_assembler_test.go
+++ b/lib/tree/btc_tree_assembler_test.go
@@ -29,9 +29,9 @@ func TestBTCTreeAssemblerBuildTree(t *testing.T) {
 		leafPkScript := genTaprootPkScript(t, leafKey)
 
 		leaves := []LeafDescriptor{{
-			CoSignerKey: leafKey,
-			PkScript:    leafPkScript,
-			Amount:      btcutil.Amount(10000),
+			SigningKey: leafKey,
+			PkScript:   leafPkScript,
+			Amount:     btcutil.Amount(10000),
 		}}
 
 		// Build tree.
@@ -81,9 +81,9 @@ func TestBTCTreeAssemblerBuildTree(t *testing.T) {
 		for i := 0; i < 5; i++ {
 			leafKey := genPubKey(t)
 			leaves = append(leaves, LeafDescriptor{
-				CoSignerKey: leafKey,
-				PkScript:    genTaprootPkScript(t, leafKey),
-				Amount:      btcutil.Amount(10000),
+				SigningKey: leafKey,
+				PkScript:   genTaprootPkScript(t, leafKey),
+				Amount:     btcutil.Amount(10000),
 			})
 		}
 
@@ -154,8 +154,8 @@ func TestBTCTreeAssemblerBuildTree(t *testing.T) {
 		t.Run("nil root output fails", func(t *testing.T) {
 			leafKey := genPubKey(t)
 			leaves := []LeafDescriptor{{
-				CoSignerKey: leafKey,
-				PkScript:    genTaprootPkScript(t, leafKey),
+				SigningKey: leafKey,
+				PkScript:   genTaprootPkScript(t, leafKey),
 			}}
 			_, err := assembler.BuildTree(rootInput, nil, leaves)
 			require.Error(t, err)
@@ -181,8 +181,8 @@ func TestBTCTreeAssemblerBuildTree(t *testing.T) {
 		rootOutput := wire.NewTxOut(10000, rootPkScript)
 		leafKey := genPubKey(t)
 		leaves := []LeafDescriptor{{
-			CoSignerKey: leafKey,
-			PkScript:    genTaprootPkScript(t, leafKey),
+			SigningKey: leafKey,
+			PkScript:   genTaprootPkScript(t, leafKey),
 		}}
 
 		_, err := assembler.BuildTree(rootInput, rootOutput, leaves)
@@ -208,9 +208,9 @@ func TestBTCTreeAssemblerBuildTree(t *testing.T) {
 		rootOutput := wire.NewTxOut(10000, rootPkScript)
 		leafKey := genPubKey(t)
 		leaves := []LeafDescriptor{{
-			CoSignerKey: leafKey,
-			PkScript:    genTaprootPkScript(t, leafKey),
-			Amount:      btcutil.Amount(10000),
+			SigningKey: leafKey,
+			PkScript:   genTaprootPkScript(t, leafKey),
+			Amount:     btcutil.Amount(10000),
 		}}
 
 		tree, err := assembler.BuildTree(rootInput, rootOutput, leaves)
@@ -229,9 +229,9 @@ func TestBTCTreeAssemblerBuildTree(t *testing.T) {
 		for i := 0; i < 8; i++ {
 			leafKey := genPubKey(t)
 			leaves = append(leaves, LeafDescriptor{
-				CoSignerKey: leafKey,
-				PkScript:    genTaprootPkScript(t, leafKey),
-				Amount:      btcutil.Amount(1000),
+				SigningKey: leafKey,
+				PkScript:   genTaprootPkScript(t, leafKey),
+				Amount:     btcutil.Amount(1000),
 			})
 		}
 
@@ -273,9 +273,9 @@ func TestBTCTreeAssemblerBuildTree(t *testing.T) {
 			leafKey := genPubKey(t)
 			leafKeys[i] = leafKey
 			leaves = append(leaves, LeafDescriptor{
-				CoSignerKey: leafKey,
-				PkScript:    genTaprootPkScript(t, leafKey),
-				Amount:      amt,
+				SigningKey: leafKey,
+				PkScript:   genTaprootPkScript(t, leafKey),
+				Amount:     amt,
 			})
 		}
 
@@ -336,14 +336,14 @@ func TestBTCTreeAssemblerBuildTree(t *testing.T) {
 		leafKey2 := genPubKey(t)
 		leaves := []LeafDescriptor{
 			{
-				CoSignerKey: genPubKey(t),
-				PkScript:    genTaprootPkScript(t, leafKey1),
-				Amount:      btcutil.Amount(10000),
+				SigningKey: genPubKey(t),
+				PkScript:   genTaprootPkScript(t, leafKey1),
+				Amount:     btcutil.Amount(10000),
 			},
 			{
-				CoSignerKey: genPubKey(t),
-				PkScript:    genTaprootPkScript(t, leafKey2),
-				Amount:      btcutil.Amount(10000),
+				SigningKey: genPubKey(t),
+				PkScript:   genTaprootPkScript(t, leafKey2),
+				Amount:     btcutil.Amount(10000),
 			},
 		}
 

--- a/lib/tree/build_test.go
+++ b/lib/tree/build_test.go
@@ -20,9 +20,9 @@ func TestPartitionLeaves(t *testing.T) {
 		for i := 0; i < count; i++ {
 			privKey, _ := btcec.NewPrivateKey()
 			leaves[i] = LeafDescriptor{
-				PkScript:    []byte("script"),
-				Amount:      btcutil.Amount(1000),
-				CoSignerKey: privKey.PubKey(),
+				PkScript:   []byte("script"),
+				Amount:     btcutil.Amount(1000),
+				SigningKey: privKey.PubKey(),
 			}
 		}
 
@@ -242,9 +242,9 @@ func TestBuildTreeBFS(t *testing.T) {
 			privKey, _ := btcec.NewPrivateKey()
 			keys[i] = privKey.PubKey()
 			leaves[i] = LeafDescriptor{
-				PkScript:    []byte("script"),
-				Amount:      btcutil.Amount(1000),
-				CoSignerKey: keys[i],
+				PkScript:   []byte("script"),
+				Amount:     btcutil.Amount(1000),
+				SigningKey: keys[i],
 			}
 		}
 
@@ -707,9 +707,9 @@ func TestBuildTreeBFSEdgeCases(t *testing.T) {
 		privKey, _ := btcec.NewPrivateKey()
 		leaves := []LeafDescriptor{
 			{
-				PkScript:    []byte("script"),
-				Amount:      btcutil.Amount(1000),
-				CoSignerKey: privKey.PubKey(),
+				PkScript:   []byte("script"),
+				Amount:     btcutil.Amount(1000),
+				SigningKey: privKey.PubKey(),
 			},
 		}
 		input := createTestInput()
@@ -731,14 +731,14 @@ func TestBuildTreeBFSEdgeCases(t *testing.T) {
 
 		leaves := []LeafDescriptor{
 			{
-				PkScript:    []byte("script"),
-				Amount:      btcutil.Amount(1000),
-				CoSignerKey: nil, // Nil cosigner!
+				PkScript:   []byte("script"),
+				Amount:     btcutil.Amount(1000),
+				SigningKey: nil, // Nil cosigner!
 			},
 			{
-				PkScript:    []byte("script"),
-				Amount:      btcutil.Amount(1000),
-				CoSignerKey: nil,
+				PkScript:   []byte("script"),
+				Amount:     btcutil.Amount(1000),
+				SigningKey: nil,
 			},
 		}
 		operatorKey := createOperatorKey()
@@ -748,7 +748,7 @@ func TestBuildTreeBFSEdgeCases(t *testing.T) {
 		// Nil cosigner keys should cause an error during tree building.
 		_, err := runBuild(t, input, leaves, operatorKey, sweepRoot, 4)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "cosigner key cannot be nil")
+		require.Contains(t, err.Error(), "signing key cannot be nil")
 	})
 
 	t.Run("various radix values work correctly", func(t *testing.T) {
@@ -757,9 +757,9 @@ func TestBuildTreeBFSEdgeCases(t *testing.T) {
 		privKey, _ := btcec.NewPrivateKey()
 		leaves := []LeafDescriptor{
 			{
-				PkScript:    []byte("script"),
-				Amount:      btcutil.Amount(1000),
-				CoSignerKey: privKey.PubKey(),
+				PkScript:   []byte("script"),
+				Amount:     btcutil.Amount(1000),
+				SigningKey: privKey.PubKey(),
 			},
 		}
 

--- a/lib/tree/leaf.go
+++ b/lib/tree/leaf.go
@@ -16,7 +16,7 @@ type LeafDescriptor struct {
 	// Amount is the value of the leaf output in satoshis.
 	Amount btcutil.Amount
 
-	// CoSignerKey is the public key of the leaf owner who must participate
-	// in signing this leaf's transaction along with the operator.
-	CoSignerKey *btcec.PublicKey
+	// SigningKey is the client key that must participate in signing this
+	// leaf's transaction along with the operator during round tree signing.
+	SigningKey *btcec.PublicKey
 }

--- a/lib/tree/node.go
+++ b/lib/tree/node.go
@@ -72,9 +72,9 @@ func NewLeafNode(input wire.OutPoint, leaf LeafDescriptor,
 	operatorKey *btcec.PublicKey, sweepTapscriptRoot []byte) (*Node,
 	error) {
 
-	// The cosigners for a leaf are the leaf owner and operator.
+	// The signers for a leaf are the leaf signing key and operator.
 	cosigners := []*btcec.PublicKey{
-		leaf.CoSignerKey,
+		leaf.SigningKey,
 		operatorKey,
 	}
 
@@ -116,15 +116,15 @@ func NewBranchNode(input wire.OutPoint, groups [][]LeafDescriptor,
 		return nil, fmt.Errorf("at least one group required")
 	}
 
-	// Validate all leaf cosigner keys.
+	// Validate all leaf signing keys.
 	for i, group := range groups {
 		if len(group) == 0 {
 			return nil, fmt.Errorf("group %d is empty", i)
 		}
 
 		for j, leaf := range group {
-			if leaf.CoSignerKey == nil {
-				return nil, fmt.Errorf("leaf cosigner key "+
+			if leaf.SigningKey == nil {
+				return nil, fmt.Errorf("leaf signing key "+
 					"cannot be nil at groups[%d][%d]", i, j)
 			}
 		}
@@ -135,7 +135,7 @@ func NewBranchNode(input wire.OutPoint, groups [][]LeafDescriptor,
 
 	// Each group will become an output.
 	for groupIdx, group := range groups {
-		// Calculate total amount and collect cosigners for this group.
+		// Calculate total amount and collect signers for this group.
 		var (
 			amount         = int64(0)
 			groupCosigners = []*btcec.PublicKey{operatorKey}
@@ -160,9 +160,9 @@ func NewBranchNode(input wire.OutPoint, groups [][]LeafDescriptor,
 
 			amount += leafAmt
 			groupCosigners = append(
-				groupCosigners, leaf.CoSignerKey,
+				groupCosigners, leaf.SigningKey,
 			)
-			allCosigners = append(allCosigners, leaf.CoSignerKey)
+			allCosigners = append(allCosigners, leaf.SigningKey)
 		}
 
 		// Deduplicate cosigners for this group.

--- a/lib/tree/node_test.go
+++ b/lib/tree/node_test.go
@@ -1058,9 +1058,9 @@ func TestNodeConstructors(t *testing.T) {
 		_, operatorKey := createTestKey(t)
 
 		leaf := LeafDescriptor{
-			PkScript:    []byte("vtxo_script"),
-			Amount:      1000,
-			CoSignerKey: ownerKey,
+			PkScript:   []byte("vtxo_script"),
+			Amount:     1000,
+			SigningKey: ownerKey,
 		}
 
 		input := wire.OutPoint{
@@ -1103,14 +1103,14 @@ func TestNodeConstructors(t *testing.T) {
 
 			leaves := []LeafDescriptor{
 				{
-					PkScript:    []byte("script1"),
-					Amount:      1000,
-					CoSignerKey: key1,
+					PkScript:   []byte("script1"),
+					Amount:     1000,
+					SigningKey: key1,
 				},
 				{
-					PkScript:    []byte("script2"),
-					Amount:      2000,
-					CoSignerKey: key2,
+					PkScript:   []byte("script2"),
+					Amount:     2000,
+					SigningKey: key2,
 				},
 			}
 
@@ -1156,22 +1156,22 @@ func TestNodeConstructors(t *testing.T) {
 
 			group1 := []LeafDescriptor{
 				{
-					PkScript:    []byte("script1"),
-					Amount:      1000,
-					CoSignerKey: key1,
+					PkScript:   []byte("script1"),
+					Amount:     1000,
+					SigningKey: key1,
 				},
 				{
-					PkScript:    []byte("script2"),
-					Amount:      2000,
-					CoSignerKey: key2,
+					PkScript:   []byte("script2"),
+					Amount:     2000,
+					SigningKey: key2,
 				},
 			}
 
 			group2 := []LeafDescriptor{
 				{
-					PkScript:    []byte("script3"),
-					Amount:      3000,
-					CoSignerKey: key3,
+					PkScript:   []byte("script3"),
+					Amount:     3000,
+					SigningKey: key3,
 				},
 			}
 
@@ -1211,14 +1211,14 @@ func TestNodeConstructors(t *testing.T) {
 		// Create two leaves with the same cosigner key.
 		leaves := []LeafDescriptor{
 			{
-				PkScript:    []byte("script1"),
-				Amount:      1000,
-				CoSignerKey: key1,
+				PkScript:   []byte("script1"),
+				Amount:     1000,
+				SigningKey: key1,
 			},
 			{
-				PkScript:    []byte("script2"),
-				Amount:      2000,
-				CoSignerKey: key1, // Same key!
+				PkScript:   []byte("script2"),
+				Amount:     2000,
+				SigningKey: key1, // Same key!
 			},
 		}
 

--- a/lib/tree/tree_structure.go
+++ b/lib/tree/tree_structure.go
@@ -9,7 +9,7 @@ import (
 
 // StructureConfig contains configuration for building tree structure.
 type StructureConfig struct {
-	// OperatorKey is the operator's public key (included in all cosigner
+	// OperatorKey is the operator's public key (included in all signer
 	// sets).
 	OperatorKey *btcec.PublicKey
 
@@ -112,14 +112,14 @@ func buildStructureRecursive(leaves []LeafDescriptor,
 
 		children[uint32(i)] = child
 
-		// Collect cosigners from child.
+		// Collect signers from child.
 		allCosigners = append(allCosigners, child.CoSigners...)
 
 		// Sum BTC amounts from children (stored in Node.Amount).
 		totalBtcAmount += child.Amount
 	}
 
-	// Deduplicate cosigners.
+	// Deduplicate signers.
 	allCosigners = UniqueCosigners(allCosigners)
 
 	// Create branch node structure.
@@ -140,12 +140,12 @@ func buildLeafStructure(leaf LeafDescriptor,
 	operatorKey *btcec.PublicKey,
 	leafScripts map[*Node][]byte) (*Node, error) {
 
-	if leaf.CoSignerKey == nil {
-		return nil, fmt.Errorf("leaf cosigner key cannot be nil")
+	if leaf.SigningKey == nil {
+		return nil, fmt.Errorf("leaf signing key cannot be nil")
 	}
 
-	// Leaf cosigners: operator + leaf owner.
-	cosigners := []*btcec.PublicKey{operatorKey, leaf.CoSignerKey}
+	// Leaf signers: operator + leaf tree signing key.
+	cosigners := []*btcec.PublicKey{operatorKey, leaf.SigningKey}
 
 	node := &Node{
 		// Input, Outputs, FinalKey left empty - filled by Materialize.

--- a/lib/tree/tree_test.go
+++ b/lib/tree/tree_test.go
@@ -31,9 +31,9 @@ func TestNewTree(t *testing.T) {
 
 		leaves := []LeafDescriptor{
 			{
-				PkScript:    []byte("vtxo_script"),
-				Amount:      1000,
-				CoSignerKey: ownerKey,
+				PkScript:   []byte("vtxo_script"),
+				Amount:     1000,
+				SigningKey: ownerKey,
 			},
 		}
 
@@ -68,9 +68,9 @@ func TestNewTree(t *testing.T) {
 		for i := range leaves {
 			_, key := createTestKey(t)
 			leaves[i] = LeafDescriptor{
-				PkScript:    []byte("script"),
-				Amount:      1000,
-				CoSignerKey: key,
+				PkScript:   []byte("script"),
+				Amount:     1000,
+				SigningKey: key,
 			}
 		}
 
@@ -104,9 +104,9 @@ func TestNewTree(t *testing.T) {
 		for i := range leaves {
 			_, key := createTestKey(t)
 			leaves[i] = LeafDescriptor{
-				PkScript:    []byte("script"),
-				Amount:      1000,
-				CoSignerKey: key,
+				PkScript:   []byte("script"),
+				Amount:     1000,
+				SigningKey: key,
 			}
 		}
 
@@ -139,9 +139,9 @@ func TestNewTree(t *testing.T) {
 
 		leaves := []LeafDescriptor{
 			{
-				PkScript:    []byte("script"),
-				Amount:      1000,
-				CoSignerKey: ownerKey,
+				PkScript:   []byte("script"),
+				Amount:     1000,
+				SigningKey: ownerKey,
 			},
 		}
 
@@ -160,9 +160,9 @@ func TestNewTree(t *testing.T) {
 
 		leaves := []LeafDescriptor{
 			{
-				PkScript:    []byte("script"),
-				Amount:      1000,
-				CoSignerKey: ownerKey,
+				PkScript:   []byte("script"),
+				Amount:     1000,
+				SigningKey: ownerKey,
 			},
 		}
 
@@ -196,9 +196,9 @@ func TestNewTree(t *testing.T) {
 
 		leaves := []LeafDescriptor{
 			{
-				PkScript:    []byte("script"),
-				Amount:      1000,
-				CoSignerKey: ownerKey,
+				PkScript:   []byte("script"),
+				Amount:     1000,
+				SigningKey: ownerKey,
 			},
 		}
 
@@ -223,9 +223,9 @@ func TestTreeVerify(t *testing.T) {
 
 		leaves := []LeafDescriptor{
 			{
-				PkScript:    []byte("script"),
-				Amount:      1000,
-				CoSignerKey: ownerKey,
+				PkScript:   []byte("script"),
+				Amount:     1000,
+				SigningKey: ownerKey,
 			},
 		}
 
@@ -252,9 +252,9 @@ func TestTreeVerify(t *testing.T) {
 
 		leaves := []LeafDescriptor{
 			{
-				PkScript:    []byte("script"),
-				Amount:      1000,
-				CoSignerKey: ownerKey,
+				PkScript:   []byte("script"),
+				Amount:     1000,
+				SigningKey: ownerKey,
 			},
 		}
 
@@ -295,14 +295,14 @@ func TestTreeExtractPathForCoSigners(t *testing.T) {
 
 		leaves := []LeafDescriptor{
 			{
-				PkScript:    []byte("script1"),
-				Amount:      1000,
-				CoSignerKey: key1,
+				PkScript:   []byte("script1"),
+				Amount:     1000,
+				SigningKey: key1,
 			},
 			{
-				PkScript:    []byte("script2"),
-				Amount:      2000,
-				CoSignerKey: key2,
+				PkScript:   []byte("script2"),
+				Amount:     2000,
+				SigningKey: key2,
 			},
 		}
 
@@ -343,9 +343,9 @@ func TestTreeExtractPathForCoSigners(t *testing.T) {
 
 		leaves := []LeafDescriptor{
 			{
-				PkScript:    []byte("script"),
-				Amount:      1000,
-				CoSignerKey: ownerKey,
+				PkScript:   []byte("script"),
+				Amount:     1000,
+				SigningKey: ownerKey,
 			},
 		}
 
@@ -370,19 +370,19 @@ func TestTreeExtractPathForCoSigners(t *testing.T) {
 
 		leaves := []LeafDescriptor{
 			{
-				PkScript:    []byte("script1"),
-				Amount:      1000,
-				CoSignerKey: key1,
+				PkScript:   []byte("script1"),
+				Amount:     1000,
+				SigningKey: key1,
 			},
 			{
-				PkScript:    []byte("script2"),
-				Amount:      2000,
-				CoSignerKey: key2,
+				PkScript:   []byte("script2"),
+				Amount:     2000,
+				SigningKey: key2,
 			},
 			{
-				PkScript:    []byte("script3"),
-				Amount:      3000,
-				CoSignerKey: key3,
+				PkScript:   []byte("script3"),
+				Amount:     3000,
+				SigningKey: key3,
 			},
 		}
 
@@ -433,9 +433,9 @@ func TestTreeExtractPathForCoSigners(t *testing.T) {
 
 		leaves := []LeafDescriptor{
 			{
-				PkScript:    []byte("script"),
-				Amount:      1000,
-				CoSignerKey: ownerKey,
+				PkScript:   []byte("script"),
+				Amount:     1000,
+				SigningKey: ownerKey,
 			},
 		}
 
@@ -457,9 +457,9 @@ func TestTreeExtractPathForCoSigners(t *testing.T) {
 
 		leaves := []LeafDescriptor{
 			{
-				PkScript:    []byte("script"),
-				Amount:      1000,
-				CoSignerKey: ownerKey,
+				PkScript:   []byte("script"),
+				Amount:     1000,
+				SigningKey: ownerKey,
 			},
 		}
 
@@ -489,9 +489,9 @@ func TestTreeExtractPathForIndices(t *testing.T) {
 		for i := range leaves {
 			_, key := createTestKey(t)
 			leaves[i] = LeafDescriptor{
-				PkScript:    []byte("script"),
-				Amount:      btcutil.Amount(1000 * (i + 1)),
-				CoSignerKey: key,
+				PkScript:   []byte("script"),
+				Amount:     btcutil.Amount(1000 * (i + 1)),
+				SigningKey: key,
 			}
 		}
 
@@ -518,9 +518,9 @@ func TestTreeExtractPathForIndices(t *testing.T) {
 
 		leaves := []LeafDescriptor{
 			{
-				PkScript:    []byte("script"),
-				Amount:      1000,
-				CoSignerKey: ownerKey,
+				PkScript:   []byte("script"),
+				Amount:     1000,
+				SigningKey: ownerKey,
 			},
 		}
 
@@ -543,9 +543,9 @@ func TestTreeExtractPathForIndices(t *testing.T) {
 
 		leaves := []LeafDescriptor{
 			{
-				PkScript:    []byte("script"),
-				Amount:      1000,
-				CoSignerKey: ownerKey,
+				PkScript:   []byte("script"),
+				Amount:     1000,
+				SigningKey: ownerKey,
 			},
 		}
 
@@ -570,9 +570,9 @@ func TestTreeExtractPathForIndices(t *testing.T) {
 		for i := range leaves {
 			_, key := createTestKey(t)
 			leaves[i] = LeafDescriptor{
-				PkScript:    []byte("script"),
-				Amount:      btcutil.Amount(1000 * (i + 1)),
-				CoSignerKey: key,
+				PkScript:   []byte("script"),
+				Amount:     btcutil.Amount(1000 * (i + 1)),
+				SigningKey: key,
 			}
 		}
 
@@ -603,9 +603,9 @@ func TestVerifyVTXOPath(t *testing.T) {
 		vtxoScript := []byte("vtxo_script_1234")
 		leaves := []LeafDescriptor{
 			{
-				PkScript:    vtxoScript,
-				Amount:      1000,
-				CoSignerKey: ownerKey,
+				PkScript:   vtxoScript,
+				Amount:     1000,
+				SigningKey: ownerKey,
 			},
 		}
 
@@ -627,9 +627,9 @@ func TestVerifyVTXOPath(t *testing.T) {
 
 		leaves := []LeafDescriptor{
 			{
-				PkScript:    []byte("actual_script"),
-				Amount:      1000,
-				CoSignerKey: ownerKey,
+				PkScript:   []byte("actual_script"),
+				Amount:     1000,
+				SigningKey: ownerKey,
 			},
 		}
 
@@ -653,9 +653,9 @@ func TestVerifyVTXOPath(t *testing.T) {
 
 		leaves := []LeafDescriptor{
 			{
-				PkScript:    []byte("script"),
-				Amount:      1000,
-				CoSignerKey: ownerKey,
+				PkScript:   []byte("script"),
+				Amount:     1000,
+				SigningKey: ownerKey,
 			},
 		}
 
@@ -678,9 +678,9 @@ func TestVerifyVTXOPath(t *testing.T) {
 
 		leaves := []LeafDescriptor{
 			{
-				PkScript:    []byte("script"),
-				Amount:      1000,
-				CoSignerKey: ownerKey,
+				PkScript:   []byte("script"),
+				Amount:     1000,
+				SigningKey: ownerKey,
 			},
 		}
 
@@ -703,9 +703,9 @@ func TestVerifyVTXOPath(t *testing.T) {
 
 		leaves := []LeafDescriptor{
 			{
-				PkScript:    []byte("script"),
-				Amount:      1000,
-				CoSignerKey: ownerKey,
+				PkScript:   []byte("script"),
+				Amount:     1000,
+				SigningKey: ownerKey,
 			},
 		}
 
@@ -730,14 +730,14 @@ func TestVerifyVTXOPath(t *testing.T) {
 
 		leaves := []LeafDescriptor{
 			{
-				PkScript:    []byte("script1"),
-				Amount:      1000,
-				CoSignerKey: key1,
+				PkScript:   []byte("script1"),
+				Amount:     1000,
+				SigningKey: key1,
 			},
 			{
-				PkScript:    []byte("script2"),
-				Amount:      2000,
-				CoSignerKey: key2,
+				PkScript:   []byte("script2"),
+				Amount:     2000,
+				SigningKey: key2,
 			},
 		}
 
@@ -767,9 +767,9 @@ func TestSubmitTreeSigs(t *testing.T) {
 		for i := range leaves {
 			_, key := createTestKey(t)
 			leaves[i] = LeafDescriptor{
-				PkScript:    []byte("script"),
-				Amount:      1000,
-				CoSignerKey: key,
+				PkScript:   []byte("script"),
+				Amount:     1000,
+				SigningKey: key,
 			}
 		}
 
@@ -809,9 +809,9 @@ func TestSubmitTreeSigs(t *testing.T) {
 
 		leaves := []LeafDescriptor{
 			{
-				PkScript:    []byte("script"),
-				Amount:      1000,
-				CoSignerKey: ownerKey,
+				PkScript:   []byte("script"),
+				Amount:     1000,
+				SigningKey: ownerKey,
 			},
 		}
 
@@ -835,9 +835,9 @@ func TestSubmitTreeSigs(t *testing.T) {
 		for i := range leaves {
 			_, key := createTestKey(t)
 			leaves[i] = LeafDescriptor{
-				PkScript:    []byte("script"),
-				Amount:      1000,
-				CoSignerKey: key,
+				PkScript:   []byte("script"),
+				Amount:     1000,
+				SigningKey: key,
 			}
 		}
 
@@ -869,9 +869,9 @@ func TestTreeMetrics(t *testing.T) {
 
 		leaves := []LeafDescriptor{
 			{
-				PkScript:    []byte("script"),
-				Amount:      1000,
-				CoSignerKey: ownerKey,
+				PkScript:   []byte("script"),
+				Amount:     1000,
+				SigningKey: ownerKey,
 			},
 		}
 
@@ -895,9 +895,9 @@ func TestTreeMetrics(t *testing.T) {
 		for i := range leaves {
 			_, key := createTestKey(t)
 			leaves[i] = LeafDescriptor{
-				PkScript:    []byte("script"),
-				Amount:      1000,
-				CoSignerKey: key,
+				PkScript:   []byte("script"),
+				Amount:     1000,
+				SigningKey: key,
 			}
 		}
 
@@ -922,9 +922,9 @@ func TestTreeMetrics(t *testing.T) {
 		for i := range leaves {
 			_, key := createTestKey(t)
 			leaves[i] = LeafDescriptor{
-				PkScript:    []byte("script"),
-				Amount:      1000,
-				CoSignerKey: key,
+				PkScript:   []byte("script"),
+				Amount:     1000,
+				SigningKey: key,
 			}
 		}
 
@@ -960,9 +960,9 @@ func TestTreePrettyPrint(t *testing.T) {
 
 		leaves := []LeafDescriptor{
 			{
-				PkScript:    []byte("script"),
-				Amount:      1000,
-				CoSignerKey: ownerKey,
+				PkScript:   []byte("script"),
+				Amount:     1000,
+				SigningKey: ownerKey,
 			},
 		}
 
@@ -1008,9 +1008,9 @@ func TestTreeExtractTxids(t *testing.T) {
 
 		leaves := []LeafDescriptor{
 			{
-				PkScript:    []byte("script"),
-				Amount:      1000,
-				CoSignerKey: ownerKey,
+				PkScript:   []byte("script"),
+				Amount:     1000,
+				SigningKey: ownerKey,
 			},
 		}
 
@@ -1038,9 +1038,9 @@ func TestTreeExtractTxids(t *testing.T) {
 		for i := range leaves {
 			_, key := createTestKey(t)
 			leaves[i] = LeafDescriptor{
-				PkScript:    []byte("script"),
-				Amount:      1000,
-				CoSignerKey: key,
+				PkScript:   []byte("script"),
+				Amount:     1000,
+				SigningKey: key,
 			}
 		}
 
@@ -1077,9 +1077,9 @@ func TestTreeExtractTxids(t *testing.T) {
 		for i := range leaves {
 			_, key := createTestKey(t)
 			leaves[i] = LeafDescriptor{
-				PkScript:    []byte("script"),
-				Amount:      1000,
-				CoSignerKey: key,
+				PkScript:   []byte("script"),
+				Amount:     1000,
+				SigningKey: key,
 			}
 		}
 
@@ -1125,9 +1125,9 @@ func TestValidatePath(t *testing.T) {
 
 		leaves := []LeafDescriptor{
 			{
-				PkScript:    []byte("script"),
-				Amount:      1000,
-				CoSignerKey: ownerKey,
+				PkScript:   []byte("script"),
+				Amount:     1000,
+				SigningKey: ownerKey,
 			},
 		}
 
@@ -1138,9 +1138,9 @@ func TestValidatePath(t *testing.T) {
 		require.NoError(t, err)
 
 		expectedLeaf := LeafDescriptor{
-			PkScript:    []byte("script"),
-			Amount:      1000,
-			CoSignerKey: ownerKey,
+			PkScript:   []byte("script"),
+			Amount:     1000,
+			SigningKey: ownerKey,
 		}
 		_, err = tree.ValidatePath(nil, expectedLeaf, operatorKey)
 		require.Error(t, err)
@@ -1156,9 +1156,9 @@ func TestValidatePath(t *testing.T) {
 
 		leaves := []LeafDescriptor{
 			{
-				PkScript:    vtxoScript,
-				Amount:      1000,
-				CoSignerKey: ownerKey,
+				PkScript:   vtxoScript,
+				Amount:     1000,
+				SigningKey: ownerKey,
 			},
 		}
 
@@ -1170,9 +1170,9 @@ func TestValidatePath(t *testing.T) {
 		require.NoError(t, err)
 
 		expectedLeaf := LeafDescriptor{
-			PkScript:    vtxoScript,
-			Amount:      1000,
-			CoSignerKey: ownerKey,
+			PkScript:   vtxoScript,
+			Amount:     1000,
+			SigningKey: ownerKey,
 		}
 		clientTree, err := tree.ValidatePath(
 			ownerKey, expectedLeaf, operatorKey,
@@ -1194,9 +1194,9 @@ func TestValidatePath(t *testing.T) {
 
 		leaves := []LeafDescriptor{
 			{
-				PkScript:    vtxoScript,
-				Amount:      1000,
-				CoSignerKey: ownerKey,
+				PkScript:   vtxoScript,
+				Amount:     1000,
+				SigningKey: ownerKey,
 			},
 		}
 
@@ -1209,9 +1209,9 @@ func TestValidatePath(t *testing.T) {
 
 		// Use wrong amount to trigger validation error.
 		expectedLeaf := LeafDescriptor{
-			PkScript:    vtxoScript,
-			Amount:      2000,
-			CoSignerKey: ownerKey,
+			PkScript:   vtxoScript,
+			Amount:     2000,
+			SigningKey: ownerKey,
 		}
 		_, err = tree.ValidatePath(ownerKey, expectedLeaf, operatorKey)
 		require.Error(t, err)
@@ -1228,9 +1228,9 @@ func TestValidatePath(t *testing.T) {
 
 		leaves := []LeafDescriptor{
 			{
-				PkScript:    vtxoScript,
-				Amount:      1000,
-				CoSignerKey: ownerKey,
+				PkScript:   vtxoScript,
+				Amount:     1000,
+				SigningKey: ownerKey,
 			},
 		}
 
@@ -1242,9 +1242,9 @@ func TestValidatePath(t *testing.T) {
 		require.NoError(t, err)
 
 		expectedLeaf := LeafDescriptor{
-			PkScript:    vtxoScript,
-			Amount:      1000,
-			CoSignerKey: ownerKey,
+			PkScript:   vtxoScript,
+			Amount:     1000,
+			SigningKey: ownerKey,
 		}
 
 		// Use wrong operator key to trigger validation error.
@@ -1280,9 +1280,9 @@ func TestValidateAndSubmitSignatures(t *testing.T) {
 
 		leaves := []LeafDescriptor{
 			{
-				PkScript:    []byte("script"),
-				Amount:      1000,
-				CoSignerKey: ownerKey,
+				PkScript:   []byte("script"),
+				Amount:     1000,
+				SigningKey: ownerKey,
 			},
 		}
 
@@ -1306,9 +1306,9 @@ func TestValidateAndSubmitSignatures(t *testing.T) {
 
 		leaves := []LeafDescriptor{
 			{
-				PkScript:    []byte("script"),
-				Amount:      1000,
-				CoSignerKey: ownerKey,
+				PkScript:   []byte("script"),
+				Amount:     1000,
+				SigningKey: ownerKey,
 			},
 		}
 

--- a/lib/tx/forfeit_test.go
+++ b/lib/tx/forfeit_test.go
@@ -43,13 +43,14 @@ func TestForfeitTransactionFlow(t *testing.T) {
 	vtxoAmount := btcutil.Amount(5_000)
 
 	vtxoDesc, err := tree.NewVTXODescriptor(
-		vtxoAmount, clientKey, operatorKey, exitDelay,
+		vtxoAmount, clientKey, operatorKey, clientKey,
+		exitDelay,
 	)
 	require.NoError(t, err)
 
 	batchOutput, err := tree.BuildBatchOutput(
-		[]tree.VTXODescriptor{*vtxoDesc}, operatorKey, sweepKey,
-		exitDelay,
+		[]tree.VTXODescriptor{*vtxoDesc}, operatorKey,
+		sweepKey, exitDelay,
 	)
 	require.NoError(t, err)
 
@@ -59,7 +60,8 @@ func TestForfeitTransactionFlow(t *testing.T) {
 	}
 
 	vtxoTree, err := tree.BuildVTXOTree(
-		batchOutpoint, batchOutput, []tree.VTXODescriptor{*vtxoDesc},
+		batchOutpoint, batchOutput,
+		[]tree.VTXODescriptor{*vtxoDesc},
 		operatorKey, sweepKey, exitDelay, 2,
 	)
 	require.NoError(t, err)

--- a/lib/types/boarding.go
+++ b/lib/types/boarding.go
@@ -11,6 +11,13 @@ import (
 	"github.com/lightningnetwork/lnd/keychain"
 )
 
+// VTXOOwnerKeyFamily is the key family used for long-lived VTXO owner
+// keys. Owner keys are committed to the VTXO output script and must persist
+// across operator term rotations. This is distinct from the MuSig2
+// tree-signing key family (keychain.KeyFamilyMultiSig) used during round
+// construction.
+const VTXOOwnerKeyFamily keychain.KeyFamily = 44
+
 // OperatorTerms holds the information that the operator will share with
 // clients. It communicates the server's terms to the client.
 type OperatorTerms struct {
@@ -115,9 +122,15 @@ type VTXORequest struct {
 	// of the VTXO.
 	Expiry uint32
 
-	// ClientKey is the public key of the client used in the construction
-	// of the collaborative spend path of the VTXO.
-	ClientKey *btcec.PublicKey
+	// ClientKey is the owner's key descriptor for the VTXO. Only the
+	// public key is sent on the wire; the key locator is preserved locally
+	// when the client owns the resulting VTXO.
+	ClientKey keychain.KeyDescriptor
+
+	// OwnsClientKey reports whether this client owns the VTXO owner key and
+	// should persist the created VTXO locally once the round confirms.
+	// This is local-only metadata and is not sent on the wire.
+	OwnsClientKey bool
 
 	// OperatorKey is the public key of the operator used in the
 	// construction of the collaborative spend path of the VTXO.

--- a/lib/types/boarding.go
+++ b/lib/types/boarding.go
@@ -110,6 +110,9 @@ type ForfeitRequest struct {
 	Amount btcutil.Amount
 }
 
+// VTXORequest is the wire message describing a VTXO the client wants to
+// receive in a round. It includes the ephemeral signing key because the
+// server needs it for tree construction.
 type VTXORequest struct {
 	// Amount is the amount of satoshis to lock in the VTXO.
 	Amount btcutil.Amount
@@ -118,28 +121,28 @@ type VTXORequest struct {
 	// both a collaborative and unilateral spend path.
 	PkScript []byte
 
-	// Expiry is the CSV delay used in the unilateral timeout script path
-	// of the VTXO.
+	// Expiry is the CSV delay used in the unilateral timeout script
+	// path of the VTXO.
 	Expiry uint32
 
-	// ClientKey is the owner's key descriptor for the VTXO. Only the
-	// public key is sent on the wire; the key locator is preserved locally
-	// when the client owns the resulting VTXO.
-	ClientKey keychain.KeyDescriptor
+	// OwnerKey is the owner's key descriptor for the VTXO. Only
+	// the public key is sent on the wire; the key locator is
+	// preserved locally when the client owns the resulting VTXO.
+	OwnerKey keychain.KeyDescriptor
 
-	// OwnsClientKey reports whether this client owns the VTXO owner key and
-	// should persist the created VTXO locally once the round confirms.
-	// This is local-only metadata and is not sent on the wire.
-	OwnsClientKey bool
+	// IsOwner reports whether this client controls the VTXO owner
+	// key and should persist the created VTXO locally once the
+	// round confirms. This is local-only metadata and is not sent
+	// on the wire.
+	IsOwner bool
 
 	// OperatorKey is the public key of the operator used in the
 	// construction of the collaborative spend path of the VTXO.
 	OperatorKey *btcec.PublicKey
 
-	// SigningKey is the key descriptor that the client will use in the
-	// building of the VTXO tree during Musig2 signing sessions. We use
-	// keychain.KeyDescriptor instead of just *btcec.PublicKey because we
-	// need the key locator for signing operations.
+	// SigningKey is the ephemeral MuSig2 tree signing key for this
+	// round. Only the public key is sent on the wire; the key
+	// locator is preserved locally for signing operations.
 	SigningKey keychain.KeyDescriptor
 }
 

--- a/lib/types/codec.go
+++ b/lib/types/codec.go
@@ -648,10 +648,12 @@ func decodeJoinAuthVTXORequest(raw []byte) (*VTXORequest, error) {
 	}
 
 	return &VTXORequest{
-		Amount:      btcutil.Amount(amount),
-		PkScript:    bytes.Clone(script),
-		Expiry:      uint32(expiry),
-		ClientKey:   clientPubKey,
+		Amount:   btcutil.Amount(amount),
+		PkScript: bytes.Clone(script),
+		Expiry:   uint32(expiry),
+		ClientKey: keychain.KeyDescriptor{
+			PubKey: clientPubKey,
+		},
 		OperatorKey: operatorPubKey,
 		SigningKey: keychain.KeyDescriptor{
 			PubKey: signingPubKey,
@@ -1031,7 +1033,7 @@ func encodeJoinAuthVTXORequest(req *VTXORequest) ([]byte, error) {
 	script := bytes.Clone(req.PkScript)
 	expiry := uint64(req.Expiry)
 
-	clientKey, err := encodeJoinAuthPubKey(req.ClientKey)
+	clientKey, err := encodeJoinAuthPubKey(req.ClientKey.PubKey)
 	if err != nil {
 		return nil, fmt.Errorf("client key: %w", err)
 	}

--- a/lib/types/codec.go
+++ b/lib/types/codec.go
@@ -651,7 +651,7 @@ func decodeJoinAuthVTXORequest(raw []byte) (*VTXORequest, error) {
 		Amount:   btcutil.Amount(amount),
 		PkScript: bytes.Clone(script),
 		Expiry:   uint32(expiry),
-		ClientKey: keychain.KeyDescriptor{
+		OwnerKey: keychain.KeyDescriptor{
 			PubKey: clientPubKey,
 		},
 		OperatorKey: operatorPubKey,
@@ -1033,7 +1033,7 @@ func encodeJoinAuthVTXORequest(req *VTXORequest) ([]byte, error) {
 	script := bytes.Clone(req.PkScript)
 	expiry := uint64(req.Expiry)
 
-	clientKey, err := encodeJoinAuthPubKey(req.ClientKey.PubKey)
+	clientKey, err := encodeJoinAuthPubKey(req.OwnerKey.PubKey)
 	if err != nil {
 		return nil, fmt.Errorf("client key: %w", err)
 	}

--- a/lib/types/codec_test.go
+++ b/lib/types/codec_test.go
@@ -321,8 +321,8 @@ func requireJoinRoundAuthRequestEqual(t *testing.T, expected *JoinRoundRequest,
 		require.Equal(t, expectedReq.PkScript, actualReq.PkScript)
 		require.Equal(t, expectedReq.Expiry, actualReq.Expiry)
 		require.Equal(
-			t, expectedReq.ClientKey.SerializeCompressed(),
-			actualReq.ClientKey.SerializeCompressed(),
+			t, expectedReq.ClientKey.PubKey.SerializeCompressed(),
+			actualReq.ClientKey.PubKey.SerializeCompressed(),
 		)
 		require.Equal(
 			t, expectedReq.OperatorKey.SerializeCompressed(),
@@ -416,10 +416,12 @@ func testJoinRoundAuthRequest(t *testing.T) *JoinRoundRequest {
 		},
 		VTXOReqs: []*VTXORequest{
 			{
-				Amount:      25_000,
-				PkScript:    []byte{0x51, 0x20, 0x11},
-				Expiry:      288,
-				ClientKey:   clientKey,
+				Amount:   25_000,
+				PkScript: []byte{0x51, 0x20, 0x11},
+				Expiry:   288,
+				ClientKey: keychain.KeyDescriptor{
+					PubKey: clientKey,
+				},
 				OperatorKey: operatorKey,
 				SigningKey: keychain.KeyDescriptor{
 					PubKey: signingKey,

--- a/lib/types/codec_test.go
+++ b/lib/types/codec_test.go
@@ -321,8 +321,8 @@ func requireJoinRoundAuthRequestEqual(t *testing.T, expected *JoinRoundRequest,
 		require.Equal(t, expectedReq.PkScript, actualReq.PkScript)
 		require.Equal(t, expectedReq.Expiry, actualReq.Expiry)
 		require.Equal(
-			t, expectedReq.ClientKey.PubKey.SerializeCompressed(),
-			actualReq.ClientKey.PubKey.SerializeCompressed(),
+			t, expectedReq.OwnerKey.PubKey.SerializeCompressed(),
+			actualReq.OwnerKey.PubKey.SerializeCompressed(),
 		)
 		require.Equal(
 			t, expectedReq.OperatorKey.SerializeCompressed(),
@@ -419,7 +419,7 @@ func testJoinRoundAuthRequest(t *testing.T) *JoinRoundRequest {
 				Amount:   25_000,
 				PkScript: []byte{0x51, 0x20, 0x11},
 				Expiry:   288,
-				ClientKey: keychain.KeyDescriptor{
+				OwnerKey: keychain.KeyDescriptor{
 					PubKey: clientKey,
 				},
 				OperatorKey: operatorKey,

--- a/oor/actor_drive_event_integration_test.go
+++ b/oor/actor_drive_event_integration_test.go
@@ -239,7 +239,7 @@ func TestOORDurableBehaviorDriveIncomingHandledNotifiesVTXOManager(
 	desc, err := BuildIncomingVTXODescriptor(
 		arkPSBT, IncomingVTXOConfig{
 			OutputIndex: recipients[0].OutputIndex,
-			ClientKey: keychain.KeyDescriptor{
+			OwnerKey: keychain.KeyDescriptor{
 				PubKey: recipientKey.PubKey(),
 			},
 			OperatorKey: operatorKey,
@@ -315,7 +315,7 @@ func TestOORDurableBehaviorDriveIncomingHandledReloadsFromStore(
 	desc, err := BuildIncomingVTXODescriptor(
 		arkPSBT, IncomingVTXOConfig{
 			OutputIndex: recipients[0].OutputIndex,
-			ClientKey: keychain.KeyDescriptor{
+			OwnerKey: keychain.KeyDescriptor{
 				PubKey: recipientKey.PubKey(),
 			},
 			OperatorKey: operatorKey,

--- a/oor/ark_sign.go
+++ b/oor/ark_sign.go
@@ -162,7 +162,7 @@ func signArkPSBTInput(signer input.Signer, arkPSBT *psbt.Packet,
 	// Pass the full KeyDescriptor (including KeyLocator) so
 	// signers that require the locator can find the private key.
 	signDesc := &input.SignDescriptor{
-		KeyDesc:    in.VTXO.ClientKey,
+		KeyDesc:    in.VTXO.OwnerKey,
 		SignMethod: input.TaprootScriptSpendSignMethod,
 		Output: &wire.TxOut{
 			Value:    witnessUtxo.Value,
@@ -187,7 +187,7 @@ func signArkPSBTInput(signer input.Signer, arkPSBT *psbt.Packet,
 	}
 
 	return psbtutil.AddTaprootScriptSpendSig(
-		pInput, in.VTXO.ClientKey.PubKey,
+		pInput, in.VTXO.OwnerKey.PubKey,
 		collabLeaf.Script, sigBytes, signDesc.HashType,
 	)
 }

--- a/oor/checkpoint_sign.go
+++ b/oor/checkpoint_sign.go
@@ -368,7 +368,7 @@ func signCheckpointPSBT(signer input.Signer, in *TransferInput,
 			Output:    prevOut,
 			TapScript: in.VTXO.TapScript,
 		},
-		in.VTXO.ClientKey,
+		in.VTXO.OwnerKey,
 		0,
 		sigHashes,
 		prevFetcher,
@@ -393,7 +393,7 @@ func signCheckpointPSBT(signer input.Signer, in *TransferInput,
 	}
 
 	err = psbtutil.AddTaprootScriptSpendSig(
-		&checkpoint.Inputs[0], in.VTXO.ClientKey.PubKey,
+		&checkpoint.Inputs[0], in.VTXO.OwnerKey.PubKey,
 		spendInfo.WitnessScript, sigBytes, signDesc.HashType,
 	)
 	if err != nil {
@@ -401,7 +401,7 @@ func signCheckpointPSBT(signer input.Signer, in *TransferInput,
 	}
 
 	sigRec, err := findTaprootScriptSpendSig(
-		&checkpoint.Inputs[0], in.VTXO.ClientKey.PubKey,
+		&checkpoint.Inputs[0], in.VTXO.OwnerKey.PubKey,
 		spendInfo.WitnessScript,
 	)
 	if err != nil {

--- a/oor/incoming_vtxo.go
+++ b/oor/incoming_vtxo.go
@@ -55,8 +55,8 @@ type IncomingVTXOConfig struct {
 	// OutputIndex is the Ark tx output index being materialized.
 	OutputIndex uint32
 
-	// ClientKey is the recipient key descriptor that controls this VTXO.
-	ClientKey keychain.KeyDescriptor
+	// OwnerKey is the recipient key descriptor that controls this VTXO.
+	OwnerKey keychain.KeyDescriptor
 
 	// OperatorKey is the operator public key used by the collaborative
 	// spend path.
@@ -83,7 +83,7 @@ func BuildIncomingVTXODescriptor(ark *psbt.Packet,
 	case ark == nil || ark.UnsignedTx == nil:
 		return nil, fmt.Errorf("ark psbt must be provided")
 
-	case cfg.ClientKey.PubKey == nil:
+	case cfg.OwnerKey.PubKey == nil:
 		return nil, fmt.Errorf("client key must be provided")
 
 	case cfg.OperatorKey == nil:
@@ -119,14 +119,14 @@ func BuildIncomingVTXODescriptor(ark *psbt.Packet,
 	}
 
 	tapscript, err := scripts.VTXOTapScript(
-		cfg.ClientKey.PubKey, cfg.OperatorKey, cfg.ExitDelay,
+		cfg.OwnerKey.PubKey, cfg.OperatorKey, cfg.ExitDelay,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("derive vtxo tapscript: %w", err)
 	}
 
 	tapKey, err := scripts.VTXOTapKey(
-		cfg.ClientKey.PubKey, cfg.OperatorKey, cfg.ExitDelay,
+		cfg.OwnerKey.PubKey, cfg.OperatorKey, cfg.ExitDelay,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("derive vtxo tapkey: %w", err)
@@ -151,7 +151,7 @@ func BuildIncomingVTXODescriptor(ark *psbt.Packet,
 		},
 		Amount:         btcutil.Amount(out.Value),
 		PkScript:       out.PkScript,
-		ClientKey:      cfg.ClientKey,
+		OwnerKey:       cfg.OwnerKey,
 		OperatorKey:    cfg.OperatorKey,
 		TapScript:      tapscript,
 		TreePath:       cfg.Metadata.TreePath,

--- a/oor/incoming_vtxo_test.go
+++ b/oor/incoming_vtxo_test.go
@@ -22,7 +22,7 @@ func TestBuildIncomingVTXODescriptorChainDepth(t *testing.T) {
 	desc, err := BuildIncomingVTXODescriptor(arkPSBT,
 		IncomingVTXOConfig{
 			OutputIndex: recipients[0].OutputIndex,
-			ClientKey: keychain.KeyDescriptor{
+			OwnerKey: keychain.KeyDescriptor{
 				PubKey: recipientKey.PubKey(),
 			},
 			OperatorKey: operatorKey,
@@ -54,7 +54,7 @@ func TestBuildIncomingVTXODescriptorZeroChainDepth(t *testing.T) {
 	desc, err := BuildIncomingVTXODescriptor(arkPSBT,
 		IncomingVTXOConfig{
 			OutputIndex: recipients[0].OutputIndex,
-			ClientKey: keychain.KeyDescriptor{
+			OwnerKey: keychain.KeyDescriptor{
 				PubKey: recipientKey.PubKey(),
 			},
 			OperatorKey: operatorKey,

--- a/oor/local_persistence_handler.go
+++ b/oor/local_persistence_handler.go
@@ -393,7 +393,7 @@ func (h *LocalPersistenceOutboxHandler) materializeIncoming(
 		desc, err := BuildIncomingVTXODescriptor(msg.ArkPSBT,
 			IncomingVTXOConfig{
 				OutputIndex: recipient.OutputIndex,
-				ClientKey:   clientKey,
+				OwnerKey:    clientKey,
 				OperatorKey: h.OperatorKey,
 				ExitDelay:   h.ExitDelay,
 				Metadata:    metadata,

--- a/oor/outbox_messages.go
+++ b/oor/outbox_messages.go
@@ -116,7 +116,7 @@ func (m *SendSubmitPackageRequest) ToProto() fn.Result[proto.Message] {
 	for _, ti := range m.TransferInputs {
 		descs = append(descs, oorpb.SigningDescriptor{
 			Outpoint:  ti.VTXO.Outpoint,
-			OwnerKey:  ti.VTXO.ClientKey.PubKey,
+			OwnerKey:  ti.VTXO.OwnerKey.PubKey,
 			ExitDelay: ti.VTXO.RelativeExpiry,
 		})
 	}

--- a/oor/receive_session_test.go
+++ b/oor/receive_session_test.go
@@ -115,7 +115,7 @@ func TestReceiveSessionNotifiesThenQueriesMetadata(t *testing.T) {
 	desc, err := BuildIncomingVTXODescriptor(queryMsg.ArkPSBT,
 		IncomingVTXOConfig{
 			OutputIndex: queryMsg.Recipients[0].OutputIndex,
-			ClientKey: keychain.KeyDescriptor{
+			OwnerKey: keychain.KeyDescriptor{
 				PubKey: recipientKey.PubKey(),
 			},
 			OperatorKey: policy.OperatorKey,

--- a/oor/test_helpers_test.go
+++ b/oor/test_helpers_test.go
@@ -46,7 +46,7 @@ func newTestTransferInput(t *testing.T, ownerKey *btcec.PrivateKey,
 			Outpoint: outpoint,
 			Amount:   amount,
 			PkScript: pkScript,
-			ClientKey: keychain.KeyDescriptor{
+			OwnerKey: keychain.KeyDescriptor{
 				PubKey: ownerKey.PubKey(),
 			},
 			OperatorKey:    operatorKey,

--- a/oor/transfer_input_snapshot.go
+++ b/oor/transfer_input_snapshot.go
@@ -67,9 +67,9 @@ func (i *TransferInput) ToSnapshot() (*TransferInputSnapshot, error) {
 	return &TransferInputSnapshot{
 		Outpoint:        i.VTXO.Outpoint,
 		AmountSat:       int64(i.VTXO.Amount),
-		ClientKeyFamily: int32(i.VTXO.ClientKey.KeyLocator.Family),
-		ClientKeyIndex:  i.VTXO.ClientKey.KeyLocator.Index,
-		ClientPubKey:    i.VTXO.ClientKey.PubKey.SerializeCompressed(),
+		ClientKeyFamily: int32(i.VTXO.OwnerKey.KeyLocator.Family),
+		ClientKeyIndex:  i.VTXO.OwnerKey.KeyLocator.Index,
+		ClientPubKey:    i.VTXO.OwnerKey.PubKey.SerializeCompressed(),
 		OperatorPubKey:  operatorKey.SerializeCompressed(),
 		ExitDelay:       exitDelay,
 		OwnerLeafScript: i.OwnerLeafScript,
@@ -138,7 +138,7 @@ func TransferInputFromSnapshot(snap *TransferInputSnapshot) (TransferInput,
 		Outpoint: snap.Outpoint,
 		Amount:   btcutil.Amount(snap.AmountSat),
 		PkScript: pkScript,
-		ClientKey: keychain.KeyDescriptor{
+		OwnerKey: keychain.KeyDescriptor{
 			KeyLocator: keychain.KeyLocator{
 				Family: keychain.KeyFamily(
 					snap.ClientKeyFamily,

--- a/oor/transfer_input_snapshot_test.go
+++ b/oor/transfer_input_snapshot_test.go
@@ -47,7 +47,7 @@ func TestTransferInputSnapshotRoundTrip(t *testing.T) {
 			},
 			Amount:   btcutil.Amount(5000),
 			PkScript: pkScript,
-			ClientKey: keychain.KeyDescriptor{
+			OwnerKey: keychain.KeyDescriptor{
 				KeyLocator: keychain.KeyLocator{
 					Family: 1,
 					Index:  2,
@@ -67,11 +67,11 @@ func TestTransferInputSnapshotRoundTrip(t *testing.T) {
 	require.NotNil(t, snap)
 	require.Equal(t, in.VTXO.Outpoint, snap.Outpoint)
 	require.Equal(t, int64(in.VTXO.Amount), snap.AmountSat)
-	require.Equal(t, int32(in.VTXO.ClientKey.KeyLocator.Family),
+	require.Equal(t, int32(in.VTXO.OwnerKey.KeyLocator.Family),
 		snap.ClientKeyFamily)
-	require.Equal(t, in.VTXO.ClientKey.KeyLocator.Index,
+	require.Equal(t, in.VTXO.OwnerKey.KeyLocator.Index,
 		snap.ClientKeyIndex)
-	require.Equal(t, in.VTXO.ClientKey.PubKey.SerializeCompressed(),
+	require.Equal(t, in.VTXO.OwnerKey.PubKey.SerializeCompressed(),
 		snap.ClientPubKey)
 	require.Equal(t, in.VTXO.OperatorKey.SerializeCompressed(),
 		snap.OperatorPubKey)
@@ -84,10 +84,10 @@ func TestTransferInputSnapshotRoundTrip(t *testing.T) {
 	require.Equal(t, in.VTXO.Outpoint, rebuilt.VTXO.Outpoint)
 	require.Equal(t, in.VTXO.Amount, rebuilt.VTXO.Amount)
 	require.Equal(t, in.VTXO.PkScript, rebuilt.VTXO.PkScript)
-	require.Equal(t, in.VTXO.ClientKey.KeyLocator,
-		rebuilt.VTXO.ClientKey.KeyLocator)
-	require.Equal(t, in.VTXO.ClientKey.PubKey.SerializeCompressed(),
-		rebuilt.VTXO.ClientKey.PubKey.SerializeCompressed())
+	require.Equal(t, in.VTXO.OwnerKey.KeyLocator,
+		rebuilt.VTXO.OwnerKey.KeyLocator)
+	require.Equal(t, in.VTXO.OwnerKey.PubKey.SerializeCompressed(),
+		rebuilt.VTXO.OwnerKey.PubKey.SerializeCompressed())
 	require.Equal(t, in.VTXO.OperatorKey.SerializeCompressed(),
 		rebuilt.VTXO.OperatorKey.SerializeCompressed())
 	require.Equal(t, in.VTXO.RelativeExpiry, rebuilt.VTXO.RelativeExpiry)

--- a/oor/transfer_inputs.go
+++ b/oor/transfer_inputs.go
@@ -54,7 +54,7 @@ func (i *TransferInput) Validate() error {
 	case i.VTXO.TapScript == nil:
 		return fmt.Errorf("vtxo tapscript must be provided")
 
-	case i.VTXO.ClientKey.PubKey == nil:
+	case i.VTXO.OwnerKey.PubKey == nil:
 		return fmt.Errorf("vtxo client key must be provided")
 
 	case len(i.OwnerLeafScript) == 0:

--- a/round/actor.go
+++ b/round/actor.go
@@ -97,28 +97,20 @@ func (e *RegisterIntentRequest) MessageType() string {
 	return "RegisterIntentRequest"
 }
 
-// buildVTXORequestFromRefresh constructs a types.VTXORequest from a refresh
-// request. Refreshes keep the existing owner key but always derive a fresh
-// tree-signing key for the new round.
-func (a *RoundClientActor) buildVTXORequestFromRefresh(
-	ctx context.Context, req *RefreshVTXORequest) (*types.VTXORequest,
-	error) {
+// buildVTXOIntentFromRefresh constructs a VTXOIntent from a refresh
+// request. Refreshes keep the existing owner key. Signing keys are
+// derived later by the FSM at registration time.
+func (a *RoundClientActor) buildVTXOIntentFromRefresh(
+	ctx context.Context,
+	req *RefreshVTXORequest) (*VTXOIntent, error) {
 
-	signingKey, err := a.cfg.Wallet.DeriveNextKey(
-		ctx, keychain.KeyFamilyMultiSig,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("derive refresh signing key: %w", err)
-	}
-
-	return &types.VTXORequest{
-		Amount:        btcutil.Amount(req.Amount),
-		PkScript:      req.PkScript,
-		Expiry:        req.Expiry,
-		ClientKey:     req.NewVTXOKey,
-		OwnsClientKey: true,
-		OperatorKey:   req.OperatorKey,
-		SigningKey:    *signingKey,
+	return &VTXOIntent{
+		Amount:      btcutil.Amount(req.Amount),
+		PkScript:    req.PkScript,
+		Expiry:      req.Expiry,
+		OwnerKey:    req.NewVTXOKey,
+		IsOwner:     true,
+		OperatorKey: req.OperatorKey,
 	}, nil
 }
 
@@ -834,12 +826,17 @@ func (a *RoundClientActor) Receive(ctx context.Context,
 	// If either type gains new fields, this adapter must be updated
 	// to carry them through.
 	case *actormsg.RegisterIntentMsg:
+		intents := make([]VTXOIntent, len(m.VTXOs))
+		for i, v := range m.VTXOs {
+			intents[i] = vtxoRequestToIntent(v)
+		}
+
 		return a.handleRegisterIntent(ctx, &RegisterIntentRequest{
-			Package: &IntentPackage{Intents: Intents{
+			Package: &IntentPackage{
 				Forfeits: m.Forfeits,
-				VTXOs:    m.VTXOs,
+				VTXOs:    intents,
 				Leaves:   m.Leaves,
-			}},
+			},
 		})
 
 	case *RefreshVTXORequest:
@@ -907,9 +904,9 @@ func (a *RoundClientActor) handleWalletBoardingConfirmed(ctx context.Context,
 	}
 
 	// Send the boarding intent to the FSM as an IntentPackage.
-	pkg := &IntentPackage{Intents: Intents{
+	pkg := &IntentPackage{
 		Boarding: []BoardingIntent{intent},
-	}}
+	}
 	err = a.askEventAndProcessOutbox(ctx, roundFSM, pkg)
 	if err != nil {
 		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
@@ -972,7 +969,7 @@ func (a *RoundClientActor) handleVTXORequests(ctx context.Context,
 		))
 	}
 
-	requests := make([]types.VTXORequest, 0, len(msg.Amounts))
+	requests := make([]VTXOIntent, 0, len(msg.Amounts))
 	for i, amount := range msg.Amounts {
 		if amount <= 0 {
 			return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
@@ -980,7 +977,7 @@ func (a *RoundClientActor) handleVTXORequests(ctx context.Context,
 			))
 		}
 
-		req, err := a.buildVTXORequest(ctx, amount)
+		req, err := a.buildVTXOIntent(ctx, amount)
 		if err != nil {
 			return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 				"build VTXO request %d: %w", i, err,
@@ -1008,9 +1005,9 @@ func (a *RoundClientActor) handleVTXORequests(ctx context.Context,
 		}
 	}
 
-	pkg := &IntentPackage{Intents: Intents{
+	pkg := &IntentPackage{
 		VTXOs: requests,
-	}}
+	}
 
 	err = a.askEventAndProcessOutbox(ctx, roundFSM, pkg)
 	if err != nil {
@@ -1051,9 +1048,13 @@ func (a *RoundClientActor) handleVTXORequestsReceived(ctx context.Context,
 		}
 	}
 
-	pkg := &IntentPackage{Intents: Intents{
-		VTXOs: req.Requests,
-	}}
+	intents := make([]VTXOIntent, len(req.Requests))
+	for i, v := range req.Requests {
+		intents[i] = vtxoRequestToIntent(v)
+	}
+	pkg := &IntentPackage{
+		VTXOs: intents,
+	}
 	err := a.askEventAndProcessOutbox(ctx, roundFSM, pkg)
 	if err != nil {
 		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
@@ -1063,10 +1064,25 @@ func (a *RoundClientActor) handleVTXORequestsReceived(ctx context.Context,
 	return fn.Ok[actormsg.RoundActorResp](nil)
 }
 
-// buildVTXORequest derives distinct owner and tree-signing keys and constructs
-// a VTXO request for the provided amount.
-func (a *RoundClientActor) buildVTXORequest(ctx context.Context,
-	amount btcutil.Amount) (*types.VTXORequest, error) {
+// buildVTXORequest derives an owner key and constructs a VTXO request for the
+// provided amount. Signing keys for the tree are handled separately.
+// vtxoRequestToIntent converts a wire-level VTXORequest to a
+// VTXOIntent, discarding the signing key (if any).
+func vtxoRequestToIntent(req types.VTXORequest) VTXOIntent {
+	return VTXOIntent{
+		Amount:      req.Amount,
+		PkScript:    req.PkScript,
+		Expiry:      req.Expiry,
+		OwnerKey:    req.OwnerKey,
+		IsOwner:     req.IsOwner,
+		OperatorKey: req.OperatorKey,
+	}
+}
+
+// buildVTXOIntent derives an owner key and constructs a VTXOIntent for
+// the provided amount. The signing key is derived later by the FSM.
+func (a *RoundClientActor) buildVTXOIntent(ctx context.Context,
+	amount btcutil.Amount) (*VTXOIntent, error) {
 
 	ownerKeyDesc, err := a.cfg.Wallet.DeriveNextKey(
 		ctx, types.VTXOOwnerKeyFamily,
@@ -1075,33 +1091,29 @@ func (a *RoundClientActor) buildVTXORequest(ctx context.Context,
 		return nil, fmt.Errorf("derive owner key: %w", err)
 	}
 
-	signingKeyDesc, err := a.cfg.Wallet.DeriveNextKey(
-		ctx, keychain.KeyFamilyMultiSig,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("derive signing key: %w", err)
-	}
-
 	operatorKey := a.cfg.OperatorTerms.PubKey
 	expiry := a.cfg.OperatorTerms.VTXOExitDelay
 	desc, err := tree.NewVTXODescriptor(
-		amount, ownerKeyDesc.PubKey, operatorKey, expiry,
+		amount, ownerKeyDesc.PubKey, operatorKey, nil, expiry,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("build VTXO descriptor for amount %v, "+
-			"client %x, operator %x, expiry %d: %w",
-			amount, ownerKeyDesc.PubKey.SerializeCompressed(),
-			operatorKey.SerializeCompressed(), expiry, err)
+		return nil, fmt.Errorf(
+			"build VTXO descriptor for amount %v, "+
+				"client %x, operator %x, expiry %d: %w",
+			amount,
+			ownerKeyDesc.PubKey.SerializeCompressed(),
+			operatorKey.SerializeCompressed(),
+			expiry, err,
+		)
 	}
 
-	return &types.VTXORequest{
-		Amount:        amount,
-		PkScript:      desc.PkScript,
-		Expiry:        expiry,
-		ClientKey:     *ownerKeyDesc,
-		OwnsClientKey: true,
-		OperatorKey:   operatorKey,
-		SigningKey:    *signingKeyDesc,
+	return &VTXOIntent{
+		Amount:      amount,
+		PkScript:    desc.PkScript,
+		Expiry:      expiry,
+		OwnerKey:    *ownerKeyDesc,
+		IsOwner:     true,
+		OperatorKey: operatorKey,
 	}, nil
 }
 
@@ -1881,7 +1893,7 @@ func (a *RoundClientActor) handleRefreshVTXORequest(ctx context.Context,
 		}
 	}
 
-	vtxoReq, err := a.buildVTXORequestFromRefresh(ctx, req)
+	vtxoReq, err := a.buildVTXOIntentFromRefresh(ctx, req)
 	if err != nil {
 		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 			"build refresh VTXO request: %w", err,
@@ -1889,13 +1901,13 @@ func (a *RoundClientActor) handleRefreshVTXORequest(ctx context.Context,
 	}
 
 	// Bundle the forfeit input and new VTXO output atomically.
-	pkg := &IntentPackage{Intents: Intents{
+	pkg := &IntentPackage{
 		Forfeits: []types.ForfeitRequest{{
 			VTXOOutpoint: &req.VTXOOutpoint,
 			Amount:       btcutil.Amount(req.Amount),
 		}},
-		VTXOs: []types.VTXORequest{*vtxoReq},
-	}}
+		VTXOs: []VTXOIntent{*vtxoReq},
+	}
 	err = a.askEventAndProcessOutbox(ctx, roundFSM, pkg)
 	if err != nil {
 		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
@@ -2017,7 +2029,7 @@ func (a *RoundClientActor) handleTriggerBoard(ctx context.Context,
 	}
 
 	// Build VTXO requests from the provided amounts.
-	requests := make([]types.VTXORequest, 0, len(cmd.Amounts))
+	requests := make([]VTXOIntent, 0, len(cmd.Amounts))
 	for i, amount := range cmd.Amounts {
 		if amount <= 0 {
 			return fn.Err[actormsg.RoundActorResp](
@@ -2029,7 +2041,7 @@ func (a *RoundClientActor) handleTriggerBoard(ctx context.Context,
 			)
 		}
 
-		req, err := a.buildVTXORequest(ctx, amount)
+		req, err := a.buildVTXOIntent(ctx, amount)
 		if err != nil {
 			return fn.Err[actormsg.RoundActorResp](
 				fmt.Errorf(
@@ -2095,10 +2107,10 @@ func (a *RoundClientActor) handleTriggerBoard(ctx context.Context,
 	}
 
 	// Register the VTXO output requests into the round FSM.
-	pkg := &IntentPackage{Intents: Intents{
+	pkg := &IntentPackage{
 		Boarding: boardingIntents,
 		VTXOs:    requests,
-	}}
+	}
 
 	err = a.askEventAndProcessOutbox(ctx, roundFSM, pkg)
 	if err != nil {

--- a/round/actor.go
+++ b/round/actor.go
@@ -55,9 +55,9 @@ type RefreshVTXORequest struct {
 	// Amount is the VTXO value in satoshis.
 	Amount int64
 
-	// NewVTXOKey is the client's public key for the new VTXO. This is
-	// typically the same as the old VTXO's key but could be fresh.
-	NewVTXOKey *btcec.PublicKey
+	// NewVTXOKey is the owner's key descriptor for the new VTXO. This is
+	// typically the same as the old VTXO's owner key but could be fresh.
+	NewVTXOKey keychain.KeyDescriptor
 
 	// PkScript is the output script for the new VTXO.
 	PkScript []byte
@@ -67,9 +67,6 @@ type RefreshVTXORequest struct {
 
 	// Expiry is the CSV delay for the new VTXO's unilateral exit path.
 	Expiry uint32
-
-	// SigningKey is the key descriptor for signing the new VTXO's tree.
-	SigningKey keychain.KeyDescriptor
 }
 
 // RoundReceivable implements actormsg.RoundReceivable marker interface.
@@ -100,20 +97,29 @@ func (e *RegisterIntentRequest) MessageType() string {
 	return "RegisterIntentRequest"
 }
 
-// buildVTXORequestFromRefresh constructs a types.VTXORequest from a
-// RefreshVTXORequest. The refresh request contains all info needed to create
-// the new VTXO output in the round.
-func buildVTXORequestFromRefresh(
-	req *RefreshVTXORequest) types.VTXORequest {
+// buildVTXORequestFromRefresh constructs a types.VTXORequest from a refresh
+// request. Refreshes keep the existing owner key but always derive a fresh
+// tree-signing key for the new round.
+func (a *RoundClientActor) buildVTXORequestFromRefresh(
+	ctx context.Context, req *RefreshVTXORequest) (*types.VTXORequest,
+	error) {
 
-	return types.VTXORequest{
-		Amount:      btcutil.Amount(req.Amount),
-		PkScript:    req.PkScript,
-		Expiry:      req.Expiry,
-		ClientKey:   req.NewVTXOKey,
-		OperatorKey: req.OperatorKey,
-		SigningKey:  req.SigningKey,
+	signingKey, err := a.cfg.Wallet.DeriveNextKey(
+		ctx, keychain.KeyFamilyMultiSig,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("derive refresh signing key: %w", err)
 	}
+
+	return &types.VTXORequest{
+		Amount:        btcutil.Amount(req.Amount),
+		PkScript:      req.PkScript,
+		Expiry:        req.Expiry,
+		ClientKey:     req.NewVTXOKey,
+		OwnsClientKey: true,
+		OperatorKey:   req.OperatorKey,
+		SigningKey:    *signingKey,
+	}, nil
 }
 
 // makeTimeoutID builds a composite timeout ID from round ID and phase.
@@ -1057,12 +1063,19 @@ func (a *RoundClientActor) handleVTXORequestsReceived(ctx context.Context,
 	return fn.Ok[actormsg.RoundActorResp](nil)
 }
 
-// buildVTXORequest derives a signing key and constructs a VTXO request for
-// the provided amount.
+// buildVTXORequest derives distinct owner and tree-signing keys and constructs
+// a VTXO request for the provided amount.
 func (a *RoundClientActor) buildVTXORequest(ctx context.Context,
 	amount btcutil.Amount) (*types.VTXORequest, error) {
 
-	keyDesc, err := a.cfg.Wallet.DeriveNextKey(
+	ownerKeyDesc, err := a.cfg.Wallet.DeriveNextKey(
+		ctx, types.VTXOOwnerKeyFamily,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("derive owner key: %w", err)
+	}
+
+	signingKeyDesc, err := a.cfg.Wallet.DeriveNextKey(
 		ctx, keychain.KeyFamilyMultiSig,
 	)
 	if err != nil {
@@ -1072,22 +1085,23 @@ func (a *RoundClientActor) buildVTXORequest(ctx context.Context,
 	operatorKey := a.cfg.OperatorTerms.PubKey
 	expiry := a.cfg.OperatorTerms.VTXOExitDelay
 	desc, err := tree.NewVTXODescriptor(
-		amount, keyDesc.PubKey, operatorKey, expiry,
+		amount, ownerKeyDesc.PubKey, operatorKey, expiry,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("build VTXO descriptor for amount %v, "+
 			"client %x, operator %x, expiry %d: %w",
-			amount, keyDesc.PubKey.SerializeCompressed(),
+			amount, ownerKeyDesc.PubKey.SerializeCompressed(),
 			operatorKey.SerializeCompressed(), expiry, err)
 	}
 
 	return &types.VTXORequest{
-		Amount:      amount,
-		PkScript:    desc.PkScript,
-		Expiry:      expiry,
-		ClientKey:   keyDesc.PubKey,
-		OperatorKey: operatorKey,
-		SigningKey:  *keyDesc,
+		Amount:        amount,
+		PkScript:      desc.PkScript,
+		Expiry:        expiry,
+		ClientKey:     *ownerKeyDesc,
+		OwnsClientKey: true,
+		OperatorKey:   operatorKey,
+		SigningKey:    *signingKeyDesc,
 	}, nil
 }
 
@@ -1867,15 +1881,20 @@ func (a *RoundClientActor) handleRefreshVTXORequest(ctx context.Context,
 		}
 	}
 
+	vtxoReq, err := a.buildVTXORequestFromRefresh(ctx, req)
+	if err != nil {
+		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
+			"build refresh VTXO request: %w", err,
+		))
+	}
+
 	// Bundle the forfeit input and new VTXO output atomically.
 	pkg := &IntentPackage{Intents: Intents{
 		Forfeits: []types.ForfeitRequest{{
 			VTXOOutpoint: &req.VTXOOutpoint,
 			Amount:       btcutil.Amount(req.Amount),
 		}},
-		VTXOs: []types.VTXORequest{
-			buildVTXORequestFromRefresh(req),
-		},
+		VTXOs: []types.VTXORequest{*vtxoReq},
 	}}
 	err = a.askEventAndProcessOutbox(ctx, roundFSM, pkg)
 	if err != nil {

--- a/round/actor_harness_test.go
+++ b/round/actor_harness_test.go
@@ -588,6 +588,17 @@ func newActorTestHarness(t *testing.T) *actorTestHarness {
 		PubKey: identifierPrivKey.PubKey(),
 	}, nil)
 
+	// The registration transition derives MuSig2 signing keys.
+	walletMock.On(
+		"DeriveNextKey", mock.Anything,
+		keychain.KeyFamilyMultiSig,
+	).Return(&keychain.KeyDescriptor{
+		PubKey: identifierPrivKey.PubKey(),
+		KeyLocator: keychain.KeyLocator{
+			Family: keychain.KeyFamilyMultiSig,
+		},
+	}, nil)
+
 	operatorTerms := &types.OperatorTerms{
 		PubKey:            operatorPubKey,
 		BoardingExitDelay: 144,
@@ -822,18 +833,6 @@ func (h *actorTestHarness) newTestBoardingIntentWithSuffix(
 	}
 }
 
-// newKeyDescriptor creates a MuSig2 signing key descriptor using the harness's
-// client key.
-func (h *actorTestHarness) newKeyDescriptor() keychain.KeyDescriptor {
-	return keychain.KeyDescriptor{
-		PubKey: h.clientPubKey,
-		KeyLocator: keychain.KeyLocator{
-			Family: keychain.KeyFamilyMultiSig,
-			Index:  0,
-		},
-	}
-}
-
 // newOwnerKeyDescriptor creates a VTXO owner key descriptor using the
 // dedicated owner key family.
 func (h *actorTestHarness) newOwnerKeyDescriptor() keychain.KeyDescriptor {
@@ -920,11 +919,9 @@ func (h *actorTestHarness) serverMessages() []serverconn.ServerConnMsg {
 func (h *actorTestHarness) sendVTXORequests(amounts ...btcutil.Amount) {
 	h.t.Helper()
 
-	// Setup mock to return a key descriptor for each DeriveNextKey call.
+	// Setup mock to return an owner key descriptor for each VTXO.
+	// Signing keys are derived later at registration time by the FSM.
 	for i := range amounts {
-		signingPrivKey, err := btcec.NewPrivateKey()
-		require.NoError(h.t, err)
-
 		ownerKeyDesc := &keychain.KeyDescriptor{
 			PubKey: h.clientPubKey,
 			KeyLocator: keychain.KeyLocator{
@@ -932,21 +929,10 @@ func (h *actorTestHarness) sendVTXORequests(amounts ...btcutil.Amount) {
 				Index:  uint32(i),
 			},
 		}
-		signingKeyDesc := &keychain.KeyDescriptor{
-			PubKey: signingPrivKey.PubKey(),
-			KeyLocator: keychain.KeyLocator{
-				Family: keychain.KeyFamilyMultiSig,
-				Index:  uint32(i),
-			},
-		}
 		h.wallet.On(
 			"DeriveNextKey", mock.Anything,
 			types.VTXOOwnerKeyFamily,
 		).Return(ownerKeyDesc, nil).Once()
-		h.wallet.On(
-			"DeriveNextKey", mock.Anything,
-			keychain.KeyFamilyMultiSig,
-		).Return(signingKeyDesc, nil).Once()
 	}
 
 	msg := &RegisterVTXORequestsRequest{Amounts: amounts}
@@ -954,30 +940,6 @@ func (h *actorTestHarness) sendVTXORequests(amounts ...btcutil.Amount) {
 	require.True(
 		h.t, result.IsOk(), "actor receive failed: %v", result.Err(),
 	)
-}
-
-// expectRefreshSigningKeys wires up fresh MuSig2 signing keys for one or more
-// refresh requests. Refreshes reuse the owner key but must derive a new tree
-// signing key for each round request.
-func (h *actorTestHarness) expectRefreshSigningKeys(count int) {
-	h.t.Helper()
-
-	for i := 0; i < count; i++ {
-		signingPrivKey, err := btcec.NewPrivateKey()
-		require.NoError(h.t, err)
-
-		signingKeyDesc := &keychain.KeyDescriptor{
-			PubKey: signingPrivKey.PubKey(),
-			KeyLocator: keychain.KeyLocator{
-				Family: keychain.KeyFamilyMultiSig,
-				Index:  uint32(i),
-			},
-		}
-		h.wallet.On(
-			"DeriveNextKey", mock.Anything,
-			keychain.KeyFamilyMultiSig,
-		).Return(signingKeyDesc, nil).Once()
-	}
 }
 
 // newTestRound creates a test Round with a unique commitment transaction,

--- a/round/actor_harness_test.go
+++ b/round/actor_harness_test.go
@@ -822,13 +822,25 @@ func (h *actorTestHarness) newTestBoardingIntentWithSuffix(
 	}
 }
 
-// newKeyDescriptor creates a keychain.KeyDescriptor using the harness's client
-// key, useful for creating test ClientVTXO structs.
+// newKeyDescriptor creates a MuSig2 signing key descriptor using the harness's
+// client key.
 func (h *actorTestHarness) newKeyDescriptor() keychain.KeyDescriptor {
 	return keychain.KeyDescriptor{
 		PubKey: h.clientPubKey,
 		KeyLocator: keychain.KeyLocator{
 			Family: keychain.KeyFamilyMultiSig,
+			Index:  0,
+		},
+	}
+}
+
+// newOwnerKeyDescriptor creates a VTXO owner key descriptor using the
+// dedicated owner key family.
+func (h *actorTestHarness) newOwnerKeyDescriptor() keychain.KeyDescriptor {
+	return keychain.KeyDescriptor{
+		PubKey: h.clientPubKey,
+		KeyLocator: keychain.KeyLocator{
+			Family: types.VTXOOwnerKeyFamily,
 			Index:  0,
 		},
 	}
@@ -910,8 +922,52 @@ func (h *actorTestHarness) sendVTXORequests(amounts ...btcutil.Amount) {
 
 	// Setup mock to return a key descriptor for each DeriveNextKey call.
 	for i := range amounts {
-		keyDesc := &keychain.KeyDescriptor{
+		signingPrivKey, err := btcec.NewPrivateKey()
+		require.NoError(h.t, err)
+
+		ownerKeyDesc := &keychain.KeyDescriptor{
 			PubKey: h.clientPubKey,
+			KeyLocator: keychain.KeyLocator{
+				Family: types.VTXOOwnerKeyFamily,
+				Index:  uint32(i),
+			},
+		}
+		signingKeyDesc := &keychain.KeyDescriptor{
+			PubKey: signingPrivKey.PubKey(),
+			KeyLocator: keychain.KeyLocator{
+				Family: keychain.KeyFamilyMultiSig,
+				Index:  uint32(i),
+			},
+		}
+		h.wallet.On(
+			"DeriveNextKey", mock.Anything,
+			types.VTXOOwnerKeyFamily,
+		).Return(ownerKeyDesc, nil).Once()
+		h.wallet.On(
+			"DeriveNextKey", mock.Anything,
+			keychain.KeyFamilyMultiSig,
+		).Return(signingKeyDesc, nil).Once()
+	}
+
+	msg := &RegisterVTXORequestsRequest{Amounts: amounts}
+	result := h.receive(msg)
+	require.True(
+		h.t, result.IsOk(), "actor receive failed: %v", result.Err(),
+	)
+}
+
+// expectRefreshSigningKeys wires up fresh MuSig2 signing keys for one or more
+// refresh requests. Refreshes reuse the owner key but must derive a new tree
+// signing key for each round request.
+func (h *actorTestHarness) expectRefreshSigningKeys(count int) {
+	h.t.Helper()
+
+	for i := 0; i < count; i++ {
+		signingPrivKey, err := btcec.NewPrivateKey()
+		require.NoError(h.t, err)
+
+		signingKeyDesc := &keychain.KeyDescriptor{
+			PubKey: signingPrivKey.PubKey(),
 			KeyLocator: keychain.KeyLocator{
 				Family: keychain.KeyFamilyMultiSig,
 				Index:  uint32(i),
@@ -920,14 +976,8 @@ func (h *actorTestHarness) sendVTXORequests(amounts ...btcutil.Amount) {
 		h.wallet.On(
 			"DeriveNextKey", mock.Anything,
 			keychain.KeyFamilyMultiSig,
-		).Return(keyDesc, nil).Once()
+		).Return(signingKeyDesc, nil).Once()
 	}
-
-	msg := &RegisterVTXORequestsRequest{Amounts: amounts}
-	result := h.receive(msg)
-	require.True(
-		h.t, result.IsOk(), "actor receive failed: %v", result.Err(),
-	)
 }
 
 // newTestRound creates a test Round with a unique commitment transaction,

--- a/round/actor_test.go
+++ b/round/actor_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
@@ -160,14 +161,28 @@ func TestActorStart(t *testing.T) {
 		err := h.start()
 		require.NoError(t, err)
 
-		signingKey := &keychain.KeyDescriptor{
+		signingPrivKey, err := btcec.NewPrivateKey()
+		require.NoError(t, err)
+
+		ownerKey := &keychain.KeyDescriptor{
 			PubKey: h.clientPubKey,
 			KeyLocator: keychain.KeyLocator{
-				Family: keychain.KeyFamilyMultiSig,
+				Family: types.VTXOOwnerKeyFamily,
 				Index:  0,
 			},
 		}
+		signingKey := &keychain.KeyDescriptor{
+			PubKey: signingPrivKey.PubKey(),
+			KeyLocator: keychain.KeyLocator{
+				Family: keychain.KeyFamilyMultiSig,
+				Index:  1,
+			},
+		}
 
+		h.wallet.On(
+			"DeriveNextKey", mock.Anything,
+			types.VTXOOwnerKeyFamily,
+		).Return(ownerKey, nil).Once()
 		h.wallet.On(
 			"DeriveNextKey", mock.Anything,
 			keychain.KeyFamilyMultiSig,
@@ -201,7 +216,7 @@ func TestActorStart(t *testing.T) {
 		require.Len(t, assembly.VTXOs, 1)
 
 		expectedDesc, err := tree.NewVTXODescriptor(
-			amount, signingKey.PubKey, h.operatorPubKey,
+			amount, ownerKey.PubKey, h.operatorPubKey,
 			h.operatorTerms.VTXOExitDelay,
 		)
 		require.NoError(t, err)
@@ -210,7 +225,8 @@ func TestActorStart(t *testing.T) {
 		require.Equal(t, amount, req.Amount)
 		require.Equal(t, expectedDesc.PkScript, req.PkScript)
 		require.Equal(t, h.operatorTerms.VTXOExitDelay, req.Expiry)
-		require.True(t, req.ClientKey.IsEqual(signingKey.PubKey))
+		require.True(t, req.ClientKey.PubKey.IsEqual(ownerKey.PubKey))
+		require.True(t, req.OwnsClientKey)
 		require.True(t, req.OperatorKey.IsEqual(h.operatorPubKey))
 		require.Equal(t, *signingKey, req.SigningKey)
 	})
@@ -1273,13 +1289,14 @@ func TestHandleRefreshVTXORequest(t *testing.T) {
 		refreshReq := &RefreshVTXORequest{
 			VTXOOutpoint: vtxoOutpoint,
 			Amount:       50000,
-			NewVTXOKey:   h.clientPubKey,
+			NewVTXOKey:   h.newOwnerKeyDescriptor(),
 			PkScript:     []byte{0x51, 0x20}, // Minimal P2TR
 			OperatorKey:  h.operatorPubKey,
 			Expiry:       144,
 		}
 
 		// Send the refresh request to the actor.
+		h.expectRefreshSigningKeys(1)
 		result := h.receive(refreshReq)
 		require.True(t, result.IsOk(), "expected Ok result, got: %v",
 			result.Err())
@@ -1333,12 +1350,13 @@ func TestHandleRefreshVTXORequest(t *testing.T) {
 		refreshReq := &RefreshVTXORequest{
 			VTXOOutpoint: vtxoOutpoint,
 			Amount:       75000,
-			NewVTXOKey:   h.clientPubKey,
+			NewVTXOKey:   h.newOwnerKeyDescriptor(),
 			PkScript:     []byte{0x51, 0x20},
 			OperatorKey:  h.operatorPubKey,
 			Expiry:       144,
 		}
 
+		h.expectRefreshSigningKeys(1)
 		result := h.receive(refreshReq)
 		require.True(t, result.IsOk())
 
@@ -1672,7 +1690,7 @@ func TestVTXOCreatedNotificationForwarding(t *testing.T) {
 			},
 			Amount:      100000,
 			PkScript:    []byte{0x51, 0x20},
-			ClientKey:   h.newKeyDescriptor(),
+			ClientKey:   h.newOwnerKeyDescriptor(),
 			OperatorKey: h.operatorPubKey,
 			Expiry:      144,
 		}
@@ -1719,7 +1737,7 @@ func TestVTXOCreatedNotificationForwarding(t *testing.T) {
 					},
 					Amount:      100000,
 					PkScript:    []byte{0x51, 0x20},
-					ClientKey:   h.newKeyDescriptor(),
+					ClientKey:   h.newOwnerKeyDescriptor(),
 					OperatorKey: h.operatorPubKey,
 					Expiry:      144,
 				},
@@ -1899,12 +1917,13 @@ func TestActorIntentMapping(t *testing.T) {
 		refreshReq := &RefreshVTXORequest{
 			VTXOOutpoint: vtxoOutpoint,
 			Amount:       75000,
-			NewVTXOKey:   h.clientPubKey,
+			NewVTXOKey:   h.newOwnerKeyDescriptor(),
 			PkScript:     []byte{0x51, 0x20},
 			OperatorKey:  h.operatorPubKey,
 			Expiry:       144,
 		}
 
+		h.expectRefreshSigningKeys(1)
 		result := h.receive(refreshReq)
 		require.True(t, result.IsOk())
 
@@ -1934,7 +1953,11 @@ func TestActorIntentMapping(t *testing.T) {
 		)
 		require.Equal(t, uint32(144), vtxoReq.Expiry)
 		require.True(
-			t, h.clientPubKey.IsEqual(vtxoReq.ClientKey),
+			t, h.clientPubKey.IsEqual(vtxoReq.ClientKey.PubKey),
+		)
+		require.Equal(
+			t, types.VTXOOwnerKeyFamily,
+			vtxoReq.ClientKey.KeyLocator.Family,
 		)
 		require.True(
 			t, h.operatorPubKey.IsEqual(vtxoReq.OperatorKey),
@@ -2026,11 +2049,12 @@ func TestActorIntentMapping(t *testing.T) {
 				Index: 0,
 			},
 			Amount:      30000,
-			NewVTXOKey:  h.clientPubKey,
+			NewVTXOKey:  h.newOwnerKeyDescriptor(),
 			PkScript:    []byte{0x51, 0x20},
 			OperatorKey: h.operatorPubKey,
 			Expiry:      144,
 		}
+		h.expectRefreshSigningKeys(1)
 		result := h.receive(refreshReq)
 		require.True(t, result.IsOk())
 
@@ -2090,12 +2114,13 @@ func TestActorIntentMapping(t *testing.T) {
 			refreshReq := &RefreshVTXORequest{
 				VTXOOutpoint: vtxoOutpoint,
 				Amount:       50000,
-				NewVTXOKey:   h.clientPubKey,
+				NewVTXOKey:   h.newOwnerKeyDescriptor(),
 				PkScript:     []byte{0x51, 0x20},
 				OperatorKey:  h.operatorPubKey,
 				Expiry:       144,
 			}
 
+			h.expectRefreshSigningKeys(1)
 			result := h.receive(refreshReq)
 			require.True(t, result.IsOk())
 		}
@@ -2145,7 +2170,7 @@ func TestHandleRegisterIntent(t *testing.T) {
 				VTXOs: []types.VTXORequest{{
 					Amount:      50000,
 					PkScript:    []byte{0x51, 0x20},
-					ClientKey:   h.clientPubKey,
+					ClientKey:   h.newOwnerKeyDescriptor(),
 					OperatorKey: h.operatorPubKey,
 					Expiry:      144,
 				}},
@@ -2278,7 +2303,7 @@ func TestHandleRegisterIntent(t *testing.T) {
 				VTXOs: []types.VTXORequest{{
 					Amount:      40000,
 					PkScript:    []byte{0x51, 0x20},
-					ClientKey:   h.clientPubKey,
+					ClientKey:   h.newOwnerKeyDescriptor(),
 					OperatorKey: h.operatorPubKey,
 					Expiry:      144,
 				}},
@@ -2336,7 +2361,7 @@ func TestHandleRegisterIntent(t *testing.T) {
 					VTXOs: []types.VTXORequest{{
 						Amount:      40000,
 						PkScript:    []byte{0x51, 0x20},
-						ClientKey:   h.clientPubKey,
+						ClientKey:   h.newOwnerKeyDescriptor(),
 						OperatorKey: h.operatorPubKey,
 						Expiry:      144,
 					}},
@@ -2403,7 +2428,7 @@ func TestHandleRegisterIntent(t *testing.T) {
 					VTXOs: []types.VTXORequest{{
 						Amount:      40000,
 						PkScript:    pkScript,
-						ClientKey:   h.clientPubKey,
+						ClientKey:   h.newOwnerKeyDescriptor(),
 						OperatorKey: h.operatorPubKey,
 						Expiry:      144,
 					}},

--- a/round/actor_test.go
+++ b/round/actor_test.go
@@ -23,6 +23,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func ownerKeyDescriptor(pubKey *btcec.PublicKey) keychain.KeyDescriptor {
+	return keychain.KeyDescriptor{
+		PubKey: pubKey,
+		KeyLocator: keychain.KeyLocator{
+			Family: types.VTXOOwnerKeyFamily,
+			Index:  0,
+		},
+	}
+}
+
 // TestActorStart verifies the actor initialization sequence, ensuring proper
 // registration with dependencies and correct handling of initial messages.
 func TestActorStart(t *testing.T) {
@@ -161,9 +171,6 @@ func TestActorStart(t *testing.T) {
 		err := h.start()
 		require.NoError(t, err)
 
-		signingPrivKey, err := btcec.NewPrivateKey()
-		require.NoError(t, err)
-
 		ownerKey := &keychain.KeyDescriptor{
 			PubKey: h.clientPubKey,
 			KeyLocator: keychain.KeyLocator{
@@ -171,22 +178,11 @@ func TestActorStart(t *testing.T) {
 				Index:  0,
 			},
 		}
-		signingKey := &keychain.KeyDescriptor{
-			PubKey: signingPrivKey.PubKey(),
-			KeyLocator: keychain.KeyLocator{
-				Family: keychain.KeyFamilyMultiSig,
-				Index:  1,
-			},
-		}
 
 		h.wallet.On(
 			"DeriveNextKey", mock.Anything,
 			types.VTXOOwnerKeyFamily,
 		).Return(ownerKey, nil).Once()
-		h.wallet.On(
-			"DeriveNextKey", mock.Anything,
-			keychain.KeyFamilyMultiSig,
-		).Return(signingKey, nil).Once()
 
 		amount := btcutil.Amount(50000)
 		msg := &RegisterVTXORequestsRequest{
@@ -217,7 +213,7 @@ func TestActorStart(t *testing.T) {
 
 		expectedDesc, err := tree.NewVTXODescriptor(
 			amount, ownerKey.PubKey, h.operatorPubKey,
-			h.operatorTerms.VTXOExitDelay,
+			nil, h.operatorTerms.VTXOExitDelay,
 		)
 		require.NoError(t, err)
 
@@ -225,10 +221,13 @@ func TestActorStart(t *testing.T) {
 		require.Equal(t, amount, req.Amount)
 		require.Equal(t, expectedDesc.PkScript, req.PkScript)
 		require.Equal(t, h.operatorTerms.VTXOExitDelay, req.Expiry)
-		require.True(t, req.ClientKey.PubKey.IsEqual(ownerKey.PubKey))
-		require.True(t, req.OwnsClientKey)
+		require.True(t, req.OwnerKey.PubKey.IsEqual(ownerKey.PubKey))
+		require.True(t, req.IsOwner)
 		require.True(t, req.OperatorKey.IsEqual(h.operatorPubKey))
-		require.Equal(t, *signingKey, req.SigningKey)
+
+		// SigningKey is not on VTXORequest — it lives on
+		// RoundVTXORequest, populated by the FSM at registration
+		// time.
 	})
 }
 
@@ -855,7 +854,7 @@ func TestActorProcessOutbox(t *testing.T) {
 
 		joinReq := &JoinRoundRequest{
 			BoardingRequests: []types.BoardingRequest{},
-			VTXORequests:     []types.VTXORequest{},
+			VTXORequests:     []RoundVTXORequest{},
 		}
 
 		h.clearServerMessages()
@@ -1296,7 +1295,6 @@ func TestHandleRefreshVTXORequest(t *testing.T) {
 		}
 
 		// Send the refresh request to the actor.
-		h.expectRefreshSigningKeys(1)
 		result := h.receive(refreshReq)
 		require.True(t, result.IsOk(), "expected Ok result, got: %v",
 			result.Err())
@@ -1356,7 +1354,6 @@ func TestHandleRefreshVTXORequest(t *testing.T) {
 			Expiry:       144,
 		}
 
-		h.expectRefreshSigningKeys(1)
 		result := h.receive(refreshReq)
 		require.True(t, result.IsOk())
 
@@ -1426,11 +1423,11 @@ func TestHandleTriggerBoard(t *testing.T) {
 	h.walletActor.setConfirmedIntents(*intent)
 
 	h.wallet.On(
-		"DeriveNextKey", mock.Anything, keychain.KeyFamilyMultiSig,
+		"DeriveNextKey", mock.Anything, types.VTXOOwnerKeyFamily,
 	).Return(&keychain.KeyDescriptor{
 		PubKey: h.clientPubKey,
 		KeyLocator: keychain.KeyLocator{
-			Family: keychain.KeyFamilyMultiSig,
+			Family: types.VTXOOwnerKeyFamily,
 			Index:  0,
 		},
 	}, nil).Once()
@@ -1688,9 +1685,11 @@ func TestVTXOCreatedNotificationForwarding(t *testing.T) {
 				Hash:  chainhash.HashH([]byte("new-vtxo")),
 				Index: 0,
 			},
-			Amount:      100000,
-			PkScript:    []byte{0x51, 0x20},
-			ClientKey:   h.newOwnerKeyDescriptor(),
+			Amount:   100000,
+			PkScript: []byte{0x51, 0x20},
+			OwnerKey: ownerKeyDescriptor(
+				h.clientPubKey,
+			),
 			OperatorKey: h.operatorPubKey,
 			Expiry:      144,
 		}
@@ -1735,9 +1734,11 @@ func TestVTXOCreatedNotificationForwarding(t *testing.T) {
 						),
 						Index: 0,
 					},
-					Amount:      100000,
-					PkScript:    []byte{0x51, 0x20},
-					ClientKey:   h.newOwnerKeyDescriptor(),
+					Amount:   100000,
+					PkScript: []byte{0x51, 0x20},
+					OwnerKey: ownerKeyDescriptor(
+						h.clientPubKey,
+					),
 					OperatorKey: h.operatorPubKey,
 					Expiry:      144,
 				},
@@ -1923,7 +1924,6 @@ func TestActorIntentMapping(t *testing.T) {
 			Expiry:       144,
 		}
 
-		h.expectRefreshSigningKeys(1)
 		result := h.receive(refreshReq)
 		require.True(t, result.IsOk())
 
@@ -1953,11 +1953,11 @@ func TestActorIntentMapping(t *testing.T) {
 		)
 		require.Equal(t, uint32(144), vtxoReq.Expiry)
 		require.True(
-			t, h.clientPubKey.IsEqual(vtxoReq.ClientKey.PubKey),
+			t, h.clientPubKey.IsEqual(vtxoReq.OwnerKey.PubKey),
 		)
 		require.Equal(
 			t, types.VTXOOwnerKeyFamily,
-			vtxoReq.ClientKey.KeyLocator.Family,
+			vtxoReq.OwnerKey.KeyLocator.Family,
 		)
 		require.True(
 			t, h.operatorPubKey.IsEqual(vtxoReq.OperatorKey),
@@ -1982,14 +1982,14 @@ func TestActorIntentMapping(t *testing.T) {
 			PkScript: []byte{0x00, 0x14, 0x01, 0x02},
 		}
 		leaveReq := &RegisterIntentRequest{
-			Package: &IntentPackage{Intents: Intents{
+			Package: &IntentPackage{
 				Forfeits: []types.ForfeitRequest{{
 					VTXOOutpoint: &vtxoOutpoint,
 				}},
 				Leaves: []*types.LeaveRequest{{
 					Output: leaveOutput,
 				}},
-			}},
+			},
 		}
 
 		result := h.receive(leaveReq)
@@ -2054,7 +2054,6 @@ func TestActorIntentMapping(t *testing.T) {
 			OperatorKey: h.operatorPubKey,
 			Expiry:      144,
 		}
-		h.expectRefreshSigningKeys(1)
 		result := h.receive(refreshReq)
 		require.True(t, result.IsOk())
 
@@ -2064,7 +2063,7 @@ func TestActorIntentMapping(t *testing.T) {
 			Index: 0,
 		}
 		leaveReq := &RegisterIntentRequest{
-			Package: &IntentPackage{Intents: Intents{
+			Package: &IntentPackage{
 				Forfeits: []types.ForfeitRequest{{
 					VTXOOutpoint: &leaveOutpoint,
 				}},
@@ -2074,7 +2073,7 @@ func TestActorIntentMapping(t *testing.T) {
 						PkScript: []byte{0x00, 0x14},
 					},
 				}},
-			}},
+			},
 		}
 		result = h.receive(leaveReq)
 		require.True(t, result.IsOk())
@@ -2120,7 +2119,6 @@ func TestActorIntentMapping(t *testing.T) {
 				Expiry:       144,
 			}
 
-			h.expectRefreshSigningKeys(1)
 			result := h.receive(refreshReq)
 			require.True(t, result.IsOk())
 		}
@@ -2162,19 +2160,21 @@ func TestHandleRegisterIntent(t *testing.T) {
 			Index: 0,
 		}
 		req := &RegisterIntentRequest{
-			Package: &IntentPackage{Intents: Intents{
+			Package: &IntentPackage{
 				Forfeits: []types.ForfeitRequest{{
 					VTXOOutpoint: &vtxoOutpoint,
 					Amount:       50000,
 				}},
-				VTXOs: []types.VTXORequest{{
-					Amount:      50000,
-					PkScript:    []byte{0x51, 0x20},
-					ClientKey:   h.newOwnerKeyDescriptor(),
+				VTXOs: []VTXOIntent{{
+					Amount:   50000,
+					PkScript: []byte{0x51, 0x20},
+					OwnerKey: ownerKeyDescriptor(
+						h.clientPubKey,
+					),
 					OperatorKey: h.operatorPubKey,
 					Expiry:      144,
 				}},
-			}},
+			},
 		}
 
 		result := h.receive(req)
@@ -2224,14 +2224,14 @@ func TestHandleRegisterIntent(t *testing.T) {
 			PkScript: []byte{0x00, 0x14, 0x01, 0x02},
 		}
 		req := &RegisterIntentRequest{
-			Package: &IntentPackage{Intents: Intents{
+			Package: &IntentPackage{
 				Forfeits: []types.ForfeitRequest{{
 					VTXOOutpoint: &vtxoOutpoint,
 				}},
 				Leaves: []*types.LeaveRequest{{
 					Output: leaveOutput,
 				}},
-			}},
+			},
 		}
 
 		result := h.receive(req)
@@ -2296,18 +2296,20 @@ func TestHandleRegisterIntent(t *testing.T) {
 			Index: 0,
 		}
 		req := &RegisterIntentRequest{
-			Package: &IntentPackage{Intents: Intents{
+			Package: &IntentPackage{
 				Forfeits: []types.ForfeitRequest{{
 					VTXOOutpoint: &vtxoOutpoint,
 				}},
-				VTXOs: []types.VTXORequest{{
-					Amount:      40000,
-					PkScript:    []byte{0x51, 0x20},
-					ClientKey:   h.newOwnerKeyDescriptor(),
+				VTXOs: []VTXOIntent{{
+					Amount:   40000,
+					PkScript: []byte{0x51, 0x20},
+					OwnerKey: ownerKeyDescriptor(
+						h.clientPubKey,
+					),
 					OperatorKey: h.operatorPubKey,
 					Expiry:      144,
 				}},
-			}},
+			},
 		}
 
 		result := h.receive(req)
@@ -2354,18 +2356,20 @@ func TestHandleRegisterIntent(t *testing.T) {
 				Index: 0,
 			}
 			req := &RegisterIntentRequest{
-				Package: &IntentPackage{Intents: Intents{
+				Package: &IntentPackage{
 					Forfeits: []types.ForfeitRequest{{
 						VTXOOutpoint: &vtxoOutpoint,
 					}},
-					VTXOs: []types.VTXORequest{{
-						Amount:      40000,
-						PkScript:    []byte{0x51, 0x20},
-						ClientKey:   h.newOwnerKeyDescriptor(),
+					VTXOs: []VTXOIntent{{
+						Amount:   40000,
+						PkScript: []byte{0x51, 0x20},
+						OwnerKey: ownerKeyDescriptor(
+							h.clientPubKey,
+						),
 						OperatorKey: h.operatorPubKey,
 						Expiry:      144,
 					}},
-				}},
+				},
 			}
 
 			result := h.receive(req)
@@ -2421,18 +2425,20 @@ func TestHandleRegisterIntent(t *testing.T) {
 				Index: 0,
 			}
 			req := &RegisterIntentRequest{
-				Package: &IntentPackage{Intents: Intents{
+				Package: &IntentPackage{
 					Forfeits: []types.ForfeitRequest{{
 						VTXOOutpoint: &outpoint,
 					}},
-					VTXOs: []types.VTXORequest{{
-						Amount:      40000,
-						PkScript:    pkScript,
-						ClientKey:   h.newOwnerKeyDescriptor(),
+					VTXOs: []VTXOIntent{{
+						Amount:   40000,
+						PkScript: pkScript,
+						OwnerKey: ownerKeyDescriptor(
+							h.clientPubKey,
+						),
 						OperatorKey: h.operatorPubKey,
 						Expiry:      144,
 					}},
-				}},
+				},
 			}
 
 			result := h.receive(req)

--- a/round/events.go
+++ b/round/events.go
@@ -299,8 +299,15 @@ func (e *RoundComplete) clientEventSealed() {}
 //   - Leave:     {Forfeits: [1], Leaves: [1]}
 //   - Consolidate N-to-1: {Forfeits: [N], VTXOs: [1]}
 //   - Resume:    {Boarding: [N], VTXOs: [M], Forfeits: [K], Leaves: [L]}
+//
+// IntentPackage carries raw client intents into the FSM accumulation phase.
+// VTXOs do not yet have signing keys; the round actor derives them at
+// registration time.
 type IntentPackage struct {
-	Intents
+	Boarding []BoardingIntent
+	VTXOs    []VTXOIntent
+	Leaves   []*types.LeaveRequest
+	Forfeits []types.ForfeitRequest
 }
 
 // isEmpty returns true if the package contains no intents.

--- a/round/from_proto.go
+++ b/round/from_proto.go
@@ -414,7 +414,9 @@ func (m *JoinRoundRequest) FromProto(p proto.Message) error {
 					i, err,
 				)
 			}
-			req.ClientKey = key
+			req.ClientKey = keychain.KeyDescriptor{
+				PubKey: key,
+			}
 		}
 
 		if len(vr.OperatorKey) > 0 {

--- a/round/from_proto.go
+++ b/round/from_proto.go
@@ -395,9 +395,10 @@ func (m *JoinRoundRequest) FromProto(p proto.Message) error {
 		m.BoardingRequests[i] = req
 	}
 
-	// Convert VTXO requests.
+	// Convert VTXO requests. Server-originated messages don't carry
+	// signing keys — those are derived locally by the FSM.
 	m.VTXORequests = make(
-		[]types.VTXORequest, len(pb.VtxoRequests),
+		[]RoundVTXORequest, len(pb.VtxoRequests),
 	)
 	for i, vr := range pb.VtxoRequests {
 		req := types.VTXORequest{
@@ -414,7 +415,7 @@ func (m *JoinRoundRequest) FromProto(p proto.Message) error {
 					i, err,
 				)
 			}
-			req.ClientKey = keychain.KeyDescriptor{
+			req.OwnerKey = keychain.KeyDescriptor{
 				PubKey: key,
 			}
 		}
@@ -430,6 +431,13 @@ func (m *JoinRoundRequest) FromProto(p proto.Message) error {
 			req.OperatorKey = key
 		}
 
+		roundReq := RoundVTXORequest{
+			VTXOIntent: vtxoRequestToIntent(req),
+		}
+
+		// Parse the signing key when present. Server-originated
+		// messages may omit it, but client round-trip decoding
+		// must preserve it.
 		if len(vr.SigningKey) > 0 {
 			key, err := btcec.ParsePubKey(vr.SigningKey)
 			if err != nil {
@@ -438,13 +446,12 @@ func (m *JoinRoundRequest) FromProto(p proto.Message) error {
 					i, err,
 				)
 			}
-
-			req.SigningKey = keychain.KeyDescriptor{
+			roundReq.SigningKey = keychain.KeyDescriptor{
 				PubKey: key,
 			}
 		}
 
-		m.VTXORequests[i] = req
+		m.VTXORequests[i] = roundReq
 	}
 
 	// Convert forfeit requests.

--- a/round/harness_test.go
+++ b/round/harness_test.go
@@ -543,14 +543,22 @@ func (h *boardingTestHarness) newTestVTXORequestForIntent(
 			Index:  0,
 		},
 	}
+	clientKey := keychain.KeyDescriptor{
+		PubKey: h.clientPubKey,
+		KeyLocator: keychain.KeyLocator{
+			Family: types.VTXOOwnerKeyFamily,
+			Index:  0,
+		},
+	}
 
 	return types.VTXORequest{
-		Amount:      intent.ChainInfo.Amount,
-		PkScript:    pkScript,
-		Expiry:      testExitDelay,
-		ClientKey:   h.clientPubKey,
-		OperatorKey: h.operatorPubKey,
-		SigningKey:  signingKey,
+		Amount:        intent.ChainInfo.Amount,
+		PkScript:      pkScript,
+		Expiry:        testExitDelay,
+		ClientKey:     clientKey,
+		OwnsClientKey: true,
+		OperatorKey:   h.operatorPubKey,
+		SigningKey:    signingKey,
 	}
 }
 

--- a/round/harness_test.go
+++ b/round/harness_test.go
@@ -379,6 +379,19 @@ func newTestHarness(t *testing.T) *boardingTestHarness {
 		PubKey: identifierPrivKey.PubKey(),
 	}, nil)
 
+	// The registration transition derives a fresh MuSig2 signing
+	// key for each VTXO request.
+	wallet.On(
+		"DeriveNextKey", mock.Anything,
+		keychain.KeyFamilyMultiSig,
+	).Return(&keychain.KeyDescriptor{
+		PubKey: identifierPrivKey.PubKey(),
+		KeyLocator: keychain.KeyLocator{
+			Family: keychain.KeyFamilyMultiSig,
+			Index:  0,
+		},
+	}, nil)
+
 	h := &boardingTestHarness{
 		t:               t,
 		ctx:             ctx,
@@ -529,20 +542,13 @@ func (h *boardingTestHarness) newTestBoardingIntent() BoardingIntent {
 // boarding intent. This is what the client would request as output for their
 // boarding input.
 func (h *boardingTestHarness) newTestVTXORequestForIntent(
-	intent BoardingIntent) types.VTXORequest {
+	intent BoardingIntent) VTXOIntent {
 
 	h.t.Helper()
 
 	pkScript, err := txscript.PayToTaprootScript(h.clientPubKey)
 	require.NoError(h.t, err)
 
-	signingKey := keychain.KeyDescriptor{
-		PubKey: h.clientPubKey,
-		KeyLocator: keychain.KeyLocator{
-			Family: keychain.KeyFamilyMultiSig,
-			Index:  0,
-		},
-	}
 	clientKey := keychain.KeyDescriptor{
 		PubKey: h.clientPubKey,
 		KeyLocator: keychain.KeyLocator{
@@ -551,15 +557,38 @@ func (h *boardingTestHarness) newTestVTXORequestForIntent(
 		},
 	}
 
-	return types.VTXORequest{
-		Amount:        intent.ChainInfo.Amount,
-		PkScript:      pkScript,
-		Expiry:        testExitDelay,
-		ClientKey:     clientKey,
-		OwnsClientKey: true,
-		OperatorKey:   h.operatorPubKey,
-		SigningKey:    signingKey,
+	return VTXOIntent{
+		Amount:      intent.ChainInfo.Amount,
+		PkScript:    pkScript,
+		Expiry:      testExitDelay,
+		OwnerKey:    clientKey,
+		IsOwner:     true,
+		OperatorKey: h.operatorPubKey,
 	}
+}
+
+// wrapVTXOIntents wraps a slice of VTXOIntent into RoundVTXORequest
+// with a test signing key derived from the harness client key.
+func (h *boardingTestHarness) wrapVTXOIntents(
+	reqs []VTXOIntent) []RoundVTXORequest {
+
+	h.t.Helper()
+
+	out := make([]RoundVTXORequest, len(reqs))
+	for i, r := range reqs {
+		out[i] = RoundVTXORequest{
+			VTXOIntent: r,
+			SigningKey: keychain.KeyDescriptor{
+				PubKey: h.clientPubKey,
+				KeyLocator: keychain.KeyLocator{
+					Family: keychain.KeyFamilyMultiSig,
+					Index:  0,
+				},
+			},
+		}
+	}
+
+	return out
 }
 
 // newTestCommitmentTx creates a commitment transaction with the given inputs.
@@ -636,9 +665,9 @@ func (h *boardingTestHarness) newTestVTXOTree(
 		require.NoError(h.t, err)
 
 		leaves[i] = tree.LeafDescriptor{
-			PkScript:    vtxoScript,
-			Amount:      leafAmount,
-			CoSignerKey: h.clientPubKey,
+			PkScript:   vtxoScript,
+			Amount:     leafAmount,
+			SigningKey: h.clientPubKey,
 		}
 	}
 
@@ -667,7 +696,7 @@ func (h *boardingTestHarness) newTestVTXOTree(
 // newTestVTXOTreeForIntents creates a VTXT tree configured for the given VTXO
 // requests, with total amount calculated from the VTXOs.
 func (h *boardingTestHarness) newTestVTXOTreeForIntents(
-	vtxoReqs []types.VTXORequest) *tree.Tree {
+	vtxoReqs []VTXOIntent) *tree.Tree {
 
 	h.t.Helper()
 
@@ -675,9 +704,9 @@ func (h *boardingTestHarness) newTestVTXOTreeForIntents(
 	leaves := make([]tree.LeafDescriptor, len(vtxoReqs))
 	for i, vtxoReq := range vtxoReqs {
 		leaves[i] = tree.LeafDescriptor{
-			PkScript:    vtxoReq.PkScript,
-			Amount:      vtxoReq.Amount,
-			CoSignerKey: h.clientPubKey,
+			PkScript:   vtxoReq.PkScript,
+			Amount:     vtxoReq.Amount,
+			SigningKey: h.clientPubKey,
 		}
 		totalAmount += vtxoReq.Amount
 	}
@@ -845,7 +874,7 @@ func (h *boardingTestHarness) newCommitmentTxReceivedState(
 	h.t.Helper()
 
 	// Generate VTXO requests from intents.
-	vtxoReqs := make([]types.VTXORequest, len(intents))
+	vtxoReqs := make([]VTXOIntent, len(intents))
 	var totalAmount btcutil.Amount
 	for i, intent := range intents {
 		vtxoReqs[i] = h.newTestVTXORequestForIntent(intent)
@@ -862,7 +891,7 @@ func (h *boardingTestHarness) newCommitmentTxReceivedState(
 		VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
 		Intents: Intents{
 			Boarding: intents,
-			VTXOs:    vtxoReqs,
+			VTXOs:    h.wrapVTXOIntents(vtxoReqs),
 		},
 		ClientTrees: make(map[SignerKey]*tree.Tree),
 	}
@@ -877,7 +906,7 @@ func (h *boardingTestHarness) newCommitmentTxValidatedState(
 	h.t.Helper()
 
 	// Generate VTXO requests from intents.
-	vtxoReqs := make([]types.VTXORequest, len(intents))
+	vtxoReqs := make([]VTXOIntent, len(intents))
 	var totalAmount btcutil.Amount
 	for i, intent := range intents {
 		vtxoReqs[i] = h.newTestVTXORequestForIntent(intent)
@@ -892,11 +921,13 @@ func (h *boardingTestHarness) newCommitmentTxValidatedState(
 		boardingInputIndices[intent.Outpoint] = i
 	}
 
+	roundVTXOReqs := h.wrapVTXOIntents(vtxoReqs)
+
 	// Populate ClientTrees by extracting sub-trees for each signer key
 	// in the VTXOs. This simulates what happens during commitment tx
 	// validation when ValidatePath is called.
 	clientTrees := make(map[SignerKey]*tree.Tree)
-	for _, vtxoReq := range vtxoReqs {
+	for _, vtxoReq := range roundVTXOReqs {
 		signerKey := NewSignerKey(vtxoReq.SigningKey.PubKey)
 
 		// The client tree is a subtree extracted from the VTXT
@@ -911,7 +942,7 @@ func (h *boardingTestHarness) newCommitmentTxValidatedState(
 		VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
 		Intents: Intents{
 			Boarding: intents,
-			VTXOs:    vtxoReqs,
+			VTXOs:    roundVTXOReqs,
 		},
 		ClientTrees:          clientTrees,
 		BoardingInputIndices: boardingInputIndices,
@@ -1087,7 +1118,7 @@ func (h *boardingTestHarness) newNoncesSentState(
 	h.t.Helper()
 
 	// Generate VTXO requests from intents.
-	vtxoReqs := make([]types.VTXORequest, len(intents))
+	vtxoReqs := make([]VTXOIntent, len(intents))
 	var totalAmount btcutil.Amount
 	for i, intent := range intents {
 		vtxoReqs[i] = h.newTestVTXORequestForIntent(intent)
@@ -1110,7 +1141,7 @@ func (h *boardingTestHarness) newNoncesSentState(
 		VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
 		Intents: Intents{
 			Boarding: intents,
-			VTXOs:    vtxoReqs,
+			VTXOs:    h.wrapVTXOIntents(vtxoReqs),
 		},
 		ClientTrees:          make(map[SignerKey]*tree.Tree),
 		Musig2Sessions:       musig2Sessions,
@@ -1125,7 +1156,7 @@ func (h *boardingTestHarness) newNoncesAggregatedState(
 	h.t.Helper()
 
 	// Generate VTXO requests from intents.
-	vtxoReqs := make([]types.VTXORequest, len(intents))
+	vtxoReqs := make([]VTXOIntent, len(intents))
 	var totalAmount btcutil.Amount
 	for i, intent := range intents {
 		vtxoReqs[i] = h.newTestVTXORequestForIntent(intent)
@@ -1165,7 +1196,7 @@ func (h *boardingTestHarness) newNoncesAggregatedState(
 		VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
 		Intents: Intents{
 			Boarding: intents,
-			VTXOs:    vtxoReqs,
+			VTXOs:    h.wrapVTXOIntents(vtxoReqs),
 		},
 		ClientTrees:          make(map[SignerKey]*tree.Tree),
 		Musig2Sessions:       make(map[SignerKey]*tree.SignerSession),
@@ -1181,7 +1212,7 @@ func (h *boardingTestHarness) newPartialSigsSentState(
 	h.t.Helper()
 
 	// Generate VTXO requests from intents.
-	vtxoReqs := make([]types.VTXORequest, len(intents))
+	vtxoReqs := make([]VTXOIntent, len(intents))
 	var totalAmount btcutil.Amount
 	for i, intent := range intents {
 		vtxoReqs[i] = h.newTestVTXORequestForIntent(intent)
@@ -1202,7 +1233,7 @@ func (h *boardingTestHarness) newPartialSigsSentState(
 		VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
 		Intents: Intents{
 			Boarding: intents,
-			VTXOs:    vtxoReqs,
+			VTXOs:    h.wrapVTXOIntents(vtxoReqs),
 		},
 		ClientTrees:          make(map[SignerKey]*tree.Tree),
 		Musig2Sessions:       make(map[SignerKey]*tree.SignerSession),
@@ -1216,7 +1247,7 @@ func (h *boardingTestHarness) newInputSigSentState(
 	h.t.Helper()
 
 	// Generate VTXO requests from intents.
-	vtxoReqs := make([]types.VTXORequest, len(intents))
+	vtxoReqs := make([]VTXOIntent, len(intents))
 	var totalAmount btcutil.Amount
 	for i, intent := range intents {
 		vtxoReqs[i] = h.newTestVTXORequestForIntent(intent)
@@ -1246,8 +1277,10 @@ func (h *boardingTestHarness) newInputSigSentState(
 		}
 	}
 
+	roundVTXOReqs := h.wrapVTXOIntents(vtxoReqs)
+
 	clientTrees := make(map[SignerKey]*tree.Tree)
-	for _, vtxoReq := range vtxoReqs {
+	for _, vtxoReq := range roundVTXOReqs {
 		signerKey := NewSignerKey(vtxoReq.SigningKey.PubKey)
 		clientTrees[signerKey] = vtxtTree
 	}
@@ -1258,7 +1291,7 @@ func (h *boardingTestHarness) newInputSigSentState(
 		VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
 		Intents: Intents{
 			Boarding: intents,
-			VTXOs:    vtxoReqs,
+			VTXOs:    roundVTXOReqs,
 		},
 		ClientTrees: clientTrees,
 		InputSigs:   inputSigs,
@@ -2058,9 +2091,9 @@ func (h *boardingTestHarness) newMinimalVTXOTree() *tree.Tree {
 
 	leaves := []tree.LeafDescriptor{
 		{
-			PkScript:    vtxoScript,
-			Amount:      leafAmount,
-			CoSignerKey: h.clientPubKey,
+			PkScript:   vtxoScript,
+			Amount:     leafAmount,
+			SigningKey: h.clientPubKey,
 		},
 	}
 

--- a/round/interfaces.go
+++ b/round/interfaces.go
@@ -215,14 +215,66 @@ const (
 
 // Intents captures all the client's intents to be included in a single round
 // join request.
+// VTXOIntent is a client's request for a VTXO output in a round. It
+// carries the output metadata but no signing key — the FSM derives
+// signing keys at registration time. This is the type used by callers
+// (wallet, vtxo actor) to request VTXOs.
+type VTXOIntent struct {
+	// Amount is the amount of satoshis to lock in the VTXO.
+	Amount btcutil.Amount
+
+	// PkScript is the output script of the VTXO.
+	PkScript []byte
+
+	// Expiry is the CSV delay for the unilateral exit path.
+	Expiry uint32
+
+	// OwnerKey is the owner's key descriptor for the VTXO.
+	OwnerKey keychain.KeyDescriptor
+
+	// IsOwner reports whether this client controls the VTXO owner
+	// key and should persist the VTXO locally once confirmed.
+	IsOwner bool
+
+	// OperatorKey is the operator's public key for collaborative
+	// spends.
+	OperatorKey *btcec.PublicKey
+}
+
+// RoundVTXORequest pairs a VTXOIntent with the ephemeral signing key
+// derived for this round's MuSig2 tree construction.
+type RoundVTXORequest struct {
+	VTXOIntent
+
+	// SigningKey is the MuSig2 tree signing key derived for this
+	// round. It is ephemeral, must not be reused across rounds,
+	// and can be discarded after batch confirmation.
+	SigningKey keychain.KeyDescriptor
+}
+
+// ToVTXORequest converts a RoundVTXORequest to a types.VTXORequest
+// for wire encoding and DB persistence.
+func (r RoundVTXORequest) ToVTXORequest() types.VTXORequest {
+	return types.VTXORequest{
+		Amount:      r.Amount,
+		PkScript:    r.PkScript,
+		Expiry:      r.Expiry,
+		OwnerKey:    r.OwnerKey,
+		IsOwner:     r.IsOwner,
+		OperatorKey: r.OperatorKey,
+		SigningKey:  r.SigningKey,
+	}
+}
+
+// Intents holds the accumulated round participation data after signing
+// keys have been derived. All VTXO requests carry their signing keys.
 type Intents struct {
 	// Boarding contains all boarding intents to include in the round.
 	Boarding []BoardingIntent
 
-	// VTXOs is the templates for the VTXO(s) requested in the round.
-	//
-	// TODO(roasbeef): add auxleaf for tap here.
-	VTXOs []types.VTXORequest
+	// VTXOs is the VTXO requests with their round-specific signing
+	// keys, derived by the FSM at registration time.
+	VTXOs []RoundVTXORequest
 
 	// Leaves contains the leave requests for VTXOs being exited to on-chain
 	// outputs. Each leave forfeits a VTXO and creates an on-chain output
@@ -377,8 +429,8 @@ type ClientVTXO struct {
 	// Expiry is the CSV delay for the unilateral exit path.
 	Expiry uint32
 
-	// ClientKey is the client's key descriptor for this VTXO.
-	ClientKey keychain.KeyDescriptor
+	// OwnerKey is the client's owner key descriptor for this VTXO.
+	OwnerKey keychain.KeyDescriptor
 
 	// OperatorKey is the operator's public key for collaborative spends.
 	OperatorKey *btcec.PublicKey

--- a/round/join_auth.go
+++ b/round/join_auth.go
@@ -197,7 +197,7 @@ func computeTotalForfeitAmount(ctx context.Context,
 // inputs, and signs everything.
 func buildJoinRoundAuth(ctx context.Context, env *ClientEnvironment,
 	identifierKeyDesc keychain.KeyDescriptor,
-	intents Intents, vtxoReqs []types.VTXORequest,
+	intents Intents, vtxoReqs []RoundVTXORequest,
 	forfeitReqs []*types.ForfeitRequest,
 	leaveReqs []*types.LeaveRequest) (*types.JoinRoundAuth, error) {
 
@@ -343,7 +343,7 @@ func buildJoinRoundAuth(ctx context.Context, env *ClientEnvironment,
 // inputs in the same order.
 func buildJoinRoundAuthRequest(ctx context.Context,
 	env *ClientEnvironment, intents Intents,
-	vtxoReqs []types.VTXORequest,
+	vtxoReqs []RoundVTXORequest,
 	forfeitReqs []*types.ForfeitRequest,
 	leaveReqs []*types.LeaveRequest) (*types.JoinRoundRequest,
 	[]joinAuthInput, error) {
@@ -405,7 +405,7 @@ func buildJoinRoundAuthRequest(ctx context.Context,
 			)
 		}
 
-		if vtxo.ClientKey.PubKey == nil {
+		if vtxo.OwnerKey.PubKey == nil {
 			return nil, nil, fmt.Errorf(
 				"forfeit auth input %s missing "+
 					"client key", outpoint,
@@ -420,7 +420,7 @@ func buildJoinRoundAuthRequest(ctx context.Context,
 		}
 
 		tapScript, err := scripts.VTXOTapScript(
-			vtxo.ClientKey.PubKey, vtxo.OperatorKey,
+			vtxo.OwnerKey.PubKey, vtxo.OperatorKey,
 			vtxo.Expiry,
 		)
 		if err != nil {
@@ -436,25 +436,25 @@ func buildJoinRoundAuthRequest(ctx context.Context,
 				Value:    int64(vtxo.Amount),
 				PkScript: bytes.Clone(vtxo.PkScript),
 			},
-			KeyDesc:   vtxo.ClientKey,
+			KeyDesc:   vtxo.OwnerKey,
 			TapScript: tapScript,
 			Sequence:  vtxo.Expiry,
 		})
 	}
 
-	// Convert VTXO requests to pointer slice for the shared type.
-	sharedVTXOReqs := make(
+	// Convert round VTXO requests to wire format.
+	wireVTXOReqs := make(
 		[]*types.VTXORequest, 0, len(vtxoReqs),
 	)
-	for i := 0; i < len(vtxoReqs); i++ {
-		reqCopy := vtxoReqs[i]
-		sharedVTXOReqs = append(sharedVTXOReqs, &reqCopy)
+	for i := range vtxoReqs {
+		req := vtxoReqs[i].ToVTXORequest()
+		wireVTXOReqs = append(wireVTXOReqs, &req)
 	}
 
 	return &types.JoinRoundRequest{
 		Identifier:   nil,
 		BoardingReqs: boardingReqs,
-		VTXOReqs:     sharedVTXOReqs,
+		VTXOReqs:     wireVTXOReqs,
 		ForfeitReqs:  forfeitReqs,
 		LeaveReqs:    leaveReqs,
 	}, signingInputs, nil

--- a/round/join_auth_test.go
+++ b/round/join_auth_test.go
@@ -265,10 +265,12 @@ func (f *joinAuthTestFixture) newVTXORequest(t *testing.T,
 	require.NoError(t, err)
 
 	return types.VTXORequest{
-		Amount:      amount,
-		PkScript:    pkScript,
-		Expiry:      expiry,
-		ClientKey:   f.clientPrivKey.PubKey(),
+		Amount:   amount,
+		PkScript: pkScript,
+		Expiry:   expiry,
+		ClientKey: keychain.KeyDescriptor{
+			PubKey: f.clientPrivKey.PubKey(),
+		},
 		OperatorKey: f.operatorPrivKey.PubKey(),
 		SigningKey: keychain.KeyDescriptor{
 			PubKey: signingKey.PubKey(),

--- a/round/join_auth_test.go
+++ b/round/join_auth_test.go
@@ -238,10 +238,10 @@ func (f *joinAuthTestFixture) newBoardingIntent(t *testing.T,
 	}
 }
 
-// newVTXORequest creates a fully-populated VTXORequest with all
+// newVTXORequest creates a fully-populated RoundVTXORequest with all
 // fields required for TLV encoding.
 func (f *joinAuthTestFixture) newVTXORequest(t *testing.T,
-	amount btcutil.Amount) types.VTXORequest {
+	amount btcutil.Amount) RoundVTXORequest {
 
 	t.Helper()
 
@@ -264,14 +264,16 @@ func (f *joinAuthTestFixture) newVTXORequest(t *testing.T,
 	signingKey, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
 
-	return types.VTXORequest{
-		Amount:   amount,
-		PkScript: pkScript,
-		Expiry:   expiry,
-		ClientKey: keychain.KeyDescriptor{
-			PubKey: f.clientPrivKey.PubKey(),
+	return RoundVTXORequest{
+		VTXOIntent: VTXOIntent{
+			Amount:   amount,
+			PkScript: pkScript,
+			Expiry:   expiry,
+			OwnerKey: keychain.KeyDescriptor{
+				PubKey: f.clientPrivKey.PubKey(),
+			},
+			OperatorKey: f.operatorPrivKey.PubKey(),
 		},
-		OperatorKey: f.operatorPrivKey.PubKey(),
 		SigningKey: keychain.KeyDescriptor{
 			PubKey: signingKey.PubKey(),
 		},
@@ -345,7 +347,7 @@ func TestBuildJoinRoundAuthBoardingOnly(t *testing.T) {
 	boardingAmount := btcutil.Amount(50000)
 	intent := f.newBoardingIntent(t, boardingAmount)
 
-	vtxoReqs := []types.VTXORequest{
+	vtxoReqs := []RoundVTXORequest{
 		f.newVTXORequest(t, 49000),
 	}
 	intents := Intents{
@@ -406,7 +408,7 @@ func TestBuildJoinRoundAuthRejectsTamperedSig(t *testing.T) {
 	boardingAmount := btcutil.Amount(50000)
 	intent := f.newBoardingIntent(t, boardingAmount)
 
-	vtxoReqs := []types.VTXORequest{
+	vtxoReqs := []RoundVTXORequest{
 		f.newVTXORequest(t, 49000),
 	}
 	intents := Intents{
@@ -515,7 +517,7 @@ func TestBuildJoinRoundAuthWithForfeit(t *testing.T) {
 		Amount:   vtxoAmount,
 		PkScript: vtxoPkScript,
 		Expiry:   vtxoExpiry,
-		ClientKey: keychain.KeyDescriptor{
+		OwnerKey: keychain.KeyDescriptor{
 			PubKey: f.clientPrivKey.PubKey(),
 		},
 		OperatorKey: f.operatorPrivKey.PubKey(),
@@ -525,7 +527,7 @@ func TestBuildJoinRoundAuthWithForfeit(t *testing.T) {
 		"GetVTXO", mock.Anything, vtxoOutpoint,
 	).Return(vtxo, nil)
 
-	vtxoReqs := []types.VTXORequest{
+	vtxoReqs := []RoundVTXORequest{
 		f.newVTXORequest(t, 70000),
 	}
 	intents := Intents{
@@ -602,7 +604,7 @@ func TestBuildJoinRoundAuthForfeitOnly(t *testing.T) {
 		Amount:   vtxoAmount,
 		PkScript: vtxoPkScript,
 		Expiry:   vtxoExpiry,
-		ClientKey: keychain.KeyDescriptor{
+		OwnerKey: keychain.KeyDescriptor{
 			PubKey: f.clientPrivKey.PubKey(),
 		},
 		OperatorKey: f.operatorPrivKey.PubKey(),
@@ -612,7 +614,7 @@ func TestBuildJoinRoundAuthForfeitOnly(t *testing.T) {
 		"GetVTXO", mock.Anything, vtxoOutpoint,
 	).Return(vtxo, nil)
 
-	vtxoReqs := []types.VTXORequest{
+	vtxoReqs := []RoundVTXORequest{
 		f.newVTXORequest(t, 39000),
 	}
 	intents := Intents{
@@ -742,7 +744,7 @@ func TestBuildJoinRoundAuthRejectsNoInputs(t *testing.T) {
 
 	f := newJoinAuthTestFixture(t)
 
-	vtxoReqs := []types.VTXORequest{
+	vtxoReqs := []RoundVTXORequest{
 		f.newVTXORequest(t, 10000),
 	}
 	intents := Intents{
@@ -769,7 +771,7 @@ func TestBuildJoinRoundAuthRejectsMissingValidFromQuery(t *testing.T) {
 	boardingAmount := btcutil.Amount(50000)
 	intent := f.newBoardingIntent(t, boardingAmount)
 
-	vtxoReqs := []types.VTXORequest{
+	vtxoReqs := []RoundVTXORequest{
 		f.newVTXORequest(t, 49000),
 	}
 	intents := Intents{

--- a/round/outbox_messages.go
+++ b/round/outbox_messages.go
@@ -35,8 +35,9 @@ type JoinRoundRequest struct {
 	// request so the server can register them in a single batch.
 	BoardingRequests []types.BoardingRequest
 
-	// VTXORequests specifies the VTXOs the client wants to receive.
-	VTXORequests []types.VTXORequest
+	// VTXORequests specifies the VTXOs the client wants to receive,
+	// paired with their round-specific signing keys.
+	VTXORequests []RoundVTXORequest
 
 	// ForfeitRequests specifies the VTXOs the client wants to forfeit.
 	ForfeitRequests []*types.ForfeitRequest
@@ -186,8 +187,8 @@ func (m *JoinRoundRequest) ToProto() fn.Result[proto.Message] {
 			PkScript: req.PkScript,
 			Expiry:   req.Expiry,
 		}
-		if req.ClientKey.PubKey != nil {
-			vr.ClientKey = req.ClientKey.PubKey.
+		if req.OwnerKey.PubKey != nil {
+			vr.ClientKey = req.OwnerKey.PubKey.
 				SerializeCompressed()
 		}
 		if req.OperatorKey != nil {

--- a/round/outbox_messages.go
+++ b/round/outbox_messages.go
@@ -186,8 +186,8 @@ func (m *JoinRoundRequest) ToProto() fn.Result[proto.Message] {
 			PkScript: req.PkScript,
 			Expiry:   req.Expiry,
 		}
-		if req.ClientKey != nil {
-			vr.ClientKey = req.ClientKey.
+		if req.ClientKey.PubKey != nil {
+			vr.ClientKey = req.ClientKey.PubKey.
 				SerializeCompressed()
 		}
 		if req.OperatorKey != nil {

--- a/round/outbox_messages_test.go
+++ b/round/outbox_messages_test.go
@@ -38,7 +38,7 @@ func TestOutboxMessagesToProto(t *testing.T) {
 			BoardingRequests: []types.BoardingRequest{
 				{ClientKey: pubKey, OperatorKey: pubKey},
 			},
-			VTXORequests: []types.VTXORequest{},
+			VTXORequests: []RoundVTXORequest{},
 		}
 
 		result := msg.ToProto().UnwrapOrFail(t)

--- a/round/states.go
+++ b/round/states.go
@@ -56,9 +56,9 @@ type PendingRoundAssembly struct {
 	// next round.
 	Boarding []BoardingIntent
 
-	// VTXOs contains the collected VTXO requests to include in the next
-	// round.
-	VTXOs []types.VTXORequest
+	// VTXOs contains the collected VTXO intents to include in the next
+	// round. Signing keys are derived at registration time.
+	VTXOs []VTXOIntent
 
 	// Forfeits tracks VTXOs being forfeited as inputs to this round.
 	// Decoupled from outputs to enable many-to-many operations.

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -1613,13 +1613,19 @@ func (s *PartialSigsSentState) transitionToForfeitCollection(
 	}, nil
 }
 
-// buildClientVTXOs constructs ClientVTXO instances from the intents and client
-// trees.
-func buildClientVTXOs(intents Intents, trees map[SignerKey]*tree.Tree,
+// buildOwnedClientVTXOs constructs locally owned ClientVTXO instances from
+// the intents and client trees. Requests for foreign-owned VTXOs are skipped:
+// the client still co-signs their tree path, but it must not persist them as
+// spendable local balance.
+func buildOwnedClientVTXOs(intents Intents, trees map[SignerKey]*tree.Tree,
 	roundID RoundID) ([]*ClientVTXO, error) {
 
 	vtxos := make([]*ClientVTXO, 0)
 	for _, req := range intents.VTXOs {
+		if !req.OwnsClientKey {
+			continue
+		}
+
 		signerKey := NewSignerKey(req.SigningKey.PubKey)
 		clientTree := trees[signerKey]
 		if clientTree == nil {
@@ -1627,26 +1633,26 @@ func buildClientVTXOs(intents Intents, trees map[SignerKey]*tree.Tree,
 				"for signing key")
 		}
 
-		leaves := clientTree.Root.GetLeafNodes()
+		// Each signing key maps to exactly one leaf
+		// (enforced by ValidatePath during tree validation).
+		leaf := clientTree.Root.GetLeafNodes()[0]
 
-		for _, leaf := range leaves {
-			outpoint, err := leaf.GetNonAnchorOutpoint()
-			if err != nil {
-				return nil, fmt.Errorf("failed to "+
-					"derive VTXO outpoint: %w", err)
-			}
-
-			vtxos = append(vtxos, &ClientVTXO{
-				Outpoint:    *outpoint,
-				Amount:      req.Amount,
-				PkScript:    req.PkScript,
-				Expiry:      req.Expiry,
-				ClientKey:   req.SigningKey,
-				OperatorKey: req.OperatorKey,
-				TreePath:    clientTree,
-				RoundID:     fn.Some(roundID),
-			})
+		outpoint, err := leaf.GetNonAnchorOutpoint()
+		if err != nil {
+			return nil, fmt.Errorf("failed to "+
+				"derive VTXO outpoint: %w", err)
 		}
+
+		vtxos = append(vtxos, &ClientVTXO{
+			Outpoint:    *outpoint,
+			Amount:      req.Amount,
+			PkScript:    req.PkScript,
+			Expiry:      req.Expiry,
+			ClientKey:   req.ClientKey,
+			OperatorKey: req.OperatorKey,
+			TreePath:    clientTree,
+			RoundID:     fn.Some(roundID),
+		})
 	}
 
 	return vtxos, nil
@@ -1678,7 +1684,7 @@ func (s *InputSigSentState) ProcessEvent(
 			slog.Int("block_height", int(evt.BlockHeight)),
 			slog.Int("confirmations", int(evt.Confirmations)))
 
-		vtxos, err := buildClientVTXOs(
+		vtxos, err := buildOwnedClientVTXOs(
 			s.Intents, s.ClientTrees, s.RoundID,
 		)
 		if err != nil {
@@ -1696,18 +1702,24 @@ func (s *InputSigSentState) ProcessEvent(
 			slog.String("round_id", s.RoundID.String()),
 			slog.Int("vtxo_count", len(vtxos)))
 
-		// Persist VTXOs with their extracted tree paths for future
-		// spending. Confirmation handling may outlive the triggering
-		// actor request, so use a detached context for the store write.
-		opCtx := context.WithoutCancel(ctx)
+		if len(vtxos) > 0 {
+			// Persist VTXOs with their extracted tree paths for future
+			// spending. Confirmation handling may outlive the
+			// triggering actor request, so use a detached context for
+			// the store write.
+			opCtx := context.WithoutCancel(ctx)
 
-		if err := env.VTXOStore.SaveVTXOs(opCtx, vtxos); err != nil {
-			return nil, fmt.Errorf("failed to save VTXOs: %w", err)
+			if err := env.VTXOStore.SaveVTXOs(opCtx, vtxos); err != nil {
+				return nil, fmt.Errorf(
+					"failed to save VTXOs: %w", err,
+				)
+			}
+
+			env.Log.InfoS(ctx,
+				"Saved owned VTXOs to store, round complete",
+				slog.String("round_id", s.RoundID.String()),
+				slog.Int("vtxo_count", len(vtxos)))
 		}
-
-		env.Log.InfoS(ctx, "Saved VTXOs to store, round complete",
-			slog.String("round_id", s.RoundID.String()),
-			slog.Int("vtxo_count", len(vtxos)))
 
 		confInfo := ConfInfo{
 			Height:    evt.BlockHeight,
@@ -1719,20 +1731,21 @@ func (s *InputSigSentState) ProcessEvent(
 		batchExpiry := evt.BlockHeight + sweepDelay
 
 		// Build outbox messages starting with standard notifications.
-		outbox := []ClientOutMsg{
-			&VTXOCreatedNotification{
+		outbox := make([]ClientOutMsg, 0, 2)
+		if len(vtxos) > 0 {
+			outbox = append(outbox, &VTXOCreatedNotification{
 				VTXOs:          vtxos,
 				RoundID:        s.RoundID.String(),
 				CommitmentTxID: evt.TxID,
 				BatchExpiry:    batchExpiry,
 				CreatedHeight:  evt.BlockHeight,
-			},
-			&RoundCompletedNotification{
-				RoundID:  s.RoundID,
-				TxID:     evt.TxID,
-				ConfInfo: confInfo,
-			},
+			})
 		}
+		outbox = append(outbox, &RoundCompletedNotification{
+			RoundID:  s.RoundID,
+			TxID:     evt.TxID,
+			ConfInfo: confInfo,
+		})
 
 		// If this round included refresh requests, notify the old VTXO
 		// actors that their forfeit is now confirmed. This allows them

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -19,6 +19,7 @@ import (
 	"github.com/lightninglabs/darepo-client/lib/tx"
 	"github.com/lightninglabs/darepo-client/lib/types"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/keychain"
 )
 
 // buildBoardingRequest constructs a types.BoardingRequest from a
@@ -388,7 +389,30 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 		// Extract the set of values from the intent map, as we don't
 		// need to track them by outpoint any longer.
 		boardingReqs := fn.Map(s.Boarding, buildBoardingRequest)
-		vtxoReqs := slices.Clone(s.VTXOs)
+
+		// Derive a fresh MuSig2 signing key for each VTXO
+		// request. Signing keys are ephemeral per-round and must
+		// not be reused across rounds.
+		vtxoReqs := make(
+			[]RoundVTXORequest, len(s.VTXOs),
+		)
+		for i, req := range s.VTXOs {
+			sigKey, keyErr := env.Wallet.DeriveNextKey(
+				opCtx, keychain.KeyFamilyMultiSig,
+			)
+			if keyErr != nil {
+				return failWithNotification(
+					"derive VTXO signing key",
+					keyErr, true,
+					fn.None[RoundID](),
+				), nil
+			}
+
+			vtxoReqs[i] = RoundVTXORequest{
+				VTXOIntent: req,
+				SigningKey: *sigKey,
+			}
+		}
 
 		// Build forfeit requests from the decoupled forfeit pool.
 		forfeitReqs, err := sortedForfeitRequests(s.Forfeits)
@@ -730,9 +754,9 @@ func (s *CommitmentTxReceivedState) ProcessEvent(
 		for i, vtxoReq := range s.Intents.VTXOs {
 			// Convert VTXORequest to LeafDescriptor for validation.
 			expectedLeaf := tree.LeafDescriptor{
-				Amount:      vtxoReq.Amount,
-				PkScript:    vtxoReq.PkScript,
-				CoSignerKey: vtxoReq.SigningKey.PubKey,
+				Amount:     vtxoReq.Amount,
+				PkScript:   vtxoReq.PkScript,
+				SigningKey: vtxoReq.SigningKey.PubKey,
 			}
 
 			// Search through all VTXO trees to find the one
@@ -1622,7 +1646,7 @@ func buildOwnedClientVTXOs(intents Intents, trees map[SignerKey]*tree.Tree,
 
 	vtxos := make([]*ClientVTXO, 0)
 	for _, req := range intents.VTXOs {
-		if !req.OwnsClientKey {
+		if !req.IsOwner {
 			continue
 		}
 
@@ -1635,7 +1659,12 @@ func buildOwnedClientVTXOs(intents Intents, trees map[SignerKey]*tree.Tree,
 
 		// Each signing key maps to exactly one leaf
 		// (enforced by ValidatePath during tree validation).
-		leaf := clientTree.Root.GetLeafNodes()[0]
+		leaves := clientTree.Root.GetLeafNodes()
+		if len(leaves) == 0 {
+			return nil, fmt.Errorf("client tree for " +
+				"signing key has no leaves")
+		}
+		leaf := leaves[0]
 
 		outpoint, err := leaf.GetNonAnchorOutpoint()
 		if err != nil {
@@ -1648,7 +1677,7 @@ func buildOwnedClientVTXOs(intents Intents, trees map[SignerKey]*tree.Tree,
 			Amount:      req.Amount,
 			PkScript:    req.PkScript,
 			Expiry:      req.Expiry,
-			ClientKey:   req.ClientKey,
+			OwnerKey:    req.OwnerKey,
 			OperatorKey: req.OperatorKey,
 			TreePath:    clientTree,
 			RoundID:     fn.Some(roundID),
@@ -1703,13 +1732,14 @@ func (s *InputSigSentState) ProcessEvent(
 			slog.Int("vtxo_count", len(vtxos)))
 
 		if len(vtxos) > 0 {
-			// Persist VTXOs with their extracted tree paths for future
-			// spending. Confirmation handling may outlive the
-			// triggering actor request, so use a detached context for
-			// the store write.
+			// Persist VTXOs with their extracted tree paths.
+			// Use a detached context; confirmation handling can
+			// outlive the actor request.
 			opCtx := context.WithoutCancel(ctx)
 
-			if err := env.VTXOStore.SaveVTXOs(opCtx, vtxos); err != nil {
+			if err := env.VTXOStore.SaveVTXOs(
+				opCtx, vtxos,
+			); err != nil {
 				return nil, fmt.Errorf(
 					"failed to save VTXOs: %w", err,
 				)

--- a/round/transitions_test.go
+++ b/round/transitions_test.go
@@ -153,7 +153,7 @@ func TestUnexpectedEventSelfLoop(t *testing.T) {
 
 				return &PendingRoundAssembly{
 					Boarding: []BoardingIntent{intent},
-					VTXOs:    []types.VTXORequest{vtxoReq},
+					VTXOs:    []VTXOIntent{vtxoReq},
 				}
 			},
 			event: &RoundComplete{},
@@ -165,7 +165,9 @@ func TestUnexpectedEventSelfLoop(t *testing.T) {
 				vtxoReq := h.newTestVTXORequestForIntent(intent)
 				intents := Intents{
 					Boarding: []BoardingIntent{intent},
-					VTXOs:    []types.VTXORequest{vtxoReq},
+					VTXOs: h.wrapVTXOIntents(
+						[]VTXOIntent{vtxoReq},
+					),
 				}
 
 				return &RegistrationSentState{Intents: intents}
@@ -179,7 +181,9 @@ func TestUnexpectedEventSelfLoop(t *testing.T) {
 				vtxoReq := h.newTestVTXORequestForIntent(intent)
 				intents := Intents{
 					Boarding: []BoardingIntent{intent},
-					VTXOs:    []types.VTXORequest{vtxoReq},
+					VTXOs: h.wrapVTXOIntents(
+						[]VTXOIntent{vtxoReq},
+					),
 				}
 
 				return &RoundJoinedState{
@@ -221,7 +225,9 @@ func TestUnexpectedEventSelfLoop(t *testing.T) {
 				trees := map[int]*tree.Tree{0: vtxtTree}
 				intents := Intents{
 					Boarding: []BoardingIntent{intent},
-					VTXOs:    []types.VTXORequest{vtxoReq},
+					VTXOs: h.wrapVTXOIntents(
+						[]VTXOIntent{vtxoReq},
+					),
 				}
 
 				return &NoncesSentState{
@@ -242,7 +248,9 @@ func TestUnexpectedEventSelfLoop(t *testing.T) {
 				trees := map[int]*tree.Tree{0: vtxtTree}
 				intents := Intents{
 					Boarding: []BoardingIntent{intent},
-					VTXOs:    []types.VTXORequest{vtxoReq},
+					VTXOs: h.wrapVTXOIntents(
+						[]VTXOIntent{vtxoReq},
+					),
 				}
 
 				return &NoncesAggregatedState{
@@ -263,7 +271,9 @@ func TestUnexpectedEventSelfLoop(t *testing.T) {
 				trees := map[int]*tree.Tree{0: vtxtTree}
 				intents := Intents{
 					Boarding: []BoardingIntent{intent},
-					VTXOs:    []types.VTXORequest{vtxoReq},
+					VTXOs: h.wrapVTXOIntents(
+						[]VTXOIntent{vtxoReq},
+					),
 				}
 
 				return &PartialSigsSentState{
@@ -284,7 +294,9 @@ func TestUnexpectedEventSelfLoop(t *testing.T) {
 				trees := map[int]*tree.Tree{0: vtxtTree}
 				intents := Intents{
 					Boarding: []BoardingIntent{intent},
-					VTXOs:    []types.VTXORequest{vtxoReq},
+					VTXOs: h.wrapVTXOIntents(
+						[]VTXOIntent{vtxoReq},
+					),
 				}
 
 				return &InputSigSentState{
@@ -345,7 +357,9 @@ func TestBoardingFailedTransitions(t *testing.T) {
 				vtxoReq := h.newTestVTXORequestForIntent(intent)
 				intents := Intents{
 					Boarding: []BoardingIntent{intent},
-					VTXOs:    []types.VTXORequest{vtxoReq},
+					VTXOs: h.wrapVTXOIntents(
+						[]VTXOIntent{vtxoReq},
+					),
 				}
 
 				return &RegistrationSentState{Intents: intents}
@@ -358,7 +372,9 @@ func TestBoardingFailedTransitions(t *testing.T) {
 				vtxoReq := h.newTestVTXORequestForIntent(intent)
 				intents := Intents{
 					Boarding: []BoardingIntent{intent},
-					VTXOs:    []types.VTXORequest{vtxoReq},
+					VTXOs: h.wrapVTXOIntents(
+						[]VTXOIntent{vtxoReq},
+					),
 				}
 
 				return &RoundJoinedState{
@@ -387,7 +403,9 @@ func TestBoardingFailedTransitions(t *testing.T) {
 				trees := map[int]*tree.Tree{0: vtxtTree}
 				intents := Intents{
 					Boarding: []BoardingIntent{intent},
-					VTXOs:    []types.VTXORequest{vtxoReq},
+					VTXOs: h.wrapVTXOIntents(
+						[]VTXOIntent{vtxoReq},
+					),
 				}
 
 				return &NoncesSentState{
@@ -407,7 +425,9 @@ func TestBoardingFailedTransitions(t *testing.T) {
 				trees := map[int]*tree.Tree{0: vtxtTree}
 				intents := Intents{
 					Boarding: []BoardingIntent{intent},
-					VTXOs:    []types.VTXORequest{vtxoReq},
+					VTXOs: h.wrapVTXOIntents(
+						[]VTXOIntent{vtxoReq},
+					),
 				}
 
 				return &PartialSigsSentState{
@@ -427,7 +447,9 @@ func TestBoardingFailedTransitions(t *testing.T) {
 				trees := map[int]*tree.Tree{0: vtxtTree}
 				intents := Intents{
 					Boarding: []BoardingIntent{intent},
-					VTXOs:    []types.VTXORequest{vtxoReq},
+					VTXOs: h.wrapVTXOIntents(
+						[]VTXOIntent{vtxoReq},
+					),
 				}
 
 				return &InputSigSentState{
@@ -515,9 +537,9 @@ func TestIdleState(t *testing.T) {
 		h.withState(&Idle{})
 
 		intent := h.newTestBoardingIntent()
-		event := &IntentPackage{Intents: Intents{
+		event := &IntentPackage{
 			Boarding: []BoardingIntent{intent},
-		}}
+		}
 
 		transition, err := h.sendEvent(event)
 		require.NoError(t, err)
@@ -535,10 +557,10 @@ func TestIdleState(t *testing.T) {
 
 		intent := h.newTestBoardingIntent()
 		vtxoReq := h.newTestVTXORequestForIntent(intent)
-		event := &IntentPackage{Intents: Intents{
+		event := &IntentPackage{
 			Boarding: []BoardingIntent{intent},
-			VTXOs:    []types.VTXORequest{vtxoReq},
-		}}
+			VTXOs:    []VTXOIntent{vtxoReq},
+		}
 
 		transition, err := h.sendEvent(event)
 		require.NoError(t, err)
@@ -576,13 +598,13 @@ func TestPendingRoundAssemblyState(t *testing.T) {
 		existingVtxoReq := h.newTestVTXORequestForIntent(existingIntent)
 		h.withState(&PendingRoundAssembly{
 			Boarding: []BoardingIntent{existingIntent},
-			VTXOs:    []types.VTXORequest{existingVtxoReq},
+			VTXOs:    []VTXOIntent{existingVtxoReq},
 		})
 
 		newIntent := h.newTestBoardingIntent()
-		event := &IntentPackage{Intents: Intents{
+		event := &IntentPackage{
 			Boarding: []BoardingIntent{newIntent},
-		}}
+		}
 
 		transition, err := h.sendEvent(event)
 		require.NoError(t, err)
@@ -601,7 +623,7 @@ func TestPendingRoundAssemblyState(t *testing.T) {
 		vtxoReq := h.newTestVTXORequestForIntent(intent)
 		h.withState(&PendingRoundAssembly{
 			Boarding: []BoardingIntent{intent},
-			VTXOs:    []types.VTXORequest{vtxoReq},
+			VTXOs:    []VTXOIntent{vtxoReq},
 		})
 
 		event := &RegistrationRequested{}
@@ -620,7 +642,7 @@ func TestPendingRoundAssemblyState(t *testing.T) {
 		h := newTestHarness(t)
 		h.withState(&PendingRoundAssembly{
 			Boarding: []BoardingIntent{},
-			VTXOs:    []types.VTXORequest{},
+			VTXOs:    []VTXOIntent{},
 		})
 
 		event := &RegistrationRequested{}
@@ -649,7 +671,7 @@ func TestPendingRoundAssemblyState(t *testing.T) {
 
 		h.withState(&PendingRoundAssembly{
 			Boarding: []BoardingIntent{intent},
-			VTXOs:    []types.VTXORequest{vtxoReq},
+			VTXOs:    []VTXOIntent{vtxoReq},
 		})
 
 		event := &RegistrationRequested{}
@@ -680,7 +702,7 @@ func TestPendingRoundAssemblyState(t *testing.T) {
 
 		h.withState(&PendingRoundAssembly{
 			Boarding: []BoardingIntent{intent},
-			VTXOs:    []types.VTXORequest{vtxoReq},
+			VTXOs:    []VTXOIntent{vtxoReq},
 		})
 
 		event := &RegistrationRequested{}
@@ -714,7 +736,7 @@ func TestPendingRoundAssemblyState(t *testing.T) {
 
 		h.withState(&PendingRoundAssembly{
 			Boarding: []BoardingIntent{intent},
-			VTXOs:    []types.VTXORequest{vtxoReq},
+			VTXOs:    []VTXOIntent{vtxoReq},
 		})
 
 		event := &RegistrationRequested{}
@@ -749,7 +771,7 @@ func TestPendingRoundAssemblyState(t *testing.T) {
 
 		h.withState(&PendingRoundAssembly{
 			Boarding: []BoardingIntent{intent},
-			VTXOs:    []types.VTXORequest{vtxoReq},
+			VTXOs:    []VTXOIntent{vtxoReq},
 		})
 
 		event := &RegistrationRequested{}
@@ -780,7 +802,7 @@ func TestPendingRoundAssemblyState(t *testing.T) {
 
 		h.withState(&PendingRoundAssembly{
 			Boarding: []BoardingIntent{intent},
-			VTXOs:    []types.VTXORequest{vtxoReq},
+			VTXOs:    []VTXOIntent{vtxoReq},
 		})
 
 		event := &RegistrationRequested{}
@@ -808,7 +830,9 @@ func TestRegistrationSentState(t *testing.T) {
 		h.withState(&RegistrationSentState{
 			Intents: Intents{
 				Boarding: []BoardingIntent{intent},
-				VTXOs:    []types.VTXORequest{vtxoReq},
+				VTXOs: h.wrapVTXOIntents(
+					[]VTXOIntent{vtxoReq},
+				),
 			},
 		})
 
@@ -839,7 +863,9 @@ func TestRoundJoinedState(t *testing.T) {
 			RoundID: testRoundIDTr("round-001"),
 			Intents: Intents{
 				Boarding: []BoardingIntent{intent},
-				VTXOs:    []types.VTXORequest{vtxoReq},
+				VTXOs: h.wrapVTXOIntents(
+					[]VTXOIntent{vtxoReq},
+				),
 			},
 		})
 
@@ -872,7 +898,7 @@ func TestCommitmentTxReceivedState(t *testing.T) {
 		intent := h.newTestBoardingIntent()
 		vtxoReq := h.newTestVTXORequestForIntent(intent)
 		intents := []BoardingIntent{intent}
-		vtxos := []types.VTXORequest{vtxoReq}
+		vtxos := []VTXOIntent{vtxoReq}
 		vtxtTree := h.newTestVTXOTreeForIntents(vtxos)
 		commitmentTx := h.newTestCommitmentTx(intents)
 
@@ -881,8 +907,11 @@ func TestCommitmentTxReceivedState(t *testing.T) {
 			CommitmentTx:  commitmentTx,
 			TxID:          commitmentTx.UnsignedTx.TxHash(),
 			VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
-			Intents:       Intents{Boarding: intents, VTXOs: vtxos},
-			ClientTrees:   make(map[SignerKey]*tree.Tree),
+			Intents: Intents{
+				Boarding: intents,
+				VTXOs:    h.wrapVTXOIntents(vtxos),
+			},
+			ClientTrees: make(map[SignerKey]*tree.Tree),
 		}
 		h.withState(state)
 
@@ -914,7 +943,7 @@ func TestCommitmentTxReceivedState(t *testing.T) {
 
 		intent := h.newTestBoardingIntent()
 		vtxoReq := h.newTestVTXORequestForIntent(intent)
-		vtxos := []types.VTXORequest{vtxoReq}
+		vtxos := []VTXOIntent{vtxoReq}
 		vtxtTree := h.newTestVTXOTreeForIntents(vtxos)
 
 		// Create tx WITHOUT the intent's outpoint. Create a fake intent
@@ -930,7 +959,9 @@ func TestCommitmentTxReceivedState(t *testing.T) {
 			VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
 			Intents: Intents{
 				Boarding: []BoardingIntent{intent},
-				VTXOs:    []types.VTXORequest{vtxoReq},
+				VTXOs: h.wrapVTXOIntents(
+					[]VTXOIntent{vtxoReq},
+				),
 			},
 			ClientTrees: make(map[SignerKey]*tree.Tree),
 		}
@@ -1132,7 +1163,7 @@ func TestPartialSigsSentState(t *testing.T) {
 		intent := h.newTestBoardingIntentWithTapscript()
 		vtxoReq := h.newTestVTXORequestForIntent(intent)
 		vtxtTree := h.newTestVTXOTreeForIntents(
-			[]types.VTXORequest{vtxoReq},
+			[]VTXOIntent{vtxoReq},
 		)
 
 		validSigs, err := h.generateValidTreeSignatures(vtxtTree)
@@ -1143,8 +1174,14 @@ func TestPartialSigsSentState(t *testing.T) {
 			[]BoardingIntent{intent}, vtxtTree,
 		)
 
+		roundVTXOReqs := h.wrapVTXOIntents(
+			[]VTXOIntent{vtxoReq},
+		)
+
 		clientTrees := make(map[SignerKey]*tree.Tree)
-		signerKey := NewSignerKey(vtxoReq.SigningKey.PubKey)
+		signerKey := NewSignerKey(
+			roundVTXOReqs[0].SigningKey.PubKey,
+		)
 		clientTrees[signerKey] = vtxtTree
 
 		state := &PartialSigsSentState{
@@ -1153,7 +1190,7 @@ func TestPartialSigsSentState(t *testing.T) {
 			VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
 			Intents: Intents{
 				Boarding: []BoardingIntent{intent},
-				VTXOs:    []types.VTXORequest{vtxoReq},
+				VTXOs:    roundVTXOReqs,
 			},
 			ClientTrees: clientTrees,
 			BoardingInputIndices: map[wire.OutPoint]int{
@@ -1245,7 +1282,7 @@ func TestPartialSigsSentState(t *testing.T) {
 		intent := h.newTestBoardingIntent()
 		vtxoReq := h.newTestVTXORequestForIntent(intent)
 		vtxtTree := h.newTestVTXOTreeForIntents(
-			[]types.VTXORequest{vtxoReq},
+			[]VTXOIntent{vtxoReq},
 		)
 		intents := []BoardingIntent{intent}
 		commitmentTx := h.newTestCommitmentTx(intents)
@@ -1256,7 +1293,9 @@ func TestPartialSigsSentState(t *testing.T) {
 			VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
 			Intents: Intents{
 				Boarding: []BoardingIntent{intent},
-				VTXOs:    []types.VTXORequest{vtxoReq},
+				VTXOs: h.wrapVTXOIntents(
+					[]VTXOIntent{vtxoReq},
+				),
 			},
 			ClientTrees: make(map[SignerKey]*tree.Tree),
 			BoardingInputIndices: map[wire.OutPoint]int{
@@ -1286,7 +1325,7 @@ func TestPartialSigsSentState(t *testing.T) {
 		intent := h.newTestBoardingIntent()
 		vtxoReq := h.newTestVTXORequestForIntent(intent)
 		vtxtTree := h.newTestVTXOTreeForIntents(
-			[]types.VTXORequest{vtxoReq},
+			[]VTXOIntent{vtxoReq},
 		)
 		intents := []BoardingIntent{intent}
 		commitmentTx := h.newTestCommitmentTx(intents)
@@ -1297,7 +1336,9 @@ func TestPartialSigsSentState(t *testing.T) {
 			VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
 			Intents: Intents{
 				Boarding: []BoardingIntent{intent},
-				VTXOs:    []types.VTXORequest{vtxoReq},
+				VTXOs: h.wrapVTXOIntents(
+					[]VTXOIntent{vtxoReq},
+				),
 			},
 			ClientTrees: make(map[SignerKey]*tree.Tree),
 			BoardingInputIndices: map[wire.OutPoint]int{
@@ -1331,7 +1372,7 @@ func TestPartialSigsSentState(t *testing.T) {
 		intent := h.newTestBoardingIntent()
 		vtxoReq := h.newTestVTXORequestForIntent(intent)
 		vtxtTree := h.newTestVTXOTreeForIntents(
-			[]types.VTXORequest{vtxoReq},
+			[]VTXOIntent{vtxoReq},
 		)
 		intents := []BoardingIntent{intent}
 		commitmentTx := h.newTestCommitmentTx(intents)
@@ -1342,7 +1383,9 @@ func TestPartialSigsSentState(t *testing.T) {
 			VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
 			Intents: Intents{
 				Boarding: []BoardingIntent{intent},
-				VTXOs:    []types.VTXORequest{vtxoReq},
+				VTXOs: h.wrapVTXOIntents(
+					[]VTXOIntent{vtxoReq},
+				),
 			},
 			ClientTrees:          make(map[SignerKey]*tree.Tree),
 			BoardingInputIndices: make(map[wire.OutPoint]int),
@@ -1378,7 +1421,7 @@ func TestPartialSigsSentState(t *testing.T) {
 		intent := h.newTestBoardingIntent()
 		vtxoReq := h.newTestVTXORequestForIntent(intent)
 		vtxtTree := h.newTestVTXOTreeForIntents(
-			[]types.VTXORequest{vtxoReq},
+			[]VTXOIntent{vtxoReq},
 		)
 		intents := []BoardingIntent{intent}
 		commitmentTx := h.newTestCommitmentTx(intents)
@@ -1389,7 +1432,9 @@ func TestPartialSigsSentState(t *testing.T) {
 			VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
 			Intents: Intents{
 				Boarding: []BoardingIntent{intent},
-				VTXOs:    []types.VTXORequest{vtxoReq},
+				VTXOs: h.wrapVTXOIntents(
+					[]VTXOIntent{vtxoReq},
+				),
 			},
 			ClientTrees: make(map[SignerKey]*tree.Tree),
 			BoardingInputIndices: map[wire.OutPoint]int{
@@ -1478,7 +1523,7 @@ func TestInputSigSentState(t *testing.T) {
 		// Mark the VTXO request as not locally owned. The
 		// client co-signed the tree path but does not own the
 		// resulting VTXO, so it must not be persisted.
-		state.Intents.VTXOs[0].OwnsClientKey = false
+		state.Intents.VTXOs[0].IsOwner = false
 
 		h.withState(state)
 
@@ -1516,7 +1561,9 @@ func TestInputSigSentState(t *testing.T) {
 			VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
 			Intents: Intents{
 				Boarding: []BoardingIntent{intent},
-				VTXOs:    []types.VTXORequest{vtxoReq},
+				VTXOs: h.wrapVTXOIntents(
+					[]VTXOIntent{vtxoReq},
+				),
 			},
 			ClientTrees: make(map[SignerKey]*tree.Tree),
 		}
@@ -1719,7 +1766,7 @@ func TestBoardingFlowIdleToPendingToRegistrationSent(t *testing.T) {
 	vtxoReq := h.newTestVTXORequestForIntent(intent)
 	h.withState(&PendingRoundAssembly{
 		Boarding: []BoardingIntent{intent},
-		VTXOs:    []types.VTXORequest{vtxoReq},
+		VTXOs:    []VTXOIntent{vtxoReq},
 	})
 
 	// Step 1: Request registration.
@@ -1751,9 +1798,9 @@ func TestBoardingFlowMultipleIntentsAccumulation(t *testing.T) {
 	// ones.
 	for i := 0; i < 3; i++ {
 		intent := h.newTestBoardingIntent()
-		event := &IntentPackage{Intents: Intents{
+		event := &IntentPackage{
 			Boarding: []BoardingIntent{intent},
-		}}
+		}
 
 		_, err := h.sendEvent(event)
 		require.NoError(t, err)
@@ -1772,7 +1819,7 @@ func TestBoardingFlowPendingToRoundJoined(t *testing.T) {
 	vtxoReq := h.newTestVTXORequestForIntent(intent)
 	h.withState(&PendingRoundAssembly{
 		Boarding: []BoardingIntent{intent},
-		VTXOs:    []types.VTXORequest{vtxoReq},
+		VTXOs:    []VTXOIntent{vtxoReq},
 	})
 
 	// Step 1: PendingRoundAssembly → RegistrationSentState.
@@ -1806,12 +1853,14 @@ func TestBoardingFlowRoundJoinedToPartialSigsSent(t *testing.T) {
 		RoundID: testRoundIDTr("round-integration-002"),
 		Intents: Intents{
 			Boarding: []BoardingIntent{intent},
-			VTXOs:    []types.VTXORequest{vtxoReq},
+			VTXOs: h.wrapVTXOIntents(
+				[]VTXOIntent{vtxoReq},
+			),
 		},
 	})
 
 	// Step 1: RoundJoined → CommitmentTxReceived.
-	vtxtTree := h.newTestVTXOTreeForIntents([]types.VTXORequest{vtxoReq})
+	vtxtTree := h.newTestVTXOTreeForIntents([]VTXOIntent{vtxoReq})
 	commitEvent := h.newCommitmentTxBuiltEvent(
 		testRoundIDTr("round-integration-002"),
 		[]BoardingIntent{intent},
@@ -1875,7 +1924,9 @@ func TestBoardingFlowFailureAndRecovery(t *testing.T) {
 		RoundID: testRoundIDTr("round-fail-001"),
 		Intents: Intents{
 			Boarding: []BoardingIntent{intent},
-			VTXOs:    []types.VTXORequest{vtxoReq},
+			VTXOs: h.wrapVTXOIntents(
+				[]VTXOIntent{vtxoReq},
+			),
 		},
 	})
 

--- a/round/transitions_test.go
+++ b/round/transitions_test.go
@@ -1463,6 +1463,44 @@ func TestInputSigSentState(t *testing.T) {
 		)
 	})
 
+	t.Run("foreign_VTXOs_not_persisted", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+		h.setupMockVTXOStoreForSave()
+
+		intent := h.newTestBoardingIntent()
+		state := h.newInputSigSentState(
+			testRoundIDTr("round-foreign"),
+			[]BoardingIntent{intent},
+		)
+
+		// Mark the VTXO request as not locally owned. The
+		// client co-signed the tree path but does not own the
+		// resulting VTXO, so it must not be persisted.
+		state.Intents.VTXOs[0].OwnsClientKey = false
+
+		h.withState(state)
+
+		event := &BoardingConfirmed{
+			TxID:          state.CommitmentTx.UnsignedTx.TxHash(),
+			BlockHeight:   101,
+			BlockHash:     chainhash.Hash{0x01},
+			Confirmations: 6,
+		}
+
+		transition, err := h.sendEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		_ = assertStateType[*ConfirmedState](h)
+
+		// Only RoundCompletedNotification should be emitted.
+		// No VTXOCreatedNotification and no SaveVTXOs call.
+		h.assertOutboxLen(1)
+		h.vtxoStore.AssertNotCalled(t, "SaveVTXOs")
+	})
+
 	t.Run("buildClientVTXOs_error", func(t *testing.T) {
 		t.Parallel()
 

--- a/vtxo/actor.go
+++ b/vtxo/actor.go
@@ -243,11 +243,10 @@ func (a *VTXOActor) processOutbox(ctx context.Context, outbox []VTXOOutMsg) {
 			refreshReq := &round.RefreshVTXORequest{
 				VTXOOutpoint: m.VTXOOutpoint,
 				Amount:       int64(vtxo.Amount),
-				NewVTXOKey:   vtxo.ClientKey.PubKey,
+				NewVTXOKey:   vtxo.ClientKey,
 				PkScript:     vtxo.PkScript,
 				OperatorKey:  vtxo.OperatorKey,
 				Expiry:       vtxo.RelativeExpiry,
-				SigningKey:   vtxo.ClientKey,
 			}
 			a.tellManager(ctx, &RelayToRoundMsg{
 				Payload: refreshReq,

--- a/vtxo/actor.go
+++ b/vtxo/actor.go
@@ -243,7 +243,7 @@ func (a *VTXOActor) processOutbox(ctx context.Context, outbox []VTXOOutMsg) {
 			refreshReq := &round.RefreshVTXORequest{
 				VTXOOutpoint: m.VTXOOutpoint,
 				Amount:       int64(vtxo.Amount),
-				NewVTXOKey:   vtxo.ClientKey,
+				NewVTXOKey:   vtxo.OwnerKey,
 				PkScript:     vtxo.PkScript,
 				OperatorKey:  vtxo.OperatorKey,
 				Expiry:       vtxo.RelativeExpiry,

--- a/vtxo/actor_test.go
+++ b/vtxo/actor_test.go
@@ -196,11 +196,10 @@ func TestProcessOutboxForfeitRequest(t *testing.T) {
 	)
 	require.Equal(t, vtxo.Outpoint, refreshReq.VTXOOutpoint)
 	require.Equal(t, int64(vtxo.Amount), refreshReq.Amount)
-	require.Equal(t, vtxo.ClientKey.PubKey, refreshReq.NewVTXOKey)
+	require.Equal(t, vtxo.ClientKey, refreshReq.NewVTXOKey)
 	require.Equal(t, vtxo.OperatorKey, refreshReq.OperatorKey)
 	require.Equal(t, vtxo.RelativeExpiry, refreshReq.Expiry)
 	require.Equal(t, vtxo.PkScript, refreshReq.PkScript)
-	require.Equal(t, vtxo.ClientKey, refreshReq.SigningKey)
 }
 
 // TestProcessOutboxTerminatedNotification verifies that

--- a/vtxo/actor_test.go
+++ b/vtxo/actor_test.go
@@ -196,7 +196,7 @@ func TestProcessOutboxForfeitRequest(t *testing.T) {
 	)
 	require.Equal(t, vtxo.Outpoint, refreshReq.VTXOOutpoint)
 	require.Equal(t, int64(vtxo.Amount), refreshReq.Amount)
-	require.Equal(t, vtxo.ClientKey, refreshReq.NewVTXOKey)
+	require.Equal(t, vtxo.OwnerKey, refreshReq.NewVTXOKey)
 	require.Equal(t, vtxo.OperatorKey, refreshReq.OperatorKey)
 	require.Equal(t, vtxo.RelativeExpiry, refreshReq.Expiry)
 	require.Equal(t, vtxo.PkScript, refreshReq.PkScript)

--- a/vtxo/harness_test.go
+++ b/vtxo/harness_test.go
@@ -364,7 +364,7 @@ func (h *vtxoTestHarness) newTestDescriptor() *Descriptor {
 	return &Descriptor{
 		Outpoint: outpoint,
 		Amount:   btcutil.Amount(50000),
-		ClientKey: keychain.KeyDescriptor{
+		OwnerKey: keychain.KeyDescriptor{
 			PubKey: h.clientPubKey,
 			KeyLocator: keychain.KeyLocator{
 				Family: keychain.KeyFamilyMultiSig,
@@ -622,7 +622,7 @@ func (h *realVTXOSigningHarness) newTestDescriptor() *Descriptor {
 		Outpoint: outpoint,
 		Amount:   btcutil.Amount(50000),
 		PkScript: pkScript,
-		ClientKey: keychain.KeyDescriptor{
+		OwnerKey: keychain.KeyDescriptor{
 			PubKey: h.clientPubKey,
 			KeyLocator: keychain.KeyLocator{
 				Family: keychain.KeyFamilyMultiSig,

--- a/vtxo/interfaces.go
+++ b/vtxo/interfaces.go
@@ -337,8 +337,8 @@ type Descriptor struct {
 	// collaborative and timeout spend paths).
 	PkScript []byte
 
-	// ClientKey is the client's key descriptor for this VTXO.
-	ClientKey keychain.KeyDescriptor
+	// OwnerKey is the client's key descriptor for this VTXO.
+	OwnerKey keychain.KeyDescriptor
 
 	// OperatorKey is the operator's public key for collaborative spends.
 	OperatorKey *btcec.PublicKey

--- a/vtxo/manager.go
+++ b/vtxo/manager.go
@@ -748,7 +748,7 @@ func clientVTXOToDescriptor(cv *round.ClientVTXO,
 	// Construct the TapScript from the client and operator keys. This is
 	// the standard VTXO tapscript with collaborative and timeout paths.
 	tapscript, err := scripts.VTXOTapScript(
-		cv.ClientKey.PubKey, cv.OperatorKey, cv.Expiry,
+		cv.OwnerKey.PubKey, cv.OperatorKey, cv.Expiry,
 	)
 	if err != nil {
 		return fn.Err[*Descriptor](
@@ -760,7 +760,7 @@ func clientVTXOToDescriptor(cv *round.ClientVTXO,
 		Outpoint:       cv.Outpoint,
 		Amount:         cv.Amount,
 		PkScript:       cv.PkScript,
-		ClientKey:      cv.ClientKey,
+		OwnerKey:       cv.OwnerKey,
 		OperatorKey:    cv.OperatorKey,
 		TapScript:      tapscript,
 		TreePath:       cv.TreePath,

--- a/vtxo/manager_test.go
+++ b/vtxo/manager_test.go
@@ -32,7 +32,7 @@ func TestClientVTXOToDescriptorChainDepthZero(t *testing.T) {
 		},
 		Amount:   btcutil.Amount(50000),
 		PkScript: []byte{0x51, 0x20},
-		ClientKey: keychain.KeyDescriptor{
+		OwnerKey: keychain.KeyDescriptor{
 			PubKey: clientKey.PubKey(),
 		},
 		OperatorKey: operatorKey.PubKey(),

--- a/vtxo/transitions.go
+++ b/vtxo/transitions.go
@@ -283,7 +283,7 @@ func signForfeitVTXOInput(vtxo *Descriptor, evt *ForfeitRequestEvent,
 	// script and control block from the tapscript, which are needed for
 	// script-path spending.
 	signDesc, _, err := tx.NewVTXOCollabSignDescriptor(
-		vtxoCtx, vtxo.ClientKey, tx.ForfeitVTXOInputIndex,
+		vtxoCtx, vtxo.OwnerKey, tx.ForfeitVTXOInputIndex,
 		sigHashes, prevFetcher,
 	)
 	if err != nil {

--- a/wallet/interfaces.go
+++ b/wallet/interfaces.go
@@ -31,8 +31,8 @@ type VTXODescriptor struct {
 	// corresponds to vtxo.Descriptor.RelativeExpiry.
 	Expiry uint32
 
-	// ClientKey is the client's key descriptor for this VTXO.
-	ClientKey keychain.KeyDescriptor
+	// OwnerKey is the client's owner key descriptor for this VTXO.
+	OwnerKey keychain.KeyDescriptor
 
 	// OperatorKey is the operator's public key for collaborative spends.
 	OperatorKey *btcec.PublicKey

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -21,7 +21,6 @@ import (
 	"github.com/lightninglabs/darepo-client/lib/types"
 	"github.com/lightninglabs/taproot-assets/proof"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
-	"github.com/lightningnetwork/lnd/keychain"
 )
 
 const (
@@ -769,35 +768,20 @@ func (a *Ark) handleRefreshVTXOs(ctx context.Context,
 		}
 
 		// Each refresh produces a forfeit of the old VTXO and a
-		// request for a new VTXO with the same parameters.
-		signingKey, err := a.backend.DeriveNextKey(
-			ctx, keychain.KeyFamilyMultiSig,
-		)
-		if err != nil {
-			a.logger(ctx).WarnS(ctx,
-				"Failed to derive refresh signing key",
-				err,
-				slog.String("outpoint",
-					outpoint.String()))
-
-			errors[outpoint] = err
-
-			continue
-		}
-
+		// request for a new VTXO with the same parameters. The
+		// round actor derives the signing key at registration.
 		op := vtxo.Outpoint
 		forfeits = append(forfeits, types.ForfeitRequest{
 			VTXOOutpoint: &op,
 			Amount:       vtxo.Amount,
 		})
 		vtxos = append(vtxos, types.VTXORequest{
-			Amount:        vtxo.Amount,
-			PkScript:      vtxo.PkScript,
-			Expiry:        vtxo.Expiry,
-			ClientKey:     vtxo.ClientKey,
-			OwnsClientKey: true,
-			OperatorKey:   vtxo.OperatorKey,
-			SigningKey:    *signingKey,
+			Amount:      vtxo.Amount,
+			PkScript:    vtxo.PkScript,
+			Expiry:      vtxo.Expiry,
+			OwnerKey:    vtxo.OwnerKey,
+			IsOwner:     true,
+			OperatorKey: vtxo.OperatorKey,
 		})
 	}
 

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -21,6 +21,7 @@ import (
 	"github.com/lightninglabs/darepo-client/lib/types"
 	"github.com/lightninglabs/taproot-assets/proof"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/keychain"
 )
 
 const (
@@ -769,18 +770,34 @@ func (a *Ark) handleRefreshVTXOs(ctx context.Context,
 
 		// Each refresh produces a forfeit of the old VTXO and a
 		// request for a new VTXO with the same parameters.
+		signingKey, err := a.backend.DeriveNextKey(
+			ctx, keychain.KeyFamilyMultiSig,
+		)
+		if err != nil {
+			a.logger(ctx).WarnS(ctx,
+				"Failed to derive refresh signing key",
+				err,
+				slog.String("outpoint",
+					outpoint.String()))
+
+			errors[outpoint] = err
+
+			continue
+		}
+
 		op := vtxo.Outpoint
 		forfeits = append(forfeits, types.ForfeitRequest{
 			VTXOOutpoint: &op,
 			Amount:       vtxo.Amount,
 		})
 		vtxos = append(vtxos, types.VTXORequest{
-			Amount:      vtxo.Amount,
-			PkScript:    vtxo.PkScript,
-			Expiry:      vtxo.Expiry,
-			ClientKey:   vtxo.ClientKey.PubKey,
-			OperatorKey: vtxo.OperatorKey,
-			SigningKey:  vtxo.ClientKey,
+			Amount:        vtxo.Amount,
+			PkScript:      vtxo.PkScript,
+			Expiry:        vtxo.Expiry,
+			ClientKey:     vtxo.ClientKey,
+			OwnsClientKey: true,
+			OperatorKey:   vtxo.OperatorKey,
+			SigningKey:    *signingKey,
 		})
 	}
 

--- a/wallet/wallet_admission_test.go
+++ b/wallet/wallet_admission_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/lightninglabs/darepo-client/lib/actormsg"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/keychain"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -392,14 +391,8 @@ func newTestWalletWithManagerAndRound(t *testing.T,
 		roundKey, roundActor,
 	)
 
-	backend := &MockBoardingBackend{}
-	backend.On(
-		"DeriveNextKey", mock.Anything,
-		keychain.KeyFamilyMultiSig,
-	).Return(&keychain.KeyDescriptor{}, nil).Maybe()
-
 	return NewArk(
-		backend, nil, vtxoReader, nil, system, btclog.Disabled,
+		nil, nil, vtxoReader, nil, system, btclog.Disabled,
 	)
 }
 
@@ -430,11 +423,11 @@ func TestRefreshReservesBeforeRoundRegistration(t *testing.T) {
 	op := testOutpoint(0)
 	vtxoDescs := map[wire.OutPoint]*VTXODescriptor{
 		op: {
-			Outpoint:  op,
-			Amount:    50000,
-			PkScript:  []byte{0x51, 0x20, 0x01},
-			Expiry:    100,
-			ClientKey: keychain.KeyDescriptor{},
+			Outpoint: op,
+			Amount:   50000,
+			PkScript: []byte{0x51, 0x20, 0x01},
+			Expiry:   100,
+			OwnerKey: keychain.KeyDescriptor{},
 		},
 	}
 
@@ -466,11 +459,11 @@ func TestRefreshReleasesOnRoundRejection(t *testing.T) {
 	op := testOutpoint(0)
 	vtxoDescs := map[wire.OutPoint]*VTXODescriptor{
 		op: {
-			Outpoint:  op,
-			Amount:    50000,
-			PkScript:  []byte{0x51, 0x20, 0x01},
-			Expiry:    100,
-			ClientKey: keychain.KeyDescriptor{},
+			Outpoint: op,
+			Amount:   50000,
+			PkScript: []byte{0x51, 0x20, 0x01},
+			Expiry:   100,
+			OwnerKey: keychain.KeyDescriptor{},
 		},
 	}
 

--- a/wallet/wallet_admission_test.go
+++ b/wallet/wallet_admission_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/lightninglabs/darepo-client/baselib/actor"
 	"github.com/lightninglabs/darepo-client/lib/actormsg"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -390,8 +392,14 @@ func newTestWalletWithManagerAndRound(t *testing.T,
 		roundKey, roundActor,
 	)
 
+	backend := &MockBoardingBackend{}
+	backend.On(
+		"DeriveNextKey", mock.Anything,
+		keychain.KeyFamilyMultiSig,
+	).Return(&keychain.KeyDescriptor{}, nil).Maybe()
+
 	return NewArk(
-		nil, nil, vtxoReader, nil, system, btclog.Disabled,
+		backend, nil, vtxoReader, nil, system, btclog.Disabled,
 	)
 }
 
@@ -422,10 +430,11 @@ func TestRefreshReservesBeforeRoundRegistration(t *testing.T) {
 	op := testOutpoint(0)
 	vtxoDescs := map[wire.OutPoint]*VTXODescriptor{
 		op: {
-			Outpoint: op,
-			Amount:   50000,
-			PkScript: []byte{0x51, 0x20, 0x01},
-			Expiry:   100,
+			Outpoint:  op,
+			Amount:    50000,
+			PkScript:  []byte{0x51, 0x20, 0x01},
+			Expiry:    100,
+			ClientKey: keychain.KeyDescriptor{},
 		},
 	}
 
@@ -457,10 +466,11 @@ func TestRefreshReleasesOnRoundRejection(t *testing.T) {
 	op := testOutpoint(0)
 	vtxoDescs := map[wire.OutPoint]*VTXODescriptor{
 		op: {
-			Outpoint: op,
-			Amount:   50000,
-			PkScript: []byte{0x51, 0x20, 0x01},
-			Expiry:   100,
+			Outpoint:  op,
+			Amount:    50000,
+			PkScript:  []byte{0x51, 0x20, 0x01},
+			Expiry:    100,
+			ClientKey: keychain.KeyDescriptor{},
 		},
 	}
 


### PR DESCRIPTION
## Summary

Previously the client reused the MuSig2 tree-signing key as the VTXO
owner key in saved descriptors. When operator terms rotated and a new
signing session was needed, the stored VTXO referenced a stale key
that could not spend the output locked to the actual owner key,
making the VTXO unspendable.

This violated the Ark spec (ARK-01, ARK-02) which **mandates** key
separation:

> Signing keys **MUST be different from VTXO ownership keys.**
> They **MUST use different derivation paths** to ensure separation.
> — ARK-01 "Key Separation", ARK-02 "VTXT Signing Keys"

The spec defines three distinct key roles:

| Spec key | Implementation | Role |
|----------|---------------|------|
| `P_v` (VTXO ownership key) | `OwnerKey` (family 44) | Committed to VTXO tapscript. Long-lived. |
| `P_o` (operator key) | `OperatorKey` | Collaborative spend cosigner. |
| `P_s` (signing key) | `SigningKey` (`KeyFamilyMultiSig`) | MuSig2 tree signing. Ephemeral per round. |

### Commit 1: `multi: separate VTXO owners from tree cosigners`

Core bug fix — stops storing the signing key as the VTXO owner key.

- Derive a dedicated owner key (family 44, `VTXOOwnerKeyFamily`)
  committed to the VTXO taproot output script.
- Change `VTXORequest.ClientKey` from `*btcec.PublicKey` to
  `keychain.KeyDescriptor` so the key locator survives persistence.
- Add `OwnsClientKey` flag so the client only persists VTXOs it
  owns, allowing co-signing for foreign recipients.
- Rename `buildClientVTXOs` → `buildOwnedClientVTXOs` with
  ownership filter.
- Extend DB schema with `client_key_family`, `client_key_index`,
  `owns_client_key` columns.

### Commit 2: `multi: restructure VTXO types and derive signing keys in FSM`

Structural cleanup and type safety improvements.

**Tree layer:**
- Rename `LeafDescriptor.CoSignerKey` → `SigningKey`.
- Add `OwnerKey`, `OperatorKey`, `ExitDelay`, `SigningKey` to
  `VTXODescriptor`.

**Rename `ClientKey` → `OwnerKey`** across all types:
- `VTXORequest`, `ClientVTXO`, `vtxo.Descriptor`,
  `wallet.VTXODescriptor`.
- `OwnsClientKey` → `IsOwner`.

**Introduce `VTXOIntent`** as the internal intent type:
- `round.VTXOIntent` — no signing key, used by wallet/vtxo actor.
- `round.RoundVTXORequest` — embeds `VTXOIntent` + `SigningKey`,
  used for FSM state and DB persistence.
- `types.VTXORequest` — wire type with `SigningKey` for TLV/proto.
- `IntentPackage` decoupled from `Intents` (own fields).

**Move signing key derivation to FSM:**
- `PendingRoundAssembly` derives signing keys when transitioning
  to `RegistrationSent`.
- Wallet and vtxo actor no longer derive signing keys.

## Testing

```
go test ./lib/... ./round/... ./db/... ./wallet/... ./vtxo/... ./oor/...
```

## Companion PR

Server-side: https://github.com/lightninglabs/darepo/pull/182