### PR TITLE
oor+round: fix checkpoint anchors and persisted client tree sigs

### DIFF
--- a/lib/tx/checkpoint/build.go
+++ b/lib/tx/checkpoint/build.go
@@ -58,8 +58,9 @@ type Result struct {
 	TapTreeEncoded []byte
 }
 
-// BuildPSBT constructs an unsigned checkpoint PSBT that spends a VTXO input and
-// pays the entire input value to a checkpoint P2TR output.
+// BuildPSBT constructs an unsigned checkpoint PSBT that spends a VTXO input,
+// pays the entire input value to a checkpoint P2TR output, and appends a
+// zero-value anchor output.
 //
 // The checkpoint output pkScript is derived deterministically from:
 //
@@ -119,6 +120,7 @@ func BuildPSBT(policy scripts.CheckpointPolicy, in Input) (*Result, error) {
 		Value:    in.SpentVTXO.Output.Value,
 		PkScript: checkpointPkScript,
 	})
+	tx.AddTxOut(scripts.AnchorOutput())
 
 	pkt, err := psbt.NewFromUnsignedTx(tx)
 	if err != nil {

--- a/lib/tx/checkpoint/build_test.go
+++ b/lib/tx/checkpoint/build_test.go
@@ -68,8 +68,9 @@ func TestBuildPSBTHappyPath(t *testing.T) {
 	require.Equal(t, int32(arktx.TxVersion), tx.Version)
 	require.Len(t, tx.TxIn, 1)
 	require.Equal(t, in.SpentVTXO.Outpoint, tx.TxIn[0].PreviousOutPoint)
-	require.Len(t, tx.TxOut, 1)
+	require.Len(t, tx.TxOut, 2)
 	require.Equal(t, witnessUtxo.Value, tx.TxOut[0].Value)
+	require.True(t, arktx.IsAnchorOutput(tx.TxOut[1]))
 
 	expectedPkScript, err := scripts.CheckpointPkScript(
 		policy, in.OwnerLeafScript,

--- a/lib/tx/oor/build.go
+++ b/lib/tx/oor/build.go
@@ -46,10 +46,8 @@ func (a *CheckpointArtifact) ToCheckpointOutput() (CheckpointOutput, error) {
 		)
 	}
 
-	if len(a.PSBT.UnsignedTx.TxOut) == 0 {
-		return CheckpointOutput{}, fmt.Errorf(
-			"checkpoint output must be provided",
-		)
+	if err := validateCheckpointTx(a.PSBT.UnsignedTx); err != nil {
+		return CheckpointOutput{}, err
 	}
 
 	return CheckpointOutput{
@@ -68,8 +66,9 @@ type RecipientOutput struct {
 	Value btcutil.Amount
 }
 
-// BuildCheckpointPSBT constructs an unsigned checkpoint PSBT that spends a VTXO
-// input and pays the entire input value to a checkpoint P2TR output.
+// BuildCheckpointPSBT constructs an unsigned checkpoint PSBT that spends a
+// VTXO input, pays the entire input value to a checkpoint P2TR output, and
+// appends a zero-value anchor output.
 //
 // The checkpoint output pkScript is derived deterministically from:
 //

--- a/lib/tx/oor/build_test.go
+++ b/lib/tx/oor/build_test.go
@@ -70,7 +70,11 @@ func TestBuildCheckpointAndArkPSBT(t *testing.T) {
 
 	checkpointTx := cpResult.PSBT.UnsignedTx
 	require.NotNil(t, checkpointTx)
-	require.Len(t, checkpointTx.TxOut, 1)
+	require.Len(t, checkpointTx.TxOut, 2)
+	require.Equal(t, scripts.AnchorOutput().Value,
+		checkpointTx.TxOut[1].Value)
+	require.Equal(t, scripts.AnchorOutput().PkScript,
+		checkpointTx.TxOut[1].PkScript)
 
 	arkPsbt, err := BuildArkPSBT([]CheckpointOutput{
 		{

--- a/lib/tx/oor/checkpoint_validate.go
+++ b/lib/tx/oor/checkpoint_validate.go
@@ -1,0 +1,54 @@
+package oor
+
+import (
+	"fmt"
+
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/tx/arktx"
+)
+
+// validateCheckpointTx enforces the shared v0 checkpoint tx shape:
+// output 0 is the spendable checkpoint output and the unique anchor output is
+// last.
+func validateCheckpointTx(tx *wire.MsgTx) error {
+	if tx == nil {
+		return fmt.Errorf("checkpoint tx must be provided")
+	}
+
+	if len(tx.TxOut) == 0 {
+		return fmt.Errorf("checkpoint tx has no outputs")
+	}
+
+	anchorCount := 0
+	anchorIndex := -1
+	for i, out := range tx.TxOut {
+		if !arktx.IsAnchorOutput(out) {
+			continue
+		}
+
+		anchorCount++
+		anchorIndex = i
+	}
+
+	if anchorCount != 1 {
+		return fmt.Errorf("checkpoint tx must have exactly "+
+			"one anchor output, got %d", anchorCount)
+	}
+
+	if len(tx.TxOut) < 2 {
+		return fmt.Errorf("checkpoint tx must have at least " +
+			"two outputs")
+	}
+
+	if arktx.IsAnchorOutput(tx.TxOut[0]) {
+		return fmt.Errorf("checkpoint tx output 0 cannot " +
+			"be an anchor output")
+	}
+
+	if anchorIndex != len(tx.TxOut)-1 {
+		return fmt.Errorf("checkpoint tx anchor must be " +
+			"the last output")
+	}
+
+	return nil
+}

--- a/lib/tx/oor/doc.go
+++ b/lib/tx/oor/doc.go
@@ -9,6 +9,8 @@ package oor
 // - PSBT is used as the transport and storage envelope.
 // - Output ordering follows BIP69 ordering (amount, then pkScript) for
 //   recipient outputs.
+// - Checkpoint txs use output 0 as the spendable output and place their
+//   anchor output last.
 // - The Ark anchor output is always last.
 //
 // The submit flow builds a package containing the Ark PSBT plus one or more

--- a/lib/tx/oor/finalize.go
+++ b/lib/tx/oor/finalize.go
@@ -46,10 +46,6 @@ func ApplyFinalizeData(ark *psbt.Packet,
 				"unsigned tx")
 		}
 
-		if len(checkpoint.UnsignedTx.TxOut) == 0 {
-			return fmt.Errorf("checkpoint tx has no outputs")
-		}
-
 		if len(checkpoint.Outputs) != len(checkpoint.UnsignedTx.TxOut) {
 			return fmt.Errorf("checkpoint psbt output count " +
 				"mismatch")
@@ -60,6 +56,13 @@ func ApplyFinalizeData(ark *psbt.Packet,
 		}
 
 		checkpointTxid := checkpoint.UnsignedTx.TxHash()
+		if err := validateCheckpointTx(
+			checkpoint.UnsignedTx,
+		); err != nil {
+			return fmt.Errorf("checkpoint %s invalid: %w",
+				checkpointTxid, err)
+		}
+
 		outpoint := wire.OutPoint{
 			Hash:  checkpointTxid,
 			Index: 0,

--- a/lib/tx/oor/finalize_test.go
+++ b/lib/tx/oor/finalize_test.go
@@ -27,6 +27,7 @@ func TestApplyFinalizeDataAttachesTapTree(t *testing.T) {
 		Value:    1234,
 		PkScript: []byte{0x51},
 	})
+	checkpointTx.AddTxOut(scripts.AnchorOutput())
 
 	checkpointPsbt, err := psbt.NewFromUnsignedTx(checkpointTx)
 	require.NoError(t, err)
@@ -81,6 +82,7 @@ func TestApplyFinalizeDataMissingTapTree(t *testing.T) {
 		Value:    1234,
 		PkScript: []byte{0x51},
 	})
+	checkpointTx.AddTxOut(scripts.AnchorOutput())
 
 	checkpointPsbt, err := psbt.NewFromUnsignedTx(checkpointTx)
 	require.NoError(t, err)
@@ -123,6 +125,7 @@ func TestApplyFinalizeDataMappingMismatch(t *testing.T) {
 		Value:    1234,
 		PkScript: []byte{0x51},
 	})
+	checkpointTx.AddTxOut(scripts.AnchorOutput())
 
 	checkpointPsbt, err := psbt.NewFromUnsignedTx(checkpointTx)
 	require.NoError(t, err)

--- a/lib/tx/oor/finalize_validate.go
+++ b/lib/tx/oor/finalize_validate.go
@@ -63,6 +63,13 @@ func ValidateFinalizePackage(ark *psbt.Packet,
 				txid)
 		}
 
+		if err := validateCheckpointTx(
+			checkpoint.UnsignedTx,
+		); err != nil {
+			return fmt.Errorf("checkpoint %s invalid: %w", txid,
+				err)
+		}
+
 		if len(checkpoint.Inputs) != len(checkpoint.UnsignedTx.TxIn) {
 			return fmt.Errorf("checkpoint psbt input count " +
 				"mismatch")

--- a/lib/tx/oor/finalize_validate_test.go
+++ b/lib/tx/oor/finalize_validate_test.go
@@ -32,6 +32,7 @@ func TestValidateFinalizePackageHappyPath(t *testing.T) {
 		Value:    1234,
 		PkScript: []byte{0x51},
 	})
+	checkpointTx.AddTxOut(scripts.AnchorOutput())
 
 	checkpointPsbt, err := psbt.NewFromUnsignedTx(checkpointTx)
 	require.NoError(t, err)
@@ -75,6 +76,7 @@ func TestValidateFinalizePackageMissingSig(t *testing.T) {
 		Value:    1234,
 		PkScript: []byte{0x51},
 	})
+	checkpointTx.AddTxOut(scripts.AnchorOutput())
 
 	checkpointPsbt, err := psbt.NewFromUnsignedTx(checkpointTx)
 	require.NoError(t, err)
@@ -115,6 +117,7 @@ func TestValidateFinalizePackageExtraCheckpoint(t *testing.T) {
 		Value:    1234,
 		PkScript: []byte{0x51},
 	})
+	checkpointTxA.AddTxOut(scripts.AnchorOutput())
 
 	checkpointPsbtA, err := psbt.NewFromUnsignedTx(checkpointTxA)
 	require.NoError(t, err)
@@ -131,6 +134,7 @@ func TestValidateFinalizePackageExtraCheckpoint(t *testing.T) {
 		Value:    1234,
 		PkScript: []byte{0x51},
 	})
+	checkpointTxB.AddTxOut(scripts.AnchorOutput())
 
 	checkpointPsbtB, err := psbt.NewFromUnsignedTx(checkpointTxB)
 	require.NoError(t, err)

--- a/lib/tx/oor/package_test.go
+++ b/lib/tx/oor/package_test.go
@@ -17,6 +17,7 @@ func TestSubmitPackageMarshalRoundTrip(t *testing.T) {
 	checkpointTx := wire.NewMsgTx(3)
 	checkpointTx.AddTxIn(&wire.TxIn{})
 	checkpointTx.AddTxOut(&wire.TxOut{Value: 5, PkScript: []byte{0x51}})
+	checkpointTx.AddTxOut(scripts.AnchorOutput())
 	checkpointPSBT, err := psbt.NewFromUnsignedTx(checkpointTx)
 	require.NoError(t, err)
 
@@ -58,6 +59,7 @@ func TestSubmitPackageUnmarshalRejectsMalformedTrailingBytes(t *testing.T) {
 	checkpointTx := wire.NewMsgTx(3)
 	checkpointTx.AddTxIn(&wire.TxIn{})
 	checkpointTx.AddTxOut(&wire.TxOut{Value: 5, PkScript: []byte{0x51}})
+	checkpointTx.AddTxOut(scripts.AnchorOutput())
 	checkpointPSBT, err := psbt.NewFromUnsignedTx(checkpointTx)
 	require.NoError(t, err)
 

--- a/lib/tx/oor/submit.go
+++ b/lib/tx/oor/submit.go
@@ -83,8 +83,11 @@ func ValidateSubmitPackage(ark *psbt.Packet,
 				checkpointTxid)
 		}
 
-		if len(checkpoint.UnsignedTx.TxOut) == 0 {
-			return nil, fmt.Errorf("checkpoint tx has no outputs")
+		if err := validateCheckpointTx(
+			checkpoint.UnsignedTx,
+		); err != nil {
+			return nil, fmt.Errorf("checkpoint %s invalid: %w",
+				checkpointTxid, err)
 		}
 
 		checkpointByTxid[checkpointTxid] = checkpoint

--- a/lib/tx/oor/submit_test.go
+++ b/lib/tx/oor/submit_test.go
@@ -28,6 +28,7 @@ func TestValidateSubmitPackageHappyPath(t *testing.T) {
 		PkScript: []byte{0x51},
 	}
 	checkpointTx.AddTxOut(checkpointOut)
+	checkpointTx.AddTxOut(scripts.AnchorOutput())
 
 	checkpointPsbt, err := psbt.NewFromUnsignedTx(checkpointTx)
 	require.NoError(t, err)
@@ -83,6 +84,7 @@ func TestValidateSubmitPackageMissingWitness(t *testing.T) {
 		Value:    1234,
 		PkScript: []byte{0x51},
 	})
+	checkpointTx.AddTxOut(scripts.AnchorOutput())
 
 	checkpointPsbt, err := psbt.NewFromUnsignedTx(checkpointTx)
 	require.NoError(t, err)
@@ -130,6 +132,7 @@ func TestValidateSubmitPackageExtraCheckpoint(t *testing.T) {
 		PkScript: []byte{0x51},
 	}
 	checkpointTxA.AddTxOut(checkpointOutA)
+	checkpointTxA.AddTxOut(scripts.AnchorOutput())
 
 	checkpointPsbtA, err := psbt.NewFromUnsignedTx(checkpointTxA)
 	require.NoError(t, err)
@@ -145,6 +148,7 @@ func TestValidateSubmitPackageExtraCheckpoint(t *testing.T) {
 		Value:    1234,
 		PkScript: []byte{0x51},
 	})
+	checkpointTxB.AddTxOut(scripts.AnchorOutput())
 
 	checkpointPsbtB, err := psbt.NewFromUnsignedTx(checkpointTxB)
 	require.NoError(t, err)
@@ -178,4 +182,56 @@ func TestValidateSubmitPackageExtraCheckpoint(t *testing.T) {
 		checkpointPsbtB,
 	})
 	require.Error(t, err)
+}
+
+// TestValidateSubmitPackageRejectsCheckpointWithoutAnchor asserts old-style
+// anchorless checkpoints fail with a clear structural error.
+func TestValidateSubmitPackageRejectsCheckpointWithoutAnchor(t *testing.T) {
+	t.Parallel()
+
+	checkpointTx := wire.NewMsgTx(3)
+	checkpointTx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{
+			Hash:  chainhash.Hash{1},
+			Index: 7,
+		},
+	})
+
+	checkpointOut := &wire.TxOut{
+		Value:    1234,
+		PkScript: []byte{0x51},
+	}
+	checkpointTx.AddTxOut(checkpointOut)
+
+	checkpointPsbt, err := psbt.NewFromUnsignedTx(checkpointTx)
+	require.NoError(t, err)
+
+	arkTx := wire.NewMsgTx(3)
+	arkTx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{
+			Hash:  checkpointTx.TxHash(),
+			Index: 0,
+		},
+	})
+	arkTx.AddTxOut(&wire.TxOut{
+		Value:    1234,
+		PkScript: []byte{0x6a, 0x01, 0x01},
+	})
+	arkTx.AddTxOut(scripts.AnchorOutput())
+
+	arkPsbt, err := psbt.NewFromUnsignedTx(arkTx)
+	require.NoError(t, err)
+
+	arkPsbt.Inputs[0].WitnessUtxo = checkpointOut
+
+	encodedTapTree, err := EncodeTapTree([][]byte{{0x51}})
+	require.NoError(t, err)
+
+	err = PutTapTreePSBTInput(arkPsbt, 0, encodedTapTree)
+	require.NoError(t, err)
+
+	_, err = ValidateSubmitPackage(
+		arkPsbt, []*psbt.Packet{checkpointPsbt},
+	)
+	require.ErrorContains(t, err, "anchor output")
 }

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -1442,6 +1442,36 @@ func (s *PartialSigsSentState) ProcessEvent(
 			}
 		}
 
