### PR TITLE
multi: quote operator fee on refresh for #269

### DIFF
--- a/darepod/congestion_roundtrip_test.go
+++ b/darepod/congestion_roundtrip_test.go
@@ -26,19 +26,59 @@ type fakeArkService struct {
 	// changes.
 	response *arkrpc.EstimateFeeResponse
 
+	// estimateFeeErr, when non-nil, is returned from EstimateFee
+	// instead of the canned response. Used by degraded-mode tests
+	// to simulate an operator that is reachable for GetInfo but
+	// fails the fee quote.
+	estimateFeeErr error
+
+	// getInfoResponse is the canned GetInfo reply. Optional;
+	// tests that don't exercise the fetchOperatorTerms path can
+	// leave it nil, in which case GetInfo falls through to the
+	// embedded Unimplemented server and returns an error.
+	getInfoResponse *arkrpc.GetInfoResponse
+
+	// getInfoErr, when non-nil, is returned from GetInfo instead
+	// of the canned response. Used to exercise the degraded-mode
+	// fetchOperatorTerms-failed branch.
+	getInfoErr error
+
 	// lastRequest records the most recent EstimateFeeRequest
 	// so tests can assert what the client asked for.
 	lastRequest *arkrpc.EstimateFeeRequest
 }
 
-// EstimateFee records the request and returns the canned reply.
+// EstimateFee records the request and returns the canned reply
+// (or an error, if the test injected one).
 func (f *fakeArkService) EstimateFee(_ context.Context,
 	req *arkrpc.EstimateFeeRequest) (
 	*arkrpc.EstimateFeeResponse, error) {
 
 	f.lastRequest = req
 
+	if f.estimateFeeErr != nil {
+		return nil, f.estimateFeeErr
+	}
+
 	return f.response, nil
+}
+
+// GetInfo returns the canned reply (or an injected error). When
+// both fields are nil the call falls through to the embedded
+// Unimplemented server, which itself returns an error — useful
+// for tests that want fetchOperatorTerms to fail via the default.
+func (f *fakeArkService) GetInfo(ctx context.Context,
+	req *arkrpc.GetInfoRequest) (*arkrpc.GetInfoResponse, error) {
+
+	if f.getInfoErr != nil {
+		return nil, f.getInfoErr
+	}
+
+	if f.getInfoResponse != nil {
+		return f.getInfoResponse, nil
+	}
+
+	return f.UnimplementedArkServiceServer.GetInfo(ctx, req)
 }
 
 // newBufconnClient builds a *grpc.ClientConn wired to an

--- a/darepod/rpc_fees.go
+++ b/darepod/rpc_fees.go
@@ -8,6 +8,7 @@ import (
 	"github.com/lightninglabs/darepo-client/arkrpc"
 	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/lightninglabs/darepo-client/db/sqlc"
+	"github.com/lightninglabs/darepo-client/vtxo"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -73,6 +74,76 @@ func (s *Server) quoteOperatorFee(ctx context.Context,
 	}
 
 	return btcutil.Amount(resp.TotalFeeSat), nil
+}
+
+// autoRefreshFeeQuoter builds the vtxo.RefreshFeeQuoter the VTXO
+// manager plumbs into every spawned VTXO actor. The quoter is
+// invoked when a VTXO approaches its batch expiry and the actor is
+// about to emit an auto-refresh RefreshVTXORequest; the returned
+// fee is what the actor deducts from the new VTXO output so the
+// round's implicit operator fee matches what server-side
+// validateOperatorFee (#269) computes via ComputeForfeitFee.
+//
+// Degraded-mode policy mirrors Board and SendVTXO: if the
+// EstimateFee RPC or the operator terms fetch fails, fall back to
+// the legacy MinOperatorFee so an unreachable operator does not
+// leave the auto-refresh stuck at zero implicit fee (which would
+// trip the new #269 validation under a non-zero fee schedule).
+// When terms are also unreachable the quoter returns zero, which
+// matches pre-#269 behavior — safe only when the server is running
+// a zero fee schedule. The actor logs the fallback in either case.
+func (s *Server) autoRefreshFeeQuoter() vtxo.RefreshFeeQuoter {
+	return func(ctx context.Context, amount btcutil.Amount,
+		remainingBlocks uint32) btcutil.Amount {
+
+		// Resolve the legacy floor first so every error branch
+		// has a consistent fallback. Terms fetch failures log
+		// locally so the operator can diagnose a misconfigured
+		// serverConn without the VTXO actor spamming duplicate
+		// errors from its side.
+		var minFee btcutil.Amount
+		terms, termsErr := s.fetchOperatorTerms(ctx)
+		if termsErr != nil {
+			s.log.WarnS(ctx,
+				"Auto-refresh fee quoter: "+
+					"fetchOperatorTerms failed; "+
+					"using zero MinOperatorFee "+
+					"fallback",
+				termsErr)
+		} else {
+			minFee = terms.MinOperatorFee
+		}
+
+		quoted, qErr := s.quoteOperatorFee(
+			ctx, int64(amount),
+			false /* isBoarding */, remainingBlocks,
+		)
+		switch {
+		case qErr != nil:
+			s.log.WarnS(ctx,
+				"Auto-refresh fee quoter: EstimateFee "+
+					"unavailable; falling back to "+
+					"MinOperatorFee",
+				qErr)
+
+			return minFee
+
+		case quoted > minFee:
+			// Server expects the dynamic quote; pay it so
+			// validateOperatorFee sees the full per-input
+			// ComputeForfeitFee amount.
+			return quoted
+
+		default:
+			// Dynamic quote is at or below the legacy floor.
+			// Pay the floor so the client's round-FSM
+			// pre-flight check at round/transitions.go
+			// still passes — it rejects any submission
+			// strictly below MinOperatorFee before the
+			// server sees it.
+			return minFee
+		}
+	}
 }
 
 // EstimateFee proxies the operator's ArkService.EstimateFee RPC over

