### PR TITLE
docs: refresh per-package agent docs after recent PRs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -126,6 +126,9 @@ corresponding state transition being durable.
 | `RPCClient` | mailbox/rpc | SendRPC/AwaitRPC interface for generated stubs |
 | `Message` | baselib/actor | Sealed interface for actor messages |
 | `Ref[Msg, Resp]` | baselib/actor | Typed actor reference (Tell, Ask) |
+| `ClientWallet` | round | MuSig2 signing + key derivation interface for round participation |
+| `VTXOReader` | wallet | Read-only VTXO descriptor access (breaks import cycle) |
+| `SelectedVTXO` | wallet | Locked VTXO descriptor for transfer inputs (breaks import cycle) |
 
 ## State Machines
 
@@ -136,6 +139,11 @@ CommitmentTxReceived → CommitmentTxValidated → NoncesSent →
 NoncesAggregated → PartialSigsSent → [ForfeitSignaturesCollecting] →
 InputSigSent → Confirmed → Idle
 ```
+ForfeitSignaturesCollecting is entered only when `len(ForfeitMappings) > 0`
+(i.e., the round includes refresh or leave VTXOs). Boarding-only rounds
+skip directly from PartialSigsSent to InputSigSent. Forfeit collection
+happens after VTXO tree signing to ensure clients only forfeit old VTXOs
+once new ones are confirmed signed.
 
 ### VTXO FSM
 ```

--- a/baselib/actor/AGENTS.md
+++ b/baselib/actor/AGENTS.md
@@ -1,0 +1,46 @@
+# baselib/actor
+
+## Purpose
+
+Core actor framework providing typed, message-driven concurrent components with
+durable mailbox persistence, service discovery via `Receptionist`, and
+crash-safe at-least-once delivery with exactly-once deduplication.
+
+## Key Types
+
+- `Actor[M, R]` — Generic actor with typed message `M` and response `R`. Processes messages sequentially from its mailbox.
+- `ActorBehavior[M, R]` — Interface that actors implement: `Start`, `Receive`, `Stop`.
+- `ActorConfig[M, R]` — Configuration for actor creation (behavior, mailbox, codec, delivery store).
+- `ActorRef[M, R]` — Typed reference for sending messages to an actor (`Tell`, `Ask`).
+- `TellOnlyRef[M]` — Fire-and-forget reference (no response type).
+- `ActorSystem` — Container managing actor lifecycles, registration, and shutdown.
+- `ServiceKey[M, R]` — Typed key for actor discovery via `Receptionist`.
+- `Receptionist` — Service locator mapping `ServiceKey` → `ActorRef` for decoupled actor wiring.
+- `Message` — Sealed interface for all actor messages (must embed `BaseMessage`).
+- `MessageCodec` — TLV-based codec for message serialization/deserialization.
+- `DeliveryStore` / `TxAwareDeliveryStore` — Interfaces for durable mailbox persistence (enqueue, claim, ack, dead-letter).
+- `DurableActor` — Actor variant with crash-safe mailbox backed by SQL persistence.
+- `Checkpoint` — Serializable actor state snapshot for recovery.
+- `Promise[T]` / `Future[T]` — Async result types for Ask-pattern responses.
+- `ChannelMailbox[M, R]` — In-memory channel-based mailbox (non-durable, for lightweight actors).
+
+## Relationships
+
+- **Depends on**: `lnd/tlv` (message serialization).
+- **Depended on by**: All domain actors (`round`, `vtxo`, `oor`, `wallet`, `serverconn`, `timeout`, `indexer`), `baselib/protofsm` (FSM-to-actor bridge), `db/actordelivery` (persistence implementation).
+
+## Invariants
+
+- Messages are processed sequentially per actor — no concurrent `Receive` calls.
+- `Tell` with a `DurableActor` persists the message before returning (crash-safe enqueue).
+- Outbox messages are dispatched only after state is persisted (outbox pattern).
+- `ServiceKey` lookup via `Receptionist` is type-safe: mismatched types return `ErrServiceKeyTypeMismatch`.
+- `RestartMessage` has `RestartPriority` (MaxInt32) ensuring it is processed before all other messages on recovery.
+- Transaction context (`WithTx`/`RequireTx`) enables same-DB-transaction joining between actors and their callers.
+
+## Deep Docs
+
+- [baselib/CLAUDE.md](../CLAUDE.md) — Parent baselib package overview.
+- [docs/durable_actor_architecture.md](../../docs/durable_actor_architecture.md) — Durable actor internals.
+- [docs/durable_actor_quickstart.md](../../docs/durable_actor_quickstart.md) — TLVMessage, ActorBehavior, migration checklist.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/baselib/actor/CLAUDE.md
+++ b/baselib/actor/CLAUDE.md
@@ -1,0 +1,46 @@
+# baselib/actor
+
+## Purpose
+
+Core actor framework providing typed, message-driven concurrent components with
+durable mailbox persistence, service discovery via `Receptionist`, and
+crash-safe at-least-once delivery with exactly-once deduplication.
+
+## Key Types
+
+- `Actor[M, R]` — Generic actor with typed message `M` and response `R`. Processes messages sequentially from its mailbox.
+- `ActorBehavior[M, R]` — Interface that actors implement: `Start`, `Receive`, `Stop`.
+- `ActorConfig[M, R]` — Configuration for actor creation (behavior, mailbox, codec, delivery store).
+- `ActorRef[M, R]` — Typed reference for sending messages to an actor (`Tell`, `Ask`).
+- `TellOnlyRef[M]` — Fire-and-forget reference (no response type).
+- `ActorSystem` — Container managing actor lifecycles, registration, and shutdown.
+- `ServiceKey[M, R]` — Typed key for actor discovery via `Receptionist`.
+- `Receptionist` — Service locator mapping `ServiceKey` → `ActorRef` for decoupled actor wiring.
+- `Message` — Sealed interface for all actor messages (must embed `BaseMessage`).
+- `MessageCodec` — TLV-based codec for message serialization/deserialization.
+- `DeliveryStore` / `TxAwareDeliveryStore` — Interfaces for durable mailbox persistence (enqueue, claim, ack, dead-letter).
+- `DurableActor` — Actor variant with crash-safe mailbox backed by SQL persistence.
+- `Checkpoint` — Serializable actor state snapshot for recovery.
+- `Promise[T]` / `Future[T]` — Async result types for Ask-pattern responses.
+- `ChannelMailbox[M, R]` — In-memory channel-based mailbox (non-durable, for lightweight actors).
+
+## Relationships
+
+- **Depends on**: `lnd/tlv` (message serialization).
+- **Depended on by**: All domain actors (`round`, `vtxo`, `oor`, `wallet`, `serverconn`, `timeout`, `indexer`), `baselib/protofsm` (FSM-to-actor bridge), `db/actordelivery` (persistence implementation).
+
+## Invariants
+
+- Messages are processed sequentially per actor — no concurrent `Receive` calls.
+- `Tell` with a `DurableActor` persists the message before returning (crash-safe enqueue).
+- Outbox messages are dispatched only after state is persisted (outbox pattern).
+- `ServiceKey` lookup via `Receptionist` is type-safe: mismatched types return `ErrServiceKeyTypeMismatch`.
+- `RestartMessage` has `RestartPriority` (MaxInt32) ensuring it is processed before all other messages on recovery.
+- Transaction context (`WithTx`/`RequireTx`) enables same-DB-transaction joining between actors and their callers.
+
+## Deep Docs
+
+- [baselib/CLAUDE.md](../CLAUDE.md) — Parent baselib package overview.
+- [docs/durable_actor_architecture.md](../../docs/durable_actor_architecture.md) — Durable actor internals.
+- [docs/durable_actor_quickstart.md](../../docs/durable_actor_quickstart.md) — TLVMessage, ActorBehavior, migration checklist.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/baselib/protofsm/AGENTS.md
+++ b/baselib/protofsm/AGENTS.md
@@ -1,0 +1,42 @@
+# baselib/protofsm
+
+## Purpose
+
+Protocol-style finite state machine engine that separates pure state transitions
+from side effects. Business logic lives in `(State, Event) → (State, []OutboxEvent)`
+transition functions; the runtime dispatches outbox messages after state is
+durably persisted.
+
+## Key Types
+
+- `State[E, O, Env]` — Interface for FSM states: `ProcessEvent` returns the next state and outbox events.
+- `StateMachine[E, O, Env]` — Non-actor FSM runner (for testing or embedded use).
+- `StateMachineCfg[E, O, Env]` — Configuration for state machines (initial state, environment, transition table).
+- `ActorStateMachine[E, O, Env]` — FSM wrapped as an actor behavior for use with `baselib/actor`.
+- `EmittedEvent[E, O]` — Pair of (next state, outbox events) returned by transitions.
+- `StateTransition[E, O, Env]` — Single transition result (new state + emitted events).
+- `TransitionTable[S, E, M]` — Declarative transition table mapping (State, Event) → handler.
+- `TransitionEntry[S, E, M]` — Single entry in a transition table.
+- `RoutedOutboxEvent[M, R]` — Outbox event that targets a specific actor via `ServiceKey` (Tell or Ask delivery).
+- `ActorOutboxEvent` — Interface for outbox events that can be dispatched by the actor runtime.
+- `Environment` — Marker interface for FSM environment (provides external resources to transitions).
+- `ErrorReporter` — Interface for reporting FSM errors to external systems.
+- `DeliveryMode` — Enum: `DeliveryModeTell` (fire-and-forget) or `DeliveryModeAsk` (request-response).
+
+## Relationships
+
+- **Depends on**: `baselib/actor` (actor integration, ServiceKey, Message).
+- **Depended on by**: `round` (round FSM), `vtxo` (VTXO lifecycle FSM), `oor` (OOR transfer FSM).
+
+## Invariants
+
+- Transition functions must be pure: no I/O, no network calls, no database writes. All side effects are expressed as outbox events.
+- Outbox events are dispatched only after the new state is durably persisted (prevents message-before-state bugs).
+- `TransitionTable` enforces exhaustive (State, Event) coverage at compile time via type constraints.
+- `RoutedOutboxEvent` captures the target `ServiceKey` so the runtime can dispatch to the correct actor without the FSM knowing about actor references.
+
+## Deep Docs
+
+- [baselib/CLAUDE.md](../CLAUDE.md) — Parent baselib package overview.
+- [docs/durable_actor_architecture.md](../../docs/durable_actor_architecture.md) — Durable actor internals.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/baselib/protofsm/CLAUDE.md
+++ b/baselib/protofsm/CLAUDE.md
@@ -1,0 +1,42 @@
+# baselib/protofsm
+
+## Purpose
+
+Protocol-style finite state machine engine that separates pure state transitions
+from side effects. Business logic lives in `(State, Event) → (State, []OutboxEvent)`
+transition functions; the runtime dispatches outbox messages after state is
+durably persisted.
+
+## Key Types
+
+- `State[E, O, Env]` — Interface for FSM states: `ProcessEvent` returns the next state and outbox events.
+- `StateMachine[E, O, Env]` — Non-actor FSM runner (for testing or embedded use).
+- `StateMachineCfg[E, O, Env]` — Configuration for state machines (initial state, environment, transition table).
+- `ActorStateMachine[E, O, Env]` — FSM wrapped as an actor behavior for use with `baselib/actor`.
+- `EmittedEvent[E, O]` — Pair of (next state, outbox events) returned by transitions.
+- `StateTransition[E, O, Env]` — Single transition result (new state + emitted events).
+- `TransitionTable[S, E, M]` — Declarative transition table mapping (State, Event) → handler.
+- `TransitionEntry[S, E, M]` — Single entry in a transition table.
+- `RoutedOutboxEvent[M, R]` — Outbox event that targets a specific actor via `ServiceKey` (Tell or Ask delivery).
+- `ActorOutboxEvent` — Interface for outbox events that can be dispatched by the actor runtime.
+- `Environment` — Marker interface for FSM environment (provides external resources to transitions).
+- `ErrorReporter` — Interface for reporting FSM errors to external systems.
+- `DeliveryMode` — Enum: `DeliveryModeTell` (fire-and-forget) or `DeliveryModeAsk` (request-response).
+
+## Relationships
+
+- **Depends on**: `baselib/actor` (actor integration, ServiceKey, Message).
+- **Depended on by**: `round` (round FSM), `vtxo` (VTXO lifecycle FSM), `oor` (OOR transfer FSM).
+
+## Invariants
+
+- Transition functions must be pure: no I/O, no network calls, no database writes. All side effects are expressed as outbox events.
+- Outbox events are dispatched only after the new state is durably persisted (prevents message-before-state bugs).
+- `TransitionTable` enforces exhaustive (State, Event) coverage at compile time via type constraints.
+- `RoutedOutboxEvent` captures the target `ServiceKey` so the runtime can dispatch to the correct actor without the FSM knowing about actor references.
+
+## Deep Docs
+
+- [baselib/CLAUDE.md](../CLAUDE.md) — Parent baselib package overview.
+- [docs/durable_actor_architecture.md](../../docs/durable_actor_architecture.md) — Durable actor internals.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/chainbackends/AGENTS.md
+++ b/chainbackends/AGENTS.md
@@ -19,6 +19,7 @@ notifications and fee estimation.
 
 - `LNDBackend` requires an lnd instance (local or remote via lndclient).
 - Provides real-time notifications via lnd's chainntnfs package.
