### PR TITLE
docs: nightly doc-gardening sweep 2026-04-29

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -53,11 +53,13 @@ package may import from a higher layer.
 |---------|---------|
 | [`darepod`](darepod/) | Daemon orchestrator: wires all subsystems, exposes gRPC API |
 | [`sdk/ark`](sdk/ark/) | Consumer-facing Go SDK facade: remote or embedded daemon access with typed models |
+| [`sdk/swaps`](sdk/swaps/) | Lightning-to-Ark / Ark-to-Lightning atomic swap SDK with durable FSM flows |
 | [`cmd/darepod`](cmd/darepod/) | Daemon entry point |
 | [`cmd/darepocli`](cmd/darepocli/) | CLI client |
 | [`timeout`](timeout/) | Generic timeout scheduling actor |
 | [`indexer`](indexer/) | Server indexing client for receive script registration |
 | [`arkrpc`](arkrpc/) | Server-side gRPC service definitions (ArkService, IndexerService) |
+| [`arkrpc/treeconv`](arkrpc/treeconv/) | Narrow re-export of tree-path conversion helpers without the full gRPC surface |
 | [`rpc`](rpc/) | Client-side RPC message definitions (roundpb, oorpb) |
 | [`daemonrpc`](daemonrpc/) | Daemon gRPC API definitions |
 

--- a/arkrpc/AGENTS.md
+++ b/arkrpc/AGENTS.md
@@ -12,7 +12,9 @@ Proto source: `arkrpc/ark.proto`, `arkrpc/indexer.proto`.
   VTXO commitment tree path. Replaces opaque TLV bytes on the wire.
 - `TreePathFromTree` / `TreePathToTree` — Lossless conversion between
   `tree.Tree` and `arkrpc.TreePath`. Uses deterministic pre-order flattening
-  with sorted child indices.
+  with sorted child indices. Re-exported under the narrower
+  `arkrpc/treeconv` sub-package for callers that do not need the full gRPC
+  surface.
 - `IncomingOOREvent` — Lightweight notification (wake-up hint). Carries only
   session_id, pk_script, event_id. Triggers the three-phase receive flow.
 - `OORRecipientEvent` — Phase 1 query response from

--- a/arkrpc/CLAUDE.md
+++ b/arkrpc/CLAUDE.md
@@ -12,7 +12,9 @@ Proto source: `arkrpc/ark.proto`, `arkrpc/indexer.proto`.
   VTXO commitment tree path. Replaces opaque TLV bytes on the wire.
 - `TreePathFromTree` / `TreePathToTree` — Lossless conversion between
   `tree.Tree` and `arkrpc.TreePath`. Uses deterministic pre-order flattening
-  with sorted child indices.
+  with sorted child indices. Re-exported under the narrower
+  `arkrpc/treeconv` sub-package for callers that do not need the full gRPC
+  surface.
 - `IncomingOOREvent` — Lightweight notification (wake-up hint). Carries only
   session_id, pk_script, event_id. Triggers the three-phase receive flow.
 - `OORRecipientEvent` — Phase 1 query response from

--- a/arkrpc/treeconv/AGENTS.md
+++ b/arkrpc/treeconv/AGENTS.md
@@ -1,0 +1,38 @@
+# arkrpc/treeconv
+
+## Purpose
+
+Thin adapter package that re-exports the two tree-path conversion helpers
+from `arkrpc` under a dedicated, narrow import path. Callers that only
+need tree serialization can import `arkrpc/treeconv` without pulling in the
+full `arkrpc` gRPC surface.
+
+## Key Types
+
+- `TreePathFromTree(t *tree.Tree) (*arkrpc.TreePath, error)` — Delegates
+  to `arkrpc.TreePathFromTree`; converts a `lib/tree.Tree` to its proto
+  wire representation using deterministic pre-order flattening with sorted
+  child indices.
+- `TreePathToTree(tp *arkrpc.TreePath) (*tree.Tree, error)` — Delegates to
+  `arkrpc.TreePathToTree`; converts a proto `TreePath` back to a
+  `lib/tree.Tree`.
+
+## Relationships
+
+- **Depends on**: `arkrpc` (conversion logic and `TreePath` proto type),
+  `lib/tree` (domain `Tree` type).
+- **Depended on by**: packages that need tree serialization without the
+  full `arkrpc` gRPC import (indexer, serverconn, oor consumers).
+
+## Invariants
+
+- Round-trip invariant (inherited from `arkrpc`): `TreePathFromTree` →
+  `TreePathToTree` must reproduce the original tree, excluding derived
+  `FinalKey` fields.
+- All logic lives in `arkrpc`; this package contains only forwarding
+  declarations — never add business logic here.
+
+## Deep Docs
+
+- [arkrpc/CLAUDE.md](../CLAUDE.md) — Parent package with full conversion details.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/arkrpc/treeconv/CLAUDE.md
+++ b/arkrpc/treeconv/CLAUDE.md
@@ -1,0 +1,38 @@
+# arkrpc/treeconv
+
+## Purpose
+
+Thin adapter package that re-exports the two tree-path conversion helpers
+from `arkrpc` under a dedicated, narrow import path. Callers that only
+need tree serialization can import `arkrpc/treeconv` without pulling in the
+full `arkrpc` gRPC surface.
+
+## Key Types
+
+- `TreePathFromTree(t *tree.Tree) (*arkrpc.TreePath, error)` — Delegates
+  to `arkrpc.TreePathFromTree`; converts a `lib/tree.Tree` to its proto
+  wire representation using deterministic pre-order flattening with sorted
+  child indices.
+- `TreePathToTree(tp *arkrpc.TreePath) (*tree.Tree, error)` — Delegates to
+  `arkrpc.TreePathToTree`; converts a proto `TreePath` back to a
+  `lib/tree.Tree`.
+
+## Relationships
+
+- **Depends on**: `arkrpc` (conversion logic and `TreePath` proto type),
+  `lib/tree` (domain `Tree` type).
+- **Depended on by**: packages that need tree serialization without the
+  full `arkrpc` gRPC import (indexer, serverconn, oor consumers).
+
+## Invariants
+
+- Round-trip invariant (inherited from `arkrpc`): `TreePathFromTree` →
+  `TreePathToTree` must reproduce the original tree, excluding derived
+  `FinalKey` fields.
+- All logic lives in `arkrpc`; this package contains only forwarding
+  declarations — never add business logic here.
+
+## Deep Docs
+
+- [arkrpc/CLAUDE.md](../CLAUDE.md) — Parent package with full conversion details.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/baselib/actor/AGENTS.md
+++ b/baselib/actor/AGENTS.md
@@ -13,8 +13,16 @@ crash-safe at-least-once delivery with exactly-once deduplication.
 - `ActorConfig[M, R]` — Configuration for actor creation (behavior, mailbox, codec, delivery store).
 - `ActorRef[M, R]` — Typed reference for sending messages to an actor (`Tell`, `Ask`).
 - `TellOnlyRef[M]` — Fire-and-forget reference (no response type).
-- `ActorSystem` — Container managing actor lifecycles, registration, and shutdown.
+- `ActorSystem` — Container managing actor lifecycles, registration, and
+  shutdown. `DeadLetters() ActorRef[Message, any]` returns the dead-letter
+  outlet configured via `ActorConfig.DLO`.
+- `SystemConfig` — Configuration for `NewActorSystem`. `Log
+  fn.Option[btclog.Logger]` injects a logger into the actor runtime; pass
+  `fn.None` to disable actor-system-level tracing.
 - `ServiceKey[M, R]` — Typed key for actor discovery via `Receptionist`.
+  Methods: `Broadcast(sys, ctx, msg)` for fan-out to all registered actors,
+  `Unregister(sys, ref)` to remove a single ref, `UnregisterAll(sys)` to
+  remove all refs for this key.
 - `Receptionist` — Service locator mapping `ServiceKey` → `ActorRef` for decoupled actor wiring.
 - `Message` — Sealed interface for all actor messages (must embed `BaseMessage`).
 - `MessageCodec` — TLV-based codec for message serialization/deserialization.

--- a/baselib/actor/CLAUDE.md
+++ b/baselib/actor/CLAUDE.md
@@ -13,8 +13,16 @@ crash-safe at-least-once delivery with exactly-once deduplication.
 - `ActorConfig[M, R]` — Configuration for actor creation (behavior, mailbox, codec, delivery store).
 - `ActorRef[M, R]` — Typed reference for sending messages to an actor (`Tell`, `Ask`).
 - `TellOnlyRef[M]` — Fire-and-forget reference (no response type).
-- `ActorSystem` — Container managing actor lifecycles, registration, and shutdown.
+- `ActorSystem` — Container managing actor lifecycles, registration, and
+  shutdown. `DeadLetters() ActorRef[Message, any]` returns the dead-letter
+  outlet configured via `ActorConfig.DLO`.
+- `SystemConfig` — Configuration for `NewActorSystem`. `Log
+  fn.Option[btclog.Logger]` injects a logger into the actor runtime; pass
+  `fn.None` to disable actor-system-level tracing.
 - `ServiceKey[M, R]` — Typed key for actor discovery via `Receptionist`.
+  Methods: `Broadcast(sys, ctx, msg)` for fan-out to all registered actors,
+  `Unregister(sys, ref)` to remove a single ref, `UnregisterAll(sys)` to
+  remove all refs for this key.
 - `Receptionist` — Service locator mapping `ServiceKey` → `ActorRef` for decoupled actor wiring.
 - `Message` — Sealed interface for all actor messages (must embed `BaseMessage`).
 - `MessageCodec` — TLV-based codec for message serialization/deserialization.

--- a/cmd/darepocli/darepoclicommands/AGENTS.md
+++ b/cmd/darepocli/darepoclicommands/AGENTS.md
@@ -23,6 +23,7 @@ embed the same command tree.
 | `send` | `SendVTXO` / `SendOOR` | Send to address |
 | `balance` | `GetBalance` | Show wallet balances |
 | `oor receive` | `NewReceiveScript` | Register a new receive script and print the receive address |
+| `oor list` | `ListOORSessions` | List locally persisted OOR sessions; `--pending` filters to non-terminal sessions; `--direction` accepts `all`/`outgoing`/`incoming` |
 | `fees estimate` | `EstimateFee` | Print an itemized fee breakdown for a given VTXO amount; flags a dust-level amount on stderr |
 | `fees history` | `GetFeeHistory` | Paginate the client-side ledger entries and print the cumulative operator fee total |
 | `unroll` | `Unroll` | Trigger a unilateral exit for the VTXO at `--outpoint txid:index`. Routes through the VTXO manager's `ForceUnrollRequest` path so the FSM transitions cleanly; the registry job is created async via the chain resolver seam. Response includes `Created` (false if already exiting) and the `ActorId` to poll. |

--- a/cmd/darepocli/darepoclicommands/CLAUDE.md
+++ b/cmd/darepocli/darepoclicommands/CLAUDE.md
@@ -23,6 +23,7 @@ embed the same command tree.
 | `send` | `SendVTXO` / `SendOOR` | Send to address |
 | `balance` | `GetBalance` | Show wallet balances |
 | `oor receive` | `NewReceiveScript` | Register a new receive script and print the receive address |
+| `oor list` | `ListOORSessions` | List locally persisted OOR sessions; `--pending` filters to non-terminal sessions; `--direction` accepts `all`/`outgoing`/`incoming` |
 | `fees estimate` | `EstimateFee` | Print an itemized fee breakdown for a given VTXO amount; flags a dust-level amount on stderr |
 | `fees history` | `GetFeeHistory` | Paginate the client-side ledger entries and print the cumulative operator fee total |
 | `unroll` | `Unroll` | Trigger a unilateral exit for the VTXO at `--outpoint txid:index`. Routes through the VTXO manager's `ForceUnrollRequest` path so the FSM transitions cleanly; the registry job is created async via the chain resolver seam. Response includes `Created` (false if already exiting) and the `ActorId` to poll. |

--- a/darepod/AGENTS.md
+++ b/darepod/AGENTS.md
@@ -26,6 +26,14 @@ gRPC API.
 - `SendVTXO` — RPC handler for in-round directed sends. Validates recipients (count cap, positive and `MaxSatoshi`-bounded amounts, overflow-safe sum), resolves destinations via `resolveRecipientOutput`, and delegates to the wallet actor.
 - `resolveRecipientOutput` — Extracts pkScript and client pubkey from an `Output` proto oneof (pubkey or address). Enforces taproot-only for directed sends.
 - `registerIncomingVTXOEventRoute` — Registers the `arkrpc.IncomingVTXOEvent` mailbox route under `MethodIncomingVTXO`, dispatching decoded events to the incoming VTXO handler actor via its service key.
+- `ListOORSessions` — RPC handler that returns locally persisted OOR
+  session progress. Delegates to the OOR actor via `oor.ClientActorCfg`'s
+  session list path, mapping `OORSessionDirection` proto enum
+  ↔ `oor.SessionDirection`, and converting each summary via
+  `oorSessionSummaryToProto`. Filters by `Pending` and `Direction` from the
+  request; response fields include `SessionID`, `Direction`, `Phase`,
+  `Pending`, `RetryAfter`, `RetryReason`, `InputOutpoints`,
+  `InputAmountSat`, and `RecipientCount`.
 - `initLedgerActor` — Constructs `ledger.LedgerActor` with both `db.NewLedgerStoreDB` (double-entry ledger) and `db.NewUTXOAuditStoreDB` (UTXO audit log) as stores, starts it, registers it with the actor system under `ledger.ServiceKeyName`, and stashes the `LedgerStoreDB` on the `Server` as `s.ledgerStore` so the RPC layer can read paginated history without going through the actor mailbox. Called in `run` after the DB and delivery store are ready but before wallet unlock, since the actor does not depend on wallet state.
 - `EstimateFee` — RPC handler that proxies to the operator's `EstimateFee` over the direct gRPC connection (`s.serverConn`, reused from `fetchOperatorTerms`). No local caching: the operator's reply reflects live treasury utilization, so callers always see fresh numbers.
 - `GetFeeHistory` — RPC handler that reads through `s.ledgerStore.ListLedgerEntriesWithFeesTotal` for mutual consistency between the page and the cumulative operator-fees-paid total. Validates limit/offset bounds (offset clamped to `math.MaxInt32`) and converts sqlc rows to proto `FeeHistoryEntry` with debit/credit accounts, round_id, session_id, and event_type verbatim via `ledgerEntryToProto`.

--- a/darepod/CLAUDE.md
+++ b/darepod/CLAUDE.md
@@ -26,6 +26,14 @@ gRPC API.
 - `SendVTXO` — RPC handler for in-round directed sends. Validates recipients (count cap, positive and `MaxSatoshi`-bounded amounts, overflow-safe sum), resolves destinations via `resolveRecipientOutput`, and delegates to the wallet actor.
 - `resolveRecipientOutput` — Extracts pkScript and client pubkey from an `Output` proto oneof (pubkey or address). Enforces taproot-only for directed sends.
 - `registerIncomingVTXOEventRoute` — Registers the `arkrpc.IncomingVTXOEvent` mailbox route under `MethodIncomingVTXO`, dispatching decoded events to the incoming VTXO handler actor via its service key.
+- `ListOORSessions` — RPC handler that returns locally persisted OOR
+  session progress. Delegates to the OOR actor via `oor.ClientActorCfg`'s
+  session list path, mapping `OORSessionDirection` proto enum
+  ↔ `oor.SessionDirection`, and converting each summary via
+  `oorSessionSummaryToProto`. Filters by `Pending` and `Direction` from the
+  request; response fields include `SessionID`, `Direction`, `Phase`,
+  `Pending`, `RetryAfter`, `RetryReason`, `InputOutpoints`,
+  `InputAmountSat`, and `RecipientCount`.
 - `initLedgerActor` — Constructs `ledger.LedgerActor` with both `db.NewLedgerStoreDB` (double-entry ledger) and `db.NewUTXOAuditStoreDB` (UTXO audit log) as stores, starts it, registers it with the actor system under `ledger.ServiceKeyName`, and stashes the `LedgerStoreDB` on the `Server` as `s.ledgerStore` so the RPC layer can read paginated history without going through the actor mailbox. Called in `run` after the DB and delivery store are ready but before wallet unlock, since the actor does not depend on wallet state.
 - `EstimateFee` — RPC handler that proxies to the operator's `EstimateFee` over the direct gRPC connection (`s.serverConn`, reused from `fetchOperatorTerms`). No local caching: the operator's reply reflects live treasury utilization, so callers always see fresh numbers.
 - `GetFeeHistory` — RPC handler that reads through `s.ledgerStore.ListLedgerEntriesWithFeesTotal` for mutual consistency between the page and the cumulative operator-fees-paid total. Validates limit/offset bounds (offset clamped to `math.MaxInt32`) and converts sqlc rows to proto `FeeHistoryEntry` with debit/credit accounts, round_id, session_id, and event_type verbatim via `ledgerEntryToProto`.

--- a/harness/AGENTS.md
+++ b/harness/AGENTS.md
@@ -10,6 +10,14 @@ containers with network isolation for end-to-end testing.
 - `Harness` — Top-level test harness owning bitcoind, lnd, and arkd lifecycle.
 - `LndInstance` — Manages an LND container's lifecycle and connection.
 - `TapdHarness` — Optional Tapd instance for asset-related tests.
+- `Options` — Configuration struct passed to `NewHarness`. Controls image
+  tags, artifact directory, log routing, tapd toggle, `GroupName`, and
+  `AlwaysKeepArtifacts`.
+- `DefaultOptions()` — Returns a populated `Options` with safe defaults.
+- `Block` — Mined block header plus txid list; used by mining helpers.
+- `BlockHeader` — Verbose bitcoind `getblockheader` RPC representation.
+- `SetPostgresEnabled(enabled bool) bool` — Toggles postgres mode
+  programmatically; returns old value for restore-on-cleanup patterns.
 
 ## Relationships
 
@@ -20,4 +28,8 @@ containers with network isolation for end-to-end testing.
 ## Key Constants
 
 - `numInitialBlocks` = 106, `defaultTimeout` = 30s, `pollInterval` = 200ms.
+- `BitcoindRPCUser` / `BitcoindRPCPass` — RPC credentials shared across
+  tests.
+- `electrsReadyTimeout` = 2 minutes — separate extended timeout for the
+  electrs container HTTP readiness check.
 - Coinbase maturity: 100 blocks + 6-block buffer.

--- a/harness/CLAUDE.md
+++ b/harness/CLAUDE.md
@@ -10,6 +10,14 @@ containers with network isolation for end-to-end testing.
 - `Harness` — Top-level test harness owning bitcoind, lnd, and arkd lifecycle.
 - `LndInstance` — Manages an LND container's lifecycle and connection.
 - `TapdHarness` — Optional Tapd instance for asset-related tests.
+- `Options` — Configuration struct passed to `NewHarness`. Controls image
+  tags, artifact directory, log routing, tapd toggle, `GroupName`, and
+  `AlwaysKeepArtifacts`.
+- `DefaultOptions()` — Returns a populated `Options` with safe defaults.
+- `Block` — Mined block header plus txid list; used by mining helpers.
+- `BlockHeader` — Verbose bitcoind `getblockheader` RPC representation.
+- `SetPostgresEnabled(enabled bool) bool` — Toggles postgres mode
+  programmatically; returns old value for restore-on-cleanup patterns.
 
 ## Relationships
 
@@ -20,4 +28,8 @@ containers with network isolation for end-to-end testing.
 ## Key Constants
 
 - `numInitialBlocks` = 106, `defaultTimeout` = 30s, `pollInterval` = 200ms.
+- `BitcoindRPCUser` / `BitcoindRPCPass` — RPC credentials shared across
+  tests.
+- `electrsReadyTimeout` = 2 minutes — separate extended timeout for the
+  electrs container HTTP readiness check.
 - Coinbase maturity: 100 blocks + 6-block buffer.

--- a/lib/actormsg/AGENTS.md
+++ b/lib/actormsg/AGENTS.md
@@ -17,7 +17,11 @@ package boundaries. Lives in `lib/` to break import cycles between `vtxo`,
 - `ReserveForfeitRequest` / `ReleaseForfeitRequest` — Forfeit reservation admission messages.
 - `ReleaseSpendRequest` / `CompleteSpendRequest` — Spend lifecycle completion messages.
 - `ForceUnrollRequest` / `ForceUnrollResponse` — Ask-message that routes an operator or chain-resolver unroll trigger through the VTXO manager into the per-VTXO FSM. `ForceUnrollResponse.Accepted` is true when the request caused a state transition; when false, `Reason` distinguishes `"no such vtxo"` from `"already terminal"` so callers don't misread a silent self-loop as success.
-- `RegisterIntentMsg` — Carries pre-composed cooperative intent package to round actor.
+- `RegisterIntentMsg` — Carries pre-composed cooperative intent package to
+  round actor. The `TriggerRegistration bool` field controls whether the
+  round FSM immediately fires `IntentRequested` after accepting the intent
+  (`true` for directed sends) or parks in `PendingRoundAssembly` for
+  batching (`false` for refresh/leave flows).
 - `TriggerBoardMsg` — Carries VTXO amounts for boarding registration to round actor.
 - `SelectedVTXO` — Describes a VTXO selected for spend (outpoint, amount, pkscript).
 - `RoundActorServiceKey()` / `VTXOManagerServiceKey()` / `VTXOActorServiceKey(outpoint wire.OutPoint)` — Service key constructors for actor discovery. `VTXOActorServiceKey` encodes the target outpoint into the key so each per-VTXO actor gets a unique, deterministic key.

--- a/lib/actormsg/CLAUDE.md
+++ b/lib/actormsg/CLAUDE.md
@@ -17,7 +17,11 @@ package boundaries. Lives in `lib/` to break import cycles between `vtxo`,
 - `ReserveForfeitRequest` / `ReleaseForfeitRequest` — Forfeit reservation admission messages.
 - `ReleaseSpendRequest` / `CompleteSpendRequest` — Spend lifecycle completion messages.
 - `ForceUnrollRequest` / `ForceUnrollResponse` — Ask-message that routes an operator or chain-resolver unroll trigger through the VTXO manager into the per-VTXO FSM. `ForceUnrollResponse.Accepted` is true when the request caused a state transition; when false, `Reason` distinguishes `"no such vtxo"` from `"already terminal"` so callers don't misread a silent self-loop as success.
