### PR TITLE
docs: nightly doc-gardening sweep 2026-04-21

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -32,7 +32,7 @@ package may import from a higher layer.
 |---------|---------|
 | [`baselib`](baselib/) | Actor framework (`baselib/actor`) and protofsm state machine engine (`baselib/protofsm`) |
 | [`chainsource`](chainsource/) | `ChainBackend` interface: fee estimation, block/conf/spend notifications |
-| [`chainbackends`](chainbackends/) | Concrete `ChainBackend` implementations (LND-backed) |
+| [`chainbackends`](chainbackends/) | LND-backed `ChainBackend` implementation plus lndclient adapters (`TxBroadcaster`, `PackageSubmitter`) |
 | [`chain`](chain/) | Bitcoind RPC utilities (package relay, `SubmitPackage`) |
 | [`lndbackend`](lndbackend/) | `BoardingBackend` implementation via LND's wallet kit |
 | [`lwwallet`](lwwallet/) | Lightweight in-process wallet (btcwallet + Esplora, no external LND) |

--- a/baselib/actor/AGENTS.md
+++ b/baselib/actor/AGENTS.md
@@ -20,6 +20,10 @@ crash-safe at-least-once delivery with exactly-once deduplication.
 - `MessageCodec` — TLV-based codec for message serialization/deserialization.
 - `DeliveryStore` / `TxAwareDeliveryStore` — Interfaces for durable mailbox persistence (enqueue, claim, ack, dead-letter).
 - `DurableActor` — Actor variant with crash-safe mailbox backed by SQL persistence. Provides `Wait(ctx)` to block until the actor stops and `StopAndWait(ctx)` to request a graceful shutdown and then wait.
+- `DurableActorConfig[M, R]` — Configuration struct for `DurableActor`: behavior, store, codec, clock, DLO, WaitGroup, `TellRetryPolicy`, lease/heartbeat/poll durations, max attempts, cleanup timeout, and deduplication TTL.
+- `DefaultDurableActorConfig[M, R]()` — Constructor returning a `DurableActorConfig` with safe defaults (30s lease, 10 max attempts, 100ms poll, DefaultTellRetryPolicy).
+- `TellRetryPolicy` — Function type `func(attempts int, lastErr error) (bool, time.Duration)` determining retry behavior for failed Tell messages. Return `(false, _)` to dead-letter immediately.
+- `DefaultTellRetryPolicy` — Exponential backoff policy: up to 5 attempts, starting at 1s, capped at 60s.
 - `Checkpoint` — Serializable actor state snapshot for recovery.
 - `WithoutOutboxID` — Context helper that strips the propagated outbox ID so child operations do not inherit the parent's delivery tracking scope.
 - `Promise[T]` / `Future[T]` — Async result types for Ask-pattern responses.

--- a/baselib/actor/CLAUDE.md
+++ b/baselib/actor/CLAUDE.md
@@ -20,6 +20,10 @@ crash-safe at-least-once delivery with exactly-once deduplication.
 - `MessageCodec` — TLV-based codec for message serialization/deserialization.
 - `DeliveryStore` / `TxAwareDeliveryStore` — Interfaces for durable mailbox persistence (enqueue, claim, ack, dead-letter).
 - `DurableActor` — Actor variant with crash-safe mailbox backed by SQL persistence. Provides `Wait(ctx)` to block until the actor stops and `StopAndWait(ctx)` to request a graceful shutdown and then wait.
+- `DurableActorConfig[M, R]` — Configuration struct for `DurableActor`: behavior, store, codec, clock, DLO, WaitGroup, `TellRetryPolicy`, lease/heartbeat/poll durations, max attempts, cleanup timeout, and deduplication TTL.
+- `DefaultDurableActorConfig[M, R]()` — Constructor returning a `DurableActorConfig` with safe defaults (30s lease, 10 max attempts, 100ms poll, DefaultTellRetryPolicy).
+- `TellRetryPolicy` — Function type `func(attempts int, lastErr error) (bool, time.Duration)` determining retry behavior for failed Tell messages. Return `(false, _)` to dead-letter immediately.
+- `DefaultTellRetryPolicy` — Exponential backoff policy: up to 5 attempts, starting at 1s, capped at 60s.
 - `Checkpoint` — Serializable actor state snapshot for recovery.
 - `WithoutOutboxID` — Context helper that strips the propagated outbox ID so child operations do not inherit the parent's delivery tracking scope.
 - `Promise[T]` / `Future[T]` — Async result types for Ask-pattern responses.

