### PR TITLE
Add shared proof key backend for darepod

### DIFF
--- a/darepod/indexer_proof_keyops.go
+++ b/darepod/indexer_proof_keyops.go
@@ -1,0 +1,60 @@
+package darepod
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/lightninglabs/darepo-client/indexer"
+	"github.com/lightningnetwork/lnd/keychain"
+)
+
+// indexerProofSignerFactory returns the signer factory for the active proof
+// key backend.
+func (s *Server) indexerProofSignerFactory() (
+	OORReceiveScriptSignerFactory, error) {
+
+	if s.proofKeyBackend == nil {
+		return nil, fmt.Errorf("wallet backend not initialized")
+	}
+
+	return s.proofKeyBackend.ProofSigner, nil
+}
+
+// IndexerProofKey derives the fixed wallet key identified by loc and returns a
+// signer that can produce indexer proof signatures for that key under the
+// active wallet backend.
+func (s *Server) IndexerProofKey(ctx context.Context,
+	loc keychain.KeyLocator) (*keychain.KeyDescriptor,
+	indexer.SchnorrSigner, error) {
+
+	if s.proofKeyBackend == nil {
+		return nil, nil, fmt.Errorf("wallet backend not initialized")
+	}
+
+	keyDesc, err := s.proofKeyBackend.DeriveKey(ctx, loc)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return keyDesc, s.proofKeyBackend.ProofSigner(*keyDesc), nil
+}
+
+// indexerProofNextKeyOps returns fresh-key derivation and signer-factory hooks
+// for the active wallet backend.
+func (s *Server) indexerProofNextKeyOps() (DeriveDefaultOORReceiveKeyFunc,
+	OORReceiveScriptSignerFactory, error) {
+
+	if s.proofKeyBackend == nil {
+		return nil, nil, fmt.Errorf("wallet backend not initialized")
+	}
+
+	deriveNextKey := func(
+		ctx context.Context) (*keychain.KeyDescriptor, error) {
+
+		return s.proofKeyBackend.DeriveNextKey(
+			ctx, keychain.KeyFamilyMultiSig,
+		)
+	}
+
+	return deriveNextKey, s.proofKeyBackend.ProofSigner, nil
+}

--- a/darepod/indexer_proof_keyops_test.go
+++ b/darepod/indexer_proof_keyops_test.go
@@ -1,0 +1,123 @@
+package darepod
+
+import (
+	"context"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/lightninglabs/darepo-client/indexer"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/stretchr/testify/require"
+)
+
+type stubProofKeyBackend struct {
+	deriveKeyResp     *keychain.KeyDescriptor
+	deriveKeyErr      error
+	deriveKeyLoc      keychain.KeyLocator
+	deriveNextKeyResp *keychain.KeyDescriptor
+	deriveNextKeyErr  error
+	deriveNextFamily  keychain.KeyFamily
+	signerKeyDesc     keychain.KeyDescriptor
+}
+
+func (b *stubProofKeyBackend) DeriveKey(_ context.Context,
+	loc keychain.KeyLocator) (*keychain.KeyDescriptor, error) {
+
+	b.deriveKeyLoc = loc
+
+	return b.deriveKeyResp, b.deriveKeyErr
+}
+
+func (b *stubProofKeyBackend) DeriveNextKey(_ context.Context,
+	family keychain.KeyFamily) (*keychain.KeyDescriptor, error) {
+
+	b.deriveNextFamily = family
+
+	return b.deriveNextKeyResp, b.deriveNextKeyErr
+}
+
+func (b *stubProofKeyBackend) ProofSigner(
+	keyDesc keychain.KeyDescriptor) indexer.SchnorrSigner {
+
+	b.signerKeyDesc = keyDesc
+
+	return indexer.NewKeyRingSchnorrSigner(nil, keyDesc)
+}
+
+func TestIndexerProofKey(t *testing.T) {
+	t.Parallel()
+
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	loc := keychain.KeyLocator{
+		Family: keychain.KeyFamilyMultiSig,
+		Index:  7,
+	}
+	wantDesc := &keychain.KeyDescriptor{
+		KeyLocator: loc,
+		PubKey:     privKey.PubKey(),
+	}
+	backend := &stubProofKeyBackend{
+		deriveKeyResp: wantDesc,
+	}
+	server := &Server{
+		proofKeyBackend: backend,
+	}
+
+	gotDesc, signer, err := server.IndexerProofKey(t.Context(), loc)
+	require.NoError(t, err)
+	require.Equal(t, loc, backend.deriveKeyLoc)
+	require.Equal(t, wantDesc, gotDesc)
+	require.Equal(t, *wantDesc, backend.signerKeyDesc)
+
+	pubKeySource, ok := signer.(interface {
+		ProofPubKey([]byte) (*btcec.PublicKey, error)
+	})
+	require.True(t, ok)
+
+	pubKey, err := pubKeySource.ProofPubKey(nil)
+	require.NoError(t, err)
+	require.True(t, pubKey.IsEqual(privKey.PubKey()))
+}
+
+func TestIndexerProofNextKeyOps(t *testing.T) {
+	t.Parallel()
+
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	wantDesc := &keychain.KeyDescriptor{
+		KeyLocator: keychain.KeyLocator{
+			Family: keychain.KeyFamilyMultiSig,
+			Index:  11,
+		},
+		PubKey: privKey.PubKey(),
+	}
+	backend := &stubProofKeyBackend{
+		deriveNextKeyResp: wantDesc,
+	}
+	server := &Server{
+		proofKeyBackend: backend,
+	}
+
+	deriveNext, signerFactory, err := server.indexerProofNextKeyOps()
+	require.NoError(t, err)
+
+	gotDesc, err := deriveNext(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, keychain.KeyFamilyMultiSig, backend.deriveNextFamily)
+	require.Equal(t, wantDesc, gotDesc)
+
+	signer := signerFactory(*wantDesc)
+	require.Equal(t, *wantDesc, backend.signerKeyDesc)
+
+	pubKeySource, ok := signer.(interface {
+		ProofPubKey([]byte) (*btcec.PublicKey, error)
+	})
+	require.True(t, ok)
+
+	pubKey, err := pubKeySource.ProofPubKey(nil)
+	require.NoError(t, err)
+	require.True(t, pubKey.IsEqual(privKey.PubKey()))
+}

