### PR TITLE
docs: full doc-gardening sweep across all packages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,6 @@ Body wrapped at 72 characters. Explain WHY, not just WHAT.
 
 - Prefix with package name (`db:`, `rpc:`, `multi:` for multiple).
 - Small, atomic commits. Separate bug fixes, refactors, and features.
-- Sign with GPG: `git commit -S -F /path/to/message.txt`
 - Tooling: [`docs/commit-tooling.md`](docs/commit-tooling.md)
 
 ## Critical Rules
@@ -80,6 +79,7 @@ Body wrapped at 72 characters. Explain WHY, not just WHAT.
 - [`docs/commit-tooling.md`](docs/commit-tooling.md) — commit_message.py workflows
 - [`docs/daemon_cli_guide.md`](docs/daemon_cli_guide.md) — darepod/darepocli setup and CLI reference
 - [`docs/go_workspace.md`](docs/go_workspace.md) — Multi-module Go workspace setup
+- [`docs/policy_arkscript_review_guide.md`](docs/policy_arkscript_review_guide.md) — Policy-first arkscript reviewer guide
 
 ### Per-Package Context
 Each major package contains a `CLAUDE.md`/`AGENTS.md` with purpose, key types,

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -18,6 +18,13 @@ package may import from a higher layer.
 | [`oor`](oor/) | Out-of-round transfer coordination FSM |
 | [`wallet`](wallet/) | On-chain boarding wallet actor (address derivation, UTXO monitoring) |
 | [`lib`](lib/) | Shared domain utilities: tree paths, BIP-322, tapscripts, types |
+| [`lib/arkscript`](lib/arkscript/) | Tapscript AST compiler and policy system for Ark taproot outputs |
+| [`lib/bip322`](lib/bip322/) | BIP-322 intent-bound message authentication |
+| [`lib/scripts`](lib/scripts/) | Low-level Bitcoin script construction for VTXO and checkpoint outputs |
+| [`lib/tx/arktx`](lib/tx/arktx/) | Canonical Ark transaction ordering and validation |
+| [`lib/tx/checkpoint`](lib/tx/checkpoint/) | Checkpoint PSBT construction for OOR transfers |
+| [`lib/tx/oor`](lib/tx/oor/) | OOR submit/finalize package builders and validators |
+| [`lib/tx/psbtutil`](lib/tx/psbtutil/) | PSBT encoding, decoding, and signature attachment helpers |
 
 ### Layer 2: Infrastructure (Chain, Storage, Messaging)
 
@@ -31,6 +38,7 @@ package may import from a higher layer.
 | [`lwwallet`](lwwallet/) | Lightweight in-process wallet (btcwallet + Esplora, no external LND) |
 | [`btcwbackend`](btcwbackend/) | Neutrino-backed wallet backend (btcwallet + compact block filters) |
 | [`walletcore`](walletcore/) | Shared wallet abstractions and boarding logic used by lwwallet and btcwbackend |
+| [`proofkeys`](proofkeys/) | Interface for wallet-managed key derivation and indexer proof signing |
 | [`db`](db/) | SQLite/PostgreSQL persistence: boarding, rounds, VTXOs, OOR artifacts |
 | [`mailbox`](mailbox/) | Mailbox protocol primitives across three sub-packages (pb, rpc, conn) |
 | [`serverconn`](serverconn/) | Unified server connector: durable egress, ingress polling, unary RPC facade |
@@ -77,10 +85,13 @@ darepod (orchestrator)
 │   ├── chainsource │ (UTXO confirmation monitoring)
 │   └── db          │ (boarding store)
 ├── oor             │
-│   └── db          │ (oor artifact store)
+│   ├── db          │ (oor artifact store)
+│   └── lib/tx      │ (arktx, checkpoint, oor, psbtutil)
 ├── serverconn      │
 │   ├── mailbox     │ (protocol primitives)
 │   └── db          │ (durable delivery store)
+├── proofkeys       │ (wallet key derivation for indexer proofs)
+│   └── walletcore / lndbackend (implementations)
 ├── chainsource     │
 │   └── chainbackends (pluggable: LND, lwwallet, or btcwbackend)
 └── db              │
@@ -131,6 +142,10 @@ corresponding state transition being durable.
 | `ClientWallet` | round | MuSig2 signing + key derivation interface for round participation |
 | `VTXOReader` | wallet | Read-only VTXO descriptor access (breaks import cycle) |
 | `SelectedVTXO` | wallet | Locked VTXO descriptor for transfer inputs (breaks import cycle) |
+| `TxInfo` | wallet | Confirmed transaction with block hash and height |
+| `Backend` | proofkeys | Wallet key derivation and proof signing interface |
+| `Node` | lib/arkscript | Sealed AST node interface for tapscript compilation |
+| `VTXOPolicy` | lib/arkscript | Compiled VTXO taproot policy with collab/exit spend paths |
 
 ## State Machines
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,7 @@ Body wrapped at 72 characters. Explain WHY, not just WHAT.
 - [`docs/commit-tooling.md`](docs/commit-tooling.md) — commit_message.py workflows
 - [`docs/daemon_cli_guide.md`](docs/daemon_cli_guide.md) — darepod/darepocli setup and CLI reference
 - [`docs/go_workspace.md`](docs/go_workspace.md) — Multi-module Go workspace setup
+- [`docs/policy_arkscript_review_guide.md`](docs/policy_arkscript_review_guide.md) — Policy-first arkscript reviewer guide
 
 ### Per-Package Context
 Each major package contains a `CLAUDE.md`/`AGENTS.md` with purpose, key types,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,6 @@ Body wrapped at 72 characters. Explain WHY, not just WHAT.
 
 - Prefix with package name (`db:`, `rpc:`, `multi:` for multiple).
 - Small, atomic commits. Separate bug fixes, refactors, and features.
-- Sign with GPG: `git commit -S -F /path/to/message.txt`
 - Tooling: [`docs/commit-tooling.md`](docs/commit-tooling.md)
 
 ## Critical Rules

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,7 @@ into specific topics below.
 | [commit-tooling.md](commit-tooling.md) | commit_message.py workflows for linting and rewording |
 | [testing-guide.md](testing-guide.md) | Coverage targets, test approaches, pre-commit checklist |
 | [go_workspace.md](go_workspace.md) | Multi-module Go workspace setup |
+| [policy_arkscript_review_guide.md](policy_arkscript_review_guide.md) | Policy-first arkscript reviewer guide |
 
 ## Operations
 

--- a/lib/AGENTS.md
+++ b/lib/AGENTS.md
@@ -13,10 +13,16 @@ interfaces, and core Ark types.
 - `Node` — Individual tree node with children and outputs.
 - `LeafDescriptor` — VTXO or connector output to include in tree construction.
 
+### lib/arkscript
+- `Node` — Sealed AST interface for tapscript spending conditions (Multisig, CSV, Condition, etc.).
+- `VTXOPolicy` / `VHTLCPolicy` / `CheckpointPolicy` — High-level policy templates.
+- `CompiledPolicy` — Fully compiled taproot tree with canonical leaf ordering.
+
 ### lib/tx