--- a/chainbackends/AGENTS.md
+++ b/chainbackends/AGENTS.md
@@ -2,23 +2,48 @@
 
 ## Purpose
 
-Concrete implementations of the `chainsource.ChainBackend` interface. Currently
-provides `LNDBackend` wrapping lnd's chainntnfs for real-time chain
-notifications and fee estimation.
+Concrete implementations of the `chainsource.ChainBackend` interface. Provides
+`LNDBackend` wrapping lnd's chainntnfs for real-time chain notifications, fee
+estimation, and optional v3 package relay via a pluggable `PackageSubmitter`.
 
 ## Key Types
 
-- `LNDBackend` — Full-node backend wrapping lnd's chain notification and fee estimation interfaces.
+- `LNDBackend` — Full-node backend wrapping lnd's chain notification and fee
+  estimation interfaces. Accepts an optional `PackageSubmitter` for v3 CPFP
+  package relay (set via `SetPackageSubmitter`).
+- `TxBroadcaster` — Interface over transaction broadcasting (wraps
+  lndclient.WalletKitClient or in-process lnd).
+- `PackageSubmitter` — Optional interface for v3 package relay:
+  `SubmitPackage(ctx, parents, child, maxFeeRate)`. Set on `LNDBackend` post-
+  construction; absent in environments that do not support package relay.
+- `LndClientTxBroadcaster` — Implements `TxBroadcaster` using
+  `lndclient.WalletKitClient`.
+- `LndClientFeeEstimator` — Implements `chainfee.Estimator` using
+  `lndclient.WalletKitClient` with a 30-second per-call timeout.
+- `LndClientChainNotifier` / `LndClientChainNotifierConfig` — Implements
+  `chainntnfs.ChainNotifier` using lndclient. Uses a 15-second registration
+  timeout and goroutine-based forwarding to bridge lndclient's height-only
+  block events to the full `chainntnfs` interface.
+- `LNDBackendFromLndClientConfig` — Config struct for building an `LNDBackend`
+  from lndclient services (notifier, wallet kit, chain kit).
+- `NewLNDBackendFromLndClient(cfg)` — Factory constructing a full `LNDBackend`
+  from an `LNDBackendFromLndClientConfig`.
 
 ## Relationships
 
 - **Depends on**: `chainsource` (implements `ChainBackend` interface).
-- **Depended on by**: `darepod` (instantiates backend).
+- **Depended on by**: `darepod` (instantiates backend and wires PackageSubmitter
+  from harness config).
 
 ## Invariants
 
 - `LNDBackend` requires an lnd instance (local or remote via lndclient).
 - Provides real-time notifications via lnd's chainntnfs package.
+- `PackageSubmitter` is optional; `LNDBackend.SubmitPackage` returns an error
+  when no submitter is set. The test harness injects
+  `BitcoindPackageSubmitter` via `darepod.Config.PackageSubmitter`.
+- `LndClientChainNotifier` enforces a 15-second timeout on registration to
+  prevent hanging under LND block load.
 - Log messages use canonical txid strings (not reversed byte slices).
 
 ## Deep Docs

--- a/chainbackends/CLAUDE.md
+++ b/chainbackends/CLAUDE.md
@@ -2,23 +2,48 @@
 
 ## Purpose
 
-Concrete implementations of the `chainsource.ChainBackend` interface. Currently
-provides `LNDBackend` wrapping lnd's chainntnfs for real-time chain
-notifications and fee estimation.
+Concrete implementations of the `chainsource.ChainBackend` interface. Provides
+`LNDBackend` wrapping lnd's chainntnfs for real-time chain notifications, fee
+estimation, and optional v3 package relay via a pluggable `PackageSubmitter`.
 
 ## Key Types
 