+- Log messages use canonical txid strings (not reversed byte slices).
 
 ## Deep Docs
 

--- a/chainbackends/CLAUDE.md
+++ b/chainbackends/CLAUDE.md
@@ -19,6 +19,7 @@ notifications and fee estimation.
 
 - `LNDBackend` requires an lnd instance (local or remote via lndclient).
 - Provides real-time notifications via lnd's chainntnfs package.
+- Log messages use canonical txid strings (not reversed byte slices).
 
 ## Deep Docs
 

--- a/darepod/AGENTS.md
+++ b/darepod/AGENTS.md
@@ -9,8 +9,9 @@ gRPC API.
 ## Key Types
 
 - `Server` — Main daemon owning wallet, DB, chainsource actor, gRPC server, and ActorSystem.
-- `RPCServer` — Implements the gRPC `DaemonService` API (Board, ListRounds, WatchRounds, NewOORReceiveScript, etc.).
-- `Config` — Daemon configuration (data dir, network, RPC host, wallet type, etc.).
+- `RPCServer` — Implements the gRPC `DaemonService` API (Board, ListRounds, WatchRounds, NewOORReceiveScript, etc.). Includes test hooks for mailbox edge factory and round registration.
+- `Config` — Daemon configuration (data dir, network, RPC host, wallet type, etc.). Includes `MailboxEdgeFactory` hook for test harness transport interception.
+- `TriggerRoundRegistration` — Test-hook method that injects a round registration event into the round actor (in `server_round_testhook.go`).
 - `WalletState` — Enum (None/Locked/Ready) for wallet lifecycle.
 - `serverDurableUnaryBuilder` — Implements `serverconn.DurableUnaryRequestBuilder` by delegating to the indexer client with proof-of-control credentials.
 - `NewOwnedReceiveScriptSigner` — Indexer signer that resolves the wallet key for any persisted owned receive script, then delegates signing to the backend-specific signer.
@@ -27,6 +28,7 @@ gRPC API.
 - Server owns ActorSystem lifetime; shutdown stops all subsystems.
 - Wallet transitions None → Locked → Ready (or direct to Ready if seed provided).
 - Two wallet modes: LND-backed or lightweight (`lwwallet`).
+- Per-subsystem logging: configurable log writer, no global mutable loggers. Each subsystem receives its own logger instance.
 - Board RPC is non-blocking: delegates to wallet actor and returns immediately.
 - ListRounds splits pending (in-memory from actor) and persisted (SQL with cursor pagination) rounds.
 - Server holds a `roundStore` reference for direct SQL queries from the RPC layer.

--- a/darepod/CLAUDE.md
+++ b/darepod/CLAUDE.md
@@ -9,8 +9,9 @@ gRPC API.
 ## Key Types
 
 - `Server` — Main daemon owning wallet, DB, chainsource actor, gRPC server, and ActorSystem.
-- `RPCServer` — Implements the gRPC `DaemonService` API (Board, ListRounds, WatchRounds, NewOORReceiveScript, etc.).
-- `Config` — Daemon configuration (data dir, network, RPC host, wallet type, etc.).
+- `RPCServer` — Implements the gRPC `DaemonService` API (Board, ListRounds, WatchRounds, NewOORReceiveScript, etc.). Includes test hooks for mailbox edge factory and round registration.
+- `Config` — Daemon configuration (data dir, network, RPC host, wallet type, etc.). Includes `MailboxEdgeFactory` hook for test harness transport interception.
+- `TriggerRoundRegistration` — Test-hook method that injects a round registration event into the round actor (in `server_round_testhook.go`).
 - `WalletState` — Enum (None/Locked/Ready) for wallet lifecycle.
 - `serverDurableUnaryBuilder` — Implements `serverconn.DurableUnaryRequestBuilder` by delegating to the indexer client with proof-of-control credentials.
 - `NewOwnedReceiveScriptSigner` — Indexer signer that resolves the wallet key for any persisted owned receive script, then delegates signing to the backend-specific signer.
@@ -27,6 +28,7 @@ gRPC API.
 - Server owns ActorSystem lifetime; shutdown stops all subsystems.
 - Wallet transitions None → Locked → Ready (or direct to Ready if seed provided).
 - Two wallet modes: LND-backed or lightweight (`lwwallet`).
+- Per-subsystem logging: configurable log writer, no global mutable loggers. Each subsystem receives its own logger instance.
 - Board RPC is non-blocking: delegates to wallet actor and returns immediately.
 - ListRounds splits pending (in-memory from actor) and persisted (SQL with cursor pagination) rounds.
 - Server holds a `roundStore` reference for direct SQL queries from the RPC layer.

--- a/db/AGENTS.md
+++ b/db/AGENTS.md
@@ -20,7 +20,7 @@ Supports SQLite and PostgreSQL backends.
 
 ## Relationships
 
-- **Depends on**: `baselib/actor` (DeliveryStore interface), `db/sqlc` (generated query layer).
+- **Depends on**: `baselib/actor` (DeliveryStore interface), `db/sqlc` (generated query layer), `db/actordelivery` (isolated actor delivery persistence with separate schema lifecycle).
 - **Depended on by**: `round`, `vtxo`, `oor`, `wallet` (all consume storage interfaces), `darepod` (wires DB backends).
 
 ## Invariants
@@ -30,6 +30,7 @@ Supports SQLite and PostgreSQL backends.
 - Round checkpoints include commitment tx, VTXO tree, client sub-trees, boarding signatures, and every intent with updated status.
 - Default retry logic: 10 retries with exponential backoff (40ms initial, capped at 3s).
 - **Never write raw SQL in Go** — add queries to `db/queries/`, regenerate with `make sqlc`.
+- Per-subsystem logging: uses instance logger instead of global package logger.
 - Latest migration: `000005_vtxo_chain_depth` adds `chain_depth INTEGER NOT NULL DEFAULT 0` to `vtxos` table. UPSERT uses zero-value sentinel pattern (same as `tree_depth`, `batch_expiry`): zero means "not yet populated", non-zero overwrites.
 
 ## Deep Docs

--- a/db/CLAUDE.md
+++ b/db/CLAUDE.md
@@ -20,7 +20,7 @@ Supports SQLite and PostgreSQL backends.
 
 ## Relationships
 
-- **Depends on**: `baselib/actor` (DeliveryStore interface), `db/sqlc` (generated query layer).
+- **Depends on**: `baselib/actor` (DeliveryStore interface), `db/sqlc` (generated query layer), `db/actordelivery` (isolated actor delivery persistence with separate schema lifecycle).
 - **Depended on by**: `round`, `vtxo`, `oor`, `wallet` (all consume storage interfaces), `darepod` (wires DB backends).
 
 ## Invariants
@@ -30,6 +30,7 @@ Supports SQLite and PostgreSQL backends.
 - Round checkpoints include commitment tx, VTXO tree, client sub-trees, boarding signatures, and every intent with updated status.
 - Default retry logic: 10 retries with exponential backoff (40ms initial, capped at 3s).
 - **Never write raw SQL in Go** — add queries to `db/queries/`, regenerate with `make sqlc`.
+- Per-subsystem logging: uses instance logger instead of global package logger.
 - Latest migration: `000005_vtxo_chain_depth` adds `chain_depth INTEGER NOT NULL DEFAULT 0` to `vtxos` table. UPSERT uses zero-value sentinel pattern (same as `tree_depth`, `batch_expiry`): zero means "not yet populated", non-zero overwrites.
 
 ## Deep Docs

--- a/db/actordelivery/AGENTS.md
+++ b/db/actordelivery/AGENTS.md
@@ -1,0 +1,37 @@
+# db/actordelivery
+
+## Purpose
+
+Isolated SQL integration surface for durable actor mailbox persistence.
+Separates actor-delivery schema lifecycle from the broader client schema so
+other services can reuse durable actor storage without pulling unrelated tables.
+
+## Key Types
+
+- `NewTxAwareDeliveryStoreFromDB` — Constructs an `actor.TxAwareDeliveryStore` from a raw `*sql.DB` and backend type.
+- `RunMigrations` — Applies only actor-delivery schema migrations with a dedicated migration bookkeeping table.
+- `ActorDeliveryQueries` — Interface for actor delivery SQL operations (enqueue, claim, ack, dead-letter).
+- `BatchedActorDeliveryQueries` — Batched transaction wrapper for `ActorDeliveryQueries`.
+- `MigrationOption` — Functional options for migration configuration.
+
+## Sub-Packages
+
+- `db/actordelivery/migrations` — Migration runner and embedded SQL migration files.
+- `db/actordelivery/sqlc` — Generated type-safe query layer (do not edit manually).
+
+## Relationships
+
+- **Depends on**: `baselib/actor` (implements `TxAwareDeliveryStore` interface).
+- **Depended on by**: `darepod` (wires delivery store at startup), `internal/actortest` (integration tests).
+
+## Invariants
+
+- Uses a separate migration bookkeeping table from the main client schema to allow independent versioning.
+- The `sqlc` sub-package is generated code — regenerate via `make sqlc`, never edit manually.
+- Migration runner is idempotent: safe to call on every startup.
+
+## Deep Docs
+
+- [db/CLAUDE.md](../CLAUDE.md) — Parent db package overview.
+- [docs/durable_actor_architecture.md](../../docs/durable_actor_architecture.md) — Durable actor internals.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/db/actordelivery/CLAUDE.md
+++ b/db/actordelivery/CLAUDE.md
@@ -1,0 +1,37 @@
+# db/actordelivery
+
+## Purpose
+
+Isolated SQL integration surface for durable actor mailbox persistence.
+Separates actor-delivery schema lifecycle from the broader client schema so
+other services can reuse durable actor storage without pulling unrelated tables.
+
+## Key Types
+
+- `NewTxAwareDeliveryStoreFromDB` — Constructs an `actor.TxAwareDeliveryStore` from a raw `*sql.DB` and backend type.
+- `RunMigrations` — Applies only actor-delivery schema migrations with a dedicated migration bookkeeping table.
+- `ActorDeliveryQueries` — Interface for actor delivery SQL operations (enqueue, claim, ack, dead-letter).
+- `BatchedActorDeliveryQueries` — Batched transaction wrapper for `ActorDeliveryQueries`.
+- `MigrationOption` — Functional options for migration configuration.
+
+## Sub-Packages
+
+- `db/actordelivery/migrations` — Migration runner and embedded SQL migration files.
+- `db/actordelivery/sqlc` — Generated type-safe query layer (do not edit manually).
+
+## Relationships
+
+- **Depends on**: `baselib/actor` (implements `TxAwareDeliveryStore` interface).
+- **Depended on by**: `darepod` (wires delivery store at startup), `internal/actortest` (integration tests).
+
+## Invariants
+
+- Uses a separate migration bookkeeping table from the main client schema to allow independent versioning.
+- The `sqlc` sub-package is generated code — regenerate via `make sqlc`, never edit manually.
+- Migration runner is idempotent: safe to call on every startup.
+
+## Deep Docs
+
+- [db/CLAUDE.md](../CLAUDE.md) — Parent db package overview.
+- [docs/durable_actor_architecture.md](../../docs/durable_actor_architecture.md) — Durable actor internals.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/indexer/AGENTS.md
+++ b/indexer/AGENTS.md
@@ -15,6 +15,8 @@ proofs for proof-of-control.
   (LND wallet), `KeyRingSchnorrSigner` (btcwallet keyring).
 - `ProofPubKey` — Returns the owner pubkey used in proof construction.
   Added to `SchnorrSigner` implementations for receive script ownership.
