### PR TITLE
daemonrpc+darepod+darepocli: wire cooperative leave end-to-end for #294

### DIFF
--- a/cmd/darepocli/darepoclicommands/cmd_mcp.go
+++ b/cmd/darepocli/darepoclicommands/cmd_mcp.go
@@ -264,6 +264,44 @@ func registerMCPTools(s *mcp.Server,
 		return r, nil, err
 	})
 
+	// vtxos_leave — cooperative leave (offboard).
+	type vtxosLeaveArgs struct {
+		Outpoints    []string          `json:"outpoints,omitempty" jsonschema:"VTXO outpoint(s) to leave (txid:index)"`                                     //nolint:ll
+		All          bool              `json:"all,omitempty" jsonschema:"leave all live VTXOs"`                                                             //nolint:ll
+		Address      string            `json:"address,omitempty" jsonschema:"default on-chain destination address"`                                         //nolint:ll
+		PkScript     string            `json:"pk_script,omitempty" jsonschema:"default destination pk_script as hex; alternative to address"`               //nolint:ll
+		Destinations map[string]string `json:"destinations,omitempty" jsonschema:"per-outpoint override map; values are either an address or script:<hex>"` //nolint:ll
+		DryRun       bool              `json:"dry_run,omitempty" jsonschema:"validate without queuing"`                                                     //nolint:ll
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "vtxos_leave",
+		Description: "Queue VTXOs for cooperative leave (offboard)",
+	}, func(ctx context.Context,
+		req *mcp.CallToolRequest,
+		args vtxosLeaveArgs) (*mcp.CallToolResult, any, error) {
+
+		// Reuse the CLI's builder so CLI and MCP can't drift on
+		// destination parsing — a divergence would let the two
+		// surfaces offboard to subtly different scripts.
+		rpcReq, err := buildLeaveVTXOsRequest(
+			args.Outpoints, args.All,
+			args.Address, args.PkScript,
+			args.Destinations, args.DryRun,
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		resp, err := client.LeaveVTXOs(ctx, rpcReq)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		r, err := mcpResult(resp)
+
+		return r, nil, err
+	})
+
 	// Register send tools in a separate function to keep each
 	// registration function under the line limit.
 	registerMCPSendTools(s, client)

--- a/cmd/darepocli/darepoclicommands/cmd_vtxos.go
+++ b/cmd/darepocli/darepoclicommands/cmd_vtxos.go
@@ -1,7 +1,9 @@
 package darepoclicommands
 
 import (
+	"bufio"
 	"context"
+	"encoding/hex"
 	"fmt"
 	"strings"
 
@@ -23,6 +25,7 @@ func newVTXOsCmd() *cobra.Command {
 	cmd.AddCommand(
 		newVTXOsListCmd(),
 		newVTXOsRefreshCmd(),
+		newVTXOsLeaveCmd(),
 	)
 
 	return cmd
@@ -231,4 +234,280 @@ func vtxosRefresh(cmd *cobra.Command, _ []string) error {
 	}
 
 	return printJSON(resp)
+}
+
+// newVTXOsLeaveCmd creates the vtxos leave subcommand.
+func newVTXOsLeaveCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "leave",
+		Short: "Queue VTXOs for cooperative leave (offboard)",
+		Long: "Queues one or more VTXOs for cooperative " +
+			"leave in the next round. Each forfeited " +
+			"VTXO pays out (amount - operator_fee) to " +
+			"the specified on-chain destination.",
+		RunE: vtxosLeave,
+	}
+
+	cmd.Flags().StringSlice("outpoint", nil,
+		"VTXO outpoint(s) to leave (txid:index)")
+
+	cmd.Flags().Bool("all", false,
+		"leave all live VTXOs")
+
+	cmd.Flags().String("address", "",
+		"default on-chain destination address")
+
+	cmd.Flags().String("pk_script", "",
+		"default destination pk_script (hex); "+
+			"alternative to --address")
+
+	cmd.Flags().StringToString("destination", nil,
+		"per-outpoint destination override: "+
+			"outpoint=addr or outpoint=script:<hex>")
+
+	cmd.Flags().Bool("dry_run", false,
+		"validate without queuing")
+
+	cmd.Flags().Bool("yes", false,
+		"skip interactive confirmation for --all")
+
+	return cmd
+}
+
+// vtxosLeave executes the LeaveVTXOs RPC. Flag handling lives in
+// buildLeaveVTXOsRequest so the same builder can be reused by the
+// MCP tool and covered with a focused unit test.
+func vtxosLeave(cmd *cobra.Command, _ []string) error {
+	client, conn, err := getDaemonClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	req := &daemonrpc.LeaveVTXOsRequest{}
+	if err := parseRequest(cmd, req, func() error {
+		outpoints, _ := cmd.Flags().GetStringSlice("outpoint")
+		all, _ := cmd.Flags().GetBool("all")
+		addr, _ := cmd.Flags().GetString("address")
+		pkScriptHex, _ := cmd.Flags().GetString("pk_script")
+		destPairs, _ := cmd.Flags().GetStringToString(
+			"destination",
+		)
+		dryRun, _ := cmd.Flags().GetBool("dry_run")
+
+		built, err := buildLeaveVTXOsRequest(
+			outpoints, all, addr, pkScriptHex,
+			destPairs, dryRun,
+		)
+		if err != nil {
+			return err
+		}
+
+		// Proto pointer-receiver shims: copy built fields onto
+		// the outer req that parseRequest owns.
+		req.Selection = built.Selection
+		req.DefaultDestination = built.DefaultDestination
+		req.Destinations = built.Destinations
+		req.DryRun = built.DryRun
+
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	if err := confirmLeaveAllIfNeeded(cmd, req); err != nil {
+		return err
+	}
+
+	resp, err := client.LeaveVTXOs(
+		context.Background(), req,
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"LeaveVTXOs RPC failed: %w", err)
+	}
+
+	return printJSON(resp)
+}
+
+// buildLeaveVTXOsRequest translates the flag surface into a
+// LeaveVTXOsRequest. Extracted so the MCP tool and the CLI share
+// the same destination-parsing logic — divergence here would let
+// the two surfaces offboard to subtly different scripts.
+func buildLeaveVTXOsRequest(outpoints []string, all bool,
+	addr, pkScriptHex string,
+	destPairs map[string]string,
+	dryRun bool) (*daemonrpc.LeaveVTXOsRequest, error) {
+
+	if !all && len(outpoints) == 0 {
+		return nil, fmt.Errorf(
+			"either --outpoint or --all is required")
+	}
+
+	if all && len(outpoints) > 0 {
+		return nil, fmt.Errorf(
+			"--outpoint and --all are mutually exclusive")
+	}
+
+	req := &daemonrpc.LeaveVTXOsRequest{DryRun: dryRun}
+
+	if all {
+		req.Selection = &daemonrpc.LeaveVTXOsRequest_All{
+			All: true,
+		}
+	} else {
+		req.Selection = &daemonrpc.LeaveVTXOsRequest_Outpoints{
+			Outpoints: &daemonrpc.OutpointSelection{
+				Outpoints: outpoints,
+			},
+		}
+	}
+
+	// Default destination: at most one of --address / --pk_script.
+	switch {
+	case addr != "" && pkScriptHex != "":
+		return nil, fmt.Errorf(
+			"--address and --pk_script are mutually " +
+				"exclusive")
+
+	case addr != "":
+		req.DefaultDestination = &daemonrpc.LeaveDestination{
+			Target: &daemonrpc.LeaveDestination_Address{
+				Address: addr,
+			},
+		}
+
+	case pkScriptHex != "":
+		raw, err := hex.DecodeString(pkScriptHex)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"invalid --pk_script hex: %w", err)
+		}
+
+		req.DefaultDestination = &daemonrpc.LeaveDestination{
+			Target: &daemonrpc.LeaveDestination_PkScript{
+				PkScript: raw,
+			},
+		}
+	}
+
+	// Per-outpoint overrides: key=outpoint, value=addr or
+	// "script:<hex>". Overrides are only meaningful under
+	// selection=outpoints; --all rejects the combination at the
+	// daemon, but the CLI catches it earlier for a cleaner error.
+	if len(destPairs) > 0 && all {
+		return nil, fmt.Errorf(
+			"--destination overrides are not supported " +
+				"with --all")
+	}
+
+	if len(destPairs) > 0 {
+		req.Destinations = make(
+			map[string]*daemonrpc.LeaveDestination,
+			len(destPairs),
+		)
+		for op, raw := range destPairs {
+			dest, err := parseDestinationValue(raw)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"--destination[%s]: %w", op, err)
+			}
+			req.Destinations[op] = dest
+		}
+	}
+
+	// A missing default without full per-outpoint coverage is
+	// rejected server-side; we let the daemon be the source of
+	// truth there rather than re-checking here (the daemon also
+	// validates outpoint strings, which we don't parse on the CLI
+	// side to avoid the btcd import weight).
+	if req.DefaultDestination == nil && len(req.Destinations) == 0 {
+		return nil, fmt.Errorf(
+			"either --address / --pk_script (default " +
+				"destination) or --destination (per-" +
+				"outpoint overrides) is required")
+	}
+
+	return req, nil
+}
+
+// parseDestinationValue parses a --destination value: either a raw
+// address or a "script:<hex>" form carrying a pre-resolved pk_script.
+func parseDestinationValue(raw string) (
+	*daemonrpc.LeaveDestination, error) {
+
+	if raw == "" {
+		return nil, fmt.Errorf("empty destination value")
+	}
+
+	const scriptPrefix = "script:"
+	if strings.HasPrefix(raw, scriptPrefix) {
+		scriptHex := strings.TrimPrefix(raw, scriptPrefix)
+		bs, err := hex.DecodeString(scriptHex)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"invalid script hex: %w", err)
+		}
+
+		return &daemonrpc.LeaveDestination{
+			Target: &daemonrpc.LeaveDestination_PkScript{
+				PkScript: bs,
+			},
+		}, nil
+	}
+
+	return &daemonrpc.LeaveDestination{
+		Target: &daemonrpc.LeaveDestination_Address{
+			Address: raw,
+		},
+	}, nil
+}
+
+// confirmLeaveAllIfNeeded gates dispatch on an interactive y/N prompt
+// when the resolved request selects all VTXOs. The check runs after
+// parseRequest returns so it covers both the flag-driven path and the
+// --json path; previously the prompt lived inside the flag callback
+// and an agent piping `{"all":true,...}` would silently skip the gate
+// that the bespoke-flag path enforced. Skip when --yes is set
+// (scripted use) or when req.DryRun is set (just previewing, not
+// moving funds).
+func confirmLeaveAllIfNeeded(cmd *cobra.Command,
+	req *daemonrpc.LeaveVTXOsRequest) error {
+
+	_, isAll := req.Selection.(*daemonrpc.LeaveVTXOsRequest_All)
+	if !isAll {
+		return nil
+	}
+
+	confirmYes, _ := cmd.Flags().GetBool("yes")
+	if confirmYes || req.DryRun {
+		return nil
+	}
+
+	return promptLeaveAllConfirmation(cmd)
+}
+
+// promptLeaveAllConfirmation asks the operator to confirm a
+// --all invocation on stdin. Any answer other than "y" or "yes"
+// (case-insensitive) aborts the command.
+func promptLeaveAllConfirmation(cmd *cobra.Command) error {
+	out := cmd.OutOrStdout()
+
+	fmt.Fprintln(out,
+		"About to queue ALL live VTXOs for cooperative "+
+			"leave. This moves funds on-chain.")
+	fmt.Fprint(out, "Proceed? [y/N]: ")
+
+	reader := bufio.NewReader(cmd.InOrStdin())
+	answer, err := reader.ReadString('\n')
+	if err != nil {
+		return fmt.Errorf("read confirmation: %w", err)
+	}
+
+	answer = strings.TrimSpace(strings.ToLower(answer))
+	if answer != "y" && answer != "yes" {
+		return fmt.Errorf("aborted by user")
+	}
+
+	return nil
 }

