### PR TITLE
round: recover checkpointed boarding restart flow

### DIFF
--- a/round/actor.go
+++ b/round/actor.go
@@ -651,6 +651,41 @@ func (a *RoundClientActor) askEventAndProcessOutbox(
 	return nil
 }
 
+// replayCheckpointedServerMessages re-emits server-bound messages that are
+// logically required after the InputSigSent checkpoint. This closes the gap
+// where the daemon can restart after persisting the checkpoint but before the
+// in-memory actor loop forwards those messages to the durable serverconn
+// runtime.
+func (a *RoundClientActor) replayCheckpointedServerMessages(
+	ctx context.Context, roundFSM *RoundFSM,
+) error {
+
+	state, err := roundFSM.FSM.CurrentState()
+	if err != nil {
+		return fmt.Errorf("get current state: %w", err)
+	}
+
+	inputSigState, ok := state.(*InputSigSentState)
+	if !ok {
+		return nil
+	}
+
+	if len(inputSigState.InputSigs) == 0 {
+		return nil
+	}
+
+	a.log.InfoS(ctx, "Replaying checkpointed boarding input signatures",
+		slog.String("round_id", inputSigState.RoundID.String()),
+		slog.Int("boarding_sig_count", len(inputSigState.InputSigs)))
+
+	return a.processOutbox(ctx, []ClientOutMsg{
+		&SubmitForfeitSigRequest{
+			RoundID:    inputSigState.RoundID,
+			Signatures: inputSigState.InputSigs,
+		},
+	})
+}
+
 // OnStop implements actor.Stoppable to gracefully shut down all FSMs when the
 // actor is stopping. This prevents goroutine leaks by stopping all round FSMs.
 func (a *RoundClientActor) OnStop(ctx context.Context) error {
@@ -741,6 +776,11 @@ func (a *RoundClientActor) Start(ctx context.Context) error {
 			a.log.InfoS(ctx, "Resumed round awaiting confirmation",
 				slog.String("round_id", round.RoundID.String()),
 				slog.String("commitment_txid", roundFSM.TxID.String()))
+		}
+
+		if err := a.replayCheckpointedServerMessages(ctx, roundFSM); err != nil {
+			return fmt.Errorf("replay checkpointed messages for round %s: %w",
+				round.RoundID, err)
 		}
 	}
 
@@ -841,22 +881,11 @@ func (a *RoundClientActor) handleWalletBoardingConfirmed(ctx context.Context,
 			walletIntent.Outpoint.Hash))
 	}
 
-	// Build the boarding request from the wallet intent. Chain-level
-	// information (ConfHeight, ConfHash, ConfTx, TxProof, Amount) is
-	// carried through the embedded wallet.BoardingIntent.ChainInfo
-	// and remains available to downstream consumers (e.g.,
-	// buildJoinRoundAuthRequest uses ChainInfo.Amount for BIP-322
-	// proof construction).
-	boardingReq := types.BoardingRequest{
-		Outpoint:    &walletIntent.Outpoint,
-		ClientKey:   walletIntent.Address.KeyDesc.PubKey,
-		OperatorKey: walletIntent.Address.OperatorKey,
-		ExitDelay:   walletIntent.Address.ExitDelay,
-		TxProof:     walletIntent.ChainInfo.TxProof,
-	}
-	intent := BoardingIntent{
-		BoardingIntent: *walletIntent,
-		Request:        boardingReq,
+	intent, err := buildBoardingIntentFromWallet(walletIntent)
+	if err != nil {
+		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
+			"build boarding intent from wallet: %w", err,
+		))
 	}
 
 	// Find an existing assembling round (Idle or PendingRoundAssembly) or
