### PR TITLE
oor: reduce durable submit deadline coupling

### DIFF
--- a/baselib/actor/AGENTS.md
+++ b/baselib/actor/AGENTS.md
@@ -29,7 +29,7 @@ crash-safe at-least-once delivery with exactly-once deduplication.
 - `DeliveryStore` / `TxAwareDeliveryStore` — Interfaces for durable mailbox persistence (enqueue, claim, ack, dead-letter).
 - `DurableActor` — Actor variant with crash-safe mailbox backed by SQL persistence. Provides `Wait(ctx)` to block until the actor stops and `StopAndWait(ctx)` to request a graceful shutdown and then wait.
 - `DurableActorConfig[M, R]` — Configuration struct for `DurableActor`: behavior, store, codec, clock, DLO, WaitGroup, `TellRetryPolicy`, lease/heartbeat/poll durations, max attempts, cleanup timeout, and deduplication TTL.
-- `DefaultDurableActorConfig[M, R]()` — Constructor returning a `DurableActorConfig` with safe defaults (30s lease, 10 max attempts, 100ms poll, DefaultTellRetryPolicy).
+- `DefaultDurableActorConfig[M, R]()` — Constructor returning a `DurableActorConfig` with safe defaults (30s lease, 10 max attempts, 1s poll fallback, DefaultTellRetryPolicy).
 - `TellRetryPolicy` — Function type `func(attempts int, lastErr error) (bool, time.Duration)` determining retry behavior for failed Tell messages. Return `(false, _)` to dead-letter immediately.
 - `DefaultTellRetryPolicy` — Exponential backoff policy: up to 5 attempts, starting at 1s, capped at 60s.
 - `Checkpoint` — Serializable actor state snapshot for recovery.

--- a/baselib/actor/CLAUDE.md
+++ b/baselib/actor/CLAUDE.md
@@ -29,7 +29,7 @@ crash-safe at-least-once delivery with exactly-once deduplication.
 - `DeliveryStore` / `TxAwareDeliveryStore` — Interfaces for durable mailbox persistence (enqueue, claim, ack, dead-letter).
 - `DurableActor` — Actor variant with crash-safe mailbox backed by SQL persistence. Provides `Wait(ctx)` to block until the actor stops and `StopAndWait(ctx)` to request a graceful shutdown and then wait.
 - `DurableActorConfig[M, R]` — Configuration struct for `DurableActor`: behavior, store, codec, clock, DLO, WaitGroup, `TellRetryPolicy`, lease/heartbeat/poll durations, max attempts, cleanup timeout, and deduplication TTL.
-- `DefaultDurableActorConfig[M, R]()` — Constructor returning a `DurableActorConfig` with safe defaults (30s lease, 10 max attempts, 100ms poll, DefaultTellRetryPolicy).
+- `DefaultDurableActorConfig[M, R]()` — Constructor returning a `DurableActorConfig` with safe defaults (30s lease, 10 max attempts, 1s poll fallback, DefaultTellRetryPolicy).
 - `TellRetryPolicy` — Function type `func(attempts int, lastErr error) (bool, time.Duration)` determining retry behavior for failed Tell messages. Return `(false, _)` to dead-letter immediately.
 - `DefaultTellRetryPolicy` — Exponential backoff policy: up to 5 attempts, starting at 1s, capped at 60s.
 - `Checkpoint` — Serializable actor state snapshot for recovery.

--- a/baselib/actor/delivery_store.go
+++ b/baselib/actor/delivery_store.go
@@ -128,6 +128,13 @@ type DeliveryStore interface {
 	CleanupExpired(ctx context.Context) error
 }
 
