### PR TITLE
oor: retry mark-inputs-spent on resume

### DIFF
--- a/oor/actor.go
+++ b/oor/actor.go
@@ -1257,7 +1257,7 @@ func (b *oorDurableBehavior) driveOutbox(ctx context.Context,
 		followUps, err := handler.Handle(ctx, sessionID, msg)
 		if err != nil {
 			//nolint:ll
-			b.logger(ctx).WarnS(ctx, "Outbox handler error, wrapping as retryable event", err,
+			b.logger(ctx).WarnS(ctx, "Outbox handler error, mapping to outbox error event", err,
 				slog.String("session_id", sessionID.String()),
 				slog.String("event_type", fmt.Sprintf("%T", msg)))
 

--- a/oor/actor_resume_test.go
+++ b/oor/actor_resume_test.go
@@ -2,6 +2,7 @@ package oor
 
 import (
 	"context"
+	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1338,4 +1339,187 @@ func TestOORClientActorDurableRestartAutoResume(t *testing.T) {
 			return false
 		}
 	}, 5*time.Second, 50*time.Millisecond)
+}
+
+// TestOORClientActorDurableRestartRetriesMarkInputsSpent asserts that a
+// retryable local-spend completion failure survives restart without moving the
+// session into Failed.
+func TestOORClientActorDurableRestartRetriesMarkInputsSpent(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	policy := scripts.CheckpointPolicy{
+		OperatorKey: operatorKey.PubKey(),
+		CSVDelay:    10,
+	}
+
+	inputValue := btcutil.Amount(10000)
+
+	clientKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	clientSigner := input.NewMockSigner([]*btcec.PrivateKey{clientKey}, nil)
+	operatorSigner := input.NewMockSigner(
+		[]*btcec.PrivateKey{operatorKey}, nil,
+	)
+
+	inputs := []TransferInput{
+		newTestTransferInput(
+			t, clientKey, policy.OperatorKey,
+			wire.OutPoint{
+				Hash:  [32]byte{0x04},
+				Index: 0,
+			},
+			inputValue,
+		),
+	}
+
+	recipients := []oortx.RecipientOutput{
+		{
+			PkScript: newTestTaprootPkScript(t, clientKey.PubKey()),
+			Value:    inputValue,
+		},
+	}
+
+	deliveryStore := newTestDeliveryStore(t)
+	const actorID = "oor-restart-mark-inputs-spent-retry"
+
+	handler1 := &retryRecordingHandler{
+		t:              t,
+		clientSigner:   clientSigner,
+		operatorSigner: operatorSigner,
+	}
+
+	var completeSpendAttempts atomic.Int32
+	completeSpend := func(_ context.Context, ops []wire.OutPoint) error {
+		require.Equal(t, InputOutpoints(inputs), ops)
+
+		// The first local-spend completion simulates the transient
+		// manager-unavailable race we see during shutdown/restart
+		// overlap.
+		if completeSpendAttempts.Add(1) == 1 {
+			return fmt.Errorf("no actors available for service key")
+		}
+
+		return nil
+	}
+
+	actor1 := NewOORClientActor(ClientActorCfg{
+		OutboxHandler: &LocalPersistenceOutboxHandler{
+			Next:          handler1,
+			CompleteSpend: completeSpend,
+		},
+		DeliveryStore: deliveryStore,
+		ActorID:       actorID,
+	})
+
+	startResp := actor1.Receive(ctx, &StartTransferRequest{
+		Policy:     policy,
+		Inputs:     inputs,
+		Recipients: recipients,
+	})
+	require.True(t, startResp.IsOk())
+
+	startMsg, ok := startResp.UnwrapOr(nil).(*StartTransferResponse)
+	require.True(t, ok)
+
+	stateResp := actor1.Receive(ctx, &GetStateRequest{
+		SessionID: startMsg.SessionID,
+	})
+	require.True(t, stateResp.IsOk())
+
+	stateMsg, ok := stateResp.UnwrapOr(nil).(*GetStateResponse)
+	require.True(t, ok)
+	require.IsType(t, &AwaitingLocalVTXOUpdate{}, stateMsg.State)
+
+	// Export the checkpoint so we can assert the retry metadata is already
+	// persisted before the first actor is stopped.
+	exportResp := actor1.Receive(ctx, &ExportSnapshotRequest{
+		SessionID: startMsg.SessionID,
+	})
+	require.True(t, exportResp.IsOk())
+
+	exportMsg, ok := exportResp.UnwrapOr(nil).(*ExportSnapshotResponse)
+	require.True(t, ok)
+	require.NotZero(t, exportMsg.Snapshot.RetryAfter)
+	require.Contains(t, exportMsg.Snapshot.FailReason,
+		"complete spend via manager")
+
+	actor1.Stop()
+
+	handler2 := &retryRecordingHandler{
+		t:              t,
+		clientSigner:   clientSigner,
+		operatorSigner: operatorSigner,
+	}
+
+	actor2 := NewOORClientActor(ClientActorCfg{
+		OutboxHandler: &LocalPersistenceOutboxHandler{
+			Next:          handler2,
+			CompleteSpend: completeSpend,
+		},
+		DeliveryStore: deliveryStore,
+		ActorID:       actorID,
+	})
+	defer actor2.Stop()
+
+	// Restart should honor the saved retry metadata by scheduling
+	// retry work rather than immediately re-driving
+	// MarkInputsSpentRequest.
+	require.Eventually(t, func() bool {
+		resp := actor2.Receive(ctx, &GetStateRequest{
+			SessionID: startMsg.SessionID,
+		})
+		if resp.IsErr() {
+			return false
+		}
+
+		got, ok := resp.UnwrapOr(nil).(*GetStateResponse)
+		if !ok {
+			return false
+		}
+
+		_, awaitingLocalUpdate := got.State.(*AwaitingLocalVTXOUpdate)
+
+		return awaitingLocalUpdate
+	}, 5*time.Second, 50*time.Millisecond)
+
+	require.True(t, handler2.sawScheduleRetry.Load(),
+		"restart should preserve retry intent for local "+
+			"spend completion")
+	require.EqualValues(t, 1, completeSpendAttempts.Load(),
+		"restart should not re-drive spend completion "+
+			"before explicit resume")
+
+	// Once the user explicitly resumes, the same durable state
+	// should replay the local spend completion and let the session
+	// finish cleanly.
+	resumeResp := actor2.Receive(ctx, &ResumeSessionRequest{
+		SessionID: startMsg.SessionID,
+	})
+	require.True(t, resumeResp.IsOk())
+
+	require.Eventually(t, func() bool {
+		resp := actor2.Receive(ctx, &GetStateRequest{
+			SessionID: startMsg.SessionID,
+		})
+		if resp.IsErr() {
+			return false
+		}
+
+		got, ok := resp.UnwrapOr(nil).(*GetStateResponse)
+		if !ok {
+			return false
+		}
+
+		_, completed := got.State.(*Completed)
+
+		return completed
+	}, 5*time.Second, 50*time.Millisecond)
+
+	require.EqualValues(t, 2, completeSpendAttempts.Load())
 }

--- a/oor/local_persistence_handler.go
+++ b/oor/local_persistence_handler.go
@@ -168,8 +168,13 @@ func (h *LocalPersistenceOutboxHandler) handleMarkInputsSpent(
 	if h.CompleteSpend != nil {
 		err := h.CompleteSpend(ctx, msg.Outpoints)
 		if err != nil {
-			return nil, fmt.Errorf("complete spend via "+
-				"manager: %w", err)
+			wrappedErr := fmt.Errorf(
+				"complete spend via manager: %w", err,
+			)
+
+			return nil, NewRetryableOutboxError(
+				wrappedErr, defaultRetryDelay,
+			)
 		}
 
 		return []Event{&InputsMarkedSpentEvent{}}, nil

--- a/oor/local_persistence_handler_test.go
+++ b/oor/local_persistence_handler_test.go
@@ -601,6 +601,9 @@ func TestLocalPersistenceHandlerMarkInputsSpentCompleterError(t *testing.T) {
 	)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "actor unavailable")
+	var retryErr *RetryableOutboxError
+	require.ErrorAs(t, err, &retryErr)
+	require.Equal(t, defaultRetryDelay, retryErr.RetryAfter)
 	require.Empty(t, events)
 }
 


### PR DESCRIPTION
## Summary

This is a focused client-side fix for the real retry classification bug we
surfaced while investigating the flaky `TestOORClientResumeAfterCoSign`
failure in `lightninglabs/darepo#184`.

When the OOR FSM reaches `AwaitingLocalVTXOUpdate`, the local persistence
handler routes `MarkInputsSpentRequest` through `CompleteSpend`. If that path
fails during shutdown or restart overlap, we want to preserve retry metadata
and resume the session later. Before this change, the handler returned a plain
error, so the actor checkpointed the session as `Failed` even though the
failure was transient.

## What changed

- wrap `CompleteSpend` failures in `NewRetryableOutboxError`
- keep the fallback direct-store path unchanged
- add a handler-level regression asserting mark-inputs-spent failures are
  tagged retryable
- add a durable restart regression proving the session stays in
  `AwaitingLocalVTXOUpdate`, preserves retry metadata across restart, and
  completes after explicit resume
- make the actor log message say it is mapping handler failures to outbox
  error events rather than claiming every failure is retryable

## Testing

- `go test ./oor -count=1`
- `make lint-changed-local base=origin/main`
- `python3 scripts/commit_message.py lint --range origin/main..HEAD`
