### PR TITLE
docs: nightly doc-gardening sweep 2026-04-27

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -53,6 +53,7 @@ package may import from a higher layer.
 |---------|---------|
 | [`darepod`](darepod/) | Daemon orchestrator: wires all subsystems, exposes gRPC API |
 | [`sdk/ark`](sdk/ark/) | Consumer-facing Go SDK facade: remote or embedded daemon access with typed models |
+| [`sdk/swaps`](sdk/swaps/) | Atomic swap SDK for Lightning-to-Ark and Ark-to-Lightning transfers via vHTLC channels |
 | [`cmd/darepod`](cmd/darepod/) | Daemon entry point |
 | [`cmd/darepocli`](cmd/darepocli/) | CLI client |
 | [`timeout`](timeout/) | Generic timeout scheduling actor |

--- a/baselib/actor/AGENTS.md
+++ b/baselib/actor/AGENTS.md
@@ -42,6 +42,11 @@ crash-safe at-least-once delivery with exactly-once deduplication.
 - `ServiceKey` lookup via `Receptionist` is type-safe: mismatched types return `ErrServiceKeyTypeMismatch`.
 - `RestartMessage` has `RestartPriority` (MaxInt32) ensuring it is processed before all other messages on recovery.
 - Transaction context (`WithTx`/`RequireTx`) enables same-DB-transaction joining between actors and their callers.
+- `mergeContexts` (used internally for Ask message processing) always uses the
+  caller's context (ctx2) as the base so request-scoped values — including DB
+  transaction keys injected by `WithTx` — are visible to the behavior during
+  processing. The shortest deadline from either context is applied on top via
+  `context.WithDeadline`; the merged cancel propagates both parent cancellations.
 
 ## Deep Docs
 

--- a/baselib/actor/CLAUDE.md
+++ b/baselib/actor/CLAUDE.md
@@ -42,6 +42,11 @@ crash-safe at-least-once delivery with exactly-once deduplication.
 - `ServiceKey` lookup via `Receptionist` is type-safe: mismatched types return `ErrServiceKeyTypeMismatch`.
 - `RestartMessage` has `RestartPriority` (MaxInt32) ensuring it is processed before all other messages on recovery.
 - Transaction context (`WithTx`/`RequireTx`) enables same-DB-transaction joining between actors and their callers.
+- `mergeContexts` (used internally for Ask message processing) always uses the
+  caller's context (ctx2) as the base so request-scoped values — including DB
+  transaction keys injected by `WithTx` — are visible to the behavior during
+  processing. The shortest deadline from either context is applied on top via
+  `context.WithDeadline`; the merged cancel propagates both parent cancellations.
 
 ## Deep Docs
 

--- a/cmd/darepocli/darepoclicommands/AGENTS.md
+++ b/cmd/darepocli/darepoclicommands/AGENTS.md
@@ -23,14 +23,24 @@ embed the same command tree.
 | `send` | `SendVTXO` / `SendOOR` | Send to address |
 | `balance` | `GetBalance` | Show wallet balances |
 | `oor receive` | `NewOORReceiveScript` | Register a new OOR receive script and print the receive address |
-| `fees estimate` | `EstimateFee` | Print an itemized fee breakdown for a given VTXO amount; flags a dust-level amount on stderr |
+| `fees estimate` | `EstimateFee` | Print an advisory fee estimate for a given VTXO amount; the binding fee is set by the server-issued `JoinRoundQuote` at seal time |
 | `fees history` | `GetFeeHistory` | Paginate the client-side ledger entries and print the cumulative operator fee total |
 | `unroll` | `Unroll` | Trigger a unilateral exit for the VTXO at `--outpoint txid:index`. Routes through the VTXO manager's `ForceUnrollRequest` path so the FSM transitions cleanly; the registry job is created async via the chain resolver seam. Response includes `Created` (false if already exiting) and the `ActorId` to poll. |
 | `unroll status` | `GetUnrollStatus` | Query progress for an unroll job by `--outpoint`. Reads through to the live registry first and falls back to the persisted `unilateral_exit_jobs` table for evicted/terminal jobs; `Found=false` (not an error) distinguishes "no such job" from lookup failure. |
+| `swap list` | (store-only) | List persisted Lightning swap sessions from the isolated `swaps.db`. `--pending` filters to resumable sessions; `--verbose` includes terminal reason and OOR session IDs. |
+| `swap receive` | `sdk/swaps` | Create a Lightning invoice that deposits into Ark as a VTXO. Blocks until the vHTLC is funded and claimed. Requires `--amount` (sats). |
+| `swap pay` | `sdk/swaps` | Pay a Lightning invoice from Ark VTXOs via vHTLC. Blocks until the payment completes or the session times out. Requires `--invoice`. |
+| `swap resume` | `sdk/swaps` | Resume a persisted pay or receive session by payment hash. Detects direction from the store when `--direction` is omitted. |
+
+The `swap` command group reads from and writes to an isolated SQLite database
+(`--swapdb`, default `~/.darepod/swaps.db`) that is separate from the main
+daemon database. All swap subcommands connect to both the Ark daemon
+(`--rpcserver`) and the swap server (`--swapserver`).
 
 ## Relationships
 
-- **Depends on**: `daemonrpc` (generated gRPC client stubs).
+- **Depends on**: `daemonrpc` (generated gRPC client stubs), `sdk/swaps`
+  (swap client), `sdk/ark` (daemon connection adapter).
 - **Depended on by**: `cmd/darepocli` (main entry point).
 
 ## Deep Docs

--- a/cmd/darepocli/darepoclicommands/CLAUDE.md
+++ b/cmd/darepocli/darepoclicommands/CLAUDE.md
@@ -23,14 +23,24 @@ embed the same command tree.
 | `send` | `SendVTXO` / `SendOOR` | Send to address |
 | `balance` | `GetBalance` | Show wallet balances |
 | `oor receive` | `NewOORReceiveScript` | Register a new OOR receive script and print the receive address |
-| `fees estimate` | `EstimateFee` | Print an itemized fee breakdown for a given VTXO amount; flags a dust-level amount on stderr |
+| `fees estimate` | `EstimateFee` | Print an advisory fee estimate for a given VTXO amount; the binding fee is set by the server-issued `JoinRoundQuote` at seal time |
 | `fees history` | `GetFeeHistory` | Paginate the client-side ledger entries and print the cumulative operator fee total |
 | `unroll` | `Unroll` | Trigger a unilateral exit for the VTXO at `--outpoint txid:index`. Routes through the VTXO manager's `ForceUnrollRequest` path so the FSM transitions cleanly; the registry job is created async via the chain resolver seam. Response includes `Created` (false if already exiting) and the `ActorId` to poll. |
 | `unroll status` | `GetUnrollStatus` | Query progress for an unroll job by `--outpoint`. Reads through to the live registry first and falls back to the persisted `unilateral_exit_jobs` table for evicted/terminal jobs; `Found=false` (not an error) distinguishes "no such job" from lookup failure. |
+| `swap list` | (store-only) | List persisted Lightning swap sessions from the isolated `swaps.db`. `--pending` filters to resumable sessions; `--verbose` includes terminal reason and OOR session IDs. |
+| `swap receive` | `sdk/swaps` | Create a Lightning invoice that deposits into Ark as a VTXO. Blocks until the vHTLC is funded and claimed. Requires `--amount` (sats). |
+| `swap pay` | `sdk/swaps` | Pay a Lightning invoice from Ark VTXOs via vHTLC. Blocks until the payment completes or the session times out. Requires `--invoice`. |
+| `swap resume` | `sdk/swaps` | Resume a persisted pay or receive session by payment hash. Detects direction from the store when `--direction` is omitted. |
+
+The `swap` command group reads from and writes to an isolated SQLite database
+(`--swapdb`, default `~/.darepod/swaps.db`) that is separate from the main
+daemon database. All swap subcommands connect to both the Ark daemon
+(`--rpcserver`) and the swap server (`--swapserver`).
 
 ## Relationships
 
-- **Depends on**: `daemonrpc` (generated gRPC client stubs).
+- **Depends on**: `daemonrpc` (generated gRPC client stubs), `sdk/swaps`
+  (swap client), `sdk/ark` (daemon connection adapter).
 - **Depended on by**: `cmd/darepocli` (main entry point).
 
 ## Deep Docs

