### PR TITLE
chainbackends: fix double-conversion in LndClientFeeEstimator

### DIFF
--- a/chainbackends/lndclient_adapters.go
+++ b/chainbackends/lndclient_adapters.go
@@ -66,8 +66,8 @@ func (e *LndClientFeeEstimator) Stop() error {
 	return nil
 }
 
-// EstimateFeePerKW returns the estimated fee rate in satoshis per kilo-weight
-// unit for the given confirmation target.
+// EstimateFeePerKW returns the estimated fee rate in satoshis per
+// kilo-weight unit for the given confirmation target.
 func (e *LndClientFeeEstimator) EstimateFeePerKW(
 	numBlocks uint32) (chainfee.SatPerKWeight, error) {
 
@@ -75,14 +75,15 @@ func (e *LndClientFeeEstimator) EstimateFeePerKW(
 		context.Background(), 30*time.Second,
 	)
 	defer cancel()
-	satPerVByte, err := e.walletKit.EstimateFeeRate(
+
+	// EstimateFeeRate already returns chainfee.SatPerKWeight
+	// (it does SatPerKWeight(resp.SatPerKw) internally).
+	satPerKw, err := e.walletKit.EstimateFeeRate(
 		ctx, int32(numBlocks),
 	)
 	if err != nil {
 		return 0, fmt.Errorf("estimate fee rate: %w", err)
 	}
-
-	satPerKw := chainfee.SatPerVByte(satPerVByte).FeePerKWeight()
 
 	return satPerKw, nil
 }


### PR DESCRIPTION
## Summary

- `lndclient.WalletKitClient.EstimateFeeRate` returns `chainfee.SatPerKWeight` directly (it does `SatPerKWeight(resp.SatPerKw)` internally)
- `LndClientFeeEstimator.EstimateFeePerKW` was assigning the result to `satPerVByte` and converting again via `SatPerVByte().FeePerKWeight()`, inflating the fee rate by ~250x
- Fix: return the `SatPerKWeight` value directly without double-conversion

This bug was dormant until lightninglabs/darepo#222 wired `LndClientFeeEstimator` into the server's round subsystem for batch commitment transactions.

## Test plan

- [x] Verified `lndclient.WalletKitClient.EstimateFeeRate` return type is `chainfee.SatPerKWeight` in `lndclient@v1.0.1`
- [x] `make fmt-check` passes
- [x] `make lint` passes