### PR TITLE
lib/arkscript: review follow-ups for policy template and vHTLC spec

### DIFF
--- a/docs/arkscript_spec.md
+++ b/docs/arkscript_spec.md
@@ -367,16 +367,19 @@ underlying VTXO.
 
 ### 5.3 vHTLC — `NewVHTLCPolicy`
 
-Six-leaf tree (`lib/arkscript/vhtlc.go`):
+Six-leaf tree (`lib/arkscript/vhtlc.go`). Leaf ordering matches
+the source docstring so leaves 1–3 are collaborative (receiver
+and/or server participate) and leaves 4–6 are the client-side
+unilateral exits gated by a CSV delay:
 
-| # | Name                              | Structure                                                                      |
-|---|-----------------------------------|--------------------------------------------------------------------------------|
-| 1 | Claim                             | `Condition{PaymentHash, Multisig{receiver, server}}`                           |
-| 2 | Refund                            | `Multisig{sender, receiver, server}`                                           |
-| 3 | UnilateralClaim                   | `CSV{UnilateralClaimDelay, Condition{PaymentHash, Multisig{receiver}}}`        |
-| 4 | UnilateralRefund                  | `CSV{UnilateralRefundDelay, Multisig{sender, receiver}}`                       |
-| 5 | UnilateralRefundAfterLocktime     | `Condition{AbsoluteLockTime(RefundLocktime), Multisig{sender}}`                |
-| 6 | UnilateralRefundWithoutReceiver   | `CSV{UnilateralRefundWithoutReceiverDelay, Multisig{sender, server}}`          |
+| # | Name                            | Structure                                                                 |
+|---|---------------------------------|---------------------------------------------------------------------------|
+| 1 | Claim                           | `Condition{PaymentHash, Multisig{receiver, server}}`                      |
+| 2 | Refund                          | `Multisig{sender, receiver, server}`                                      |
+| 3 | RefundWithoutReceiver           | `Condition{CLTV(RefundLocktime), Multisig{sender, server}}`               |
+| 4 | UnilateralClaim                 | `CSV{UnilateralClaimDelay, Condition{PaymentHash, Multisig{receiver}}}`   |
+| 5 | UnilateralRefund                | `CSV{UnilateralRefundDelay, Multisig{sender, receiver}}`                  |
+| 6 | UnilateralRefundWithoutReceiver | `CSV{UnilateralRefundWithoutReceiverDelay, Multisig{sender}}`             |
 
 Full cross-party behaviour is documented inline at
 `lib/arkscript/vhtlc.go` — this spec only enumerates the shape.

--- a/lib/arkscript/policy_template.go
+++ b/lib/arkscript/policy_template.go
@@ -702,9 +702,19 @@ func writeVarBytes(w io.Writer, value []byte) error {
 	return err
 }
 
-// readVarBytes reads one length-prefixed byte slice.
+// readVarBytes reads one length-prefixed byte slice. The inner
+// cap matches the outer MaxPolicyTemplateBytes cap so a single
+// nested field can never claim more bytes than the enclosing
+// blob carries. The previous 1 << 20 (1 MiB) value was
+// cooperatively redundant -- the outer DecodePolicyTemplate cap
+// (64 KiB) made the larger inner cap unreachable in practice --
+// but keeping the two numbers identical makes the invariant
+// explicit and prevents a future loosening of either side from
+// silently widening the other.
 func readVarBytes(r *bytes.Reader, field string) ([]byte, error) {
-	value, err := wire.ReadVarBytes(r, 0, 1<<20, field)
+	value, err := wire.ReadVarBytes(
+		r, 0, MaxPolicyTemplateBytes, field,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/arkscript/standard_vtxo.go
+++ b/lib/arkscript/standard_vtxo.go
@@ -51,10 +51,14 @@ func StandardVTXOTemplate(ownerKey, operatorKey *btcec.PublicKey,
 		return nil, fmt.Errorf("vtxo: exit delay must be non-zero")
 	}
 
-	// exitDelay is a raw block count; convert to the BIP-68 block-mode
-	// sequence encoding before storing on the CSV leaf so the field is
-	// self-describing rather than relying on the raw-blocks/encoded-blocks
-	// identity that only holds for small block counts.
+	// exitDelay is a raw block count. LockTimeToSequence's first
+	// argument selects time-mode (true) vs block-mode (false);
+	// passing false produces the BIP-68 block-mode sequence
+	// encoding, which stores the block count in the low 16 bits
+	// with the type-flag and disable bits cleared. Make the
+	// encoding explicit so the field is self-describing rather
+	// than relying on the raw-blocks/encoded-blocks numeric
+	// identity that only holds for very small counts.
 	exitSeq := blockchain.LockTimeToSequence(false, exitDelay)
 
 	return &PolicyTemplate{


### PR DESCRIPTION
Two arkscript review nits split off the fees-03-rpc PR.

- readVarBytes inner cap aligned with MaxPolicyTemplateBytes; expanded LockTimeToSequence BIP-68 comment.
- vHTLC leaf table in section 5.3 corrected against lib/arkscript/vhtlc.go.