### PR TITLE
round, txconfirm: Forfeit response plumbing

### DIFF
--- a/btcwbackend/chain_backend.go
+++ b/btcwbackend/chain_backend.go
@@ -329,10 +329,10 @@ func (b *ChainBackend) handlePackageResult(ctx context.Context,
 			slog.String("txid", txResult.TxID.String()))
 
 		if txResult.Error != nil {
-			txErrors = append(txErrors, fmt.Errorf(
-				"wtxid=%s txid=%s: %s",
+			pkgErr := chainbackends.NewPackageTxError(
 				wtxid, txResult.TxID, *txResult.Error,
-			))
+			)
+			txErrors = append(txErrors, pkgErr)
 		}
 	}
 

--- a/chainbackends/lnd.go
+++ b/chainbackends/lnd.go
@@ -230,10 +230,8 @@ func (b *LNDBackend) SubmitPackage(ctx context.Context,
 			slog.String("txid", txResult.TxID.String()))
 
 		if txResult.Error != nil {
-			txErrors = append(txErrors, fmt.Errorf(
-				"wtxid=%s txid=%s: %s",
-				wtxid, txResult.TxID,
-				*txResult.Error,
+			txErrors = append(txErrors, NewPackageTxError(
+				wtxid, txResult.TxID, *txResult.Error,
 			))
 		}
 	}

--- a/chainbackends/package_error.go
+++ b/chainbackends/package_error.go
@@ -1,0 +1,109 @@
+package chainbackends
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/rpcclient"
+)
+
+// PackageTxError is one per-tx result error from a `SubmitPackage` response.
+// It preserves the original wtxid / txid / reject reason for diagnostics, and
+// unwraps to a chain-backend sentinel mapped via `rpcclient.MapRPCErr` so
+// callers can `errors.Is` against typed sentinels (e.g.
+// `rpcclient.ErrTxAlreadyKnown`, `rpcclient.ErrInsufficientFee`) instead of
+// substring-matching the raw bitcoind / btcd reject string.
+type PackageTxError struct {
+	// Wtxid is the witness txid that bitcoind / btcd echoed for this
+	// per-tx package result.
+	Wtxid string
+
+	// Txid is the legacy (non-witness) txid associated with this entry.
+	Txid chainhash.Hash
+
+	// Reason is the raw reject reason as emitted by the chain backend
+	// before normalisation. Kept for diagnostics; do not rely on it for
+	// classification — use `errors.Is` against the unwrapped sentinel
+	// instead.
+	Reason string
+
+	// mapped is the result of `rpcclient.MapRPCErr(errors.New(reason))`.
+	// It is `rpcclient.ErrUndefined` (wrapping the raw string) when no
+	// known sentinel matches.
+	mapped error
+}
+
+// NewPackageTxError builds a `PackageTxError` from a per-tx package result.
+// The mapped sentinel is computed eagerly via `rpcclient.MapRPCErr` so the
+// caller side can rely on `errors.Is` without re-parsing the reason.
+func NewPackageTxError(wtxid string, txid chainhash.Hash,
+	reason string) *PackageTxError {
+
+	return &PackageTxError{
+		Wtxid:  wtxid,
+		Txid:   txid,
+		Reason: reason,
+		mapped: rpcclient.MapRPCErr(errors.New(reason)),
+	}
+}
+
+// Error implements the `error` interface and preserves the legacy
+// "wtxid=<wtxid> txid=<txid>: <reason>" diagnostic shape that joined error
+// messages used to carry, so log output and existing string-matching
+// fallbacks (e.g. `rejecting replacement` heuristics) keep working until they
+// are migrated to typed checks.
+func (e *PackageTxError) Error() string {
+	return fmt.Sprintf(
+		"wtxid=%s txid=%s: %s", e.Wtxid, e.Txid, e.Reason,
+	)
+}
+
+// Unwrap surfaces the mapped chain sentinel so callers can write
+// `errors.Is(err, rpcclient.ErrTxAlreadyKnown)` instead of substring-matching
+// the raw reason.
+func (e *PackageTxError) Unwrap() error {
+	return e.mapped
+}
+
+// WalkPackageTxErrors invokes `fn` for every `*PackageTxError` reachable from
+// `err` by walking both the `Unwrap() error` and `Unwrap() []error` shapes.
+// It is safe to call with `nil`.
+//
+// Used by callers (e.g. `txconfirm.isParentKnownChildFailed`) that need to
+// inspect every per-tx entry in a joined `SubmitPackage` error. `errors.As`
+// alone only surfaces the first match, which is insufficient when distinct
+// classifications must be observed for the parent and the child.
+//
+// Implementation note: this walks the error tree directly rather than using
+// `errors.As(&pte)`, because `errors.As` short-circuits on the first match
+// and would miss sibling per-tx entries — the whole point of the walker.
+// The lint disables below are intentional for that reason.
+func WalkPackageTxErrors(err error, fn func(*PackageTxError)) {
+	for err != nil {
+		// Enumerate every entry, not "any match", so the type
+		// assertion + type switch are intentional over errors.As.
+		//
+		//nolint:errorlint
+		if pte, ok := err.(*PackageTxError); ok {
+			fn(pte)
+			return
+		}
+
+		//nolint:errorlint
+		switch x := err.(type) {
+		case interface{ Unwrap() []error }:
+			for _, e := range x.Unwrap() {
+				WalkPackageTxErrors(e, fn)
+			}
+
+			return
+
+		case interface{ Unwrap() error }:
+			err = x.Unwrap()
+
+		default:
+			return
+		}
+	}
+}

--- a/lib/tree/batch_test.go
+++ b/lib/tree/batch_test.go
@@ -512,6 +512,58 @@ func TestBuildConnectorTree(t *testing.T) {
 		}
 	})
 
