### PR TITLE
swaps: support same-Ark p2p vHTLCs

### DIFF
--- a/sdk/swaps/client.go
+++ b/sdk/swaps/client.go
@@ -28,6 +28,19 @@ const (
 	SwapDirectionReceive SwapDirection = "receive"
 )
 
+// SettlementType identifies the settlement path selected by the swap server.
+type SettlementType string
+
+const (
+	// SettlementTypeLightning means the swap server bridges through
+	// Lightning.
+	SettlementTypeLightning SettlementType = "lightning"
+
+	// SettlementTypeInArk means the sender and receiver settle with one
+	// vHTLC inside the same Ark instance.
+	SettlementTypeInArk SettlementType = "in_ark"
+)
+
 // SwapSummary is the stable list view for one persisted swap session.
 type SwapSummary struct {
 	// Direction identifies whether this is a pay or receive session.
@@ -229,6 +242,37 @@ type OutSwapHtlcNotification struct {
 	Ack       func(context.Context) error
 }
 
+// InArkHtlcEvent carries same-Ark vHTLC metadata that the receiver validates
+// before revealing its invoice preimage.
+type InArkHtlcEvent struct {
+	// PaymentHash is the invoice payment hash.
+	PaymentHash lntypes.Hash
+
+	// AmountSat is the amount funded by the sender.
+	AmountSat int64
+
+	// SenderPubkey is the sender key used in the vHTLC refund paths.
+	SenderPubkey *btcec.PublicKey
+
+	// VHTLCConfig contains the script parameters for the funded vHTLC.
+	VHTLCConfig VHTLCConfig
+
+	// VHTLCOutpoint is the funded outpoint when known by the server.
+	VHTLCOutpoint string
+
+	// VHTLCAmountSat is the indexed funded amount when known by the server.
+	VHTLCAmountSat int64
+}
+
+// IncomingVHTLCNotification carries either a Lightning-backed out-swap event
+// or a direct same-Ark vHTLC event.
+type IncomingVHTLCNotification struct {
+	OutSwap   *OutSwapHtlcEvent
+	InArk     *InArkHtlcEvent
+	AckCursor uint64
+	Ack       func(context.Context) error
+}
+
 // OutSwapEventReceiver waits for server-pushed out-swap mailbox events.
 type OutSwapEventReceiver interface {
 	WaitOutSwapHtlc(
@@ -243,6 +287,16 @@ type OutSwapEventReceiver interface {
 		mailboxPubkey *btcec.PublicKey,
 		cursor uint64,
 	) error
+}
+
+// IncomingVHTLCEventReceiver waits for any incoming vHTLC event type that can
+// satisfy a prepared receive invoice.
+type IncomingVHTLCEventReceiver interface {
+	WaitIncomingVHTLC(
+		ctx context.Context,
+		paymentHash lntypes.Hash,
+		mailboxPubkey *btcec.PublicKey,
+	) (*IncomingVHTLCNotification, error)
 }
 
 // InSwapConfig is returned by the server when creating an in-swap.
@@ -270,6 +324,10 @@ type InSwapConfig struct {
 	// Expiry is the wall-clock deadline by which the swap must
 	// complete before it is considered expired.
 	Expiry time.Time
+
+	// SettlementType identifies whether this pay session is bridged through
+	// Lightning or settled directly inside Ark.
+	SettlementType SettlementType
 }
 
 // SwapServerConn abstracts the connection to the swap server's

--- a/sdk/swaps/grpc_conn.go
+++ b/sdk/swaps/grpc_conn.go
@@ -198,6 +198,49 @@ func outSwapHtlcEventFromProto(
 	}, nil
 }
 
+// inArkHtlcEventFromProto converts one generated p2p event into the local SDK
+// shape.
+func inArkHtlcEventFromProto(
+	event *swaprpc.InArkHtlcEvent) (*InArkHtlcEvent, error) {
+
+	if event == nil {
+		return nil, fmt.Errorf("in-ark HTLC event must be provided")
+	}
+	if len(event.GetPaymentHash()) != lntypes.HashSize {
+		return nil, fmt.Errorf(
+			"in-ark event payment hash must be %d bytes",
+			lntypes.HashSize,
+		)
+	}
+	if event.GetAmountSat() > math.MaxInt64 ||
+		event.GetVhtlcAmountSat() > math.MaxInt64 {
+
+		return nil, fmt.Errorf("in-ark event amount exceeds int64")
+	}
+
+	var paymentHash lntypes.Hash
+	copy(paymentHash[:], event.GetPaymentHash())
+
+	senderKey, err := btcec.ParsePubKey(event.GetSenderPubkey())
+	if err != nil {
+		return nil, fmt.Errorf("parse in-ark sender pubkey: %w", err)
+	}
+
+	cfg, err := vhtlcConfigFromProto(event.GetVhtlcConfig())
+	if err != nil {
+		return nil, err
+	}
+
+	return &InArkHtlcEvent{
+		PaymentHash:    paymentHash,
+		AmountSat:      int64(event.GetAmountSat()),
+		SenderPubkey:   senderKey,
+		VHTLCConfig:    *cfg,
+		VHTLCOutpoint:  event.GetVhtlcOutpoint(),
+		VHTLCAmountSat: int64(event.GetVhtlcAmountSat()),
+	}, nil
+}
+
 // inSwapConfigFromProto converts one generated in-swap response into the local
 // SDK shape.
 func inSwapConfigFromProto(
@@ -262,14 +305,41 @@ func inSwapConfigFromProto(
 		)
 	}
 
+	settlementType, err := settlementTypeFromProto(
+		resp.GetSettlementType(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	return &InSwapConfig{
-		PaymentHash:  paymentHash,
-		AmountSat:    int64(resp.GetAmountSat()),
-		FeeSat:       resp.GetFeeSat(),
-		ServerPubkey: serverPubkey,
-		VHTLCConfig:  *cfg,
-		Expiry:       expiryTime,
+		PaymentHash:    paymentHash,
+		AmountSat:      int64(resp.GetAmountSat()),
+		FeeSat:         resp.GetFeeSat(),
+		ServerPubkey:   serverPubkey,
+		VHTLCConfig:    *cfg,
+		Expiry:         expiryTime,
+		SettlementType: settlementType,
 	}, nil
+}
+
+// settlementTypeFromProto converts the wire settlement enum, treating
+// unspecified as Lightning for compatibility with older test fixtures.
+func settlementTypeFromProto(
+	wireType swaprpc.SettlementType) (SettlementType, error) {
+
+	switch wireType {
+	case swaprpc.SettlementType_SETTLEMENT_TYPE_UNSPECIFIED,
+		swaprpc.SettlementType_SETTLEMENT_TYPE_LIGHTNING:
+
+		return SettlementTypeLightning, nil
+
+	case swaprpc.SettlementType_SETTLEMENT_TYPE_IN_ARK:
+		return SettlementTypeInArk, nil
+
+	default:
+		return "", fmt.Errorf("unknown settlement type %v", wireType)
+	}
 }
 
 // Ensure GRPCSwapServerConn satisfies the SwapServerConn interface.

--- a/sdk/swaps/in_swap.go
+++ b/sdk/swaps/in_swap.go
@@ -530,6 +530,9 @@ func (s *paySession) createSwap(ctx context.Context) error {
 	if cfg == nil {
 		return fmt.Errorf("in-swap config is required")
 	}
+	if cfg.SettlementType == "" {
+		cfg.SettlementType = SettlementTypeLightning
+	}
 
 	operatorKey, err := s.client.daemon.OperatorPubKey(ctx)
 	if err != nil {
@@ -571,6 +574,7 @@ func (s *paySession) createSwap(ctx context.Context) error {
 		btclog.Hex("hash", cfg.PaymentHash[:]),
 		slog.Int64("amount_sat", cfg.AmountSat),
 		slog.Uint64("fee_sat", cfg.FeeSat),
+		slog.String("settlement_type", string(cfg.SettlementType)),
 		slog.Time("deadline", cfg.Expiry),
 	)
 

--- a/sdk/swaps/out_swap.go
+++ b/sdk/swaps/out_swap.go
@@ -236,14 +236,17 @@ type ReceiveSession struct {
 	// PaymentHash is the Lightning payment hash for this receive flow.
 	PaymentHash lntypes.Hash
 
-	client               *SwapClient
-	amountSat            btcutil.Amount
-	state                ReceiveState
-	deadline             time.Time
-	createdAt            time.Time
-	updatedAt            time.Time
-	clientPubKey         *btcec.PublicKey
-	operatorPubKey       *btcec.PublicKey
+	client         *SwapClient
+	amountSat      btcutil.Amount
+	state          ReceiveState
+	deadline       time.Time
+	createdAt      time.Time
+	updatedAt      time.Time
+	clientPubKey   *btcec.PublicKey
+	operatorPubKey *btcec.PublicKey
+	// swapServerPubKey is the remote sender in the accepted vHTLC policy.
+	// For Lightning-backed receives this is the swap server key; for
+	// direct same-Ark receives this is the paying client's sender key.
 	swapServerPubKey     *btcec.PublicKey
 	vhtlcConfig          VHTLCConfig
 	vhtlcPolicy          *arkscript.VHTLCPolicy
@@ -674,23 +677,21 @@ func (s *ReceiveSession) waitForHTLCEvent(ctx context.Context) error {
 		return fmt.Errorf("get receive auth key: %w", err)
 	}
 
-	notification, err := s.client.outEvents.WaitOutSwapHtlc(
-		ctx, s.PaymentHash, s.clientPubKey,
+	notification, err := s.waitIncomingVHTLCNotification(
+		ctx, authKey,
 	)
 	if err != nil {
-		return fmt.Errorf("wait for out-swap HTLC event: %w", err)
+		return err
 	}
 	if notification == nil {
-		return fmt.Errorf("out-swap HTLC notification must be provided")
+		return fmt.Errorf(
+			"incoming vHTLC notification must be provided",
+		)
 	}
 	if notification.Ack != nil && notification.AckCursor == 0 {
-		return fmt.Errorf("out-swap HTLC ack cursor must be provided")
-	}
-
-	if err := s.acceptOutSwapHtlcEvent(
-		ctx, notification.Event, authKey, notification.AckCursor,
-	); err != nil {
-		return err
+		return fmt.Errorf(
+			"incoming vHTLC ack cursor must be provided",
+		)
 	}
 
 	return s.ackAcceptedHTLCEvent(ctx, notification.Ack)
@@ -730,6 +731,108 @@ func (s *ReceiveSession) waitForFunding(ctx context.Context) error {
 
 		return s.transition(receiveEventVHTLCFunded)
 	})
+}
+
+// waitIncomingVHTLCNotification waits for and validates the server notification
+// that tells this receiver which vHTLC script should be funded.
+func (s *ReceiveSession) waitIncomingVHTLCNotification(
+	ctx context.Context,
+	authKey ReceiveAuthKey) (*IncomingVHTLCNotification, error) {
+
+	if receiver, ok := s.client.outEvents.(IncomingVHTLCEventReceiver); ok {
+		notification, err := receiver.WaitIncomingVHTLC(
+			ctx, s.PaymentHash, s.clientPubKey,
+		)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"wait for incoming vHTLC event: %w", err,
+			)
+		}
+		if err := validateIncomingVHTLCAck(notification); err != nil {
+			return nil, err
+		}
+
+		return s.acceptIncomingVHTLCNotification(
+			ctx, notification, authKey,
+		)
+	}
+
+	notification, err := s.client.outEvents.WaitOutSwapHtlc(
+		ctx, s.PaymentHash, s.clientPubKey,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("wait for out-swap HTLC event: %w", err)
+	}
+	if notification == nil {
+		return nil, fmt.Errorf(
+			"out-swap HTLC notification must be provided",
+		)
+	}
+
+	incoming := &IncomingVHTLCNotification{
+		OutSwap:   notification.Event,
+		AckCursor: notification.AckCursor,
+		Ack:       notification.Ack,
+	}
+	if err := validateIncomingVHTLCAck(incoming); err != nil {
+		return nil, err
+	}
+
+	return s.acceptIncomingVHTLCNotification(ctx, incoming, authKey)
+}
+
+// validateIncomingVHTLCAck checks mailbox ack metadata before the notification
+// is durably accepted.
+func validateIncomingVHTLCAck(
+	notification *IncomingVHTLCNotification) error {
+
+	if notification == nil {
+		return fmt.Errorf(
+			"incoming vHTLC notification must be provided",
+		)
+	}
+	if notification.Ack != nil && notification.AckCursor == 0 {
+		return fmt.Errorf(
+			"incoming vHTLC ack cursor must be provided",
+		)
+	}
+
+	return nil
+}
+
+// acceptIncomingVHTLCNotification validates and persists either incoming vHTLC
+// event shape.
+func (s *ReceiveSession) acceptIncomingVHTLCNotification(
+	ctx context.Context, notification *IncomingVHTLCNotification,
+	authKey ReceiveAuthKey) (*IncomingVHTLCNotification, error) {
+
+	if notification == nil {
+		return nil, fmt.Errorf(
+			"incoming vHTLC notification must be provided",
+		)
+	}
+
+	switch {
+	case notification.OutSwap != nil:
+		if err := s.acceptOutSwapHtlcEvent(
+			ctx, notification.OutSwap, authKey,
+			notification.AckCursor,
+		); err != nil {
+			return nil, err
+		}
+
+	case notification.InArk != nil:
+		if err := s.acceptInArkHtlcEvent(
+			ctx, notification.InArk, notification.AckCursor,
+		); err != nil {
+			return nil, err
+		}
+
+	default:
+		return nil, fmt.Errorf("incoming vHTLC event missing payload")
+	}
+
+	return notification, nil
 }
 
 // acceptOutSwapHtlcEvent validates the server's funded HTLC notification and
@@ -853,6 +956,77 @@ func (s *ReceiveSession) clearPendingHTLCAck(ctx context.Context) error {
 		s.pendingHTLCAckCursor = 0
 
 		return nil
+	})
+}
+
+// acceptInArkHtlcEvent validates a direct same-Ark vHTLC notification and
+// builds the policy that the receiver will later claim.
+func (s *ReceiveSession) acceptInArkHtlcEvent(ctx context.Context,
+	event *InArkHtlcEvent, ackCursor uint64) error {
+
+	if event == nil {
+		return fmt.Errorf("in-ark HTLC event must be provided")
+	}
+	if event.PaymentHash != s.PaymentHash {
+		return s.failTerminal(ctx,
+			"in-ark HTLC event payment hash mismatch", nil, nil,
+		)
+	}
+	if event.AmountSat != int64(s.amountSat) {
+		return s.failTerminal(ctx, fmt.Sprintf(
+			"in-ark HTLC amount %d does not match "+
+				"invoice amount %d",
+			event.AmountSat, s.amountSat,
+		), nil, nil)
+	}
+	if event.SenderPubkey == nil {
+		return fmt.Errorf("in-ark HTLC sender pubkey is required")
+	}
+	cfg := event.VHTLCConfig
+	cfgSenderKey, err := btcec.ParsePubKey(cfg.SwapServerPubkey)
+	if err != nil {
+		return fmt.Errorf("parse in-ark vHTLC sender pubkey: %w", err)
+	}
+	if !cfgSenderKey.IsEqual(event.SenderPubkey) {
+		return s.failTerminal(ctx,
+			"in-ark HTLC sender pubkey mismatch", nil, nil,
+		)
+	}
+	refundNoReceiverDelay := cfg.UnilateralRefundWithoutReceiverDelay
+
+	policy, err := arkscript.NewVHTLCPolicy(arkscript.VHTLCOpts{
+		Sender:                               event.SenderPubkey,
+		Receiver:                             s.clientPubKey,
+		Server:                               s.operatorPubKey,
+		PreimageHash:                         s.PaymentHash,
+		RefundLocktime:                       cfg.RefundLocktime,
+		UnilateralClaimDelay:                 cfg.UnilateralClaimDelay,
+		UnilateralRefundDelay:                cfg.UnilateralRefundDelay,
+		UnilateralRefundWithoutReceiverDelay: refundNoReceiverDelay,
+	})
+	if err != nil {
+		return fmt.Errorf("build in-ark vHTLC policy: %w", err)
+	}
+
+	pkScript, err := policy.PkScript()
+	if err != nil {
+		return fmt.Errorf("get in-ark vHTLC pkScript: %w", err)
+	}
+
+	policyTemplate, err := encodeVHTLCPolicyTemplate(policy)
+	if err != nil {
+		return fmt.Errorf("encode in-ark vHTLC policy: %w", err)
+	}
+
+	return s.mutateAndPersist(ctx, func() error {
+		s.swapServerPubKey = event.SenderPubkey
+		s.vhtlcConfig = event.VHTLCConfig
+		s.vhtlcPolicy = policy
+		s.vhtlcPolicyTemplate = policyTemplate
+		s.vhtlcPkScript = pkScript
+		s.pendingHTLCAckCursor = ackCursor
+
+		return s.transition(receiveEventHTLCEventAccepted)
 	})
 }
 