--- a/darepod/rpc_fees_test.go
+++ b/darepod/rpc_fees_test.go
@@ -5,6 +5,10 @@ import (
 	"math"
 	"testing"
 
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/arkrpc"
 	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/lightninglabs/darepo-client/db/sqlc"
 	"github.com/lightninglabs/darepo-client/ledger"
@@ -249,6 +253,156 @@ func TestLedgerEntryToProtoRoundFee(t *testing.T) {
 	require.Equal(t, ledger.EventBoardingFeePaid, got.EventType)
 	require.Equal(t, roundID, got.RoundId)
 	require.Empty(t, got.SessionId)
+}
+
+// newFakeOperatorResponse builds a canned GetInfoResponse with a
+// valid (parseable) pubkey and the given MinOperatorFee. Shared by
+// the autoRefreshFeeQuoter degraded-mode tests below.
+func newFakeOperatorResponse(t *testing.T,
+	minOperatorFee int64) *arkrpc.GetInfoResponse {
+
+	t.Helper()
+
+	priv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	return &arkrpc.GetInfoResponse{
+		Pubkey:         priv.PubKey().SerializeCompressed(),
+		VtxoExitDelay:  144,
+		SweepDelay:     1008,
+		MinOperatorFee: minOperatorFee,
+	}
+}
+
+// TestAutoRefreshFeeQuoterQuoteFailsFallsBackToMinFee verifies that
+// when the operator is reachable for GetInfo (so MinOperatorFee is
+// known) but the EstimateFee RPC fails, the quoter returns the
+// legacy MinOperatorFee rather than silently collapsing to zero.
+// Silent zero would fail the server's #269 validateOperatorFee
+// under a non-zero fee schedule, and the VTXO would eventually
+// tip over into unilateral exit.
+func TestAutoRefreshFeeQuoterQuoteFailsFallsBackToMinFee(t *testing.T) {
+	t.Parallel()
+
+	const wantMinFee = btcutil.Amount(500)
+
+	svc := &fakeArkService{
+		getInfoResponse: newFakeOperatorResponse(
+			t, int64(wantMinFee),
+		),
+		estimateFeeErr: errors.New("operator overload"),
+	}
+
+	s := &Server{
+		serverConn: newBufconnClient(t, svc),
+		log:        btclog.Disabled,
+	}
+
+	got := s.autoRefreshFeeQuoter()(
+		t.Context(), 100_000, 200,
+	)
+	require.Equal(t, wantMinFee, got,
+		"quoter falls back to MinOperatorFee when EstimateFee "+
+			"fails, not to zero")
+}
+
+// TestAutoRefreshFeeQuoterTermsFailReturnsZeroFloor verifies that
+// when fetchOperatorTerms fails (operator unreachable for GetInfo),
+// minFee degrades to zero. The actor still calls EstimateFee, so
+// if that succeeds the quoter returns the dynamic quote; if it
+// also fails, the quoter returns zero. This test covers the
+// both-fail branch: terms unreachable AND EstimateFee unreachable
+// returns zero, matching pre-#269 behavior (safe only on zero-fee
+// schedules).
+func TestAutoRefreshFeeQuoterTermsAndQuoteFailReturnsZero(t *testing.T) {
+	t.Parallel()
+
+	// Leave getInfoResponse nil so GetInfo falls through to the
+	// embedded Unimplemented server (which returns an error).
+	svc := &fakeArkService{
+		estimateFeeErr: errors.New("operator overload"),
+	}
+
+	s := &Server{
+		serverConn: newBufconnClient(t, svc),
+		log:        btclog.Disabled,
+	}
+
+	got := s.autoRefreshFeeQuoter()(
+		t.Context(), 100_000, 200,
+	)
+	require.Equal(t, btcutil.Amount(0), got,
+		"both failures → zero, matching pre-#269 behavior")
+}
+
+// TestAutoRefreshFeeQuoterReturnsQuoteWhenAboveMinFee verifies that
+// when both operator calls succeed and the dynamic quote exceeds
+// the floor, the quoter returns the dynamic quote. This is the
+// happy path: the server's validateOperatorFee expects the full
+// ComputeForfeitFee amount, not the static floor.
+func TestAutoRefreshFeeQuoterReturnsQuoteWhenAboveMinFee(t *testing.T) {
+	t.Parallel()
+
+	const (
+		wantMinFee = btcutil.Amount(100)
+		wantQuote  = btcutil.Amount(750)
+	)
+
+	svc := &fakeArkService{
+		getInfoResponse: newFakeOperatorResponse(
+			t, int64(wantMinFee),
+		),
+		response: &arkrpc.EstimateFeeResponse{
+			TotalFeeSat: int64(wantQuote),
+		},
+	}
+
+	s := &Server{
+		serverConn: newBufconnClient(t, svc),
+		log:        btclog.Disabled,
+	}
+
+	got := s.autoRefreshFeeQuoter()(
+		t.Context(), 100_000, 200,
+	)
+	require.Equal(t, wantQuote, got,
+		"quote > floor → dynamic quote wins")
+}
+
+// TestAutoRefreshFeeQuoterReturnsMinFeeWhenQuoteBelowFloor verifies
+// that when the dynamic quote is at or below MinOperatorFee, the
+// quoter returns the floor. Under a low-congestion schedule the
+// round FSM's pre-flight check rejects any submission strictly
+// below MinOperatorFee before the round is even sent to the
+// server, so over-paying the floor is the safe default.
+func TestAutoRefreshFeeQuoterReturnsMinFeeWhenQuoteBelowFloor(t *testing.T) {
+	t.Parallel()
+
+	const (
+		wantMinFee = btcutil.Amount(500)
+		smallQuote = btcutil.Amount(50)
+	)
+
+	svc := &fakeArkService{
+		getInfoResponse: newFakeOperatorResponse(
+			t, int64(wantMinFee),
+		),
+		response: &arkrpc.EstimateFeeResponse{
+			TotalFeeSat: int64(smallQuote),
+		},
+	}
+
+	s := &Server{
+		serverConn: newBufconnClient(t, svc),
+		log:        btclog.Disabled,
+	}
+
+	got := s.autoRefreshFeeQuoter()(
+		t.Context(), 100_000, 200,
+	)
+	require.Equal(t, wantMinFee, got,
+		"quote <= floor → floor wins so the round FSM pre-flight "+
+			"check does not reject the submission")
 }
 
 // TestLedgerEntryToProtoExitCost verifies that an exit-cost row

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -751,11 +751,28 @@ func (r *RPCServer) RefreshVTXOs(ctx context.Context,
 		}, nil
 	}
 
+	// Quote the per-VTXO operator fee for each target so the
+	// wallet deducts it from each new refresh output and the
+	// round's implicit operator fee matches what the server's
+	// validateOperatorFee (#269) computes per-input via
+	// ComputeForfeitFee. Without this map the implicit fee is
+	// zero and every refresh is rejected under a non-zero
+	// schedule.
+	//
+	// Outpoint-keyed so the wallet handler can look up each
+	// input's fee directly rather than depending on slice
+	// ordering. Zero fees (e.g. operator running a zero
+	// schedule) produce map entries with zero values; the wallet
+	// treats missing-or-zero as "no deduction," which is the
+	// pre-#269 behavior.
+	operatorFees := r.quoteRefreshOperatorFees(ctx, targets)
+
 	// Send the refresh request to the wallet actor and await its
 	// response.
 	refreshReq := &wallet.RefreshVTXOsRequest{
 		TargetOutpoints: targets,
 		ForceRefresh:    true,
+		OperatorFees:    operatorFees,
 	}
 	future := wRef.Ask(ctx, refreshReq)
 	result := future.Await(ctx)
@@ -816,6 +833,145 @@ func (r *RPCServer) RefreshVTXOs(ctx context.Context,
 		QueuedOutpoints: queued,
 		Status:          "queued",
 	}, nil
