### PR TITLE
docs: nightly doc-gardening sweep 2026-04-15

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -17,10 +17,9 @@ package may import from a higher layer.
 | [`vtxo`](vtxo/) | VTXO lifecycle FSM (live, forfeiting, forfeited, spent, expiring) |
 | [`oor`](oor/) | Out-of-round transfer coordination FSM |
 | [`wallet`](wallet/) | On-chain boarding wallet actor (address derivation, UTXO monitoring) |
-| [`lib`](lib/) | Shared domain utilities: tree paths, BIP-322, tapscripts, types |
+| [`lib`](lib/) | Shared domain utilities: tree paths, BIP-322, arkscript policy, types |
 | [`lib/arkscript`](lib/arkscript/) | Tapscript AST compiler and policy system for Ark taproot outputs |
 | [`lib/bip322`](lib/bip322/) | BIP-322 intent-bound message authentication |
-| [`lib/scripts`](lib/scripts/) | Low-level Bitcoin script construction for VTXO and checkpoint outputs |
 | [`lib/tx/arktx`](lib/tx/arktx/) | Canonical Ark transaction ordering and validation |
 | [`lib/tx/checkpoint`](lib/tx/checkpoint/) | Checkpoint PSBT construction for OOR transfers |
 | [`lib/tx/oor`](lib/tx/oor/) | OOR submit/finalize package builders and validators |
@@ -77,7 +76,7 @@ darepod (orchestrator)
 │   ├── serverconn  │ (outbound RPCs to operator)
 │   ├── timeout     │ (scheduling)
 │   ├── wallet      │ (boarding intents)
-│   └── lib         │ (tree, types, scripts, bip322)
+│   └── lib         │ (tree, types, arkscript, bip322)
 ├── vtxo            │
 │   ├── chainsource │ (block epoch events)
 │   └── db          │ (vtxo store)

--- a/baselib/actor/AGENTS.md
+++ b/baselib/actor/AGENTS.md
@@ -19,8 +19,9 @@ crash-safe at-least-once delivery with exactly-once deduplication.
 - `Message` — Sealed interface for all actor messages (must embed `BaseMessage`).
 - `MessageCodec` — TLV-based codec for message serialization/deserialization.
 - `DeliveryStore` / `TxAwareDeliveryStore` — Interfaces for durable mailbox persistence (enqueue, claim, ack, dead-letter).
-- `DurableActor` — Actor variant with crash-safe mailbox backed by SQL persistence.
+- `DurableActor` — Actor variant with crash-safe mailbox backed by SQL persistence. Provides `Wait(ctx)` to block until the actor stops and `StopAndWait(ctx)` to request a graceful shutdown and then wait.
 - `Checkpoint` — Serializable actor state snapshot for recovery.
+- `WithoutOutboxID` — Context helper that strips the propagated outbox ID so child operations do not inherit the parent's delivery tracking scope.
 - `Promise[T]` / `Future[T]` — Async result types for Ask-pattern responses.
 - `ChannelMailbox[M, R]` — In-memory channel-based mailbox (non-durable, for lightweight actors).
 

--- a/baselib/actor/CLAUDE.md
+++ b/baselib/actor/CLAUDE.md
@@ -19,8 +19,9 @@ crash-safe at-least-once delivery with exactly-once deduplication.
 - `Message` — Sealed interface for all actor messages (must embed `BaseMessage`).
 - `MessageCodec` — TLV-based codec for message serialization/deserialization.
 - `DeliveryStore` / `TxAwareDeliveryStore` — Interfaces for durable mailbox persistence (enqueue, claim, ack, dead-letter).
-- `DurableActor` — Actor variant with crash-safe mailbox backed by SQL persistence.
+- `DurableActor` — Actor variant with crash-safe mailbox backed by SQL persistence. Provides `Wait(ctx)` to block until the actor stops and `StopAndWait(ctx)` to request a graceful shutdown and then wait.
 - `Checkpoint` — Serializable actor state snapshot for recovery.
+- `WithoutOutboxID` — Context helper that strips the propagated outbox ID so child operations do not inherit the parent's delivery tracking scope.
 - `Promise[T]` / `Future[T]` — Async result types for Ask-pattern responses.
 - `ChannelMailbox[M, R]` — In-memory channel-based mailbox (non-durable, for lightweight actors).
 

--- a/cmd/darepocli/darepoclicommands/AGENTS.md
+++ b/cmd/darepocli/darepoclicommands/AGENTS.md
@@ -22,6 +22,7 @@ embed the same command tree.
 | `vtxos list` | `ListVTXOs` | List wallet VTXOs |
 | `send` | `SendVTXO` / `SendOOR` | Send to address |
 | `balance` | `GetBalance` | Show wallet balances |
+| `oor receive` | `NewOORReceiveScript` | Register a new OOR receive script and print the receive address |
 
 ## Relationships
 

--- a/cmd/darepocli/darepoclicommands/CLAUDE.md
+++ b/cmd/darepocli/darepoclicommands/CLAUDE.md
@@ -22,6 +22,7 @@ embed the same command tree.
 | `vtxos list` | `ListVTXOs` | List wallet VTXOs |
 | `send` | `SendVTXO` / `SendOOR` | Send to address |
 | `balance` | `GetBalance` | Show wallet balances |
+| `oor receive` | `NewOORReceiveScript` | Register a new OOR receive script and print the receive address |
 
 ## Relationships
 

--- a/darepod/AGENTS.md
+++ b/darepod/AGENTS.md
@@ -15,6 +15,7 @@ gRPC API.
 - `GetStoredVTXO` — Harness-only accessor that returns a persisted `vtxo.Descriptor` for a given outpoint directly from the daemon's VTXO store. Lets integration tests inspect partial unroll state without reaching into internal fields.
 - `WalletState` — Enum (None/Locked/Ready) for wallet lifecycle.
 - `serverDurableUnaryBuilder` — Implements `serverconn.DurableUnaryRequestBuilder` by delegating to the indexer client with proof-of-control credentials.
+- `IndexerProofKey` — Public server method that derives the fixed wallet key for a given key locator and returns an `indexer.SchnorrSigner` backed by the proof-key backend. Used by `EnsureDefaultOORReceiveScript` and the `serverDurableUnaryBuilder` to produce per-request proof-of-control signatures.
 - `NewOwnedReceiveScriptSigner` — Indexer signer that resolves the wallet key for any persisted owned receive script, then delegates signing to the backend-specific signer.
 - `ownedScriptCheckerAdapter` — Wraps `db.OORArtifactPersistenceStore` to satisfy `round.OwnedScriptChecker`. Uses `context.WithoutCancel` so the confirmation-time ownership lookup survives FSM shutdown. Returns `false` on `sql.ErrNoRows`.
 - `ownedScriptRegistrarAdapter` — Wraps the same store to satisfy `round.OwnedScriptRegistrar`. Persists pkScripts as `OwnedReceiveScriptSourceWallet` with the operator pubkey and VTXO exit delay from `OperatorTerms`.

