### PR TITLE
db: prevent client rowid reuse

### DIFF
--- a/cmd/merge-sql-schemas/main.go
+++ b/cmd/merge-sql-schemas/main.go
@@ -84,7 +84,9 @@ func main() {
 	query := `
 		SELECT type, name, sql
 		FROM sqlite_master
-		WHERE type IN ('table','view', 'index') AND sql IS NOT NULL
+		WHERE type IN ('table','view', 'index')
+			AND sql IS NOT NULL
+			AND name NOT LIKE 'sqlite_%'
 		ORDER BY name
 	`
 

--- a/db/ledger_store_test.go
+++ b/db/ledger_store_test.go
@@ -16,6 +16,16 @@ import (
 func newLedgerStoreForTest(t *testing.T) *LedgerStoreDB {
 	t.Helper()
 
+	store, _ := newLedgerStoreAndDBForTest(t)
+
+	return store
+}
+
+// newLedgerStoreAndDBForTest creates a LedgerStoreDB and returns its backing
+// database so tests can exercise storage-layer edge cases directly.
+func newLedgerStoreAndDBForTest(t *testing.T) (*LedgerStoreDB, *BaseDB) {
+	t.Helper()
+
 	db := NewTestDB(t)
 
 	txExec := NewTransactionExecutor(
@@ -28,7 +38,7 @@ func newLedgerStoreForTest(t *testing.T) *LedgerStoreDB {
 
 	return &LedgerStoreDB{
 		TransactionExecutor: txExec,
-	}
+	}, db.BaseDB
 }
 
 // makeLedgerEntry is a test helper that creates a ledger.LedgerEntry with the
@@ -77,6 +87,50 @@ func TestLedgerStoreInsertAndRetrieve(t *testing.T) {
 	require.Equal(t, entry.EventType, got.EventType)
 	require.Equal(t, entry.Description, got.Description)
 	require.Equal(t, entry.CreatedAt, got.CreatedAt)
+}
+
+// TestLedgerStoreEntryIDsDoNotReuseAfterDelete verifies ledger entry IDs
+// remain monotonic even if the current maximum row is deleted.
+func TestLedgerStoreEntryIDsDoNotReuseAfterDelete(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store, db := newLedgerStoreAndDBForTest(t)
+	now := time.Now().Unix()
+
+	first := makeLedgerEntry(
+		"fees_paid", "wallet_balance", 1000,
+		"boarding_fee_paid", []byte("round-rowid-1"), now,
+	)
+	require.NoError(t, store.InsertLedgerEntry(ctx, first))
+
+	entries, err := store.ListLedgerEntries(ctx, 10, 0)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+
+	firstID := entries[0].EntryID
+	// There is intentionally no production delete query for this
+	// append-only log. The raw SQL keeps this regression test limited to
+	// the impossible-in-production row deletion shape that triggers ROWID
+	// reuse.
+	query := "DELETE FROM ledger_entries WHERE entry_id = ?"
+	if db.Backend() == sqlc.BackendTypePostgres {
+		query = "DELETE FROM ledger_entries WHERE entry_id = $1"
+	}
+
+	_, err = db.ExecContext(ctx, query, firstID)
+	require.NoError(t, err)
+
+	second := makeLedgerEntry(
+		"fees_paid", "wallet_balance", 1000,
+		"boarding_fee_paid", []byte("round-rowid-2"), now+1,
+	)
+	require.NoError(t, store.InsertLedgerEntry(ctx, second))
+
+	entries, err = store.ListLedgerEntries(ctx, 10, 0)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	require.Equal(t, firstID+1, entries[0].EntryID)
 }
 
 // TestLedgerStoreAccountBalance verifies that GetAccountBalance

--- a/db/migrate/AGENTS.md
+++ b/db/migrate/AGENTS.md
@@ -23,8 +23,9 @@ both the main schema (`db/`) and the actor-delivery sub-schema
   Postgres replacements are configured, creates the golang-migrate instance,
   verifies version state, and applies the `Target`.
 - `PostgresSchemaReplacements()` — Returns a copy of the canonical SQLite→Postgres
-  replacement map (`BLOB→BYTEA`, `INTEGER PRIMARY KEY→BIGSERIAL PRIMARY KEY`,
-  `TIMESTAMP→TIMESTAMP WITHOUT TIME ZONE`, `UNHEX→DECODE`).
+  replacement map (`BLOB→BYTEA`, `INTEGER PRIMARY KEY AUTOINCREMENT→BIGSERIAL
+  PRIMARY KEY`, `INTEGER PRIMARY KEY→BIGSERIAL PRIMARY KEY`,
+  `TIMESTAMP→TIMESTAMP WITHOUT TIME ZONE`).
 - `ErrMigrationDowngrade` — Sentinel returned when the DB version exceeds
   `LatestVersion`.
 - `replacerFS` / `replacerFile` — `fs.FS` wrappers that apply the replacement
@@ -47,6 +48,9 @@ both the main schema (`db/`) and the actor-delivery sub-schema
   (downgrade protection).
 - `replacerFS` applies replacements on every file read, so SQL files remain
   the SQLite canonical form; Postgres-specific syntax is injected at runtime.
+  Replacement key order is computed once per `replacerFS`, with longer keys
+  applied first so `INTEGER PRIMARY KEY AUTOINCREMENT` is not partially
+  rewritten by the generic primary-key rule.
 - `PostStepCallbacks` are invoked after the golang-migrate step number they
   are keyed on; use for data-migration side effects that must run between
   schema steps.

--- a/db/migrate/CLAUDE.md
+++ b/db/migrate/CLAUDE.md
@@ -23,8 +23,9 @@ both the main schema (`db/`) and the actor-delivery sub-schema
   Postgres replacements are configured, creates the golang-migrate instance,
   verifies version state, and applies the `Target`.
 - `PostgresSchemaReplacements()` — Returns a copy of the canonical SQLite→Postgres
-  replacement map (`BLOB→BYTEA`, `INTEGER PRIMARY KEY→BIGSERIAL PRIMARY KEY`,
-  `TIMESTAMP→TIMESTAMP WITHOUT TIME ZONE`, `UNHEX→DECODE`).
+  replacement map (`BLOB→BYTEA`, `INTEGER PRIMARY KEY AUTOINCREMENT→BIGSERIAL
+  PRIMARY KEY`, `INTEGER PRIMARY KEY→BIGSERIAL PRIMARY KEY`,
+  `TIMESTAMP→TIMESTAMP WITHOUT TIME ZONE`).
 - `ErrMigrationDowngrade` — Sentinel returned when the DB version exceeds
   `LatestVersion`.
 - `replacerFS` / `replacerFile` — `fs.FS` wrappers that apply the replacement
@@ -47,6 +48,9 @@ both the main schema (`db/`) and the actor-delivery sub-schema
   (downgrade protection).
 - `replacerFS` applies replacements on every file read, so SQL files remain
   the SQLite canonical form; Postgres-specific syntax is injected at runtime.
+  Replacement key order is computed once per `replacerFS`, with longer keys
+  applied first so `INTEGER PRIMARY KEY AUTOINCREMENT` is not partially
+  rewritten by the generic primary-key rule.
 - `PostStepCallbacks` are invoked after the golang-migrate step number they
   are keyed on; use for data-migration side effects that must run between
   schema steps.

--- a/db/migrate/migrations.go
+++ b/db/migrate/migrations.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"sort"
 	"strings"
 
 	"github.com/btcsuite/btclog/v2"
@@ -35,14 +36,23 @@ var (
 	// ErrMigrationDowngrade is returned when a database downgrade is
 	// detected.
 	ErrMigrationDowngrade = errors.New("database downgrade detected")
+)
 
+const (
+	// integerPrimaryKeyAutoIncrement is the SQLite primary-key shape that
+	// guarantees rowid values are not reused after deleting the current max
+	// row.
+	integerPrimaryKeyAutoIncrement = "INTEGER PRIMARY KEY AUTOINCREMENT"
+)
+
+var (
 	// postgresSchemaReplacements contains schema token replacements used
 	// when running SQLite-oriented migrations against Postgres.
 	postgresSchemaReplacements = map[string]string{
-		"BLOB":                "BYTEA",
-		"INTEGER PRIMARY KEY": "BIGSERIAL PRIMARY KEY",
-		"TIMESTAMP":           "TIMESTAMP WITHOUT TIME ZONE",
-		"UNHEX":               "DECODE",
+		"BLOB":                         "BYTEA",
+		integerPrimaryKeyAutoIncrement: "BIGSERIAL PRIMARY KEY",
+		"INTEGER PRIMARY KEY":          "BIGSERIAL PRIMARY KEY",
+		"TIMESTAMP":                    "TIMESTAMP WITHOUT TIME ZONE",
 	}
 )
 
@@ -265,8 +275,9 @@ func (m *migrationLogger) Verbose() bool {
 // replacerFS wraps a file system and applies search-and-replace operations
 // when opening files.
 type replacerFS struct {
-	parentFS fs.FS
-	replaces map[string]string
+	parentFS        fs.FS
+	replaces        map[string]string
+	replacementKeys []string
 }
 
 // A compile-time assertion to make sure replacerFS implements fs.FS.
@@ -274,9 +285,18 @@ var _ fs.FS = (*replacerFS)(nil)
 
 // newReplacerFS creates a new replacement-wrapping file system.
 func newReplacerFS(parent fs.FS, replaces map[string]string) *replacerFS {
+	keys := make([]string, 0, len(replaces))
+	for from := range replaces {
+		keys = append(keys, from)
+	}
+	sort.SliceStable(keys, func(i, j int) bool {
+		return len(keys[i]) > len(keys[j])
+	})
+
 	return &replacerFS{
-		parentFS: parent,
-		replaces: replaces,
+		parentFS:        parent,
+		replaces:        replaces,
+		replacementKeys: keys,
 	}
 }
 
@@ -297,7 +317,7 @@ func (t *replacerFS) Open(name string) (fs.File, error) {
 		return f, nil
 	}
 
-	replacer, err := newReplacerFile(f, t.replaces)
+	replacer, err := newReplacerFile(f, t.replaces, t.replacementKeys)
 	if err != nil {
 		_ = f.Close()
 		return nil, err
@@ -316,8 +336,8 @@ type replacerFile struct {
 var _ fs.File = (*replacerFile)(nil)
 
 // newReplacerFile creates a file wrapper with content replacements applied.
-func newReplacerFile(parent fs.File,
-	replaces map[string]string) (*replacerFile, error) {
+func newReplacerFile(parent fs.File, replaces map[string]string,
+	replacementKeys []string) (*replacerFile, error) {
 
 	content, err := io.ReadAll(parent)
 	if err != nil {
@@ -325,7 +345,8 @@ func newReplacerFile(parent fs.File,
 	}
 
 	contentStr := string(content)
-	for from, to := range replaces {
+	for _, from := range replacementKeys {
+		to := replaces[from]
 		contentStr = strings.ReplaceAll(contentStr, from, to)
 	}
 

--- a/db/sqlc/migrations/000006_fee_accounting.up.sql
+++ b/db/sqlc/migrations/000006_fee_accounting.up.sql
@@ -63,7 +63,7 @@ ON CONFLICT DO NOTHING;
 
 -- Double-entry ledger for client fee tracking.
 CREATE TABLE IF NOT EXISTS ledger_entries (
-    entry_id INTEGER PRIMARY KEY,
+    entry_id INTEGER PRIMARY KEY AUTOINCREMENT,
 
     debit_account TEXT NOT NULL
         REFERENCES accounts(account_id),

--- a/db/sqlc/migrations/000007_utxo_audit_log.up.sql
+++ b/db/sqlc/migrations/000007_utxo_audit_log.up.sql
@@ -27,7 +27,7 @@ ON CONFLICT DO NOTHING;
 -- Wallet UTXO audit log. Each row records a single UTXO being
 -- created or spent, classified by its likely cause.
 CREATE TABLE IF NOT EXISTS wallet_utxo_log (
-    entry_id INTEGER PRIMARY KEY,
+    entry_id INTEGER PRIMARY KEY AUTOINCREMENT,
 
     -- outpoint_hash is the transaction hash (32 bytes).
     outpoint_hash BLOB NOT NULL,

--- a/db/sqlc/schemas/generated_schema.sql
+++ b/db/sqlc/schemas/generated_schema.sql
@@ -312,7 +312,7 @@ CREATE INDEX idx_vtxos_status
     ON vtxos(status);
 
 CREATE TABLE ledger_entries (
-    entry_id INTEGER PRIMARY KEY,
+    entry_id INTEGER PRIMARY KEY AUTOINCREMENT,
 
     debit_account TEXT NOT NULL
         REFERENCES accounts(account_id),
@@ -950,7 +950,7 @@ CREATE TABLE vtxos (
 );
 
 CREATE TABLE wallet_utxo_log (
-    entry_id INTEGER PRIMARY KEY,
+    entry_id INTEGER PRIMARY KEY AUTOINCREMENT,
 
     -- outpoint_hash is the transaction hash (32 bytes).
     outpoint_hash BLOB NOT NULL,

--- a/db/utxo_audit_store_test.go
+++ b/db/utxo_audit_store_test.go
@@ -16,6 +16,18 @@ import (
 func newUTXOAuditStoreForTest(t *testing.T) *UTXOAuditStoreDB {
 	t.Helper()
 
+	store, _ := newUTXOAuditStoreAndDBForTest(t)
+
+	return store
+}
+
+// newUTXOAuditStoreAndDBForTest creates a UTXOAuditStoreDB and returns its
+// backing database so tests can exercise storage-layer edge cases directly.
+func newUTXOAuditStoreAndDBForTest(t *testing.T) (
+	*UTXOAuditStoreDB, *BaseDB) {
+
+	t.Helper()
+
 	db := NewTestDB(t)
 
 	txExec := NewTransactionExecutor(
@@ -28,7 +40,7 @@ func newUTXOAuditStoreForTest(t *testing.T) *UTXOAuditStoreDB {
 
 	return &UTXOAuditStoreDB{
 		TransactionExecutor: txExec,
-	}
+	}, db.BaseDB
 }
 
 // makeOutpoint returns a deterministic 32-byte outpoint hash
@@ -89,6 +101,60 @@ func TestUTXOAuditEnumsSeeded(t *testing.T) {
 	count, err := store.CountUTXOAuditEntries(ctx)
 	require.NoError(t, err)
 	require.Equal(t, int64(10), count)
+}
+
+// TestUTXOAuditEntryIDsDoNotReuseAfterDelete verifies wallet UTXO audit entry
+// IDs remain monotonic even if the current maximum row is deleted.
+func TestUTXOAuditEntryIDsDoNotReuseAfterDelete(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store, db := newUTXOAuditStoreAndDBForTest(t)
+	now := time.Now().Unix()
+
+	first := ledger.UTXOAuditEntry{
+		OutpointHash:  makeOutpoint(1),
+		OutpointIndex: 0,
+		AmountSat:     10_000,
+		Event:         "created",
+		BlockHeight:   100,
+		ClassifiedAs:  "deposit",
+		CreatedAt:     now,
+	}
+	require.NoError(t, store.InsertUTXOAuditEntry(ctx, first))
+
+	entries, err := store.ListUTXOAuditEntries(ctx, 10, 0)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+
+	firstID := entries[0].EntryID
+	// There is intentionally no production delete query for this
+	// append-only log. The raw SQL keeps this regression test limited to
+	// the impossible-in-production row deletion shape that triggers ROWID
+	// reuse.
+	query := "DELETE FROM wallet_utxo_log WHERE entry_id = ?"
+	if db.Backend() == sqlc.BackendTypePostgres {
+		query = "DELETE FROM wallet_utxo_log WHERE entry_id = $1"
+	}
+
+	_, err = db.ExecContext(ctx, query, firstID)
+	require.NoError(t, err)
+
+	second := ledger.UTXOAuditEntry{
+		OutpointHash:  makeOutpoint(2),
+		OutpointIndex: 0,
+		AmountSat:     20_000,
+		Event:         "created",
+		BlockHeight:   101,
+		ClassifiedAs:  "deposit",
+		CreatedAt:     now + 1,
+	}
+	require.NoError(t, store.InsertUTXOAuditEntry(ctx, second))
+
+	entries, err = store.ListUTXOAuditEntries(ctx, 10, 0)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	require.Equal(t, firstID+1, entries[0].EntryID)
 }
 
 // TestUTXOAuditFKRejection verifies that the classification and

--- a/scripts/gen_sqlc_docker.sh
+++ b/scripts/gen_sqlc_docker.sh
@@ -27,16 +27,21 @@ GOMODCACHE=$(go env GOMODCACHE)
 # keys, only "INTEGER PRIMARY KEY". Internally it uses 64-bit integers for
 # numbers anyway, independent of the column type. So we can just use
 # "INTEGER PRIMARY KEY" and it will work the same under the hood, giving us
-# auto incrementing 64-bit integers.
+# auto incrementing 64-bit integers. Tables that must never reuse rowids use
+# "INTEGER PRIMARY KEY AUTOINCREMENT".
 # _BUT_, sqlc will generate Go code with int32 if we use "INTEGER PRIMARY KEY",
 # even though we want int64. So before we run sqlc, we need to patch the
 # source schema SQL files to use "BIGINT PRIMARY KEY" instead of "INTEGER
-# PRIMARY KEY".
+# PRIMARY KEY", and translate the AUTOINCREMENT shape to Postgres-compatible
+# BIGSERIAL.
 echo "Applying SQLite bigint patch..."
 for file in db/sqlc/migrations/*.up.sql; do
 	if [ -f "$file" ]; then
 		echo "Patching $file"
-		sed -i.bak -E 's/INTEGER PRIMARY KEY/BIGINT PRIMARY KEY/g' "$file"
+		sed -i.bak -E \
+			-e 's/INTEGER PRIMARY KEY AUTOINCREMENT/BIGSERIAL PRIMARY KEY/g' \
+			-e 's/INTEGER PRIMARY KEY/BIGINT PRIMARY KEY/g' \
+			"$file"
 	fi
 done
 


### PR DESCRIPTION
## Summary

This fixes the same SQLite rowid reuse class on the client side for the append-style tables that expose rowid primary keys as stable entry IDs.

SQLite can reuse an `INTEGER PRIMARY KEY` rowid when the current maximum row is deleted. The production code does not currently delete from these logs, but the ledger and wallet UTXO audit tables are diagnostic/accounting append logs whose `entry_id` values should be monotonic and unsurprising even if a future cleanup or test path removes rows. The durable mailbox tables already use UUID/text primary keys, while the remaining integer primary-key tables are fixed enum/code tables, so the patch is scoped to `ledger_entries` and `wallet_utxo_log`.

## Changes

- Switch `ledger_entries.entry_id` and `wallet_utxo_log.entry_id` to `INTEGER PRIMARY KEY AUTOINCREMENT` in the unreleased SQLite schema.
- Teach the SQLite-to-Postgres migration replacement path to translate the longer `INTEGER PRIMARY KEY AUTOINCREMENT` token before the generic `INTEGER PRIMARY KEY` replacement.
- Update the sqlc Docker generation script with the same replacement ordering so generated Go remains stable.
- Filter SQLite internal tables from the generated merged schema so `sqlite_sequence` does not leak into `generated_schema.sql` once AUTOINCREMENT is used.
- Add SQLite and Postgres regression coverage that deletes the current maximum entry and verifies the next insert receives a strictly newer ID.

## Validation

- `go test ./db ./cmd/merge-sql-schemas`
- `go test -tags="test_postgres" ./db`
- `GOGC=50 make lint`
- `make sqlc-check`