### PR TITLE
darepod: add OOR change outputs

### DIFF
--- a/darepod/receive_script.go
+++ b/darepod/receive_script.go
@@ -2,6 +2,7 @@ package darepod
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"time"
@@ -118,6 +119,11 @@ func ResolveOwnedReceiveScriptKey(ctx context.Context,
 
 	rec, err := store.LookupOwnedReceiveScript(ctx, recipient.PkScript)
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return keychain.KeyDescriptor{},
+				oor.ErrIncomingRecipientNotOwned
+		}
+
 		return keychain.KeyDescriptor{}, fmt.Errorf("lookup owned "+
 			"receive script: %w", err)
 	}

--- a/darepod/receive_script_test.go
+++ b/darepod/receive_script_test.go
@@ -2,6 +2,7 @@ package darepod
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"testing"
@@ -13,6 +14,7 @@ import (
 	"github.com/lightninglabs/darepo-client/db"
 	"github.com/lightninglabs/darepo-client/indexer"
 	mailboxrpc "github.com/lightninglabs/darepo-client/mailbox/rpc"
+	"github.com/lightninglabs/darepo-client/oor"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/stretchr/testify/require"
@@ -56,7 +58,7 @@ func (s *testReceiveScriptStore) LookupOwnedReceiveScript(_ context.Context,
 		return &rec, nil
 	}
 
-	return nil, fmt.Errorf("owned receive script not found")
+	return nil, sql.ErrNoRows
 }
 
 // ListOwnedReceiveScripts returns all tracked owned receive-script records.
@@ -282,6 +284,25 @@ func TestEnsureDefaultOORReceiveKeyDerivesWhenMissing(t *testing.T) {
 		expected.PubKey.SerializeCompressed(),
 		keyDesc.PubKey.SerializeCompressed(),
 	)
+}
+
+// TestResolveOwnedReceiveScriptKeyNotOwned verifies that an unregistered
+// receive script is reported using the OOR recipient-not-owned sentinel so
+// mixed-recipient packages can skip foreign outputs.
+func TestResolveOwnedReceiveScriptKeyNotOwned(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	recipient := oor.ArkRecipientOutput{
+		OutputIndex: 0,
+		PkScript:    []byte{0x51, 0x20, 0x01},
+		Value:       1000,
+	}
+
+	_, err := ResolveOwnedReceiveScriptKey(
+		ctx, &testReceiveScriptStore{}, recipient,
+	)
+	require.ErrorIs(t, err, oor.ErrIncomingRecipientNotOwned)
 }
 
 // testKeyDescriptor creates a deterministic test key descriptor.

--- a/darepod/rpc_oor_receive.go
+++ b/darepod/rpc_oor_receive.go
@@ -13,7 +13,10 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-const defaultOORReceiveScriptLabel = "oor receive"
+const (
+	defaultOORReceiveScriptLabel = "oor receive"
+	defaultOORChangeScriptLabel  = "oor change"
+)
 
 // NewOORReceiveScript allocates a fresh wallet key, registers the matching
 // taproot receive script with the indexer, and returns the script details

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -109,6 +109,99 @@ func (r *RPCServer) reserveCustomInputs(
 	return release, nil
 }
 
+type oorChangeRecipientBuilder func(context.Context,
+	btcutil.Amount) (oortx.RecipientOutput, error)
+
+// sumOORInputAmounts returns the total value consumed by an OOR transfer.
+func sumOORInputAmounts(inputs []oor.TransferInput) (btcutil.Amount, error) {
+	var total btcutil.Amount
+	for i := range inputs {
+		input := inputs[i]
+		if input.VTXO == nil {
+			return 0, fmt.Errorf("input %d missing VTXO", i)
+		}
+
+		if input.VTXO.Amount <= 0 {
+			return 0, fmt.Errorf("input %d amount must be "+
+				"positive", i)
+		}
+
+		total += input.VTXO.Amount
+	}
+
+	return total, nil
+}
+
+// appendOORChangeRecipient appends a wallet-owned change output when selected
+// OOR inputs exceed the requested recipient amount. OOR v0 packages are
+// fee-less, so the selected input sum must be paid out exactly.
+func appendOORChangeRecipient(
+	ctx context.Context, recipients []oortx.RecipientOutput,
+	inputTotal, dustLimit btcutil.Amount,
+	buildChange oorChangeRecipientBuilder) (
+	[]oortx.RecipientOutput, btcutil.Amount, error) {
+
+	if len(recipients) == 0 {
+		return nil, 0, status.Errorf(codes.InvalidArgument,
+			"OOR recipient must be provided")
+	}
+
+	var targetAmt btcutil.Amount
+	for i, recipient := range recipients {
+		if recipient.Value <= 0 {
+			return nil, 0, status.Errorf(codes.InvalidArgument,
+				"recipient %d amount must be positive", i)
+		}
+
+		targetAmt += recipient.Value
+	}
+
+	if inputTotal < targetAmt {
+		return nil, 0, status.Errorf(codes.InvalidArgument,
+			"selected input amount %d sat is below recipient "+
+				"amount %d sat", inputTotal, targetAmt)
+	}
+
+	out := append([]oortx.RecipientOutput(nil), recipients...)
+	change := inputTotal - targetAmt
+	if change == 0 {
+		return out, 0, nil
+	}
+
+	if dustLimit > 0 && change < dustLimit {
+		return nil, change, status.Errorf(codes.InvalidArgument,
+			"OOR change output %d sat is below dust limit %d "+
+				"sat; choose exact inputs or a larger amount",
+			change, dustLimit)
+	}
+
+	if buildChange == nil {
+		return nil, change, status.Errorf(codes.Internal,
+			"OOR change builder not configured")
+	}
+
+	changeRecipient, err := buildChange(ctx, change)
+	if err != nil {
+		return nil, change, err
+	}
+
+	if len(changeRecipient.PkScript) == 0 {
+		return nil, change, status.Errorf(codes.Internal,
+			"OOR change script is empty")
+	}
+
+	if changeRecipient.Value != 0 && changeRecipient.Value != change {
+		return nil, change, status.Errorf(codes.Internal,
+			"OOR change builder returned %d sat for %d sat "+
+				"change", changeRecipient.Value, change)
+	}
+
+	changeRecipient.Value = change
+	out = append(out, changeRecipient)
+
+	return out, change, nil
+}
+
 // GetInfo returns basic information about the running daemon instance,
 // including version, network, and lnd connection state.
 func (r *RPCServer) GetInfo(ctx context.Context,
@@ -1474,14 +1567,7 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 			ctx, r.server.vtxoStore, outpoints,
 		)
 		if err != nil {
-			if unlockErr := r.unlockVTXOs(
-				ctx, locked.SelectedVTXOs,
-			); unlockErr != nil {
-				r.server.log.ErrorS(ctx,
-					"Unable to unlock VTXOs",
-					unlockErr,
-				)
-			}
+			r.unlockSelectedVTXOsBestEffort(ctx, locked)
 
 			return nil, status.Errorf(codes.Internal,
 				"build transfer inputs: %v", err)
@@ -1496,6 +1582,30 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 		Value:              targetAmt,
 		VTXOPolicyTemplate: recipientPolicyTemplate,
 	}}
