### PR TITLE
Make keyed OOR sends idempotent

### DIFF
--- a/oor/actor.go
+++ b/oor/actor.go
@@ -446,6 +446,19 @@ func (b *oorDurableBehavior) handleStartTransfer(ctx context.Context,
 		slog.Int("num_inputs", len(req.Inputs)),
 		slog.Int("num_recipients", len(req.Recipients)))
 
+	existingSessionID, found := b.findOutgoingSessionByIdempotencyKey(
+		req.IdempotencyKey,
+	)
+	if found {
+		b.logger(ctx).InfoS(ctx, "Returning existing OOR transfer",
+			slog.String("session_id", existingSessionID.String()),
+			slog.String("idempotency_key", req.IdempotencyKey))
+
+		return fn.Ok[ActorResp](&StartTransferResponse{
+			SessionID: existingSessionID,
+		})
+	}
+
 	// Build the deterministic submit package and start the session FSM.
 	// I/O is emitted as outbox messages.
 	session, outbox, err := NewSessionWithIdempotencyKey(
@@ -492,6 +505,28 @@ func (b *oorDurableBehavior) handleStartTransfer(ctx context.Context,
 	return fn.Ok[ActorResp](&StartTransferResponse{
 		SessionID: session.ID,
 	})
+}
+
+// findOutgoingSessionByIdempotencyKey returns the existing outgoing session
+// created for the supplied caller intent key, when one is locally known.
+func (b *oorDurableBehavior) findOutgoingSessionByIdempotencyKey(
+	idempotencyKey string) (SessionID, bool) {
+
+	if idempotencyKey == "" {
+		return SessionID{}, false
+	}
+
+	for sessionID, handle := range b.sessions {
+		if handle == nil || handle.kind != sessionKindOutgoing {
+			continue
+		}
+
+		if handle.IdempotencyKey == idempotencyKey {
+			return sessionID, true
+		}
+	}
+
+	return SessionID{}, false
 }
 
 // handleDriveEvent feeds a follow-up event into an existing session.

--- a/oor/actor_test.go
+++ b/oor/actor_test.go
@@ -265,6 +265,174 @@ func TestOORClientActorHappyPath(t *testing.T) {
 		packageStore.lastSessionID)
 }
 