+- `SyncClient` / `SyncCursorStore` / `SyncBackend` — Cursor-based sync infrastructure for VTXO/OOR event polling.
+- `MemorySyncCursorStore` — In-memory cursor store (test-only compilation unit).
 
 ## Relationships
 

--- a/indexer/CLAUDE.md
+++ b/indexer/CLAUDE.md
@@ -15,6 +15,8 @@ proofs for proof-of-control.
   (LND wallet), `KeyRingSchnorrSigner` (btcwallet keyring).
 - `ProofPubKey` — Returns the owner pubkey used in proof construction.
   Added to `SchnorrSigner` implementations for receive script ownership.
+- `SyncClient` / `SyncCursorStore` / `SyncBackend` — Cursor-based sync infrastructure for VTXO/OOR event polling.
+- `MemorySyncCursorStore` — In-memory cursor store (test-only compilation unit).
 
 ## Relationships
 

--- a/internal/actortest/AGENTS.md
+++ b/internal/actortest/AGENTS.md
@@ -3,10 +3,18 @@
 ## Purpose
 
 Durable actor integration tests using real DB backends (SQLite, Postgres).
-Verifies at-least-once delivery, exactly-once deduplication, FIFO ordering, and
-atomic state+outbox checkpointing.
+Verifies at-least-once delivery, exactly-once deduplication, FIFO ordering,
+priority ordering, dead-letter queue invariants, DurableAsk/outbox-delivered
+responses, concurrent senders/asks, recovery/restart scenarios, and atomic
+state+outbox checkpointing.
+
+## Key Test Infrastructure
+
+- `testHarness` / `newTestHarness` — Central test scaffolding: sets up real DB, actor system, delivery store, and outbox publisher.
+- `eventuallyWithOutboxPublish` — Helper that actively triggers `OutboxPublisher.PublishPending()` on every polling iteration, making outbox delivery assertions robust under the race detector and CI scheduler pressure.
+- Timeout constants: `outboxForwardProcessingTimeout` (5s), `outboxDeliveryTimeout` (10s), `durableAskResponseTimeout` (10s).
 
 ## Relationships
 
-- **Depends on**: `baselib/actor`, `db` (real backends, not mocks).
+- **Depends on**: `baselib/actor`, `db/actordelivery` (real backends, not mocks).
 - **Depended on by**: nothing (test-only).

--- a/internal/actortest/CLAUDE.md
+++ b/internal/actortest/CLAUDE.md
@@ -3,10 +3,18 @@
 ## Purpose
 
 Durable actor integration tests using real DB backends (SQLite, Postgres).
-Verifies at-least-once delivery, exactly-once deduplication, FIFO ordering, and
-atomic state+outbox checkpointing.
+Verifies at-least-once delivery, exactly-once deduplication, FIFO ordering,
+priority ordering, dead-letter queue invariants, DurableAsk/outbox-delivered
+responses, concurrent senders/asks, recovery/restart scenarios, and atomic
+state+outbox checkpointing.
+
+## Key Test Infrastructure
+
+- `testHarness` / `newTestHarness` — Central test scaffolding: sets up real DB, actor system, delivery store, and outbox publisher.
+- `eventuallyWithOutboxPublish` — Helper that actively triggers `OutboxPublisher.PublishPending()` on every polling iteration, making outbox delivery assertions robust under the race detector and CI scheduler pressure.
+- Timeout constants: `outboxForwardProcessingTimeout` (5s), `outboxDeliveryTimeout` (10s), `durableAskResponseTimeout` (10s).
 
 ## Relationships
 
-- **Depends on**: `baselib/actor`, `db` (real backends, not mocks).
+- **Depends on**: `baselib/actor`, `db/actordelivery` (real backends, not mocks).
 - **Depended on by**: nothing (test-only).

--- a/lib/AGENTS.md
+++ b/lib/AGENTS.md
@@ -32,10 +32,10 @@ interfaces, and core Ark types.
 - `Signer` — Interface for producing BIP-322 signatures over intents.
 
 ### lib/actormsg
-- `VTXOActorMsg`, `RoundReceivable` — Marker interfaces avoiding import cycles.
-- `VTXOActorServiceKey()`, `RoundActorServiceKey()` — Deterministic actor lookup.
-- `TriggerBoardMsg` — Cross-package message from wallet→round for boarding (VTXO amounts).
-- `TriggerVTXORefreshMsg`, `TriggerVTXOLeaveMsg` — Cross-package wallet→round triggers.
+- `VTXOActorMsg`, `VTXOManagerMsg`, `RoundReceivable` — Marker interfaces avoiding import cycles.
+- `VTXOActorServiceKey()`, `VTXOManagerServiceKey()`, `RoundActorServiceKey()` — Deterministic actor lookup.
+- `TriggerBoardMsg`, `RegisterIntentMsg` — Cross-package messages from wallet→round.
+- `SelectAndReserveSpendRequest`, `ReserveForfeitRequest`, etc. — VTXO manager admission types.
 
 ## Relationships
 

--- a/lib/CLAUDE.md
+++ b/lib/CLAUDE.md
@@ -32,10 +32,10 @@ interfaces, and core Ark types.
 - `Signer` — Interface for producing BIP-322 signatures over intents.
 
 ### lib/actormsg
-- `VTXOActorMsg`, `RoundReceivable` — Marker interfaces avoiding import cycles.
-- `VTXOActorServiceKey()`, `RoundActorServiceKey()` — Deterministic actor lookup.
-- `TriggerBoardMsg` — Cross-package message from wallet→round for boarding (VTXO amounts).
-- `TriggerVTXORefreshMsg`, `TriggerVTXOLeaveMsg` — Cross-package wallet→round triggers.
+- `VTXOActorMsg`, `VTXOManagerMsg`, `RoundReceivable` — Marker interfaces avoiding import cycles.
+- `VTXOActorServiceKey()`, `VTXOManagerServiceKey()`, `RoundActorServiceKey()` — Deterministic actor lookup.
+- `TriggerBoardMsg`, `RegisterIntentMsg` — Cross-package messages from wallet→round.
+- `SelectAndReserveSpendRequest`, `ReserveForfeitRequest`, etc. — VTXO manager admission types.
 
 ## Relationships
 

