### PR TITLE
client: fan out board targets

### DIFF
--- a/cmd/darepocli/darepoclicommands/cmd_board.go
+++ b/cmd/darepocli/darepoclicommands/cmd_board.go
@@ -13,13 +13,19 @@ import (
 func newBoardCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "board",
-		Short: "Board confirmed UTXOs into a VTXO",
+		Short: "Board confirmed UTXOs into VTXOs",
 		Long: "Triggers the client to join the next " +
 			"round with any confirmed boarding UTXOs. " +
-			"The resulting VTXO replaces the on-chain " +
-			"boarding balance.",
+			"The resulting VTXO set replaces the on-chain " +
+			"boarding balance. By default the whole balance " +
+			"is boarded into one VTXO.",
 		RunE: board,
 	}
+
+	cmd.Flags().Uint32(
+		"target-vtxo-count", 0,
+		"number of VTXOs to fan the boarded balance into",
+	)
 
 	return cmd
 }
@@ -33,7 +39,12 @@ func board(cmd *cobra.Command, _ []string) error {
 	defer conn.Close()
 
 	req := &daemonrpc.BoardRequest{}
-	if err := parseRequest(cmd, req, nil); err != nil {
+	if err := parseRequest(cmd, req, func() error {
+		count, _ := cmd.Flags().GetUint32("target-vtxo-count")
+		req.TargetVtxoCount = count
+
+		return nil
+	}); err != nil {
 		return err
 	}
 

--- a/daemonrpc/daemon.pb.go
+++ b/daemonrpc/daemon.pb.go
@@ -2700,9 +2700,13 @@ func (x *LeaveVTXOsResponse) GetStatus() string {
 }
 
 type BoardRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// target_vtxo_count asks the daemon to fan the confirmed boarding
+	// balance out into this many VTXO outputs in the next round. Zero
+	// preserves the legacy behavior of creating one boarded VTXO.
+	TargetVtxoCount uint32 `protobuf:"varint,1,opt,name=target_vtxo_count,json=targetVtxoCount,proto3" json:"target_vtxo_count,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *BoardRequest) Reset() {
@@ -2735,11 +2739,21 @@ func (*BoardRequest) Descriptor() ([]byte, []int) {
 	return file_daemon_proto_rawDescGZIP(), []int{34}
 }
 
+func (x *BoardRequest) GetTargetVtxoCount() uint32 {
+	if x != nil {
+		return x.TargetVtxoCount
+	}
+	return 0
+}
+
 type BoardResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// status is "registered" on success, "no_boarding_utxos" if
 	// nothing to board.
-	Status        string `protobuf:"bytes,1,opt,name=status,proto3" json:"status,omitempty"`
+	Status string `protobuf:"bytes,1,opt,name=status,proto3" json:"status,omitempty"`
+	// vtxo_count is the number of VTXO target outputs accepted for
+	// boarding. It is zero when status is "no_boarding_utxos".
+	VtxoCount     uint32 `protobuf:"varint,2,opt,name=vtxo_count,json=vtxoCount,proto3" json:"vtxo_count,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2779,6 +2793,13 @@ func (x *BoardResponse) GetStatus() string {
 		return x.Status
 	}
 	return ""
+}
+
+func (x *BoardResponse) GetVtxoCount() uint32 {
+	if x != nil {
+		return x.VtxoCount
+	}
+	return 0
 }
 
 // RoundVTXOInfo describes a VTXO created in a round.
@@ -3946,10 +3967,13 @@ const file_daemon_proto_rawDesc = "" +
 	"\tselection\"W\n" +
 	"\x12LeaveVTXOsResponse\x12)\n" +
 	"\x10queued_outpoints\x18\x01 \x03(\tR\x0fqueuedOutpoints\x12\x16\n" +
-	"\x06status\x18\x02 \x01(\tR\x06status\"\x0e\n" +
-	"\fBoardRequest\"'\n" +
+	"\x06status\x18\x02 \x01(\tR\x06status\":\n" +
+	"\fBoardRequest\x12*\n" +
+	"\x11target_vtxo_count\x18\x01 \x01(\rR\x0ftargetVtxoCount\"F\n" +
 	"\rBoardResponse\x12\x16\n" +
-	"\x06status\x18\x01 \x01(\tR\x06status\"J\n" +
+	"\x06status\x18\x01 \x01(\tR\x06status\x12\x1d\n" +
+	"\n" +
+	"vtxo_count\x18\x02 \x01(\rR\tvtxoCount\"J\n" +
 	"\rRoundVTXOInfo\x12\x1a\n" +
 	"\boutpoint\x18\x01 \x01(\tR\boutpoint\x12\x1d\n" +
 	"\n" +

