### PR TITLE
docs: nightly doc-gardening sweep 2026-04-22

### DIFF
--- a/btcwbackend/AGENTS.md
+++ b/btcwbackend/AGENTS.md
@@ -12,12 +12,17 @@ or LND node.
 - `Wallet` — Top-level wallet wrapping `walletcore.Wallet` with neutrino chain service, chain backend, and boarding adapter. Constructors: `New` (owns neutrino lifecycle) and `NewWithNeutrino` (reuses pre-started service).
 - `NeutrinoService` — Manages the neutrino `ChainService`, its bbolt DB, and lifecycle. Pre-started by the daemon for early P2P sync.
 - `ChainBackend` — Implements `chainsource.ChainBackend` using neutrino's native `ChainNotifier` for confirmation tracking, spend detection, and fee estimation.
-- `BoardingBackendAdapter` — Implements `wallet.BoardingBackend` by embedding `walletcore.BoardingBackendBase` and adding neutrino-backed `ListUnspent`, `GetTransaction`, and `GetBlock`.
+- `BoardingBackendAdapter` — Implements `wallet.BoardingBackend` and
+  `wallet.OutputLeaser` by embedding `walletcore.BoardingBackendBase` and
+  adding neutrino-backed `ListUnspent`, `GetTransaction`, and `GetBlock`.
+  `LeaseOutput` / `ReleaseOutput` forward to btcwallet's native
+  coin-selection lock table; btcwallet persists leases across restarts so
+  a reserved UTXO stays excluded even if the daemon restarts mid-bump.
 - `Config` — Embeds `walletcore.Config` and adds neutrino-specific fields (peers, fee URL, persist filters).
 
 ## Relationships
 
-- **Depends on**: `walletcore` (shared wallet/boarding base), `chainsource` (ChainBackend interface), `wallet` (BoardingBackend interface), `build` (logging).
+- **Depends on**: `walletcore` (shared wallet/boarding base), `chainsource` (ChainBackend interface), `wallet` (BoardingBackend and OutputLeaser interfaces), `build` (logging).
 - **Depended on by**: `darepod` (daemon startup and wallet lifecycle).
 
 ## Invariants

--- a/btcwbackend/CLAUDE.md
+++ b/btcwbackend/CLAUDE.md
@@ -12,12 +12,17 @@ or LND node.
 - `Wallet` — Top-level wallet wrapping `walletcore.Wallet` with neutrino chain service, chain backend, and boarding adapter. Constructors: `New` (owns neutrino lifecycle) and `NewWithNeutrino` (reuses pre-started service).
 - `NeutrinoService` — Manages the neutrino `ChainService`, its bbolt DB, and lifecycle. Pre-started by the daemon for early P2P sync.
 - `ChainBackend` — Implements `chainsource.ChainBackend` using neutrino's native `ChainNotifier` for confirmation tracking, spend detection, and fee estimation.
-- `BoardingBackendAdapter` — Implements `wallet.BoardingBackend` by embedding `walletcore.BoardingBackendBase` and adding neutrino-backed `ListUnspent`, `GetTransaction`, and `GetBlock`.
+- `BoardingBackendAdapter` — Implements `wallet.BoardingBackend` and
+  `wallet.OutputLeaser` by embedding `walletcore.BoardingBackendBase` and
+  adding neutrino-backed `ListUnspent`, `GetTransaction`, and `GetBlock`.
+  `LeaseOutput` / `ReleaseOutput` forward to btcwallet's native
+  coin-selection lock table; btcwallet persists leases across restarts so
+  a reserved UTXO stays excluded even if the daemon restarts mid-bump.
 - `Config` — Embeds `walletcore.Config` and adds neutrino-specific fields (peers, fee URL, persist filters).
 
 ## Relationships
 
-- **Depends on**: `walletcore` (shared wallet/boarding base), `chainsource` (ChainBackend interface), `wallet` (BoardingBackend interface), `build` (logging).
+- **Depends on**: `walletcore` (shared wallet/boarding base), `chainsource` (ChainBackend interface), `wallet` (BoardingBackend and OutputLeaser interfaces), `build` (logging).
 - **Depended on by**: `darepod` (daemon startup and wallet lifecycle).
 
 ## Invariants

--- a/chainsource/AGENTS.md
+++ b/chainsource/AGENTS.md
@@ -10,7 +10,14 @@ communication alongside the raw registration API.
 ## Key Types
 
 - `ChainBackend` — Interface: `EstimateFee`, `BestBlock`, `BroadcastTx`,
