### PR TITLE
docs: nightly doc-gardening sweep 2026-04-24

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -52,6 +52,7 @@ package may import from a higher layer.
 | Package | Purpose |
 |---------|---------|
 | [`darepod`](darepod/) | Daemon orchestrator: wires all subsystems, exposes gRPC API |
+| [`sdk/ark`](sdk/ark/) | Consumer-facing Go SDK facade: remote or embedded daemon access with typed models |
 | [`cmd/darepod`](cmd/darepod/) | Daemon entry point |
 | [`cmd/darepocli`](cmd/darepocli/) | CLI client |
 | [`timeout`](timeout/) | Generic timeout scheduling actor |

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ into specific topics below.
 | [durable_actor_architecture.md](durable_actor_architecture.md) | CDC pattern, durable mailbox lifecycle, recovery flow |
 | [durable_actor_quickstart.md](durable_actor_quickstart.md) | Developer guide: TLVMessage, ActorBehavior, migration checklist |
 | [fee_ledger.md](fee_ledger.md) | Client-side double-entry fee ledger: chart of accounts, per-flow walkthroughs, emission sites, replay safety |
+| [sdk_layered_architecture.md](sdk_layered_architecture.md) | SDK layering rationale: `sdk/ark` facade, remote vs. embedded modes, `sdk/swaps` future direction |
 | [mailbox_architecture.md](mailbox_architecture.md) | Three-layer mailbox system: pb, rpc, conn, serverconn |
 | [RPC_MAILBOX_CONTRACT.md](RPC_MAILBOX_CONTRACT.md) | Envelope semantics, at-least-once delivery, ack watermarks |
 

--- a/round/AGENTS.md
+++ b/round/AGENTS.md
@@ -17,6 +17,7 @@ protocols with MuSig2 signing ceremonies.
 - `Intents` — Pools of boarding, VTXO, forfeit, and leave requests accumulated before registration.
 - `IntentPackage` — FSM event wrapping `Intents` for atomic delivery to the round FSM.
 - `RegisterIntentRequest` — Actor message carrying a pre-composed `IntentPackage` from the wallet.
+- `RefreshVTXORequest` — Per-VTXO refresh registration carrying `Amount`, `VTXO`, `SigningKey`, and `OperatorFee int64`. The `OperatorFee` is quoted by the VTXO actor's `RefreshFeeQuoter` before emission; `buildVTXORequestFromRefresh` subtracts it from the new VTXO output amount and clamps to zero so a buggy quoter cannot produce a negative output.
 - `VTXOIntent` — Pre-registration VTXO request carrying `OwnerKey`, `OperatorKey`. For directed sends, `OwnerKey` is the recipient's key (distinct from the sender's `SigningKey`). Ownership is determined at confirmation time via `OwnedScriptChecker` — there is no `IsOwner` flag on the wire or in local state.
 - `RoundVTXORequest` — Pairs a `VTXOIntent` with an ephemeral `SigningKey` derived at registration time for MuSig2 tree construction.
 - `OwnedScriptChecker` — Interface that answers "does this pkScript belong to the local wallet?" The `InputSigSent → Confirmed` transition calls this for every VTXO in the round to decide which entries `buildOwnedClientVTXOs` persists as spendable local balance. Backed in production by the OOR artifact store (owned receive scripts table).

--- a/round/CLAUDE.md
+++ b/round/CLAUDE.md
@@ -17,6 +17,7 @@ protocols with MuSig2 signing ceremonies.
 - `Intents` — Pools of boarding, VTXO, forfeit, and leave requests accumulated before registration.
 - `IntentPackage` — FSM event wrapping `Intents` for atomic delivery to the round FSM.
 - `RegisterIntentRequest` — Actor message carrying a pre-composed `IntentPackage` from the wallet.
