### PR TITLE
[codex] Expire receive swaps after refund locktime

### DIFF
--- a/sdk/swaps/out_swap.go
+++ b/sdk/swaps/out_swap.go
@@ -625,12 +625,11 @@ func (s *ReceiveSession) prepareInvoice(ctx context.Context) error {
 func (s *ReceiveSession) waitForFunding(ctx context.Context) error {
 	outpoint, amount, err := s.client.waitForVHTLC(
 		ctx, s.vhtlcPkScript, s.deadline,
+		s.ensureReceiveFundingStillPossible,
 	)
 	if err != nil {
 		if errors.Is(err, errSwapExpired) {
-			return s.mutateAndPersist(ctx, func() error {
-				return s.transition(receiveEventExpired)
-			})
+			return err
 		}
 
 		return fmt.Errorf("wait for vHTLC: %w", err)
@@ -646,6 +645,32 @@ func (s *ReceiveSession) waitForFunding(ctx context.Context) error {
 
 		return s.transition(receiveEventVHTLCFunded)
 	})
+}
+
+// ensureReceiveFundingStillPossible stops an invoice-created receive session
+// once the vHTLC refund path has matured and no live claimable vHTLC was found.
+func (s *ReceiveSession) ensureReceiveFundingStillPossible(
+	ctx context.Context) error {
+
+	height, err := s.client.daemon.BlockHeight(ctx)
+	if err != nil {
+		s.client.log.DebugS(ctx,
+			"Unable to query receive refund locktime height", err,
+			btclog.Hex("hash", s.PaymentHash[:]),
+		)
+
+		return nil
+	}
+
+	if height+s.client.refundLocktimeBuffer < s.vhtlcConfig.RefundLocktime {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"refund locktime %d is imminent or reached before receive "+
+			"funding was observed at height %d: %w",
+		s.vhtlcConfig.RefundLocktime, height, errSwapExpired,
+	)
 }
 
 // validateReceiveFunding checks manually or automatically observed funding
@@ -905,7 +930,8 @@ func encodeVHTLCPolicyTemplate(policy *arkscript.VHTLCPolicy) ([]byte, error) {
 // waitForVHTLC polls the authoritative indexer until the expected vHTLC is
 // live, then returns its outpoint and amount.
 func (c *SwapClient) waitForVHTLC(ctx context.Context,
-	pkScript []byte, deadline time.Time) (string, int64, error) {
+	pkScript []byte, deadline time.Time,
+	keepWaiting func(context.Context) error) (string, int64, error) {
 
 	pkScriptHex := hex.EncodeToString(pkScript)
 	if deadline.IsZero() {
@@ -930,6 +956,12 @@ func (c *SwapClient) waitForVHTLC(ctx context.Context,
 			)
 
 			return vtxo.Outpoint, vtxo.AmountSat, nil
+		}
+
+		if keepWaiting != nil {
+			if err := keepWaiting(ctx); err != nil {
+				return "", 0, err
+			}
 		}
 
 		if !deadline.IsZero() && !c.currentTime().Before(deadline) {

--- a/sdk/swaps/out_swap_test.go
+++ b/sdk/swaps/out_swap_test.go
@@ -469,6 +469,86 @@ func TestReceiveSessionCancelDoesNotPersistFailed(t *testing.T) {
 	require.Equal(t, ReceiveStateInvoiceCreated, resumed.State())
 }
 
+// TestReceiveSessionExpiresAtRefundLocktimeWithoutFunding asserts a resumed
+// receive does not wait for the longer invoice deadline after the server-side
+// refund window has opened and no live vHTLC can still be claimed.
+func TestReceiveSessionExpiresAtRefundLocktimeWithoutFunding(t *testing.T) {
+	t.Parallel()
+
+	store := newTestSwapStore(t)
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	serverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	creator := &testInvoiceCreator{
+		invoice: &invoices.Invoice{
+			PaymentRequest: []byte("lnrtest1swap"),
+		},
+	}
+	serverPubKey := serverPriv.PubKey().SerializeCompressed()
+
+	serverConn := &testSwapServerConn{
+		hint: &RouteHint{
+			NodeID:          serverPubKey,
+			ChannelID:       99,
+			FeeBaseMsat:     1,
+			FeePropPpm:      2,
+			CltvExpiryDelta: 40,
+		},
+		cfg: &VHTLCConfig{
+			RefundLocktime:                       144,
+			UnilateralClaimDelay:                 12,
+			UnilateralRefundDelay:                24,
+			UnilateralRefundWithoutReceiverDelay: 36,
+			SwapServerPubkey:                     serverPubKey,
+		},
+	}
+
+	daemonConn := &testDaemonConn{
+		identityKey: clientPriv.PubKey(),
+		operatorKey: operatorPriv.PubKey(),
+	}
+
+	client := NewSwapClientWithStore(
+		serverConn, daemonConn, nil, creator, store,
+	)
+	client.waitPollInterval = time.Millisecond
+
+	session, err := client.StartReceiveViaLightning(
+		t.Context(), btcutil.Amount(42_000),
+	)
+	require.NoError(t, err)
+
+	daemonConn.blockHeight = 143
+
+	resumed, err := client.ResumeReceiveViaLightning(
+		t.Context(), session.PaymentHash,
+	)
+	require.NoError(t, err)
+	require.Equal(t, ReceiveStateInvoiceCreated, resumed.State())
+
+	_, _, err = resumed.WaitForFunding(t.Context())
+	require.ErrorIs(t, err, errSwapExpired)
+	require.ErrorContains(t, err,
+		"refund locktime 144 is imminent or reached")
+	require.Equal(t, ReceiveStateExpired, resumed.State())
+
+	reloaded, err := client.ResumeReceiveViaLightning(
+		t.Context(), session.PaymentHash,
+	)
+	require.NoError(t, err)
+	require.Equal(t, ReceiveStateExpired, reloaded.State())
+
+	_, err = reloaded.Wait(t.Context())
+	require.ErrorIs(t, err, errSwapExpired)
+}
+
 // TestReceiveSessionFailsOnAmountMismatch asserts the client stops with an
 // ordinary terminal failure when the funded vHTLC amount does not match the
 // invoice amount it requested.


### PR DESCRIPTION
## Summary

This fixes resumed Lightning-to-Ark receive swaps that remain stuck in `InvoiceCreated` after the swap server has already refunded the funded vHTLC.

The receive wait path now checks the negotiated vHTLC refund locktime while polling for the expected live vHTLC. A live vHTLC still wins first, preserving the existing index-lag behavior, but once the refund window has opened with no live output to claim the client persists the receive session as `Expired` and returns the original timeout cause.

## Root Cause

A receive session that was interrupted before observing funding only persisted `InvoiceCreated` and the expected vHTLC script. If the swap server later funded and then refunded the vHTLC, resuming the client only waited for a live vHTLC until the long invoice deadline. The client did not consider the already-mature refund locktime for the expected vHTLC.

## Validation

- `go test ./sdk/swaps`
- From the parent swapdk-server checkout: `go test ./...`
- `git diff --check`