### PR TITLE
client: trace OOR input selection

### DIFF
--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -1534,8 +1534,9 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 	}
 
 	var (
-		selectedInputs []oor.TransferInput
-		locked         *wallet.SelectAndLockVTXOsResponse
+		selectedInputs     []oor.TransferInput
+		locked             *wallet.SelectAndLockVTXOsResponse
+		inputWalletTimings wallet.SelectAndLockVTXOTimings
 	)
 
 	if len(req.CustomInputs) > 0 {
@@ -1614,6 +1615,7 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 				"unexpected response type: %T",
 				selectResp)
 		}
+		inputWalletTimings = locked.Timings
 		inputSelectDuration = time.Since(phaseStart)
 
 		outpoints := make(
@@ -1733,6 +1735,24 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 			policyResolveDuration),
 		slog.Duration("input_select_duration",
 			inputSelectDuration),
+		slog.Duration("input_wallet_handle_duration",
+			inputWalletTimings.HandleDuration),
+		slog.Duration("input_wallet_manager_ask_duration",
+			inputWalletTimings.ManagerAskDuration),
+		slog.Duration("input_wallet_translate_duration",
+			inputWalletTimings.TranslateDuration),
+		slog.Duration("input_manager_duration",
+			inputWalletTimings.ManagerTimings.TotalDuration),
+		slog.Duration("input_manager_list_live_duration",
+			inputWalletTimings.ManagerTimings.ListLiveDuration),
+		slog.Duration("input_manager_coin_select_duration",
+			inputWalletTimings.ManagerTimings.CoinSelectDuration),
+		slog.Duration("input_manager_reserve_duration",
+			inputWalletTimings.ManagerTimings.ReserveDuration),
+		slog.Duration("input_manager_rollback_duration",
+			inputWalletTimings.ManagerTimings.RollbackDuration),
+		slog.Duration("input_manager_build_response_duration",
+			inputWalletTimings.ManagerTimings.BuildResponseDuration),
 		slog.Duration("build_inputs_duration",
 			buildInputsDuration),
 		slog.Duration("change_output_duration",

--- a/lib/actormsg/vtxo_admission.go
+++ b/lib/actormsg/vtxo_admission.go
@@ -1,6 +1,8 @@
 package actormsg
 
 import (
+	"time"
+
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
@@ -48,6 +50,31 @@ type SelectedVTXO struct {
 	PkScript []byte
 }
 
+// SpendReservationTimings splits VTXO-manager spend admission latency into
+// the local phases that make up SelectAndReserveSpendResponse.
+type SpendReservationTimings struct {
+	// TotalDuration is the full manager handler time after it starts
+	// processing the message.
+	TotalDuration time.Duration
+
+	// ListLiveDuration is the time spent loading live candidate VTXOs.
+	ListLiveDuration time.Duration
+
+	// CoinSelectDuration is the local largest-first selection time.
+	CoinSelectDuration time.Duration
+
+	// ReserveDuration is the aggregate time spent asking child VTXO actors
+	// to reserve the selected outpoints.
+	ReserveDuration time.Duration
+
+	// RollbackDuration is the aggregate time spent releasing already
+	// reserved outpoints after a partial reservation failure.
+	RollbackDuration time.Duration
+
+	// BuildResponseDuration is the local response translation time.
+	BuildResponseDuration time.Duration
+}
+
 // SelectAndReserveSpendResponse returns the VTXOs that were selected and
 // reserved for an OOR spend.
 type SelectAndReserveSpendResponse struct {
@@ -56,6 +83,9 @@ type SelectAndReserveSpendResponse struct {
 
 	// TotalSelected is the sum of all selected VTXO amounts.
 	TotalSelected btcutil.Amount
+
+	// Timings splits manager-side admission time for diagnostics.
+	Timings SpendReservationTimings
 }
 
 // VTXOManagerResp implements the VTXOManagerResp marker interface.

--- a/vtxo/manager.go
+++ b/vtxo/manager.go
@@ -547,41 +547,67 @@ type reserveParams struct {
 // already-reserved outpoints. Returns the selected VTXO details and
 // total amount on success.
 func (m *Manager) selectAndReserveVTXOs(ctx context.Context,
-	p reserveParams) ([]SelectedVTXO, btcutil.Amount, error) {
+	p reserveParams) ([]SelectedVTXO, btcutil.Amount,
+	actormsg.SpendReservationTimings, error) {
+
+	startTime := time.Now()
+	var timings actormsg.SpendReservationTimings
+	finishTimings := func() {
+		timings.TotalDuration = time.Since(startTime)
+	}
+
+	rollback := func(reserved []wire.OutPoint) {
+		phaseStart := time.Now()
+		p.rollback(ctx, reserved)
+		timings.RollbackDuration += time.Since(phaseStart)
+	}
 
 	if p.targetAmount <= 0 {
-		return nil, 0, fmt.Errorf(
+		finishTimings()
+
+		return nil, 0, timings, fmt.Errorf(
 			"target amount must be positive",
 		)
 	}
 
 	// List live candidates from the store.
+	phaseStart := time.Now()
 	candidates, err := m.cfg.Store.ListVTXOsByStatus(
 		ctx, VTXOStatusLive,
 	)
+	timings.ListLiveDuration = time.Since(phaseStart)
 	if err != nil {
-		return nil, 0, fmt.Errorf(
+		finishTimings()
+
+		return nil, 0, timings, fmt.Errorf(
 			"list live vtxos: %w", err,
 		)
 	}
 
 	// Run largest-first selection.
+	phaseStart = time.Now()
 	selected := selectLargestFirst(candidates, p.targetAmount)
+	timings.CoinSelectDuration = time.Since(phaseStart)
 	if selected == nil {
-		return nil, 0, fmt.Errorf(
+		finishTimings()
+
+		return nil, 0, timings, fmt.Errorf(
 			"insufficient funds: need %d", p.targetAmount,
 		)
 	}
 
 	// Reserve each selected VTXO via its actor. Track successfully
 	// reserved outpoints so we can roll back on partial failure.
+	phaseStart = time.Now()
 	var reserved []wire.OutPoint
 	for _, vtxo := range selected {
 		ref, ok := m.actors[vtxo.Outpoint]
 		if !ok {
-			p.rollback(ctx, reserved)
+			timings.ReserveDuration = time.Since(phaseStart)
+			rollback(reserved)
+			finishTimings()
 
-			return nil, 0, fmt.Errorf(
+			return nil, 0, timings, fmt.Errorf(
 				"no actor for outpoint %s",
 				vtxo.Outpoint,
 			)
@@ -589,16 +615,22 @@ func (m *Manager) selectAndReserveVTXOs(ctx context.Context,
 
 		result := p.ask(ctx, ref, p.reserveEvent)
 		if _, err := result.Unpack(); err != nil {
+			timings.ReserveDuration = time.Since(phaseStart)
+			rollback(reserved)
+			finishTimings()
 			m.logger(ctx).WarnS(
 				ctx, p.label+" reserve failed", err,
 				slog.String(
 					"outpoint",
 					vtxo.Outpoint.String(),
 				),
+				slog.Duration(
+					"rollback_duration",
+					timings.RollbackDuration,
+				),
 			)
-			p.rollback(ctx, reserved)
 
-			return nil, 0, fmt.Errorf(
+			return nil, 0, timings, fmt.Errorf(
 				"reserve %s %s: %w", p.label,
 				vtxo.Outpoint, err,
 			)
@@ -606,8 +638,10 @@ func (m *Manager) selectAndReserveVTXOs(ctx context.Context,
 
 		reserved = append(reserved, vtxo.Outpoint)
 	}
+	timings.ReserveDuration = time.Since(phaseStart)
 
 	// Build the result with selected VTXO details.
+	phaseStart = time.Now()
 	var (
 		selectedVTXOs []SelectedVTXO
 		totalSelected btcutil.Amount
@@ -620,15 +654,10 @@ func (m *Manager) selectAndReserveVTXOs(ctx context.Context,
 		})
 		totalSelected += vtxo.Amount
 	}
+	timings.BuildResponseDuration = time.Since(phaseStart)
+	finishTimings()
 
-	m.logger(ctx).InfoS(
-		ctx, "Reserved VTXOs for "+p.label,
-		slog.Int("count", len(selected)),
-		slog.Int64("total", int64(totalSelected)),
-		slog.Int64("target", int64(p.targetAmount)),
-	)
-
-	return selectedVTXOs, totalSelected, nil
+	return selectedVTXOs, totalSelected, timings, nil
 }
 
 // handleSelectAndReserveSpend selects VTXOs covering the target amount using
@@ -638,13 +667,15 @@ func (m *Manager) selectAndReserveVTXOs(ctx context.Context,
 func (m *Manager) handleSelectAndReserveSpend(ctx context.Context,
 	req *SelectAndReserveSpendRequest) fn.Result[ManagerResp] {
 
-	vtxos, total, err := m.selectAndReserveVTXOs(ctx, reserveParams{
-		targetAmount: req.TargetAmount,
-		reserveEvent: &SpendReserveEvent{},
-		rollback:     m.rollbackSpend,
-		ask:          m.askVTXOActor,
-		label:        "spend",
-	})
+	vtxos, total, timings, err := m.selectAndReserveVTXOs(
+		ctx, reserveParams{
+			targetAmount: req.TargetAmount,
+			reserveEvent: &SpendReserveEvent{},
+			rollback:     m.rollbackSpend,
+			ask:          m.askVTXOActor,
+			label:        "spend",
+		},
+	)
 	if err != nil {
 		return fn.Err[ManagerResp](err)
 	}
@@ -652,6 +683,7 @@ func (m *Manager) handleSelectAndReserveSpend(ctx context.Context,
 	return fn.Ok[ManagerResp](&SelectAndReserveSpendResponse{
 		SelectedVTXOs: vtxos,
 		TotalSelected: total,
+		Timings:       timings,
 	})
 }
 
@@ -944,7 +976,7 @@ func (m *Manager) handleReleaseForfeit(ctx context.Context,
 func (m *Manager) handleSelectAndReserveForfeit(ctx context.Context,
 	req *SelectAndReserveForfeitRequest) fn.Result[ManagerResp] {
 
-	vtxos, total, err := m.selectAndReserveVTXOs(ctx, reserveParams{
+	vtxos, total, _, err := m.selectAndReserveVTXOs(ctx, reserveParams{
 		targetAmount: req.TargetAmount,
 		reserveEvent: &PendingForfeitEvent{},
 		rollback:     m.rollbackForfeit,

--- a/vtxo/manager_admission_test.go
+++ b/vtxo/manager_admission_test.go
@@ -236,6 +236,43 @@ func TestSelectAndReserveSpendMultipleVTXOs(t *testing.T) {
 	require.Equal(t, btcutil.Amount(55000), spendResp.TotalSelected)
 }
 
+// TestSelectAndReserveTimingsIncludeRollback verifies that error-path timings
+// include total manager time and partial-reservation rollback time.
+func TestSelectAndReserveTimingsIncludeRollback(t *testing.T) {
+	t.Parallel()
+
+	vtxo1 := makeDescriptor(t, 30000, 0)
+	vtxo2 := makeDescriptor(t, 25000, 1)
+
+	mgr, store := newTestManager(t, []*Descriptor{
+		vtxo1, vtxo2,
+	})
+	delete(mgr.actors, vtxo2.Outpoint)
+
+	store.On(
+		"ListVTXOsByStatus", t.Context(), VTXOStatusLive,
+	).Return([]*Descriptor{vtxo1, vtxo2}, nil)
+
+	_, _, timings, err := mgr.selectAndReserveVTXOs(
+		t.Context(), reserveParams{
+			targetAmount: 50000,
+			reserveEvent: &SpendReserveEvent{},
+			rollback: func(ctx context.Context,
+				ops []wire.OutPoint) {
+
+				time.Sleep(time.Millisecond)
+				mgr.rollbackSpend(ctx, ops)
+			},
+			ask:   mgr.askVTXOActor,
+			label: "spend",
+		},
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no actor for outpoint")
+	require.Positive(t, timings.TotalDuration)
+	require.GreaterOrEqual(t, timings.RollbackDuration, time.Millisecond)
+}
+
 // TestSelectAndReserveSpendInsufficientFunds verifies that selection fails
 // when candidates cannot cover the target.
 func TestSelectAndReserveSpendInsufficientFunds(t *testing.T) {

--- a/wallet/messages.go
+++ b/wallet/messages.go
@@ -1,11 +1,14 @@
 package wallet
 
 import (
+	"time"
+
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
 	"github.com/lightninglabs/darepo-client/chainsource"
+	"github.com/lightninglabs/darepo-client/lib/actormsg"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 )
 
@@ -373,6 +376,24 @@ type SelectedVTXO struct {
 	PkScript []byte
 }
 
+// SelectAndLockVTXOTimings splits wallet-side spend admission latency for OOR
+// diagnostics.
+type SelectAndLockVTXOTimings struct {
+	// HandleDuration is the full wallet actor handler time after it starts
+	// processing the message.
+	HandleDuration time.Duration
+
+	// ManagerAskDuration is the time spent waiting for the VTXO manager.
+	ManagerAskDuration time.Duration
+
+	// ManagerTimings splits the manager-side admission work.
+	ManagerTimings actormsg.SpendReservationTimings
+
+	// TranslateDuration is the local manager-to-wallet response mapping
+	// time.
+	TranslateDuration time.Duration
+}
+
 // SelectAndLockVTXOsResponse returns the VTXOs that were selected and locked.
 type SelectAndLockVTXOsResponse struct {
 	actor.BaseMessage
@@ -384,6 +405,9 @@ type SelectAndLockVTXOsResponse struct {
 
 	// TotalSelected is the sum of all selected VTXO amounts.
 	TotalSelected btcutil.Amount
+
+	// Timings splits wallet and manager admission work for diagnostics.
+	Timings SelectAndLockVTXOTimings
 }
 
 // MessageType returns the message type identifier for logging and debugging.

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -1414,14 +1414,16 @@ func (a *Ark) releaseManagerForfeit(ctx context.Context,
 func (a *Ark) handleSelectAndLockVTXOs(ctx context.Context,
 	req *SelectAndLockVTXOsRequest) fn.Result[WalletResp] {
 
-	a.logger(ctx).InfoS(ctx, "Selecting and locking VTXOs for spend",
-		slog.Int64("target", int64(req.TargetAmount)))
+	startTime := time.Now()
+	var timings SelectAndLockVTXOTimings
 
+	phaseStart := time.Now()
 	resp, err := a.askManager(
 		ctx, &actormsg.SelectAndReserveSpendRequest{
 			TargetAmount: req.TargetAmount,
 		},
 	)
+	timings.ManagerAskDuration = time.Since(phaseStart)
 	if err != nil {
 		return fn.Err[WalletResp](
 			fmt.Errorf("select and reserve: %w", err),
@@ -1430,8 +1432,10 @@ func (a *Ark) handleSelectAndLockVTXOs(ctx context.Context,
 
 	//nolint:forcetypeassert
 	mgrResp := resp.(*actormsg.SelectAndReserveSpendResponse)
+	timings.ManagerTimings = mgrResp.Timings
 
 	// Translate manager response to wallet response.
+	phaseStart = time.Now()
 	selected := make([]SelectedVTXO, len(mgrResp.SelectedVTXOs))
 	for i, v := range mgrResp.SelectedVTXOs {
 		selected[i] = SelectedVTXO{
@@ -1440,14 +1444,13 @@ func (a *Ark) handleSelectAndLockVTXOs(ctx context.Context,
 			PkScript: v.PkScript,
 		}
 	}
-
-	a.logger(ctx).InfoS(ctx, "VTXOs selected and locked",
-		slog.Int("count", len(selected)),
-		slog.Int64("total", int64(mgrResp.TotalSelected)))
+	timings.TranslateDuration = time.Since(phaseStart)
+	timings.HandleDuration = time.Since(startTime)
 
 	return fn.Ok[WalletResp](&SelectAndLockVTXOsResponse{
 		SelectedVTXOs: selected,
 		TotalSelected: mgrResp.TotalSelected,
+		Timings:       timings,
 	})
 }
 


### PR DESCRIPTION
## Summary

This stacks on #332 and adds diagnostics for the remaining high-concurrency OOR latency tail.

The latest arktest stress runs showed `input_select_duration` as a second p99/max head after change-output registration. This change splits fresh OOR input selection into wallet handler timing and VTXO manager admission timing so the next trace run can tell whether the tail is queueing, live-VTXO listing, coin selection, child reservation, rollback after partial reservation, or response construction.

The timing fields are included on the top-level `OOR transfer submitted` log line, which keeps each measurement tied to a single payment. Manager total duration is populated on error paths too, and rollback duration is tracked separately for partial-reservation failures. Lower-level wallet and manager handlers return the timing structs without emitting their own success logs, so the extra observability does not add per-layer info-log noise.

## Validation

- `go test ./lib/actormsg ./vtxo ./wallet ./darepod`
- `go test ./darepod -run 'TestSendOOR'`
- `go test ./vtxo -run 'TestSelectAndReserve(TimingsIncludeRollback|SpendSuccess|SpendMultipleVTXOs)' -count=1`
- `GOGC=50 make lint`
- `make commitmsg-lint range=origin/perf/oor-transport-outbox..HEAD`