--- a/darepod/CLAUDE.md
+++ b/darepod/CLAUDE.md
@@ -15,6 +15,7 @@ gRPC API.
 - `GetStoredVTXO` — Harness-only accessor that returns a persisted `vtxo.Descriptor` for a given outpoint directly from the daemon's VTXO store. Lets integration tests inspect partial unroll state without reaching into internal fields.
 - `WalletState` — Enum (None/Locked/Ready) for wallet lifecycle.
 - `serverDurableUnaryBuilder` — Implements `serverconn.DurableUnaryRequestBuilder` by delegating to the indexer client with proof-of-control credentials.
+- `IndexerProofKey` — Public server method that derives the fixed wallet key for a given key locator and returns an `indexer.SchnorrSigner` backed by the proof-key backend. Used by `EnsureDefaultOORReceiveScript` and the `serverDurableUnaryBuilder` to produce per-request proof-of-control signatures.
 - `NewOwnedReceiveScriptSigner` — Indexer signer that resolves the wallet key for any persisted owned receive script, then delegates signing to the backend-specific signer.
 - `ownedScriptCheckerAdapter` — Wraps `db.OORArtifactPersistenceStore` to satisfy `round.OwnedScriptChecker`. Uses `context.WithoutCancel` so the confirmation-time ownership lookup survives FSM shutdown. Returns `false` on `sql.ErrNoRows`.
 - `ownedScriptRegistrarAdapter` — Wraps the same store to satisfy `round.OwnedScriptRegistrar`. Persists pkScripts as `OwnedReceiveScriptSourceWallet` with the operator pubkey and VTXO exit delay from `OperatorTerms`.

--- a/indexer/AGENTS.md
+++ b/indexer/AGENTS.md
@@ -18,7 +18,19 @@ proofs for proof-of-control.
 - `SyncClient` / `SyncCursorStore` / `SyncBackend` — Cursor-based sync infrastructure for VTXO/OOR event polling.
 - `MemorySyncCursorStore` — In-memory cursor store (test-only compilation unit).
 
+## Key Methods (on `*Client`)
+
+- `BuildListVTXOsByScriptsTaprootRequest` / `ListVTXOsByScriptsTaproot` — Build and execute taproot-scope-proofed `ListVTXOsByScripts` queries. The proof covers each pkScript in the request using owner-key signatures gated on script scope.
+- `BuildGetOORSessionByTxidTaprootRequest` / `GetOORSessionByTxidTaproot` — Build and execute a taproot-proofed OOR session lookup by Ark txid.
+- `BuildListOORRecipientEventsByScriptTaprootRequest` / `ListOORRecipientEventsByScriptTaproot` — Build and execute a taproot-proofed listing of OOR receive events for a given pkScript.
+
 ## Relationships
 
 - **Depends on**: `arkrpc` (IndexerService stubs), `serverconn` (mailbox transport).
 - **Depended on by**: `darepod` (wiring, receive script registration, metadata queries).
+
+## Invariants
+
+- All proof-of-control signatures are Schnorr (BIP-340) over a tagged hash of the request scope.
+- Taproot-scoped proofs (`buildTaprootScopes`) attach per-script owner signatures so the server can verify that the caller controls the scripts being queried — preventing unauthorized balance enumeration.
+- `WithSigner` returns a shallow copy; both the original and the copy share the same underlying RPC transport.

--- a/indexer/CLAUDE.md
+++ b/indexer/CLAUDE.md
@@ -18,7 +18,19 @@ proofs for proof-of-control.
 - `SyncClient` / `SyncCursorStore` / `SyncBackend` — Cursor-based sync infrastructure for VTXO/OOR event polling.
 - `MemorySyncCursorStore` — In-memory cursor store (test-only compilation unit).
 
+## Key Methods (on `*Client`)
+
+- `BuildListVTXOsByScriptsTaprootRequest` / `ListVTXOsByScriptsTaproot` — Build and execute taproot-scope-proofed `ListVTXOsByScripts` queries. The proof covers each pkScript in the request using owner-key signatures gated on script scope.
+- `BuildGetOORSessionByTxidTaprootRequest` / `GetOORSessionByTxidTaproot` — Build and execute a taproot-proofed OOR session lookup by Ark txid.
+- `BuildListOORRecipientEventsByScriptTaprootRequest` / `ListOORRecipientEventsByScriptTaproot` — Build and execute a taproot-proofed listing of OOR receive events for a given pkScript.
+
 ## Relationships
 
 - **Depends on**: `arkrpc` (IndexerService stubs), `serverconn` (mailbox transport).
 - **Depended on by**: `darepod` (wiring, receive script registration, metadata queries).
+
+## Invariants
+
+- All proof-of-control signatures are Schnorr (BIP-340) over a tagged hash of the request scope.
+- Taproot-scoped proofs (`buildTaprootScopes`) attach per-script owner signatures so the server can verify that the caller controls the scripts being queried — preventing unauthorized balance enumeration.
+- `WithSigner` returns a shallow copy; both the original and the copy share the same underlying RPC transport.

--- a/lib/AGENTS.md
+++ b/lib/AGENTS.md
@@ -3,8 +3,8 @@
 ## Purpose
 
 Shared domain utilities used across the codebase: tree construction, transaction
-builders, Bitcoin script helpers, BIP-322 signing, cross-package actor message
-interfaces, and core Ark types.
+builders, tapscript policy compilation, BIP-322 signing, cross-package actor
+message interfaces, and core Ark types.
 
 ## Sub-Packages
 
@@ -17,6 +17,8 @@ interfaces, and core Ark types.
 - `Node` — Sealed AST interface for tapscript spending conditions (Multisig, CSV, Condition, etc.).
 - `VTXOPolicy` / `VHTLCPolicy` / `CheckpointPolicy` — High-level policy templates.
 - `CompiledPolicy` — Fully compiled taproot tree with canonical leaf ordering.
+- `PolicyTemplate` / `StandardVTXOParams` — Serializable policy template with helpers for encoding, decoding, and deriving pkScripts.
+- `SpendInfo` / `AnchorPkScript` — Taproot spend helpers and standardized P2A anchor output construction.
 
 ### lib/tx
 - `arktx` — Canonical output ordering and validation for Ark transactions.
@@ -28,10 +30,6 @@ interfaces, and core Ark types.
 - `OperatorTerms` — Server-published terms (key, delays, fee rate, dust limit).
 - `JoinRoundRequest` — Primary round participation message.
 - `VTXORequest`, `BoardingRequest`, `LeaveRequest`, `ForfeitRequest` — Sub-requests.
-
-### lib/scripts
-- Bitcoin script construction for Ark outputs (VTXO taproot, connectors, anchors).
-- `AnchorPkScript` — Standardized P2A zero-value output for CPFP fee bumping.
 
 ### lib/bip322
 - `Intent` — Application payload with ValidFrom/ValidUntil block height range.

--- a/lib/CLAUDE.md
+++ b/lib/CLAUDE.md
@@ -3,8 +3,8 @@
 ## Purpose
 
 Shared domain utilities used across the codebase: tree construction, transaction