--- a/lib/actormsg/AGENTS.md
+++ b/lib/actormsg/AGENTS.md
@@ -1,0 +1,37 @@
+# lib/actormsg
+
+## Purpose
+
+Shared actor message marker interfaces and concrete admission types that cross
+package boundaries. Lives in `lib/` to break import cycles between `vtxo`,
+`round`, and `wallet` (which would otherwise create circular dependencies).
+
+## Key Types
+
+- `RoundReceivable` — Marker interface for messages the round actor can receive (used by `vtxo` and `wallet` to send to round without importing `round`).
+- `RoundActorResp` — Marker interface for round actor responses.
+- `VTXOManagerMsg` / `VTXOManagerResp` — Marker interfaces for VTXO manager messages and responses.
+- `VTXOActorMsg` / `VTXOActorResp` — Marker interfaces for per-VTXO actor messages and responses.
+- `SelectAndReserveSpendRequest` / `SelectAndReserveSpendResponse` — Ask-message to select and lock VTXOs for OOR spend.
+- `ReserveForfeitRequest` / `ReleaseForfeitRequest` — Forfeit reservation admission messages.
+- `ReleaseSpendRequest` / `CompleteSpendRequest` — Spend lifecycle completion messages.
+- `RegisterIntentMsg` — Carries pre-composed cooperative intent package to round actor.
+- `TriggerBoardMsg` — Carries VTXO amounts for boarding registration to round actor.
+- `SelectedVTXO` — Describes a VTXO selected for spend (outpoint, amount, pkscript).
+- `RoundActorServiceKey()` / `VTXOManagerServiceKey()` — Service key constructors for actor discovery.
+
+## Relationships
+
+- **Depends on**: `baselib/actor` (ServiceKey, Message interfaces).
+- **Depended on by**: `vtxo` (re-exports admission types as aliases), `wallet` (sends admission requests), `round` (receives `RoundReceivable` messages), `darepod` (wiring service keys).
+
+## Invariants
+
+- All cross-boundary actor messages must implement the appropriate marker interface (`RoundReceivable`, `VTXOManagerMsg`, etc.) for type-safe actor routing.
+- Service key names are constants (`RoundActorServiceKeyName`, `VTXOManagerServiceKeyName`) shared across the codebase for consistent actor discovery.
+- `SelectedVTXO` intentionally duplicates minimal VTXO info to avoid `wallet` importing `vtxo.Descriptor`.
+
+## Deep Docs
+
+- [lib/CLAUDE.md](../CLAUDE.md) — Parent lib package overview.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/lib/actormsg/CLAUDE.md
+++ b/lib/actormsg/CLAUDE.md
@@ -1,0 +1,37 @@
+# lib/actormsg
+
+## Purpose
+
+Shared actor message marker interfaces and concrete admission types that cross
+package boundaries. Lives in `lib/` to break import cycles between `vtxo`,
+`round`, and `wallet` (which would otherwise create circular dependencies).
+
+## Key Types
+
+- `RoundReceivable` — Marker interface for messages the round actor can receive (used by `vtxo` and `wallet` to send to round without importing `round`).
+- `RoundActorResp` — Marker interface for round actor responses.
+- `VTXOManagerMsg` / `VTXOManagerResp` — Marker interfaces for VTXO manager messages and responses.
+- `VTXOActorMsg` / `VTXOActorResp` — Marker interfaces for per-VTXO actor messages and responses.
+- `SelectAndReserveSpendRequest` / `SelectAndReserveSpendResponse` — Ask-message to select and lock VTXOs for OOR spend.
+- `ReserveForfeitRequest` / `ReleaseForfeitRequest` — Forfeit reservation admission messages.
+- `ReleaseSpendRequest` / `CompleteSpendRequest` — Spend lifecycle completion messages.
+- `RegisterIntentMsg` — Carries pre-composed cooperative intent package to round actor.
+- `TriggerBoardMsg` — Carries VTXO amounts for boarding registration to round actor.
+- `SelectedVTXO` — Describes a VTXO selected for spend (outpoint, amount, pkscript).
+- `RoundActorServiceKey()` / `VTXOManagerServiceKey()` — Service key constructors for actor discovery.
+
+## Relationships
+
+- **Depends on**: `baselib/actor` (ServiceKey, Message interfaces).
+- **Depended on by**: `vtxo` (re-exports admission types as aliases), `wallet` (sends admission requests), `round` (receives `RoundReceivable` messages), `darepod` (wiring service keys).
+
+## Invariants
+
+- All cross-boundary actor messages must implement the appropriate marker interface (`RoundReceivable`, `VTXOManagerMsg`, etc.) for type-safe actor routing.
+- Service key names are constants (`RoundActorServiceKeyName`, `VTXOManagerServiceKeyName`) shared across the codebase for consistent actor discovery.
+- `SelectedVTXO` intentionally duplicates minimal VTXO info to avoid `wallet` importing `vtxo.Descriptor`.
+
+## Deep Docs
+
+- [lib/CLAUDE.md](../CLAUDE.md) — Parent lib package overview.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/lib/tree/AGENTS.md
+++ b/lib/tree/AGENTS.md
@@ -1,0 +1,38 @@
+# lib/tree
+
+## Purpose
+
+VTXO tree construction, materialization, and MuSig2 signing session management.
+Builds the Merkle-like transaction tree structure used in Ark rounds, from leaf
+descriptors through branch nodes to the batch output.
+
+## Key Types
+
+- `Tree` — Complete VTXO or connector tree: root outpoint, root output, node hierarchy, and traversal helpers. Built via `BuildVTXOTree` or `BuildConnectorTree`.
+- `Node` — Single tree node representing a transaction in the tree (branch or leaf).
+- `LeafDescriptor` — Describes a single VTXO leaf: amount, owner pubkeys, cosigner keys, CSV delay.
+- `VTXODescriptor` — Interface for VTXO metadata needed by tree construction (amount, cosigners, owner key).
+- `ConnectorDescriptor` — Describes a connector output for forfeit transaction construction.
+- `Structure` — Intermediate tree layout built by `BuildStructure` before materialization.
+- `StructureConfig` — Configuration for tree building (radix, partition weight function).
+- `SignerSession` — MuSig2 signing session for tree transactions, wrapping `input.MuSig2Signer`.
+- `Materializer` / `BTCMaterializer` — Interface and implementation for materializing tree nodes into actual Bitcoin transactions.
+- `Queue[T]` — Generic queue used internally for BFS tree traversal.
+
+## Relationships
+
+- **Depends on**: `lib/scripts` (taproot script construction, `VTXOSpendData`).
+- **Depended on by**: `round` (tree construction/validation), `vtxo` (tree paths in `Descriptor`), `oor` (tree references), `db` (tree serialization), `lib/tx` (forfeit construction).
+
+## Invariants
+
+- `DefaultRadix` is 2 (binary tree). Each internal node has at most 2 children.
+- `NumLeafOutputs` is 2 per leaf transaction (VTXO output + sweep output).
+- Cosigner keys must be deduplicated (`UniqueCosigners`) before computing the final MuSig2 key.
+- Tree materialization is deterministic given the same leaf descriptors and operator key.
+- `ValidateVTXODescriptors` / `ValidateConnectorDescriptor` must pass before tree construction.
+
+## Deep Docs
+
+- [lib/CLAUDE.md](../CLAUDE.md) — Parent lib package overview.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/lib/tree/CLAUDE.md
+++ b/lib/tree/CLAUDE.md
@@ -1,0 +1,38 @@
+# lib/tree
+
+## Purpose
+
+VTXO tree construction, materialization, and MuSig2 signing session management.
+Builds the Merkle-like transaction tree structure used in Ark rounds, from leaf
+descriptors through branch nodes to the batch output.
+
+## Key Types
+
+- `Tree` — Complete VTXO or connector tree: root outpoint, root output, node hierarchy, and traversal helpers. Built via `BuildVTXOTree` or `BuildConnectorTree`.
+- `Node` — Single tree node representing a transaction in the tree (branch or leaf).
+- `LeafDescriptor` — Describes a single VTXO leaf: amount, owner pubkeys, cosigner keys, CSV delay.
+- `VTXODescriptor` — Interface for VTXO metadata needed by tree construction (amount, cosigners, owner key).
+- `ConnectorDescriptor` — Describes a connector output for forfeit transaction construction.
+- `Structure` — Intermediate tree layout built by `BuildStructure` before materialization.
+- `StructureConfig` — Configuration for tree building (radix, partition weight function).
+- `SignerSession` — MuSig2 signing session for tree transactions, wrapping `input.MuSig2Signer`.
+- `Materializer` / `BTCMaterializer` — Interface and implementation for materializing tree nodes into actual Bitcoin transactions.
+- `Queue[T]` — Generic queue used internally for BFS tree traversal.
+
+## Relationships
+
+- **Depends on**: `lib/scripts` (taproot script construction, `VTXOSpendData`).
+- **Depended on by**: `round` (tree construction/validation), `vtxo` (tree paths in `Descriptor`), `oor` (tree references), `db` (tree serialization), `lib/tx` (forfeit construction).
+
+## Invariants
+
+- `DefaultRadix` is 2 (binary tree). Each internal node has at most 2 children.
+- `NumLeafOutputs` is 2 per leaf transaction (VTXO output + sweep output).
+- Cosigner keys must be deduplicated (`UniqueCosigners`) before computing the final MuSig2 key.
+- Tree materialization is deterministic given the same leaf descriptors and operator key.
+- `ValidateVTXODescriptors` / `ValidateConnectorDescriptor` must pass before tree construction.
+
+## Deep Docs
+
+- [lib/CLAUDE.md](../CLAUDE.md) — Parent lib package overview.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/lib/tx/AGENTS.md
+++ b/lib/tx/AGENTS.md
@@ -1,0 +1,39 @@
+# lib/tx
+
+## Purpose
+
+Transaction construction utilities for Ark protocol transactions: forfeit
+transactions, VTXO collaborative signing, and related helpers. Sub-packages
+handle specific transaction types (Ark batch, checkpoint, OOR, PSBT utilities).
+
+## Key Types
+
+- `BuildForfeitTx` — Constructs a forfeit transaction spending a VTXO via the collaborative tapscript path to a connector output.
+- `ValidateForfeitTx` — Validates a forfeit transaction structure and amounts.
+- `VTXOSpendContext` — Contextual data for spending a VTXO (outpoint, amount, tapscript, internal key).
+- `ConnectorSpendContext` — Contextual data for the connector input in a forfeit transaction.
+- `NewVTXOCollabSignDescriptor` — Creates a sign descriptor for VTXO collaborative (MuSig2) signing.
+- `NewForfeitPrevOutFetcher` — Constructs a `PrevOutputFetcher` for forfeit transaction signing.
+- `ForfeitTxParams` — Parameters for forfeit transaction validation.
+
+## Sub-Packages
+
+- `lib/tx/arktx` — Ark batch transaction construction (commitment tx building, input/output assembly).
+- `lib/tx/checkpoint` — OOR checkpoint transaction construction (2-of-2 collab path).
+- `lib/tx/oor` — OOR-specific transaction helpers (transfer package assembly).
+- `lib/tx/psbtutil` — PSBT utility functions (serialization, merging, input/output helpers).
+
+## Relationships
+
+- **Depends on**: `lib/scripts` (taproot script construction), `lib/tree` (tree types).
+- **Depended on by**: `round` (forfeit construction/validation), `oor` (checkpoint/Ark signing), `vtxo` (forfeit signing).
+
+## Invariants
+
+- `ForfeitVTXOInputIndex` is 0; `ForfeitConnectorInputIndex` is 1. Forfeit transactions always have the VTXO as the first input and the connector as the second.
+- Forfeit transaction construction is deterministic given the same inputs.
+
+## Deep Docs
+
+- [lib/CLAUDE.md](../CLAUDE.md) — Parent lib package overview.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/lib/tx/CLAUDE.md
+++ b/lib/tx/CLAUDE.md
@@ -1,0 +1,39 @@
+# lib/tx
+
+## Purpose
+
+Transaction construction utilities for Ark protocol transactions: forfeit
+transactions, VTXO collaborative signing, and related helpers. Sub-packages
+handle specific transaction types (Ark batch, checkpoint, OOR, PSBT utilities).
+
+## Key Types
+
+- `BuildForfeitTx` — Constructs a forfeit transaction spending a VTXO via the collaborative tapscript path to a connector output.
+- `ValidateForfeitTx` — Validates a forfeit transaction structure and amounts.
+- `VTXOSpendContext` — Contextual data for spending a VTXO (outpoint, amount, tapscript, internal key).
+- `ConnectorSpendContext` — Contextual data for the connector input in a forfeit transaction.
+- `NewVTXOCollabSignDescriptor` — Creates a sign descriptor for VTXO collaborative (MuSig2) signing.
+- `NewForfeitPrevOutFetcher` — Constructs a `PrevOutputFetcher` for forfeit transaction signing.
+- `ForfeitTxParams` — Parameters for forfeit transaction validation.
+
+## Sub-Packages
+
+- `lib/tx/arktx` — Ark batch transaction construction (commitment tx building, input/output assembly).
+- `lib/tx/checkpoint` — OOR checkpoint transaction construction (2-of-2 collab path).
+- `lib/tx/oor` — OOR-specific transaction helpers (transfer package assembly).
+- `lib/tx/psbtutil` — PSBT utility functions (serialization, merging, input/output helpers).
+
+## Relationships
+
+- **Depends on**: `lib/scripts` (taproot script construction), `lib/tree` (tree types).
+- **Depended on by**: `round` (forfeit construction/validation), `oor` (checkpoint/Ark signing), `vtxo` (forfeit signing).
+
+## Invariants
+
+- `ForfeitVTXOInputIndex` is 0; `ForfeitConnectorInputIndex` is 1. Forfeit transactions always have the VTXO as the first input and the connector as the second.
+- Forfeit transaction construction is deterministic given the same inputs.
+
+## Deep Docs
+
+- [lib/CLAUDE.md](../CLAUDE.md) — Parent lib package overview.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/lib/types/AGENTS.md
+++ b/lib/types/AGENTS.md
@@ -1,0 +1,38 @@
+# lib/types
+
+## Purpose
+
+Shared domain types for Ark protocol messages exchanged between client and
+server during round participation. These types are used across `round`, `vtxo`,
+`wallet`, and `db` packages.
+
+## Key Types
+
+- `JoinRoundRequest` — Client's round registration request: boarding inputs, VTXO requests, forfeit requests, leave requests.
+- `JoinRoundAuth` — Authentication data for round join (Schnorr signature proof-of-control).
+- `VTXORequest` — Describes a new VTXO to create in a round (amount, owner key, cosigner keys).
+- `ForfeitRequest` — Describes a VTXO being forfeited (outpoint, connector leaf info, forfeit tx signature).
+- `LeaveRequest` — Describes a cooperative exit (VTXO outpoint, destination address).
+- `BoardingRequest` — Describes a boarding input (outpoint, amount, script).
+- `OperatorTerms` — Server-published round parameters (fee rates, expiry config, connector dust amount).
+- `ClientBatchInfo` — Client's view of batch output info after tree construction.
+- `BatchOutputInfo` — Batch output metadata (outpoint, value, tree root).
+- `ConnectorLeafInfo` — Connector output index and leaf info for forfeit construction.
+- `BoardingInputSignature` — Signed boarding input for round commitment.
+- `ForfeitTxSig` — Forfeit transaction signature.
+- `OORPackageDirection` / `OORPackageLinkKind` — Enums for OOR package direction and link types.
+
+## Relationships
+
+- **Depends on**: `lib/scripts` (taproot script types), `lib/tree` (tree types).
+- **Depended on by**: `round` (round protocol messages), `wallet` (boarding types), `db` (persistence), `rpc` (proto conversion).
+
+## Invariants
+
+- `VTXOOwnerKeyFamily` (44) is the HD key family used for deriving VTXO owner signing keys.
+- `JoinRoundAuthMessage` produces a deterministic byte encoding for Schnorr signature verification.
+
+## Deep Docs
+
+- [lib/CLAUDE.md](../CLAUDE.md) — Parent lib package overview.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/lib/types/CLAUDE.md
+++ b/lib/types/CLAUDE.md
@@ -1,0 +1,38 @@
+# lib/types
+
+## Purpose
+
+Shared domain types for Ark protocol messages exchanged between client and
+server during round participation. These types are used across `round`, `vtxo`,
+`wallet`, and `db` packages.
+
+## Key Types
+
+- `JoinRoundRequest` — Client's round registration request: boarding inputs, VTXO requests, forfeit requests, leave requests.
+- `JoinRoundAuth` — Authentication data for round join (Schnorr signature proof-of-control).
+- `VTXORequest` — Describes a new VTXO to create in a round (amount, owner key, cosigner keys).
+- `ForfeitRequest` — Describes a VTXO being forfeited (outpoint, connector leaf info, forfeit tx signature).
+- `LeaveRequest` — Describes a cooperative exit (VTXO outpoint, destination address).
+- `BoardingRequest` — Describes a boarding input (outpoint, amount, script).
+- `OperatorTerms` — Server-published round parameters (fee rates, expiry config, connector dust amount).
+- `ClientBatchInfo` — Client's view of batch output info after tree construction.
+- `BatchOutputInfo` — Batch output metadata (outpoint, value, tree root).
+- `ConnectorLeafInfo` — Connector output index and leaf info for forfeit construction.
+- `BoardingInputSignature` — Signed boarding input for round commitment.
+- `ForfeitTxSig` — Forfeit transaction signature.
+- `OORPackageDirection` / `OORPackageLinkKind` — Enums for OOR package direction and link types.
+
+## Relationships
+
+- **Depends on**: `lib/scripts` (taproot script types), `lib/tree` (tree types).
+- **Depended on by**: `round` (round protocol messages), `wallet` (boarding types), `db` (persistence), `rpc` (proto conversion).
+
+## Invariants
+
+- `VTXOOwnerKeyFamily` (44) is the HD key family used for deriving VTXO owner signing keys.
+- `JoinRoundAuthMessage` produces a deterministic byte encoding for Schnorr signature verification.
+
+## Deep Docs
+
+- [lib/CLAUDE.md](../CLAUDE.md) — Parent lib package overview.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/lndbackend/AGENTS.md
+++ b/lndbackend/AGENTS.md
@@ -5,7 +5,16 @@
 `BoardingBackend` implementation wrapping lndclient's WalletKitClient for key
 derivation, taproot script import, and UTXO enumeration via LND.
 
