### PR TITLE
darepod: re-expose GetStoredVTXO for harness inspection

### DIFF
--- a/darepod/server.go
+++ b/darepod/server.go
@@ -317,6 +317,21 @@ func (s *Server) DaemonReady() <-chan struct{} {
 	return s.daemonReady
 }
 
+// GetStoredVTXO returns the persisted VTXO descriptor for the given
+// outpoint. This method exists for test harnesses only; it lets
+// server-side integration tests inspect locally stored partial-unroll
+// state without reaching into internal daemon fields.
+func (s *Server) GetStoredVTXO(ctx context.Context,
+	outpoint wire.OutPoint) (*vtxo.Descriptor, error) {
+
+	if s.vtxoStore == nil {
+		return nil, fmt.Errorf("client daemon VTXO " +
+			"store not initialized")
+	}
+
+	return s.vtxoStore.GetVTXO(ctx, outpoint)
+}
+
 // RPCAddr returns the bound daemon gRPC listener address once startup has
 // progressed far enough to create the listener.
 func (s *Server) RPCAddr() net.Addr {


### PR DESCRIPTION
## Summary

Restore the harness-only `GetStoredVTXO` accessor on `darepod.Server`
that was introduced in #239 and then accidentally removed during the
policy-migration refactor in 35dc614 (`darepod: wire policy through
daemon and CLI`). The docs in `darepod/CLAUDE.md` and `darepod/AGENTS.md`
still reference this method, so the removal left the API surface
doc-inconsistent.

## Motivation

The server-side integration harness (`harness/arkharness.go` in the
darepo repo) needs to inspect a client daemon's persisted
partial-unroll state during itests. Without this accessor:

- reaching into the unexported `vtxoStore` field across package+repo
  boundaries requires reflection or a visibility change, both of which
  break the "harness does not poke private daemon state" invariant
  that the client `CLAUDE.md` explicitly calls out;
- widening `vtxoStore` to an exported field exports the entire
  `*db.VTXOPersistenceStore` surface area when only a single lookup is
  needed.

## Change

Re-add the 15-line accessor that delegates straight to
`s.vtxoStore.GetVTXO(ctx, outpoint)`. Same shape as the original in
PR #239. No other code touched.

## Test plan

- [x] Client `go build ./darepod/...` clean.
- [ ] Server-side itests against this client commit (in the
      pr223-followup branch of darepo) run green.