### PR TITLE
multi: implement in-round directed VTXO sends

### DIFF
--- a/daemonrpc/daemon.pb.go
+++ b/daemonrpc/daemon.pb.go
@@ -1427,8 +1427,14 @@ type SendVTXOResponse struct {
 	// total_amount_sat is the total amount being sent (sum of
 	// recipients).
 	TotalAmountSat int64 `protobuf:"varint,3,opt,name=total_amount_sat,json=totalAmountSat,proto3" json:"total_amount_sat,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// change_amount_sat is the change returned to the sender. Zero if
+	// the selected VTXOs exactly covered the total.
+	ChangeAmountSat int64 `protobuf:"varint,4,opt,name=change_amount_sat,json=changeAmountSat,proto3" json:"change_amount_sat,omitempty"`
+	// selected_count is the number of VTXOs selected as inputs for
+	// this send.
+	SelectedCount int32 `protobuf:"varint,5,opt,name=selected_count,json=selectedCount,proto3" json:"selected_count,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *SendVTXOResponse) Reset() {
@@ -1478,6 +1484,20 @@ func (x *SendVTXOResponse) GetRoundId() string {
 func (x *SendVTXOResponse) GetTotalAmountSat() int64 {
 	if x != nil {
 		return x.TotalAmountSat
+	}
+	return 0
+}
+
+func (x *SendVTXOResponse) GetChangeAmountSat() int64 {
+	if x != nil {
+		return x.ChangeAmountSat
+	}
+	return 0
+}
+
+func (x *SendVTXOResponse) GetSelectedCount() int32 {
+	if x != nil {
+		return x.SelectedCount
 	}
 	return 0
 }
@@ -2292,11 +2312,13 @@ const file_daemon_proto_rawDesc = "" +
 	"\n" +
 	"recipients\x18\x01 \x03(\v2\x11.daemonrpc.OutputR\n" +
 	"recipients\x12\x17\n" +
-	"\adry_run\x18\x02 \x01(\bR\x06dryRun\"o\n" +
+	"\adry_run\x18\x02 \x01(\bR\x06dryRun\"\xc2\x01\n" +
 	"\x10SendVTXOResponse\x12\x16\n" +
 	"\x06status\x18\x01 \x01(\tR\x06status\x12\x19\n" +
 	"\bround_id\x18\x02 \x01(\tR\aroundId\x12(\n" +
-	"\x10total_amount_sat\x18\x03 \x01(\x03R\x0etotalAmountSat\"Z\n" +
+	"\x10total_amount_sat\x18\x03 \x01(\x03R\x0etotalAmountSat\x12*\n" +
+	"\x11change_amount_sat\x18\x04 \x01(\x03R\x0fchangeAmountSat\x12%\n" +
+	"\x0eselected_count\x18\x05 \x01(\x05R\rselectedCount\"Z\n" +
 	"\x0eSendOORRequest\x12/\n" +
 	"\trecipient\x18\x01 \x01(\v2\x11.daemonrpc.OutputR\trecipient\x12\x17\n" +
 	"\adry_run\x18\x02 \x01(\bR\x06dryRun\"H\n" +

--- a/daemonrpc/daemon.proto
+++ b/daemonrpc/daemon.proto
@@ -350,6 +350,14 @@ message SendVTXOResponse {
     // total_amount_sat is the total amount being sent (sum of
     // recipients).
     int64 total_amount_sat = 3;
+
+    // change_amount_sat is the change returned to the sender. Zero if
+    // the selected VTXOs exactly covered the total.
+    int64 change_amount_sat = 4;
+
+    // selected_count is the number of VTXOs selected as inputs for
+    // this send.
+    int32 selected_count = 5;
 }
 
 message SendOORRequest {

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -638,43 +639,130 @@ func (r *RPCServer) SendVTXO(ctx context.Context,
 			"at least one recipient is required")
 	}
 
-	// Validate recipients and compute total amount.
+	// Resolve each recipient's owner key from the proto Output.
+	recipients := make(
+		[]wallet.SendRecipient, 0, len(req.Recipients),
+	)
 	var totalAmount int64
-	for i, out := range req.Recipients {
-		if out.GetDestination() == nil {
-			return nil, status.Errorf(
-				codes.InvalidArgument,
-				"recipient %d: destination is "+
-					"required", i)
-		}
 
+	for i, out := range req.Recipients {
 		if out.AmountSat <= 0 {
 			return nil, status.Errorf(
 				codes.InvalidArgument,
 				"recipient %d: amount must be "+
-					"positive", i)
+					"positive", i,
+			)
 		}
+
+		ownerKey, err := resolveRecipientOwnerKey(out)
+		if err != nil {
+			return nil, status.Errorf(
+				codes.InvalidArgument,
+				"recipient %d: %v", i, err,
+			)
+		}
+
+		recipients = append(recipients, wallet.SendRecipient{
+			OwnerKey: ownerKey,
+			Amount:   btcutil.Amount(out.AmountSat),
+		})
 
 		totalAmount += out.AmountSat
 	}
 
-	// For dry_run, validate inputs and return a preview.
-	if req.DryRun {
-		return &daemonrpc.SendVTXOResponse{
-			Status:         "preview",
-			TotalAmountSat: totalAmount,
-		}, nil
+	// Fetch operator terms for fee, dust limit, exit delay, and
+	// operator key.
+	terms, err := r.server.fetchOperatorTerms(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"unable to fetch operator terms: %v", err)
 	}
 
-	// TODO(roasbeef): In-round directed sends are not yet
-	// implemented. The wallet actor's RefreshVTXOsRequest only
-	// supports self-refresh (sending back to self), not directed
-	// transfers to external recipients. Once the round protocol
-	// supports recipient outputs, this handler should build a
-	// proper send request with the validated recipients.
-	return nil, status.Errorf(codes.Unimplemented,
-		"in-round directed sends are not yet implemented; "+
-			"use SendOOR for out-of-round transfers")
+	if !r.server.walletRef.IsSome() {
+		return nil, status.Errorf(codes.Internal,
+			"wallet actor not initialized")
+	}
+
+	wRef := r.server.walletRef.UnsafeFromSome()
+
+	sendReq := &wallet.SendVTXOsRequest{
+		Recipients:    recipients,
+		OperatorFee:   terms.MinOperatorFee,
+		DustLimit:     terms.DustLimit,
+		OperatorKey:   terms.PubKey,
+		VTXOExitDelay: terms.VTXOExitDelay,
+		DryRun:        req.DryRun,
+	}
+
+	future := wRef.Ask(ctx, sendReq)
+	result := future.Await(ctx)
+
+	resp, err := result.Unpack()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"send failed: %v", err)
+	}
+
+	sendResp, ok := resp.(*wallet.SendVTXOsResponse)
+	if !ok {
+		return nil, status.Errorf(codes.Internal,
+			"unexpected response type: %T", resp)
+	}
+
+	return &daemonrpc.SendVTXOResponse{
+		Status:          sendResp.Status,
+		TotalAmountSat:  totalAmount,
+		ChangeAmountSat: int64(sendResp.ChangeAmount),
+		SelectedCount:   int32(sendResp.SelectedCount),
+	}, nil
+}
+
+// resolveRecipientOwnerKey extracts the recipient's x-only public key
+// from a proto Output destination. Only pubkey destinations are
+// supported for directed sends — the recipient's owner key is needed
+// to construct the VTXO descriptor.
+func resolveRecipientOwnerKey(
+	out *daemonrpc.Output) (*btcec.PublicKey, error) {
+
+	switch d := out.Destination.(type) {
+	case *daemonrpc.Output_Pubkey:
+		if len(d.Pubkey) != schnorr.PubKeyBytesLen {
+			return nil, fmt.Errorf(
+				"pubkey must be %d bytes, got %d",
+				schnorr.PubKeyBytesLen,
+				len(d.Pubkey),
+			)
+		}
+
+		key, err := schnorr.ParsePubKey(d.Pubkey)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"invalid pubkey: %w", err,
+			)
+		}
+
+		return key, nil
+
+	case *daemonrpc.Output_Address:
+		return nil, fmt.Errorf(
+			"address destinations are not supported " +
+				"for directed sends; use the " +
+				"recipient's x-only public key",
+		)
+
+	case *daemonrpc.Output_PkScript:
+		return nil, fmt.Errorf(
+			"pk_script destinations are not supported " +
+				"for directed sends; use the " +
+				"recipient's x-only public key",
+		)
+
+	default:
+		return nil, fmt.Errorf(
+			"unsupported destination type: %T",
+			out.Destination,
+		)
+	}
 }
 
 // SendOOR initiates an out-of-round transfer directly between the

