### PR TITLE
[codex] oor: wait for spent vtxo persistence

### DIFF
--- a/baselib/actor/actor.go
+++ b/baselib/actor/actor.go
@@ -10,8 +10,8 @@ import (
 
 // mergeContexts creates a new context that cancels when either parent context
 // cancels, enabling actors to respect both system shutdown and caller deadlines
-// simultaneously. It preserves the shortest deadline between the two contexts
-// to ensure the most restrictive timeout is honored.
+// simultaneously. It preserves caller context values while honoring the
+// shortest deadline between the two contexts.
 //
 // A background goroutine monitors both parent contexts and cancels the merged
 // context when either parent cancels. The goroutine exits as soon as any
@@ -24,17 +24,16 @@ import (
 // overhead should be measured. The goroutine is short-lived and exits when
 // message processing completes.
 func mergeContexts(ctx1, ctx2 context.Context) (context.Context, context.CancelFunc) {
-	// Get deadlines from both contexts.
+	// Use the caller context as the base so request-scoped values, such as
+	// durable actor database transactions, are visible while processing an
+	// Ask message.
+	baseCtx := ctx2
+	baseCancel := func() {}
+
 	deadline1, hasDeadline1 := ctx1.Deadline()
 	deadline2, hasDeadline2 := ctx2.Deadline()
-
-	// Determine which context has the earliest deadline. By default, we'll
-	// use ctx1 and only switch to ctx2 if it has an earlier deadline.
-	baseCtx := ctx1
-	if hasDeadline2 {
-		if !hasDeadline1 || deadline2.Before(deadline1) {
-			baseCtx = ctx2
-		}
+	if hasDeadline1 && (!hasDeadline2 || deadline1.Before(deadline2)) {
+		baseCtx, baseCancel = context.WithDeadline(ctx2, deadline1)
 	}
 
 	// Create a new context that will be cancelled explicitly.
@@ -53,7 +52,10 @@ func mergeContexts(ctx1, ctx2 context.Context) (context.Context, context.CancelF
 		}
 	}()
 
-	return mergedCtx, cancel
+	return mergedCtx, func() {
+		cancel()
+		baseCancel()
+	}
 }
 
 // ActorConfig holds the configuration parameters for creating a new Actor.

--- a/baselib/actor/caller_context_test.go
+++ b/baselib/actor/caller_context_test.go
@@ -2,6 +2,7 @@ package actor
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 	"time"
 
@@ -166,6 +167,41 @@ func TestActorShutdownOverridesCallerDeadline(t *testing.T) {
 	// Result should reflect the error.
 	result := future.Await(context.Background())
 	require.True(t, result.IsErr())
+}
+
+// TestAskPreservesCallerTransactionContext verifies that Ask processing keeps
+// the caller's transaction marker. Durable actors rely on this when they ask a
+// regular actor to perform DB work inside the durable actor's current tx.
+func TestAskPreservesCallerTransactionContext(t *testing.T) {
+	t.Parallel()
+
+	system := NewActorSystem()
+	defer func() {
+		err := system.Shutdown(context.Background())
+		require.NoError(t, err)
+	}()
+
+	txSeen := make(chan bool, 1)
+
+	behavior := NewFunctionBehavior(
+		func(ctx context.Context, msg *testMsg) fn.Result[string] {
+			txSeen <- HasTx(ctx)
+
+			return fn.Ok("done")
+		},
+	)
+
+	key := NewServiceKey[*testMsg, string]("tx-aware")
+	ref := RegisterWithSystem(system, "tx-aware-actor", key, behavior)
+
+	askCtx := WithTx(context.Background(), (*sql.Tx)(nil))
+	future := ref.Ask(askCtx, newTestMsg("work"))
+
+	result := future.Await(context.Background())
+	_, err := result.Unpack()
+	require.NoError(t, err)
+
+	require.True(t, <-txSeen, "actor should receive caller transaction")
 }
 
 // TestTellIgnoresCallerContextAfterEnqueue verifies that Tell preserves

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -2982,18 +2982,22 @@ func (s *Server) initOORActor(ctx context.Context,
 
 	// Wire spend completion through the VTXO manager so each consumed
 	// VTXO transitions to SpentState via its own FSM, rather than
-	// writing VTXOStatusSpent directly to the store. Use Tell rather
-	// than Ask so the OOR durable actor can commit its own delivery
-	// transaction before the VTXO actor performs follow-up DB writes.
+	// writing VTXOStatusSpent directly to the store. Wait for the
+	// manager response so OOR only checkpoints Completed after the
+	// VTXO actor has durably persisted the spent status.
 	mgrKey := actormsg.VTXOManagerServiceKey()
 	completeSpend := func(ctx context.Context,
 		outpoints []wire.OutPoint) error {
 
-		return mgrKey.Ref(s.actorSystem).Tell(
+		result := mgrKey.Ref(s.actorSystem).Ask(
 			ctx, &actormsg.CompleteSpendRequest{
 				Outpoints: outpoints,
 			},
-		)
+		).Await(ctx)
+
+		_, err := result.Unpack()
+
+		return err
 	}
 
 	outboxHandler := &oor.LocalPersistenceOutboxHandler{

--- a/oor/local_persistence_handler.go
+++ b/oor/local_persistence_handler.go
@@ -3,6 +3,7 @@ package oor
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -48,8 +49,9 @@ type IncomingMetadataResolver func(ctx context.Context, sessionID SessionID,
 
 // SpendCompleter enqueues OOR spend completion through the VTXO manager so
 // each VTXO actor transitions to SpentState via its own FSM. Implementations
-// should avoid blocking on downstream DB writes because the OOR durable actor
-// may already be running inside a transaction.
+// must return only after the manager has either durably completed the spend or
+// reported an error so the OOR actor does not checkpoint Completed ahead of
+// local VTXO persistence.
 type SpendCompleter func(ctx context.Context,
 	outpoints []wire.OutPoint) error
 
@@ -148,8 +150,9 @@ func (h *LocalPersistenceOutboxHandler) Handle(ctx context.Context,
 //
 // When CompleteSpend is configured, the handler enqueues completion through
 // the VTXO manager so each VTXO actor transitions to SpentState via its own
-// FSM. This keeps the VTXO actor as the source of truth for availability
-// state without blocking the OOR durable actor on nested write transactions.
+// FSM and only emits InputsMarkedSpentEvent after the manager reports success.
+// This keeps the VTXO actor as the source of truth for availability state
+// while preserving the durable ordering required by OOR resume.
 //
 // When CompleteSpend is nil, the handler falls back to direct store writes
 // for backwards compatibility during migration.
@@ -175,6 +178,16 @@ func (h *LocalPersistenceOutboxHandler) handleMarkInputsSpent(
 
 		_, err := h.Store.GetVTXO(ctx, msg.Outpoints[i])
 		if err != nil {
+			if !errors.Is(err, sql.ErrNoRows) {
+				return nil, NewRetryableOutboxError(
+					fmt.Errorf(
+						"load local vtxo %s: %w",
+						msg.Outpoints[i], err,
+					),
+					defaultRetryDelay,
+				)
+			}
+
 			logger(ctx).DebugS(
 				ctx, "Skipping non-local OOR input spend "+
 					"completion",

--- a/oor/local_persistence_handler_test.go
+++ b/oor/local_persistence_handler_test.go
@@ -56,6 +56,7 @@ func (s *testPackageStore) UpsertBinding(_ context.Context, _ wire.OutPoint,
 // testVTXOStore is a minimal in-memory vtxo.VTXOStore used by handler tests.
 type testVTXOStore struct {
 	records map[wire.OutPoint]*vtxo.Descriptor
+	getErr  error
 }
 
 // newTestVTXOStore creates a new testVTXOStore.
@@ -87,9 +88,13 @@ func (s *testVTXOStore) SaveVTXO(_ context.Context,
 func (s *testVTXOStore) GetVTXO(_ context.Context,
 	outpoint wire.OutPoint) (*vtxo.Descriptor, error) {
 
+	if s.getErr != nil {
+		return nil, s.getErr
+	}
+
 	desc, ok := s.records[outpoint]
 	if !ok {
-		return nil, fmt.Errorf("not found")
+		return nil, fmt.Errorf("get VTXO: %w", sql.ErrNoRows)
 	}
 
 	cpy := *desc
@@ -782,6 +787,42 @@ func TestLocalPersistenceHandlerMarkInputsSpentSkipsNonLocal(t *testing.T) {
 	require.IsType(t, &InputsMarkedSpentEvent{}, events[0])
 	require.Equal(t, []wire.OutPoint{localOutpoint},
 		completedOutpoints)
+}
+
+// TestLocalPersistenceHandlerMarkInputsSpentRetriesLookupError asserts that
+// store lookup failures are not mistaken for non-local inputs.
+func TestLocalPersistenceHandlerMarkInputsSpentRetriesLookupError(
+	t *testing.T) {
+
+	t.Parallel()
+
+	store := newTestVTXOStore()
+	store.getErr = context.Canceled
+
+	handler := &LocalPersistenceOutboxHandler{
+		Store: store,
+		CompleteSpend: func(_ context.Context,
+			_ []wire.OutPoint) error {
+
+			t.Fatalf("CompleteSpend must not be called after " +
+				"lookup error")
+
+			return nil
+		},
+	}
+
+	events, err := handler.Handle(
+		t.Context(), SessionID{},
+		&MarkInputsSpentRequest{
+			Outpoints: []wire.OutPoint{{Hash: [32]byte{0x01}}},
+		},
+	)
+	require.Error(t, err)
+	require.Empty(t, events)
+
+	var retryErr *RetryableOutboxError
+	require.True(t, errors.As(err, &retryErr))
+	require.ErrorContains(t, err, "load local vtxo")
 }
 
 // TestLocalPersistenceHandlerMarkInputsSpentCompleterError asserts that

--- a/vtxo/actor.go
+++ b/vtxo/actor.go
@@ -278,21 +278,26 @@ func (a *VTXOActor) Receive(ctx context.Context,
 			"unexpected state type: %T", transition.NextState,
 		))
 	}
-	a.state = nextState
-
-	// Unsubscribe from block epochs when reaching terminal state.
-	if a.state.IsTerminal() && !priorState.IsTerminal() {
-		a.unsubscribeBlockEpochs(ctx)
-	}
-
 	// Extract outbox messages for caller to dispatch.
 	var outbox []VTXOOutMsg
 	transition.NewEvents.WhenSome(func(emitted VTXOEmittedEvent) {
 		outbox = emitted.Outbox
 	})
 
-	// Process persistence updates immediately.
-	a.processOutbox(ctx, outbox)
+	// Process persistence updates before publishing the in-memory state
+	// transition. If the durable write fails, callers must see an error
+	// and retries must re-drive the original state rather than observing
+	// a terminal state that never made it to disk.
+	if err := a.processOutbox(ctx, outbox); err != nil {
+		return fn.Err[actormsg.VTXOActorResp](err)
+	}
+
+	a.state = nextState
+
+	// Unsubscribe from block epochs when reaching terminal state.
+	if a.state.IsTerminal() && !priorState.IsTerminal() {
+		a.unsubscribeBlockEpochs(ctx)
+	}
 
 	return fn.Ok[actormsg.VTXOActorResp](VTXOActorResponse{
 		PriorState: priorState,
@@ -303,47 +308,29 @@ func (a *VTXOActor) Receive(ctx context.Context,
 
 // processOutbox routes outbox messages to their destinations. This includes
 // persistence updates, messages to the round actor, chain resolver, and
-// manager for cleanup.
-func (a *VTXOActor) processOutbox(ctx context.Context, outbox []VTXOOutMsg) {
+// manager for cleanup. Status updates are always persisted before any
+// notification side effects so persistence failures leave the actor state
+// unchanged and retryable.
+func (a *VTXOActor) processOutbox(ctx context.Context,
+	outbox []VTXOOutMsg) error {
+
+	// Persist status updates first so a DB failure causes Receive to
+	// return an error before applying the in-memory state transition.
+	for _, msg := range outbox {
+		statusUpdate, ok := msg.(*VTXOStatusUpdate)
+		if !ok {
+			continue
+		}
+
+		if err := a.processStatusUpdate(ctx, statusUpdate); err != nil {
+			return err
+		}
+	}
+
 	for _, msg := range outbox {
 		switch m := msg.(type) {
 		case *VTXOStatusUpdate:
-			// For forfeiting status with a forfeit tx, use
-			// MarkForfeiting to persist both status and the signed
-			// tx for crash recovery.
-			var err error
-			isForfeitingWithTx :=
-				m.NewStatus == VTXOStatusForfeiting &&
-					m.ForfeitTx != nil
-
-			a.logger(ctx).DebugS(ctx, "Processing VTXOStatusUpdate",
-				slog.String("outpoint", m.Outpoint.String()),
-				slog.String("new_status", m.NewStatus.String()),
-				slog.Bool("has_forfeit_tx", m.ForfeitTx != nil),
-				slog.Bool("is_forfeiting_with_tx", isForfeitingWithTx))
-
-			if isForfeitingWithTx {
-				err = a.cfg.Store.MarkForfeiting(
-					ctx, m.Outpoint, m.RoundID, m.ForfeitTx,
-				)
-				a.logger(ctx).DebugS(
-					ctx, "Called MarkForfeiting",
-					slog.String("outpoint", m.Outpoint.String()),
-					slog.String("round_id", m.RoundID),
-					slog.Bool("error", err != nil),
-				)
-			} else {
-				err = a.cfg.Store.UpdateVTXOStatus(
-					ctx, m.Outpoint, m.NewStatus,
-				)
-			}
-			if err != nil {
-				a.logger(ctx).ErrorS(ctx,
-					"Failed to update VTXO status", err,
-					slog.String("outpoint", m.Outpoint.String()),
-					slog.String("status", m.NewStatus.String()),
-				)
-			}
+			continue
 
 		case *ForfeitRequest:
 			// Relay forfeit request through the manager. The
@@ -436,6 +423,54 @@ func (a *VTXOActor) processOutbox(ctx context.Context, outbox []VTXOOutMsg) {
 			})
 		}
 	}
+
+	return nil
+}
+
+// processStatusUpdate persists a VTXO status transition and returns any write
+// error to the actor caller so higher-level durable workflows can retry.
+func (a *VTXOActor) processStatusUpdate(ctx context.Context,
+	m *VTXOStatusUpdate) error {
+
+	// For forfeiting status with a forfeit tx, use MarkForfeiting to
+	// persist both status and the signed tx for crash recovery.
+	var err error
+	isForfeitingWithTx := m.NewStatus == VTXOStatusForfeiting &&
+		m.ForfeitTx != nil
+
+	a.logger(ctx).DebugS(ctx, "Processing VTXOStatusUpdate",
+		slog.String("outpoint", m.Outpoint.String()),
+		slog.String("new_status", m.NewStatus.String()),
+		slog.Bool("has_forfeit_tx", m.ForfeitTx != nil),
+		slog.Bool("is_forfeiting_with_tx", isForfeitingWithTx))
+
+	if isForfeitingWithTx {
+		err = a.cfg.Store.MarkForfeiting(
+			ctx, m.Outpoint, m.RoundID, m.ForfeitTx,
+		)
+		a.logger(ctx).DebugS(
+			ctx, "Called MarkForfeiting",
+			slog.String("outpoint", m.Outpoint.String()),
+			slog.String("round_id", m.RoundID),
+			slog.Bool("error", err != nil),
+		)
+	} else {
+		err = a.cfg.Store.UpdateVTXOStatus(
+			ctx, m.Outpoint, m.NewStatus,
+		)
+	}
+	if err != nil {
+		a.logger(ctx).ErrorS(ctx,
+			"Failed to update VTXO status", err,
+			slog.String("outpoint", m.Outpoint.String()),
+			slog.String("status", m.NewStatus.String()),
+		)
+
+		return fmt.Errorf("persist vtxo status %s to %s: %w",
+			m.Outpoint, m.NewStatus, err)
+	}
+
+	return nil
 }
 
 // subscribeBlockEpochs registers for block notifications with chainsource.

--- a/vtxo/actor_test.go
+++ b/vtxo/actor_test.go
@@ -2,6 +2,7 @@ package vtxo
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/btcsuite/btcd/btcutil"
@@ -9,6 +10,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/chainsource"
 	"github.com/lightninglabs/darepo-client/internal/testutils"
 	"github.com/lightninglabs/darepo-client/ledger"
 	"github.com/lightninglabs/darepo-client/lib/arkscript"
@@ -17,6 +19,46 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+type noopChainSourceRef struct{}
+
+func (n noopChainSourceRef) ID() string { return "noop-chainsource" }
+
+func (n noopChainSourceRef) Tell(_ context.Context,
+	_ chainsource.ChainSourceMsg) error {
+
+	return nil
+}
+
+func (n noopChainSourceRef) Ask(_ context.Context,
+	msg chainsource.ChainSourceMsg,
+) actor.Future[chainsource.ChainSourceResp] {
+
+	promise := actor.NewPromise[chainsource.ChainSourceResp]()
+	switch msg.(type) {
+	case *chainsource.SubscribeBlocksRequest:
+		promise.Complete(fn.Ok[chainsource.ChainSourceResp](
+			&chainsource.SubscribeBlocksResponse{},
+		))
+
+	case *chainsource.UnsubscribeBlocksRequest:
+		promise.Complete(fn.Ok[chainsource.ChainSourceResp](
+			&chainsource.UnsubscribeBlocksResponse{},
+		))
+
+	default:
+		promise.Complete(fn.Err[chainsource.ChainSourceResp](
+			errors.New("unexpected chainsource message"),
+		))
+	}
+
+	return promise.Future()
+}
+
+var _ actor.ActorRef[
+	chainsource.ChainSourceMsg,
+	chainsource.ChainSourceResp,
+] = noopChainSourceRef{}
 
 // TestProcessOutboxForfeitSignature verifies that ForfeitSignatureSubmission
 // messages are relayed through the manager to the round actor.
@@ -58,7 +100,7 @@ func TestProcessOutboxForfeitSignature(t *testing.T) {
 		},
 	}
 
-	actor.processOutbox(h.ctx, outbox)
+	require.NoError(t, actor.processOutbox(h.ctx, outbox))
 
 	msgs := manager.getMessages()
 	require.Len(t, msgs, 1)
@@ -113,7 +155,7 @@ func TestProcessOutboxMarkForfeiting(t *testing.T) {
 		},
 	}
 
-	actor.processOutbox(h.ctx, outbox)
+	require.NoError(t, actor.processOutbox(h.ctx, outbox))
 
 	h.store.AssertCalled(
 		t, "MarkForfeiting", h.ctx, vtxo.Outpoint,
@@ -151,12 +193,60 @@ func TestProcessOutboxStatusUpdate(t *testing.T) {
 		},
 	}
 
-	actor.processOutbox(h.ctx, outbox)
+	require.NoError(t, actor.processOutbox(h.ctx, outbox))
 
 	h.store.AssertCalled(
 		t, "UpdateVTXOStatus", h.ctx, vtxo.Outpoint,
 		VTXOStatusPendingForfeit,
 	)
+}
+
+// TestReceiveStatusUpdateFailurePreservesStateForRetry verifies that a failed
+// durable VTXO status write prevents the actor from publishing the in-memory
+// state transition. A later retry should re-drive the same SpendingState event
+// and complete normally once the store accepts the write.
+func TestReceiveStatusUpdateFailurePreservesStateForRetry(t *testing.T) {
+	t.Parallel()
+
+	h := newVTXOTestHarness(t)
+	vtxo := h.newTestDescriptor()
+	actor := &VTXOActor{
+		cfg: &VTXOActorConfig{
+			VTXO:        vtxo,
+			Store:       h.store,
+			ChainSource: noopChainSourceRef{},
+			ChainParams: &chaincfg.RegressionNetParams,
+		},
+		state: &SpendingState{
+			VTXO:              vtxo,
+			LastCheckedHeight: vtxo.CreatedHeight,
+		},
+		env: h.env,
+	}
+
+	h.store.On(
+		"UpdateVTXOStatus", h.ctx, vtxo.Outpoint, VTXOStatusSpent,
+	).Return(errors.New("db down")).Once()
+
+	result := actor.Receive(h.ctx, &SpendCompletedEvent{})
+	_, err := result.Unpack()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "persist vtxo status")
+	_, ok := actor.state.(*SpendingState)
+	require.True(t, ok, "expected retryable SpendingState, got %T",
+		actor.state)
+
+	h.store.On(
+		"UpdateVTXOStatus", h.ctx, vtxo.Outpoint, VTXOStatusSpent,
+	).Return(nil).Once()
+
+	result = actor.Receive(h.ctx, &SpendCompletedEvent{})
+	_, err = result.Unpack()
+	require.NoError(t, err)
+	_, ok = actor.state.(*SpentState)
+	require.True(t, ok, "expected SpentState, got %T", actor.state)
+
+	h.store.AssertExpectations(t)
 }
 
 // TestProcessOutboxForfeitRequest verifies that ForfeitRequest messages are
@@ -187,7 +277,7 @@ func TestProcessOutboxForfeitRequest(t *testing.T) {
 		},
 	}
 
-	actor.processOutbox(h.ctx, outbox)
+	require.NoError(t, actor.processOutbox(h.ctx, outbox))
 
 	msgs := manager.getMessages()
 	require.Len(t, msgs, 1)
@@ -352,7 +442,7 @@ func TestProcessOutboxTerminatedNotification(t *testing.T) {
 		},
 	}
 
-	actor.processOutbox(h.ctx, outbox)
+	require.NoError(t, actor.processOutbox(h.ctx, outbox))
 
 	msgs := manager.getMessages()
 	require.Len(t, msgs, 1)
@@ -392,7 +482,7 @@ func TestProcessOutboxExpiringNotification(t *testing.T) {
 		},
 	}
 
-	actor.processOutbox(h.ctx, outbox)
+	require.NoError(t, actor.processOutbox(h.ctx, outbox))
 
 	msgs := chainResolver.getMessages()
 	require.Len(t, msgs, 1)
@@ -438,7 +528,7 @@ func TestProcessOutboxExpiringNotificationNoLedgerEmission(t *testing.T) {
 		},
 	}
 
-	vtxoActor.processOutbox(h.ctx, outbox)
+	require.NoError(t, vtxoActor.processOutbox(h.ctx, outbox))
 
 	// Chain resolver still receives the notification.
 	require.Len(t, chainResolver.getMessages(), 1)

--- a/vtxo/manager.go
+++ b/vtxo/manager.go
@@ -2,6 +2,7 @@ package vtxo
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -670,6 +671,16 @@ func (m *Manager) handleCompleteSpend(ctx context.Context,
 	for _, op := range outpoints {
 		ref, ok := m.actors[op]
 		if !ok {
+			spent, err := m.isPersistedSpent(ctx, op)
+			if err != nil {
+				return fn.Err[ManagerResp](err)
+			}
+			if spent {
+				completed++
+
+				continue
+			}
+
 			return fn.Err[ManagerResp](fmt.Errorf(
 				"no actor for outpoint %s", op,
 			))
@@ -693,6 +704,38 @@ func (m *Manager) handleCompleteSpend(ctx context.Context,
 	return fn.Ok[ManagerResp](&CompleteSpendResponse{
 		CompletedCount: completed,
 	})
+}
+
+// isPersistedSpent returns true when an actor was already cleaned up after
+// the spend status reached durable storage. It returns false with no error
+// when the VTXO is absent, and returns an error when the store cannot give a
+// definitive answer.
+//
+// This makes CompleteSpend idempotent across crashes that happen after the
+// VTXO status commit but before the OOR session checkpoints Completed.
+func (m *Manager) isPersistedSpent(ctx context.Context,
+	op wire.OutPoint) (bool, error) {
+
+	if m.cfg.Store == nil {
+		return false, nil
+	}
+
+	desc, err := m.cfg.Store.GetVTXO(ctx, op)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf(
+			"load vtxo for spent check %s: %w", op, err,
+		)
+	}
+
+	if desc == nil {
+		return false, nil
+	}
+
+	return desc.Status == VTXOStatusSpent, nil
 }
 
 // =============================================================================

--- a/vtxo/manager_admission_test.go
+++ b/vtxo/manager_admission_test.go
@@ -2,6 +2,8 @@ package vtxo
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -345,6 +347,79 @@ func TestCompleteSpend(t *testing.T) {
 
 	_, ok = ref.state.(*SpentState)
 	require.True(t, ok, "expected SpentState, got %T", ref.state)
+}
+
+// TestCompleteSpendAlreadyPersistedSpentIsIdempotent verifies the resume case
+// where a previous CompleteSpend call durably wrote VTXOStatusSpent, the VTXO
+// actor was cleaned up, and the OOR actor retries MarkInputsSpent before it has
+// checkpointed Completed.
+func TestCompleteSpendAlreadyPersistedSpentIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	vtxo := makeDescriptor(t, 50000, 0)
+	vtxo.Status = VTXOStatusSpent
+
+	mgr, store := newTestManager(t, nil)
+	store.On(
+		"GetVTXO", t.Context(), vtxo.Outpoint,
+	).Return(vtxo, nil).Once()
+
+	result := mgr.Receive(t.Context(), &CompleteSpendRequest{
+		Outpoints: []wire.OutPoint{vtxo.Outpoint},
+	})
+	resp, err := result.Unpack()
+	require.NoError(t, err)
+
+	completeResp, ok := resp.(*CompleteSpendResponse)
+	require.True(t, ok, "expected *CompleteSpendResponse")
+	require.Equal(t, 1, completeResp.CompletedCount)
+
+	store.AssertExpectations(t)
+}
+
+// TestCompleteSpendMissingPersistedVTXOReturnsNoActor verifies that a missing
+// persisted VTXO remains a normal unknown-outpoint error.
+func TestCompleteSpendMissingPersistedVTXOReturnsNoActor(t *testing.T) {
+	t.Parallel()
+
+	unknownOP := wire.OutPoint{Index: 99}
+
+	mgr, store := newTestManager(t, nil)
+	store.On(
+		"GetVTXO", t.Context(), unknownOP,
+	).Return(nil, sql.ErrNoRows).Once()
+
+	result := mgr.Receive(t.Context(), &CompleteSpendRequest{
+		Outpoints: []wire.OutPoint{unknownOP},
+	})
+	_, err := result.Unpack()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no actor for outpoint")
+
+	store.AssertExpectations(t)
+}
+
+// TestCompleteSpendPersistedSpentCheckError verifies that transient lookup
+// errors are surfaced instead of being reported as a missing actor.
+func TestCompleteSpendPersistedSpentCheckError(t *testing.T) {
+	t.Parallel()
+
+	unknownOP := wire.OutPoint{Index: 99}
+	storeErr := errors.New("temporary db outage")
+
+	mgr, store := newTestManager(t, nil)
+	store.On(
+		"GetVTXO", t.Context(), unknownOP,
+	).Return(nil, storeErr).Once()
+
+	result := mgr.Receive(t.Context(), &CompleteSpendRequest{
+		Outpoints: []wire.OutPoint{unknownOP},
+	})
+	_, err := result.Unpack()
+	require.ErrorIs(t, err, storeErr)
+	require.Contains(t, err.Error(), "load vtxo for spent check")
+
+	store.AssertExpectations(t)
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- wait for the VTXO manager to report `CompleteSpend` success before OOR emits `InputsMarkedSpentEvent`
- preserve caller transaction context across regular actor `Ask` handling so durable actor work can remain in one DB tx
- make VTXO actor status persistence errors fail the actor request before publishing the in-memory transition
- make retried `CompleteSpend` idempotent when the DB already contains `VTXOStatusSpent`
- distinguish real VTXO lookup failures from `sql.ErrNoRows` when filtering non-local OOR inputs and persisted-spent checks

## Root Cause

OOR could checkpoint `Completed` after the `CompleteSpendRequest` was accepted into the VTXO manager mailbox, before the consumed local VTXOs were durably marked spent. If the process stopped in that window, OOR would resume as completed while the VTXO row remained live or spending.

The first CI pass also exposed that waiting for manager completion must keep the durable actor's DB transaction across the manager/VTXO `Ask` chain. Otherwise the spent-status write can open a competing transaction while the OOR durable actor is still waiting inside its own transaction.

## Review Follow-up

- address Gemini/Claude feedback by making `isPersistedSpent` return `(bool, error)` and propagate real DB lookup failures instead of reporting them as missing actors
- document the VTXO outbox ordering guarantee that status persistence happens before notifications

## Validation

- `go test ./vtxo -run 'TestCompleteSpendAlreadyPersistedSpentIsIdempotent|TestCompleteSpendMissingPersistedVTXOReturnsNoActor|TestCompleteSpendPersistedSpentCheckError|TestCompleteSpend|TestReceiveStatusUpdateFailurePreservesStateForRetry|TestProcessOutbox' -count=1`
- `go test ./baselib/actor ./oor ./vtxo ./darepod -count=1`
- `make lint-source`
- `git diff --check`

Refs lightninglabs/darepo#281