+		// Propagate validated signatures to client sub-trees.
+		// ClientTrees were extracted before signing (in
+		// CommitmentTxReceivedState) via ExtractPathForCoSigners
+		// which creates new node objects. Those copies don't have
+		// the aggregated signatures that were just submitted to
+		// VTXOTreePaths. We submit the same signatures to ensure
+		// persisted client trees contain valid signatures for
+		// unilateral exit (unrolling).
+		for _, clientTree := range s.ClientTrees {
+			if err := clientTree.SubmitTreeSigs(
+				evt.AggSigs,
+			); err != nil {
+				return failWithNotification(
+					"failed to propagate sigs "+
+						"to client tree",
+					err, false,
+					fn.Some(s.RoundID),
+				), nil
+			}
+
+			if err := clientTree.VerifySigned(); err != nil {
+				return failWithNotification(
+					"client tree sig "+
+						"verification failed",
+					err, false,
+					fn.Some(s.RoundID),
+				), nil
+			}
+		}
+
 		env.Log.InfoS(ctx, "Validated aggregated signatures",
 			slog.String("round_id", s.RoundID.String()),
 			slog.Int("forfeit_mapping_count", len(s.ForfeitMappings)))

--- a/round/transitions_test.go
+++ b/round/transitions_test.go
@@ -1223,6 +1223,84 @@ func TestPartialSigsSentState(t *testing.T) {
 		h.assertOutboxContainsType("*round.RegisterConfirmationRequest")
 	})
 
