### PR TITLE
darepod: guard self-managed wallet Option in deriveIdentityPubkey

### DIFF
--- a/darepod/rpc_server_test.go
+++ b/darepod/rpc_server_test.go
@@ -1,6 +1,7 @@
 package darepod
 
 import (
+	"context"
 	"testing"
 
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -322,4 +323,63 @@ func TestEncodeStandardRecipientPolicyPkScriptMismatch(t *testing.T) {
 	require.True(t, ok, "expected gRPC status error, got %T", err)
 	require.Equal(t, codes.Internal, st.Code())
 	require.Contains(t, st.Message(), "does not match pk_script")
+}
+
+// TestDeriveIdentityPubkeyPreWalletInit verifies that GetInfo's call to
+// deriveIdentityPubkey returns a structured error rather than panicking
+// when the self-managed wallet Option is still None. GetInfo is
+// intentionally callable before InitWallet / UnlockWallet so the
+// client can probe WalletReady; the previous implementation unwrapped
+// the Option unconditionally on the lw/btcwallet branches, which
+// panicked on pre-init callers.
+func TestDeriveIdentityPubkeyPreWalletInit(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		walletType string
+		wantErrMsg string
+	}{
+		{
+			name:       "lwwallet not initialized",
+			walletType: WalletTypeLwwallet,
+			wantErrMsg: "lwwallet not initialized",
+		},
+		{
+			name:       "btcwallet not initialized",
+			walletType: WalletTypeBtcwallet,
+			wantErrMsg: "btcwallet not initialized",
+		},
+		{
+			name:       "lnd not connected",
+			walletType: WalletTypeLnd,
+			wantErrMsg: "lnd wallet not connected",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := &RPCServer{
+				server: &Server{
+					cfg: &Config{
+						Wallet: &WalletConfig{
+							Type: tc.walletType,
+						},
+					},
+				},
+			}
+
+			// Must not panic: the None Option has to surface
+			// as a structured error.
+			identity, err := r.deriveIdentityPubkey(
+				context.Background(),
+			)
+			require.Error(t, err)
+			require.Empty(t, identity)
+			require.Contains(t, err.Error(), tc.wantErrMsg)
+		})
+	}
 }

--- a/darepod/rpc_wallet.go
+++ b/darepod/rpc_wallet.go
@@ -222,10 +222,23 @@ func (r *RPCServer) deriveIdentityPubkey(
 		desc, err = lndSvc.WalletKit.DeriveKey(ctx, &loc)
 
 	case WalletTypeLwwallet:
+		// GetInfo is intentionally callable before InitWallet /
+		// UnlockWallet (clients probe WalletReady via GetInfo).
+		// Guard the Option so we surface a structured error
+		// instead of panicking on UnsafeFromSome for a wallet
+		// that has not been initialized yet.
+		if !r.server.lwWallet.IsSome() {
+			return "", fmt.Errorf("lwwallet not initialized")
+		}
+
 		w := r.server.lwWallet.UnsafeFromSome()
 		desc, err = w.DeriveKey(ctx, loc)
 
 	case WalletTypeBtcwallet:
+		if !r.server.btcwWallet.IsSome() {
+			return "", fmt.Errorf("btcwallet not initialized")
+		}
+
 		w := r.server.btcwWallet.UnsafeFromSome()
 		desc, err = w.DeriveKey(ctx, loc)
 


### PR DESCRIPTION
## Summary

Followup to #267. `deriveIdentityPubkey` on the lwwallet and btcwallet
branches was calling `UnsafeFromSome()` on the wallet `fn.Option`
directly, so `GetInfo` panicked with `Option was None()` when invoked
before `InitWallet` / `UnlockWallet` on a self-managed daemon.

This hit darepo's itest matrix on every self-managed wallet run:

```
panic: Option was None()
...
darepod/rpc_wallet.go:229 +0x30b
.../rpc_server.go:148 +0x2ae
```

## Fix

Guard the lw/btcwallet branches with `IsSome` and return a structured
error, mirroring the existing lnd branch. The GetInfo caller already
logs and omits `IdentityPubkey` on error, so the pre-init response is
now a well-formed `GetInfoResponse{WalletReady: false, ...}` instead
of a process crash.

## Test plan

- New `TestDeriveIdentityPubkeyPreWalletInit` (table-driven) pins all
  three wallet-type branches to the `None -> error` contract.
- `go test ./darepod/...` — green.
- Reviewed the existing call sites of `deriveIdentityPubkey` to
  confirm the only caller (`RPCServer.GetInfo`) handles the error
  branch non-fatally.

## Root cause context

Caught by a review comment on the original PR (C-1 "RPCServer.GetInfo
will panic on lwwallet/btcwallet before wallet init"). The review
recommended exactly this fix plus a pre-init regression test; both
are included here.