@@ -864,7 +893,6 @@ func (a *RoundClientActor) handleWalletBoardingConfirmed(ctx context.Context,
 	// accumulate in the same round.
 	roundFSM := a.findAssemblingRound()
 	if roundFSM == nil {
-		var err error
 		roundFSM, err = a.createNewRound(ctx)
 		if err != nil {
 			return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
@@ -876,13 +904,55 @@ func (a *RoundClientActor) handleWalletBoardingConfirmed(ctx context.Context,
 	pkg := &IntentPackage{Intents: Intents{
 		Boarding: []BoardingIntent{intent},
 	}}
-	err := a.askEventAndProcessOutbox(ctx, roundFSM, pkg)
+	err = a.askEventAndProcessOutbox(ctx, roundFSM, pkg)
 	if err != nil {
 		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 			"FSM error processing boarding confirmation: %w", err))
 	}
 
 	return fn.Ok[actormsg.RoundActorResp](nil)
+}
+
+// buildBoardingIntentFromWallet converts the wallet's persisted boarding
+// representation into the round actor's intent shape, validating the chain
+// data needed for round registration and join-auth.
+func buildBoardingIntentFromWallet(
+	walletIntent *wallet.BoardingIntent,
+) (BoardingIntent, error) {
+
+	if walletIntent == nil {
+		return BoardingIntent{}, fmt.Errorf("wallet intent is nil")
+	}
+
+	confTx := walletIntent.ChainInfo.ConfTx
+	if confTx == nil {
+		return BoardingIntent{}, fmt.Errorf(
+			"boarding confirmation missing tx",
+		)
+	}
+	if int(walletIntent.Outpoint.Index) >= len(confTx.TxOut) {
+		return BoardingIntent{}, fmt.Errorf(
+			"invalid outpoint index %d for tx %s",
+			walletIntent.Outpoint.Index,
+			walletIntent.Outpoint.Hash,
+		)
+	}
+
+	// Chain-level information (ConfHeight, ConfHash, ConfTx, TxProof,
+	// Amount) is carried through the embedded wallet.BoardingIntent and
+	// remains available to downstream consumers such as join-auth.
+	boardingReq := types.BoardingRequest{
+		Outpoint:    &walletIntent.Outpoint,
+		ClientKey:   walletIntent.Address.KeyDesc.PubKey,
+		OperatorKey: walletIntent.Address.OperatorKey,
+		ExitDelay:   walletIntent.Address.ExitDelay,
+		TxProof:     walletIntent.ChainInfo.TxProof,
+	}
+
+	return BoardingIntent{
+		BoardingIntent: *walletIntent,
+		Request:        boardingReq,
+	}, nil
 }
 
 // handleVTXORequests processes client-submitted VTXO requests and forwards
@@ -917,12 +987,13 @@ func (a *RoundClientActor) handleVTXORequests(ctx context.Context,
 	a.log.InfoS(ctx, "Received VTXO requests",
 		slog.Int("count", len(requests)))
 
+	var err error
+
 	// Find an existing assembling round (Idle or PendingRoundAssembly) or
 	// create a new one. This allows VTXOs to join a round that already has
 	// boarding intents being assembled.
 	roundFSM := a.findAssemblingRound()
 	if roundFSM == nil {
-		var err error
 		roundFSM, err = a.createNewRound(ctx)
 		if err != nil {
 			return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
@@ -935,7 +1006,7 @@ func (a *RoundClientActor) handleVTXORequests(ctx context.Context,
 		VTXOs: requests,
 	}}
 
-	err := a.askEventAndProcessOutbox(ctx, roundFSM, pkg)
+	err = a.askEventAndProcessOutbox(ctx, roundFSM, pkg)
 	if err != nil {
 		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 			"FSM error processing VTXO requests: %w", err,
@@ -1785,9 +1856,9 @@ func (a *RoundClientActor) handleRefreshVTXORequest(ctx context.Context,
 	// temp-key status, which includes rounds in RegistrationSentState.
 	// Feeding an IntentPackage to RegistrationSentState would self-loop
 	// silently, discarding the intent.
+	var err error
 	roundFSM := a.findAssemblingRound()
 	if roundFSM == nil {
-		var err error
 		roundFSM, err = a.createNewRound(ctx)
 		if err != nil {
 			return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
@@ -1806,7 +1877,7 @@ func (a *RoundClientActor) handleRefreshVTXORequest(ctx context.Context,
 			buildVTXORequestFromRefresh(req),
 		},
 	}}
-	err := a.askEventAndProcessOutbox(ctx, roundFSM, pkg)
+	err = a.askEventAndProcessOutbox(ctx, roundFSM, pkg)
 	if err != nil {
 		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 			"FSM error processing refresh package: %w", err,
@@ -1956,10 +2027,43 @@ func (a *RoundClientActor) handleTriggerBoard(ctx context.Context,
 	a.log.InfoS(ctx, "Processing board request",
 		slog.Int("vtxo_count", len(requests)))
 
+	confirmedBoarding, err := a.cfg.WalletActor.Ask(
+		ctx, &wallet.GetConfirmedBoardingIntentsRequest{},
+	).Await(ctx).Unpack()
+	if err != nil {
+		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
+			"fetch confirmed boarding intents: %w", err,
+		))
+	}
+
+	boardingResp, ok := confirmedBoarding.(*wallet.GetConfirmedBoardingIntentsResponse)
+	if !ok {
+		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
+			"unexpected wallet response type: %T",
+			confirmedBoarding,
+		))
+	}
+
+	boardingIntents := make(
+		[]BoardingIntent, 0, len(boardingResp.Intents),
+	)
+	for i := range boardingResp.Intents {
+		intent, err := buildBoardingIntentFromWallet(
+			&boardingResp.Intents[i],
+		)
+		if err != nil {
+			return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
+				"convert confirmed boarding intent %d: %w",
+				i, err,
+			))
+		}
+
+		boardingIntents = append(boardingIntents, intent)
+	}
+
 	// Find an existing assembling round or create a new one.
 	roundFSM := a.findAssemblingRound()
 	if roundFSM == nil {
-		var err error
 		roundFSM, err = a.createNewRound(ctx)
 		if err != nil {
 			return fn.Err[actormsg.RoundActorResp](
@@ -1973,10 +2077,11 @@ func (a *RoundClientActor) handleTriggerBoard(ctx context.Context,
 
 	// Register the VTXO output requests into the round FSM.
 	pkg := &IntentPackage{Intents: Intents{
-		VTXOs: requests,
+		Boarding: boardingIntents,
+		VTXOs:    requests,
 	}}
 
-	err := a.askEventAndProcessOutbox(ctx, roundFSM, pkg)
+	err = a.askEventAndProcessOutbox(ctx, roundFSM, pkg)
 	if err != nil {
 		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
 			"register board VTXO requests: %w", err,

--- a/round/actor_harness_test.go
+++ b/round/actor_harness_test.go
@@ -85,6 +85,13 @@ func (m *mockServerConnRef) clearMessages() {
 	m.messages = m.messages[:0]
 }
 
+func (m *mockServerConnRef) snapshotMessages() []serverconn.ServerConnMsg {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return append([]serverconn.ServerConnMsg(nil), m.messages...)
+}
+
 // assertMessageSent checks that a message of the given type was sent.
 func (m *mockServerConnRef) assertMessageSent(t *testing.T, msgType string) {
 	t.Helper()
@@ -189,6 +196,9 @@ type mockWalletActorRef struct {
 	// adoptedOutpoints captures outpoints from
 	// MarkBoardingIntentsAdoptedRequest calls.
 	adoptedOutpoints []wire.OutPoint
+
+	// confirmedIntents are returned to TriggerBoard recovery queries.
+	confirmedIntents []wallet.BoardingIntent
 }
 
 func newMockWalletActorRef(t *testing.T) *mockWalletActorRef {
@@ -196,6 +206,7 @@ func newMockWalletActorRef(t *testing.T) *mockWalletActorRef {
 		t:                t,
 		id:               "mock-wallet-actor",
 		adoptedOutpoints: make([]wire.OutPoint, 0),
+		confirmedIntents: make([]wallet.BoardingIntent, 0),
 	}
 }
 
@@ -241,6 +252,17 @@ func (m *mockWalletActorRef) Ask(_ context.Context,
 		return newImmediateFuture[wallet.WalletResp](resp)
 	}
 
+	if _, ok := msg.(*wallet.GetConfirmedBoardingIntentsRequest); ok {
+		resp := &wallet.GetConfirmedBoardingIntentsResponse{
+			Intents: append(
+				[]wallet.BoardingIntent(nil),
+				m.confirmedIntents...,
+			),
+		}
+
+		return newImmediateFuture[wallet.WalletResp](resp)
+	}
+
 	return newImmediateFuture[wallet.WalletResp](nil)
 }
 
@@ -249,6 +271,18 @@ func (m *mockWalletActorRef) adoptedRequests() []wire.OutPoint {
 	defer m.mu.Unlock()
 
 	return append([]wire.OutPoint(nil), m.adoptedOutpoints...)
+}
+
+func (m *mockWalletActorRef) setConfirmedIntents(
+	intents ...wallet.BoardingIntent,
+) {
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.confirmedIntents = append(
+		[]wallet.BoardingIntent(nil), intents...,
+	)
 }
 
 // sendBoardingConfirmation simulates a boarding UTXO confirmation from wallet.
@@ -859,6 +893,13 @@ func (h *actorTestHarness) assertServerMessageSent(msgType string) {
 // verify only new messages sent after this point.
 func (h *actorTestHarness) clearServerMessages() {
 	h.serverConn.clearMessages()
+}
+
+// serverMessages returns a snapshot of messages sent to the server.
+func (h *actorTestHarness) serverMessages() []serverconn.ServerConnMsg {
+	h.t.Helper()
+
+	return h.serverConn.snapshotMessages()
 }
 
 // sendVTXORequests sends VTXO request amounts to the actor. This sets up the

--- a/round/actor_test.go
+++ b/round/actor_test.go
@@ -10,8 +10,10 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
 	"github.com/lightninglabs/darepo-client/internal/testutils"
+	"github.com/lightninglabs/darepo-client/lib/actormsg"
 	"github.com/lightninglabs/darepo-client/lib/tree"
 	"github.com/lightninglabs/darepo-client/lib/types"
+	"github.com/lightninglabs/darepo-client/serverconn"
 	"github.com/lightninglabs/darepo-client/timeout"
 	"github.com/lightninglabs/darepo-client/wallet"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
@@ -284,6 +286,64 @@ func TestActorRecovery(t *testing.T) {
 
 		require.Len(t, h.actor.commitmentTxIndex, 3)
 		require.Len(t, h.chainSource.registrations, 3)
+	})
+
+	t.Run("replays_checkpointed_boarding_input_sigs", func(t *testing.T) {
+		t.Parallel()
+
+		h := newActorTestHarness(t)
+
+		roundID := testRoundID("replay-input-sigs")
+		round := h.newTestRound(roundID)
+		walletIntent := h.newTestBoardingIntent()
+		intent, err := buildBoardingIntentFromWallet(walletIntent)
+		require.NoError(t, err)
+		inputSig := &types.BoardingInputSignature{
+			InputIndex: 0,
+			Outpoint:   walletIntent.Outpoint,
+			ClientSignature: testutils.TestSchnorrSignature(
+				t, "replay",
+			),
+		}
+
+		h.roundStore.On(
+			"ListActiveRounds", mock.Anything,
+		).Return([]*Round{round}, nil)
+		h.roundStore.On(
+			"FetchState", mock.Anything, round.RoundID,
+		).Return(
+			round,
+			&InputSigSentState{
+				RoundID: roundID,
+				CommitmentTx: round.CommitmentTx.
+					UnwrapOrFail(t),
+				Intents: Intents{
+					Boarding: []BoardingIntent{intent},
+				},
+				InputSigs: []*types.BoardingInputSignature{
+					inputSig,
+				},
+			},
+			nil,
+		)
+
+		err = h.start()
+		require.NoError(t, err)
+
+		msgs := h.serverMessages()
+		require.Len(t, msgs, 1)
+
+		req, ok := msgs[0].(*serverconn.SendClientEventRequest)
+		require.True(t, ok, "expected SendClientEventRequest, got %T",
+			msgs[0])
+
+		replayed, ok := req.Message.(*SubmitForfeitSigRequest)
+		require.True(t, ok, "expected SubmitForfeitSigRequest, got %T",
+			req.Message)
+		require.Equal(t, roundID, replayed.RoundID)
+		require.Len(t, replayed.Signatures, 1)
+		require.Equal(t, walletIntent.Outpoint,
+			replayed.Signatures[0].Outpoint)
 	})
 }
 
@@ -1331,6 +1391,53 @@ func TestHandleForfeitSignatureResponse(t *testing.T) {
 		require.True(t, result.IsErr())
 		require.Contains(t, result.Err().Error(), "unknown round")
 	})
+}
+
+// TestHandleTriggerBoard verifies the board trigger path rebuilds confirmed
+// boarding intents from the wallet actor before round registration.
+func TestHandleTriggerBoard(t *testing.T) {
+	t.Parallel()
+
+	h := newActorTestHarness(t)
+	h.setupMockRoundStoreForStart()
+
+	err := h.start()
+	require.NoError(t, err)
+
+	intent := h.newTestBoardingIntent()
+	h.walletActor.setConfirmedIntents(*intent)
+
+	h.wallet.On(
+		"DeriveNextKey", mock.Anything, keychain.KeyFamilyMultiSig,
+	).Return(&keychain.KeyDescriptor{
+		PubKey: h.clientPubKey,
+		KeyLocator: keychain.KeyLocator{
+			Family: keychain.KeyFamilyMultiSig,
+			Index:  0,
+		},
+	}, nil).Once()
+
+	result := h.receive(&actormsg.TriggerBoardMsg{
+		Amounts: []btcutil.Amount{49_000},
+	})
+	require.True(t, result.IsOk(), "expected Ok, got: %v",
+		result.Err())
+
+	states := h.queryState()
+	tempState, exists := h.findTempState(states)
+	require.True(t, exists, "expected temp-keyed FSM state")
+
+	regState, ok := tempState.State.(*RegistrationSentState)
+	require.True(t, ok, "expected RegistrationSentState, got %T",
+		tempState.State)
+	require.Len(t, regState.Intents.Boarding, 1)
+	require.Equal(
+		t, intent.Outpoint, regState.Intents.Boarding[0].Outpoint,
+	)
+	require.Len(t, regState.Intents.VTXOs, 1)
+	require.Equal(
+		t, btcutil.Amount(49_000), regState.Intents.VTXOs[0].Amount,
+	)
 }
 
 // TestHandleForfeitCollectionTimeout verifies timeout-message handling for

--- a/wallet/interfaces.go
+++ b/wallet/interfaces.go
@@ -112,6 +112,13 @@ var MessageSpec = struct {
 		*RegisterConfirmationNotifierResponse,
 	]
 
+	// GetConfirmedBoardingIntents returns the currently confirmed boarding
+	// intents tracked by the wallet.
+	GetConfirmedBoardingIntents Ask[
+		*GetConfirmedBoardingIntentsRequest,
+		*GetConfirmedBoardingIntentsResponse,
+	]
+
 	// UnregisterConfirmationNotifier removes a previously registered
 	// confirmation notifier subscription.
 	UnregisterConfirmationNotifier Ask[

--- a/wallet/messages.go
+++ b/wallet/messages.go
@@ -186,6 +186,40 @@ func (m *RegisterConfirmationNotifierResponse) MessageType() string {
 // walletRespSealed implements the sealed WalletResp interface.
 func (m *RegisterConfirmationNotifierResponse) walletRespSealed() {}
 
+// GetConfirmedBoardingIntentsRequest asks the wallet actor for the currently
+// confirmed boarding intents. Round retry after restart uses this to rebuild
+// the boarding side of round assembly from the wallet's persisted source of
+// truth.
+type GetConfirmedBoardingIntentsRequest struct {
+	actor.BaseMessage
+}
+
+// MessageType returns the message type identifier for logging and debugging.
+func (m *GetConfirmedBoardingIntentsRequest) MessageType() string {
+	return "GetConfirmedBoardingIntentsRequest"
+}
+
+// walletMsgSealed implements the sealed WalletMsg interface.
+func (m *GetConfirmedBoardingIntentsRequest) walletMsgSealed() {}
+
+// GetConfirmedBoardingIntentsResponse returns the confirmed boarding intents
+// currently tracked by the wallet actor.
+type GetConfirmedBoardingIntentsResponse struct {
+	actor.BaseMessage
+
+	// Intents are the confirmed boarding intents ready for round
+	// registration.
+	Intents []BoardingIntent
+}
+
+// MessageType returns the message type identifier for logging and debugging.
+func (m *GetConfirmedBoardingIntentsResponse) MessageType() string {
+	return "GetConfirmedBoardingIntentsResponse"
+}
+
+// walletRespSealed implements the sealed WalletResp interface.
+func (m *GetConfirmedBoardingIntentsResponse) walletRespSealed() {}
+
 // UnregisterConfirmationNotifierRequest removes a previously registered
 // confirmation notifier. The actor will no longer receive boarding UTXO
 // confirmation events.

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -290,6 +290,9 @@ func (a *Ark) Receive(ctx context.Context,
 	case *RegisterConfirmationNotifierRequest:
 		return a.handleRegisterNotifier(ctx, m)
 
+	case *GetConfirmedBoardingIntentsRequest:
+		return a.handleGetConfirmedBoardingIntents(ctx, m)
+
 	case *UnregisterConfirmationNotifierRequest:
 		return a.handleUnregisterNotifier(ctx, m)
 
@@ -464,6 +467,26 @@ func (a *Ark) handleRegisterNotifier(ctx context.Context,
 	}
 
 	return fn.Ok[WalletResp](resp)
+}
+
+// handleGetConfirmedBoardingIntents returns the wallet's currently confirmed
+// boarding intents. This gives the round actor a restart-safe way to rebuild
+// pending boarding input packages from the wallet's persisted state.
+func (a *Ark) handleGetConfirmedBoardingIntents(ctx context.Context,
+	_ *GetConfirmedBoardingIntentsRequest) fn.Result[WalletResp] {
+
+	intents, err := a.store.FetchBoardingIntentsByStatus(
+		ctx, BoardingStatusConfirmed,
+	)
+	if err != nil {
+		return fn.Err[WalletResp](fmt.Errorf(
+			"fetch confirmed boarding intents: %w", err,
+		))
+	}
+
+	return fn.Ok[WalletResp](&GetConfirmedBoardingIntentsResponse{
+		Intents: intents,
+	})
 }
 
 // handleUnregisterNotifier removes an actor from the notification list.

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -1033,6 +1033,56 @@ func TestGetBoardingBalance(t *testing.T) {
 	store.AssertExpectations(t)
 }
 
+// TestGetConfirmedBoardingIntents verifies the wallet actor returns the
+// currently confirmed boarding intents for restart-safe round retries.
+func TestGetConfirmedBoardingIntents(t *testing.T) {
+	t.Parallel()
+
+	backend := &MockBoardingBackend{}
+	store := &MockBoardingStore{}
+	confirmed := []BoardingIntent{{
+		Outpoint: wire.OutPoint{
+			Hash:  chainhash.HashH([]byte("confirmed")),
+			Index: 1,
+		},
+		Status: BoardingStatusConfirmed,
+		ChainInfo: BoardingChainInfo{
+			Amount: 42_000,
+		},
+	}}
+	store.On(
+		"FetchBoardingIntentsByStatus",
+		mock.Anything, BoardingStatusConfirmed,
+	).Return(
+		confirmed, nil,
+	)
+
+	epochChan := make(chan chainsource.BlockEpoch, 1)
+	chainSource := newMockChainSourceActor(epochChan)
+
+	walletActor := NewArk(
+		backend, store, nil, chainSource, nil,
+		btclog.Disabled,
+	)
+
+	result := walletActor.Receive(
+		t.Context(), &GetConfirmedBoardingIntentsRequest{},
+	)
+	require.True(t, result.IsOk())
+
+	respVal, _ := result.Unpack()
+	resp, ok := respVal.(*GetConfirmedBoardingIntentsResponse)
+	require.True(t, ok)
+	require.Len(t, resp.Intents, 1)
+	require.Equal(t, confirmed[0].Outpoint, resp.Intents[0].Outpoint)
+	require.Equal(
+		t, confirmed[0].ChainInfo.Amount,
+		resp.Intents[0].ChainInfo.Amount,
+	)
+
+	store.AssertExpectations(t)
+}
+
 // TestMarkBoardingIntentsAdopted verifies that checkpoint notifications from
 // the round actor transition consumed boarding intents out of Confirmed status.
 func TestMarkBoardingIntentsAdopted(t *testing.T) {


### PR DESCRIPTION
## Summary

This fixes two restart-related boarding gaps on the client side.

First, `TriggerBoard` now rebuilds confirmed boarding intents from the
wallet actor's persisted state instead of rebuilding only VTXO output
requests from balance. That makes retry after restart use the actual
confirmed boarding inputs that fund the board flow.

Second, startup recovery now replays boarding input signature
submission for rounds restored in `InputSigSentState`. Before this,
a daemon could checkpoint the round successfully and still lose the
`SubmitForfeitSigRequest` send if it restarted before the in-memory
actor loop forwarded that message to `serverconn`.

Together these changes make the implementation line up with the current
design boundary: pre-checkpoint rounds are still not guaranteed to
resume, but rounds at `InputSigSent` and beyond now recover cleanly.

## Testing

- `go test ./wallet -run 'TestGetConfirmedBoardingIntents' -count=1`
- `go test ./round ./wallet -run 'TestActorRecovery|TestHandleTriggerBoard|TestGetConfirmedBoardingIntents' -count=1`
- `make lint-changed-local base=origin/master`