-builders, Bitcoin script helpers, BIP-322 signing, cross-package actor message
-interfaces, and core Ark types.
+builders, tapscript policy compilation, BIP-322 signing, cross-package actor
+message interfaces, and core Ark types.
 
 ## Sub-Packages
 
@@ -17,6 +17,8 @@ interfaces, and core Ark types.
 - `Node` — Sealed AST interface for tapscript spending conditions (Multisig, CSV, Condition, etc.).
 - `VTXOPolicy` / `VHTLCPolicy` / `CheckpointPolicy` — High-level policy templates.
 - `CompiledPolicy` — Fully compiled taproot tree with canonical leaf ordering.
+- `PolicyTemplate` / `StandardVTXOParams` — Serializable policy template with helpers for encoding, decoding, and deriving pkScripts.
+- `SpendInfo` / `AnchorPkScript` — Taproot spend helpers and standardized P2A anchor output construction.
 
 ### lib/tx
 - `arktx` — Canonical output ordering and validation for Ark transactions.
@@ -28,10 +30,6 @@ interfaces, and core Ark types.
 - `OperatorTerms` — Server-published terms (key, delays, fee rate, dust limit).
 - `JoinRoundRequest` — Primary round participation message.
 - `VTXORequest`, `BoardingRequest`, `LeaveRequest`, `ForfeitRequest` — Sub-requests.
-
-### lib/scripts
-- Bitcoin script construction for Ark outputs (VTXO taproot, connectors, anchors).
-- `AnchorPkScript` — Standardized P2A zero-value output for CPFP fee bumping.
 
 ### lib/bip322
 - `Intent` — Application payload with ValidFrom/ValidUntil block height range.

--- a/lib/arkscript/AGENTS.md
+++ b/lib/arkscript/AGENTS.md
@@ -19,15 +19,20 @@ validated invariants.
   Provides `CollabSpendInfo()` and `ExitSpendInfo()`.
 - `VHTLCPolicy` — 6-leaf vHTLC policy with claim/refund/unilateral paths for
   hash-time-locked conditional transfers.
-- `CheckpointPolicy` — Parameters for OOR checkpoint taproot tree construction.
-- `SpendInfo` — Witness script + control block needed to spend a specific leaf.
+- `CheckpointPolicy` — Parameters for OOR checkpoint taproot tree construction. `CheckpointTapScript` / `CheckpointPkScript` derive the checkpoint output.
+- `SpendInfo` — Witness script + control block needed to spend a specific leaf. Methods: `BuildSignDescriptor`, `CollabWitness`, `TimeoutWitness`.
+- `SpendPath` — Serializable spend path (leaf index + encoded leaf data) with `Witness` and `AttachTapLeafScript` helpers for PSBT integration.
+- `StandardVTXOParams` — Decoded parameters for a standard Ark VTXO policy (owner key, operator key, CSV delay). Derived via `DecodeStandardVTXOParams`.
+- `ComposedPolicy` — Composes an existing `CompiledPolicy` with an additional sibling tap branch root, allowing sub-tree aggregation. Built with `ComposeWithSiblingRoot`.
+- `AnchorOutput` — Creates a zero-value P2A anchor transaction output for CPFP fee bumping (replaces the removed `lib/scripts.AnchorPkScript`).
+- `EncodedLeaf` / `EncodeTapTree` / `DecodeTapTree` — TLV-based tap tree serialization for PSBT sidecars compatible with `waddrmgr` format.
 
 ## Relationships
 
 - **Depends on**: (no internal repo imports; pure cryptographic library).
-- **Depended on by**: `darepod`, `db`, `lib/tree`, `lib/tx/arktx`,
-  `lib/tx/checkpoint`, `lib/tx/oor`, `lib/tx/psbtutil`, `oor`, `round`,
-  `vtxo`, `wallet`.
+- **Depended on by**: `darepod`, `db`, `lib/tree`, `lib/types`, `lib/tx/arktx`,
+  `lib/tx/checkpoint`, `lib/tx`, `lib/tx/oor`, `lib/tx/psbtutil`,
+  `oor`, `round`, `vtxo`, `wallet`.
 
 ## Invariants
 

--- a/lib/arkscript/CLAUDE.md
+++ b/lib/arkscript/CLAUDE.md
@@ -19,15 +19,20 @@ validated invariants.
   Provides `CollabSpendInfo()` and `ExitSpendInfo()`.
 - `VHTLCPolicy` — 6-leaf vHTLC policy with claim/refund/unilateral paths for
   hash-time-locked conditional transfers.
-- `CheckpointPolicy` — Parameters for OOR checkpoint taproot tree construction.
-- `SpendInfo` — Witness script + control block needed to spend a specific leaf.
+- `CheckpointPolicy` — Parameters for OOR checkpoint taproot tree construction. `CheckpointTapScript` / `CheckpointPkScript` derive the checkpoint output.
+- `SpendInfo` — Witness script + control block needed to spend a specific leaf. Methods: `BuildSignDescriptor`, `CollabWitness`, `TimeoutWitness`.
+- `SpendPath` — Serializable spend path (leaf index + encoded leaf data) with `Witness` and `AttachTapLeafScript` helpers for PSBT integration.
+- `StandardVTXOParams` — Decoded parameters for a standard Ark VTXO policy (owner key, operator key, CSV delay). Derived via `DecodeStandardVTXOParams`.
+- `ComposedPolicy` — Composes an existing `CompiledPolicy` with an additional sibling tap branch root, allowing sub-tree aggregation. Built with `ComposeWithSiblingRoot`.
+- `AnchorOutput` — Creates a zero-value P2A anchor transaction output for CPFP fee bumping (replaces the removed `lib/scripts.AnchorPkScript`).
+- `EncodedLeaf` / `EncodeTapTree` / `DecodeTapTree` — TLV-based tap tree serialization for PSBT sidecars compatible with `waddrmgr` format.
 
 ## Relationships
 
 - **Depends on**: (no internal repo imports; pure cryptographic library).
-- **Depended on by**: `darepod`, `db`, `lib/tree`, `lib/tx/arktx`,
-  `lib/tx/checkpoint`, `lib/tx/oor`, `lib/tx/psbtutil`, `oor`, `round`,
-  `vtxo`, `wallet`.
+- **Depended on by**: `darepod`, `db`, `lib/tree`, `lib/types`, `lib/tx/arktx`,
+  `lib/tx/checkpoint`, `lib/tx`, `lib/tx/oor`, `lib/tx/psbtutil`,
+  `oor`, `round`, `vtxo`, `wallet`.
 
 ## Invariants
 

--- a/lib/scripts/AGENTS.md
+++ b/lib/scripts/AGENTS.md
@@ -2,46 +2,16 @@
 
 ## Purpose
 
