### PR TITLE
docs: nightly doc-gardening sweep 2026-04-26

### DIFF
--- a/cmd/darepocli/darepoclicommands/AGENTS.md
+++ b/cmd/darepocli/darepoclicommands/AGENTS.md
@@ -23,7 +23,7 @@ embed the same command tree.
 | `send` | `SendVTXO` / `SendOOR` | Send to address |
 | `balance` | `GetBalance` | Show wallet balances |
 | `oor receive` | `NewOORReceiveScript` | Register a new OOR receive script and print the receive address |
-| `fees estimate` | `EstimateFee` | Print an itemized fee breakdown for a given VTXO amount; flags a dust-level amount on stderr |
+| `fees estimate` | `EstimateFee` | Print an itemized fee breakdown for a given VTXO amount; advisory only — the binding per-round fee is set by the server's `JoinRoundQuote` at seal time (#270). `--boarding` defaults to `true` (intentional divergence from proto zero value) so first-time users get boarding semantics without an explicit flag. `--remaining-blocks` is required for refresh estimates. Dust-level warnings go to stderr even when JSON output is requested. |
 | `fees history` | `GetFeeHistory` | Paginate the client-side ledger entries and print the cumulative operator fee total |
 | `unroll` | `Unroll` | Trigger a unilateral exit for the VTXO at `--outpoint txid:index`. Routes through the VTXO manager's `ForceUnrollRequest` path so the FSM transitions cleanly; the registry job is created async via the chain resolver seam. Response includes `Created` (false if already exiting) and the `ActorId` to poll. |
 | `unroll status` | `GetUnrollStatus` | Query progress for an unroll job by `--outpoint`. Reads through to the live registry first and falls back to the persisted `unilateral_exit_jobs` table for evicted/terminal jobs; `Found=false` (not an error) distinguishes "no such job" from lookup failure. |

--- a/cmd/darepocli/darepoclicommands/CLAUDE.md
+++ b/cmd/darepocli/darepoclicommands/CLAUDE.md
@@ -23,7 +23,7 @@ embed the same command tree.
 | `send` | `SendVTXO` / `SendOOR` | Send to address |
 | `balance` | `GetBalance` | Show wallet balances |
 | `oor receive` | `NewOORReceiveScript` | Register a new OOR receive script and print the receive address |
-| `fees estimate` | `EstimateFee` | Print an itemized fee breakdown for a given VTXO amount; flags a dust-level amount on stderr |
+| `fees estimate` | `EstimateFee` | Print an itemized fee breakdown for a given VTXO amount; advisory only — the binding per-round fee is set by the server's `JoinRoundQuote` at seal time (#270). `--boarding` defaults to `true` (intentional divergence from proto zero value) so first-time users get boarding semantics without an explicit flag. `--remaining-blocks` is required for refresh estimates. Dust-level warnings go to stderr even when JSON output is requested. |
 | `fees history` | `GetFeeHistory` | Paginate the client-side ledger entries and print the cumulative operator fee total |
 | `unroll` | `Unroll` | Trigger a unilateral exit for the VTXO at `--outpoint txid:index`. Routes through the VTXO manager's `ForceUnrollRequest` path so the FSM transitions cleanly; the registry job is created async via the chain resolver seam. Response includes `Created` (false if already exiting) and the `ActorId` to poll. |
 | `unroll status` | `GetUnrollStatus` | Query progress for an unroll job by `--outpoint`. Reads through to the live registry first and falls back to the persisted `unilateral_exit_jobs` table for evicted/terminal jobs; `Found=false` (not an error) distinguishes "no such job" from lookup failure. |

--- a/cmd/darepod/AGENTS.md
+++ b/cmd/darepod/AGENTS.md
@@ -5,6 +5,12 @@
 Daemon entry point. Parses flags, initializes configuration, and starts the
 `darepod.Server`.
 
+## Key Flags
+
+- `--maxoperatorfeesat` — Maximum operator fee (sats) the client will accept
+  per seal-time quote under the #270 fee handshake. Zero is rejected at
+  config-load time as explicit misconfiguration.
+
 ## Relationships
 
 - **Depends on**: `darepod` (Server orchestrator).

