### PR TITLE
docs: nightly doc-gardening sweep 2026-04-30

### DIFF
--- a/arkrpc/AGENTS.md
+++ b/arkrpc/AGENTS.md
@@ -15,19 +15,37 @@ Proto source: `arkrpc/ark.proto`, `arkrpc/indexer.proto`.
   with sorted child indices. Re-exported under the narrower
   `arkrpc/treeconv` sub-package for callers that do not need the full gRPC
   surface.
+- `AncestryPath` — Proto message carrying one commitment-tree fragment for
+  multi-tree VTXO ancestry. Fields: `TreePath`, `CommitmentTxid []byte`,
+  `InputIndices []uint32`, `TreeDepth uint32`. An indexer `VTXO` response
+  carries `[]AncestryPath` for OOR VTXOs with cross-commitment ancestry.
+- `AncestryPathFromTree(t, commitmentTxID, inputIndices)` — Constructs an
+  `AncestryPath` from a `tree.Tree` by calling `TreePathFromTree` and computing
+  `treeMaxDepth`. Depth walk is bounded by `MaxAncestryTreeWalkDepth = 32`.
+- `AncestryPathToTree(p)` — Inverse of `AncestryPathFromTree`; converts proto
+  `AncestryPath` back to `*tree.Tree` via `TreePathToTree`.
+- `AncestryCommitmentTxID(p)` — Decodes `p.CommitmentTxid` bytes into a
+  `chainhash.Hash`; returns an error if the length is not `chainhash.HashSize`.
+- `MaxAncestryTreeWalkDepth = 32` — Max tree depth walked by `treeMaxDepth`;
+  prevents runaway recursion on untrusted blobs (same bound as
+  `db.MaxTreeDeserializeDepth`).
 - `IncomingOOREvent` — Lightweight notification (wake-up hint). Carries only
   session_id, pk_script, event_id. Triggers the three-phase receive flow.
 - `OORRecipientEvent` — Phase 1 query response from
   `ListOORRecipientEventsByScript`. Carries the full Ark PSBT and checkpoint
   PSBTs that `IncomingOOREvent` intentionally omits.
 - `VTXO` — Phase 2 query response from `ListVTXOsByScripts`. Carries
-  authoritative lineage metadata including the structured `TreePath`.
+  authoritative lineage metadata including `[]AncestryPath` (replaces the
+  singular `TreePath` field).
 
 ## Relationships
 
-- **Depends on**: `lib/tree` (for conversion utilities in `tree_path_convert.go`).
+- **Depends on**: `lib/tree` (for conversion utilities in `tree_path_convert.go`
+  and `ancestry_path_convert.go`).
 - **Depended on by**: `indexer`, `darepod`, `serverconn`, `oor` (uses generated
-  clients and conversion helpers).
+  clients and conversion helpers); `darepod` uses `AncestryPathToTree` /
+  `AncestryCommitmentTxID` in `incoming_metadata.go` to convert indexer
+  `VTXO.ancestry_paths` into `[]vtxo.Ancestry` for domain materialization.
 
 ## Invariants
 
@@ -36,3 +54,7 @@ Proto source: `arkrpc/ark.proto`, `arkrpc/indexer.proto`.
   reproduce the original tree (excluding derived `FinalKey` fields).
 - Child iteration during flattening is sorted by output index for
   deterministic serialization.
+- `AncestryPathFromTree` copies `inputIndices` to avoid aliasing the caller's
+  slice; the proto bytes for `CommitmentTxid` are also cloned.
+- `treeMaxDepth` is bounded by `MaxAncestryTreeWalkDepth = 32` to prevent
+  unbounded recursion on operator-sourced tree blobs.

--- a/arkrpc/CLAUDE.md
+++ b/arkrpc/CLAUDE.md
@@ -15,19 +15,37 @@ Proto source: `arkrpc/ark.proto`, `arkrpc/indexer.proto`.
   with sorted child indices. Re-exported under the narrower
   `arkrpc/treeconv` sub-package for callers that do not need the full gRPC
   surface.
+- `AncestryPath` — Proto message carrying one commitment-tree fragment for
+  multi-tree VTXO ancestry. Fields: `TreePath`, `CommitmentTxid []byte`,
+  `InputIndices []uint32`, `TreeDepth uint32`. An indexer `VTXO` response
+  carries `[]AncestryPath` for OOR VTXOs with cross-commitment ancestry.
+- `AncestryPathFromTree(t, commitmentTxID, inputIndices)` — Constructs an
+  `AncestryPath` from a `tree.Tree` by calling `TreePathFromTree` and computing
+  `treeMaxDepth`. Depth walk is bounded by `MaxAncestryTreeWalkDepth = 32`.
+- `AncestryPathToTree(p)` — Inverse of `AncestryPathFromTree`; converts proto
+  `AncestryPath` back to `*tree.Tree` via `TreePathToTree`.
+- `AncestryCommitmentTxID(p)` — Decodes `p.CommitmentTxid` bytes into a
+  `chainhash.Hash`; returns an error if the length is not `chainhash.HashSize`.
+- `MaxAncestryTreeWalkDepth = 32` — Max tree depth walked by `treeMaxDepth`;
+  prevents runaway recursion on untrusted blobs (same bound as
+  `db.MaxTreeDeserializeDepth`).
 - `IncomingOOREvent` — Lightweight notification (wake-up hint). Carries only
   session_id, pk_script, event_id. Triggers the three-phase receive flow.
 - `OORRecipientEvent` — Phase 1 query response from
   `ListOORRecipientEventsByScript`. Carries the full Ark PSBT and checkpoint
   PSBTs that `IncomingOOREvent` intentionally omits.
 - `VTXO` — Phase 2 query response from `ListVTXOsByScripts`. Carries
-  authoritative lineage metadata including the structured `TreePath`.
+  authoritative lineage metadata including `[]AncestryPath` (replaces the
+  singular `TreePath` field).
 
 ## Relationships
 
-- **Depends on**: `lib/tree` (for conversion utilities in `tree_path_convert.go`).
+- **Depends on**: `lib/tree` (for conversion utilities in `tree_path_convert.go`
+  and `ancestry_path_convert.go`).
 - **Depended on by**: `indexer`, `darepod`, `serverconn`, `oor` (uses generated
-  clients and conversion helpers).
+  clients and conversion helpers); `darepod` uses `AncestryPathToTree` /
+  `AncestryCommitmentTxID` in `incoming_metadata.go` to convert indexer
+  `VTXO.ancestry_paths` into `[]vtxo.Ancestry` for domain materialization.
 
 ## Invariants
 
@@ -36,3 +54,7 @@ Proto source: `arkrpc/ark.proto`, `arkrpc/indexer.proto`.
   reproduce the original tree (excluding derived `FinalKey` fields).
 - Child iteration during flattening is sorted by output index for
   deterministic serialization.
+- `AncestryPathFromTree` copies `inputIndices` to avoid aliasing the caller's
+  slice; the proto bytes for `CommitmentTxid` are also cloned.
+- `treeMaxDepth` is bounded by `MaxAncestryTreeWalkDepth = 32` to prevent
+  unbounded recursion on operator-sourced tree blobs.

--- a/db/AGENTS.md
+++ b/db/AGENTS.md
@@ -30,6 +30,36 @@ and client-side fee accounting. Supports SQLite and PostgreSQL backends.
 - `UnilateralExitJobStatus` — Integer enum: `Pending(0)`, `Materializing(1)`, `CSVPending(2)`, `Sweeping(3)`, `Completed(4)`, `Failed(5)`, `SweepBroadcasting(6)`. `SweepBroadcasting` is appended last (iota 6) so existing rows at status 3 continue to decode as "sweep broadcast, awaiting conf" without shifting semantics.
 - `UnilateralExitJobTrigger` — Integer enum: `Manual(0)`, `CriticalExpiry(1)`, `Restart(2)`, `FraudSpend(3)`.
 - `VTXOPersistenceStore.ensureRoundExists` — Inserts a minimal "confirmed" round row for incoming VTXOs that reference remote rounds. Uses check-then-insert (not upsert) to avoid overwriting richer round state.