-Low-level Bitcoin script construction helpers for standard Ark outputs (VTXO and
-checkpoint tapscripts). Provides deterministic script builders and witness
-construction for taproot spending paths.
+**Removed.** This package previously provided low-level Bitcoin script
+construction helpers for standard Ark outputs (VTXO and checkpoint
+tapscripts). All functionality has been migrated to `lib/arkscript`, which
+provides a policy-based tapscript compiler with the same canonical output.
 
-## Key Types
-
-- `VTXOLeafType` — Enum identifying VTXO tapscript tree leaves:
-  `VTXOCollabPathLeaf` (index 0) and `VTXOTimeoutPathLeaf` (index 1).
-- `VTXOSpendData` — Witness script + control block needed to spend a VTXO via
-  collab or timeout path.
-
-## Key Functions
-
-- `VTXOTapScript` / `VTXOTapKey` — Full VTXO tapscript and taproot output key
-  construction.
-- `NewVTXOSpendInfo` / `VTXOSignDesc` — Derive spend info and sign descriptors
-  for any leaf path.
-- `VTXOTimeoutSpendWitness` / `VTXOCollabSpendWitness` — Construct witnesses
-  for the two VTXO spending paths.
-- `CheckpointOORScript` — Checkpoint script helpers for OOR transactions.
-- `AnchorPkScript` — Standardized P2A zero-value output for CPFP fee bumping.
-
-## Relationships
-
-- **Depends on**: (no internal repo imports; pure script library).
-- **Depended on by**: `darepod`, `db`, `lib/tx/*`, `round`, `vtxo`, `wallet`,
-  `walletcore`.
-
-## Invariants
-
-- VTXO tree structure is immutable: NUMS key path (unspendable), collab leaf
-  (index 0, owner CHECKSIGVERIFY + cosigner CHECKSIG), timeout leaf (index 1,
-  owner CHECKSIG + CSV delay + DROP).
-- Collab spend requires both owner and cosigner signatures. Timeout spend
-  requires owner signature only (after CSV delay).
-- Witness stack ordering: collab = [cosigner_sig, owner_sig, script,
-  control_block]; timeout = [owner_sig, script, control_block].
-- ARK NUMS key is unspendable (no known discrete log); key path is never
-  usable.
+See `lib/arkscript` for `VTXOPolicy`, `CheckpointPolicy`, `SpendInfo`,
+`AnchorOutput`, and related types that replace the former contents of this
+package.
 
 ## Deep Docs
 
+- [lib/arkscript/CLAUDE.md](../arkscript/CLAUDE.md) — Replacement package.
 - [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/lib/scripts/CLAUDE.md
+++ b/lib/scripts/CLAUDE.md
@@ -2,46 +2,16 @@
 
 ## Purpose
 
-Low-level Bitcoin script construction helpers for standard Ark outputs (VTXO and
-checkpoint tapscripts). Provides deterministic script builders and witness
-construction for taproot spending paths.
+**Removed.** This package previously provided low-level Bitcoin script
+construction helpers for standard Ark outputs (VTXO and checkpoint
+tapscripts). All functionality has been migrated to `lib/arkscript`, which
+provides a policy-based tapscript compiler with the same canonical output.
 
-## Key Types
-
-- `VTXOLeafType` — Enum identifying VTXO tapscript tree leaves:
-  `VTXOCollabPathLeaf` (index 0) and `VTXOTimeoutPathLeaf` (index 1).
-- `VTXOSpendData` — Witness script + control block needed to spend a VTXO via
-  collab or timeout path.
-
-## Key Functions
-
-- `VTXOTapScript` / `VTXOTapKey` — Full VTXO tapscript and taproot output key
-  construction.
-- `NewVTXOSpendInfo` / `VTXOSignDesc` — Derive spend info and sign descriptors
-  for any leaf path.
-- `VTXOTimeoutSpendWitness` / `VTXOCollabSpendWitness` — Construct witnesses
-  for the two VTXO spending paths.
-- `CheckpointOORScript` — Checkpoint script helpers for OOR transactions.
-- `AnchorPkScript` — Standardized P2A zero-value output for CPFP fee bumping.
-
-## Relationships
-
-- **Depends on**: (no internal repo imports; pure script library).
-- **Depended on by**: `darepod`, `db`, `lib/tx/*`, `round`, `vtxo`, `wallet`,
-  `walletcore`.
-
-## Invariants
-
-- VTXO tree structure is immutable: NUMS key path (unspendable), collab leaf
-  (index 0, owner CHECKSIGVERIFY + cosigner CHECKSIG), timeout leaf (index 1,
-  owner CHECKSIG + CSV delay + DROP).
-- Collab spend requires both owner and cosigner signatures. Timeout spend
-  requires owner signature only (after CSV delay).
-- Witness stack ordering: collab = [cosigner_sig, owner_sig, script,
-  control_block]; timeout = [owner_sig, script, control_block].
-- ARK NUMS key is unspendable (no known discrete log); key path is never
-  usable.
+See `lib/arkscript` for `VTXOPolicy`, `CheckpointPolicy`, `SpendInfo`,
+`AnchorOutput`, and related types that replace the former contents of this
+package.
 
 ## Deep Docs
 
+- [lib/arkscript/CLAUDE.md](../arkscript/CLAUDE.md) — Replacement package.
 - [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/lib/tree/AGENTS.md
+++ b/lib/tree/AGENTS.md
@@ -21,7 +21,7 @@ descriptors through branch nodes to the batch output.
 
 ## Relationships
 
-- **Depends on**: `lib/scripts` (taproot script construction, `VTXOSpendData`).
+- **Depends on**: `lib/arkscript` (taproot script construction, policy templates, `SpendInfo`).
 - **Depended on by**: `round` (tree construction/validation), `vtxo` (tree paths in `Descriptor`), `oor` (tree references), `db` (tree serialization), `lib/tx` (forfeit construction).
 
 ## Invariants

--- a/lib/tree/CLAUDE.md
+++ b/lib/tree/CLAUDE.md
@@ -21,7 +21,7 @@ descriptors through branch nodes to the batch output.
 
 ## Relationships
 
-- **Depends on**: `lib/scripts` (taproot script construction, `VTXOSpendData`).
+- **Depends on**: `lib/arkscript` (taproot script construction, policy templates, `SpendInfo`).
 - **Depended on by**: `round` (tree construction/validation), `vtxo` (tree paths in `Descriptor`), `oor` (tree references), `db` (tree serialization), `lib/tx` (forfeit construction).
 
 ## Invariants

--- a/lib/tx/AGENTS.md
+++ b/lib/tx/AGENTS.md
@@ -9,6 +9,8 @@ handle specific transaction types (Ark batch, checkpoint, OOR, PSBT utilities).
 ## Key Types
 
 - `BuildForfeitTx` — Constructs a forfeit transaction spending a VTXO via the collaborative tapscript path to a connector output.
+- `BuildForfeitTxWithContext` — Policy-aware forfeit construction using `ForfeitTxContext` to supply tapscript leaves and witness material derived from `lib/arkscript`.
+- `ForfeitTxContext` — Per-VTXO context carrying the owner-leaf policy script and spend witness data needed for policy-backed forfeit transactions.
 - `ValidateForfeitTx` — Validates a forfeit transaction structure and amounts.
 - `VTXOSpendContext` — Contextual data for spending a VTXO (outpoint, amount, tapscript, internal key).
 - `ConnectorSpendContext` — Contextual data for the connector input in a forfeit transaction.
@@ -25,7 +27,7 @@ handle specific transaction types (Ark batch, checkpoint, OOR, PSBT utilities).
 
 ## Relationships
 
-- **Depends on**: `lib/scripts` (taproot script construction), `lib/tree` (tree types).
+- **Depends on**: `lib/arkscript` (taproot script construction, policy types), `lib/tree` (tree types).
 - **Depended on by**: `round` (forfeit construction/validation), `oor` (checkpoint/Ark signing), `vtxo` (forfeit signing).
 
 ## Invariants

--- a/lib/tx/CLAUDE.md
+++ b/lib/tx/CLAUDE.md
@@ -9,6 +9,8 @@ handle specific transaction types (Ark batch, checkpoint, OOR, PSBT utilities).
 ## Key Types
 
 - `BuildForfeitTx` — Constructs a forfeit transaction spending a VTXO via the collaborative tapscript path to a connector output.
+- `BuildForfeitTxWithContext` — Policy-aware forfeit construction using `ForfeitTxContext` to supply tapscript leaves and witness material derived from `lib/arkscript`.
+- `ForfeitTxContext` — Per-VTXO context carrying the owner-leaf policy script and spend witness data needed for policy-backed forfeit transactions.
 - `ValidateForfeitTx` — Validates a forfeit transaction structure and amounts.
 - `VTXOSpendContext` — Contextual data for spending a VTXO (outpoint, amount, tapscript, internal key).
 - `ConnectorSpendContext` — Contextual data for the connector input in a forfeit transaction.
@@ -25,7 +27,7 @@ handle specific transaction types (Ark batch, checkpoint, OOR, PSBT utilities).
 
 ## Relationships
 
-- **Depends on**: `lib/scripts` (taproot script construction), `lib/tree` (tree types).
+- **Depends on**: `lib/arkscript` (taproot script construction, policy types), `lib/tree` (tree types).
 - **Depended on by**: `round` (forfeit construction/validation), `oor` (checkpoint/Ark signing), `vtxo` (forfeit signing).
 
 ## Invariants

--- a/lib/tx/arktx/AGENTS.md
+++ b/lib/tx/arktx/AGENTS.md
@@ -22,7 +22,7 @@ construction).
 
 ## Relationships
 
-- **Depends on**: `lib/scripts` (for `AnchorPkScript`).
+- **Depends on**: `lib/arkscript` (for `AnchorPkScript`).
 - **Depended on by**: `lib/tx/checkpoint`, `lib/tx/oor`, `oor`.
 
 ## Invariants

--- a/lib/tx/arktx/CLAUDE.md
+++ b/lib/tx/arktx/CLAUDE.md
@@ -22,7 +22,7 @@ construction).
 
 ## Relationships
 
