### PR TITLE
docs: nightly doc-gardening sweep 2026-04-15

### DIFF
--- a/darepod/AGENTS.md
+++ b/darepod/AGENTS.md
@@ -9,7 +9,7 @@ gRPC API.
 ## Key Types
 
 - `Server` — Main daemon owning wallet, DB, chainsource actor, gRPC server, and ActorSystem. Caches `localMailboxID` (pubkey-derived), `authSigHex` (Schnorr auth) and a single `clk` (`clock.Clock`) that all sub-stores share for deterministic time injection.
-- `RPCServer` — Implements the gRPC `DaemonService` API (Board, ListRounds, WatchRounds, NewOORReceiveScript, SendVTXO, etc.). Includes test hooks for mailbox edge factory and round registration.
+- `RPCServer` — Implements the gRPC `DaemonService` API (Board, ListRounds, WatchRounds, NewOORReceiveScript, SendVTXO, etc.). Includes test hooks for mailbox edge factory and round registration. Holds an in-memory `customInputLocks` map (guarded by `customInputLocksMu`) that reserves custom OOR input outpoints for the duration of a `SendOOR` call to prevent concurrent callers from double-signing the same custom input.
 - `Config` — Daemon configuration (data dir, network, RPC host, wallet type, etc.). Includes `MailboxEdgeFactory` hook for test harness transport interception.
 - `TriggerRoundRegistration` — Test-hook method that injects a round registration event into the round actor (in `server_round_testhook.go`).
 - `GetStoredVTXO` — Harness-only accessor that returns a persisted `vtxo.Descriptor` for a given outpoint directly from the daemon's VTXO store. Lets integration tests inspect partial unroll state without reaching into internal fields.
@@ -29,6 +29,7 @@ gRPC API.
 - `deriveIdentityKeyEarly` — Derives the client's secp256k1 identity key from LND or lwwallet before mailbox transport starts. Propagates wallet-specific errors on failure.
 - `signMailboxAuth` — Produces Schnorr auth signature. LND path uses tagged Schnorr signing RPC (`withSchnorrTag`); lwwallet path signs locally via `serverconn.SignMailboxAuth`.
 - `fetchOperatorPubKeyDirect` — Fetches operator pubkey via direct gRPC `GetInfo` call before the mailbox runtime starts.
+- `reserveCustomInputs` (on `RPCServer`) — Atomically claims every custom OOR outpoint for the duration of a `SendOOR` call. Rejects if any outpoint is already reserved. Returns a release function (typically deferred) that frees all claimed outpoints. Prevents two concurrent `SendOOR` callers from double-signing the same vHTLC claim or other non-wallet-managed input.
 
 ## Relationships
 
