### PR TITLE
[codex] swaps: include payment address in invoices

### DIFF
--- a/sdk/swaps/invoice.go
+++ b/sdk/swaps/invoice.go
@@ -223,14 +223,30 @@ func buildSignedInvoice(amountSat btcutil.Amount, memo string,
 	}
 
 	paymentHash := invoicePreimage.Hash()
+	var paymentAddr [32]byte
+	if _, err := rand.Read(paymentAddr[:]); err != nil {
+		return nil, lntypes.Hash{}, fmt.Errorf(
+			"generate payment address: %w", err,
+		)
+	}
+
 	createdAt := time.Now()
 	msat := lnwire.NewMSatFromSatoshis(amountSat)
+	features := lnwire.NewFeatureVector(
+		lnwire.NewRawFeatureVector(
+			lnwire.TLVOnionPayloadRequired,
+			lnwire.PaymentAddrRequired,
+		),
+		lnwire.Features,
+	)
 	invoice, err := zpay32.NewInvoice(
 		chainParams, paymentHash, createdAt,
 		zpay32.Amount(msat),
 		zpay32.Description(memo),
 		zpay32.RouteHint([]zpay32.HopHint{hopHint}),
 		zpay32.Expiry(expiry),
+		zpay32.PaymentAddr(paymentAddr),
+		zpay32.Features(features),
 	)
 	if err != nil {
 		return nil, lntypes.Hash{}, fmt.Errorf(
@@ -247,10 +263,19 @@ func buildSignedInvoice(amountSat btcutil.Amount, memo string,
 		)
 	}
 
+	storedPreimage := *invoicePreimage
+
 	return &invoices.Invoice{
 		Memo:           []byte(memo),
 		PaymentRequest: []byte(paymentRequest),
 		CreationDate:   createdAt,
+		Terms: invoices.ContractTerm{
+			PaymentPreimage: &storedPreimage,
+			Value:           msat,
+			PaymentAddr:     paymentAddr,
+			Expiry:          expiry,
+			Features:        features.Clone(),
+		},
 	}, paymentHash, nil
 }
 

--- a/sdk/swaps/invoice_test.go
+++ b/sdk/swaps/invoice_test.go
@@ -1,9 +1,15 @@
 package swaps
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/zpay32"
 	"github.com/stretchr/testify/require"
 )
 
@@ -36,4 +42,56 @@ func TestValidateRouteHintRejectsTruncatedFields(t *testing.T) {
 	}
 	err = validateRouteHint(routeHint)
 	require.ErrorContains(t, err, "CLTV expiry delta")
+}
+
+// TestInvoiceGeneratorIncludesPaymentAddress verifies generated invoices are
+// accepted by modern LND senders, which reject BOLT11 invoices without either a
+// payment address or blinded paths.
+func TestInvoiceGeneratorIncludesPaymentAddress(t *testing.T) {
+	t.Parallel()
+
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	creator := NewEphemeralInvoiceGenerator(
+		privKey, nil, &chaincfg.RegressionNetParams,
+	)
+
+	preimage, err := NewPreimage()
+	require.NoError(t, err)
+
+	invoice, hash, err := creator.CreateInvoice(
+		context.Background(), btcutil.Amount(50_000), "swap",
+		&RouteHint{
+			NodeID:          privKey.PubKey().SerializeCompressed(),
+			ChannelID:       42,
+			CltvExpiryDelta: 40,
+		},
+		time.Hour, &preimage,
+	)
+	require.NoError(t, err)
+	require.Equal(t, preimage.Hash(), hash)
+	require.Equal(t, preimage, *invoice.Terms.PaymentPreimage)
+	expectedMSat := lnwire.NewMSatFromSatoshis(50_000)
+	require.Equal(t, expectedMSat, invoice.Terms.Value)
+	require.NotZero(t, invoice.Terms.PaymentAddr)
+	require.Equal(t, time.Hour, invoice.Terms.Expiry)
+	require.True(t, invoice.Terms.Features.HasFeature(
+		lnwire.TLVOnionPayloadOptional,
+	))
+	require.True(t, invoice.Terms.Features.HasFeature(
+		lnwire.PaymentAddrOptional,
+	))
+
+	decoded, err := zpay32.Decode(
+		string(invoice.PaymentRequest), &chaincfg.RegressionNetParams,
+	)
+	require.NoError(t, err)
+	require.True(t, decoded.PaymentAddr.IsSome())
+	decodedPayAddr := decoded.PaymentAddr.UnwrapOr([32]byte{})
+	require.Equal(t, invoice.Terms.PaymentAddr, decodedPayAddr)
+	require.True(t, decoded.Features.HasFeature(
+		lnwire.TLVOnionPayloadOptional,
+	))
+	require.True(t, decoded.Features.HasFeature(lnwire.PaymentAddrOptional))
 }


### PR DESCRIPTION
## Summary

- generate a random BOLT11 payment address for swap invoices
- advertise TLV onion payload and payment address feature bits on generated invoices
- add coverage that decodes a generated invoice and asserts the payment address/features are present

## Motivation

Modern LND rejects invoices that contain neither a payment address nor blinded paths. Swap invoices generated by the SDK were missing both, so external `lncli payinvoice` calls failed before attempting a route.

## Validation

- `go test ./sdk/swaps ./darepod ./oor ./lib/tx/oor`