### PR TITLE
arkscript: policy-first followup hardening

### DIFF
--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -75,7 +75,7 @@ func NewRPCServer(server *Server) *RPCServer {
 // function reverses the claim and is safe to call on either success or
 // failure paths (e.g. via defer).
 func (r *RPCServer) reserveCustomInputs(
-	outpoints []wire.OutPoint) (release func(), err error) {
+	outpoints []wire.OutPoint) (func(), error) {
 
 	r.customInputLocksMu.Lock()
 	defer r.customInputLocksMu.Unlock()
@@ -94,7 +94,7 @@ func (r *RPCServer) reserveCustomInputs(
 		r.customInputLocks[outpoints[i]] = struct{}{}
 	}
 
-	release = func() {
+	release := func() {
 		r.customInputLocksMu.Lock()
 		defer r.customInputLocksMu.Unlock()
 

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -43,13 +44,66 @@ type RPCServer struct {
 	daemonrpc.UnimplementedDaemonServiceServer
 
 	server *Server
+
+	// customInputLocksMu guards customInputLocks. Together they form
+	// a lightweight in-memory mutex on custom OOR input outpoints
+	// currently being processed by concurrent SendOOR calls. Without
+	// this gate two concurrent callers supplying the same custom
+	// input (e.g. the same vHTLC claim outpoint) could each succeed
+	// through BuildCustomTransferInputs and end up double-signing
+	// the same input. Standard wallet-managed VTXOs are locked via
+	// the VTXO manager's reservation flow; custom inputs live
+	// outside that managed set, so we dedup them here.
+	customInputLocksMu sync.Mutex
+
+	// customInputLocks is the set of custom OOR input outpoints
+	// currently reserved by an in-flight SendOOR call.
+	customInputLocks map[wire.OutPoint]struct{}
 }
 
 // NewRPCServer creates a new RPCServer backed by the given Server.
 func NewRPCServer(server *Server) *RPCServer {
 	return &RPCServer{
-		server: server,
+		server:           server,
+		customInputLocks: make(map[wire.OutPoint]struct{}),
 	}
+}
+
+// reserveCustomInputs atomically claims every outpoint in the supplied
+// slice. If any outpoint is already reserved by another in-flight call,
+// no claims are taken and an error is returned. The returned release
+// function reverses the claim and is safe to call on either success or
+// failure paths (e.g. via defer).
+func (r *RPCServer) reserveCustomInputs(
+	outpoints []wire.OutPoint) (release func(), err error) {
+
+	r.customInputLocksMu.Lock()
+	defer r.customInputLocksMu.Unlock()
+
+	// First pass: check for collisions so we don't partially reserve.
+	for i := range outpoints {
+		if _, taken := r.customInputLocks[outpoints[i]]; taken {
+			return nil, fmt.Errorf("custom input %s already "+
+				"reserved by another in-flight SendOOR",
+				outpoints[i])
+		}
+	}
+
+	// Second pass: commit the reservations.
+	for i := range outpoints {
+		r.customInputLocks[outpoints[i]] = struct{}{}
+	}
+
+	release = func() {
+		r.customInputLocksMu.Lock()
+		defer r.customInputLocksMu.Unlock()
+
+		for i := range outpoints {
+			delete(r.customInputLocks, outpoints[i])
+		}
+	}
+
+	return release, nil
 }
 
 // GetInfo returns basic information about the running daemon instance,
@@ -890,6 +944,8 @@ func (r *RPCServer) SendVTXO(ctx context.Context,
 // SendOOR initiates an out-of-round transfer directly between the
 // client and operator, without waiting for a round. The transfer
 // completes asynchronously via the OOR protocol.
+//
+//nolint:funlen
 func (r *RPCServer) SendOOR(ctx context.Context,
 	req *daemonrpc.SendOORRequest) (
 	*daemonrpc.SendOORResponse, error) {
@@ -965,16 +1021,43 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 	)
 
 	if len(req.CustomInputs) > 0 {
-		// Custom inputs provided — bypass wallet selection
-		// and build TransferInputs from the specified VTXOs.
+		// Custom inputs provided — bypass wallet selection and
+		// build TransferInputs from the specified VTXOs.
 		//
-		// NOTE: Custom inputs are not locked via the wallet
-		// actor because they typically refer to non-standard
-		// VTXOs (e.g. vHTLC outputs) that live outside the
-		// wallet's managed set. The caller is responsible for
-		// ensuring these inputs are not double-spent. A future
-		// improvement could add explicit locking for custom
-		// inputs that overlap with wallet-managed VTXOs.
+		// Custom inputs typically refer to non-standard VTXOs
+		// (e.g. vHTLC claim outpoints) that live outside the
+		// wallet's managed set and therefore are not reserved
+		// through the VTXO manager's PendingForfeit flow.
+		// Without any dedup, two concurrent SendOOR callers
+		// supplying the same custom input could each succeed
+		// through BuildCustomTransferInputs and double-sign the
+		// same outpoint. We gate that race here with an
+		// in-memory reservation keyed by outpoint; the
+		// reservation is released regardless of success or
+		// failure via defer.
+		customOutpoints := make(
+			[]wire.OutPoint, 0, len(req.CustomInputs),
+		)
+		for _, ci := range req.CustomInputs {
+			op, err := parseOutpointString(ci.Outpoint)
+			if err != nil {
+				return nil, status.Errorf(
+					codes.InvalidArgument,
+					"parse custom input outpoint %q: %v",
+					ci.Outpoint, err)
+			}
+
+			customOutpoints = append(customOutpoints, op)
+		}
+
+		release, err := r.reserveCustomInputs(customOutpoints)
+		if err != nil {
+			return nil, status.Errorf(
+				codes.Aborted,
+				"custom input double-use: %v", err)
+		}
+		defer release()
+
 		selectedInputs, err = BuildCustomTransferInputs(
 			ctx, r.server.vtxoStore, req.CustomInputs,
 			r.server.clientKeyDesc, terms.PubKey,
@@ -1279,6 +1362,7 @@ func (r *RPCServer) resolveOutputPolicyTemplate(_ context.Context,
 
 		return validateOutputPolicyTemplate(
 			pkScript, d.PolicyTemplate, operatorKey,
+			exitDelay,
 		)
 
 	case nil:
@@ -1289,7 +1373,7 @@ func (r *RPCServer) resolveOutputPolicyTemplate(_ context.Context,
 	if len(out.VtxoPolicyTemplate) > 0 {
 		return validateOutputPolicyTemplate(
 			pkScript, out.VtxoPolicyTemplate,
-			operatorKey,
+			operatorKey, exitDelay,
 		)
 	}
 
@@ -1311,11 +1395,38 @@ func (r *RPCServer) resolveOutputPolicyTemplate(_ context.Context,
 }
 
 // validateOutputPolicyTemplate verifies one provided semantic policy against
-// the derived recipient script, checks Ark invariants, and returns a defensive
-// copy on success.
+// the derived recipient script, checks structural Ark invariants, and
+// returns a defensive copy on success.
+//
+// The per-leaf exit-delay minimum is intentionally NOT enforced here:
+// non-standard recipient policies (e.g. vHTLC) legitimately carry
+// protocol-specific unilateral delays that may fall below the operator's
+// standard VTXOExitDelay. What IS enforced:
+//
+//  1. DecodePolicyTemplate — well-formed encoding.
+//  2. MatchesPkScript — the semantic policy compiles bit-for-bit to the
+//     on-chain output; this is the core binding that prevents quoting
+//     one policy on the wire while committing under another.
+//  3. ValidatePolicy structural invariants — at least one collab leaf
+//     containing the operator, at least one CSV-gated non-operator exit
+//     leaf, and no operator-unilateral spend paths anywhere in the tree.
+//  4. A non-zero operator exit delay — the zero-delay fail-closed gate
+//     inherited from the H-4/H-5 hardening: a zero operator minimum
+//     would invite callers to produce policies the operator cannot
+//     actually enforce. Standard-shape recipients are checked against
+//     their declared exit delay at the server; custom shapes carry
+//     their own per-path delays that pkScript binding transitively
+//     verifies.
+//
+// Standard-shape recipients (SendVTXO-directed sends) are pre-filtered by
+// DecodeStandardVTXOParams in resolveRecipientOutput before reaching this
+// helper, so the weaker structural check here does not relax the
+// standard-VTXO contract — it lets the OOR recipient path accept vHTLC
+// and other custom shapes, which is the intent of the arkscript policy
+// layer.
 func validateOutputPolicyTemplate(pkScript,
-	policyTemplate []byte,
-	operatorKey *btcec.PublicKey) ([]byte, error) {
+	policyTemplate []byte, operatorKey *btcec.PublicKey,
+	minExitDelay uint32) ([]byte, error) {
 
 	template, err := arkscript.DecodePolicyTemplate(
 		policyTemplate,
@@ -1330,9 +1441,18 @@ func validateOutputPolicyTemplate(pkScript,
 			"policy_template does not match output script")
 	}
 
-	// Validate Ark invariants: collab leaf with operator, CSV-gated
-	// exit leaves.
 	if operatorKey != nil {
+		// Fail closed on a zero operator minimum: this value is
+		// supplied by the server's operator terms and a zero here
+		// indicates an unconfigured or degraded operator rather
+		// than a legitimate shape choice.
+		if minExitDelay == 0 {
+			return nil, status.Errorf(
+				codes.FailedPrecondition,
+				"operator exit delay must be non-zero",
+			)
+		}
+
 		nodes := make(
 			[]arkscript.Node, len(template.Leaves),
 		)
@@ -1340,6 +1460,10 @@ func validateOutputPolicyTemplate(pkScript,
 			nodes[i] = leaf.Node
 		}
 
+		// Structural invariants only — MinExitDelay is left unset
+		// so per-leaf CSV values are not forced to meet the
+		// operator's standard-VTXO minimum. See the docstring
+		// above for why this is safe.
 		if err := arkscript.ValidatePolicy(
 			nodes, arkscript.PolicyValidationOpts{
 				OperatorKey: operatorKey,
@@ -1357,12 +1481,26 @@ func validateOutputPolicyTemplate(pkScript,
 }
 
 // encodeStandardRecipientPolicy derives the canonical standard Ark VTXO policy
-// and verifies it compiles back to the target output script.
+// and verifies it compiles back to the target output script. Fails closed
+// when any required term is missing rather than silently returning a nil
+// policy: a zero exit delay or a missing operator key would otherwise
+// produce a "policyless" VTXO and silently bypass admission validation.
 func encodeStandardRecipientPolicy(ownerKey, operatorKey *btcec.PublicKey,
 	exitDelay uint32, pkScript []byte) ([]byte, error) {
 
-	if ownerKey == nil || operatorKey == nil || exitDelay == 0 {
-		return nil, nil
+	switch {
+	case ownerKey == nil:
+		return nil, status.Errorf(codes.InvalidArgument,
+			"owner key must be provided")
+
+	case operatorKey == nil:
+		return nil, status.Errorf(codes.FailedPrecondition,
+			"operator key must be fetched before encoding "+
+				"standard recipient policy")
+
+	case exitDelay == 0:
+		return nil, status.Errorf(codes.FailedPrecondition,
+			"operator exit delay must be non-zero")
 	}
 
 	policyTemplate, err := arkscript.EncodeStandardVTXOTemplate(

--- a/darepod/rpc_server_test.go
+++ b/darepod/rpc_server_test.go
@@ -7,9 +7,12 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/txscript"
 	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/lightninglabs/darepo-client/lib/arkscript"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // newTestRPCServer creates a minimal RPCServer with chain params set
@@ -180,4 +183,143 @@ func TestResolveRecipientOutputInvalidPubkey(t *testing.T) {
 	_, _, err := r.resolveRecipientOutput(out)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "32 bytes")
+}
+
+// encodeStandardRecipientPolicy was hardened in this branch to return gRPC
+// status errors on every precondition failure instead of silently returning
+// (nil, nil). The silent-passthrough version would have emitted a
+// "policyless" VTXO that bypassed admission validation, so regression
+// coverage on the three fail-closed paths plus the happy path is essential.
+
+// TestEncodeStandardRecipientPolicyHappy verifies the happy path: valid
+// inputs whose compiled pkScript matches the caller's expected pkScript
+// return a non-empty policy template and no error.
+func TestEncodeStandardRecipientPolicyHappy(t *testing.T) {
+	t.Parallel()
+
+	ownerPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	const exitDelay uint32 = 144
+
+	// Derive the expected pkScript the way the caller in SendVTXO does:
+	// compile the standard VTXO policy and take its P2TR script.
+	policy, err := arkscript.NewVTXOPolicy(
+		ownerPriv.PubKey(), operatorPriv.PubKey(), exitDelay,
+	)
+	require.NoError(t, err)
+
+	pkScript, err := txscript.PayToTaprootScript(policy.OutputKey())
+	require.NoError(t, err)
+
+	template, err := encodeStandardRecipientPolicy(
+		ownerPriv.PubKey(), operatorPriv.PubKey(), exitDelay, pkScript,
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, template)
+}
+
+// TestEncodeStandardRecipientPolicyNilOwner verifies that a nil owner key
+// is rejected with codes.InvalidArgument and a descriptive message. A
+// silent pass-through here would let a client receive funds on a policy
+// that has no collab leaf for any owner.
+func TestEncodeStandardRecipientPolicyNilOwner(t *testing.T) {
+	t.Parallel()
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	template, err := encodeStandardRecipientPolicy(
+		nil, operatorPriv.PubKey(), 144, []byte{0x51},
+	)
+	require.Error(t, err)
+	require.Nil(t, template)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok, "expected gRPC status error, got %T", err)
+	require.Equal(t, codes.InvalidArgument, st.Code())
+	require.Contains(t, st.Message(), "owner key must be provided")
+}
+
+// TestEncodeStandardRecipientPolicyNilOperator verifies that a nil
+// operator key is rejected with codes.FailedPrecondition. This path
+// triggers when operator terms have not been fetched yet; silently
+// substituting a nil would emit a policy with no operator cosigner.
+func TestEncodeStandardRecipientPolicyNilOperator(t *testing.T) {
+	t.Parallel()
+
+	ownerPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	template, err := encodeStandardRecipientPolicy(
+		ownerPriv.PubKey(), nil, 144, []byte{0x51},
+	)
+	require.Error(t, err)
+	require.Nil(t, template)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok, "expected gRPC status error, got %T", err)
+	require.Equal(t, codes.FailedPrecondition, st.Code())
+	require.Contains(t, st.Message(), "operator key must be fetched")
+}
+
+// TestEncodeStandardRecipientPolicyZeroExitDelay verifies that a zero
+// exit delay is rejected fail-closed. A 1-block CSV would break the
+// forfeit incentive, and silently encoding with zero would defeat the
+// admission validation that downstream forfeit logic depends on.
+func TestEncodeStandardRecipientPolicyZeroExitDelay(t *testing.T) {
+	t.Parallel()
+
+	ownerPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	template, err := encodeStandardRecipientPolicy(
+		ownerPriv.PubKey(), operatorPriv.PubKey(), 0, []byte{0x51},
+	)
+	require.Error(t, err)
+	require.Nil(t, template)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok, "expected gRPC status error, got %T", err)
+	require.Equal(t, codes.FailedPrecondition, st.Code())
+	require.Contains(t, st.Message(), "exit delay must be non-zero")
+}
+
+// TestEncodeStandardRecipientPolicyPkScriptMismatch verifies that a
+// pkScript that does not match the compiled policy is rejected with
+// codes.Internal. Accepting this silently would let a caller quote one
+// script while the operator commits the VTXO under a different one.
+func TestEncodeStandardRecipientPolicyPkScriptMismatch(t *testing.T) {
+	t.Parallel()
+
+	ownerPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	// An arbitrary 34-byte P2TR script that is not the one derived from
+	// the supplied policy parameters.
+	unrelated, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	bogusPkScript, err := txscript.PayToTaprootScript(unrelated.PubKey())
+	require.NoError(t, err)
+
+	template, err := encodeStandardRecipientPolicy(
+		ownerPriv.PubKey(), operatorPriv.PubKey(), 144, bogusPkScript,
+	)
+	require.Error(t, err)
+	require.Nil(t, template)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok, "expected gRPC status error, got %T", err)
+	require.Equal(t, codes.Internal, st.Code())
+	require.Contains(t, st.Message(), "does not match pk_script")
 }

--- a/darepod/wallet_ops.go
+++ b/darepod/wallet_ops.go
@@ -209,6 +209,23 @@ func BuildCustomTransferInputs(ctx context.Context,
 				)
 			}
 
+			// When the caller also supplied a pkScript, verify
+			// the policy template compiles to that pkScript. This
+			// binds the semantic policy to the on-chain output
+			// before any signature is produced and closes the
+			// signature-oracle path where a caller could claim
+			// one policy on the wire and produce signatures
+			// against an unrelated tap tree.
+			if len(ci.PkScript) > 0 &&
+				!template.MatchesPkScript(ci.PkScript) {
+
+				return nil, fmt.Errorf(
+					"policy template for %s does not "+
+						"match supplied pkScript",
+					outpoint,
+				)
+			}
+
 			nodes := make(
 				[]arkscript.Node, len(template.Leaves),
 			)
@@ -216,6 +233,13 @@ func BuildCustomTransferInputs(ctx context.Context,
 				nodes[i] = leaf.Node
 			}
 
+			// Custom OOR inputs (e.g. vHTLC claims) have
+			// protocol-specific unilateral delays independent of
+			// the operator's standard VTXO exit delay. Validate
+			// structural invariants (collab leaf, exit leaf,
+			// CSV-gated exits, no operator-unilateral spend) but
+			// do not impose the standard-VTXO MinExitDelay
+			// minimum here.
 			err = arkscript.ValidatePolicy(
 				nodes, arkscript.PolicyValidationOpts{
 					OperatorKey: operatorKey,
@@ -241,6 +265,23 @@ func BuildCustomTransferInputs(ctx context.Context,
 			if err != nil {
 				return nil, fmt.Errorf(
 					"decode spend path for %s: %w",
+					outpoint, err,
+				)
+			}
+
+			// The spend path carries its own witness script and
+			// control block. Verify the control block commits to
+			// a taproot tree whose output key is exactly the VTXO
+			// pkScript. Without this check a caller could supply a
+			// control block for an unrelated tap tree and coerce
+			// the wallet into emitting a Schnorr signature over an
+			// attacker-chosen tapscript.
+			if err := spendPath.VerifyBindsToPkScript(
+				desc.PkScript,
+			); err != nil {
+				return nil, fmt.Errorf(
+					"spend path for %s does not bind to "+
+						"VTXO pkScript: %w",
 					outpoint, err,
 				)
 			}

--- a/darepod/wallet_ops_test.go
+++ b/darepod/wallet_ops_test.go
@@ -257,3 +257,72 @@ func TestBuildCustomTransferInputsStoreLookupVHTLCClaim(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, spendPath, effectiveRaw)
 }
+
+// TestReserveCustomInputsRejectsDoubleUse verifies that the in-memory
+// custom-input reservation map refuses to hand out the same outpoint to
+// two concurrent SendOOR calls, closing the M-1 race window.
+func TestReserveCustomInputsRejectsDoubleUse(t *testing.T) {
+	t.Parallel()
+
+	srv := &RPCServer{
+		customInputLocks: make(map[wire.OutPoint]struct{}),
+	}
+
+	op := wire.OutPoint{
+		Hash:  chainhash.HashH([]byte("m1-test-vtxo")),
+		Index: 0,
+	}
+
+	// First caller claims the outpoint.
+	release, err := srv.reserveCustomInputs([]wire.OutPoint{op})
+	require.NoError(t, err)
+	require.NotNil(t, release)
+
+	// Concurrent second caller must see the reservation and fail
+	// rather than silently succeed.
+	_, err = srv.reserveCustomInputs([]wire.OutPoint{op})
+	require.ErrorContains(t, err, "already reserved")
+
+	// After release, the outpoint is re-usable.
+	release()
+
+	release2, err := srv.reserveCustomInputs([]wire.OutPoint{op})
+	require.NoError(t, err)
+	release2()
+}
+
+// TestReserveCustomInputsAtomicOnCollision verifies that when a batch
+// reservation includes any already-reserved outpoint, none of the other
+// outpoints in the batch are claimed — the reservation is all-or-nothing.
+// Without this property a partial reservation could leak into the map and
+// block subsequent unrelated callers.
+func TestReserveCustomInputsAtomicOnCollision(t *testing.T) {
+	t.Parallel()
+
+	srv := &RPCServer{
+		customInputLocks: make(map[wire.OutPoint]struct{}),
+	}
+
+	op1 := wire.OutPoint{Hash: chainhash.HashH([]byte("op1")), Index: 0}
+	op2 := wire.OutPoint{Hash: chainhash.HashH([]byte("op2")), Index: 0}
+	op3 := wire.OutPoint{Hash: chainhash.HashH([]byte("op3")), Index: 0}
+
+	// First caller claims op2 alone.
+	release, err := srv.reserveCustomInputs([]wire.OutPoint{op2})
+	require.NoError(t, err)
+	defer release()
+
+	// Second caller attempts [op1, op2, op3]. op2 collides and the
+	// whole batch must fail; op1 and op3 must NOT end up locked.
+	_, err = srv.reserveCustomInputs(
+		[]wire.OutPoint{op1, op2, op3},
+	)
+	require.Error(t, err)
+
+	// op1 and op3 should be available to a fresh caller.
+	release2, err := srv.reserveCustomInputs(
+		[]wire.OutPoint{op1, op3},
+	)
+	require.NoError(t, err)
+	release2()
+}

--- a/db/store.go
+++ b/db/store.go
@@ -265,7 +265,12 @@ func (s *Store) NewVTXOStore(
 		s.log,
 	)
 
-	return NewVTXOPersistenceStore(roundDB, clk)
+	// Wire the daemon's subsystem logger through so rehydrate-path
+	// diagnostics (expiry drift warnings etc.) land in the daemon's
+	// log stream rather than being silently dropped.
+	return NewVTXOPersistenceStoreWithLogger(
+		roundDB, clk, fn.Some(s.log),
+	)
 }
 
 // NewOORArtifactStore builds the OOR artifact persistence store with

--- a/db/vtxo_store.go
+++ b/db/vtxo_store.go
@@ -11,12 +11,15 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/lightninglabs/darepo-client/build"
 	"github.com/lightninglabs/darepo-client/db/sqlc"
 	"github.com/lightninglabs/darepo-client/lib/arkscript"
 	"github.com/lightninglabs/darepo-client/lib/tree"
 	"github.com/lightninglabs/darepo-client/vtxo"
 	"github.com/lightningnetwork/lnd/clock"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/keychain"
 )
 
@@ -28,10 +31,20 @@ type VTXOPersistenceStore struct {
 
 	// clock provides time for timestamps.
 	clock clock.Clock
+
+	// Log is an optional logger for this persistence store. If None,
+	// the store falls back to extracting a logger from context via
+	// build.LoggerFromContext, or uses btclog.Disabled if no logger
+	// is found. Matches the fn.Option[btclog.Logger] pattern used by
+	// other subsystems (indexer.SyncClient, oor.Actor, etc.).
+	Log fn.Option[btclog.Logger]
 }
 
 // NewVTXOPersistenceStore creates a new VTXO persistence store using the
-// transaction executor pattern.
+// transaction executor pattern. The logger is unset by default; to route
+// rehydrate-path diagnostics (e.g. expiry drift warnings) through the
+// daemon's subsystem logger, set Log to fn.Some(logger) after construction
+// or use NewVTXOPersistenceStoreWithLogger.
 func NewVTXOPersistenceStore(
 	db BatchedRoundStore, c clock.Clock,
 ) *VTXOPersistenceStore {
@@ -40,6 +53,25 @@ func NewVTXOPersistenceStore(
 		db:    db,
 		clock: c,
 	}
+}
+
+// NewVTXOPersistenceStoreWithLogger constructs a VTXO persistence store
+// with an explicit logger attached.
+func NewVTXOPersistenceStoreWithLogger(
+	db BatchedRoundStore, c clock.Clock,
+	log fn.Option[btclog.Logger]) *VTXOPersistenceStore {
+
+	return &VTXOPersistenceStore{
+		db:    db,
+		clock: c,
+		Log:   log,
+	}
+}
+
+// logger returns the configured logger, falling back to extracting a
+// logger from context. If neither is available, returns btclog.Disabled.
+func (s *VTXOPersistenceStore) logger(ctx context.Context) btclog.Logger {
+	return s.Log.UnwrapOr(build.LoggerFromContext(ctx))
 }
 
 // SaveVTXO persists a new VTXO to storage. Called when a VTXO actor is created.
@@ -488,17 +520,43 @@ func (s *VTXOPersistenceStore) rowToDescriptor(
 			)
 		}
 
+		// Prefer stored compressed pubkeys when available; only
+		// lift from the policy template as a fallback. See
+		// issue #252 for the encoding-wide discussion.
 		if params, err := arkscript.DecodeStandardVTXOParams(
 			template,
 		); err == nil {
 			if operatorPubkey == nil {
 				operatorPubkey = params.OperatorKey
 			}
-			relativeExpiry = params.ExitDelay
 
 			if clientPubkey == nil {
 				clientPubkey = params.OwnerKey
 			}
+
+			// Warn on expiry drift between the stored column
+			// and the policy-derived value: they should match
+			// on a well-formed row. A mismatch points at a
+			// corrupted row or a partially-applied migration,
+			// and silently letting the policy win here would
+			// mask the divergence.
+			if relativeExpiry != 0 &&
+				relativeExpiry != params.ExitDelay {
+
+				ctx := context.Background()
+				s.logger(ctx).WarnS(
+					ctx,
+					"VTXO expiry drift between "+
+						"stored column and "+
+						"policy template",
+					nil,
+					"outpoint", outpoint.String(),
+					"stored_expiry", relativeExpiry,
+					"policy_expiry", params.ExitDelay,
+				)
+			}
+
+			relativeExpiry = params.ExitDelay
 		}
 	}
 

--- a/db/vtxo_store.go
+++ b/db/vtxo_store.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log/slog"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
@@ -167,7 +168,7 @@ func (s *VTXOPersistenceStore) GetVTXO(
 			return fmt.Errorf("get VTXO: %w", err)
 		}
 
-		desc, err := s.rowToDescriptor(row)
+		desc, err := s.rowToDescriptor(ctx, row)
 		if err != nil {
 			return fmt.Errorf("convert VTXO: %w", err)
 		}
@@ -198,7 +199,7 @@ func (s *VTXOPersistenceStore) ListLiveVTXOs(
 
 		descs := make([]*vtxo.Descriptor, 0, len(rows))
 		for _, row := range rows {
-			desc, err := s.rowToDescriptor(row)
+			desc, err := s.rowToDescriptor(ctx, row)
 			if err != nil {
 				return fmt.Errorf("convert VTXO: %w", err)
 			}
@@ -233,7 +234,7 @@ func (s *VTXOPersistenceStore) ListVTXOsByStatus(
 
 		descs := make([]*vtxo.Descriptor, 0, len(rows))
 		for _, row := range rows {
-			desc, err := s.rowToDescriptor(row)
+			desc, err := s.rowToDescriptor(ctx, row)
 			if err != nil {
 				return fmt.Errorf("convert VTXO: %w", err)
 			}
@@ -448,10 +449,12 @@ func (s *VTXOPersistenceStore) descriptorToInsertParams(
 	}, nil
 }
 
-// rowToDescriptor converts a database VTXO row to a vtxo.Descriptor.
-func (s *VTXOPersistenceStore) rowToDescriptor(
-	row VTXORow,
-) (*vtxo.Descriptor, error) {
+// rowToDescriptor converts a database VTXO row to a vtxo.Descriptor. The
+// caller's context is threaded through so any diagnostics emitted during
+// rehydrate (e.g. the expiry-drift warning) can pick up request-scoped
+// logger metadata.
+func (s *VTXOPersistenceStore) rowToDescriptor(ctx context.Context,
+	row VTXORow) (*vtxo.Descriptor, error) {
 
 	var outpointHash chainhash.Hash
 	copy(outpointHash[:], row.OutpointHash)
@@ -543,16 +546,24 @@ func (s *VTXOPersistenceStore) rowToDescriptor(
 			if relativeExpiry != 0 &&
 				relativeExpiry != params.ExitDelay {
 
-				ctx := context.Background()
 				s.logger(ctx).WarnS(
 					ctx,
 					"VTXO expiry drift between "+
 						"stored column and "+
 						"policy template",
 					nil,
-					"outpoint", outpoint.String(),
-					"stored_expiry", relativeExpiry,
-					"policy_expiry", params.ExitDelay,
+					slog.String(
+						"outpoint",
+						outpoint.String(),
+					),
+					slog.Uint64(
+						"stored_expiry",
+						uint64(relativeExpiry),
+					),
+					slog.Uint64(
+						"policy_expiry",
+						uint64(params.ExitDelay),
+					),
 				)
 			}
 

--- a/docs/arkscript_spec.md
+++ b/docs/arkscript_spec.md
@@ -1,0 +1,621 @@
+# arkscript Specification
+
+**Status:** Draft (pre-1.0)
+**Package:** `lib/arkscript`
+**Scope:** Semantic tapscript policy compiler and runtime for Ark protocol
+outputs.
+**Audience:** Auditors, implementors, and reviewers who need an authoritative
+account of what arkscript compiles to, what its on-disk/on-wire encodings
+look like, what invariants it enforces, and what it deliberately does not.
+
+---
+
+## 1. Overview
+
+arkscript is the single source of truth for the taproot outputs used in the
+Ark protocol on this client. It provides:
+
+- A **sealed AST** of spending conditions (`Node`: `Multisig`, `CSV`,
+  `Condition`).
+- A **policy layer** that composes named leaves (`PolicyTemplate`,
+  `LeafTemplate`) with stable binary encoding.
+- **Standard shapes** for the three taproot outputs the protocol uses: the
+  VTXO, the checkpoint output, and the vHTLC.
+- **Spend metadata** in the form of `SpendInfo` (script + control block) and
+  `SpendPath` (script + control block + nSequence/nLockTime + condition
+  witnesses).
+- **Validation** of the admission-surface invariants (`ValidatePolicy`,
+  `ValidateStandardVTXOPolicy`).
+
+Downstream packages (`lib/tree`, `lib/tx/*`, `oor`, `round`, `vtxo`,
+`darepod`, `db`) consume arkscript's compiled artifacts to build, sign, and
+validate Ark transactions. Only arkscript is allowed to produce tapscript
+bytes for protocol outputs; no other package is permitted to hand-roll
+taproot scripts for VTXO / checkpoint / vHTLC outputs.
+
+Related documents:
+
+- `docs/policy_arkscript_review_guide.md` — reviewer-focused walkthrough.
+- `ARCHITECTURE.md` — where arkscript sits in the package graph.
+- `docs/mailbox_architecture.md` — the transport these outputs flow over.
+
+---
+
+## 2. AST
+
+### 2.1 Node interface
+
+```go
+type Node interface {
+    Script() ([]byte, error)
+    nodeSealed()
+}
+```
+
+The `nodeSealed` marker makes `Node` a closed interface: only types defined in
+`lib/arkscript` can implement it. This prevents third-party node types from
+being smuggled into `PolicyTemplate.Leaves`, which in turn means every leaf
+script we compile has a known shape.
+
+Defined in: `lib/arkscript/node.go:14-22`.
+
+### 2.2 Concrete node kinds
+
+#### `Multisig` — N-of-N signature check
+
+```go
+type Multisig struct {
+    Keys []*btcec.PublicKey  // order matters
+}
+```
+
+Script encoding (from `scriptChecksig`, `lib/arkscript/node.go:50-65`):
+
+```
+<k0> OP_CHECKSIGVERIFY <k1> OP_CHECKSIGVERIFY ... <kn-1> OP_CHECKSIG
+```
+
+Keys are emitted as 32-byte x-only (BIP-341 requirement) via
+`schnorr.SerializePubKey`. All keys in the set must produce a valid schnorr
+signature for the script to succeed. Signatures in the witness stack must be
+provided in **reverse** of key order (the last key's CHECKSIG is evaluated
+first because the script VM is stack-based, and signatures sit below the
+witness script on the stack).
+
+#### `CSV` — relative timelock gate
+
+```go
+type CSV struct {
+    Lock  uint32  // BIP-68 encoded sequence value
+    Inner Node
+}
+```
+
+Script encoding (from `CSV.Script`, `lib/arkscript/node.go:82-101`):
+
+```
+<inner> <lock> OP_CHECKSEQUENCEVERIFY OP_DROP
+```
+
+At runtime the spending transaction's input `nSequence` must satisfy the
+BIP-68 relative-lock relation to the UTXO's confirmation height. Callers
+read the required sequence from a `SpendPath.RequiredSequence` computed by
+`DeriveSequence` (see §6).
+
+#### `Condition` — generic predicate prefix
+
+```go
+type Condition struct {
+    Predicate []byte  // canonical script fragment (enforces its own VERIFY)
+    Inner     Node
+}
+```
+
+Script encoding (from `Condition.Script`, `lib/arkscript/node.go:120-141`):
+
+```
+<predicate> <inner>
+```
+
+`Condition` is the extension point for non-signature preconditions (hash
+locks, absolute locktimes, payment-hash preimages). Helper builders live in
+`lib/arkscript/node.go:148-190`:
+
+- `Hash160Condition(hash []byte)` — `HASH160 <hash> EQUALVERIFY`.
+- `AbsoluteLockTimeCondition(lock uint32)` — `<lock> CLTV DROP`.
+- `PaymentHash160Condition(paymentHash)` — Lightning payment-hash predicate
+  that also enforces the 32-byte preimage-size rule.
+
+The predicate bytes are opaque to the AST walker for the purposes of
+`ContainsKey` and key extraction (`lib/arkscript/validate.go:90-129`). This
+is intentional: the AST reasons about *who can sign*, not about *what
+hashlock values are in play*.
+
+### 2.3 What is NOT in the AST
+
+- No `OR` nodes. Ark expresses alternatives as separate tap leaves; the
+  tapscript merkle tree already provides the OR semantics.
+- No `AND` nodes. Multisig is N-of-N; chain multiple signatures inside a
+  single `Multisig`. CSV-gated signatures compose via `CSV{Inner: Multisig}`.
+- No custom opcode escape hatch. A future node kind requires a code change
+  in `lib/arkscript` and an encoding version bump (see §3.5).
+
+---
+
+## 3. PolicyTemplate
+
+### 3.1 Shape
+
+```go
+type LeafTemplate struct {
+    Node Node
+}
+
+type PolicyTemplate struct {
+    Leaves []LeafTemplate
+}
+```
+
+Defined in: `lib/arkscript/policy_template.go:116-200`.
+
+`PolicyTemplate` preserves the author's leaf order. The canonical taproot
+tree ordering (by leaf version, then lexicographic script bytes) is applied
+at `BuildTree` time, not at encode time. Two policies with identical leaves
+in different input orders produce different encoded bytes but identical
+compiled output keys — callers should treat the encoded form as *structural*
+and the output key as *semantic*.
+
+### 3.2 Binary encoding — PolicyTemplate
+
+```
++--------+-----------+------------------+
+| 1 byte | varint    | N × leaf blob    |
+| ver    | leafCount | (each var-length)|
++--------+-----------+------------------+
+```
+
+Where:
+
+- `ver` is `policyTemplateVersion` = `1` (`lib/arkscript/policy_template.go:22`).
+- `leafCount` is a Bitcoin `VarInt`.
+- each leaf blob is a length-prefixed `LeafTemplate` encoding (below).
+
+Implemented by `PolicyTemplate.Encode` / `DecodePolicyTemplate`
+(`lib/arkscript/policy_template.go:174-287`).
+
+### 3.3 Binary encoding — LeafTemplate
+
+```
++--------+------------------+
+| 1 byte | length-prefixed  |
+| ver    | node encoding    |
++--------+------------------+
+```
+
+Where `ver` is `leafTemplateVersion` = `1` (`lib/arkscript/policy_template.go:18`).
+
+### 3.4 Binary encoding — Node
+
+Each node is `kind(1) || payload`. Payload layout by kind:
+
+| Kind            | byte | Payload                                                                |
+|-----------------|------|------------------------------------------------------------------------|
+| `Multisig`      | `1`  | `varint(keyCount) || key[0..32] × keyCount`                            |
+| `CSV`           | `2`  | `varint(lock) || varbytes(child-node-encoding)`                        |
+| `Condition`     | `3`  | `varbytes(predicate) || varbytes(child-node-encoding)`                 |
+
+Implemented by `EncodeNode` / `decodeNodePayload` / `decodeLockedNode`
+(`lib/arkscript/policy_template.go:289-595`).
+
+> **Note on key encoding:** Multisig currently encodes keys as 32-byte
+> x-only (via `schnorr.SerializePubKey`). This round-trips lossy for
+> y-parity: a compressed key with odd parity that is encoded and decoded
+> comes back with synthesised even parity. Upstream layers that need
+> lossless parity (DB columns, wire descriptors) persist the compressed
+> form in a separate column and prefer it over the lifted-from-policy
+> value during rehydration. See lightninglabs/darepo-client#252 for the
+> design discussion about whether to switch to lossless 33-byte
+> compressed encoding in the policy template itself.
+
+### 3.5 Decode limits
+
+Every decode entry point bounds allocation and CPU against
+attacker-controlled input. Constants live in
+`lib/arkscript/policy_template.go:26-56`:
+
+| Constant                   | Value  | Bounded thing                                  |
+|----------------------------|--------|------------------------------------------------|
+| `MaxPolicyTemplateBytes`   | 64 KiB | Raw size of a full policy blob.                |
+| `MaxLeafTemplateBytes`     | 16 KiB | Raw size of a single leaf blob.                |
+| `MaxPolicyLeaves`          | 32     | Leaves in one `PolicyTemplate`.                |
+| `MaxPolicyDepth`           | 16     | AST recursion depth (Condition/CSV nesting).   |
+| `MaxPolicyNodes`           | 256    | Total AST node count across one decode call.   |
+| `MaxMultisigKeys`          | 64     | Keys inside one `Multisig` node.               |
+
+Depth and node-count are shared across all leaves of a single policy decode
+via the internal `decodeBudget` — an adversary cannot claim `MaxPolicyNodes`
+per leaf. This was the fix for review finding H-2; tests in
+`lib/arkscript/policy_template_test.go:TestDecode*RejectsDeep* /
+RejectsTooMany* / BudgetSharedAcrossLeaves`.
+
+Issue lightninglabs/darepo-client#253 tracks the workload-driven tuning of
+these numbers over time.
+
+### 3.6 Versioning
+
+`policyTemplateVersion` and `leafTemplateVersion` are independent single-byte
+fields. A version bump implies:
+
+- Existing consumers reject the blob with `unknown ... version N`.
+- Producers must emit the new version only after every cluster consumer has
+  been upgraded; otherwise rolling-upgrade produces hard failures.
+
+Extensions that can be added WITHOUT a version bump:
+
+- New `Condition` predicate byte strings. Predicates are opaque to the
+  AST, so a new HTLC-style condition is just a new builder function in
+  `lib/arkscript` that emits canonical script fragments.
+
+Extensions that REQUIRE a version bump:
+
+- New node kinds (add a new `nodeKind` constant).
+- Changes to `Multisig` key encoding (e.g. switching to compressed 33-byte
+  per #252).
+- Any size/shape change to an existing payload.
+
+---
+
+## 4. CompiledPolicy and BuildTree
+
+### 4.1 Compilation
+
+`PolicyTemplate.Compile` (`lib/arkscript/policy_template.go:125-149`) walks
+each leaf's AST, calls `Node.Script()`, wraps the bytes in a
+`txscript.NewBaseTapLeaf`, and hands the result to `BuildTree`.
+
+```go
+type CompiledPolicy struct {
+    InternalKey  *btcec.PublicKey
+    Leaves       []PolicyLeaf
+    RootHash     []byte
+    leafHashes   []chainhash.Hash  // unexported: for control-block build
+    merkleProofs [][]chainhash.Hash
+}
+```
+
+Defined in `lib/arkscript/tree.go:33-53`.
+
+### 4.2 Canonical leaf ordering
+
+`sortLeaves` (`lib/arkscript/tree.go:187-198`) sorts by
+`(LeafVersion, Script)` — leaf version first, then lexicographic by script
+bytes. This gives a deterministic tap-tree shape independent of how the
+caller constructed the `PolicyTemplate`. BIP-341 further sorts child hashes
+at each merkle branch via `tapBranchHash` (`lib/arkscript/tree.go:310-320`),
+so the tree root is stable under reordering at both layers.
+
+### 4.3 Internal key: ARK NUMS point
+
+Every Ark output uses the Ark NUMS internal key
+(`lib/arkscript/nums.go`). `BuildTree` enforces this:
+
+```go
+if !internalKey.IsEqual(&ARKNUMSKey) {
+    return nil, fmt.Errorf("internal key must be the Ark NUMS key")
+}
+```
+
+(`lib/arkscript/tree.go:224-229`)
+
+Because the NUMS key is provably unspendable via key-path, every Ark output
+is script-path-only. This is the foundational invariant that the "no
+operator-unilateral spend" admission check (§7) can build on.
+
+### 4.4 Control block derivation
+
+`CompiledPolicy.SpendInfo(leafIndex)` (`lib/arkscript/tree.go:60-79`)
+returns a `*SpendInfo` with the witness script and a freshly built BIP-341
+control block:
+
+- Control byte = `LeafVersion | (outputKeyParity << 0)`.
+- Internal key = 32-byte x-only of `ARKNUMSKey`.
+- Inclusion proof = sibling hashes from leaf to root, collected during
+  tree construction.
+
+Verifying a control block is the job of the caller (typically via
+`txscript.ParseControlBlock` + `ctrlBlock.RootHash(witnessScript)`); the
+binding check `SpendPath.VerifyBindsToPkScript` is implemented in
+`lib/arkscript/spend_path.go` and used anywhere the client accepts a
+caller-supplied control block (see §9).
+
+---
+
+## 5. Standard shapes
+
+### 5.1 VTXO — `StandardVTXOTemplate`
+
+```go
+Leaves: [
+  Multisig{owner, operator},                       // collab
+  CSV{Lock: exitDelay, Inner: Multisig{owner}},    // unilateral exit
+]
+```
+
+Defined in `lib/arkscript/standard_vtxo.go:36-67`.
+
+Compiled output key computed by `VTXOTapKey` (same file); canonical P2TR
+pkScript by `EncodeStandardVTXOArtifacts`
+(`lib/arkscript/standard_vtxo.go:81-116`) — the helper used by the wallet
+when constructing recipient descriptors without touching the tree-layer
+signing key.
+
+### 5.2 Checkpoint — `CheckpointTapScript`
+
+Two-leaf tree (`lib/arkscript/checkpoint.go:43-75`):
+
+```go
+Leaves: [
+  CSV{Lock: CSVDelay, Inner: Multisig{operatorKey}},   // operator CSV unroll
+  owner-supplied leaf script,                           // collab
+]
+```
+
+The "owner-supplied" leaf is a raw script blob rather than an AST node at
+this layer — the checkpoint builder trusts the upstream `oor` pipeline to
+have produced a leaf that matches the owner's collab spend path on the
+underlying VTXO.
+
+### 5.3 vHTLC — `NewVHTLCPolicy`
+
+Six-leaf tree (`lib/arkscript/vhtlc.go`):
+
+| # | Name                              | Structure                                                                      |
+|---|-----------------------------------|--------------------------------------------------------------------------------|
+| 1 | Claim                             | `Condition{PaymentHash, Multisig{receiver, server}}`                           |
+| 2 | Refund                            | `Multisig{sender, receiver, server}`                                           |
+| 3 | UnilateralClaim                   | `CSV{UnilateralClaimDelay, Condition{PaymentHash, Multisig{receiver}}}`        |
+| 4 | UnilateralRefund                  | `CSV{UnilateralRefundDelay, Multisig{sender, receiver}}`                       |
+| 5 | UnilateralRefundAfterLocktime     | `Condition{AbsoluteLockTime(RefundLocktime), Multisig{sender}}`                |
+| 6 | UnilateralRefundWithoutReceiver   | `CSV{UnilateralRefundWithoutReceiverDelay, Multisig{sender, server}}`          |
+
+Full cross-party behaviour is documented inline at
+`lib/arkscript/vhtlc.go` — this spec only enumerates the shape.
+
+---
+
+## 6. SpendPath
+
+### 6.1 Shape
+
+```go
+type SpendPath struct {
+    *SpendInfo                     // WitnessScript + ControlBlock
+    RequiredSequence uint32        // BIP-68 (0xffffffff = no constraint)
+    RequiredLockTime uint32        // nLockTime (0 = no constraint)
+    Conditions       [][]byte      // extra witness items before script
+}
+```
+
+Defined in `lib/arkscript/spend_path.go:22-38`.
+
+### 6.2 Witness stack order
+
+`SpendPath.Witness(sigItems...)` (`lib/arkscript/spend_path.go:208-224`)
+assembles:
+
+```
+[ sig_n, sig_{n-1}, ..., sig_0,    // reverse of key order (§2.2)
+  condition_0, condition_1, ...,   // in order, as produced
+  witnessScript,
+  controlBlock ]
+```
+
+Any caller that produces its own witness manually MUST follow this exact
+order — the script VM consumes top-of-stack first, so signatures need to
+land in reverse key order.
+
+### 6.3 Tx-context requirements
+
+- `RequiredSequence` comes from `DeriveSequence(node)`
+  (`lib/arkscript/tree.go:160` via `SpendPathForNode`). For CSV-gated paths
+  it returns the `CSV.Lock` value; for non-CSV paths it returns
+  `0xffffffff` (opt-out of BIP-68).
+- `RequiredLockTime` comes from `ExtractAbsoluteLockTime(node)`. Set only
+  for leaves with an `AbsoluteLockTimeCondition`.
+- If `RequiredLockTime != 0` but `RequiredSequence == 0xffffffff`, the
+  builder drops sequence to `0xfffffffe` so CLTV is actually enforced
+  (BIP-65 requires `nSequence != 0xffffffff`).
+
+These values MUST be applied by the spending-tx builder to the
+corresponding `TxIn.Sequence` and `TxIn.TxOut`'s parent tx `LockTime`;
+otherwise the witness passes the VM at signature check but fails at the
+CSV/CLTV op-code.
+
+### 6.4 Binary encoding
+
+```
++--------+---------+----------+-----------------+---------+------+------+
+| 1 byte | varint  | N × item | witnessScript   | control | seq  | lock |
+| ver    | condCnt | varbytes | varbytes        | varbytes| varint| varint|
++--------+---------+----------+-----------------+---------+------+------+
+```
+
+Where `ver = spendPathVersion = 1` (`lib/arkscript/spend_path.go:17`). The
+decoder (`DecodeSpendPath`) caps `conditionCount` at 64 (`maxConditions`
+at `lib/arkscript/spend_path.go:131`).
+
+### 6.5 Condition witness (durable persistence)
+
+The OOR actor durably persists a `TransferInputSnapshot` that includes a
+`ConditionWitness [][]byte`. Encoded by
+`oor/actor_durable_message.go encodeConditionWitness`:
+
+```
+varint(count) || N × varbytes(item)
+```
+
+Caps (`oor/actor_durable_message.go:815-832`):
+
+| Constant                      | Value | Bounded thing                             |
+|-------------------------------|-------|-------------------------------------------|
+| `maxConditionWitnessItems`    | 64    | Item count.                               |
+| `maxConditionWitnessItemBytes`| 520   | Per-item size (Bitcoin standard script-element max). |
+
+Encoder and decoder enforce the same caps so in-memory state cannot drift
+from what the persisted form can represent.
+
+---
+
+## 7. Validation
+
+### 7.1 `ValidatePolicy` — structural
+
+Signature and invariants (`lib/arkscript/validate.go:30-120`):
+
+```go
+func ValidatePolicy(nodes []Node, opts PolicyValidationOpts) error
+
+// Invariants:
+//  1. At least one operator-containing leaf (collab).
+//  2. At least one non-operator leaf (exit).
+//  3. No leaf permits operator-unilateral spend.
+//  4. Every non-operator leaf is CSV-gated.
+//  5. If opts.MinExitDelay > 0: smallest exit delay >= opts.MinExitDelay.
+```
+
+`MinExitDelay` is optional here (zero = skip). Use
+`ValidateStandardVTXOPolicy` when that check must be mandatory (see §7.2).
+
+Invariant 3 is enforced by `rejectOperatorUnilateral`: every `Multisig`
+node reachable from every leaf's AST must contain at least one non-operator
+key. This rejects `Multisig{operator}` and `CSV{_, Multisig{operator}}`
+style leaves, which were the H-4 attack shape.
+
+### 7.2 `ValidateStandardVTXOPolicy` — strict admission
+
+```go
+func ValidateStandardVTXOPolicy(nodes []Node,
+    operatorKey *btcec.PublicKey, minExitDelay uint32) error
+```
+
+Requires `minExitDelay > 0` fail-closed, then delegates to
+`ValidatePolicy`. Use this on any admission surface that consumes a
+**standard Ark VTXO recipient** (e.g. `darepod/rpc_server.go` output
+resolver). Custom shapes (vHTLC claims from daemon RPC) continue to use
+the structural `ValidatePolicy`.
+
+### 7.3 Invariants that are NOT enforced here
+
+- **Policy-to-pkScript binding** is NOT checked by either validator —
+  that's the caller's job via `PolicyTemplate.MatchesPkScript`.
+- **Control-block-to-pkScript binding** lives on `SpendPath` (§9.2).
+- **Spec-level constraints** (e.g. "MinExitDelay comes from operator
+  terms") are imposed by the admission site, not by `arkscript`.
+
+---
+
+## 8. Encoding stability and extension guidelines
+
+| Change                                                                 | Ok without version bump? |
+|------------------------------------------------------------------------|---------------------------|
+| Add a new `Condition` predicate helper.                                | Yes.                      |
+| Add a new standard shape (e.g. multi-party vHTLC).                     | Yes, if it only composes existing nodes. |
+| Raise a `Max*` cap.                                                    | Yes (lenience is backward compatible). Announce it so operators can re-baseline. |
+| Lower a `Max*` cap.                                                    | No — breaks existing durable blobs. |
+| Add a new `nodeKind`.                                                  | Yes on write-side only — decoders in earlier versions will reject. Coordinate rollout. |
+| Change `Multisig` key encoding (e.g. 33-byte compressed per #252).     | No — bump `policyTemplateVersion` + `leafTemplateVersion`. |
+| Change the `SpendPath` binary shape.                                   | No — bump `spendPathVersion`. |
+| Change `Node.Script()` output for an existing node kind.               | No — this changes compiled output keys. |
+
+---
+
+## 9. Security considerations
+
+### 9.1 DoS decode-bomb defense
+
+The policy decoder operates on attacker-controlled bytes in at least these
+call sites (all reachable from unauthenticated network input):
+
+- `round/from_proto.go` — peer-supplied JoinRound messages.
+- `lib/types/codec.go` — durable join-auth TLV.
+- `darepod/rpc_server.go` (multiple) — local RPC.
+- `darepod/wallet_ops.go` — custom OOR inputs.
+- `oor/transfer_inputs.go` — OOR session state.
+- `db/vtxo_store.go`, `db/round_store.go` — rehydrate from DB.
+
+Every call goes through `arkscript.DecodePolicyTemplate`, which caps
+bytes upfront and then threads a shared depth/node-count budget through
+recursion (§3.5). A crafted blob exceeding any cap fails fast before any
+meaningful allocation.
+
+### 9.2 Signature-oracle binding
+
+Signers that accept a caller-supplied witness script + control block MUST
+verify the control block commits to a tap tree whose output key is the
+declared pkScript. `SpendPath.VerifyBindsToPkScript`
+(`lib/arkscript/spend_path.go:60-107`) does this:
+
+1. Parse the control block.
+2. Assert internal key is `ARKNUMSKey`.
+3. Compute the root hash from `ctrlBlock.RootHash(witnessScript)`.
+4. Compute the taproot output key via
+   `txscript.ComputeTaprootOutputKey(ARKNUMSKey, rootHash)`.
+5. Compare the derived P2TR script to the supplied pkScript.
+
+Wired into:
+
+- `darepod/wallet_ops.go BuildCustomTransferInputs` — RPC entry.
+- `oor/checkpoint_sign.go signCustomCheckpointPSBT` — defense-in-depth at
+  the signing site.
+
+Without this check a caller could hand the daemon a control block for an
+arbitrary tapscript and obtain a Schnorr signature over it under the VTXO
+owner key.
+
+### 9.3 Operator-unilateral-spend rejection
+
+`ValidatePolicy` invariant 3 rejects any `Multisig` leaf whose sole
+participant is the operator (§7.1). This catches the specific H-4 attack
+shape `[collab, csv_exit, multisig(operator_only)]` and every trivially
+equivalent nesting (`CSV{_, Multisig{operator_only}}`,
+`Condition{_, Multisig{operator_only}}`). It does NOT catch more exotic
+constructions where the operator can unilaterally produce the predicate
+witness that unlocks a hash-locked single-operator multisig — such
+constructions are explicitly outside the AST's reasoning surface.
+
+### 9.4 Pubkey encoding parity
+
+See issue lightninglabs/darepo-client#252. Summary: the current `Multisig`
+encoder uses 32-byte x-only, so a `PolicyTemplate` round-trip is lossy
+for y-parity. Consumers that need lossless parity (DB operator-key columns)
+persist the 33-byte compressed form separately and prefer it over the
+lifted-from-policy value on rehydration. A future wire-compatible fix may
+switch to lossless 33-byte compressed in the policy template itself.
+
+### 9.5 Admission gates are additive, not subtractive
+
+`ValidatePolicy` and `ValidateStandardVTXOPolicy` enforce a MINIMUM set of
+invariants. The admission surfaces in `darepod/rpc_server.go` and
+`darepod/wallet_ops.go` layer additional policy-specific checks on top:
+
+- Recipient outputs use `ValidateStandardVTXOPolicy` (with operator-derived
+  `MinExitDelay`).
+- Custom OOR inputs use structural `ValidatePolicy` but also
+  `MatchesPkScript` and `SpendPath.VerifyBindsToPkScript`.
+
+Removing any of these upstream checks on the assumption that arkscript
+alone is sufficient would reintroduce the attack shapes they were added
+to close.
+
+---
+
+## 10. References
+
+- BIP-341 — Taproot.
+- BIP-342 — Tapscript.
+- BIP-65 — `OP_CHECKLOCKTIMEVERIFY`.
+- BIP-68 — Relative lock-time.
+- BIP-112 — `OP_CHECKSEQUENCEVERIFY`.
+- `docs/policy_arkscript_review_guide.md` — reviewer walkthrough.
+- lightninglabs/darepo-client#252 — pubkey encoding design.
+- lightninglabs/darepo-client#253 — DoS cap tuning.

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@ into specific topics below.
 | Document | Description |
 |----------|-------------|
 | [ARCHITECTURE.md](../ARCHITECTURE.md) | Package layers, dependency graph, key types, patterns |
+| [arkscript_spec.md](arkscript_spec.md) | RFC-style specification for the `lib/arkscript` tapscript policy system (AST, encoding, invariants, security considerations) |
 | [durable_actor_architecture.md](durable_actor_architecture.md) | CDC pattern, durable mailbox lifecycle, recovery flow |
 | [durable_actor_quickstart.md](durable_actor_quickstart.md) | Developer guide: TLVMessage, ActorBehavior, migration checklist |
 | [mailbox_architecture.md](mailbox_architecture.md) | Three-layer mailbox system: pb, rpc, conn, serverconn |

--- a/lib/arkscript/policy_template.go
+++ b/lib/arkscript/policy_template.go
@@ -21,7 +21,90 @@ const (
 	// policyTemplateVersion is the current binary encoding
 	// version for semantic policy templates.
 	policyTemplateVersion = uint8(1)
+
+	// MaxPolicyTemplateBytes caps the raw size of a policy template
+	// blob accepted for decoding. Standard Ark policies are well under
+	// 1 KiB; the headroom tolerates future custom policies while still
+	// preventing decode-bomb amplification from untrusted sources.
+	MaxPolicyTemplateBytes = 64 * 1024
+
+	// MaxLeafTemplateBytes caps the raw size of a single leaf template
+	// blob. Sized to hold the largest legitimate vHTLC-style leaf with
+	// comfortable headroom.
+	MaxLeafTemplateBytes = 16 * 1024
+
+	// MaxPolicyLeaves caps the number of leaves in a single policy
+	// template. Standard Ark VTXO policies have 2 leaves; vHTLC has
+	// 6. The cap is intentionally generous for future policy shapes
+	// while still bounding the per-policy work.
+	MaxPolicyLeaves = 32
+
+	// MaxPolicyDepth caps the AST recursion depth during decode. Ark
+	// policies nest at most a couple of levels (e.g. CSV->Multisig,
+	// Condition->Multisig). Anything deeper is either a bug or an
+	// attempt to cause stack/CPU blowup.
+	MaxPolicyDepth = 16
+
+	// MaxPolicyNodes caps the total node count decoded from a single
+	// policy or leaf blob. Prevents an attacker from amplifying a
+	// moderate-size blob into a huge in-memory AST.
+	MaxPolicyNodes = 256
+
+	// MaxMultisigKeys caps the number of keys inside a single Multisig
+	// node. Ark multisig nodes typically have 1-3 keys.
+	MaxMultisigKeys = 64
 )
+
+// decodeBudget bounds work performed while decoding a policy or node
+// blob. It is threaded through the recursive decode helpers so every
+// nested node charges against the same depth and node-count caps.
+type decodeBudget struct {
+	// maxDepth is the allowed recursion depth.
+	maxDepth int
+
+	// maxNodes is the allowed total node count across the whole
+	// decode call.
+	maxNodes int
+
+	// depth is the current recursion depth.
+	depth int
+
+	// nodes is the running node count.
+	nodes int
+}
+
+// defaultDecodeBudget returns a budget initialised with the package
+// default limits.
+func defaultDecodeBudget() *decodeBudget {
+	return &decodeBudget{
+		maxDepth: MaxPolicyDepth,
+		maxNodes: MaxPolicyNodes,
+	}
+}
+
+// enter charges one level of recursion and one node against the
+// budget. Callers must pair this with exit.
+func (b *decodeBudget) enter() error {
+	b.depth++
+	b.nodes++
+
+	if b.depth > b.maxDepth {
+		return fmt.Errorf("policy decode depth %d exceeds maximum %d",
+			b.depth, b.maxDepth)
+	}
+
+	if b.nodes > b.maxNodes {
+		return fmt.Errorf("policy decode node count %d exceeds "+
+			"maximum %d", b.nodes, b.maxNodes)
+	}
+
+	return nil
+}
+
+// exit releases one level of recursion.
+func (b *decodeBudget) exit() {
+	b.depth--
+}
 
 // nodeKind identifies the semantic AST node type during binary encoding.
 type nodeKind uint8
@@ -78,8 +161,25 @@ func (l LeafTemplate) ParticipantKeys() []*btcec.PublicKey {
 	return collectNodeKeys(l.Node)
 }
 
-// DecodeLeafTemplate deserializes a binary leaf template.
+// DecodeLeafTemplate deserializes a binary leaf template using the default
+// decode budget. It rejects blobs larger than MaxLeafTemplateBytes and
+// caps AST recursion via MaxPolicyDepth/MaxPolicyNodes.
 func DecodeLeafTemplate(raw []byte) (*LeafTemplate, error) {
+	if len(raw) > MaxLeafTemplateBytes {
+		return nil, fmt.Errorf("leaf template size %d exceeds "+
+			"maximum %d", len(raw), MaxLeafTemplateBytes)
+	}
+
+	return decodeLeafTemplateWithBudget(raw, defaultDecodeBudget())
+}
+
+// decodeLeafTemplateWithBudget deserializes a leaf template while charging
+// every nested node against the supplied budget. The budget is shared across
+// all leaves decoded from the same policy template so a decode-bomb cannot
+// amplify across leaf boundaries.
+func decodeLeafTemplateWithBudget(raw []byte,
+	budget *decodeBudget) (*LeafTemplate, error) {
+
 	if len(raw) == 0 {
 		return nil, fmt.Errorf("leaf template encoding is empty")
 	}
@@ -100,7 +200,7 @@ func DecodeLeafTemplate(raw []byte) (*LeafTemplate, error) {
 		return nil, err
 	}
 
-	node, err := DecodeNode(nodeBytes)
+	node, err := decodeNodeWithBudget(nodeBytes, budget)
 	if err != nil {
 		return nil, err
 	}
@@ -236,8 +336,17 @@ func (p *PolicyTemplate) ParticipantKeys() []*btcec.PublicKey {
 	return keys
 }
 
-// DecodePolicyTemplate deserializes a binary policy template.
+// DecodePolicyTemplate deserializes a binary policy template using the
+// default decode budget. It rejects blobs larger than MaxPolicyTemplateBytes,
+// policies with more than MaxPolicyLeaves leaves, and ASTs that exceed
+// MaxPolicyDepth recursion or MaxPolicyNodes total nodes. The budget is
+// shared across all leaves so a crafted blob cannot amplify across leaves.
 func DecodePolicyTemplate(raw []byte) (*PolicyTemplate, error) {
+	if len(raw) > MaxPolicyTemplateBytes {
+		return nil, fmt.Errorf("policy template size %d exceeds "+
+			"maximum %d", len(raw), MaxPolicyTemplateBytes)
+	}
+
 	if len(raw) == 0 {
 		return nil, fmt.Errorf("policy template encoding is empty")
 	}
@@ -262,6 +371,15 @@ func DecodePolicyTemplate(raw []byte) (*PolicyTemplate, error) {
 	if leafCount == 0 {
 		return nil, fmt.Errorf("policy template must contain leaves")
 	}
+	if leafCount > MaxPolicyLeaves {
+		return nil, fmt.Errorf("policy template leaf count %d "+
+			"exceeds maximum %d", leafCount, MaxPolicyLeaves)
+	}
+
+	// A single budget is shared across every leaf decode so an adversary
+	// cannot spend MaxPolicyNodes per leaf — the caps apply to the whole
+	// policy blob, not per-leaf.
+	budget := defaultDecodeBudget()
 
 	template.Leaves = make([]LeafTemplate, 0, leafCount)
 	for i := uint64(0); i < leafCount; i++ {
@@ -270,7 +388,13 @@ func DecodePolicyTemplate(raw []byte) (*PolicyTemplate, error) {
 			return nil, err
 		}
 
-		leaf, err := DecodeLeafTemplate(leafBytes)
+		if len(leafBytes) > MaxLeafTemplateBytes {
+			return nil, fmt.Errorf("leaf %d size %d exceeds "+
+				"maximum %d", i, len(leafBytes),
+				MaxLeafTemplateBytes)
+		}
+
+		leaf, err := decodeLeafTemplateWithBudget(leafBytes, budget)
 		if err != nil {
 			return nil, fmt.Errorf("decode leaf %d: %w", i, err)
 		}
@@ -353,11 +477,24 @@ func EncodeNode(node Node) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// DecodeNode deserializes one semantic AST node from binary encoding.
+// DecodeNode deserializes one semantic AST node from binary encoding using
+// the default decode budget. Each nested node charges against
+// MaxPolicyDepth and MaxPolicyNodes.
 func DecodeNode(raw []byte) (Node, error) {
+	return decodeNodeWithBudget(raw, defaultDecodeBudget())
+}
+
+// decodeNodeWithBudget deserializes one AST node while charging the supplied
+// budget for each level of recursion and each node added to the tree.
+func decodeNodeWithBudget(raw []byte, budget *decodeBudget) (Node, error) {
 	if len(raw) == 0 {
 		return nil, fmt.Errorf("node encoding is empty")
 	}
+
+	if err := budget.enter(); err != nil {
+		return nil, err
+	}
+	defer budget.exit()
 
 	r := bytes.NewReader(raw)
 
@@ -366,7 +503,7 @@ func DecodeNode(raw []byte) (Node, error) {
 		return nil, err
 	}
 
-	node, err := decodeNodePayload(r, nodeKind(kindByte))
+	node, err := decodeNodePayload(r, nodeKind(kindByte), budget)
 	if err != nil {
 		return nil, err
 	}
@@ -405,8 +542,11 @@ func encodeUnaryNode(buf *bytes.Buffer, kind nodeKind, lock uint32,
 	return nil
 }
 
-// decodeNodePayload decodes the payload for one node kind.
-func decodeNodePayload(r *bytes.Reader, kind nodeKind) (Node, error) {
+// decodeNodePayload decodes the payload for one node kind, charging any
+// recursive child decode against the supplied budget.
+func decodeNodePayload(r *bytes.Reader, kind nodeKind,
+	budget *decodeBudget) (Node, error) {
+
 	switch kind {
 	case nodeKindMultisig:
 		keyCount, err := wire.ReadVarInt(r, 0)
@@ -419,11 +559,10 @@ func decodeNodePayload(r *bytes.Reader, kind nodeKind) (Node, error) {
 
 		// Sanity check: Ark multisig nodes have a small number
 		// of keys (typically 1-3).
-		const maxMultisigKeys = 64
-		if keyCount > maxMultisigKeys {
+		if keyCount > MaxMultisigKeys {
 			return nil, fmt.Errorf(
 				"multisig key count %d exceeds maximum %d",
-				keyCount, maxMultisigKeys,
+				keyCount, MaxMultisigKeys,
 			)
 		}
 
@@ -447,7 +586,7 @@ func decodeNodePayload(r *bytes.Reader, kind nodeKind) (Node, error) {
 		}, nil
 
 	case nodeKindCSV:
-		return decodeLockedNode(r)
+		return decodeLockedNode(r, budget)
 
 	case nodeKindCondition:
 		predicate, err := readVarBytes(r, "condition predicate")
@@ -466,7 +605,7 @@ func decodeNodePayload(r *bytes.Reader, kind nodeKind) (Node, error) {
 			return nil, err
 		}
 
-		child, err := DecodeNode(childBytes)
+		child, err := decodeNodeWithBudget(childBytes, budget)
 		if err != nil {
 			return nil, err
 		}
@@ -481,8 +620,9 @@ func decodeNodePayload(r *bytes.Reader, kind nodeKind) (Node, error) {
 	}
 }
 
-// decodeLockedNode decodes one CSV-gated unary node.
-func decodeLockedNode(r *bytes.Reader) (Node, error) {
+// decodeLockedNode decodes one CSV-gated unary node, charging the recursive
+// child decode against the supplied budget.
+func decodeLockedNode(r *bytes.Reader, budget *decodeBudget) (Node, error) {
 	lock, err := wire.ReadVarInt(r, 0)
 	if err != nil {
 		return nil, err
@@ -499,7 +639,7 @@ func decodeLockedNode(r *bytes.Reader) (Node, error) {
 		return nil, err
 	}
 
-	child, err := DecodeNode(childBytes)
+	child, err := decodeNodeWithBudget(childBytes, budget)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/arkscript/policy_template_test.go
+++ b/lib/arkscript/policy_template_test.go
@@ -1,7 +1,6 @@
 package arkscript
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -290,43 +289,60 @@ func TestDecodePolicyTemplateRejectsTooManyLeaves(t *testing.T) {
 
 // TestDecodePolicyTemplateBudgetSharedAcrossLeaves verifies that the node
 // budget is shared across every leaf in a policy, so an attacker cannot
-// allocate MaxPolicyNodes nodes per leaf.
+// allocate MaxPolicyNodes nodes per leaf. The test crafts a policy whose
+// per-leaf node count is well under MaxPolicyNodes but whose *total* node
+// count across leaves exceeds it — a per-leaf budget would accept the
+// blob; only a shared budget rejects it.
 func TestDecodePolicyTemplateBudgetSharedAcrossLeaves(t *testing.T) {
 	t.Parallel()
 
-	// Build two leaves, each nested deep enough that together they
-	// exceed MaxPolicyNodes. Per-leaf count is under MaxPolicyNodes, but
-	// the shared budget should still reject the combined policy.
-	leafDepth := MaxPolicyNodes/2 + 1
-	if leafDepth > MaxPolicyDepth {
-		leafDepth = MaxPolicyDepth
-	}
-
+	// Each leaf is (MaxPolicyDepth - 1) nested Conditions wrapping a
+	// single-key Multisig, contributing exactly MaxPolicyDepth nodes
+	// (one per enter() call). That keeps each leaf safely under both
+	// the depth cap and the per-leaf node budget while giving us a
+	// predictable contribution to the shared running count.
+	perLeafNodes := MaxPolicyDepth
 	leaf := LeafTemplate{
-		Node: nestedConditionNode(t, leafDepth),
+		Node: nestedConditionNode(t, MaxPolicyDepth-1),
 	}
 
-	encoded, err := (&PolicyTemplate{
-		Leaves: []LeafTemplate{leaf, leaf, leaf, leaf, leaf},
-	}).Encode()
+	// Positive case: leaves that safely fit under the shared cap must
+	// decode cleanly. This guards against a regression where a
+	// too-strict cap rejects legitimate policies.
+	undercapLeaves := MaxPolicyNodes / perLeafNodes
+	require.Positive(t, undercapLeaves)
+	require.LessOrEqual(t, undercapLeaves, MaxPolicyLeaves)
+
+	under := make([]LeafTemplate, undercapLeaves)
+	for i := range under {
+		under[i] = leaf
+	}
+
+	encodedUnder, err := (&PolicyTemplate{Leaves: under}).Encode()
 	require.NoError(t, err)
+	require.LessOrEqual(t, len(encodedUnder), MaxPolicyTemplateBytes)
 
-	// The combined node count MAY exceed MaxPolicyNodes. The decoder
-	// should reject cleanly rather than allocate unbounded.
-	if len(encoded) > MaxPolicyTemplateBytes {
-		// If the encoded blob is already too big, the outer byte
-		// cap catches it — also a valid rejection.
-		_, err = DecodePolicyTemplate(encoded)
-		require.ErrorContains(t, err, "exceeds maximum")
-		return
+	decodedUnder, err := DecodePolicyTemplate(encodedUnder)
+	require.NoError(t, err)
+	require.Len(t, decodedUnder.Leaves, undercapLeaves)
+
+	// Negative case: add enough additional leaves that the TOTAL node
+	// count strictly exceeds MaxPolicyNodes even though each individual
+	// leaf stays well below the cap. A per-leaf budget would accept
+	// this; a shared budget must reject it at the node-count check.
+	overcapLeaves := MaxPolicyNodes/perLeafNodes + 1
+	require.LessOrEqual(t, overcapLeaves, MaxPolicyLeaves)
+	require.Greater(t, overcapLeaves*perLeafNodes, MaxPolicyNodes)
+
+	over := make([]LeafTemplate, overcapLeaves)
+	for i := range over {
+		over[i] = leaf
 	}
 
-	_, err = DecodePolicyTemplate(encoded)
-	if err != nil {
-		msg := err.Error()
-		require.True(t,
-			strings.Contains(msg, "node count") ||
-				strings.Contains(msg, "depth"),
-			"expected node-count or depth rejection, got: %v", err)
-	}
+	encodedOver, err := (&PolicyTemplate{Leaves: over}).Encode()
+	require.NoError(t, err)
+	require.LessOrEqual(t, len(encodedOver), MaxPolicyTemplateBytes)
+
+	_, err = DecodePolicyTemplate(encodedOver)
+	require.ErrorContains(t, err, "node count")
 }

--- a/lib/arkscript/policy_template_test.go
+++ b/lib/arkscript/policy_template_test.go
@@ -1,6 +1,7 @@
 package arkscript
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -195,4 +196,137 @@ func TestVHTLCSettlementPairsMissingParticipant(t *testing.T) {
 		otherKey, opts.Server,
 	)
 	require.ErrorContains(t, err, "no settlement pairs")
+}
+
+// nestedConditionNode returns a Condition AST nested to the requested depth.
+// Each level wraps the child in a Condition with a trivial 1-byte predicate.
+// At depth=0 the base case is a minimal single-key Multisig.
+func nestedConditionNode(t *testing.T, depth int) Node {
+	t.Helper()
+
+	key, _ := testutils.CreateKey(1)
+
+	var node Node = &Multisig{
+		Keys: []*btcec.PublicKey{key},
+	}
+
+	for i := 0; i < depth; i++ {
+		node = &Condition{
+			Predicate: []byte{0x01},
+			Inner:     node,
+		}
+	}
+
+	return node
+}
+
+// TestDecodePolicyTemplateRejectsOversizeBlob verifies that a raw blob larger
+// than MaxPolicyTemplateBytes is rejected before any decode work begins.
+func TestDecodePolicyTemplateRejectsOversizeBlob(t *testing.T) {
+	t.Parallel()
+
+	blob := make([]byte, MaxPolicyTemplateBytes+1)
+	_, err := DecodePolicyTemplate(blob)
+	require.ErrorContains(t, err, "exceeds maximum")
+}
+
+// TestDecodeNodeRejectsDeepRecursion verifies that an AST nested deeper than
+// MaxPolicyDepth is rejected. This is the primary decode-bomb defense: the
+// security-auditor PoC nested 100_000 Conditions into a 778 KB blob.
+func TestDecodeNodeRejectsDeepRecursion(t *testing.T) {
+	t.Parallel()
+
+	deep := nestedConditionNode(t, MaxPolicyDepth+1)
+
+	encoded, err := EncodeNode(deep)
+	require.NoError(t, err)
+
+	_, err = DecodeNode(encoded)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "depth")
+}
+
+// TestDecodeNodeAcceptsShallowRecursion verifies that the budget does not
+// reject legitimate shallow ASTs at the boundary.
+func TestDecodeNodeAcceptsShallowRecursion(t *testing.T) {
+	t.Parallel()
+
+	// Wrap the multisig leaf in MaxPolicyDepth-1 conditions so the root
+	// decode consumes depth MaxPolicyDepth exactly.
+	node := nestedConditionNode(t, MaxPolicyDepth-1)
+
+	encoded, err := EncodeNode(node)
+	require.NoError(t, err)
+
+	decoded, err := DecodeNode(encoded)
+	require.NoError(t, err)
+	require.NotNil(t, decoded)
+}
+
+// TestDecodePolicyTemplateRejectsTooManyLeaves verifies that a policy with
+// more than MaxPolicyLeaves leaves is rejected by the decoder.
+func TestDecodePolicyTemplateRejectsTooManyLeaves(t *testing.T) {
+	t.Parallel()
+
+	ownerKey, _ := testutils.CreateKey(1)
+
+	leaf := LeafTemplate{
+		Node: &Multisig{
+			Keys: []*btcec.PublicKey{ownerKey},
+		},
+	}
+
+	tooMany := make([]LeafTemplate, MaxPolicyLeaves+1)
+	for i := range tooMany {
+		tooMany[i] = leaf
+	}
+
+	encoded, err := (&PolicyTemplate{Leaves: tooMany}).Encode()
+	require.NoError(t, err)
+
+	_, err = DecodePolicyTemplate(encoded)
+	require.ErrorContains(t, err, "leaf count")
+}
+
+// TestDecodePolicyTemplateBudgetSharedAcrossLeaves verifies that the node
+// budget is shared across every leaf in a policy, so an attacker cannot
+// allocate MaxPolicyNodes nodes per leaf.
+func TestDecodePolicyTemplateBudgetSharedAcrossLeaves(t *testing.T) {
+	t.Parallel()
+
+	// Build two leaves, each nested deep enough that together they
+	// exceed MaxPolicyNodes. Per-leaf count is under MaxPolicyNodes, but
+	// the shared budget should still reject the combined policy.
+	leafDepth := MaxPolicyNodes/2 + 1
+	if leafDepth > MaxPolicyDepth {
+		leafDepth = MaxPolicyDepth
+	}
+
+	leaf := LeafTemplate{
+		Node: nestedConditionNode(t, leafDepth),
+	}
+
+	encoded, err := (&PolicyTemplate{
+		Leaves: []LeafTemplate{leaf, leaf, leaf, leaf, leaf},
+	}).Encode()
+	require.NoError(t, err)
+
+	// The combined node count MAY exceed MaxPolicyNodes. The decoder
+	// should reject cleanly rather than allocate unbounded.
+	if len(encoded) > MaxPolicyTemplateBytes {
+		// If the encoded blob is already too big, the outer byte
+		// cap catches it — also a valid rejection.
+		_, err = DecodePolicyTemplate(encoded)
+		require.ErrorContains(t, err, "exceeds maximum")
+		return
+	}
+
+	_, err = DecodePolicyTemplate(encoded)
+	if err != nil {
+		msg := err.Error()
+		require.True(t,
+			strings.Contains(msg, "node count") ||
+				strings.Contains(msg, "depth"),
+			"expected node-count or depth rejection, got: %v", err)
+	}
 }

--- a/lib/arkscript/spend_path.go
+++ b/lib/arkscript/spend_path.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
@@ -51,6 +52,66 @@ func (s *SpendPath) Validate() error {
 
 	case len(s.ControlBlock) == 0:
 		return fmt.Errorf("control block must be provided")
+	}
+
+	return nil
+}
+
+// VerifyBindsToPkScript checks that the spend path's witness script and
+// control block commit to a taproot output whose script is exactly the
+// supplied pkScript. This is the binding check that prevents a caller
+// from supplying a malformed control block for an unrelated taproot
+// output and obtaining signatures against a script they did not prove
+// ownership of.
+//
+// The check runs:
+//
+//  1. Parse the control block.
+//  2. Verify the internal key is the Ark NUMS point (no key-path spend).
+//  3. Compute the tap root hash from the witness script using the
+//     control block's inclusion proof.
+//  4. Tweak the NUMS internal key by the root hash to get the taproot
+//     output key.
+//  5. Build a P2TR script from the output key and compare to pkScript.
+func (s *SpendPath) VerifyBindsToPkScript(pkScript []byte) error {
+	if err := s.Validate(); err != nil {
+		return err
+	}
+
+	if len(pkScript) == 0 {
+		return fmt.Errorf("pk script must be provided")
+	}
+
+	ctrlBlock, err := txscript.ParseControlBlock(s.ControlBlock)
+	if err != nil {
+		return fmt.Errorf("parse control block: %w", err)
+	}
+
+	// Every Ark taproot output commits to the NUMS internal key so no
+	// key-path spend is possible. A control block whose internal key
+	// deviates from NUMS is either malformed or a different output key
+	// entirely, and the downstream binding check would fail anyway —
+	// rejecting early yields a clearer error.
+	internalX := schnorr.SerializePubKey(ctrlBlock.InternalKey)
+	numsX := schnorr.SerializePubKey(&ARKNUMSKey)
+	if !bytes.Equal(internalX, numsX) {
+		return fmt.Errorf("control block internal key is not the " +
+			"Ark NUMS point")
+	}
+
+	rootHash := ctrlBlock.RootHash(s.WitnessScript)
+
+	outputKey := txscript.ComputeTaprootOutputKey(&ARKNUMSKey, rootHash)
+
+	expectedPkScript, err := txscript.PayToTaprootScript(outputKey)
+	if err != nil {
+		return fmt.Errorf("derive p2tr from output key: %w", err)
+	}
+
+	if !bytes.Equal(expectedPkScript, pkScript) {
+		return fmt.Errorf("control block does not commit to "+
+			"declared pkScript: got %x want %x",
+			expectedPkScript, pkScript)
 	}
 
 	return nil

--- a/lib/arkscript/spend_path_test.go
+++ b/lib/arkscript/spend_path_test.go
@@ -1,0 +1,206 @@
+package arkscript
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/lightninglabs/darepo-client/internal/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+// makeSpendPathFromPolicy is a small helper that builds a SpendPath for the
+// collab leaf of a VTXO policy and returns the expected pkScript for that
+// output. It centralises the setup that every binding test needs: a real
+// compiled policy, a real NUMS-tweaked P2TR script, and a control block
+// whose inclusion proof actually commits to the leaf.
+func makeSpendPathFromPolicy(t *testing.T,
+	policy *VTXOPolicy) (*SpendPath, []byte) {
+
+	t.Helper()
+
+	info, err := policy.CollabSpendInfo()
+	require.NoError(t, err)
+
+	pkScript, err := txscript.PayToTaprootScript(policy.OutputKey())
+	require.NoError(t, err)
+
+	return &SpendPath{
+		SpendInfo:        info,
+		RequiredSequence: 0xffffffff,
+	}, pkScript
+}
+
+// TestVerifyBindsToPkScript exercises the binding check that prevents a
+// caller from producing a control block for one taproot output and having
+// the operator sign as if it had authorised spending a different output.
+// Each subtest covers one of the rejection paths in VerifyBindsToPkScript
+// plus the happy path.
+func TestVerifyBindsToPkScript(t *testing.T) {
+	t.Parallel()
+
+	ownerKey, _ := testutils.CreateKey(101)
+	operatorKey, _ := testutils.CreateKey(102)
+
+	policy, err := NewVTXOPolicy(ownerKey, operatorKey, 144)
+	require.NoError(t, err)
+
+	// A happy-path binding against the policy's own pkScript is the
+	// baseline: a control block whose inclusion proof commits to the
+	// witness script under the NUMS-tweaked output key must verify
+	// against the P2TR script derived from that output key.
+	t.Run("binds to real policy pkScript", func(t *testing.T) {
+		t.Parallel()
+
+		spendPath, pkScript := makeSpendPathFromPolicy(t, policy)
+
+		require.NoError(t, spendPath.VerifyBindsToPkScript(pkScript))
+	})
+
+	// Calling VerifyBindsToPkScript on a nil SpendPath must surface the
+	// "spend path must be provided" error from Validate rather than
+	// panicking or silently accepting.
+	t.Run("nil spend path rejected", func(t *testing.T) {
+		t.Parallel()
+
+		var s *SpendPath
+		err := s.VerifyBindsToPkScript([]byte{0x51})
+		require.ErrorContains(t, err, "spend path must be provided")
+	})
+
+	// A SpendPath with a nil embedded SpendInfo must fail the
+	// "spend info must be provided" precondition — without the witness
+	// script and control block there is nothing to bind.
+	t.Run("nil spend info rejected", func(t *testing.T) {
+		t.Parallel()
+
+		s := &SpendPath{RequiredSequence: 0xffffffff}
+		err := s.VerifyBindsToPkScript([]byte{0x51})
+		require.ErrorContains(t, err, "spend info must be provided")
+	})
+
+	// A SpendPath whose WitnessScript is empty must fail the
+	// "witness script must be provided" precondition.
+	t.Run("empty witness script rejected", func(t *testing.T) {
+		t.Parallel()
+
+		spendPath, pkScript := makeSpendPathFromPolicy(t, policy)
+		spendPath.WitnessScript = nil
+
+		err := spendPath.VerifyBindsToPkScript(pkScript)
+		require.ErrorContains(t, err, "witness script must be provided")
+	})
+
+	// A SpendPath whose ControlBlock is empty must fail the
+	// "control block must be provided" precondition.
+	t.Run("empty control block rejected", func(t *testing.T) {
+		t.Parallel()
+
+		spendPath, pkScript := makeSpendPathFromPolicy(t, policy)
+		spendPath.ControlBlock = nil
+
+		err := spendPath.VerifyBindsToPkScript(pkScript)
+		require.ErrorContains(t, err, "control block must be provided")
+	})
+
+	// An empty pkScript must be refused — the binding check has nothing
+	// to compare against, and silently accepting would subvert the point
+	// of the check.
+	t.Run("empty pk script rejected", func(t *testing.T) {
+		t.Parallel()
+
+		spendPath, _ := makeSpendPathFromPolicy(t, policy)
+
+		err := spendPath.VerifyBindsToPkScript(nil)
+		require.ErrorContains(t, err, "pk script must be provided")
+	})
+
+	// A malformed control block (fewer bytes than a valid taproot control
+	// block) must fail at the parse step.
+	t.Run("malformed control block rejected", func(t *testing.T) {
+		t.Parallel()
+
+		spendPath, pkScript := makeSpendPathFromPolicy(t, policy)
+		spendPath.ControlBlock = []byte{0xc0, 0x01, 0x02}
+
+		err := spendPath.VerifyBindsToPkScript(pkScript)
+		require.ErrorContains(t, err, "parse control block")
+	})
+
+	// Every Ark taproot output commits to the NUMS internal key so that
+	// no key-path spend is possible. A control block whose internal key
+	// is not NUMS must be rejected with a dedicated error before any
+	// downstream tweak math runs, even if its inclusion proof would
+	// otherwise produce the expected output key.
+	t.Run("non-NUMS internal key rejected", func(t *testing.T) {
+		t.Parallel()
+
+		spendPath, pkScript := makeSpendPathFromPolicy(t, policy)
+
+		// Swap the first 32 bytes of the control block (the internal
+		// key) with an arbitrary public key. The rest of the proof is
+		// kept intact; the rejection must come from the NUMS check.
+		attackerKey, _ := testutils.CreateKey(103)
+		attackerX := schnorr.SerializePubKey(attackerKey)
+
+		mutated := append([]byte(nil), spendPath.ControlBlock...)
+		copy(mutated[1:33], attackerX)
+		spendPath.ControlBlock = mutated
+
+		err := spendPath.VerifyBindsToPkScript(pkScript)
+		require.ErrorContains(t, err, "not the Ark NUMS point")
+	})
+
+	// A control block that would legitimately bind to some pkScript
+	// (because it was produced for a real Ark output) must still be
+	// rejected when the caller presents a pkScript from a DIFFERENT
+	// policy. This is the core signature-oracle defence: the operator
+	// must not be tricked into signing for an output whose leaf set
+	// we haven't proven ownership of.
+	t.Run("wrong pk script rejected", func(t *testing.T) {
+		t.Parallel()
+
+		spendPath, _ := makeSpendPathFromPolicy(t, policy)
+
+		// Derive a pkScript from an unrelated policy (different owner
+		// and exit delay). It is a well-formed Ark P2TR script but is
+		// not the one our control block commits to.
+		otherOwner, _ := testutils.CreateKey(201)
+		otherPolicy, err := NewVTXOPolicy(
+			otherOwner, operatorKey, 200,
+		)
+		require.NoError(t, err)
+
+		otherPkScript, err := txscript.PayToTaprootScript(
+			otherPolicy.OutputKey(),
+		)
+		require.NoError(t, err)
+
+		err = spendPath.VerifyBindsToPkScript(otherPkScript)
+		require.ErrorContains(
+			t, err, "does not commit to declared pkScript",
+		)
+	})
+
+	// The pkScript bytes may be a syntactically valid 34-byte P2TR
+	// script whose output key is completely unrelated to anything we
+	// control. The binding check must still reject.
+	t.Run("arbitrary P2TR pk script rejected", func(t *testing.T) {
+		t.Parallel()
+
+		spendPath, _ := makeSpendPathFromPolicy(t, policy)
+
+		// Generate an unrelated public key and build a P2TR script
+		// directly from it; no taproot tweak math was applied, so
+		// the operator cannot possibly have authorised it.
+		unrelated, _ := btcec.NewPrivateKey()
+		bogus, err := txscript.PayToTaprootScript(unrelated.PubKey())
+		require.NoError(t, err)
+
+		err = spendPath.VerifyBindsToPkScript(bogus)
+		require.ErrorContains(
+			t, err, "does not commit to declared pkScript",
+		)
+	})
+}

--- a/lib/arkscript/standard_vtxo.go
+++ b/lib/arkscript/standard_vtxo.go
@@ -78,6 +78,37 @@ func EncodeStandardVTXOTemplate(ownerKey, operatorKey *btcec.PublicKey,
 	return template.Encode()
 }
 
+// EncodeStandardVTXOArtifacts is a convenience that returns both the encoded
+// policy template bytes and the canonical P2TR pkScript for the standard Ark
+// VTXO shape defined by (ownerKey, operatorKey, exitDelay). Callers that
+// need the full tree-construction descriptor should use
+// tree.NewVTXODescriptor instead — this helper is for surfaces that only
+// need the output-level artifacts (e.g. recipient descriptor construction
+// in the wallet, where the ephemeral MuSig2 signing key is derived later
+// by the round FSM).
+func EncodeStandardVTXOArtifacts(ownerKey, operatorKey *btcec.PublicKey,
+	exitDelay uint32) (policyTemplate, pkScript []byte, err error) {
+
+	policyTemplate, err = EncodeStandardVTXOTemplate(
+		ownerKey, operatorKey, exitDelay,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	outputKey, err := VTXOTapKey(ownerKey, operatorKey, exitDelay)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pkScript, err = txscript.PayToTaprootScript(outputKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return policyTemplate, pkScript, nil
+}
+
 // DecodeStandardVTXOParams validates that the semantic policy is a standard
 // Ark VTXO policy and extracts its owner/operator/exit-delay tuple.
 func DecodeStandardVTXOParams(

--- a/lib/arkscript/standard_vtxo.go
+++ b/lib/arkscript/standard_vtxo.go
@@ -87,9 +87,9 @@ func EncodeStandardVTXOTemplate(ownerKey, operatorKey *btcec.PublicKey,
 // in the wallet, where the ephemeral MuSig2 signing key is derived later
 // by the round FSM).
 func EncodeStandardVTXOArtifacts(ownerKey, operatorKey *btcec.PublicKey,
-	exitDelay uint32) (policyTemplate, pkScript []byte, err error) {
+	exitDelay uint32) ([]byte, []byte, error) {
 
-	policyTemplate, err = EncodeStandardVTXOTemplate(
+	policyTemplate, err := EncodeStandardVTXOTemplate(
 		ownerKey, operatorKey, exitDelay,
 	)
 	if err != nil {
@@ -101,7 +101,7 @@ func EncodeStandardVTXOArtifacts(ownerKey, operatorKey *btcec.PublicKey,
 		return nil, nil, err
 	}
 
-	pkScript, err = txscript.PayToTaprootScript(outputKey)
+	pkScript, err := txscript.PayToTaprootScript(outputKey)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/lib/arkscript/standard_vtxo_test.go
+++ b/lib/arkscript/standard_vtxo_test.go
@@ -1,0 +1,238 @@
+package arkscript
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/lightninglabs/darepo-client/internal/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+// requireSameXOnlyKey asserts that two public keys agree on their x-only
+// form. The standard VTXO policy template encodes keys as 32-byte x-only
+// values, so any odd-parity input is lifted to even parity on decode;
+// comparing via IsEqual would spuriously fail for odd-y inputs, while the
+// x-only projection is the actual invariant the protocol preserves.
+func requireSameXOnlyKey(t *testing.T, want, got *btcec.PublicKey) {
+	t.Helper()
+
+	require.Equal(
+		t, schnorr.SerializePubKey(want), schnorr.SerializePubKey(got),
+	)
+}
+
+// TestEncodeStandardVTXOArtifacts covers the helper that returns the
+// (policyTemplate, pkScript) pair for the standard Ark VTXO shape. The
+// helper is now on the production wallet send path (via buildSendVTXORequests
+// → EncodeStandardVTXOArtifacts), so regression coverage on both the happy
+// path and the three fail-closed precondition paths is essential.
+func TestEncodeStandardVTXOArtifacts(t *testing.T) {
+	t.Parallel()
+
+	ownerKey, _ := testutils.CreateKey(1)
+	operatorKey, _ := testutils.CreateKey(2)
+	const exitDelay uint32 = 144
+
+	// Happy path: the returned policyTemplate must round-trip through
+	// DecodeStandardVTXOParams back to the original tuple, and the
+	// returned pkScript must equal the P2TR script derived from the
+	// compiled policy's output key. This is the dual-invariant check
+	// that callers depend on.
+	t.Run("happy path round-trips and matches policy pkScript",
+		func(t *testing.T) {
+
+			t.Parallel()
+
+			template, pkScript, err := EncodeStandardVTXOArtifacts(
+				ownerKey, operatorKey, exitDelay,
+			)
+			require.NoError(t, err)
+			require.NotEmpty(t, template)
+			require.NotEmpty(t, pkScript)
+
+			// The encoded template must decode back to the exact
+			// (owner, operator, exitDelay) tuple the helper was
+			// called with.
+			decoded, err := DecodePolicyTemplate(template)
+			require.NoError(t, err)
+
+			params, err := DecodeStandardVTXOParams(decoded)
+			require.NoError(t, err)
+			requireSameXOnlyKey(t, ownerKey, params.OwnerKey)
+			requireSameXOnlyKey(t, operatorKey, params.OperatorKey)
+			require.Equal(t, exitDelay, params.ExitDelay)
+
+			// The returned pkScript must equal the canonical
+			// P2TR derived from the compiled policy's output key.
+			// If these diverge, the wallet would quote one script
+			// to the counterparty and the compiler would expect a
+			// different one.
+			policy, err := NewVTXOPolicy(
+				ownerKey, operatorKey, exitDelay,
+			)
+			require.NoError(t, err)
+
+			expectedPkScript, err := txscript.PayToTaprootScript(
+				policy.OutputKey(),
+			)
+			require.NoError(t, err)
+			require.Equal(t, expectedPkScript, pkScript)
+		})
+
+	// A nil owner key must be rejected fail-closed: returning a
+	// well-formed pkScript built from a zero-valued key would let the
+	// wallet quote a recipient policy no one can spend.
+	t.Run("nil owner key rejected", func(t *testing.T) {
+		t.Parallel()
+
+		template, pkScript, err := EncodeStandardVTXOArtifacts(
+			nil, operatorKey, exitDelay,
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "owner key is nil")
+		require.Nil(t, template)
+		require.Nil(t, pkScript)
+	})
+
+	// Likewise for a nil operator key.
+	t.Run("nil operator key rejected", func(t *testing.T) {
+		t.Parallel()
+
+		template, pkScript, err := EncodeStandardVTXOArtifacts(
+			ownerKey, nil, exitDelay,
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "operator key is nil")
+		require.Nil(t, template)
+		require.Nil(t, pkScript)
+	})
+
+	// A zero exit delay is rejected fail-closed because a 1-block CSV
+	// would break the forfeit incentive; the helper must not silently
+	// substitute a default.
+	t.Run("zero exit delay rejected", func(t *testing.T) {
+		t.Parallel()
+
+		template, pkScript, err := EncodeStandardVTXOArtifacts(
+			ownerKey, operatorKey, 0,
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "exit delay must be non-zero")
+		require.Nil(t, template)
+		require.Nil(t, pkScript)
+	})
+
+	// Changing any input parameter must change the pkScript. This is a
+	// light fuzz-like sanity check that the helper is actually
+	// threading every parameter into the compiled output key and not,
+	// e.g., hashing only the owner key.
+	t.Run("all inputs influence the pkScript", func(t *testing.T) {
+		t.Parallel()
+
+		_, baselinePkScript, err := EncodeStandardVTXOArtifacts(
+			ownerKey, operatorKey, exitDelay,
+		)
+		require.NoError(t, err)
+
+		otherOwner, _ := testutils.CreateKey(3)
+		_, pkScriptOwner, err := EncodeStandardVTXOArtifacts(
+			otherOwner, operatorKey, exitDelay,
+		)
+		require.NoError(t, err)
+		require.NotEqual(t, baselinePkScript, pkScriptOwner)
+
+		otherOperator, _ := testutils.CreateKey(4)
+		_, pkScriptOperator, err := EncodeStandardVTXOArtifacts(
+			ownerKey, otherOperator, exitDelay,
+		)
+		require.NoError(t, err)
+		require.NotEqual(t, baselinePkScript, pkScriptOperator)
+
+		_, pkScriptDelay, err := EncodeStandardVTXOArtifacts(
+			ownerKey, operatorKey, exitDelay+1,
+		)
+		require.NoError(t, err)
+		require.NotEqual(t, baselinePkScript, pkScriptDelay)
+	})
+}
+
+// TestStandardVTXOTemplateRoundTrip exercises the round trip through the
+// encode/decode pair at the template level: serialize via
+// EncodeStandardVTXOTemplate, decode via DecodePolicyTemplate, extract
+// parameters via DecodeStandardVTXOParams.
+func TestStandardVTXOTemplateRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		owner     int32
+		operator  int32
+		exitDelay uint32
+	}{
+		{"typical", 1, 2, 144},
+		{"short delay", 5, 6, 1},
+		{"large delay", 7, 8, 100_000},
+		{"distinct high indices", 42, 99, 2016},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ownerKey, _ := testutils.CreateKey(tc.owner)
+			operatorKey, _ := testutils.CreateKey(tc.operator)
+
+			encoded, err := EncodeStandardVTXOTemplate(
+				ownerKey, operatorKey, tc.exitDelay,
+			)
+			require.NoError(t, err)
+
+			decoded, err := DecodePolicyTemplate(encoded)
+			require.NoError(t, err)
+
+			params, err := DecodeStandardVTXOParams(decoded)
+			require.NoError(t, err)
+			requireSameXOnlyKey(t, ownerKey, params.OwnerKey)
+			requireSameXOnlyKey(
+				t, operatorKey, params.OperatorKey,
+			)
+			require.Equal(t, tc.exitDelay, params.ExitDelay)
+
+			// IsStandardVTXOTemplate must agree with the decode
+			// result — they are the two entry points and must not
+			// drift.
+			require.True(t, IsStandardVTXOTemplate(decoded))
+		})
+	}
+}
+
+// TestEncodeStandardVTXOArtifactsPkScriptMatchesWallet asserts that the
+// pkScript returned by the artifact helper equals the compiled policy's
+// PkScript(). The wallet path quotes the helper's pkScript to counterparties
+// and later verification paths compile the template via PolicyTemplate →
+// PkScript(); if the two ever diverge the wallet would send funds to a
+// script the operator refuses to accept.
+func TestEncodeStandardVTXOArtifactsPkScriptMatchesWallet(t *testing.T) {
+	t.Parallel()
+
+	ownerKey, _ := testutils.CreateKey(11)
+	operatorKey, _ := testutils.CreateKey(12)
+
+	templateBytes, pkScript, err := EncodeStandardVTXOArtifacts(
+		ownerKey, operatorKey, 144,
+	)
+	require.NoError(t, err)
+
+	template, err := DecodePolicyTemplate(templateBytes)
+	require.NoError(t, err)
+
+	templatePkScript, err := template.PkScript()
+	require.NoError(t, err)
+
+	require.Equal(t, templatePkScript, pkScript)
+}
+

--- a/lib/arkscript/standard_vtxo_test.go
+++ b/lib/arkscript/standard_vtxo_test.go
@@ -40,46 +40,45 @@ func TestEncodeStandardVTXOArtifacts(t *testing.T) {
 	// returned pkScript must equal the P2TR script derived from the
 	// compiled policy's output key. This is the dual-invariant check
 	// that callers depend on.
-	t.Run("happy path round-trips and matches policy pkScript",
-		func(t *testing.T) {
+	happyName := "happy path round-trips and matches policy pkScript"
+	t.Run(happyName, func(t *testing.T) {
+		t.Parallel()
 
-			t.Parallel()
+		template, pkScript, err := EncodeStandardVTXOArtifacts(
+			ownerKey, operatorKey, exitDelay,
+		)
+		require.NoError(t, err)
+		require.NotEmpty(t, template)
+		require.NotEmpty(t, pkScript)
 
-			template, pkScript, err := EncodeStandardVTXOArtifacts(
-				ownerKey, operatorKey, exitDelay,
-			)
-			require.NoError(t, err)
-			require.NotEmpty(t, template)
-			require.NotEmpty(t, pkScript)
+		// The encoded template must decode back to the exact
+		// (owner, operator, exitDelay) tuple the helper was
+		// called with.
+		decoded, err := DecodePolicyTemplate(template)
+		require.NoError(t, err)
 
-			// The encoded template must decode back to the exact
-			// (owner, operator, exitDelay) tuple the helper was
-			// called with.
-			decoded, err := DecodePolicyTemplate(template)
-			require.NoError(t, err)
+		params, err := DecodeStandardVTXOParams(decoded)
+		require.NoError(t, err)
+		requireSameXOnlyKey(t, ownerKey, params.OwnerKey)
+		requireSameXOnlyKey(t, operatorKey, params.OperatorKey)
+		require.Equal(t, exitDelay, params.ExitDelay)
 
-			params, err := DecodeStandardVTXOParams(decoded)
-			require.NoError(t, err)
-			requireSameXOnlyKey(t, ownerKey, params.OwnerKey)
-			requireSameXOnlyKey(t, operatorKey, params.OperatorKey)
-			require.Equal(t, exitDelay, params.ExitDelay)
+		// The returned pkScript must equal the canonical P2TR
+		// derived from the compiled policy's output key. If these
+		// diverge, the wallet would quote one script to the
+		// counterparty and the compiler would expect a different
+		// one.
+		policy, err := NewVTXOPolicy(
+			ownerKey, operatorKey, exitDelay,
+		)
+		require.NoError(t, err)
 
-			// The returned pkScript must equal the canonical
-			// P2TR derived from the compiled policy's output key.
-			// If these diverge, the wallet would quote one script
-			// to the counterparty and the compiler would expect a
-			// different one.
-			policy, err := NewVTXOPolicy(
-				ownerKey, operatorKey, exitDelay,
-			)
-			require.NoError(t, err)
-
-			expectedPkScript, err := txscript.PayToTaprootScript(
-				policy.OutputKey(),
-			)
-			require.NoError(t, err)
-			require.Equal(t, expectedPkScript, pkScript)
-		})
+		expectedPkScript, err := txscript.PayToTaprootScript(
+			policy.OutputKey(),
+		)
+		require.NoError(t, err)
+		require.Equal(t, expectedPkScript, pkScript)
+	})
 
 	// A nil owner key must be rejected fail-closed: returning a
 	// well-formed pkScript built from a zero-valued key would let the
@@ -235,4 +234,3 @@ func TestEncodeStandardVTXOArtifactsPkScriptMatchesWallet(t *testing.T) {
 
 	require.Equal(t, templatePkScript, pkScript)
 }
-

--- a/lib/arkscript/validate.go
+++ b/lib/arkscript/validate.go
@@ -149,7 +149,30 @@ func walkRejectOperatorUnilateral(node Node, target []byte) error {
 			return nil
 		}
 
-		if len(n.Keys) < 2 {
+		// A length check alone is insufficient: Multisig{operator,
+		// operator} has len(Keys) == 2 but is still unilaterally
+		// spendable by the operator because every required signer is
+		// the same key. Require at least one key in the set that is
+		// not the operator (and not nil). Nil keys cannot participate
+		// in a valid CHECKSIG and so do not count as cooperating
+		// signers for this invariant.
+		hasNonOperator := false
+		for _, k := range n.Keys {
+			if k == nil {
+				continue
+			}
+
+			if !bytes.Equal(
+				schnorr.SerializePubKey(k), target,
+			) {
+
+				hasNonOperator = true
+
+				break
+			}
+		}
+
+		if !hasNonOperator {
 			return fmt.Errorf("multisig is operator-only")
 		}
 

--- a/lib/arkscript/validate.go
+++ b/lib/arkscript/validate.go
@@ -15,18 +15,31 @@ type PolicyValidationOpts struct {
 	// must contain this key for the operator to safely co-sign.
 	OperatorKey *btcec.PublicKey
 
-	// MinExitDelay is the minimum CSV delay required on exit
-	// leaves (in blocks). Set to 0 to skip this check.
+	// MinExitDelay is the minimum CSV delay required on exit leaves
+	// (in blocks). When zero, the CSV-minimum check is skipped —
+	// callers that admit standard VTXO policies should use
+	// ValidateStandardVTXOPolicy instead, which requires MinExitDelay
+	// to be set and refuses zero fail-closed.
 	MinExitDelay uint32
 }
 
-// ValidatePolicy checks that a set of AST nodes satisfies the minimum Ark
-// policy invariants inferred from the signer structure:
+// ValidatePolicy checks that a set of AST nodes satisfies the structural
+// Ark policy invariants inferred from the signer structure:
 //
-//  1. At least one operator-containing leaf.
-//  2. At least one non-operator leaf.
-//  3. Every non-operator leaf is CSV-gated.
-//  4. Smallest inferred exit delay >= MinExitDelay.
+//  1. At least one operator-containing leaf (collab).
+//  2. At least one non-operator leaf (exit).
+//  3. No leaf permits the operator to spend unilaterally (every Multisig
+//     node that contains the operator key must contain at least one other
+//     key, so the operator always needs a cooperating signer).
+//  4. Every non-operator leaf is CSV-gated.
+//  5. When opts.MinExitDelay > 0, the smallest inferred exit delay must be
+//     at least opts.MinExitDelay. When opts.MinExitDelay == 0, this check
+//     is skipped — use ValidateStandardVTXOPolicy to require a non-zero
+//     minimum.
+//
+// ValidatePolicy is the correct admission check for custom policy shapes
+// (e.g. vHTLC) whose unilateral delays are protocol-specific rather than
+// tied to the operator's standard VTXO exit delay.
 func ValidatePolicy(nodes []Node, opts PolicyValidationOpts) error {
 	if opts.OperatorKey == nil {
 		return fmt.Errorf("operator key must be provided")
@@ -41,6 +54,18 @@ func ValidatePolicy(nodes []Node, opts PolicyValidationOpts) error {
 		smallestCSVLock uint32
 		foundCSV        bool
 	)
+
+	// Invariant 3 is enforced across every leaf, not just collab leaves,
+	// so a malformed exit leaf that nevertheless includes the operator
+	// is still rejected.
+	for i, node := range nodes {
+		if err := rejectOperatorUnilateral(
+			node, opts.OperatorKey,
+		); err != nil {
+			return fmt.Errorf("leaf %d permits operator "+
+				"unilateral spend: %w", i, err)
+		}
+	}
 
 	for _, node := range nodes {
 		if ContainsKey(node, opts.OperatorKey) {
@@ -82,6 +107,81 @@ func ValidatePolicy(nodes []Node, opts PolicyValidationOpts) error {
 	}
 
 	return nil
+}
+
+// ValidateStandardVTXOPolicy is the admission check for a standard Ark
+// VTXO recipient. It enforces every invariant of ValidatePolicy and
+// additionally requires a non-zero MinExitDelay. A zero minimum is
+// rejected fail-closed because it would otherwise silently accept a
+// policy with a 1-block CSV, breaking the forfeit incentive.
+func ValidateStandardVTXOPolicy(nodes []Node, operatorKey *btcec.PublicKey,
+	minExitDelay uint32) error {
+
+	if minExitDelay == 0 {
+		return fmt.Errorf("MinExitDelay must be non-zero for " +
+			"standard VTXO admission: a zero minimum would " +
+			"accept a 1-block CSV and break forfeit incentives")
+	}
+
+	return ValidatePolicy(nodes, PolicyValidationOpts{
+		OperatorKey:  operatorKey,
+		MinExitDelay: minExitDelay,
+	})
+}
+
+// rejectOperatorUnilateral walks the AST and returns an error if any Multisig
+// node contains the operator key as its sole participant. Such a leaf would
+// let the operator spend without any cooperating signer, bypassing the Ark
+// protocol's custody assumptions.
+func rejectOperatorUnilateral(node Node, operatorKey *btcec.PublicKey) error {
+	target := schnorr.SerializePubKey(operatorKey)
+
+	return walkRejectOperatorUnilateral(node, target)
+}
+
+// walkRejectOperatorUnilateral is the recursive helper for
+// rejectOperatorUnilateral. It descends through CSV and Condition wrappers
+// and inspects every Multisig node it finds.
+func walkRejectOperatorUnilateral(node Node, target []byte) error {
+	switch n := node.(type) {
+	case *Multisig:
+		if !multisigContainsKey(n, target) {
+			return nil
+		}
+
+		if len(n.Keys) < 2 {
+			return fmt.Errorf("multisig is operator-only")
+		}
+
+		// The multisig contains the operator AND at least one other
+		// key, so unilateral spend is impossible here.
+		return nil
+
+	case *CSV:
+		return walkRejectOperatorUnilateral(n.Inner, target)
+
+	case *Condition:
+		return walkRejectOperatorUnilateral(n.Inner, target)
+
+	default:
+		return nil
+	}
+}
+
+// multisigContainsKey reports whether the multisig references the target
+// x-only public key.
+func multisigContainsKey(m *Multisig, target []byte) bool {
+	for _, k := range m.Keys {
+		if k == nil {
+			continue
+		}
+
+		if bytes.Equal(schnorr.SerializePubKey(k), target) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // ContainsKey walks the typed AST nodes (Multisig, CSV, Condition) and

--- a/lib/arkscript/validate_test.go
+++ b/lib/arkscript/validate_test.go
@@ -280,7 +280,8 @@ func TestValidatePolicy(t *testing.T) {
 	// ValidatePolicy itself permits a zero MinExitDelay because custom
 	// policies (e.g. vHTLC) carry protocol-specific unilateral delays
 	// independent of the operator's standard VTXO exit delay.
-	t.Run("structural ValidatePolicy allows zero MinExitDelay", func(t *testing.T) {
+	structuralName := "structural ValidatePolicy allows zero MinExitDelay"
+	t.Run(structuralName, func(t *testing.T) {
 		t.Parallel()
 
 		collabNode := &Multisig{
@@ -354,34 +355,33 @@ func TestValidatePolicy(t *testing.T) {
 	// descend through the predicate wrapper and reject the inner
 	// Multisig; a regression that dropped the Condition branch would
 	// silently accept this shape.
-	t.Run("operator-unilateral under Condition rejected",
-		func(t *testing.T) {
+	conditionName := "operator-unilateral under Condition rejected"
+	t.Run(conditionName, func(t *testing.T) {
+		t.Parallel()
 
-			t.Parallel()
+		collabNode := &Multisig{
+			Keys: []*btcec.PublicKey{owner, operator},
+		}
+		exitNode := &CSV{
+			Lock: 144,
+			Inner: &Multisig{
+				Keys: []*btcec.PublicKey{owner},
+			},
+		}
+		operatorOnlyCondition := &Condition{
+			Predicate: []byte{0x01},
+			Inner: &Multisig{
+				Keys: []*btcec.PublicKey{operator},
+			},
+		}
 
-			collabNode := &Multisig{
-				Keys: []*btcec.PublicKey{owner, operator},
-			}
-			exitNode := &CSV{
-				Lock: 144,
-				Inner: &Multisig{
-					Keys: []*btcec.PublicKey{owner},
-				},
-			}
-			operatorOnlyCondition := &Condition{
-				Predicate: []byte{0x01},
-				Inner: &Multisig{
-					Keys: []*btcec.PublicKey{operator},
-				},
-			}
+		nodes := []Node{
+			collabNode, exitNode, operatorOnlyCondition,
+		}
 
-			nodes := []Node{
-				collabNode, exitNode, operatorOnlyCondition,
-			}
-
-			err := ValidatePolicy(nodes, opts)
-			require.ErrorContains(t, err, "operator unilateral")
-		})
+		err := ValidatePolicy(nodes, opts)
+		require.ErrorContains(t, err, "operator unilateral")
+	})
 
 	// A Multisig with the operator key duplicated — Multisig{op, op} —
 	// has len(Keys) == 2 yet is still unilaterally spendable by the

--- a/lib/arkscript/validate_test.go
+++ b/lib/arkscript/validate_test.go
@@ -257,6 +257,96 @@ func TestValidatePolicy(t *testing.T) {
 		err := ValidatePolicy(nodes, opts)
 		require.ErrorIs(t, err, ErrMissingCollab)
 	})
+
+	// ValidateStandardVTXOPolicy must reject a zero MinExitDelay
+	// fail-closed so no caller can accidentally bypass the
+	// forfeit-incentive check on the standard-VTXO admission surface.
+	t.Run("standard policy zero MinExitDelay rejected", func(t *testing.T) {
+		t.Parallel()
+
+		collabNode := &Multisig{
+			Keys: []*btcec.PublicKey{owner, operator},
+		}
+		exitNode := &CSV{
+			Lock:  144,
+			Inner: &Multisig{Keys: []*btcec.PublicKey{owner}},
+		}
+		nodes := []Node{collabNode, exitNode}
+
+		err := ValidateStandardVTXOPolicy(nodes, operator, 0)
+		require.ErrorContains(t, err, "MinExitDelay must be non-zero")
+	})
+
+	// ValidatePolicy itself permits a zero MinExitDelay because custom
+	// policies (e.g. vHTLC) carry protocol-specific unilateral delays
+	// independent of the operator's standard VTXO exit delay.
+	t.Run("structural ValidatePolicy allows zero MinExitDelay", func(t *testing.T) {
+		t.Parallel()
+
+		collabNode := &Multisig{
+			Keys: []*btcec.PublicKey{owner, operator},
+		}
+		exitNode := &CSV{
+			Lock:  10,
+			Inner: &Multisig{Keys: []*btcec.PublicKey{owner}},
+		}
+		nodes := []Node{collabNode, exitNode}
+
+		err := ValidatePolicy(nodes, PolicyValidationOpts{
+			OperatorKey: operator,
+		})
+		require.NoError(t, err)
+	})
+
+	// A leaf that is a plain Multisig containing only the operator key
+	// would grant the operator a unilateral spend path. ValidatePolicy
+	// must reject it regardless of whether the policy otherwise looks
+	// well-formed.
+	t.Run("operator-unilateral leaf rejected", func(t *testing.T) {
+		t.Parallel()
+
+		collabNode := &Multisig{
+			Keys: []*btcec.PublicKey{owner, operator},
+		}
+		exitNode := &CSV{
+			Lock:  144,
+			Inner: &Multisig{Keys: []*btcec.PublicKey{owner}},
+		}
+		operatorOnly := &Multisig{
+			Keys: []*btcec.PublicKey{operator},
+		}
+
+		nodes := []Node{collabNode, exitNode, operatorOnly}
+
+		err := ValidatePolicy(nodes, opts)
+		require.ErrorContains(t, err, "operator unilateral")
+	})
+
+	// The same invariant applies when the operator-only leaf is hidden
+	// behind a CSV or Condition wrapper: the recursive walk must catch
+	// the offending Multisig wherever it appears.
+	t.Run("operator-unilateral under CSV rejected", func(t *testing.T) {
+		t.Parallel()
+
+		collabNode := &Multisig{
+			Keys: []*btcec.PublicKey{owner, operator},
+		}
+		exitNode := &CSV{
+			Lock:  144,
+			Inner: &Multisig{Keys: []*btcec.PublicKey{owner}},
+		}
+		operatorOnlyCSV := &CSV{
+			Lock: 10,
+			Inner: &Multisig{
+				Keys: []*btcec.PublicKey{operator},
+			},
+		}
+
+		nodes := []Node{collabNode, exitNode, operatorOnlyCSV}
+
+		err := ValidatePolicy(nodes, opts)
+		require.ErrorContains(t, err, "operator unilateral")
+	})
 }
 
 // TestScriptContainsKey tests the byte-level script key substring scan.

--- a/lib/arkscript/validate_test.go
+++ b/lib/arkscript/validate_test.go
@@ -348,6 +348,41 @@ func TestValidatePolicy(t *testing.T) {
 		require.ErrorContains(t, err, "operator unilateral")
 	})
 
+	// Same invariant, but now the operator-only Multisig is hidden
+	// behind a Condition predicate rather than a CSV. The explicit
+	// `case *Condition` branch in walkRejectOperatorUnilateral must
+	// descend through the predicate wrapper and reject the inner
+	// Multisig; a regression that dropped the Condition branch would
+	// silently accept this shape.
+	t.Run("operator-unilateral under Condition rejected",
+		func(t *testing.T) {
+
+			t.Parallel()
+
+			collabNode := &Multisig{
+				Keys: []*btcec.PublicKey{owner, operator},
+			}
+			exitNode := &CSV{
+				Lock: 144,
+				Inner: &Multisig{
+					Keys: []*btcec.PublicKey{owner},
+				},
+			}
+			operatorOnlyCondition := &Condition{
+				Predicate: []byte{0x01},
+				Inner: &Multisig{
+					Keys: []*btcec.PublicKey{operator},
+				},
+			}
+
+			nodes := []Node{
+				collabNode, exitNode, operatorOnlyCondition,
+			}
+
+			err := ValidatePolicy(nodes, opts)
+			require.ErrorContains(t, err, "operator unilateral")
+		})
+
 	// A Multisig with the operator key duplicated — Multisig{op, op} —
 	// has len(Keys) == 2 yet is still unilaterally spendable by the
 	// operator, since every required signer resolves to the same key.

--- a/lib/arkscript/validate_test.go
+++ b/lib/arkscript/validate_test.go
@@ -347,6 +347,62 @@ func TestValidatePolicy(t *testing.T) {
 		err := ValidatePolicy(nodes, opts)
 		require.ErrorContains(t, err, "operator unilateral")
 	})
+
+	// A Multisig with the operator key duplicated — Multisig{op, op} —
+	// has len(Keys) == 2 yet is still unilaterally spendable by the
+	// operator, since every required signer resolves to the same key.
+	// The pre-fix length check treated this as safe; the distinctness
+	// check must reject it.
+	t.Run("duplicate-operator-key multisig rejected", func(t *testing.T) {
+		t.Parallel()
+
+		collabNode := &Multisig{
+			Keys: []*btcec.PublicKey{owner, operator},
+		}
+		exitNode := &CSV{
+			Lock: 144,
+			Inner: &Multisig{
+				Keys: []*btcec.PublicKey{owner},
+			},
+		}
+		duplicateOperator := &Multisig{
+			Keys: []*btcec.PublicKey{operator, operator},
+		}
+
+		nodes := []Node{collabNode, exitNode, duplicateOperator}
+
+		err := ValidatePolicy(nodes, opts)
+		require.ErrorContains(t, err, "operator-only")
+	})
+
+	// The same distinctness check applies when the duplicate-operator
+	// Multisig is wrapped in a CSV: unilateral spend after the delay is
+	// still unilateral.
+	name := "duplicate-operator-key multisig under CSV rejected"
+	t.Run(name, func(t *testing.T) {
+		t.Parallel()
+
+		collabNode := &Multisig{
+			Keys: []*btcec.PublicKey{owner, operator},
+		}
+		exitNode := &CSV{
+			Lock: 144,
+			Inner: &Multisig{
+				Keys: []*btcec.PublicKey{owner},
+			},
+		}
+		duplicateUnderCSV := &CSV{
+			Lock: 10,
+			Inner: &Multisig{
+				Keys: []*btcec.PublicKey{operator, operator},
+			},
+		}
+
+		nodes := []Node{collabNode, exitNode, duplicateUnderCSV}
+
+		err := ValidatePolicy(nodes, opts)
+		require.ErrorContains(t, err, "operator-only")
+	})
 }
 
 // TestScriptContainsKey tests the byte-level script key substring scan.

--- a/oor/actor_durable_message.go
+++ b/oor/actor_durable_message.go
@@ -812,16 +812,47 @@ func decodeTransferInputSnapshot(raw []byte) (*TransferInputSnapshot, error) {
 	return snap, nil
 }
 
+const (
+	// maxConditionWitnessItems caps the number of witness stack
+	// elements carried in a persisted TransferInputSnapshot. Ark's
+	// custom spend paths (vHTLC claim/refund) use at most a
+	// handful of condition items; the cap is generous but bounds
+	// memory allocation when decoding an attacker-controlled or
+	// corrupted durable blob.
+	maxConditionWitnessItems = 64
+
+	// maxConditionWitnessItemBytes caps the size of each individual
+	// witness stack element. Bitcoin's consensus limit on standard
+	// witness elements is 520 bytes (MAX_SCRIPT_ELEMENT_SIZE); we
+	// apply the same limit here so a persisted condition witness
+	// cannot hold any value that could not actually make it onto
+	// the chain.
+	maxConditionWitnessItemBytes = 520
+)
+
 // encodeConditionWitness serializes a list of witness items as
-// count-prefixed length-prefixed byte strings.
+// count-prefixed length-prefixed byte strings. Enforces the same caps
+// as the decoder so in-memory state and on-disk state can't drift.
 func encodeConditionWitness(items [][]byte) ([]byte, error) {
+	if len(items) > maxConditionWitnessItems {
+		return nil, fmt.Errorf("condition witness item count %d "+
+			"exceeds maximum %d", len(items),
+			maxConditionWitnessItems)
+	}
+
 	var buf bytes.Buffer
 
 	if err := wire.WriteVarInt(&buf, 0, uint64(len(items))); err != nil {
 		return nil, err
 	}
 
-	for _, item := range items {
+	for i, item := range items {
+		if len(item) > maxConditionWitnessItemBytes {
+			return nil, fmt.Errorf("condition witness item %d "+
+				"size %d exceeds maximum %d", i, len(item),
+				maxConditionWitnessItemBytes)
+		}
+
 		if err := wire.WriteVarBytes(&buf, 0, item); err != nil {
 			return nil, err
 		}
@@ -830,7 +861,9 @@ func encodeConditionWitness(items [][]byte) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// decodeConditionWitness deserializes a list of witness items.
+// decodeConditionWitness deserializes a list of witness items,
+// bounding both the item count and the per-item size so a crafted or
+// corrupted durable blob cannot force multi-GB allocations.
 func decodeConditionWitness(raw []byte) ([][]byte, error) {
 	r := bytes.NewReader(raw)
 
@@ -839,10 +872,16 @@ func decodeConditionWitness(raw []byte) ([][]byte, error) {
 		return nil, err
 	}
 
+	if count > maxConditionWitnessItems {
+		return nil, fmt.Errorf("condition witness item count %d "+
+			"exceeds maximum %d", count, maxConditionWitnessItems)
+	}
+
 	items := make([][]byte, count)
 	for i := uint64(0); i < count; i++ {
 		item, readErr := wire.ReadVarBytes(
-			r, 0, 10000, "condition witness item",
+			r, 0, maxConditionWitnessItemBytes,
+			"condition witness item",
 		)
 		if readErr != nil {
 			return nil, readErr

--- a/oor/actor_durable_message_test.go
+++ b/oor/actor_durable_message_test.go
@@ -322,3 +322,92 @@ func TestDriveEventPayloadRequiresEvent(t *testing.T) {
 	)
 	require.ErrorContains(t, err, "event must be provided")
 }
+
+// TestEncodeConditionWitnessRejectsTooManyItems verifies the encode path
+// refuses to emit a condition witness that exceeds the per-witness
+// item-count cap, so in-memory state cannot diverge from what the
+// decoder will accept.
+func TestEncodeConditionWitnessRejectsTooManyItems(t *testing.T) {
+	t.Parallel()
+
+	items := make([][]byte, maxConditionWitnessItems+1)
+	for i := range items {
+		items[i] = []byte{0x01}
+	}
+
+	_, err := encodeConditionWitness(items)
+	require.ErrorContains(t, err, "count")
+}
+
+// TestEncodeConditionWitnessRejectsOversizeItem verifies the encode path
+// refuses to emit a witness item larger than Bitcoin's standard witness
+// element size.
+func TestEncodeConditionWitnessRejectsOversizeItem(t *testing.T) {
+	t.Parallel()
+
+	items := [][]byte{make([]byte, maxConditionWitnessItemBytes+1)}
+
+	_, err := encodeConditionWitness(items)
+	require.ErrorContains(t, err, "size")
+}
+
+// TestDecodeConditionWitnessRejectsTooManyItems verifies the decoder
+// fails fast on a blob that claims more than maxConditionWitnessItems
+// items, preventing a large make([][]byte, count) allocation.
+func TestDecodeConditionWitnessRejectsTooManyItems(t *testing.T) {
+	t.Parallel()
+
+	// Hand-craft a blob with a varint claiming many items. We only
+	// need the count prefix; the decoder must reject before touching
+	// the (absent) items.
+	var buf bytes.Buffer
+	require.NoError(t, wire.WriteVarInt(
+		&buf, 0, uint64(maxConditionWitnessItems+1),
+	))
+
+	_, err := decodeConditionWitness(buf.Bytes())
+	require.ErrorContains(t, err, "count")
+}
+
+// TestDecodeConditionWitnessRejectsOversizeItem verifies the decoder
+// rejects a blob whose item size exceeds the standard witness element
+// cap.
+func TestDecodeConditionWitnessRejectsOversizeItem(t *testing.T) {
+	t.Parallel()
+
+	oversized := make([]byte, maxConditionWitnessItemBytes+1)
+	_, err := encodeConditionWitness([][]byte{oversized})
+	require.Error(t, err)
+
+	// Hand-craft a blob that bypasses the encoder's check: one
+	// witness item with a declared length above the decoder cap.
+	var buf bytes.Buffer
+	require.NoError(t, wire.WriteVarInt(&buf, 0, 1))
+	require.NoError(t, wire.WriteVarInt(
+		&buf, 0, uint64(maxConditionWitnessItemBytes+1),
+	))
+	buf.Write(oversized)
+
+	_, err = decodeConditionWitness(buf.Bytes())
+	require.Error(t, err)
+}
+
+// TestEncodeDecodeConditionWitnessRoundTripAtCapBoundaries verifies a
+// round-trip at exactly the allowed maximums still succeeds so the caps
+// don't accidentally reject legitimate inputs at their boundary.
+func TestEncodeDecodeConditionWitnessRoundTripAtCapBoundaries(t *testing.T) {
+	t.Parallel()
+
+	items := make([][]byte, maxConditionWitnessItems)
+	for i := range items {
+		items[i] = make([]byte, maxConditionWitnessItemBytes)
+		items[i][0] = byte(i)
+	}
+
+	encoded, err := encodeConditionWitness(items)
+	require.NoError(t, err)
+
+	decoded, err := decodeConditionWitness(encoded)
+	require.NoError(t, err)
+	require.Equal(t, items, decoded)
+}

--- a/oor/checkpoint_sign.go
+++ b/oor/checkpoint_sign.go
@@ -472,6 +472,21 @@ func signCustomCheckpointPSBT(signer input.Signer, in *TransferInput,
 			len(checkpoint.Inputs))
 	}
 
+	// Defense-in-depth binding check: the caller-supplied witness script
+	// and control block must commit to a taproot output whose P2TR script
+	// is exactly the VTXO's pkScript. Without this, a malformed control
+	// block would coerce the signer into producing a Schnorr signature
+	// over an attacker-chosen tapscript. BuildCustomTransferInputs
+	// performs the same check at the RPC boundary; we re-verify here so
+	// downstream paths that bypass that constructor (e.g. persisted
+	// TransferInputSnapshots resumed from disk) are still covered.
+	if err := in.CustomSpend.VerifyBindsToPkScript(
+		in.VTXO.PkScript,
+	); err != nil {
+		return fmt.Errorf("custom spend path does not bind to "+
+			"VTXO pkScript: %w", err)
+	}
+
 	prevOut := &wire.TxOut{
 		Value:    int64(in.VTXO.Amount),
 		PkScript: in.VTXO.PkScript,

--- a/round/actor_test.go
+++ b/round/actor_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/lightninglabs/darepo-client/internal/testutils"
 	"github.com/lightninglabs/darepo-client/lib/actormsg"
 	"github.com/lightninglabs/darepo-client/lib/arkscript"
-	"github.com/lightninglabs/darepo-client/lib/tree"
 	"github.com/lightninglabs/darepo-client/lib/types"
 	"github.com/lightninglabs/darepo-client/serverconn"
 	"github.com/lightninglabs/darepo-client/timeout"
@@ -216,10 +215,11 @@ func TestActorStart(t *testing.T) {
 		)
 		require.Len(t, assembly.VTXOs, 1)
 
-		expectedDesc, err := tree.NewVTXODescriptor(
-			amount, ownerKey.PubKey, h.operatorPubKey,
-			h.operatorTerms.VTXOExitDelay,
-		)
+		_, expectedPkScript, err := arkscript.
+			EncodeStandardVTXOArtifacts(
+				ownerKey.PubKey, h.operatorPubKey,
+				h.operatorTerms.VTXOExitDelay,
+			)
 		require.NoError(t, err)
 
 		req := assembly.VTXOs[0]
@@ -229,7 +229,7 @@ func TestActorStart(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, amount, req.Amount)
-		require.Equal(t, expectedDesc.PkScript, actualPkScript)
+		require.Equal(t, expectedPkScript, actualPkScript)
 		require.Equal(
 			t, h.operatorTerms.VTXOExitDelay,
 			params.ExitDelay,

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -18,7 +18,6 @@ import (
 	"github.com/lightninglabs/darepo-client/chainsource"
 	"github.com/lightninglabs/darepo-client/lib/actormsg"
 	"github.com/lightninglabs/darepo-client/lib/arkscript"
-	"github.com/lightninglabs/darepo-client/lib/tree"
 	"github.com/lightninglabs/darepo-client/lib/types"
 	"github.com/lightninglabs/taproot-assets/proof"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
@@ -1526,26 +1525,26 @@ func (a *Ark) buildSendVTXORequests(ctx context.Context,
 		len(req.Recipients)+1,
 	)
 	for i, r := range req.Recipients {
-		// Derive the VTXO descriptor pkScript from
-		// (ownerKey, operatorKey, exitDelay). Signing keys
-		// are NOT derived here — the round FSM derives them
-		// during the RegistrationSent transition per #210.
-		desc, descErr := tree.NewVTXODescriptor(
-			r.Amount, r.ClientKey,
-			req.OperatorKey,
-			req.VTXOExitDelay,
-		)
-		if descErr != nil {
+		// Derive the VTXO policy template and pkScript from
+		// (ownerKey, operatorKey, exitDelay). Signing keys are
+		// NOT derived here — the round FSM derives them during
+		// the RegistrationSent transition per #210.
+		policyTemplate, pkScript, err := arkscript.
+			EncodeStandardVTXOArtifacts(
+				r.ClientKey, req.OperatorKey,
+				req.VTXOExitDelay,
+			)
+		if err != nil {
 			return nil, fmt.Errorf(
 				"build recipient %d descriptor: %w",
-				i, descErr,
+				i, err,
 			)
 		}
 
 		vtxoRequests = append(vtxoRequests, types.VTXORequest{
 			Amount:         r.Amount,
-			PolicyTemplate: desc.PolicyTemplate,
-			PkScript:       desc.PkScript,
+			PolicyTemplate: policyTemplate,
+			PkScript:       pkScript,
 			Expiry:         req.VTXOExitDelay,
 			ClientKey:      r.ClientKey,
 			OperatorKey:    req.OperatorKey,
@@ -1566,23 +1565,23 @@ func (a *Ark) buildSendVTXORequests(ctx context.Context,
 			)
 		}
 
-		changeDesc, descErr := tree.NewVTXODescriptor(
-			change, changeClientKey.PubKey,
-			req.OperatorKey,
-			req.VTXOExitDelay,
-		)
-		if descErr != nil {
+		policyTemplate, pkScript, err := arkscript.
+			EncodeStandardVTXOArtifacts(
+				changeClientKey.PubKey,
+				req.OperatorKey,
+				req.VTXOExitDelay,
+			)
+		if err != nil {
 			return nil, fmt.Errorf(
-				"build change descriptor: %w",
-				descErr,
+				"build change descriptor: %w", err,
 			)
 		}
 
 		vtxoRequests = append(
 			vtxoRequests, types.VTXORequest{
 				Amount:         change,
-				PolicyTemplate: changeDesc.PolicyTemplate,
-				PkScript:       changeDesc.PkScript,
+				PolicyTemplate: policyTemplate,
+				PkScript:       pkScript,
 				Expiry:         req.VTXOExitDelay,
 				ClientKey:      changeClientKey.PubKey,
 				OwnerKey:       *changeClientKey,


### PR DESCRIPTION
In this PR, we land the followup fixes flagged by the multi-agent code
review of #212. The parent PR moved the client to a policy-first
`arkscript` model, and the review surfaced a handful of hardening
opportunities in the admission surfaces, the durable-message decoders,
and the VTXO rehydrate paths. None of the findings are exploitable on a
deployed system (the parent PR hasn't shipped yet), but we want to land
the fixes on top of the same stack so the merged history carries them
as one unit.

See each commit message for the detailed rationale w.r.t the incremental
changes. The full review report is at
`.reviews/lightninglabs_darepo-client_PR_212_review.md` in the parent
branch, and the highest-severity findings addressed here are:

- **H-2** Decode-bomb vector in `arkscript.DecodePolicyTemplate`. A
  778 KB blob of 100k nested `Condition` nodes could consume ~7.8s of
  CPU on decode; every reachable call site was gated only by a 10 KB
  envelope cap or no cap at all. We now thread a shared depth /
  node-count budget through every recursive decoder and reject
  oversize blobs upfront.
- **H-3** Signature-oracle via `CustomOORInput`. Callers could supply
  an arbitrary `(pkScript, witness_script, control_block)` tuple and
  obtain a Schnorr signature under the VTXO owner key without any
  check that the control block actually committed to the declared
  pkScript. The new `SpendPath.VerifyBindsToPkScript` recomputes the
  output key from the supplied control block and asserts equality
  against the prevout pkScript. Wired into both the RPC boundary
  (`BuildCustomTransferInputs`) and the signer
  (`signCustomCheckpointPSBT`) for defense-in-depth.
- **H-4 + H-5** Admission validator was too permissive. `ValidatePolicy`
  silently accepted policies containing `Multisig{operator_only}`
  leaves (unilateral operator spend), and the daemon never passed a
  non-zero `MinExitDelay` so a 1-block CSV would slip through and
  break the forfeit incentive. We split `ValidatePolicy` into a
  structural validator and a stricter `ValidateStandardVTXOPolicy`
  that refuses a zero minimum fail-closed, and we walk every
  `Multisig` node to reject operator-only participants.
- **H-7** `tree.NewVTXODescriptor` helper was conflating the VTXO
  owner key with the MuSig2 tree-construction `CoSignerKey`. The
  production round path was already correct (it threads an
  ephemeral per-round `SigningKey` derived via
  `keychain.DeriveNextKey`), but the helper was an exported
  footgun. We require an explicit `signingKey` parameter and
  restore the \"ephemeral per round, never reused\" invariant in
  the docstring so a future caller can't silently collapse the
  MuSig2 aggregate-key set when one wallet contributes multiple
  VTXOs to the same round.
- **H-8** `db/vtxo_store.go` was unconditionally overwriting the
  stored compressed operator pubkey with the x-only-lifted value
  from the policy template, silently flipping y-parity. `round_store`
  already handled this correctly by preferring the stored column;
  we now match that pattern in `vtxo_store`. The deeper
  architectural question of whether to switch the policy template
  encoding to lossless 33-byte compressed is tracked in #252.
- **M-1** Concurrent `SendOOR` callers could race on the same
  caller-supplied custom input. The RPC server now holds a
  mutex-protected reservation map keyed by outpoint; collisions
  fail with `Aborted` rather than double-signing.
- **M-5** `NewFallbackSchnorrSigner` was dead code that silently
  swallowed primary-signer errors. Deleted.
- **M-7** Rehydrate now emits a structured warn-log when the stored
  `Expiry` column and the policy-derived `ExitDelay` disagree,
  surfacing drift that would otherwise be silently masked.
- **M-10** `oor/actor_durable_message.go` condition-witness decoder
  accepted 10 KB per item with no count cap, so a crafted durable
  blob could force multi-MB allocation during replay. Capped at 64
  items and 520 bytes per item (Bitcoin's
  `MAX_SCRIPT_ELEMENT_SIZE`). Encoder enforces the same caps so
  in-memory state can't drift from what the persisted form admits.

Also included: **H-9** (duplicate-checkpoint-txid rejection) was
verified preserved in `lib/tx/oor/submit.go` and the finalize
validator, no code change needed. The review had flagged it as
missing because the check moved files during the PR 212 refactor.

## Docs

The last commit adds `docs/arkscript_spec.md`, an RFC-style
specification of `lib/arkscript` covering the AST, policy template
binary encoding, canonical ordering, standard shapes (VTXO,
checkpoint, vHTLC), `SpendPath` witness contract, `ValidatePolicy`
invariants, and the security-considerations section cross-referenced
from this PR. Intended for external auditors and future implementors.

## Deferred design discussions

- [#252](https://github.com/lightninglabs/darepo-client/issues/252):
  pubkey encoding strategy. The lossy x-only encoding in
  `Multisig` is the root cause of the H-8 parity class. This PR
  fixes the immediate bug in `vtxo_store` but we want a design
  decision (switch to lossless 33-byte compressed, keep x-only with
  rehydrate discipline, or split the type) before sweeping the
  whole codebase.
- [#253](https://github.com/lightninglabs/darepo-client/issues/253):
  tuning the DoS caps introduced here. The numbers are generous
  first-guesses based on known Ark policy shapes (standard VTXO =
  2 leaves, vHTLC = 6 leaves); we want to instrument real workloads
  and resize to something like 10x the observed p99 before locking
  the numbers in.

## Base branch

This branches off #212 (\`policy-arkscript\`) because the fixes depend
on the policy-first types it introduces. Can be rebased onto \`main\`
once the parent lands.

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./lib/arkscript/... ./darepod/ ./oor/ ./round/ ./wallet/ ./db/ ./lib/tree/ ./lib/tx/... -count=1\`
- [x] New tests for every non-trivial fix: decode-cap boundaries,
  `ValidatePolicy` invariants, `NewVTXODescriptor` regression,
  `reserveCustomInputs` collision and atomicity, condition-witness cap
  round-trip.
- [ ] systest + itest sweep before merge.
- [ ] Reconcile against parent PR #212 rebase if the parent picks up
  new commits.