-- **Depends on**: `lib/scripts` (for `AnchorPkScript`).
+- **Depends on**: `lib/arkscript` (for `AnchorPkScript`).
 - **Depended on by**: `lib/tx/checkpoint`, `lib/tx/oor`, `oor`.
 
 ## Invariants

--- a/lib/tx/checkpoint/AGENTS.md
+++ b/lib/tx/checkpoint/AGENTS.md
@@ -25,7 +25,7 @@ transfers.
 
 ## Relationships
 
-- **Depends on**: `lib/scripts` (CheckpointPolicy, CheckpointTapScript),
+- **Depends on**: `lib/arkscript` (CheckpointPolicy, CheckpointTapScript),
   `lib/tx/arktx` (TxVersion, validation).
 - **Depended on by**: `lib/tx/oor`, `oor`.
 

--- a/lib/tx/checkpoint/CLAUDE.md
+++ b/lib/tx/checkpoint/CLAUDE.md
@@ -25,7 +25,7 @@ transfers.
 
 ## Relationships
 
-- **Depends on**: `lib/scripts` (CheckpointPolicy, CheckpointTapScript),
+- **Depends on**: `lib/arkscript` (CheckpointPolicy, CheckpointTapScript),
   `lib/tx/arktx` (TxVersion, validation).
 - **Depended on by**: `lib/tx/oor`, `oor`.
 

--- a/lib/tx/oor/AGENTS.md
+++ b/lib/tx/oor/AGENTS.md
@@ -31,7 +31,7 @@ finalize packages.
 
 ## Relationships
 
-- **Depends on**: `lib/scripts`, `lib/tx/arktx` (validation, TxVersion),
+- **Depends on**: `lib/arkscript` (policy types, spend helpers), `lib/tx/arktx` (validation, TxVersion),
   `lib/tx/checkpoint` (BuildPSBT), `lib/tx/psbtutil` (Serialize/Parse).
 - **Depended on by**: `oor` (session state machine), `db` (artifact store),
   `rpc/oorpb`, `darepod` (RPC server).

--- a/lib/tx/oor/CLAUDE.md
+++ b/lib/tx/oor/CLAUDE.md
@@ -31,7 +31,7 @@ finalize packages.
 
 ## Relationships
 
-- **Depends on**: `lib/scripts`, `lib/tx/arktx` (validation, TxVersion),
+- **Depends on**: `lib/arkscript` (policy types, spend helpers), `lib/tx/arktx` (validation, TxVersion),
   `lib/tx/checkpoint` (BuildPSBT), `lib/tx/psbtutil` (Serialize/Parse).
 - **Depended on by**: `oor` (session state machine), `db` (artifact store),
   `rpc/oorpb`, `darepod` (RPC server).

--- a/lib/tx/psbtutil/AGENTS.md
+++ b/lib/tx/psbtutil/AGENTS.md
@@ -17,7 +17,7 @@ transaction semantics — callers run appropriate protocol validators.
 
 ## Relationships
 
-- **Depends on**: `lib/scripts` (VTXOSpendData for taproot helpers).
+- **Depends on**: `lib/arkscript` (`SpendInfo` for taproot helpers).
 - **Depended on by**: `lib/tx/oor` (package marshaling), `oor` (signing flow),
   `db` (persistence layers).
 

--- a/lib/tx/psbtutil/CLAUDE.md
+++ b/lib/tx/psbtutil/CLAUDE.md
@@ -17,7 +17,7 @@ transaction semantics — callers run appropriate protocol validators.
 
 ## Relationships
 
-- **Depends on**: `lib/scripts` (VTXOSpendData for taproot helpers).
+- **Depends on**: `lib/arkscript` (`SpendInfo` for taproot helpers).
 - **Depended on by**: `lib/tx/oor` (package marshaling), `oor` (signing flow),
   `db` (persistence layers).
 

