### PR TITLE
sdk/ark: add initial daemon facade

### DIFF
--- a/docs/sdk_layered_architecture.md
+++ b/docs/sdk_layered_architecture.md
@@ -1,0 +1,274 @@
+# SDK Layered Architecture
+
+This note describes the client-side layering direction in
+`darepo-client`.
+
+The shape is:
+
+- `darepod` remains the canonical Ark client runtime.
+- `sdk/ark` is the consumer-facing Go SDK for that runtime.
+- the same `sdk/ark` API can talk to a remote daemon over gRPC or
+  an embedded in-process daemon over `bufconn` or another injected
+  listener.
+- future higher-level libraries such as `sdk/swaps` build on top of
+  `sdk/ark` rather than reaching directly into daemon internals.
+
+The goal is to support both process separation and process
+embedding from a single codebase, without ending up with two
+different Ark client implementations that must be kept in sync.
+
+## Motivation
+
+Two deployment modes matter to us: a standalone Ark client daemon,
+and an application that embeds the Ark client in the same binary.
+Higher-level libraries, starting with the swap client, need to work
+in both modes without caring how the Ark runtime is hosted.
+
+That combination has historically tempted projects into building
+two parallel implementations — a "real daemon" path and a
+"just-the-good-bits" in-process path. Those always drift. Our
+version avoids the drift by keeping exactly one runtime and
+changing only the hosting environment around it.
+
+Concretely, that gives us three design constraints:
+
+1. one canonical Ark runtime (the daemon),
+2. a consumer-facing SDK that depends only on the daemon's public
+   RPC surface, not its internals, and
+3. embedding as a hosting decision, not a separate behavior path.
+
+## Layering
+
+The intended stack:
+
+```text
+Applications / CLIs / services / mobile glue
+    |
+    v
+sdk/swaps          future high-level swap orchestration
+    |
+    v
+sdk/ark            consumer-facing Ark Go SDK
+    |
+    v
+daemonrpc          stable transport contract
+    |
+    v
+darepod            canonical Ark client runtime
+    |
+    v
+wallet, indexer, round, oor, ledger, db, mailbox transport
+```
+
+The important boundary is between `sdk/ark` and `darepod`. `darepod`
+owns the real runtime: persistence, actor lifecycle, recovery
+rules, wallet wiring, and Ark protocol execution. `sdk/ark` owns
+transport selection, lifecycle management for embedders, and Go
+ergonomics for callers on top of that runtime. Critically, `sdk/ark`
+is not a second Ark engine. It is a facade, and it stays that way.
+
+## Runtime modes
+
+The same `sdk/ark` client API supports two transports.
+
+**Remote mode** connects to an already-running `darepod` over gRPC:
+
+```text
+app -> sdk/ark -> daemonrpc over TCP/TLS -> darepod
+```
+
+This is the right fit when the daemon is managed separately, when
+process isolation is desirable, when multiple clients need to talk
+to the same daemon, or when non-Go consumers also need access.
+
+**Embedded mode** starts `darepod` in-process and talks to it
+through an injected listener, typically `bufconn`:
+
+```text
+app -> sdk/ark -> daemonrpc over bufconn -> darepod
+```
+
+This is the right fit when a single binary should contain the whole
+Ark client (desktop, mobile, or service hosts that want simpler
+lifecycle management), or when tests want a fast in-process runtime
+without real port allocation.
+
+The architectural point is that embedded mode still crosses the
+same service boundary. Only the transport changes; the runtime does
+not. That is what lets one SDK surface serve both modes and lets
+the daemon stay the single source of truth for behavior.
+
+Injected-listener support in `darepod` is what makes this honest.
+Without it, embedded hosts would have to allocate a real TCP port
+and pretend to be a daemon process. With it, we get in-process
+startup for SDK hosts, no fake port management, fast end-to-end
+tests, and a uniform `daemonrpc` contract in both modes. That is
+why the listener work lands first in the stack — it is the
+substrate that makes embedding a first-class mode rather than an
+afterthought.
+
+Because embedded mode owns a daemon run goroutine in-process, the
+SDK also owns its failure semantics. Startup blocks until the
+embedded daemon is accepting RPCs, a `Wait()` method surfaces the
+daemon's terminal run error through a blocking channel read without
+requiring `Close()`, and
+`Close()` cancels the embedded daemon, waits for shutdown with a
+bounded timeout, and is safe to call more than once. This gives
+higher-level callers a way to supervise embedded mode rather than
+discovering failures only when the next RPC breaks.
+
+## Where `sdk/ark` ends and `darepod` begins
+
+`sdk/ark` is the consumer-facing Go API for Ark operations that the
+daemon already supports. In the near term that covers:
+
+- daemon status and operator terms
+- wallet bootstrap and unlock flows
+- balance and VTXO listing
+- boarding address allocation
+- policy-backed convenience helpers for OOR and indexed lookups that
+  higher-level clients such as swaps need
+- OOR receive script allocation
+- indexer lookups
+- round and refresh operations
+- OOR send operations
+- fee estimation and fee history
+- stream access for daemon-driven updates
+
+What stays below the SDK layer is everything that makes the runtime
+a runtime: daemon lifecycle, actor orchestration, mailbox transport
+implementation, wallet backend internals, durable state management,
+Ark protocol execution, retry policy beyond transport-safe client
+behavior, swap persistence and swap FSM state, secret-material
+storage policy (the SDK passes wallet passwords through to the daemon
+but does not persist them), and
+cross-cutting instrumentation ownership for daemon internals.
+Keeping those in `darepod` is the thing that prevents drift between
+the "real daemon" path and the "embedded SDK" path — there is only
+one place where runtime behavior is defined.
+
+Two boundary choices are worth calling out explicitly because they
+surface in the first SDK slice.
+
+**API model policy.** Some `sdk/ark` methods currently return
+`daemonrpc` protobuf request and response types directly rather
+than SDK-owned models. This is deliberate for the first slice: the
+immediate goal is to establish one stable consumer entry point and
+one stable transport story, not to invent domain types for every
+RPC upfront. The tradeoff is that proto-typed passthrough methods
+are pre-1.0 and may change as richer SDK-owned models are
+introduced. Higher-level packages such as `sdk/swaps` should treat
+those passthroughs as a temporary compatibility layer, not a
+long-term domain model guarantee. The long-term direction is to
+move high-traffic APIs toward SDK-owned typed models, but we are
+not pretending all methods are there yet.
+
+Because of that, `daemonrpc` changes carry SDK consequences today.
+The working rule is that `daemonrpc` changes should be additive
+whenever possible, that removed protobuf fields must reserve their
+tags and names, and that generated-proto churn should be treated as
+SDK-surface churn for as long as passthrough methods still exist.
+This is another reason the long-term direction points toward
+SDK-owned typed models.
+
+**Embedded config boundary.** `EmbeddedConfig` currently accepts a
+full `*darepod.Config`. That is an explicit choice for the first
+embedding slice: `sdk/ark` hides transport and lifecycle
+management, but it does not yet hide the full daemon configuration
+surface. A narrower SDK-owned embedded config may make sense later,
+but we do not want to invent one before we know which daemon knobs
+higher-level callers actually need.
+
+## Caller contract
+
+`sdk/ark.Client` is safe for concurrent use. Higher-level
+orchestration such as swaps will mix unary RPCs, streaming
+subscriptions, and shutdown coordination without serializing
+through a single goroutine, so the client must support that
+natively.
+
+Client readiness is staged rather than binary. A running daemon
+walks through several checkpoints — listener open, gRPC accepting
+RPCs, wallet unlocked or initialized, round actor initialized,
+mailbox transport connected, operator terms cached — and callers
+need a way to observe them. Today `GetInfo` is the caller-facing
+readiness surface: `WalletReady == true` means wallet-dependent
+RPCs are expected to work, `ServerConnected == true` is the current
+best-effort signal that mailbox ingress is running, and
+`ServerInfo != nil` means operator terms have been fetched and
+cached. Round-oriented
+callers should wait for all three before issuing round-sensitive
+operations. `ServerInfo` is intentionally nullable because operator
+bootstrap happens after the daemon process starts accepting RPCs, and
+the current daemon refreshes that snapshot only during bootstrap, so
+it remains the latest known terms for the current session until
+refresh wiring lands.
+
+The SDK is not unary-only. The daemon already exposes streaming
+state such as `WatchRounds`, and future higher-level callers will
+likely need more event-driven hooks for round state changes,
+mailbox connect and disconnect transitions, incoming VTXO
+observations, and operator-policy refresh events. The direction is
+to expose and use streams where the daemon already has them, and to
+prefer subscription-driven orchestration over polling in
+higher-level flows such as swaps. That keeps `sdk/swaps` aligned
+with the daemon's real event model.
+
+The error model is intentionally modest for now. The SDK wraps RPC
+failures with contextual `fmt.Errorf(...: %w)` messages and
+preserves the underlying gRPC status codes, so callers may branch
+on status codes today. Daemon-specific semantic categories will be
+introduced as exported SDK sentinels only once the daemon surfaces
+them consistently, and richer SDK-owned error categories are
+expected to land incrementally as higher-level consumers such as
+`sdk/swaps` need them. We do not want to freeze a misleading error
+taxonomy before the daemon surface is ready for it.
+
+## Future `sdk/swaps`
+
+The future swap client will sit on top of `sdk/ark`, not beside it:
+
+```text
+app
+  -> sdk/swaps
+      -> sdk/ark
+          -> darepod
+```
+
+That means swap logic can assume one Ark client facade, swap code
+does not need to know whether the Ark client is remote or embedded,
+swap persistence and FSM logic stay in the swap layer, and Ark-
+specific wallet, OOR, indexer, and round operations are delegated
+downward to `sdk/ark`.
+
+This matters most for restart safety and correctness. The swap
+layer orchestrates high-level workflow, while the Ark client
+runtime remains the single source of truth for Ark-side execution
+and durability.
+
+A future umbrella SDK — for example, a higher-level wallet package
+that bundles Ark and swaps — may still make sense if it becomes
+useful. The intended dependency direction is
+`umbrella SDK -> sdk/swaps -> sdk/ark`, not `umbrella SDK -> daemon
+internals directly`. That keeps the layering honest and preserves
+the daemon boundary as the runtime contract.
+
+## Implementation sequence
+
+The stack lands in four incremental slices:
+
+1. make `darepod` embeddable by accepting injected RPC listeners,
+2. expose the daemon metadata needed by SDK callers, such as
+   operator terms on `GetInfo`,
+3. build the first `sdk/ark` facade on top of that boundary,
+4. move higher-level clients, starting with swaps, onto `sdk/ark`.
+
+This sequence keeps each step reviewable and avoids a single giant
+"SDK rewrite" PR.
+
+Correspondingly, the architecture does not try to replace `darepod`
+with a separate direct-library Ark implementation, bypass the
+daemon boundary for main client flows, or fully redesign the daemon
+RPC surface before an SDK can exist. Those are explicit non-goals.
+The daemon is the runtime; the SDK is the consumer-facing facade
+over it.