+- `MapSQLError(err) error` — Classifies a raw database error into one of the
+  typed sentinel errors below (`ErrDeadlockError`, `ErrSerializationError`,
+  `ErrSQLUniqueConstraintViolation`, `ErrSchemaError`). Returns the original
+  error unchanged when no pattern matches.
+- `IsDeadlockError` / `IsSerializationError` / `IsSerializationOrDeadlockError`
+  / `IsSchemaError` — Boolean predicates for each SQL error class; used by the
+  retry loop and callers that need to distinguish transient from permanent
+  failures without matching error strings.
+- `ErrDeadlockError` / `ErrSerializationError` / `ErrSQLUniqueConstraintViolation`
+  / `ErrSchemaError` — Typed sentinel error structs wrapping the underlying DB
+  error; all implement the `error` interface and expose the original via
+  `Unwrap()`.
+- `MaxTreeDeserializeDepth = 32` — Maximum recursion depth for `DeserializeTree`
+  / `treeMaxDepth`; prevents unbounded recursion on operator-sourced VTXO tree
+  blobs stored in the database.
+- `LatestMigrationVersion = 9` — Bumped from 8 to 9 by migration
+  `000009_vtxo_ancestry_paths` (see Invariants).
+- `upsertAncestryPaths` (internal) — Writes one row per `vtxo.Ancestry` entry
+  into the `vtxo_ancestry_paths` side table. Enforces `maxAncestryRowsPerVTXO
+  = 64` and rejects duplicate `CommitmentTxID` entries. Called by
+  `VTXOPersistenceStore.InsertClientVTXO` and `FinalizeRound`.
+- `groupAncestryRows` (internal) — Aggregates a flat `[]sqlc.VtxoAncestryPath`
+  result into a `map[wire.OutPoint][]vtxo.Ancestry` for O(1) attachment during
+  batch VTXO list queries (eliminates the N+1 per-VTXO ancestry join).
+- `OORUnrollResolver` (via `oor_unroll_resolver.go`) — Resolves OOR package
+  bundles for unroll proof assembly. Now falls back to a session-ID lookup
+  (`loadPackageBundleBySessionID`) when the primary output-hash lookup returns
+  `sql.ErrNoRows`. This supports foreign-ancestor packages that the local wallet
+  has session-keyed visibility into (received from the server) but did not
+  create itself.
 
 ## Relationships
 
@@ -42,9 +72,27 @@ and client-side fee accounting. Supports SQLite and PostgreSQL backends.
 - Boarding intents persist from registration until round completion or failure.
 - Round checkpoints include commitment tx, VTXO tree, client sub-trees, boarding signatures, and every intent with updated status.
 - Default retry logic: 10 retries with exponential backoff (40ms initial, capped at 3s).
+- SQLite `busy_timeout` is set to 30 000 ms (30s) under WAL mode. The previous
+  5s cap was too short under aggressive regtest mining when multiple actors
+  (VTXO actors, unroll registry, txconfirm, ledger, receive scripts) all write
+  to the same DB concurrently; timeouts surfaced as spurious "mailbox full" /
+  "Failed to lease message" upstream errors. Transaction-begin failures during
+  context cancellation (e.g. daemon shutdown) are demoted to debug level to
+  avoid log-flooding at the tail of every integration test.
+- `ErrResolveUnrollMaxDepthExceeded` — Sentinel returned by the OOR unroll
+  resolver when package traversal exceeds the configured recursion limit.
 - **Never write raw SQL in Go** — add queries to `db/queries/`, regenerate with `make sqlc`.
 - Per-subsystem logging: uses instance logger instead of global package logger.
-- Latest migration: `000008_unilateral_exit_store` adds `unilateral_exit_jobs`, one row per target outpoint, holding the manager-facing control-plane view for the per-target unroll actor. `status` is an INTEGER column with documented values 0-6 (the `sweep_broadcasting` and `sweeping` values deliberately distinguish "sweep built, not yet submitted" from "sweep broadcast, awaiting confirmation"). `trigger` is 0-3 (`manual`, `critical_expiry`, `restart`, `fraud_spend`). `UnilateralExitJobStatusSweepBroadcasting` is appended at the end of the Go enum (iota value 6) so existing rows written at status=3 continue to decode as "sweep broadcast, awaiting conf" rather than silently shifting semantics; `UnilateralExitJobTriggerFraudSpend` round-trips through the Go `unroll.TriggerFraudSpend` constant rather than being silently downgraded to `TriggerManual`.
+- Latest migration: `000009_vtxo_ancestry_paths` adds the `vtxo_ancestry_paths`
+  side table: one row per `(vtxo_outpoint_hash, vtxo_outpoint_index,
+  commitment_txid)` triple, holding the serialized tree path blob, input
+  indices array, and tree depth for each ancestry fragment. The table uses
+  `AUTOINCREMENT` primary keys (→ `BIGSERIAL` on Postgres) to prevent rowid
+  reuse after deletions. Batch ancestry queries (`ListLiveVTXOAncestryPaths`,
+  `ListVTXOAncestryPathsByStatus`, `ListUnspentVTXOAncestryPaths`) let list
+  operations load all ancestry in one SQL call and group client-side instead of
+  issuing per-VTXO queries.
+- Prior migration: `000008_unilateral_exit_store` adds `unilateral_exit_jobs`, one row per target outpoint, holding the manager-facing control-plane view for the per-target unroll actor. `status` is an INTEGER column with documented values 0-6 (the `sweep_broadcasting` and `sweeping` values deliberately distinguish "sweep built, not yet submitted" from "sweep broadcast, awaiting confirmation"). `trigger` is 0-3 (`manual`, `critical_expiry`, `restart`, `fraud_spend`). `UnilateralExitJobStatusSweepBroadcasting` is appended at the end of the Go enum (iota value 6) so existing rows written at status=3 continue to decode as "sweep broadcast, awaiting conf" rather than silently shifting semantics; `UnilateralExitJobTriggerFraudSpend` round-trips through the Go `unroll.TriggerFraudSpend` constant rather than being silently downgraded to `TriggerManual`.
 - Prior migration: `000007_utxo_audit_log` adds an append-only UTXO audit log (`wallet_utxo_log`) with FK-constrained enum tables (`utxo_classifications`, `utxo_events`), indexes on block_height, outpoint, and classification, and a `UNIQUE(outpoint_hash, outpoint_index, event)` index that makes inserts idempotent under `RestartMessage` replay.
 - Migration `000006_fee_accounting` seeds the client chart of accounts — `wallet_balance`, `vtxo_balance` (assets); `fees_paid`, `onchain_fees`, `transfers_out` (expenses); `transfers_in` (revenue); `opening_balance` (equity, the source-of-funds counterparty for wallet UTXO deposits) — and `ledger_entries`. `ledger_entries` carries three optional scope columns — `round_id` (16-byte UUID), `session_id` (32-byte OOR identifier), and `idempotency_key` (outpoint-derived BLOB) — each paired with its own partial unique index (`idx_client_ledger_idempotent_round`, `_session`, `_key`) so every event class gets an at-least-once-idempotent path without colliding with the others. `InsertClientLedgerEntry` uses `ON CONFLICT DO NOTHING` so a redelivered durable-actor message resolves to a silent no-op across all three indexes. The `account_types` enum adds `equity` alongside `asset`, `liability`, `revenue`, `expense`. Ledger event types include `wallet_utxo_created` so the deposit leg written by `handleUTXOCreated` (debit `wallet_balance`, credit `opening_balance`) has a classification distinct from fee / transfer events.
 

--- a/db/CLAUDE.md
+++ b/db/CLAUDE.md
@@ -30,6 +30,36 @@ and client-side fee accounting. Supports SQLite and PostgreSQL backends.
 - `UnilateralExitJobStatus` — Integer enum: `Pending(0)`, `Materializing(1)`, `CSVPending(2)`, `Sweeping(3)`, `Completed(4)`, `Failed(5)`, `SweepBroadcasting(6)`. `SweepBroadcasting` is appended last (iota 6) so existing rows at status 3 continue to decode as "sweep broadcast, awaiting conf" without shifting semantics.
 - `UnilateralExitJobTrigger` — Integer enum: `Manual(0)`, `CriticalExpiry(1)`, `Restart(2)`, `FraudSpend(3)`.
 - `VTXOPersistenceStore.ensureRoundExists` — Inserts a minimal "confirmed" round row for incoming VTXOs that reference remote rounds. Uses check-then-insert (not upsert) to avoid overwriting richer round state.