--- a/lib/types/AGENTS.md
+++ b/lib/types/AGENTS.md
@@ -21,10 +21,13 @@ server during round participation. These types are used across `round`, `vtxo`,
 - `BoardingInputSignature` — Signed boarding input for round commitment.
 - `ForfeitTxSig` — Forfeit transaction signature.
 - `OORPackageDirection` / `OORPackageLinkKind` — Enums for OOR package direction and link types.
+- `VTXORequest.EffectivePolicyTemplate` / `DecodePolicyTemplate` / `DecodeStandardPolicyTemplate` / `EffectivePkScript` — Policy helpers that decode the serialized `PolicyTemplate` field into an `arkscript.PolicyTemplate` and derive the output pkScript.
+- `BoardingRequest.EffectivePolicyTemplate` / `DecodePolicyTemplate` / `DecodeStandardPolicyTemplate` — Equivalent policy helpers for boarding inputs.
+- `VTXORequest.HasLocalOwner` — Reports whether the VTXO request has a locally-owned key (non-zero `KeyLocator`).
 
 ## Relationships
 
-- **Depends on**: `lib/scripts` (taproot script types), `lib/tree` (tree types).
+- **Depends on**: `lib/arkscript` (policy template decoding, `StandardVTXOParams`), `lib/tree` (tree types).
 - **Depended on by**: `round` (round protocol messages), `wallet` (boarding types), `db` (persistence), `rpc` (proto conversion).
 
 ## Invariants

--- a/lib/types/CLAUDE.md
+++ b/lib/types/CLAUDE.md
@@ -21,10 +21,13 @@ server during round participation. These types are used across `round`, `vtxo`,
 - `BoardingInputSignature` — Signed boarding input for round commitment.
 - `ForfeitTxSig` — Forfeit transaction signature.
 - `OORPackageDirection` / `OORPackageLinkKind` — Enums for OOR package direction and link types.
+- `VTXORequest.EffectivePolicyTemplate` / `DecodePolicyTemplate` / `DecodeStandardPolicyTemplate` / `EffectivePkScript` — Policy helpers that decode the serialized `PolicyTemplate` field into an `arkscript.PolicyTemplate` and derive the output pkScript.
+- `BoardingRequest.EffectivePolicyTemplate` / `DecodePolicyTemplate` / `DecodeStandardPolicyTemplate` — Equivalent policy helpers for boarding inputs.
+- `VTXORequest.HasLocalOwner` — Reports whether the VTXO request has a locally-owned key (non-zero `KeyLocator`).
 
 ## Relationships
 
-- **Depends on**: `lib/scripts` (taproot script types), `lib/tree` (tree types).
+- **Depends on**: `lib/arkscript` (policy template decoding, `StandardVTXOParams`), `lib/tree` (tree types).
 - **Depended on by**: `round` (round protocol messages), `wallet` (boarding types), `db` (persistence), `rpc` (proto conversion).
 
 ## Invariants

--- a/oor/AGENTS.md
+++ b/oor/AGENTS.md
@@ -93,7 +93,7 @@ resume semantics.
 
 ## Relationships
 
-- **Depends on**: `baselib/protofsm` (FSM engine), `baselib/actor` (durable actors), `serverconn` (durable transport).
+- **Depends on**: `baselib/protofsm` (FSM engine), `baselib/actor` (durable actors), `serverconn` (durable transport), `lib/arkscript` (policy-backed tapscript for checkpoint signing and VTXO policy templates in transfer TLV records).
 - **Depended on by**: `darepod` (wiring).
 - **Sends**:
   - → `serverconn`: `SendSubmitPackageRequest`, `SendFinalizePackageRequest`, `SendIncomingAckRequest`

--- a/oor/CLAUDE.md
+++ b/oor/CLAUDE.md
@@ -93,7 +93,7 @@ resume semantics.
 
 ## Relationships
 
-- **Depends on**: `baselib/protofsm` (FSM engine), `baselib/actor` (durable actors), `serverconn` (durable transport).
+- **Depends on**: `baselib/protofsm` (FSM engine), `baselib/actor` (durable actors), `serverconn` (durable transport), `lib/arkscript` (policy-backed tapscript for checkpoint signing and VTXO policy templates in transfer TLV records).
 - **Depended on by**: `darepod` (wiring).
 - **Sends**:
   - → `serverconn`: `SendSubmitPackageRequest`, `SendFinalizePackageRequest`, `SendIncomingAckRequest`

--- a/round/AGENTS.md
+++ b/round/AGENTS.md
@@ -27,7 +27,7 @@ protocols with MuSig2 signing ceremonies.
 
 ## Relationships
 
-- **Depends on**: `baselib/protofsm` (FSM engine), `lib/tree` (Merkle trees), `lib/types` (shared domain types), `lib/scripts` (taproot scripts), `wallet` (types: `BoardingAddress`, `BoardingIntent`, `SelectedVTXO`).
+- **Depends on**: `baselib/protofsm` (FSM engine), `lib/tree` (Merkle trees), `lib/types` (shared domain types), `lib/arkscript` (policy-backed tapscript construction), `wallet` (types: `BoardingAddress`, `BoardingIntent`, `SelectedVTXO`).
 - **Depended on by**: `vtxo` (forfeit coordination), `db` (round persistence), `darepod` (wiring, owned-script adapters).
 - **Sends**:
   - → `serverconn`: `JoinRoundRequest`, `SubmitNoncesRequest`, `SubmitPartialSigRequest`, `SubmitVTXOForfeitSigsToServer`

--- a/round/CLAUDE.md
+++ b/round/CLAUDE.md
@@ -27,7 +27,7 @@ protocols with MuSig2 signing ceremonies.
 
 ## Relationships
 
-- **Depends on**: `baselib/protofsm` (FSM engine), `lib/tree` (Merkle trees), `lib/types` (shared domain types), `lib/scripts` (taproot scripts), `wallet` (types: `BoardingAddress`, `BoardingIntent`, `SelectedVTXO`).
+- **Depends on**: `baselib/protofsm` (FSM engine), `lib/tree` (Merkle trees), `lib/types` (shared domain types), `lib/arkscript` (policy-backed tapscript construction), `wallet` (types: `BoardingAddress`, `BoardingIntent`, `SelectedVTXO`).
 - **Depended on by**: `vtxo` (forfeit coordination), `db` (round persistence), `darepod` (wiring, owned-script adapters).
 - **Sends**:
   - → `serverconn`: `JoinRoundRequest`, `SubmitNoncesRequest`, `SubmitPartialSigRequest`, `SubmitVTXOForfeitSigsToServer`

--- a/vtxo/AGENTS.md
+++ b/vtxo/AGENTS.md
@@ -22,7 +22,7 @@ when the local wallet owns the receive script.
 - `FilterOptions` / `FilterDescriptors` — VTXO filtering by expiry status, spend state, etc.
 - `GetActiveVTXOCountRequest` / `GetActiveVTXOCountResponse` — Ask-message for querying active VTXO count from the manager.
 - `ManagerMsg` / `ManagerResp` — Type aliases for `actormsg.VTXOManagerMsg` / `actormsg.VTXOManagerResp` (admission types live in `lib/actormsg` to avoid import cycles).
