### PR TITLE
chore: ignore native custom-gcl binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ DS_Store
 
 # Go workspace sum file - regenerated locally as needed.
 go.work.sum
+
+/tools/custom-gcl


### PR DESCRIPTION
## Summary

Ignore the generated native `custom-gcl` binary in the client repo.

## Why

The native linter installer writes a machine-local binary to
`tools/custom-gcl`. That artifact is useful for local linting, but it is
compiled build output and should not appear as an untracked repo change.

Ignoring it keeps local installs from adding status noise during review
and branch cleanup.
