### PR TITLE
darepod: expose integration itest control hooks

### DIFF
--- a/darepod/config.go
+++ b/darepod/config.go
@@ -8,7 +8,9 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/chaincfg"
+	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
 	"github.com/lightninglabs/darepo-client/rpc/roundpb"
+	"google.golang.org/grpc"
 )
 
 const (
@@ -90,6 +92,11 @@ type Config struct {
 	// writes logs to stdout.
 	LogWriter io.Writer
 
+	// MailboxEdgeFactory optionally wraps the mailbox transport edge used
+	// by the serverconn runtime. Test harnesses use this to intercept
+	// durable transport traffic without changing production config files.
+	MailboxEdgeFactory MailboxEdgeFactory
+
 	// Lnd configures the connection to the backing lnd node.
 	Lnd *LndConfig `mapstructure:"lnd"`
 
@@ -116,6 +123,12 @@ type Config struct {
 	// mainnet during development, since DefaultNetwork is "mainnet".
 	AllowMainnet bool `mapstructure:"allow-mainnet"`
 }
+
+// MailboxEdgeFactory constructs the mailbox edge client used by the
+// serverconn runtime from the underlying gRPC connection to the operator.
+type MailboxEdgeFactory func(
+	conn grpc.ClientConnInterface,
+) mailboxpb.MailboxServiceClient
 
 // LndConfig holds connection parameters for the backing lnd node.
 type LndConfig struct {

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -1067,6 +1067,10 @@ func (s *Server) dialServer(ctx context.Context) (
 // connection. The runtime uses this to send and pull envelopes through the
 // operator's mailbox edge service.
 func (s *Server) newMailboxEdge() mailboxpb.MailboxServiceClient {
+	if s.cfg.MailboxEdgeFactory != nil {
+		return s.cfg.MailboxEdgeFactory(s.serverConn)
+	}
+
 	return mailboxpb.NewMailboxServiceClient(s.serverConn)
 }
 

--- a/darepod/server_mailbox_edge_test.go
+++ b/darepod/server_mailbox_edge_test.go
@@ -1,0 +1,53 @@
+package darepod
+
+import (
+	"context"
+	"testing"
+
+	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+type stubMailboxServiceClient struct{}
+
+func (s *stubMailboxServiceClient) Send(context.Context,
+	*mailboxpb.SendRequest, ...grpc.CallOption) (
+	*mailboxpb.SendResponse, error) {
+
+	return &mailboxpb.SendResponse{}, nil
+}
+
+func (s *stubMailboxServiceClient) Pull(context.Context,
+	*mailboxpb.PullRequest, ...grpc.CallOption) (
+	*mailboxpb.PullResponse, error) {
+
+	return &mailboxpb.PullResponse{}, nil
+}
+
+func (s *stubMailboxServiceClient) AckUpTo(context.Context,
+	*mailboxpb.AckUpToRequest, ...grpc.CallOption) (
+	*mailboxpb.AckUpToResponse, error) {
+
+	return &mailboxpb.AckUpToResponse{}, nil
+}
+
+// TestServerNewMailboxEdgeUsesFactory verifies the daemon wiring can replace
+// the default mailbox edge client for test harness interception.
+func TestServerNewMailboxEdgeUsesFactory(t *testing.T) {
+	t.Parallel()
+
+	expected := &stubMailboxServiceClient{}
+	server := &Server{
+		cfg: &Config{
+			MailboxEdgeFactory: func(
+				grpc.ClientConnInterface,
+			) mailboxpb.MailboxServiceClient {
+
+				return expected
+			},
+		},
+	}
+
+	require.Same(t, expected, server.newMailboxEdge())
+}

--- a/darepod/server_round_testhook.go
+++ b/darepod/server_round_testhook.go
@@ -1,0 +1,31 @@
+package darepod
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/lightninglabs/darepo-client/round"
+)
+
+// TriggerRoundRegistration injects a RegistrationRequested event into the
+// client round actor. The integration harness uses this to advance a queued
+// round intent without reaching through private actor internals directly.
+func (s *Server) TriggerRoundRegistration(ctx context.Context) error {
+	if s.actorSystem == nil {
+		return fmt.Errorf("actor system not initialized")
+	}
+
+	roundRef := round.NewServiceKey().Ref(s.actorSystem)
+	future := roundRef.Ask(ctx, &round.ServerMessageNotification{
+		Message: &round.RegistrationRequested{},
+	})
+	result := future.Await(ctx)
+	if err := result.Err(); err != nil {
+		return fmt.Errorf(
+			"failed to trigger round registration: %w",
+			err,
+		)
+	}
+
+	return nil
+}

--- a/darepod/server_round_testhook_test.go
+++ b/darepod/server_round_testhook_test.go
@@ -1,0 +1,69 @@
+package darepod
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/lib/actormsg"
+	"github.com/lightninglabs/darepo-client/round"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestServerTriggerRoundRegistrationRequiresActorSystem verifies the harness
+// helper fails fast before daemon startup has initialized the actor system.
+func TestServerTriggerRoundRegistrationRequiresActorSystem(t *testing.T) {
+	t.Parallel()
+
+	server := &Server{}
+
+	err := server.TriggerRoundRegistration(t.Context())
+	require.EqualError(t, err, "actor system not initialized")
+}
+
+// TestServerTriggerRoundRegistration verifies the helper injects the expected
+// RegistrationRequested event through the round actor service key.
+func TestServerTriggerRoundRegistration(t *testing.T) {
+	t.Parallel()
+
+	system := actor.NewActorSystem()
+	defer func() {
+		err := system.Shutdown(t.Context())
+		require.NoError(t, err)
+	}()
+
+	delivered := make(chan *round.ServerMessageNotification, 1)
+	key := round.NewServiceKey()
+	behavior := actor.NewFunctionBehavior(
+		func(_ context.Context,
+			msg actormsg.RoundReceivable,
+		) fn.Result[actormsg.RoundActorResp] {
+
+			notif, ok := msg.(*round.ServerMessageNotification)
+			require.True(
+				t, ok,
+				"expected server notification, got %T",
+				msg,
+			)
+
+			delivered <- notif
+
+			return fn.Ok[actormsg.RoundActorResp](
+				&round.ServerMessageResponse{},
+			)
+		},
+	)
+	_ = actor.RegisterWithSystem(system, "round-under-test", key, behavior)
+
+	server := &Server{actorSystem: system}
+	require.NoError(t, server.TriggerRoundRegistration(t.Context()))
+
+	select {
+	case notif := <-delivered:
+		require.IsType(t, &round.RegistrationRequested{}, notif.Message)
+
+	case <-t.Context().Done():
+		t.Fatal("round registration was not delivered")
+	}
+}


### PR DESCRIPTION
## Summary
- add a mailbox edge factory hook so the server-side itest harness can wrap real darepod mailbox traffic
- add a narrow TriggerRoundRegistration helper for driving queued round intents through the real round actor
- cover both hooks with focused darepod tests

## Testing
- go test ./darepod -run "TestServerNewMailboxEdgeUsesFactory|TestServerTriggerRoundRegistration" -count=1
- make lint-changed-local base=origin/main