-- `IncomingVTXOHandler` — Actor that consumes `arkrpc.IncomingVTXOEvent` push notifications, looks up the receive script in the owned-script store, builds a `Descriptor` (with tapscript derived via `lib/scripts.VTXOTapScript`), persists it via `VTXOSaver`, and tells the manager via `VTXOsMaterializedNotification`. Only `VTXO_EVENT_TYPE_CREATED` events are acted on; unknown event kinds and unowned scripts are silently ignored. Inputs are validated for outpoint shape, pkScript presence, and `int64`/`MaxSatoshi` value bounds before any DB write.
+- `IncomingVTXOHandler` — Actor that consumes `arkrpc.IncomingVTXOEvent` push notifications, looks up the receive script in the owned-script store, builds a `Descriptor` (with tapscript derived via `lib/arkscript`), persists it via `VTXOSaver`, and tells the manager via `VTXOsMaterializedNotification`. Only `VTXO_EVENT_TYPE_CREATED` events are acted on; unknown event kinds and unowned scripts are silently ignored. Inputs are validated for outpoint shape, pkScript presence, and `int64`/`MaxSatoshi` value bounds before any DB write.
 - `IncomingVTXOMsg` / `IncomingVTXOResp` — Actor envelope wrapping an `arkrpc.IncomingVTXOEvent` and the `any`-typed response.
 - `IncomingVTXOServiceKey` — Well-known service key (`"incoming-vtxo-handler"`) used by `darepod` to register the actor and by `serverconn.EventRouter` to dispatch routed events.
 - `OwnedReceiveScript` / `OwnedScriptLookup` — Read-only view of the owned receive scripts store used by the incoming handler. `LookupOwnedReceiveScript` returns `sql.ErrNoRows` for unknown scripts; the handler treats this as "not ours" and exits cleanly.
@@ -31,7 +31,7 @@ when the local wallet owns the receive script.
 
 ## Relationships
 
-- **Depends on**: `baselib/protofsm` (FSM engine), `baselib/actor` (actor system), `lib/tree` (tree paths), `lib/scripts` (taproot construction in `IncomingVTXOHandler`), `lib/actormsg` (admission message types), `arkrpc` (`IncomingVTXOEvent`), `chainsource` (block epochs).
+- **Depends on**: `baselib/protofsm` (FSM engine), `baselib/actor` (actor system), `lib/tree` (tree paths), `lib/arkscript` (taproot construction and policy helpers in `IncomingVTXOHandler`), `lib/actormsg` (admission message types), `arkrpc` (`IncomingVTXOEvent`), `chainsource` (block epochs).
 - **Depended on by**: `round` (triggers forfeit requests), `oor` (incoming VTXOs), `wallet` (admission gating), `db` (persistence), `darepod` (wiring, owned-script adapters, incoming event route).
 - **Sends**:
   - → `round` (via manager relay): `RelayToRoundMsg` wrapping `ForfeitSignatureSubmission`

--- a/vtxo/CLAUDE.md
+++ b/vtxo/CLAUDE.md
@@ -22,7 +22,7 @@ when the local wallet owns the receive script.
 - `FilterOptions` / `FilterDescriptors` — VTXO filtering by expiry status, spend state, etc.
 - `GetActiveVTXOCountRequest` / `GetActiveVTXOCountResponse` — Ask-message for querying active VTXO count from the manager.
 - `ManagerMsg` / `ManagerResp` — Type aliases for `actormsg.VTXOManagerMsg` / `actormsg.VTXOManagerResp` (admission types live in `lib/actormsg` to avoid import cycles).
-- `IncomingVTXOHandler` — Actor that consumes `arkrpc.IncomingVTXOEvent` push notifications, looks up the receive script in the owned-script store, builds a `Descriptor` (with tapscript derived via `lib/scripts.VTXOTapScript`), persists it via `VTXOSaver`, and tells the manager via `VTXOsMaterializedNotification`. Only `VTXO_EVENT_TYPE_CREATED` events are acted on; unknown event kinds and unowned scripts are silently ignored. Inputs are validated for outpoint shape, pkScript presence, and `int64`/`MaxSatoshi` value bounds before any DB write.
+- `IncomingVTXOHandler` — Actor that consumes `arkrpc.IncomingVTXOEvent` push notifications, looks up the receive script in the owned-script store, builds a `Descriptor` (with tapscript derived via `lib/arkscript`), persists it via `VTXOSaver`, and tells the manager via `VTXOsMaterializedNotification`. Only `VTXO_EVENT_TYPE_CREATED` events are acted on; unknown event kinds and unowned scripts are silently ignored. Inputs are validated for outpoint shape, pkScript presence, and `int64`/`MaxSatoshi` value bounds before any DB write.
 - `IncomingVTXOMsg` / `IncomingVTXOResp` — Actor envelope wrapping an `arkrpc.IncomingVTXOEvent` and the `any`-typed response.
 - `IncomingVTXOServiceKey` — Well-known service key (`"incoming-vtxo-handler"`) used by `darepod` to register the actor and by `serverconn.EventRouter` to dispatch routed events.
 - `OwnedReceiveScript` / `OwnedScriptLookup` — Read-only view of the owned receive scripts store used by the incoming handler. `LookupOwnedReceiveScript` returns `sql.ErrNoRows` for unknown scripts; the handler treats this as "not ours" and exits cleanly.
@@ -31,7 +31,7 @@ when the local wallet owns the receive script.
 
 ## Relationships
 
-- **Depends on**: `baselib/protofsm` (FSM engine), `baselib/actor` (actor system), `lib/tree` (tree paths), `lib/scripts` (taproot construction in `IncomingVTXOHandler`), `lib/actormsg` (admission message types), `arkrpc` (`IncomingVTXOEvent`), `chainsource` (block epochs).
+- **Depends on**: `baselib/protofsm` (FSM engine), `baselib/actor` (actor system), `lib/tree` (tree paths), `lib/arkscript` (taproot construction and policy helpers in `IncomingVTXOHandler`), `lib/actormsg` (admission message types), `arkrpc` (`IncomingVTXOEvent`), `chainsource` (block epochs).
 - **Depended on by**: `round` (triggers forfeit requests), `oor` (incoming VTXOs), `wallet` (admission gating), `db` (persistence), `darepod` (wiring, owned-script adapters, incoming event route).
 - **Sends**:
   - → `round` (via manager relay): `RelayToRoundMsg` wrapping `ForfeitSignatureSubmission`

--- a/wallet/AGENTS.md
+++ b/wallet/AGENTS.md
@@ -28,6 +28,8 @@ refresh, leave, OOR spend, and directed send flows.
 - `UnlockVTXOsRequest` — Tell-message to release locked VTXOs on failure.
 - `SendRecipient` — Describes a single directed send destination (pkscript, amount, recipient client key).
 - `SendVTXOsRequest` / `SendVTXOsResponse` — Ask-request for in-round directed sends. Validates each recipient amount is within `(0, MaxSatoshi]` and that the running total never overflows `int64`, atomically selects and reserves VTXOs via `SelectAndReserveForfeitRequest`, builds forfeit + recipient VTXO intents, and registers with the round actor. Supports dry-run mode for previewing coin selection without committing. Reserved VTXOs are released via a deferred cleanup that uses `context.WithoutCancel` so cleanup survives caller disconnect; on success, a `committed` flag is set to skip the release.
