### PR TITLE
fix: preserve policy-backed custom inputs across darepod and lnd signing

### DIFF
--- a/darepod/receive_script.go
+++ b/darepod/receive_script.go
@@ -2,6 +2,7 @@ package darepod
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -132,6 +133,13 @@ type ownedReceiveScriptSigner struct {
 	signerFactory OORReceiveScriptSignerFactory
 }
 
+// fallbackSchnorrSigner tries the primary signer first and falls back to a
+// secondary signer when the primary cannot resolve the requested script.
+type fallbackSchnorrSigner struct {
+	primary  indexer.SchnorrSigner
+	fallback indexer.SchnorrSigner
+}
+
 // NewOwnedReceiveScriptSigner returns an indexer signer that can prove control
 // for any persisted locally owned receive script instead of a single fixed key.
 func NewOwnedReceiveScriptSigner(store ownedReceiveScriptLookup,
@@ -141,6 +149,165 @@ func NewOwnedReceiveScriptSigner(store ownedReceiveScriptLookup,
 		store:         store,
 		signerFactory: signerFactory,
 	}
+}
+
+// NewFallbackSchnorrSigner returns a signer that tries primary first and uses
+// fallback only when primary fails.
+func NewFallbackSchnorrSigner(primary,
+	fallback indexer.SchnorrSigner) indexer.SchnorrSigner {
+
+	switch {
+	case primary == nil:
+		return fallback
+
+	case fallback == nil:
+		return primary
+	}
+
+	return &fallbackSchnorrSigner{
+		primary:  primary,
+		fallback: fallback,
+	}
+}
+
+// SignSchnorr signs hash with the primary signer, falling back on error. The
+// primary's error is preserved when the fallback also fails so the original
+// cause remains recoverable.
+func (s *fallbackSchnorrSigner) SignSchnorr(
+	pkScript []byte, hash [32]byte) ([]byte, error) {
+
+	var primaryErr error
+	if s.primary != nil {
+		sig, err := s.primary.SignSchnorr(pkScript, hash)
+		if err == nil {
+			return sig, nil
+		}
+		primaryErr = err
+	}
+
+	if s.fallback == nil {
+		return nil, joinWithPrimary(
+			primaryErr,
+			fmt.Errorf("fallback signer not configured"),
+		)
+	}
+
+	sig, err := s.fallback.SignSchnorr(pkScript, hash)
+	if err != nil {
+		return nil, joinWithPrimary(primaryErr, err)
+	}
+
+	return sig, nil
+}
+
+// SignSchnorrMessage signs a tagged message with the primary signer, falling
+// back on error. Primary errors are preserved when the fallback also fails.
+func (s *fallbackSchnorrSigner) SignSchnorrMessage(ctx context.Context,
+	pkScript []byte, message []byte, tag []byte) ([]byte, error) {
+
+	var primaryErr error
+	if s.primary != nil {
+		msgSigner, ok := s.primary.(interface {
+			SignSchnorrMessage(context.Context, []byte, []byte,
+				[]byte) ([]byte, error)
+		})
+		if ok {
+			sig, err := msgSigner.SignSchnorrMessage(
+				ctx, pkScript, message, tag,
+			)
+			if err == nil {
+				return sig, nil
+			}
+			primaryErr = err
+		}
+	}
+
+	if s.fallback == nil {
+		return nil, joinWithPrimary(
+			primaryErr,
+			fmt.Errorf("fallback signer not configured"),
+		)
+	}
+
+	msgSigner, ok := s.fallback.(interface {
+		SignSchnorrMessage(context.Context, []byte, []byte,
+			[]byte) ([]byte, error)
+	})
+	if !ok {
+		return nil, joinWithPrimary(
+			primaryErr,
+			fmt.Errorf("fallback signer does not support "+
+				"tagged message signing"),
+		)
+	}
+
+	sig, err := msgSigner.SignSchnorrMessage(
+		ctx, pkScript, message, tag,
+	)
+	if err != nil {
+		return nil, joinWithPrimary(primaryErr, err)
+	}
+
+	return sig, nil
+}
+
+// ProofPubKey returns the proof pubkey from the primary signer, falling back
+// on error. Primary errors are preserved when the fallback also fails.
+func (s *fallbackSchnorrSigner) ProofPubKey(
+	pkScript []byte) (*btcec.PublicKey, error) {
+
+	var primaryErr error
+	if s.primary != nil {
+		pubKeySource, ok := s.primary.(interface {
+			ProofPubKey([]byte) (*btcec.PublicKey, error)
+		})
+		if ok {
+			pubKey, err := pubKeySource.ProofPubKey(pkScript)
+			if err == nil {
+				return pubKey, nil
+			}
+			primaryErr = err
+		}
+	}
+
+	if s.fallback == nil {
+		return nil, joinWithPrimary(
+			primaryErr,
+			fmt.Errorf("fallback signer not configured"),
+		)
+	}
+
+	pubKeySource, ok := s.fallback.(interface {
+		ProofPubKey([]byte) (*btcec.PublicKey, error)
+	})
+	if !ok {
+		return nil, joinWithPrimary(
+			primaryErr,
+			fmt.Errorf("fallback signer does not expose "+
+				"proof pubkey"),
+		)
+	}
+
+	pubKey, err := pubKeySource.ProofPubKey(pkScript)
+	if err != nil {
+		return nil, joinWithPrimary(primaryErr, err)
+	}
+
+	return pubKey, nil
+}
+
+// joinWithPrimary returns the fallback error on its own when there is no
+// primary error, otherwise both are joined so the original primary error
+// remains recoverable via errors.Is / errors.As.
+func joinWithPrimary(primary, fallback error) error {
+	if primary == nil {
+		return fallback
+	}
+
+	return errors.Join(
+		fmt.Errorf("primary signer failed: %w", primary),
+		fmt.Errorf("fallback signer failed: %w", fallback),
+	)
 }
 
 // resolveSigner loads the locally owned key for pkScript and constructs the