--- a/cmd/darepocli/darepoclicommands/cmd_vtxos_leave_test.go
+++ b/cmd/darepocli/darepoclicommands/cmd_vtxos_leave_test.go
@@ -1,0 +1,371 @@
+package darepoclicommands
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+// newLeaveTestCmd returns a vtxos leave cobra command with the same
+// flag surface as the real one, plumbed with the supplied stdin so
+// the prompt path is testable. Output buffers are returned so tests
+// can assert the prompt wording was emitted.
+func newLeaveTestCmd(t *testing.T,
+	stdin string) (*cobra.Command, *bytes.Buffer) {
+
+	t.Helper()
+
+	cmd := newVTXOsLeaveCmd()
+	cmd.SetIn(strings.NewReader(stdin))
+
+	out := &bytes.Buffer{}
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+
+	return cmd, out
+}
+
+// TestBuildLeaveVTXOsRequestExplicitOutpoints covers the common
+// case: a caller picks specific outpoints and gives a single
+// default destination address. The resulting request must carry
+// the outpoint selection and the address-typed default, nothing
+// else.
+func TestBuildLeaveVTXOsRequestExplicitOutpoints(t *testing.T) {
+	t.Parallel()
+
+	req, err := buildLeaveVTXOsRequest(
+		[]string{"abcd:0", "abcd:1"},
+		false, /* all */
+		"bcrt1pexample",
+		"",   /* pk_script */
+		nil,  /* destinations */
+		true, /* dry_run */
+	)
+	require.NoError(t, err)
+	require.NotNil(t, req)
+	require.True(t, req.DryRun)
+
+	sel, ok := req.Selection.(*daemonrpc.LeaveVTXOsRequest_Outpoints)
+	require.True(t, ok, "expected outpoint selection")
+	require.Equal(t,
+		[]string{"abcd:0", "abcd:1"},
+		sel.Outpoints.Outpoints,
+	)
+
+	def := req.DefaultDestination
+	require.NotNil(t, def)
+	addr, ok := def.Target.(*daemonrpc.LeaveDestination_Address)
+	require.True(t, ok, "default destination must be address-typed")
+	require.Equal(t, "bcrt1pexample", addr.Address)
+
+	require.Empty(t, req.Destinations)
+}
+
+// TestBuildLeaveVTXOsRequestAll verifies the --all path produces
+// an LeaveVTXOsRequest_All selection and keeps the per-outpoint
+// overrides map empty.
+func TestBuildLeaveVTXOsRequestAll(t *testing.T) {
+	t.Parallel()
+
+	req, err := buildLeaveVTXOsRequest(
+		nil, /* outpoints */
+		true,
+		"bcrt1pexample",
+		"", nil, false,
+	)
+	require.NoError(t, err)
+
+	sel, ok := req.Selection.(*daemonrpc.LeaveVTXOsRequest_All)
+	require.True(t, ok, "expected All selection")
+	require.True(t, sel.All)
+
+	require.Empty(t, req.Destinations)
+}
+
+// TestBuildLeaveVTXOsRequestPkScriptDefault verifies the
+// --pk_script alternative to --address: the default destination is
+// built from raw hex-decoded bytes.
+func TestBuildLeaveVTXOsRequestPkScriptDefault(t *testing.T) {
+	t.Parallel()
+
+	req, err := buildLeaveVTXOsRequest(
+		[]string{"abcd:0"},
+		false,
+		"",           /* address */
+		"5120aabbcc", /* pk_script hex */
+		nil, false,
+	)
+	require.NoError(t, err)
+
+	def := req.DefaultDestination
+	require.NotNil(t, def)
+	ps, ok := def.Target.(*daemonrpc.LeaveDestination_PkScript)
+	require.True(t, ok)
+	require.Equal(t,
+		[]byte{0x51, 0x20, 0xaa, 0xbb, 0xcc},
+		ps.PkScript,
+	)
+}
+
+// TestBuildLeaveVTXOsRequestRejectsBothAddressAndPkScript locks in
+// the mutually-exclusive check on --address vs --pk_script for the
+// default destination.
+func TestBuildLeaveVTXOsRequestRejectsBothAddressAndPkScript(t *testing.T) {
+	t.Parallel()
+
+	_, err := buildLeaveVTXOsRequest(
+		[]string{"abcd:0"}, false,
+		"bcrt1pexample", "5120aa",
+		nil, false,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "mutually exclusive")
+}
+
+// TestBuildLeaveVTXOsRequestRejectsNoDestination verifies that a
+// caller with neither a default nor per-outpoint overrides gets a
+// clean CLI-side error rather than hitting the daemon with an
+// empty request.
+func TestBuildLeaveVTXOsRequestRejectsNoDestination(t *testing.T) {
+	t.Parallel()
+
+	_, err := buildLeaveVTXOsRequest(
+		[]string{"abcd:0"}, false,
+		"", "", nil, false,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "default destination")
+}
+
+// TestBuildLeaveVTXOsRequestPerOutpointOverrides covers the batch
+// case: distinct destinations per outpoint via --destination. The
+// "script:<hex>" form resolves to a pk_script-typed destination,
+// a plain value resolves to an address-typed one.
+func TestBuildLeaveVTXOsRequestPerOutpointOverrides(t *testing.T) {
+	t.Parallel()
+
+	req, err := buildLeaveVTXOsRequest(
+		[]string{"aa:0", "bb:1"}, false,
+		"bcrt1pdefault",
+		"",
+		map[string]string{
+			"aa:0": "bcrt1pfirst",
+			"bb:1": "script:5120ff",
+		},
+		false,
+	)
+	require.NoError(t, err)
+	require.Len(t, req.Destinations, 2)
+
+	first := req.Destinations["aa:0"]
+	require.NotNil(t, first)
+	_, ok := first.Target.(*daemonrpc.LeaveDestination_Address)
+	require.True(t, ok, "plain value must map to address")
+
+	second := req.Destinations["bb:1"]
+	require.NotNil(t, second)
+	ps, ok := second.Target.(*daemonrpc.LeaveDestination_PkScript)
+	require.True(t, ok, "script: prefix must map to pk_script")
+	require.Equal(t, []byte{0x51, 0x20, 0xff}, ps.PkScript)
+}
+
+// TestBuildLeaveVTXOsRequestRejectsOverridesWithAll verifies that
+// --destination + --all fail fast at the CLI layer, matching the
+// daemon's rejection but saving a round trip.
+func TestBuildLeaveVTXOsRequestRejectsOverridesWithAll(t *testing.T) {
+	t.Parallel()
+
+	_, err := buildLeaveVTXOsRequest(
+		nil, true,
+		"bcrt1pdefault", "",
+		map[string]string{"aa:0": "bcrt1pfirst"},
+		false,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "--all")
+}
+
+// TestBuildLeaveVTXOsRequestRejectsOutpointAndAll verifies that a
+// caller can't combine --outpoint and --all on the CLI.
+func TestBuildLeaveVTXOsRequestRejectsOutpointAndAll(t *testing.T) {
+	t.Parallel()
+
+	_, err := buildLeaveVTXOsRequest(
+		[]string{"aa:0"}, true,
+		"bcrt1pdefault", "",
+		nil, false,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "mutually exclusive")
+}
+
+// TestBuildLeaveVTXOsRequestRejectsInvalidPkScriptHex locks in the
+// error path for a typo in --pk_script.
+func TestBuildLeaveVTXOsRequestRejectsInvalidPkScriptHex(t *testing.T) {
+	t.Parallel()
+
+	_, err := buildLeaveVTXOsRequest(
+		[]string{"aa:0"}, false,
+		"", "not-hex",
+		nil, false,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid --pk_script hex")
+}
+
+// TestParseDestinationValueAddress verifies that a plain string is
+// treated as an address.
+func TestParseDestinationValueAddress(t *testing.T) {
+	t.Parallel()
+
+	dest, err := parseDestinationValue("bcrt1pexample")
+	require.NoError(t, err)
+
+	addr, ok := dest.Target.(*daemonrpc.LeaveDestination_Address)
+	require.True(t, ok)
+	require.Equal(t, "bcrt1pexample", addr.Address)
+}
+
+// TestParseDestinationValueScriptPrefix verifies the "script:<hex>"
+// form maps to the pk_script branch.
+func TestParseDestinationValueScriptPrefix(t *testing.T) {
+	t.Parallel()
+
+	dest, err := parseDestinationValue("script:5120aabbcc")
+	require.NoError(t, err)
+
+	ps, ok := dest.Target.(*daemonrpc.LeaveDestination_PkScript)
+	require.True(t, ok)
+	require.Equal(t,
+		[]byte{0x51, 0x20, 0xaa, 0xbb, 0xcc},
+		ps.PkScript,
+	)
+}
+
+// TestParseDestinationValueInvalidScriptHex locks in the error
+// path for a malformed "script:<hex>" value.
+func TestParseDestinationValueInvalidScriptHex(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseDestinationValue("script:not-hex")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid script hex")
+}
+
+// TestParseDestinationValueEmpty verifies that an empty value is
+// rejected rather than silently treated as an address.
+func TestParseDestinationValueEmpty(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseDestinationValue("")
+	require.Error(t, err)
+}
+
+// TestConfirmLeaveAllIfNeededJSONStillPrompts is the C-1 regression
+// guard: a request whose `selection.all` was set via the --json input
+// path (i.e. without ever entering the flag callback) must still hit
+// the y/N prompt. Before the fix the prompt lived inside the flag
+// callback and the JSON path silently bypassed it.
+func TestConfirmLeaveAllIfNeededJSONStillPrompts(t *testing.T) {
+	t.Parallel()
+
+	cmd, _ := newLeaveTestCmd(t, "n\n")
+
+	req := &daemonrpc.LeaveVTXOsRequest{
+		Selection: &daemonrpc.LeaveVTXOsRequest_All{All: true},
+		DefaultDestination: &daemonrpc.LeaveDestination{
+			Target: &daemonrpc.LeaveDestination_Address{
+				Address: "bcrt1pexample",
+			},
+		},
+	}
+
+	err := confirmLeaveAllIfNeeded(cmd, req)
+	require.Error(t, err, "selection=all without --yes/--dry_run "+
+		"must abort when stdin says 'n'")
+	require.Contains(t, err.Error(), "aborted by user")
+}
+
+// TestConfirmLeaveAllIfNeededAcceptsYes verifies the prompt accepts
+// "y" and proceeds.
+func TestConfirmLeaveAllIfNeededAcceptsYes(t *testing.T) {
+	t.Parallel()
+
+	cmd, _ := newLeaveTestCmd(t, "y\n")
+
+	req := &daemonrpc.LeaveVTXOsRequest{
+		Selection: &daemonrpc.LeaveVTXOsRequest_All{All: true},
+	}
+
+	require.NoError(t, confirmLeaveAllIfNeeded(cmd, req))
+}
+
+// TestConfirmLeaveAllIfNeededYesFlagBypasses verifies the --yes flag
+// short-circuits the prompt for scripted use.
+func TestConfirmLeaveAllIfNeededYesFlagBypasses(t *testing.T) {
+	t.Parallel()
+
+	cmd, _ := newLeaveTestCmd(t, "" /* no stdin */)
+	require.NoError(t, cmd.Flags().Set("yes", "true"))
+
+	req := &daemonrpc.LeaveVTXOsRequest{
+		Selection: &daemonrpc.LeaveVTXOsRequest_All{All: true},
+	}
+
+	require.NoError(t, confirmLeaveAllIfNeeded(cmd, req))
+}
+
+// TestConfirmLeaveAllIfNeededDryRunBypasses verifies that a dry-run
+// preview is not gated on the prompt — the user is just previewing,
+// not moving funds.
+func TestConfirmLeaveAllIfNeededDryRunBypasses(t *testing.T) {
+	t.Parallel()
+
+	cmd, _ := newLeaveTestCmd(t, "" /* no stdin */)
+
+	req := &daemonrpc.LeaveVTXOsRequest{
+		Selection: &daemonrpc.LeaveVTXOsRequest_All{All: true},
+		DryRun:    true,
+	}
+
+	require.NoError(t, confirmLeaveAllIfNeeded(cmd, req))
+}
+
+// TestConfirmLeaveAllIfNeededOutpointSelectionSkipsPrompt verifies
+// that selection=outpoints is unaffected — only --all triggers the
+// gate.
+func TestConfirmLeaveAllIfNeededOutpointSelectionSkipsPrompt(t *testing.T) {
+	t.Parallel()
+
+	cmd, _ := newLeaveTestCmd(t, "" /* no stdin */)
+
+	req := &daemonrpc.LeaveVTXOsRequest{
+		Selection: &daemonrpc.LeaveVTXOsRequest_Outpoints{
+			Outpoints: &daemonrpc.OutpointSelection{
+				Outpoints: []string{"aa:0"},
+			},
+		},
+	}
+
+	require.NoError(t, confirmLeaveAllIfNeeded(cmd, req))
+}
+
+// TestConfirmLeaveAllIfNeededRejectsBlankInput verifies that simply
+// pressing enter at the prompt aborts (default-N posture).
+func TestConfirmLeaveAllIfNeededRejectsBlankInput(t *testing.T) {
+	t.Parallel()
+
+	cmd, _ := newLeaveTestCmd(t, "\n")
+
+	req := &daemonrpc.LeaveVTXOsRequest{
+		Selection: &daemonrpc.LeaveVTXOsRequest_All{All: true},
+	}
+
+	err := confirmLeaveAllIfNeeded(cmd, req)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "aborted by user")
+}