-- `arktx` — Canonical output ordering for virtual-chain step transactions.
-- `checkpoint` — Checkpoint transaction construction.
-- `oor` — OOR-specific transaction builders.
+- `arktx` — Canonical output ordering and validation for Ark transactions.
+- `checkpoint` — Checkpoint PSBT construction for OOR on-chain anchors.
+- `oor` — OOR submit/finalize package builders and validators.
+- `psbtutil` — PSBT encoding, decoding, and signature attachment helpers.
 
 ### lib/types
 - `OperatorTerms` — Server-published terms (key, delays, fee rate, dust limit).

--- a/lib/CLAUDE.md
+++ b/lib/CLAUDE.md
@@ -13,10 +13,16 @@ interfaces, and core Ark types.
 - `Node` — Individual tree node with children and outputs.
 - `LeafDescriptor` — VTXO or connector output to include in tree construction.
 
+### lib/arkscript
+- `Node` — Sealed AST interface for tapscript spending conditions (Multisig, CSV, Condition, etc.).
+- `VTXOPolicy` / `VHTLCPolicy` / `CheckpointPolicy` — High-level policy templates.
+- `CompiledPolicy` — Fully compiled taproot tree with canonical leaf ordering.
+
 ### lib/tx
-- `arktx` — Canonical output ordering for virtual-chain step transactions.
-- `checkpoint` — Checkpoint transaction construction.
-- `oor` — OOR-specific transaction builders.
+- `arktx` — Canonical output ordering and validation for Ark transactions.
+- `checkpoint` — Checkpoint PSBT construction for OOR on-chain anchors.
+- `oor` — OOR submit/finalize package builders and validators.
+- `psbtutil` — PSBT encoding, decoding, and signature attachment helpers.
 
 ### lib/types
 - `OperatorTerms` — Server-published terms (key, delays, fee rate, dust limit).

