### PR TITLE
build: refresh docker and repo ignores

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,23 @@
-# Only include files needed for the protobuf builder image.
-# The repo is volume-mounted at runtime, so the image only needs
-# go.mod/go.sum and the protoc-gen-mailboxrpc plugin source.
-*
-!go.mod
-!go.sum
-!cmd/protoc-gen-mailboxrpc/
+.git
+.github
+.vscode
+.idea
+.serena
+.reviews
+.claude
+.claude/worktrees
+*.log
+*.test
+*.out
+bin/
+**/test-artifacts
+**/build/
+**/log/
+**/data/
+**/datadir/
+**/.cache/
+**/.gocache/
+DS_Store
+._.DS_Store
+**/.DS_Store
+**/._.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,6 @@ DS_Store
 
 # Go workspace sum file - regenerated locally as needed.
 go.work.sum
-
 /tools/custom-gcl
 .reviews/
+.claude/worktrees/

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ WORKDIR /build
 # that workspace-only dependencies are also downloaded in this layer.
 COPY go.mod go.sum go.work go.work.sum* ./
 COPY baselib/go.mod baselib/go.sum ./baselib/
+COPY tools/go.mod tools/go.sum ./tools/
 
 RUN go mod download
 


### PR DESCRIPTION
## Summary

Extracted from #212 to keep the policy-first migration reviewable.

This PR contains the Dockerfile and ignore-list housekeeping that is useful, but orthogonal to the client policy migration.

## Test Plan

- [ ] Not run (build/ignore-only change)
