### PR TITLE
harness: mine relay-floor refresh txs

### DIFF
--- a/chainbackends/lnd.go
+++ b/chainbackends/lnd.go
@@ -163,7 +163,7 @@ func (b *LNDBackend) BroadcastTx(ctx context.Context, tx *wire.MsgTx,
 
 	txHash := tx.TxHash()
 	b.logger(ctx).InfoS(ctx, "Broadcasting transaction via LND",
-		btclog.Hex("txid", txHash[:]),
+		slog.String("txid", txHash.String()),
 		slog.String("label", label))
 
 	err := b.broadcaster.PublishTransaction(ctx, tx, label)
@@ -172,7 +172,7 @@ func (b *LNDBackend) BroadcastTx(ctx context.Context, tx *wire.MsgTx,
 	}
 
 	b.logger(ctx).InfoS(ctx, "Transaction broadcast successfully",
-		btclog.Hex("txid", txHash[:]))
+		slog.String("txid", txHash.String()))
 
 	return nil
 }

--- a/harness/harness.go
+++ b/harness/harness.go
@@ -1068,6 +1068,9 @@ func (h *Harness) startBitcoind() {
 		// Match the lower fee estimates we see from electrs in tests so
 		// commitment packages targeting ~0.5 sat/vB still pass policy.
 		"-minrelaytxfee=0.00000500",
+		// Keep the miner inclusion floor aligned with relay policy so
+		// low-fee mempool transactions are still mined on regtest.
+		"-blockmintxfee=0.00000500",
 		fmt.Sprintf("-rpcuser=%s", bitcoindRPCUser),
 		fmt.Sprintf("-rpcpassword=%s", bitcoindRPCPass),
 		"-rpcallowip=0.0.0.0/0",


### PR DESCRIPTION
## Summary
- align the regtest miner floor with the already-relaxed relay floor
- log LND broadcast txids in canonical string form
- fix the harness condition that let refresh commitment txs sit in mempool without ever being mined

## Testing
- `go test ./chainbackends -count=1`
- `go test ./harness -run '^TestHarnessFaucet$' -count=1`
- `make lint-changed-local base=origin/main`