--- a/cmd/darepod/CLAUDE.md
+++ b/cmd/darepod/CLAUDE.md
@@ -5,6 +5,12 @@
 Daemon entry point. Parses flags, initializes configuration, and starts the
 `darepod.Server`.
 
+## Key Flags
+
+- `--maxoperatorfeesat` — Maximum operator fee (sats) the client will accept
+  per seal-time quote under the #270 fee handshake. Zero is rejected at
+  config-load time as explicit misconfiguration.
+
 ## Relationships
 
 - **Depends on**: `darepod` (Server orchestrator).

--- a/daemonrpc/AGENTS.md
+++ b/daemonrpc/AGENTS.md
@@ -5,11 +5,26 @@
 Daemon gRPC API definitions for wallet operations and round queries. Proto
 source: `daemonrpc/daemon.proto`.
 
+## Key Types
+
+- `RoundState` enum — Client-visible FSM state for a round participation
+  lifecycle. Notable values:
+  - `ROUND_STATE_REGISTRATION_SENT` (intent sent, awaiting server admission
+    and seal-time quote)
+  - `ROUND_STATE_QUOTE_RECEIVED = 15` — Client has received the server's
+    `JoinRoundQuote` and is deciding whether to accept or reject it. Inserted
+    between `REGISTRATION_SENT` and `JOINED` as Phase-2 of the #270 seal-time
+    fee handshake.
+  - `ROUND_STATE_JOINED` (quote accepted, awaiting commitment tx)
+
 ## Relationships
 
 - **Depends on**: nothing (proto definitions).
-- **Depended on by**: `darepod` (implements services), `cmd/darepocli` (uses generated clients).
+- **Depended on by**: `darepod` (implements services), `cmd/darepocli` (uses
+  generated clients), `rpc/roundpb` (generated from related proto).
 
 ## Invariants
 
 - **Never edit generated code** — regenerate via `make rpc`.
+- The `Board` RPC triggers `IntentRequested` (not `RegistrationRequested`) in
+  the round FSM — the event was renamed as part of the #270 handshake.

--- a/daemonrpc/CLAUDE.md
+++ b/daemonrpc/CLAUDE.md
@@ -5,11 +5,26 @@
 Daemon gRPC API definitions for wallet operations and round queries. Proto
 source: `daemonrpc/daemon.proto`.
 
+## Key Types
+
+- `RoundState` enum — Client-visible FSM state for a round participation
+  lifecycle. Notable values:
+  - `ROUND_STATE_REGISTRATION_SENT` (intent sent, awaiting server admission
+    and seal-time quote)
+  - `ROUND_STATE_QUOTE_RECEIVED = 15` — Client has received the server's
+    `JoinRoundQuote` and is deciding whether to accept or reject it. Inserted
+    between `REGISTRATION_SENT` and `JOINED` as Phase-2 of the #270 seal-time
+    fee handshake.
+  - `ROUND_STATE_JOINED` (quote accepted, awaiting commitment tx)
+
 ## Relationships
 
 - **Depends on**: nothing (proto definitions).
-- **Depended on by**: `darepod` (implements services), `cmd/darepocli` (uses generated clients).
+- **Depended on by**: `darepod` (implements services), `cmd/darepocli` (uses
+  generated clients), `rpc/roundpb` (generated from related proto).
 
 ## Invariants
 
 - **Never edit generated code** — regenerate via `make rpc`.
+- The `Board` RPC triggers `IntentRequested` (not `RegistrationRequested`) in
+  the round FSM — the event was renamed as part of the #270 handshake.

--- a/harness/AGENTS.md
+++ b/harness/AGENTS.md
@@ -20,4 +20,8 @@ containers with network isolation for end-to-end testing.
 ## Key Constants
 
 - `numInitialBlocks` = 106, `defaultTimeout` = 30s, `pollInterval` = 200ms.
+- `electrsReadyTimeout` = 2 minutes — longer window for electrs Esplora HTTP
+  endpoint readiness; CI parallelism occasionally races past `defaultTimeout`
+  due to docker layer cache + HTTP listener bring-up, producing spurious
+  failures unrelated to the protocol under test.
 - Coinbase maturity: 100 blocks + 6-block buffer.