-  `TestMempoolAccept`, `RegisterConf/Spend/Blocks`, `SubmitPackage`, `Start/Stop`.
+  `TestMempoolAccept` (variadic: accepts one or more `*wire.MsgTx`, evaluates
+  as a package when len > 1), `RegisterConf/Spend/Blocks`, `SubmitPackage`,
+  `Start/Stop`.
+- `MempoolAcceptResult` — Per-transaction outcome of a `TestMempoolAccept`
+  call: `Txid chainhash.Hash`, `Accepted bool`, `Reason string`.
+- `ErrPackageMempoolAcceptUnsupported` — Sentinel returned by `ChainBackend`
+  implementations whose underlying RPC cannot evaluate a multi-transaction
+  package. Distinct from a per-tx "rejected" outcome.
 - `ChainSourceActor` — Factory actor spawning sub-actors for each monitoring
   request. Registered under `ChainSourceKey`.
 - `ChainSourceConfig` — Config struct: `Backend ChainBackend`, `System
@@ -21,6 +28,11 @@ communication alongside the raw registration API.
   `BroadcastTxRequest/Response`, `TestMempoolAcceptRequest/Response`,
   `SubmitPackageRequest/Response` — Request/response pairs implementing
   `ChainSourceMsg`/`ChainSourceResp`.
+- `TestMempoolAcceptRequest` — Carries `Txs []*wire.MsgTx` (one tx = single
+  test; multiple = package test). Replaces the former single-`Tx` field.
+- `TestMempoolAcceptResponse` — Carries `Results []MempoolAcceptResult`, one
+  entry per input tx in the same order. Replaces the former `Accepted bool` +
+  `Reason string` flat fields.
 - `ConfMsg` / `ConfResp` — Sealed interfaces for confirmation sub-actor messages.
 - `RegisterConfRequest/Response`, `UnregisterConfRequest/Response` — Request
   types for conf-actor lifecycle. `RegisterConfRequest` carries an optional

--- a/chainsource/CLAUDE.md
+++ b/chainsource/CLAUDE.md
@@ -10,7 +10,14 @@ communication alongside the raw registration API.
 ## Key Types
 
 - `ChainBackend` — Interface: `EstimateFee`, `BestBlock`, `BroadcastTx`,
-  `TestMempoolAccept`, `RegisterConf/Spend/Blocks`, `SubmitPackage`, `Start/Stop`.
+  `TestMempoolAccept` (variadic: accepts one or more `*wire.MsgTx`, evaluates
+  as a package when len > 1), `RegisterConf/Spend/Blocks`, `SubmitPackage`,
+  `Start/Stop`.
+- `MempoolAcceptResult` — Per-transaction outcome of a `TestMempoolAccept`
+  call: `Txid chainhash.Hash`, `Accepted bool`, `Reason string`.
+- `ErrPackageMempoolAcceptUnsupported` — Sentinel returned by `ChainBackend`
+  implementations whose underlying RPC cannot evaluate a multi-transaction
+  package. Distinct from a per-tx "rejected" outcome.
 - `ChainSourceActor` — Factory actor spawning sub-actors for each monitoring
   request. Registered under `ChainSourceKey`.
 - `ChainSourceConfig` — Config struct: `Backend ChainBackend`, `System
@@ -21,6 +28,11 @@ communication alongside the raw registration API.
   `BroadcastTxRequest/Response`, `TestMempoolAcceptRequest/Response`,
   `SubmitPackageRequest/Response` — Request/response pairs implementing
   `ChainSourceMsg`/`ChainSourceResp`.
+- `TestMempoolAcceptRequest` — Carries `Txs []*wire.MsgTx` (one tx = single
+  test; multiple = package test). Replaces the former single-`Tx` field.
+- `TestMempoolAcceptResponse` — Carries `Results []MempoolAcceptResult`, one
+  entry per input tx in the same order. Replaces the former `Accepted bool` +
+  `Reason string` flat fields.
 - `ConfMsg` / `ConfResp` — Sealed interfaces for confirmation sub-actor messages.
 - `RegisterConfRequest/Response`, `UnregisterConfRequest/Response` — Request
   types for conf-actor lifecycle. `RegisterConfRequest` carries an optional

