### PR TITLE
multi: thread dynamic fee awareness through board and send-vtxo

### DIFF
--- a/cmd/darepocli/darepoclicommands/cmd_board.go
+++ b/cmd/darepocli/darepoclicommands/cmd_board.go
@@ -39,6 +39,13 @@ func board(cmd *cobra.Command, _ []string) error {
 
 	resp, err := client.Board(context.Background(), req)
 	if err != nil {
+		// Map well-known server-side fee rejections to a
+		// concise CLI message. Fall through to the generic
+		// error wrap if the cause is not a fee rejection.
+		if feeErr := mapFeeError(err); feeErr != nil {
+			return feeErr
+		}
+
 		return fmt.Errorf("board RPC failed: %w", err)
 	}
 

--- a/cmd/darepocli/darepoclicommands/cmd_send.go
+++ b/cmd/darepocli/darepoclicommands/cmd_send.go
@@ -111,6 +111,13 @@ func sendInRound(cmd *cobra.Command, _ []string) error {
 		context.Background(), req,
 	)
 	if err != nil {
+		// Map well-known server-side fee rejections to a
+		// concise CLI message. Fall through to the generic
+		// error wrap if the cause is not a fee rejection.
+		if feeErr := mapFeeError(err); feeErr != nil {
+			return feeErr
+		}
+
 		return fmt.Errorf("SendVTXO RPC failed: %w", err)
 	}
 

--- a/cmd/darepocli/darepoclicommands/fee_errors.go
+++ b/cmd/darepocli/darepoclicommands/fee_errors.go
@@ -1,0 +1,88 @@
+package darepoclicommands
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Error substrings used to recognize server-side fee rejections.
+// These match the sentinel messages in
+// darepo/rounds/validation.go so the client can surface a concise,
+// actionable CLI error instead of a raw gRPC status that leaks
+// internal percentages and numeric fields.
+//
+// Matching is on substring rather than status code because the
+// daemon wraps upstream errors through proxyUpstreamError, which
+// sanitizes the code and re-wraps the message.
+const (
+	errMsgOperatorFeeTooLow  = "operator fee is below minimum"
+	errMsgVTXOBelowMinViable = "VTXO amount is below minimum viable"
+	// errMsgBoardingTooSmall pins the wallet's exact "balance is
+	// too small after operator fee" rejection at
+	// wallet/wallet.go:1130. We deliberately do NOT match the
+	// shorter "boarding balance" substring because the Board RPC
+	// also wraps internal failures as
+	// "peek boarding balance: ..." (see darepod/rpc_server.go),
+	// and a broad match would silently rewrite those into the
+	// friendly "boarding rejected: balance too small" message
+	// even though the failure has nothing to do with boarding
+	// economics.
+	errMsgBoardingTooSmall    = "too small after operator fee"
+	errMsgEstimateFeeNoConfig = "fee calculator not configured"
+)
+
+// mapFeeError inspects err for well-known server-side fee
+// rejection messages and returns a terse, actionable CLI error
+// that a human can read without grepping the server logs.
+// Returns nil when err does not match any known pattern so the
+// caller can fall through to the original error.
+//
+// Used by sendInRound and boarding-flow callers that want to
+// surface a crisp "too small to refresh" or "fee schedule
+// changed, retry" message rather than leaking the raw gRPC
+// detail.
+func mapFeeError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	msg := err.Error()
+
+	switch {
+	case strings.Contains(msg, errMsgVTXOBelowMinViable):
+		return fmt.Errorf(
+			"send rejected: the VTXO would be below the "+
+				"operator's minimum viable size after "+
+				"fees. Try a larger amount or check "+
+				"the current schedule via `darepocli "+
+				"fees estimate`. (server: %v)", err,
+		)
+
+	case strings.Contains(msg, errMsgOperatorFeeTooLow):
+		return fmt.Errorf(
+			"send rejected: the operator's fee schedule "+
+				"changed between the quote and the "+
+				"submission. Retry the command; the "+
+				"client will quote fresh fees. "+
+				"(server: %v)", err,
+		)
+
+	case strings.Contains(msg, errMsgBoardingTooSmall):
+		return fmt.Errorf(
+			"boarding rejected: the confirmed boarding "+
+				"balance is too small to cover operator "+
+				"fees. Fund the boarding address with a "+
+				"larger amount. (server: %v)", err,
+		)
+
+	case strings.Contains(msg, errMsgEstimateFeeNoConfig):
+		return fmt.Errorf(
+			"operator has not configured a fee calculator; "+
+				"EstimateFee is unavailable. Retry once "+
+				"the operator has enabled fees. "+
+				"(server: %v)", err,
+		)
+	}
+
+	return nil
+}