-- `LNDBackend` — Full-node backend wrapping lnd's chain notification and fee estimation interfaces.
+- `LNDBackend` — Full-node backend wrapping lnd's chain notification and fee
+  estimation interfaces. Accepts an optional `PackageSubmitter` for v3 CPFP
+  package relay (set via `SetPackageSubmitter`).
+- `TxBroadcaster` — Interface over transaction broadcasting (wraps
+  lndclient.WalletKitClient or in-process lnd).
+- `PackageSubmitter` — Optional interface for v3 package relay:
+  `SubmitPackage(ctx, parents, child, maxFeeRate)`. Set on `LNDBackend` post-
+  construction; absent in environments that do not support package relay.
+- `LndClientTxBroadcaster` — Implements `TxBroadcaster` using
+  `lndclient.WalletKitClient`.
+- `LndClientFeeEstimator` — Implements `chainfee.Estimator` using
+  `lndclient.WalletKitClient` with a 30-second per-call timeout.
+- `LndClientChainNotifier` / `LndClientChainNotifierConfig` — Implements
+  `chainntnfs.ChainNotifier` using lndclient. Uses a 15-second registration
+  timeout and goroutine-based forwarding to bridge lndclient's height-only
+  block events to the full `chainntnfs` interface.
+- `LNDBackendFromLndClientConfig` — Config struct for building an `LNDBackend`
+  from lndclient services (notifier, wallet kit, chain kit).
+- `NewLNDBackendFromLndClient(cfg)` — Factory constructing a full `LNDBackend`
+  from an `LNDBackendFromLndClientConfig`.
 
 ## Relationships
 
 - **Depends on**: `chainsource` (implements `ChainBackend` interface).
-- **Depended on by**: `darepod` (instantiates backend).
+- **Depended on by**: `darepod` (instantiates backend and wires PackageSubmitter
+  from harness config).
 
 ## Invariants
 
 - `LNDBackend` requires an lnd instance (local or remote via lndclient).
 - Provides real-time notifications via lnd's chainntnfs package.
+- `PackageSubmitter` is optional; `LNDBackend.SubmitPackage` returns an error
+  when no submitter is set. The test harness injects
+  `BitcoindPackageSubmitter` via `darepod.Config.PackageSubmitter`.
+- `LndClientChainNotifier` enforces a 15-second timeout on registration to
+  prevent hanging under LND block load.
 - Log messages use canonical txid strings (not reversed byte slices).
 
 ## Deep Docs

--- a/chainsource/AGENTS.md
+++ b/chainsource/AGENTS.md
@@ -4,24 +4,58 @@
 
 Chain backend abstraction layer providing a blockchain interface for fee
 estimation, broadcasting, and event-driven monitoring of confirmations, spends,
-and new blocks.
+and new blocks. Exposes a full actor message hierarchy for bidirectional actor
+communication alongside the raw registration API.
 
 ## Key Types
 
-- `ChainBackend` — Interface: EstimateFee, BestBlock, BroadcastTx, TestMempoolAccept, RegisterConf/Spend/Blocks.
-- `ChainSourceActor` — Factory actor spawning sub-actors for each monitoring request.
-- `ConfRegistration` / `SpendRegistration` / `BlockRegistration` — Structs with buffered channels and Cancel.
+- `ChainBackend` — Interface: `EstimateFee`, `BestBlock`, `BroadcastTx`,
+  `TestMempoolAccept`, `RegisterConf/Spend/Blocks`, `SubmitPackage`, `Start/Stop`.
+- `ChainSourceActor` — Factory actor spawning sub-actors for each monitoring
+  request. Registered under `ChainSourceKey`.
+- `ChainSourceConfig` — Config struct: `Backend ChainBackend`, `System
+  *actor.ActorSystem`, `Log fn.Option[btclog.Logger]`.
+- `ChainSourceMsg` / `ChainSourceResp` — Sealed actor message interfaces for
+  requests and responses sent to the `ChainSourceActor`.
+- `FeeEstimateRequest/Response`, `BestHeightRequest/Response`,
+  `BroadcastTxRequest/Response`, `TestMempoolAcceptRequest/Response`,
+  `SubmitPackageRequest/Response` — Request/response pairs implementing
+  `ChainSourceMsg`/`ChainSourceResp`.
+- `ConfMsg` / `ConfResp` — Sealed interfaces for confirmation sub-actor messages.
+- `RegisterConfRequest/Response`, `UnregisterConfRequest/Response` — Request
+  types for conf-actor lifecycle. `RegisterConfRequest` carries an optional
+  `NotifyActor fn.Option[actor.TellOnlyRef[ConfirmationEvent]]` for async-mode
+  notification without blocking on a Future.
+- `SpendMsg` / `SpendResp` — Sealed interfaces for spend sub-actor messages.
+- `RegisterSpendRequest/Response`, `UnregisterSpendRequest/Response` — Spend
+  monitoring lifecycle.
+- `EpochMsg` / `EpochResp` — Sealed interfaces for block-epoch sub-actor.
+- `SubscribeBlocksRequest/Response`, `UnsubscribeBlocksRequest/Response` —
+  Block subscription lifecycle.
+- `ConfRegistration` / `SpendRegistration` / `BlockRegistration` — Structs with
+  buffered notification channels and a `Cancel()` function.
+- `ConfirmationEvent`, `SpendEvent`, `BlockEpoch` — Notification payload types.
+- `MapBlockEpoch`, `MapConfirmationEvent`, `MapSpendEvent` — Generic helpers
+  that wrap a target `TellOnlyRef[Out]` and a mapping function, producing a
+  `TellOnlyRef` of the source event type for actor-to-actor notification wiring.
 
 ## Relationships
 
 - **Depends on**: `baselib/actor` (ActorSystem, ActorBehavior, ServiceKey).