--- a/darepod/rpc_server_test.go
+++ b/darepod/rpc_server_test.go
@@ -1,0 +1,81 @@
+package darepod
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolveRecipientOwnerKey covers destination resolution for
+// directed sends.
+func TestResolveRecipientOwnerKey(t *testing.T) {
+	t.Parallel()
+
+	// Generate a test key.
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	xOnlyBytes := schnorr.SerializePubKey(privKey.PubKey())
+
+	t.Run("pubkey valid", func(t *testing.T) {
+		t.Parallel()
+
+		out := &daemonrpc.Output{
+			Destination: &daemonrpc.Output_Pubkey{
+				Pubkey: xOnlyBytes,
+			},
+		}
+
+		key, err := resolveRecipientOwnerKey(out)
+		require.NoError(t, err)
+		require.True(t,
+			key.IsEqual(privKey.PubKey()),
+			"resolved key should match input",
+		)
+	})
+
+	t.Run("pubkey wrong length", func(t *testing.T) {
+		t.Parallel()
+
+		out := &daemonrpc.Output{
+			Destination: &daemonrpc.Output_Pubkey{
+				Pubkey: []byte{0x01, 0x02},
+			},
+		}
+
+		_, err := resolveRecipientOwnerKey(out)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "pubkey must be")
+	})
+
+	t.Run("address rejected", func(t *testing.T) {
+		t.Parallel()
+
+		out := &daemonrpc.Output{
+			Destination: &daemonrpc.Output_Address{
+				Address: "bcrt1pxxx",
+			},
+		}
+
+		_, err := resolveRecipientOwnerKey(out)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not supported")
+	})
+
+	t.Run("pk_script rejected", func(t *testing.T) {
+		t.Parallel()
+
+		out := &daemonrpc.Output{
+			Destination: &daemonrpc.Output_PkScript{
+				PkScript: []byte{0x51, 0x20},
+			},
+		}
+
+		_, err := resolveRecipientOwnerKey(out)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not supported")
+	})
+}