+## Key Types
+
+- `BoardingBackend` — Struct holding `walletKit lndclient.WalletKitClient` and `chainKit lndclient.ChainKitClient`. Implements `wallet.BoardingBackend`.
+- `GetTransaction` / `GetBlock` — Methods using `chainKit` for raw tx/block fetching (for `TxProof` construction, added by vtxo-owner-cosigner-split).
+
 ## Relationships
 
 - **Depends on**: `wallet` (implements `BoardingBackend`).
 - **Depended on by**: `darepod` (LND-backed wallet mode).
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/lndbackend/CLAUDE.md
+++ b/lndbackend/CLAUDE.md
@@ -5,7 +5,16 @@
 `BoardingBackend` implementation wrapping lndclient's WalletKitClient for key
 derivation, taproot script import, and UTXO enumeration via LND.
 
+## Key Types
+
+- `BoardingBackend` — Struct holding `walletKit lndclient.WalletKitClient` and `chainKit lndclient.ChainKitClient`. Implements `wallet.BoardingBackend`.
+- `GetTransaction` / `GetBlock` — Methods using `chainKit` for raw tx/block fetching (for `TxProof` construction, added by vtxo-owner-cosigner-split).
+
 ## Relationships
 
 - **Depends on**: `wallet` (implements `BoardingBackend`).
 - **Depended on by**: `darepod` (LND-backed wallet mode).
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/lwwallet/AGENTS.md
+++ b/lwwallet/AGENTS.md
@@ -7,7 +7,20 @@ Lightweight in-process wallet using btcwallet for HD key management and Esplora
 Implements `wallet.BoardingBackend`, `input.Signer` + MuSig2, and
 `chainsource.ChainBackend`.
 
+## Key Types
+
+- `BoardingBackendAdapter` — Implements `wallet.BoardingBackend`. Queries Esplora directly for UTXOs (bypasses btcwallet's UTXO tracking because btcwallet skips credit marking for non-default key scopes like m/1017').
+- `GetTransaction` / `GetBlock` — Methods on `BoardingBackendAdapter` for fetching raw tx/block data from Esplora, used for `TxProof` construction.
+
 ## Relationships
 
 - **Depends on**: `chainsource` (implements `ChainBackend`), `wallet` (implements `BoardingBackend`).
 - **Depended on by**: `darepod` (alternative to LND-backed wallet).
+
+## Invariants
+
+- UTXO enumeration queries Esplora directly rather than btcwallet's internal UTXO set, because btcwallet does not credit-mark outputs for non-default key scopes (m/1017').
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/lwwallet/CLAUDE.md
+++ b/lwwallet/CLAUDE.md
@@ -7,7 +7,20 @@ Lightweight in-process wallet using btcwallet for HD key management and Esplora
 Implements `wallet.BoardingBackend`, `input.Signer` + MuSig2, and
 `chainsource.ChainBackend`.
 
+## Key Types
+
+- `BoardingBackendAdapter` — Implements `wallet.BoardingBackend`. Queries Esplora directly for UTXOs (bypasses btcwallet's UTXO tracking because btcwallet skips credit marking for non-default key scopes like m/1017').
+- `GetTransaction` / `GetBlock` — Methods on `BoardingBackendAdapter` for fetching raw tx/block data from Esplora, used for `TxProof` construction.
+
 ## Relationships
 
 - **Depends on**: `chainsource` (implements `ChainBackend`), `wallet` (implements `BoardingBackend`).
 - **Depended on by**: `darepod` (alternative to LND-backed wallet).
+
+## Invariants
+
+- UTXO enumeration queries Esplora directly rather than btcwallet's internal UTXO set, because btcwallet does not credit-mark outputs for non-default key scopes (m/1017').
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/oor/AGENTS.md
+++ b/oor/AGENTS.md
@@ -17,6 +17,8 @@ resume semantics.
 - `ClientActorCfg` — Configuration for OORClientActor (OutboxHandler,
   ServerConn, PackageStore, DeliveryStore, VTXOManager).
 - `OORClientActor` — Durable actor wrapping per-session state machines. Handles both outgoing transfers and incoming receive via three-phase async resolution.
+- `NewRetryCallbackRef` — Bridges timeout actor expiry notifications into OOR actor `ResumeSessionRequest` messages for event-driven retry scheduling.
+- `IncomingSnapshot` / `NewIncomingSnapshot` — Serializable snapshot of incoming receive session state for diagnostics.
 
 ### Actor Messages (OORDurableMsg / ActorMsg)
 
@@ -41,6 +43,8 @@ resume semantics.
   the wallet/state layer to persist incoming VTXO records.
 - `SendIncomingAckRequest` — Outbox event that asks the transport layer to
   ack the incoming transfer to the server.
+- `IncomingTransferNotification` — Outbox event emitted alongside metadata query during incoming transfer processing.
+- `ScheduleRetryRequest` — Outbox event for scheduling retryable outbox operations via the timeout actor.
 
 ### Events (Event / ReceiveState)
 
@@ -53,6 +57,7 @@ resume semantics.
 - `IncomingHandledEvent` — FSM event indicating the wallet layer has
   persisted incoming VTXOs; carries `MaterializedOutpoints` for the
   durable callback round-trip.
+- `IncomingAckSentEvent` — FSM event driving `ReceiveAwaitingAck → ReceiveCompleted` transition.
 
 ### Incoming Receive FSM States (ReceiveState)
 

--- a/oor/CLAUDE.md
+++ b/oor/CLAUDE.md
@@ -17,6 +17,8 @@ resume semantics.
 - `ClientActorCfg` — Configuration for OORClientActor (OutboxHandler,
   ServerConn, PackageStore, DeliveryStore, VTXOManager).
 - `OORClientActor` — Durable actor wrapping per-session state machines. Handles both outgoing transfers and incoming receive via three-phase async resolution.
+- `NewRetryCallbackRef` — Bridges timeout actor expiry notifications into OOR actor `ResumeSessionRequest` messages for event-driven retry scheduling.
+- `IncomingSnapshot` / `NewIncomingSnapshot` — Serializable snapshot of incoming receive session state for diagnostics.
 
 ### Actor Messages (OORDurableMsg / ActorMsg)
 
@@ -41,6 +43,8 @@ resume semantics.
   the wallet/state layer to persist incoming VTXO records.
 - `SendIncomingAckRequest` — Outbox event that asks the transport layer to
   ack the incoming transfer to the server.
+- `IncomingTransferNotification` — Outbox event emitted alongside metadata query during incoming transfer processing.
+- `ScheduleRetryRequest` — Outbox event for scheduling retryable outbox operations via the timeout actor.
 
 ### Events (Event / ReceiveState)
 
@@ -53,6 +57,7 @@ resume semantics.
 - `IncomingHandledEvent` — FSM event indicating the wallet layer has
   persisted incoming VTXOs; carries `MaterializedOutpoints` for the
   durable callback round-trip.
+- `IncomingAckSentEvent` — FSM event driving `ReceiveAwaitingAck → ReceiveCompleted` transition.
 
 ### Incoming Receive FSM States (ReceiveState)
 

--- a/round/AGENTS.md
+++ b/round/AGENTS.md
@@ -8,28 +8,34 @@ protocols with MuSig2 signing ceremonies.
 
 ## Key Types
 
-- `ClientState` — Sealed interface for all 15 FSM states (Idle through Confirmed/ClientFailed).
-- `ClientEvent` — Inbound events triggering transitions (CommitmentTxBuilt, NoncesAggregated, OperatorSigned, etc.).
-- `ClientOutMsg` — Outbound messages (JoinRoundRequest, SubmitNoncesRequest, SubmitPartialSigRequest, VTXOCreatedNotification).
+- `ClientState` — Sealed interface for all 14 FSM states (Idle through Confirmed/ClientFailed), including `ForfeitSignaturesCollectingState` and `RecoveryInitiatedState`.
+- `ClientEvent` — Inbound events triggering transitions (CommitmentTxBuilt, NoncesAggregated, OperatorSigned, ForfeitSignatureResponse, ForfeitCollectionTimedOut, etc.).
+- `ClientOutMsg` — Outbound messages (JoinRoundRequest, SubmitNoncesRequest, SubmitPartialSigRequest, SubmitVTXOForfeitSigsToServer, VTXOCreatedNotification).
 - `ClientEnvironment` — FSM environment providing storage access (boarding intents, round checkpoints, VTXO store).
+- `ClientWallet` — Interface for client wallet operations (embeds `input.Signer` for MuSig2 signing, adds `DeriveNextKey` for VTXO signing keys).
 - `BoardingIntent` — Represents a funded on-chain input to include in a round.
 - `Intents` — Pools of boarding, VTXO, forfeit, and leave requests accumulated before registration.
 - `IntentPackage` — FSM event wrapping `Intents` for atomic delivery to the round FSM.
 - `RegisterIntentRequest` — Actor message carrying a pre-composed `IntentPackage` from the wallet.
+- `VTXOIntent` — Pre-registration VTXO request carrying `OwnerKey`, `OperatorKey`, `IsOwner` flag.
+- `RoundVTXORequest` — Pairs a `VTXOIntent` with an ephemeral `SigningKey` derived at registration time for MuSig2 tree construction.
+- `ForfeitSignaturesCollectingState` — State entered after VTXO tree signing when round includes refresh/leave VTXOs. Waits for all expected forfeit signatures before submitting to server.
+- `ForfeitSignatureResponse` — Carries a VTXO's forfeit signature back from the VTXO actor.
+- `ConnectorLeafInfo` — Maps a VTXO outpoint to its connector output index and leaf info for forfeit construction.
 
 ## Relationships
 
-- **Depends on**: `baselib/protofsm` (FSM engine), `lib/tree` (Merkle trees), `lib/types` (shared domain types), `lib/scripts` (taproot scripts).
+- **Depends on**: `baselib/protofsm` (FSM engine), `lib/tree` (Merkle trees), `lib/types` (shared domain types), `lib/scripts` (taproot scripts), `wallet` (types: `BoardingAddress`, `BoardingIntent`, `SelectedVTXO`).
 - **Depended on by**: `vtxo` (forfeit coordination), `db` (round persistence), `darepod` (wiring).
 - **Sends**:
-  - → `serverconn`: `JoinRoundRequest`, `SubmitNoncesRequest`, `SubmitPartialSigRequest`, `SubmitForfeitSigRequest`, `SubmitVTXOForfeitSigsToServer`
-  - → `vtxo`: `ForfeitRequestEvent`, `ForfeitConfirmedEvent`, `BlockEpochEvent`
+  - → `serverconn`: `JoinRoundRequest`, `SubmitNoncesRequest`, `SubmitPartialSigRequest`, `SubmitVTXOForfeitSigsToServer`
+  - → `vtxo`: `ForfeitRequestEvent`, `ForfeitConfirmedEvent`, `BlockEpochEvent`, `PendingForfeitEvent`, `SpendReserveEvent`, `SpendCompletedEvent`, `ForfeitReleasedEvent`
   - → `vtxo` manager: `VTXOCreatedNotification`
   - → `wallet`: `RegisterConfirmationNotifierRequest`
   - → `timeout`: `ScheduleTimeoutRequest`, `CancelTimeoutRequest`
 - **Receives**:
   - ← `serverconn`: `CommitmentTxBuilt`, `NoncesAggregated`, `OperatorSigned`, `RoundJoined`, `BoardingFailed`