-- `RegisterIntentMsg` — Carries pre-composed cooperative intent package to round actor.
+- `RegisterIntentMsg` — Carries pre-composed cooperative intent package to
+  round actor. The `TriggerRegistration bool` field controls whether the
+  round FSM immediately fires `IntentRequested` after accepting the intent
+  (`true` for directed sends) or parks in `PendingRoundAssembly` for
+  batching (`false` for refresh/leave flows).
 - `TriggerBoardMsg` — Carries VTXO amounts for boarding registration to round actor.
 - `SelectedVTXO` — Describes a VTXO selected for spend (outpoint, amount, pkscript).
 - `RoundActorServiceKey()` / `VTXOManagerServiceKey()` / `VTXOActorServiceKey(outpoint wire.OutPoint)` — Service key constructors for actor discovery. `VTXOActorServiceKey` encodes the target outpoint into the key so each per-VTXO actor gets a unique, deterministic key.

--- a/lib/types/AGENTS.md
+++ b/lib/types/AGENTS.md
@@ -10,10 +10,22 @@ server during round participation. These types are used across `round`, `vtxo`,
 
 - `JoinRoundRequest` — Client's round registration request: boarding inputs, VTXO requests, forfeit requests, leave requests.
 - `JoinRoundAuth` — Authentication data for round join (Schnorr signature proof-of-control).
-- `VTXORequest` — Describes a new VTXO to create in a round (amount, owner key, cosigner keys).
-- `ForfeitRequest` — Describes a VTXO being forfeited (outpoint, connector leaf info, forfeit tx signature).
-- `LeaveRequest` — Describes a cooperative exit (VTXO outpoint, destination address).
+- `VTXORequest` — Describes a new VTXO to create in a round (amount,
+  owner key, cosigner keys). `IsChange bool` (TLV record 4) marks the
+  output that absorbs the server-computed fee residual under the #270
+  seal-time handshake; serialized into `JoinRoundAuth`.
+- `ForfeitRequest` — Describes a VTXO being forfeited (outpoint,
+  connector leaf info, forfeit tx signature). Local-only fields:
+  `AuthSpend *arkscript.SpendPath` (proof-of-control path for custom-script
+  join-auth construction) and `ForfeitSpend *arkscript.SpendPath` (spend
+  path for forfeit tx building when the VTXO uses a non-standard policy).
+- `LeaveRequest` — Describes a cooperative exit (VTXO outpoint, destination
+  address). `IsChange bool` (TLV record 3) marks the leave output that
+  absorbs the server fee residual; serialized into `JoinRoundAuth`.
 - `BoardingRequest` — Describes a boarding input (outpoint, amount, script).
+  `TxProof fn.Option[proof.TxProof]` carries an optional SPV merkle
+  inclusion proof for server-side verification of boarding UTXOs without
+  requiring the server's own chain source.
 - `OperatorTerms` — Server-published round parameters (fee rates, expiry config, connector dust amount).
 - `ClientBatchInfo` — Client's view of batch output info after tree construction.
 - `BatchOutputInfo` — Batch output metadata (outpoint, value, tree root).

--- a/lib/types/CLAUDE.md
+++ b/lib/types/CLAUDE.md
@@ -10,10 +10,22 @@ server during round participation. These types are used across `round`, `vtxo`,
 
 - `JoinRoundRequest` — Client's round registration request: boarding inputs, VTXO requests, forfeit requests, leave requests.
 - `JoinRoundAuth` — Authentication data for round join (Schnorr signature proof-of-control).
-- `VTXORequest` — Describes a new VTXO to create in a round (amount, owner key, cosigner keys).
-- `ForfeitRequest` — Describes a VTXO being forfeited (outpoint, connector leaf info, forfeit tx signature).
-- `LeaveRequest` — Describes a cooperative exit (VTXO outpoint, destination address).
+- `VTXORequest` — Describes a new VTXO to create in a round (amount,
+  owner key, cosigner keys). `IsChange bool` (TLV record 4) marks the
+  output that absorbs the server-computed fee residual under the #270
+  seal-time handshake; serialized into `JoinRoundAuth`.
+- `ForfeitRequest` — Describes a VTXO being forfeited (outpoint,
+  connector leaf info, forfeit tx signature). Local-only fields:
+  `AuthSpend *arkscript.SpendPath` (proof-of-control path for custom-script
+  join-auth construction) and `ForfeitSpend *arkscript.SpendPath` (spend
+  path for forfeit tx building when the VTXO uses a non-standard policy).
+- `LeaveRequest` — Describes a cooperative exit (VTXO outpoint, destination
+  address). `IsChange bool` (TLV record 3) marks the leave output that
+  absorbs the server fee residual; serialized into `JoinRoundAuth`.
 - `BoardingRequest` — Describes a boarding input (outpoint, amount, script).
+  `TxProof fn.Option[proof.TxProof]` carries an optional SPV merkle
+  inclusion proof for server-side verification of boarding UTXOs without
+  requiring the server's own chain source.
 - `OperatorTerms` — Server-published round parameters (fee rates, expiry config, connector dust amount).
 - `ClientBatchInfo` — Client's view of batch output info after tree construction.
 - `BatchOutputInfo` — Batch output metadata (outpoint, value, tree root).

--- a/oor/AGENTS.md
+++ b/oor/AGENTS.md
@@ -12,25 +12,50 @@ resume semantics.
 
 - `SessionID` — Stable session identifier (Ark txid hash in v0).
 - `Environment` — FSM environment providing SessionID and external system access.
-- `OutboxHandler` — Interface for executing FSM outbox requests (RPC, signing, persistence).
-- `SignArkPSBT` — Signs Ark PSBT inputs using the client key on the checkpoint 2-of-2 collab leaf; uses `MultiPrevOutFetcher` for correct BIP-341 sighash across multiple inputs.
+- `OutboxHandler` — Interface for executing FSM outbox requests (RPC, signing,
+  persistence).
+- `SignArkPSBT` — Signs Ark PSBT inputs using the client key on the checkpoint
+  2-of-2 collab leaf; uses `MultiPrevOutFetcher` for correct BIP-341 sighash
+  across multiple inputs.
 - `ClientActorCfg` — Configuration for OORClientActor (OutboxHandler,
-  ServerConn, PackageStore, DeliveryStore, VTXOManager, and optional `LedgerSink fn.Option[ledger.Sink]` for fire-and-forget accounting emission).
-- `OORClientActor` — Durable actor wrapping per-session state machines. Handles both outgoing transfers and incoming receive via three-phase async resolution. Emits `VTXOSentMsg` / `VTXOReceivedMsg` to the ledger actor at the two points the package observes state transitions it owns (FinalizeAcceptedEvent and materialized-VTXO notification).
-- `emitVTXOSent(ctx, sessionID, inputs)` — Internal helper called on `FinalizeAcceptedEvent` after the outgoing package has been persisted. Sums `TransferInputs` to get the total sent amount and Tells a `VTXOSentMsg` with the 32-byte session ID stamped on the entry. Gated on `fn.Some(ledgerSink)` — `fn.None` tests see a silent no-op.
-- `emitVTXOsReceived(ctx, descriptors)` — Internal helper called in `notifyMaterializedVTXOs`. Tells one `VTXOReceivedMsg` per descriptor with `Source = SourceOOR` so the entry books as `transfers_in` on the ledger side.
-- `NewRetryCallbackRef` — Bridges timeout actor expiry notifications into OOR actor `ResumeSessionRequest` messages for event-driven retry scheduling.
-- `IncomingSnapshot` / `NewIncomingSnapshot` — Serializable snapshot of incoming receive session state for diagnostics.
+  ServerConn, PackageStore, DeliveryStore, VTXOManager, VTXOStore, and optional
+  `LedgerSink fn.Option[ledger.Sink]` for fire-and-forget accounting emission).
+- `OORClientActor` — Durable actor wrapping per-session state machines. Handles
+  both outgoing transfers and incoming receive via three-phase async resolution.
+  Emits `VTXOSentMsg` / `VTXOReceivedMsg` to the ledger actor at the two points
+  the package observes state transitions it owns (FinalizeAcceptedEvent and
+  materialized-VTXO notification).
+- `emitVTXOSent(ctx, sessionID, inputs)` — Internal helper called on
+  `FinalizeAcceptedEvent` after the outgoing package has been persisted. Sums
+  `TransferInputs` to get the total sent amount and Tells a `VTXOSentMsg` with
+  the 32-byte session ID stamped on the entry. Gated on `fn.Some(ledgerSink)` —
+  `fn.None` tests see a silent no-op.
+- `emitVTXOsReceived(ctx, descriptors)` — Internal helper called in
+  `notifyMaterializedVTXOs`. Tells one `VTXOReceivedMsg` per descriptor with
+  `Source = SourceOOR` so the entry books as `transfers_in` on the ledger side.
+- `NewRetryCallbackRef` — Bridges timeout actor expiry notifications into OOR
+  actor `ResumeSessionRequest` messages for event-driven retry scheduling.
+- `IncomingSnapshot` / `NewIncomingSnapshot` — Serializable snapshot of incoming
+  receive session state for checkpoint persistence and diagnostics.
 
 ### Actor Messages (OORDurableMsg / ActorMsg)
 
 - `ResolveIncomingTransferRequest` — TLV-durable actor message (TLV type
   `0x7016`) persisted by the ingress route. Carries SessionID,
-  RecipientPkScript, and RecipientEventID so the actor can resume
-  phase-1 indexer resolution after a crash.
+  RecipientPkScript, and RecipientEventID so the actor can resume phase-1
+  indexer resolution after a crash.
 - `DriveEventRequest` — Generic actor message that wraps an Event and a
-  SessionID; used to feed FSM events back into a running session from
-  outbox callbacks and durable unary response routes.
+  SessionID; used to feed FSM events back into a running session from outbox
+  callbacks and durable unary response routes.
+- `ListSessionsRequest` / `ListSessionsResponse` — TLV-durable actor message
+  (TLV type `0x7017`) for querying locally known OOR sessions. Carries a
+  `SessionDirection` filter and a `PendingOnly` flag. Response is a slice of
+  `SessionSummary`.
+- `SessionSummary` — Compact diagnostic projection of an OOR session: SessionID,
+  Direction, Phase (string), Pending bool, RetryAfter, RetryReason,
+  InputOutpoints, InputAmountSat, RecipientCount.
+- `SessionDirection` — Enum (`SessionDirectionAll`, `SessionDirectionOutgoing`,
+  `SessionDirectionIncoming`) used to filter `ListSessionsRequest`.
 
 ### Outbox Events (OutboxEvent)
 
@@ -41,93 +66,196 @@ resume semantics.
   `IncomingTransferEvent` is processed; actor.go maps this to a
   `serverconn.SendListVTXOsByScriptsRequest` durable query.
 - `MaterializeIncomingVTXOsRequest` — Outbox event carrying the Ark PSBT,
-  checkpoint PSBTs, recipients, and resolved `MetadataMatches`; sent to
-  the wallet/state layer to persist incoming VTXO records.
-- `SendIncomingAckRequest` — Outbox event that asks the transport layer to
-  ack the incoming transfer to the server.
-- `IncomingTransferNotification` — Outbox event emitted alongside metadata query during incoming transfer processing.
-- `ScheduleRetryRequest` — Outbox event for scheduling retryable outbox operations via the timeout actor.
+  checkpoint PSBTs, recipients, and resolved `MetadataMatches`; sent to the
+  wallet/state layer to persist incoming VTXO records.
+- `SendIncomingAckRequest` — Outbox event that asks the transport layer to ack
+  the incoming transfer to the server.
+- `IncomingTransferNotification` — Outbox event emitted alongside metadata query
+  during incoming transfer processing.
+- `ScheduleRetryRequest` — Outbox event for scheduling retryable outbox
+  operations via the timeout actor.
 
 ### Events (Event / ReceiveState)
 
-- `IncomingTransferEvent` — FSM event carrying the full Ark PSBT and
-  checkpoint PSBTs for an incoming transfer; delivered by the phase-1
-  durable unary response route.
-- `IncomingMetadataResolvedEvent` — FSM event delivering authoritative
-  metadata query results back into the receive FSM; delivered by the
-  phase-2 durable unary response route.
-- `IncomingHandledEvent` — FSM event indicating the wallet layer has
-  persisted incoming VTXOs; carries `MaterializedOutpoints` for the
-  durable callback round-trip.
-- `IncomingAckSentEvent` — FSM event driving `ReceiveAwaitingAck → ReceiveCompleted` transition.
+- `IncomingTransferEvent` — FSM event carrying the full Ark PSBT and checkpoint
+  PSBTs for an incoming transfer; delivered by the phase-1 durable unary
+  response route.
+- `IncomingMetadataResolvedEvent` — FSM event delivering authoritative metadata
+  query results back into the receive FSM; delivered by the phase-2 durable
+  unary response route.
+- `IncomingHandledEvent` — FSM event indicating the wallet layer has persisted
+  incoming VTXOs; carries `MaterializedOutpoints` for the durable callback
+  round-trip.
+- `IncomingAckSentEvent` — FSM event driving `ReceiveAwaitingAck →
+  ReceiveCompleted` transition.
 
 ### Incoming Receive FSM States (ReceiveState)
 
 - `ReceiveIdle` — Initial state; no pending incoming transfer.
-- `ReceiveResolving` — Durable hint persisted; waiting for the phase-1
-  indexer query (ListOORRecipientEventsByScript) to return the full Ark
-  package outside the actor transaction.
-- `ReceiveNotified` — Full Ark/checkpoint package received; waiting for
-  local materialization to complete.
+- `ReceiveResolving` — Durable hint persisted; waiting for the phase-1 indexer
+  query (ListOORRecipientEventsByScript) to return the full Ark package outside
+  the actor transaction.
+- `ReceiveNotified` — Full Ark/checkpoint package received; waiting for local
+  materialization to complete.
 - `ReceiveAwaitingAck` — VTXOs materialized; waiting for ack transport to
   complete.
 - `ReceiveCompleted` — Terminal success state.
 
+### Local Persistence and Outbox Handler Chain
+
+- `LocalPersistenceOutboxHandler` — Handles persistence-related outbox requests
+  (`MarkInputsSpentRequest`, `QueryIncomingMetadataRequest`,
+  `MaterializeIncomingVTXOsRequest`, `SendIncomingAckRequest`). Delegates all
+  others to `Next`. Also implements `IncomingMetadataRecipientFilter` via
+  `FilterIncomingMetadataRecipients` so the transport layer can pre-filter
+  owned recipients before durable server queries.
+- `SpendCompleter` — Callback type (`func(ctx, []wire.OutPoint) error`) that
+  routes OOR spend completion through the VTXO manager so each consumed VTXO
+  transitions to `SpentState` via its own FSM. When nil in
+  `LocalPersistenceOutboxHandler`, falls back to direct store writes for
+  migration compatibility.
+- `IncomingClientKeyResolver` — Callback type (`func(ctx, ArkRecipientOutput)
+  (keychain.KeyDescriptor, error)`) that resolves the local client key for a
+  recipient output being materialized. Returns `ErrIncomingRecipientNotOwned`
+  for outputs belonging to other clients.
+- `IncomingMetadataResolver` — Callback type (`func(ctx, SessionID,
+  ArkRecipientOutput, *psbt.Packet, []*psbt.Packet) (IncomingVTXOMetadata,
+  error)`) that resolves authoritative lineage and expiry metadata.
+- `IncomingMetadataRecipientFilter` — Interface with
+  `FilterIncomingMetadataRecipients`; implemented by
+  `LocalPersistenceOutboxHandler` to filter wallet-owned recipients before
+  server metadata queries.
+- `IncomingVTXONotifier` — Callback type (`func(ctx, []*vtxo.Descriptor) error`)
+  called after incoming VTXOs are durably materialized; used outside the durable
+  actor path (e.g. systest, non-actor consumers).
+- `OutboxHandlerConfig` / `NewOutboxHandler` — Shared factory for the standard
+  two-layer outbox handler chain (LocalPersistenceOutboxHandler →
+  SigningOutboxHandler). Both production darepod and systest use this for
+  identical outbox handling.
+
+### Snapshot and Phase Types
+
+- `OutgoingSnapshot` — Portable outgoing session state for checkpoint and
+  restore. Carries Phase, ArkPSBT, TransferInputSnapshots, RetryAfter,
+  FailReason.
+- `OutgoingPhase` — String enum for coarse outgoing transfer stages:
+  `ark_sign_requested`, `submit_sent`, `cosigned`, `finalize_sent`,
+  `local_vtxo_update`, `completed`, `failed`.
+- `IncomingSnapshot` — Serializable snapshot of an incoming receive session;
+  used in the checkpoint blob alongside outgoing snapshots.
+- `IncomingPhase` — String enum for incoming receive stages: `resolve_pending`,
+  `materialize_pending`, `ack_pending`, `completed`, `failed`.
+- `TransferInputSnapshot` — Portable encoding of client-side signing context
+  required to finalize checkpoint PSBTs after restart. Carries Outpoint,
+  AmountSat, key material, OwnerLeafScript/Policy, VTXOPolicyTemplate, PkScript
+  (for custom spend), SpendWitnessScript, SpendControlBlock, ConditionWitness,
+  RequiredSequence, RequiredLockTime.
+
 ### Shared Adapters and Metadata Types
 
-- `IncomingVTXOMetadata` — Lineage metadata for incoming OOR VTXOs including `ChainDepth` (OOR checkpoint hop count).
-- `IncomingMetadataMatch` — Authoritative metadata for one materialized
-  incoming Ark output, keyed by OutputIndex.
+- `IncomingVTXOMetadata` — Lineage metadata for incoming OOR VTXOs including
+  `ChainDepth` (OOR checkpoint hop count).
+- `IncomingMetadataMatch` — Authoritative metadata for one materialized incoming
+  Ark output, keyed by OutputIndex.
 - `IncomingMetadataMatchesFromResponse` — Filters a
-  `ListVTXOsByScriptsResponse` down to outputs matching the current Ark
-  session and converts them to `[]IncomingMetadataMatch`.
+  `ListVTXOsByScriptsResponse` down to outputs matching the current Ark session
+  and converts them to `[]IncomingMetadataMatch`.
 - `IncomingTransferEventFromResponse` — Validates and converts one
   `ListOORRecipientEventsByScriptResponse` payload into an
   `IncomingTransferEvent` for the receive FSM.
 - `NewResolveIncomingTransferRequest` — Converts a lightweight
-  `IncomingOOREvent` notification proto into a
-  `ResolveIncomingTransferRequest`; shared by darepod and systest.
+  `IncomingOOREvent` notification proto into a `ResolveIncomingTransferRequest`;
+  shared by darepod and systest.
 - `IncomingResolveCorrelationID` / `ParseIncomingResolveCorrelationID` —
   Stable correlation ID helpers for phase-1 durable queries.
 - `IncomingMetadataCorrelationID` / `ParseIncomingMetadataCorrelationID` —
   Stable correlation ID helpers for phase-2 durable queries.
-- `NewOutboxHandler` / `OutboxHandlerConfig` — Shared factory for the standard two-layer outbox handler chain (LocalPersistenceOutboxHandler → SigningOutboxHandler).
 
 ## Relationships
 
-- **Depends on**: `baselib/protofsm` (FSM engine), `baselib/actor` (durable actors), `serverconn` (durable transport), `lib/arkscript` (policy-backed tapscript for checkpoint signing and VTXO policy templates in transfer TLV records), `ledger` (`Sink` + emission message types).
+- **Depends on**: `baselib/protofsm` (FSM engine), `baselib/actor` (durable
+  actors), `serverconn` (durable transport), `lib/arkscript` (policy-backed
+  tapscript for checkpoint signing and VTXO policy templates in transfer TLV
+  records), `ledger` (`Sink` + emission message types), `timeout` (retry
+  scheduling via `TimeoutActor`).
 - **Depended on by**: `darepod` (wiring).
 - **Sends**:
-  - → `serverconn`: `SendSubmitPackageRequest`, `SendFinalizePackageRequest`, `SendIncomingAckRequest`
-  - → `serverconn` (durable unary, via outbox): `QueryIncomingTransferRequest` → `SendListOORRecipientEventsByScriptRequest`; `QueryIncomingMetadataRequest` → `SendListVTXOsByScriptsRequest`
+  - → `serverconn`: `SendSubmitPackageRequest`, `SendFinalizePackageRequest`,
+    `SendIncomingAckRequest`
+  - → `serverconn` (durable unary, via outbox):
+    `QueryIncomingTransferRequest` → `SendListOORRecipientEventsByScriptRequest`;
+    `QueryIncomingMetadataRequest` → `SendListVTXOsByScriptsRequest`
   - → `db` (via outbox): `MarkInputsSpentRequest`
   - → `wallet`: `MaterializeIncomingVTXOsRequest`
-  - → `vtxo` manager: `VTXOsMaterializedNotification` (after incoming VTXOs are durably materialized)
-  - → `ledger` actor (via `ledger.Sink` Tell, when `fn.Some`): `VTXOSentMsg` on FinalizeAcceptedEvent (post-persistence); `VTXOReceivedMsg` with `Source=SourceOOR` per materialized descriptor
+  - → `vtxo` manager: `VTXOsMaterializedNotification` (after incoming VTXOs are
+    durably materialized)
+  - → `ledger` actor (via `ledger.Sink` Tell, when `fn.Some`): `VTXOSentMsg` on
+    FinalizeAcceptedEvent (post-persistence); `VTXOReceivedMsg` with
+    `Source=SourceOOR` per materialized descriptor
 - **Receives**:
-  - ← `serverconn` (via EventRouter): `SubmitAcceptedEvent`, `FinalizeAcceptedEvent`, `ResolveIncomingTransferRequest`
+  - ← `serverconn` (via EventRouter): `SubmitAcceptedEvent`,
+    `FinalizeAcceptedEvent`, `ResolveIncomingTransferRequest`
   - ← `serverconn` durable unary response routes:
     `DriveEventRequest{IncomingTransferEvent}`,
     `DriveEventRequest{IncomingMetadataResolvedEvent}`
   - ← local persistence callback path:
     `DriveEventRequest{IncomingHandledEvent}`
-  - ← API: `StartTransferRequest`, `DriveEventRequest`, `RestoreSessionRequest`, `ResumeSessionRequest`
+  - ← API: `StartTransferRequest`, `DriveEventRequest`,
+    `RestoreSessionRequest`, `ResumeSessionRequest`, `ListSessionsRequest`
 
 ## Invariants
 
