### PR TITLE
timeout: wire self ref before timers fire

### DIFF
--- a/baselib/actor/system.go
+++ b/baselib/actor/system.go
@@ -130,6 +130,12 @@ func newStoppedActorRef[M Message, R any](id string) ActorRef[M, R] {
 	return actor.Ref()
 }
 
+// selfStartingBehavior is implemented by behaviors that need their own actor
+// ref before processing any mailbox messages.
+type selfStartingBehavior[M Message] interface {
+	Start(TellOnlyRef[M])
+}
+
 // RegisterWithSystem creates an actor with the given ID, service key, and
 // behavior within the specified ActorSystem. It starts the actor, adds it to
 // the system's management, registers it with the receptionist using the
@@ -154,6 +160,9 @@ func RegisterWithSystem[M Message, R any](as *ActorSystem, id string, key Servic
 		Wg:          &as.actorWg,
 	}
 	actorInstance := NewActor(actorCfg)
+	if starter, ok := behavior.(selfStartingBehavior[M]); ok {
+		starter.Start(actorInstance.Ref())
+	}
 	actorInstance.Start()
 
 	// Add the actor instance to the system's list of stoppable actors.

--- a/timeout/actor.go
+++ b/timeout/actor.go
@@ -3,6 +3,7 @@ package timeout
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	"github.com/lightninglabs/darepo-client/baselib/actor"
@@ -50,9 +51,9 @@ type Actor struct {
 
 	// self is the actor's reference to its own mailbox. Set by Start
 	// after the actor system has registered the behavior. Clock
-	// callbacks deliver internal messages here so all state mutation
-	// runs inside Receive.
-	self actor.TellOnlyRef[Msg]
+	// callbacks run in separate goroutines, so Start publishes the ref
+	// atomically before any callback reads it.
+	self atomic.Value
 
 	// nextGen issues a fresh generation number on every Schedule call.
 	// A stale internalTimerFired/internalTickFired arriving after a
@@ -95,7 +96,14 @@ func NewActorWithClock(clock Clock) *Actor {
 // ScheduleRecurringTickRequest is delivered. It is safe to call once
 // only — subsequent calls overwrite the self-ref.
 func (a *Actor) Start(self actor.TellOnlyRef[Msg]) {
-	a.self = self
+	a.self.Store(self)
+}
+
+// loadSelf returns the actor self-reference published by Start. The false case
+// is only expected in direct tests or misuse that bypasses actor registration.
+func (a *Actor) loadSelf() (actor.TellOnlyRef[Msg], bool) {
+	self, ok := a.self.Load().(actor.TellOnlyRef[Msg])
+	return self, ok
 }
 
 // Receive processes incoming messages.
@@ -138,7 +146,12 @@ func (a *Actor) handleSchedule(_ context.Context,
 	// message back into self, where Receive will deliver the
 	// user-visible ExpiredMsg single-threadedly.
 	timer := a.clock.AfterFunc(req.Duration, func() {
-		_ = a.self.Tell(context.Background(), &internalTimerFired{
+		self, ok := a.loadSelf()
+		if !ok {
+			return
+		}
+
+		_ = self.Tell(context.Background(), &internalTimerFired{
 			ID:  id,
 			Gen: gen,
 		})
@@ -263,7 +276,12 @@ func (a *Actor) handleTickFired(ctx context.Context,
 // gen check on arrival.
 func (a *Actor) armRecurring(id ID, gen uint64, d time.Duration) {
 	timer := a.clock.AfterFunc(d, func() {
-		_ = a.self.Tell(context.Background(), &internalTickFired{
+		self, ok := a.loadSelf()
+		if !ok {
+			return
+		}
+
+		_ = self.Tell(context.Background(), &internalTickFired{
 			ID:      id,
 			Gen:     gen,
 			FiredAt: a.clock.Now(),

--- a/timeout/actor_recurring_test.go
+++ b/timeout/actor_recurring_test.go
@@ -7,6 +7,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestActorRecurringWithoutStartDropsTimerFire verifies direct tests that
+// forget to inject the self-ref do not panic from recurring timer goroutines.
+func TestActorRecurringWithoutStartDropsTimerFire(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	clock := newFakeClock(startEpoch)
+	a := NewActorWithClock(clock)
+	callback := newMockTickCallback(t, "callback")
+
+	result := a.Receive(ctx, &ScheduleRecurringTickRequest{
+		ID:       "missing-self",
+		Interval: 50 * time.Millisecond,
+		Callback: callback,
+	})
+	require.True(t, result.IsOk(), "schedule should succeed")
+
+	require.NotPanics(t, func() {
+		clock.Advance(50 * time.Millisecond)
+	})
+	require.Equal(t, 0, callback.count())
+}
+
 // TestActorScheduleRecurringTick verifies that a fixed interval produces
 // exactly the expected number of ticks over a fixed advance window.
 func TestActorScheduleRecurringTick(t *testing.T) {

--- a/timeout/actor_test.go
+++ b/timeout/actor_test.go
@@ -64,6 +64,29 @@ func (m *mockCallbackRef) assertNoMessages(t *testing.T) {
 		"expected no messages, got %d", len(m.messages))
 }
 
+// TestActorScheduleWithoutStartDropsTimerFire verifies direct tests that forget
+// to inject the self-ref do not panic from timer goroutines.
+func TestActorScheduleWithoutStartDropsTimerFire(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	clock := newFakeClock(startEpoch)
+	a := NewActorWithClock(clock)
+	callback := newMockCallbackRef(t, "callback")
+
+	result := a.Receive(ctx, &ScheduleTimeoutRequest{
+		ID:       "missing-self",
+		Duration: 50 * time.Millisecond,
+		Callback: callback,
+	})
+	require.True(t, result.IsOk(), "schedule should succeed")
+
+	require.NotPanics(t, func() {
+		clock.Advance(50 * time.Millisecond)
+	})
+	callback.assertNoMessages(t)
+}
+
 // TestActorScheduleAndExpire tests basic timeout scheduling and expiration.
 func TestActorScheduleAndExpire(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

- publish the timeout actor self-reference before its mailbox starts processing messages
- store the timeout actor self-reference atomically so timer callbacks can safely self-tell from their own goroutine
- keep recurring tick and one-shot timer callbacks routed back through the actor mailbox
- tolerate direct actor tests or misuse that fire timers before `Start` by dropping the internal timer message instead of panicking

## Why

The timeout actor arms timers from mailbox messages, but the actual timer callback runs outside the actor mailbox. To preserve the actor model, that callback sends an internal message back to the timeout actor's own mailbox, which means the timeout actor must already know its own actor ref before any scheduled timer can fire.

Before this change, `RegisterWithSystem` opened the actor mailbox before behaviors that need their own ref could receive it. That left a startup window where the timeout actor could process a schedule request, arm a timer, and later have the timer callback try to self-tell through an unset `self` ref. In direct tests or unusual startup ordering, that can panic when the callback fires.

This PR closes that window by letting behaviors opt into receiving their own ref before the mailbox is started. The timeout actor stores that ref with `atomic.Value`, giving timer callback goroutines a safe publication path when they later load the ref.

## Validation

- `go test ./timeout ./baselib/actor`