--- a/darepod/AGENTS.md
+++ b/darepod/AGENTS.md
@@ -27,7 +27,16 @@ gRPC API.
 - `resolveRecipientOutput` — Extracts pkScript and client pubkey from an `Output` proto oneof (pubkey or address). Enforces taproot-only for directed sends.
 - `registerIncomingVTXOEventRoute` — Registers the `arkrpc.IncomingVTXOEvent` mailbox route under `MethodIncomingVTXO`, dispatching decoded events to the incoming VTXO handler actor via its service key.
 - `initLedgerActor` — Constructs `ledger.LedgerActor` with both `db.NewLedgerStoreDB` (double-entry ledger) and `db.NewUTXOAuditStoreDB` (UTXO audit log) as stores, starts it, registers it with the actor system under `ledger.ServiceKeyName`, and stashes the `LedgerStoreDB` on the `Server` as `s.ledgerStore` so the RPC layer can read paginated history without going through the actor mailbox. Called in `run` after the DB and delivery store are ready but before wallet unlock, since the actor does not depend on wallet state.
-- `EstimateFee` — RPC handler that proxies to the operator's `EstimateFee` over the direct gRPC connection (`s.serverConn`, reused from `fetchOperatorTerms`). No local caching: the operator's reply reflects live treasury utilization, so callers always see fresh numbers.
+- `LeaveVTXOs` — RPC handler for cooperative leave (offboard). Parses an
+  outpoint selection (`all` or explicit list) plus optional per-outpoint
+  destination overrides (`req.Destinations` map). Under the #270 seal-time fee
+  handshake the server stamps the residual (`Σin − Σ(fixed) − fee`) onto the
+  wallet's `IsChange=true` leave output at seal time, so no per-VTXO fee
+  quoting is performed here. Strict argument validation: `selection=all` cannot
+  combine with per-outpoint overrides; every key in `Destinations` must appear
+  in the selection (fails with `InvalidArgument` on a stray outpoint to catch
+  typos before funds move).
+- `EstimateFee` — RPC handler that proxies to the operator's `EstimateFee` over the direct gRPC connection (`s.serverConn`, reused from `fetchOperatorTerms`). No local caching: the operator's reply reflects live treasury utilization, so callers always see fresh numbers. The value is advisory under #270; the binding fee is set by the server-issued `JoinRoundQuote` at seal time.
 - `GetFeeHistory` — RPC handler that reads through `s.ledgerStore.ListLedgerEntriesWithFeesTotal` for mutual consistency between the page and the cumulative operator-fees-paid total. Validates limit/offset bounds (offset clamped to `math.MaxInt32`) and converts sqlc rows to proto `FeeHistoryEntry` with debit/credit accounts, round_id, session_id, and event_type verbatim via `ledgerEntryToProto`.
 - `proxyUpstreamError(err, msg) error` — gRPC-safety helper that extracts the upstream gRPC status, preserves the code, and returns a new status carrying a generic RPC-scoped message. Errors without a status map to `codes.Unavailable` so clients can retry. Used by `EstimateFee` and `GetFeeHistory` to avoid collapsing codes to `Unknown` and leaking operator-side error text across the daemon→client boundary.
 - `deriveIdentityKeyEarly` — Derives the client's secp256k1 identity key from LND or lwwallet before mailbox transport starts. Propagates wallet-specific errors on failure.