--- a/sdk/ark/AGENTS.md
+++ b/sdk/ark/AGENTS.md
@@ -1,0 +1,48 @@
+# sdk/ark
+
+## Purpose
+
+Consumer-facing Go SDK facade over a `darepod` runtime. Supports both
+remote daemon connections and embedded in-process daemon hosting
+without duplicating Ark runtime behavior.
+
+## Key Types
+
+- `Client` — Concurrency-safe SDK handle around a `daemonrpc`
+  client. Owns transport shutdown and, in embedded mode, exposes
+  `Wait()` for the daemon run result.
+- `RemoteConfig` — Remote daemon dialing config. Secure by default:
+  callers must provide transport credentials or explicitly opt into
+  insecure transport for local development.
+- `EmbeddedConfig` — In-process daemon hosting config. Currently
+  passes through a cloned `*darepod.Config`; the SDK hides transport
+  and lifecycle management, not the full daemon config surface.
+- `Info` / `ServerInfo` / `Seed` / `WalletInitResult` — SDK-owned
+  typed models for the higher-level status and wallet bootstrap flows.
+- Policy/OOR helpers such as `SendOORWithPolicy`,
+  `SendOORWithCustomInputs`, typed indexed VTXO lookups, and typed
+  receive-script decoding belong here so higher-level packages do not
+  rebuild daemonrpc adapters.
+
+## Relationships
+
+- **Depends on**: `daemonrpc`, `darepod`, gRPC.
+- **Depended on by**: future `sdk/swaps`, Go hosts that want remote or
+  embedded Ark client access.
+
+## Invariants
+
+- `Client` is safe for concurrent use.
+- `darepod` remains the canonical Ark runtime; `sdk/ark` must not
+  reimplement wallet, round, OOR, or persistence behavior.
+- Embedded startup must not mutate the caller's daemon config.
+- Embedded startup waits until the in-process daemon is accepting RPCs
+  before returning.
+- Embedded `Wait()` returns a blocking channel that surfaces the
+  daemon's terminal run error.
+- `Close()` is idempotent and bounds embedded shutdown wait time.
+- `ServerInfo` is a bootstrap-time operator-terms snapshot; refresh
+  after reconnect is not wired through yet.
+- Pre-1.0, some methods intentionally return `daemonrpc` protobuf
+  types directly. Those passthrough APIs are not yet treated as
+  stable SDK-owned models.

--- a/sdk/ark/CLAUDE.md
+++ b/sdk/ark/CLAUDE.md
@@ -1,0 +1,48 @@
+# sdk/ark
+
+## Purpose
+
+Consumer-facing Go SDK facade over a `darepod` runtime. Supports both
+remote daemon connections and embedded in-process daemon hosting
+without duplicating Ark runtime behavior.
+
+## Key Types
+
+- `Client` — Concurrency-safe SDK handle around a `daemonrpc`
+  client. Owns transport shutdown and, in embedded mode, exposes
+  `Wait()` for the daemon run result.
+- `RemoteConfig` — Remote daemon dialing config. Secure by default:
+  callers must provide transport credentials or explicitly opt into
+  insecure transport for local development.
+- `EmbeddedConfig` — In-process daemon hosting config. Currently
+  passes through a cloned `*darepod.Config`; the SDK hides transport
+  and lifecycle management, not the full daemon config surface.
+- `Info` / `ServerInfo` / `Seed` / `WalletInitResult` — SDK-owned
+  typed models for the higher-level status and wallet bootstrap flows.
+- Policy/OOR helpers such as `SendOORWithPolicy`,
+  `SendOORWithCustomInputs`, typed indexed VTXO lookups, and typed
+  receive-script decoding belong here so higher-level packages do not
+  rebuild daemonrpc adapters.
+
+## Relationships
+
+- **Depends on**: `daemonrpc`, `darepod`, gRPC.
+- **Depended on by**: future `sdk/swaps`, Go hosts that want remote or
+  embedded Ark client access.
+
+## Invariants
+
+- `Client` is safe for concurrent use.
+- `darepod` remains the canonical Ark runtime; `sdk/ark` must not
+  reimplement wallet, round, OOR, or persistence behavior.
+- Embedded startup must not mutate the caller's daemon config.
+- Embedded startup waits until the in-process daemon is accepting RPCs
+  before returning.
+- Embedded `Wait()` returns a blocking channel that surfaces the
+  daemon's terminal run error.
+- `Close()` is idempotent and bounds embedded shutdown wait time.
+- `ServerInfo` is a bootstrap-time operator-terms snapshot; refresh
+  after reconnect is not wired through yet.
+- Pre-1.0, some methods intentionally return `daemonrpc` protobuf
+  types directly. Those passthrough APIs are not yet treated as
+  stable SDK-owned models.