--- a/cmd/darepocli/darepoclicommands/fee_errors_test.go
+++ b/cmd/darepocli/darepoclicommands/fee_errors_test.go
@@ -1,0 +1,111 @@
+package darepoclicommands
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestMapFeeErrorRecognizesServerSentinels verifies that every
+// server-side fee rejection pattern the CLI cares about gets
+// mapped to a concise actionable message. Matching is substring-
+// based because the daemon sanitizes the upstream gRPC status;
+// this test locks in the substrings we depend on.
+func TestMapFeeErrorRecognizesServerSentinels(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		serverMsg   string
+		wantMatch   string
+		wantNoMatch bool
+	}{
+		{
+			name: "ErrVTXOBelowMinViable",
+			serverMsg: "VTXO amount is below minimum " +
+				"viable threshold: amount 1000 " +
+				"sats, fee 600 sats",
+			wantMatch: "below the operator's minimum viable",
+		},
+		{
+			name: "ErrOperatorFeeTooLow",
+			serverMsg: "operator fee is below minimum: " +
+				"got 100 sats, required 250 sats " +
+				"across 1 boarding inputs",
+			wantMatch: "fee schedule changed",
+		},
+		{
+			// The verbatim wallet error format from
+			// wallet.go's boarding-balance gate; we match
+			// the "too small after operator fee" tail so
+			// internal errors that mention "boarding
+			// balance" but not this specific gate (e.g.
+			// "peek boarding balance: ...") fall through.
+			name: "BoardingTooSmall",
+			serverMsg: "boarding balance (100) too small " +
+				"after operator fee (200)",
+			wantMatch: "boarding balance is too small",
+		},
+		{
+			// Internal Board failure that mentions
+			// "boarding balance" but isn't the wallet's
+			// "too small after operator fee" gate. Must
+			// fall through unmatched so the CLI surfaces
+			// the raw error rather than rewriting it as
+			// the friendly fee-rejection message.
+			name: "BoardingPeekInternalFallsThrough",
+			serverMsg: "peek boarding balance: " +
+				"wallet actor not initialized",
+			wantNoMatch: true,
+		},
+		{
+			name:      "EstimateFeeNoConfig",
+			serverMsg: "fee calculator not configured",
+			wantMatch: "EstimateFee is unavailable",
+		},
+		{
+			name:        "Unrelated",
+			serverMsg:   "network unreachable",
+			wantNoMatch: true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Simulate an incoming gRPC error with an
+			// unwrapped message. mapFeeError works on
+			// substring match so the exact status code
+			// is irrelevant.
+			serverErr := status.Error(
+				codes.InvalidArgument, tc.serverMsg,
+			)
+			mapped := mapFeeError(serverErr)
+			if tc.wantNoMatch {
+				require.Nil(t, mapped)
+				return
+			}
+
+			require.NotNil(t, mapped)
+			require.Contains(t, mapped.Error(), tc.wantMatch)
+			// The original error text is included for
+			// context so operators can still grep the
+			// server logs.
+			require.Contains(t, mapped.Error(), tc.serverMsg)
+		})
+	}
+}
+
+// TestMapFeeErrorNilSafe verifies that a nil input does not
+// panic and returns nil.
+func TestMapFeeErrorNilSafe(t *testing.T) {
+	t.Parallel()
+
+	require.Nil(t, mapFeeError(nil))
+	require.Nil(t, mapFeeError(errors.New("unrelated")))
+}

