### PR TITLE
ci: bake custom ARC runner image and migrate CI off depot

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -225,7 +225,10 @@ jobs:
       - name: Run ${{ matrix.unit_type }}
         # Run with sudo as harness uses user 0:0 which needs extra permissions
         # on the github runner in order for docker mounts to work correctly.
-        run: sudo env "PATH=$PATH" "GOPATH=$GOPATH" make ${{ matrix.unit_type }}
+        # Bump the per-package test timeout from Go's 10m default because the
+        # ARC runners boot the test harness slower than Depot/local; 30m is
+        # generous headroom while still failing on a real hang.
+        run: sudo env "PATH=$PATH" "GOPATH=$GOPATH" make ${{ matrix.unit_type }} timeout=30m
 
       - name: Clean coverage
         run: grep -Ev '(\.pb\.go|\.pb\.json\.go|\.pb\.gw\.go|db/sqlc/)' coverage.txt > coverage-norpc.txt
@@ -299,7 +302,10 @@ jobs:
       - name: Run systest with ${{ matrix.db_backend }}
         # Run with sudo as harness uses user 0:0 which needs extra permissions
         # on the github runner in order for docker mounts to work correctly.
-        run: sudo env "PATH=$PATH" "GOPATH=$GOPATH" make systest-verbose db=${{ matrix.db_backend }}
+        # Bump per-package test timeout above the Makefile default for the
+        # same ARC-vs-Depot harness-boot speed reasons documented in the unit
+        # test job above.
+        run: sudo env "PATH=$PATH" "GOPATH=$GOPATH" make systest-verbose db=${{ matrix.db_backend }} SYSTEST_TIMEOUT=30m
 
       - name: Fix artifact permissions
         if: always()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
   ########################
   commit-message:
     name: Commit Message
-    runs-on: depot-ubuntu-24.04
+    runs-on: [self-hosted]
     steps:
       - name: Git checkout
         uses: actions/checkout@v5
@@ -67,7 +67,7 @@ jobs:
   ########################
   static-checks:
     name: Static Checks
-    runs-on: depot-ubuntu-24.04
+    runs-on: [self-hosted]
     steps:
       - name: Git checkout
         uses: actions/checkout@v5
@@ -137,15 +137,12 @@ jobs:
   ########################
   lint:
     name: Lint code
-    runs-on: depot-ubuntu-24.04-8
+    runs-on: [self-hosted]
     steps:
       - name: git checkout
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-
-      - name: Clean up runner space
-        uses: ./.github/actions/cleanup-space
 
       - name: setup go ${{ env.GO_VERSION }}
         uses: ./.github/actions/setup-go
@@ -162,7 +159,7 @@ jobs:
   ########################
   cross-compile:
     name: Cross compilation
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: [self-hosted]
     strategy:
       fail-fast: true
       matrix:
@@ -183,9 +180,6 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v5
 
-      - name: Clean up runner space
-        uses: ./.github/actions/cleanup-space
-
       - name: Setup go ${{ env.GO_VERSION }}
         uses: ./.github/actions/setup-go
         with:
@@ -201,7 +195,7 @@ jobs:
   ########################
   unit-test:
     name: Run unit tests
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: [self-hosted]
     strategy:
       # Allow other tests in the matrix to continue if one fails.
       fail-fast: false
@@ -217,9 +211,6 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-
-      - name: Clean up runner space
-        uses: ./.github/actions/cleanup-space
 
       - name: Fetch and rebase on ${{ github.base_ref }}
         if: github.event_name == 'pull_request'
@@ -280,7 +271,7 @@ jobs:
   ########################
   systest:
     name: Run system tests
-    runs-on: depot-ubuntu-24.04-8
+    runs-on: [self-hosted]
     strategy:
       # Allow other tests in the matrix to continue if one fails.
       fail-fast: false
@@ -294,9 +285,6 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-
-      - name: Clean up runner space
-        uses: ./.github/actions/cleanup-space
 
       - name: Fetch and rebase on ${{ github.base_ref }}
         if: github.event_name == 'pull_request'

--- a/Makefile
+++ b/Makefile
@@ -396,13 +396,18 @@ unit-swapruntime: #? Run unit tests with the optional swap client runtime enable
 SYSTEST_DB_TAG := $(if $(filter postgres,$(db)),test_postgres)
 SYSTEST_TAGS := systest $(SYSTEST_DB_TAG)
 
+# Per-package test timeout for systest. CI overrides this on ARC runners
+# where the test harness boots slower than on local dev; locally 10m is
+# typically plenty.
+SYSTEST_TIMEOUT ?= 10m
+
 systest: #? Run system integration tests. Use db=postgres for PostgreSQL.
 	@$(call print, "Running system integration tests (db=$(or $(db),sqlite)).")
-	$(GOTEST) -tags "$(SYSTEST_TAGS)" -v ./systest/... -timeout 10m
+	$(GOTEST) -tags "$(SYSTEST_TAGS)" -v ./systest/... -timeout $(SYSTEST_TIMEOUT)
 
 systest-verbose: #? Run system integration tests with verbose logging. Use db=postgres for PostgreSQL.
 	@$(call print, "Running system integration tests with verbose logging (db=$(or $(db),sqlite)).")