--- a/lib/arkscript/AGENTS.md
+++ b/lib/arkscript/AGENTS.md
@@ -1,0 +1,46 @@
+# lib/arkscript
+
+## Purpose
+
+Bitcoin script compiler and policy system for constructing Ark protocol taproot
+outputs. Provides an AST of semantic nodes that compile to tapscript, plus
+higher-level policy templates for VTXO, vHTLC, and checkpoint outputs with
+validated invariants.
+
+## Key Types
+
+- `Node` — Sealed interface for all AST nodes representing spending conditions.
+  Implementations: `Multisig`, `CSV`, `Condition`, `Preimage`, `CLTV`.
+- `PolicyTemplate` — Semantic representation of a tapscript policy with named
+  leaves. Supports encode/decode for persistence.
+- `CompiledPolicy` — Fully compiled policy with canonical leaf ordering, merkle
+  tree, and control block derivation.
+- `VTXOPolicy` — Compiled VTXO taproot policy with collab and exit spend paths.
+  Provides `CollabSpendInfo()` and `ExitSpendInfo()`.
+- `VHTLCPolicy` — 6-leaf vHTLC policy with claim/refund/unilateral paths for
+  hash-time-locked conditional transfers.
+- `CheckpointPolicy` — Parameters for OOR checkpoint taproot tree construction.
+- `SpendInfo` — Witness script + control block needed to spend a specific leaf.
+
+## Relationships
+
+- **Depends on**: (no internal repo imports; pure cryptographic library).
+- **Depended on by**: `darepod`, `db`, `lib/tree`, `lib/tx/arktx`,
+  `lib/tx/checkpoint`, `lib/tx/oor`, `lib/tx/psbtutil`, `oor`, `round`,
+  `vtxo`, `wallet`.
+
+## Invariants
+
+- Node interface is sealed: only types defined in this package can implement it.
+- Every collab leaf must contain the operator key for safe cosigning.
+- Every exit leaf must be CSV-gated for unilateral recovery.
+- Canonical leaf ordering: sorted by version then lexicographic script bytes.
+- All taproot outputs use the unspendable ARK NUMS key for key path (no
+  key-path spend possible).
+- Policy validation enforces at least one operator-containing leaf
+  (collaborative) and at least one non-operator leaf (exit/unilateral).
+- Exit delay must be >= `MinExitDelay`.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/lib/arkscript/CLAUDE.md
+++ b/lib/arkscript/CLAUDE.md
@@ -1,0 +1,46 @@
+# lib/arkscript
+
+## Purpose
+
+Bitcoin script compiler and policy system for constructing Ark protocol taproot
+outputs. Provides an AST of semantic nodes that compile to tapscript, plus
+higher-level policy templates for VTXO, vHTLC, and checkpoint outputs with
+validated invariants.
+
+## Key Types
+
+- `Node` — Sealed interface for all AST nodes representing spending conditions.
+  Implementations: `Multisig`, `CSV`, `Condition`, `Preimage`, `CLTV`.
+- `PolicyTemplate` — Semantic representation of a tapscript policy with named
+  leaves. Supports encode/decode for persistence.
+- `CompiledPolicy` — Fully compiled policy with canonical leaf ordering, merkle
+  tree, and control block derivation.
+- `VTXOPolicy` — Compiled VTXO taproot policy with collab and exit spend paths.
+  Provides `CollabSpendInfo()` and `ExitSpendInfo()`.
+- `VHTLCPolicy` — 6-leaf vHTLC policy with claim/refund/unilateral paths for
+  hash-time-locked conditional transfers.
+- `CheckpointPolicy` — Parameters for OOR checkpoint taproot tree construction.
+- `SpendInfo` — Witness script + control block needed to spend a specific leaf.
+
+## Relationships
+
+- **Depends on**: (no internal repo imports; pure cryptographic library).
+- **Depended on by**: `darepod`, `db`, `lib/tree`, `lib/tx/arktx`,
+  `lib/tx/checkpoint`, `lib/tx/oor`, `lib/tx/psbtutil`, `oor`, `round`,
+  `vtxo`, `wallet`.
+
+## Invariants
+
+- Node interface is sealed: only types defined in this package can implement it.
+- Every collab leaf must contain the operator key for safe cosigning.
+- Every exit leaf must be CSV-gated for unilateral recovery.
+- Canonical leaf ordering: sorted by version then lexicographic script bytes.
+- All taproot outputs use the unspendable ARK NUMS key for key path (no
+  key-path spend possible).
+- Policy validation enforces at least one operator-containing leaf
+  (collaborative) and at least one non-operator leaf (exit/unilateral).
+- Exit delay must be >= `MinExitDelay`.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/lib/bip322/AGENTS.md
+++ b/lib/bip322/AGENTS.md
@@ -1,0 +1,39 @@
+# lib/bip322
+
+## Purpose
+
+BIP-322 message authentication implementation for Bitcoin/Ark protocol, enabling
+intent-bound signatures over application payloads with block height validity
+windows. Provides full-format signature construction, validation, and intent
+metadata encoding.
+
+## Key Types
+
+- `TxSigner` — Interface for producing BIP-322 signatures (signs the to_spend
+  and to_sign virtual transactions).
+- `Intent` — Application payload with `ValidFrom`/`ValidUntil` block height
+  range. TLV-encoded with domain tag `darepo-bip322-intent`.
+- `Sig` — Full-format BIP-322 signature (serialized to_sign transaction).
+- `IntentAuthContext` — Complete intent-bound auth validation context (intent,
+  message challenge, signature, proof prev outputs, chain height).
+- `VerificationResult` — Validation outcome with state (Valid/Invalid/
+  Inconclusive) and reason.
+
+## Relationships
+
+- **Depends on**: (no internal repo imports; pure cryptographic library).
+- **Depended on by**: `round` (intent signing), `darepod` (auth validation),
+  `wallet` (signing support).
+
+## Invariants
+
+- `ValidUntil` >= `ValidFrom` (or `ValidUntil` = 0 for no upper bound).
+- Full-format only: signature is the serialized to_sign transaction.
+- Max 128 additional inputs per validation (proof-of-funds limit).
+- Height validation: signature valid only if `current >= ValidFrom` AND
+  (`ValidUntil == 0` OR `current <= ValidUntil`).
+
+## Deep Docs
+
+- [lib/bip322/README.md](README.md) — BIP-322 implementation guide.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/lib/bip322/CLAUDE.md
+++ b/lib/bip322/CLAUDE.md
@@ -1,0 +1,39 @@
+# lib/bip322
+
+## Purpose
+
+BIP-322 message authentication implementation for Bitcoin/Ark protocol, enabling
+intent-bound signatures over application payloads with block height validity
+windows. Provides full-format signature construction, validation, and intent
+metadata encoding.
+
+## Key Types
+
+- `TxSigner` — Interface for producing BIP-322 signatures (signs the to_spend
+  and to_sign virtual transactions).
+- `Intent` — Application payload with `ValidFrom`/`ValidUntil` block height
+  range. TLV-encoded with domain tag `darepo-bip322-intent`.
+- `Sig` — Full-format BIP-322 signature (serialized to_sign transaction).
+- `IntentAuthContext` — Complete intent-bound auth validation context (intent,
+  message challenge, signature, proof prev outputs, chain height).
+- `VerificationResult` — Validation outcome with state (Valid/Invalid/
+  Inconclusive) and reason.
+
+## Relationships
+
+- **Depends on**: (no internal repo imports; pure cryptographic library).
+- **Depended on by**: `round` (intent signing), `darepod` (auth validation),
+  `wallet` (signing support).
+
+## Invariants
+
+- `ValidUntil` >= `ValidFrom` (or `ValidUntil` = 0 for no upper bound).
+- Full-format only: signature is the serialized to_sign transaction.
+- Max 128 additional inputs per validation (proof-of-funds limit).
+- Height validation: signature valid only if `current >= ValidFrom` AND
+  (`ValidUntil == 0` OR `current <= ValidUntil`).
+
+## Deep Docs
+
+- [lib/bip322/README.md](README.md) — BIP-322 implementation guide.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/lib/scripts/AGENTS.md
+++ b/lib/scripts/AGENTS.md
@@ -1,0 +1,47 @@
+# lib/scripts
+
+## Purpose
+
+Low-level Bitcoin script construction helpers for standard Ark outputs (VTXO and
+checkpoint tapscripts). Provides deterministic script builders and witness
+construction for taproot spending paths.
+
+## Key Types
+
+- `VTXOLeafType` — Enum identifying VTXO tapscript tree leaves:
+  `VTXOCollabPathLeaf` (index 0) and `VTXOTimeoutPathLeaf` (index 1).
+- `VTXOSpendData` — Witness script + control block needed to spend a VTXO via
+  collab or timeout path.
+
+## Key Functions
+
+- `VTXOTapScript` / `VTXOTapKey` — Full VTXO tapscript and taproot output key
+  construction.
+- `NewVTXOSpendInfo` / `VTXOSignDesc` — Derive spend info and sign descriptors
+  for any leaf path.
+- `VTXOTimeoutSpendWitness` / `VTXOCollabSpendWitness` — Construct witnesses
+  for the two VTXO spending paths.
+- `CheckpointOORScript` — Checkpoint script helpers for OOR transactions.
+- `AnchorPkScript` — Standardized P2A zero-value output for CPFP fee bumping.
+
+## Relationships
+
+- **Depends on**: (no internal repo imports; pure script library).
+- **Depended on by**: `darepod`, `db`, `lib/tx/*`, `round`, `vtxo`, `wallet`,
+  `walletcore`.
+
+## Invariants
+
+- VTXO tree structure is immutable: NUMS key path (unspendable), collab leaf
+  (index 0, owner CHECKSIGVERIFY + cosigner CHECKSIG), timeout leaf (index 1,
+  owner CHECKSIG + CSV delay + DROP).
+- Collab spend requires both owner and cosigner signatures. Timeout spend
+  requires owner signature only (after CSV delay).
+- Witness stack ordering: collab = [cosigner_sig, owner_sig, script,
+  control_block]; timeout = [owner_sig, script, control_block].
+- ARK NUMS key is unspendable (no known discrete log); key path is never
+  usable.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/lib/scripts/CLAUDE.md
+++ b/lib/scripts/CLAUDE.md
@@ -1,0 +1,47 @@
+# lib/scripts
+
+## Purpose
+
+Low-level Bitcoin script construction helpers for standard Ark outputs (VTXO and
+checkpoint tapscripts). Provides deterministic script builders and witness
+construction for taproot spending paths.
+
+## Key Types
+
+- `VTXOLeafType` — Enum identifying VTXO tapscript tree leaves:
+  `VTXOCollabPathLeaf` (index 0) and `VTXOTimeoutPathLeaf` (index 1).
+- `VTXOSpendData` — Witness script + control block needed to spend a VTXO via
+  collab or timeout path.
+
+## Key Functions
+
+- `VTXOTapScript` / `VTXOTapKey` — Full VTXO tapscript and taproot output key
+  construction.
+- `NewVTXOSpendInfo` / `VTXOSignDesc` — Derive spend info and sign descriptors
+  for any leaf path.
+- `VTXOTimeoutSpendWitness` / `VTXOCollabSpendWitness` — Construct witnesses
+  for the two VTXO spending paths.
+- `CheckpointOORScript` — Checkpoint script helpers for OOR transactions.
+- `AnchorPkScript` — Standardized P2A zero-value output for CPFP fee bumping.
+
+## Relationships
+
+- **Depends on**: (no internal repo imports; pure script library).
+- **Depended on by**: `darepod`, `db`, `lib/tx/*`, `round`, `vtxo`, `wallet`,
+  `walletcore`.
+
+## Invariants
+
+- VTXO tree structure is immutable: NUMS key path (unspendable), collab leaf
+  (index 0, owner CHECKSIGVERIFY + cosigner CHECKSIG), timeout leaf (index 1,
+  owner CHECKSIG + CSV delay + DROP).
+- Collab spend requires both owner and cosigner signatures. Timeout spend
+  requires owner signature only (after CSV delay).
+- Witness stack ordering: collab = [cosigner_sig, owner_sig, script,
+  control_block]; timeout = [owner_sig, script, control_block].
+- ARK NUMS key is unspendable (no known discrete log); key path is never
+  usable.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/lib/tx/arktx/AGENTS.md
+++ b/lib/tx/arktx/AGENTS.md
@@ -1,0 +1,37 @@
+# lib/tx/arktx
+
+## Purpose
+
+Helpers for constructing and validating Ark transactions representing the
+virtual-chain step following checkpoints. Enforces canonical output ordering
+(critical because multiple subsystems rely on byte-identical transaction
+construction).
+
+## Key Types
+
+- `TxVersion` — Canonical transaction version (v3) for Ark transfers to support
+  package relay.
+
+## Key Functions
+
+- `ValidateCanonicalTx` / `ValidateCanonicalPSBT` — Validate canonical ordering
+  rules including exactly one anchor output placed last.
+- `CanonicalizeOrdering` — Sorts transaction inputs/outputs in-place according
+  to v0 canonical rules (BIP69 ordering).
+- `IsAnchorOutput` — Identifies v0 Ark anchor outputs (P2A, value 0).
+
+## Relationships
+
+- **Depends on**: `lib/scripts` (for `AnchorPkScript`).
+- **Depended on by**: `lib/tx/checkpoint`, `lib/tx/oor`, `oor`.
+
+## Invariants
+
+- Anchor output must be exactly one and must be the last output.
+- Input ordering follows BIP69: sorted by outpoint hash then index.
+- Recipient output ordering follows BIP69: sorted by amount then pkScript.
+- Validation is deterministic and byte-identical across client and server.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../../ARCHITECTURE.md) — System-wide package map.