-- **Depended on by**: `round`, `vtxo`, `wallet` (monitoring), `chainbackends` (implements interface), `darepod` (wiring).
+- **Depended on by**: `round`, `vtxo`, `wallet` (monitoring), `chainbackends`
+  (implements `ChainBackend`), `btcwbackend`, `lwwallet` (also implement
+  `ChainBackend`), `darepod` (wiring).
 
 ## Invariants
 
-- `ChainBackend` is an interface; implementations live in `chainbackends`.
-- Each monitoring request spawns a dedicated sub-actor (no shared state between monitors).
+- `ChainBackend` is an interface; implementations live in `chainbackends`,
+  `btcwbackend`, and `lwwallet`.
+- Each monitoring request spawns a dedicated sub-actor (no shared state between
+  monitors).
 - Registration channels are buffered.
+- Confirmation sub-actors support two notification modes: Future-based (blocking
+  await) and actor-based (async `Tell` via `NotifyActor`). Callers use the actor
+  mode when blocking inside a durable actor transaction is unsafe.
 
 ## Deep Docs
 

--- a/chainsource/CLAUDE.md
+++ b/chainsource/CLAUDE.md
@@ -4,24 +4,58 @@
 
 Chain backend abstraction layer providing a blockchain interface for fee
 estimation, broadcasting, and event-driven monitoring of confirmations, spends,
-and new blocks.
+and new blocks. Exposes a full actor message hierarchy for bidirectional actor
+communication alongside the raw registration API.
 
 ## Key Types
 
-- `ChainBackend` — Interface: EstimateFee, BestBlock, BroadcastTx, TestMempoolAccept, RegisterConf/Spend/Blocks.
-- `ChainSourceActor` — Factory actor spawning sub-actors for each monitoring request.
-- `ConfRegistration` / `SpendRegistration` / `BlockRegistration` — Structs with buffered channels and Cancel.
+- `ChainBackend` — Interface: `EstimateFee`, `BestBlock`, `BroadcastTx`,
+  `TestMempoolAccept`, `RegisterConf/Spend/Blocks`, `SubmitPackage`, `Start/Stop`.
+- `ChainSourceActor` — Factory actor spawning sub-actors for each monitoring
+  request. Registered under `ChainSourceKey`.
+- `ChainSourceConfig` — Config struct: `Backend ChainBackend`, `System
+  *actor.ActorSystem`, `Log fn.Option[btclog.Logger]`.
+- `ChainSourceMsg` / `ChainSourceResp` — Sealed actor message interfaces for
+  requests and responses sent to the `ChainSourceActor`.
+- `FeeEstimateRequest/Response`, `BestHeightRequest/Response`,
+  `BroadcastTxRequest/Response`, `TestMempoolAcceptRequest/Response`,
+  `SubmitPackageRequest/Response` — Request/response pairs implementing
+  `ChainSourceMsg`/`ChainSourceResp`.
+- `ConfMsg` / `ConfResp` — Sealed interfaces for confirmation sub-actor messages.
+- `RegisterConfRequest/Response`, `UnregisterConfRequest/Response` — Request
+  types for conf-actor lifecycle. `RegisterConfRequest` carries an optional
+  `NotifyActor fn.Option[actor.TellOnlyRef[ConfirmationEvent]]` for async-mode
+  notification without blocking on a Future.
+- `SpendMsg` / `SpendResp` — Sealed interfaces for spend sub-actor messages.
+- `RegisterSpendRequest/Response`, `UnregisterSpendRequest/Response` — Spend
+  monitoring lifecycle.
+- `EpochMsg` / `EpochResp` — Sealed interfaces for block-epoch sub-actor.
+- `SubscribeBlocksRequest/Response`, `UnsubscribeBlocksRequest/Response` —
+  Block subscription lifecycle.
+- `ConfRegistration` / `SpendRegistration` / `BlockRegistration` — Structs with
+  buffered notification channels and a `Cancel()` function.
+- `ConfirmationEvent`, `SpendEvent`, `BlockEpoch` — Notification payload types.
+- `MapBlockEpoch`, `MapConfirmationEvent`, `MapSpendEvent` — Generic helpers
+  that wrap a target `TellOnlyRef[Out]` and a mapping function, producing a
+  `TellOnlyRef` of the source event type for actor-to-actor notification wiring.
 
 ## Relationships
 
 - **Depends on**: `baselib/actor` (ActorSystem, ActorBehavior, ServiceKey).