+	t.Run("OperatorSigned_propagates_sigs_to_extracted_client_tree",
+		func(t *testing.T) {
+			t.Parallel()
+
+			h := newRealSigningTestHarness(t)
+
+			intent := h.newTestBoardingIntentWithTapscript()
+			vtxoReq := h.newTestVTXORequestForIntent(intent)
+			vtxtTree := h.newTestVTXOTreeForIntents(
+				[]VTXOIntent{vtxoReq},
+			)
+
+			validSigs, err := h.generateValidTreeSignatures(
+				vtxtTree,
+			)
+			require.NoError(t, err)
+			require.NotEmpty(t, validSigs)
+
+			commitmentTx := h.newCommitmentTxForIntents(
+				[]BoardingIntent{intent}, vtxtTree,
+			)
+
+			roundVTXOReqs := h.wrapVTXOIntents(
+				[]VTXOIntent{vtxoReq},
+			)
+			signerKey := NewSignerKey(
+				roundVTXOReqs[0].SigningKey.PubKey,
+			)
+
+			clientTree, err := vtxtTree.ExtractPathForCoSigners(
+				roundVTXOReqs[0].SigningKey.PubKey,
+			)
+			require.NoError(t, err)
+			require.NotNil(t, clientTree)
+			require.Error(t, clientTree.VerifySigned())
+
+			state := &PartialSigsSentState{
+				RoundID: testRoundIDTr(
+					"round-client-tree-sigs",
+				),
+				CommitmentTx:  commitmentTx,
+				VTXOTreePaths: map[int]*tree.Tree{0: vtxtTree},
+				Intents: Intents{
+					Boarding: []BoardingIntent{intent},
+					VTXOs:    roundVTXOReqs,
+				},
+				ClientTrees: map[SignerKey]*tree.Tree{
+					signerKey: clientTree,
+				},
+				BoardingInputIndices: map[wire.OutPoint]int{
+					intent.Outpoint: 0,
+				},
+				Musig2Sessions: make(
+					map[SignerKey]*tree.SignerSession,
+				),
+			}
+
+			h.setupMockWalletForBoardingSigning()
+			h.setupMockRoundStoreForCommit()
+			h.withState(state)
+
+			event := &OperatorSigned{
+				RoundID: testRoundIDTr(
+					"round-client-tree-sigs",
+				),
+				AggSigs: validSigs,
+			}
+
+			transition, err := h.sendEvent(event)
+			require.NoError(t, err)
+			require.NotNil(t, transition)
+
+			assertStateType[*InputSigSentState](
+				h.boardingTestHarness,
+			)
+			require.NoError(t, clientTree.VerifySigned())
+		})
+
 	t.Run("OperatorSigned_starts_forfeit_timeout", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
## Summary

This PR pulls out two low-risk bug fixes that are needed for the unrolling
work, but are both fixes to behavior that is already wrong on `main` today.

It does two things:

- ensure OOR checkpoint transactions always include a valid anchor output and
  reject malformed checkpoint artifacts early
- propagate aggregated round signatures to extracted `ClientTrees` so the
  client-side trees that get persisted for unilateral exit are actually signed

## Root Cause

There were two separate bugs.

First, OOR checkpoint construction and validation were too permissive. That let
anchorless or malformed checkpoint artifacts exist, even though downstream OOR
and unrolling logic depends on the checkpoint anchor invariant.

Second, the round flow validated aggregated signatures on `VTXOTreePaths`, but
`ClientTrees` are extracted copies created earlier via
`ExtractPathForCoSigners`. Those copied trees never received the aggregated
signatures, so persisted client trees could remain unsigned even after the
round completed successfully.

## What Changed

### Checkpoint anchor fix

- make checkpoint builders always include the expected anchor output
- add checkpoint validation helpers for OOR package build/finalize/submit paths
- add unit coverage for anchorless checkpoint rejection and anchor invariants

### Client tree signature propagation fix

- after validating aggregated signatures on the main VTXO tree paths, submit
  the same signatures to the extracted `ClientTrees`
- verify those client trees are signed before progressing
- add a focused regression test that uses a real extracted client tree copy,
  which is the case that previously lost signatures

## Why This Is Needed For Unrolling

Unrolling depends on the client having a valid, signed recovery path.

- checkpoint artifacts need anchors so they are structurally valid and can be
  handled consistently by OOR/unrolling code
- persisted client trees need the aggregated signatures so unilateral-exit
  recovery transactions are actually broadcastable

These fixes are intentionally separated from the larger unrolling feature work
so they can land as standalone bug-fix PRs.

## Validation

- `go test ./round ./lib/tx/checkpoint ./lib/tx/oor`