--- a/lib/tx/arktx/CLAUDE.md
+++ b/lib/tx/arktx/CLAUDE.md
@@ -1,0 +1,37 @@
+# lib/tx/arktx
+
+## Purpose
+
+Helpers for constructing and validating Ark transactions representing the
+virtual-chain step following checkpoints. Enforces canonical output ordering
+(critical because multiple subsystems rely on byte-identical transaction
+construction).
+
+## Key Types
+
+- `TxVersion` — Canonical transaction version (v3) for Ark transfers to support
+  package relay.
+
+## Key Functions
+
+- `ValidateCanonicalTx` / `ValidateCanonicalPSBT` — Validate canonical ordering
+  rules including exactly one anchor output placed last.
+- `CanonicalizeOrdering` — Sorts transaction inputs/outputs in-place according
+  to v0 canonical rules (BIP69 ordering).
+- `IsAnchorOutput` — Identifies v0 Ark anchor outputs (P2A, value 0).
+
+## Relationships
+
+- **Depends on**: `lib/scripts` (for `AnchorPkScript`).
+- **Depended on by**: `lib/tx/checkpoint`, `lib/tx/oor`, `oor`.
+
+## Invariants
+
+- Anchor output must be exactly one and must be the last output.
+- Input ordering follows BIP69: sorted by outpoint hash then index.
+- Recipient output ordering follows BIP69: sorted by amount then pkScript.
+- Validation is deterministic and byte-identical across client and server.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../../ARCHITECTURE.md) — System-wide package map.

--- a/lib/tx/checkpoint/AGENTS.md
+++ b/lib/tx/checkpoint/AGENTS.md
@@ -1,0 +1,42 @@
+# lib/tx/checkpoint
+
+## Purpose
+
+Helpers for constructing and validating Ark checkpoint transactions. Checkpoints
+are taproot transactions that spend one or more VTXOs into a new on-chain output
+with defined closure semantics, used as the on-chain anchor for out-of-round
+transfers.
+
+## Key Types
+
+- `Input` — Describes a VTXO input being transformed into a checkpoint output
+  (SpentVTXO identifier + OwnerLeafScript).
+- `SpentVTXORef` — Groups spent VTXO outpoint and output data, ensuring callers
+  don't mismatch identity and witness material.
+- `Result` — Output of `BuildPSBT` containing the unsigned checkpoint PSBT.
+
+## Key Functions
+
+- `BuildPSBT` — Constructs an unsigned checkpoint PSBT spending a VTXO input,
+  paying entire input value to a checkpoint P2TR output, appending a zero-value
+  anchor.
+- `EncodeTapTree` / `DecodeTapTree` — TLV-based tapscript leaf serialization
+  compatible with waddrmgr format.
+
+## Relationships
+
+- **Depends on**: `lib/scripts` (CheckpointPolicy, CheckpointTapScript),
+  `lib/tx/arktx` (TxVersion, validation).
+- **Depended on by**: `lib/tx/oor`, `oor`.
+
+## Invariants
+
+- Checkpoint output pkScript is derived deterministically from operator
+  checkpoint policy + caller-provided owner leaf script.
+- Minimum CSV delay is `MinCheckpointCSVDelay` (10 blocks).
+- Checkpoint transactions must have exactly one anchor output placed last.
+- Tap tree encoding uses TLV format matching waddrmgr for durability.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../../ARCHITECTURE.md) — System-wide package map.

--- a/lib/tx/checkpoint/CLAUDE.md
+++ b/lib/tx/checkpoint/CLAUDE.md
@@ -1,0 +1,42 @@
+# lib/tx/checkpoint
+
+## Purpose
+
+Helpers for constructing and validating Ark checkpoint transactions. Checkpoints
+are taproot transactions that spend one or more VTXOs into a new on-chain output
+with defined closure semantics, used as the on-chain anchor for out-of-round
+transfers.
+
+## Key Types
+
+- `Input` — Describes a VTXO input being transformed into a checkpoint output
+  (SpentVTXO identifier + OwnerLeafScript).
+- `SpentVTXORef` — Groups spent VTXO outpoint and output data, ensuring callers
+  don't mismatch identity and witness material.
+- `Result` — Output of `BuildPSBT` containing the unsigned checkpoint PSBT.
+
+## Key Functions
+
+- `BuildPSBT` — Constructs an unsigned checkpoint PSBT spending a VTXO input,
+  paying entire input value to a checkpoint P2TR output, appending a zero-value
+  anchor.
+- `EncodeTapTree` / `DecodeTapTree` — TLV-based tapscript leaf serialization
+  compatible with waddrmgr format.
+
+## Relationships
+
+- **Depends on**: `lib/scripts` (CheckpointPolicy, CheckpointTapScript),
+  `lib/tx/arktx` (TxVersion, validation).
+- **Depended on by**: `lib/tx/oor`, `oor`.
+
+## Invariants
+
+- Checkpoint output pkScript is derived deterministically from operator
+  checkpoint policy + caller-provided owner leaf script.
+- Minimum CSV delay is `MinCheckpointCSVDelay` (10 blocks).
+- Checkpoint transactions must have exactly one anchor output placed last.
+- Tap tree encoding uses TLV format matching waddrmgr for durability.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../../ARCHITECTURE.md) — System-wide package map.