-- **Depended on by**: `round`, `vtxo`, `wallet` (monitoring), `chainbackends` (implements interface), `darepod` (wiring).
+- **Depended on by**: `round`, `vtxo`, `wallet` (monitoring), `chainbackends`
+  (implements `ChainBackend`), `btcwbackend`, `lwwallet` (also implement
+  `ChainBackend`), `darepod` (wiring).
 
 ## Invariants
 
-- `ChainBackend` is an interface; implementations live in `chainbackends`.
-- Each monitoring request spawns a dedicated sub-actor (no shared state between monitors).
+- `ChainBackend` is an interface; implementations live in `chainbackends`,
+  `btcwbackend`, and `lwwallet`.
+- Each monitoring request spawns a dedicated sub-actor (no shared state between
+  monitors).
 - Registration channels are buffered.
+- Confirmation sub-actors support two notification modes: Future-based (blocking
+  await) and actor-based (async `Tell` via `NotifyActor`). Callers use the actor
+  mode when blocking inside a durable actor transaction is unsafe.
 
 ## Deep Docs
 

--- a/darepod/AGENTS.md
+++ b/darepod/AGENTS.md
@@ -10,7 +10,7 @@ gRPC API.
 
 - `Server` — Main daemon owning wallet, DB, chainsource actor, gRPC server, and ActorSystem. Caches `localMailboxID` (pubkey-derived), `authSigHex` (Schnorr auth) and a single `clk` (`clock.Clock`) that all sub-stores share for deterministic time injection.
 - `RPCServer` — Implements the gRPC `DaemonService` API (Board, ListRounds, WatchRounds, NewOORReceiveScript, SendVTXO, etc.). Includes test hooks for mailbox edge factory and round registration. Holds an in-memory `customInputLocks` map (guarded by `customInputLocksMu`) that reserves custom OOR input outpoints for the duration of a `SendOOR` call to prevent concurrent callers from double-signing the same custom input.
-- `Config` — Daemon configuration (data dir, network, RPC host, wallet type, etc.). Includes `MailboxEdgeFactory` hook for test harness transport interception.
+- `Config` — Daemon configuration (data dir, network, RPC host, wallet type, etc.). Includes `MailboxEdgeFactory` hook for test harness transport interception and `PackageSubmitter chainbackends.PackageSubmitter` for injecting a v3 CPFP package submitter (set by the test harness via `BitcoindPackageSubmitter`; not serialized to config files).
 - `TriggerRoundRegistration` — Test-hook method that injects a round registration event into the round actor (in `server_round_testhook.go`).
 - `GetStoredVTXO` — Harness-only accessor that returns a persisted `vtxo.Descriptor` for a given outpoint directly from the daemon's VTXO store. Lets integration tests inspect partial unroll state without reaching into internal fields.
 - `WalletState` — Enum (None/Locked/Ready) for wallet lifecycle.

--- a/darepod/CLAUDE.md
+++ b/darepod/CLAUDE.md
@@ -10,7 +10,7 @@ gRPC API.
 
 - `Server` — Main daemon owning wallet, DB, chainsource actor, gRPC server, and ActorSystem. Caches `localMailboxID` (pubkey-derived), `authSigHex` (Schnorr auth) and a single `clk` (`clock.Clock`) that all sub-stores share for deterministic time injection.
 - `RPCServer` — Implements the gRPC `DaemonService` API (Board, ListRounds, WatchRounds, NewOORReceiveScript, SendVTXO, etc.). Includes test hooks for mailbox edge factory and round registration. Holds an in-memory `customInputLocks` map (guarded by `customInputLocksMu`) that reserves custom OOR input outpoints for the duration of a `SendOOR` call to prevent concurrent callers from double-signing the same custom input.