--- a/cmd/darepocli/darepoclicommands/schema_registry.go
+++ b/cmd/darepocli/darepoclicommands/schema_registry.go
@@ -46,8 +46,21 @@ type schemaMethod struct {
 
 // methodRegistry returns the full schema for all darepocli commands.
 // This is the single source of truth for both the schema command and
-// MCP tool definitions.
+// MCP tool definitions. The body is split across helper functions to
+// stay under the funlen linter cap.
 func methodRegistry() []schemaMethod {
+	out := baseMethodRegistry()
+	out = append(out, vtxoLifecycleMethodRegistry()...)
+	out = append(out, sendMethodRegistry()...)
+
+	return out
+}
+
+// baseMethodRegistry returns the schema entries for the base
+// daemon-level commands (info / wallet / boarding / list-* / fees /
+// unroll). Split out of methodRegistry to keep the function under the
+// funlen cap.
+func baseMethodRegistry() []schemaMethod {
 	return []schemaMethod{
 		{
 			Method:       "getinfo",
@@ -124,6 +137,14 @@ func methodRegistry() []schemaMethod {
 			ResponseType: "NewOORReceiveScriptResponse",
 			JSONInput:    true,
 		},
+	}
+}
+
+// vtxoLifecycleMethodRegistry returns the VTXO lifecycle commands
+// (list / refresh / leave). Split out of methodRegistry so the parent
+// stays under the funlen cap as new entries land.
+func vtxoLifecycleMethodRegistry() []schemaMethod {
+	return []schemaMethod{
 		{
 			Method:      "vtxos.list",
 			Description: "List VTXOs with optional filters",
@@ -185,6 +206,61 @@ func methodRegistry() []schemaMethod {
 			DryRun:       true,
 			JSONInput:    true,
 		},
+		{
+			Method: "vtxos.leave",
+			Description: "Queue VTXOs for cooperative leave " +
+				"(offboard)",
+			Params: []schemaParam{
+				{
+					Name: "outpoint",
+					Type: "string[]",
+					Description: "VTXO outpoint(s) to " +
+						"leave (txid:index)",
+				},
+				{
+					Name:        "all",
+					Type:        "bool",
+					Description: "leave all live VTXOs",
+				},
+				{
+					Name: "address",
+					Type: "string",
+					Description: "default on-chain " +
+						"destination address",
+				},
+				{
+					Name: "pk_script",
+					Type: "string",
+					Description: "default destination " +
+						"pk_script (hex)",
+				},
+				{
+					Name: "destination",
+					Type: "map[string]string",
+					Description: "per-outpoint override: " +
+						"outpoint=addr or " +
+						"outpoint=script:<hex>",
+				},
+				{
+					Name: "yes",
+					Type: "bool",
+					Description: "skip --all " +
+						"interactive confirmation",
+				},
+			},
+			RequestType:  "LeaveVTXOsRequest",
+			ResponseType: "LeaveVTXOsResponse",
+			DryRun:       true,
+			JSONInput:    true,
+		},
+	}
+}
+
+// sendMethodRegistry returns the send.* schema entries (in-round and
+// OOR). Split out of methodRegistry so the parent stays under the
+// funlen cap as new entries land.
+func sendMethodRegistry() []schemaMethod {
+	return []schemaMethod{
 		{
 			Method:      "send.inround",
 			Description: "Send via in-round refresh",

--- a/daemonrpc/daemon.pb.go
+++ b/daemonrpc/daemon.pb.go
@@ -2414,6 +2414,279 @@ func (x *RefreshVTXOsResponse) GetStatus() string {
 	return ""
 }
 
+// LeaveDestination describes where a single leave output should land.
+// Unlike Output (used for VTXO sends), leave destinations are on-chain
+// and carry no VTXO-shape constraints: any standard address or
+// recognised raw pkScript is acceptable.
+type LeaveDestination struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Target:
+	//
+	//	*LeaveDestination_Address
+	//	*LeaveDestination_PkScript
+	Target        isLeaveDestination_Target `protobuf_oneof:"target"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *LeaveDestination) Reset() {
+	*x = LeaveDestination{}
+	mi := &file_daemon_proto_msgTypes[31]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LeaveDestination) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LeaveDestination) ProtoMessage() {}
+
+func (x *LeaveDestination) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[31]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LeaveDestination.ProtoReflect.Descriptor instead.
+func (*LeaveDestination) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{31}
+}
+
+func (x *LeaveDestination) GetTarget() isLeaveDestination_Target {
+	if x != nil {
+		return x.Target
+	}
+	return nil
+}
+
+func (x *LeaveDestination) GetAddress() string {
+	if x != nil {
+		if x, ok := x.Target.(*LeaveDestination_Address); ok {
+			return x.Address
+		}
+	}
+	return ""
+}
+
+func (x *LeaveDestination) GetPkScript() []byte {
+	if x != nil {
+		if x, ok := x.Target.(*LeaveDestination_PkScript); ok {
+			return x.PkScript
+		}
+	}
+	return nil
+}
+
+type isLeaveDestination_Target interface {
+	isLeaveDestination_Target()
+}
+
+type LeaveDestination_Address struct {
+	// address is the bech32m/base58 on-chain recipient. The daemon
+	// decodes it via btcutil.DecodeAddress using its configured
+	// chain params, so cross-network addresses are rejected.
+	Address string `protobuf:"bytes,1,opt,name=address,proto3,oneof"`
+}
+
+type LeaveDestination_PkScript struct {
+	// pk_script is the raw output script to pay. Useful when the
+	// caller has already resolved the script (custom policies,
+	// OP_RETURN exits, etc.) and does not want address re-encoding.
+	// The daemon caps the script at txscript.MaxScriptSize, rejects
+	// the BIP 431 P2A anchor pattern, and whitelists standard
+	// classes (P2PKH, P2SH, P2WPKH, P2WSH, P2TR, P2PK, multisig,
+	// OP_RETURN). Network binding is the caller's responsibility on
+	// this branch — pkScripts are network-agnostic, so the daemon
+	// does not (and cannot) re-bind them to its chain params.
+	PkScript []byte `protobuf:"bytes,2,opt,name=pk_script,json=pkScript,proto3,oneof"`
+}
+
+func (*LeaveDestination_Address) isLeaveDestination_Target() {}
+
+func (*LeaveDestination_PkScript) isLeaveDestination_Target() {}
+
+type LeaveVTXOsRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Selection:
+	//
+	//	*LeaveVTXOsRequest_Outpoints
+	//	*LeaveVTXOsRequest_All
+	Selection isLeaveVTXOsRequest_Selection `protobuf_oneof:"selection"`
+	// default_destination applies to every selected outpoint that is
+	// not overridden in destinations. Required whenever selection=all,
+	// or whenever any selected outpoint is not present in the
+	// destinations map.
+	DefaultDestination *LeaveDestination `protobuf:"bytes,3,opt,name=default_destination,json=defaultDestination,proto3" json:"default_destination,omitempty"`
+	// destinations overrides the default destination on a per-outpoint
+	// basis. The key is the outpoint in "txid:index" format. Only
+	// honored when selection=outpoints; the RPC rejects non-empty
+	// overrides combined with selection=all.
+	Destinations map[string]*LeaveDestination `protobuf:"bytes,4,rep,name=destinations,proto3" json:"destinations,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// dry_run validates the request without queuing the leave.
+	DryRun        bool `protobuf:"varint,5,opt,name=dry_run,json=dryRun,proto3" json:"dry_run,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *LeaveVTXOsRequest) Reset() {
+	*x = LeaveVTXOsRequest{}
+	mi := &file_daemon_proto_msgTypes[32]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LeaveVTXOsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LeaveVTXOsRequest) ProtoMessage() {}
+
+func (x *LeaveVTXOsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[32]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LeaveVTXOsRequest.ProtoReflect.Descriptor instead.
+func (*LeaveVTXOsRequest) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{32}
+}
+
+func (x *LeaveVTXOsRequest) GetSelection() isLeaveVTXOsRequest_Selection {
+	if x != nil {
+		return x.Selection
+	}
+	return nil
+}
+
+func (x *LeaveVTXOsRequest) GetOutpoints() *OutpointSelection {
+	if x != nil {
+		if x, ok := x.Selection.(*LeaveVTXOsRequest_Outpoints); ok {
+			return x.Outpoints
+		}
+	}
+	return nil
+}
+
+func (x *LeaveVTXOsRequest) GetAll() bool {
+	if x != nil {
+		if x, ok := x.Selection.(*LeaveVTXOsRequest_All); ok {
+			return x.All
+		}
+	}
+	return false
+}
+
+func (x *LeaveVTXOsRequest) GetDefaultDestination() *LeaveDestination {
+	if x != nil {
+		return x.DefaultDestination
+	}
+	return nil
+}
+
+func (x *LeaveVTXOsRequest) GetDestinations() map[string]*LeaveDestination {
+	if x != nil {
+		return x.Destinations
+	}
+	return nil
+}
+
+func (x *LeaveVTXOsRequest) GetDryRun() bool {
+	if x != nil {
+		return x.DryRun
+	}
+	return false
+}
+
+type isLeaveVTXOsRequest_Selection interface {
+	isLeaveVTXOsRequest_Selection()
+}
+
+type LeaveVTXOsRequest_Outpoints struct {
+	// outpoints lists specific VTXOs to leave, in "txid:index"
+	// format.
+	Outpoints *OutpointSelection `protobuf:"bytes,1,opt,name=outpoints,proto3,oneof"`
+}
+
+type LeaveVTXOsRequest_All struct {
+	// all leaves every live VTXO when true. Per-outpoint overrides
+	// are rejected under this selection because the daemon does
+	// not know the outpoint set ahead of time.
+	All bool `protobuf:"varint,2,opt,name=all,proto3,oneof"`
+}
+
+func (*LeaveVTXOsRequest_Outpoints) isLeaveVTXOsRequest_Selection() {}
+
+func (*LeaveVTXOsRequest_All) isLeaveVTXOsRequest_Selection() {}
+
+type LeaveVTXOsResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// queued_outpoints lists the outpoints that were successfully
+	// queued for leave.
+	QueuedOutpoints []string `protobuf:"bytes,1,rep,name=queued_outpoints,json=queuedOutpoints,proto3" json:"queued_outpoints,omitempty"`
+	// status is the result: "queued" on success, "preview" on dry_run.
+	Status        string `protobuf:"bytes,2,opt,name=status,proto3" json:"status,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *LeaveVTXOsResponse) Reset() {
+	*x = LeaveVTXOsResponse{}
+	mi := &file_daemon_proto_msgTypes[33]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LeaveVTXOsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LeaveVTXOsResponse) ProtoMessage() {}
+
+func (x *LeaveVTXOsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[33]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LeaveVTXOsResponse.ProtoReflect.Descriptor instead.
+func (*LeaveVTXOsResponse) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{33}
+}
+
+func (x *LeaveVTXOsResponse) GetQueuedOutpoints() []string {
+	if x != nil {
+		return x.QueuedOutpoints
+	}
+	return nil
+}
+
+func (x *LeaveVTXOsResponse) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
 type BoardRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -2422,7 +2695,7 @@ type BoardRequest struct {
 
 func (x *BoardRequest) Reset() {
 	*x = BoardRequest{}
-	mi := &file_daemon_proto_msgTypes[31]
+	mi := &file_daemon_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2434,7 +2707,7 @@ func (x *BoardRequest) String() string {
 func (*BoardRequest) ProtoMessage() {}
 
 func (x *BoardRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[31]
+	mi := &file_daemon_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2447,7 +2720,7 @@ func (x *BoardRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoardRequest.ProtoReflect.Descriptor instead.
 func (*BoardRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{31}
+	return file_daemon_proto_rawDescGZIP(), []int{34}
 }
 
 type BoardResponse struct {
@@ -2461,7 +2734,7 @@ type BoardResponse struct {
 
 func (x *BoardResponse) Reset() {
 	*x = BoardResponse{}
-	mi := &file_daemon_proto_msgTypes[32]
+	mi := &file_daemon_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2473,7 +2746,7 @@ func (x *BoardResponse) String() string {
 func (*BoardResponse) ProtoMessage() {}
 
 func (x *BoardResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[32]
+	mi := &file_daemon_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2486,7 +2759,7 @@ func (x *BoardResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoardResponse.ProtoReflect.Descriptor instead.
 func (*BoardResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{32}
+	return file_daemon_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *BoardResponse) GetStatus() string {
@@ -2509,7 +2782,7 @@ type RoundVTXOInfo struct {
 
 func (x *RoundVTXOInfo) Reset() {
 	*x = RoundVTXOInfo{}
-	mi := &file_daemon_proto_msgTypes[33]
+	mi := &file_daemon_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2521,7 +2794,7 @@ func (x *RoundVTXOInfo) String() string {
 func (*RoundVTXOInfo) ProtoMessage() {}
 
 func (x *RoundVTXOInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[33]
+	mi := &file_daemon_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2534,7 +2807,7 @@ func (x *RoundVTXOInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoundVTXOInfo.ProtoReflect.Descriptor instead.
 func (*RoundVTXOInfo) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{33}
+	return file_daemon_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *RoundVTXOInfo) GetOutpoint() string {
@@ -2573,7 +2846,7 @@ type RoundInfo struct {
 
 func (x *RoundInfo) Reset() {
 	*x = RoundInfo{}
-	mi := &file_daemon_proto_msgTypes[34]
+	mi := &file_daemon_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2585,7 +2858,7 @@ func (x *RoundInfo) String() string {
 func (*RoundInfo) ProtoMessage() {}
 
 func (x *RoundInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[34]
+	mi := &file_daemon_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2598,7 +2871,7 @@ func (x *RoundInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoundInfo.ProtoReflect.Descriptor instead.
 func (*RoundInfo) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{34}
+	return file_daemon_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *RoundInfo) GetRoundId() string {
@@ -2650,7 +2923,7 @@ type ListRoundsRequest struct {
 
 func (x *ListRoundsRequest) Reset() {
 	*x = ListRoundsRequest{}
-	mi := &file_daemon_proto_msgTypes[35]
+	mi := &file_daemon_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2662,7 +2935,7 @@ func (x *ListRoundsRequest) String() string {
 func (*ListRoundsRequest) ProtoMessage() {}
 
 func (x *ListRoundsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[35]
+	mi := &file_daemon_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2675,7 +2948,7 @@ func (x *ListRoundsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRoundsRequest.ProtoReflect.Descriptor instead.
 func (*ListRoundsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{35}
+	return file_daemon_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *ListRoundsRequest) GetPageSize() int32 {
@@ -2712,7 +2985,7 @@ type ListRoundsResponse struct {
 
 func (x *ListRoundsResponse) Reset() {
 	*x = ListRoundsResponse{}
-	mi := &file_daemon_proto_msgTypes[36]
+	mi := &file_daemon_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2724,7 +2997,7 @@ func (x *ListRoundsResponse) String() string {
 func (*ListRoundsResponse) ProtoMessage() {}
 
 func (x *ListRoundsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[36]
+	mi := &file_daemon_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2737,7 +3010,7 @@ func (x *ListRoundsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRoundsResponse.ProtoReflect.Descriptor instead.
 func (*ListRoundsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{36}
+	return file_daemon_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *ListRoundsResponse) GetRounds() []*RoundInfo {
@@ -2762,7 +3035,7 @@ type WatchRoundsRequest struct {
 
 func (x *WatchRoundsRequest) Reset() {
 	*x = WatchRoundsRequest{}
-	mi := &file_daemon_proto_msgTypes[37]
+	mi := &file_daemon_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2774,7 +3047,7 @@ func (x *WatchRoundsRequest) String() string {
 func (*WatchRoundsRequest) ProtoMessage() {}
 
 func (x *WatchRoundsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[37]
+	mi := &file_daemon_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2787,7 +3060,7 @@ func (x *WatchRoundsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchRoundsRequest.ProtoReflect.Descriptor instead.
 func (*WatchRoundsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{37}
+	return file_daemon_proto_rawDescGZIP(), []int{40}
 }
 
 type WatchRoundsResponse struct {
@@ -2801,7 +3074,7 @@ type WatchRoundsResponse struct {
 
 func (x *WatchRoundsResponse) Reset() {
 	*x = WatchRoundsResponse{}
-	mi := &file_daemon_proto_msgTypes[38]
+	mi := &file_daemon_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2813,7 +3086,7 @@ func (x *WatchRoundsResponse) String() string {
 func (*WatchRoundsResponse) ProtoMessage() {}
 
 func (x *WatchRoundsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[38]
+	mi := &file_daemon_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2826,7 +3099,7 @@ func (x *WatchRoundsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchRoundsResponse.ProtoReflect.Descriptor instead.
 func (*WatchRoundsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{38}
+	return file_daemon_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *WatchRoundsResponse) GetRound() *RoundInfo {
@@ -2854,7 +3127,7 @@ type EstimateFeeRequest struct {
 
 func (x *EstimateFeeRequest) Reset() {
 	*x = EstimateFeeRequest{}
-	mi := &file_daemon_proto_msgTypes[39]
+	mi := &file_daemon_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2866,7 +3139,7 @@ func (x *EstimateFeeRequest) String() string {
 func (*EstimateFeeRequest) ProtoMessage() {}
 
 func (x *EstimateFeeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[39]
+	mi := &file_daemon_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2879,7 +3152,7 @@ func (x *EstimateFeeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EstimateFeeRequest.ProtoReflect.Descriptor instead.
 func (*EstimateFeeRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{39}
+	return file_daemon_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *EstimateFeeRequest) GetAmountSat() int64 {
@@ -2933,7 +3206,7 @@ type EstimateFeeResponse struct {
 
 func (x *EstimateFeeResponse) Reset() {
 	*x = EstimateFeeResponse{}
-	mi := &file_daemon_proto_msgTypes[40]
+	mi := &file_daemon_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2945,7 +3218,7 @@ func (x *EstimateFeeResponse) String() string {
 func (*EstimateFeeResponse) ProtoMessage() {}
 
 func (x *EstimateFeeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[40]
+	mi := &file_daemon_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2958,7 +3231,7 @@ func (x *EstimateFeeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EstimateFeeResponse.ProtoReflect.Descriptor instead.
 func (*EstimateFeeResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{40}
+	return file_daemon_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *EstimateFeeResponse) GetLiquidityFeeSat() int64 {
@@ -3028,7 +3301,7 @@ type GetFeeHistoryRequest struct {
 
 func (x *GetFeeHistoryRequest) Reset() {
 	*x = GetFeeHistoryRequest{}
-	mi := &file_daemon_proto_msgTypes[41]
+	mi := &file_daemon_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3040,7 +3313,7 @@ func (x *GetFeeHistoryRequest) String() string {
 func (*GetFeeHistoryRequest) ProtoMessage() {}
 
 func (x *GetFeeHistoryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[41]
+	mi := &file_daemon_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3053,7 +3326,7 @@ func (x *GetFeeHistoryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetFeeHistoryRequest.ProtoReflect.Descriptor instead.
 func (*GetFeeHistoryRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{41}
+	return file_daemon_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *GetFeeHistoryRequest) GetLimit() uint32 {
@@ -3128,7 +3401,7 @@ type FeeHistoryEntry struct {
 
 func (x *FeeHistoryEntry) Reset() {
 	*x = FeeHistoryEntry{}
-	mi := &file_daemon_proto_msgTypes[42]
+	mi := &file_daemon_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3140,7 +3413,7 @@ func (x *FeeHistoryEntry) String() string {
 func (*FeeHistoryEntry) ProtoMessage() {}
 
 func (x *FeeHistoryEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[42]
+	mi := &file_daemon_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3153,7 +3426,7 @@ func (x *FeeHistoryEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FeeHistoryEntry.ProtoReflect.Descriptor instead.
 func (*FeeHistoryEntry) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{42}
+	return file_daemon_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *FeeHistoryEntry) GetEntryId() int64 {
@@ -3233,7 +3506,7 @@ type GetFeeHistoryResponse struct {
 
 func (x *GetFeeHistoryResponse) Reset() {
 	*x = GetFeeHistoryResponse{}
-	mi := &file_daemon_proto_msgTypes[43]
+	mi := &file_daemon_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3245,7 +3518,7 @@ func (x *GetFeeHistoryResponse) String() string {
 func (*GetFeeHistoryResponse) ProtoMessage() {}
 
 func (x *GetFeeHistoryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[43]
+	mi := &file_daemon_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3258,7 +3531,7 @@ func (x *GetFeeHistoryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetFeeHistoryResponse.ProtoReflect.Descriptor instead.
 func (*GetFeeHistoryResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{43}
+	return file_daemon_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *GetFeeHistoryResponse) GetEntries() []*FeeHistoryEntry {
@@ -3286,7 +3559,7 @@ type UnrollRequest struct {
 
 func (x *UnrollRequest) Reset() {
 	*x = UnrollRequest{}
-	mi := &file_daemon_proto_msgTypes[44]
+	mi := &file_daemon_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3298,7 +3571,7 @@ func (x *UnrollRequest) String() string {
 func (*UnrollRequest) ProtoMessage() {}
 
 func (x *UnrollRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[44]
+	mi := &file_daemon_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3311,7 +3584,7 @@ func (x *UnrollRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnrollRequest.ProtoReflect.Descriptor instead.
 func (*UnrollRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{44}
+	return file_daemon_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *UnrollRequest) GetOutpoint() string {
@@ -3334,7 +3607,7 @@ type UnrollResponse struct {
 
 func (x *UnrollResponse) Reset() {
 	*x = UnrollResponse{}
-	mi := &file_daemon_proto_msgTypes[45]
+	mi := &file_daemon_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3346,7 +3619,7 @@ func (x *UnrollResponse) String() string {
 func (*UnrollResponse) ProtoMessage() {}
 
 func (x *UnrollResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[45]
+	mi := &file_daemon_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3359,7 +3632,7 @@ func (x *UnrollResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnrollResponse.ProtoReflect.Descriptor instead.
 func (*UnrollResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{45}
+	return file_daemon_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *UnrollResponse) GetCreated() bool {
@@ -3386,7 +3659,7 @@ type GetUnrollStatusRequest struct {
 
 func (x *GetUnrollStatusRequest) Reset() {
 	*x = GetUnrollStatusRequest{}
-	mi := &file_daemon_proto_msgTypes[46]
+	mi := &file_daemon_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3398,7 +3671,7 @@ func (x *GetUnrollStatusRequest) String() string {
 func (*GetUnrollStatusRequest) ProtoMessage() {}
 
 func (x *GetUnrollStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[46]
+	mi := &file_daemon_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3411,7 +3684,7 @@ func (x *GetUnrollStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUnrollStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetUnrollStatusRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{46}
+	return file_daemon_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *GetUnrollStatusRequest) GetOutpoint() string {
@@ -3439,7 +3712,7 @@ type GetUnrollStatusResponse struct {
 
 func (x *GetUnrollStatusResponse) Reset() {
 	*x = GetUnrollStatusResponse{}
-	mi := &file_daemon_proto_msgTypes[47]
+	mi := &file_daemon_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3451,7 +3724,7 @@ func (x *GetUnrollStatusResponse) String() string {
 func (*GetUnrollStatusResponse) ProtoMessage() {}
 
 func (x *GetUnrollStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[47]
+	mi := &file_daemon_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3464,7 +3737,7 @@ func (x *GetUnrollStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUnrollStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetUnrollStatusResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{47}
+	return file_daemon_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *GetUnrollStatusResponse) GetFound() bool {
@@ -3643,6 +3916,23 @@ const file_daemon_proto_rawDesc = "" +
 	"\tselection\"Y\n" +
 	"\x14RefreshVTXOsResponse\x12)\n" +
 	"\x10queued_outpoints\x18\x01 \x03(\tR\x0fqueuedOutpoints\x12\x16\n" +
+	"\x06status\x18\x02 \x01(\tR\x06status\"W\n" +
+	"\x10LeaveDestination\x12\x1a\n" +
+	"\aaddress\x18\x01 \x01(\tH\x00R\aaddress\x12\x1d\n" +
+	"\tpk_script\x18\x02 \x01(\fH\x00R\bpkScriptB\b\n" +
+	"\x06target\"\x8b\x03\n" +
+	"\x11LeaveVTXOsRequest\x12<\n" +
+	"\toutpoints\x18\x01 \x01(\v2\x1c.daemonrpc.OutpointSelectionH\x00R\toutpoints\x12\x12\n" +
+	"\x03all\x18\x02 \x01(\bH\x00R\x03all\x12L\n" +
+	"\x13default_destination\x18\x03 \x01(\v2\x1b.daemonrpc.LeaveDestinationR\x12defaultDestination\x12R\n" +
+	"\fdestinations\x18\x04 \x03(\v2..daemonrpc.LeaveVTXOsRequest.DestinationsEntryR\fdestinations\x12\x17\n" +
+	"\adry_run\x18\x05 \x01(\bR\x06dryRun\x1a\\\n" +
+	"\x11DestinationsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x121\n" +
+	"\x05value\x18\x02 \x01(\v2\x1b.daemonrpc.LeaveDestinationR\x05value:\x028\x01B\v\n" +
+	"\tselection\"W\n" +
+	"\x12LeaveVTXOsResponse\x12)\n" +
+	"\x10queued_outpoints\x18\x01 \x03(\tR\x0fqueuedOutpoints\x12\x16\n" +
 	"\x06status\x18\x02 \x01(\tR\x06status\"\x0e\n" +
 	"\fBoardRequest\"'\n" +
 	"\rBoardResponse\x12\x16\n" +
@@ -3752,7 +4042,7 @@ const file_daemon_proto_rawDesc = "" +
 	"\x1dUNROLL_JOB_STATUS_CSV_PENDING\x10\x03\x12\x1e\n" +
 	"\x1aUNROLL_JOB_STATUS_SWEEPING\x10\x04\x12\x1f\n" +
 	"\x1bUNROLL_JOB_STATUS_COMPLETED\x10\x05\x12\x1c\n" +
-	"\x18UNROLL_JOB_STATUS_FAILED\x10\x062\xcd\f\n" +
+	"\x18UNROLL_JOB_STATUS_FAILED\x10\x062\x98\r\n" +
 	"\rDaemonService\x12@\n" +
 	"\aGetInfo\x12\x19.daemonrpc.GetInfoRequest\x1a\x1a.daemonrpc.GetInfoResponse\x12@\n" +
 	"\aGenSeed\x12\x19.daemonrpc.GenSeedRequest\x1a\x1a.daemonrpc.GenSeedResponse\x12I\n" +
@@ -3769,7 +4059,9 @@ const file_daemon_proto_rawDesc = "" +
 	"\x1aGetIndexedOORSessionByTxid\x12,.daemonrpc.GetIndexedOORSessionByTxidRequest\x1a-.daemonrpc.GetIndexedOORSessionByTxidResponse\x12C\n" +
 	"\bSendVTXO\x12\x1a.daemonrpc.SendVTXORequest\x1a\x1b.daemonrpc.SendVTXOResponse\x12@\n" +
 	"\aSendOOR\x12\x19.daemonrpc.SendOORRequest\x1a\x1a.daemonrpc.SendOORResponse\x12O\n" +
-	"\fRefreshVTXOs\x12\x1e.daemonrpc.RefreshVTXOsRequest\x1a\x1f.daemonrpc.RefreshVTXOsResponse\x12:\n" +
+	"\fRefreshVTXOs\x12\x1e.daemonrpc.RefreshVTXOsRequest\x1a\x1f.daemonrpc.RefreshVTXOsResponse\x12I\n" +
+	"\n" +
+	"LeaveVTXOs\x12\x1c.daemonrpc.LeaveVTXOsRequest\x1a\x1d.daemonrpc.LeaveVTXOsResponse\x12:\n" +
 	"\x05Board\x12\x17.daemonrpc.BoardRequest\x1a\x18.daemonrpc.BoardResponse\x12I\n" +
 	"\n" +
 	"ListRounds\x12\x1c.daemonrpc.ListRoundsRequest\x1a\x1d.daemonrpc.ListRoundsResponse\x12N\n" +
@@ -3792,7 +4084,7 @@ func file_daemon_proto_rawDescGZIP() []byte {
 }
 
 var file_daemon_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 48)
+var file_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 52)
 var file_daemon_proto_goTypes = []any{
 	(VTXOStatus)(0),                            // 0: daemonrpc.VTXOStatus
 	(RoundState)(0),                            // 1: daemonrpc.RoundState
@@ -3828,23 +4120,27 @@ var file_daemon_proto_goTypes = []any{
 	(*OutpointSelection)(nil),                  // 31: daemonrpc.OutpointSelection
 	(*RefreshVTXOsRequest)(nil),                // 32: daemonrpc.RefreshVTXOsRequest
 	(*RefreshVTXOsResponse)(nil),               // 33: daemonrpc.RefreshVTXOsResponse
-	(*BoardRequest)(nil),                       // 34: daemonrpc.BoardRequest
-	(*BoardResponse)(nil),                      // 35: daemonrpc.BoardResponse
-	(*RoundVTXOInfo)(nil),                      // 36: daemonrpc.RoundVTXOInfo
-	(*RoundInfo)(nil),                          // 37: daemonrpc.RoundInfo
-	(*ListRoundsRequest)(nil),                  // 38: daemonrpc.ListRoundsRequest
-	(*ListRoundsResponse)(nil),                 // 39: daemonrpc.ListRoundsResponse
-	(*WatchRoundsRequest)(nil),                 // 40: daemonrpc.WatchRoundsRequest
-	(*WatchRoundsResponse)(nil),                // 41: daemonrpc.WatchRoundsResponse
-	(*EstimateFeeRequest)(nil),                 // 42: daemonrpc.EstimateFeeRequest
-	(*EstimateFeeResponse)(nil),                // 43: daemonrpc.EstimateFeeResponse
-	(*GetFeeHistoryRequest)(nil),               // 44: daemonrpc.GetFeeHistoryRequest
-	(*FeeHistoryEntry)(nil),                    // 45: daemonrpc.FeeHistoryEntry
-	(*GetFeeHistoryResponse)(nil),              // 46: daemonrpc.GetFeeHistoryResponse
-	(*UnrollRequest)(nil),                      // 47: daemonrpc.UnrollRequest
-	(*UnrollResponse)(nil),                     // 48: daemonrpc.UnrollResponse
-	(*GetUnrollStatusRequest)(nil),             // 49: daemonrpc.GetUnrollStatusRequest
-	(*GetUnrollStatusResponse)(nil),            // 50: daemonrpc.GetUnrollStatusResponse
+	(*LeaveDestination)(nil),                   // 34: daemonrpc.LeaveDestination
+	(*LeaveVTXOsRequest)(nil),                  // 35: daemonrpc.LeaveVTXOsRequest
+	(*LeaveVTXOsResponse)(nil),                 // 36: daemonrpc.LeaveVTXOsResponse
+	(*BoardRequest)(nil),                       // 37: daemonrpc.BoardRequest
+	(*BoardResponse)(nil),                      // 38: daemonrpc.BoardResponse
+	(*RoundVTXOInfo)(nil),                      // 39: daemonrpc.RoundVTXOInfo
+	(*RoundInfo)(nil),                          // 40: daemonrpc.RoundInfo
+	(*ListRoundsRequest)(nil),                  // 41: daemonrpc.ListRoundsRequest
+	(*ListRoundsResponse)(nil),                 // 42: daemonrpc.ListRoundsResponse
+	(*WatchRoundsRequest)(nil),                 // 43: daemonrpc.WatchRoundsRequest
+	(*WatchRoundsResponse)(nil),                // 44: daemonrpc.WatchRoundsResponse
+	(*EstimateFeeRequest)(nil),                 // 45: daemonrpc.EstimateFeeRequest
+	(*EstimateFeeResponse)(nil),                // 46: daemonrpc.EstimateFeeResponse
+	(*GetFeeHistoryRequest)(nil),               // 47: daemonrpc.GetFeeHistoryRequest
+	(*FeeHistoryEntry)(nil),                    // 48: daemonrpc.FeeHistoryEntry
+	(*GetFeeHistoryResponse)(nil),              // 49: daemonrpc.GetFeeHistoryResponse
+	(*UnrollRequest)(nil),                      // 50: daemonrpc.UnrollRequest
+	(*UnrollResponse)(nil),                     // 51: daemonrpc.UnrollResponse
+	(*GetUnrollStatusRequest)(nil),             // 52: daemonrpc.GetUnrollStatusRequest
+	(*GetUnrollStatusResponse)(nil),            // 53: daemonrpc.GetUnrollStatusResponse
+	nil,                                        // 54: daemonrpc.LeaveVTXOsRequest.DestinationsEntry
 }
 var file_daemon_proto_depIdxs = []int32{
 	5,  // 0: daemonrpc.GetInfoResponse.server_info:type_name -> daemonrpc.ServerInfo
@@ -3857,57 +4153,63 @@ var file_daemon_proto_depIdxs = []int32{
 	25, // 7: daemonrpc.SendOORRequest.recipient:type_name -> daemonrpc.Output
 	29, // 8: daemonrpc.SendOORRequest.custom_inputs:type_name -> daemonrpc.CustomOORInput
 	31, // 9: daemonrpc.RefreshVTXOsRequest.outpoints:type_name -> daemonrpc.OutpointSelection
-	1,  // 10: daemonrpc.RoundInfo.state:type_name -> daemonrpc.RoundState
-	36, // 11: daemonrpc.RoundInfo.vtxos:type_name -> daemonrpc.RoundVTXOInfo
-	37, // 12: daemonrpc.ListRoundsResponse.rounds:type_name -> daemonrpc.RoundInfo
-	37, // 13: daemonrpc.WatchRoundsResponse.round:type_name -> daemonrpc.RoundInfo
-	45, // 14: daemonrpc.GetFeeHistoryResponse.entries:type_name -> daemonrpc.FeeHistoryEntry
-	2,  // 15: daemonrpc.GetUnrollStatusResponse.status:type_name -> daemonrpc.UnrollJobStatus
-	3,  // 16: daemonrpc.DaemonService.GetInfo:input_type -> daemonrpc.GetInfoRequest
-	6,  // 17: daemonrpc.DaemonService.GenSeed:input_type -> daemonrpc.GenSeedRequest
-	8,  // 18: daemonrpc.DaemonService.InitWallet:input_type -> daemonrpc.InitWalletRequest
-	10, // 19: daemonrpc.DaemonService.UnlockWallet:input_type -> daemonrpc.UnlockWalletRequest
-	12, // 20: daemonrpc.DaemonService.GetBalance:input_type -> daemonrpc.GetBalanceRequest
-	15, // 21: daemonrpc.DaemonService.ListVTXOs:input_type -> daemonrpc.ListVTXOsRequest
-	17, // 22: daemonrpc.DaemonService.NewAddress:input_type -> daemonrpc.NewAddressRequest
-	19, // 23: daemonrpc.DaemonService.NewOORReceiveScript:input_type -> daemonrpc.NewOORReceiveScriptRequest
-	21, // 24: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:input_type -> daemonrpc.GetIndexedVTXOByPkScriptRequest
-	23, // 25: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:input_type -> daemonrpc.GetIndexedOORSessionByTxidRequest
-	26, // 26: daemonrpc.DaemonService.SendVTXO:input_type -> daemonrpc.SendVTXORequest
-	28, // 27: daemonrpc.DaemonService.SendOOR:input_type -> daemonrpc.SendOORRequest
-	32, // 28: daemonrpc.DaemonService.RefreshVTXOs:input_type -> daemonrpc.RefreshVTXOsRequest
-	34, // 29: daemonrpc.DaemonService.Board:input_type -> daemonrpc.BoardRequest
-	38, // 30: daemonrpc.DaemonService.ListRounds:input_type -> daemonrpc.ListRoundsRequest
-	40, // 31: daemonrpc.DaemonService.WatchRounds:input_type -> daemonrpc.WatchRoundsRequest
-	42, // 32: daemonrpc.DaemonService.EstimateFee:input_type -> daemonrpc.EstimateFeeRequest
-	44, // 33: daemonrpc.DaemonService.GetFeeHistory:input_type -> daemonrpc.GetFeeHistoryRequest
-	47, // 34: daemonrpc.DaemonService.Unroll:input_type -> daemonrpc.UnrollRequest
-	49, // 35: daemonrpc.DaemonService.GetUnrollStatus:input_type -> daemonrpc.GetUnrollStatusRequest
-	4,  // 36: daemonrpc.DaemonService.GetInfo:output_type -> daemonrpc.GetInfoResponse
-	7,  // 37: daemonrpc.DaemonService.GenSeed:output_type -> daemonrpc.GenSeedResponse
-	9,  // 38: daemonrpc.DaemonService.InitWallet:output_type -> daemonrpc.InitWalletResponse
-	11, // 39: daemonrpc.DaemonService.UnlockWallet:output_type -> daemonrpc.UnlockWalletResponse
-	13, // 40: daemonrpc.DaemonService.GetBalance:output_type -> daemonrpc.GetBalanceResponse
-	16, // 41: daemonrpc.DaemonService.ListVTXOs:output_type -> daemonrpc.ListVTXOsResponse
-	18, // 42: daemonrpc.DaemonService.NewAddress:output_type -> daemonrpc.NewAddressResponse
-	20, // 43: daemonrpc.DaemonService.NewOORReceiveScript:output_type -> daemonrpc.NewOORReceiveScriptResponse
-	22, // 44: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:output_type -> daemonrpc.GetIndexedVTXOByPkScriptResponse
-	24, // 45: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:output_type -> daemonrpc.GetIndexedOORSessionByTxidResponse
-	27, // 46: daemonrpc.DaemonService.SendVTXO:output_type -> daemonrpc.SendVTXOResponse
-	30, // 47: daemonrpc.DaemonService.SendOOR:output_type -> daemonrpc.SendOORResponse
-	33, // 48: daemonrpc.DaemonService.RefreshVTXOs:output_type -> daemonrpc.RefreshVTXOsResponse
-	35, // 49: daemonrpc.DaemonService.Board:output_type -> daemonrpc.BoardResponse
-	39, // 50: daemonrpc.DaemonService.ListRounds:output_type -> daemonrpc.ListRoundsResponse
-	41, // 51: daemonrpc.DaemonService.WatchRounds:output_type -> daemonrpc.WatchRoundsResponse
-	43, // 52: daemonrpc.DaemonService.EstimateFee:output_type -> daemonrpc.EstimateFeeResponse
-	46, // 53: daemonrpc.DaemonService.GetFeeHistory:output_type -> daemonrpc.GetFeeHistoryResponse
-	48, // 54: daemonrpc.DaemonService.Unroll:output_type -> daemonrpc.UnrollResponse
-	50, // 55: daemonrpc.DaemonService.GetUnrollStatus:output_type -> daemonrpc.GetUnrollStatusResponse
-	36, // [36:56] is the sub-list for method output_type
-	16, // [16:36] is the sub-list for method input_type
-	16, // [16:16] is the sub-list for extension type_name
-	16, // [16:16] is the sub-list for extension extendee
-	0,  // [0:16] is the sub-list for field type_name
+	31, // 10: daemonrpc.LeaveVTXOsRequest.outpoints:type_name -> daemonrpc.OutpointSelection
+	34, // 11: daemonrpc.LeaveVTXOsRequest.default_destination:type_name -> daemonrpc.LeaveDestination
+	54, // 12: daemonrpc.LeaveVTXOsRequest.destinations:type_name -> daemonrpc.LeaveVTXOsRequest.DestinationsEntry
+	1,  // 13: daemonrpc.RoundInfo.state:type_name -> daemonrpc.RoundState
+	39, // 14: daemonrpc.RoundInfo.vtxos:type_name -> daemonrpc.RoundVTXOInfo
+	40, // 15: daemonrpc.ListRoundsResponse.rounds:type_name -> daemonrpc.RoundInfo
+	40, // 16: daemonrpc.WatchRoundsResponse.round:type_name -> daemonrpc.RoundInfo
+	48, // 17: daemonrpc.GetFeeHistoryResponse.entries:type_name -> daemonrpc.FeeHistoryEntry
+	2,  // 18: daemonrpc.GetUnrollStatusResponse.status:type_name -> daemonrpc.UnrollJobStatus
+	34, // 19: daemonrpc.LeaveVTXOsRequest.DestinationsEntry.value:type_name -> daemonrpc.LeaveDestination
+	3,  // 20: daemonrpc.DaemonService.GetInfo:input_type -> daemonrpc.GetInfoRequest
+	6,  // 21: daemonrpc.DaemonService.GenSeed:input_type -> daemonrpc.GenSeedRequest
+	8,  // 22: daemonrpc.DaemonService.InitWallet:input_type -> daemonrpc.InitWalletRequest
+	10, // 23: daemonrpc.DaemonService.UnlockWallet:input_type -> daemonrpc.UnlockWalletRequest
+	12, // 24: daemonrpc.DaemonService.GetBalance:input_type -> daemonrpc.GetBalanceRequest
+	15, // 25: daemonrpc.DaemonService.ListVTXOs:input_type -> daemonrpc.ListVTXOsRequest
+	17, // 26: daemonrpc.DaemonService.NewAddress:input_type -> daemonrpc.NewAddressRequest
+	19, // 27: daemonrpc.DaemonService.NewOORReceiveScript:input_type -> daemonrpc.NewOORReceiveScriptRequest
+	21, // 28: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:input_type -> daemonrpc.GetIndexedVTXOByPkScriptRequest
+	23, // 29: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:input_type -> daemonrpc.GetIndexedOORSessionByTxidRequest
+	26, // 30: daemonrpc.DaemonService.SendVTXO:input_type -> daemonrpc.SendVTXORequest
+	28, // 31: daemonrpc.DaemonService.SendOOR:input_type -> daemonrpc.SendOORRequest
+	32, // 32: daemonrpc.DaemonService.RefreshVTXOs:input_type -> daemonrpc.RefreshVTXOsRequest
+	35, // 33: daemonrpc.DaemonService.LeaveVTXOs:input_type -> daemonrpc.LeaveVTXOsRequest
+	37, // 34: daemonrpc.DaemonService.Board:input_type -> daemonrpc.BoardRequest
+	41, // 35: daemonrpc.DaemonService.ListRounds:input_type -> daemonrpc.ListRoundsRequest
+	43, // 36: daemonrpc.DaemonService.WatchRounds:input_type -> daemonrpc.WatchRoundsRequest
+	45, // 37: daemonrpc.DaemonService.EstimateFee:input_type -> daemonrpc.EstimateFeeRequest
+	47, // 38: daemonrpc.DaemonService.GetFeeHistory:input_type -> daemonrpc.GetFeeHistoryRequest
+	50, // 39: daemonrpc.DaemonService.Unroll:input_type -> daemonrpc.UnrollRequest
+	52, // 40: daemonrpc.DaemonService.GetUnrollStatus:input_type -> daemonrpc.GetUnrollStatusRequest
+	4,  // 41: daemonrpc.DaemonService.GetInfo:output_type -> daemonrpc.GetInfoResponse
+	7,  // 42: daemonrpc.DaemonService.GenSeed:output_type -> daemonrpc.GenSeedResponse
+	9,  // 43: daemonrpc.DaemonService.InitWallet:output_type -> daemonrpc.InitWalletResponse
+	11, // 44: daemonrpc.DaemonService.UnlockWallet:output_type -> daemonrpc.UnlockWalletResponse
+	13, // 45: daemonrpc.DaemonService.GetBalance:output_type -> daemonrpc.GetBalanceResponse
+	16, // 46: daemonrpc.DaemonService.ListVTXOs:output_type -> daemonrpc.ListVTXOsResponse
+	18, // 47: daemonrpc.DaemonService.NewAddress:output_type -> daemonrpc.NewAddressResponse
+	20, // 48: daemonrpc.DaemonService.NewOORReceiveScript:output_type -> daemonrpc.NewOORReceiveScriptResponse
+	22, // 49: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:output_type -> daemonrpc.GetIndexedVTXOByPkScriptResponse
+	24, // 50: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:output_type -> daemonrpc.GetIndexedOORSessionByTxidResponse
+	27, // 51: daemonrpc.DaemonService.SendVTXO:output_type -> daemonrpc.SendVTXOResponse
+	30, // 52: daemonrpc.DaemonService.SendOOR:output_type -> daemonrpc.SendOORResponse
+	33, // 53: daemonrpc.DaemonService.RefreshVTXOs:output_type -> daemonrpc.RefreshVTXOsResponse
+	36, // 54: daemonrpc.DaemonService.LeaveVTXOs:output_type -> daemonrpc.LeaveVTXOsResponse
+	38, // 55: daemonrpc.DaemonService.Board:output_type -> daemonrpc.BoardResponse
+	42, // 56: daemonrpc.DaemonService.ListRounds:output_type -> daemonrpc.ListRoundsResponse
+	44, // 57: daemonrpc.DaemonService.WatchRounds:output_type -> daemonrpc.WatchRoundsResponse
+	46, // 58: daemonrpc.DaemonService.EstimateFee:output_type -> daemonrpc.EstimateFeeResponse
+	49, // 59: daemonrpc.DaemonService.GetFeeHistory:output_type -> daemonrpc.GetFeeHistoryResponse
+	51, // 60: daemonrpc.DaemonService.Unroll:output_type -> daemonrpc.UnrollResponse
+	53, // 61: daemonrpc.DaemonService.GetUnrollStatus:output_type -> daemonrpc.GetUnrollStatusResponse
+	41, // [41:62] is the sub-list for method output_type
+	20, // [20:41] is the sub-list for method input_type
+	20, // [20:20] is the sub-list for extension type_name
+	20, // [20:20] is the sub-list for extension extendee
+	0,  // [0:20] is the sub-list for field type_name
 }
 
 func init() { file_daemon_proto_init() }
@@ -3924,13 +4226,21 @@ func file_daemon_proto_init() {
 		(*RefreshVTXOsRequest_Outpoints)(nil),
 		(*RefreshVTXOsRequest_All)(nil),
 	}
+	file_daemon_proto_msgTypes[31].OneofWrappers = []any{
+		(*LeaveDestination_Address)(nil),
+		(*LeaveDestination_PkScript)(nil),
+	}
+	file_daemon_proto_msgTypes[32].OneofWrappers = []any{
+		(*LeaveVTXOsRequest_Outpoints)(nil),
+		(*LeaveVTXOsRequest_All)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_daemon_proto_rawDesc), len(file_daemon_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   48,
+			NumMessages:   52,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/daemonrpc/daemon.proto
+++ b/daemonrpc/daemon.proto
@@ -70,6 +70,12 @@ service DaemonService {
     // round. This extends their expiry without changing ownership.
     rpc RefreshVTXOs (RefreshVTXOsRequest) returns (RefreshVTXOsResponse);
 
+    // LeaveVTXOs queues one or more VTXOs for cooperative leave
+    // (offboard) in the next round. Each VTXO is forfeited and the
+    // forfeited amount (minus the quoted per-input operator fee)
+    // lands as an on-chain output at the specified destination.
+    rpc LeaveVTXOs (LeaveVTXOsRequest) returns (LeaveVTXOsResponse);
+
     // Board triggers the client to join the next round with any
     // confirmed boarding UTXOs. This sends IntentRequested to
     // the round FSM, which emits a JoinRoundRequest to the server.
@@ -572,6 +578,67 @@ message RefreshVTXOsRequest {
 message RefreshVTXOsResponse {
     // queued_outpoints lists the outpoints that were successfully queued
     // for refresh.
+    repeated string queued_outpoints = 1;
+
+    // status is the result: "queued" on success, "preview" on dry_run.
+    string status = 2;
+}
+
+// LeaveDestination describes where a single leave output should land.
+// Unlike Output (used for VTXO sends), leave destinations are on-chain
+// and carry no VTXO-shape constraints: any standard address or
+// recognised raw pkScript is acceptable.
+message LeaveDestination {
+    oneof target {
+        // address is the bech32m/base58 on-chain recipient. The daemon
+        // decodes it via btcutil.DecodeAddress using its configured
+        // chain params, so cross-network addresses are rejected.
+        string address = 1;
+
+        // pk_script is the raw output script to pay. Useful when the
+        // caller has already resolved the script (custom policies,
+        // OP_RETURN exits, etc.) and does not want address re-encoding.
+        // The daemon caps the script at txscript.MaxScriptSize, rejects
+        // the BIP 431 P2A anchor pattern, and whitelists standard
+        // classes (P2PKH, P2SH, P2WPKH, P2WSH, P2TR, P2PK, multisig,
+        // OP_RETURN). Network binding is the caller's responsibility on
+        // this branch — pkScripts are network-agnostic, so the daemon
+        // does not (and cannot) re-bind them to its chain params.
+        bytes pk_script = 2;
+    }
+}
+
+message LeaveVTXOsRequest {
+    oneof selection {
+        // outpoints lists specific VTXOs to leave, in "txid:index"
+        // format.
+        OutpointSelection outpoints = 1;
+
+        // all leaves every live VTXO when true. Per-outpoint overrides
+        // are rejected under this selection because the daemon does
+        // not know the outpoint set ahead of time.
+        bool all = 2;
+    }
+
+    // default_destination applies to every selected outpoint that is
+    // not overridden in destinations. Required whenever selection=all,
+    // or whenever any selected outpoint is not present in the
+    // destinations map.
+    LeaveDestination default_destination = 3;
+
+    // destinations overrides the default destination on a per-outpoint
+    // basis. The key is the outpoint in "txid:index" format. Only
+    // honored when selection=outpoints; the RPC rejects non-empty
+    // overrides combined with selection=all.
+    map<string, LeaveDestination> destinations = 4;
+
+    // dry_run validates the request without queuing the leave.
+    bool dry_run = 5;
+}
+
+message LeaveVTXOsResponse {
+    // queued_outpoints lists the outpoints that were successfully
+    // queued for leave.
     repeated string queued_outpoints = 1;
 
     // status is the result: "queued" on success, "preview" on dry_run.

--- a/daemonrpc/daemon_grpc.pb.go
+++ b/daemonrpc/daemon_grpc.pb.go
@@ -32,6 +32,7 @@ const (
 	DaemonService_SendVTXO_FullMethodName                   = "/daemonrpc.DaemonService/SendVTXO"
 	DaemonService_SendOOR_FullMethodName                    = "/daemonrpc.DaemonService/SendOOR"
 	DaemonService_RefreshVTXOs_FullMethodName               = "/daemonrpc.DaemonService/RefreshVTXOs"
+	DaemonService_LeaveVTXOs_FullMethodName                 = "/daemonrpc.DaemonService/LeaveVTXOs"
 	DaemonService_Board_FullMethodName                      = "/daemonrpc.DaemonService/Board"
 	DaemonService_ListRounds_FullMethodName                 = "/daemonrpc.DaemonService/ListRounds"
 	DaemonService_WatchRounds_FullMethodName                = "/daemonrpc.DaemonService/WatchRounds"
@@ -95,6 +96,11 @@ type DaemonServiceClient interface {
 	// RefreshVTXOs queues one or more VTXOs for refresh in the next
 	// round. This extends their expiry without changing ownership.
 	RefreshVTXOs(ctx context.Context, in *RefreshVTXOsRequest, opts ...grpc.CallOption) (*RefreshVTXOsResponse, error)
+	// LeaveVTXOs queues one or more VTXOs for cooperative leave
+	// (offboard) in the next round. Each VTXO is forfeited and the
+	// forfeited amount (minus the quoted per-input operator fee)
+	// lands as an on-chain output at the specified destination.
+	LeaveVTXOs(ctx context.Context, in *LeaveVTXOsRequest, opts ...grpc.CallOption) (*LeaveVTXOsResponse, error)
 	// Board triggers the client to join the next round with any
 	// confirmed boarding UTXOs. This sends IntentRequested to
 	// the round FSM, which emits a JoinRoundRequest to the server.
@@ -262,6 +268,16 @@ func (c *daemonServiceClient) RefreshVTXOs(ctx context.Context, in *RefreshVTXOs
 	return out, nil
 }
 
+func (c *daemonServiceClient) LeaveVTXOs(ctx context.Context, in *LeaveVTXOsRequest, opts ...grpc.CallOption) (*LeaveVTXOsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(LeaveVTXOsResponse)
+	err := c.cc.Invoke(ctx, DaemonService_LeaveVTXOs_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *daemonServiceClient) Board(ctx context.Context, in *BoardRequest, opts ...grpc.CallOption) (*BoardResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(BoardResponse)
@@ -395,6 +411,11 @@ type DaemonServiceServer interface {
 	// RefreshVTXOs queues one or more VTXOs for refresh in the next
 	// round. This extends their expiry without changing ownership.
 	RefreshVTXOs(context.Context, *RefreshVTXOsRequest) (*RefreshVTXOsResponse, error)
+	// LeaveVTXOs queues one or more VTXOs for cooperative leave
+	// (offboard) in the next round. Each VTXO is forfeited and the
+	// forfeited amount (minus the quoted per-input operator fee)
+	// lands as an on-chain output at the specified destination.
+	LeaveVTXOs(context.Context, *LeaveVTXOsRequest) (*LeaveVTXOsResponse, error)
 	// Board triggers the client to join the next round with any
 	// confirmed boarding UTXOs. This sends IntentRequested to
 	// the round FSM, which emits a JoinRoundRequest to the server.
@@ -470,6 +491,9 @@ func (UnimplementedDaemonServiceServer) SendOOR(context.Context, *SendOORRequest
 }
 func (UnimplementedDaemonServiceServer) RefreshVTXOs(context.Context, *RefreshVTXOsRequest) (*RefreshVTXOsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method RefreshVTXOs not implemented")
+}
+func (UnimplementedDaemonServiceServer) LeaveVTXOs(context.Context, *LeaveVTXOsRequest) (*LeaveVTXOsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method LeaveVTXOs not implemented")
 }
 func (UnimplementedDaemonServiceServer) Board(context.Context, *BoardRequest) (*BoardResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Board not implemented")
@@ -747,6 +771,24 @@ func _DaemonService_RefreshVTXOs_Handler(srv interface{}, ctx context.Context, d
 	return interceptor(ctx, in, info, handler)
 }
 
+func _DaemonService_LeaveVTXOs_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(LeaveVTXOsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DaemonServiceServer).LeaveVTXOs(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DaemonService_LeaveVTXOs_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DaemonServiceServer).LeaveVTXOs(ctx, req.(*LeaveVTXOsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _DaemonService_Board_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(BoardRequest)
 	if err := dec(in); err != nil {
@@ -924,6 +966,10 @@ var DaemonService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "RefreshVTXOs",
 			Handler:    _DaemonService_RefreshVTXOs_Handler,
+		},
+		{
+			MethodName: "LeaveVTXOs",
+			Handler:    _DaemonService_LeaveVTXOs_Handler,
 		},
 		{
 			MethodName: "Board",

--- a/daemonrpc/daemon_mailboxrpc.pb.go
+++ b/daemonrpc/daemon_mailboxrpc.pb.go
@@ -50,6 +50,8 @@ type DaemonServiceMailboxServer interface {
 	SendOOR(ctx context.Context, req *SendOORRequest) (*SendOORResponse, error)
 	// RefreshVTXOs handles RefreshVTXOs.
 	RefreshVTXOs(ctx context.Context, req *RefreshVTXOsRequest) (*RefreshVTXOsResponse, error)
+	// LeaveVTXOs handles LeaveVTXOs.
+	LeaveVTXOs(ctx context.Context, req *LeaveVTXOsRequest) (*LeaveVTXOsResponse, error)
 	// Board handles Board.
 	Board(ctx context.Context, req *BoardRequest) (*BoardResponse, error)
 	// ListRounds handles ListRounds.
@@ -197,6 +199,16 @@ func RegisterDaemonServiceMailboxServer(r rpc.Router, impl DaemonServiceMailboxS
 		}
 
 		return impl.RefreshVTXOs(ctx, req)
+	})
+	r.Handle("daemonrpc.DaemonService", "LeaveVTXOs", func() proto.Message {
+		return &LeaveVTXOsRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*LeaveVTXOsRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.LeaveVTXOs(ctx, req)
 	})
 	r.Handle("daemonrpc.DaemonService", "Board", func() proto.Message {
 		return &BoardRequest{}
@@ -562,6 +574,29 @@ func (c *DaemonServiceMailboxClient) RefreshVTXOs(ctx context.Context, req *Refr
 	}
 
 	resp := new(RefreshVTXOsResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// LeaveVTXOs calls the LeaveVTXOs RPC.
+func (c *DaemonServiceMailboxClient) LeaveVTXOs(ctx context.Context, req *LeaveVTXOsRequest, opts ...rpc.RPCOptions) (*LeaveVTXOsResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "daemonrpc.DaemonService",
+		Method:  "LeaveVTXOs",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(LeaveVTXOsResponse)
 	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
 		return nil, err
 	}

--- a/darepod/rpc_leave_test.go
+++ b/darepod/rpc_leave_test.go
@@ -1,0 +1,563 @@
+package darepod
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestResolveLeaveDestinationInvalidAddress verifies a malformed
+// address string surfaces a clean "invalid leave address" error
+// (the shape any caller would see on a typo) rather than a raw
+// bech32 decode message bubbling up to gRPC.
+func TestResolveLeaveDestinationInvalidAddress(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRPCServer()
+
+	_, err := r.resolveLeaveDestination(&daemonrpc.LeaveDestination{
+		Target: &daemonrpc.LeaveDestination_Address{
+			Address: "not-a-valid-address",
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid leave address")
+}
+
+// TestResolveLeaveDestinationValidTaproot verifies the happy path
+// on a real regtest taproot address. We construct the address
+// programmatically so the test stays valid across bech32m checksum
+// changes in the library.
+func TestResolveLeaveDestinationValidTaproot(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRPCServer()
+
+	// Build a regtest P2TR address from a deterministic 32-byte
+	// x-only key. The choice of key is irrelevant — we only want
+	// a structurally valid taproot address to feed DecodeAddress.
+	xOnly := make([]byte, 32)
+	xOnly[0] = 0xab
+	addr, err := btcutil.NewAddressTaproot(
+		xOnly, &chaincfg.RegressionNetParams,
+	)
+	require.NoError(t, err)
+
+	wantScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+
+	pkScript, err := r.resolveLeaveDestination(
+		&daemonrpc.LeaveDestination{
+			Target: &daemonrpc.LeaveDestination_Address{
+				Address: addr.String(),
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, wantScript, pkScript,
+		"resolveLeaveDestination matches btcutil's canonical "+
+			"PayToAddrScript output")
+}
+
+// TestResolveLeaveDestinationPkScript verifies that the pk_script
+// branch returns the bytes verbatim once the class-whitelist guard
+// has accepted them (a structurally-valid P2TR script in this case).
+func TestResolveLeaveDestinationPkScript(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRPCServer()
+
+	want := validP2TRPkScript(0xaa)
+	got, err := r.resolveLeaveDestination(&daemonrpc.LeaveDestination{
+		Target: &daemonrpc.LeaveDestination_PkScript{
+			PkScript: want,
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, want, got,
+		"pk_script is returned verbatim")
+}
+
+// TestResolveLeaveDestinationNil surfaces a clean error when the
+// caller passes a nil destination. Protects against a future
+// handler change that would nil-deref here instead of surfacing
+// an InvalidArgument to the caller.
+func TestResolveLeaveDestinationNil(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRPCServer()
+	_, err := r.resolveLeaveDestination(nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "destination is required")
+}
+
+// TestResolveLeaveDestinationEmptyAddress verifies that an empty
+// address string is rejected before DecodeAddress is called.
+func TestResolveLeaveDestinationEmptyAddress(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRPCServer()
+	_, err := r.resolveLeaveDestination(&daemonrpc.LeaveDestination{
+		Target: &daemonrpc.LeaveDestination_Address{},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "address is empty")
+}
+
+// TestResolveLeaveDestinationEmptyPkScript verifies that an empty
+// pk_script is rejected with a clear error rather than being
+// silently shipped to the wallet as a zero-byte script.
+func TestResolveLeaveDestinationEmptyPkScript(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRPCServer()
+	_, err := r.resolveLeaveDestination(&daemonrpc.LeaveDestination{
+		Target: &daemonrpc.LeaveDestination_PkScript{},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "pk_script is empty")
+}
+
+// TestResolveLeaveDestinationPkScriptOversized locks in the
+// MaxScriptSize cap so a hostile or buggy caller cannot ship a
+// multi-kilobyte pkScript through the leave path.
+func TestResolveLeaveDestinationPkScriptOversized(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRPCServer()
+	tooLarge := make([]byte, txscript.MaxScriptSize+1)
+
+	_, err := r.resolveLeaveDestination(&daemonrpc.LeaveDestination{
+		Target: &daemonrpc.LeaveDestination_PkScript{
+			PkScript: tooLarge,
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "too large")
+}
+
+// TestResolveLeaveDestinationPkScriptRejectsP2A locks in the BIP 431
+// P2A anchor rejection: a P2A pkScript is anyone-can-spend and
+// landing leave funds on it would effectively burn them, so the RPC
+// rejects this exact byte pattern.
+func TestResolveLeaveDestinationPkScriptRejectsP2A(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRPCServer()
+	p2a := []byte{txscript.OP_1, txscript.OP_DATA_2, 0x4e, 0x73}
+
+	_, err := r.resolveLeaveDestination(&daemonrpc.LeaveDestination{
+		Target: &daemonrpc.LeaveDestination_PkScript{
+			PkScript: p2a,
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "P2A")
+}
+
+// TestResolveLeaveDestinationPkScriptRejectsNonStandard verifies
+// that a pkScript GetScriptClass classifies as NonStandardTy (e.g.
+// a truncated push that fails to parse) is rejected before dispatch.
+func TestResolveLeaveDestinationPkScriptRejectsNonStandard(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRPCServer()
+
+	// Truncated taproot push: OP_1 OP_DATA_32 followed by only 2
+	// bytes of payload — fails to parse, classifies NonStandardTy.
+	truncated := []byte{0x51, 0x20, 0xaa, 0xbb}
+
+	_, err := r.resolveLeaveDestination(&daemonrpc.LeaveDestination{
+		Target: &daemonrpc.LeaveDestination_PkScript{
+			PkScript: truncated,
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not supported")
+}
+
+// TestResolveLeaveDestinationPkScriptAcceptsOPRETURN verifies that
+// OP_RETURN scripts (NullDataTy) remain a supported power-user
+// destination — burns / data-carrier exits are explicit caller
+// intent.
+func TestResolveLeaveDestinationPkScriptAcceptsOPRETURN(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRPCServer()
+
+	// OP_RETURN <empty>: the canonical data-carrier shape.
+	opReturn := []byte{txscript.OP_RETURN}
+
+	got, err := r.resolveLeaveDestination(&daemonrpc.LeaveDestination{
+		Target: &daemonrpc.LeaveDestination_PkScript{
+			PkScript: opReturn,
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, opReturn, got)
+}
+
+// TestResolveLeaveDestinationCrossNetwork verifies that a mainnet
+// address under regtest chain params is rejected by
+// btcutil.DecodeAddress rather than silently yielding a pkScript.
+// Leave is funds-moving, so a cross-network address would send
+// real funds to an unintended script — this guard matters.
+func TestResolveLeaveDestinationCrossNetwork(t *testing.T) {
+	t.Parallel()
+
+	// Build a mainnet P2TR address programmatically so the test
+	// doesn't depend on a hand-encoded bech32m string.
+	xOnly := make([]byte, 32)
+	xOnly[0] = 0xcd
+	mainnetAddr, err := btcutil.NewAddressTaproot(
+		xOnly, &chaincfg.MainNetParams,
+	)
+	require.NoError(t, err)
+
+	// newTestRPCServer uses RegressionNetParams, so decoding a
+	// mainnet address must fail.
+	r := newTestRPCServer()
+	_, err = r.resolveLeaveDestination(&daemonrpc.LeaveDestination{
+		Target: &daemonrpc.LeaveDestination_Address{
+			Address: mainnetAddr.String(),
+		},
+	})
+	require.Error(t, err)
+}
+
+// TestLeaveVTXOsRejectsAllWithPerOutpointOverrides verifies the
+// handler's primary "all + destinations" safety check: we can't
+// honor per-outpoint overrides when we don't know the outpoint
+// set up front, so the handler must reject the combination with
+// codes.InvalidArgument rather than silently dropping overrides.
+func TestLeaveVTXOsRejectsAllWithPerOutpointOverrides(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRPCServer()
+	req := &daemonrpc.LeaveVTXOsRequest{
+		Selection: &daemonrpc.LeaveVTXOsRequest_All{All: true},
+		DefaultDestination: &daemonrpc.LeaveDestination{
+			Target: &daemonrpc.LeaveDestination_PkScript{
+				PkScript: validP2TRPkScript(0x01),
+			},
+		},
+		Destinations: map[string]*daemonrpc.LeaveDestination{
+			validOutpoint(): {
+				Target: &daemonrpc.LeaveDestination_PkScript{
+					PkScript: validP2TRPkScript(0x02),
+				},
+			},
+		},
+	}
+
+	_, err := r.LeaveVTXOs(t.Context(), req)
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, status.Code(err),
+		"all + destinations must be InvalidArgument")
+	require.Contains(t, err.Error(), "selection=all")
+}
+
+// TestLeaveVTXOsRejectsMissingDefaultForUncoveredOutpoint verifies
+// that the handler refuses to dispatch a batch where any outpoint
+// has no destination — either the caller sets default_destination,
+// or every outpoint must be explicitly covered by destinations.
+func TestLeaveVTXOsRejectsMissingDefaultForUncoveredOutpoint(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRPCServer()
+	op1 := validOutpoint()
+	op2 := validOutpoint2()
+
+	req := &daemonrpc.LeaveVTXOsRequest{
+		Selection: &daemonrpc.LeaveVTXOsRequest_Outpoints{
+			Outpoints: &daemonrpc.OutpointSelection{
+				Outpoints: []string{op1, op2},
+			},
+		},
+		Destinations: map[string]*daemonrpc.LeaveDestination{
+			op1: {
+				Target: &daemonrpc.LeaveDestination_PkScript{
+					PkScript: validP2TRPkScript(0xaa),
+				},
+			},
+		},
+	}
+
+	_, err := r.LeaveVTXOs(t.Context(), req)
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.Contains(t, err.Error(), "no destination")
+}
+
+// TestLeaveVTXOsRejectsEmptyOutpoints mirrors RefreshVTXOs: an
+// outpoints selection with an empty slice is an explicit bug on
+// the caller's end.
+func TestLeaveVTXOsRejectsEmptyOutpoints(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRPCServer()
+	req := &daemonrpc.LeaveVTXOsRequest{
+		Selection: &daemonrpc.LeaveVTXOsRequest_Outpoints{
+			Outpoints: &daemonrpc.OutpointSelection{
+				Outpoints: nil,
+			},
+		},
+	}
+
+	_, err := r.LeaveVTXOs(t.Context(), req)
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.Contains(t, err.Error(), "empty")
+}
+
+// TestLeaveVTXOsRejectsInvalidOutpoint verifies that malformed
+// "txid:index" strings in the selection are caught before the
+// handler reaches the wallet dispatch path.
+func TestLeaveVTXOsRejectsInvalidOutpoint(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRPCServer()
+	req := &daemonrpc.LeaveVTXOsRequest{
+		Selection: &daemonrpc.LeaveVTXOsRequest_Outpoints{
+			Outpoints: &daemonrpc.OutpointSelection{
+				Outpoints: []string{"not-an-outpoint"},
+			},
+		},
+	}
+
+	_, err := r.LeaveVTXOs(t.Context(), req)
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.Contains(t, err.Error(), "invalid outpoint")
+}
+
+// TestLeaveVTXOsRejectsInvalidDestinationKey verifies that a
+// destinations map keyed by a malformed outpoint string is
+// rejected before dispatch. Bad keys on the override map are a
+// caller bug, not a soft per-outpoint error.
+func TestLeaveVTXOsRejectsInvalidDestinationKey(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRPCServer()
+	op := validOutpoint()
+
+	req := &daemonrpc.LeaveVTXOsRequest{
+		Selection: &daemonrpc.LeaveVTXOsRequest_Outpoints{
+			Outpoints: &daemonrpc.OutpointSelection{
+				Outpoints: []string{op},
+			},
+		},
+		DefaultDestination: &daemonrpc.LeaveDestination{
+			Target: &daemonrpc.LeaveDestination_PkScript{
+				PkScript: validP2TRPkScript(0x01),
+			},
+		},
+		Destinations: map[string]*daemonrpc.LeaveDestination{
+			"not-an-outpoint": {
+				Target: &daemonrpc.LeaveDestination_PkScript{
+					PkScript: validP2TRPkScript(0x02),
+				},
+			},
+		},
+	}
+
+	_, err := r.LeaveVTXOs(t.Context(), req)
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.Contains(t, err.Error(), "destinations")
+}
+
+// TestLeaveVTXOsRejectsExtraneousDestinationKey is the H-4
+// regression guard: a destination override keyed by a syntactically
+// valid outpoint that isn't in the selection (a typo'd index,
+// copy-paste from another VTXO list) must fail closed with
+// InvalidArgument so the typo surfaces immediately. Before the fix
+// the stray entry was silently accepted into destOutputs and the
+// real target fell back to default_destination — a money-moving
+// footgun.
+func TestLeaveVTXOsRejectsExtraneousDestinationKey(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRPCServer()
+
+	op1 := validOutpoint()
+	stray := validOutpoint2()
+
+	req := &daemonrpc.LeaveVTXOsRequest{
+		Selection: &daemonrpc.LeaveVTXOsRequest_Outpoints{
+			Outpoints: &daemonrpc.OutpointSelection{
+				Outpoints: []string{op1},
+			},
+		},
+		DefaultDestination: &daemonrpc.LeaveDestination{
+			Target: &daemonrpc.LeaveDestination_PkScript{
+				PkScript: validP2TRPkScript(0x01),
+			},
+		},
+		Destinations: map[string]*daemonrpc.LeaveDestination{
+			stray: {
+				Target: &daemonrpc.LeaveDestination_PkScript{
+					PkScript: validP2TRPkScript(0x02),
+				},
+			},
+		},
+	}
+
+	_, err := r.LeaveVTXOs(t.Context(), req)
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.Contains(t, err.Error(), "outpoint not in selection")
+}
+
+// TestLeaveVTXOsRejectsMissingDefaultForAll verifies that
+// selection=all without a default_destination fails fast — there's
+// no way to supply per-outpoint overrides under "all", so a
+// missing default is unambiguous caller error.
+func TestLeaveVTXOsRejectsMissingDefaultForAll(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRPCServer()
+	req := &daemonrpc.LeaveVTXOsRequest{
+		Selection: &daemonrpc.LeaveVTXOsRequest_All{All: true},
+	}
+
+	_, err := r.LeaveVTXOs(t.Context(), req)
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.Contains(t, err.Error(), "default_destination")
+}
+
+// TestLeaveVTXOsDryRunReturnsPreview verifies the dry_run
+// short-circuit: echo the parsed outpoints with status="preview"
+// without touching the wallet actor or the quoter. This is the
+// path the CLI uses for pre-flight validation.
+func TestLeaveVTXOsDryRunReturnsPreview(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRPCServer()
+	op1 := validOutpoint()
+	op2 := validOutpoint2()
+
+	req := &daemonrpc.LeaveVTXOsRequest{
+		Selection: &daemonrpc.LeaveVTXOsRequest_Outpoints{
+			Outpoints: &daemonrpc.OutpointSelection{
+				Outpoints: []string{op1, op2},
+			},
+		},
+		DefaultDestination: &daemonrpc.LeaveDestination{
+			Target: &daemonrpc.LeaveDestination_PkScript{
+				PkScript: validP2TRPkScript(0x01),
+			},
+		},
+		DryRun: true,
+	}
+
+	resp, err := r.LeaveVTXOs(t.Context(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, "preview", resp.Status)
+	require.ElementsMatch(t,
+		[]string{op1, op2}, resp.QueuedOutpoints,
+	)
+}
+
+// TestLeaveVTXOsAllDryRunReturnsPreview is the H-5 smoke test: a
+// selection=all dry_run request must reach the dry_run echo (status
+// "preview") rather than short-circuiting on the wallet-ready gate
+// or any other path before enumeration. Before the fix the dry_run
+// echo ran *before* live VTXO enumeration so the queued_outpoints
+// list was always empty for this combination, which lulled callers
+// into re-running without --dry_run and draining every VTXO. After
+// the fix the enumeration runs first, then the dry_run echo emits
+// the live target set. Without a real vtxoStore in the in-package
+// fixture we can only assert the path is reachable and returns
+// "preview"; the populated-store case is exercised via the
+// system-level itest follow-up.
+func TestLeaveVTXOsAllDryRunReturnsPreview(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRPCServer()
+	req := &daemonrpc.LeaveVTXOsRequest{
+		Selection: &daemonrpc.LeaveVTXOsRequest_All{All: true},
+		DefaultDestination: &daemonrpc.LeaveDestination{
+			Target: &daemonrpc.LeaveDestination_PkScript{
+				PkScript: validP2TRPkScript(0x01),
+			},
+		},
+		DryRun: true,
+	}
+
+	resp, err := r.LeaveVTXOs(t.Context(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, "preview", resp.Status,
+		"all + dry_run reaches the dry_run echo regardless "+
+			"of vtxoStore wiring")
+}
+
+// TestLeaveVTXOsSelectionRequired verifies that omitting the
+// selection oneof entirely is an InvalidArgument error. A missing
+// selection is never the intended request shape.
+func TestLeaveVTXOsSelectionRequired(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRPCServer()
+	req := &daemonrpc.LeaveVTXOsRequest{
+		DefaultDestination: &daemonrpc.LeaveDestination{
+			Target: &daemonrpc.LeaveDestination_PkScript{
+				PkScript: validP2TRPkScript(0x01),
+			},
+		},
+	}
+
+	_, err := r.LeaveVTXOs(t.Context(), req)
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.Contains(t, err.Error(), "selection is required")
+}
+
+// validOutpoint returns a deterministic valid "txid:index" string
+// so tests can reference a consistent outpoint without manual hex
+// bookkeeping.
+func validOutpoint() string {
+	txid := make([]byte, 32)
+	txid[0] = 0xaa
+
+	return hex.EncodeToString(txid) + ":0"
+}
+
+// validOutpoint2 returns a second deterministic outpoint distinct
+// from validOutpoint for multi-outpoint scenarios.
+func validOutpoint2() string {
+	txid := make([]byte, 32)
+	txid[0] = 0xbb
+
+	return hex.EncodeToString(txid) + ":1"
+}
+
+// validP2TRPkScript returns a structurally-valid 34-byte P2TR
+// pkScript (`OP_1 OP_DATA_32 <32 bytes>`) for tests that need a
+// real LeaveDestination_PkScript payload. The class-whitelist guard
+// in resolveLeaveDestination rejects truncated / malformed pushes,
+// so this helper centralises the few magic bytes test code needs.
+func validP2TRPkScript(seed byte) []byte {
+	pkScript := make([]byte, 34)
+	pkScript[0] = 0x51 // OP_1
+	pkScript[1] = 0x20 // OP_DATA_32
+	pkScript[2] = seed
+
+	return pkScript
+}
+
+// compile-time check that the package-level chainParams pointer
+// matches RegressionNetParams — catches a regression where
+// newTestRPCServer silently stops using regtest params and the
+// cross-network test becomes a false pass.
+var _ = chaincfg.RegressionNetParams

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
@@ -818,6 +819,263 @@ func (r *RPCServer) RefreshVTXOs(ctx context.Context,
 	}, nil
 }
 
+// LeaveVTXOs queues one or more VTXOs for cooperative leave
+// (offboard) in the next round. Each VTXO is forfeited and the
+// forfeited amount lands on-chain at the caller's destination —
+// either the default one or a per-outpoint override from the
+// destinations map. Under the #270 seal-time fee handshake the
+// server stamps the residual (Σin − Σ(fixed) − fee) onto the
+// wallet's IsChange=true leave output at seal time, so the RPC
+// layer does not need to pre-quote any per-input operator fee.
+//
+// Shape mirrors RefreshVTXOs: OutpointSelection oneof + dry_run +
+// {queued_outpoints, status}.
+func (r *RPCServer) LeaveVTXOs(ctx context.Context,
+	req *daemonrpc.LeaveVTXOsRequest) (
+	*daemonrpc.LeaveVTXOsResponse, error) {
+
+	// Pure-argument validation (selection / destinations / dry_run)
+	// runs before the wallet-ready gate so a malformed request
+	// surfaces InvalidArgument regardless of wallet state. This
+	// matches the API-correctness ordering rule: client bugs should
+	// always look like client bugs.
+
+	// Parse selection. "All" cannot be combined with per-outpoint
+	// destination overrides because we don't know the outpoint set
+	// up front — callers that want distinct destinations must
+	// enumerate the outpoints themselves.
+	var (
+		targets  []wire.OutPoint
+		leaveAll bool
+	)
+	switch sel := req.Selection.(type) {
+	case *daemonrpc.LeaveVTXOsRequest_All:
+		leaveAll = sel.All
+		if len(req.Destinations) > 0 {
+			return nil, status.Errorf(
+				codes.InvalidArgument,
+				"per-outpoint destinations not "+
+					"supported with selection=all",
+			)
+		}
+
+	case *daemonrpc.LeaveVTXOsRequest_Outpoints:
+		if sel.Outpoints == nil ||
+			len(sel.Outpoints.Outpoints) == 0 {
+
+			return nil, status.Errorf(
+				codes.InvalidArgument,
+				"outpoints list is empty")
+		}
+
+		for _, opStr := range sel.Outpoints.Outpoints {
+			op, err := parseOutpointString(opStr)
+			if err != nil {
+				return nil, status.Errorf(
+					codes.InvalidArgument,
+					"invalid outpoint %q: %v",
+					opStr, err)
+			}
+
+			targets = append(targets, op)
+		}
+
+	default:
+		return nil, status.Errorf(
+			codes.InvalidArgument,
+			"selection is required (outpoints or all)")
+	}
+
+	// Resolve the default destination (if set). It becomes the
+	// wallet's req.DestOutput, i.e. the fallback for any outpoint
+	// not overridden in destinations.
+	var defaultOutput *wire.TxOut
+	if req.DefaultDestination != nil {
+		pkScript, err := r.resolveLeaveDestination(
+			req.DefaultDestination,
+		)
+		if err != nil {
+			return nil, status.Errorf(
+				codes.InvalidArgument,
+				"default_destination: %v", err)
+		}
+
+		// Under the seal-time fee handshake the server stamps
+		// the binding amount on the IsChange=true output, so the
+		// Value field is unused here; we leave it zero.
+		defaultOutput = &wire.TxOut{PkScript: pkScript}
+	}
+
+	// Build the target set up front so the destinations loop can
+	// reject keys that aren't in the selection. selection=all
+	// already rejected non-empty Destinations above, so the set is
+	// only consulted on the explicit-outpoints branch.
+	targetSet := make(map[wire.OutPoint]struct{}, len(targets))
+	for _, op := range targets {
+		targetSet[op] = struct{}{}
+	}
+
+	// Resolve per-outpoint overrides. Each destination key must be
+	// a valid outpoint AND must appear in the selection — a stray
+	// key (typo'd index, copy-paste from another VTXO list) routes
+	// silently to default_destination on a funds-moving call, so we
+	// fail closed here and surface the typo as InvalidArgument
+	// before we dispatch anything to the wallet.
+	destOutputs := make(map[wire.OutPoint]*wire.TxOut)
+	for opStr, dest := range req.Destinations {
+		op, err := parseOutpointString(opStr)
+		if err != nil {
+			return nil, status.Errorf(
+				codes.InvalidArgument,
+				"destinations: invalid outpoint %q: %v",
+				opStr, err)
+		}
+
+		if _, inTargets := targetSet[op]; !inTargets {
+			return nil, status.Errorf(
+				codes.InvalidArgument,
+				"destinations[%s]: outpoint not in "+
+					"selection", opStr)
+		}
+
+		pkScript, err := r.resolveLeaveDestination(dest)
+		if err != nil {
+			return nil, status.Errorf(
+				codes.InvalidArgument,
+				"destinations[%s]: %v", opStr, err)
+		}
+
+		destOutputs[op] = &wire.TxOut{PkScript: pkScript}
+	}
+
+	// Guarantee every explicit target has some destination before
+	// dispatch — the wallet surfaces a per-outpoint error for a
+	// missing destination, but catching it at the RPC layer gives
+	// the caller a single clean InvalidArgument instead of a
+	// partially-accepted batch. For selection=all we can't
+	// enumerate targets here (the wallet enumerates via
+	// vtxoStore), so we just require a default destination.
+	if defaultOutput == nil {
+		if leaveAll {
+			return nil, status.Errorf(
+				codes.InvalidArgument,
+				"default_destination is required "+
+					"with selection=all")
+		}
+
+		for _, op := range targets {
+			if _, ok := destOutputs[op]; !ok {
+				return nil, status.Errorf(
+					codes.InvalidArgument,
+					"outpoint %s has no destination; "+
+						"set default_destination or "+
+						"destinations[%s]",
+					op, op)
+			}
+		}
+	}
+
+	// When selection=all, enumerate live VTXOs so both the dry_run
+	// preview AND the queued list below cover the full set. The
+	// vtxoStore is populated independently of the wallet actor
+	// (it's a SQL view), so this runs before the wallet-ready gate
+	// — including under dry_run, which is the path users reach for
+	// to preview a "leave all" before committing. Doing the
+	// enumeration *after* the dry-run echo is the bug the H-5 fix
+	// closes: it returned an empty queued_outpoints list and a
+	// confused user (or LLM) reading the empty preview as a no-op
+	// would re-run without --dry_run and drain every VTXO.
+	if leaveAll && r.server.vtxoStore != nil {
+		liveVTXOs, err := r.server.vtxoStore.ListLiveVTXOs(ctx)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal,
+				"list live VTXOs: %v", err)
+		}
+
+		for _, v := range liveVTXOs {
+			targets = append(targets, v.Outpoint)
+		}
+	}
+
+	// For dry_run, echo the outpoints without touching the
+	// wallet or the operator. Matches RefreshVTXOs semantics; the
+	// short-circuit stays before the wallet-ready gate so callers
+	// can validate a request (and preview the live target set
+	// under selection=all) without a live wallet.
+	if req.DryRun {
+		outpointStrs := make([]string, 0, len(targets))
+		for _, op := range targets {
+			outpointStrs = append(outpointStrs,
+				fmt.Sprintf("%s:%d",
+					op.Hash, op.Index))
+		}
+
+		return &daemonrpc.LeaveVTXOsResponse{
+			QueuedOutpoints: outpointStrs,
+			Status:          "preview",
+		}, nil
+	}
+
+	// Every path below touches the wallet, so gate on it now.
+	if err := r.requireWalletReady(); err != nil {
+		return nil, err
+	}
+
+	if !r.server.walletRef.IsSome() {
+		return nil, status.Errorf(codes.Internal,
+			"wallet actor not initialized")
+	}
+
+	wRef := r.server.walletRef.UnsafeFromSome()
+
+	leaveReq := &wallet.LeaveVTXOsRequest{
+		TargetOutpoints: targets,
+		DestOutput:      defaultOutput,
+		DestOutputs:     destOutputs,
+	}
+	future := wRef.Ask(ctx, leaveReq)
+	result := future.Await(ctx)
+
+	leaveResp, err := result.Unpack()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"leave request failed: %v", err)
+	}
+
+	resp, ok := leaveResp.(*wallet.LeaveVTXOsResponse)
+	if !ok {
+		return nil, status.Errorf(codes.Internal,
+			"unexpected response type: %T", leaveResp)
+	}
+
+	// Log per-outpoint errors but don't fail the overall request.
+	for op, opErr := range resp.Errors {
+		r.server.log.WarnS(ctx, "VTXO leave error", opErr,
+			slog.String("outpoint", op.String()))
+	}
+
+	// Build the list of outpoints that were successfully queued.
+	// For selection=all we already populated targets from the
+	// vtxoStore above, so the same iteration works for both
+	// selection modes.
+	queued := make([]string, 0, resp.LeavingCount)
+	for _, op := range targets {
+		if _, hasErr := resp.Errors[op]; !hasErr {
+			queued = append(queued, fmt.Sprintf("%s:%d",
+				op.Hash, op.Index))
+		}
+	}
+
+	r.server.log.InfoS(ctx, "VTXOs queued for leave",
+		slog.Int("queued_count", len(queued)),
+		slog.Int("error_count", len(resp.Errors)))
+
+	return &daemonrpc.LeaveVTXOsResponse{
+		QueuedOutpoints: queued,
+		Status:          "queued",
+	}, nil
+}
+
 // Board triggers the client to join the next round with any confirmed
 // boarding UTXOs. The RPC delegates the full flow to the wallet actor:
 // balance check, VTXO amount computation, and round registration. It
@@ -1310,6 +1568,167 @@ func (r *RPCServer) unlockVTXOs(ctx context.Context,
 	return wRef.Tell(ctx, &wallet.UnlockVTXOsRequest{
 		Outpoints: outpoints,
 	})
+}
+
+// addrNetName returns a best-effort network name for a decoded
+// address so cross-network error messages can be specific. We
+// iterate the four standard nets and pick the one the address
+// claims IsForNet on; if none match (structurally impossible for
+// anything DecodeAddress returned successfully) we fall back to
+// "unknown" rather than panic.
+func addrNetName(addr btcutil.Address) string {
+	for _, p := range []*chaincfg.Params{
+		&chaincfg.MainNetParams,
+		&chaincfg.TestNet3Params,
+		&chaincfg.SigNetParams,
+		&chaincfg.RegressionNetParams,
+	} {
+		if addr.IsForNet(p) {
+			return p.Name
+		}
+	}
+
+	return "unknown"
+}
+
+// resolveLeaveDestination extracts the on-chain pkScript from a
+// LeaveDestination oneof. Unlike resolveRecipientOutput — which is
+// VTXO-centric and requires a taproot shape plus a client public key
+// — leave destinations are plain on-chain outputs, so we accept any
+// standard address (taproot, segwit, legacy) decoded against the
+// daemon's chainParams, or a raw pkScript the caller has already
+// resolved. Raw pkScripts are length-capped and class-whitelisted
+// here because no downstream layer re-validates the bytes, and a
+// typo'd / hostile pkScript on a funds-moving call would otherwise
+// land coins on an unspendable script.
+func (r *RPCServer) resolveLeaveDestination(
+	d *daemonrpc.LeaveDestination) ([]byte, error) {
+
+	if d == nil {
+		return nil, fmt.Errorf("leave destination is required")
+	}
+
+	switch t := d.Target.(type) {
+	case *daemonrpc.LeaveDestination_Address:
+		if t.Address == "" {
+			return nil, fmt.Errorf(
+				"leave destination address is empty",
+			)
+		}
+
+		addr, err := btcutil.DecodeAddress(
+			t.Address, r.server.chainParams,
+		)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"invalid leave address: %w", err,
+			)
+		}
+
+		// DecodeAddress honors the HRP for bech32 addresses and
+		// uses defaultNet only as a hint, so a mainnet address
+		// decoded under regtest still succeeds. The explicit
+		// IsForNet check below blocks the cross-network footgun:
+		// leave is funds-moving and a mismatched net would send
+		// real coins to an unintended script.
+		if !addr.IsForNet(r.server.chainParams) {
+			return nil, fmt.Errorf(
+				"invalid leave address: address is for %q, "+
+					"daemon is on %q",
+				addrNetName(addr),
+				r.server.chainParams.Name,
+			)
+		}
+
+		pkScript, err := txscript.PayToAddrScript(addr)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"derive leave pkScript: %w", err,
+			)
+		}
+
+		return pkScript, nil
+
+	case *daemonrpc.LeaveDestination_PkScript:
+		if err := validateLeavePkScript(t.PkScript); err != nil {
+			return nil, err
+		}
+
+		return t.PkScript, nil
+
+	default:
+		return nil, fmt.Errorf(
+			"leave destination target is required",
+		)
+	}
+}
+
+// p2aPkScript is the canonical Pay-to-Anchor (BIP 431) script that
+// CPFP packages use as their ephemeral anchor (`OP_1 <0x4e73>`). A
+// caller pointing a leave at this script would be assigning
+// real-value coins to a 240-sat anyone-can-spend output, which is
+// almost always a bug — we reject it explicitly so the typo surfaces
+// as InvalidArgument rather than a silently-burned VTXO.
+var p2aPkScript = []byte{
+	txscript.OP_1, txscript.OP_DATA_2, 0x4e, 0x73,
+}
+
+// validateLeavePkScript enforces the structural guard rails on the
+// raw `pk_script` branch of a LeaveDestination: a non-empty, ≤
+// MaxScriptSize byte string of a recognised standard class, with
+// witness-unknown and the BIP 431 anchor pattern explicitly rejected.
+// An address-typed destination cannot fail any of these (DecodeAddress
+// + PayToAddrScript only ever produce P2*KH / P2*SH / P2TR), so this
+// helper is only invoked on caller-supplied raw bytes.
+func validateLeavePkScript(pkScript []byte) error {
+	if len(pkScript) == 0 {
+		return fmt.Errorf(
+			"leave destination pk_script is empty",
+		)
+	}
+
+	if len(pkScript) > txscript.MaxScriptSize {
+		return fmt.Errorf(
+			"leave destination pk_script too large: %d > %d",
+			len(pkScript), txscript.MaxScriptSize,
+		)
+	}
+
+	// Reject the BIP 431 P2A anchor pattern. P2A is intentionally
+	// anyone-can-spend and only meaningful as a CPFP hook; a leave
+	// that lands on it is effectively a burn.
+	if bytes.Equal(pkScript, p2aPkScript) {
+		return fmt.Errorf(
+			"leave destination pk_script is the P2A anchor " +
+				"pattern; reject as funds-burn",
+		)
+	}
+
+	// Whitelist standard classes. Witness-unknown / non-standard
+	// scripts may relay-reject or land at an unspendable output;
+	// requiring a recognised class catches typo'd bytes that would
+	// otherwise silently ship to the round actor.
+	class := txscript.GetScriptClass(pkScript)
+	switch class {
+	case txscript.PubKeyTy,
+		txscript.PubKeyHashTy,
+		txscript.ScriptHashTy,
+		txscript.WitnessV0PubKeyHashTy,
+		txscript.WitnessV0ScriptHashTy,
+		txscript.WitnessV1TaprootTy,
+		txscript.MultiSigTy,
+		txscript.NullDataTy:
+
+		return nil
+
+	default:
+		return fmt.Errorf(
+			"leave destination pk_script class %s is not "+
+				"supported; use a standard P2PKH/P2SH/"+
+				"P2WPKH/P2WSH/P2TR/OP_RETURN script",
+			class,
+		)
+	}
 }
 
 // resolveRecipientOutput extracts both the pkScript and the client

--- a/wallet/AGENTS.md
+++ b/wallet/AGENTS.md
@@ -27,7 +27,7 @@ refresh, leave, OOR spend, and directed send flows.
 - `BoardRequest` / `BoardResponse` — Ask-request from RPC to trigger boarding flow.
 - `RefreshVTXOsRequest` — Ask-request to select VTXOs for refresh and compose intent package. Carries `OperatorFees map[wire.OutPoint]btcutil.Amount`; when non-empty, the handler validates each fee is non-negative and below the VTXO amount, then subtracts it from the new VTXO output before registering with the round actor. Empty map is pre-#269 zero-fee behavior (tests, legacy paths).
 - `SelectAndLockVTXOsRequest` — Ask-request to select and lock VTXOs for OOR spend.
-- `LeaveVTXOsRequest` — Ask-request to select VTXOs for cooperative leave. Carries `OperatorFees map[wire.OutPoint]btcutil.Amount`; when populated, the per-target leave output value is derived as VTXO amount minus the quoted fee (ignoring `DestOutput.Value`). When empty, `DestOutput.Value` is used as-is (legacy behavior).
+- `LeaveVTXOsRequest` — Ask-request to select VTXOs for cooperative leave. Carries a singular `DestOutput *wire.TxOut` plus a per-outpoint `DestOutputs map[wire.OutPoint]*wire.TxOut` override map; the handler picks `DestOutputs[op]` when set and falls back to `DestOutput`. Per-input operator fees are no longer pre-quoted on the client — under the #270 seal-time fee handshake the server stamps the residual onto the IsChange=true leave output at seal time, so the wallet ships the full forfeited amount on each leave output.
 - `CompleteSpendVTXOsRequest` — Tell-message to finalize spend and release locks.
 - `UnlockVTXOsRequest` — Tell-message to release locked VTXOs on failure.
 - `SendRecipient` — Describes a single directed send destination (pkscript, amount, recipient client key).

--- a/wallet/CLAUDE.md
+++ b/wallet/CLAUDE.md
@@ -27,7 +27,7 @@ refresh, leave, OOR spend, and directed send flows.
 - `BoardRequest` / `BoardResponse` — Ask-request from RPC to trigger boarding flow.
 - `RefreshVTXOsRequest` — Ask-request to select VTXOs for refresh and compose intent package. Carries `OperatorFees map[wire.OutPoint]btcutil.Amount`; when non-empty, the handler validates each fee is non-negative and below the VTXO amount, then subtracts it from the new VTXO output before registering with the round actor. Empty map is pre-#269 zero-fee behavior (tests, legacy paths).
 - `SelectAndLockVTXOsRequest` — Ask-request to select and lock VTXOs for OOR spend.
-- `LeaveVTXOsRequest` — Ask-request to select VTXOs for cooperative leave. Carries `OperatorFees map[wire.OutPoint]btcutil.Amount`; when populated, the per-target leave output value is derived as VTXO amount minus the quoted fee (ignoring `DestOutput.Value`). When empty, `DestOutput.Value` is used as-is (legacy behavior).
+- `LeaveVTXOsRequest` — Ask-request to select VTXOs for cooperative leave. Carries a singular `DestOutput *wire.TxOut` plus a per-outpoint `DestOutputs map[wire.OutPoint]*wire.TxOut` override map; the handler picks `DestOutputs[op]` when set and falls back to `DestOutput`. Per-input operator fees are no longer pre-quoted on the client — under the #270 seal-time fee handshake the server stamps the residual onto the IsChange=true leave output at seal time, so the wallet ships the full forfeited amount on each leave output.
 - `CompleteSpendVTXOsRequest` — Tell-message to finalize spend and release locks.
 - `UnlockVTXOsRequest` — Tell-message to release locked VTXOs on failure.
 - `SendRecipient` — Describes a single directed send destination (pkscript, amount, recipient client key).

--- a/wallet/messages.go
+++ b/wallet/messages.go
@@ -475,10 +475,22 @@ type LeaveVTXOsRequest struct {
 	// TargetOutpoints specifies which VTXOs to leave (offboard).
 	TargetOutpoints []wire.OutPoint
 
-	// DestOutput carries the destination pkScript. Under #270 its
-	// Value field is used only as a target hint — the binding
-	// amount comes from the server's JoinRoundQuote.
+	// DestOutput carries the default destination pkScript applied to
+	// every target outpoint that is not overridden in DestOutputs.
+	// Under #270 its Value field is used only as a target hint — the
+	// binding amount comes from the server's JoinRoundQuote at seal
+	// time.
 	DestOutput *wire.TxOut
+
+	// DestOutputs optionally overrides DestOutput on a per-outpoint
+	// basis. When an entry is present for an outpoint, the wallet
+	// handler uses its PkScript for that leave output; any outpoint
+	// without an entry falls back to DestOutput. This lets a single
+	// LeaveVTXOsRequest batch offboards to distinct on-chain
+	// destinations in one round. Like DestOutput, the binding amount
+	// is decided by the server's JoinRoundQuote — the entry's Value
+	// field is treated only as a target hint.
+	DestOutputs map[wire.OutPoint]*wire.TxOut
 }
 
 // MessageType returns the message type identifier for logging and debugging.

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -978,9 +978,14 @@ func (a *Ark) handleRefreshVTXOs(ctx context.Context,
 // forfeits are still submitted (partial participation). The caller should
 // check Errors in the response to detect partial failures.
 //
-// All VTXOs in a single request produce individual LeaveRequest objects
-// pointing to the same DestOutput. The server is expected to create a
-// separate on-chain output for each leave, not aggregate them.
+// Each target produces its own LeaveRequest whose pkScript is taken
+// from req.DestOutputs[outpoint] (per-outpoint override) when the
+// entry is set, falling back to the singular req.DestOutput when it
+// is not. A target with no destination on either side surfaces a
+// per-outpoint error instead of panicking — the RPC layer is
+// responsible for guaranteeing coverage before dispatch. The server
+// creates a separate on-chain output for each leave; it does not
+// aggregate them.
 func (a *Ark) handleLeaveVTXOs(ctx context.Context,
 	req *LeaveVTXOsRequest) fn.Result[WalletResp] {
 
@@ -1041,13 +1046,35 @@ func (a *Ark) handleLeaveVTXOs(ctx context.Context,
 		// two LeaveVTXOs RPCs land back-to-back during the same
 		// PendingRoundAssembly window.
 		op := outpoint
+
+		// Pick the destination: per-outpoint override from
+		// DestOutputs takes precedence so a single batch can
+		// offboard to distinct on-chain targets; otherwise the
+		// caller's singular DestOutput applies. A missing entry
+		// on both sides is a misuse by the RPC layer (which is
+		// responsible for guaranteeing every target has a
+		// destination before dispatch), so surface a clean
+		// per-outpoint error rather than panicking.
+		leaveOutput := req.DestOutputs[op]
+		if leaveOutput == nil {
+			leaveOutput = req.DestOutput
+		}
+		if leaveOutput == nil {
+			errors[outpoint] = fmt.Errorf(
+				"no destination for outpoint %s",
+				outpoint,
+			)
+
+			continue
+		}
+
 		forfeits = append(forfeits, types.ForfeitRequest{
 			VTXOOutpoint: &op,
 			Amount:       vtxo.Amount,
 		})
 		leaves = append(leaves, &types.LeaveRequest{
 			Output: &wire.TxOut{
-				PkScript: req.DestOutput.PkScript,
+				PkScript: leaveOutput.PkScript,
 				Value:    int64(vtxo.Amount),
 			},
 		})

--- a/wallet/wallet_admission_test.go
+++ b/wallet/wallet_admission_test.go
@@ -642,14 +642,202 @@ func TestLeaveReleasesOnRoundRejection(t *testing.T) {
 	require.Equal(t, 1, mgr.forfeitReleaseCalls)
 }
 
-// TestLeaveDeductsPerInputOperatorFee verifies that when the daemon
-// pre-quotes a non-zero per-VTXO operator fee on LeaveVTXOsRequest,
-// the wallet builds each leave output at (vtxo_amount -
-// operator_fee). The round's implicit operator fee (Σ forfeit
-// inputs − Σ leave outputs) must equal Σ per-input fees so the
-// server's validateOperatorFee (#269) ComputeForfeitFee check
-// accepts the submission. Mirror of TestRefreshDeductsPerInputOperatorFee
-// for the leave path.
+// TestLeavePerOutpointDestinations verifies that when the caller
+// populates DestOutputs with per-outpoint overrides, each leave output
+// uses its own destination pkScript. Under the #270 seal-time fee
+// handshake the leave output value is the forfeited VTXO's full
+// amount; the server stamps the residual on whichever output the FSM
+// designates as IsChange=true. The wallet handler intentionally does
+// NOT set IsChange — that's the FSM's job during intent assembly so a
+// single marker survives across multiple LeaveVTXOs RPCs in the same
+// pending-round window.
+func TestLeavePerOutpointDestinations(t *testing.T) {
+	t.Parallel()
+
+	op1 := testOutpoint(0)
+	op2 := testOutpoint(1)
+
+	vtxoDescs := map[wire.OutPoint]*VTXODescriptor{
+		op1: {
+			Outpoint: op1,
+			Amount:   50_000,
+			PkScript: []byte{0x51, 0x20, 0x01},
+			Expiry:   100,
+		},
+		op2: {
+			Outpoint: op2,
+			Amount:   80_000,
+			PkScript: []byte{0x51, 0x20, 0x02},
+			Expiry:   200,
+		},
+	}
+
+	mgr := &mockVTXOManagerBehavior{
+		forfeitReserveResp: &actormsg.ReserveForfeitResponse{},
+	}
+	roundActor := &mockRoundActorBehavior{}
+
+	w := newTestWalletWithManagerAndRound(
+		t, mgr, roundActor, testVTXOReader(vtxoDescs),
+	)
+
+	// Distinct per-outpoint destinations. DestOutput is left nil on
+	// purpose so a regression that fell through to the default would
+	// be caught by the nil-destination error path.
+	script1 := []byte{0x51, 0x20, 0xaa}
+	script2 := []byte{0x51, 0x20, 0xbb}
+	req := &LeaveVTXOsRequest{
+		TargetOutpoints: []wire.OutPoint{op1, op2},
+		DestOutputs: map[wire.OutPoint]*wire.TxOut{
+			op1: {PkScript: script1},
+			op2: {PkScript: script2},
+		},
+	}
+	result := w.Receive(t.Context(), req)
+	require.True(t, result.IsOk(), "expected ok, got: %v",
+		result.Err())
+
+	require.Equal(t, 1, roundActor.registerCalls)
+	require.NotNil(t, roundActor.capturedIntent)
+
+	forfeits := roundActor.capturedIntent.Forfeits
+	leaves := roundActor.capturedIntent.Leaves
+	require.Len(t, forfeits, 2)
+	require.Len(t, leaves, 2)
+
+	want := map[wire.OutPoint]struct {
+		script []byte
+		value  int64
+	}{
+		op1: {script: script1, value: int64(vtxoDescs[op1].Amount)},
+		op2: {script: script2, value: int64(vtxoDescs[op2].Amount)},
+	}
+	for i := range forfeits {
+		require.NotNil(t, forfeits[i].VTXOOutpoint)
+		op := *forfeits[i].VTXOOutpoint
+		expect, ok := want[op]
+		require.True(t, ok, "unexpected outpoint %s", op)
+
+		require.NotNil(t, leaves[i].Output)
+		require.Equal(t, expect.script, leaves[i].Output.PkScript,
+			"per-outpoint pkScript is preserved")
+		require.Equal(t, expect.value, leaves[i].Output.Value,
+			"leaf value carries the forfeited VTXO amount")
+
+		require.False(t, leaves[i].IsChange,
+			"wallet handler must not stamp IsChange — the "+
+				"FSM designates the change marker centrally "+
+				"during intent assembly")
+	}
+}
+
+// TestLeaveFallsBackToDefaultDestWhenMapMisses verifies the hybrid
+// case where DestOutputs overrides one outpoint and the other falls
+// through to DestOutput. Both leave outputs must carry the correct
+// pkScript for their source.
+func TestLeaveFallsBackToDefaultDestWhenMapMisses(t *testing.T) {
+	t.Parallel()
+
+	op1 := testOutpoint(0)
+	op2 := testOutpoint(1)
+
+	vtxoDescs := map[wire.OutPoint]*VTXODescriptor{
+		op1: {
+			Outpoint: op1,
+			Amount:   30_000,
+			PkScript: []byte{0x51, 0x20, 0x01},
+			Expiry:   100,
+		},
+		op2: {
+			Outpoint: op2,
+			Amount:   40_000,
+			PkScript: []byte{0x51, 0x20, 0x02},
+			Expiry:   200,
+		},
+	}
+
+	mgr := &mockVTXOManagerBehavior{
+		forfeitReserveResp: &actormsg.ReserveForfeitResponse{},
+	}
+	roundActor := &mockRoundActorBehavior{}
+
+	w := newTestWalletWithManagerAndRound(
+		t, mgr, roundActor, testVTXOReader(vtxoDescs),
+	)
+
+	overrideScript := []byte{0x51, 0x20, 0xab}
+	defaultScript := []byte{0x51, 0x20, 0xcd}
+	req := &LeaveVTXOsRequest{
+		TargetOutpoints: []wire.OutPoint{op1, op2},
+		DestOutput:      &wire.TxOut{PkScript: defaultScript},
+		DestOutputs: map[wire.OutPoint]*wire.TxOut{
+			op1: {PkScript: overrideScript},
+		},
+	}
+	result := w.Receive(t.Context(), req)
+	require.True(t, result.IsOk(), "expected ok, got: %v",
+		result.Err())
+
+	leaves := roundActor.capturedIntent.Leaves
+	require.Len(t, leaves, 2)
+
+	want := map[wire.OutPoint][]byte{
+		op1: overrideScript,
+		op2: defaultScript,
+	}
+	for i, forfeit := range roundActor.capturedIntent.Forfeits {
+		op := *forfeit.VTXOOutpoint
+		require.Equal(t, want[op], leaves[i].Output.PkScript,
+			"outpoint %s used wrong script source", op)
+	}
+}
+
+// TestLeaveRejectsMissingDestination verifies the handler surfaces a
+// per-outpoint error when neither DestOutputs[op] nor DestOutput is
+// set for a target. The RPC layer is supposed to guarantee a
+// destination before dispatch; if it ever slips this guarantee we
+// want a named error, not a nil-pointer panic, and no round
+// registration on the all-rejected case.
+func TestLeaveRejectsMissingDestination(t *testing.T) {
+	t.Parallel()
+
+	op := testOutpoint(0)
+	vtxoDescs := map[wire.OutPoint]*VTXODescriptor{
+		op: {
+			Outpoint: op,
+			Amount:   50_000,
+			PkScript: []byte{0x51, 0x20, 0x01},
+			Expiry:   100,
+		},
+	}
+
+	mgr := &mockVTXOManagerBehavior{
+		forfeitReserveResp: &actormsg.ReserveForfeitResponse{},
+	}
+	roundActor := &mockRoundActorBehavior{}
+
+	w := newTestWalletWithManagerAndRound(
+		t, mgr, roundActor, testVTXOReader(vtxoDescs),
+	)
+
+	req := &LeaveVTXOsRequest{
+		TargetOutpoints: []wire.OutPoint{op},
+	}
+	result := w.Receive(t.Context(), req)
+	require.True(t, result.IsOk(),
+		"handler returns ok with per-outpoint error; got: %v",
+		result.Err())
+
+	respVal, _ := result.Unpack()
+	resp, ok := respVal.(*LeaveVTXOsResponse)
+	require.True(t, ok)
+	require.Zero(t, resp.LeavingCount)
+	require.Contains(t, resp.Errors[op].Error(),
+		"no destination for outpoint")
+
+	require.Equal(t, 0, roundActor.registerCalls)
+}
+
 // =============================================================================
 // Directed send tests
 // =============================================================================


### PR DESCRIPTION
Closes #294.

## Summary

Wires `wallet.LeaveVTXOsRequest` (which already existed) through the full daemon stack so cooperative leave has a user-facing surface. Before this PR, `LeaveVTXOsRequest` was only constructed in tests; there was no daemonrpc method, no CLI, and no MCP tool — leave was an internal abstraction with no way to invoke it. The seal-time fee handshake (#270) already shipped, so the RPC layer does no client-side fee quoting; the server stamps the residual onto the `IsChange=true` leave output at seal time.

Five logical commits plus a fixup pass:

1. **`daemonrpc: add LeaveVTXOs RPC messages and service method`**
   New `LeaveDestination` oneof (`address` | `pk_script`), `LeaveVTXOsRequest` (`OutpointSelection`/`all` + `default_destination` + per-outpoint `destinations` map + `dry_run`), `LeaveVTXOsResponse`. Shape mirrors `RefreshVTXOs`; the per-outpoint override map unlocks batched offboards to distinct on-chain targets in one round.

2. **`wallet: allow per-outpoint destinations on LeaveVTXOsRequest`**
   Additive `DestOutputs map[wire.OutPoint]*wire.TxOut` field. `handleLeaveVTXOs` prefers overrides, falls back to singular `DestOutput`, surfaces a per-outpoint error if both are missing. Existing tests and the systest `TriggerVTXOLeave` helper keep working unchanged.

3. **`darepod: add LeaveVTXOs RPC handler`**
   Handler mirrors `RefreshVTXOs` but reorders pre-dispatch validation to run before the wallet-ready gate (malformed requests should always look like client bugs). New `resolveLeaveDestination` helper with an explicit `IsForNet` check — `btcutil.DecodeAddress` otherwise accepts a mainnet address under regtest `defaultNet`, which is a real footgun for a funds-moving RPC. The raw `pk_script` branch is length-capped (`txscript.MaxScriptSize`), class-whitelisted to standard forms (P2PKH/P2SH/P2WPKH/P2WSH/P2TR/P2PK/multisig/`OP_RETURN`), and rejects the BIP 431 P2A anchor pattern explicitly so a typo'd or hostile script can't silently burn funds. Stale destination keys (well-formed outpoints not in the selection) are rejected with `InvalidArgument` rather than silently dropped, and `--all --dry_run` enumerates live VTXOs into the preview so the user sees what would actually be queued.

4. **`darepocli: add vtxos leave subcommand`**
   `darepocli vtxos leave` follows the `vtxos refresh` pattern. `--all` is gated behind a y/N stdin confirmation unless `--yes` is passed. The confirmation gate runs after `parseRequest` returns so it covers both the flag-driven path and the `--json` path; previously the prompt lived inside the flag callback and an agent piping `{"all":true,...}` would silently bypass it. `--destination outpoint=addr` or `--destination outpoint=script:<hex>` supplies per-outpoint overrides. Flag parsing is extracted to `buildLeaveVTXOsRequest` so CLI and MCP stay in lock-step.

5. **`darepocli: wire leave into MCP and schema registry`**
   `vtxos_leave` MCP tool plus `vtxos.leave` schema registry entry. `make schema-check` passes.

## Test plan

- [x] `make unit pkg=./wallet/... timeout=5m` — Leave tests including `TestLeavePerOutpointDestinations`, `TestLeaveFallsBackToDefaultDestWhenMapMisses`, `TestLeaveRejectsMissingDestination`.
- [x] `make unit pkg=./darepod/... timeout=5m` — `rpc_leave_test.go` covers `resolveLeaveDestination` (address / pk_script / oversized / P2A / non-standard / OP_RETURN / cross-network / nil), every `LeaveVTXOs` pre-dispatch validation branch (all+overrides, extraneous destination keys, missing destination, malformed outpoint, malformed destination key, dry_run preview, all+dry_run preview).
- [x] `make unit pkg=./cmd/darepocli/... timeout=5m` — 18 tests in `cmd_vtxos_leave_test.go` covering every flag-combination validation path plus the JSON-bypass regression for the `--all` confirmation gate (`TestConfirmLeaveAllIfNeededJSONStillPrompts` and friends).
- [x] `make unit pkg=./daemonrpc/... timeout=5m`.
- [x] `make lint-native` (0 issues).
- [x] `make schema-check`.
- [x] `go build ./...` (clean for new code; unrelated `runtime.main_main` warning on root directory is pre-existing).
- [x] `darepocli vtxos leave --help` smoke.
- [ ] Regtest real-leave round-trip — deferred to the parent-repo itest follow-up so coverage lives where the harness pattern already is (`itest/refresh_test.go`).

## Follow-ups

- Parent-repo itest (`itest/leave_test.go`) driving this RPC end-to-end under a non-zero fee schedule.
- Parent-repo submodule pointer bump once this merges.