+- `MapSQLError(err) error` — Classifies a raw database error into one of the
+  typed sentinel errors below (`ErrDeadlockError`, `ErrSerializationError`,
+  `ErrSQLUniqueConstraintViolation`, `ErrSchemaError`). Returns the original
+  error unchanged when no pattern matches.
+- `IsDeadlockError` / `IsSerializationError` / `IsSerializationOrDeadlockError`
+  / `IsSchemaError` — Boolean predicates for each SQL error class; used by the
+  retry loop and callers that need to distinguish transient from permanent
+  failures without matching error strings.
+- `ErrDeadlockError` / `ErrSerializationError` / `ErrSQLUniqueConstraintViolation`
+  / `ErrSchemaError` — Typed sentinel error structs wrapping the underlying DB
+  error; all implement the `error` interface and expose the original via
+  `Unwrap()`.
+- `MaxTreeDeserializeDepth = 32` — Maximum recursion depth for `DeserializeTree`
+  / `treeMaxDepth`; prevents unbounded recursion on operator-sourced VTXO tree
+  blobs stored in the database.
+- `LatestMigrationVersion = 9` — Bumped from 8 to 9 by migration
+  `000009_vtxo_ancestry_paths` (see Invariants).
+- `upsertAncestryPaths` (internal) — Writes one row per `vtxo.Ancestry` entry
+  into the `vtxo_ancestry_paths` side table. Enforces `maxAncestryRowsPerVTXO
+  = 64` and rejects duplicate `CommitmentTxID` entries. Called by
+  `VTXOPersistenceStore.InsertClientVTXO` and `FinalizeRound`.
+- `groupAncestryRows` (internal) — Aggregates a flat `[]sqlc.VtxoAncestryPath`
+  result into a `map[wire.OutPoint][]vtxo.Ancestry` for O(1) attachment during
+  batch VTXO list queries (eliminates the N+1 per-VTXO ancestry join).
+- `OORUnrollResolver` (via `oor_unroll_resolver.go`) — Resolves OOR package
+  bundles for unroll proof assembly. Now falls back to a session-ID lookup
+  (`loadPackageBundleBySessionID`) when the primary output-hash lookup returns
+  `sql.ErrNoRows`. This supports foreign-ancestor packages that the local wallet
+  has session-keyed visibility into (received from the server) but did not
+  create itself.
 
 ## Relationships
 
@@ -42,9 +72,27 @@ and client-side fee accounting. Supports SQLite and PostgreSQL backends.
 - Boarding intents persist from registration until round completion or failure.
 - Round checkpoints include commitment tx, VTXO tree, client sub-trees, boarding signatures, and every intent with updated status.
 - Default retry logic: 10 retries with exponential backoff (40ms initial, capped at 3s).
+- SQLite `busy_timeout` is set to 30 000 ms (30s) under WAL mode. The previous
+  5s cap was too short under aggressive regtest mining when multiple actors
+  (VTXO actors, unroll registry, txconfirm, ledger, receive scripts) all write
+  to the same DB concurrently; timeouts surfaced as spurious "mailbox full" /
+  "Failed to lease message" upstream errors. Transaction-begin failures during
+  context cancellation (e.g. daemon shutdown) are demoted to debug level to
+  avoid log-flooding at the tail of every integration test.
+- `ErrResolveUnrollMaxDepthExceeded` — Sentinel returned by the OOR unroll
+  resolver when package traversal exceeds the configured recursion limit.
 - **Never write raw SQL in Go** — add queries to `db/queries/`, regenerate with `make sqlc`.
 - Per-subsystem logging: uses instance logger instead of global package logger.
-- Latest migration: `000008_unilateral_exit_store` adds `unilateral_exit_jobs`, one row per target outpoint, holding the manager-facing control-plane view for the per-target unroll actor. `status` is an INTEGER column with documented values 0-6 (the `sweep_broadcasting` and `sweeping` values deliberately distinguish "sweep built, not yet submitted" from "sweep broadcast, awaiting confirmation"). `trigger` is 0-3 (`manual`, `critical_expiry`, `restart`, `fraud_spend`). `UnilateralExitJobStatusSweepBroadcasting` is appended at the end of the Go enum (iota value 6) so existing rows written at status=3 continue to decode as "sweep broadcast, awaiting conf" rather than silently shifting semantics; `UnilateralExitJobTriggerFraudSpend` round-trips through the Go `unroll.TriggerFraudSpend` constant rather than being silently downgraded to `TriggerManual`.
+- Latest migration: `000009_vtxo_ancestry_paths` adds the `vtxo_ancestry_paths`
+  side table: one row per `(vtxo_outpoint_hash, vtxo_outpoint_index,
+  commitment_txid)` triple, holding the serialized tree path blob, input
+  indices array, and tree depth for each ancestry fragment. The table uses
+  `AUTOINCREMENT` primary keys (→ `BIGSERIAL` on Postgres) to prevent rowid
+  reuse after deletions. Batch ancestry queries (`ListLiveVTXOAncestryPaths`,
+  `ListVTXOAncestryPathsByStatus`, `ListUnspentVTXOAncestryPaths`) let list
+  operations load all ancestry in one SQL call and group client-side instead of
+  issuing per-VTXO queries.
+- Prior migration: `000008_unilateral_exit_store` adds `unilateral_exit_jobs`, one row per target outpoint, holding the manager-facing control-plane view for the per-target unroll actor. `status` is an INTEGER column with documented values 0-6 (the `sweep_broadcasting` and `sweeping` values deliberately distinguish "sweep built, not yet submitted" from "sweep broadcast, awaiting confirmation"). `trigger` is 0-3 (`manual`, `critical_expiry`, `restart`, `fraud_spend`). `UnilateralExitJobStatusSweepBroadcasting` is appended at the end of the Go enum (iota value 6) so existing rows written at status=3 continue to decode as "sweep broadcast, awaiting conf" rather than silently shifting semantics; `UnilateralExitJobTriggerFraudSpend` round-trips through the Go `unroll.TriggerFraudSpend` constant rather than being silently downgraded to `TriggerManual`.
 - Prior migration: `000007_utxo_audit_log` adds an append-only UTXO audit log (`wallet_utxo_log`) with FK-constrained enum tables (`utxo_classifications`, `utxo_events`), indexes on block_height, outpoint, and classification, and a `UNIQUE(outpoint_hash, outpoint_index, event)` index that makes inserts idempotent under `RestartMessage` replay.
 - Migration `000006_fee_accounting` seeds the client chart of accounts — `wallet_balance`, `vtxo_balance` (assets); `fees_paid`, `onchain_fees`, `transfers_out` (expenses); `transfers_in` (revenue); `opening_balance` (equity, the source-of-funds counterparty for wallet UTXO deposits) — and `ledger_entries`. `ledger_entries` carries three optional scope columns — `round_id` (16-byte UUID), `session_id` (32-byte OOR identifier), and `idempotency_key` (outpoint-derived BLOB) — each paired with its own partial unique index (`idx_client_ledger_idempotent_round`, `_session`, `_key`) so every event class gets an at-least-once-idempotent path without colliding with the others. `InsertClientLedgerEntry` uses `ON CONFLICT DO NOTHING` so a redelivered durable-actor message resolves to a silent no-op across all three indexes. The `account_types` enum adds `equity` alongside `asset`, `liability`, `revenue`, `expense`. Ledger event types include `wallet_utxo_created` so the deposit leg written by `handleUTXOCreated` (debit `wallet_balance`, credit `opening_balance`) has a classification distinct from fee / transfer events.
 

--- a/lib/types/AGENTS.md
+++ b/lib/types/AGENTS.md
@@ -8,6 +8,15 @@ server during round participation. These types are used across `round`, `vtxo`,
 
 ## Key Types
 
