### PR TITLE
multi: fix neutrino btcwallet UTXO detection, TxProof, and startup

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -29,6 +29,8 @@ package may import from a higher layer.
 | [`chain`](chain/) | Bitcoind RPC utilities (package relay, `SubmitPackage`) |
 | [`lndbackend`](lndbackend/) | `BoardingBackend` implementation via LND's wallet kit |
 | [`lwwallet`](lwwallet/) | Lightweight in-process wallet (btcwallet + Esplora, no external LND) |
+| [`btcwbackend`](btcwbackend/) | Neutrino-backed wallet backend (btcwallet + compact block filters) |
+| [`walletcore`](walletcore/) | Shared wallet abstractions and boarding logic used by lwwallet and btcwbackend |
 | [`db`](db/) | SQLite/PostgreSQL persistence: boarding, rounds, VTXOs, OOR artifacts |
 | [`mailbox`](mailbox/) | Mailbox protocol primitives across three sub-packages (pb, rpc, conn) |
 | [`serverconn`](serverconn/) | Unified server connector: durable egress, ingress polling, unary RPC facade |
@@ -80,7 +82,7 @@ darepod (orchestrator)
 │   ├── mailbox     │ (protocol primitives)
 │   └── db          │ (durable delivery store)
 ├── chainsource     │