@@ -61,6 +70,12 @@ gRPC API.
 - Board RPC is non-blocking: delegates to wallet actor and returns immediately.
 - `SendVTXO` enforces a hard recipient cap (`maxRecipients = 256`, see TODO #241), rejects per-recipient amounts outside `(0, MaxSatoshi]`, and uses overflow-safe accumulation when summing recipient amounts. Wallet-side validation (`handleSendVTXOs`) repeats these checks as a defense-in-depth boundary.
 - `SendOOR` with custom inputs uses `reserveCustomInputs` to serialize concurrent calls on the same outpoints. Custom inputs are locked for the RPC lifetime; the lock is released via deferred release on both success and failure paths. Standard wallet-managed VTXOs are separately locked via the VTXO manager's reservation flow.
+- `completeSpend` (wired into `oor.LocalPersistenceOutboxHandler`) uses `Ask`
+  on the VTXO manager (not `Tell`) so OOR only checkpoints `Completed` after
+  the manager has durably persisted the `SpentState` transition. This preserves
+  the durable ordering required by OOR resume: if the VTXO persistence fails,
+  the OOR actor sees an error and retries rather than advancing to `Completed`
+  with an unacknowledged spend.
 - `BuildCustomTransferInputs` validates that (a) the caller-supplied policy template compiles to the provided pkScript (via `PolicyTemplate.MatchesPkScript`), and (b) the spend path's control block commits to the same pkScript (via `SpendPath.VerifyBindsToPkScript`). Together these prevent a caller from obtaining signatures for an unrelated tapscript by claiming a different output's policy template.
 - ListRounds splits pending (in-memory from actor) and persisted (SQL with cursor pagination) rounds.
 - Server holds a `roundStore` reference for direct SQL queries from the RPC layer.

--- a/darepod/CLAUDE.md
+++ b/darepod/CLAUDE.md
@@ -27,7 +27,16 @@ gRPC API.
 - `resolveRecipientOutput` — Extracts pkScript and client pubkey from an `Output` proto oneof (pubkey or address). Enforces taproot-only for directed sends.
 - `registerIncomingVTXOEventRoute` — Registers the `arkrpc.IncomingVTXOEvent` mailbox route under `MethodIncomingVTXO`, dispatching decoded events to the incoming VTXO handler actor via its service key.
 - `initLedgerActor` — Constructs `ledger.LedgerActor` with both `db.NewLedgerStoreDB` (double-entry ledger) and `db.NewUTXOAuditStoreDB` (UTXO audit log) as stores, starts it, registers it with the actor system under `ledger.ServiceKeyName`, and stashes the `LedgerStoreDB` on the `Server` as `s.ledgerStore` so the RPC layer can read paginated history without going through the actor mailbox. Called in `run` after the DB and delivery store are ready but before wallet unlock, since the actor does not depend on wallet state.
-- `EstimateFee` — RPC handler that proxies to the operator's `EstimateFee` over the direct gRPC connection (`s.serverConn`, reused from `fetchOperatorTerms`). No local caching: the operator's reply reflects live treasury utilization, so callers always see fresh numbers.
+- `LeaveVTXOs` — RPC handler for cooperative leave (offboard). Parses an
+  outpoint selection (`all` or explicit list) plus optional per-outpoint
+  destination overrides (`req.Destinations` map). Under the #270 seal-time fee
+  handshake the server stamps the residual (`Σin − Σ(fixed) − fee`) onto the
+  wallet's `IsChange=true` leave output at seal time, so no per-VTXO fee
+  quoting is performed here. Strict argument validation: `selection=all` cannot
+  combine with per-outpoint overrides; every key in `Destinations` must appear
+  in the selection (fails with `InvalidArgument` on a stray outpoint to catch
+  typos before funds move).
+- `EstimateFee` — RPC handler that proxies to the operator's `EstimateFee` over the direct gRPC connection (`s.serverConn`, reused from `fetchOperatorTerms`). No local caching: the operator's reply reflects live treasury utilization, so callers always see fresh numbers. The value is advisory under #270; the binding fee is set by the server-issued `JoinRoundQuote` at seal time.
 - `GetFeeHistory` — RPC handler that reads through `s.ledgerStore.ListLedgerEntriesWithFeesTotal` for mutual consistency between the page and the cumulative operator-fees-paid total. Validates limit/offset bounds (offset clamped to `math.MaxInt32`) and converts sqlc rows to proto `FeeHistoryEntry` with debit/credit accounts, round_id, session_id, and event_type verbatim via `ledgerEntryToProto`.
 - `proxyUpstreamError(err, msg) error` — gRPC-safety helper that extracts the upstream gRPC status, preserves the code, and returns a new status carrying a generic RPC-scoped message. Errors without a status map to `codes.Unavailable` so clients can retry. Used by `EstimateFee` and `GetFeeHistory` to avoid collapsing codes to `Unknown` and leaking operator-side error text across the daemon→client boundary.
 - `deriveIdentityKeyEarly` — Derives the client's secp256k1 identity key from LND or lwwallet before mailbox transport starts. Propagates wallet-specific errors on failure.
@@ -61,6 +70,12 @@ gRPC API.
 - Board RPC is non-blocking: delegates to wallet actor and returns immediately.
 - `SendVTXO` enforces a hard recipient cap (`maxRecipients = 256`, see TODO #241), rejects per-recipient amounts outside `(0, MaxSatoshi]`, and uses overflow-safe accumulation when summing recipient amounts. Wallet-side validation (`handleSendVTXOs`) repeats these checks as a defense-in-depth boundary.
 - `SendOOR` with custom inputs uses `reserveCustomInputs` to serialize concurrent calls on the same outpoints. Custom inputs are locked for the RPC lifetime; the lock is released via deferred release on both success and failure paths. Standard wallet-managed VTXOs are separately locked via the VTXO manager's reservation flow.
+- `completeSpend` (wired into `oor.LocalPersistenceOutboxHandler`) uses `Ask`
+  on the VTXO manager (not `Tell`) so OOR only checkpoints `Completed` after
+  the manager has durably persisted the `SpentState` transition. This preserves
+  the durable ordering required by OOR resume: if the VTXO persistence fails,
+  the OOR actor sees an error and retries rather than advancing to `Completed`
+  with an unacknowledged spend.
 - `BuildCustomTransferInputs` validates that (a) the caller-supplied policy template compiles to the provided pkScript (via `PolicyTemplate.MatchesPkScript`), and (b) the spend path's control block commits to the same pkScript (via `SpendPath.VerifyBindsToPkScript`). Together these prevent a caller from obtaining signatures for an unrelated tapscript by claiming a different output's policy template.
 - ListRounds splits pending (in-memory from actor) and persisted (SQL with cursor pagination) rounds.
 - Server holds a `roundStore` reference for direct SQL queries from the RPC layer.

--- a/harness/AGENTS.md
+++ b/harness/AGENTS.md
@@ -20,4 +20,7 @@ containers with network isolation for end-to-end testing.
 ## Key Constants
 
 - `numInitialBlocks` = 106, `defaultTimeout` = 30s, `pollInterval` = 200ms.
+- `electrsReadyTimeout` = 2 min — longer window for the electrs container's
+  Esplora HTTP endpoint because CI layer-cache races occasionally push startup
+  past `defaultTimeout`.
 - Coinbase maturity: 100 blocks + 6-block buffer.

--- a/harness/CLAUDE.md
+++ b/harness/CLAUDE.md
@@ -20,4 +20,7 @@ containers with network isolation for end-to-end testing.
 ## Key Constants
 
 - `numInitialBlocks` = 106, `defaultTimeout` = 30s, `pollInterval` = 200ms.
+- `electrsReadyTimeout` = 2 min — longer window for the electrs container's
+  Esplora HTTP endpoint because CI layer-cache races occasionally push startup
+  past `defaultTimeout`.
 - Coinbase maturity: 100 blocks + 6-block buffer.

--- a/lib/types/AGENTS.md
+++ b/lib/types/AGENTS.md
@@ -10,9 +10,19 @@ server during round participation. These types are used across `round`, `vtxo`,
 
 - `JoinRoundRequest` — Client's round registration request: boarding inputs, VTXO requests, forfeit requests, leave requests.
 - `JoinRoundAuth` — Authentication data for round join (Schnorr signature proof-of-control).
-- `VTXORequest` — Describes a new VTXO to create in a round (amount, owner key, cosigner keys).
+- `VTXORequest` — Describes a new VTXO to create in a round (amount, owner
+  key, cosigner keys). `IsChange bool` marks the request as the intent's
+  designated fee-bearing change output under the #270 seal-time fee handshake;
+  the server computes the residual (`Σin − Σ(fixed) − fee`) for this output at
+  seal time and returns it in the `JoinRoundQuote`. Serialized in the TLV
+  join-round auth as record type 4 (uint8 flag).
 - `ForfeitRequest` — Describes a VTXO being forfeited (outpoint, connector leaf info, forfeit tx signature).
-- `LeaveRequest` — Describes a cooperative exit (VTXO outpoint, destination address).
+- `LeaveRequest` — Describes a cooperative exit (VTXO outpoint, destination
+  address). `IsChange bool` marks the leave output as the fee-bearing change
+  slot analogously to `VTXORequest.IsChange`. Serialized in TLV join-round
+  auth as record type 3 (uint8 flag). `Output.Value` is the client's target
+  amount; when `IsChange=true` the server overrides it with the residual at
+  seal time.
 - `BoardingRequest` — Describes a boarding input (outpoint, amount, script).
 - `OperatorTerms` — Server-published round parameters (fee rates, expiry config, connector dust amount).
 - `ClientBatchInfo` — Client's view of batch output info after tree construction.
@@ -35,6 +45,9 @@ server during round participation. These types are used across `round`, `vtxo`,
 
 - `VTXOOwnerKeyFamily` (44) is the HD key family used for deriving VTXO owner signing keys.
 - `JoinRoundAuthMessage` produces a deterministic byte encoding for Schnorr signature verification.
+- Exactly one output across `VTXORequests + LeaveRequests` in an intent may
+  have `IsChange=true`; having zero or more than one is a protocol violation
+  that the server will reject at seal time.
 
 ## Deep Docs
 

--- a/lib/types/CLAUDE.md
+++ b/lib/types/CLAUDE.md
@@ -10,9 +10,19 @@ server during round participation. These types are used across `round`, `vtxo`,
 
 - `JoinRoundRequest` — Client's round registration request: boarding inputs, VTXO requests, forfeit requests, leave requests.
 - `JoinRoundAuth` — Authentication data for round join (Schnorr signature proof-of-control).
-- `VTXORequest` — Describes a new VTXO to create in a round (amount, owner key, cosigner keys).
+- `VTXORequest` — Describes a new VTXO to create in a round (amount, owner
+  key, cosigner keys). `IsChange bool` marks the request as the intent's
+  designated fee-bearing change output under the #270 seal-time fee handshake;
+  the server computes the residual (`Σin − Σ(fixed) − fee`) for this output at
+  seal time and returns it in the `JoinRoundQuote`. Serialized in the TLV
+  join-round auth as record type 4 (uint8 flag).
 - `ForfeitRequest` — Describes a VTXO being forfeited (outpoint, connector leaf info, forfeit tx signature).
-- `LeaveRequest` — Describes a cooperative exit (VTXO outpoint, destination address).
+- `LeaveRequest` — Describes a cooperative exit (VTXO outpoint, destination
+  address). `IsChange bool` marks the leave output as the fee-bearing change
+  slot analogously to `VTXORequest.IsChange`. Serialized in TLV join-round
+  auth as record type 3 (uint8 flag). `Output.Value` is the client's target
+  amount; when `IsChange=true` the server overrides it with the residual at
+  seal time.
 - `BoardingRequest` — Describes a boarding input (outpoint, amount, script).
 - `OperatorTerms` — Server-published round parameters (fee rates, expiry config, connector dust amount).
 - `ClientBatchInfo` — Client's view of batch output info after tree construction.
@@ -35,6 +45,9 @@ server during round participation. These types are used across `round`, `vtxo`,
 
 - `VTXOOwnerKeyFamily` (44) is the HD key family used for deriving VTXO owner signing keys.
 - `JoinRoundAuthMessage` produces a deterministic byte encoding for Schnorr signature verification.
+- Exactly one output across `VTXORequests + LeaveRequests` in an intent may
+  have `IsChange=true`; having zero or more than one is a protocol violation
+  that the server will reject at seal time.
 
 ## Deep Docs
 

--- a/oor/AGENTS.md
+++ b/oor/AGENTS.md
@@ -75,6 +75,12 @@ resume semantics.
 
 ### Shared Adapters and Metadata Types
 
+- `TransferInputSnapshot.RequiredSequence` / `TransferInputSnapshot.RequiredLockTime`
+  — Persisted nSequence and nLockTime values required by a custom spend path
+  (e.g. vHTLC refunds using CLTV-gated leaves). Both survive TLV snapshot
+  round-trips so resumed custom OOR spends rebuild byte-identical checkpoint
+  and Ark transactions. Encoded as TLV types 15 and 16 respectively; omitted
+  (zero) for standard spend paths.
 - `IncomingVTXOMetadata` — Lineage metadata for incoming OOR VTXOs including `ChainDepth` (OOR checkpoint hop count).
 - `IncomingMetadataMatch` — Authoritative metadata for one materialized
   incoming Ark output, keyed by OutputIndex.

--- a/oor/CLAUDE.md
+++ b/oor/CLAUDE.md
@@ -75,6 +75,12 @@ resume semantics.
 
 ### Shared Adapters and Metadata Types
 
+- `TransferInputSnapshot.RequiredSequence` / `TransferInputSnapshot.RequiredLockTime`
+  — Persisted nSequence and nLockTime values required by a custom spend path
+  (e.g. vHTLC refunds using CLTV-gated leaves). Both survive TLV snapshot
+  round-trips so resumed custom OOR spends rebuild byte-identical checkpoint
+  and Ark transactions. Encoded as TLV types 15 and 16 respectively; omitted
+  (zero) for standard spend paths.
 - `IncomingVTXOMetadata` — Lineage metadata for incoming OOR VTXOs including `ChainDepth` (OOR checkpoint hop count).
 - `IncomingMetadataMatch` — Authoritative metadata for one materialized
   incoming Ark output, keyed by OutputIndex.

--- a/round/AGENTS.md
+++ b/round/AGENTS.md
@@ -15,10 +15,26 @@ protocols with MuSig2 signing ceremonies.
 - `IntentSentState` — State entered after `IntentRequested` (out of `PendingRoundAssembly`). Holds the client's `Intents` and an `AdmittedRoundID RoundID` field that is zero until the server's `RoundJoined` admission ack lands. `RoundJoined` is consumed as a watermark only — the actor layer re-keys the FSM from the ephemeral temp key to the server-assigned `RoundID`, but the FSM stays parked in `IntentSentState` (with `AdmittedRoundID` populated) until the seal-time `JoinRoundQuoteReceived` arrives. The quote handler cross-checks `evt.RoundID` against `s.AdmittedRoundID` and fails the FSM via `failWithNotification` if (a) `AdmittedRoundID` is still zero (quote arrived before admission) or (b) the IDs differ (server-routing or trust violation).
 - `QuoteReceivedState` — State entered on `JoinRoundQuoteReceived` between `IntentSentState` and `RoundJoinedState`. Carries `RoundID`, the `*ClientQuote`, and the cloned `Intents`. `evaluateQuote` compares the quoted `OperatorFeeSat` against `env.MaxOperatorFee`, requires `RejectReason == QuoteReason_QUOTE_OK`, validates the per-output echoes (pkScript, recipient key, non-change amount) against the intent, and rejects expired quotes (`QuoteExpiresAt`). On accept it emits `JoinRoundAcceptOutbox` (echoing `quote_id`) and advances to `RoundJoinedState`; on reject (cap exceeded, expired, or server-side non-OK reason) it emits `JoinRoundRejectOutbox` and transitions to `ClientFailedState`. A `JoinRoundQuoteReceived` arriving here with a strictly higher `SealPass` replaces the in-state quote and re-evaluates; lower-or-equal `SealPass` deliveries self-loop as stale redeliveries.
 - `RoundJoinedState` — State entered after `QuoteAccepted`. Carries the assigned `RoundID`, the cloned `Intents` (with the quote's leave amounts captured onto `Intents.QuotedLeaveAmounts` for downstream fee accounting), and the accepted `*ClientQuote`. Waits for `CommitmentTxBuilt`, which is asserted to carry `evt.RoundID == s.RoundID` (a mismatch fails the FSM with "commitment round_id mismatch"). A `JoinRoundQuoteReceived` arriving here with a strictly higher `SealPass` is treated as a server reseal-after-accept: the FSM walks back to `QuoteReceivedState` for re-evaluation (the in-flight accept's older `quote_id` is dropped server-side); the new quote's `RoundID` must still match `s.RoundID`. Lower-or-equal `SealPass` deliveries self-loop as stale.
-- `ClientEnvironment` — FSM environment providing storage access (boarding intents, round checkpoints, VTXO store).
+- `ClientEnvironment` — FSM environment providing storage access (boarding
+  intents, round checkpoints, VTXO store). Key fields: `MaxOperatorFee`
+  (per-round fee cap, must be positive — zero fails closed); `Now func() time.Time`
+  (injectable clock used by `evaluateQuote` to check `QuoteExpiresAt`, falls
+  back to `time.Now()` when nil so existing callers need no change).
+- `QuoteAccepted` — Internal FSM event fired by `QuoteReceivedState` after the
+  fee-cap check passes; drives the transition to `RoundJoinedState` with
+  `JoinRoundAcceptOutbox` on the outbox. Carries `RoundID` and `QuoteID`.
+- `QuoteRejected` — Internal FSM event fired by `QuoteReceivedState` when the
+  fee cap is exceeded or the server's `reject_reason` is non-OK; drives
+  transition to `ClientFailedState` with `JoinRoundRejectOutbox`. Carries
+  `RoundID`, `QuoteID`, and human-readable `Reason`.
 - `ClientWallet` — Interface for client wallet operations (embeds `input.Signer` for MuSig2 signing, adds `DeriveNextKey` for VTXO signing keys).
 - `BoardingIntent` — Represents a funded on-chain input to include in a round.
-- `Intents` — Pools of boarding, VTXO, forfeit, and leave requests accumulated before registration.
+- `Intents` — Pools of boarding, VTXO, forfeit, and leave requests accumulated
+  before registration. Carries `QuotedLeaveAmounts []int64`, the server-
+  authoritative leave output amounts (positional, matching `Leaves`) captured
+  at `QuoteAccepted` time. `LeaveAmount(idx int) int64` returns the override
+  when present and falls back to `Leaves[i].Output.Value` for pre-#270 harness
+  paths that bypass the seal-time handshake.
 - `IntentPackage` — FSM event wrapping `Intents` for atomic delivery to the round FSM.
 - `RegisterIntentRequest` — Actor message carrying a pre-composed `IntentPackage` from the wallet.
 - `RefreshVTXORequest` — Per-VTXO refresh registration carrying `Amount`, `VTXO`, `SigningKey`, and `OperatorFee int64`. The `OperatorFee` is quoted by the VTXO actor's `RefreshFeeQuoter` before emission; `buildVTXORequestFromRefresh` subtracts it from the new VTXO output amount and clamps to zero so a buggy quoter cannot produce a negative output.

--- a/round/CLAUDE.md
+++ b/round/CLAUDE.md
@@ -15,10 +15,26 @@ protocols with MuSig2 signing ceremonies.
 - `IntentSentState` — State entered after `IntentRequested` (out of `PendingRoundAssembly`). Holds the client's `Intents` and an `AdmittedRoundID RoundID` field that is zero until the server's `RoundJoined` admission ack lands. `RoundJoined` is consumed as a watermark only — the actor layer re-keys the FSM from the ephemeral temp key to the server-assigned `RoundID`, but the FSM stays parked in `IntentSentState` (with `AdmittedRoundID` populated) until the seal-time `JoinRoundQuoteReceived` arrives. The quote handler cross-checks `evt.RoundID` against `s.AdmittedRoundID` and fails the FSM via `failWithNotification` if (a) `AdmittedRoundID` is still zero (quote arrived before admission) or (b) the IDs differ (server-routing or trust violation).
 - `QuoteReceivedState` — State entered on `JoinRoundQuoteReceived` between `IntentSentState` and `RoundJoinedState`. Carries `RoundID`, the `*ClientQuote`, and the cloned `Intents`. `evaluateQuote` compares the quoted `OperatorFeeSat` against `env.MaxOperatorFee`, requires `RejectReason == QuoteReason_QUOTE_OK`, validates the per-output echoes (pkScript, recipient key, non-change amount) against the intent, and rejects expired quotes (`QuoteExpiresAt`). On accept it emits `JoinRoundAcceptOutbox` (echoing `quote_id`) and advances to `RoundJoinedState`; on reject (cap exceeded, expired, or server-side non-OK reason) it emits `JoinRoundRejectOutbox` and transitions to `ClientFailedState`. A `JoinRoundQuoteReceived` arriving here with a strictly higher `SealPass` replaces the in-state quote and re-evaluates; lower-or-equal `SealPass` deliveries self-loop as stale redeliveries.
 - `RoundJoinedState` — State entered after `QuoteAccepted`. Carries the assigned `RoundID`, the cloned `Intents` (with the quote's leave amounts captured onto `Intents.QuotedLeaveAmounts` for downstream fee accounting), and the accepted `*ClientQuote`. Waits for `CommitmentTxBuilt`, which is asserted to carry `evt.RoundID == s.RoundID` (a mismatch fails the FSM with "commitment round_id mismatch"). A `JoinRoundQuoteReceived` arriving here with a strictly higher `SealPass` is treated as a server reseal-after-accept: the FSM walks back to `QuoteReceivedState` for re-evaluation (the in-flight accept's older `quote_id` is dropped server-side); the new quote's `RoundID` must still match `s.RoundID`. Lower-or-equal `SealPass` deliveries self-loop as stale.
-- `ClientEnvironment` — FSM environment providing storage access (boarding intents, round checkpoints, VTXO store).
+- `ClientEnvironment` — FSM environment providing storage access (boarding
+  intents, round checkpoints, VTXO store). Key fields: `MaxOperatorFee`
+  (per-round fee cap, must be positive — zero fails closed); `Now func() time.Time`
+  (injectable clock used by `evaluateQuote` to check `QuoteExpiresAt`, falls
+  back to `time.Now()` when nil so existing callers need no change).
+- `QuoteAccepted` — Internal FSM event fired by `QuoteReceivedState` after the
+  fee-cap check passes; drives the transition to `RoundJoinedState` with
+  `JoinRoundAcceptOutbox` on the outbox. Carries `RoundID` and `QuoteID`.
+- `QuoteRejected` — Internal FSM event fired by `QuoteReceivedState` when the
+  fee cap is exceeded or the server's `reject_reason` is non-OK; drives
+  transition to `ClientFailedState` with `JoinRoundRejectOutbox`. Carries
+  `RoundID`, `QuoteID`, and human-readable `Reason`.
 - `ClientWallet` — Interface for client wallet operations (embeds `input.Signer` for MuSig2 signing, adds `DeriveNextKey` for VTXO signing keys).
 - `BoardingIntent` — Represents a funded on-chain input to include in a round.
-- `Intents` — Pools of boarding, VTXO, forfeit, and leave requests accumulated before registration.
+- `Intents` — Pools of boarding, VTXO, forfeit, and leave requests accumulated
+  before registration. Carries `QuotedLeaveAmounts []int64`, the server-
+  authoritative leave output amounts (positional, matching `Leaves`) captured
+  at `QuoteAccepted` time. `LeaveAmount(idx int) int64` returns the override
+  when present and falls back to `Leaves[i].Output.Value` for pre-#270 harness
+  paths that bypass the seal-time handshake.
 - `IntentPackage` — FSM event wrapping `Intents` for atomic delivery to the round FSM.
 - `RegisterIntentRequest` — Actor message carrying a pre-composed `IntentPackage` from the wallet.
 - `RefreshVTXORequest` — Per-VTXO refresh registration carrying `Amount`, `VTXO`, `SigningKey`, and `OperatorFee int64`. The `OperatorFee` is quoted by the VTXO actor's `RefreshFeeQuoter` before emission; `buildVTXORequestFromRefresh` subtracts it from the new VTXO output amount and clamps to zero so a buggy quoter cannot produce a negative output.

--- a/sdk/ark/AGENTS.md
+++ b/sdk/ark/AGENTS.md
@@ -29,6 +29,9 @@ without duplicating Ark runtime behavior.
   CheckpointPSBTs) returned by `GetIndexedOORSession` lookups.
 - `CustomOORInput` — Caller-specified OOR input carrying a policy
   template, spend path, and UTXO info for `SendOORWithCustomInputs`.
+- `BlockHeight(ctx) (uint32, error)` — Returns the daemon's best known chain
+  height via `GetInfo`. Satisfies `sdk/swaps.DaemonConn` so `Client` can be
+  used directly as the swap package's daemon adapter.
 - Policy/OOR helpers such as `SendOORWithPolicy`,
   `SendOORWithCustomInputs`, typed indexed VTXO lookups, and typed
   receive-script decoding belong here so higher-level packages do not
@@ -37,8 +40,8 @@ without duplicating Ark runtime behavior.
 ## Relationships
 
 - **Depends on**: `daemonrpc`, `darepod`, gRPC.
-- **Depended on by**: future `sdk/swaps`, Go hosts that want remote or
-  embedded Ark client access.
+- **Depended on by**: `sdk/swaps` (DaemonConn adapter), Go hosts that want
+  remote or embedded Ark client access.
 
 ## Invariants
 

--- a/sdk/ark/CLAUDE.md
+++ b/sdk/ark/CLAUDE.md
@@ -29,6 +29,9 @@ without duplicating Ark runtime behavior.
   CheckpointPSBTs) returned by `GetIndexedOORSession` lookups.
 - `CustomOORInput` — Caller-specified OOR input carrying a policy
   template, spend path, and UTXO info for `SendOORWithCustomInputs`.