+}
+
+// quoteRefreshOperatorFees asks the operator's EstimateFee RPC for
+// the per-VTXO operator fee of every target outpoint so the wallet
+// handler can deduct the correct amount from each refresh output.
+// The sum of the returned fees is the aggregate implicit operator
+// fee the round's server-side validateOperatorFee (#269) will
+// compare against its own per-input ComputeForfeitFee expectation.
+//
+// Each quote passes `remainingBlocks = BatchExpiry - currentHeight`
+// so the server's ComputeForfeitFee sees the same age-adjusted
+// input as its eventual validateOperatorFee check. The liquidity
+// component of the fee scales with the VTXO's remaining lock-up
+// time, so a fresh quote with the real remaining-blocks value
+// matches server-side validation; passing 0 makes the server fall
+// back to SweepDelay (pre-#269 behavior), which over-quotes long
+// but still validates because implicit_fee >= expected.
+//
+// Behavior on missing data or quote failure: an unknown outpoint
+// (vtxoStore miss) and a quote RPC failure both fall back to
+// terms.MinOperatorFee for that outpoint — the same degraded-mode
+// policy Board and SendVTXO use. A zero-value MinOperatorFee is
+// left as zero, matching the pre-#269 refresh behavior where no
+// fee is deducted. All failures log at WarnS; none abort the
+// refresh because the wallet handler still applies its own
+// per-outpoint GetVTXO check and will surface a clean error for
+// the affected outpoints.
+func (r *RPCServer) quoteRefreshOperatorFees(ctx context.Context,
+	targets []wire.OutPoint) map[wire.OutPoint]btcutil.Amount {
+
+	// No work if the caller didn't ask for any, or if the VTXO
+	// store is unwired. Returning nil lets the wallet handler treat
+	// every entry as zero fee, matching pre-#269 behavior on
+	// schedules with no liquidity fee. vtxoStore is set once at
+	// startup so the guard hoists cleanly out of the per-target
+	// loop below.
+	if len(targets) == 0 || r.server.vtxoStore == nil {
+		return nil
+	}
+
+	// Fetch operator terms once so every per-VTXO fallback uses
+	// the same MinOperatorFee floor. If terms are unreachable we
+	// fall back to zero for the floor — that keeps the pre-#269
+	// no-fee behavior rather than making the refresh refuse to
+	// run when the operator is partially unreachable.
+	var minFee btcutil.Amount
+	terms, termsErr := r.server.fetchOperatorTerms(ctx)
+	if termsErr != nil {
+		r.server.log.WarnS(ctx,
+			"fetchOperatorTerms failed; refresh fee "+
+				"fallback will use zero floor",
+			termsErr)
+	} else {
+		minFee = terms.MinOperatorFee
+	}
+
+	// Fetch the current best block height once so we can compute
+	// remaining-blocks per target VTXO. If the chain backend is
+	// unreachable we leave currentHeight at zero and fall back
+	// to a zero remaining-blocks hint on the quote; the server
+	// then applies its SweepDelay default, which slightly
+	// over-quotes but still validates since implicit_fee >=
+	// expected.
+	var currentHeight int32
+	if r.server.chainBackend != nil {
+		h, _, hErr := r.server.chainBackend.BestBlock(ctx)
+		if hErr != nil {
+			r.server.log.WarnS(ctx,
+				"BestBlock unavailable; refresh quotes "+
+					"will use zero remaining-blocks "+
+					"hint and the server's SweepDelay "+
+					"default",
+				hErr)
+		} else {
+			currentHeight = h
+		}
+	}
+
+	out := make(map[wire.OutPoint]btcutil.Amount, len(targets))
+
+	for _, op := range targets {
+		desc, err := r.server.vtxoStore.GetVTXO(ctx, op)
+		if err != nil || desc == nil {
+			r.server.log.WarnS(ctx,
+				"Refresh quote skipped; VTXO lookup "+
+					"failed, falling back to "+
+					"MinOperatorFee", err,
+				slog.String("outpoint", op.String()))
+
+			out[op] = minFee
+
+			continue
+		}
+
+		// Compute remaining blocks until this VTXO's batch
+		// expires. Clamp negative or zero differences to zero;
+		// the server's EstimateFee treats zero as "use the
+		// SweepDelay default," which is the safe over-quote.
+		var remainingBlocks uint32
+		if currentHeight > 0 &&
+			desc.BatchExpiry > currentHeight {
+
+			remainingBlocks = uint32(
+				desc.BatchExpiry - currentHeight,
+			)
+		}
+
+		quoted, qErr := r.server.quoteOperatorFee(
+			ctx, int64(desc.Amount),
+			false /* isBoarding */, remainingBlocks,
+		)
+		switch {
+		case qErr != nil:
+			r.server.log.WarnS(ctx,
+				"EstimateFee unavailable for refresh; "+
+					"falling back to MinOperatorFee",
+				qErr,
+				slog.String("outpoint", op.String()))
+
+			out[op] = minFee
+
+		case quoted > minFee:
+			// Server expects the dynamic quote; pay it exactly
+			// so validateOperatorFee sees the full per-input
+			// ComputeForfeitFee amount.
+			out[op] = quoted
+
+		default:
+			// Dynamic quote is at or below the legacy floor;
+			// pay the floor. The server's dynamic validation
+			// accepts implicit fees >= the expected sum, so
+			// over-paying the floor when the schedule is
+			// cheap is safe (the surplus is booked as
+			// operator margin).
+			out[op] = minFee
+		}
+	}
+
+	return out
 }
 
 // Board triggers the client to join the next round with any confirmed

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -2856,15 +2856,16 @@ func (s *Server) initVTXOManager(ctx context.Context,
 	vtxoStore := dbStore.NewVTXOStore(s.clk)
 
 	manager := vtxo.NewManager(&vtxo.ManagerConfig{
-		Store:         vtxoStore,
-		Wallet:        vtxoWallet,
-		ChainSource:   chainSourceRef,
-		ActorSystem:   s.actorSystem,
-		ChainParams:   s.chainParams,
-		Log:           fn.Some(s.subLogger(vtxo.Subsystem)),
-		RoundActor:    round.NewServiceKey().Ref(s.actorSystem),
-		LedgerSink:    fn.Some(ledger.NewSink(s.actorSystem)),
-		ChainResolver: chainResolver,
+		Store:            vtxoStore,
+		Wallet:           vtxoWallet,
+		ChainSource:      chainSourceRef,
+		ActorSystem:      s.actorSystem,
+		ChainParams:      s.chainParams,
+		Log:              fn.Some(s.subLogger(vtxo.Subsystem)),
+		RoundActor:       round.NewServiceKey().Ref(s.actorSystem),
+		LedgerSink:       fn.Some(ledger.NewSink(s.actorSystem)),
+		ChainResolver:    chainResolver,
+		RefreshFeeQuoter: s.autoRefreshFeeQuoter(),
 	})
 
 	managerKey := actor.NewServiceKey[vtxo.ManagerMsg, vtxo.ManagerResp](

--- a/round/actor.go
+++ b/round/actor.go
@@ -56,6 +56,18 @@ type RefreshVTXORequest struct {
 	// Amount is the VTXO value in satoshis.
 	Amount int64
 
+	// OperatorFee is the operator fee (in satoshis) the VTXO actor
+	// quoted from the server's EstimateFee RPC before relaying this
+	// refresh request. The round actor deducts it from the new VTXO's
+	// output amount so the round's implicit operator fee (sum of forfeit
+	// inputs minus sum of new VTXO outputs) matches what the server-
+	// side validateOperatorFee (#269) expects per-input via
+	// ComputeForfeitFee. A zero value is the pre-#269 behavior — no
+	// deduction, zero implicit fee on this input — which is only
+	// correct under a zero fee schedule or when the quote RPC was
+	// unreachable at auto-refresh time.
+	OperatorFee int64
+
 	// PolicyTemplate is the semantic arkscript policy for the refreshed
 	// output. This is the authoritative round-registration representation.
 	PolicyTemplate []byte
@@ -107,12 +119,30 @@ func (e *RegisterIntentRequest) MessageType() string {
 // VTXOOriginRoundRefresh so the round actor routes the downstream
 // ledger emission to SourceRoundRefresh (cancels the paired forfeit
 // on transfers_out rather than crediting wallet_balance).
+//
+// The new VTXO's Amount is the forfeit input amount minus the quoted
+// operator fee on the request. The difference forms this input's
+// contribution to the round's implicit operator fee, which
+// server-side validateOperatorFee (#269) compares against
+// ComputeForfeitFee for this specific input.
 func buildVTXORequestFromRefresh(
 	req *RefreshVTXORequest) types.VTXORequest {
 
+	// Clamp any negative residual from a buggy fee to zero so the
+	// downstream VTXO construction never panics on a signed-int
+	// underflow. On the manual-refresh path the wallet handler
+	// rejects fees >= vtxo.Amount upstream, so this branch is
+	// defense-in-depth. On the auto-refresh path (VTXO actor ->
+	// round actor, no wallet involved) this clamp is the sole
+	// guard against a buggy RefreshFeeQuoter.
+	newAmount := req.Amount - req.OperatorFee
+	if newAmount < 0 {
+		newAmount = 0
+	}
+
 	return types.VTXORequest{
 		PolicyTemplate: req.PolicyTemplate,
-		Amount:         btcutil.Amount(req.Amount),
+		Amount:         btcutil.Amount(newAmount),
 		ClientKey:      req.OwnerKey.PubKey,
 		OwnerKey:       req.OwnerKey,
 		SigningKey:     req.SigningKey,

--- a/vtxo/actor.go
+++ b/vtxo/actor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btclog/v2"
@@ -26,6 +27,25 @@ func VTXOActorServiceKey(outpoint wire.OutPoint) actor.ServiceKey[
 
 	return actormsg.VTXOActorServiceKey(outpoint)
 }
+
+// RefreshFeeQuoter is the VTXO actor's hook into the operator's
+// EstimateFee RPC. The actor calls this just before relaying an
+// auto-refresh ForfeitRequest so the derived RefreshVTXORequest
+// embeds the server-expected operator fee on its output. The
+// implementation receives the VTXO amount and remaining blocks to
+// expiry so the server's ComputeForfeitFee sees the same inputs
+// as its eventual validateOperatorFee (#269) check.
+//
+// Returns the final fee to attach. The implementation is expected
+// to handle its own degraded-mode fallback (e.g. legacy
+// MinOperatorFee when the quote RPC errors) so the VTXO actor can
+// treat the return value as authoritative. A zero return means
+// "no deduction on this input" — safe only under a zero fee
+// schedule; under a non-zero schedule the server-side
+// validateOperatorFee will reject the refresh until the operator is
+// reachable again.
+type RefreshFeeQuoter func(ctx context.Context,
+	amount btcutil.Amount, remainingBlocks uint32) btcutil.Amount
 
 // VTXOActorConfig holds configuration for a single VTXO actor.
 type VTXOActorConfig struct {
@@ -57,6 +77,16 @@ type VTXOActorConfig struct {
 	// accounting DB sees the on-chain fee debit and the matching
 	// VTXO send leg. When None, ledger emission is skipped.
 	LedgerSink fn.Option[ledger.Sink]
+
+	// RefreshFeeQuoter, when set, is invoked on every auto-refresh
+	// emission so the relayed RefreshVTXORequest carries the
+	// server-expected operator fee. The quoter is expected to
+	// handle its own degraded-mode fallback (e.g. returning the
+	// legacy MinOperatorFee when the quote RPC is unreachable).
+	// When nil, the actor emits RefreshVTXORequest with
+	// OperatorFee=0 — pre-#269 behavior, used by tests and by
+	// operators running a zero fee schedule.
+	RefreshFeeQuoter RefreshFeeQuoter
 }
 
 // VTXOActor manages the lifecycle of a single VTXO. It processes events using
@@ -130,6 +160,52 @@ func (a *VTXOActor) tellManager(ctx context.Context, msg ManagerMsg) {
 			slog.String("msg_type", fmt.Sprintf("%T", msg)),
 			slog.String("outpoint", a.cfg.VTXO.Outpoint.String()))
 	}
+}
+
+// quoteRefreshFee asks the configured RefreshFeeQuoter for this
+// VTXO's operator fee at the observed block height, so the auto-
+// refresh RefreshVTXORequest relayed to the round actor embeds the
+// exact per-input fee the server-side validateOperatorFee (#269)
+// will expect. The quoter is given the VTXO's amount and remaining
+// blocks until batch expiry so ComputeForfeitFee sees the same
+// inputs as validation.
+//
+// lastCheckedHeight is the height observed by the FSM when it
+// emitted the ForfeitRequest outbox message, carried on the
+// message itself so this helper does not have to look at
+// a.state — by the time processOutbox runs a.state has already
+// transitioned past LiveState.
+//
+// Returns zero when no quoter is configured (tests, or operators
+// running a zero fee schedule). Otherwise returns whatever the
+// quoter supplies — the quoter implementation is expected to
+// handle its own fallback policy (e.g. legacy MinOperatorFee) when
+// the operator is unreachable.
+func (a *VTXOActor) quoteRefreshFee(ctx context.Context,
+	vtxo *Descriptor, lastCheckedHeight int32) btcutil.Amount {
+
+	if a.cfg.RefreshFeeQuoter == nil {
+		return 0
+	}
+
+	// Compute remaining blocks until batch expiry from the height
+	// the FSM observed when it emitted the ForfeitRequest. Clamp
+	// non-positive differences to zero; the server's EstimateFee
+	// treats zero as the SweepDelay default, which slightly
+	// over-quotes but still validates because implicit_fee >=
+	// expected.
+	var remainingBlocks uint32
+	if lastCheckedHeight > 0 &&
+		vtxo.BatchExpiry > lastCheckedHeight {
+
+		remainingBlocks = uint32(
+			vtxo.BatchExpiry - lastCheckedHeight,
+		)
+	}
+
+	return a.cfg.RefreshFeeQuoter(
+		ctx, vtxo.Amount, remainingBlocks,
+	)
 }
 
 // Start initializes the actor and subscribes to block epochs.
@@ -280,9 +356,24 @@ func (a *VTXOActor) processOutbox(ctx context.Context, outbox []VTXOOutMsg) {
 				continue
 			}
 
+			// Quote the operator fee for this VTXO so the
+			// RefreshVTXORequest carries the exact per-input
+			// ComputeForfeitFee the server will expect in its
+			// validateOperatorFee (#269) check. The FSM stamped
+			// the height it observed onto the outbox message so
+			// the quoter sees the same remaining-blocks hint
+			// the validator will use. The quoter is nil in
+			// tests and under a zero fee schedule; in both
+			// cases we emit OperatorFee=0, which is the
+			// pre-#269 behavior.
+			operatorFee := a.quoteRefreshFee(
+				ctx, vtxo, m.LastCheckedHeight,
+			)
+
 			refreshReq := &round.RefreshVTXORequest{
 				VTXOOutpoint:   m.VTXOOutpoint,
 				Amount:         int64(vtxo.Amount),
+				OperatorFee:    int64(operatorFee),
 				PolicyTemplate: policyTemplate,
 				OwnerKey:       vtxo.ClientKey,
 				SigningKey:     vtxo.ClientKey,

--- a/vtxo/actor_test.go
+++ b/vtxo/actor_test.go
@@ -1,8 +1,10 @@
 package vtxo
 
 import (
+	"context"
 	"testing"
 
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btclog/v2"
@@ -207,6 +209,119 @@ func TestProcessOutboxForfeitRequest(t *testing.T) {
 	require.Equal(t, int64(vtxo.Amount), refreshReq.Amount)
 	require.Equal(t, policyTemplate, refreshReq.PolicyTemplate)
 	require.Equal(t, vtxo.ClientKey, refreshReq.SigningKey)
+
+	// With no RefreshFeeQuoter configured, OperatorFee stays zero
+	// (pre-#269 behavior). Under a non-zero fee schedule the server's
+	// validateOperatorFee will reject the resulting round, but that
+	// is the caller-of-NewManager's responsibility to wire.
+	require.Equal(t, int64(0), refreshReq.OperatorFee,
+		"unconfigured quoter emits zero OperatorFee")
+}
+
+// TestProcessOutboxForfeitRequestQuotesFee verifies that when a
+// RefreshFeeQuoter is configured on VTXOActorConfig, the auto-refresh
+// emission threads the quoted fee onto the relayed RefreshVTXORequest
+// so the server-side validateOperatorFee (#269) sees a non-zero
+// implicit operator fee on the refresh input. Drives the full
+// Receive path so the FSM's LastCheckedHeight stamp on the outbox
+// ForfeitRequest is exercised end-to-end — a previous version read
+// the height from a.state inside processOutbox, which by that point
+// had already transitioned out of LiveState, causing remainingBlocks
+// to silently collapse to zero.
+func TestProcessOutboxForfeitRequestQuotesFee(t *testing.T) {
+	t.Parallel()
+
+	h := newVTXOTestHarness(t)
+	vtxo := h.newTestDescriptor()
+
+	// Pick a block height in the refresh window: batch expires
+	// 200 blocks out (above criticalThreshold for testExitDelay=144
+	// and TreeDepth=2 → safeExit=156, critical=156, refresh=
+	// max(144, 156+72)=228), so 156 < 200 <= 228 lands in
+	// ExpiryStatusNeedsRefresh.
+	currentHeight := vtxo.BatchExpiry - 200
+	expectedRemaining := uint32(200)
+
+	// Record the amount + remaining-blocks the quoter was called
+	// with so we can assert them independently of its return.
+	var (
+		gotAmount    btcutil.Amount
+		gotRemaining uint32
+	)
+	const quotedFee = btcutil.Amount(1_234)
+	quoter := func(_ context.Context, amt btcutil.Amount,
+		remaining uint32) btcutil.Amount {
+
+		gotAmount = amt
+		gotRemaining = remaining
+
+		return quotedFee
+	}
+
+	h.store.On(
+		"UpdateVTXOStatus", h.ctx, vtxo.Outpoint,
+		VTXOStatusPendingForfeit,
+	).Return(nil)
+
+	manager := newMockManagerRef(t)
+	a := &VTXOActor{
+		cfg: &VTXOActorConfig{
+			VTXO:             vtxo,
+			Store:            h.store,
+			Wallet:           h.wallet,
+			ChainParams:      &chaincfg.RegressionNetParams,
+			Manager:          manager,
+			RefreshFeeQuoter: quoter,
+		},
+		state: &LiveState{VTXO: vtxo},
+		env:   h.env,
+	}
+
+	// Drive the FSM through Receive so the state assignment and
+	// outbox dispatch run in the production order. The regression
+	// we are guarding against is that a.state is reassigned to
+	// PendingForfeitState before processOutbox runs; if the quoter
+	// reads a.state.(*LiveState), remainingBlocks collapses to
+	// zero. With the fix the height is stamped on the ForfeitRequest
+	// outbox message by the FSM transition itself.
+	epoch := h.newBlockEpochEvent(currentHeight)
+	result := a.Receive(h.ctx, epoch)
+	_, err := result.Unpack()
+	require.NoError(t, err)
+
+	// Confirm the transition actually advanced out of LiveState;
+	// otherwise the outbox would have emitted nothing and the
+	// assertions below would falsely pass.
+	_, inPending := a.state.(*PendingForfeitState)
+	require.True(t, inPending,
+		"Receive should have transitioned to PendingForfeitState, "+
+			"got %T", a.state)
+
+	msgs := manager.getMessages()
+	require.Len(t, msgs, 1)
+
+	relayMsg, ok := msgs[0].(*RelayToRoundMsg)
+	require.True(t, ok, "expected RelayToRoundMsg, got %T", msgs[0])
+
+	refreshReq, ok := relayMsg.Payload.(*round.RefreshVTXORequest)
+	require.True(
+		t, ok, "expected RefreshVTXORequest, got %T",
+		relayMsg.Payload,
+	)
+
+	require.Equal(t, int64(quotedFee), refreshReq.OperatorFee,
+		"OperatorFee carries the quoter's return value")
+	require.Equal(t, vtxo.Amount, gotAmount,
+		"quoter sees the VTXO amount")
+	require.Equal(t, expectedRemaining, gotRemaining,
+		"quoter sees BatchExpiry - LastCheckedHeight from the "+
+			"FSM-stamped outbox message, not a re-read of a.state")
+
+	// Forfeit input's Amount stays at the full VTXO value so the
+	// implicit operator fee = sum(forfeits) - sum(new_vtxos) =
+	// OperatorFee on this input.
+	require.Equal(t, int64(vtxo.Amount), refreshReq.Amount,
+		"forfeit input Amount is unchanged by the quote")
 }
 
 // TestProcessOutboxTerminatedNotification verifies that

--- a/vtxo/manager.go
+++ b/vtxo/manager.go
@@ -59,6 +59,16 @@ type ManagerConfig struct {
 	// fee + send-leg pair. When None, accounting emission is
 	// silently skipped.
 	LedgerSink fn.Option[ledger.Sink]
+
+	// RefreshFeeQuoter is propagated to each spawned VTXOActor so
+	// auto-refresh emissions embed the server-expected operator
+	// fee (#269 dynamic fee model) on the relayed
+	// RefreshVTXORequest. The quoter is expected to handle its own
+	// degraded-mode fallback (e.g. returning MinOperatorFee when
+	// the quote RPC errors). When nil, spawned actors emit with
+	// OperatorFee=0, which is pre-#269 behavior — safe only
+	// under a zero fee schedule.
+	RefreshFeeQuoter RefreshFeeQuoter
 }
 
 // Manager coordinates VTXO actor lifecycle - spawning new actors when VTXOs
@@ -415,16 +425,17 @@ func (m *Manager) spawnVTXOActor(ctx context.Context,
 	serviceKey := VTXOActorServiceKey(vtxo.Outpoint)
 
 	actorCfg := &VTXOActorConfig{
-		VTXO:          vtxo,
-		Store:         m.cfg.Store,
-		Wallet:        m.cfg.Wallet,
-		ChainSource:   m.cfg.ChainSource,
-		ChainParams:   m.cfg.ChainParams,
-		ExpiryConfig:  m.cfg.ExpiryConfig,
-		Log:           m.cfg.Log,
-		ChainResolver: m.cfg.ChainResolver,
-		Manager:       m.managerRef,
-		LedgerSink:    m.cfg.LedgerSink,
+		VTXO:             vtxo,
+		Store:            m.cfg.Store,
+		Wallet:           m.cfg.Wallet,
+		ChainSource:      m.cfg.ChainSource,
+		ChainParams:      m.cfg.ChainParams,
+		ExpiryConfig:     m.cfg.ExpiryConfig,
+		Log:              m.cfg.Log,
+		ChainResolver:    m.cfg.ChainResolver,
+		Manager:          m.managerRef,
+		LedgerSink:       m.cfg.LedgerSink,
+		RefreshFeeQuoter: m.cfg.RefreshFeeQuoter,
 	}
 
 	vtxoActor := NewVTXOActor(ctx, actorCfg)

--- a/vtxo/outbox_messages.go
+++ b/vtxo/outbox_messages.go
@@ -50,6 +50,15 @@ type ForfeitRequest struct {
 
 	// VTXOOutpoint identifies the VTXO to forfeit.
 	VTXOOutpoint wire.OutPoint
+
+	// LastCheckedHeight is the block height observed by the FSM at
+	// the moment this request was emitted. The outbox processor
+	// uses it to compute remaining-blocks for the operator fee
+	// quote without reading the actor's current state (which has
+	// already transitioned out of LiveState by the time the outbox
+	// runs). Zero means "unknown"; the quoter then falls back to
+	// the server's SweepDelay default.
+	LastCheckedHeight int32
 }
 
 func (m *ForfeitRequest) vtxoOutMsgSealed() {}

--- a/vtxo/transitions.go
+++ b/vtxo/transitions.go
@@ -158,9 +158,15 @@ func (s *LiveState) handleBlockEpoch(
 
 	case ExpiryStatusNeedsRefresh:
 		// Request cooperative forfeit before expiry becomes critical.
+		// LastCheckedHeight carries the current block height into
+		// the outbox so the actor's operator-fee quoter can compute
+		// remaining-blocks without reading its own state (which the
+		// Receive loop has already advanced to PendingForfeitState
+		// by the time the outbox is dispatched).
 		outbox := []VTXOOutMsg{
 			&ForfeitRequest{
-				VTXOOutpoint: s.VTXO.Outpoint,
+				VTXOOutpoint:      s.VTXO.Outpoint,
+				LastCheckedHeight: evt.Height,
 			},
 			&VTXOStatusUpdate{
 				Outpoint:  s.VTXO.Outpoint,

--- a/wallet/messages.go
+++ b/wallet/messages.go
@@ -480,16 +480,30 @@ func (m *CompleteSpendVTXOsResponse) MessageType() string {
 func (m *CompleteSpendVTXOsResponse) walletRespSealed() {}
 
 // LeaveVTXOsRequest triggers leave (offboard) of specified VTXOs. The VTXOs
-// will be forfeited and their value sent to the specified destination output.
+// will be forfeited and their value sent to the specified destination output,
+// minus the per-input operator fee when one is quoted.
 type LeaveVTXOsRequest struct {
 	actor.BaseMessage
 
 	// TargetOutpoints specifies which VTXOs to leave (offboard).
 	TargetOutpoints []wire.OutPoint
 
-	// DestOutput is the on-chain destination output where the funds will
-	// be sent. This output will be included in the batch transaction.
+	// DestOutput carries the destination pkScript. When OperatorFees is
+	// empty, Value is used verbatim for every leave output (legacy
+	// behavior). When OperatorFees is populated the per-leave output
+	// value is derived from the forfeited VTXO amount minus the quoted
+	// per-input operator fee, and DestOutput.Value is ignored in favor
+	// of the per-input computation so the implicit operator fee matches
+	// what the server's validateOperatorFee expects after #269.
 	DestOutput *wire.TxOut
+
+	// OperatorFees, when populated, carries the per-target operator fee
+	// the caller already quoted via the operator's EstimateFee RPC. The
+	// wallet handler subtracts OperatorFees[outpoint] from that VTXO's
+	// amount to produce the leave output value. Missing or zero entries
+	// produce a zero-fee leave (pre-#269 behavior), which the server
+	// will only accept under a zero fee schedule.
+	OperatorFees map[wire.OutPoint]btcutil.Amount
 }
 
 // MessageType returns the message type identifier for logging and debugging.

--- a/wallet/messages.go
+++ b/wallet/messages.go
@@ -307,6 +307,22 @@ type RefreshVTXOsRequest struct {
 	// ForceRefresh ignores the expiry threshold and refreshes immediately.
 	// Used by tests or when user explicitly requests refresh.
 	ForceRefresh bool
+
+	// OperatorFees, when non-empty, binds a per-VTXO operator fee to each
+	// target outpoint. The daemon quotes each fee from the server's
+	// EstimateFee RPC before sending the request; the wallet deducts the
+	// fee from the new VTXO produced by refreshing that specific input.
+	// The sum of these per-input fees forms the round's implicit operator
+	// fee that server-side validateOperatorFee (#269) checks against its
+	// own per-input ComputeForfeitFee expectation.
+	//
+	// Outpoint-keyed (rather than an index-parallel slice) so the wallet
+	// can look up each input's fee directly without relying on slice
+	// ordering matching between the daemon and the wallet handler. When
+	// nil or empty, the wallet keeps the legacy zero-fee behavior where
+	// each new VTXO inherits its forfeit input's amount — used by tests
+	// and by operators running a zero fee schedule.
+	OperatorFees map[wire.OutPoint]btcutil.Amount
 }
 
 // MessageType returns the message type identifier for logging and debugging.

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -1045,15 +1045,53 @@ func (a *Ark) handleLeaveVTXOs(ctx context.Context,
 			continue
 		}
 
-		// Each leave produces a forfeit of the old VTXO and a
-		// leave request with the destination output.
+		// Derive the per-leave output value from the forfeited
+		// VTXO amount minus the caller-quoted operator fee, so
+		// the implicit operator fee (Σinputs − Σoutputs) matches
+		// the server's per-input ComputeForfeitFee check after
+		// #269. When OperatorFees is empty the caller opted into
+		// the legacy zero-fee behavior and we fall back to
+		// DestOutput.Value verbatim; the server will only accept
+		// that under a zero fee schedule.
 		op := outpoint
+
+		leaveOutput := req.DestOutput
+		if len(req.OperatorFees) > 0 {
+			opFee := req.OperatorFees[op]
+			if opFee < 0 {
+				errors[outpoint] = fmt.Errorf(
+					"negative operator fee %d",
+					int64(opFee),
+				)
+
+				continue
+			}
+
+			if opFee >= vtxo.Amount {
+				errors[outpoint] = fmt.Errorf(
+					"operator fee %d >= vtxo amount %d",
+					int64(opFee), int64(vtxo.Amount),
+				)
+
+				continue
+			}
+
+			// Per-leaf output: preserve the caller's pkScript
+			// and carry the fee-adjusted value. Dust floor is
+			// enforced upstream (at quote time) and server-side
+			// by the schedule's MinViableVTXO check.
+			leaveOutput = &wire.TxOut{
+				PkScript: req.DestOutput.PkScript,
+				Value:    int64(vtxo.Amount - opFee),
+			}
+		}
+
 		forfeits = append(forfeits, types.ForfeitRequest{
 			VTXOOutpoint: &op,
 			Amount:       vtxo.Amount,
 		})
 		leaves = append(leaves, &types.LeaveRequest{
-			Output: req.DestOutput,
+			Output: leaveOutput,
 		})
 	}
 

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -842,14 +842,13 @@ func (a *Ark) handleRefreshVTXOs(ctx context.Context,
 			continue
 		}
 
-		// Each refresh produces a forfeit of the old VTXO and a
-		// request for a new VTXO with the same parameters.
-		op := vtxo.Outpoint
-		forfeits = append(forfeits, types.ForfeitRequest{
-			VTXOOutpoint: &op,
-			Amount:       vtxo.Amount,
-		})
-
+		// Validate the per-input operator fee up front so a
+		// rejected outpoint never lands in the forfeits slice
+		// without a matching VTXO request. A mixed-outcome
+		// request with one valid and one invalid outpoint would
+		// otherwise ship a Forfeits/VTXOs mismatch to
+		// RegisterIntentMsg and reserve a VTXO into
+		// PendingForfeitState with no replacement.
 		policyTemplate, err := vtxo.EffectivePolicyTemplate()
 		if err != nil {
 			a.logger(ctx).WarnS(ctx,
@@ -863,9 +862,44 @@ func (a *Ark) handleRefreshVTXOs(ctx context.Context,
 			continue
 		}
 
+		// Deduct the per-input operator fee (if the daemon quoted
+		// one) so the round's implicit operator fee matches what
+		// the server's validateOperatorFee will expect. A zero
+		// fee (missing map entry or a zero-schedule operator)
+		// leaves the new VTXO at the forfeit input's full amount,
+		// preserving the pre-#269 behavior.
+		opFee := req.OperatorFees[outpoint]
+		if opFee < 0 {
+			errors[outpoint] = fmt.Errorf(
+				"negative operator fee: %d",
+				int64(opFee),
+			)
+
+			continue
+		}
+
+		newAmount := vtxo.Amount - opFee
+		if opFee > 0 && newAmount <= 0 {
+			errors[outpoint] = fmt.Errorf(
+				"operator fee %d exceeds VTXO amount %d",
+				int64(opFee), int64(vtxo.Amount),
+			)
+
+			continue
+		}
+
+		// All validation has passed: append the forfeit and its
+		// matching VTXO request together so the two slices stay
+		// strictly paired. Mirrors the structure used by
+		// handleLeaveVTXOs.
+		op := vtxo.Outpoint
+		forfeits = append(forfeits, types.ForfeitRequest{
+			VTXOOutpoint: &op,
+			Amount:       vtxo.Amount,
+		})
 		vtxos = append(vtxos, types.VTXORequest{
 			PolicyTemplate: policyTemplate,
-			Amount:         vtxo.Amount,
+			Amount:         newAmount,
 			OwnerKey:       vtxo.ClientKey,
 			SigningKey:     vtxo.ClientKey,
 			// Refresh output: the new VTXO is funded by the

--- a/wallet/wallet_admission_test.go
+++ b/wallet/wallet_admission_test.go
@@ -454,10 +454,11 @@ func TestRefreshReservesBeforeRoundRegistration(t *testing.T) {
 	op := testOutpoint(0)
 	vtxoDescs := map[wire.OutPoint]*VTXODescriptor{
 		op: {
-			Outpoint: op,
-			Amount:   50000,
-			PkScript: []byte{0x51, 0x20, 0x01},
-			Expiry:   100,
+			Outpoint:       op,
+			Amount:         50000,
+			PkScript:       []byte{0x51, 0x20, 0x01},
+			PolicyTemplate: []byte{0xde, 0xad, 0xbe, 0xef},
+			Expiry:         100,
 		},
 	}
 
@@ -489,10 +490,11 @@ func TestRefreshReleasesOnRoundRejection(t *testing.T) {
 	op := testOutpoint(0)
 	vtxoDescs := map[wire.OutPoint]*VTXODescriptor{
 		op: {
-			Outpoint: op,
-			Amount:   50000,
-			PkScript: []byte{0x51, 0x20, 0x01},
-			Expiry:   100,
+			Outpoint:       op,
+			Amount:         50000,
+			PkScript:       []byte{0x51, 0x20, 0x01},
+			PolicyTemplate: []byte{0xde, 0xad, 0xbe, 0xef},
+			Expiry:         100,
 		},
 	}
 
@@ -521,6 +523,206 @@ func TestRefreshReleasesOnRoundRejection(t *testing.T) {
 	require.Equal(t, 1, mgr.forfeitReleaseCalls)
 }
 
+// TestRefreshDeductsPerInputOperatorFee verifies that when the daemon
+// pre-quotes a non-zero per-VTXO operator fee on RefreshVTXOsRequest,
+// the wallet builds the new VTXO's amount as (forfeit_amount -
+// operator_fee). The round's implicit operator fee (sum of forfeit
+// inputs minus sum of new VTXO outputs) must equal the sum of the
+// per-input fees so the server's validateOperatorFee (#269)
+// ComputeForfeitFee check accepts the submission.
+func TestRefreshDeductsPerInputOperatorFee(t *testing.T) {
+	t.Parallel()
+
+	op1 := testOutpoint(0)
+	op2 := testOutpoint(1)
+
+	// Policy template need only be non-empty so
+	// EffectivePolicyTemplate returns ok — the round actor mock
+	// does not parse it.
+	policy := []byte{0xde, 0xad, 0xbe, 0xef}
+
+	vtxoDescs := map[wire.OutPoint]*VTXODescriptor{
+		op1: {
+			Outpoint:       op1,
+			Amount:         50_000,
+			PkScript:       []byte{0x51, 0x20, 0x01},
+			PolicyTemplate: policy,
+			Expiry:         100,
+		},
+		op2: {
+			Outpoint:       op2,
+			Amount:         80_000,
+			PkScript:       []byte{0x51, 0x20, 0x02},
+			PolicyTemplate: policy,
+			Expiry:         200,
+		},
+	}
+
+	mgr := &mockVTXOManagerBehavior{
+		forfeitReserveResp: &actormsg.ReserveForfeitResponse{},
+	}
+	roundActor := &mockRoundActorBehavior{}
+
+	w := newTestWalletWithManagerAndRound(
+		t, mgr, roundActor, testVTXOReader(vtxoDescs),
+	)
+
+	const (
+		fee1 = btcutil.Amount(123)
+		fee2 = btcutil.Amount(456)
+	)
+	req := &RefreshVTXOsRequest{
+		TargetOutpoints: []wire.OutPoint{op1, op2},
+		OperatorFees: map[wire.OutPoint]btcutil.Amount{
+			op1: fee1,
+			op2: fee2,
+		},
+	}
+	result := w.Receive(t.Context(), req)
+	require.True(t, result.IsOk(), "expected ok, got: %v",
+		result.Err())
+
+	require.Equal(t, 1, roundActor.registerCalls)
+	require.NotNil(t, roundActor.capturedIntent)
+
+	// The intent should carry one forfeit at full amount and one
+	// new VTXO at (amount - fee) per input.
+	forfeits := roundActor.capturedIntent.Forfeits
+	vtxos := roundActor.capturedIntent.VTXOs
+	require.Len(t, forfeits, 2)
+	require.Len(t, vtxos, 2)
+
+	forfeitByOp := make(map[wire.OutPoint]btcutil.Amount, 2)
+	for _, f := range forfeits {
+		require.NotNil(t, f.VTXOOutpoint)
+		forfeitByOp[*f.VTXOOutpoint] = f.Amount
+	}
+	require.Equal(t,
+		vtxoDescs[op1].Amount, forfeitByOp[op1],
+		"forfeit input carries original amount",
+	)
+	require.Equal(t,
+		vtxoDescs[op2].Amount, forfeitByOp[op2],
+		"forfeit input carries original amount",
+	)
+
+	// Aggregate implicit fee = Σforfeits − Σnew_vtxos. Computed
+	// over the slices independently so the assertion does not rely
+	// on forfeits and vtxos being appended in the same order.
+	var sumForfeits, sumNewVTXOs btcutil.Amount
+	for _, f := range forfeits {
+		sumForfeits += f.Amount
+	}
+	for _, v := range vtxos {
+		sumNewVTXOs += v.Amount
+	}
+	require.Equal(t, fee1+fee2, sumForfeits-sumNewVTXOs,
+		"aggregate implicit fee matches the per-input quote sum")
+
+	// Per-input deduction: the multiset of new VTXO amounts must
+	// equal {desc.Amount − fee} across both inputs. Multiset-style
+	// check so a swap between op1 and op2 would be caught but the
+	// test doesn't wire in a forfeit→vtxo index pairing assumption.
+	wantNewAmounts := map[btcutil.Amount]int{
+		vtxoDescs[op1].Amount - fee1: 1,
+		vtxoDescs[op2].Amount - fee2: 1,
+	}
+	gotNewAmounts := map[btcutil.Amount]int{}
+	for _, v := range vtxos {
+		gotNewAmounts[v.Amount]++
+	}
+	require.Equal(t, wantNewAmounts, gotNewAmounts,
+		"each new VTXO amount equals its source VTXO's amount "+
+			"minus its operator fee")
+}
+
+// TestRefreshOrphansNoForfeitOnFeeValidationFailure verifies that if
+// fee validation fails for one outpoint in a mixed request, that
+// outpoint's forfeit is NOT appended to the intent package — so the
+// RegisterIntentMsg submitted to the round actor stays strictly
+// paired (len(Forfeits) == len(VTXOs)) and no VTXO is reserved into
+// PendingForfeitState without a matching replacement request.
+func TestRefreshOrphansNoForfeitOnFeeValidationFailure(t *testing.T) {
+	t.Parallel()
+
+	goodOp := testOutpoint(0)
+	badOp := testOutpoint(1)
+
+	policy := []byte{0xde, 0xad, 0xbe, 0xef}
+
+	vtxoDescs := map[wire.OutPoint]*VTXODescriptor{
+		goodOp: {
+			Outpoint:       goodOp,
+			Amount:         50_000,
+			PkScript:       []byte{0x51, 0x20, 0x01},
+			PolicyTemplate: policy,
+			Expiry:         100,
+		},
+		badOp: {
+			Outpoint:       badOp,
+			Amount:         1_000,
+			PkScript:       []byte{0x51, 0x20, 0x02},
+			PolicyTemplate: policy,
+			Expiry:         200,
+		},
+	}
+
+	mgr := &mockVTXOManagerBehavior{
+		forfeitReserveResp: &actormsg.ReserveForfeitResponse{},
+	}
+	roundActor := &mockRoundActorBehavior{}
+
+	w := newTestWalletWithManagerAndRound(
+		t, mgr, roundActor, testVTXOReader(vtxoDescs),
+	)
+
+	const goodFee = btcutil.Amount(123)
+
+	// badOp's fee exceeds its VTXO amount so validation rejects it.
+	// goodOp carries a valid fee so it should survive and land in
+	// the intent alone.
+	req := &RefreshVTXOsRequest{
+		TargetOutpoints: []wire.OutPoint{goodOp, badOp},
+		OperatorFees: map[wire.OutPoint]btcutil.Amount{
+			goodOp: goodFee,
+			badOp:  vtxoDescs[badOp].Amount + 1,
+		},
+	}
+	result := w.Receive(t.Context(), req)
+	require.True(t, result.IsOk(), "expected ok, got: %v",
+		result.Err())
+
+	require.Equal(t, 1, roundActor.registerCalls)
+	require.NotNil(t, roundActor.capturedIntent)
+
+	forfeits := roundActor.capturedIntent.Forfeits
+	vtxos := roundActor.capturedIntent.VTXOs
+
+	// Only goodOp should reach the intent. A forfeit for badOp
+	// without a matching VTXO would be a mismatched package the
+	// server rejects and a PendingForfeitState reservation with
+	// no replacement.
+	require.Len(t, forfeits, 1,
+		"only the valid outpoint's forfeit is appended")
+	require.Len(t, vtxos, 1,
+		"forfeit and VTXO slices stay paired")
+	require.NotNil(t, forfeits[0].VTXOOutpoint)
+	require.Equal(t, goodOp, *forfeits[0].VTXOOutpoint)
+	require.Equal(t,
+		vtxoDescs[goodOp].Amount-goodFee, vtxos[0].Amount,
+		"the surviving new VTXO carries the fee-adjusted amount")
+
+	resp, err := result.Unpack()
+	require.NoError(t, err)
+	refreshResp, ok := resp.(*RefreshVTXOsResponse)
+	require.True(t, ok)
+	require.Equal(t, 1, refreshResp.RefreshingCount,
+		"response reports the count of successful refreshes")
+	require.Contains(t, refreshResp.Errors, badOp,
+		"response surfaces the rejected outpoint in Errors")
+	require.NotContains(t, refreshResp.Errors, goodOp)
+}
+
 // TestRefreshFailsOnManagerRejection verifies that the wallet surfaces
 // manager reservation errors without sending to the round actor.
 func TestRefreshFailsOnManagerRejection(t *testing.T) {
@@ -529,10 +731,11 @@ func TestRefreshFailsOnManagerRejection(t *testing.T) {
 	op := testOutpoint(0)
 	vtxoDescs := map[wire.OutPoint]*VTXODescriptor{
 		op: {
-			Outpoint: op,
-			Amount:   50000,
-			PkScript: []byte{0x51, 0x20, 0x01},
-			Expiry:   100,
+			Outpoint:       op,
+			Amount:         50000,
+			PkScript:       []byte{0x51, 0x20, 0x01},
+			PolicyTemplate: []byte{0xde, 0xad, 0xbe, 0xef},
+			Expiry:         100,
 		},
 	}
 

--- a/wallet/wallet_admission_test.go
+++ b/wallet/wallet_admission_test.go
@@ -837,6 +837,222 @@ func TestLeaveReleasesOnRoundRejection(t *testing.T) {
 	require.Equal(t, 1, mgr.forfeitReleaseCalls)
 }
 
+// TestLeaveDeductsPerInputOperatorFee verifies that when the daemon
+// pre-quotes a non-zero per-VTXO operator fee on LeaveVTXOsRequest,
+// the wallet builds each leave output at (vtxo_amount -
+// operator_fee). The round's implicit operator fee (Σ forfeit
+// inputs − Σ leave outputs) must equal Σ per-input fees so the
+// server's validateOperatorFee (#269) ComputeForfeitFee check
+// accepts the submission. Mirror of TestRefreshDeductsPerInputOperatorFee
+// for the leave path.
+func TestLeaveDeductsPerInputOperatorFee(t *testing.T) {
+	t.Parallel()
+
+	op1 := testOutpoint(0)
+	op2 := testOutpoint(1)
+
+	vtxoDescs := map[wire.OutPoint]*VTXODescriptor{
+		op1: {
+			Outpoint: op1,
+			Amount:   50_000,
+			PkScript: []byte{0x51, 0x20, 0x01},
+			Expiry:   100,
+		},
+		op2: {
+			Outpoint: op2,
+			Amount:   80_000,
+			PkScript: []byte{0x51, 0x20, 0x02},
+			Expiry:   200,
+		},
+	}
+
+	mgr := &mockVTXOManagerBehavior{
+		forfeitReserveResp: &actormsg.ReserveForfeitResponse{},
+	}
+	roundActor := &mockRoundActorBehavior{}
+
+	w := newTestWalletWithManagerAndRound(
+		t, mgr, roundActor, testVTXOReader(vtxoDescs),
+	)
+
+	const (
+		fee1 = btcutil.Amount(321)
+		fee2 = btcutil.Amount(654)
+	)
+
+	// DestOutput.Value is ignored when OperatorFees is populated;
+	// set it to a sentinel so a regression that accidentally used
+	// it would surface as a wrong per-leaf value in the assertions
+	// below.
+	const sentinelValue = int64(999_999_999)
+	destScript := []byte{0x51, 0x20, 0xff}
+	req := &LeaveVTXOsRequest{
+		TargetOutpoints: []wire.OutPoint{op1, op2},
+		DestOutput: &wire.TxOut{
+			Value:    sentinelValue,
+			PkScript: destScript,
+		},
+		OperatorFees: map[wire.OutPoint]btcutil.Amount{
+			op1: fee1,
+			op2: fee2,
+		},
+	}
+	result := w.Receive(t.Context(), req)
+	require.True(t, result.IsOk(), "expected ok, got: %v",
+		result.Err())
+
+	require.Equal(t, 1, roundActor.registerCalls)
+	require.NotNil(t, roundActor.capturedIntent)
+
+	forfeits := roundActor.capturedIntent.Forfeits
+	leaves := roundActor.capturedIntent.Leaves
+	require.Len(t, forfeits, 2)
+	require.Len(t, leaves, 2)
+
+	// Build input→fee map for deterministic lookup regardless of
+	// slice ordering (the handler iterates TargetOutpoints so the
+	// order is preserved, but the test should be robust to future
+	// reordering).
+	type leafExpectation struct {
+		inputAmount  btcutil.Amount
+		leafValue    int64
+		wantImplicit btcutil.Amount
+	}
+	want := map[wire.OutPoint]leafExpectation{
+		op1: {
+			inputAmount:  vtxoDescs[op1].Amount,
+			leafValue:    int64(vtxoDescs[op1].Amount - fee1),
+			wantImplicit: fee1,
+		},
+		op2: {
+			inputAmount:  vtxoDescs[op2].Amount,
+			leafValue:    int64(vtxoDescs[op2].Amount - fee2),
+			wantImplicit: fee2,
+		},
+	}
+
+	var gotImplicit btcutil.Amount
+	for i := range forfeits {
+		require.NotNil(t, forfeits[i].VTXOOutpoint)
+		op := *forfeits[i].VTXOOutpoint
+		expect, ok := want[op]
+		require.True(t, ok, "unexpected forfeit outpoint %s",
+			op.String())
+
+		require.Equal(t, expect.inputAmount, forfeits[i].Amount,
+			"forfeit input carries full VTXO amount")
+
+		require.NotNil(t, leaves[i].Output)
+		require.Equal(t, expect.leafValue, leaves[i].Output.Value,
+			"leave output value = vtxo amount - operator fee")
+		require.Equal(t, destScript, leaves[i].Output.PkScript,
+			"pkScript is taken from DestOutput unchanged")
+
+		gotImplicit += forfeits[i].Amount - btcutil.Amount(
+			leaves[i].Output.Value,
+		)
+	}
+
+	require.Equal(t, fee1+fee2, gotImplicit,
+		"aggregate implicit fee matches the per-input quote sum")
+}
+
+// TestLeaveRejectsNegativeOperatorFee guards the wallet against a
+// caller passing a negative fee. The negative would otherwise make
+// the leave output *larger* than the forfeit amount (the operator
+// paying the client), silently inverting the fee direction. The
+// handler must reject before building the intent.
+func TestLeaveRejectsNegativeOperatorFee(t *testing.T) {
+	t.Parallel()
+
+	op := testOutpoint(0)
+	vtxoDescs := map[wire.OutPoint]*VTXODescriptor{
+		op: {
+			Outpoint: op,
+			Amount:   50_000,
+			PkScript: []byte{0x51, 0x20, 0x01},
+			Expiry:   100,
+		},
+	}
+
+	mgr := &mockVTXOManagerBehavior{
+		forfeitReserveResp: &actormsg.ReserveForfeitResponse{},
+	}
+	roundActor := &mockRoundActorBehavior{}
+
+	w := newTestWalletWithManagerAndRound(
+		t, mgr, roundActor, testVTXOReader(vtxoDescs),
+	)
+
+	req := &LeaveVTXOsRequest{
+		TargetOutpoints: []wire.OutPoint{op},
+		DestOutput:      &wire.TxOut{PkScript: []byte{0x51, 0x20}},
+		OperatorFees: map[wire.OutPoint]btcutil.Amount{
+			op: -1,
+		},
+	}
+	result := w.Receive(t.Context(), req)
+	require.True(t, result.IsOk(),
+		"handler returns ok with per-outpoint error; got: %v",
+		result.Err())
+
+	respVal, _ := result.Unpack()
+	resp, ok := respVal.(*LeaveVTXOsResponse)
+	require.True(t, ok)
+	require.Zero(t, resp.LeavingCount)
+	require.Contains(t, resp.Errors[op].Error(),
+		"negative operator fee")
+
+	// No round registration on all-rejected request.
+	require.Equal(t, 0, roundActor.registerCalls)
+}
+
+// TestLeaveRejectsFeeAtOrAboveAmount covers the bound the other way:
+// a fee >= VTXO amount would produce a zero or negative leave output,
+// which the server would reject anyway but the wallet should surface
+// as a clean per-input error rather than send a garbage intent.
+func TestLeaveRejectsFeeAtOrAboveAmount(t *testing.T) {
+	t.Parallel()
+
+	op := testOutpoint(0)
+	vtxoDescs := map[wire.OutPoint]*VTXODescriptor{
+		op: {
+			Outpoint: op,
+			Amount:   1_000,
+			PkScript: []byte{0x51, 0x20, 0x01},
+			Expiry:   100,
+		},
+	}
+
+	mgr := &mockVTXOManagerBehavior{
+		forfeitReserveResp: &actormsg.ReserveForfeitResponse{},
+	}
+	roundActor := &mockRoundActorBehavior{}
+
+	w := newTestWalletWithManagerAndRound(
+		t, mgr, roundActor, testVTXOReader(vtxoDescs),
+	)
+
+	req := &LeaveVTXOsRequest{
+		TargetOutpoints: []wire.OutPoint{op},
+		DestOutput:      &wire.TxOut{PkScript: []byte{0x51, 0x20}},
+		OperatorFees: map[wire.OutPoint]btcutil.Amount{
+			op: 1_000,
+		},
+	}
+	result := w.Receive(t.Context(), req)
+	require.True(t, result.IsOk(),
+		"handler returns ok with per-outpoint error; got: %v",
+		result.Err())
+
+	respVal, _ := result.Unpack()
+	resp, ok := respVal.(*LeaveVTXOsResponse)
+	require.True(t, ok)
+	require.Zero(t, resp.LeavingCount)
+	require.Contains(t, resp.Errors[op].Error(),
+		"operator fee 1000 >= vtxo amount 1000")
+}
+
 // =============================================================================
 // Directed send tests
 // =============================================================================


### PR DESCRIPTION
In this PR, we close the client-side half of the refresh fee gap that
will be exposed once the server-side fix for
[lightninglabs/darepo#269](https://github.com/lightninglabs/darepo/issues/269)
lands. Today the client's refresh flows don't quote the operator fee at
all: the implicit operator fee on the round (sum of forfeit inputs minus
sum of new VTXO outputs) is zero. That's fine under a zero fee
schedule, but the server's extension of `validateOperatorFee` to refresh
and send paths turns the same silent-zero into a hard rejection under
any non-zero schedule, which for the auto-refresh path would push VTXOs
toward unilateral exit. We fix both refresh paths so the client's
implicit fee matches what the server's per-input `ComputeForfeitFee`
check expects.

Refresh on the client comes in two flavors and they travel through
entirely different paths. Both needed fixing.

## Manual refresh (daemon RPC → wallet actor)

For `darepocli refresh-vtxos`, the daemon now pre-quotes the operator
fee per target outpoint before handing the request to the wallet actor.
`RefreshVTXOs` resolves each VTXO via `vtxoStore.GetVTXO`, asks
`chainBackend.BestBlock` for the current tip, and calls
`quoteOperatorFee(amount, isBoarding=false, remainingBlocks=BatchExpiry - currentHeight)`
per input. The results land on a new outpoint-keyed
`OperatorFees map[wire.OutPoint]btcutil.Amount` field on
`wallet.RefreshVTXOsRequest`. `handleRefreshVTXOs` then deducts each
per-input fee from its matching new VTXO's `Amount`. The aggregate
identity `sum(forfeits) - sum(new_vtxos) = sum(per-input quotes)`
holds by construction, which is exactly what the server's
`validateOperatorFee` will compare against.

Outpoint-keyed (rather than index-parallel) so the wallet handler
looks up each input's fee directly without depending on the
slice-ordering invariant matching between the daemon and the wallet.
Degraded-mode policy mirrors `Board` and `SendVTXO`: on quote RPC
failure or operator-terms fetch failure, the helper falls back to
`terms.MinOperatorFee` per outpoint and logs at `WarnS`, so a partially
unreachable operator doesn't leave the refresh stuck at zero implicit
fee.

## Auto-refresh (VTXO actor → round actor, near batch expiry)

The auto-refresh path bypasses the wallet entirely. When a VTXO hits
`ExpiryStatusNeedsRefresh`, the FSM emits a `ForfeitRequest` on the
outbox, and the VTXO actor's outbox processor translates it to a
`round.RefreshVTXORequest` that goes through the manager to the round
actor. To make that translation fee-aware we add a
`RefreshFeeQuoter` hook on `VTXOActorConfig` and a matching field on
`ManagerConfig` that propagates into every spawned VTXO actor.

The daemon wires `autoRefreshFeeQuoter()`, a closure that wraps
`s.quoteOperatorFee` with an `s.fetchOperatorTerms` lookup for the
`MinOperatorFee` fallback. At auto-refresh time the actor reads the
VTXO's amount and computes remaining blocks as
`vtxo.BatchExpiry - state.LastCheckedHeight` (the last block epoch the
actor observed in `LiveState`), passes both to the quoter, and puts
the result on `round.RefreshVTXORequest.OperatorFee`. On the round
side, `buildVTXORequestFromRefresh` subtracts `req.OperatorFee` from
the new VTXO's `Amount` with a defensive clamp to zero so a buggy fee
never underflows the new output.

When the quoter is nil (tests, or operators running a zero schedule)
the auto-refresh emits `OperatorFee=0`, preserving pre-#269 behavior.

## Why `remainingBlocks` matters

Both paths pass the real remaining-blocks value to the quote, not
zero. The server's liquidity fee scales with how much of the VTXO's
lifetime is left (via `ComputeForfeitFee`). If the client quotes with
`remainingBlocks=0`, the server falls back to `SweepDelay` as the
default, which models a fresh full-cycle VTXO and over-quotes.
Over-quoting still validates (implicit fee >= expected) but it
over-charges the client on every refresh. Passing
`BatchExpiry - currentHeight` matches the server's own
`ExpiryHeight - currentHeight` computation at validation time, so the
quote and the validation see the same inputs.

## Test plan

- `TestProcessOutboxForfeitRequestQuotesFee` (vtxo) asserts the
  auto-refresh path threads the VTXO amount and
  `BatchExpiry - LastCheckedHeight` into the quoter and populates
  `OperatorFee` on the relayed request.
- `TestProcessOutboxForfeitRequest` (vtxo, existing) keeps covering
  the pre-#269 path: with no quoter configured, `OperatorFee` is 0
  and the forfeit input's `Amount` is unchanged.
- `TestRefreshDeductsPerInputOperatorFee` (wallet) drives a
  two-outpoint manual refresh with distinct per-input fees and
  asserts the aggregate implicit fee `sum(forfeits) - sum(new_vtxos)`
  equals the sum of per-input quotes.
- Full suite: `go test ./vtxo/... ./round/... ./wallet/... ./darepod/...`
  and `make lint-native` are both clean.

## Cross-reference

Client half of [lightninglabs/darepo#269](https://github.com/lightninglabs/darepo/issues/269).
The server half lands as part of a bundle on lightninglabs/darepo
covering #267 (chain-backed fee estimator),
#268 (at-cost batch sizing), and #269 (forfeit-path validation).
Once this PR merges, the server PR bumps the submodule pointer.