--- a/harness/CLAUDE.md
+++ b/harness/CLAUDE.md
@@ -20,4 +20,8 @@ containers with network isolation for end-to-end testing.
 ## Key Constants
 
 - `numInitialBlocks` = 106, `defaultTimeout` = 30s, `pollInterval` = 200ms.
+- `electrsReadyTimeout` = 2 minutes — longer window for electrs Esplora HTTP
+  endpoint readiness; CI parallelism occasionally races past `defaultTimeout`
+  due to docker layer cache + HTTP listener bring-up, producing spurious
+  failures unrelated to the protocol under test.
 - Coinbase maturity: 100 blocks + 6-block buffer.

--- a/lib/actormsg/AGENTS.md
+++ b/lib/actormsg/AGENTS.md
@@ -17,7 +17,10 @@ package boundaries. Lives in `lib/` to break import cycles between `vtxo`,
 - `ReserveForfeitRequest` / `ReleaseForfeitRequest` — Forfeit reservation admission messages.
 - `ReleaseSpendRequest` / `CompleteSpendRequest` — Spend lifecycle completion messages.
 - `ForceUnrollRequest` / `ForceUnrollResponse` — Ask-message that routes an operator or chain-resolver unroll trigger through the VTXO manager into the per-VTXO FSM. `ForceUnrollResponse.Accepted` is true when the request caused a state transition; when false, `Reason` distinguishes `"no such vtxo"` from `"already terminal"` so callers don't misread a silent self-loop as success.
-- `RegisterIntentMsg` — Carries pre-composed cooperative intent package to round actor.
+- `RegisterIntentMsg` — Carries pre-composed cooperative intent package to round
+  actor. `TriggerRegistration=true` causes the round actor to immediately fire
+  `IntentRequested` after accepting the intent, advancing the FSM from
+  `PendingRoundAssembly` to `RegistrationSent`.
 - `TriggerBoardMsg` — Carries VTXO amounts for boarding registration to round actor.
 - `SelectedVTXO` — Describes a VTXO selected for spend (outpoint, amount, pkscript).
 - `RoundActorServiceKey()` / `VTXOManagerServiceKey()` / `VTXOActorServiceKey(outpoint wire.OutPoint)` — Service key constructors for actor discovery. `VTXOActorServiceKey` encodes the target outpoint into the key so each per-VTXO actor gets a unique, deterministic key.

--- a/lib/actormsg/CLAUDE.md
+++ b/lib/actormsg/CLAUDE.md
@@ -17,7 +17,10 @@ package boundaries. Lives in `lib/` to break import cycles between `vtxo`,
 - `ReserveForfeitRequest` / `ReleaseForfeitRequest` — Forfeit reservation admission messages.
 - `ReleaseSpendRequest` / `CompleteSpendRequest` — Spend lifecycle completion messages.
 - `ForceUnrollRequest` / `ForceUnrollResponse` — Ask-message that routes an operator or chain-resolver unroll trigger through the VTXO manager into the per-VTXO FSM. `ForceUnrollResponse.Accepted` is true when the request caused a state transition; when false, `Reason` distinguishes `"no such vtxo"` from `"already terminal"` so callers don't misread a silent self-loop as success.
-- `RegisterIntentMsg` — Carries pre-composed cooperative intent package to round actor.
+- `RegisterIntentMsg` — Carries pre-composed cooperative intent package to round
+  actor. `TriggerRegistration=true` causes the round actor to immediately fire
+  `IntentRequested` after accepting the intent, advancing the FSM from
+  `PendingRoundAssembly` to `RegistrationSent`.
 - `TriggerBoardMsg` — Carries VTXO amounts for boarding registration to round actor.
 - `SelectedVTXO` — Describes a VTXO selected for spend (outpoint, amount, pkscript).
 - `RoundActorServiceKey()` / `VTXOManagerServiceKey()` / `VTXOActorServiceKey(outpoint wire.OutPoint)` — Service key constructors for actor discovery. `VTXOActorServiceKey` encodes the target outpoint into the key so each per-VTXO actor gets a unique, deterministic key.