--- a/sdk/swaps/out_swap_mailbox.go
+++ b/sdk/swaps/out_swap_mailbox.go
@@ -123,6 +123,83 @@ func (r *MailboxOutSwapEventReceiver) WaitOutSwapHtlc(ctx context.Context,
 	}
 }
 
+// WaitIncomingVHTLC waits until either a Lightning-backed out-swap event or a
+// same-Ark vHTLC event is available for the payment hash.
+func (r *MailboxOutSwapEventReceiver) WaitIncomingVHTLC(
+	ctx context.Context, paymentHash lntypes.Hash,
+	mailboxPubkey *btcec.PublicKey) (*IncomingVHTLCNotification, error) {
+
+	if r == nil || r.edge == nil {
+		return nil, fmt.Errorf("mailbox event receiver not configured")
+	}
+	if mailboxPubkey == nil {
+		return nil, fmt.Errorf("mailbox pubkey must be provided")
+	}
+
+	mailboxID := r.mailboxID
+	if mailboxID == "" {
+		mailboxID = OutSwapMailboxID(mailboxPubkey, paymentHash)
+	}
+
+	cursor := uint64(0)
+	for {
+		resp, err := r.edge.Pull(ctx, &mailboxpb.PullRequest{
+			MailboxId:     mailboxID,
+			MaxEnvelopes:  r.pullMaxEnvelopes,
+			WaitTimeoutMs: uint32(r.pullWaitTimeout.Milliseconds()),
+			Cursor:        cursor,
+		})
+		if err != nil {
+			return nil, fmt.Errorf(
+				"pull incoming vHTLC mailbox: %w", err,
+			)
+		}
+		if resp.GetStatus() != nil && !resp.GetStatus().GetOk() {
+			return nil, fmt.Errorf(
+				"pull incoming vHTLC mailbox: %s (%s)",
+				resp.GetStatus().GetMessage(),
+				resp.GetStatus().GetCode())
+		}
+
+		if len(resp.GetEnvelopes()) == 0 {
+			cursor = resp.GetNextCursor()
+			continue
+		}
+
+		for _, env := range resp.GetEnvelopes() {
+			event, ok, err := incomingEventFromMailboxEnvelope(env)
+			if err != nil {
+				return nil, err
+			}
+			if !ok {
+				continue
+			}
+
+			eventHash := lntypes.Hash{}
+			switch {
+			case event.OutSwap != nil:
+				eventHash = event.OutSwap.PaymentHash
+
+			case event.InArk != nil:
+				eventHash = event.InArk.PaymentHash
+			}
+			if eventHash != paymentHash {
+				continue
+			}
+
+			ackCursor := env.GetEventSeq() + 1
+			event.AckCursor = ackCursor
+			event.Ack = func(ctx context.Context) error {
+				return r.ack(ctx, mailboxID, ackCursor)
+			}
+
+			return event, nil
+		}
+
+		cursor = resp.GetNextCursor()
+	}
+}
+
 // AckOutSwapHtlc advances the remote mailbox cursor after the caller has
 // durably accepted the matching notification.
 func (r *MailboxOutSwapEventReceiver) AckOutSwapHtlc(ctx context.Context,
@@ -140,6 +217,14 @@ func (r *MailboxOutSwapEventReceiver) AckOutSwapHtlc(ctx context.Context,
 	if mailboxID == "" {
 		mailboxID = OutSwapMailboxID(mailboxPubkey, paymentHash)
 	}
+
+	return r.ack(ctx, mailboxID, cursor)
+}
+
+// ack advances the remote mailbox cursor after the caller has durably accepted
+// the matching notification.
+func (r *MailboxOutSwapEventReceiver) ack(ctx context.Context, mailboxID string,
+	cursor uint64) error {
 
 	resp, err := r.edge.AckUpTo(ctx, &mailboxpb.AckUpToRequest{
 		MailboxId: mailboxID,
@@ -162,6 +247,65 @@ func (r *MailboxOutSwapEventReceiver) AckOutSwapHtlc(ctx context.Context,
 func outSwapEventFromMailboxEnvelope(
 	env *mailboxpb.Envelope) (*OutSwapHtlcEvent, bool, error) {
 
+	wrapped, ok, err := swapMailboxEventFromEnvelope(env)
+	if err != nil {
+		return nil, false, err
+	}
+	if !ok {
+		return nil, false, nil
+	}
+
+	event := wrapped.GetOutSwapHtlc()
+	if event == nil {
+		return nil, false, nil
+	}
+
+	local, err := outSwapHtlcEventFromProto(event)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return local, true, nil
+}
+
+// incomingEventFromMailboxEnvelope unwraps either incoming vHTLC event type.
+func incomingEventFromMailboxEnvelope(
+	env *mailboxpb.Envelope) (*IncomingVHTLCNotification, bool, error) {
+
+	wrapped, ok, err := swapMailboxEventFromEnvelope(env)
+	if err != nil || !ok {
+		return nil, ok, err
+	}
+
+	if outSwap := wrapped.GetOutSwapHtlc(); outSwap != nil {
+		local, err := outSwapHtlcEventFromProto(outSwap)
+		if err != nil {
+			return nil, false, err
+		}
+
+		return &IncomingVHTLCNotification{
+			OutSwap: local,
+		}, true, nil
+	}
+
+	if inArk := wrapped.GetInArkHtlc(); inArk != nil {
+		local, err := inArkHtlcEventFromProto(inArk)
+		if err != nil {
+			return nil, false, err
+		}
+
+		return &IncomingVHTLCNotification{
+			InArk: local,
+		}, true, nil
+	}
+
+	return nil, false, nil
+}
+
+// swapMailboxEventFromEnvelope unwraps one shared swap mailbox event envelope.
+func swapMailboxEventFromEnvelope(
+	env *mailboxpb.Envelope) (*swaprpc.SwapMailboxEvent, bool, error) {
+
 	if env == nil || env.GetRpc() == nil {
 		return nil, false, nil
 	}
@@ -176,33 +320,26 @@ func outSwapEventFromMailboxEnvelope(
 
 	body := env.GetBody()
 	if body == nil {
-		return nil, false, fmt.Errorf("out-swap event missing body")
+		return nil, false, fmt.Errorf("swap mailbox event missing body")
 	}
 
 	msg, err := body.UnmarshalNew()
 	if err != nil {
 		return nil, false, fmt.Errorf(
-			"unmarshal out-swap event body: %w", err,
+			"unmarshal swap mailbox event body: %w", err,
 		)
 	}
 
 	wrapped, ok := msg.(*swaprpc.SwapMailboxEvent)
 	if !ok {
 		return nil, false, fmt.Errorf(
-			"unexpected out-swap event body type %T", msg,
+			"unexpected swap mailbox event body type %T", msg,
 		)
 	}
-	event := wrapped.GetOutSwapHtlc()
-	if event == nil {
-		return nil, false, nil
-	}
 
-	local, err := outSwapHtlcEventFromProto(event)
-	if err != nil {
-		return nil, false, err
-	}
-
-	return local, true, nil
+	return wrapped, true, nil
 }
 
 var _ OutSwapEventReceiver = (*MailboxOutSwapEventReceiver)(nil)
+
+var _ IncomingVHTLCEventReceiver = (*MailboxOutSwapEventReceiver)(nil)

--- a/sdk/swaps/out_swap_mailbox_test.go
+++ b/sdk/swaps/out_swap_mailbox_test.go
@@ -110,3 +110,92 @@ func TestMailboxOutSwapEventReceiverPullsAndAcks(t *testing.T) {
 	)
 	require.Equal(t, uint64(8), edge.ackReq.GetCursor())
 }
+
+// TestMailboxOutSwapEventReceiverPullsInArkEvent verifies that same-Ark vHTLC
+// events use the shared mailbox envelope and carry ack metadata.
+func TestMailboxOutSwapEventReceiverPullsInArkEvent(t *testing.T) {
+	t.Parallel()
+
+	senderKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	receiverKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	hash := lntypes.Hash{4, 5, 6}
+	protoEvent := &swaprpc.InArkHtlcEvent{
+		PaymentHash:  hash[:],
+		AmountSat:    21_000,
+		SenderPubkey: senderKey.PubKey().SerializeCompressed(),
+		VhtlcConfig: &swaprpc.VHTLCConfig{
+			RefundLocktime:                       155,
+			UnilateralClaimDelay:                 10,
+			UnilateralRefundDelay:                20,
+			UnilateralRefundWithoutReceiverDelay: 30,
+			SwapserverPubkey: senderKey.PubKey().
+				SerializeCompressed(),
+		},
+		VhtlcOutpoint:  "txid:0",
+		VhtlcAmountSat: 21_500,
+	}
+	body, err := anypb.New(&swaprpc.SwapMailboxEvent{
+		Event: &swaprpc.SwapMailboxEvent_InArkHtlc{
+			InArkHtlc: protoEvent,
+		},
+	})
+	require.NoError(t, err)
+
+	edge := &testOutSwapMailboxEdge{
+		pullResp: &mailboxpb.PullResponse{
+			Status:     &mailboxpb.Status{Ok: true},
+			NextCursor: 13,
+			Envelopes: []*mailboxpb.Envelope{{
+				Type:     outSwapMailboxEventType,
+				Body:     body,
+				EventSeq: 12,
+				Rpc: &mailboxpb.RpcMeta{
+					Kind: mailboxpb.
+						RpcMeta_KIND_EVENT,
+					Service: outSwapMailboxEventService,
+					Method:  outSwapMailboxEventMethod,
+				},
+			}},
+		},
+	}
+	receiver := NewMailboxOutSwapEventReceiver(edge, "")
+	receiver.pullWaitTimeout = time.Millisecond
+
+	notification, err := receiver.WaitIncomingVHTLC(
+		t.Context(), hash, receiverKey.PubKey(),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, notification)
+	require.Nil(t, notification.OutSwap)
+	require.NotNil(t, notification.InArk)
+	require.Equal(t, hash, notification.InArk.PaymentHash)
+	require.EqualValues(t, 21_000, notification.InArk.AmountSat)
+	require.True(
+		t, notification.InArk.SenderPubkey.IsEqual(senderKey.PubKey()),
+	)
+	require.EqualValues(
+		t, 155, notification.InArk.VHTLCConfig.RefundLocktime,
+	)
+	require.EqualValues(
+		t, 30,
+		notification.InArk.VHTLCConfig.
+			UnilateralRefundWithoutReceiverDelay,
+	)
+	require.Equal(t, "txid:0", notification.InArk.VHTLCOutpoint)
+	require.EqualValues(t, 21_500, notification.InArk.VHTLCAmountSat)
+	require.Equal(t, uint64(13), notification.AckCursor)
+	require.NotNil(t, notification.Ack)
+	require.Nil(t, edge.ackReq)
+
+	require.NoError(t, notification.Ack(t.Context()))
+	require.NotNil(t, edge.ackReq)
+	require.Equal(
+		t, OutSwapMailboxID(receiverKey.PubKey(), hash),
+		edge.ackReq.GetMailboxId(),
+	)
+	require.Equal(t, uint64(13), edge.ackReq.GetCursor())
+}

--- a/sdk/swaps/out_swap_test.go
+++ b/sdk/swaps/out_swap_test.go
@@ -127,6 +127,68 @@ func TestStartReceiveDerivesReceiveAuthKeyPerPaymentHash(t *testing.T) {
 	))
 }
 
+// TestAcceptInArkHtlcEventBuildsSenderReceiverPolicy verifies that same-Ark
+// receive events are validated directly without requiring a Lightning onion.
+func TestAcceptInArkHtlcEventBuildsSenderReceiverPolicy(t *testing.T) {
+	t.Parallel()
+
+	senderPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	receiverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	preimage := lntypes.Preimage{1, 2, 3}
+	hash := preimage.Hash()
+	cfg := VHTLCConfig{
+		RefundLocktime:                       900,
+		UnilateralClaimDelay:                 5,
+		UnilateralRefundDelay:                6,
+		UnilateralRefundWithoutReceiverDelay: 7,
+		SwapServerPubkey: senderPriv.PubKey().
+			SerializeCompressed(),
+	}
+	session := &ReceiveSession{
+		client: &SwapClient{
+			daemon: &testDaemonConn{},
+		},
+		amountSat:      btcutil.Amount(42_000),
+		state:          ReceiveStateInvoiceCreated,
+		PaymentHash:    hash,
+		clientPubKey:   receiverPriv.PubKey(),
+		operatorPubKey: operatorPriv.PubKey(),
+	}
+
+	err = session.acceptInArkHtlcEvent(t.Context(), &InArkHtlcEvent{
+		PaymentHash:  hash,
+		AmountSat:    42_000,
+		SenderPubkey: senderPriv.PubKey(),
+		VHTLCConfig:  cfg,
+	}, 0)
+	require.NoError(t, err)
+
+	refundNoReceiverDelay := cfg.UnilateralRefundWithoutReceiverDelay
+	expected, err := arkscript.NewVHTLCPolicy(arkscript.VHTLCOpts{
+		Sender:                               senderPriv.PubKey(),
+		Receiver:                             receiverPriv.PubKey(),
+		Server:                               operatorPriv.PubKey(),
+		PreimageHash:                         hash,
+		RefundLocktime:                       cfg.RefundLocktime,
+		UnilateralClaimDelay:                 cfg.UnilateralClaimDelay,
+		UnilateralRefundDelay:                cfg.UnilateralRefundDelay,
+		UnilateralRefundWithoutReceiverDelay: refundNoReceiverDelay,
+	})
+	require.NoError(t, err)
+
+	expectedScript, err := expected.PkScript()
+	require.NoError(t, err)
+	require.Equal(t, expectedScript, session.vhtlcPkScript)
+	require.True(t, session.swapServerPubKey.IsEqual(senderPriv.PubKey()))
+}
+
 type testSwapServerConn struct {
 	hint          *RouteHint
 	cfg           *VHTLCConfig
@@ -140,6 +202,31 @@ type testSwapServerConn struct {
 	lastAckCursor uint64
 
 	lastVhtlcPubkey *btcec.PublicKey
+}
+
+type testIncomingEventReceiver struct {
+	notification *IncomingVHTLCNotification
+}
+
+// WaitOutSwapHtlc is unused when the incoming vHTLC path is available.
+func (r *testIncomingEventReceiver) WaitOutSwapHtlc(context.Context,
+	lntypes.Hash, *btcec.PublicKey) (*OutSwapHtlcNotification, error) {
+
+	return nil, fmt.Errorf("unexpected out-swap wait")
+}
+
+// AckOutSwapHtlc is unused when the incoming vHTLC path is available.
+func (r *testIncomingEventReceiver) AckOutSwapHtlc(context.Context,
+	lntypes.Hash, *btcec.PublicKey, uint64) error {
+
+	return fmt.Errorf("unexpected out-swap ack")
+}
+
+// WaitIncomingVHTLC returns the configured incoming vHTLC notification.
+func (r *testIncomingEventReceiver) WaitIncomingVHTLC(context.Context,
+	lntypes.Hash, *btcec.PublicKey) (*IncomingVHTLCNotification, error) {
+
+	return r.notification, nil
 }
 
 // RequestChannelID returns the preconfigured out-swap route hint.
@@ -254,6 +341,36 @@ func acceptTestOutSwapHtlcEvent(t *testing.T, client *SwapClient,
 	)
 	require.NoError(t, err)
 	require.Equal(t, ReceiveStateHTLCEventAccepted, session.State())
+}
+
+// TestWaitIncomingVHTLCNotificationRejectsMissingAckCursor verifies ack
+// metadata is checked before the event is durably accepted.
+func TestWaitIncomingVHTLCNotificationRejectsMissingAckCursor(t *testing.T) {
+	t.Parallel()
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	ack := func(context.Context) error {
+		return nil
+	}
+	session := &ReceiveSession{
+		client: &SwapClient{
+			outEvents: &testIncomingEventReceiver{
+				notification: &IncomingVHTLCNotification{
+					OutSwap: &OutSwapHtlcEvent{},
+					Ack:     ack,
+				},
+			},
+		},
+		state:        ReceiveStateInvoiceCreated,
+		clientPubKey: clientPriv.PubKey(),
+	}
+
+	_, err = session.waitIncomingVHTLCNotification(t.Context(), nil)
+	require.ErrorContains(t, err, "incoming vHTLC ack cursor")
+	require.Equal(t, ReceiveStateInvoiceCreated, session.State())
+	require.Zero(t, session.pendingHTLCAckCursor)
 }
 
 type testDaemonConn struct {

--- a/swaprpc/swap.pb.go
+++ b/swaprpc/swap.pb.go
@@ -22,6 +22,61 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// SettlementType identifies which settlement path backs a swap negotiation.
+type SettlementType int32
+
+const (
+	// SETTLEMENT_TYPE_UNSPECIFIED is accepted as Lightning for backward
+	// compatibility with older responses.
+	SettlementType_SETTLEMENT_TYPE_UNSPECIFIED SettlementType = 0
+	// SETTLEMENT_TYPE_LIGHTNING means the swap server bridges to Lightning.
+	SettlementType_SETTLEMENT_TYPE_LIGHTNING SettlementType = 1
+	// SETTLEMENT_TYPE_IN_ARK means sender and receiver settle with one Ark
+	// vHTLC inside the same Ark instance.
+	SettlementType_SETTLEMENT_TYPE_IN_ARK SettlementType = 2
+)
+
+// Enum value maps for SettlementType.
+var (
+	SettlementType_name = map[int32]string{
+		0: "SETTLEMENT_TYPE_UNSPECIFIED",
+		1: "SETTLEMENT_TYPE_LIGHTNING",
+		2: "SETTLEMENT_TYPE_IN_ARK",
+	}
+	SettlementType_value = map[string]int32{
+		"SETTLEMENT_TYPE_UNSPECIFIED": 0,
+		"SETTLEMENT_TYPE_LIGHTNING":   1,
+		"SETTLEMENT_TYPE_IN_ARK":      2,
+	}
+)
+
+func (x SettlementType) Enum() *SettlementType {
+	p := new(SettlementType)
+	*p = x
+	return p
+}
+
+func (x SettlementType) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (SettlementType) Descriptor() protoreflect.EnumDescriptor {
+	return file_swap_proto_enumTypes[0].Descriptor()
+}
+
+func (SettlementType) Type() protoreflect.EnumType {
+	return &file_swap_proto_enumTypes[0]
+}
+
+func (x SettlementType) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use SettlementType.Descriptor instead.
+func (SettlementType) EnumDescriptor() ([]byte, []int) {
+	return file_swap_proto_rawDescGZIP(), []int{0}
+}
+
 // RequestChannelIdRequest starts one Lightning-to-Ark receive negotiation.
 type RequestChannelIdRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -219,6 +274,7 @@ type SwapMailboxEvent struct {
 	// Types that are valid to be assigned to Event:
 	//
 	//	*SwapMailboxEvent_OutSwapHtlc
+	//	*SwapMailboxEvent_InArkHtlc
 	Event         isSwapMailboxEvent_Event `protobuf_oneof:"event"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -270,6 +326,15 @@ func (x *SwapMailboxEvent) GetOutSwapHtlc() *OutSwapHtlcEvent {
 	return nil
 }
 
+func (x *SwapMailboxEvent) GetInArkHtlc() *InArkHtlcEvent {
+	if x != nil {
+		if x, ok := x.Event.(*SwapMailboxEvent_InArkHtlc); ok {
+			return x.InArkHtlc
+		}
+	}
+	return nil
+}
+
 type isSwapMailboxEvent_Event interface {
 	isSwapMailboxEvent_Event()
 }
@@ -280,7 +345,111 @@ type SwapMailboxEvent_OutSwapHtlc struct {
 	OutSwapHtlc *OutSwapHtlcEvent `protobuf:"bytes,1,opt,name=out_swap_htlc,json=outSwapHtlc,proto3,oneof"`
 }
 
+type SwapMailboxEvent_InArkHtlc struct {
+	// in_ark_htlc is emitted when a same-Ark sender has funded or
+	// accepted funding for a direct vHTLC.
+	InArkHtlc *InArkHtlcEvent `protobuf:"bytes,2,opt,name=in_ark_htlc,json=inArkHtlc,proto3,oneof"`
+}
+
 func (*SwapMailboxEvent_OutSwapHtlc) isSwapMailboxEvent_Event() {}
+
+func (*SwapMailboxEvent_InArkHtlc) isSwapMailboxEvent_Event() {}
+
+// InArkHtlcEvent describes one same-Ark vHTLC payment coordinated by the swap
+// server. The event is intentionally not onion-shaped: the receiver validates
+// the vHTLC script directly against the invoice payment hash and sender key.
+type InArkHtlcEvent struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// payment_hash is the invoice payment hash.
+	PaymentHash []byte `protobuf:"bytes,1,opt,name=payment_hash,json=paymentHash,proto3" json:"payment_hash,omitempty"`
+	// amount_sat is the whole-satoshi amount funded in the vHTLC.
+	AmountSat uint64 `protobuf:"varint,2,opt,name=amount_sat,json=amountSat,proto3" json:"amount_sat,omitempty"`
+	// sender_pubkey is the payment sender's public key used in the vHTLC
+	// refund paths.
+	SenderPubkey []byte `protobuf:"bytes,3,opt,name=sender_pubkey,json=senderPubkey,proto3" json:"sender_pubkey,omitempty"`
+	// vhtlc_config contains the virtual HTLC parameters the receiver should
+	// use when constructing the expected output.
+	VhtlcConfig *VHTLCConfig `protobuf:"bytes,4,opt,name=vhtlc_config,json=vhtlcConfig,proto3" json:"vhtlc_config,omitempty"`
+	// vhtlc_outpoint is the observed funded vHTLC outpoint, when the server
+	// knows it at notification time.
+	VhtlcOutpoint string `protobuf:"bytes,5,opt,name=vhtlc_outpoint,json=vhtlcOutpoint,proto3" json:"vhtlc_outpoint,omitempty"`
+	// vhtlc_amount_sat is the observed vHTLC amount in satoshis when known.
+	VhtlcAmountSat uint64 `protobuf:"varint,6,opt,name=vhtlc_amount_sat,json=vhtlcAmountSat,proto3" json:"vhtlc_amount_sat,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *InArkHtlcEvent) Reset() {
+	*x = InArkHtlcEvent{}
+	mi := &file_swap_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InArkHtlcEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InArkHtlcEvent) ProtoMessage() {}
+
+func (x *InArkHtlcEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_swap_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InArkHtlcEvent.ProtoReflect.Descriptor instead.
+func (*InArkHtlcEvent) Descriptor() ([]byte, []int) {
+	return file_swap_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *InArkHtlcEvent) GetPaymentHash() []byte {
+	if x != nil {
+		return x.PaymentHash
+	}
+	return nil
+}
+
+func (x *InArkHtlcEvent) GetAmountSat() uint64 {
+	if x != nil {
+		return x.AmountSat
+	}
+	return 0
+}
+
+func (x *InArkHtlcEvent) GetSenderPubkey() []byte {
+	if x != nil {
+		return x.SenderPubkey
+	}
+	return nil
+}
+
+func (x *InArkHtlcEvent) GetVhtlcConfig() *VHTLCConfig {
+	if x != nil {
+		return x.VhtlcConfig
+	}
+	return nil
+}
+
+func (x *InArkHtlcEvent) GetVhtlcOutpoint() string {
+	if x != nil {
+		return x.VhtlcOutpoint
+	}
+	return ""
+}
+
+func (x *InArkHtlcEvent) GetVhtlcAmountSat() uint64 {
+	if x != nil {
+		return x.VhtlcAmountSat
+	}
+	return 0
+}
 
 // RouteHint describes one hop hint for a Lightning invoice route.
 type RouteHint struct {
@@ -301,7 +470,7 @@ type RouteHint struct {
 
 func (x *RouteHint) Reset() {
 	*x = RouteHint{}
-	mi := &file_swap_proto_msgTypes[4]
+	mi := &file_swap_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -313,7 +482,7 @@ func (x *RouteHint) String() string {
 func (*RouteHint) ProtoMessage() {}
 
 func (x *RouteHint) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[4]
+	mi := &file_swap_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -326,7 +495,7 @@ func (x *RouteHint) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RouteHint.ProtoReflect.Descriptor instead.
 func (*RouteHint) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{4}
+	return file_swap_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *RouteHint) GetNodeId() []byte {
@@ -388,7 +557,7 @@ type VHTLCConfig struct {
 
 func (x *VHTLCConfig) Reset() {
 	*x = VHTLCConfig{}
-	mi := &file_swap_proto_msgTypes[5]
+	mi := &file_swap_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -400,7 +569,7 @@ func (x *VHTLCConfig) String() string {
 func (*VHTLCConfig) ProtoMessage() {}
 
 func (x *VHTLCConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[5]
+	mi := &file_swap_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -413,7 +582,7 @@ func (x *VHTLCConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VHTLCConfig.ProtoReflect.Descriptor instead.
 func (*VHTLCConfig) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{5}
+	return file_swap_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *VHTLCConfig) GetRefundLocktime() uint32 {
@@ -467,7 +636,7 @@ type CreateInSwapRequest struct {
 
 func (x *CreateInSwapRequest) Reset() {
 	*x = CreateInSwapRequest{}
-	mi := &file_swap_proto_msgTypes[6]
+	mi := &file_swap_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -479,7 +648,7 @@ func (x *CreateInSwapRequest) String() string {
 func (*CreateInSwapRequest) ProtoMessage() {}
 
 func (x *CreateInSwapRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[6]
+	mi := &file_swap_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -492,7 +661,7 @@ func (x *CreateInSwapRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateInSwapRequest.ProtoReflect.Descriptor instead.
 func (*CreateInSwapRequest) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{6}
+	return file_swap_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *CreateInSwapRequest) GetInvoice() string {
@@ -530,14 +699,17 @@ type CreateInSwapResponse struct {
 	// vhtlc_config contains the negotiated virtual HTLC parameters.
 	VhtlcConfig *VHTLCConfig `protobuf:"bytes,5,opt,name=vhtlc_config,json=vhtlcConfig,proto3" json:"vhtlc_config,omitempty"`
 	// expiry is the wall-clock deadline by which the swap must complete.
-	Expiry        *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=expiry,proto3" json:"expiry,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Expiry *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=expiry,proto3" json:"expiry,omitempty"`
+	// settlement_type identifies whether this negotiation should be completed
+	// through Lightning or directly inside the Ark instance.
+	SettlementType SettlementType `protobuf:"varint,7,opt,name=settlement_type,json=settlementType,proto3,enum=swaprpc.SettlementType" json:"settlement_type,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *CreateInSwapResponse) Reset() {
 	*x = CreateInSwapResponse{}
-	mi := &file_swap_proto_msgTypes[7]
+	mi := &file_swap_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -549,7 +721,7 @@ func (x *CreateInSwapResponse) String() string {
 func (*CreateInSwapResponse) ProtoMessage() {}
 
 func (x *CreateInSwapResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[7]
+	mi := &file_swap_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -562,7 +734,7 @@ func (x *CreateInSwapResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateInSwapResponse.ProtoReflect.Descriptor instead.
 func (*CreateInSwapResponse) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{7}
+	return file_swap_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *CreateInSwapResponse) GetPaymentHash() []byte {
@@ -607,6 +779,13 @@ func (x *CreateInSwapResponse) GetExpiry() *timestamppb.Timestamp {
 	return nil
 }
 
+func (x *CreateInSwapResponse) GetSettlementType() SettlementType {
+	if x != nil {
+		return x.SettlementType
+	}
+	return SettlementType_SETTLEMENT_TYPE_UNSPECIFIED
+}
+
 var File_swap_proto protoreflect.FileDescriptor
 
 const file_swap_proto_rawDesc = "" +
@@ -626,10 +805,19 @@ const file_swap_proto_rawDesc = "" +
 	"amount_sat\x18\x02 \x01(\x04R\tamountSat\x12\x1d\n" +
 	"\n" +
 	"onion_blob\x18\x03 \x01(\fR\tonionBlob\x127\n" +
-	"\fvhtlc_config\x18\x04 \x01(\v2\x14.swaprpc.VHTLCConfigR\vvhtlcConfig\"\\\n" +
+	"\fvhtlc_config\x18\x04 \x01(\v2\x14.swaprpc.VHTLCConfigR\vvhtlcConfig\"\x97\x01\n" +
 	"\x10SwapMailboxEvent\x12?\n" +
-	"\rout_swap_htlc\x18\x01 \x01(\v2\x19.swaprpc.OutSwapHtlcEventH\x00R\voutSwapHtlcB\a\n" +
-	"\x05event\"\xc5\x01\n" +
+	"\rout_swap_htlc\x18\x01 \x01(\v2\x19.swaprpc.OutSwapHtlcEventH\x00R\voutSwapHtlc\x129\n" +
+	"\vin_ark_htlc\x18\x02 \x01(\v2\x17.swaprpc.InArkHtlcEventH\x00R\tinArkHtlcB\a\n" +
+	"\x05event\"\x81\x02\n" +
+	"\x0eInArkHtlcEvent\x12!\n" +
+	"\fpayment_hash\x18\x01 \x01(\fR\vpaymentHash\x12\x1d\n" +
+	"\n" +
+	"amount_sat\x18\x02 \x01(\x04R\tamountSat\x12#\n" +
+	"\rsender_pubkey\x18\x03 \x01(\fR\fsenderPubkey\x127\n" +
+	"\fvhtlc_config\x18\x04 \x01(\v2\x14.swaprpc.VHTLCConfigR\vvhtlcConfig\x12%\n" +
+	"\x0evhtlc_outpoint\x18\x05 \x01(\tR\rvhtlcOutpoint\x12(\n" +
+	"\x10vhtlc_amount_sat\x18\x06 \x01(\x04R\x0evhtlcAmountSat\"\xc5\x01\n" +
 	"\tRouteHint\x12\x17\n" +
 	"\anode_id\x18\x01 \x01(\fR\x06nodeId\x12\x1d\n" +
 	"\n" +
@@ -646,7 +834,7 @@ const file_swap_proto_rawDesc = "" +
 	"\x13CreateInSwapRequest\x12\x18\n" +
 	"\ainvoice\x18\x01 \x01(\tR\ainvoice\x12\x1e\n" +
 	"\vmax_fee_sat\x18\x02 \x01(\x04R\tmaxFeeSat\x12.\n" +
-	"\x13client_vhtlc_pubkey\x18\x03 \x01(\fR\x11clientVhtlcPubkey\"\x83\x02\n" +
+	"\x13client_vhtlc_pubkey\x18\x03 \x01(\fR\x11clientVhtlcPubkey\"\xc5\x02\n" +
 	"\x14CreateInSwapResponse\x12!\n" +
 	"\fpayment_hash\x18\x01 \x01(\fR\vpaymentHash\x12\x1d\n" +
 	"\n" +
@@ -654,7 +842,12 @@ const file_swap_proto_rawDesc = "" +
 	"\afee_sat\x18\x03 \x01(\x04R\x06feeSat\x12#\n" +
 	"\rserver_pubkey\x18\x04 \x01(\fR\fserverPubkey\x127\n" +
 	"\fvhtlc_config\x18\x05 \x01(\v2\x14.swaprpc.VHTLCConfigR\vvhtlcConfig\x122\n" +
-	"\x06expiry\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\x06expiry2\xb3\x01\n" +
+	"\x06expiry\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\x06expiry\x12@\n" +
+	"\x0fsettlement_type\x18\a \x01(\x0e2\x17.swaprpc.SettlementTypeR\x0esettlementType*l\n" +
+	"\x0eSettlementType\x12\x1f\n" +
+	"\x1bSETTLEMENT_TYPE_UNSPECIFIED\x10\x00\x12\x1d\n" +
+	"\x19SETTLEMENT_TYPE_LIGHTNING\x10\x01\x12\x1a\n" +
+	"\x16SETTLEMENT_TYPE_IN_ARK\x10\x022\xb3\x01\n" +
 	"\vSwapService\x12W\n" +
 	"\x10RequestChannelId\x12 .swaprpc.RequestChannelIdRequest\x1a!.swaprpc.RequestChannelIdResponse\x12K\n" +
 	"\fCreateInSwap\x12\x1c.swaprpc.CreateInSwapRequest\x1a\x1d.swaprpc.CreateInSwapResponseB0Z.github.com/lightninglabs/darepo-client/swaprpcb\x06proto3"
@@ -671,33 +864,39 @@ func file_swap_proto_rawDescGZIP() []byte {
 	return file_swap_proto_rawDescData
 }
 
-var file_swap_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
+var file_swap_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_swap_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
 var file_swap_proto_goTypes = []any{
-	(*RequestChannelIdRequest)(nil),  // 0: swaprpc.RequestChannelIdRequest
-	(*RequestChannelIdResponse)(nil), // 1: swaprpc.RequestChannelIdResponse
-	(*OutSwapHtlcEvent)(nil),         // 2: swaprpc.OutSwapHtlcEvent
-	(*SwapMailboxEvent)(nil),         // 3: swaprpc.SwapMailboxEvent
-	(*RouteHint)(nil),                // 4: swaprpc.RouteHint
-	(*VHTLCConfig)(nil),              // 5: swaprpc.VHTLCConfig
-	(*CreateInSwapRequest)(nil),      // 6: swaprpc.CreateInSwapRequest
-	(*CreateInSwapResponse)(nil),     // 7: swaprpc.CreateInSwapResponse
-	(*timestamppb.Timestamp)(nil),    // 8: google.protobuf.Timestamp
+	(SettlementType)(0),              // 0: swaprpc.SettlementType
+	(*RequestChannelIdRequest)(nil),  // 1: swaprpc.RequestChannelIdRequest
+	(*RequestChannelIdResponse)(nil), // 2: swaprpc.RequestChannelIdResponse
+	(*OutSwapHtlcEvent)(nil),         // 3: swaprpc.OutSwapHtlcEvent
+	(*SwapMailboxEvent)(nil),         // 4: swaprpc.SwapMailboxEvent
+	(*InArkHtlcEvent)(nil),           // 5: swaprpc.InArkHtlcEvent
+	(*RouteHint)(nil),                // 6: swaprpc.RouteHint
+	(*VHTLCConfig)(nil),              // 7: swaprpc.VHTLCConfig
+	(*CreateInSwapRequest)(nil),      // 8: swaprpc.CreateInSwapRequest
+	(*CreateInSwapResponse)(nil),     // 9: swaprpc.CreateInSwapResponse
+	(*timestamppb.Timestamp)(nil),    // 10: google.protobuf.Timestamp
 }
 var file_swap_proto_depIdxs = []int32{
-	4, // 0: swaprpc.RequestChannelIdResponse.route_hint:type_name -> swaprpc.RouteHint
-	5, // 1: swaprpc.OutSwapHtlcEvent.vhtlc_config:type_name -> swaprpc.VHTLCConfig
-	2, // 2: swaprpc.SwapMailboxEvent.out_swap_htlc:type_name -> swaprpc.OutSwapHtlcEvent
-	5, // 3: swaprpc.CreateInSwapResponse.vhtlc_config:type_name -> swaprpc.VHTLCConfig
-	8, // 4: swaprpc.CreateInSwapResponse.expiry:type_name -> google.protobuf.Timestamp
-	0, // 5: swaprpc.SwapService.RequestChannelId:input_type -> swaprpc.RequestChannelIdRequest
-	6, // 6: swaprpc.SwapService.CreateInSwap:input_type -> swaprpc.CreateInSwapRequest
-	1, // 7: swaprpc.SwapService.RequestChannelId:output_type -> swaprpc.RequestChannelIdResponse
-	7, // 8: swaprpc.SwapService.CreateInSwap:output_type -> swaprpc.CreateInSwapResponse
-	7, // [7:9] is the sub-list for method output_type
-	5, // [5:7] is the sub-list for method input_type
-	5, // [5:5] is the sub-list for extension type_name
-	5, // [5:5] is the sub-list for extension extendee
-	0, // [0:5] is the sub-list for field type_name
+	6,  // 0: swaprpc.RequestChannelIdResponse.route_hint:type_name -> swaprpc.RouteHint
+	7,  // 1: swaprpc.OutSwapHtlcEvent.vhtlc_config:type_name -> swaprpc.VHTLCConfig
+	3,  // 2: swaprpc.SwapMailboxEvent.out_swap_htlc:type_name -> swaprpc.OutSwapHtlcEvent
+	5,  // 3: swaprpc.SwapMailboxEvent.in_ark_htlc:type_name -> swaprpc.InArkHtlcEvent
+	7,  // 4: swaprpc.InArkHtlcEvent.vhtlc_config:type_name -> swaprpc.VHTLCConfig
+	7,  // 5: swaprpc.CreateInSwapResponse.vhtlc_config:type_name -> swaprpc.VHTLCConfig
+	10, // 6: swaprpc.CreateInSwapResponse.expiry:type_name -> google.protobuf.Timestamp
+	0,  // 7: swaprpc.CreateInSwapResponse.settlement_type:type_name -> swaprpc.SettlementType
+	1,  // 8: swaprpc.SwapService.RequestChannelId:input_type -> swaprpc.RequestChannelIdRequest
+	8,  // 9: swaprpc.SwapService.CreateInSwap:input_type -> swaprpc.CreateInSwapRequest
+	2,  // 10: swaprpc.SwapService.RequestChannelId:output_type -> swaprpc.RequestChannelIdResponse
+	9,  // 11: swaprpc.SwapService.CreateInSwap:output_type -> swaprpc.CreateInSwapResponse
+	10, // [10:12] is the sub-list for method output_type
+	8,  // [8:10] is the sub-list for method input_type
+	8,  // [8:8] is the sub-list for extension type_name
+	8,  // [8:8] is the sub-list for extension extendee
+	0,  // [0:8] is the sub-list for field type_name
 }
 
 func init() { file_swap_proto_init() }
@@ -707,19 +906,21 @@ func file_swap_proto_init() {
 	}
 	file_swap_proto_msgTypes[3].OneofWrappers = []any{
 		(*SwapMailboxEvent_OutSwapHtlc)(nil),
+		(*SwapMailboxEvent_InArkHtlc)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_swap_proto_rawDesc), len(file_swap_proto_rawDesc)),
-			NumEnums:      0,
-			NumMessages:   8,
+			NumEnums:      1,
+			NumMessages:   9,
 			NumExtensions: 0,
 			NumServices:   1,
 		},
 		GoTypes:           file_swap_proto_goTypes,
 		DependencyIndexes: file_swap_proto_depIdxs,
+		EnumInfos:         file_swap_proto_enumTypes,
 		MessageInfos:      file_swap_proto_msgTypes,
 	}.Build()
 	File_swap_proto = out.File

--- a/swaprpc/swap.proto
+++ b/swaprpc/swap.proto
@@ -6,6 +6,20 @@ option go_package = "github.com/lightninglabs/darepo-client/swaprpc";
 
 import "google/protobuf/timestamp.proto";
 
+// SettlementType identifies which settlement path backs a swap negotiation.
+enum SettlementType {
+    // SETTLEMENT_TYPE_UNSPECIFIED is accepted as Lightning for backward
+    // compatibility with older responses.
+    SETTLEMENT_TYPE_UNSPECIFIED = 0;
+
+    // SETTLEMENT_TYPE_LIGHTNING means the swap server bridges to Lightning.
+    SETTLEMENT_TYPE_LIGHTNING = 1;
+
+    // SETTLEMENT_TYPE_IN_ARK means sender and receiver settle with one Ark
+    // vHTLC inside the same Ark instance.
+    SETTLEMENT_TYPE_IN_ARK = 2;
+}
+
 // SwapService exposes the external swap server API consumed by the client SDK.
 service SwapService {
     // RequestChannelId asks the swap server to allocate a short channel ID and
@@ -66,7 +80,37 @@ message SwapMailboxEvent {
         // out_swap_htlc is emitted when the server has funded or accepted
         // funding for an out-swap HTLC.
         OutSwapHtlcEvent out_swap_htlc = 1;
+
+        // in_ark_htlc is emitted when a same-Ark sender has funded or
+        // accepted funding for a direct vHTLC.
+        InArkHtlcEvent in_ark_htlc = 2;
     }
+}
+
+// InArkHtlcEvent describes one same-Ark vHTLC payment coordinated by the swap
+// server. The event is intentionally not onion-shaped: the receiver validates
+// the vHTLC script directly against the invoice payment hash and sender key.
+message InArkHtlcEvent {
+    // payment_hash is the invoice payment hash.
+    bytes payment_hash = 1;
+
+    // amount_sat is the whole-satoshi amount funded in the vHTLC.
+    uint64 amount_sat = 2;
+
+    // sender_pubkey is the payment sender's public key used in the vHTLC
+    // refund paths.
+    bytes sender_pubkey = 3;
+
+    // vhtlc_config contains the virtual HTLC parameters the receiver should
+    // use when constructing the expected output.
+    VHTLCConfig vhtlc_config = 4;
+
+    // vhtlc_outpoint is the observed funded vHTLC outpoint, when the server
+    // knows it at notification time.
+    string vhtlc_outpoint = 5;
+
+    // vhtlc_amount_sat is the observed vHTLC amount in satoshis when known.
+    uint64 vhtlc_amount_sat = 6;
 }
 
 // RouteHint describes one hop hint for a Lightning invoice route.
@@ -142,4 +186,8 @@ message CreateInSwapResponse {
 
     // expiry is the wall-clock deadline by which the swap must complete.
     google.protobuf.Timestamp expiry = 6;
+
+    // settlement_type identifies whether this negotiation should be completed
+    // through Lightning or directly inside the Ark instance.
+    SettlementType settlement_type = 7;
 }


### PR DESCRIPTION
## Summary
- add swaprpc settlement typing and a dedicated in-Ark vHTLC event payload
- teach the SDK to receive either Lightning out-swap events or direct same-Ark vHTLC events
- validate direct p2p vHTLC policy construction without requiring an onion payload

## Testing
- make commitmsg-lint range=HEAD~3..HEAD
- git diff --check
- go test ./sdk/swaps -run TestAcceptInArkHtlcEventBuildsSenderReceiverPolicy -count=1
- go test ./sdk/swaps -run "^$"

Note: a full `go test ./sdk/swaps` was attempted after rebasing and hit `TestPaySessionResumeFundingGraceEventuallyRetries`; the focused p2p test and package compile check pass.