### PR TITLE
darepod: quiet expected lookup and shutdown noise

### DIFF
--- a/darepod/server.go
+++ b/darepod/server.go
@@ -578,58 +578,59 @@ func (s *Server) run(ctx context.Context,
 		MailboxCapacity: actor.DefaultConfig().MailboxCapacity,
 		Log:             fn.Some(s.subLogger(actor.Subsystem)),
 	})
-	// Register cleanup from least dependent to most dependent so that the
-	// defer LIFO order tears down components from most dependent to least
-	// dependent: actor system -> chain backend -> DB.
-	defer func() {
-		if s.runtime != nil {
-			s.setServerConnected(false)
-			s.runtime.Stop()
-		}
-	}()
-	defer func() {
-		if s.serverConn != nil {
-			_ = s.serverConn.Close()
-		}
-	}()
-	defer func() {
-		if s.db != nil {
-			_ = s.db.Close()
-		}
-	}()
-	defer func() {
-		if s.chainBackend != nil {
-			_ = s.chainBackend.Stop()
-		}
-	}()
-	defer func() {
-		s.lwWallet.WhenSome(
-			func(w *lwwallet.Wallet) {
-				w.Stop()
-			},
-		)
-	}()
-	defer func() {
-		s.btcwWallet.WhenSome(
-			func(w *btcwbackend.Wallet) {
-				w.Stop()
-			},
-		)
-	}()
 	defer func() {
 		shutdownCtx, shutdownCancel := context.WithTimeout(
 			context.Background(), DefaultShutdownTimeout,
 		)
 		defer shutdownCancel()
 
+		if s.unrollRegistry != nil {
+			s.unrollRegistry.Stop()
+		}
+
+		if s.oorActor != nil {
+			err := s.oorActor.StopAndWait(shutdownCtx)
+			if err != nil {
+				s.log.WarnS(
+					ctx, "OOR actor shutdown failed", err,
+				)
+			}
+		}
+
 		if s.runtime != nil {
 			s.setServerConnected(false)
 			_ = s.runtime.StopAndWait(shutdownCtx)
 		}
-	}()
-	defer func() {
-		if s.unrollRegistry != nil {
-			s.unrollRegistry.Stop()
+
+		if s.actorSystem != nil {
+			err := s.actorSystem.Shutdown(shutdownCtx)
+			if err != nil {
+				s.log.WarnS(
+					ctx, "Actor system shutdown failed",
+					err,
+				)
+			}
+		}
+
+		s.btcwWallet.WhenSome(
+			func(w *btcwbackend.Wallet) {
+				w.Stop()
+			},
+		)
+		s.lwWallet.WhenSome(
+			func(w *lwwallet.Wallet) {
+				w.Stop()
+			},
+		)
+
+		if s.chainBackend != nil {
+			_ = s.chainBackend.Stop()
+		}
+		if s.serverConn != nil {
+			_ = s.serverConn.Close()
+		}
+		if s.db != nil {
+			_ = s.db.Close()
 		}
 	}()
 

--- a/db/interfaces.go
+++ b/db/interfaces.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"math"
 	prand "math/rand"
 	"time"
@@ -298,7 +299,16 @@ func (t *TransactionExecutor[Q]) ExecTx(ctx context.Context,
 				continue
 			}
 
-			t.log.WarnS(ctx, "Transaction body failed", dbErr)
+			// A missing row is a normal negative lookup for several
+			// stores, for example when wallet UTXOs are checked
+			// against known boarding addresses. Let callers decide
+			// whether that miss is noteworthy instead of warning
+			// at the transaction layer.
+			if !errors.Is(dbErr, sql.ErrNoRows) {
+				t.log.WarnS(
+					ctx, "Transaction body failed", dbErr,
+				)
+			}
 
 			return dbErr
 		}

--- a/ledger/actor.go
+++ b/ledger/actor.go
@@ -275,9 +275,15 @@ type LedgerActor struct {
 	clk clock.Clock
 }
 
-// Compile-time check that LedgerActor implements the durable
-// actor behavior interface.
-var _ actor.ActorBehavior[LedgerMsg, LedgerResp] = (*LedgerActor)(nil)
+var (
+	// Compile-time check that LedgerActor implements the durable
+	// actor behavior interface.
+	_ actor.ActorBehavior[LedgerMsg, LedgerResp] = (*LedgerActor)(nil)
+
+	// Compile-time check that LedgerActor implements actor-system
+	// cleanup.
+	_ actor.Stoppable = (*LedgerActor)(nil)
+)
 
 // NewLedgerActor creates a new client-side ledger actor
 // instance. This is a pure constructor that performs no I/O.
@@ -309,10 +315,14 @@ func (a *LedgerActor) Start(ctx context.Context) error {
 
 	codec := newLedgerCodec()
 
+	// The durable actor should not see LedgerActor's OnStop hook, because
+	// that hook waits for the durable actor itself to exit. The
+	// actor-system wrapper owns that cleanup instead.
+	durableBehavior := actor.NewFunctionBehavior(a.Receive)
 	durableCfg := actor.DefaultDurableActorConfig[
 		LedgerMsg, LedgerResp,
 	](
-		a.actorID, a, a.cfg.DeliveryStore, codec,
+		a.actorID, durableBehavior, a.cfg.DeliveryStore, codec,
 	)
 	a.durable = actor.NewDurableActor(durableCfg)
 	a.ref = a.durable.Ref()
@@ -346,6 +356,16 @@ func (a *LedgerActor) Stop() {
 	if a.durable != nil {
 		a.durable.Stop()
 	}
+}
+
+// OnStop implements actor.Stoppable by stopping the durable ledger runtime and
+// waiting for it to exit before the actor system closes shared storage.
+func (a *LedgerActor) OnStop(ctx context.Context) error {
+	if a.durable == nil {
+		return nil
+	}
+
+	return a.durable.StopAndWait(ctx)
 }
 
 // Ref returns the actor reference for sending messages.


### PR DESCRIPTION
## Summary

This PR fixes two noisy-but-expected client daemon log paths that showed up while driving the manual Ark harness.

The transaction executor no longer warns for `sql.ErrNoRows` transaction body failures. Those misses are a normal negative lookup for paths like checking ordinary LND wallet UTXOs against tracked boarding addresses, and the caller still receives the original error if it needs to handle it.

Daemon shutdown now stops the OOR actor, server connection runtime, actor system, and the ledger actor's embedded durable runtime before closing the database. This prevents background actor work from reporting `sql: database is closed` during clean shutdown.

## Validation

- `go test ./db ./wallet ./ledger ./darepod`
- Downstream manual `arktest` flow with Alice/Bob boarding, an OOR send, clean shutdown, and log scans for:
  - `get boarding address: sql: no rows`
  - `Transaction body failed`
  - `Transaction begin failed`
  - `Failed to lease message from mailbox`
  - `database is closed`