@@ -47,6 +48,8 @@ gRPC API.
 - All sub-stores share the single `s.clk` clock instance assigned at `NewServer`. New code must not call `clock.NewDefaultClock()` inside `init*` methods — use `s.clk` so tests can inject deterministic time.
 - Board RPC is non-blocking: delegates to wallet actor and returns immediately.
 - `SendVTXO` enforces a hard recipient cap (`maxRecipients = 256`, see TODO #241), rejects per-recipient amounts outside `(0, MaxSatoshi]`, and uses overflow-safe accumulation when summing recipient amounts. Wallet-side validation (`handleSendVTXOs`) repeats these checks as a defense-in-depth boundary.
+- `SendOOR` with custom inputs uses `reserveCustomInputs` to serialize concurrent calls on the same outpoints. Custom inputs are locked for the RPC lifetime; the lock is released via deferred release on both success and failure paths. Standard wallet-managed VTXOs are separately locked via the VTXO manager's reservation flow.
+- `BuildCustomTransferInputs` validates that (a) the caller-supplied policy template compiles to the provided pkScript (via `PolicyTemplate.MatchesPkScript`), and (b) the spend path's control block commits to the same pkScript (via `SpendPath.VerifyBindsToPkScript`). Together these prevent a caller from obtaining signatures for an unrelated tapscript by claiming a different output's policy template.
 - ListRounds splits pending (in-memory from actor) and persisted (SQL with cursor pagination) rounds.
 - Server holds a `roundStore` reference for direct SQL queries from the RPC layer.
 - Actor startup order: VTXO manager starts before round actor and OOR actor, so the manager ref is available for both. The round actor ref in the VTXO manager is lazy (service-key-based, resolved at Tell time).

--- a/darepod/CLAUDE.md
+++ b/darepod/CLAUDE.md
@@ -9,7 +9,7 @@ gRPC API.
 ## Key Types
 
 - `Server` — Main daemon owning wallet, DB, chainsource actor, gRPC server, and ActorSystem. Caches `localMailboxID` (pubkey-derived), `authSigHex` (Schnorr auth) and a single `clk` (`clock.Clock`) that all sub-stores share for deterministic time injection.
-- `RPCServer` — Implements the gRPC `DaemonService` API (Board, ListRounds, WatchRounds, NewOORReceiveScript, SendVTXO, etc.). Includes test hooks for mailbox edge factory and round registration.
+- `RPCServer` — Implements the gRPC `DaemonService` API (Board, ListRounds, WatchRounds, NewOORReceiveScript, SendVTXO, etc.). Includes test hooks for mailbox edge factory and round registration. Holds an in-memory `customInputLocks` map (guarded by `customInputLocksMu`) that reserves custom OOR input outpoints for the duration of a `SendOOR` call to prevent concurrent callers from double-signing the same custom input.
 - `Config` — Daemon configuration (data dir, network, RPC host, wallet type, etc.). Includes `MailboxEdgeFactory` hook for test harness transport interception.
 - `TriggerRoundRegistration` — Test-hook method that injects a round registration event into the round actor (in `server_round_testhook.go`).
 - `GetStoredVTXO` — Harness-only accessor that returns a persisted `vtxo.Descriptor` for a given outpoint directly from the daemon's VTXO store. Lets integration tests inspect partial unroll state without reaching into internal fields.
@@ -29,6 +29,7 @@ gRPC API.
 - `deriveIdentityKeyEarly` — Derives the client's secp256k1 identity key from LND or lwwallet before mailbox transport starts. Propagates wallet-specific errors on failure.
 - `signMailboxAuth` — Produces Schnorr auth signature. LND path uses tagged Schnorr signing RPC (`withSchnorrTag`); lwwallet path signs locally via `serverconn.SignMailboxAuth`.
 - `fetchOperatorPubKeyDirect` — Fetches operator pubkey via direct gRPC `GetInfo` call before the mailbox runtime starts.
+- `reserveCustomInputs` (on `RPCServer`) — Atomically claims every custom OOR outpoint for the duration of a `SendOOR` call. Rejects if any outpoint is already reserved. Returns a release function (typically deferred) that frees all claimed outpoints. Prevents two concurrent `SendOOR` callers from double-signing the same vHTLC claim or other non-wallet-managed input.
 
 ## Relationships
 
@@ -47,6 +48,8 @@ gRPC API.
 - All sub-stores share the single `s.clk` clock instance assigned at `NewServer`. New code must not call `clock.NewDefaultClock()` inside `init*` methods — use `s.clk` so tests can inject deterministic time.
 - Board RPC is non-blocking: delegates to wallet actor and returns immediately.
 - `SendVTXO` enforces a hard recipient cap (`maxRecipients = 256`, see TODO #241), rejects per-recipient amounts outside `(0, MaxSatoshi]`, and uses overflow-safe accumulation when summing recipient amounts. Wallet-side validation (`handleSendVTXOs`) repeats these checks as a defense-in-depth boundary.
+- `SendOOR` with custom inputs uses `reserveCustomInputs` to serialize concurrent calls on the same outpoints. Custom inputs are locked for the RPC lifetime; the lock is released via deferred release on both success and failure paths. Standard wallet-managed VTXOs are separately locked via the VTXO manager's reservation flow.
+- `BuildCustomTransferInputs` validates that (a) the caller-supplied policy template compiles to the provided pkScript (via `PolicyTemplate.MatchesPkScript`), and (b) the spend path's control block commits to the same pkScript (via `SpendPath.VerifyBindsToPkScript`). Together these prevent a caller from obtaining signatures for an unrelated tapscript by claiming a different output's policy template.
 - ListRounds splits pending (in-memory from actor) and persisted (SQL with cursor pagination) rounds.
 - Server holds a `roundStore` reference for direct SQL queries from the RPC layer.
 - Actor startup order: VTXO manager starts before round actor and OOR actor, so the manager ref is available for both. The round actor ref in the VTXO manager is lazy (service-key-based, resolved at Tell time).

--- a/lib/arkscript/AGENTS.md
+++ b/lib/arkscript/AGENTS.md
@@ -13,6 +13,10 @@ validated invariants.
   Implementations: `Multisig`, `CSV`, `Condition`, `Preimage`, `CLTV`.
 - `PolicyTemplate` — Semantic representation of a tapscript policy with named
   leaves. Supports encode/decode for persistence.
+  - `PolicyTemplate.MatchesPkScript(pkScript []byte) bool` — Compiles the
+    policy and checks whether it produces the given P2TR script. Used by
+    `BuildCustomTransferInputs` to bind a caller-supplied policy to the
+    on-chain output before signatures are produced.
 - `CompiledPolicy` — Fully compiled policy with canonical leaf ordering, merkle
   tree, and control block derivation.
 - `VTXOPolicy` — Compiled VTXO taproot policy with collab and exit spend paths.
@@ -22,10 +26,32 @@ validated invariants.
 - `CheckpointPolicy` — Parameters for OOR checkpoint taproot tree construction. `CheckpointTapScript` / `CheckpointPkScript` derive the checkpoint output.
 - `SpendInfo` — Witness script + control block needed to spend a specific leaf. Methods: `BuildSignDescriptor`, `CollabWitness`, `TimeoutWitness`.
 - `SpendPath` — Serializable spend path (leaf index + encoded leaf data) with `Witness` and `AttachTapLeafScript` helpers for PSBT integration.
+  - `SpendPath.VerifyBindsToPkScript(pkScript []byte) error` — Checks that the
+    spend path's witness script and control block commit to a taproot output
+    whose P2TR script exactly matches `pkScript`. Prevents a caller from
+    supplying a control block for an unrelated tap tree and obtaining a
+    signature over an attacker-chosen tapscript.
 - `StandardVTXOParams` — Decoded parameters for a standard Ark VTXO policy (owner key, operator key, CSV delay). Derived via `DecodeStandardVTXOParams`.
 - `ComposedPolicy` — Composes an existing `CompiledPolicy` with an additional sibling tap branch root, allowing sub-tree aggregation. Built with `ComposeWithSiblingRoot`.
 - `AnchorOutput` — Creates a zero-value P2A anchor transaction output for CPFP fee bumping (replaces the removed `lib/scripts.AnchorPkScript`).
 - `EncodedLeaf` / `EncodeTapTree` / `DecodeTapTree` — TLV-based tap tree serialization for PSBT sidecars compatible with `waddrmgr` format.
+- `EncodeStandardVTXOArtifacts(ownerKey, operatorKey, exitDelay)` — Convenience
+  helper returning both the encoded policy template bytes and the canonical P2TR
+  pkScript for the standard VTXO shape. Use `tree.NewVTXODescriptor` when the
+  full tree-construction descriptor is also needed.
+- `ValidateStandardVTXOPolicy(nodes, operatorKey, minExitDelay)` — Admission
+  check for standard Ark VTXO recipient policies. Wraps `ValidatePolicy` but
+  requires a non-zero `minExitDelay`, failing closed so callers must specify
+  an explicit floor rather than silently accepting any exit delay (including
+  dangerously small values that would break forfeit incentives).
+- `ValidatePolicy(nodes, opts)` — Structural admission check for any Ark policy
+  shape (custom vHTLC, etc.). Enforces: collab leaf with operator key, exit
+  leaf without operator key, no operator-unilateral leaf, CSV gating on exit
+  paths. `opts.MinExitDelay = 0` skips the CSV minimum check.
+- Decode budget constants: `MaxPolicyTemplateBytes` (64 KiB),
+  `MaxLeafTemplateBytes` (16 KiB), `MaxPolicyLeaves` (32),
+  `MaxPolicyDepth` (16), `MaxPolicyNodes` (256), `MaxMultisigKeys` (64) —
+  cap decode work to prevent amplification from untrusted blobs.
 
 ## Relationships
 
@@ -39,13 +65,27 @@ validated invariants.
 - Node interface is sealed: only types defined in this package can implement it.
 - Every collab leaf must contain the operator key for safe cosigning.
 - Every exit leaf must be CSV-gated for unilateral recovery.
+- No leaf may permit the operator to spend unilaterally: every `Multisig` node
+  containing the operator key must contain at least one non-operator key.
+  `Multisig{operator, operator}` is rejected because both signers resolve to the
+  same party.
+- CSV encoding uses `blockchain.LockTimeToSequence(false, exitDelay)` to store
+  the BIP-68 block-mode sequence value, not the raw block count. Decoders that
+  compare raw block counts against CSV lock values must convert accordingly.
 - Canonical leaf ordering: sorted by version then lexicographic script bytes.
 - All taproot outputs use the unspendable ARK NUMS key for key path (no
   key-path spend possible).
 - Policy validation enforces at least one operator-containing leaf
   (collaborative) and at least one non-operator leaf (exit/unilateral).
-- Exit delay must be >= `MinExitDelay`.
+- Exit delay must be >= `MinExitDelay` when `ValidateStandardVTXOPolicy` is
+  used; `ValidatePolicy` with `MinExitDelay = 0` skips this check.
+- Decode budget: policy template decode caps at `MaxPolicyTemplateBytes` /
+  `MaxPolicyLeaves` / `MaxPolicyDepth` / `MaxPolicyNodes`; a single budget is
+  shared across all leaves of one policy so an adversary cannot multiply work by
+  packing many max-node leaves into one blob.
 
 ## Deep Docs
 
+- [docs/arkscript_spec.md](../../docs/arkscript_spec.md) — RFC-style specification: AST grammar, encoding format, invariants, and security considerations.
+- [docs/policy_arkscript_review_guide.md](../../docs/policy_arkscript_review_guide.md) — Policy-first reviewer guide for inspecting custom policies.
 - [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/lib/arkscript/CLAUDE.md
+++ b/lib/arkscript/CLAUDE.md
@@ -13,6 +13,10 @@ validated invariants.
   Implementations: `Multisig`, `CSV`, `Condition`, `Preimage`, `CLTV`.
 - `PolicyTemplate` — Semantic representation of a tapscript policy with named
   leaves. Supports encode/decode for persistence.
+  - `PolicyTemplate.MatchesPkScript(pkScript []byte) bool` — Compiles the
+    policy and checks whether it produces the given P2TR script. Used by
+    `BuildCustomTransferInputs` to bind a caller-supplied policy to the
+    on-chain output before signatures are produced.
 - `CompiledPolicy` — Fully compiled policy with canonical leaf ordering, merkle
   tree, and control block derivation.
 - `VTXOPolicy` — Compiled VTXO taproot policy with collab and exit spend paths.
@@ -22,10 +26,32 @@ validated invariants.
 - `CheckpointPolicy` — Parameters for OOR checkpoint taproot tree construction. `CheckpointTapScript` / `CheckpointPkScript` derive the checkpoint output.
 - `SpendInfo` — Witness script + control block needed to spend a specific leaf. Methods: `BuildSignDescriptor`, `CollabWitness`, `TimeoutWitness`.
 - `SpendPath` — Serializable spend path (leaf index + encoded leaf data) with `Witness` and `AttachTapLeafScript` helpers for PSBT integration.
+  - `SpendPath.VerifyBindsToPkScript(pkScript []byte) error` — Checks that the
+    spend path's witness script and control block commit to a taproot output
+    whose P2TR script exactly matches `pkScript`. Prevents a caller from
+    supplying a control block for an unrelated tap tree and obtaining a
+    signature over an attacker-chosen tapscript.
 - `StandardVTXOParams` — Decoded parameters for a standard Ark VTXO policy (owner key, operator key, CSV delay). Derived via `DecodeStandardVTXOParams`.
 - `ComposedPolicy` — Composes an existing `CompiledPolicy` with an additional sibling tap branch root, allowing sub-tree aggregation. Built with `ComposeWithSiblingRoot`.
 - `AnchorOutput` — Creates a zero-value P2A anchor transaction output for CPFP fee bumping (replaces the removed `lib/scripts.AnchorPkScript`).
 - `EncodedLeaf` / `EncodeTapTree` / `DecodeTapTree` — TLV-based tap tree serialization for PSBT sidecars compatible with `waddrmgr` format.
+- `EncodeStandardVTXOArtifacts(ownerKey, operatorKey, exitDelay)` — Convenience
+  helper returning both the encoded policy template bytes and the canonical P2TR
+  pkScript for the standard VTXO shape. Use `tree.NewVTXODescriptor` when the
+  full tree-construction descriptor is also needed.
+- `ValidateStandardVTXOPolicy(nodes, operatorKey, minExitDelay)` — Admission
+  check for standard Ark VTXO recipient policies. Wraps `ValidatePolicy` but
+  requires a non-zero `minExitDelay`, failing closed so callers must specify
+  an explicit floor rather than silently accepting any exit delay (including
+  dangerously small values that would break forfeit incentives).
+- `ValidatePolicy(nodes, opts)` — Structural admission check for any Ark policy
+  shape (custom vHTLC, etc.). Enforces: collab leaf with operator key, exit
+  leaf without operator key, no operator-unilateral leaf, CSV gating on exit
+  paths. `opts.MinExitDelay = 0` skips the CSV minimum check.
+- Decode budget constants: `MaxPolicyTemplateBytes` (64 KiB),
+  `MaxLeafTemplateBytes` (16 KiB), `MaxPolicyLeaves` (32),
+  `MaxPolicyDepth` (16), `MaxPolicyNodes` (256), `MaxMultisigKeys` (64) —
+  cap decode work to prevent amplification from untrusted blobs.
 
 ## Relationships
 
@@ -39,13 +65,27 @@ validated invariants.
 - Node interface is sealed: only types defined in this package can implement it.
 - Every collab leaf must contain the operator key for safe cosigning.
 - Every exit leaf must be CSV-gated for unilateral recovery.
+- No leaf may permit the operator to spend unilaterally: every `Multisig` node
+  containing the operator key must contain at least one non-operator key.
+  `Multisig{operator, operator}` is rejected because both signers resolve to the
+  same party.
+- CSV encoding uses `blockchain.LockTimeToSequence(false, exitDelay)` to store
+  the BIP-68 block-mode sequence value, not the raw block count. Decoders that
+  compare raw block counts against CSV lock values must convert accordingly.
 - Canonical leaf ordering: sorted by version then lexicographic script bytes.
 - All taproot outputs use the unspendable ARK NUMS key for key path (no
   key-path spend possible).
 - Policy validation enforces at least one operator-containing leaf
   (collaborative) and at least one non-operator leaf (exit/unilateral).
-- Exit delay must be >= `MinExitDelay`.
+- Exit delay must be >= `MinExitDelay` when `ValidateStandardVTXOPolicy` is
+  used; `ValidatePolicy` with `MinExitDelay = 0` skips this check.
+- Decode budget: policy template decode caps at `MaxPolicyTemplateBytes` /
+  `MaxPolicyLeaves` / `MaxPolicyDepth` / `MaxPolicyNodes`; a single budget is
+  shared across all leaves of one policy so an adversary cannot multiply work by
+  packing many max-node leaves into one blob.
 
 ## Deep Docs
 
+- [docs/arkscript_spec.md](../../docs/arkscript_spec.md) — RFC-style specification: AST grammar, encoding format, invariants, and security considerations.
+- [docs/policy_arkscript_review_guide.md](../../docs/policy_arkscript_review_guide.md) — Policy-first reviewer guide for inspecting custom policies.
 - [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/oor/AGENTS.md
+++ b/oor/AGENTS.md
@@ -113,6 +113,8 @@ resume semantics.
 ## Invariants
 
 - Checkpoint output collab path is 2-of-2 `MultiSigCollabTapLeaf(clientKey, operatorKey)`, not single-sig. Both parties must sign the Ark tx that spends checkpoint outputs.
+- `signCustomCheckpointPSBT` re-verifies that the custom spend path binds to the VTXO pkScript via `SpendPath.VerifyBindsToPkScript` before signing. This defense-in-depth check covers persisted `TransferInputSnapshot`s resumed from disk that bypassed the `BuildCustomTransferInputs` constructor.
+- Condition witness encoding/decoding (`encodeConditionWitness`/`decodeConditionWitness`) is bounded by `maxConditionWitnessItems = 64` items and `maxConditionWitnessItemBytes = 520` bytes per item (matching Bitcoin's `MAX_SCRIPT_ELEMENT_SIZE`). Both functions enforce these limits via `wire.ReadVarBytes` so a crafted or corrupted durable blob cannot cause large memory allocations. (The separate `arkscript.readVarBytes` used by policy template decoding has its own 1 MiB budget; the 520-byte cap applies only to persisted OOR condition witnesses.)
 - At submit time only structural validation runs (`ValidateSubmitPackage`); full script VM validation requires both signatures and runs at finalize.
 - Point-of-no-return: when server co-signs checkpoint transaction(s).
 - After checkpoint signature, client must resume and obtain byte-identical co-signed PSBTs (deterministic construction).

--- a/oor/CLAUDE.md
+++ b/oor/CLAUDE.md
@@ -113,6 +113,8 @@ resume semantics.
 ## Invariants
 
 - Checkpoint output collab path is 2-of-2 `MultiSigCollabTapLeaf(clientKey, operatorKey)`, not single-sig. Both parties must sign the Ark tx that spends checkpoint outputs.
+- `signCustomCheckpointPSBT` re-verifies that the custom spend path binds to the VTXO pkScript via `SpendPath.VerifyBindsToPkScript` before signing. This defense-in-depth check covers persisted `TransferInputSnapshot`s resumed from disk that bypassed the `BuildCustomTransferInputs` constructor.
+- Condition witness encoding/decoding (`encodeConditionWitness`/`decodeConditionWitness`) is bounded by `maxConditionWitnessItems = 64` items and `maxConditionWitnessItemBytes = 520` bytes per item (matching Bitcoin's `MAX_SCRIPT_ELEMENT_SIZE`). Both functions enforce these limits via `wire.ReadVarBytes` so a crafted or corrupted durable blob cannot cause large memory allocations. (The separate `arkscript.readVarBytes` used by policy template decoding has its own 1 MiB budget; the 520-byte cap applies only to persisted OOR condition witnesses.)
 - At submit time only structural validation runs (`ValidateSubmitPackage`); full script VM validation requires both signatures and runs at finalize.
 - Point-of-no-return: when server co-signs checkpoint transaction(s).
 - After checkpoint signature, client must resume and obtain byte-identical co-signed PSBTs (deterministic construction).


### PR DESCRIPTION
Nightly automated sweep of per-package CLAUDE.md/AGENTS.md files.

Updated three packages with changes since the last merged sweep (af60831):

- lib/arkscript: Added EncodeStandardVTXOArtifacts, ValidateStandardVTXOPolicy, SpendPath.VerifyBindsToPkScript, PolicyTemplate.MatchesPkScript; decode budget constants (MaxPolicy*, MaxLeaf*, MaxMultisigKeys); operator-unilateral rejection invariant; CSV BIP-68 encoding note; links to docs/arkscript_spec.md and docs/policy_arkscript_review_guide.md.
- darepod: Added reserveCustomInputs method and customInputLocks map on RPCServer for concurrent SendOOR dedup; BuildCustomTransferInputs policy/spend-path binding invariants.
- oor: Added condition witness size caps (maxConditionWitnessItems=64, maxConditionWitnessItemBytes=520) and defense-in-depth VerifyBindsToPkScript check in signCustomCheckpointPSBT.

No changes to ARCHITECTURE.md or docs/index.md (both already current).

Please review the updated CLAUDE.md/AGENTS.md diffs for accuracy.
