### PR TITLE
actor: fix restart recovery writes

### DIFF
--- a/baselib/actor/actor.go
+++ b/baselib/actor/actor.go
@@ -324,14 +324,21 @@ func (ref *actorRefImpl[M, R]) Tell(ctx context.Context, msg M) error {
 		"actor_id", ref.actor.id,
 		"msg_type", msg.MessageType())
 
+	// Tell is fire-and-forget. If the caller is a durable actor currently
+	// processing inside a database transaction, do not retain that transaction
+	// in the queued envelope. The receiving actor cannot make async Tell
+	// processing atomic with the caller's transaction, and the transaction may
+	// already be committed or rolled back by the time the message is handled.
+	sendCtx := WithoutTx(ctx)
+
 	// Attempt to send the message to the mailbox. The mailbox's Send
 	// method handles context cancellation and actor termination internally.
 	env := envelope[M, R]{
 		message:   msg,
 		promise:   nil,
-		callerCtx: ctx,
+		callerCtx: sendCtx,
 	}
-	ok := ref.actor.mailbox.Send(ctx, env)
+	ok := ref.actor.mailbox.Send(sendCtx, env)
 
 	// If the send failed, determine the error and whether to route to DLO.
 	if !ok {

--- a/baselib/actor/caller_context_test.go
+++ b/baselib/actor/caller_context_test.go
@@ -252,3 +252,43 @@ func TestTellIgnoresCallerContextAfterEnqueue(t *testing.T) {
 		t.Fatal("Tell message was not processed despite being enqueued")
 	}
 }
+
+// TestTellStripsCallerTransactionBeforeEnqueue verifies that Tell does not
+// retain a durable actor's active transaction in the queued envelope. Tell
+// processing is asynchronous, so the caller's transaction may be committed or
+// rolled back before the receiving actor handles the message.
+func TestTellStripsCallerTransactionBeforeEnqueue(t *testing.T) {
+	t.Parallel()
+
+	behavior := NewFunctionBehavior(
+		func(ctx context.Context, msg *testMsg) fn.Result[string] {
+			return fn.Ok("done")
+		},
+	)
+
+	actor := NewActor(ActorConfig[*testMsg, string]{
+		ID:          "tell-strip-tx",
+		Behavior:    behavior,
+		MailboxSize: 1,
+	})
+
+	txCtx := WithTx(context.Background(), (*sql.Tx)(nil))
+	require.True(t, HasTx(txCtx))
+
+	err := actor.Ref().Tell(txCtx, newTestMsg("fire-and-forget"))
+	require.NoError(t, err)
+
+	receiveCtx, cancel := context.WithTimeout(
+		context.Background(), time.Second,
+	)
+	defer cancel()
+
+	for env := range actor.mailbox.Receive(receiveCtx) {
+		require.False(t, HasTx(env.callerCtx))
+		require.NoError(t, env.callerCtx.Err())
+
+		return
+	}
+
+	t.Fatal("timed out waiting for enqueued Tell envelope")
+}