+
+	inputTotal, err := sumOORInputAmounts(selectedInputs)
+	if err != nil {
+		r.unlockSelectedVTXOsBestEffort(ctx, locked)
+
+		return nil, status.Errorf(codes.Internal,
+			"sum OOR input amounts: %v", err)
+	}
+
+	recipients, changeAmt, err := appendOORChangeRecipient(
+		ctx, recipients, inputTotal, terms.DustLimit,
+		func(ctx context.Context, change btcutil.Amount) (
+			oortx.RecipientOutput, error) {
+
+			return r.buildOORChangeRecipient(
+				ctx, terms.PubKey, terms.VTXOExitDelay, change,
+			)
+		},
+	)
+	if err != nil {
+		r.unlockSelectedVTXOsBestEffort(ctx, locked)
+
+		return nil, err
+	}
 
 	// Resolve the OOR actor via the service key registered in the
 	// actor system's receptionist. This avoids holding a direct
@@ -1517,16 +1627,7 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 	if err != nil {
 		// Unlock VTXOs on OOR failure so they can be
 		// reused (only for wallet-selected inputs).
-		if locked != nil {
-			if unlockErr := r.unlockVTXOs(
-				ctx, locked.SelectedVTXOs,
-			); unlockErr != nil {
-				r.server.log.ErrorS(ctx,
-					"Unable to unlock VTXOs",
-					unlockErr,
-				)
-			}
-		}
+		r.unlockSelectedVTXOsBestEffort(ctx, locked)
 
 		return nil, status.Errorf(codes.Internal,
 			"OOR transfer failed: %v", err)
@@ -1540,12 +1641,82 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 
 	r.server.log.InfoS(ctx, "OOR transfer submitted",
 		slog.String("session_id", resp.SessionID.String()),
-		slog.Int64("amount_sat", req.Recipient.AmountSat))
+		slog.Int64("amount_sat", req.Recipient.AmountSat),
+		slog.Int64("input_total_sat", int64(inputTotal)),
+		slog.Int64("change_sat", int64(changeAmt)),
+		slog.Int("recipient_count", len(recipients)))
 
 	return &daemonrpc.SendOORResponse{
 		Status:    "submitted",
 		SessionId: resp.SessionID.String(),
 	}, nil
+}
+
+// buildOORChangeRecipient allocates and registers a wallet-owned receive
+// script for an OOR change output.
+func (r *RPCServer) buildOORChangeRecipient(ctx context.Context,
+	operatorKey *btcec.PublicKey, exitDelay uint32,
+	change btcutil.Amount) (oortx.RecipientOutput, error) {
+
+	if r.server.indexer == nil {
+		return oortx.RecipientOutput{}, status.Errorf(codes.Internal,
+			"indexer client not initialized")
+	}
+
+	store, err := r.newOORReceiveScriptStore()
+	if err != nil {
+		return oortx.RecipientOutput{}, status.Errorf(codes.Internal,
+			"unable to initialize OOR receive-script "+
+				"store: %v", err)
+	}
+
+	deriveNextKey, signerFactory, err := r.oorReceiveKeyOps()
+	if err != nil {
+		return oortx.RecipientOutput{}, status.Errorf(codes.Internal,
+			"unable to initialize OOR receive key ops: %v", err)
+	}
+
+	keyDesc, pkScript, err := CreateOORReceiveScript(
+		ctx, r.server.indexer, store, deriveNextKey, signerFactory,
+		operatorKey, exitDelay, defaultOORChangeScriptLabel,
+	)
+	if err != nil {
+		return oortx.RecipientOutput{}, status.Errorf(codes.Internal,
+			"unable to create OOR change script: %v", err)
+	}
+
+	if keyDesc == nil || keyDesc.PubKey == nil {
+		return oortx.RecipientOutput{}, status.Errorf(codes.Internal,
+			"missing OOR change key descriptor")
+	}
+
+	policyTemplate, err := encodeStandardRecipientPolicy(
+		keyDesc.PubKey, operatorKey, exitDelay, pkScript,
+	)
+	if err != nil {
+		return oortx.RecipientOutput{}, err
+	}
+
+	return oortx.RecipientOutput{
+		PkScript:           pkScript,
+		Value:              change,
+		VTXOPolicyTemplate: policyTemplate,
+	}, nil
+}
+
+// unlockSelectedVTXOsBestEffort releases wallet-selected inputs after an OOR
+// setup failure. Custom inputs are released by reserveCustomInputs' defer path.
+func (r *RPCServer) unlockSelectedVTXOsBestEffort(ctx context.Context,
+	locked *wallet.SelectAndLockVTXOsResponse) {
+
+	if locked == nil || len(locked.SelectedVTXOs) == 0 {
+		return
+	}
+
+	unlockErr := r.unlockVTXOs(ctx, locked.SelectedVTXOs)
+	if unlockErr != nil {
+		r.server.log.ErrorS(ctx, "Unable to unlock VTXOs", unlockErr)
+	}
 }
 
 // unlockVTXOs sends an UnlockVTXOsRequest to the wallet actor for the