--- a/daemonrpc/daemon.proto
+++ b/daemonrpc/daemon.proto
@@ -652,12 +652,20 @@ message LeaveVTXOsResponse {
 }
 
 message BoardRequest {
+    // target_vtxo_count asks the daemon to fan the confirmed boarding
+    // balance out into this many VTXO outputs in the next round. Zero
+    // preserves the legacy behavior of creating one boarded VTXO.
+    uint32 target_vtxo_count = 1;
 }
 
 message BoardResponse {
     // status is "registered" on success, "no_boarding_utxos" if
     // nothing to board.
     string status = 1;
+
+    // vtxo_count is the number of VTXO target outputs accepted for
+    // boarding. It is zero when status is "no_boarding_utxos".
+    uint32 vtxo_count = 2;
 }
 
 // RoundState represents the lifecycle state of a client's round FSM.

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -1183,8 +1183,12 @@ func (r *RPCServer) LeaveVTXOs(ctx context.Context,
 // returns immediately after the wallet accepts the request; use
 // ListRounds/WatchRounds to observe round progress.
 func (r *RPCServer) Board(ctx context.Context,
-	_ *daemonrpc.BoardRequest) (
+	req *daemonrpc.BoardRequest) (
 	*daemonrpc.BoardResponse, error) {
+
+	if req == nil {
+		req = &daemonrpc.BoardRequest{}
+	}
 
 	if err := r.requireWalletReady(); err != nil {
 		return nil, err
@@ -1216,7 +1220,9 @@ func (r *RPCServer) Board(ctx context.Context,
 	// EstimateFee RPC, not by the Board admission path.
 	_ = terms
 
-	boardReq := &wallet.BoardRequest{}
+	boardReq := &wallet.BoardRequest{
+		TargetVTXOCount: req.GetTargetVtxoCount(),
+	}
 
 	future := wRef.Ask(ctx, boardReq)
 	result := future.Await(ctx)
@@ -1258,10 +1264,12 @@ func (r *RPCServer) Board(ctx context.Context,
 		btclog.Fmt("boarding_balance", "%v",
 			boardResp.BoardingBalance),
 		btclog.Fmt("vtxo_amount", "%v",
-			boardResp.VTXOAmount))
+			boardResp.VTXOAmount),
+		slog.Int("vtxo_count", len(boardResp.VTXOAmounts)))
 
 	return &daemonrpc.BoardResponse{
-		Status: "registered",
+		Status:    "registered",
+		VtxoCount: uint32(len(boardResp.VTXOAmounts)),
 	}, nil
 }
 

--- a/round/actor_test.go
+++ b/round/actor_test.go
@@ -1908,6 +1908,70 @@ func TestHandleTriggerBoard(t *testing.T) {
 	)
 }
 