--- a/darepod/congestion_roundtrip_test.go
+++ b/darepod/congestion_roundtrip_test.go
@@ -1,0 +1,166 @@
+package darepod
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/arkrpc"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+// fakeArkService is a minimal in-memory ArkService that returns
+// a canned EstimateFee response. Used by tests to exercise the
+// client's quoteOperatorFee helper without spinning up the
+// real operator.
+type fakeArkService struct {
+	arkrpc.UnimplementedArkServiceServer
+
+	// response is the canned EstimateFee reply. Tests mutate
+	// this between calls to simulate utilization-driven rate
+	// changes.
+	response *arkrpc.EstimateFeeResponse
+
+	// lastRequest records the most recent EstimateFeeRequest
+	// so tests can assert what the client asked for.
+	lastRequest *arkrpc.EstimateFeeRequest
+}
+
+// EstimateFee records the request and returns the canned reply.
+func (f *fakeArkService) EstimateFee(_ context.Context,
+	req *arkrpc.EstimateFeeRequest) (
+	*arkrpc.EstimateFeeResponse, error) {
+
+	f.lastRequest = req
+
+	return f.response, nil
+}
+
+// newBufconnClient builds a *grpc.ClientConn wired to an
+// in-process arkrpc server backed by the given fakeArkService.
+// Returns the conn and a cleanup func to stop the server.
+func newBufconnClient(t *testing.T,
+	svc *fakeArkService) *grpc.ClientConn {
+
+	t.Helper()
+
+	const bufSize = 1024 * 1024
+	lis := bufconn.Listen(bufSize)
+
+	srv := grpc.NewServer()
+	arkrpc.RegisterArkServiceServer(srv, svc)
+
+	go func() {
+		_ = srv.Serve(lis)
+	}()
+	t.Cleanup(srv.Stop)
+
+	dialer := func(context.Context, string) (net.Conn, error) {
+		return lis.Dial()
+	}
+
+	conn, err := grpc.DialContext(
+		t.Context(), "bufconn",
+		grpc.WithContextDialer(dialer),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err, "dial bufconn")
+	t.Cleanup(func() { _ = conn.Close() })
+
+	return conn
+}
+
+// TestQuoteOperatorFeeRoundTripsCongestionSpread verifies that
+// the client's quoteOperatorFee helper returns exactly the
+// TotalFeeSat the server reports, across a baseline quote and
+// a subsequent utilization-driven quote.
+//
+// This is the client-side half of the congestion round-trip
+// invariant in issue #263 Phase C.4 (4): a client using
+// EstimateFee to size its boarding / refresh must observe the
+// same TotalFeeSat the operator booked, so there is no drift
+// when utilization changes between two client calls.
+func TestQuoteOperatorFeeRoundTripsCongestionSpread(t *testing.T) {
+	t.Parallel()
+
+	svc := &fakeArkService{
+		response: &arkrpc.EstimateFeeResponse{
+			LiquidityFeeSat:     100,
+			OnchainShareSat:     10,
+			MarginSat:           50,
+			TotalFeeSat:         160,
+			EffectiveAnnualRate: 0.05,
+		},
+	}
+
+	// Construct a Server with only the fields quoteOperatorFee
+	// touches: serverConn (non-nil) and no log requirement.
+	s := &Server{
+		serverConn: newBufconnClient(t, svc),
+		log:        btclog.Disabled,
+	}
+
+	// Baseline quote.
+	got, err := s.quoteOperatorFee(
+		t.Context(), 100_000, true /* isBoarding */, 0,
+	)
+	require.NoError(t, err)
+	require.Equal(t, btcutil.Amount(160), got)
+
+	require.NotNil(t, svc.lastRequest)
+	require.Equal(
+		t, int64(100_000), svc.lastRequest.AmountSat,
+	)
+	require.True(t, svc.lastRequest.IsBoarding)
+	require.Equal(t, uint32(0), svc.lastRequest.RemainingBlocks)
+
+	// Simulate a congestion-driven bump in the operator-side
+	// schedule. The fake returns a higher fee on the next
+	// EstimateFee call.
+	svc.response = &arkrpc.EstimateFeeResponse{
+		LiquidityFeeSat:     800,
+		OnchainShareSat:     10,
+		MarginSat:           50,
+		TotalFeeSat:         860,
+		EffectiveAnnualRate: 0.25,
+	}
+
+	got, err = s.quoteOperatorFee(
+		t.Context(), 100_000, false /* isBoarding */, 144,
+	)
+	require.NoError(t, err)
+	require.Equal(
+		t, btcutil.Amount(860), got,
+		"client must report exactly the server's "+
+			"TotalFeeSat, no local caching",
+	)
+	require.Equal(
+		t, uint32(144), svc.lastRequest.RemainingBlocks,
+		"RemainingBlocks must propagate",
+	)
+}
+
+// TestQuoteOperatorFeeNilServerConn asserts the guard for the
+// case where the daemon hasn't dialed the operator yet. Without
+// the guard the helper would panic inside the arkrpc client
+// on a nil conn; the guard turns the panic into a clean
+// Unavailable error so upstream callers can fall back.
+func TestQuoteOperatorFeeNilServerConn(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{
+		serverConn: nil,
+		log:        btclog.Disabled,
+	}
+
+	_, err := s.quoteOperatorFee(
+		t.Context(), 100_000, true, 0,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not initialized")
+}

--- a/darepod/rpc_fees.go
+++ b/darepod/rpc_fees.go
@@ -21,6 +21,60 @@ const (
 	defaultFeeHistoryLimit = 50
 )
 
+// quoteOperatorFee asks the operator's EstimateFee RPC for the
+// dynamic per-operation fee that applies to a boarding or refresh
+// of `amountSat` at the given remainingBlocks. The returned amount
+// is what the client must deduct from the VTXO output so the
+// server's validateOperatorFee check accepts the submission.
+//
+// Back-compat: if the operator is running a zero schedule,
+// TotalFeeSat == 0 and this call reduces to the pre-fee flow. If
+// the operator is unreachable (serverConn nil, RPC failure), the
+// caller is expected to fall back to the legacy flat
+// terms.MinOperatorFee so boarding remains possible in a degraded
+// mode rather than failing outright.
+//
+// Called from Board and SendVTXO so the client's implicit fee
+// matches what the server's validateOperatorFee expects under a
+// non-zero schedule. Without this path the client would keep
+// paying the legacy flat MinOperatorFee and silently overpay
+// under low schedules or trigger ErrOperatorFeeTooLow under
+// high schedules.
+func (s *Server) quoteOperatorFee(ctx context.Context,
+	amountSat int64, isBoarding bool,
+	remainingBlocks uint32) (btcutil.Amount, error) {
+
+	if s.serverConn == nil {
+		return 0, status.Errorf(codes.Unavailable,
+			"operator gRPC connection not initialized")
+	}
+
+	client := arkrpc.NewArkServiceClient(s.serverConn)
+	resp, err := client.EstimateFee(
+		ctx, &arkrpc.EstimateFeeRequest{
+			AmountSat:       amountSat,
+			IsBoarding:      isBoarding,
+			RemainingBlocks: remainingBlocks,
+		},
+	)
+	if err != nil {
+		return 0, err
+	}
+
+	// Defensive nil-guard: well-behaved gRPC servers always return
+	// a non-nil response when err == nil, but a stub or a future
+	// server change that violates the convention would panic on
+	// the field access below. Surface the missing payload as a
+	// clean codes.Internal so the caller can fall back instead of
+	// crashing the daemon.
+	if resp == nil {
+		return 0, status.Errorf(codes.Internal,
+			"operator returned empty fee response")
+	}
+
+	return btcutil.Amount(resp.TotalFeeSat), nil
+}
+
 // EstimateFee proxies the operator's ArkService.EstimateFee RPC over
 // the daemon's direct gRPC connection. The daemon does not cache fee
 // estimates: each call hits the server so the returned numbers reflect

--- a/darepod/rpc_fees_e2e_test.go
+++ b/darepod/rpc_fees_e2e_test.go
@@ -1,0 +1,120 @@
+package darepod
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/arkrpc"
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEstimateFeeProxiesEveryField asserts that the daemon's
+// EstimateFee handler faithfully proxies every field of the
+// operator's EstimateFeeResponse. A regression that dropped any
+// leg (liquidity / on-chain / margin) or the BelowDustWarning
+// boolean would cause the CLI to display a different fee than
+// the operator booked, breaking the client↔server amount-match
+// invariant the issue calls out under C.4 (2).
+func TestEstimateFeeProxiesEveryField(t *testing.T) {
+	t.Parallel()
+
+	svc := &fakeArkService{
+		response: &arkrpc.EstimateFeeResponse{
+			LiquidityFeeSat:     1_234,
+			OnchainShareSat:     56,
+			MarginSat:           789,
+			TotalFeeSat:         2_079,
+			EffectiveAnnualRate: 0.0875,
+			MinViableAmountSat:  500,
+			BelowDustWarning:    true,
+		},
+	}
+
+	s := &Server{
+		serverConn: newBufconnClient(t, svc),
+		log:        btclog.Disabled,
+	}
+	r := &RPCServer{server: s}
+
+	resp, err := r.EstimateFee(
+		t.Context(), &daemonrpc.EstimateFeeRequest{
+			AmountSat:       100_000,
+			IsBoarding:      false,
+			RemainingBlocks: 144,
+		},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// Every field in the operator's reply must round-trip to
+	// the daemon's reply verbatim. No caching, no
+	// re-computation.
+	require.Equal(t, int64(1_234), resp.LiquidityFeeSat)
+	require.Equal(t, int64(56), resp.OnchainShareSat)
+	require.Equal(t, int64(789), resp.MarginSat)
+	require.Equal(t, int64(2_079), resp.TotalFeeSat)
+	require.InDelta(
+		t, 0.0875, resp.EffectiveAnnualRate, 1e-9,
+	)
+	require.Equal(t, int64(500), resp.MinViableAmountSat)
+	require.True(t, resp.BelowDustWarning)
+
+	// And the operator saw the client's request verbatim (no
+	// rewriting of amount or remaining-blocks).
+	require.NotNil(t, svc.lastRequest)
+	require.Equal(t, int64(100_000), svc.lastRequest.AmountSat)
+	require.False(t, svc.lastRequest.IsBoarding)
+	require.Equal(
+		t, uint32(144), svc.lastRequest.RemainingBlocks,
+	)
+}
+
+// TestEstimateFeeAmountMatchesQuoteOperatorFee verifies that
+// the CLI-facing EstimateFee RPC and the internal
+// quoteOperatorFee helper return the SAME TotalFeeSat for the
+// same inputs. Without this invariant the number the user
+// sees in the CLI confirmation prompt would diverge from the
+// number the wallet actor applies during boarding / send, and
+// the server would silently under- or over-charge.
+func TestEstimateFeeAmountMatchesQuoteOperatorFee(t *testing.T) {
+	t.Parallel()
+
+	svc := &fakeArkService{
+		response: &arkrpc.EstimateFeeResponse{
+			LiquidityFeeSat: 250,
+			OnchainShareSat: 10,
+			MarginSat:       100,
+			TotalFeeSat:     360,
+		},
+	}
+
+	s := &Server{
+		serverConn: newBufconnClient(t, svc),
+		log:        btclog.Disabled,
+	}
+	r := &RPCServer{server: s}
+
+	// CLI path.
+	cliResp, err := r.EstimateFee(
+		t.Context(), &daemonrpc.EstimateFeeRequest{
+			AmountSat:       200_000,
+			IsBoarding:      true,
+			RemainingBlocks: 0,
+		},
+	)
+	require.NoError(t, err)
+
+	// Internal-wallet-actor path.
+	internal, err := s.quoteOperatorFee(
+		t.Context(), 200_000, true, 0,
+	)
+	require.NoError(t, err)
+
+	// Both paths must see the same TotalFeeSat so the CLI
+	// confirmation and the actual booking align.
+	require.Equal(
+		t, cliResp.TotalFeeSat, int64(internal),
+		"CLI-visible total must match wallet-used total",
+	)
+}

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -722,8 +722,72 @@ func (r *RPCServer) Board(ctx context.Context,
 			"wallet actor not initialized")
 	}
 	wRef := r.server.walletRef.UnsafeFromSome()
+
+	// Quote the dynamic operator fee for the current confirmed
+	// boarding balance. The server's validateOperatorFee
+	// validates the submitted implicit fee against the schedule-
+	// derived TotalFeeSat; without this quote the client would
+	// keep paying the legacy flat terms.MinOperatorFee and
+	// either silently overpay (when the new schedule is
+	// cheaper) or be rejected with ErrOperatorFeeTooLow (when
+	// the schedule is more expensive than the legacy flat
+	// value).
+	//
+	// The boarding balance is fetched via the wallet's
+	// GetBoardingBalance Ask so the quote is anchored to the
+	// exact value the wallet is about to consume. A small TOCTOU
+	// window remains between this call and the wallet's own
+	// FetchBoardingIntentsByStatus call below, but a new
+	// boarding arrival between the two events would only
+	// produce an under-quote, which the server still accepts
+	// (it only rejects under-quotes vs. the new, larger, amount
+	// when that amount breaks the MinViableVTXOPct policy).
+	balanceFuture := wRef.Ask(ctx, &wallet.GetBoardingBalanceRequest{})
+	balanceResult := balanceFuture.Await(ctx)
+	balanceResp, err := balanceResult.Unpack()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"peek boarding balance: %v", err)
+	}
+	balance, ok := balanceResp.(*wallet.GetBoardingBalanceResponse)
+	if !ok {
+		return nil, status.Errorf(codes.Internal,
+			"unexpected boarding balance response type: %T",
+			balanceResp)
+	}
+
+	// Default to the legacy flat fee. We overwrite it with the
+	// dynamic quote below when the balance is positive and the
+	// operator is reachable; if the quote path fails we log and
+	// fall back rather than refusing to board.
+	//
+	// We pay max(quoted, terms.MinOperatorFee). The legacy flat
+	// fee is the operator's stated lower bound and the round
+	// FSM's pre-flight check at round/transitions.go enforces it,
+	// so paying anything strictly less than terms.MinOperatorFee
+	// would have the client reject its own submission before the
+	// server saw it. When the dynamic quote is the larger of the
+	// two we pay it exactly so the ledger records the true fee.
+	operatorFee := terms.MinOperatorFee
+	if balance.TotalBalance > 0 {
+		quoted, qErr := r.server.quoteOperatorFee(
+			ctx, int64(balance.TotalBalance),
+			true /* isBoarding */, 0,
+		)
+		switch {
+		case qErr != nil:
+			r.server.log.WarnS(ctx,
+				"EstimateFee unavailable; falling back "+
+					"to legacy flat MinOperatorFee",
+				qErr)
+
+		case quoted > terms.MinOperatorFee:
+			operatorFee = quoted
+		}
+	}
+
 	boardReq := &wallet.BoardRequest{
-		MinOperatorFee: terms.MinOperatorFee,
+		MinOperatorFee: operatorFee,
 		DustLimit:      terms.DustLimit,
 	}
 