--- a/lwwallet/AGENTS.md
+++ b/lwwallet/AGENTS.md
@@ -9,7 +9,12 @@ Implements `wallet.BoardingBackend`, `input.Signer` + MuSig2, and
 
 ## Key Types
 
-- `BoardingBackendAdapter` — Implements `wallet.BoardingBackend`. Queries Esplora directly for UTXOs (bypasses btcwallet's UTXO tracking because btcwallet skips credit marking for non-default key scopes like m/1017').
+- `BoardingBackendAdapter` — Implements `wallet.BoardingBackend` and
+  `wallet.OutputLeaser`. Queries Esplora directly for UTXOs (bypasses
+  btcwallet's UTXO tracking because btcwallet skips credit marking for
+  non-default key scopes like m/1017'). `LeaseOutput` / `ReleaseOutput`
+  delegate to btcwallet's native coin-selection lock table; `wallet.LockID`
+  is a direct cast to `wtxmgr.LockID` (both are `[32]byte`).
 - `GetTransaction` / `GetBlock` — Methods on `BoardingBackendAdapter` for fetching raw tx/block data from Esplora. `GetTransaction` returns `*wallet.TxInfo` (containing tx, block hash, and block height).
 - `ChainBackend` — Implements `chainsource.ChainBackend` via Esplora polling.
   Constructor: `NewChainBackend(esplora, pollInterval, logger)`. Maintains
@@ -26,7 +31,7 @@ Implements `wallet.BoardingBackend`, `input.Signer` + MuSig2, and
 
 ## Relationships
 
-- **Depends on**: `chainsource` (implements `ChainBackend`), `wallet` (implements `BoardingBackend`).
+- **Depends on**: `chainsource` (implements `ChainBackend`), `wallet` (implements `BoardingBackend` and `OutputLeaser`).
 - **Depended on by**: `darepod` (alternative to LND-backed wallet).
 
 ## Invariants

--- a/lwwallet/CLAUDE.md
+++ b/lwwallet/CLAUDE.md
@@ -9,7 +9,12 @@ Implements `wallet.BoardingBackend`, `input.Signer` + MuSig2, and
 
 ## Key Types
 
-- `BoardingBackendAdapter` — Implements `wallet.BoardingBackend`. Queries Esplora directly for UTXOs (bypasses btcwallet's UTXO tracking because btcwallet skips credit marking for non-default key scopes like m/1017').
+- `BoardingBackendAdapter` — Implements `wallet.BoardingBackend` and
+  `wallet.OutputLeaser`. Queries Esplora directly for UTXOs (bypasses
+  btcwallet's UTXO tracking because btcwallet skips credit marking for
+  non-default key scopes like m/1017'). `LeaseOutput` / `ReleaseOutput`
+  delegate to btcwallet's native coin-selection lock table; `wallet.LockID`
+  is a direct cast to `wtxmgr.LockID` (both are `[32]byte`).
 - `GetTransaction` / `GetBlock` — Methods on `BoardingBackendAdapter` for fetching raw tx/block data from Esplora. `GetTransaction` returns `*wallet.TxInfo` (containing tx, block hash, and block height).
 - `ChainBackend` — Implements `chainsource.ChainBackend` via Esplora polling.
   Constructor: `NewChainBackend(esplora, pollInterval, logger)`. Maintains
@@ -26,7 +31,7 @@ Implements `wallet.BoardingBackend`, `input.Signer` + MuSig2, and
 
 ## Relationships
 
-- **Depends on**: `chainsource` (implements `ChainBackend`), `wallet` (implements `BoardingBackend`).
+- **Depends on**: `chainsource` (implements `ChainBackend`), `wallet` (implements `BoardingBackend` and `OutputLeaser`).
 - **Depended on by**: `darepod` (alternative to LND-backed wallet).
 
 ## Invariants

--- a/wallet/AGENTS.md
+++ b/wallet/AGENTS.md
@@ -10,6 +10,14 @@ refresh, leave, OOR spend, and directed send flows.
 
 ## Key Types
 
+- `LockID` — `[32]byte` caller-scoped identifier used when leasing a wallet
+  output. Each subsystem should derive its own `LockID` from a stable prefix
+  (e.g. first 32 bytes of `sha256("txconfirm")`) to prevent accidental
+  cross-subsystem releases.
+- `OutputLeaser` — Interface for wallet backends that support UTXO leasing:
+  `LeaseOutput(ctx, LockID, OutPoint, expiry) (time.Time, error)` and
+  `ReleaseOutput(ctx, LockID, OutPoint) error`. Shape matches btcwallet and
+  lndclient.WalletKit so backends can delegate directly.
 - `Ark` — Main actor managing boarding addresses, UTXO enumeration, confirmation polling, admission forwarding, and VTXO selection/locking. Holds a `ledgerSink` field (`fn.Option[ledger.Sink]`) used by the `emitUTXOCreated` helper to Tell `UTXOCreatedMsg` to the ledger actor whenever a confirmed wallet UTXO is observed.
 - `NewArk` — Constructor; takes the `ledgerSink` as a **required** argument (`fn.Option[ledger.Sink]`) rather than a setter, so every call site is forced to make an explicit emission choice. Production passes `fn.Some(ledger.NewSink(actorSystem))`; harnesses and unit tests that do not register a ledger actor pass `fn.None[ledger.Sink]()`.
 - `emitUTXOCreated(ctx, utxo, blockHeight, classification)` — Internal helper that null-safely builds a `ledger.UTXOCreatedMsg` from a wallet `Utxo` and Tells it to `ledgerSink`. Negative block heights clamp to `0` rather than wrapping under a direct `uint32` cast; nil `utxo` and `fn.None` sink are silent no-ops.

--- a/wallet/CLAUDE.md
+++ b/wallet/CLAUDE.md
@@ -10,6 +10,14 @@ refresh, leave, OOR spend, and directed send flows.
 
 ## Key Types
 
+- `LockID` — `[32]byte` caller-scoped identifier used when leasing a wallet
+  output. Each subsystem should derive its own `LockID` from a stable prefix
+  (e.g. first 32 bytes of `sha256("txconfirm")`) to prevent accidental
+  cross-subsystem releases.
+- `OutputLeaser` — Interface for wallet backends that support UTXO leasing:
+  `LeaseOutput(ctx, LockID, OutPoint, expiry) (time.Time, error)` and
+  `ReleaseOutput(ctx, LockID, OutPoint) error`. Shape matches btcwallet and
+  lndclient.WalletKit so backends can delegate directly.
 - `Ark` — Main actor managing boarding addresses, UTXO enumeration, confirmation polling, admission forwarding, and VTXO selection/locking. Holds a `ledgerSink` field (`fn.Option[ledger.Sink]`) used by the `emitUTXOCreated` helper to Tell `UTXOCreatedMsg` to the ledger actor whenever a confirmed wallet UTXO is observed.
 - `NewArk` — Constructor; takes the `ledgerSink` as a **required** argument (`fn.Option[ledger.Sink]`) rather than a setter, so every call site is forced to make an explicit emission choice. Production passes `fn.Some(ledger.NewSink(actorSystem))`; harnesses and unit tests that do not register a ledger actor pass `fn.None[ledger.Sink]()`.
 - `emitUTXOCreated(ctx, utxo, blockHeight, classification)` — Internal helper that null-safely builds a `ledger.UTXOCreatedMsg` from a wallet `Utxo` and Tells it to `ledgerSink`. Negative block heights clamp to `0` rather than wrapping under a direct `uint32` cast; nil `utxo` and `fn.None` sink are silent no-ops.


### PR DESCRIPTION
Update per-package CLAUDE.md/AGENTS.md for changes merged since the last
nightly sweep (base: `3ed67aa`).

**Packages updated:**
- `chainsource` — `TestMempoolAccept` interface is now variadic; added
  `MempoolAcceptResult` type and `ErrPackageMempoolAcceptUnsupported` sentinel;
  updated `TestMempoolAcceptRequest` (`.Txs`) and `TestMempoolAcceptResponse`
  (`.Results`) docs.
- `wallet` — Added `LockID` and `OutputLeaser` interface docs.
- `lwwallet` — `BoardingBackendAdapter` now also implements `wallet.OutputLeaser`.
- `btcwbackend` — `BoardingBackendAdapter` now also implements `wallet.OutputLeaser`.

`make doc-check` passes. AGENTS.md files are mirrored from their CLAUDE.md
counterparts in all updated packages.

Please review the diffs in `chainsource/CLAUDE.md`, `wallet/CLAUDE.md`,
`lwwallet/CLAUDE.md`, and `btcwbackend/CLAUDE.md` (plus their AGENTS.md
mirrors). `ARCHITECTURE.md` and `docs/index.md` are unchanged this sweep.