-- Checkpoint output collab path is 2-of-2 `MultiSigCollabTapLeaf(clientKey, operatorKey)`, not single-sig. Both parties must sign the Ark tx that spends checkpoint outputs.
-- `signCustomCheckpointPSBT` re-verifies that the custom spend path binds to the VTXO pkScript via `SpendPath.VerifyBindsToPkScript` before signing. This defense-in-depth check covers persisted `TransferInputSnapshot`s resumed from disk that bypassed the `BuildCustomTransferInputs` constructor.
-- Condition witness encoding/decoding (`encodeConditionWitness`/`decodeConditionWitness`) is bounded by `maxConditionWitnessItems = 64` items and `maxConditionWitnessItemBytes = 520` bytes per item (matching Bitcoin's `MAX_SCRIPT_ELEMENT_SIZE`). Both functions enforce these limits via `wire.ReadVarBytes` so a crafted or corrupted durable blob cannot cause large memory allocations. (The separate `arkscript.readVarBytes` used by policy template decoding caps at `MaxPolicyTemplateBytes` (64 KiB); the 520-byte cap applies only to persisted OOR condition witnesses.)
-- At submit time only structural validation runs (`ValidateSubmitPackage`); full script VM validation requires both signatures and runs at finalize.
+- Checkpoint output collab path is 2-of-2
+  `MultiSigCollabTapLeaf(clientKey, operatorKey)`, not single-sig. Both parties
+  must sign the Ark tx that spends checkpoint outputs.
+- `signCustomCheckpointPSBT` re-verifies that the custom spend path binds to the
+  VTXO pkScript via `SpendPath.VerifyBindsToPkScript` before signing. This
+  defense-in-depth check covers persisted `TransferInputSnapshot`s resumed from
+  disk that bypassed the `BuildCustomTransferInputs` constructor.
+- Condition witness encoding/decoding (`encodeConditionWitness` /
+  `decodeConditionWitness`) is bounded by `maxConditionWitnessItems = 64` items
+  and `maxConditionWitnessItemBytes = 520` bytes per item (matching Bitcoin's
+  `MAX_SCRIPT_ELEMENT_SIZE`). Both functions enforce these limits via
+  `wire.ReadVarBytes` so a crafted or corrupted durable blob cannot cause large
+  memory allocations. (The separate `arkscript.readVarBytes` used by policy
+  template decoding caps at `MaxPolicyTemplateBytes` (64 KiB); the 520-byte cap
+  applies only to persisted OOR condition witnesses.)
+- At submit time only structural validation runs (`ValidateSubmitPackage`); full
+  script VM validation requires both signatures and runs at finalize.
 - Point-of-no-return: when server co-signs checkpoint transaction(s).
-- After checkpoint signature, client must resume and obtain byte-identical co-signed PSBTs (deterministic construction).
-- Transport outbox events (submit, finalize, ack) are Tell'd to ServerConn within the actor's DB transaction for atomic enqueue (same-DB tx joining via `ExecTx`).
-- Package persistence tracks finalized outgoing packages and local input bindings for recovery.
+- After checkpoint signature, client must resume and obtain byte-identical
+  co-signed PSBTs (deterministic construction).
+- Transport outbox events (submit, finalize, ack) are Tell'd to ServerConn
+  within the actor's DB transaction for atomic enqueue (same-DB tx joining via
+  `ExecTx`).
+- Package persistence tracks finalized outgoing packages and local input
+  bindings for recovery.
 - Incoming receive never performs synchronous unary RPCs inside the durable
-  actor DB transaction. Both incoming-hint resolution and authoritative
-  metadata lookup are emitted as transport-native durable `serverconn`
-  query messages and delivered back as fresh durable messages.
-- `LocalPersistenceOutboxHandler.CallbackRef` receives async materialization results so indexer queries run outside the actor tx, preventing SQLite write-lock starvation.
+  actor DB transaction. Both incoming-hint resolution and authoritative metadata
+  lookup are emitted as transport-native durable `serverconn` query messages and
+  delivered back as fresh durable messages.
+- `LocalPersistenceOutboxHandler.CallbackRef` (on the inner `SigningOutboxHandler`)
+  receives async materialization results so indexer queries run outside the actor
+  tx, preventing SQLite write-lock starvation.
+- `handleMarkInputsSpent` skips non-local outpoints (those not found in the VTXO
+  store) before routing to `CompleteSpend` or direct store writes. When
+  `CompleteSpend` is nil, falls back to direct `UpdateVTXOStatus` writes for
+  migration compatibility. A retryable error is returned if
+  `actor.ErrNoActorsAvailable` is returned by the VTXO manager.
+- `handleMaterializeIncoming` only calls `NotifyIncomingVTXOs` directly when the
+  handler is running outside a durable actor DB tx (`hasActorDBTx` returns
+  false). Inside a durable actor tx, notification is deferred to
+  `notifyMaterializedVTXOs` via the `IncomingHandledEvent` follow-up path so the
+  manager sees materialization exactly once.
+- `ListSessionsRequest` collects summaries from the in-memory `sessions` map;
+  results are sorted deterministically by SessionID string for stable output.
+  Direction and PendingOnly filters are applied after projection.
+- Checkpoint version is `oorCheckpointVersion = 2`. The restore path accepts
+  versions 1 and 2; unknown versions are rejected.
+- Self-transfer: a `ResolveIncomingTransferRequest` for a session that has an
+  active outgoing session returns an error until the outgoing session reaches a
+  terminal state, at which point the outgoing entry is deleted and an incoming
+  session is created in its place.
 
 ## Deep Docs
 

--- a/oor/CLAUDE.md
+++ b/oor/CLAUDE.md
@@ -12,25 +12,50 @@ resume semantics.
 
 - `SessionID` — Stable session identifier (Ark txid hash in v0).
 - `Environment` — FSM environment providing SessionID and external system access.
-- `OutboxHandler` — Interface for executing FSM outbox requests (RPC, signing, persistence).
-- `SignArkPSBT` — Signs Ark PSBT inputs using the client key on the checkpoint 2-of-2 collab leaf; uses `MultiPrevOutFetcher` for correct BIP-341 sighash across multiple inputs.
+- `OutboxHandler` — Interface for executing FSM outbox requests (RPC, signing,
+  persistence).
+- `SignArkPSBT` — Signs Ark PSBT inputs using the client key on the checkpoint
+  2-of-2 collab leaf; uses `MultiPrevOutFetcher` for correct BIP-341 sighash
+  across multiple inputs.
 - `ClientActorCfg` — Configuration for OORClientActor (OutboxHandler,
-  ServerConn, PackageStore, DeliveryStore, VTXOManager, and optional `LedgerSink fn.Option[ledger.Sink]` for fire-and-forget accounting emission).
-- `OORClientActor` — Durable actor wrapping per-session state machines. Handles both outgoing transfers and incoming receive via three-phase async resolution. Emits `VTXOSentMsg` / `VTXOReceivedMsg` to the ledger actor at the two points the package observes state transitions it owns (FinalizeAcceptedEvent and materialized-VTXO notification).
-- `emitVTXOSent(ctx, sessionID, inputs)` — Internal helper called on `FinalizeAcceptedEvent` after the outgoing package has been persisted. Sums `TransferInputs` to get the total sent amount and Tells a `VTXOSentMsg` with the 32-byte session ID stamped on the entry. Gated on `fn.Some(ledgerSink)` — `fn.None` tests see a silent no-op.
-- `emitVTXOsReceived(ctx, descriptors)` — Internal helper called in `notifyMaterializedVTXOs`. Tells one `VTXOReceivedMsg` per descriptor with `Source = SourceOOR` so the entry books as `transfers_in` on the ledger side.
-- `NewRetryCallbackRef` — Bridges timeout actor expiry notifications into OOR actor `ResumeSessionRequest` messages for event-driven retry scheduling.
-- `IncomingSnapshot` / `NewIncomingSnapshot` — Serializable snapshot of incoming receive session state for diagnostics.
+  ServerConn, PackageStore, DeliveryStore, VTXOManager, VTXOStore, and optional
+  `LedgerSink fn.Option[ledger.Sink]` for fire-and-forget accounting emission).
+- `OORClientActor` — Durable actor wrapping per-session state machines. Handles
+  both outgoing transfers and incoming receive via three-phase async resolution.
+  Emits `VTXOSentMsg` / `VTXOReceivedMsg` to the ledger actor at the two points
+  the package observes state transitions it owns (FinalizeAcceptedEvent and
+  materialized-VTXO notification).
+- `emitVTXOSent(ctx, sessionID, inputs)` — Internal helper called on
+  `FinalizeAcceptedEvent` after the outgoing package has been persisted. Sums
+  `TransferInputs` to get the total sent amount and Tells a `VTXOSentMsg` with
+  the 32-byte session ID stamped on the entry. Gated on `fn.Some(ledgerSink)` —
+  `fn.None` tests see a silent no-op.
+- `emitVTXOsReceived(ctx, descriptors)` — Internal helper called in
+  `notifyMaterializedVTXOs`. Tells one `VTXOReceivedMsg` per descriptor with
+  `Source = SourceOOR` so the entry books as `transfers_in` on the ledger side.
+- `NewRetryCallbackRef` — Bridges timeout actor expiry notifications into OOR
+  actor `ResumeSessionRequest` messages for event-driven retry scheduling.
+- `IncomingSnapshot` / `NewIncomingSnapshot` — Serializable snapshot of incoming
+  receive session state for checkpoint persistence and diagnostics.
 
 ### Actor Messages (OORDurableMsg / ActorMsg)
 
 - `ResolveIncomingTransferRequest` — TLV-durable actor message (TLV type
   `0x7016`) persisted by the ingress route. Carries SessionID,
-  RecipientPkScript, and RecipientEventID so the actor can resume
-  phase-1 indexer resolution after a crash.
+  RecipientPkScript, and RecipientEventID so the actor can resume phase-1
+  indexer resolution after a crash.
 - `DriveEventRequest` — Generic actor message that wraps an Event and a
-  SessionID; used to feed FSM events back into a running session from
-  outbox callbacks and durable unary response routes.
+  SessionID; used to feed FSM events back into a running session from outbox
+  callbacks and durable unary response routes.
+- `ListSessionsRequest` / `ListSessionsResponse` — TLV-durable actor message
+  (TLV type `0x7017`) for querying locally known OOR sessions. Carries a
+  `SessionDirection` filter and a `PendingOnly` flag. Response is a slice of
+  `SessionSummary`.
+- `SessionSummary` — Compact diagnostic projection of an OOR session: SessionID,
+  Direction, Phase (string), Pending bool, RetryAfter, RetryReason,
+  InputOutpoints, InputAmountSat, RecipientCount.
+- `SessionDirection` — Enum (`SessionDirectionAll`, `SessionDirectionOutgoing`,
+  `SessionDirectionIncoming`) used to filter `ListSessionsRequest`.
 
 ### Outbox Events (OutboxEvent)
 
@@ -41,93 +66,196 @@ resume semantics.
   `IncomingTransferEvent` is processed; actor.go maps this to a
   `serverconn.SendListVTXOsByScriptsRequest` durable query.
 - `MaterializeIncomingVTXOsRequest` — Outbox event carrying the Ark PSBT,
-  checkpoint PSBTs, recipients, and resolved `MetadataMatches`; sent to
-  the wallet/state layer to persist incoming VTXO records.
-- `SendIncomingAckRequest` — Outbox event that asks the transport layer to
-  ack the incoming transfer to the server.
-- `IncomingTransferNotification` — Outbox event emitted alongside metadata query during incoming transfer processing.
-- `ScheduleRetryRequest` — Outbox event for scheduling retryable outbox operations via the timeout actor.
+  checkpoint PSBTs, recipients, and resolved `MetadataMatches`; sent to the
+  wallet/state layer to persist incoming VTXO records.
+- `SendIncomingAckRequest` — Outbox event that asks the transport layer to ack
+  the incoming transfer to the server.
+- `IncomingTransferNotification` — Outbox event emitted alongside metadata query
+  during incoming transfer processing.
+- `ScheduleRetryRequest` — Outbox event for scheduling retryable outbox
+  operations via the timeout actor.
 
 ### Events (Event / ReceiveState)
 
-- `IncomingTransferEvent` — FSM event carrying the full Ark PSBT and
-  checkpoint PSBTs for an incoming transfer; delivered by the phase-1
-  durable unary response route.
-- `IncomingMetadataResolvedEvent` — FSM event delivering authoritative
-  metadata query results back into the receive FSM; delivered by the
-  phase-2 durable unary response route.
-- `IncomingHandledEvent` — FSM event indicating the wallet layer has
-  persisted incoming VTXOs; carries `MaterializedOutpoints` for the
-  durable callback round-trip.
-- `IncomingAckSentEvent` — FSM event driving `ReceiveAwaitingAck → ReceiveCompleted` transition.
+- `IncomingTransferEvent` — FSM event carrying the full Ark PSBT and checkpoint
+  PSBTs for an incoming transfer; delivered by the phase-1 durable unary
+  response route.
+- `IncomingMetadataResolvedEvent` — FSM event delivering authoritative metadata
+  query results back into the receive FSM; delivered by the phase-2 durable
+  unary response route.
+- `IncomingHandledEvent` — FSM event indicating the wallet layer has persisted
+  incoming VTXOs; carries `MaterializedOutpoints` for the durable callback
+  round-trip.
+- `IncomingAckSentEvent` — FSM event driving `ReceiveAwaitingAck →
+  ReceiveCompleted` transition.
 
 ### Incoming Receive FSM States (ReceiveState)
 
 - `ReceiveIdle` — Initial state; no pending incoming transfer.
-- `ReceiveResolving` — Durable hint persisted; waiting for the phase-1
-  indexer query (ListOORRecipientEventsByScript) to return the full Ark
-  package outside the actor transaction.
-- `ReceiveNotified` — Full Ark/checkpoint package received; waiting for
-  local materialization to complete.
+- `ReceiveResolving` — Durable hint persisted; waiting for the phase-1 indexer
+  query (ListOORRecipientEventsByScript) to return the full Ark package outside
+  the actor transaction.
+- `ReceiveNotified` — Full Ark/checkpoint package received; waiting for local
+  materialization to complete.
 - `ReceiveAwaitingAck` — VTXOs materialized; waiting for ack transport to
   complete.
 - `ReceiveCompleted` — Terminal success state.
 
+### Local Persistence and Outbox Handler Chain
+
+- `LocalPersistenceOutboxHandler` — Handles persistence-related outbox requests
+  (`MarkInputsSpentRequest`, `QueryIncomingMetadataRequest`,
+  `MaterializeIncomingVTXOsRequest`, `SendIncomingAckRequest`). Delegates all
+  others to `Next`. Also implements `IncomingMetadataRecipientFilter` via
+  `FilterIncomingMetadataRecipients` so the transport layer can pre-filter
+  owned recipients before durable server queries.
+- `SpendCompleter` — Callback type (`func(ctx, []wire.OutPoint) error`) that
+  routes OOR spend completion through the VTXO manager so each consumed VTXO
+  transitions to `SpentState` via its own FSM. When nil in
+  `LocalPersistenceOutboxHandler`, falls back to direct store writes for
+  migration compatibility.
+- `IncomingClientKeyResolver` — Callback type (`func(ctx, ArkRecipientOutput)
+  (keychain.KeyDescriptor, error)`) that resolves the local client key for a
+  recipient output being materialized. Returns `ErrIncomingRecipientNotOwned`
+  for outputs belonging to other clients.
+- `IncomingMetadataResolver` — Callback type (`func(ctx, SessionID,
+  ArkRecipientOutput, *psbt.Packet, []*psbt.Packet) (IncomingVTXOMetadata,
+  error)`) that resolves authoritative lineage and expiry metadata.
+- `IncomingMetadataRecipientFilter` — Interface with
+  `FilterIncomingMetadataRecipients`; implemented by
+  `LocalPersistenceOutboxHandler` to filter wallet-owned recipients before
+  server metadata queries.
+- `IncomingVTXONotifier` — Callback type (`func(ctx, []*vtxo.Descriptor) error`)
+  called after incoming VTXOs are durably materialized; used outside the durable
+  actor path (e.g. systest, non-actor consumers).
+- `OutboxHandlerConfig` / `NewOutboxHandler` — Shared factory for the standard
+  two-layer outbox handler chain (LocalPersistenceOutboxHandler →
+  SigningOutboxHandler). Both production darepod and systest use this for
+  identical outbox handling.
+
+### Snapshot and Phase Types
+
+- `OutgoingSnapshot` — Portable outgoing session state for checkpoint and
+  restore. Carries Phase, ArkPSBT, TransferInputSnapshots, RetryAfter,
+  FailReason.
+- `OutgoingPhase` — String enum for coarse outgoing transfer stages:
+  `ark_sign_requested`, `submit_sent`, `cosigned`, `finalize_sent`,
+  `local_vtxo_update`, `completed`, `failed`.
+- `IncomingSnapshot` — Serializable snapshot of an incoming receive session;
+  used in the checkpoint blob alongside outgoing snapshots.
+- `IncomingPhase` — String enum for incoming receive stages: `resolve_pending`,
+  `materialize_pending`, `ack_pending`, `completed`, `failed`.
+- `TransferInputSnapshot` — Portable encoding of client-side signing context
+  required to finalize checkpoint PSBTs after restart. Carries Outpoint,
+  AmountSat, key material, OwnerLeafScript/Policy, VTXOPolicyTemplate, PkScript
+  (for custom spend), SpendWitnessScript, SpendControlBlock, ConditionWitness,
+  RequiredSequence, RequiredLockTime.
+
 ### Shared Adapters and Metadata Types
 
-- `IncomingVTXOMetadata` — Lineage metadata for incoming OOR VTXOs including `ChainDepth` (OOR checkpoint hop count).
-- `IncomingMetadataMatch` — Authoritative metadata for one materialized
-  incoming Ark output, keyed by OutputIndex.
+- `IncomingVTXOMetadata` — Lineage metadata for incoming OOR VTXOs including
+  `ChainDepth` (OOR checkpoint hop count).
+- `IncomingMetadataMatch` — Authoritative metadata for one materialized incoming
+  Ark output, keyed by OutputIndex.
 - `IncomingMetadataMatchesFromResponse` — Filters a
-  `ListVTXOsByScriptsResponse` down to outputs matching the current Ark
-  session and converts them to `[]IncomingMetadataMatch`.
+  `ListVTXOsByScriptsResponse` down to outputs matching the current Ark session
+  and converts them to `[]IncomingMetadataMatch`.
 - `IncomingTransferEventFromResponse` — Validates and converts one
   `ListOORRecipientEventsByScriptResponse` payload into an
   `IncomingTransferEvent` for the receive FSM.
 - `NewResolveIncomingTransferRequest` — Converts a lightweight
-  `IncomingOOREvent` notification proto into a
-  `ResolveIncomingTransferRequest`; shared by darepod and systest.
+  `IncomingOOREvent` notification proto into a `ResolveIncomingTransferRequest`;
+  shared by darepod and systest.
 - `IncomingResolveCorrelationID` / `ParseIncomingResolveCorrelationID` —
   Stable correlation ID helpers for phase-1 durable queries.
 - `IncomingMetadataCorrelationID` / `ParseIncomingMetadataCorrelationID` —
   Stable correlation ID helpers for phase-2 durable queries.
-- `NewOutboxHandler` / `OutboxHandlerConfig` — Shared factory for the standard two-layer outbox handler chain (LocalPersistenceOutboxHandler → SigningOutboxHandler).
 
 ## Relationships
 
-- **Depends on**: `baselib/protofsm` (FSM engine), `baselib/actor` (durable actors), `serverconn` (durable transport), `lib/arkscript` (policy-backed tapscript for checkpoint signing and VTXO policy templates in transfer TLV records), `ledger` (`Sink` + emission message types).
+- **Depends on**: `baselib/protofsm` (FSM engine), `baselib/actor` (durable
+  actors), `serverconn` (durable transport), `lib/arkscript` (policy-backed
+  tapscript for checkpoint signing and VTXO policy templates in transfer TLV
+  records), `ledger` (`Sink` + emission message types), `timeout` (retry
+  scheduling via `TimeoutActor`).
 - **Depended on by**: `darepod` (wiring).
 - **Sends**:
-  - → `serverconn`: `SendSubmitPackageRequest`, `SendFinalizePackageRequest`, `SendIncomingAckRequest`
-  - → `serverconn` (durable unary, via outbox): `QueryIncomingTransferRequest` → `SendListOORRecipientEventsByScriptRequest`; `QueryIncomingMetadataRequest` → `SendListVTXOsByScriptsRequest`
+  - → `serverconn`: `SendSubmitPackageRequest`, `SendFinalizePackageRequest`,
+    `SendIncomingAckRequest`
+  - → `serverconn` (durable unary, via outbox):
+    `QueryIncomingTransferRequest` → `SendListOORRecipientEventsByScriptRequest`;
+    `QueryIncomingMetadataRequest` → `SendListVTXOsByScriptsRequest`
   - → `db` (via outbox): `MarkInputsSpentRequest`
   - → `wallet`: `MaterializeIncomingVTXOsRequest`
-  - → `vtxo` manager: `VTXOsMaterializedNotification` (after incoming VTXOs are durably materialized)
-  - → `ledger` actor (via `ledger.Sink` Tell, when `fn.Some`): `VTXOSentMsg` on FinalizeAcceptedEvent (post-persistence); `VTXOReceivedMsg` with `Source=SourceOOR` per materialized descriptor
+  - → `vtxo` manager: `VTXOsMaterializedNotification` (after incoming VTXOs are
+    durably materialized)
+  - → `ledger` actor (via `ledger.Sink` Tell, when `fn.Some`): `VTXOSentMsg` on
+    FinalizeAcceptedEvent (post-persistence); `VTXOReceivedMsg` with
+    `Source=SourceOOR` per materialized descriptor
 - **Receives**:
-  - ← `serverconn` (via EventRouter): `SubmitAcceptedEvent`, `FinalizeAcceptedEvent`, `ResolveIncomingTransferRequest`
+  - ← `serverconn` (via EventRouter): `SubmitAcceptedEvent`,
+    `FinalizeAcceptedEvent`, `ResolveIncomingTransferRequest`
   - ← `serverconn` durable unary response routes:
     `DriveEventRequest{IncomingTransferEvent}`,
     `DriveEventRequest{IncomingMetadataResolvedEvent}`
   - ← local persistence callback path:
     `DriveEventRequest{IncomingHandledEvent}`
-  - ← API: `StartTransferRequest`, `DriveEventRequest`, `RestoreSessionRequest`, `ResumeSessionRequest`
+  - ← API: `StartTransferRequest`, `DriveEventRequest`,
+    `RestoreSessionRequest`, `ResumeSessionRequest`, `ListSessionsRequest`
 
 ## Invariants
 
