### PR TITLE
unroll: build sweep as v3 (TRUC) + register UNRL subsystem logger

### DIFF
--- a/darepod/logging.go
+++ b/darepod/logging.go
@@ -38,6 +38,7 @@ var allSubsystems = []string{
 	indexer.Subsystem,
 	db.Subsystem,
 	"TXCF",
+	"UNRL",
 }
 
 // SetupLoggersWithShutdownFn registers all subsystem loggers using a plain

--- a/unroll/sweep.go
+++ b/unroll/sweep.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lightninglabs/darepo-client/chainsource"
 	"github.com/lightninglabs/darepo-client/lib/arkscript"
 	"github.com/lightninglabs/darepo-client/lib/recovery"
+	"github.com/lightninglabs/darepo-client/lib/tx/arktx"
 	"github.com/lightninglabs/darepo-client/vtxo"
 )
 
@@ -87,7 +88,9 @@ func estimateSweepFeeRate(ctx context.Context,
 //
 // Structure of the produced transaction:
 //
-//   - Version 2 (required for CSV-relative timelocks).
+//   - Version 3 (TRUC). CSV-relative timelocks work for any version >=2;
+//     v3 is required because the shared txconfirm CPFP broadcaster gates
+//     parent tx submission on BIP-431 (TRUC) semantics.
 //   - One input spending proof.TargetOutpoint with Sequence set to the
 //     descriptor's RelativeExpiry. That sequence value is what arms the
 //     CSV check on chain; spending earlier is consensus-invalid, so the
@@ -154,11 +157,14 @@ func buildSweepTx(ctx context.Context, wallet SweepWallet,
 		return nil, fmt.Errorf("wallet returned empty pkscript")
 	}
 
-	// Version 2 is required for CSV-relative timelocks. Sequence =
-	// desc.RelativeExpiry is what tells consensus "this input is only
-	// valid at least RelativeExpiry blocks after the target
-	// confirmed" — the same CSV the planner is tracking off-chain.
-	sweepTx := wire.NewMsgTx(2)
+	// Version 3 (TRUC) — CSV works for any v>=2, but the shared
+	// txconfirm CPFP broadcaster rejects non-v3 parents because the
+	// anchor-detection heuristic and package-relay strategy assume
+	// BIP-431 semantics. Sequence = desc.RelativeExpiry is what tells
+	// consensus "this input is only valid at least RelativeExpiry
+	// blocks after the target confirmed" — the same CSV the planner
+	// is tracking off-chain.
+	sweepTx := wire.NewMsgTx(arktx.TxVersion)
 	sweepTx.AddTxIn(&wire.TxIn{
 		PreviousOutPoint: proof.TargetOutpoint(),
 		Sequence:         desc.RelativeExpiry,


### PR DESCRIPTION
In this PR, we fix two issues that surface the moment a server running the new `validateOperatorFee` broadening path drives any unilateral-exit flow: the unroll sweep gets rejected by the shared TRUC gate in `txconfirm`, and the debug trail that would have caught it is dropped on the floor because the unroll subsystem logger was never registered with darepod.

Both fixes are one-liners in isolation, but they're tightly coupled w.r.t. debuggability, hence the bundle.

## `unroll: build sweep tx as v3 (TRUC) for CPFP broadcaster`

`client/unroll/sweep.go` built the timeout-path sweep as `wire.NewMsgTx(2)`. After `0c0f211` ("txconfirm: gate Submit on v3 (TRUC) parents") landed, the shared CPFP broadcaster rejects any non-v3 parent:

```
broadcast: parent transaction must be v3 (TRUC) for CPFP broadcast: got version 2, want 3
```

CSV-relative timelocks work for any version >=2, so the fix is purely TRUC-compatibility: switch to `arktx.TxVersion`. Reusing the canonical constant means the unroll sweep and the rest of the Ark transaction graph stay in lockstep if we ever need to bump the version again.

The failure mode is uncomfortably subtle. The unroll FSM still transitions `AwaitingSweepBroadcast -> AwaitingSweepConfirmation` because that transition is driven by the `Ask` reply from `txconfirm.EnsureConfirmedReq`, not by the async notification. The subsequent `TxFailed` that `txconfirm` fires gets dropped on a `mailbox full` error because by then the unroll actor's mailbox is saturated with `HeightObservedMsg` deliveries from the chainsource block subscription. So the FSM never learns the sweep failed, the job never evicts, and `GetUnrollStatus` sits at `UNROLL_JOB_STATUS_UNSPECIFIED` forever.

## `darepod: register UNRL subsystem logger`

`initUnrollSubsystem` already calls `s.subLogger("UNRL")` and threads the result into every `UnrollRegistryActor` and `VTXOUnrollActor` config. But `"UNRL"` was never added to `allSubsystems` in `darepod/logging.go`, so `subLogger` returned `btclog.Disabled` and every unroll log line was silently dropped.

This matches how `"TXCF"` is registered for the sibling `txconfirm` package. Both use bare string tags (no exported `Subsystem` const) because they started as subsystem-neutral helpers that got named at wiring time.

Without this, the FSM's `AwaitingSweepBroadcast -> Failed` transition (and every other state event in unroll) is invisible. That's exactly how the TRUC sweep rejection above slipped past the original unroll series: the server-side saw the sweep fail, but nothing surfaced on the client.

## Validation

Verified against the three unilateral-exit integration tests on darepo:

```
--- PASS: TestUnilateralExitManualStartSingleParentTree (66.75s)
--- PASS: TestUnilateralExitRoundBornCompletion (64.91s)
--- PASS: TestUnilateralExitOORDerivedCompletion (85.89s)
```

All three run sweep broadcast -> confirmation -> completion end-to-end.

## Test plan

- [x] Unit tests pass (`go test ./unroll/... ./darepod/...`)
- [x] All three `TestUnilateralExit*` itests on darepo pass end-to-end
- [x] `make build` + `make lint-native` clean