+- `BlockHeight(ctx) (uint32, error)` — Returns the daemon's best known chain
+  height via `GetInfo`. Satisfies `sdk/swaps.DaemonConn` so `Client` can be
+  used directly as the swap package's daemon adapter.
 - Policy/OOR helpers such as `SendOORWithPolicy`,
   `SendOORWithCustomInputs`, typed indexed VTXO lookups, and typed
   receive-script decoding belong here so higher-level packages do not
@@ -37,8 +40,8 @@ without duplicating Ark runtime behavior.
 ## Relationships
 
 - **Depends on**: `daemonrpc`, `darepod`, gRPC.
-- **Depended on by**: future `sdk/swaps`, Go hosts that want remote or
-  embedded Ark client access.
+- **Depended on by**: `sdk/swaps` (DaemonConn adapter), Go hosts that want
+  remote or embedded Ark client access.
 
 ## Invariants
 

--- a/sdk/swaps/AGENTS.md
+++ b/sdk/swaps/AGENTS.md
@@ -1,0 +1,193 @@
+# sdk/swaps
+
+## Purpose
+
+Atomic swap SDK for Lightning-to-Ark and Ark-to-Lightning transfers coordinated
+via virtual HTLC (vHTLC) channels. Provides durable per-session FSM-based state
+machines with SQL-backed persistence, resumable cross-chain coordination, and
+deterministic taproot script derivation.
+
+## Key Types
+
+- `SwapClient` — Main public API facade. Wraps `SwapServerConn` (swap server),
+  `DaemonConn` (local Ark daemon), `InvoiceCreator` (Lightning invoices), and
+  `Store` (isolated session persistence). Owns reconciliation FSMs and timeout
+  management for both pay and receive flows. Configurable poll intervals,
+  grace periods, and retry limits. Construct via `NewSwapClient` (full wiring)
+  or `NewSwapClientWithStore` (store-only, for list/inspect without connections).
+
+- `SwapSummary` — Stable list view for persisted swap sessions: Direction
+  (pay/receive), PaymentHash, State, Pending (bool), AmountSat, FeeSat,
+  MaxFeeSat, VHTLCOutpoint, VHTLCAmountSat, FundingSessionID, ClaimSessionID,
+  RefundSessionID, TerminalReason, CreatedAt, UpdatedAt, Deadline,
+  RefundLocktime.
+
+- `PayState` (uint8) — Ark-to-Lightning client-side FSM states:
+  - `PayStateCreated` → `PayStateSwapCreated` → `PayStateFundingInitiated` →
+    `PayStateVHTLCFunded` → `PayStateWaitingForClaim` → `PayStateCompleted`
+    (success path)
+  - `PayStateRefundInitiated` → `PayStateRefunded` (timeout recovery path)
+  - `PayStateExpired`, `PayStateNeedsIntervention`, `PayStateFailed` (terminal
+    error states)
+
+- `ReceiveState` (uint8) — Lightning-to-Ark client-side FSM states:
+  - `ReceiveStateCreated` → `ReceiveStateInvoiceCreated` →
+    `ReceiveStateVHTLCFunded` → `ReceiveStateClaimInitiated` →
+    `ReceiveStateCompleted` (success path)
+  - `ReceiveStateExpired`, `ReceiveStateNeedsIntervention`, `ReceiveStateFailed`
+    (terminal error states)
+
+- `paySession` — Durable per-session state for pay flows: PaymentHash,
+  RequestedAmount, ServerAmount, FeeSat, MaxFeeSat, ServerVHTLCPkScript,
+  ServerClaimScript, ServerUnilateralClaimDelay, ServerRefundLocktime,
+  ClientVHTLCPrivKey, ServerPubKey, InvoiceStr, VHTLCOutpoint,
+  FundingSessionID, FundingResumeAttempts, ClaimPreimage, CurrentPayState,
+  TerminalReason, CreatedAt, UpdatedAt.
+
+- `ReceiveSession` — Durable per-session state for receive flows:
+  PaymentHash, RequestedAmount, FeeSat, Invoice, Preimage, RouteHints,
+  ServerVHTLCPkScript, ServerClaimScript, ServerUnilateralClaimDelay,
+  ServerRefundLocktime, ClientVHTLCPrivKey, ServerPubKey, ExpirySeconds,
+  VHTLCOutpoint, VHTLCAmount, ClaimSessionID, ClaimResumeAttempts,
+  CurrentReceiveState, TerminalReason, CreatedAt, UpdatedAt.
+
+- `SwapServerConn` — Interface for swap server communication:
+  - `RequestChannelID(ctx, vhtlcPubkey, expirySeconds)` →
+    (RouteHint, VHTLCConfig, error)
+  - `CreateInSwap(ctx, invoice, maxFeeSat, clientVhtlcPubkey)` →
+    (InSwapConfig, error)
+  - `Close()` error
+
+- `DaemonConn` — Interface for local Ark daemon wallet/OOR operations
+  (capability boundary for swap FSMs):
+  - `BlockHeight(ctx)` → uint32
+  - `SendOORWithPolicy(ctx, amountSat, recipientPolicyTemplate)` →
+    (sessionID string, error)
+  - `SendOORWithCustomInputs(ctx, recipientPubKey, amountSat, inputs)` →
+    (sessionID string, error)
+  - `IdentityPubKey(ctx)`, `OperatorPubKey(ctx)` → (*btcec.PublicKey, error)
+  - `ListLiveVTXOs(ctx)`, `ListSpentVTXOs(ctx)` → ([]VTXOInfo, error)
+  - `FindLiveVTXOByPkScript(ctx, pkScript)`,
+    `FindSpentVTXOByPkScript(ctx, pkScript)` → (*VTXOInfo, error)
+  - `GetIndexedOORSession(ctx, pkScript, sessionTxID)` →
+    (*IndexedOORSessionInfo, error)
+  - `AllocateOORReceiveScript(ctx, label)` → (*OORReceiveInfo, error)
+
+- `InvoiceCreator` — Interface for Lightning invoice generation:
+  `CreateInvoice(ctx, amountSat, memo, routeHint, expiry, preimage)` →
+  (*invoices.Invoice, Hash, error).
+
+- `VHTLCConfig` — Server-provided vHTLC parameters: RefundLocktime (absolute
+  block height), UnilateralClaimDelay, UnilateralRefundDelay,
+  UnilateralRefundWithoutReceiverDelay (all relative blocks), SwapServerPubkey.
+
+- `InSwapConfig` — Server response for Ark-to-Lightning swap creation:
+  PaymentHash, VHTLCPkScript, ClaimScript, VHTLCAmount, RefundLocktime,
+  ExpirySeconds, SwapServerPubkey.
+
+- `PayResult` — Outcome of successful `PayViaLightning`: PaymentHash, Preimage,
+  FundingSessionID, FeeSat.
+
+- `ReceiveResult` — Outcome of successful `ReceiveViaLightning`: Invoice,
+  Preimage, PaymentHash, VTXOOutpoint, AmountSat.
+
+- `RouteHint` — Lightning route hint for invoices: NodeID, ChannelID,
+  FeeBaseMsat, FeePropPpm, CltvExpiryDelta.
+
+- `Store` — Isolated SQLite-backed persistence for swap sessions. Provides
+  read/write on `paySession` and `ReceiveSession` with TLV-based row
+  serialization. Uses `golang-migrate` for schema versioning.
+  `LatestMigrationVersion = 1`.
+
+- `SqliteStoreConfig` — Configuration for the isolated swap SQLite database:
+  DatabaseFileName (default `"swaps.db"`), SkipMigrations.
+
+- Error sentinels:
+  - `ErrSwapExpired` — Swap deadline elapsed (terminal, no refund available yet)
+  - `ErrSwapRefunded` — Pay swap timed out and refund completed (terminal)
+  - `interventionError` — Anomalous state; wrapped with reason and cause for
+    operator inspection (terminal)
+  - `failureError` — Unrecoverable non-intervention failure (terminal)
+  - `retryableActionError` — External action may have succeeded but durable
+    metadata persistence failed; signals FSM to retry the transition
+
+## Relationships
+
+- **Depends on**: `sdk/ark` (DaemonConn adapter, VTXOInfo, OORReceiveInfo,
+  CustomOORInput, IndexedOORSessionInfo), `lib/arkscript` (policy template ops
+  for vHTLC script derivation), `lnd/lntypes` + `lnd/invoices` (preimage,
+  hash, invoice types), `btcd/btcec/v2` (key ops), database/sql + SQLite
+  (session persistence), `golang-migrate` (schema management).
+- **Depended on by**: `cmd/darepocli/darepoclicommands` (swap CLI commands).
+
+## Sends / Receives
+
+### Pay Flow (Ark → Lightning)
+
+1. **← API**: `PayViaLightning(ctx, routes, amountSat, maxFeeSat)` or
+   `StartPayViaLightning(ctx, …, targetState)` to stop mid-flow.
+2. **→ SwapServerConn**: `RequestChannelID(vhtlcPubkey, expirySeconds)` —
+   get route hint + VHTLCConfig, derive vHTLC pkScript.
+3. **→ SwapServerConn**: `CreateInSwap(invoice, maxFeeSat, pubkey)` →
+   `InSwapConfig`; persisted as `paySession` at `PayStateSwapCreated`.
+4. **→ DaemonConn**: `SendOORWithPolicy(amountSat, vHTLCPolicy)` — OOR session
+   ID persisted at `PayStateFundingInitiated`.
+5. **→ DaemonConn**: `FindLiveVTXOByPkScript(vHTLCPkScript)` — poll until
+   vHTLC indexed (`PayStateVHTLCFunded`).
+6. **→ DaemonConn**: `GetIndexedOORSession(vHTLCPkScript, sessionID)` — poll
+   for server claim spend + preimage (`PayStateWaitingForClaim` →
+   `PayStateCompleted`).
+7. On timeout: `PayStateRefundInitiated` → submit/observe refund spend →
+   `PayStateRefunded` (returns `ErrSwapRefunded`).
+
+### Receive Flow (Lightning → Ark)
+
+1. **← API**: `ReceiveViaLightning(ctx, amountSat, expirySeconds, memo)` or
+   `StartReceiveViaLightning(ctx, …, targetState)`.
+2. **→ SwapServerConn**: `RequestChannelID(vhtlcPubkey, expirySeconds)` — get
+   route hint + VHTLCConfig.
+3. **→ InvoiceCreator**: `CreateInvoice(…, routeHint, expiry, preimage)` —
+   invoice + preimage generated; persisted at `ReceiveStateInvoiceCreated`.
+4. **→ DaemonConn**: `FindLiveVTXOByPkScript(vHTLCPkScript)` — poll until
+   server funds vHTLC (`ReceiveStateVHTLCFunded`).
+5. **→ DaemonConn**: `AllocateOORReceiveScript(label)` + `SendOORWithCustomInputs`
+   — sweep vHTLC with preimage; OOR claim session ID persisted at
+   `ReceiveStateClaimInitiated`.
+6. **→ DaemonConn**: `GetIndexedOORSession(…)` — poll until claim indexed
+   (`ReceiveStateCompleted`).
+
+### Resume / List
+
+- `ResumePayViaLightning(ctx, paymentHash)` / `ResumeReceiveViaLightning` —
+  load session from store, re-enter FSM at last persisted state, reconcile to
+  terminal.
+- `ListSwapSummaries(ctx, pendingOnly)` — scan store, return summarized
+  sessions; usable with a store-only `SwapClient` (no live connections
+  required).
+
+## Invariants
+
+- Swap session state in the SQLite store is the single source of truth;
+  in-memory FSMs are ephemeral and rebuilt from the store on resume.
+- OOR session IDs (FundingSessionID, ClaimSessionID, RefundSessionID) are
+  persisted durably before being passed to external daemon calls. Resume
+  never re-issues the same OOR transfer for the same session.
+- vHTLC script derivation is deterministic from (hash, server pubkey, refund
+  locktime, timelocks) — same inputs always produce the same pkScript.
+- Pay swaps refund only after `VHTLCConfig.RefundLocktime` (absolute block
+  height); `refundLocktimeBuffer` blocks before that deadline is enforced so
+  the client never attempts a funding or refund too close to the window edge.
+- Receive swaps claim with the preimage generated locally at invoice creation
+  time; the preimage is never mutated after `ReceiveStateInvoiceCreated`.
+- Swap deadlines (invoice lifetime, pay swap expiry window) are never extended
+  and gate every state transition that depends on time.
+- Resume operations are idempotent: re-entering a terminal session returns the
+  same terminal result without additional external effects.
+- Error classification (ErrSwapExpired, interventionError, failureError reason)
+  is persisted with the session so the same classification survives restart.
+- `fundingExpiryBuffer` and `refundLocktimeBuffer` ensure the client aborts if
+  the server deadline has less than the safety margin remaining.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/sdk/swaps/CLAUDE.md
+++ b/sdk/swaps/CLAUDE.md
@@ -1,0 +1,193 @@
+# sdk/swaps
+
+## Purpose
+
+Atomic swap SDK for Lightning-to-Ark and Ark-to-Lightning transfers coordinated
+via virtual HTLC (vHTLC) channels. Provides durable per-session FSM-based state
+machines with SQL-backed persistence, resumable cross-chain coordination, and
+deterministic taproot script derivation.
+
+## Key Types
+
+- `SwapClient` — Main public API facade. Wraps `SwapServerConn` (swap server),
+  `DaemonConn` (local Ark daemon), `InvoiceCreator` (Lightning invoices), and
+  `Store` (isolated session persistence). Owns reconciliation FSMs and timeout
+  management for both pay and receive flows. Configurable poll intervals,
+  grace periods, and retry limits. Construct via `NewSwapClient` (full wiring)
+  or `NewSwapClientWithStore` (store-only, for list/inspect without connections).
+
+- `SwapSummary` — Stable list view for persisted swap sessions: Direction
+  (pay/receive), PaymentHash, State, Pending (bool), AmountSat, FeeSat,
+  MaxFeeSat, VHTLCOutpoint, VHTLCAmountSat, FundingSessionID, ClaimSessionID,
+  RefundSessionID, TerminalReason, CreatedAt, UpdatedAt, Deadline,
+  RefundLocktime.
+
+- `PayState` (uint8) — Ark-to-Lightning client-side FSM states:
+  - `PayStateCreated` → `PayStateSwapCreated` → `PayStateFundingInitiated` →
+    `PayStateVHTLCFunded` → `PayStateWaitingForClaim` → `PayStateCompleted`
+    (success path)
+  - `PayStateRefundInitiated` → `PayStateRefunded` (timeout recovery path)
+  - `PayStateExpired`, `PayStateNeedsIntervention`, `PayStateFailed` (terminal
+    error states)
+
+- `ReceiveState` (uint8) — Lightning-to-Ark client-side FSM states:
+  - `ReceiveStateCreated` → `ReceiveStateInvoiceCreated` →
+    `ReceiveStateVHTLCFunded` → `ReceiveStateClaimInitiated` →
+    `ReceiveStateCompleted` (success path)
+  - `ReceiveStateExpired`, `ReceiveStateNeedsIntervention`, `ReceiveStateFailed`
+    (terminal error states)
+
+- `paySession` — Durable per-session state for pay flows: PaymentHash,
+  RequestedAmount, ServerAmount, FeeSat, MaxFeeSat, ServerVHTLCPkScript,
+  ServerClaimScript, ServerUnilateralClaimDelay, ServerRefundLocktime,
+  ClientVHTLCPrivKey, ServerPubKey, InvoiceStr, VHTLCOutpoint,
+  FundingSessionID, FundingResumeAttempts, ClaimPreimage, CurrentPayState,
+  TerminalReason, CreatedAt, UpdatedAt.
+
+- `ReceiveSession` — Durable per-session state for receive flows:
+  PaymentHash, RequestedAmount, FeeSat, Invoice, Preimage, RouteHints,
+  ServerVHTLCPkScript, ServerClaimScript, ServerUnilateralClaimDelay,
+  ServerRefundLocktime, ClientVHTLCPrivKey, ServerPubKey, ExpirySeconds,
+  VHTLCOutpoint, VHTLCAmount, ClaimSessionID, ClaimResumeAttempts,
+  CurrentReceiveState, TerminalReason, CreatedAt, UpdatedAt.
+
+- `SwapServerConn` — Interface for swap server communication:
+  - `RequestChannelID(ctx, vhtlcPubkey, expirySeconds)` →
+    (RouteHint, VHTLCConfig, error)
+  - `CreateInSwap(ctx, invoice, maxFeeSat, clientVhtlcPubkey)` →
+    (InSwapConfig, error)
+  - `Close()` error
+
+- `DaemonConn` — Interface for local Ark daemon wallet/OOR operations
+  (capability boundary for swap FSMs):
+  - `BlockHeight(ctx)` → uint32
+  - `SendOORWithPolicy(ctx, amountSat, recipientPolicyTemplate)` →
+    (sessionID string, error)
+  - `SendOORWithCustomInputs(ctx, recipientPubKey, amountSat, inputs)` →
+    (sessionID string, error)
+  - `IdentityPubKey(ctx)`, `OperatorPubKey(ctx)` → (*btcec.PublicKey, error)
+  - `ListLiveVTXOs(ctx)`, `ListSpentVTXOs(ctx)` → ([]VTXOInfo, error)
+  - `FindLiveVTXOByPkScript(ctx, pkScript)`,
+    `FindSpentVTXOByPkScript(ctx, pkScript)` → (*VTXOInfo, error)
+  - `GetIndexedOORSession(ctx, pkScript, sessionTxID)` →
+    (*IndexedOORSessionInfo, error)
+  - `AllocateOORReceiveScript(ctx, label)` → (*OORReceiveInfo, error)
+
+- `InvoiceCreator` — Interface for Lightning invoice generation:
+  `CreateInvoice(ctx, amountSat, memo, routeHint, expiry, preimage)` →
+  (*invoices.Invoice, Hash, error).
+
+- `VHTLCConfig` — Server-provided vHTLC parameters: RefundLocktime (absolute
+  block height), UnilateralClaimDelay, UnilateralRefundDelay,
+  UnilateralRefundWithoutReceiverDelay (all relative blocks), SwapServerPubkey.
+
+- `InSwapConfig` — Server response for Ark-to-Lightning swap creation:
+  PaymentHash, VHTLCPkScript, ClaimScript, VHTLCAmount, RefundLocktime,
+  ExpirySeconds, SwapServerPubkey.
+
+- `PayResult` — Outcome of successful `PayViaLightning`: PaymentHash, Preimage,
+  FundingSessionID, FeeSat.
+
+- `ReceiveResult` — Outcome of successful `ReceiveViaLightning`: Invoice,
+  Preimage, PaymentHash, VTXOOutpoint, AmountSat.
+
+- `RouteHint` — Lightning route hint for invoices: NodeID, ChannelID,
+  FeeBaseMsat, FeePropPpm, CltvExpiryDelta.
+
+- `Store` — Isolated SQLite-backed persistence for swap sessions. Provides
+  read/write on `paySession` and `ReceiveSession` with TLV-based row
+  serialization. Uses `golang-migrate` for schema versioning.
+  `LatestMigrationVersion = 1`.
+
+- `SqliteStoreConfig` — Configuration for the isolated swap SQLite database:
+  DatabaseFileName (default `"swaps.db"`), SkipMigrations.
+
+- Error sentinels:
+  - `ErrSwapExpired` — Swap deadline elapsed (terminal, no refund available yet)
+  - `ErrSwapRefunded` — Pay swap timed out and refund completed (terminal)
+  - `interventionError` — Anomalous state; wrapped with reason and cause for
+    operator inspection (terminal)
+  - `failureError` — Unrecoverable non-intervention failure (terminal)
+  - `retryableActionError` — External action may have succeeded but durable
+    metadata persistence failed; signals FSM to retry the transition
+
+## Relationships
+
+- **Depends on**: `sdk/ark` (DaemonConn adapter, VTXOInfo, OORReceiveInfo,
+  CustomOORInput, IndexedOORSessionInfo), `lib/arkscript` (policy template ops
+  for vHTLC script derivation), `lnd/lntypes` + `lnd/invoices` (preimage,
+  hash, invoice types), `btcd/btcec/v2` (key ops), database/sql + SQLite
+  (session persistence), `golang-migrate` (schema management).
+- **Depended on by**: `cmd/darepocli/darepoclicommands` (swap CLI commands).
+
+## Sends / Receives
+
+### Pay Flow (Ark → Lightning)
+
+1. **← API**: `PayViaLightning(ctx, routes, amountSat, maxFeeSat)` or
+   `StartPayViaLightning(ctx, …, targetState)` to stop mid-flow.
+2. **→ SwapServerConn**: `RequestChannelID(vhtlcPubkey, expirySeconds)` —
+   get route hint + VHTLCConfig, derive vHTLC pkScript.
+3. **→ SwapServerConn**: `CreateInSwap(invoice, maxFeeSat, pubkey)` →
+   `InSwapConfig`; persisted as `paySession` at `PayStateSwapCreated`.
+4. **→ DaemonConn**: `SendOORWithPolicy(amountSat, vHTLCPolicy)` — OOR session
+   ID persisted at `PayStateFundingInitiated`.
+5. **→ DaemonConn**: `FindLiveVTXOByPkScript(vHTLCPkScript)` — poll until
+   vHTLC indexed (`PayStateVHTLCFunded`).
+6. **→ DaemonConn**: `GetIndexedOORSession(vHTLCPkScript, sessionID)` — poll
+   for server claim spend + preimage (`PayStateWaitingForClaim` →
+   `PayStateCompleted`).
+7. On timeout: `PayStateRefundInitiated` → submit/observe refund spend →
+   `PayStateRefunded` (returns `ErrSwapRefunded`).
+
+### Receive Flow (Lightning → Ark)
+
+1. **← API**: `ReceiveViaLightning(ctx, amountSat, expirySeconds, memo)` or
+   `StartReceiveViaLightning(ctx, …, targetState)`.
+2. **→ SwapServerConn**: `RequestChannelID(vhtlcPubkey, expirySeconds)` — get
+   route hint + VHTLCConfig.
+3. **→ InvoiceCreator**: `CreateInvoice(…, routeHint, expiry, preimage)` —
+   invoice + preimage generated; persisted at `ReceiveStateInvoiceCreated`.
+4. **→ DaemonConn**: `FindLiveVTXOByPkScript(vHTLCPkScript)` — poll until
+   server funds vHTLC (`ReceiveStateVHTLCFunded`).
+5. **→ DaemonConn**: `AllocateOORReceiveScript(label)` + `SendOORWithCustomInputs`
+   — sweep vHTLC with preimage; OOR claim session ID persisted at
+   `ReceiveStateClaimInitiated`.
+6. **→ DaemonConn**: `GetIndexedOORSession(…)` — poll until claim indexed
+   (`ReceiveStateCompleted`).
+
+### Resume / List
+
+- `ResumePayViaLightning(ctx, paymentHash)` / `ResumeReceiveViaLightning` —
+  load session from store, re-enter FSM at last persisted state, reconcile to
+  terminal.
+- `ListSwapSummaries(ctx, pendingOnly)` — scan store, return summarized
+  sessions; usable with a store-only `SwapClient` (no live connections
+  required).
+
+## Invariants
+
+- Swap session state in the SQLite store is the single source of truth;
+  in-memory FSMs are ephemeral and rebuilt from the store on resume.
+- OOR session IDs (FundingSessionID, ClaimSessionID, RefundSessionID) are
+  persisted durably before being passed to external daemon calls. Resume
+  never re-issues the same OOR transfer for the same session.
+- vHTLC script derivation is deterministic from (hash, server pubkey, refund
+  locktime, timelocks) — same inputs always produce the same pkScript.
+- Pay swaps refund only after `VHTLCConfig.RefundLocktime` (absolute block
+  height); `refundLocktimeBuffer` blocks before that deadline is enforced so
+  the client never attempts a funding or refund too close to the window edge.
+- Receive swaps claim with the preimage generated locally at invoice creation
+  time; the preimage is never mutated after `ReceiveStateInvoiceCreated`.
+- Swap deadlines (invoice lifetime, pay swap expiry window) are never extended
+  and gate every state transition that depends on time.
+- Resume operations are idempotent: re-entering a terminal session returns the
+  same terminal result without additional external effects.
+- Error classification (ErrSwapExpired, interventionError, failureError reason)
+  is persisted with the session so the same classification survives restart.
+- `fundingExpiryBuffer` and `refundLocktimeBuffer` ensure the client aborts if
+  the server deadline has less than the safety margin remaining.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/vtxo/AGENTS.md
+++ b/vtxo/AGENTS.md
@@ -30,7 +30,7 @@ when the local wallet owns the receive script.
 - `VTXOSaver` — Narrow persistence interface (`SaveVTXO(ctx, *Descriptor)`) the incoming handler uses; the production implementation is the `db` VTXO store, which serializes a missing tree path as an empty blob.
 - `VTXOsMaterializedNotification` — Manager-facing notification carrying already-persisted descriptors; the manager spawns one actor per descriptor without performing another store write. Used by both the OOR receive path and the new incoming round VTXO handler.
 - `LazyChainResolver` — Forwarding `TellOnlyRef[ExpiringNotification]` that buffers notifications until `Set()` wires the real chain-resolver target. Breaks the init-order dependency between the VTXO manager (which spawns `LazyChainResolver` at startup) and the unroll registry (which is wired after the VTXO manager starts). Buffered notifications are replayed in-order on `Set()`.