--- a/lib/tx/oor/AGENTS.md
+++ b/lib/tx/oor/AGENTS.md
@@ -1,0 +1,54 @@
+# lib/tx/oor
+
+## Purpose
+
+OOR-specific transaction builders and validators for out-of-round transfer
+packages. Combines checkpoint and Ark transaction construction, validates the
+structural relationships between them, and provides serialization for submit and
+finalize packages.
+
+## Key Types
+
+- `SubmitPackage` — v0 OOR submit payload: Ark tx PSBT plus checkpoint PSBTs.
+  SessionID derived from unsigned Ark txid.
+- `FinalizePackage` — v0 OOR finalize payload: Ark tx PSBT plus finalized
+  checkpoint PSBTs with tap tree metadata.
+- `ValidatedSubmitPackage` — Output of structural validation ensuring canonical
+  ordering, checkpoint/input matching, and witness UTXO presence.
+- `CheckpointOutput` / `RecipientOutput` / `CheckpointInput` — Builder inputs
+  for PSBT construction.
+- `CheckpointArtifact` — Wraps checkpoint PSBT with tap tree sidecar metadata.
+
+## Key Functions
+
+- `BuildArkPSBT` — Constructs deterministic Ark PSBT spending checkpoint
+  outputs, enforcing fee-less transfers and canonical ordering.
+- `BuildCheckpointPSBT` — Wraps checkpoint.BuildPSBT with tap tree metadata.
+- `ValidateSubmitPackage` / `ValidateFinalizePackage` — Structural validators
+  ensuring canonical Ark PSBT, checkpoint set matches inputs, witness UTXOs
+  present.
+- `ApplyFinalizeData` — Applies finalize data to a validated submit package.
+
+## Relationships
+
+- **Depends on**: `lib/scripts`, `lib/tx/arktx` (validation, TxVersion),
+  `lib/tx/checkpoint` (BuildPSBT), `lib/tx/psbtutil` (Serialize/Parse).
+- **Depended on by**: `oor` (session state machine), `db` (artifact store),
+  `rpc/oorpb`, `darepod` (RPC server).
+
+## Invariants
+
+- `SubmitPackage.SessionID` is stable (derived from unsigned Ark txid) across
+  restarts and retries.
+- Checkpoint set must exactly match Ark input references (no missing, no extra).
+- Each Ark input spends checkpoint output index 0 (canonical v0 mapping).
+- Witness UTXOs must be present in Ark PSBT inputs (package is self-contained).
+- Tap tree metadata (`TapTreePSBTKey`) required on all Ark inputs for
+  finalization.
+- Fee-less constraint: sum(checkpoint inputs) == sum(recipient outputs excluding
+  anchor).
+- Anchor output always last with value 0.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../../ARCHITECTURE.md) — System-wide package map.

--- a/lib/tx/oor/CLAUDE.md
+++ b/lib/tx/oor/CLAUDE.md
@@ -1,0 +1,54 @@
+# lib/tx/oor
+
+## Purpose
+
+OOR-specific transaction builders and validators for out-of-round transfer
+packages. Combines checkpoint and Ark transaction construction, validates the
+structural relationships between them, and provides serialization for submit and
+finalize packages.
+
+## Key Types
+
+- `SubmitPackage` — v0 OOR submit payload: Ark tx PSBT plus checkpoint PSBTs.
+  SessionID derived from unsigned Ark txid.
+- `FinalizePackage` — v0 OOR finalize payload: Ark tx PSBT plus finalized
+  checkpoint PSBTs with tap tree metadata.
+- `ValidatedSubmitPackage` — Output of structural validation ensuring canonical
+  ordering, checkpoint/input matching, and witness UTXO presence.
+- `CheckpointOutput` / `RecipientOutput` / `CheckpointInput` — Builder inputs
+  for PSBT construction.
+- `CheckpointArtifact` — Wraps checkpoint PSBT with tap tree sidecar metadata.
+
+## Key Functions
+
+- `BuildArkPSBT` — Constructs deterministic Ark PSBT spending checkpoint
+  outputs, enforcing fee-less transfers and canonical ordering.
+- `BuildCheckpointPSBT` — Wraps checkpoint.BuildPSBT with tap tree metadata.
+- `ValidateSubmitPackage` / `ValidateFinalizePackage` — Structural validators
+  ensuring canonical Ark PSBT, checkpoint set matches inputs, witness UTXOs
+  present.
+- `ApplyFinalizeData` — Applies finalize data to a validated submit package.
+
+## Relationships
+
+- **Depends on**: `lib/scripts`, `lib/tx/arktx` (validation, TxVersion),
+  `lib/tx/checkpoint` (BuildPSBT), `lib/tx/psbtutil` (Serialize/Parse).
+- **Depended on by**: `oor` (session state machine), `db` (artifact store),
+  `rpc/oorpb`, `darepod` (RPC server).
+
+## Invariants
+
+- `SubmitPackage.SessionID` is stable (derived from unsigned Ark txid) across
+  restarts and retries.
+- Checkpoint set must exactly match Ark input references (no missing, no extra).
+- Each Ark input spends checkpoint output index 0 (canonical v0 mapping).
+- Witness UTXOs must be present in Ark PSBT inputs (package is self-contained).
+- Tap tree metadata (`TapTreePSBTKey`) required on all Ark inputs for
+  finalization.
+- Fee-less constraint: sum(checkpoint inputs) == sum(recipient outputs excluding
+  anchor).
+- Anchor output always last with value 0.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../../ARCHITECTURE.md) — System-wide package map.

--- a/lib/tx/psbtutil/AGENTS.md
+++ b/lib/tx/psbtutil/AGENTS.md
@@ -1,0 +1,33 @@
+# lib/tx/psbtutil
+
+## Purpose
+
+Small helpers for encoding, decoding, and manipulating PSBTs. Intentionally
+"dumb": only serialize/parse bytes and attach signatures. Does not validate
+transaction semantics — callers run appropriate protocol validators.
+
+## Key Functions
+
+- `Serialize` / `Parse` — Encode/decode PSBT packets to/from raw bytes.
+- `EncodeBase64` / `DecodeBase64` — Standard (not URL-safe) base64 PSBT
+  encoding for tool compatibility.
+- `AddTaprootScriptSpendSig` — Adds or replaces a taproot script-path spend
+  signature, keyed by (x-only pubkey, leaf hash).
+- `AddTapLeafScript` — Idempotent tapscript leaf attachment to PSBT input.
+
+## Relationships
+
+- **Depends on**: `lib/scripts` (VTXOSpendData for taproot helpers).
+- **Depended on by**: `lib/tx/oor` (package marshaling), `oor` (signing flow),
+  `db` (persistence layers).
+
+## Invariants
+
+- Base64 encoding uses standard alphabet (not URL-safe) for tool compatibility.
+- Serialization is symmetric: `Parse(Serialize(pkt))` round-trips.
+- `AddTaprootScriptSpendSig` replaces existing signature with same key.
+- `AddTapLeafScript` is idempotent: adding the same leaf twice is a no-op.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../../ARCHITECTURE.md) — System-wide package map.

--- a/lib/tx/psbtutil/CLAUDE.md
+++ b/lib/tx/psbtutil/CLAUDE.md
@@ -1,0 +1,33 @@
+# lib/tx/psbtutil
+
+## Purpose
+
+Small helpers for encoding, decoding, and manipulating PSBTs. Intentionally
+"dumb": only serialize/parse bytes and attach signatures. Does not validate
+transaction semantics — callers run appropriate protocol validators.
+
+## Key Functions
+
+- `Serialize` / `Parse` — Encode/decode PSBT packets to/from raw bytes.
+- `EncodeBase64` / `DecodeBase64` — Standard (not URL-safe) base64 PSBT
+  encoding for tool compatibility.
+- `AddTaprootScriptSpendSig` — Adds or replaces a taproot script-path spend
+  signature, keyed by (x-only pubkey, leaf hash).
+- `AddTapLeafScript` — Idempotent tapscript leaf attachment to PSBT input.
+
+## Relationships
+
+- **Depends on**: `lib/scripts` (VTXOSpendData for taproot helpers).
+- **Depended on by**: `lib/tx/oor` (package marshaling), `oor` (signing flow),
+  `db` (persistence layers).
+
+## Invariants
+
+- Base64 encoding uses standard alphabet (not URL-safe) for tool compatibility.
+- Serialization is symmetric: `Parse(Serialize(pkt))` round-trips.
+- `AddTaprootScriptSpendSig` replaces existing signature with same key.
+- `AddTapLeafScript` is idempotent: adding the same leaf twice is a no-op.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../../ARCHITECTURE.md) — System-wide package map.

