### PR TITLE
docs: hint agents at go doc + gopls for cheap API lookups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,50 @@ Body wrapped at 72 characters. Explain WHY, not just WHAT.
 7. Do not batch actor messages without backpressure.
 8. Comments explain WHY and HOW, not WHAT.
 
+## Efficient Code Lookup (save tokens)
+
+Prefer targeted queries over `Read`-ing whole files when you just
+need a signature, docstring, or symbol location. Reading an entire
+file to find one type costs orders of magnitude more tokens than
+the tools below.
+
+- `go doc pkg` — Package-level overview: every exported identifier
+  with its one-line summary. Start here before opening any file in a
+  package you haven't touched.
+- `go doc pkg.Symbol` — Full doc comment + signature for one type,
+  function, constant, or method. Drops a `Read` on a 500-line file to
+  ~20 lines of output. Works on third-party dependencies too (e.g.
+  `go doc github.com/lightningnetwork/lnd/fn/v2.Option`).
+- `go doc -all pkg` — Every exported symbol's full doc in one shot;
+  useful when auditing a package's surface.
+- `go doc -src pkg.Symbol` — Full Go source of the named symbol.
+  Cheaper than opening the file when the surrounding code is
+  irrelevant.
+- `gopls definition file:line:col` — Jump from a use site to the
+  definition when you need the exact file:line (returns
+  `filename:line:col-line:col`).
+- `gopls references file:line:col` — Find every caller of a function
+  or use of a type. Alternative to grepping when you want semantic
+  matches instead of string matches.
+- `gopls symbols <file>` — List all top-level symbols in a file with
+  their kinds and line ranges; useful to navigate a big file without
+  reading it end-to-end.
+- `gopls workspace_symbol <query>` — Fuzzy-search exported symbols
+  across the whole module.
+- `gopls check <file>` — Run type-check diagnostics on a single file
+  without a full `go build`, which is dramatically faster on large
+  modules.
+
+If your harness exposes an `LSP` tool (gopls), the same operations
+are available structurally: `documentSymbol`, `hover`,
+`goToDefinition`, `findReferences`, `goToImplementation`,
+`incomingCalls`, `outgoingCalls`, `workspaceSymbol`. Prefer those
+over the CLI when available — output is JSON-structured.
+
+Rule of thumb: if you only need to *know* something about a symbol
+(signature, doc, callers), reach for `go doc` or `gopls` first. Only
+open a file with `Read` when you actually need to *read* its body.
+
 ## Knowledge Base Map
 
 ### Architecture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,50 @@ Body wrapped at 72 characters. Explain WHY, not just WHAT.
 7. Do not batch actor messages without backpressure.
 8. Comments explain WHY and HOW, not WHAT.
 
+## Efficient Code Lookup (save tokens)
+
+Prefer targeted queries over `Read`-ing whole files when you just
+need a signature, docstring, or symbol location. Reading an entire
+file to find one type costs orders of magnitude more tokens than
+the tools below.
+
+- `go doc pkg` — Package-level overview: every exported identifier
+  with its one-line summary. Start here before opening any file in a
+  package you haven't touched.
+- `go doc pkg.Symbol` — Full doc comment + signature for one type,
+  function, constant, or method. Drops a `Read` on a 500-line file to
+  ~20 lines of output. Works on third-party dependencies too (e.g.
+  `go doc github.com/lightningnetwork/lnd/fn/v2.Option`).
+- `go doc -all pkg` — Every exported symbol's full doc in one shot;
+  useful when auditing a package's surface.
+- `go doc -src pkg.Symbol` — Full Go source of the named symbol.
+  Cheaper than opening the file when the surrounding code is
+  irrelevant.
+- `gopls definition file:line:col` — Jump from a use site to the
+  definition when you need the exact file:line (returns
+  `filename:line:col-line:col`).
+- `gopls references file:line:col` — Find every caller of a function
+  or use of a type. Alternative to grepping when you want semantic
+  matches instead of string matches.
+- `gopls symbols <file>` — List all top-level symbols in a file with
+  their kinds and line ranges; useful to navigate a big file without
+  reading it end-to-end.
+- `gopls workspace_symbol <query>` — Fuzzy-search exported symbols
+  across the whole module.
+- `gopls check <file>` — Run type-check diagnostics on a single file
+  without a full `go build`, which is dramatically faster on large
+  modules.
+
+If your harness exposes an `LSP` tool (gopls), the same operations
+are available structurally: `documentSymbol`, `hover`,
+`goToDefinition`, `findReferences`, `goToImplementation`,
+`incomingCalls`, `outgoingCalls`, `workspaceSymbol`. Prefer those
+over the CLI when available — output is JSON-structured.
+
+Rule of thumb: if you only need to *know* something about a symbol
+(signature, doc, callers), reach for `go doc` or `gopls` first. Only
+open a file with `Read` when you actually need to *read* its body.
+
 ## Knowledge Base Map
 
 ### Architecture


### PR DESCRIPTION
In this PR, we add a short "Efficient Code Lookup (save tokens)" section to
the top-level `CLAUDE.md` (and the mirror `AGENTS.md`) that points agents
at `go doc` and `gopls` as the first thing to reach for when answering a
question about a Go API. The motivation is purely token economics: an
agent reading a 500-line file end-to-end to find one type signature is
spending two or three orders of magnitude more context than it would on a
`go doc pkg.Symbol` invocation that returns the same answer in ~20 lines.
That overhead compounds quickly across a session, especially when an
agent is exploring an unfamiliar package or auditing the surface of a
module it's about to modify.

The section enumerates the most useful invocations in a single readable
list. For `go doc` that's the package-level overview (`go doc pkg`), the
single-symbol lookup (`go doc pkg.Symbol`), the source variant (`go doc
-src pkg.Symbol`) when you want the implementation without the
surrounding file, and `go doc -all pkg` for whole-package surface audits.
For `gopls` it's the CLI subcommands an agent can shell out to:
`definition`, `references`, `symbols`, `workspace_symbol`, and `check`.
Semantic queries via gopls are also a strict win over grep in cases
where you actually want callers of a function rather than every string
match of its name.

We also note that some agent harnesses expose a structural `LSP` tool
backed by gopls (`documentSymbol`, `hover`, `goToDefinition`,
`findReferences`, `goToImplementation`, `incomingCalls`,
`outgoingCalls`, `workspaceSymbol`); when that's available, the JSON
output is preferable to parsing CLI output. Closes with a one-line rule
of thumb: only reach for `Read` when the implementation body is itself
what you need.

Both files are kept byte-identical, so the diff is the same +44/-0 hunk
applied to each.

## Test plan

- [x] `diff -q CLAUDE.md AGENTS.md` returns no difference
- [x] Section renders correctly on GitHub markdown preview