-- `Config` — Daemon configuration (data dir, network, RPC host, wallet type, etc.). Includes `MailboxEdgeFactory` hook for test harness transport interception.
+- `Config` — Daemon configuration (data dir, network, RPC host, wallet type, etc.). Includes `MailboxEdgeFactory` hook for test harness transport interception and `PackageSubmitter chainbackends.PackageSubmitter` for injecting a v3 CPFP package submitter (set by the test harness via `BitcoindPackageSubmitter`; not serialized to config files).
 - `TriggerRoundRegistration` — Test-hook method that injects a round registration event into the round actor (in `server_round_testhook.go`).
 - `GetStoredVTXO` — Harness-only accessor that returns a persisted `vtxo.Descriptor` for a given outpoint directly from the daemon's VTXO store. Lets integration tests inspect partial unroll state without reaching into internal fields.
 - `WalletState` — Enum (None/Locked/Ready) for wallet lifecycle.

--- a/db/AGENTS.md
+++ b/db/AGENTS.md
@@ -10,7 +10,13 @@ and client-side fee accounting. Supports SQLite and PostgreSQL backends.
 
 - `BatchedTx[Q]` — Generic interface for atomic transactions (`ExecTx`, `Backend`).
 - `BoardingStore` — Interface for boarding intent persistence (CreateBoardingIntent, FetchByOutpoint, ListActive).
-- `RoundStore` — Interface for round state persistence (CommitState, FetchState, ListRoundsPaginated).
+- `RoundStore` — Interface for round state persistence. Covers the full round
+  lifecycle: `InsertRound`, `GetRound`, `GetRoundByCommitmentTxid`,
+  `ListActiveRounds`, `ListRoundsByStatus`, `UpdateRoundStatus`,
+  `FinalizeRound`; boarding-intent queries (`InsertRoundBoardingIntent`,
+  `GetRoundBoardingIntents`); VTXO-request queries (`InsertRoundVtxoRequest`,
+  `GetRoundVtxoRequests`); and client-tree queries (`InsertRoundClientTree`,
+  `GetRoundClientTrees`, `InsertClientTreeTxid`).
 - `RoundPersistenceStore` — Concrete implementation wrapping `BatchedTx[RoundStore]` with domain conversion.
 - `RoundSummary` / `VTXOSummary` — Lightweight descriptors for paginated round listing (avoids deserializing full trees).
 - `VTXOPersistenceStore` — Persistent store for VTXO descriptors (InsertClientVTXO, FetchByOutpoint). Persists `ChainDepth` (OOR hop count) alongside other VTXO metadata.

--- a/db/CLAUDE.md
+++ b/db/CLAUDE.md
@@ -10,7 +10,13 @@ and client-side fee accounting. Supports SQLite and PostgreSQL backends.
 
 - `BatchedTx[Q]` — Generic interface for atomic transactions (`ExecTx`, `Backend`).
 - `BoardingStore` — Interface for boarding intent persistence (CreateBoardingIntent, FetchByOutpoint, ListActive).
-- `RoundStore` — Interface for round state persistence (CommitState, FetchState, ListRoundsPaginated).
+- `RoundStore` — Interface for round state persistence. Covers the full round
+  lifecycle: `InsertRound`, `GetRound`, `GetRoundByCommitmentTxid`,
+  `ListActiveRounds`, `ListRoundsByStatus`, `UpdateRoundStatus`,
+  `FinalizeRound`; boarding-intent queries (`InsertRoundBoardingIntent`,
+  `GetRoundBoardingIntents`); VTXO-request queries (`InsertRoundVtxoRequest`,
+  `GetRoundVtxoRequests`); and client-tree queries (`InsertRoundClientTree`,
+  `GetRoundClientTrees`, `InsertClientTreeTxid`).
 - `RoundPersistenceStore` — Concrete implementation wrapping `BatchedTx[RoundStore]` with domain conversion.
 - `RoundSummary` / `VTXOSummary` — Lightweight descriptors for paginated round listing (avoids deserializing full trees).
 - `VTXOPersistenceStore` — Persistent store for VTXO descriptors (InsertClientVTXO, FetchByOutpoint). Persists `ChainDepth` (OOR hop count) alongside other VTXO metadata.