-- Checkpoint output collab path is 2-of-2 `MultiSigCollabTapLeaf(clientKey, operatorKey)`, not single-sig. Both parties must sign the Ark tx that spends checkpoint outputs.
-- `signCustomCheckpointPSBT` re-verifies that the custom spend path binds to the VTXO pkScript via `SpendPath.VerifyBindsToPkScript` before signing. This defense-in-depth check covers persisted `TransferInputSnapshot`s resumed from disk that bypassed the `BuildCustomTransferInputs` constructor.
-- Condition witness encoding/decoding (`encodeConditionWitness`/`decodeConditionWitness`) is bounded by `maxConditionWitnessItems = 64` items and `maxConditionWitnessItemBytes = 520` bytes per item (matching Bitcoin's `MAX_SCRIPT_ELEMENT_SIZE`). Both functions enforce these limits via `wire.ReadVarBytes` so a crafted or corrupted durable blob cannot cause large memory allocations. (The separate `arkscript.readVarBytes` used by policy template decoding caps at `MaxPolicyTemplateBytes` (64 KiB); the 520-byte cap applies only to persisted OOR condition witnesses.)
-- At submit time only structural validation runs (`ValidateSubmitPackage`); full script VM validation requires both signatures and runs at finalize.
+- Checkpoint output collab path is 2-of-2
+  `MultiSigCollabTapLeaf(clientKey, operatorKey)`, not single-sig. Both parties
+  must sign the Ark tx that spends checkpoint outputs.
+- `signCustomCheckpointPSBT` re-verifies that the custom spend path binds to the
+  VTXO pkScript via `SpendPath.VerifyBindsToPkScript` before signing. This
+  defense-in-depth check covers persisted `TransferInputSnapshot`s resumed from
+  disk that bypassed the `BuildCustomTransferInputs` constructor.
+- Condition witness encoding/decoding (`encodeConditionWitness` /
+  `decodeConditionWitness`) is bounded by `maxConditionWitnessItems = 64` items
+  and `maxConditionWitnessItemBytes = 520` bytes per item (matching Bitcoin's
+  `MAX_SCRIPT_ELEMENT_SIZE`). Both functions enforce these limits via
+  `wire.ReadVarBytes` so a crafted or corrupted durable blob cannot cause large
+  memory allocations. (The separate `arkscript.readVarBytes` used by policy
+  template decoding caps at `MaxPolicyTemplateBytes` (64 KiB); the 520-byte cap
+  applies only to persisted OOR condition witnesses.)
+- At submit time only structural validation runs (`ValidateSubmitPackage`); full
+  script VM validation requires both signatures and runs at finalize.
 - Point-of-no-return: when server co-signs checkpoint transaction(s).
-- After checkpoint signature, client must resume and obtain byte-identical co-signed PSBTs (deterministic construction).
-- Transport outbox events (submit, finalize, ack) are Tell'd to ServerConn within the actor's DB transaction for atomic enqueue (same-DB tx joining via `ExecTx`).
-- Package persistence tracks finalized outgoing packages and local input bindings for recovery.
+- After checkpoint signature, client must resume and obtain byte-identical
+  co-signed PSBTs (deterministic construction).
+- Transport outbox events (submit, finalize, ack) are Tell'd to ServerConn
+  within the actor's DB transaction for atomic enqueue (same-DB tx joining via
+  `ExecTx`).
+- Package persistence tracks finalized outgoing packages and local input
+  bindings for recovery.
 - Incoming receive never performs synchronous unary RPCs inside the durable
-  actor DB transaction. Both incoming-hint resolution and authoritative
-  metadata lookup are emitted as transport-native durable `serverconn`
-  query messages and delivered back as fresh durable messages.
-- `LocalPersistenceOutboxHandler.CallbackRef` receives async materialization results so indexer queries run outside the actor tx, preventing SQLite write-lock starvation.
+  actor DB transaction. Both incoming-hint resolution and authoritative metadata
+  lookup are emitted as transport-native durable `serverconn` query messages and
+  delivered back as fresh durable messages.
+- `LocalPersistenceOutboxHandler.CallbackRef` (on the inner `SigningOutboxHandler`)
+  receives async materialization results so indexer queries run outside the actor
+  tx, preventing SQLite write-lock starvation.
+- `handleMarkInputsSpent` skips non-local outpoints (those not found in the VTXO
+  store) before routing to `CompleteSpend` or direct store writes. When
+  `CompleteSpend` is nil, falls back to direct `UpdateVTXOStatus` writes for
+  migration compatibility. A retryable error is returned if
+  `actor.ErrNoActorsAvailable` is returned by the VTXO manager.
+- `handleMaterializeIncoming` only calls `NotifyIncomingVTXOs` directly when the
+  handler is running outside a durable actor DB tx (`hasActorDBTx` returns
+  false). Inside a durable actor tx, notification is deferred to
+  `notifyMaterializedVTXOs` via the `IncomingHandledEvent` follow-up path so the
+  manager sees materialization exactly once.
+- `ListSessionsRequest` collects summaries from the in-memory `sessions` map;
+  results are sorted deterministically by SessionID string for stable output.
+  Direction and PendingOnly filters are applied after projection.
+- Checkpoint version is `oorCheckpointVersion = 2`. The restore path accepts
+  versions 1 and 2; unknown versions are rejected.
+- Self-transfer: a `ResolveIncomingTransferRequest` for a session that has an
+  active outgoing session returns an error until the outgoing session reaches a
+  terminal state, at which point the outgoing entry is deleted and an incoming
+  session is created in its place.
 
 ## Deep Docs
 

--- a/round/AGENTS.md
+++ b/round/AGENTS.md
@@ -8,73 +8,393 @@ protocols with MuSig2 signing ceremonies.
 
 ## Key Types
 