--- a/sdk/ark/client.go
+++ b/sdk/ark/client.go
@@ -1,0 +1,928 @@
+package ark
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"google.golang.org/grpc"
+)
+
+const (
+	// defaultCloseTimeout bounds how long Close waits for an embedded
+	// daemon to shut down after cancellation.
+	defaultCloseTimeout = 5 * time.Second
+)
+
+// Client is the consumer-facing Ark SDK facade. It hides whether the caller
+// is talking to a remote daemon or an embedded in-process daemon runtime.
+// Client is safe for concurrent use.
+type Client struct {
+	daemon daemonrpc.DaemonServiceClient
+	waitCh <-chan error
+
+	closeFn   func(context.Context) error
+	closeOnce sync.Once
+	closeErr  error
+}
+
+// Info describes the current status of a running darepod instance.
+type Info struct {
+	// Version is the daemon's semantic version string.
+	Version string
+
+	// Commit is the build's git commit identifier.
+	Commit string
+
+	// Network is the active bitcoin network.
+	Network string
+
+	// LndIdentityPubKey is the connected lnd node identity public key
+	// when the daemon is running in lnd-backed mode.
+	LndIdentityPubKey string
+
+	// BlockHeight is the best block height known to the daemon.
+	BlockHeight uint32
+
+	// ServerConnected reports whether the daemon's mailbox transport to the
+	// Ark operator currently has mailbox ingress running.
+	ServerConnected bool
+
+	// LndAlias is the connected lnd node alias when applicable.
+	LndAlias string
+
+	// WalletType is the active wallet backend name.
+	WalletType string
+
+	// WalletReady reports whether the daemon wallet subsystem is
+	// initialized and ready to serve wallet-dependent RPCs.
+	WalletReady bool
+
+	// IdentityPubKey is the daemon identity public key derived from the
+	// active wallet backend.
+	IdentityPubKey string
+
+	// ServerInfo contains cached operator terms when the daemon has
+	// already connected to the Ark server and fetched them. It remains
+	// nil until the daemon reaches the operator-bootstrap stage, and is
+	// currently refreshed only during bootstrap.
+	ServerInfo *ServerInfo
+}
+
+// ServerInfo describes operator terms learned from the remote Ark server and
+// cached by the daemon.
+type ServerInfo struct {
+	// OperatorPubKey is the compressed SEC-encoded public key of the Ark
+	// operator.
+	OperatorPubKey []byte
+
+	// BoardingExitDelay is the minimum CSV delay required for boarding
+	// outputs.
+	BoardingExitDelay uint32
+
+	// VTXOExitDelay is the minimum CSV delay required for VTXO outputs.
+	VTXOExitDelay uint32
+
+	// ForfeitScript is the raw serialized scriptPubKey required in
+	// forfeit transactions.
+	ForfeitScript []byte
+
+	// SweepKey is the compressed SEC-encoded operator public key used in
+	// VTXO sweep paths when present.
+	SweepKey []byte
+
+	// SweepDelay is the batch-wide absolute timelock in blocks.
+	SweepDelay uint32
+
+	// DustLimit is the minimum output value accepted by the operator.
+	DustLimit uint64
+
+	// MinBoardingAmount is the smallest boarding amount accepted by the
+	// operator.
+	MinBoardingAmount uint64
+
+	// MaxBoardingAmount is the largest boarding amount accepted by the
+	// operator. A value of zero means no cap.
+	MaxBoardingAmount uint64
+
+	// FeeRate is the operator's target package feerate in sat/vbyte.
+	FeeRate uint64
+
+	// MinOperatorFee is the minimum operator fee in satoshis.
+	MinOperatorFee uint64
+
+	// MinConfirmations is the minimum confirmations required on boarding
+	// inputs.
+	MinConfirmations uint32
+}
+
+// Seed contains the mnemonic and enciphered seed bytes returned by GenSeed.
+type Seed struct {
+	// Mnemonic is the generated 24-word aezeed mnemonic.
+	Mnemonic []string
+
+	// EncipheredSeed is the raw enciphered seed bytes returned by the
+	// daemon.
+	EncipheredSeed []byte
+}
+
+// WalletInitResult contains the daemon identity derived after wallet creation
+// or unlock completes.
+type WalletInitResult struct {
+	// IdentityPubKey is the daemon identity public key derived after the
+	// wallet was created or unlocked.
+	IdentityPubKey string
+}
+
+// VTXOInfo is the SDK-owned typed view of a daemon VTXO record.
+type VTXOInfo struct {
+	// Outpoint is the VTXO's outpoint in "txid:index" format.
+	Outpoint string
+
+	// AmountSat is the VTXO value in satoshis.
+	AmountSat int64
+
+	// Status is the daemon's current lifecycle state for the VTXO.
+	Status daemonrpc.VTXOStatus
+
+	// BatchExpiry is the absolute block height of the batch-wide expiry.
+	BatchExpiry int32
+
+	// RoundID is the identifier of the round that created the VTXO.
+	RoundID string
+
+	// CreatedHeight is the block height at which the VTXO was created.
+	CreatedHeight int32
+
+	// RelativeExpiry is the CSV delay, in blocks, for unilateral exit.
+	RelativeExpiry uint32
+
+	// PkScript is the raw taproot output script decoded from the daemon's
+	// hex-encoded protobuf field.
+	PkScript []byte
+
+	// CommitmentTxID is the on-chain commitment txid anchoring the VTXO's
+	// tree.
+	CommitmentTxID string
+
+	// ChainDepth is the number of OOR checkpoint hops between this VTXO
+	// and the most recent on-chain commitment.
+	ChainDepth uint32
+
+	// FinalCheckpointPSBTs are the finalized checkpoint PSBTs that spent
+	// this VTXO through an OOR package when known.
+	FinalCheckpointPSBTs [][]byte
+
+	// SpentByTxID is the Ark or OOR txid that spent this VTXO when known.
+	SpentByTxID string
+}
+
+// OORReceiveInfo is the SDK-owned typed view of a wallet-owned OOR receive
+// destination allocated by the daemon.
+type OORReceiveInfo struct {
+	// PkScript is the raw taproot output script for the receive
+	// destination.
+	PkScript []byte
+
+	// PubKeyXOnly is the 32-byte x-only owner pubkey controlling the
+	// receive destination.
+	PubKeyXOnly []byte
+
+	// KeyFamily is the wallet key family used for the receive key.
+	KeyFamily uint32
+
+	// KeyIndex is the wallet key index used for the receive key.
+	KeyIndex uint32
+
+	// Label is the human-readable registration label stored with the
+	// indexer.
+	Label string
+}
+
+// IndexedOORSessionInfo is the SDK-owned typed view of an indexed OOR session
+// and its finalized checkpoints.
+type IndexedOORSessionInfo struct {
+	// ArkPSBT is the serialized Ark PSBT for the indexed OOR session.
+	ArkPSBT []byte
+
+	// CheckpointPSBTs are the serialized finalized checkpoint PSBTs for
+	// the indexed OOR session.
+	CheckpointPSBTs [][]byte
+}
+
+// CustomOORInput describes one caller-specified OOR input with an explicit
+// policy template and spend path.
+type CustomOORInput struct {
+	// Outpoint identifies the VTXO to spend in "txid:vout" format.
+	Outpoint string
+
+	// VTXOPolicyTemplate is the serialized arkscript policy template for
+	// the spent VTXO.
+	VTXOPolicyTemplate []byte
+
+	// SpendPath is the serialized arkscript spend path selected for this
+	// checkpoint spend.
+	SpendPath []byte
+
+	// AmountSat is the VTXO value in satoshis.
+	AmountSat int64
+
+	// PkScript is the raw taproot output script of the spent VTXO.
+	PkScript []byte
+}
+
+// Close releases the client transport and, for embedded clients, shuts down
+// the in-process daemon.
+func (c *Client) Close() error {
+	if c == nil {
+		return nil
+	}
+
+	c.closeOnce.Do(func() {
+		if c.closeFn == nil {
+			return
+		}
+
+		closeCtx, cancel := context.WithTimeout(
+			context.Background(), defaultCloseTimeout,
+		)
+		defer cancel()
+
+		c.closeErr = c.closeFn(closeCtx)
+	})
+
+	return c.closeErr
+}
+
+// Wait returns a blocking channel that reports the embedded daemon's terminal
+// run error. Remote clients return an already-closed channel because there is
+// no in-process runtime to observe.
+func (c *Client) Wait() <-chan error {
+	if c == nil || c.waitCh == nil {
+		return closedWaitChan()
+	}
+
+	return c.waitCh
+}
+
+// closedWaitChan returns an already-closed wait channel for client modes that
+// do not manage an in-process daemon runtime.
+func closedWaitChan() <-chan error {
+	ch := make(chan error)
+	close(ch)
+
+	return ch
+}
+
+// GetInfo returns the daemon's current status, wallet state, and any cached
+// operator terms.
+func (c *Client) GetInfo(ctx context.Context) (*Info, error) {
+	resp, err := c.daemon.GetInfo(ctx, &daemonrpc.GetInfoRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("get daemon info: %w", err)
+	}
+
+	info := &Info{
+		Version:           resp.Version,
+		Commit:            resp.Commit,
+		Network:           resp.Network,
+		LndIdentityPubKey: resp.LndIdentityPubkey,
+		BlockHeight:       resp.BlockHeight,
+		ServerConnected:   resp.ServerConnected,
+		LndAlias:          resp.LndAlias,
+		WalletType:        resp.WalletType,
+		WalletReady:       resp.WalletReady,
+		IdentityPubKey:    resp.IdentityPubkey,
+	}
+
+	if resp.ServerInfo != nil {
+		info.ServerInfo = &ServerInfo{
+			OperatorPubKey: bytes.Clone(
+				resp.ServerInfo.OperatorPubkey,
+			),
+			BoardingExitDelay: resp.ServerInfo.BoardingExitDelay,
+			VTXOExitDelay:     resp.ServerInfo.VtxoExitDelay,
+			ForfeitScript: bytes.Clone(
+				resp.ServerInfo.ForfeitScript,
+			),
+			SweepKey: bytes.Clone(
+				resp.ServerInfo.SweepKey,
+			),
+			SweepDelay:        resp.ServerInfo.SweepDelay,
+			DustLimit:         resp.ServerInfo.DustLimit,
+			MinBoardingAmount: resp.ServerInfo.MinBoardingAmount,
+			MaxBoardingAmount: resp.ServerInfo.MaxBoardingAmount,
+			FeeRate:           resp.ServerInfo.FeeRate,
+			MinOperatorFee:    resp.ServerInfo.MinOperatorFee,
+			MinConfirmations:  resp.ServerInfo.MinConfirmations,
+		}
+	}
+
+	return info, nil
+}
+
+// IdentityPubKey parses and returns the daemon identity public key from the
+// current GetInfo snapshot.
+func (c *Client) IdentityPubKey(ctx context.Context) (*btcec.PublicKey, error) {
+	info, err := c.GetInfo(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return parseHexPubKey(info.IdentityPubKey, "identity")
+}
+
+// OperatorPubKey parses and returns the operator public key from the daemon's
+// cached operator terms snapshot.
+func (c *Client) OperatorPubKey(ctx context.Context) (*btcec.PublicKey, error) {
+	info, err := c.GetInfo(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if info.ServerInfo == nil {
+		return nil, fmt.Errorf("operator terms are unavailable")
+	}
+
+	key, err := btcec.ParsePubKey(info.ServerInfo.OperatorPubKey)
+	if err != nil {
+		return nil, fmt.Errorf("parse operator public key: %w", err)
+	}
+
+	return key, nil
+}
+
+// GenSeed requests a fresh aezeed seed from a self-managed wallet daemon.
+func (c *Client) GenSeed(ctx context.Context,
+	seedPassphrase []byte) (*Seed, error) {
+
+	resp, err := c.daemon.GenSeed(ctx, &daemonrpc.GenSeedRequest{
+		SeedPassphrase: bytes.Clone(seedPassphrase),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("generate seed: %w", err)
+	}
+
+	return &Seed{
+		Mnemonic:       append([]string(nil), resp.Mnemonic...),
+		EncipheredSeed: bytes.Clone(resp.EncipheredSeed),
+	}, nil
+}
+
+// InitWallet creates a new self-managed wallet from the supplied mnemonic and
+// returns the daemon's derived identity public key.
+func (c *Client) InitWallet(ctx context.Context, mnemonic []string,
+	seedPassphrase, walletPassword []byte) (*WalletInitResult, error) {
+
+	resp, err := c.daemon.InitWallet(ctx, &daemonrpc.InitWalletRequest{
+		Mnemonic:       append([]string(nil), mnemonic...),
+		SeedPassphrase: bytes.Clone(seedPassphrase),
+		WalletPassword: bytes.Clone(walletPassword),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("initialize wallet: %w", err)
+	}
+
+	return &WalletInitResult{
+		IdentityPubKey: resp.IdentityPubkey,
+	}, nil
+}
+
+// UnlockWallet unlocks an existing self-managed wallet and returns the daemon
+// identity public key derived after startup completes.
+func (c *Client) UnlockWallet(ctx context.Context,
+	walletPassword []byte) (*WalletInitResult, error) {
+
+	resp, err := c.daemon.UnlockWallet(ctx,
+		&daemonrpc.UnlockWalletRequest{
+			WalletPassword: bytes.Clone(walletPassword),
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("unlock wallet: %w", err)
+	}
+
+	return &WalletInitResult{
+		IdentityPubKey: resp.IdentityPubkey,
+	}, nil
+}
+
+// GetBalance returns the daemon's current wallet balances split across the
+// boarding and VTXO buckets.
+func (c *Client) GetBalance(ctx context.Context) (
+	*daemonrpc.GetBalanceResponse, error) {
+
+	resp, err := c.daemon.GetBalance(ctx,
+		&daemonrpc.GetBalanceRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("get wallet balance: %w", err)
+	}
+
+	return resp, nil
+}
+
+// ListVTXOs returns the daemon's known VTXOs using the supplied filter
+// request. Passing nil uses the daemon defaults with no extra filters.
+func (c *Client) ListVTXOs(ctx context.Context,
+	req *daemonrpc.ListVTXOsRequest) (*daemonrpc.ListVTXOsResponse, error) {
+
+	if req == nil {
+		req = &daemonrpc.ListVTXOsRequest{}
+	}
+
+	resp, err := c.daemon.ListVTXOs(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("list vtxos: %w", err)
+	}
+
+	return resp, nil
+}
+
+// NewAddress allocates a fresh boarding address from the daemon wallet.
+func (c *Client) NewAddress(ctx context.Context) (
+	*daemonrpc.NewAddressResponse, error) {
+
+	resp, err := c.daemon.NewAddress(ctx, &daemonrpc.NewAddressRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("create boarding address: %w", err)
+	}
+
+	return resp, nil
+}
+
+// NewOORReceiveScript allocates and registers a fresh OOR receive script with
+// the daemon and indexer.
+func (c *Client) NewOORReceiveScript(ctx context.Context, label string) (
+	*daemonrpc.NewOORReceiveScriptResponse, error) {
+
+	resp, err := c.daemon.NewOORReceiveScript(ctx,
+		&daemonrpc.NewOORReceiveScriptRequest{
+			Label: label,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create oor receive script: %w", err)
+	}
+
+	return resp, nil
+}
+
+// AllocateOORReceiveScript allocates and decodes a wallet-owned OOR receive
+// destination for higher-level callers such as sdk/swaps.
+func (c *Client) AllocateOORReceiveScript(ctx context.Context,
+	label string) (*OORReceiveInfo, error) {
+
+	resp, err := c.NewOORReceiveScript(ctx, label)
+	if err != nil {
+		return nil, err
+	}
+
+	return newOORReceiveInfo(resp)
+}
+
+// GetIndexedVTXOByPkScript asks the daemon's indexer client for the first VTXO
+// matching the supplied script and status filters. Passing nil uses the
+// daemon defaults.
+func (c *Client) GetIndexedVTXOByPkScript(ctx context.Context,
+	req *daemonrpc.GetIndexedVTXOByPkScriptRequest) (
+	*daemonrpc.GetIndexedVTXOByPkScriptResponse, error) {
+
+	if req == nil {
+		req = &daemonrpc.GetIndexedVTXOByPkScriptRequest{}
+	}
+
+	resp, err := c.daemon.GetIndexedVTXOByPkScript(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("get indexed vtxo by script: %w", err)
+	}
+
+	return resp, nil
+}
+
+// GetIndexedOORSessionByTxid asks the daemon's indexer client for the indexed
+// OOR session matching the supplied spent-script proof and session txid.
+// Passing nil uses the daemon defaults.
+func (c *Client) GetIndexedOORSessionByTxid(ctx context.Context,
+	req *daemonrpc.GetIndexedOORSessionByTxidRequest) (
+	*daemonrpc.GetIndexedOORSessionByTxidResponse, error) {
+
+	if req == nil {
+		req = &daemonrpc.GetIndexedOORSessionByTxidRequest{}
+	}
+
+	resp, err := c.daemon.GetIndexedOORSessionByTxid(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("get indexed oor session: %w", err)
+	}
+
+	return resp, nil
+}
+
+// FindLiveVTXOByPkScript returns the first live indexed VTXO matching the
+// supplied output script.
+func (c *Client) FindLiveVTXOByPkScript(ctx context.Context,
+	pkScript []byte) (*VTXOInfo, error) {
+
+	return c.findIndexedVTXOByPkScript(
+		ctx, pkScript, daemonrpc.VTXOStatus_VTXO_STATUS_LIVE,
+	)
+}
+
+// FindSpentVTXOByPkScript returns the first spent indexed VTXO matching the
+// supplied output script.
+func (c *Client) FindSpentVTXOByPkScript(ctx context.Context,
+	pkScript []byte) (*VTXOInfo, error) {
+
+	return c.findIndexedVTXOByPkScript(
+		ctx, pkScript, daemonrpc.VTXOStatus_VTXO_STATUS_SPENT,
+	)
+}
+
+// findIndexedVTXOByPkScript queries the daemon's authoritative indexer view
+// for one VTXO matching the supplied script and status.
+func (c *Client) findIndexedVTXOByPkScript(ctx context.Context,
+	pkScript []byte, status daemonrpc.VTXOStatus) (*VTXOInfo, error) {
+
+	resp, err := c.GetIndexedVTXOByPkScript(ctx,
+		&daemonrpc.GetIndexedVTXOByPkScriptRequest{
+			PkScript: append([]byte(nil), pkScript...),
+			StatusFilter: []daemonrpc.VTXOStatus{
+				status,
+			},
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.GetVtxo() == nil {
+		return nil, nil
+	}
+
+	return newVTXOInfo(resp.GetVtxo())
+}
+
+// GetIndexedOORSession looks up one indexed OOR session by the spent output
+// script and deterministic session txid.
+func (c *Client) GetIndexedOORSession(ctx context.Context, pkScript []byte,
+	sessionTxID string) (*IndexedOORSessionInfo, error) {
+
+	sessionHash, err := parseSessionTxID(sessionTxID)
+	if err != nil {
+		return nil, fmt.Errorf("parse session txid: %w", err)
+	}
+
+	resp, err := c.GetIndexedOORSessionByTxid(ctx,
+		&daemonrpc.GetIndexedOORSessionByTxidRequest{
+			PkScript:    append([]byte(nil), pkScript...),
+			SessionTxid: sessionHash,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return newIndexedOORSessionInfo(resp), nil
+}
+
+// SendVTXO submits an in-round send request through the daemon. Passing nil
+// uses an empty request.
+func (c *Client) SendVTXO(ctx context.Context,
+	req *daemonrpc.SendVTXORequest) (*daemonrpc.SendVTXOResponse, error) {
+
+	if req == nil {
+		req = &daemonrpc.SendVTXORequest{}
+	}
+
+	resp, err := c.daemon.SendVTXO(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("send vtxo: %w", err)
+	}
+
+	return resp, nil
+}
+
+// SendOOR submits an out-of-round send request through the daemon. Passing nil
+// uses an empty request.
+func (c *Client) SendOOR(ctx context.Context,
+	req *daemonrpc.SendOORRequest) (*daemonrpc.SendOORResponse, error) {
+
+	if req == nil {
+		req = &daemonrpc.SendOORRequest{}
+	}
+
+	resp, err := c.daemon.SendOOR(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("send oor transfer: %w", err)
+	}
+
+	return resp, nil
+}
+
+// SendOORWithPolicy sends one OOR transfer to a semantic policy-backed
+// destination and returns the resulting OOR session id.
+func (c *Client) SendOORWithPolicy(ctx context.Context, amountSat int64,
+	recipientPolicyTemplate []byte) (string, error) {
+
+	resp, err := c.SendOOR(ctx, &daemonrpc.SendOORRequest{
+		Recipient: &daemonrpc.Output{
+			Destination: &daemonrpc.Output_PolicyTemplate{
+				PolicyTemplate: append(
+					[]byte(nil), recipientPolicyTemplate...,
+				),
+			},
+			AmountSat: amountSat,
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return resp.GetSessionId(), nil
+}
+
+// SendOORWithCustomInputs sends one OOR transfer using caller-specified
+// inputs and a standard x-only pubkey destination.
+func (c *Client) SendOORWithCustomInputs(ctx context.Context,
+	recipientPubKey []byte, amountSat int64,
+	inputs []CustomOORInput) (string, error) {
+
+	rpcInputs := make([]*daemonrpc.CustomOORInput, len(inputs))
+	for i := range inputs {
+		rpcInputs[i] = &daemonrpc.CustomOORInput{
+			Outpoint: inputs[i].Outpoint,
+			VtxoPolicyTemplate: append(
+				[]byte(nil), inputs[i].VTXOPolicyTemplate...,
+			),
+			SpendPath: append([]byte(nil), inputs[i].SpendPath...),
+			AmountSat: inputs[i].AmountSat,
+			PkScript:  append([]byte(nil), inputs[i].PkScript...),
+		}
+	}
+
+	resp, err := c.SendOOR(ctx, &daemonrpc.SendOORRequest{
+		Recipient: &daemonrpc.Output{
+			Destination: &daemonrpc.Output_Pubkey{
+				Pubkey: append([]byte(nil), recipientPubKey...),
+			},
+			AmountSat: amountSat,
+		},
+		CustomInputs: rpcInputs,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return resp.GetSessionId(), nil
+}
+
+// ListLiveVTXOs returns the daemon's live spendable VTXOs as typed SDK-owned
+// models.
+func (c *Client) ListLiveVTXOs(ctx context.Context) ([]VTXOInfo, error) {
+	return c.listVTXOsByStatus(
+		ctx, daemonrpc.VTXOStatus_VTXO_STATUS_LIVE,
+	)
+}
+
+// ListSpentVTXOs returns the daemon's locally tracked spent VTXOs as typed
+// SDK-owned models.
+func (c *Client) ListSpentVTXOs(ctx context.Context) ([]VTXOInfo, error) {
+	return c.listVTXOsByStatus(
+		ctx, daemonrpc.VTXOStatus_VTXO_STATUS_SPENT,
+	)
+}
+
+// listVTXOsByStatus loads one daemon VTXO status bucket and converts it into
+// typed SDK-owned models.
+func (c *Client) listVTXOsByStatus(ctx context.Context,
+	status daemonrpc.VTXOStatus) ([]VTXOInfo, error) {
+
+	resp, err := c.ListVTXOs(ctx, &daemonrpc.ListVTXOsRequest{
+		StatusFilter: status,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	vtxos := make([]VTXOInfo, 0, len(resp.GetVtxos()))
+	for _, vtxo := range resp.GetVtxos() {
+		info, err := newVTXOInfo(vtxo)
+		if err != nil {
+			return nil, err
+		}
+
+		vtxos = append(vtxos, *info)
+	}
+
+	return vtxos, nil
+}
+
+// RefreshVTXOs queues one or more VTXOs for refresh in the next round.
+// Passing nil uses an empty request.
+func (c *Client) RefreshVTXOs(ctx context.Context,
+	req *daemonrpc.RefreshVTXOsRequest) (
+	*daemonrpc.RefreshVTXOsResponse, error) {
+
+	if req == nil {
+		req = &daemonrpc.RefreshVTXOsRequest{}
+	}
+
+	resp, err := c.daemon.RefreshVTXOs(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("refresh vtxos: %w", err)
+	}
+
+	return resp, nil
+}
+
+// Board tells the daemon to register any confirmed boarding UTXOs in the next
+// round.
+func (c *Client) Board(ctx context.Context) (
+	*daemonrpc.BoardResponse, error) {
+
+	resp, err := c.daemon.Board(ctx, &daemonrpc.BoardRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("board confirmed utxos: %w", err)
+	}
+
+	return resp, nil
+}
+
+// ListRounds returns the daemon's current round FSM snapshots. Passing nil
+// uses the daemon defaults.
+func (c *Client) ListRounds(ctx context.Context,
+	req *daemonrpc.ListRoundsRequest) (
+	*daemonrpc.ListRoundsResponse, error) {
+
+	if req == nil {
+		req = &daemonrpc.ListRoundsRequest{}
+	}
+
+	resp, err := c.daemon.ListRounds(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("list rounds: %w", err)
+	}
+
+	return resp, nil
+}
+
+// WatchRounds subscribes to streaming round FSM updates from the daemon. This
+// is a pre-1.0 passthrough stream and currently exposes the generated gRPC
+// stream type directly.
+func (c *Client) WatchRounds(ctx context.Context) (
+	grpc.ServerStreamingClient[daemonrpc.WatchRoundsResponse], error) {
+
+	stream, err := c.daemon.WatchRounds(ctx,
+		&daemonrpc.WatchRoundsRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("watch rounds: %w", err)
+	}
+
+	return stream, nil
+}
+
+// EstimateFee asks the daemon to proxy an operator fee estimate for the
+// supplied operation parameters. Passing nil uses an empty request.
+func (c *Client) EstimateFee(ctx context.Context,
+	req *daemonrpc.EstimateFeeRequest) (
+	*daemonrpc.EstimateFeeResponse, error) {
+
+	if req == nil {
+		req = &daemonrpc.EstimateFeeRequest{}
+	}
+
+	resp, err := c.daemon.EstimateFee(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("estimate fee: %w", err)
+	}
+
+	return resp, nil
+}
+
+// GetFeeHistory returns paginated fee history from the daemon's local ledger.
+// Passing nil uses the daemon defaults.
+func (c *Client) GetFeeHistory(ctx context.Context,
+	req *daemonrpc.GetFeeHistoryRequest) (
+	*daemonrpc.GetFeeHistoryResponse, error) {
+
+	if req == nil {
+		req = &daemonrpc.GetFeeHistoryRequest{}
+	}
+
+	resp, err := c.daemon.GetFeeHistory(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("get fee history: %w", err)
+	}
+
+	return resp, nil
+}
+
+// parseHexPubKey decodes and parses one compressed public key encoded as hex.
+func parseHexPubKey(pubKeyHex, field string) (*btcec.PublicKey, error) {
+	pubKeyBytes, err := hex.DecodeString(pubKeyHex)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"decode %s public key hex: %w", field, err,
+		)
+	}
+
+	pubKey, err := btcec.ParsePubKey(pubKeyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s public key: %w", field, err)
+	}
+
+	return pubKey, nil
+}
+
+// newVTXOInfo converts one daemon protobuf VTXO into the SDK-owned typed
+// model, decoding any hex-encoded binary fields along the way.
+func newVTXOInfo(vtxo *daemonrpc.VTXO) (*VTXOInfo, error) {
+	pkScript, err := hex.DecodeString(vtxo.GetPkScript())
+	if err != nil {
+		return nil, fmt.Errorf("decode vtxo pk_script: %w", err)
+	}
+
+	checkpoints := make([][]byte, 0, len(vtxo.GetOorFinalCheckpointPsbts()))
+	for i := range vtxo.GetOorFinalCheckpointPsbts() {
+		checkpoints = append(checkpoints, append(
+			[]byte(nil), vtxo.GetOorFinalCheckpointPsbts()[i]...,
+		))
+	}
+
+	return &VTXOInfo{
+		Outpoint:             vtxo.GetOutpoint(),
+		AmountSat:            vtxo.GetAmountSat(),
+		Status:               vtxo.GetStatus(),
+		BatchExpiry:          vtxo.GetBatchExpiry(),
+		RoundID:              vtxo.GetRoundId(),
+		CreatedHeight:        vtxo.GetCreatedHeight(),
+		RelativeExpiry:       vtxo.GetRelativeExpiry(),
+		PkScript:             pkScript,
+		CommitmentTxID:       vtxo.GetCommitmentTxid(),
+		ChainDepth:           vtxo.GetChainDepth(),
+		FinalCheckpointPSBTs: checkpoints,
+		SpentByTxID:          vtxo.GetSpentByTxid(),
+	}, nil
+}
+
+// newOORReceiveInfo converts one daemon protobuf OOR receive-script response
+// into the SDK-owned typed model.
+func newOORReceiveInfo(resp *daemonrpc.NewOORReceiveScriptResponse) (
+	*OORReceiveInfo, error) {
+
+	pkScript, err := hex.DecodeString(resp.GetPkScriptHex())
+	if err != nil {
+		return nil, fmt.Errorf("decode oor receive pk_script: %w", err)
+	}
+
+	pubKeyXOnly, err := hex.DecodeString(resp.GetPubkeyXonlyHex())
+	if err != nil {
+		return nil, fmt.Errorf(
+			"decode oor receive x-only pubkey: %w", err,
+		)
+	}
+
+	return &OORReceiveInfo{
+		PkScript:    pkScript,
+		PubKeyXOnly: pubKeyXOnly,
+		KeyFamily:   resp.GetKeyFamily(),
+		KeyIndex:    resp.GetKeyIndex(),
+		Label:       resp.GetLabel(),
+	}, nil
+}
+
+// newIndexedOORSessionInfo converts one daemon protobuf indexed OOR session
+// into the SDK-owned typed model.
+func newIndexedOORSessionInfo(
+	resp *daemonrpc.GetIndexedOORSessionByTxidResponse,
+) *IndexedOORSessionInfo {
+
+	checkpoints := make([][]byte, 0, len(resp.GetCheckpointPsbts()))
+	for i := range resp.GetCheckpointPsbts() {
+		checkpoints = append(checkpoints, append(
+			[]byte(nil), resp.GetCheckpointPsbts()[i]...,
+		))
+	}
+
+	return &IndexedOORSessionInfo{
+		ArkPSBT:         append([]byte(nil), resp.GetArkPsbt()...),
+		CheckpointPSBTs: checkpoints,
+	}
+}
+
+// parseSessionTxID converts a human-readable txid string into the raw byte
+// order expected by the daemon's indexer RPC.
+func parseSessionTxID(sessionTxID string) ([]byte, error) {
+	hash, err := chainhash.NewHashFromStr(sessionTxID)
+	if err != nil {
+		return nil, err
+	}
+
+	return append([]byte(nil), hash[:]...), nil
+}

--- a/sdk/ark/client.go
+++ b/sdk/ark/client.go
@@ -237,6 +237,20 @@ type CustomOORInput struct {
 	PkScript []byte
 }
 
+// WrapDaemonClient creates an Ark SDK facade from an already-connected daemon
+// gRPC client. The optional closeFn lets callers release the underlying
+// transport when the SDK facade owns it; pass nil when another layer manages
+// the daemon client's lifetime.
+func WrapDaemonClient(daemon daemonrpc.DaemonServiceClient,
+	closeFn func(context.Context) error) *Client {
+
+	return &Client{
+		daemon:  daemon,
+		waitCh:  closedWaitChan(),
+		closeFn: closeFn,
+	}
+}
+
 // Close releases the client transport and, for embedded clients, shuts down
 // the in-process daemon.
 func (c *Client) Close() error {

--- a/sdk/ark/client_test.go
+++ b/sdk/ark/client_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 type fakeDaemonService struct {
@@ -760,6 +761,46 @@ func TestClientCloseIsIdempotent(t *testing.T) {
 	}
 
 	require.NoError(t, client.Close())
+	require.NoError(t, client.Close())
+	require.Equal(t, int32(1), closeCalls.Load())
+}
+
+// TestWrapDaemonClientUsesExistingClient verifies the SDK can wrap an already
+// constructed daemon client without introducing its own runtime supervision.
+func TestWrapDaemonClientUsesExistingClient(t *testing.T) {
+	t.Parallel()
+
+	serverAddr := startFakeDaemonServer(t)
+
+	conn, err := grpc.NewClient(
+		serverAddr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = conn.Close()
+	})
+
+	daemonClient := daemonrpc.NewDaemonServiceClient(conn)
+
+	var closeCalls atomic.Int32
+	client := WrapDaemonClient(daemonClient, func(context.Context) error {
+		closeCalls.Add(1)
+		return nil
+	})
+
+	info, err := client.GetInfo(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "1.2.3", info.Version)
+
+	select {
+	case _, ok := <-client.Wait():
+		require.False(t, ok)
+
+	default:
+		t.Fatal("expected wrapped client wait channel to be closed")
+	}
+
 	require.NoError(t, client.Close())
 	require.Equal(t, int32(1), closeCalls.Load())
 }

--- a/sdk/ark/client_test.go
+++ b/sdk/ark/client_test.go
@@ -1,0 +1,765 @@
+package ark
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"io"
+	"math/big"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/lightninglabs/darepo-client/darepod"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+)
+
+type fakeDaemonService struct {
+	daemonrpc.UnimplementedDaemonServiceServer
+
+	mu sync.Mutex
+
+	infoResp              *daemonrpc.GetInfoResponse
+	listVtxosResp         *daemonrpc.ListVTXOsResponse
+	newOORReceiveResp     *daemonrpc.NewOORReceiveScriptResponse
+	indexedVTXOResp       *daemonrpc.GetIndexedVTXOByPkScriptResponse
+	indexedOORSessionResp *daemonrpc.GetIndexedOORSessionByTxidResponse
+	sendOORResp           *daemonrpc.SendOORResponse
+
+	lastListVTXOsReq   *daemonrpc.ListVTXOsRequest
+	lastIndexedVTXOReq *daemonrpc.GetIndexedVTXOByPkScriptRequest
+	lastIndexedOORReq  *daemonrpc.GetIndexedOORSessionByTxidRequest
+	lastSendOORReq     *daemonrpc.SendOORRequest
+}
+
+const (
+	// testLiveVTXOStatus keeps the fake VTXO response readable while
+	// staying within the repository's line-length limit.
+	testLiveVTXOStatus = daemonrpc.VTXOStatus_VTXO_STATUS_LIVE
+)
+
+// watchRoundsResponse shortens the generic stream signature used by the fake
+// daemon service.
+type watchRoundsResponse = daemonrpc.WatchRoundsResponse
+
+var (
+	// testIdentityPubKeyHex is the deterministic compressed pubkey used for
+	// the fake daemon identity.
+	testIdentityPubKeyHex = compressedPubKeyHex(1)
+
+	// testOperatorPubKeyHex is the deterministic compressed pubkey used for
+	// the fake operator terms.
+	testOperatorPubKeyHex = compressedPubKeyHex(2)
+
+	// testSweepPubKeyHex is the deterministic compressed pubkey used for
+	// the fake sweep key.
+	testSweepPubKeyHex = compressedPubKeyHex(3)
+)
+
+// newFakeDaemonService creates a fake daemon service with deterministic
+// defaults that the SDK tests can override per case.
+func newFakeDaemonService() *fakeDaemonService {
+	return &fakeDaemonService{
+		infoResp: &daemonrpc.GetInfoResponse{
+			Version:         "1.2.3",
+			Commit:          "deadbeef",
+			Network:         "regtest",
+			ServerConnected: true,
+			WalletType:      "btcwallet",
+			WalletReady:     true,
+			IdentityPubkey:  testIdentityPubKeyHex,
+			ServerInfo: &daemonrpc.ServerInfo{
+				OperatorPubkey: mustDecodeHex(
+					testOperatorPubKeyHex,
+				),
+				BoardingExitDelay: 144,
+				VtxoExitDelay:     288,
+				ForfeitScript:     []byte{0x51},
+				SweepKey: mustDecodeHex(
+					testSweepPubKeyHex,
+				),
+				SweepDelay:        432,
+				DustLimit:         546,
+				MinBoardingAmount: 10_000,
+				MaxBoardingAmount: 20_000,
+				FeeRate:           15,
+				MinOperatorFee:    20,
+				MinConfirmations:  2,
+			},
+		},
+		listVtxosResp: &daemonrpc.ListVTXOsResponse{
+			Vtxos: []*daemonrpc.VTXO{
+				{
+					Outpoint:  "txid:0",
+					AmountSat: 1234,
+					Status:    testLiveVTXOStatus,
+					PkScript:  "5120c0ffee",
+					OorFinalCheckpointPsbts: [][]byte{
+						{0x01, 0x02},
+					},
+					SpentByTxid: "spent-txid",
+				},
+			},
+		},
+		newOORReceiveResp: &daemonrpc.NewOORReceiveScriptResponse{
+			PkScriptHex: "5120c0ffee",
+			PubkeyXonlyHex: "11111111111111111111111111111111" +
+				"11111111111111111111111111111111",
+			KeyFamily: 23,
+			KeyIndex:  7,
+			Label:     "receive-label",
+		},
+		indexedVTXOResp: &daemonrpc.GetIndexedVTXOByPkScriptResponse{
+			Vtxo: &daemonrpc.VTXO{
+				Outpoint:  "indexed:1",
+				AmountSat: 42,
+				Status: daemonrpc.
+					VTXOStatus_VTXO_STATUS_SPENT,
+				PkScript:                "5120c0ffee",
+				OorFinalCheckpointPsbts: [][]byte{{0xaa}},
+				SpentByTxid:             "indexed-spender",
+			},
+		},
+		indexedOORSessionResp: &daemonrpc.
+			GetIndexedOORSessionByTxidResponse{
+			ArkPsbt:         []byte{0x01, 0x02, 0x03},
+			CheckpointPsbts: [][]byte{{0x04}, {0x05}},
+		},
+		sendOORResp: &daemonrpc.SendOORResponse{
+			SessionId: "session-123",
+		},
+	}
+}
+
+// mustDecodeHex decodes a hex string for deterministic test fixtures.
+func mustDecodeHex(value string) []byte {
+	decoded, err := hex.DecodeString(value)
+	if err != nil {
+		panic(err)
+	}
+
+	return decoded
+}
+
+// compressedPubKeyHex deterministically derives one compressed public key hex
+// string from a tiny scalar for test fixtures.
+func compressedPubKeyHex(scalar byte) string {
+	privKeyBytes := make([]byte, 32)
+	privKeyBytes[len(privKeyBytes)-1] = scalar
+
+	_, pubKey := btcec.PrivKeyFromBytes(privKeyBytes)
+
+	return hex.EncodeToString(pubKey.SerializeCompressed())
+}
+
+// startFakeDaemonServer boots a fake daemon gRPC server and returns the
+// listener address that tests can dial through the SDK facade.
+func startFakeDaemonServer(t *testing.T,
+	serverOpts ...grpc.ServerOption) string {
+
+	return startFakeDaemonServerWithService(
+		t, newFakeDaemonService(), serverOpts...,
+	)
+}
+
+// startFakeDaemonServerWithService boots a fake daemon gRPC server using the
+// supplied service implementation and returns the listener address that tests
+// can dial through the SDK facade.
+func startFakeDaemonServerWithService(t *testing.T,
+	service daemonrpc.DaemonServiceServer,
+	serverOpts ...grpc.ServerOption) string {
+
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	server := grpc.NewServer(serverOpts...)
+	daemonrpc.RegisterDaemonServiceServer(server, service)
+
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- server.Serve(listener)
+	}()
+
+	t.Cleanup(func() {
+		server.Stop()
+		<-errChan
+	})
+
+	return listener.Addr().String()
+}
+
+// newLoopbackTLSCreds creates matching server and client transport
+// credentials for a loopback-only TLS test server.
+func newLoopbackTLSCreds(t *testing.T) (
+	credentials.TransportCredentials,
+	credentials.TransportCredentials) {
+
+	t.Helper()
+
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	serialNumber, err := rand.Int(
+		rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128),
+	)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			CommonName: "127.0.0.1",
+		},
+		NotBefore: time.Now().Add(-1 * time.Hour),
+		NotAfter:  time.Now().Add(24 * time.Hour),
+		KeyUsage: x509.KeyUsageDigitalSignature |
+			x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage: []x509.ExtKeyUsage{
+			x509.ExtKeyUsageServerAuth,
+		},
+		IPAddresses: []net.IP{
+			net.ParseIP("127.0.0.1"),
+		},
+		DNSNames: []string{"localhost"},
+	}
+
+	certDER, err := x509.CreateCertificate(
+		rand.Reader, template, template, &privKey.PublicKey, privKey,
+	)
+	require.NoError(t, err)
+
+	cert := tls.Certificate{
+		Certificate: [][]byte{certDER},
+		PrivateKey:  privKey,
+	}
+	serverCreds := credentials.NewServerTLSFromCert(&cert)
+
+	pool := x509.NewCertPool()
+	parsedCert, err := x509.ParseCertificate(certDER)
+	require.NoError(t, err)
+	pool.AddCert(parsedCert)
+
+	clientCreds := credentials.NewTLS(&tls.Config{
+		RootCAs:    pool,
+		ServerName: "127.0.0.1",
+		MinVersion: tls.VersionTLS12,
+	})
+
+	return serverCreds, clientCreds
+}
+
+// GetInfo returns a fixed response so the remote-client test can assert the
+// SDK's proto-to-typed-model conversion.
+func (f *fakeDaemonService) GetInfo(context.Context,
+	*daemonrpc.GetInfoRequest) (*daemonrpc.GetInfoResponse, error) {
+
+	return f.infoResp, nil
+}
+
+// GetBalance returns a fixed balance response so the SDK wrapper can be
+// exercised against a remote daemon transport.
+func (f *fakeDaemonService) GetBalance(context.Context,
+	*daemonrpc.GetBalanceRequest) (*daemonrpc.GetBalanceResponse, error) {
+
+	return &daemonrpc.GetBalanceResponse{
+		BoardingConfirmedSat:   111,
+		BoardingUnconfirmedSat: 222,
+		VtxoBalanceSat:         333,
+		TotalConfirmedSat:      444,
+	}, nil
+}
+
+// ListVTXOs returns one fixed VTXO so the SDK's thin passthrough wrapper can
+// be exercised without needing a real daemon database.
+func (f *fakeDaemonService) ListVTXOs(_ context.Context,
+	req *daemonrpc.ListVTXOsRequest) (*daemonrpc.ListVTXOsResponse, error) {
+
+	f.mu.Lock()
+	f.lastListVTXOsReq = req
+	f.mu.Unlock()
+
+	return f.listVtxosResp, nil
+}
+
+// NewAddress returns a fixed boarding address for SDK facade testing.
+func (f *fakeDaemonService) NewAddress(context.Context,
+	*daemonrpc.NewAddressRequest) (*daemonrpc.NewAddressResponse, error) {
+
+	return &daemonrpc.NewAddressResponse{
+		Address: "bcrt1ptestaddress",
+	}, nil
+}
+
+// NewOORReceiveScript returns one deterministic OOR receive script so the SDK
+// can verify its typed receive-script helper.
+func (f *fakeDaemonService) NewOORReceiveScript(_ context.Context,
+	_ *daemonrpc.NewOORReceiveScriptRequest) (
+	*daemonrpc.NewOORReceiveScriptResponse, error) {
+
+	return f.newOORReceiveResp, nil
+}
+
+// GetIndexedVTXOByPkScript returns one deterministic indexed VTXO and records
+// the lookup request for helper assertions.
+func (f *fakeDaemonService) GetIndexedVTXOByPkScript(_ context.Context,
+	req *daemonrpc.GetIndexedVTXOByPkScriptRequest) (
+	*daemonrpc.GetIndexedVTXOByPkScriptResponse, error) {
+
+	f.mu.Lock()
+	f.lastIndexedVTXOReq = req
+	f.mu.Unlock()
+
+	return f.indexedVTXOResp, nil
+}
+
+// GetIndexedOORSessionByTxid returns one deterministic indexed OOR session
+// and records the lookup request for helper assertions.
+func (f *fakeDaemonService) GetIndexedOORSessionByTxid(_ context.Context,
+	req *daemonrpc.GetIndexedOORSessionByTxidRequest) (
+	*daemonrpc.GetIndexedOORSessionByTxidResponse, error) {
+
+	f.mu.Lock()
+	f.lastIndexedOORReq = req
+	f.mu.Unlock()
+
+	return f.indexedOORSessionResp, nil
+}
+
+// SendOOR records the submitted OOR request and returns one deterministic
+// session id so the helper methods can assert their request translation.
+func (f *fakeDaemonService) SendOOR(_ context.Context,
+	req *daemonrpc.SendOORRequest) (*daemonrpc.SendOORResponse, error) {
+
+	f.mu.Lock()
+	f.lastSendOORReq = req
+	f.mu.Unlock()
+
+	return f.sendOORResp, nil
+}
+
+// Board returns a fixed status so the SDK can verify the board wrapper against
+// a remote daemon.
+func (f *fakeDaemonService) Board(context.Context,
+	*daemonrpc.BoardRequest) (*daemonrpc.BoardResponse, error) {
+
+	return &daemonrpc.BoardResponse{Status: "registered"}, nil
+}
+
+// EstimateFee returns a fixed fee quote for the SDK facade test.
+func (f *fakeDaemonService) EstimateFee(context.Context,
+	*daemonrpc.EstimateFeeRequest) (*daemonrpc.EstimateFeeResponse, error) {
+
+	return &daemonrpc.EstimateFeeResponse{
+		TotalFeeSat:         77,
+		BelowDustWarning:    false,
+		MinViableAmountSat:  1000,
+		EffectiveAnnualRate: 0.5,
+	}, nil
+}
+
+// GetFeeHistory returns one fixed ledger entry for the SDK facade test.
+func (f *fakeDaemonService) GetFeeHistory(context.Context,
+	*daemonrpc.GetFeeHistoryRequest) (
+	*daemonrpc.GetFeeHistoryResponse, error) {
+
+	return &daemonrpc.GetFeeHistoryResponse{
+		Entries: []*daemonrpc.FeeHistoryEntry{
+			{
+				EntryId:       1,
+				EventType:     "vtxo_sent",
+				AmountSat:     55,
+				DebitAccount:  "transfers_out",
+				CreditAccount: "vtxo_balance",
+			},
+		},
+		TotalFeesPaidSat: 999,
+	}, nil
+}
+
+// WatchRounds sends one synthetic round update and then closes the stream so
+// the SDK can verify its streaming wrapper.
+func (f *fakeDaemonService) WatchRounds(_ *daemonrpc.WatchRoundsRequest,
+	stream grpc.ServerStreamingServer[watchRoundsResponse]) error {
+
+	if err := stream.Send(&daemonrpc.WatchRoundsResponse{
+		Round: &daemonrpc.RoundInfo{
+			RoundId: "round-1",
+			State:   daemonrpc.RoundState_ROUND_STATE_JOINED,
+		},
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// TestDialRemoteGetInfo verifies the SDK can talk to a standalone daemon
+// endpoint and convert the protobuf GetInfo response into the typed SDK model.
+func TestDialRemoteGetInfo(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	client, err := DialRemote(ctx, RemoteConfig{
+		Address:       startFakeDaemonServer(t),
+		AllowInsecure: true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, client.Close())
+	})
+
+	info, err := client.GetInfo(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "1.2.3", info.Version)
+	require.True(t, info.ServerConnected)
+	require.NotNil(t, info.ServerInfo)
+	require.Equal(t, mustDecodeHex(testOperatorPubKeyHex),
+		info.ServerInfo.OperatorPubKey,
+	)
+	require.Equal(t, uint32(144),
+		info.ServerInfo.BoardingExitDelay,
+	)
+	require.Equal(t, uint64(20),
+		info.ServerInfo.MinOperatorFee,
+	)
+}
+
+// TestDialRemoteCoversFacadeMethods verifies the thin SDK wrappers beyond
+// GetInfo by exercising representative unary and streaming daemon RPCs.
+func TestDialRemoteCoversFacadeMethods(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	client, err := DialRemote(ctx, RemoteConfig{
+		Address:       startFakeDaemonServer(t),
+		AllowInsecure: true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, client.Close())
+	})
+
+	balance, err := client.GetBalance(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, int64(444), balance.TotalConfirmedSat)
+
+	vtxos, err := client.ListVTXOs(context.Background(), nil)
+	require.NoError(t, err)
+	require.Len(t, vtxos.Vtxos, 1)
+
+	address, err := client.NewAddress(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "bcrt1ptestaddress", address.Address)
+
+	boardResp, err := client.Board(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "registered", boardResp.Status)
+
+	feeResp, err := client.EstimateFee(context.Background(),
+		&daemonrpc.EstimateFeeRequest{AmountSat: 10_000})
+	require.NoError(t, err)
+	require.Equal(t, int64(77), feeResp.TotalFeeSat)
+
+	history, err := client.GetFeeHistory(context.Background(),
+		&daemonrpc.GetFeeHistoryRequest{Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, history.Entries, 1)
+
+	stream, err := client.WatchRounds(context.Background())
+	require.NoError(t, err)
+
+	update, err := stream.Recv()
+	require.NoError(t, err)
+	require.Equal(t, "round-1", update.Round.RoundId)
+
+	_, err = stream.Recv()
+	require.ErrorIs(t, err, io.EOF)
+}
+
+// TestDialRemotePolicyHelpers verifies the higher-level policy and indexer
+// helpers that sdk/swaps will depend on, so those adapters can live in
+// sdk/ark rather than being reimplemented in the swap layer.
+func TestDialRemotePolicyHelpers(t *testing.T) {
+	t.Parallel()
+
+	service := newFakeDaemonService()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	client, err := DialRemote(ctx, RemoteConfig{
+		Address:       startFakeDaemonServerWithService(t, service),
+		AllowInsecure: true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, client.Close())
+	})
+
+	identityPubKey, err := client.IdentityPubKey(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, testIdentityPubKeyHex,
+		hex.EncodeToString(identityPubKey.SerializeCompressed()),
+	)
+
+	operatorPubKey, err := client.OperatorPubKey(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, testOperatorPubKeyHex,
+		hex.EncodeToString(operatorPubKey.SerializeCompressed()),
+	)
+
+	sessionID, err := client.SendOORWithPolicy(
+		context.Background(), 42_000, []byte{0xaa, 0xbb},
+	)
+	require.NoError(t, err)
+	require.Equal(t, "session-123", sessionID)
+
+	service.mu.Lock()
+	policyReq := service.lastSendOORReq
+	service.mu.Unlock()
+
+	require.NotNil(t, policyReq)
+	require.Equal(t, int64(42_000), policyReq.GetRecipient().GetAmountSat())
+	require.Equal(t, []byte{0xaa, 0xbb},
+		policyReq.GetRecipient().GetPolicyTemplate(),
+	)
+
+	sessionID, err = client.SendOORWithCustomInputs(
+		context.Background(), []byte{0x11, 0x22}, 21_000,
+		[]CustomOORInput{
+			{
+				Outpoint:           "custom:0",
+				VTXOPolicyTemplate: []byte{0x01},
+				SpendPath:          []byte{0x02},
+				AmountSat:          21_000,
+				PkScript:           []byte{0x51},
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, "session-123", sessionID)
+
+	service.mu.Lock()
+	customReq := service.lastSendOORReq
+	service.mu.Unlock()
+
+	require.NotNil(t, customReq)
+	require.Equal(t, []byte{0x11, 0x22},
+		customReq.GetRecipient().GetPubkey(),
+	)
+	require.Len(t, customReq.GetCustomInputs(), 1)
+	require.Equal(
+		t, "custom:0", customReq.GetCustomInputs()[0].GetOutpoint(),
+	)
+
+	liveVTXOs, err := client.ListLiveVTXOs(context.Background())
+	require.NoError(t, err)
+	require.Len(t, liveVTXOs, 1)
+	require.Equal(t, []byte{0x51, 0x20, 0xc0, 0xff, 0xee},
+		liveVTXOs[0].PkScript,
+	)
+
+	service.mu.Lock()
+	listReq := service.lastListVTXOsReq
+	service.mu.Unlock()
+
+	require.NotNil(t, listReq)
+	require.Equal(t, daemonrpc.VTXOStatus_VTXO_STATUS_LIVE,
+		listReq.GetStatusFilter(),
+	)
+
+	indexedVTXO, err := client.FindSpentVTXOByPkScript(
+		context.Background(), []byte{0x51, 0x20, 0xc0, 0xff, 0xee},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, indexedVTXO)
+	require.Equal(t, "indexed:1", indexedVTXO.Outpoint)
+
+	service.mu.Lock()
+	indexedReq := service.lastIndexedVTXOReq
+	service.mu.Unlock()
+
+	require.NotNil(t, indexedReq)
+	require.Equal(t, []byte{0x51, 0x20, 0xc0, 0xff, 0xee},
+		indexedReq.GetPkScript(),
+	)
+	require.Equal(t, []daemonrpc.VTXOStatus{
+		daemonrpc.VTXOStatus_VTXO_STATUS_SPENT,
+	}, indexedReq.GetStatusFilter())
+
+	receiveInfo, err := client.AllocateOORReceiveScript(
+		context.Background(), "receive-label",
+	)
+	require.NoError(t, err)
+	require.Equal(t, []byte{0x51, 0x20, 0xc0, 0xff, 0xee},
+		receiveInfo.PkScript,
+	)
+	require.Equal(t, uint32(23), receiveInfo.KeyFamily)
+
+	const sessionTxID = "11111111111111111111111111111111" +
+		"11111111111111111111111111111111"
+
+	session, err := client.GetIndexedOORSession(
+		context.Background(), []byte{0x51},
+		sessionTxID,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []byte{0x01, 0x02, 0x03}, session.ArkPSBT)
+	require.Len(t, session.CheckpointPSBTs, 2)
+
+	service.mu.Lock()
+	indexedOORReq := service.lastIndexedOORReq
+	service.mu.Unlock()
+
+	require.NotNil(t, indexedOORReq)
+	require.Equal(t, []byte{0x51}, indexedOORReq.GetPkScript())
+	expectedHash, err := chainhash.NewHashFromStr(sessionTxID)
+	require.NoError(t, err)
+	require.Equal(t, expectedHash[:], indexedOORReq.GetSessionTxid())
+}
+
+// TestDialRemoteRequiresExplicitInsecureOptIn verifies that remote dialers
+// must either provide TLS credentials or explicitly allow plaintext
+// transport.
+func TestDialRemoteRequiresExplicitInsecureOptIn(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := DialRemote(ctx, RemoteConfig{
+		Address: startFakeDaemonServer(t),
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "credentials are required")
+}
+
+// TestDialRemoteTLSGetInfo verifies the remote SDK path works with explicit
+// TLS credentials instead of development-only insecure transport.
+func TestDialRemoteTLSGetInfo(t *testing.T) {
+	t.Parallel()
+
+	serverCreds, clientCreds := newLoopbackTLSCreds(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	client, err := DialRemote(ctx, RemoteConfig{
+		Address: startFakeDaemonServer(
+			t, grpc.Creds(serverCreds),
+		),
+		Credentials: clientCreds,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, client.Close())
+	})
+
+	info, err := client.GetInfo(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "1.2.3", info.Version)
+}
+
+// TestStartEmbeddedUsesBufconnTransport verifies the SDK can boot an embedded
+// daemon, call pre-wallet RPCs, and leave the caller's config unmodified.
+func TestStartEmbeddedUsesBufconnTransport(t *testing.T) {
+	t.Parallel()
+
+	cfg := darepod.DefaultConfig()
+	cfg.DataDir = t.TempDir()
+	cfg.Network = "regtest"
+	cfg.Server.Host = "127.0.0.1:10010"
+	cfg.Wallet.Type = darepod.WalletTypeBtcwallet
+	cfg.Wallet.FeeURL = "http://127.0.0.1:3001"
+	cfg.Wallet.EsploraURL = ""
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	client, err := StartEmbedded(ctx, EmbeddedConfig{
+		DaemonConfig: cfg,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, client.Close())
+	})
+
+	info, err := client.GetInfo(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "regtest", info.Network)
+	require.Equal(t, darepod.WalletTypeBtcwallet, info.WalletType)
+	require.False(t, info.WalletReady)
+
+	seed, err := client.GenSeed(context.Background(), nil)
+	require.NoError(t, err)
+	require.Len(t, seed.Mnemonic, 24)
+
+	waitErr := make(chan error, 1)
+	go func() {
+		waitErr <- <-client.Wait()
+	}()
+
+	require.NoError(t, client.Close())
+	require.NoError(t, <-waitErr)
+
+	require.Nil(t, cfg.RPC.Listener)
+}
+
+// TestStartEmbeddedFailsFastOnBootError verifies embedded startup returns the
+// daemon boot error promptly instead of waiting for the caller's readiness
+// timeout when the daemon exits during startup.
+func TestStartEmbeddedFailsFastOnBootError(t *testing.T) {
+	t.Parallel()
+
+	cfg := darepod.DefaultConfig()
+	cfg.DataDir = t.TempDir()
+	cfg.Network = "regtest"
+	cfg.Server.Host = "127.0.0.1:10010"
+	cfg.Wallet.Type = "bogus"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	_, err := StartEmbedded(ctx, EmbeddedConfig{
+		DaemonConfig: cfg,
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, `unknown wallet type "bogus"`)
+	require.Less(t, time.Since(start), time.Second)
+}
+
+// TestClientCloseIsIdempotent verifies repeated Close calls only run the
+// underlying shutdown path once.
+func TestClientCloseIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	var closeCalls atomic.Int32
+	client := &Client{
+		closeFn: func(context.Context) error {
+			closeCalls.Add(1)
+			return nil
+		},
+	}
+
+	require.NoError(t, client.Close())
+	require.NoError(t, client.Close())
+	require.Equal(t, int32(1), closeCalls.Load())
+}

--- a/sdk/ark/doc.go
+++ b/sdk/ark/doc.go
@@ -1,0 +1,36 @@
+// Package ark provides a consumer-facing Go SDK for interacting with a
+// darepod runtime. Callers can either connect to a remote daemon over gRPC or
+// embed a daemon in-process and talk to it over an injected in-memory
+// listener.
+//
+// The package intentionally treats darepod as the canonical Ark runtime. This
+// SDK owns transport, lifecycle, and Go ergonomics; it does not reimplement
+// wallet, round, OOR, or persistence logic outside the daemon.
+// Higher-level Ark policy, OOR, and indexed-lookup convenience methods also
+// live here so future layers such as sdk/swaps can depend on sdk/ark instead
+// of rebuilding daemonrpc adapter logic themselves.
+//
+// Readiness is staged. Callers should use GetInfo to learn which parts of the
+// runtime are ready: WalletReady gates wallet-dependent RPCs, ServerConnected
+// reports whether mailbox ingress is currently running, and ServerInfo stays
+// nil until operator terms have been cached during bootstrap. Round-oriented
+// callers should wait until WalletReady is true, ServerConnected is true, and
+// ServerInfo is non-nil before attempting round-sensitive operations. The
+// cached ServerInfo snapshot is currently refreshed only during bootstrap, so
+// callers should treat it as the latest known terms for the current session.
+//
+// Pre-1.0, some SDK methods intentionally return daemonrpc-generated protobuf
+// types directly. Those passthrough shapes are not yet stable and may change
+// as richer SDK-owned models are introduced. Higher-level callers such as a
+// future sdk/swaps package should treat those responses as a temporary
+// compatibility layer rather than a long-term public model commitment.
+//
+// Client is safe for concurrent use. Embedded clients expose Wait so callers
+// can block on the in-process daemon's terminal run error without waiting for
+// Close. Remote clients return an already-closed Wait channel because there
+// is no in-process runtime to supervise.
+//
+// See docs/sdk_layered_architecture.md for the layered architecture, error
+// categorization goals, and daemonrpc versioning expectations that this
+// package builds on.
+package ark

--- a/sdk/ark/embedded.go
+++ b/sdk/ark/embedded.go
@@ -1,0 +1,263 @@
+package ark
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/lightninglabs/darepo-client/darepod"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+const (
+	// defaultBufConnSize is the size of the in-memory listener buffer used
+	// by embedded clients that do not provide their own transport.
+	defaultBufConnSize = 1 << 20
+)
+
+// EmbeddedConfig configures an in-process daemon runtime managed by the SDK.
+type EmbeddedConfig struct {
+	// DaemonConfig is the full darepod configuration snapshot to clone
+	// and run in-process. The SDK currently hides transport and
+	// lifecycle management, not the underlying daemon configuration
+	// surface.
+	DaemonConfig *darepod.Config
+
+	// BufferSize overrides the bufconn listener size used for in-process
+	// gRPC traffic. When zero, the SDK uses a sane default.
+	BufferSize int
+
+	// DialOptions overrides the default gRPC dial options used against the
+	// injected in-memory listener.
+	DialOptions []grpc.DialOption
+}
+
+// StartEmbedded starts a darepod runtime in-process and returns an SDK facade
+// that communicates with it over an injected in-memory listener.
+func StartEmbedded(ctx context.Context,
+	cfg EmbeddedConfig) (*Client, error) {
+
+	if cfg.DaemonConfig == nil {
+		return nil, fmt.Errorf("daemon config is required")
+	}
+
+	daemonCfg := cloneDaemonConfig(cfg.DaemonConfig)
+	bufferSize := cfg.BufferSize
+	if bufferSize == 0 {
+		bufferSize = defaultBufConnSize
+	}
+
+	listener := bufconn.Listen(bufferSize)
+	if daemonCfg.RPC == nil {
+		daemonCfg.RPC = &darepod.RPCConfig{}
+	}
+	daemonCfg.RPC.Listener = listener
+
+	server, err := darepod.NewServer(daemonCfg)
+	if err != nil {
+		_ = listener.Close()
+
+		return nil, fmt.Errorf("create embedded daemon: %w", err)
+	}
+
+	// The embedded daemon has its own lifetime and should keep running
+	// after the startup dial context expires, so use a detached root
+	// context here.
+	runCtx, cancel := context.WithCancel(context.Background())
+	runErrChan := make(chan error, 1)
+	runDoneChan := make(chan error, 1)
+	waitErrChan := make(chan error, 1)
+	go func() {
+		runErr := server.RunWithContext(runCtx)
+		runErrChan <- runErr
+		runDoneChan <- runErr
+		waitErrChan <- runErr
+		close(waitErrChan)
+	}()
+
+	dialOpts := append([]grpc.DialOption(nil), cfg.DialOptions...)
+	if len(dialOpts) == 0 {
+		dialOpts = append(dialOpts,
+			grpc.WithTransportCredentials(
+				insecure.NewCredentials(),
+			),
+		)
+	}
+
+	dialOpts = append(dialOpts,
+		grpc.WithContextDialer(func(dialCtx context.Context,
+			_ string) (net.Conn, error) {
+
+			return listener.DialContext(dialCtx)
+		}),
+	)
+
+	conn, err := grpc.NewClient("passthrough:///bufnet", dialOpts...)
+	if err != nil {
+		cancel()
+		shutdownCtx, shutdownCancel := context.WithTimeout(
+			context.Background(), defaultCloseTimeout,
+		)
+
+		runErr := waitForRunExit(shutdownCtx, runErrChan)
+		shutdownCancel()
+		_ = listener.Close()
+
+		if runErr != nil {
+			return nil, fmt.Errorf(
+				"dial embedded daemon: %w (daemon exited: %w)",
+				err, runErr,
+			)
+		}
+
+		return nil, fmt.Errorf("dial embedded daemon: %w", err)
+	}
+
+	if err := waitForReady(ctx, conn, runDoneChan); err != nil {
+		closeErr := conn.Close()
+		cancel()
+		shutdownCtx, shutdownCancel := context.WithTimeout(
+			context.Background(), defaultCloseTimeout,
+		)
+
+		runErr := waitForRunExit(shutdownCtx, runErrChan)
+		shutdownCancel()
+		listenerErr := listener.Close()
+
+		return nil, fmt.Errorf("wait for embedded daemon readiness: %w",
+			errors.Join(err, closeErr, runErr, listenerErr),
+		)
+	}
+
+	return &Client{
+		daemon: daemonrpc.NewDaemonServiceClient(conn),
+		waitCh: waitErrChan,
+		closeFn: func(closeCtx context.Context) error {
+			closeErr := conn.Close()
+			cancel()
+			runErr := waitForRunExit(closeCtx, runErrChan)
+			listenerErr := listener.Close()
+
+			return errors.Join(closeErr, runErr, listenerErr)
+		},
+	}, nil
+}
+
+// cloneDaemonConfig copies the daemon config deeply enough that embedded
+// startup can inject a listener without mutating the caller's config. This is
+// intentionally a passthrough clone of darepod.Config and must be updated if
+// new reference-typed fields are added there.
+func cloneDaemonConfig(cfg *darepod.Config) *darepod.Config {
+	clone := *cfg
+
+	if cfg.Lnd != nil {
+		lndCfg := *cfg.Lnd
+		clone.Lnd = &lndCfg
+	}
+
+	if cfg.Server != nil {
+		serverCfg := *cfg.Server
+		clone.Server = &serverCfg
+	}
+
+	if cfg.RPC != nil {
+		rpcCfg := *cfg.RPC
+		clone.RPC = &rpcCfg
+	}
+
+	if cfg.Wallet != nil {
+		walletCfg := *cfg.Wallet
+		walletCfg.BtcwalletPeers = append(
+			[]string(nil), cfg.Wallet.BtcwalletPeers...,
+		)
+		walletCfg.BtcwalletAddPeers = append(
+			[]string(nil), cfg.Wallet.BtcwalletAddPeers...,
+		)
+		clone.Wallet = &walletCfg
+	}
+
+	return &clone
+}
+
+// waitForRunExit waits for the embedded daemon run goroutine to exit or for
+// the caller's shutdown context to expire.
+func waitForRunExit(ctx context.Context,
+	runErrChan <-chan error) error {
+
+	select {
+	case runErr := <-runErrChan:
+		return runErr
+
+	case <-ctx.Done():
+		return fmt.Errorf("wait for embedded daemon shutdown: %w",
+			ctx.Err())
+	}
+}
+
+// waitForReady forces a new client connection to attempt dialing and waits
+// until it reaches READY, the embedded daemon exits, or the caller's context
+// expires.
+func waitForReady(ctx context.Context, conn *grpc.ClientConn,
+	runDoneChan <-chan error) error {
+
+	conn.Connect()
+
+	for {
+		state := conn.GetState()
+		if state == connectivity.Ready {
+			return nil
+		}
+
+		if state == connectivity.Shutdown {
+			return fmt.Errorf(
+				"grpc connection shut down before readiness",
+			)
+		}
+
+		waitCtx, waitCancel := context.WithCancel(ctx)
+		runExitErr := make(chan error, 1)
+		go func() {
+			select {
+			case runErr := <-runDoneChan:
+				if runErr != nil {
+					runExitErr <- fmt.Errorf(
+						"embedded daemon exited "+
+							"before readiness: %w",
+						runErr,
+					)
+				} else {
+					runExitErr <- fmt.Errorf(
+						"embedded daemon exited " +
+							"before readiness",
+					)
+				}
+
+				waitCancel()
+
+			case <-waitCtx.Done():
+			}
+		}()
+
+		if !conn.WaitForStateChange(waitCtx, state) {
+			waitCancel()
+
+			select {
+			case err := <-runExitErr:
+				return err
+
+			default:
+			}
+
+			return fmt.Errorf(
+				"wait for grpc readiness: %w", ctx.Err(),
+			)
+		}
+
+		waitCancel()
+	}
+}

--- a/sdk/ark/remote.go
+++ b/sdk/ark/remote.go
@@ -1,0 +1,75 @@
+package ark
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// RemoteConfig configures a connection to a standalone darepod instance.
+type RemoteConfig struct {
+	// Address is the gRPC address of the standalone daemon.
+	Address string
+
+	// Credentials secures the remote daemon connection. Callers must
+	// either provide transport credentials here or opt into
+	// AllowInsecure for local development setups.
+	Credentials credentials.TransportCredentials
+
+	// AllowInsecure opts into plaintext transport for local development.
+	// It is rejected by default so remote daemon access is
+	// secure-by-default.
+	AllowInsecure bool
+
+	// DialOptions appends extra gRPC dial options after the SDK's transport
+	// credential choice, so later options may override the SDK's default
+	// transport credentials.
+	DialOptions []grpc.DialOption
+}
+
+// DialRemote connects the SDK facade to a remote darepod gRPC endpoint. The
+// context is currently used only as an upfront cancellation signal because
+// grpc.NewClient performs dialing asynchronously.
+func DialRemote(ctx context.Context, cfg RemoteConfig) (*Client, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("dial remote daemon: %w", err)
+	}
+
+	if cfg.Address == "" {
+		return nil, fmt.Errorf("remote address is required")
+	}
+
+	creds := cfg.Credentials
+	if creds == nil {
+		if !cfg.AllowInsecure {
+			return nil, fmt.Errorf(
+				"remote credentials are required unless " +
+					"AllowInsecure is set",
+			)
+		}
+
+		creds = insecure.NewCredentials()
+	}
+
+	dialOpts := []grpc.DialOption{
+		grpc.WithTransportCredentials(creds),
+	}
+	dialOpts = append(dialOpts, cfg.DialOptions...)
+
+	conn, err := grpc.NewClient(cfg.Address, dialOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("dial remote daemon: %w", err)
+	}
+
+	return &Client{
+		daemon: daemonrpc.NewDaemonServiceClient(conn),
+		waitCh: closedWaitChan(),
+		closeFn: func(context.Context) error {
+			return conn.Close()
+		},
+	}, nil
+}


### PR DESCRIPTION
## Summary

Third and final PR in the stack. Introduces `sdk/ark`, the consumer-
facing Go SDK over a `darepod` runtime. A single `Client` type works
against either a remote daemon over gRPC or an in-process daemon
started over `bufconn`; the daemon stays the canonical Ark runtime
in both cases.

## Stack

- #289 — injected RPC listeners on `darepod`
- #290 — operator terms on `daemonrpc.GetInfo`
- **#291 (this PR)** — `sdk/ark` facade on top of both

## What this PR adds

- a `Client` facade that hides whether the transport is remote or
  embedded, is safe for concurrent use, is idempotent on `Close`,
  and exposes `Wait()` so embedded callers can supervise the
  in-process daemon's terminal run error
- `DialRemote` for standalone daemons, secure by default — callers
  must either supply transport credentials or explicitly opt into
  insecure transport for local development
- `StartEmbedded` for in-process hosting over an injected `bufconn`
  listener, with readiness-gated startup and bounded shutdown
- SDK-owned typed models and bootstrap helpers (`GetInfo`,
  `IdentityPubKey`, `OperatorPubKey`, `GenSeed`, `InitWallet`,
  `UnlockWallet`)
- higher-level typed helpers for the OOR and indexer flows that
  swaps and other downstream clients need — `SendOORWithPolicy` for
  policy-template destinations, `SendOORWithCustomInputs` for
  caller-specified inputs, `AllocateOORReceiveScript` for typed
  receive-script decoding, `FindLiveVTXOByPkScript` /
  `FindSpentVTXOByPkScript` / `GetIndexedOORSession` for typed
  indexer lookups, and `ListLiveVTXOs` / `ListSpentVTXOs` for typed
  VTXO listing
- thin passthroughs over the remaining `daemonrpc` request and
  response types for the round, OOR, indexer, and ledger surfaces
  that have not yet been promoted to SDK-owned models
- a package-level doc, `sdk/ark/CLAUDE.md`, and the layered
  architecture note describing transport, readiness, boundary, and
  stability expectations
- tests covering both transport paths, streaming, TLS, the
  insecure-opt-in contract, and idempotent close

## API shape

The SDK surface is in three tiers.

**Typed SDK models** for daemon status and wallet bootstrap:

- `GetInfo`, `IdentityPubKey`, `OperatorPubKey`, `GenSeed`,
  `InitWallet`, `UnlockWallet`

**Policy-backed OOR and typed indexer helpers** that higher-level
clients such as swaps build on so they do not rebuild daemonrpc
adapters:

- `SendOORWithPolicy`, `SendOORWithCustomInputs`,
  `AllocateOORReceiveScript`, `FindLiveVTXOByPkScript`,
  `FindSpentVTXOByPkScript`, `GetIndexedOORSession`,
  `ListLiveVTXOs`, `ListSpentVTXOs`

**Thin proto-typed passthroughs** where domain modeling is deferred:

- `GetBalance`, `ListVTXOs`, `NewAddress`, `NewOORReceiveScript`,
  `GetIndexedVTXOByPkScript`, `GetIndexedOORSessionByTxid`,
  `SendVTXO`, `SendOOR`, `RefreshVTXOs`, `Board`, `ListRounds`,
  `WatchRounds`, `EstimateFee`, `GetFeeHistory`

The architecture note treats the passthroughs as a pre-1.0 layer
that will harden toward SDK-owned models as higher-level consumers
need them.

## Verification

- `make commitmsg-lint range=origin/darepod-getinfo-serverinfo..HEAD`
- `GOWORK=off go test -modfile=/tmp/darepo-client-test.mod ./sdk/ark ./darepod ./daemonrpc`

(Same local `-modfile` note as #289/#290.)

## Follow-ups

Deliberately out of scope for this slice:

- refresh semantics for cached operator terms (bootstrap snapshot
  only today)
- promoting the remaining proto-typed passthroughs onto SDK-owned
  models
- rebasing `sdk/swaps` and other higher-level clients onto this
  facade