--- a/lndbackend/AGENTS.md
+++ b/lndbackend/AGENTS.md
@@ -2,17 +2,24 @@
 
 ## Purpose
 
-`BoardingBackend` implementation wrapping lndclient's WalletKitClient for key
-derivation, taproot script import, and UTXO enumeration via LND.
+`BoardingBackend` and `ProofKeyBackend` implementations wrapping lndclient's
+WalletKitClient for key derivation, taproot script import, UTXO enumeration,
+and proof key signing via LND.
 
 ## Key Types
 
-- `BoardingBackend` — Struct holding `walletKit lndclient.WalletKitClient` and `chainKit lndclient.ChainKitClient`. Implements `wallet.BoardingBackend`.
-- `GetTransaction` / `GetBlock` — Methods using `chainKit` for raw tx/block fetching (for `TxProof` construction, added by vtxo-owner-cosigner-split).
+- `BoardingBackend` — Struct holding `walletKit lndclient.WalletKitClient` and
+  `chainKit lndclient.ChainKitClient`. Implements `wallet.BoardingBackend`.
+  `GetTransaction` returns `*wallet.TxInfo`; `GetBlock` fetches raw blocks via
+  `chainKit`.
+- `ProofKeyBackend` — Implements `proofkeys.Backend` for LND-backed key
+  derivation and Schnorr proof signing. Wraps `walletKit` for `DeriveKey`,
+  `DeriveNextKey`, and produces `indexer.SchnorrSigner` instances.
 
 ## Relationships
 
-- **Depends on**: `wallet` (implements `BoardingBackend`).
+- **Depends on**: `wallet` (implements `BoardingBackend`), `proofkeys`
+  (implements `Backend`), `indexer` (SchnorrSigner interface).
 - **Depended on by**: `darepod` (LND-backed wallet mode).
 
 ## Deep Docs

--- a/lndbackend/CLAUDE.md
+++ b/lndbackend/CLAUDE.md
@@ -2,17 +2,24 @@
 
 ## Purpose
 
-`BoardingBackend` implementation wrapping lndclient's WalletKitClient for key
-derivation, taproot script import, and UTXO enumeration via LND.
+`BoardingBackend` and `ProofKeyBackend` implementations wrapping lndclient's
+WalletKitClient for key derivation, taproot script import, UTXO enumeration,
+and proof key signing via LND.
 
 ## Key Types
 
-- `BoardingBackend` — Struct holding `walletKit lndclient.WalletKitClient` and `chainKit lndclient.ChainKitClient`. Implements `wallet.BoardingBackend`.
-- `GetTransaction` / `GetBlock` — Methods using `chainKit` for raw tx/block fetching (for `TxProof` construction, added by vtxo-owner-cosigner-split).
+- `BoardingBackend` — Struct holding `walletKit lndclient.WalletKitClient` and
+  `chainKit lndclient.ChainKitClient`. Implements `wallet.BoardingBackend`.
+  `GetTransaction` returns `*wallet.TxInfo`; `GetBlock` fetches raw blocks via
+  `chainKit`.
+- `ProofKeyBackend` — Implements `proofkeys.Backend` for LND-backed key
+  derivation and Schnorr proof signing. Wraps `walletKit` for `DeriveKey`,
+  `DeriveNextKey`, and produces `indexer.SchnorrSigner` instances.
 
 ## Relationships
 
-- **Depends on**: `wallet` (implements `BoardingBackend`).
+- **Depends on**: `wallet` (implements `BoardingBackend`), `proofkeys`
+  (implements `Backend`), `indexer` (SchnorrSigner interface).
 - **Depended on by**: `darepod` (LND-backed wallet mode).
 
 ## Deep Docs

--- a/lwwallet/AGENTS.md
+++ b/lwwallet/AGENTS.md
@@ -10,7 +10,7 @@ Implements `wallet.BoardingBackend`, `input.Signer` + MuSig2, and
 ## Key Types
 
 - `BoardingBackendAdapter` — Implements `wallet.BoardingBackend`. Queries Esplora directly for UTXOs (bypasses btcwallet's UTXO tracking because btcwallet skips credit marking for non-default key scopes like m/1017').
-- `GetTransaction` / `GetBlock` — Methods on `BoardingBackendAdapter` for fetching raw tx/block data from Esplora, used for `TxProof` construction.
+- `GetTransaction` / `GetBlock` — Methods on `BoardingBackendAdapter` for fetching raw tx/block data from Esplora. `GetTransaction` returns `*wallet.TxInfo` (containing tx, block hash, and block height).
 
 ## Relationships
 
@@ -20,6 +20,7 @@ Implements `wallet.BoardingBackend`, `input.Signer` + MuSig2, and
 ## Invariants
 
 - UTXO enumeration queries Esplora directly rather than btcwallet's internal UTXO set, because btcwallet does not credit-mark outputs for non-default key scopes (m/1017').
+- `Stop()` explicitly closes btcwallet's internal database to prevent resource leaks.
 
 ## Deep Docs
 

--- a/lwwallet/CLAUDE.md
+++ b/lwwallet/CLAUDE.md
@@ -10,7 +10,7 @@ Implements `wallet.BoardingBackend`, `input.Signer` + MuSig2, and
 ## Key Types
 
 - `BoardingBackendAdapter` — Implements `wallet.BoardingBackend`. Queries Esplora directly for UTXOs (bypasses btcwallet's UTXO tracking because btcwallet skips credit marking for non-default key scopes like m/1017').
-- `GetTransaction` / `GetBlock` — Methods on `BoardingBackendAdapter` for fetching raw tx/block data from Esplora, used for `TxProof` construction.
+- `GetTransaction` / `GetBlock` — Methods on `BoardingBackendAdapter` for fetching raw tx/block data from Esplora. `GetTransaction` returns `*wallet.TxInfo` (containing tx, block hash, and block height).
 
 ## Relationships
 
@@ -20,6 +20,7 @@ Implements `wallet.BoardingBackend`, `input.Signer` + MuSig2, and
 ## Invariants
 
 - UTXO enumeration queries Esplora directly rather than btcwallet's internal UTXO set, because btcwallet does not credit-mark outputs for non-default key scopes (m/1017').
+- `Stop()` explicitly closes btcwallet's internal database to prevent resource leaks.
 
 ## Deep Docs
 

