### PR TITLE
darepod: expose stored vtxos for harness inspection

### DIFF
--- a/darepod/server.go
+++ b/darepod/server.go
@@ -314,6 +314,21 @@ func (s *Server) RPCAddr() net.Addr {
 	return s.rpcAddr
 }
 
+// GetStoredVTXO returns the persisted VTXO descriptor for the
+// given outpoint. This method exists for test harnesses only;
+// it lets integration tests inspect locally stored partial
+// unroll state without reaching into internal daemon fields.
+func (s *Server) GetStoredVTXO(ctx context.Context,
+	outpoint wire.OutPoint) (*vtxo.Descriptor, error) {
+
+	if s.vtxoStore == nil {
+		return nil, fmt.Errorf("client daemon VTXO " +
+			"store not initialized")
+	}
+
+	return s.vtxoStore.GetVTXO(ctx, outpoint)
+}
+
 // RunUntilShutdown starts all subsystems and blocks until the shutdown
 // interceptor fires or a fatal error occurs. The startup sequence
 // branches on the configured wallet type: in lnd mode, the daemon


### PR DESCRIPTION
## Summary

- Add a narrow `GetStoredVTXO` accessor on the daemon server so integration
  harnesses can inspect a client's persisted VTXO descriptor (including its
  `TreePath`) without reaching into private daemon fields.
- Needed by the server-side partial-unroll integration test which reads the
  client's stored tree path to drive on-chain branch spends and assert watcher
  state.

## Test plan

- [ ] `go build ./darepod/...`
- [ ] Server-side integration test (`TestPartialUnrollIntegrationRatchetsWatcherForward`)
      exercises this accessor end-to-end via the harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)