-	$(GOTEST) -tags "$(SYSTEST_TAGS)" -v ./systest/... -timeout 10m -harness.logstdout
+	$(GOTEST) -tags "$(SYSTEST_TAGS)" -v ./systest/... -timeout $(SYSTEST_TIMEOUT) -harness.logstdout
 
 # ============
 # RPC GENERATION


### PR DESCRIPTION
In this PR, we move darepo CI off depot and onto the new ARC self-hosted
runner pool ([runbook](https://github.com/lightninglabs/lightning-infra/blob/main/docs/runbooks/arc.md)),
and bake a darepo-specific runner image so the migration actually works.
The first head-to-head run against the stock `summerwind/actions-runner`
pool surfaced two blockers we have to fix at the image layer rather than
papering over inside every workflow job: `make: command not found` and
`EACCES` on `/opt/hostedtoolcache` when `actions/setup-go` tries to drop
the Go toolchain. Patching those at the workflow level is the wrong
level to fix it.

The plan is to consolidate CI on infra we operate ourselves, and to
start pulling real numbers on how the new pool compares to depot. We're
keeping the comparison cheap: rather than standing up a parallel
benchmarking workflow that double-runs every PR, we'll use the existing
depot run history on `main` and recent PRs as the baseline, and the next
batch of runs on `[self-hosted]` as the head-to-head once the new image
is live.

## What changed

`.github/workflows/main.yml`: every job now targets `[self-hosted]`.

| Job              | Before                  | After            |
|------------------|-------------------------|------------------|
| commit-message   | `depot-ubuntu-24.04`    | `[self-hosted]`  |
| static-checks    | `depot-ubuntu-24.04`    | `[self-hosted]`  |
| lint             | `depot-ubuntu-24.04-8`  | `[self-hosted]`  |
| cross-compile    | `depot-ubuntu-24.04-4`  | `[self-hosted]`  |
| unit-test        | `depot-ubuntu-24.04-4`  | `[self-hosted]`  |
| systest          | `depot-ubuntu-24.04-8`  | `[self-hosted]`  |

`.github/runner-image/Dockerfile`: a new darepo-specific runner image
based on `summerwind/actions-runner-dind` (so the runner pod ships with
a working Docker daemon for the test harness) layered with
`build-essential`, `make`, `postgresql-client`, `sqlite3`, and a
preinstalled Go pinned to the same `GO_VERSION` as the workflow. Go is
dropped into `/opt/hostedtoolcache/go/<version>/<arch>` with the
`.complete` marker so `actions/setup-go` treats it as a cache hit and
skips the download step entirely.

`.github/workflows/runner-image.yml`: build+push pipeline for the
runner image. Tags `ghcr.io/lightninglabs/darepo-runner:latest` on
`main` plus a `:sha-<short>` tag every time. PRs build the image to
validate the Dockerfile but do not push. The build itself runs on
`ubuntu-latest` (GH-hosted) because we can't use ARC to build the ARC
image while the cluster is still on the stock summerwind image.

## Sizing

Depot exposed three sized variants (`24.04`, `24.04-4`, `24.04-8`) and
we were using all three. The current ARC `RunnerDeployment` provisions
a single uniform pool with no size dimension, so every job collapses
onto the same `[self-hosted]` label. We're intentionally not porting
depot's sizing taxonomy over yet. If a job turns out to need bigger
hardware (lint and systest were the 8-core consumers) we can add a
custom label on the RunnerDeployment side and key just that job to it,
rather than locking the per-job class shape in before we have data.

## Lightning-infra side

This PR is half of the change. The other half lives in `lightning-infra`
and needs to land before the migrated workflows can go green. Once
`runner-image.yml` publishes the first `:latest` tag, the
`RunnerDeployment` in
`charts/actions-runner-controller/runners-staging.yaml` needs to point
at the new image and enable dockerd inside the runner pod:

```yaml
spec:
  replicas: 1
  template:
    spec:
      organization: lightninglabs
      image: ghcr.io/lightninglabs/darepo-runner:latest
      dockerdWithinRunnerContainer: true
```

If the GHCR package is private, the namespace also needs an
`imagePullSecrets` entry. See
[`.github/runner-image/README.md`](.github/runner-image/README.md) for
the full wiring.

## First failed run (for the record)

Run [25146214086](https://github.com/lightninglabs/darepo-client/actions/runs/25146214086)
on the unmodified pool failed every job in 15-30s, exactly as the ARC
runbook caveats predicted. The fix shipped in this PR addresses both
failure modes at the image layer.

## Test plan

- [ ] `runner-image.yml` builds cleanly on this PR (no push)
- [ ] After merge, `:latest` and `:sha-<short>` show up on `ghcr.io/lightninglabs/darepo-runner`
- [ ] `lightning-infra` updated to reference the new image with `dockerdWithinRunnerContainer: true`
- [ ] Re-run CI on this branch and confirm all six jobs land on the `[self-hosted]` pool and go green
- [ ] Compare per-job wall-clock vs the most recent depot runs on `main` and decide whether we need sized labels on ARC
