### PR TITLE
ci: add nightly /doc-gardening cron workflow

### DIFF
--- a/.github/workflows/doc-gardening-nightly.yml
+++ b/.github/workflows/doc-gardening-nightly.yml
@@ -1,0 +1,188 @@
+name: Doc Gardening (Nightly)
+
+# Nightly cron that runs the /doc-gardening skill (see
+# .claude/skills/doc-gardening/SKILL.md) via the existing
+# anthropics/claude-code-action@v1 integration, and opens a PR against master
+# when the sweep produces any doc drift. A clean sweep exits silently.
+
+on:
+  schedule:
+    # 06:00 UTC daily. Both repos run at the same time; their PRs are
+    # independent so they don't contend.
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+concurrency:
+  # Serialize runs so a manual dispatch never races the scheduled one.
+  group: doc-gardening-nightly
+  cancel-in-progress: false
+
+permissions:
+  # Checkout uses BOT_GITHUB_TOKEN directly, so the default GITHUB_TOKEN
+  # only needs read access for the action's own bookkeeping.
+  contents: read
+  pull-requests: read
+
+jobs:
+  sweep:
+    name: Run /doc-gardening and open PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout (bot token)
+        uses: actions/checkout@v5
+        with:
+          # Use BOT_GITHUB_TOKEN so subsequent `git push` operations
+          # authenticate as the bot. This is required for the resulting PR
+          # to trigger downstream workflow events (agent-docs-sync, main,
+          # etc.) — the default GITHUB_TOKEN cannot create PRs that trigger
+          # other workflows.
+          token: ${{ secrets.BOT_GITHUB_TOKEN }}
+          # Full history: the doc-gardening skill runs git diff/log against
+          # master to detect stale packages. A shallow clone silently
+          # returns empty history and turns the sweep into a false no-op.
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Prime module cache
+        # Phase 7 of the skill runs `make doc-check`, which may shell out to
+        # `go doc` against third-party modules. Prime the cache so a cold
+        # runner doesn't hit network errors mid-sweep.
+        run: go mod download
+
+      - name: Close stale nightly PRs
+        env:
+          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+        run: |
+          # Close any still-open auto-PRs so each sweep is authoritative
+          # against current master. Done in plain shell (not inside the
+          # Claude action) so it's a guaranteed clean slate before the
+          # model runs.
+          gh pr list \
+            --label automation --label documentation \
+            --state open --json number,headRefName \
+            --jq '.[] | select(.headRefName | startswith("doc-gardening/nightly-")) | .number' \
+          | while read -r pr; do
+              gh pr close "$pr" \
+                --comment "Superseded by tonight's doc-gardening sweep." \
+                --delete-branch
+            done
+
+      - name: Run /doc-gardening sweep and open PR
+        uses: anthropics/claude-code-action@v1
+        env:
+          # Routes BOT_GITHUB_TOKEN into Claude's Bash subprocess. The gh
+          # CLI honors GH_TOKEN over GITHUB_TOKEN, so `gh pr create` runs
+          # as the bot identity. Do NOT set GITHUB_TOKEN here — leave the
+          # action's internal token alone.
+          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+          # Bot identity for commits. Set via env vars instead of
+          # `git config` so Claude doesn't need Bash(git config:*) in its
+          # allowlist.
+          GIT_AUTHOR_NAME: darepo-doc-bot
+          GIT_AUTHOR_EMAIL: bot@lightning.engineering
+          GIT_COMMITTER_NAME: darepo-doc-bot
+          GIT_COMMITTER_EMAIL: bot@lightning.engineering
+          # Surface GitHub Actions context into Claude's env so the prompt
+          # can interpolate via shell $VAR expansion instead of templating.
+          REPO_NAME: ${{ github.repository }}
+          RUN_NUMBER: ${{ github.run_number }}
+          RUN_ID: ${{ github.run_id }}
+          SERVER_URL: ${{ github.server_url }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            You are running in a nightly GitHub Actions cron job. Your job
+            is to sweep the documentation graph and — if anything changed —
+            open a PR against master. The `gh` CLI is already authenticated
+            as the bot via GH_TOKEN, so use it directly to open the PR.
+
+            Do not ask for confirmation. Do not stop after producing a diff.
+            The end state of a successful run is either (a) no changes + a
+            clean exit, or (b) a branch pushed and a PR opened.
+
+            Execute these steps in order:
+
+            1. **Run the skill.** Read `.claude/skills/doc-gardening/SKILL.md`
+               and execute its Phases 1-7 with scope = `all`. After each
+               phase, print `PHASE N COMPLETE` on its own line so the
+               Actions log is grep-able. Do NOT skip phases.
+
+            2. **Validate.** Phase 7 runs `make doc-check`. If it fails,
+               iterate to fix the errors — never commit broken docs. If you
+               cannot make it pass after reasonable effort, print
+               `DOC-GARDENING ABORTED: make doc-check still failing` and
+               exit without committing, pushing, or opening a PR.
+
+            3. **Zero-change exit.** Run `git status --porcelain`. If
+               empty, print `DOC-GARDENING NO-OP` and exit cleanly. Do not
+               create a branch, do not push, do not open a PR.
+
+            4. **Branch and commit.** If there are changes:
+               - Create and check out a fresh branch:
+                 `BRANCH="doc-gardening/nightly-$(date -u +%Y-%m-%d)-${RUN_NUMBER}"`
+                 then `git checkout -b "$BRANCH"`.
+               - Stage everything with `git add -A`.
+               - Write the commit message to `.git/COMMIT_MSG` using this
+                 template (substitute today's UTC date):
+
+                     docs: nightly doc-gardening sweep <YYYY-MM-DD>
+
+                     Automated sweep via .claude/skills/doc-gardening.
+                     Updates per-package CLAUDE.md/AGENTS.md, docs/index.md
+                     entries, and ARCHITECTURE.md as needed.
+
+                     Workflow run: ${SERVER_URL}/${REPO_NAME}/actions/runs/${RUN_ID}
+
+               - Commit with `git commit -F .git/COMMIT_MSG`.
+
+            5. **Push and open PR.**
+               - `git fetch origin master` (refresh the base ref in case
+                 master advanced during the sweep).
+               - `git push -u origin "$BRANCH"`.
+               - Write a short PR body to `.git/PR_BODY.md` containing:
+                 a one-line description, a link to the workflow run, and a
+                 note to review the updated CLAUDE.md/AGENTS.md and
+                 ARCHITECTURE.md diffs.
+               - Open the PR:
+
+                     gh pr create \
+                       --base master \
+                       --head "$BRANCH" \
+                       --title "docs: nightly doc-gardening sweep $(date -u +%Y-%m-%d)" \
+                       --body-file .git/PR_BODY.md \
+                       --label documentation \
+                       --label automation
+
+            6. **Finish.** Print the PR URL `gh pr create` returned on its
+               own line prefixed with `DOC-GARDENING PR: ` so the Actions
+               log surfaces it clearly.
+
+            Constraints:
+            - Never run `git push --force` or `git push -f`.
+            - Never push to `master` directly.
+            - Never modify files outside this repo.
+            - Never add reviewers or assignees to the PR.
+            - If any `gh` command fails, print the error and exit non-zero
+              so the workflow's failure handler opens an issue.
+          claude_args: >-
+            --max-turns 200
+            --allowed-tools
+            "Bash(git status:*),Bash(git diff:*),Bash(git add:*),Bash(git commit:*),Bash(git checkout:*),Bash(git log:*),Bash(git rev-parse:*),Bash(git branch:*),Bash(git fetch:*),Bash(git push:*),Bash(make doc-check:*),Bash(go doc:*),Bash(find:*),Bash(ls:*),Bash(cp:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(date:*),Bash(sort:*),Bash(sed:*),Bash(awk:*),Bash(gh pr create:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh auth status:*)"
+            --disallowed-tools
+            "Bash(rm:*),Bash(rmdir:*),Bash(git push --force:*),Bash(git push -f:*),Bash(git push --delete:*),Bash(git reset --hard:*),Bash(git commit --amend:*),Bash(gh api:*),Bash(gh secret:*),Bash(gh auth login:*),Bash(gh auth logout:*),Bash(gh auth refresh:*),Bash(gh repo delete:*),Bash(gh workflow:*),Bash(gh release:*),Bash(curl:*),Bash(wget:*)"
+
+      - name: Notify on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+        run: |
+          gh issue create \
+            --title "Doc gardening nightly failed on $(date -u +%Y-%m-%d)" \
+            --body "The nightly doc-gardening workflow failed. See run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --label automation --label bug

--- a/.github/workflows/doc-gardening-nightly.yml
+++ b/.github/workflows/doc-gardening-nightly.yml
@@ -79,10 +79,11 @@ jobs:
       - name: Run /doc-gardening sweep and open PR
         uses: anthropics/claude-code-action@v1
         env:
-          # Routes BOT_GITHUB_TOKEN into Claude's Bash subprocess. The gh
-          # CLI honors GH_TOKEN over GITHUB_TOKEN, so `gh pr create` runs
-          # as the bot identity. Do NOT set GITHUB_TOKEN here — leave the
-          # action's internal token alone.
+          # Belt-and-suspenders: also surface the bot token as GH_TOKEN on
+          # the step env so `gh` inside Claude's Bash subprocess picks it
+          # up regardless of how the action wires its own env. The
+          # authoritative handoff to the action's internal git/gh
+          # operations is the `github_token:` input below.
           GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
           # Bot identity for commits. Set via env vars instead of
           # `git config` so Claude doesn't need Bash(git config:*) in its
@@ -99,6 +100,16 @@ jobs:
           SERVER_URL: ${{ github.server_url }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Authoritative token handoff. Without this input, the action's
+          # setupGitHubToken() falls back to an OIDC token-exchange flow
+          # (src/github/token.ts) that fails fast with "Did you remember
+          # to add `id-token: write`" unless the workflow grants
+          # `id-token: write` permissions. Providing github_token sets
+          # OVERRIDE_GITHUB_TOKEN, which short-circuits the OIDC path and
+          # routes the bot token into the action's internal git/gh
+          # operations — so the PR the action opens comes from the bot
+          # identity and triggers downstream workflow events as intended.
+          github_token: ${{ secrets.BOT_GITHUB_TOKEN }}
           prompt: |
             You are running in a nightly GitHub Actions cron job. Your job
             is to sweep the documentation graph and — if anything changed —

--- a/.github/workflows/doc-gardening-nightly.yml
+++ b/.github/workflows/doc-gardening-nightly.yml
@@ -7,9 +7,12 @@ name: Doc Gardening (Nightly)
 
 on:
   schedule:
-    # 06:00 UTC daily. Both repos run at the same time; their PRs are
-    # independent so they don't contend.
-    - cron: '0 6 * * *'
+    # 06:17 UTC daily. Avoid top-of-hour (XX:00) slots, which GitHub docs
+    # flag as high-load windows where scheduled runs can be delayed or
+    # dropped. The 17-minute offset puts us outside that window while still
+    # keeping the sweep within the low-traffic overnight band (both repos
+    # share this slot; their PRs are independent and don't contend).
+    - cron: '17 6 * * *'
   workflow_dispatch:
 
 concurrency:
@@ -177,12 +180,31 @@ jobs:
             --disallowed-tools
             "Bash(rm:*),Bash(rmdir:*),Bash(git push --force:*),Bash(git push -f:*),Bash(git push --delete:*),Bash(git reset --hard:*),Bash(git commit --amend:*),Bash(gh api:*),Bash(gh secret:*),Bash(gh auth login:*),Bash(gh auth logout:*),Bash(gh auth refresh:*),Bash(gh repo delete:*),Bash(gh workflow:*),Bash(gh release:*),Bash(curl:*),Bash(wget:*)"
 
-      - name: Notify on failure
+      - name: Notify on failure (create tracking issue)
         if: failure()
+        id: notify_create
         env:
           GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
         run: |
-          gh issue create \
+          # Create the tracking issue WITHOUT labels first so a missing or
+          # renamed label can never swallow the canary. The label-attach
+          # step below is best-effort and isolated so a label failure here
+          # doesn't also eat the tracking issue itself.
+          url=$(gh issue create \
             --title "Doc gardening nightly failed on $(date -u +%Y-%m-%d)" \
-            --body "The nightly doc-gardening workflow failed. See run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            --label automation --label bug
+            --body "The nightly doc-gardening workflow failed. See run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}")
+          echo "issue_url=${url}" >> "$GITHUB_OUTPUT"
+
+      - name: Notify on failure (label tracking issue)
+        if: failure() && steps.notify_create.outputs.issue_url != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+          ISSUE_URL: ${{ steps.notify_create.outputs.issue_url }}
+        run: |
+          # Best-effort label attach. `continue-on-error: true` plus `|| true`
+          # means a missing label logs a warning but never fails the workflow
+          # — the issue itself is the canary that matters, labels are just
+          # triage sugar.
+          gh issue edit "$ISSUE_URL" \
+            --add-label automation --add-label bug || true


### PR DESCRIPTION
In this PR, we add a nightly GitHub Actions cron that runs the project-scoped `/doc-gardening` skill via the existing `anthropics/claude-code-action@v1` integration, and opens a PR against master whenever the sweep finds drift in any per-package `CLAUDE.md`/`AGENTS.md`, in `ARCHITECTURE.md`, or in `docs/index.md`. Today the skill is only run on demand by humans, so doc drift accumulates silently between sprints and the next person to notice is usually whoever sees `make doc-check` red-X in CI. Running it nightly turns that drift into a small reviewable PR each morning instead of a quarterly cleanup pass.

The workflow shape: checkout w/ `BOT_GITHUB_TOKEN` (full history, since the skill walks `git log`/`git diff` against master), `setup-go` + `go mod download` to prime the cache for `go doc`, a shell step that closes any still-open auto-PRs from prior runs (so each sweep is authoritative against current master), then the Claude action with a focused prompt, and a `failure()` handler that opens a tracking issue if the run red-Xes overnight.

## Why bot token everywhere

We pass `BOT_GITHUB_TOKEN` both as the `actions/checkout` `token:` and as step-level `GH_TOKEN` on the Claude action. The first wires `git push` to the bot identity. The second makes `gh` (which honors `GH_TOKEN` over `GITHUB_TOKEN`) authenticate as the bot inside Claude's Bash subprocess. Both are required because PRs created with the default `GITHUB_TOKEN` don't trigger downstream workflow events, and we want `agent-docs-sync` and the rest of CI to fire on the nightly PR like any other change. We deliberately don't touch `GITHUB_TOKEN` itself, the action's internal bookkeeping uses it.

## Capability boundary

Since Claude is driving the full pipeline (sweep, commit, branch, push, `gh pr create`), the `--allowed-tools`/`--disallowed-tools` pair is the primary safety boundary. Allowed: `git` subcommands, `make doc-check`, `go doc`, the file/text primitives the skill needs (`find`, `cp`, `sed`, `awk`, etc), and `gh pr create`/`list`/`view`/`auth status`. Explicitly disallowed: `rm`, `gh api`, `gh secret`, `gh workflow`, `gh release`, `gh repo delete`, `gh auth login`/`logout`/`refresh`, `curl`, `wget`, `git push --force`, `git push -f`, `git push --delete`, `git reset --hard`, `git commit --amend`. Worst-case prompt-injection landing in some `CLAUDE.md` Phase 1 reads can do at most what an honest doc-gardening run can do, and we have master branch protection on the server side as a hard backstop against direct pushes.

## Prompt shape

The prompt tells Claude explicitly to read `.claude/skills/doc-gardening/SKILL.md` and execute Phases 1-7 with `scope=all`. We don't rely on slash-command auto-dispatch, since headless `claude -p` doesn't reliably surface project skills the way the REPL does. After each phase the model prints `PHASE N COMPLETE` so the Actions log is grep-able. On a clean sweep it prints `DOC-GARDENING NO-OP` and exits without committing. On a successful sweep it cuts a `doc-gardening/nightly-YYYY-MM-DD-${RUN_NUMBER}` branch, commits with `git commit -F .git/COMMIT_MSG`, pushes, opens the PR via `gh pr create --base master --head $BRANCH --label documentation --label automation`, and prints the resulting URL prefixed with `DOC-GARDENING PR: ` so it's easy to find in the log.

Note: the workflow uses an `automation` label that doesn't currently exist in this repo. It needs to be created (`gh label create automation --color c5def5 --description "Automated changes from CI bots"`) before the first nightly run, otherwise `gh pr create` inside the action will fail with "label not found".

## Observability

A `failure()` step opens a tracking issue on the repo if the workflow red-Xes for any reason (OAuth token expiry, `make doc-check` regression that the skill can't fix, runner OOM, etc, etc). The next-day Issue is the canary, no need to babysit cron at 06:00 UTC. Stale auto-PRs from prior days are closed by a shell step at the start of each run with `--delete-branch`, so the queue doesn't grow unbounded if nobody merges yesterday's sweep.

## Test plan

- [ ] Create the `automation` label in this repo (see note above) before first run.
- [ ] Manual `workflow_dispatch` after merge: watch for `PHASE 1 COMPLETE` through `PHASE 7 COMPLETE`, then either `DOC-GARDENING NO-OP` or `DOC-GARDENING PR: <url>`.
- [ ] On the sweep-with-changes path, confirm downstream CI fires on the resulting PR (proves the bot token plumbing is correct, not the default `GITHUB_TOKEN`).
- [ ] Verify `gh pr view <number> --json author` shows the bot identity, not the default actions user.
- [ ] Trigger a second `workflow_dispatch` the same day to confirm the stale-PR cleanup step closes yesterday's auto-PR.
