### PR TITLE
darepod: support injected RPC listeners for embedding

### DIFF
--- a/darepod/config.go
+++ b/darepod/config.go
@@ -3,6 +3,7 @@ package darepod
 import (
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"path/filepath"
 	"time"
@@ -188,8 +189,18 @@ type ServerConfig struct {
 
 // RPCConfig holds configuration for the daemon's own gRPC server.
 type RPCConfig struct {
-	// ListenAddr is the network address the gRPC server binds to.
+	// ListenAddr is the network address the gRPC server binds to when the
+	// daemon opens its own TCP listener. Valid RPC configurations either
+	// set ListenAddr to a non-empty address or supply Listener
+	// programmatically.
 	ListenAddr string `mapstructure:"listenaddr"`
+
+	// Listener is an optional pre-created listener. When non-nil, the
+	// daemon serves on this listener instead of binding to ListenAddr.
+	// This enables SDK-style embedding and in-memory transports such as
+	// bufconn in tests. Listener is programmatic-only and is not loaded
+	// from config files.
+	Listener net.Listener
 
 	// TLSCertPath is the path to the daemon's TLS certificate. If empty,
 	// one is auto-generated in the data directory.
@@ -348,8 +359,9 @@ func (c *Config) Validate() error {
 	if c.RPC == nil {
 		return fmt.Errorf("rpc config is required")
 	}
-	if c.RPC.ListenAddr == "" {
-		return fmt.Errorf("rpc listen address is required")
+	if c.RPC.Listener == nil && c.RPC.ListenAddr == "" {
+		return fmt.Errorf("rpc listen address or injected " +
+			"listener is required")
 	}
 
 	return nil

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -341,6 +341,31 @@ func (s *Server) RPCAddr() net.Addr {
 	return s.rpcAddr
 }
 
+// openRPCListener returns the daemon RPC listener. Embedders can inject a
+// pre-created listener through the config, while the standalone daemon path
+// binds a fresh TCP listener on ListenAddr.
+func (s *Server) openRPCListener() (net.Listener, error) {
+	if s.cfg.RPC.Listener != nil {
+		s.rpcAddrMu.Lock()
+		s.rpcAddr = s.cfg.RPC.Listener.Addr()
+		s.rpcAddrMu.Unlock()
+
+		return s.cfg.RPC.Listener, nil
+	}
+
+	lis, err := net.Listen("tcp", s.cfg.RPC.ListenAddr)
+	if err != nil {
+		return nil, fmt.Errorf("unable to listen on %s: %w",
+			s.cfg.RPC.ListenAddr, err)
+	}
+
+	s.rpcAddrMu.Lock()
+	s.rpcAddr = lis.Addr()
+	s.rpcAddrMu.Unlock()
+
+	return lis, nil
+}
+
 // RunUntilShutdown starts all subsystems and blocks until the shutdown
 // interceptor fires or a fatal error occurs. The startup sequence
 // branches on the configured wallet type: in lnd mode, the daemon
@@ -622,15 +647,10 @@ func (s *Server) run(ctx context.Context,
 		&rpcMailboxAdapter{RPCServer: s.rpcServer},
 	)
 
-	lis, err := net.Listen("tcp", s.cfg.RPC.ListenAddr)
+	lis, err := s.openRPCListener()
 	if err != nil {
-		return fmt.Errorf("unable to listen on %s: %w",
-			s.cfg.RPC.ListenAddr, err)
+		return err
 	}
-
-	s.rpcAddrMu.Lock()
-	s.rpcAddr = lis.Addr()
-	s.rpcAddrMu.Unlock()
 
 	go func() {
 		s.log.InfoS(ctx, "gRPC server listening",

--- a/darepod/server_rpc_listener_test.go
+++ b/darepod/server_rpc_listener_test.go
@@ -1,0 +1,152 @@
+package darepod
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+// testConfigWithInjectedRPCListener returns a config that is valid for
+// Validate while relying on an injected RPC listener instead of a listen
+// address string.
+func testConfigWithInjectedRPCListener(listener net.Listener) *Config {
+	cfg := DefaultConfig()
+	cfg.Network = "regtest"
+	// A syntactically valid mailbox host is still required by daemon
+	// config validation even though the tests below only exercise the
+	// local RPC server.
+	cfg.Server.Host = "127.0.0.1:10010"
+	cfg.Wallet.EsploraURL = "http://127.0.0.1:3000"
+	cfg.RPC.ListenAddr = ""
+	cfg.RPC.Listener = listener
+
+	return cfg
+}
+
+// TestConfigValidateAllowsInjectedRPCListener verifies embedders can skip
+// ListenAddr entirely when they provide a pre-created listener in code.
+func TestConfigValidateAllowsInjectedRPCListener(t *testing.T) {
+	t.Parallel()
+
+	listener := bufconn.Listen(1024)
+	t.Cleanup(func() {
+		require.NoError(t, listener.Close())
+	})
+
+	cfg := testConfigWithInjectedRPCListener(listener)
+
+	require.NoError(t, cfg.Validate())
+}
+
+// TestOpenRPCListenerUsesInjectedListener verifies the daemon reuses an
+// injected listener verbatim so embedded runtimes can own the transport.
+func TestOpenRPCListenerUsesInjectedListener(t *testing.T) {
+	t.Parallel()
+
+	listener := bufconn.Listen(1024)
+	t.Cleanup(func() {
+		require.NoError(t, listener.Close())
+	})
+
+	server := &Server{
+		cfg: testConfigWithInjectedRPCListener(listener),
+	}
+
+	lis, err := server.openRPCListener()
+	require.NoError(t, err)
+	require.Same(t, listener, lis)
+	require.Equal(t, listener.Addr(), server.RPCAddr())
+}
+
+// TestOpenRPCListenerBindsListenAddr verifies the standalone daemon path still
+// binds a fresh TCP listener when no listener is injected.
+func TestOpenRPCListenerBindsListenAddr(t *testing.T) {
+	t.Parallel()
+
+	cfg := DefaultConfig()
+	cfg.RPC.ListenAddr = "127.0.0.1:0"
+
+	server := &Server{cfg: cfg}
+
+	lis, err := server.openRPCListener()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, lis.Close())
+	})
+
+	tcpAddr, ok := lis.Addr().(*net.TCPAddr)
+	require.True(t, ok)
+	require.NotZero(t, tcpAddr.Port)
+	require.Equal(t, lis.Addr(), server.RPCAddr())
+}
+
+// TestRunWithContextServesInjectedListener verifies the daemon can boot on an
+// injected in-memory listener and serve a real gRPC request before the wallet
+// has been initialized.
+func TestRunWithContextServesInjectedListener(t *testing.T) {
+	t.Parallel()
+
+	listener := bufconn.Listen(1 << 20)
+	cfg := testConfigWithInjectedRPCListener(listener)
+	cfg.DataDir = t.TempDir()
+	cfg.Wallet.Type = WalletTypeBtcwallet
+	cfg.Wallet.FeeURL = "http://127.0.0.1:3001"
+	cfg.Wallet.EsploraURL = ""
+
+	server, err := NewServer(cfg)
+	require.NoError(t, err)
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- server.RunWithContext(runCtx)
+	}()
+
+	require.Eventually(t, func() bool {
+		return server.RPCAddr() != nil
+	}, 5*time.Second, 20*time.Millisecond)
+
+	connCtx, connCancel := context.WithTimeout(
+		context.Background(), 5*time.Second,
+	)
+	defer connCancel()
+
+	conn, err := grpc.NewClient(
+		"passthrough:///bufnet",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithContextDialer(func(ctx context.Context,
+			_ string) (net.Conn, error) {
+
+			return listener.DialContext(ctx)
+		}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
+
+	conn.Connect()
+	require.Eventually(t, func() bool {
+		return conn.GetState() == connectivity.Ready
+	}, 5*time.Second, 20*time.Millisecond)
+
+	client := daemonrpc.NewDaemonServiceClient(conn)
+
+	resp, err := client.GenSeed(connCtx, &daemonrpc.GenSeedRequest{})
+	require.NoError(t, err)
+	require.Len(t, resp.Mnemonic, 24)
+	require.Equal(t, listener.Addr(), server.RPCAddr())
+
+	cancel()
+	require.NoError(t, <-errChan)
+}


### PR DESCRIPTION
## Summary

First of three stacked PRs that move us toward a `sdk/ark` daemon
facade. This one is pure embedding substrate: it lets callers hand
`darepod` a pre-created RPC listener so the daemon can serve over
injected transports (bufconn, in-memory, anything satisfying
`net.Listener`) instead of always binding `ListenAddr` itself.

Nothing about daemon behavior changes. The standalone startup path
still binds `ListenAddr`, and validation still requires at least one
of `Listener` or `ListenAddr` to be set. What this buys us is a clean
way to embed the daemon in a Go host binary without fake TCP ports,
and a substrate for fast in-process end-to-end tests.

See `docs/sdk_layered_architecture.md` for the broader layering
context.

## Stack

- **#289 (this PR)** — injected RPC listeners on `darepod`
- #290 — operator terms on `daemonrpc.GetInfo`
- #291 — `sdk/ark` facade on top of both

## What changed

- add `RPCConfig.Listener net.Listener` (programmatic-only; not
  loaded from config files)
- centralize RPC listener setup via a new `openRPCListener` helper
  that returns the injected listener verbatim or binds `ListenAddr`
  as before
- treat an injected listener as satisfying RPC config validation so
  embedded setups can leave `ListenAddr` empty
- add focused listener-selection tests for validation, the injected
  path, and the TCP-bind path
- add a higher-level daemon-boot test that serves `darepod` over a
  `bufconn` listener and completes a real `GenSeed` RPC round-trip

## Verification

- `make commitmsg-lint range=origin/main..HEAD`
- `GOWORK=off go test -modfile=/tmp/darepo-client-test.mod ./darepod`

The local test run uses a temporary `-modfile` with a local `replace`
for `github.com/lightninglabs/lndclient` because current `main`
points at an unresolved pseudo-version that also blocks
`make lint-native`.