### PR TITLE
serverconn: trim docs and obsolete durable-unary tests

### DIFF
--- a/serverconn/actor.go
+++ b/serverconn/actor.go
@@ -538,9 +538,9 @@ func (m *SendUnaryRequest) serverConnMsgSealed() {}
 // ServerConnectionActor is the unified connector boundary for all mailbox
 // traffic between the client and the remote server. It serves as both:
 //
-//  1. An egress actor: receives outbound messages from durable protocol actors
-//     (for example round and OOR) plus unary facade requests, then sends them
-//     via the mailbox edge.
+//  1. An egress actor: receives outbound messages from the round actor (FSM
+//     events) and unary facade (RPC requests), then sends them via the
+//     mailbox edge.
 //
 //  2. An ingress loop: continuously pulls envelopes from the remote mailbox,
 //     dispatches them to local actors via ServiceKey-based routing, and
@@ -548,7 +548,7 @@ func (m *SendUnaryRequest) serverConnMsgSealed() {}
 //     delivery with crash safety.
 //
 // The actor is backed by a DurableActor for crash-safe egress. Outbound
-// messages from protocol actors persist in the durable mailbox before
+// messages from the round actor persist in the durable mailbox before
 // processing, ensuring no message loss on crashes.
 type ServerConnectionActor struct {
 	// cfg holds all dependencies and tuning knobs for the connector.

--- a/serverconn/connector_test.go
+++ b/serverconn/connector_test.go
@@ -631,50 +631,6 @@ func TestEgress_EventRetriesPreserveIdempotencyKey(t *testing.T) {
 	require.Equal(t, testEventMethod, envs[1].Rpc.Method)
 }
 
-// TestEventRoutingMetadata verifies how SendClientEventRequest route fields are
-// resolved when explicit values and ServerMessage metadata are combined.
-func TestEventRoutingMetadata(t *testing.T) {
-	t.Parallel()
-
-	service, method := eventRoutingMetadata(nil)
-	require.Equal(t, "", service)
-	require.Equal(t, "", method)
-
-	service, method = eventRoutingMetadata(&SendClientEventRequest{
-		Service: "svc.explicit",
-		Method:  "method.explicit",
-		Message: &testServerMessage{value: "ignored"},
-	})
-	require.Equal(t, "svc.explicit", service)
-	require.Equal(t, "method.explicit", method)
-
-	service, method = eventRoutingMetadata(&SendClientEventRequest{
-		Message: &testServerMessage{value: "fallback"},
-	})
-	require.Equal(t, testEventService, service)
-	require.Equal(t, testEventMethod, method)
-
-	service, method = eventRoutingMetadata(&SendClientEventRequest{
-		Service: "svc.partial",
-		Message: &testServerMessage{value: "fill-method"},
-	})
-	require.Equal(t, "svc.partial", service)
-	require.Equal(t, testEventMethod, method)
-
-	service, method = eventRoutingMetadata(&SendClientEventRequest{
-		Method:  "method.partial",
-		Message: &testServerMessage{value: "fill-service"},
-	})
-	require.Equal(t, testEventService, service)
-	require.Equal(t, "method.partial", method)
-
-	service, method = eventRoutingMetadata(&SendClientEventRequest{
-		Service: "svc.only",
-	})
-	require.Equal(t, "svc.only", service)
-	require.Equal(t, "", method)
-}
-
 // TestIngress_PartialDispatch_NoDuplicateRedelivery verifies that when
 // a batch dispatch fails mid-way, the already-dispatched envelopes are
 // not re-dispatched on the next loop iteration. This is a regression test

--- a/serverconn/doc.go
+++ b/serverconn/doc.go
@@ -3,11 +3,11 @@
 //
 // The connector serves as both an egress actor and an ingress loop:
 //
-//   - Egress: Receives outbound messages from round and OOR durable actors, as
-//     well as unary facade calls, then sends them via the mailbox edge. The
-//     actor is backed by a DurableActor for crash-safe egress: outbound actor
-//     messages are durably queued before processing, so crashes do not drop
-//     in-flight mailbox work.
+//   - Egress: Receives outbound messages from the round actor (FSM events) and
+//     the unary facade (RPC requests), then sends them via the mailbox edge.
+//     The actor is backed by a DurableActor for crash-safe egress — outbound
+//     messages from the round actor persist in the durable mailbox before
+//     processing, ensuring no message loss on crashes.
 //
 //   - Ingress: Continuously pulls envelopes from the remote mailbox, dispatches
 //     them to local actors via ServiceKey-based routing, and manages the ack
@@ -43,19 +43,6 @@
 // KIND_RESPONSE envelopes are delivered to in-memory response waiters via the
 // response registry. This is not durable — if the process crashes, callers'
 // contexts are cancelled and they retry.
-//
-// OOR routing is first-class in this dispatch model. Current wiring registers
-// OOR service routes for:
-//   - submit/finalize response adaptation into OOR DriveEvent requests;
-//   - incoming transfer push events from indexer service notifications; and
-//   - durable indexer-query responses used by incoming receive resolution.
-//
-// This means serverconn handles both outgoing OOR protocol traffic and
-// the corresponding ingress callbacks needed to advance the OOR FSM after
-// restart-safe delivery.
-//
-// Note: incoming OOR ack response routing is intentionally absent today because
-// the wire proto does not yet define an ack response RPC.
 //
 // # Unary Facade
 //

--- a/serverconn/restart_replay_test.go
+++ b/serverconn/restart_replay_test.go
@@ -11,7 +11,6 @@ import (
 	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 // failFirstSendEdge wraps the in-memory mailbox edge and fails the first Send
@@ -161,88 +160,4 @@ func TestEgress_RestartReplayPreservesStableIDs(t *testing.T) {
 
 	require.Equal(t, firstMsgID, replayed.MsgId)
 	require.Equal(t, firstIdemKey, replayed.IdempotencyKey)
-}
-
-// TestDurableUnary_RestartReplayPreservesStableIDs verifies a durable unary
-// query replayed after actor restart reuses the same MsgId and
-// IdempotencyKey while preserving route/correlation metadata.
-func TestDurableUnary_RestartReplayPreservesStableIDs(t *testing.T) {
-	t.Parallel()
-
-	mb := newInMemoryMailbox()
-	edge := newFailFirstSendEdge(mb)
-	store := newMemCheckpointStore()
-
-	cfg := newTestConnectorConfig(mb, store)
-	cfg.Edge = edge
-	cfg.Codec = NewServerConnCodec()
-	cfg.DurableUnaryBuilder = &testDurableUnaryBuilder{}
-
-	// First actor instance fails once and leaves the durable unary
-	// send queued for replay.
-	durable1 := newDurableConnectorForTest(cfg, 500*time.Millisecond)
-	durable1.Start()
-
-	err := durable1.TellRef().Tell(
-		t.Context(), &SendListVTXOsByScriptsRequest{
-			PkScripts: [][]byte{
-				{0x51, 0x20, 0x01},
-			},
-			AfterCursor:   11,
-			Limit:         5,
-			CorrelationID: "corr-vtxo-restart",
-		},
-	)
-	require.NoError(t, err)
-
-	require.Eventually(t, func() bool {
-		attempts, _, _ := edge.Snapshot()
-
-		return attempts >= 1
-	}, 5*time.Second, 10*time.Millisecond)
-
-	durable1.Stop()
-
-	attempts, firstMsgID, firstIdemKey := edge.Snapshot()
-	require.Equal(t, 1, attempts)
-	require.NotEmpty(t, firstMsgID)
-	require.NotEmpty(t, firstIdemKey)
-
-	mb.mu.Lock()
-	firstRunEnvs := append(
-		[]*mailboxpb.Envelope(nil), mb.mailboxes["server-1"]...,
-	)
-	mb.mu.Unlock()
-	require.Empty(t, firstRunEnvs)
-
-	// Second actor instance replays from the same durable store and then
-	// succeeds.
-	durable2 := newDurableConnectorForTest(cfg, 20*time.Millisecond)
-	durable2.Start()
-	defer durable2.Stop()
-
-	require.Eventually(t, func() bool {
-		mb.mu.Lock()
-		defer mb.mu.Unlock()
-
-		return len(mb.mailboxes["server-1"]) == 1
-	}, 8*time.Second, 10*time.Millisecond)
-
-	mb.mu.Lock()
-	replayed := mb.mailboxes["server-1"][0]
-	mb.mu.Unlock()
-
-	require.Equal(t, firstMsgID, replayed.MsgId)
-	require.Equal(t, firstIdemKey, replayed.IdempotencyKey)
-	require.Equal(
-		t, "arkrpc.IndexerService",
-		replayed.GetRpc().GetService(),
-	)
-	require.Equal(t, "ListVTXOsByScripts", replayed.GetRpc().GetMethod())
-	require.Equal(t, "corr-vtxo-restart",
-		replayed.GetRpc().GetCorrelationId())
-
-	payload := &wrapperspb.StringValue{}
-	require.NoError(t, replayed.GetBody().UnmarshalTo(payload))
-	require.Equal(t, "vtxos:1:11:5", payload.GetValue())
 }


### PR DESCRIPTION
## Summary

Extracted from #212 to keep the policy-first migration reviewable.

This PR narrows `serverconn` documentation and removes obsolete durable-unary coverage that no longer matches the connector's current role.

## Test Plan

- [x] `go test ./serverconn`