+- `RefreshVTXORequest` — Per-VTXO refresh registration carrying `Amount`, `VTXO`, `SigningKey`, and `OperatorFee int64`. The `OperatorFee` is quoted by the VTXO actor's `RefreshFeeQuoter` before emission; `buildVTXORequestFromRefresh` subtracts it from the new VTXO output amount and clamps to zero so a buggy quoter cannot produce a negative output.
 - `VTXOIntent` — Pre-registration VTXO request carrying `OwnerKey`, `OperatorKey`. For directed sends, `OwnerKey` is the recipient's key (distinct from the sender's `SigningKey`). Ownership is determined at confirmation time via `OwnedScriptChecker` — there is no `IsOwner` flag on the wire or in local state.
 - `RoundVTXORequest` — Pairs a `VTXOIntent` with an ephemeral `SigningKey` derived at registration time for MuSig2 tree construction.
 - `OwnedScriptChecker` — Interface that answers "does this pkScript belong to the local wallet?" The `InputSigSent → Confirmed` transition calls this for every VTXO in the round to decide which entries `buildOwnedClientVTXOs` persists as spendable local balance. Backed in production by the OOR artifact store (owned receive scripts table).

--- a/sdk/ark/AGENTS.md
+++ b/sdk/ark/AGENTS.md
@@ -18,7 +18,17 @@ without duplicating Ark runtime behavior.
   passes through a cloned `*darepod.Config`; the SDK hides transport
   and lifecycle management, not the full daemon config surface.
 - `Info` / `ServerInfo` / `Seed` / `WalletInitResult` — SDK-owned
-  typed models for the higher-level status and wallet bootstrap flows.
+  typed models for daemon status and wallet bootstrap flows.
+- `VTXOInfo` — Typed VTXO view (Outpoint, AmountSat, Status,
+  BatchExpiry, RoundID, CreatedHeight, etc.) returned by
+  `ListLiveVTXOs` / `ListSpentVTXOs`.
+- `OORReceiveInfo` — Typed OOR receive destination (PkScript,
+  PubKeyXOnly) returned by `NewOORReceiveScript` /
+  `AllocateOORReceiveScript`.
+- `IndexedOORSessionInfo` — Indexed OOR session view (ArkPSBT,
+  CheckpointPSBTs) returned by `GetIndexedOORSession` lookups.
+- `CustomOORInput` — Caller-specified OOR input carrying a policy
+  template, spend path, and UTXO info for `SendOORWithCustomInputs`.
 - Policy/OOR helpers such as `SendOORWithPolicy`,
   `SendOORWithCustomInputs`, typed indexed VTXO lookups, and typed
   receive-script decoding belong here so higher-level packages do not

--- a/sdk/ark/CLAUDE.md
+++ b/sdk/ark/CLAUDE.md
@@ -18,7 +18,17 @@ without duplicating Ark runtime behavior.
   passes through a cloned `*darepod.Config`; the SDK hides transport
   and lifecycle management, not the full daemon config surface.
 - `Info` / `ServerInfo` / `Seed` / `WalletInitResult` — SDK-owned
-  typed models for the higher-level status and wallet bootstrap flows.
+  typed models for daemon status and wallet bootstrap flows.
+- `VTXOInfo` — Typed VTXO view (Outpoint, AmountSat, Status,
+  BatchExpiry, RoundID, CreatedHeight, etc.) returned by
+  `ListLiveVTXOs` / `ListSpentVTXOs`.
+- `OORReceiveInfo` — Typed OOR receive destination (PkScript,
+  PubKeyXOnly) returned by `NewOORReceiveScript` /
+  `AllocateOORReceiveScript`.
+- `IndexedOORSessionInfo` — Indexed OOR session view (ArkPSBT,
+  CheckpointPSBTs) returned by `GetIndexedOORSession` lookups.
+- `CustomOORInput` — Caller-specified OOR input carrying a policy
+  template, spend path, and UTXO info for `SendOORWithCustomInputs`.
 - Policy/OOR helpers such as `SendOORWithPolicy`,
   `SendOORWithCustomInputs`, typed indexed VTXO lookups, and typed
   receive-script decoding belong here so higher-level packages do not

--- a/unroll/AGENTS.md
+++ b/unroll/AGENTS.md
@@ -149,6 +149,7 @@ control-plane record per target to `db` so restart can restore in-flight jobs.
   distinction. `TriggerFraudSpend` round-trips through a dedicated
   `UnilateralExitJobTriggerFraudSpend` constant instead of silently
   downgrading to `TriggerManual`.
+- **Sweep tx is v3 (TRUC).** `buildSweepTx` creates the sweep transaction with `wire.NewMsgTx(arktx.TxVersion)` (= 3). The shared `txconfirm` CPFP broadcaster gates parent submission on v3/BIP-431 semantics; CSV-relative timelocks work for any `version >= 2` but the anchor-detection heuristic requires v3.
 - **FSM outbox events are side-effect-only.** `RequestSweepBuild`,
   `EnsureReadyTransactions`, `ReissueInFlightTransactions`, and
   `ReissueSweepConfirmation` never mutate `JobState`; they are routed by

