### PR TITLE
docs: nightly doc-gardening sweep 2026-04-17

### DIFF
--- a/cmd/merge-sql-schemas/AGENTS.md
+++ b/cmd/merge-sql-schemas/AGENTS.md
@@ -1,0 +1,39 @@
+# cmd/merge-sql-schemas
+
+## Purpose
+
+Build-time tool that applies all `.up.sql` migration files from
+`db/sqlc/migrations` and `db/actordelivery/migrations` to an in-memory SQLite
+database, then dumps the resulting combined schema to
+`db/sqlc/schemas/generated_schema.sql`. Used by the sqlc code-generation
+pipeline to give sqlc a single flat schema file.
+
+## Key Types
+
+- `main()` — Opens an in-memory SQLite DB, applies both migration directories
+  in lexicographic order via `applyMigrationDir`, queries `sqlite_master` for
+  all tables/views/indexes, and writes the concatenated DDL to the output file.
+- `applyMigrationDir(db, dir)` — Reads `.up.sql` files from `dir` in sorted
+  order and executes each against `db`. Returns an error on the first failure.
+
+## Relationships
+
+- **Depends on**: `modernc.org/sqlite` (in-memory SQLite driver), standard
+  library only.
+- **Depended on by**: `make sqlc` Makefile target (run before `sqlc generate`
+  so sqlc sees a merged schema).
+
+## Invariants
+
+- Migration files are applied in lexicographic order within each directory;
+  cross-directory order is fixed: `db/sqlc/migrations` before
+  `db/actordelivery/migrations`.
+- Output file is always overwritten; the tool is idempotent given the same
+  migration inputs.
+- Never edit `db/sqlc/schemas/generated_schema.sql` by hand — regenerate via
+  `make sqlc`.
+
+## Deep Docs
+
+- [db/CLAUDE.md](../../db/CLAUDE.md) — DB layer and migration conventions.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/cmd/merge-sql-schemas/CLAUDE.md
+++ b/cmd/merge-sql-schemas/CLAUDE.md
@@ -1,0 +1,39 @@
+# cmd/merge-sql-schemas
+
+## Purpose
+
+Build-time tool that applies all `.up.sql` migration files from
+`db/sqlc/migrations` and `db/actordelivery/migrations` to an in-memory SQLite
+database, then dumps the resulting combined schema to
+`db/sqlc/schemas/generated_schema.sql`. Used by the sqlc code-generation
+pipeline to give sqlc a single flat schema file.
+
+## Key Types
+
+- `main()` — Opens an in-memory SQLite DB, applies both migration directories
+  in lexicographic order via `applyMigrationDir`, queries `sqlite_master` for
+  all tables/views/indexes, and writes the concatenated DDL to the output file.
+- `applyMigrationDir(db, dir)` — Reads `.up.sql` files from `dir` in sorted
+  order and executes each against `db`. Returns an error on the first failure.
+
+## Relationships
+
+- **Depends on**: `modernc.org/sqlite` (in-memory SQLite driver), standard
+  library only.
+- **Depended on by**: `make sqlc` Makefile target (run before `sqlc generate`
+  so sqlc sees a merged schema).
+
+## Invariants
+
+- Migration files are applied in lexicographic order within each directory;
+  cross-directory order is fixed: `db/sqlc/migrations` before
+  `db/actordelivery/migrations`.
+- Output file is always overwritten; the tool is idempotent given the same
+  migration inputs.
+- Never edit `db/sqlc/schemas/generated_schema.sql` by hand — regenerate via
+  `make sqlc`.
+
+## Deep Docs
+
+- [db/CLAUDE.md](../../db/CLAUDE.md) — DB layer and migration conventions.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/mailbox/rpc/AGENTS.md
+++ b/mailbox/rpc/AGENTS.md
@@ -1,0 +1,53 @@
+# mailbox/rpc
+
+## Purpose
+
+Runtime interfaces used by generated RPC-over-mailbox stubs. Provides the
+narrow contracts (`RPCClient`, `Router`, `HandlerFunc`) that both client stubs
+and server-side routing need without including any transport implementation.
+
+## Key Types
+
+- `RPCClient` — Interface for generated stubs: `SendRPC` enqueues a request and
+  returns a `SendResult`; `AwaitRPC` blocks until the correlated response
+  arrives. Implementations must be safe for concurrent in-flight calls.
+- `Router` — Interface for registering typed handlers by `(service, method)`
+  pair. Consumed by the `serverconn` ingress layer and server-side generated
+  code.
+- `ServeMux` — Concrete in-process `Router` implementation. Maps
+  `(service, method)` keys to `(newReq, HandlerFunc)` entries under a
+  `sync.RWMutex`. Returns `ErrNoHandler` for unregistered routes.
+- `HandlerFunc` — `func(context.Context, proto.Message) (proto.Message, error)`.
+  Implementations must be idempotent (at-least-once delivery via idempotency
+  key).
+- `ServiceMethod` — Pairs a fully-qualified protobuf service name
+  (e.g. `"arkrpc.ArkService"`) with a method name (e.g. `"GetInfo"`).
+- `SendResult` — Holds the `CorrelationID` and `IdempotencyKey` returned by a
+  successful `SendRPC` call. Callers pass `CorrelationID` to `AwaitRPC`.
+- `RPCOptions` — Per-call overrides: `IdempotencyKey`, `CorrelationID`,
+  `Headers`. All fields are optional; zero values use implementation defaults.
+
+## Relationships
+
+- **Depends on**: `google.golang.org/protobuf/proto` only — intentionally
+  dependency-free so generated stubs can import it without pulling in transport.
+- **Depended on by**: `serverconn` (wraps `RPCClient` for the durable transport
+  path), `arkrpc` / `daemonrpc` (generated stubs embed the interfaces),
+  `mailbox/conn` (adapts `AckState` and response registry to satisfy
+  `RPCClient`).
+
+## Invariants
+
+- `ServeMux.Handle` panics on empty service or method strings (programming
+  error, not a runtime condition).
+- `HandlerFunc` implementations must be idempotent: the mailbox layer may
+  redeliver the same `idempotency_key` after a crash.
+- `ServiceMethod.Service` uses the fully-qualified protobuf package + service
+  name, not the Go package path.
+
+## Deep Docs
+
+- [mailbox/CLAUDE.md](../CLAUDE.md) — Parent mailbox package overview.
+- [docs/mailbox_architecture.md](../../docs/mailbox_architecture.md) — Three-layer mailbox architecture.
+- [docs/RPC_MAILBOX_CONTRACT.md](../../docs/RPC_MAILBOX_CONTRACT.md) — Envelope semantics and ack watermarks.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/mailbox/rpc/CLAUDE.md
+++ b/mailbox/rpc/CLAUDE.md
@@ -1,0 +1,53 @@
+# mailbox/rpc
+
+## Purpose
+
+Runtime interfaces used by generated RPC-over-mailbox stubs. Provides the
+narrow contracts (`RPCClient`, `Router`, `HandlerFunc`) that both client stubs
+and server-side routing need without including any transport implementation.
+
+## Key Types
+
+- `RPCClient` — Interface for generated stubs: `SendRPC` enqueues a request and
+  returns a `SendResult`; `AwaitRPC` blocks until the correlated response
+  arrives. Implementations must be safe for concurrent in-flight calls.
+- `Router` — Interface for registering typed handlers by `(service, method)`
+  pair. Consumed by the `serverconn` ingress layer and server-side generated
+  code.
+- `ServeMux` — Concrete in-process `Router` implementation. Maps
+  `(service, method)` keys to `(newReq, HandlerFunc)` entries under a
+  `sync.RWMutex`. Returns `ErrNoHandler` for unregistered routes.
+- `HandlerFunc` — `func(context.Context, proto.Message) (proto.Message, error)`.
+  Implementations must be idempotent (at-least-once delivery via idempotency
+  key).
+- `ServiceMethod` — Pairs a fully-qualified protobuf service name
+  (e.g. `"arkrpc.ArkService"`) with a method name (e.g. `"GetInfo"`).
+- `SendResult` — Holds the `CorrelationID` and `IdempotencyKey` returned by a
+  successful `SendRPC` call. Callers pass `CorrelationID` to `AwaitRPC`.
+- `RPCOptions` — Per-call overrides: `IdempotencyKey`, `CorrelationID`,
+  `Headers`. All fields are optional; zero values use implementation defaults.
+
+## Relationships
+
+- **Depends on**: `google.golang.org/protobuf/proto` only — intentionally
+  dependency-free so generated stubs can import it without pulling in transport.
+- **Depended on by**: `serverconn` (wraps `RPCClient` for the durable transport
+  path), `arkrpc` / `daemonrpc` (generated stubs embed the interfaces),
+  `mailbox/conn` (adapts `AckState` and response registry to satisfy
+  `RPCClient`).
+
+## Invariants
+
+- `ServeMux.Handle` panics on empty service or method strings (programming
+  error, not a runtime condition).
+- `HandlerFunc` implementations must be idempotent: the mailbox layer may
+  redeliver the same `idempotency_key` after a crash.
+- `ServiceMethod.Service` uses the fully-qualified protobuf package + service
+  name, not the Go package path.
+
+## Deep Docs
+
+- [mailbox/CLAUDE.md](../CLAUDE.md) — Parent mailbox package overview.
+- [docs/mailbox_architecture.md](../../docs/mailbox_architecture.md) — Three-layer mailbox architecture.
+- [docs/RPC_MAILBOX_CONTRACT.md](../../docs/RPC_MAILBOX_CONTRACT.md) — Envelope semantics and ack watermarks.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/scripts/verify-schema-registry/AGENTS.md
+++ b/scripts/verify-schema-registry/AGENTS.md
@@ -1,0 +1,44 @@
+# scripts/verify-schema-registry
+
+## Purpose
+
+CI check that parses the `cmd/darepocli` Go source via `go/ast` and verifies
+that the schema registry (`methodRegistry()`), MCP tool definitions
+(`registerMCPTools()`), and cobra command tree are all in sync. Exits 0 on
+success, 1 on drift. Run via `make schema-check`.
+
+## Key Functions
+
+- `main()` — Entry point: parses the CLI package, extracts all three sets, runs
+  subset checks, and prints a summary or error list.
+- `extractSchemaMethods(pkg)` — Walks `methodRegistry()` body looking for
+  `Method` key-value fields in composite literals; returns sorted method names.
+- `extractMCPToolNames(pkg)` — Walks all `mcp.AddTool[T](...)` calls and
+  extracts the `Name` field from the `&mcp.Tool{}` argument; returns sorted
+  tool names.
+- `extractCobraLeafCommands(pkg)` — Walks all `new*Cmd()` functions to build a
+  dotted command-path tree (e.g. `fees.estimate`); returns leaf commands that
+  have a `RunE` handler; excludes schema-introspection and MCP server commands.
+- `checkSubset(setA, setB, transform)` — Verifies every element of setA (after
+  optional name transform) appears in setB. One-directional: setB may have extra
+  entries (some schema methods are CLI-only).
+
+## Relationships
+
+- **Depends on**: `go/ast`, `go/parser` — reads source at the file system level,
+  no imports from this repository.
+- **Depended on by**: `make schema-check` Makefile target (CI gate).
+
+## Invariants
+
+- MCP tool names use `namespace_method` format; schema registry uses
+  `namespace.method`. `mcpToSchema` converts by replacing the first underscore.
+- Cobra command paths use dotted notation matching the schema registry key.
+- The check is one-directional for MCP vs schema: every MCP tool must have a
+  schema entry, but schema entries for sensitive CLI-only operations (wallet key
+  material, etc.) need not have an MCP tool.
+
+## Deep Docs
+
+- [scripts/CLAUDE.md](../CLAUDE.md) — Parent scripts package overview.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/scripts/verify-schema-registry/CLAUDE.md
+++ b/scripts/verify-schema-registry/CLAUDE.md
@@ -1,0 +1,44 @@
+# scripts/verify-schema-registry
+
+## Purpose
+
+CI check that parses the `cmd/darepocli` Go source via `go/ast` and verifies
+that the schema registry (`methodRegistry()`), MCP tool definitions
+(`registerMCPTools()`), and cobra command tree are all in sync. Exits 0 on
+success, 1 on drift. Run via `make schema-check`.
+
+## Key Functions
+
+- `main()` — Entry point: parses the CLI package, extracts all three sets, runs
+  subset checks, and prints a summary or error list.
+- `extractSchemaMethods(pkg)` — Walks `methodRegistry()` body looking for
+  `Method` key-value fields in composite literals; returns sorted method names.
+- `extractMCPToolNames(pkg)` — Walks all `mcp.AddTool[T](...)` calls and
+  extracts the `Name` field from the `&mcp.Tool{}` argument; returns sorted
+  tool names.
+- `extractCobraLeafCommands(pkg)` — Walks all `new*Cmd()` functions to build a
+  dotted command-path tree (e.g. `fees.estimate`); returns leaf commands that
+  have a `RunE` handler; excludes schema-introspection and MCP server commands.
+- `checkSubset(setA, setB, transform)` — Verifies every element of setA (after
+  optional name transform) appears in setB. One-directional: setB may have extra
+  entries (some schema methods are CLI-only).
+
+## Relationships
+
+- **Depends on**: `go/ast`, `go/parser` — reads source at the file system level,
+  no imports from this repository.
+- **Depended on by**: `make schema-check` Makefile target (CI gate).
+
+## Invariants
+
+- MCP tool names use `namespace_method` format; schema registry uses
+  `namespace.method`. `mcpToSchema` converts by replacing the first underscore.
+- Cobra command paths use dotted notation matching the schema registry key.
+- The check is one-directional for MCP vs schema: every MCP tool must have a
+  schema entry, but schema entries for sensitive CLI-only operations (wallet key
+  material, etc.) need not have an MCP tool.
+
+## Deep Docs
+
+- [scripts/CLAUDE.md](../CLAUDE.md) — Parent scripts package overview.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.


### PR DESCRIPTION
Nightly automated doc-gardening sweep for 2026-04-17. Added CLAUDE.md/AGENTS.md for mailbox/rpc, cmd/merge-sql-schemas, and scripts/verify-schema-registry. All other stale docs were already current from fee-ledger work commits. make doc-check passes.