### PR TITLE
multi: harden durable actor runtime contracts

### DIFF
--- a/baselib/actor/delivery.go
+++ b/baselib/actor/delivery.go
@@ -27,6 +27,10 @@ type Delivery[M TLVMessage, R any] struct {
 	// ID is the unique identifier for this delivery.
 	ID string
 
+	// PromiseID identifies the Ask result row for Ask messages.
+	// Empty for Tell messages.
+	PromiseID string
+
 	// Message is the delivered message.
 	Message M
 
@@ -64,6 +68,14 @@ type Delivery[M TLVMessage, R any] struct {
 	// store is the backing store for persisting ack/nack operations.
 	store DeliveryStore
 
+	// nowFn provides the current time for lease bookkeeping and Ask-result
+	// expiry. When nil, wall clock time is used.
+	nowFn func() time.Time
+
+	// onAskSettled releases any in-memory Ask bookkeeping once the Ask has
+	// durably reached a terminal state.
+	onAskSettled func()
+
 	// mu guards mutable fields (acked, LeaseUntil) that may be accessed
 	// concurrently by the heartbeat goroutine (Extend) and the main
 	// processing goroutine (Ack/Nack).
@@ -100,7 +112,7 @@ func (d *Delivery[M, R]) LeaseRemaining() time.Duration {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	return time.Until(d.LeaseUntil)
+	return d.LeaseUntil.Sub(d.now())
 }
 
 // IsLeaseExpired returns true if the lease has expired.
@@ -108,7 +120,7 @@ func (d *Delivery[M, R]) IsLeaseExpired() bool {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	return time.Now().After(d.LeaseUntil)
+	return d.now().After(d.LeaseUntil)
 }
 
 // ShouldDeadLetter returns true if this message should be moved to the dead
@@ -137,23 +149,6 @@ func (d *Delivery[M, R]) Ack(ctx context.Context, result fn.Result[R]) error {
 	}
 	d.mu.Unlock()
 
-	// Validate lease ownership by acking the mailbox message first.
-	// This must happen before SaveAskResult to prevent stale lease
-	// holders from persisting results: ask_results uses ON CONFLICT
-	// DO NOTHING, so a stale write would silently block the valid
-	// worker's result.
-	rowsAffected, err := d.store.AckMessage(ctx, d.ID, d.LeaseToken)
-	if err != nil {
-		return fmt.Errorf("ack message: %w", err)
-	}
-
-	if rowsAffected == 0 {
-		return ErrLeaseExpired
-	}
-
-	// For Ask messages, persist the result for crash recovery. This
-	// runs after AckMessage so only the valid lease holder writes the
-	// result.
 	if d.IsAsk() && d.Promise != nil {
 		var resultBlob []byte
 		var errorText string
@@ -167,14 +162,31 @@ func (d *Delivery[M, R]) Ack(ctx context.Context, result fn.Result[R]) error {
 			resultBlob = nil
 		}
 
-		saveErr := d.store.SaveAskResult(ctx, AskResultParams{
-			PromiseID:  d.ID,
-			ResultBlob: resultBlob,
-			ErrorText:  errorText,
-			ExpiresAt:  time.Now().Add(24 * time.Hour),
-		})
-		if saveErr != nil {
-			return fmt.Errorf("save ask result: %w", saveErr)
+		rowsAffected, err := d.store.AckMessageWithAskResult(
+			ctx, d.ID, d.LeaseToken, AskResultParams{
+				PromiseID:  d.askPromiseID(),
+				ResultBlob: resultBlob,
+				ErrorText:  errorText,
+				ExpiresAt:  d.now().Add(24 * time.Hour),
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("ack ask message: %w", err)
+		}
+
+		if rowsAffected == 0 {
+			return ErrLeaseExpired
+		}
+	} else {
+		rowsAffected, err := d.store.AckMessage(
+			ctx, d.ID, d.LeaseToken,
+		)
+		if err != nil {
+			return fmt.Errorf("ack message: %w", err)
+		}
+
+		if rowsAffected == 0 {
+			return ErrLeaseExpired
 		}
 	}
 
@@ -187,7 +199,7 @@ func (d *Delivery[M, R]) Ack(ctx context.Context, result fn.Result[R]) error {
 	// operation that was not durably committed. When deferPromise is
 	// set, the caller (tx path) handles completion after commit.
 	if d.IsAsk() && d.Promise != nil && !d.deferPromise {
-		d.Promise.Complete(result)
+		d.settleAsk(result)
 	}
 
 	return nil
@@ -220,15 +232,15 @@ func (d *Delivery[M, R]) Nack(
 			reason = fmt.Sprintf("max attempts reached: %v", err)
 		}
 
-		if dlErr := d.store.MoveToDeadLetter(
-			ctx, d.ID, reason,
-		); dlErr != nil {
+		rowsAffected, dlErr := d.store.MoveToDeadLetter(
+			ctx, d.ID, d.LeaseToken, reason,
+		)
+		if dlErr != nil {
 			return fmt.Errorf("move to dead letter: %w", dlErr)
 		}
 
-		if delErr := d.store.DeleteMessage(ctx, d.ID); delErr != nil {
-			return fmt.Errorf("delete message after dead "+
-				"letter: %w", delErr)
+		if rowsAffected == 0 {
+			return ErrLeaseExpired
 		}
 
 		d.mu.Lock()
@@ -285,7 +297,7 @@ func (d *Delivery[M, R]) Extend(ctx context.Context,
 	// Update local state under the lock since the heartbeat goroutine
 	// may read LeaseUntil concurrently.
 	d.mu.Lock()
-	d.LeaseUntil = time.Now().Add(extension)
+	d.LeaseUntil = d.now().Add(extension)
 	d.mu.Unlock()
 
 	return nil
@@ -297,11 +309,15 @@ func newDelivery[M TLVMessage, R any](
 	decoded M,
 	promise Promise[R],
 	callerCtx context.Context,
+	promiseID string,
 	store DeliveryStore,
+	nowFn func() time.Time,
+	onAskSettled func(),
 ) *Delivery[M, R] {
 
 	return &Delivery[M, R]{
 		ID:              msg.ID,
+		PromiseID:       promiseID,
 		Message:         decoded,
 		Promise:         promise,
 		CallerCtx:       callerCtx,
@@ -312,6 +328,38 @@ func newDelivery[M TLVMessage, R any](
 		Attempts:        msg.Attempts,
 		MaxAttempts:     msg.MaxAttempts,
 		store:           store,
+		nowFn:           nowFn,
+		onAskSettled:    onAskSettled,
 		acked:           false,
 	}
+}
+
+// askPromiseID returns the durable Ask-result key for this delivery.
+func (d *Delivery[M, R]) askPromiseID() string {
+	if d.PromiseID != "" {
+		return d.PromiseID
+	}
+
+	return d.ID
+}
+
+// settleAsk completes the in-memory promise and releases any Ask bookkeeping
+// once the Ask has durably reached a terminal state.
+func (d *Delivery[M, R]) settleAsk(result fn.Result[R]) {
+	d.Promise.Complete(result)
+
+	if d.onAskSettled != nil {
+		d.onAskSettled()
+		d.onAskSettled = nil
+	}
+}
+
+// now returns the delivery's configured clock reading or wall clock time when
+// no custom clock was supplied.
+func (d *Delivery[M, R]) now() time.Time {
+	if d.nowFn != nil {
+		return d.nowFn()
+	}
+
+	return time.Now()
 }

--- a/baselib/actor/delivery_store.go
+++ b/baselib/actor/delivery_store.go
@@ -27,6 +27,13 @@ type DeliveryStore interface {
 	// of rows affected (0 if token mismatch, 1 if success).
 	AckMessage(ctx context.Context, id, leaseToken string) (int64, error)
 
+	// AckMessageWithAskResult atomically validates lease ownership, removes
+	// the mailbox message, and persists the Ask result marker. This avoids
+	// a non-transactional loss window where AckMessage succeeds but the Ask
+	// result write fails afterward.
+	AckMessageWithAskResult(ctx context.Context, id, leaseToken string,
+		params AskResultParams) (int64, error)
+
 	// NackMessage releases a message for redelivery after the specified
 	// delay. Clears the lease and sets a new available_at time.
 	// Validates the lease token to prevent stale nacks.
@@ -39,7 +46,11 @@ type DeliveryStore interface {
 		extension time.Duration) (int64, error)
 
 	// MoveToDeadLetter moves a failed message to the dead letter queue.
-	MoveToDeadLetter(ctx context.Context, id, reason string) error
+	// Validates the lease token to prevent stale consumers from
+	// dead-lettering a message they no longer own. Returns the number
+	// of rows affected (0 if the lease was lost, 1 if success).
+	MoveToDeadLetter(ctx context.Context, id, leaseToken,
+		reason string) (int64, error)
 
 	// DeleteMessage removes a message from the mailbox (cleanup).
 	DeleteMessage(ctx context.Context, id string) error
@@ -70,11 +81,18 @@ type DeliveryStore interface {
 
 	// CompleteOutbox marks an outbox message as successfully delivered.
 	// The claim token must match the token set during ClaimOutboxBatch.
-	CompleteOutbox(ctx context.Context, id, claimToken string) error
+	// Returns the number of rows affected (0 if the claim was lost, 1 if
+	// success).
+	CompleteOutbox(ctx context.Context, id,
+		claimToken string) (int64, error)
 
 	// FailOutbox marks an outbox message as failed (dead letter).
 	// The claim token must match the token set during ClaimOutboxBatch.
-	FailOutbox(ctx context.Context, id, claimToken string) error
+	// The failure reason is persisted for operational debugging.
+	// Returns the number of rows affected (0 if the claim was lost, 1 if
+	// success).
+	FailOutbox(ctx context.Context, id, claimToken,
+		reason string) (int64, error)
 
 	// ===== Deduplication Operations =====
 
@@ -102,14 +120,15 @@ type DeliveryStore interface {
 	// ===== Dead Letter Operations =====
 
 	// GetDeadLetter retrieves a specific dead letter message.
-	GetDeadLetter(ctx context.Context, id string) (*DeadLetter, error)
+	GetDeadLetter(ctx context.Context, source,
+		id string) (*DeadLetter, error)
 
 	// ListDeadLetters lists dead letters for an actor with pagination.
 	ListDeadLetters(ctx context.Context, actorID string,
 		limit int) ([]DeadLetter, error)
 
 	// DeleteDeadLetter removes a dead letter after manual processing.
-	DeleteDeadLetter(ctx context.Context, id string) error
+	DeleteDeadLetter(ctx context.Context, source, id string) error
 
 	// ===== Maintenance Operations =====
 
@@ -357,7 +376,8 @@ type Checkpoint struct {
 
 // DeadLetter represents a failed message in the dead letter queue.
 type DeadLetter struct {
-	// ID is the original message identifier.
+	// ID is the original message identifier. Dead-letter identity is the
+	// pair `(Source, ID)`, not `ID` alone.
 	ID string
 
 	// Source indicates where the message originated: 'mailbox' or 'outbox'.

--- a/baselib/actor/delivery_test.go
+++ b/baselib/actor/delivery_test.go
@@ -46,6 +46,9 @@ type mockDeliveryStore struct {
 
 	// injectEnqueueError causes only EnqueueMessage to fail.
 	injectEnqueueError error
+
+	// injectAskResultError causes only Ask-result persistence to fail.
+	injectAskResultError error
 }
 
 func newMockDeliveryStore() *mockDeliveryStore {
@@ -59,8 +62,14 @@ func newMockDeliveryStore() *mockDeliveryStore {
 	}
 }
 
-func (m *mockDeliveryStore) EnqueueMessage(ctx context.Context,
-	params EnqueueParams) error {
+// deadLetterKey returns the stable in-memory key for a dead letter entry.
+func deadLetterKey(source, id string) string {
+	return source + ":" + id
+}
+
+func (m *mockDeliveryStore) EnqueueMessage(
+	ctx context.Context, params EnqueueParams,
+) error {
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -155,6 +164,46 @@ func (m *mockDeliveryStore) AckMessage(ctx context.Context, id,
 	return 1, nil
 }
 
+// AckMessageWithAskResult removes a mailbox row and persists the Ask result
+// under the same critical section to emulate the real store's atomic behavior.
+func (m *mockDeliveryStore) AckMessageWithAskResult(ctx context.Context, id,
+	leaseToken string, params AskResultParams) (int64, error) {
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.injectError != nil {
+		return 0, m.injectError
+	}
+
+	msg, ok := m.messages[id]
+	if !ok {
+		return 0, nil
+	}
+
+	if msg.LeaseToken != leaseToken {
+		return 0, nil
+	}
+
+	if m.injectAskResultError != nil {
+		return 0, m.injectAskResultError
+	}
+
+	if _, ok := m.askResults[params.PromiseID]; !ok {
+		m.askResults[params.PromiseID] = &AskResult{
+			PromiseID:  params.PromiseID,
+			ResultBlob: append([]byte(nil), params.ResultBlob...),
+			ErrorText:  params.ErrorText,
+			CreatedAt:  time.Now(),
+			ExpiresAt:  params.ExpiresAt,
+		}
+	}
+
+	delete(m.messages, id)
+
+	return 1, nil
+}
+
 func (m *mockDeliveryStore) NackMessage(ctx context.Context, id,
 	leaseToken string, retryAfter time.Duration) (int64, error) {
 
@@ -206,21 +255,25 @@ func (m *mockDeliveryStore) ExtendLease(ctx context.Context, id,
 }
 
 func (m *mockDeliveryStore) MoveToDeadLetter(ctx context.Context, id,
-	reason string) error {
+	leaseToken, reason string) (int64, error) {
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	if m.injectError != nil {
-		return m.injectError
+		return 0, m.injectError
 	}
 
 	msg, ok := m.messages[id]
 	if !ok {
-		return nil
+		return 0, nil
 	}
 
-	m.deadLetters[id] = &DeadLetter{
+	if msg.LeaseToken != leaseToken {
+		return 0, nil
+	}
+
+	m.deadLetters[deadLetterKey("mailbox", id)] = &DeadLetter{
 		ID:            id,
 		Source:        "mailbox",
 		ActorID:       msg.MailboxID,
@@ -231,7 +284,9 @@ func (m *mockDeliveryStore) MoveToDeadLetter(ctx context.Context, id,
 		CreatedAt:     time.Now(),
 	}
 
-	return nil
+	delete(m.messages, id)
+
+	return 1, nil
 }
 
 func (m *mockDeliveryStore) DeleteMessage(ctx context.Context,
@@ -259,9 +314,17 @@ func (m *mockDeliveryStore) SaveAskResult(ctx context.Context,
 		return m.injectError
 	}
 
+	if m.injectAskResultError != nil {
+		return m.injectAskResultError
+	}
+
+	if _, ok := m.askResults[params.PromiseID]; ok {
+		return nil
+	}
+
 	m.askResults[params.PromiseID] = &AskResult{
 		PromiseID:  params.PromiseID,
-		ResultBlob: params.ResultBlob,
+		ResultBlob: append([]byte(nil), params.ResultBlob...),
 		ErrorText:  params.ErrorText,
 		CreatedAt:  time.Now(),
 		ExpiresAt:  params.ExpiresAt,
@@ -369,32 +432,53 @@ func (m *mockDeliveryStore) ClaimOutboxBatch(ctx context.Context,
 	return result, nil
 }
 
-func (m *mockDeliveryStore) CompleteOutbox(
-	ctx context.Context, id, claimToken string,
-) error {
+func (m *mockDeliveryStore) CompleteOutbox(ctx context.Context, id,
+	claimToken string) (int64, error) {
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	if msg, ok := m.outbox[id]; ok {
+		if msg.ClaimToken != claimToken || msg.Status != "pending" {
+			return 0, nil
+		}
+
 		msg.Status = "completed"
+
+		return 1, nil
 	}
 
-	return nil
+	return 0, nil
 }
 
-func (m *mockDeliveryStore) FailOutbox(
-	ctx context.Context, id, claimToken string,
-) error {
+func (m *mockDeliveryStore) FailOutbox(ctx context.Context, id, claimToken,
+	reason string) (int64, error) {
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	if msg, ok := m.outbox[id]; ok {
+		if msg.ClaimToken != claimToken || msg.Status != "pending" {
+			return 0, nil
+		}
+
 		msg.Status = "dead_letter"
+
+		m.deadLetters[deadLetterKey("outbox", id)] = &DeadLetter{
+			ID:            id,
+			Source:        "outbox",
+			ActorID:       msg.SourceActorID,
+			MessageType:   msg.MessageType,
+			Payload:       append([]byte(nil), msg.Payload...),
+			FailureReason: reason,
+			Attempts:      msg.DeliveryAttempts,
+			CreatedAt:     time.Now(),
+		}
+
+		return 1, nil
 	}
 
-	return nil
+	return 0, nil
 }
 
 func (m *mockDeliveryStore) IsProcessed(ctx context.Context, id string) (bool,
@@ -461,13 +545,13 @@ func (m *mockDeliveryStore) DeleteCheckpoint(ctx context.Context,
 	return nil
 }
 
-func (m *mockDeliveryStore) GetDeadLetter(ctx context.Context, id string) (
-	*DeadLetter, error) {
+func (m *mockDeliveryStore) GetDeadLetter(ctx context.Context, source,
+	id string) (*DeadLetter, error) {
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	return m.deadLetters[id], nil
+	return m.deadLetters[deadLetterKey(source, id)], nil
 }
 
 func (m *mockDeliveryStore) ListDeadLetters(ctx context.Context, actorID string,
@@ -490,13 +574,14 @@ func (m *mockDeliveryStore) ListDeadLetters(ctx context.Context, actorID string,
 	return result, nil
 }
 
-func (m *mockDeliveryStore) DeleteDeadLetter(ctx context.Context,
-	id string) error {
+func (m *mockDeliveryStore) DeleteDeadLetter(
+	ctx context.Context, source, id string,
+) error {
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	delete(m.deadLetters, id)
+	delete(m.deadLetters, deadLetterKey(source, id))
 
 	return nil
 }
@@ -612,6 +697,56 @@ func TestDeliveryAckWithPromise(t *testing.T) {
 	require.Len(t, store.askResults, 1)
 }
 
+// TestDeliveryAckWithPromiseKeepsMessageOnAskResultFailure verifies that Ask
+// ack/result persistence is atomic: a failed ask-result write must not drop the
+// mailbox message.
+func TestDeliveryAckWithPromiseKeepsMessageOnAskResultFailure(t *testing.T) {
+	t.Parallel()
+
+	store := newMockDeliveryStore()
+	store.injectAskResultError = errors.New("save ask result failed")
+	ctx := context.Background()
+
+	msgID := "test-msg-1"
+	leaseToken := "test-lease-token"
+	store.messages[msgID] = &LeasedMessage{
+		ID:          msgID,
+		MailboxID:   "test-actor",
+		LeaseToken:  leaseToken,
+		LeaseUntil:  time.Now().Add(30 * time.Second),
+		Attempts:    1,
+		MaxAttempts: 10,
+	}
+
+	promise := NewPromise[string]()
+	delivery := &Delivery[*testTLVMsg, string]{
+		ID: msgID,
+		Message: &testTLVMsg{
+			Value: tlv.NewPrimitiveRecord[tlv.TlvType1](uint64(42)),
+		},
+		Promise:     promise,
+		LeaseToken:  leaseToken,
+		LeaseUntil:  time.Now().Add(30 * time.Second),
+		Attempts:    1,
+		MaxAttempts: 10,
+		store:       store,
+	}
+
+	err := delivery.Ack(ctx, fn.Ok("the result"))
+	require.ErrorContains(t, err, "ack ask message")
+
+	// The mailbox row must still exist because the ack/result step is
+	// atomic.
+	require.Contains(t, store.messages, msgID)
+	require.Empty(t, store.askResults)
+
+	promiseCtx, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
+	defer cancel()
+
+	result := promise.Future().Await(promiseCtx)
+	require.Error(t, result.Err())
+}
+
 // TestDeliveryNack tests basic Nack functionality.
 func TestDeliveryNack(t *testing.T) {
 	t.Parallel()
@@ -702,7 +837,7 @@ func TestDeliveryNackPoisonPill(t *testing.T) {
 
 	// Message should be in dead letter queue.
 	require.Len(t, store.deadLetters, 1)
-	dl := store.deadLetters[msgID]
+	dl := store.deadLetters[deadLetterKey("mailbox", msgID)]
 	require.Equal(t, "mailbox", dl.Source)
 	require.Contains(t, dl.FailureReason, "max attempts reached")
 }
@@ -838,6 +973,70 @@ func TestDeliveryHelperMethods(t *testing.T) {
 	require.True(t, askDelivery.IsLeaseExpired())
 	require.True(t, askDelivery.ShouldDeadLetter())
 	require.True(t, askDelivery.LeaseRemaining() < 0)
+}
+
+// TestDeliveryUsesInjectedClock tests that Delivery uses its configured clock
+// for lease bookkeeping and Ask-result expiry instead of wall clock time.
+func TestDeliveryUsesInjectedClock(t *testing.T) {
+	t.Parallel()
+
+	store := newMockDeliveryStore()
+	ctx := context.Background()
+	baseTime := time.Unix(1_700_000_000, 0)
+
+	msgID := "clocked-ask"
+	leaseToken := "clocked-lease"
+	store.messages[msgID] = &LeasedMessage{
+		ID:          msgID,
+		MailboxID:   "test-actor",
+		LeaseToken:  leaseToken,
+		LeaseUntil:  baseTime.Add(30 * time.Second),
+		Attempts:    1,
+		MaxAttempts: 10,
+	}
+
+	delivery := &Delivery[*testTLVMsg, string]{
+		ID: msgID,
+		Message: &testTLVMsg{
+			Value: tlv.NewPrimitiveRecord[tlv.TlvType1](uint64(7)),
+		},
+		Promise:     NewPromise[string](),
+		LeaseToken:  leaseToken,
+		LeaseUntil:  baseTime.Add(30 * time.Second),
+		Attempts:    1,
+		MaxAttempts: 10,
+		store:       store,
+		nowFn: func() time.Time {
+			return baseTime
+		},
+	}
+
+	require.Equal(t, 30*time.Second, delivery.LeaseRemaining())
+	require.False(t, delivery.IsLeaseExpired())
+
+	err := delivery.Ack(ctx, fn.Ok("ok"))
+	require.NoError(t, err)
+
+	store.mu.Lock()
+	result := store.askResults[msgID]
+	store.mu.Unlock()
+
+	require.NotNil(t, result)
+	require.Equal(t, baseTime.Add(24*time.Hour), result.ExpiresAt)
+
+	delivery.acked = false
+	store.messages[msgID] = &LeasedMessage{
+		ID:          msgID,
+		MailboxID:   "test-actor",
+		LeaseToken:  leaseToken,
+		LeaseUntil:  baseTime.Add(30 * time.Second),
+		Attempts:    1,
+		MaxAttempts: 10,
+	}
+
+	err = delivery.Extend(ctx, 45*time.Second)
+	require.NoError(t, err)
+	require.Equal(t, baseTime.Add(45*time.Second), delivery.LeaseUntil)
 }
 
 // TestDeliveryRapidAckNack is a property-based test for Ack/Nack behavior.

--- a/baselib/actor/durable_actor.go
+++ b/baselib/actor/durable_actor.go
@@ -177,6 +177,25 @@ func NewTxBehaviorEither[M TLVMessage, R any, S any](
 	)
 }
 
+const (
+	defaultDurableCleanupTimeout = 5 * time.Second
+	defaultDeduplicationTTL      = 24 * time.Hour
+)
+
+// defaultDurableHeartbeatInterval returns the default lease heartbeat interval
+// derived from the configured lease duration.
+func defaultDurableHeartbeatInterval(
+	leaseDuration time.Duration,
+) time.Duration {
+
+	heartbeatInterval := leaseDuration / 3
+	if heartbeatInterval <= 0 {
+		return time.Nanosecond
+	}
+
+	return heartbeatInterval
+}
+
 // DefaultDurableActorConfig returns a config with sensible defaults.
 func DefaultDurableActorConfig[M TLVMessage, R any](
 	id string,
@@ -185,22 +204,24 @@ func DefaultDurableActorConfig[M TLVMessage, R any](
 	codec *MessageCodec,
 ) DurableActorConfig[M, R] {
 
-	leaseDuration := 30 * time.Second
+	leaseDuration := defaultDurableLeaseDuration
 
 	return DurableActorConfig[M, R]{
-		ID:                id,
-		Log:               fn.None[btclog.Logger](),
-		Behavior:          NewClassicBehavior(behavior),
-		Store:             store,
-		Codec:             codec,
-		TellRetryPolicy:   DefaultTellRetryPolicy,
-		LeaseDuration:     leaseDuration,
-		HeartbeatInterval: leaseDuration / 3,
-		PollInterval:      time.Second,
-		MaxAttempts:       10,
-		CleanupTimeout:    5 * time.Second,
-		DeduplicationTTL:  24 * time.Hour,
-		NumWorkers:        1,
+		ID:              id,
+		Log:             fn.None[btclog.Logger](),
+		Behavior:        NewClassicBehavior(behavior),
+		Store:           store,
+		Codec:           codec,
+		TellRetryPolicy: DefaultTellRetryPolicy,
+		LeaseDuration:   leaseDuration,
+		HeartbeatInterval: defaultDurableHeartbeatInterval(
+			leaseDuration,
+		),
+		PollInterval:     defaultDurablePollInterval,
+		MaxAttempts:      defaultDurableMaxAttempts,
+		CleanupTimeout:   defaultDurableCleanupTimeout,
+		DeduplicationTTL: defaultDeduplicationTTL,
+		NumWorkers:       1,
 	}
 }
 
@@ -367,14 +388,41 @@ func NewDurableActor[M TLVMessage, R any](
 		numWorkers = 1
 	}
 
+	leaseDuration := cfg.LeaseDuration
+	if leaseDuration <= 0 {
+		leaseDuration = defaultDurableLeaseDuration
+	}
+
+	pollInterval := cfg.PollInterval
+	if pollInterval <= 0 {
+		pollInterval = defaultDurablePollInterval
+	}
+
+	maxAttempts := cfg.MaxAttempts
+	if maxAttempts <= 0 {
+		maxAttempts = defaultDurableMaxAttempts
+	}
+
+	heartbeatInterval := cfg.HeartbeatInterval
+	if heartbeatInterval <= 0 || heartbeatInterval >= leaseDuration/2 {
+		heartbeatInterval = defaultDurableHeartbeatInterval(
+			leaseDuration,
+		)
+	}
+
+	cleanupTimeout := cfg.CleanupTimeout
+	if cleanupTimeout <= 0 {
+		cleanupTimeout = defaultDurableCleanupTimeout
+	}
+
 	mailboxCfg := DurableMailboxConfig{
 		MailboxID:     cfg.ID,
 		Store:         cfg.Store,
 		Codec:         cfg.Codec,
 		Clock:         cfg.Clock,
-		LeaseDuration: cfg.LeaseDuration,
-		PollInterval:  cfg.PollInterval,
-		MaxAttempts:   cfg.MaxAttempts,
+		LeaseDuration: leaseDuration,
+		PollInterval:  pollInterval,
+		MaxAttempts:   maxAttempts,
 
 		// Size the wake channel to the worker count so a burst of
 		// enqueues can rouse every idle worker at once.
@@ -387,8 +435,8 @@ func NewDurableActor[M TLVMessage, R any](
 	}
 
 	deduplicationTTL := cfg.DeduplicationTTL
-	if deduplicationTTL == 0 {
-		deduplicationTTL = 24 * time.Hour
+	if deduplicationTTL <= 0 {
+		deduplicationTTL = defaultDeduplicationTTL
 	}
 
 	// Check if the store supports transaction awareness.
@@ -451,9 +499,9 @@ func NewDurableActor[M TLVMessage, R any](
 		dlo:               cfg.DLO,
 		wg:                cfg.Wg,
 		tellRetryPolicy:   tellPolicy,
-		leaseDuration:     cfg.LeaseDuration,
-		heartbeatInterval: cfg.HeartbeatInterval,
-		cleanupTimeout:    cfg.CleanupTimeout,
+		leaseDuration:     leaseDuration,
+		heartbeatInterval: heartbeatInterval,
+		cleanupTimeout:    cleanupTimeout,
 		deduplicationTTL:  deduplicationTTL,
 		numWorkers:        numWorkers,
 		done:              make(chan struct{}),
@@ -542,6 +590,11 @@ func (a *DurableActor[M, R]) teardown() {
 	// The actor's context has been cancelled and all workers have exited.
 	// Close the mailbox.
 	a.mailbox.Close()
+
+	// Standard Ask promises are in-memory only. Once the durable actor
+	// stops, any still-pending live asks must fail instead of hanging
+	// forever while the mailbox rows remain on disk for a later restart.
+	a.mailbox.failPendingAsks(fn.Err[R](ErrActorTerminated))
 
 	// For durable mailboxes, we don't drain to DLO since messages persist
 	// in the database and will be picked up on restart.
@@ -718,7 +771,7 @@ func (a *DurableActor[M, R]) processInTransaction(ctx context.Context,
 	// Transaction committed -- now it is safe to complete the
 	// in-memory promise so the caller observes the result.
 	if delivery.IsAsk() && delivery.Promise != nil {
-		delivery.Promise.Complete(behaviorResult)
+		delivery.settleAsk(behaviorResult)
 	}
 }
 
@@ -1030,6 +1083,7 @@ func (a *DurableActor[M, R]) handleResultInTx(
 	// promise completion after ExecTx returns.
 	txDelivery := &Delivery[M, R]{
 		ID:              delivery.ID,
+		PromiseID:       delivery.PromiseID,
 		Message:         delivery.Message,
 		Promise:         delivery.Promise,
 		CallerCtx:       delivery.CallerCtx,
@@ -1040,6 +1094,8 @@ func (a *DurableActor[M, R]) handleResultInTx(
 		Attempts:        delivery.Attempts,
 		MaxAttempts:     delivery.MaxAttempts,
 		store:           store,
+		nowFn:           delivery.nowFn,
+		onAskSettled:    delivery.onAskSettled,
 		deferPromise:    delivery.deferPromise,
 	}
 
@@ -1107,7 +1163,18 @@ func (a *DurableActor[M, R]) handleResultInTx(
 			return fmt.Errorf("mark processed: %w", err)
 		}
 
-		return store.MoveToDeadLetter(ctx, delivery.ID, err.Error())
+		rowsAffected, moveErr := store.MoveToDeadLetter(
+			ctx, delivery.ID, delivery.LeaseToken, err.Error(),
+		)
+		if moveErr != nil {
+			return moveErr
+		}
+
+		if rowsAffected == 0 {
+			return ErrLeaseExpired
+		}
+
+		return nil
 	}
 
 	// Success - mark as processed and Ack the message.
@@ -1218,25 +1285,20 @@ func (a *DurableActor[M, R]) handleResult(ctx context.Context,
 			// Max retries exceeded or policy says don't retry.
 			// Explicitly move to dead letter queue.
 			reason := fmt.Sprintf("retry policy exhausted: %v", err)
-			if dlErr := a.store.MoveToDeadLetter(
-				ctx, delivery.ID, reason,
-			); dlErr != nil {
-
-				logger(ctx).WarnS(ctx, "Failed to dead-letter "+
-					"Tell message",
+			rowsAffected, dlErr := a.store.MoveToDeadLetter(
+				ctx, delivery.ID, delivery.LeaseToken, reason,
+			)
+			if dlErr != nil {
+				logger(ctx).WarnS(ctx,
+					"Failed to dead-letter Tell message",
 					dlErr,
 					"actor_id", a.id,
 					"delivery_id", delivery.ID)
-			}
-
-			// Delete from mailbox after dead-lettering.
-			if delErr := a.store.DeleteMessage(
-				ctx, delivery.ID,
-			); delErr != nil {
-
-				logger(ctx).WarnS(ctx, "Failed to delete "+
-					"dead-lettered message",
-					delErr,
+			} else if rowsAffected == 0 {
+				logger(ctx).WarnS(ctx,
+					"Skipped dead-lettering Tell message "+
+						"after lease loss",
+					nil,
 					"actor_id", a.id,
 					"delivery_id", delivery.ID)
 			}

--- a/baselib/actor/durable_actor_test.go
+++ b/baselib/actor/durable_actor_test.go
@@ -174,6 +174,9 @@ type mockTxAwareStore struct {
 	// txShouldFail causes ExecTx to fail.
 	txShouldFail bool
 
+	// txFailuresRemaining causes the next N ExecTx calls to fail.
+	txFailuresRemaining int
+
 	// nackCalled tracks whether NackMessage was called after tx failure.
 	nackCalled atomic.Bool
 
@@ -199,7 +202,16 @@ func (m *mockTxAwareStore) ExecTx(
 	m.txExecuted.Store(true)
 	m.txCount.Add(1)
 
-	if m.txShouldFail {
+	m.mu.Lock()
+	shouldFail := m.txShouldFail
+	if m.txFailuresRemaining > 0 {
+		shouldFail = true
+		m.txFailuresRemaining--
+	}
+	postCallbackHook := m.txPostCallbackHook
+	m.mu.Unlock()
+
+	if shouldFail {
 		return errors.New("simulated tx failure")
 	}
 
@@ -211,8 +223,8 @@ func (m *mockTxAwareStore) ExecTx(
 	// Run the post-callback hook if set. This simulates the window
 	// between the callback completing and commit returning, which is
 	// where premature promise completion would be observable.
-	if m.txPostCallbackHook != nil {
-		m.txPostCallbackHook()
+	if postCallbackHook != nil {
+		postCallbackHook()
 	}
 
 	return nil
@@ -244,6 +256,89 @@ func TestDurableActorCreation(t *testing.T) {
 	require.Equal(t, 10*time.Second, actor.heartbeatInterval)
 	require.Equal(t, 5*time.Second, actor.cleanupTimeout)
 	require.Equal(t, 24*time.Hour, actor.deduplicationTTL)
+}
+
+// TestDurableActorAppliesZeroValueDefaults tests that constructing a durable
+// actor directly still applies the documented defaults.
+func TestDurableActorAppliesZeroValueDefaults(t *testing.T) {
+	t.Parallel()
+
+	store := newMockDeliveryStore()
+	codec := newActorTestCodec()
+	behavior := newMockBehavior(fn.Ok(42))
+
+	cfg := DurableActorConfig[*actorTestMsg, int]{
+		ID:       "test-actor",
+		Behavior: NewClassicBehavior[*actorTestMsg, int](behavior),
+		Store:    store,
+		Codec:    codec,
+	}
+	actor := NewDurableActor(cfg).UnwrapOrFail(t)
+
+	require.Equal(t, defaultDurableLeaseDuration, actor.leaseDuration)
+	require.Equal(t, defaultDurableLeaseDuration/3, actor.heartbeatInterval)
+	require.Equal(
+		t, defaultDurablePollInterval, actor.mailbox.cfg.PollInterval,
+	)
+	require.Equal(
+		t, defaultDurableMaxAttempts, actor.mailbox.cfg.MaxAttempts,
+	)
+	require.Equal(t, defaultDurableCleanupTimeout, actor.cleanupTimeout)
+	require.Equal(t, defaultDeduplicationTTL, actor.deduplicationTTL)
+}
+
+// TestDurableActorNormalizesUnsafeHeartbeat tests that heartbeat settings that
+// would let leases expire before renewal are reset to the safe default.
+func TestDurableActorNormalizesUnsafeHeartbeat(t *testing.T) {
+	t.Parallel()
+
+	store := newMockDeliveryStore()
+	codec := newActorTestCodec()
+	behavior := newMockBehavior(fn.Ok(42))
+
+	cfg := DurableActorConfig[*actorTestMsg, int]{
+		ID: "test-actor",
+		Behavior: NewClassicBehavior[*actorTestMsg, int](
+			behavior,
+		),
+		Store:             store,
+		Codec:             codec,
+		LeaseDuration:     30 * time.Second,
+		HeartbeatInterval: 20 * time.Second,
+		PollInterval:      10 * time.Millisecond,
+		MaxAttempts:       3,
+		CleanupTimeout:    time.Second,
+		DeduplicationTTL:  time.Hour,
+	}
+	actor := NewDurableActor(cfg).UnwrapOrFail(t)
+
+	require.Equal(t, 30*time.Second, actor.leaseDuration)
+	require.Equal(t, 10*time.Second, actor.heartbeatInterval)
+}
+
+// TestDurableActorTinyLeaseKeepsHeartbeatPositive tests that even very small
+// lease durations still normalize to a positive heartbeat interval.
+func TestDurableActorTinyLeaseKeepsHeartbeatPositive(t *testing.T) {
+	t.Parallel()
+
+	store := newMockDeliveryStore()
+	codec := newActorTestCodec()
+	behavior := newMockBehavior(fn.Ok(42))
+
+	cfg := DurableActorConfig[*actorTestMsg, int]{
+		ID: "test-actor",
+		Behavior: NewClassicBehavior[*actorTestMsg, int](
+			behavior,
+		),
+		Store:             store,
+		Codec:             codec,
+		LeaseDuration:     time.Nanosecond,
+		HeartbeatInterval: 0,
+	}
+	actor := NewDurableActor(cfg).UnwrapOrFail(t)
+
+	require.Equal(t, time.Nanosecond, actor.leaseDuration)
+	require.Positive(t, actor.heartbeatInterval)
 }
 
 // TestDurableActorStartStop tests basic lifecycle.
@@ -580,6 +675,43 @@ func TestDurableActorPanicRecovery(t *testing.T) {
 	require.NoError(t, actor.ctx.Err())
 }
 
+// TestDurableActorAskRespectsCallerDeadline tests that durable Ask preserves
+// the original caller context so behavior can observe deadline cancellation.
+func TestDurableActorAskRespectsCallerDeadline(t *testing.T) {
+	t.Parallel()
+
+	store := newMockDeliveryStore()
+	codec := newActorTestCodec()
+	behavior := newMockBehavior(fn.Ok(42))
+	behavior.setDelay(500 * time.Millisecond)
+
+	cfg := DefaultDurableActorConfig("test-actor", behavior, store, codec)
+	cfg.PollInterval = 10 * time.Millisecond
+	actor := NewDurableActor(cfg).UnwrapOrFail(t)
+
+	actor.Start()
+	defer actor.Stop()
+
+	msg := &actorTestMsg{
+		Value: tlv.NewPrimitiveRecord[tlv.TlvType1](uint64(42)),
+	}
+
+	askCtx, cancel := context.WithTimeout(
+		context.Background(), 50*time.Millisecond,
+	)
+	defer cancel()
+
+	start := time.Now()
+	result := actor.Ref().Ask(askCtx, msg).Await(context.Background())
+	elapsed := time.Since(start)
+
+	require.True(
+		t, result.IsErr(),
+		"durable Ask should fail on caller deadline",
+	)
+	require.Less(t, elapsed, 300*time.Millisecond)
+}
+
 // TestDurableActorTellRetryPolicy tests that Tell respects retry policy.
 func TestDurableActorTellRetryPolicy(t *testing.T) {
 	t.Parallel()
@@ -857,6 +989,60 @@ func TestDurableActorAskToTerminatedActor(t *testing.T) {
 	result := future.Await(ctx)
 	require.Error(t, result.Err())
 	require.Equal(t, ErrActorTerminated, result.Err())
+}
+
+// TestDurableActorStopFailsQueuedAsk verifies that queued live Ask promises are
+// failed on durable actor shutdown instead of hanging indefinitely.
+func TestDurableActorStopFailsQueuedAsk(t *testing.T) {
+	t.Parallel()
+
+	store := newMockDeliveryStore()
+	codec := newActorTestCodec()
+	behavior := newMockBehavior(fn.Ok(42))
+	firstStarted := make(chan struct{}, 1)
+	behavior.onReceive = func(ctx context.Context, msg *actorTestMsg) {
+		select {
+		case firstStarted <- struct{}{}:
+		default:
+		}
+
+		<-ctx.Done()
+	}
+
+	cfg := DefaultDurableActorConfig("test-actor", behavior, store, codec)
+	cfg.PollInterval = 10 * time.Millisecond
+	actor := NewDurableActor(cfg).UnwrapOrFail(t)
+
+	actor.Start()
+	defer actor.Stop()
+
+	msg := &actorTestMsg{
+		Value: tlv.NewPrimitiveRecord[tlv.TlvType1](uint64(42)),
+	}
+
+	ctx := context.Background()
+	firstFuture := actor.Ref().Ask(ctx, msg)
+
+	select {
+	case <-firstStarted:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("first ask never started processing")
+	}
+
+	secondFuture := actor.Ref().Ask(ctx, msg)
+
+	actor.Stop()
+
+	secondCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer cancel()
+
+	secondResult := secondFuture.Await(secondCtx)
+	require.ErrorIs(t, secondResult.Err(), ErrActorTerminated)
+
+	firstCtx, cancelFirst := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer cancelFirst()
+
+	_ = firstFuture.Await(firstCtx)
 }
 
 // TestDurableActorWithWaitGroup tests lifecycle tracking with WaitGroup.
@@ -1709,6 +1895,50 @@ func TestPromiseNotCompletedOnTxFailure(t *testing.T) {
 
 	// Should time out or get context error - not a real result.
 	require.Error(t, result.Err())
+}
+
+// TestPromiseSurvivesTxRetry verifies that a durable Ask keeps its original
+// in-memory promise across transaction retries instead of dropping the future
+// after the first lease attempt.
+func TestPromiseSurvivesTxRetry(t *testing.T) {
+	t.Parallel()
+
+	store := newMockTxAwareStore()
+	store.txFailuresRemaining = 1
+	codec := newActorTestCodec()
+	behavior := newMockBehavior(fn.Ok(42))
+
+	cfg := DefaultDurableActorConfig("test-actor", behavior, store, codec)
+	cfg.PollInterval = 10 * time.Millisecond
+	actor := NewDurableActor(cfg).UnwrapOrFail(t)
+
+	actor.Start()
+	defer actor.Stop()
+
+	msg := &actorTestMsg{
+		Value: tlv.NewPrimitiveRecord[tlv.TlvType1](uint64(99)),
+	}
+
+	ctx := context.Background()
+	future := actor.Ref().Ask(ctx, msg)
+
+	// Force the first attempt through the tx-failure path.
+	require.Eventually(t, func() bool {
+		return store.txExecuted.Load()
+	}, 500*time.Millisecond, 10*time.Millisecond)
+
+	require.Eventually(t, func() bool {
+		return store.nackCalled.Load()
+	}, 500*time.Millisecond, 10*time.Millisecond)
+
+	resultCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	result := future.Await(resultCtx)
+	val, err := result.Unpack()
+	require.NoError(t, err)
+	require.Equal(t, 42, val)
+	require.Equal(t, 1, behavior.callCount())
 }
 
 // TestDeliveryConcurrentExtendAndAck verifies that concurrent Extend and Ack

--- a/baselib/actor/durable_mailbox.go
+++ b/baselib/actor/durable_mailbox.go
@@ -48,6 +48,12 @@ func isExpectedShutdownErr(err error) bool {
 	return false
 }
 
+const (
+	defaultDurableLeaseDuration = 30 * time.Second
+	defaultDurablePollInterval  = 100 * time.Millisecond
+	defaultDurableMaxAttempts   = 10
+)
+
 // generateID generates a UUIDv7 which provides both uniqueness and
 // time-ordering. UUIDv7 embeds a Unix timestamp in milliseconds in the most
 // significant bits, ensuring that IDs generated later sort after IDs generated
@@ -104,9 +110,9 @@ func DefaultDurableMailboxConfig(mailboxID string, store DeliveryStore,
 		MailboxID:     mailboxID,
 		Store:         store,
 		Codec:         codec,
-		LeaseDuration: 30 * time.Second,
-		PollInterval:  time.Second,
-		MaxAttempts:   10,
+		LeaseDuration: defaultDurableLeaseDuration,
+		PollInterval:  defaultDurablePollInterval,
+		MaxAttempts:   defaultDurableMaxAttempts,
 	}
 }
 
@@ -139,11 +145,28 @@ type DurableMailbox[M TLVMessage, R any] struct {
 	promiseRegistryMu sync.RWMutex
 }
 
+// pendingAskState keeps the in-memory pieces of a durable Ask that cannot be
+// reconstructed from the persisted mailbox row alone.
+type pendingAskState struct {
+	promise   any
+	callerCtx context.Context
+}
+
 // NewDurableMailbox creates a new durable mailbox with the given configuration.
 func NewDurableMailbox[M TLVMessage, R any](
 	actorCtx context.Context,
 	cfg DurableMailboxConfig,
 ) *DurableMailbox[M, R] {
+
+	if cfg.LeaseDuration <= 0 {
+		cfg.LeaseDuration = defaultDurableLeaseDuration
+	}
+	if cfg.PollInterval <= 0 {
+		cfg.PollInterval = defaultDurablePollInterval
+	}
+	if cfg.MaxAttempts <= 0 {
+		cfg.MaxAttempts = defaultDurableMaxAttempts
+	}
 
 	wakeBuffer := cfg.WakeBuffer
 	if wakeBuffer < 1 {
@@ -213,9 +236,14 @@ func (m *DurableMailbox[M, R]) Send(ctx context.Context,
 		promiseID = id
 
 		// Register the promise for later retrieval when the message is
-		// received from the database.
+		// received from the database. The original caller context is
+		// also kept in-memory so Ask messages retain deadline
+		// propagation while the process is alive.
 		m.promiseRegistryMu.Lock()
-		m.promiseRegistry[id] = env.promise
+		m.promiseRegistry[id] = pendingAskState{
+			promise:   env.promise,
+			callerCtx: env.callerCtx,
+		}
 		m.promiseRegistryMu.Unlock()
 	}
 
@@ -431,26 +459,38 @@ func (m *DurableMailbox[M, R]) Receive(
 			// Retrieve the promise from the registry if this is an
 			// Ask.
 			var promise Promise[R]
+			var callerCtx context.Context
+			var onAskSettled func()
 			if leased.PromiseID != "" {
 				m.promiseRegistryMu.Lock()
-				if p, ok := m.promiseRegistry[leased.PromiseID]; ok {
-					if typedPromise, ok := p.(Promise[R]); ok {
+				if raw, ok := m.promiseRegistry[leased.PromiseID]; ok {
+					if state, ok := raw.(pendingAskState); ok {
+						if typedPromise, ok := state.promise.(Promise[R]); ok {
+							promise = typedPromise
+							callerCtx = state.callerCtx
+						}
+					} else if typedPromise, ok := raw.(Promise[R]); ok {
 						promise = typedPromise
+						callerCtx = ctx
 					}
+				}
+				m.promiseRegistryMu.Unlock()
 
-					// Remove from registry - each promise
-					// is used once.
+				onAskSettled = func() {
+					m.promiseRegistryMu.Lock()
 					delete(
 						m.promiseRegistry,
 						leased.PromiseID,
 					)
+					m.promiseRegistryMu.Unlock()
 				}
-				m.promiseRegistryMu.Unlock()
 			}
 
 			// Create the delivery with the promise attached.
 			delivery := newDelivery[M, R](
-				leased, msg, promise, ctx, m.cfg.Store,
+				leased, msg, promise, callerCtx,
+				leased.PromiseID, m.cfg.Store, m.clock.Now,
+				onAskSettled,
 			)
 
 			// Wrap in envelope for compatibility with the Mailbox
@@ -461,7 +501,7 @@ func (m *DurableMailbox[M, R]) Receive(
 			env := envelope[M, R]{
 				message:   msg,
 				promise:   promise,
-				callerCtx: ctx,
+				callerCtx: callerCtx,
 				delivery:  delivery,
 			}
 
@@ -486,10 +526,10 @@ func (m *DurableMailbox[M, R]) handlePoisonMessage(ctx context.Context,
 		dlReason := fmt.Sprintf("poison message (attempts %d/%d): %s",
 			leased.Attempts, leased.MaxAttempts, reason)
 
-		if dlErr := m.cfg.Store.MoveToDeadLetter(
-			ctx, leased.ID, dlReason,
-		); dlErr != nil {
-
+		rowsAffected, dlErr := m.cfg.Store.MoveToDeadLetter(
+			ctx, leased.ID, leased.LeaseToken, dlReason,
+		)
+		if dlErr != nil {
 			logger(ctx).WarnS(ctx,
 				"Failed to dead-letter poison message",
 				dlErr,
@@ -499,16 +539,15 @@ func (m *DurableMailbox[M, R]) handlePoisonMessage(ctx context.Context,
 			return
 		}
 
-		if delErr := m.cfg.Store.DeleteMessage(
-			ctx, leased.ID,
-		); delErr != nil {
-
+		if rowsAffected == 0 {
 			logger(ctx).WarnS(ctx,
-				"Failed to delete dead-lettered poison "+
-					"message",
-				delErr,
+				"Skipped dead-lettering poison message after "+
+					"lease loss",
+				nil,
 				"mailbox_id", m.cfg.MailboxID,
 				"message_id", leased.ID)
+
+			return
 		}
 
 		logger(ctx).InfoS(
@@ -536,6 +575,27 @@ func (m *DurableMailbox[M, R]) Close() {
 
 	if m.closed.CompareAndSwap(false, true) {
 		close(m.wake)
+	}
+}
+
+// failPendingAsks completes any still-registered in-memory Ask promises with
+// the supplied terminal result and clears the registry.
+func (m *DurableMailbox[M, R]) failPendingAsks(result fn.Result[R]) {
+	m.promiseRegistryMu.Lock()
+	pending := m.promiseRegistry
+	m.promiseRegistry = make(map[string]any)
+	m.promiseRegistryMu.Unlock()
+
+	for _, raw := range pending {
+		switch state := raw.(type) {
+		case pendingAskState:
+			if promise, ok := state.promise.(Promise[R]); ok {
+				promise.Complete(result)
+			}
+
+		case Promise[R]:
+			state.Complete(result)
+		}
 	}
 }
 

--- a/baselib/actor/durable_mailbox_test.go
+++ b/baselib/actor/durable_mailbox_test.go
@@ -101,9 +101,30 @@ func TestDurableMailboxNewMailbox(t *testing.T) {
 	require.NotNil(t, mailbox)
 	require.False(t, mailbox.IsClosed())
 	require.Equal(t, "test-mailbox", mailbox.cfg.MailboxID)
-	require.Equal(t, 30*time.Second, mailbox.cfg.LeaseDuration)
-	require.Equal(t, time.Second, mailbox.cfg.PollInterval)
-	require.Equal(t, 10, mailbox.cfg.MaxAttempts)
+	require.Equal(t, defaultDurableLeaseDuration, mailbox.cfg.LeaseDuration)
+	require.Equal(t, defaultDurablePollInterval, mailbox.cfg.PollInterval)
+	require.Equal(t, defaultDurableMaxAttempts, mailbox.cfg.MaxAttempts)
+}
+
+// TestDurableMailboxAppliesZeroValueDefaults tests that constructing a durable
+// mailbox directly still applies the documented defaults.
+func TestDurableMailboxAppliesZeroValueDefaults(t *testing.T) {
+	t.Parallel()
+
+	store := newMockDeliveryStore()
+	codec := newDurableTestCodec()
+	ctx := context.Background()
+
+	cfg := DurableMailboxConfig{
+		MailboxID: "test-mailbox",
+		Store:     store,
+		Codec:     codec,
+	}
+	mailbox := NewDurableMailbox[*durableTestMsg, int](ctx, cfg)
+
+	require.Equal(t, defaultDurableLeaseDuration, mailbox.cfg.LeaseDuration)
+	require.Equal(t, defaultDurablePollInterval, mailbox.cfg.PollInterval)
+	require.Equal(t, defaultDurableMaxAttempts, mailbox.cfg.MaxAttempts)
 }
 
 // TestDurableMailboxSend tests that Send persists messages to the store.

--- a/baselib/actor/outbox_publisher.go
+++ b/baselib/actor/outbox_publisher.go
@@ -8,6 +8,13 @@ import (
 	"github.com/google/uuid"
 )
 
+const (
+	defaultOutboxPublisherPollInterval        = 100 * time.Millisecond
+	defaultOutboxPublisherBatchSize           = 100
+	defaultOutboxPublisherMaxDeliveryAttempts = 10
+	defaultOutboxPublisherClaimDuration       = 30 * time.Second
+)
+
 // OutboxPublisherConfig holds configuration for the OutboxPublisher.
 type OutboxPublisherConfig struct {
 	// Store is the persistence layer for outbox operations.
@@ -50,10 +57,10 @@ func DefaultOutboxPublisherConfig(
 		Store:               store,
 		Codec:               codec,
 		System:              system,
-		PollInterval:        time.Second,
-		BatchSize:           100,
-		MaxDeliveryAttempts: 10,
-		ClaimDuration:       30 * time.Second,
+		PollInterval:        defaultOutboxPublisherPollInterval,
+		BatchSize:           defaultOutboxPublisherBatchSize,
+		MaxDeliveryAttempts: defaultOutboxPublisherMaxDeliveryAttempts,
+		ClaimDuration:       defaultOutboxPublisherClaimDuration,
 	}
 }
 
@@ -94,17 +101,18 @@ type OutboxPublisher struct {
 func NewOutboxPublisher(cfg OutboxPublisherConfig) *OutboxPublisher {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	if cfg.PollInterval == 0 {
-		cfg.PollInterval = time.Second
+	if cfg.PollInterval <= 0 {
+		cfg.PollInterval = defaultOutboxPublisherPollInterval
 	}
-	if cfg.BatchSize == 0 {
-		cfg.BatchSize = 100
+	if cfg.BatchSize <= 0 {
+		cfg.BatchSize = defaultOutboxPublisherBatchSize
 	}
-	if cfg.MaxDeliveryAttempts == 0 {
-		cfg.MaxDeliveryAttempts = 10
+	if cfg.MaxDeliveryAttempts <= 0 {
+		cfg.MaxDeliveryAttempts =
+			defaultOutboxPublisherMaxDeliveryAttempts
 	}
-	if cfg.ClaimDuration == 0 {
-		cfg.ClaimDuration = 30 * time.Second
+	if cfg.ClaimDuration <= 0 {
+		cfg.ClaimDuration = defaultOutboxPublisherClaimDuration
 	}
 
 	p := &OutboxPublisher{
@@ -211,13 +219,19 @@ func (p *OutboxPublisher) deliverMessage(msg OutboxMessage) {
 			"attempts", msg.DeliveryAttempts,
 			"max_attempts", p.cfg.MaxDeliveryAttempts)
 
-		dlErr := p.cfg.Store.FailOutbox(
-			p.ctx, msg.ID, msg.ClaimToken,
+		reason := "max delivery attempts exceeded"
+		rowsAffected, dlErr := p.cfg.Store.FailOutbox(
+			p.ctx, msg.ID, msg.ClaimToken, reason,
 		)
 		if dlErr != nil {
 			logger(p.ctx).WarnS(p.ctx,
 				"Failed to dead-letter outbox message",
 				dlErr, "message_id", msg.ID)
+		} else if rowsAffected == 0 {
+			logger(p.ctx).WarnS(p.ctx,
+				"Skipped dead-lettering outbox message after "+
+					"claim loss",
+				nil, "message_id", msg.ID)
 		}
 
 		return
@@ -231,13 +245,19 @@ func (p *OutboxPublisher) deliverMessage(msg OutboxMessage) {
 			"message_type", msg.MessageType)
 
 		// Poison pill - mark as failed (dead letter).
-		dlErr := p.cfg.Store.FailOutbox(
-			p.ctx, msg.ID, msg.ClaimToken,
+		reason := "failed to decode outbox payload: " + err.Error()
+		rowsAffected, dlErr := p.cfg.Store.FailOutbox(
+			p.ctx, msg.ID, msg.ClaimToken, reason,
 		)
 		if dlErr != nil {
 			logger(p.ctx).WarnS(p.ctx,
 				"Failed to dead-letter outbox message",
 				dlErr, "message_id", msg.ID)
+		} else if rowsAffected == 0 {
+			logger(p.ctx).WarnS(p.ctx,
+				"Skipped dead-lettering outbox message after "+
+					"claim loss",
+				nil, "message_id", msg.ID)
 		}
 
 		return
@@ -273,12 +293,22 @@ func (p *OutboxPublisher) deliverMessage(msg OutboxMessage) {
 	}
 
 	// Mark as complete after successful durable send.
-	completeErr := p.cfg.Store.CompleteOutbox(
+	rowsAffected, completeErr := p.cfg.Store.CompleteOutbox(
 		p.ctx, msg.ID, msg.ClaimToken,
 	)
 	if completeErr != nil {
 		logger(p.ctx).WarnS(p.ctx, "Failed to complete outbox message",
 			completeErr, "message_id", msg.ID)
+
+		return
+	}
+
+	if rowsAffected == 0 {
+		logger(p.ctx).WarnS(p.ctx,
+			"Skipped completing outbox message after claim loss",
+			nil, "message_id", msg.ID)
+
+		return
 	}
 
 	logger(p.ctx).TraceS(p.ctx, "Delivered outbox message",

--- a/baselib/actor/outbox_publisher_test.go
+++ b/baselib/actor/outbox_publisher_test.go
@@ -150,9 +150,54 @@ func TestOutboxPublisherCreation(t *testing.T) {
 	publisher := NewOutboxPublisher(cfg)
 
 	require.NotNil(t, publisher)
-	require.Equal(t, time.Second, publisher.cfg.PollInterval)
-	require.Equal(t, 100, publisher.cfg.BatchSize)
-	require.Equal(t, 10, publisher.cfg.MaxDeliveryAttempts)
+	require.Equal(
+		t, defaultOutboxPublisherPollInterval,
+		publisher.cfg.PollInterval,
+	)
+	require.Equal(
+		t, defaultOutboxPublisherBatchSize, publisher.cfg.BatchSize,
+	)
+	require.Equal(
+		t, defaultOutboxPublisherMaxDeliveryAttempts,
+		publisher.cfg.MaxDeliveryAttempts,
+	)
+}
+
+// TestOutboxPublisherAppliesNonPositiveDefaults tests that constructing an
+// outbox publisher directly still applies the documented defaults.
+func TestOutboxPublisherAppliesNonPositiveDefaults(t *testing.T) {
+	t.Parallel()
+
+	store := newMockDeliveryStore()
+	codec := newOutboxTestCodec()
+	system := newMockSystem()
+
+	cfg := OutboxPublisherConfig{
+		Store:               store,
+		Codec:               codec,
+		System:              system,
+		PollInterval:        -time.Second,
+		BatchSize:           -1,
+		MaxDeliveryAttempts: -1,
+		ClaimDuration:       -time.Second,
+	}
+	publisher := NewOutboxPublisher(cfg)
+
+	require.Equal(
+		t, defaultOutboxPublisherPollInterval,
+		publisher.cfg.PollInterval,
+	)
+	require.Equal(
+		t, defaultOutboxPublisherBatchSize, publisher.cfg.BatchSize,
+	)
+	require.Equal(
+		t, defaultOutboxPublisherMaxDeliveryAttempts,
+		publisher.cfg.MaxDeliveryAttempts,
+	)
+	require.Equal(
+		t, defaultOutboxPublisherClaimDuration,
+		publisher.cfg.ClaimDuration,
+	)
 }
 
 // TestOutboxPublisherStartStop tests lifecycle.

--- a/db/actor_delivery_store.md
+++ b/db/actor_delivery_store.md
@@ -24,8 +24,9 @@ The durable mailbox schema consists of six tables:
 2. **outbox_messages**: Transactional outbox for CDC pattern. Messages written
    here are delivered asynchronously by the OutboxPublisher.
 
-3. **ask_results**: Persists results for Ask messages so callers can recover
-   outcomes after crash.
+3. **ask_results**: Persists Ask result markers so mailbox ack and result
+   durability can commit together, even though standard `Ask` callers still
+   consume responses through an in-memory future.
 
 4. **processed_messages**: Deduplication table tracking processed message IDs
    with TTL-based expiry.
@@ -101,8 +102,8 @@ erDiagram
     }
 
     dead_letters {
-        TEXT id "PK"
-        TEXT source "mailbox|outbox"
+        TEXT source "PK (part 1), mailbox|outbox"
+        TEXT id "PK (part 2)"
         TEXT actor_id "Idx"
         TEXT message_type
         BLOB payload
@@ -184,11 +185,13 @@ changes. The OutboxPublisher drains this table and delivers messages.
   for delivery.
 
 - `domain_key`: Optional natural idempotency key. For example:
-  `"round:abc123:phase:nonces"` ensures the same round/phase combination is only
-  processed once by the receiver.
+  `"round:abc123:phase:nonces"` can be used by higher layers to correlate
+  related messages. The store currently persists and indexes this field, but
+  does not itself enforce deduplication or supersession by `domain_key`.
 
-- `version`: Monotonic counter for ordering within a domain. Higher versions
-  supersede lower versions for the same `domain_key`.
+- `version`: Monotonic counter associated with a `domain_key`. The store
+  persists this metadata, but higher versions do not currently suppress lower
+  versions automatically.
 
 - `status`: Delivery lifecycle state:
   - `pending`: Awaiting delivery (OutboxPublisher polls this)
@@ -201,7 +204,8 @@ changes. The OutboxPublisher drains this table and delivers messages.
 - `idx_outbox_messages_pending`: Partial index on `(status, created_at)` for
   efficient polling of pending messages.
 
-- `idx_outbox_messages_domain_key`: Partial index for idempotency checks.
+- `idx_outbox_messages_domain_key`: Partial index for domain-key lookups by
+  higher-level tooling or future supersession logic.
 
 **CDC flow**:
 1. Actor writes to outbox within transaction (alongside FSM state changes)
@@ -214,24 +218,28 @@ changes. The OutboxPublisher drains this table and delivers messages.
 
 ### ask_results
 
-Persists results for Ask messages so callers can recover outcomes after crash.
-Separating this from mailbox_messages allows the original message to be deleted
-while the result remains available.
+Persists Ask result markers separately from mailbox messages so acknowledging an
+Ask can atomically remove the inbox row and retain its outcome metadata.
+Standard `Ask` still completes through the in-memory promise path; full
+crash-safe response delivery remains the `DurableAsk` mechanism.
 
 **Key fields**:
 - `promise_id`: Links to the original Ask message.
 
-- `result_blob`: TLV-encoded successful result (NULL if error).
+- `result_blob`: Optional persisted success payload. The current runtime stores
+  this only when a caller explicitly writes a blob through the store API; the
+  standard actor `Ask` path persists success/failure status but not the
+  successful return value itself.
 
 - `error_text`: Error message if the request failed (NULL if success).
 
 - `expires_at`: Unix timestamp for TTL-based garbage collection.
 
 **Usage pattern**: When an actor processes an Ask message:
-1. Result (success or error) is written to `ask_results`
-2. Original message is deleted from `mailbox_messages`
-3. In-memory Promise is completed
-4. For DurableAsk: AskResponse is also written to outbox for callback delivery
+1. The store atomically validates the lease, deletes the mailbox row, and
+   inserts the Ask result marker
+2. The in-memory Promise is completed after that durable step succeeds
+3. For DurableAsk: AskResponse is also written to outbox for callback delivery
 
 ### processed_messages
 
@@ -281,7 +289,8 @@ Failed messages after max_attempts or unrecoverable errors. Supports debugging
 and manual intervention for operational recovery.
 
 **Key fields**:
-- `id`: Original message ID for correlation.
+- `source`, `id`: Composite durable identity. The same propagated message ID can
+  appear once as a mailbox dead letter and once as an outbox dead letter.
 
 - `source`: Whether from `mailbox` (incoming) or `outbox` (outgoing).
 

--- a/db/actordelivery/migrations/000003_dead_letter_source_key.down.sql
+++ b/db/actordelivery/migrations/000003_dead_letter_source_key.down.sql
@@ -1,0 +1,36 @@
+-- Rebuild dead_letters back to a single-column primary key. This downgrade is
+-- lossy when both mailbox and outbox dead letters exist for the same original
+-- message ID: it keeps the oldest row for each ID.
+CREATE TABLE IF NOT EXISTS dead_letters_v1 (
+    id TEXT PRIMARY KEY,
+    source TEXT NOT NULL,
+    actor_id TEXT NOT NULL,
+    message_type TEXT NOT NULL,
+    payload BLOB NOT NULL,
+    failure_reason TEXT NOT NULL,
+    attempts INTEGER NOT NULL,
+    created_at BIGINT NOT NULL
+);
+
+INSERT INTO dead_letters_v1 (
+    id, source, actor_id, message_type, payload,
+    failure_reason, attempts, created_at
+)
+SELECT
+    d.id, d.source, d.actor_id, d.message_type, d.payload,
+    d.failure_reason, d.attempts, d.created_at
+FROM dead_letters d
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM dead_letters newer
+    WHERE newer.id = d.id AND newer.created_at < d.created_at
+);
+
+DROP TABLE dead_letters;
+ALTER TABLE dead_letters_v1 RENAME TO dead_letters;
+
+CREATE INDEX IF NOT EXISTS idx_dead_letters_actor
+    ON dead_letters(actor_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_dead_letters_source
+    ON dead_letters(source, created_at DESC);

--- a/db/actordelivery/migrations/000003_dead_letter_source_key.up.sql
+++ b/db/actordelivery/migrations/000003_dead_letter_source_key.up.sql
@@ -1,0 +1,33 @@
+-- Rebuild dead_letters so mailbox and outbox rows can coexist under the same
+-- propagated message ID. Dead-letter identity is `(source, id)`, not `id`
+-- alone, because outbox IDs are intentionally reused as mailbox IDs for
+-- receiver-side deduplication.
+CREATE TABLE IF NOT EXISTS dead_letters_v2 (
+    id TEXT NOT NULL,
+    source TEXT NOT NULL,
+    actor_id TEXT NOT NULL,
+    message_type TEXT NOT NULL,
+    payload BLOB NOT NULL,
+    failure_reason TEXT NOT NULL,
+    attempts INTEGER NOT NULL,
+    created_at BIGINT NOT NULL,
+    PRIMARY KEY (source, id)
+);
+
+INSERT INTO dead_letters_v2 (
+    id, source, actor_id, message_type, payload,
+    failure_reason, attempts, created_at
+)
+SELECT
+    id, source, actor_id, message_type, payload,
+    failure_reason, attempts, created_at
+FROM dead_letters;
+
+DROP TABLE dead_letters;
+ALTER TABLE dead_letters_v2 RENAME TO dead_letters;
+
+CREATE INDEX IF NOT EXISTS idx_dead_letters_actor
+    ON dead_letters(actor_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_dead_letters_source
+    ON dead_letters(source, created_at DESC);

--- a/db/actordelivery/migrations/runner.go
+++ b/db/actordelivery/migrations/runner.go
@@ -16,7 +16,7 @@ const (
 	//
 	// NOTE: This MUST be updated when a new actor-delivery migration is
 	// added.
-	LatestMigrationVersion uint = 2
+	LatestMigrationVersion uint = 3
 
 	// DefaultMigrationsTable is the default migration bookkeeping table.
 	DefaultMigrationsTable = "actor_delivery_schema_migrations"

--- a/db/actordelivery/queries/mailbox.sql
+++ b/db/actordelivery/queries/mailbox.sql
@@ -38,8 +38,8 @@ ON CONFLICT (id) DO NOTHING;
 --
 -- Ordering: priority DESC ensures high-priority (e.g., restart) messages
 -- first, then available_at ASC for delivery order, then created_at ASC as
--- a tiebreaker to ensure deterministic ordering when priority and
--- available_at are equal.
+-- a tiebreaker, then id ASC so UUIDv7 time-ordering remains the final
+-- deterministic tiebreaker when rows land in the same created_at second.
 --
 -- Per-correlation-key FIFO: when a row carries a non-NULL correlation_key,
 -- it is eligible only if no earlier same-key row exists in this mailbox.
@@ -83,7 +83,7 @@ WHERE mailbox_messages.id = (
                 AND m2.attempts < m2.max_attempts
           )
       )
-    ORDER BY m.priority DESC, m.available_at ASC, m.created_at ASC
+    ORDER BY m.priority DESC, m.available_at ASC, m.created_at ASC, m.id ASC
     LIMIT 1
 )
 RETURNING *;
@@ -131,12 +131,12 @@ SET
     lease_until = NULL
 WHERE lease_until IS NOT NULL AND lease_until < $1;
 
--- name: MoveMailboxToDeadLetter :exec
+-- name: MoveMailboxToDeadLetter :execrows
 -- Move a failed message to the dead letter queue.
 INSERT INTO dead_letters (id, source, actor_id, message_type, payload, failure_reason, attempts, created_at)
-SELECT m.id, 'mailbox', m.mailbox_id, m.message_type, m.payload, $2, m.attempts, $3
+SELECT m.id, 'mailbox', m.mailbox_id, m.message_type, m.payload, $3, m.attempts, $4
 FROM mailbox_messages m
-WHERE m.id = $1;
+WHERE m.id = $1 AND m.lease_token = $2;
 
 -- name: DeleteMailboxMessage :exec
 -- Delete a mailbox message by ID (used after moving to dead letter).
@@ -146,7 +146,7 @@ DELETE FROM mailbox_messages WHERE id = $1;
 -- List all messages for an actor's mailbox (for debugging).
 SELECT * FROM mailbox_messages
 WHERE mailbox_id = $1
-ORDER BY priority DESC, available_at ASC, created_at ASC;
+ORDER BY priority DESC, available_at ASC, created_at ASC, id ASC;
 
 -- =============================================================================
 -- Ask Result Operations
@@ -192,6 +192,8 @@ INSERT INTO outbox_messages (
 -- Claim a batch of pending outbox messages for delivery. Sets a claim token
 -- and expiry to prevent concurrent publishers from processing the same messages.
 -- Only selects rows that are unclaimed or whose claim has expired.
+-- Ordering uses created_at ASC and then id ASC so UUIDv7 remains the final
+-- deterministic tiebreaker when rows land in the same created_at second.
 UPDATE outbox_messages
 SET delivery_attempts = delivery_attempts + 1,
     claim_token = $2,
@@ -200,24 +202,24 @@ WHERE id IN (
     SELECT o.id FROM outbox_messages o
     WHERE o.status = 'pending'
       AND (o.claimed_until IS NULL OR o.claimed_until < $4)
-    ORDER BY o.created_at ASC
+    ORDER BY o.created_at ASC, o.id ASC
     LIMIT $1
 )
 RETURNING *;
 
--- name: CompleteOutboxMessage :exec
+-- name: CompleteOutboxMessage :execrows
 -- Mark an outbox message as successfully delivered. The claim token must match
 -- to prevent stale publishers from completing messages they no longer own.
 UPDATE outbox_messages
 SET status = 'completed', completed_at = $2
-WHERE id = $1 AND claim_token = $3;
+WHERE id = $1 AND claim_token = $3 AND status = 'pending';
 
--- name: FailOutboxMessage :exec
+-- name: FailOutboxMessage :execrows
 -- Mark an outbox message as failed (dead letter). The claim token must match
 -- to prevent stale publishers from failing messages they no longer own.
 UPDATE outbox_messages
 SET status = 'dead_letter', completed_at = $2
-WHERE id = $1 AND claim_token = $3;
+WHERE id = $1 AND claim_token = $3 AND status = 'pending';
 
 -- name: GetOutboxMessage :one
 -- Get a specific outbox message by ID.
@@ -231,7 +233,7 @@ SELECT COUNT(*) FROM outbox_messages WHERE status = 'pending';
 -- List pending outbox messages for a specific target actor.
 SELECT * FROM outbox_messages
 WHERE target_actor_id = $1 AND status = 'pending'
-ORDER BY created_at ASC;
+ORDER BY created_at ASC, id ASC;
 
 -- name: MoveOutboxToDeadLetter :exec
 -- Move a failed outbox message to the dead letter queue.
@@ -295,7 +297,7 @@ SELECT * FROM fsm_checkpoints ORDER BY updated_at DESC;
 
 -- name: GetDeadLetter :one
 -- Get a specific dead letter by ID.
-SELECT * FROM dead_letters WHERE id = $1;
+SELECT * FROM dead_letters WHERE source = $1 AND id = $2;
 
 -- name: ListDeadLettersByActor :many
 -- List dead letters for a specific actor.
@@ -313,7 +315,7 @@ LIMIT $2;
 
 -- name: DeleteDeadLetter :exec
 -- Delete a dead letter after manual processing.
-DELETE FROM dead_letters WHERE id = $1;
+DELETE FROM dead_letters WHERE source = $1 AND id = $2;
 
 -- name: CountDeadLetters :one
 -- Count total dead letters.

--- a/db/actordelivery/sqlc/mailbox.sql.go
+++ b/db/actordelivery/sqlc/mailbox.sql.go
@@ -39,7 +39,7 @@ WHERE id IN (
     SELECT o.id FROM outbox_messages o
     WHERE o.status = 'pending'
       AND (o.claimed_until IS NULL OR o.claimed_until < $4)
-    ORDER BY o.created_at ASC
+    ORDER BY o.created_at ASC, o.id ASC
     LIMIT $1
 )
 RETURNING id, source_actor_id, target_actor_id, message_type, payload, domain_key, version, status, delivery_attempts, claim_token, claimed_until, created_at, completed_at
@@ -55,6 +55,8 @@ type ClaimOutboxBatchParams struct {
 // Claim a batch of pending outbox messages for delivery. Sets a claim token
 // and expiry to prevent concurrent publishers from processing the same messages.
 // Only selects rows that are unclaimed or whose claim has expired.
+// Ordering uses created_at ASC and then id ASC so UUIDv7 remains the final
+// deterministic tiebreaker when rows land in the same created_at second.
 func (q *Queries) ClaimOutboxBatch(ctx context.Context, arg ClaimOutboxBatchParams) ([]OutboxMessage, error) {
 	rows, err := q.db.QueryContext(ctx, ClaimOutboxBatch,
 		arg.Limit,
@@ -127,10 +129,10 @@ func (q *Queries) CleanupOldDeadLetters(ctx context.Context, createdAt int64) er
 	return err
 }
 
-const CompleteOutboxMessage = `-- name: CompleteOutboxMessage :exec
+const CompleteOutboxMessage = `-- name: CompleteOutboxMessage :execrows
 UPDATE outbox_messages
 SET status = 'completed', completed_at = $2
-WHERE id = $1 AND claim_token = $3
+WHERE id = $1 AND claim_token = $3 AND status = 'pending'
 `
 
 type CompleteOutboxMessageParams struct {
@@ -141,9 +143,12 @@ type CompleteOutboxMessageParams struct {
 
 // Mark an outbox message as successfully delivered. The claim token must match
 // to prevent stale publishers from completing messages they no longer own.
-func (q *Queries) CompleteOutboxMessage(ctx context.Context, arg CompleteOutboxMessageParams) error {
-	_, err := q.db.ExecContext(ctx, CompleteOutboxMessage, arg.ID, arg.CompletedAt, arg.ClaimToken)
-	return err
+func (q *Queries) CompleteOutboxMessage(ctx context.Context, arg CompleteOutboxMessageParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, CompleteOutboxMessage, arg.ID, arg.CompletedAt, arg.ClaimToken)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 const CountDeadLetters = `-- name: CountDeadLetters :one
@@ -200,12 +205,17 @@ func (q *Queries) DeleteAskResult(ctx context.Context, promiseID string) error {
 }
 
 const DeleteDeadLetter = `-- name: DeleteDeadLetter :exec
-DELETE FROM dead_letters WHERE id = $1
+DELETE FROM dead_letters WHERE source = $1 AND id = $2
 `
 
+type DeleteDeadLetterParams struct {
+	Source string
+	ID     string
+}
+
 // Delete a dead letter after manual processing.
-func (q *Queries) DeleteDeadLetter(ctx context.Context, id string) error {
-	_, err := q.db.ExecContext(ctx, DeleteDeadLetter, id)
+func (q *Queries) DeleteDeadLetter(ctx context.Context, arg DeleteDeadLetterParams) error {
+	_, err := q.db.ExecContext(ctx, DeleteDeadLetter, arg.Source, arg.ID)
 	return err
 }
 
@@ -377,10 +387,10 @@ func (q *Queries) ExtendMailboxLease(ctx context.Context, arg ExtendMailboxLease
 	return result.RowsAffected()
 }
 
-const FailOutboxMessage = `-- name: FailOutboxMessage :exec
+const FailOutboxMessage = `-- name: FailOutboxMessage :execrows
 UPDATE outbox_messages
 SET status = 'dead_letter', completed_at = $2
-WHERE id = $1 AND claim_token = $3
+WHERE id = $1 AND claim_token = $3 AND status = 'pending'
 `
 
 type FailOutboxMessageParams struct {
@@ -391,9 +401,12 @@ type FailOutboxMessageParams struct {
 
 // Mark an outbox message as failed (dead letter). The claim token must match
 // to prevent stale publishers from failing messages they no longer own.
-func (q *Queries) FailOutboxMessage(ctx context.Context, arg FailOutboxMessageParams) error {
-	_, err := q.db.ExecContext(ctx, FailOutboxMessage, arg.ID, arg.CompletedAt, arg.ClaimToken)
-	return err
+func (q *Queries) FailOutboxMessage(ctx context.Context, arg FailOutboxMessageParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, FailOutboxMessage, arg.ID, arg.CompletedAt, arg.ClaimToken)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 const GetAskResult = `-- name: GetAskResult :one
@@ -416,15 +429,20 @@ func (q *Queries) GetAskResult(ctx context.Context, promiseID string) (AskResult
 
 const GetDeadLetter = `-- name: GetDeadLetter :one
 
-SELECT id, source, actor_id, message_type, payload, failure_reason, attempts, created_at FROM dead_letters WHERE id = $1
+SELECT id, source, actor_id, message_type, payload, failure_reason, attempts, created_at FROM dead_letters WHERE source = $1 AND id = $2
 `
+
+type GetDeadLetterParams struct {
+	Source string
+	ID     string
+}
 
 // =============================================================================
 // Dead Letter Operations
 // =============================================================================
 // Get a specific dead letter by ID.
-func (q *Queries) GetDeadLetter(ctx context.Context, id string) (DeadLetter, error) {
-	row := q.db.QueryRowContext(ctx, GetDeadLetter, id)
+func (q *Queries) GetDeadLetter(ctx context.Context, arg GetDeadLetterParams) (DeadLetter, error) {
+	row := q.db.QueryRowContext(ctx, GetDeadLetter, arg.Source, arg.ID)
 	var i DeadLetter
 	err := row.Scan(
 		&i.ID,
@@ -575,7 +593,7 @@ WHERE mailbox_messages.id = (
                 AND m2.attempts < m2.max_attempts
           )
       )
-    ORDER BY m.priority DESC, m.available_at ASC, m.created_at ASC
+    ORDER BY m.priority DESC, m.available_at ASC, m.created_at ASC, m.id ASC
     LIMIT 1
 )
 RETURNING id, mailbox_id, message_type, payload, promise_id, callback_actor_id, correlation_id, priority, lease_token, lease_until, available_at, attempts, max_attempts, created_at, correlation_key
@@ -594,8 +612,8 @@ type LeaseNextMailboxMessageParams struct {
 //
 // Ordering: priority DESC ensures high-priority (e.g., restart) messages
 // first, then available_at ASC for delivery order, then created_at ASC as
-// a tiebreaker to ensure deterministic ordering when priority and
-// available_at are equal.
+// a tiebreaker, then id ASC so UUIDv7 time-ordering remains the final
+// deterministic tiebreaker when rows land in the same created_at second.
 //
 // Per-correlation-key FIFO: when a row carries a non-NULL correlation_key,
 // it is eligible only if no earlier same-key row exists in this mailbox.
@@ -773,7 +791,7 @@ func (q *Queries) ListFSMCheckpoints(ctx context.Context) ([]FsmCheckpoint, erro
 const ListMailboxMessagesByActor = `-- name: ListMailboxMessagesByActor :many
 SELECT id, mailbox_id, message_type, payload, promise_id, callback_actor_id, correlation_id, priority, lease_token, lease_until, available_at, attempts, max_attempts, created_at, correlation_key FROM mailbox_messages
 WHERE mailbox_id = $1
-ORDER BY priority DESC, available_at ASC, created_at ASC
+ORDER BY priority DESC, available_at ASC, created_at ASC, id ASC
 `
 
 // List all messages for an actor's mailbox (for debugging).
@@ -819,7 +837,7 @@ func (q *Queries) ListMailboxMessagesByActor(ctx context.Context, mailboxID stri
 const ListPendingOutboxByTarget = `-- name: ListPendingOutboxByTarget :many
 SELECT id, source_actor_id, target_actor_id, message_type, payload, domain_key, version, status, delivery_attempts, claim_token, claimed_until, created_at, completed_at FROM outbox_messages
 WHERE target_actor_id = $1 AND status = 'pending'
-ORDER BY created_at ASC
+ORDER BY created_at ASC, id ASC
 `
 
 // List pending outbox messages for a specific target actor.
@@ -893,23 +911,32 @@ func (q *Queries) MarkMessageProcessed(ctx context.Context, arg MarkMessageProce
 	return err
 }
 
-const MoveMailboxToDeadLetter = `-- name: MoveMailboxToDeadLetter :exec
+const MoveMailboxToDeadLetter = `-- name: MoveMailboxToDeadLetter :execrows
 INSERT INTO dead_letters (id, source, actor_id, message_type, payload, failure_reason, attempts, created_at)
-SELECT m.id, 'mailbox', m.mailbox_id, m.message_type, m.payload, $2, m.attempts, $3
+SELECT m.id, 'mailbox', m.mailbox_id, m.message_type, m.payload, $3, m.attempts, $4
 FROM mailbox_messages m
-WHERE m.id = $1
+WHERE m.id = $1 AND m.lease_token = $2
 `
 
 type MoveMailboxToDeadLetterParams struct {
 	ID            string
+	LeaseToken    sql.NullString
 	FailureReason string
 	CreatedAt     int64
 }
 
 // Move a failed message to the dead letter queue.
-func (q *Queries) MoveMailboxToDeadLetter(ctx context.Context, arg MoveMailboxToDeadLetterParams) error {
-	_, err := q.db.ExecContext(ctx, MoveMailboxToDeadLetter, arg.ID, arg.FailureReason, arg.CreatedAt)
-	return err
+func (q *Queries) MoveMailboxToDeadLetter(ctx context.Context, arg MoveMailboxToDeadLetterParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, MoveMailboxToDeadLetter,
+		arg.ID,
+		arg.LeaseToken,
+		arg.FailureReason,
+		arg.CreatedAt,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 const MoveOutboxToDeadLetter = `-- name: MoveOutboxToDeadLetter :exec

--- a/db/actordelivery/sqlc/querier.go
+++ b/db/actordelivery/sqlc/querier.go
@@ -16,6 +16,8 @@ type Querier interface {
 	// Claim a batch of pending outbox messages for delivery. Sets a claim token
 	// and expiry to prevent concurrent publishers from processing the same messages.
 	// Only selects rows that are unclaimed or whose claim has expired.
+	// Ordering uses created_at ASC and then id ASC so UUIDv7 remains the final
+	// deterministic tiebreaker when rows land in the same created_at second.
 	ClaimOutboxBatch(ctx context.Context, arg ClaimOutboxBatchParams) ([]OutboxMessage, error)
 	// Delete Ask results that have expired.
 	CleanupExpiredAskResults(ctx context.Context, expiresAt int64) error
@@ -25,7 +27,7 @@ type Querier interface {
 	CleanupOldDeadLetters(ctx context.Context, createdAt int64) error
 	// Mark an outbox message as successfully delivered. The claim token must match
 	// to prevent stale publishers from completing messages they no longer own.
-	CompleteOutboxMessage(ctx context.Context, arg CompleteOutboxMessageParams) error
+	CompleteOutboxMessage(ctx context.Context, arg CompleteOutboxMessageParams) (int64, error)
 	// Count total dead letters.
 	CountDeadLetters(ctx context.Context) (int64, error)
 	// Count pending messages for an actor's mailbox.
@@ -35,7 +37,7 @@ type Querier interface {
 	// Delete an Ask result after retrieval.
 	DeleteAskResult(ctx context.Context, promiseID string) error
 	// Delete a dead letter after manual processing.
-	DeleteDeadLetter(ctx context.Context, id string) error
+	DeleteDeadLetter(ctx context.Context, arg DeleteDeadLetterParams) error
 	// Delete an FSM checkpoint (e.g., when actor terminates normally).
 	DeleteFSMCheckpoint(ctx context.Context, actorID string) error
 	// Delete a mailbox message by ID (used after moving to dead letter).
@@ -69,14 +71,14 @@ type Querier interface {
 	ExtendMailboxLease(ctx context.Context, arg ExtendMailboxLeaseParams) (int64, error)
 	// Mark an outbox message as failed (dead letter). The claim token must match
 	// to prevent stale publishers from failing messages they no longer own.
-	FailOutboxMessage(ctx context.Context, arg FailOutboxMessageParams) error
+	FailOutboxMessage(ctx context.Context, arg FailOutboxMessageParams) (int64, error)
 	// Retrieve the result of an Ask message.
 	GetAskResult(ctx context.Context, promiseID string) (AskResult, error)
 	// =============================================================================
 	// Dead Letter Operations
 	// =============================================================================
 	// Get a specific dead letter by ID.
-	GetDeadLetter(ctx context.Context, id string) (DeadLetter, error)
+	GetDeadLetter(ctx context.Context, arg GetDeadLetterParams) (DeadLetter, error)
 	// Load an FSM checkpoint for an actor.
 	GetFSMCheckpoint(ctx context.Context, actorID string) (FsmCheckpoint, error)
 	// Get a specific mailbox message by ID.
@@ -96,8 +98,8 @@ type Querier interface {
 	//
 	// Ordering: priority DESC ensures high-priority (e.g., restart) messages
 	// first, then available_at ASC for delivery order, then created_at ASC as
-	// a tiebreaker to ensure deterministic ordering when priority and
-	// available_at are equal.
+	// a tiebreaker, then id ASC so UUIDv7 time-ordering remains the final
+	// deterministic tiebreaker when rows land in the same created_at second.
 	//
 	// Per-correlation-key FIFO: when a row carries a non-NULL correlation_key,
 	// it is eligible only if no earlier same-key row exists in this mailbox.
@@ -141,7 +143,7 @@ type Querier interface {
 	// Record that a message has been processed for deduplication.
 	MarkMessageProcessed(ctx context.Context, arg MarkMessageProcessedParams) error
 	// Move a failed message to the dead letter queue.
-	MoveMailboxToDeadLetter(ctx context.Context, arg MoveMailboxToDeadLetterParams) error
+	MoveMailboxToDeadLetter(ctx context.Context, arg MoveMailboxToDeadLetterParams) (int64, error)
 	// Move a failed outbox message to the dead letter queue.
 	MoveOutboxToDeadLetter(ctx context.Context, arg MoveOutboxToDeadLetterParams) error
 	// Release message for redelivery after retry delay.

--- a/db/actordelivery/store_impl.go
+++ b/db/actordelivery/store_impl.go
@@ -33,6 +33,8 @@ type (
 	MarkProcessedParams    = adsqlc.MarkMessageProcessedParams
 	SaveCheckpointParams   = adsqlc.SaveFSMCheckpointParams
 	DeadLetterInsertParams = adsqlc.MoveMailboxToDeadLetterParams
+	GetDeadLetterParams    = adsqlc.GetDeadLetterParams
+	DeleteDeadLetterParams = adsqlc.DeleteDeadLetterParams
 	ListDeadLettersParams  = adsqlc.ListDeadLettersByActorParams
 )
 
@@ -80,9 +82,10 @@ type ActorDeliveryQueries interface {
 		arg ClaimOutboxBatchParams) ([]OutboxMsgRow, error)
 
 	CompleteOutboxMessage(ctx context.Context,
-		arg CompleteOutboxParams) error
+		arg CompleteOutboxParams) (int64, error)
 
-	FailOutboxMessage(ctx context.Context, arg FailOutboxParams) error
+	FailOutboxMessage(ctx context.Context,
+		arg FailOutboxParams) (int64, error)
 
 	// Deduplication operations.
 	IsMessageProcessed(ctx context.Context, id string) (bool, error)
@@ -98,16 +101,19 @@ type ActorDeliveryQueries interface {
 	DeleteFSMCheckpoint(ctx context.Context, actorID string) error
 
 	// Dead letter operations.
-	MoveMailboxToDeadLetter(
-		ctx context.Context, arg DeadLetterInsertParams,
-	) error
+	MoveMailboxToDeadLetter(ctx context.Context,
+		arg DeadLetterInsertParams) (int64, error)
 
-	GetDeadLetter(ctx context.Context, id string) (DeadLetterRow, error)
+	MoveOutboxToDeadLetter(ctx context.Context,
+		arg adsqlc.MoveOutboxToDeadLetterParams) error
+
+	GetDeadLetter(ctx context.Context,
+		arg GetDeadLetterParams) (DeadLetterRow, error)
 
 	ListDeadLettersByActor(ctx context.Context,
 		arg ListDeadLettersParams) ([]DeadLetterRow, error)
 
-	DeleteDeadLetter(ctx context.Context, id string) error
+	DeleteDeadLetter(ctx context.Context, arg DeleteDeadLetterParams) error
 
 	// Cleanup operations.
 	CleanupExpiredProcessedMessages(ctx context.Context,
@@ -271,6 +277,45 @@ func (s *Store) AckMessage(ctx context.Context, id, leaseToken string) (int64,
 	return rows, err
 }
 
+// AckMessageWithAskResult atomically removes a mailbox message and persists
+// the Ask result marker for the same lease holder.
+func (s *Store) AckMessageWithAskResult(ctx context.Context, id,
+	leaseToken string, params actor.AskResultParams) (int64, error) {
+
+	writeTxOpts := db.WriteTxOption()
+
+	var rows int64
+
+	err := s.db.ExecTx(
+		ctx,
+		writeTxOpts,
+		func(q ActorDeliveryQueries) error {
+			var err error
+			rows, err = q.AckMailboxMessage(ctx, AckMailboxParams{
+				ID:         id,
+				LeaseToken: toNullString(leaseToken),
+			})
+			if err != nil {
+				return err
+			}
+
+			if rows == 0 {
+				return nil
+			}
+
+			return q.InsertAskResult(ctx, InsertAskResultParams{
+				PromiseID:  params.PromiseID,
+				ResultBlob: params.ResultBlob,
+				ErrorText:  toNullString(params.ErrorText),
+				CreatedAt:  s.clock.Now().Unix(),
+				ExpiresAt:  params.ExpiresAt.Unix(),
+			})
+		},
+	)
+
+	return rows, err
+}
+
 // NackMessage releases a message for redelivery after the specified delay.
 func (s *Store) NackMessage(ctx context.Context, id, leaseToken string,
 	retryAfter time.Duration) (int64, error) {
@@ -333,23 +378,26 @@ func (s *Store) ExtendLease(ctx context.Context, id, leaseToken string,
 }
 
 // MoveToDeadLetter moves a failed message to the dead letter queue.
-func (s *Store) MoveToDeadLetter(
-	ctx context.Context, id, reason string,
-) error {
+func (s *Store) MoveToDeadLetter(ctx context.Context, id, leaseToken,
+	reason string) (int64, error) {
 
 	writeTxOpts := db.WriteTxOption()
 
-	return s.db.ExecTx(
+	var rows int64
+
+	err := s.db.ExecTx(
 		ctx,
 		writeTxOpts,
 		func(q ActorDeliveryQueries) error {
 			createdAt := s.clock.Now().Unix()
 
 			// First, move to dead letter.
-			err := q.MoveMailboxToDeadLetter(
+			var err error
+			rows, err = q.MoveMailboxToDeadLetter(
 				ctx,
 				DeadLetterInsertParams{
 					ID:            id,
+					LeaseToken:    toNullString(leaseToken),
 					FailureReason: reason,
 					CreatedAt:     createdAt,
 				},
@@ -358,10 +406,16 @@ func (s *Store) MoveToDeadLetter(
 				return err
 			}
 
+			if rows == 0 {
+				return nil
+			}
+
 			// Then delete from mailbox.
 			return q.DeleteMailboxMessage(ctx, id)
 		},
 	)
+
+	return rows, err
 }
 
 // DeleteMessage removes a message from the mailbox.
@@ -570,17 +624,19 @@ func (s *Store) ClaimOutboxBatch(ctx context.Context,
 
 // CompleteOutbox marks an outbox message as successfully delivered. The
 // claim token must match the token set during ClaimOutboxBatch.
-func (s *Store) CompleteOutbox(
-	ctx context.Context, id, claimToken string,
-) error {
+func (s *Store) CompleteOutbox(ctx context.Context, id, claimToken string) (
+	int64, error) {
 
 	writeTxOpts := db.WriteTxOption()
 
-	return s.db.ExecTx(
+	var rows int64
+
+	err := s.db.ExecTx(
 		ctx,
 		writeTxOpts,
 		func(q ActorDeliveryQueries) error {
-			return q.CompleteOutboxMessage(
+			var err error
+			rows, err = q.CompleteOutboxMessage(
 				ctx,
 				CompleteOutboxParams{
 					ID: id,
@@ -592,31 +648,54 @@ func (s *Store) CompleteOutbox(
 					),
 				},
 			)
+
+			return err
 		},
 	)
+
+	return rows, err
 }
 
 // FailOutbox marks an outbox message as failed (dead letter). The claim
 // token must match the token set during ClaimOutboxBatch.
-func (s *Store) FailOutbox(
-	ctx context.Context, id, claimToken string,
-) error {
+func (s *Store) FailOutbox(ctx context.Context, id, claimToken, reason string) (
+	int64, error) {
 
 	writeTxOpts := db.WriteTxOption()
 
-	return s.db.ExecTx(
+	var rows int64
+
+	err := s.db.ExecTx(
 		ctx,
 		writeTxOpts,
 		func(q ActorDeliveryQueries) error {
-			return q.FailOutboxMessage(ctx, FailOutboxParams{
+			var err error
+			rows, err = q.FailOutboxMessage(ctx, FailOutboxParams{
 				ID: id,
 				CompletedAt: toNullInt64(
 					s.clock.Now().Unix(),
 				),
 				ClaimToken: toNullString(claimToken),
 			})
+			if err != nil {
+				return err
+			}
+
+			if rows == 0 {
+				return nil
+			}
+
+			return q.MoveOutboxToDeadLetter(
+				ctx, adsqlc.MoveOutboxToDeadLetterParams{
+					ID:            id,
+					FailureReason: reason,
+					CreatedAt:     s.clock.Now().Unix(),
+				},
+			)
 		},
 	)
+
+	return rows, err
 }
 
 // IsProcessed checks if a message has already been processed.
@@ -734,7 +813,7 @@ func (s *Store) DeleteCheckpoint(
 }
 
 // GetDeadLetter retrieves a specific dead letter message.
-func (s *Store) GetDeadLetter(ctx context.Context, id string) (
+func (s *Store) GetDeadLetter(ctx context.Context, source, id string) (
 	*actor.DeadLetter, error) {
 
 	readTxOpts := db.ReadTxOption()
@@ -742,7 +821,10 @@ func (s *Store) GetDeadLetter(ctx context.Context, id string) (
 	var result *actor.DeadLetter
 
 	err := s.db.ExecTx(ctx, readTxOpts, func(q ActorDeliveryQueries) error {
-		row, err := q.GetDeadLetter(ctx, id)
+		row, err := q.GetDeadLetter(ctx, GetDeadLetterParams{
+			Source: source,
+			ID:     id,
+		})
 		if err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
 				return nil
@@ -812,7 +894,7 @@ func (s *Store) ListDeadLetters(ctx context.Context, actorID string,
 
 // DeleteDeadLetter removes a dead letter after manual processing.
 func (s *Store) DeleteDeadLetter(
-	ctx context.Context, id string,
+	ctx context.Context, source, id string,
 ) error {
 
 	writeTxOpts := db.WriteTxOption()
@@ -821,7 +903,10 @@ func (s *Store) DeleteDeadLetter(
 		ctx,
 		writeTxOpts,
 		func(q ActorDeliveryQueries) error {
-			return q.DeleteDeadLetter(ctx, id)
+			return q.DeleteDeadLetter(ctx, DeleteDeadLetterParams{
+				Source: source,
+				ID:     id,
+			})
 		},
 	)
 }
@@ -1001,6 +1086,32 @@ func (s *TxActorDeliveryStore) AckMessage(ctx context.Context, id,
 	})
 }
 
+// AckMessageWithAskResult atomically removes a mailbox message and persists
+// the Ask result marker for the same lease holder.
+func (s *TxActorDeliveryStore) AckMessageWithAskResult(ctx context.Context, id,
+	leaseToken string, params actor.AskResultParams) (int64, error) {
+
+	rows, err := s.querier.AckMailboxMessage(ctx, AckMailboxParams{
+		ID:         id,
+		LeaseToken: toNullString(leaseToken),
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	if rows == 0 {
+		return 0, nil
+	}
+
+	return rows, s.querier.InsertAskResult(ctx, InsertAskResultParams{
+		PromiseID:  params.PromiseID,
+		ResultBlob: params.ResultBlob,
+		ErrorText:  toNullString(params.ErrorText),
+		CreatedAt:  s.clock.Now().Unix(),
+		ExpiresAt:  params.ExpiresAt.Unix(),
+	})
+}
+
 // NackMessage releases a message for redelivery after the specified delay.
 func (s *TxActorDeliveryStore) NackMessage(ctx context.Context, id,
 	leaseToken string, retryAfter time.Duration) (int64, error) {
@@ -1028,20 +1139,29 @@ func (s *TxActorDeliveryStore) ExtendLease(ctx context.Context, id,
 }
 
 // MoveToDeadLetter moves a failed message to the dead letter queue.
-func (s *TxActorDeliveryStore) MoveToDeadLetter(
-	ctx context.Context, id, reason string,
-) error {
+func (s *TxActorDeliveryStore) MoveToDeadLetter(ctx context.Context, id,
+	leaseToken, reason string) (int64, error) {
 
-	err := s.querier.MoveMailboxToDeadLetter(ctx, DeadLetterInsertParams{
-		ID:            id,
-		FailureReason: reason,
-		CreatedAt:     s.clock.Now().Unix(),
-	})
+	rows, err := s.querier.MoveMailboxToDeadLetter(
+		ctx, DeadLetterInsertParams{
+			ID:            id,
+			LeaseToken:    toNullString(leaseToken),
+			FailureReason: reason,
+			CreatedAt:     s.clock.Now().Unix(),
+		})
 	if err != nil {
-		return err
+		return 0, err
 	}
 
-	return s.querier.DeleteMailboxMessage(ctx, id)
+	if rows == 0 {
+		return 0, nil
+	}
+
+	if err := s.querier.DeleteMailboxMessage(ctx, id); err != nil {
+		return 0, err
+	}
+
+	return rows, nil
 }
 
 // DeleteMessage removes a message from the mailbox.
@@ -1163,9 +1283,8 @@ func (s *TxActorDeliveryStore) ClaimOutboxBatch(ctx context.Context,
 
 // CompleteOutbox marks an outbox message as successfully delivered. The
 // claim token must match the token set during ClaimOutboxBatch.
-func (s *TxActorDeliveryStore) CompleteOutbox(
-	ctx context.Context, id, claimToken string,
-) error {
+func (s *TxActorDeliveryStore) CompleteOutbox(ctx context.Context, id,
+	claimToken string) (int64, error) {
 
 	return s.querier.CompleteOutboxMessage(ctx, CompleteOutboxParams{
 		ID:          id,
@@ -1175,15 +1294,34 @@ func (s *TxActorDeliveryStore) CompleteOutbox(
 }
 
 // FailOutbox marks an outbox message as failed.
-func (s *TxActorDeliveryStore) FailOutbox(
-	ctx context.Context, id, claimToken string,
-) error {
+func (s *TxActorDeliveryStore) FailOutbox(ctx context.Context, id, claimToken,
+	reason string) (int64, error) {
 
-	return s.querier.FailOutboxMessage(ctx, FailOutboxParams{
+	rows, err := s.querier.FailOutboxMessage(ctx, FailOutboxParams{
 		ID:          id,
 		CompletedAt: toNullInt64(s.clock.Now().Unix()),
 		ClaimToken:  toNullString(claimToken),
 	})
+	if err != nil {
+		return 0, err
+	}
+
+	if rows == 0 {
+		return 0, nil
+	}
+
+	err = s.querier.MoveOutboxToDeadLetter(
+		ctx, adsqlc.MoveOutboxToDeadLetterParams{
+			ID:            id,
+			FailureReason: reason,
+			CreatedAt:     s.clock.Now().Unix(),
+		},
+	)
+	if err != nil {
+		return 0, err
+	}
+
+	return rows, nil
 }
 
 // IsProcessed checks if a message has already been processed.
@@ -1256,10 +1394,13 @@ func (s *TxActorDeliveryStore) DeleteCheckpoint(
 }
 
 // GetDeadLetter retrieves a specific dead letter message.
-func (s *TxActorDeliveryStore) GetDeadLetter(ctx context.Context, id string) (
-	*actor.DeadLetter, error) {
+func (s *TxActorDeliveryStore) GetDeadLetter(ctx context.Context, source,
+	id string) (*actor.DeadLetter, error) {
 
-	row, err := s.querier.GetDeadLetter(ctx, id)
+	row, err := s.querier.GetDeadLetter(ctx, GetDeadLetterParams{
+		Source: source,
+		ID:     id,
+	})
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
@@ -1314,10 +1455,13 @@ func (s *TxActorDeliveryStore) ListDeadLetters(ctx context.Context,
 
 // DeleteDeadLetter removes a dead letter after manual processing.
 func (s *TxActorDeliveryStore) DeleteDeadLetter(
-	ctx context.Context, id string,
+	ctx context.Context, source, id string,
 ) error {
 
-	return s.querier.DeleteDeadLetter(ctx, id)
+	return s.querier.DeleteDeadLetter(ctx, DeleteDeadLetterParams{
+		Source: source,
+		ID:     id,
+	})
 }
 
 // ExpireLeases releases all expired leases so messages can be redelivered.

--- a/db/actordelivery/store_impl_test.go
+++ b/db/actordelivery/store_impl_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btclog/v2"
+	"github.com/google/uuid"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
 	"github.com/lightninglabs/darepo-client/db"
 	adsqlc "github.com/lightninglabs/darepo-client/db/actordelivery/sqlc"
@@ -75,6 +76,29 @@ func generateTestID() string {
 	_, _ = rand.Read(b)
 
 	return hex.EncodeToString(b)
+}
+
+// orderedUUIDv7Pair returns two UUIDv7 strings that sort in generation order.
+// The helper waits for a later millisecond so the ordering is not left to the
+// random suffix inside a single timestamp bucket.
+func orderedUUIDv7Pair(t *testing.T) (string, string) {
+	t.Helper()
+
+	earlierID := uuid.Must(uuid.NewV7()).String()
+
+	var laterID string
+	for i := 0; i < 10; i++ {
+		time.Sleep(2 * time.Millisecond)
+
+		laterID = uuid.Must(uuid.NewV7()).String()
+		if earlierID < laterID {
+			return earlierID, laterID
+		}
+	}
+
+	require.FailNow(t, "expected UUIDv7 ids to sort by generation time")
+
+	return "", ""
 }
 
 // TestActorDeliveryStoreEnqueueAndLease tests basic enqueue and lease
@@ -251,12 +275,21 @@ func TestActorDeliveryStoreMoveToDeadLetter(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Move to dead letter.
-	err = store.MoveToDeadLetter(ctx, "msg-dead", "max attempts exceeded")
+	leased, err := store.LeaseNextMessage(
+		ctx, "actor-1", "token-dead", 30*time.Second,
+	)
 	require.NoError(t, err)
+	require.NotNil(t, leased)
+
+	// Move to dead letter.
+	rowsAffected, err := store.MoveToDeadLetter(
+		ctx, "msg-dead", leased.LeaseToken, "max attempts exceeded",
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), rowsAffected)
 
 	// Verify it's in dead letters.
-	dl, err := store.GetDeadLetter(ctx, "msg-dead")
+	dl, err := store.GetDeadLetter(ctx, "mailbox", "msg-dead")
 	require.NoError(t, err)
 	require.NotNil(t, dl)
 
@@ -266,11 +299,63 @@ func TestActorDeliveryStoreMoveToDeadLetter(t *testing.T) {
 	require.Equal(t, "max attempts exceeded", dl.FailureReason)
 
 	// Original message should be deleted.
-	leased, err := store.LeaseNextMessage(
+	leased, err = store.LeaseNextMessage(
 		ctx, "actor-1", "token", 30*time.Second,
 	)
 	require.NoError(t, err)
 	require.Nil(t, leased)
+}
+
+// TestActorDeliveryStoreMoveToDeadLetterClaimMismatch surfaces stale lease
+// loss instead of silently dead-lettering a message after ownership moved.
+func TestActorDeliveryStoreMoveToDeadLetterClaimMismatch(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := newActorDeliveryStoreForTest(t)
+
+	err := store.EnqueueMessage(ctx, actor.EnqueueParams{
+		ID:          "msg-dead-stale",
+		MailboxID:   "actor-1",
+		MessageType: "test.Message",
+		Payload:     []byte{1, 2, 3},
+		AvailableAt: store.clock.Now().Add(-time.Minute),
+		MaxAttempts: 2,
+	})
+	require.NoError(t, err)
+
+	firstLease, err := store.LeaseNextMessage(
+		ctx, "actor-1", "token-old", 5*time.Second,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, firstLease)
+
+	store.clock.SetTime(store.clock.Now().Add(6 * time.Second))
+	err = store.ExpireLeases(ctx)
+	require.NoError(t, err)
+
+	secondLease, err := store.LeaseNextMessage(
+		ctx, "actor-1", "token-new", 5*time.Second,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, secondLease)
+	require.Equal(t, firstLease.ID, secondLease.ID)
+
+	rowsAffected, err := store.MoveToDeadLetter(
+		ctx, firstLease.ID, firstLease.LeaseToken, "stale failure",
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), rowsAffected)
+
+	dl, err := store.GetDeadLetter(ctx, "mailbox", firstLease.ID)
+	require.NoError(t, err)
+	require.Nil(t, dl)
+
+	rowsAffected, err = store.MoveToDeadLetter(
+		ctx, secondLease.ID, secondLease.LeaseToken, "fresh failure",
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), rowsAffected)
 }
 
 // TestActorDeliveryStorePriorityOrdering tests message priority ordering.
@@ -328,6 +413,108 @@ func TestActorDeliveryStorePriorityOrdering(t *testing.T) {
 		_, err = store.AckMessage(ctx, leased.ID, "token-"+exp)
 		require.NoError(t, err)
 	}
+}
+
+// TestActorDeliveryStoreSameSecondTieBreak uses UUIDv7 ordering when two rows
+// land in the same created_at second. This pins the durable store contract to
+// priority, available_at, created_at, and finally id.
+func TestActorDeliveryStoreSameSecondTieBreak(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := newActorDeliveryStoreForTest(t)
+
+	// Freeze the durable store clock so both rows persist with the same
+	// created_at second while still using real UUIDv7 values.
+	now := time.Unix(1_700_000_000, 0)
+	store.clock.SetTime(now)
+
+	earlierID, laterID := orderedUUIDv7Pair(t)
+
+	availableAt := now.Add(-time.Minute)
+
+	// Insert the later UUID first so the store must choose between UUID
+	// order and the SQL tie behavior when created_at is identical.
+	err := store.EnqueueMessage(ctx, actor.EnqueueParams{
+		ID:          laterID,
+		MailboxID:   "actor-1",
+		MessageType: "test.Message",
+		Payload:     []byte{2},
+		Priority:    5,
+		AvailableAt: availableAt,
+		MaxAttempts: 3,
+	})
+	require.NoError(t, err)
+
+	err = store.EnqueueMessage(ctx, actor.EnqueueParams{
+		ID:          earlierID,
+		MailboxID:   "actor-1",
+		MessageType: "test.Message",
+		Payload:     []byte{1},
+		Priority:    5,
+		AvailableAt: availableAt,
+		MaxAttempts: 3,
+	})
+	require.NoError(t, err)
+
+	leased, err := store.LeaseNextMessage(
+		ctx, "actor-1", "token-first", 30*time.Second,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, leased)
+
+	require.Equal(
+		t, earlierID, leased.ID,
+		"same-second created_at ties must break by UUIDv7 order",
+	)
+}
+
+// TestActorDeliveryStoreOutboxSameSecondTieBreak uses UUIDv7 ordering when two
+// outbox rows land in the same created_at second. This pins the CDC contract
+// to created_at and then id.
+func TestActorDeliveryStoreOutboxSameSecondTieBreak(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := newActorDeliveryStoreForTest(t)
+
+	now := time.Unix(1_700_000_100, 0)
+	store.clock.SetTime(now)
+
+	earlierID, laterID := orderedUUIDv7Pair(t)
+
+	err := store.EnqueueOutbox(ctx, actor.OutboxParams{
+		ID:            laterID,
+		SourceActorID: "round-actor",
+		TargetActorID: "wallet-actor",
+		MessageType:   "round.SignRequest",
+		Payload:       []byte{2},
+		Version:       2,
+	})
+	require.NoError(t, err)
+
+	err = store.EnqueueOutbox(ctx, actor.OutboxParams{
+		ID:            earlierID,
+		SourceActorID: "round-actor",
+		TargetActorID: "wallet-actor",
+		MessageType:   "round.SignRequest",
+		Payload:       []byte{1},
+		Version:       1,
+	})
+	require.NoError(t, err)
+
+	batch, err := store.ClaimOutboxBatch(ctx, actor.OutboxClaimParams{
+		Limit:         1,
+		ClaimToken:    "claim-token",
+		ClaimDuration: 30 * time.Second,
+	})
+	require.NoError(t, err)
+	require.Len(t, batch, 1)
+
+	require.Equal(
+		t, earlierID, batch[0].ID,
+		"same-second created_at ties must break by UUIDv7 order",
+	)
 }
 
 // TestActorDeliveryStoreAskResult tests Ask result persistence.
@@ -388,6 +575,53 @@ func TestActorDeliveryStoreAskResultError(t *testing.T) {
 	require.Nil(t, result.ResultBlob)
 }
 
+// TestActorDeliveryStoreAckMessageWithAskResult tests atomic Ask ack/result
+// persistence at the store boundary.
+func TestActorDeliveryStoreAckMessageWithAskResult(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := newActorDeliveryStoreForTest(t)
+
+	err := store.EnqueueMessage(ctx, actor.EnqueueParams{
+		ID:          "msg-ask-ack",
+		MailboxID:   "actor-1",
+		MessageType: "test.Message",
+		Payload:     []byte{9, 9, 9},
+		PromiseID:   "promise-ask-ack",
+		AvailableAt: time.Now().Add(-time.Minute),
+		MaxAttempts: 3,
+	})
+	require.NoError(t, err)
+
+	leased, err := store.LeaseNextMessage(
+		ctx, "actor-1", "token-ask-ack", 30*time.Second,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, leased)
+
+	rows, err := store.AckMessageWithAskResult(
+		ctx, "msg-ask-ack", "token-ask-ack", actor.AskResultParams{
+			PromiseID: "promise-ask-ack",
+			ErrorText: "boom",
+			ExpiresAt: time.Now().Add(time.Hour),
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), rows)
+
+	leased, err = store.LeaseNextMessage(
+		ctx, "actor-1", "token-again", 30*time.Second,
+	)
+	require.NoError(t, err)
+	require.Nil(t, leased)
+
+	result, err := store.GetAskResult(ctx, "promise-ask-ack")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "boom", result.ErrorText)
+}
+
 // TestActorDeliveryStoreOutbox tests outbox operations.
 func TestActorDeliveryStoreOutbox(t *testing.T) {
 	t.Parallel()
@@ -424,12 +658,245 @@ func TestActorDeliveryStoreOutbox(t *testing.T) {
 	}
 
 	// Complete one with matching claim token.
-	err = store.CompleteOutbox(ctx, batch[0].ID, claimToken)
+	rowsAffected, err := store.CompleteOutbox(
+		ctx, batch[0].ID, claimToken,
+	)
 	require.NoError(t, err)
+	require.Equal(t, int64(1), rowsAffected)
 
 	// Fail another with matching claim token.
-	err = store.FailOutbox(ctx, batch[1].ID, claimToken)
+	rowsAffected, err = store.FailOutbox(
+		ctx, batch[1].ID, claimToken, "test outbox failure",
+	)
 	require.NoError(t, err)
+	require.Equal(t, int64(1), rowsAffected)
+
+	dl, err := store.GetDeadLetter(ctx, "outbox", batch[1].ID)
+	require.NoError(t, err)
+	require.NotNil(t, dl)
+	require.Equal(t, "outbox", dl.Source)
+	require.Equal(t, "round-actor", dl.ActorID)
+	require.Equal(t, "test outbox failure", dl.FailureReason)
+}
+
+// TestActorDeliveryStoreOutboxCompleteClaimMismatch surfaces stale claim loss
+// at the store boundary instead of silently reporting success.
+func TestActorDeliveryStoreOutboxCompleteClaimMismatch(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := newActorDeliveryStoreForTest(t)
+
+	err := store.EnqueueOutbox(ctx, actor.OutboxParams{
+		ID:            "outbox-complete-stale",
+		SourceActorID: "source-actor",
+		TargetActorID: "target-actor",
+		MessageType:   "test.Message",
+		Payload:       []byte{1},
+		Version:       1,
+	})
+	require.NoError(t, err)
+
+	firstBatch, err := store.ClaimOutboxBatch(ctx, actor.OutboxClaimParams{
+		Limit:         1,
+		ClaimToken:    "claim-old",
+		ClaimDuration: 30 * time.Second,
+	})
+	require.NoError(t, err)
+	require.Len(t, firstBatch, 1)
+
+	store.clock.SetTime(store.clock.Now().Add(31 * time.Second))
+
+	secondBatch, err := store.ClaimOutboxBatch(ctx, actor.OutboxClaimParams{
+		Limit:         1,
+		ClaimToken:    "claim-new",
+		ClaimDuration: 30 * time.Second,
+	})
+	require.NoError(t, err)
+	require.Len(t, secondBatch, 1)
+	require.Equal(t, firstBatch[0].ID, secondBatch[0].ID)
+
+	rowsAffected, err := store.CompleteOutbox(
+		ctx, firstBatch[0].ID, "claim-old",
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), rowsAffected)
+
+	rowsAffected, err = store.CompleteOutbox(
+		ctx, firstBatch[0].ID, "claim-new",
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), rowsAffected)
+}
+
+// TestActorDeliveryStoreOutboxFailClaimMismatch surfaces stale claim loss at
+// the dead-letter boundary instead of silently reporting success.
+func TestActorDeliveryStoreOutboxFailClaimMismatch(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := newActorDeliveryStoreForTest(t)
+
+	err := store.EnqueueOutbox(ctx, actor.OutboxParams{
+		ID:            "outbox-fail-stale",
+		SourceActorID: "source-actor",
+		TargetActorID: "target-actor",
+		MessageType:   "test.Message",
+		Payload:       []byte{1},
+		Version:       1,
+	})
+	require.NoError(t, err)
+
+	firstBatch, err := store.ClaimOutboxBatch(ctx, actor.OutboxClaimParams{
+		Limit:         1,
+		ClaimToken:    "claim-old",
+		ClaimDuration: 30 * time.Second,
+	})
+	require.NoError(t, err)
+	require.Len(t, firstBatch, 1)
+
+	store.clock.SetTime(store.clock.Now().Add(31 * time.Second))
+
+	secondBatch, err := store.ClaimOutboxBatch(ctx, actor.OutboxClaimParams{
+		Limit:         1,
+		ClaimToken:    "claim-new",
+		ClaimDuration: 30 * time.Second,
+	})
+	require.NoError(t, err)
+	require.Len(t, secondBatch, 1)
+	require.Equal(t, firstBatch[0].ID, secondBatch[0].ID)
+
+	rowsAffected, err := store.FailOutbox(
+		ctx, firstBatch[0].ID, "claim-old", "stale failure",
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), rowsAffected)
+
+	rowsAffected, err = store.FailOutbox(
+		ctx, firstBatch[0].ID, "claim-new", "fresh failure",
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), rowsAffected)
+}
+
+// TestActorDeliveryStoreOutboxCompleteIsTerminal pins completion as a terminal
+// outbox transition under the active claim token.
+func TestActorDeliveryStoreOutboxCompleteIsTerminal(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := newActorDeliveryStoreForTest(t)
+
+	err := store.EnqueueOutbox(ctx, actor.OutboxParams{
+		ID:            "outbox-complete-terminal",
+		SourceActorID: "source-actor",
+		TargetActorID: "target-actor",
+		MessageType:   "test.Message",
+		Payload:       []byte{1},
+		Version:       1,
+	})
+	require.NoError(t, err)
+
+	batch, err := store.ClaimOutboxBatch(ctx, actor.OutboxClaimParams{
+		Limit:         1,
+		ClaimToken:    "claim-token",
+		ClaimDuration: 30 * time.Second,
+	})
+	require.NoError(t, err)
+	require.Len(t, batch, 1)
+
+	rowsAffected, err := store.CompleteOutbox(
+		ctx, batch[0].ID, "claim-token",
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), rowsAffected)
+
+	rowsAffected, err = store.FailOutbox(
+		ctx, batch[0].ID, "claim-token", "terminal failure",
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), rowsAffected)
+}
+
+// TestActorDeliveryStoreOutboxDeadLetterIsTerminal pins dead-lettering as a
+// terminal outbox transition under the active claim token.
+func TestActorDeliveryStoreOutboxDeadLetterIsTerminal(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := newActorDeliveryStoreForTest(t)
+
+	err := store.EnqueueOutbox(ctx, actor.OutboxParams{
+		ID:            "outbox-dead-terminal",
+		SourceActorID: "source-actor",
+		TargetActorID: "target-actor",
+		MessageType:   "test.Message",
+		Payload:       []byte{1},
+		Version:       1,
+	})
+	require.NoError(t, err)
+
+	batch, err := store.ClaimOutboxBatch(ctx, actor.OutboxClaimParams{
+		Limit:         1,
+		ClaimToken:    "claim-token",
+		ClaimDuration: 30 * time.Second,
+	})
+	require.NoError(t, err)
+	require.Len(t, batch, 1)
+
+	rowsAffected, err := store.FailOutbox(
+		ctx, batch[0].ID, "claim-token", "terminal failure",
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), rowsAffected)
+
+	rowsAffected, err = store.CompleteOutbox(
+		ctx, batch[0].ID, "claim-token",
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), rowsAffected)
+}
+
+// TestActorDeliveryStoreOutboxFailCreatesDeadLetter verifies that failing an
+// outbox row also populates the durable dead-letter store.
+func TestActorDeliveryStoreOutboxFailCreatesDeadLetter(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := newActorDeliveryStoreForTest(t)
+
+	err := store.EnqueueOutbox(ctx, actor.OutboxParams{
+		ID:            "outbox-dl-visible",
+		SourceActorID: "source-actor",
+		TargetActorID: "target-actor",
+		MessageType:   "test.Message",
+		Payload:       []byte{7, 8, 9},
+		Version:       1,
+	})
+	require.NoError(t, err)
+
+	batch, err := store.ClaimOutboxBatch(ctx, actor.OutboxClaimParams{
+		Limit:         1,
+		ClaimToken:    "claim-token",
+		ClaimDuration: 30 * time.Second,
+	})
+	require.NoError(t, err)
+	require.Len(t, batch, 1)
+
+	rowsAffected, err := store.FailOutbox(
+		ctx, batch[0].ID, "claim-token", "decode failure",
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), rowsAffected)
+
+	dl, err := store.GetDeadLetter(ctx, "outbox", batch[0].ID)
+	require.NoError(t, err)
+	require.NotNil(t, dl)
+	require.Equal(t, "outbox", dl.Source)
+	require.Equal(t, "source-actor", dl.ActorID)
+	require.Equal(t, "test.Message", dl.MessageType)
+	require.Equal(t, []byte{7, 8, 9}, dl.Payload)
+	require.Equal(t, "decode failure", dl.FailureReason)
 }
 
 // TestTxAwareActorDeliveryStoreOutboxWake verifies that transaction-scoped
@@ -596,8 +1063,17 @@ func TestActorDeliveryStoreDeadLetterList(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		err = store.MoveToDeadLetter(ctx, id, "test failure")
+		leased, err := store.LeaseNextMessage(
+			ctx, "actor-1", "token-"+id, 30*time.Second,
+		)
 		require.NoError(t, err)
+		require.NotNil(t, leased)
+
+		rowsAffected, err := store.MoveToDeadLetter(
+			ctx, id, leased.LeaseToken, "test failure",
+		)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), rowsAffected)
 	}
 
 	// List dead letters.
@@ -606,13 +1082,80 @@ func TestActorDeliveryStoreDeadLetterList(t *testing.T) {
 	require.Len(t, dls, 3)
 
 	// Delete one.
-	err = store.DeleteDeadLetter(ctx, dls[0].ID)
+	err = store.DeleteDeadLetter(ctx, dls[0].Source, dls[0].ID)
 	require.NoError(t, err)
 
 	// Should have 2 left.
 	dls, err = store.ListDeadLetters(ctx, "actor-1", 10)
 	require.NoError(t, err)
 	require.Len(t, dls, 2)
+}
+
+// TestActorDeliveryStoreDeadLetterSourceScopesIdentity verifies mailbox and
+// outbox dead letters can coexist under the same propagated message ID.
+func TestActorDeliveryStoreDeadLetterSourceScopesIdentity(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := newActorDeliveryStoreForTest(t)
+
+	const sharedID = "shared-dead-letter-id"
+
+	err := store.EnqueueMessage(ctx, actor.EnqueueParams{
+		ID:          sharedID,
+		MailboxID:   "actor-1",
+		MessageType: "test.Message",
+		Payload:     []byte{1, 2, 3},
+		AvailableAt: time.Now().Add(-time.Minute),
+		MaxAttempts: 1,
+	})
+	require.NoError(t, err)
+
+	leased, err := store.LeaseNextMessage(
+		ctx, "actor-1", "mailbox-token", 30*time.Second,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, leased)
+
+	rowsAffected, err := store.MoveToDeadLetter(
+		ctx, sharedID, leased.LeaseToken, "mailbox failure",
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), rowsAffected)
+
+	err = store.EnqueueOutbox(ctx, actor.OutboxParams{
+		ID:            sharedID,
+		SourceActorID: "source-actor",
+		TargetActorID: "target-actor",
+		MessageType:   "test.Message",
+		Payload:       []byte{9, 8, 7},
+		Version:       1,
+	})
+	require.NoError(t, err)
+
+	batch, err := store.ClaimOutboxBatch(ctx, actor.OutboxClaimParams{
+		Limit:         1,
+		ClaimToken:    "outbox-token",
+		ClaimDuration: 30 * time.Second,
+	})
+	require.NoError(t, err)
+	require.Len(t, batch, 1)
+
+	rowsAffected, err = store.FailOutbox(
+		ctx, sharedID, "outbox-token", "outbox failure",
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), rowsAffected)
+
+	mailboxDL, err := store.GetDeadLetter(ctx, "mailbox", sharedID)
+	require.NoError(t, err)
+	require.NotNil(t, mailboxDL)
+	require.Equal(t, "mailbox failure", mailboxDL.FailureReason)
+
+	outboxDL, err := store.GetDeadLetter(ctx, "outbox", sharedID)
+	require.NoError(t, err)
+	require.NotNil(t, outboxDL)
+	require.Equal(t, "outbox failure", outboxDL.FailureReason)
 }
 
 // TestActorDeliveryStoreExpireLeases tests lease expiration.

--- a/db/sqlc/schemas/generated_schema.sql
+++ b/db/sqlc/schemas/generated_schema.sql
@@ -40,8 +40,10 @@ CREATE TABLE boarding_addresses (
     -- client_key_id references the internal_keys registry row for the client
     -- wallet key used in the tapscript. The registry row carries the
     -- compressed pubkey plus the lnd KeyLocator needed to reconstruct the
-    -- signing descriptor. Nullable so a row can be written before the key is
-    -- registered, though the write path always registers first.
+    -- signing descriptor. Declared nullable only for uniformity with the
+    -- genuinely-optional internal_keys FKs (vtxos, round_vtxo_requests); in
+    -- practice every boarding address has a client key, so the write path
+    -- always registers it first and the read path treats a NULL as an error.
     client_key_id BIGINT REFERENCES internal_keys(id),
 
     -- operator_pubkey is the serialized public key (33 bytes compressed) of
@@ -182,30 +184,16 @@ CREATE TABLE client_tree_txids (
         ON DELETE CASCADE
 );
 
-CREATE TABLE dead_letters (
-    -- id is the original message ID.
-    id TEXT PRIMARY KEY,
-
-    -- source indicates where the message originated: 'mailbox' or 'outbox'.
+CREATE TABLE "dead_letters" (
+    id TEXT NOT NULL,
     source TEXT NOT NULL,
-
-    -- actor_id identifies the target actor (for mailbox) or source (for outbox).
     actor_id TEXT NOT NULL,
-
-    -- message_type is the type name for the failed message.
     message_type TEXT NOT NULL,
-
-    -- payload contains the original TLV-encoded message data.
     payload BLOB NOT NULL,
-
-    -- failure_reason describes why the message was dead-lettered.
     failure_reason TEXT NOT NULL,
-
-    -- attempts is the number of delivery attempts before dead-lettering.
     attempts INTEGER NOT NULL,
-
-    -- created_at is the unix timestamp when the message was dead-lettered.
-    created_at BIGINT NOT NULL
+    created_at BIGINT NOT NULL,
+    PRIMARY KEY (source, id)
 );
 
 CREATE TABLE fsm_checkpoints (
@@ -714,8 +702,11 @@ CREATE TABLE owned_receive_scripts (
 
     -- client_key_id references the internal_keys registry row for the client
     -- wallet key used in the checkpoint taptree. The registry row carries the
-    -- compressed pubkey plus the lnd KeyLocator. Nullable, though the write
-    -- path always registers the key first.
+    -- compressed pubkey plus the lnd KeyLocator. Declared nullable only for
+    -- uniformity with the genuinely-optional internal_keys FKs (vtxos,
+    -- round_vtxo_requests); in practice every owned receive script has a
+    -- client key, so the write path always registers it first and the read
+    -- path treats a NULL as an error.
     client_key_id BIGINT REFERENCES internal_keys(id),
 
     -- operator_pubkey is the operator key used in the checkpoint taptree.

--- a/internal/actortest/e2e_test.go
+++ b/internal/actortest/e2e_test.go
@@ -1104,8 +1104,10 @@ func TestDeadLetter_BoundedRetries(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Simulate multiple failed attempts via lease/nack cycles.
-	for i := 0; i < maxAttempts; i++ {
+	// Simulate repeated transient failures via lease/nack cycles, then keep
+	// the final lease live so dead-lettering still validates current
+	// ownership.
+	for i := 0; i < maxAttempts-1; i++ {
 		token := fmt.Sprintf("token-%c", rune('A'+i))
 
 		leased, err := h.store.LeaseNextMessage(
@@ -1126,14 +1128,22 @@ func TestDeadLetter_BoundedRetries(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 
-	// After max attempts, move to dead letter.
-	err = h.store.MoveToDeadLetter(
-		h.ctx, messageID, "max attempts exceeded",
+	// Final attempt reaches max_attempts and is dead-lettered instead of
+	// being nacked again.
+	leased, err := h.store.LeaseNextMessage(
+		h.ctx, mailboxID, "token-final", 5*time.Second,
 	)
 	require.NoError(t, err)
+	require.NotNil(t, leased)
+
+	rowsAffected, err := h.store.MoveToDeadLetter(
+		h.ctx, messageID, leased.LeaseToken, "max attempts exceeded",
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), rowsAffected)
 
 	// Verify it's in dead letters.
-	dl, err := h.store.GetDeadLetter(h.ctx, messageID)
+	dl, err := h.store.GetDeadLetter(h.ctx, "mailbox", messageID)
 	require.NoError(t, err)
 	require.NotNil(t, dl)
 	require.Equal(t, messageID, dl.ID)
@@ -1163,12 +1173,21 @@ func TestDeadLetter_PayloadPreserved(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Move to dead letter.
-	err = h.store.MoveToDeadLetter(h.ctx, messageID, "test failure")
+	leased, err := h.store.LeaseNextMessage(
+		h.ctx, "preserve-test", "token-preserve", 5*time.Second,
+	)
 	require.NoError(t, err)
+	require.NotNil(t, leased)
+
+	// Move to dead letter.
+	rowsAffected, err := h.store.MoveToDeadLetter(
+		h.ctx, messageID, leased.LeaseToken, "test failure",
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), rowsAffected)
 
 	// Retrieve dead letter and verify payload is preserved.
-	dl, err := h.store.GetDeadLetter(h.ctx, messageID)
+	dl, err := h.store.GetDeadLetter(h.ctx, "mailbox", messageID)
 	require.NoError(t, err)
 	require.NotNil(t, dl)
 

--- a/p-models/durableactor/bridge/mailbox_trace.go
+++ b/p-models/durableactor/bridge/mailbox_trace.go
@@ -360,9 +360,13 @@ func replayDeadLetter(t *testing.T, store actor.TxAwareDeliveryStore,
 		reason = "model trace dead letter"
 	}
 
-	requireNoError(t, store.MoveToDeadLetter(t.Context(), event.ID, reason))
+	rows, err := store.MoveToDeadLetter(
+		t.Context(), event.ID, event.LeaseToken, reason,
+	)
+	requireNoError(t, err)
+	requireExpectedRows(t, rows, event, "dead_letter")
 
-	deadLetter, err := store.GetDeadLetter(t.Context(), event.ID)
+	deadLetter, err := store.GetDeadLetter(t.Context(), "mailbox", event.ID)
 	requireNoError(t, err)
 	if deadLetter == nil {
 		t.Fatalf("expected dead letter %s, got nil", event.ID)

--- a/p-models/durableactor/traces/mailbox_dead_letter_unblocks_successor.json
+++ b/p-models/durableactor/traces/mailbox_dead_letter_unblocks_successor.json
@@ -30,6 +30,7 @@
     {
       "op": "dead_letter",
       "id": "00000000-0000-7000-8000-000000000701",
+      "lease_token": "lease-1",
       "now": 0,
       "failure_reason": "model trace poison message"
     },

--- a/serverconn/testutil_test.go
+++ b/serverconn/testutil_test.go
@@ -305,6 +305,11 @@ type memCheckpointStore struct {
 	outbox      map[string]*actor.OutboxMessage
 }
 
+// deadLetterKey returns the stable in-memory key for a dead letter entry.
+func deadLetterKey(source, id string) string {
+	return source + ":" + id
+}
+
 // storeMessage tracks mailbox delivery state in memory.
 type storeMessage struct {
 	leased      actor.LeasedMessage
@@ -518,9 +523,8 @@ func (s *memCheckpointStore) ExtendLease(ctx context.Context, id,
 }
 
 // MoveToDeadLetter moves a mailbox message to the dead letter map.
-func (s *memCheckpointStore) MoveToDeadLetter(
-	ctx context.Context, id, reason string,
-) error {
+func (s *memCheckpointStore) MoveToDeadLetter(ctx context.Context, id,
+	leaseToken, reason string) (int64, error) {
 
 	_ = ctx
 
@@ -529,12 +533,16 @@ func (s *memCheckpointStore) MoveToDeadLetter(
 
 	msg, ok := s.messages[id]
 	if !ok {
-		return nil
+		return 0, nil
+	}
+
+	if msg.leased.LeaseToken != leaseToken {
+		return 0, nil
 	}
 
 	payloadCopy := append([]byte(nil), msg.leased.Payload...)
 
-	s.deadLetters[id] = &actor.DeadLetter{
+	s.deadLetters[deadLetterKey("mailbox", id)] = &actor.DeadLetter{
 		ID:            id,
 		Source:        "mailbox",
 		ActorID:       msg.leased.MailboxID,
@@ -545,7 +553,9 @@ func (s *memCheckpointStore) MoveToDeadLetter(
 		CreatedAt:     time.Now(),
 	}
 
-	return nil
+	delete(s.messages, id)
+
+	return 1, nil
 }
 
 // DeleteMessage removes a mailbox message by ID.
@@ -584,6 +594,42 @@ func (s *memCheckpointStore) SaveAskResult(
 	}
 
 	return nil
+}
+
+// AckMessageWithAskResult removes a mailbox message and stores the Ask result
+// in memory as a single critical section.
+func (s *memCheckpointStore) AckMessageWithAskResult(ctx context.Context, id,
+	leaseToken string, params actor.AskResultParams) (int64, error) {
+
+	_ = ctx
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	msg, ok := s.messages[id]
+	if !ok {
+		return 0, nil
+	}
+
+	if msg.leased.LeaseToken != leaseToken {
+		return 0, nil
+	}
+
+	if _, ok := s.askResults[params.PromiseID]; !ok {
+		resultBlob := append([]byte(nil), params.ResultBlob...)
+
+		s.askResults[params.PromiseID] = &actor.AskResult{
+			PromiseID:  params.PromiseID,
+			ResultBlob: resultBlob,
+			ErrorText:  params.ErrorText,
+			CreatedAt:  time.Now(),
+			ExpiresAt:  params.ExpiresAt,
+		}
+	}
+
+	delete(s.messages, id)
+
+	return 1, nil
 }
 
 // GetAskResult retrieves an ask result from memory.
@@ -680,9 +726,8 @@ func (s *memCheckpointStore) ClaimOutboxBatch(ctx context.Context,
 }
 
 // CompleteOutbox marks a claimed outbox message as completed.
-func (s *memCheckpointStore) CompleteOutbox(
-	ctx context.Context, id, claimToken string,
-) error {
+func (s *memCheckpointStore) CompleteOutbox(ctx context.Context, id,
+	claimToken string) (int64, error) {
 
 	_ = ctx
 
@@ -691,22 +736,21 @@ func (s *memCheckpointStore) CompleteOutbox(
 
 	msg, ok := s.outbox[id]
 	if !ok {
-		return nil
+		return 0, nil
 	}
 
-	if msg.ClaimToken != claimToken {
-		return nil
+	if msg.ClaimToken != claimToken || msg.Status != "pending" {
+		return 0, nil
 	}
 
 	msg.Status = "completed"
 
-	return nil
+	return 1, nil
 }
 
 // FailOutbox marks a claimed outbox message as dead-lettered.
-func (s *memCheckpointStore) FailOutbox(
-	ctx context.Context, id, claimToken string,
-) error {
+func (s *memCheckpointStore) FailOutbox(ctx context.Context, id, claimToken,
+	reason string) (int64, error) {
 
 	_ = ctx
 
@@ -715,16 +759,28 @@ func (s *memCheckpointStore) FailOutbox(
 
 	msg, ok := s.outbox[id]
 	if !ok {
-		return nil
+		return 0, nil
 	}
 
-	if msg.ClaimToken != claimToken {
-		return nil
+	if msg.ClaimToken != claimToken || msg.Status != "pending" {
+		return 0, nil
 	}
 
 	msg.Status = "dead_letter"
 
-	return nil
+	payloadCopy := append([]byte(nil), msg.Payload...)
+	s.deadLetters[deadLetterKey("outbox", id)] = &actor.DeadLetter{
+		ID:            id,
+		Source:        "outbox",
+		ActorID:       msg.SourceActorID,
+		MessageType:   msg.MessageType,
+		Payload:       payloadCopy,
+		FailureReason: reason,
+		Attempts:      msg.DeliveryAttempts,
+		CreatedAt:     time.Now(),
+	}
+
+	return 1, nil
 }
 
 // IsProcessed returns true when the message ID is marked processed.
@@ -773,15 +829,15 @@ func (s *memCheckpointStore) DeleteCheckpoint(
 }
 
 // GetDeadLetter returns a dead letter entry by ID.
-func (s *memCheckpointStore) GetDeadLetter(ctx context.Context, id string) (
-	*actor.DeadLetter, error) {
+func (s *memCheckpointStore) GetDeadLetter(ctx context.Context, source,
+	id string) (*actor.DeadLetter, error) {
 
 	_ = ctx
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	deadLetter, ok := s.deadLetters[id]
+	deadLetter, ok := s.deadLetters[deadLetterKey(source, id)]
 	if !ok {
 		return nil, nil
 	}
@@ -824,7 +880,7 @@ func (s *memCheckpointStore) ListDeadLetters(ctx context.Context,
 
 // DeleteDeadLetter deletes a dead-letter entry by ID.
 func (s *memCheckpointStore) DeleteDeadLetter(
-	ctx context.Context, id string,
+	ctx context.Context, source, id string,
 ) error {
 
 	_ = ctx
@@ -832,7 +888,7 @@ func (s *memCheckpointStore) DeleteDeadLetter(
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	delete(s.deadLetters, id)
+	delete(s.deadLetters, deadLetterKey(source, id))
 
 	return nil
 }

--- a/unroll/actor_test.go
+++ b/unroll/actor_test.go
@@ -796,6 +796,13 @@ func (s *memCheckpointStore) AckMessage(context.Context, string, string) (int64,
 	return 1, nil
 }
 
+// AckMessageWithAskResult is unused in these tests.
+func (s *memCheckpointStore) AckMessageWithAskResult(context.Context, string,
+	string, actor.AskResultParams) (int64, error) {
+
+	return 1, nil
+}
+
 // NackMessage is unused in these tests.
 func (s *memCheckpointStore) NackMessage(context.Context, string, string,
 	time.Duration) (int64, error) {
@@ -811,10 +818,10 @@ func (s *memCheckpointStore) ExtendLease(context.Context, string, string,
 }
 
 // MoveToDeadLetter is unused in these tests.
-func (s *memCheckpointStore) MoveToDeadLetter(context.Context, string,
-	string) error {
+func (s *memCheckpointStore) MoveToDeadLetter(context.Context, string, string,
+	string) (int64, error) {
 
-	return nil
+	return 1, nil
 }
 
 // DeleteMessage is unused in these tests.
@@ -856,15 +863,17 @@ func (s *memCheckpointStore) ClaimOutboxBatch(context.Context,
 }
 
 // CompleteOutbox is unused in these tests.
-func (s *memCheckpointStore) CompleteOutbox(context.Context, string,
-	string) error {
+func (s *memCheckpointStore) CompleteOutbox(context.Context, string, string) (
+	int64, error) {
 
-	return nil
+	return 1, nil
 }
 
 // FailOutbox is unused in these tests.
-func (s *memCheckpointStore) FailOutbox(context.Context, string, string) error {
-	return nil
+func (s *memCheckpointStore) FailOutbox(context.Context, string, string,
+	string) (int64, error) {
+
+	return 1, nil
 }
 
 // IsProcessed is unused in these tests.
@@ -882,7 +891,7 @@ func (s *memCheckpointStore) MarkProcessed(context.Context, string, string,
 }
 
 // GetDeadLetter is unused in these tests.
-func (s *memCheckpointStore) GetDeadLetter(context.Context, string) (
+func (s *memCheckpointStore) GetDeadLetter(context.Context, string, string) (
 	*actor.DeadLetter, error) {
 
 	return nil, nil
@@ -896,7 +905,9 @@ func (s *memCheckpointStore) ListDeadLetters(context.Context, string, int) (
 }
 
 // DeleteDeadLetter is unused in these tests.
-func (s *memCheckpointStore) DeleteDeadLetter(context.Context, string) error {
+func (s *memCheckpointStore) DeleteDeadLetter(context.Context, string,
+	string) error {
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary

This is a checkpoint PR from the Ark P-model/formalization work in
`darepo-ark-spec`.

The P model has been pushing the durable actor runtime toward explicit mailbox,
outbox, lease, and retry contracts. As that model got more precise, it started
surfacing concrete mismatches in the Go implementation rather than just spec
gaps. This PR collects the client/runtime fixes from that pass.

## What changed

- harden dead-letter identity so mailbox and outbox entries are keyed by
  `(source, id)` instead of `id` alone
- surface stale mailbox lease loss and stale outbox claim loss at the store
  boundary instead of silently succeeding
- make outbox terminal states actually terminal and persist outbox dead-letter
  rows with failure reasons
- tighten durable ordering by using `id` as the final tie-breaker after
  `created_at`, which keeps UUIDv7 ordering meaningful in same-second ties
- add an atomic `AckMessageWithAskResult` path so standard `Ask` cannot lose the
  mailbox row before persisting its result marker
- keep live durable `Ask` promises aligned across retries and actor shutdown
  instead of dropping the future on first lease or leaving queued asks hanging
- normalize zero-value/non-positive config defaults for the durable actor,
  mailbox, and outbox publisher, and keep delivery lease bookkeeping on the
  injected clock

## Why this came out of the P model

The current P model work in `darepo-ark-spec/p-models` now includes explicit
actor-store and mailbox-disk semantics alongside the protocol model. That work
made several implementation assumptions executable:

- mailbox/outbox ownership must be validated at the completion boundary
- dead-letter identity must distinguish mailbox from outbox sources
- terminal outbox states must not be re-flippable
- `Ask` completion must be atomic at the durable boundary
- live `Ask` state must survive retry/replay until terminal settlement

Those assumptions exposed real bugs and contract gaps in the current runtime,
which this PR fixes and pins with regressions.

## Verification

- `make sqlc`
- `GOCACHE=/tmp/go-build go test ./baselib/actor ./db/actordelivery ./serverconn ./internal/actortest -count=1`
- `make lint-changed-local`
