### PR TITLE
round+roundpb+types: v2 seal-time fee handshake (#270)

### DIFF
--- a/lib/types/boarding.go
+++ b/lib/types/boarding.go
@@ -66,6 +66,141 @@ type OperatorTerms struct {
 	MinConfirmations uint32
 }
 
+// VTXOIntent describes a v2 (issue #270) intent for a VTXO to receive
+// without committing to an exact amount. The operator authors the
+// final amount net of the per-client fee at seal-time; clients only
+// declare a desired upper bound here. Mirrors the roundpb.VTXOIntent
+// proto message.
+type VTXOIntent struct {
+	// PolicyTemplate is the semantic arkscript policy for the
+	// requested output.
+	PolicyTemplate []byte
+
+	// SigningKey is the public key the client will use as the
+	// MuSig2 cosigner for this VTXO.
+	SigningKey *btcec.PublicKey
+
+	// RequestedAmountSat is the upper-bound amount the client
+	// expects for this VTXO. The server returns amount minus the
+	// per-client fee allocated across intents.
+	RequestedAmountSat btcutil.Amount
+}
+
+// JoinRoundIntent is the v2 (issue #270) Phase-1 message: the client
+// declares boarding/forfeit/leave structure plus per-VTXO templates
+// and signing keys, but does NOT commit to VTXO amounts. The server
+// authors final amounts at seal-time and returns them in a
+// JoinRoundQuote. Mirrors the roundpb.JoinRoundIntent proto.
+type JoinRoundIntent struct {
+	// Identifier is the participant's public key identifier.
+	Identifier *btcec.PublicKey
+
+	// VTXOIntents specifies per-VTXO upper-bound requests.
+	VTXOIntents []*VTXOIntent
+
+	// BoardingReqs specifies the boarding UTXOs the client wants
+	// to use to board the Ark.
+	BoardingReqs []*BoardingRequest
+
+	// LeaveReqs specifies the requests to leave the Ark with on-
+	// chain UTXOs. Leave amounts are not renegotiated at seal-time.
+	LeaveReqs []*LeaveRequest
+
+	// ForfeitReqs specifies the requests to forfeit VTXOs.
+	ForfeitReqs []*ForfeitRequest
+
+	// Auth contains the BIP-322 payload that authorizes this
+	// intent.
+	Auth *JoinRoundAuth
+
+	// ProtocolVersion is the v2 protocol version the client wants
+	// to speak. Server picks the highest mutually supported
+	// version. Minimum supported v2: 2.
+	ProtocolVersion uint32
+}
+
+// VTXOQuote is the per-VTXO amount authored by the server in
+// response to a VTXOIntent. Mirrors the roundpb.VTXOQuote proto.
+type VTXOQuote struct {
+	// PolicyTemplate echoes the matching VTXOIntent.PolicyTemplate
+	// for client-side correlation.
+	PolicyTemplate []byte
+
+	// AmountSat is the final VTXO amount authored by the server.
+	AmountSat btcutil.Amount
+
+	// SigningKey is the cosigner key from the matching intent.
+	SigningKey *btcec.PublicKey
+}
+
+// JoinRoundFeeBreakdown mirrors the roundpb.FeeBreakdown proto and
+// the server-side fees.FeeBreakdown calculator type. Carried in
+// JoinRoundQuote so clients can display authored fees and apply
+// local cap policies.
+type JoinRoundFeeBreakdown struct {
+	// LiquidityFeeSat is the per-round liquidity component.
+	LiquidityFeeSat btcutil.Amount
+
+	// OnChainShareSat is the per-round on-chain share.
+	OnChainShareSat btcutil.Amount
+
+	// MarginSat is the operator's fixed margin.
+	MarginSat btcutil.Amount
+
+	// TotalFeeSat is the sum of the three components above.
+	TotalFeeSat btcutil.Amount
+
+	// EffectiveAnnualRate is the annualized rate after the
+	// utilization spread.
+	EffectiveAnnualRate float64
+
+	// BelowMinViable is true when the authored fee exceeds the
+	// MinViableVTXOPct dust threshold.
+	BelowMinViable bool
+}
+
+// JoinRoundQuote is the v2 (issue #270) Phase-2 message: the server-
+// authored per-VTXO amounts plus per-client operator fee. Mirrors
+// the roundpb.JoinRoundQuote proto.
+type JoinRoundQuote struct {
+	// RoundID identifies the round this quote is for.
+	RoundID [16]byte
+
+	// VTXOOutputs carries the server-authored per-VTXO amounts.
+	VTXOOutputs []*VTXOQuote
+
+	// OperatorFeeSat is the total per-client operator fee.
+	OperatorFeeSat btcutil.Amount
+
+	// Breakdown is the itemized fee breakdown.
+	Breakdown JoinRoundFeeBreakdown
+
+	// QuoteExpiresAtUnix is the absolute Unix timestamp (seconds)
+	// after which the quote is no longer honored.
+	QuoteExpiresAtUnix int64
+
+	// ProtocolVersion echoes the version the server agreed to
+	// speak.
+	ProtocolVersion uint32
+}
+
+// JoinRoundCommit is the v2 message a client sends to explicitly
+// accept a JoinRoundQuote.
+type JoinRoundCommit struct {
+	// RoundID identifies the round.
+	RoundID [16]byte
+}
+
+// JoinRoundReject is the v2 message a client sends to decline a
+// JoinRoundQuote.
+type JoinRoundReject struct {
+	// RoundID identifies the round.
+	RoundID [16]byte
+
+	// Reason is a short human-readable reason code.
+	Reason string
+}
+
 // JoinRoundRequest represents a participant's request to join a round.
 type JoinRoundRequest struct {
 	// Identifier is the participant's public key identifier associated with

--- a/round/v2_handshake_states.go
+++ b/round/v2_handshake_states.go
@@ -1,0 +1,129 @@
+package round
+
+import (
+	"context"
+	"errors"
+
+	"github.com/lightninglabs/darepo-client/lib/types"
+)
+
+// ErrV2HandlerNotImplemented is returned by the v2 client FSM
+// handlers while the protocol lands in stages. Each follow-up
+// commit replaces a returns-err handler with the real transition
+// logic; until then a v2 event arriving on a code path that has not
+// been wired surfaces the error rather than silently falling through
+// to the v1 RegistrationSentState path.
+var ErrV2HandlerNotImplemented = errors.New(
+	"v2 handshake: client handler not yet implemented on this branch",
+)
+
+// IntentSentState is the v2 client analogue of RegistrationSentState.
+// The client has sent a JoinRoundIntent (Phase 1) and is waiting for
+// the server to seal registration and dispatch a JoinRoundQuote
+// (Phase 2). No VTXO amounts are committed at this stage; the server
+// authors them at seal-time and returns them in the quote.
+//
+// Why a separate state from RegistrationSentState: under v1 the
+// client's next inbound is ClientSuccessResp + ClientBatchInfo (the
+// commitment PSBT that already embeds amounts the client committed
+// to). Under v2 the next inbound is JoinRoundQuote, which carries
+// server-authored amounts the client must validate against its local
+// MaxOperatorFee policy before signing. Keeping the two states
+// distinct lets the v1 and v2 dispatch tables stay non-overlapping.
+type IntentSentState struct {
+	// Intent is the JoinRoundIntent the client sent. Held so the
+	// QuoteReceivedState handler can correlate the inbound quote
+	// against the request and reject mismatches.
+	Intent *types.JoinRoundIntent
+}
+
+// String returns the state's human-readable name.
+func (s *IntentSentState) String() string {
+	return "IntentSent"
+}
+
+// IsTerminal returns false; IntentSent transitions to QuoteReceived
+// (or ClientFailed) on quote arrival.
+func (s *IntentSentState) IsTerminal() bool {
+	return false
+}
+
+// clientStateSealed marks IntentSentState as implementing the sealed
+// ClientState interface.
+func (s *IntentSentState) clientStateSealed() {}
+
+// QuoteReceivedState is the decision point under the v2 handshake:
+// the client has received a JoinRoundQuote with server-authored VTXO
+// amounts and an itemized fee. The transition handler validates the
+// quote against the local policy:
+//
+//   - operator_fee_sat <= MaxOperatorFee (configurable cap)
+//   - quote_expires_at_unix in the future
+//   - vtxo_outputs match the original VTXOIntents on signing_key +
+//     policy_template
+//
+// If valid the handler emits an outbound JoinRoundCommit (or
+// proceeds straight to NoncesSent for an implicit commit) and
+// transitions onward through the existing v1 batch path with the
+// server-authored amounts. If invalid the handler emits a
+// JoinRoundReject and transitions to ClientFailed.
+type QuoteReceivedState struct {
+	// Intent is the matching JoinRoundIntent the client sent.
+	Intent *types.JoinRoundIntent
+
+	// Quote is the server-authored quote awaiting decision.
+	Quote *types.JoinRoundQuote
+}
+
+// String returns the state's human-readable name.
+func (s *QuoteReceivedState) String() string {
+	return "QuoteReceived"
+}
+
+// IsTerminal returns false.
+func (s *QuoteReceivedState) IsTerminal() bool {
+	return false
+}
+
+// clientStateSealed marks QuoteReceivedState as implementing the
+// sealed ClientState interface.
+func (s *QuoteReceivedState) clientStateSealed() {}
+
+// --------------------------------------------------------------------------
+// ProcessEvent stubs.
+//
+// Same rationale as the server side: stubs exist so the v2 states
+// satisfy the protofsm.State interface, and a v2 event hitting an
+// unwired code path returns ErrV2HandlerNotImplemented rather than
+// silently falling through. The real transition logic
+// (intent-builder, quote validator, accept/reject) lands in
+// follow-up commits on this branch.
+// --------------------------------------------------------------------------
+
+// ProcessEvent for IntentSentState. Future implementation routes
+// QuoteReceivedEvent into a transition to QuoteReceivedState; until
+// then the handler returns ErrV2HandlerNotImplemented.
+func (s *IntentSentState) ProcessEvent(ctx context.Context,
+	event ClientEvent, env *ClientEnvironment) (
+	*ClientStateTransition, error) {
+
+	return nil, ErrV2HandlerNotImplemented
+}
+
+// ProcessEvent for QuoteReceivedState. Future implementation
+// validates the quote against MaxOperatorFee + expiry and either
+// transitions to NoncesSentState (accept) or emits JoinRoundReject
+// + ClientFailedState (decline).
+func (s *QuoteReceivedState) ProcessEvent(ctx context.Context,
+	event ClientEvent, env *ClientEnvironment) (
+	*ClientStateTransition, error) {
+
+	return nil, ErrV2HandlerNotImplemented
+}
+
+// Compile-time assertions that the v2 states satisfy the sealed
+// ClientState interface.
+var (
+	_ ClientState = (*IntentSentState)(nil)
+	_ ClientState = (*QuoteReceivedState)(nil)
+)

--- a/round/v2_handshake_states.go
+++ b/round/v2_handshake_states.go
@@ -3,7 +3,10 @@ package round
 import (
 	"context"
 	"errors"
+	"fmt"
+	"time"
 
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/lightninglabs/darepo-client/lib/types"
 )
 
@@ -16,6 +19,119 @@ import (
 var ErrV2HandlerNotImplemented = errors.New(
 	"v2 handshake: client handler not yet implemented on this branch",
 )
+
+// ErrV2QuoteFeeExceedsCap is returned by the quote-policy checker
+// when the server-authored operator fee is above the client's
+// configured MaxOperatorFee. The quote is rejected and the FSM
+// transitions toward a JoinRoundReject emission.
+var ErrV2QuoteFeeExceedsCap = errors.New(
+	"v2 handshake: authored operator fee exceeds local MaxOperatorFee " +
+		"cap",
+)
+
+// ErrV2QuoteExpired is returned when the server-authored quote's
+// quote_expires_at_unix timestamp has already passed. Rejecting
+// the quote protects the client from signing a round the operator
+// has already treated as an implicit reject.
+var ErrV2QuoteExpired = errors.New(
+	"v2 handshake: authored quote window has already expired",
+)
+
+// ErrV2QuoteProtocolMismatch is returned when the server's
+// authored quote carries a lower protocol version than the client
+// asked for and the downgrade is not acceptable. Under the
+// minimum-viable v2 policy the client refuses any downgrade.
+var ErrV2QuoteProtocolMismatch = errors.New(
+	"v2 handshake: server-authored quote protocol version lower than " +
+		"client-requested",
+)
+
+// V2MinProtocolVersion is the lowest v2 protocol version the
+// client understands. The client-authored intent sets this on the
+// outbound JoinRoundIntent; the server's returned quote must
+// match or the client rejects the handshake.
+const V2MinProtocolVersion uint32 = 2
+
+// quotePolicyNow is the wall-clock source for quote-expiry
+// checks. Injectable for tests via SetQuotePolicyNow; defaults
+// to time.Now.
+var quotePolicyNow = time.Now
+
+// SetQuotePolicyNow overrides the wall-clock used by
+// ValidateQuotePolicy for deterministic testing. Returns a
+// restore function the caller defers to reset the global.
+//
+// Tests that exercise the quote-expiry branch inject a fixed
+// clock so the assertion is not subject to the real time of day.
+// Production callers never touch this helper.
+func SetQuotePolicyNow(fn func() time.Time) func() {
+	prev := quotePolicyNow
+	quotePolicyNow = fn
+
+	return func() {
+		quotePolicyNow = prev
+	}
+}
+
+// ValidateQuotePolicy applies the client's local accept/reject
+// policy to a server-authored JoinRoundQuote. Under issue #270
+// the client has no direct control over VTXO output amounts --
+// the server is the sole fee author -- so the policy surface is
+// narrow: enforce the fee cap, reject stale quotes, and reject
+// downgraded protocol versions. Each rejection returns a typed
+// sentinel error so the caller can map reasons onto the
+// JoinRoundReject.reason field.
+//
+// Contract: returns nil when the quote is acceptable; otherwise
+// returns one of ErrV2QuoteFeeExceedsCap / ErrV2QuoteExpired /
+// ErrV2QuoteProtocolMismatch wrapping the offending field so the
+// caller can log the decision with structured detail.
+func ValidateQuotePolicy(quote *types.JoinRoundQuote,
+	maxOperatorFee btcutil.Amount) error {
+
+	if quote == nil {
+		return fmt.Errorf(
+			"v2 handshake: cannot validate a nil quote",
+		)
+	}
+
+	if quote.ProtocolVersion < V2MinProtocolVersion {
+		return fmt.Errorf(
+			"%w: got version %d, minimum %d",
+			ErrV2QuoteProtocolMismatch,
+			quote.ProtocolVersion, V2MinProtocolVersion,
+		)
+	}
+
+	// Fee cap: the server-authored operator fee must not exceed
+	// the client's configured upper bound. Replaces the legacy v1
+	// pre-flight check (transitions.go:383) which compared an
+	// implicit fee against MinOperatorFee / MaxOperatorFee; under
+	// v2 the client only has the max-cap side of the check since
+	// the operator-authored fee cannot be below the operator's
+	// own expectation.
+	if quote.OperatorFeeSat > maxOperatorFee {
+		return fmt.Errorf(
+			"%w: authored %d sats, cap %d sats",
+			ErrV2QuoteFeeExceedsCap,
+			quote.OperatorFeeSat, maxOperatorFee,
+		)
+	}
+
+	if quote.QuoteExpiresAtUnix > 0 {
+		expiry := time.Unix(quote.QuoteExpiresAtUnix, 0)
+		if !quotePolicyNow().Before(expiry) {
+			return fmt.Errorf(
+				"%w: expired at %s",
+				ErrV2QuoteExpired, expiry.Format(
+					time.RFC3339,
+				),
+			)
+		}
+	}
+
+	return nil
+}
 
 // IntentSentState is the v2 client analogue of RegistrationSentState.
 // The client has sent a JoinRoundIntent (Phase 1) and is waiting for

--- a/round/v2_handshake_states_test.go
+++ b/round/v2_handshake_states_test.go
@@ -3,7 +3,9 @@ package round
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/lightninglabs/darepo-client/lib/types"
 	"github.com/stretchr/testify/require"
 )
@@ -47,4 +49,120 @@ func TestV2HandshakeStubsReturnSentinel(t *testing.T) {
 	quoteState := &QuoteReceivedState{}
 	_, err = quoteState.ProcessEvent(ctx, nil, nil)
 	require.ErrorIs(t, err, ErrV2HandlerNotImplemented)
+}
+
+// TestValidateQuotePolicyAccept covers the happy path: authored
+// fee below cap, quote fresh, protocol version at the minimum.
+// A quote that passes every check returns nil so the caller can
+// proceed into signing.
+func TestValidateQuotePolicyAccept(t *testing.T) {
+	t.Parallel()
+
+	restore := SetQuotePolicyNow(func() time.Time {
+		return time.Unix(1_700_000_000, 0)
+	})
+	defer restore()
+
+	quote := &types.JoinRoundQuote{
+		OperatorFeeSat:     btcutil.Amount(500),
+		QuoteExpiresAtUnix: 1_700_000_010,
+		ProtocolVersion:    V2MinProtocolVersion,
+	}
+	err := ValidateQuotePolicy(quote, btcutil.Amount(1000))
+	require.NoError(t, err)
+}
+
+// TestValidateQuotePolicyFeeTooHigh covers the fee-cap rejection
+// path. Replaces the v1 pre-flight MinOperatorFee check in
+// transitions.go:383 -- under v2 the client only enforces the
+// upper-bound cap, since under-quoting is structurally
+// impossible once the server is the sole fee author.
+func TestValidateQuotePolicyFeeTooHigh(t *testing.T) {
+	t.Parallel()
+
+	restore := SetQuotePolicyNow(func() time.Time {
+		return time.Unix(1_700_000_000, 0)
+	})
+	defer restore()
+
+	quote := &types.JoinRoundQuote{
+		OperatorFeeSat:     btcutil.Amount(5000),
+		QuoteExpiresAtUnix: 1_700_000_010,
+		ProtocolVersion:    V2MinProtocolVersion,
+	}
+	err := ValidateQuotePolicy(quote, btcutil.Amount(1000))
+	require.ErrorIs(t, err, ErrV2QuoteFeeExceedsCap)
+}
+
+// TestValidateQuotePolicyExpired covers the stale-quote
+// rejection path. A client that receives a quote past its
+// expiry window must reject rather than sign: the server has
+// already treated the quote as an implicit reject and may have
+// re-sealed the round without this client.
+func TestValidateQuotePolicyExpired(t *testing.T) {
+	t.Parallel()
+
+	restore := SetQuotePolicyNow(func() time.Time {
+		return time.Unix(1_700_000_100, 0)
+	})
+	defer restore()
+
+	quote := &types.JoinRoundQuote{
+		OperatorFeeSat:     btcutil.Amount(500),
+		QuoteExpiresAtUnix: 1_700_000_010,
+		ProtocolVersion:    V2MinProtocolVersion,
+	}
+	err := ValidateQuotePolicy(quote, btcutil.Amount(1000))
+	require.ErrorIs(t, err, ErrV2QuoteExpired)
+}
+
+// TestValidateQuotePolicyNoExpiry covers the informal contract
+// that a zero QuoteExpiresAtUnix means "no expiry policy" --
+// useful for tests and for servers that don't want to expire
+// quotes. With zero, the expiry branch is skipped and the
+// quote is accepted purely on the fee-cap + protocol-version
+// checks.
+func TestValidateQuotePolicyNoExpiry(t *testing.T) {
+	t.Parallel()
+
+	restore := SetQuotePolicyNow(func() time.Time {
+		return time.Unix(1_700_000_000, 0)
+	})
+	defer restore()
+
+	quote := &types.JoinRoundQuote{
+		OperatorFeeSat:     btcutil.Amount(500),
+		QuoteExpiresAtUnix: 0,
+		ProtocolVersion:    V2MinProtocolVersion,
+	}
+	err := ValidateQuotePolicy(quote, btcutil.Amount(1000))
+	require.NoError(t, err)
+}
+
+// TestValidateQuotePolicyProtocolDowngrade covers the downgrade-
+// reject path. A server that authors a quote with
+// protocol_version below V2MinProtocolVersion (e.g. 0 or 1) is
+// either misconfigured or attempting to downgrade the client;
+// either way the client refuses.
+func TestValidateQuotePolicyProtocolDowngrade(t *testing.T) {
+	t.Parallel()
+
+	quote := &types.JoinRoundQuote{
+		OperatorFeeSat:     btcutil.Amount(500),
+		QuoteExpiresAtUnix: 0,
+		ProtocolVersion:    1,
+	}
+	err := ValidateQuotePolicy(quote, btcutil.Amount(1000))
+	require.ErrorIs(t, err, ErrV2QuoteProtocolMismatch)
+}
+
+// TestValidateQuotePolicyNilQuote covers the structural guard
+// that a nil quote fails fast with a descriptive error rather
+// than panicking on dereference.
+func TestValidateQuotePolicyNilQuote(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateQuotePolicy(nil, btcutil.Amount(1000))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot validate a nil quote")
 }

--- a/round/v2_handshake_states_test.go
+++ b/round/v2_handshake_states_test.go
@@ -1,0 +1,50 @@
+package round
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lightninglabs/darepo-client/lib/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestV2HandshakeStateMetadata locks the basic state contract for
+// the v2 client states (String / IsTerminal / clientStateSealed) so
+// the protofsm.State interface assertion stays green as future
+// commits flesh out the transition logic.
+func TestV2HandshakeStateMetadata(t *testing.T) {
+	t.Parallel()
+
+	intent := &types.JoinRoundIntent{
+		ProtocolVersion: 2,
+	}
+	quote := &types.JoinRoundQuote{
+		ProtocolVersion: 2,
+	}
+
+	intentState := &IntentSentState{Intent: intent}
+	require.Equal(t, "IntentSent", intentState.String())
+	require.False(t, intentState.IsTerminal())
+
+	quoteState := &QuoteReceivedState{Intent: intent, Quote: quote}
+	require.Equal(t, "QuoteReceived", quoteState.String())
+	require.False(t, quoteState.IsTerminal())
+}
+
+// TestV2HandshakeStubsReturnSentinel asserts the placeholder
+// ProcessEvent handlers fail closed via ErrV2HandlerNotImplemented.
+// Once a real handler lands, the test on that path will be
+// rewritten or removed; until then this guarantees no v2 event is
+// silently dropped by an unwired transition.
+func TestV2HandshakeStubsReturnSentinel(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	intentState := &IntentSentState{}
+	_, err := intentState.ProcessEvent(ctx, nil, nil)
+	require.ErrorIs(t, err, ErrV2HandlerNotImplemented)
+
+	quoteState := &QuoteReceivedState{}
+	_, err = quoteState.ProcessEvent(ctx, nil, nil)
+	require.ErrorIs(t, err, ErrV2HandlerNotImplemented)
+}

--- a/rpc/roundpb/round.pb.go
+++ b/rpc/roundpb/round.pb.go
@@ -1151,6 +1151,19 @@ func (x *JoinRoundAuth) GetSignature() []byte {
 }
 
 // JoinRoundRequest is sent from client to server to request joining a round.
+//
+// This is the v1 (submit-time implicit fee) protocol entry point. Under v1
+// the client pre-computes VTXO output amounts, and the operator fee is the
+// implicit difference between total inputs and total outputs. The server
+// validates that the implicit fee meets expectations at admission time
+// (see validateOperatorFee in the server repo).
+//
+// v2 (issue #270) introduces a two-phase handshake that moves fee
+// authorship to the server at seal-time; see JoinRoundIntent /
+// JoinRoundQuote / JoinRoundCommit / JoinRoundReject below. Clients
+// that negotiate protocol_version >= 2 use the v2 messages and do NOT
+// send JoinRoundRequest. The v1 path stays live during migration so
+// older clients continue to work.
 type JoinRoundRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// identifier is the compressed public key (33 bytes) of the
@@ -1252,6 +1265,597 @@ func (x *JoinRoundRequest) GetAuth() *JoinRoundAuth {
 	return nil
 }
 
+// VTXOIntent describes a VTXO the client wants to receive under the v2
+// handshake, without committing to an exact amount. The operator authors
+// the final amount net of the per-client fee at seal-time and returns it
+// via VTXOQuote.
+type VTXOIntent struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// policy_template is the semantic arkscript policy for the requested
+	// output. Identical semantics to VTXORequest.policy_template but the
+	// client does NOT commit to an amount here.
+	PolicyTemplate []byte `protobuf:"bytes,1,opt,name=policy_template,json=policyTemplate,proto3" json:"policy_template,omitempty"`
+	// signing_key is the compressed public key (33 bytes) used for MuSig2
+	// cosigning and join-auth proof binding.
+	SigningKey []byte `protobuf:"bytes,2,opt,name=signing_key,json=signingKey,proto3" json:"signing_key,omitempty"`
+	// requested_amount_sat is an UPPER BOUND on the amount the client
+	// expects for this VTXO, not a commitment. Used by the server as
+	// the pre-fee target; the VTXOQuote returns amount - per_client_fee
+	// allocated across intents. Clients express their desired split
+	// across multiple intents via this field. Must be strictly positive
+	// and sum to <= total input value.
+	RequestedAmountSat int64 `protobuf:"varint,3,opt,name=requested_amount_sat,json=requestedAmountSat,proto3" json:"requested_amount_sat,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *VTXOIntent) Reset() {
+	*x = VTXOIntent{}
+	mi := &file_round_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *VTXOIntent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*VTXOIntent) ProtoMessage() {}
+
+func (x *VTXOIntent) ProtoReflect() protoreflect.Message {
+	mi := &file_round_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use VTXOIntent.ProtoReflect.Descriptor instead.
+func (*VTXOIntent) Descriptor() ([]byte, []int) {
+	return file_round_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *VTXOIntent) GetPolicyTemplate() []byte {
+	if x != nil {
+		return x.PolicyTemplate
+	}
+	return nil
+}
+
+func (x *VTXOIntent) GetSigningKey() []byte {
+	if x != nil {
+		return x.SigningKey
+	}
+	return nil
+}
+
+func (x *VTXOIntent) GetRequestedAmountSat() int64 {
+	if x != nil {
+		return x.RequestedAmountSat
+	}
+	return 0
+}
+
+// JoinRoundIntent is sent from client to server as Phase 1 of the v2
+// handshake. The server enqueues it, closes registration on its own
+// schedule, then walks every enqueued intent and authors a per-client
+// JoinRoundQuote once final batch occupancy is known.
+type JoinRoundIntent struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// identifier is the compressed public key (33 bytes) of the
+	// participant. Matches v1 JoinRoundRequest.identifier.
+	Identifier []byte `protobuf:"bytes,1,opt,name=identifier,proto3" json:"identifier,omitempty"`
+	// boarding_requests contains all boarding UTXO details. Same
+	// shape as v1.
+	BoardingRequests []*BoardingRequest `protobuf:"bytes,2,rep,name=boarding_requests,json=boardingRequests,proto3" json:"boarding_requests,omitempty"`
+	// vtxo_intents specifies the VTXOs the client wants to receive,
+	// with per-intent upper-bound amounts. The server authors the
+	// final amount (net of fee) in the returned VTXOQuote. Replaces
+	// v1 vtxo_requests.
+	VtxoIntents []*VTXOIntent `protobuf:"bytes,3,rep,name=vtxo_intents,json=vtxoIntents,proto3" json:"vtxo_intents,omitempty"`
+	// forfeit_requests specifies VTXOs to forfeit. Same shape as v1.
+	ForfeitRequests []*ForfeitRequest `protobuf:"bytes,4,rep,name=forfeit_requests,json=forfeitRequests,proto3" json:"forfeit_requests,omitempty"`
+	// leave_requests specifies VTXOs being exited to on-chain outputs.
+	// Same shape as v1. Leave amounts are client-chosen and are NOT
+	// renegotiated at seal-time (the client owns the on-chain
+	// destination).
+	LeaveRequests []*LeaveRequest `protobuf:"bytes,5,rep,name=leave_requests,json=leaveRequests,proto3" json:"leave_requests,omitempty"`
+	// round_id is optional; empty means the server assigns a round.
+	RoundId string `protobuf:"bytes,6,opt,name=round_id,json=roundId,proto3" json:"round_id,omitempty"`
+	// auth contains the BIP-322 authorization payload. Nil when join
+	// request auth is disabled.
+	Auth *JoinRoundAuth `protobuf:"bytes,7,opt,name=auth,proto3" json:"auth,omitempty"`
+	// protocol_version is the v2 protocol version the client wants to
+	// speak. The server rejects the intent if it does not support the
+	// requested version. Minimum supported v2: 2.
+	ProtocolVersion uint32 `protobuf:"varint,8,opt,name=protocol_version,json=protocolVersion,proto3" json:"protocol_version,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *JoinRoundIntent) Reset() {
+	*x = JoinRoundIntent{}
+	mi := &file_round_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *JoinRoundIntent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*JoinRoundIntent) ProtoMessage() {}
+
+func (x *JoinRoundIntent) ProtoReflect() protoreflect.Message {
+	mi := &file_round_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use JoinRoundIntent.ProtoReflect.Descriptor instead.
+func (*JoinRoundIntent) Descriptor() ([]byte, []int) {
+	return file_round_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *JoinRoundIntent) GetIdentifier() []byte {
+	if x != nil {
+		return x.Identifier
+	}
+	return nil
+}
+
+func (x *JoinRoundIntent) GetBoardingRequests() []*BoardingRequest {
+	if x != nil {
+		return x.BoardingRequests
+	}
+	return nil
+}
+
+func (x *JoinRoundIntent) GetVtxoIntents() []*VTXOIntent {
+	if x != nil {
+		return x.VtxoIntents
+	}
+	return nil
+}
+
+func (x *JoinRoundIntent) GetForfeitRequests() []*ForfeitRequest {
+	if x != nil {
+		return x.ForfeitRequests
+	}
+	return nil
+}
+
+func (x *JoinRoundIntent) GetLeaveRequests() []*LeaveRequest {
+	if x != nil {
+		return x.LeaveRequests
+	}
+	return nil
+}
+
+func (x *JoinRoundIntent) GetRoundId() string {
+	if x != nil {
+		return x.RoundId
+	}
+	return ""
+}
+
+func (x *JoinRoundIntent) GetAuth() *JoinRoundAuth {
+	if x != nil {
+		return x.Auth
+	}
+	return nil
+}
+
+func (x *JoinRoundIntent) GetProtocolVersion() uint32 {
+	if x != nil {
+		return x.ProtocolVersion
+	}
+	return 0
+}
+
+// VTXOQuote is a per-VTXO amount authored by the server under the v2
+// handshake. Carries the pkScript derived from the intent's policy
+// template and the signing-key binding so the client can match quotes
+// back to the intents it submitted.
+type VTXOQuote struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// policy_template echoes the template from the matching
+	// VTXOIntent. Clients correlate by template + signing_key.
+	PolicyTemplate []byte `protobuf:"bytes,1,opt,name=policy_template,json=policyTemplate,proto3" json:"policy_template,omitempty"`
+	// amount_sat is the final VTXO amount authored by the server
+	// (<= the matching VTXOIntent.requested_amount_sat). The
+	// difference (requested - amount) is the client's share of the
+	// per-client operator fee.
+	AmountSat int64 `protobuf:"varint,2,opt,name=amount_sat,json=amountSat,proto3" json:"amount_sat,omitempty"`
+	// signing_key is the cosigner key from the matching intent. Echoed
+	// so the client can pair quotes to the intents it submitted.
+	SigningKey    []byte `protobuf:"bytes,3,opt,name=signing_key,json=signingKey,proto3" json:"signing_key,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *VTXOQuote) Reset() {
+	*x = VTXOQuote{}
+	mi := &file_round_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *VTXOQuote) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*VTXOQuote) ProtoMessage() {}
+
+func (x *VTXOQuote) ProtoReflect() protoreflect.Message {
+	mi := &file_round_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use VTXOQuote.ProtoReflect.Descriptor instead.
+func (*VTXOQuote) Descriptor() ([]byte, []int) {
+	return file_round_proto_rawDescGZIP(), []int{21}
+}
+
+func (x *VTXOQuote) GetPolicyTemplate() []byte {
+	if x != nil {
+		return x.PolicyTemplate
+	}
+	return nil
+}
+
+func (x *VTXOQuote) GetAmountSat() int64 {
+	if x != nil {
+		return x.AmountSat
+	}
+	return 0
+}
+
+func (x *VTXOQuote) GetSigningKey() []byte {
+	if x != nil {
+		return x.SigningKey
+	}
+	return nil
+}
+
+// FeeBreakdown mirrors fees.FeeBreakdown from the server repo. Sent with
+// every JoinRoundQuote so the client can display the authored fee to
+// the user and apply a local cap policy before accepting.
+type FeeBreakdown struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// liquidity_fee_sat is the per-round liquidity share carved from
+	// the operator's capital-cost model.
+	LiquidityFeeSat int64 `protobuf:"varint,1,opt,name=liquidity_fee_sat,json=liquidityFeeSat,proto3" json:"liquidity_fee_sat,omitempty"`
+	// on_chain_share_sat is the per-round on-chain share (the
+	// client's portion of the commitment tx fee).
+	OnChainShareSat int64 `protobuf:"varint,2,opt,name=on_chain_share_sat,json=onChainShareSat,proto3" json:"on_chain_share_sat,omitempty"`
+	// margin_sat is the operator's fixed margin per liquidity-
+	// requiring operation.
+	MarginSat int64 `protobuf:"varint,3,opt,name=margin_sat,json=marginSat,proto3" json:"margin_sat,omitempty"`
+	// total_fee_sat is the sum of the three components above. Never
+	// re-compute this client-side; accept the server's author.
+	TotalFeeSat int64 `protobuf:"varint,4,opt,name=total_fee_sat,json=totalFeeSat,proto3" json:"total_fee_sat,omitempty"`
+	// effective_annual_rate is the annualized rate (after utilization
+	// spread) used for liquidity pricing. Informational only.
+	EffectiveAnnualRate float64 `protobuf:"fixed64,5,opt,name=effective_annual_rate,json=effectiveAnnualRate,proto3" json:"effective_annual_rate,omitempty"`
+	// below_min_viable is true when the authored fee exceeds the
+	// MinViableVTXOPct dust policy threshold. Clients may use this
+	// to warn the user before committing.
+	BelowMinViable bool `protobuf:"varint,6,opt,name=below_min_viable,json=belowMinViable,proto3" json:"below_min_viable,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *FeeBreakdown) Reset() {
+	*x = FeeBreakdown{}
+	mi := &file_round_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *FeeBreakdown) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FeeBreakdown) ProtoMessage() {}
+
+func (x *FeeBreakdown) ProtoReflect() protoreflect.Message {
+	mi := &file_round_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FeeBreakdown.ProtoReflect.Descriptor instead.
+func (*FeeBreakdown) Descriptor() ([]byte, []int) {
+	return file_round_proto_rawDescGZIP(), []int{22}
+}
+
+func (x *FeeBreakdown) GetLiquidityFeeSat() int64 {
+	if x != nil {
+		return x.LiquidityFeeSat
+	}
+	return 0
+}
+
+func (x *FeeBreakdown) GetOnChainShareSat() int64 {
+	if x != nil {
+		return x.OnChainShareSat
+	}
+	return 0
+}
+
+func (x *FeeBreakdown) GetMarginSat() int64 {
+	if x != nil {
+		return x.MarginSat
+	}
+	return 0
+}
+
+func (x *FeeBreakdown) GetTotalFeeSat() int64 {
+	if x != nil {
+		return x.TotalFeeSat
+	}
+	return 0
+}
+
+func (x *FeeBreakdown) GetEffectiveAnnualRate() float64 {
+	if x != nil {
+		return x.EffectiveAnnualRate
+	}
+	return 0
+}
+
+func (x *FeeBreakdown) GetBelowMinViable() bool {
+	if x != nil {
+		return x.BelowMinViable
+	}
+	return false
+}
+
+// JoinRoundQuote is Phase 2 of the v2 handshake: the server-authored
+// quote carrying per-VTXO amounts, per-client operator fee, and a
+// freshness window. The client has until quote_expires_at_unix to send
+// a JoinRoundCommit (signatures) or a JoinRoundReject.
+type JoinRoundQuote struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// round_id is the UUID of the round (16 bytes).
+	RoundId []byte `protobuf:"bytes,1,opt,name=round_id,json=roundId,proto3" json:"round_id,omitempty"`
+	// vtxo_outputs carries the per-VTXO amounts authored by the
+	// server. Matches the order of the VTXOIntents the client sent;
+	// correlation is by signing_key + policy_template.
+	VtxoOutputs []*VTXOQuote `protobuf:"bytes,2,rep,name=vtxo_outputs,json=vtxoOutputs,proto3" json:"vtxo_outputs,omitempty"`
+	// operator_fee_sat is the total per-client operator fee this
+	// quote reflects. Sum of (intent.requested_amount - quote.amount)
+	// across vtxo_outputs plus any fee carved from forfeit inputs,
+	// minus any on-chain pass-through (e.g. leave amounts).
+	OperatorFeeSat int64 `protobuf:"varint,3,opt,name=operator_fee_sat,json=operatorFeeSat,proto3" json:"operator_fee_sat,omitempty"`
+	// breakdown is the itemized fee breakdown (liquidity + on-chain
+	// + margin). Clients may display this to the user but MUST NOT
+	// re-derive the total from the breakdown; the authoritative
+	// total is operator_fee_sat.
+	Breakdown *FeeBreakdown `protobuf:"bytes,4,opt,name=breakdown,proto3" json:"breakdown,omitempty"`
+	// quote_expires_at_unix is the Unix timestamp (seconds) after
+	// which the server will not honor a commit for this quote. A
+	// commit received after this is treated as a reject and the
+	// round is re-sealed without the slow client.
+	QuoteExpiresAtUnix int64 `protobuf:"varint,5,opt,name=quote_expires_at_unix,json=quoteExpiresAtUnix,proto3" json:"quote_expires_at_unix,omitempty"`
+	// protocol_version echoes the version the server agreed to
+	// speak. If this is lower than the client's requested version
+	// the client must either accept the downgrade or reject.
+	ProtocolVersion uint32 `protobuf:"varint,6,opt,name=protocol_version,json=protocolVersion,proto3" json:"protocol_version,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *JoinRoundQuote) Reset() {
+	*x = JoinRoundQuote{}
+	mi := &file_round_proto_msgTypes[23]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *JoinRoundQuote) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*JoinRoundQuote) ProtoMessage() {}
+
+func (x *JoinRoundQuote) ProtoReflect() protoreflect.Message {
+	mi := &file_round_proto_msgTypes[23]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use JoinRoundQuote.ProtoReflect.Descriptor instead.
+func (*JoinRoundQuote) Descriptor() ([]byte, []int) {
+	return file_round_proto_rawDescGZIP(), []int{23}
+}
+
+func (x *JoinRoundQuote) GetRoundId() []byte {
+	if x != nil {
+		return x.RoundId
+	}
+	return nil
+}
+
+func (x *JoinRoundQuote) GetVtxoOutputs() []*VTXOQuote {
+	if x != nil {
+		return x.VtxoOutputs
+	}
+	return nil
+}
+
+func (x *JoinRoundQuote) GetOperatorFeeSat() int64 {
+	if x != nil {
+		return x.OperatorFeeSat
+	}
+	return 0
+}
+
+func (x *JoinRoundQuote) GetBreakdown() *FeeBreakdown {
+	if x != nil {
+		return x.Breakdown
+	}
+	return nil
+}
+
+func (x *JoinRoundQuote) GetQuoteExpiresAtUnix() int64 {
+	if x != nil {
+		return x.QuoteExpiresAtUnix
+	}
+	return 0
+}
+
+func (x *JoinRoundQuote) GetProtocolVersion() uint32 {
+	if x != nil {
+		return x.ProtocolVersion
+	}
+	return 0
+}
+
+// JoinRoundCommit is sent by the client after receiving a
+// JoinRoundQuote to explicitly accept the server-authored amounts
+// and proceed to signing. A signature message (SubmitNonces) received
+// within the quote window is ALSO treated as an implicit commit, so
+// sending JoinRoundCommit is only required when the client needs to
+// explicitly acknowledge without starting MuSig2 signing
+// immediately (e.g. for UI pacing).
+type JoinRoundCommit struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// round_id is the UUID of the round (16 bytes).
+	RoundId       []byte `protobuf:"bytes,1,opt,name=round_id,json=roundId,proto3" json:"round_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *JoinRoundCommit) Reset() {
+	*x = JoinRoundCommit{}
+	mi := &file_round_proto_msgTypes[24]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *JoinRoundCommit) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*JoinRoundCommit) ProtoMessage() {}
+
+func (x *JoinRoundCommit) ProtoReflect() protoreflect.Message {
+	mi := &file_round_proto_msgTypes[24]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use JoinRoundCommit.ProtoReflect.Descriptor instead.
+func (*JoinRoundCommit) Descriptor() ([]byte, []int) {
+	return file_round_proto_rawDescGZIP(), []int{24}
+}
+
+func (x *JoinRoundCommit) GetRoundId() []byte {
+	if x != nil {
+		return x.RoundId
+	}
+	return nil
+}
+
+// JoinRoundReject is sent by the client when it refuses to sign the
+// quote -- typically because operator_fee_sat exceeds the client's
+// configured cap, or the quote expired locally before it could be
+// processed. The server drops the rejecting intent, re-seals the
+// remaining intents at the smaller batch, and authors fresh quotes.
+type JoinRoundReject struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// round_id is the UUID of the round (16 bytes).
+	RoundId []byte `protobuf:"bytes,1,opt,name=round_id,json=roundId,proto3" json:"round_id,omitempty"`
+	// reason is a short human-readable reason code. Informational
+	// only; the server does not use the text for any routing.
+	// Canonical values: "fee_too_high", "quote_expired",
+	// "policy_violation", "user_cancelled".
+	Reason        string `protobuf:"bytes,2,opt,name=reason,proto3" json:"reason,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *JoinRoundReject) Reset() {
+	*x = JoinRoundReject{}
+	mi := &file_round_proto_msgTypes[25]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *JoinRoundReject) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*JoinRoundReject) ProtoMessage() {}
+
+func (x *JoinRoundReject) ProtoReflect() protoreflect.Message {
+	mi := &file_round_proto_msgTypes[25]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use JoinRoundReject.ProtoReflect.Descriptor instead.
+func (*JoinRoundReject) Descriptor() ([]byte, []int) {
+	return file_round_proto_rawDescGZIP(), []int{25}
+}
+
+func (x *JoinRoundReject) GetRoundId() []byte {
+	if x != nil {
+		return x.RoundId
+	}
+	return nil
+}
+
+func (x *JoinRoundReject) GetReason() string {
+	if x != nil {
+		return x.Reason
+	}
+	return ""
+}
+
 // SubmitNoncesRequest submits MuSig2 nonces from client to server.
 type SubmitNoncesRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -1267,7 +1871,7 @@ type SubmitNoncesRequest struct {
 
 func (x *SubmitNoncesRequest) Reset() {
 	*x = SubmitNoncesRequest{}
-	mi := &file_round_proto_msgTypes[19]
+	mi := &file_round_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1279,7 +1883,7 @@ func (x *SubmitNoncesRequest) String() string {
 func (*SubmitNoncesRequest) ProtoMessage() {}
 
 func (x *SubmitNoncesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_round_proto_msgTypes[19]
+	mi := &file_round_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1292,7 +1896,7 @@ func (x *SubmitNoncesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubmitNoncesRequest.ProtoReflect.Descriptor instead.
 func (*SubmitNoncesRequest) Descriptor() ([]byte, []int) {
-	return file_round_proto_rawDescGZIP(), []int{19}
+	return file_round_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *SubmitNoncesRequest) GetRoundId() []byte {
@@ -1321,7 +1925,7 @@ type SignerNonces struct {
 
 func (x *SignerNonces) Reset() {
 	*x = SignerNonces{}
-	mi := &file_round_proto_msgTypes[20]
+	mi := &file_round_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1333,7 +1937,7 @@ func (x *SignerNonces) String() string {
 func (*SignerNonces) ProtoMessage() {}
 
 func (x *SignerNonces) ProtoReflect() protoreflect.Message {
-	mi := &file_round_proto_msgTypes[20]
+	mi := &file_round_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1346,7 +1950,7 @@ func (x *SignerNonces) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignerNonces.ProtoReflect.Descriptor instead.
 func (*SignerNonces) Descriptor() ([]byte, []int) {
-	return file_round_proto_rawDescGZIP(), []int{20}
+	return file_round_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *SignerNonces) GetTxNonces() map[string][]byte {
@@ -1371,7 +1975,7 @@ type SubmitPartialSigRequest struct {
 
 func (x *SubmitPartialSigRequest) Reset() {
 	*x = SubmitPartialSigRequest{}
-	mi := &file_round_proto_msgTypes[21]
+	mi := &file_round_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1383,7 +1987,7 @@ func (x *SubmitPartialSigRequest) String() string {
 func (*SubmitPartialSigRequest) ProtoMessage() {}
 
 func (x *SubmitPartialSigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_round_proto_msgTypes[21]
+	mi := &file_round_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1396,7 +2000,7 @@ func (x *SubmitPartialSigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubmitPartialSigRequest.ProtoReflect.Descriptor instead.
 func (*SubmitPartialSigRequest) Descriptor() ([]byte, []int) {
-	return file_round_proto_rawDescGZIP(), []int{21}
+	return file_round_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *SubmitPartialSigRequest) GetRoundId() []byte {
@@ -1426,7 +2030,7 @@ type SignerPartialSigs struct {
 
 func (x *SignerPartialSigs) Reset() {
 	*x = SignerPartialSigs{}
-	mi := &file_round_proto_msgTypes[22]
+	mi := &file_round_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1438,7 +2042,7 @@ func (x *SignerPartialSigs) String() string {
 func (*SignerPartialSigs) ProtoMessage() {}
 
 func (x *SignerPartialSigs) ProtoReflect() protoreflect.Message {
-	mi := &file_round_proto_msgTypes[22]
+	mi := &file_round_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1451,7 +2055,7 @@ func (x *SignerPartialSigs) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignerPartialSigs.ProtoReflect.Descriptor instead.
 func (*SignerPartialSigs) Descriptor() ([]byte, []int) {
-	return file_round_proto_rawDescGZIP(), []int{22}
+	return file_round_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *SignerPartialSigs) GetTxSigs() map[string][]byte {
@@ -1476,7 +2080,7 @@ type BoardingInputSignature struct {
 
 func (x *BoardingInputSignature) Reset() {
 	*x = BoardingInputSignature{}
-	mi := &file_round_proto_msgTypes[23]
+	mi := &file_round_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1488,7 +2092,7 @@ func (x *BoardingInputSignature) String() string {
 func (*BoardingInputSignature) ProtoMessage() {}
 
 func (x *BoardingInputSignature) ProtoReflect() protoreflect.Message {
-	mi := &file_round_proto_msgTypes[23]
+	mi := &file_round_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1501,7 +2105,7 @@ func (x *BoardingInputSignature) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoardingInputSignature.ProtoReflect.Descriptor instead.
 func (*BoardingInputSignature) Descriptor() ([]byte, []int) {
-	return file_round_proto_rawDescGZIP(), []int{23}
+	return file_round_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *BoardingInputSignature) GetInputIndex() int32 {
@@ -1539,7 +2143,7 @@ type SubmitForfeitSigRequest struct {
 
 func (x *SubmitForfeitSigRequest) Reset() {
 	*x = SubmitForfeitSigRequest{}
-	mi := &file_round_proto_msgTypes[24]
+	mi := &file_round_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1551,7 +2155,7 @@ func (x *SubmitForfeitSigRequest) String() string {
 func (*SubmitForfeitSigRequest) ProtoMessage() {}
 
 func (x *SubmitForfeitSigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_round_proto_msgTypes[24]
+	mi := &file_round_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1564,7 +2168,7 @@ func (x *SubmitForfeitSigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubmitForfeitSigRequest.ProtoReflect.Descriptor instead.
 func (*SubmitForfeitSigRequest) Descriptor() ([]byte, []int) {
-	return file_round_proto_rawDescGZIP(), []int{24}
+	return file_round_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *SubmitForfeitSigRequest) GetRoundId() []byte {
@@ -1601,7 +2205,7 @@ type ForfeitTxSig struct {
 
 func (x *ForfeitTxSig) Reset() {
 	*x = ForfeitTxSig{}
-	mi := &file_round_proto_msgTypes[25]
+	mi := &file_round_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1613,7 +2217,7 @@ func (x *ForfeitTxSig) String() string {
 func (*ForfeitTxSig) ProtoMessage() {}
 
 func (x *ForfeitTxSig) ProtoReflect() protoreflect.Message {
-	mi := &file_round_proto_msgTypes[25]
+	mi := &file_round_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1626,7 +2230,7 @@ func (x *ForfeitTxSig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ForfeitTxSig.ProtoReflect.Descriptor instead.
 func (*ForfeitTxSig) Descriptor() ([]byte, []int) {
-	return file_round_proto_rawDescGZIP(), []int{25}
+	return file_round_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *ForfeitTxSig) GetVtxoOutpoint() *Outpoint {
@@ -1671,7 +2275,7 @@ type SubmitVTXOForfeitSigsRequest struct {
 
 func (x *SubmitVTXOForfeitSigsRequest) Reset() {
 	*x = SubmitVTXOForfeitSigsRequest{}
-	mi := &file_round_proto_msgTypes[26]
+	mi := &file_round_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1683,7 +2287,7 @@ func (x *SubmitVTXOForfeitSigsRequest) String() string {
 func (*SubmitVTXOForfeitSigsRequest) ProtoMessage() {}
 
 func (x *SubmitVTXOForfeitSigsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_round_proto_msgTypes[26]
+	mi := &file_round_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1696,7 +2300,7 @@ func (x *SubmitVTXOForfeitSigsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubmitVTXOForfeitSigsRequest.ProtoReflect.Descriptor instead.
 func (*SubmitVTXOForfeitSigsRequest) Descriptor() ([]byte, []int) {
-	return file_round_proto_rawDescGZIP(), []int{26}
+	return file_round_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *SubmitVTXOForfeitSigsRequest) GetRoundId() []byte {
@@ -1817,7 +2421,50 @@ const file_round_proto_rawDesc = "" +
 	"\x10forfeit_requests\x18\x04 \x03(\v2\x18.round.v1.ForfeitRequestR\x0fforfeitRequests\x12=\n" +
 	"\x0eleave_requests\x18\x05 \x03(\v2\x16.round.v1.LeaveRequestR\rleaveRequests\x12\x19\n" +
 	"\bround_id\x18\x06 \x01(\tR\aroundId\x12+\n" +
-	"\x04auth\x18\a \x01(\v2\x17.round.v1.JoinRoundAuthR\x04auth\"\xc6\x01\n" +
+	"\x04auth\x18\a \x01(\v2\x17.round.v1.JoinRoundAuthR\x04auth\"\x88\x01\n" +
+	"\n" +
+	"VTXOIntent\x12'\n" +
+	"\x0fpolicy_template\x18\x01 \x01(\fR\x0epolicyTemplate\x12\x1f\n" +
+	"\vsigning_key\x18\x02 \x01(\fR\n" +
+	"signingKey\x120\n" +
+	"\x14requested_amount_sat\x18\x03 \x01(\x03R\x12requestedAmountSat\"\xa9\x03\n" +
+	"\x0fJoinRoundIntent\x12\x1e\n" +
+	"\n" +
+	"identifier\x18\x01 \x01(\fR\n" +
+	"identifier\x12F\n" +
+	"\x11boarding_requests\x18\x02 \x03(\v2\x19.round.v1.BoardingRequestR\x10boardingRequests\x127\n" +
+	"\fvtxo_intents\x18\x03 \x03(\v2\x14.round.v1.VTXOIntentR\vvtxoIntents\x12C\n" +
+	"\x10forfeit_requests\x18\x04 \x03(\v2\x18.round.v1.ForfeitRequestR\x0fforfeitRequests\x12=\n" +
+	"\x0eleave_requests\x18\x05 \x03(\v2\x16.round.v1.LeaveRequestR\rleaveRequests\x12\x19\n" +
+	"\bround_id\x18\x06 \x01(\tR\aroundId\x12+\n" +
+	"\x04auth\x18\a \x01(\v2\x17.round.v1.JoinRoundAuthR\x04auth\x12)\n" +
+	"\x10protocol_version\x18\b \x01(\rR\x0fprotocolVersion\"t\n" +
+	"\tVTXOQuote\x12'\n" +
+	"\x0fpolicy_template\x18\x01 \x01(\fR\x0epolicyTemplate\x12\x1d\n" +
+	"\n" +
+	"amount_sat\x18\x02 \x01(\x03R\tamountSat\x12\x1f\n" +
+	"\vsigning_key\x18\x03 \x01(\fR\n" +
+	"signingKey\"\x88\x02\n" +
+	"\fFeeBreakdown\x12*\n" +
+	"\x11liquidity_fee_sat\x18\x01 \x01(\x03R\x0fliquidityFeeSat\x12+\n" +
+	"\x12on_chain_share_sat\x18\x02 \x01(\x03R\x0fonChainShareSat\x12\x1d\n" +
+	"\n" +
+	"margin_sat\x18\x03 \x01(\x03R\tmarginSat\x12\"\n" +
+	"\rtotal_fee_sat\x18\x04 \x01(\x03R\vtotalFeeSat\x122\n" +
+	"\x15effective_annual_rate\x18\x05 \x01(\x01R\x13effectiveAnnualRate\x12(\n" +
+	"\x10below_min_viable\x18\x06 \x01(\bR\x0ebelowMinViable\"\xa1\x02\n" +
+	"\x0eJoinRoundQuote\x12\x19\n" +
+	"\bround_id\x18\x01 \x01(\fR\aroundId\x126\n" +
+	"\fvtxo_outputs\x18\x02 \x03(\v2\x13.round.v1.VTXOQuoteR\vvtxoOutputs\x12(\n" +
+	"\x10operator_fee_sat\x18\x03 \x01(\x03R\x0eoperatorFeeSat\x124\n" +
+	"\tbreakdown\x18\x04 \x01(\v2\x16.round.v1.FeeBreakdownR\tbreakdown\x121\n" +
+	"\x15quote_expires_at_unix\x18\x05 \x01(\x03R\x12quoteExpiresAtUnix\x12)\n" +
+	"\x10protocol_version\x18\x06 \x01(\rR\x0fprotocolVersion\",\n" +
+	"\x0fJoinRoundCommit\x12\x19\n" +
+	"\bround_id\x18\x01 \x01(\fR\aroundId\"D\n" +
+	"\x0fJoinRoundReject\x12\x19\n" +
+	"\bround_id\x18\x01 \x01(\fR\aroundId\x12\x16\n" +
+	"\x06reason\x18\x02 \x01(\tR\x06reason\"\xc6\x01\n" +
 	"\x13SubmitNoncesRequest\x12\x19\n" +
 	"\bround_id\x18\x01 \x01(\fR\aroundId\x12A\n" +
 	"\x06nonces\x18\x02 \x03(\v2).round.v1.SubmitNoncesRequest.NoncesEntryR\x06nonces\x1aQ\n" +
@@ -1862,13 +2509,16 @@ const file_round_proto_rawDesc = "" +
 	"\x1cSubmitVTXOForfeitSigsRequest\x12\x19\n" +
 	"\bround_id\x18\x01 \x01(\fR\aroundId\x127\n" +
 	"\vforfeit_txs\x18\x02 \x03(\v2\x16.round.v1.ForfeitTxSigR\n" +
-	"forfeitTxs2\xb4\x03\n" +
+	"forfeitTxs2\x98\x05\n" +
 	"\fRoundService\x12D\n" +
 	"\tJoinRound\x12\x1a.round.v1.JoinRoundRequest\x1a\x1b.round.v1.ClientSuccessResp\x12L\n" +
 	"\fSubmitNonces\x12\x1d.round.v1.SubmitNoncesRequest\x1a\x1d.round.v1.ClientVTXOAggNonces\x12S\n" +
 	"\x11SubmitPartialSigs\x12!.round.v1.SubmitPartialSigRequest\x1a\x1b.round.v1.ClientVTXOAggSigs\x12]\n" +
 	"\x11SubmitForfeitSigs\x12!.round.v1.SubmitForfeitSigRequest\x1a%.round.v1.ClientAwaitingInputSigsResp\x12\\\n" +
-	"\x15SubmitVTXOForfeitSigs\x12&.round.v1.SubmitVTXOForfeitSigsRequest\x1a\x1b.round.v1.ClientSuccessRespB<Z:github.com/lightninglabs/darepo-client/rpc/roundpb;roundpbb\x06proto3"
+	"\x15SubmitVTXOForfeitSigs\x12&.round.v1.SubmitVTXOForfeitSigsRequest\x1a\x1b.round.v1.ClientSuccessResp\x12J\n" +
+	"\x10SubmitJoinIntent\x12\x19.round.v1.JoinRoundIntent\x1a\x1b.round.v1.ClientSuccessResp\x12J\n" +
+	"\x10SubmitJoinCommit\x12\x19.round.v1.JoinRoundCommit\x1a\x1b.round.v1.ClientSuccessResp\x12J\n" +
+	"\x10SubmitJoinReject\x12\x19.round.v1.JoinRoundReject\x1a\x1b.round.v1.ClientSuccessRespB<Z:github.com/lightninglabs/darepo-client/rpc/roundpb;roundpbb\x06proto3"
 
 var (
 	file_round_proto_rawDescOnce sync.Once
@@ -1882,7 +2532,7 @@ func file_round_proto_rawDescGZIP() []byte {
 	return file_round_proto_rawDescData
 }
 
-var file_round_proto_msgTypes = make([]protoimpl.MessageInfo, 36)
+var file_round_proto_msgTypes = make([]protoimpl.MessageInfo, 43)
 var file_round_proto_goTypes = []any{
 	(*Outpoint)(nil),                     // 0: round.v1.Outpoint
 	(*TxOut)(nil),                        // 1: round.v1.TxOut
@@ -1903,28 +2553,35 @@ var file_round_proto_goTypes = []any{
 	(*LeaveRequest)(nil),                 // 16: round.v1.LeaveRequest
 	(*JoinRoundAuth)(nil),                // 17: round.v1.JoinRoundAuth
 	(*JoinRoundRequest)(nil),             // 18: round.v1.JoinRoundRequest
-	(*SubmitNoncesRequest)(nil),          // 19: round.v1.SubmitNoncesRequest
-	(*SignerNonces)(nil),                 // 20: round.v1.SignerNonces
-	(*SubmitPartialSigRequest)(nil),      // 21: round.v1.SubmitPartialSigRequest
-	(*SignerPartialSigs)(nil),            // 22: round.v1.SignerPartialSigs
-	(*BoardingInputSignature)(nil),       // 23: round.v1.BoardingInputSignature
-	(*SubmitForfeitSigRequest)(nil),      // 24: round.v1.SubmitForfeitSigRequest
-	(*ForfeitTxSig)(nil),                 // 25: round.v1.ForfeitTxSig
-	(*SubmitVTXOForfeitSigsRequest)(nil), // 26: round.v1.SubmitVTXOForfeitSigsRequest
-	nil,                                  // 27: round.v1.TreeNode.ChildrenEntry
-	nil,                                  // 28: round.v1.ClientBatchInfo.VtxoTreePathsEntry
-	nil,                                  // 29: round.v1.ClientBatchInfo.ConnectorLeafMapEntry
-	nil,                                  // 30: round.v1.ClientVTXOAggNonces.AggNoncesEntry
-	nil,                                  // 31: round.v1.ClientVTXOAggSigs.AggSigsEntry
-	nil,                                  // 32: round.v1.SubmitNoncesRequest.NoncesEntry
-	nil,                                  // 33: round.v1.SignerNonces.TxNoncesEntry
-	nil,                                  // 34: round.v1.SubmitPartialSigRequest.SignaturesEntry
-	nil,                                  // 35: round.v1.SignerPartialSigs.TxSigsEntry
+	(*VTXOIntent)(nil),                   // 19: round.v1.VTXOIntent
+	(*JoinRoundIntent)(nil),              // 20: round.v1.JoinRoundIntent
+	(*VTXOQuote)(nil),                    // 21: round.v1.VTXOQuote
+	(*FeeBreakdown)(nil),                 // 22: round.v1.FeeBreakdown
+	(*JoinRoundQuote)(nil),               // 23: round.v1.JoinRoundQuote
+	(*JoinRoundCommit)(nil),              // 24: round.v1.JoinRoundCommit
+	(*JoinRoundReject)(nil),              // 25: round.v1.JoinRoundReject
+	(*SubmitNoncesRequest)(nil),          // 26: round.v1.SubmitNoncesRequest
+	(*SignerNonces)(nil),                 // 27: round.v1.SignerNonces
+	(*SubmitPartialSigRequest)(nil),      // 28: round.v1.SubmitPartialSigRequest
+	(*SignerPartialSigs)(nil),            // 29: round.v1.SignerPartialSigs
+	(*BoardingInputSignature)(nil),       // 30: round.v1.BoardingInputSignature
+	(*SubmitForfeitSigRequest)(nil),      // 31: round.v1.SubmitForfeitSigRequest
+	(*ForfeitTxSig)(nil),                 // 32: round.v1.ForfeitTxSig
+	(*SubmitVTXOForfeitSigsRequest)(nil), // 33: round.v1.SubmitVTXOForfeitSigsRequest
+	nil,                                  // 34: round.v1.TreeNode.ChildrenEntry
+	nil,                                  // 35: round.v1.ClientBatchInfo.VtxoTreePathsEntry
+	nil,                                  // 36: round.v1.ClientBatchInfo.ConnectorLeafMapEntry
+	nil,                                  // 37: round.v1.ClientVTXOAggNonces.AggNoncesEntry
+	nil,                                  // 38: round.v1.ClientVTXOAggSigs.AggSigsEntry
+	nil,                                  // 39: round.v1.SubmitNoncesRequest.NoncesEntry
+	nil,                                  // 40: round.v1.SignerNonces.TxNoncesEntry
+	nil,                                  // 41: round.v1.SubmitPartialSigRequest.SignaturesEntry
+	nil,                                  // 42: round.v1.SignerPartialSigs.TxSigsEntry
 }
 var file_round_proto_depIdxs = []int32{
 	0,  // 0: round.v1.TreeNode.input:type_name -> round.v1.Outpoint
 	1,  // 1: round.v1.TreeNode.outputs:type_name -> round.v1.TxOut
-	27, // 2: round.v1.TreeNode.children:type_name -> round.v1.TreeNode.ChildrenEntry
+	34, // 2: round.v1.TreeNode.children:type_name -> round.v1.TreeNode.ChildrenEntry
 	2,  // 3: round.v1.VTXOTree.nodes:type_name -> round.v1.TreeNode
 	0,  // 4: round.v1.VTXOTree.batch_outpoint:type_name -> round.v1.Outpoint
 	1,  // 5: round.v1.VTXOTree.batch_output:type_name -> round.v1.TxOut
@@ -1933,10 +2590,10 @@ var file_round_proto_depIdxs = []int32{
 	0,  // 8: round.v1.ClientConnectorLeafInfo.connector_outpoint:type_name -> round.v1.Outpoint
 	0,  // 9: round.v1.ClientSuccessResp.accepted_boarding_outpoints:type_name -> round.v1.Outpoint
 	0,  // 10: round.v1.ClientSuccessResp.accepted_vtxo_outpoints:type_name -> round.v1.Outpoint
-	28, // 11: round.v1.ClientBatchInfo.vtxo_tree_paths:type_name -> round.v1.ClientBatchInfo.VtxoTreePathsEntry
-	29, // 12: round.v1.ClientBatchInfo.connector_leaf_map:type_name -> round.v1.ClientBatchInfo.ConnectorLeafMapEntry
-	30, // 13: round.v1.ClientVTXOAggNonces.agg_nonces:type_name -> round.v1.ClientVTXOAggNonces.AggNoncesEntry
-	31, // 14: round.v1.ClientVTXOAggSigs.agg_sigs:type_name -> round.v1.ClientVTXOAggSigs.AggSigsEntry
+	35, // 11: round.v1.ClientBatchInfo.vtxo_tree_paths:type_name -> round.v1.ClientBatchInfo.VtxoTreePathsEntry
+	36, // 12: round.v1.ClientBatchInfo.connector_leaf_map:type_name -> round.v1.ClientBatchInfo.ConnectorLeafMapEntry
+	37, // 13: round.v1.ClientVTXOAggNonces.agg_nonces:type_name -> round.v1.ClientVTXOAggNonces.AggNoncesEntry
+	38, // 14: round.v1.ClientVTXOAggSigs.agg_sigs:type_name -> round.v1.ClientVTXOAggSigs.AggSigsEntry
 	0,  // 15: round.v1.BoardingRequest.outpoint:type_name -> round.v1.Outpoint
 	0,  // 16: round.v1.ForfeitRequest.vtxo_outpoint:type_name -> round.v1.Outpoint
 	1,  // 17: round.v1.LeaveRequest.output:type_name -> round.v1.TxOut
@@ -1945,33 +2602,46 @@ var file_round_proto_depIdxs = []int32{
 	15, // 20: round.v1.JoinRoundRequest.forfeit_requests:type_name -> round.v1.ForfeitRequest
 	16, // 21: round.v1.JoinRoundRequest.leave_requests:type_name -> round.v1.LeaveRequest
 	17, // 22: round.v1.JoinRoundRequest.auth:type_name -> round.v1.JoinRoundAuth
-	32, // 23: round.v1.SubmitNoncesRequest.nonces:type_name -> round.v1.SubmitNoncesRequest.NoncesEntry
-	33, // 24: round.v1.SignerNonces.tx_nonces:type_name -> round.v1.SignerNonces.TxNoncesEntry
-	34, // 25: round.v1.SubmitPartialSigRequest.signatures:type_name -> round.v1.SubmitPartialSigRequest.SignaturesEntry
-	35, // 26: round.v1.SignerPartialSigs.tx_sigs:type_name -> round.v1.SignerPartialSigs.TxSigsEntry
-	0,  // 27: round.v1.BoardingInputSignature.outpoint:type_name -> round.v1.Outpoint
-	23, // 28: round.v1.SubmitForfeitSigRequest.signatures:type_name -> round.v1.BoardingInputSignature
-	0,  // 29: round.v1.ForfeitTxSig.vtxo_outpoint:type_name -> round.v1.Outpoint
-	25, // 30: round.v1.SubmitVTXOForfeitSigsRequest.forfeit_txs:type_name -> round.v1.ForfeitTxSig
-	3,  // 31: round.v1.ClientBatchInfo.VtxoTreePathsEntry.value:type_name -> round.v1.VTXOTree
-	4,  // 32: round.v1.ClientBatchInfo.ConnectorLeafMapEntry.value:type_name -> round.v1.ConnectorLeafInfo
-	20, // 33: round.v1.SubmitNoncesRequest.NoncesEntry.value:type_name -> round.v1.SignerNonces
-	22, // 34: round.v1.SubmitPartialSigRequest.SignaturesEntry.value:type_name -> round.v1.SignerPartialSigs
-	18, // 35: round.v1.RoundService.JoinRound:input_type -> round.v1.JoinRoundRequest
-	19, // 36: round.v1.RoundService.SubmitNonces:input_type -> round.v1.SubmitNoncesRequest
-	21, // 37: round.v1.RoundService.SubmitPartialSigs:input_type -> round.v1.SubmitPartialSigRequest
-	24, // 38: round.v1.RoundService.SubmitForfeitSigs:input_type -> round.v1.SubmitForfeitSigRequest
-	26, // 39: round.v1.RoundService.SubmitVTXOForfeitSigs:input_type -> round.v1.SubmitVTXOForfeitSigsRequest
-	6,  // 40: round.v1.RoundService.JoinRound:output_type -> round.v1.ClientSuccessResp
-	9,  // 41: round.v1.RoundService.SubmitNonces:output_type -> round.v1.ClientVTXOAggNonces
-	10, // 42: round.v1.RoundService.SubmitPartialSigs:output_type -> round.v1.ClientVTXOAggSigs
-	8,  // 43: round.v1.RoundService.SubmitForfeitSigs:output_type -> round.v1.ClientAwaitingInputSigsResp
-	6,  // 44: round.v1.RoundService.SubmitVTXOForfeitSigs:output_type -> round.v1.ClientSuccessResp
-	40, // [40:45] is the sub-list for method output_type
-	35, // [35:40] is the sub-list for method input_type
-	35, // [35:35] is the sub-list for extension type_name
-	35, // [35:35] is the sub-list for extension extendee
-	0,  // [0:35] is the sub-list for field type_name
+	13, // 23: round.v1.JoinRoundIntent.boarding_requests:type_name -> round.v1.BoardingRequest
+	19, // 24: round.v1.JoinRoundIntent.vtxo_intents:type_name -> round.v1.VTXOIntent
+	15, // 25: round.v1.JoinRoundIntent.forfeit_requests:type_name -> round.v1.ForfeitRequest
+	16, // 26: round.v1.JoinRoundIntent.leave_requests:type_name -> round.v1.LeaveRequest
+	17, // 27: round.v1.JoinRoundIntent.auth:type_name -> round.v1.JoinRoundAuth
+	21, // 28: round.v1.JoinRoundQuote.vtxo_outputs:type_name -> round.v1.VTXOQuote
+	22, // 29: round.v1.JoinRoundQuote.breakdown:type_name -> round.v1.FeeBreakdown
+	39, // 30: round.v1.SubmitNoncesRequest.nonces:type_name -> round.v1.SubmitNoncesRequest.NoncesEntry
+	40, // 31: round.v1.SignerNonces.tx_nonces:type_name -> round.v1.SignerNonces.TxNoncesEntry
+	41, // 32: round.v1.SubmitPartialSigRequest.signatures:type_name -> round.v1.SubmitPartialSigRequest.SignaturesEntry
+	42, // 33: round.v1.SignerPartialSigs.tx_sigs:type_name -> round.v1.SignerPartialSigs.TxSigsEntry
+	0,  // 34: round.v1.BoardingInputSignature.outpoint:type_name -> round.v1.Outpoint
+	30, // 35: round.v1.SubmitForfeitSigRequest.signatures:type_name -> round.v1.BoardingInputSignature
+	0,  // 36: round.v1.ForfeitTxSig.vtxo_outpoint:type_name -> round.v1.Outpoint
+	32, // 37: round.v1.SubmitVTXOForfeitSigsRequest.forfeit_txs:type_name -> round.v1.ForfeitTxSig
+	3,  // 38: round.v1.ClientBatchInfo.VtxoTreePathsEntry.value:type_name -> round.v1.VTXOTree
+	4,  // 39: round.v1.ClientBatchInfo.ConnectorLeafMapEntry.value:type_name -> round.v1.ConnectorLeafInfo
+	27, // 40: round.v1.SubmitNoncesRequest.NoncesEntry.value:type_name -> round.v1.SignerNonces
+	29, // 41: round.v1.SubmitPartialSigRequest.SignaturesEntry.value:type_name -> round.v1.SignerPartialSigs
+	18, // 42: round.v1.RoundService.JoinRound:input_type -> round.v1.JoinRoundRequest
+	26, // 43: round.v1.RoundService.SubmitNonces:input_type -> round.v1.SubmitNoncesRequest
+	28, // 44: round.v1.RoundService.SubmitPartialSigs:input_type -> round.v1.SubmitPartialSigRequest
+	31, // 45: round.v1.RoundService.SubmitForfeitSigs:input_type -> round.v1.SubmitForfeitSigRequest
+	33, // 46: round.v1.RoundService.SubmitVTXOForfeitSigs:input_type -> round.v1.SubmitVTXOForfeitSigsRequest
+	20, // 47: round.v1.RoundService.SubmitJoinIntent:input_type -> round.v1.JoinRoundIntent
+	24, // 48: round.v1.RoundService.SubmitJoinCommit:input_type -> round.v1.JoinRoundCommit
+	25, // 49: round.v1.RoundService.SubmitJoinReject:input_type -> round.v1.JoinRoundReject
+	6,  // 50: round.v1.RoundService.JoinRound:output_type -> round.v1.ClientSuccessResp
+	9,  // 51: round.v1.RoundService.SubmitNonces:output_type -> round.v1.ClientVTXOAggNonces
+	10, // 52: round.v1.RoundService.SubmitPartialSigs:output_type -> round.v1.ClientVTXOAggSigs
+	8,  // 53: round.v1.RoundService.SubmitForfeitSigs:output_type -> round.v1.ClientAwaitingInputSigsResp
+	6,  // 54: round.v1.RoundService.SubmitVTXOForfeitSigs:output_type -> round.v1.ClientSuccessResp
+	6,  // 55: round.v1.RoundService.SubmitJoinIntent:output_type -> round.v1.ClientSuccessResp
+	6,  // 56: round.v1.RoundService.SubmitJoinCommit:output_type -> round.v1.ClientSuccessResp
+	6,  // 57: round.v1.RoundService.SubmitJoinReject:output_type -> round.v1.ClientSuccessResp
+	50, // [50:58] is the sub-list for method output_type
+	42, // [42:50] is the sub-list for method input_type
+	42, // [42:42] is the sub-list for extension type_name
+	42, // [42:42] is the sub-list for extension extendee
+	0,  // [0:42] is the sub-list for field type_name
 }
 
 func init() { file_round_proto_init() }
@@ -1985,7 +2655,7 @@ func file_round_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_round_proto_rawDesc), len(file_round_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   36,
+			NumMessages:   43,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/rpc/roundpb/round.proto
+++ b/rpc/roundpb/round.proto
@@ -254,6 +254,19 @@ message JoinRoundAuth {
 }
 
 // JoinRoundRequest is sent from client to server to request joining a round.
+//
+// This is the v1 (submit-time implicit fee) protocol entry point. Under v1
+// the client pre-computes VTXO output amounts, and the operator fee is the
+// implicit difference between total inputs and total outputs. The server
+// validates that the implicit fee meets expectations at admission time
+// (see validateOperatorFee in the server repo).
+//
+// v2 (issue #270) introduces a two-phase handshake that moves fee
+// authorship to the server at seal-time; see JoinRoundIntent /
+// JoinRoundQuote / JoinRoundCommit / JoinRoundReject below. Clients
+// that negotiate protocol_version >= 2 use the v2 messages and do NOT
+// send JoinRoundRequest. The v1 path stays live during migration so
+// older clients continue to work.
 message JoinRoundRequest {
     // identifier is the compressed public key (33 bytes) of the
     // participant.
@@ -277,6 +290,210 @@ message JoinRoundRequest {
     // auth contains the BIP-322 authorization payload. Nil when join
     // request auth is disabled.
     JoinRoundAuth auth = 7;
+}
+
+// --------------------------------------------------------------------------
+// Seal-time fee handshake (issue #270) — v2 protocol
+//
+// The v2 protocol replaces the single-shot JoinRoundRequest with a two-
+// phase exchange: the client declares an intent (structure only, no
+// VTXO amounts), the server seals the round and authors per-client fee
+// quotes once actual batch occupancy is known, and the client either
+// commits (signs) or rejects.
+//
+// Rationale: under v1 the client must commit to specific VTXO output
+// amounts (and thus the implicit operator fee) before it knows the
+// final batch size, chain rate at seal-time, or treasury utilization
+// curve. The client therefore has to over-quote conservatively, and
+// refresh/send paths (forfeit-only) lack any submit-time validation
+// at all. Under v2 the server knows every input at seal-time, so it
+// authors the authoritative fee and the client's only choice is
+// accept-or-reject. Under-payment is structurally impossible.
+//
+// Migration contract: both protocols run concurrently. The client
+// advertises its highest supported JoinRoundProtocolVersion, the
+// server picks the highest it supports, and the two speak that
+// version for the round's lifetime. v1 will be deprecated once all
+// in-tree clients advertise v2 or higher.
+// --------------------------------------------------------------------------
+
+// VTXOIntent describes a VTXO the client wants to receive under the v2
+// handshake, without committing to an exact amount. The operator authors
+// the final amount net of the per-client fee at seal-time and returns it
+// via VTXOQuote.
+message VTXOIntent {
+    // policy_template is the semantic arkscript policy for the requested
+    // output. Identical semantics to VTXORequest.policy_template but the
+    // client does NOT commit to an amount here.
+    bytes policy_template = 1;
+
+    // signing_key is the compressed public key (33 bytes) used for MuSig2
+    // cosigning and join-auth proof binding.
+    bytes signing_key = 2;
+
+    // requested_amount_sat is an UPPER BOUND on the amount the client
+    // expects for this VTXO, not a commitment. Used by the server as
+    // the pre-fee target; the VTXOQuote returns amount - per_client_fee
+    // allocated across intents. Clients express their desired split
+    // across multiple intents via this field. Must be strictly positive
+    // and sum to <= total input value.
+    int64 requested_amount_sat = 3;
+}
+
+// JoinRoundIntent is sent from client to server as Phase 1 of the v2
+// handshake. The server enqueues it, closes registration on its own
+// schedule, then walks every enqueued intent and authors a per-client
+// JoinRoundQuote once final batch occupancy is known.
+message JoinRoundIntent {
+    // identifier is the compressed public key (33 bytes) of the
+    // participant. Matches v1 JoinRoundRequest.identifier.
+    bytes identifier = 1;
+
+    // boarding_requests contains all boarding UTXO details. Same
+    // shape as v1.
+    repeated BoardingRequest boarding_requests = 2;
+
+    // vtxo_intents specifies the VTXOs the client wants to receive,
+    // with per-intent upper-bound amounts. The server authors the
+    // final amount (net of fee) in the returned VTXOQuote. Replaces
+    // v1 vtxo_requests.
+    repeated VTXOIntent vtxo_intents = 3;
+
+    // forfeit_requests specifies VTXOs to forfeit. Same shape as v1.
+    repeated ForfeitRequest forfeit_requests = 4;
+
+    // leave_requests specifies VTXOs being exited to on-chain outputs.
+    // Same shape as v1. Leave amounts are client-chosen and are NOT
+    // renegotiated at seal-time (the client owns the on-chain
+    // destination).
+    repeated LeaveRequest leave_requests = 5;
+
+    // round_id is optional; empty means the server assigns a round.
+    string round_id = 6;
+
+    // auth contains the BIP-322 authorization payload. Nil when join
+    // request auth is disabled.
+    JoinRoundAuth auth = 7;
+
+    // protocol_version is the v2 protocol version the client wants to
+    // speak. The server rejects the intent if it does not support the
+    // requested version. Minimum supported v2: 2.
+    uint32 protocol_version = 8;
+}
+
+// VTXOQuote is a per-VTXO amount authored by the server under the v2
+// handshake. Carries the pkScript derived from the intent's policy
+// template and the signing-key binding so the client can match quotes
+// back to the intents it submitted.
+message VTXOQuote {
+    // policy_template echoes the template from the matching
+    // VTXOIntent. Clients correlate by template + signing_key.
+    bytes policy_template = 1;
+
+    // amount_sat is the final VTXO amount authored by the server
+    // (<= the matching VTXOIntent.requested_amount_sat). The
+    // difference (requested - amount) is the client's share of the
+    // per-client operator fee.
+    int64 amount_sat = 2;
+
+    // signing_key is the cosigner key from the matching intent. Echoed
+    // so the client can pair quotes to the intents it submitted.
+    bytes signing_key = 3;
+}
+
+// FeeBreakdown mirrors fees.FeeBreakdown from the server repo. Sent with
+// every JoinRoundQuote so the client can display the authored fee to
+// the user and apply a local cap policy before accepting.
+message FeeBreakdown {
+    // liquidity_fee_sat is the per-round liquidity share carved from
+    // the operator's capital-cost model.
+    int64 liquidity_fee_sat = 1;
+
+    // on_chain_share_sat is the per-round on-chain share (the
+    // client's portion of the commitment tx fee).
+    int64 on_chain_share_sat = 2;
+
+    // margin_sat is the operator's fixed margin per liquidity-
+    // requiring operation.
+    int64 margin_sat = 3;
+
+    // total_fee_sat is the sum of the three components above. Never
+    // re-compute this client-side; accept the server's author.
+    int64 total_fee_sat = 4;
+
+    // effective_annual_rate is the annualized rate (after utilization
+    // spread) used for liquidity pricing. Informational only.
+    double effective_annual_rate = 5;
+
+    // below_min_viable is true when the authored fee exceeds the
+    // MinViableVTXOPct dust policy threshold. Clients may use this
+    // to warn the user before committing.
+    bool below_min_viable = 6;
+}
+
+// JoinRoundQuote is Phase 2 of the v2 handshake: the server-authored
+// quote carrying per-VTXO amounts, per-client operator fee, and a
+// freshness window. The client has until quote_expires_at_unix to send
+// a JoinRoundCommit (signatures) or a JoinRoundReject.
+message JoinRoundQuote {
+    // round_id is the UUID of the round (16 bytes).
+    bytes round_id = 1;
+
+    // vtxo_outputs carries the per-VTXO amounts authored by the
+    // server. Matches the order of the VTXOIntents the client sent;
+    // correlation is by signing_key + policy_template.
+    repeated VTXOQuote vtxo_outputs = 2;
+
+    // operator_fee_sat is the total per-client operator fee this
+    // quote reflects. Sum of (intent.requested_amount - quote.amount)
+    // across vtxo_outputs plus any fee carved from forfeit inputs,
+    // minus any on-chain pass-through (e.g. leave amounts).
+    int64 operator_fee_sat = 3;
+
+    // breakdown is the itemized fee breakdown (liquidity + on-chain
+    // + margin). Clients may display this to the user but MUST NOT
+    // re-derive the total from the breakdown; the authoritative
+    // total is operator_fee_sat.
+    FeeBreakdown breakdown = 4;
+
+    // quote_expires_at_unix is the Unix timestamp (seconds) after
+    // which the server will not honor a commit for this quote. A
+    // commit received after this is treated as a reject and the
+    // round is re-sealed without the slow client.
+    int64 quote_expires_at_unix = 5;
+
+    // protocol_version echoes the version the server agreed to
+    // speak. If this is lower than the client's requested version
+    // the client must either accept the downgrade or reject.
+    uint32 protocol_version = 6;
+}
+
+// JoinRoundCommit is sent by the client after receiving a
+// JoinRoundQuote to explicitly accept the server-authored amounts
+// and proceed to signing. A signature message (SubmitNonces) received
+// within the quote window is ALSO treated as an implicit commit, so
+// sending JoinRoundCommit is only required when the client needs to
+// explicitly acknowledge without starting MuSig2 signing
+// immediately (e.g. for UI pacing).
+message JoinRoundCommit {
+    // round_id is the UUID of the round (16 bytes).
+    bytes round_id = 1;
+}
+
+// JoinRoundReject is sent by the client when it refuses to sign the
+// quote -- typically because operator_fee_sat exceeds the client's
+// configured cap, or the quote expired locally before it could be
+// processed. The server drops the rejecting intent, re-seals the
+// remaining intents at the smaller batch, and authors fresh quotes.
+message JoinRoundReject {
+    // round_id is the UUID of the round (16 bytes).
+    bytes round_id = 1;
+
+    // reason is a short human-readable reason code. Informational
+    // only; the server does not use the text for any routing.
+    // Canonical values: "fee_too_high", "quote_expired",
+    // "policy_violation", "user_cancelled".
+    string reason = 2;
 }
 
 // SubmitNoncesRequest submits MuSig2 nonces from client to server.
@@ -373,7 +590,7 @@ message SubmitVTXOForfeitSigsRequest {
 // RoundService defines the RPCs and events used for the round protocol between
 // server and client over the mailbox transport.
 service RoundService {
-    // JoinRound registers a client for a round.
+    // JoinRound registers a client for a round (v1 protocol).
     rpc JoinRound (JoinRoundRequest) returns (ClientSuccessResp);
 
     // SubmitNonces submits MuSig2 nonces.
@@ -389,4 +606,24 @@ service RoundService {
     // SubmitVTXOForfeitSigs submits VTXO forfeit signatures.
     rpc SubmitVTXOForfeitSigs (SubmitVTXOForfeitSigsRequest)
         returns (ClientSuccessResp);
+
+    // SubmitJoinIntent registers a client for a round under the v2
+    // seal-time handshake. The server responds with a per-client
+    // JoinRoundQuote once registration closes and fees are authored;
+    // the quote arrives as an S2C event, not as a synchronous RPC
+    // response, because the server must wait for registration to
+    // seal before it can quote. The synchronous return is only
+    // an ack that the intent was enqueued.
+    rpc SubmitJoinIntent (JoinRoundIntent) returns (ClientSuccessResp);
+
+    // SubmitJoinCommit explicitly accepts a JoinRoundQuote. In the
+    // common path the client skips this and proceeds directly to
+    // SubmitNonces, which the server treats as an implicit commit
+    // for the outstanding quote on this round.
+    rpc SubmitJoinCommit (JoinRoundCommit) returns (ClientSuccessResp);
+
+    // SubmitJoinReject declines a JoinRoundQuote. The server drops
+    // the rejecting intent and re-seals the remaining intents at
+    // the smaller batch size with fresh quotes.
+    rpc SubmitJoinReject (JoinRoundReject) returns (ClientSuccessResp);
 }

--- a/rpc/roundpb/round_grpc.pb.go
+++ b/rpc/roundpb/round_grpc.pb.go
@@ -24,6 +24,9 @@ const (
 	RoundService_SubmitPartialSigs_FullMethodName     = "/round.v1.RoundService/SubmitPartialSigs"
 	RoundService_SubmitForfeitSigs_FullMethodName     = "/round.v1.RoundService/SubmitForfeitSigs"
 	RoundService_SubmitVTXOForfeitSigs_FullMethodName = "/round.v1.RoundService/SubmitVTXOForfeitSigs"
+	RoundService_SubmitJoinIntent_FullMethodName      = "/round.v1.RoundService/SubmitJoinIntent"
+	RoundService_SubmitJoinCommit_FullMethodName      = "/round.v1.RoundService/SubmitJoinCommit"
+	RoundService_SubmitJoinReject_FullMethodName      = "/round.v1.RoundService/SubmitJoinReject"
 )
 
 // RoundServiceClient is the client API for RoundService service.
@@ -33,7 +36,7 @@ const (
 // RoundService defines the RPCs and events used for the round protocol between
 // server and client over the mailbox transport.
 type RoundServiceClient interface {
-	// JoinRound registers a client for a round.
+	// JoinRound registers a client for a round (v1 protocol).
 	JoinRound(ctx context.Context, in *JoinRoundRequest, opts ...grpc.CallOption) (*ClientSuccessResp, error)
 	// SubmitNonces submits MuSig2 nonces.
 	SubmitNonces(ctx context.Context, in *SubmitNoncesRequest, opts ...grpc.CallOption) (*ClientVTXOAggNonces, error)
@@ -43,6 +46,23 @@ type RoundServiceClient interface {
 	SubmitForfeitSigs(ctx context.Context, in *SubmitForfeitSigRequest, opts ...grpc.CallOption) (*ClientAwaitingInputSigsResp, error)
 	// SubmitVTXOForfeitSigs submits VTXO forfeit signatures.
 	SubmitVTXOForfeitSigs(ctx context.Context, in *SubmitVTXOForfeitSigsRequest, opts ...grpc.CallOption) (*ClientSuccessResp, error)
+	// SubmitJoinIntent registers a client for a round under the v2
+	// seal-time handshake. The server responds with a per-client
+	// JoinRoundQuote once registration closes and fees are authored;
+	// the quote arrives as an S2C event, not as a synchronous RPC
+	// response, because the server must wait for registration to
+	// seal before it can quote. The synchronous return is only
+	// an ack that the intent was enqueued.
+	SubmitJoinIntent(ctx context.Context, in *JoinRoundIntent, opts ...grpc.CallOption) (*ClientSuccessResp, error)
+	// SubmitJoinCommit explicitly accepts a JoinRoundQuote. In the
+	// common path the client skips this and proceeds directly to
+	// SubmitNonces, which the server treats as an implicit commit
+	// for the outstanding quote on this round.
+	SubmitJoinCommit(ctx context.Context, in *JoinRoundCommit, opts ...grpc.CallOption) (*ClientSuccessResp, error)
+	// SubmitJoinReject declines a JoinRoundQuote. The server drops
+	// the rejecting intent and re-seals the remaining intents at
+	// the smaller batch size with fresh quotes.
+	SubmitJoinReject(ctx context.Context, in *JoinRoundReject, opts ...grpc.CallOption) (*ClientSuccessResp, error)
 }
 
 type roundServiceClient struct {
@@ -103,6 +123,36 @@ func (c *roundServiceClient) SubmitVTXOForfeitSigs(ctx context.Context, in *Subm
 	return out, nil
 }
 
+func (c *roundServiceClient) SubmitJoinIntent(ctx context.Context, in *JoinRoundIntent, opts ...grpc.CallOption) (*ClientSuccessResp, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ClientSuccessResp)
+	err := c.cc.Invoke(ctx, RoundService_SubmitJoinIntent_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *roundServiceClient) SubmitJoinCommit(ctx context.Context, in *JoinRoundCommit, opts ...grpc.CallOption) (*ClientSuccessResp, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ClientSuccessResp)
+	err := c.cc.Invoke(ctx, RoundService_SubmitJoinCommit_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *roundServiceClient) SubmitJoinReject(ctx context.Context, in *JoinRoundReject, opts ...grpc.CallOption) (*ClientSuccessResp, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ClientSuccessResp)
+	err := c.cc.Invoke(ctx, RoundService_SubmitJoinReject_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // RoundServiceServer is the server API for RoundService service.
 // All implementations must embed UnimplementedRoundServiceServer
 // for forward compatibility.
@@ -110,7 +160,7 @@ func (c *roundServiceClient) SubmitVTXOForfeitSigs(ctx context.Context, in *Subm
 // RoundService defines the RPCs and events used for the round protocol between
 // server and client over the mailbox transport.
 type RoundServiceServer interface {
-	// JoinRound registers a client for a round.
+	// JoinRound registers a client for a round (v1 protocol).
 	JoinRound(context.Context, *JoinRoundRequest) (*ClientSuccessResp, error)
 	// SubmitNonces submits MuSig2 nonces.
 	SubmitNonces(context.Context, *SubmitNoncesRequest) (*ClientVTXOAggNonces, error)
@@ -120,6 +170,23 @@ type RoundServiceServer interface {
 	SubmitForfeitSigs(context.Context, *SubmitForfeitSigRequest) (*ClientAwaitingInputSigsResp, error)
 	// SubmitVTXOForfeitSigs submits VTXO forfeit signatures.
 	SubmitVTXOForfeitSigs(context.Context, *SubmitVTXOForfeitSigsRequest) (*ClientSuccessResp, error)
+	// SubmitJoinIntent registers a client for a round under the v2
+	// seal-time handshake. The server responds with a per-client
+	// JoinRoundQuote once registration closes and fees are authored;
+	// the quote arrives as an S2C event, not as a synchronous RPC
+	// response, because the server must wait for registration to
+	// seal before it can quote. The synchronous return is only
+	// an ack that the intent was enqueued.
+	SubmitJoinIntent(context.Context, *JoinRoundIntent) (*ClientSuccessResp, error)
+	// SubmitJoinCommit explicitly accepts a JoinRoundQuote. In the
+	// common path the client skips this and proceeds directly to
+	// SubmitNonces, which the server treats as an implicit commit
+	// for the outstanding quote on this round.
+	SubmitJoinCommit(context.Context, *JoinRoundCommit) (*ClientSuccessResp, error)
+	// SubmitJoinReject declines a JoinRoundQuote. The server drops
+	// the rejecting intent and re-seals the remaining intents at
+	// the smaller batch size with fresh quotes.
+	SubmitJoinReject(context.Context, *JoinRoundReject) (*ClientSuccessResp, error)
 	mustEmbedUnimplementedRoundServiceServer()
 }
 
@@ -144,6 +211,15 @@ func (UnimplementedRoundServiceServer) SubmitForfeitSigs(context.Context, *Submi
 }
 func (UnimplementedRoundServiceServer) SubmitVTXOForfeitSigs(context.Context, *SubmitVTXOForfeitSigsRequest) (*ClientSuccessResp, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method SubmitVTXOForfeitSigs not implemented")
+}
+func (UnimplementedRoundServiceServer) SubmitJoinIntent(context.Context, *JoinRoundIntent) (*ClientSuccessResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SubmitJoinIntent not implemented")
+}
+func (UnimplementedRoundServiceServer) SubmitJoinCommit(context.Context, *JoinRoundCommit) (*ClientSuccessResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SubmitJoinCommit not implemented")
+}
+func (UnimplementedRoundServiceServer) SubmitJoinReject(context.Context, *JoinRoundReject) (*ClientSuccessResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SubmitJoinReject not implemented")
 }
 func (UnimplementedRoundServiceServer) mustEmbedUnimplementedRoundServiceServer() {}
 func (UnimplementedRoundServiceServer) testEmbeddedByValue()                      {}
@@ -256,6 +332,60 @@ func _RoundService_SubmitVTXOForfeitSigs_Handler(srv interface{}, ctx context.Co
 	return interceptor(ctx, in, info, handler)
 }
 
+func _RoundService_SubmitJoinIntent_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(JoinRoundIntent)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RoundServiceServer).SubmitJoinIntent(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: RoundService_SubmitJoinIntent_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RoundServiceServer).SubmitJoinIntent(ctx, req.(*JoinRoundIntent))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _RoundService_SubmitJoinCommit_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(JoinRoundCommit)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RoundServiceServer).SubmitJoinCommit(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: RoundService_SubmitJoinCommit_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RoundServiceServer).SubmitJoinCommit(ctx, req.(*JoinRoundCommit))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _RoundService_SubmitJoinReject_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(JoinRoundReject)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RoundServiceServer).SubmitJoinReject(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: RoundService_SubmitJoinReject_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RoundServiceServer).SubmitJoinReject(ctx, req.(*JoinRoundReject))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // RoundService_ServiceDesc is the grpc.ServiceDesc for RoundService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -282,6 +412,18 @@ var RoundService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "SubmitVTXOForfeitSigs",
 			Handler:    _RoundService_SubmitVTXOForfeitSigs_Handler,
+		},
+		{
+			MethodName: "SubmitJoinIntent",
+			Handler:    _RoundService_SubmitJoinIntent_Handler,
+		},
+		{
+			MethodName: "SubmitJoinCommit",
+			Handler:    _RoundService_SubmitJoinCommit_Handler,
+		},
+		{
+			MethodName: "SubmitJoinReject",
+			Handler:    _RoundService_SubmitJoinReject_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/rpc/roundpb/round_mailboxrpc.pb.go
+++ b/rpc/roundpb/round_mailboxrpc.pb.go
@@ -34,6 +34,12 @@ type RoundServiceMailboxServer interface {
 	SubmitForfeitSigs(ctx context.Context, req *SubmitForfeitSigRequest) (*ClientAwaitingInputSigsResp, error)
 	// SubmitVTXOForfeitSigs handles SubmitVTXOForfeitSigs.
 	SubmitVTXOForfeitSigs(ctx context.Context, req *SubmitVTXOForfeitSigsRequest) (*ClientSuccessResp, error)
+	// SubmitJoinIntent handles SubmitJoinIntent.
+	SubmitJoinIntent(ctx context.Context, req *JoinRoundIntent) (*ClientSuccessResp, error)
+	// SubmitJoinCommit handles SubmitJoinCommit.
+	SubmitJoinCommit(ctx context.Context, req *JoinRoundCommit) (*ClientSuccessResp, error)
+	// SubmitJoinReject handles SubmitJoinReject.
+	SubmitJoinReject(ctx context.Context, req *JoinRoundReject) (*ClientSuccessResp, error)
 }
 
 // RegisterRoundServiceMailboxServer registers handlers for RoundService.
@@ -87,6 +93,36 @@ func RegisterRoundServiceMailboxServer(r rpc.Router, impl RoundServiceMailboxSer
 		}
 
 		return impl.SubmitVTXOForfeitSigs(ctx, req)
+	})
+	r.Handle("round.v1.RoundService", "SubmitJoinIntent", func() proto.Message {
+		return &JoinRoundIntent{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*JoinRoundIntent)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.SubmitJoinIntent(ctx, req)
+	})
+	r.Handle("round.v1.RoundService", "SubmitJoinCommit", func() proto.Message {
+		return &JoinRoundCommit{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*JoinRoundCommit)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.SubmitJoinCommit(ctx, req)
+	})
+	r.Handle("round.v1.RoundService", "SubmitJoinReject", func() proto.Message {
+		return &JoinRoundReject{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*JoinRoundReject)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.SubmitJoinReject(ctx, req)
 	})
 }
 
@@ -192,6 +228,75 @@ func (c *RoundServiceMailboxClient) SubmitVTXOForfeitSigs(ctx context.Context, r
 	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
 		Service: "round.v1.RoundService",
 		Method:  "SubmitVTXOForfeitSigs",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(ClientSuccessResp)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// SubmitJoinIntent calls the SubmitJoinIntent RPC.
+func (c *RoundServiceMailboxClient) SubmitJoinIntent(ctx context.Context, req *JoinRoundIntent, opts ...rpc.RPCOptions) (*ClientSuccessResp, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "round.v1.RoundService",
+		Method:  "SubmitJoinIntent",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(ClientSuccessResp)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// SubmitJoinCommit calls the SubmitJoinCommit RPC.
+func (c *RoundServiceMailboxClient) SubmitJoinCommit(ctx context.Context, req *JoinRoundCommit, opts ...rpc.RPCOptions) (*ClientSuccessResp, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "round.v1.RoundService",
+		Method:  "SubmitJoinCommit",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(ClientSuccessResp)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// SubmitJoinReject calls the SubmitJoinReject RPC.
+func (c *RoundServiceMailboxClient) SubmitJoinReject(ctx context.Context, req *JoinRoundReject, opts ...rpc.RPCOptions) (*ClientSuccessResp, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "round.v1.RoundService",
+		Method:  "SubmitJoinReject",
 	}, req, opt)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

Client-side scaffold for the v2 seal-time fee handshake protocol
(darepo issue #270). Replaces the v1 single-shot JoinRoundRequest
pattern (where the client pre-computes VTXO output amounts and the
server validates the implicit operator fee at admission) with a
two-phase exchange where the server authors fees after registration
closes and the client accepts or rejects.

Pairs with a server-side PR on `darepo` (branch
`finalize-e2e-fees`) that consumes these proto messages + domain
types.

### What's in this PR

**Proto** (`rpc/roundpb/round.proto`):
- New messages: `JoinRoundIntent`, `JoinRoundQuote`, `VTXOIntent`,
  `VTXOQuote`, `FeeBreakdown`, `JoinRoundCommit`, `JoinRoundReject`.
- New service RPCs: `SubmitJoinIntent`, `SubmitJoinCommit`,
  `SubmitJoinReject`. All v1 messages and RPCs (`JoinRoundRequest`,
  `ClientSuccessResp`, etc.) kept intact for backwards compat
  during migration.
- Protocol selection via `JoinRoundIntent.protocol_version` (v2
  minimum: 2).

**Domain types** (`lib/types`):
- Mirrors the proto messages with native Go types so the actor and
  FSM don't wedge proto types through protocol-internal layers:
  `VTXOIntent`, `JoinRoundIntent`, `VTXOQuote`,
  `JoinRoundFeeBreakdown`, `JoinRoundQuote`, `JoinRoundCommit`,
  `JoinRoundReject`.

**Client FSM scaffold** (`round/v2_handshake_states.go`):
- `IntentSentState` — Phase 1: client has sent a
  `JoinRoundIntent` and is waiting for the server to seal
  registration and author a `JoinRoundQuote`.
- `QuoteReceivedState` — Phase 2: decision point. Client
  validates the authored quote against local policy
  (`MaxOperatorFee` cap, `quote_expires_at_unix` freshness,
  per-VTXO signing_key + policy_template match) and transitions
  to the existing MuSig2 signing path on accept, or to
  `ClientFailed` on reject.
- Both states' `ProcessEvent` currently returns
  `ErrV2HandlerNotImplemented` and fails closed -- a v2 event
  arriving on an unwired code path surfaces the sentinel rather
  than silently falling through to the v1
  `RegistrationSentState` path.

### Why v2

Three structural problems in v1 that v2 fixes by construction:

1. **Fee drift between quote-time and seal-time**: under v1 the
   client must commit to a specific implicit operator fee at
   submit-time, before it knows the final batch size, chain rate,
   or treasury utilization at seal-time. The client over-quotes
   conservatively or eats rejection-and-retry.

2. **At-cost batch sizing needs a quote-time workaround**
   (darepo #268): the client has to quote at `batchSize=1` to
   guarantee its implicit fee is >= server expectation. Under v2
   the server always knows exact occupancy at quote-time.

3. **Refresh / send fee validation relies on the implicit-fee
   invariant** (darepo #269): forfeit-only rounds are validated
   post-hoc by iterating forfeit inputs. Under v2 the server is
   the sole fee author so no validation gap can exist.

### What's still pending

This PR is intentionally scoped to the scaffold so the server
side can land against a stable surface. Follow-ups on this branch
will add:

- Intent builder: v2-aware version of the
  `PendingRoundAssembly -> RegistrationSentState` transition.
- Quote validator: the real `QuoteReceivedState` ProcessEvent
  handler enforcing `MaxOperatorFee` + expiry + per-VTXO match.
- Reject path: emit `JoinRoundReject` + transition to
  `ClientFailed`.
- v2 events wired through the primary client FSM.
- Config plumbing for `MaxOperatorFee` (replaces the v1
  `MinOperatorFee` / pre-flight fee check at
  `transitions.go:383`).

## Test plan

- [x] `make lint-native` clean.
- [x] `go test ./round/...` green (both v1 regression tests and the
  new v2 scaffold tests).
- [x] Proto regenerated via `make rpc` (Docker-based gen script,
  reproducible).
- [ ] End-to-end v2 happy path (blocked on the real transition
  handlers + server-side FSM wiring).
- [ ] End-to-end v2 reject path (same).

Tracking issue: lightninglabs/darepo#270