### PR TITLE
darepod: add vHTLC custom input coverage

### DIFF
--- a/chainbackends/lnd.go
+++ b/chainbackends/lnd.go
@@ -162,7 +162,7 @@ func (b *LNDBackend) BroadcastTx(ctx context.Context, tx *wire.MsgTx,
 
 	txHash := tx.TxHash()
 	b.logger(ctx).InfoS(ctx, "Broadcasting transaction via LND",
-		slog.String("txid", txHash.String()),
+		btclog.Hex("txid", txHash[:]),
 		slog.String("label", label))
 
 	err := b.broadcaster.PublishTransaction(ctx, tx, label)
@@ -171,7 +171,7 @@ func (b *LNDBackend) BroadcastTx(ctx context.Context, tx *wire.MsgTx,
 	}
 
 	b.logger(ctx).InfoS(ctx, "Transaction broadcast successfully",
-		slog.String("txid", txHash.String()))
+		btclog.Hex("txid", txHash[:]))
 
 	return nil
 }

--- a/chainbackends/lndclient_adapters.go
+++ b/chainbackends/lndclient_adapters.go
@@ -66,8 +66,8 @@ func (e *LndClientFeeEstimator) Stop() error {
 	return nil
 }
 
-// EstimateFeePerKW returns the estimated fee rate in satoshis per
-// kilo-weight unit for the given confirmation target.
+// EstimateFeePerKW returns the estimated fee rate in satoshis per kilo-weight
+// unit for the given confirmation target.
 func (e *LndClientFeeEstimator) EstimateFeePerKW(
 	numBlocks uint32) (chainfee.SatPerKWeight, error) {
 
@@ -75,15 +75,14 @@ func (e *LndClientFeeEstimator) EstimateFeePerKW(
 		context.Background(), 30*time.Second,
 	)
 	defer cancel()
-
-	// EstimateFeeRate already returns chainfee.SatPerKWeight
-	// (it does SatPerKWeight(resp.SatPerKw) internally).
-	satPerKw, err := e.walletKit.EstimateFeeRate(
+	satPerVByte, err := e.walletKit.EstimateFeeRate(
 		ctx, int32(numBlocks),
 	)
 	if err != nil {
 		return 0, fmt.Errorf("estimate fee rate: %w", err)
 	}
+
+	satPerKw := chainfee.SatPerVByte(satPerVByte).FeePerKWeight()
 
 	return satPerKw, nil
 }

--- a/cmd/darepocli/darepoclicommands/cmd_mcp.go
+++ b/cmd/darepocli/darepoclicommands/cmd_mcp.go
@@ -322,11 +322,10 @@ func registerMCPSendTools(s *mcp.Server,
 
 	// send_oor — out-of-round send.
 	type sendOORArgs struct {
-		Address        string `json:"address,omitempty" jsonschema:"recipient address (mutually exclusive with pubkey_xonly_hex and pk_script_hex)"`                   //nolint:ll
-		PubKeyXOnlyHex string `json:"pubkey_xonly_hex,omitempty" jsonschema:"recipient 32-byte x-only pubkey hex (mutually exclusive with address and pk_script_hex)"` //nolint:ll
-		PkScriptHex    string `json:"pk_script_hex,omitempty" jsonschema:"recipient raw pk_script hex (mutually exclusive with address and pubkey_xonly_hex)"`         //nolint:ll
-		AmountSat      int64  `json:"amount_sat" jsonschema:"amount in sats"`                                                                                          //nolint:ll
-		DryRun         bool   `json:"dry_run,omitempty" jsonschema:"validate without initiating"`                                                                      //nolint:ll
+		Address        string `json:"address,omitempty" jsonschema:"recipient address (mutually exclusive with pubkey_xonly_hex)"`                   //nolint:ll
+		PubKeyXOnlyHex string `json:"pubkey_xonly_hex,omitempty" jsonschema:"recipient 32-byte x-only pubkey hex (mutually exclusive with address)"` //nolint:ll
+		AmountSat      int64  `json:"amount_sat" jsonschema:"amount in sats"`                                                                        //nolint:ll
+		DryRun         bool   `json:"dry_run,omitempty" jsonschema:"validate without initiating"`                                                    //nolint:ll
 	}
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "send_oor",
@@ -336,8 +335,7 @@ func registerMCPSendTools(s *mcp.Server,
 		args sendOORArgs) (*mcp.CallToolResult, any, error) {
 
 		recipient, err := buildOORRecipientOutput(
-			args.Address, args.PubKeyXOnlyHex,
-			args.PkScriptHex, args.AmountSat,
+			args.Address, args.PubKeyXOnlyHex, args.AmountSat,
 		)
 		if err != nil {
 			return nil, nil, err

--- a/cmd/darepocli/darepoclicommands/cmd_send.go
+++ b/cmd/darepocli/darepoclicommands/cmd_send.go
@@ -134,9 +134,6 @@ func newSendOORCmd() *cobra.Command {
 	cmd.Flags().String("pubkey", "",
 		"recipient 32-byte x-only pubkey hex")
 
-	cmd.Flags().String("pk_script", "",
-		"recipient raw pk_script hex")
-
 	cmd.Flags().Int64("amount", 0,
 		"amount in sats")
 
@@ -144,7 +141,7 @@ func newSendOORCmd() *cobra.Command {
 		"validate without initiating")
 
 	cmd.MarkFlagsMutuallyExclusive(
-		"to", "pubkey", "pk_script",
+		"to", "pubkey",
 	)
 
 	return cmd
@@ -162,12 +159,11 @@ func sendOOR(cmd *cobra.Command, _ []string) error {
 	if err := parseRequest(cmd, req, func() error {
 		address, _ := cmd.Flags().GetString("to")
 		pubKeyHex, _ := cmd.Flags().GetString("pubkey")
-		pkScriptHex, _ := cmd.Flags().GetString("pk_script")
 		amount, _ := cmd.Flags().GetInt64("amount")
 		dryRun, _ := cmd.Flags().GetBool("dry_run")
 
 		recipient, err := buildOORRecipientOutput(
-			address, pubKeyHex, pkScriptHex, amount,
+			address, pubKeyHex, amount,
 		)
 		if err != nil {
 			return err

--- a/cmd/darepocli/darepoclicommands/oor_destination.go
+++ b/cmd/darepocli/darepoclicommands/oor_destination.go
@@ -16,7 +16,7 @@ const (
 
 // buildOORRecipientOutput converts the user-facing OOR destination flags or
 // MCP args into the daemonrpc Output used by SendOOR.
-func buildOORRecipientOutput(address, pubKeyHex, pkScriptHex string,
+func buildOORRecipientOutput(address, pubKeyHex string,
 	amount int64) (*daemonrpc.Output, error) {
 
 	if amount <= 0 {
@@ -25,7 +25,6 @@ func buildOORRecipientOutput(address, pubKeyHex, pkScriptHex string,
 
 	address = strings.TrimSpace(address)
 	pubKeyHex = strings.TrimSpace(pubKeyHex)
-	pkScriptHex = strings.TrimSpace(pkScriptHex)
 
 	destinations := 0
 	if address != "" {
@@ -34,13 +33,10 @@ func buildOORRecipientOutput(address, pubKeyHex, pkScriptHex string,
 	if pubKeyHex != "" {
 		destinations++
 	}
-	if pkScriptHex != "" {
-		destinations++
-	}
 
 	if destinations != 1 {
-		return nil, fmt.Errorf("exactly one of to, pubkey, or " +
-			"pk_script is required")
+		return nil, fmt.Errorf("exactly one of to or pubkey " +
+			"is required")
 	}
 
 	output := &daemonrpc.Output{
@@ -61,16 +57,6 @@ func buildOORRecipientOutput(address, pubKeyHex, pkScriptHex string,
 
 		output.Destination = &daemonrpc.Output_Pubkey{
 			Pubkey: pubKey,
-		}
-
-	case pkScriptHex != "":
-		pkScript, err := parseOORPkScriptHex(pkScriptHex)
-		if err != nil {
-			return nil, err
-		}
-
-		output.Destination = &daemonrpc.Output_PkScript{
-			PkScript: pkScript,
 		}
 	}
 
@@ -95,18 +81,4 @@ func parseOORPubKeyHex(pubKeyHex string) ([]byte, error) {
 	}
 
 	return schnorr.SerializePubKey(pubKey), nil
-}
-
-// parseOORPkScriptHex validates and decodes a raw output script hex string.
-func parseOORPkScriptHex(pkScriptHex string) ([]byte, error) {
-	pkScript, err := hex.DecodeString(pkScriptHex)
-	if err != nil {
-		return nil, fmt.Errorf("invalid pk_script hex: %w", err)
-	}
-
-	if len(pkScript) == 0 {
-		return nil, fmt.Errorf("pk_script must not be empty")
-	}
-
-	return pkScript, nil
 }

--- a/cmd/darepocli/darepoclicommands/oor_destination_test.go
+++ b/cmd/darepocli/darepoclicommands/oor_destination_test.go
@@ -16,7 +16,7 @@ func TestBuildOORRecipientOutputAddress(t *testing.T) {
 	t.Parallel()
 
 	output, err := buildOORRecipientOutput(
-		"tb1ptestdestination", "", "", 12_345,
+		"tb1ptestdestination", "", 12_345,
 	)
 	require.NoError(t, err)
 
@@ -37,7 +37,7 @@ func TestBuildOORRecipientOutputPubKey(t *testing.T) {
 	pubKeyHex := schnorr.SerializePubKey(privKey.PubKey())
 
 	output, err := buildOORRecipientOutput(
-		"", hex.EncodeToString(pubKeyHex), "", 9_999,
+		"", hex.EncodeToString(pubKeyHex), 9_999,
 	)
 	require.NoError(t, err)
 
@@ -45,23 +45,6 @@ func TestBuildOORRecipientOutputPubKey(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, pubKeyHex, pubKey.Pubkey)
 	require.EqualValues(t, 9_999, output.AmountSat)
-}
-
-// TestBuildOORRecipientOutputPkScript verifies pk_script destinations are
-// decoded from hex.
-func TestBuildOORRecipientOutputPkScript(t *testing.T) {
-	t.Parallel()
-
-	output, err := buildOORRecipientOutput(
-		"", "", "5120deadbeef", 4_321,
-	)
-	require.NoError(t, err)
-
-	pkScript, ok := output.Destination.(*daemonrpc.Output_PkScript)
-	require.True(t, ok)
-	require.Equal(t, []byte{0x51, 0x20, 0xde, 0xad, 0xbe, 0xef},
-		pkScript.PkScript)
-	require.EqualValues(t, 4_321, output.AmountSat)
 }
 
 // TestBuildOORRecipientOutputValidation verifies the helper rejects ambiguous
@@ -73,7 +56,6 @@ func TestBuildOORRecipientOutputValidation(t *testing.T) {
 		name        string
 		address     string
 		pubKeyHex   string
-		pkScriptHex string
 		amount      int64
 		errContains string
 	}{
@@ -100,12 +82,6 @@ func TestBuildOORRecipientOutputValidation(t *testing.T) {
 			amount:      1,
 			errContains: "32-byte x-only key",
 		},
-		{
-			name:        "invalid pkscript hex",
-			pkScriptHex: "zz",
-			amount:      1,
-			errContains: "invalid pk_script hex",
-		},
 	}
 
 	for _, testCase := range testCases {
@@ -116,15 +92,15 @@ func TestBuildOORRecipientOutputValidation(t *testing.T) {
 
 			_, err := buildOORRecipientOutput(
 				testCase.address, testCase.pubKeyHex,
-				testCase.pkScriptHex, testCase.amount,
+				testCase.amount,
 			)
 			require.ErrorContains(t, err, testCase.errContains)
 		})
 	}
 }
 
-// TestMethodRegistrySendOORSchema verifies the schema advertises all OOR send
-// destination forms.
+// TestMethodRegistrySendOORSchema verifies the schema advertises the public
+// OOR send destination forms.
 func TestMethodRegistrySendOORSchema(t *testing.T) {
 	t.Parallel()
 
@@ -136,7 +112,6 @@ func TestMethodRegistrySendOORSchema(t *testing.T) {
 
 	require.Contains(t, paramNames, "to")
 	require.Contains(t, paramNames, "pubkey")
-	require.Contains(t, paramNames, "pk_script")
 	require.Contains(t, paramNames, "amount")
 }
 

--- a/daemonrpc/daemon.proto
+++ b/daemonrpc/daemon.proto
@@ -372,7 +372,9 @@ message Output {
 
         // policy_template is the serialized arkscript policy for the
         // recipient. The daemon derives the concrete pk_script from
-        // this semantic destination.
+        // this semantic destination, and APIs that need a collaborative
+        // owner key require the template to use the standard Ark VTXO
+        // shape.
         bytes policy_template = 4;
     }
 

--- a/darepod/config.go
+++ b/darepod/config.go
@@ -34,6 +34,10 @@ const (
 	// mailbox edge server.
 	DefaultServerHost = "localhost:10010"
 
+	// DefaultIndexerServerID is the canonical operator identifier used
+	// in signed indexer proofs.
+	DefaultIndexerServerID = "arkd"
+
 	// DefaultRPCTimeout is the default timeout for RPC calls to lnd.
 	DefaultRPCTimeout = 30 * time.Second
 

--- a/darepod/receive_script.go
+++ b/darepod/receive_script.go
@@ -9,7 +9,7 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/lightninglabs/darepo-client/db"
 	"github.com/lightninglabs/darepo-client/indexer"
-	"github.com/lightninglabs/darepo-client/lib/scripts"
+	"github.com/lightninglabs/darepo-client/lib/arkscript"
 	"github.com/lightninglabs/darepo-client/oor"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/keychain"
@@ -17,7 +17,19 @@ import (
 
 const (
 	defaultOORReceiveScriptRegistrationTTL = 30 * 24 * time.Hour
+
+	// oorReceiveKeyFamily is the key family used for OOR receive
+	// keys. Uses a custom family distinct from the identity key
+	// family to keep receive keys in their own derivation path.
+	oorReceiveKeyFamily = keychain.KeyFamily(987_200)
 )
+
+// DefaultOORReceiveKeyFamily returns the key family used for
+// deriving OOR receive keys. Exported so that test harnesses can
+// derive keys from the same family.
+func DefaultOORReceiveKeyFamily() keychain.KeyFamily {
+	return oorReceiveKeyFamily
+}
 
 // ownedReceiveScriptStore persists locally owned receive-script metadata.
 type ownedReceiveScriptStore interface {
@@ -70,7 +82,7 @@ func BuildPubKeyVTXOReceiveScript(recipientKey,
 		return nil, fmt.Errorf("operator key must be provided")
 	}
 
-	tapKey, err := scripts.VTXOTapKey(
+	tapKey, err := arkscript.VTXOTapKey(
 		recipientKey, operatorKey, exitDelay,
 	)
 	if err != nil {
@@ -129,6 +141,121 @@ func NewOwnedReceiveScriptSigner(store ownedReceiveScriptLookup,
 		store:         store,
 		signerFactory: signerFactory,
 	}
+}
+
+// fallbackSchnorrSigner tries the primary signer first and falls back to a
+// secondary signer when the primary cannot resolve the requested script.
+type fallbackSchnorrSigner struct {
+	primary  indexer.SchnorrSigner
+	fallback indexer.SchnorrSigner
+}
+
+// NewFallbackSchnorrSigner returns a signer that tries primary first and uses
+// fallback only when primary fails.
+func NewFallbackSchnorrSigner(primary,
+	fallback indexer.SchnorrSigner) indexer.SchnorrSigner {
+
+	switch {
+	case primary == nil:
+		return fallback
+
+	case fallback == nil:
+		return primary
+	}
+
+	return &fallbackSchnorrSigner{
+		primary:  primary,
+		fallback: fallback,
+	}
+}
+
+// SignSchnorr signs hash with the primary signer, falling back on error.
+func (s *fallbackSchnorrSigner) SignSchnorr(
+	pkScript []byte, hash [32]byte) ([]byte, error) {
+
+	if s.primary != nil {
+		sig, err := s.primary.SignSchnorr(pkScript, hash)
+		if err == nil {
+			return sig, nil
+		}
+	}
+
+	if s.fallback == nil {
+		return nil, fmt.Errorf("fallback signer not configured")
+	}
+
+	return s.fallback.SignSchnorr(pkScript, hash)
+}
+
+// SignSchnorrMessage signs a tagged message with the primary signer, falling
+// back on error.
+func (s *fallbackSchnorrSigner) SignSchnorrMessage(ctx context.Context,
+	pkScript []byte, message []byte, tag []byte) ([]byte, error) {
+
+	if s.primary != nil {
+		msgSigner, ok := s.primary.(interface {
+			SignSchnorrMessage(context.Context, []byte, []byte,
+				[]byte) ([]byte, error)
+		})
+		if ok {
+			sig, err := msgSigner.SignSchnorrMessage(
+				ctx, pkScript, message, tag,
+			)
+			if err == nil {
+				return sig, nil
+			}
+		}
+	}
+
+	if s.fallback == nil {
+		return nil, fmt.Errorf("fallback signer not configured")
+	}
+
+	msgSigner, ok := s.fallback.(interface {
+		SignSchnorrMessage(context.Context, []byte, []byte,
+			[]byte) ([]byte, error)
+	})
+	if !ok {
+		return nil, fmt.Errorf("fallback signer does not support " +
+			"tagged message signing")
+	}
+
+	return msgSigner.SignSchnorrMessage(
+		ctx, pkScript, message, tag,
+	)
+}
+
+// ProofPubKey returns the proof pubkey from the primary signer, falling back
+// on error.
+func (s *fallbackSchnorrSigner) ProofPubKey(
+	pkScript []byte) (*btcec.PublicKey, error) {
+
+	if s.primary != nil {
+		pubKeySource, ok := s.primary.(interface {
+			ProofPubKey([]byte) (*btcec.PublicKey, error)
+		})
+		if ok {
+			pubKey, err := pubKeySource.ProofPubKey(pkScript)
+			if err == nil {
+				return pubKey, nil
+			}
+		}
+	}
+
+	if s.fallback == nil {
+		return nil, fmt.Errorf("fallback signer not configured")
+	}
+
+	pubKeySource, ok := s.fallback.(interface {
+		ProofPubKey([]byte) (*btcec.PublicKey, error)
+	})
+	if !ok {
+		return nil, fmt.Errorf(
+			"fallback signer does not expose proof pubkey",
+		)
+	}
+
+	return pubKeySource.ProofPubKey(pkScript)
 }
 
 // resolveSigner loads the locally owned key for pkScript and constructs the

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -1,8 +1,11 @@
 package darepod
 
 import (
+	"bytes"
 	"context"
+	"database/sql"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strconv"
@@ -19,14 +22,17 @@ import (
 	"github.com/lightninglabs/darepo-client/btcwbackend"
 	"github.com/lightninglabs/darepo-client/build"
 	"github.com/lightninglabs/darepo-client/daemonrpc"
-	"github.com/lightninglabs/darepo-client/lib/scripts"
+	"github.com/lightninglabs/darepo-client/db"
+	"github.com/lightninglabs/darepo-client/lib/arkscript"
 	oortx "github.com/lightninglabs/darepo-client/lib/tx/oor"
+	"github.com/lightninglabs/darepo-client/lib/tx/psbtutil"
 	"github.com/lightninglabs/darepo-client/lwwallet"
 	"github.com/lightninglabs/darepo-client/oor"
 	"github.com/lightninglabs/darepo-client/round"
 	"github.com/lightninglabs/darepo-client/vtxo"
 	"github.com/lightninglabs/darepo-client/wallet"
 	"github.com/lightninglabs/lndclient"
+	"github.com/lightningnetwork/lnd/clock"
 	"github.com/lightningnetwork/lnd/keychain"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -297,13 +303,38 @@ func (r *RPCServer) ListVTXOs(ctx context.Context,
 
 	filtered := vtxo.FilterDescriptors(dbVTXOs, filterOpts)
 
+	var packageStore *db.OORArtifactPersistenceStore
+	for i := range filtered {
+		if filtered[i].Status == vtxo.VTXOStatusSpent ||
+			filtered[i].ChainDepth > 0 {
+
+			packageStore = r.newLocalOORArtifactStore()
+
+			break
+		}
+	}
+
 	// Convert to proto.
 	protoVTXOs := make(
 		[]*daemonrpc.VTXO, 0, len(filtered),
 	)
 	for _, v := range filtered {
-		protoVTXOs = append(protoVTXOs,
-			descriptorToProto(v))
+		protoVTXO := descriptorToProto(v)
+		if packageStore != nil &&
+			(v.Status == vtxo.VTXOStatusSpent ||
+				v.ChainDepth > 0) {
+
+			err := populatePackageCheckpointPSBTs(
+				ctx, packageStore, v, protoVTXO,
+			)
+			if err != nil {
+				return nil, status.Errorf(codes.Internal,
+					"populate package checkpoint psbts: %v",
+					err)
+			}
+		}
+
+		protoVTXOs = append(protoVTXOs, protoVTXO)
 	}
 
 	return &daemonrpc.ListVTXOsResponse{
@@ -393,6 +424,62 @@ func descriptorToProto(v *vtxo.Descriptor) *daemonrpc.VTXO {
 		CommitmentTxid: v.CommitmentTxID.String(),
 		ChainDepth:     uint32(v.ChainDepth),
 	}
+}
+
+// newLocalOORArtifactStore returns the local artifact store used to resolve
+// persisted OOR package checkpoints for spent VTXOs.
+func (r *RPCServer) newLocalOORArtifactStore() *db.OORArtifactPersistenceStore {
+	if r.server.db == nil {
+		return nil
+	}
+
+	dbStore := db.NewStore(
+		r.server.db.DB, r.server.db.Queries,
+		r.server.db.Backend(), r.server.log,
+	)
+
+	return dbStore.NewOORArtifactStore(clock.NewDefaultClock())
+}
+
+// populatePackageCheckpointPSBTs attaches locally persisted finalized
+// checkpoint PSBTs to one VTXO response when an OOR package is available for
+// its outpoint.
+func populatePackageCheckpointPSBTs(ctx context.Context,
+	store *db.OORArtifactPersistenceStore, desc *vtxo.Descriptor,
+	protoVTXO *daemonrpc.VTXO) error {
+
+	if store == nil || desc == nil || protoVTXO == nil {
+		return nil
+	}
+
+	bundle, err := store.GetPackageForOutpoint(ctx, desc.Outpoint)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return nil
+
+	case err != nil:
+		return err
+	}
+
+	checkpoints := make(
+		[][]byte, 0, len(bundle.FinalCheckpointPSBTs),
+	)
+	for i := range bundle.FinalCheckpointPSBTs {
+		raw, err := psbtutil.Serialize(
+			bundle.FinalCheckpointPSBTs[i],
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"serialize checkpoint %d: %w", i, err,
+			)
+		}
+
+		checkpoints = append(checkpoints, raw)
+	}
+
+	protoVTXO.OorFinalCheckpointPsbts = checkpoints
+
+	return nil
 }
 
 // NewAddress generates a new boarding address that can receive
@@ -790,8 +877,7 @@ func (r *RPCServer) SendVTXO(ctx context.Context,
 			sendResp.SelectedCount),
 		slog.Int64("total_selected",
 			int64(sendResp.TotalSelected)),
-		slog.Int64("change",
-			int64(sendResp.ChangeAmount)))
+		slog.Int64("change", int64(sendResp.ChangeAmount)))
 
 	return &daemonrpc.SendVTXOResponse{
 		Status:          sendResp.Status,
@@ -860,67 +946,104 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 			"unable to fetch operator terms: %v", err)
 	}
 
-	policy := scripts.CheckpointPolicy{
+	policy := arkscript.CheckpointPolicy{
 		OperatorKey: terms.PubKey,
 		CSVDelay:    terms.VTXOExitDelay,
 	}
 
-	// Ask the wallet actor to select and lock VTXOs covering the
-	// send amount. This is atomic: selected VTXOs are locked to
-	// prevent double-spends until the transfer completes or is
-	// cancelled.
-	targetAmt := btcutil.Amount(req.Recipient.AmountSat)
-	wRef := r.server.walletRef.UnsafeFromSome()
-
-	selectReq := &wallet.SelectAndLockVTXOsRequest{
-		TargetAmount: targetAmt,
-	}
-	selectFuture := wRef.Ask(ctx, selectReq)
-	selectResult := selectFuture.Await(ctx)
-
-	selectResp, err := selectResult.Unpack()
-	if err != nil {
-		return nil, status.Errorf(codes.Internal,
-			"VTXO selection failed: %v", err)
-	}
-
-	locked, ok := selectResp.(*wallet.SelectAndLockVTXOsResponse)
-	if !ok {
-		return nil, status.Errorf(codes.Internal,
-			"unexpected response type: %T", selectResp)
-	}
-
-	// Look up full VTXO descriptors from the store and build
-	// OOR transfer inputs. This is delegated to a package-level
-	// function so a future SDK can call it directly.
-	outpoints := make(
-		[]wire.OutPoint, 0, len(locked.SelectedVTXOs),
-	)
-	for _, sv := range locked.SelectedVTXOs {
-		outpoints = append(outpoints, sv.Outpoint)
-	}
-
-	selectedInputs, err := BuildTransferInputs(
-		ctx, r.server.vtxoStore, outpoints,
+	recipientPolicyTemplate, err := r.resolveOutputPolicyTemplate(
+		ctx, req.Recipient, pkScript, terms.PubKey,
+		terms.VTXOExitDelay,
 	)
 	if err != nil {
-		if unlockErr := r.unlockVTXOs(
-			ctx, locked.SelectedVTXOs,
-		); unlockErr != nil {
-			r.server.log.ErrorS(
-				ctx, "Unable to unlock VTXOs",
-				unlockErr,
+		return nil, err
+	}
+
+	var (
+		selectedInputs []oor.TransferInput
+		locked         *wallet.SelectAndLockVTXOsResponse
+	)
+
+	if len(req.CustomInputs) > 0 {
+		// Custom inputs provided — bypass wallet selection
+		// and build TransferInputs from the specified VTXOs.
+		//
+		// NOTE: Custom inputs are not locked via the wallet
+		// actor because they typically refer to non-standard
+		// VTXOs (e.g. vHTLC outputs) that live outside the
+		// wallet's managed set. The caller is responsible for
+		// ensuring these inputs are not double-spent. A future
+		// improvement could add explicit locking for custom
+		// inputs that overlap with wallet-managed VTXOs.
+		selectedInputs, err = BuildCustomTransferInputs(
+			ctx, r.server.vtxoStore, req.CustomInputs,
+			r.server.clientKeyDesc, terms.PubKey,
+			terms.VTXOExitDelay,
+		)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal,
+				"build custom inputs: %v", err)
+		}
+	} else {
+		// Standard path: select and lock VTXOs from wallet.
+		targetAmt := btcutil.Amount(req.Recipient.AmountSat)
+		wRef := r.server.walletRef.UnsafeFromSome()
+
+		selectReq := &wallet.SelectAndLockVTXOsRequest{
+			TargetAmount: targetAmt,
+		}
+		selectFuture := wRef.Ask(ctx, selectReq)
+		selectResult := selectFuture.Await(ctx)
+
+		selectResp, err := selectResult.Unpack()
+		if err != nil {
+			return nil, status.Errorf(codes.Internal,
+				"VTXO selection failed: %v", err)
+		}
+
+		var ok bool
+		locked, ok = selectResp.(*wallet.SelectAndLockVTXOsResponse)
+		if !ok {
+			return nil, status.Errorf(codes.Internal,
+				"unexpected response type: %T",
+				selectResp)
+		}
+
+		outpoints := make(
+			[]wire.OutPoint, 0,
+			len(locked.SelectedVTXOs),
+		)
+		for _, sv := range locked.SelectedVTXOs {
+			outpoints = append(
+				outpoints, sv.Outpoint,
 			)
 		}
 
-		return nil, status.Errorf(codes.Internal,
-			"unable to build transfer inputs: %v", err)
+		selectedInputs, err = BuildTransferInputs(
+			ctx, r.server.vtxoStore, outpoints,
+		)
+		if err != nil {
+			if unlockErr := r.unlockVTXOs(
+				ctx, locked.SelectedVTXOs,
+			); unlockErr != nil {
+				r.server.log.ErrorS(ctx,
+					"Unable to unlock VTXOs",
+					unlockErr,
+				)
+			}
+
+			return nil, status.Errorf(codes.Internal,
+				"build transfer inputs: %v", err)
+		}
 	}
+
+	targetAmt := btcutil.Amount(req.Recipient.AmountSat)
 
 	// Build the recipient output for the OOR transfer.
 	recipients := []oortx.RecipientOutput{{
-		PkScript: pkScript,
-		Value:    targetAmt,
+		PkScript:           pkScript,
+		Value:              targetAmt,
+		VTXOPolicyTemplate: recipientPolicyTemplate,
 	}}
 
 	// Resolve the OOR actor via the service key registered in the
@@ -942,14 +1065,16 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 	oorResp, err := oorResult.Unpack()
 	if err != nil {
 		// Unlock VTXOs on OOR failure so they can be
-		// reused.
-		if unlockErr := r.unlockVTXOs(
-			ctx, locked.SelectedVTXOs,
-		); unlockErr != nil {
-			r.server.log.ErrorS(
-				ctx, "Unable to unlock VTXOs",
-				unlockErr,
-			)
+		// reused (only for wallet-selected inputs).
+		if locked != nil {
+			if unlockErr := r.unlockVTXOs(
+				ctx, locked.SelectedVTXOs,
+			); unlockErr != nil {
+				r.server.log.ErrorS(ctx,
+					"Unable to unlock VTXOs",
+					unlockErr,
+				)
+			}
 		}
 
 		return nil, status.Errorf(codes.Internal,
@@ -996,9 +1121,9 @@ func (r *RPCServer) unlockVTXOs(ctx context.Context,
 
 // resolveRecipientOutput extracts both the pkScript and the client
 // public key from an Output proto. The client key is required for
-// constructing VTXO descriptors in directed sends. Only the pubkey and
-// taproot address destination types are supported — raw pk_script does
-// not carry the public key needed for MuSig2.
+// constructing VTXO descriptors in directed sends, so policy-template
+// destinations must decode to the standard Ark VTXO shape with an
+// explicit owner key.
 func (r *RPCServer) resolveRecipientOutput(
 	out *daemonrpc.Output) ([]byte, *btcec.PublicKey, error) {
 
@@ -1078,18 +1203,194 @@ func (r *RPCServer) resolveRecipientOutput(
 
 		return pkScript, clientKey, nil
 
+	case *daemonrpc.Output_PolicyTemplate:
+		if len(d.PolicyTemplate) == 0 {
+			return nil, nil, fmt.Errorf(
+				"policy_template is empty",
+			)
+		}
+
+		template, err := arkscript.DecodePolicyTemplate(
+			d.PolicyTemplate,
+		)
+		if err != nil {
+			return nil, nil, fmt.Errorf(
+				"decode policy_template: %w", err,
+			)
+		}
+
+		params, err := arkscript.DecodeStandardVTXOParams(
+			template,
+		)
+		if err != nil {
+			return nil, nil, fmt.Errorf(
+				"directed sends require a standard "+
+					"policy_template: %w",
+				err,
+			)
+		}
+
+		pkScript, err := template.PkScript()
+		if err != nil {
+			return nil, nil, fmt.Errorf(
+				"derive pkScript from policy_template: %w",
+				err,
+			)
+		}
+
+		return pkScript, params.OwnerKey, nil
+
 	default:
 		return nil, nil, fmt.Errorf(
-			"directed sends require pubkey or taproot "+
-				"address destination, got %T", d,
+			"directed sends require pubkey, taproot "+
+				"address, or standard policy_template "+
+				"destination, got %T", d,
 		)
 	}
 }
 
-// resolveOutputPkScript derives a pkScript from the Output's
-// destination oneof. It supports address, raw pubkey, and raw
-// pkScript destinations. For pubkey destinations, operator terms
-// are fetched to derive a VTXO-compatible taproot output.
+// resolveOutputPolicyTemplate returns the semantic policy template to persist
+// for one OOR recipient output when it is known locally.
+func (r *RPCServer) resolveOutputPolicyTemplate(_ context.Context,
+	out *daemonrpc.Output, pkScript []byte, operatorKey *btcec.PublicKey,
+	exitDelay uint32) ([]byte, error) {
+
+	if out == nil {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"recipient must be provided")
+	}
+
+	switch d := out.Destination.(type) {
+	case *daemonrpc.Output_PolicyTemplate:
+		if len(d.PolicyTemplate) == 0 {
+			return nil, status.Errorf(codes.InvalidArgument,
+				"policy_template is empty")
+		}
+
+		if len(out.VtxoPolicyTemplate) > 0 &&
+			!bytes.Equal(
+				out.VtxoPolicyTemplate, d.PolicyTemplate,
+			) {
+
+			return nil, status.Errorf(codes.InvalidArgument,
+				"destination policy_template does not "+
+					"match vtxo_policy_template")
+		}
+
+		return validateOutputPolicyTemplate(
+			pkScript, d.PolicyTemplate, operatorKey,
+		)
+
+	case nil:
+		return nil, status.Errorf(codes.InvalidArgument,
+			"recipient destination is required")
+	}
+
+	if len(out.VtxoPolicyTemplate) > 0 {
+		return validateOutputPolicyTemplate(
+			pkScript, out.VtxoPolicyTemplate,
+			operatorKey,
+		)
+	}
+
+	switch d := out.Destination.(type) {
+	case *daemonrpc.Output_Pubkey:
+		ownerKey, err := schnorr.ParsePubKey(d.Pubkey)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument,
+				"invalid pubkey: %v", err)
+		}
+
+		return encodeStandardRecipientPolicy(
+			ownerKey, operatorKey, exitDelay, pkScript,
+		)
+
+	default:
+		return nil, nil
+	}
+}
+
+// validateOutputPolicyTemplate verifies one provided semantic policy against
+// the derived recipient script, checks Ark invariants, and returns a defensive
+// copy on success.
+func validateOutputPolicyTemplate(pkScript,
+	policyTemplate []byte,
+	operatorKey *btcec.PublicKey) ([]byte, error) {
+
+	template, err := arkscript.DecodePolicyTemplate(
+		policyTemplate,
+	)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"decode policy_template: %v", err)
+	}
+
+	if !template.MatchesPkScript(pkScript) {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"policy_template does not match output script")
+	}
+
+	// Validate Ark invariants: collab leaf with operator, CSV-gated
+	// exit leaves.
+	if operatorKey != nil {
+		nodes := make(
+			[]arkscript.Node, len(template.Leaves),
+		)
+		for i, leaf := range template.Leaves {
+			nodes[i] = leaf.Node
+		}
+
+		if err := arkscript.ValidatePolicy(
+			nodes, arkscript.PolicyValidationOpts{
+				OperatorKey: operatorKey,
+			},
+		); err != nil {
+			return nil, status.Errorf(
+				codes.InvalidArgument,
+				"policy violates Ark invariants: %v",
+				err,
+			)
+		}
+	}
+
+	return append([]byte(nil), policyTemplate...), nil
+}
+
+// encodeStandardRecipientPolicy derives the canonical standard Ark VTXO policy
+// and verifies it compiles back to the target output script.
+func encodeStandardRecipientPolicy(ownerKey, operatorKey *btcec.PublicKey,
+	exitDelay uint32, pkScript []byte) ([]byte, error) {
+
+	if ownerKey == nil || operatorKey == nil || exitDelay == 0 {
+		return nil, nil
+	}
+
+	policyTemplate, err := arkscript.EncodeStandardVTXOTemplate(
+		ownerKey, operatorKey, exitDelay,
+	)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"encode standard recipient policy: %v", err)
+	}
+
+	template, err := arkscript.DecodePolicyTemplate(policyTemplate)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"decode derived recipient policy: %v", err)
+	}
+
+	if !template.MatchesPkScript(pkScript) {
+		return nil, status.Errorf(codes.Internal,
+			"derived recipient policy does not match pk_script")
+	}
+
+	return policyTemplate, nil
+}
+
+// resolveOutputPkScript derives a pkScript from the Output's destination
+// oneof. It supports address, pubkey, and semantic policy destinations. For
+// pubkey destinations, operator terms are fetched to derive a VTXO-compatible
+// taproot output.
 func (r *RPCServer) resolveOutputPkScript(ctx context.Context,
 	out *daemonrpc.Output) ([]byte, error) {
 
@@ -1162,15 +1463,34 @@ func (r *RPCServer) resolveOutputPkScript(ctx context.Context,
 
 		return pkScript, nil
 
-	case *daemonrpc.Output_PkScript:
-		if len(d.PkScript) == 0 {
+	case *daemonrpc.Output_PolicyTemplate:
+		if len(d.PolicyTemplate) == 0 {
 			return nil, status.Errorf(
 				codes.InvalidArgument,
-				"pk_script is empty",
+				"policy_template is empty",
 			)
 		}
 
-		return d.PkScript, nil
+		template, err := arkscript.DecodePolicyTemplate(
+			d.PolicyTemplate,
+		)
+		if err != nil {
+			return nil, status.Errorf(
+				codes.InvalidArgument,
+				"decode policy_template: %v", err,
+			)
+		}
+
+		pkScript, err := template.PkScript()
+		if err != nil {
+			return nil, status.Errorf(
+				codes.InvalidArgument,
+				"derive pkScript from policy_template: %v",
+				err,
+			)
+		}
+
+		return pkScript, nil
 
 	default:
 		return nil, status.Errorf(

--- a/darepod/rpc_server_test.go
+++ b/darepod/rpc_server_test.go
@@ -4,9 +4,11 @@ import (
 	"testing"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/lightninglabs/darepo-client/lib/arkscript"
 	"github.com/stretchr/testify/require"
 )
 
@@ -87,23 +89,59 @@ func TestResolveRecipientOutputAddress(t *testing.T) {
 	require.Equal(t, xOnly, clientKey.SerializeCompressed()[1:])
 }
 
-// TestResolveRecipientOutputPkScriptRejected verifies that raw
-// pk_script destinations are rejected for directed sends.
-func TestResolveRecipientOutputPkScriptRejected(t *testing.T) {
+// TestResolveRecipientOutputPolicyTemplateStandard verifies that directed
+// sends can resolve a standard policy template into both a concrete
+// pkScript and the owner key needed for collaborative VTXO creation.
+func TestResolveRecipientOutputPolicyTemplateStandard(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRPCServer()
+
+	ownerPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	policyTemplate, err := arkscript.EncodeStandardVTXOTemplate(
+		ownerPriv.PubKey(), operatorPriv.PubKey(), 144,
+	)
+	require.NoError(t, err)
+
+	out := &daemonrpc.Output{
+		Destination: &daemonrpc.Output_PolicyTemplate{
+			PolicyTemplate: policyTemplate,
+		},
+		AmountSat: 50_000,
+	}
+
+	pkScript, clientKey, err := r.resolveRecipientOutput(out)
+	require.NoError(t, err)
+	require.NotEmpty(t, pkScript)
+	require.Equal(
+		t, schnorr.SerializePubKey(ownerPriv.PubKey()),
+		schnorr.SerializePubKey(clientKey),
+	)
+}
+
+// TestResolveRecipientOutputPolicyTemplateCustomRejected verifies that
+// directed sends reject non-standard policy templates that do not expose
+// the collaborative owner key required for VTXO creation.
+func TestResolveRecipientOutputPolicyTemplateCustomRejected(t *testing.T) {
 	t.Parallel()
 
 	r := newTestRPCServer()
 
 	out := &daemonrpc.Output{
-		Destination: &daemonrpc.Output_PkScript{
-			PkScript: []byte{0x51, 0x20, 0x01},
+		Destination: &daemonrpc.Output_PolicyTemplate{
+			PolicyTemplate: []byte{0x01},
 		},
 		AmountSat: 50_000,
 	}
 
 	_, _, err := r.resolveRecipientOutput(out)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "directed sends require")
+	require.Contains(t, err.Error(), "decode policy_template")
 }
 
 // TestResolveRecipientOutputNonTaprootRejected verifies that

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -320,21 +320,6 @@ func (s *Server) RPCAddr() net.Addr {
 	return s.rpcAddr
 }
 
-// GetStoredVTXO returns the persisted VTXO descriptor for the
-// given outpoint. This method exists for test harnesses only;
-// it lets integration tests inspect locally stored partial
-// unroll state without reaching into internal daemon fields.
-func (s *Server) GetStoredVTXO(ctx context.Context,
-	outpoint wire.OutPoint) (*vtxo.Descriptor, error) {
-
-	if s.vtxoStore == nil {
-		return nil, fmt.Errorf("client daemon VTXO " +
-			"store not initialized")
-	}
-
-	return s.vtxoStore.GetVTXO(ctx, outpoint)
-}
-
 // RunUntilShutdown starts all subsystems and blocks until the shutdown
 // interceptor fires or a fatal error occurs. The startup sequence
 // branches on the configured wallet type: in lnd mode, the daemon
@@ -535,11 +520,8 @@ func (s *Server) run(ctx context.Context,
 		)
 		defer shutdownCancel()
 
-		_ = s.actorSystem.Shutdown(shutdownCtx)
-	}()
-	defer func() {
-		if s.oorActor != nil {
-			s.oorActor.Stop()
+		if s.runtime != nil {
+			_ = s.runtime.StopAndWait(shutdownCtx)
 		}
 	}()
 
@@ -630,7 +612,21 @@ func (s *Server) run(ctx context.Context,
 			s.log.ErrorS(ctx, "gRPC server error", err)
 		}
 	}()
-	defer s.grpcServer.GracefulStop()
+	defer func() {
+		stopped := make(chan struct{})
+
+		go func() {
+			s.grpcServer.GracefulStop()
+			close(stopped)
+		}()
+
+		select {
+		case <-stopped:
+		case <-time.After(DefaultShutdownTimeout):
+			s.grpcServer.Stop()
+			<-stopped
+		}
+	}()
 
 	// -------------------------------------------------------
 	// 7-11. Mailbox transport + wallet-dependent actors.
@@ -2477,12 +2473,13 @@ func (s *Server) initWalletActor(ctx context.Context,
 		}
 
 		return &wallet.VTXODescriptor{
-			Outpoint:    desc.Outpoint,
-			Amount:      desc.Amount,
-			PkScript:    desc.PkScript,
-			Expiry:      desc.RelativeExpiry,
-			OwnerKey:    desc.OwnerKey,
-			OperatorKey: desc.OperatorKey,
+			Outpoint:       desc.Outpoint,
+			Amount:         desc.Amount,
+			PolicyTemplate: desc.PolicyTemplate,
+			PkScript:       desc.PkScript,
+			Expiry:         desc.RelativeExpiry,
+			ClientKey:      desc.ClientKey,
+			OperatorKey:    desc.OperatorKey,
 		}, nil
 	})
 
@@ -2938,7 +2935,7 @@ func (s *Server) fetchOperatorTerms(
 		}
 	}
 
-	return &types.OperatorTerms{
+	terms := &types.OperatorTerms{
 		PubKey:            pubKey,
 		BoardingExitDelay: resp.BoardingExitDelay,
 		VTXOExitDelay:     resp.VtxoExitDelay,
@@ -2951,7 +2948,9 @@ func (s *Server) fetchOperatorTerms(
 		FeeRate:           btcutil.Amount(resp.FeeRate),
 		MinOperatorFee:    btcutil.Amount(resp.MinOperatorFee),
 		MinConfirmations:  resp.MinConfirmations,
-	}, nil
+	}
+
+	return terms, nil
 }
 
 // deriveIdentityKeyEarly derives the client's identity key before the

--- a/darepod/wallet_ops.go
+++ b/darepod/wallet_ops.go
@@ -4,11 +4,15 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/lightninglabs/darepo-client/lib/scripts"
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/lightninglabs/darepo-client/lib/arkscript"
 	"github.com/lightninglabs/darepo-client/oor"
 	"github.com/lightninglabs/darepo-client/vtxo"
 	"github.com/lightningnetwork/lnd/aezeed"
+	"github.com/lightningnetwork/lnd/keychain"
 )
 
 // InitWalletFromMnemonic validates a mnemonic, derives the raw seed,
@@ -126,8 +130,8 @@ func BuildTransferInputs(ctx context.Context,
 		// between the VTXO owner and the operator, matching the
 		// VTXO's own collaborative spend path. This ensures both
 		// parties must sign the Ark tx that spends the checkpoint.
-		collabLeaf, err := scripts.MultiSigCollabTapLeaf(
-			desc.OwnerKey.PubKey, desc.OperatorKey,
+		collabLeaf, err := arkscript.MultiSigCollabTapLeaf(
+			desc.ClientKey.PubKey, desc.OperatorKey,
 		)
 		if err != nil {
 			return nil, fmt.Errorf(
@@ -140,6 +144,111 @@ func BuildTransferInputs(ctx context.Context,
 			VTXO:            desc,
 			OwnerLeafScript: collabLeaf.Script,
 		})
+	}
+
+	return inputs, nil
+}
+
+// BuildCustomTransferInputs constructs OOR transfer inputs from
+// explicit custom input specifications. This bypasses wallet VTXO
+// selection for non-standard spend paths (e.g., vHTLC claims).
+func BuildCustomTransferInputs(ctx context.Context,
+	store vtxo.VTXOStore,
+	customInputs []*daemonrpc.CustomOORInput,
+	clientKey keychain.KeyDescriptor,
+	operatorKey *btcec.PublicKey,
+	exitDelay uint32) (
+	[]oor.TransferInput, error) {
+
+	inputs := make([]oor.TransferInput, 0, len(customInputs))
+
+	for _, ci := range customInputs {
+		outpoint, err := parseOutpointString(ci.Outpoint)
+		if err != nil {
+			return nil, fmt.Errorf("parse outpoint %q: %w",
+				ci.Outpoint, err)
+		}
+
+		var desc *vtxo.Descriptor
+
+		// If the caller provided amount and pkscript, build
+		// the descriptor directly (for VTXOs not in the local
+		// store, e.g., received via OOR).
+		if ci.AmountSat > 0 && len(ci.PkScript) > 0 {
+			desc = &vtxo.Descriptor{
+				Outpoint: outpoint,
+				Amount:   btcutil.Amount(ci.AmountSat),
+				PolicyTemplate: append([]byte(nil),
+					ci.VtxoPolicyTemplate...),
+				PkScript:       ci.PkScript,
+				ClientKey:      clientKey,
+				OperatorKey:    operatorKey,
+				RelativeExpiry: exitDelay,
+			}
+		} else {
+			// Fall back to store lookup.
+			desc, err = store.GetVTXO(ctx, outpoint)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"look up VTXO %s: %w",
+					outpoint, err)
+			}
+		}
+
+		// Validate the policy template against Ark invariants
+		// when one is provided. This catches malformed policies
+		// before they reach the server.
+		if len(ci.VtxoPolicyTemplate) > 0 {
+			template, err := arkscript.DecodePolicyTemplate(
+				ci.VtxoPolicyTemplate,
+			)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"decode policy for %s: %w",
+					outpoint, err,
+				)
+			}
+
+			nodes := make(
+				[]arkscript.Node, len(template.Leaves),
+			)
+			for i, leaf := range template.Leaves {
+				nodes[i] = leaf.Node
+			}
+
+			err = arkscript.ValidatePolicy(
+				nodes, arkscript.PolicyValidationOpts{
+					OperatorKey: operatorKey,
+				},
+			)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"invalid policy for %s: %w",
+					outpoint, err,
+				)
+			}
+		}
+
+		input := oor.TransferInput{
+			VTXO:               desc,
+			VTXOPolicyTemplate: ci.VtxoPolicyTemplate,
+		}
+
+		if len(ci.SpendPath) > 0 {
+			spendPath, err := arkscript.DecodeSpendPath(
+				ci.SpendPath,
+			)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"decode spend path for %s: %w",
+					outpoint, err,
+				)
+			}
+
+			input.CustomSpend = spendPath
+		}
+
+		inputs = append(inputs, input)
 	}
 
 	return inputs, nil

--- a/darepod/wallet_ops_test.go
+++ b/darepod/wallet_ops_test.go
@@ -1,0 +1,259 @@
+package darepod
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/lightninglabs/darepo-client/lib/arkscript"
+	"github.com/lightninglabs/darepo-client/vtxo"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/stretchr/testify/require"
+)
+
+type testCustomInputStore struct {
+	desc    *vtxo.Descriptor
+	lookups []wire.OutPoint
+}
+
+func (s *testCustomInputStore) SaveVTXO(
+	context.Context, *vtxo.Descriptor) error {
+
+	return fmt.Errorf("unexpected SaveVTXO call")
+}
+
+func (s *testCustomInputStore) GetVTXO(_ context.Context,
+	outpoint wire.OutPoint) (*vtxo.Descriptor, error) {
+
+	s.lookups = append(s.lookups, outpoint)
+
+	if s.desc == nil {
+		return nil, fmt.Errorf("vtxo not found")
+	}
+
+	return s.desc, nil
+}
+
+func (s *testCustomInputStore) ListLiveVTXOs(
+	context.Context) ([]*vtxo.Descriptor,
+	error) {
+
+	return nil, fmt.Errorf("unexpected ListLiveVTXOs call")
+}
+
+func (s *testCustomInputStore) ListVTXOsByStatus(context.Context,
+	vtxo.VTXOStatus) ([]*vtxo.Descriptor, error) {
+
+	return nil, fmt.Errorf("unexpected ListVTXOsByStatus call")
+}
+
+func (s *testCustomInputStore) UpdateVTXOStatus(context.Context,
+	wire.OutPoint, vtxo.VTXOStatus) error {
+
+	return fmt.Errorf("unexpected UpdateVTXOStatus call")
+}
+
+func (s *testCustomInputStore) MarkForfeiting(context.Context, wire.OutPoint,
+	string, *wire.MsgTx) error {
+
+	return fmt.Errorf("unexpected MarkForfeiting call")
+}
+
+func (s *testCustomInputStore) GetForfeitTx(context.Context,
+	wire.OutPoint) (*wire.MsgTx, error) {
+
+	return nil, fmt.Errorf("unexpected GetForfeitTx call")
+}
+
+func (s *testCustomInputStore) MarkForfeited(context.Context,
+	wire.OutPoint, chainhash.Hash) error {
+
+	return fmt.Errorf("unexpected MarkForfeited call")
+}
+
+func (s *testCustomInputStore) DeleteVTXO(context.Context,
+	wire.OutPoint) error {
+
+	return fmt.Errorf("unexpected DeleteVTXO call")
+}
+
+func testVHTLCPolicyFixture(t *testing.T) (
+	*arkscript.VHTLCPolicy, lntypes.Preimage, *btcec.PrivateKey,
+	*btcec.PrivateKey, *btcec.PrivateKey,
+) {
+
+	t.Helper()
+
+	senderPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	receiverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	serverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	var preimage lntypes.Preimage
+	copy(preimage[:], bytes.Repeat([]byte{0x42}, len(preimage)))
+
+	policy, err := arkscript.NewVHTLCPolicy(arkscript.VHTLCOpts{
+		Sender:                               senderPriv.PubKey(),
+		Receiver:                             receiverPriv.PubKey(),
+		Server:                               serverPriv.PubKey(),
+		PreimageHash:                         preimage.Hash(),
+		RefundLocktime:                       144,
+		UnilateralClaimDelay:                 10,
+		UnilateralRefundDelay:                20,
+		UnilateralRefundWithoutReceiverDelay: 30,
+	})
+	require.NoError(t, err)
+
+	return policy, preimage, senderPriv, receiverPriv, serverPriv
+}
+
+func testWalletOpsOutpoint(seed byte) wire.OutPoint {
+	var hashBytes [32]byte
+	hashBytes[0] = seed
+
+	return wire.OutPoint{
+		Hash:  chainhash.Hash(hashBytes),
+		Index: uint32(seed),
+	}
+}
+
+// TestBuildCustomTransferInputsExternalVHTLCClaim verifies that callers can
+// provide an external vHTLC output plus explicit claim spend path without
+// consulting the local VTXO store.
+func TestBuildCustomTransferInputsExternalVHTLCClaim(t *testing.T) {
+	t.Parallel()
+
+	policy, preimage, _, receiverPriv, serverPriv :=
+		testVHTLCPolicyFixture(t)
+	policyTemplate, err := policy.Template.Encode()
+	require.NoError(t, err)
+
+	pkScript, err := policy.PkScript()
+	require.NoError(t, err)
+
+	claimPath, err := policy.ClaimPath(preimage)
+	require.NoError(t, err)
+
+	spendPath, err := claimPath.Encode()
+	require.NoError(t, err)
+
+	clientKey := keychain.KeyDescriptor{
+		PubKey: receiverPriv.PubKey(),
+		KeyLocator: keychain.KeyLocator{
+			Family: 1,
+			Index:  2,
+		},
+	}
+
+	store := &testCustomInputStore{}
+	outpoint := testWalletOpsOutpoint(1)
+
+	inputs, err := BuildCustomTransferInputs(
+		t.Context(), store, []*daemonrpc.CustomOORInput{{
+			Outpoint:           outpoint.String(),
+			VtxoPolicyTemplate: policyTemplate,
+			SpendPath:          spendPath,
+			AmountSat:          42_000,
+			PkScript:           pkScript,
+		}}, clientKey, serverPriv.PubKey(), 144,
+	)
+	require.NoError(t, err)
+	require.Len(t, inputs, 1)
+	require.Empty(t, store.lookups)
+
+	input := inputs[0]
+	require.Equal(t, outpoint, input.VTXO.Outpoint)
+	require.Equal(t, btcutil.Amount(42_000), input.VTXO.Amount)
+	require.Equal(t, pkScript, input.VTXO.PkScript)
+	require.Equal(t, policyTemplate, input.VTXOPolicyTemplate)
+	require.True(t, input.VTXO.ClientKey.PubKey.IsEqual(clientKey.PubKey))
+	require.True(t, input.VTXO.OperatorKey.IsEqual(serverPriv.PubKey()))
+	require.NoError(t, input.Validate())
+
+	effective, err := input.EffectiveSpendPath()
+	require.NoError(t, err)
+
+	effectiveRaw, err := effective.Encode()
+	require.NoError(t, err)
+	require.Equal(t, spendPath, effectiveRaw)
+}
+
+// TestBuildCustomTransferInputsStoreLookupVHTLCClaim verifies that custom
+// inputs can still use the local VTXO store when the caller only supplies
+// semantic policy and spend-path metadata.
+func TestBuildCustomTransferInputsStoreLookupVHTLCClaim(t *testing.T) {
+	t.Parallel()
+
+	policy, preimage, _, receiverPriv, serverPriv :=
+		testVHTLCPolicyFixture(t)
+	policyTemplate, err := policy.Template.Encode()
+	require.NoError(t, err)
+
+	pkScript, err := policy.PkScript()
+	require.NoError(t, err)
+
+	claimPath, err := policy.ClaimPath(preimage)
+	require.NoError(t, err)
+
+	spendPath, err := claimPath.Encode()
+	require.NoError(t, err)
+
+	outpoint := testWalletOpsOutpoint(2)
+	clientKey := keychain.KeyDescriptor{
+		PubKey: receiverPriv.PubKey(),
+		KeyLocator: keychain.KeyLocator{
+			Family: 3,
+			Index:  4,
+		},
+	}
+
+	store := &testCustomInputStore{
+		desc: &vtxo.Descriptor{
+			Outpoint:       outpoint,
+			Amount:         btcutil.Amount(55_000),
+			PolicyTemplate: policyTemplate,
+			PkScript:       pkScript,
+			ClientKey:      clientKey,
+			OperatorKey:    serverPriv.PubKey(),
+			TapScript: &waddrmgr.Tapscript{
+				Type: waddrmgr.TapscriptTypeFullTree,
+			},
+		},
+	}
+
+	inputs, err := BuildCustomTransferInputs(
+		t.Context(), store, []*daemonrpc.CustomOORInput{{
+			Outpoint:           outpoint.String(),
+			VtxoPolicyTemplate: policyTemplate,
+			SpendPath:          spendPath,
+		}}, clientKey, serverPriv.PubKey(), 144,
+	)
+	require.NoError(t, err)
+	require.Len(t, inputs, 1)
+	require.Equal(t, []wire.OutPoint{outpoint}, store.lookups)
+
+	input := inputs[0]
+	require.Equal(t, btcutil.Amount(55_000), input.VTXO.Amount)
+	require.Equal(t, pkScript, input.VTXO.PkScript)
+	require.Equal(t, policyTemplate, input.VTXOPolicyTemplate)
+	require.NoError(t, input.Validate())
+
+	effective, err := input.EffectiveSpendPath()
+	require.NoError(t, err)
+
+	effectiveRaw, err := effective.Encode()
+	require.NoError(t, err)
+	require.Equal(t, spendPath, effectiveRaw)
+}

--- a/serverconn/runtime.go
+++ b/serverconn/runtime.go
@@ -14,11 +14,9 @@ func DurableActorID(localMailboxID string) string {
 }
 
 // Runtime embeds a DurableActor for serverconn egress and wires it together
-// with the ingress loop and unary facade. Higher-level protocol actors (round,
-// OOR, and future durable mailbox clients) use TellRef for crash-safe egress.
-//
-// Because the DurableActor is embedded, Runtime can be registered directly
-// with the actor system: Ref and TellRef are promoted without wrapper methods.
+// with the ingress loop and unary facade. Because the DurableActor is
+// embedded, Runtime can be registered directly with the actor system — Ref
+// and TellRef are promoted without wrapper methods.
 type Runtime struct {
 	*actor.DurableActor[ServerConnMsg, ServerConnResp]
 
@@ -100,6 +98,14 @@ func (r *Runtime) StartIngress(ctx context.Context) error {
 func (r *Runtime) Stop() {
 	r.connector.StopIngress()
 	r.DurableActor.Stop()
+}
+
+// StopAndWait shuts down ingress polling and waits for durable egress
+// processing to exit.
+func (r *Runtime) StopAndWait(ctx context.Context) error {
+	r.connector.StopIngress()
+
+	return r.DurableActor.StopAndWait(ctx)
 }
 
 // Unary returns the unary RPC facade bound to this runtime.

--- a/systest/send_vtxo_test.go
+++ b/systest/send_vtxo_test.go
@@ -581,7 +581,7 @@ func seedLiveVTXO(t *testing.T, cfg *darepod.Config,
 	require.NoError(t, err)
 
 	descriptor, err := tree.NewVTXODescriptor(
-		amount, clientPriv.PubKey(), operatorKey, nil, 144,
+		amount, clientPriv.PubKey(), operatorKey, 144,
 	)
 	require.NoError(t, err)
 
@@ -641,7 +641,7 @@ func seedLiveVTXO(t *testing.T, cfg *darepod.Config,
 		Outpoint: outpoint,
 		Amount:   amount,
 		PkScript: descriptor.PkScript,
-		OwnerKey: keychain.KeyDescriptor{
+		ClientKey: keychain.KeyDescriptor{
 			PubKey: clientPriv.PubKey(),
 			KeyLocator: keychain.KeyLocator{
 				Family: keychain.KeyFamilyMultiSig,


### PR DESCRIPTION
## Summary

This PR adds focused unit coverage for the vHTLC custom-input path that already exists on top of the policy-first `arkscript` stack.

Rather than reviving the old `lib/vhtlc` branch shape from `#145`, this small follow-up proves the modern client flow that survived into `policy-arkscript`:

- external vHTLC outputs can be passed through `SendOOR` custom inputs without consulting the local VTXO store
- store-backed custom inputs can reconstruct the same claim path from persisted descriptor state
- `BuildCustomTransferInputs` preserves the semantic policy template and decodes the serialized `SpendPath` into an OOR input whose `EffectiveSpendPath()` matches the expected vHTLC claim path

## Why this PR

The original vHTLC work was overtaken by the later policy-first migration. In the current codebase the relevant functionality lives in:

- `lib/arkscript/vhtlc.go`
- `lib/arkscript/spend_path.go`
- `darepod/wallet_ops.go`
- `daemonrpc/daemon.proto`

So this PR keeps the review surface honest and small: it does not try to resurrect the old package layout, it just adds the focused coverage that demonstrates the modern path is still working.

## Test Plan

- [x] `go test ./darepod ./lib/arkscript ./oor -count=1`
- [x] `make lint-local`