-- `ClientState` — Sealed interface for all 15 FSM states (Idle through Confirmed/ClientFailed), including `IntentSentState`, `QuoteReceivedState`, `RoundJoinedState`, `ForfeitSignaturesCollectingState`, and `RecoveryInitiatedState`.
-- `ClientEvent` — Inbound events triggering transitions (CommitmentTxBuilt, NoncesAggregated, OperatorSigned, ForfeitSignatureResponse, ForfeitCollectionTimedOut, etc.).
-- `ClientOutMsg` — Outbound messages (JoinRoundRequest, JoinRoundAcceptOutbox, JoinRoundRejectOutbox, SubmitNoncesRequest, SubmitPartialSigRequest, SubmitVTXOForfeitSigsToServer, VTXOCreatedNotification). `JoinRoundAcceptOutbox` / `JoinRoundRejectOutbox` are the explicit accept / reject responses to a server-issued seal-time `JoinRoundQuote` (#270). Both echo the `quote_id` so the server can drop stale responses after a reseal.
-- `ClientQuote` — Client-side view of `roundpb.JoinRoundQuote`. Carries `QuoteID`, `SealPass`, `OperatorFeeSat`, positional `VTXOQuotes` / `LeaveQuotes` (server-decided amounts plus echoed pkScripts and recipient keys), `QuoteExpiresAt`, and `RejectReason`. Stored on `QuoteReceivedState` and threaded forward through `RoundJoinedState` and `CommitmentTxReceivedState` so amount validation compares against the quote rather than intent targets.
-- `IntentSentState` — State entered after `IntentRequested` (out of `PendingRoundAssembly`). Holds the client's `Intents` and an `AdmittedRoundID RoundID` field that is zero until the server's `RoundJoined` admission ack lands. `RoundJoined` is consumed as a watermark only — the actor layer re-keys the FSM from the ephemeral temp key to the server-assigned `RoundID`, but the FSM stays parked in `IntentSentState` (with `AdmittedRoundID` populated) until the seal-time `JoinRoundQuoteReceived` arrives. The quote handler cross-checks `evt.RoundID` against `s.AdmittedRoundID` and fails the FSM via `failWithNotification` if (a) `AdmittedRoundID` is still zero (quote arrived before admission) or (b) the IDs differ (server-routing or trust violation).
-- `QuoteReceivedState` — State entered on `JoinRoundQuoteReceived` between `IntentSentState` and `RoundJoinedState`. Carries `RoundID`, the `*ClientQuote`, and the cloned `Intents`. `evaluateQuote` compares the quoted `OperatorFeeSat` against `env.MaxOperatorFee`, requires `RejectReason == QuoteReason_QUOTE_OK`, validates the per-output echoes (pkScript, recipient key, non-change amount) against the intent, and rejects expired quotes (`QuoteExpiresAt`). On accept it emits `JoinRoundAcceptOutbox` (echoing `quote_id`) and advances to `RoundJoinedState`; on reject (cap exceeded, expired, or server-side non-OK reason) it emits `JoinRoundRejectOutbox` and transitions to `ClientFailedState`. A `JoinRoundQuoteReceived` arriving here with a strictly higher `SealPass` replaces the in-state quote and re-evaluates; lower-or-equal `SealPass` deliveries self-loop as stale redeliveries.
-- `RoundJoinedState` — State entered after `QuoteAccepted`. Carries the assigned `RoundID`, the cloned `Intents` (with the quote's leave amounts captured onto `Intents.QuotedLeaveAmounts` for downstream fee accounting), and the accepted `*ClientQuote`. Waits for `CommitmentTxBuilt`, which is asserted to carry `evt.RoundID == s.RoundID` (a mismatch fails the FSM with "commitment round_id mismatch"). A `JoinRoundQuoteReceived` arriving here with a strictly higher `SealPass` is treated as a server reseal-after-accept: the FSM walks back to `QuoteReceivedState` for re-evaluation (the in-flight accept's older `quote_id` is dropped server-side); the new quote's `RoundID` must still match `s.RoundID`. Lower-or-equal `SealPass` deliveries self-loop as stale.
-- `ClientEnvironment` — FSM environment providing storage access (boarding intents, round checkpoints, VTXO store).
-- `ClientWallet` — Interface for client wallet operations (embeds `input.Signer` for MuSig2 signing, adds `DeriveNextKey` for VTXO signing keys).
-- `BoardingIntent` — Represents a funded on-chain input to include in a round.
-- `Intents` — Pools of boarding, VTXO, forfeit, and leave requests accumulated before registration.
-- `IntentPackage` — FSM event wrapping `Intents` for atomic delivery to the round FSM.
-- `RegisterIntentRequest` — Actor message carrying a pre-composed `IntentPackage` from the wallet.
-- `RefreshVTXORequest` — Per-VTXO refresh registration carrying `Amount`, `VTXO`, `SigningKey`, and `OperatorFee int64`. The `OperatorFee` is quoted by the VTXO actor's `RefreshFeeQuoter` before emission; `buildVTXORequestFromRefresh` subtracts it from the new VTXO output amount and clamps to zero so a buggy quoter cannot produce a negative output.
-- `VTXOIntent` — Pre-registration VTXO request carrying `OwnerKey`, `OperatorKey`. For directed sends, `OwnerKey` is the recipient's key (distinct from the sender's `SigningKey`). Ownership is determined at confirmation time via `OwnedScriptChecker` — there is no `IsOwner` flag on the wire or in local state.
-- `RoundVTXORequest` — Pairs a `VTXOIntent` with an ephemeral `SigningKey` derived at registration time for MuSig2 tree construction.
-- `OwnedScriptChecker` — Interface that answers "does this pkScript belong to the local wallet?" The `InputSigSent → Confirmed` transition calls this for every VTXO in the round to decide which entries `buildOwnedClientVTXOs` persists as spendable local balance. Backed in production by the OOR artifact store (owned receive scripts table).
-- `OwnedScriptRegistrar` — Interface used by the round actor when building VTXO intents (refresh change, boarding change, directed-send change outputs) to persist the pkScript + owner key before the round registers. This ensures the `OwnedScriptChecker` recognizes the script when the round confirms. `handleRegisterIntent` also registers any VTXO in an incoming `RegisterIntentMsg` whose `OwnerKey.KeyLocator` is non-zero (remote recipient keys are left with a zero locator and skipped).
-- `ForfeitSignaturesCollectingState` — State entered after VTXO tree signing when round includes refresh/leave VTXOs. Waits for all expected forfeit signatures before submitting to server.
-- `ForfeitSignatureResponse` — Carries a VTXO's forfeit signature back from the VTXO actor.
-- `ConnectorLeafInfo` — Maps a VTXO outpoint to its connector output index and leaf info for forfeit construction.
-- `RoundClientConfig.LedgerSink` — Optional `fn.Option[ledger.Sink]` plumbed onto the round actor so `VTXOCreatedNotification` dispatch can fire-and-forget ledger messages. Gated on `fn.Some`; unit tests that do not register a ledger actor pass `fn.None`.
-- `emitVTXOsReceived(ctx, n)` — Origin-routed emission invoked on `VTXOCreatedNotification` dispatch. Per owned VTXO it calls `emitOwnedVTXOLedgerEntry`, which switches on `ClientVTXO.Origin` (set by the wallet at intent composition): `RoundBoarding` → `VTXOReceivedMsg{Source=SourceRoundBoarding}`; `RoundRefresh` → paired `VTXOSentMsg{Outpoint}` + `VTXOReceivedMsg{Source=SourceRoundRefresh}` so the two legs cancel on `transfers_out`; `RoundTransfer` → `VTXOReceivedMsg{Source=SourceRoundTransfer}`; `Unknown` is a silent no-op (strictly safer than a default that would corrupt the chart of accounts). After the per-VTXO loop, `emitRoundFee` appends a single `FeePaidMsg{FeeType=FeeTypeRefresh}` when `OperatorFeeSat > 0` and at least one refresh-origin VTXO was present (boarding-fee emission deferred).
-- `computeClientOperatorFee(intents, ownedVTXOs) int64` — Transition-side helper that derives the per-client operator fee as Σ(boarding input amounts) + Σ(forfeited VTXO amounts) − Σ(owned output VTXO amounts) − Σ(cooperative leave output values). Clamps to zero. Called inside the `InputSigSent → Confirmed` transition; the result is carried on `VTXOCreatedNotification.OperatorFeeSat` for the actor's emission path to read.
+### FSM States (`states.go`)
+
+- `ClientState` — Sealed interface for all 15 FSM states (Idle through
+  Confirmed/ClientFailed). Concrete states: `Idle`,
+  `PendingRoundAssembly`, `IntentSentState`, `QuoteReceivedState`,
+  `RoundJoinedState`, `CommitmentTxReceivedState`,
+  `CommitmentTxValidatedState`, `NoncesSentState`,
+  `NoncesAggregatedState`, `PartialSigsSentState`,
+  `ForfeitSignaturesCollectingState`, `InputSigSentState`,
+  `ConfirmedState`, `ClientFailedState`, `RecoveryInitiatedState`.
+- `IntentSentState` — State entered after `IntentRequested` (out of
+  `PendingRoundAssembly`). Holds the client's `Intents` and an
+  `AdmittedRoundID RoundID` field that is zero until the server's
+  `RoundJoined` admission ack lands. `RoundJoined` is consumed as a
+  watermark only — the actor layer re-keys the FSM from the ephemeral
+  temp key to the server-assigned `RoundID`, but the FSM stays parked
+  in `IntentSentState` (with `AdmittedRoundID` populated) until the
+  seal-time `JoinRoundQuoteReceived` arrives.
+- `QuoteReceivedState` — Entered on `JoinRoundQuoteReceived` between
+  `IntentSentState` and `RoundJoinedState`. Carries `RoundID`, the
+  `*ClientQuote`, and the cloned `Intents`. `evaluateQuote` compares
+  `OperatorFeeSat` against `env.MaxOperatorFee`, validates echoed
+  per-output amounts/pkScripts/recipient keys, and rejects expired
+  quotes. On accept emits `JoinRoundAcceptOutbox`; on reject emits
+  `JoinRoundRejectOutbox` and transitions to `ClientFailedState`. A
+  `JoinRoundQuoteReceived` with a strictly higher `SealPass` replaces
+  the in-state quote and re-evaluates; lower-or-equal deliveries
+  self-loop as stale.
+- `RoundJoinedState` — Entered after `QuoteAccepted`. Carries
+  `RoundID`, the cloned `Intents` (with leave amounts captured on
+  `Intents.QuotedLeaveAmounts`), and the accepted `*ClientQuote`.
+  Awaits `CommitmentTxBuilt`. A `JoinRoundQuoteReceived` with a
+  strictly higher `SealPass` walks the FSM back to
+  `QuoteReceivedState` for re-evaluation.
+- `ForfeitSignaturesCollectingState` — Entered after VTXO tree signing
+  when the round includes refresh/leave VTXOs. Fields:
+  `ExpectedForfeits map[wire.OutPoint]*ConnectorLeafInfo` and
+  `CollectedForfeits map[wire.OutPoint]*ForfeitSignatureResponse`.
+  Waits until all expected forfeit signatures are collected, then
+  submits to server.
+- `ClientQuote` — Client-side view of `roundpb.JoinRoundQuote`.
+  Carries `QuoteID [32]byte`, `SealPass uint32`, `OperatorFeeSat
+  int64`, positional `VTXOQuotes []VTXOQuoteEntry` / `LeaveQuotes
+  []LeaveQuoteEntry` (server-decided amounts plus echoed pkScripts and
+  recipient keys), `QuoteExpiresAt int64`, and `RejectReason
+  roundpb.QuoteReason`. Stored on `QuoteReceivedState` and threaded
+  forward through `RoundJoinedState` and `CommitmentTxReceivedState`.
+- `VTXOQuoteEntry` — Per-VTXO positional entry in a `ClientQuote`.
+  Fields: `PkScript []byte`, `AmountSat int64`, `RecipientKey []byte`.
+  `evaluateQuote` cross-checks all three against the intent's
+  positional `VTXORequest`.
+- `LeaveQuoteEntry` — Per-leave positional entry in a `ClientQuote`.
+  Fields: `PkScript []byte`, `AmountSat int64`. Echoed pkScript lets
+  `evaluateQuote` cross-check positional agreement with intent's
+  `LeaveRequests`.
+
+### Events (`events.go`)
+
+- `ClientEvent` — Sealed interface for all FSM inbound events.
+- `JoinRoundQuoteReceived` — Carries `RoundID` and `*ClientQuote`.
+  Transitions the FSM from `IntentSentState` to `QuoteReceivedState`.
+  Also accepted in `QuoteReceivedState` (reseal, higher `SealPass`)
+  and `RoundJoinedState` (reseal-after-accept, walks back to
+  `QuoteReceivedState`).
+- `QuoteAccepted` — Internal event fired by `QuoteReceivedState` after
+  fee-cap check passes. Carries `RoundID` and `QuoteID [32]byte`.
+- `QuoteRejected` — Internal event fired by `QuoteReceivedState` when
+  fee cap is exceeded or server reject reason is non-OK. Carries
+  `RoundID`, `QuoteID [32]byte`, and `Reason string`.
+- `ForfeitCollectionTimedOut` — Emitted by the round actor when the
+  forfeit signature collection window expires. Carries `RoundID`.
+- `ForfeitSignatureResponse` — Carries a VTXO's forfeit signature back
+  from the VTXO actor. Fields: `VTXOOutpoint`, `RoundID string`,
+  `ForfeitTx *wire.MsgTx`, `Signature *schnorr.Signature`, `SpendPath
+  *arkscript.SpendPath`.
+- `ConnectorLeafInfo` — Maps a VTXO outpoint to its connector info for
+  forfeit construction. Fields: `LeafIndex int` (not populated by
+  `FromProto`), `ConnectorOutpoint wire.OutPoint`,
+  `ConnectorPkScript []byte`, `ConnectorAmount int64`, `VTXOAmount
+  btcutil.Amount`. `VTXOAmount` enables validation that the forfeit
+  penalty output equals the correct forfeited amount.
+- `IntentPackage` — Single FSM event embedding `Intents` for atomic
+  delivery. Covers all pooled intent types (boarding, VTXO, forfeit,
+  leave). `isEmpty()` guards against sending empty packages.
+
+### Outbox Messages (`outbox_messages.go`)
+
+- `ClientOutMsg` — Sealed interface for all FSM outbox messages.
+- `JoinRoundAcceptOutbox` — Emitted after quote fee-cap check passes.
+  Carries `RoundID` and `QuoteID [32]byte`; routed to
+  `MethodAcceptQuote`. `ToProto()` encodes to `roundpb.JoinRoundAccept`.
+- `JoinRoundRejectOutbox` — Emitted when client refuses the server's
+  quote. Carries `RoundID`, `QuoteID [32]byte`, `Reason string`;
+  routed to `MethodRejectQuote`. `ToProto()` encodes to
+  `roundpb.JoinRoundReject`.
+- `SubmitForfeitSigRequest` — Carries `RoundID` and `Signatures
+  []*types.BoardingInputSignature`; routed to
+  `MethodSubmitForfeitSigs`. `ToProto()` converts via
+  `roundpb.BoardingInputSigToProto`.
+- `StartTimeoutReq` — Asks the actor to schedule a timeout for a
+  round phase. Fields: `RoundID`, `Phase TimeoutPhase`, `Duration
+  time.Duration`.
+- `CancelTimeoutReq` — Asks the actor to cancel a previously
+  scheduled timeout. Fields: `RoundID`, `Phase TimeoutPhase`.
+- `RoundCheckpointedNotification` — Emitted by the primary FSM when it
+  reaches `InputSigSentState`, signalling the actor to migrate this
+  round to a dedicated round FSM. Carries `RoundID`.
+- `RoundCompletedNotification` — Emitted when an FSM reaches
+  `ConfirmedState`. Carries `RoundID`, `TxID`, and `ConfInfo`. Signals
+  actor to perform cleanup (remove from `activeRounds`, finalize
+  storage).
+- `RoundFailedNotification` — Emitted when an FSM transitions to
+  `ClientFailedState`. Carries `RoundID fn.Option[RoundID]`, `Reason
+  string`, `Recoverable bool`, `OriginalError error`.
+- `ForfeitRequestToVTXO` — Emitted by the FSM to ask a VTXO actor to
+  sign its forfeit tx. Fields: `VTXOOutpoint`, `RoundID string`,
+  `ConnectorOutpoint`, `ConnectorPkScript`, `ConnectorAmount int64`,
+  `ServerForfeitPkScript []byte`, `ForfeitSpend *arkscript.SpendPath`
+  (overrides default collaborative leaf for custom-policy VTXOs).
+- `ForfeitConfirmedToVTXO` — Emitted on commitment tx confirmation to
+  signal old VTXO actors they are permanently forfeited. Fields:
+  `VTXOOutpoint`, `CommitmentTxID`, `BlockHeight int32`.
+
+### Interfaces (`interfaces.go`)
+
+- `ClientEnvironment` — FSM environment providing storage access
+  (boarding intents, round checkpoints, VTXO store).
+- `ClientWallet` — Interface for client wallet operations (embeds
+  `input.Signer` for MuSig2 signing, adds `DeriveNextKey` for VTXO
+  signing keys).
+- `OwnedScriptChecker` — Interface that answers "does this pkScript
+  belong to the local wallet?" `IsOwnedScript(ctx, pkScript) →
+  fn.Result[bool]`. The `InputSigSent → Confirmed` transition calls
+  this for every VTXO in the round to decide which entries
+  `buildOwnedClientVTXOs` persists. Backed in production by the OOR
+  artifact store. When nil (tests), every VTXO is treated as owned.
+- `OwnedScriptRegistrar` — `RegisterOwnedScript(ctx, pkScript,
+  ownerKey)` called at intent-build time for change/refresh outputs
+  and inside `handleRegisterIntent` for entries with a non-zero
+  `KeyLocator`. Remote recipient keys carry a zero `KeyLocator` and
+  are skipped.
+- `VTXOStore` — Persistence for off-chain balance. Methods:
+  `SaveVTXOs`, `ListVTXOs`, `GetVTXO`, `MarkVTXOSpent`.
+- `RoundStore` — Persistence for round FSM state. Methods:
+  `CommitState`, `FetchState`, `LookupRoundByCommitmentTx`,
+  `ListActiveRounds`, `FinalizeRound`.
+
+### Key Data Types (`interfaces.go`)
+
+- `Intents` — Pools of boarding, VTXO, forfeit, and leave requests.
+  Field `QuotedLeaveAmounts []int64` holds server-authoritative leave
+  output amounts captured at `QuoteAccepted` time. `LeaveAmount(idx)`
+  returns the authoritative value, falling back to intent target when
+  no quote was accepted.
+- `VTXOIntent` — Pre-registration VTXO request carrying `Amount`,
+  `PolicyTemplate`, `PkScript`, `Expiry`, `OwnerKey`, `OperatorKey`.
+  For directed sends, `OwnerKey` is the recipient's key.
+- `RoundVTXORequest` — Pairs a `VTXOIntent` with an ephemeral
+  `SigningKey keychain.KeyDescriptor` for MuSig2 tree construction.
+  `ToVTXORequest()` converts to `types.VTXORequest`.
+- `ClientVTXO` — Full VTXO descriptor owned by the client. Adds
+  `Origin types.VTXOOrigin`, `CommitmentTxID`, `BatchExpiry int32`,
+  and `CreatedHeight int32` on top of the basic VTXO fields.
+- `BoardingIntent` — Embeds `wallet.BoardingIntent` plus a
+  `Request types.BoardingRequest`.
+
+### Actor-level Types (`actor_messages.go`, `actor.go`)
+
+- `ClientMsg` — Marker interface for messages receivable by
+  `RoundClientActor` (embeds `actormsg.RoundReceivable`).
+- `ClientResp` — Sealed interface for responses from
+  `RoundClientActor` (embeds `actormsg.RoundActorResp`).
+- `ServerMsg` / `ServerResp` — Sealed interfaces for round server
+  actor messages (stubs; server actor types TBD).
+- `WalletBoardingConfirmed` — Wraps `wallet.BoardingIntent` to make
+  boarding UTXO confirmations compatible with the `ClientMsg`
+  interface.
+- `ServerMessageNotification` — Delivers a `ClientEvent` from the
+  server FSM outbox to the round actor.
+- `ServerMessageResponse` — Acknowledges receipt of a server message.
+- `GetClientStateRequest` / `GetClientStateResponse` — Query the
+  current state of all FSMs. `GetClientStateResponse.States` maps FSM
+  key strings to `FSMStateInfo{State, IsTemp, RoundID}`.
+- `FSMStateInfo` — Bundles `State ClientState`, `IsTemp bool`, and
+  `RoundID` for introspection without exposing the full FSM.
+- `CancelRoundRequest` / `CancelRoundResponse` — Cancel participation
+  in a round identified by `RoundKey fn.Option[RoundKeyStr]`.
+- `RegisterVTXORequestsRequest` / `RegisterVTXORequestsResponse` —
+  Inform the FSM of VTXO amounts to include in the next round.
+- `ConfirmationEvent` — Wraps a chain confirmation from `ChainSource`.
+  Fields: `Txid`, `BlockHeight int32`, `BlockHash`, `Confirmations
+  uint32`, `Tx *wire.MsgTx`.
+- `TimeoutMsg` — Sent to the round actor when a timeout fires. Carries
+  `TimeoutID timeout.ID`.
+- `RegisterIntentRequest` — Actor message carrying a pre-composed
+  `IntentPackage` from the wallet.
+- `RefreshVTXORequest` — Per-VTXO refresh registration carrying
+  `Amount`, `VTXO`, `SigningKey`, and `OperatorFee int64`. The
+  `OperatorFee` is quoted by the VTXO actor's `RefreshFeeQuoter` before
+  emission; `buildVTXORequestFromRefresh` subtracts it from the new
+  VTXO output amount and clamps to zero so a buggy quoter cannot
+  produce a negative output.
+
+### VTXO Actor Messages (`vtxo_messages.go`)
+
+- `VTXOActorMsg` / `VTXOManagerMsg` — Marker interfaces for messages
+  to VTXO actors and the VTXO manager.
+- `BlockEpochEvent` — New block notification. Fields: `Height int32`,
+  `Hash`, `Timestamp int64`.
+- `ForfeitRequestEvent` — Asks a VTXO actor to sign its forfeit tx.
+  Fields mirror `ForfeitRequestToVTXO` plus `ForfeitSpend
+  *arkscript.SpendPath`.
+- `ForfeitConfirmedEvent` — Commitment tx confirmed, forfeit final.
+  Fields: `CommitmentTxID`, `BlockHeight int32`.
+- `SpendReserveEvent` — Claims a VTXO for an OOR spend (LiveState
+  only).
+- `SpendReleasedEvent` — Releases a VTXO from spend reservation back
+  to LiveState.
+- `SpendCompletedEvent` — Marks a VTXO as fully spent via OOR tx.
+- `ForfeitReleasedEvent` — Releases a VTXO from pending forfeit back
+  to LiveState when round registration fails.
+- `ForfeitSignedEvent` — Internal: forfeit tx signed and submitted.
+  Carries `ForfeitTxID`.
+- `VTXOFailedEvent` — Error during VTXO processing. Fields: `Reason`,
+  `Error`, `Recoverable bool`.
+- `ResumeVTXOEvent` — Sent during startup to restore a VTXO actor
+  from persisted state.
+- `PendingForfeitEvent` — Transitions a VTXO to `PendingForfeitState`
+  when the round actor admits it for cooperative consumption.
+- `VTXOTerminatedMsg` — Notifies the VTXO manager that a VTXO actor
+  has reached a terminal state. Fields: `Outpoint`, `FinalState
+  string`, `Reason string`.
+
+### Timeout Types (`fsm_timeouts.go`)
+
+- `TimeoutPhase string` — Identifies which FSM phase owns a timeout.
+  Only defined value: `TimeoutPhaseForfeitCollection =
+  "forfeit-collection"`.
+
+### Proto Deserialization (`from_proto.go`)
+
+- `MaxQuoteEntriesPerClient = 1024` — Bounds the per-quote VTXO/leave
+  entry slices decoded from the server to cheaply reject malformed or
+  malicious envelopes before allocating large backing slices.
+- `FromProto` methods on `JoinRoundQuoteReceived`, `RoundJoined`,
+  `CommitmentTxBuilt`, `AwaitingBoardingSigs`, `NoncesAggregated`,
+  `OperatorSigned`, `BoardingFailed`, and `JoinRoundRequest`. All
+  implement the private `inboundServerMessage` interface checked by
+  compile-time assertions.
+
+### Ledger Emission
+
+- `RoundClientConfig.LedgerSink` — Optional `fn.Option[ledger.Sink]`
+  plumbed onto the round actor so `VTXOCreatedNotification` dispatch
+  can fire-and-forget ledger messages. Gated on `fn.Some`; unit tests
+  that do not register a ledger actor pass `fn.None`.
+- `emitVTXOsReceived(ctx, n)` — Origin-routed emission. Per owned
+  VTXO switches on `ClientVTXO.Origin`: `RoundBoarding` →
+  `VTXOReceivedMsg{Source=SourceRoundBoarding}`; `RoundRefresh` →
+  paired `VTXOSentMsg{Outpoint}` + `VTXOReceivedMsg{Source=
+  SourceRoundRefresh}`; `RoundTransfer` →
+  `VTXOReceivedMsg{Source=SourceRoundTransfer}`; `Unknown` → silent
+  no-op. After the per-VTXO loop, `emitRoundFee` appends one
+  `FeePaidMsg{FeeType=FeeTypeRefresh}` when `OperatorFeeSat > 0` and
+  at least one refresh-origin VTXO was emitted.
+- `computeClientOperatorFee(intents, ownedVTXOs) int64` —
+  Σ(boarding inputs) + Σ(forfeited VTXOs) − Σ(owned output VTXOs) −
+  Σ(cooperative leave outputs). Clamps to zero. Called inside the
+  `InputSigSent → Confirmed` transition; result is carried on
+  `VTXOCreatedNotification.OperatorFeeSat`.
 
 ## Relationships
 
-- **Depends on**: `baselib/protofsm` (FSM engine), `lib/tree` (Merkle trees), `lib/types` (shared domain types), `lib/arkscript` (policy-backed tapscript construction), `wallet` (types: `BoardingAddress`, `BoardingIntent`, `SelectedVTXO`), `ledger` (`Sink` + `VTXOReceivedMsg` / `Source*` constants), `google/uuid` (round ID parsing for ledger emission).
-- **Depended on by**: `vtxo` (forfeit coordination), `db` (round persistence), `darepod` (wiring, owned-script adapters).
+- **Depends on**: `baselib/protofsm` (FSM engine), `lib/tree` (Merkle
+  trees), `lib/types` (shared domain types), `lib/arkscript`
+  (policy-backed tapscript construction), `wallet` (types:
+  `BoardingAddress`, `BoardingIntent`), `ledger` (`Sink` +
+  `VTXOReceivedMsg` / `Source*` constants), `timeout` (timeout
+  scheduling), `google/uuid` (round ID parsing).
+- **Depended on by**: `vtxo` (forfeit coordination), `db` (round
+  persistence), `darepod` (wiring, owned-script adapters).
 - **Sends**:
-  - → `serverconn`: `JoinRoundRequest`, `JoinRoundAcceptOutbox`, `JoinRoundRejectOutbox`, `SubmitNoncesRequest`, `SubmitPartialSigRequest`, `SubmitVTXOForfeitSigsToServer`
-  - → `vtxo`: `ForfeitRequestEvent`, `ForfeitConfirmedEvent`, `BlockEpochEvent`, `PendingForfeitEvent`, `SpendReserveEvent`, `SpendCompletedEvent`, `ForfeitReleasedEvent`
-  - → `vtxo` manager: `VTXOCreatedNotification`
-  - → `wallet`: `RegisterConfirmationNotifierRequest`
-  - → `timeout`: `ScheduleTimeoutRequest`, `CancelTimeoutRequest`
-  - → `OwnedScriptRegistrar` (darepod adapter over OOR artifact store): `RegisterOwnedScript(pkScript, ownerKey)`
-  - → `ledger` actor (via `ledger.Sink` Tell, when `fn.Some`), origin-routed per owned `ClientVTXO`:
-    `VTXOReceivedMsg{Source=SourceRoundBoarding}` for boarding-origin VTXOs;
-    paired `VTXOSentMsg{Outpoint}` + `VTXOReceivedMsg{Source=SourceRoundRefresh}` for refresh-origin VTXOs (legs cancel on transfers_out);
-    `VTXOReceivedMsg{Source=SourceRoundTransfer}` for participant-transfer-origin VTXOs;
-    one `FeePaidMsg{FeeType=FeeTypeRefresh}` per round when `OperatorFeeSat > 0` and any refresh-origin VTXO was emitted (boarding-fee emission deferred).
+  - → `serverconn`: `JoinRoundRequest`, `JoinRoundAcceptOutbox`,
+    `JoinRoundRejectOutbox`, `SubmitNoncesRequest`,
+    `SubmitPartialSigRequest`, `SubmitForfeitSigRequest`,
+    `SubmitVTXOForfeitSigsToServer`
+  - → `vtxo` actors: `ForfeitRequestToVTXO`, `ForfeitConfirmedToVTXO`,
+    `ForfeitRequestEvent`, `ForfeitConfirmedEvent`, `BlockEpochEvent`,
+    `PendingForfeitEvent`, `SpendReserveEvent`, `SpendCompletedEvent`,
+    `ForfeitReleasedEvent`, `SpendReleasedEvent`
+  - → `vtxo` manager: `VTXOCreatedNotification`, `VTXOTerminatedMsg`
+  - → `wallet`: `RegisterConfirmationRequest`
+  - → `timeout` (via `StartTimeoutReq` / `CancelTimeoutReq`)
+  - → `OwnedScriptRegistrar` (darepod adapter over OOR artifact store):
+    `RegisterOwnedScript(pkScript, ownerKey)`
+  - → `ledger` actor (via `ledger.Sink` Tell, when `fn.Some`),
+    origin-routed per owned `ClientVTXO`:
+    `VTXOReceivedMsg{Source=SourceRoundBoarding}` for boarding-origin;
+    paired `VTXOSentMsg{Outpoint}` +
+    `VTXOReceivedMsg{Source=SourceRoundRefresh}` for refresh-origin
+    (legs cancel on transfers_out);
+    `VTXOReceivedMsg{Source=SourceRoundTransfer}` for transfer-origin;
+    one `FeePaidMsg{FeeType=FeeTypeRefresh}` per round when
+    `OperatorFeeSat > 0` and any refresh-origin VTXO was emitted.
 - **Receives**:
-  - ← `serverconn`: `CommitmentTxBuilt`, `NoncesAggregated`, `OperatorSigned`, `RoundJoined`, `BoardingFailed`, `JoinRoundQuoteReceived`
+  - ← `serverconn`: `CommitmentTxBuilt`, `NoncesAggregated`,
+    `OperatorSigned`, `RoundJoined`, `BoardingFailed`,
+    `JoinRoundQuoteReceived` (via `ServerMessageNotification`)
   - ← `vtxo`: `ForfeitSignatureResponse` (relayed through manager)
-  - ← `wallet` (via `lib/actormsg`): `RegisterIntentMsg` (cooperative intent packages pre-admitted by manager), `TriggerBoardMsg` (VTXO registration + registration trigger)
-  - ← `wallet`: `BoardingUtxoConfirmedEvent`
+  - ← `wallet` (via `lib/actormsg`): `RegisterIntentMsg` (cooperative
+    intent packages pre-admitted by manager), `TriggerBoardMsg` (VTXO
+    registration + registration trigger)
+  - ← `wallet` (via `WalletBoardingConfirmed`): boarding UTXO
+    confirmations
   - ← `timeout`: `TimeoutMsg`
   - ← `chainsource`: `ConfirmationEvent`
 
 ## Invariants
 
-- Tree signatures must be validated BEFORE boarding input signatures are released (security checkpoint at InputSigSent).
-- Forfeit signatures are collected AFTER VTXO tree signing is complete (ForfeitSignaturesCollectingState), ensuring clients only forfeit old VTXOs after verifying new VTXOs are properly signed.
-- After aggregated signatures are validated on `VTXOTreePaths`, they are
-  propagated to extracted `ClientTrees` via `SubmitTreeSigs` + `VerifySigned`.
-  This ensures persisted client trees contain valid signatures for unilateral
-  exit (unrolling).
-- Round state is checkpointed atomically after tree validation; crash before checkpoint means client has no record of sent signatures.
-- Primary FSM handles interactive phases (through InputSigSent); a dedicated FSM per round handles confirmation monitoring.
-- The round actor does not mark VTXOs as PendingForfeit — the wallet/manager admits VTXOs before sending RegisterIntentMsg.
-- `ClientWallet` provides MuSig2 signing and key derivation; boarding address creation is handled by the wallet actor (not the round FSM).
-- Persisted VTXO ownership uses `OwnerKey` (not `SigningKey`). For directed sends the sender's signing key participates in MuSig2 tree construction, but the recipient's owner key determines VTXO ownership.
-- Local-balance persistence on confirmation is driven by `OwnedScriptChecker.IsOwnedScript(pkScript)`, not by any per-intent boolean. `buildOwnedClientVTXOs` skips any VTXO whose pkScript the checker does not recognize; the client still co-signs its tree path, so foreign recipients in a directed send still get a valid unroll proof. When the checker is nil (tests), every VTXO is treated as owned.
-- VTXO pkScripts are registered with `OwnedScriptRegistrar` at intent-build time for change/refresh outputs, and inside `handleRegisterIntent` for any `RegisterIntentMsg` entry with a non-zero `KeyLocator`. Remote recipient keys in directed sends carry a zero `KeyLocator` and are intentionally left unregistered.
-- Each client sub-tree in the commitment tree must contain exactly one non-anchor leaf. `buildOwnedClientVTXOs` fails the transition if a signing-key sub-tree yields anything other than one leaf.
-- Seal-time fee handshake (#270): the server is the amount authority. When `QuoteReceivedState.Quote` is non-nil, it threads through `RoundJoinedState` → `CommitmentTxReceivedState`, and `CommitmentTxReceivedState` validates each VTXO leaf and leave output against the quote's positional amount (not the intent target). `env.MaxOperatorFee` is applied at `QuoteReceivedState` — each seal pass re-evaluates the cap independently. Quote-less harness paths fall back to intent targets so pre-#270 FSM tests keep working.
-- RoundID identity is asserted at every server-pushed event that carries one. `IntentSentState` records the admitted `RoundID` from the `RoundJoined` ack onto `AdmittedRoundID` and cross-checks `JoinRoundQuoteReceived.RoundID` against it; `RoundJoinedState` cross-checks both `CommitmentTxBuilt.RoundID` and any reseal-after-accept `JoinRoundQuoteReceived.RoundID` against its own `RoundID`. The actor's routing map is keyed by the same RoundID, so under normal operation these checks agree by construction; the FSM-level assertion is defense-in-depth against a future actor-routing regression or a server stamping a foreign RoundID onto a payload.
+- Tree signatures must be validated BEFORE boarding input signatures
+  are released (security checkpoint at `InputSigSent`).
+- Forfeit signatures are collected AFTER VTXO tree signing is complete
+  (`ForfeitSignaturesCollectingState`), ensuring clients only forfeit
+  old VTXOs after verifying new VTXOs are properly signed.
+- After aggregated signatures are validated on `VTXOTreePaths`, they
+  are propagated to extracted `ClientTrees` via `SubmitTreeSigs` +
+  `VerifySigned`. This ensures persisted client trees contain valid
+  signatures for unilateral exit (unrolling).
+- Round state is checkpointed atomically after tree validation; crash
+  before checkpoint means client has no record of sent signatures.
+- Primary FSM handles interactive phases (through `InputSigSent`); a
+  dedicated FSM per round handles confirmation monitoring.
+- The round actor does not mark VTXOs as `PendingForfeit` — the
+  wallet/manager admits VTXOs before sending `RegisterIntentMsg`.
+- `ClientWallet` provides MuSig2 signing and key derivation; boarding
+  address creation is handled by the wallet actor (not the round FSM).
+- Persisted VTXO ownership uses `OwnerKey` (not `SigningKey`). For
+  directed sends the sender's signing key participates in MuSig2 tree
+  construction, but the recipient's owner key determines VTXO
+  ownership.
+- Local-balance persistence on confirmation is driven by
+  `OwnedScriptChecker.IsOwnedScript(pkScript)`, not by any per-intent
+  boolean. `buildOwnedClientVTXOs` skips any VTXO whose pkScript the
+  checker does not recognize; the client still co-signs its tree path,
+  so foreign recipients in a directed send still get a valid unroll
+  proof. When the checker is nil (tests), every VTXO is treated as
+  owned.
+- VTXO pkScripts are registered with `OwnedScriptRegistrar` at
+  intent-build time for change/refresh outputs, and inside
+  `handleRegisterIntent` for any `RegisterIntentMsg` entry with a
+  non-zero `KeyLocator`. Remote recipient keys in directed sends carry
+  a zero `KeyLocator` and are intentionally left unregistered.
+- Each client sub-tree in the commitment tree must contain exactly one
+  non-anchor leaf. `buildOwnedClientVTXOs` fails the transition if a
+  signing-key sub-tree yields anything other than one leaf.
+- Seal-time fee handshake (#270): the server is the amount authority.
+  When `QuoteReceivedState.Quote` is non-nil, it threads through
+  `RoundJoinedState` → `CommitmentTxReceivedState`, and
+  `CommitmentTxReceivedState` validates each VTXO leaf and leave
+  output against the quote's positional amount (not the intent
+  target). `env.MaxOperatorFee` is applied at `QuoteReceivedState` —
+  each seal pass re-evaluates the cap independently. Quote-less
+  harness paths fall back to intent targets so pre-#270 FSM tests
+  keep working.
+- RoundID identity is asserted at every server-pushed event that
+  carries one. `IntentSentState` records the admitted `RoundID` from
+  the `RoundJoined` ack onto `AdmittedRoundID` and cross-checks
+  `JoinRoundQuoteReceived.RoundID` against it; `RoundJoinedState`
+  cross-checks both `CommitmentTxBuilt.RoundID` and any
+  reseal-after-accept `JoinRoundQuoteReceived.RoundID` against its
+  own `RoundID`. The actor's routing map is keyed by the same RoundID,
+  so under normal operation these checks agree by construction; the
+  FSM-level assertion is defense-in-depth against future routing
+  regressions.
+- `ConnectorLeafInfo.VTXOAmount` is populated from local VTXO state
+  (not from the server's proto), ensuring the forfeit penalty output
+  equals the canonical local value rather than a server-supplied one.
+- `MaxQuoteEntriesPerClient = 1024` is enforced in `FromProto` before
+  allocating the `VTXOQuotes` / `LeaveQuotes` slices to prevent
+  resource exhaustion from malformed server envelopes.
+- `SubmitForfeitSigRequest` (boarding input signatures) is distinct
+  from `SubmitVTXOForfeitSigsToServer` (VTXO forfeit signatures);
+  these are separate mailbox methods with separate proto types.
+- `ForfeitRequestToVTXO.ForfeitSpend` overrides the default
+  standard-VTXO collaborative leaf when the live output uses a custom
+  script policy; without it, the VTXO actor would construct a forfeit
+  using the wrong tapscript branch.
 
 ## Deep Docs
 

--- a/round/CLAUDE.md
+++ b/round/CLAUDE.md
@@ -8,73 +8,393 @@ protocols with MuSig2 signing ceremonies.
 
 ## Key Types
 
-- `ClientState` — Sealed interface for all 15 FSM states (Idle through Confirmed/ClientFailed), including `IntentSentState`, `QuoteReceivedState`, `RoundJoinedState`, `ForfeitSignaturesCollectingState`, and `RecoveryInitiatedState`.
-- `ClientEvent` — Inbound events triggering transitions (CommitmentTxBuilt, NoncesAggregated, OperatorSigned, ForfeitSignatureResponse, ForfeitCollectionTimedOut, etc.).
-- `ClientOutMsg` — Outbound messages (JoinRoundRequest, JoinRoundAcceptOutbox, JoinRoundRejectOutbox, SubmitNoncesRequest, SubmitPartialSigRequest, SubmitVTXOForfeitSigsToServer, VTXOCreatedNotification). `JoinRoundAcceptOutbox` / `JoinRoundRejectOutbox` are the explicit accept / reject responses to a server-issued seal-time `JoinRoundQuote` (#270). Both echo the `quote_id` so the server can drop stale responses after a reseal.
-- `ClientQuote` — Client-side view of `roundpb.JoinRoundQuote`. Carries `QuoteID`, `SealPass`, `OperatorFeeSat`, positional `VTXOQuotes` / `LeaveQuotes` (server-decided amounts plus echoed pkScripts and recipient keys), `QuoteExpiresAt`, and `RejectReason`. Stored on `QuoteReceivedState` and threaded forward through `RoundJoinedState` and `CommitmentTxReceivedState` so amount validation compares against the quote rather than intent targets.
-- `IntentSentState` — State entered after `IntentRequested` (out of `PendingRoundAssembly`). Holds the client's `Intents` and an `AdmittedRoundID RoundID` field that is zero until the server's `RoundJoined` admission ack lands. `RoundJoined` is consumed as a watermark only — the actor layer re-keys the FSM from the ephemeral temp key to the server-assigned `RoundID`, but the FSM stays parked in `IntentSentState` (with `AdmittedRoundID` populated) until the seal-time `JoinRoundQuoteReceived` arrives. The quote handler cross-checks `evt.RoundID` against `s.AdmittedRoundID` and fails the FSM via `failWithNotification` if (a) `AdmittedRoundID` is still zero (quote arrived before admission) or (b) the IDs differ (server-routing or trust violation).
-- `QuoteReceivedState` — State entered on `JoinRoundQuoteReceived` between `IntentSentState` and `RoundJoinedState`. Carries `RoundID`, the `*ClientQuote`, and the cloned `Intents`. `evaluateQuote` compares the quoted `OperatorFeeSat` against `env.MaxOperatorFee`, requires `RejectReason == QuoteReason_QUOTE_OK`, validates the per-output echoes (pkScript, recipient key, non-change amount) against the intent, and rejects expired quotes (`QuoteExpiresAt`). On accept it emits `JoinRoundAcceptOutbox` (echoing `quote_id`) and advances to `RoundJoinedState`; on reject (cap exceeded, expired, or server-side non-OK reason) it emits `JoinRoundRejectOutbox` and transitions to `ClientFailedState`. A `JoinRoundQuoteReceived` arriving here with a strictly higher `SealPass` replaces the in-state quote and re-evaluates; lower-or-equal `SealPass` deliveries self-loop as stale redeliveries.
-- `RoundJoinedState` — State entered after `QuoteAccepted`. Carries the assigned `RoundID`, the cloned `Intents` (with the quote's leave amounts captured onto `Intents.QuotedLeaveAmounts` for downstream fee accounting), and the accepted `*ClientQuote`. Waits for `CommitmentTxBuilt`, which is asserted to carry `evt.RoundID == s.RoundID` (a mismatch fails the FSM with "commitment round_id mismatch"). A `JoinRoundQuoteReceived` arriving here with a strictly higher `SealPass` is treated as a server reseal-after-accept: the FSM walks back to `QuoteReceivedState` for re-evaluation (the in-flight accept's older `quote_id` is dropped server-side); the new quote's `RoundID` must still match `s.RoundID`. Lower-or-equal `SealPass` deliveries self-loop as stale.
-- `ClientEnvironment` — FSM environment providing storage access (boarding intents, round checkpoints, VTXO store).
-- `ClientWallet` — Interface for client wallet operations (embeds `input.Signer` for MuSig2 signing, adds `DeriveNextKey` for VTXO signing keys).
-- `BoardingIntent` — Represents a funded on-chain input to include in a round.
-- `Intents` — Pools of boarding, VTXO, forfeit, and leave requests accumulated before registration.
-- `IntentPackage` — FSM event wrapping `Intents` for atomic delivery to the round FSM.
-- `RegisterIntentRequest` — Actor message carrying a pre-composed `IntentPackage` from the wallet.
-- `RefreshVTXORequest` — Per-VTXO refresh registration carrying `Amount`, `VTXO`, `SigningKey`, and `OperatorFee int64`. The `OperatorFee` is quoted by the VTXO actor's `RefreshFeeQuoter` before emission; `buildVTXORequestFromRefresh` subtracts it from the new VTXO output amount and clamps to zero so a buggy quoter cannot produce a negative output.
-- `VTXOIntent` — Pre-registration VTXO request carrying `OwnerKey`, `OperatorKey`. For directed sends, `OwnerKey` is the recipient's key (distinct from the sender's `SigningKey`). Ownership is determined at confirmation time via `OwnedScriptChecker` — there is no `IsOwner` flag on the wire or in local state.
-- `RoundVTXORequest` — Pairs a `VTXOIntent` with an ephemeral `SigningKey` derived at registration time for MuSig2 tree construction.
-- `OwnedScriptChecker` — Interface that answers "does this pkScript belong to the local wallet?" The `InputSigSent → Confirmed` transition calls this for every VTXO in the round to decide which entries `buildOwnedClientVTXOs` persists as spendable local balance. Backed in production by the OOR artifact store (owned receive scripts table).
-- `OwnedScriptRegistrar` — Interface used by the round actor when building VTXO intents (refresh change, boarding change, directed-send change outputs) to persist the pkScript + owner key before the round registers. This ensures the `OwnedScriptChecker` recognizes the script when the round confirms. `handleRegisterIntent` also registers any VTXO in an incoming `RegisterIntentMsg` whose `OwnerKey.KeyLocator` is non-zero (remote recipient keys are left with a zero locator and skipped).
-- `ForfeitSignaturesCollectingState` — State entered after VTXO tree signing when round includes refresh/leave VTXOs. Waits for all expected forfeit signatures before submitting to server.
-- `ForfeitSignatureResponse` — Carries a VTXO's forfeit signature back from the VTXO actor.
-- `ConnectorLeafInfo` — Maps a VTXO outpoint to its connector output index and leaf info for forfeit construction.
-- `RoundClientConfig.LedgerSink` — Optional `fn.Option[ledger.Sink]` plumbed onto the round actor so `VTXOCreatedNotification` dispatch can fire-and-forget ledger messages. Gated on `fn.Some`; unit tests that do not register a ledger actor pass `fn.None`.
-- `emitVTXOsReceived(ctx, n)` — Origin-routed emission invoked on `VTXOCreatedNotification` dispatch. Per owned VTXO it calls `emitOwnedVTXOLedgerEntry`, which switches on `ClientVTXO.Origin` (set by the wallet at intent composition): `RoundBoarding` → `VTXOReceivedMsg{Source=SourceRoundBoarding}`; `RoundRefresh` → paired `VTXOSentMsg{Outpoint}` + `VTXOReceivedMsg{Source=SourceRoundRefresh}` so the two legs cancel on `transfers_out`; `RoundTransfer` → `VTXOReceivedMsg{Source=SourceRoundTransfer}`; `Unknown` is a silent no-op (strictly safer than a default that would corrupt the chart of accounts). After the per-VTXO loop, `emitRoundFee` appends a single `FeePaidMsg{FeeType=FeeTypeRefresh}` when `OperatorFeeSat > 0` and at least one refresh-origin VTXO was present (boarding-fee emission deferred).
-- `computeClientOperatorFee(intents, ownedVTXOs) int64` — Transition-side helper that derives the per-client operator fee as Σ(boarding input amounts) + Σ(forfeited VTXO amounts) − Σ(owned output VTXO amounts) − Σ(cooperative leave output values). Clamps to zero. Called inside the `InputSigSent → Confirmed` transition; the result is carried on `VTXOCreatedNotification.OperatorFeeSat` for the actor's emission path to read.
+### FSM States (`states.go`)
+
+- `ClientState` — Sealed interface for all 15 FSM states (Idle through
+  Confirmed/ClientFailed). Concrete states: `Idle`,
+  `PendingRoundAssembly`, `IntentSentState`, `QuoteReceivedState`,
+  `RoundJoinedState`, `CommitmentTxReceivedState`,
+  `CommitmentTxValidatedState`, `NoncesSentState`,
+  `NoncesAggregatedState`, `PartialSigsSentState`,
+  `ForfeitSignaturesCollectingState`, `InputSigSentState`,
+  `ConfirmedState`, `ClientFailedState`, `RecoveryInitiatedState`.
+- `IntentSentState` — State entered after `IntentRequested` (out of
+  `PendingRoundAssembly`). Holds the client's `Intents` and an
+  `AdmittedRoundID RoundID` field that is zero until the server's
+  `RoundJoined` admission ack lands. `RoundJoined` is consumed as a
+  watermark only — the actor layer re-keys the FSM from the ephemeral
+  temp key to the server-assigned `RoundID`, but the FSM stays parked
+  in `IntentSentState` (with `AdmittedRoundID` populated) until the
+  seal-time `JoinRoundQuoteReceived` arrives.
+- `QuoteReceivedState` — Entered on `JoinRoundQuoteReceived` between
+  `IntentSentState` and `RoundJoinedState`. Carries `RoundID`, the
+  `*ClientQuote`, and the cloned `Intents`. `evaluateQuote` compares
+  `OperatorFeeSat` against `env.MaxOperatorFee`, validates echoed
+  per-output amounts/pkScripts/recipient keys, and rejects expired
+  quotes. On accept emits `JoinRoundAcceptOutbox`; on reject emits
+  `JoinRoundRejectOutbox` and transitions to `ClientFailedState`. A
+  `JoinRoundQuoteReceived` with a strictly higher `SealPass` replaces
+  the in-state quote and re-evaluates; lower-or-equal deliveries
+  self-loop as stale.
+- `RoundJoinedState` — Entered after `QuoteAccepted`. Carries
+  `RoundID`, the cloned `Intents` (with leave amounts captured on
+  `Intents.QuotedLeaveAmounts`), and the accepted `*ClientQuote`.
+  Awaits `CommitmentTxBuilt`. A `JoinRoundQuoteReceived` with a
+  strictly higher `SealPass` walks the FSM back to
+  `QuoteReceivedState` for re-evaluation.
+- `ForfeitSignaturesCollectingState` — Entered after VTXO tree signing
+  when the round includes refresh/leave VTXOs. Fields:
+  `ExpectedForfeits map[wire.OutPoint]*ConnectorLeafInfo` and
+  `CollectedForfeits map[wire.OutPoint]*ForfeitSignatureResponse`.
+  Waits until all expected forfeit signatures are collected, then
+  submits to server.
+- `ClientQuote` — Client-side view of `roundpb.JoinRoundQuote`.
+  Carries `QuoteID [32]byte`, `SealPass uint32`, `OperatorFeeSat
+  int64`, positional `VTXOQuotes []VTXOQuoteEntry` / `LeaveQuotes
+  []LeaveQuoteEntry` (server-decided amounts plus echoed pkScripts and
+  recipient keys), `QuoteExpiresAt int64`, and `RejectReason
+  roundpb.QuoteReason`. Stored on `QuoteReceivedState` and threaded
+  forward through `RoundJoinedState` and `CommitmentTxReceivedState`.
+- `VTXOQuoteEntry` — Per-VTXO positional entry in a `ClientQuote`.
+  Fields: `PkScript []byte`, `AmountSat int64`, `RecipientKey []byte`.
+  `evaluateQuote` cross-checks all three against the intent's
+  positional `VTXORequest`.
+- `LeaveQuoteEntry` — Per-leave positional entry in a `ClientQuote`.
+  Fields: `PkScript []byte`, `AmountSat int64`. Echoed pkScript lets
+  `evaluateQuote` cross-check positional agreement with intent's
+  `LeaveRequests`.
+
+### Events (`events.go`)
+
+- `ClientEvent` — Sealed interface for all FSM inbound events.
+- `JoinRoundQuoteReceived` — Carries `RoundID` and `*ClientQuote`.
+  Transitions the FSM from `IntentSentState` to `QuoteReceivedState`.
+  Also accepted in `QuoteReceivedState` (reseal, higher `SealPass`)
+  and `RoundJoinedState` (reseal-after-accept, walks back to
+  `QuoteReceivedState`).
+- `QuoteAccepted` — Internal event fired by `QuoteReceivedState` after
+  fee-cap check passes. Carries `RoundID` and `QuoteID [32]byte`.
+- `QuoteRejected` — Internal event fired by `QuoteReceivedState` when
+  fee cap is exceeded or server reject reason is non-OK. Carries
+  `RoundID`, `QuoteID [32]byte`, and `Reason string`.
+- `ForfeitCollectionTimedOut` — Emitted by the round actor when the
+  forfeit signature collection window expires. Carries `RoundID`.
+- `ForfeitSignatureResponse` — Carries a VTXO's forfeit signature back
+  from the VTXO actor. Fields: `VTXOOutpoint`, `RoundID string`,
+  `ForfeitTx *wire.MsgTx`, `Signature *schnorr.Signature`, `SpendPath
+  *arkscript.SpendPath`.
+- `ConnectorLeafInfo` — Maps a VTXO outpoint to its connector info for
+  forfeit construction. Fields: `LeafIndex int` (not populated by
+  `FromProto`), `ConnectorOutpoint wire.OutPoint`,
+  `ConnectorPkScript []byte`, `ConnectorAmount int64`, `VTXOAmount
+  btcutil.Amount`. `VTXOAmount` enables validation that the forfeit
+  penalty output equals the correct forfeited amount.
+- `IntentPackage` — Single FSM event embedding `Intents` for atomic
+  delivery. Covers all pooled intent types (boarding, VTXO, forfeit,
+  leave). `isEmpty()` guards against sending empty packages.
+
+### Outbox Messages (`outbox_messages.go`)
+
+- `ClientOutMsg` — Sealed interface for all FSM outbox messages.
+- `JoinRoundAcceptOutbox` — Emitted after quote fee-cap check passes.
+  Carries `RoundID` and `QuoteID [32]byte`; routed to
+  `MethodAcceptQuote`. `ToProto()` encodes to `roundpb.JoinRoundAccept`.
+- `JoinRoundRejectOutbox` — Emitted when client refuses the server's
+  quote. Carries `RoundID`, `QuoteID [32]byte`, `Reason string`;
+  routed to `MethodRejectQuote`. `ToProto()` encodes to
+  `roundpb.JoinRoundReject`.
+- `SubmitForfeitSigRequest` — Carries `RoundID` and `Signatures
+  []*types.BoardingInputSignature`; routed to
+  `MethodSubmitForfeitSigs`. `ToProto()` converts via
+  `roundpb.BoardingInputSigToProto`.
+- `StartTimeoutReq` — Asks the actor to schedule a timeout for a
+  round phase. Fields: `RoundID`, `Phase TimeoutPhase`, `Duration
+  time.Duration`.
+- `CancelTimeoutReq` — Asks the actor to cancel a previously
+  scheduled timeout. Fields: `RoundID`, `Phase TimeoutPhase`.
+- `RoundCheckpointedNotification` — Emitted by the primary FSM when it
+  reaches `InputSigSentState`, signalling the actor to migrate this
+  round to a dedicated round FSM. Carries `RoundID`.
+- `RoundCompletedNotification` — Emitted when an FSM reaches
+  `ConfirmedState`. Carries `RoundID`, `TxID`, and `ConfInfo`. Signals
+  actor to perform cleanup (remove from `activeRounds`, finalize
+  storage).
+- `RoundFailedNotification` — Emitted when an FSM transitions to
+  `ClientFailedState`. Carries `RoundID fn.Option[RoundID]`, `Reason
+  string`, `Recoverable bool`, `OriginalError error`.
+- `ForfeitRequestToVTXO` — Emitted by the FSM to ask a VTXO actor to
+  sign its forfeit tx. Fields: `VTXOOutpoint`, `RoundID string`,
+  `ConnectorOutpoint`, `ConnectorPkScript`, `ConnectorAmount int64`,
+  `ServerForfeitPkScript []byte`, `ForfeitSpend *arkscript.SpendPath`
+  (overrides default collaborative leaf for custom-policy VTXOs).
+- `ForfeitConfirmedToVTXO` — Emitted on commitment tx confirmation to
+  signal old VTXO actors they are permanently forfeited. Fields:
+  `VTXOOutpoint`, `CommitmentTxID`, `BlockHeight int32`.
+
+### Interfaces (`interfaces.go`)
+
+- `ClientEnvironment` — FSM environment providing storage access
+  (boarding intents, round checkpoints, VTXO store).
+- `ClientWallet` — Interface for client wallet operations (embeds
+  `input.Signer` for MuSig2 signing, adds `DeriveNextKey` for VTXO
+  signing keys).
+- `OwnedScriptChecker` — Interface that answers "does this pkScript
+  belong to the local wallet?" `IsOwnedScript(ctx, pkScript) →
+  fn.Result[bool]`. The `InputSigSent → Confirmed` transition calls
+  this for every VTXO in the round to decide which entries
+  `buildOwnedClientVTXOs` persists. Backed in production by the OOR
+  artifact store. When nil (tests), every VTXO is treated as owned.
+- `OwnedScriptRegistrar` — `RegisterOwnedScript(ctx, pkScript,
+  ownerKey)` called at intent-build time for change/refresh outputs
+  and inside `handleRegisterIntent` for entries with a non-zero
+  `KeyLocator`. Remote recipient keys carry a zero `KeyLocator` and
+  are skipped.
+- `VTXOStore` — Persistence for off-chain balance. Methods:
+  `SaveVTXOs`, `ListVTXOs`, `GetVTXO`, `MarkVTXOSpent`.
+- `RoundStore` — Persistence for round FSM state. Methods:
+  `CommitState`, `FetchState`, `LookupRoundByCommitmentTx`,
+  `ListActiveRounds`, `FinalizeRound`.
+
+### Key Data Types (`interfaces.go`)
+
+- `Intents` — Pools of boarding, VTXO, forfeit, and leave requests.
+  Field `QuotedLeaveAmounts []int64` holds server-authoritative leave
+  output amounts captured at `QuoteAccepted` time. `LeaveAmount(idx)`
+  returns the authoritative value, falling back to intent target when
+  no quote was accepted.
+- `VTXOIntent` — Pre-registration VTXO request carrying `Amount`,
+  `PolicyTemplate`, `PkScript`, `Expiry`, `OwnerKey`, `OperatorKey`.
+  For directed sends, `OwnerKey` is the recipient's key.
+- `RoundVTXORequest` — Pairs a `VTXOIntent` with an ephemeral
+  `SigningKey keychain.KeyDescriptor` for MuSig2 tree construction.
+  `ToVTXORequest()` converts to `types.VTXORequest`.
+- `ClientVTXO` — Full VTXO descriptor owned by the client. Adds
+  `Origin types.VTXOOrigin`, `CommitmentTxID`, `BatchExpiry int32`,
+  and `CreatedHeight int32` on top of the basic VTXO fields.
+- `BoardingIntent` — Embeds `wallet.BoardingIntent` plus a
+  `Request types.BoardingRequest`.
+
+### Actor-level Types (`actor_messages.go`, `actor.go`)
+
+- `ClientMsg` — Marker interface for messages receivable by
+  `RoundClientActor` (embeds `actormsg.RoundReceivable`).
+- `ClientResp` — Sealed interface for responses from
+  `RoundClientActor` (embeds `actormsg.RoundActorResp`).
+- `ServerMsg` / `ServerResp` — Sealed interfaces for round server
+  actor messages (stubs; server actor types TBD).
+- `WalletBoardingConfirmed` — Wraps `wallet.BoardingIntent` to make
+  boarding UTXO confirmations compatible with the `ClientMsg`
+  interface.
+- `ServerMessageNotification` — Delivers a `ClientEvent` from the
+  server FSM outbox to the round actor.
+- `ServerMessageResponse` — Acknowledges receipt of a server message.
+- `GetClientStateRequest` / `GetClientStateResponse` — Query the
+  current state of all FSMs. `GetClientStateResponse.States` maps FSM
+  key strings to `FSMStateInfo{State, IsTemp, RoundID}`.
+- `FSMStateInfo` — Bundles `State ClientState`, `IsTemp bool`, and
+  `RoundID` for introspection without exposing the full FSM.
+- `CancelRoundRequest` / `CancelRoundResponse` — Cancel participation
+  in a round identified by `RoundKey fn.Option[RoundKeyStr]`.
+- `RegisterVTXORequestsRequest` / `RegisterVTXORequestsResponse` —
+  Inform the FSM of VTXO amounts to include in the next round.
+- `ConfirmationEvent` — Wraps a chain confirmation from `ChainSource`.
+  Fields: `Txid`, `BlockHeight int32`, `BlockHash`, `Confirmations
+  uint32`, `Tx *wire.MsgTx`.
+- `TimeoutMsg` — Sent to the round actor when a timeout fires. Carries
+  `TimeoutID timeout.ID`.
+- `RegisterIntentRequest` — Actor message carrying a pre-composed
+  `IntentPackage` from the wallet.
+- `RefreshVTXORequest` — Per-VTXO refresh registration carrying
+  `Amount`, `VTXO`, `SigningKey`, and `OperatorFee int64`. The
+  `OperatorFee` is quoted by the VTXO actor's `RefreshFeeQuoter` before
+  emission; `buildVTXORequestFromRefresh` subtracts it from the new
+  VTXO output amount and clamps to zero so a buggy quoter cannot
+  produce a negative output.
+
+### VTXO Actor Messages (`vtxo_messages.go`)
+
+- `VTXOActorMsg` / `VTXOManagerMsg` — Marker interfaces for messages
+  to VTXO actors and the VTXO manager.
+- `BlockEpochEvent` — New block notification. Fields: `Height int32`,
+  `Hash`, `Timestamp int64`.
+- `ForfeitRequestEvent` — Asks a VTXO actor to sign its forfeit tx.
+  Fields mirror `ForfeitRequestToVTXO` plus `ForfeitSpend
+  *arkscript.SpendPath`.
+- `ForfeitConfirmedEvent` — Commitment tx confirmed, forfeit final.
+  Fields: `CommitmentTxID`, `BlockHeight int32`.
+- `SpendReserveEvent` — Claims a VTXO for an OOR spend (LiveState
+  only).
+- `SpendReleasedEvent` — Releases a VTXO from spend reservation back
+  to LiveState.
+- `SpendCompletedEvent` — Marks a VTXO as fully spent via OOR tx.
+- `ForfeitReleasedEvent` — Releases a VTXO from pending forfeit back
+  to LiveState when round registration fails.
+- `ForfeitSignedEvent` — Internal: forfeit tx signed and submitted.
+  Carries `ForfeitTxID`.
+- `VTXOFailedEvent` — Error during VTXO processing. Fields: `Reason`,
+  `Error`, `Recoverable bool`.
+- `ResumeVTXOEvent` — Sent during startup to restore a VTXO actor
+  from persisted state.
+- `PendingForfeitEvent` — Transitions a VTXO to `PendingForfeitState`
+  when the round actor admits it for cooperative consumption.
+- `VTXOTerminatedMsg` — Notifies the VTXO manager that a VTXO actor
+  has reached a terminal state. Fields: `Outpoint`, `FinalState
+  string`, `Reason string`.
+
+### Timeout Types (`fsm_timeouts.go`)
+
+- `TimeoutPhase string` — Identifies which FSM phase owns a timeout.
+  Only defined value: `TimeoutPhaseForfeitCollection =
+  "forfeit-collection"`.
+
+### Proto Deserialization (`from_proto.go`)
+
+- `MaxQuoteEntriesPerClient = 1024` — Bounds the per-quote VTXO/leave
+  entry slices decoded from the server to cheaply reject malformed or
+  malicious envelopes before allocating large backing slices.
+- `FromProto` methods on `JoinRoundQuoteReceived`, `RoundJoined`,
+  `CommitmentTxBuilt`, `AwaitingBoardingSigs`, `NoncesAggregated`,
+  `OperatorSigned`, `BoardingFailed`, and `JoinRoundRequest`. All
+  implement the private `inboundServerMessage` interface checked by
+  compile-time assertions.
+
+### Ledger Emission
+
+- `RoundClientConfig.LedgerSink` — Optional `fn.Option[ledger.Sink]`
+  plumbed onto the round actor so `VTXOCreatedNotification` dispatch
+  can fire-and-forget ledger messages. Gated on `fn.Some`; unit tests
+  that do not register a ledger actor pass `fn.None`.
+- `emitVTXOsReceived(ctx, n)` — Origin-routed emission. Per owned
+  VTXO switches on `ClientVTXO.Origin`: `RoundBoarding` →
+  `VTXOReceivedMsg{Source=SourceRoundBoarding}`; `RoundRefresh` →
+  paired `VTXOSentMsg{Outpoint}` + `VTXOReceivedMsg{Source=
+  SourceRoundRefresh}`; `RoundTransfer` →
+  `VTXOReceivedMsg{Source=SourceRoundTransfer}`; `Unknown` → silent
+  no-op. After the per-VTXO loop, `emitRoundFee` appends one
+  `FeePaidMsg{FeeType=FeeTypeRefresh}` when `OperatorFeeSat > 0` and
+  at least one refresh-origin VTXO was emitted.
+- `computeClientOperatorFee(intents, ownedVTXOs) int64` —
+  Σ(boarding inputs) + Σ(forfeited VTXOs) − Σ(owned output VTXOs) −
+  Σ(cooperative leave outputs). Clamps to zero. Called inside the
+  `InputSigSent → Confirmed` transition; result is carried on
+  `VTXOCreatedNotification.OperatorFeeSat`.
 
 ## Relationships
 
-- **Depends on**: `baselib/protofsm` (FSM engine), `lib/tree` (Merkle trees), `lib/types` (shared domain types), `lib/arkscript` (policy-backed tapscript construction), `wallet` (types: `BoardingAddress`, `BoardingIntent`, `SelectedVTXO`), `ledger` (`Sink` + `VTXOReceivedMsg` / `Source*` constants), `google/uuid` (round ID parsing for ledger emission).
-- **Depended on by**: `vtxo` (forfeit coordination), `db` (round persistence), `darepod` (wiring, owned-script adapters).
+- **Depends on**: `baselib/protofsm` (FSM engine), `lib/tree` (Merkle
+  trees), `lib/types` (shared domain types), `lib/arkscript`
+  (policy-backed tapscript construction), `wallet` (types:
+  `BoardingAddress`, `BoardingIntent`), `ledger` (`Sink` +
+  `VTXOReceivedMsg` / `Source*` constants), `timeout` (timeout
+  scheduling), `google/uuid` (round ID parsing).
+- **Depended on by**: `vtxo` (forfeit coordination), `db` (round
+  persistence), `darepod` (wiring, owned-script adapters).
 - **Sends**:
-  - → `serverconn`: `JoinRoundRequest`, `JoinRoundAcceptOutbox`, `JoinRoundRejectOutbox`, `SubmitNoncesRequest`, `SubmitPartialSigRequest`, `SubmitVTXOForfeitSigsToServer`
-  - → `vtxo`: `ForfeitRequestEvent`, `ForfeitConfirmedEvent`, `BlockEpochEvent`, `PendingForfeitEvent`, `SpendReserveEvent`, `SpendCompletedEvent`, `ForfeitReleasedEvent`
-  - → `vtxo` manager: `VTXOCreatedNotification`
-  - → `wallet`: `RegisterConfirmationNotifierRequest`
-  - → `timeout`: `ScheduleTimeoutRequest`, `CancelTimeoutRequest`
-  - → `OwnedScriptRegistrar` (darepod adapter over OOR artifact store): `RegisterOwnedScript(pkScript, ownerKey)`
-  - → `ledger` actor (via `ledger.Sink` Tell, when `fn.Some`), origin-routed per owned `ClientVTXO`:
-    `VTXOReceivedMsg{Source=SourceRoundBoarding}` for boarding-origin VTXOs;
-    paired `VTXOSentMsg{Outpoint}` + `VTXOReceivedMsg{Source=SourceRoundRefresh}` for refresh-origin VTXOs (legs cancel on transfers_out);
-    `VTXOReceivedMsg{Source=SourceRoundTransfer}` for participant-transfer-origin VTXOs;
-    one `FeePaidMsg{FeeType=FeeTypeRefresh}` per round when `OperatorFeeSat > 0` and any refresh-origin VTXO was emitted (boarding-fee emission deferred).
+  - → `serverconn`: `JoinRoundRequest`, `JoinRoundAcceptOutbox`,
+    `JoinRoundRejectOutbox`, `SubmitNoncesRequest`,
+    `SubmitPartialSigRequest`, `SubmitForfeitSigRequest`,
+    `SubmitVTXOForfeitSigsToServer`
+  - → `vtxo` actors: `ForfeitRequestToVTXO`, `ForfeitConfirmedToVTXO`,
+    `ForfeitRequestEvent`, `ForfeitConfirmedEvent`, `BlockEpochEvent`,
+    `PendingForfeitEvent`, `SpendReserveEvent`, `SpendCompletedEvent`,
+    `ForfeitReleasedEvent`, `SpendReleasedEvent`
+  - → `vtxo` manager: `VTXOCreatedNotification`, `VTXOTerminatedMsg`
+  - → `wallet`: `RegisterConfirmationRequest`
+  - → `timeout` (via `StartTimeoutReq` / `CancelTimeoutReq`)
+  - → `OwnedScriptRegistrar` (darepod adapter over OOR artifact store):
+    `RegisterOwnedScript(pkScript, ownerKey)`
+  - → `ledger` actor (via `ledger.Sink` Tell, when `fn.Some`),
+    origin-routed per owned `ClientVTXO`:
+    `VTXOReceivedMsg{Source=SourceRoundBoarding}` for boarding-origin;
+    paired `VTXOSentMsg{Outpoint}` +
+    `VTXOReceivedMsg{Source=SourceRoundRefresh}` for refresh-origin
+    (legs cancel on transfers_out);
+    `VTXOReceivedMsg{Source=SourceRoundTransfer}` for transfer-origin;
+    one `FeePaidMsg{FeeType=FeeTypeRefresh}` per round when
+    `OperatorFeeSat > 0` and any refresh-origin VTXO was emitted.
 - **Receives**:
-  - ← `serverconn`: `CommitmentTxBuilt`, `NoncesAggregated`, `OperatorSigned`, `RoundJoined`, `BoardingFailed`, `JoinRoundQuoteReceived`
+  - ← `serverconn`: `CommitmentTxBuilt`, `NoncesAggregated`,
+    `OperatorSigned`, `RoundJoined`, `BoardingFailed`,
+    `JoinRoundQuoteReceived` (via `ServerMessageNotification`)
   - ← `vtxo`: `ForfeitSignatureResponse` (relayed through manager)
-  - ← `wallet` (via `lib/actormsg`): `RegisterIntentMsg` (cooperative intent packages pre-admitted by manager), `TriggerBoardMsg` (VTXO registration + registration trigger)
-  - ← `wallet`: `BoardingUtxoConfirmedEvent`
+  - ← `wallet` (via `lib/actormsg`): `RegisterIntentMsg` (cooperative
+    intent packages pre-admitted by manager), `TriggerBoardMsg` (VTXO
+    registration + registration trigger)
+  - ← `wallet` (via `WalletBoardingConfirmed`): boarding UTXO
+    confirmations
   - ← `timeout`: `TimeoutMsg`
   - ← `chainsource`: `ConfirmationEvent`
 
 ## Invariants
 
-- Tree signatures must be validated BEFORE boarding input signatures are released (security checkpoint at InputSigSent).
-- Forfeit signatures are collected AFTER VTXO tree signing is complete (ForfeitSignaturesCollectingState), ensuring clients only forfeit old VTXOs after verifying new VTXOs are properly signed.
-- After aggregated signatures are validated on `VTXOTreePaths`, they are
-  propagated to extracted `ClientTrees` via `SubmitTreeSigs` + `VerifySigned`.
-  This ensures persisted client trees contain valid signatures for unilateral
-  exit (unrolling).
-- Round state is checkpointed atomically after tree validation; crash before checkpoint means client has no record of sent signatures.
-- Primary FSM handles interactive phases (through InputSigSent); a dedicated FSM per round handles confirmation monitoring.
-- The round actor does not mark VTXOs as PendingForfeit — the wallet/manager admits VTXOs before sending RegisterIntentMsg.
-- `ClientWallet` provides MuSig2 signing and key derivation; boarding address creation is handled by the wallet actor (not the round FSM).
-- Persisted VTXO ownership uses `OwnerKey` (not `SigningKey`). For directed sends the sender's signing key participates in MuSig2 tree construction, but the recipient's owner key determines VTXO ownership.
-- Local-balance persistence on confirmation is driven by `OwnedScriptChecker.IsOwnedScript(pkScript)`, not by any per-intent boolean. `buildOwnedClientVTXOs` skips any VTXO whose pkScript the checker does not recognize; the client still co-signs its tree path, so foreign recipients in a directed send still get a valid unroll proof. When the checker is nil (tests), every VTXO is treated as owned.
-- VTXO pkScripts are registered with `OwnedScriptRegistrar` at intent-build time for change/refresh outputs, and inside `handleRegisterIntent` for any `RegisterIntentMsg` entry with a non-zero `KeyLocator`. Remote recipient keys in directed sends carry a zero `KeyLocator` and are intentionally left unregistered.
-- Each client sub-tree in the commitment tree must contain exactly one non-anchor leaf. `buildOwnedClientVTXOs` fails the transition if a signing-key sub-tree yields anything other than one leaf.
-- Seal-time fee handshake (#270): the server is the amount authority. When `QuoteReceivedState.Quote` is non-nil, it threads through `RoundJoinedState` → `CommitmentTxReceivedState`, and `CommitmentTxReceivedState` validates each VTXO leaf and leave output against the quote's positional amount (not the intent target). `env.MaxOperatorFee` is applied at `QuoteReceivedState` — each seal pass re-evaluates the cap independently. Quote-less harness paths fall back to intent targets so pre-#270 FSM tests keep working.
-- RoundID identity is asserted at every server-pushed event that carries one. `IntentSentState` records the admitted `RoundID` from the `RoundJoined` ack onto `AdmittedRoundID` and cross-checks `JoinRoundQuoteReceived.RoundID` against it; `RoundJoinedState` cross-checks both `CommitmentTxBuilt.RoundID` and any reseal-after-accept `JoinRoundQuoteReceived.RoundID` against its own `RoundID`. The actor's routing map is keyed by the same RoundID, so under normal operation these checks agree by construction; the FSM-level assertion is defense-in-depth against a future actor-routing regression or a server stamping a foreign RoundID onto a payload.
+- Tree signatures must be validated BEFORE boarding input signatures
+  are released (security checkpoint at `InputSigSent`).
+- Forfeit signatures are collected AFTER VTXO tree signing is complete
+  (`ForfeitSignaturesCollectingState`), ensuring clients only forfeit
+  old VTXOs after verifying new VTXOs are properly signed.
+- After aggregated signatures are validated on `VTXOTreePaths`, they
+  are propagated to extracted `ClientTrees` via `SubmitTreeSigs` +
+  `VerifySigned`. This ensures persisted client trees contain valid
+  signatures for unilateral exit (unrolling).
+- Round state is checkpointed atomically after tree validation; crash
+  before checkpoint means client has no record of sent signatures.
+- Primary FSM handles interactive phases (through `InputSigSent`); a
+  dedicated FSM per round handles confirmation monitoring.
+- The round actor does not mark VTXOs as `PendingForfeit` — the
+  wallet/manager admits VTXOs before sending `RegisterIntentMsg`.
+- `ClientWallet` provides MuSig2 signing and key derivation; boarding
+  address creation is handled by the wallet actor (not the round FSM).
+- Persisted VTXO ownership uses `OwnerKey` (not `SigningKey`). For
+  directed sends the sender's signing key participates in MuSig2 tree
+  construction, but the recipient's owner key determines VTXO
+  ownership.
+- Local-balance persistence on confirmation is driven by
+  `OwnedScriptChecker.IsOwnedScript(pkScript)`, not by any per-intent
+  boolean. `buildOwnedClientVTXOs` skips any VTXO whose pkScript the
+  checker does not recognize; the client still co-signs its tree path,
+  so foreign recipients in a directed send still get a valid unroll
+  proof. When the checker is nil (tests), every VTXO is treated as
+  owned.
+- VTXO pkScripts are registered with `OwnedScriptRegistrar` at
+  intent-build time for change/refresh outputs, and inside
+  `handleRegisterIntent` for any `RegisterIntentMsg` entry with a
+  non-zero `KeyLocator`. Remote recipient keys in directed sends carry
+  a zero `KeyLocator` and are intentionally left unregistered.
+- Each client sub-tree in the commitment tree must contain exactly one
+  non-anchor leaf. `buildOwnedClientVTXOs` fails the transition if a
+  signing-key sub-tree yields anything other than one leaf.
+- Seal-time fee handshake (#270): the server is the amount authority.
+  When `QuoteReceivedState.Quote` is non-nil, it threads through
+  `RoundJoinedState` → `CommitmentTxReceivedState`, and
+  `CommitmentTxReceivedState` validates each VTXO leaf and leave
+  output against the quote's positional amount (not the intent
+  target). `env.MaxOperatorFee` is applied at `QuoteReceivedState` —
+  each seal pass re-evaluates the cap independently. Quote-less
+  harness paths fall back to intent targets so pre-#270 FSM tests
+  keep working.
+- RoundID identity is asserted at every server-pushed event that
+  carries one. `IntentSentState` records the admitted `RoundID` from
+  the `RoundJoined` ack onto `AdmittedRoundID` and cross-checks
+  `JoinRoundQuoteReceived.RoundID` against it; `RoundJoinedState`
+  cross-checks both `CommitmentTxBuilt.RoundID` and any
+  reseal-after-accept `JoinRoundQuoteReceived.RoundID` against its
+  own `RoundID`. The actor's routing map is keyed by the same RoundID,
+  so under normal operation these checks agree by construction; the
+  FSM-level assertion is defense-in-depth against future routing
+  regressions.
+- `ConnectorLeafInfo.VTXOAmount` is populated from local VTXO state
+  (not from the server's proto), ensuring the forfeit penalty output
+  equals the canonical local value rather than a server-supplied one.
+- `MaxQuoteEntriesPerClient = 1024` is enforced in `FromProto` before
+  allocating the `VTXOQuotes` / `LeaveQuotes` slices to prevent
+  resource exhaustion from malformed server envelopes.
+- `SubmitForfeitSigRequest` (boarding input signatures) is distinct
+  from `SubmitVTXOForfeitSigsToServer` (VTXO forfeit signatures);
+  these are separate mailbox methods with separate proto types.
+- `ForfeitRequestToVTXO.ForfeitSpend` overrides the default
+  standard-VTXO collaborative leaf when the live output uses a custom
+  script policy; without it, the VTXO actor would construct a forfeit
+  using the wrong tapscript branch.
 
 ## Deep Docs
 

--- a/rpc/roundpb/AGENTS.md
+++ b/rpc/roundpb/AGENTS.md
@@ -1,0 +1,45 @@
+# rpc/roundpb
+
+## Purpose
+
+Generated protobuf/gRPC stubs for the round protocol, plus hand-written
+`service.go` containing the canonical mailbox method name constants used
+for routing client↔server round messages through the durable transport
+layer.
+
+## Key Types
+
+All `*.pb.go` files are generated — never edit directly; regenerate with
+`make rpc`. The manually-maintained `service.go` defines:
+
+- `ServiceName` — Fully-qualified protobuf service name
+  (`"round.v1.RoundService"`) used for mailbox event routing.
+- Server→client push method names: `MethodJoinAck`, `MethodBatchInfo`,
+  `MethodAwaitingInputSigs`, `MethodAggNonces`, `MethodAggSigs`,
+  `MethodRoundFailed`, `MethodError`, `MethodJoinRoundQuote`.
+- Client→server method names: `MethodJoinRound`, `MethodAcceptQuote`,
+  `MethodRejectQuote`, `MethodSubmitNonces`, `MethodSubmitPartialSigs`,
+  `MethodSubmitForfeitSigs` (boarding input sigs),
+  `MethodSubmitVTXOForfeitSigs` (VTXO forfeit sigs).
+
+`MethodSubmitForfeitSigs` and `MethodSubmitVTXOForfeitSigs` are distinct
+wire methods for two different payload types; see `round/CLAUDE.md` for
+the `SubmitForfeitSigRequest` vs `SubmitVTXOForfeitSigsToServer`
+distinction.
+
+## Relationships
+
+- **Depends on**: nothing (generated proto types only).
+- **Depended on by**: `round` (outbox routing, `FromProto` helpers),
+  `serverconn` (mailbox method dispatch), `darepod` (proto conversion).
+
+## Invariants
+
+- **Never edit generated code** — regenerate via `make rpc`.
+- Method name constants in `service.go` must match the proto service
+  definition; mismatches silently drop events at the mailbox router.
+
+## Deep Docs
+
+- [rpc/CLAUDE.md](../CLAUDE.md) — Parent rpc package overview.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/rpc/roundpb/CLAUDE.md
+++ b/rpc/roundpb/CLAUDE.md
@@ -1,0 +1,45 @@
+# rpc/roundpb
+
+## Purpose
+
+Generated protobuf/gRPC stubs for the round protocol, plus hand-written
+`service.go` containing the canonical mailbox method name constants used
+for routing client↔server round messages through the durable transport
+layer.
+
+## Key Types
+
+All `*.pb.go` files are generated — never edit directly; regenerate with
+`make rpc`. The manually-maintained `service.go` defines:
+
+- `ServiceName` — Fully-qualified protobuf service name
+  (`"round.v1.RoundService"`) used for mailbox event routing.
+- Server→client push method names: `MethodJoinAck`, `MethodBatchInfo`,
+  `MethodAwaitingInputSigs`, `MethodAggNonces`, `MethodAggSigs`,
+  `MethodRoundFailed`, `MethodError`, `MethodJoinRoundQuote`.
+- Client→server method names: `MethodJoinRound`, `MethodAcceptQuote`,
+  `MethodRejectQuote`, `MethodSubmitNonces`, `MethodSubmitPartialSigs`,
+  `MethodSubmitForfeitSigs` (boarding input sigs),
+  `MethodSubmitVTXOForfeitSigs` (VTXO forfeit sigs).
+
+`MethodSubmitForfeitSigs` and `MethodSubmitVTXOForfeitSigs` are distinct
+wire methods for two different payload types; see `round/CLAUDE.md` for
+the `SubmitForfeitSigRequest` vs `SubmitVTXOForfeitSigsToServer`
+distinction.
+
+## Relationships
+
+- **Depends on**: nothing (generated proto types only).
+- **Depended on by**: `round` (outbox routing, `FromProto` helpers),
+  `serverconn` (mailbox method dispatch), `darepod` (proto conversion).
+
+## Invariants
+
+- **Never edit generated code** — regenerate via `make rpc`.
+- Method name constants in `service.go` must match the proto service
+  definition; mismatches silently drop events at the mailbox router.
+
+## Deep Docs
+
+- [rpc/CLAUDE.md](../CLAUDE.md) — Parent rpc package overview.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/sdk/ark/AGENTS.md
+++ b/sdk/ark/AGENTS.md
@@ -33,6 +33,21 @@ without duplicating Ark runtime behavior.
   `SendOORWithCustomInputs`, typed indexed VTXO lookups, and typed
   receive-script decoding belong here so higher-level packages do not
   rebuild daemonrpc adapters.
+- `OORSessionDirection` — Enum (`OORSessionDirectionAll`,
+  `OORSessionDirectionOutgoing`, `OORSessionDirectionIncoming`) for
+  filtering local OOR session listings.
+- `ListOORSessionsRequest` — Filter struct: `PendingOnly bool`,
+  `Direction OORSessionDirection`.
+- `OORSessionInfo` — Typed view of one locally persisted OOR session:
+  `SessionID`, `Direction`, `Phase`, `Pending`, `RetryAfter`,
+  `RetryReason`, `InputOutpoints`, `InputAmountSat`, `RecipientCount`.
+- `ListLocalOORSessions(ctx, ListOORSessionsRequest) ([]OORSessionInfo,
+  error)` — Typed wrapper converting proto response to SDK types.
+- `ListPendingOORSessions(ctx) ([]OORSessionInfo, error)` — Convenience
+  wrapper calling `ListLocalOORSessions` with `PendingOnly: true`.
+- `ListOORSessions` — Lower-level passthrough returning the raw
+  `*daemonrpc.ListOORSessionsResponse`; `ListLocalOORSessions` is
+  preferred for new callers.
 
 ## Relationships
 

--- a/sdk/ark/CLAUDE.md
+++ b/sdk/ark/CLAUDE.md
@@ -33,6 +33,21 @@ without duplicating Ark runtime behavior.
   `SendOORWithCustomInputs`, typed indexed VTXO lookups, and typed
   receive-script decoding belong here so higher-level packages do not
   rebuild daemonrpc adapters.
+- `OORSessionDirection` — Enum (`OORSessionDirectionAll`,
+  `OORSessionDirectionOutgoing`, `OORSessionDirectionIncoming`) for
+  filtering local OOR session listings.
+- `ListOORSessionsRequest` — Filter struct: `PendingOnly bool`,
+  `Direction OORSessionDirection`.
+- `OORSessionInfo` — Typed view of one locally persisted OOR session:
+  `SessionID`, `Direction`, `Phase`, `Pending`, `RetryAfter`,
+  `RetryReason`, `InputOutpoints`, `InputAmountSat`, `RecipientCount`.
+- `ListLocalOORSessions(ctx, ListOORSessionsRequest) ([]OORSessionInfo,
+  error)` — Typed wrapper converting proto response to SDK types.
+- `ListPendingOORSessions(ctx) ([]OORSessionInfo, error)` — Convenience
+  wrapper calling `ListLocalOORSessions` with `PendingOnly: true`.
+- `ListOORSessions` — Lower-level passthrough returning the raw
+  `*daemonrpc.ListOORSessionsResponse`; `ListLocalOORSessions` is
+  preferred for new callers.
 
 ## Relationships
 

--- a/sdk/swaps/AGENTS.md
+++ b/sdk/swaps/AGENTS.md
@@ -1,0 +1,80 @@
+# sdk/swaps
+
+## Purpose
+
+High-level client SDK for Lightning-to-Ark (receive) and Ark-to-Lightning
+(pay) atomic swaps via virtual HTLCs (vHTLCs). Orchestrates two durable
+FSM-driven flows using the Loop FSM engine, coordinating with a remote swap
+server and the local Ark daemon to fund, claim, or refund on-chain vHTLCs.
+Persists every state transition in an isolated SQLite database.
+
+## Key Types
+
+- `SwapClient` — Top-level entry point. Constructed via `NewSwapClient`
+  (no persistence) or `NewSwapClientWithStore` (SQLite-backed). Drives
+  both pay and receive flows.
+- `PaySession` — Owns one Ark-to-Lightning pay flow. FSM states:
+  `Created → SwapCreated → FundingInitiated → VHTLCFunded →
+  WaitingForClaim → Completed` (or `Expired / RefundInitiated →
+  Refunded / NeedsIntervention / Failed`).
+- `ReceiveSession` — Owns one Lightning-to-Ark receive flow. FSM states:
+  `Created → InvoiceCreated → VHTLCFunded → ClaimInitiated → Completed`
+  (or `Expired / NeedsIntervention / Failed`).
+- `Store` — Isolated SQLite persistence for swap sessions. Runs its own
+  migration table (`swap_client_schema_migrations`) separate from the
+  main daemon DB.
+- `SwapServerConn` / `GRPCSwapServerConn` — Interface/impl for remote
+  swap-server gRPC calls (`RequestChannelID`, `CreateInSwap`).
+- `DaemonConn` — Interface for wallet operations (OOR sends, VTXO
+  lookups, key queries) provided by the Ark daemon.
+- `InvoiceCreator` / `DirectInvoiceCreator` — BOLT-11 invoice building
+  for the receive flow.
+- `PayState` / `ReceiveState` — Typed FSM state enums with `IsTerminal()`
+  and `String()`.
+- `VHTLCConfig`, `InSwapConfig`, `RouteHint` — Server negotiation DTOs.
+- `SwapSummary` — Flat list view for persisted sessions.
+
+## Relationships
+
+- **Depends on**: `lib/arkscript` (vHTLC policy construction, claim/refund
+  tapscript paths), `sdk/ark` (type aliases: `CustomOORInput`, `VTXOInfo`,
+  `IndexedOORSessionInfo`, `ReceiveInfo`), `swaprpc` (generated gRPC stubs),
+  `db/migrate` + `db/sqlc` (migration infrastructure), `sdk/swaps/sqlc`
+  (internal generated query adapter), `github.com/lightninglabs/loop/fsm`
+  (FSM engine).
+- **Depended on by**: `cmd/darepocli/darepoclicommands` (CLI `pay` and
+  `receive` commands).
+
+## Sends / Receives
+
+Both FSMs use `loopfsm.StateMachine.SendEvent(ctx, OnAdvance, nil)` per
+tick. The pay flow calls `DaemonConn.SendOORWithPolicy` to fund the vHTLC
+and `DaemonConn.SendOORWithCustomInputs` to refund. The receive flow calls
+`DaemonConn.SendOORWithCustomInputs` to claim the funded vHTLC using the
+preimage spend path.
+
+## Invariants
+
+- `mutateAndPersist` is the only way to change session state; it snapshots
+  before mutation and rolls back on store failure. Never write
+  `s.state = ...` directly outside this wrapper.
+- OOR session IDs must be persisted before transitioning; failure wraps in
+  `newRetryableActionError` so the FSM retries rather than advancing past
+  a durable boundary.
+- The store is optional: `NewSwapClient` (no store) and
+  `NewSwapClientWithStore` are both valid; all `persist()` calls are
+  no-ops when `store == nil`.
+- Amount mismatch on a live vHTLC triggers `RefundInitiated` (pay) or
+  `Failed` (receive) immediately — never `NeedsIntervention`.
+- `NeedsIntervention` is reserved for anomalous server behavior (e.g.,
+  vHTLC spent without a matching preimage).
+- `PaySession` / `ReceiveSession` are not goroutine-safe; `Wait`, `Claim`,
+  `WaitForFunding`, and `State` must not be called concurrently.
+- Preimage extraction uses a multi-strategy scan of finalized checkpoint
+  PSBTs (final witness, condition witness, taproot spend sig) to tolerate
+  different Ark indexer versions. Only accepted when
+  `SHA256(preimage) == paymentHash`.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/sdk/swaps/CLAUDE.md
+++ b/sdk/swaps/CLAUDE.md
@@ -1,0 +1,80 @@
+# sdk/swaps
+
+## Purpose
+
+High-level client SDK for Lightning-to-Ark (receive) and Ark-to-Lightning
+(pay) atomic swaps via virtual HTLCs (vHTLCs). Orchestrates two durable
+FSM-driven flows using the Loop FSM engine, coordinating with a remote swap
+server and the local Ark daemon to fund, claim, or refund on-chain vHTLCs.
+Persists every state transition in an isolated SQLite database.
+
+## Key Types
+
+- `SwapClient` — Top-level entry point. Constructed via `NewSwapClient`
+  (no persistence) or `NewSwapClientWithStore` (SQLite-backed). Drives
+  both pay and receive flows.
+- `PaySession` — Owns one Ark-to-Lightning pay flow. FSM states:
+  `Created → SwapCreated → FundingInitiated → VHTLCFunded →
+  WaitingForClaim → Completed` (or `Expired / RefundInitiated →
+  Refunded / NeedsIntervention / Failed`).
+- `ReceiveSession` — Owns one Lightning-to-Ark receive flow. FSM states:
+  `Created → InvoiceCreated → VHTLCFunded → ClaimInitiated → Completed`
+  (or `Expired / NeedsIntervention / Failed`).
+- `Store` — Isolated SQLite persistence for swap sessions. Runs its own
+  migration table (`swap_client_schema_migrations`) separate from the
+  main daemon DB.
+- `SwapServerConn` / `GRPCSwapServerConn` — Interface/impl for remote
+  swap-server gRPC calls (`RequestChannelID`, `CreateInSwap`).
+- `DaemonConn` — Interface for wallet operations (OOR sends, VTXO
+  lookups, key queries) provided by the Ark daemon.
+- `InvoiceCreator` / `DirectInvoiceCreator` — BOLT-11 invoice building
+  for the receive flow.
+- `PayState` / `ReceiveState` — Typed FSM state enums with `IsTerminal()`
+  and `String()`.
+- `VHTLCConfig`, `InSwapConfig`, `RouteHint` — Server negotiation DTOs.
+- `SwapSummary` — Flat list view for persisted sessions.
+
+## Relationships
+
+- **Depends on**: `lib/arkscript` (vHTLC policy construction, claim/refund
+  tapscript paths), `sdk/ark` (type aliases: `CustomOORInput`, `VTXOInfo`,
+  `IndexedOORSessionInfo`, `ReceiveInfo`), `swaprpc` (generated gRPC stubs),
+  `db/migrate` + `db/sqlc` (migration infrastructure), `sdk/swaps/sqlc`
+  (internal generated query adapter), `github.com/lightninglabs/loop/fsm`
+  (FSM engine).
+- **Depended on by**: `cmd/darepocli/darepoclicommands` (CLI `pay` and
+  `receive` commands).
+
+## Sends / Receives
+
+Both FSMs use `loopfsm.StateMachine.SendEvent(ctx, OnAdvance, nil)` per
+tick. The pay flow calls `DaemonConn.SendOORWithPolicy` to fund the vHTLC
+and `DaemonConn.SendOORWithCustomInputs` to refund. The receive flow calls
+`DaemonConn.SendOORWithCustomInputs` to claim the funded vHTLC using the
+preimage spend path.
+
+## Invariants
+
+- `mutateAndPersist` is the only way to change session state; it snapshots
+  before mutation and rolls back on store failure. Never write
+  `s.state = ...` directly outside this wrapper.
+- OOR session IDs must be persisted before transitioning; failure wraps in
+  `newRetryableActionError` so the FSM retries rather than advancing past
+  a durable boundary.
+- The store is optional: `NewSwapClient` (no store) and
+  `NewSwapClientWithStore` are both valid; all `persist()` calls are
+  no-ops when `store == nil`.
+- Amount mismatch on a live vHTLC triggers `RefundInitiated` (pay) or
+  `Failed` (receive) immediately — never `NeedsIntervention`.
+- `NeedsIntervention` is reserved for anomalous server behavior (e.g.,
+  vHTLC spent without a matching preimage).
+- `PaySession` / `ReceiveSession` are not goroutine-safe; `Wait`, `Claim`,
+  `WaitForFunding`, and `State` must not be called concurrently.
+- Preimage extraction uses a multi-strategy scan of finalized checkpoint
+  PSBTs (final witness, condition witness, taproot spend sig) to tolerate
+  different Ark indexer versions. Only accepted when
+  `SHA256(preimage) == paymentHash`.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/timeout/AGENTS.md
+++ b/timeout/AGENTS.md
@@ -23,6 +23,43 @@ semantics (next fire = handler-finish + interval) rather than
 `time.Ticker`'s "fixed-rate with drops". Stale fires that race with a
 Cancel or reschedule are filtered by a per-entry generation token.
 
+## Clock Abstraction
+
+- `Clock` — Interface (`Now() time.Time`, `AfterFunc(d, f) Stoppable`)
+  that drives all timer creation. Allows deterministic time injection in
+  tests.
+- `Stoppable` — Interface satisfied directly by `*time.Timer`; returned
+  by `Clock.AfterFunc`.
+- `RealClock` — Production implementation backed by the standard library.
+- `NewActor()` — Constructor using `RealClock`.
+- `NewActorWithClock(clock Clock)` — Test constructor; inject a fake
+  clock for deterministic timer behavior without wall-clock delays.
+
+## Transform Helpers
+
+- `MapTimeoutExpired[Out](targetRef, mapFn)` — Wraps a target ref to
+  convert `*ExpiredMsg` deliveries into the caller's message type using
+  `actor.NewMapInputRef`. Eliminates boilerplate adapter types when wiring
+  one-shot timeouts to domain actors.
+- `MapTickFired[Out](targetRef, mapFn)` — Same pattern for `*TickFiredMsg`.
+  Both helpers are the idiomatic way to wire the timeout actor to a domain
+  actor.
+
+## Message Types
+
+- `ScheduleTimeoutRequest` — Schedule a one-shot timer for `Duration`.
+  Fires `*ExpiredMsg` to `Target` ref.
+- `ScheduleRecurringTickRequest` — Schedule a recurring tick. `Interval`
+  must be strictly positive (zero/negative is rejected before touching
+  state). Fires `*TickFiredMsg` on each tick.
+- `CancelTimeoutRequest` — Cancel a scheduled timeout or recurring tick by
+  ID. One-shot and recurring timers share the same ID namespace; either
+  type can be cancelled with this message.
+- `ExpiredMsg` — Delivered to the target ref when a one-shot timer fires.
+- `TickFiredMsg` — Delivered on each recurring tick. `FiredAt` carries the
+  clock-goroutine capture time, not the Receive-processing time; important
+  for test assertions.
+
 ## Wiring
 
 Callers must call `Start(ref)` after registering the actor with the
@@ -37,3 +74,14 @@ clock callbacks expect a serializing mailbox in front of `Receive`.
 - **Depends on**: `baselib/actor` (actor framework).
 - **Depended on by**: `round` (forfeit collection timeouts, registration
   timeouts), `oor` (retry timers via `SigningOutboxHandler.TimeoutActor`).
+
+## Invariants
+
+- One-shot and recurring timers share the same ID namespace. Scheduling
+  either type with an existing ID cancels the prior entry, regardless of
+  type.
+- `ScheduleRecurringTickRequest.Interval` must be strictly positive;
+  zero or negative is rejected before touching actor state.
+- Every `Receive` path returns `fn.Ok[Resp](&AckResponse{Success: true})`;
+  the only error return is for invalid `Interval` on
+  `ScheduleRecurringTickRequest`.

--- a/timeout/CLAUDE.md
+++ b/timeout/CLAUDE.md
@@ -23,6 +23,43 @@ semantics (next fire = handler-finish + interval) rather than
 `time.Ticker`'s "fixed-rate with drops". Stale fires that race with a
 Cancel or reschedule are filtered by a per-entry generation token.
 
+## Clock Abstraction
+
+- `Clock` — Interface (`Now() time.Time`, `AfterFunc(d, f) Stoppable`)
+  that drives all timer creation. Allows deterministic time injection in
+  tests.
+- `Stoppable` — Interface satisfied directly by `*time.Timer`; returned
+  by `Clock.AfterFunc`.
+- `RealClock` — Production implementation backed by the standard library.
+- `NewActor()` — Constructor using `RealClock`.
+- `NewActorWithClock(clock Clock)` — Test constructor; inject a fake
+  clock for deterministic timer behavior without wall-clock delays.
+
+## Transform Helpers
+
+- `MapTimeoutExpired[Out](targetRef, mapFn)` — Wraps a target ref to
+  convert `*ExpiredMsg` deliveries into the caller's message type using
+  `actor.NewMapInputRef`. Eliminates boilerplate adapter types when wiring
+  one-shot timeouts to domain actors.
+- `MapTickFired[Out](targetRef, mapFn)` — Same pattern for `*TickFiredMsg`.
+  Both helpers are the idiomatic way to wire the timeout actor to a domain
+  actor.
+
+## Message Types
+
+- `ScheduleTimeoutRequest` — Schedule a one-shot timer for `Duration`.
+  Fires `*ExpiredMsg` to `Target` ref.
+- `ScheduleRecurringTickRequest` — Schedule a recurring tick. `Interval`
+  must be strictly positive (zero/negative is rejected before touching
+  state). Fires `*TickFiredMsg` on each tick.
+- `CancelTimeoutRequest` — Cancel a scheduled timeout or recurring tick by
+  ID. One-shot and recurring timers share the same ID namespace; either
+  type can be cancelled with this message.
+- `ExpiredMsg` — Delivered to the target ref when a one-shot timer fires.
+- `TickFiredMsg` — Delivered on each recurring tick. `FiredAt` carries the
+  clock-goroutine capture time, not the Receive-processing time; important
+  for test assertions.
+
 ## Wiring
 
 Callers must call `Start(ref)` after registering the actor with the
@@ -37,3 +74,14 @@ clock callbacks expect a serializing mailbox in front of `Receive`.
 - **Depends on**: `baselib/actor` (actor framework).
 - **Depended on by**: `round` (forfeit collection timeouts, registration
   timeouts), `oor` (retry timers via `SigningOutboxHandler.TimeoutActor`).
+
+## Invariants
+
+- One-shot and recurring timers share the same ID namespace. Scheduling
+  either type with an existing ID cancels the prior entry, regardless of
+  type.
+- `ScheduleRecurringTickRequest.Interval` must be strictly positive;
+  zero or negative is rejected before touching actor state.
+- Every `Receive` path returns `fn.Ok[Resp](&AckResponse{Success: true})`;
+  the only error return is for invalid `Interval` on
+  `ScheduleRecurringTickRequest`.

--- a/wallet/AGENTS.md
+++ b/wallet/AGENTS.md
@@ -41,7 +41,11 @@ refresh, leave, OOR spend, and directed send flows.
 - **Depended on by**: `round` (boarding intents, types: `BoardingAddress`, `SelectedVTXO`), `db` (persistence), `darepod` (wiring).
 - **Sends**:
   - → `round` (via registered notifier): `BoardingUtxoConfirmedEvent`
-  - → `round` (via `lib/actormsg`): `TriggerBoardMsg` (VTXO amounts for boarding), `RegisterIntentMsg` (pre-composed cooperative intents with forfeits + VTXOs/leaves)
+  - → `round` (via `lib/actormsg`): `TriggerBoardMsg` (VTXO amounts for
+    boarding), `RegisterIntentMsg` (pre-composed cooperative intents with
+    forfeits + VTXOs/leaves); `TriggerRegistration=true` for directed sends
+    so the round FSM advances from `PendingRoundAssembly` immediately,
+    `false` for refresh/leave batching
   - → `vtxo` manager (via `lib/actormsg`): `SelectAndReserveSpendRequest`, `ReleaseSpendRequest`, `CompleteSpendRequest`, `ReserveForfeitRequest`, `ReleaseForfeitRequest`, `SelectAndReserveForfeitRequest`
   - → `ledger` actor (via `ledger.Sink` Tell, when `fn.Some`): `UTXOCreatedMsg` on every processed confirmed wallet UTXO, tagged `ClassificationDeposit`. `handleUTXOCreated` expands this into both a `wallet_utxo_log` audit row AND a double-entry deposit leg (debit `wallet_balance`, credit `opening_balance`). (`UTXOSpentMsg` emission is a planned follow-up.)
   - → `round` (via `lib/types.VTXORequest.Origin`): wallet intent composition tags each locally-owned VTXO output with a `VTXOOrigin` classifier so the round actor's downstream ledger emission dispatches to the correct `Source`. Refresh outputs and directed-send self-change get `VTXOOriginRoundRefresh`; boarding-path tagging lives in `round.handleTriggerBoard` (`VTXOOriginRoundBoarding`).

--- a/wallet/CLAUDE.md
+++ b/wallet/CLAUDE.md
@@ -41,7 +41,11 @@ refresh, leave, OOR spend, and directed send flows.
 - **Depended on by**: `round` (boarding intents, types: `BoardingAddress`, `SelectedVTXO`), `db` (persistence), `darepod` (wiring).
 - **Sends**:
   - → `round` (via registered notifier): `BoardingUtxoConfirmedEvent`
-  - → `round` (via `lib/actormsg`): `TriggerBoardMsg` (VTXO amounts for boarding), `RegisterIntentMsg` (pre-composed cooperative intents with forfeits + VTXOs/leaves)
+  - → `round` (via `lib/actormsg`): `TriggerBoardMsg` (VTXO amounts for
+    boarding), `RegisterIntentMsg` (pre-composed cooperative intents with
+    forfeits + VTXOs/leaves); `TriggerRegistration=true` for directed sends
+    so the round FSM advances from `PendingRoundAssembly` immediately,
+    `false` for refresh/leave batching
   - → `vtxo` manager (via `lib/actormsg`): `SelectAndReserveSpendRequest`, `ReleaseSpendRequest`, `CompleteSpendRequest`, `ReserveForfeitRequest`, `ReleaseForfeitRequest`, `SelectAndReserveForfeitRequest`
   - → `ledger` actor (via `ledger.Sink` Tell, when `fn.Some`): `UTXOCreatedMsg` on every processed confirmed wallet UTXO, tagged `ClassificationDeposit`. `handleUTXOCreated` expands this into both a `wallet_utxo_log` audit row AND a double-entry deposit leg (debit `wallet_balance`, credit `opening_balance`). (`UTXOSpentMsg` emission is a planned follow-up.)
   - → `round` (via `lib/types.VTXORequest.Origin`): wallet intent composition tags each locally-owned VTXO output with a `VTXOOrigin` classifier so the round actor's downstream ledger emission dispatches to the correct `Source`. Refresh outputs and directed-send self-change get `VTXOOriginRoundRefresh`; boarding-path tagging lives in `round.handleTriggerBoard` (`VTXOOriginRoundBoarding`).


### PR DESCRIPTION
## Summary

- Added CLAUDE.md/AGENTS.md for new packages: `arkrpc/treeconv`, `sdk/swaps`, `rpc/roundpb`
- Updated stale CLAUDE.md/AGENTS.md for packages with significant changes since last sweep: `oor`, `round`, `timeout`, `sdk/ark`, `darepod`, `harness`, `cmd/darepocli/darepoclicommands`, `lib/actormsg`, `lib/types`, `baselib/actor`, `wallet`, `arkrpc`
- Updated ARCHITECTURE.md with new `sdk/swaps` and `arkrpc/treeconv` entries

Key changes documented:
- `sdk/swaps`: new Lightning/Ark atomic swap SDK with durable FSM flows
- `oor`: ListSessionsRequest/SessionSummary/SessionDirection for local OOR session listing; SpendCompleter routing; TransferInputSnapshot RequiredSequence/RequiredLockTime fields
- `round`: comprehensive restructure covering all FSM states, events, outbox messages, interfaces, VTXO actor messages, timeout types, and proto deserialization
- `timeout`: Clock abstraction, MapTimeoutExpired/MapTickFired transform helpers, shared ID namespace invariant
- `arkrpc/treeconv`: new narrow re-export sub-package for tree serialization

Workflow run: https://github.com/lightninglabs/darepo-client/actions/runs/0

Please review the updated CLAUDE.md/AGENTS.md and ARCHITECTURE.md diffs.