+- `Ancestry` — One rooted commitment-tree fragment that contributes ancestry to
+  a VTXO. Round-direct VTXOs have exactly one entry; OOR VTXOs whose ancestry
+  spans multiple commitment txs (cross-round multi-input Ark spend) have one
+  entry per distinct commitment tx. Fields: `TreePath *tree.Tree`,
+  `CommitmentTxID chainhash.Hash`, `InputIndices []uint32` (Ark tx input indices
+  served by this fragment; empty for round-direct VTXOs), `TreeDepth uint32`
+  (worst-case unilateral-exit depth for this fragment). Lives in `lib/types` so
+  both `round.ClientVTXO` and `vtxo.Descriptor` can carry the same multi-fragment
+  ancestry without an import cycle.
 - `JoinRoundRequest` — Client's round registration request: boarding inputs, VTXO requests, forfeit requests, leave requests.
 - `JoinRoundAuth` — Authentication data for round join (Schnorr signature proof-of-control).
 - `VTXORequest` — Describes a new VTXO to create in a round (amount,
@@ -41,7 +50,7 @@ server during round participation. These types are used across `round`, `vtxo`,
 ## Relationships
 
 - **Depends on**: `lib/arkscript` (policy template decoding, `StandardVTXOParams`), `lib/tree` (tree types).
-- **Depended on by**: `round` (round protocol messages), `wallet` (boarding types), `db` (persistence), `rpc` (proto conversion).
+- **Depended on by**: `round` (round protocol messages, `ClientVTXO.Ancestry`), `vtxo` (re-exported as `vtxo.Ancestry` type alias), `wallet` (boarding types), `db` (persistence), `rpc` (proto conversion).
 
 ## Invariants
 

--- a/lib/types/CLAUDE.md
+++ b/lib/types/CLAUDE.md
@@ -8,6 +8,15 @@ server during round participation. These types are used across `round`, `vtxo`,
 
 ## Key Types
 
+- `Ancestry` — One rooted commitment-tree fragment that contributes ancestry to
+  a VTXO. Round-direct VTXOs have exactly one entry; OOR VTXOs whose ancestry
+  spans multiple commitment txs (cross-round multi-input Ark spend) have one
+  entry per distinct commitment tx. Fields: `TreePath *tree.Tree`,
+  `CommitmentTxID chainhash.Hash`, `InputIndices []uint32` (Ark tx input indices
+  served by this fragment; empty for round-direct VTXOs), `TreeDepth uint32`
+  (worst-case unilateral-exit depth for this fragment). Lives in `lib/types` so
+  both `round.ClientVTXO` and `vtxo.Descriptor` can carry the same multi-fragment
+  ancestry without an import cycle.
 - `JoinRoundRequest` — Client's round registration request: boarding inputs, VTXO requests, forfeit requests, leave requests.
 - `JoinRoundAuth` — Authentication data for round join (Schnorr signature proof-of-control).
 - `VTXORequest` — Describes a new VTXO to create in a round (amount,
@@ -41,7 +50,7 @@ server during round participation. These types are used across `round`, `vtxo`,
 ## Relationships
 
 - **Depends on**: `lib/arkscript` (policy template decoding, `StandardVTXOParams`), `lib/tree` (tree types).
-- **Depended on by**: `round` (round protocol messages), `wallet` (boarding types), `db` (persistence), `rpc` (proto conversion).
+- **Depended on by**: `round` (round protocol messages, `ClientVTXO.Ancestry`), `vtxo` (re-exported as `vtxo.Ancestry` type alias), `wallet` (boarding types), `db` (persistence), `rpc` (proto conversion).
 
 ## Invariants
 

--- a/oor/AGENTS.md
+++ b/oor/AGENTS.md
@@ -203,6 +203,18 @@ resume semantics.
   - ← API: `StartTransferRequest`, `DriveEventRequest`,
     `RestoreSessionRequest`, `ResumeSessionRequest`, `ListSessionsRequest`
 
+## Multi-Tree Ancestry + Lineage Cap
+
+- `IncomingVTXOMetadata.Ancestry []vtxo.Ancestry` replaces the singular
+  `TreePath` field. The TLV record on the durable mailbox is
+  `incomingMetadataMatchAncestryPathsRecordType`; per-entry layout is
+  `(TreePath, CommitmentTxID, InputIndices, TreeDepth)`.
+- Server-side rejection of an over-cap submit is surfaced as
+  `*oorpb.SubmitRejectedError{Code: OOR_REJECT_LINEAGE_TOO_LARGE}`
+  during response parsing. `oor.ClassifySubmitError(err)` maps that to
+  the typed `*oor.ErrLineageTooLarge` so wallet callers can route on
+  the cause without depending on the proto type.
+
 ## Invariants
 
 - Checkpoint output collab path is 2-of-2

--- a/round/AGENTS.md
+++ b/round/AGENTS.md
@@ -170,7 +170,12 @@ protocols with MuSig2 signing ceremonies.
   `ToVTXORequest()` converts to `types.VTXORequest`.
 - `ClientVTXO` — Full VTXO descriptor owned by the client. Adds
   `Origin types.VTXOOrigin`, `CommitmentTxID`, `BatchExpiry int32`,
-  and `CreatedHeight int32` on top of the basic VTXO fields.
+  `CreatedHeight int32`, and `Ancestry []types.Ancestry` on top of the basic
+  VTXO fields. `Ancestry` replaces the former singular `TreePath` field;
+  round-direct VTXOs get a single-entry slice stamped with the round's
+  commitment txid at `InputSigSent → Confirmed` transition time. The
+  `CommitmentTxID` on each ancestry entry is also filled at confirmation time
+  so the `db` ancestry side table can link rows to their commitment tx.
 - `BoardingIntent` — Embeds `wallet.BoardingIntent` plus a
   `Request types.BoardingRequest`.
 

--- a/round/CLAUDE.md
+++ b/round/CLAUDE.md
@@ -170,7 +170,12 @@ protocols with MuSig2 signing ceremonies.
   `ToVTXORequest()` converts to `types.VTXORequest`.
 - `ClientVTXO` — Full VTXO descriptor owned by the client. Adds
   `Origin types.VTXOOrigin`, `CommitmentTxID`, `BatchExpiry int32`,
-  and `CreatedHeight int32` on top of the basic VTXO fields.
+  `CreatedHeight int32`, and `Ancestry []types.Ancestry` on top of the basic
+  VTXO fields. `Ancestry` replaces the former singular `TreePath` field;
+  round-direct VTXOs get a single-entry slice stamped with the round's
+  commitment txid at `InputSigSent → Confirmed` transition time. The
+  `CommitmentTxID` on each ancestry entry is also filled at confirmation time
+  so the `db` ancestry side table can link rows to their commitment tx.
 - `BoardingIntent` — Embeds `wallet.BoardingIntent` plus a
   `Request types.BoardingRequest`.
 

--- a/rpc/oorpb/AGENTS.md
+++ b/rpc/oorpb/AGENTS.md
@@ -1,0 +1,75 @@
+# rpc/oorpb
+
+## Purpose
+
+Hand-written domain helpers for the OOR mailbox RPC package. Provides typed
+request/response builders and parsers for the OOR submit/finalize/ack wire
+protocol, layered on top of the generated proto stubs in this directory.
+
+## Key Types
+
+- `SigningDescriptor` — Minimal signing metadata for one checkpoint input.
+  Fields: `Outpoint wire.OutPoint`, `VTXOPolicyTemplate []byte`,
+  `SpendPath []byte`, `OwnerLeafPolicy []byte`. Converted to/from
+  `OORSigningDescriptor` proto by `encodeSigningDescriptor` /
+  `decodeSigningDescriptor`.
+- `SubmitRejectedError` — Typed error returned by `ParseSubmitPackageResponse`
+  when the operator rejected the submit. Fields: `Code OORRejectCode`,
+  `Reason string`. Callers can route on `Code` (e.g. fall back to in-round
+  payment for `OOR_REJECT_LINEAGE_TOO_LARGE`) without string-matching `Reason`.
+- `ServiceName = "oorpb.OORMailboxService"` — Mailbox RPC service name used
+  for submit/finalize request-response flows.
+- `MethodSubmitPackage` / `MethodFinalizePackage` / `MethodIncomingAck` —
+  Well-known mailbox method name constants.
+
+## Key Functions (payloads.go)
+
+- `NewSubmitPackageRequest` — Builds a `*SubmitPackageRequest` proto from
+  domain types: Ark PSBT, checkpoint PSBTs, signing descriptors, recipients.
+  Serializes PSBTs via `psbtutil.Serialize`.
+- `ParseSubmitPackageRequest` — Inverse of `NewSubmitPackageRequest`; decodes
+  the request back to domain types. Validates that every `OORSigningDescriptor`
+  and `OORRecipientOutput` is non-nil.
+- `NewSubmitPackageResponse` — Builds the success branch of
+  `*SubmitPackageResponse` (carries session id and co-signed checkpoint PSBTs).
+- `NewSubmitPackageRejection` — Builds the rejection branch of
+  `*SubmitPackageResponse` (carries `OORRejectCode`, human-readable reason, and
+  the session id echoed back so the client EventRouter can route the failure to
+  the correct OOR FSM).
+- `ParseSubmitPackageResponse` — Decodes the response oneof; returns
+  `(sessionID, coSignedCheckpoints, nil)` on success or
+  `(sessionID, nil, *SubmitRejectedError)` on rejection. The session id is
+  decoded best-effort even from rejection branches — a malformed session id
+  surfaces as a typed error with a zero hash rather than dropping the branch
+  entirely.
+- `NewFinalizePackageRequest` / `ParseFinalizePackageRequest` — Build/decode
+  finalize request (session id + final checkpoint PSBTs).
+- `NewFinalizePackageResponse` / `ParseFinalizePackageResponse` — Build/decode
+  finalize response (echoed session id).
+
+## Relationships
+
+- **Depends on**: `lib/tx/oor` (`RecipientOutput`), `lib/tx/psbtutil` (PSBT
+  serialization), `btcd/psbt`, `btcd/wire`.
+- **Depended on by**: `oor` (uses builders/parsers for submit/finalize outbox
+  events), `serverconn` (routes the mailbox methods), operator-side RPC
+  handlers (use `ParseSubmitPackageRequest` / `NewSubmitPackageResponse`).
+
+## Invariants
+
+- **Never edit generated code** — the `.pb.go` and `*_mailboxrpc.pb.go` files
+  in this directory are regenerated via `make rpc`. Only `payloads.go` and its
+  test are hand-written.
+- `SubmitRejectedError` carries `SessionId` echoed from the server rejection so
+  the durable `EventRouter` dispatch path can route the failure to the correct
+  OOR session FSM rather than stalling the ingress cursor on an undispatchable
+  envelope. A zero session hash (from a malformed rejection) is non-routable and
+  the FSM-side error path handles it gracefully.
+- `encodeOutPoint` / `decodeOutPoint` enforce `chainhash.HashSize` (32 bytes)
+  on all outpoint txids; short blobs are rejected with a descriptive error
+  rather than a bounds panic.
+
+## Deep Docs
+
+- [rpc/CLAUDE.md](../CLAUDE.md) — Parent rpc package overview.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/rpc/oorpb/CLAUDE.md
+++ b/rpc/oorpb/CLAUDE.md
@@ -1,0 +1,75 @@
+# rpc/oorpb
+
+## Purpose
+
+Hand-written domain helpers for the OOR mailbox RPC package. Provides typed
+request/response builders and parsers for the OOR submit/finalize/ack wire
+protocol, layered on top of the generated proto stubs in this directory.
+
+## Key Types
+
+- `SigningDescriptor` — Minimal signing metadata for one checkpoint input.
+  Fields: `Outpoint wire.OutPoint`, `VTXOPolicyTemplate []byte`,
+  `SpendPath []byte`, `OwnerLeafPolicy []byte`. Converted to/from
+  `OORSigningDescriptor` proto by `encodeSigningDescriptor` /
+  `decodeSigningDescriptor`.
+- `SubmitRejectedError` — Typed error returned by `ParseSubmitPackageResponse`
+  when the operator rejected the submit. Fields: `Code OORRejectCode`,
+  `Reason string`. Callers can route on `Code` (e.g. fall back to in-round
+  payment for `OOR_REJECT_LINEAGE_TOO_LARGE`) without string-matching `Reason`.
+- `ServiceName = "oorpb.OORMailboxService"` — Mailbox RPC service name used
+  for submit/finalize request-response flows.
+- `MethodSubmitPackage` / `MethodFinalizePackage` / `MethodIncomingAck` —
+  Well-known mailbox method name constants.
+
+## Key Functions (payloads.go)
+
+- `NewSubmitPackageRequest` — Builds a `*SubmitPackageRequest` proto from
+  domain types: Ark PSBT, checkpoint PSBTs, signing descriptors, recipients.
+  Serializes PSBTs via `psbtutil.Serialize`.
+- `ParseSubmitPackageRequest` — Inverse of `NewSubmitPackageRequest`; decodes
+  the request back to domain types. Validates that every `OORSigningDescriptor`
+  and `OORRecipientOutput` is non-nil.
+- `NewSubmitPackageResponse` — Builds the success branch of
+  `*SubmitPackageResponse` (carries session id and co-signed checkpoint PSBTs).
+- `NewSubmitPackageRejection` — Builds the rejection branch of
+  `*SubmitPackageResponse` (carries `OORRejectCode`, human-readable reason, and
+  the session id echoed back so the client EventRouter can route the failure to
+  the correct OOR FSM).
+- `ParseSubmitPackageResponse` — Decodes the response oneof; returns
+  `(sessionID, coSignedCheckpoints, nil)` on success or
+  `(sessionID, nil, *SubmitRejectedError)` on rejection. The session id is
+  decoded best-effort even from rejection branches — a malformed session id
+  surfaces as a typed error with a zero hash rather than dropping the branch
+  entirely.
+- `NewFinalizePackageRequest` / `ParseFinalizePackageRequest` — Build/decode
+  finalize request (session id + final checkpoint PSBTs).
+- `NewFinalizePackageResponse` / `ParseFinalizePackageResponse` — Build/decode
+  finalize response (echoed session id).
+
+## Relationships
+
+- **Depends on**: `lib/tx/oor` (`RecipientOutput`), `lib/tx/psbtutil` (PSBT
+  serialization), `btcd/psbt`, `btcd/wire`.
+- **Depended on by**: `oor` (uses builders/parsers for submit/finalize outbox
+  events), `serverconn` (routes the mailbox methods), operator-side RPC
+  handlers (use `ParseSubmitPackageRequest` / `NewSubmitPackageResponse`).
+
+## Invariants
+
+- **Never edit generated code** — the `.pb.go` and `*_mailboxrpc.pb.go` files
+  in this directory are regenerated via `make rpc`. Only `payloads.go` and its
+  test are hand-written.
+- `SubmitRejectedError` carries `SessionId` echoed from the server rejection so
+  the durable `EventRouter` dispatch path can route the failure to the correct
+  OOR session FSM rather than stalling the ingress cursor on an undispatchable
+  envelope. A zero session hash (from a malformed rejection) is non-routable and
+  the FSM-side error path handles it gracefully.
+- `encodeOutPoint` / `decodeOutPoint` enforce `chainhash.HashSize` (32 bytes)
+  on all outpoint txids; short blobs are rejected with a descriptive error
+  rather than a bounds panic.
+
+## Deep Docs
+
+- [rpc/CLAUDE.md](../CLAUDE.md) — Parent rpc package overview.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/txconfirm/AGENTS.md
+++ b/txconfirm/AGENTS.md
@@ -13,9 +13,14 @@ each still receives its own terminal notification.
 ## Key Types
 
 - `TxBroadcasterActor` — Message-driven orchestrator (in `actor.go`). Holds
-  a txid-keyed tracked-tx map, runs a protofsm lifecycle per txid, and
-  fans chainsource callbacks (confirmations, block epochs) back into
-  per-txid state transitions.
+  a txid-keyed tracked-tx map plus a `terminalNotifyInflight` set, runs a
+  protofsm lifecycle per txid, and fans chainsource callbacks (confirmations,
+  block epochs) back into per-txid state transitions.
+- `terminalNotifyResultMsg` — Internal message returned by background terminal
+  notification goroutines that timed out on the actor path. Carries `txid`,
+  `subscriberID`, `inflightKey`, and `err`; processed by
+  `handleTerminalNotifyResult` to remove the subscriber from the tracked entry
+  or retry on the next actor tick.
 - `CPFPBroadcaster` — Actor-free helper (in `broadcaster.go`) that handles
   broadcast mechanics: direct submission for txs without anchors, CPFP
   child construction for anchor parents, fee estimation, script-aware
@@ -74,6 +79,14 @@ each still receives its own terminal notification.
 
 ## Invariants
 
+- **Terminal notification retry**: when a terminal `TxConfirmed` / `TxFailed`
+  Tell to a subscriber blocks longer than `terminalNotifyTimeout` (1 second),
+  the actor does NOT block its mailbox. It launches a background goroutine that
+  completes the Tell and returns the result via `terminalNotifyResultMsg`. The
+  tracked entry is retained (without a conf watch) and retried on later actor
+  ticks until all subscribers are notified. The `terminalNotifyInflight` set
+  prevents duplicate background goroutines for the same `(txid, subscriberID)`
+  pair.
 - **Dedup check is strict**: two `EnsureConfirmedReq` for the same txid
   must agree on `TargetConfs` and `ConfirmationPkScript`; mismatches are
   rejected with `ErrEnsureParamsMismatch` rather than silently reusing the
@@ -117,14 +130,14 @@ each still receives its own terminal notification.
   txid+script keyed service-actor lookup resolves symmetrically; one
   conf sub-actor per tracked tx.
 - **Terminal eviction**: on Confirmed or Failed, the actor first delivers
-  terminal notifications. If a subscriber is slow or transiently fails,
-  the tracked entry is retained without a conf watch and retried on later
-  actor ticks. Once every subscriber has been notified or cancelled, the
-  actor stops the per-txid FSM goroutine, releases per-parent broadcaster
-  state (fee-bump history + reservations + wallet leases), and deletes the
-  tracked-tx entry. Late callers arriving after eviction re-register from
-  scratch and receive an immediate `TxConfirmed` via the normal path if the
-  tx is already on chain.
+  terminal notifications (with the 1s timeout budget). Slow or transiently
+  failing subscribers are retried on later actor ticks via the
+  `terminalNotifyInflight` / `terminalNotifyResultMsg` path. Once every
+  subscriber has been notified or cancelled, `evictTerminal` stops the per-txid
+  FSM goroutine, releases per-parent broadcaster state (fee-bump history +
+  reservations + wallet leases), and deletes the tracked-tx entry. Late callers
+  arriving after eviction re-register from scratch and receive an immediate
+  `TxConfirmed` via the normal path if the tx is already on chain.
 
 ## Deep Docs
 

--- a/txconfirm/CLAUDE.md
+++ b/txconfirm/CLAUDE.md
@@ -13,9 +13,14 @@ each still receives its own terminal notification.
 ## Key Types
 
 - `TxBroadcasterActor` — Message-driven orchestrator (in `actor.go`). Holds
-  a txid-keyed tracked-tx map, runs a protofsm lifecycle per txid, and
-  fans chainsource callbacks (confirmations, block epochs) back into
-  per-txid state transitions.
+  a txid-keyed tracked-tx map plus a `terminalNotifyInflight` set, runs a
+  protofsm lifecycle per txid, and fans chainsource callbacks (confirmations,
+  block epochs) back into per-txid state transitions.
+- `terminalNotifyResultMsg` — Internal message returned by background terminal
+  notification goroutines that timed out on the actor path. Carries `txid`,
+  `subscriberID`, `inflightKey`, and `err`; processed by
+  `handleTerminalNotifyResult` to remove the subscriber from the tracked entry
+  or retry on the next actor tick.
 - `CPFPBroadcaster` — Actor-free helper (in `broadcaster.go`) that handles
   broadcast mechanics: direct submission for txs without anchors, CPFP
   child construction for anchor parents, fee estimation, script-aware
@@ -74,6 +79,14 @@ each still receives its own terminal notification.
 
 ## Invariants
 
+- **Terminal notification retry**: when a terminal `TxConfirmed` / `TxFailed`
+  Tell to a subscriber blocks longer than `terminalNotifyTimeout` (1 second),
+  the actor does NOT block its mailbox. It launches a background goroutine that
+  completes the Tell and returns the result via `terminalNotifyResultMsg`. The
+  tracked entry is retained (without a conf watch) and retried on later actor
+  ticks until all subscribers are notified. The `terminalNotifyInflight` set
+  prevents duplicate background goroutines for the same `(txid, subscriberID)`
+  pair.
 - **Dedup check is strict**: two `EnsureConfirmedReq` for the same txid
   must agree on `TargetConfs` and `ConfirmationPkScript`; mismatches are
   rejected with `ErrEnsureParamsMismatch` rather than silently reusing the
@@ -117,14 +130,14 @@ each still receives its own terminal notification.
   txid+script keyed service-actor lookup resolves symmetrically; one
   conf sub-actor per tracked tx.
 - **Terminal eviction**: on Confirmed or Failed, the actor first delivers
-  terminal notifications. If a subscriber is slow or transiently fails,
-  the tracked entry is retained without a conf watch and retried on later
-  actor ticks. Once every subscriber has been notified or cancelled, the
-  actor stops the per-txid FSM goroutine, releases per-parent broadcaster
-  state (fee-bump history + reservations + wallet leases), and deletes the
-  tracked-tx entry. Late callers arriving after eviction re-register from
-  scratch and receive an immediate `TxConfirmed` via the normal path if the
-  tx is already on chain.
+  terminal notifications (with the 1s timeout budget). Slow or transiently
+  failing subscribers are retried on later actor ticks via the
+  `terminalNotifyInflight` / `terminalNotifyResultMsg` path. Once every
+  subscriber has been notified or cancelled, `evictTerminal` stops the per-txid
+  FSM goroutine, releases per-parent broadcaster state (fee-bump history +
+  reservations + wallet leases), and deletes the tracked-tx entry. Late callers
+  arriving after eviction re-register from scratch and receive an immediate
+  `TxConfirmed` via the normal path if the tx is already on chain.
 
 ## Deep Docs
 

--- a/unroll/AGENTS.md
+++ b/unroll/AGENTS.md
@@ -31,6 +31,12 @@ control-plane record per target to `db` so restart can restore in-flight jobs.
   `messages_test.go`.
 - `StartTrigger` — What caused the job to start: `TriggerManual`,
   `TriggerCriticalExpiry`, `TriggerRestart`, `TriggerFraudSpend`.
+- Message `Priority()` methods — `HeightObservedMsg`, `TxConfirmedMsg`,
+  `TxFailedMsg`, `SpendObservedMsg`, and `GetStateRequest` now implement the
+  optional `Priority() int` interface so the durable mailbox sorts
+  higher-priority messages before lower-priority ones when multiple are
+  pending. `GetStateRequest` gets the lowest priority; chain-observation
+  messages are ranked above it.
 - `Phase` — Coarse derived phase for control-plane visibility:
   `PhasePending` / `PhaseMaterializing` / `PhaseCSVPending` /
   `PhaseSweepBroadcast` / `PhaseSweepConfirmation` / `PhaseCompleted` /
@@ -42,7 +48,27 @@ control-plane record per target to `db` so restart can restore in-flight jobs.
 - `UnrollRegistryActor` — Thin coordinator over the set of
   `VTXOUnrollActor`s. Handles `EnsureUnrollRequest` / `GetStatusRequest`
   admission, receives `UnrollTerminatedMsg` from children, persists records,
-  and `RestoreNonTerminal` on boot.
+  and `RestoreNonTerminal` on boot. Admission now persists the control-plane
+  record synchronously before sending `StartUnrollRequest`, then attempts a
+  bounded `Ask` (`childAdmissionTimeout = 30s`) to confirm the child started.
+  Cancellation races (context deadline or child stopped) fall back to a
+  fire-and-forget `Tell` on `context.WithoutCancel` so the durable mailbox
+  retry loop picks up the start message. Real start errors mark the record
+  `PhaseFailed` immediately via `failAdmittedChild`.
+- `childAdmissionTimeout` — 30s bound on the synchronous Ask used to confirm a
+  newly-admitted child started. After this deadline the registry distinguishes
+  cancellation races from real errors via `isCancellationRace`.
+- `terminalChildDrainTimeout` — 30s bound on the cleanup probe used before
+  stopping a terminal child actor (`stopChildAfterDrain`).
+- `failAdmittedChild` — Helper that marks the durable record `PhaseFailed`,
+  stops and removes the child from `r.active`, so a real start error does not
+  leave a silent orphan job.
+- `isCancellationRace(err) bool` — Returns true when `err` is
+  `context.Canceled`, `context.DeadlineExceeded`, or wraps
+  `actor.ErrActorStopped`; used to distinguish retryable race conditions from
+  structural start errors.
+- `stopChildAfterDrain` — Sends a bounded drain probe to the child then calls
+  `Stop()`. Avoids blocking the registry goroutine if the child is stuck.
 - `RegistryConfig` — Store, `DeliveryStore`, `ProofAssembler`, `VTXOStore`,
   `TxConfirmRef`, `ChainSource`, `Wallet`, `MaxSweepFeeRateSatPerVByte`.
 - `RegistryRecord` — Control-plane row: `TargetOutpoint`, `ActorID`,
@@ -102,6 +128,16 @@ control-plane record per target to `db` so restart can restore in-flight jobs.
   - ← `chainsource` block epochs: re-wrapped as `HeightObservedMsg`.
   - ← `chainsource` spend notifications: re-wrapped as `SpendObservedMsg`.
 
+## Multi-Tree Ancestry
+
+- `LineageMaterial.TreePaths` was already plural — the multi-tree
+  refactor wires that infrastructure all the way through.
+  `descriptor_resolver.go` now iterates `desc.Ancestry` and appends
+  every fragment's `TreePath` so cross-commitment multi-input OOR
+  VTXOs surface every required commitment tree to the planner.
+- `proof_assembler.go`'s descriptor pre-condition is
+  `len(desc.Ancestry) == 0` (was `desc.TreePath == nil`).
+
 ## Invariants
 
 - **Persist-before-broadcast.** `startSweep` calls `persistCheckpoint`
@@ -133,6 +169,13 @@ control-plane record per target to `db` so restart can restore in-flight jobs.
   reboot, silently losing the job. Subsequent updates stay on the async
   `requestPersist` path so the registry goroutine is not held hostage by
   every state transition.
+- **Cancellation-race fallback.** When the bounded start Ask times out or the
+  child's context ends before the first message commits, `isCancellationRace`
+  distinguishes this expected race from a structural failure. The retry path
+  issues a fire-and-forget `Tell` on `context.WithoutCancel` so the durable
+  mailbox poll loop delivers `StartUnrollRequest` after the race resolves.
+  The caller still receives `Created=true` because the job IS admitted and the
+  durable record is already on disk.
 - **Durable mailbox messages are TLV, not JSON.** Every message in
   `messages.go` implements `actor.TLVMessage` with a hand-written
   `Encode`/`Decode` pair driven by `tlv.Stream`. Inner record types start at

--- a/unroll/CLAUDE.md
+++ b/unroll/CLAUDE.md
@@ -31,6 +31,12 @@ control-plane record per target to `db` so restart can restore in-flight jobs.
   `messages_test.go`.
 - `StartTrigger` — What caused the job to start: `TriggerManual`,
   `TriggerCriticalExpiry`, `TriggerRestart`, `TriggerFraudSpend`.
+- Message `Priority()` methods — `HeightObservedMsg`, `TxConfirmedMsg`,
+  `TxFailedMsg`, `SpendObservedMsg`, and `GetStateRequest` now implement the
+  optional `Priority() int` interface so the durable mailbox sorts
+  higher-priority messages before lower-priority ones when multiple are
+  pending. `GetStateRequest` gets the lowest priority; chain-observation
+  messages are ranked above it.
 - `Phase` — Coarse derived phase for control-plane visibility:
   `PhasePending` / `PhaseMaterializing` / `PhaseCSVPending` /
   `PhaseSweepBroadcast` / `PhaseSweepConfirmation` / `PhaseCompleted` /
@@ -42,7 +48,27 @@ control-plane record per target to `db` so restart can restore in-flight jobs.
 - `UnrollRegistryActor` — Thin coordinator over the set of
   `VTXOUnrollActor`s. Handles `EnsureUnrollRequest` / `GetStatusRequest`
   admission, receives `UnrollTerminatedMsg` from children, persists records,
-  and `RestoreNonTerminal` on boot.
+  and `RestoreNonTerminal` on boot. Admission now persists the control-plane
+  record synchronously before sending `StartUnrollRequest`, then attempts a
+  bounded `Ask` (`childAdmissionTimeout = 30s`) to confirm the child started.
+  Cancellation races (context deadline or child stopped) fall back to a
+  fire-and-forget `Tell` on `context.WithoutCancel` so the durable mailbox
+  retry loop picks up the start message. Real start errors mark the record
+  `PhaseFailed` immediately via `failAdmittedChild`.
+- `childAdmissionTimeout` — 30s bound on the synchronous Ask used to confirm a
+  newly-admitted child started. After this deadline the registry distinguishes
+  cancellation races from real errors via `isCancellationRace`.
+- `terminalChildDrainTimeout` — 30s bound on the cleanup probe used before
+  stopping a terminal child actor (`stopChildAfterDrain`).
+- `failAdmittedChild` — Helper that marks the durable record `PhaseFailed`,
+  stops and removes the child from `r.active`, so a real start error does not
+  leave a silent orphan job.
+- `isCancellationRace(err) bool` — Returns true when `err` is
+  `context.Canceled`, `context.DeadlineExceeded`, or wraps
+  `actor.ErrActorStopped`; used to distinguish retryable race conditions from
+  structural start errors.
+- `stopChildAfterDrain` — Sends a bounded drain probe to the child then calls
+  `Stop()`. Avoids blocking the registry goroutine if the child is stuck.
 - `RegistryConfig` — Store, `DeliveryStore`, `ProofAssembler`, `VTXOStore`,
   `TxConfirmRef`, `ChainSource`, `Wallet`, `MaxSweepFeeRateSatPerVByte`.
 - `RegistryRecord` — Control-plane row: `TargetOutpoint`, `ActorID`,
@@ -143,6 +169,13 @@ control-plane record per target to `db` so restart can restore in-flight jobs.
   reboot, silently losing the job. Subsequent updates stay on the async
   `requestPersist` path so the registry goroutine is not held hostage by
   every state transition.
+- **Cancellation-race fallback.** When the bounded start Ask times out or the
+  child's context ends before the first message commits, `isCancellationRace`
+  distinguishes this expected race from a structural failure. The retry path
+  issues a fire-and-forget `Tell` on `context.WithoutCancel` so the durable
+  mailbox poll loop delivers `StartUnrollRequest` after the race resolves.
+  The caller still receives `Created=true` because the job IS admitted and the
+  durable record is already on disk.
 - **Durable mailbox messages are TLV, not JSON.** Every message in
   `messages.go` implements `actor.TLVMessage` with a hand-written
   `Encode`/`Decode` pair driven by `tlv.Stream`. Inner record types start at

--- a/vtxo/AGENTS.md
+++ b/vtxo/AGENTS.md
@@ -14,7 +14,7 @@ when the local wallet owns the receive script.
 ## Key Types
 
 - `VTXOState` — Sealed interface for all states (Live, Spending, Spent, PendingForfeit, Forfeiting, Forfeited, UnilateralExit, Failed).
-- `Descriptor` — Complete VTXO metadata: `Outpoint`, `Amount`, `PkScript`, `OwnerKey` (keychain.KeyDescriptor), `OperatorKey`, `TapScript`, `TreePath`, `RoundID`, `CommitmentTxID`, `BatchExpiry`, `RelativeExpiry`, `TreeDepth`, `ChainDepth` (OOR hop count), `CreatedHeight`, `Status`.
+- `Descriptor` — Complete VTXO metadata: `Outpoint`, `Amount`, `PolicyTemplate`, `PkScript`, `ClientKey` (keychain.KeyDescriptor), `OperatorKey`, `TapScript`, `Ancestry []Ancestry` (multi-fragment commitment-tree ancestry; replaces the former singular `TreePath` field), `RoundID`, `CommitmentTxID`, `BatchExpiry`, `RelativeExpiry`, `ChainDepth` (OOR hop count), `CreatedHeight`, `Status`. Helper methods: `MaxTreeDepth()` returns `max(TreeDepth)` across ancestry entries for worst-case exit timing; `PrimaryAncestry()` returns a pointer to `Ancestry[0]` or nil.
 - `Manager` — Actor managing per-VTXO FSM instances, lifecycle, and admission gating. Configured via `ManagerConfig`.
 - `ManagerConfig` — Configuration holding Store, Wallet, ChainSource, ActorSystem, ExpiryConfig, RoundActor ref, ChainResolver ref, optional `Log`, and optional `LedgerSink fn.Option[ledger.Sink]`. The manager propagates the sink into each spawned `VTXOActor` so per-VTXO handlers can fire-and-forget `ExitCostMsg` emissions.
 - `VTXOActorConfig.LedgerSink` — Per-VTXO actor field plumbed from the manager. The `emitExitCost` helper is wired onto the unilateral-exit transition but is currently a no-op pending chain resolver integration: the actor cannot determine the on-chain miner fee until the chain resolver reports the confirmed exit-spend transaction. The emission site exists so a single future change in the chain resolver wiring enables it without touching the FSM transition logic.
@@ -47,6 +47,22 @@ when the local wallet owns the receive script.
   - ← `chainsource` (via Manager): `BlockEpochEvent`
   - ← `serverconn` (via `EventRouter` route `MethodIncomingVTXO`): `IncomingVTXOMsg` (wrapping `arkrpc.IncomingVTXOEvent`), routed to `IncomingVTXOHandler`
 
+## Multi-Tree Ancestry
+
+- `Descriptor.Ancestry []Ancestry` replaces the singular
+  `Descriptor.TreePath` field. Round-direct and same-commitment OOR
+  VTXOs carry a length-1 slice; cross-commitment multi-input OOR VTXOs
+  carry one entry per distinct contributing commitment tx.
+- Each `Ancestry` carries `TreePath`, `CommitmentTxID`, `InputIndices`
+  (Ark tx input indices the fragment serves), and `TreeDepth`.
+- `Descriptor.MaxTreeDepth()` returns `max(TreeDepth)` across the
+  ancestry slice for callers that need worst-case unilateral-exit
+  timing (e.g. `expiry.go`).
+- The DB persistence layer stores ancestry rows in the
+  `vtxo_ancestry_paths` side table (migration 000009) keyed by VTXO
+  outpoint; routine queries (`ListUnspentVTXOs`, `GetVTXO`) skip the
+  ancestry join and only load it when the unroller resolves an exit.
+
 ## Invariants
 
 - VTXO actor state is the single source of truth for availability.
@@ -61,7 +77,10 @@ when the local wallet owns the receive script.
 - Admission types (`SelectAndReserveSpendRequest`, `SelectAndReserveForfeitRequest`, `ReserveForfeitRequest`, etc.) are defined in `lib/actormsg` and re-exported as type aliases to avoid wallet → vtxo → round → wallet import cycles.
 - `selectAndReserveVTXOs` is a shared helper parameterized by `reserveParams` that serves both the OOR spend and cooperative forfeit coin selection paths, avoiding code duplication.
 - `IncomingVTXOHandler` only handles `VTXO_EVENT_TYPE_CREATED` events. Other event kinds, missing/short outpoints, empty pkScripts, oversized values (`> int64` or `> MaxSatoshi`), and tapscript derivation failures all return success without persisting — they cannot crash the actor or block the indexer push stream. Real DB lookup/save errors are surfaced.
-- Incoming VTXOs are saved with `Status: VTXOStatusLive` and no `TreePath` (the round commitment tree is not pushed alongside the event); `db.VTXOPersistenceStore.descriptorToInsertParams` accepts an empty tree-path blob to support this.
+- Incoming VTXOs are saved with `Status: VTXOStatusLive` and an empty
+  `Ancestry` slice (the round commitment tree is not pushed alongside the event);
+  `db.VTXOPersistenceStore` persists an empty ancestry side-table for these
+  rows without error.
 - The `CommitmentTxID` on a materialized incoming VTXO comes from `IncomingVTXOEvent.CommitmentTxid`, which is the round commitment txid — **not** the leaf txid in the outpoint.
 - Per-subsystem logging: `ManagerConfig.Log` provides an optional instance logger; falls back to `build.LoggerFromContext` (no global mutable loggers).
 

--- a/vtxo/CLAUDE.md
+++ b/vtxo/CLAUDE.md
@@ -14,7 +14,7 @@ when the local wallet owns the receive script.
 ## Key Types
 
 - `VTXOState` — Sealed interface for all states (Live, Spending, Spent, PendingForfeit, Forfeiting, Forfeited, UnilateralExit, Failed).
-- `Descriptor` — Complete VTXO metadata: `Outpoint`, `Amount`, `PkScript`, `OwnerKey` (keychain.KeyDescriptor), `OperatorKey`, `TapScript`, `TreePath`, `RoundID`, `CommitmentTxID`, `BatchExpiry`, `RelativeExpiry`, `TreeDepth`, `ChainDepth` (OOR hop count), `CreatedHeight`, `Status`.
+- `Descriptor` — Complete VTXO metadata: `Outpoint`, `Amount`, `PolicyTemplate`, `PkScript`, `ClientKey` (keychain.KeyDescriptor), `OperatorKey`, `TapScript`, `Ancestry []Ancestry` (multi-fragment commitment-tree ancestry; replaces the former singular `TreePath` field), `RoundID`, `CommitmentTxID`, `BatchExpiry`, `RelativeExpiry`, `ChainDepth` (OOR hop count), `CreatedHeight`, `Status`. Helper methods: `MaxTreeDepth()` returns `max(TreeDepth)` across ancestry entries for worst-case exit timing; `PrimaryAncestry()` returns a pointer to `Ancestry[0]` or nil.
 - `Manager` — Actor managing per-VTXO FSM instances, lifecycle, and admission gating. Configured via `ManagerConfig`.
 - `ManagerConfig` — Configuration holding Store, Wallet, ChainSource, ActorSystem, ExpiryConfig, RoundActor ref, ChainResolver ref, optional `Log`, and optional `LedgerSink fn.Option[ledger.Sink]`. The manager propagates the sink into each spawned `VTXOActor` so per-VTXO handlers can fire-and-forget `ExitCostMsg` emissions.
 - `VTXOActorConfig.LedgerSink` — Per-VTXO actor field plumbed from the manager. The `emitExitCost` helper is wired onto the unilateral-exit transition but is currently a no-op pending chain resolver integration: the actor cannot determine the on-chain miner fee until the chain resolver reports the confirmed exit-spend transaction. The emission site exists so a single future change in the chain resolver wiring enables it without touching the FSM transition logic.
@@ -77,7 +77,10 @@ when the local wallet owns the receive script.
 - Admission types (`SelectAndReserveSpendRequest`, `SelectAndReserveForfeitRequest`, `ReserveForfeitRequest`, etc.) are defined in `lib/actormsg` and re-exported as type aliases to avoid wallet → vtxo → round → wallet import cycles.
 - `selectAndReserveVTXOs` is a shared helper parameterized by `reserveParams` that serves both the OOR spend and cooperative forfeit coin selection paths, avoiding code duplication.
 - `IncomingVTXOHandler` only handles `VTXO_EVENT_TYPE_CREATED` events. Other event kinds, missing/short outpoints, empty pkScripts, oversized values (`> int64` or `> MaxSatoshi`), and tapscript derivation failures all return success without persisting — they cannot crash the actor or block the indexer push stream. Real DB lookup/save errors are surfaced.
-- Incoming VTXOs are saved with `Status: VTXOStatusLive` and no `TreePath` (the round commitment tree is not pushed alongside the event); `db.VTXOPersistenceStore.descriptorToInsertParams` accepts an empty tree-path blob to support this.
+- Incoming VTXOs are saved with `Status: VTXOStatusLive` and an empty
+  `Ancestry` slice (the round commitment tree is not pushed alongside the event);
+  `db.VTXOPersistenceStore` persists an empty ancestry side-table for these
+  rows without error.
 - The `CommitmentTxID` on a materialized incoming VTXO comes from `IncomingVTXOEvent.CommitmentTxid`, which is the round commitment txid — **not** the leaf txid in the outpoint.
 - Per-subsystem logging: `ManagerConfig.Log` provides an optional instance logger; falls back to `build.LoggerFromContext` (no global mutable loggers).
 


### PR DESCRIPTION
Automated nightly documentation sweep covering 30 commits since last sweep (baseline e41dac0). Updates: lib/types (new Ancestry type), arkrpc (AncestryPath helpers), db (error classification, migration 000009, SQLite timeout), vtxo (Descriptor.Ancestry replaces TreePath), round (ClientVTXO.Ancestry), txconfirm (terminal notification retry), unroll (admission timeout, cancellation-race fallback), oor (sync Multi-Tree Ancestry section to AGENTS.md), rpc/oorpb (new CLAUDE.md/AGENTS.md). Please review updated per-package docs diffs before merging.