--- a/darepod/rpc_oor_receive.go
+++ b/darepod/rpc_oor_receive.go
@@ -8,9 +8,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/lightninglabs/darepo-client/db"
-	"github.com/lightninglabs/darepo-client/indexer"
 	"github.com/lightningnetwork/lnd/clock"
-	"github.com/lightningnetwork/lnd/keychain"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -113,56 +111,5 @@ func (r *RPCServer) newOORReceiveScriptStore() (
 func (r *RPCServer) oorReceiveKeyOps() (DeriveDefaultOORReceiveKeyFunc,
 	OORReceiveScriptSignerFactory, error) {
 
-	switch {
-	case r.server.lnd.IsSome():
-		lndSvc := r.server.lnd.UnsafeFromSome()
-
-		return func(ctx context.Context) (*keychain.KeyDescriptor, error) { //nolint:ll
-				keyDesc, err := lndSvc.WalletKit.DeriveNextKey(
-					ctx, int32(keychain.KeyFamilyMultiSig),
-				)
-				if err != nil {
-					return nil, fmt.Errorf("derive next key: %w", err) //nolint:ll
-				}
-
-				return keyDesc, nil
-			}, func(keyDesc keychain.KeyDescriptor) indexer.SchnorrSigner { //nolint:ll
-				return indexer.NewLNDSchnorrSigner(
-					lndSvc.Signer, keyDesc,
-				)
-			}, nil
-
-	case r.server.lwWallet.IsSome():
-		wallet := r.server.lwWallet.UnsafeFromSome()
-
-		return func(ctx context.Context) (*keychain.KeyDescriptor, error) { //nolint:ll
-				return wallet.DeriveNextKey(
-					ctx, keychain.KeyFamilyMultiSig,
-				)
-			}, func(
-				keyDesc keychain.KeyDescriptor) indexer.SchnorrSigner { //nolint:ll
-
-				return indexer.NewKeyRingSchnorrSigner(
-					wallet.KeyRing(), keyDesc,
-				)
-			}, nil
-
-	case r.server.btcwWallet.IsSome():
-		wallet := r.server.btcwWallet.UnsafeFromSome()
-
-		return func(ctx context.Context) (*keychain.KeyDescriptor, error) { //nolint:ll
-				return wallet.DeriveNextKey(
-					ctx, keychain.KeyFamilyMultiSig,
-				)
-			}, func(
-				keyDesc keychain.KeyDescriptor) indexer.SchnorrSigner { //nolint:ll
-
-				return indexer.NewKeyRingSchnorrSigner(
-					wallet.KeyRing(), keyDesc,
-				)
-			}, nil
-
-	default:
-		return nil, nil, fmt.Errorf("wallet backend not initialized")
-	}
+	return r.server.indexerProofNextKeyOps()
 }

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -36,6 +36,7 @@ import (
 	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
 	mailboxrpc "github.com/lightninglabs/darepo-client/mailbox/rpc"
 	"github.com/lightninglabs/darepo-client/oor"
+	"github.com/lightninglabs/darepo-client/proofkeys"
 	"github.com/lightninglabs/darepo-client/round"
 	"github.com/lightninglabs/darepo-client/rpc/oorpb"
 	"github.com/lightninglabs/darepo-client/rpc/roundpb"
@@ -194,6 +195,10 @@ type Server struct {
 	runtime *serverconn.Runtime
 	ark     *arkrpc.ArkServiceMailboxClient
 	indexer *indexer.Client
+
+	// proofKeyBackend derives wallet-managed keys and produces proof
+	// signers for daemon-owned receive scripts and indexer identity.
+	proofKeyBackend proofkeys.Backend
 
 	actorSystem  *actor.ActorSystem
 	chainBackend chainsource.ChainBackend
@@ -681,6 +686,7 @@ func (s *Server) initLndBackend(ctx context.Context) error {
 		return fmt.Errorf("unable to connect to lnd: %w", err)
 	}
 	s.lnd = fn.Some(lndServices)
+	s.refreshProofKeyBackend()
 
 	// Use lnd's chain params as the authoritative source.
 	s.chainParams = lndServices.ChainParams
@@ -693,6 +699,39 @@ func (s *Server) initLndBackend(ctx context.Context) error {
 	s.markWalletReady()
 
 	return nil
+}
+
+// refreshProofKeyBackend resolves the active wallet backend to the shared
+// proof-key capability used by daemon-owned receive scripts and indexer proof
+// generation.
+func (s *Server) refreshProofKeyBackend() {
+	switch s.cfg.Wallet.Type {
+	case WalletTypeLnd:
+		if s.lnd.IsSome() {
+			lndSvc := s.lnd.UnsafeFromSome()
+			s.proofKeyBackend = lndbackend.NewProofKeyBackend(
+				lndSvc.WalletKit, lndSvc.Signer,
+			)
+
+			return
+		}
+
+	case WalletTypeLwwallet:
+		if s.lwWallet.IsSome() {
+			s.proofKeyBackend = s.lwWallet.UnsafeFromSome()
+
+			return
+		}
+
+	case WalletTypeBtcwallet:
+		if s.btcwWallet.IsSome() {
+			s.proofKeyBackend = s.btcwWallet.UnsafeFromSome()
+
+			return
+		}
+	}
+
+	s.proofKeyBackend = nil
 }
 
 // tryAutoUnlockLwwallet attempts to initialize the lwwallet backend
@@ -836,6 +875,7 @@ func (s *Server) startLwwallet(ctx context.Context,
 	}
 
 	s.lwWallet = fn.Some(w)
+	s.refreshProofKeyBackend()
 
 	// Refresh the RPC clients once the wallet is available so the
 	// indexer client picks up the wallet-backed identity key and signer
@@ -1068,6 +1108,7 @@ func (s *Server) startBtcwallet(ctx context.Context,
 	}
 
 	s.btcwWallet = fn.Some(w)
+	s.refreshProofKeyBackend()
 
 	// Initialize the chain backend if it was deferred at startup
 	// because the wallet was not yet available.
@@ -2113,9 +2154,13 @@ func (s *Server) initRPCClients(ctx context.Context) {
 	// correct wallet key from the persisted owned-script map for each
 	// pkScript.
 	var signer indexer.SchnorrSigner
-	s.lnd.WhenSome(func(lndSvc *lndclient.GrpcLndServices) {
-		identityDesc, err := lndSvc.WalletKit.DeriveKey(ctx,
-			&keychain.KeyLocator{
+	signerFactory, err := s.indexerProofSignerFactory()
+	if err != nil {
+		s.log.WarnS(ctx,
+			"Unable to initialize indexer signer factory", err)
+	} else {
+		identityDesc, _, err := s.IndexerProofKey(
+			ctx, keychain.KeyLocator{
 				Family: identityKeyFamily,
 				Index:  0,
 			},
@@ -2123,65 +2168,13 @@ func (s *Server) initRPCClients(ctx context.Context) {
 		if err != nil {
 			s.log.WarnS(ctx,
 				"Unable to derive identity key for indexer", err)
-
-			return
-		}
-
-		s.clientKeyDesc = *identityDesc
-		signer = NewOwnedReceiveScriptSigner(
-			packageStore,
-			func(keyDesc keychain.KeyDescriptor) indexer.SchnorrSigner { //nolint:ll
-				return indexer.NewLNDSchnorrSigner(
-					lndSvc.Signer, keyDesc,
-				)
-			},
-		)
-	})
-	s.lwWallet.WhenSome(func(w *lwwallet.Wallet) {
-		// Derive the node identity key from the wallet
-		// keyring. This is safe even if the wallet isn't
-		// fully synced, as it only depends on the seed.
-		identityDesc, err := w.DeriveKey(ctx, keychain.KeyLocator{
-			Family: identityKeyFamily,
-			Index:  0,
-		})
-		if err != nil {
-			s.log.WarnS(ctx,
-				"Unable to derive identity key for "+
-					"indexer", err)
 		} else {
 			s.clientKeyDesc = *identityDesc
 			signer = NewOwnedReceiveScriptSigner(
-				packageStore,
-				func(keyDesc keychain.KeyDescriptor) indexer.SchnorrSigner { //nolint:ll
-					return indexer.NewKeyRingSchnorrSigner(
-						w.KeyRing(), keyDesc,
-					)
-				},
+				packageStore, signerFactory,
 			)
 		}
-	})
-	s.btcwWallet.WhenSome(func(w *btcwbackend.Wallet) {
-		identityDesc, err := w.DeriveKey(ctx, keychain.KeyLocator{
-			Family: identityKeyFamily,
-			Index:  0,
-		})
-		if err != nil {
-			s.log.WarnS(ctx,
-				"Unable to derive identity key for "+
-					"indexer", err)
-		} else {
-			s.clientKeyDesc = *identityDesc
-			signer = NewOwnedReceiveScriptSigner(
-				packageStore,
-				func(keyDesc keychain.KeyDescriptor) indexer.SchnorrSigner { //nolint:ll
-					return indexer.NewKeyRingSchnorrSigner(
-						w.KeyRing(), keyDesc,
-					)
-				},
-			)
-		}
-	})
+	}
 
 	s.indexer = indexer.New(
 		s.runtime.Unary(), signer,

--- a/lndbackend/proof_keys.go
+++ b/lndbackend/proof_keys.go
@@ -1,0 +1,61 @@
+package lndbackend
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/lightninglabs/darepo-client/indexer"
+	"github.com/lightninglabs/darepo-client/proofkeys"
+	"github.com/lightninglabs/lndclient"
+	"github.com/lightningnetwork/lnd/keychain"
+)
+
+// ProofKeyBackend adapts lnd's wallet and signer RPCs to the shared proof key
+// capability used by darepod.
+type ProofKeyBackend struct {
+	walletKit lndclient.WalletKitClient
+	signer    lndclient.SignerClient
+}
+
+// NewProofKeyBackend creates a proof-key backend backed by lnd RPCs.
+func NewProofKeyBackend(walletKit lndclient.WalletKitClient,
+	signer lndclient.SignerClient) *ProofKeyBackend {
+
+	return &ProofKeyBackend{
+		walletKit: walletKit,
+		signer:    signer,
+	}
+}
+
+// DeriveKey returns the stable key identified by loc via WalletKit.
+func (b *ProofKeyBackend) DeriveKey(ctx context.Context,
+	loc keychain.KeyLocator) (*keychain.KeyDescriptor, error) {
+
+	keyDesc, err := b.walletKit.DeriveKey(ctx, &loc)
+	if err != nil {
+		return nil, fmt.Errorf("derive key: %w", err)
+	}
+
+	return keyDesc, nil
+}
+
+// DeriveNextKey derives the next key in family via WalletKit.
+func (b *ProofKeyBackend) DeriveNextKey(ctx context.Context,
+	family keychain.KeyFamily) (*keychain.KeyDescriptor, error) {
+
+	keyDesc, err := b.walletKit.DeriveNextKey(ctx, int32(family))
+	if err != nil {
+		return nil, fmt.Errorf("derive next key: %w", err)
+	}
+
+	return keyDesc, nil
+}
+
+// ProofSigner returns an lnd-backed indexer proof signer for keyDesc.
+func (b *ProofKeyBackend) ProofSigner(
+	keyDesc keychain.KeyDescriptor) indexer.SchnorrSigner {
+
+	return indexer.NewLNDSchnorrSigner(b.signer, keyDesc)
+}
+
+var _ proofkeys.Backend = (*ProofKeyBackend)(nil)

--- a/proofkeys/backend.go
+++ b/proofkeys/backend.go
@@ -1,0 +1,25 @@
+package proofkeys
+
+import (
+	"context"
+
+	"github.com/lightninglabs/darepo-client/indexer"
+	"github.com/lightningnetwork/lnd/keychain"
+)
+
+// Backend exposes the wallet-managed key operations needed for daemon-owned
+// receive scripts and indexer proof generation across wallet backends.
+type Backend interface {
+	// DeriveKey returns the stable key identified by loc.
+	DeriveKey(context.Context, keychain.KeyLocator) (
+		*keychain.KeyDescriptor, error,
+	)
+
+	// DeriveNextKey returns the next key in the given family.
+	DeriveNextKey(context.Context, keychain.KeyFamily) (
+		*keychain.KeyDescriptor, error,
+	)
+
+	// ProofSigner returns a signer bound to keyDesc for indexer proofs.
+	ProofSigner(keychain.KeyDescriptor) indexer.SchnorrSigner
+}

--- a/walletcore/wallet.go
+++ b/walletcore/wallet.go
@@ -9,6 +9,8 @@ import (
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/build"
+	"github.com/lightninglabs/darepo-client/indexer"
+	"github.com/lightninglabs/darepo-client/proofkeys"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
@@ -80,6 +82,14 @@ func (w *Wallet) DeriveKey(_ context.Context,
 	return &desc, nil
 }
 
+// ProofSigner returns an indexer proof signer bound to keyDesc using the
+// wallet's local secret key ring.
+func (w *Wallet) ProofSigner(
+	keyDesc keychain.KeyDescriptor) indexer.SchnorrSigner {
+
+	return indexer.NewKeyRingSchnorrSigner(w.KeyRing, keyDesc)
+}
+
 // NewAddress generates a new BIP86 taproot receiving address (P2TR
 // key-path only) via btcwallet.
 func (w *Wallet) NewAddress(
@@ -98,6 +108,8 @@ func (w *Wallet) NewAddress(
 
 	return addr, nil
 }
+
+var _ proofkeys.Backend = (*Wallet)(nil)
 
 // Balance returns the confirmed and unconfirmed balance across all
 // wallet-managed addresses. Confirmed balance requires at least 1


### PR DESCRIPTION
## Summary

This PR makes darepod expose the same proof-key semantics for every
supported wallet backend instead of leaving downstream callers on an effectively LND-only path.

After this change, darepod can derive proof-capable keys and build the
matching indexer proof signers uniformly for:

- `lnd`
- `lwwallet`
- `btcwallet`

The design intentionally moves the semantics to the backend layer rather
than adding another backend-selection helper inside `darepod`.

## Why

Downstream harness and integration code needs a stable wallet key plus the
matching indexer proof signer for a real daemon. Before this PR, that was
not modeled as a shared daemon capability. In practice, callers either had
to reach into `WalletKit` directly or duplicate wallet-type selection logic
around the daemon, which made the path effectively LND-specific.

A smaller `darepod` helper would have fixed the immediate symptom, but it
would also have kept backend-specific derivation and signer wiring in the
daemon layer. Instead, this PR establishes one semantic backend capability
and has `darepod` consume that capability.

## Design

### 1. Added a shared proof-key capability

`proofkeys.Backend` captures the three operations the daemon actually needs:

- derive a fixed key by locator
- derive the next key in a family
- produce an indexer proof signer for a chosen descriptor

`walletcore.Wallet` now satisfies that capability for local wallets by
reusing its existing derivation methods and local key ring. LND gets a
dedicated adapter in `lndbackend` backed by `WalletKit` and signrpc.

This gives us one shared contract across backends without forcing them to
pretend they expose the same low-level internals.

### 2. Reworked darepod to consume the capability

`darepod.Server` now resolves one active `proofKeyBackend` when the
configured wallet backend becomes available. The indexer identity path and
the OOR receive-script path both delegate through that shared backend
instead of each carrying their own wallet-type switch.

That makes `darepod/indexer_proof_keyops.go` a thin wrapper around the
semantic backend rather than the place where backend selection happens.

### 3. Updated tests around the new boundary

The focused unit test now stubs the semantic proof-key backend instead of
the old `darepod`-local adapter internals. That keeps the test aligned with
the architecture we want to preserve.

## Review Guide

The stack is easiest to review in order:

1. `3527f13` `proofkeys: add backend capability`
2. `60d020a` `darepod: use shared proof key backend`

The first commit introduces the cross-backend contract. The second shows
how `darepod` gets simpler once it can depend on that contract.

## Validation

I ran:

- `go test ./darepod ./indexer ./walletcore ./lndbackend ./lwwallet ./btcwbackend ./proofkeys`
- `make lint-source-local`
- `./scripts/commit_message.py lint --range origin/main..HEAD`

## Scope

This PR makes the daemon-side proof-key path work uniformly for all
supported wallet backends. A matching downstream harness change can then
consume that path end to end.
