### PR TITLE
sdk: validate onion-forwarded out-swap events

### DIFF
--- a/cmd/darepocli/darepoclicommands/cmd_swap.go
+++ b/cmd/darepocli/darepoclicommands/cmd_swap.go
@@ -17,6 +17,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/daemonrpc"
+	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
 	sdkark "github.com/lightninglabs/darepo-client/sdk/ark"
 	"github.com/lightninglabs/darepo-client/sdk/swaps"
 	"github.com/lightningnetwork/lnd/keychain"
@@ -211,7 +212,7 @@ func swapReceive(cmd *cobra.Command, _ []string) error {
 
 	if verbose {
 		if err := printReceiveVerboseStart(
-			cmd, amount, session,
+			cmd, amount,
 		); err != nil {
 			return err
 		}
@@ -223,9 +224,11 @@ func swapReceive(cmd *cobra.Command, _ []string) error {
 	}
 
 	if verbose {
-		printReceiveVerboseFunding(
+		if err := printReceiveVerboseFunding(
 			cmd, outpoint, fundedAmount, session,
-		)
+		); err != nil {
+			return err
+		}
 	}
 
 	result, err := session.Claim(ctx, outpoint, fundedAmount)
@@ -243,25 +246,14 @@ func swapReceive(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-// printReceiveVerboseStart prints the expected incoming vHTLC scripts for one
-// receive flow before funding is observed.
-func printReceiveVerboseStart(cmd *cobra.Command, amount int64,
-	session *swaps.ReceiveSession) error {
-
-	info, err := session.VHTLCInfo()
-	if err != nil {
-		return fmt.Errorf("describe receive vhtlc: %w", err)
-	}
-
+// printReceiveVerboseStart prints the expected receive amount before the
+// server's mailbox event has provided the concrete vHTLC script.
+func printReceiveVerboseStart(cmd *cobra.Command, amount int64) error {
 	fmt.Fprintf(cmd.OutOrStdout(),
 		"\nIncoming vHTLC\n"+
 			"  amount:        %d sat\n"+
-			"  output script: %x\n"+
-			"  claim script:  %x\n"+
 			"  waiting for:   funding via paid invoice\n",
 		amount,
-		info.PkScript,
-		info.ClaimScript,
 	)
 
 	return nil
@@ -270,18 +262,29 @@ func printReceiveVerboseStart(cmd *cobra.Command, amount int64,
 // printReceiveVerboseFunding prints the funded vHTLC acceptance and the
 // upcoming preimage sweep step.
 func printReceiveVerboseFunding(cmd *cobra.Command, outpoint string,
-	amount int64, session *swaps.ReceiveSession) {
+	amount int64, session *swaps.ReceiveSession) error {
+
+	info, err := session.VHTLCInfo()
+	if err != nil {
+		return fmt.Errorf("describe receive vhtlc: %w", err)
+	}
 
 	fmt.Fprintf(cmd.OutOrStdout(),
 		"\nAccepted incoming vHTLC\n"+
 			"  outpoint: %s\n"+
 			"  amount:   %d sat\n"+
+			"  output script: %x\n"+
+			"  claim script:  %x\n"+
 			"\nSweeping vHTLC\n"+
 			"  preimage: %x\n",
 		outpoint,
 		amount,
+		info.PkScript,
+		info.ClaimScript,
 		session.Preimage[:],
 	)
+
+	return nil
 }
 
 // swapPay executes the swap pay command.
@@ -530,11 +533,15 @@ func buildSwapClient(cmd *cobra.Command,
 	}
 
 	serverConn := swaps.NewGRPCSwapServerConn(swapConn)
+	mailboxClient := mailboxpb.NewMailboxServiceClient(swapConn)
 
 	client := swaps.NewSwapClientWithStore(
 		serverConn, arkClient, nil,
 		clientInvoiceGenerator(invoiceKey, daemonClient, chainParams),
 		store,
+	)
+	client.SetOutSwapEventReceiver(
+		swaps.NewMailboxOutSwapEventReceiver(mailboxClient, ""),
 	)
 
 	cleanup := func() {

--- a/daemonrpc/daemon.pb.go
+++ b/daemonrpc/daemon.pb.go
@@ -1631,6 +1631,418 @@ func (x *NewReceiveScriptResponse) GetLabel() string {
 	return ""
 }
 
+type ReceiveAuthKeyRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// payment_hash is the 32-byte Lightning payment hash for the receive
+	// swap that will use the derived key.
+	PaymentHash   []byte `protobuf:"bytes,1,opt,name=payment_hash,json=paymentHash,proto3" json:"payment_hash,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ReceiveAuthKeyRequest) Reset() {
+	*x = ReceiveAuthKeyRequest{}
+	mi := &file_daemon_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ReceiveAuthKeyRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ReceiveAuthKeyRequest) ProtoMessage() {}
+
+func (x *ReceiveAuthKeyRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ReceiveAuthKeyRequest.ProtoReflect.Descriptor instead.
+func (*ReceiveAuthKeyRequest) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *ReceiveAuthKeyRequest) GetPaymentHash() []byte {
+	if x != nil {
+		return x.PaymentHash
+	}
+	return nil
+}
+
+type ReceiveAuthKeyResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// pubkey is the compressed public key for the payment-scoped receive-auth
+	// key. The private scalar never leaves the daemon.
+	Pubkey        []byte `protobuf:"bytes,1,opt,name=pubkey,proto3" json:"pubkey,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ReceiveAuthKeyResponse) Reset() {
+	*x = ReceiveAuthKeyResponse{}
+	mi := &file_daemon_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ReceiveAuthKeyResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ReceiveAuthKeyResponse) ProtoMessage() {}
+
+func (x *ReceiveAuthKeyResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ReceiveAuthKeyResponse.ProtoReflect.Descriptor instead.
+func (*ReceiveAuthKeyResponse) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *ReceiveAuthKeyResponse) GetPubkey() []byte {
+	if x != nil {
+		return x.Pubkey
+	}
+	return nil
+}
+
+type SignReceiveAuthMessageRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// payment_hash is the 32-byte Lightning payment hash for the receive
+	// swap whose receive-auth key signs this message.
+	PaymentHash []byte `protobuf:"bytes,1,opt,name=payment_hash,json=paymentHash,proto3" json:"payment_hash,omitempty"`
+	// message is the raw message to sign.
+	Message []byte `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+	// double_hash controls whether the message is double-SHA256 hashed before
+	// signing. If false, the daemon applies a single SHA256.
+	DoubleHash    bool `protobuf:"varint,3,opt,name=double_hash,json=doubleHash,proto3" json:"double_hash,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SignReceiveAuthMessageRequest) Reset() {
+	*x = SignReceiveAuthMessageRequest{}
+	mi := &file_daemon_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SignReceiveAuthMessageRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SignReceiveAuthMessageRequest) ProtoMessage() {}
+
+func (x *SignReceiveAuthMessageRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SignReceiveAuthMessageRequest.ProtoReflect.Descriptor instead.
+func (*SignReceiveAuthMessageRequest) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *SignReceiveAuthMessageRequest) GetPaymentHash() []byte {
+	if x != nil {
+		return x.PaymentHash
+	}
+	return nil
+}
+
+func (x *SignReceiveAuthMessageRequest) GetMessage() []byte {
+	if x != nil {
+		return x.Message
+	}
+	return nil
+}
+
+func (x *SignReceiveAuthMessageRequest) GetDoubleHash() bool {
+	if x != nil {
+		return x.DoubleHash
+	}
+	return false
+}
+
+type SignReceiveAuthMessageResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// signature is the DER-encoded ECDSA signature.
+	Signature     []byte `protobuf:"bytes,1,opt,name=signature,proto3" json:"signature,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SignReceiveAuthMessageResponse) Reset() {
+	*x = SignReceiveAuthMessageResponse{}
+	mi := &file_daemon_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SignReceiveAuthMessageResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SignReceiveAuthMessageResponse) ProtoMessage() {}
+
+func (x *SignReceiveAuthMessageResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SignReceiveAuthMessageResponse.ProtoReflect.Descriptor instead.
+func (*SignReceiveAuthMessageResponse) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{21}
+}
+
+func (x *SignReceiveAuthMessageResponse) GetSignature() []byte {
+	if x != nil {
+		return x.Signature
+	}
+	return nil
+}
+
+type SignReceiveAuthMessageCompactRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// payment_hash is the 32-byte Lightning payment hash for the receive
+	// swap whose receive-auth key signs this message.
+	PaymentHash []byte `protobuf:"bytes,1,opt,name=payment_hash,json=paymentHash,proto3" json:"payment_hash,omitempty"`
+	// message is the raw message to sign.
+	Message []byte `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+	// double_hash controls whether the message is double-SHA256 hashed before
+	// signing. If false, the daemon applies a single SHA256.
+	DoubleHash    bool `protobuf:"varint,3,opt,name=double_hash,json=doubleHash,proto3" json:"double_hash,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SignReceiveAuthMessageCompactRequest) Reset() {
+	*x = SignReceiveAuthMessageCompactRequest{}
+	mi := &file_daemon_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SignReceiveAuthMessageCompactRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SignReceiveAuthMessageCompactRequest) ProtoMessage() {}
+
+func (x *SignReceiveAuthMessageCompactRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SignReceiveAuthMessageCompactRequest.ProtoReflect.Descriptor instead.
+func (*SignReceiveAuthMessageCompactRequest) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{22}
+}
+
+func (x *SignReceiveAuthMessageCompactRequest) GetPaymentHash() []byte {
+	if x != nil {
+		return x.PaymentHash
+	}
+	return nil
+}
+
+func (x *SignReceiveAuthMessageCompactRequest) GetMessage() []byte {
+	if x != nil {
+		return x.Message
+	}
+	return nil
+}
+
+func (x *SignReceiveAuthMessageCompactRequest) GetDoubleHash() bool {
+	if x != nil {
+		return x.DoubleHash
+	}
+	return false
+}
+
+type SignReceiveAuthMessageCompactResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// signature is the compact public-key-recoverable ECDSA signature.
+	Signature     []byte `protobuf:"bytes,1,opt,name=signature,proto3" json:"signature,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SignReceiveAuthMessageCompactResponse) Reset() {
+	*x = SignReceiveAuthMessageCompactResponse{}
+	mi := &file_daemon_proto_msgTypes[23]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SignReceiveAuthMessageCompactResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SignReceiveAuthMessageCompactResponse) ProtoMessage() {}
+
+func (x *SignReceiveAuthMessageCompactResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[23]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SignReceiveAuthMessageCompactResponse.ProtoReflect.Descriptor instead.
+func (*SignReceiveAuthMessageCompactResponse) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{23}
+}
+
+func (x *SignReceiveAuthMessageCompactResponse) GetSignature() []byte {
+	if x != nil {
+		return x.Signature
+	}
+	return nil
+}
+
+type ReceiveAuthECDHRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// payment_hash is the 32-byte Lightning payment hash for the receive
+	// swap whose receive-auth key derives this shared secret.
+	PaymentHash []byte `protobuf:"bytes,1,opt,name=payment_hash,json=paymentHash,proto3" json:"payment_hash,omitempty"`
+	// pubkey is the remote compressed public key to use for ECDH.
+	Pubkey        []byte `protobuf:"bytes,2,opt,name=pubkey,proto3" json:"pubkey,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ReceiveAuthECDHRequest) Reset() {
+	*x = ReceiveAuthECDHRequest{}
+	mi := &file_daemon_proto_msgTypes[24]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ReceiveAuthECDHRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ReceiveAuthECDHRequest) ProtoMessage() {}
+
+func (x *ReceiveAuthECDHRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[24]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ReceiveAuthECDHRequest.ProtoReflect.Descriptor instead.
+func (*ReceiveAuthECDHRequest) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{24}
+}
+
+func (x *ReceiveAuthECDHRequest) GetPaymentHash() []byte {
+	if x != nil {
+		return x.PaymentHash
+	}
+	return nil
+}
+
+func (x *ReceiveAuthECDHRequest) GetPubkey() []byte {
+	if x != nil {
+		return x.Pubkey
+	}
+	return nil
+}
+
+type ReceiveAuthECDHResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// shared_secret is the 32-byte Sphinx shared secret.
+	SharedSecret  []byte `protobuf:"bytes,1,opt,name=shared_secret,json=sharedSecret,proto3" json:"shared_secret,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ReceiveAuthECDHResponse) Reset() {
+	*x = ReceiveAuthECDHResponse{}
+	mi := &file_daemon_proto_msgTypes[25]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ReceiveAuthECDHResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ReceiveAuthECDHResponse) ProtoMessage() {}
+
+func (x *ReceiveAuthECDHResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[25]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ReceiveAuthECDHResponse.ProtoReflect.Descriptor instead.
+func (*ReceiveAuthECDHResponse) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{25}
+}
+
+func (x *ReceiveAuthECDHResponse) GetSharedSecret() []byte {
+	if x != nil {
+		return x.SharedSecret
+	}
+	return nil
+}
+
 type GetIndexedVTXOByPkScriptRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// pk_script is the raw output script to query.
@@ -1644,7 +2056,7 @@ type GetIndexedVTXOByPkScriptRequest struct {
 
 func (x *GetIndexedVTXOByPkScriptRequest) Reset() {
 	*x = GetIndexedVTXOByPkScriptRequest{}
-	mi := &file_daemon_proto_msgTypes[18]
+	mi := &file_daemon_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1656,7 +2068,7 @@ func (x *GetIndexedVTXOByPkScriptRequest) String() string {
 func (*GetIndexedVTXOByPkScriptRequest) ProtoMessage() {}
 
 func (x *GetIndexedVTXOByPkScriptRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[18]
+	mi := &file_daemon_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1669,7 +2081,7 @@ func (x *GetIndexedVTXOByPkScriptRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetIndexedVTXOByPkScriptRequest.ProtoReflect.Descriptor instead.
 func (*GetIndexedVTXOByPkScriptRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{18}
+	return file_daemon_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *GetIndexedVTXOByPkScriptRequest) GetPkScript() []byte {
@@ -1696,7 +2108,7 @@ type GetIndexedVTXOByPkScriptResponse struct {
 
 func (x *GetIndexedVTXOByPkScriptResponse) Reset() {
 	*x = GetIndexedVTXOByPkScriptResponse{}
-	mi := &file_daemon_proto_msgTypes[19]
+	mi := &file_daemon_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1708,7 +2120,7 @@ func (x *GetIndexedVTXOByPkScriptResponse) String() string {
 func (*GetIndexedVTXOByPkScriptResponse) ProtoMessage() {}
 
 func (x *GetIndexedVTXOByPkScriptResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[19]
+	mi := &file_daemon_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1721,7 +2133,7 @@ func (x *GetIndexedVTXOByPkScriptResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetIndexedVTXOByPkScriptResponse.ProtoReflect.Descriptor instead.
 func (*GetIndexedVTXOByPkScriptResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{19}
+	return file_daemon_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *GetIndexedVTXOByPkScriptResponse) GetVtxo() *VTXO {
@@ -1743,7 +2155,7 @@ type GetIndexedOORSessionByTxidRequest struct {
 
 func (x *GetIndexedOORSessionByTxidRequest) Reset() {
 	*x = GetIndexedOORSessionByTxidRequest{}
-	mi := &file_daemon_proto_msgTypes[20]
+	mi := &file_daemon_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1755,7 +2167,7 @@ func (x *GetIndexedOORSessionByTxidRequest) String() string {
 func (*GetIndexedOORSessionByTxidRequest) ProtoMessage() {}
 
 func (x *GetIndexedOORSessionByTxidRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[20]
+	mi := &file_daemon_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1768,7 +2180,7 @@ func (x *GetIndexedOORSessionByTxidRequest) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use GetIndexedOORSessionByTxidRequest.ProtoReflect.Descriptor instead.
 func (*GetIndexedOORSessionByTxidRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{20}
+	return file_daemon_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *GetIndexedOORSessionByTxidRequest) GetPkScript() []byte {
@@ -1798,7 +2210,7 @@ type GetIndexedOORSessionByTxidResponse struct {
 
 func (x *GetIndexedOORSessionByTxidResponse) Reset() {
 	*x = GetIndexedOORSessionByTxidResponse{}
-	mi := &file_daemon_proto_msgTypes[21]
+	mi := &file_daemon_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1810,7 +2222,7 @@ func (x *GetIndexedOORSessionByTxidResponse) String() string {
 func (*GetIndexedOORSessionByTxidResponse) ProtoMessage() {}
 
 func (x *GetIndexedOORSessionByTxidResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[21]
+	mi := &file_daemon_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1823,7 +2235,7 @@ func (x *GetIndexedOORSessionByTxidResponse) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use GetIndexedOORSessionByTxidResponse.ProtoReflect.Descriptor instead.
 func (*GetIndexedOORSessionByTxidResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{21}
+	return file_daemon_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *GetIndexedOORSessionByTxidResponse) GetArkPsbt() []byte {
@@ -1861,7 +2273,7 @@ type Output struct {
 
 func (x *Output) Reset() {
 	*x = Output{}
-	mi := &file_daemon_proto_msgTypes[22]
+	mi := &file_daemon_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1873,7 +2285,7 @@ func (x *Output) String() string {
 func (*Output) ProtoMessage() {}
 
 func (x *Output) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[22]
+	mi := &file_daemon_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1886,7 +2298,7 @@ func (x *Output) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Output.ProtoReflect.Descriptor instead.
 func (*Output) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{22}
+	return file_daemon_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *Output) GetDestination() isOutput_Destination {
@@ -1983,7 +2395,7 @@ type SendVTXORequest struct {
 
 func (x *SendVTXORequest) Reset() {
 	*x = SendVTXORequest{}
-	mi := &file_daemon_proto_msgTypes[23]
+	mi := &file_daemon_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1995,7 +2407,7 @@ func (x *SendVTXORequest) String() string {
 func (*SendVTXORequest) ProtoMessage() {}
 
 func (x *SendVTXORequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[23]
+	mi := &file_daemon_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2008,7 +2420,7 @@ func (x *SendVTXORequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendVTXORequest.ProtoReflect.Descriptor instead.
 func (*SendVTXORequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{23}
+	return file_daemon_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *SendVTXORequest) GetRecipients() []*Output {
@@ -2048,7 +2460,7 @@ type SendVTXOResponse struct {
 
 func (x *SendVTXOResponse) Reset() {
 	*x = SendVTXOResponse{}
-	mi := &file_daemon_proto_msgTypes[24]
+	mi := &file_daemon_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2060,7 +2472,7 @@ func (x *SendVTXOResponse) String() string {
 func (*SendVTXOResponse) ProtoMessage() {}
 
 func (x *SendVTXOResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[24]
+	mi := &file_daemon_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2073,7 +2485,7 @@ func (x *SendVTXOResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendVTXOResponse.ProtoReflect.Descriptor instead.
 func (*SendVTXOResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{24}
+	return file_daemon_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *SendVTXOResponse) GetStatus() string {
@@ -2133,7 +2545,7 @@ type SendOORRequest struct {
 
 func (x *SendOORRequest) Reset() {
 	*x = SendOORRequest{}
-	mi := &file_daemon_proto_msgTypes[25]
+	mi := &file_daemon_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2145,7 +2557,7 @@ func (x *SendOORRequest) String() string {
 func (*SendOORRequest) ProtoMessage() {}
 
 func (x *SendOORRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[25]
+	mi := &file_daemon_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2158,7 +2570,7 @@ func (x *SendOORRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendOORRequest.ProtoReflect.Descriptor instead.
 func (*SendOORRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{25}
+	return file_daemon_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *SendOORRequest) GetRecipient() *Output {
@@ -2212,7 +2624,7 @@ type CustomOORInput struct {
 
 func (x *CustomOORInput) Reset() {
 	*x = CustomOORInput{}
-	mi := &file_daemon_proto_msgTypes[26]
+	mi := &file_daemon_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2224,7 +2636,7 @@ func (x *CustomOORInput) String() string {
 func (*CustomOORInput) ProtoMessage() {}
 
 func (x *CustomOORInput) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[26]
+	mi := &file_daemon_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2237,7 +2649,7 @@ func (x *CustomOORInput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CustomOORInput.ProtoReflect.Descriptor instead.
 func (*CustomOORInput) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{26}
+	return file_daemon_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *CustomOORInput) GetOutpoint() string {
@@ -2288,7 +2700,7 @@ type SendOORResponse struct {
 
 func (x *SendOORResponse) Reset() {
 	*x = SendOORResponse{}
-	mi := &file_daemon_proto_msgTypes[27]
+	mi := &file_daemon_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2300,7 +2712,7 @@ func (x *SendOORResponse) String() string {
 func (*SendOORResponse) ProtoMessage() {}
 
 func (x *SendOORResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[27]
+	mi := &file_daemon_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2313,7 +2725,7 @@ func (x *SendOORResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendOORResponse.ProtoReflect.Descriptor instead.
 func (*SendOORResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{27}
+	return file_daemon_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *SendOORResponse) GetStatus() string {
@@ -2343,7 +2755,7 @@ type OutpointSelection struct {
 
 func (x *OutpointSelection) Reset() {
 	*x = OutpointSelection{}
-	mi := &file_daemon_proto_msgTypes[28]
+	mi := &file_daemon_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2355,7 +2767,7 @@ func (x *OutpointSelection) String() string {
 func (*OutpointSelection) ProtoMessage() {}
 
 func (x *OutpointSelection) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[28]
+	mi := &file_daemon_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2368,7 +2780,7 @@ func (x *OutpointSelection) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OutpointSelection.ProtoReflect.Descriptor instead.
 func (*OutpointSelection) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{28}
+	return file_daemon_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *OutpointSelection) GetOutpoints() []string {
@@ -2393,7 +2805,7 @@ type RefreshVTXOsRequest struct {
 
 func (x *RefreshVTXOsRequest) Reset() {
 	*x = RefreshVTXOsRequest{}
-	mi := &file_daemon_proto_msgTypes[29]
+	mi := &file_daemon_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2405,7 +2817,7 @@ func (x *RefreshVTXOsRequest) String() string {
 func (*RefreshVTXOsRequest) ProtoMessage() {}
 
 func (x *RefreshVTXOsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[29]
+	mi := &file_daemon_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2418,7 +2830,7 @@ func (x *RefreshVTXOsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RefreshVTXOsRequest.ProtoReflect.Descriptor instead.
 func (*RefreshVTXOsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{29}
+	return file_daemon_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *RefreshVTXOsRequest) GetSelection() isRefreshVTXOsRequest_Selection {
@@ -2485,7 +2897,7 @@ type RefreshVTXOsResponse struct {
 
 func (x *RefreshVTXOsResponse) Reset() {
 	*x = RefreshVTXOsResponse{}
-	mi := &file_daemon_proto_msgTypes[30]
+	mi := &file_daemon_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2497,7 +2909,7 @@ func (x *RefreshVTXOsResponse) String() string {
 func (*RefreshVTXOsResponse) ProtoMessage() {}
 
 func (x *RefreshVTXOsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[30]
+	mi := &file_daemon_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2510,7 +2922,7 @@ func (x *RefreshVTXOsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RefreshVTXOsResponse.ProtoReflect.Descriptor instead.
 func (*RefreshVTXOsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{30}
+	return file_daemon_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *RefreshVTXOsResponse) GetQueuedOutpoints() []string {
@@ -2544,7 +2956,7 @@ type LeaveDestination struct {
 
 func (x *LeaveDestination) Reset() {
 	*x = LeaveDestination{}
-	mi := &file_daemon_proto_msgTypes[31]
+	mi := &file_daemon_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2556,7 +2968,7 @@ func (x *LeaveDestination) String() string {
 func (*LeaveDestination) ProtoMessage() {}
 
 func (x *LeaveDestination) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[31]
+	mi := &file_daemon_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2569,7 +2981,7 @@ func (x *LeaveDestination) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LeaveDestination.ProtoReflect.Descriptor instead.
 func (*LeaveDestination) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{31}
+	return file_daemon_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *LeaveDestination) GetTarget() isLeaveDestination_Target {
@@ -2650,7 +3062,7 @@ type LeaveVTXOsRequest struct {
 
 func (x *LeaveVTXOsRequest) Reset() {
 	*x = LeaveVTXOsRequest{}
-	mi := &file_daemon_proto_msgTypes[32]
+	mi := &file_daemon_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2662,7 +3074,7 @@ func (x *LeaveVTXOsRequest) String() string {
 func (*LeaveVTXOsRequest) ProtoMessage() {}
 
 func (x *LeaveVTXOsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[32]
+	mi := &file_daemon_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2675,7 +3087,7 @@ func (x *LeaveVTXOsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LeaveVTXOsRequest.ProtoReflect.Descriptor instead.
 func (*LeaveVTXOsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{32}
+	return file_daemon_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *LeaveVTXOsRequest) GetSelection() isLeaveVTXOsRequest_Selection {
@@ -2758,7 +3170,7 @@ type LeaveVTXOsResponse struct {
 
 func (x *LeaveVTXOsResponse) Reset() {
 	*x = LeaveVTXOsResponse{}
-	mi := &file_daemon_proto_msgTypes[33]
+	mi := &file_daemon_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2770,7 +3182,7 @@ func (x *LeaveVTXOsResponse) String() string {
 func (*LeaveVTXOsResponse) ProtoMessage() {}
 
 func (x *LeaveVTXOsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[33]
+	mi := &file_daemon_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2783,7 +3195,7 @@ func (x *LeaveVTXOsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LeaveVTXOsResponse.ProtoReflect.Descriptor instead.
 func (*LeaveVTXOsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{33}
+	return file_daemon_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *LeaveVTXOsResponse) GetQueuedOutpoints() []string {
@@ -2812,7 +3224,7 @@ type BoardRequest struct {
 
 func (x *BoardRequest) Reset() {
 	*x = BoardRequest{}
-	mi := &file_daemon_proto_msgTypes[34]
+	mi := &file_daemon_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2824,7 +3236,7 @@ func (x *BoardRequest) String() string {
 func (*BoardRequest) ProtoMessage() {}
 
 func (x *BoardRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[34]
+	mi := &file_daemon_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2837,7 +3249,7 @@ func (x *BoardRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoardRequest.ProtoReflect.Descriptor instead.
 func (*BoardRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{34}
+	return file_daemon_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *BoardRequest) GetTargetVtxoCount() uint32 {
@@ -2861,7 +3273,7 @@ type BoardResponse struct {
 
 func (x *BoardResponse) Reset() {
 	*x = BoardResponse{}
-	mi := &file_daemon_proto_msgTypes[35]
+	mi := &file_daemon_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2873,7 +3285,7 @@ func (x *BoardResponse) String() string {
 func (*BoardResponse) ProtoMessage() {}
 
 func (x *BoardResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[35]
+	mi := &file_daemon_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2886,7 +3298,7 @@ func (x *BoardResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoardResponse.ProtoReflect.Descriptor instead.
 func (*BoardResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{35}
+	return file_daemon_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *BoardResponse) GetStatus() string {
@@ -2916,7 +3328,7 @@ type RoundVTXOInfo struct {
 
 func (x *RoundVTXOInfo) Reset() {
 	*x = RoundVTXOInfo{}
-	mi := &file_daemon_proto_msgTypes[36]
+	mi := &file_daemon_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2928,7 +3340,7 @@ func (x *RoundVTXOInfo) String() string {
 func (*RoundVTXOInfo) ProtoMessage() {}
 
 func (x *RoundVTXOInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[36]
+	mi := &file_daemon_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2941,7 +3353,7 @@ func (x *RoundVTXOInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoundVTXOInfo.ProtoReflect.Descriptor instead.
 func (*RoundVTXOInfo) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{36}
+	return file_daemon_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *RoundVTXOInfo) GetOutpoint() string {
@@ -3001,7 +3413,7 @@ type RoundInfo struct {
 
 func (x *RoundInfo) Reset() {
 	*x = RoundInfo{}
-	mi := &file_daemon_proto_msgTypes[37]
+	mi := &file_daemon_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3013,7 +3425,7 @@ func (x *RoundInfo) String() string {
 func (*RoundInfo) ProtoMessage() {}
 
 func (x *RoundInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[37]
+	mi := &file_daemon_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3026,7 +3438,7 @@ func (x *RoundInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoundInfo.ProtoReflect.Descriptor instead.
 func (*RoundInfo) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{37}
+	return file_daemon_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *RoundInfo) GetRoundId() string {
@@ -3138,7 +3550,7 @@ type ListRoundsRequest struct {
 
 func (x *ListRoundsRequest) Reset() {
 	*x = ListRoundsRequest{}
-	mi := &file_daemon_proto_msgTypes[38]
+	mi := &file_daemon_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3150,7 +3562,7 @@ func (x *ListRoundsRequest) String() string {
 func (*ListRoundsRequest) ProtoMessage() {}
 
 func (x *ListRoundsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[38]
+	mi := &file_daemon_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3163,7 +3575,7 @@ func (x *ListRoundsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRoundsRequest.ProtoReflect.Descriptor instead.
 func (*ListRoundsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{38}
+	return file_daemon_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *ListRoundsRequest) GetPageSize() int32 {
@@ -3218,7 +3630,7 @@ type GetRoundRequest struct {
 
 func (x *GetRoundRequest) Reset() {
 	*x = GetRoundRequest{}
-	mi := &file_daemon_proto_msgTypes[39]
+	mi := &file_daemon_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3230,7 +3642,7 @@ func (x *GetRoundRequest) String() string {
 func (*GetRoundRequest) ProtoMessage() {}
 
 func (x *GetRoundRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[39]
+	mi := &file_daemon_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3243,7 +3655,7 @@ func (x *GetRoundRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRoundRequest.ProtoReflect.Descriptor instead.
 func (*GetRoundRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{39}
+	return file_daemon_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *GetRoundRequest) GetRoundId() string {
@@ -3263,7 +3675,7 @@ type GetRoundResponse struct {
 
 func (x *GetRoundResponse) Reset() {
 	*x = GetRoundResponse{}
-	mi := &file_daemon_proto_msgTypes[40]
+	mi := &file_daemon_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3275,7 +3687,7 @@ func (x *GetRoundResponse) String() string {
 func (*GetRoundResponse) ProtoMessage() {}
 
 func (x *GetRoundResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[40]
+	mi := &file_daemon_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3288,7 +3700,7 @@ func (x *GetRoundResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRoundResponse.ProtoReflect.Descriptor instead.
 func (*GetRoundResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{40}
+	return file_daemon_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *GetRoundResponse) GetRound() *RoundInfo {
@@ -3311,7 +3723,7 @@ type ListRoundsResponse struct {
 
 func (x *ListRoundsResponse) Reset() {
 	*x = ListRoundsResponse{}
-	mi := &file_daemon_proto_msgTypes[41]
+	mi := &file_daemon_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3323,7 +3735,7 @@ func (x *ListRoundsResponse) String() string {
 func (*ListRoundsResponse) ProtoMessage() {}
 
 func (x *ListRoundsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[41]
+	mi := &file_daemon_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3336,7 +3748,7 @@ func (x *ListRoundsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRoundsResponse.ProtoReflect.Descriptor instead.
 func (*ListRoundsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{41}
+	return file_daemon_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *ListRoundsResponse) GetRounds() []*RoundInfo {
@@ -3361,7 +3773,7 @@ type WatchRoundsRequest struct {
 
 func (x *WatchRoundsRequest) Reset() {
 	*x = WatchRoundsRequest{}
-	mi := &file_daemon_proto_msgTypes[42]
+	mi := &file_daemon_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3373,7 +3785,7 @@ func (x *WatchRoundsRequest) String() string {
 func (*WatchRoundsRequest) ProtoMessage() {}
 
 func (x *WatchRoundsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[42]
+	mi := &file_daemon_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3386,7 +3798,7 @@ func (x *WatchRoundsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchRoundsRequest.ProtoReflect.Descriptor instead.
 func (*WatchRoundsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{42}
+	return file_daemon_proto_rawDescGZIP(), []int{50}
 }
 
 type WatchRoundsResponse struct {
@@ -3400,7 +3812,7 @@ type WatchRoundsResponse struct {
 
 func (x *WatchRoundsResponse) Reset() {
 	*x = WatchRoundsResponse{}
-	mi := &file_daemon_proto_msgTypes[43]
+	mi := &file_daemon_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3412,7 +3824,7 @@ func (x *WatchRoundsResponse) String() string {
 func (*WatchRoundsResponse) ProtoMessage() {}
 
 func (x *WatchRoundsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[43]
+	mi := &file_daemon_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3425,7 +3837,7 @@ func (x *WatchRoundsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchRoundsResponse.ProtoReflect.Descriptor instead.
 func (*WatchRoundsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{43}
+	return file_daemon_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *WatchRoundsResponse) GetRound() *RoundInfo {
@@ -3463,7 +3875,7 @@ type OORSessionInfo struct {
 
 func (x *OORSessionInfo) Reset() {
 	*x = OORSessionInfo{}
-	mi := &file_daemon_proto_msgTypes[44]
+	mi := &file_daemon_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3475,7 +3887,7 @@ func (x *OORSessionInfo) String() string {
 func (*OORSessionInfo) ProtoMessage() {}
 
 func (x *OORSessionInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[44]
+	mi := &file_daemon_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3488,7 +3900,7 @@ func (x *OORSessionInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OORSessionInfo.ProtoReflect.Descriptor instead.
 func (*OORSessionInfo) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{44}
+	return file_daemon_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *OORSessionInfo) GetSessionId() string {
@@ -3572,7 +3984,7 @@ type ListOORSessionsRequest struct {
 
 func (x *ListOORSessionsRequest) Reset() {
 	*x = ListOORSessionsRequest{}
-	mi := &file_daemon_proto_msgTypes[45]
+	mi := &file_daemon_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3584,7 +3996,7 @@ func (x *ListOORSessionsRequest) String() string {
 func (*ListOORSessionsRequest) ProtoMessage() {}
 
 func (x *ListOORSessionsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[45]
+	mi := &file_daemon_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3597,7 +4009,7 @@ func (x *ListOORSessionsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListOORSessionsRequest.ProtoReflect.Descriptor instead.
 func (*ListOORSessionsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{45}
+	return file_daemon_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *ListOORSessionsRequest) GetPageSize() int32 {
@@ -3641,7 +4053,7 @@ type ListOORSessionsResponse struct {
 
 func (x *ListOORSessionsResponse) Reset() {
 	*x = ListOORSessionsResponse{}
-	mi := &file_daemon_proto_msgTypes[46]
+	mi := &file_daemon_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3653,7 +4065,7 @@ func (x *ListOORSessionsResponse) String() string {
 func (*ListOORSessionsResponse) ProtoMessage() {}
 
 func (x *ListOORSessionsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[46]
+	mi := &file_daemon_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3666,7 +4078,7 @@ func (x *ListOORSessionsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListOORSessionsResponse.ProtoReflect.Descriptor instead.
 func (*ListOORSessionsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{46}
+	return file_daemon_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *ListOORSessionsResponse) GetSessions() []*OORSessionInfo {
@@ -3693,7 +4105,7 @@ type GetOORSessionRequest struct {
 
 func (x *GetOORSessionRequest) Reset() {
 	*x = GetOORSessionRequest{}
-	mi := &file_daemon_proto_msgTypes[47]
+	mi := &file_daemon_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3705,7 +4117,7 @@ func (x *GetOORSessionRequest) String() string {
 func (*GetOORSessionRequest) ProtoMessage() {}
 
 func (x *GetOORSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[47]
+	mi := &file_daemon_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3718,7 +4130,7 @@ func (x *GetOORSessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetOORSessionRequest.ProtoReflect.Descriptor instead.
 func (*GetOORSessionRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{47}
+	return file_daemon_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *GetOORSessionRequest) GetSessionId() string {
@@ -3738,7 +4150,7 @@ type GetOORSessionResponse struct {
 
 func (x *GetOORSessionResponse) Reset() {
 	*x = GetOORSessionResponse{}
-	mi := &file_daemon_proto_msgTypes[48]
+	mi := &file_daemon_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3750,7 +4162,7 @@ func (x *GetOORSessionResponse) String() string {
 func (*GetOORSessionResponse) ProtoMessage() {}
 
 func (x *GetOORSessionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[48]
+	mi := &file_daemon_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3763,7 +4175,7 @@ func (x *GetOORSessionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetOORSessionResponse.ProtoReflect.Descriptor instead.
 func (*GetOORSessionResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{48}
+	return file_daemon_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *GetOORSessionResponse) GetSession() *OORSessionInfo {
@@ -3791,7 +4203,7 @@ type EstimateFeeRequest struct {
 
 func (x *EstimateFeeRequest) Reset() {
 	*x = EstimateFeeRequest{}
-	mi := &file_daemon_proto_msgTypes[49]
+	mi := &file_daemon_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3803,7 +4215,7 @@ func (x *EstimateFeeRequest) String() string {
 func (*EstimateFeeRequest) ProtoMessage() {}
 
 func (x *EstimateFeeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[49]
+	mi := &file_daemon_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3816,7 +4228,7 @@ func (x *EstimateFeeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EstimateFeeRequest.ProtoReflect.Descriptor instead.
 func (*EstimateFeeRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{49}
+	return file_daemon_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *EstimateFeeRequest) GetAmountSat() int64 {
@@ -3870,7 +4282,7 @@ type EstimateFeeResponse struct {
 
 func (x *EstimateFeeResponse) Reset() {
 	*x = EstimateFeeResponse{}
-	mi := &file_daemon_proto_msgTypes[50]
+	mi := &file_daemon_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3882,7 +4294,7 @@ func (x *EstimateFeeResponse) String() string {
 func (*EstimateFeeResponse) ProtoMessage() {}
 
 func (x *EstimateFeeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[50]
+	mi := &file_daemon_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3895,7 +4307,7 @@ func (x *EstimateFeeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EstimateFeeResponse.ProtoReflect.Descriptor instead.
 func (*EstimateFeeResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{50}
+	return file_daemon_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *EstimateFeeResponse) GetLiquidityFeeSat() int64 {
@@ -3965,7 +4377,7 @@ type GetFeeHistoryRequest struct {
 
 func (x *GetFeeHistoryRequest) Reset() {
 	*x = GetFeeHistoryRequest{}
-	mi := &file_daemon_proto_msgTypes[51]
+	mi := &file_daemon_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3977,7 +4389,7 @@ func (x *GetFeeHistoryRequest) String() string {
 func (*GetFeeHistoryRequest) ProtoMessage() {}
 
 func (x *GetFeeHistoryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[51]
+	mi := &file_daemon_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3990,7 +4402,7 @@ func (x *GetFeeHistoryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetFeeHistoryRequest.ProtoReflect.Descriptor instead.
 func (*GetFeeHistoryRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{51}
+	return file_daemon_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *GetFeeHistoryRequest) GetLimit() uint32 {
@@ -4065,7 +4477,7 @@ type FeeHistoryEntry struct {
 
 func (x *FeeHistoryEntry) Reset() {
 	*x = FeeHistoryEntry{}
-	mi := &file_daemon_proto_msgTypes[52]
+	mi := &file_daemon_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4077,7 +4489,7 @@ func (x *FeeHistoryEntry) String() string {
 func (*FeeHistoryEntry) ProtoMessage() {}
 
 func (x *FeeHistoryEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[52]
+	mi := &file_daemon_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4090,7 +4502,7 @@ func (x *FeeHistoryEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FeeHistoryEntry.ProtoReflect.Descriptor instead.
 func (*FeeHistoryEntry) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{52}
+	return file_daemon_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *FeeHistoryEntry) GetEntryId() int64 {
@@ -4170,7 +4582,7 @@ type GetFeeHistoryResponse struct {
 
 func (x *GetFeeHistoryResponse) Reset() {
 	*x = GetFeeHistoryResponse{}
-	mi := &file_daemon_proto_msgTypes[53]
+	mi := &file_daemon_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4182,7 +4594,7 @@ func (x *GetFeeHistoryResponse) String() string {
 func (*GetFeeHistoryResponse) ProtoMessage() {}
 
 func (x *GetFeeHistoryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[53]
+	mi := &file_daemon_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4195,7 +4607,7 @@ func (x *GetFeeHistoryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetFeeHistoryResponse.ProtoReflect.Descriptor instead.
 func (*GetFeeHistoryResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{53}
+	return file_daemon_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *GetFeeHistoryResponse) GetEntries() []*FeeHistoryEntry {
@@ -4223,7 +4635,7 @@ type UnrollRequest struct {
 
 func (x *UnrollRequest) Reset() {
 	*x = UnrollRequest{}
-	mi := &file_daemon_proto_msgTypes[54]
+	mi := &file_daemon_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4235,7 +4647,7 @@ func (x *UnrollRequest) String() string {
 func (*UnrollRequest) ProtoMessage() {}
 
 func (x *UnrollRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[54]
+	mi := &file_daemon_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4248,7 +4660,7 @@ func (x *UnrollRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnrollRequest.ProtoReflect.Descriptor instead.
 func (*UnrollRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{54}
+	return file_daemon_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *UnrollRequest) GetOutpoint() string {
@@ -4271,7 +4683,7 @@ type UnrollResponse struct {
 
 func (x *UnrollResponse) Reset() {
 	*x = UnrollResponse{}
-	mi := &file_daemon_proto_msgTypes[55]
+	mi := &file_daemon_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4283,7 +4695,7 @@ func (x *UnrollResponse) String() string {
 func (*UnrollResponse) ProtoMessage() {}
 
 func (x *UnrollResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[55]
+	mi := &file_daemon_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4296,7 +4708,7 @@ func (x *UnrollResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnrollResponse.ProtoReflect.Descriptor instead.
 func (*UnrollResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{55}
+	return file_daemon_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *UnrollResponse) GetCreated() bool {
@@ -4323,7 +4735,7 @@ type GetUnrollStatusRequest struct {
 
 func (x *GetUnrollStatusRequest) Reset() {
 	*x = GetUnrollStatusRequest{}
-	mi := &file_daemon_proto_msgTypes[56]
+	mi := &file_daemon_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4335,7 +4747,7 @@ func (x *GetUnrollStatusRequest) String() string {
 func (*GetUnrollStatusRequest) ProtoMessage() {}
 
 func (x *GetUnrollStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[56]
+	mi := &file_daemon_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4348,7 +4760,7 @@ func (x *GetUnrollStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUnrollStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetUnrollStatusRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{56}
+	return file_daemon_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *GetUnrollStatusRequest) GetOutpoint() string {
@@ -4376,7 +4788,7 @@ type GetUnrollStatusResponse struct {
 
 func (x *GetUnrollStatusResponse) Reset() {
 	*x = GetUnrollStatusResponse{}
-	mi := &file_daemon_proto_msgTypes[57]
+	mi := &file_daemon_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4388,7 +4800,7 @@ func (x *GetUnrollStatusResponse) String() string {
 func (*GetUnrollStatusResponse) ProtoMessage() {}
 
 func (x *GetUnrollStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[57]
+	mi := &file_daemon_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4401,7 +4813,7 @@ func (x *GetUnrollStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUnrollStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetUnrollStatusResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{57}
+	return file_daemon_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *GetUnrollStatusResponse) GetFound() bool {
@@ -4524,7 +4936,30 @@ const file_daemon_proto_rawDesc = "" +
 	"\n" +
 	"key_family\x18\x03 \x01(\rR\tkeyFamily\x12\x1b\n" +
 	"\tkey_index\x18\x04 \x01(\rR\bkeyIndex\x12\x14\n" +
-	"\x05label\x18\x05 \x01(\tR\x05label\"z\n" +
+	"\x05label\x18\x05 \x01(\tR\x05label\":\n" +
+	"\x15ReceiveAuthKeyRequest\x12!\n" +
+	"\fpayment_hash\x18\x01 \x01(\fR\vpaymentHash\"0\n" +
+	"\x16ReceiveAuthKeyResponse\x12\x16\n" +
+	"\x06pubkey\x18\x01 \x01(\fR\x06pubkey\"}\n" +
+	"\x1dSignReceiveAuthMessageRequest\x12!\n" +
+	"\fpayment_hash\x18\x01 \x01(\fR\vpaymentHash\x12\x18\n" +
+	"\amessage\x18\x02 \x01(\fR\amessage\x12\x1f\n" +
+	"\vdouble_hash\x18\x03 \x01(\bR\n" +
+	"doubleHash\">\n" +
+	"\x1eSignReceiveAuthMessageResponse\x12\x1c\n" +
+	"\tsignature\x18\x01 \x01(\fR\tsignature\"\x84\x01\n" +
+	"$SignReceiveAuthMessageCompactRequest\x12!\n" +
+	"\fpayment_hash\x18\x01 \x01(\fR\vpaymentHash\x12\x18\n" +
+	"\amessage\x18\x02 \x01(\fR\amessage\x12\x1f\n" +
+	"\vdouble_hash\x18\x03 \x01(\bR\n" +
+	"doubleHash\"E\n" +
+	"%SignReceiveAuthMessageCompactResponse\x12\x1c\n" +
+	"\tsignature\x18\x01 \x01(\fR\tsignature\"S\n" +
+	"\x16ReceiveAuthECDHRequest\x12!\n" +
+	"\fpayment_hash\x18\x01 \x01(\fR\vpaymentHash\x12\x16\n" +
+	"\x06pubkey\x18\x02 \x01(\fR\x06pubkey\">\n" +
+	"\x17ReceiveAuthECDHResponse\x12#\n" +
+	"\rshared_secret\x18\x01 \x01(\fR\fsharedSecret\"z\n" +
 	"\x1fGetIndexedVTXOByPkScriptRequest\x12\x1b\n" +
 	"\tpk_script\x18\x01 \x01(\fR\bpkScript\x12:\n" +
 	"\rstatus_filter\x18\x02 \x03(\x0e2\x15.daemonrpc.VTXOStatusR\fstatusFilter\"G\n" +
@@ -4761,7 +5196,7 @@ const file_daemon_proto_rawDesc = "" +
 	"\x1dUNROLL_JOB_STATUS_CSV_PENDING\x10\x03\x12\x1e\n" +
 	"\x1aUNROLL_JOB_STATUS_SWEEPING\x10\x04\x12\x1f\n" +
 	"\x1bUNROLL_JOB_STATUS_COMPLETED\x10\x05\x12\x1c\n" +
-	"\x18UNROLL_JOB_STATUS_FAILED\x10\x062\x82\x0f\n" +
+	"\x18UNROLL_JOB_STATUS_FAILED\x10\x062\xa7\x12\n" +
 	"\rDaemonService\x12@\n" +
 	"\aGetInfo\x12\x19.daemonrpc.GetInfoRequest\x1a\x1a.daemonrpc.GetInfoResponse\x12@\n" +
 	"\aGenSeed\x12\x19.daemonrpc.GenSeedRequest\x1a\x1a.daemonrpc.GenSeedResponse\x12I\n" +
@@ -4773,7 +5208,11 @@ const file_daemon_proto_rawDesc = "" +
 	"\tListVTXOs\x12\x1b.daemonrpc.ListVTXOsRequest\x1a\x1c.daemonrpc.ListVTXOsResponse\x12I\n" +
 	"\n" +
 	"NewAddress\x12\x1c.daemonrpc.NewAddressRequest\x1a\x1d.daemonrpc.NewAddressResponse\x12[\n" +
-	"\x10NewReceiveScript\x12\".daemonrpc.NewReceiveScriptRequest\x1a#.daemonrpc.NewReceiveScriptResponse\x12s\n" +
+	"\x10NewReceiveScript\x12\".daemonrpc.NewReceiveScriptRequest\x1a#.daemonrpc.NewReceiveScriptResponse\x12U\n" +
+	"\x0eReceiveAuthKey\x12 .daemonrpc.ReceiveAuthKeyRequest\x1a!.daemonrpc.ReceiveAuthKeyResponse\x12m\n" +
+	"\x16SignReceiveAuthMessage\x12(.daemonrpc.SignReceiveAuthMessageRequest\x1a).daemonrpc.SignReceiveAuthMessageResponse\x12\x82\x01\n" +
+	"\x1dSignReceiveAuthMessageCompact\x12/.daemonrpc.SignReceiveAuthMessageCompactRequest\x1a0.daemonrpc.SignReceiveAuthMessageCompactResponse\x12X\n" +
+	"\x0fReceiveAuthECDH\x12!.daemonrpc.ReceiveAuthECDHRequest\x1a\".daemonrpc.ReceiveAuthECDHResponse\x12s\n" +
 	"\x18GetIndexedVTXOByPkScript\x12*.daemonrpc.GetIndexedVTXOByPkScriptRequest\x1a+.daemonrpc.GetIndexedVTXOByPkScriptResponse\x12y\n" +
 	"\x1aGetIndexedOORSessionByTxid\x12,.daemonrpc.GetIndexedOORSessionByTxidRequest\x1a-.daemonrpc.GetIndexedOORSessionByTxidResponse\x12C\n" +
 	"\bSendVTXO\x12\x1a.daemonrpc.SendVTXORequest\x1a\x1b.daemonrpc.SendVTXOResponse\x12@\n" +
@@ -4806,72 +5245,80 @@ func file_daemon_proto_rawDescGZIP() []byte {
 }
 
 var file_daemon_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 59)
+var file_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 67)
 var file_daemon_proto_goTypes = []any{
-	(VTXOStatus)(0),                            // 0: daemonrpc.VTXOStatus
-	(RoundState)(0),                            // 1: daemonrpc.RoundState
-	(OORSessionDirection)(0),                   // 2: daemonrpc.OORSessionDirection
-	(OORSessionStatus)(0),                      // 3: daemonrpc.OORSessionStatus
-	(UnrollJobStatus)(0),                       // 4: daemonrpc.UnrollJobStatus
-	(*GetInfoRequest)(nil),                     // 5: daemonrpc.GetInfoRequest
-	(*GetInfoResponse)(nil),                    // 6: daemonrpc.GetInfoResponse
-	(*ServerInfo)(nil),                         // 7: daemonrpc.ServerInfo
-	(*GenSeedRequest)(nil),                     // 8: daemonrpc.GenSeedRequest
-	(*GenSeedResponse)(nil),                    // 9: daemonrpc.GenSeedResponse
-	(*InitWalletRequest)(nil),                  // 10: daemonrpc.InitWalletRequest
-	(*InitWalletResponse)(nil),                 // 11: daemonrpc.InitWalletResponse
-	(*UnlockWalletRequest)(nil),                // 12: daemonrpc.UnlockWalletRequest
-	(*UnlockWalletResponse)(nil),               // 13: daemonrpc.UnlockWalletResponse
-	(*GetBalanceRequest)(nil),                  // 14: daemonrpc.GetBalanceRequest
-	(*GetBalanceResponse)(nil),                 // 15: daemonrpc.GetBalanceResponse
-	(*VTXO)(nil),                               // 16: daemonrpc.VTXO
-	(*ListVTXOsRequest)(nil),                   // 17: daemonrpc.ListVTXOsRequest
-	(*ListVTXOsResponse)(nil),                  // 18: daemonrpc.ListVTXOsResponse
-	(*NewAddressRequest)(nil),                  // 19: daemonrpc.NewAddressRequest
-	(*NewAddressResponse)(nil),                 // 20: daemonrpc.NewAddressResponse
-	(*NewReceiveScriptRequest)(nil),            // 21: daemonrpc.NewReceiveScriptRequest
-	(*NewReceiveScriptResponse)(nil),           // 22: daemonrpc.NewReceiveScriptResponse
-	(*GetIndexedVTXOByPkScriptRequest)(nil),    // 23: daemonrpc.GetIndexedVTXOByPkScriptRequest
-	(*GetIndexedVTXOByPkScriptResponse)(nil),   // 24: daemonrpc.GetIndexedVTXOByPkScriptResponse
-	(*GetIndexedOORSessionByTxidRequest)(nil),  // 25: daemonrpc.GetIndexedOORSessionByTxidRequest
-	(*GetIndexedOORSessionByTxidResponse)(nil), // 26: daemonrpc.GetIndexedOORSessionByTxidResponse
-	(*Output)(nil),                             // 27: daemonrpc.Output
-	(*SendVTXORequest)(nil),                    // 28: daemonrpc.SendVTXORequest
-	(*SendVTXOResponse)(nil),                   // 29: daemonrpc.SendVTXOResponse
-	(*SendOORRequest)(nil),                     // 30: daemonrpc.SendOORRequest
-	(*CustomOORInput)(nil),                     // 31: daemonrpc.CustomOORInput
-	(*SendOORResponse)(nil),                    // 32: daemonrpc.SendOORResponse
-	(*OutpointSelection)(nil),                  // 33: daemonrpc.OutpointSelection
-	(*RefreshVTXOsRequest)(nil),                // 34: daemonrpc.RefreshVTXOsRequest
-	(*RefreshVTXOsResponse)(nil),               // 35: daemonrpc.RefreshVTXOsResponse
-	(*LeaveDestination)(nil),                   // 36: daemonrpc.LeaveDestination
-	(*LeaveVTXOsRequest)(nil),                  // 37: daemonrpc.LeaveVTXOsRequest
-	(*LeaveVTXOsResponse)(nil),                 // 38: daemonrpc.LeaveVTXOsResponse
-	(*BoardRequest)(nil),                       // 39: daemonrpc.BoardRequest
-	(*BoardResponse)(nil),                      // 40: daemonrpc.BoardResponse
-	(*RoundVTXOInfo)(nil),                      // 41: daemonrpc.RoundVTXOInfo
-	(*RoundInfo)(nil),                          // 42: daemonrpc.RoundInfo
-	(*ListRoundsRequest)(nil),                  // 43: daemonrpc.ListRoundsRequest
-	(*GetRoundRequest)(nil),                    // 44: daemonrpc.GetRoundRequest
-	(*GetRoundResponse)(nil),                   // 45: daemonrpc.GetRoundResponse
-	(*ListRoundsResponse)(nil),                 // 46: daemonrpc.ListRoundsResponse
-	(*WatchRoundsRequest)(nil),                 // 47: daemonrpc.WatchRoundsRequest
-	(*WatchRoundsResponse)(nil),                // 48: daemonrpc.WatchRoundsResponse
-	(*OORSessionInfo)(nil),                     // 49: daemonrpc.OORSessionInfo
-	(*ListOORSessionsRequest)(nil),             // 50: daemonrpc.ListOORSessionsRequest
-	(*ListOORSessionsResponse)(nil),            // 51: daemonrpc.ListOORSessionsResponse
-	(*GetOORSessionRequest)(nil),               // 52: daemonrpc.GetOORSessionRequest
-	(*GetOORSessionResponse)(nil),              // 53: daemonrpc.GetOORSessionResponse
-	(*EstimateFeeRequest)(nil),                 // 54: daemonrpc.EstimateFeeRequest
-	(*EstimateFeeResponse)(nil),                // 55: daemonrpc.EstimateFeeResponse
-	(*GetFeeHistoryRequest)(nil),               // 56: daemonrpc.GetFeeHistoryRequest
-	(*FeeHistoryEntry)(nil),                    // 57: daemonrpc.FeeHistoryEntry
-	(*GetFeeHistoryResponse)(nil),              // 58: daemonrpc.GetFeeHistoryResponse
-	(*UnrollRequest)(nil),                      // 59: daemonrpc.UnrollRequest
-	(*UnrollResponse)(nil),                     // 60: daemonrpc.UnrollResponse
-	(*GetUnrollStatusRequest)(nil),             // 61: daemonrpc.GetUnrollStatusRequest
-	(*GetUnrollStatusResponse)(nil),            // 62: daemonrpc.GetUnrollStatusResponse
-	nil,                                        // 63: daemonrpc.LeaveVTXOsRequest.DestinationsEntry
+	(VTXOStatus)(0),                               // 0: daemonrpc.VTXOStatus
+	(RoundState)(0),                               // 1: daemonrpc.RoundState
+	(OORSessionDirection)(0),                      // 2: daemonrpc.OORSessionDirection
+	(OORSessionStatus)(0),                         // 3: daemonrpc.OORSessionStatus
+	(UnrollJobStatus)(0),                          // 4: daemonrpc.UnrollJobStatus
+	(*GetInfoRequest)(nil),                        // 5: daemonrpc.GetInfoRequest
+	(*GetInfoResponse)(nil),                       // 6: daemonrpc.GetInfoResponse
+	(*ServerInfo)(nil),                            // 7: daemonrpc.ServerInfo
+	(*GenSeedRequest)(nil),                        // 8: daemonrpc.GenSeedRequest
+	(*GenSeedResponse)(nil),                       // 9: daemonrpc.GenSeedResponse
+	(*InitWalletRequest)(nil),                     // 10: daemonrpc.InitWalletRequest
+	(*InitWalletResponse)(nil),                    // 11: daemonrpc.InitWalletResponse
+	(*UnlockWalletRequest)(nil),                   // 12: daemonrpc.UnlockWalletRequest
+	(*UnlockWalletResponse)(nil),                  // 13: daemonrpc.UnlockWalletResponse
+	(*GetBalanceRequest)(nil),                     // 14: daemonrpc.GetBalanceRequest
+	(*GetBalanceResponse)(nil),                    // 15: daemonrpc.GetBalanceResponse
+	(*VTXO)(nil),                                  // 16: daemonrpc.VTXO
+	(*ListVTXOsRequest)(nil),                      // 17: daemonrpc.ListVTXOsRequest
+	(*ListVTXOsResponse)(nil),                     // 18: daemonrpc.ListVTXOsResponse
+	(*NewAddressRequest)(nil),                     // 19: daemonrpc.NewAddressRequest
+	(*NewAddressResponse)(nil),                    // 20: daemonrpc.NewAddressResponse
+	(*NewReceiveScriptRequest)(nil),               // 21: daemonrpc.NewReceiveScriptRequest
+	(*NewReceiveScriptResponse)(nil),              // 22: daemonrpc.NewReceiveScriptResponse
+	(*ReceiveAuthKeyRequest)(nil),                 // 23: daemonrpc.ReceiveAuthKeyRequest
+	(*ReceiveAuthKeyResponse)(nil),                // 24: daemonrpc.ReceiveAuthKeyResponse
+	(*SignReceiveAuthMessageRequest)(nil),         // 25: daemonrpc.SignReceiveAuthMessageRequest
+	(*SignReceiveAuthMessageResponse)(nil),        // 26: daemonrpc.SignReceiveAuthMessageResponse
+	(*SignReceiveAuthMessageCompactRequest)(nil),  // 27: daemonrpc.SignReceiveAuthMessageCompactRequest
+	(*SignReceiveAuthMessageCompactResponse)(nil), // 28: daemonrpc.SignReceiveAuthMessageCompactResponse
+	(*ReceiveAuthECDHRequest)(nil),                // 29: daemonrpc.ReceiveAuthECDHRequest
+	(*ReceiveAuthECDHResponse)(nil),               // 30: daemonrpc.ReceiveAuthECDHResponse
+	(*GetIndexedVTXOByPkScriptRequest)(nil),       // 31: daemonrpc.GetIndexedVTXOByPkScriptRequest
+	(*GetIndexedVTXOByPkScriptResponse)(nil),      // 32: daemonrpc.GetIndexedVTXOByPkScriptResponse
+	(*GetIndexedOORSessionByTxidRequest)(nil),     // 33: daemonrpc.GetIndexedOORSessionByTxidRequest
+	(*GetIndexedOORSessionByTxidResponse)(nil),    // 34: daemonrpc.GetIndexedOORSessionByTxidResponse
+	(*Output)(nil),                                // 35: daemonrpc.Output
+	(*SendVTXORequest)(nil),                       // 36: daemonrpc.SendVTXORequest
+	(*SendVTXOResponse)(nil),                      // 37: daemonrpc.SendVTXOResponse
+	(*SendOORRequest)(nil),                        // 38: daemonrpc.SendOORRequest
+	(*CustomOORInput)(nil),                        // 39: daemonrpc.CustomOORInput
+	(*SendOORResponse)(nil),                       // 40: daemonrpc.SendOORResponse
+	(*OutpointSelection)(nil),                     // 41: daemonrpc.OutpointSelection
+	(*RefreshVTXOsRequest)(nil),                   // 42: daemonrpc.RefreshVTXOsRequest
+	(*RefreshVTXOsResponse)(nil),                  // 43: daemonrpc.RefreshVTXOsResponse
+	(*LeaveDestination)(nil),                      // 44: daemonrpc.LeaveDestination
+	(*LeaveVTXOsRequest)(nil),                     // 45: daemonrpc.LeaveVTXOsRequest
+	(*LeaveVTXOsResponse)(nil),                    // 46: daemonrpc.LeaveVTXOsResponse
+	(*BoardRequest)(nil),                          // 47: daemonrpc.BoardRequest
+	(*BoardResponse)(nil),                         // 48: daemonrpc.BoardResponse
+	(*RoundVTXOInfo)(nil),                         // 49: daemonrpc.RoundVTXOInfo
+	(*RoundInfo)(nil),                             // 50: daemonrpc.RoundInfo
+	(*ListRoundsRequest)(nil),                     // 51: daemonrpc.ListRoundsRequest
+	(*GetRoundRequest)(nil),                       // 52: daemonrpc.GetRoundRequest
+	(*GetRoundResponse)(nil),                      // 53: daemonrpc.GetRoundResponse
+	(*ListRoundsResponse)(nil),                    // 54: daemonrpc.ListRoundsResponse
+	(*WatchRoundsRequest)(nil),                    // 55: daemonrpc.WatchRoundsRequest
+	(*WatchRoundsResponse)(nil),                   // 56: daemonrpc.WatchRoundsResponse
+	(*OORSessionInfo)(nil),                        // 57: daemonrpc.OORSessionInfo
+	(*ListOORSessionsRequest)(nil),                // 58: daemonrpc.ListOORSessionsRequest
+	(*ListOORSessionsResponse)(nil),               // 59: daemonrpc.ListOORSessionsResponse
+	(*GetOORSessionRequest)(nil),                  // 60: daemonrpc.GetOORSessionRequest
+	(*GetOORSessionResponse)(nil),                 // 61: daemonrpc.GetOORSessionResponse
+	(*EstimateFeeRequest)(nil),                    // 62: daemonrpc.EstimateFeeRequest
+	(*EstimateFeeResponse)(nil),                   // 63: daemonrpc.EstimateFeeResponse
+	(*GetFeeHistoryRequest)(nil),                  // 64: daemonrpc.GetFeeHistoryRequest
+	(*FeeHistoryEntry)(nil),                       // 65: daemonrpc.FeeHistoryEntry
+	(*GetFeeHistoryResponse)(nil),                 // 66: daemonrpc.GetFeeHistoryResponse
+	(*UnrollRequest)(nil),                         // 67: daemonrpc.UnrollRequest
+	(*UnrollResponse)(nil),                        // 68: daemonrpc.UnrollResponse
+	(*GetUnrollStatusRequest)(nil),                // 69: daemonrpc.GetUnrollStatusRequest
+	(*GetUnrollStatusResponse)(nil),               // 70: daemonrpc.GetUnrollStatusResponse
+	nil,                                           // 71: daemonrpc.LeaveVTXOsRequest.DestinationsEntry
 }
 var file_daemon_proto_depIdxs = []int32{
 	7,  // 0: daemonrpc.GetInfoResponse.server_info:type_name -> daemonrpc.ServerInfo
@@ -4880,28 +5327,28 @@ var file_daemon_proto_depIdxs = []int32{
 	16, // 3: daemonrpc.ListVTXOsResponse.vtxos:type_name -> daemonrpc.VTXO
 	0,  // 4: daemonrpc.GetIndexedVTXOByPkScriptRequest.status_filter:type_name -> daemonrpc.VTXOStatus
 	16, // 5: daemonrpc.GetIndexedVTXOByPkScriptResponse.vtxo:type_name -> daemonrpc.VTXO
-	27, // 6: daemonrpc.SendVTXORequest.recipients:type_name -> daemonrpc.Output
-	27, // 7: daemonrpc.SendOORRequest.recipient:type_name -> daemonrpc.Output
-	31, // 8: daemonrpc.SendOORRequest.custom_inputs:type_name -> daemonrpc.CustomOORInput
-	33, // 9: daemonrpc.RefreshVTXOsRequest.outpoints:type_name -> daemonrpc.OutpointSelection
-	33, // 10: daemonrpc.LeaveVTXOsRequest.outpoints:type_name -> daemonrpc.OutpointSelection
-	36, // 11: daemonrpc.LeaveVTXOsRequest.default_destination:type_name -> daemonrpc.LeaveDestination
-	63, // 12: daemonrpc.LeaveVTXOsRequest.destinations:type_name -> daemonrpc.LeaveVTXOsRequest.DestinationsEntry
+	35, // 6: daemonrpc.SendVTXORequest.recipients:type_name -> daemonrpc.Output
+	35, // 7: daemonrpc.SendOORRequest.recipient:type_name -> daemonrpc.Output
+	39, // 8: daemonrpc.SendOORRequest.custom_inputs:type_name -> daemonrpc.CustomOORInput
+	41, // 9: daemonrpc.RefreshVTXOsRequest.outpoints:type_name -> daemonrpc.OutpointSelection
+	41, // 10: daemonrpc.LeaveVTXOsRequest.outpoints:type_name -> daemonrpc.OutpointSelection
+	44, // 11: daemonrpc.LeaveVTXOsRequest.default_destination:type_name -> daemonrpc.LeaveDestination
+	71, // 12: daemonrpc.LeaveVTXOsRequest.destinations:type_name -> daemonrpc.LeaveVTXOsRequest.DestinationsEntry
 	1,  // 13: daemonrpc.RoundInfo.state:type_name -> daemonrpc.RoundState
-	41, // 14: daemonrpc.RoundInfo.vtxos:type_name -> daemonrpc.RoundVTXOInfo
+	49, // 14: daemonrpc.RoundInfo.vtxos:type_name -> daemonrpc.RoundVTXOInfo
 	1,  // 15: daemonrpc.ListRoundsRequest.state_filter:type_name -> daemonrpc.RoundState
-	42, // 16: daemonrpc.GetRoundResponse.round:type_name -> daemonrpc.RoundInfo
-	42, // 17: daemonrpc.ListRoundsResponse.rounds:type_name -> daemonrpc.RoundInfo
-	42, // 18: daemonrpc.WatchRoundsResponse.round:type_name -> daemonrpc.RoundInfo
+	50, // 16: daemonrpc.GetRoundResponse.round:type_name -> daemonrpc.RoundInfo
+	50, // 17: daemonrpc.ListRoundsResponse.rounds:type_name -> daemonrpc.RoundInfo
+	50, // 18: daemonrpc.WatchRoundsResponse.round:type_name -> daemonrpc.RoundInfo
 	2,  // 19: daemonrpc.OORSessionInfo.direction:type_name -> daemonrpc.OORSessionDirection
 	3,  // 20: daemonrpc.OORSessionInfo.status:type_name -> daemonrpc.OORSessionStatus
 	2,  // 21: daemonrpc.ListOORSessionsRequest.direction_filter:type_name -> daemonrpc.OORSessionDirection
 	3,  // 22: daemonrpc.ListOORSessionsRequest.status_filter:type_name -> daemonrpc.OORSessionStatus
-	49, // 23: daemonrpc.ListOORSessionsResponse.sessions:type_name -> daemonrpc.OORSessionInfo
-	49, // 24: daemonrpc.GetOORSessionResponse.session:type_name -> daemonrpc.OORSessionInfo
-	57, // 25: daemonrpc.GetFeeHistoryResponse.entries:type_name -> daemonrpc.FeeHistoryEntry
+	57, // 23: daemonrpc.ListOORSessionsResponse.sessions:type_name -> daemonrpc.OORSessionInfo
+	57, // 24: daemonrpc.GetOORSessionResponse.session:type_name -> daemonrpc.OORSessionInfo
+	65, // 25: daemonrpc.GetFeeHistoryResponse.entries:type_name -> daemonrpc.FeeHistoryEntry
 	4,  // 26: daemonrpc.GetUnrollStatusResponse.status:type_name -> daemonrpc.UnrollJobStatus
-	36, // 27: daemonrpc.LeaveVTXOsRequest.DestinationsEntry.value:type_name -> daemonrpc.LeaveDestination
+	44, // 27: daemonrpc.LeaveVTXOsRequest.DestinationsEntry.value:type_name -> daemonrpc.LeaveDestination
 	5,  // 28: daemonrpc.DaemonService.GetInfo:input_type -> daemonrpc.GetInfoRequest
 	8,  // 29: daemonrpc.DaemonService.GenSeed:input_type -> daemonrpc.GenSeedRequest
 	10, // 30: daemonrpc.DaemonService.InitWallet:input_type -> daemonrpc.InitWalletRequest
@@ -4910,48 +5357,56 @@ var file_daemon_proto_depIdxs = []int32{
 	17, // 33: daemonrpc.DaemonService.ListVTXOs:input_type -> daemonrpc.ListVTXOsRequest
 	19, // 34: daemonrpc.DaemonService.NewAddress:input_type -> daemonrpc.NewAddressRequest
 	21, // 35: daemonrpc.DaemonService.NewReceiveScript:input_type -> daemonrpc.NewReceiveScriptRequest
-	23, // 36: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:input_type -> daemonrpc.GetIndexedVTXOByPkScriptRequest
-	25, // 37: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:input_type -> daemonrpc.GetIndexedOORSessionByTxidRequest
-	28, // 38: daemonrpc.DaemonService.SendVTXO:input_type -> daemonrpc.SendVTXORequest
-	30, // 39: daemonrpc.DaemonService.SendOOR:input_type -> daemonrpc.SendOORRequest
-	34, // 40: daemonrpc.DaemonService.RefreshVTXOs:input_type -> daemonrpc.RefreshVTXOsRequest
-	37, // 41: daemonrpc.DaemonService.LeaveVTXOs:input_type -> daemonrpc.LeaveVTXOsRequest
-	39, // 42: daemonrpc.DaemonService.Board:input_type -> daemonrpc.BoardRequest
-	43, // 43: daemonrpc.DaemonService.ListRounds:input_type -> daemonrpc.ListRoundsRequest
-	44, // 44: daemonrpc.DaemonService.GetRound:input_type -> daemonrpc.GetRoundRequest
-	47, // 45: daemonrpc.DaemonService.WatchRounds:input_type -> daemonrpc.WatchRoundsRequest
-	50, // 46: daemonrpc.DaemonService.ListOORSessions:input_type -> daemonrpc.ListOORSessionsRequest
-	52, // 47: daemonrpc.DaemonService.GetOORSession:input_type -> daemonrpc.GetOORSessionRequest
-	54, // 48: daemonrpc.DaemonService.EstimateFee:input_type -> daemonrpc.EstimateFeeRequest
-	56, // 49: daemonrpc.DaemonService.GetFeeHistory:input_type -> daemonrpc.GetFeeHistoryRequest
-	59, // 50: daemonrpc.DaemonService.Unroll:input_type -> daemonrpc.UnrollRequest
-	61, // 51: daemonrpc.DaemonService.GetUnrollStatus:input_type -> daemonrpc.GetUnrollStatusRequest
-	6,  // 52: daemonrpc.DaemonService.GetInfo:output_type -> daemonrpc.GetInfoResponse
-	9,  // 53: daemonrpc.DaemonService.GenSeed:output_type -> daemonrpc.GenSeedResponse
-	11, // 54: daemonrpc.DaemonService.InitWallet:output_type -> daemonrpc.InitWalletResponse
-	13, // 55: daemonrpc.DaemonService.UnlockWallet:output_type -> daemonrpc.UnlockWalletResponse
-	15, // 56: daemonrpc.DaemonService.GetBalance:output_type -> daemonrpc.GetBalanceResponse
-	18, // 57: daemonrpc.DaemonService.ListVTXOs:output_type -> daemonrpc.ListVTXOsResponse
-	20, // 58: daemonrpc.DaemonService.NewAddress:output_type -> daemonrpc.NewAddressResponse
-	22, // 59: daemonrpc.DaemonService.NewReceiveScript:output_type -> daemonrpc.NewReceiveScriptResponse
-	24, // 60: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:output_type -> daemonrpc.GetIndexedVTXOByPkScriptResponse
-	26, // 61: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:output_type -> daemonrpc.GetIndexedOORSessionByTxidResponse
-	29, // 62: daemonrpc.DaemonService.SendVTXO:output_type -> daemonrpc.SendVTXOResponse
-	32, // 63: daemonrpc.DaemonService.SendOOR:output_type -> daemonrpc.SendOORResponse
-	35, // 64: daemonrpc.DaemonService.RefreshVTXOs:output_type -> daemonrpc.RefreshVTXOsResponse
-	38, // 65: daemonrpc.DaemonService.LeaveVTXOs:output_type -> daemonrpc.LeaveVTXOsResponse
-	40, // 66: daemonrpc.DaemonService.Board:output_type -> daemonrpc.BoardResponse
-	46, // 67: daemonrpc.DaemonService.ListRounds:output_type -> daemonrpc.ListRoundsResponse
-	45, // 68: daemonrpc.DaemonService.GetRound:output_type -> daemonrpc.GetRoundResponse
-	48, // 69: daemonrpc.DaemonService.WatchRounds:output_type -> daemonrpc.WatchRoundsResponse
-	51, // 70: daemonrpc.DaemonService.ListOORSessions:output_type -> daemonrpc.ListOORSessionsResponse
-	53, // 71: daemonrpc.DaemonService.GetOORSession:output_type -> daemonrpc.GetOORSessionResponse
-	55, // 72: daemonrpc.DaemonService.EstimateFee:output_type -> daemonrpc.EstimateFeeResponse
-	58, // 73: daemonrpc.DaemonService.GetFeeHistory:output_type -> daemonrpc.GetFeeHistoryResponse
-	60, // 74: daemonrpc.DaemonService.Unroll:output_type -> daemonrpc.UnrollResponse
-	62, // 75: daemonrpc.DaemonService.GetUnrollStatus:output_type -> daemonrpc.GetUnrollStatusResponse
-	52, // [52:76] is the sub-list for method output_type
-	28, // [28:52] is the sub-list for method input_type
+	23, // 36: daemonrpc.DaemonService.ReceiveAuthKey:input_type -> daemonrpc.ReceiveAuthKeyRequest
+	25, // 37: daemonrpc.DaemonService.SignReceiveAuthMessage:input_type -> daemonrpc.SignReceiveAuthMessageRequest
+	27, // 38: daemonrpc.DaemonService.SignReceiveAuthMessageCompact:input_type -> daemonrpc.SignReceiveAuthMessageCompactRequest
+	29, // 39: daemonrpc.DaemonService.ReceiveAuthECDH:input_type -> daemonrpc.ReceiveAuthECDHRequest
+	31, // 40: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:input_type -> daemonrpc.GetIndexedVTXOByPkScriptRequest
+	33, // 41: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:input_type -> daemonrpc.GetIndexedOORSessionByTxidRequest
+	36, // 42: daemonrpc.DaemonService.SendVTXO:input_type -> daemonrpc.SendVTXORequest
+	38, // 43: daemonrpc.DaemonService.SendOOR:input_type -> daemonrpc.SendOORRequest
+	42, // 44: daemonrpc.DaemonService.RefreshVTXOs:input_type -> daemonrpc.RefreshVTXOsRequest
+	45, // 45: daemonrpc.DaemonService.LeaveVTXOs:input_type -> daemonrpc.LeaveVTXOsRequest
+	47, // 46: daemonrpc.DaemonService.Board:input_type -> daemonrpc.BoardRequest
+	51, // 47: daemonrpc.DaemonService.ListRounds:input_type -> daemonrpc.ListRoundsRequest
+	52, // 48: daemonrpc.DaemonService.GetRound:input_type -> daemonrpc.GetRoundRequest
+	55, // 49: daemonrpc.DaemonService.WatchRounds:input_type -> daemonrpc.WatchRoundsRequest
+	58, // 50: daemonrpc.DaemonService.ListOORSessions:input_type -> daemonrpc.ListOORSessionsRequest
+	60, // 51: daemonrpc.DaemonService.GetOORSession:input_type -> daemonrpc.GetOORSessionRequest
+	62, // 52: daemonrpc.DaemonService.EstimateFee:input_type -> daemonrpc.EstimateFeeRequest
+	64, // 53: daemonrpc.DaemonService.GetFeeHistory:input_type -> daemonrpc.GetFeeHistoryRequest
+	67, // 54: daemonrpc.DaemonService.Unroll:input_type -> daemonrpc.UnrollRequest
+	69, // 55: daemonrpc.DaemonService.GetUnrollStatus:input_type -> daemonrpc.GetUnrollStatusRequest
+	6,  // 56: daemonrpc.DaemonService.GetInfo:output_type -> daemonrpc.GetInfoResponse
+	9,  // 57: daemonrpc.DaemonService.GenSeed:output_type -> daemonrpc.GenSeedResponse
+	11, // 58: daemonrpc.DaemonService.InitWallet:output_type -> daemonrpc.InitWalletResponse
+	13, // 59: daemonrpc.DaemonService.UnlockWallet:output_type -> daemonrpc.UnlockWalletResponse
+	15, // 60: daemonrpc.DaemonService.GetBalance:output_type -> daemonrpc.GetBalanceResponse
+	18, // 61: daemonrpc.DaemonService.ListVTXOs:output_type -> daemonrpc.ListVTXOsResponse
+	20, // 62: daemonrpc.DaemonService.NewAddress:output_type -> daemonrpc.NewAddressResponse
+	22, // 63: daemonrpc.DaemonService.NewReceiveScript:output_type -> daemonrpc.NewReceiveScriptResponse
+	24, // 64: daemonrpc.DaemonService.ReceiveAuthKey:output_type -> daemonrpc.ReceiveAuthKeyResponse
+	26, // 65: daemonrpc.DaemonService.SignReceiveAuthMessage:output_type -> daemonrpc.SignReceiveAuthMessageResponse
+	28, // 66: daemonrpc.DaemonService.SignReceiveAuthMessageCompact:output_type -> daemonrpc.SignReceiveAuthMessageCompactResponse
+	30, // 67: daemonrpc.DaemonService.ReceiveAuthECDH:output_type -> daemonrpc.ReceiveAuthECDHResponse
+	32, // 68: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:output_type -> daemonrpc.GetIndexedVTXOByPkScriptResponse
+	34, // 69: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:output_type -> daemonrpc.GetIndexedOORSessionByTxidResponse
+	37, // 70: daemonrpc.DaemonService.SendVTXO:output_type -> daemonrpc.SendVTXOResponse
+	40, // 71: daemonrpc.DaemonService.SendOOR:output_type -> daemonrpc.SendOORResponse
+	43, // 72: daemonrpc.DaemonService.RefreshVTXOs:output_type -> daemonrpc.RefreshVTXOsResponse
+	46, // 73: daemonrpc.DaemonService.LeaveVTXOs:output_type -> daemonrpc.LeaveVTXOsResponse
+	48, // 74: daemonrpc.DaemonService.Board:output_type -> daemonrpc.BoardResponse
+	54, // 75: daemonrpc.DaemonService.ListRounds:output_type -> daemonrpc.ListRoundsResponse
+	53, // 76: daemonrpc.DaemonService.GetRound:output_type -> daemonrpc.GetRoundResponse
+	56, // 77: daemonrpc.DaemonService.WatchRounds:output_type -> daemonrpc.WatchRoundsResponse
+	59, // 78: daemonrpc.DaemonService.ListOORSessions:output_type -> daemonrpc.ListOORSessionsResponse
+	61, // 79: daemonrpc.DaemonService.GetOORSession:output_type -> daemonrpc.GetOORSessionResponse
+	63, // 80: daemonrpc.DaemonService.EstimateFee:output_type -> daemonrpc.EstimateFeeResponse
+	66, // 81: daemonrpc.DaemonService.GetFeeHistory:output_type -> daemonrpc.GetFeeHistoryResponse
+	68, // 82: daemonrpc.DaemonService.Unroll:output_type -> daemonrpc.UnrollResponse
+	70, // 83: daemonrpc.DaemonService.GetUnrollStatus:output_type -> daemonrpc.GetUnrollStatusResponse
+	56, // [56:84] is the sub-list for method output_type
+	28, // [28:56] is the sub-list for method input_type
 	28, // [28:28] is the sub-list for extension type_name
 	28, // [28:28] is the sub-list for extension extendee
 	0,  // [0:28] is the sub-list for field type_name
@@ -4962,20 +5417,20 @@ func file_daemon_proto_init() {
 	if File_daemon_proto != nil {
 		return
 	}
-	file_daemon_proto_msgTypes[22].OneofWrappers = []any{
+	file_daemon_proto_msgTypes[30].OneofWrappers = []any{
 		(*Output_Address)(nil),
 		(*Output_Pubkey)(nil),
 		(*Output_PolicyTemplate)(nil),
 	}
-	file_daemon_proto_msgTypes[29].OneofWrappers = []any{
+	file_daemon_proto_msgTypes[37].OneofWrappers = []any{
 		(*RefreshVTXOsRequest_Outpoints)(nil),
 		(*RefreshVTXOsRequest_All)(nil),
 	}
-	file_daemon_proto_msgTypes[31].OneofWrappers = []any{
+	file_daemon_proto_msgTypes[39].OneofWrappers = []any{
 		(*LeaveDestination_Address)(nil),
 		(*LeaveDestination_PkScript)(nil),
 	}
-	file_daemon_proto_msgTypes[32].OneofWrappers = []any{
+	file_daemon_proto_msgTypes[40].OneofWrappers = []any{
 		(*LeaveVTXOsRequest_Outpoints)(nil),
 		(*LeaveVTXOsRequest_All)(nil),
 	}
@@ -4985,7 +5440,7 @@ func file_daemon_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_daemon_proto_rawDesc), len(file_daemon_proto_rawDesc)),
 			NumEnums:      5,
-			NumMessages:   59,
+			NumMessages:   67,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/daemonrpc/daemon.proto
+++ b/daemonrpc/daemon.proto
@@ -47,6 +47,24 @@ service DaemonService {
     rpc NewReceiveScript (NewReceiveScriptRequest)
         returns (NewReceiveScriptResponse);
 
+    // ReceiveAuthKey returns the per-payment receive-auth public key.
+    rpc ReceiveAuthKey (ReceiveAuthKeyRequest) returns (ReceiveAuthKeyResponse);
+
+    // SignReceiveAuthMessage signs one message with the per-payment
+    // receive-auth key.
+    rpc SignReceiveAuthMessage (SignReceiveAuthMessageRequest)
+        returns (SignReceiveAuthMessageResponse);
+
+    // SignReceiveAuthMessageCompact signs one message with the
+    // per-payment receive-auth key and returns a compact signature.
+    rpc SignReceiveAuthMessageCompact (SignReceiveAuthMessageCompactRequest)
+        returns (SignReceiveAuthMessageCompactResponse);
+
+    // ReceiveAuthECDH derives one Sphinx shared secret with the
+    // per-payment receive-auth key.
+    rpc ReceiveAuthECDH (ReceiveAuthECDHRequest)
+        returns (ReceiveAuthECDHResponse);
+
     // GetIndexedVTXOByPkScript queries the authoritative indexer for the
     // first VTXO matching the given script and status filter.
     rpc GetIndexedVTXOByPkScript (GetIndexedVTXOByPkScriptRequest)
@@ -429,6 +447,68 @@ message NewReceiveScriptResponse {
 
     // label is the registration label stored with the indexer.
     string label = 5;
+}
+
+message ReceiveAuthKeyRequest {
+    // payment_hash is the 32-byte Lightning payment hash for the receive
+    // swap that will use the derived key.
+    bytes payment_hash = 1;
+}
+
+message ReceiveAuthKeyResponse {
+    // pubkey is the compressed public key for the payment-scoped receive-auth
+    // key. The private scalar never leaves the daemon.
+    bytes pubkey = 1;
+}
+
+message SignReceiveAuthMessageRequest {
+    // payment_hash is the 32-byte Lightning payment hash for the receive
+    // swap whose receive-auth key signs this message.
+    bytes payment_hash = 1;
+
+    // message is the raw message to sign.
+    bytes message = 2;
+
+    // double_hash controls whether the message is double-SHA256 hashed before
+    // signing. If false, the daemon applies a single SHA256.
+    bool double_hash = 3;
+}
+
+message SignReceiveAuthMessageResponse {
+    // signature is the DER-encoded ECDSA signature.
+    bytes signature = 1;
+}
+
+message SignReceiveAuthMessageCompactRequest {
+    // payment_hash is the 32-byte Lightning payment hash for the receive
+    // swap whose receive-auth key signs this message.
+    bytes payment_hash = 1;
+
+    // message is the raw message to sign.
+    bytes message = 2;
+
+    // double_hash controls whether the message is double-SHA256 hashed before
+    // signing. If false, the daemon applies a single SHA256.
+    bool double_hash = 3;
+}
+
+message SignReceiveAuthMessageCompactResponse {
+    // signature is the compact public-key-recoverable ECDSA signature.
+    bytes signature = 1;
+}
+
+message ReceiveAuthECDHRequest {
+    // payment_hash is the 32-byte Lightning payment hash for the receive
+    // swap whose receive-auth key derives this shared secret.
+    bytes payment_hash = 1;
+
+    // pubkey is the remote compressed public key to use for ECDH.
+    bytes pubkey = 2;
+}
+
+message ReceiveAuthECDHResponse {
+    // shared_secret is the 32-byte Sphinx shared secret.
+    bytes shared_secret = 1;
 }
 
 message GetIndexedVTXOByPkScriptRequest {

--- a/daemonrpc/daemon_grpc.pb.go
+++ b/daemonrpc/daemon_grpc.pb.go
@@ -19,30 +19,34 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	DaemonService_GetInfo_FullMethodName                    = "/daemonrpc.DaemonService/GetInfo"
-	DaemonService_GenSeed_FullMethodName                    = "/daemonrpc.DaemonService/GenSeed"
-	DaemonService_InitWallet_FullMethodName                 = "/daemonrpc.DaemonService/InitWallet"
-	DaemonService_UnlockWallet_FullMethodName               = "/daemonrpc.DaemonService/UnlockWallet"
-	DaemonService_GetBalance_FullMethodName                 = "/daemonrpc.DaemonService/GetBalance"
-	DaemonService_ListVTXOs_FullMethodName                  = "/daemonrpc.DaemonService/ListVTXOs"
-	DaemonService_NewAddress_FullMethodName                 = "/daemonrpc.DaemonService/NewAddress"
-	DaemonService_NewReceiveScript_FullMethodName           = "/daemonrpc.DaemonService/NewReceiveScript"
-	DaemonService_GetIndexedVTXOByPkScript_FullMethodName   = "/daemonrpc.DaemonService/GetIndexedVTXOByPkScript"
-	DaemonService_GetIndexedOORSessionByTxid_FullMethodName = "/daemonrpc.DaemonService/GetIndexedOORSessionByTxid"
-	DaemonService_SendVTXO_FullMethodName                   = "/daemonrpc.DaemonService/SendVTXO"
-	DaemonService_SendOOR_FullMethodName                    = "/daemonrpc.DaemonService/SendOOR"
-	DaemonService_RefreshVTXOs_FullMethodName               = "/daemonrpc.DaemonService/RefreshVTXOs"
-	DaemonService_LeaveVTXOs_FullMethodName                 = "/daemonrpc.DaemonService/LeaveVTXOs"
-	DaemonService_Board_FullMethodName                      = "/daemonrpc.DaemonService/Board"
-	DaemonService_ListRounds_FullMethodName                 = "/daemonrpc.DaemonService/ListRounds"
-	DaemonService_GetRound_FullMethodName                   = "/daemonrpc.DaemonService/GetRound"
-	DaemonService_WatchRounds_FullMethodName                = "/daemonrpc.DaemonService/WatchRounds"
-	DaemonService_ListOORSessions_FullMethodName            = "/daemonrpc.DaemonService/ListOORSessions"
-	DaemonService_GetOORSession_FullMethodName              = "/daemonrpc.DaemonService/GetOORSession"
-	DaemonService_EstimateFee_FullMethodName                = "/daemonrpc.DaemonService/EstimateFee"
-	DaemonService_GetFeeHistory_FullMethodName              = "/daemonrpc.DaemonService/GetFeeHistory"
-	DaemonService_Unroll_FullMethodName                     = "/daemonrpc.DaemonService/Unroll"
-	DaemonService_GetUnrollStatus_FullMethodName            = "/daemonrpc.DaemonService/GetUnrollStatus"
+	DaemonService_GetInfo_FullMethodName                       = "/daemonrpc.DaemonService/GetInfo"
+	DaemonService_GenSeed_FullMethodName                       = "/daemonrpc.DaemonService/GenSeed"
+	DaemonService_InitWallet_FullMethodName                    = "/daemonrpc.DaemonService/InitWallet"
+	DaemonService_UnlockWallet_FullMethodName                  = "/daemonrpc.DaemonService/UnlockWallet"
+	DaemonService_GetBalance_FullMethodName                    = "/daemonrpc.DaemonService/GetBalance"
+	DaemonService_ListVTXOs_FullMethodName                     = "/daemonrpc.DaemonService/ListVTXOs"
+	DaemonService_NewAddress_FullMethodName                    = "/daemonrpc.DaemonService/NewAddress"
+	DaemonService_NewReceiveScript_FullMethodName              = "/daemonrpc.DaemonService/NewReceiveScript"
+	DaemonService_ReceiveAuthKey_FullMethodName                = "/daemonrpc.DaemonService/ReceiveAuthKey"
+	DaemonService_SignReceiveAuthMessage_FullMethodName        = "/daemonrpc.DaemonService/SignReceiveAuthMessage"
+	DaemonService_SignReceiveAuthMessageCompact_FullMethodName = "/daemonrpc.DaemonService/SignReceiveAuthMessageCompact"
+	DaemonService_ReceiveAuthECDH_FullMethodName               = "/daemonrpc.DaemonService/ReceiveAuthECDH"
+	DaemonService_GetIndexedVTXOByPkScript_FullMethodName      = "/daemonrpc.DaemonService/GetIndexedVTXOByPkScript"
+	DaemonService_GetIndexedOORSessionByTxid_FullMethodName    = "/daemonrpc.DaemonService/GetIndexedOORSessionByTxid"
+	DaemonService_SendVTXO_FullMethodName                      = "/daemonrpc.DaemonService/SendVTXO"
+	DaemonService_SendOOR_FullMethodName                       = "/daemonrpc.DaemonService/SendOOR"
+	DaemonService_RefreshVTXOs_FullMethodName                  = "/daemonrpc.DaemonService/RefreshVTXOs"
+	DaemonService_LeaveVTXOs_FullMethodName                    = "/daemonrpc.DaemonService/LeaveVTXOs"
+	DaemonService_Board_FullMethodName                         = "/daemonrpc.DaemonService/Board"
+	DaemonService_ListRounds_FullMethodName                    = "/daemonrpc.DaemonService/ListRounds"
+	DaemonService_GetRound_FullMethodName                      = "/daemonrpc.DaemonService/GetRound"
+	DaemonService_WatchRounds_FullMethodName                   = "/daemonrpc.DaemonService/WatchRounds"
+	DaemonService_ListOORSessions_FullMethodName               = "/daemonrpc.DaemonService/ListOORSessions"
+	DaemonService_GetOORSession_FullMethodName                 = "/daemonrpc.DaemonService/GetOORSession"
+	DaemonService_EstimateFee_FullMethodName                   = "/daemonrpc.DaemonService/EstimateFee"
+	DaemonService_GetFeeHistory_FullMethodName                 = "/daemonrpc.DaemonService/GetFeeHistory"
+	DaemonService_Unroll_FullMethodName                        = "/daemonrpc.DaemonService/Unroll"
+	DaemonService_GetUnrollStatus_FullMethodName               = "/daemonrpc.DaemonService/GetUnrollStatus"
 )
 
 // DaemonServiceClient is the client API for DaemonService service.
@@ -83,6 +87,17 @@ type DaemonServiceClient interface {
 	// matching taproot receive script with the indexer, and returns the
 	// script details needed to hand the destination to a sender.
 	NewReceiveScript(ctx context.Context, in *NewReceiveScriptRequest, opts ...grpc.CallOption) (*NewReceiveScriptResponse, error)
+	// ReceiveAuthKey returns the per-payment receive-auth public key.
+	ReceiveAuthKey(ctx context.Context, in *ReceiveAuthKeyRequest, opts ...grpc.CallOption) (*ReceiveAuthKeyResponse, error)
+	// SignReceiveAuthMessage signs one message with the per-payment
+	// receive-auth key.
+	SignReceiveAuthMessage(ctx context.Context, in *SignReceiveAuthMessageRequest, opts ...grpc.CallOption) (*SignReceiveAuthMessageResponse, error)
+	// SignReceiveAuthMessageCompact signs one message with the
+	// per-payment receive-auth key and returns a compact signature.
+	SignReceiveAuthMessageCompact(ctx context.Context, in *SignReceiveAuthMessageCompactRequest, opts ...grpc.CallOption) (*SignReceiveAuthMessageCompactResponse, error)
+	// ReceiveAuthECDH derives one Sphinx shared secret with the
+	// per-payment receive-auth key.
+	ReceiveAuthECDH(ctx context.Context, in *ReceiveAuthECDHRequest, opts ...grpc.CallOption) (*ReceiveAuthECDHResponse, error)
 	// GetIndexedVTXOByPkScript queries the authoritative indexer for the
 	// first VTXO matching the given script and status filter.
 	GetIndexedVTXOByPkScript(ctx context.Context, in *GetIndexedVTXOByPkScriptRequest, opts ...grpc.CallOption) (*GetIndexedVTXOByPkScriptResponse, error)
@@ -226,6 +241,46 @@ func (c *daemonServiceClient) NewReceiveScript(ctx context.Context, in *NewRecei
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(NewReceiveScriptResponse)
 	err := c.cc.Invoke(ctx, DaemonService_NewReceiveScript_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *daemonServiceClient) ReceiveAuthKey(ctx context.Context, in *ReceiveAuthKeyRequest, opts ...grpc.CallOption) (*ReceiveAuthKeyResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ReceiveAuthKeyResponse)
+	err := c.cc.Invoke(ctx, DaemonService_ReceiveAuthKey_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *daemonServiceClient) SignReceiveAuthMessage(ctx context.Context, in *SignReceiveAuthMessageRequest, opts ...grpc.CallOption) (*SignReceiveAuthMessageResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SignReceiveAuthMessageResponse)
+	err := c.cc.Invoke(ctx, DaemonService_SignReceiveAuthMessage_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *daemonServiceClient) SignReceiveAuthMessageCompact(ctx context.Context, in *SignReceiveAuthMessageCompactRequest, opts ...grpc.CallOption) (*SignReceiveAuthMessageCompactResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SignReceiveAuthMessageCompactResponse)
+	err := c.cc.Invoke(ctx, DaemonService_SignReceiveAuthMessageCompact_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *daemonServiceClient) ReceiveAuthECDH(ctx context.Context, in *ReceiveAuthECDHRequest, opts ...grpc.CallOption) (*ReceiveAuthECDHResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ReceiveAuthECDHResponse)
+	err := c.cc.Invoke(ctx, DaemonService_ReceiveAuthECDH_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -439,6 +494,17 @@ type DaemonServiceServer interface {
 	// matching taproot receive script with the indexer, and returns the
 	// script details needed to hand the destination to a sender.
 	NewReceiveScript(context.Context, *NewReceiveScriptRequest) (*NewReceiveScriptResponse, error)
+	// ReceiveAuthKey returns the per-payment receive-auth public key.
+	ReceiveAuthKey(context.Context, *ReceiveAuthKeyRequest) (*ReceiveAuthKeyResponse, error)
+	// SignReceiveAuthMessage signs one message with the per-payment
+	// receive-auth key.
+	SignReceiveAuthMessage(context.Context, *SignReceiveAuthMessageRequest) (*SignReceiveAuthMessageResponse, error)
+	// SignReceiveAuthMessageCompact signs one message with the
+	// per-payment receive-auth key and returns a compact signature.
+	SignReceiveAuthMessageCompact(context.Context, *SignReceiveAuthMessageCompactRequest) (*SignReceiveAuthMessageCompactResponse, error)
+	// ReceiveAuthECDH derives one Sphinx shared secret with the
+	// per-payment receive-auth key.
+	ReceiveAuthECDH(context.Context, *ReceiveAuthECDHRequest) (*ReceiveAuthECDHResponse, error)
 	// GetIndexedVTXOByPkScript queries the authoritative indexer for the
 	// first VTXO matching the given script and status filter.
 	GetIndexedVTXOByPkScript(context.Context, *GetIndexedVTXOByPkScriptRequest) (*GetIndexedVTXOByPkScriptResponse, error)
@@ -531,6 +597,18 @@ func (UnimplementedDaemonServiceServer) NewAddress(context.Context, *NewAddressR
 }
 func (UnimplementedDaemonServiceServer) NewReceiveScript(context.Context, *NewReceiveScriptRequest) (*NewReceiveScriptResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method NewReceiveScript not implemented")
+}
+func (UnimplementedDaemonServiceServer) ReceiveAuthKey(context.Context, *ReceiveAuthKeyRequest) (*ReceiveAuthKeyResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ReceiveAuthKey not implemented")
+}
+func (UnimplementedDaemonServiceServer) SignReceiveAuthMessage(context.Context, *SignReceiveAuthMessageRequest) (*SignReceiveAuthMessageResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SignReceiveAuthMessage not implemented")
+}
+func (UnimplementedDaemonServiceServer) SignReceiveAuthMessageCompact(context.Context, *SignReceiveAuthMessageCompactRequest) (*SignReceiveAuthMessageCompactResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SignReceiveAuthMessageCompact not implemented")
+}
+func (UnimplementedDaemonServiceServer) ReceiveAuthECDH(context.Context, *ReceiveAuthECDHRequest) (*ReceiveAuthECDHResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ReceiveAuthECDH not implemented")
 }
 func (UnimplementedDaemonServiceServer) GetIndexedVTXOByPkScript(context.Context, *GetIndexedVTXOByPkScriptRequest) (*GetIndexedVTXOByPkScriptResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetIndexedVTXOByPkScript not implemented")
@@ -741,6 +819,78 @@ func _DaemonService_NewReceiveScript_Handler(srv interface{}, ctx context.Contex
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(DaemonServiceServer).NewReceiveScript(ctx, req.(*NewReceiveScriptRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DaemonService_ReceiveAuthKey_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ReceiveAuthKeyRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DaemonServiceServer).ReceiveAuthKey(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DaemonService_ReceiveAuthKey_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DaemonServiceServer).ReceiveAuthKey(ctx, req.(*ReceiveAuthKeyRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DaemonService_SignReceiveAuthMessage_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SignReceiveAuthMessageRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DaemonServiceServer).SignReceiveAuthMessage(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DaemonService_SignReceiveAuthMessage_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DaemonServiceServer).SignReceiveAuthMessage(ctx, req.(*SignReceiveAuthMessageRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DaemonService_SignReceiveAuthMessageCompact_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SignReceiveAuthMessageCompactRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DaemonServiceServer).SignReceiveAuthMessageCompact(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DaemonService_SignReceiveAuthMessageCompact_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DaemonServiceServer).SignReceiveAuthMessageCompact(ctx, req.(*SignReceiveAuthMessageCompactRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DaemonService_ReceiveAuthECDH_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ReceiveAuthECDHRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DaemonServiceServer).ReceiveAuthECDH(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DaemonService_ReceiveAuthECDH_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DaemonServiceServer).ReceiveAuthECDH(ctx, req.(*ReceiveAuthECDHRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -1064,6 +1214,22 @@ var DaemonService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "NewReceiveScript",
 			Handler:    _DaemonService_NewReceiveScript_Handler,
+		},
+		{
+			MethodName: "ReceiveAuthKey",
+			Handler:    _DaemonService_ReceiveAuthKey_Handler,
+		},
+		{
+			MethodName: "SignReceiveAuthMessage",
+			Handler:    _DaemonService_SignReceiveAuthMessage_Handler,
+		},
+		{
+			MethodName: "SignReceiveAuthMessageCompact",
+			Handler:    _DaemonService_SignReceiveAuthMessageCompact_Handler,
+		},
+		{
+			MethodName: "ReceiveAuthECDH",
+			Handler:    _DaemonService_ReceiveAuthECDH_Handler,
 		},
 		{
 			MethodName: "GetIndexedVTXOByPkScript",

--- a/daemonrpc/daemon_mailboxrpc.pb.go
+++ b/daemonrpc/daemon_mailboxrpc.pb.go
@@ -40,6 +40,14 @@ type DaemonServiceMailboxServer interface {
 	NewAddress(ctx context.Context, req *NewAddressRequest) (*NewAddressResponse, error)
 	// NewReceiveScript handles NewReceiveScript.
 	NewReceiveScript(ctx context.Context, req *NewReceiveScriptRequest) (*NewReceiveScriptResponse, error)
+	// ReceiveAuthKey handles ReceiveAuthKey.
+	ReceiveAuthKey(ctx context.Context, req *ReceiveAuthKeyRequest) (*ReceiveAuthKeyResponse, error)
+	// SignReceiveAuthMessage handles SignReceiveAuthMessage.
+	SignReceiveAuthMessage(ctx context.Context, req *SignReceiveAuthMessageRequest) (*SignReceiveAuthMessageResponse, error)
+	// SignReceiveAuthMessageCompact handles SignReceiveAuthMessageCompact.
+	SignReceiveAuthMessageCompact(ctx context.Context, req *SignReceiveAuthMessageCompactRequest) (*SignReceiveAuthMessageCompactResponse, error)
+	// ReceiveAuthECDH handles ReceiveAuthECDH.
+	ReceiveAuthECDH(ctx context.Context, req *ReceiveAuthECDHRequest) (*ReceiveAuthECDHResponse, error)
 	// GetIndexedVTXOByPkScript handles GetIndexedVTXOByPkScript.
 	GetIndexedVTXOByPkScript(ctx context.Context, req *GetIndexedVTXOByPkScriptRequest) (*GetIndexedVTXOByPkScriptResponse, error)
 	// GetIndexedOORSessionByTxid handles GetIndexedOORSessionByTxid.
@@ -155,6 +163,46 @@ func RegisterDaemonServiceMailboxServer(r rpc.Router, impl DaemonServiceMailboxS
 		}
 
 		return impl.NewReceiveScript(ctx, req)
+	})
+	r.Handle("daemonrpc.DaemonService", "ReceiveAuthKey", func() proto.Message {
+		return &ReceiveAuthKeyRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*ReceiveAuthKeyRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.ReceiveAuthKey(ctx, req)
+	})
+	r.Handle("daemonrpc.DaemonService", "SignReceiveAuthMessage", func() proto.Message {
+		return &SignReceiveAuthMessageRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*SignReceiveAuthMessageRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.SignReceiveAuthMessage(ctx, req)
+	})
+	r.Handle("daemonrpc.DaemonService", "SignReceiveAuthMessageCompact", func() proto.Message {
+		return &SignReceiveAuthMessageCompactRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*SignReceiveAuthMessageCompactRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.SignReceiveAuthMessageCompact(ctx, req)
+	})
+	r.Handle("daemonrpc.DaemonService", "ReceiveAuthECDH", func() proto.Message {
+		return &ReceiveAuthECDHRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*ReceiveAuthECDHRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.ReceiveAuthECDH(ctx, req)
 	})
 	r.Handle("daemonrpc.DaemonService", "GetIndexedVTXOByPkScript", func() proto.Message {
 		return &GetIndexedVTXOByPkScriptRequest{}
@@ -495,6 +543,98 @@ func (c *DaemonServiceMailboxClient) NewReceiveScript(ctx context.Context, req *
 	}
 
 	resp := new(NewReceiveScriptResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// ReceiveAuthKey calls the ReceiveAuthKey RPC.
+func (c *DaemonServiceMailboxClient) ReceiveAuthKey(ctx context.Context, req *ReceiveAuthKeyRequest, opts ...rpc.RPCOptions) (*ReceiveAuthKeyResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "daemonrpc.DaemonService",
+		Method:  "ReceiveAuthKey",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(ReceiveAuthKeyResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// SignReceiveAuthMessage calls the SignReceiveAuthMessage RPC.
+func (c *DaemonServiceMailboxClient) SignReceiveAuthMessage(ctx context.Context, req *SignReceiveAuthMessageRequest, opts ...rpc.RPCOptions) (*SignReceiveAuthMessageResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "daemonrpc.DaemonService",
+		Method:  "SignReceiveAuthMessage",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(SignReceiveAuthMessageResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// SignReceiveAuthMessageCompact calls the SignReceiveAuthMessageCompact RPC.
+func (c *DaemonServiceMailboxClient) SignReceiveAuthMessageCompact(ctx context.Context, req *SignReceiveAuthMessageCompactRequest, opts ...rpc.RPCOptions) (*SignReceiveAuthMessageCompactResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "daemonrpc.DaemonService",
+		Method:  "SignReceiveAuthMessageCompact",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(SignReceiveAuthMessageCompactResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// ReceiveAuthECDH calls the ReceiveAuthECDH RPC.
+func (c *DaemonServiceMailboxClient) ReceiveAuthECDH(ctx context.Context, req *ReceiveAuthECDHRequest, opts ...rpc.RPCOptions) (*ReceiveAuthECDHResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "daemonrpc.DaemonService",
+		Method:  "ReceiveAuthECDH",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(ReceiveAuthECDHResponse)
 	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
 		return nil, err
 	}

--- a/darepod/rpc_wallet.go
+++ b/darepod/rpc_wallet.go
@@ -2,10 +2,16 @@ package darepod
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/lightninglabs/lndclient"
 	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/lntypes"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -14,6 +20,209 @@ import (
 // identity public key. This matches lnd's KeyFamilyNodeKey (family 6)
 // so the derived key sits at m/1017'/coinType'/6'/0/0.
 const identityKeyFamily = keychain.KeyFamilyNodeKey
+
+const receiveAuthKeyTag = "darepo/swap/receive-auth/v1"
+
+// ReceiveAuthKey returns the public key for the payment-scoped receive-auth
+// key while keeping the private scalar inside the daemon.
+func (r *RPCServer) ReceiveAuthKey(ctx context.Context,
+	req *daemonrpc.ReceiveAuthKeyRequest) (
+	*daemonrpc.ReceiveAuthKeyResponse, error) {
+
+	privKey, err := r.receiveAuthPrivateKey(ctx, req.GetPaymentHash())
+	if err != nil {
+		return nil, err
+	}
+
+	return &daemonrpc.ReceiveAuthKeyResponse{
+		Pubkey: privKey.PubKey().SerializeCompressed(),
+	}, nil
+}
+
+// SignReceiveAuthMessage signs one message with the payment-scoped
+// receive-auth key without returning private-key-equivalent material.
+func (r *RPCServer) SignReceiveAuthMessage(ctx context.Context,
+	req *daemonrpc.SignReceiveAuthMessageRequest) (
+	*daemonrpc.SignReceiveAuthMessageResponse, error) {
+
+	privKey, err := r.receiveAuthPrivateKey(ctx, req.GetPaymentHash())
+	if err != nil {
+		return nil, err
+	}
+
+	digest := receiveAuthDigest(req.GetMessage(), req.GetDoubleHash())
+	sig := ecdsa.Sign(privKey, digest)
+
+	return &daemonrpc.SignReceiveAuthMessageResponse{
+		Signature: sig.Serialize(),
+	}, nil
+}
+
+// SignReceiveAuthMessageCompact signs one message with the payment-scoped
+// receive-auth key and returns a compact recoverable signature.
+func (r *RPCServer) SignReceiveAuthMessageCompact(ctx context.Context,
+	req *daemonrpc.SignReceiveAuthMessageCompactRequest) (
+	*daemonrpc.SignReceiveAuthMessageCompactResponse, error) {
+
+	privKey, err := r.receiveAuthPrivateKey(ctx, req.GetPaymentHash())
+	if err != nil {
+		return nil, err
+	}
+
+	digest := receiveAuthDigest(req.GetMessage(), req.GetDoubleHash())
+	sig := ecdsa.SignCompact(privKey, digest, true)
+
+	return &daemonrpc.SignReceiveAuthMessageCompactResponse{
+		Signature: sig,
+	}, nil
+}
+
+// ReceiveAuthECDH derives one Sphinx shared secret with the payment-scoped
+// receive-auth key without exposing the receive-auth scalar to the caller.
+func (r *RPCServer) ReceiveAuthECDH(ctx context.Context,
+	req *daemonrpc.ReceiveAuthECDHRequest) (
+	*daemonrpc.ReceiveAuthECDHResponse, error) {
+
+	privKey, err := r.receiveAuthPrivateKey(ctx, req.GetPaymentHash())
+	if err != nil {
+		return nil, err
+	}
+
+	pubKey, err := btcec.ParsePubKey(req.GetPubkey())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"invalid pubkey: %v", err)
+	}
+
+	sharedSecret := receiveAuthECDH(privKey, pubKey)
+
+	return &daemonrpc.ReceiveAuthECDHResponse{
+		SharedSecret: sharedSecret[:],
+	}, nil
+}
+
+// deriveReceiveAuthKey derives the receive-auth base using the same
+// Diffie-Hellman construction as lnd's Signer.DeriveSharedKey RPC, then
+// domain-separates it for one payment hash.
+func (r *RPCServer) deriveReceiveAuthKey(
+	ctx context.Context, paymentHash lntypes.Hash) ([32]byte, error) {
+
+	keyDesc := keychain.KeyDescriptor{
+		KeyLocator: *lndclient.SharedKeyLocator,
+	}
+	var (
+		base [32]byte
+		err  error
+	)
+
+	switch r.server.cfg.Wallet.Type {
+	case WalletTypeLnd:
+		if !r.server.lnd.IsSome() {
+			return [32]byte{}, fmt.Errorf(
+				"lnd wallet not connected",
+			)
+		}
+
+		lndSvc := r.server.lnd.UnsafeFromSome()
+
+		base, err = lndSvc.Signer.DeriveSharedKey(
+			ctx, lndclient.SharedKeyNUMS,
+			lndclient.SharedKeyLocator,
+		)
+
+	case WalletTypeLwwallet:
+		if !r.server.lwWallet.IsSome() {
+			return [32]byte{}, fmt.Errorf(
+				"lwwallet not initialized",
+			)
+		}
+
+		w := r.server.lwWallet.UnsafeFromSome()
+
+		base, err = w.KeyRing().ECDH(keyDesc, lndclient.SharedKeyNUMS)
+
+	case WalletTypeBtcwallet:
+		if !r.server.btcwWallet.IsSome() {
+			return [32]byte{}, fmt.Errorf(
+				"btcwallet not initialized",
+			)
+		}
+
+		w := r.server.btcwWallet.UnsafeFromSome()
+
+		base, err = w.KeyRing().ECDH(
+			keyDesc, lndclient.SharedKeyNUMS,
+		)
+
+	default:
+		return [32]byte{}, fmt.Errorf("receive auth key derivation "+
+			"not supported for wallet type %q",
+			r.server.cfg.Wallet.Type)
+	}
+	if err != nil {
+		return [32]byte{}, err
+	}
+
+	key := chainhash.TaggedHash(
+		[]byte(receiveAuthKeyTag), base[:], paymentHash[:],
+	)
+
+	return [32]byte(*key), nil
+}
+
+// receiveAuthPrivateKey validates the request payment hash and derives the
+// matching private key inside the daemon process.
+func (r *RPCServer) receiveAuthPrivateKey(
+	ctx context.Context, rawPaymentHash []byte) (*btcec.PrivateKey, error) {
+
+	if len(rawPaymentHash) != lntypes.HashSize {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"payment_hash must be %d bytes", lntypes.HashSize)
+	}
+	var paymentHash lntypes.Hash
+	copy(paymentHash[:], rawPaymentHash)
+
+	if err := r.requireWalletReady(); err != nil {
+		return nil, err
+	}
+
+	key, err := r.deriveReceiveAuthKey(ctx, paymentHash)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"derive receive auth key: %v", err)
+	}
+
+	privKey, _ := btcec.PrivKeyFromBytes(key[:])
+
+	return privKey, nil
+}
+
+// receiveAuthDigest matches keychain.PrivKeyMessageSigner's hashing behavior
+// so daemon-backed receive-auth signatures are byte-for-byte compatible.
+func receiveAuthDigest(message []byte, doubleHash bool) []byte {
+	if doubleHash {
+		return chainhash.DoubleHashB(message)
+	}
+
+	return chainhash.HashB(message)
+}
+
+// receiveAuthECDH matches the lightning-onion SingleKeyECDH contract by
+// returning the SHA256 of the compressed shared point.
+func receiveAuthECDH(privKey *btcec.PrivateKey,
+	pubKey *btcec.PublicKey) [32]byte {
+
+	var pubJ btcec.JacobianPoint
+	pubKey.AsJacobian(&pubJ)
+
+	var ecdhPoint btcec.JacobianPoint
+	btcec.ScalarMultNonConst(&privKey.Key, &pubJ, &ecdhPoint)
+
+	ecdhPoint.ToAffine()
+	ecdhPubKey := btcec.NewPublicKey(&ecdhPoint.X, &ecdhPoint.Y)
+
+	return sha256.Sum256(ecdhPubKey.SerializeCompressed())
+}
 
 // GenSeed generates a new aezeed cipher seed mnemonic. This is the
 // first step when creating a new lwwallet-backed wallet. The returned

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/lightninglabs/neutrino/cache v1.1.3
 	github.com/lightninglabs/taproot-assets v0.7.0
 	github.com/lightninglabs/taproot-assets/taprpc v1.0.11
+	github.com/lightningnetwork/lightning-onion v1.3.0
 	github.com/lightningnetwork/lnd v0.21.0-beta.rc1
 	github.com/lightningnetwork/lnd/clock v1.1.1
 	github.com/lightningnetwork/lnd/fn/v2 v2.0.9
@@ -126,7 +127,6 @@ require (
 	github.com/klauspost/compress v1.17.9 // indirect
 	github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf // indirect
 	github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.4-0.20250610182311-2f1d46ef18b7 // indirect
-	github.com/lightningnetwork/lightning-onion v1.3.0 // indirect
 	github.com/lightningnetwork/lnd/actor v0.0.6 // indirect
 	github.com/lightningnetwork/lnd/cert v1.2.2 // indirect
 	github.com/lightningnetwork/lnd/healthcheck v1.2.6 // indirect

--- a/sdk/ark/client.go
+++ b/sdk/ark/client.go
@@ -9,8 +9,10 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/lightningnetwork/lnd/lntypes"
 	"google.golang.org/grpc"
 )
 
@@ -509,6 +511,107 @@ func (c *Client) AllocateReceiveScript(ctx context.Context,
 	}
 
 	return newReceiveInfo(resp)
+}
+
+// ReceiveAuthKey asks the daemon wallet for the payment-scoped receive-auth
+// public key used by higher-level swap receive flows.
+func (c *Client) ReceiveAuthKey(ctx context.Context,
+	paymentHash lntypes.Hash) (*btcec.PublicKey, error) {
+
+	resp, err := c.daemon.ReceiveAuthKey(
+		ctx, &daemonrpc.ReceiveAuthKeyRequest{
+			PaymentHash: paymentHash[:],
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get receive auth key: %w", err)
+	}
+
+	pubKey, err := btcec.ParsePubKey(resp.GetPubkey())
+	if err != nil {
+		return nil, fmt.Errorf("parse receive auth pubkey: %w", err)
+	}
+
+	return pubKey, nil
+}
+
+// SignReceiveAuthMessage asks the daemon wallet to sign one message with the
+// payment-scoped receive-auth key.
+func (c *Client) SignReceiveAuthMessage(ctx context.Context,
+	paymentHash lntypes.Hash, message []byte,
+	doubleHash bool) (*ecdsa.Signature, error) {
+
+	resp, err := c.daemon.SignReceiveAuthMessage(
+		ctx, &daemonrpc.SignReceiveAuthMessageRequest{
+			PaymentHash: paymentHash[:],
+			Message:     message,
+			DoubleHash:  doubleHash,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("sign receive auth message: %w", err)
+	}
+
+	sig, err := ecdsa.ParseDERSignature(resp.GetSignature())
+	if err != nil {
+		return nil, fmt.Errorf("parse receive auth signature: %w", err)
+	}
+
+	return sig, nil
+}
+
+// SignReceiveAuthMessageCompact asks the daemon wallet to sign one message
+// with the payment-scoped receive-auth key and return a compact signature.
+func (c *Client) SignReceiveAuthMessageCompact(ctx context.Context,
+	paymentHash lntypes.Hash, message []byte,
+	doubleHash bool) ([]byte, error) {
+
+	resp, err := c.daemon.SignReceiveAuthMessageCompact(
+		ctx, &daemonrpc.SignReceiveAuthMessageCompactRequest{
+			PaymentHash: paymentHash[:],
+			Message:     message,
+			DoubleHash:  doubleHash,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"sign receive auth message compact: %w", err,
+		)
+	}
+
+	return append([]byte(nil), resp.GetSignature()...), nil
+}
+
+// ReceiveAuthECDH asks the daemon wallet to derive one Sphinx shared secret
+// with the payment-scoped receive-auth key.
+func (c *Client) ReceiveAuthECDH(ctx context.Context,
+	paymentHash lntypes.Hash, pubKey *btcec.PublicKey) ([32]byte, error) {
+
+	if pubKey == nil {
+		return [32]byte{}, fmt.Errorf(
+			"receive auth ECDH pubkey is required",
+		)
+	}
+
+	resp, err := c.daemon.ReceiveAuthECDH(
+		ctx, &daemonrpc.ReceiveAuthECDHRequest{
+			PaymentHash: paymentHash[:],
+			Pubkey:      pubKey.SerializeCompressed(),
+		},
+	)
+	if err != nil {
+		return [32]byte{}, fmt.Errorf("receive auth ECDH: %w", err)
+	}
+	if len(resp.GetSharedSecret()) != 32 {
+		return [32]byte{}, fmt.Errorf(
+			"receive auth shared secret must be 32 bytes",
+		)
+	}
+
+	var sharedSecret [32]byte
+	copy(sharedSecret[:], resp.GetSharedSecret())
+
+	return sharedSecret, nil
 }
 
 // GetIndexedVTXOByPkScript asks the daemon's indexer client for the first VTXO

--- a/sdk/ark/client_test.go
+++ b/sdk/ark/client_test.go
@@ -1,6 +1,7 @@
 package ark
 
 import (
+	"bytes"
 	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
@@ -18,9 +19,11 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	btcecdsa "github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/lightninglabs/darepo-client/darepod"
+	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -163,6 +166,17 @@ func compressedPubKeyHex(scalar byte) string {
 	_, pubKey := btcec.PrivKeyFromBytes(privKeyBytes)
 
 	return hex.EncodeToString(pubKey.SerializeCompressed())
+}
+
+// fakeReceiveAuthPrivKey returns the deterministic key used by fake daemon
+// receive-auth operations.
+func fakeReceiveAuthPrivKey() *btcec.PrivateKey {
+	privKeyBytes := make([]byte, 32)
+	privKeyBytes[len(privKeyBytes)-1] = 4
+
+	privKey, _ := btcec.PrivKeyFromBytes(privKeyBytes)
+
+	return privKey
 }
 
 // startFakeDaemonServer boots a fake daemon gRPC server and returns the
@@ -311,6 +325,64 @@ func (f *fakeDaemonService) NewReceiveScript(_ context.Context,
 	*daemonrpc.NewReceiveScriptResponse, error) {
 
 	return f.newReceiveResp, nil
+}
+
+// ReceiveAuthKey returns one deterministic receive-auth public key.
+func (f *fakeDaemonService) ReceiveAuthKey(context.Context,
+	*daemonrpc.ReceiveAuthKeyRequest) (
+	*daemonrpc.ReceiveAuthKeyResponse, error) {
+
+	return &daemonrpc.ReceiveAuthKeyResponse{
+		Pubkey: fakeReceiveAuthPrivKey().PubKey().
+			SerializeCompressed(),
+	}, nil
+}
+
+// SignReceiveAuthMessage signs with the deterministic receive-auth key.
+func (f *fakeDaemonService) SignReceiveAuthMessage(_ context.Context,
+	req *daemonrpc.SignReceiveAuthMessageRequest) (
+	*daemonrpc.SignReceiveAuthMessageResponse, error) {
+
+	digest := chainhash.HashB(req.GetMessage())
+	if req.GetDoubleHash() {
+		digest = chainhash.DoubleHashB(req.GetMessage())
+	}
+
+	sig := btcecdsa.Sign(fakeReceiveAuthPrivKey(), digest)
+
+	return &daemonrpc.SignReceiveAuthMessageResponse{
+		Signature: sig.Serialize(),
+	}, nil
+}
+
+// SignReceiveAuthMessageCompact signs with the deterministic receive-auth key
+// and returns the compact signature.
+func (f *fakeDaemonService) SignReceiveAuthMessageCompact(_ context.Context,
+	req *daemonrpc.SignReceiveAuthMessageCompactRequest) (
+	*daemonrpc.SignReceiveAuthMessageCompactResponse, error) {
+
+	digest := chainhash.HashB(req.GetMessage())
+	if req.GetDoubleHash() {
+		digest = chainhash.DoubleHashB(req.GetMessage())
+	}
+
+	sig := btcecdsa.SignCompact(
+		fakeReceiveAuthPrivKey(), digest, true,
+	)
+
+	return &daemonrpc.SignReceiveAuthMessageCompactResponse{
+		Signature: sig,
+	}, nil
+}
+
+// ReceiveAuthECDH returns one deterministic shared secret for facade tests.
+func (f *fakeDaemonService) ReceiveAuthECDH(context.Context,
+	*daemonrpc.ReceiveAuthECDHRequest) (
+	*daemonrpc.ReceiveAuthECDHResponse, error) {
+
+	return &daemonrpc.ReceiveAuthECDHResponse{
+		SharedSecret: bytes.Repeat([]byte{0x55}, 32),
+	}, nil
 }
 
 // GetIndexedVTXOByPkScript returns one deterministic indexed VTXO and records
@@ -613,6 +685,37 @@ func TestDialRemotePolicyHelpers(t *testing.T) {
 		receiveInfo.PkScript,
 	)
 	require.Equal(t, uint32(23), receiveInfo.KeyFamily)
+
+	authPubKey, err := client.ReceiveAuthKey(
+		context.Background(), lntypes.Hash{1, 2, 3},
+	)
+	require.NoError(t, err)
+	require.True(t, authPubKey.IsEqual(fakeReceiveAuthPrivKey().PubKey()))
+
+	authSig, err := client.SignReceiveAuthMessage(
+		context.Background(), lntypes.Hash{1, 2, 3}, []byte("msg"),
+		false,
+	)
+	require.NoError(t, err)
+	require.True(t, authSig.Verify(
+		chainhash.HashB([]byte("msg")), authPubKey,
+	))
+
+	compactSig, err := client.SignReceiveAuthMessageCompact(
+		context.Background(), lntypes.Hash{1, 2, 3}, []byte("msg"),
+		true,
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, compactSig)
+
+	remotePriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	sharedSecret, err := client.ReceiveAuthECDH(
+		context.Background(), lntypes.Hash{1, 2, 3},
+		remotePriv.PubKey(),
+	)
+	require.NoError(t, err)
+	require.Equal(t, bytes.Repeat([]byte{0x55}, 32), sharedSecret[:])
 
 	const sessionTxID = "11111111111111111111111111111111" +
 		"11111111111111111111111111111111"

--- a/sdk/swaps/auth_key.go
+++ b/sdk/swaps/auth_key.go
@@ -1,0 +1,85 @@
+package swaps
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
+	sphinx "github.com/lightningnetwork/lightning-onion"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/lntypes"
+)
+
+// ReceiveAuthKey signs receive invoices and decrypts the forwarded final-hop
+// onion for one payment-scoped receive-auth key.
+type ReceiveAuthKey interface {
+	keychain.SingleKeyMessageSigner
+	sphinx.SingleKeyECDH
+}
+
+// daemonReceiveAuthKey adapts daemon-backed receive-auth operations to the
+// signer and ECDH interfaces used by invoice creation and onion decoding.
+type daemonReceiveAuthKey struct {
+	ctx         func() context.Context
+	daemon      DaemonConn
+	paymentHash lntypes.Hash
+	pubKey      *btcec.PublicKey
+}
+
+// PubKey returns the public key for the receive-auth key.
+func (k *daemonReceiveAuthKey) PubKey() *btcec.PublicKey {
+	return k.pubKey
+}
+
+// KeyLocator returns the placeholder locator used by daemon-backed receive
+// auth.
+func (k *daemonReceiveAuthKey) KeyLocator() keychain.KeyLocator {
+	return keychain.KeyLocator{}
+}
+
+// SignMessage signs one message with the receive-auth key.
+func (k *daemonReceiveAuthKey) SignMessage(message []byte,
+	doubleHash bool) (*ecdsa.Signature, error) {
+
+	return k.daemon.SignReceiveAuthMessage(
+		k.ctx(), k.paymentHash, message, doubleHash,
+	)
+}
+
+// SignMessageCompact signs one message with the receive-auth key.
+func (k *daemonReceiveAuthKey) SignMessageCompact(message []byte,
+	doubleHash bool) ([]byte, error) {
+
+	return k.daemon.SignReceiveAuthMessageCompact(
+		k.ctx(), k.paymentHash, message, doubleHash,
+	)
+}
+
+// ECDH derives the Sphinx shared secret with a remote onion ephemeral key.
+func (k *daemonReceiveAuthKey) ECDH(pub *btcec.PublicKey) ([32]byte, error) {
+	return k.daemon.ReceiveAuthECDH(k.ctx(), k.paymentHash, pub)
+}
+
+// receiveAuthKey returns a daemon-backed payment-scoped receive-auth key. The
+// SDK receives only a public key and delegates signing/ECDH to the daemon.
+func (c *SwapClient) receiveAuthKey(
+	ctx context.Context, paymentHash lntypes.Hash) (ReceiveAuthKey, error) {
+
+	if c.daemon == nil {
+		return nil, fmt.Errorf("daemon connection is required to " +
+			"use receive auth key")
+	}
+
+	pubKey, err := c.daemon.ReceiveAuthKey(ctx, paymentHash)
+	if err != nil {
+		return nil, fmt.Errorf("get receive auth key: %w", err)
+	}
+
+	return &daemonReceiveAuthKey{
+		ctx:         func() context.Context { return ctx },
+		daemon:      c.daemon,
+		paymentHash: paymentHash,
+		pubKey:      pubKey,
+	}, nil
+}

--- a/sdk/swaps/client.go
+++ b/sdk/swaps/client.go
@@ -5,10 +5,12 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btclog/v2"
 	sdkark "github.com/lightninglabs/darepo-client/sdk/ark"
 	"github.com/lightningnetwork/lnd/invoices"
+	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lntypes"
 )
 
@@ -145,6 +147,16 @@ type InvoiceCreator interface {
 		routeHint *RouteHint, expiry time.Duration,
 		preimage *lntypes.Preimage) (*invoices.Invoice, lntypes.Hash,
 		error)
+
+	// CreateInvoiceWithKey builds one signed invoice using the client's
+	// receive auth key. Receive swaps use this key as the invoice
+	// destination and later decode the forwarded final-hop onion with it.
+	CreateInvoiceWithKey(ctx context.Context,
+		amountSat btcutil.Amount, memo string,
+		routeHint *RouteHint, expiry time.Duration,
+		authKey keychain.SingleKeyMessageSigner,
+		preimage *lntypes.Preimage) (*invoices.Invoice, lntypes.Hash,
+		error)
 }
 
 // RouteHint describes a single hop hint for Lightning invoices.
@@ -193,6 +205,46 @@ type VHTLCConfig struct {
 	SwapServerPubkey []byte
 }
 
+// OutSwapHtlcEvent carries the server-funded HTLC metadata that the client
+// validates before revealing its invoice preimage.
+type OutSwapHtlcEvent struct {
+	// PaymentHash is the intercepted Lightning payment hash.
+	PaymentHash lntypes.Hash
+
+	// AmountSat is the amount funded by the server.
+	AmountSat int64
+
+	// OnionBlob is the raw final-hop onion blob forwarded by the server.
+	OnionBlob []byte
+
+	// VHTLCConfig contains the script parameters for the funded vHTLC.
+	VHTLCConfig VHTLCConfig
+}
+
+// OutSwapHtlcNotification carries one mailbox-delivered out-swap HTLC event
+// and an optional acknowledgement hook.
+type OutSwapHtlcNotification struct {
+	Event     *OutSwapHtlcEvent
+	AckCursor uint64
+	Ack       func(context.Context) error
+}
+
+// OutSwapEventReceiver waits for server-pushed out-swap mailbox events.
+type OutSwapEventReceiver interface {
+	WaitOutSwapHtlc(
+		ctx context.Context,
+		paymentHash lntypes.Hash,
+		mailboxPubkey *btcec.PublicKey,
+	) (*OutSwapHtlcNotification, error)
+
+	AckOutSwapHtlc(
+		ctx context.Context,
+		paymentHash lntypes.Hash,
+		mailboxPubkey *btcec.PublicKey,
+		cursor uint64,
+	) error
+}
+
 // InSwapConfig is returned by the server when creating an in-swap.
 type InSwapConfig struct {
 	// PaymentHash is the SHA-256 payment hash extracted from the
@@ -224,13 +276,13 @@ type InSwapConfig struct {
 // gRPC service. This allows the client to talk to the swap server
 // without importing the server module.
 type SwapServerConn interface {
-	// RequestChannelID asks the server for a route hint and
-	// the locked-in vHTLC configuration for this swap.
+	// RequestChannelID asks the server for a route hint for this swap.
 	RequestChannelID(
 		ctx context.Context,
 		vhtlcPubkey *btcec.PublicKey,
+		paymentHash lntypes.Hash,
 		expirySeconds uint32,
-	) (*RouteHint, *VHTLCConfig, error)
+	) (*RouteHint, error)
 
 	// CreateInSwap initiates an Ark->LN swap on the server.
 	CreateInSwap(
@@ -314,6 +366,28 @@ type DaemonConn interface {
 	AllocateReceiveScript(
 		ctx context.Context, label string,
 	) (*ReceiveInfo, error)
+
+	// ReceiveAuthKey returns the payment-scoped receive-auth public key.
+	ReceiveAuthKey(ctx context.Context,
+		paymentHash lntypes.Hash) (*btcec.PublicKey, error)
+
+	// SignReceiveAuthMessage signs one message with the payment-scoped
+	// receive-auth key.
+	SignReceiveAuthMessage(ctx context.Context,
+		paymentHash lntypes.Hash, message []byte,
+		doubleHash bool) (*ecdsa.Signature, error)
+
+	// SignReceiveAuthMessageCompact signs one message with the
+	// payment-scoped receive-auth key and returns a compact signature.
+	SignReceiveAuthMessageCompact(ctx context.Context,
+		paymentHash lntypes.Hash, message []byte,
+		doubleHash bool) ([]byte, error)
+
+	// ReceiveAuthECDH derives one Sphinx shared secret with the
+	// payment-scoped receive-auth key.
+	ReceiveAuthECDH(ctx context.Context,
+		paymentHash lntypes.Hash,
+		pubKey *btcec.PublicKey) ([32]byte, error)
 }
 
 // CustomInput aliases the Ark SDK's typed custom OOR input.
@@ -331,6 +405,7 @@ type SwapClient struct {
 	server     SwapServerConn
 	daemon     DaemonConn
 	invoiceGen InvoiceCreator
+	outEvents  OutSwapEventReceiver
 	store      *Store
 	log        btclog.Logger
 
@@ -342,7 +417,16 @@ type SwapClient struct {
 	refundLocktimeBuffer     uint32
 	claimRetryDelay          time.Duration
 	claimMaxAttempts         int
+	decodeOutSwapOnion       outSwapOnionDecoder
 	now                      func() time.Time
+}
+
+// SetOutSwapEventReceiver sets the mailbox event receiver used by
+// ReceiveViaLightning. Callers should configure this before starting receives.
+func (c *SwapClient) SetOutSwapEventReceiver(
+	receiver OutSwapEventReceiver) {
+
+	c.outEvents = receiver
 }
 
 // NewSwapClient creates a new swap client. The invoice creator may be nil for
@@ -366,10 +450,16 @@ func NewSwapClientWithStore(server SwapServerConn, daemon DaemonConn,
 		log = btclog.Disabled
 	}
 
+	var outEvents OutSwapEventReceiver
+	if receiver, ok := server.(OutSwapEventReceiver); ok {
+		outEvents = receiver
+	}
+
 	return &SwapClient{
 		server:                   server,
 		daemon:                   daemon,
 		invoiceGen:               invoiceGen,
+		outEvents:                outEvents,
 		store:                    store,
 		log:                      log,
 		waitPollInterval:         2 * time.Second,
@@ -380,6 +470,7 @@ func NewSwapClientWithStore(server SwapServerConn, daemon DaemonConn,
 		refundLocktimeBuffer:     defaultRefundLocktimeBuffer,
 		claimRetryDelay:          time.Second,
 		claimMaxAttempts:         10,
+		decodeOutSwapOnion:       decodeOutSwapOnion,
 		now:                      time.Now,
 	}
 }

--- a/sdk/swaps/errors.go
+++ b/sdk/swaps/errors.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 
 	loopfsm "github.com/lightninglabs/loop/fsm"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 var (
@@ -27,6 +29,12 @@ var errSwapExpired = ErrSwapExpired
 // already been observed in the indexer, so no OOR session id should be
 // persisted for the current process.
 var errReceiveClaimAlreadyIndexed = errors.New("receive claim already indexed")
+
+// errReceiveVHTLCSpentWithoutPreimage reports that the funded receive vHTLC
+// was spent by a path that did not reveal the invoice preimage.
+var errReceiveVHTLCSpentWithoutPreimage = errors.New(
+	"receive vHTLC spent without claim preimage",
+)
 
 // interventionError records an anomalous swap condition that should stop the
 // FSM in a terminal NeedsIntervention state rather than collapsing into a
@@ -160,6 +168,22 @@ func failureReason(err error) string {
 func isInterruptErr(err error) bool {
 	return errors.Is(err, context.Canceled) ||
 		errors.Is(err, context.DeadlineExceeded)
+}
+
+// isDeadlineExceededErr reports whether err carries a deadline-exceeded
+// signal, regardless of whether it was produced locally as
+// context.DeadlineExceeded or returned over gRPC as a status error. gRPC's
+// status type does not unwrap to context.DeadlineExceeded, so the bare
+// errors.Is check on its own would miss the wire-encoded form.
+func isDeadlineExceededErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+
+	return status.Code(err) == codes.DeadlineExceeded
 }
 
 // handleFailure persists the terminal swap state associated with err and

--- a/sdk/swaps/grpc_conn.go
+++ b/sdk/swaps/grpc_conn.go
@@ -27,41 +27,38 @@ func NewGRPCSwapServerConn(
 	}
 }
 
-// RequestChannelID asks the swap server for one route hint and the negotiated
-// vHTLC configuration for a Lightning-to-Ark receive flow.
+// RequestChannelID asks the swap server for one route hint for a
+// Lightning-to-Ark receive flow.
 func (g *GRPCSwapServerConn) RequestChannelID(ctx context.Context,
-	vhtlcPubkey *btcec.PublicKey,
-	expirySeconds uint32) (*RouteHint, *VHTLCConfig, error) {
+	vhtlcPubkey *btcec.PublicKey, paymentHash lntypes.Hash,
+	expirySeconds uint32) (*RouteHint, error) {
 
 	if vhtlcPubkey == nil {
-		return nil, nil, fmt.Errorf(
-			"vHTLC pubkey must be provided",
-		)
+		return nil, fmt.Errorf("vHTLC pubkey must be provided")
 	}
 
 	resp, err := g.client.RequestChannelId(
 		ctx, &swaprpc.RequestChannelIdRequest{
-			ExpirySeconds:     expirySeconds,
-			ClientVhtlcPubkey: vhtlcPubkey.SerializeCompressed(),
+			ExpirySeconds: expirySeconds,
+			ClientVhtlcPubkey: vhtlcPubkey.
+				SerializeCompressed(),
+			PaymentHash: append(
+				[]byte(nil), paymentHash[:]...,
+			),
 		},
 	)
 	if err != nil {
-		return nil, nil, fmt.Errorf(
+		return nil, fmt.Errorf(
 			"RequestChannelId RPC: %w", err,
 		)
 	}
 
 	hint, err := routeHintFromProto(resp.GetRouteHint())
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	cfg, err := vhtlcConfigFromProto(resp.GetVhtlcConfig())
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return hint, cfg, nil
+	return hint, nil
 }
 
 // CreateInSwap initiates one Ark-to-Lightning swap on the swap server.
@@ -162,6 +159,42 @@ func vhtlcConfigFromProto(cfg *swaprpc.VHTLCConfig) (*VHTLCConfig, error) {
 		SwapServerPubkey: append(
 			[]byte(nil), cfg.GetSwapserverPubkey()...,
 		),
+	}, nil
+}
+
+// outSwapHtlcEventFromProto converts one generated funded-HTLC event into the
+// local SDK shape.
+func outSwapHtlcEventFromProto(
+	event *swaprpc.OutSwapHtlcEvent) (*OutSwapHtlcEvent, error) {
+
+	if event == nil {
+		return nil, fmt.Errorf("out-swap HTLC event must be provided")
+	}
+	if len(event.GetPaymentHash()) != lntypes.HashSize {
+		return nil, fmt.Errorf(
+			"out-swap event payment hash must be %d bytes",
+			lntypes.HashSize,
+		)
+	}
+	if event.GetAmountSat() > math.MaxInt64 {
+		return nil, fmt.Errorf("out-swap event amount exceeds int64")
+	}
+
+	var paymentHash lntypes.Hash
+	copy(paymentHash[:], event.GetPaymentHash())
+
+	cfg, err := vhtlcConfigFromProto(event.GetVhtlcConfig())
+	if err != nil {
+		return nil, err
+	}
+
+	return &OutSwapHtlcEvent{
+		PaymentHash: paymentHash,
+		AmountSat:   int64(event.GetAmountSat()),
+		OnionBlob: append(
+			[]byte(nil), event.GetOnionBlob()...,
+		),
+		VHTLCConfig: *cfg,
 	}, nil
 }
 

--- a/sdk/swaps/in_swap_test.go
+++ b/sdk/swaps/in_swap_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,10 +21,10 @@ type testInSwapServerConn struct {
 
 // RequestChannelID is unused in these tests.
 func (c *testInSwapServerConn) RequestChannelID(
-	_ context.Context, _ *btcec.PublicKey,
-	_ uint32) (*RouteHint, *VHTLCConfig, error) {
+	_ context.Context, _ *btcec.PublicKey, _ lntypes.Hash,
+	_ uint32) (*RouteHint, error) {
 
-	return nil, nil, nil
+	return nil, nil
 }
 
 // CreateInSwap returns the preconfigured in-swap config.
@@ -548,7 +549,7 @@ func TestPaySessionResumeFundingGraceSkipsImmediateResend(t *testing.T) {
 	require.Equal(t, PayStateFundingInitiated, resumed.State())
 
 	waitCtx, cancel := context.WithTimeout(
-		t.Context(), 5*time.Millisecond,
+		t.Context(), 100*time.Millisecond,
 	)
 	defer cancel()
 

--- a/sdk/swaps/invoice.go
+++ b/sdk/swaps/invoice.go
@@ -8,26 +8,30 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
-	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/lightningnetwork/lnd/graph/db/models"
 	"github.com/lightningnetwork/lnd/invoices"
 	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/lnrpc/invoicesrpc"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/netann"
+	"github.com/lightningnetwork/lnd/routing/route"
 	"github.com/lightningnetwork/lnd/zpay32"
 )
 
 const (
-	// defaultInvoiceExpiry is the default expiry duration for
-	// swap invoices when none is specified by the caller.
+	// defaultInvoiceExpiry is the default expiry duration for swap invoices
+	// when none is specified by the caller.
 	defaultInvoiceExpiry = time.Hour
+
+	// defaultCLTVExpiry is the default CLTV expiry delta for invoices.
+	defaultCLTVExpiry = 40
 )
 
-type compactInvoiceSigner func([]byte) ([]byte, error)
-
-// InvoiceStore persists created invoices so they can be looked up
-// when HTLCs arrive.
+// InvoiceStore persists created invoices so they can be looked up when HTLCs
+// arrive.
 type InvoiceStore interface {
 	// AddInvoice stores a new invoice keyed by payment hash.
 	AddInvoice(
@@ -37,8 +41,8 @@ type InvoiceStore interface {
 	) (uint64, error)
 }
 
-// NewPreimage generates a cryptographically random 32-byte
-// preimage suitable for use as a Lightning payment preimage.
+// NewPreimage generates a cryptographically random 32-byte preimage suitable
+// for use as a Lightning payment preimage.
 func NewPreimage() (lntypes.Preimage, error) {
 	var preimage lntypes.Preimage
 	if _, err := rand.Read(preimage[:]); err != nil {
@@ -50,19 +54,19 @@ func NewPreimage() (lntypes.Preimage, error) {
 	return preimage, nil
 }
 
-// InvoiceGenerator creates properly signed Lightning invoices
-// with route hints pointing through the swap server using direct
-// BOLT-11 encoding and a SingleKeyMessageSigner.
+// InvoiceGenerator creates properly signed Lightning invoices with route hints
+// pointing through the swap server. It delegates invoice construction to lnd's
+// invoicesrpc.AddInvoice machinery so feature bits, payment address handling,
+// and invoice storage follow the same path as normal lnd invoices.
 type InvoiceGenerator struct {
-	signer      keychain.SingleKeyMessageSigner
+	invoiceCfg  *invoicesrpc.AddInvoiceConfig
 	chainParams *chaincfg.Params
 }
 
-// DirectInvoiceCreator creates signed BOLT-11 invoices directly from a private
-// key without depending on a full lnd invoice registry.
+// DirectInvoiceCreator is kept for source compatibility with older SDK users.
+// It now delegates to InvoiceGenerator instead of manually encoding invoices.
 type DirectInvoiceCreator struct {
-	privKey     *btcec.PrivateKey
-	chainParams *chaincfg.Params
+	generator *InvoiceGenerator
 }
 
 // MemoryInvoiceStore keeps invoices in memory for ephemeral callers such as
@@ -101,104 +105,179 @@ func (s *MemoryInvoiceStore) AddInvoice(_ context.Context,
 // NewInvoiceGenerator creates an InvoiceGenerator.
 //
 // The signer is used to sign invoices, typically through the wallet key ring.
-// The bestHeight and store parameters are retained only for source
-// compatibility with earlier swap SDK revisions and are ignored by this
-// stateless invoice encoder.
+// The bestHeight function returns the current best block height. The store
+// persists created invoices.
 func NewInvoiceGenerator(
 	signer keychain.SingleKeyMessageSigner,
 	bestHeight func() (uint32, error),
 	store InvoiceStore,
 	chainParams *chaincfg.Params) *InvoiceGenerator {
 
-	_ = bestHeight
-	_ = store
+	nodeSigner := netann.NewNodeSigner(signer)
 
 	return &InvoiceGenerator{
-		signer:      signer,
+		invoiceCfg: genInvoiceCfg(
+			nodeSigner, bestHeight, store, chainParams,
+		),
 		chainParams: chainParams,
 	}
 }
 
-// NewEphemeralInvoiceGenerator creates an ephemeral invoice creator backed by a
-// private key and direct BOLT-11 encoding.
-//
-// The bestHeight parameter is retained only for source compatibility with
-// earlier swap SDK revisions and is ignored by this stateless invoice encoder.
+// genInvoiceCfg returns the minimal AddInvoice configuration needed for swap
+// invoices that carry explicit route hints and do not depend on a real graph.
+func genInvoiceCfg(nodeSigner *netann.NodeSigner,
+	bestHeight func() (uint32, error), store InvoiceStore,
+	chainParams *chaincfg.Params) *invoicesrpc.AddInvoiceConfig {
+
+	if bestHeight == nil {
+		bestHeight = func() (uint32, error) {
+			return 0, nil
+		}
+	}
+	if store == nil {
+		store = NewMemoryInvoiceStore()
+	}
+
+	return &invoicesrpc.AddInvoiceConfig{
+		AddInvoice: store.AddInvoice,
+		IsChannelActive: func(lnwire.ChannelID) bool {
+			return true
+		},
+		ChainParams:       chainParams,
+		NodeSigner:        nodeSigner,
+		DefaultCLTVExpiry: defaultCLTVExpiry,
+		ChanDB:            nil,
+		Graph:             &mockGraph{},
+		GenInvoiceFeatures: func() *lnwire.FeatureVector {
+			return lnwire.NewFeatureVector(
+				lnwire.NewRawFeatureVector(
+					lnwire.TLVOnionPayloadRequired,
+					lnwire.PaymentAddrRequired,
+				),
+				lnwire.Features,
+			)
+		},
+		GenAmpInvoiceFeatures: func() *lnwire.FeatureVector {
+			return lnwire.NewFeatureVector(
+				lnwire.NewRawFeatureVector(
+					lnwire.TLVOnionPayloadRequired,
+					lnwire.PaymentAddrRequired,
+					lnwire.AMPRequired,
+				),
+				lnwire.Features,
+			)
+		},
+		GetAlias: func(
+			lnwire.ChannelID,
+		) (lnwire.ShortChannelID, error) {
+
+			return lnwire.ShortChannelID{}, nil
+		},
+		BestHeight: bestHeight,
+		QueryBlindedRoutes: func(
+			lnwire.MilliSatoshi,
+		) ([]*route.Route, error) {
+
+			return nil, nil
+		},
+	}
+}
+
+// mockGraph satisfies the subset of graph lookups AddInvoice expects when
+// normalizing caller-provided route hints for virtual channels.
+type mockGraph struct{}
+
+// IsPublicNode reports all nodes as public for route hint validation.
+func (m *mockGraph) IsPublicNode(_ context.Context,
+	_ [33]byte) (bool, error) {
+
+	return true, nil
+}
+
+// FetchChannelEdgesByID reports no backing graph edges for swap virtual
+// channels.
+func (m *mockGraph) FetchChannelEdgesByID(_ context.Context,
+	_ uint64) (*models.ChannelEdgeInfo, *models.ChannelEdgePolicy,
+	*models.ChannelEdgePolicy, error) {
+
+	return nil, nil, nil, nil
+}
+
+// NewEphemeralInvoiceGenerator creates an ephemeral invoice creator backed by
+// a private key and the standard AddInvoice invoice construction path.
 func NewEphemeralInvoiceGenerator(privKey *btcec.PrivateKey,
 	bestHeight func() (uint32, error),
 	chainParams *chaincfg.Params) InvoiceCreator {
 
-	_ = bestHeight
+	signer := keychain.NewPrivKeyMessageSigner(
+		privKey, keychain.KeyLocator{},
+	)
 
 	return &DirectInvoiceCreator{
-		privKey:     privKey,
-		chainParams: chainParams,
+		generator: NewInvoiceGenerator(
+			signer, bestHeight, NewMemoryInvoiceStore(),
+			chainParams,
+		),
 	}
 }
 
-// CreateInvoice builds a signed BOLT-11 Lightning invoice with a
-// route hint pointing through the swap server's virtual channel.
-// When preimage is non-nil, the invoice is locked to that preimage
-// so the caller can construct a matching vHTLC. Returns the
-// invoice, its payment hash, and any error.
-func (g *InvoiceGenerator) CreateInvoice(_ context.Context,
+// CreateInvoice builds a signed BOLT-11 Lightning invoice with a route hint
+// pointing through the swap server's virtual channel. When preimage is non-nil,
+// the invoice is locked to that preimage so the caller can construct a matching
+// vHTLC.
+func (g *InvoiceGenerator) CreateInvoice(ctx context.Context,
 	amountSat btcutil.Amount, memo string,
 	routeHint *RouteHint, expiry time.Duration,
 	preimage *lntypes.Preimage) (*invoices.Invoice, lntypes.Hash,
 	error) {
 
-	if g == nil || g.signer == nil {
-		return nil, lntypes.Hash{}, fmt.Errorf(
-			"invoice signer is required",
-		)
-	}
-
-	return buildSignedInvoice(
-		amountSat, memo, routeHint, expiry, preimage,
-		g.chainParams, func(hash []byte) ([]byte, error) {
-			return g.signer.SignMessageCompact(hash, false)
-		},
-	)
+	return g.createInvoice(ctx, g.invoiceCfg, amountSat, memo, routeHint,
+		expiry, preimage)
 }
 
-// CreateInvoice creates one signed BOLT-11 invoice using direct zpay32
-// encoding.
-func (g *DirectInvoiceCreator) CreateInvoice(_ context.Context,
-	amountSat btcutil.Amount, memo string, routeHint *RouteHint,
-	expiry time.Duration, preimage *lntypes.Preimage) (*invoices.Invoice,
-	lntypes.Hash, error) {
-
-	if g == nil || g.privKey == nil {
-		return nil, lntypes.Hash{}, fmt.Errorf(
-			"invoice creator private key is required",
-		)
-	}
-
-	return buildSignedInvoice(
-		amountSat, memo, routeHint, expiry, preimage,
-		g.chainParams, func(hash []byte) ([]byte, error) {
-			return ecdsa.SignCompact(g.privKey, hash, true), nil
-		},
-	)
-}
-
-func buildSignedInvoice(amountSat btcutil.Amount, memo string,
+// CreateInvoiceWithKey creates one invoice signed by the supplied auth key.
+func (g *InvoiceGenerator) CreateInvoiceWithKey(ctx context.Context,
+	amountSat btcutil.Amount, memo string,
 	routeHint *RouteHint, expiry time.Duration,
-	preimage *lntypes.Preimage, chainParams *chaincfg.Params,
-	sign compactInvoiceSigner) (*invoices.Invoice, lntypes.Hash, error) {
+	authKey keychain.SingleKeyMessageSigner,
+	preimage *lntypes.Preimage) (*invoices.Invoice, lntypes.Hash,
+	error) {
 
-	if chainParams == nil {
+	if authKey == nil {
+		return nil, lntypes.Hash{}, fmt.Errorf(
+			"invoice auth key is required",
+		)
+	}
+	if g == nil || g.invoiceCfg == nil {
+		return nil, lntypes.Hash{}, fmt.Errorf(
+			"invoice generator is required",
+		)
+	}
+
+	invoiceCfg := *g.invoiceCfg
+	invoiceCfg.NodeSigner = netann.NewNodeSigner(authKey)
+
+	return g.createInvoice(ctx, &invoiceCfg, amountSat, memo, routeHint,
+		expiry, preimage)
+}
+
+// createInvoice builds one signed BOLT-11 invoice through invoicesrpc.
+func (g *InvoiceGenerator) createInvoice(ctx context.Context,
+	cfg *invoicesrpc.AddInvoiceConfig, amountSat btcutil.Amount,
+	memo string, routeHint *RouteHint, expiry time.Duration,
+	preimage *lntypes.Preimage) (*invoices.Invoice, lntypes.Hash,
+	error) {
+
+	if g == nil || cfg == nil || cfg.NodeSigner == nil {
+		return nil, lntypes.Hash{}, fmt.Errorf(
+			"invoice generator is required",
+		)
+	}
+	if cfg.ChainParams == nil {
 		return nil, lntypes.Hash{}, fmt.Errorf(
 			"chain parameters are required",
 		)
 	}
-
-	if sign == nil {
-		return nil, lntypes.Hash{}, fmt.Errorf(
-			"invoice signer is required",
-		)
-	}
-
 	if err := validateInvoiceAmount(amountSat); err != nil {
 		return nil, lntypes.Hash{}, err
 	}
@@ -207,46 +286,24 @@ func buildSignedInvoice(amountSat btcutil.Amount, memo string,
 	if err != nil {
 		return nil, lntypes.Hash{}, err
 	}
-
 	if expiry == 0 {
 		expiry = defaultInvoiceExpiry
 	}
 
-	invoicePreimage := preimage
-	if invoicePreimage == nil {
-		generatedPreimage, err := NewPreimage()
-		if err != nil {
-			return nil, lntypes.Hash{}, err
-		}
-
-		invoicePreimage = &generatedPreimage
-	}
-
-	paymentHash := invoicePreimage.Hash()
-	var paymentAddr [32]byte
-	if _, err := rand.Read(paymentAddr[:]); err != nil {
-		return nil, lntypes.Hash{}, fmt.Errorf(
-			"generate payment address: %w", err,
-		)
-	}
-
-	createdAt := time.Now()
-	msat := lnwire.NewMSatFromSatoshis(amountSat)
-	features := lnwire.NewFeatureVector(
-		lnwire.NewRawFeatureVector(
-			lnwire.TLVOnionPayloadRequired,
-			lnwire.PaymentAddrRequired,
+	invoiceData := &invoicesrpc.AddInvoiceData{
+		Memo:     memo,
+		Preimage: preimage,
+		Value: lnwire.NewMSatFromSatoshis(
+			amountSat,
 		),
-		lnwire.Features,
-	)
-	invoice, err := zpay32.NewInvoice(
-		chainParams, paymentHash, createdAt,
-		zpay32.Amount(msat),
-		zpay32.Description(memo),
-		zpay32.RouteHint([]zpay32.HopHint{hopHint}),
-		zpay32.Expiry(expiry),
-		zpay32.PaymentAddr(paymentAddr),
-		zpay32.Features(features),
+		RouteHints: [][]zpay32.HopHint{
+			{hopHint},
+		},
+		Expiry: int64(expiry.Seconds()),
+	}
+
+	paymentHash, invoice, err := invoicesrpc.AddInvoice(
+		ctx, cfg, invoiceData,
 	)
 	if err != nil {
 		return nil, lntypes.Hash{}, fmt.Errorf(
@@ -254,29 +311,43 @@ func buildSignedInvoice(amountSat btcutil.Amount, memo string,
 		)
 	}
 
-	paymentRequest, err := invoice.Encode(zpay32.MessageSigner{
-		SignCompact: sign,
-	})
-	if err != nil {
+	return invoice, *paymentHash, nil
+}
+
+// CreateInvoice creates one signed BOLT-11 invoice using AddInvoice.
+func (g *DirectInvoiceCreator) CreateInvoice(ctx context.Context,
+	amountSat btcutil.Amount, memo string, routeHint *RouteHint,
+	expiry time.Duration, preimage *lntypes.Preimage) (*invoices.Invoice,
+	lntypes.Hash, error) {
+
+	if g == nil || g.generator == nil {
 		return nil, lntypes.Hash{}, fmt.Errorf(
-			"encode invoice: %w", err,
+			"invoice generator is required",
 		)
 	}
 
-	storedPreimage := *invoicePreimage
+	return g.generator.CreateInvoice(
+		ctx, amountSat, memo, routeHint, expiry, preimage,
+	)
+}
 
-	return &invoices.Invoice{
-		Memo:           []byte(memo),
-		PaymentRequest: []byte(paymentRequest),
-		CreationDate:   createdAt,
-		Terms: invoices.ContractTerm{
-			PaymentPreimage: &storedPreimage,
-			Value:           msat,
-			PaymentAddr:     paymentAddr,
-			Expiry:          expiry,
-			Features:        features.Clone(),
-		},
-	}, paymentHash, nil
+// CreateInvoiceWithKey creates one invoice signed by the supplied auth key.
+func (g *DirectInvoiceCreator) CreateInvoiceWithKey(ctx context.Context,
+	amountSat btcutil.Amount, memo string, routeHint *RouteHint,
+	expiry time.Duration, authKey keychain.SingleKeyMessageSigner,
+	preimage *lntypes.Preimage) (*invoices.Invoice,
+	lntypes.Hash, error) {
+
+	if g == nil || g.generator == nil {
+		return nil, lntypes.Hash{}, fmt.Errorf(
+			"invoice generator is required",
+		)
+	}
+
+	return g.generator.CreateInvoiceWithKey(
+		ctx, amountSat, memo, routeHint, expiry, authKey,
+		preimage,
+	)
 }
 
 func validateInvoiceAmount(amountSat btcutil.Amount) error {

--- a/sdk/swaps/migrations/000001_swap_sessions.up.sql
+++ b/sdk/swaps/migrations/000001_swap_sessions.up.sql
@@ -31,6 +31,10 @@ CREATE TABLE IF NOT EXISTS receive_swaps (
     -- client_pubkey is the receiver/client key used in the expected vHTLC.
     client_pubkey BLOB NOT NULL,
 
+    -- payment_addr is the invoice MPP payment address the client validates
+    -- against the forwarded final-hop onion.
+    payment_addr BLOB NOT NULL DEFAULT x'',
+
     -- operator_pubkey is the Ark operator key used in the expected vHTLC.
     operator_pubkey BLOB NOT NULL,
 
@@ -65,13 +69,25 @@ CREATE TABLE IF NOT EXISTS receive_swaps (
     -- vhtlc_amount is the observed funded vHTLC amount in satoshis.
     vhtlc_amount BIGINT NOT NULL DEFAULT 0,
 
+    -- pending_htlc_ack_cursor is the mailbox cursor that still needs to be
+    -- acknowledged after the HTLC event is durably accepted.
+    pending_htlc_ack_cursor BIGINT NOT NULL DEFAULT 0,
+
+    -- claim_receive_pubkey is the wallet-owned x-only pubkey allocated before
+    -- the invoice is returned and reused as the destination for the
+    -- receive-side claim spend.
+    claim_receive_pubkey BLOB,
+
+    -- claim_receive_pkscript is the exact wallet-owned receive script
+    -- registered for the receive-side claim destination.
+    claim_receive_pkscript BLOB,
+
     -- claim_session_id is the deterministic OOR session identifier returned
     -- by the daemon when the client submits the receive-side claim.
     claim_session_id TEXT NOT NULL DEFAULT '',
 
     -- intervention_reason is the durable terminal explanation stored when a
-    -- receive session fails or stops in NeedsIntervention. The column name is
-    -- kept narrow for compatibility with the first swap-session schema.
+    -- receive session fails or stops in NeedsIntervention.
     intervention_reason TEXT NOT NULL DEFAULT '',
 
     -- created_at_unix is when this durable receive session row was first
@@ -174,8 +190,7 @@ CREATE TABLE IF NOT EXISTS pay_swaps (
     preimage BLOB,
 
     -- intervention_reason is the durable terminal explanation stored when a
-    -- pay session fails or stops in NeedsIntervention. The column name is kept
-    -- narrow for compatibility with the first swap-session schema.
+    -- pay session fails or stops in NeedsIntervention.
     intervention_reason TEXT NOT NULL DEFAULT '',
 
     -- created_at_unix is when this durable pay session row was first created.

--- a/sdk/swaps/out_swap.go
+++ b/sdk/swaps/out_swap.go
@@ -1,6 +1,7 @@
 package swaps
 
 import (
+	"bytes"
 	"context"
 	"encoding/hex"
 	"errors"
@@ -13,7 +14,10 @@ import (
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/lib/arkscript"
 	loopfsm "github.com/lightninglabs/loop/fsm"
+	sphinx "github.com/lightningnetwork/lightning-onion"
+	"github.com/lightningnetwork/lnd/htlcswitch/hop"
 	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnwire"
 )
 
 const (
@@ -52,6 +56,16 @@ const (
 	defaultRefundLocktimeBuffer = uint32(1)
 )
 
+type outSwapOnionDecoder func(ReceiveAuthKey, lntypes.Hash,
+	[]byte) (*decodedOutSwapOnion, error)
+
+type decodedOutSwapOnion struct {
+	amountToForward lnwire.MilliSatoshi
+	totalAmount     lnwire.MilliSatoshi
+	paymentAddr     [32]byte
+	hasMPP          bool
+}
+
 // ReceiveState identifies the client-side lifecycle state of a
 // Lightning-to-Ark receive flow.
 type ReceiveState uint8
@@ -62,8 +76,13 @@ const (
 	ReceiveStateCreated ReceiveState = iota
 
 	// ReceiveStateInvoiceCreated means the route hint, invoice, preimage,
-	// and expected vHTLC script are all available to the caller.
+	// and mailbox metadata are all available to the caller.
 	ReceiveStateInvoiceCreated
+
+	// ReceiveStateHTLCEventAccepted means the server's mailbox event has
+	// been validated and durably accepted, so the client can resume funding
+	// detection without requiring mailbox redelivery.
+	ReceiveStateHTLCEventAccepted
 
 	// ReceiveStateVHTLCFunded means the swap server funded the expected
 	// vHTLC and the client has recorded the live outpoint and amount.
@@ -98,6 +117,8 @@ func (s ReceiveState) String() string {
 		return "Created"
 	case ReceiveStateInvoiceCreated:
 		return "InvoiceCreated"
+	case ReceiveStateHTLCEventAccepted:
+		return "HTLCEventAccepted"
 	case ReceiveStateVHTLCFunded:
 		return "VHTLCFunded"
 	case ReceiveStateClaimInitiated:
@@ -132,8 +153,14 @@ const (
 	receiveEventAdvance = loopfsm.EventType("OnAdvance")
 
 	// receiveEventInvoiceCreated records that the client has prepared the
-	// invoice and expected vHTLC script.
+	// invoice and mailbox metadata.
 	receiveEventInvoiceCreated = loopfsm.EventType("OnInvoiceCreated")
+
+	// receiveEventHTLCEventAccepted records that the server's mailbox event
+	// has been validated and durably accepted.
+	receiveEventHTLCEventAccepted = loopfsm.EventType(
+		"OnHTLCEventAccepted",
+	)
 
 	// receiveEventVHTLCFunded records that the expected vHTLC has been
 	// observed on Ark.
@@ -169,6 +196,12 @@ var receiveTransitions = map[ReceiveState]map[receiveEvent]ReceiveState{
 		receiveEventFailed:            ReceiveStateFailed,
 	},
 	ReceiveStateInvoiceCreated: {
+		receiveEventHTLCEventAccepted: ReceiveStateHTLCEventAccepted,
+		receiveEventExpired:           ReceiveStateExpired,
+		receiveEventNeedsIntervention: ReceiveStateNeedsIntervention,
+		receiveEventFailed:            ReceiveStateFailed,
+	},
+	ReceiveStateHTLCEventAccepted: {
 		receiveEventVHTLCFunded:       ReceiveStateVHTLCFunded,
 		receiveEventExpired:           ReceiveStateExpired,
 		receiveEventNeedsIntervention: ReceiveStateNeedsIntervention,
@@ -203,22 +236,26 @@ type ReceiveSession struct {
 	// PaymentHash is the Lightning payment hash for this receive flow.
 	PaymentHash lntypes.Hash
 
-	client              *SwapClient
-	amountSat           btcutil.Amount
-	state               ReceiveState
-	deadline            time.Time
-	createdAt           time.Time
-	updatedAt           time.Time
-	clientPubKey        *btcec.PublicKey
-	operatorPubKey      *btcec.PublicKey
-	swapServerPubKey    *btcec.PublicKey
-	vhtlcConfig         VHTLCConfig
-	vhtlcPolicy         *arkscript.VHTLCPolicy
-	vhtlcPolicyTemplate []byte
-	vhtlcPkScript       []byte
-	vhtlcOutpoint       string
-	vhtlcAmount         int64
-	claimSessionID      string
+	client               *SwapClient
+	amountSat            btcutil.Amount
+	state                ReceiveState
+	deadline             time.Time
+	createdAt            time.Time
+	updatedAt            time.Time
+	clientPubKey         *btcec.PublicKey
+	operatorPubKey       *btcec.PublicKey
+	swapServerPubKey     *btcec.PublicKey
+	vhtlcConfig          VHTLCConfig
+	vhtlcPolicy          *arkscript.VHTLCPolicy
+	vhtlcPolicyTemplate  []byte
+	vhtlcPkScript        []byte
+	vhtlcOutpoint        string
+	vhtlcAmount          int64
+	paymentAddr          [32]byte
+	pendingHTLCAckCursor uint64
+	claimReceivePubKey   []byte
+	claimReceiveScript   []byte
+	claimSessionID       string
 	// claimIntentRecordedInProcess distinguishes freshly-recorded claim
 	// intent from a restored ClaimInitiated row whose accepted spend may
 	// still be missing from the indexer.
@@ -402,6 +439,13 @@ func (s *ReceiveSession) Claim(ctx context.Context, outpoint string,
 	}
 
 	if s.state == ReceiveStateInvoiceCreated {
+		return nil, fmt.Errorf(
+			"cannot claim receive session before out-swap HTLC " +
+				"event is accepted",
+		)
+	}
+
+	if s.state == ReceiveStateHTLCEventAccepted {
 		err := s.validateReceiveFunding(ctx, outpoint, amount)
 		if err != nil {
 			return nil, err
@@ -462,6 +506,11 @@ func (s *ReceiveSession) Claim(ctx context.Context, outpoint string,
 func (s *ReceiveSession) VHTLCInfo() (*ReceiveVHTLCInfo, error) {
 	if s == nil || s.client == nil {
 		return nil, fmt.Errorf("receive session must be provided")
+	}
+	if s.vhtlcPolicy == nil || len(s.vhtlcPkScript) == 0 {
+		return nil, fmt.Errorf(
+			"out-swap HTLC event has not been accepted yet",
+		)
 	}
 
 	claimPath, err := s.vhtlcPolicy.ClaimPath(s.Preimage)
@@ -533,6 +582,26 @@ func (s *ReceiveSession) prepareInvoice(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("generate preimage: %w", err)
 	}
+	paymentHash := preimage.Hash()
+
+	authKey, err := s.client.receiveAuthKey(ctx, paymentHash)
+	if err != nil {
+		return fmt.Errorf("get receive auth key: %w", err)
+	}
+
+	claimReceiveInfo, err := s.client.daemon.AllocateReceiveScript(ctx, "")
+	if err != nil {
+		return fmt.Errorf("allocate claim receive script: %w", err)
+	}
+	if claimReceiveInfo == nil {
+		return fmt.Errorf("claim receive script is required")
+	}
+	if len(claimReceiveInfo.PubKeyXOnly) == 0 {
+		return fmt.Errorf("claim receive pubkey is required")
+	}
+	if len(claimReceiveInfo.PkScript) == 0 {
+		return fmt.Errorf("claim receive script is required")
+	}
 
 	// Receive setup is the one session edge that prepares external
 	// metadata before the first durable row exists. The server's route hint
@@ -541,8 +610,8 @@ func (s *ReceiveSession) prepareInvoice(ctx context.Context) error {
 	// database. The session is persisted before the invoice is returned to
 	// the caller.
 	expiry := time.Duration(defaultReceiveExpirySeconds) * time.Second
-	hint, vhtlcCfg, err := s.client.server.RequestChannelID(
-		ctx, clientKey, defaultReceiveExpirySeconds,
+	hint, err := s.client.server.RequestChannelID(
+		ctx, clientKey, paymentHash, defaultReceiveExpirySeconds,
 	)
 	if err != nil {
 		return fmt.Errorf("request channel ID: %w", err)
@@ -552,44 +621,14 @@ func (s *ReceiveSession) prepareInvoice(ctx context.Context) error {
 		slog.Uint64("channel_id", hint.ChannelID),
 	)
 
-	inv, hash, err := s.client.invoiceGen.CreateInvoice(
-		ctx, s.amountSat, "swap", hint, expiry, &preimage,
+	inv, hash, err := s.client.invoiceGen.CreateInvoiceWithKey(
+		ctx, s.amountSat, "swap", hint, expiry, authKey, &preimage,
 	)
 	if err != nil {
 		return fmt.Errorf("create invoice: %w", err)
 	}
-
-	serverKey, err := btcec.ParsePubKey(vhtlcCfg.SwapServerPubkey)
-	if err != nil {
-		return fmt.Errorf("parse server pubkey: %w", err)
-	}
-
-	policy, err := arkscript.NewVHTLCPolicy(arkscript.VHTLCOpts{
-		Sender:       serverKey,
-		Receiver:     clientKey,
-		Server:       operatorKey,
-		PreimageHash: hash,
-		RefundLocktime: vhtlcCfg.
-			RefundLocktime,
-		UnilateralClaimDelay: vhtlcCfg.
-			UnilateralClaimDelay,
-		UnilateralRefundDelay: vhtlcCfg.
-			UnilateralRefundDelay,
-		UnilateralRefundWithoutReceiverDelay: vhtlcCfg.
-			UnilateralRefundWithoutReceiverDelay,
-	})
-	if err != nil {
-		return fmt.Errorf("build vHTLC policy: %w", err)
-	}
-
-	pkScript, err := policy.PkScript()
-	if err != nil {
-		return fmt.Errorf("get vHTLC pkScript: %w", err)
-	}
-
-	policyTemplate, err := encodeVHTLCPolicyTemplate(policy)
-	if err != nil {
-		return fmt.Errorf("encode vHTLC policy: %w", err)
+	if hash != paymentHash {
+		return fmt.Errorf("invoice hash does not match route hash")
 	}
 
 	s.client.log.InfoS(ctx, "Invoice created for out-swap",
@@ -611,18 +650,64 @@ func (s *ReceiveSession) prepareInvoice(ctx context.Context) error {
 		}
 		s.clientPubKey = clientKey
 		s.operatorPubKey = operatorKey
-		s.swapServerPubKey = serverKey
-		s.vhtlcConfig = *vhtlcCfg
-		s.vhtlcPolicy = policy
-		s.vhtlcPolicyTemplate = policyTemplate
-		s.vhtlcPkScript = pkScript
+		s.paymentAddr = inv.Terms.PaymentAddr
+		s.claimReceivePubKey = append(
+			[]byte(nil), claimReceiveInfo.PubKeyXOnly...,
+		)
+		s.claimReceiveScript = append(
+			[]byte(nil), claimReceiveInfo.PkScript...,
+		)
 
 		return s.transition(receiveEventInvoiceCreated)
 	})
 }
 
-// waitForFunding waits until the expected vHTLC is indexed as live.
+// waitForHTLCEvent waits until the swap server delivers the HTLC event,
+// validates it, then persists the accepted event before acking the mailbox.
+func (s *ReceiveSession) waitForHTLCEvent(ctx context.Context) error {
+	if s.client.outEvents == nil {
+		return fmt.Errorf("out-swap event receiver is not configured")
+	}
+
+	authKey, err := s.client.receiveAuthKey(ctx, s.PaymentHash)
+	if err != nil {
+		return fmt.Errorf("get receive auth key: %w", err)
+	}
+
+	notification, err := s.client.outEvents.WaitOutSwapHtlc(
+		ctx, s.PaymentHash, s.clientPubKey,
+	)
+	if err != nil {
+		return fmt.Errorf("wait for out-swap HTLC event: %w", err)
+	}
+	if notification == nil {
+		return fmt.Errorf("out-swap HTLC notification must be provided")
+	}
+	if notification.Ack != nil && notification.AckCursor == 0 {
+		return fmt.Errorf("out-swap HTLC ack cursor must be provided")
+	}
+
+	if err := s.acceptOutSwapHtlcEvent(
+		ctx, notification.Event, authKey, notification.AckCursor,
+	); err != nil {
+		return err
+	}
+
+	return s.ackAcceptedHTLCEvent(ctx, notification.Ack)
+}
+
+// waitForFunding waits until the expected accepted vHTLC is indexed as live.
 func (s *ReceiveSession) waitForFunding(ctx context.Context) error {
+	if err := s.ackAcceptedHTLCEvent(ctx, nil); err != nil {
+		return err
+	}
+
+	if s.vhtlcPolicy == nil || len(s.vhtlcPkScript) == 0 {
+		return fmt.Errorf(
+			"out-swap HTLC event has not been accepted yet",
+		)
+	}
+
 	outpoint, amount, err := s.client.waitForVHTLC(
 		ctx, s.vhtlcPkScript, s.deadline,
 		s.ensureReceiveFundingStillPossible,
@@ -645,6 +730,214 @@ func (s *ReceiveSession) waitForFunding(ctx context.Context) error {
 
 		return s.transition(receiveEventVHTLCFunded)
 	})
+}
+
+// acceptOutSwapHtlcEvent validates the server's funded HTLC notification and
+// builds the vHTLC policy that the client will later claim.
+func (s *ReceiveSession) acceptOutSwapHtlcEvent(ctx context.Context,
+	event *OutSwapHtlcEvent, authKey ReceiveAuthKey,
+	ackCursor uint64) error {
+
+	if event == nil {
+		return fmt.Errorf("out-swap HTLC event must be provided")
+	}
+	if authKey == nil {
+		return fmt.Errorf("receive auth key must be provided")
+	}
+	if event.PaymentHash != s.PaymentHash {
+		return s.failTerminal(ctx,
+			"out-swap HTLC event payment hash mismatch",
+			nil, nil,
+		)
+	}
+	if event.AmountSat != int64(s.amountSat) {
+		return s.failTerminal(ctx, fmt.Sprintf(
+			"out-swap HTLC amount %d does not match "+
+				"invoice amount %d",
+			event.AmountSat, s.amountSat,
+		), nil, nil)
+	}
+	if err := s.validateOnionPayload(event, authKey); err != nil {
+		return s.failTerminal(ctx,
+			"out-swap HTLC onion validation failed", err, nil)
+	}
+
+	serverKey, err := btcec.ParsePubKey(
+		event.VHTLCConfig.SwapServerPubkey,
+	)
+	if err != nil {
+		return fmt.Errorf("parse server pubkey: %w", err)
+	}
+
+	policy, err := arkscript.NewVHTLCPolicy(arkscript.VHTLCOpts{
+		Sender:       serverKey,
+		Receiver:     s.clientPubKey,
+		Server:       s.operatorPubKey,
+		PreimageHash: s.PaymentHash,
+		RefundLocktime: event.VHTLCConfig.
+			RefundLocktime,
+		UnilateralClaimDelay: event.VHTLCConfig.
+			UnilateralClaimDelay,
+		UnilateralRefundDelay: event.VHTLCConfig.
+			UnilateralRefundDelay,
+		UnilateralRefundWithoutReceiverDelay: event.VHTLCConfig.
+			UnilateralRefundWithoutReceiverDelay,
+	})
+	if err != nil {
+		return fmt.Errorf("build vHTLC policy: %w", err)
+	}
+
+	pkScript, err := policy.PkScript()
+	if err != nil {
+		return fmt.Errorf("get vHTLC pkScript: %w", err)
+	}
+
+	policyTemplate, err := encodeVHTLCPolicyTemplate(policy)
+	if err != nil {
+		return fmt.Errorf("encode vHTLC policy: %w", err)
+	}
+
+	return s.mutateAndPersist(ctx, func() error {
+		s.swapServerPubKey = serverKey
+		s.vhtlcConfig = event.VHTLCConfig
+		s.vhtlcPolicy = policy
+		s.vhtlcPolicyTemplate = policyTemplate
+		s.vhtlcPkScript = pkScript
+		s.pendingHTLCAckCursor = ackCursor
+
+		return s.transition(receiveEventHTLCEventAccepted)
+	})
+}
+
+// ackAcceptedHTLCEvent retries any mailbox ack that is still pending after the
+// HTLC event was durably accepted.
+func (s *ReceiveSession) ackAcceptedHTLCEvent(ctx context.Context,
+	ack func(context.Context) error) error {
+
+	if s.pendingHTLCAckCursor == 0 {
+		return nil
+	}
+
+	if ack == nil {
+		if s.client.outEvents == nil {
+			return fmt.Errorf(
+				"out-swap event receiver is not configured",
+			)
+		}
+
+		ack = func(ctx context.Context) error {
+			return s.client.outEvents.AckOutSwapHtlc(
+				ctx, s.PaymentHash, s.clientPubKey,
+				s.pendingHTLCAckCursor,
+			)
+		}
+	}
+
+	if err := ack(ctx); err != nil {
+		return newRetryableActionError(fmt.Errorf(
+			"ack out-swap HTLC event: %w", err,
+		))
+	}
+
+	if err := s.clearPendingHTLCAck(ctx); err != nil {
+		return newRetryableActionError(err)
+	}
+
+	return nil
+}
+
+// clearPendingHTLCAck records that the accepted HTLC event's mailbox cursor
+// was durably acknowledged.
+func (s *ReceiveSession) clearPendingHTLCAck(ctx context.Context) error {
+	return s.mutateAndPersist(ctx, func() error {
+		s.pendingHTLCAckCursor = 0
+
+		return nil
+	})
+}
+
+// validateOnionPayload decodes the final-hop onion with the invoice auth key
+// and checks that it matches the prepared invoice fields.
+func (s *ReceiveSession) validateOnionPayload(event *OutSwapHtlcEvent,
+	authKey ReceiveAuthKey) error {
+
+	if authKey == nil {
+		return fmt.Errorf("receive auth key must be provided")
+	}
+
+	decoder := s.client.decodeOutSwapOnion
+	payload, err := decoder(
+		authKey, s.PaymentHash, event.OnionBlob,
+	)
+	if err != nil {
+		return err
+	}
+
+	expectedMsat := lnwire.NewMSatFromSatoshis(s.amountSat)
+	if payload.amountToForward != expectedMsat {
+		return fmt.Errorf(
+			"onion amount %d msat does not match "+
+				"invoice amount %d msat",
+			payload.amountToForward, expectedMsat,
+		)
+	}
+	if !payload.hasMPP {
+		return fmt.Errorf("onion missing MPP payment address")
+	}
+	if payload.paymentAddr != s.paymentAddr {
+		return fmt.Errorf("onion payment address mismatch")
+	}
+	if payload.totalAmount != expectedMsat {
+		return fmt.Errorf(
+			"onion total amount %d msat does not match "+
+				"invoice amount %d msat",
+			payload.totalAmount, expectedMsat,
+		)
+	}
+
+	return nil
+}
+
+// decodeOutSwapOnion decodes the final-hop onion with the invoice auth key.
+func decodeOutSwapOnion(receiveAuthKey ReceiveAuthKey,
+	paymentHash lntypes.Hash, onionBlob []byte) (*decodedOutSwapOnion,
+	error) {
+
+	router := sphinx.NewRouter(
+		receiveAuthKey, sphinx.NewMemoryReplayLog(),
+	)
+	processor := hop.NewOnionProcessor(router)
+	if err := processor.Start(); err != nil {
+		return nil, fmt.Errorf("start onion processor: %w", err)
+	}
+	defer func() {
+		_ = processor.Stop()
+	}()
+
+	iterator, err := processor.ReconstructHopIterator(
+		bytes.NewReader(onionBlob),
+		paymentHash[:],
+		hop.ReconstructBlindingInfo{},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("decode onion: %w", err)
+	}
+
+	payload, _, err := iterator.HopPayload()
+	if err != nil {
+		return nil, fmt.Errorf("decode hop payload: %w", err)
+	}
+
+	result := &decodedOutSwapOnion{
+		amountToForward: payload.ForwardingInfo().AmountToForward,
+	}
+	if payload.MPP != nil {
+		result.hasMPP = true
+		result.paymentAddr = payload.MPP.PaymentAddr()
+		result.totalAmount = payload.MPP.TotalMsat()
+	}
+
+	return result, nil
 }
 
 // ensureReceiveFundingStillPossible stops an invoice-created receive session
@@ -712,25 +1005,60 @@ func (s *ReceiveSession) validateReceiveFunding(ctx context.Context,
 // claimFundedVHTLC reconciles an already-spent vHTLC before sending the claim
 // transaction, then submits the preimage claim if no spend is indexed yet.
 func (s *ReceiveSession) claimFundedVHTLC(ctx context.Context) error {
-	claimed, err := s.client.receiveClaimAlreadyIndexed(
-		ctx, s.PaymentHash, s.vhtlcPkScript,
-	)
-	if err != nil {
-		return err
-	}
-	if claimed {
+	if s.claimSessionID != "" {
+		// A persisted claim session ID means the daemon accepted the
+		// custom-input claim spend before this attempt. Do not submit
+		// another claim for the same vHTLC.
 		return s.mutateAndPersist(ctx, func() error {
 			return s.transition(receiveEventCompleted)
 		})
 	}
 
-	if s.claimSessionID != "" {
-		return s.mutateAndPersist(ctx, func() error {
-			return s.transition(receiveEventCompleted)
-		})
+	if s.state == ReceiveStateClaimInitiated &&
+		!s.claimIntentRecordedInProcess {
+
+		// A restored ClaimInitiated row without in-process intent
+		// may have submitted before restart but failed to persist the
+		// returned session ID, so reconcile fully before deciding to
+		// retry.
+		claimed, err := s.client.receiveClaimAlreadyIndexed(
+			ctx, s.PaymentHash, s.vhtlcPkScript,
+		)
+		if err != nil {
+			return err
+		}
+		if claimed {
+			return s.mutateAndPersist(ctx, func() error {
+				return s.transition(receiveEventCompleted)
+			})
+		}
+	}
+
+	if s.claimIntentRecordedInProcess {
+		// A fresh in-process claim only gets a bounded spend check. A
+		// slow indexer must not consume the caller's context before the
+		// claim submission below.
+		claimed, err := s.client.receiveClaimAlreadyIndexedBounded(
+			ctx, s.PaymentHash, s.vhtlcPkScript,
+		)
+		if err != nil {
+			return err
+		}
+		if claimed {
+			return s.mutateAndPersist(ctx, func() error {
+				return s.transition(receiveEventCompleted)
+			})
+		}
 	}
 
 	if err := s.waitForClaimResumeGrace(ctx); err != nil {
+		return err
+	}
+
+	if err := s.ensureReceiveClaimStillPossible(ctx); err != nil {
+		return err
+	}
+	if err := s.ensureClaimReceiveInfo(ctx); err != nil {
 		return err
 	}
 
@@ -738,8 +1066,12 @@ func (s *ReceiveSession) claimFundedVHTLC(ctx context.Context) error {
 		ctx, s.PaymentHash, s.Preimage, s.vhtlcPolicy,
 		s.vhtlcPolicyTemplate,
 		s.vhtlcPkScript, s.vhtlcOutpoint, s.vhtlcAmount,
+		s.claimReceivePubKey,
 	)
 	if errors.Is(err, errReceiveClaimAlreadyIndexed) {
+		// Spent-without-preimage is terminal for retry purposes inside
+		// claimReceiveVHTLC; this branch only handles a matching
+		// preimage-backed spend observed during retry reconciliation.
 		return s.mutateAndPersist(ctx, func() error {
 			return s.transition(receiveEventCompleted)
 		})
@@ -763,6 +1095,71 @@ func (s *ReceiveSession) claimFundedVHTLC(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// ensureClaimReceiveInfo recovers a missing claim destination for legacy or
+// manually constructed sessions before submitting the claim spend.
+func (s *ReceiveSession) ensureClaimReceiveInfo(ctx context.Context) error {
+	if len(s.claimReceivePubKey) != 0 && len(s.claimReceiveScript) != 0 {
+		return nil
+	}
+
+	receiveInfo, err := s.client.daemon.AllocateReceiveScript(ctx, "")
+	if err != nil {
+		return fmt.Errorf("allocate claim receive script: %w", err)
+	}
+	if receiveInfo == nil {
+		return fmt.Errorf("claim receive script is required")
+	}
+	if len(receiveInfo.PubKeyXOnly) == 0 {
+		return fmt.Errorf("claim receive pubkey is required")
+	}
+	if len(receiveInfo.PkScript) == 0 {
+		return fmt.Errorf("claim receive script is required")
+	}
+
+	return s.mutateAndPersist(ctx, func() error {
+		s.claimReceivePubKey = append(
+			[]byte(nil), receiveInfo.PubKeyXOnly...,
+		)
+		s.claimReceiveScript = append(
+			[]byte(nil), receiveInfo.PkScript...,
+		)
+
+		return nil
+	})
+}
+
+// ensureReceiveClaimStillPossible stops a new claim attempt once the refund
+// path is mature enough for the swap server to recover the vHTLC.
+func (s *ReceiveSession) ensureReceiveClaimStillPossible(
+	ctx context.Context) error {
+
+	height, err := s.client.daemon.BlockHeight(ctx)
+	if err != nil {
+		return fmt.Errorf("get block height: %w", err)
+	}
+
+	if height+s.client.refundLocktimeBuffer < s.vhtlcConfig.RefundLocktime {
+		return nil
+	}
+
+	// Once the refund locktime is mature, a new receive claim becomes a
+	// late race with the server refund path and should stop durably.
+	reason := fmt.Sprintf(
+		"refund locktime %d is imminent or reached before receive "+
+			"claim at height %d",
+		s.vhtlcConfig.RefundLocktime, height,
+	)
+	if err := s.mutateAndPersist(ctx, func() error {
+		s.interventionReason = reason
+
+		return s.transition(receiveEventExpired)
+	}); err != nil {
+		return err
+	}
+
+	return fmt.Errorf("%s: %w", reason, errSwapExpired)
 }
 
 // waitForClaimResumeGrace gives an accepted-but-not-yet-indexed receive claim a
@@ -825,16 +1222,55 @@ func (c *SwapClient) receiveClaimAlreadyIndexed(ctx context.Context,
 	if err != nil {
 		return false, err
 	}
+	if !preimageMatchesHash(preimage, paymentHash) {
+		return false, errReceiveVHTLCSpentWithoutPreimage
+	}
 
-	return preimageMatchesHash(preimage, paymentHash), nil
+	return true, nil
 }
 
-// claimReceiveVHTLC claims one funded vHTLC with the session preimage into a
-// fresh wallet-owned receive script.
+// receiveClaimAlreadyIndexedBounded performs best-effort reconciliation before
+// a freshly initiated claim without letting an absent spent record consume the
+// caller's whole claim context.
+func (c *SwapClient) receiveClaimAlreadyIndexedBounded(ctx context.Context,
+	paymentHash lntypes.Hash, pkScript []byte) (bool, error) {
+
+	reconcileCtx, cancel := context.WithTimeout(ctx, c.waitPollInterval)
+	defer cancel()
+
+	claimed, err := c.receiveClaimAlreadyIndexed(
+		reconcileCtx, paymentHash, pkScript,
+	)
+	if err != nil {
+		// Swallow the bounded reconcile timeout however the
+		// transport encoded it. gRPC wraps a tripped client
+		// deadline as a status error that does not unwrap to
+		// context.DeadlineExceeded, so check the inner ctx and the
+		// gRPC status code in addition to errors.Is.
+		boundedTimedOut := reconcileCtx.Err() != nil &&
+			ctx.Err() == nil
+		if boundedTimedOut || isDeadlineExceededErr(err) {
+			c.log.DebugS(ctx,
+				"Timed out checking indexed receive claim", err,
+				btclog.Hex("hash", paymentHash[:]),
+			)
+
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	return claimed, nil
+}
+
+// claimReceiveVHTLC claims one funded vHTLC with the session preimage into the
+// wallet-owned receive pubkey prepared when the receive session was created.
 func (c *SwapClient) claimReceiveVHTLC(ctx context.Context,
 	paymentHash lntypes.Hash, preimage lntypes.Preimage,
 	policy *arkscript.VHTLCPolicy, policyTemplate []byte, pkScript []byte,
-	outpoint string, amount int64) (string, error) {
+	outpoint string, amount int64, claimReceivePubKey []byte) (
+	string, error) {
 
 	c.log.InfoS(ctx, "vHTLC found, claiming",
 		btclog.Hex("hash", paymentHash[:]),
@@ -852,18 +1288,14 @@ func (c *SwapClient) claimReceiveVHTLC(ctx context.Context,
 		return "", fmt.Errorf("encode claim path: %w", err)
 	}
 
-	receiveInfo, err := c.daemon.AllocateReceiveScript(ctx, "")
-	if err != nil {
-		return "", fmt.Errorf("get receive script: %w", err)
-	}
-	if receiveInfo == nil {
-		return "", fmt.Errorf("receive script is required")
+	if len(claimReceivePubKey) == 0 {
+		return "", fmt.Errorf("claim receive pubkey is required")
 	}
 
 	var lastSendErr error
 	for attempt := 1; attempt <= c.claimMaxAttempts; attempt++ {
 		claimSessionID, err := c.daemon.SendOORWithCustomInputs(
-			ctx, receiveInfo.PubKeyXOnly, amount, []CustomInput{{
+			ctx, claimReceivePubKey, amount, []CustomInput{{
 				Outpoint:           outpoint,
 				VTXOPolicyTemplate: policyTemplate,
 				SpendPath:          spendPath,

--- a/sdk/swaps/out_swap_fsm.go
+++ b/sdk/swaps/out_swap_fsm.go
@@ -13,6 +13,11 @@ var (
 	receiveStateInvoiceCreated = receiveStateType(
 		ReceiveStateInvoiceCreated,
 	)
+	// receiveStateHTLCEventAccepted is the Loop FSM key for
+	// HTLCEventAccepted.
+	receiveStateHTLCEventAccepted = receiveStateType(
+		ReceiveStateHTLCEventAccepted,
+	)
 	// receiveStateVHTLCFunded is the Loop FSM key for VHTLCFunded.
 	receiveStateVHTLCFunded = receiveStateType(ReceiveStateVHTLCFunded)
 	// receiveStateClaimInitiated is the Loop FSM key for ClaimInitiated.
@@ -98,6 +103,12 @@ func (m *receiveLoopFSM) states() loopfsm.States {
 				ReceiveStateInvoiceCreated,
 			),
 		},
+		receiveStateHTLCEventAccepted: {
+			Action: m.handleHTLCEventAccepted,
+			Transitions: receiveLoopTransitionsFor(
+				ReceiveStateHTLCEventAccepted,
+			),
+		},
 		receiveStateVHTLCFunded: {
 			Action: m.handleVHTLCFunded,
 			Transitions: receiveLoopTransitionsFor(
@@ -149,8 +160,21 @@ func (m *receiveLoopFSM) handleCreated(ctx context.Context,
 	return m.eventForProgress(prev)
 }
 
-// handleInvoiceCreated waits until the expected vHTLC is indexed as live.
+// handleInvoiceCreated waits until the server's HTLC mailbox event is durably
+// accepted.
 func (m *receiveLoopFSM) handleInvoiceCreated(ctx context.Context,
+	_ loopfsm.EventContext) loopfsm.EventType {
+
+	prev := m.session.state
+	if err := m.session.waitForHTLCEvent(ctx); err != nil {
+		return m.fail(ctx, err)
+	}
+
+	return m.eventForProgress(prev)
+}
+
+// handleHTLCEventAccepted waits until the accepted vHTLC is indexed as live.
+func (m *receiveLoopFSM) handleHTLCEventAccepted(ctx context.Context,
 	_ loopfsm.EventContext) loopfsm.EventType {
 
 	prev := m.session.state
@@ -246,6 +270,8 @@ func receiveLoopState(state ReceiveState) loopfsm.StateType {
 		return receiveStateCreated
 	case ReceiveStateInvoiceCreated:
 		return receiveStateInvoiceCreated
+	case ReceiveStateHTLCEventAccepted:
+		return receiveStateHTLCEventAccepted
 	case ReceiveStateVHTLCFunded:
 		return receiveStateVHTLCFunded
 	case ReceiveStateClaimInitiated:
@@ -268,6 +294,8 @@ func receiveEventForState(state ReceiveState) loopfsm.EventType {
 	switch state {
 	case ReceiveStateInvoiceCreated:
 		return receiveEventInvoiceCreated
+	case ReceiveStateHTLCEventAccepted:
+		return receiveEventHTLCEventAccepted
 	case ReceiveStateVHTLCFunded:
 		return receiveEventVHTLCFunded
 	case ReceiveStateClaimInitiated:

--- a/sdk/swaps/out_swap_mailbox.go
+++ b/sdk/swaps/out_swap_mailbox.go
@@ -1,0 +1,208 @@
+package swaps
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
+	"github.com/lightninglabs/darepo-client/serverconn"
+	"github.com/lightninglabs/darepo-client/swaprpc"
+	"github.com/lightningnetwork/lnd/lntypes"
+)
+
+const (
+	outSwapMailboxEventType    = "swap.mailbox_event"
+	outSwapMailboxEventService = "swaprpc.SwapService"
+	outSwapMailboxEventMethod  = "SwapMailboxEvent"
+)
+
+// OutSwapMailboxID derives the per-receive mailbox from the client's stable
+// identity key and the invoice payment hash. This keeps one key per client
+// while avoiding AckUpTo races between concurrent receive sessions.
+func OutSwapMailboxID(mailboxPubkey *btcec.PublicKey,
+	paymentHash lntypes.Hash) string {
+
+	return serverconn.CompoundMailboxID(
+		serverconn.PubKeyMailboxID(mailboxPubkey),
+		hex.EncodeToString(paymentHash[:]),
+	)
+}
+
+// MailboxOutSwapEventReceiver pulls out-swap HTLC events from a mailbox edge.
+type MailboxOutSwapEventReceiver struct {
+	edge             mailboxpb.MailboxServiceClient
+	mailboxID        string
+	pullWaitTimeout  time.Duration
+	pullMaxEnvelopes uint32
+}
+
+// NewMailboxOutSwapEventReceiver creates a mailbox-backed out-swap event
+// receiver. When mailboxID is empty, WaitOutSwapHtlc derives the mailbox from
+// the client identity key supplied by the caller.
+func NewMailboxOutSwapEventReceiver(edge mailboxpb.MailboxServiceClient,
+	mailboxID string) *MailboxOutSwapEventReceiver {
+
+	return &MailboxOutSwapEventReceiver{
+		edge:             edge,
+		mailboxID:        mailboxID,
+		pullWaitTimeout:  5 * time.Second,
+		pullMaxEnvelopes: 1,
+	}
+}
+
+// WaitOutSwapHtlc waits until the matching out-swap HTLC mailbox event is
+// available. The returned acknowledgement must be called only after the caller
+// has validated and persisted the event.
+func (r *MailboxOutSwapEventReceiver) WaitOutSwapHtlc(ctx context.Context,
+	paymentHash lntypes.Hash,
+	mailboxPubkey *btcec.PublicKey) (*OutSwapHtlcNotification, error) {
+
+	if r == nil || r.edge == nil {
+		return nil, fmt.Errorf("mailbox event receiver not configured")
+	}
+	if mailboxPubkey == nil {
+		return nil, fmt.Errorf("mailbox pubkey must be provided")
+	}
+
+	mailboxID := r.mailboxID
+	if mailboxID == "" {
+		mailboxID = OutSwapMailboxID(mailboxPubkey, paymentHash)
+	}
+
+	cursor := uint64(0)
+	for {
+		resp, err := r.edge.Pull(ctx, &mailboxpb.PullRequest{
+			MailboxId:     mailboxID,
+			MaxEnvelopes:  r.pullMaxEnvelopes,
+			WaitTimeoutMs: uint32(r.pullWaitTimeout.Milliseconds()),
+			Cursor:        cursor,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("pull out-swap mailbox: %w", err)
+		}
+		if resp.GetStatus() != nil && !resp.GetStatus().GetOk() {
+			return nil, fmt.Errorf("pull out-swap mailbox: %s (%s)",
+				resp.GetStatus().GetMessage(),
+				resp.GetStatus().GetCode())
+		}
+
+		if len(resp.GetEnvelopes()) == 0 {
+			cursor = resp.GetNextCursor()
+			continue
+		}
+
+		for _, env := range resp.GetEnvelopes() {
+			event, ok, err := outSwapEventFromMailboxEnvelope(env)
+			if err != nil {
+				return nil, err
+			}
+			if !ok {
+				continue
+			}
+			if event.PaymentHash != paymentHash {
+				continue
+			}
+			ackCursor := env.GetEventSeq() + 1
+
+			return &OutSwapHtlcNotification{
+				Event:     event,
+				AckCursor: ackCursor,
+				Ack: func(ctx context.Context) error {
+					return r.AckOutSwapHtlc(
+						ctx, paymentHash, mailboxPubkey,
+						ackCursor,
+					)
+				},
+			}, nil
+		}
+
+		cursor = resp.GetNextCursor()
+	}
+}
+
+// AckOutSwapHtlc advances the remote mailbox cursor after the caller has
+// durably accepted the matching notification.
+func (r *MailboxOutSwapEventReceiver) AckOutSwapHtlc(ctx context.Context,
+	paymentHash lntypes.Hash, mailboxPubkey *btcec.PublicKey,
+	cursor uint64) error {
+
+	if r == nil || r.edge == nil {
+		return fmt.Errorf("mailbox event receiver not configured")
+	}
+	if mailboxPubkey == nil {
+		return fmt.Errorf("mailbox pubkey must be provided")
+	}
+
+	mailboxID := r.mailboxID
+	if mailboxID == "" {
+		mailboxID = OutSwapMailboxID(mailboxPubkey, paymentHash)
+	}
+
+	resp, err := r.edge.AckUpTo(ctx, &mailboxpb.AckUpToRequest{
+		MailboxId: mailboxID,
+		Cursor:    cursor,
+	})
+	if err != nil {
+		return err
+	}
+	if resp.GetStatus() != nil && !resp.GetStatus().GetOk() {
+		return fmt.Errorf("ack out-swap mailbox: %s (%s)",
+			resp.GetStatus().GetMessage(),
+			resp.GetStatus().GetCode())
+	}
+
+	return nil
+}
+
+// outSwapEventFromMailboxEnvelope unwraps one mailbox event envelope when it
+// matches the out-swap HTLC event route.
+func outSwapEventFromMailboxEnvelope(
+	env *mailboxpb.Envelope) (*OutSwapHtlcEvent, bool, error) {
+
+	if env == nil || env.GetRpc() == nil {
+		return nil, false, nil
+	}
+	rpc := env.GetRpc()
+	if rpc.GetKind() != mailboxpb.RpcMeta_KIND_EVENT ||
+		rpc.GetService() != outSwapMailboxEventService ||
+		rpc.GetMethod() != outSwapMailboxEventMethod ||
+		env.GetType() != outSwapMailboxEventType {
+
+		return nil, false, nil
+	}
+
+	body := env.GetBody()
+	if body == nil {
+		return nil, false, fmt.Errorf("out-swap event missing body")
+	}
+
+	msg, err := body.UnmarshalNew()
+	if err != nil {
+		return nil, false, fmt.Errorf(
+			"unmarshal out-swap event body: %w", err,
+		)
+	}
+
+	wrapped, ok := msg.(*swaprpc.SwapMailboxEvent)
+	if !ok {
+		return nil, false, fmt.Errorf(
+			"unexpected out-swap event body type %T", msg,
+		)
+	}
+	event := wrapped.GetOutSwapHtlc()
+	if event == nil {
+		return nil, false, nil
+	}
+
+	local, err := outSwapHtlcEventFromProto(event)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return local, true, nil
+}
+
+var _ OutSwapEventReceiver = (*MailboxOutSwapEventReceiver)(nil)

--- a/sdk/swaps/out_swap_mailbox_test.go
+++ b/sdk/swaps/out_swap_mailbox_test.go
@@ -1,0 +1,112 @@
+package swaps
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
+	"github.com/lightninglabs/darepo-client/swaprpc"
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+type testOutSwapMailboxEdge struct {
+	pullResp *mailboxpb.PullResponse
+	ackReq   *mailboxpb.AckUpToRequest
+}
+
+func (t *testOutSwapMailboxEdge) Send(context.Context,
+	*mailboxpb.SendRequest, ...grpc.CallOption) (
+	*mailboxpb.SendResponse, error) {
+
+	return nil, nil
+}
+
+func (t *testOutSwapMailboxEdge) Pull(context.Context,
+	*mailboxpb.PullRequest, ...grpc.CallOption) (
+	*mailboxpb.PullResponse, error) {
+
+	return t.pullResp, nil
+}
+
+func (t *testOutSwapMailboxEdge) AckUpTo(_ context.Context,
+	req *mailboxpb.AckUpToRequest, _ ...grpc.CallOption) (
+	*mailboxpb.AckUpToResponse, error) {
+
+	t.ackReq = req
+
+	return &mailboxpb.AckUpToResponse{
+		Status: &mailboxpb.Status{Ok: true},
+	}, nil
+}
+
+// TestMailboxOutSwapEventReceiverPullsAndAcks verifies that the SDK pulls a
+// matching mailbox event and acks it only after the caller accepts it.
+func TestMailboxOutSwapEventReceiverPullsAndAcks(t *testing.T) {
+	t.Parallel()
+
+	authKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	hash := lntypes.Hash{9, 8, 7}
+	protoEvent := &swaprpc.OutSwapHtlcEvent{
+		PaymentHash: hash[:],
+		AmountSat:   42_000,
+		VhtlcConfig: &swaprpc.VHTLCConfig{
+			RefundLocktime:                       144,
+			UnilateralClaimDelay:                 12,
+			UnilateralRefundDelay:                24,
+			UnilateralRefundWithoutReceiverDelay: 36,
+			SwapserverPubkey: authKey.PubKey().
+				SerializeCompressed(),
+		},
+	}
+	body, err := anypb.New(&swaprpc.SwapMailboxEvent{
+		Event: &swaprpc.SwapMailboxEvent_OutSwapHtlc{
+			OutSwapHtlc: protoEvent,
+		},
+	})
+	require.NoError(t, err)
+
+	edge := &testOutSwapMailboxEdge{
+		pullResp: &mailboxpb.PullResponse{
+			Status:     &mailboxpb.Status{Ok: true},
+			NextCursor: 8,
+			Envelopes: []*mailboxpb.Envelope{{
+				Type:     outSwapMailboxEventType,
+				Body:     body,
+				EventSeq: 7,
+				Rpc: &mailboxpb.RpcMeta{
+					Kind: mailboxpb.
+						RpcMeta_KIND_EVENT,
+					Service: outSwapMailboxEventService,
+					Method:  outSwapMailboxEventMethod,
+				},
+			}},
+		},
+	}
+	receiver := NewMailboxOutSwapEventReceiver(edge, "")
+	receiver.pullWaitTimeout = time.Millisecond
+
+	notification, err := receiver.WaitOutSwapHtlc(
+		t.Context(), hash, authKey.PubKey(),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, notification)
+	require.Equal(t, hash, notification.Event.PaymentHash)
+	require.EqualValues(t, 42_000, notification.Event.AmountSat)
+	require.Equal(t, uint64(8), notification.AckCursor)
+	require.Nil(t, edge.ackReq)
+
+	require.NoError(t, notification.Ack(t.Context()))
+	require.NotNil(t, edge.ackReq)
+	require.Equal(
+		t, OutSwapMailboxID(authKey.PubKey(), hash),
+		edge.ackReq.GetMailboxId(),
+	)
+	require.Equal(t, uint64(8), edge.ackReq.GetCursor())
+}

--- a/sdk/swaps/out_swap_test.go
+++ b/sdk/swaps/out_swap_test.go
@@ -5,22 +5,30 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/lightninglabs/darepo-client/lib/arkscript"
 	"github.com/lightningnetwork/lnd/invoices"
+	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type testInvoiceCreator struct {
 	invoice     *invoices.Invoice
 	paymentHash lntypes.Hash
+	lastAuthKey keychain.SingleKeyMessageSigner
+	authKeys    []keychain.SingleKeyMessageSigner
 }
 
 // CreateInvoice returns the preconfigured invoice and payment hash.
@@ -35,6 +43,18 @@ func (c *testInvoiceCreator) CreateInvoice(_ context.Context,
 	}
 
 	return c.invoice, c.paymentHash, nil
+}
+
+// CreateInvoiceWithKey returns the preconfigured invoice and payment hash.
+func (c *testInvoiceCreator) CreateInvoiceWithKey(ctx context.Context,
+	amount btcutil.Amount, memo string, hint *RouteHint,
+	expiry time.Duration, authKey keychain.SingleKeyMessageSigner,
+	preimage *lntypes.Preimage) (*invoices.Invoice, lntypes.Hash, error) {
+
+	c.lastAuthKey = authKey
+	c.authKeys = append(c.authKeys, authKey)
+
+	return c.CreateInvoice(ctx, amount, memo, hint, expiry, preimage)
 }
 
 // TestStartReceiveRejectsInvalidAmount verifies invalid amounts are rejected
@@ -56,16 +76,130 @@ func TestStartReceiveRejectsInvalidAmount(t *testing.T) {
 	require.ErrorContains(t, err, "exceeds max bitcoin supply")
 }
 
+// TestStartReceiveDerivesReceiveAuthKeyPerPaymentHash verifies new receive
+// sessions use payment-scoped auth keys.
+func TestStartReceiveDerivesReceiveAuthKeyPerPaymentHash(t *testing.T) {
+	t.Parallel()
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	serverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	creator := &testInvoiceCreator{
+		invoice: &invoices.Invoice{
+			PaymentRequest: []byte("lnrtest1swap"),
+		},
+	}
+	serverPubKey := serverPriv.PubKey().SerializeCompressed()
+	serverConn := &testSwapServerConn{
+		hint: &RouteHint{
+			NodeID:          serverPubKey,
+			ChannelID:       99,
+			FeeBaseMsat:     1,
+			FeePropPpm:      2,
+			CltvExpiryDelta: 40,
+		},
+	}
+	daemonConn := &testDaemonConn{
+		identityKey: clientPriv.PubKey(),
+		operatorKey: operatorPriv.PubKey(),
+	}
+
+	client := NewSwapClient(serverConn, daemonConn, nil, creator)
+	for i := 0; i < 2; i++ {
+		_, err := client.StartReceiveViaLightning(
+			t.Context(), btcutil.Amount(42_000),
+		)
+		require.NoError(t, err)
+	}
+
+	require.NotNil(t, serverConn.lastVhtlcPubkey)
+	require.True(t, serverConn.lastVhtlcPubkey.IsEqual(clientPriv.PubKey()))
+	require.Len(t, creator.authKeys, 2)
+	require.NotSame(t, creator.authKeys[0], creator.authKeys[1])
+	require.False(t, creator.authKeys[0].PubKey().IsEqual(
+		creator.authKeys[1].PubKey(),
+	))
+}
+
 type testSwapServerConn struct {
-	hint *RouteHint
-	cfg  *VHTLCConfig
+	hint          *RouteHint
+	cfg           *VHTLCConfig
+	htlcAmountSat uint64
+	waitErr       error
+	ackErr        error
+	ackErrs       []error
+	ackCursor     uint64
+	waitCalls     int
+	ackCalls      int
+	lastAckCursor uint64
+
+	lastVhtlcPubkey *btcec.PublicKey
 }
 
 // RequestChannelID returns the preconfigured out-swap route hint.
-func (c *testSwapServerConn) RequestChannelID(context.Context,
-	*btcec.PublicKey, uint32) (*RouteHint, *VHTLCConfig, error) {
+func (c *testSwapServerConn) RequestChannelID(_ context.Context,
+	vhtlcPubkey *btcec.PublicKey, _ lntypes.Hash,
+	_ uint32) (*RouteHint, error) {
 
-	return c.hint, c.cfg, nil
+	c.lastVhtlcPubkey = vhtlcPubkey
+
+	return c.hint, nil
+}
+
+// WaitOutSwapHtlc returns the preconfigured out-swap HTLC event.
+func (c *testSwapServerConn) WaitOutSwapHtlc(_ context.Context,
+	hash lntypes.Hash,
+	_ *btcec.PublicKey) (*OutSwapHtlcNotification, error) {
+
+	c.waitCalls++
+	if c.waitErr != nil {
+		return nil, c.waitErr
+	}
+
+	amountSat := c.htlcAmountSat
+	if amountSat == 0 {
+		amountSat = 42_000
+	}
+	ackCursor := c.ackCursor
+	if ackCursor == 0 {
+		ackCursor = 8
+	}
+
+	return &OutSwapHtlcNotification{
+		Event: &OutSwapHtlcEvent{
+			PaymentHash: hash,
+			AmountSat:   int64(amountSat),
+			VHTLCConfig: *c.cfg,
+		},
+		AckCursor: ackCursor,
+		Ack: func(ctx context.Context) error {
+			return c.AckOutSwapHtlc(
+				ctx, hash, nil, ackCursor,
+			)
+		},
+	}, nil
+}
+
+// AckOutSwapHtlc records the preconfigured out-swap HTLC ack request.
+func (c *testSwapServerConn) AckOutSwapHtlc(_ context.Context,
+	_ lntypes.Hash, _ *btcec.PublicKey, cursor uint64) error {
+
+	c.ackCalls++
+	c.lastAckCursor = cursor
+	if len(c.ackErrs) > 0 {
+		err := c.ackErrs[0]
+		c.ackErrs = c.ackErrs[1:]
+
+		return err
+	}
+
+	return c.ackErr
 }
 
 // CreateInSwap is unused in these tests.
@@ -80,28 +214,76 @@ func (c *testSwapServerConn) Close() error {
 	return nil
 }
 
+// useTestOnionDecoder installs a deterministic final-hop onion decoder for
+// unit tests that exercise receive lifecycle behavior with a fake server.
+func useTestOnionDecoder(client *SwapClient, amount btcutil.Amount) {
+	client.decodeOutSwapOnion = func(ReceiveAuthKey, lntypes.Hash,
+		[]byte) (*decodedOutSwapOnion, error) {
+
+		msat := lnwire.NewMSatFromSatoshis(amount)
+
+		return &decodedOutSwapOnion{
+			amountToForward: msat,
+			totalAmount:     msat,
+			hasMPP:          true,
+		}, nil
+	}
+}
+
+// acceptTestOutSwapHtlcEvent moves a receive session through the durable
+// mailbox-event boundary without waiting for the test server receiver.
+func acceptTestOutSwapHtlcEvent(t *testing.T, client *SwapClient,
+	session *ReceiveSession, cfg VHTLCConfig) {
+
+	t.Helper()
+
+	authKey, err := client.receiveAuthKey(
+		t.Context(), session.PaymentHash,
+	)
+	require.NoError(t, err)
+
+	err = session.acceptOutSwapHtlcEvent(
+		t.Context(),
+		&OutSwapHtlcEvent{
+			PaymentHash: session.PaymentHash,
+			AmountSat:   int64(session.amountSat),
+			VHTLCConfig: cfg,
+		},
+		authKey,
+		0,
+	)
+	require.NoError(t, err)
+	require.Equal(t, ReceiveStateHTLCEventAccepted, session.State())
+}
+
 type testDaemonConn struct {
-	identityKey     *btcec.PublicKey
-	operatorKey     *btcec.PublicKey
-	blockHeight     uint32
-	liveVTXOs       []VTXOInfo
-	spentVTXOs      []VTXOInfo
-	vhtlc           *VTXOInfo
-	liveByPkScript  map[string]*VTXOInfo
-	spentVTXO       *VTXOInfo
-	indexedPackage  *OORPackageInfo
-	indexedPackages []*OORPackageInfo
-	receiveInfo     *ReceiveInfo
-	sendSessionID   string
-	sendPolicyErr   error
-	sendCustomErr   error
-	listSpentErr    error
-	spendOnCustom   bool
-	sendPolicyCalls int
-	sendCustomCalls int
-	lastSendPolicy  []byte
-	lastClaimPubKey []byte
-	lastClaimInput  []CustomInput
+	identityKey       *btcec.PublicKey
+	operatorKey       *btcec.PublicKey
+	blockHeight       uint32
+	liveVTXOs         []VTXOInfo
+	spentVTXOs        []VTXOInfo
+	vhtlc             *VTXOInfo
+	liveByPkScript    map[string]*VTXOInfo
+	spentVTXO         *VTXOInfo
+	indexedPackage    *OORPackageInfo
+	indexedPackages   []*OORPackageInfo
+	receiveInfo       *ReceiveInfo
+	receiveAuthKey    []byte
+	receiveAuthErr    error
+	receiveAllocCalls int
+	sendSessionID     string
+	sendPolicyErr     error
+	sendCustomErr     error
+	listSpentErr      error
+	spentLookupErr    error
+	spentLookupBlock  time.Duration
+	spendOnCustom     bool
+	sendPolicyCalls   int
+	sendCustomCalls   int
+	spentLookupCalls  int
+	lastSendPolicy    []byte
+	lastClaimPubKey   []byte
+	lastClaimInput    []CustomInput
 }
 
 // BlockHeight returns the configured best block height.
@@ -177,6 +359,95 @@ func (d *testDaemonConn) OperatorPubKey(context.Context) (
 	return d.operatorKey, nil
 }
 
+// receiveAuthPrivKey derives the configured deterministic receive-auth key.
+func (d *testDaemonConn) receiveAuthPrivKey(
+	paymentHash lntypes.Hash) (*btcec.PrivateKey, error) {
+
+	if d.receiveAuthErr != nil {
+		return nil, d.receiveAuthErr
+	}
+
+	if len(d.receiveAuthKey) == 0 {
+		key := sha256.Sum256(append(
+			[]byte("test receive auth key"), paymentHash[:]...,
+		))
+
+		privKey, _ := btcec.PrivKeyFromBytes(key[:])
+
+		return privKey, nil
+	}
+
+	privKey, _ := btcec.PrivKeyFromBytes(d.receiveAuthKey)
+
+	return privKey, nil
+}
+
+// ReceiveAuthKey returns the configured deterministic receive-auth pubkey.
+func (d *testDaemonConn) ReceiveAuthKey(_ context.Context,
+	paymentHash lntypes.Hash) (*btcec.PublicKey, error) {
+
+	privKey, err := d.receiveAuthPrivKey(paymentHash)
+	if err != nil {
+		return nil, err
+	}
+
+	return privKey.PubKey(), nil
+}
+
+// SignReceiveAuthMessage signs a message with the deterministic receive-auth
+// key.
+func (d *testDaemonConn) SignReceiveAuthMessage(_ context.Context,
+	paymentHash lntypes.Hash, message []byte,
+	doubleHash bool) (*ecdsa.Signature, error) {
+
+	privKey, err := d.receiveAuthPrivKey(paymentHash)
+	if err != nil {
+		return nil, err
+	}
+
+	return keychain.NewPrivKeyMessageSigner(
+		privKey, keychain.KeyLocator{},
+	).SignMessage(message, doubleHash)
+}
+
+// SignReceiveAuthMessageCompact signs a message with the deterministic
+// receive-auth key and returns the compact signature.
+func (d *testDaemonConn) SignReceiveAuthMessageCompact(_ context.Context,
+	paymentHash lntypes.Hash, message []byte,
+	doubleHash bool) ([]byte, error) {
+
+	privKey, err := d.receiveAuthPrivKey(paymentHash)
+	if err != nil {
+		return nil, err
+	}
+
+	return keychain.NewPrivKeyMessageSigner(
+		privKey, keychain.KeyLocator{},
+	).SignMessageCompact(message, doubleHash)
+}
+
+// ReceiveAuthECDH derives one Sphinx shared secret with the deterministic
+// receive-auth key.
+func (d *testDaemonConn) ReceiveAuthECDH(_ context.Context,
+	paymentHash lntypes.Hash, pubKey *btcec.PublicKey) ([32]byte, error) {
+
+	privKey, err := d.receiveAuthPrivKey(paymentHash)
+	if err != nil {
+		return [32]byte{}, err
+	}
+
+	var pubJ btcec.JacobianPoint
+	pubKey.AsJacobian(&pubJ)
+
+	var ecdhPoint btcec.JacobianPoint
+	btcec.ScalarMultNonConst(&privKey.Key, &pubJ, &ecdhPoint)
+
+	ecdhPoint.ToAffine()
+	ecdhPubKey := btcec.NewPublicKey(&ecdhPoint.X, &ecdhPoint.Y)
+
+	return sha256.Sum256(ecdhPubKey.SerializeCompressed()), nil
+}
+
 // ListLiveVTXOs is unused in these tests.
 func (d *testDaemonConn) ListLiveVTXOs(context.Context) ([]VTXOInfo, error) {
 	return append([]VTXOInfo(nil), d.liveVTXOs...), nil
@@ -201,11 +472,26 @@ func (d *testDaemonConn) FindLiveVTXOByPkScript(_ context.Context,
 	return d.vhtlc, nil
 }
 
-// FindSpentVTXOByPkScript is unused in these tests.
-func (d *testDaemonConn) FindSpentVTXOByPkScript(context.Context,
-	[]byte) (*VTXOInfo, error) {
+// FindSpentVTXOByPkScript returns the configured spent vHTLC. When
+// spentLookupBlock is set, the call waits for the caller's context to expire
+// before returning the configured error so test cases can exercise the bounded
+// reconcile timeout.
+func (d *testDaemonConn) FindSpentVTXOByPkScript(ctx context.Context,
+	_ []byte) (*VTXOInfo, error) {
 
-	return d.spentVTXO, nil
+	d.spentLookupCalls++
+
+	if d.spentLookupBlock > 0 {
+		timer := time.NewTimer(d.spentLookupBlock)
+		defer timer.Stop()
+
+		select {
+		case <-ctx.Done():
+		case <-timer.C:
+		}
+	}
+
+	return d.spentVTXO, d.spentLookupErr
 }
 
 // GetIndexedOORSession returns the preconfigured indexed package.
@@ -226,8 +512,21 @@ func (d *testDaemonConn) GetIndexedOORSession(context.Context,
 func (d *testDaemonConn) AllocateReceiveScript(context.Context,
 	string) (*ReceiveInfo, error) {
 
+	d.receiveAllocCalls++
 	if d.receiveInfo == nil {
-		return nil, nil
+		if d.identityKey == nil {
+			return nil, nil
+		}
+
+		pkScript, err := txscript.PayToTaprootScript(d.identityKey)
+		if err != nil {
+			return nil, err
+		}
+
+		return &ReceiveInfo{
+			PkScript:    pkScript,
+			PubKeyXOnly: d.identityKey.X().Bytes(),
+		}, nil
 	}
 
 	return &ReceiveInfo{
@@ -257,6 +556,8 @@ func TestReceiveSessionWaitClaimsVHTLC(t *testing.T) {
 		paymentHash: lntypes.Hash{},
 	}
 	serverPubKey := serverPriv.PubKey().SerializeCompressed()
+	authPrivKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
 
 	serverConn := &testSwapServerConn{
 		hint: &RouteHint{
@@ -278,7 +579,11 @@ func TestReceiveSessionWaitClaimsVHTLC(t *testing.T) {
 	daemonConn := &testDaemonConn{
 		identityKey: clientPriv.PubKey(),
 		operatorKey: operatorPriv.PubKey(),
-		vhtlc:       &VTXOInfo{Outpoint: "txid:0", AmountSat: 42_000},
+		vhtlc: &VTXOInfo{
+			Outpoint:  "txid:0",
+			AmountSat: 42_000,
+		},
+		receiveAuthKey: authPrivKey.Serialize(),
 		receiveInfo: &ReceiveInfo{
 			PkScript:    []byte{0x51},
 			PubKeyXOnly: clientPriv.PubKey().X().Bytes(),
@@ -287,6 +592,7 @@ func TestReceiveSessionWaitClaimsVHTLC(t *testing.T) {
 	}
 
 	client := NewSwapClient(serverConn, daemonConn, nil, creator)
+	useTestOnionDecoder(client, 42_000)
 	client.waitPollInterval = time.Millisecond
 	client.waitVHTLCTimeout = 50 * time.Millisecond
 
@@ -299,6 +605,11 @@ func TestReceiveSessionWaitClaimsVHTLC(t *testing.T) {
 		t, lntypes.Hash(sha256.Sum256(session.Preimage[:])),
 		session.PaymentHash,
 	)
+	require.True(t, creator.lastAuthKey.PubKey().IsEqual(
+		authPrivKey.PubKey(),
+	))
+	require.NotNil(t, serverConn.lastVhtlcPubkey)
+	require.True(t, serverConn.lastVhtlcPubkey.IsEqual(clientPriv.PubKey()))
 
 	result, err := session.Wait(t.Context())
 	require.NoError(t, err)
@@ -311,6 +622,140 @@ func TestReceiveSessionWaitClaimsVHTLC(t *testing.T) {
 	require.NotEmpty(t, daemonConn.lastClaimInput[0].SpendPath)
 	require.Equal(t, daemonConn.receiveInfo.PubKeyXOnly,
 		daemonConn.lastClaimPubKey)
+}
+
+// TestReceiveSessionVHTLCInfoWaitsForAcceptedEvent asserts callers get a
+// clear error instead of a nil-policy panic before the mailbox event arrives.
+func TestReceiveSessionVHTLCInfoWaitsForAcceptedEvent(t *testing.T) {
+	t.Parallel()
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	serverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	creator := &testInvoiceCreator{
+		invoice: &invoices.Invoice{
+			PaymentRequest: []byte("lnrtest1swap"),
+		},
+	}
+	serverPubKey := serverPriv.PubKey().SerializeCompressed()
+	cfg := VHTLCConfig{
+		RefundLocktime:                       144,
+		UnilateralClaimDelay:                 12,
+		UnilateralRefundDelay:                24,
+		UnilateralRefundWithoutReceiverDelay: 36,
+		SwapServerPubkey:                     serverPubKey,
+	}
+	serverConn := &testSwapServerConn{
+		hint: &RouteHint{
+			NodeID:          serverPubKey,
+			ChannelID:       99,
+			FeeBaseMsat:     1,
+			FeePropPpm:      2,
+			CltvExpiryDelta: 40,
+		},
+		cfg: &cfg,
+	}
+	daemonConn := &testDaemonConn{
+		identityKey: clientPriv.PubKey(),
+		operatorKey: operatorPriv.PubKey(),
+	}
+
+	client := NewSwapClient(serverConn, daemonConn, nil, creator)
+	useTestOnionDecoder(client, 42_000)
+
+	session, err := client.StartReceiveViaLightning(
+		t.Context(), btcutil.Amount(42_000),
+	)
+	require.NoError(t, err)
+
+	_, err = session.VHTLCInfo()
+	require.ErrorContains(
+		t, err, "out-swap HTLC event has not been accepted yet",
+	)
+
+	acceptTestOutSwapHtlcEvent(t, client, session, cfg)
+
+	info, err := session.VHTLCInfo()
+	require.NoError(t, err)
+	require.NotEmpty(t, info.PkScript)
+	require.NotEmpty(t, info.ClaimScript)
+}
+
+// TestReceiveSessionRejectsInvalidOnion asserts the SDK refuses to claim a
+// mailbox-notified vHTLC when final-hop onion validation fails.
+func TestReceiveSessionRejectsInvalidOnion(t *testing.T) {
+	t.Parallel()
+
+	store := newTestSwapStore(t)
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	serverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	creator := &testInvoiceCreator{
+		invoice: &invoices.Invoice{
+			PaymentRequest: []byte("lnrtest1swap"),
+		},
+	}
+	serverPubKey := serverPriv.PubKey().SerializeCompressed()
+	serverConn := &testSwapServerConn{
+		hint: &RouteHint{
+			NodeID:          serverPubKey,
+			ChannelID:       99,
+			FeeBaseMsat:     1,
+			FeePropPpm:      2,
+			CltvExpiryDelta: 40,
+		},
+		cfg: &VHTLCConfig{
+			RefundLocktime:                       144,
+			UnilateralClaimDelay:                 12,
+			UnilateralRefundDelay:                24,
+			UnilateralRefundWithoutReceiverDelay: 36,
+			SwapServerPubkey:                     serverPubKey,
+		},
+	}
+
+	daemonConn := &testDaemonConn{
+		identityKey: clientPriv.PubKey(),
+		operatorKey: operatorPriv.PubKey(),
+		vhtlc:       &VTXOInfo{Outpoint: "txid:0", AmountSat: 42_000},
+	}
+
+	client := NewSwapClientWithStore(
+		serverConn, daemonConn, nil, creator, store,
+	)
+	client.decodeOutSwapOnion = func(ReceiveAuthKey, lntypes.Hash,
+		[]byte) (*decodedOutSwapOnion, error) {
+
+		return nil, errors.New("bad onion")
+	}
+
+	session, err := client.StartReceiveViaLightning(
+		t.Context(), btcutil.Amount(42_000),
+	)
+	require.NoError(t, err)
+
+	_, err = session.Wait(t.Context())
+	require.ErrorContains(t, err, "out-swap HTLC onion validation failed")
+	require.Equal(t, ReceiveStateFailed, session.State())
+	require.Zero(t, daemonConn.sendCustomCalls)
+
+	resumed, err := client.ResumeReceiveViaLightning(
+		t.Context(), session.PaymentHash,
+	)
+	require.NoError(t, err)
+	require.Equal(t, ReceiveStateFailed, resumed.State())
 }
 
 // TestReceiveSessionResumeFromStore asserts the SDK can reload a persisted
@@ -366,12 +811,14 @@ func TestReceiveSessionResumeFromStore(t *testing.T) {
 	client := NewSwapClientWithStore(
 		serverConn, daemonConn, nil, creator, store,
 	)
+	useTestOnionDecoder(client, 42_000)
 	client.waitPollInterval = time.Millisecond
 
 	session, err := client.StartReceiveViaLightning(
 		t.Context(), btcutil.Amount(42_000),
 	)
 	require.NoError(t, err)
+	require.Equal(t, 1, daemonConn.receiveAllocCalls)
 
 	daemonConn.vhtlc = &VTXOInfo{
 		Outpoint:  "resume-txid:1",
@@ -381,6 +828,7 @@ func TestReceiveSessionResumeFromStore(t *testing.T) {
 	resumedClient := NewSwapClientWithStore(
 		serverConn, daemonConn, nil, creator, store,
 	)
+	useTestOnionDecoder(resumedClient, 42_000)
 	resumedClient.waitPollInterval = time.Millisecond
 
 	resumed, err := resumedClient.ResumeReceiveViaLightning(
@@ -394,6 +842,9 @@ func TestReceiveSessionResumeFromStore(t *testing.T) {
 	require.Equal(t, "resume-txid:1", result.VTXOOutpoint)
 	require.EqualValues(t, 42_000, result.AmountSat)
 	require.Len(t, daemonConn.lastClaimInput, 1)
+	require.Equal(t, daemonConn.receiveInfo.PubKeyXOnly,
+		daemonConn.lastClaimPubKey)
+	require.Equal(t, 1, daemonConn.receiveAllocCalls)
 }
 
 // TestReceiveSessionCancelDoesNotPersistFailed asserts caller cancellation
@@ -444,6 +895,7 @@ func TestReceiveSessionCancelDoesNotPersistFailed(t *testing.T) {
 	client := NewSwapClientWithStore(
 		serverConn, daemonConn, nil, creator, store,
 	)
+	useTestOnionDecoder(client, 42_000)
 	client.waitPollInterval = time.Millisecond
 
 	session, err := client.StartReceiveViaLightning(
@@ -452,7 +904,7 @@ func TestReceiveSessionCancelDoesNotPersistFailed(t *testing.T) {
 	require.NoError(t, err)
 
 	waitCtx, cancel := context.WithTimeout(
-		t.Context(), 5*time.Millisecond,
+		t.Context(), 100*time.Millisecond,
 	)
 	defer cancel()
 
@@ -462,11 +914,207 @@ func TestReceiveSessionCancelDoesNotPersistFailed(t *testing.T) {
 	resumedClient := NewSwapClientWithStore(
 		serverConn, daemonConn, nil, creator, store,
 	)
+	useTestOnionDecoder(resumedClient, 42_000)
 	resumed, err := resumedClient.ResumeReceiveViaLightning(
 		t.Context(), session.PaymentHash,
 	)
 	require.NoError(t, err)
-	require.Equal(t, ReceiveStateInvoiceCreated, resumed.State())
+	require.Equal(t, ReceiveStateHTLCEventAccepted, resumed.State())
+}
+
+// TestReceiveSessionResumesAfterAckedHTLCEvent asserts a receive can recover
+// when it crashes after acking the mailbox event but before funding is indexed.
+func TestReceiveSessionResumesAfterAckedHTLCEvent(t *testing.T) {
+	t.Parallel()
+
+	store := newTestSwapStore(t)
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	serverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	creator := &testInvoiceCreator{
+		invoice: &invoices.Invoice{
+			PaymentRequest: []byte("lnrtest1swap"),
+		},
+	}
+	serverPubKey := serverPriv.PubKey().SerializeCompressed()
+	cfg := &VHTLCConfig{
+		RefundLocktime:                       144,
+		UnilateralClaimDelay:                 12,
+		UnilateralRefundDelay:                24,
+		UnilateralRefundWithoutReceiverDelay: 36,
+		SwapServerPubkey:                     serverPubKey,
+	}
+	serverConn := &testSwapServerConn{
+		hint: &RouteHint{
+			NodeID:          serverPubKey,
+			ChannelID:       99,
+			FeeBaseMsat:     1,
+			FeePropPpm:      2,
+			CltvExpiryDelta: 40,
+		},
+		cfg: cfg,
+	}
+
+	daemonConn := &testDaemonConn{
+		identityKey: clientPriv.PubKey(),
+		operatorKey: operatorPriv.PubKey(),
+		blockHeight: 100,
+	}
+
+	client := NewSwapClientWithStore(
+		serverConn, daemonConn, nil, creator, store,
+	)
+	useTestOnionDecoder(client, 42_000)
+	client.waitPollInterval = time.Millisecond
+
+	session, err := client.StartReceiveViaLightning(
+		t.Context(), btcutil.Amount(42_000),
+	)
+	require.NoError(t, err)
+
+	err = session.waitForHTLCEvent(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, ReceiveStateHTLCEventAccepted, session.State())
+	require.Equal(t, 1, serverConn.waitCalls)
+	require.Equal(t, 1, serverConn.ackCalls)
+	require.Equal(t, uint64(8), serverConn.lastAckCursor)
+	require.Zero(t, session.pendingHTLCAckCursor)
+
+	resumeServer := &testSwapServerConn{
+		waitErr: errors.New("unexpected mailbox wait"),
+	}
+	resumedClient := NewSwapClientWithStore(
+		resumeServer, daemonConn, nil, creator, store,
+	)
+	resumedClient.waitPollInterval = time.Millisecond
+
+	resumed, err := resumedClient.ResumeReceiveViaLightning(
+		t.Context(), session.PaymentHash,
+	)
+	require.NoError(t, err)
+	require.Equal(t, ReceiveStateHTLCEventAccepted, resumed.State())
+
+	daemonConn.vhtlc = &VTXOInfo{
+		Outpoint:  "resume-txid:1",
+		AmountSat: 42_000,
+	}
+
+	outpoint, amount, err := resumed.WaitForFunding(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "resume-txid:1", outpoint)
+	require.EqualValues(t, 42_000, amount)
+	require.Zero(t, resumeServer.waitCalls)
+}
+
+// TestReceiveSessionRetriesAcceptedHTLCAckOnResume asserts mailbox ack errors
+// after event acceptance are retried from the durable accepted-event state.
+func TestReceiveSessionRetriesAcceptedHTLCAckOnResume(t *testing.T) {
+	t.Parallel()
+
+	store := newTestSwapStore(t)
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	serverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	creator := &testInvoiceCreator{
+		invoice: &invoices.Invoice{
+			PaymentRequest: []byte("lnrtest1swap"),
+		},
+	}
+	serverPubKey := serverPriv.PubKey().SerializeCompressed()
+	cfg := &VHTLCConfig{
+		RefundLocktime:                       144,
+		UnilateralClaimDelay:                 12,
+		UnilateralRefundDelay:                24,
+		UnilateralRefundWithoutReceiverDelay: 36,
+		SwapServerPubkey:                     serverPubKey,
+	}
+	ackErr := errors.New("temporary ack failure")
+	serverConn := &testSwapServerConn{
+		hint: &RouteHint{
+			NodeID:          serverPubKey,
+			ChannelID:       99,
+			FeeBaseMsat:     1,
+			FeePropPpm:      2,
+			CltvExpiryDelta: 40,
+		},
+		cfg:       cfg,
+		ackErrs:   []error{ackErr},
+		ackCursor: 12,
+	}
+
+	daemonConn := &testDaemonConn{
+		identityKey: clientPriv.PubKey(),
+		operatorKey: operatorPriv.PubKey(),
+		blockHeight: 100,
+	}
+
+	client := NewSwapClientWithStore(
+		serverConn, daemonConn, nil, creator, store,
+	)
+	useTestOnionDecoder(client, 42_000)
+	client.waitPollInterval = time.Millisecond
+
+	session, err := client.StartReceiveViaLightning(
+		t.Context(), btcutil.Amount(42_000),
+	)
+	require.NoError(t, err)
+
+	err = session.waitForHTLCEvent(t.Context())
+	require.ErrorIs(t, err, ackErr)
+	require.Equal(t, ReceiveStateHTLCEventAccepted, session.State())
+	require.EqualValues(t, 12, session.pendingHTLCAckCursor)
+	require.Equal(t, 1, serverConn.waitCalls)
+	require.Equal(t, 1, serverConn.ackCalls)
+	require.Equal(t, uint64(12), serverConn.lastAckCursor)
+
+	resumeServer := &testSwapServerConn{
+		waitErr: errors.New("unexpected mailbox wait"),
+	}
+	resumedClient := NewSwapClientWithStore(
+		resumeServer, daemonConn, nil, creator, store,
+	)
+	resumedClient.waitPollInterval = time.Millisecond
+
+	resumed, err := resumedClient.ResumeReceiveViaLightning(
+		t.Context(), session.PaymentHash,
+	)
+	require.NoError(t, err)
+	require.Equal(t, ReceiveStateHTLCEventAccepted, resumed.State())
+	require.EqualValues(t, 12, resumed.pendingHTLCAckCursor)
+
+	daemonConn.vhtlc = &VTXOInfo{
+		Outpoint:  "resume-txid:1",
+		AmountSat: 42_000,
+	}
+
+	outpoint, amount, err := resumed.WaitForFunding(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "resume-txid:1", outpoint)
+	require.EqualValues(t, 42_000, amount)
+	require.Zero(t, resumeServer.waitCalls)
+	require.Equal(t, 1, resumeServer.ackCalls)
+	require.Equal(t, uint64(12), resumeServer.lastAckCursor)
+	require.Zero(t, resumed.pendingHTLCAckCursor)
+
+	reloaded, err := resumedClient.ResumeReceiveViaLightning(
+		t.Context(), session.PaymentHash,
+	)
+	require.NoError(t, err)
+	require.Zero(t, reloaded.pendingHTLCAckCursor)
 }
 
 // TestReceiveSessionExpiresAtRefundLocktimeWithoutFunding asserts a resumed
@@ -518,6 +1166,7 @@ func TestReceiveSessionExpiresAtRefundLocktimeWithoutFunding(t *testing.T) {
 	client := NewSwapClientWithStore(
 		serverConn, daemonConn, nil, creator, store,
 	)
+	useTestOnionDecoder(client, 42_000)
 	client.waitPollInterval = time.Millisecond
 
 	session, err := client.StartReceiveViaLightning(
@@ -603,6 +1252,7 @@ func TestReceiveSessionFailsOnAmountMismatch(t *testing.T) {
 	client := NewSwapClientWithStore(
 		serverConn, daemonConn, nil, creator, store,
 	)
+	useTestOnionDecoder(client, 42_000)
 	client.waitPollInterval = time.Millisecond
 	client.waitVHTLCTimeout = 50 * time.Millisecond
 
@@ -678,6 +1328,7 @@ func TestReceiveSessionWaitReconcilesBeforeExpiry(t *testing.T) {
 	}
 
 	client := NewSwapClient(serverConn, daemonConn, nil, creator)
+	useTestOnionDecoder(client, 42_000)
 	session, err := client.StartReceiveViaLightning(
 		t.Context(), btcutil.Amount(42_000),
 	)
@@ -690,9 +1341,9 @@ func TestReceiveSessionWaitReconcilesBeforeExpiry(t *testing.T) {
 	require.EqualValues(t, 42_000, result.AmountSat)
 }
 
-// TestReceiveSessionClaimFailsOnAmountMismatch asserts manual claims use the
-// same amount guard as automatic funding observation.
-func TestReceiveSessionClaimFailsOnAmountMismatch(t *testing.T) {
+// TestReceiveSessionClaimBeforeHTLCEventFailsClearly asserts manual claims
+// cannot proceed before mailbox metadata identifies the concrete vHTLC.
+func TestReceiveSessionClaimBeforeHTLCEventFailsClearly(t *testing.T) {
 	t.Parallel()
 
 	store := newTestSwapStore(t)
@@ -742,10 +1393,80 @@ func TestReceiveSessionClaimFailsOnAmountMismatch(t *testing.T) {
 	client := NewSwapClientWithStore(
 		serverConn, daemonConn, nil, creator, store,
 	)
+	useTestOnionDecoder(client, 42_000)
 	session, err := client.StartReceiveViaLightning(
 		t.Context(), btcutil.Amount(42_000),
 	)
 	require.NoError(t, err)
+
+	_, err = session.Claim(t.Context(), "funding:0", 42_000)
+	require.ErrorContains(
+		t, err, "before out-swap HTLC event is accepted",
+	)
+	require.Equal(t, ReceiveStateInvoiceCreated, session.State())
+	require.Zero(t, daemonConn.sendCustomCalls)
+}
+
+// TestReceiveSessionClaimFailsOnAmountMismatch asserts manual claims use the
+// same amount guard as automatic funding observation after the HTLC event is
+// accepted.
+func TestReceiveSessionClaimFailsOnAmountMismatch(t *testing.T) {
+	t.Parallel()
+
+	store := newTestSwapStore(t)
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	serverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	creator := &testInvoiceCreator{
+		invoice: &invoices.Invoice{
+			PaymentRequest: []byte("lnrtest1swap"),
+		},
+	}
+	serverPubKey := serverPriv.PubKey().SerializeCompressed()
+	cfg := VHTLCConfig{
+		RefundLocktime:                       144,
+		UnilateralClaimDelay:                 12,
+		UnilateralRefundDelay:                24,
+		UnilateralRefundWithoutReceiverDelay: 36,
+		SwapServerPubkey:                     serverPubKey,
+	}
+	serverConn := &testSwapServerConn{
+		hint: &RouteHint{
+			NodeID:          serverPubKey,
+			ChannelID:       99,
+			FeeBaseMsat:     1,
+			FeePropPpm:      2,
+			CltvExpiryDelta: 40,
+		},
+		cfg: &cfg,
+	}
+	daemonConn := &testDaemonConn{
+		identityKey: clientPriv.PubKey(),
+		operatorKey: operatorPriv.PubKey(),
+		blockHeight: 100,
+		receiveInfo: &ReceiveInfo{
+			PkScript:    []byte{0x51},
+			PubKeyXOnly: clientPriv.PubKey().X().Bytes(),
+		},
+		sendSessionID: "claim-session",
+	}
+
+	client := NewSwapClientWithStore(
+		serverConn, daemonConn, nil, creator, store,
+	)
+	useTestOnionDecoder(client, 42_000)
+	session, err := client.StartReceiveViaLightning(
+		t.Context(), btcutil.Amount(42_000),
+	)
+	require.NoError(t, err)
+	acceptTestOutSwapHtlcEvent(t, client, session, cfg)
 
 	_, err = session.Claim(t.Context(), "funding:0", 41_999)
 	require.ErrorContains(t, err, "does not match invoice amount")
@@ -753,6 +1474,296 @@ func TestReceiveSessionClaimFailsOnAmountMismatch(t *testing.T) {
 	require.Contains(t, session.TerminalReason(),
 		"does not match invoice amount")
 	require.Empty(t, session.InterventionReason())
+	require.Zero(t, daemonConn.sendCustomCalls)
+}
+
+// TestReceiveSessionFreshClaimBoundsSpentLookup asserts the first claim attempt
+// does not spend the caller's whole context on optional duplicate-claim
+// reconciliation.
+func TestReceiveSessionFreshClaimBoundsSpentLookup(t *testing.T) {
+	t.Parallel()
+
+	senderPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	receiverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	preimage, err := NewPreimage()
+	require.NoError(t, err)
+
+	policy, err := arkscript.NewVHTLCPolicy(arkscript.VHTLCOpts{
+		Sender:   senderPriv.PubKey(),
+		Receiver: receiverPriv.PubKey(),
+		Server:   operatorPriv.PubKey(),
+		PreimageHash: lntypes.Hash(
+			sha256.Sum256(preimage[:]),
+		),
+		RefundLocktime:                       144,
+		UnilateralClaimDelay:                 12,
+		UnilateralRefundDelay:                24,
+		UnilateralRefundWithoutReceiverDelay: 36,
+	})
+	require.NoError(t, err)
+
+	policyTemplate, err := encodeVHTLCPolicyTemplate(policy)
+	require.NoError(t, err)
+
+	pkScript, err := policy.PkScript()
+	require.NoError(t, err)
+
+	daemonConn := &testDaemonConn{
+		blockHeight: 100,
+		receiveInfo: &ReceiveInfo{
+			PkScript:    []byte{0x51},
+			PubKeyXOnly: receiverPriv.PubKey().X().Bytes(),
+		},
+		sendSessionID:  "claim-session",
+		spentLookupErr: context.DeadlineExceeded,
+	}
+
+	client := NewSwapClient(nil, daemonConn, nil, nil)
+	session := &ReceiveSession{
+		client:              client,
+		state:               ReceiveStateVHTLCFunded,
+		Preimage:            preimage,
+		PaymentHash:         preimage.Hash(),
+		vhtlcPolicy:         policy,
+		vhtlcPolicyTemplate: policyTemplate,
+		vhtlcPkScript:       pkScript,
+		vhtlcConfig: VHTLCConfig{
+			RefundLocktime: 144,
+		},
+		vhtlcOutpoint: "funding:0",
+		vhtlcAmount:   42_000,
+	}
+
+	_, err = session.Claim(t.Context(), "funding:0", 42_000)
+	require.NoError(t, err)
+	require.Equal(t, ReceiveStateCompleted, session.State())
+	require.Equal(t, 1, daemonConn.sendCustomCalls)
+	require.Equal(t, 1, daemonConn.spentLookupCalls)
+}
+
+// TestReceiveSessionFreshClaimBoundsSpentLookupGRPCDeadline mirrors
+// TestReceiveSessionFreshClaimBoundsSpentLookup but the daemon returns the
+// gRPC status form of DeadlineExceeded rather than context.DeadlineExceeded.
+// The bounded reconcile must still swallow it so the bounded check stays
+// agnostic to the wire encoding the caller's transport happens to use.
+func TestReceiveSessionFreshClaimBoundsSpentLookupGRPCDeadline(t *testing.T) {
+	t.Parallel()
+
+	senderPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	receiverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	preimage, err := NewPreimage()
+	require.NoError(t, err)
+
+	policy, err := arkscript.NewVHTLCPolicy(arkscript.VHTLCOpts{
+		Sender:   senderPriv.PubKey(),
+		Receiver: receiverPriv.PubKey(),
+		Server:   operatorPriv.PubKey(),
+		PreimageHash: lntypes.Hash(
+			sha256.Sum256(preimage[:]),
+		),
+		RefundLocktime:                       144,
+		UnilateralClaimDelay:                 12,
+		UnilateralRefundDelay:                24,
+		UnilateralRefundWithoutReceiverDelay: 36,
+	})
+	require.NoError(t, err)
+
+	policyTemplate, err := encodeVHTLCPolicyTemplate(policy)
+	require.NoError(t, err)
+
+	pkScript, err := policy.PkScript()
+	require.NoError(t, err)
+
+	grpcDeadline := status.Error(
+		codes.DeadlineExceeded, context.DeadlineExceeded.Error(),
+	)
+
+	daemonConn := &testDaemonConn{
+		blockHeight: 100,
+		receiveInfo: &ReceiveInfo{
+			PkScript:    []byte{0x51},
+			PubKeyXOnly: receiverPriv.PubKey().X().Bytes(),
+		},
+		sendSessionID: "claim-session",
+		spentLookupErr: fmt.Errorf(
+			"get indexed vtxo by script: %w", grpcDeadline,
+		),
+		spentLookupBlock: 50 * time.Millisecond,
+	}
+
+	client := NewSwapClient(nil, daemonConn, nil, nil)
+	client.waitPollInterval = 5 * time.Millisecond
+
+	session := &ReceiveSession{
+		client:              client,
+		state:               ReceiveStateVHTLCFunded,
+		Preimage:            preimage,
+		PaymentHash:         preimage.Hash(),
+		vhtlcPolicy:         policy,
+		vhtlcPolicyTemplate: policyTemplate,
+		vhtlcPkScript:       pkScript,
+		vhtlcConfig: VHTLCConfig{
+			RefundLocktime: 144,
+		},
+		vhtlcOutpoint: "funding:0",
+		vhtlcAmount:   42_000,
+	}
+
+	_, err = session.Claim(t.Context(), "funding:0", 42_000)
+	require.NoError(t, err)
+	require.Equal(t, ReceiveStateCompleted, session.State())
+	require.Equal(t, 1, daemonConn.sendCustomCalls)
+	require.Equal(t, 1, daemonConn.spentLookupCalls)
+}
+
+// TestReceiveSessionClaimRejectsAfterRefundLocktime asserts a late manual
+// claim does not race the swap server's refund once the refund path is mature.
+func TestReceiveSessionClaimRejectsAfterRefundLocktime(t *testing.T) {
+	t.Parallel()
+
+	senderPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	receiverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	preimage, err := NewPreimage()
+	require.NoError(t, err)
+
+	policy, err := arkscript.NewVHTLCPolicy(arkscript.VHTLCOpts{
+		Sender:   senderPriv.PubKey(),
+		Receiver: receiverPriv.PubKey(),
+		Server:   operatorPriv.PubKey(),
+		PreimageHash: lntypes.Hash(
+			sha256.Sum256(preimage[:]),
+		),
+		RefundLocktime:                       144,
+		UnilateralClaimDelay:                 12,
+		UnilateralRefundDelay:                24,
+		UnilateralRefundWithoutReceiverDelay: 36,
+	})
+	require.NoError(t, err)
+
+	policyTemplate, err := encodeVHTLCPolicyTemplate(policy)
+	require.NoError(t, err)
+
+	pkScript, err := policy.PkScript()
+	require.NoError(t, err)
+
+	daemonConn := &testDaemonConn{
+		blockHeight: 144,
+		receiveInfo: &ReceiveInfo{
+			PkScript:    []byte{0x51},
+			PubKeyXOnly: receiverPriv.PubKey().X().Bytes(),
+		},
+		sendSessionID: "claim-session",
+	}
+
+	client := NewSwapClient(nil, daemonConn, nil, nil)
+	session := &ReceiveSession{
+		client:              client,
+		state:               ReceiveStateVHTLCFunded,
+		Preimage:            preimage,
+		PaymentHash:         preimage.Hash(),
+		vhtlcPolicy:         policy,
+		vhtlcPolicyTemplate: policyTemplate,
+		vhtlcPkScript:       pkScript,
+		vhtlcConfig: VHTLCConfig{
+			RefundLocktime: 144,
+		},
+		vhtlcOutpoint: "funding:0",
+		vhtlcAmount:   42_000,
+	}
+
+	_, err = session.Claim(t.Context(), "funding:0", 42_000)
+	require.ErrorIs(t, err, errSwapExpired)
+	require.Equal(t, ReceiveStateExpired, session.State())
+	require.Zero(t, daemonConn.sendCustomCalls)
+}
+
+// TestReceiveSessionClaimRejectsSpentVHTLCWithoutPreimage asserts the client
+// does not submit a claim once the indexed vHTLC spend lacks the invoice
+// preimage.
+func TestReceiveSessionClaimRejectsSpentVHTLCWithoutPreimage(t *testing.T) {
+	t.Parallel()
+
+	senderPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	receiverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	preimage, err := NewPreimage()
+	require.NoError(t, err)
+
+	policy, err := arkscript.NewVHTLCPolicy(arkscript.VHTLCOpts{
+		Sender:   senderPriv.PubKey(),
+		Receiver: receiverPriv.PubKey(),
+		Server:   operatorPriv.PubKey(),
+		PreimageHash: lntypes.Hash(
+			sha256.Sum256(preimage[:]),
+		),
+		RefundLocktime:                       144,
+		UnilateralClaimDelay:                 12,
+		UnilateralRefundDelay:                24,
+		UnilateralRefundWithoutReceiverDelay: 36,
+	})
+	require.NoError(t, err)
+
+	policyTemplate, err := encodeVHTLCPolicyTemplate(policy)
+	require.NoError(t, err)
+
+	pkScript, err := policy.PkScript()
+	require.NoError(t, err)
+
+	daemonConn := &testDaemonConn{
+		blockHeight: 100,
+		spentVTXO: &VTXOInfo{
+			Outpoint:    "funding:0",
+			AmountSat:   42_000,
+			SpentByTxID: "refund-session",
+		},
+	}
+
+	client := NewSwapClient(nil, daemonConn, nil, nil)
+	session := &ReceiveSession{
+		client:              client,
+		state:               ReceiveStateVHTLCFunded,
+		Preimage:            preimage,
+		PaymentHash:         preimage.Hash(),
+		vhtlcPolicy:         policy,
+		vhtlcPolicyTemplate: policyTemplate,
+		vhtlcPkScript:       pkScript,
+		vhtlcConfig: VHTLCConfig{
+			RefundLocktime: 144,
+		},
+		vhtlcOutpoint: "funding:0",
+		vhtlcAmount:   42_000,
+	}
+
+	_, err = session.Claim(t.Context(), "funding:0", 42_000)
+	require.ErrorIs(t, err, errReceiveVHTLCSpentWithoutPreimage)
+	require.Equal(t, ReceiveStateFailed, session.State())
 	require.Zero(t, daemonConn.sendCustomCalls)
 }
 
@@ -804,10 +1815,12 @@ func TestReceiveSessionClaimIDPreventsDuplicateClaim(t *testing.T) {
 	client := NewSwapClientWithStore(
 		serverConn, daemonConn, nil, creator, store,
 	)
+	useTestOnionDecoder(client, 42_000)
 	session, err := client.StartReceiveViaLightning(
 		t.Context(), btcutil.Amount(42_000),
 	)
 	require.NoError(t, err)
+	acceptTestOutSwapHtlcEvent(t, client, session, *serverConn.cfg)
 	err = session.mutateAndPersist(t.Context(), func() error {
 		session.vhtlcOutpoint = "funding:0"
 		session.vhtlcAmount = 42_000
@@ -883,6 +1896,7 @@ func TestReceiveSessionClaimReturnsLastSendError(t *testing.T) {
 	_, err = client.claimReceiveVHTLC(
 		t.Context(), preimage.Hash(), preimage, policy,
 		policyTemplate, pkScript, "funding:0", 42_000,
+		receiverPriv.PubKey().X().Bytes(),
 	)
 	require.ErrorIs(t, err, sendErr)
 	require.ErrorContains(t, err, "claim vHTLC")

--- a/sdk/swaps/queries/swaps.sql
+++ b/sdk/swaps/queries/swaps.sql
@@ -7,6 +7,7 @@ INSERT INTO receive_swaps (
     preimage,
     deadline_unix,
     client_pubkey,
+    payment_addr,
     operator_pubkey,
     swap_server_pubkey,
     refund_locktime,
@@ -17,13 +18,16 @@ INSERT INTO receive_swaps (
     vhtlc_policy_template,
     vhtlc_outpoint,
     vhtlc_amount,
+    pending_htlc_ack_cursor,
+    claim_receive_pubkey,
+    claim_receive_pkscript,
     claim_session_id,
     intervention_reason,
     created_at_unix,
     updated_at_unix
 ) VALUES (
     $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16,
-    $17, $18, $19, $20, $21
+    $17, $18, $19, $20, $21, $22, $23, $24, $25
 )
 ON CONFLICT (payment_hash) DO UPDATE SET
     amount_sat = EXCLUDED.amount_sat,
@@ -32,6 +36,7 @@ ON CONFLICT (payment_hash) DO UPDATE SET
     preimage = EXCLUDED.preimage,
     deadline_unix = EXCLUDED.deadline_unix,
     client_pubkey = EXCLUDED.client_pubkey,
+    payment_addr = EXCLUDED.payment_addr,
     operator_pubkey = EXCLUDED.operator_pubkey,
     swap_server_pubkey = EXCLUDED.swap_server_pubkey,
     refund_locktime = EXCLUDED.refund_locktime,
@@ -43,6 +48,9 @@ ON CONFLICT (payment_hash) DO UPDATE SET
     vhtlc_policy_template = EXCLUDED.vhtlc_policy_template,
     vhtlc_outpoint = EXCLUDED.vhtlc_outpoint,
     vhtlc_amount = EXCLUDED.vhtlc_amount,
+    pending_htlc_ack_cursor = EXCLUDED.pending_htlc_ack_cursor,
+    claim_receive_pubkey = EXCLUDED.claim_receive_pubkey,
+    claim_receive_pkscript = EXCLUDED.claim_receive_pkscript,
     claim_session_id = EXCLUDED.claim_session_id,
     intervention_reason = EXCLUDED.intervention_reason,
     updated_at_unix = EXCLUDED.updated_at_unix;

--- a/sdk/swaps/sqlc/models.go
+++ b/sdk/swaps/sqlc/models.go
@@ -41,6 +41,7 @@ type ReceiveSwap struct {
 	Preimage                             []byte
 	DeadlineUnix                         int64
 	ClientPubkey                         []byte
+	PaymentAddr                          []byte
 	OperatorPubkey                       []byte
 	SwapServerPubkey                     []byte
 	RefundLocktime                       int64
@@ -51,6 +52,9 @@ type ReceiveSwap struct {
 	VhtlcPolicyTemplate                  []byte
 	VhtlcOutpoint                        string
 	VhtlcAmount                          int64
+	PendingHtlcAckCursor                 int64
+	ClaimReceivePubkey                   []byte
+	ClaimReceivePkscript                 []byte
 	ClaimSessionID                       string
 	InterventionReason                   string
 	CreatedAtUnix                        int64

--- a/sdk/swaps/sqlc/swaps.sql.go
+++ b/sdk/swaps/sqlc/swaps.sql.go
@@ -50,7 +50,7 @@ func (q *Queries) GetPaySwap(ctx context.Context, paymentHash []byte) (PaySwap, 
 }
 
 const GetReceiveSwap = `-- name: GetReceiveSwap :one
-SELECT payment_hash, amount_sat, state, invoice, preimage, deadline_unix, client_pubkey, operator_pubkey, swap_server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, vhtlc_pkscript, vhtlc_policy_template, vhtlc_outpoint, vhtlc_amount, claim_session_id, intervention_reason, created_at_unix, updated_at_unix FROM receive_swaps
+SELECT payment_hash, amount_sat, state, invoice, preimage, deadline_unix, client_pubkey, payment_addr, operator_pubkey, swap_server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, vhtlc_pkscript, vhtlc_policy_template, vhtlc_outpoint, vhtlc_amount, pending_htlc_ack_cursor, claim_receive_pubkey, claim_receive_pkscript, claim_session_id, intervention_reason, created_at_unix, updated_at_unix FROM receive_swaps
 WHERE payment_hash = $1
 LIMIT 1
 `
@@ -66,6 +66,7 @@ func (q *Queries) GetReceiveSwap(ctx context.Context, paymentHash []byte) (Recei
 		&i.Preimage,
 		&i.DeadlineUnix,
 		&i.ClientPubkey,
+		&i.PaymentAddr,
 		&i.OperatorPubkey,
 		&i.SwapServerPubkey,
 		&i.RefundLocktime,
@@ -76,6 +77,9 @@ func (q *Queries) GetReceiveSwap(ctx context.Context, paymentHash []byte) (Recei
 		&i.VhtlcPolicyTemplate,
 		&i.VhtlcOutpoint,
 		&i.VhtlcAmount,
+		&i.PendingHtlcAckCursor,
+		&i.ClaimReceivePubkey,
+		&i.ClaimReceivePkscript,
 		&i.ClaimSessionID,
 		&i.InterventionReason,
 		&i.CreatedAtUnix,
@@ -198,7 +202,7 @@ func (q *Queries) ListPendingPaySwaps(ctx context.Context) ([]PaySwap, error) {
 }
 
 const ListPendingReceiveSwaps = `-- name: ListPendingReceiveSwaps :many
-SELECT payment_hash, amount_sat, state, invoice, preimage, deadline_unix, client_pubkey, operator_pubkey, swap_server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, vhtlc_pkscript, vhtlc_policy_template, vhtlc_outpoint, vhtlc_amount, claim_session_id, intervention_reason, created_at_unix, updated_at_unix FROM receive_swaps
+SELECT payment_hash, amount_sat, state, invoice, preimage, deadline_unix, client_pubkey, payment_addr, operator_pubkey, swap_server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, vhtlc_pkscript, vhtlc_policy_template, vhtlc_outpoint, vhtlc_amount, pending_htlc_ack_cursor, claim_receive_pubkey, claim_receive_pkscript, claim_session_id, intervention_reason, created_at_unix, updated_at_unix FROM receive_swaps
 WHERE state NOT IN ('Completed', 'Expired', 'NeedsIntervention', 'Failed')
 ORDER BY created_at_unix ASC
 `
@@ -220,6 +224,7 @@ func (q *Queries) ListPendingReceiveSwaps(ctx context.Context) ([]ReceiveSwap, e
 			&i.Preimage,
 			&i.DeadlineUnix,
 			&i.ClientPubkey,
+			&i.PaymentAddr,
 			&i.OperatorPubkey,
 			&i.SwapServerPubkey,
 			&i.RefundLocktime,
@@ -230,6 +235,9 @@ func (q *Queries) ListPendingReceiveSwaps(ctx context.Context) ([]ReceiveSwap, e
 			&i.VhtlcPolicyTemplate,
 			&i.VhtlcOutpoint,
 			&i.VhtlcAmount,
+			&i.PendingHtlcAckCursor,
+			&i.ClaimReceivePubkey,
+			&i.ClaimReceivePkscript,
 			&i.ClaimSessionID,
 			&i.InterventionReason,
 			&i.CreatedAtUnix,
@@ -249,7 +257,7 @@ func (q *Queries) ListPendingReceiveSwaps(ctx context.Context) ([]ReceiveSwap, e
 }
 
 const ListReceiveSwaps = `-- name: ListReceiveSwaps :many
-SELECT payment_hash, amount_sat, state, invoice, preimage, deadline_unix, client_pubkey, operator_pubkey, swap_server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, vhtlc_pkscript, vhtlc_policy_template, vhtlc_outpoint, vhtlc_amount, claim_session_id, intervention_reason, created_at_unix, updated_at_unix FROM receive_swaps
+SELECT payment_hash, amount_sat, state, invoice, preimage, deadline_unix, client_pubkey, payment_addr, operator_pubkey, swap_server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, vhtlc_pkscript, vhtlc_policy_template, vhtlc_outpoint, vhtlc_amount, pending_htlc_ack_cursor, claim_receive_pubkey, claim_receive_pkscript, claim_session_id, intervention_reason, created_at_unix, updated_at_unix FROM receive_swaps
 ORDER BY created_at_unix ASC
 `
 
@@ -270,6 +278,7 @@ func (q *Queries) ListReceiveSwaps(ctx context.Context) ([]ReceiveSwap, error) {
 			&i.Preimage,
 			&i.DeadlineUnix,
 			&i.ClientPubkey,
+			&i.PaymentAddr,
 			&i.OperatorPubkey,
 			&i.SwapServerPubkey,
 			&i.RefundLocktime,
@@ -280,6 +289,9 @@ func (q *Queries) ListReceiveSwaps(ctx context.Context) ([]ReceiveSwap, error) {
 			&i.VhtlcPolicyTemplate,
 			&i.VhtlcOutpoint,
 			&i.VhtlcAmount,
+			&i.PendingHtlcAckCursor,
+			&i.ClaimReceivePubkey,
+			&i.ClaimReceivePkscript,
 			&i.ClaimSessionID,
 			&i.InterventionReason,
 			&i.CreatedAtUnix,
@@ -428,6 +440,7 @@ INSERT INTO receive_swaps (
     preimage,
     deadline_unix,
     client_pubkey,
+    payment_addr,
     operator_pubkey,
     swap_server_pubkey,
     refund_locktime,
@@ -438,13 +451,16 @@ INSERT INTO receive_swaps (
     vhtlc_policy_template,
     vhtlc_outpoint,
     vhtlc_amount,
+    pending_htlc_ack_cursor,
+    claim_receive_pubkey,
+    claim_receive_pkscript,
     claim_session_id,
     intervention_reason,
     created_at_unix,
     updated_at_unix
 ) VALUES (
     $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16,
-    $17, $18, $19, $20, $21
+    $17, $18, $19, $20, $21, $22, $23, $24, $25
 )
 ON CONFLICT (payment_hash) DO UPDATE SET
     amount_sat = EXCLUDED.amount_sat,
@@ -453,6 +469,7 @@ ON CONFLICT (payment_hash) DO UPDATE SET
     preimage = EXCLUDED.preimage,
     deadline_unix = EXCLUDED.deadline_unix,
     client_pubkey = EXCLUDED.client_pubkey,
+    payment_addr = EXCLUDED.payment_addr,
     operator_pubkey = EXCLUDED.operator_pubkey,
     swap_server_pubkey = EXCLUDED.swap_server_pubkey,
     refund_locktime = EXCLUDED.refund_locktime,
@@ -464,6 +481,9 @@ ON CONFLICT (payment_hash) DO UPDATE SET
     vhtlc_policy_template = EXCLUDED.vhtlc_policy_template,
     vhtlc_outpoint = EXCLUDED.vhtlc_outpoint,
     vhtlc_amount = EXCLUDED.vhtlc_amount,
+    pending_htlc_ack_cursor = EXCLUDED.pending_htlc_ack_cursor,
+    claim_receive_pubkey = EXCLUDED.claim_receive_pubkey,
+    claim_receive_pkscript = EXCLUDED.claim_receive_pkscript,
     claim_session_id = EXCLUDED.claim_session_id,
     intervention_reason = EXCLUDED.intervention_reason,
     updated_at_unix = EXCLUDED.updated_at_unix
@@ -477,6 +497,7 @@ type UpsertReceiveSwapParams struct {
 	Preimage                             []byte
 	DeadlineUnix                         int64
 	ClientPubkey                         []byte
+	PaymentAddr                          []byte
 	OperatorPubkey                       []byte
 	SwapServerPubkey                     []byte
 	RefundLocktime                       int64
@@ -487,6 +508,9 @@ type UpsertReceiveSwapParams struct {
 	VhtlcPolicyTemplate                  []byte
 	VhtlcOutpoint                        string
 	VhtlcAmount                          int64
+	PendingHtlcAckCursor                 int64
+	ClaimReceivePubkey                   []byte
+	ClaimReceivePkscript                 []byte
 	ClaimSessionID                       string
 	InterventionReason                   string
 	CreatedAtUnix                        int64
@@ -502,6 +526,7 @@ func (q *Queries) UpsertReceiveSwap(ctx context.Context, arg UpsertReceiveSwapPa
 		arg.Preimage,
 		arg.DeadlineUnix,
 		arg.ClientPubkey,
+		arg.PaymentAddr,
 		arg.OperatorPubkey,
 		arg.SwapServerPubkey,
 		arg.RefundLocktime,
@@ -512,6 +537,9 @@ func (q *Queries) UpsertReceiveSwap(ctx context.Context, arg UpsertReceiveSwapPa
 		arg.VhtlcPolicyTemplate,
 		arg.VhtlcOutpoint,
 		arg.VhtlcAmount,
+		arg.PendingHtlcAckCursor,
+		arg.ClaimReceivePubkey,
+		arg.ClaimReceivePkscript,
 		arg.ClaimSessionID,
 		arg.InterventionReason,
 		arg.CreatedAtUnix,

--- a/sdk/swaps/store_sessions.go
+++ b/sdk/swaps/store_sessions.go
@@ -369,14 +369,14 @@ func (s *ReceiveSession) persist(ctx context.Context) error {
 		Invoice:      s.Invoice,
 		Preimage:     append([]byte(nil), s.Preimage[:]...),
 		DeadlineUnix: s.deadline.Unix(),
-		ClientPubkey: append(
-			[]byte(nil), s.clientPubKey.SerializeCompressed()...,
+		ClientPubkey: cloneBytesOrEmpty(pubKeyBytes(s.clientPubKey)),
+		PaymentAddr:  cloneBytesOrEmpty(s.paymentAddr[:]),
+		OperatorPubkey: cloneBytesOrEmpty(
+			pubKeyBytes(s.operatorPubKey),
 		),
-		OperatorPubkey: append(
-			[]byte(nil), s.operatorPubKey.SerializeCompressed()...,
+		SwapServerPubkey: cloneBytesOrEmpty(
+			pubKeyBytes(s.swapServerPubKey),
 		),
-		SwapServerPubkey: append([]byte(nil),
-			s.swapServerPubKey.SerializeCompressed()...),
 		RefundLocktime: int64(s.vhtlcConfig.RefundLocktime),
 		UnilateralClaimDelay: int64(
 			s.vhtlcConfig.UnilateralClaimDelay,
@@ -387,16 +387,19 @@ func (s *ReceiveSession) persist(ctx context.Context) error {
 		UnilateralRefundWithoutReceiverDelay: int64(
 			s.vhtlcConfig.UnilateralRefundWithoutReceiverDelay,
 		),
-		VhtlcPkscript: append([]byte(nil), s.vhtlcPkScript...),
-		VhtlcPolicyTemplate: append(
-			[]byte(nil), s.vhtlcPolicyTemplate...,
+		VhtlcPkscript:       cloneBytesOrEmpty(s.vhtlcPkScript),
+		VhtlcPolicyTemplate: cloneBytesOrEmpty(s.vhtlcPolicyTemplate),
+		VhtlcOutpoint:       s.vhtlcOutpoint,
+		VhtlcAmount:         s.vhtlcAmount,
+		PendingHtlcAckCursor: int64(
+			s.pendingHTLCAckCursor,
 		),
-		VhtlcOutpoint:      s.vhtlcOutpoint,
-		VhtlcAmount:        s.vhtlcAmount,
-		ClaimSessionID:     s.claimSessionID,
-		InterventionReason: s.interventionReason,
-		CreatedAtUnix:      s.createdAt.Unix(),
-		UpdatedAtUnix:      now,
+		ClaimReceivePubkey:   cloneBytesOrEmpty(s.claimReceivePubKey),
+		ClaimReceivePkscript: cloneBytesOrEmpty(s.claimReceiveScript),
+		ClaimSessionID:       s.claimSessionID,
+		InterventionReason:   s.interventionReason,
+		CreatedAtUnix:        s.createdAt.Unix(),
+		UpdatedAtUnix:        now,
 	}
 
 	if s.createdAt.IsZero() {
@@ -412,6 +415,25 @@ func (s *ReceiveSession) persist(ctx context.Context) error {
 	s.updatedAt = time.Unix(now, 0)
 
 	return nil
+}
+
+// cloneBytesOrEmpty keeps optional BLOB columns non-NULL while preserving a
+// defensive copy for values that have been negotiated.
+func cloneBytesOrEmpty(src []byte) []byte {
+	if len(src) == 0 {
+		return []byte{}
+	}
+
+	return append([]byte(nil), src...)
+}
+
+// pubKeyBytes serializes an optional public key for durable storage.
+func pubKeyBytes(pubKey *btcec.PublicKey) []byte {
+	if pubKey == nil {
+		return nil
+	}
+
+	return pubKey.SerializeCompressed()
 }
 
 // mutateAndPersist applies one in-memory pay-session mutation and rolls it
@@ -550,11 +572,14 @@ func receiveSessionFromRow(c *SwapClient,
 		return nil, fmt.Errorf("parse receive operator pubkey: %w", err)
 	}
 
-	swapServerKey, err := btcec.ParsePubKey(row.SwapServerPubkey)
-	if err != nil {
-		return nil, fmt.Errorf(
-			"parse receive swap-server pubkey: %w", err,
-		)
+	var swapServerKey *btcec.PublicKey
+	if len(row.SwapServerPubkey) != 0 {
+		swapServerKey, err = btcec.ParsePubKey(row.SwapServerPubkey)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"parse receive swap-server pubkey: %w", err,
+			)
+		}
 	}
 
 	paymentHash, err := hashFromBytes(row.PaymentHash)
@@ -567,26 +592,37 @@ func receiveSessionFromRow(c *SwapClient,
 		return nil, err
 	}
 
-	policy, err := arkscript.NewVHTLCPolicy(arkscript.VHTLCOpts{
-		Sender:       swapServerKey,
-		Receiver:     clientKey,
-		Server:       operatorKey,
-		PreimageHash: paymentHash,
-		RefundLocktime: uint32(
-			row.RefundLocktime,
-		),
-		UnilateralClaimDelay: uint32(
-			row.UnilateralClaimDelay,
-		),
-		UnilateralRefundDelay: uint32(
-			row.UnilateralRefundDelay,
-		),
-		UnilateralRefundWithoutReceiverDelay: uint32(
-			row.UnilateralRefundWithoutReceiverDelay,
-		),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("rebuild receive vHTLC policy: %w", err)
+	var (
+		policy      *arkscript.VHTLCPolicy
+		paymentAddr [32]byte
+	)
+	if len(row.PaymentAddr) == len(paymentAddr) {
+		copy(paymentAddr[:], row.PaymentAddr)
+	}
+	if swapServerKey != nil {
+		policy, err = arkscript.NewVHTLCPolicy(arkscript.VHTLCOpts{
+			Sender:       swapServerKey,
+			Receiver:     clientKey,
+			Server:       operatorKey,
+			PreimageHash: paymentHash,
+			RefundLocktime: uint32(
+				row.RefundLocktime,
+			),
+			UnilateralClaimDelay: uint32(
+				row.UnilateralClaimDelay,
+			),
+			UnilateralRefundDelay: uint32(
+				row.UnilateralRefundDelay,
+			),
+			UnilateralRefundWithoutReceiverDelay: uint32(
+				row.UnilateralRefundWithoutReceiverDelay,
+			),
+		})
+		if err != nil {
+			return nil, fmt.Errorf(
+				"rebuild receive vHTLC policy: %w", err,
+			)
+		}
 	}
 
 	return &ReceiveSession{
@@ -602,14 +638,24 @@ func receiveSessionFromRow(c *SwapClient,
 		vhtlcPolicyTemplate: append(
 			[]byte(nil), row.VhtlcPolicyTemplate...,
 		),
-		vhtlcPkScript:      append([]byte(nil), row.VhtlcPkscript...),
-		vhtlcOutpoint:      row.VhtlcOutpoint,
-		vhtlcAmount:        row.VhtlcAmount,
+		vhtlcPkScript: append([]byte(nil), row.VhtlcPkscript...),
+		vhtlcOutpoint: row.VhtlcOutpoint,
+		vhtlcAmount:   row.VhtlcAmount,
+		pendingHTLCAckCursor: uint64(
+			row.PendingHtlcAckCursor,
+		),
+		claimReceivePubKey: append(
+			[]byte(nil), row.ClaimReceivePubkey...,
+		),
+		claimReceiveScript: append(
+			[]byte(nil), row.ClaimReceivePkscript...,
+		),
 		claimSessionID:     row.ClaimSessionID,
 		interventionReason: row.InterventionReason,
 		clientPubKey:       clientKey,
 		operatorPubKey:     operatorKey,
 		swapServerPubKey:   swapServerKey,
+		paymentAddr:        paymentAddr,
 		createdAt:          time.Unix(row.CreatedAtUnix, 0),
 		updatedAt:          time.Unix(row.UpdatedAtUnix, 0),
 	}, nil
@@ -779,6 +825,8 @@ func parseReceiveState(state string) (ReceiveState, error) {
 		return ReceiveStateCreated, nil
 	case ReceiveStateInvoiceCreated.String():
 		return ReceiveStateInvoiceCreated, nil
+	case ReceiveStateHTLCEventAccepted.String():
+		return ReceiveStateHTLCEventAccepted, nil
 	case ReceiveStateVHTLCFunded.String():
 		return ReceiveStateVHTLCFunded, nil
 	case ReceiveStateClaimInitiated.String():

--- a/sdk/swaps/store_test.go
+++ b/sdk/swaps/store_test.go
@@ -8,8 +8,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btclog/v2"
 	swapsqlc "github.com/lightninglabs/darepo-client/sdk/swaps/sqlc"
+	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/stretchr/testify/require"
 )
 
@@ -99,6 +101,55 @@ func TestSwapSqliteStoreRunsMigrations(t *testing.T) {
 	require.True(t, sqliteTableExists(
 		t, store.DB(), DefaultMigrationsTable,
 	))
+	var (
+		version int
+		dirty   bool
+	)
+	err := store.DB().QueryRow(
+		"SELECT version, dirty FROM "+DefaultMigrationsTable+
+			" LIMIT 1",
+	).Scan(&version, &dirty)
+	require.NoError(t, err)
+	require.EqualValues(t, LatestMigrationVersion, version)
+	require.False(t, dirty)
+}
+
+// TestReceiveAuthKeyDerivesAcrossRestart verifies receive-auth keys come from
+// the wallet-backed daemon derivation and are not stored in the swap DB.
+func TestReceiveAuthKeyDerivesAcrossRestart(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), DefaultSqliteDatabaseFileName)
+	authPrivKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	daemon := &testDaemonConn{
+		receiveAuthKey: authPrivKey.Serialize(),
+	}
+
+	store, err := NewSqliteStore(&SqliteStoreConfig{
+		DatabaseFileName: dbPath,
+	}, btclog.Disabled)
+	require.NoError(t, err)
+
+	client := NewSwapClientWithStore(nil, daemon, nil, nil, store)
+	key, err := client.receiveAuthKey(ctx, lntypes.Hash{1})
+	require.NoError(t, err)
+	firstPubKey := key.PubKey().SerializeCompressed()
+	require.NoError(t, store.Close())
+
+	store, err = NewSqliteStore(&SqliteStoreConfig{
+		DatabaseFileName: dbPath,
+	}, btclog.Disabled)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, store.Close())
+	})
+
+	client = NewSwapClientWithStore(nil, daemon, nil, nil, store)
+	key, err = client.receiveAuthKey(ctx, lntypes.Hash{1})
+	require.NoError(t, err)
+	require.Equal(t, firstPubKey, key.PubKey().SerializeCompressed())
 }
 
 // TestListSwapSummariesIncludesFeesAndPendingFilter verifies the public list
@@ -151,6 +202,7 @@ func TestListSwapSummariesIncludesFeesAndPendingFilter(t *testing.T) {
 			Preimage:            receivePreimage[:],
 			DeadlineUnix:        time.Unix(1_800, 0).Unix(),
 			ClientPubkey:        testPubKeyBytes(5),
+			PaymentAddr:         []byte{},
 			OperatorPubkey:      testPubKeyBytes(6),
 			SwapServerPubkey:    testPubKeyBytes(7),
 			RefundLocktime:      155,

--- a/swaprpc/swap.pb.go
+++ b/swaprpc/swap.pb.go
@@ -31,8 +31,12 @@ type RequestChannelIdRequest struct {
 	// client_vhtlc_pubkey is the client's public key used in the vHTLC spend
 	// paths.
 	ClientVhtlcPubkey []byte `protobuf:"bytes,2,opt,name=client_vhtlc_pubkey,json=clientVhtlcPubkey,proto3" json:"client_vhtlc_pubkey,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	// payment_hash is the invoice payment hash. The swap server combines it
+	// with client_vhtlc_pubkey to derive a unique virtual channel ID without
+	// adding a separate auth identity.
+	PaymentHash   []byte `protobuf:"bytes,3,opt,name=payment_hash,json=paymentHash,proto3" json:"payment_hash,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *RequestChannelIdRequest) Reset() {
@@ -79,15 +83,18 @@ func (x *RequestChannelIdRequest) GetClientVhtlcPubkey() []byte {
 	return nil
 }
 
-// RequestChannelIdResponse returns the route hint and vHTLC configuration for
-// one receive negotiation.
+func (x *RequestChannelIdRequest) GetPaymentHash() []byte {
+	if x != nil {
+		return x.PaymentHash
+	}
+	return nil
+}
+
+// RequestChannelIdResponse returns the route hint for one receive negotiation.
 type RequestChannelIdResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// route_hint contains the hop hint the client should embed in the invoice.
-	RouteHint *RouteHint `protobuf:"bytes,1,opt,name=route_hint,json=routeHint,proto3" json:"route_hint,omitempty"`
-	// vhtlc_config contains the virtual HTLC parameters the client should use
-	// when constructing the expected output.
-	VhtlcConfig   *VHTLCConfig `protobuf:"bytes,2,opt,name=vhtlc_config,json=vhtlcConfig,proto3" json:"vhtlc_config,omitempty"`
+	RouteHint     *RouteHint `protobuf:"bytes,1,opt,name=route_hint,json=routeHint,proto3" json:"route_hint,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -129,12 +136,151 @@ func (x *RequestChannelIdResponse) GetRouteHint() *RouteHint {
 	return nil
 }
 
-func (x *RequestChannelIdResponse) GetVhtlcConfig() *VHTLCConfig {
+// OutSwapHtlcEvent describes one server-funded intercepted HTLC. The event is
+// intentionally raw from the Lightning side: the client must decode onion_blob
+// with the invoice/auth private key before it claims the Ark vHTLC.
+type OutSwapHtlcEvent struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// payment_hash is the intercepted HTLC hash.
+	PaymentHash []byte `protobuf:"bytes,1,opt,name=payment_hash,json=paymentHash,proto3" json:"payment_hash,omitempty"`
+	// amount_sat is the whole-satoshi amount funded in the vHTLC.
+	AmountSat uint64 `protobuf:"varint,2,opt,name=amount_sat,json=amountSat,proto3" json:"amount_sat,omitempty"`
+	// onion_blob is the raw next-hop onion blob delivered by LND.
+	OnionBlob []byte `protobuf:"bytes,3,opt,name=onion_blob,json=onionBlob,proto3" json:"onion_blob,omitempty"`
+	// vhtlc_config contains the virtual HTLC parameters the client should use
+	// when constructing the expected output.
+	VhtlcConfig   *VHTLCConfig `protobuf:"bytes,4,opt,name=vhtlc_config,json=vhtlcConfig,proto3" json:"vhtlc_config,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *OutSwapHtlcEvent) Reset() {
+	*x = OutSwapHtlcEvent{}
+	mi := &file_swap_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *OutSwapHtlcEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OutSwapHtlcEvent) ProtoMessage() {}
+
+func (x *OutSwapHtlcEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_swap_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use OutSwapHtlcEvent.ProtoReflect.Descriptor instead.
+func (*OutSwapHtlcEvent) Descriptor() ([]byte, []int) {
+	return file_swap_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *OutSwapHtlcEvent) GetPaymentHash() []byte {
+	if x != nil {
+		return x.PaymentHash
+	}
+	return nil
+}
+
+func (x *OutSwapHtlcEvent) GetAmountSat() uint64 {
+	if x != nil {
+		return x.AmountSat
+	}
+	return 0
+}
+
+func (x *OutSwapHtlcEvent) GetOnionBlob() []byte {
+	if x != nil {
+		return x.OnionBlob
+	}
+	return nil
+}
+
+func (x *OutSwapHtlcEvent) GetVhtlcConfig() *VHTLCConfig {
 	if x != nil {
 		return x.VhtlcConfig
 	}
 	return nil
 }
+
+// SwapMailboxEvent is the explicit event wrapper carried by swap mailbox
+// envelopes.
+type SwapMailboxEvent struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Event:
+	//
+	//	*SwapMailboxEvent_OutSwapHtlc
+	Event         isSwapMailboxEvent_Event `protobuf_oneof:"event"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SwapMailboxEvent) Reset() {
+	*x = SwapMailboxEvent{}
+	mi := &file_swap_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SwapMailboxEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SwapMailboxEvent) ProtoMessage() {}
+
+func (x *SwapMailboxEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_swap_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SwapMailboxEvent.ProtoReflect.Descriptor instead.
+func (*SwapMailboxEvent) Descriptor() ([]byte, []int) {
+	return file_swap_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *SwapMailboxEvent) GetEvent() isSwapMailboxEvent_Event {
+	if x != nil {
+		return x.Event
+	}
+	return nil
+}
+
+func (x *SwapMailboxEvent) GetOutSwapHtlc() *OutSwapHtlcEvent {
+	if x != nil {
+		if x, ok := x.Event.(*SwapMailboxEvent_OutSwapHtlc); ok {
+			return x.OutSwapHtlc
+		}
+	}
+	return nil
+}
+
+type isSwapMailboxEvent_Event interface {
+	isSwapMailboxEvent_Event()
+}
+
+type SwapMailboxEvent_OutSwapHtlc struct {
+	// out_swap_htlc is emitted when the server has funded or accepted
+	// funding for an out-swap HTLC.
+	OutSwapHtlc *OutSwapHtlcEvent `protobuf:"bytes,1,opt,name=out_swap_htlc,json=outSwapHtlc,proto3,oneof"`
+}
+
+func (*SwapMailboxEvent_OutSwapHtlc) isSwapMailboxEvent_Event() {}
 
 // RouteHint describes one hop hint for a Lightning invoice route.
 type RouteHint struct {
@@ -155,7 +301,7 @@ type RouteHint struct {
 
 func (x *RouteHint) Reset() {
 	*x = RouteHint{}
-	mi := &file_swap_proto_msgTypes[2]
+	mi := &file_swap_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -167,7 +313,7 @@ func (x *RouteHint) String() string {
 func (*RouteHint) ProtoMessage() {}
 
 func (x *RouteHint) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[2]
+	mi := &file_swap_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -180,7 +326,7 @@ func (x *RouteHint) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RouteHint.ProtoReflect.Descriptor instead.
 func (*RouteHint) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{2}
+	return file_swap_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *RouteHint) GetNodeId() []byte {
@@ -242,7 +388,7 @@ type VHTLCConfig struct {
 
 func (x *VHTLCConfig) Reset() {
 	*x = VHTLCConfig{}
-	mi := &file_swap_proto_msgTypes[3]
+	mi := &file_swap_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -254,7 +400,7 @@ func (x *VHTLCConfig) String() string {
 func (*VHTLCConfig) ProtoMessage() {}
 
 func (x *VHTLCConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[3]
+	mi := &file_swap_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -267,7 +413,7 @@ func (x *VHTLCConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VHTLCConfig.ProtoReflect.Descriptor instead.
 func (*VHTLCConfig) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{3}
+	return file_swap_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *VHTLCConfig) GetRefundLocktime() uint32 {
@@ -321,7 +467,7 @@ type CreateInSwapRequest struct {
 
 func (x *CreateInSwapRequest) Reset() {
 	*x = CreateInSwapRequest{}
-	mi := &file_swap_proto_msgTypes[4]
+	mi := &file_swap_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -333,7 +479,7 @@ func (x *CreateInSwapRequest) String() string {
 func (*CreateInSwapRequest) ProtoMessage() {}
 
 func (x *CreateInSwapRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[4]
+	mi := &file_swap_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -346,7 +492,7 @@ func (x *CreateInSwapRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateInSwapRequest.ProtoReflect.Descriptor instead.
 func (*CreateInSwapRequest) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{4}
+	return file_swap_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *CreateInSwapRequest) GetInvoice() string {
@@ -391,7 +537,7 @@ type CreateInSwapResponse struct {
 
 func (x *CreateInSwapResponse) Reset() {
 	*x = CreateInSwapResponse{}
-	mi := &file_swap_proto_msgTypes[5]
+	mi := &file_swap_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -403,7 +549,7 @@ func (x *CreateInSwapResponse) String() string {
 func (*CreateInSwapResponse) ProtoMessage() {}
 
 func (x *CreateInSwapResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[5]
+	mi := &file_swap_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -416,7 +562,7 @@ func (x *CreateInSwapResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateInSwapResponse.ProtoReflect.Descriptor instead.
 func (*CreateInSwapResponse) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{5}
+	return file_swap_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *CreateInSwapResponse) GetPaymentHash() []byte {
@@ -466,14 +612,24 @@ var File_swap_proto protoreflect.FileDescriptor
 const file_swap_proto_rawDesc = "" +
 	"\n" +
 	"\n" +
-	"swap.proto\x12\aswaprpc\x1a\x1fgoogle/protobuf/timestamp.proto\"p\n" +
+	"swap.proto\x12\aswaprpc\x1a\x1fgoogle/protobuf/timestamp.proto\"\x93\x01\n" +
 	"\x17RequestChannelIdRequest\x12%\n" +
 	"\x0eexpiry_seconds\x18\x01 \x01(\rR\rexpirySeconds\x12.\n" +
-	"\x13client_vhtlc_pubkey\x18\x02 \x01(\fR\x11clientVhtlcPubkey\"\x86\x01\n" +
+	"\x13client_vhtlc_pubkey\x18\x02 \x01(\fR\x11clientVhtlcPubkey\x12!\n" +
+	"\fpayment_hash\x18\x03 \x01(\fR\vpaymentHash\"M\n" +
 	"\x18RequestChannelIdResponse\x121\n" +
 	"\n" +
-	"route_hint\x18\x01 \x01(\v2\x12.swaprpc.RouteHintR\trouteHint\x127\n" +
-	"\fvhtlc_config\x18\x02 \x01(\v2\x14.swaprpc.VHTLCConfigR\vvhtlcConfig\"\xc5\x01\n" +
+	"route_hint\x18\x01 \x01(\v2\x12.swaprpc.RouteHintR\trouteHint\"\xac\x01\n" +
+	"\x10OutSwapHtlcEvent\x12!\n" +
+	"\fpayment_hash\x18\x01 \x01(\fR\vpaymentHash\x12\x1d\n" +
+	"\n" +
+	"amount_sat\x18\x02 \x01(\x04R\tamountSat\x12\x1d\n" +
+	"\n" +
+	"onion_blob\x18\x03 \x01(\fR\tonionBlob\x127\n" +
+	"\fvhtlc_config\x18\x04 \x01(\v2\x14.swaprpc.VHTLCConfigR\vvhtlcConfig\"\\\n" +
+	"\x10SwapMailboxEvent\x12?\n" +
+	"\rout_swap_htlc\x18\x01 \x01(\v2\x19.swaprpc.OutSwapHtlcEventH\x00R\voutSwapHtlcB\a\n" +
+	"\x05event\"\xc5\x01\n" +
 	"\tRouteHint\x12\x17\n" +
 	"\anode_id\x18\x01 \x01(\fR\x06nodeId\x12\x1d\n" +
 	"\n" +
@@ -515,30 +671,33 @@ func file_swap_proto_rawDescGZIP() []byte {
 	return file_swap_proto_rawDescData
 }
 
-var file_swap_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
+var file_swap_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
 var file_swap_proto_goTypes = []any{
 	(*RequestChannelIdRequest)(nil),  // 0: swaprpc.RequestChannelIdRequest
 	(*RequestChannelIdResponse)(nil), // 1: swaprpc.RequestChannelIdResponse
-	(*RouteHint)(nil),                // 2: swaprpc.RouteHint
-	(*VHTLCConfig)(nil),              // 3: swaprpc.VHTLCConfig
-	(*CreateInSwapRequest)(nil),      // 4: swaprpc.CreateInSwapRequest
-	(*CreateInSwapResponse)(nil),     // 5: swaprpc.CreateInSwapResponse
-	(*timestamppb.Timestamp)(nil),    // 6: google.protobuf.Timestamp
+	(*OutSwapHtlcEvent)(nil),         // 2: swaprpc.OutSwapHtlcEvent
+	(*SwapMailboxEvent)(nil),         // 3: swaprpc.SwapMailboxEvent
+	(*RouteHint)(nil),                // 4: swaprpc.RouteHint
+	(*VHTLCConfig)(nil),              // 5: swaprpc.VHTLCConfig
+	(*CreateInSwapRequest)(nil),      // 6: swaprpc.CreateInSwapRequest
+	(*CreateInSwapResponse)(nil),     // 7: swaprpc.CreateInSwapResponse
+	(*timestamppb.Timestamp)(nil),    // 8: google.protobuf.Timestamp
 }
 var file_swap_proto_depIdxs = []int32{
-	2, // 0: swaprpc.RequestChannelIdResponse.route_hint:type_name -> swaprpc.RouteHint
-	3, // 1: swaprpc.RequestChannelIdResponse.vhtlc_config:type_name -> swaprpc.VHTLCConfig
-	3, // 2: swaprpc.CreateInSwapResponse.vhtlc_config:type_name -> swaprpc.VHTLCConfig
-	6, // 3: swaprpc.CreateInSwapResponse.expiry:type_name -> google.protobuf.Timestamp
-	0, // 4: swaprpc.SwapService.RequestChannelId:input_type -> swaprpc.RequestChannelIdRequest
-	4, // 5: swaprpc.SwapService.CreateInSwap:input_type -> swaprpc.CreateInSwapRequest
-	1, // 6: swaprpc.SwapService.RequestChannelId:output_type -> swaprpc.RequestChannelIdResponse
-	5, // 7: swaprpc.SwapService.CreateInSwap:output_type -> swaprpc.CreateInSwapResponse
-	6, // [6:8] is the sub-list for method output_type
-	4, // [4:6] is the sub-list for method input_type
-	4, // [4:4] is the sub-list for extension type_name
-	4, // [4:4] is the sub-list for extension extendee
-	0, // [0:4] is the sub-list for field type_name
+	4, // 0: swaprpc.RequestChannelIdResponse.route_hint:type_name -> swaprpc.RouteHint
+	5, // 1: swaprpc.OutSwapHtlcEvent.vhtlc_config:type_name -> swaprpc.VHTLCConfig
+	2, // 2: swaprpc.SwapMailboxEvent.out_swap_htlc:type_name -> swaprpc.OutSwapHtlcEvent
+	5, // 3: swaprpc.CreateInSwapResponse.vhtlc_config:type_name -> swaprpc.VHTLCConfig
+	8, // 4: swaprpc.CreateInSwapResponse.expiry:type_name -> google.protobuf.Timestamp
+	0, // 5: swaprpc.SwapService.RequestChannelId:input_type -> swaprpc.RequestChannelIdRequest
+	6, // 6: swaprpc.SwapService.CreateInSwap:input_type -> swaprpc.CreateInSwapRequest
+	1, // 7: swaprpc.SwapService.RequestChannelId:output_type -> swaprpc.RequestChannelIdResponse
+	7, // 8: swaprpc.SwapService.CreateInSwap:output_type -> swaprpc.CreateInSwapResponse
+	7, // [7:9] is the sub-list for method output_type
+	5, // [5:7] is the sub-list for method input_type
+	5, // [5:5] is the sub-list for extension type_name
+	5, // [5:5] is the sub-list for extension extendee
+	0, // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_swap_proto_init() }
@@ -546,13 +705,16 @@ func file_swap_proto_init() {
 	if File_swap_proto != nil {
 		return
 	}
+	file_swap_proto_msgTypes[3].OneofWrappers = []any{
+		(*SwapMailboxEvent_OutSwapHtlc)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_swap_proto_rawDesc), len(file_swap_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   6,
+			NumMessages:   8,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/swaprpc/swap.proto
+++ b/swaprpc/swap.proto
@@ -9,8 +9,8 @@ import "google/protobuf/timestamp.proto";
 // SwapService exposes the external swap server API consumed by the client SDK.
 service SwapService {
     // RequestChannelId asks the swap server to allocate a short channel ID and
-    // return the route hint plus vHTLC configuration the client should use for
-    // one Lightning-to-Ark receive flow.
+    // return the route hint the client should use for one Lightning-to-Ark
+    // receive flow.
     rpc RequestChannelId (RequestChannelIdRequest)
         returns (RequestChannelIdResponse);
 
@@ -28,17 +28,45 @@ message RequestChannelIdRequest {
     // client_vhtlc_pubkey is the client's public key used in the vHTLC spend
     // paths.
     bytes client_vhtlc_pubkey = 2;
+
+    // payment_hash is the invoice payment hash. The swap server combines it
+    // with client_vhtlc_pubkey to derive a unique virtual channel ID without
+    // adding a separate auth identity.
+    bytes payment_hash = 3;
 }
 
-// RequestChannelIdResponse returns the route hint and vHTLC configuration for
-// one receive negotiation.
+// RequestChannelIdResponse returns the route hint for one receive negotiation.
 message RequestChannelIdResponse {
     // route_hint contains the hop hint the client should embed in the invoice.
     RouteHint route_hint = 1;
+}
+
+// OutSwapHtlcEvent describes one server-funded intercepted HTLC. The event is
+// intentionally raw from the Lightning side: the client must decode onion_blob
+// with the invoice/auth private key before it claims the Ark vHTLC.
+message OutSwapHtlcEvent {
+    // payment_hash is the intercepted HTLC hash.
+    bytes payment_hash = 1;
+
+    // amount_sat is the whole-satoshi amount funded in the vHTLC.
+    uint64 amount_sat = 2;
+
+    // onion_blob is the raw next-hop onion blob delivered by LND.
+    bytes onion_blob = 3;
 
     // vhtlc_config contains the virtual HTLC parameters the client should use
     // when constructing the expected output.
-    VHTLCConfig vhtlc_config = 2;
+    VHTLCConfig vhtlc_config = 4;
+}
+
+// SwapMailboxEvent is the explicit event wrapper carried by swap mailbox
+// envelopes.
+message SwapMailboxEvent {
+    oneof event {
+        // out_swap_htlc is emitted when the server has funded or accepted
+        // funding for an out-swap HTLC.
+        OutSwapHtlcEvent out_swap_htlc = 1;
+    }
 }
 
 // RouteHint describes one hop hint for a Lightning invoice route.

--- a/swaprpc/swap_grpc.pb.go
+++ b/swaprpc/swap_grpc.pb.go
@@ -30,8 +30,8 @@ const (
 // SwapService exposes the external swap server API consumed by the client SDK.
 type SwapServiceClient interface {
 	// RequestChannelId asks the swap server to allocate a short channel ID and
-	// return the route hint plus vHTLC configuration the client should use for
-	// one Lightning-to-Ark receive flow.
+	// return the route hint the client should use for one Lightning-to-Ark
+	// receive flow.
 	RequestChannelId(ctx context.Context, in *RequestChannelIdRequest, opts ...grpc.CallOption) (*RequestChannelIdResponse, error)
 	// CreateInSwap initiates an Ark-to-Lightning swap for the given invoice and
 	// returns the negotiated vHTLC parameters.
@@ -73,8 +73,8 @@ func (c *swapServiceClient) CreateInSwap(ctx context.Context, in *CreateInSwapRe
 // SwapService exposes the external swap server API consumed by the client SDK.
 type SwapServiceServer interface {
 	// RequestChannelId asks the swap server to allocate a short channel ID and
-	// return the route hint plus vHTLC configuration the client should use for
-	// one Lightning-to-Ark receive flow.
+	// return the route hint the client should use for one Lightning-to-Ark
+	// receive flow.
 	RequestChannelId(context.Context, *RequestChannelIdRequest) (*RequestChannelIdResponse, error)
 	// CreateInSwap initiates an Ark-to-Lightning swap for the given invoice and
 	// returns the negotiated vHTLC parameters.


### PR DESCRIPTION
## Summary

- add the mailbox-delivered out-swap HTLC event RPC shape
- have the SDK pull per-receive HTLC events from mailbox and validate the forwarded onion locally
- keep receive auth as a single client key, persist receive metadata for resume, and bound receive-claim reconciliation

## Tests

- `go test -count=1 ./sdk/swaps ./swaprpc`
- `make commitmsg-lint range=origin/main..HEAD`