--- a/baselib/actor/durable_actor.go
+++ b/baselib/actor/durable_actor.go
@@ -327,11 +327,17 @@ func (a *DurableActor[M, R]) process() {
 // transaction wrapping, panic recovery, lease heartbeating, and automatic
 // ack/nack based on result.
 func (a *DurableActor[M, R]) processDelivery(delivery *Delivery[M, R]) {
-	// Create a context that merges actor and caller contexts.
+	// Create a context for processing. Ask/DurableAsk messages merge the
+	// actor and caller contexts so request deadlines can still interrupt
+	// synchronous work. Tell messages use only the actor context, matching
+	// non-durable actor semantics: once a fire-and-forget message is
+	// durably enqueued, later caller cancellation must not cancel processing.
 	var processCtx context.Context
 	var cancel context.CancelFunc
 
-	if delivery.CallerCtx != nil {
+	if delivery.CallerCtx != nil &&
+		(delivery.IsAsk() || delivery.IsDurableAsk()) {
+
 		processCtx, cancel = mergeContexts(a.ctx, delivery.CallerCtx)
 	} else {
 		processCtx = a.ctx

--- a/baselib/actor/durable_actor_test.go
+++ b/baselib/actor/durable_actor_test.go
@@ -306,6 +306,106 @@ func TestDurableActorTellProcessing(t *testing.T) {
 	}, 500*time.Millisecond, 10*time.Millisecond)
 }
 
+// TestDurableActorTellIgnoresCallerContextAfterEnqueue verifies that durable
+// Tell preserves fire-and-forget semantics. Once the message is enqueued, a
+// caller cancellation must not cancel behavior processing.
+func TestDurableActorTellIgnoresCallerContextAfterEnqueue(t *testing.T) {
+	t.Parallel()
+
+	store := newMockDeliveryStore()
+	codec := newActorTestCodec()
+
+	ctxErr := make(chan error, 1)
+	behavior := newMockBehavior(fn.Ok(42))
+	behavior.onReceive = func(ctx context.Context, msg *actorTestMsg) {
+		ctxErr <- ctx.Err()
+	}
+
+	cfg := DefaultDurableActorConfig("test-actor", behavior, store, codec)
+	cfg.PollInterval = 10 * time.Millisecond
+	actor := NewDurableActor(cfg)
+
+	msg := &actorTestMsg{
+		Value: tlv.NewPrimitiveRecord[tlv.TlvType1](uint64(42)),
+	}
+
+	tellCtx, cancel := context.WithCancel(context.Background())
+	err := actor.Ref().Tell(tellCtx, msg)
+	require.NoError(t, err)
+
+	// Cancel after enqueue but before the actor starts processing.
+	cancel()
+
+	actor.Start()
+	defer actor.Stop()
+
+	require.Eventually(t, func() bool {
+		return behavior.callCount() == 1
+	}, 500*time.Millisecond, 10*time.Millisecond)
+
+	require.NoError(t, <-ctxErr)
+}
+
+// TestDurableActorAskRespectsCallerContextAfterEnqueue verifies the Ask side
+// of the delivery context split. Ask is request/response, so caller
+// cancellation after enqueue must still cancel behavior processing.
+func TestDurableActorAskRespectsCallerContextAfterEnqueue(t *testing.T) {
+	t.Parallel()
+
+	store := newMockDeliveryStore()
+	codec := newActorTestCodec()
+
+	ctxErr := make(chan error, 1)
+	behavior := newMockBehavior(fn.Ok(42))
+	behavior.onReceive = func(ctx context.Context, msg *actorTestMsg) {
+		select {
+		case <-ctx.Done():
+			ctxErr <- ctx.Err()
+
+		case <-time.After(200 * time.Millisecond):
+			ctxErr <- nil
+		}
+	}
+
+	cfg := DefaultDurableActorConfig("test-actor", behavior, store, codec)
+	actor := NewDurableActor(cfg)
+
+	askCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	msg := &actorTestMsg{
+		Value: tlv.NewPrimitiveRecord[tlv.TlvType1](uint64(42)),
+	}
+
+	const (
+		deliveryID = "ask-context-delivery"
+		leaseToken = "ask-context-lease"
+	)
+
+	store.messages[deliveryID] = &LeasedMessage{
+		ID:          deliveryID,
+		LeaseToken:  leaseToken,
+		LeaseUntil:  time.Now().Add(time.Minute),
+		Attempts:    1,
+		MaxAttempts: 3,
+	}
+
+	actor.processDelivery(&Delivery[*actorTestMsg, int]{
+		ID:          deliveryID,
+		Message:     msg,
+		Promise:     NewPromise[int](),
+		CallerCtx:   askCtx,
+		LeaseToken:  leaseToken,
+		LeaseUntil:  time.Now().Add(time.Minute),
+		Attempts:    1,
+		MaxAttempts: 3,
+		store:       store,
+	})
+
+	require.Equal(t, 1, behavior.callCount())
+	require.ErrorIs(t, <-ctxErr, context.Canceled)
+}
+
 // TestDurableActorAskProcessing tests Ask message processing.
 func TestDurableActorAskProcessing(t *testing.T) {
 	t.Parallel()

--- a/cmd/darepocli/darepoclicommands/cmd_board.go
+++ b/cmd/darepocli/darepoclicommands/cmd_board.go
@@ -13,13 +13,19 @@ import (
 func newBoardCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "board",
-		Short: "Board confirmed UTXOs into a VTXO",
+		Short: "Board confirmed UTXOs into VTXOs",
 		Long: "Triggers the client to join the next " +
 			"round with any confirmed boarding UTXOs. " +
-			"The resulting VTXO replaces the on-chain " +
-			"boarding balance.",
+			"The resulting VTXO set replaces the on-chain " +
+			"boarding balance. By default the whole balance " +
+			"is boarded into one VTXO.",
 		RunE: board,
 	}
+
+	cmd.Flags().Uint32(
+		"target-vtxo-count", 0,
+		"number of VTXOs to fan the boarded balance into",
+	)
 
 	return cmd
 }
@@ -33,7 +39,12 @@ func board(cmd *cobra.Command, _ []string) error {
 	defer conn.Close()
 
 	req := &daemonrpc.BoardRequest{}
-	if err := parseRequest(cmd, req, nil); err != nil {
+	if err := parseRequest(cmd, req, func() error {
+		count, _ := cmd.Flags().GetUint32("target-vtxo-count")
+		req.TargetVtxoCount = count
+
+		return nil
+	}); err != nil {
 		return err
 	}
 

--- a/daemonrpc/daemon.pb.go
+++ b/daemonrpc/daemon.pb.go
@@ -2700,9 +2700,13 @@ func (x *LeaveVTXOsResponse) GetStatus() string {
 }
 
 type BoardRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// target_vtxo_count asks the daemon to fan the confirmed boarding
+	// balance out into this many VTXO outputs in the next round. Zero
+	// preserves the legacy behavior of creating one boarded VTXO.
+	TargetVtxoCount uint32 `protobuf:"varint,1,opt,name=target_vtxo_count,json=targetVtxoCount,proto3" json:"target_vtxo_count,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *BoardRequest) Reset() {
@@ -2735,11 +2739,21 @@ func (*BoardRequest) Descriptor() ([]byte, []int) {
 	return file_daemon_proto_rawDescGZIP(), []int{34}
 }
 
+func (x *BoardRequest) GetTargetVtxoCount() uint32 {
+	if x != nil {
+		return x.TargetVtxoCount
+	}
+	return 0
+}
+
 type BoardResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// status is "registered" on success, "no_boarding_utxos" if
 	// nothing to board.
-	Status        string `protobuf:"bytes,1,opt,name=status,proto3" json:"status,omitempty"`
+	Status string `protobuf:"bytes,1,opt,name=status,proto3" json:"status,omitempty"`
+	// vtxo_count is the number of VTXO target outputs accepted for
+	// boarding. It is zero when status is "no_boarding_utxos".
+	VtxoCount     uint32 `protobuf:"varint,2,opt,name=vtxo_count,json=vtxoCount,proto3" json:"vtxo_count,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2779,6 +2793,13 @@ func (x *BoardResponse) GetStatus() string {
 		return x.Status
 	}
 	return ""
+}
+
+func (x *BoardResponse) GetVtxoCount() uint32 {
+	if x != nil {
+		return x.VtxoCount
+	}
+	return 0
 }
 
 // RoundVTXOInfo describes a VTXO created in a round.
@@ -3946,10 +3967,13 @@ const file_daemon_proto_rawDesc = "" +
 	"\tselection\"W\n" +
 	"\x12LeaveVTXOsResponse\x12)\n" +
 	"\x10queued_outpoints\x18\x01 \x03(\tR\x0fqueuedOutpoints\x12\x16\n" +
-	"\x06status\x18\x02 \x01(\tR\x06status\"\x0e\n" +
-	"\fBoardRequest\"'\n" +
+	"\x06status\x18\x02 \x01(\tR\x06status\":\n" +
+	"\fBoardRequest\x12*\n" +
+	"\x11target_vtxo_count\x18\x01 \x01(\rR\x0ftargetVtxoCount\"F\n" +
 	"\rBoardResponse\x12\x16\n" +
-	"\x06status\x18\x01 \x01(\tR\x06status\"J\n" +
+	"\x06status\x18\x01 \x01(\tR\x06status\x12\x1d\n" +
+	"\n" +
+	"vtxo_count\x18\x02 \x01(\rR\tvtxoCount\"J\n" +
 	"\rRoundVTXOInfo\x12\x1a\n" +
 	"\boutpoint\x18\x01 \x01(\tR\boutpoint\x12\x1d\n" +
 	"\n" +

--- a/daemonrpc/daemon.proto
+++ b/daemonrpc/daemon.proto
@@ -652,12 +652,20 @@ message LeaveVTXOsResponse {
 }
 
 message BoardRequest {
+    // target_vtxo_count asks the daemon to fan the confirmed boarding
+    // balance out into this many VTXO outputs in the next round. Zero
+    // preserves the legacy behavior of creating one boarded VTXO.
+    uint32 target_vtxo_count = 1;
 }
 
 message BoardResponse {
     // status is "registered" on success, "no_boarding_utxos" if
     // nothing to board.
     string status = 1;
+
+    // vtxo_count is the number of VTXO target outputs accepted for
+    // boarding. It is zero when status is "no_boarding_utxos".
+    uint32 vtxo_count = 2;
 }
 
 // RoundState represents the lifecycle state of a client's round FSM.

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -1183,8 +1183,12 @@ func (r *RPCServer) LeaveVTXOs(ctx context.Context,
 // returns immediately after the wallet accepts the request; use
 // ListRounds/WatchRounds to observe round progress.
 func (r *RPCServer) Board(ctx context.Context,
-	_ *daemonrpc.BoardRequest) (
+	req *daemonrpc.BoardRequest) (
 	*daemonrpc.BoardResponse, error) {
+
+	if req == nil {
+		req = &daemonrpc.BoardRequest{}
+	}
 
 	if err := r.requireWalletReady(); err != nil {
 		return nil, err
@@ -1216,7 +1220,9 @@ func (r *RPCServer) Board(ctx context.Context,
 	// EstimateFee RPC, not by the Board admission path.
 	_ = terms
 
-	boardReq := &wallet.BoardRequest{}
+	boardReq := &wallet.BoardRequest{
+		TargetVTXOCount: req.GetTargetVtxoCount(),
+	}
 
 	future := wRef.Ask(ctx, boardReq)
 	result := future.Await(ctx)
@@ -1258,10 +1264,12 @@ func (r *RPCServer) Board(ctx context.Context,
 		btclog.Fmt("boarding_balance", "%v",
 			boardResp.BoardingBalance),
 		btclog.Fmt("vtxo_amount", "%v",
-			boardResp.VTXOAmount))
+			boardResp.VTXOAmount),
+		slog.Int("vtxo_count", len(boardResp.VTXOAmounts)))
 
 	return &daemonrpc.BoardResponse{
-		Status: "registered",
+		Status:    "registered",
+		VtxoCount: uint32(len(boardResp.VTXOAmounts)),
 	}, nil
 }
 

--- a/db/round_store.go
+++ b/db/round_store.go
@@ -268,7 +268,7 @@ func (s *RoundPersistenceStore) CommitState(ctx context.Context,
 			for i, intent := range r.Intents.Boarding {
 				sig := inputSigState.InputSigs[i]
 				iParams, err := s.domainIntentToRoundParams(
-					r.RoundID.String(), &intent, i, sig,
+					r.RoundID.String(), &intent, sig,
 				)
 				if err != nil {
 					return fmt.Errorf(
@@ -1101,7 +1101,7 @@ func (s *RoundPersistenceStore) reconstructInputSigSentState(
 // contains the client's input signature for this boarding intent, which is
 // critical for state recovery after restart.
 func (s *RoundPersistenceStore) domainIntentToRoundParams(
-	roundID string, intent *round.BoardingIntent, inputIndex int,
+	roundID string, intent *round.BoardingIntent,
 	inputSig *types.BoardingInputSignature,
 ) (sqlc.InsertRoundBoardingIntentParams, error) {
 
@@ -1135,9 +1135,18 @@ func (s *RoundPersistenceStore) domainIntentToRoundParams(
 	operatorKey := params.OperatorKey.SerializeCompressed()
 
 	var inputIdxVal sql.NullInt32
-	if inputIndex >= 0 {
+	if inputSig != nil {
+		if inputSig.Outpoint != intent.Outpoint {
+			return sqlc.InsertRoundBoardingIntentParams{},
+				fmt.Errorf(
+					"input signature outpoint %s does "+
+						"not match intent outpoint %s",
+					inputSig.Outpoint, intent.Outpoint,
+				)
+		}
+
 		inputIdxVal = sql.NullInt32{
-			Int32: int32(inputIndex),
+			Int32: int32(inputSig.InputIndex),
 			Valid: true,
 		}
 	}

--- a/db/round_store_test.go
+++ b/db/round_store_test.go
@@ -1195,6 +1195,12 @@ func TestRoundStoreWithBoardingGroup(t *testing.T) {
 		)
 		require.NoError(t, err)
 	}
+	// The commitment transaction can order inputs differently from the
+	// client's boarding intent list. Recovery must preserve the actual
+	// commitment input index stored in the signature, not the intent's
+	// position in the local slice.
+	fixtures[0].inputSig.InputIndex = 1
+	fixtures[1].inputSig.InputIndex = 0
 
 	// Build the round's boarding group from the fixtures.
 	roundIntents := make([]round.BoardingIntent, numIntents)
@@ -1210,7 +1216,8 @@ func TestRoundStoreWithBoardingGroup(t *testing.T) {
 
 	// Create the commitment tx with inputs from all boarding intents.
 	tx := wire.NewMsgTx(2)
-	for _, f := range fixtures {
+	for i := len(fixtures) - 1; i >= 0; i-- {
+		f := fixtures[i]
 		tx.AddTxIn(&wire.TxIn{
 			PreviousOutPoint: f.outpoint,
 		})

--- a/oor/AGENTS.md
+++ b/oor/AGENTS.md
@@ -229,7 +229,9 @@ resume semantics.
   within the actor's DB transaction for atomic enqueue (same-DB tx joining via
   `ExecTx`).
 - Package persistence tracks finalized outgoing packages and local input
-  bindings for recovery.
+  bindings for recovery. On outgoing finalize, local input-spend completion is
+  driven before the package write so the VTXO manager can join the durable OOR
+  actor transaction instead of racing a second SQLite writer.
 - Incoming receive never performs synchronous unary RPCs inside the durable
   actor DB transaction. Both incoming-hint resolution and authoritative metadata
   lookup are emitted as transport-native durable `serverconn` query messages and
@@ -240,8 +242,10 @@ resume semantics.
 - `handleMarkInputsSpent` skips non-local outpoints (those not found in the VTXO
   store) before routing to `CompleteSpend` or direct store writes. When
   `CompleteSpend` is nil, falls back to direct `UpdateVTXOStatus` writes for
-  migration compatibility. A retryable error is returned if
-  `actor.ErrNoActorsAvailable` is returned by the VTXO manager.
+  migration compatibility. When `CompleteSpend` is configured, its synchronous
+  manager `Ask` can join the durable actor tx; package persistence is ordered
+  after this step to avoid racing a second SQLite writer. A retryable error is
+  returned if `actor.ErrNoActorsAvailable` is returned by the VTXO manager.
 - `handleMaterializeIncoming` only calls `NotifyIncomingVTXOs` directly when the
   handler is running outside a durable actor DB tx (`hasActorDBTx` returns
   false). Inside a durable actor tx, notification is deferred to

--- a/oor/CLAUDE.md
+++ b/oor/CLAUDE.md
@@ -241,7 +241,9 @@ resume semantics.
   within the actor's DB transaction for atomic enqueue (same-DB tx joining via
   `ExecTx`).
 - Package persistence tracks finalized outgoing packages and local input
-  bindings for recovery.
+  bindings for recovery. On outgoing finalize, local input-spend completion is
+  driven before the package write so the VTXO manager can join the durable OOR
+  actor transaction instead of racing a second SQLite writer.
 - Incoming receive never performs synchronous unary RPCs inside the durable
   actor DB transaction. Both incoming-hint resolution and authoritative metadata
   lookup are emitted as transport-native durable `serverconn` query messages and
@@ -252,8 +254,10 @@ resume semantics.
 - `handleMarkInputsSpent` skips non-local outpoints (those not found in the VTXO
   store) before routing to `CompleteSpend` or direct store writes. When
   `CompleteSpend` is nil, falls back to direct `UpdateVTXOStatus` writes for
-  migration compatibility. A retryable error is returned if
-  `actor.ErrNoActorsAvailable` is returned by the VTXO manager.
+  migration compatibility. When `CompleteSpend` is configured, its synchronous
+  manager `Ask` can join the durable actor tx; package persistence is ordered
+  after this step to avoid racing a second SQLite writer. A retryable error is
+  returned if `actor.ErrNoActorsAvailable` is returned by the VTXO manager.
 - `handleMaterializeIncoming` only calls `NotifyIncomingVTXOs` directly when the
   handler is running outside a durable actor DB tx (`hasActorDBTx` returns
   false). Inside a durable actor tx, notification is deferred to

--- a/oor/actor.go
+++ b/oor/actor.go
@@ -637,13 +637,34 @@ func (b *oorDurableBehavior) handleDriveEvent(ctx context.Context,
 	}
 	handle.clearRetryMetadata()
 
-	if finalizeState != nil {
-		err := b.persistOutgoingPackage(
-			ctx, req.SessionID, finalizeState,
-		)
+	b.notifyMaterializedVTXOs(ctx, req.Event)
+
+	if finalizeState == nil {
+		err = b.persistCheckpoint(ctx)
 		if err != nil {
 			return fn.Err[ActorResp](err)
 		}
+
+		err = b.driveOutbox(ctx, req.SessionID, handle, outbox)
+		if err != nil {
+			return fn.Err[ActorResp](err)
+		}
+
+		return fn.Ok[ActorResp](&DriveEventResponse{})
+	}
+
+	// FinalizeAcceptedEvent emits MarkInputsSpentRequest, which may cross
+	// from this durable actor into the VTXO manager. Drive that local
+	// completion before taking this actor's package-store write lock so
+	// SQLite backends do not deadlock on two actor transactions.
+	err = b.driveOutbox(ctx, req.SessionID, handle, outbox)
+	if err != nil {
+		return fn.Err[ActorResp](err)
+	}
+
+	err = b.persistOutgoingPackage(ctx, req.SessionID, finalizeState)
+	if err != nil {
+		return fn.Err[ActorResp](err)
 	}
 
 	err = b.persistCheckpoint(ctx)
@@ -658,13 +679,6 @@ func (b *oorDurableBehavior) handleDriveEvent(ctx context.Context,
 	// persistence does not double-book the transfers_out leg on
 	// replay.
 	b.emitVTXOSent(ctx, req.SessionID, finalizeState)
-
-	b.notifyMaterializedVTXOs(ctx, req.Event)
-
-	err = b.driveOutbox(ctx, req.SessionID, handle, outbox)
-	if err != nil {
-		return fn.Err[ActorResp](err)
-	}
 
 	return fn.Ok[ActorResp](&DriveEventResponse{})
 }
@@ -1568,20 +1582,39 @@ func (b *oorDurableBehavior) driveOutbox(ctx context.Context,
 			}
 			handle.applyRetryEvent(followUp)
 
-			if finalizeState != nil {
-				err = b.persistOutgoingPackage(ctx, sessionID,
-					finalizeState)
+			if finalizeState == nil {
+				err = b.persistCheckpoint(ctx)
 				if err != nil {
 					return err
 				}
+
+				err = b.driveOutbox(
+					ctx, sessionID, handle, nextOutbox,
+				)
+				if err != nil {
+					return err
+				}
+
+				continue
 			}
 
-			err = b.persistCheckpoint(ctx)
+			// FinalizeAcceptedEvent emits local input-spend work.
+			// Run it before this actor writes the outgoing package.
+			// This keeps SQLite from holding two contending actor
+			// transactions.
+			err = b.driveOutbox(ctx, sessionID, handle, nextOutbox)
 			if err != nil {
 				return err
 			}
 
-			err = b.driveOutbox(ctx, sessionID, handle, nextOutbox)
+			err = b.persistOutgoingPackage(
+				ctx, sessionID, finalizeState,
+			)
+			if err != nil {
+				return err
+			}
+
+			err = b.persistCheckpoint(ctx)
 			if err != nil {
 				return err
 			}

--- a/oor/actor_test.go
+++ b/oor/actor_test.go
@@ -144,12 +144,18 @@ type testOutgoingPackageStore struct {
 	lastSessionID chainhash.Hash
 
 	bindingErrByOutpoint map[wire.OutPoint]error
+
+	onUpsertPackage func()
 }
 
 // UpsertPackage records one outgoing package persistence invocation.
 func (s *testOutgoingPackageStore) UpsertPackage(_ context.Context,
 	direction PackageDirection, sessionID chainhash.Hash, _ *psbt.Packet,
 	_ []*psbt.Packet) error {
+
+	if s.onUpsertPackage != nil {
+		s.onUpsertPackage()
+	}
 
 	s.packageCalls++
 	s.lastDirection = direction
@@ -1078,7 +1084,14 @@ func TestOORClientActorTransportViaServerConn(t *testing.T) {
 	operatorSigner := input.NewMockSigner(
 		[]*btcec.PrivateKey{operatorKey}, nil,
 	)
-	packageStore := &testOutgoingPackageStore{}
+	var completeSpendCalled bool
+	packageStore := &testOutgoingPackageStore{
+		onUpsertPackage: func() {
+			require.True(t, completeSpendCalled,
+				"local spend completion must run before "+
+					"package persistence")
+		},
+	}
 	mockConn := newMockServerConnRef(t)
 
 	inputs := []TransferInput{
@@ -1105,9 +1118,21 @@ func TestOORClientActorTransportViaServerConn(t *testing.T) {
 	// serverconn. Transport events should go to the mock, local events
 	// to the handler.
 	actor := NewOORClientActor(ClientActorCfg{
-		OutboxHandler: &localOnlyOutboxHandler{
-			t:            t,
-			clientSigner: clientSigner,
+		OutboxHandler: &LocalPersistenceOutboxHandler{
+			Next: &localOnlyOutboxHandler{
+				t:            t,
+				clientSigner: clientSigner,
+			},
+			CompleteSpend: func(_ context.Context,
+				ops []wire.OutPoint) error {
+
+				require.Equal(t, InputOutpoints(inputs), ops)
+				require.Zero(t, packageStore.packageCalls)
+
+				completeSpendCalled = true
+
+				return nil
+			},
 		},
 		ServerConn:    mockConn,
 		PackageStore:  packageStore,
@@ -1205,6 +1230,7 @@ func TestOORClientActorTransportViaServerConn(t *testing.T) {
 	require.IsType(t, &Completed{}, stateMsg.State)
 
 	// Verify package was persisted.
+	require.True(t, completeSpendCalled)
 	require.Equal(t, 1, packageStore.packageCalls)
 	require.Equal(t, len(inputs), packageStore.bindingCalls)
 }

--- a/oor/local_persistence_handler.go
+++ b/oor/local_persistence_handler.go
@@ -220,7 +220,10 @@ func (h *LocalPersistenceOutboxHandler) handleMarkInputsSpent(
 
 	// When a SpendCompleter is configured, route completion through the
 	// VTXO manager so each actor processes SpendCompletedEvent and
-	// persists VTXOStatusSpent through its own outbox path.
+	// persists VTXOStatusSpent through its own outbox path. This is a
+	// synchronous Ask: if the caller is a durable actor, the manager's
+	// status write should join the caller transaction so SQLite sees one
+	// writer instead of two contending transactions.
 	if h.CompleteSpend != nil {
 		err := h.CompleteSpend(ctx, knownOutpoints)
 		if err != nil {

--- a/oor/local_persistence_handler_test.go
+++ b/oor/local_persistence_handler_test.go
@@ -58,8 +58,9 @@ func (s *testPackageStore) UpsertBinding(_ context.Context, _ wire.OutPoint,
 
 // testVTXOStore is a minimal in-memory vtxo.VTXOStore used by handler tests.
 type testVTXOStore struct {
-	records map[wire.OutPoint]*vtxo.Descriptor
-	getErr  error
+	records       map[wire.OutPoint]*vtxo.Descriptor
+	getErr        error
+	lastGetCtxHas bool
 }
 
 // newTestVTXOStore creates a new testVTXOStore.
@@ -88,8 +89,10 @@ func (s *testVTXOStore) SaveVTXO(_ context.Context,
 }
 
 // GetVTXO returns a descriptor by outpoint.
-func (s *testVTXOStore) GetVTXO(_ context.Context,
+func (s *testVTXOStore) GetVTXO(ctx context.Context,
 	outpoint wire.OutPoint) (*vtxo.Descriptor, error) {
+
+	s.lastGetCtxHas = actor.HasTx(ctx)
 
 	if s.getErr != nil {
 		return nil, s.getErr
@@ -742,23 +745,38 @@ func TestLocalPersistenceHandlerMarkInputsSpentViaCompleter(t *testing.T) {
 	}
 
 	var completedOutpoints []wire.OutPoint
+	var completeCtxHas bool
+	store := newTestVTXOStore()
+	store.records[outpoints[0]] = &vtxo.Descriptor{
+		Outpoint: outpoints[0],
+		Status:   vtxo.VTXOStatusLive,
+	}
+	store.records[outpoints[1]] = &vtxo.Descriptor{
+		Outpoint: outpoints[1],
+		Status:   vtxo.VTXOStatusLive,
+	}
 	handler := &LocalPersistenceOutboxHandler{
-		CompleteSpend: func(_ context.Context,
+		Store: store,
+		CompleteSpend: func(ctx context.Context,
 			ops []wire.OutPoint) error {
 
+			completeCtxHas = actor.HasTx(ctx)
 			completedOutpoints = ops
 			return nil
 		},
 	}
 
+	ctx := actor.WithTx(t.Context(), (*sql.Tx)(nil))
 	events, err := handler.Handle(
-		t.Context(), SessionID{},
+		ctx, SessionID{},
 		&MarkInputsSpentRequest{Outpoints: outpoints},
 	)
 	require.NoError(t, err)
 	require.Len(t, events, 1)
 	require.IsType(t, &InputsMarkedSpentEvent{}, events[0])
 	require.Equal(t, outpoints, completedOutpoints)
+	require.True(t, completeCtxHas)
+	require.True(t, store.lastGetCtxHas)
 }
 
 // TestLocalPersistenceHandlerMarkInputsSpentSkipsNonLocal asserts that custom

--- a/round/actor_test.go
+++ b/round/actor_test.go
@@ -1908,6 +1908,70 @@ func TestHandleTriggerBoard(t *testing.T) {
 	)
 }
 
+// TestHandleTriggerBoardMultipleVTXOs verifies board fanout registers one VTXO
+// request per requested target amount.
+func TestHandleTriggerBoardMultipleVTXOs(t *testing.T) {
+	t.Parallel()
+
+	h := newActorTestHarness(t)
+	h.setupMockRoundStoreForStart()
+
+	err := h.start()
+	require.NoError(t, err)
+
+	intent := h.newTestBoardingIntent()
+	h.walletActor.setConfirmedIntents(*intent)
+
+	for i := 0; i < 3; i++ {
+		h.wallet.On(
+			"DeriveNextKey", mock.Anything,
+			types.VTXOOwnerKeyFamily,
+		).Return(&keychain.KeyDescriptor{
+			PubKey: h.clientPubKey,
+			KeyLocator: keychain.KeyLocator{
+				Family: types.VTXOOwnerKeyFamily,
+				Index:  uint32(i),
+			},
+		}, nil).Once()
+		h.wallet.On(
+			"DeriveNextKey", mock.Anything,
+			keychain.KeyFamilyMultiSig,
+		).Return(&keychain.KeyDescriptor{
+			PubKey: h.clientPubKey,
+			KeyLocator: keychain.KeyLocator{
+				Family: keychain.KeyFamilyMultiSig,
+				Index:  uint32(i),
+			},
+		}, nil).Once()
+	}
+
+	result := h.receive(&actormsg.TriggerBoardMsg{
+		Amounts: []btcutil.Amount{17_000, 17_000, 16_000},
+	})
+	require.True(t, result.IsOk(), "expected Ok, got: %v",
+		result.Err())
+
+	states := h.queryState()
+	tempState, exists := h.findTempState(states)
+	require.True(t, exists, "expected temp-keyed FSM state")
+
+	regState, ok := tempState.State.(*IntentSentState)
+	require.True(t, ok, "expected IntentSentState, got %T",
+		tempState.State)
+	require.Len(t, regState.Intents.Boarding, 1)
+	require.Len(t, regState.Intents.VTXOs, 3)
+
+	require.Equal(
+		t, btcutil.Amount(17_000), regState.Intents.VTXOs[0].Amount,
+	)
+	require.Equal(
+		t, btcutil.Amount(17_000), regState.Intents.VTXOs[1].Amount,
+	)
+	require.Equal(
+		t, btcutil.Amount(16_000), regState.Intents.VTXOs[2].Amount,
+	)
+}
+
 // TestHandleForfeitCollectionTimeout verifies timeout-message handling for
 // rounds waiting on forfeit signatures.
 func TestHandleForfeitCollectionTimeout(t *testing.T) {

--- a/sdk/ark/client.go
+++ b/sdk/ark/client.go
@@ -780,11 +780,16 @@ func (c *Client) RefreshVTXOs(ctx context.Context,
 }
 
 // Board tells the daemon to register any confirmed boarding UTXOs in the next
-// round.
-func (c *Client) Board(ctx context.Context) (
-	*daemonrpc.BoardResponse, error) {
+// round. Passing no request preserves the legacy single-VTXO board behavior.
+func (c *Client) Board(ctx context.Context,
+	reqs ...*daemonrpc.BoardRequest) (*daemonrpc.BoardResponse, error) {
 
-	resp, err := c.daemon.Board(ctx, &daemonrpc.BoardRequest{})
+	req := &daemonrpc.BoardRequest{}
+	if len(reqs) > 0 && reqs[0] != nil {
+		req = reqs[0]
+	}
+
+	resp, err := c.daemon.Board(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("board confirmed utxos: %w", err)
 	}

--- a/wallet/messages.go
+++ b/wallet/messages.go
@@ -504,11 +504,15 @@ func (m *LeaveVTXOsRequest) walletMsgSealed() {}
 // BoardRequest triggers the wallet to board all confirmed boarding UTXOs
 // into the next round. Under the #270 seal-time fee handshake the server
 // decides the operator fee when the round seals; the wallet ships the full
-// confirmed boarding balance as the VTXO intent target and the server
-// stamps the residual at seal time. This is a non-blocking operation; use
+// confirmed boarding balance as VTXO intent targets and the server stamps
+// the residual at seal time. This is a non-blocking operation; use
 // ListRounds/WatchRounds to observe round progress.
 type BoardRequest struct {
 	actor.BaseMessage
+
+	// TargetVTXOCount is the requested number of boarded VTXOs. Zero means
+	// one output, preserving the legacy single-VTXO board behavior.
+	TargetVTXOCount uint32
 }
 
 // MessageType returns the message type identifier for logging and debugging.
@@ -529,8 +533,13 @@ type BoardResponse struct {
 	BoardingBalance btcutil.Amount
 
 	// VTXOAmount is the VTXO output amount that was registered for the
-	// next round (boarding balance minus operator fee).
+	// next round. When multiple VTXOs are requested, this is the total of
+	// VTXOAmounts and is kept for existing internal callers.
 	VTXOAmount btcutil.Amount
+
+	// VTXOAmounts are the per-output target amounts registered for the
+	// next round before seal-time operator fees are stamped.
+	VTXOAmounts []btcutil.Amount
 }
 
 // MessageType returns the message type identifier for logging and debugging.

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -1152,7 +1152,7 @@ func (a *Ark) handleLeaveVTXOs(ctx context.Context,
 }
 
 // handleBoard processes a boarding request by checking the confirmed balance,
-// computing the VTXO output amount after operator fees, and forwarding a
+// computing the requested VTXO output target amounts, and forwarding a
 // TriggerBoardMsg to the round actor. The round actor handles the actual
 // registration and FSM transitions asynchronously.
 func (a *Ark) handleBoard(ctx context.Context,
@@ -1181,20 +1181,26 @@ func (a *Ark) handleBoard(ctx context.Context,
 	// Under the #270 seal-time fee handshake the server decides
 	// the operator fee when the round seals, not at submit time.
 	// The wallet therefore ships the full confirmed balance as
-	// the VTXO intent target; the boarding output is the sole
-	// output of the single-output intent, so the proto's
-	// single-output change-marker exception applies and the
-	// server stamps `totalBalance − fee` at seal time. We skip
+	// one or more VTXO intent targets. For multi-output boarding,
+	// the common change-marker logic marks one output as the
+	// residual output the server can stamp at seal time. We skip
 	// the pre-#270 `vtxoAmount <= DustLimit` gate because it was
 	// driven by an advisory submit-time fee estimate and would
 	// spuriously reject boards that the seal-time quote would
 	// have accepted.
-	vtxoAmount := totalBalance
+	vtxoAmounts, err := splitBoardingAmount(
+		totalBalance, req.TargetVTXOCount,
+	)
+	if err != nil {
+		return fn.Err[WalletResp](err)
+	}
+	vtxoAmount := sumBoardingAmounts(vtxoAmounts)
 
 	a.logger(ctx).InfoS(ctx, "Boarding request accepted",
 		slog.Int64("boarding_balance",
 			int64(totalBalance)),
-		slog.Int64("vtxo_amount", int64(vtxoAmount)))
+		slog.Int64("vtxo_amount", int64(vtxoAmount)),
+		slog.Int("vtxo_count", len(vtxoAmounts)))
 
 	// Forward to round actor via service key lookup. The round actor
 	// registers the VTXO output requests and triggers the round join.
@@ -1209,7 +1215,7 @@ func (a *Ark) handleBoard(ctx context.Context,
 
 	if err := roundRef.Tell(
 		ctx, &actormsg.TriggerBoardMsg{
-			Amounts: []btcutil.Amount{vtxoAmount},
+			Amounts: vtxoAmounts,
 		},
 	); err != nil {
 		return fn.Err[WalletResp](fmt.Errorf(
@@ -1220,9 +1226,54 @@ func (a *Ark) handleBoard(ctx context.Context,
 	resp := &BoardResponse{
 		BoardingBalance: totalBalance,
 		VTXOAmount:      vtxoAmount,
+		VTXOAmounts:     vtxoAmounts,
 	}
 
 	return fn.Ok[WalletResp](resp)
+}
+
+// splitBoardingAmount fans a confirmed boarding balance into count VTXO
+// target amounts. A zero count preserves the legacy single-output behavior.
+func splitBoardingAmount(total btcutil.Amount,
+	count uint32) ([]btcutil.Amount, error) {
+
+	if count == 0 {
+		count = 1
+	}
+	if total <= 0 {
+		return nil, fmt.Errorf("boarding balance must be positive")
+	}
+
+	base := int64(total) / int64(count)
+	remainder := int64(total) % int64(count)
+	if base <= 0 {
+		return nil, fmt.Errorf(
+			"boarding balance %v too small for %d VTXOs",
+			total, count,
+		)
+	}
+
+	amounts := make([]btcutil.Amount, count)
+	for i := range amounts {
+		amount := base
+		if int64(i) < remainder {
+			amount++
+		}
+
+		amounts[i] = btcutil.Amount(amount)
+	}
+
+	return amounts, nil
+}
+
+// sumBoardingAmounts returns the total of boarding target amounts.
+func sumBoardingAmounts(amounts []btcutil.Amount) btcutil.Amount {
+	var total btcutil.Amount
+	for _, amount := range amounts {
+		total += amount
+	}
+
+	return total
 }
 
 // buildBoardingTxProof fetches the confirmation block and computes a merkle

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -1207,6 +1207,64 @@ func TestGetConfirmedBoardingIntents(t *testing.T) {
 	store.AssertExpectations(t)
 }
 
+// TestSplitBoardingAmount verifies board fanout preserves total balance while
+// producing stable per-output target amounts.
+func TestSplitBoardingAmount(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		total     btcutil.Amount
+		count     uint32
+		want      []btcutil.Amount
+		wantError string
+	}{
+		{
+			name:  "zero count defaults to one output",
+			total: 10_000,
+			count: 0,
+			want:  []btcutil.Amount{10_000},
+		},
+		{
+			name:  "even split",
+			total: 12_000,
+			count: 3,
+			want:  []btcutil.Amount{4_000, 4_000, 4_000},
+		},
+		{
+			name:  "remainder is spread across leading outputs",
+			total: 10_001,
+			count: 3,
+			want:  []btcutil.Amount{3_334, 3_334, 3_333},
+		},
+		{
+			name:      "count cannot exceed sats",
+			total:     2,
+			count:     3,
+			wantError: "too small",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := splitBoardingAmount(
+				test.total, test.count,
+			)
+			if test.wantError != "" {
+				require.ErrorContains(t, err, test.wantError)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, test.want, got)
+			require.Equal(t, test.total, sumBoardingAmounts(got))
+		})
+	}
+}
+
 // TestSendBacklog tests the sendBacklog method which delivers historical
 // confirmation events to newly registered notifiers.
 func TestSendBacklog(t *testing.T) {


### PR DESCRIPTION
## Summary

Fix restart recovery write ordering across the actor paths involved in #306 and the parent darepo #308 CI failure.

Regular actor `Tell` now strips any caller transaction at the enqueue boundary with `actor.WithoutTx(ctx)`. This matters when a durable actor sends fire-and-forget work to a normal actor: the queued work must not inherit a DB transaction that may be committed or rolled back before the receiver handles it.

Durable actors still preserve `Tell` semantics after durable enqueue by processing delivery with the actor context, so caller cancellation after enqueue does not cancel behavior execution. `Ask` and `DurableAsk` continue to merge caller context because request deadlines and synchronous completion are part of that contract.

Round recovery also persists the actual commitment transaction input index for checkpointed boarding signatures. Restart replay must send the same input index that was signed, not the boarding intent's local slice position, otherwise recovery can replay a valid signature against the wrong input.

OOR finalize replay now completes local input-spend work before outgoing package persistence. The spend completion path is a synchronous `Ask`, so it intentionally keeps the durable actor transaction and lets the VTXO status update join that transaction instead of racing a second SQLite writer.

## Why

This is expected to address the root cause behind lightninglabs/darepo#306, where a refresh join reached the operator actor but failed validation while looking up a forfeit VTXO with `context canceled`.

The transaction-stripping follow-up matches the actor contract more directly: async `Tell` transfers work to the receiver, while synchronous `Ask` remains the path that can intentionally share caller-scoped transaction context.

The checkpointed input-index fix covers a restart race exposed by lightninglabs/darepo#308 CI: the client can shut down after persisting `InputSigSent` but before the original durable send reaches the operator, so replay has to be semantically equivalent to the original send.

The OOR ordering fix covers the follow-up #308 CI failure where OOR resumed after restart but the sender input stayed `spending`. Completing the VTXO manager update before package persistence avoids a SQLite writer-lock inversion during durable replay.

## Test Plan

- `go test ./oor ./vtxo ./baselib/actor ./db ./round`
- `GOGC=50 make lint`
- `make commitmsg-lint range=origin/main..HEAD`
- `go test -tags "systest" -v ./systest/... -run '^TestOORClientResumeAfterCoSign$' -timeout 10m` from the parent darepo branch
- `make itest backend=btcwallet icase=TestBoardingIntegrationRestartAfterInputSigSent` from the parent darepo branch