--- a/darepod/rpc_server_test.go
+++ b/darepod/rpc_server_test.go
@@ -13,7 +13,10 @@ import (
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/lightninglabs/darepo-client/lib/arkscript"
+	oortx "github.com/lightninglabs/darepo-client/lib/tx/oor"
 	"github.com/lightninglabs/darepo-client/lib/types"
+	"github.com/lightninglabs/darepo-client/oor"
+	"github.com/lightninglabs/darepo-client/vtxo"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -27,6 +30,225 @@ func newTestRPCServer() *RPCServer {
 			chainParams: &chaincfg.RegressionNetParams,
 		},
 	}
+}
+
+func TestSumOORInputAmounts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		inputs  []oor.TransferInput
+		want    btcutil.Amount
+		wantErr string
+	}{
+		{
+			name: "sums valid inputs",
+			inputs: []oor.TransferInput{
+				{
+					VTXO: &vtxo.Descriptor{
+						Amount: 1_000,
+					},
+				},
+				{
+					VTXO: &vtxo.Descriptor{
+						Amount: 2_500,
+					},
+				},
+			},
+			want: 3_500,
+		},
+		{
+			name: "missing descriptor",
+			inputs: []oor.TransferInput{
+				{},
+			},
+			wantErr: "input 0 missing VTXO",
+		},
+		{
+			name: "non-positive amount",
+			inputs: []oor.TransferInput{
+				{
+					VTXO: &vtxo.Descriptor{},
+				},
+			},
+			wantErr: "input 0 amount must be positive",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := sumOORInputAmounts(tc.inputs)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestAppendOORChangeRecipient(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	baseRecipient := oortx.RecipientOutput{
+		PkScript: []byte{0x51, 0x20, 0x01},
+		Value:    1_000,
+	}
+
+	t.Run("exact input needs no change", func(t *testing.T) {
+		t.Parallel()
+
+		called := false
+		recipients, change, err := appendOORChangeRecipient(
+			ctx, []oortx.RecipientOutput{baseRecipient},
+			1_000, 546,
+			func(context.Context, btcutil.Amount) (
+				oortx.RecipientOutput, error) {
+
+				called = true
+				return oortx.RecipientOutput{}, nil
+			},
+		)
+		require.NoError(t, err)
+		require.False(t, called)
+		require.Zero(t, change)
+		require.Len(t, recipients, 1)
+		require.Equal(t, baseRecipient, recipients[0])
+	})
+
+	t.Run("overselection appends change", func(t *testing.T) {
+		t.Parallel()
+
+		recipients, change, err := appendOORChangeRecipient(
+			ctx, []oortx.RecipientOutput{baseRecipient},
+			2_500, 546,
+			func(_ context.Context, got btcutil.Amount) (
+				oortx.RecipientOutput, error) {
+
+				require.Equal(t, btcutil.Amount(1_500), got)
+
+				return oortx.RecipientOutput{
+					PkScript: []byte{0x51, 0x20, 0x02},
+				}, nil
+			},
+		)
+		require.NoError(t, err)
+		require.Equal(t, btcutil.Amount(1_500), change)
+		require.Len(t, recipients, 2)
+		require.Equal(t, btcutil.Amount(1_500), recipients[1].Value)
+		require.Equal(t, []byte{0x51, 0x20, 0x02},
+			recipients[1].PkScript)
+	})
+
+	t.Run("dust change rejected", func(t *testing.T) {
+		t.Parallel()
+
+		_, change, err := appendOORChangeRecipient(
+			ctx, []oortx.RecipientOutput{baseRecipient},
+			1_545, 546, nil,
+		)
+		require.Error(t, err)
+		require.Equal(t, btcutil.Amount(545), change)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		require.Equal(t, codes.InvalidArgument, st.Code())
+		require.Contains(t, st.Message(), "below dust limit")
+	})
+
+	t.Run("limit change accepted", func(t *testing.T) {
+		t.Parallel()
+
+		recipients, change, err := appendOORChangeRecipient(
+			ctx, []oortx.RecipientOutput{baseRecipient},
+			1_546, 546,
+			func(context.Context, btcutil.Amount) (
+				oortx.RecipientOutput, error) {
+
+				return oortx.RecipientOutput{
+					PkScript: []byte{0x51, 0x20, 0x02},
+				}, nil
+			},
+		)
+		require.NoError(t, err)
+		require.Equal(t, btcutil.Amount(546), change)
+		require.Len(t, recipients, 2)
+		require.Equal(t, btcutil.Amount(546), recipients[1].Value)
+	})
+
+	t.Run("insufficient inputs rejected", func(t *testing.T) {
+		t.Parallel()
+
+		_, _, err := appendOORChangeRecipient(
+			ctx, []oortx.RecipientOutput{baseRecipient},
+			999, 546, nil,
+		)
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		require.Equal(t, codes.InvalidArgument, st.Code())
+		require.Contains(t, st.Message(), "below recipient amount")
+	})
+
+	t.Run("builder amount mismatch rejected", func(t *testing.T) {
+		t.Parallel()
+
+		_, change, err := appendOORChangeRecipient(
+			ctx, []oortx.RecipientOutput{baseRecipient},
+			2_000, 546,
+			func(context.Context, btcutil.Amount) (
+				oortx.RecipientOutput, error) {
+
+				return oortx.RecipientOutput{
+					PkScript: []byte{0x51, 0x20, 0x03},
+					Value:    999,
+				}, nil
+			},
+		)
+		require.Error(t, err)
+		require.Equal(t, btcutil.Amount(1_000), change)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		require.Equal(t, codes.Internal, st.Code())
+		require.Contains(t, st.Message(), "builder returned")
+	})
+
+	t.Run("empty recipients rejected", func(t *testing.T) {
+		t.Parallel()
+
+		_, _, err := appendOORChangeRecipient(ctx, nil, 1_000, 546, nil)
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		require.Equal(t, codes.InvalidArgument, st.Code())
+		require.Contains(t, st.Message(), "recipient must be provided")
+	})
+
+	t.Run("zero recipient amount rejected", func(t *testing.T) {
+		t.Parallel()
+
+		_, _, err := appendOORChangeRecipient(
+			ctx, []oortx.RecipientOutput{{
+				PkScript: []byte{0x51, 0x20, 0x01},
+			}}, 1_000, 546, nil,
+		)
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		require.Equal(t, codes.InvalidArgument, st.Code())
+		require.Contains(t, st.Message(), "amount must be positive")
+	})
 }
 
 // TestResolveRecipientOutputPubkey verifies that a raw x-only pubkey

--- a/oor/actor.go
+++ b/oor/actor.go
@@ -41,6 +41,8 @@ type OutboxHandler interface {
 		outbox OutboxEvent) ([]Event, error)
 }
 
+type incomingMetadataFilter = IncomingMetadataRecipientFilter
+
 // ClientActorCfg configures the OORClientActor.
 type ClientActorCfg struct {
 	// Log is an optional logger for this actor instance. If None, the
@@ -1325,10 +1327,31 @@ func (b *oorDurableBehavior) sendTransportEvent(ctx context.Context,
 		return nil
 
 	case *QueryIncomingMetadataRequest:
-		pkScripts := make([][]byte, 0, len(queryReq.Recipients))
-		for i := range queryReq.Recipients {
+		recipients := queryReq.Recipients
+
+		filter, ok := b.cfg.OutboxHandler.(incomingMetadataFilter)
+		if ok {
+			var err error
+			owned, err := filter.FilterIncomingMetadataRecipients(
+				ctx, queryReq.Recipients,
+			)
+			if err != nil {
+				return fmt.Errorf("filter incoming metadata "+
+					"recipients: %w", err)
+			}
+
+			recipients = owned
+		}
+
+		if len(recipients) == 0 {
+			return fmt.Errorf("incoming metadata query " +
+				"contains no wallet-owned recipients")
+		}
+
+		pkScripts := make([][]byte, 0, len(recipients))
+		for i := range recipients {
 			pkScripts = append(pkScripts, append(
-				[]byte(nil), queryReq.Recipients[i].PkScript...,
+				[]byte(nil), recipients[i].PkScript...,
 			))
 		}
 

--- a/oor/actor_durable_message.go
+++ b/oor/actor_durable_message.go
@@ -11,6 +11,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	clientdb "github.com/lightninglabs/darepo-client/db"
+	"github.com/lightninglabs/darepo-client/lib/tree"
 	"github.com/lightninglabs/darepo-client/lib/tx/psbtutil"
 	"github.com/lightningnetwork/lnd/tlv"
 )
@@ -313,9 +314,13 @@ func encodeIncomingMetadataMatch(match IncomingMetadataMatch) ([]byte, error) {
 	chainDepth := uint32(match.Metadata.ChainDepth)
 	createdHeight := uint32(match.Metadata.CreatedHeight)
 
-	treePath, err := clientdb.SerializeTree(match.Metadata.TreePath)
-	if err != nil {
-		return nil, err
+	var treePath []byte
+	if match.Metadata.TreePath != nil {
+		var err error
+		treePath, err = clientdb.SerializeTree(match.Metadata.TreePath)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	records := []tlv.Record{
@@ -452,9 +457,12 @@ func decodeIncomingMetadataMatch(raw []byte) (IncomingMetadataMatch, error) {
 		return IncomingMetadataMatch{}, err
 	}
 
-	decodedTreePath, err := clientdb.DeserializeTree(treePath)
-	if err != nil {
-		return IncomingMetadataMatch{}, err
+	var decodedTreePath *tree.Tree
+	if len(treePath) > 0 {
+		decodedTreePath, err = clientdb.DeserializeTree(treePath)
+		if err != nil {
+			return IncomingMetadataMatch{}, err
+		}
 	}
 
 	var decodedCommitmentTxID chainhash.Hash

--- a/oor/actor_durable_message_test.go
+++ b/oor/actor_durable_message_test.go
@@ -268,6 +268,55 @@ func TestDriveEventRequestRoundTripIncomingHandledEvent(t *testing.T) {
 	require.Empty(t, handledEvt.MaterializedVTXOs)
 }
 
+// TestDriveEventRequestRoundTripIncomingMetadataResolvedEvent asserts
+// DriveEventRequest TLV Encode/Decode round-trips resolved incoming metadata
+// even when the indexer cannot return a singular tree path.
+func TestDriveEventRequestRoundTripIncomingMetadataResolvedEvent(t *testing.T) {
+	t.Parallel()
+
+	sessionID := SessionID(chainhash.Hash{10, 10, 10})
+	commitmentTxID := chainhash.Hash{11, 11, 11}
+	msg := &DriveEventRequest{
+		SessionID: sessionID,
+		Event: &IncomingMetadataResolvedEvent{
+			Matches: []IncomingMetadataMatch{{
+				OutputIndex: 1,
+				Metadata: IncomingVTXOMetadata{
+					RoundID:        "mixed-lineage",
+					CommitmentTxID: commitmentTxID,
+					BatchExpiry:    144,
+					TreeDepth:      0,
+					ChainDepth:     2,
+					CreatedHeight:  42,
+					TreePath:       nil,
+				},
+			}},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, msg.Encode(&buf))
+
+	decoded := &DriveEventRequest{}
+	require.NoError(t, decoded.Decode(&buf))
+
+	require.Equal(t, sessionID, decoded.SessionID)
+
+	metadataEvt, ok := decoded.Event.(*IncomingMetadataResolvedEvent)
+	require.True(t, ok)
+	require.Len(t, metadataEvt.Matches, 1)
+
+	match := metadataEvt.Matches[0]
+	require.EqualValues(t, 1, match.OutputIndex)
+	require.Equal(t, "mixed-lineage", match.Metadata.RoundID)
+	require.Equal(t, commitmentTxID, match.Metadata.CommitmentTxID)
+	require.EqualValues(t, 144, match.Metadata.BatchExpiry)
+	require.Zero(t, match.Metadata.TreeDepth)
+	require.EqualValues(t, 2, match.Metadata.ChainDepth)
+	require.EqualValues(t, 42, match.Metadata.CreatedHeight)
+	require.Nil(t, match.Metadata.TreePath)
+}
+
 // TestDriveEventRequestRoundTripIncomingAckSentEvent asserts
 // DriveEventRequest TLV Encode/Decode round-trips IncomingAckSentEvent
 // correctly.

--- a/oor/actor_test.go
+++ b/oor/actor_test.go
@@ -552,6 +552,8 @@ type mockServerConnRef struct {
 	tellErr error
 }
 
+type testVTXOQueryRequest = serverconn.SendListVTXOsByScriptsRequest
+
 // newMockServerConnRef creates a new mock server connection reference.
 func newMockServerConnRef(t *testing.T) *mockServerConnRef {
 	return &mockServerConnRef{
@@ -602,8 +604,25 @@ func (m *mockServerConnRef) lastSent() *serverconn.SendClientEventRequest {
 	return req
 }
 
-// lastRecipientQuery returns the most recent durable recipient-events query
-// captured by the mock. It fails the test if no messages have been captured.
+// lastVTXOQuery returns the most recent durable VTXO query captured by the
+// mock. It fails the test if no messages have been captured.
+func (m *mockServerConnRef) lastVTXOQuery() *testVTXOQueryRequest {
+	m.t.Helper()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	require.NotEmpty(m.t, m.messages, "no messages captured")
+
+	last := m.messages[len(m.messages)-1]
+	req, ok := last.(*serverconn.SendListVTXOsByScriptsRequest)
+	require.True(
+		m.t, ok, "last message is not SendListVTXOsByScriptsRequest",
+	)
+
+	return req
+}
+
 // localOnlyOutboxHandler handles only local outbox events (signing,
 // persistence, timers). Transport events should be routed through serverconn
 // and never reach this handler.
@@ -669,6 +688,68 @@ func (h *localOnlyOutboxHandler) Handle(_ context.Context,
 }
 
 var _ OutboxHandler = (*localOnlyOutboxHandler)(nil)
+
+// TestOORClientActorFiltersIncomingMetadataQueryRecipients verifies that
+// durable metadata queries only ask serverconn to prove scripts owned by the
+// local wallet, even when the incoming Ark package contains other recipients.
+func TestOORClientActorFiltersIncomingMetadataQueryRecipients(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	ownedScript := []byte{0x51, 0x20, 0x01}
+	foreignScript := []byte{0x51, 0x20, 0x02}
+	notOwnedErr := ErrIncomingRecipientNotOwned
+
+	mockConn := newMockServerConnRef(t)
+	behavior := &oorDurableBehavior{
+		cfg: ClientActorCfg{
+			ServerConn: mockConn,
+			OutboxHandler: &LocalPersistenceOutboxHandler{
+				ResolveIncomingClientKey: func(
+					_ context.Context,
+					recipient ArkRecipientOutput,
+				) (keychain.KeyDescriptor, error) {
+
+					if string(recipient.PkScript) !=
+						string(ownedScript) {
+
+						return keychain.KeyDescriptor{},
+							notOwnedErr
+					}
+
+					return keychain.KeyDescriptor{}, nil
+				},
+			},
+		},
+	}
+
+	sessionID := SessionID{0x01}
+	err := behavior.sendTransportEvent(ctx, &QueryIncomingMetadataRequest{
+		SessionID: sessionID,
+		Recipients: []ArkRecipientOutput{
+			{
+				OutputIndex: 0,
+				PkScript:    foreignScript,
+				Value:       1000,
+			},
+			{
+				OutputIndex: 1,
+				PkScript:    ownedScript,
+				Value:       2000,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	query := mockConn.lastVTXOQuery()
+	require.Len(t, query.PkScripts, 1)
+	require.Equal(t, ownedScript, query.PkScripts[0])
+	require.Equal(
+		t, IncomingMetadataCorrelationID(sessionID),
+		query.CorrelationID,
+	)
+}
 
 // TestOORClientActorTransportViaServerConn verifies that transport outbox
 // events (submit, finalize, ack) are Tell'd to the serverconn actor when

--- a/oor/local_persistence_handler.go
+++ b/oor/local_persistence_handler.go
@@ -47,6 +47,15 @@ type IncomingMetadataResolver func(ctx context.Context, sessionID SessionID,
 	recipient ArkRecipientOutput, ark *psbt.Packet,
 	finalCheckpoints []*psbt.Packet) (IncomingVTXOMetadata, error)
 
+// IncomingMetadataRecipientFilter filters an incoming Ark package down to the
+// recipient outputs controlled by the local wallet.
+type IncomingMetadataRecipientFilter interface {
+	// FilterIncomingMetadataRecipients returns only locally owned
+	// recipients from the provided incoming Ark package recipients.
+	FilterIncomingMetadataRecipients(ctx context.Context,
+		recipients []ArkRecipientOutput) ([]ArkRecipientOutput, error)
+}
+
 // SpendCompleter enqueues OOR spend completion through the VTXO manager so
 // each VTXO actor transitions to SpentState via its own FSM. Implementations
 // must return only after the manager has either durably completed the spend or
@@ -359,6 +368,42 @@ func (h *LocalPersistenceOutboxHandler) handleQueryIncomingMetadata(
 	}}, nil
 }
 
+// FilterIncomingMetadataRecipients returns only the incoming recipients owned
+// by the local wallet. Durable metadata queries use this before asking the
+// server/indexer to prove script ownership, because mixed OOR packages can
+// contain recipient outputs belonging to other clients.
+func (h *LocalPersistenceOutboxHandler) FilterIncomingMetadataRecipients(
+	ctx context.Context,
+	recipients []ArkRecipientOutput) ([]ArkRecipientOutput, error) {
+
+	if h == nil {
+		return nil, fmt.Errorf("handler must be provided")
+	}
+
+	if h.ResolveIncomingClientKey == nil {
+		return nil, fmt.Errorf("incoming client key resolver must be " +
+			"provided")
+	}
+
+	owned := make([]ArkRecipientOutput, 0, len(recipients))
+	for i := range recipients {
+		recipient := recipients[i]
+
+		_, err := h.ResolveIncomingClientKey(ctx, recipient)
+		if err != nil {
+			if IsIncomingRecipientNotOwned(err) {
+				continue
+			}
+
+			return nil, err
+		}
+
+		owned = append(owned, recipient)
+	}
+
+	return owned, nil
+}
+
 // materializeIncoming persists recipient VTXOs for an incoming transfer and
 // optionally notifies the VTXO manager directly when the caller is not
 // resuming the durable actor with a follow-up event.
@@ -575,3 +620,4 @@ func (h *LocalPersistenceOutboxHandler) handleIncomingAck(
 }
 
 var _ OutboxHandler = (*LocalPersistenceOutboxHandler)(nil)
+var _ IncomingMetadataRecipientFilter = (*LocalPersistenceOutboxHandler)(nil)

--- a/systest/oor_vtxo_manager_test.go
+++ b/systest/oor_vtxo_manager_test.go
@@ -3,6 +3,7 @@
 package systest
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"fmt"
@@ -34,11 +35,19 @@ const (
 	oorVTXOManagerEventuallyPoll    = 100 * time.Millisecond
 )
 
-// TestOORIncomingMaterializationSpawnsVTXOActor verifies the OOR receive flow
-// materializes an incoming VTXO, notifies the VTXO manager, and results in a
-// live VTXO actor registered in the actor system.
-func TestOORIncomingMaterializationSpawnsVTXOActor(t *testing.T) {
-	ParallelN(t)
+type oorVTXOManagerSystestFixture struct {
+	h             *SysTestHarness
+	clk           clock.Clock
+	roundStore    db.RoundStore
+	vtxoStore     vtxo.VTXOStore
+	deliveryStore actor.TxAwareDeliveryStore
+	managerRef    actor.ActorRef[vtxo.ManagerMsg, vtxo.ManagerResp]
+}
+
+func newOORVTXOManagerSystestFixture(t *testing.T,
+	name string) *oorVTXOManagerSystestFixture {
+
+	t.Helper()
 
 	h := NewSysTestHarness(t)
 	ctx := h.Context()
@@ -68,28 +77,49 @@ func TestOORIncomingMaterializationSpawnsVTXOActor(t *testing.T) {
 		ChainParams: h.ChainParams(),
 		Log:         fn.Some(h.SubLogger(vtxo.Subsystem)),
 	})
+
+	serviceName := "systest-vtxo-manager-" + name
 	managerKey := actor.NewServiceKey[vtxo.ManagerMsg, vtxo.ManagerResp](
-		"systest-vtxo-manager",
+		serviceName,
 	)
 	managerRef := actor.RegisterWithSystem(
-		h.ActorSystem(), "systest-vtxo-manager", managerKey, manager,
+		h.ActorSystem(), serviceName, managerKey, manager,
 	)
 
 	err = manager.Start(ctx, managerRef)
 	require.NoError(t, err)
+
+	return &oorVTXOManagerSystestFixture{
+		h:             h,
+		clk:           clk,
+		roundStore:    sqlDB.Queries,
+		vtxoStore:     vtxoStore,
+		deliveryStore: deliveryStore,
+		managerRef:    managerRef,
+	}
+}
+
+// TestOORIncomingMaterializationSpawnsVTXOActor verifies the OOR receive flow
+// materializes an incoming VTXO, notifies the VTXO manager, and results in a
+// live VTXO actor registered in the actor system.
+func TestOORIncomingMaterializationSpawnsVTXOActor(t *testing.T) {
+	ParallelN(t)
+
+	f := newOORVTXOManagerSystestFixture(t, "incoming")
+	ctx := f.h.Context()
 
 	arkPSBT, finalCheckpoints, recipients, metadata, recipientKey,
 		operatorKey := buildSystemTestIncomingMaterialization(t)
 	sessionID := oor.SessionID(arkPSBT.UnsignedTx.TxHash())
 	expectedIndex := recipients[0].OutputIndex
 
-	err = seedIncomingRound(
-		ctx, sqlDB.Queries, metadata.RoundID, clk.Now().Unix(),
+	err := seedIncomingRound(
+		ctx, f.roundStore, metadata.RoundID, f.clk.Now().Unix(),
 	)
 	require.NoError(t, err)
 
 	handler := &oor.LocalPersistenceOutboxHandler{
-		Store:       vtxoStore,
+		Store:       f.vtxoStore,
 		OperatorKey: operatorKey,
 		ExitDelay:   10,
 		NotifyIncomingVTXOs: func(_ context.Context,
@@ -121,12 +151,12 @@ func TestOORIncomingMaterializationSpawnsVTXOActor(t *testing.T) {
 	}
 
 	oorActor := oor.NewOORClientActor(oor.ClientActorCfg{
-		Log:           fn.Some(h.SubLogger(oor.Subsystem)),
+		Log:           fn.Some(f.h.SubLogger(oor.Subsystem)),
 		OutboxHandler: handler,
-		DeliveryStore: deliveryStore,
-		ActorSystem:   h.ActorSystem(),
+		DeliveryStore: f.deliveryStore,
+		ActorSystem:   f.h.ActorSystem(),
 		ActorID:       "systest-oor-vtxo-manager",
-		VTXOManager:   managerRef,
+		VTXOManager:   f.managerRef,
 	})
 	defer oorActor.Stop()
 
@@ -136,7 +166,7 @@ func TestOORIncomingMaterializationSpawnsVTXOActor(t *testing.T) {
 	require.NoError(t, err)
 
 	err = driveIncomingOutbox(
-		ctx, session, handler, sessionID, managerRef, outbox,
+		ctx, session, handler, sessionID, f.managerRef, outbox,
 	)
 	require.NoError(t, err)
 
@@ -146,7 +176,7 @@ func TestOORIncomingMaterializationSpawnsVTXOActor(t *testing.T) {
 	}
 
 	require.Eventually(t, func() bool {
-		count, countErr := activeVTXOCount(ctx, managerRef)
+		count, countErr := activeVTXOCount(ctx, f.managerRef)
 		if countErr != nil {
 			return false
 		}
@@ -156,20 +186,140 @@ func TestOORIncomingMaterializationSpawnsVTXOActor(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		refs := actor.FindInReceptionist(
-			h.ActorSystem().Receptionist(),
+			f.h.ActorSystem().Receptionist(),
 			vtxo.VTXOActorServiceKey(outpoint),
 		)
 
 		return len(refs) == 1
 	}, oorVTXOManagerEventuallyTimeout, oorVTXOManagerEventuallyPoll)
 
-	desc, err := vtxoStore.GetVTXO(ctx, outpoint)
+	desc, err := f.vtxoStore.GetVTXO(ctx, outpoint)
 	require.NoError(t, err)
 	require.Equal(t, metadata.RoundID, desc.RoundID)
 	require.Equal(t, metadata.CommitmentTxID, desc.CommitmentTxID)
 	require.Equal(t, metadata.BatchExpiry, desc.BatchExpiry)
 	require.Equal(t, metadata.CreatedHeight, desc.CreatedHeight)
 	require.Equal(t, metadata.ChainDepth, desc.ChainDepth)
+
+	state, err := session.FSM.CurrentState()
+	require.NoError(t, err)
+	require.IsType(t, &oor.ReceiveCompleted{}, state)
+}
+
+// TestOORSelfChangeMaterializationSkipsExternalRecipient verifies the OOR
+// receive path can materialize only the wallet-owned change output from a
+// multi-recipient Ark tx while ignoring the external recipient output.
+func TestOORSelfChangeMaterializationSkipsExternalRecipient(t *testing.T) {
+	ParallelN(t)
+
+	f := newOORVTXOManagerSystestFixture(t, "change")
+	ctx := f.h.Context()
+
+	arkPSBT, finalCheckpoints, recipients, changeRecipient, metadata,
+		changeKey, operatorKey := buildSystemTestChangeMaterialization(
+		t,
+	)
+	sessionID := oor.SessionID(arkPSBT.UnsignedTx.TxHash())
+
+	err := seedIncomingRound(
+		ctx, f.roundStore, metadata.RoundID, f.clk.Now().Unix(),
+	)
+	require.NoError(t, err)
+
+	handler := &oor.LocalPersistenceOutboxHandler{
+		Store:       f.vtxoStore,
+		OperatorKey: operatorKey,
+		ExitDelay:   10,
+		NotifyIncomingVTXOs: func(_ context.Context,
+			_ []*vtxo.Descriptor) error {
+
+			return nil
+		},
+		ResolveIncomingClientKey: func(_ context.Context,
+			recipient oor.ArkRecipientOutput) (
+			keychain.KeyDescriptor, error) {
+
+			if !bytes.Equal(
+				recipient.PkScript, changeRecipient.PkScript,
+			) {
+
+				return keychain.KeyDescriptor{},
+					oor.ErrIncomingRecipientNotOwned
+			}
+
+			require.Equal(
+				t, changeRecipient.OutputIndex,
+				recipient.OutputIndex,
+			)
+
+			return keychain.KeyDescriptor{
+				PubKey: changeKey.PubKey(),
+			}, nil
+		},
+		ResolveIncomingMetadata: func(_ context.Context,
+			gotSessionID oor.SessionID,
+			recipient oor.ArkRecipientOutput, _ *psbt.Packet,
+			_ []*psbt.Packet) (
+			oor.IncomingVTXOMetadata, error) {
+
+			require.Equal(t, sessionID, gotSessionID)
+			require.Equal(
+				t, changeRecipient.OutputIndex,
+				recipient.OutputIndex,
+			)
+
+			return metadata, nil
+		},
+	}
+
+	oorActor := oor.NewOORClientActor(oor.ClientActorCfg{
+		Log:           fn.Some(f.h.SubLogger(oor.Subsystem)),
+		OutboxHandler: handler,
+		DeliveryStore: f.deliveryStore,
+		ActorSystem:   f.h.ActorSystem(),
+		ActorID:       "systest-oor-change-vtxo-manager",
+		VTXOManager:   f.managerRef,
+	})
+	defer oorActor.Stop()
+
+	session, outbox, err := oor.DriveIncomingTransferWithCheckpoints(
+		ctx, sessionID, arkPSBT, finalCheckpoints,
+	)
+	require.NoError(t, err)
+
+	err = driveIncomingOutbox(
+		ctx, session, handler, sessionID, f.managerRef, outbox,
+	)
+	require.NoError(t, err)
+
+	outpoint := wire.OutPoint{
+		Hash:  arkPSBT.UnsignedTx.TxHash(),
+		Index: changeRecipient.OutputIndex,
+	}
+
+	require.Eventually(t, func() bool {
+		count, countErr := activeVTXOCount(ctx, f.managerRef)
+		if countErr != nil {
+			return false
+		}
+
+		return count == 1
+	}, oorVTXOManagerEventuallyTimeout, oorVTXOManagerEventuallyPoll)
+
+	require.Eventually(t, func() bool {
+		refs := actor.FindInReceptionist(
+			f.h.ActorSystem().Receptionist(),
+			vtxo.VTXOActorServiceKey(outpoint),
+		)
+
+		return len(refs) == 1
+	}, oorVTXOManagerEventuallyTimeout, oorVTXOManagerEventuallyPoll)
+
+	desc, err := f.vtxoStore.GetVTXO(ctx, outpoint)
+	require.NoError(t, err)
+	require.Equal(t, changeRecipient.Value, desc.Amount)
+	require.Equal(t, metadata.RoundID, desc.RoundID)
+	require.Len(t, recipients, 2)
 
 	state, err := session.FSM.CurrentState()
 	require.NoError(t, err)
@@ -411,6 +561,143 @@ func buildSystemTestIncomingMaterialization(t *testing.T) (*psbt.Packet,
 
 	return arkPSBT, []*psbt.Packet{checkpoint.PSBT}, recipients, metadata,
 		recipientKey, operatorKey.PubKey()
+}
+
+// buildSystemTestChangeMaterialization constructs an Ark PSBT with an
+// external recipient and a wallet-owned change recipient.
+func buildSystemTestChangeMaterialization(t *testing.T) (*psbt.Packet,
+	[]*psbt.Packet, []oor.ArkRecipientOutput, oor.ArkRecipientOutput,
+	oor.IncomingVTXOMetadata, *btcec.PrivateKey, *btcec.PublicKey) {
+
+	t.Helper()
+
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	policy := arkscript.CheckpointPolicy{
+		OperatorKey: operatorKey.PubKey(),
+		CSVDelay:    10,
+	}
+
+	externalKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	changeKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	const (
+		externalValue btcutil.Amount = 6_000
+		changeValue   btcutil.Amount = 4_000
+	)
+	inputValue := externalValue + changeValue
+
+	inputs := []oortx.CheckpointInput{
+		{
+			SpentVTXO: oortx.SpentVTXORef{
+				Outpoint: wire.OutPoint{
+					Hash:  [32]byte{0x22},
+					Index: 0,
+				},
+				Output: &wire.TxOut{
+					Value: int64(inputValue),
+					PkScript: systemTestTaprootPkScript(
+						t, operatorKey.PubKey(),
+					),
+				},
+			},
+			OwnerLeafScript: []byte{0x51},
+		},
+	}
+
+	externalPkScript := systemTestVTXOPkScript(
+		t, externalKey.PubKey(), policy.OperatorKey, 10,
+	)
+	changePkScript := systemTestVTXOPkScript(
+		t, changeKey.PubKey(), policy.OperatorKey, 10,
+	)
+
+	outputs := []oortx.RecipientOutput{
+		{
+			PkScript: externalPkScript,
+			Value:    externalValue,
+		},
+		{
+			PkScript: changePkScript,
+			Value:    changeValue,
+		},
+	}
+
+	checkpoint, err := oortx.BuildCheckpointPSBT(policy, inputs[0])
+	require.NoError(t, err)
+	checkpointTxHash := checkpoint.PSBT.UnsignedTx.TxHash()
+	checkpointTxOut := checkpoint.PSBT.UnsignedTx.TxOut[0]
+
+	arkPSBT, err := oortx.BuildArkPSBT(
+		[]oortx.CheckpointOutput{
+			{
+				Txid:           checkpointTxHash,
+				Output:         checkpointTxOut,
+				TapTreeEncoded: checkpoint.TapTreeEncoded,
+			},
+		},
+		outputs,
+	)
+	require.NoError(t, err)
+
+	recipients, err := oor.ExtractArkRecipients(arkPSBT)
+	require.NoError(t, err)
+
+	var changeRecipient oor.ArkRecipientOutput
+	for _, recipient := range recipients {
+		if bytes.Equal(recipient.PkScript, changePkScript) {
+			changeRecipient = recipient
+			break
+		}
+	}
+	require.NotZero(t, changeRecipient.Value)
+	require.Equal(t, changeValue, changeRecipient.Value)
+
+	metadata := oor.IncomingVTXOMetadata{
+		RoundID:        "systest-change-round",
+		CommitmentTxID: inputs[0].SpentVTXO.Outpoint.Hash,
+		BatchExpiry:    1000,
+		TreeDepth:      1,
+		ChainDepth:     2,
+		CreatedHeight:  700,
+		TreePath: &tree.Tree{
+			BatchOutpoint: wire.OutPoint{
+				Hash:  inputs[0].SpentVTXO.Outpoint.Hash,
+				Index: 0,
+			},
+			Root: &tree.Node{
+				Input: inputs[0].SpentVTXO.Outpoint,
+				Outputs: []*wire.TxOut{
+					checkpoint.PSBT.UnsignedTx.TxOut[0],
+				},
+				CoSigners: []*btcec.PublicKey{},
+				Children:  make(map[uint32]*tree.Node),
+			},
+		},
+	}
+
+	return arkPSBT, []*psbt.Packet{checkpoint.PSBT}, recipients,
+		changeRecipient, metadata, changeKey, operatorKey.PubKey()
+}
+
+func systemTestVTXOPkScript(t *testing.T, clientKey,
+	operatorKey *btcec.PublicKey, exitDelay uint32) []byte {
+
+	t.Helper()
+
+	vtxoTapKey, err := arkscript.VTXOTapKey(
+		clientKey, operatorKey, exitDelay,
+	)
+	require.NoError(t, err)
+
+	pkScript, err := txscript.PayToTaprootScript(vtxoTapKey)
+	require.NoError(t, err)
+
+	return pkScript
 }
 
 // systemTestTaprootPkScript returns a valid P2TR pkScript for systest


### PR DESCRIPTION
Fixes #200.

## Summary
- add daemon-side OOR change recipient construction when selected inputs exceed the requested recipient amount
- register the change recipient through the existing OOR receive-script path so later incoming materialization can recover it
- reject residual change at or below the operator dust limit instead of building an invalid fee-less Ark package
- add unit coverage for OOR change recipient calculation and systest coverage for materializing wallet-owned change from a multi-recipient Ark tx

## Tests
- go test -tags="dev nolog test_sqlite" ./darepod ./oor ./lib/tx/oor
- go test -tags "systest" -v ./systest/... -run 'TestOOR(IncomingMaterializationSpawnsVTXOActor|SelfChangeMaterializationSkipsExternalRecipient)$' -timeout 10m
- make lint-changed-local base=origin/main
- make commitmsg-lint commit=HEAD