-│   └── chainbackends (pluggable: LND or lwwallet)
+│   └── chainbackends (pluggable: LND, lwwallet, or btcwbackend)
 └── db              │
     └── (SQLite | PostgreSQL)
 ```

--- a/btcwbackend/AGENTS.md
+++ b/btcwbackend/AGENTS.md
@@ -1,0 +1,32 @@
+# btcwbackend
+
+## Purpose
+
+Lightweight in-process Bitcoin wallet backed by LND's btcwallet and a neutrino
+(BIP 157/158) chain backend. Provides a self-contained SPV wallet that connects
+directly to the Bitcoin P2P network without requiring an external Esplora server
+or LND node.
+
+## Key Types
+
+- `Wallet` — Top-level wallet wrapping `walletcore.Wallet` with neutrino chain service, chain backend, and boarding adapter. Constructors: `New` (owns neutrino lifecycle) and `NewWithNeutrino` (reuses pre-started service).
+- `NeutrinoService` — Manages the neutrino `ChainService`, its bbolt DB, and lifecycle. Pre-started by the daemon for early P2P sync.
+- `ChainBackend` — Implements `chainsource.ChainBackend` using neutrino's native `ChainNotifier` for confirmation tracking, spend detection, and fee estimation.
+- `BoardingBackendAdapter` — Implements `wallet.BoardingBackend` by embedding `walletcore.BoardingBackendBase` and adding neutrino-backed `ListUnspent`, `GetTransaction`, and `GetBlock`.
+- `Config` — Embeds `walletcore.Config` and adds neutrino-specific fields (peers, fee URL, persist filters).
+
+## Relationships
+
+- **Depends on**: `walletcore` (shared wallet/boarding base), `chainsource` (ChainBackend interface), `wallet` (BoardingBackend interface), `build` (logging).
+- **Depended on by**: `darepod` (daemon startup and wallet lifecycle).
+
+## Invariants
+
+- `NewWithNeutrino` does not own the neutrino service lifecycle; the caller is responsible for stopping it. `New` owns the service and stops it on error or via `Wallet.Stop()`.
+- Chain notifier cancel functions are wrapped in `sync.Once` to prevent double-cancel panics from lnd's notificationDispatcher.
+- Block cache size is in bytes (2 MiB default), not block count. This differs from neutrino's count-based API.
+- Taproot script imports use `KeyScopeBIP0086` (via `walletcore.BoardingBackendBase`) to ensure btcwallet's block processing tracks credits correctly.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/btcwbackend/CLAUDE.md
+++ b/btcwbackend/CLAUDE.md
@@ -1,0 +1,32 @@
+# btcwbackend
+
+## Purpose
+
+Lightweight in-process Bitcoin wallet backed by LND's btcwallet and a neutrino
+(BIP 157/158) chain backend. Provides a self-contained SPV wallet that connects
+directly to the Bitcoin P2P network without requiring an external Esplora server
+or LND node.
+
+## Key Types
+
+- `Wallet` — Top-level wallet wrapping `walletcore.Wallet` with neutrino chain service, chain backend, and boarding adapter. Constructors: `New` (owns neutrino lifecycle) and `NewWithNeutrino` (reuses pre-started service).
+- `NeutrinoService` — Manages the neutrino `ChainService`, its bbolt DB, and lifecycle. Pre-started by the daemon for early P2P sync.
+- `ChainBackend` — Implements `chainsource.ChainBackend` using neutrino's native `ChainNotifier` for confirmation tracking, spend detection, and fee estimation.
+- `BoardingBackendAdapter` — Implements `wallet.BoardingBackend` by embedding `walletcore.BoardingBackendBase` and adding neutrino-backed `ListUnspent`, `GetTransaction`, and `GetBlock`.
+- `Config` — Embeds `walletcore.Config` and adds neutrino-specific fields (peers, fee URL, persist filters).
+
+## Relationships
+
+- **Depends on**: `walletcore` (shared wallet/boarding base), `chainsource` (ChainBackend interface), `wallet` (BoardingBackend interface), `build` (logging).
+- **Depended on by**: `darepod` (daemon startup and wallet lifecycle).
+
+## Invariants
+
+- `NewWithNeutrino` does not own the neutrino service lifecycle; the caller is responsible for stopping it. `New` owns the service and stops it on error or via `Wallet.Stop()`.
+- Chain notifier cancel functions are wrapped in `sync.Once` to prevent double-cancel panics from lnd's notificationDispatcher.
+- Block cache size is in bytes (2 MiB default), not block count. This differs from neutrino's count-based API.
+- Taproot script imports use `KeyScopeBIP0086` (via `walletcore.BoardingBackendBase`) to ensure btcwallet's block processing tracks credits correctly.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/btcwbackend/chain_backend.go
+++ b/btcwbackend/chain_backend.go
@@ -313,12 +313,22 @@ func (b *ChainBackend) RegisterConf(ctx context.Context,
 	// cancelled.
 	notifyCtx, cancel := context.WithCancel(context.Background())
 
+	// Wrap event.Cancel in a sync.Once to prevent double-cancel
+	// panics. Both the forwarding goroutine and the returned Cancel
+	// closure call this, but lnd's notificationDispatcher panics
+	// if Cancel is sent twice for the same registration ID
+	// (nil map lookup after delete).
+	var cancelOnce sync.Once
+	safeCancel := func() {
+		cancelOnce.Do(event.Cancel)
+	}
+
 	confChan := make(chan *chainsource.TxConfirmation, 1)
 
 	go func() {
 		defer close(confChan)
 		defer cancel()
-		defer event.Cancel()
+		defer safeCancel()
 
 		select {
 		case lndConf, ok := <-event.Confirmed:
@@ -350,7 +360,7 @@ func (b *ChainBackend) RegisterConf(ctx context.Context,
 		Confirmed: confChan,
 		Cancel: func() {
 			cancel()
-			event.Cancel()
+			safeCancel()
 		},
 	}, nil
 }
@@ -374,12 +384,19 @@ func (b *ChainBackend) RegisterSpend(ctx context.Context,
 
 	notifyCtx, cancel := context.WithCancel(context.Background())
 
+	// Wrap event.Cancel in a sync.Once to prevent double-cancel
+	// panics — same rationale as RegisterConf.
+	var cancelOnce sync.Once
+	safeCancel := func() {
+		cancelOnce.Do(event.Cancel)
+	}
+
 	spendChan := make(chan *chainsource.SpendDetail, 1)
 
 	go func() {
 		defer close(spendChan)
 		defer cancel()
-		defer event.Cancel()
+		defer safeCancel()
 
 		select {
 		case lndSpend, ok := <-event.Spend:
@@ -411,7 +428,7 @@ func (b *ChainBackend) RegisterSpend(ctx context.Context,
 		Spend: spendChan,
 		Cancel: func() {
 			cancel()
-			event.Cancel()
+			safeCancel()
 		},
 	}, nil
 }
@@ -435,12 +452,19 @@ func (b *ChainBackend) RegisterBlocks(
 	// the returned Cancel function.
 	notifyCtx, cancel := context.WithCancel(context.Background())
 
+	// Wrap event.Cancel in a sync.Once to prevent double-cancel
+	// panics — same rationale as RegisterConf.
+	var cancelOnce sync.Once
+	safeCancel := func() {
+		cancelOnce.Do(event.Cancel)
+	}
+
 	epochChan := make(chan *chainsource.BlockEpoch, 10)
 
 	go func() {
 		defer close(epochChan)
 		defer cancel()
-		defer event.Cancel()
+		defer safeCancel()
 
 		for {
 			select {
@@ -482,7 +506,7 @@ func (b *ChainBackend) RegisterBlocks(
 		Epochs: epochChan,
 		Cancel: func() {
 			cancel()
-			event.Cancel()
+			safeCancel()
 		},
 	}, nil
 }

--- a/btcwbackend/neutrino.go
+++ b/btcwbackend/neutrino.go
@@ -10,6 +10,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btclog/v2"
 	"github.com/btcsuite/btcwallet/chain"
+	basewallet "github.com/btcsuite/btcwallet/wallet"
 	"github.com/btcsuite/btcwallet/walletdb"
 	_ "github.com/btcsuite/btcwallet/walletdb/bdb" // Register bdb backend.
 	"github.com/lightninglabs/neutrino"
@@ -19,10 +20,12 @@ import (
 // neutrinoDBName is the filename for the neutrino bbolt database.
 const neutrinoDBName = "neutrino.db"
 
-// defaultBlockCacheSize is the number of blocks to cache in memory.
-// This prevents redundant block fetches during wallet sync and chain
-// notification processing.
-const defaultBlockCacheSize uint64 = 20
+// defaultBlockCacheSize is the maximum size in bytes of the in-memory
+// block cache. This prevents redundant block fetches during wallet
+// sync, chain notification processing, and TxProof construction.
+// lnd uses 20 MiB; we use a smaller default since the light client
+// only fetches blocks on demand.
+const defaultBlockCacheSize uint64 = 2 * 1024 * 1024 // 2 MiB
 
 // defaultDBTimeout is the default timeout for opening the neutrino
 // bbolt database.
@@ -107,6 +110,12 @@ func NewNeutrinoService(dataDir string, chainParams *chaincfg.Params,
 // syncing headers and compact block filters.
 func (n *NeutrinoService) Start() error {
 	n.log.InfoS(context.Background(), "Starting neutrino chain service")
+
+	// Wire up neutrino and btcwallet chain client internal loggers
+	// so their debug output is visible alongside our daemon logs.
+	neutrino.UseLogger(n.log)
+	chain.UseLogger(n.log)
+	basewallet.UseLogger(n.log)
 
 	if err := n.cs.Start(); err != nil {
 		return fmt.Errorf("start neutrino: %w", err)

--- a/btcwbackend/wallet.go
+++ b/btcwbackend/wallet.go
@@ -41,15 +41,19 @@ type Wallet struct {
 	// boardingBackend wraps btcwallet to provide the
 	// wallet.BoardingBackend interface for Ark boarding.
 	boardingBackend *BoardingBackendAdapter
+
+	// ownsNeutrino is true when the wallet created and owns the
+	// neutrino service lifecycle (created via New). When false
+	// (created via NewWithNeutrino), the caller manages neutrino
+	// shutdown.
+	ownsNeutrino bool
 }
 
 // New creates a new neutrino-backed wallet from the given
-// configuration. The caller must provide a DBDir for btcwallet's
-// bbolt database and is responsible for managing the directory's
-// lifecycle.
+// configuration. The wallet creates and owns its own neutrino
+// service, which is stopped when the wallet is stopped.
 func New(cfg Config) (*Wallet, error) {
 	walletLog := cfg.Log.UnwrapOr(btclog.Disabled)
-
 	neutrinoDataDir := cfg.neutrinoDataDir()
 
 	// Create and start the neutrino chain service.
@@ -65,6 +69,31 @@ func New(cfg Config) (*Wallet, error) {
 	if err := neutrinoSvc.Start(); err != nil {
 		return nil, fmt.Errorf("start neutrino service: %w", err)
 	}
+
+	w, err := NewWithNeutrino(cfg, neutrinoSvc)
+	if err != nil {
+		_ = neutrinoSvc.Stop()
+
+		return nil, err
+	}
+
+	// Mark that this wallet owns the neutrino service lifecycle.
+	w.ownsNeutrino = true
+
+	return w, nil
+}
+
+// NewWithNeutrino creates a new neutrino-backed wallet using a
+// pre-started NeutrinoService. The caller retains ownership of the
+// neutrino service lifecycle — the wallet will NOT stop it on
+// Wallet.Stop(). This allows the daemon to start neutrino early
+// (for P2P connection and header sync) independently of wallet
+// unlock timing.
+func NewWithNeutrino(cfg Config,
+	neutrinoSvc *NeutrinoService) (*Wallet, error) {
+
+	walletLog := cfg.Log.UnwrapOr(btclog.Disabled)
+	neutrinoDataDir := cfg.neutrinoDataDir()
 
 	// Create the btcwallet chain client backed by neutrino.
 	chainClient := neutrinoSvc.ChainClient()
@@ -87,8 +116,6 @@ func New(cfg Config) (*Wallet, error) {
 		},
 	}, blockCache)
 	if err != nil {
-		_ = neutrinoSvc.Stop()
-
 		return nil, fmt.Errorf("create btcwallet: %w", err)
 	}
 
@@ -107,7 +134,6 @@ func New(cfg Config) (*Wallet, error) {
 	)
 	if err != nil {
 		_ = btcw.Stop()
-		_ = neutrinoSvc.Stop()
 
 		return nil, fmt.Errorf("create chain backend: %w", err)
 	}
@@ -162,7 +188,9 @@ func (w *Wallet) Start() error {
 	return nil
 }
 
-// Stop shuts down the wallet, neutrino service, and chain backend.
+// Stop shuts down the wallet and, if the wallet owns the neutrino
+// service (created via New), stops it too. When created via
+// NewWithNeutrino, the caller manages the neutrino lifecycle.
 func (w *Wallet) Stop() {
 	ctx := context.Background()
 
@@ -176,7 +204,10 @@ func (w *Wallet) Stop() {
 	// Stop order: btcwallet (depends on neutrino chain client)
 	// must stop before neutrino service.
 	_ = w.BtcWallet.Stop()
-	_ = w.neutrinoSvc.Stop()
+
+	if w.ownsNeutrino {
+		_ = w.neutrinoSvc.Stop()
+	}
 
 	w.Logger(ctx).InfoS(ctx, "Neutrino-backed wallet stopped")
 }
@@ -197,4 +228,12 @@ func (w *Wallet) ChainBackend() *ChainBackend {
 // and message signing operations.
 func (w *Wallet) KeyRing() keychain.SecretKeyRing {
 	return w.Wallet.KeyRing
+}
+
+// IsSynced returns whether the underlying btcwallet has fully synced
+// to the current best block. This includes completion of any recovery
+// scan. Callers should poll this before marking the wallet ready to
+// ensure the chain notification pipeline is fully operational.
+func (w *Wallet) IsSynced() (bool, int64, error) {
+	return w.BtcWallet.IsSynced()
 }

--- a/darepod/AGENTS.md
+++ b/darepod/AGENTS.md
@@ -22,14 +22,14 @@ gRPC API.
 
 ## Relationships
 
-- **Depends on**: `baselib/actor` (ActorSystem), `chainbackends`, `chainsource`, `lib/actormsg`, `db`, `round`, `vtxo`, `wallet`, `oor`, `serverconn`, `indexer`, `arkrpc`.
+- **Depends on**: `baselib/actor` (ActorSystem), `btcwbackend`, `chainbackends`, `chainsource`, `lib/actormsg`, `db`, `round`, `vtxo`, `wallet`, `walletcore`, `oor`, `serverconn`, `indexer`, `arkrpc`.
 - **Depended on by**: `cmd/darepod` (main entry point).
 
 ## Invariants
 
 - Server owns ActorSystem lifetime; shutdown stops all subsystems.
 - Wallet transitions None → Locked → Ready (or direct to Ready if seed provided).
-- Two wallet modes: LND-backed or lightweight (`lwwallet`).
+- Three wallet modes: LND-backed, lightweight (`lwwallet`), or neutrino-backed (`btcwallet` via `btcwbackend`).
 - Per-subsystem logging: configurable log writer, no global mutable loggers. Each subsystem receives its own logger instance.
 - Board RPC is non-blocking: delegates to wallet actor and returns immediately.
 - ListRounds splits pending (in-memory from actor) and persisted (SQL with cursor pagination) rounds.
@@ -37,6 +37,8 @@ gRPC API.
 - Actor startup order: VTXO manager starts before round actor and OOR actor, so the manager ref is available for both. The round actor ref in the VTXO manager is lazy (service-key-based, resolved at Tell time).
 - `mapRoundVTXOManagerMsg` bridges `round.VTXOManagerMsg` → `vtxo.ManagerMsg` via `MapInputRef`. Compile-time assertions enforce that all `round.VTXOManagerMsg` implementors satisfy `vtxo.ManagerMsg`.
 - OOR receive-key is derived once at startup via `EnsureDefaultOORReceiveScript` and persisted for restart-safe re-registration. The `DurableUnaryBuilder` is wired through `serverconn.ConnectorConfig` so all indexer queries flow through the durable transport path.
+- In btcwallet mode, neutrino is pre-started before seed availability so P2P sync proceeds in parallel. The `neutrinoSvc` field uses `fn.Option` and is reused by `startBtcwallet` via `NewWithNeutrino`.
+- The neutrino sync-wait goroutine polls indefinitely (no timeout) to avoid leaving the wallet permanently unready. Progress is logged every 30 seconds.
 - `ensureRoundExists` in `db/vtxo_store.go` uses check-then-insert (not upsert) because `InsertRound`'s `ON CONFLICT DO UPDATE` would overwrite richer round state.
 
 ## Deep Docs

--- a/darepod/CLAUDE.md
+++ b/darepod/CLAUDE.md
@@ -22,14 +22,14 @@ gRPC API.
 
 ## Relationships
 
-- **Depends on**: `baselib/actor` (ActorSystem), `chainbackends`, `chainsource`, `lib/actormsg`, `db`, `round`, `vtxo`, `wallet`, `oor`, `serverconn`, `indexer`, `arkrpc`.
+- **Depends on**: `baselib/actor` (ActorSystem), `btcwbackend`, `chainbackends`, `chainsource`, `lib/actormsg`, `db`, `round`, `vtxo`, `wallet`, `walletcore`, `oor`, `serverconn`, `indexer`, `arkrpc`.
 - **Depended on by**: `cmd/darepod` (main entry point).
 
 ## Invariants
 
 - Server owns ActorSystem lifetime; shutdown stops all subsystems.
 - Wallet transitions None → Locked → Ready (or direct to Ready if seed provided).
-- Two wallet modes: LND-backed or lightweight (`lwwallet`).
+- Three wallet modes: LND-backed, lightweight (`lwwallet`), or neutrino-backed (`btcwallet` via `btcwbackend`).
 - Per-subsystem logging: configurable log writer, no global mutable loggers. Each subsystem receives its own logger instance.
 - Board RPC is non-blocking: delegates to wallet actor and returns immediately.
 - ListRounds splits pending (in-memory from actor) and persisted (SQL with cursor pagination) rounds.
@@ -37,6 +37,8 @@ gRPC API.
 - Actor startup order: VTXO manager starts before round actor and OOR actor, so the manager ref is available for both. The round actor ref in the VTXO manager is lazy (service-key-based, resolved at Tell time).
 - `mapRoundVTXOManagerMsg` bridges `round.VTXOManagerMsg` → `vtxo.ManagerMsg` via `MapInputRef`. Compile-time assertions enforce that all `round.VTXOManagerMsg` implementors satisfy `vtxo.ManagerMsg`.
 - OOR receive-key is derived once at startup via `EnsureDefaultOORReceiveScript` and persisted for restart-safe re-registration. The `DurableUnaryBuilder` is wired through `serverconn.ConnectorConfig` so all indexer queries flow through the durable transport path.
+- In btcwallet mode, neutrino is pre-started before seed availability so P2P sync proceeds in parallel. The `neutrinoSvc` field uses `fn.Option` and is reused by `startBtcwallet` via `NewWithNeutrino`.
+- The neutrino sync-wait goroutine polls indefinitely (no timeout) to avoid leaving the wallet permanently unready. Progress is logged every 30 seconds.
 - `ensureRoundExists` in `db/vtxo_store.go` uses check-then-insert (not upsert) because `InsertRound`'s `ON CONFLICT DO UPDATE` would overwrite richer round state.
 
 ## Deep Docs

--- a/darepod/logging.go
+++ b/darepod/logging.go
@@ -3,6 +3,7 @@ package darepod
 import (
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/btcwbackend"
 	"github.com/lightninglabs/darepo-client/chainbackends"
 	"github.com/lightninglabs/darepo-client/db"
 	"github.com/lightninglabs/darepo-client/indexer"
@@ -29,6 +30,7 @@ var allSubsystems = []string{
 	vtxo.Subsystem,
 	wallet.Subsystem,
 	lwwallet.Subsystem,
+	btcwbackend.Subsystem,
 	serverconn.Subsystem,
 	chainbackends.Subsystem,
 	chainbackends.LndClientSubsystem,

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/btcwbackend"
 	"github.com/lightninglabs/darepo-client/build"
 	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/lightninglabs/darepo-client/lib/scripts"
@@ -90,6 +91,47 @@ func (r *RPCServer) GetInfo(ctx context.Context,
 			// index 0), matching lnd's identity key
 			// derivation path. DeriveKey (not
 			// DeriveNextKey) ensures a stable identity.
+			desc, err := w.DeriveKey(
+				ctx, keychain.KeyLocator{
+					Family: identityKeyFamily,
+					Index:  0,
+				},
+			)
+			if err != nil {
+				r.server.log.WarnS(ctx,
+					"Unable to derive identity key",
+					err)
+			} else {
+				resp.IdentityPubkey = fmt.Sprintf(
+					"%x",
+					desc.PubKey.SerializeCompressed(),
+				)
+			}
+
+			// Get block height from the chain backend.
+			if r.server.chainBackend != nil {
+				height, _, err :=
+					r.server.chainBackend.BestBlock(
+						ctx,
+					)
+				if err != nil {
+					r.server.log.WarnS(ctx,
+						"Unable to fetch block "+
+							"height", err)
+				} else {
+					resp.BlockHeight = uint32(height)
+				}
+			}
+		},
+	)
+
+	// Populate btcwallet fields if the neutrino-backed wallet is
+	// active.
+	r.server.btcwWallet.WhenSome(
+		func(w *btcwbackend.Wallet) {
+			// Derive the node identity key using the same
+			// path as lnd/lwwallet: KeyFamilyNodeKey (family
+			// 6, index 0).
 			desc, err := w.DeriveKey(
 				ctx, keychain.KeyLocator{
 					Family: identityKeyFamily,

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -139,6 +139,13 @@ type Server struct {
 	// wallet.type is "btcwallet". It is None in other modes.
 	btcwWallet fn.Option[*btcwbackend.Wallet]
 
+	// neutrinoSvc holds the pre-started neutrino chain service
+	// when wallet.type is "btcwallet". Started early in daemon
+	// startup (before seed is available) so P2P peer connection
+	// and header sync can proceed in parallel. Reused by
+	// startBtcwallet when the wallet is finally unlocked.
+	neutrinoSvc fn.Option[*btcwbackend.NeutrinoService]
+
 	// walletState tracks the lifecycle state of the wallet
 	// subsystem. In lnd mode this is always WalletStateReady
 	// after successful lnd connection. In lwwallet mode it
@@ -230,6 +237,11 @@ func (s *Server) isWalletReady() bool {
 	default:
 		return false
 	}
+}
+
+// WalletType returns the configured wallet backend type string.
+func (s *Server) WalletType() string {
+	return s.cfg.Wallet.Type
 }
 
 // markWalletReady atomically stores WalletStateReady and closes the
@@ -373,6 +385,17 @@ func (s *Server) run(ctx context.Context,
 		// In btcwallet mode, use the same auto-unlock flow
 		// as lwwallet but start a neutrino-backed wallet.
 		s.tryAutoUnlockBtcwallet(ctx)
+
+		// Register neutrino cleanup immediately so it fires
+		// even if a later startup step (dialServer, actor
+		// system init) fails before the main defer block.
+		defer func() {
+			s.neutrinoSvc.WhenSome(
+				func(svc *btcwbackend.NeutrinoService) {
+					_ = svc.Stop()
+				},
+			)
+		}()
 
 	default:
 		return fmt.Errorf("unknown wallet type %q",
@@ -820,7 +843,25 @@ func (s *Server) startLwwallet(ctx context.Context,
 // backend at startup without user interaction. It follows the same
 // pattern as tryAutoUnlockLwwallet: check for a seed in the
 // environment, then check for an encrypted seed file with a password.
+//
+// Neutrino is started eagerly before checking for a wallet seed so
+// that P2P peer connection and header sync can proceed in parallel
+// while the daemon waits for the InitWallet or UnlockWallet RPC.
+// The pre-started service is stored in s.neutrinoSvc and reused by
+// startBtcwallet when the seed becomes available.
 func (s *Server) tryAutoUnlockBtcwallet(ctx context.Context) {
+	// Start neutrino early so it can connect to P2P peers and
+	// sync headers while we wait for the wallet seed. This
+	// dramatically reduces the time startBtcwallet needs when
+	// the UnlockWallet RPC finally arrives.
+	if err := s.preStartNeutrino(ctx); err != nil {
+		s.log.ErrorS(ctx,
+			"Failed to pre-start neutrino service", err)
+
+		// Non-fatal: startBtcwallet will create its own
+		// neutrino service if s.neutrinoSvc is nil.
+	}
+
 	// Check for a raw seed in the environment (dev/CI path).
 	seed, err := LoadSeedFromEnv()
 	if err != nil {
@@ -921,9 +962,51 @@ func (s *Server) tryAutoUnlockBtcwallet(ctx context.Context) {
 	}
 }
 
+// preStartNeutrino creates and starts the neutrino chain service
+// early so it can begin P2P peer connection and header/filter sync
+// while the daemon waits for a wallet seed. The started service is
+// stored in s.neutrinoSvc for reuse by startBtcwallet.
+func (s *Server) preStartNeutrino(ctx context.Context) error {
+	walletLog := s.subLogger(btcwbackend.Subsystem)
+
+	neutrinoDataDir := s.cfg.Wallet.BtcwalletDataDir
+	if neutrinoDataDir == "" {
+		networkDir, err := s.cfg.NetworkDir()
+		if err != nil {
+			return fmt.Errorf(
+				"resolve network directory: %w", err,
+			)
+		}
+
+		neutrinoDataDir = networkDir
+	}
+
+	svc, err := btcwbackend.NewNeutrinoService(
+		neutrinoDataDir, s.chainParams,
+		s.cfg.Wallet.BtcwalletPeers,
+		s.cfg.Wallet.BtcwalletAddPeers,
+		s.cfg.Wallet.PersistFilters, walletLog,
+	)
+	if err != nil {
+		return fmt.Errorf("create neutrino service: %w", err)
+	}
+
+	if err := svc.Start(); err != nil {
+		return fmt.Errorf("start neutrino service: %w", err)
+	}
+
+	s.neutrinoSvc = fn.Some(svc)
+	s.log.InfoS(ctx,
+		"Neutrino service pre-started for P2P sync")
+
+	return nil
+}
+
 // startBtcwallet creates and starts the neutrino-backed wallet from
-// the given raw seed. On success it populates s.btcwWallet and marks
-// the wallet as ready.
+// the given raw seed. If a neutrino service was pre-started via
+// preStartNeutrino, it is reused; otherwise a new one is created.
+// On success it populates s.btcwWallet and marks the wallet as
+// ready.
 func (s *Server) startBtcwallet(ctx context.Context,
 	seed [rawSeedLen]byte) error {
 
@@ -937,7 +1020,7 @@ func (s *Server) startBtcwallet(ctx context.Context,
 		recoveryWindow = DefaultRecoveryWindow
 	}
 
-	w, err := btcwbackend.New(btcwbackend.Config{
+	cfg := btcwbackend.Config{
 		Config: walletcore.Config{
 			Seed:           seed,
 			ChainParams:    s.chainParams,
@@ -952,7 +1035,18 @@ func (s *Server) startBtcwallet(ctx context.Context,
 		AddPeers:        s.cfg.Wallet.BtcwalletAddPeers,
 		FeeURL:          s.cfg.Wallet.FeeURL,
 		PersistFilters:  s.cfg.Wallet.PersistFilters,
-	})
+	}
+
+	// Reuse the pre-started neutrino service if available.
+	// Otherwise, create a new one (fallback for callers that
+	// skip preStartNeutrino).
+	var w *btcwbackend.Wallet
+	if s.neutrinoSvc.IsSome() {
+		svc := s.neutrinoSvc.UnsafeFromSome()
+		w, err = btcwbackend.NewWithNeutrino(cfg, svc)
+	} else {
+		w, err = btcwbackend.New(cfg)
+	}
 	if err != nil {
 		return fmt.Errorf("create btcwallet: %w", err)
 	}
@@ -985,46 +1079,65 @@ func (s *Server) startBtcwallet(ctx context.Context,
 	s.log.InfoS(ctx, "Neutrino-backed wallet started, "+
 		"waiting for initial sync in background")
 
-	// Wait for neutrino to sync at least one block before marking
-	// the wallet ready. This runs in a goroutine so the InitWallet
-	// RPC can return without blocking on neutrino header sync.
+	// Wait for btcwallet to fully sync with the chain before
+	// marking the wallet ready. This includes the recovery scan
+	// (when recoveryWindow > 0) which downloads and checks compact
+	// block filters for all existing blocks. Without this wait,
+	// the daemon would accept requests while btcwallet's chain
+	// notification handler is blocked in syncWithChain, causing
+	// newly mined blocks to be missed.
+	//
+	// The goroutine polls indefinitely rather than timing out,
+	// because a timeout would leave the wallet permanently
+	// unready with no retry path. Progress is logged every 30
+	// seconds so operators can observe sync advancement.
 	go func() {
-		syncCtx, syncCancel := context.WithTimeout(
-			context.Background(), 2*time.Minute,
-		)
-		defer syncCancel()
-
 		ticker := time.NewTicker(500 * time.Millisecond)
 		defer ticker.Stop()
 
-		for {
-			select {
-			case <-syncCtx.Done():
-				s.log.ErrorS(
-					syncCtx,
-					"Neutrino did not sync in time",
-					syncCtx.Err(),
-				)
+		logInterval := 30 * time.Second
+		lastLog := time.Now()
 
+		for range ticker.C {
+			if ctx.Err() != nil {
 				return
-
-			case <-ticker.C:
-				height, _, err := w.ChainBackend().BestBlock(
-					syncCtx,
-				)
-				if err == nil && height > 0 {
-					s.log.InfoS(syncCtx,
-						"Neutrino initial sync "+
-							"complete",
-						slog.Int("height",
-							int(height)),
-					)
-
-					s.markWalletReady()
-
-					return
-				}
 			}
+
+			synced, bestTimestamp, err := w.IsSynced()
+			if err != nil {
+				continue
+			}
+
+			if !synced {
+				if time.Since(lastLog) >= logInterval {
+					s.log.InfoS(ctx,
+						"Waiting for neutrino "+
+							"wallet sync",
+					)
+					lastLog = time.Now()
+				}
+
+				continue
+			}
+
+			height, _, hErr := w.ChainBackend().BestBlock(
+				ctx,
+			)
+			if hErr != nil || height == 0 {
+				continue
+			}
+
+			s.log.InfoS(ctx,
+				"Neutrino initial sync complete",
+				slog.Int("height",
+					int(height)),
+				slog.Int64("best_time",
+					bestTimestamp),
+			)
+
+			s.markWalletReady()
+
+			return
 		}
 	}()
 

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -151,7 +151,7 @@ type Server struct {
 	// when the daemon shuts down. Background goroutines that
 	// must outlive RPC handlers but not the daemon should
 	// select on runCtx.Done().
-	runCtx context.Context
+	runCtx context.Context //nolint:containedctx
 
 	// walletState tracks the lifecycle state of the wallet
 	// subsystem. In lnd mode this is always WalletStateReady

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -146,6 +146,13 @@ type Server struct {
 	// startBtcwallet when the wallet is finally unlocked.
 	neutrinoSvc fn.Option[*btcwbackend.NeutrinoService]
 
+	// runCtx is the context that spans the server's entire Run
+	// lifecycle. It is set at the start of run() and cancelled
+	// when the daemon shuts down. Background goroutines that
+	// must outlive RPC handlers but not the daemon should
+	// select on runCtx.Done().
+	runCtx context.Context
+
 	// walletState tracks the lifecycle state of the wallet
 	// subsystem. In lnd mode this is always WalletStateReady
 	// after successful lnd connection. In lwwallet mode it
@@ -319,6 +326,11 @@ func (s *Server) RunWithContext(ctx context.Context) error {
 //nolint:funlen
 func (s *Server) run(ctx context.Context,
 	shutdownFn func()) error {
+
+	// Store the run context so background goroutines (like the
+	// btcwallet sync poller) can outlive individual RPC
+	// handlers but still shut down with the daemon.
+	s.runCtx = ctx
 
 	// -------------------------------------------------------
 	// 0. Initialize the logging backend and subsystem loggers.
@@ -1087,25 +1099,32 @@ func (s *Server) startBtcwallet(ctx context.Context,
 	// notification handler is blocked in syncWithChain, causing
 	// newly mined blocks to be missed.
 	//
-	// The goroutine polls indefinitely rather than timing out,
-	// because a timeout would leave the wallet permanently
-	// unready with no retry path. Progress is logged every 30
-	// seconds so operators can observe sync advancement.
+	// The goroutine polls until sync completes or the daemon
+	// shuts down. We use s.walletReady as the success signal
+	// (closed by markWalletReady) and a server-scoped quit
+	// channel so the goroutine doesn't outlive the daemon.
 	//
-	// We use a detached context because the caller's ctx (from
-	// the InitWallet/UnlockWallet RPC) is cancelled as soon as
-	// the RPC handler returns. The sync goroutine must outlive
-	// the RPC.
+	// We must NOT use the caller's ctx here: the RPC context
+	// is cancelled when the handler returns, but the sync
+	// goroutine must outlive the RPC. Instead, we select on
+	// the server's runCtx (the context passed to Run, which
+	// lives until daemon shutdown).
+	runCtx := s.runCtx
 	go func() {
-		syncCtx := context.Background()
-
 		ticker := time.NewTicker(500 * time.Millisecond)
 		defer ticker.Stop()
 
 		logInterval := 30 * time.Second
 		lastLog := time.Now()
 
-		for range ticker.C {
+		for {
+			select {
+			case <-runCtx.Done():
+				return
+
+			case <-ticker.C:
+			}
+
 			synced, bestTimestamp, err := w.IsSynced()
 			if err != nil {
 				continue
@@ -1113,7 +1132,8 @@ func (s *Server) startBtcwallet(ctx context.Context,
 
 			if !synced {
 				if time.Since(lastLog) >= logInterval {
-					s.log.InfoS(syncCtx,
+					s.log.InfoS(
+						context.Background(),
 						"Waiting for neutrino "+
 							"wallet sync",
 					)
@@ -1124,13 +1144,13 @@ func (s *Server) startBtcwallet(ctx context.Context,
 			}
 
 			height, _, hErr := w.ChainBackend().BestBlock(
-				syncCtx,
+				context.Background(),
 			)
 			if hErr != nil || height == 0 {
 				continue
 			}
 
-			s.log.InfoS(syncCtx,
+			s.log.InfoS(context.Background(),
 				"Neutrino initial sync complete",
 				slog.Int("height",
 					int(height)),

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -1091,7 +1091,14 @@ func (s *Server) startBtcwallet(ctx context.Context,
 	// because a timeout would leave the wallet permanently
 	// unready with no retry path. Progress is logged every 30
 	// seconds so operators can observe sync advancement.
+	//
+	// We use a detached context because the caller's ctx (from
+	// the InitWallet/UnlockWallet RPC) is cancelled as soon as
+	// the RPC handler returns. The sync goroutine must outlive
+	// the RPC.
 	go func() {
+		syncCtx := context.Background()
+
 		ticker := time.NewTicker(500 * time.Millisecond)
 		defer ticker.Stop()
 
@@ -1099,10 +1106,6 @@ func (s *Server) startBtcwallet(ctx context.Context,
 		lastLog := time.Now()
 
 		for range ticker.C {
-			if ctx.Err() != nil {
-				return
-			}
-
 			synced, bestTimestamp, err := w.IsSynced()
 			if err != nil {
 				continue
@@ -1110,7 +1113,7 @@ func (s *Server) startBtcwallet(ctx context.Context,
 
 			if !synced {
 				if time.Since(lastLog) >= logInterval {
-					s.log.InfoS(ctx,
+					s.log.InfoS(syncCtx,
 						"Waiting for neutrino "+
 							"wallet sync",
 					)
@@ -1121,13 +1124,13 @@ func (s *Server) startBtcwallet(ctx context.Context,
 			}
 
 			height, _, hErr := w.ChainBackend().BestBlock(
-				ctx,
+				syncCtx,
 			)
 			if hErr != nil || height == 0 {
 				continue
 			}
 
-			s.log.InfoS(ctx,
+			s.log.InfoS(syncCtx,
 				"Neutrino initial sync complete",
 				slog.Int("height",
 					int(height)),

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -42,7 +42,10 @@ const (
 	// ListUnspent query within a single block epoch if we didn't detect any
 	// new boarding UTXOs. This mitigates a race where we receive a block
 	// epoch notification before the wallet's UTXO set is fully updated.
-	listUnspentMaxRetries = 5
+	// For neutrino backends, btcwallet's internal block processing
+	// (fetching the full block from P2P, running AddCredit) can take
+	// over a second after the epoch arrives.
+	listUnspentMaxRetries = 10
 
 	// listUnspentRetryDelay is the delay between ListUnspent retries.
 	// We keep this small so confirmed boarding UTXOs are detected

--- a/walletcore/AGENTS.md
+++ b/walletcore/AGENTS.md
@@ -1,0 +1,29 @@
+# walletcore
+
+## Purpose
+
+Shared btcwallet wrapping used by both lwwallet (Esplora-backed) and btcwbackend
+(neutrino-backed) wallet implementations. Extracts common HD key management,
+signing, address generation, and balance operations that delegate to
+btcwallet.BtcWallet regardless of the underlying chain source.
+
+## Key Types
+
+- `Wallet` — Core wallet struct embedding `input.Signer`. Provides key derivation, P2TR address generation, balance queries, and UTXO listing. Chain-specific implementations embed this to satisfy `round.ClientWallet`.
+- `BoardingBackendBase` — Shared boarding functionality: taproot script import under BIP86 scope, imported address tracking for UTXO filtering, and HD key derivation. Chain-specific adapters embed this and add `ListUnspent`, `GetTransaction`, `GetBlock`.
+- `Config` — Base configuration (seed, chain params, recovery window, DB dir, logger) shared by all btcwallet-backed wallet backends.
+
+## Relationships
+
+- **Depends on**: `build` (context logger extraction).
+- **Depended on by**: `lwwallet` (embeds Wallet + BoardingBackendBase), `btcwbackend` (embeds Wallet + BoardingBackendBase).
+
+## Invariants
+
+- Taproot scripts must be imported under `KeyScopeBIP0086` (not the custom chain key scope), because btcwallet's block processing skips credit tracking for non-default scopes (`chainntfns.go:IsDefaultScope` check).
+- `ImportedAddrs` is in-memory only; repopulated on restart from the database by the wallet actor's `handleStartupRecovery`.
+- `WalletPassphrase` is shared across all wallet backends for both `PrivatePass` and `PublicPass`.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/walletcore/CLAUDE.md
+++ b/walletcore/CLAUDE.md
@@ -1,0 +1,29 @@
+# walletcore
+
+## Purpose
+
+Shared btcwallet wrapping used by both lwwallet (Esplora-backed) and btcwbackend
+(neutrino-backed) wallet implementations. Extracts common HD key management,
+signing, address generation, and balance operations that delegate to
+btcwallet.BtcWallet regardless of the underlying chain source.
+
+## Key Types
+
+- `Wallet` — Core wallet struct embedding `input.Signer`. Provides key derivation, P2TR address generation, balance queries, and UTXO listing. Chain-specific implementations embed this to satisfy `round.ClientWallet`.
+- `BoardingBackendBase` — Shared boarding functionality: taproot script import under BIP86 scope, imported address tracking for UTXO filtering, and HD key derivation. Chain-specific adapters embed this and add `ListUnspent`, `GetTransaction`, `GetBlock`.
+- `Config` — Base configuration (seed, chain params, recovery window, DB dir, logger) shared by all btcwallet-backed wallet backends.
+
+## Relationships
+
+- **Depends on**: `build` (context logger extraction).
+- **Depended on by**: `lwwallet` (embeds Wallet + BoardingBackendBase), `btcwbackend` (embeds Wallet + BoardingBackendBase).
+
+## Invariants
+
+- Taproot scripts must be imported under `KeyScopeBIP0086` (not the custom chain key scope), because btcwallet's block processing skips credit tracking for non-default scopes (`chainntfns.go:IsDefaultScope` check).
+- `ImportedAddrs` is in-memory only; repopulated on restart from the database by the wallet actor's `handleStartupRecovery`.
+- `WalletPassphrase` is shared across all wallet backends for both `PrivatePass` and `PublicPass`.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/walletcore/boarding_backend.go
+++ b/walletcore/boarding_backend.go
@@ -94,12 +94,19 @@ func (b *BoardingBackendBase) DeriveNextKey(ctx context.Context,
 // btcwallet will track UTXOs paying to this address via whatever
 // chain source is configured (Esplora notifications or neutrino
 // compact block filter matching).
+//
+// The script is imported under BIP86 (default taproot) scope rather
+// than the custom chain key scope used for key derivation. This
+// matches lnd's ImportTaprootScript RPC behavior and is required
+// because btcwallet's block processing pipeline skips credit
+// tracking for addresses in non-default scopes
+// (chainntfns.go:IsDefaultScope check).
 func (b *BoardingBackendBase) ImportTaprootScript(
 	ctx context.Context,
 	script *waddrmgr.Tapscript) (btcutil.Address, error) {
 
 	managedAddr, err := b.BtcWallet.ImportTaprootScript(
-		b.ChainKeyScope, script,
+		waddrmgr.KeyScopeBIP0086, script,
 	)
 	if err != nil {
 		return nil, fmt.Errorf(


### PR DESCRIPTION
## Summary

This PR fixes several critical issues with the neutrino-backed btcwallet
backend that prevented boarding flows from working end-to-end:

- **Boarding UTXOs invisible to wallet**: `ImportTaprootScript` used the
  custom `m/1017'/coinType'` key scope, but btcwallet's `chainntfns.go`
  skips `AddCredit` for non-default scopes. Switched to
  `KeyScopeBIP0086` to match lnd's behavior — neutrino now correctly
  detects and tracks boarding outputs via compact block filters.

- **TxProof construction always failed**: The block cache capacity was
  set to 20 (bytes, not blocks). Since even the smallest regtest block
  exceeds 20 bytes, every `GetBlock` call errored out, causing
  `buildBoardingTxProof` to return `None`. The server then rejected
  join requests with "TxProof is required when server has no chain
  source". Raised to 2 MiB.

- **Nil pointer panic on shutdown**: `RegisterConf`, `RegisterSpend`,
  and `RegisterBlocks` called `event.Cancel()` from both a deferred
  goroutine and the returned Cancel closure. lnd's
  `notificationDispatcher` panics on double-cancel (nil map lookup
  after delete). Wrapped in `sync.Once`.

- **Empty IdentityPubkey in GetInfo**: The btcwallet case was missing
  from the `GetInfo` RPC handler, leaving `IdentityPubkey` and
  `BlockHeight` empty. This broke `SendVTXO` tests that derive
  recipient keys from `GetInfo`.

- **Silent log suppression**: `btcwbackend.Subsystem` was missing from
  `allSubsystems`, causing all BTCW logs to route to `btclog.Disabled`.

- **Slow wallet unlock on restart**: Neutrino P2P connection happened
  inside the `UnlockWallet` RPC, causing timeouts when the connection
  manager hit backoff retries. Introduced `preStartNeutrino` to begin
  P2P sync early in daemon startup, and `NewWithNeutrino` to let the
  wallet reuse the pre-connected service.

- **Premature wallet-ready signal**: The sync wait goroutine checked
  `BestBlock height > 0` which could pass during header sync before
  btcwallet's recovery scan completed. Now uses `IsSynced()` which
  gates on both header sync and recovery completion.

## Test plan

- [x] All 8 boarding itests pass with `backend=btcwallet`
- [x] `TestSendVTXOIntegrationDryRunPreview` passes with `backend=btcwallet`
- [x] Both restart tests pass (RestartAfterRoundBroadcast, RestartAfterInputSigSent)
- [x] Systests pass (18/21, 3 failures are Docker network pool exhaustion)
- [x] Clean shutdown — no nil pointer panics