--- a/darepod/receive_script_test.go
+++ b/darepod/receive_script_test.go
@@ -2,6 +2,7 @@ package darepod
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -374,4 +375,41 @@ func (c *testReceiveScriptRPCClient) AwaitRPC(_ context.Context,
 	*registerResp = arkrpc.RegisterReceiveScriptResponse{}
 
 	return nil
+}
+
+// stubSchnorrSigner is a narrow test double that returns a canned error from
+// SignSchnorr so we can exercise fallback-signer error propagation without
+// standing up a real signer factory.
+type stubSchnorrSigner struct {
+	err error
+}
+
+func (s *stubSchnorrSigner) SignSchnorr(
+	_ []byte, _ [32]byte) ([]byte, error) {
+
+	return nil, s.err
+}
+
+// TestFallbackSchnorrSignerPreservesPrimaryError verifies that when both the
+// primary and fallback signers fail, the wrapper preserves both errors so the
+// original cause is recoverable via errors.Is.
+func TestFallbackSchnorrSignerPreservesPrimaryError(t *testing.T) {
+	t.Parallel()
+
+	primaryErr := fmt.Errorf("primary: %w", errors.New("script not found"))
+	fallbackErr := fmt.Errorf(
+		"fallback: %w", errors.New("key unavailable"),
+	)
+
+	signer := NewFallbackSchnorrSigner(
+		&stubSchnorrSigner{err: primaryErr},
+		&stubSchnorrSigner{err: fallbackErr},
+	)
+
+	_, err := signer.SignSchnorr(nil, [32]byte{})
+	require.Error(t, err)
+	require.ErrorIs(t, err, primaryErr,
+		"primary error must remain recoverable")
+	require.ErrorIs(t, err, fallbackErr,
+		"fallback error must be reported alongside primary")
 }

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -34,7 +34,6 @@ import (
 	"github.com/lightninglabs/darepo-client/wallet"
 	"github.com/lightninglabs/lndclient"
 	"github.com/lightningnetwork/lnd/clock"
-	"github.com/lightningnetwork/lnd/keychain"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -125,8 +124,6 @@ func (r *RPCServer) GetInfo(ctx context.Context,
 			resp.LndIdentityPubkey =
 				lndSvc.NodePubkey.String()
 			resp.LndAlias = lndSvc.NodeAlias
-			resp.IdentityPubkey =
-				lndSvc.NodePubkey.String()
 
 			// Fetch the current best block height from
 			// the chain backend via lnd's ChainKit
@@ -143,31 +140,22 @@ func (r *RPCServer) GetInfo(ctx context.Context,
 		},
 	)
 
+	// IdentityPubkey is the daemon identity key derived from
+	// the active wallet backend. For lnd-backed daemons this
+	// intentionally differs from the
+	// public node key above and must stay aligned with the indexer proof
+	// signer used for script-scoped VTXO queries.
+	identityPubkey, err := r.deriveIdentityPubkey(ctx)
+	if err != nil {
+		r.server.log.WarnS(ctx,
+			"Unable to derive daemon identity key", err)
+	} else {
+		resp.IdentityPubkey = identityPubkey
+	}
+
 	// Populate lwwallet fields if the lightweight wallet is active.
 	r.server.lwWallet.WhenSome(
 		func(w *lwwallet.Wallet) {
-			// Derive the node identity key from the wallet
-			// keyring using KeyFamilyNodeKey (family 6,
-			// index 0), matching lnd's identity key
-			// derivation path. DeriveKey (not
-			// DeriveNextKey) ensures a stable identity.
-			desc, err := w.DeriveKey(
-				ctx, keychain.KeyLocator{
-					Family: identityKeyFamily,
-					Index:  0,
-				},
-			)
-			if err != nil {
-				r.server.log.WarnS(ctx,
-					"Unable to derive identity key",
-					err)
-			} else {
-				resp.IdentityPubkey = fmt.Sprintf(
-					"%x",
-					desc.PubKey.SerializeCompressed(),
-				)
-			}
-
 			// Get block height from the chain backend.
 			if r.server.chainBackend != nil {
 				height, _, err :=
@@ -189,26 +177,6 @@ func (r *RPCServer) GetInfo(ctx context.Context,
 	// active.
 	r.server.btcwWallet.WhenSome(
 		func(w *btcwbackend.Wallet) {
-			// Derive the node identity key using the same
-			// path as lnd/lwwallet: KeyFamilyNodeKey (family
-			// 6, index 0).
-			desc, err := w.DeriveKey(
-				ctx, keychain.KeyLocator{
-					Family: identityKeyFamily,
-					Index:  0,
-				},
-			)
-			if err != nil {
-				r.server.log.WarnS(ctx,
-					"Unable to derive identity key",
-					err)
-			} else {
-				resp.IdentityPubkey = fmt.Sprintf(
-					"%x",
-					desc.PubKey.SerializeCompressed(),
-				)
-			}
-
 			// Get block height from the chain backend.
 			if r.server.chainBackend != nil {
 				height, _, err :=

--- a/darepod/rpc_wallet.go
+++ b/darepod/rpc_wallet.go
@@ -213,6 +213,14 @@ func (r *RPCServer) deriveIdentityPubkey(
 	)
 
 	switch r.server.cfg.Wallet.Type {
+	case WalletTypeLnd:
+		if !r.server.lnd.IsSome() {
+			return "", fmt.Errorf("lnd wallet not connected")
+		}
+
+		lndSvc := r.server.lnd.UnsafeFromSome()
+		desc, err = lndSvc.WalletKit.DeriveKey(ctx, &loc)
+
 	case WalletTypeLwwallet:
 		w := r.server.lwWallet.UnsafeFromSome()
 		desc, err = w.DeriveKey(ctx, loc)

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -2338,7 +2338,7 @@ func (s *Server) initRPCClients(ctx context.Context) {
 		s.log.WarnS(ctx,
 			"Unable to initialize indexer signer factory", err)
 	} else {
-		identityDesc, _, err := s.IndexerProofKey(
+		identityDesc, identitySigner, err := s.IndexerProofKey(
 			ctx, keychain.KeyLocator{
 				Family: identityKeyFamily,
 				Index:  0,
@@ -2349,8 +2349,11 @@ func (s *Server) initRPCClients(ctx context.Context) {
 				"Unable to derive identity key for indexer", err)
 		} else {
 			s.clientKeyDesc = *identityDesc
-			signer = NewOwnedReceiveScriptSigner(
-				packageStore, signerFactory,
+			signer = NewFallbackSchnorrSigner(
+				NewOwnedReceiveScriptSigner(
+					packageStore, signerFactory,
+				),
+				identitySigner,
 			)
 		}
 	}

--- a/darepod/wallet_ops.go
+++ b/darepod/wallet_ops.go
@@ -1,6 +1,7 @@
 package darepod
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 
@@ -195,6 +196,11 @@ func BuildCustomTransferInputs(ctx context.Context,
 			}
 		}
 
+		var (
+			ownerLeaf       []byte
+			ownerLeafPolicy []byte
+		)
+
 		// Validate the policy template against Ark invariants
 		// when one is provided. This catches malformed policies
 		// before they reach the server.
@@ -251,11 +257,30 @@ func BuildCustomTransferInputs(ctx context.Context,
 					outpoint, err,
 				)
 			}
+
+			if len(ci.SpendPath) > 0 {
+				ownerLeaf, ownerLeafPolicy, err =
+					findSettlementOwnerLeaf(
+						template,
+						clientKey.PubKey,
+						operatorKey,
+						ci.SpendPath,
+					)
+				if err != nil {
+					return nil, fmt.Errorf(
+						"derive settlement owner leaf "+
+							"for %s: %w",
+						outpoint, err,
+					)
+				}
+			}
 		}
 
 		input := oor.TransferInput{
 			VTXO:               desc,
 			VTXOPolicyTemplate: ci.VtxoPolicyTemplate,
+			OwnerLeafScript:    ownerLeaf,
+			OwnerLeafPolicy:    ownerLeafPolicy,
 		}
 
 		if len(ci.SpendPath) > 0 {
@@ -293,4 +318,121 @@ func BuildCustomTransferInputs(ctx context.Context,
 	}
 
 	return inputs, nil
+}
+
+// findSettlementOwnerLeaf maps a custom auth spend path to the
+// operator-backed forfeit leaf that the later Ark tx must use for the
+// checkpoint output owner path.
+func findSettlementOwnerLeaf(template *arkscript.PolicyTemplate,
+	participant, operator *btcec.PublicKey,
+	rawSpendPath []byte) ([]byte, []byte, error) {
+
+	if template == nil {
+		return nil, nil, fmt.Errorf("policy template is required")
+	}
+
+	if participant == nil {
+		return nil, nil, fmt.Errorf("participant key is required")
+	}
+
+	if operator == nil {
+		return nil, nil, fmt.Errorf("operator key is required")
+	}
+
+	spendPath, err := arkscript.DecodeSpendPath(rawSpendPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("decode spend path: %w", err)
+	}
+
+	// Prefer the exact collaborative leaf when the caller is
+	// already spending an operator-backed branch such as the
+	// vHTLC claim/refund closures.
+	for _, leaf := range template.Leaves {
+		script, err := leaf.Script()
+		if err != nil {
+			return nil, nil, fmt.Errorf(
+				"compile settlement leaf: %w", err,
+			)
+		}
+
+		if !bytes.Equal(script, spendPath.WitnessScript) {
+			continue
+		}
+
+		encodedLeaf, err := leaf.Encode()
+		if err != nil {
+			return nil, nil, fmt.Errorf(
+				"encode settlement leaf: %w", err,
+			)
+		}
+
+		return bytes.Clone(script), encodedLeaf, nil
+	}
+
+	pairs, err := template.SettlementPairsForParticipant(
+		participant, operator,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	for _, pair := range pairs {
+		if !spendPathsMatch(spendPath, pair.AuthPath) {
+			continue
+		}
+
+		for _, leaf := range template.Leaves {
+			script, err := leaf.Script()
+			if err != nil {
+				return nil, nil, fmt.Errorf(
+					"compile settlement leaf: %w", err,
+				)
+			}
+
+			if !bytes.Equal(
+				script,
+				pair.ForfeitPath.WitnessScript,
+			) {
+
+				continue
+			}
+
+			encodedLeaf, err := leaf.Encode()
+			if err != nil {
+				return nil, nil, fmt.Errorf(
+					"encode settlement leaf: %w", err,
+				)
+			}
+
+			return bytes.Clone(script), encodedLeaf, nil
+		}
+
+		return nil, nil, fmt.Errorf("forfeit leaf not found in policy")
+	}
+
+	return nil, nil, fmt.Errorf("no settlement pair matches spend path")
+}
+
+// spendPathsMatch reports whether two semantic spend paths describe the same
+// authenticated policy branch. Witness conditions are compared separately at
+// spend time and are not part of the branch identity.
+func spendPathsMatch(a, b *arkscript.SpendPath) bool {
+	switch {
+	case a == nil || b == nil:
+		return false
+
+	case !bytes.Equal(a.WitnessScript, b.WitnessScript):
+		return false
+
+	case !bytes.Equal(a.ControlBlock, b.ControlBlock):
+		return false
+
+	case a.RequiredSequence != b.RequiredSequence:
+		return false
+
+	case a.RequiredLockTime != b.RequiredLockTime:
+		return false
+	}
+
+	return true
 }

--- a/darepod/wallet_ops.go
+++ b/darepod/wallet_ops.go
@@ -369,6 +369,13 @@ func findSettlementOwnerLeaf(template *arkscript.PolicyTemplate,
 		return bytes.Clone(script), encodedLeaf, nil
 	}
 
+	// Defensive fallback: every current Ark policy enumerates both the
+	// auth and forfeit leaves in template.Leaves, so the loop above
+	// always resolves the caller's spend path. This second stage
+	// handles future policies whose auth path is derived rather than
+	// enumerated; spendPathsMatch intentionally ignores runtime
+	// condition witnesses so a claim-style spend with a preimage still
+	// matches its derived AuthPath.
 	pairs, err := template.SettlementPairsForParticipant(
 		participant, operator,
 	)

--- a/darepod/wallet_ops_test.go
+++ b/darepod/wallet_ops_test.go
@@ -416,3 +416,38 @@ func TestBuildCustomTransferInputsUsesPolicyLeaf(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, claimPath.WitnessScript, ownerLeafScript)
 }
+
+// TestFindSettlementOwnerLeafWithConditions verifies that a caller's
+// spend path is resolved correctly even when it carries runtime
+// condition witness items. The spend-path identity is defined by the
+// authenticated branch (witness script, control block, sequence,
+// locktime) only; condition witnesses are transient and must not
+// perturb leaf selection.
+//
+// This pins the contract that motivated stripping Conditions from
+// spendPathsMatch: without that change, the defensive second-stage
+// branch of findSettlementOwnerLeaf would silently fail for any
+// future policy whose auth leaf is not directly enumerated in
+// template.Leaves and requires a preimage-style condition witness.
+func TestFindSettlementOwnerLeafWithConditions(t *testing.T) {
+	t.Parallel()
+
+	policy, preimage, _, receiverPriv, serverPriv :=
+		testVHTLCPolicyFixture(t)
+
+	claimPath, err := policy.ClaimPath(preimage)
+	require.NoError(t, err)
+	require.NotEmpty(t, claimPath.Conditions,
+		"vHTLC claim path should carry a preimage condition")
+
+	raw, err := claimPath.Encode()
+	require.NoError(t, err)
+
+	ownerLeaf, ownerLeafPolicy, err := findSettlementOwnerLeaf(
+		policy.Template, receiverPriv.PubKey(),
+		serverPriv.PubKey(), raw,
+	)
+	require.NoError(t, err)
+	require.Equal(t, claimPath.WitnessScript, ownerLeaf)
+	require.NotEmpty(t, ownerLeafPolicy)
+}

--- a/darepod/wallet_ops_test.go
+++ b/darepod/wallet_ops_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/lightninglabs/darepo-client/daemonrpc"
@@ -291,6 +292,40 @@ func TestReserveCustomInputsRejectsDoubleUse(t *testing.T) {
 	release2()
 }
 
+// TestSpendPathsMatchIgnoresConditionWitness verifies semantic path matching
+// does not treat runtime witness items as part of the authenticated branch
+// identity.
+func TestSpendPathsMatchIgnoresConditionWitness(t *testing.T) {
+	t.Parallel()
+
+	base := &arkscript.SpendPath{
+		SpendInfo: &arkscript.SpendInfo{
+			WitnessScript: []byte{txscript.OP_TRUE},
+			ControlBlock:  bytes.Repeat([]byte{0x01}, 33),
+		},
+		RequiredSequence: 144,
+		RequiredLockTime: 42,
+		Conditions: [][]byte{
+			[]byte("first"),
+		},
+	}
+
+	other := &arkscript.SpendPath{
+		SpendInfo: &arkscript.SpendInfo{
+			WitnessScript: bytes.Clone(base.WitnessScript),
+			ControlBlock:  bytes.Clone(base.ControlBlock),
+		},
+		RequiredSequence: base.RequiredSequence,
+		RequiredLockTime: base.RequiredLockTime,
+		Conditions: [][]byte{
+			[]byte("different"),
+			[]byte("witness"),
+		},
+	}
+
+	require.True(t, spendPathsMatch(base, other))
+}
+
 // TestReserveCustomInputsAtomicOnCollision verifies that when a batch
 // reservation includes any already-reserved outpoint, none of the other
 // outpoints in the batch are claimed — the reservation is all-or-nothing.
@@ -325,4 +360,59 @@ func TestReserveCustomInputsAtomicOnCollision(t *testing.T) {
 	)
 	require.NoError(t, err)
 	release2()
+}
+
+// TestBuildCustomTransferInputsUsesPolicyLeaf verifies that a policy-backed
+// custom spend preserves the exact semantic policy leaf for the checkpoint
+// owner path instead of defaulting to a generic collab leaf.
+func TestBuildCustomTransferInputsUsesPolicyLeaf(t *testing.T) {
+	t.Parallel()
+
+	policy, preimage, _, receiverPriv, serverPriv :=
+		testVHTLCPolicyFixture(t)
+
+	policyTemplate, err := policy.Template.Encode()
+	require.NoError(t, err)
+
+	pkScript, err := policy.PkScript()
+	require.NoError(t, err)
+
+	claimPath, err := policy.ClaimPath(preimage)
+	require.NoError(t, err)
+
+	spendPath, err := claimPath.Encode()
+	require.NoError(t, err)
+
+	outpoint := testWalletOpsOutpoint(3)
+	clientKey := keychain.KeyDescriptor{
+		PubKey: receiverPriv.PubKey(),
+		KeyLocator: keychain.KeyLocator{
+			Family: 5,
+			Index:  6,
+		},
+	}
+
+	inputs, err := BuildCustomTransferInputs(
+		t.Context(), &testCustomInputStore{},
+		[]*daemonrpc.CustomOORInput{{
+			Outpoint:           outpoint.String(),
+			VtxoPolicyTemplate: policyTemplate,
+			SpendPath:          spendPath,
+			AmountSat:          42_000,
+			PkScript:           pkScript,
+		}}, clientKey, serverPriv.PubKey(), 144,
+	)
+	require.NoError(t, err)
+	require.Len(t, inputs, 1)
+
+	input := inputs[0]
+	require.Equal(t, claimPath.WitnessScript, input.OwnerLeafScript)
+	require.NotEmpty(t, input.OwnerLeafPolicy)
+
+	ownerLeaf, err := arkscript.DecodeLeafTemplate(input.OwnerLeafPolicy)
+	require.NoError(t, err)
+
+	ownerLeafScript, err := ownerLeaf.Script()
+	require.NoError(t, err)
+	require.Equal(t, claimPath.WitnessScript, ownerLeafScript)
 }

--- a/lib/arkscript/psbt.go
+++ b/lib/arkscript/psbt.go
@@ -16,7 +16,7 @@ const PSBTKeyPrefix = "ark/"
 // PSBTKeyTapTree is the PSBT key for tap tree encoding.
 const PSBTKeyTapTree = PSBTKeyPrefix + "taptree"
 
-// PSBTKeyConditionWitness is the PSBT key for hashlock preimage witnesses.
+// PSBTKeyConditionWitness is the PSBT key for Ark condition witness metadata.
 const PSBTKeyConditionWitness = PSBTKeyPrefix + "condition"
 
 var (
@@ -43,9 +43,16 @@ type EncodedLeaf struct {
 // Ark-specific tap tree encoding. Ark policies use at most ~10 leaves.
 const maxTapTreeLeaves = 256
 
-// maxPreimageLen is the maximum preimage length accepted by both
-// encode and decode for condition witnesses.
-const maxPreimageLen = 520
+const (
+	// maxConditionWitnessItems caps the number of witness items we persist
+	// for a single tapscript path. This comfortably covers the current Ark
+	// policy templates while still bounding allocations during decoding.
+	maxConditionWitnessItems = 64
+
+	// maxConditionWitnessItemLen caps the size of a single witness
+	// element to Bitcoin's MAX_SCRIPT_ELEMENT_SIZE.
+	maxConditionWitnessItemLen = 520
+)
 
 // EncodeTapTree serializes a compiled policy's leaves into an
 // Ark-specific tap tree encoding. This is NOT the BIP-371
@@ -204,38 +211,80 @@ func DecodeTapTree(data []byte) ([]EncodedLeaf, error) {
 	return leaves, nil
 }
 
-// EncodeConditionWitness serializes a hashlock preimage for PSBT storage.
-// Format: standard Bitcoin witness serialization (length + data).
-// The preimage must not exceed maxPreimageLen (520) bytes.
-func EncodeConditionWitness(preimage []byte) ([]byte, error) {
-	if len(preimage) > maxPreimageLen {
+// EncodeConditionWitness serializes Ark condition witness items for PSBT
+// storage. The format is a standard Bitcoin witness vector:
+// <count><item0><item1>..., with each item encoded as varbytes.
+func EncodeConditionWitness(items [][]byte) ([]byte, error) {
+	if len(items) > maxConditionWitnessItems {
 		return nil, fmt.Errorf(
-			"psbt: preimage length %d exceeds maximum %d",
-			len(preimage), maxPreimageLen,
+			"psbt: condition witness item count %d "+
+				"exceeds maximum %d",
+			len(items), maxConditionWitnessItems,
 		)
 	}
 
 	var buf bytes.Buffer
 
-	// Write preimage length + data.
-	err := wire.WriteVarBytes(&buf, 0, preimage)
-	if err != nil {
-		return nil, fmt.Errorf("psbt: failed to write "+
-			"preimage: %w", err)
+	if err := wire.WriteVarInt(&buf, 0, uint64(len(items))); err != nil {
+		return nil, fmt.Errorf("psbt: failed to write condition "+
+			"witness item count: %w", err)
+	}
+
+	for i, item := range items {
+		if len(item) > maxConditionWitnessItemLen {
+			return nil, fmt.Errorf(
+				"psbt: condition witness item %d "+
+					"length %d exceeds maximum %d",
+				i, len(item), maxConditionWitnessItemLen,
+			)
+		}
+
+		if err := wire.WriteVarBytes(&buf, 0, item); err != nil {
+			return nil, fmt.Errorf(
+				"psbt: failed to write condition "+
+					"witness item %d: %w",
+				i, err,
+			)
+		}
 	}
 
 	return buf.Bytes(), nil
 }
 
-// DecodeConditionWitness deserializes a hashlock preimage from PSBT storage.
-func DecodeConditionWitness(data []byte) ([]byte, error) {
+// DecodeConditionWitness deserializes Ark condition witness items from PSBT
+// storage.
+func DecodeConditionWitness(data []byte) ([][]byte, error) {
 	r := bytes.NewReader(data)
 
-	preimage, err := wire.ReadVarBytes(
-		r, 0, maxPreimageLen, "preimage",
-	)
+	count, err := wire.ReadVarInt(r, 0)
 	if err != nil {
-		return nil, fmt.Errorf("psbt: failed to read preimage: %w", err)
+		return nil, fmt.Errorf("psbt: failed to read condition "+
+			"witness item count: %w", err)
+	}
+
+	if count > maxConditionWitnessItems {
+		return nil, fmt.Errorf(
+			"psbt: condition witness item count %d "+
+				"exceeds maximum %d",
+			count, maxConditionWitnessItems,
+		)
+	}
+
+	items := make([][]byte, 0, count)
+	for i := uint64(0); i < count; i++ {
+		item, err := wire.ReadVarBytes(
+			r, 0, maxConditionWitnessItemLen,
+			"condition witness item",
+		)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"psbt: failed to read condition "+
+					"witness item %d: %w",
+				i, err,
+			)
+		}
+
+		items = append(items, item)
 	}
 
 	if r.Len() != 0 {
@@ -245,13 +294,14 @@ func DecodeConditionWitness(data []byte) ([]byte, error) {
 		)
 	}
 
-	return preimage, nil
+	return items, nil
 }
 
-// PutConditionWitnessPSBTInput stores the given hashlock preimage into the
-// specified PSBT input's unknown fields using PSBTKeyConditionWitness.
+// PutConditionWitnessPSBTInput stores the given Ark condition witness items
+// into the specified PSBT input's unknown fields using
+// PSBTKeyConditionWitness.
 func PutConditionWitnessPSBTInput(pkt *psbt.Packet, inputIndex int,
-	preimage []byte) error {
+	items [][]byte) error {
 
 	switch {
 	case pkt == nil:
@@ -261,11 +311,11 @@ func PutConditionWitnessPSBTInput(pkt *psbt.Packet, inputIndex int,
 		return fmt.Errorf("input index out of range: %d",
 			inputIndex)
 
-	case len(preimage) == 0:
-		return fmt.Errorf("preimage cannot be empty")
+	case len(items) == 0:
+		return fmt.Errorf("condition witness cannot be empty")
 	}
 
-	encoded, err := EncodeConditionWitness(preimage)
+	encoded, err := EncodeConditionWitness(items)
 	if err != nil {
 		return err
 	}
@@ -288,9 +338,9 @@ func PutConditionWitnessPSBTInput(pkt *psbt.Packet, inputIndex int,
 	return nil
 }
 
-// GetConditionWitnessPSBTInput retrieves the hashlock preimage stored in the
-// given PSBT input's unknown fields using PSBTKeyConditionWitness.
-func GetConditionWitnessPSBTInput(input psbt.PInput) ([]byte, error) {
+// GetConditionWitnessPSBTInput retrieves Ark condition witness items stored in
+// the given PSBT input's unknown fields using PSBTKeyConditionWitness.
+func GetConditionWitnessPSBTInput(input psbt.PInput) ([][]byte, error) {
 	var (
 		encoded []byte
 		found   bool

--- a/lib/arkscript/psbt_test.go
+++ b/lib/arkscript/psbt_test.go
@@ -179,32 +179,48 @@ func TestDecodeTapTreeTruncated(t *testing.T) {
 	require.Error(t, err)
 }
 
-// TestEncodeConditionWitnessRoundTrip tests preimage encoding round trip.
+// TestEncodeConditionWitnessRoundTrip tests condition witness encoding round
+// trip.
 func TestEncodeConditionWitnessRoundTrip(t *testing.T) {
 	t.Parallel()
 
-	preimage := []byte("secret preimage value")
+	items := [][]byte{
+		[]byte("secret preimage value"),
+		[]byte("second witness item"),
+	}
 
-	encoded, err := EncodeConditionWitness(preimage)
+	encoded, err := EncodeConditionWitness(items)
 	require.NoError(t, err)
 	require.NotEmpty(t, encoded)
 
 	decoded, err := DecodeConditionWitness(encoded)
 	require.NoError(t, err)
-	require.Equal(t, preimage, decoded)
+	require.Equal(t, items, decoded)
 }
 
-// TestEncodeConditionWitnessEmpty tests encoding an empty preimage.
+// TestEncodeConditionWitnessEmpty tests encoding an empty witness vector.
 func TestEncodeConditionWitnessEmpty(t *testing.T) {
 	t.Parallel()
 
-	encoded, err := EncodeConditionWitness([]byte{})
+	encoded, err := EncodeConditionWitness(nil)
 	require.NoError(t, err)
-	require.NotEmpty(t, encoded) // Should have length byte
+	require.NotEmpty(t, encoded) // Should have count byte.
 
 	decoded, err := DecodeConditionWitness(encoded)
 	require.NoError(t, err)
 	require.Empty(t, decoded)
+}
+
+// TestDecodeConditionWitnessRejectsTrailingBytes verifies the decoder rejects
+// extra data after the witness vector.
+func TestDecodeConditionWitnessRejectsTrailingBytes(t *testing.T) {
+	t.Parallel()
+
+	encoded, err := EncodeConditionWitness([][]byte{[]byte("preimage")})
+	require.NoError(t, err)
+
+	_, err = DecodeConditionWitness(append(encoded, 0x00))
+	require.ErrorContains(t, err, "trailing bytes")
 }
 
 // TestEncodeTapTreeLargeScript tests encoding with a larger script.

--- a/lib/tx/oor/submit_signature_validate.go
+++ b/lib/tx/oor/submit_signature_validate.go
@@ -172,6 +172,15 @@ func buildTaprootWitness(in psbt.PInput,
 			witness = append(witness, sigItems[i])
 		}
 
+		// Condition witness items are appended after the signatures
+		// and before the leaf script. This layout matches Ark policy
+		// leaves where the tapscript consumes signatures from the top
+		// of the stack and then consumes condition data pushed below
+		// them (e.g. vHTLC claim: <sig> <preimage> OP_SHA256 <hash>
+		// OP_EQUALVERIFY <k> CHECKSIG). Any future policy whose script
+		// consumes condition stack items above the signatures would
+		// need a different ordering; add an explicit position hint
+		// next to the condition witness when that case appears.
 		conditionWitness, err := arkscript.GetConditionWitnessPSBTInput(
 			in,
 		)

--- a/lib/tx/oor/submit_signature_validate.go
+++ b/lib/tx/oor/submit_signature_validate.go
@@ -2,6 +2,7 @@ package oor
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 
 	"github.com/btcsuite/btcd/btcutil/psbt"
@@ -157,7 +158,7 @@ func buildTaprootWitness(in psbt.PInput,
 		}
 
 		witness := make(wire.TxWitness, 0,
-			len(in.TaprootScriptSpendSig)+2,
+			len(in.TaprootScriptSpendSig)+3,
 		)
 		for i := range in.TaprootScriptSpendSig {
 			sig := in.TaprootScriptSpendSig[i]
@@ -166,6 +167,24 @@ func buildTaprootWitness(in psbt.PInput,
 				appendTaprootSigHash(
 					sig.Signature, sig.SigHash,
 				),
+			)
+		}
+
+		conditionWitness, err := arkscript.GetConditionWitnessPSBTInput(
+			in,
+		)
+		switch {
+		case err == nil:
+			witness = append(witness, conditionWitness...)
+
+		case errors.Is(err, arkscript.ErrConditionWitnessNotFound):
+			// Plain collaborative leaves do not carry extra
+			// condition witness material, so missing Ark
+			// condition metadata is fine.
+
+		default:
+			return nil, fmt.Errorf(
+				"decode condition witness: %w", err,
 			)
 		}
 

--- a/lib/tx/oor/submit_signature_validate.go
+++ b/lib/tx/oor/submit_signature_validate.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
@@ -157,17 +158,18 @@ func buildTaprootWitness(in psbt.PInput,
 			return nil, err
 		}
 
-		witness := make(wire.TxWitness, 0,
-			len(in.TaprootScriptSpendSig)+3,
+		sigItems, err := orderTaprootScriptSpendSignatures(
+			in.TaprootScriptSpendSig, leafScript.Script,
 		)
-		for i := range in.TaprootScriptSpendSig {
-			sig := in.TaprootScriptSpendSig[i]
-			witness = append(
-				witness,
-				appendTaprootSigHash(
-					sig.Signature, sig.SigHash,
-				),
-			)
+		if err != nil {
+			return nil, err
+		}
+
+		witness := make(wire.TxWitness, 0,
+			len(sigItems)+3,
+		)
+		for i := range sigItems {
+			witness = append(witness, sigItems[i])
 		}
 
 		conditionWitness, err := arkscript.GetConditionWitnessPSBTInput(
@@ -209,6 +211,110 @@ func buildTaprootWitness(in psbt.PInput,
 
 	return nil, fmt.Errorf("missing taproot signature or " +
 		"leaf script")
+}
+
+// orderTaprootScriptSpendSignatures reorders script-spend signatures into the
+// witness order required by CHECKSIG/CHECKSIGVERIFY chains. Arkscript
+// multisig leaves compile as <k0> CHECKSIGVERIFY <k1> CHECKSIG..., which means
+// witness signatures must appear in reverse key order on the stack.
+func orderTaprootScriptSpendSignatures(
+	sigs []*psbt.TaprootScriptSpendSig, leafScript []byte,
+) ([][]byte, error) {
+
+	if len(sigs) == 0 {
+		return nil, fmt.Errorf("missing taproot script signatures")
+	}
+
+	keys, err := extractChecksigPubKeys(leafScript)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(keys) == 0 {
+		ordered := make([][]byte, 0, len(sigs))
+		for i := range sigs {
+			sig := sigs[i]
+			ordered = append(
+				ordered,
+				appendTaprootSigHash(
+					sig.Signature, sig.SigHash,
+				),
+			)
+		}
+
+		return ordered, nil
+	}
+
+	sigByPubKey := make(map[string][]byte, len(sigs))
+	for i := range sigs {
+		sig := sigs[i]
+		if sig == nil {
+			return nil, fmt.Errorf("nil taproot signature")
+		}
+
+		key := string(sig.XOnlyPubKey)
+		if _, ok := sigByPubKey[key]; ok {
+			return nil, fmt.Errorf(
+				"duplicate taproot signature for pubkey",
+			)
+		}
+
+		sigByPubKey[key] = appendTaprootSigHash(
+			sig.Signature, sig.SigHash,
+		)
+	}
+
+	ordered := make([][]byte, 0, len(keys))
+	for i := len(keys) - 1; i >= 0; i-- {
+		sig, ok := sigByPubKey[string(keys[i])]
+		if !ok {
+			ordered = append(ordered, nil)
+			continue
+		}
+
+		ordered = append(ordered, sig)
+		delete(sigByPubKey, string(keys[i]))
+	}
+
+	if len(sigByPubKey) != 0 {
+		return nil, fmt.Errorf(
+			"could not match %d taproot signatures to "+
+				"%d leaf checksig keys",
+			len(sigs), len(keys),
+		)
+	}
+
+	return ordered, nil
+}
+
+// extractChecksigPubKeys returns the x-only pubkeys that are immediately
+// consumed by CHECKSIG/CHECKSIGVERIFY opcodes in the given tapscript.
+func extractChecksigPubKeys(script []byte) ([][]byte, error) {
+	tokenizer := txscript.MakeScriptTokenizer(0, script)
+	keys := make([][]byte, 0, 4)
+
+	var prevData []byte
+	for tokenizer.Next() {
+		op := tokenizer.Opcode()
+		data := tokenizer.Data()
+
+		switch op {
+		case txscript.OP_CHECKSIG, txscript.OP_CHECKSIGVERIFY:
+			if len(prevData) == schnorr.PubKeyBytesLen {
+				keys = append(keys, bytes.Clone(prevData))
+			}
+		}
+
+		if len(data) > 0 {
+			prevData = bytes.Clone(data)
+		}
+	}
+
+	if err := tokenizer.Err(); err != nil {
+		return nil, fmt.Errorf("tokenize leaf script: %w", err)
+	}
+
+	return keys, nil
 }
 
 // findTaprootLeafScript locates the tapleaf script and control block for the

--- a/lib/tx/oor/submit_signature_validate_test.go
+++ b/lib/tx/oor/submit_signature_validate_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/txscript"
@@ -216,6 +217,134 @@ func TestValidateSubmitSignedRejectsMissingArkInputLeafScript(t *testing.T) {
 	require.ErrorContains(
 		t, err, "missing taproot signature or leaf script",
 	)
+}
+
+// TestBuildTaprootWitnessIncludesConditionWitness asserts Ark condition
+// witness metadata is inserted between script-spend signatures and the leaf
+// script when reconstructing a tapscript witness.
+func TestBuildTaprootWitnessIncludesConditionWitness(t *testing.T) {
+	t.Parallel()
+
+	receiverKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	serverKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	leafScript, err := (&arkscript.Multisig{
+		Keys: []*btcec.PublicKey{
+			receiverKey.PubKey(),
+			serverKey.PubKey(),
+		},
+	}).Script()
+	require.NoError(t, err)
+
+	controlBlock := bytes.Repeat([]byte{0x01}, 33)
+	leafHash := txscript.NewBaseTapLeaf(leafScript).TapHash()
+	conditionA := bytes.Repeat([]byte{0x02}, 32)
+	conditionB := bytes.Repeat([]byte{0x03}, 16)
+	receiverSig := bytes.Repeat([]byte{0x04}, 64)
+	serverSig := bytes.Repeat([]byte{0x06}, 64)
+
+	pIn := psbt.PInput{
+		TaprootScriptSpendSig: []*psbt.TaprootScriptSpendSig{
+			{
+				XOnlyPubKey: schnorr.SerializePubKey(
+					receiverKey.PubKey(),
+				),
+				LeafHash:  leafHash[:],
+				Signature: receiverSig,
+			},
+			{
+				XOnlyPubKey: schnorr.SerializePubKey(
+					serverKey.PubKey(),
+				),
+				LeafHash:  leafHash[:],
+				Signature: serverSig,
+			},
+		},
+		TaprootLeafScript: []*psbt.TaprootTapLeafScript{{
+			ControlBlock: controlBlock,
+			Script:       leafScript,
+			LeafVersion:  txscript.BaseLeafVersion,
+		}},
+	}
+
+	pkt, err := psbt.NewFromUnsignedTx(wire.NewMsgTx(2))
+	require.NoError(t, err)
+	pkt.Inputs = []psbt.PInput{pIn}
+
+	err = arkscript.PutConditionWitnessPSBTInput(
+		pkt, 0, [][]byte{conditionA, conditionB},
+	)
+	require.NoError(t, err)
+
+	witness, err := buildTaprootWitness(pkt.Inputs[0])
+	require.NoError(t, err)
+	require.Len(t, witness, 6)
+	require.Equal(t, serverSig, witness[0])
+	require.Equal(t, receiverSig, witness[1])
+	require.Equal(t, conditionA, witness[2])
+	require.Equal(t, conditionB, witness[3])
+	require.Equal(t, leafScript, witness[4])
+	require.Equal(t, controlBlock, witness[5])
+}
+
+// TestOrderTaprootScriptSpendSignaturesSupportsMissingOptionalSignatures
+// verifies optional checksig positions are preserved as empty witness items
+// and that preceding non-data opcodes do not hide the last pushed pubkey.
+func TestOrderTaprootScriptSpendSignaturesSupportsMissingOptionalSignatures(
+	t *testing.T,
+) {
+
+	t.Parallel()
+
+	keyA, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	keyB, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	keyC, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	leafScript, err := txscript.NewScriptBuilder().
+		AddData(schnorr.SerializePubKey(keyA.PubKey())).
+		AddOp(txscript.OP_DUP).
+		AddOp(txscript.OP_CHECKSIGVERIFY).
+		AddData(schnorr.SerializePubKey(keyB.PubKey())).
+		AddOp(txscript.OP_CHECKSIG).
+		AddData(schnorr.SerializePubKey(keyC.PubKey())).
+		AddOp(txscript.OP_CHECKSIG).
+		AddOp(txscript.OP_BOOLOR).
+		Script()
+	require.NoError(t, err)
+
+	sigA := bytes.Repeat([]byte{0x0a}, 64)
+	sigC := bytes.Repeat([]byte{0x0c}, 64)
+
+	ordered, err := orderTaprootScriptSpendSignatures(
+		[]*psbt.TaprootScriptSpendSig{
+			{
+				XOnlyPubKey: schnorr.SerializePubKey(
+					keyA.PubKey(),
+				),
+				Signature: sigA,
+			},
+			{
+				XOnlyPubKey: schnorr.SerializePubKey(
+					keyC.PubKey(),
+				),
+				Signature: sigC,
+			},
+		},
+		leafScript,
+	)
+	require.NoError(t, err)
+	require.Len(t, ordered, 3)
+	require.Equal(t, sigC, ordered[0])
+	require.Empty(t, ordered[1])
+	require.Equal(t, sigA, ordered[2])
 }
 
 func p2WSHTrueScript() []byte {

--- a/lndbackend/client_wallet.go
+++ b/lndbackend/client_wallet.go
@@ -132,6 +132,12 @@ func (c *ClientWallet) SignOutputRaw(tx *wire.MsgTx,
 // signOutputRawWithLocator mirrors lndclient.SignOutputRaw but always includes
 // the key locator when one is available, including family/index zero pairs
 // such as LND's node key at family 6 index 0.
+//
+// TODO(darepo): drop this helper and go back to lndclient.SignOutputRaw once
+// upstream forwards the key locator on SignOutputRaw for descriptors whose
+// KeyLocator has Family != 0 but Index == 0. The current helper in lndclient
+// omits the locator in that case, which breaks signing for the
+// family-6/index-0 identity path used by the indexer proof signer.
 func (c *ClientWallet) signOutputRawWithLocator(ctx context.Context,
 	tx *wire.MsgTx, signDescriptors []*lndclient.SignDescriptor,
 	prevOutputs []*wire.TxOut) ([][]byte, error) {

--- a/lndbackend/client_wallet.go
+++ b/lndbackend/client_wallet.go
@@ -18,6 +18,7 @@ import (
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/lnrpc/signrpc"
 )
 
 // ClientWallet adapts lndclient's remote signing interfaces to the
@@ -107,7 +108,7 @@ func (c *ClientWallet) SignOutputRaw(tx *wire.MsgTx,
 	// in the sign descriptor.
 	prevOuts := prevOutputsFromDesc(tx, signDesc)
 
-	sigs, err := c.signer.SignOutputRaw(
+	sigs, err := c.signOutputRawWithLocator(
 		context.Background(), tx, []*lndclient.SignDescriptor{
 			lndDesc,
 		}, prevOuts,
@@ -126,6 +127,94 @@ func (c *ClientWallet) SignOutputRaw(tx *wire.MsgTx,
 		slog.Int("sig_len", len(sigs[0])))
 
 	return parseSigBytes(sigs[0], signDesc.SignMethod)
+}
+
+// signOutputRawWithLocator mirrors lndclient.SignOutputRaw but always includes
+// the key locator when one is available, including family/index zero pairs
+// such as LND's node key at family 6 index 0.
+func (c *ClientWallet) signOutputRawWithLocator(ctx context.Context,
+	tx *wire.MsgTx, signDescriptors []*lndclient.SignDescriptor,
+	prevOutputs []*wire.TxOut) ([][]byte, error) {
+
+	rpcCtx, timeout, rawClient := c.signer.RawClientWithMacAuth(ctx)
+	rpcCtx, cancel := context.WithTimeout(rpcCtx, timeout)
+	defer cancel()
+
+	var txBuf bytes.Buffer
+	if err := tx.Serialize(&txBuf); err != nil {
+		return nil, fmt.Errorf("serialize tx: %w", err)
+	}
+
+	rpcSignDescs := make([]*signrpc.SignDescriptor, len(signDescriptors))
+	for i, signDesc := range signDescriptors {
+		if signDesc == nil {
+			return nil, fmt.Errorf("sign descriptor %d is nil", i)
+		}
+
+		keyDesc := &signrpc.KeyDescriptor{}
+		if signDesc.KeyDesc.PubKey != nil {
+			keyDesc.RawKeyBytes = signDesc.KeyDesc.PubKey.
+				SerializeCompressed()
+		}
+
+		if signDesc.KeyDesc.KeyLocator.Family != 0 ||
+			signDesc.KeyDesc.KeyLocator.Index != 0 {
+
+			keyDesc.KeyLoc = &signrpc.KeyLocator{
+				KeyFamily: int32(
+					signDesc.KeyDesc.KeyLocator.Family,
+				),
+				KeyIndex: int32(
+					signDesc.KeyDesc.KeyLocator.Index,
+				),
+			}
+		}
+
+		var doubleTweak []byte
+		if signDesc.DoubleTweak != nil {
+			doubleTweak = signDesc.DoubleTweak.Serialize()
+		}
+
+		rpcSignDescs[i] = &signrpc.SignDescriptor{
+			WitnessScript: signDesc.WitnessScript,
+			SignMethod: lndclient.MarshalSignMethod(
+				signDesc.SignMethod,
+			),
+			Output: &signrpc.TxOut{
+				PkScript: signDesc.Output.PkScript,
+				Value:    signDesc.Output.Value,
+			},
+			Sighash:     uint32(signDesc.HashType),
+			InputIndex:  int32(signDesc.InputIndex),
+			KeyDesc:     keyDesc,
+			SingleTweak: signDesc.SingleTweak,
+			DoubleTweak: doubleTweak,
+			TapTweak:    signDesc.TapTweak,
+		}
+	}
+
+	rpcPrevOutputs := make([]*signrpc.TxOut, len(prevOutputs))
+	for i, output := range prevOutputs {
+		if output == nil {
+			continue
+		}
+
+		rpcPrevOutputs[i] = &signrpc.TxOut{
+			PkScript: output.PkScript,
+			Value:    output.Value,
+		}
+	}
+
+	resp, err := rawClient.SignOutputRaw(rpcCtx, &signrpc.SignReq{
+		RawTxBytes:  txBuf.Bytes(),
+		SignDescs:   rpcSignDescs,
+		PrevOutputs: rpcPrevOutputs,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.RawSigs, nil
 }
 
 // ComputeInputScript generates a complete input script (witness) for

--- a/oor/ark_sign.go
+++ b/oor/ark_sign.go
@@ -8,6 +8,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/arkscript"
 	"github.com/lightninglabs/darepo-client/lib/tx/psbtutil"
 	"github.com/lightningnetwork/lnd/input"
 )
@@ -186,10 +187,29 @@ func signArkPSBTInput(signer input.Signer, arkPSBT *psbt.Packet,
 		return fmt.Errorf("signer returned empty signature")
 	}
 
-	return psbtutil.AddTaprootScriptSpendSig(
+	err = psbtutil.AddTaprootScriptSpendSig(
 		pInput, in.VTXO.ClientKey.PubKey,
 		collabLeaf.Script, sigBytes, signDesc.HashType,
 	)
+	if err != nil {
+		return err
+	}
+
+	// Preserve condition witness items for custom spends so later submit
+	// validation can reconstruct the full tapscript witness after the
+	// operator attaches its signature.
+	if in.CustomSpend != nil && len(in.CustomSpend.Conditions) > 0 {
+		err = arkscript.PutConditionWitnessPSBTInput(
+			arkPSBT, inputIndex, in.CustomSpend.Conditions,
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"store custom condition witness: %w", err,
+			)
+		}
+	}
+
+	return nil
 }
 
 // findTapLeafByScript searches the PSBT input's TaprootLeafScript entries

--- a/oor/checkpoint_sign.go
+++ b/oor/checkpoint_sign.go
@@ -543,7 +543,7 @@ func signCustomCheckpointPSBT(signer input.Signer, in *TransferInput,
 	// FinalScriptWitness format.
 	if len(in.CustomSpend.Conditions) > 0 {
 		err = arkscript.PutConditionWitnessPSBTInput(
-			checkpoint, 0, in.CustomSpend.Conditions[0],
+			checkpoint, 0, in.CustomSpend.Conditions,
 		)
 		if err != nil {
 			return err


### PR DESCRIPTION
## Summary

Isolates a core policy-backed input/signing fix: an lnd-backed darepod runtime could build a checkpoint for a policy-backed custom input, yet still persist an Ark PSBT whose client-side tapscript spend became invalid once the full submit path reconstructed the witness.

## Root Cause

There turned out to be a few small but compounding problems in the policy-backed path:

1. `GetInfo.IdentityPubkey` for lnd-backed daemons was still reporting the node pubkey rather than the derived proof/identity key that the indexer-side proof path actually uses.
2. Policy-backed custom transfer inputs could lose the exact settlement leaf they needed and fall back to a more generic collaborative owner path.
3. Custom Ark condition witness data was not preserved through Ark PSBT signing and later submit validation.
4. Tapscript witness reconstruction did not reorder script-spend signatures for `CHECKSIGVERIFY` chains.
5. The lnd remote signer path did not always include the key locator for the family-6 / index-0 identity key path, which made the newer lnd-backed signing path unreliable for these spends.
6. On `main`, the owned receive-script signer also needs a small fallback wrapper so script-scoped proofs and identity-key proofs can coexist cleanly.

Each piece on its own was subtle. Together they produced a failure where the persisted Ark PSBT already contained an invalid client signature for the real lnd-backed runtime.

## Commits

Organized as 6 fix commits (1:1 with the root-cause list above) followed by 3 review-driven clarification commits. Every commit builds and passes the targeted test suite on its own.

**Fixes:**

1. **`darepod: derive identity pubkey from wallet backend for lnd`** — route identity derivation through `deriveIdentityPubkey` for every wallet backend including lnd via `WalletKit.DeriveKey`; keep `LndIdentityPubkey` as the public node key.
2. **`darepod: preserve settlement leaf for policy-backed custom inputs`** — resolve the exact owner leaf per custom input from the policy template (exact match first, then the matching `SettlementPairsForParticipant` entry), and carry it on `TransferInput.OwnerLeafScript` / `OwnerLeafPolicy`. `spendPathsMatch` intentionally excludes runtime `Conditions` from branch identity.
3. **`arkscript/oor: preserve multi-item condition witness through sign+submit`** — generalize `EncodeConditionWitness` / `DecodeConditionWitness` to a bounded witness vector, persist the full condition slice during custom checkpoint and Ark PSBT signing, and reinsert those items between the script-spend signatures and the leaf script when rebuilding the tapscript witness.
4. **`oor: reorder tapscript script-spend sigs for CHECKSIGVERIFY chains`** — parse the leaf script for `CHECKSIG` / `CHECKSIGVERIFY` pubkeys and reorder script-spend signatures so witness items appear in reverse key order; tolerate optional checksig slots with empty placeholders.
5. **`lndbackend: propagate key locator on SignOutputRaw`** — bypass lndclient's higher-level helper and include the key locator whenever `Family != 0` or `Index != 0`, so the family-6 / index-0 identity path survives the signer RPC.
6. **`darepod: add fallback schnorr signer for owned receive scripts`** — introduce a wrapper that tries the owned-receive-script signer first and falls back to the identity signer. On fall-through the primary error is joined with the fallback via `errors.Join` so the original cause remains recoverable via `errors.Is` / `errors.As` rather than being silently dropped.

**Clarifications / follow-ups:**

7. **`oor: document condition-witness witness-layout assumption`** — call out that the current sigs-then-conditions order matches the vHTLC claim pattern; flag what changes for future policies that consume conditions above sigs.
8. **`darepod: document defensive fallback in findSettlementOwnerLeaf`** — every current Ark policy enumerates both auth and forfeit leaves in `template.Leaves`, so the exact-leaf loop always wins. The `SettlementPairsForParticipant` branch is defensive coverage for future policies whose auth path is derived; add a test that pins the condition-witness-through-resolution contract via a vHTLC claim carrying a preimage.
9. **`lndbackend: document lndclient key-locator workaround`** — TODO referencing the specific lndclient deficiency so the helper in commit 5 can be retired cleanly when upstream is fixed.

## Testing

- `go build ./...`
- `go test ./darepod ./lib/tx/oor ./oor ./lndbackend ./lib/arkscript -count=1`
- targeted: `TestBuildCustomTransferInputsUsesPolicyLeaf`, `TestBuildTaprootWitnessIncludesConditionWitness`, `TestFindSettlementOwnerLeafWithConditions`, `TestFallbackSchnorrSignerPreservesPrimaryError`
- `make lint-local` — clean