--- a/harness/AGENTS.md
+++ b/harness/AGENTS.md
@@ -5,9 +5,20 @@
 Docker-based Bitcoin/LND integration test environment. Manages bitcoind and LND
 containers with network isolation for end-to-end testing.
 
+## Key Types
+
+- `Harness` — Top-level test harness owning bitcoind, lnd, and arkd lifecycle.
+- `BitcoindPackageSubmitter` — Implements `chainbackends.PackageSubmitter` via
+  direct bitcoind JSON-RPC. Injected into `darepod.Config.PackageSubmitter` to
+  enable v3 CPFP package submission in integration tests without going through
+  LND. Constructor: `NewBitcoindPackageSubmitter(host, user, password)`.
+- `LndInstance` — Manages an LND container's lifecycle and connection.
+- `TapdHarness` — Optional Tapd instance for asset-related tests.
+
 ## Relationships
 
-- **Depends on**: `chain` (bitcoind RPC), `lndbackend` (LND integration).
+- **Depends on**: `chain` (bitcoind RPC), `lndbackend` (LND integration),
+  `chainbackends` (PackageSubmitter interface).
 - **Depended on by**: `systest` (system-level tests).
 
 ## Key Constants

--- a/harness/CLAUDE.md
+++ b/harness/CLAUDE.md
@@ -5,9 +5,20 @@
 Docker-based Bitcoin/LND integration test environment. Manages bitcoind and LND
 containers with network isolation for end-to-end testing.
 
+## Key Types
+
+- `Harness` — Top-level test harness owning bitcoind, lnd, and arkd lifecycle.
+- `BitcoindPackageSubmitter` — Implements `chainbackends.PackageSubmitter` via
+  direct bitcoind JSON-RPC. Injected into `darepod.Config.PackageSubmitter` to
+  enable v3 CPFP package submission in integration tests without going through
+  LND. Constructor: `NewBitcoindPackageSubmitter(host, user, password)`.
+- `LndInstance` — Manages an LND container's lifecycle and connection.
+- `TapdHarness` — Optional Tapd instance for asset-related tests.
+
 ## Relationships
 
-- **Depends on**: `chain` (bitcoind RPC), `lndbackend` (LND integration).
+- **Depends on**: `chain` (bitcoind RPC), `lndbackend` (LND integration),
+  `chainbackends` (PackageSubmitter interface).
 - **Depended on by**: `systest` (system-level tests).
 
 ## Key Constants

--- a/lndbackend/AGENTS.md
+++ b/lndbackend/AGENTS.md
@@ -11,7 +11,9 @@ and proof key signing via LND.
 - `BoardingBackend` — Struct holding `walletKit lndclient.WalletKitClient` and
   `chainKit lndclient.ChainKitClient`. Implements `wallet.BoardingBackend`.
   `GetTransaction` returns `*wallet.TxInfo`; `GetBlock` fetches raw blocks via
-  `chainKit`.
+  `chainKit`. Exposes `WalletKit() lndclient.WalletKitClient` for callers that
+  need operations beyond the `BoardingBackend` interface (e.g., building the
+  `LndClientTxBroadcaster` in `chainbackends`).
 - `ProofKeyBackend` — Implements `proofkeys.Backend` for LND-backed key
   derivation and Schnorr proof signing. Wraps `walletKit` for `DeriveKey`,
   `DeriveNextKey`, and produces `indexer.SchnorrSigner` instances.

--- a/lndbackend/CLAUDE.md
+++ b/lndbackend/CLAUDE.md
@@ -11,7 +11,9 @@ and proof key signing via LND.
 - `BoardingBackend` — Struct holding `walletKit lndclient.WalletKitClient` and
   `chainKit lndclient.ChainKitClient`. Implements `wallet.BoardingBackend`.
   `GetTransaction` returns `*wallet.TxInfo`; `GetBlock` fetches raw blocks via
-  `chainKit`.
+  `chainKit`. Exposes `WalletKit() lndclient.WalletKitClient` for callers that
+  need operations beyond the `BoardingBackend` interface (e.g., building the
+  `LndClientTxBroadcaster` in `chainbackends`).
 - `ProofKeyBackend` — Implements `proofkeys.Backend` for LND-backed key
   derivation and Schnorr proof signing. Wraps `walletKit` for `DeriveKey`,
   `DeriveNextKey`, and produces `indexer.SchnorrSigner` instances.