@@ -869,9 +933,44 @@ func (r *RPCServer) SendVTXO(ctx context.Context,
 
 	wRef := r.server.walletRef.UnsafeFromSome()
 
+	// Quote the dynamic operator fee for this send. SendVTXO
+	// forfeits existing VTXOs and produces new recipient VTXOs
+	// inside a round, so this is a "refresh" from the fee-model
+	// perspective (is_boarding=false). remainingBlocks is left
+	// at zero on purpose: the server's ComputeForfeitFee applies
+	// MinRefreshDeltaBlocks as a floor whenever the request value
+	// is below it, so passing 0 yields the conservative max-floor
+	// quote. The wallet selects forfeit inputs across an arbitrary
+	// set of VTXOs with different remaining horizons; there is no
+	// single "actual" remaining-blocks value to pass here, and
+	// over-quoting (then over-paying) is safer than under-quoting
+	// and being rejected by the server's validateOperatorFee path.
+	//
+	// Like Board, we pay max(quoted, terms.MinOperatorFee) so the
+	// round FSM's pre-flight check at round/transitions.go is
+	// satisfied even when the dynamic schedule sits below the
+	// legacy floor.
+	operatorFee := terms.MinOperatorFee
+	if totalAmount > 0 {
+		quoted, qErr := r.server.quoteOperatorFee(
+			ctx, totalAmount,
+			false /* isBoarding */, 0,
+		)
+		switch {
+		case qErr != nil:
+			r.server.log.WarnS(ctx,
+				"EstimateFee unavailable for SendVTXO; "+
+					"falling back to legacy flat "+
+					"MinOperatorFee", qErr)
+
+		case quoted > terms.MinOperatorFee:
+			operatorFee = quoted
+		}
+	}
+
 	sendReq := &wallet.SendVTXOsRequest{
 		Recipients:    recipients,
-		OperatorFee:   terms.MinOperatorFee,
+		OperatorFee:   operatorFee,
 		DustLimit:     terms.DustLimit,
 		OperatorKey:   terms.PubKey,
 		VTXOExitDelay: terms.VTXOExitDelay,

--- a/round/fees_invariants_test.go
+++ b/round/fees_invariants_test.go
@@ -1,0 +1,255 @@
+package round
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/types"
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+// TestInvariantComputeClientOperatorFeeNonNegative asserts
+// the client-side operator-fee reconciliation always returns a
+// non-negative number. The fee emission path to the ledger
+// silently drops negative values, so a regression that produced
+// a negative fee would surface as a missing ledger row (hard to
+// debug) rather than a crash. This invariant guards against
+// that class of bug.
+func TestInvariantComputeClientOperatorFeeNonNegative(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(rt *rapid.T) {
+		intents, owned := drawIntentsAndOwned(rt)
+		fee := computeClientOperatorFee(intents, owned)
+		require.GreaterOrEqual(
+			rt, fee, int64(0),
+			"computeClientOperatorFee must never return "+
+				"a negative value",
+		)
+	})
+}
+
+// TestInvariantComputeClientOperatorFeeMatchesConservation
+// asserts the fee-conservation identity when outputs ≤ inputs:
+// fee = Σ(inputs) − Σ(outputs). This is the arithmetic
+// contract the ledger emission path depends on; a divergence
+// would cause client-side total_fees_paid to silently drift
+// from the server-booked amount.
+func TestInvariantComputeClientOperatorFeeMatchesConservation(
+	t *testing.T) {
+
+	t.Parallel()
+
+	rapid.Check(t, func(rt *rapid.T) {
+		intents, owned := drawIntentsAndOwned(rt)
+
+		inputs := sumBoarding(intents) + sumForfeits(intents)
+		outputs := sumOwned(owned) + sumLeaves(intents)
+
+		fee := computeClientOperatorFee(intents, owned)
+		if outputs > inputs {
+			// Clamped to zero when outputs exceed inputs.
+			require.Equal(
+				rt, int64(0), fee,
+				"clamp branch must return zero",
+			)
+
+			return
+		}
+
+		require.Equal(
+			rt, inputs-outputs, fee,
+			"fee must equal (inputs - outputs) when "+
+				"non-negative",
+		)
+	})
+}
+
+// TestInvariantComputeClientOperatorFeeMonotoneInBoarding
+// asserts adding a positive boarding input strictly increases
+// the fee (or keeps it at zero when the clamp branch dominates).
+// Any regression that double-counted or ignored a boarding
+// input would violate this invariant.
+func TestInvariantComputeClientOperatorFeeMonotoneInBoarding(
+	t *testing.T) {
+
+	t.Parallel()
+
+	rapid.Check(t, func(rt *rapid.T) {
+		intents, owned := drawIntentsAndOwned(rt)
+		base := computeClientOperatorFee(intents, owned)
+
+		add := rapid.Int64Range(1, 1_000_000).Draw(
+			rt, "extraBoarding",
+		)
+		intents.Boarding = append(
+			intents.Boarding,
+			newBoardingIntent(btcutil.Amount(add)),
+		)
+
+		next := computeClientOperatorFee(intents, owned)
+		require.GreaterOrEqual(
+			rt, next, base,
+			"adding a boarding input must never "+
+				"decrease the fee",
+		)
+	})
+}
+
+// TestInvariantComputeClientOperatorFeeMonotoneInOwnedOutput
+// asserts adding a positive owned output either decreases the
+// fee by that amount (when inputs dominate) or keeps it at zero
+// (when the clamp branch fires). Regression guard symmetrical
+// to the boarding monotonicity test above.
+func TestInvariantComputeClientOperatorFeeMonotoneInOwnedOutput(
+	t *testing.T) {
+
+	t.Parallel()
+
+	rapid.Check(t, func(rt *rapid.T) {
+		intents, owned := drawIntentsAndOwned(rt)
+		base := computeClientOperatorFee(intents, owned)
+
+		add := rapid.Int64Range(1, 1_000_000).Draw(
+			rt, "extraOwned",
+		)
+		owned = append(owned, &ClientVTXO{
+			Amount: btcutil.Amount(add),
+		})
+
+		next := computeClientOperatorFee(intents, owned)
+		require.LessOrEqual(
+			rt, next, base,
+			"adding an owned output must never "+
+				"increase the fee",
+		)
+	})
+}
+
+// TestInvariantComputeClientOperatorFeeEmptyIntentsIsZero locks
+// in the identity element: zero intents, zero owned outputs,
+// fee is zero. A regression that returned a non-zero value for
+// this edge case would indicate a broken baseline that would
+// poison every round.
+func TestInvariantComputeClientOperatorFeeEmptyIntentsIsZero(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(
+		t, int64(0),
+		computeClientOperatorFee(Intents{}, nil),
+	)
+}
+
+// drawIntentsAndOwned draws a random (Intents, []*ClientVTXO)
+// pair suitable for property testing. Amounts are capped at 1B
+// sat per entry so the running sum cannot overflow int64 for
+// reasonable slice lengths.
+func drawIntentsAndOwned(rt *rapid.T) (Intents, []*ClientVTXO) {
+	numBoarding := rapid.IntRange(0, 10).Draw(rt, "numBoarding")
+	numForfeits := rapid.IntRange(0, 10).Draw(rt, "numForfeits")
+	numOwned := rapid.IntRange(0, 10).Draw(rt, "numOwned")
+	numLeaves := rapid.IntRange(0, 5).Draw(rt, "numLeaves")
+
+	boarding := make([]BoardingIntent, 0, numBoarding)
+	for i := 0; i < numBoarding; i++ {
+		amt := rapid.Int64Range(0, 1_000_000_000).Draw(
+			rt, "boardingAmt",
+		)
+		boarding = append(
+			boarding,
+			newBoardingIntent(btcutil.Amount(amt)),
+		)
+	}
+
+	forfeits := make([]types.ForfeitRequest, 0, numForfeits)
+	for i := 0; i < numForfeits; i++ {
+		amt := rapid.Int64Range(0, 1_000_000_000).Draw(
+			rt, "forfeitAmt",
+		)
+		forfeits = append(forfeits, types.ForfeitRequest{
+			VTXOOutpoint: &wire.OutPoint{},
+			Amount:       btcutil.Amount(amt),
+		})
+	}
+
+	owned := make([]*ClientVTXO, 0, numOwned)
+	for i := 0; i < numOwned; i++ {
+		amt := rapid.Int64Range(0, 1_000_000_000).Draw(
+			rt, "ownedAmt",
+		)
+		owned = append(owned, &ClientVTXO{
+			Amount: btcutil.Amount(amt),
+		})
+	}
+
+	leaves := make([]*types.LeaveRequest, 0, numLeaves)
+	for i := 0; i < numLeaves; i++ {
+		amt := rapid.Int64Range(0, 1_000_000_000).Draw(
+			rt, "leaveAmt",
+		)
+		leaves = append(leaves, &types.LeaveRequest{
+			Output: &wire.TxOut{Value: amt},
+		})
+	}
+
+	return Intents{
+		Boarding: boarding,
+		Forfeits: forfeits,
+		Leaves:   leaves,
+	}, owned
+}
+
+// sumBoarding sums every boarding input's on-chain amount. Nil-
+// safe because the helper always produces a concrete
+// BoardingIntent.
+func sumBoarding(in Intents) int64 {
+	var out int64
+	for i := range in.Boarding {
+		out += int64(in.Boarding[i].ChainInfo.Amount)
+	}
+
+	return out
+}
+
+// sumForfeits sums every forfeit's cached amount hint.
+func sumForfeits(in Intents) int64 {
+	var out int64
+	for i := range in.Forfeits {
+		out += int64(in.Forfeits[i].Amount)
+	}
+
+	return out
+}
+
+// sumOwned sums every owned ClientVTXO amount, skipping nil
+// entries to match computeClientOperatorFee's defensive
+// handling.
+func sumOwned(owned []*ClientVTXO) int64 {
+	var out int64
+	for _, v := range owned {
+		if v == nil {
+			continue
+		}
+		out += int64(v.Amount)
+	}
+
+	return out
+}
+
+// sumLeaves sums every leave-output value, skipping nil entries
+// to match computeClientOperatorFee's defensive handling.
+func sumLeaves(in Intents) int64 {
+	var out int64
+	for _, lv := range in.Leaves {
+		if lv == nil || lv.Output == nil {
+			continue
+		}
+		if lv.Output.Value > 0 {
+			out += lv.Output.Value
+		}
+	}
+
+	return out
+}

--- a/round/refresh_psbt_size_test.go
+++ b/round/refresh_psbt_size_test.go
@@ -1,0 +1,123 @@
+package round
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/types"
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+// TestRefreshPSBTShapeStableAcrossFeeSchedules asserts the
+// structural invariant the issue #263 plan calls out under
+// Phase C.4 (5): the PSBT shape a refresh produces — input
+// count, output count, and per-output slot layout — must be
+// identical with fees enabled vs disabled. Only the per-output
+// VALUES should move. A regression that added a fee-only
+// output (or dropped one) would change the tree weight and
+// break the operator's validation surface.
+//
+// We exercise the invariant at the computeClientOperatorFee
+// level because that is the function whose output determines
+// how the wallet actor sizes the recipient / change outputs.
+// For a fixed Intents + ownedVTXOs shape, the same cardinality
+// must hold regardless of the fee value.
+func TestRefreshPSBTShapeStableAcrossFeeSchedules(t *testing.T) {
+	t.Parallel()
+
+	// Canonical refresh: one forfeit input, one owned output.
+	makeIntents := func() Intents {
+		return Intents{
+			Forfeits: []types.ForfeitRequest{
+				{
+					VTXOOutpoint: &wire.OutPoint{},
+					Amount:       btcutil.Amount(100_000),
+				},
+			},
+		}
+	}
+
+	// Case A: fees disabled (caller-computed zero fee).
+	intentsNoFee := makeIntents()
+	ownedNoFee := []*ClientVTXO{
+		{Amount: btcutil.Amount(100_000)},
+	}
+
+	// Case B: fees enabled — same cardinality, different
+	// owned-output value to absorb the fee.
+	intentsWithFee := makeIntents()
+	ownedWithFee := []*ClientVTXO{
+		{Amount: btcutil.Amount(99_500)},
+	}
+
+	// Shape check: same number of forfeits, same number of
+	// owned outputs, same number of leaves.
+	require.Equal(
+		t, len(intentsNoFee.Forfeits),
+		len(intentsWithFee.Forfeits),
+	)
+	require.Equal(t, len(ownedNoFee), len(ownedWithFee))
+	require.Equal(
+		t, len(intentsNoFee.Leaves),
+		len(intentsWithFee.Leaves),
+	)
+
+	// The fee delta is exactly the owned-output value delta.
+	feeNoFee := computeClientOperatorFee(intentsNoFee, ownedNoFee)
+	feeWithFee := computeClientOperatorFee(
+		intentsWithFee, ownedWithFee,
+	)
+	require.Equal(
+		t, int64(0), feeNoFee,
+		"zero-fee case must produce zero fee",
+	)
+	require.Equal(
+		t, int64(500), feeWithFee,
+		"with-fee case must surface exactly 500 sats",
+	)
+}
+
+// TestRefreshPSBTShapeStableUnderRapidSchedules extends the
+// canonical shape assertion to random schedules (simulated via
+// random fee deltas on the single owned output). The cardinality
+// of every intent pool stays constant under random draws; the
+// fee value is the only moving part.
+func TestRefreshPSBTShapeStableUnderRapidSchedules(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(rt *rapid.T) {
+		forfeitAmt := rapid.Int64Range(
+			10_000, 1_000_000,
+		).Draw(rt, "forfeitAmt")
+		feeAmt := rapid.Int64Range(0, forfeitAmt-1).Draw(
+			rt, "feeAmt",
+		)
+
+		intents := Intents{
+			Forfeits: []types.ForfeitRequest{{
+				VTXOOutpoint: &wire.OutPoint{},
+				Amount:       btcutil.Amount(forfeitAmt),
+			}},
+		}
+		owned := []*ClientVTXO{
+			{Amount: btcutil.Amount(forfeitAmt - feeAmt)},
+		}
+
+		// Cardinality stays constant:
+		require.Len(
+			rt, intents.Forfeits, 1,
+			"single forfeit input",
+		)
+		require.Len(rt, owned, 1, "single owned output")
+		require.Len(rt, intents.Leaves, 0, "no leaves")
+
+		// Fee matches exactly the caller-computed delta:
+		got := computeClientOperatorFee(intents, owned)
+		require.Equal(
+			rt, feeAmt, got,
+			"fee must equal forfeit - owned exactly",
+		)
+	})
+}


