### PR TITLE
arkscript: reuse txscript and blockchain primitives where they fit

### DIFF
--- a/lib/arkscript/settlement.go
+++ b/lib/arkscript/settlement.go
@@ -215,19 +215,10 @@ func spendPathForLeaf(policy *CompiledPolicy, leafIndex int,
 		return nil, err
 	}
 
-	seq := DeriveSequence(node)
-	lock := ExtractAbsoluteLockTime(node)
-
-	if lock != 0 && seq == 0xffffffff {
-		// CLTV requires a non-final sequence even when the leaf
-		// does not carry an Ark-level CSV delay.
-		seq = 0xfffffffe
-	}
-
 	return &SpendPath{
 		SpendInfo:        info,
-		RequiredSequence: seq,
-		RequiredLockTime: lock,
+		RequiredSequence: DeriveSequence(node),
+		RequiredLockTime: ExtractAbsoluteLockTime(node),
 		Conditions:       cloneWitnessItems(conditions),
 	}, nil
 }

--- a/lib/arkscript/settlement.go
+++ b/lib/arkscript/settlement.go
@@ -314,8 +314,17 @@ func parseAbsoluteLockTimePredicate(script []byte) (uint32, bool) {
 	return uint32(lock), true
 }
 
+// cltvScriptNumLen is the max byte length of a script number operand used
+// with OP_CHECKLOCKTIMEVERIFY, per BIP-65. Absolute locktimes can exceed
+// the 4-byte range (e.g. past Nov 2038), so CLTV permits one extra byte
+// above the default 4-byte ceiling used by most opcodes.
+const cltvScriptNumLen = 5
+
 // parseScriptNumToken decodes the current tokenizer token as a minimally
