### PR TITLE
docs: nightly doc-gardening sweep 2026-05-02

### DIFF
--- a/rpc/oorpb/AGENTS.md
+++ b/rpc/oorpb/AGENTS.md
@@ -1,0 +1,44 @@
+# rpc/oorpb
+
+## Purpose
+
+Generated protobuf/gRPC stubs for the OOR (out-of-round) transfer protocol,
+plus hand-written `payloads.go` containing typed builder/parser helpers and
+the canonical mailbox method name constants used for routing OOR
+client↔server messages through the durable transport layer.
+
+## Key Types
+
+All `*.pb.go` files are generated — never edit directly; regenerate with
+`make rpc`. The manually-maintained `payloads.go` defines:
+
+- `ServiceName` — Fully-qualified mailbox service name
+  (`"oorpb.OORMailboxService"`) used for mailbox event routing.
+- `MethodSubmitPackage`, `MethodFinalizePackage`, `MethodIncomingAck` —
+  RPC method name constants for the three OOR wire flows.
+- `SigningDescriptor` — Minimal co-signing metadata (outpoint, policy
+  template, spend path, owner-leaf policy) passed from client to server.
+- `SubmitRejectedError` — Typed error returned by `ParseSubmitPackageResponse`
+  when the server issued a rejection; callers route on `Code` without
+  string-matching `Reason`.
+
+## Relationships
+
+- **Depends on**: `lib/tx/oor` (RecipientOutput), `lib/tx/psbtutil`
+  (PSBT encode/decode helpers), `btcd/wire`, `btcd/btcutil/psbt`.
+- **Depended on by**: `oor` (builds/parses OOR protocol messages),
+  `serverconn` (mailbox method dispatch by ServiceName/Method constants).
+
+## Invariants
+
+- **Never edit generated code** — regenerate via `make rpc`.
+- Method name constants in `payloads.go` must match the proto service
+  definition; mismatches silently drop events at the mailbox router.
+- `SubmitPackageResponse` carries either a `Success` or `Rejection` branch;
+  `ParseSubmitPackageResponse` returns `*SubmitRejectedError` for the
+  rejection case — callers must not treat a non-nil error as an I/O failure.
+
+## Deep Docs
+
+- [rpc/CLAUDE.md](../CLAUDE.md) — Parent rpc package overview.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/rpc/oorpb/CLAUDE.md
+++ b/rpc/oorpb/CLAUDE.md
@@ -1,0 +1,44 @@
+# rpc/oorpb
+
+## Purpose
+
+Generated protobuf/gRPC stubs for the OOR (out-of-round) transfer protocol,
+plus hand-written `payloads.go` containing typed builder/parser helpers and
+the canonical mailbox method name constants used for routing OOR
+client↔server messages through the durable transport layer.
+
+## Key Types
+
+All `*.pb.go` files are generated — never edit directly; regenerate with
+`make rpc`. The manually-maintained `payloads.go` defines:
+
+- `ServiceName` — Fully-qualified mailbox service name
+  (`"oorpb.OORMailboxService"`) used for mailbox event routing.
+- `MethodSubmitPackage`, `MethodFinalizePackage`, `MethodIncomingAck` —
+  RPC method name constants for the three OOR wire flows.
+- `SigningDescriptor` — Minimal co-signing metadata (outpoint, policy
+  template, spend path, owner-leaf policy) passed from client to server.
+- `SubmitRejectedError` — Typed error returned by `ParseSubmitPackageResponse`
+  when the server issued a rejection; callers route on `Code` without
+  string-matching `Reason`.
+
+## Relationships
+
+- **Depends on**: `lib/tx/oor` (RecipientOutput), `lib/tx/psbtutil`
+  (PSBT encode/decode helpers), `btcd/wire`, `btcd/btcutil/psbt`.
+- **Depended on by**: `oor` (builds/parses OOR protocol messages),
+  `serverconn` (mailbox method dispatch by ServiceName/Method constants).
+
+## Invariants
+
+- **Never edit generated code** — regenerate via `make rpc`.
+- Method name constants in `payloads.go` must match the proto service
+  definition; mismatches silently drop events at the mailbox router.
+- `SubmitPackageResponse` carries either a `Success` or `Rejection` branch;
+  `ParseSubmitPackageResponse` returns `*SubmitRejectedError` for the
+  rejection case — callers must not treat a non-nil error as an I/O failure.
+
+## Deep Docs
+
+- [rpc/CLAUDE.md](../CLAUDE.md) — Parent rpc package overview.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.


### PR DESCRIPTION
Nightly automated documentation sweep (2026-05-02).

**Changes:** Added `rpc/oorpb/CLAUDE.md` and `rpc/oorpb/AGENTS.md` — the only package with hand-written Go source (`payloads.go`) but no per-package docs. All sqlc-generated and proto-only packages were correctly skipped.

**Workflow run:** https://github.com/lightninglabs/darepo-client/actions/runs/0

Please review the updated `rpc/oorpb/CLAUDE.md` diff to verify the Key Types, Relationships, and Invariants sections are accurate.