### PR TITLE
ci: switch CI runners to Depot for faster builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
   ########################
   static-checks:
     name: Static Checks
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     steps:
       - name: Git checkout
         uses: actions/checkout@v5
@@ -91,7 +91,7 @@ jobs:
   ########################
   lint:
     name: Lint code
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-8
     steps:
       - name: git checkout
         uses: actions/checkout@v5
@@ -116,7 +116,7 @@ jobs:
   ########################
   cross-compile:
     name: Cross compilation
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-4
     strategy:
       fail-fast: true
       matrix:
@@ -155,7 +155,7 @@ jobs:
   ########################
   unit-test:
     name: Run unit tests
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-4
     strategy:
       # Allow other tests in the matrix to continue if one fails.
       fail-fast: false
@@ -234,7 +234,7 @@ jobs:
   ########################
   systest:
     name: Run system tests
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-8
     strategy:
       # Allow other tests in the matrix to continue if one fails.
       fail-fast: false


### PR DESCRIPTION
In this PR, we migrate the CI pipeline from GitHub-hosted `ubuntu-latest`
runners to Depot-managed runners. Depot runners are single-tenant VMs with
RAM-backed disk acceleration, which cuts build and test times across the
board. Secrets stay on GitHub; Depot only provides the VMs.

The main motivation here is that our CI has gotten pretty slow as the
codebase has grown. The lint job in particular has been struggling with
memory (hence the `GOGC=50` we already set), so we're giving it an 8-core
/ 32GB runner. The systest jobs also get 8-core runners. The remaining
compilation-heavy jobs (cross-compile, unit tests) get 4-core / 16GB
runners. Static checks stay at the base 2-core tier since that workload
is light.

Depot's OIDC trust relationship is already configured for the repo. The
existing `actions/cache` setup for Go build caches is runner-agnostic and
keeps working as-is.

## Runner sizing

| Job | Before | After | Specs |
|-----|--------|-------|-------|
| static-checks | `ubuntu-latest` | `depot-ubuntu-24.04` | 2c / 8GB |
| lint | `ubuntu-latest` | `depot-ubuntu-24.04-8` | 8c / 32GB |
| cross-compile | `ubuntu-latest` | `depot-ubuntu-24.04-4` | 4c / 16GB |
| unit-test | `ubuntu-latest` | `depot-ubuntu-24.04-4` | 4c / 16GB |
| systest | `ubuntu-latest` | `depot-ubuntu-24.04-8` | 8c / 32GB |

## Benchmark results

Comparison of a recent `main` CI run on `ubuntu-latest` against Depot
runners with warm caches:

| Job | `main` (ubuntu-latest) | Depot (warm) | Speedup |
|-----|----------------------|--------------|---------|
| Static Checks | 1.5m | 0.9m | 1.7x |
| Lint code | 11.1m | 3.0m | 3.7x |
| Cross compilation (avg) | 3.0m | 2.4m | 1.3x |
| Unit tests (cover) | 8.9m | 4.3m | 2.1x |
| Unit tests (sqlite) | 9.4m | 4.8m | 2.0x |
| Unit tests (postgres) | 13.6m | 5.8m | 2.3x |
| Unit tests (race) | 13.2m | 6.9m | 1.9x |
| System tests (sqlite) | 9.1m | 3.9m | 2.3x |
| System tests (postgres) | 8.9m | 4.5m | 2.0x |
| **End-to-end (longest)** | **13.6m** | **6.9m** | **2.0x** |

End-to-end CI time cut in half. The lint job is the biggest winner,
which makes sense given it went from 2c/7GB to 8c/32GB. We can always
dial the runner sizes up or down once we have more data points.