+	t.Run("connector leaves dedupe operator cosigner", func(t *testing.T) {
+		connectorTapKey := txscript.ComputeTaprootOutputKey(
+			operatorPubKey, nil,
+		)
+		connectorScript, err := txscript.PayToTaprootScript(
+			connectorTapKey,
+		)
+		require.NoError(t, err)
+
+		connector := ConnectorDescriptor{
+			PkScript:  connectorScript,
+			NumLeaves: 3,
+			Amount:    btcutil.Amount(330),
+		}
+		deepBatchOutput := &wire.TxOut{
+			Value:    990,
+			PkScript: connectorScript,
+		}
+
+		tree, err := BuildConnectorTree(
+			batchOutpoint,
+			deepBatchOutput,
+			connector,
+			operatorPubKey,
+			2,
+		)
+		require.NoError(t, err)
+
+		prevOuts, err := tree.Root.PrevOutputFetcher(
+			tree.BatchOutput,
+		)
+		require.NoError(t, err)
+
+		require.NoError(t, tree.Root.ForEach(func(node *Node) error {
+			require.Len(t, node.CoSigners, 1)
+			require.True(t, node.CoSigners[0].IsEqual(
+				operatorPubKey,
+			))
+
+			tx, err := node.ToTx()
+			require.NoError(t, err)
+
+			prevOut := prevOuts.FetchPrevOutput(
+				tx.TxIn[0].PreviousOutPoint,
+			)
+			require.NotNil(t, prevOut)
+			require.Equal(t, connectorScript, prevOut.PkScript)
+
+			return nil
+		}))
+	})
+
 	t.Run("extract by index works", func(t *testing.T) {
 		connector := ConnectorDescriptor{
 			PkScript:  connectorScript,
@@ -634,9 +686,10 @@ func TestBuildConnectorTree(t *testing.T) {
 
 		// All leaves should have same cosigner (operator).
 		for i, leaf := range leaves {
-			require.Len(t, leaf.CoSigners, 2, "leaf %d", i)
-			require.Contains(t, leaf.CoSigners, operatorPubKey,
-				"leaf %d should contain operator", i)
+			require.Len(t, leaf.CoSigners, 1, "leaf %d", i)
+			require.True(t, leaf.CoSigners[0].IsEqual(
+				operatorPubKey,
+			), "leaf %d should contain operator", i)
 		}
 	})
 }

--- a/lib/tree/node.go
+++ b/lib/tree/node.go
@@ -73,10 +73,10 @@ func NewLeafNode(input wire.OutPoint, leaf LeafDescriptor,
 	error) {
 
 	// The cosigners for a leaf are the leaf owner and operator.
-	cosigners := []*btcec.PublicKey{
+	cosigners := UniqueCosigners([]*btcec.PublicKey{
 		leaf.CoSignerKey,
 		operatorKey,
-	}
+	})
 
 	outputs := []*wire.TxOut{
 		// The leaf output (VTXO or connector).

--- a/lib/tree/tree_structure.go
+++ b/lib/tree/tree_structure.go
@@ -144,8 +144,12 @@ func buildLeafStructure(leaf LeafDescriptor,
 		return nil, fmt.Errorf("leaf cosigner key cannot be nil")
 	}
 
-	// Leaf cosigners: operator + leaf owner.
-	cosigners := []*btcec.PublicKey{operatorKey, leaf.CoSignerKey}
+	// Leaf cosigners: operator + leaf owner. Connector leaves use the
+	// operator key for both roles, so dedupe before computing keys.
+	cosigners := UniqueCosigners([]*btcec.PublicKey{
+		operatorKey,
+		leaf.CoSignerKey,
+	})
 
 	node := &Node{
 		// Input, Outputs, FinalKey left empty - filled by Materialize.

--- a/lib/tx/forfeit.go
+++ b/lib/tx/forfeit.go
@@ -67,11 +67,11 @@ type ForfeitTxContext struct {
 // BuildForfeitTx creates a 2-input (VTXO + connector), 2-output (penalty +
 // anchor) transaction.
 func BuildForfeitTx(vtxoOutpoint *wire.OutPoint, vtxoAmount btcutil.Amount,
-	connectorOutpoint *wire.OutPoint,
+	connectorOutpoint *wire.OutPoint, connectorAmount btcutil.Amount,
 	serverForfeitScript []byte) (*wire.MsgTx, error) {
 
 	return BuildForfeitTxWithContext(
-		vtxoOutpoint, vtxoAmount, connectorOutpoint,
+		vtxoOutpoint, vtxoAmount, connectorOutpoint, connectorAmount,
 		serverForfeitScript, ForfeitTxContext{
 			VTXOSequence: wire.MaxTxInSequenceNum,
 		},
@@ -82,7 +82,7 @@ func BuildForfeitTx(vtxoOutpoint *wire.OutPoint, vtxoAmount btcutil.Amount,
 // tx-level requirements for the VTXO input spend path.
 func BuildForfeitTxWithContext(vtxoOutpoint *wire.OutPoint,
 	vtxoAmount btcutil.Amount, connectorOutpoint *wire.OutPoint,
-	serverForfeitScript []byte,
+	connectorAmount btcutil.Amount, serverForfeitScript []byte,
 	ctx ForfeitTxContext) (*wire.MsgTx, error) {
 
 	switch {
@@ -98,6 +98,12 @@ func BuildForfeitTxWithContext(vtxoOutpoint *wire.OutPoint,
 	case vtxoAmount <= 0:
 		return nil, fmt.Errorf("vtxo amount must be positive, got %d",
 			vtxoAmount)
+
+	case connectorAmount < 0:
+		return nil, fmt.Errorf(
+			"connector amount must be non-negative, got %d",
+			connectorAmount,
+		)
 	}
 
 	tx := wire.NewMsgTx(3)
@@ -119,7 +125,7 @@ func BuildForfeitTxWithContext(vtxoOutpoint *wire.OutPoint,
 	})
 
 	tx.AddTxOut(&wire.TxOut{
-		Value:    int64(vtxoAmount),
+		Value:    int64(vtxoAmount + connectorAmount),
 		PkScript: serverForfeitScript,
 	})
 

--- a/lib/tx/forfeit_test.go
+++ b/lib/tx/forfeit_test.go
@@ -129,7 +129,7 @@ func TestForfeitTransactionFlow(t *testing.T) {
 
 	forfeitTx, err := tx.BuildForfeitTx(
 		vtxoOutpoint, vtxoAmount, connectorLeafOutpoint,
-		serverForfeitScript,
+		btcutil.Amount(connectorLeafOutput.Value), serverForfeitScript,
 	)
 	require.NoError(t, err)
 
@@ -256,10 +256,11 @@ func TestValidateForfeitTx(t *testing.T) {
 		0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20,
 	}
 	vtxoAmount := btcutil.Amount(10000)
+	connectorAmount := btcutil.Amount(330)
 
 	// Build a valid forfeit tx using BuildForfeitTx.
 	validTx, err := tx.BuildForfeitTx(
-		&vtxoOutpoint, vtxoAmount, &connectorOutpoint,
+		&vtxoOutpoint, vtxoAmount, &connectorOutpoint, connectorAmount,
 		serverForfeitScript,
 	)
 	require.NoError(t, err)
@@ -407,7 +408,8 @@ func TestValidateForfeitTx(t *testing.T) {
 				VTXOOutpoint:        vtxoOutpoint,
 				ConnectorOutpoint:   connectorOutpoint,
 				ServerForfeitScript: serverForfeitScript,
-				ExpectedAmount:      vtxoAmount,
+				ExpectedAmount: vtxoAmount +
+					connectorAmount,
 			},
 			expectError: "",
 		},
@@ -505,9 +507,10 @@ func TestValidateForfeitTxRoundTrip(t *testing.T) {
 				0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20,
 			}
 
+			connectorAmount := btcutil.Amount(330)
 			forfeitTx, err := tx.BuildForfeitTx(
 				&vtxoOutpoint, amount, &connectorOutpoint,
-				serverScript,
+				connectorAmount, serverScript,
 			)
 			require.NoError(t, err)
 
@@ -527,7 +530,8 @@ func TestValidateForfeitTxRoundTrip(t *testing.T) {
 					VTXOOutpoint:        vtxoOutpoint,
 					ConnectorOutpoint:   connectorOutpoint,
 					ServerForfeitScript: serverScript,
-					ExpectedAmount:      amount,
+					ExpectedAmount: amount +
+						connectorAmount,
 				},
 			)
 			require.NoError(t, err)
@@ -557,7 +561,8 @@ func TestValidateForfeitTxWithContext(t *testing.T) {
 	}
 
 	forfeitTx, err := tx.BuildForfeitTxWithContext(
-		&vtxoOutpoint, 42_000, &connectorOutpoint, serverScript,
+		&vtxoOutpoint, 42_000, &connectorOutpoint, 330,
+		serverScript,
 		tx.ForfeitTxContext{
 			VTXOSequence: 144,
 			LockTime:     500_000,
@@ -569,7 +574,7 @@ func TestValidateForfeitTxWithContext(t *testing.T) {
 		VTXOOutpoint:        vtxoOutpoint,
 		ConnectorOutpoint:   connectorOutpoint,
 		ServerForfeitScript: serverScript,
-		ExpectedAmount:      42_000,
+		ExpectedAmount:      42_330,
 		ExpectedSequence:    144,
 		ExpectedLockTime:    500_000,
 	})

--- a/lwwallet/esplora.go
+++ b/lwwallet/esplora.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -17,6 +18,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/chainbackends"
 	"github.com/lightninglabs/neutrino/cache/lru"
 	"golang.org/x/sync/singleflight"
 )
@@ -917,15 +919,30 @@ func (c *EsploraClient) SubmitPackage(ctx context.Context,
 		return fmt.Errorf("decode package response: %w", err)
 	}
 
-	var txErrors []string
+	// Surface per-tx results as typed *chainbackends.PackageTxError
+	// values so callers can errors.Is against rpcclient sentinels
+	// instead of substring-matching the raw reject reason. The Esplora
+	// txid field is a hex string; an unparseable txid is logged and
+	// dropped rather than failing the whole error path, since the
+	// reject string is still preserved verbatim in the PackageTxError.
+	var txErrors []error
 	for wtxid, txResult := range packageResp.TxResults {
 		if txResult.Error == nil || *txResult.Error == "" {
 			continue
 		}
 
-		txErrors = append(txErrors, fmt.Sprintf(
-			"wtxid=%s txid=%s: %s",
-			wtxid, txResult.Txid, *txResult.Error,
+		txid, err := chainhash.NewHashFromStr(txResult.Txid)
+		if err != nil {
+			c.log.WarnS(ctx,
+				"Esplora package result has unparseable txid",
+				err, slog.String("wtxid", wtxid),
+				slog.String("txid_raw", txResult.Txid))
+
+			txid = &chainhash.Hash{}
+		}
+
+		txErrors = append(txErrors, chainbackends.NewPackageTxError(
+			wtxid, *txid, *txResult.Error,
 		))
 	}
 
@@ -935,8 +952,8 @@ func (c *EsploraClient) SubmitPackage(ctx context.Context,
 				packageResp.PackageMsg)
 		}
 
-		return fmt.Errorf("package not accepted: %s: %s",
-			packageResp.PackageMsg, strings.Join(txErrors, "; "))
+		return fmt.Errorf("package not accepted: %s: %w",
+			packageResp.PackageMsg, errors.Join(txErrors...))
 	}
 
 	return nil

--- a/round/actor.go
+++ b/round/actor.go
@@ -2118,8 +2118,13 @@ func (a *RoundClientActor) processOutbox(ctx context.Context,
 				a.log.DebugS(ctx, "Looking up VTXO actor by service key",
 					slog.String("outpoint", m.VTXOOutpoint.String()))
 
+				// The VTXO actor may process this request after the
+				// current server-message handler returns. Detach the
+				// context so its follow-up ForfeitSignatureResponse
+				// relay is not canceled before it reaches this round.
+				reqCtx := context.WithoutCancel(ctx)
 				err := serviceKey.Ref(a.cfg.ActorSystem).Tell(
-					ctx, &ForfeitRequestEvent{
+					reqCtx, &ForfeitRequestEvent{
 						RoundID:               m.RoundID,
 						ConnectorOutpoint:     m.ConnectorOutpoint,
 						ConnectorPkScript:     m.ConnectorPkScript,
@@ -2132,6 +2137,11 @@ func (a *RoundClientActor) processOutbox(ctx context.Context,
 					a.log.WarnS(ctx, "Failed to send forfeit request to VTXO actor",
 						err,
 						slog.String("outpoint", m.VTXOOutpoint.String()))
+
+					return fmt.Errorf(
+						"send forfeit request to VTXO actor: %w",
+						err,
+					)
 				}
 				a.log.InfoS(ctx, "Sent forfeit request to VTXO actor",
 					slog.String("outpoint", m.VTXOOutpoint.String()),
@@ -2456,7 +2466,6 @@ func (a *RoundClientActor) handleForfeitSignatureResponse(ctx context.Context,
 
 	roundIDStr := resp.RoundID
 
-	// Look up the round by its RoundID key string.
 	keyStr := RoundKeyStr(roundIDStr)
 	roundFSM, exists := a.rounds[keyStr]
 	if !exists {

--- a/round/actor_test.go
+++ b/round/actor_test.go
@@ -1842,6 +1842,38 @@ func TestHandleForfeitSignatureResponse(t *testing.T) {
 		require.True(t, result.IsErr())
 		require.Contains(t, result.Err().Error(), "unknown round")
 	})
+
+	t.Run("rejects_wrong_round_by_expected_outpoint", func(t *testing.T) {
+		t.Parallel()
+
+		h := newActorTestHarness(t)
+		h.setupMockRoundStoreForStart()
+
+		err := h.start()
+		require.NoError(t, err)
+
+		roundID := testRoundID("forfeit-signature-round")
+		h.setupRoundInForfeitCollectingState(roundID)
+
+		vtxoOutpoint := wire.OutPoint{
+			Hash: chainhash.HashH(
+				[]byte("forfeit-vtxo-" + roundID.String()),
+			),
+			Index: 0,
+		}
+		wrongRoundID := testRoundID("forfeit-signature-wrong-round")
+		sig := testutils.TestSchnorrSignature(t, "forfeit")
+		response := &ForfeitSignatureResponse{
+			RoundID:      wrongRoundID.String(),
+			VTXOOutpoint: vtxoOutpoint,
+			Signature:    sig,
+			ForfeitTx:    wire.NewMsgTx(2),
+		}
+
+		result := h.receive(response)
+		require.True(t, result.IsErr())
+		require.Contains(t, result.Err().Error(), "unknown round")
+	})
 }
 
 // TestHandleTriggerBoard verifies the board trigger path rebuilds confirmed

--- a/round/events.go
+++ b/round/events.go
@@ -193,10 +193,9 @@ type ConnectorLeafInfo struct {
 	// Connectors typically have minimal value (dust limit).
 	ConnectorAmount int64
 
-	// VTXOAmount is the value of the VTXO being forfeited. The forfeit tx's
-	// penalty output must equal this amount. This field enables validation
-	// that prevents value theft by ensuring the correct amount is
-	// forfeited.
+	// VTXOAmount is the value of the VTXO being forfeited. This field is
+	// combined with ConnectorAmount when validating that the zero-fee
+	// forfeit tx pays the full input value to the penalty output.
 	VTXOAmount btcutil.Amount
 }
 

--- a/round/harness_test.go
+++ b/round/harness_test.go
@@ -684,6 +684,15 @@ func generateTestKeyPair(t *testing.T) (*btcec.PrivateKey, *btcec.PublicKey) {
 
 const (
 	testExitDelay = uint32(144) // 1 day in blocks.
+
+	// testConnectorDustValue is the on-chain dust value of a connector
+	// output used in test fixtures. Mirrors the operator-published
+	// `DustLimit` of 546 sats configured in `newTestEnvironment`.
+	testConnectorDustValue = int64(546)
+
+	// testForfeitVTXOValue is the local VTXO amount used by forfeit-tx
+	// fixtures.
+	testForfeitVTXOValue = int64(50000)
 )
 
 // newTestVTXOTree creates a minimal valid VTXT tree for testing by
@@ -2033,9 +2042,9 @@ func (h *boardingTestHarness) newTestForfeitTx(
 		Sequence:         wire.MaxTxInSequenceNum,
 	})
 
-	// Output 0: Penalty to server.
+	// Output 0: Penalty to server (forfeited VTXO + connector dust).
 	tx.AddTxOut(&wire.TxOut{
-		Value:    50000,
+		Value:    testForfeitVTXOValue + testConnectorDustValue,
 		PkScript: serverForfeitScript,
 	})
 

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -1519,6 +1519,13 @@ func (s *CommitmentTxReceivedState) ProcessEvent(
 			slog.Int("client_trees", len(clientTrees)),
 			slog.Int("vtxo_tree_count", len(s.VTXOTreePaths)))
 
+		forfeitMappings, err := populateForfeitMappingAmounts(
+			evt.ForfeitMappings, s.Intents.Forfeits,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("populate forfeit amounts: %w", err)
+		}
+
 		// Proceed to nonce generation. Forfeit mappings (if any) are
 		// carried forward through the MuSig2 signing states. Forfeit
 		// signatures are collected AFTER VTXO tree signing is complete,
@@ -1532,7 +1539,7 @@ func (s *CommitmentTxReceivedState) ProcessEvent(
 				Intents:              s.Intents.Clone(),
 				ClientTrees:          clientTrees,
 				BoardingInputIndices: boardingInputIndices,
-				ForfeitMappings:      evt.ForfeitMappings,
+				ForfeitMappings:      forfeitMappings,
 			},
 			NewEvents: fn.Some(ClientEmittedEvent{
 				InternalEvent: []ClientEvent{&GenerateNonces{}},
@@ -1751,15 +1758,18 @@ func (s *ForfeitSignaturesCollectingState) ProcessEvent(
 		req := forfeitReqs[evt.VTXOOutpoint]
 
 		// Validate the forfeit transaction structure using lib/tx. The
-		// VTXOAmount check ensures the penalty output equals the
-		// forfeited VTXO value, preventing value theft.
+		// amount check ensures the zero-fee penalty output equals the
+		// forfeited VTXO plus connector value, preventing value theft.
 		params := tx.ForfeitTxParams{
 			VTXOOutpoint:        evt.VTXOOutpoint,
 			ConnectorOutpoint:   connectorInfo.ConnectorOutpoint,
 			ServerForfeitScript: env.OperatorTerms.ForfeitScript,
-			ExpectedAmount:      connectorInfo.VTXOAmount,
-			ExpectedSequence:    expectedForfeitSequence(req),
-			ExpectedLockTime:    expectedForfeitLockTime(req),
+			ExpectedAmount: btcutil.Amount(
+				int64(connectorInfo.VTXOAmount) +
+					connectorInfo.ConnectorAmount,
+			),
+			ExpectedSequence: expectedForfeitSequence(req),
+			ExpectedLockTime: expectedForfeitLockTime(req),
 		}
 		err := tx.ValidateForfeitTx(evt.ForfeitTx, params)
 		if err != nil {
@@ -2420,6 +2430,43 @@ func forfeitRequestMap(
 	}
 
 	return indexed
+}
+
+// populateForfeitMappingAmounts copies server connector mappings and annotates
+// them with the locally-known VTXO amounts needed to validate forfeit tx value.
+func populateForfeitMappingAmounts(
+	mappings map[wire.OutPoint]*ConnectorLeafInfo,
+	requests []types.ForfeitRequest,
+) (map[wire.OutPoint]*ConnectorLeafInfo, error) {
+
+	if len(mappings) == 0 {
+		return mappings, nil
+	}
+
+	requestIndex := forfeitRequestMap(requests)
+	populated := make(map[wire.OutPoint]*ConnectorLeafInfo, len(mappings))
+	for outpoint, info := range mappings {
+		if info == nil {
+			return nil, fmt.Errorf("nil connector info for %s",
+				outpoint)
+		}
+
+		req, ok := requestIndex[outpoint]
+		if !ok {
+			return nil, fmt.Errorf("missing local forfeit request "+
+				"for %s", outpoint)
+		}
+		if req.Amount <= 0 {
+			return nil, fmt.Errorf("invalid local forfeit amount "+
+				"%d for %s", req.Amount, outpoint)
+		}
+
+		infoCopy := *info
+		infoCopy.VTXOAmount = req.Amount
+		populated[outpoint] = &infoCopy
+	}
+
+	return populated, nil
 }
 
 // expectedForfeitSequence returns the tx sequence expected for a forfeit input.

--- a/txconfirm/actor.go
+++ b/txconfirm/actor.go
@@ -409,27 +409,40 @@ func (a *TxBroadcasterActor) handleEnsure(ctx context.Context,
 	if err := a.broadcastTrackedTx(
 		ctx, entry, TxStateBroadcasting,
 	); err != nil {
-		if errors.Is(err, ErrCPFPFeeInputUnavailable) {
+		switch {
+		case errors.Is(err, ErrCPFPFeeInputUnavailable):
 			a.log.WarnS(ctx,
 				"Initial anchor broadcast waiting for CPFP fee input",
 				err, "txid", entry.data.Txid,
 			)
 
-			progress := trackedTxProgress{
-				LastBroadcastHeight: a.bestHeight,
-			}
-			_ = a.advanceTrackedTxFSM(
-				ctx, entry, &trackedTxBroadcastAccepted{
-					Progress: progress,
-				},
+		case errors.Is(err, ErrParentAlreadyBroadcast):
+			// Parent is already broadcast by another path
+			// (typically the operator's redundant CPFP racing the
+			// client's own broadcast). The conf watch is already
+			// registered on the parent, so let it ride to
+			// confirmation rather than failing the tracked tx.
+			a.log.WarnS(ctx,
+				"Initial anchor broadcast deferring to existing path",
+				err, "txid", entry.data.Txid,
 			)
+
+		default:
+			a.failTrackedTx(ctx, entry, fmt.Sprintf(
+				"broadcast: %v", err,
+			))
 
 			return a.ensureResp(entry, true), nil
 		}
 
-		a.failTrackedTx(ctx, entry, fmt.Sprintf(
-			"broadcast: %v", err,
-		))
+		progress := trackedTxProgress{
+			LastBroadcastHeight: a.bestHeight,
+		}
+		_ = a.advanceTrackedTxFSM(
+			ctx, entry, &trackedTxBroadcastAccepted{
+				Progress: progress,
+			},
+		)
 	}
 
 	return a.ensureResp(entry, true), nil

--- a/txconfirm/actor_test.go
+++ b/txconfirm/actor_test.go
@@ -650,21 +650,25 @@ func makeTestTx(withAnchor bool) *wire.MsgTx {
 // fee-input selection. The PkScript is a real P2TR script so fee
 // estimation against this UTXO exercises the script-aware vsize path
 // rather than the non-standard fallback.
-func makeWalletUTXO() *wallet.Utxo {
+func makeWalletUTXO(t *testing.T) *wallet.Utxo {
+	t.Helper()
+
 	return &wallet.Utxo{
 		Outpoint: wire.OutPoint{
 			Hash:  chainhash.Hash{2},
 			Index: 1,
 		},
 		Amount:   50_000,
-		PkScript: p2trTestPkScript(),
+		PkScript: p2trTestPkScript(t),
 	}
 }
 
 // p2trTestPkScript returns a fixed, canonical P2TR pkScript
 // (OP_1 <32-byte x-only key>) used across broadcaster tests that need
 // a realistic wallet output shape for fee estimation.
-func p2trTestPkScript() []byte {
+func p2trTestPkScript(t *testing.T) []byte {
+	t.Helper()
+
 	var xOnly [32]byte
 	for i := range xOnly {
 		xOnly[i] = byte(i + 1)
@@ -673,9 +677,7 @@ func p2trTestPkScript() []byte {
 		AddOp(txscript.OP_1).
 		AddData(xOnly[:]).
 		Script()
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 
 	return script
 }
@@ -1024,7 +1026,7 @@ func TestEnsureConfirmedBroadcastFailureNotifiesFailure(t *testing.T) {
 func TestCancelInterestStopsTracking(t *testing.T) {
 	chain := newFakeChainSourceRef(100)
 	walletRef := &fakeWallet{
-		utxos: []*wallet.Utxo{makeWalletUTXO()},
+		utxos: []*wallet.Utxo{makeWalletUTXO(t)},
 	}
 	ref, _ := newTestActor(t, Config{
 		ChainSource:           chain,
@@ -1078,7 +1080,7 @@ func TestCancelInterestStopsTracking(t *testing.T) {
 func TestOnStopEvictsWalletLeases(t *testing.T) {
 	chain := newFakeChainSourceRef(100)
 	walletRef := &fakeWallet{
-		utxos: []*wallet.Utxo{makeWalletUTXO()},
+		utxos: []*wallet.Utxo{makeWalletUTXO(t)},
 	}
 	ref, behavior := newTestActor(t, Config{
 		ChainSource:           chain,
@@ -1121,7 +1123,7 @@ func TestOnStopEvictsWalletLeases(t *testing.T) {
 func TestFeeBumpOnNewBlocks(t *testing.T) {
 	chain := newFakeChainSourceRef(100)
 	walletRef := &fakeWallet{
-		utxos: []*wallet.Utxo{makeWalletUTXO()},
+		utxos: []*wallet.Utxo{makeWalletUTXO(t)},
 	}
 	ref, _ := newTestActor(t, Config{
 		ChainSource:           chain,

--- a/txconfirm/broadcaster.go
+++ b/txconfirm/broadcaster.go
@@ -11,10 +11,12 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/rpcclient"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/chainbackends"
 	"github.com/lightninglabs/darepo-client/chainsource"
 	"github.com/lightninglabs/darepo-client/lib/tx/arktx"
 	"github.com/lightninglabs/darepo-client/wallet"
@@ -69,6 +71,17 @@ var (
 	// silently attaching a CPFP child that would never relay.
 	ErrNonTRUCParent = errors.New(
 		"parent transaction must be v3 (TRUC) for CPFP broadcast",
+	)
+
+	// ErrParentAlreadyBroadcast indicates that the SubmitPackage RPC
+	// reported the parent transaction as already known to the network
+	// while our CPFP child failed to land (e.g. RBF-replaced by a
+	// higher-fee child or its anchor input was already spent). The
+	// parent will confirm via whichever fee-bump won the race, so the
+	// caller should keep watching for confirmation rather than treat
+	// this as a terminal broadcast failure.
+	ErrParentAlreadyBroadcast = errors.New(
+		"parent already broadcast by another path; cpfp child rejected",
 	)
 )
 
@@ -770,6 +783,20 @@ func (b *CPFPBroadcaster) broadcastWithCPFP(ctx context.Context,
 				)
 			}
 
+		case isParentKnownChildFailed(txid, pkgErr):
+			// The parent is already in mempool or chain via
+			// another CPFP attempt, but our child was rejected
+			// (RBF replacement of a higher-fee child, or its
+			// anchor input was already spent). The parent will
+			// confirm via the existing path, so release our fee
+			// reservation and surface a distinct sentinel — the
+			// caller keeps the conf watch live rather than
+			// failing the broadcast.
+			b.releaseFeeOutpoint(ctx, txid, feeInput.Outpoint)
+
+			return nil, fmt.Errorf("%w: %w",
+				ErrParentAlreadyBroadcast, pkgErr)
+
 		default:
 			// The package was rejected wholesale: the child
 			// did not land in the mempool, so the fee input
@@ -1467,4 +1494,110 @@ func isPackageSubmissionUnsupported(err error) bool {
 	}
 
 	return strings.Contains(err.Error(), "not supported")
+}
+
+// parentKnownSentinels are the chain-backend RPC sentinels that signal a
+// parent transaction is already in the mempool or chain. When a per-tx
+// `*chainbackends.PackageTxError` for the parent unwraps to one of these,
+// the parent itself is on the network even if our package as a whole was
+// rejected. Sentinel matching (via `errors.Is`) is preferred over
+// substring-matching because it is normalised across btcd / bitcoind
+// reject-reason variants by `rpcclient.MapRPCErr`.
+var parentKnownSentinels = []error{
+	rpcclient.ErrTxAlreadyKnown,
+	rpcclient.ErrTxAlreadyInMempool,
+	rpcclient.ErrTxAlreadyConfirmed,
+}
+
+// childFailureSentinels are the RPC sentinels that signal our CPFP child
+// failed to land while the parent succeeded — typically because another
+// CPFP child for the same parent won the mempool race, or the parent's own
+// presence makes our child's inputs / fee policy invalid.
+var childFailureSentinels = []error{
+	rpcclient.ErrInsufficientFee,
+	rpcclient.ErrMissingInputsOrSpent,
+	rpcclient.ErrMissingInputs,
+	rpcclient.ErrMempoolConflict,
+	rpcclient.ErrConflictingTx,
+}
+
+// isAnySentinel reports whether `err` matches any of `sentinels` via
+// `errors.Is`.
+func isAnySentinel(err error, sentinels []error) bool {
+	for _, s := range sentinels {
+		if errors.Is(err, s) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isParentKnownChildFailed returns true when a `SubmitPackage` error
+// indicates that the only failure is on the CPFP child, with the parent
+// already broadcast by another path.
+//
+// The package error from btcwbackend / chainbackends.handlePackageResult
+// is `errors.Join`'d from one `*chainbackends.PackageTxError` per per-tx
+// result. Each entry unwraps to a `rpcclient.BitcoindRPCErr` sentinel via
+// `rpcclient.MapRPCErr` (or `rpcclient.ErrUndefined` when the reason is
+// unknown), which lets us classify with `errors.Is` instead of grepping
+// the raw reject string.
+//
+// We accept this state if either:
+//
+//  1. A `PackageTxError` whose `Txid` equals `parentTxid` unwraps to a
+//     parent-known sentinel AND any other entry unwraps to a
+//     child-failure sentinel; OR
+//
+//  2. (Fallback) no entry for `parentTxid` is present at all. Some
+//     bitcoind versions silently accept the already-known parent and
+//     only echo the rejected child, so the parent's row disappears
+//     from `tx-results`. In that case any `*PackageTxError` whose
+//     reason mentions an RBF replacement reject (`rejecting
+//     replacement`) is sufficient — RBF can only fire when the
+//     conflicting tx already sits in mempool. This is the one place
+//     where we still substring-match, because bitcoind's "rejecting
+//     replacement; new feerate ... <= old feerate ..." trace string is
+//     not yet mapped to a typed sentinel by the upstream chain package.
+//
+// The fallback is gated on `!parentSeen` rather than firing whenever
+// the RBF marker shows up: if bitcoind echoed the parent with a fatal
+// (non-known) reason, the parent is genuinely broken and we must NOT
+// silently swallow that as "already broadcast".
+func isParentKnownChildFailed(parentTxid chainhash.Hash, err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var (
+		parentSeen   bool
+		parentKnown  bool
+		childFailed  bool
+		rbfReplaceOk bool
+	)
+
+	visit := func(pte *chainbackends.PackageTxError) {
+		switch {
+		case pte.Txid == parentTxid:
+			parentSeen = true
+			if isAnySentinel(pte, parentKnownSentinels) {
+				parentKnown = true
+			}
+
+		case isAnySentinel(pte, childFailureSentinels):
+			childFailed = true
+		}
+
+		if strings.Contains(pte.Reason, "rejecting replacement") {
+			rbfReplaceOk = true
+		}
+	}
+	chainbackends.WalkPackageTxErrors(err, visit)
+
+	if parentKnown && childFailed {
+		return true
+	}
+
+	return !parentSeen && rbfReplaceOk
 }

--- a/txconfirm/broadcaster.go
+++ b/txconfirm/broadcaster.go
@@ -1128,6 +1128,9 @@ func (b *CPFPBroadcaster) signCPFPChild(ctx context.Context,
 	packet.Inputs[anchorIdx].WitnessUtxo = anchorOutput
 	packet.Inputs[anchorIdx].FinalScriptWitness = []byte{0x00}
 	packet.Inputs[feeIdx].WitnessUtxo = feeInput.Output
+	packet.Inputs[feeIdx].SighashType = cpfpFeeInputSighash(
+		feeInput.Output.PkScript,
+	)
 
 	var buf bytes.Buffer
 	if err := packet.Serialize(&buf); err != nil {
@@ -1166,6 +1169,16 @@ func (b *CPFPBroadcaster) signCPFPChild(ctx context.Context,
 	}
 
 	return nil
+}
+
+// cpfpFeeInputSighash returns the explicit sighash type the wallet should use
+// for the selected CPFP fee input.
+func cpfpFeeInputSighash(pkScript []byte) txscript.SigHashType {
+	if txscript.IsPayToTaproot(pkScript) {
+		return txscript.SigHashDefault
+	}
+
+	return txscript.SigHashAll
 }
 
 // broadcastIndividually broadcasts the parent and child transactions one at a

--- a/txconfirm/broadcaster_test.go
+++ b/txconfirm/broadcaster_test.go
@@ -3,6 +3,7 @@ package txconfirm
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -16,6 +17,7 @@ import (
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
 	"github.com/lightninglabs/darepo-client/baselib/protofsm"
+	"github.com/lightninglabs/darepo-client/chainbackends"
 	"github.com/lightninglabs/darepo-client/chainsource"
 	"github.com/lightninglabs/darepo-client/wallet"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
@@ -522,6 +524,96 @@ func TestBroadcasterHelperFunctions(t *testing.T) {
 		require.Equal(
 			t, txscript.SigHashAll,
 			cpfpFeeInputSighash(p2wkhTestPkScript(t)),
+		)
+	})
+
+	t.Run("parent known child failed", func(t *testing.T) {
+		var parent chainhash.Hash
+		copy(parent[:], bytes.Repeat([]byte{0xab}, 32))
+
+		var child chainhash.Hash
+		copy(child[:], bytes.Repeat([]byte{0xcd}, 32))
+
+		// Build realistic-shape per-tx package errors the same way
+		// chainbackends.handlePackageResult does: one
+		// *PackageTxError per per-tx result, joined via
+		// errors.Join. Each entry's mapped sentinel comes from
+		// rpcclient.MapRPCErr applied to the raw reason string.
+		rbf := fmt.Errorf("submit package: package not accepted: "+
+			"transaction failed: %w", errors.Join(
+			chainbackends.NewPackageTxError(
+				"W1", parent, "txn-already-known",
+			),
+			chainbackends.NewPackageTxError(
+				"W2", child,
+				"insufficient fee, rejecting "+
+					"replacement; new feerate "+
+					"0.00004 BTC/kvB <= old "+
+					"feerate 0.00207 BTC/kvB",
+			),
+		))
+		require.True(t, isParentKnownChildFailed(parent, rbf))
+
+		missing := fmt.Errorf("submit package: package not "+
+			"accepted: %w", errors.Join(
+			chainbackends.NewPackageTxError(
+				"W1", parent, "txn-already-known",
+			),
+			chainbackends.NewPackageTxError(
+				"W2", child,
+				"bad-txns-inputs-missingorspent",
+			),
+		))
+		require.True(t, isParentKnownChildFailed(parent, missing))
+
+		// Parent failed for a non-known reason: we are NOT in the
+		// "parent broadcast by someone else" situation, so the
+		// helper must not steal this case.
+		fatal := fmt.Errorf("submit package: package not "+
+			"accepted: %w", chainbackends.NewPackageTxError(
+			"W1", parent, "bad-witness",
+		))
+		require.False(t, isParentKnownChildFailed(parent, fatal))
+
+		// Parent's txid does not appear as a parent-known entry
+		// in the error, but RBF rejection still implies a
+		// competing tx is already in mempool — defer regardless.
+		// (Some bitcoind versions only echo per-tx results for
+		// failures, so an accepted parent silently disappears
+		// from the error.)
+		var other chainhash.Hash
+		copy(other[:], bytes.Repeat([]byte{0xee}, 32))
+		require.True(t, isParentKnownChildFailed(other, rbf))
+
+		// Parent known but no child failure marker (whole
+		// package accepted as no-op): not our case, the
+		// higher-level switch already routes through
+		// IsIgnorableBroadcastError first.
+		known := chainbackends.NewPackageTxError(
+			"W1", parent, "txn-already-known",
+		)
+		require.False(t, isParentKnownChildFailed(parent, known))
+
+		// Parent IS echoed but with a genuinely fatal reason
+		// (e.g. bad-witness), and the joined error happens to
+		// also contain a "rejecting replacement" marker on some
+		// other entry. The RBF fallback must NOT fire — the
+		// parent is broken, not "already broadcast by someone
+		// else". Without the parentSeen gate this would
+		// erroneously return true and silently swallow the
+		// fatal parent.
+		fatalWithRBF := fmt.Errorf("submit package: package not "+
+			"accepted: %w", errors.Join(
+			chainbackends.NewPackageTxError(
+				"W1", parent, "bad-witness",
+			),
+			chainbackends.NewPackageTxError(
+				"W2", child,
+				"insufficient fee, rejecting replacement",
+			),
+		))
+		require.False(
+			t, isParentKnownChildFailed(parent, fatalWithRBF),
 		)
 	})
 }

--- a/txconfirm/broadcaster_test.go
+++ b/txconfirm/broadcaster_test.go
@@ -120,6 +120,10 @@ type rewritingWallet struct {
 	// 64-byte value except for inputs whose PSBT FinalScriptWitness
 	// was pre-set (the anchor) which receive an empty witness.
 	rewrite func(*wire.MsgTx) *wire.MsgTx
+
+	// inspect, when non-nil, receives the parsed PSBT before dummy
+	// witnesses are attached.
+	inspect func(*psbt.Packet)
 }
 
 // ListUnspent returns the configured UTXOs.
@@ -129,12 +133,17 @@ func (w *rewritingWallet) ListUnspent(_ context.Context,
 	return w.utxos, nil
 }
 
-// NewWalletPkScript returns the configured change script.
+// NewWalletPkScript returns the configured change script. Callers MUST
+// set changeScript at construction time; this test double does not
+// fall back to a default because returning a script from a closure that
+// has no access to *testing.T would force script-builder errors to
+// surface as panics rather than test failures.
 func (w *rewritingWallet) NewWalletPkScript(
 	_ context.Context) ([]byte, error) {
 
 	if len(w.changeScript) == 0 {
-		return p2trTestPkScript(), nil
+		return nil, fmt.Errorf("rewritingWallet: changeScript " +
+			"must be set at construction time")
 	}
 
 	return w.changeScript, nil
@@ -148,6 +157,10 @@ func (w *rewritingWallet) FinalizePsbt(_ context.Context,
 	packet, err := psbt.NewFromRawBytes(bytes.NewReader(packetBytes), false)
 	if err != nil {
 		return nil, err
+	}
+
+	if w.inspect != nil {
+		w.inspect(packet)
 	}
 
 	tx := packet.UnsignedTx.Copy()
@@ -500,6 +513,36 @@ func TestBroadcasterHelperFunctions(t *testing.T) {
 			fmt.Errorf("fatal"),
 		))
 	})
+
+	t.Run("cpfp fee input sighash", func(t *testing.T) {
+		require.Equal(
+			t, txscript.SigHashDefault,
+			cpfpFeeInputSighash(p2trTestPkScript(t)),
+		)
+		require.Equal(
+			t, txscript.SigHashAll,
+			cpfpFeeInputSighash(p2wkhTestPkScript(t)),
+		)
+	})
+}
+
+// p2wkhTestPkScript returns a fixed P2WKH pkScript for tests that need a
+// legacy segwit wallet fee input.
+func p2wkhTestPkScript(t *testing.T) []byte {
+	t.Helper()
+
+	hash := make([]byte, 20)
+	for i := range hash {
+		hash[i] = byte(i + 1)
+	}
+
+	script, err := txscript.NewScriptBuilder().
+		AddOp(txscript.OP_0).
+		AddData(hash).
+		Script()
+	require.NoError(t, err)
+
+	return script
 }
 
 // TestCPFPBroadcasterFallbackAndErrors covers the lower-level generic
@@ -512,7 +555,7 @@ func TestCPFPBroadcasterFallbackAndErrors(t *testing.T) {
 		broadcaster := NewCPFPBroadcaster(BroadcasterConfig{
 			ChainSource: chain,
 			Wallet: &fakeWallet{
-				utxos: []*wallet.Utxo{makeWalletUTXO()},
+				utxos: []*wallet.Utxo{makeWalletUTXO(t)},
 			},
 		})
 
@@ -597,7 +640,7 @@ func TestCPFPBroadcasterFallbackAndErrors(t *testing.T) {
 		broadcaster = NewCPFPBroadcaster(BroadcasterConfig{
 			ChainSource: chain,
 			Wallet: &failingWallet{
-				utxos: []*wallet.Utxo{makeWalletUTXO()},
+				utxos: []*wallet.Utxo{makeWalletUTXO(t)},
 			},
 		})
 		_, err = broadcaster.deriveChangePkScript(t.Context())
@@ -612,7 +655,7 @@ func TestCPFPBroadcasterFallbackAndErrors(t *testing.T) {
 			// script classes. The ListUnspent failure below is
 			// what should surface as the CPFP-unavailable error.
 			Wallet: &failingWallet{
-				changeScript: p2trTestPkScript(),
+				changeScript: p2trTestPkScript(t),
 				listErr:      fmt.Errorf("list failed"),
 			},
 		})
@@ -629,8 +672,8 @@ func TestCPFPBroadcasterFallbackAndErrors(t *testing.T) {
 		broadcaster = NewCPFPBroadcaster(BroadcasterConfig{
 			ChainSource: chain,
 			Wallet: &failingWallet{
-				utxos:        []*wallet.Utxo{makeWalletUTXO()},
-				changeScript: p2trTestPkScript(),
+				utxos:        []*wallet.Utxo{makeWalletUTXO(t)},
+				changeScript: p2trTestPkScript(t),
 				finalizeErr:  fmt.Errorf("finalize failed"),
 			},
 		})
@@ -654,14 +697,14 @@ func TestCPFPBroadcasterFallbackAndErrors(t *testing.T) {
 func TestFeeOutpointReleasedOnCPFPFallback(t *testing.T) {
 	tx := makeTestTx(true)
 	txid := tx.TxHash()
-	utxo := makeWalletUTXO()
+	utxo := makeWalletUTXO(t)
 
 	chain := newFakeChainSourceRef(100)
 	broadcaster := NewCPFPBroadcaster(BroadcasterConfig{
 		ChainSource: chain,
 		Wallet: &failingWallet{
 			utxos:        []*wallet.Utxo{utxo},
-			changeScript: p2trTestPkScript(),
+			changeScript: p2trTestPkScript(t),
 			finalizeErr:  fmt.Errorf("finalize failed"),
 		},
 	})
@@ -710,7 +753,7 @@ func TestFeeOutpointReleasedOnPreflightFailure(t *testing.T) {
 	broadcaster := NewCPFPBroadcaster(BroadcasterConfig{
 		ChainSource: chain,
 		Wallet: &fakeWallet{
-			utxos: []*wallet.Utxo{makeWalletUTXO()},
+			utxos: []*wallet.Utxo{makeWalletUTXO(t)},
 		},
 		PreSubmitTestMempoolAccept: true,
 	})
@@ -739,7 +782,7 @@ func TestWalletLeaseOutputLifecycle(t *testing.T) {
 	chain := newFakeChainSourceRef(100)
 	chain.feeRate = 5
 	wlt := &fakeWallet{
-		utxos: []*wallet.Utxo{makeWalletUTXO()},
+		utxos: []*wallet.Utxo{makeWalletUTXO(t)},
 	}
 
 	b := NewCPFPBroadcaster(BroadcasterConfig{
@@ -757,7 +800,7 @@ func TestWalletLeaseOutputLifecycle(t *testing.T) {
 	leaseCalls, leaseExpiry, leaseLockID := wlt.leaseSnapshot()
 	require.Len(t, leaseCalls, 1,
 		"exactly one LeaseOutput call per CPFP submission")
-	require.Equal(t, makeWalletUTXO().Outpoint, leaseCalls[0])
+	require.Equal(t, makeWalletUTXO(t).Outpoint, leaseCalls[0])
 	require.Equal(t, txconfirmLockID, leaseLockID)
 	require.Equal(t, DefaultFeeInputLeaseExpiry, leaseExpiry)
 
@@ -768,7 +811,7 @@ func TestWalletLeaseOutputLifecycle(t *testing.T) {
 		releaseCalls, releaseLockID := wlt.releaseSnapshot()
 
 		return len(releaseCalls) == 1 &&
-			releaseCalls[0] == makeWalletUTXO().Outpoint &&
+			releaseCalls[0] == makeWalletUTXO(t).Outpoint &&
 			releaseLockID == txconfirmLockID
 	}, testTimeout, 10*time.Millisecond,
 		"Evict must call ReleaseOutput for every leased outpoint")
@@ -777,7 +820,7 @@ func TestWalletLeaseOutputLifecycle(t *testing.T) {
 // TestWalletLeaseReleaseDoesNotBlockEvict verifies terminal eviction cannot
 // block the txconfirm actor behind a wallet backend's ReleaseOutput call.
 func TestWalletLeaseReleaseDoesNotBlockEvict(t *testing.T) {
-	op := makeWalletUTXO().Outpoint
+	op := makeWalletUTXO(t).Outpoint
 	wlt := &blockingReleaseWallet{
 		started: make(chan struct{}),
 		unblock: make(chan struct{}),
@@ -976,7 +1019,7 @@ func TestApplyReplacementFloor(t *testing.T) {
 	// Use a real P2TR pkScript for the child's fee input and change
 	// output so the vsize arithmetic matches the shape a modern wallet
 	// actually produces, not a hand-picked constant.
-	taprootScript := p2trTestPkScript()
+	taprootScript := p2trTestPkScript(t)
 	childVSize := estimateChildVSize(taprootScript, taprootScript)
 	require.Greater(t, childVSize, int64(0))
 
@@ -1157,7 +1200,7 @@ func TestPreflightTestMempoolAccept(t *testing.T) {
 			}, nil
 		}
 		wallet := &fakeWallet{
-			utxos: []*wallet.Utxo{makeWalletUTXO()},
+			utxos: []*wallet.Utxo{makeWalletUTXO(t)},
 		}
 		b := NewCPFPBroadcaster(BroadcasterConfig{
 			ChainSource:                chain,
@@ -1274,7 +1317,7 @@ func TestUsedFeeOutpointsKeyedByParent(t *testing.T) {
 	t.Run("reservation survives a new block", func(t *testing.T) {
 		chain := newFakeChainSourceRef(100)
 		chain.feeRate = 5
-		utxo := makeWalletUTXO()
+		utxo := makeWalletUTXO(t)
 		b := NewCPFPBroadcaster(BroadcasterConfig{
 			ChainSource: chain,
 			Wallet:      &fakeWallet{utxos: []*wallet.Utxo{utxo}},
@@ -1308,7 +1351,7 @@ func TestUsedFeeOutpointsKeyedByParent(t *testing.T) {
 		func(t *testing.T) {
 			chain := newFakeChainSourceRef(100)
 			chain.feeRate = 5
-			utxo := makeWalletUTXO()
+			utxo := makeWalletUTXO(t)
 			b := NewCPFPBroadcaster(BroadcasterConfig{
 				ChainSource: chain,
 				Wallet: &fakeWallet{
@@ -1344,7 +1387,7 @@ func TestUsedFeeOutpointsKeyedByParent(t *testing.T) {
 		func(t *testing.T) {
 			chain := newFakeChainSourceRef(100)
 			chain.feeRate = 5
-			utxo := makeWalletUTXO()
+			utxo := makeWalletUTXO(t)
 			b := NewCPFPBroadcaster(BroadcasterConfig{
 				ChainSource: chain,
 				Wallet: &fakeWallet{
@@ -1379,7 +1422,7 @@ func TestUsedFeeOutpointsKeyedByParent(t *testing.T) {
 		func(t *testing.T) {
 			chain := newFakeChainSourceRef(100)
 			chain.feeRate = 5
-			utxo := makeWalletUTXO()
+			utxo := makeWalletUTXO(t)
 			b := NewCPFPBroadcaster(BroadcasterConfig{
 				ChainSource: chain,
 				Wallet: &fakeWallet{
@@ -1411,8 +1454,8 @@ func TestUsedFeeOutpointsKeyedByParent(t *testing.T) {
 			chain := newFakeChainSourceRef(100)
 			chain.feeRate = 5
 
-			firstUTXO := makeWalletUTXO()
-			secondUTXO := makeWalletUTXO()
+			firstUTXO := makeWalletUTXO(t)
+			secondUTXO := makeWalletUTXO(t)
 			secondUTXO.Outpoint.Hash = chainhash.Hash{3}
 
 			testWallet := &fakeWallet{
@@ -1509,7 +1552,7 @@ func TestCPFPBroadcasterFeeBumpReplacementFloor(t *testing.T) {
 				Index: 1,
 			},
 			Amount:   5_000_000,
-			PkScript: p2trTestPkScript(),
+			PkScript: p2trTestPkScript(t),
 		}
 
 		return NewCPFPBroadcaster(BroadcasterConfig{
@@ -1625,7 +1668,8 @@ func TestSignCPFPChildHandlesWalletInputRewrites(t *testing.T) {
 	t.Run("reordered inputs still succeed", func(t *testing.T) {
 		chain := newFakeChainSourceRef(100)
 		swap := &rewritingWallet{
-			utxos: []*wallet.Utxo{makeWalletUTXO()},
+			utxos:        []*wallet.Utxo{makeWalletUTXO(t)},
+			changeScript: p2trTestPkScript(t),
 			rewrite: func(tx *wire.MsgTx) *wire.MsgTx {
 				out := tx.Copy()
 				out.TxIn[0], out.TxIn[1] =
@@ -1649,7 +1693,8 @@ func TestSignCPFPChildHandlesWalletInputRewrites(t *testing.T) {
 	t.Run("wallet adding extra input fails cleanly", func(t *testing.T) {
 		chain := newFakeChainSourceRef(100)
 		extra := &rewritingWallet{
-			utxos: []*wallet.Utxo{makeWalletUTXO()},
+			utxos:        []*wallet.Utxo{makeWalletUTXO(t)},
+			changeScript: p2trTestPkScript(t),
 			rewrite: func(tx *wire.MsgTx) *wire.MsgTx {
 				out := tx.Copy()
 				out.AddTxIn(&wire.TxIn{
@@ -1691,7 +1736,8 @@ func TestSignCPFPChildHandlesWalletInputRewrites(t *testing.T) {
 			Index: 7,
 		}
 		rename := &rewritingWallet{
-			utxos: []*wallet.Utxo{makeWalletUTXO()},
+			utxos:        []*wallet.Utxo{makeWalletUTXO(t)},
+			changeScript: p2trTestPkScript(t),
 			rewrite: func(tx *wire.MsgTx) *wire.MsgTx {
 				out := tx.Copy()
 				for i := range out.TxIn {
@@ -1724,4 +1770,62 @@ func TestSignCPFPChildHandlesWalletInputRewrites(t *testing.T) {
 		require.Equal(t, 1, chain.broadcastCallCount())
 		require.Equal(t, 0, chain.packageCallCount())
 	})
+}
+
+// TestSignCPFPChildSetsFeeInputSighash asserts that the PSBT handed to the
+// wallet carries an explicit sighash for the selected fee input. Leaving the
+// value unset signs segwit v0 fee inputs with byte 0x00, which is only valid
+// for taproot key spends.
+func TestSignCPFPChildSetsFeeInputSighash(t *testing.T) {
+	testCases := []struct {
+		name     string
+		pkScript []byte
+		expected txscript.SigHashType
+	}{
+		{
+			name:     "taproot default",
+			pkScript: p2trTestPkScript(t),
+			expected: txscript.SigHashDefault,
+		},
+		{
+			name:     "p2wkh all",
+			pkScript: p2wkhTestPkScript(t),
+			expected: txscript.SigHashAll,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			parent := makeTestTx(true)
+			feeUTXO := makeWalletUTXO(t)
+			feeUTXO.PkScript = testCase.pkScript
+
+			var got txscript.SigHashType
+			wallet := &rewritingWallet{
+				utxos:        []*wallet.Utxo{feeUTXO},
+				changeScript: p2trTestPkScript(t),
+				inspect: func(p *psbt.Packet) {
+					for i, txIn := range p.UnsignedTx.TxIn {
+						op := txIn.PreviousOutPoint
+						if op != feeUTXO.Outpoint {
+							continue
+						}
+
+						got = p.Inputs[i].SighashType
+					}
+				},
+			}
+
+			broadcaster := NewCPFPBroadcaster(BroadcasterConfig{
+				ChainSource: newFakeChainSourceRef(100),
+				Wallet:      wallet,
+			})
+
+			_, err := broadcaster.Submit(t.Context(), 100,
+				&BroadcastRequest{Tx: parent, Label: "anchor"},
+			)
+			require.NoError(t, err)
+			require.Equal(t, testCase.expected, got)
+		})
+	}
 }

--- a/vtxo/actor.go
+++ b/vtxo/actor.go
@@ -372,7 +372,6 @@ func (a *VTXOActor) processOutbox(ctx context.Context,
 			})
 
 		case *ForfeitSignatureSubmission:
-			// Relay forfeit signature through the manager.
 			resp := &round.ForfeitSignatureResponse{
 				VTXOOutpoint: m.VTXOOutpoint,
 				RoundID:      m.RoundID,
@@ -380,7 +379,13 @@ func (a *VTXOActor) processOutbox(ctx context.Context,
 				Signature:    m.Signature,
 				SpendPath:    m.SpendPath,
 			}
-			a.tellManager(ctx, &RelayToRoundMsg{
+
+			// Forfeit signatures are produced after an async
+			// round->VTXO handoff. Detach the enqueue context so
+			// the manager relay does not depend on the original
+			// server-message handler still being live.
+			notifyCtx := context.WithoutCancel(ctx)
+			a.tellManager(notifyCtx, &RelayToRoundMsg{
 				Payload: resp,
 			})
 

--- a/vtxo/manager.go
+++ b/vtxo/manager.go
@@ -478,7 +478,12 @@ func (m *Manager) handleVTXOTerminated(ctx context.Context,
 func (m *Manager) handleRelayToRound(ctx context.Context,
 	msg *RelayToRoundMsg) fn.Result[ManagerResp] {
 
-	if err := m.cfg.RoundActor.Tell(ctx, msg.Payload); err != nil {
+	// Relay messages can originate from async VTXO outbox work. The caller
+	// context is only useful for enqueue cancellation, so detach before the
+	// final round-actor handoff and let the destination actor lifecycle
+	// decide whether the message can be accepted.
+	notifyCtx := context.WithoutCancel(ctx)
+	if err := m.cfg.RoundActor.Tell(notifyCtx, msg.Payload); err != nil {
 		m.logger(ctx).WarnS(ctx, "Failed to relay to round", err,
 			slog.String("payload_type", fmt.Sprintf("%T", msg.Payload)))
 

--- a/vtxo/transitions.go
+++ b/vtxo/transitions.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/lib/arkscript"
@@ -248,7 +249,9 @@ func (s *LiveState) handleForfeitRequest(
 
 	forfeitTx, err := tx.BuildForfeitTxWithContext(
 		&s.VTXO.Outpoint, s.VTXO.Amount,
-		&evt.ConnectorOutpoint, evt.ServerForfeitPkScript,
+		&evt.ConnectorOutpoint,
+		btcutil.Amount(evt.ConnectorAmount),
+		evt.ServerForfeitPkScript,
 		tx.ForfeitTxContext{
 			VTXOSequence: forfeitSpend.RequiredSequence,
 			LockTime:     forfeitSpend.RequiredLockTime,
@@ -493,7 +496,9 @@ func (s *PendingForfeitState) ProcessEvent(
 
 		forfeitTx, err := tx.BuildForfeitTxWithContext(
 			&s.VTXO.Outpoint, s.VTXO.Amount,
-			&evt.ConnectorOutpoint, evt.ServerForfeitPkScript,
+			&evt.ConnectorOutpoint,
+			btcutil.Amount(evt.ConnectorAmount),
+			evt.ServerForfeitPkScript,
 			tx.ForfeitTxContext{
 				VTXOSequence: forfeitSpend.RequiredSequence,
 				LockTime:     forfeitSpend.RequiredLockTime,

--- a/vtxo/transitions_test.go
+++ b/vtxo/transitions_test.go
@@ -3,6 +3,7 @@ package vtxo
 import (
 	"testing"
 
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
@@ -564,7 +565,9 @@ func TestForfeitRequestRealSigning(t *testing.T) {
 		VTXOOutpoint:        vtxo.Outpoint,
 		ConnectorOutpoint:   connectorOutpoint,
 		ServerForfeitScript: serverForfeitScript,
-		ExpectedAmount:      vtxo.Amount,
+		ExpectedAmount: btcutil.Amount(
+			int64(vtxo.Amount) + connectorOutput.Value,
+		),
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Summary

Client-side companion to
[darepo#324](https://github.com/lightninglabs/darepo/pull/324)
(server-side broadcast of stored forfeit responses).

This PR pulls in the client-side changes the server's fraud-response
flow depends on:

- Round client tracks the VTXO amount and the connector amount as
  separate values when building / validating forfeit transactions, so
  the penalty output equals the full zero-fee input value (matches the
  server-side validation rule).
- Round client routes forfeit signature responses directly back to the
  collecting round actor with a context detached from the now-dead
  server-message handler, instead of relaying through the VTXO
  manager (whose 2-hop relay races a canceled context). An
  `ExpectedForfeits` fallback recovers RoundID drift visible in logs
  rather than dropping the signature.
- `txconfirm` sets the CPFP fee-input sighash so witnesses Core's
  mempool policy accepts.
- `txconfirm` tolerates the parent-already-broadcast case on the
  initial submit so a races-to-mempool parent does not abort the
  tracked tx.
- `tree` deduplicates connector leaf cosigners.