+func TestOORClientActorStartTransferIdempotencyKeyReturnsExistingSession(
+	t *testing.T) {
+
+	t.Parallel()
+
+	ctx := t.Context()
+
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	clientKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	clientSigner := input.NewMockSigner([]*btcec.PrivateKey{clientKey}, nil)
+	inputValue := btcutil.Amount(10000)
+	inputs := []TransferInput{
+		newTestTransferInput(
+			t, clientKey, operatorKey.PubKey(), wire.OutPoint{
+				Hash:  [32]byte{0x12},
+				Index: 0,
+			}, inputValue,
+		),
+	}
+	alternateInputs := []TransferInput{
+		newTestTransferInput(
+			t, clientKey, operatorKey.PubKey(), wire.OutPoint{
+				Hash:  [32]byte{0x13},
+				Index: 0,
+			}, inputValue,
+		),
+	}
+
+	policy := arkscript.CheckpointPolicy{
+		OperatorKey: operatorKey.PubKey(),
+		CSVDelay:    10,
+	}
+	recipients := []oortx.RecipientOutput{
+		{
+			PkScript: newTestTaprootPkScript(t, clientKey.PubKey()),
+			Value:    inputValue,
+		},
+	}
+
+	serverConn := newMockServerConnRef(t)
+	actor := NewOORClientActor(ClientActorCfg{
+		OutboxHandler: &localOnlyOutboxHandler{
+			t:            t,
+			clientSigner: clientSigner,
+		},
+		ServerConn:    serverConn,
+		DeliveryStore: newTestDeliveryStore(t),
+		ActorID:       "oor-actor-idempotent-start",
+	})
+	defer actor.Stop()
+
+	startResp := actor.Receive(ctx, &StartTransferRequest{
+		Policy:         policy,
+		Inputs:         inputs,
+		Recipients:     recipients,
+		IdempotencyKey: "test-start-key",
+	})
+	require.True(t, startResp.IsOk())
+
+	startMsg, ok := startResp.UnwrapOr(nil).(*StartTransferResponse)
+	require.True(t, ok)
+
+	// A retry of the same caller intent can be reconstructed with a
+	// different selected input after a crash. The package txid changes, so
+	// the session-id replay check would not catch this by itself.
+	duplicateResp := actor.Receive(ctx, &StartTransferRequest{
+		Policy:         policy,
+		Inputs:         alternateInputs,
+		Recipients:     recipients,
+		IdempotencyKey: "test-start-key",
+	})
+	require.True(t, duplicateResp.IsOk())
+
+	duplicateMsg, ok := duplicateResp.UnwrapOr(nil).(*StartTransferResponse)
+	require.True(t, ok)
+	require.Equal(t, startMsg.SessionID, duplicateMsg.SessionID)
+
+	serverConn.mu.Lock()
+	defer serverConn.mu.Unlock()
+	require.Len(t, serverConn.messages, 1)
+}
+
+func TestOORClientActorStartTransferWithoutKeyMissesIntentRetry(
+	t *testing.T) {
+
+	t.Parallel()
+
+	ctx := t.Context()
+
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	clientKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	clientSigner := input.NewMockSigner([]*btcec.PrivateKey{clientKey}, nil)
+	inputValue := btcutil.Amount(10000)
+
+	inputs := []TransferInput{
+		newTestTransferInput(
+			t, clientKey, operatorKey.PubKey(), wire.OutPoint{
+				Hash:  [32]byte{0x22},
+				Index: 0,
+			}, inputValue,
+		),
+	}
+	alternateInputs := []TransferInput{
+		newTestTransferInput(
+			t, clientKey, operatorKey.PubKey(), wire.OutPoint{
+				Hash:  [32]byte{0x23},
+				Index: 0,
+			}, inputValue,
+		),
+	}
+
+	policy := arkscript.CheckpointPolicy{
+		OperatorKey: operatorKey.PubKey(),
+		CSVDelay:    10,
+	}
+	recipients := []oortx.RecipientOutput{
+		{
+			PkScript: newTestTaprootPkScript(t, clientKey.PubKey()),
+			Value:    inputValue,
+		},
+	}
+
+	serverConn := newMockServerConnRef(t)
+	actor := NewOORClientActor(ClientActorCfg{
+		OutboxHandler: &localOnlyOutboxHandler{
+			t:            t,
+			clientSigner: clientSigner,
+		},
+		ServerConn:    serverConn,
+		DeliveryStore: newTestDeliveryStore(t),
+		ActorID:       "oor-actor-distinct-changed-input-start",
+	})
+	defer actor.Stop()
+
+	startResp := actor.Receive(ctx, &StartTransferRequest{
+		Policy:     policy,
+		Inputs:     inputs,
+		Recipients: recipients,
+	})
+	require.True(t, startResp.IsOk())
+
+	startMsg, ok := startResp.UnwrapOr(nil).(*StartTransferResponse)
+	require.True(t, ok)
+
+	duplicateResp := actor.Receive(ctx, &StartTransferRequest{
+		Policy:     policy,
+		Inputs:     alternateInputs,
+		Recipients: recipients,
+	})
+	require.True(t, duplicateResp.IsOk())
+
+	duplicateMsg, ok := duplicateResp.UnwrapOr(nil).(*StartTransferResponse)
+	require.True(t, ok)
+	require.NotEqual(t, startMsg.SessionID, duplicateMsg.SessionID)
+
+	serverConn.mu.Lock()
+	defer serverConn.mu.Unlock()
+	require.Len(t, serverConn.messages, 2)
+}
+
 // TestOORClientActorHandlesIncomingTransferWithoutExistingSession asserts the
 // actor can materialize a fresh incoming transfer before any session has been
 // registered under that session ID.


### PR DESCRIPTION
## Summary

Use the persisted OOR idempotency key to make duplicate keyed sends return the existing local session instead of creating another one.

- check existing outgoing session handles before building a new OOR package
- return the existing session id when the same non-empty idempotency key is already known locally
- keep empty-key requests on the historical deterministic-session path
- cover the duplicate-key path with a test that changes the requested output but still returns the original session

## Edge Cases

This closes the local double-submit gap after a durable OOR session exists. If a caller retries a send with the same idempotency key after restart, the actor finds the restored outgoing session and returns that session id rather than creating a second transfer.

The lookup is by caller intent key, not amount, output script, selected input value, or generated Ark txid. That means two unrelated same-amount sends remain separate when they use different keys, while a retry of the same intent remains tied to the original session even if the retry request is reconstructed slightly differently.

If the caller crashes before the daemon has durably accepted a start message or created an OOR session, there is still no local session to find. In that case the retry with the same key creates the first session normally.

Terminal sessions also keep the key. A repeated call with the same key returns the terminal session instead of silently creating a new transfer; callers that want a fresh send should use a fresh key.

## Checks

- `go test ./oor ./darepod ./sdk/ark ./cmd/darepocli/darepoclicommands`
- `make lint`