+- `GetConfirmedBoardingIntentsRequest` / `GetConfirmedBoardingIntentsResponse` — Ask-request to retrieve currently confirmed boarding intents (used by the RPC/CLI layer to report boarding balance with policy metadata).
+- `VTXODescriptor.EffectivePolicyTemplate` — Decodes the serialized `PolicyTemplate` field on the wallet-level VTXO descriptor using `lib/arkscript`.
 
 ## Relationships
 
@@ -40,7 +42,7 @@ refresh, leave, OOR spend, and directed send flows.
 - **Receives**:
   - ← `chainsource`: `BlockEpochNotification` (triggers UTXO polling)
   - ← `round`: `RegisterConfirmationNotifierRequest`, `UnregisterConfirmationNotifierRequest`
-  - ← API: `CreateBoardingAddressRequest`, `GetActiveBoardingAddressesRequest`, `GetBoardingBalanceRequest`, `RefreshVTXOsRequest`, `SelectAndLockVTXOsRequest`, `LeaveVTXOsRequest`, `BoardRequest`, `CompleteSpendVTXOsRequest`, `UnlockVTXOsRequest`, `SendVTXOsRequest`
+  - ← API: `CreateBoardingAddressRequest`, `GetActiveBoardingAddressesRequest`, `GetBoardingBalanceRequest`, `GetConfirmedBoardingIntentsRequest`, `RefreshVTXOsRequest`, `SelectAndLockVTXOsRequest`, `LeaveVTXOsRequest`, `BoardRequest`, `CompleteSpendVTXOsRequest`, `UnlockVTXOsRequest`, `SendVTXOsRequest`
 
 ## Invariants
 

--- a/wallet/CLAUDE.md
+++ b/wallet/CLAUDE.md
@@ -28,6 +28,8 @@ refresh, leave, OOR spend, and directed send flows.
 - `UnlockVTXOsRequest` — Tell-message to release locked VTXOs on failure.
 - `SendRecipient` — Describes a single directed send destination (pkscript, amount, recipient client key).
 - `SendVTXOsRequest` / `SendVTXOsResponse` — Ask-request for in-round directed sends. Validates each recipient amount is within `(0, MaxSatoshi]` and that the running total never overflows `int64`, atomically selects and reserves VTXOs via `SelectAndReserveForfeitRequest`, builds forfeit + recipient VTXO intents, and registers with the round actor. Supports dry-run mode for previewing coin selection without committing. Reserved VTXOs are released via a deferred cleanup that uses `context.WithoutCancel` so cleanup survives caller disconnect; on success, a `committed` flag is set to skip the release.
+- `GetConfirmedBoardingIntentsRequest` / `GetConfirmedBoardingIntentsResponse` — Ask-request to retrieve currently confirmed boarding intents (used by the RPC/CLI layer to report boarding balance with policy metadata).
+- `VTXODescriptor.EffectivePolicyTemplate` — Decodes the serialized `PolicyTemplate` field on the wallet-level VTXO descriptor using `lib/arkscript`.
 
 ## Relationships
 
@@ -40,7 +42,7 @@ refresh, leave, OOR spend, and directed send flows.
 - **Receives**:
   - ← `chainsource`: `BlockEpochNotification` (triggers UTXO polling)
   - ← `round`: `RegisterConfirmationNotifierRequest`, `UnregisterConfirmationNotifierRequest`
-  - ← API: `CreateBoardingAddressRequest`, `GetActiveBoardingAddressesRequest`, `GetBoardingBalanceRequest`, `RefreshVTXOsRequest`, `SelectAndLockVTXOsRequest`, `LeaveVTXOsRequest`, `BoardRequest`, `CompleteSpendVTXOsRequest`, `UnlockVTXOsRequest`, `SendVTXOsRequest`
+  - ← API: `CreateBoardingAddressRequest`, `GetActiveBoardingAddressesRequest`, `GetBoardingBalanceRequest`, `GetConfirmedBoardingIntentsRequest`, `RefreshVTXOsRequest`, `SelectAndLockVTXOsRequest`, `LeaveVTXOsRequest`, `BoardRequest`, `CompleteSpendVTXOsRequest`, `UnlockVTXOsRequest`, `SendVTXOsRequest`
 
 ## Invariants
 


### PR DESCRIPTION
Automated nightly documentation sweep updating per-package CLAUDE.md/AGENTS.md
and ARCHITECTURE.md to reflect code changes merged since the last sweep.

## Summary

- **lib/scripts removal**: All `Depends on: lib/scripts` references updated to
  `lib/arkscript` across `lib/tree`, `lib/tx/*`, `lib/types`, `round`, `vtxo`,
  `oor`. `lib/scripts/CLAUDE.md` updated to reflect the package was removed and
  redirects to `lib/arkscript`.
- **ARCHITECTURE.md**: Removed `lib/scripts` row from Layer 1; updated `lib`
  row purpose and dependency flow diagram.
- **lib/arkscript**: Documented new types: `StandardVTXOParams`, `SpendPath`,
  `ComposedPolicy`, `AnchorOutput`, `EncodedLeaf`/`EncodeTapTree`/`DecodeTapTree`,
  `CheckpointPolicy` helpers; updated `Depended-on-by` list.
- **baselib/actor**: Documented `Wait`, `StopAndWait`, `WithoutOutboxID`.
- **lib/types**: Documented new policy helpers (`EffectivePolicyTemplate`,
  `DecodePolicyTemplate`, `DecodeStandardPolicyTemplate`, `EffectivePkScript`,
  `HasLocalOwner`) on `VTXORequest` and `BoardingRequest`.
- **lib/tx**: Documented `ForfeitTxContext` and `BuildForfeitTxWithContext`.
- **oor**: Added `lib/arkscript` to `Depends-on`.
- **indexer**: Documented taproot-scoped proof methods.
- **wallet**: Documented `GetConfirmedBoardingIntentsRequest/Response` and
  `VTXODescriptor.EffectivePolicyTemplate`.
- **darepod**: Documented `IndexerProofKey` server method.
- **cmd/darepocli/darepoclicommands**: Added `oor receive` command to the
  commands table.

## Review notes

Please check the updated `CLAUDE.md`/`AGENTS.md` diffs in:
- `lib/arkscript/`, `lib/scripts/`, `lib/tx/`, `lib/types/`, `lib/tree/`
- `round/`, `vtxo/`, `oor/`, `wallet/`, `indexer/`, `darepod/`
- `baselib/actor/`, `cmd/darepocli/darepoclicommands/`
- `ARCHITECTURE.md`

`make doc-check` passes on this branch.