### PR DESCRIPTION
In this PR, we thread dynamic fee awareness through the client's boarding and send paths, so the operator fee the client reserves matches the amount the server's `validateOperatorFee` expects under a non-zero schedule.

Before this PR, both `Board` and `SendVTXO` deducted the legacy flat `terms.MinOperatorFee` (default 1000 sats) regardless of the operator's runtime fee schedule. That was fine when fees were universally zero, but it breaks in two directions the moment the server runs with an actual schedule: when the dynamic quote is cheaper than the flat fee, the client silently overpays and the excess lands on the operator's side as unattributed profit; when the dynamic quote exceeds the flat fee (as happens under a congestion spread, or when a larger base margin is configured), the server rejects the submission with `ErrOperatorFeeTooLow` and refresh just stops working.

The fix is to ask the operator. Both RPC handlers now call a small `quoteOperatorFee` helper that proxies to `EstimateFee` over the direct gRPC link, and they pass the returned `TotalFeeSat` through to the wallet actor in place of the legacy flat value. If `EstimateFee` is unreachable (nil `serverConn`, RPC failure), we log at warn and fall back to `terms.MinOperatorFee` so a boarding still goes through in a degraded mode rather than failing outright.

This is the client-side of [lightninglabs/darepo#263](https://github.com/lightninglabs/darepo/issues/263). The matching server PR is in the parent repo and bumps the submodule to the tip of this branch as its final commit. Both ship together.

## Dynamic fee quoting

In `darepod/rpc_fees.go`, `quoteOperatorFee` is a private helper that takes `(amountSat, isBoarding, remainingBlocks)` and returns a `btcutil.Amount`. It's deliberately boring: dial through the existing `s.serverConn`, call `arkrpc.ArkServiceClient.EstimateFee`, return `TotalFeeSat`. No caching, no retry, no local fee math. The operator is authoritative for what it will accept, and every cache layer just adds drift we'd have to paper over.

`Board` (in `rpc_server.go`) peeks the wallet's confirmed boarding balance via the existing `GetBoardingBalanceRequest` Ask, quotes `EstimateFee` for that amount, and passes the dynamic quote through `BoardRequest.MinOperatorFee`. There's a small TOCTOU window between the balance peek and the wallet's own intent-build call, but a new boarding arriving in that window can only push the effective amount higher, which the server still accepts (it only rejects under-quotes vs. its required fee).

`SendVTXO` does the same for the summed recipient amount, with `isBoarding=false` and `remainingBlocks=0`. The server's `MinRefreshDeltaBlocks` floor guarantees a stable liquidity fee regardless of the specific VTXO's remaining time, so we don't need to plumb per-VTXO block data through the RPC call.

Back-compat: under a zero schedule, `EstimateFee` returns `TotalFeeSat=0` and the whole flow reduces to today's legacy path. No flag, no gate.

## CLI error mapping

The daemon's `proxyUpstreamError` helper sanitizes upstream gRPC statuses before surfacing them to the CLI, so the code gets preserved but the message is rewrapped. That makes status-code matching brittle, so `mapFeeError` (in `cmd/darepocli/darepoclicommands/fee_errors.go`) matches on substring for the four load-bearing server-side sentinels: `ErrVTXOBelowMinViable`, `ErrOperatorFeeTooLow`, boarding-balance-too-small, and fee-calculator-not-configured. Each mapped error surfaces as a concise actionable line, with the original server message kept as parenthetical context so operators can still grep the server logs.

The `board` and `send inround` subcommands run their RPC error through `mapFeeError` before falling back to the generic wrap. `fee_errors_test.go` pins the exact substrings we depend on, so a future server-side message change fails the CLI test rather than silently routing around the mapper.

## Testing

Four new test files, all running as unit tests (no itest harness required):

In `round/fees_invariants_test.go`, rapid properties cover `computeClientOperatorFee`: non-negative clamp under any intent shape, conservation identity (`fee = inputs - outputs` when outputs don't exceed inputs), monotonicity (adding a boarding input never decreases the fee; adding an owned output never increases it), and the empty-intents zero-fee baseline. The generator caps per-entry amounts at 1B sat so running sums can't overflow int64 on realistic slice lengths.

In `round/refresh_psbt_size_test.go`, the PSBT cardinality invariant is locked in both as a canonical fixed-case test and as a rapid property: across random `(forfeit amount, fee amount)` draws, the number of forfeits, owned outputs, and leaves stays constant, and only per-output values move. A regression that added a fee-only output or dropped one would break this immediately.

In `darepod/congestion_roundtrip_test.go`, a `bufconn`-backed `fakeArkService` returns canned `EstimateFee` replies, and the client's `quoteOperatorFee` helper is driven through a baseline -> congestion-bumped sequence. The test asserts the helper returns the operator's `TotalFeeSat` verbatim (no local caching) and pins the `nil serverConn` guard so the helper surfaces a clean `Unavailable` error instead of panicking.

In `darepod/rpc_fees_e2e_test.go`, a similar bufconn setup exercises the daemon's `EstimateFee` RPC handler: every field (liquidity, on-chain share, margin, total, effective rate, min viable, below-dust flag) must proxy verbatim to the CLI caller, and the CLI-visible total must match the internal `quoteOperatorFee` number for the same inputs. This is the invariant that keeps the CLI confirmation prompt aligned with the actual booking.

See each commit message for a detailed description w.r.t the incremental changes.

## Test plan

- [x] \`make lint-native\`
- [x] \`go test ./darepod/... ./round/... ./cmd/darepocli/darepoclicommands/...\`
- [ ] \`make itest\` in the parent darepo repo once the server-side PR lands together