--- a/unroll/CLAUDE.md
+++ b/unroll/CLAUDE.md
@@ -149,6 +149,7 @@ control-plane record per target to `db` so restart can restore in-flight jobs.
   distinction. `TriggerFraudSpend` round-trips through a dedicated
   `UnilateralExitJobTriggerFraudSpend` constant instead of silently
   downgrading to `TriggerManual`.
+- **Sweep tx is v3 (TRUC).** `buildSweepTx` creates the sweep transaction with `wire.NewMsgTx(arktx.TxVersion)` (= 3). The shared `txconfirm` CPFP broadcaster gates parent submission on v3/BIP-431 semantics; CSV-relative timelocks work for any `version >= 2` but the anchor-detection heuristic requires v3.
 - **FSM outbox events are side-effect-only.** `RequestSweepBuild`,
   `EnsureReadyTransactions`, `ReissueInFlightTransactions`, and
   `ReissueSweepConfirmation` never mutate `JobState`; they are routed by

--- a/vtxo/AGENTS.md
+++ b/vtxo/AGENTS.md
@@ -30,6 +30,7 @@ when the local wallet owns the receive script.
 - `VTXOSaver` — Narrow persistence interface (`SaveVTXO(ctx, *Descriptor)`) the incoming handler uses; the production implementation is the `db` VTXO store, which serializes a missing tree path as an empty blob.
 - `VTXOsMaterializedNotification` — Manager-facing notification carrying already-persisted descriptors; the manager spawns one actor per descriptor without performing another store write. Used by both the OOR receive path and the new incoming round VTXO handler.
 - `LazyChainResolver` — Forwarding `TellOnlyRef[ExpiringNotification]` that buffers notifications until `Set()` wires the real chain-resolver target. Breaks the init-order dependency between the VTXO manager (which spawns `LazyChainResolver` at startup) and the unroll registry (which is wired after the VTXO manager starts). Buffered notifications are replayed in-order on `Set()`.
+- `RefreshFeeQuoter` — Function type `func(ctx, amount btcutil.Amount, remainingBlocks uint32) btcutil.Amount`. Optional hook on `VTXOActorConfig`; invoked just before each auto-refresh emission to quote the per-input operator fee the server-side `validateOperatorFee` expects. Nil quoter (legacy and test paths) yields `OperatorFee=0`. The quoted fee is embedded on `RefreshVTXORequest.OperatorFee` sent to the round actor, which deducts it from the new VTXO output amount.
 
 ## Relationships
 

--- a/vtxo/CLAUDE.md
+++ b/vtxo/CLAUDE.md
@@ -30,6 +30,7 @@ when the local wallet owns the receive script.
 - `VTXOSaver` — Narrow persistence interface (`SaveVTXO(ctx, *Descriptor)`) the incoming handler uses; the production implementation is the `db` VTXO store, which serializes a missing tree path as an empty blob.
 - `VTXOsMaterializedNotification` — Manager-facing notification carrying already-persisted descriptors; the manager spawns one actor per descriptor without performing another store write. Used by both the OOR receive path and the new incoming round VTXO handler.
 - `LazyChainResolver` — Forwarding `TellOnlyRef[ExpiringNotification]` that buffers notifications until `Set()` wires the real chain-resolver target. Breaks the init-order dependency between the VTXO manager (which spawns `LazyChainResolver` at startup) and the unroll registry (which is wired after the VTXO manager starts). Buffered notifications are replayed in-order on `Set()`.
+- `RefreshFeeQuoter` — Function type `func(ctx, amount btcutil.Amount, remainingBlocks uint32) btcutil.Amount`. Optional hook on `VTXOActorConfig`; invoked just before each auto-refresh emission to quote the per-input operator fee the server-side `validateOperatorFee` expects. Nil quoter (legacy and test paths) yields `OperatorFee=0`. The quoted fee is embedded on `RefreshVTXORequest.OperatorFee` sent to the round actor, which deducts it from the new VTXO output amount.
 
 ## Relationships
 