-  - ← `vtxo`: `RefreshVTXORequest`, `ForfeitSignatureSubmission`
+  - ← `vtxo`: `ForfeitSignatureResponse` (relayed through manager)
   - ← `wallet` (via `lib/actormsg`): `RegisterIntentMsg` (cooperative intent packages pre-admitted by manager), `TriggerBoardMsg` (VTXO registration + registration trigger)
   - ← `wallet`: `BoardingUtxoConfirmedEvent`
   - ← `timeout`: `TimeoutMsg`
@@ -38,10 +44,11 @@ protocols with MuSig2 signing ceremonies.
 ## Invariants
 
 - Tree signatures must be validated BEFORE boarding input signatures are released (security checkpoint at InputSigSent).
+- Forfeit signatures are collected AFTER VTXO tree signing is complete (ForfeitSignaturesCollectingState), ensuring clients only forfeit old VTXOs after verifying new VTXOs are properly signed.
 - Round state is checkpointed atomically after tree validation; crash before checkpoint means client has no record of sent signatures.
 - Primary FSM handles interactive phases (through InputSigSent); a dedicated FSM per round handles confirmation monitoring.
-- Forfeit signatures must be collected BEFORE boarding inputs are signed (atomic replacement guarantee).
 - The round actor does not mark VTXOs as PendingForfeit — the wallet/manager admits VTXOs before sending RegisterIntentMsg.
+- `ClientWallet` provides MuSig2 signing and key derivation; boarding address creation is handled by the wallet actor (not the round FSM).
 
 ## Deep Docs
 

--- a/round/CLAUDE.md
+++ b/round/CLAUDE.md
@@ -8,28 +8,34 @@ protocols with MuSig2 signing ceremonies.
 
 ## Key Types
 
-- `ClientState` — Sealed interface for all 15 FSM states (Idle through Confirmed/ClientFailed).
-- `ClientEvent` — Inbound events triggering transitions (CommitmentTxBuilt, NoncesAggregated, OperatorSigned, etc.).
-- `ClientOutMsg` — Outbound messages (JoinRoundRequest, SubmitNoncesRequest, SubmitPartialSigRequest, VTXOCreatedNotification).
+- `ClientState` — Sealed interface for all 14 FSM states (Idle through Confirmed/ClientFailed), including `ForfeitSignaturesCollectingState` and `RecoveryInitiatedState`.
+- `ClientEvent` — Inbound events triggering transitions (CommitmentTxBuilt, NoncesAggregated, OperatorSigned, ForfeitSignatureResponse, ForfeitCollectionTimedOut, etc.).
+- `ClientOutMsg` — Outbound messages (JoinRoundRequest, SubmitNoncesRequest, SubmitPartialSigRequest, SubmitVTXOForfeitSigsToServer, VTXOCreatedNotification).
 - `ClientEnvironment` — FSM environment providing storage access (boarding intents, round checkpoints, VTXO store).
+- `ClientWallet` — Interface for client wallet operations (embeds `input.Signer` for MuSig2 signing, adds `DeriveNextKey` for VTXO signing keys).
 - `BoardingIntent` — Represents a funded on-chain input to include in a round.
 - `Intents` — Pools of boarding, VTXO, forfeit, and leave requests accumulated before registration.
 - `IntentPackage` — FSM event wrapping `Intents` for atomic delivery to the round FSM.
 - `RegisterIntentRequest` — Actor message carrying a pre-composed `IntentPackage` from the wallet.
+- `VTXOIntent` — Pre-registration VTXO request carrying `OwnerKey`, `OperatorKey`, `IsOwner` flag.
+- `RoundVTXORequest` — Pairs a `VTXOIntent` with an ephemeral `SigningKey` derived at registration time for MuSig2 tree construction.
+- `ForfeitSignaturesCollectingState` — State entered after VTXO tree signing when round includes refresh/leave VTXOs. Waits for all expected forfeit signatures before submitting to server.
+- `ForfeitSignatureResponse` — Carries a VTXO's forfeit signature back from the VTXO actor.
+- `ConnectorLeafInfo` — Maps a VTXO outpoint to its connector output index and leaf info for forfeit construction.
 
 ## Relationships
 
-- **Depends on**: `baselib/protofsm` (FSM engine), `lib/tree` (Merkle trees), `lib/types` (shared domain types), `lib/scripts` (taproot scripts).
+- **Depends on**: `baselib/protofsm` (FSM engine), `lib/tree` (Merkle trees), `lib/types` (shared domain types), `lib/scripts` (taproot scripts), `wallet` (types: `BoardingAddress`, `BoardingIntent`, `SelectedVTXO`).
 - **Depended on by**: `vtxo` (forfeit coordination), `db` (round persistence), `darepod` (wiring).
 - **Sends**:
-  - → `serverconn`: `JoinRoundRequest`, `SubmitNoncesRequest`, `SubmitPartialSigRequest`, `SubmitForfeitSigRequest`, `SubmitVTXOForfeitSigsToServer`
-  - → `vtxo`: `ForfeitRequestEvent`, `ForfeitConfirmedEvent`, `BlockEpochEvent`
+  - → `serverconn`: `JoinRoundRequest`, `SubmitNoncesRequest`, `SubmitPartialSigRequest`, `SubmitVTXOForfeitSigsToServer`
+  - → `vtxo`: `ForfeitRequestEvent`, `ForfeitConfirmedEvent`, `BlockEpochEvent`, `PendingForfeitEvent`, `SpendReserveEvent`, `SpendCompletedEvent`, `ForfeitReleasedEvent`
   - → `vtxo` manager: `VTXOCreatedNotification`
   - → `wallet`: `RegisterConfirmationNotifierRequest`
   - → `timeout`: `ScheduleTimeoutRequest`, `CancelTimeoutRequest`
 - **Receives**:
   - ← `serverconn`: `CommitmentTxBuilt`, `NoncesAggregated`, `OperatorSigned`, `RoundJoined`, `BoardingFailed`
-  - ← `vtxo`: `RefreshVTXORequest`, `ForfeitSignatureSubmission`
+  - ← `vtxo`: `ForfeitSignatureResponse` (relayed through manager)
   - ← `wallet` (via `lib/actormsg`): `RegisterIntentMsg` (cooperative intent packages pre-admitted by manager), `TriggerBoardMsg` (VTXO registration + registration trigger)
   - ← `wallet`: `BoardingUtxoConfirmedEvent`
   - ← `timeout`: `TimeoutMsg`
@@ -38,10 +44,11 @@ protocols with MuSig2 signing ceremonies.
 ## Invariants
 
 - Tree signatures must be validated BEFORE boarding input signatures are released (security checkpoint at InputSigSent).
+- Forfeit signatures are collected AFTER VTXO tree signing is complete (ForfeitSignaturesCollectingState), ensuring clients only forfeit old VTXOs after verifying new VTXOs are properly signed.
 - Round state is checkpointed atomically after tree validation; crash before checkpoint means client has no record of sent signatures.
 - Primary FSM handles interactive phases (through InputSigSent); a dedicated FSM per round handles confirmation monitoring.
-- Forfeit signatures must be collected BEFORE boarding inputs are signed (atomic replacement guarantee).
 - The round actor does not mark VTXOs as PendingForfeit — the wallet/manager admits VTXOs before sending RegisterIntentMsg.
+- `ClientWallet` provides MuSig2 signing and key derivation; boarding address creation is handled by the wallet actor (not the round FSM).
 
 ## Deep Docs
 

--- a/serverconn/AGENTS.md
+++ b/serverconn/AGENTS.md
@@ -16,8 +16,8 @@ background ingress polling with event routing.
 - `SendUnaryRequest` — Durable typed unary request that becomes a real unary RPC after commit. The response arrives via KIND_RESPONSE and, if no in-memory waiter exists, falls back to durable route dispatch via the EventRouter.
 - `DurableUnaryRequestBuilder` — Interface for proof-gated request-body construction. Implementations build the actual proto request (e.g., with signed proofs) at send time, not at persist time. The interface is provided via `ConnectorConfig.DurableUnaryBuilder`.
 - `DurableUnaryQuery` — Interface implemented by transport-native durable query messages that persist raw query parameters (not a full proto). The `ServerConnectionActor` matches any `DurableUnaryQuery` generically in its `Receive` loop and calls `buildDurableUnary` to construct a `SendUnaryRequest` on the fly, using `BuildBody`, `QueryCorrelationID`, `QueryMsgID`, `QueryIdempotencyKey`, and `ServiceMethod`.
-- `SendListOORRecipientEventsByScriptRequest` — TLV-durable (type `2003`) indexer query message for phase-1 OOR receive resolution. Persists PkScript, AfterEventID, Limit, and CorrelationID; the proof-gated proto body is built at send time by `DurableUnaryRequestBuilder.BuildListOORRecipientEventsByScriptRequest`.
-- `SendListVTXOsByScriptsRequest` — TLV-durable (type `2004`) indexer query message for phase-2 OOR metadata resolution. Persists PkScripts (count-prefixed, length-prefixed list), AfterCursor, Limit, and CorrelationID; the proof-gated proto body is built by `DurableUnaryRequestBuilder.BuildListVTXOsByScriptsRequest`.
+- `SendListOORRecipientEventsByScriptRequest` — TLV-durable (type `2003`) indexer query message for phase-1 OOR receive resolution. Persists PkScript, AfterEventID, Limit, CorrelationID, MsgID, and IdempotencyKey; the proof-gated proto body is built at send time by `DurableUnaryRequestBuilder.BuildListOORRecipientEventsByScriptRequest`.
+- `SendListVTXOsByScriptsRequest` — TLV-durable (type `2004`) indexer query message for phase-2 OOR metadata resolution. Persists PkScripts (count-prefixed, length-prefixed list), AfterCursor, Limit, CorrelationID, MsgID, and IdempotencyKey; the proof-gated proto body is built by `DurableUnaryRequestBuilder.BuildListVTXOsByScriptsRequest`.
 
 ## Relationships
 
@@ -43,6 +43,8 @@ background ingress polling with event routing.
 - Ingress loop checkpoints pull cursor and ack state; on restart, resumes from checkpoint.
 - `DurableUnaryQuery` values are handled generically in `ServerConnectionActor.Receive` via `buildDurableUnary`: the query is converted to a `SendUnaryRequest` using the configured `DurableUnaryRequestBuilder`. Adding a new durable indexer query type requires only implementing `DurableUnaryQuery` — no new `Receive` case is needed.
 - `DurableUnaryQuery` implementations must produce stable identity bytes in `BuildBody` so that `MsgID` and `IdempotencyKey` are deterministic across restarts (auto-derived via `mailboxconn.StableEventMsgID` / `StableEventIdempotencyKey` when the caller leaves them empty).
+- `ServerConnectionActor` runs a background heartbeat goroutine (`DefaultHeartbeatInterval` = 30s) to keep the mailbox session alive.
+- Ingress handles header-only error responses (nil body) by routing them as errors rather than panicking on nil proto.
 
 ## Deep Docs
 

--- a/serverconn/CLAUDE.md
+++ b/serverconn/CLAUDE.md
@@ -16,8 +16,8 @@ background ingress polling with event routing.
 - `SendUnaryRequest` — Durable typed unary request that becomes a real unary RPC after commit. The response arrives via KIND_RESPONSE and, if no in-memory waiter exists, falls back to durable route dispatch via the EventRouter.
 - `DurableUnaryRequestBuilder` — Interface for proof-gated request-body construction. Implementations build the actual proto request (e.g., with signed proofs) at send time, not at persist time. The interface is provided via `ConnectorConfig.DurableUnaryBuilder`.
 - `DurableUnaryQuery` — Interface implemented by transport-native durable query messages that persist raw query parameters (not a full proto). The `ServerConnectionActor` matches any `DurableUnaryQuery` generically in its `Receive` loop and calls `buildDurableUnary` to construct a `SendUnaryRequest` on the fly, using `BuildBody`, `QueryCorrelationID`, `QueryMsgID`, `QueryIdempotencyKey`, and `ServiceMethod`.