--- a/lib/actormsg/vtxo_admission.go
+++ b/lib/actormsg/vtxo_admission.go
@@ -167,3 +167,43 @@ type ReleaseForfeitResponse struct {
 
 // VTXOManagerResp implements the VTXOManagerResp marker interface.
 func (r *ReleaseForfeitResponse) VTXOManagerResp() {}
+
+// =============================================================================
+// Atomic cooperative select-and-reserve: wallet → Manager → VTXO actors
+// =============================================================================
+
+// SelectAndReserveForfeitRequest asks the VTXO manager to select VTXOs
+// covering a target amount and atomically reserve them for cooperative
+// consumption (PendingForfeitState). The manager runs largest-first
+// coin selection, then Asks each selected VTXO actor to process
+// PendingForfeitEvent. If any reservation fails, already-reserved
+// VTXOs are rolled back via ForfeitReleasedEvent.
+type SelectAndReserveForfeitRequest struct {
+	actor.BaseMessage
+
+	// TargetAmount is the minimum total value the selected VTXOs must
+	// cover.
+	TargetAmount btcutil.Amount
+}
+
+// VTXOManagerMsg implements VTXOManagerMsg marker interface.
+func (m *SelectAndReserveForfeitRequest) VTXOManagerMsg() {}
+
+// MessageType returns the message type for logging.
+func (m *SelectAndReserveForfeitRequest) MessageType() string {
+	return "SelectAndReserveForfeitRequest"
+}
+
+// SelectAndReserveForfeitResponse returns the VTXOs that were selected
+// and reserved for cooperative consumption.
+type SelectAndReserveForfeitResponse struct {
+	// SelectedVTXOs is the set of VTXOs reserved for this cooperative
+	// operation.
+	SelectedVTXOs []SelectedVTXO
+
+	// TotalSelected is the sum of all selected VTXO amounts.
+	TotalSelected btcutil.Amount
+}
+
+// VTXOManagerResp implements the VTXOManagerResp marker interface.
+func (r *SelectAndReserveForfeitResponse) VTXOManagerResp() {}

--- a/round/actor.go
+++ b/round/actor.go
@@ -1969,7 +1969,18 @@ func (a *RoundClientActor) handleRegisterIntent(ctx context.Context,
 	// PendingForfeitState by the time the round registers the
 	// intent. The manager handles atomic reservation and rollback.
 
-	a.log.InfoS(ctx, "Registered intent package",
+	// Trigger registration to advance the FSM from
+	// PendingRoundAssembly to RegistrationSent, which emits the
+	// JoinRoundRequest to the server via the mailbox.
+	regEvent := &RegistrationRequested{}
+	err = a.askEventAndProcessOutbox(ctx, roundFSM, regEvent)
+	if err != nil {
+		return fn.Err[actormsg.RoundActorResp](fmt.Errorf(
+			"trigger send registration: %w", err,
+		))
+	}
+
+	a.log.InfoS(ctx, "Directed send intent registered",
 		slog.Int("forfeits", len(req.Package.Forfeits)),
 		slog.Int("vtxos", len(req.Package.VTXOs)),
 		slog.Int("leaves", len(req.Package.Leaves)))

--- a/vtxo/manager.go
+++ b/vtxo/manager.go
@@ -160,6 +160,9 @@ func (m *Manager) Receive(ctx context.Context,
 	case *ReleaseForfeitRequest:
 		return m.handleReleaseForfeit(ctx, req)
 
+	case *SelectAndReserveForfeitRequest:
+		return m.handleSelectAndReserveForfeit(ctx, req)
+
 	case *GetActiveVTXOCountRequest:
 		return fn.Ok[ManagerResp](&GetActiveVTXOCountResponse{
 			Count: len(m.actors),
@@ -352,16 +355,27 @@ func (m *Manager) spawnVTXOActor(ctx context.Context,
 // Spend admission handlers
 // =============================================================================
 
-// handleSelectAndReserveSpend selects VTXOs covering the target amount using
-// largest-first coin selection, then atomically reserves them for an OOR
-// spend by Asking each VTXO actor to process SpendReserveEvent. If any
-// reservation fails, already-reserved VTXOs are rolled back.
-func (m *Manager) handleSelectAndReserveSpend(ctx context.Context,
-	req *SelectAndReserveSpendRequest) fn.Result[ManagerResp] {
+// reserveParams bundles the per-caller differences for
+// selectAndReserveVTXOs so the shared coin-selection + reservation
+// logic does not need to be duplicated.
+type reserveParams struct {
+	targetAmount btcutil.Amount
+	reserveEvent actormsg.VTXOActorMsg
+	rollback     func(ctx context.Context, ops []wire.OutPoint)
+	label        string
+}
 
-	if req.TargetAmount <= 0 {
-		return fn.Err[ManagerResp](
-			fmt.Errorf("target amount must be positive"),
+// selectAndReserveVTXOs performs largest-first coin selection and
+// atomically reserves each selected VTXO by sending reserveEvent to
+// its actor. On partial failure the rollback function is called for
+// already-reserved outpoints. Returns the selected VTXO details and
+// total amount on success.
+func (m *Manager) selectAndReserveVTXOs(ctx context.Context,
+	p reserveParams) ([]SelectedVTXO, btcutil.Amount, error) {
+
+	if p.targetAmount <= 0 {
+		return nil, 0, fmt.Errorf(
+			"target amount must be positive",
 		)
 	}
 
@@ -370,17 +384,16 @@ func (m *Manager) handleSelectAndReserveSpend(ctx context.Context,
 		ctx, VTXOStatusLive,
 	)
 	if err != nil {
-		return fn.Err[ManagerResp](
-			fmt.Errorf("list live vtxos: %w", err),
+		return nil, 0, fmt.Errorf(
+			"list live vtxos: %w", err,
 		)
 	}
 
 	// Run largest-first selection.
-	selected := selectLargestFirst(candidates, req.TargetAmount)
+	selected := selectLargestFirst(candidates, p.targetAmount)
 	if selected == nil {
-		return fn.Err[ManagerResp](
-			fmt.Errorf("insufficient funds: need %d",
-				req.TargetAmount),
+		return nil, 0, fmt.Errorf(
+			"insufficient funds: need %d", p.targetAmount,
 		)
 	}
 
@@ -390,34 +403,37 @@ func (m *Manager) handleSelectAndReserveSpend(ctx context.Context,
 	for _, vtxo := range selected {
 		ref, ok := m.actors[vtxo.Outpoint]
 		if !ok {
-			m.rollbackSpend(ctx, reserved)
+			p.rollback(ctx, reserved)
 
-			return fn.Err[ManagerResp](fmt.Errorf(
+			return nil, 0, fmt.Errorf(
 				"no actor for outpoint %s",
 				vtxo.Outpoint,
-			))
+			)
 		}
 
-		result := ref.Ask(ctx, &SpendReserveEvent{}).Await(ctx)
+		result := ref.Ask(
+			ctx, p.reserveEvent,
+		).Await(ctx)
 		if _, err := result.Unpack(); err != nil {
 			m.logger(ctx).WarnS(
-				ctx, "Spend reserve failed", err,
+				ctx, p.label+" reserve failed", err,
 				slog.String(
 					"outpoint",
 					vtxo.Outpoint.String(),
 				),
 			)
-			m.rollbackSpend(ctx, reserved)
+			p.rollback(ctx, reserved)
 
-			return fn.Err[ManagerResp](fmt.Errorf(
-				"reserve %s: %w", vtxo.Outpoint, err,
-			))
+			return nil, 0, fmt.Errorf(
+				"reserve %s %s: %w", p.label,
+				vtxo.Outpoint, err,
+			)
 		}
 
 		reserved = append(reserved, vtxo.Outpoint)
 	}
 
-	// Build the response with selected VTXO details.
+	// Build the result with selected VTXO details.
 	var (
 		selectedVTXOs []SelectedVTXO
 		totalSelected btcutil.Amount
@@ -431,14 +447,36 @@ func (m *Manager) handleSelectAndReserveSpend(ctx context.Context,
 		totalSelected += vtxo.Amount
 	}
 
-	m.logger(ctx).InfoS(ctx, "Reserved VTXOs for spend",
+	m.logger(ctx).InfoS(
+		ctx, "Reserved VTXOs for "+p.label,
 		slog.Int("count", len(selected)),
 		slog.Int64("total", int64(totalSelected)),
-		slog.Int64("target", int64(req.TargetAmount)))
+		slog.Int64("target", int64(p.targetAmount)),
+	)
+
+	return selectedVTXOs, totalSelected, nil
+}
+
+// handleSelectAndReserveSpend selects VTXOs covering the target amount using
+// largest-first coin selection, then atomically reserves them for an OOR
+// spend by Asking each VTXO actor to process SpendReserveEvent. If any
+// reservation fails, already-reserved VTXOs are rolled back.
+func (m *Manager) handleSelectAndReserveSpend(ctx context.Context,
+	req *SelectAndReserveSpendRequest) fn.Result[ManagerResp] {
+
+	vtxos, total, err := m.selectAndReserveVTXOs(ctx, reserveParams{
+		targetAmount: req.TargetAmount,
+		reserveEvent: &SpendReserveEvent{},
+		rollback:     m.rollbackSpend,
+		label:        "spend",
+	})
+	if err != nil {
+		return fn.Err[ManagerResp](err)
+	}
 
 	return fn.Ok[ManagerResp](&SelectAndReserveSpendResponse{
-		SelectedVTXOs: selectedVTXOs,
-		TotalSelected: totalSelected,
+		SelectedVTXOs: vtxos,
+		TotalSelected: total,
 	})
 }
 
@@ -676,6 +714,33 @@ func (m *Manager) handleReleaseForfeit(ctx context.Context,
 	return fn.Ok[ManagerResp](&ReleaseForfeitResponse{
 		ReleasedCount: released,
 	})
+}
+
+// handleSelectAndReserveForfeit selects VTXOs covering the target amount
+// using largest-first coin selection, then atomically reserves them for
+// cooperative consumption by Asking each VTXO actor to process
+// PendingForfeitEvent. If any reservation fails, already-reserved VTXOs
+// are rolled back. This is the directed-send counterpart of
+// handleSelectAndReserveSpend.
+func (m *Manager) handleSelectAndReserveForfeit(ctx context.Context,
+	req *SelectAndReserveForfeitRequest) fn.Result[ManagerResp] {
+
+	vtxos, total, err := m.selectAndReserveVTXOs(ctx, reserveParams{
+		targetAmount: req.TargetAmount,
+		reserveEvent: &PendingForfeitEvent{},
+		rollback:     m.rollbackForfeit,
+		label:        "forfeit",
+	})
+	if err != nil {
+		return fn.Err[ManagerResp](err)
+	}
+
+	return fn.Ok[ManagerResp](
+		&SelectAndReserveForfeitResponse{
+			SelectedVTXOs: vtxos,
+			TotalSelected: total,
+		},
+	)
 }
 
 // =============================================================================

--- a/vtxo/manager_admission_test.go
+++ b/vtxo/manager_admission_test.go
@@ -1015,3 +1015,208 @@ func TestRecoveredPendingForfeitAllowsRelease(t *testing.T) {
 	_, ok = ref.state.(*LiveState)
 	require.True(t, ok, "expected LiveState, got %T", ref.state)
 }
+
+// =============================================================================
+// Atomic cooperative select-and-reserve tests
+// =============================================================================
+
+// TestSelectAndReserveForfeitSuccess verifies that the manager selects
+// and reserves VTXOs for cooperative consumption using largest-first
+// selection, driving each into PendingForfeitState.
+func TestSelectAndReserveForfeitSuccess(t *testing.T) {
+	t.Parallel()
+
+	vtxo1 := makeDescriptor(t, 30000, 0)
+	vtxo2 := makeDescriptor(t, 50000, 1)
+	vtxo3 := makeDescriptor(t, 20000, 2)
+
+	mgr, store := newTestManager(t, []*Descriptor{
+		vtxo1, vtxo2, vtxo3,
+	})
+
+	store.On(
+		"ListVTXOsByStatus", t.Context(), VTXOStatusLive,
+	).Return([]*Descriptor{vtxo1, vtxo2, vtxo3}, nil)
+
+	result := mgr.Receive(
+		t.Context(), &SelectAndReserveForfeitRequest{
+			TargetAmount: 40000,
+		},
+	)
+	resp, err := result.Unpack()
+	require.NoError(t, err)
+
+	forfeitResp, ok := resp.(*SelectAndReserveForfeitResponse)
+	require.True(t, ok)
+
+	// Largest-first picks vtxo2 (50000) covering 40000.
+	require.Len(t, forfeitResp.SelectedVTXOs, 1)
+	require.Equal(t,
+		vtxo2.Outpoint, forfeitResp.SelectedVTXOs[0].Outpoint,
+	)
+	require.Equal(t,
+		btcutil.Amount(50000), forfeitResp.TotalSelected,
+	)
+
+	// Verify the actor is now in PendingForfeitState.
+	actorAny, ok := mgr.actors[vtxo2.Outpoint]
+	require.True(t, ok, "actor not found for vtxo2")
+
+	actorRef, ok := actorAny.(*mockVTXOActorRef)
+	require.True(t, ok, "expected *mockVTXOActorRef")
+
+	_, ok = actorRef.state.(*PendingForfeitState)
+	require.True(t, ok,
+		"expected PendingForfeitState, got %T", actorRef.state,
+	)
+}
+
+// TestSelectAndReserveForfeitMultipleVTXOs verifies that coin selection
+// picks multiple VTXOs when no single VTXO covers the target.
+func TestSelectAndReserveForfeitMultipleVTXOs(t *testing.T) {
+	t.Parallel()
+
+	vtxo1 := makeDescriptor(t, 30000, 0)
+	vtxo2 := makeDescriptor(t, 25000, 1)
+	vtxo3 := makeDescriptor(t, 20000, 2)
+
+	mgr, store := newTestManager(t, []*Descriptor{
+		vtxo1, vtxo2, vtxo3,
+	})
+
+	store.On(
+		"ListVTXOsByStatus", t.Context(), VTXOStatusLive,
+	).Return([]*Descriptor{vtxo1, vtxo2, vtxo3}, nil)
+
+	result := mgr.Receive(
+		t.Context(), &SelectAndReserveForfeitRequest{
+			TargetAmount: 50000,
+		},
+	)
+	resp, err := result.Unpack()
+	require.NoError(t, err)
+
+	forfeitResp, ok := resp.(*SelectAndReserveForfeitResponse)
+	require.True(t, ok, "expected *SelectAndReserveForfeitResponse")
+
+	// Largest-first: vtxo1 (30000) + vtxo2 (25000) = 55000.
+	require.Len(t, forfeitResp.SelectedVTXOs, 2)
+	require.Equal(t,
+		btcutil.Amount(55000), forfeitResp.TotalSelected,
+	)
+}
+
+// TestSelectAndReserveForfeitInsufficientFunds verifies that selection
+// fails when live candidates cannot cover the target.
+func TestSelectAndReserveForfeitInsufficientFunds(t *testing.T) {
+	t.Parallel()
+
+	vtxo1 := makeDescriptor(t, 10000, 0)
+
+	mgr, store := newTestManager(t, []*Descriptor{vtxo1})
+
+	store.On(
+		"ListVTXOsByStatus", t.Context(), VTXOStatusLive,
+	).Return([]*Descriptor{vtxo1}, nil)
+
+	result := mgr.Receive(
+		t.Context(), &SelectAndReserveForfeitRequest{
+			TargetAmount: 50000,
+		},
+	)
+	_, err := result.Unpack()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "insufficient funds")
+}
+
+// TestSelectAndReserveForfeitSkipsNonLive verifies that VTXOs already
+// in SpendingState or PendingForfeitState are excluded from candidates
+// because only Live VTXOs are returned by ListVTXOsByStatus.
+func TestSelectAndReserveForfeitSkipsNonLive(t *testing.T) {
+	t.Parallel()
+
+	vtxo1 := makeDescriptor(t, 50000, 0)
+	vtxo2 := makeDescriptor(t, 30000, 1)
+
+	mgr, store := newTestManager(t, []*Descriptor{
+		vtxo1, vtxo2,
+	})
+
+	// Put vtxo1 into SpendingState so it won't be listed as Live.
+	mgr.actors[vtxo1.Outpoint] = newMockVTXOActorRef(
+		vtxo1.Outpoint.String(),
+		&SpendingState{VTXO: vtxo1},
+	)
+
+	// Store only returns vtxo2 as Live.
+	store.On(
+		"ListVTXOsByStatus", t.Context(), VTXOStatusLive,
+	).Return([]*Descriptor{vtxo2}, nil)
+
+	result := mgr.Receive(
+		t.Context(), &SelectAndReserveForfeitRequest{
+			TargetAmount: 25000,
+		},
+	)
+	resp, err := result.Unpack()
+	require.NoError(t, err)
+
+	forfeitResp, ok := resp.(*SelectAndReserveForfeitResponse)
+	require.True(t, ok, "expected *SelectAndReserveForfeitResponse")
+
+	// Only vtxo2 was available and selected.
+	require.Len(t, forfeitResp.SelectedVTXOs, 1)
+	require.Equal(t,
+		vtxo2.Outpoint,
+		forfeitResp.SelectedVTXOs[0].Outpoint,
+	)
+}
+
+// TestSelectAndReserveForfeitPartialRollback verifies that if one VTXO
+// rejects PendingForfeitEvent, previously reserved VTXOs are rolled
+// back via ForfeitReleasedEvent.
+func TestSelectAndReserveForfeitPartialRollback(t *testing.T) {
+	t.Parallel()
+
+	vtxo1 := makeDescriptor(t, 30000, 0)
+	vtxo2 := makeDescriptor(t, 25000, 1)
+
+	mgr, store := newTestManager(t, []*Descriptor{
+		vtxo1, vtxo2,
+	})
+
+	// Put vtxo2 (second in sort order) into SpendingState so it
+	// will reject PendingForfeitEvent during reservation.
+	mgr.actors[vtxo2.Outpoint] = newMockVTXOActorRef(
+		vtxo2.Outpoint.String(),
+		&SpendingState{VTXO: vtxo2},
+	)
+
+	// Store returns both as Live (stale view).
+	store.On(
+		"ListVTXOsByStatus", t.Context(), VTXOStatusLive,
+	).Return([]*Descriptor{vtxo1, vtxo2}, nil)
+
+	// Target requires both VTXOs.
+	result := mgr.Receive(
+		t.Context(), &SelectAndReserveForfeitRequest{
+			TargetAmount: 50000,
+		},
+	)
+	_, err := result.Unpack()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "reserve forfeit")
+
+	// Verify vtxo1 was rolled back to LiveState.
+	actorAny, ok := mgr.actors[vtxo1.Outpoint]
+	require.True(t, ok, "actor not found for vtxo1")
+
+	actorRef, ok := actorAny.(*mockVTXOActorRef)
+	require.True(t, ok, "expected *mockVTXOActorRef")
+
+	_, ok = actorRef.state.(*LiveState)
+	require.True(t, ok,
+		"expected LiveState after rollback, got %T",
+		actorRef.state,
+	)
+}

--- a/vtxo/messages.go
+++ b/vtxo/messages.go
@@ -157,3 +157,11 @@ type ReleaseForfeitRequest = actormsg.ReleaseForfeitRequest
 
 // ReleaseForfeitResponse is an alias for the canonical type in actormsg.
 type ReleaseForfeitResponse = actormsg.ReleaseForfeitResponse
+
+// SelectAndReserveForfeitRequest is an alias for the canonical type in
+// actormsg.
+type SelectAndReserveForfeitRequest = actormsg.SelectAndReserveForfeitRequest
+
+// SelectAndReserveForfeitResponse is an alias for the canonical type in
+// actormsg.
+type SelectAndReserveForfeitResponse = actormsg.SelectAndReserveForfeitResponse

--- a/wallet/messages.go
+++ b/wallet/messages.go
@@ -584,3 +584,82 @@ func (m *LeaveVTXOsResponse) MessageType() string {
 
 // walletRespSealed implements the sealed WalletResp interface.
 func (m *LeaveVTXOsResponse) walletRespSealed() {}
+
+// SendRecipient describes a single recipient for an in-round directed
+// send. The wallet derives the VTXO output script from OwnerKey and
+// operator terms.
+type SendRecipient struct {
+	// OwnerKey is the recipient's x-only public key. The wallet
+	// uses this together with the operator key and exit delay to
+	// derive the VTXO tapscript output.
+	OwnerKey *btcec.PublicKey
+
+	// Amount is the value to send to this recipient in satoshis.
+	Amount btcutil.Amount
+}
+
+// SendVTXOsRequest asks the wallet to execute an in-round directed
+// send. The wallet atomically selects and reserves VTXOs for
+// cooperative consumption, builds the IntentPackage (forfeits +
+// recipient VTXOs + change), and registers it with the round actor.
+type SendVTXOsRequest struct {
+	actor.BaseMessage
+
+	// Recipients is the list of send destinations with resolved
+	// pkScripts and amounts.
+	Recipients []SendRecipient
+
+	// OperatorFee is the fee deducted from the total to pay the
+	// operator.
+	OperatorFee btcutil.Amount
+
+	// DustLimit is the minimum viable VTXO output amount. Change
+	// below this threshold causes the send to be rejected.
+	DustLimit btcutil.Amount
+
+	// OperatorKey is the operator's public key for constructing
+	// new VTXO descriptors (change output).
+	OperatorKey *btcec.PublicKey
+
+	// VTXOExitDelay is the CSV delay for the unilateral exit path
+	// of new VTXOs.
+	VTXOExitDelay uint32
+
+	// DryRun when true validates coin selection and immediately
+	// releases the reservation without registering with the round.
+	DryRun bool
+}
+
+// MessageType returns the message type identifier for logging.
+func (m *SendVTXOsRequest) MessageType() string {
+	return "SendVTXOsRequest"
+}
+
+// walletMsgSealed implements the sealed WalletMsg interface.
+func (m *SendVTXOsRequest) walletMsgSealed() {}
+
+// SendVTXOsResponse contains the result of a directed send request.
+type SendVTXOsResponse struct {
+	actor.BaseMessage
+
+	// Status is "submitted" for real sends or "preview" for dry-run.
+	Status string
+
+	// SelectedCount is the number of VTXOs selected as inputs.
+	SelectedCount int
+
+	// TotalSelected is the sum of selected VTXO amounts.
+	TotalSelected btcutil.Amount
+
+	// ChangeAmount is the change returned to the sender. Zero if
+	// the selection exactly covered the total.
+	ChangeAmount btcutil.Amount
+}
+
+// MessageType returns the message type identifier for logging.
+func (m *SendVTXOsResponse) MessageType() string {
+	return "SendVTXOsResponse"
+}
+
+// walletRespSealed implements the sealed WalletResp interface.
+func (m *SendVTXOsResponse) walletRespSealed() {}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -18,9 +18,11 @@ import (
 	"github.com/lightninglabs/darepo-client/chainsource"
 	"github.com/lightninglabs/darepo-client/lib/actormsg"
 	"github.com/lightninglabs/darepo-client/lib/scripts"
+	"github.com/lightninglabs/darepo-client/lib/tree"
 	"github.com/lightninglabs/darepo-client/lib/types"
 	"github.com/lightninglabs/taproot-assets/proof"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/keychain"
 )
 
 const (
@@ -319,6 +321,9 @@ func (a *Ark) Receive(ctx context.Context,
 
 	case *MarkBoardingIntentsAdoptedRequest:
 		return a.handleMarkBoardingIntentsAdopted(ctx, m)
+
+	case *SendVTXOsRequest:
+		return a.handleSendVTXOs(ctx, m)
 
 	default:
 		return fn.Err[WalletResp](
@@ -1356,4 +1361,264 @@ func buildBoardingTapscript(clientKey, operatorKey *btcec.PublicKey,
 	}
 
 	return tapscript, nil
+}
+
+// handleSendVTXOs processes an in-round directed send. It atomically
+// selects and reserves VTXOs for cooperative consumption, builds an
+// IntentPackage with forfeits + recipient VTXOs + change, and
+// registers it with the round actor. On failure, all reservations are
+// released. For dry-run, the reservation is immediately released
+// after validation.
+func (a *Ark) handleSendVTXOs(ctx context.Context,
+	req *SendVTXOsRequest) fn.Result[WalletResp] {
+
+	if len(req.Recipients) == 0 {
+		return fn.Err[WalletResp](
+			fmt.Errorf("no recipients provided"),
+		)
+	}
+
+	var totalRecipientAmount btcutil.Amount
+	for i, r := range req.Recipients {
+		if r.OwnerKey == nil {
+			return fn.Err[WalletResp](fmt.Errorf(
+				"recipient %d: nil owner key", i,
+			))
+		}
+
+		if r.Amount <= 0 {
+			return fn.Err[WalletResp](fmt.Errorf(
+				"recipient %d: amount must be positive",
+				i,
+			))
+		}
+
+		totalRecipientAmount += r.Amount
+	}
+
+	totalNeeded := totalRecipientAmount + req.OperatorFee
+
+	a.logger(ctx).InfoS(ctx, "Processing directed send",
+		slog.Int("recipients", len(req.Recipients)),
+		slog.Int64("total_amount",
+			int64(totalRecipientAmount)),
+		slog.Int64("operator_fee",
+			int64(req.OperatorFee)),
+		slog.Bool("dry_run", req.DryRun))
+
+	// Atomic select-and-reserve for cooperative consumption.
+	resp, err := a.askManager(
+		ctx,
+		&actormsg.SelectAndReserveForfeitRequest{
+			TargetAmount: totalNeeded,
+		},
+	)
+	if err != nil {
+		return fn.Err[WalletResp](fmt.Errorf(
+			"select and reserve forfeit: %w", err,
+		))
+	}
+
+	//nolint:forcetypeassert
+	mgrResp := resp.(*actormsg.SelectAndReserveForfeitResponse)
+
+	reservedOutpoints := make(
+		[]wire.OutPoint, 0, len(mgrResp.SelectedVTXOs),
+	)
+	for _, v := range mgrResp.SelectedVTXOs {
+		reservedOutpoints = append(
+			reservedOutpoints, v.Outpoint,
+		)
+	}
+
+	releaseAndFail := func(primary error) fn.Result[WalletResp] {
+		releaseErr := a.releaseManagerForfeitStrict(
+			ctx, reservedOutpoints,
+		)
+		if releaseErr != nil {
+			return fn.Err[WalletResp](fmt.Errorf(
+				"%w; additionally, forfeit "+
+					"release failed: %v",
+				primary, releaseErr,
+			))
+		}
+
+		return fn.Err[WalletResp](primary)
+	}
+
+	change := mgrResp.TotalSelected - totalNeeded
+	if change < 0 {
+		return releaseAndFail(fmt.Errorf(
+			"selection shortfall: selected %d, need %d",
+			mgrResp.TotalSelected, totalNeeded,
+		))
+	}
+
+	if change > 0 && change <= req.DustLimit {
+		return releaseAndFail(fmt.Errorf(
+			"change %d is below dust limit %d; "+
+				"adjust send amount",
+			change, req.DustLimit,
+		))
+	}
+
+	if req.DryRun {
+		releaseErr := a.releaseManagerForfeitStrict(
+			ctx, reservedOutpoints,
+		)
+		if releaseErr != nil {
+			return fn.Err[WalletResp](fmt.Errorf(
+				"dry-run release failed, funds may "+
+					"be temporarily unavailable: "+
+					"%w", releaseErr,
+			))
+		}
+
+		return fn.Ok[WalletResp](&SendVTXOsResponse{
+			Status:        "preview",
+			SelectedCount: len(mgrResp.SelectedVTXOs),
+			TotalSelected: mgrResp.TotalSelected,
+			ChangeAmount:  change,
+		})
+	}
+
+	// Build the intent package.
+	forfeits := make(
+		[]types.ForfeitRequest, 0,
+		len(mgrResp.SelectedVTXOs),
+	)
+	for _, v := range mgrResp.SelectedVTXOs {
+		op := v.Outpoint
+		forfeits = append(forfeits, types.ForfeitRequest{
+			VTXOOutpoint: &op,
+			Amount:       v.Amount,
+		})
+	}
+
+	vtxoRequests, buildErr := a.buildSendVTXORequests(
+		ctx, req, change,
+	)
+	if buildErr != nil {
+		return releaseAndFail(buildErr)
+	}
+
+	// Register the intent with the round actor.
+	serviceKey := actormsg.RoundActorServiceKey()
+	roundRef := serviceKey.Ref(a.actorSystem)
+
+	future := roundRef.Ask(ctx, &actormsg.RegisterIntentMsg{
+		Forfeits: forfeits,
+		VTXOs:    vtxoRequests,
+	})
+	result := future.Await(ctx)
+	if result.IsErr() {
+		a.logger(ctx).WarnS(ctx,
+			"Round rejected send intent", result.Err())
+
+		return releaseAndFail(fmt.Errorf(
+			"round rejected send intent: %w",
+			result.Err(),
+		))
+	}
+
+	a.logger(ctx).InfoS(ctx, "Directed send intent registered",
+		slog.Int("forfeits", len(forfeits)),
+		slog.Int("recipient_vtxos", len(req.Recipients)),
+		slog.Int64("change", int64(change)))
+
+	return fn.Ok[WalletResp](&SendVTXOsResponse{
+		Status:        "submitted",
+		SelectedCount: len(mgrResp.SelectedVTXOs),
+		TotalSelected: mgrResp.TotalSelected,
+		ChangeAmount:  change,
+	})
+}
+
+// buildSendVTXORequests assembles VTXORequest entries for each
+// recipient plus an optional change output. The PkScript for each
+// VTXO is derived from the VTXO descriptor (owner key + operator
+// key + exit delay). Signing keys are left empty — they are derived
+// later by the round FSM during the signing ceremony.
+func (a *Ark) buildSendVTXORequests(ctx context.Context,
+	req *SendVTXOsRequest,
+	change btcutil.Amount) ([]types.VTXORequest, error) {
+
+	vtxoRequests := make(
+		[]types.VTXORequest, 0,
+		len(req.Recipients)+1,
+	)
+	for i, r := range req.Recipients {
+		desc, err := tree.NewVTXODescriptor(
+			r.Amount, r.OwnerKey,
+			req.OperatorKey, nil,
+			req.VTXOExitDelay,
+		)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"build recipient %d descriptor: %w",
+				i, err,
+			)
+		}
+
+		vtxoRequests = append(vtxoRequests, types.VTXORequest{
+			Amount:   r.Amount,
+			PkScript: desc.PkScript,
+			Expiry:   req.VTXOExitDelay,
+			OwnerKey: keychain.KeyDescriptor{
+				PubKey: r.OwnerKey,
+			},
+			IsOwner:     false,
+			OperatorKey: req.OperatorKey,
+		})
+	}
+
+	// Add change VTXO if needed. The sender owns the change.
+	if change > 0 {
+		changeOwnerKey, err := a.backend.DeriveNextKey(
+			ctx, types.VTXOOwnerKeyFamily,
+		)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"derive change owner key: %w", err,
+			)
+		}
+
+		changeDesc, err := tree.NewVTXODescriptor(
+			change, changeOwnerKey.PubKey,
+			req.OperatorKey, nil,
+			req.VTXOExitDelay,
+		)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"build change descriptor: %w", err,
+			)
+		}
+
+		vtxoRequests = append(
+			vtxoRequests, types.VTXORequest{
+				Amount:      change,
+				PkScript:    changeDesc.PkScript,
+				Expiry:      req.VTXOExitDelay,
+				OwnerKey:    *changeOwnerKey,
+				IsOwner:     true,
+				OperatorKey: req.OperatorKey,
+			},
+		)
+	}
+
+	return vtxoRequests, nil
+}
+
+// releaseManagerForfeitStrict releases forfeit reservations and returns
+// the error rather than swallowing it.
+func (a *Ark) releaseManagerForfeitStrict(ctx context.Context,
+	outpoints []wire.OutPoint) error {
+
+	_, err := a.askManager(
+		ctx, &actormsg.ReleaseForfeitRequest{
+			Outpoints: outpoints,
+		},
+	)
+
+	return err
 }


### PR DESCRIPTION
## Summary

Replaces #176.

Implements in-round directed sends through `SendVTXO`, built on the
key-separation foundation from #210.

Instead of the old approach that mixed directed send with the OOR spend
path, directed send uses the cooperative admission model:

- The wallet asks the VTXO manager to atomically select and reserve
  inputs for cooperative use (`SelectAndReserveForfeitRequest`)
- Selected VTXOs enter `PendingForfeitState`
- The wallet builds an `IntentPackage` with forfeits + recipient
  VTXOs + change VTXO
- The round actor registers the intent and immediately triggers
  registration with the server

### Key differences from #176

- **PkScript derived correctly**: recipient VTXO output scripts are
  derived from the VTXO descriptor (`ownerKey + operatorKey + exitDelay`),
  not plain BIP-86 P2TR. This is done in the wallet where operator terms
  are available.
- **Consistent OwnerKey semantics**: `SendRecipient` carries the raw
  x-only `OwnerKey`. Only pubkey destinations are supported (address
  and pk_script are rejected since they don't provide the untweaked key
  needed for VTXO construction).
- **Ownership filtering via #210**: recipient VTXOs set `IsOwner=false`
  so `buildOwnedClientVTXOs` skips them — the sender doesn't persist or
  manage recipient VTXOs.
- **No signing keys in wallet**: signing keys are left empty in
  `VTXORequest` — the round FSM derives them per #210.
- **Tracking deferred**: round key tracking, `TriggerRegistration` RPC,
  and temp key preservation from #176 are deferred to a follow-up issue.
  The send flow works without them.

## Commits

1. `actormsg: add SelectAndReserveForfeitRequest types`
2. `vtxo: add atomic forfeit selection to manager`
3. `wallet: add SendVTXOsRequest message types`
4. `wallet: implement handleSendVTXOs for directed send`
5. `daemonrpc: add change_amount_sat and selected_count to SendVTXOResponse`
6. `darepod: implement SendVTXO RPC for directed sends`
7. `round: auto-trigger registration after directed send intent`

## Testing

- `go test ./vtxo/ ./wallet/ ./darepod/` — all pass
- Server-side itest: `TestDirectedSendIntegration` (in companion PR)
  exercises the full flow: alice boards, sends 30k to bob, round
  completes, alice has correct change VTXO

## Companion PR

Server-side itest: lightninglabs/darepo#TBD