+// TestHandleTriggerBoardMultipleVTXOs verifies board fanout registers one VTXO
+// request per requested target amount.
+func TestHandleTriggerBoardMultipleVTXOs(t *testing.T) {
+	t.Parallel()
+
+	h := newActorTestHarness(t)
+	h.setupMockRoundStoreForStart()
+
+	err := h.start()
+	require.NoError(t, err)
+
+	intent := h.newTestBoardingIntent()
+	h.walletActor.setConfirmedIntents(*intent)
+
+	for i := 0; i < 3; i++ {
+		h.wallet.On(
+			"DeriveNextKey", mock.Anything,
+			types.VTXOOwnerKeyFamily,
+		).Return(&keychain.KeyDescriptor{
+			PubKey: h.clientPubKey,
+			KeyLocator: keychain.KeyLocator{
+				Family: types.VTXOOwnerKeyFamily,
+				Index:  uint32(i),
+			},
+		}, nil).Once()
+		h.wallet.On(
+			"DeriveNextKey", mock.Anything,
+			keychain.KeyFamilyMultiSig,
+		).Return(&keychain.KeyDescriptor{
+			PubKey: h.clientPubKey,
+			KeyLocator: keychain.KeyLocator{
+				Family: keychain.KeyFamilyMultiSig,
+				Index:  uint32(i),
+			},
+		}, nil).Once()
+	}
+
+	result := h.receive(&actormsg.TriggerBoardMsg{
+		Amounts: []btcutil.Amount{17_000, 17_000, 16_000},
+	})
+	require.True(t, result.IsOk(), "expected Ok, got: %v",
+		result.Err())
+
+	states := h.queryState()
+	tempState, exists := h.findTempState(states)
+	require.True(t, exists, "expected temp-keyed FSM state")
+
+	regState, ok := tempState.State.(*IntentSentState)
+	require.True(t, ok, "expected IntentSentState, got %T",
+		tempState.State)
+	require.Len(t, regState.Intents.Boarding, 1)
+	require.Len(t, regState.Intents.VTXOs, 3)
+
+	require.Equal(
+		t, btcutil.Amount(17_000), regState.Intents.VTXOs[0].Amount,
+	)
+	require.Equal(
+		t, btcutil.Amount(17_000), regState.Intents.VTXOs[1].Amount,
+	)
+	require.Equal(
+		t, btcutil.Amount(16_000), regState.Intents.VTXOs[2].Amount,
+	)
+}
+
 // TestHandleForfeitCollectionTimeout verifies timeout-message handling for
 // rounds waiting on forfeit signatures.
 func TestHandleForfeitCollectionTimeout(t *testing.T) {

--- a/sdk/ark/client.go
+++ b/sdk/ark/client.go
@@ -780,11 +780,16 @@ func (c *Client) RefreshVTXOs(ctx context.Context,
 }
 
 // Board tells the daemon to register any confirmed boarding UTXOs in the next
-// round.
-func (c *Client) Board(ctx context.Context) (
-	*daemonrpc.BoardResponse, error) {
+// round. Passing no request preserves the legacy single-VTXO board behavior.
+func (c *Client) Board(ctx context.Context,
+	reqs ...*daemonrpc.BoardRequest) (*daemonrpc.BoardResponse, error) {
 
-	resp, err := c.daemon.Board(ctx, &daemonrpc.BoardRequest{})
+	req := &daemonrpc.BoardRequest{}
+	if len(reqs) > 0 && reqs[0] != nil {
+		req = reqs[0]
+	}
+
+	resp, err := c.daemon.Board(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("board confirmed utxos: %w", err)
 	}

--- a/wallet/messages.go
+++ b/wallet/messages.go
@@ -504,11 +504,15 @@ func (m *LeaveVTXOsRequest) walletMsgSealed() {}
 // BoardRequest triggers the wallet to board all confirmed boarding UTXOs
 // into the next round. Under the #270 seal-time fee handshake the server
 // decides the operator fee when the round seals; the wallet ships the full
-// confirmed boarding balance as the VTXO intent target and the server
-// stamps the residual at seal time. This is a non-blocking operation; use
+// confirmed boarding balance as VTXO intent targets and the server stamps
+// the residual at seal time. This is a non-blocking operation; use
 // ListRounds/WatchRounds to observe round progress.
 type BoardRequest struct {
 	actor.BaseMessage
+
+	// TargetVTXOCount is the requested number of boarded VTXOs. Zero means
+	// one output, preserving the legacy single-VTXO board behavior.
+	TargetVTXOCount uint32
 }
 
 // MessageType returns the message type identifier for logging and debugging.
@@ -529,8 +533,13 @@ type BoardResponse struct {
 	BoardingBalance btcutil.Amount
 
 	// VTXOAmount is the VTXO output amount that was registered for the
-	// next round (boarding balance minus operator fee).
+	// next round. When multiple VTXOs are requested, this is the total of
+	// VTXOAmounts and is kept for existing internal callers.
 	VTXOAmount btcutil.Amount
+
+	// VTXOAmounts are the per-output target amounts registered for the
+	// next round before seal-time operator fees are stamped.
+	VTXOAmounts []btcutil.Amount
 }
 
 // MessageType returns the message type identifier for logging and debugging.

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -1152,7 +1152,7 @@ func (a *Ark) handleLeaveVTXOs(ctx context.Context,
 }
 
 // handleBoard processes a boarding request by checking the confirmed balance,
-// computing the VTXO output amount after operator fees, and forwarding a
+// computing the requested VTXO output target amounts, and forwarding a
 // TriggerBoardMsg to the round actor. The round actor handles the actual
 // registration and FSM transitions asynchronously.
 func (a *Ark) handleBoard(ctx context.Context,
@@ -1181,20 +1181,26 @@ func (a *Ark) handleBoard(ctx context.Context,
 	// Under the #270 seal-time fee handshake the server decides
 	// the operator fee when the round seals, not at submit time.
 	// The wallet therefore ships the full confirmed balance as
-	// the VTXO intent target; the boarding output is the sole
-	// output of the single-output intent, so the proto's
-	// single-output change-marker exception applies and the
-	// server stamps `totalBalance − fee` at seal time. We skip
+	// one or more VTXO intent targets. For multi-output boarding,
+	// the common change-marker logic marks one output as the
+	// residual output the server can stamp at seal time. We skip
 	// the pre-#270 `vtxoAmount <= DustLimit` gate because it was
 	// driven by an advisory submit-time fee estimate and would
 	// spuriously reject boards that the seal-time quote would
 	// have accepted.
-	vtxoAmount := totalBalance
+	vtxoAmounts, err := splitBoardingAmount(
+		totalBalance, req.TargetVTXOCount,
+	)
+	if err != nil {
+		return fn.Err[WalletResp](err)
+	}
+	vtxoAmount := sumBoardingAmounts(vtxoAmounts)
 
 	a.logger(ctx).InfoS(ctx, "Boarding request accepted",
 		slog.Int64("boarding_balance",
 			int64(totalBalance)),
-		slog.Int64("vtxo_amount", int64(vtxoAmount)))
+		slog.Int64("vtxo_amount", int64(vtxoAmount)),
+		slog.Int("vtxo_count", len(vtxoAmounts)))
 
 	// Forward to round actor via service key lookup. The round actor
 	// registers the VTXO output requests and triggers the round join.
@@ -1209,7 +1215,7 @@ func (a *Ark) handleBoard(ctx context.Context,
 
 	if err := roundRef.Tell(
 		ctx, &actormsg.TriggerBoardMsg{
-			Amounts: []btcutil.Amount{vtxoAmount},
+			Amounts: vtxoAmounts,
 		},
 	); err != nil {
 		return fn.Err[WalletResp](fmt.Errorf(
@@ -1220,9 +1226,54 @@ func (a *Ark) handleBoard(ctx context.Context,
 	resp := &BoardResponse{
 		BoardingBalance: totalBalance,
 		VTXOAmount:      vtxoAmount,
+		VTXOAmounts:     vtxoAmounts,
 	}
 
 	return fn.Ok[WalletResp](resp)
+}
+
+// splitBoardingAmount fans a confirmed boarding balance into count VTXO
+// target amounts. A zero count preserves the legacy single-output behavior.
+func splitBoardingAmount(total btcutil.Amount,
+	count uint32) ([]btcutil.Amount, error) {
+
+	if count == 0 {
+		count = 1
+	}
+	if total <= 0 {
+		return nil, fmt.Errorf("boarding balance must be positive")
+	}
+
+	base := int64(total) / int64(count)
+	remainder := int64(total) % int64(count)
+	if base <= 0 {
+		return nil, fmt.Errorf(
+			"boarding balance %v too small for %d VTXOs",
+			total, count,
+		)
+	}
+
+	amounts := make([]btcutil.Amount, count)
+	for i := range amounts {
+		amount := base
+		if int64(i) < remainder {
+			amount++
+		}
+
+		amounts[i] = btcutil.Amount(amount)
+	}
+
+	return amounts, nil
+}
+
+// sumBoardingAmounts returns the total of boarding target amounts.
+func sumBoardingAmounts(amounts []btcutil.Amount) btcutil.Amount {
+	var total btcutil.Amount
+	for _, amount := range amounts {
+		total += amount
+	}
+
+	return total
 }
 
 // buildBoardingTxProof fetches the confirmation block and computes a merkle

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -1207,6 +1207,64 @@ func TestGetConfirmedBoardingIntents(t *testing.T) {
 	store.AssertExpectations(t)
 }
 
+// TestSplitBoardingAmount verifies board fanout preserves total balance while
+// producing stable per-output target amounts.
+func TestSplitBoardingAmount(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		total     btcutil.Amount
+		count     uint32
+		want      []btcutil.Amount
+		wantError string
+	}{
+		{
+			name:  "zero count defaults to one output",
+			total: 10_000,
+			count: 0,
+			want:  []btcutil.Amount{10_000},
+		},
+		{
+			name:  "even split",
+			total: 12_000,
+			count: 3,
+			want:  []btcutil.Amount{4_000, 4_000, 4_000},
+		},
+		{
+			name:  "remainder is spread across leading outputs",
+			total: 10_001,
+			count: 3,
+			want:  []btcutil.Amount{3_334, 3_334, 3_333},
+		},
+		{
+			name:      "count cannot exceed sats",
+			total:     2,
+			count:     3,
+			wantError: "too small",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := splitBoardingAmount(
+				test.total, test.count,
+			)
+			if test.wantError != "" {
+				require.ErrorContains(t, err, test.wantError)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, test.want, got)
+			require.Equal(t, test.total, sumBoardingAmounts(got))
+		})
+	}
+}
+
 // TestSendBacklog tests the sendBacklog method which delivers historical
 // confirmation events to newly registered notifiers.
 func TestSendBacklog(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds a `target_vtxo_count` field to the daemon `BoardRequest` so callers can
fan confirmed boarding balance out into multiple VTXO targets in the next
round.

The default remains unchanged: a zero count boards into one VTXO. When a count
is provided, the wallet splits the confirmed boarding balance into stable target
amounts, forwards them through the existing `TriggerBoardMsg.Amounts` path, and
returns the accepted VTXO count in `BoardResponse`.

This exposes the board-time VTXO fanout that high-concurrency callers need to
create multiple spend lanes up front, instead of relying on later payment
queueing or refresh behavior.

Used by lightninglabs/darepo#307.

## Validation

- `make -C client rpc`
- `go test ./wallet ./round ./darepod ./sdk/ark ./cmd/darepocli/darepoclicommands`
- `go test ./round`
- `GOGC=50 make lint`
- `make -C client commitmsg-lint commit=HEAD`