-- `SendListOORRecipientEventsByScriptRequest` — TLV-durable (type `2003`) indexer query message for phase-1 OOR receive resolution. Persists PkScript, AfterEventID, Limit, and CorrelationID; the proof-gated proto body is built at send time by `DurableUnaryRequestBuilder.BuildListOORRecipientEventsByScriptRequest`.
-- `SendListVTXOsByScriptsRequest` — TLV-durable (type `2004`) indexer query message for phase-2 OOR metadata resolution. Persists PkScripts (count-prefixed, length-prefixed list), AfterCursor, Limit, and CorrelationID; the proof-gated proto body is built by `DurableUnaryRequestBuilder.BuildListVTXOsByScriptsRequest`.
+- `SendListOORRecipientEventsByScriptRequest` — TLV-durable (type `2003`) indexer query message for phase-1 OOR receive resolution. Persists PkScript, AfterEventID, Limit, CorrelationID, MsgID, and IdempotencyKey; the proof-gated proto body is built at send time by `DurableUnaryRequestBuilder.BuildListOORRecipientEventsByScriptRequest`.
+- `SendListVTXOsByScriptsRequest` — TLV-durable (type `2004`) indexer query message for phase-2 OOR metadata resolution. Persists PkScripts (count-prefixed, length-prefixed list), AfterCursor, Limit, CorrelationID, MsgID, and IdempotencyKey; the proof-gated proto body is built by `DurableUnaryRequestBuilder.BuildListVTXOsByScriptsRequest`.
 
 ## Relationships
 
@@ -43,6 +43,8 @@ background ingress polling with event routing.
 - Ingress loop checkpoints pull cursor and ack state; on restart, resumes from checkpoint.
 - `DurableUnaryQuery` values are handled generically in `ServerConnectionActor.Receive` via `buildDurableUnary`: the query is converted to a `SendUnaryRequest` using the configured `DurableUnaryRequestBuilder`. Adding a new durable indexer query type requires only implementing `DurableUnaryQuery` — no new `Receive` case is needed.
 - `DurableUnaryQuery` implementations must produce stable identity bytes in `BuildBody` so that `MsgID` and `IdempotencyKey` are deterministic across restarts (auto-derived via `mailboxconn.StableEventMsgID` / `StableEventIdempotencyKey` when the caller leaves them empty).
+- `ServerConnectionActor` runs a background heartbeat goroutine (`DefaultHeartbeatInterval` = 30s) to keep the mailbox session alive.
+- Ingress handles header-only error responses (nil body) by routing them as errors rather than panicking on nil proto.
 
 ## Deep Docs
 

--- a/vtxo/AGENTS.md
+++ b/vtxo/AGENTS.md
@@ -12,22 +12,26 @@ versus leave.
 ## Key Types
 
 - `VTXOState` — Sealed interface for all states (Live, Spending, Spent, PendingForfeit, Forfeiting, Forfeited, UnilateralExit, Failed).
-- `Descriptor` — Complete VTXO metadata: outpoint, amount, taproot key, CSV expiry, tree path to root.
-- `Manager` — Actor managing per-VTXO FSM instances, lifecycle, and admission gating.
+- `Descriptor` — Complete VTXO metadata: `Outpoint`, `Amount`, `PkScript`, `OwnerKey` (keychain.KeyDescriptor), `OperatorKey`, `TapScript`, `TreePath`, `RoundID`, `CommitmentTxID`, `BatchExpiry`, `RelativeExpiry`, `TreeDepth`, `ChainDepth` (OOR hop count), `CreatedHeight`, `Status`.
+- `Manager` — Actor managing per-VTXO FSM instances, lifecycle, and admission gating. Configured via `ManagerConfig`.
+- `ManagerConfig` — Configuration holding Store, Wallet, ChainSource, ActorSystem, ExpiryConfig, RoundActor ref, ChainResolver ref, and optional `Log`.
 - `VTXOEvent` — Inbound events (BlockEpochEvent, ForfeitRequest, ForfeitConfirmed, SpendReserveEvent, SpendCompletedEvent, etc.).
 - `VTXOOutMsg` — Outbound messages (ForfeitRequest, ExpiringNotify, StatusUpdate, Terminated).
+- `FilterOptions` / `FilterDescriptors` — VTXO filtering by expiry status, spend state, etc.
+- `GetActiveVTXOCountRequest` / `GetActiveVTXOCountResponse` — Ask-message for querying active VTXO count from the manager.
+- `ManagerMsg` / `ManagerResp` — Type aliases for `actormsg.VTXOManagerMsg` / `actormsg.VTXOManagerResp` (admission types live in `lib/actormsg` to avoid import cycles).
 
 ## Relationships
 
-- **Depends on**: `baselib/protofsm` (FSM engine), `lib/tree` (tree paths).
-- **Depended on by**: `round` (triggers forfeit requests), `oor` (incoming VTXOs), `db` (persistence), `darepod` (wiring).
+- **Depends on**: `baselib/protofsm` (FSM engine), `baselib/actor` (actor system), `lib/tree` (tree paths), `lib/actormsg` (admission message types), `chainsource` (block epochs).
+- **Depended on by**: `round` (triggers forfeit requests), `oor` (incoming VTXOs), `wallet` (admission gating), `db` (persistence), `darepod` (wiring).
 - **Sends**:
-  - → `round` (via manager relay): `RefreshVTXORequest` (auto-expiry path), `ForfeitSignatureSubmission`
+  - → `round` (via manager relay): `RelayToRoundMsg` wrapping `ForfeitSignatureSubmission`
   - → `db` (via outbox): `VTXOStatusUpdate`
   - → `vtxo` manager: `VTXOTerminatedNotification`, `RelayToRoundMsg`
 - **Receives**:
-  - ← `round`: `ForfeitRequestEvent`, `ForfeitConfirmedEvent`, `BlockEpochEvent`
-  - ← `manager` (admission): `SpendReserveEvent`, `SpendReleasedEvent`, `SpendCompletedEvent`, `PendingForfeitEvent`, `ForfeitReleasedEvent`
+  - ← `round`: `ForfeitRequestEvent`, `ForfeitConfirmedEvent`, `ForfeitSignedEvent`, `ForfeitReleasedEvent`, `BlockEpochEvent`, `PendingForfeitEvent`, `SpendReserveEvent`, `SpendReleasedEvent`, `SpendCompletedEvent`, `ResumeVTXOEvent`
+  - ← `wallet` (via `lib/actormsg`): `SelectAndReserveSpendRequest`, `ReleaseSpendRequest`, `CompleteSpendRequest`, `ReserveForfeitRequest`, `ReleaseForfeitRequest`
   - ← `chainsource` (via Manager): `BlockEpochEvent`
 
 ## Invariants
@@ -39,6 +43,8 @@ versus leave.
 - SpendingState is persisted as VTXOStatusSpending and survives restarts.
 - OOR completion transitions VTXOs to SpentState through the VTXO actor FSM, not by direct store writes.
 - A VTXO in SpendingState cannot be admitted for cooperative consumption, and vice versa.
+- Admission types (`SelectAndReserveSpendRequest`, `ReserveForfeitRequest`, etc.) are defined in `lib/actormsg` and re-exported as type aliases to avoid wallet → vtxo → round → wallet import cycles.
+- Per-subsystem logging: `ManagerConfig.Log` provides an optional instance logger; falls back to `build.LoggerFromContext` (no global mutable loggers).
 
 ## Deep Docs
 

--- a/vtxo/CLAUDE.md
+++ b/vtxo/CLAUDE.md
@@ -12,22 +12,26 @@ versus leave.
 ## Key Types
 
 - `VTXOState` — Sealed interface for all states (Live, Spending, Spent, PendingForfeit, Forfeiting, Forfeited, UnilateralExit, Failed).
-- `Descriptor` — Complete VTXO metadata: outpoint, amount, taproot key, CSV expiry, tree path to root.
-- `Manager` — Actor managing per-VTXO FSM instances, lifecycle, and admission gating.
+- `Descriptor` — Complete VTXO metadata: `Outpoint`, `Amount`, `PkScript`, `OwnerKey` (keychain.KeyDescriptor), `OperatorKey`, `TapScript`, `TreePath`, `RoundID`, `CommitmentTxID`, `BatchExpiry`, `RelativeExpiry`, `TreeDepth`, `ChainDepth` (OOR hop count), `CreatedHeight`, `Status`.
+- `Manager` — Actor managing per-VTXO FSM instances, lifecycle, and admission gating. Configured via `ManagerConfig`.
+- `ManagerConfig` — Configuration holding Store, Wallet, ChainSource, ActorSystem, ExpiryConfig, RoundActor ref, ChainResolver ref, and optional `Log`.
 - `VTXOEvent` — Inbound events (BlockEpochEvent, ForfeitRequest, ForfeitConfirmed, SpendReserveEvent, SpendCompletedEvent, etc.).
 - `VTXOOutMsg` — Outbound messages (ForfeitRequest, ExpiringNotify, StatusUpdate, Terminated).
+- `FilterOptions` / `FilterDescriptors` — VTXO filtering by expiry status, spend state, etc.
+- `GetActiveVTXOCountRequest` / `GetActiveVTXOCountResponse` — Ask-message for querying active VTXO count from the manager.
+- `ManagerMsg` / `ManagerResp` — Type aliases for `actormsg.VTXOManagerMsg` / `actormsg.VTXOManagerResp` (admission types live in `lib/actormsg` to avoid import cycles).
 
 ## Relationships
 
-- **Depends on**: `baselib/protofsm` (FSM engine), `lib/tree` (tree paths).
-- **Depended on by**: `round` (triggers forfeit requests), `oor` (incoming VTXOs), `db` (persistence), `darepod` (wiring).
+- **Depends on**: `baselib/protofsm` (FSM engine), `baselib/actor` (actor system), `lib/tree` (tree paths), `lib/actormsg` (admission message types), `chainsource` (block epochs).
+- **Depended on by**: `round` (triggers forfeit requests), `oor` (incoming VTXOs), `wallet` (admission gating), `db` (persistence), `darepod` (wiring).
 - **Sends**:
-  - → `round` (via manager relay): `RefreshVTXORequest` (auto-expiry path), `ForfeitSignatureSubmission`
+  - → `round` (via manager relay): `RelayToRoundMsg` wrapping `ForfeitSignatureSubmission`
   - → `db` (via outbox): `VTXOStatusUpdate`
   - → `vtxo` manager: `VTXOTerminatedNotification`, `RelayToRoundMsg`
 - **Receives**:
-  - ← `round`: `ForfeitRequestEvent`, `ForfeitConfirmedEvent`, `BlockEpochEvent`
-  - ← `manager` (admission): `SpendReserveEvent`, `SpendReleasedEvent`, `SpendCompletedEvent`, `PendingForfeitEvent`, `ForfeitReleasedEvent`
+  - ← `round`: `ForfeitRequestEvent`, `ForfeitConfirmedEvent`, `ForfeitSignedEvent`, `ForfeitReleasedEvent`, `BlockEpochEvent`, `PendingForfeitEvent`, `SpendReserveEvent`, `SpendReleasedEvent`, `SpendCompletedEvent`, `ResumeVTXOEvent`
+  - ← `wallet` (via `lib/actormsg`): `SelectAndReserveSpendRequest`, `ReleaseSpendRequest`, `CompleteSpendRequest`, `ReserveForfeitRequest`, `ReleaseForfeitRequest`
   - ← `chainsource` (via Manager): `BlockEpochEvent`
 
 ## Invariants
@@ -39,6 +43,8 @@ versus leave.
 - SpendingState is persisted as VTXOStatusSpending and survives restarts.
 - OOR completion transitions VTXOs to SpentState through the VTXO actor FSM, not by direct store writes.
 - A VTXO in SpendingState cannot be admitted for cooperative consumption, and vice versa.
+- Admission types (`SelectAndReserveSpendRequest`, `ReserveForfeitRequest`, etc.) are defined in `lib/actormsg` and re-exported as type aliases to avoid wallet → vtxo → round → wallet import cycles.
+- Per-subsystem logging: `ManagerConfig.Log` provides an optional instance logger; falls back to `build.LoggerFromContext` (no global mutable loggers).
 
 ## Deep Docs
 

--- a/wallet/AGENTS.md
+++ b/wallet/AGENTS.md
@@ -5,30 +5,39 @@
 Manages on-chain boarding addresses (2-of-2 multisig with operator + CSV
 timeout), monitors for confirmed boarding UTXOs, composes cooperative
 intent packages, and gates round registration through the VTXO manager