-// encoded script number.
+// encoded script number. Small-integer opcodes (OP_0, OP_1..OP_16,
+// OP_1NEGATE) are handled inline; everything else is delegated to
+// txscript.MakeScriptNum so the consensus minimal-encoding rules stay
+// anchored to the upstream interpreter.
 func parseScriptNumToken(tokenizer *txscript.ScriptTokenizer) (int64, bool) {
 	if tokenizer == nil {
 		return 0, false
@@ -338,20 +347,12 @@ func parseScriptNumToken(tokenizer *txscript.ScriptTokenizer) (int64, bool) {
 		return 0, false
 	}
 
-	negative := data[len(data)-1]&0x80 != 0
-	last := data[len(data)-1] & 0x7f
-
-	var result int64
-	for i := 0; i < len(data)-1; i++ {
-		result |= int64(data[i]) << (8 * i)
-	}
-	result |= int64(last) << (8 * (len(data) - 1))
-
-	if negative {
-		result = -result
+	num, err := txscript.MakeScriptNum(data, true, cltvScriptNumLen)
+	if err != nil {
+		return 0, false
 	}
 
-	return result, true
+	return int64(num), true
 }
 
 // sameXOnlyKey returns true when both public keys serialize to the same x-only

--- a/lib/arkscript/spend_helpers.go
+++ b/lib/arkscript/spend_helpers.go
@@ -3,6 +3,7 @@ package arkscript
 import (
 	"fmt"
 
+	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
@@ -104,11 +105,14 @@ func (s *SpendInfo) TimeoutWitness(
 // The canonical script encoding matches the arkscript CSV node:
 //
 //	<timeout_key_xonly> OP_CHECKSIG <exit_delay> OP_CSV OP_DROP
+//
+// The csvDelay parameter is a raw block count; it is converted to the
+// BIP-68 block-mode sequence encoding before being stored on the leaf.
 func UnilateralCSVTimeoutTapLeaf(timeoutKey *btcec.PublicKey,
 	csvDelay uint32) (txscript.TapLeaf, error) {
 
 	csvNode := &CSV{
-		Lock:  csvDelay,
+		Lock:  blockchain.LockTimeToSequence(false, csvDelay),
 		Inner: &Multisig{Keys: []*btcec.PublicKey{timeoutKey}},
 	}
 

--- a/lib/arkscript/standard_vtxo.go
+++ b/lib/arkscript/standard_vtxo.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/txscript"
@@ -50,6 +51,12 @@ func StandardVTXOTemplate(ownerKey, operatorKey *btcec.PublicKey,
 		return nil, fmt.Errorf("vtxo: exit delay must be non-zero")
 	}
 
+	// exitDelay is a raw block count; convert to the BIP-68 block-mode
+	// sequence encoding before storing on the CSV leaf so the field is
+	// self-describing rather than relying on the raw-blocks/encoded-blocks
+	// identity that only holds for small block counts.
+	exitSeq := blockchain.LockTimeToSequence(false, exitDelay)
+
 	return &PolicyTemplate{
 		Leaves: []LeafTemplate{{
 			Node: &Multisig{
@@ -57,7 +64,7 @@ func StandardVTXOTemplate(ownerKey, operatorKey *btcec.PublicKey,
 			},
 		}, {
 			Node: &CSV{
-				Lock: exitDelay,
+				Lock: exitSeq,
 				Inner: &Multisig{
 					Keys: []*btcec.PublicKey{ownerKey},
 				},

--- a/lib/arkscript/tree.go
+++ b/lib/arkscript/tree.go
@@ -79,39 +79,35 @@ func (p *CompiledPolicy) SpendInfo(leafIndex int) (*SpendInfo, error) {
 }
 
 // buildControlBlock constructs the BIP-341 control block for the leaf at the
-// given index.
+// given index. The merkle proof is built by our own tree walker (see
+// BuildTree) because Ark's split-at-n/2 layout differs from txscript's
+// pair-then-merge layout for non-power-of-two leaf counts; only the final
+// serialization is delegated to txscript.ControlBlock.ToBytes so the exact
+// byte layout stays anchored to the upstream taproot implementation.
 func (p *CompiledPolicy) buildControlBlock(leafIndex int) ([]byte, error) {
 	leaf := &p.Leaves[leafIndex]
 	proof := p.merkleProofs[leafIndex]
 
-	// Determine output key parity for the control byte.
-	outputKey := p.OutputKey()
-	outputKeyParity := outputKey.SerializeCompressed()[0] == 0x03
-
-	// Control block format:
-	// - 1 byte: control byte (leaf version + output key parity)
-	// - 32 bytes: internal key (x-only)
-	// - 32 * n bytes: merkle proof (sibling hashes)
-	controlBlockLen := 1 + 32 + 32*len(proof)
-	controlBlock := make([]byte, 0, controlBlockLen)
-
-	// Control byte: leaf version | (parity << 0).
-	controlByte := byte(leaf.Leaf.LeafVersion)
-	if outputKeyParity {
-		controlByte |= 0x01
-	}
-	controlBlock = append(controlBlock, controlByte)
-
-	// Append internal key (x-only, 32 bytes).
-	internalKeyBytes := p.InternalKey.SerializeCompressed()[1:]
-	controlBlock = append(controlBlock, internalKeyBytes...)
-
-	// Append merkle proof (sibling hashes from leaf to root).
+	// Flatten the sibling hashes into the concatenated inclusion proof
+	// form that ControlBlock expects.
+	inclusionProof := make([]byte, 0, chainhash.HashSize*len(proof))
 	for _, siblingHash := range proof {
-		controlBlock = append(controlBlock, siblingHash[:]...)
+		inclusionProof = append(inclusionProof, siblingHash[:]...)
 	}
 
-	return controlBlock, nil
+	// The output key parity bit is derived from the compressed SEC1
+	// encoding: 0x02 is even, 0x03 is odd.
+	outputKey := p.OutputKey()
+	outputKeyYIsOdd := outputKey.SerializeCompressed()[0] == 0x03
+
+	ctrlBlock := txscript.ControlBlock{
+		InternalKey:     p.InternalKey,
+		OutputKeyYIsOdd: outputKeyYIsOdd,
+		LeafVersion:     leaf.Leaf.LeafVersion,
+		InclusionProof:  inclusionProof,
+	}
+
+	return ctrlBlock.ToBytes()
 }
 
 // SpendInfo contains the witness-level data needed to spend a specific

--- a/lib/arkscript/tree.go
+++ b/lib/arkscript/tree.go
@@ -153,17 +153,10 @@ func (p *CompiledPolicy) SpendPathForNode(
 		return nil, err
 	}
 
-	seq := DeriveSequence(node)
-	lock := ExtractAbsoluteLockTime(node)
-
-	if lock != 0 && seq == 0xffffffff {
-		seq = 0xfffffffe
-	}
-
 	return &SpendPath{
 		SpendInfo:        info,
-		RequiredSequence: seq,
-		RequiredLockTime: lock,
+		RequiredSequence: DeriveSequence(node),
+		RequiredLockTime: ExtractAbsoluteLockTime(node),
 		Conditions:       cloneWitnessItems(conditions),
 	}, nil
 }

--- a/lib/arkscript/vhtlc.go
+++ b/lib/arkscript/vhtlc.go
@@ -3,6 +3,7 @@ package arkscript
 import (
 	"fmt"
 
+	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/lightningnetwork/lnd/lntypes"
@@ -121,10 +122,25 @@ func NewVHTLCPolicy(opts VHTLCOpts) (*VHTLCPolicy, error) {
 		},
 	}
 
+	// The delay fields on VHTLCOpts are raw block counts; wrap them with
+	// blockchain.LockTimeToSequence so the CSV leaf explicitly stores the
+	// BIP-68 block-mode encoding rather than relying on the identity
+	// collapse of "raw blocks == encoded sequence" that only holds for
+	// small values in block mode.
+	claimSeq := blockchain.LockTimeToSequence(
+		false, opts.UnilateralClaimDelay,
+	)
+	refundSeq := blockchain.LockTimeToSequence(
+		false, opts.UnilateralRefundDelay,
+	)
+	refundNoRecvSeq := blockchain.LockTimeToSequence(
+		false, opts.UnilateralRefundWithoutReceiverDelay,
+	)
+
 	// 4. UnilateralClaim: CSV(delay) + SHA256(preimage) +
 	// Multisig([receiver]).
 	unilateralClaimClosure := &CSV{
-		Lock: opts.UnilateralClaimDelay,
+		Lock: claimSeq,
 		Inner: &Condition{
 			Predicate: claimPredicate,
 			Inner: &Multisig{
@@ -135,7 +151,7 @@ func NewVHTLCPolicy(opts VHTLCOpts) (*VHTLCPolicy, error) {
 
 	// 5. UnilateralRefund: CSV(delay) + Multisig([sender, receiver]).
 	unilateralRefundClosure := &CSV{
-		Lock: opts.UnilateralRefundDelay,
+		Lock: refundSeq,
 		Inner: &Multisig{
 			Keys: []*btcec.PublicKey{
 				opts.Sender, opts.Receiver,
@@ -146,7 +162,7 @@ func NewVHTLCPolicy(opts VHTLCOpts) (*VHTLCPolicy, error) {
 	// 6. UnilateralRefundWithoutReceiver: CSV(delay) +
 	// Multisig([sender]).
 	unilateralRefundWithoutReceiverClosure := &CSV{
-		Lock: opts.UnilateralRefundWithoutReceiverDelay,
+		Lock: refundNoRecvSeq,
 		Inner: &Multisig{
 			Keys: []*btcec.PublicKey{opts.Sender},
 		},

--- a/lib/arkscript/vtxo.go
+++ b/lib/arkscript/vtxo.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/wire"
 )
 
 // VTXOPolicy represents a compiled VTXO taproot policy with canonical
@@ -81,8 +82,10 @@ func NewVTXOPolicy(ownerKey, operatorKey *btcec.PublicKey,
 
 // DeriveSequence returns the required nSequence value for spending the given
 // AST node. This implements the tx-context derivation rules from the RFC:
-// - If the node contains CSV(lock, ...), return the lock value.
-// - Else return 0xffffffff.
+//   - If the node contains CSV(lock, ...), return the lock value.
+//   - If the node contains CLTV, return the "non-final" sentinel
+//     (wire.MaxTxInSequenceNum - 1) so OP_CHECKLOCKTIMEVERIFY can evaluate.
+//   - Otherwise return the fully-final wire.MaxTxInSequenceNum.
 func DeriveSequence(node Node) uint32 {
 	csvLock := extractCSVDelay(node)
 	if csvLock > 0 {
@@ -90,12 +93,13 @@ func DeriveSequence(node Node) uint32 {
 	}
 
 	// If the node contains CLTV, nSequence must be non-final to allow
-	// OP_CHECKLOCKTIMEVERIFY evaluation.
+	// OP_CHECKLOCKTIMEVERIFY evaluation. Subtracting one from the
+	// fully-final value gives the canonical "CLTV-enabled" sequence.
 	if ExtractAbsoluteLockTime(node) > 0 {
-		return 0xfffffffe
+		return wire.MaxTxInSequenceNum - 1
 	}
 
-	return 0xffffffff
+	return wire.MaxTxInSequenceNum
 }
 
 // DeriveLockTime returns the required nLockTime value for spending the given


### PR DESCRIPTION
In this PR, we replace a handful of hand-rolled primitives inside `lib/arkscript` with equivalents from `btcsuite/txscript`, `btcsuite/blockchain`, and `btcsuite/wire`. The motivation was a walkthrough of the Ark AST looking for spots where we were re-implementing something the upstream taproot/consensus code already does. In each case the goal is to stay anchored to the reference implementation so future consensus nits land in one place rather than in parallel copies scattered through the policy compiler.

## What stays custom

Before the replacements, one thing worth calling out: we can't drop in `txscript.AssembleTaprootScriptTree` as a full replacement for `BuildTree`. Ark's tree layout uses a recursive split-at-n/2 construction while the upstream helper pairs leaves two-at-a-time and merges the odd one into the last branch. For any leaf count that isn't a power of two (i.e., the 6-leaf vHTLC and any variable-sized settlement branch), the two algorithms produce different merkle roots, which would change the taproot output key and break every golden vector we have. So the tree walker and the per-leaf merkle proof collection stay ours. What we can safely delegate is the serialization layer that sits on top of the proof, which is what the first commit does.

## Commit-by-commit

**`arkscript: delegate control block serialization to txscript.ControlBlock`** swaps the hand-rolled byte layout in `buildControlBlock` for a `txscript.ControlBlock` struct serialized via `ToBytes`. We still compute the merkle proof ourselves (see above), but the final control byte + internal key + inclusion proof layout now matches upstream byte-for-byte and picks up `ParseControlBlock` as a symmetric decoder if we ever need it.

**`arkscript: delegate script number parsing to txscript.MakeScriptNum`** replaces the hand-rolled minimal script-number decoder in `parseScriptNumToken` with `txscript.MakeScriptNum`. The small-integer opcode fast path (`OP_0`, `OP_1..OP_16`, `OP_1NEGATE`) stays inline since `MakeScriptNum` only handles data-push operands. We also define `cltvScriptNumLen = 5` to document why CLTV gets one extra byte above the usual 4-byte ceiling: absolute locktimes can exceed 2^31 once we cross the Nov 2038 threshold, which is exactly what BIP-65 carves out.

**`arkscript: use wire.MaxTxInSequenceNum for sequence sentinels`** replaces the `0xffffffff` and `0xfffffffe` magic values in `DeriveSequence`, `spendPathForLeaf`, and `SpendPathForNode` with `wire.MaxTxInSequenceNum` and `wire.MaxTxInSequenceNum - 1`. No behavioral change, the intent just reads directly now.

**`arkscript: encode CSV locks via blockchain.LockTimeToSequence`** wraps the raw-block-count values flowing into `CSV.Lock` with `blockchain.LockTimeToSequence(false, delay)`. The `CSV.Lock` field is documented as BIP-68 encoded, but every construction site was passing raw block counts and relying on the fact that block-mode encoding is an identity collapse for small values. Now the encoding is explicit, and there's an obvious extension point if a future caller wants seconds-granularity without reverse-engineering the encoding at the call site. No behavioral change for current callers.

## Test plan

- [x] `go test ./lib/arkscript/... -count=1` passes (golden byte-identity vectors still match)
- [x] `go test ./lib/...` passes (no downstream breakage in scripts, tree, tx/*, bip322, etc.)
- [x] `make lint-native` clean