--- a/wallet/AGENTS.md
+++ b/wallet/AGENTS.md
@@ -25,9 +25,9 @@ refresh, leave, OOR spend, and directed send flows.
 - `BlockEpochNotification` — Tell-message from chain source triggering UTXO polling.
 - `BoardingUtxoConfirmedEvent` — Tell-message sent when a VTXO confirms.
 - `BoardRequest` / `BoardResponse` — Ask-request from RPC to trigger boarding flow.
-- `RefreshVTXOsRequest` — Ask-request to select VTXOs for refresh and compose intent package.
+- `RefreshVTXOsRequest` — Ask-request to select VTXOs for refresh and compose intent package. Carries `OperatorFees map[wire.OutPoint]btcutil.Amount`; when non-empty, the handler validates each fee is non-negative and below the VTXO amount, then subtracts it from the new VTXO output before registering with the round actor. Empty map is pre-#269 zero-fee behavior (tests, legacy paths).
 - `SelectAndLockVTXOsRequest` — Ask-request to select and lock VTXOs for OOR spend.
-- `LeaveVTXOsRequest` — Ask-request to select VTXOs for cooperative leave.
+- `LeaveVTXOsRequest` — Ask-request to select VTXOs for cooperative leave. Carries `OperatorFees map[wire.OutPoint]btcutil.Amount`; when populated, the per-target leave output value is derived as VTXO amount minus the quoted fee (ignoring `DestOutput.Value`). When empty, `DestOutput.Value` is used as-is (legacy behavior).
 - `CompleteSpendVTXOsRequest` — Tell-message to finalize spend and release locks.
 - `UnlockVTXOsRequest` — Tell-message to release locked VTXOs on failure.
 - `SendRecipient` — Describes a single directed send destination (pkscript, amount, recipient client key).

--- a/wallet/CLAUDE.md
+++ b/wallet/CLAUDE.md
@@ -25,9 +25,9 @@ refresh, leave, OOR spend, and directed send flows.
 - `BlockEpochNotification` — Tell-message from chain source triggering UTXO polling.
 - `BoardingUtxoConfirmedEvent` — Tell-message sent when a VTXO confirms.
 - `BoardRequest` / `BoardResponse` — Ask-request from RPC to trigger boarding flow.
-- `RefreshVTXOsRequest` — Ask-request to select VTXOs for refresh and compose intent package.
+- `RefreshVTXOsRequest` — Ask-request to select VTXOs for refresh and compose intent package. Carries `OperatorFees map[wire.OutPoint]btcutil.Amount`; when non-empty, the handler validates each fee is non-negative and below the VTXO amount, then subtracts it from the new VTXO output before registering with the round actor. Empty map is pre-#269 zero-fee behavior (tests, legacy paths).
 - `SelectAndLockVTXOsRequest` — Ask-request to select and lock VTXOs for OOR spend.
-- `LeaveVTXOsRequest` — Ask-request to select VTXOs for cooperative leave.
+- `LeaveVTXOsRequest` — Ask-request to select VTXOs for cooperative leave. Carries `OperatorFees map[wire.OutPoint]btcutil.Amount`; when populated, the per-target leave output value is derived as VTXO amount minus the quoted fee (ignoring `DestOutput.Value`). When empty, `DestOutput.Value` is used as-is (legacy behavior).
 - `CompleteSpendVTXOsRequest` — Tell-message to finalize spend and release locks.
 - `UnlockVTXOsRequest` — Tell-message to release locked VTXOs on failure.
 - `SendRecipient` — Describes a single directed send destination (pkscript, amount, recipient client key).


### PR DESCRIPTION
Automated nightly documentation sweep for 2026-04-24.

Updates per-package CLAUDE.md/AGENTS.md for packages that changed since the
last merged sweep (base: 3bc4bb2):

- vtxo: added RefreshFeeQuoter function type to Key Types
- round: added RefreshVTXORequest.OperatorFee field to Key Types
- wallet: updated RefreshVTXOsRequest and LeaveVTXOsRequest with OperatorFees map documentation
- unroll: added sweep-tx-v3 (TRUC) invariant
- sdk/ark: added VTXOInfo, OORReceiveInfo, IndexedOORSessionInfo, CustomOORInput to Key Types
- ARCHITECTURE.md: added sdk/ark to Layer 3 table
- docs/index.md: added sdk_layered_architecture.md entry

Please review the updated CLAUDE.md/AGENTS.md diffs and ARCHITECTURE.md
changes for accuracy.

Generated by the nightly doc-gardening workflow.
