### PR TITLE
darepod: add mailbox edge factory hook

### DIFF
--- a/darepod/config.go
+++ b/darepod/config.go
@@ -8,7 +8,9 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/chaincfg"
+	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
 	"github.com/lightninglabs/darepo-client/rpc/roundpb"
+	"google.golang.org/grpc"
 )
 
 const (
@@ -90,6 +92,11 @@ type Config struct {
 	// writes logs to stdout.
 	LogWriter io.Writer
 
+	// MailboxEdgeFactory optionally wraps the mailbox transport edge used
+	// by the serverconn runtime. Test harnesses use this to intercept
+	// durable transport traffic without changing production config files.
+	MailboxEdgeFactory MailboxEdgeFactory
+
 	// Lnd configures the connection to the backing lnd node.
 	Lnd *LndConfig `mapstructure:"lnd"`
 
@@ -116,6 +123,12 @@ type Config struct {
 	// mainnet during development, since DefaultNetwork is "mainnet".
 	AllowMainnet bool `mapstructure:"allow-mainnet"`
 }
+
+// MailboxEdgeFactory constructs the mailbox edge client used by the
+// serverconn runtime from the underlying gRPC connection to the operator.
+type MailboxEdgeFactory func(
+	conn grpc.ClientConnInterface,
+) mailboxpb.MailboxServiceClient
 
 // LndConfig holds connection parameters for the backing lnd node.
 type LndConfig struct {

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -1067,6 +1067,10 @@ func (s *Server) dialServer(ctx context.Context) (
 // connection. The runtime uses this to send and pull envelopes through the
 // operator's mailbox edge service.
 func (s *Server) newMailboxEdge() mailboxpb.MailboxServiceClient {
+	if s.cfg.MailboxEdgeFactory != nil {
+		return s.cfg.MailboxEdgeFactory(s.serverConn)
+	}
+
 	return mailboxpb.NewMailboxServiceClient(s.serverConn)
 }
 

--- a/darepod/server_mailbox_edge_test.go
+++ b/darepod/server_mailbox_edge_test.go
@@ -1,0 +1,53 @@
+package darepod
+
+import (
+	"context"
+	"testing"
+
+	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+type stubMailboxServiceClient struct{}
+
+func (s *stubMailboxServiceClient) Send(context.Context,
+	*mailboxpb.SendRequest, ...grpc.CallOption) (
+	*mailboxpb.SendResponse, error) {
+
+	return &mailboxpb.SendResponse{}, nil
+}
+
+func (s *stubMailboxServiceClient) Pull(context.Context,
+	*mailboxpb.PullRequest, ...grpc.CallOption) (
+	*mailboxpb.PullResponse, error) {
+
+	return &mailboxpb.PullResponse{}, nil
+}
+
+func (s *stubMailboxServiceClient) AckUpTo(context.Context,
+	*mailboxpb.AckUpToRequest, ...grpc.CallOption) (
+	*mailboxpb.AckUpToResponse, error) {
+
+	return &mailboxpb.AckUpToResponse{}, nil
+}
+
+// TestServerNewMailboxEdgeUsesFactory verifies the daemon wiring can replace
+// the default mailbox edge client for test harness interception.
+func TestServerNewMailboxEdgeUsesFactory(t *testing.T) {
+	t.Parallel()
+
+	expected := &stubMailboxServiceClient{}
+	server := &Server{
+		cfg: &Config{
+			MailboxEdgeFactory: func(
+				grpc.ClientConnInterface,
+			) mailboxpb.MailboxServiceClient {
+
+				return expected
+			},
+		},
+	}
+
+	require.Same(t, expected, server.newMailboxEdge())
+}


### PR DESCRIPTION
## Summary
- add a `MailboxEdgeFactory` hook to darepod config so harnesses can wrap mailbox transport without changing production behavior
- route `Server.newMailboxEdge` through that hook and keep the default generated gRPC client path unchanged
- add focused darepod coverage for the injected mailbox edge path

## Testing
- go test ./darepod -run TestServerNewMailboxEdgeUsesFactory -count=1
- make lint-changed-local base=origin/main