-admission APIs.
+admission APIs. The wallet actor owns VTXO selection and locking for
+refresh, leave, and OOR spend flows.
 
 ## Key Types
 
-- `Ark` — Main actor managing boarding addresses, UTXO enumeration, confirmation polling, and admission forwarding.
+- `Ark` — Main actor managing boarding addresses, UTXO enumeration, confirmation polling, admission forwarding, and VTXO selection/locking.
 - `BoardingBackend` — Interface for wallet integration (key derivation, taproot import, ListUnspent).
 - `BoardingStore` — Interface for persisting boarding addresses and intents.
+- `VTXOReader` — Read-only interface for loading VTXO descriptors by outpoint. Wallet uses this to build intent packages without importing `vtxo` directly.
+- `VTXODescriptor` — Wallet-level VTXO descriptor (outpoint, amount, pkscript, tree, expiry). Avoids direct dependency on `vtxo.Descriptor`.
+- `SelectedVTXO` — Describes a VTXO selected and locked for use as a transfer input (outpoint, amount, pkscript). Breaks the vtxo → round → wallet import cycle.
 - `CreateBoardingAddressRequest` / `CreateBoardingAddressResponse` — Ask-request for deriving new address.
 - `BlockEpochNotification` — Tell-message from chain source triggering UTXO polling.
 - `BoardingUtxoConfirmedEvent` — Tell-message sent when a VTXO confirms.
-- `BoardRequest` / `BoardResponse` — Ask-request from RPC to trigger boarding flow (balance check, fee deduction, round registration).
+- `BoardRequest` / `BoardResponse` — Ask-request from RPC to trigger boarding flow.
+- `RefreshVTXOsRequest` — Ask-request to select VTXOs for refresh and compose intent package.
+- `SelectAndLockVTXOsRequest` — Ask-request to select and lock VTXOs for OOR spend.
+- `LeaveVTXOsRequest` — Ask-request to select VTXOs for cooperative leave.
+- `CompleteSpendVTXOsRequest` — Tell-message to finalize spend and release locks.
+- `UnlockVTXOsRequest` — Tell-message to release locked VTXOs on failure.
 
 ## Relationships
 
 - **Depends on**: `baselib/actor` (actor system), `chainsource` (block epoch notifications), `lib/actormsg` (VTXO manager admission types).
-- **Depended on by**: `round` (boarding intents), `db` (persistence), `darepod` (wiring).
+- **Depended on by**: `round` (boarding intents, types: `BoardingAddress`, `SelectedVTXO`), `db` (persistence), `darepod` (wiring).
 - **Sends**:
   - → `round` (via registered notifier): `BoardingUtxoConfirmedEvent`
   - → `round` (via `lib/actormsg`): `TriggerBoardMsg` (VTXO amounts for boarding), `RegisterIntentMsg` (pre-composed cooperative intents with forfeits + VTXOs/leaves)
   - → `vtxo` manager (via `lib/actormsg`): `SelectAndReserveSpendRequest`, `ReleaseSpendRequest`, `CompleteSpendRequest`, `ReserveForfeitRequest`, `ReleaseForfeitRequest`
 - **Receives**:
   - ← `chainsource`: `BlockEpochNotification` (triggers UTXO polling)
-  - ← `round`: `RegisterConfirmationNotifierRequest`
-  - ← API: `CreateBoardingAddressRequest`, `GetActiveBoardingAddressesRequest`, `GetBoardingBalanceRequest`, `RefreshVTXOsRequest`, `SelectAndLockVTXOsRequest`, `LeaveVTXOsRequest`, `BoardRequest`
+  - ← `round`: `RegisterConfirmationNotifierRequest`, `UnregisterConfirmationNotifierRequest`
+  - ← API: `CreateBoardingAddressRequest`, `GetActiveBoardingAddressesRequest`, `GetBoardingBalanceRequest`, `RefreshVTXOsRequest`, `SelectAndLockVTXOsRequest`, `LeaveVTXOsRequest`, `BoardRequest`, `CompleteSpendVTXOsRequest`, `UnlockVTXOsRequest`
 
 ## Invariants
 
@@ -37,6 +46,8 @@ admission APIs.
 - Notifier registration captures `minConf` parameter per actor; different actors can require different confirmation depths.
 - Cooperative admission (refresh/leave) must reserve forfeit inputs through the VTXO manager before sending `RegisterIntentMsg` to the round actor.
 - If round registration fails after successful admission, the wallet releases the forfeit reservation so VTXOs return to LiveState.
+- `VTXOReader` / `VTXODescriptor` / `SelectedVTXO` break the vtxo → round → wallet import cycle by providing wallet-level types that don't reference `vtxo.Descriptor` directly.
+- Per-subsystem logging via `build.LoggerFromContext` (no global mutable loggers).
 
 ## Deep Docs
 

--- a/wallet/CLAUDE.md
+++ b/wallet/CLAUDE.md
@@ -5,30 +5,39 @@
 Manages on-chain boarding addresses (2-of-2 multisig with operator + CSV
 timeout), monitors for confirmed boarding UTXOs, composes cooperative
 intent packages, and gates round registration through the VTXO manager
-admission APIs.
+admission APIs. The wallet actor owns VTXO selection and locking for
+refresh, leave, and OOR spend flows.
 
 ## Key Types
 
-- `Ark` — Main actor managing boarding addresses, UTXO enumeration, confirmation polling, and admission forwarding.
+- `Ark` — Main actor managing boarding addresses, UTXO enumeration, confirmation polling, admission forwarding, and VTXO selection/locking.
 - `BoardingBackend` — Interface for wallet integration (key derivation, taproot import, ListUnspent).
 - `BoardingStore` — Interface for persisting boarding addresses and intents.
+- `VTXOReader` — Read-only interface for loading VTXO descriptors by outpoint. Wallet uses this to build intent packages without importing `vtxo` directly.
+- `VTXODescriptor` — Wallet-level VTXO descriptor (outpoint, amount, pkscript, tree, expiry). Avoids direct dependency on `vtxo.Descriptor`.
+- `SelectedVTXO` — Describes a VTXO selected and locked for use as a transfer input (outpoint, amount, pkscript). Breaks the vtxo → round → wallet import cycle.
 - `CreateBoardingAddressRequest` / `CreateBoardingAddressResponse` — Ask-request for deriving new address.
 - `BlockEpochNotification` — Tell-message from chain source triggering UTXO polling.
 - `BoardingUtxoConfirmedEvent` — Tell-message sent when a VTXO confirms.
-- `BoardRequest` / `BoardResponse` — Ask-request from RPC to trigger boarding flow (balance check, fee deduction, round registration).
+- `BoardRequest` / `BoardResponse` — Ask-request from RPC to trigger boarding flow.
+- `RefreshVTXOsRequest` — Ask-request to select VTXOs for refresh and compose intent package.
+- `SelectAndLockVTXOsRequest` — Ask-request to select and lock VTXOs for OOR spend.
+- `LeaveVTXOsRequest` — Ask-request to select VTXOs for cooperative leave.
+- `CompleteSpendVTXOsRequest` — Tell-message to finalize spend and release locks.
+- `UnlockVTXOsRequest` — Tell-message to release locked VTXOs on failure.
 
 ## Relationships
 
 - **Depends on**: `baselib/actor` (actor system), `chainsource` (block epoch notifications), `lib/actormsg` (VTXO manager admission types).
-- **Depended on by**: `round` (boarding intents), `db` (persistence), `darepod` (wiring).
+- **Depended on by**: `round` (boarding intents, types: `BoardingAddress`, `SelectedVTXO`), `db` (persistence), `darepod` (wiring).
 - **Sends**:
   - → `round` (via registered notifier): `BoardingUtxoConfirmedEvent`
   - → `round` (via `lib/actormsg`): `TriggerBoardMsg` (VTXO amounts for boarding), `RegisterIntentMsg` (pre-composed cooperative intents with forfeits + VTXOs/leaves)
   - → `vtxo` manager (via `lib/actormsg`): `SelectAndReserveSpendRequest`, `ReleaseSpendRequest`, `CompleteSpendRequest`, `ReserveForfeitRequest`, `ReleaseForfeitRequest`
 - **Receives**:
   - ← `chainsource`: `BlockEpochNotification` (triggers UTXO polling)
-  - ← `round`: `RegisterConfirmationNotifierRequest`
-  - ← API: `CreateBoardingAddressRequest`, `GetActiveBoardingAddressesRequest`, `GetBoardingBalanceRequest`, `RefreshVTXOsRequest`, `SelectAndLockVTXOsRequest`, `LeaveVTXOsRequest`, `BoardRequest`
+  - ← `round`: `RegisterConfirmationNotifierRequest`, `UnregisterConfirmationNotifierRequest`
+  - ← API: `CreateBoardingAddressRequest`, `GetActiveBoardingAddressesRequest`, `GetBoardingBalanceRequest`, `RefreshVTXOsRequest`, `SelectAndLockVTXOsRequest`, `LeaveVTXOsRequest`, `BoardRequest`, `CompleteSpendVTXOsRequest`, `UnlockVTXOsRequest`
 
 ## Invariants
 
@@ -37,6 +46,8 @@ admission APIs.
 - Notifier registration captures `minConf` parameter per actor; different actors can require different confirmation depths.
 - Cooperative admission (refresh/leave) must reserve forfeit inputs through the VTXO manager before sending `RegisterIntentMsg` to the round actor.
 - If round registration fails after successful admission, the wallet releases the forfeit reservation so VTXOs return to LiveState.
+- `VTXOReader` / `VTXODescriptor` / `SelectedVTXO` break the vtxo → round → wallet import cycle by providing wallet-level types that don't reference `vtxo.Descriptor` directly.
+- Per-subsystem logging via `build.LoggerFromContext` (no global mutable loggers).
 
 ## Deep Docs
 


### PR DESCRIPTION
In this PR, we run a full doc gardening pass across the repo's per-package
`CLAUDE.md`/`AGENTS.md` files. Several recent PRs landed significant
structural changes (vtxo-owner-cosigner-split #210, no-global-loggers #218,
OOR/serverconn fixes, forfeit reorder) that left the documentation graph
stale.

The work breaks down into three pieces:

**New docs for undocumented packages.** Seven infrastructure packages had
Go source but no `CLAUDE.md` at all: `baselib/actor`, `baselib/protofsm`,
`lib/actormsg`, `lib/tree`, `lib/tx`, `lib/types`, and `db/actordelivery`.
We add full docs for each following the standard template (Purpose, Key
Types, Relationships, Invariants, Deep Docs), derived from reading the
current source and running `go doc` against each package.

**Stale doc updates.** The owner-cosigner split was the biggest driver of
staleness. In `vtxo`, `Descriptor` now carries `OwnerKey`,
`OperatorKey`, and several new metadata fields, while admission types moved
to `lib/actormsg` as type aliases. In `round`, the state count was wrong
(15 vs actual 14), and `VTXOIntent`/`RoundVTXORequest` were missing from
the key types. The `wallet` package gained `VTXOReader`, `VTXODescriptor`,
and `SelectedVTXO` to break the vtxo-round-wallet import cycle.

For `serverconn`, durable query type descriptions now include the `MsgID`
and `IdempotencyKey` fields, and we note the heartbeat goroutine and
header-only error response handling. The `oor` docs pick up missing outbox
events (`ScheduleRetryRequest`, `IncomingTransferNotification`,
`IncomingAckSentEvent`). Smaller updates touch `darepod` (test hooks),
`lwwallet` and `lndbackend` (Key Types sections), `chainbackends`
(canonical txid logging), `indexer` (SyncClient types), `db`
(actordelivery sub-package ref), and `internal/actortest` (hardened outbox
wait helpers).

**ARCHITECTURE.md refresh.** The Round FSM diagram now includes
`ForfeitSignaturesCollecting` and `AwaitingBoardingSigs`, reflecting the
reordered forfeit flow. The key types table gains `ClientWallet`,
`VTXOReader`, and `SelectedVTXO`.

All `AGENTS.md` mirrors are in sync and `make doc-check` passes. See each
commit message for a detailed description w.r.t the incremental changes.