--- a/lib/types/AGENTS.md
+++ b/lib/types/AGENTS.md
@@ -10,9 +10,17 @@ server during round participation. These types are used across `round`, `vtxo`,
 
 - `JoinRoundRequest` — Client's round registration request: boarding inputs, VTXO requests, forfeit requests, leave requests.
 - `JoinRoundAuth` — Authentication data for round join (Schnorr signature proof-of-control).
-- `VTXORequest` — Describes a new VTXO to create in a round (amount, owner key, cosigner keys).
-- `ForfeitRequest` — Describes a VTXO being forfeited (outpoint, connector leaf info, forfeit tx signature).
-- `LeaveRequest` — Describes a cooperative exit (VTXO outpoint, destination address).
+- `VTXORequest` — Describes a new VTXO to create in a round (target amount,
+  owner key, cosigner keys). `IsChange bool` marks this as the intent's
+  designated fee-bearing change output: the server computes its final amount as
+  residual (`Σin − Σ(fixed outputs) − fee`) at seal time (#270). A
+  directed-send request may also be marked `IsChange` to opt into
+  "subtract fee from send amount" semantics.
+- `ForfeitRequest` — Describes a VTXO being forfeited (outpoint, connector
+  leaf info, forfeit tx signature).
+- `LeaveRequest` — Describes a cooperative exit (VTXO outpoint, destination
+  address). `IsChange bool` marks the output as the fee-bearing change output
+  with server-computed final amount, same semantics as `VTXORequest.IsChange`.
 - `BoardingRequest` — Describes a boarding input (outpoint, amount, script).
 - `OperatorTerms` — Server-published round parameters (fee rates, expiry config, connector dust amount).
 - `ClientBatchInfo` — Client's view of batch output info after tree construction.
@@ -35,6 +43,10 @@ server during round participation. These types are used across `round`, `vtxo`,
 
 - `VTXOOwnerKeyFamily` (44) is the HD key family used for deriving VTXO owner signing keys.
 - `JoinRoundAuthMessage` produces a deterministic byte encoding for Schnorr signature verification.
+- Exactly one output across `JoinRoundRequest.VTXORequests` + `LeaveRequests`
+  must have `IsChange=true` (servers reject intents with 0 or ≥2 markers,
+  except single-output intents). TLV codec uses record type 4 for
+  `VTXORequest.IsChange` and type 3 for `LeaveRequest.IsChange`.
 
 ## Deep Docs
 

--- a/lib/types/CLAUDE.md
+++ b/lib/types/CLAUDE.md
@@ -10,9 +10,17 @@ server during round participation. These types are used across `round`, `vtxo`,
 
 - `JoinRoundRequest` — Client's round registration request: boarding inputs, VTXO requests, forfeit requests, leave requests.
 - `JoinRoundAuth` — Authentication data for round join (Schnorr signature proof-of-control).
-- `VTXORequest` — Describes a new VTXO to create in a round (amount, owner key, cosigner keys).
-- `ForfeitRequest` — Describes a VTXO being forfeited (outpoint, connector leaf info, forfeit tx signature).
-- `LeaveRequest` — Describes a cooperative exit (VTXO outpoint, destination address).
+- `VTXORequest` — Describes a new VTXO to create in a round (target amount,
+  owner key, cosigner keys). `IsChange bool` marks this as the intent's
+  designated fee-bearing change output: the server computes its final amount as
+  residual (`Σin − Σ(fixed outputs) − fee`) at seal time (#270). A
+  directed-send request may also be marked `IsChange` to opt into
+  "subtract fee from send amount" semantics.
+- `ForfeitRequest` — Describes a VTXO being forfeited (outpoint, connector
+  leaf info, forfeit tx signature).
+- `LeaveRequest` — Describes a cooperative exit (VTXO outpoint, destination
+  address). `IsChange bool` marks the output as the fee-bearing change output
+  with server-computed final amount, same semantics as `VTXORequest.IsChange`.
 - `BoardingRequest` — Describes a boarding input (outpoint, amount, script).
 - `OperatorTerms` — Server-published round parameters (fee rates, expiry config, connector dust amount).
 - `ClientBatchInfo` — Client's view of batch output info after tree construction.
@@ -35,6 +43,10 @@ server during round participation. These types are used across `round`, `vtxo`,
 
 - `VTXOOwnerKeyFamily` (44) is the HD key family used for deriving VTXO owner signing keys.
 - `JoinRoundAuthMessage` produces a deterministic byte encoding for Schnorr signature verification.
+- Exactly one output across `JoinRoundRequest.VTXORequests` + `LeaveRequests`
+  must have `IsChange=true` (servers reject intents with 0 or ≥2 markers,
+  except single-output intents). TLV codec uses record type 4 for
+  `VTXORequest.IsChange` and type 3 for `LeaveRequest.IsChange`.
 
 ## Deep Docs
 

--- a/rpc/roundpb/AGENTS.md
+++ b/rpc/roundpb/AGENTS.md
@@ -1,0 +1,55 @@
+# rpc/roundpb
+
+## Purpose
+
+Generated gRPC protocol types and service constants for the round service.
+Defines the two-phase seal-time fee handshake messages introduced in #270:
+client intents (Phase 1) and server-issued per-client quotes (Phase 2).
+
+## Key Types
+
+- `JoinRoundRequest` — Phase-1 client intent: target amounts per output,
+  `is_change` marker on the designated change output, boarding inputs, forfeits.
+- `JoinRoundQuote` — Phase-2 server response issued when the round seals.
+  Contains per-output server-decided amounts, total operator fee,
+  `FeeBreakdown`, quote expiry timestamp, and a `quote_id` that clients must
+  echo in their accept/reject message to detect staleness across reseals.
+- `JoinRoundAccept` / `JoinRoundReject` — Client's explicit Phase-2 response
+  (echoes `round_id` + `quote_id`). Server reseals over remaining intents after
+  a reject or timeout.
+- `VTXOQuote` / `LeaveQuote` — Per-output server-computed amounts (one entry
+  per `VTXORequest` / `LeaveRequest` in intent order).
+- `FeeBreakdown` — Itemized operator fee: `chain_fee_sat`, `liquidity_fee_sat`,
+  `congestion_fee_sat`, fee rate at seal time, and batch size. Used for
+  client-side cap validation.
+- `QuoteReason` — Rejection reason enum: `QUOTE_OK`, `INSUFFICIENT_RESIDUAL`
+  (change residual negative or below dust), `INVALID_CHANGE_DESIGNATION`
+  (missing or duplicate `is_change` marker).
+
+## Service Method Constants (service.go)
+
+- `MethodJoinRoundQuote` — Server→client push via durable per-client mailbox
+  egress; crash between seal and dispatch redelivers on reconnect.
+- `MethodAcceptQuote` / `MethodRejectQuote` — Client→server explicit
+  accept/reject of the seal-time quote.
+
+## Relationships
+
+- **Depends on**: nothing (generated proto types + handwritten `service.go`
+  constants).
+- **Depended on by**: `serverconn` (client send/receive), `round` (server
+  sends `JoinRoundQuote`), `darepod` (service implementation).
+
+## Invariants
+
+- **Never edit generated `.pb.go` files** — regenerate via `make rpc`.
+- `quote_id` must be echoed verbatim in `JoinRoundAccept` / `JoinRoundReject`
+  so the server can discard stale responses from a previous seal pass.
+- Exactly one output in `JoinRoundRequest` may carry `is_change=true`; the
+  server rejects intents that violate this with `INVALID_CHANGE_DESIGNATION`.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.
+- [docs/fee-change-model.md](../../docs/fee-change-model.md) — Scenario
+  catalogue for the seal-time fee handshake.

--- a/rpc/roundpb/CLAUDE.md
+++ b/rpc/roundpb/CLAUDE.md
@@ -1,0 +1,55 @@
+# rpc/roundpb
+
+## Purpose
+
+Generated gRPC protocol types and service constants for the round service.
+Defines the two-phase seal-time fee handshake messages introduced in #270:
+client intents (Phase 1) and server-issued per-client quotes (Phase 2).
+
+## Key Types
+
+- `JoinRoundRequest` — Phase-1 client intent: target amounts per output,
+  `is_change` marker on the designated change output, boarding inputs, forfeits.
+- `JoinRoundQuote` — Phase-2 server response issued when the round seals.
+  Contains per-output server-decided amounts, total operator fee,
+  `FeeBreakdown`, quote expiry timestamp, and a `quote_id` that clients must
+  echo in their accept/reject message to detect staleness across reseals.
+- `JoinRoundAccept` / `JoinRoundReject` — Client's explicit Phase-2 response
+  (echoes `round_id` + `quote_id`). Server reseals over remaining intents after
+  a reject or timeout.
+- `VTXOQuote` / `LeaveQuote` — Per-output server-computed amounts (one entry
+  per `VTXORequest` / `LeaveRequest` in intent order).
+- `FeeBreakdown` — Itemized operator fee: `chain_fee_sat`, `liquidity_fee_sat`,
+  `congestion_fee_sat`, fee rate at seal time, and batch size. Used for
+  client-side cap validation.
+- `QuoteReason` — Rejection reason enum: `QUOTE_OK`, `INSUFFICIENT_RESIDUAL`
+  (change residual negative or below dust), `INVALID_CHANGE_DESIGNATION`
+  (missing or duplicate `is_change` marker).
+
+## Service Method Constants (service.go)
+
+- `MethodJoinRoundQuote` — Server→client push via durable per-client mailbox
+  egress; crash between seal and dispatch redelivers on reconnect.
+- `MethodAcceptQuote` / `MethodRejectQuote` — Client→server explicit
+  accept/reject of the seal-time quote.
+
+## Relationships
+
+- **Depends on**: nothing (generated proto types + handwritten `service.go`
+  constants).
+- **Depended on by**: `serverconn` (client send/receive), `round` (server
+  sends `JoinRoundQuote`), `darepod` (service implementation).
+
+## Invariants
+
+- **Never edit generated `.pb.go` files** — regenerate via `make rpc`.
+- `quote_id` must be echoed verbatim in `JoinRoundAccept` / `JoinRoundReject`
+  so the server can discard stale responses from a previous seal pass.
+- Exactly one output in `JoinRoundRequest` may carry `is_change=true`; the
+  server rejects intents that violate this with `INVALID_CHANGE_DESIGNATION`.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.
+- [docs/fee-change-model.md](../../docs/fee-change-model.md) — Scenario
+  catalogue for the seal-time fee handshake.


### PR DESCRIPTION
Automated nightly documentation sweep for 2026-04-26.

## What changed

Updated per-package CLAUDE.md/AGENTS.md for 7 stale packages and created
docs for 1 new package (`rpc/roundpb`), all reflecting the seal-time fee
handshake landed in the #270 batch:

- **cmd/darepocli/darepoclicommands**: `fees estimate` is advisory; binding
  fee set by server's `JoinRoundQuote` at seal time. Documents `--boarding`
  default divergence and `--remaining-blocks` requirement.
- **cmd/darepod**: Documents new `--maxoperatorfeesat` flag for #270 fee cap.
- **daemonrpc**: Documents new `ROUND_STATE_QUOTE_RECEIVED = 15` enum value
  and corrected event name (`IntentRequested` not `RegistrationRequested`).
- **harness**: Documents `electrsReadyTimeout = 2min` constant for CI
  infrastructure readiness races.
- **lib/actormsg**: Corrects `RegisterIntentMsg` description to use
  `IntentRequested` event name.
- **lib/types**: Documents new `IsChange` field on `VTXORequest` and
  `LeaveRequest` with exactly-one-change-output invariant and TLV record types.
- **rpc/roundpb** (NEW): Documents `JoinRoundQuote`, `JoinRoundAccept/Reject`,
  `FeeBreakdown`, `QuoteReason`, and service method constants for the
  two-phase seal-time handshake protocol.

Please review the CLAUDE.md/AGENTS.md and ARCHITECTURE.md diffs for accuracy.