--- a/lwwallet/AGENTS.md
+++ b/lwwallet/AGENTS.md
@@ -11,6 +11,18 @@ Implements `wallet.BoardingBackend`, `input.Signer` + MuSig2, and
 
 - `BoardingBackendAdapter` — Implements `wallet.BoardingBackend`. Queries Esplora directly for UTXOs (bypasses btcwallet's UTXO tracking because btcwallet skips credit marking for non-default key scopes like m/1017').
 - `GetTransaction` / `GetBlock` — Methods on `BoardingBackendAdapter` for fetching raw tx/block data from Esplora. `GetTransaction` returns `*wallet.TxInfo` (containing tx, block hash, and block height).
+- `ChainBackend` — Implements `chainsource.ChainBackend` via Esplora polling.
+  Constructor: `NewChainBackend(esplora, pollInterval, logger)`. Maintains
+  registration maps (`confRegs`, `spendRegs`, `blockRegs`) protected by a
+  mutex. A `poll()` loop checks for new blocks and processes pending
+  confirmation/spend registrations on each tick.
+- `EsploraClient` — HTTP REST client for the Esplora/mempool.space API.
+  Constructor: `NewEsploraClient(baseURL, logger)`. Provides methods for tip
+  height, block hash, tx status, raw tx/block, script UTXOs, outspend queries,
+  fee estimates, transaction broadcast, and package submission.
+- `EsploraChainService` — btcwallet `chain.Interface` adapter over
+  `EsploraClient`, used to give btcwallet an Esplora-backed chain source for
+  address-credit marking.
 
 ## Relationships
 

--- a/lwwallet/CLAUDE.md
+++ b/lwwallet/CLAUDE.md
@@ -11,6 +11,18 @@ Implements `wallet.BoardingBackend`, `input.Signer` + MuSig2, and
 
 - `BoardingBackendAdapter` — Implements `wallet.BoardingBackend`. Queries Esplora directly for UTXOs (bypasses btcwallet's UTXO tracking because btcwallet skips credit marking for non-default key scopes like m/1017').
 - `GetTransaction` / `GetBlock` — Methods on `BoardingBackendAdapter` for fetching raw tx/block data from Esplora. `GetTransaction` returns `*wallet.TxInfo` (containing tx, block hash, and block height).
+- `ChainBackend` — Implements `chainsource.ChainBackend` via Esplora polling.
+  Constructor: `NewChainBackend(esplora, pollInterval, logger)`. Maintains
+  registration maps (`confRegs`, `spendRegs`, `blockRegs`) protected by a
+  mutex. A `poll()` loop checks for new blocks and processes pending
+  confirmation/spend registrations on each tick.
+- `EsploraClient` — HTTP REST client for the Esplora/mempool.space API.
+  Constructor: `NewEsploraClient(baseURL, logger)`. Provides methods for tip
+  height, block hash, tx status, raw tx/block, script UTXOs, outspend queries,
+  fee estimates, transaction broadcast, and package submission.
+- `EsploraChainService` — btcwallet `chain.Interface` adapter over
+  `EsploraClient`, used to give btcwallet an Esplora-backed chain source for
+  address-credit marking.
 
 ## Relationships
 


### PR DESCRIPTION
## Summary

- Updated per-package CLAUDE.md/AGENTS.md for 8 packages changed since the last sweep (ba1cb90)
- Added new types to `baselib/actor` (`DurableActorConfig`, `TellRetryPolicy`, `DefaultTellRetryPolicy`, `DefaultDurableActorConfig`)
- Expanded `chainbackends` docs with new `TxBroadcaster`, `PackageSubmitter`, and lndclient adapter types
- Expanded `chainsource` docs with full actor message hierarchy (`ChainSourceMsg/Resp`, `ConfMsg/Resp`, `SpendMsg/Resp`, `EpochMsg/Resp`, mapper helpers)
- Added `ChainBackend`, `EsploraClient`, `EsploraChainService` to `lwwallet`
- Added `BitcoindPackageSubmitter` to `harness`
- Updated `db.RoundStore` description to reflect expanded interface
- Updated `darepod.Config` with new `PackageSubmitter` field, `lndbackend.BoardingBackend` with `WalletKit()` accessor
- Updated `ARCHITECTURE.md` `chainbackends` description

## Review

Please review the updated CLAUDE.md/AGENTS.md diffs in the changed packages and ARCHITECTURE.md.

Workflow run: automated nightly doc-gardening sweep 2026-04-21

🤖 Generated with [Claude Code](https://claude.com/claude-code)