### PR TITLE
[codex] Run commit message lint in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,37 @@ env:
 
 jobs:
   ########################
+  # commit message lint
+  ########################
+  commit-message:
+    name: Commit Message
+    runs-on: depot-ubuntu-24.04
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Lint commit messages
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BEFORE_SHA: ${{ github.event.before }}
+          GITHUB_SHA: ${{ github.sha }}
+        run: |
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            range="$BASE_SHA..$HEAD_SHA"
+          elif [ "$EVENT_NAME" = "push" ] &&
+               [ "$BEFORE_SHA" != "0000000000000000000000000000000000000000" ]; then
+            range="$BEFORE_SHA..$GITHUB_SHA"
+          else
+            range="$(git rev-parse HEAD^ 2>/dev/null)..HEAD"
+          fi
+
+          make commitmsg-lint range="$range"
+
+  ########################
   # static checks
   ########################
   static-checks:


### PR DESCRIPTION
## Summary

- add an early Commit Message CI job before the heavier checks
- lint the relevant commit range for pull requests and pushes
- delegate validation to the existing `commitmsg-lint` Make target

## Validation

- `make commitmsg-lint commit=HEAD`
- `make commitmsg-lint range=origin/main..HEAD`
- `git diff --check origin/main..HEAD`