--- a/proofkeys/AGENTS.md
+++ b/proofkeys/AGENTS.md
@@ -1,0 +1,31 @@
+# proofkeys
+
+## Purpose
+
+Interface package defining wallet-managed key operations for daemon-owned
+receive scripts and indexer proof generation. Acts as the abstraction boundary
+between wallet backends and proof key derivation.
+
+## Key Types
+
+- `Backend` — Interface defining the wallet key derivation contract:
+  `DeriveKey`, `DeriveNextKey`, and `ProofSigner`. Implemented by
+  `walletcore.Wallet` and `lndbackend.ProofKeyBackend`.
+
+## Relationships
+
+- **Depends on**: `indexer` (SchnorrSigner interface for proof signing).
+- **Depended on by**: `walletcore` (implements Backend), `lndbackend`
+  (implements Backend via ProofKeyBackend), `darepod` (consumes Backend for
+  indexer proof operations).
+
+## Invariants
+
+- `Backend` must provide deterministic key derivation for the same locator
+  inputs.
+- `ProofSigner` binds to the exact key descriptor and produces Schnorr
+  signatures for indexer proof-of-control.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/proofkeys/CLAUDE.md
+++ b/proofkeys/CLAUDE.md
@@ -1,0 +1,31 @@
+# proofkeys
+
+## Purpose
+
+Interface package defining wallet-managed key operations for daemon-owned
+receive scripts and indexer proof generation. Acts as the abstraction boundary
+between wallet backends and proof key derivation.
+
+## Key Types
+
+- `Backend` — Interface defining the wallet key derivation contract:
+  `DeriveKey`, `DeriveNextKey`, and `ProofSigner`. Implemented by
+  `walletcore.Wallet` and `lndbackend.ProofKeyBackend`.
+
+## Relationships
+
+- **Depends on**: `indexer` (SchnorrSigner interface for proof signing).
+- **Depended on by**: `walletcore` (implements Backend), `lndbackend`
+  (implements Backend via ProofKeyBackend), `darepod` (consumes Backend for
+  indexer proof operations).
+
+## Invariants
+
+- `Backend` must provide deterministic key derivation for the same locator
+  inputs.
+- `ProofSigner` binds to the exact key descriptor and produces Schnorr
+  signatures for indexer proof-of-control.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/round/AGENTS.md
+++ b/round/AGENTS.md
@@ -45,6 +45,10 @@ protocols with MuSig2 signing ceremonies.
 
 - Tree signatures must be validated BEFORE boarding input signatures are released (security checkpoint at InputSigSent).
 - Forfeit signatures are collected AFTER VTXO tree signing is complete (ForfeitSignaturesCollectingState), ensuring clients only forfeit old VTXOs after verifying new VTXOs are properly signed.
+- After aggregated signatures are validated on `VTXOTreePaths`, they are
+  propagated to extracted `ClientTrees` via `SubmitTreeSigs` + `VerifySigned`.
+  This ensures persisted client trees contain valid signatures for unilateral
+  exit (unrolling).
 - Round state is checkpointed atomically after tree validation; crash before checkpoint means client has no record of sent signatures.
 - Primary FSM handles interactive phases (through InputSigSent); a dedicated FSM per round handles confirmation monitoring.
 - The round actor does not mark VTXOs as PendingForfeit — the wallet/manager admits VTXOs before sending RegisterIntentMsg.

--- a/round/CLAUDE.md
+++ b/round/CLAUDE.md
@@ -45,6 +45,10 @@ protocols with MuSig2 signing ceremonies.
 
 - Tree signatures must be validated BEFORE boarding input signatures are released (security checkpoint at InputSigSent).
 - Forfeit signatures are collected AFTER VTXO tree signing is complete (ForfeitSignaturesCollectingState), ensuring clients only forfeit old VTXOs after verifying new VTXOs are properly signed.
+- After aggregated signatures are validated on `VTXOTreePaths`, they are
+  propagated to extracted `ClientTrees` via `SubmitTreeSigs` + `VerifySigned`.
+  This ensures persisted client trees contain valid signatures for unilateral
+  exit (unrolling).
 - Round state is checkpointed atomically after tree validation; crash before checkpoint means client has no record of sent signatures.
 - Primary FSM handles interactive phases (through InputSigSent); a dedicated FSM per round handles confirmation monitoring.
 - The round actor does not mark VTXOs as PendingForfeit — the wallet/manager admits VTXOs before sending RegisterIntentMsg.

--- a/wallet/AGENTS.md
+++ b/wallet/AGENTS.md
@@ -11,7 +11,8 @@ refresh, leave, OOR spend, and directed send flows.
 ## Key Types
 
 - `Ark` — Main actor managing boarding addresses, UTXO enumeration, confirmation polling, admission forwarding, and VTXO selection/locking.
-- `BoardingBackend` — Interface for wallet integration (key derivation, taproot import, ListUnspent).
+- `BoardingBackend` — Interface for wallet integration (key derivation, taproot import, ListUnspent). `GetTransaction` returns `*TxInfo` (containing tx, block hash, and block height).
+- `TxInfo` — Struct wrapping a confirmed transaction with its block hash and block height. Returned by `BoardingBackend.GetTransaction`.
 - `BoardingStore` — Interface for persisting boarding addresses and intents.
 - `VTXOReader` — Read-only interface for loading VTXO descriptors by outpoint. Wallet uses this to build intent packages without importing `vtxo` directly.
 - `VTXODescriptor` — Wallet-level VTXO descriptor (outpoint, amount, pkscript, tree, expiry). Avoids direct dependency on `vtxo.Descriptor`.
@@ -44,7 +45,7 @@ refresh, leave, OOR spend, and directed send flows.
 ## Invariants
 
 - UTXO confirmation requires `MinBoardingConfs` (1) on-chain confirmations.
-- `ListUnspent` queries are retried up to 5 times with 200ms delay (mitigates race between block epoch and wallet update).
+- `ListUnspent` queries are retried up to 10 times with 200ms delay (mitigates race between block epoch and wallet update, especially for neutrino backends).
 - Notifier registration captures `minConf` parameter per actor; different actors can require different confirmation depths.
 - Cooperative admission (refresh/leave) must reserve forfeit inputs through the VTXO manager before sending `RegisterIntentMsg` to the round actor.
 - If round registration fails after successful admission, the wallet releases the forfeit reservation so VTXOs return to LiveState.

--- a/wallet/CLAUDE.md
+++ b/wallet/CLAUDE.md
@@ -11,7 +11,8 @@ refresh, leave, OOR spend, and directed send flows.
 ## Key Types
 
 - `Ark` — Main actor managing boarding addresses, UTXO enumeration, confirmation polling, admission forwarding, and VTXO selection/locking.
-- `BoardingBackend` — Interface for wallet integration (key derivation, taproot import, ListUnspent).
+- `BoardingBackend` — Interface for wallet integration (key derivation, taproot import, ListUnspent). `GetTransaction` returns `*TxInfo` (containing tx, block hash, and block height).
+- `TxInfo` — Struct wrapping a confirmed transaction with its block hash and block height. Returned by `BoardingBackend.GetTransaction`.
 - `BoardingStore` — Interface for persisting boarding addresses and intents.
 - `VTXOReader` — Read-only interface for loading VTXO descriptors by outpoint. Wallet uses this to build intent packages without importing `vtxo` directly.
 - `VTXODescriptor` — Wallet-level VTXO descriptor (outpoint, amount, pkscript, tree, expiry). Avoids direct dependency on `vtxo.Descriptor`.