+// OutboxWakeRegistrar is optionally implemented by stores that can notify a
+// same-process publisher after new outbox work commits. Polling remains the
+// cross-process and restart fallback.
+type OutboxWakeRegistrar interface {
+	RegisterOutboxWake(func())
+}
+
 // EnqueueParams contains parameters for enqueueing a mailbox message.
 type EnqueueParams struct {
 	// ID is the unique message identifier (ULID recommended).

--- a/baselib/actor/delivery_test.go
+++ b/baselib/actor/delivery_test.go
@@ -35,6 +35,9 @@ type mockDeliveryStore struct {
 	// Outbox stores outbox messages.
 	outbox map[string]*OutboxMessage
 
+	// outboxWakes stores callbacks invoked after outbox enqueue.
+	outboxWakes []func()
+
 	// Error injection for testing.
 	injectError error
 
@@ -288,13 +291,14 @@ func (m *mockDeliveryStore) DeleteAskResult(ctx context.Context, promiseID strin
 
 func (m *mockDeliveryStore) EnqueueOutbox(ctx context.Context, params OutboxParams) error {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 
 	if m.injectOutboxError != nil {
+		m.mu.Unlock()
 		return m.injectOutboxError
 	}
 
 	if m.injectError != nil {
+		m.mu.Unlock()
 		return m.injectError
 	}
 
@@ -309,8 +313,25 @@ func (m *mockDeliveryStore) EnqueueOutbox(ctx context.Context, params OutboxPara
 		Status:        "pending",
 		CreatedAt:     time.Now(),
 	}
+	wakes := append([]func(){}, m.outboxWakes...)
+	m.mu.Unlock()
+
+	for _, wake := range wakes {
+		wake()
+	}
 
 	return nil
+}
+
+func (m *mockDeliveryStore) RegisterOutboxWake(wake func()) {
+	if wake == nil {
+		return
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.outboxWakes = append(m.outboxWakes, wake)
 }
 
 func (m *mockDeliveryStore) ClaimOutboxBatch(

--- a/baselib/actor/durable_actor.go
+++ b/baselib/actor/durable_actor.go
@@ -79,7 +79,9 @@ type DurableActorConfig[M TLVMessage, R any] struct {
 	HeartbeatInterval time.Duration
 
 	// PollInterval is how often to poll for new messages when empty.
-	// Default: 100ms.
+	// Same-process sends wake the mailbox immediately, so polling is only
+	// the fallback for missed wakes, restarts, and external enqueues.
+	// Default: 1s.
 	PollInterval time.Duration
 
 	// MaxAttempts is the default maximum delivery attempts.
@@ -115,7 +117,7 @@ func DefaultDurableActorConfig[M TLVMessage, R any](
 		TellRetryPolicy:   DefaultTellRetryPolicy,
 		LeaseDuration:     leaseDuration,
 		HeartbeatInterval: leaseDuration / 3,
-		PollInterval:      100 * time.Millisecond,
+		PollInterval:      time.Second,
 		MaxAttempts:       10,
 		CleanupTimeout:    5 * time.Second,
 		DeduplicationTTL:  24 * time.Hour,

--- a/baselib/actor/durable_mailbox.go
+++ b/baselib/actor/durable_mailbox.go
@@ -77,7 +77,9 @@ type DurableMailboxConfig struct {
 	LeaseDuration time.Duration
 
 	// PollInterval is how often to poll for new messages when empty.
-	// Default: 100ms.
+	// Same-process sends wake the mailbox immediately, so polling is only
+	// the fallback for missed wakes, restarts, and external enqueues.
+	// Default: 1s.
 	PollInterval time.Duration
 
 	// MaxAttempts is the default maximum delivery attempts.
@@ -92,7 +94,7 @@ func DefaultDurableMailboxConfig(mailboxID string, store DeliveryStore, codec *M
 		Store:         store,
 		Codec:         codec,
 		LeaseDuration: 30 * time.Second,
-		PollInterval:  100 * time.Millisecond,
+		PollInterval:  time.Second,
 		MaxAttempts:   10,
 	}
 }

--- a/baselib/actor/durable_mailbox_test.go
+++ b/baselib/actor/durable_mailbox_test.go
@@ -99,7 +99,7 @@ func TestDurableMailboxNewMailbox(t *testing.T) {
 	require.False(t, mailbox.IsClosed())
 	require.Equal(t, "test-mailbox", mailbox.cfg.MailboxID)
 	require.Equal(t, 30*time.Second, mailbox.cfg.LeaseDuration)
-	require.Equal(t, 100*time.Millisecond, mailbox.cfg.PollInterval)
+	require.Equal(t, time.Second, mailbox.cfg.PollInterval)
 	require.Equal(t, 10, mailbox.cfg.MaxAttempts)
 }
 

--- a/baselib/actor/outbox_publisher.go
+++ b/baselib/actor/outbox_publisher.go
@@ -78,6 +78,9 @@ type OutboxPublisher struct {
 	// wg tracks the background goroutine.
 	wg sync.WaitGroup
 
+	// wake nudges the publisher when same-process outbox work commits.
+	wake chan struct{}
+
 	// startOnce ensures Run is only called once.
 	startOnce sync.Once
 
@@ -102,11 +105,18 @@ func NewOutboxPublisher(cfg OutboxPublisherConfig) *OutboxPublisher {
 		cfg.ClaimDuration = 30 * time.Second
 	}
 
-	return &OutboxPublisher{
+	p := &OutboxPublisher{
 		cfg:    cfg,
 		ctx:    ctx,
 		cancel: cancel,
+		wake:   make(chan struct{}, 1),
 	}
+
+	if registrar, ok := cfg.Store.(OutboxWakeRegistrar); ok {
+		registrar.RegisterOutboxWake(p.Wake)
+	}
+
+	return p
 }
 
 // Start begins the background publishing loop.
@@ -144,6 +154,9 @@ func (p *OutboxPublisher) run() {
 			return
 
 		case <-ticker.C:
+			p.publishBatch()
+
+		case <-p.wake:
 			p.publishBatch()
 		}
 	}
@@ -274,4 +287,13 @@ func (p *OutboxPublisher) deliverMessage(msg OutboxMessage) {
 // or when immediate delivery is needed after a transaction commits.
 func (p *OutboxPublisher) PublishPending() {
 	p.publishBatch()
+}
+
+// Wake asks the publisher to run a publish cycle soon. The signal is
+// best-effort because the periodic poll remains the durability fallback.
+func (p *OutboxPublisher) Wake() {
+	select {
+	case p.wake <- struct{}{}:
+	default:
+	}
 }

--- a/baselib/actor/outbox_publisher.go
+++ b/baselib/actor/outbox_publisher.go
@@ -20,7 +20,9 @@ type OutboxPublisherConfig struct {
 	System SystemContext
 
 	// PollInterval is how often to poll for pending outbox messages.
-	// Default: 100ms.
+	// Same-process outbox commits wake the publisher immediately, so polling
+	// is only the fallback for missed wakes and process restarts.
+	// Default: 1s.
 	PollInterval time.Duration
 
 	// BatchSize is the maximum number of messages to process per poll.
@@ -48,7 +50,7 @@ func DefaultOutboxPublisherConfig(
 		Store:               store,
 		Codec:               codec,
 		System:              system,
-		PollInterval:        100 * time.Millisecond,
+		PollInterval:        time.Second,
 		BatchSize:           100,
 		MaxDeliveryAttempts: 10,
 		ClaimDuration:       30 * time.Second,
@@ -93,7 +95,7 @@ func NewOutboxPublisher(cfg OutboxPublisherConfig) *OutboxPublisher {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	if cfg.PollInterval == 0 {
-		cfg.PollInterval = 100 * time.Millisecond
+		cfg.PollInterval = time.Second
 	}
 	if cfg.BatchSize == 0 {
 		cfg.BatchSize = 100

--- a/baselib/actor/outbox_publisher_test.go
+++ b/baselib/actor/outbox_publisher_test.go
@@ -424,6 +424,44 @@ func TestOutboxPublisherPublishPending(t *testing.T) {
 	system.mu.Unlock()
 }
 
+// TestOutboxPublisherWakesOnEnqueue verifies same-process outbox enqueue wakes
+// the publisher without waiting for its polling fallback.
+func TestOutboxPublisherWakesOnEnqueue(t *testing.T) {
+	t.Parallel()
+
+	store := newMockDeliveryStore()
+	codec := newOutboxTestCodec()
+	system := newMockSystem()
+
+	cfg := DefaultOutboxPublisherConfig(store, codec, system)
+	cfg.PollInterval = time.Hour
+	publisher := NewOutboxPublisher(cfg)
+	publisher.Start()
+	defer publisher.Stop()
+
+	msg := &outboxTestMsg{
+		Value: tlv.NewPrimitiveRecord[tlv.TlvType1](uint64(42)),
+	}
+	payload, err := codec.Encode(msg)
+	require.NoError(t, err)
+
+	err = store.EnqueueOutbox(t.Context(), OutboxParams{
+		ID:            "outbox-wake",
+		SourceActorID: "source-actor",
+		TargetActorID: "target-actor",
+		MessageType:   msg.MessageType(),
+		Payload:       payload,
+	})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		system.mu.Lock()
+		defer system.mu.Unlock()
+
+		return len(system.tellCalls) == 1
+	}, 500*time.Millisecond, 10*time.Millisecond)
+}
+
 // TestOutboxPublisherPropagatesOutboxID verifies that the OutboxPublisher
 // injects the outbox message ID into the context when calling Tell on the
 // target actor. This is the publisher-side half of the receiver-side

--- a/baselib/actor/outbox_publisher_test.go
+++ b/baselib/actor/outbox_publisher_test.go
@@ -146,7 +146,7 @@ func TestOutboxPublisherCreation(t *testing.T) {
 	publisher := NewOutboxPublisher(cfg)
 
 	require.NotNil(t, publisher)
-	require.Equal(t, 100*time.Millisecond, publisher.cfg.PollInterval)
+	require.Equal(t, time.Second, publisher.cfg.PollInterval)
 	require.Equal(t, 100, publisher.cfg.BatchSize)
 	require.Equal(t, 10, publisher.cfg.MaxDeliveryAttempts)
 }

--- a/darepod/rpc_oor_idempotency_test.go
+++ b/darepod/rpc_oor_idempotency_test.go
@@ -3,6 +3,7 @@ package darepod
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -27,6 +28,8 @@ import (
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type sendOORTestWallet struct {
@@ -113,6 +116,37 @@ func (h *sendOORNoopOutboxHandler) Handle(_ context.Context,
 	_ oor.SessionID, _ oor.OutboxEvent) ([]oor.Event, error) {
 
 	return nil, nil
+}
+
+type blockingSendOORActor struct {
+	once      sync.Once
+	started   chan struct{}
+	release   chan struct{}
+	completed chan struct{}
+	response  oor.ActorResp
+}
+
+func (a *blockingSendOORActor) Receive(ctx context.Context,
+	msg oor.OORDurableMsg) fn.Result[oor.ActorResp] {
+
+	if _, ok := msg.(*oor.StartTransferRequest); !ok {
+		return fn.Err[oor.ActorResp](
+			fmt.Errorf("unexpected OOR message %T", msg),
+		)
+	}
+
+	a.once.Do(func() {
+		close(a.started)
+	})
+	defer close(a.completed)
+
+	select {
+	case <-a.release:
+		return fn.Ok(a.response)
+
+	case <-ctx.Done():
+		return fn.Err[oor.ActorResp](ctx.Err())
+	}
 }
 
 // TestSendOORReturnsExistingIdempotencyKeyBeforeWalletSelection verifies a
@@ -333,6 +367,239 @@ func TestSendOORUnlocksSelectedInputsForExistingSession(t *testing.T) {
 		return len(batches[0]) == 1 &&
 			batches[0][0] == desc.Outpoint
 	}, 5*time.Second, 50*time.Millisecond)
+}
+
+// TestSendOORWaitDeadlineDoesNotUnlockSubmittedInputs verifies that once a
+// detached OOR actor Ask has been submitted, a caller wait deadline does not
+// release wallet-selected inputs while that actor work is still in flight.
+func TestSendOORWaitDeadlineDoesNotUnlockSubmittedInputs(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	recipientKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	const (
+		amountSat = int64(10000)
+		exitDelay = uint32(10)
+	)
+
+	vtxoStore, _ := newSendOORTestStores(t)
+
+	desc := newSendOORTestVTXO(
+		t, operatorKey.PubKey(), 0x31, btcutil.Amount(amountSat),
+	)
+	require.NoError(t, vtxoStore.SaveVTXO(ctx, desc))
+
+	testWallet := &sendOORTestWallet{
+		selections: [][]wallet.SelectedVTXO{
+			{selectedVTXOFromDescriptor(desc)},
+		},
+	}
+
+	system := actor.NewActorSystem()
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(
+			context.Background(), 5*time.Second,
+		)
+		defer cancel()
+
+		require.NoError(t, system.Shutdown(shutdownCtx))
+	})
+
+	walletKey := actor.NewServiceKey[
+		wallet.WalletMsg, wallet.WalletResp,
+	]("send-oor-deadline-test-wallet")
+	walletRef := walletKey.Spawn(
+		system, "send-oor-deadline-test-wallet", testWallet,
+	)
+
+	sessionHash := chainhash.HashH([]byte("send-oor-deadline-session"))
+	blockingActor := &blockingSendOORActor{
+		started:   make(chan struct{}),
+		release:   make(chan struct{}),
+		completed: make(chan struct{}),
+		response: &oor.StartTransferResponse{
+			SessionID: oor.SessionID(sessionHash),
+		},
+	}
+	oorKey := oor.NewServiceKey()
+	oorKey.Spawn(system, "send-oor-deadline-test-actor", blockingActor)
+
+	walletReady := make(chan struct{})
+	close(walletReady)
+
+	server := &Server{
+		cfg:         &Config{},
+		log:         btclog.Disabled,
+		walletReady: walletReady,
+		chainParams: &chaincfg.RegressionNetParams,
+		serverConn: newBufconnClient(t, &fakeArkService{
+			getInfoResponse: &arkrpc.GetInfoResponse{
+				Pubkey:        operatorKey.PubKey().SerializeCompressed(),
+				VtxoExitDelay: exitDelay,
+				DustLimit:     1,
+			},
+		}),
+		actorSystem: system,
+		vtxoStore:   vtxoStore,
+		walletRef:   fn.Some(walletRef),
+	}
+
+	rpcServer := NewRPCServer(server)
+	recipient := sendOORPolicyRecipient(
+		t, recipientKey.PubKey(), operatorKey.PubKey(),
+		exitDelay, amountSat,
+	)
+
+	waitCtx, cancel := context.WithTimeout(
+		context.Background(), 50*time.Millisecond,
+	)
+	defer cancel()
+
+	_, err = rpcServer.SendOOR(waitCtx, &daemonrpc.SendOORRequest{
+		Recipient: recipient,
+	})
+	require.Equal(t, codes.DeadlineExceeded, status.Code(err))
+
+	require.Eventually(t, func() bool {
+		select {
+		case <-blockingActor.started:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+	require.Empty(t, testWallet.unlockBatches())
+
+	close(blockingActor.release)
+	require.Eventually(t, func() bool {
+		select {
+		case <-blockingActor.completed:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+	require.Empty(t, testWallet.unlockBatches())
+}
+
+// TestSubmittedOORCleanupDefersCustomInputRelease verifies custom-input
+// double-use reservations are not released while a detached OOR actor future is
+// still in flight after the RPC caller stopped waiting.
+func TestSubmittedOORCleanupDefersCustomInputRelease(t *testing.T) {
+	t.Parallel()
+
+	rpcServer := &RPCServer{
+		server: &Server{
+			log: btclog.Disabled,
+		},
+		customInputLocks: make(map[wire.OutPoint]struct{}),
+	}
+
+	op := wire.OutPoint{
+		Hash:  chainhash.HashH([]byte("send-oor-custom-in-flight")),
+		Index: 0,
+	}
+
+	release, err := rpcServer.reserveCustomInputs([]wire.OutPoint{op})
+	require.NoError(t, err)
+
+	promise := actor.NewPromise[oor.ActorResp]()
+	rpcServer.cleanupSubmittedOORStart(
+		context.Background(), promise.Future(), nil, release,
+	)
+
+	_, err = rpcServer.reserveCustomInputs([]wire.OutPoint{op})
+	require.ErrorContains(t, err, "already reserved")
+
+	sessionHash := chainhash.HashH([]byte("send-oor-custom-complete"))
+	promise.Complete(fn.Ok[oor.ActorResp](&oor.StartTransferResponse{
+		SessionID: oor.SessionID(sessionHash),
+	}))
+
+	require.Eventually(t, func() bool {
+		release2, err := rpcServer.reserveCustomInputs(
+			[]wire.OutPoint{op},
+		)
+		if err != nil {
+			return false
+		}
+
+		defer release2()
+
+		return true
+	}, time.Second, 10*time.Millisecond)
+}
+
+// TestSubmittedOORCleanupTimeoutReleasesCustomInput verifies the detached OOR
+// cleanup waiter is bounded even if the actor future never completes.
+func TestSubmittedOORCleanupTimeoutReleasesCustomInput(t *testing.T) {
+	t.Parallel()
+
+	rpcServer := &RPCServer{
+		server: &Server{
+			log: btclog.Disabled,
+		},
+		customInputLocks: make(map[wire.OutPoint]struct{}),
+	}
+
+	op := wire.OutPoint{
+		Hash:  chainhash.HashH([]byte("send-oor-custom-timeout")),
+		Index: 0,
+	}
+
+	release, err := rpcServer.reserveCustomInputs([]wire.OutPoint{op})
+	require.NoError(t, err)
+
+	promise := actor.NewPromise[oor.ActorResp]()
+	rpcServer.cleanupSubmittedOORStartWithTimeout(
+		context.Background(), promise.Future(), nil, release,
+		10*time.Millisecond,
+	)
+
+	_, err = rpcServer.reserveCustomInputs([]wire.OutPoint{op})
+	require.ErrorContains(t, err, "already reserved")
+
+	require.Eventually(t, func() bool {
+		release2, err := rpcServer.reserveCustomInputs(
+			[]wire.OutPoint{op},
+		)
+		if err != nil {
+			return false
+		}
+
+		defer release2()
+
+		return true
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestIsAwaitContextError(t *testing.T) {
+	t.Parallel()
+
+	deadlineCtx, cancel := context.WithTimeout(
+		context.Background(), time.Nanosecond,
+	)
+	defer cancel()
+	<-deadlineCtx.Done()
+
+	require.True(t, isAwaitContextError(
+		deadlineCtx, context.DeadlineExceeded,
+	))
+	require.True(t, isAwaitContextError(
+		deadlineCtx, context.Canceled,
+	))
+	require.False(t, isAwaitContextError(
+		context.Background(), context.Canceled,
+	))
+	require.False(t, isAwaitContextError(
+		deadlineCtx, errors.New("actor failed"),
+	))
 }
 
 func newSendOORTestStores(t *testing.T) (

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -48,6 +48,14 @@ const (
 	// stream so a CLI disconnect does not cancel the unilateral-exit
 	// handoff.
 	manualUnrollAdmissionTimeout = 30 * time.Second
+
+	// submittedOORCleanupTimeout bounds the post-RPC cleanup waiter
+	// used after a detached OOR actor submit has been accepted but the
+	// caller stopped waiting for the response. The wait should normally
+	// end when the actor future completes or daemon shutdown fails
+	// pending futures; this ceiling prevents a pathological actor stall
+	// from retaining wallet/custom input reservations forever.
+	submittedOORCleanupTimeout = 10 * time.Minute
 )
 
 // RPCServer implements the daemon's gRPC DaemonService interface.
@@ -1427,6 +1435,18 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 	req *daemonrpc.SendOORRequest) (
 	*daemonrpc.SendOORResponse, error) {
 
+	startTime := time.Now()
+	var (
+		idempotencyDuration   time.Duration
+		resolveScriptDuration time.Duration
+		operatorTermsDuration time.Duration
+		policyResolveDuration time.Duration
+		inputSelectDuration   time.Duration
+		buildInputsDuration   time.Duration
+		changeOutputDuration  time.Duration
+		oorActorDuration      time.Duration
+	)
+
 	if err := r.requireWalletReady(); err != nil {
 		return nil, err
 	}
@@ -1442,9 +1462,11 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 	}
 
 	if req.GetIdempotencyKey() != "" && !req.DryRun {
+		phaseStart := time.Now()
 		key := req.GetIdempotencyKey()
 		sessionID, found, err :=
 			r.findOutgoingOORSessionByIdempotencyKey(ctx, key)
+		idempotencyDuration = time.Since(phaseStart)
 		if err != nil {
 			return nil, err
 		}
@@ -1465,7 +1487,9 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 	// Resolve the recipient's pkScript from the destination
 	// oneof. Pubkey destinations need operator terms to derive
 	// VTXO-compatible taproot outputs, so we pass a lazy fetcher.
+	phaseStart := time.Now()
 	pkScript, err := r.resolveOutputPkScript(ctx, req.Recipient)
+	resolveScriptDuration = time.Since(phaseStart)
 	if err != nil {
 		return nil, err
 	}
@@ -1494,7 +1518,9 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 	}
 
 	// Fetch operator terms for the checkpoint policy.
+	phaseStart = time.Now()
 	terms, err := r.server.fetchOperatorTerms(ctx)
+	operatorTermsDuration = time.Since(phaseStart)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal,
 			"unable to fetch operator terms: %v", err)
@@ -1505,20 +1531,25 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 		CSVDelay:    terms.VTXOExitDelay,
 	}
 
+	phaseStart = time.Now()
 	recipientPolicyTemplate, err := r.resolveOutputPolicyTemplate(
 		ctx, req.Recipient, pkScript, terms.PubKey,
 		terms.VTXOExitDelay,
 	)
+	policyResolveDuration = time.Since(phaseStart)
 	if err != nil {
 		return nil, err
 	}
 
 	var (
-		selectedInputs []oor.TransferInput
-		locked         *wallet.SelectAndLockVTXOsResponse
+		selectedInputs      []oor.TransferInput
+		locked              *wallet.SelectAndLockVTXOsResponse
+		customInputsRelease func()
+		releaseCustomInputs bool
 	)
 
 	if len(req.CustomInputs) > 0 {
+		phaseStart = time.Now()
 		// Custom inputs provided — bypass wallet selection and
 		// build TransferInputs from the specified VTXOs.
 		//
@@ -1532,7 +1563,10 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 		// same outpoint. We gate that race here with an
 		// in-memory reservation keyed by outpoint; the
 		// reservation is released regardless of success or
-		// failure via defer.
+		// failure via defer, unless the detached OOR actor submit has
+		// already been accepted and the caller only stopped waiting for
+		// its response. In that case the release is deferred until the
+		// actor future actually completes.
 		customOutpoints := make(
 			[]wire.OutPoint, 0, len(req.CustomInputs),
 		)
@@ -1554,19 +1588,29 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 				codes.Aborted,
 				"custom input double-use: %v", err)
 		}
-		defer release()
+		customInputsRelease = release
+		releaseCustomInputs = true
+		defer func() {
+			if releaseCustomInputs && customInputsRelease != nil {
+				customInputsRelease()
+			}
+		}()
+		inputSelectDuration = time.Since(phaseStart)
 
+		phaseStart = time.Now()
 		selectedInputs, err = BuildCustomTransferInputs(
 			ctx, r.server.vtxoStore, req.CustomInputs,
 			r.server.clientKeyDesc, terms.PubKey,
 			terms.VTXOExitDelay,
 		)
+		buildInputsDuration = time.Since(phaseStart)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal,
 				"build custom inputs: %v", err)
 		}
 	} else {
 		// Standard path: select and lock VTXOs from wallet.
+		phaseStart = time.Now()
 		targetAmt := btcutil.Amount(req.Recipient.AmountSat)
 		wRef := r.server.walletRef.UnsafeFromSome()
 
@@ -1589,6 +1633,7 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 				"unexpected response type: %T",
 				selectResp)
 		}
+		inputSelectDuration = time.Since(phaseStart)
 
 		outpoints := make(
 			[]wire.OutPoint, 0,
@@ -1600,9 +1645,11 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 			)
 		}
 
+		phaseStart = time.Now()
 		selectedInputs, err = BuildTransferInputs(
 			ctx, r.server.vtxoStore, outpoints,
 		)
+		buildInputsDuration = time.Since(phaseStart)
 		if err != nil {
 			r.unlockSelectedVTXOsBestEffort(ctx, locked)
 
@@ -1620,6 +1667,7 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 		VTXOPolicyTemplate: recipientPolicyTemplate,
 	}}
 
+	phaseStart = time.Now()
 	inputTotal, err := sumOORInputAmounts(selectedInputs)
 	if err != nil {
 		r.unlockSelectedVTXOsBestEffort(ctx, locked)
@@ -1643,6 +1691,7 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 
 		return nil, err
 	}
+	changeOutputDuration = time.Since(phaseStart)
 
 	// Resolve the OOR actor via the service key registered in the
 	// actor system's receptionist. This avoids holding a direct
@@ -1658,11 +1707,29 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 		IdempotencyKey: req.GetIdempotencyKey(),
 	}
 
-	future := oorRef.Ask(ctx, oorReq)
+	phaseStart = time.Now()
+	oorCtx := actor.WithoutTx(context.WithoutCancel(ctx))
+	future := oorRef.Ask(oorCtx, oorReq)
 	oorResult := future.Await(ctx)
+	oorActorDuration = time.Since(phaseStart)
 
 	oorResp, err := oorResult.Unpack()
 	if err != nil {
+		if isAwaitContextError(ctx, err) {
+			releaseCustomInputs = false
+			r.cleanupSubmittedOORStart(
+				ctx, future, locked, customInputsRelease,
+			)
+
+			code := codes.Canceled
+			if errors.Is(err, context.DeadlineExceeded) {
+				code = codes.DeadlineExceeded
+			}
+
+			return nil, status.Errorf(code,
+				"OOR transfer response wait: %v", err)
+		}
+
 		// Unlock VTXOs on OOR failure so they can be
 		// reused (only for wallet-selected inputs).
 		r.unlockSelectedVTXOsBestEffort(ctx, locked)
@@ -1689,7 +1756,22 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 		slog.Int64("amount_sat", req.Recipient.AmountSat),
 		slog.Int64("input_total_sat", int64(inputTotal)),
 		slog.Int64("change_sat", int64(changeAmt)),
-		slog.Int("recipient_count", len(recipients)))
+		slog.Int("recipient_count", len(recipients)),
+		slog.Duration("duration", time.Since(startTime)),
+		slog.Duration("idempotency_duration", idempotencyDuration),
+		slog.Duration("resolve_script_duration",
+			resolveScriptDuration),
+		slog.Duration("operator_terms_duration",
+			operatorTermsDuration),
+		slog.Duration("policy_resolve_duration",
+			policyResolveDuration),
+		slog.Duration("input_select_duration",
+			inputSelectDuration),
+		slog.Duration("build_inputs_duration",
+			buildInputsDuration),
+		slog.Duration("change_output_duration",
+			changeOutputDuration),
+		slog.Duration("oor_actor_duration", oorActorDuration))
 
 	return &daemonrpc.SendOORResponse{
 		Status:    "submitted",
@@ -1800,6 +1882,87 @@ func (r *RPCServer) unlockSelectedVTXOsBestEffort(ctx context.Context,
 	if unlockErr != nil {
 		r.server.log.ErrorS(ctx, "Unable to unlock VTXOs", unlockErr)
 	}
+}
+
+// isAwaitContextError returns true when a future await stopped because the
+// caller's wait context ended, rather than because the submitted actor work
+// completed with a real result.
+func isAwaitContextError(ctx context.Context, err error) bool {
+	if ctx.Err() == nil {
+		return false
+	}
+
+	return errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded)
+}
+
+// cleanupSubmittedOORStart waits for a detached OOR start future to finish
+// after the RPC caller stopped waiting. Once the actor has actually completed,
+// cleanup follows the same rules as the synchronous path: wallet-selected
+// inputs are unlocked only on actor failure or duplicate/existing sessions,
+// while custom input reservations are released when the in-flight actor start
+// is no longer using the RPC-level double-use guard.
+func (r *RPCServer) cleanupSubmittedOORStart(ctx context.Context,
+	future actor.Future[oor.ActorResp],
+	locked *wallet.SelectAndLockVTXOsResponse, releaseCustomInputs func()) {
+
+	r.cleanupSubmittedOORStartWithTimeout(
+		ctx, future, locked, releaseCustomInputs,
+		submittedOORCleanupTimeout,
+	)
+}
+
+func (r *RPCServer) cleanupSubmittedOORStartWithTimeout(ctx context.Context,
+	future actor.Future[oor.ActorResp],
+	locked *wallet.SelectAndLockVTXOsResponse,
+	releaseCustomInputs func(), timeout time.Duration) {
+
+	cleanupCtx, cancel := context.WithTimeout(
+		context.WithoutCancel(ctx), timeout,
+	)
+
+	go func() {
+		defer cancel()
+
+		oorResult := future.Await(cleanupCtx)
+		oorResp, err := oorResult.Unpack()
+		if err != nil {
+			if cleanupCtx.Err() != nil {
+				r.server.log.ErrorS(
+					cleanupCtx,
+					"Timed out waiting for detached OOR "+
+						"submit cleanup",
+					err,
+					slog.Duration("timeout", timeout),
+				)
+			}
+
+			r.unlockSelectedVTXOsBestEffort(cleanupCtx, locked)
+			if releaseCustomInputs != nil {
+				releaseCustomInputs()
+			}
+
+			return
+		}
+
+		resp, ok := oorResp.(*oor.StartTransferResponse)
+		if !ok {
+			r.unlockSelectedVTXOsBestEffort(cleanupCtx, locked)
+			if releaseCustomInputs != nil {
+				releaseCustomInputs()
+			}
+
+			return
+		}
+
+		if resp.Existing {
+			r.unlockSelectedVTXOsBestEffort(cleanupCtx, locked)
+		}
+
+		if releaseCustomInputs != nil {
+			releaseCustomInputs()
+		}
+	}()
 }
 
 // unlockVTXOs sends an UnlockVTXOsRequest to the wallet actor for the

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -3262,9 +3262,11 @@ func (s *Server) initOORActor(ctx context.Context,
 
 	// Wire spend completion through the VTXO manager so each consumed
 	// VTXO transitions to SpentState via its own FSM, rather than
-	// writing VTXOStatusSpent directly to the store. Wait for the
-	// manager response so OOR only checkpoints Completed after the
-	// VTXO actor has durably persisted the spent status.
+	// writing VTXOStatusSpent directly to the store. This synchronous
+	// Ask intentionally keeps the OOR transaction in scope: the manager
+	// and VTXO actor complete before the durable OOR turn can commit or
+	// roll back, avoiding a second SQLite writer inside the same local
+	// completion step.
 	mgrKey := actormsg.VTXOManagerServiceKey()
 	completeSpend := func(ctx context.Context,
 		outpoints []wire.OutPoint) error {

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -222,6 +222,8 @@ type Server struct {
 	ark     *arkrpc.ArkServiceMailboxClient
 	indexer *indexer.Client
 
+	outboxPublisher *actor.OutboxPublisher
+
 	// proofKeyBackend derives wallet-managed keys and produces proof
 	// signers for daemon-owned receive scripts and indexer identity.
 	proofKeyBackend proofkeys.Backend
@@ -743,6 +745,10 @@ func (s *Server) run(ctx context.Context,
 					ctx, "OOR actor shutdown failed", err,
 				)
 			}
+		}
+
+		if s.outboxPublisher != nil {
+			s.outboxPublisher.Stop()
 		}
 
 		if s.runtime != nil {
@@ -2702,6 +2708,54 @@ func (s *Server) initRPCClients(ctx context.Context) {
 	s.log.InfoS(ctx, "RPC clients initialized")
 }
 
+// startActorOutboxPublisher registers the serverconn durable actor under the
+// type-erased key used by the actor outbox publisher, then starts the shared
+// publisher loop. OOR transport handoff uses this path so the OOR actor can
+// commit its own state before serverconn mailbox enqueue runs.
+func (s *Server) startActorOutboxPublisher(ctx context.Context) error {
+	if s.runtime == nil {
+		return fmt.Errorf("serverconn runtime must be initialized")
+	}
+
+	if s.actorSystem == nil {
+		return fmt.Errorf("actor system must be initialized")
+	}
+
+	if s.deliveryStore == nil {
+		return fmt.Errorf("delivery store must be initialized")
+	}
+
+	serverConnRef := s.runtime.Ref()
+	erasingRef := actor.TypeAssertingRef[
+		actor.Message,
+		serverconn.ServerConnMsg,
+		serverconn.ServerConnResp,
+	](serverConnRef)
+
+	key := actor.NewServiceKey[actor.Message, any](serverConnRef.ID())
+	if err := actor.RegisterWithReceptionist(
+		s.actorSystem.Receptionist(), key, erasingRef,
+	); err != nil {
+		return fmt.Errorf("register serverconn outbox target: %w", err)
+	}
+
+	codec := serverconn.NewServerConnCodec()
+	codec.MustRegister(actor.AskResponseMsgType, func() actor.TLVMessage {
+		return &actor.AskResponse{}
+	})
+
+	cfg := actor.DefaultOutboxPublisherConfig(
+		s.deliveryStore, codec, s.actorSystem,
+	)
+	s.outboxPublisher = actor.NewOutboxPublisher(cfg)
+	s.outboxPublisher.Start()
+
+	s.log.InfoS(ctx, "Actor outbox publisher started",
+		slog.String("serverconn_target", serverConnRef.ID()))
+
+	return nil
+}
+
 // connectAndBootstrapMailbox derives the identity key, connects to the
 // ark operator, fetches the operator pubkey, and wires the mailbox
 // transport runtime. This is called synchronously for LND (wallet
@@ -2787,6 +2841,10 @@ func (s *Server) connectAndBootstrapMailbox(
 	// are registered. On restart the remote mailbox may already contain
 	// queued server-push envelopes targeting the round or OOR actors.
 	s.runtime.StartEgress()
+
+	if err := s.startActorOutboxPublisher(ctx); err != nil {
+		return err
+	}
 
 	s.log.InfoS(ctx, "Mailbox transport runtime started",
 		slog.String("local_mailbox", s.localMailboxID),
@@ -3236,16 +3294,17 @@ func (s *Server) initOORActor(ctx context.Context,
 	}
 
 	s.oorActor = oor.NewOORClientActor(oor.ClientActorCfg{
-		Log:           fn.Some(s.subLogger(oor.Subsystem)),
-		OutboxHandler: outboxHandler,
-		ServerConn:    s.runtime.TellRef(),
-		PackageStore:  packageStore,
-		DeliveryStore: s.deliveryStore,
-		ActorSystem:   s.actorSystem,
-		ActorID:       oor.OORActorServiceKeyName,
-		VTXOManager:   vtxoManagerRef,
-		VTXOStore:     vtxoStore,
-		LedgerSink:    fn.Some(ledger.NewSink(s.actorSystem)),
+		Log:             fn.Some(s.subLogger(oor.Subsystem)),
+		OutboxHandler:   outboxHandler,
+		ServerConn:      s.runtime.TellRef(),
+		TransportOutbox: true,
+		PackageStore:    packageStore,
+		DeliveryStore:   s.deliveryStore,
+		ActorSystem:     s.actorSystem,
+		ActorID:         oor.OORActorServiceKeyName,
+		VTXOManager:     vtxoManagerRef,
+		VTXOStore:       vtxoStore,
+		LedgerSink:      fn.Some(ledger.NewSink(s.actorSystem)),
 	})
 
 	// Wire the timeout callback ref using the registered service

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -244,7 +244,8 @@ type Server struct {
 	walletRef    fn.Option[actor.ActorRef[
 		wallet.WalletMsg, wallet.WalletResp,
 	]]
-	oorActor *oor.OORClientActor
+	oorActor         *oor.OORClientActor
+	oorSigningEffect *oor.SigningEffectActor
 
 	// ledgerStore exposes the client-side ledger DB adapter for
 	// read-only RPC handlers (GetFeeHistory). Writes go through
@@ -736,6 +737,16 @@ func (s *Server) run(ctx context.Context,
 
 		if s.unrollRegistry != nil {
 			s.unrollRegistry.Stop()
+		}
+
+		if s.oorSigningEffect != nil {
+			err := s.oorSigningEffect.StopAndWait(shutdownCtx)
+			if err != nil {
+				s.log.WarnS(
+					ctx, "OOR signing effect shutdown failed",
+					err,
+				)
+			}
 		}
 
 		if s.oorActor != nil {
@@ -2740,6 +2751,10 @@ func (s *Server) startActorOutboxPublisher(ctx context.Context) error {
 	}
 
 	codec := serverconn.NewServerConnCodec()
+	// The shared publisher decodes serverconn outbox entries, signing
+	// effect entries, and durable ask responses. MustRegister panics if a
+	// future TLV type collides across those message sets.
+	oor.RegisterSigningEffectMessages(codec)
 	codec.MustRegister(actor.AskResponseMsgType, func() actor.TLVMessage {
 		return &actor.AskResponse{}
 	})
@@ -3228,6 +3243,22 @@ func (s *Server) initOORActor(ctx context.Context,
 		Signer:       oorSigner,
 		TimeoutActor: oorTimeoutRef,
 	}
+	oorKey := oor.NewServiceKey()
+
+	var err error
+	s.oorSigningEffect, err = oor.NewSigningEffectActor(
+		oor.SigningEffectActorConfig{
+			ActorID:       oor.SigningEffectActorID,
+			DeliveryStore: s.deliveryStore,
+			Signer:        oorSigner,
+			OORRef:        oorKey.Ref(s.actorSystem),
+			ActorSystem:   s.actorSystem,
+			Log:           fn.Some(s.subLogger(oor.Subsystem)),
+		},
+	)
+	if err != nil {
+		return err
+	}
 
 	// Wire spend completion through the VTXO manager so each consumed
 	// VTXO transitions to SpentState via its own FSM, rather than
@@ -3298,6 +3329,7 @@ func (s *Server) initOORActor(ctx context.Context,
 		OutboxHandler:   outboxHandler,
 		ServerConn:      s.runtime.TellRef(),
 		TransportOutbox: true,
+		SigningEffect:   s.oorSigningEffect.Ref(),
 		PackageStore:    packageStore,
 		DeliveryStore:   s.deliveryStore,
 		ActorSystem:     s.actorSystem,
@@ -3314,7 +3346,6 @@ func (s *Server) initOORActor(ctx context.Context,
 	// OOR actor via the receptionist, and the MapInputRef
 	// transforms *timeout.ExpiredMsg into a DriveEventRequest
 	// with RetryDueEvent targeting the correct session.
-	oorKey := oor.NewServiceKey()
 	signingHandler.CallbackRef = oor.NewRetryCallbackRef(
 		oorKey.Ref(s.actorSystem),
 	)

--- a/db/actordelivery/store_impl.go
+++ b/db/actordelivery/store_impl.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"sync"
 	"time"
 
 	"github.com/lightninglabs/darepo-client/baselib/actor"
@@ -114,6 +115,9 @@ type BatchedActorDeliveryQueries interface {
 type Store struct {
 	db    BatchedActorDeliveryQueries
 	clock clock.Clock
+
+	outboxWakeMu sync.Mutex
+	outboxWakes  []func()
 }
 
 // NewStore creates a new actor delivery store using the
@@ -448,7 +452,7 @@ func (s *Store) EnqueueOutbox(
 
 	writeTxOpts := db.WriteTxOption()
 
-	return s.db.ExecTx(
+	err := s.db.ExecTx(
 		ctx,
 		writeTxOpts,
 		func(q ActorDeliveryQueries) error {
@@ -464,6 +468,36 @@ func (s *Store) EnqueueOutbox(
 			})
 		},
 	)
+	if err != nil {
+		return err
+	}
+
+	s.notifyOutboxWake()
+
+	return nil
+}
+
+// RegisterOutboxWake registers a same-process callback that runs after outbox
+// work commits. The publisher still polls as the durable fallback.
+func (s *Store) RegisterOutboxWake(wake func()) {
+	if wake == nil {
+		return
+	}
+
+	s.outboxWakeMu.Lock()
+	defer s.outboxWakeMu.Unlock()
+
+	s.outboxWakes = append(s.outboxWakes, wake)
+}
+
+func (s *Store) notifyOutboxWake() {
+	s.outboxWakeMu.Lock()
+	wakes := append([]func(){}, s.outboxWakes...)
+	s.outboxWakeMu.Unlock()
+
+	for _, wake := range wakes {
+		wake()
+	}
 }
 
 // ClaimOutboxBatch claims a batch of pending outbox messages for delivery.
@@ -873,17 +907,21 @@ type TxActorDeliveryStore struct {
 	querier ActorDeliveryQueries
 	clock   clock.Clock
 	tx      *sql.Tx
+
+	outboxEnqueued *bool
 }
 
 // newTxActorDeliveryStore creates a new transaction-scoped delivery store.
 func newTxActorDeliveryStore(
 	querier ActorDeliveryQueries, clock clock.Clock, tx *sql.Tx,
+	outboxEnqueued *bool,
 ) *TxActorDeliveryStore {
 
 	return &TxActorDeliveryStore{
-		querier: querier,
-		clock:   clock,
-		tx:      tx,
+		querier:        querier,
+		clock:          clock,
+		tx:             tx,
+		outboxEnqueued: outboxEnqueued,
 	}
 }
 
@@ -1072,7 +1110,7 @@ func (s *TxActorDeliveryStore) EnqueueOutbox(
 	ctx context.Context, params actor.OutboxParams,
 ) error {
 
-	return s.querier.EnqueueOutboxMessage(ctx, EnqueueOutboxParams{
+	err := s.querier.EnqueueOutboxMessage(ctx, EnqueueOutboxParams{
 		ID:            params.ID,
 		SourceActorID: params.SourceActorID,
 		TargetActorID: params.TargetActorID,
@@ -1082,6 +1120,15 @@ func (s *TxActorDeliveryStore) EnqueueOutbox(
 		Version:       int32(params.Version),
 		CreatedAt:     s.clock.Now().Unix(),
 	})
+	if err != nil {
+		return err
+	}
+
+	if s.outboxEnqueued != nil {
+		*s.outboxEnqueued = true
+	}
+
+	return nil
 }
 
 // ClaimOutboxBatch claims a batch of pending outbox messages for delivery.
@@ -1355,7 +1402,10 @@ func (s *TxAwareActorDeliveryStore) ExecTx(
 
 	// Create a transaction-scoped queries object.
 	txQuerier := adsqlc.New(tx)
-	txStore := newTxActorDeliveryStore(txQuerier, s.clock, tx)
+	outboxEnqueued := false
+	txStore := newTxActorDeliveryStore(
+		txQuerier, s.clock, tx, &outboxEnqueued,
+	)
 
 	// Attach transaction to context.
 	txCtx := actor.WithTx(ctx, tx)
@@ -1365,11 +1415,22 @@ func (s *TxAwareActorDeliveryStore) ExecTx(
 		return err
 	}
 
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+
+	if outboxEnqueued {
+		s.notifyOutboxWake()
+	}
+
+	return nil
 }
 
 // Compile-time check that Store implements actor.DeliveryStore.
 var _ actor.DeliveryStore = (*Store)(nil)
+
+// Compile-time check that Store can wake same-process outbox publishers.
+var _ actor.OutboxWakeRegistrar = (*Store)(nil)
 
 // Compile-time check that TxAwareActorDeliveryStore implements
 // actor.TxAwareDeliveryStore.

--- a/db/actordelivery/store_impl_test.go
+++ b/db/actordelivery/store_impl_test.go
@@ -1,9 +1,11 @@
 package actordelivery
 
 import (
+	"context"
 	"crypto/rand"
 	"database/sql"
 	"encoding/hex"
+	"errors"
 	"testing"
 	"time"
 
@@ -43,6 +45,25 @@ func newActorDeliveryStoreForTest(t *testing.T) *testActorDeliveryStore {
 		Store: NewStore(actorDB, testClock),
 		clock: testClock,
 	}
+}
+
+func newTxAwareActorDeliveryStoreForTest(
+	t *testing.T) *TxAwareActorDeliveryStore {
+
+	testDB := db.NewTestDB(t)
+	actorQueries := adsqlc.New(testDB.DB)
+
+	actorDB := db.NewTransactionExecutor(
+		testDB.BaseDB,
+		func(tx *sql.Tx) ActorDeliveryQueries {
+			return actorQueries.WithTx(tx)
+		},
+		btclog.Disabled,
+	)
+
+	return NewTxAwareActorDeliveryStore(
+		actorDB, testDB.BaseDB, clock.NewTestClock(time.Now()),
+	)
 }
 
 // generateTestID generates a random 16-byte hex-encoded ID for testing.
@@ -400,6 +421,68 @@ func TestActorDeliveryStoreOutbox(t *testing.T) {
 	// Fail another with matching claim token.
 	err = store.FailOutbox(ctx, batch[1].ID, claimToken)
 	require.NoError(t, err)
+}
+
+// TestTxAwareActorDeliveryStoreOutboxWake verifies that transaction-scoped
+// outbox writes wake same-process publishers after the transaction commits.
+func TestTxAwareActorDeliveryStoreOutboxWake(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := newTxAwareActorDeliveryStoreForTest(t)
+	wakeChan := make(chan struct{}, 1)
+	store.RegisterOutboxWake(func() {
+		select {
+		case wakeChan <- struct{}{}:
+		default:
+		}
+	})
+
+	rollbackErr := errors.New("rollback")
+	err := store.ExecTx(ctx, false, func(
+		txCtx context.Context, txStore actor.DeliveryStore,
+	) error {
+
+		err := txStore.EnqueueOutbox(txCtx, actor.OutboxParams{
+			ID:            generateTestID(),
+			SourceActorID: "round-actor",
+			TargetActorID: "wallet-actor",
+			MessageType:   "round.SignRequest",
+			Payload:       []byte{1},
+		})
+		require.NoError(t, err)
+
+		return rollbackErr
+	})
+	require.ErrorIs(t, err, rollbackErr)
+
+	select {
+	case <-wakeChan:
+		t.Fatal("rollback should not wake outbox publisher")
+
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	err = store.ExecTx(ctx, false, func(
+		txCtx context.Context, txStore actor.DeliveryStore,
+	) error {
+
+		return txStore.EnqueueOutbox(txCtx, actor.OutboxParams{
+			ID:            generateTestID(),
+			SourceActorID: "round-actor",
+			TargetActorID: "wallet-actor",
+			MessageType:   "round.SignRequest",
+			Payload:       []byte{2},
+		})
+	})
+	require.NoError(t, err)
+
+	select {
+	case <-wakeChan:
+
+	case <-time.After(time.Second):
+		t.Fatal("commit did not wake outbox publisher")
+	}
 }
 
 // TestActorDeliveryStoreDeduplication tests deduplication operations.

--- a/db/ancestry_codec.go
+++ b/db/ancestry_codec.go
@@ -2,12 +2,17 @@ package db
 
 import (
 	"context"
+	"crypto/sha256"
+	"errors"
 	"fmt"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/db/sqlc"
+	"github.com/lightninglabs/darepo-client/lib/tree"
 	"github.com/lightninglabs/darepo-client/vtxo"
+	"github.com/lightninglabs/neutrino/cache"
+	"github.com/lightninglabs/neutrino/cache/lru"
 )
 
 // ancestry_codec.go converts between vtxo.Ancestry slices and the
@@ -48,6 +53,74 @@ type ancestryStore interface {
 // Go-side check fails earlier with a clearer error than a sqlite/pg
 // constraint violation.
 const maxAncestryRowsPerVTXO = 64
+
+// maxAncestryTreeCacheEntries bounds the process-local decoded ancestry
+// tree cache by entry count. Trees are immutable once committed, so
+// eviction is opportunistic: a miss simply re-decodes the tree from durable
+// storage.
+const maxAncestryTreeCacheEntries = 4096
+
+type ancestryTreeCacheValue struct {
+	tree *tree.Tree
+}
+
+func (v *ancestryTreeCacheValue) Size() (uint64, error) {
+	return 1, nil
+}
+
+type ancestryTreeCache struct {
+	trees *lru.Cache[[sha256.Size]byte, *ancestryTreeCacheValue]
+}
+
+// newAncestryTreeCache creates a process-local decode cache for finalized
+// VTXO ancestry trees. Tree paths are immutable once committed; callers must
+// treat cached *tree.Tree values as read-only.
+func newAncestryTreeCache() *ancestryTreeCache {
+	return newAncestryTreeCacheWithLimit(maxAncestryTreeCacheEntries)
+}
+
+func newAncestryTreeCacheWithLimit(maxEntries int) *ancestryTreeCache {
+	if maxEntries <= 0 {
+		return &ancestryTreeCache{}
+	}
+
+	return &ancestryTreeCache{
+		trees: lru.NewCache[
+			[sha256.Size]byte, *ancestryTreeCacheValue,
+		](uint64(maxEntries)),
+	}
+}
+
+func (c *ancestryTreeCache) getOrDecode(
+	treePath []byte) (*tree.Tree, error) {
+
+	if c == nil || c.trees == nil {
+		return DeserializeTree(treePath)
+	}
+
+	key := sha256.Sum256(treePath)
+
+	cached, err := c.trees.Get(key)
+	switch {
+	case err == nil:
+		return cached.tree, nil
+
+	case !errors.Is(err, cache.ErrElementNotFound):
+		return nil, fmt.Errorf("get ancestry tree cache: %w", err)
+	}
+
+	t, err := DeserializeTree(treePath)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = c.trees.Put(key, &ancestryTreeCacheValue{tree: t})
+	if err != nil {
+		return nil, fmt.Errorf("put ancestry tree cache: %w", err)
+	}
+
+	return t, nil
+}
 
 // upsertAncestryPaths replaces the persisted ancestry rows for one VTXO
 // with the supplied slice. Must be called inside the same transaction
@@ -146,6 +219,15 @@ func upsertAncestryPaths(ctx context.Context, q ancestryStore,
 func loadAncestryPaths(ctx context.Context, q ancestryStore,
 	outpointHash []byte, outpointIndex int32) ([]vtxo.Ancestry, error) {
 
+	return loadAncestryPathsWithCache(
+		ctx, q, outpointHash, outpointIndex, nil,
+	)
+}
+
+func loadAncestryPathsWithCache(ctx context.Context, q ancestryStore,
+	outpointHash []byte, outpointIndex int32,
+	cache *ancestryTreeCache) ([]vtxo.Ancestry, error) {
+
 	rows, err := q.ListVTXOAncestryPaths(
 		ctx, sqlc.ListVTXOAncestryPathsParams{
 			VtxoOutpointHash:  outpointHash,
@@ -162,7 +244,7 @@ func loadAncestryPaths(ctx context.Context, q ancestryStore,
 
 	out := make([]vtxo.Ancestry, 0, len(rows))
 	for i, row := range rows {
-		entry, err := ancestryRowToDomain(row)
+		entry, err := ancestryRowToDomain(row, cache)
 		if err != nil {
 			return nil, fmt.Errorf(
 				"decode ancestry row[%d]: %w", i, err,
@@ -189,13 +271,19 @@ func loadAncestryPaths(ctx context.Context, q ancestryStore,
 func groupAncestryRows(rows []sqlc.VtxoAncestryPath) (
 	map[wire.OutPoint][]vtxo.Ancestry, error) {
 
+	return groupAncestryRowsWithCache(rows, nil)
+}
+
+func groupAncestryRowsWithCache(rows []sqlc.VtxoAncestryPath,
+	cache *ancestryTreeCache) (map[wire.OutPoint][]vtxo.Ancestry, error) {
+
 	if len(rows) == 0 {
 		return nil, nil
 	}
 
 	out := make(map[wire.OutPoint][]vtxo.Ancestry)
 	for i, row := range rows {
-		entry, err := ancestryRowToDomain(row)
+		entry, err := ancestryRowToDomain(row, cache)
 		if err != nil {
 			return nil, fmt.Errorf(
 				"decode ancestry row[%d]: %w", i, err,
@@ -221,7 +309,9 @@ func groupAncestryRows(rows []sqlc.VtxoAncestryPath) (
 
 // ancestryRowToDomain decodes one sqlc VtxoAncestryPath row into
 // vtxo.Ancestry, including deserializing the embedded tree fragment.
-func ancestryRowToDomain(row sqlc.VtxoAncestryPath) (vtxo.Ancestry, error) {
+func ancestryRowToDomain(row sqlc.VtxoAncestryPath,
+	cache *ancestryTreeCache) (vtxo.Ancestry, error) {
+
 	var entry vtxo.Ancestry
 
 	if len(row.CommitmentTxid) != len(entry.CommitmentTxID) {
@@ -243,7 +333,7 @@ func ancestryRowToDomain(row sqlc.VtxoAncestryPath) (vtxo.Ancestry, error) {
 	entry.InputIndices = indices
 
 	if len(row.TreePath) > 0 {
-		t, err := DeserializeTree(row.TreePath)
+		t, err := cache.getOrDecode(row.TreePath)
 		if err != nil {
 			return vtxo.Ancestry{}, fmt.Errorf(
 				"deserialize tree: %w", err,

--- a/db/ancestry_codec_test.go
+++ b/db/ancestry_codec_test.go
@@ -2,11 +2,15 @@ package db
 
 import (
 	"context"
+	"crypto/sha256"
+	"errors"
 	"testing"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/lightninglabs/darepo-client/db/sqlc"
+	"github.com/lightninglabs/darepo-client/lib/tree"
 	"github.com/lightninglabs/darepo-client/vtxo"
+	"github.com/lightninglabs/neutrino/cache"
 	"github.com/stretchr/testify/require"
 )
 
@@ -133,4 +137,47 @@ func TestUpsertAncestryPathsAcceptsValid(t *testing.T) {
 			"path_order must be contiguous 0..N-1",
 		)
 	}
+}
+
+// TestAncestryTreeCacheEvictsLeastRecentlyUsed verifies the decoded tree cache
+// is bounded and refreshes LRU order on reads.
+func TestAncestryTreeCacheEvictsLeastRecentlyUsed(t *testing.T) {
+	t.Parallel()
+
+	treeCache := newAncestryTreeCacheWithLimit(2)
+	key1 := sha256.Sum256([]byte("tree-1"))
+	key2 := sha256.Sum256([]byte("tree-2"))
+	key3 := sha256.Sum256([]byte("tree-3"))
+	tree1 := &tree.Tree{}
+	tree2 := &tree.Tree{}
+	tree3 := &tree.Tree{}
+
+	_, err := treeCache.trees.Put(
+		key1, &ancestryTreeCacheValue{tree: tree1},
+	)
+	require.NoError(t, err)
+	_, err = treeCache.trees.Put(
+		key2, &ancestryTreeCacheValue{tree: tree2},
+	)
+	require.NoError(t, err)
+
+	got, err := treeCache.trees.Get(key1)
+	require.NoError(t, err)
+	require.Same(t, tree1, got.tree)
+
+	_, err = treeCache.trees.Put(
+		key3, &ancestryTreeCacheValue{tree: tree3},
+	)
+	require.NoError(t, err)
+
+	_, err = treeCache.trees.Get(key2)
+	require.True(t, errors.Is(err, cache.ErrElementNotFound))
+
+	got, err = treeCache.trees.Get(key1)
+	require.NoError(t, err)
+	require.Same(t, tree1, got.tree)
+
+	got, err = treeCache.trees.Get(key3)
+	require.NoError(t, err)
+	require.Same(t, tree3, got.tree)
 }

--- a/db/vtxo_store.go
+++ b/db/vtxo_store.go
@@ -32,6 +32,10 @@ type VTXOPersistenceStore struct {
 	// clock provides time for timestamps.
 	clock clock.Clock
 
+	// ancestryCache aliases immutable decoded ancestry tree fragments
+	// across repeated list and selection queries.
+	ancestryCache *ancestryTreeCache
+
 	// Log is an optional logger for this persistence store. If None,
 	// the store falls back to extracting a logger from context via
 	// build.LoggerFromContext, or uses btclog.Disabled if no logger
@@ -50,8 +54,9 @@ func NewVTXOPersistenceStore(
 ) *VTXOPersistenceStore {
 
 	return &VTXOPersistenceStore{
-		db:    db,
-		clock: c,
+		db:            db,
+		clock:         c,
+		ancestryCache: newAncestryTreeCache(),
 	}
 }
 
@@ -62,9 +67,10 @@ func NewVTXOPersistenceStoreWithLogger(
 	log fn.Option[btclog.Logger]) *VTXOPersistenceStore {
 
 	return &VTXOPersistenceStore{
-		db:    db,
-		clock: c,
-		Log:   log,
+		db:            db,
+		clock:         c,
+		ancestryCache: newAncestryTreeCache(),
+		Log:           log,
 	}
 }
 
@@ -213,7 +219,9 @@ func (s *VTXOPersistenceStore) ListLiveVTXOs(
 			)
 		}
 
-		ancestryByOutpoint, err := groupAncestryRows(ancestryRows)
+		ancestryByOutpoint, err := groupAncestryRowsWithCache(
+			ancestryRows, s.ancestryCache,
+		)
 		if err != nil {
 			return fmt.Errorf("group ancestry rows: %w", err)
 		}
@@ -266,7 +274,9 @@ func (s *VTXOPersistenceStore) ListVTXOsByStatus(
 			)
 		}
 
-		ancestryByOutpoint, err := groupAncestryRows(ancestryRows)
+		ancestryByOutpoint, err := groupAncestryRowsWithCache(
+			ancestryRows, s.ancestryCache,
+		)
 		if err != nil {
 			return fmt.Errorf("group ancestry rows: %w", err)
 		}
@@ -538,8 +548,9 @@ func (s *VTXOPersistenceStore) rowToDescriptor(ctx context.Context,
 	if preloaded != nil {
 		ancestry = preloaded[outpoint]
 	} else {
-		ancestry, err = loadAncestryPaths(
+		ancestry, err = loadAncestryPathsWithCache(
 			ctx, q, row.OutpointHash, row.OutpointIndex,
+			s.ancestryCache,
 		)
 		if err != nil {
 			return nil, fmt.Errorf(

--- a/db/vtxo_store_test.go
+++ b/db/vtxo_store_test.go
@@ -805,6 +805,66 @@ func TestGroupAncestryRowsPreservesOrder(t *testing.T) {
 	require.Equal(t, byte(0x21), groups[keyB][1].CommitmentTxID[0])
 }
 
+// TestGroupAncestryRowsCachesTreePaths verifies that repeated serialized
+// ancestry tree fragments alias one decoded immutable tree.
+func TestGroupAncestryRowsCachesTreePaths(t *testing.T) {
+	t.Parallel()
+
+	var hash chainhash.Hash
+	hash[0] = 0x01
+	treePath := &tree.Tree{
+		BatchOutpoint: wire.OutPoint{Hash: hash, Index: 0},
+		Root: &tree.Node{
+			Input:     wire.OutPoint{Hash: hash, Index: 0},
+			Outputs:   []*wire.TxOut{},
+			CoSigners: []*btcec.PublicKey{},
+			Children:  make(map[uint32]*tree.Node),
+		},
+	}
+
+	treeBytes, err := SerializeTree(treePath)
+	require.NoError(t, err)
+
+	makeRow := func(hashByte byte, commitByte byte) sqlc.VtxoAncestryPath {
+		var op chainhash.Hash
+		op[0] = hashByte
+		var commitTx chainhash.Hash
+		commitTx[0] = commitByte
+
+		return sqlc.VtxoAncestryPath{
+			VtxoOutpointHash:  op[:],
+			VtxoOutpointIndex: 0,
+			PathOrder:         0,
+			CommitmentTxid:    commitTx[:],
+			TreePath:          treeBytes,
+			TreeDepth:         1,
+			InputIndices:      encodeUint32SliceBE(nil),
+		}
+	}
+
+	groups, err := groupAncestryRowsWithCache(
+		[]sqlc.VtxoAncestryPath{
+			makeRow(0xa1, 0x10),
+			makeRow(0xb2, 0x20),
+		},
+		newAncestryTreeCache(),
+	)
+	require.NoError(t, err)
+
+	var hashA chainhash.Hash
+	hashA[0] = 0xa1
+	keyA := wire.OutPoint{Hash: hashA, Index: 0}
+
+	var hashB chainhash.Hash
+	hashB[0] = 0xb2
+	keyB := wire.OutPoint{Hash: hashB, Index: 0}
+
+	require.Same(
+		t, groups[keyA][0].TreePath,
+		groups[keyB][0].TreePath,
+	)
+}
+
 // TestVTXOPersistenceStoreStatusTransitions tests the status update methods.
 func TestVTXOPersistenceStoreStatusTransitions(t *testing.T) {
 	t.Parallel()

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/lightninglabs/lndclient v0.21.0-rc1
 	github.com/lightninglabs/loop v0.33.0-beta
 	github.com/lightninglabs/neutrino v0.16.2
+	github.com/lightninglabs/neutrino/cache v1.1.3
 	github.com/lightninglabs/taproot-assets v0.7.0
 	github.com/lightninglabs/taproot-assets/taprpc v1.0.11
 	github.com/lightningnetwork/lnd v0.21.0-beta.rc1
@@ -124,7 +125,6 @@ require (
 	github.com/klauspost/compress v1.17.9 // indirect
 	github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf // indirect
 	github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.4-0.20250610182311-2f1d46ef18b7 // indirect
-	github.com/lightninglabs/neutrino/cache v1.1.3 // indirect
 	github.com/lightningnetwork/lightning-onion v1.3.0 // indirect
 	github.com/lightningnetwork/lnd/actor v0.0.6 // indirect
 	github.com/lightningnetwork/lnd/cert v1.2.2 // indirect

--- a/oor/AGENTS.md
+++ b/oor/AGENTS.md
@@ -237,9 +237,10 @@ resume semantics.
 - Point-of-no-return: when server co-signs checkpoint transaction(s).
 - After checkpoint signature, client must resume and obtain byte-identical
   co-signed PSBTs (deterministic construction).
-- Transport outbox events (submit, finalize, ack) are Tell'd to ServerConn
-  within the actor's DB transaction for atomic enqueue (same-DB tx joining via
-  `ExecTx`).
+- Transport outbox events (submit, finalize, ack) are durably enqueued, then
+  delivered to ServerConn after the OOR actor transaction commits. The enqueue
+  is part of the actor transition; the transport side effect runs outside the
+  actor DB transaction and is retried through the actor delivery store.
 - Package persistence tracks finalized outgoing packages and local input
   bindings for recovery. On outgoing finalize, local input-spend completion is
   driven before the package write so the VTXO manager can join the durable OOR

--- a/oor/CLAUDE.md
+++ b/oor/CLAUDE.md
@@ -237,9 +237,10 @@ resume semantics.
 - Point-of-no-return: when server co-signs checkpoint transaction(s).
 - After checkpoint signature, client must resume and obtain byte-identical
   co-signed PSBTs (deterministic construction).
-- Transport outbox events (submit, finalize, ack) are Tell'd to ServerConn
-  within the actor's DB transaction for atomic enqueue (same-DB tx joining via
-  `ExecTx`).
+- Transport outbox events (submit, finalize, ack) are durably enqueued, then
+  delivered to ServerConn after the OOR actor transaction commits. The enqueue
+  is part of the actor transition; the transport side effect runs outside the
+  actor DB transaction and is retried through the actor delivery store.
 - Package persistence tracks finalized outgoing packages and local input
   bindings for recovery. On outgoing finalize, local input-spend completion is
   driven before the package write so the VTXO manager can join the durable OOR

--- a/oor/actor.go
+++ b/oor/actor.go
@@ -60,6 +60,14 @@ type ClientActorCfg struct {
 	// events are routed through OutboxHandler for backward compatibility.
 	ServerConn actor.TellOnlyRef[serverconn.ServerConnMsg]
 
+	// TransportOutbox writes server transport events to the actor
+	// transactional outbox instead of Tell'ing ServerConn directly. This
+	// lets the OOR actor commit its FSM/checkpoint transaction before the
+	// serverconn mailbox enqueue happens. A daemon using this mode must run
+	// an actor.OutboxPublisher and register ServerConn under its target
+	// actor ID.
+	TransportOutbox bool
+
 	// PackageStore persists finalized outgoing packages and local input
 	// bindings used by unroll/recovery tooling.
 	PackageStore PackagePersistence
@@ -108,6 +116,8 @@ type OORClientActor struct {
 
 	startupErr error
 }
+
+var serverConnOutboxCodec = serverconn.NewServerConnCodec()
 
 // newOORActorCodec creates a MessageCodec with all OOR actor message types
 // registered. This allows the durable actor to serialize and deserialize each
@@ -1387,10 +1397,10 @@ func (b *oorDurableBehavior) isTransportEvent(msg OutboxEvent) bool {
 	}
 }
 
-// sendTransportEvent wraps the outbox message in a SendClientEventRequest and
-// Tell's it to the serverconn actor for durable delivery to the server.
-func (b *oorDurableBehavior) sendTransportEvent(ctx context.Context,
-	msg OutboxEvent) error {
+// buildTransportMessage wraps the outbox message into the serverconn message
+// that should be durably delivered to the server transport actor.
+func (b *oorDurableBehavior) buildTransportMessage(ctx context.Context,
+	msg OutboxEvent) (serverconn.ServerConnMsg, error) {
 
 	serverMsg, ok := msg.(serverconn.ServerMessage)
 	switch queryReq := msg.(type) {
@@ -1412,12 +1422,7 @@ func (b *oorDurableBehavior) sendTransportEvent(ctx context.Context,
 			),
 		}
 
-		if err := b.cfg.ServerConn.Tell(ctx, sendReq); err != nil {
-			return fmt.Errorf("send incoming resolve query to "+
-				"server: %w", err)
-		}
-
-		return nil
+		return sendReq, nil
 
 	case *QueryIncomingMetadataRequest:
 		recipients := queryReq.Recipients
@@ -1429,15 +1434,17 @@ func (b *oorDurableBehavior) sendTransportEvent(ctx context.Context,
 				ctx, queryReq.Recipients,
 			)
 			if err != nil {
-				return fmt.Errorf("filter incoming metadata "+
-					"recipients: %w", err)
+				return nil, fmt.Errorf(
+					"filter incoming metadata "+
+						"recipients: %w", err,
+				)
 			}
 
 			recipients = owned
 		}
 
 		if len(recipients) == 0 {
-			return fmt.Errorf("incoming metadata query " +
+			return nil, fmt.Errorf("incoming metadata query " +
 				"contains no wallet-owned recipients")
 		}
 
@@ -1456,16 +1463,11 @@ func (b *oorDurableBehavior) sendTransportEvent(ctx context.Context,
 			),
 		}
 
-		if err := b.cfg.ServerConn.Tell(ctx, sendReq); err != nil {
-			return fmt.Errorf("send metadata query to server: %w",
-				err)
-		}
-
-		return nil
+		return sendReq, nil
 	}
 
 	if !ok {
-		return fmt.Errorf("transport event %T does not implement "+
+		return nil, fmt.Errorf("transport event %T does not implement "+
 			"ServerMessage", msg)
 	}
 
@@ -1476,9 +1478,65 @@ func (b *oorDurableBehavior) sendTransportEvent(ctx context.Context,
 		Method:  sm.Method,
 	}
 
+	return sendReq, nil
+}
+
+// sendTransportEvent wraps the outbox message in a serverconn request and
+// either writes it to the transactional outbox or Tell's it directly to the
+// serverconn actor for durable delivery to the server.
+func (b *oorDurableBehavior) sendTransportEvent(ctx context.Context,
+	msg OutboxEvent) error {
+
+	sendReq, err := b.buildTransportMessage(ctx, msg)
+	if err != nil {
+		return err
+	}
+
+	if b.cfg.TransportOutbox {
+		return b.enqueueTransportOutbox(ctx, sendReq)
+	}
+
 	if err := b.cfg.ServerConn.Tell(ctx, sendReq); err != nil {
 		return fmt.Errorf("send transport event to server: %w", err)
 	}
+
+	return nil
+}
+
+// enqueueTransportOutbox writes the serverconn transport request to the actor
+// outbox so delivery happens after the OOR actor transaction commits.
+func (b *oorDurableBehavior) enqueueTransportOutbox(ctx context.Context,
+	msg serverconn.ServerConnMsg) error {
+
+	if b.cfg.DeliveryStore == nil {
+		return fmt.Errorf("delivery store must be provided")
+	}
+
+	if b.cfg.ServerConn == nil {
+		return fmt.Errorf("serverconn ref must be provided")
+	}
+
+	payload, err := serverConnOutboxCodec.Encode(msg)
+	if err != nil {
+		return fmt.Errorf("encode serverconn message: %w", err)
+	}
+
+	id := uuid.Must(uuid.NewV7()).String()
+	params := actor.OutboxParams{
+		ID:            id,
+		SourceActorID: b.cfg.ActorID,
+		TargetActorID: b.cfg.ServerConn.ID(),
+		MessageType:   msg.MessageType(),
+		Payload:       payload,
+	}
+
+	if err := b.cfg.DeliveryStore.EnqueueOutbox(ctx, params); err != nil {
+		return fmt.Errorf("enqueue transport outbox: %w", err)
+	}
+
+	b.logger(ctx).DebugS(ctx, "Queued transport event in outbox",
+		slog.String("target_actor_id", params.TargetActorID),
+		slog.String("message_type", params.MessageType))
 
 	return nil
 }

--- a/oor/actor.go
+++ b/oor/actor.go
@@ -68,6 +68,12 @@ type ClientActorCfg struct {
 	// actor ID.
 	TransportOutbox bool
 
+	// SigningEffect receives durable signing requests when configured. This
+	// lets OOR persist the FSM state and queue wallet signing work without
+	// executing signer calls inside the OOR actor turn. When nil, signing
+	// continues through OutboxHandler for backward compatibility.
+	SigningEffect actor.TellOnlyRef[SigningEffectMsg]
+
 	// PackageStore persists finalized outgoing packages and local input
 	// bindings used by unroll/recovery tooling.
 	PackageStore PackagePersistence
@@ -118,6 +124,7 @@ type OORClientActor struct {
 }
 
 var serverConnOutboxCodec = serverconn.NewServerConnCodec()
+var signingEffectOutboxCodec = NewSigningEffectCodec()
 
 // newOORActorCodec creates a MessageCodec with all OOR actor message types
 // registered. This allows the durable actor to serialize and deserialize each
@@ -634,6 +641,16 @@ func (b *oorDurableBehavior) handleDriveEvent(ctx context.Context,
 		}
 	}
 
+	alreadyApplied, err := b.alreadyAppliedSigningDriveEvent(
+		ctx, handle, req.Event,
+	)
+	if err != nil {
+		return fn.Err[ActorResp](err)
+	}
+	if alreadyApplied {
+		return fn.Ok[ActorResp](&DriveEventResponse{})
+	}
+
 	finalizeState, err := b.captureFinalizeStateForEvent(
 		handle.FSM, req.Event,
 	)
@@ -645,7 +662,7 @@ func (b *oorDurableBehavior) handleDriveEvent(ctx context.Context,
 	if err != nil {
 		return fn.Err[ActorResp](err)
 	}
-	handle.clearRetryMetadata()
+	handle.applyRetryEvent(req.Event)
 
 	b.notifyMaterializedVTXOs(ctx, req.Event)
 
@@ -691,6 +708,90 @@ func (b *oorDurableBehavior) handleDriveEvent(ctx context.Context,
 	b.emitVTXOSent(ctx, req.SessionID, finalizeState)
 
 	return fn.Ok[ActorResp](&DriveEventResponse{})
+}
+
+// alreadyAppliedSigningDriveEvent reports whether a durable signing effect
+// replay delivered a result for a signing stage the session has already left.
+// Signing-effect messages can be retried independently of the OOR actor. The
+// OOR FSM must therefore treat stale duplicate signing results as no-ops once
+// the corresponding signing event has already advanced the session.
+func (b *oorDurableBehavior) alreadyAppliedSigningDriveEvent(
+	ctx context.Context, handle *sessionHandle, event Event) (bool, error) {
+
+	if handle.kind != sessionKindOutgoing {
+		return false, nil
+	}
+
+	state, err := handle.currentOutgoingState()
+	if err != nil {
+		return false, err
+	}
+
+	if !isStaleSigningEvent(state, event) {
+		return false, nil
+	}
+
+	b.logger(ctx).DebugS(ctx, "Ignoring stale signing event",
+		slog.String("state", fmt.Sprintf("%T", state)),
+		slog.String("event_type", fmt.Sprintf("%T", event)))
+
+	return true, nil
+}
+
+func isStaleSigningEvent(state State, event Event) bool {
+	switch evt := event.(type) {
+	case *ArkSignedEvent:
+		return isPastArkSigningState(state)
+
+	case *CheckpointsSignedEvent:
+		return isPastCheckpointSigningState(state)
+
+	case *OutboxErrorEvent:
+		switch evt.OutboxType {
+		case (&RequestArkSignatures{}).outboxType():
+			return isPastArkSigningState(state) ||
+				isTerminalSigningFailure(state)
+
+		case (&RequestCheckpointSignatures{}).outboxType():
+			return isPastCheckpointSigningState(state) ||
+				isTerminalSigningFailure(state)
+
+		default:
+			return false
+		}
+
+	default:
+		return false
+	}
+}
+
+func isPastArkSigningState(state State) bool {
+	switch state.(type) {
+	case *AwaitingSubmitAccepted, *AwaitingCheckpointSignatures,
+		*AwaitingFinalizeAccepted, *AwaitingLocalVTXOUpdate,
+		*Completed:
+
+		return true
+
+	default:
+		return false
+	}
+}
+
+func isPastCheckpointSigningState(state State) bool {
+	switch state.(type) {
+	case *AwaitingFinalizeAccepted, *AwaitingLocalVTXOUpdate, *Completed:
+		return true
+
+	default:
+		return false
+	}
+}
+
+func isTerminalSigningFailure(state State) bool {
+	_, ok := state.(*Failed)
+
+	return ok
 }
 
 // handleResolveIncomingTransfer durably records a lightweight incoming OOR
@@ -1541,6 +1642,45 @@ func (b *oorDurableBehavior) enqueueTransportOutbox(ctx context.Context,
 	return nil
 }
 
+// enqueueSigningEffect writes a local signing request to the actor outbox so
+// the signing effect actor can execute wallet signing after OOR commits.
+func (b *oorDurableBehavior) enqueueSigningEffect(ctx context.Context,
+	sessionID SessionID, req *SigningEffectRequest) error {
+
+	if b.cfg.DeliveryStore == nil {
+		return fmt.Errorf("delivery store must be provided")
+	}
+
+	if b.cfg.SigningEffect == nil {
+		return fmt.Errorf("signing effect ref must be provided")
+	}
+
+	payload, err := signingEffectOutboxCodec.Encode(req)
+	if err != nil {
+		return fmt.Errorf("encode signing effect request: %w", err)
+	}
+
+	id := uuid.Must(uuid.NewV7()).String()
+	params := actor.OutboxParams{
+		ID:            id,
+		SourceActorID: b.cfg.ActorID,
+		TargetActorID: b.cfg.SigningEffect.ID(),
+		MessageType:   req.MessageType(),
+		Payload:       payload,
+	}
+
+	if err := b.cfg.DeliveryStore.EnqueueOutbox(ctx, params); err != nil {
+		return fmt.Errorf("enqueue signing effect: %w", err)
+	}
+
+	b.logger(ctx).DebugS(ctx, "Queued signing effect in outbox",
+		slog.String("session_id", sessionID.String()),
+		slog.String("target_actor_id", params.TargetActorID),
+		slog.String("message_type", params.MessageType))
+
+	return nil
+}
+
 // driveOutbox executes outbox work using the configured handler and feeds any
 // follow-up events back into the FSM.
 func (b *oorDurableBehavior) driveOutbox(ctx context.Context,
@@ -1592,6 +1732,29 @@ func (b *oorDurableBehavior) driveOutbox(ctx context.Context,
 			}
 
 			continue
+		}
+
+		if b.cfg.SigningEffect != nil {
+			req, ok := signingEffectRequest(sessionID, msg)
+			if ok {
+				b.logger(ctx).DebugS(
+					ctx, "Queueing signing effect",
+					slog.String(
+						"session_id", sessionID.String(),
+					),
+					slog.String(
+						"event_type", fmt.Sprintf("%T", msg),
+					),
+				)
+
+				if err := b.enqueueSigningEffect(
+					ctx, sessionID, req,
+				); err != nil {
+					return err
+				}
+
+				continue
+			}
 		}
 
 		b.logger(ctx).DebugS(ctx, "Handling local outbox event",

--- a/oor/actor_drive_event_test.go
+++ b/oor/actor_drive_event_test.go
@@ -1,15 +1,32 @@
 package oor
 
 import (
+	"context"
 	"testing"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/baselib/actor"
 	"github.com/lightninglabs/darepo-client/lib/arkscript"
 	oortx "github.com/lightninglabs/darepo-client/lib/tx/oor"
+	"github.com/lightningnetwork/lnd/input"
 	"github.com/stretchr/testify/require"
 )
+
+type noopSigningEffectRef struct{}
+
+func (noopSigningEffectRef) ID() string {
+	return "noop-signing-effect"
+}
+
+func (noopSigningEffectRef) Tell(_ context.Context,
+	_ SigningEffectMsg) error {
+
+	return nil
+}
+
+var _ actor.TellOnlyRef[SigningEffectMsg] = (*noopSigningEffectRef)(nil)
 
 // TestOORClientActorDriveEventErrors asserts the DriveEventRequest handler
 // rejects malformed inputs.
@@ -127,4 +144,161 @@ func TestOORClientActorDriveEventAppliesEvent(t *testing.T) {
 	failedState, ok := stateMsg.State.(*Failed)
 	require.True(t, ok)
 	require.Equal(t, "boom", failedState.Reason)
+}
+
+// TestOORClientActorDriveEventIgnoresStaleSigningResults verifies durable
+// signing effect replay can re-deliver a signing result after OOR has already
+// advanced past that signing stage.
+func TestOORClientActorDriveEventIgnoresStaleSigningResults(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	clientKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	clientSigner := input.NewMockSigner([]*btcec.PrivateKey{clientKey}, nil)
+	operatorSigner := input.NewMockSigner(
+		[]*btcec.PrivateKey{operatorKey}, nil,
+	)
+
+	policy := arkscript.CheckpointPolicy{
+		OperatorKey: operatorKey.PubKey(),
+		CSVDelay:    10,
+	}
+
+	inputValue := btcutil.Amount(10_000)
+	inputs := []TransferInput{
+		newTestTransferInput(
+			t,
+			clientKey,
+			policy.OperatorKey,
+			wire.OutPoint{
+				Hash:  [32]byte{0x02},
+				Index: 0,
+			},
+			inputValue,
+		),
+	}
+	recipients := []oortx.RecipientOutput{{
+		PkScript: newTestTaprootPkScript(t, clientKey.PubKey()),
+		Value:    inputValue,
+	}}
+
+	actor := NewOORClientActor(ClientActorCfg{
+		OutboxHandler: &noopOutboxHandler{},
+		DeliveryStore: newTestDeliveryStore(t),
+		ActorID:       "oor-drive-event-stale-signing",
+		SigningEffect: &noopSigningEffectRef{},
+	})
+	defer actor.Stop()
+
+	startResp := actor.Receive(ctx, &StartTransferRequest{
+		Policy:     policy,
+		Inputs:     inputs,
+		Recipients: recipients,
+	})
+	require.True(t, startResp.IsOk())
+
+	startMsg, ok := startResp.UnwrapOr(nil).(*StartTransferResponse)
+	require.True(t, ok)
+
+	stateMsg := requireOORState[*AwaitingArkSignatures](
+		t, ctx, actor, startMsg.SessionID,
+	)
+
+	err = SignArkPSBT(
+		clientSigner, stateMsg.ArkPSBT, stateMsg.CheckpointPSBTs,
+		stateMsg.TransferInputs,
+	)
+	require.NoError(t, err)
+
+	arkSigned := &ArkSignedEvent{
+		ArkPSBT: stateMsg.ArkPSBT,
+	}
+	driveResp := actor.Receive(ctx, &DriveEventRequest{
+		SessionID: startMsg.SessionID,
+		Event:     arkSigned,
+	})
+	require.True(t, driveResp.IsOk())
+	requireOORState[*AwaitingSubmitAccepted](
+		t, ctx, actor, startMsg.SessionID,
+	)
+
+	driveResp = actor.Receive(ctx, &DriveEventRequest{
+		SessionID: startMsg.SessionID,
+		Event:     arkSigned,
+	})
+	require.True(t, driveResp.IsOk())
+	submitState := requireOORState[*AwaitingSubmitAccepted](
+		t, ctx, actor, startMsg.SessionID,
+	)
+
+	err = coSignCheckpointPSBTsForTest(
+		operatorSigner, submitState.TransferInputs,
+		submitState.CheckpointPSBTs,
+	)
+	require.NoError(t, err)
+
+	driveResp = actor.Receive(ctx, &DriveEventRequest{
+		SessionID: startMsg.SessionID,
+		Event: &SubmitAcceptedEvent{
+			SessionID:               startMsg.SessionID,
+			ArkPSBT:                 submitState.ArkPSBT,
+			CoSignedCheckpointPSBTs: submitState.CheckpointPSBTs,
+		},
+	})
+	require.True(t, driveResp.IsOk())
+
+	checkpointState := requireOORState[*AwaitingCheckpointSignatures](
+		t, ctx, actor, startMsg.SessionID,
+	)
+	err = SignCheckpointPSBTs(
+		clientSigner, checkpointState.TransferInputs,
+		checkpointState.CoSignedCheckpointPSBTs,
+	)
+	require.NoError(t, err)
+
+	checkpointsSigned := &CheckpointsSignedEvent{
+		FinalCheckpointPSBTs: checkpointState.CoSignedCheckpointPSBTs,
+	}
+	driveResp = actor.Receive(ctx, &DriveEventRequest{
+		SessionID: startMsg.SessionID,
+		Event:     checkpointsSigned,
+	})
+	require.True(t, driveResp.IsOk())
+	requireOORState[*AwaitingFinalizeAccepted](
+		t, ctx, actor, startMsg.SessionID,
+	)
+
+	driveResp = actor.Receive(ctx, &DriveEventRequest{
+		SessionID: startMsg.SessionID,
+		Event:     checkpointsSigned,
+	})
+	require.True(t, driveResp.IsOk())
+	requireOORState[*AwaitingFinalizeAccepted](
+		t, ctx, actor, startMsg.SessionID,
+	)
+}
+
+func requireOORState[T State](t *testing.T, ctx context.Context,
+	actor *OORClientActor, sessionID SessionID) T {
+
+	t.Helper()
+
+	stateResp := actor.Receive(ctx, &GetStateRequest{
+		SessionID: sessionID,
+	})
+	require.True(t, stateResp.IsOk())
+
+	stateMsg, ok := stateResp.UnwrapOr(nil).(*GetStateResponse)
+	require.True(t, ok)
+
+	state, ok := stateMsg.State.(T)
+	require.True(t, ok)
+
+	return state
 }

--- a/oor/actor_durable_message.go
+++ b/oor/actor_durable_message.go
@@ -1452,6 +1452,7 @@ func decodeDriveEventRequestPayload(raw []byte) (SessionID, Event, error) {
 	return sessionID, event, nil
 }
 
+//nolint:funlen
 func encodeEventPayload(event Event) ([]byte, error) {
 	var (
 		eventKind       uint64

--- a/oor/actor_durable_message.go
+++ b/oor/actor_durable_message.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"time"
 
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -60,6 +61,9 @@ const (
 	eventPayloadOutpointsRecordType        tlv.Type = 11
 	eventPayloadMetadataMatchesRecordType  tlv.Type = 13
 	eventPayloadAncestorPackagesRecordType tlv.Type = 15
+	eventPayloadOutboxTypeRecordType       tlv.Type = 17
+	eventPayloadRetryableRecordType        tlv.Type = 19
+	eventPayloadRetryAfterNanosRecordType  tlv.Type = 21
 )
 
 const (
@@ -72,6 +76,8 @@ const (
 	eventKindIncomingHandled   uint64 = 8
 	eventKindIncomingAckSent   uint64 = 9
 	eventKindIncomingMetadata  uint64 = 10
+	eventKindOutboxError       uint64 = 11
+	eventKindArkSigned         uint64 = 12
 )
 
 const (
@@ -1463,10 +1469,24 @@ func encodeEventPayload(event Event) ([]byte, error) {
 		outpointPayload []byte
 		metadataPayload []byte
 		ancestorPayload []byte
+		outboxType      []byte
+		retryable       uint8
+		retryAfterNanos uint64
 		err             error
 	)
 
 	switch evt := event.(type) {
+	case *ArkSignedEvent:
+		eventKind = eventKindArkSigned
+		if evt.ArkPSBT == nil {
+			return nil, fmt.Errorf("ark signed event psbt required")
+		}
+
+		arkPSBT, err = psbtutil.Serialize(evt.ArkPSBT)
+		if err != nil {
+			return nil, err
+		}
+
 	case *SubmitAcceptedEvent:
 		eventKind = eventKindSubmitAccepted
 		submitSession = sessionIDBytes(evt.SessionID)
@@ -1585,6 +1605,15 @@ func encodeEventPayload(event Event) ([]byte, error) {
 	case *IncomingAckSentEvent:
 		eventKind = eventKindIncomingAckSent
 
+	case *OutboxErrorEvent:
+		eventKind = eventKindOutboxError
+		outboxType = []byte(evt.OutboxType)
+		if evt.Retryable {
+			retryable = 1
+		}
+		retryAfterNanos = uint64(evt.RetryAfter)
+		reason = []byte(evt.ErrorReason)
+
 	default:
 		return nil, fmt.Errorf("unsupported event type: %T", event)
 	}
@@ -1611,6 +1640,16 @@ func encodeEventPayload(event Event) ([]byte, error) {
 			eventPayloadAncestorPackagesRecordType,
 			&ancestorPayload,
 		),
+		tlv.MakePrimitiveRecord(
+			eventPayloadOutboxTypeRecordType, &outboxType,
+		),
+		tlv.MakePrimitiveRecord(
+			eventPayloadRetryableRecordType, &retryable,
+		),
+		tlv.MakePrimitiveRecord(
+			eventPayloadRetryAfterNanosRecordType,
+			&retryAfterNanos,
+		),
 	}
 
 	stream, err := tlv.NewStream(records...)
@@ -1636,6 +1675,9 @@ func decodeEventPayload(raw []byte) (Event, error) {
 		outpointPayload []byte
 		metadataPayload []byte
 		ancestorPayload []byte
+		outboxType      []byte
+		retryable       uint8
+		retryAfterNanos uint64
 	)
 
 	records := []tlv.Record{
@@ -1660,6 +1702,16 @@ func decodeEventPayload(raw []byte) (Event, error) {
 			eventPayloadAncestorPackagesRecordType,
 			&ancestorPayload,
 		),
+		tlv.MakePrimitiveRecord(
+			eventPayloadOutboxTypeRecordType, &outboxType,
+		),
+		tlv.MakePrimitiveRecord(
+			eventPayloadRetryableRecordType, &retryable,
+		),
+		tlv.MakePrimitiveRecord(
+			eventPayloadRetryAfterNanosRecordType,
+			&retryAfterNanos,
+		),
 	}
 
 	stream, err := tlv.NewStream(records...)
@@ -1673,6 +1725,14 @@ func decodeEventPayload(raw []byte) (Event, error) {
 	}
 
 	switch eventKind {
+	case eventKindArkSigned:
+		ark, err := psbtutil.Parse(arkPSBT)
+		if err != nil {
+			return nil, err
+		}
+
+		return &ArkSignedEvent{ArkPSBT: ark}, nil
+
 	case eventKindSubmitAccepted:
 		sessionID, err := parseSessionID(submitSession)
 		if err != nil {
@@ -1794,6 +1854,14 @@ func decodeEventPayload(raw []byte) (Event, error) {
 
 	case eventKindIncomingAckSent:
 		return &IncomingAckSentEvent{}, nil
+
+	case eventKindOutboxError:
+		return &OutboxErrorEvent{
+			OutboxType:  string(outboxType),
+			Retryable:   retryable != 0,
+			RetryAfter:  time.Duration(retryAfterNanos),
+			ErrorReason: string(reason),
+		}, nil
 
 	default:
 		return nil, fmt.Errorf("unknown event kind: %d", eventKind)

--- a/oor/actor_test.go
+++ b/oor/actor_test.go
@@ -12,9 +12,11 @@ import (
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/baselib/actor"
 	"github.com/lightninglabs/darepo-client/lib/arkscript"
 	oortx "github.com/lightninglabs/darepo-client/lib/tx/oor"
 	libtypes "github.com/lightninglabs/darepo-client/lib/types"
+	"github.com/lightninglabs/darepo-client/rpc/oorpb"
 	"github.com/lightninglabs/darepo-client/serverconn"
 	"github.com/lightninglabs/darepo-client/vtxo"
 	"github.com/lightningnetwork/lnd/input"
@@ -1432,6 +1434,103 @@ func TestOORClientActorSkipsMissingConsumedInputBinding(t *testing.T) {
 	require.IsType(t, &Completed{}, stateMsg.State)
 	require.Equal(t, 1, packageStore.packageCalls)
 	require.Equal(t, 1, packageStore.bindingCalls)
+}
+
+// TestOORClientActorTransportViaTransactionalOutbox verifies that production
+// wiring can persist transport events into the actor outbox instead of
+// enqueueing them directly into serverconn from the OOR actor turn.
+func TestOORClientActorTransportViaTransactionalOutbox(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	policy := arkscript.CheckpointPolicy{
+		OperatorKey: operatorKey.PubKey(),
+		CSVDelay:    10,
+	}
+
+	inputValue := btcutil.Amount(10000)
+
+	clientKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	clientSigner := input.NewMockSigner(
+		[]*btcec.PrivateKey{clientKey}, nil,
+	)
+	mockConn := newMockServerConnRef(t)
+	store := newTestDeliveryStore(t)
+
+	inputs := []TransferInput{
+		newTestTransferInput(
+			t, clientKey, policy.OperatorKey,
+			wire.OutPoint{
+				Hash:  [32]byte{0x07},
+				Index: 0,
+			},
+			inputValue,
+		),
+	}
+
+	recipients := []oortx.RecipientOutput{
+		{
+			PkScript: newTestTaprootPkScript(
+				t, clientKey.PubKey(),
+			),
+			Value: inputValue,
+		},
+	}
+
+	actorInstance := NewOORClientActor(ClientActorCfg{
+		OutboxHandler: &localOnlyOutboxHandler{
+			t:            t,
+			clientSigner: clientSigner,
+		},
+		ServerConn:      mockConn,
+		TransportOutbox: true,
+		PackageStore:    &testOutgoingPackageStore{},
+		DeliveryStore:   store,
+		ActorID:         "oor-actor-transport-outbox-test",
+	})
+	defer actorInstance.Stop()
+
+	startResp := actorInstance.Receive(ctx, &StartTransferRequest{
+		Policy:     policy,
+		Inputs:     inputs,
+		Recipients: recipients,
+	})
+	require.True(t, startResp.IsOk())
+
+	mockConn.mu.Lock()
+	require.Empty(t, mockConn.messages)
+	mockConn.mu.Unlock()
+
+	outbox, err := store.ClaimOutboxBatch(ctx, actor.OutboxClaimParams{
+		Limit:         10,
+		ClaimToken:    "test-claim",
+		ClaimDuration: time.Minute,
+	})
+	require.NoError(t, err)
+	require.Len(t, outbox, 1)
+
+	require.Equal(t, mockConn.ID(), outbox[0].TargetActorID)
+	require.Equal(t, "SendClientEventRequest", outbox[0].MessageType)
+
+	decoded, err := serverconn.NewServerConnCodec().Decode(
+		outbox[0].Payload,
+	)
+	require.NoError(t, err)
+
+	sendReq, ok := decoded.(*serverconn.SendClientEventRequest)
+	require.True(t, ok)
+	require.Equal(t, oorpb.ServiceName, sendReq.Service)
+	require.Equal(t, oorpb.MethodSubmitPackage, sendReq.Method)
+
+	protoMsg, err := sendReq.Message.ToProto().Unpack()
+	require.NoError(t, err)
+	require.IsType(t, &oorpb.SubmitPackageRequest{}, protoMsg)
 }
 
 // TestIsTransportEventClassification verifies that isTransportEvent correctly

--- a/oor/actor_test.go
+++ b/oor/actor_test.go
@@ -1533,6 +1533,133 @@ func TestOORClientActorTransportViaTransactionalOutbox(t *testing.T) {
 	require.IsType(t, &oorpb.SubmitPackageRequest{}, protoMsg)
 }
 
+// TestOORClientActorSigningViaEffectActor verifies that OOR can commit the
+// initial session state, queue signing work through the actor outbox, and then
+// continue when the signing effect actor drives ArkSignedEvent back in.
+func TestOORClientActorSigningViaEffectActor(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	system := actor.NewActorSystem()
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(
+			context.Background(), 5*time.Second,
+		)
+		defer cancel()
+
+		require.NoError(t, system.Shutdown(shutdownCtx))
+	})
+
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	policy := arkscript.CheckpointPolicy{
+		OperatorKey: operatorKey.PubKey(),
+		CSVDelay:    10,
+	}
+
+	inputValue := btcutil.Amount(10000)
+
+	clientKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	clientSigner := input.NewMockSigner(
+		[]*btcec.PrivateKey{clientKey}, nil,
+	)
+	mockConn := newMockServerConnRef(t)
+	store := newTestDeliveryStore(t)
+
+	oorKey := NewServiceKey()
+	effect, err := NewSigningEffectActor(SigningEffectActorConfig{
+		ActorID:       SigningEffectActorID,
+		DeliveryStore: store,
+		Signer:        clientSigner,
+		OORRef:        oorKey.Ref(system),
+		ActorSystem:   system,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(
+			context.Background(), 5*time.Second,
+		)
+		defer cancel()
+
+		require.NoError(t, effect.StopAndWait(shutdownCtx))
+	})
+
+	publisherCfg := actor.DefaultOutboxPublisherConfig(
+		store, NewSigningEffectCodec(), system,
+	)
+	publisherCfg.PollInterval = 10 * time.Millisecond
+	publisher := actor.NewOutboxPublisher(publisherCfg)
+	publisher.Start()
+	t.Cleanup(publisher.Stop)
+
+	inputs := []TransferInput{
+		newTestTransferInput(
+			t, clientKey, policy.OperatorKey,
+			wire.OutPoint{
+				Hash:  [32]byte{0x08},
+				Index: 0,
+			},
+			inputValue,
+		),
+	}
+
+	recipients := []oortx.RecipientOutput{
+		{
+			PkScript: newTestTaprootPkScript(
+				t, clientKey.PubKey(),
+			),
+			Value: inputValue,
+		},
+	}
+
+	actorInstance := NewOORClientActor(ClientActorCfg{
+		OutboxHandler: &localOnlyOutboxHandler{
+			t:            t,
+			clientSigner: clientSigner,
+		},
+		ServerConn:    mockConn,
+		SigningEffect: effect.Ref(),
+		PackageStore:  &testOutgoingPackageStore{},
+		DeliveryStore: store,
+		ActorSystem:   system,
+		ActorID:       "oor-actor-signing-effect-test",
+	})
+	defer actorInstance.Stop()
+
+	startResp := actorInstance.Receive(ctx, &StartTransferRequest{
+		Policy:     policy,
+		Inputs:     inputs,
+		Recipients: recipients,
+	})
+	require.True(t, startResp.IsOk())
+
+	mockConn.mu.Lock()
+	require.Empty(t, mockConn.messages)
+	mockConn.mu.Unlock()
+
+	require.Eventually(t, func() bool {
+		mockConn.mu.Lock()
+		defer mockConn.mu.Unlock()
+
+		if len(mockConn.messages) == 0 {
+			return false
+		}
+
+		req, ok := mockConn.messages[0].(*serverconn.
+			SendClientEventRequest)
+		if !ok {
+			return false
+		}
+
+		return req.Service == oorpb.ServiceName &&
+			req.Method == oorpb.MethodSubmitPackage
+	}, 5*time.Second, 10*time.Millisecond)
+}
+
 // TestIsTransportEventClassification verifies that isTransportEvent correctly
 // classifies all outbox event types. Transport events (submit, finalize, ack)
 // must be routed to serverconn, while local events (signing, persistence,

--- a/oor/signing_effect_actor.go
+++ b/oor/signing_effect_actor.go
@@ -1,0 +1,433 @@
+package oor
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+
+	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/build"
+	"github.com/lightninglabs/darepo-client/lib/tx/psbtutil"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+const (
+	// SigningEffectActorID is the default durable mailbox id for OOR
+	// signing side effects.
+	SigningEffectActorID = "oor-signing-effect"
+
+	signingEffectRequestTLVType tlv.Type = 0x7020
+)
+
+const (
+	signingEffectKindRecordType       tlv.Type = 1
+	signingEffectSessionIDRecordType  tlv.Type = 3
+	signingEffectArkPSBTRecordType    tlv.Type = 5
+	signingEffectCheckpointRecordType tlv.Type = 7
+	signingEffectTransferInputType    tlv.Type = 9
+	signingEffectRequestArk           uint64   = 1
+	signingEffectRequestCheckpoint    uint64   = 2
+)
+
+// SigningEffectMsg is the sealed message set accepted by the signing effect
+// actor.
+type SigningEffectMsg interface {
+	actor.TLVMessage
+	signingEffectMsgSealed()
+}
+
+// SigningEffectRequest is a durable request to perform wallet signing for one
+// OOR session and feed the resulting event back into the OOR actor.
+type SigningEffectRequest struct {
+	actor.BaseMessage
+
+	Kind            uint64
+	SessionID       SessionID
+	ArkPSBT         *psbt.Packet
+	CheckpointPSBTs []*psbt.Packet
+	TransferInputs  []TransferInput
+}
+
+// MessageType returns a human-readable type name for logging.
+func (m *SigningEffectRequest) MessageType() string {
+	return "SigningEffectRequest"
+}
+
+// TLVType returns the durable mailbox type identifier.
+func (m *SigningEffectRequest) TLVType() tlv.Type {
+	return signingEffectRequestTLVType
+}
+
+// signingEffectMsgSealed marks this as a signing-effect actor message.
+func (m *SigningEffectRequest) signingEffectMsgSealed() {}
+
+// Encode serializes the signing request.
+func (m *SigningEffectRequest) Encode(w io.Writer) error {
+	if m == nil {
+		return fmt.Errorf("signing effect request must be provided")
+	}
+
+	sessionBytes := sessionIDBytes(m.SessionID)
+
+	var arkBytes []byte
+	if m.ArkPSBT != nil {
+		var err error
+		arkBytes, err = psbtutil.Serialize(m.ArkPSBT)
+		if err != nil {
+			return err
+		}
+	}
+
+	checkpoints, err := serializePSBTSlice(m.CheckpointPSBTs)
+	if err != nil {
+		return err
+	}
+
+	checkpointBytes, err := encodeLengthPrefixedBlobList(checkpoints)
+	if err != nil {
+		return err
+	}
+
+	inputSnaps, err := snapshotTransferInputs(m.TransferInputs)
+	if err != nil {
+		return err
+	}
+
+	inputBytes, err := encodeTransferInputSnapshots(inputSnaps)
+	if err != nil {
+		return err
+	}
+
+	records := []tlv.Record{
+		tlv.MakePrimitiveRecord(
+			signingEffectKindRecordType, &m.Kind,
+		),
+		tlv.MakePrimitiveRecord(
+			signingEffectSessionIDRecordType, &sessionBytes,
+		),
+		tlv.MakePrimitiveRecord(
+			signingEffectArkPSBTRecordType, &arkBytes,
+		),
+		tlv.MakePrimitiveRecord(
+			signingEffectCheckpointRecordType, &checkpointBytes,
+		),
+		tlv.MakePrimitiveRecord(
+			signingEffectTransferInputType, &inputBytes,
+		),
+	}
+
+	stream, err := tlv.NewStream(records...)
+	if err != nil {
+		return err
+	}
+
+	return stream.Encode(w)
+}
+
+// Decode deserializes the signing request.
+func (m *SigningEffectRequest) Decode(r io.Reader) error {
+	var (
+		sessionBytes   []byte
+		arkBytes       []byte
+		checkpointBlob []byte
+		inputBlob      []byte
+	)
+
+	records := []tlv.Record{
+		tlv.MakePrimitiveRecord(
+			signingEffectKindRecordType, &m.Kind,
+		),
+		tlv.MakePrimitiveRecord(
+			signingEffectSessionIDRecordType, &sessionBytes,
+		),
+		tlv.MakePrimitiveRecord(
+			signingEffectArkPSBTRecordType, &arkBytes,
+		),
+		tlv.MakePrimitiveRecord(
+			signingEffectCheckpointRecordType, &checkpointBlob,
+		),
+		tlv.MakePrimitiveRecord(
+			signingEffectTransferInputType, &inputBlob,
+		),
+	}
+
+	stream, err := tlv.NewStream(records...)
+	if err != nil {
+		return err
+	}
+
+	if _, err := stream.DecodeWithParsedTypes(r); err != nil {
+		return err
+	}
+
+	m.SessionID, err = parseSessionID(sessionBytes)
+	if err != nil {
+		return err
+	}
+
+	if len(arkBytes) > 0 {
+		m.ArkPSBT, err = psbtutil.Parse(arkBytes)
+		if err != nil {
+			return err
+		}
+	}
+
+	checkpointRaw, err := decodeLengthPrefixedBlobList(checkpointBlob)
+	if err != nil {
+		return err
+	}
+
+	m.CheckpointPSBTs, err = parsePSBTSlice(checkpointRaw)
+	if err != nil {
+		return err
+	}
+
+	inputSnaps, err := decodeTransferInputSnapshots(inputBlob)
+	if err != nil {
+		return err
+	}
+
+	m.TransferInputs = make([]TransferInput, 0, len(inputSnaps))
+	for i := range inputSnaps {
+		input, err := TransferInputFromSnapshot(inputSnaps[i])
+		if err != nil {
+			return err
+		}
+
+		m.TransferInputs = append(m.TransferInputs, input)
+	}
+
+	return nil
+}
+
+// NewSigningEffectCodec registers the signing effect message set.
+func NewSigningEffectCodec() *actor.MessageCodec {
+	codec := actor.NewMessageCodec()
+	RegisterSigningEffectMessages(codec)
+
+	return codec
+}
+
+// RegisterSigningEffectMessages registers signing effect messages on a codec.
+func RegisterSigningEffectMessages(codec *actor.MessageCodec) {
+	codec.MustRegister(
+		signingEffectRequestTLVType, func() actor.TLVMessage {
+			return &SigningEffectRequest{}
+		},
+	)
+}
+
+// SigningEffectActorConfig configures the OOR signing effect actor.
+type SigningEffectActorConfig struct {
+	ActorID       string
+	DeliveryStore actor.DeliveryStore
+	Signer        input.Signer
+	OORRef        actor.TellOnlyRef[OORDurableMsg]
+	ActorSystem   actor.SystemContext
+	Log           fn.Option[btclog.Logger]
+}
+
+// SigningEffectActor performs wallet signing outside the OOR actor turn.
+type SigningEffectActor struct {
+	cfg     SigningEffectActorConfig
+	durable *actor.DurableActor[SigningEffectMsg, actor.Message]
+}
+
+// NewSigningEffectActor creates, starts, and optionally registers a durable
+// signing effect actor.
+func NewSigningEffectActor(cfg SigningEffectActorConfig) (*SigningEffectActor,
+	error) {
+
+	if cfg.ActorID == "" {
+		cfg.ActorID = SigningEffectActorID
+	}
+
+	if cfg.DeliveryStore == nil {
+		return nil, fmt.Errorf("delivery store must be provided")
+	}
+
+	if cfg.Signer == nil {
+		return nil, fmt.Errorf("signer must be provided")
+	}
+
+	if cfg.OORRef == nil {
+		return nil, fmt.Errorf("oor ref must be provided")
+	}
+
+	effect := &SigningEffectActor{cfg: cfg}
+
+	durableCfg := actor.DefaultDurableActorConfig[
+		SigningEffectMsg, actor.Message,
+	](
+		cfg.ActorID,
+		effect,
+		cfg.DeliveryStore,
+		NewSigningEffectCodec(),
+	)
+	durableCfg.Log = cfg.Log
+
+	effect.durable = actor.NewDurableActor(durableCfg)
+	effect.durable.Start()
+
+	if cfg.ActorSystem != nil {
+		erasingRef := actor.TypeAssertingRef[
+			actor.Message,
+			SigningEffectMsg,
+			actor.Message,
+		](effect.durable.Ref())
+
+		key := actor.NewServiceKey[actor.Message, any](cfg.ActorID)
+		if err := actor.RegisterWithReceptionist(
+			cfg.ActorSystem.Receptionist(), key, erasingRef,
+		); err != nil {
+			effect.durable.Stop()
+			return nil, fmt.Errorf("register signing effect: %w",
+				err)
+		}
+	}
+
+	effect.logger(context.Background()).InfoS(
+		context.Background(), "OOR signing effect actor started",
+		slog.String("actor_id", cfg.ActorID),
+	)
+
+	return effect, nil
+}
+
+// Ref returns the durable actor ref.
+func (a *SigningEffectActor) Ref() actor.ActorRef[SigningEffectMsg,
+	actor.Message] {
+
+	return a.durable.Ref()
+}
+
+// StopAndWait stops the signing effect actor and waits for shutdown.
+func (a *SigningEffectActor) StopAndWait(ctx context.Context) error {
+	a.durable.Stop()
+
+	return a.durable.Wait(ctx)
+}
+
+// Receive handles one signing request and feeds the result back to OOR.
+func (a *SigningEffectActor) Receive(ctx context.Context,
+	msg SigningEffectMsg) fn.Result[actor.Message] {
+
+	req, ok := msg.(*SigningEffectRequest)
+	if !ok {
+		return fn.Err[actor.Message](fmt.Errorf(
+			"unknown signing effect message: %T", msg,
+		))
+	}
+
+	events := a.handleSigningRequest(ctx, req)
+	for _, event := range events {
+		// A durable signing request may be retried after this Tell has
+		// already reached OOR. The OOR DriveEventRequest handler
+		// treats stale duplicate signing results for the same session
+		// as no-ops once the FSM has advanced past the corresponding
+		// signing state.
+		if err := a.cfg.OORRef.Tell(ctx, &DriveEventRequest{
+			SessionID: req.SessionID,
+			Event:     event,
+		}); err != nil {
+			return fn.Err[actor.Message](fmt.Errorf(
+				"drive signing result: %w", err,
+			))
+		}
+	}
+
+	return fn.Ok[actor.Message](nil)
+}
+
+func (a *SigningEffectActor) handleSigningRequest(ctx context.Context,
+	req *SigningEffectRequest) []Event {
+
+	outbox, err := req.toOutboxEvent()
+	if err != nil {
+		return []Event{&FailEvent{Reason: err.Error()}}
+	}
+
+	handler := &SigningOutboxHandler{
+		Signer: a.cfg.Signer,
+	}
+
+	followUps, err := handler.Handle(ctx, req.SessionID, outbox)
+	if err != nil {
+		return []Event{NewOutboxErrorEvent(outbox, err)}
+	}
+
+	if len(followUps) == 0 {
+		return []Event{
+			&FailEvent{
+				Reason: "signing produced no follow-up event",
+			},
+		}
+	}
+
+	return followUps
+}
+
+func (m *SigningEffectRequest) toOutboxEvent() (OutboxEvent, error) {
+	switch m.Kind {
+	case signingEffectRequestArk:
+		return &RequestArkSignatures{
+			ArkPSBT:         m.ArkPSBT,
+			CheckpointPSBTs: m.CheckpointPSBTs,
+			TransferInputs:  m.TransferInputs,
+		}, nil
+
+	case signingEffectRequestCheckpoint:
+		return &RequestCheckpointSignatures{
+			ArkPSBT:                 m.ArkPSBT,
+			CoSignedCheckpointPSBTs: m.CheckpointPSBTs,
+			TransferInputs:          m.TransferInputs,
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("unknown signing request kind: %d",
+			m.Kind)
+	}
+}
+
+func (a *SigningEffectActor) logger(ctx context.Context) btclog.Logger {
+	return a.cfg.Log.UnwrapOr(build.LoggerFromContext(ctx))
+}
+
+func signingEffectRequest(sessionID SessionID,
+	outbox OutboxEvent) (*SigningEffectRequest, bool) {
+
+	switch msg := outbox.(type) {
+	case *RequestArkSignatures:
+		return &SigningEffectRequest{
+			Kind:            signingEffectRequestArk,
+			SessionID:       sessionID,
+			ArkPSBT:         msg.ArkPSBT,
+			CheckpointPSBTs: msg.CheckpointPSBTs,
+			TransferInputs:  msg.TransferInputs,
+		}, true
+
+	case *RequestCheckpointSignatures:
+		return &SigningEffectRequest{
+			Kind:            signingEffectRequestCheckpoint,
+			SessionID:       sessionID,
+			ArkPSBT:         msg.ArkPSBT,
+			CheckpointPSBTs: msg.CoSignedCheckpointPSBTs,
+			TransferInputs:  msg.TransferInputs,
+		}, true
+
+	default:
+		return nil, false
+	}
+}
+
+type signingEffectBehavior = actor.ActorBehavior[
+	SigningEffectMsg, actor.Message,
+]
+
+var _ SigningEffectMsg = (*SigningEffectRequest)(nil)
+var _ signingEffectBehavior = (*SigningEffectActor)(nil)

--- a/vtxo/manager.go
+++ b/vtxo/manager.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sort"
+	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
@@ -21,6 +22,10 @@ import (
 	"github.com/lightninglabs/darepo-client/round"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 )
+
+// defaultForfeitVTXOActorAskTimeout bounds one stalled refresh/forfeit child
+// actor turn without making healthy child work race an overly short deadline.
+const defaultForfeitVTXOActorAskTimeout = 5 * time.Second
 
 // VTXOActorRef is the actor reference type for VTXO actors. Uses
 // actormsg.VTXOActorMsg as the message type to enable both round and vtxo
@@ -53,6 +58,14 @@ type ManagerConfig struct {
 	// ChainResolver receives expiring notifications for unilateral exit.
 	// Passed through to spawned VTXO actors.
 	ChainResolver actor.TellOnlyRef[ExpiringNotification]
+
+	// ForfeitVTXOActorAskTimeout bounds manager-to-VTXO Ask calls on
+	// forfeit admission paths. The manager actor is a shared admission
+	// point, so a slow or blocked refresh/forfeit child actor must fail
+	// that request instead of monopolizing the manager until the outer
+	// RPC deadline. Zero uses the default timeout; negative disables the
+	// timeout.
+	ForfeitVTXOActorAskTimeout time.Duration
 
 	// LedgerSink is an optional reference to the client-side
 	// ledger accounting actor, propagated to each spawned
@@ -104,6 +117,64 @@ func NewManager(cfg *ManagerConfig) *Manager {
 // context. If no logger is found in either location, returns btclog.Disabled.
 func (m *Manager) logger(ctx context.Context) btclog.Logger {
 	return m.cfg.Log.UnwrapOr(build.LoggerFromContext(ctx))
+}
+
+// forfeitVTXOActorAskTimeout returns the timeout used for refresh/forfeit
+// manager-to-child VTXO actor asks. Spend paths keep the caller's context so
+// healthy OOR payments are not failed by an artificial shorter deadline.
+func (m *Manager) forfeitVTXOActorAskTimeout() time.Duration {
+	timeout := m.cfg.ForfeitVTXOActorAskTimeout
+	switch {
+	case timeout < 0:
+		return 0
+
+	case timeout == 0:
+		return defaultForfeitVTXOActorAskTimeout
+
+	default:
+		return timeout
+	}
+}
+
+// askVTXOActor asks a child VTXO actor with the caller's context.
+func (m *Manager) askVTXOActor(ctx context.Context, ref VTXOActorRef,
+	msg actormsg.VTXOActorMsg) fn.Result[actormsg.VTXOActorResp] {
+
+	return ref.Ask(ctx, msg).Await(ctx)
+}
+
+// askForfeitVTXOActor asks a child VTXO actor with the manager's bounded
+// forfeit timeout. The parent context is still honored, but a blocked
+// refresh/forfeit child actor can only hold the shared manager admission point
+// for a short window.
+func (m *Manager) askForfeitVTXOActor(ctx context.Context, ref VTXOActorRef,
+	msg actormsg.VTXOActorMsg) fn.Result[actormsg.VTXOActorResp] {
+
+	askCtx := ctx
+	cancel := func() {}
+	if timeout := m.forfeitVTXOActorAskTimeout(); timeout > 0 {
+		askCtx, cancel = context.WithTimeout(ctx, timeout)
+	}
+	defer cancel()
+
+	return ref.Ask(askCtx, msg).Await(askCtx)
+}
+
+// rollbackContext returns a bounded context for best-effort local rollback.
+// Rollback should not inherit a canceled RPC context, because admission may
+// have partially reserved child VTXOs before the caller timed out.
+//
+// A negative ForfeitVTXOActorAskTimeout intentionally disables both the
+// admission ask deadline and this rollback deadline for tests/diagnostics.
+func (m *Manager) rollbackContext(ctx context.Context) (context.Context,
+	context.CancelFunc) {
+
+	rollbackCtx := context.WithoutCancel(ctx)
+	if timeout := m.forfeitVTXOActorAskTimeout(); timeout > 0 {
+		return context.WithTimeout(rollbackCtx, timeout)
+	}
+
+	return rollbackCtx, func() {}
 }
 
 // Start initializes the manager by recovering persisted VTXOs. The selfRef
@@ -467,7 +538,9 @@ type reserveParams struct {
 	targetAmount btcutil.Amount
 	reserveEvent actormsg.VTXOActorMsg
 	rollback     func(ctx context.Context, ops []wire.OutPoint)
-	label        string
+	ask          func(context.Context, VTXOActorRef,
+		actormsg.VTXOActorMsg) fn.Result[actormsg.VTXOActorResp]
+	label string
 }
 
 // selectAndReserveVTXOs performs largest-first coin selection and
@@ -516,9 +589,7 @@ func (m *Manager) selectAndReserveVTXOs(ctx context.Context,
 			)
 		}
 
-		result := ref.Ask(
-			ctx, p.reserveEvent,
-		).Await(ctx)
+		result := p.ask(ctx, ref, p.reserveEvent)
 		if _, err := result.Unpack(); err != nil {
 			m.logger(ctx).WarnS(
 				ctx, p.label+" reserve failed", err,
@@ -573,6 +644,7 @@ func (m *Manager) handleSelectAndReserveSpend(ctx context.Context,
 		targetAmount: req.TargetAmount,
 		reserveEvent: &SpendReserveEvent{},
 		rollback:     m.rollbackSpend,
+		ask:          m.askVTXOActor,
 		label:        "spend",
 	})
 	if err != nil {
@@ -590,15 +662,18 @@ func (m *Manager) handleSelectAndReserveSpend(ctx context.Context,
 func (m *Manager) rollbackSpend(ctx context.Context,
 	outpoints []wire.OutPoint) {
 
+	rollbackCtx, cancel := m.rollbackContext(ctx)
+	defer cancel()
+
 	for _, op := range outpoints {
 		ref, ok := m.actors[op]
 		if !ok {
 			continue
 		}
 
-		result := ref.Ask(
-			ctx, &SpendReleasedEvent{},
-		).Await(ctx)
+		result := m.askVTXOActor(
+			rollbackCtx, ref, &SpendReleasedEvent{},
+		)
 		if _, err := result.Unpack(); err != nil {
 			m.logger(ctx).WarnS(
 				ctx, "Spend rollback failed", err,
@@ -631,9 +706,7 @@ func (m *Manager) handleReleaseSpend(ctx context.Context,
 			continue
 		}
 
-		result := ref.Ask(
-			ctx, &SpendReleasedEvent{},
-		).Await(ctx)
+		result := m.askVTXOActor(ctx, ref, &SpendReleasedEvent{})
 		if _, err := result.Unpack(); err != nil {
 			m.logger(ctx).WarnS(
 				ctx, "Spend release failed", err,
@@ -686,9 +759,7 @@ func (m *Manager) handleCompleteSpend(ctx context.Context,
 			))
 		}
 
-		result := ref.Ask(
-			ctx, &SpendCompletedEvent{},
-		).Await(ctx)
+		result := m.askVTXOActor(ctx, ref, &SpendCompletedEvent{})
 		if _, err := result.Unpack(); err != nil {
 			return fn.Err[ManagerResp](fmt.Errorf(
 				"complete %s: %w", op, err,
@@ -763,9 +834,9 @@ func (m *Manager) handleReserveForfeit(ctx context.Context,
 	var reserved []wire.OutPoint
 	for _, op := range outpoints {
 		ref := m.actors[op]
-		result := ref.Ask(
-			ctx, &PendingForfeitEvent{},
-		).Await(ctx)
+		result := m.askForfeitVTXOActor(
+			ctx, ref, &PendingForfeitEvent{},
+		)
 		if _, err := result.Unpack(); err != nil {
 			m.logger(ctx).WarnS(
 				ctx, "Forfeit reserve failed", err,
@@ -792,15 +863,18 @@ func (m *Manager) handleReserveForfeit(ctx context.Context,
 func (m *Manager) rollbackForfeit(ctx context.Context,
 	outpoints []wire.OutPoint) {
 
+	rollbackCtx, cancel := m.rollbackContext(ctx)
+	defer cancel()
+
 	for _, op := range outpoints {
 		ref, ok := m.actors[op]
 		if !ok {
 			continue
 		}
 
-		result := ref.Ask(
-			ctx, &ForfeitReleasedEvent{},
-		).Await(ctx)
+		result := m.askForfeitVTXOActor(
+			rollbackCtx, ref, &ForfeitReleasedEvent{},
+		)
 		if _, err := result.Unpack(); err != nil {
 			m.logger(ctx).WarnS(
 				ctx, "Forfeit rollback failed", err,
@@ -833,9 +907,9 @@ func (m *Manager) handleReleaseForfeit(ctx context.Context,
 			continue
 		}
 
-		result := ref.Ask(
-			ctx, &ForfeitReleasedEvent{},
-		).Await(ctx)
+		result := m.askForfeitVTXOActor(
+			ctx, ref, &ForfeitReleasedEvent{},
+		)
 		if _, err := result.Unpack(); err != nil {
 			m.logger(ctx).WarnS(
 				ctx, "Forfeit release failed", err,
@@ -876,6 +950,7 @@ func (m *Manager) handleSelectAndReserveForfeit(ctx context.Context,
 		targetAmount: req.TargetAmount,
 		reserveEvent: &PendingForfeitEvent{},
 		rollback:     m.rollbackForfeit,
+		ask:          m.askForfeitVTXOActor,
 		label:        "forfeit",
 	})
 	if err != nil {

--- a/vtxo/manager_admission_test.go
+++ b/vtxo/manager_admission_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/wire"
@@ -82,6 +83,35 @@ func (m *mockVTXOActorRef) Ask(ctx context.Context,
 
 // Compile-time check that mockVTXOActorRef implements VTXOActorRef.
 var _ VTXOActorRef = (*mockVTXOActorRef)(nil)
+
+// blockingVTXOActorRef returns asks that never complete on their own. Awaiters
+// are unblocked only by their context, which lets admission tests verify that
+// the manager bounds child actor asks.
+type blockingVTXOActorRef struct {
+	id string
+}
+
+// ID returns the mock actor ID.
+func (b *blockingVTXOActorRef) ID() string { return b.id }
+
+// Tell sends a fire-and-forget message.
+func (b *blockingVTXOActorRef) Tell(_ context.Context,
+	_ actormsg.VTXOActorMsg) error {
+
+	return nil
+}
+
+// Ask returns a future that remains pending until the await context ends.
+func (b *blockingVTXOActorRef) Ask(_ context.Context,
+	_ actormsg.VTXOActorMsg) actor.Future[actormsg.VTXOActorResp] {
+
+	promise := actor.NewPromise[actormsg.VTXOActorResp]()
+
+	return promise.Future()
+}
+
+// Compile-time check that blockingVTXOActorRef implements VTXOActorRef.
+var _ VTXOActorRef = (*blockingVTXOActorRef)(nil)
 
 // newTestManager creates a Manager with mock actors for testing admission
 // handlers. The store and actors map are populated from the given
@@ -349,6 +379,30 @@ func TestCompleteSpend(t *testing.T) {
 	require.True(t, ok, "expected SpentState, got %T", ref.state)
 }
 
+// TestCompleteSpendUsesCallerDeadline verifies that spend completion is not
+// failed by the shorter forfeit admission timeout.
+func TestCompleteSpendUsesCallerDeadline(t *testing.T) {
+	t.Parallel()
+
+	vtxo := makeDescriptor(t, 50000, 0)
+	mgr, _ := newTestManager(t, nil)
+	mgr.cfg.ForfeitVTXOActorAskTimeout = 10 * time.Millisecond
+	mgr.actors[vtxo.Outpoint] = &blockingVTXOActorRef{
+		id: vtxo.Outpoint.String(),
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	result := mgr.Receive(ctx, &CompleteSpendRequest{
+		Outpoints: []wire.OutPoint{vtxo.Outpoint},
+	})
+	_, err := result.Unpack()
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.GreaterOrEqual(t, time.Since(start), 75*time.Millisecond)
+}
+
 // TestCompleteSpendAlreadyPersistedSpentIsIdempotent verifies the resume case
 // where a previous CompleteSpend call durably wrote VTXOStatusSpent, the VTXO
 // actor was cleaned up, and the OOR actor retries MarkInputsSpent before it has
@@ -497,6 +551,77 @@ func TestReserveForfeitRejectedWhenSpending(t *testing.T) {
 	require.Contains(t, err.Error(), "cannot accept pending forfeit")
 
 	// vtxo1 should be rolled back to LiveState.
+	refAny, ok := mgr.actors[vtxo1.Outpoint]
+	require.True(t, ok, "actor not found for vtxo1")
+
+	ref1, ok := refAny.(*mockVTXOActorRef)
+	require.True(t, ok, "expected *mockVTXOActorRef, got %T", refAny)
+
+	_, ok = ref1.state.(*LiveState)
+	require.True(t, ok, "expected LiveState after rollback, got %T",
+		ref1.state)
+}
+
+// TestReserveForfeitTimeoutRollsBackReservedVTXOs verifies that a blocked
+// child actor times out quickly and previously reserved VTXOs are released.
+func TestReserveForfeitTimeoutRollsBackReservedVTXOs(t *testing.T) {
+	t.Parallel()
+
+	vtxo1 := makeDescriptor(t, 50000, 0)
+	vtxo2 := makeDescriptor(t, 30000, 1)
+
+	mgr, _ := newTestManager(t, []*Descriptor{vtxo1, vtxo2})
+	mgr.cfg.ForfeitVTXOActorAskTimeout = 10 * time.Millisecond
+	mgr.actors[vtxo2.Outpoint] = &blockingVTXOActorRef{
+		id: vtxo2.Outpoint.String(),
+	}
+
+	start := time.Now()
+	result := mgr.Receive(t.Context(), &ReserveForfeitRequest{
+		Outpoints: []wire.OutPoint{
+			vtxo1.Outpoint, vtxo2.Outpoint,
+		},
+	})
+	_, err := result.Unpack()
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Less(t, time.Since(start), time.Second)
+
+	refAny, ok := mgr.actors[vtxo1.Outpoint]
+	require.True(t, ok, "actor not found for vtxo1")
+
+	ref1, ok := refAny.(*mockVTXOActorRef)
+	require.True(t, ok, "expected *mockVTXOActorRef, got %T", refAny)
+
+	_, ok = ref1.state.(*LiveState)
+	require.True(t, ok, "expected LiveState after rollback, got %T",
+		ref1.state)
+}
+
+// TestReserveForfeitCallerTimeoutStillRollsBack verifies that rollback does
+// not inherit a canceled caller context after a partial reservation.
+func TestReserveForfeitCallerTimeoutStillRollsBack(t *testing.T) {
+	t.Parallel()
+
+	vtxo1 := makeDescriptor(t, 50000, 0)
+	vtxo2 := makeDescriptor(t, 30000, 1)
+
+	mgr, _ := newTestManager(t, []*Descriptor{vtxo1, vtxo2})
+	mgr.cfg.ForfeitVTXOActorAskTimeout = time.Second
+	mgr.actors[vtxo2.Outpoint] = &blockingVTXOActorRef{
+		id: vtxo2.Outpoint.String(),
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
+	defer cancel()
+
+	result := mgr.Receive(ctx, &ReserveForfeitRequest{
+		Outpoints: []wire.OutPoint{
+			vtxo1.Outpoint, vtxo2.Outpoint,
+		},
+	})
+	_, err := result.Unpack()
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
 	refAny, ok := mgr.actors[vtxo1.Outpoint]
 	require.True(t, ok, "actor not found for vtxo1")
 


### PR DESCRIPTION
## Summary

This PR is the client-side OOR performance/liveness base from the high-concurrency arktest investigation.

The short version: OOR sends were timing out under stress while durable actor work, transport effects, signing effects, and VTXO-manager child-actor work were still queued behind each other. This branch keeps the durable state transitions durable, but moves slow/retriable side effects out of the hottest transaction paths, wakes outbox delivery immediately when work is available, and reduces repeated decode/manager pressure.

Main changes:

- durably queue OOR transport events through the actor outbox instead of sending them inline from the OOR actor turn
- move OOR signing work into a signing effect actor so wallet signing is no longer part of the core OOR actor critical path
- make stale replayed signing results no-ops once the OOR FSM has already advanced past the matching signing state
- detach the durable OOR submit context from RPC cancellation after input selection, while still making the RPC response respect the caller deadline
- bound detached-submit cleanup so a permanently stalled actor future cannot retain wallet/custom-input reservations forever
- strip inherited actor DB transactions from the durable submit path before sending across actor boundaries
- wake outbox publishers on enqueue so active same-process delivery is event-driven instead of waiting for the fallback poll interval
- relax durable mailbox/outbox fallback polling now that explicit wakeups handle the hot path
- cache decoded ancestry trees behind a bounded LRU so repeated VTXO ancestry reads do not re-decode the same committed tree blobs without retaining every historical tree forever
- bound refresh/forfeit VTXO child-actor asks so a stuck child cannot monopolize the shared VTXO manager admission path
- keep `oor/CLAUDE.md` and `oor/AGENTS.md` in sync after updating the OOR actor invariants

## Problem

High-concurrency arktest runs originally showed several symptoms that all looked like generic slow OOR payments from the outside:

- OOR `SendOOR` calls could hit the caller deadline even though durable actor work was still making progress
- transport submission lived too close to the durable actor transaction path
- signing work could extend the OOR actor turn instead of being treated as an effect
- durable outbox/mailbox loops relied too much on short polling intervals for latency
- repeated ancestry tree decoding showed up under stress
- refresh/forfeit child actors could hold the VTXO manager while unrelated OOR completion work waited behind it

The goal here is not to make the RPC ignore user deadlines. The RPC should still return when the caller context expires. The goal is to prevent cancellation, stale transactions, or slow side effects from corrupting or unnecessarily stretching the durable actor transition once OOR inputs have already been selected.

## Design

### OOR transport outbox

Transport events such as submit/finalize/ack are now durably enqueued and delivered to `ServerConn` after the OOR actor transition commits. The transport side effect runs outside the actor DB transaction and is retried through the actor delivery store.

This preserves the important durable ordering while keeping RPC transport work out of the actor transaction itself.

### Signing effect actor

OOR signing is moved into a signing effect actor. The OOR actor emits signing requests as effects, and the signing effect actor sends the resulting follow-up events back into OOR.

That gives signing the same durable/effect shape as transport work and avoids treating wallet signing as part of the core OOR actor state transition.

A durable signing request may be replayed after its result already reached the OOR actor. The OOR `DriveEventRequest` handler now treats stale duplicate `ArkSignedEvent`, `CheckpointsSignedEvent`, and matching signing `OutboxErrorEvent` messages as no-ops once the FSM has advanced past the corresponding signing state. That keeps signing-effect retry/replay idempotent without hiding fresh events that still belong to the current state.

### Submit context and actor transaction hygiene

The RPC server now detaches the durable OOR submit from caller cancellation after fresh inputs have been selected. The future wait still uses the caller context, so the RPC response can still deadline or cancel normally, but the durable actor submit is not killed by that response deadline.

If the caller stops waiting after the detached submit has been accepted, selected inputs remain owned by the in-flight actor work. Wallet locks and custom-input reservations are only released after the actor future actually completes with failure or a duplicate/existing-session response. This avoids making RPC timeout cleanup race against a still-running durable OOR transfer.

The response-wait cleanup path also has a long finite ceiling. If the detached actor future never completes, the cleanup waiter logs loudly after 10 minutes and releases the wallet/custom-input reservations rather than leaking a goroutine and held inputs indefinitely.

The submit path also uses the actor option that strips inherited DB transactions before crossing actor boundaries. That avoids passing a transaction that may be rolled back by the time downstream actor work uses it.

### Outbox wakeups and polling

The actor delivery store now wakes outbox publishers when work is enqueued. With explicit wakeups in the hot path, the durable mailbox/outbox fallback polling interval can be relaxed. This lowers idle DB pressure without adding same-process latency when new work is available.

### Ancestry tree cache

Decoded ancestry trees are cached by their serialized tree bytes. These trees represent committed round data and callers treat cached values as read-only. This avoids re-decoding the same tree blobs during repeated VTXO ancestry reads.

The cache is a fixed-size LRU, currently capped at 4096 entries. Eviction is opportunistic rather than correctness-driven: trees are immutable, age does not imply staleness, and a cache miss simply re-decodes the tree from durable storage. This keeps the optimization bounded for long-lived daemons and stress runs.

### VTXO manager child asks

Refresh/forfeit child-actor asks are bounded so one stuck child cannot hold the shared VTXO manager admission point indefinitely. Normal OOR spend reservation/completion still uses the caller deadline, so this does not introduce artificial short deadlines for healthy OOR payments.

## Telemetry

`SendOOR` keeps one low-noise success log with coarse phase durations such as input selection, change output construction, and OOR actor submission. Those fields are intended production telemetry for future stress/debug runs.

What was dropped from this PR was the temporary deep diagnostic instrumentation added during investigation, including the lower-level change-output breakdowns and the separate input-selection timing split. Those were useful while chasing the issue, but they are not needed in the final performance branch.

## Review Guide

Suggested review order:

1. `oor/actor.go`, `oor/actor_durable_message.go`, and `oor/signing_effect_actor.go` for the OOR outbox/effect shape and stale signing-result no-op handling.
2. `darepod/rpc_server.go` and `darepod/server.go` for submit context handling, bounded cleanup, effect actor wiring, and shutdown ordering.
3. `baselib/actor/*` and `db/actordelivery/*` for outbox publisher wakeups and durable polling behavior.
4. `db/ancestry_codec.go`, `db/vtxo_store.go`, and related tests for bounded ancestry tree caching.
5. `vtxo/manager.go` and `vtxo/manager_admission_test.go` for bounded child asks and rollback context behavior.
6. `oor/CLAUDE.md` and `oor/AGENTS.md` for the updated actor invariants.

## Validation

Local checks run on this branch:

```sh
make commitmsg-lint range=origin/main..HEAD
go test ./db -run 'TestAncestryTreeCache|TestUpsertAncestryPaths' -count=1
go test ./darepod -run 'TestSendOOR|TestSubmittedOORCleanup|TestIsAwaitContextError' -count=1
go test ./oor -run 'TestOORClientActorDriveEvent|Test.*Signing|Test.*Outbox|Test.*Transport' -count=1
GOGC=50 make lint
```

Additional focused package coverage from the branch history/review cycle included:

```sh
go test ./darepod ./oor ./baselib/actor
go test ./db ./vtxo ./darepod ./oor ./baselib/actor ./db/actordelivery
go test ./indexer ./darepod
```

The parent arktest stress stack that consumes this pointer no longer showed OOR `DeadlineExceeded` or `SQLITE_BUSY` failures in the relevant high-concurrency run after this client branch plus the parent SQLite timeout/mailbox/indexer changes. Remaining unexpected failures were refresh-round related and are intentionally left visible for follow-up work.