-- `RefreshFeeQuoter` — Function type `func(ctx, amount btcutil.Amount, remainingBlocks uint32) btcutil.Amount`. Optional hook on `VTXOActorConfig`; invoked as an **advisory preview** before each auto-refresh emission to estimate the per-input operator fee for UX surfaces. Under the seal-time fee handshake (#270) the server is the binding fee authority — the quoter's return value is no longer attached to the wire intent. Nil quoter (legacy and test paths) yields `OperatorFee=0` on the harness-local `RefreshVTXORequest`, which has no effect on the round protocol.
+- `RefreshFeeQuoter` — Function type `func(ctx, amount btcutil.Amount, remainingBlocks uint32) btcutil.Amount`. Optional hook on `VTXOActorConfig`; invoked as an **advisory-only** preview before each auto-refresh emission. Under the seal-time fee handshake (#270) the returned value is carried on `RefreshVTXORequest.OperatorFee` for observability but is NOT subtracted from the new VTXO output or persisted into the intent — the server decides the authoritative fee at seal time and the client enforces its cap via `QuoteReceivedState.MaxOperatorFee`. Nil quoter (legacy and test paths) yields `OperatorFee=0`, which is safe: the auto-refresh still emits and the server fills in the residual.
 
 ## Relationships
 
@@ -50,6 +50,10 @@ when the local wallet owns the receive script.
 ## Invariants
 
 - VTXO actor state is the single source of truth for availability.
+- `processOutbox` persists `VTXOStatusUpdate` rows to the store BEFORE applying
+  the in-memory state transition. A DB failure causes `Receive` to return an
+  error with the state unchanged, so callers can retry by re-driving the prior
+  state rather than observing a terminal state that never reached disk.
 - Forfeit transaction is not broadcast until the connector output's round confirms (atomic replacement).
 - Refresh is auto-triggered at configurable height before expiry.
 - Once ForfeitedState is reached, the old VTXO is unspendable; the new VTXO is available only after round confirmation.

--- a/vtxo/CLAUDE.md
+++ b/vtxo/CLAUDE.md
@@ -30,7 +30,7 @@ when the local wallet owns the receive script.
 - `VTXOSaver` — Narrow persistence interface (`SaveVTXO(ctx, *Descriptor)`) the incoming handler uses; the production implementation is the `db` VTXO store, which serializes a missing tree path as an empty blob.
 - `VTXOsMaterializedNotification` — Manager-facing notification carrying already-persisted descriptors; the manager spawns one actor per descriptor without performing another store write. Used by both the OOR receive path and the new incoming round VTXO handler.
 - `LazyChainResolver` — Forwarding `TellOnlyRef[ExpiringNotification]` that buffers notifications until `Set()` wires the real chain-resolver target. Breaks the init-order dependency between the VTXO manager (which spawns `LazyChainResolver` at startup) and the unroll registry (which is wired after the VTXO manager starts). Buffered notifications are replayed in-order on `Set()`.
-- `RefreshFeeQuoter` — Function type `func(ctx, amount btcutil.Amount, remainingBlocks uint32) btcutil.Amount`. Optional hook on `VTXOActorConfig`; invoked as an **advisory preview** before each auto-refresh emission to estimate the per-input operator fee for UX surfaces. Under the seal-time fee handshake (#270) the server is the binding fee authority — the quoter's return value is no longer attached to the wire intent. Nil quoter (legacy and test paths) yields `OperatorFee=0` on the harness-local `RefreshVTXORequest`, which has no effect on the round protocol.
+- `RefreshFeeQuoter` — Function type `func(ctx, amount btcutil.Amount, remainingBlocks uint32) btcutil.Amount`. Optional hook on `VTXOActorConfig`; invoked as an **advisory-only** preview before each auto-refresh emission. Under the seal-time fee handshake (#270) the returned value is carried on `RefreshVTXORequest.OperatorFee` for observability but is NOT subtracted from the new VTXO output or persisted into the intent — the server decides the authoritative fee at seal time and the client enforces its cap via `QuoteReceivedState.MaxOperatorFee`. Nil quoter (legacy and test paths) yields `OperatorFee=0`, which is safe: the auto-refresh still emits and the server fills in the residual.
 
 ## Relationships
 
@@ -50,6 +50,10 @@ when the local wallet owns the receive script.
 ## Invariants
 
 - VTXO actor state is the single source of truth for availability.
+- `processOutbox` persists `VTXOStatusUpdate` rows to the store BEFORE applying
+  the in-memory state transition. A DB failure causes `Receive` to return an
+  error with the state unchanged, so callers can retry by re-driving the prior
+  state rather than observing a terminal state that never reached disk.
 - Forfeit transaction is not broadcast until the connector output's round confirms (atomic replacement).
 - Refresh is auto-triggered at configurable height before expiry.
 - Once ForfeitedState is reached, the old VTXO is unspendable; the new VTXO is available only after round confirmation.


### PR DESCRIPTION
## Summary

Automated nightly doc-gardening sweep against baseline `cca73c6` (last merged sweep).

- **New**: `sdk/swaps/CLAUDE.md` + `sdk/swaps/AGENTS.md` — documents the new Lightning↔Ark atomic swap SDK (vHTLC, `PayState`/`ReceiveState` FSMs, `DaemonConn`, `SwapServerConn`, durable SQLite-backed session store)
- **Updated**: `round`, `vtxo`, `oor`, `lib/types`, `darepod`, `sdk/ark`, `harness`, `baselib/actor`, `cmd/darepocli/darepoclicommands` — seal-time fee handshake (#270), `IsChange` on `VTXORequest`/`LeaveRequest`, CLTV-gated OOR spend paths, `mergeContexts` caller-context invariant, `electrsReadyTimeout`, swap CLI commands
- **ARCHITECTURE.md**: added `sdk/swaps` to Layer 3 table
- `make doc-check` passes ✓

## Test plan

- [ ] Verify `make doc-check` passes on CI
- [ ] Spot-check `sdk/swaps/CLAUDE.md` key types against source files in `sdk/swaps/`
- [ ] Confirm `ARCHITECTURE.md` Layer 3 table includes `sdk/swaps`

🤖 Generated with [Claude Code](https://claude.com/claude-code)