@@ -44,7 +45,7 @@ refresh, leave, OOR spend, and directed send flows.
 ## Invariants
 
 - UTXO confirmation requires `MinBoardingConfs` (1) on-chain confirmations.
-- `ListUnspent` queries are retried up to 5 times with 200ms delay (mitigates race between block epoch and wallet update).
+- `ListUnspent` queries are retried up to 10 times with 200ms delay (mitigates race between block epoch and wallet update, especially for neutrino backends).
 - Notifier registration captures `minConf` parameter per actor; different actors can require different confirmation depths.
 - Cooperative admission (refresh/leave) must reserve forfeit inputs through the VTXO manager before sending `RegisterIntentMsg` to the round actor.
 - If round registration fails after successful admission, the wallet releases the forfeit reservation so VTXOs return to LiveState.

--- a/walletcore/AGENTS.md
+++ b/walletcore/AGENTS.md
@@ -9,14 +9,14 @@ btcwallet.BtcWallet regardless of the underlying chain source.
 
 ## Key Types
 
-- `Wallet` — Core wallet struct embedding `input.Signer`. Provides key derivation, P2TR address generation, balance queries, and UTXO listing. Chain-specific implementations embed this to satisfy `round.ClientWallet`.
+- `Wallet` — Core wallet struct embedding `input.Signer`. Provides key derivation, P2TR address generation, balance queries, and UTXO listing. Also implements `proofkeys.Backend` (via `ProofSigner` method). Chain-specific implementations embed this to satisfy `round.ClientWallet`.
 - `BoardingBackendBase` — Shared boarding functionality: taproot script import under BIP86 scope, imported address tracking for UTXO filtering, and HD key derivation. Chain-specific adapters embed this and add `ListUnspent`, `GetTransaction`, `GetBlock`.
 - `Config` — Base configuration (seed, chain params, recovery window, DB dir, logger) shared by all btcwallet-backed wallet backends.
 
 ## Relationships
 
-- **Depends on**: `build` (context logger extraction).
-- **Depended on by**: `lwwallet` (embeds Wallet + BoardingBackendBase), `btcwbackend` (embeds Wallet + BoardingBackendBase).
+- **Depends on**: `build` (context logger extraction), `proofkeys` (implements Backend), `indexer` (SchnorrSigner interface).
+- **Depended on by**: `lwwallet` (embeds Wallet + BoardingBackendBase), `btcwbackend` (embeds Wallet + BoardingBackendBase), `darepod` (proof key backend).
 
 ## Invariants
 

--- a/walletcore/CLAUDE.md
+++ b/walletcore/CLAUDE.md
@@ -9,14 +9,14 @@ btcwallet.BtcWallet regardless of the underlying chain source.
 
 ## Key Types
 
-- `Wallet` — Core wallet struct embedding `input.Signer`. Provides key derivation, P2TR address generation, balance queries, and UTXO listing. Chain-specific implementations embed this to satisfy `round.ClientWallet`.
+- `Wallet` — Core wallet struct embedding `input.Signer`. Provides key derivation, P2TR address generation, balance queries, and UTXO listing. Also implements `proofkeys.Backend` (via `ProofSigner` method). Chain-specific implementations embed this to satisfy `round.ClientWallet`.
 - `BoardingBackendBase` — Shared boarding functionality: taproot script import under BIP86 scope, imported address tracking for UTXO filtering, and HD key derivation. Chain-specific adapters embed this and add `ListUnspent`, `GetTransaction`, `GetBlock`.
 - `Config` — Base configuration (seed, chain params, recovery window, DB dir, logger) shared by all btcwallet-backed wallet backends.
 
 ## Relationships
 
-- **Depends on**: `build` (context logger extraction).
-- **Depended on by**: `lwwallet` (embeds Wallet + BoardingBackendBase), `btcwbackend` (embeds Wallet + BoardingBackendBase).
+- **Depends on**: `build` (context logger extraction), `proofkeys` (implements Backend), `indexer` (SchnorrSigner interface).
+- **Depended on by**: `lwwallet` (embeds Wallet + BoardingBackendBase), `btcwbackend` (embeds Wallet + BoardingBackendBase), `darepod` (proof key backend).
 
 ## Invariants
 


### PR DESCRIPTION
In this PR, we run a full doc-gardening sweep across every package in the repo. The per-package `CLAUDE.md`/`AGENTS.md` files haven't been updated in several PRs worth of merges (arkscript, proofkeys, btcwbackend fixes, pubkey-derived mailbox auth, OOR bugfixes, client tree sig propagation, etc), so a number of packages either had no docs at all or had docs that drifted from the current code.

## New per-package docs

We add `CLAUDE.md` + `AGENTS.md` for eight packages that shipped without documentation:

- `proofkeys`: the wallet key derivation interface for indexer proof signing, bridging `walletcore`/`lndbackend` implementations to `darepod`
- `lib/arkscript`: the tapscript AST compiler and policy system (VTXO, vHTLC, checkpoint policies with canonical leaf ordering and invariant validation)
- `lib/bip322`: BIP-322 intent-bound message authentication with block height validity windows
- `lib/scripts`: low-level Bitcoin script construction for VTXO and checkpoint taproot outputs
- `lib/tx/arktx`: canonical Ark transaction ordering and validation (BIP69, anchor-last)
- `lib/tx/checkpoint`: checkpoint PSBT construction for OOR on-chain anchors
- `lib/tx/oor`: OOR submit/finalize package builders and structural validators
- `lib/tx/psbtutil`: PSBT encoding/decoding and taproot signature attachment helpers

## Stale doc updates

We also update five packages whose code changed but whose docs didn't keep up:

- `wallet`: document the new `TxInfo` struct (replaces the bare `*wire.MsgTx` return from `GetTransaction`), bump the `ListUnspent` retry count from 5 to 10 for neutrino backends
- `lndbackend`: add the new `ProofKeyBackend` type that implements `proofkeys.Backend` for LND-backed key derivation
- `lwwallet`: update `GetTransaction` return type to `*wallet.TxInfo`, note the explicit btcwallet DB close in `Stop()`
- `walletcore`: document the `proofkeys.Backend` implementation via `ProofSigner`, add `proofkeys` and `indexer` to the dependency list
- `round`: add invariant for client tree signature propagation (aggregated sigs submitted to extracted `ClientTrees` via `SubmitTreeSigs` + `VerifySigned` after validation)

## Architecture and top-level updates

`ARCHITECTURE.md` gets all eight new packages added to the layer tables, `proofkeys` wired into the dependency graph, and four new entries in the key types table (`TxInfo`, `Backend`, `Node`, `VTXOPolicy`). The `lib/` parent doc picks up the arkscript sub-package section and updated `lib/tx` descriptions. `docs/index.md` and the root `CLAUDE.md` both get the `policy_arkscript_review_guide.md` link that was missing.

We also remove the GPG signing instruction (`git commit -S`) from the top-level `CLAUDE.md` since it blocks agent autonomy (agents can't provide GPG passphrases or access hardware tokens).

See each commit message for a detailed description w.r.t the incremental changes.