### PR TITLE
daemonrpc: add operation status endpoints

### DIFF
--- a/cmd/darepocli/darepoclicommands/AGENTS.md
+++ b/cmd/darepocli/darepoclicommands/AGENTS.md
@@ -17,13 +17,15 @@ embed the same command tree.
 | Command | RPC | Description |
 |---------|-----|-------------|
 | `board` | `Board` | Trigger boarding with confirmed UTXOs |
-| `rounds list` | `ListRounds` | List round FSM states with pagination |
+| `rounds get` | `GetRound` | Fetch one round by server-assigned round id |
+| `rounds list` | `ListRounds` | List round FSM states with pagination and optional state/time filters |
 | `rounds watch` | `WatchRounds` | Stream round state updates |
 | `vtxos list` | `ListVTXOs` | List wallet VTXOs |
 | `send` | `SendVTXO` / `SendOOR` | Send to address |
 | `balance` | `GetBalance` | Show wallet balances |
 | `oor receive` | `NewReceiveScript` | Register a new receive script and print the receive address |
-| `oor list` | `ListOORSessions` | List locally persisted OOR sessions; `--pending` filters to non-terminal sessions; `--direction` accepts `all`/`outgoing`/`incoming` |
+| `oor get` | `GetOORSession` | Fetch one locally known OOR session by session id |
+| `oor list` | `ListOORSessions` | List locally known OOR sessions; `--status` accepts `all`/`pending`/`completed`/`failed`; `--direction` accepts `all`/`outgoing`/`incoming` |
 | `fees estimate` | `EstimateFee` | Print an itemized fee breakdown for a given VTXO amount; flags a dust-level amount on stderr |
 | `fees history` | `GetFeeHistory` | Paginate the client-side ledger entries and print the cumulative operator fee total |
 | `unroll` | `Unroll` | Trigger a unilateral exit for the VTXO at `--outpoint txid:index`. Routes through the VTXO manager's `ForceUnrollRequest` path so the FSM transitions cleanly; the registry job is created async via the chain resolver seam. Response includes `Created` (false if already exiting) and the `ActorId` to poll. |

--- a/cmd/darepocli/darepoclicommands/CLAUDE.md
+++ b/cmd/darepocli/darepoclicommands/CLAUDE.md
@@ -17,13 +17,15 @@ embed the same command tree.
 | Command | RPC | Description |
 |---------|-----|-------------|
 | `board` | `Board` | Trigger boarding with confirmed UTXOs |
-| `rounds list` | `ListRounds` | List round FSM states with pagination |
+| `rounds get` | `GetRound` | Fetch one round by server-assigned round id |
+| `rounds list` | `ListRounds` | List round FSM states with pagination and optional state/time filters |
 | `rounds watch` | `WatchRounds` | Stream round state updates |
 | `vtxos list` | `ListVTXOs` | List wallet VTXOs |
 | `send` | `SendVTXO` / `SendOOR` | Send to address |
 | `balance` | `GetBalance` | Show wallet balances |
 | `oor receive` | `NewReceiveScript` | Register a new receive script and print the receive address |
-| `oor list` | `ListOORSessions` | List locally persisted OOR sessions; `--pending` filters to non-terminal sessions; `--direction` accepts `all`/`outgoing`/`incoming` |
+| `oor get` | `GetOORSession` | Fetch one locally known OOR session by session id |
+| `oor list` | `ListOORSessions` | List locally known OOR sessions; `--status` accepts `all`/`pending`/`completed`/`failed`; `--direction` accepts `all`/`outgoing`/`incoming` |
 | `fees estimate` | `EstimateFee` | Print an itemized fee breakdown for a given VTXO amount; flags a dust-level amount on stderr |
 | `fees history` | `GetFeeHistory` | Paginate the client-side ledger entries and print the cumulative operator fee total |
 | `unroll` | `Unroll` | Trigger a unilateral exit for the VTXO at `--outpoint txid:index`. Routes through the VTXO manager's `ForceUnrollRequest` path so the FSM transitions cleanly; the registry job is created async via the chain resolver seam. Response includes `Created` (false if already exiting) and the `ActorId` to poll. |

--- a/cmd/darepocli/darepoclicommands/cmd_oor.go
+++ b/cmd/darepocli/darepoclicommands/cmd_oor.go
@@ -18,8 +18,44 @@ func newOORCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(
+		newOORGetCmd(),
+		newOORListCmd(),
 		newOORReceiveCmd(),
 	)
+
+	return cmd
+}
+
+// newOORGetCmd creates the oor get subcommand.
+func newOORGetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get",
+		Short: "Get one OOR session status",
+		RunE:  oorGet,
+	}
+
+	cmd.Flags().String("session-id", "",
+		"OOR session id to fetch")
+
+	return cmd
+}
+
+// newOORListCmd creates the oor list subcommand.
+func newOORListCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List OOR session statuses",
+		RunE:  oorList,
+	}
+
+	cmd.Flags().String("direction", "all",
+		"direction filter: all, outgoing, or incoming")
+	cmd.Flags().String("status", "all",
+		"status filter: all, pending, completed, or failed")
+	cmd.Flags().Int32("page-size", 0,
+		"maximum number of sessions to return")
+	cmd.Flags().String("page-token", "",
+		"cursor from a previous response for pagination")
 
 	return cmd
 }
@@ -39,6 +75,79 @@ func newOORReceiveCmd() *cobra.Command {
 		"optional label stored with the receive-script registration")
 
 	return cmd
+}
+
+// oorGet executes the GetOORSession RPC.
+func oorGet(cmd *cobra.Command, _ []string) error {
+	client, conn, err := getDaemonClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	req := &daemonrpc.GetOORSessionRequest{}
+	if err := parseRequest(cmd, req, func() error {
+		sessionID, _ := cmd.Flags().GetString("session-id")
+		req.SessionId = sessionID
+
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	resp, err := client.GetOORSession(context.Background(), req)
+	if err != nil {
+		return fmt.Errorf("GetOORSession RPC failed: %w", err)
+	}
+
+	return printJSON(resp)
+}
+
+// oorList executes the ListOORSessions RPC.
+func oorList(cmd *cobra.Command, _ []string) error {
+	client, conn, err := getDaemonClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	req := &daemonrpc.ListOORSessionsRequest{}
+	if err := parseRequest(cmd, req, func() error {
+		direction, _ := cmd.Flags().GetString("direction")
+		directionFilter, err := parseOORDirectionFilter(direction)
+		if err != nil {
+			return err
+		}
+		req.DirectionFilter = directionFilter
+
+		status, _ := cmd.Flags().GetString("status")
+		statusFilter, err := parseOORStatusFilter(status)
+		if err != nil {
+			return err
+		}
+		req.StatusFilter = statusFilter
+
+		pageSize, _ := cmd.Flags().GetInt32("page-size")
+		req.PageSize = pageSize
+
+		pageToken, _ := cmd.Flags().GetString("page-token")
+		req.PageToken = pageToken
+
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	resp, err := client.ListOORSessions(context.Background(), req)
+	if err != nil {
+		return fmt.Errorf("ListOORSessions RPC failed: %w", err)
+	}
+
+	return printJSON(resp)
 }
 
 // oorReceive executes the NewReceiveScript RPC.
@@ -69,4 +178,61 @@ func oorReceive(cmd *cobra.Command, _ []string) error {
 	}
 
 	return printJSON(resp)
+}
+
+// parseOORDirectionFilter converts a CLI direction filter into the proto enum.
+func parseOORDirectionFilter(
+	direction string) (daemonrpc.OORSessionDirection, error) {
+
+	unspecified := daemonrpc.
+		OORSessionDirection_OOR_SESSION_DIRECTION_UNSPECIFIED
+	outgoing := daemonrpc.
+		OORSessionDirection_OOR_SESSION_DIRECTION_OUTGOING
+	incoming := daemonrpc.
+		OORSessionDirection_OOR_SESSION_DIRECTION_INCOMING
+
+	switch direction {
+	case "", "all":
+		return unspecified, nil
+
+	case "outgoing":
+		return outgoing, nil
+
+	case "incoming":
+		return incoming, nil
+
+	default:
+		return unspecified, fmt.Errorf(
+			"unknown OOR direction filter: %s", direction,
+		)
+	}
+}
+
+// parseOORStatusFilter converts a CLI status filter into the proto enum.
+func parseOORStatusFilter(
+	status string) (daemonrpc.OORSessionStatus, error) {
+
+	unspecified := daemonrpc.OORSessionStatus_OOR_SESSION_STATUS_UNSPECIFIED
+	pending := daemonrpc.OORSessionStatus_OOR_SESSION_STATUS_PENDING
+	completed := daemonrpc.OORSessionStatus_OOR_SESSION_STATUS_COMPLETED
+	failed := daemonrpc.OORSessionStatus_OOR_SESSION_STATUS_FAILED
+
+	switch status {
+	case "", "all":
+		return unspecified, nil
+
+	case "pending":
+		return pending, nil
+
+	case "completed":
+		return completed, nil
+
+	case "failed":
+		return failed, nil
+
+	default:
+		return unspecified, fmt.Errorf(
+			"unknown OOR status filter: %s", status,
+		)
+	}
 }

--- a/cmd/darepocli/darepoclicommands/cmd_operation_status_test.go
+++ b/cmd/darepocli/darepoclicommands/cmd_operation_status_test.go
@@ -1,0 +1,56 @@
+package darepoclicommands
+
+import (
+	"testing"
+
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseOORFilters verifies user-facing OOR filter names map to proto.
+func TestParseOORFilters(t *testing.T) {
+	t.Parallel()
+
+	direction, err := parseOORDirectionFilter("incoming")
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		daemonrpc.OORSessionDirection_OOR_SESSION_DIRECTION_INCOMING,
+		direction,
+	)
+
+	status, err := parseOORStatusFilter("failed")
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		daemonrpc.OORSessionStatus_OOR_SESSION_STATUS_FAILED,
+		status,
+	)
+
+	_, err = parseOORDirectionFilter("sideways")
+	require.ErrorContains(t, err, "unknown OOR direction")
+
+	_, err = parseOORStatusFilter("mystery")
+	require.ErrorContains(t, err, "unknown OOR status")
+}
+
+// TestParseRoundStateFilter verifies user-facing round state names map to
+// proto.
+func TestParseRoundStateFilter(t *testing.T) {
+	t.Parallel()
+
+	state, err := parseRoundStateFilter("confirmed")
+	require.NoError(t, err)
+	require.Equal(
+		t, daemonrpc.RoundState_ROUND_STATE_CONFIRMED, state,
+	)
+
+	state, err = parseRoundStateFilter("partial_sigs_sent")
+	require.NoError(t, err)
+	require.Equal(
+		t, daemonrpc.RoundState_ROUND_STATE_PARTIAL_SIGS_SENT, state,
+	)
+
+	_, err = parseRoundStateFilter("definitely_not_a_state")
+	require.ErrorContains(t, err, "unknown round state")
+}

--- a/cmd/darepocli/darepoclicommands/cmd_rounds.go
+++ b/cmd/darepocli/darepoclicommands/cmd_rounds.go
@@ -23,9 +23,24 @@ func newRoundsCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(
+		newRoundsGetCmd(),
 		newRoundsListCmd(),
 		newRoundsWatchCmd(),
 	)
+
+	return cmd
+}
+
+// newRoundsGetCmd creates the 'rounds get' subcommand.
+func newRoundsGetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get",
+		Short: "Get one round status",
+		RunE:  roundsGet,
+	}
+
+	cmd.Flags().String("round-id", "",
+		"server-assigned round id to fetch")
 
 	return cmd
 }
@@ -44,6 +59,12 @@ func newRoundsListCmd() *cobra.Command {
 		"maximum number of persisted rounds to return")
 	cmd.Flags().String("page-token", "",
 		"cursor from a previous response for pagination")
+	cmd.Flags().String("state", "",
+		"optional state filter, for example confirmed or failed")
+	cmd.Flags().Int64("created-after", 0,
+		"only show persisted rounds created at or after this Unix time")
+	cmd.Flags().Int64("created-before", 0,
+		"only show persisted rounds created before this Unix time")
 
 	return cmd
 }
@@ -60,13 +81,45 @@ func newRoundsWatchCmd() *cobra.Command {
 	}
 }
 
+// roundsGet executes the GetRound RPC and prints the result.
+func roundsGet(cmd *cobra.Command, _ []string) error {
+	client, conn, err := getDaemonClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	req := &daemonrpc.GetRoundRequest{}
+	fromFlags := func() error {
+		roundID, _ := cmd.Flags().GetString("round-id")
+		req.RoundId = roundID
+
+		return nil
+	}
+
+	if err := parseRequest(cmd, req, fromFlags); err != nil {
+		return err
+	}
+
+	resp, err := client.GetRound(context.Background(), req)
+	if err != nil {
+		return fmt.Errorf("GetRound RPC failed: %w", err)
+	}
+
+	return printJSON(resp)
+}
+
 // roundsList executes the ListRounds RPC and prints the result.
 func roundsList(cmd *cobra.Command, _ []string) error {
 	client, conn, err := getDaemonClient(cmd)
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
+	defer func() {
+		_ = conn.Close()
+	}()
 
 	req := &daemonrpc.ListRoundsRequest{}
 	fromFlags := func() error {
@@ -78,6 +131,19 @@ func roundsList(cmd *cobra.Command, _ []string) error {
 
 		pageToken, _ := cmd.Flags().GetString("page-token")
 		req.PageToken = pageToken
+
+		state, _ := cmd.Flags().GetString("state")
+		filter, err := parseRoundStateFilter(state)
+		if err != nil {
+			return err
+		}
+		req.StateFilter = filter
+
+		createdAfter, _ := cmd.Flags().GetInt64("created-after")
+		req.CreatedAfter = createdAfter
+
+		createdBefore, _ := cmd.Flags().GetInt64("created-before")
+		req.CreatedBefore = createdBefore
 
 		return nil
 	}
@@ -123,5 +189,63 @@ func roundsWatch(cmd *cobra.Command, _ []string) error {
 		if err := printJSON(resp); err != nil {
 			return err
 		}
+	}
+}
+
+// parseRoundStateFilter converts a CLI state filter into the proto enum.
+func parseRoundStateFilter(state string) (daemonrpc.RoundState, error) {
+	switch state {
+	case "", "all":
+		return daemonrpc.RoundState_ROUND_STATE_UNKNOWN, nil
+
+	case "idle":
+		return daemonrpc.RoundState_ROUND_STATE_IDLE, nil
+
+	case "pending_assembly":
+		return daemonrpc.RoundState_ROUND_STATE_PENDING_ASSEMBLY, nil
+
+	case "registration_sent":
+		return daemonrpc.RoundState_ROUND_STATE_REGISTRATION_SENT, nil
+
+	case "quote_received":
+		return daemonrpc.RoundState_ROUND_STATE_QUOTE_RECEIVED, nil
+
+	case "joined":
+		return daemonrpc.RoundState_ROUND_STATE_JOINED, nil
+
+	case "commitment_received":
+		return daemonrpc.RoundState_ROUND_STATE_COMMITMENT_RECEIVED, nil
+
+	case "commitment_validated":
+		return daemonrpc.RoundState_ROUND_STATE_COMMITMENT_VALIDATED,
+			nil
+
+	case "forfeit_collecting":
+		return daemonrpc.RoundState_ROUND_STATE_FORFEIT_COLLECTING, nil
+
+	case "nonces_sent":
+		return daemonrpc.RoundState_ROUND_STATE_NONCES_SENT, nil
+
+	case "nonces_aggregated":
+		return daemonrpc.RoundState_ROUND_STATE_NONCES_AGGREGATED, nil
+
+	case "partial_sigs_sent":
+		return daemonrpc.RoundState_ROUND_STATE_PARTIAL_SIGS_SENT, nil
+
+	case "input_sig_sent":
+		return daemonrpc.RoundState_ROUND_STATE_INPUT_SIG_SENT, nil
+
+	case "confirmed":
+		return daemonrpc.RoundState_ROUND_STATE_CONFIRMED, nil
+
+	case "failed":
+		return daemonrpc.RoundState_ROUND_STATE_FAILED, nil
+
+	case "recovery":
+		return daemonrpc.RoundState_ROUND_STATE_RECOVERY, nil
+
+	default:
+		return daemonrpc.RoundState_ROUND_STATE_UNKNOWN,
+			fmt.Errorf("unknown round state filter: %s", state)
 	}
 }

--- a/daemonrpc/daemon.pb.go
+++ b/daemonrpc/daemon.pb.go
@@ -226,6 +226,107 @@ func (RoundState) EnumDescriptor() ([]byte, []int) {
 	return file_daemon_proto_rawDescGZIP(), []int{1}
 }
 
+type OORSessionDirection int32
+
+const (
+	OORSessionDirection_OOR_SESSION_DIRECTION_UNSPECIFIED OORSessionDirection = 0
+	OORSessionDirection_OOR_SESSION_DIRECTION_OUTGOING    OORSessionDirection = 1
+	OORSessionDirection_OOR_SESSION_DIRECTION_INCOMING    OORSessionDirection = 2
+)
+
+// Enum value maps for OORSessionDirection.
+var (
+	OORSessionDirection_name = map[int32]string{
+		0: "OOR_SESSION_DIRECTION_UNSPECIFIED",
+		1: "OOR_SESSION_DIRECTION_OUTGOING",
+		2: "OOR_SESSION_DIRECTION_INCOMING",
+	}
+	OORSessionDirection_value = map[string]int32{
+		"OOR_SESSION_DIRECTION_UNSPECIFIED": 0,
+		"OOR_SESSION_DIRECTION_OUTGOING":    1,
+		"OOR_SESSION_DIRECTION_INCOMING":    2,
+	}
+)
+
+func (x OORSessionDirection) Enum() *OORSessionDirection {
+	p := new(OORSessionDirection)
+	*p = x
+	return p
+}
+
+func (x OORSessionDirection) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (OORSessionDirection) Descriptor() protoreflect.EnumDescriptor {
+	return file_daemon_proto_enumTypes[2].Descriptor()
+}
+
+func (OORSessionDirection) Type() protoreflect.EnumType {
+	return &file_daemon_proto_enumTypes[2]
+}
+
+func (x OORSessionDirection) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use OORSessionDirection.Descriptor instead.
+func (OORSessionDirection) EnumDescriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{2}
+}
+
+type OORSessionStatus int32
+
+const (
+	OORSessionStatus_OOR_SESSION_STATUS_UNSPECIFIED OORSessionStatus = 0
+	OORSessionStatus_OOR_SESSION_STATUS_PENDING     OORSessionStatus = 1
+	OORSessionStatus_OOR_SESSION_STATUS_COMPLETED   OORSessionStatus = 2
+	OORSessionStatus_OOR_SESSION_STATUS_FAILED      OORSessionStatus = 3
+)
+
+// Enum value maps for OORSessionStatus.
+var (
+	OORSessionStatus_name = map[int32]string{
+		0: "OOR_SESSION_STATUS_UNSPECIFIED",
+		1: "OOR_SESSION_STATUS_PENDING",
+		2: "OOR_SESSION_STATUS_COMPLETED",
+		3: "OOR_SESSION_STATUS_FAILED",
+	}
+	OORSessionStatus_value = map[string]int32{
+		"OOR_SESSION_STATUS_UNSPECIFIED": 0,
+		"OOR_SESSION_STATUS_PENDING":     1,
+		"OOR_SESSION_STATUS_COMPLETED":   2,
+		"OOR_SESSION_STATUS_FAILED":      3,
+	}
+)
+
+func (x OORSessionStatus) Enum() *OORSessionStatus {
+	p := new(OORSessionStatus)
+	*p = x
+	return p
+}
+
+func (x OORSessionStatus) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (OORSessionStatus) Descriptor() protoreflect.EnumDescriptor {
+	return file_daemon_proto_enumTypes[3].Descriptor()
+}
+
+func (OORSessionStatus) Type() protoreflect.EnumType {
+	return &file_daemon_proto_enumTypes[3]
+}
+
+func (x OORSessionStatus) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use OORSessionStatus.Descriptor instead.
+func (OORSessionStatus) EnumDescriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{3}
+}
+
 // UnrollJobStatus represents the high-level phase of an unroll job.
 type UnrollJobStatus int32
 
@@ -284,11 +385,11 @@ func (x UnrollJobStatus) String() string {
 }
 
 func (UnrollJobStatus) Descriptor() protoreflect.EnumDescriptor {
-	return file_daemon_proto_enumTypes[2].Descriptor()
+	return file_daemon_proto_enumTypes[4].Descriptor()
 }
 
 func (UnrollJobStatus) Type() protoreflect.EnumType {
-	return &file_daemon_proto_enumTypes[2]
+	return &file_daemon_proto_enumTypes[4]
 }
 
 func (x UnrollJobStatus) Number() protoreflect.EnumNumber {
@@ -297,7 +398,7 @@ func (x UnrollJobStatus) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use UnrollJobStatus.Descriptor instead.
 func (UnrollJobStatus) EnumDescriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{2}
+	return file_daemon_proto_rawDescGZIP(), []int{4}
 }
 
 type GetInfoRequest struct {
@@ -2872,7 +2973,28 @@ type RoundInfo struct {
 	// vtxos lists the VTXOs created by this round. Only populated
 	// for persisted rounds (input_sig_sent, confirmed). Empty for
 	// pending/in-memory rounds.
-	Vtxos         []*RoundVTXOInfo `protobuf:"bytes,4,rep,name=vtxos,proto3" json:"vtxos,omitempty"`
+	Vtxos []*RoundVTXOInfo `protobuf:"bytes,4,rep,name=vtxos,proto3" json:"vtxos,omitempty"`
+	// commitment_txid is the round commitment transaction id when the round
+	// has been persisted.
+	CommitmentTxid string `protobuf:"bytes,5,opt,name=commitment_txid,json=commitmentTxid,proto3" json:"commitment_txid,omitempty"`
+	// commitment_height is the block height that confirmed the commitment
+	// transaction, when known.
+	CommitmentHeight int32 `protobuf:"varint,6,opt,name=commitment_height,json=commitmentHeight,proto3" json:"commitment_height,omitempty"`
+	// creation_time is the Unix timestamp when the persisted round row was
+	// first created.
+	CreationTime int64 `protobuf:"varint,7,opt,name=creation_time,json=creationTime,proto3" json:"creation_time,omitempty"`
+	// last_update_time is the Unix timestamp when the persisted round row
+	// was last updated.
+	LastUpdateTime int64 `protobuf:"varint,8,opt,name=last_update_time,json=lastUpdateTime,proto3" json:"last_update_time,omitempty"`
+	// input_outpoints lists locally known inputs associated with this round.
+	// For boarding rounds this includes locally persisted boarding inputs.
+	InputOutpoints []string `protobuf:"bytes,9,rep,name=input_outpoints,json=inputOutpoints,proto3" json:"input_outpoints,omitempty"`
+	// output_outpoints lists locally known VTXO outpoints created by this
+	// round.
+	OutputOutpoints []string `protobuf:"bytes,10,rep,name=output_outpoints,json=outputOutpoints,proto3" json:"output_outpoints,omitempty"`
+	// failure_reason contains the live FSM failure reason when available.
+	// Historical failed rounds loaded only from persistence leave this empty.
+	FailureReason string `protobuf:"bytes,11,opt,name=failure_reason,json=failureReason,proto3" json:"failure_reason,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2935,6 +3057,55 @@ func (x *RoundInfo) GetVtxos() []*RoundVTXOInfo {
 	return nil
 }
 
+func (x *RoundInfo) GetCommitmentTxid() string {
+	if x != nil {
+		return x.CommitmentTxid
+	}
+	return ""
+}
+
+func (x *RoundInfo) GetCommitmentHeight() int32 {
+	if x != nil {
+		return x.CommitmentHeight
+	}
+	return 0
+}
+
+func (x *RoundInfo) GetCreationTime() int64 {
+	if x != nil {
+		return x.CreationTime
+	}
+	return 0
+}
+
+func (x *RoundInfo) GetLastUpdateTime() int64 {
+	if x != nil {
+		return x.LastUpdateTime
+	}
+	return 0
+}
+
+func (x *RoundInfo) GetInputOutpoints() []string {
+	if x != nil {
+		return x.InputOutpoints
+	}
+	return nil
+}
+
+func (x *RoundInfo) GetOutputOutpoints() []string {
+	if x != nil {
+		return x.OutputOutpoints
+	}
+	return nil
+}
+
+func (x *RoundInfo) GetFailureReason() string {
+	if x != nil {
+		return x.FailureReason
+	}
+	return ""
+}
+
 type ListRoundsRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// page_size is the maximum number of persisted rounds to return.
@@ -2950,6 +3121,17 @@ type ListRoundsRequest struct {
 	// returns only rounds that have been persisted to disk
 	// (input_sig_sent, confirmed, etc.).
 	PersistedOnly bool `protobuf:"varint,3,opt,name=persisted_only,json=persistedOnly,proto3" json:"persisted_only,omitempty"`
+	// state_filter restricts results to a single state when set to a value
+	// other than ROUND_STATE_UNKNOWN.
+	StateFilter RoundState `protobuf:"varint,4,opt,name=state_filter,json=stateFilter,proto3,enum=daemonrpc.RoundState" json:"state_filter,omitempty"`
+	// created_after restricts persisted rows to rounds created at or after
+	// the given Unix timestamp. Pending in-memory rounds are not filtered by
+	// creation time because they do not expose a stable creation timestamp.
+	CreatedAfter int64 `protobuf:"varint,5,opt,name=created_after,json=createdAfter,proto3" json:"created_after,omitempty"`
+	// created_before restricts persisted rows to rounds created at or before
+	// the given Unix timestamp. Pending in-memory rounds are not filtered by
+	// creation time because they do not expose a stable creation timestamp.
+	CreatedBefore int64 `protobuf:"varint,6,opt,name=created_before,json=createdBefore,proto3" json:"created_before,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3005,6 +3187,117 @@ func (x *ListRoundsRequest) GetPersistedOnly() bool {
 	return false
 }
 
+func (x *ListRoundsRequest) GetStateFilter() RoundState {
+	if x != nil {
+		return x.StateFilter
+	}
+	return RoundState_ROUND_STATE_UNKNOWN
+}
+
+func (x *ListRoundsRequest) GetCreatedAfter() int64 {
+	if x != nil {
+		return x.CreatedAfter
+	}
+	return 0
+}
+
+func (x *ListRoundsRequest) GetCreatedBefore() int64 {
+	if x != nil {
+		return x.CreatedBefore
+	}
+	return 0
+}
+
+type GetRoundRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// round_id identifies the server-assigned round to fetch.
+	RoundId       string `protobuf:"bytes,1,opt,name=round_id,json=roundId,proto3" json:"round_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetRoundRequest) Reset() {
+	*x = GetRoundRequest{}
+	mi := &file_daemon_proto_msgTypes[39]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetRoundRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetRoundRequest) ProtoMessage() {}
+
+func (x *GetRoundRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[39]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetRoundRequest.ProtoReflect.Descriptor instead.
+func (*GetRoundRequest) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{39}
+}
+
+func (x *GetRoundRequest) GetRoundId() string {
+	if x != nil {
+		return x.RoundId
+	}
+	return ""
+}
+
+type GetRoundResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// round is the matching round status.
+	Round         *RoundInfo `protobuf:"bytes,1,opt,name=round,proto3" json:"round,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetRoundResponse) Reset() {
+	*x = GetRoundResponse{}
+	mi := &file_daemon_proto_msgTypes[40]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetRoundResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetRoundResponse) ProtoMessage() {}
+
+func (x *GetRoundResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[40]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetRoundResponse.ProtoReflect.Descriptor instead.
+func (*GetRoundResponse) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{40}
+}
+
+func (x *GetRoundResponse) GetRound() *RoundInfo {
+	if x != nil {
+		return x.Round
+	}
+	return nil
+}
+
 type ListRoundsResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// rounds lists the current state of all round FSM instances.
@@ -3018,7 +3311,7 @@ type ListRoundsResponse struct {
 
 func (x *ListRoundsResponse) Reset() {
 	*x = ListRoundsResponse{}
-	mi := &file_daemon_proto_msgTypes[39]
+	mi := &file_daemon_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3030,7 +3323,7 @@ func (x *ListRoundsResponse) String() string {
 func (*ListRoundsResponse) ProtoMessage() {}
 
 func (x *ListRoundsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[39]
+	mi := &file_daemon_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3043,7 +3336,7 @@ func (x *ListRoundsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRoundsResponse.ProtoReflect.Descriptor instead.
 func (*ListRoundsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{39}
+	return file_daemon_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *ListRoundsResponse) GetRounds() []*RoundInfo {
@@ -3068,7 +3361,7 @@ type WatchRoundsRequest struct {
 
 func (x *WatchRoundsRequest) Reset() {
 	*x = WatchRoundsRequest{}
-	mi := &file_daemon_proto_msgTypes[40]
+	mi := &file_daemon_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3080,7 +3373,7 @@ func (x *WatchRoundsRequest) String() string {
 func (*WatchRoundsRequest) ProtoMessage() {}
 
 func (x *WatchRoundsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[40]
+	mi := &file_daemon_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3093,7 +3386,7 @@ func (x *WatchRoundsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchRoundsRequest.ProtoReflect.Descriptor instead.
 func (*WatchRoundsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{40}
+	return file_daemon_proto_rawDescGZIP(), []int{42}
 }
 
 type WatchRoundsResponse struct {
@@ -3107,7 +3400,7 @@ type WatchRoundsResponse struct {
 
 func (x *WatchRoundsResponse) Reset() {
 	*x = WatchRoundsResponse{}
-	mi := &file_daemon_proto_msgTypes[41]
+	mi := &file_daemon_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3119,7 +3412,7 @@ func (x *WatchRoundsResponse) String() string {
 func (*WatchRoundsResponse) ProtoMessage() {}
 
 func (x *WatchRoundsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[41]
+	mi := &file_daemon_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3132,12 +3425,350 @@ func (x *WatchRoundsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchRoundsResponse.ProtoReflect.Descriptor instead.
 func (*WatchRoundsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{41}
+	return file_daemon_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *WatchRoundsResponse) GetRound() *RoundInfo {
 	if x != nil {
 		return x.Round
+	}
+	return nil
+}
+
+type OORSessionInfo struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// session_id is the stable OOR session identifier.
+	SessionId string `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	// direction is from the local client's perspective.
+	Direction OORSessionDirection `protobuf:"varint,2,opt,name=direction,proto3,enum=daemonrpc.OORSessionDirection" json:"direction,omitempty"`
+	// status is the coarse operation state.
+	Status OORSessionStatus `protobuf:"varint,3,opt,name=status,proto3,enum=daemonrpc.OORSessionStatus" json:"status,omitempty"`
+	// phase is the detailed OOR FSM phase string.
+	Phase string `protobuf:"bytes,4,opt,name=phase,proto3" json:"phase,omitempty"`
+	// created_at is the Unix timestamp when the persisted package was first
+	// recorded, when known.
+	CreatedAt int64 `protobuf:"varint,5,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	// updated_at is the Unix timestamp when the session/package was last
+	// updated, when known.
+	UpdatedAt int64 `protobuf:"varint,6,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
+	// consumed_outpoints are locally known VTXOs consumed by this session.
+	ConsumedOutpoints []string `protobuf:"bytes,7,rep,name=consumed_outpoints,json=consumedOutpoints,proto3" json:"consumed_outpoints,omitempty"`
+	// created_outpoints are locally known VTXOs created by this session.
+	CreatedOutpoints []string `protobuf:"bytes,8,rep,name=created_outpoints,json=createdOutpoints,proto3" json:"created_outpoints,omitempty"`
+	// failure_reason is populated for failed live OOR sessions when known.
+	FailureReason string `protobuf:"bytes,9,opt,name=failure_reason,json=failureReason,proto3" json:"failure_reason,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *OORSessionInfo) Reset() {
+	*x = OORSessionInfo{}
+	mi := &file_daemon_proto_msgTypes[44]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *OORSessionInfo) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OORSessionInfo) ProtoMessage() {}
+
+func (x *OORSessionInfo) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[44]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use OORSessionInfo.ProtoReflect.Descriptor instead.
+func (*OORSessionInfo) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{44}
+}
+
+func (x *OORSessionInfo) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+func (x *OORSessionInfo) GetDirection() OORSessionDirection {
+	if x != nil {
+		return x.Direction
+	}
+	return OORSessionDirection_OOR_SESSION_DIRECTION_UNSPECIFIED
+}
+
+func (x *OORSessionInfo) GetStatus() OORSessionStatus {
+	if x != nil {
+		return x.Status
+	}
+	return OORSessionStatus_OOR_SESSION_STATUS_UNSPECIFIED
+}
+
+func (x *OORSessionInfo) GetPhase() string {
+	if x != nil {
+		return x.Phase
+	}
+	return ""
+}
+
+func (x *OORSessionInfo) GetCreatedAt() int64 {
+	if x != nil {
+		return x.CreatedAt
+	}
+	return 0
+}
+
+func (x *OORSessionInfo) GetUpdatedAt() int64 {
+	if x != nil {
+		return x.UpdatedAt
+	}
+	return 0
+}
+
+func (x *OORSessionInfo) GetConsumedOutpoints() []string {
+	if x != nil {
+		return x.ConsumedOutpoints
+	}
+	return nil
+}
+
+func (x *OORSessionInfo) GetCreatedOutpoints() []string {
+	if x != nil {
+		return x.CreatedOutpoints
+	}
+	return nil
+}
+
+func (x *OORSessionInfo) GetFailureReason() string {
+	if x != nil {
+		return x.FailureReason
+	}
+	return ""
+}
+
+type ListOORSessionsRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// page_size is the maximum number of sessions to return. If zero, the
+	// daemon uses a default page size.
+	PageSize int32 `protobuf:"varint,1,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
+	// page_token is an opaque session cursor returned by a previous
+	// ListOORSessionsResponse.
+	PageToken string `protobuf:"bytes,2,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
+	// direction_filter restricts results by local direction when set.
+	DirectionFilter OORSessionDirection `protobuf:"varint,3,opt,name=direction_filter,json=directionFilter,proto3,enum=daemonrpc.OORSessionDirection" json:"direction_filter,omitempty"`
+	// status_filter restricts results by operation status when set.
+	StatusFilter  OORSessionStatus `protobuf:"varint,4,opt,name=status_filter,json=statusFilter,proto3,enum=daemonrpc.OORSessionStatus" json:"status_filter,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListOORSessionsRequest) Reset() {
+	*x = ListOORSessionsRequest{}
+	mi := &file_daemon_proto_msgTypes[45]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListOORSessionsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListOORSessionsRequest) ProtoMessage() {}
+
+func (x *ListOORSessionsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[45]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListOORSessionsRequest.ProtoReflect.Descriptor instead.
+func (*ListOORSessionsRequest) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{45}
+}
+
+func (x *ListOORSessionsRequest) GetPageSize() int32 {
+	if x != nil {
+		return x.PageSize
+	}
+	return 0
+}
+
+func (x *ListOORSessionsRequest) GetPageToken() string {
+	if x != nil {
+		return x.PageToken
+	}
+	return ""
+}
+
+func (x *ListOORSessionsRequest) GetDirectionFilter() OORSessionDirection {
+	if x != nil {
+		return x.DirectionFilter
+	}
+	return OORSessionDirection_OOR_SESSION_DIRECTION_UNSPECIFIED
+}
+
+func (x *ListOORSessionsRequest) GetStatusFilter() OORSessionStatus {
+	if x != nil {
+		return x.StatusFilter
+	}
+	return OORSessionStatus_OOR_SESSION_STATUS_UNSPECIFIED
+}
+
+type ListOORSessionsResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// sessions lists locally known OOR operation status entries.
+	Sessions []*OORSessionInfo `protobuf:"bytes,1,rep,name=sessions,proto3" json:"sessions,omitempty"`
+	// next_page_token is an opaque cursor for the next page. Empty when
+	// there are no more results.
+	NextPageToken string `protobuf:"bytes,2,opt,name=next_page_token,json=nextPageToken,proto3" json:"next_page_token,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListOORSessionsResponse) Reset() {
+	*x = ListOORSessionsResponse{}
+	mi := &file_daemon_proto_msgTypes[46]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListOORSessionsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListOORSessionsResponse) ProtoMessage() {}
+
+func (x *ListOORSessionsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[46]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListOORSessionsResponse.ProtoReflect.Descriptor instead.
+func (*ListOORSessionsResponse) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{46}
+}
+
+func (x *ListOORSessionsResponse) GetSessions() []*OORSessionInfo {
+	if x != nil {
+		return x.Sessions
+	}
+	return nil
+}
+
+func (x *ListOORSessionsResponse) GetNextPageToken() string {
+	if x != nil {
+		return x.NextPageToken
+	}
+	return ""
+}
+
+type GetOORSessionRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// session_id identifies the OOR session to fetch.
+	SessionId     string `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetOORSessionRequest) Reset() {
+	*x = GetOORSessionRequest{}
+	mi := &file_daemon_proto_msgTypes[47]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetOORSessionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetOORSessionRequest) ProtoMessage() {}
+
+func (x *GetOORSessionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[47]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetOORSessionRequest.ProtoReflect.Descriptor instead.
+func (*GetOORSessionRequest) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{47}
+}
+
+func (x *GetOORSessionRequest) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+type GetOORSessionResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// session is the matching OOR operation status.
+	Session       *OORSessionInfo `protobuf:"bytes,1,opt,name=session,proto3" json:"session,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetOORSessionResponse) Reset() {
+	*x = GetOORSessionResponse{}
+	mi := &file_daemon_proto_msgTypes[48]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetOORSessionResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetOORSessionResponse) ProtoMessage() {}
+
+func (x *GetOORSessionResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[48]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetOORSessionResponse.ProtoReflect.Descriptor instead.
+func (*GetOORSessionResponse) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{48}
+}
+
+func (x *GetOORSessionResponse) GetSession() *OORSessionInfo {
+	if x != nil {
+		return x.Session
 	}
 	return nil
 }
@@ -3160,7 +3791,7 @@ type EstimateFeeRequest struct {
 
 func (x *EstimateFeeRequest) Reset() {
 	*x = EstimateFeeRequest{}
-	mi := &file_daemon_proto_msgTypes[42]
+	mi := &file_daemon_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3172,7 +3803,7 @@ func (x *EstimateFeeRequest) String() string {
 func (*EstimateFeeRequest) ProtoMessage() {}
 
 func (x *EstimateFeeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[42]
+	mi := &file_daemon_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3185,7 +3816,7 @@ func (x *EstimateFeeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EstimateFeeRequest.ProtoReflect.Descriptor instead.
 func (*EstimateFeeRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{42}
+	return file_daemon_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *EstimateFeeRequest) GetAmountSat() int64 {
@@ -3239,7 +3870,7 @@ type EstimateFeeResponse struct {
 
 func (x *EstimateFeeResponse) Reset() {
 	*x = EstimateFeeResponse{}
-	mi := &file_daemon_proto_msgTypes[43]
+	mi := &file_daemon_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3251,7 +3882,7 @@ func (x *EstimateFeeResponse) String() string {
 func (*EstimateFeeResponse) ProtoMessage() {}
 
 func (x *EstimateFeeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[43]
+	mi := &file_daemon_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3264,7 +3895,7 @@ func (x *EstimateFeeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EstimateFeeResponse.ProtoReflect.Descriptor instead.
 func (*EstimateFeeResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{43}
+	return file_daemon_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *EstimateFeeResponse) GetLiquidityFeeSat() int64 {
@@ -3334,7 +3965,7 @@ type GetFeeHistoryRequest struct {
 
 func (x *GetFeeHistoryRequest) Reset() {
 	*x = GetFeeHistoryRequest{}
-	mi := &file_daemon_proto_msgTypes[44]
+	mi := &file_daemon_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3346,7 +3977,7 @@ func (x *GetFeeHistoryRequest) String() string {
 func (*GetFeeHistoryRequest) ProtoMessage() {}
 
 func (x *GetFeeHistoryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[44]
+	mi := &file_daemon_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3359,7 +3990,7 @@ func (x *GetFeeHistoryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetFeeHistoryRequest.ProtoReflect.Descriptor instead.
 func (*GetFeeHistoryRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{44}
+	return file_daemon_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *GetFeeHistoryRequest) GetLimit() uint32 {
@@ -3434,7 +4065,7 @@ type FeeHistoryEntry struct {
 
 func (x *FeeHistoryEntry) Reset() {
 	*x = FeeHistoryEntry{}
-	mi := &file_daemon_proto_msgTypes[45]
+	mi := &file_daemon_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3446,7 +4077,7 @@ func (x *FeeHistoryEntry) String() string {
 func (*FeeHistoryEntry) ProtoMessage() {}
 
 func (x *FeeHistoryEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[45]
+	mi := &file_daemon_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3459,7 +4090,7 @@ func (x *FeeHistoryEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FeeHistoryEntry.ProtoReflect.Descriptor instead.
 func (*FeeHistoryEntry) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{45}
+	return file_daemon_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *FeeHistoryEntry) GetEntryId() int64 {
@@ -3539,7 +4170,7 @@ type GetFeeHistoryResponse struct {
 
 func (x *GetFeeHistoryResponse) Reset() {
 	*x = GetFeeHistoryResponse{}
-	mi := &file_daemon_proto_msgTypes[46]
+	mi := &file_daemon_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3551,7 +4182,7 @@ func (x *GetFeeHistoryResponse) String() string {
 func (*GetFeeHistoryResponse) ProtoMessage() {}
 
 func (x *GetFeeHistoryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[46]
+	mi := &file_daemon_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3564,7 +4195,7 @@ func (x *GetFeeHistoryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetFeeHistoryResponse.ProtoReflect.Descriptor instead.
 func (*GetFeeHistoryResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{46}
+	return file_daemon_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *GetFeeHistoryResponse) GetEntries() []*FeeHistoryEntry {
@@ -3592,7 +4223,7 @@ type UnrollRequest struct {
 
 func (x *UnrollRequest) Reset() {
 	*x = UnrollRequest{}
-	mi := &file_daemon_proto_msgTypes[47]
+	mi := &file_daemon_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3604,7 +4235,7 @@ func (x *UnrollRequest) String() string {
 func (*UnrollRequest) ProtoMessage() {}
 
 func (x *UnrollRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[47]
+	mi := &file_daemon_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3617,7 +4248,7 @@ func (x *UnrollRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnrollRequest.ProtoReflect.Descriptor instead.
 func (*UnrollRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{47}
+	return file_daemon_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *UnrollRequest) GetOutpoint() string {
@@ -3640,7 +4271,7 @@ type UnrollResponse struct {
 
 func (x *UnrollResponse) Reset() {
 	*x = UnrollResponse{}
-	mi := &file_daemon_proto_msgTypes[48]
+	mi := &file_daemon_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3652,7 +4283,7 @@ func (x *UnrollResponse) String() string {
 func (*UnrollResponse) ProtoMessage() {}
 
 func (x *UnrollResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[48]
+	mi := &file_daemon_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3665,7 +4296,7 @@ func (x *UnrollResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnrollResponse.ProtoReflect.Descriptor instead.
 func (*UnrollResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{48}
+	return file_daemon_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *UnrollResponse) GetCreated() bool {
@@ -3692,7 +4323,7 @@ type GetUnrollStatusRequest struct {
 
 func (x *GetUnrollStatusRequest) Reset() {
 	*x = GetUnrollStatusRequest{}
-	mi := &file_daemon_proto_msgTypes[49]
+	mi := &file_daemon_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3704,7 +4335,7 @@ func (x *GetUnrollStatusRequest) String() string {
 func (*GetUnrollStatusRequest) ProtoMessage() {}
 
 func (x *GetUnrollStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[49]
+	mi := &file_daemon_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3717,7 +4348,7 @@ func (x *GetUnrollStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUnrollStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetUnrollStatusRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{49}
+	return file_daemon_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *GetUnrollStatusRequest) GetOutpoint() string {
@@ -3745,7 +4376,7 @@ type GetUnrollStatusResponse struct {
 
 func (x *GetUnrollStatusResponse) Reset() {
 	*x = GetUnrollStatusResponse{}
-	mi := &file_daemon_proto_msgTypes[50]
+	mi := &file_daemon_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3757,7 +4388,7 @@ func (x *GetUnrollStatusResponse) String() string {
 func (*GetUnrollStatusResponse) ProtoMessage() {}
 
 func (x *GetUnrollStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[50]
+	mi := &file_daemon_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3770,7 +4401,7 @@ func (x *GetUnrollStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUnrollStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetUnrollStatusResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{50}
+	return file_daemon_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *GetUnrollStatusResponse) GetFound() bool {
@@ -3977,23 +4608,65 @@ const file_daemon_proto_rawDesc = "" +
 	"\rRoundVTXOInfo\x12\x1a\n" +
 	"\boutpoint\x18\x01 \x01(\tR\boutpoint\x12\x1d\n" +
 	"\n" +
-	"amount_sat\x18\x02 \x01(\x03R\tamountSat\"\x9c\x01\n" +
+	"amount_sat\x18\x02 \x01(\x03R\tamountSat\"\xbc\x03\n" +
 	"\tRoundInfo\x12\x19\n" +
 	"\bround_id\x18\x01 \x01(\tR\aroundId\x12+\n" +
 	"\x05state\x18\x02 \x01(\x0e2\x15.daemonrpc.RoundStateR\x05state\x12\x17\n" +
 	"\ais_temp\x18\x03 \x01(\bR\x06isTemp\x12.\n" +
-	"\x05vtxos\x18\x04 \x03(\v2\x18.daemonrpc.RoundVTXOInfoR\x05vtxos\"v\n" +
+	"\x05vtxos\x18\x04 \x03(\v2\x18.daemonrpc.RoundVTXOInfoR\x05vtxos\x12'\n" +
+	"\x0fcommitment_txid\x18\x05 \x01(\tR\x0ecommitmentTxid\x12+\n" +
+	"\x11commitment_height\x18\x06 \x01(\x05R\x10commitmentHeight\x12#\n" +
+	"\rcreation_time\x18\a \x01(\x03R\fcreationTime\x12(\n" +
+	"\x10last_update_time\x18\b \x01(\x03R\x0elastUpdateTime\x12'\n" +
+	"\x0finput_outpoints\x18\t \x03(\tR\x0einputOutpoints\x12)\n" +
+	"\x10output_outpoints\x18\n" +
+	" \x03(\tR\x0foutputOutpoints\x12%\n" +
+	"\x0efailure_reason\x18\v \x01(\tR\rfailureReason\"\xfc\x01\n" +
 	"\x11ListRoundsRequest\x12\x1b\n" +
 	"\tpage_size\x18\x01 \x01(\x05R\bpageSize\x12\x1d\n" +
 	"\n" +
 	"page_token\x18\x02 \x01(\tR\tpageToken\x12%\n" +
-	"\x0epersisted_only\x18\x03 \x01(\bR\rpersistedOnly\"j\n" +
+	"\x0epersisted_only\x18\x03 \x01(\bR\rpersistedOnly\x128\n" +
+	"\fstate_filter\x18\x04 \x01(\x0e2\x15.daemonrpc.RoundStateR\vstateFilter\x12#\n" +
+	"\rcreated_after\x18\x05 \x01(\x03R\fcreatedAfter\x12%\n" +
+	"\x0ecreated_before\x18\x06 \x01(\x03R\rcreatedBefore\",\n" +
+	"\x0fGetRoundRequest\x12\x19\n" +
+	"\bround_id\x18\x01 \x01(\tR\aroundId\">\n" +
+	"\x10GetRoundResponse\x12*\n" +
+	"\x05round\x18\x01 \x01(\v2\x14.daemonrpc.RoundInfoR\x05round\"j\n" +
 	"\x12ListRoundsResponse\x12,\n" +
 	"\x06rounds\x18\x01 \x03(\v2\x14.daemonrpc.RoundInfoR\x06rounds\x12&\n" +
 	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"\x14\n" +
 	"\x12WatchRoundsRequest\"A\n" +
 	"\x13WatchRoundsResponse\x12*\n" +
-	"\x05round\x18\x01 \x01(\v2\x14.daemonrpc.RoundInfoR\x05round\"\x7f\n" +
+	"\x05round\x18\x01 \x01(\v2\x14.daemonrpc.RoundInfoR\x05round\"\xf9\x02\n" +
+	"\x0eOORSessionInfo\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\x12<\n" +
+	"\tdirection\x18\x02 \x01(\x0e2\x1e.daemonrpc.OORSessionDirectionR\tdirection\x123\n" +
+	"\x06status\x18\x03 \x01(\x0e2\x1b.daemonrpc.OORSessionStatusR\x06status\x12\x14\n" +
+	"\x05phase\x18\x04 \x01(\tR\x05phase\x12\x1d\n" +
+	"\n" +
+	"created_at\x18\x05 \x01(\x03R\tcreatedAt\x12\x1d\n" +
+	"\n" +
+	"updated_at\x18\x06 \x01(\x03R\tupdatedAt\x12-\n" +
+	"\x12consumed_outpoints\x18\a \x03(\tR\x11consumedOutpoints\x12+\n" +
+	"\x11created_outpoints\x18\b \x03(\tR\x10createdOutpoints\x12%\n" +
+	"\x0efailure_reason\x18\t \x01(\tR\rfailureReason\"\xe1\x01\n" +
+	"\x16ListOORSessionsRequest\x12\x1b\n" +
+	"\tpage_size\x18\x01 \x01(\x05R\bpageSize\x12\x1d\n" +
+	"\n" +
+	"page_token\x18\x02 \x01(\tR\tpageToken\x12I\n" +
+	"\x10direction_filter\x18\x03 \x01(\x0e2\x1e.daemonrpc.OORSessionDirectionR\x0fdirectionFilter\x12@\n" +
+	"\rstatus_filter\x18\x04 \x01(\x0e2\x1b.daemonrpc.OORSessionStatusR\fstatusFilter\"x\n" +
+	"\x17ListOORSessionsResponse\x125\n" +
+	"\bsessions\x18\x01 \x03(\v2\x19.daemonrpc.OORSessionInfoR\bsessions\x12&\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"5\n" +
+	"\x14GetOORSessionRequest\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\"L\n" +
+	"\x15GetOORSessionResponse\x123\n" +
+	"\asession\x18\x01 \x01(\v2\x19.daemonrpc.OORSessionInfoR\asession\"\x7f\n" +
 	"\x12EstimateFeeRequest\x12\x1d\n" +
 	"\n" +
 	"amount_sat\x18\x01 \x01(\x03R\tamountSat\x12\x1f\n" +
@@ -4071,7 +4744,16 @@ const file_daemon_proto_rawDesc = "" +
 	"\x15ROUND_STATE_CONFIRMED\x10\f\x12\x16\n" +
 	"\x12ROUND_STATE_FAILED\x10\r\x12\x18\n" +
 	"\x14ROUND_STATE_RECOVERY\x10\x0e\x12\x1e\n" +
-	"\x1aROUND_STATE_QUOTE_RECEIVED\x10\x0f*\xfa\x01\n" +
+	"\x1aROUND_STATE_QUOTE_RECEIVED\x10\x0f*\x84\x01\n" +
+	"\x13OORSessionDirection\x12%\n" +
+	"!OOR_SESSION_DIRECTION_UNSPECIFIED\x10\x00\x12\"\n" +
+	"\x1eOOR_SESSION_DIRECTION_OUTGOING\x10\x01\x12\"\n" +
+	"\x1eOOR_SESSION_DIRECTION_INCOMING\x10\x02*\x97\x01\n" +
+	"\x10OORSessionStatus\x12\"\n" +
+	"\x1eOOR_SESSION_STATUS_UNSPECIFIED\x10\x00\x12\x1e\n" +
+	"\x1aOOR_SESSION_STATUS_PENDING\x10\x01\x12 \n" +
+	"\x1cOOR_SESSION_STATUS_COMPLETED\x10\x02\x12\x1d\n" +
+	"\x19OOR_SESSION_STATUS_FAILED\x10\x03*\xfa\x01\n" +
 	"\x0fUnrollJobStatus\x12!\n" +
 	"\x1dUNROLL_JOB_STATUS_UNSPECIFIED\x10\x00\x12\x1d\n" +
 	"\x19UNROLL_JOB_STATUS_PENDING\x10\x01\x12#\n" +
@@ -4079,7 +4761,7 @@ const file_daemon_proto_rawDesc = "" +
 	"\x1dUNROLL_JOB_STATUS_CSV_PENDING\x10\x03\x12\x1e\n" +
 	"\x1aUNROLL_JOB_STATUS_SWEEPING\x10\x04\x12\x1f\n" +
 	"\x1bUNROLL_JOB_STATUS_COMPLETED\x10\x05\x12\x1c\n" +
-	"\x18UNROLL_JOB_STATUS_FAILED\x10\x062\x8f\r\n" +
+	"\x18UNROLL_JOB_STATUS_FAILED\x10\x062\x82\x0f\n" +
 	"\rDaemonService\x12@\n" +
 	"\aGetInfo\x12\x19.daemonrpc.GetInfoRequest\x1a\x1a.daemonrpc.GetInfoResponse\x12@\n" +
 	"\aGenSeed\x12\x19.daemonrpc.GenSeedRequest\x1a\x1a.daemonrpc.GenSeedResponse\x12I\n" +
@@ -4101,8 +4783,11 @@ const file_daemon_proto_rawDesc = "" +
 	"LeaveVTXOs\x12\x1c.daemonrpc.LeaveVTXOsRequest\x1a\x1d.daemonrpc.LeaveVTXOsResponse\x12:\n" +
 	"\x05Board\x12\x17.daemonrpc.BoardRequest\x1a\x18.daemonrpc.BoardResponse\x12I\n" +
 	"\n" +
-	"ListRounds\x12\x1c.daemonrpc.ListRoundsRequest\x1a\x1d.daemonrpc.ListRoundsResponse\x12N\n" +
-	"\vWatchRounds\x12\x1d.daemonrpc.WatchRoundsRequest\x1a\x1e.daemonrpc.WatchRoundsResponse0\x01\x12L\n" +
+	"ListRounds\x12\x1c.daemonrpc.ListRoundsRequest\x1a\x1d.daemonrpc.ListRoundsResponse\x12C\n" +
+	"\bGetRound\x12\x1a.daemonrpc.GetRoundRequest\x1a\x1b.daemonrpc.GetRoundResponse\x12N\n" +
+	"\vWatchRounds\x12\x1d.daemonrpc.WatchRoundsRequest\x1a\x1e.daemonrpc.WatchRoundsResponse0\x01\x12X\n" +
+	"\x0fListOORSessions\x12!.daemonrpc.ListOORSessionsRequest\x1a\".daemonrpc.ListOORSessionsResponse\x12R\n" +
+	"\rGetOORSession\x12\x1f.daemonrpc.GetOORSessionRequest\x1a .daemonrpc.GetOORSessionResponse\x12L\n" +
 	"\vEstimateFee\x12\x1d.daemonrpc.EstimateFeeRequest\x1a\x1e.daemonrpc.EstimateFeeResponse\x12R\n" +
 	"\rGetFeeHistory\x12\x1f.daemonrpc.GetFeeHistoryRequest\x1a .daemonrpc.GetFeeHistoryResponse\x12=\n" +
 	"\x06Unroll\x12\x18.daemonrpc.UnrollRequest\x1a\x19.daemonrpc.UnrollResponse\x12X\n" +
@@ -4120,133 +4805,156 @@ func file_daemon_proto_rawDescGZIP() []byte {
 	return file_daemon_proto_rawDescData
 }
 
-var file_daemon_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 52)
+var file_daemon_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
+var file_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 59)
 var file_daemon_proto_goTypes = []any{
 	(VTXOStatus)(0),                            // 0: daemonrpc.VTXOStatus
 	(RoundState)(0),                            // 1: daemonrpc.RoundState
-	(UnrollJobStatus)(0),                       // 2: daemonrpc.UnrollJobStatus
-	(*GetInfoRequest)(nil),                     // 3: daemonrpc.GetInfoRequest
-	(*GetInfoResponse)(nil),                    // 4: daemonrpc.GetInfoResponse
-	(*ServerInfo)(nil),                         // 5: daemonrpc.ServerInfo
-	(*GenSeedRequest)(nil),                     // 6: daemonrpc.GenSeedRequest
-	(*GenSeedResponse)(nil),                    // 7: daemonrpc.GenSeedResponse
-	(*InitWalletRequest)(nil),                  // 8: daemonrpc.InitWalletRequest
-	(*InitWalletResponse)(nil),                 // 9: daemonrpc.InitWalletResponse
-	(*UnlockWalletRequest)(nil),                // 10: daemonrpc.UnlockWalletRequest
-	(*UnlockWalletResponse)(nil),               // 11: daemonrpc.UnlockWalletResponse
-	(*GetBalanceRequest)(nil),                  // 12: daemonrpc.GetBalanceRequest
-	(*GetBalanceResponse)(nil),                 // 13: daemonrpc.GetBalanceResponse
-	(*VTXO)(nil),                               // 14: daemonrpc.VTXO
-	(*ListVTXOsRequest)(nil),                   // 15: daemonrpc.ListVTXOsRequest
-	(*ListVTXOsResponse)(nil),                  // 16: daemonrpc.ListVTXOsResponse
-	(*NewAddressRequest)(nil),                  // 17: daemonrpc.NewAddressRequest
-	(*NewAddressResponse)(nil),                 // 18: daemonrpc.NewAddressResponse
-	(*NewReceiveScriptRequest)(nil),            // 19: daemonrpc.NewReceiveScriptRequest
-	(*NewReceiveScriptResponse)(nil),           // 20: daemonrpc.NewReceiveScriptResponse
-	(*GetIndexedVTXOByPkScriptRequest)(nil),    // 21: daemonrpc.GetIndexedVTXOByPkScriptRequest
-	(*GetIndexedVTXOByPkScriptResponse)(nil),   // 22: daemonrpc.GetIndexedVTXOByPkScriptResponse
-	(*GetIndexedOORSessionByTxidRequest)(nil),  // 23: daemonrpc.GetIndexedOORSessionByTxidRequest
-	(*GetIndexedOORSessionByTxidResponse)(nil), // 24: daemonrpc.GetIndexedOORSessionByTxidResponse
-	(*Output)(nil),                             // 25: daemonrpc.Output
-	(*SendVTXORequest)(nil),                    // 26: daemonrpc.SendVTXORequest
-	(*SendVTXOResponse)(nil),                   // 27: daemonrpc.SendVTXOResponse
-	(*SendOORRequest)(nil),                     // 28: daemonrpc.SendOORRequest
-	(*CustomOORInput)(nil),                     // 29: daemonrpc.CustomOORInput
-	(*SendOORResponse)(nil),                    // 30: daemonrpc.SendOORResponse
-	(*OutpointSelection)(nil),                  // 31: daemonrpc.OutpointSelection
-	(*RefreshVTXOsRequest)(nil),                // 32: daemonrpc.RefreshVTXOsRequest
-	(*RefreshVTXOsResponse)(nil),               // 33: daemonrpc.RefreshVTXOsResponse
-	(*LeaveDestination)(nil),                   // 34: daemonrpc.LeaveDestination
-	(*LeaveVTXOsRequest)(nil),                  // 35: daemonrpc.LeaveVTXOsRequest
-	(*LeaveVTXOsResponse)(nil),                 // 36: daemonrpc.LeaveVTXOsResponse
-	(*BoardRequest)(nil),                       // 37: daemonrpc.BoardRequest
-	(*BoardResponse)(nil),                      // 38: daemonrpc.BoardResponse
-	(*RoundVTXOInfo)(nil),                      // 39: daemonrpc.RoundVTXOInfo
-	(*RoundInfo)(nil),                          // 40: daemonrpc.RoundInfo
-	(*ListRoundsRequest)(nil),                  // 41: daemonrpc.ListRoundsRequest
-	(*ListRoundsResponse)(nil),                 // 42: daemonrpc.ListRoundsResponse
-	(*WatchRoundsRequest)(nil),                 // 43: daemonrpc.WatchRoundsRequest
-	(*WatchRoundsResponse)(nil),                // 44: daemonrpc.WatchRoundsResponse
-	(*EstimateFeeRequest)(nil),                 // 45: daemonrpc.EstimateFeeRequest
-	(*EstimateFeeResponse)(nil),                // 46: daemonrpc.EstimateFeeResponse
-	(*GetFeeHistoryRequest)(nil),               // 47: daemonrpc.GetFeeHistoryRequest
-	(*FeeHistoryEntry)(nil),                    // 48: daemonrpc.FeeHistoryEntry
-	(*GetFeeHistoryResponse)(nil),              // 49: daemonrpc.GetFeeHistoryResponse
-	(*UnrollRequest)(nil),                      // 50: daemonrpc.UnrollRequest
-	(*UnrollResponse)(nil),                     // 51: daemonrpc.UnrollResponse
-	(*GetUnrollStatusRequest)(nil),             // 52: daemonrpc.GetUnrollStatusRequest
-	(*GetUnrollStatusResponse)(nil),            // 53: daemonrpc.GetUnrollStatusResponse
-	nil,                                        // 54: daemonrpc.LeaveVTXOsRequest.DestinationsEntry
+	(OORSessionDirection)(0),                   // 2: daemonrpc.OORSessionDirection
+	(OORSessionStatus)(0),                      // 3: daemonrpc.OORSessionStatus
+	(UnrollJobStatus)(0),                       // 4: daemonrpc.UnrollJobStatus
+	(*GetInfoRequest)(nil),                     // 5: daemonrpc.GetInfoRequest
+	(*GetInfoResponse)(nil),                    // 6: daemonrpc.GetInfoResponse
+	(*ServerInfo)(nil),                         // 7: daemonrpc.ServerInfo
+	(*GenSeedRequest)(nil),                     // 8: daemonrpc.GenSeedRequest
+	(*GenSeedResponse)(nil),                    // 9: daemonrpc.GenSeedResponse
+	(*InitWalletRequest)(nil),                  // 10: daemonrpc.InitWalletRequest
+	(*InitWalletResponse)(nil),                 // 11: daemonrpc.InitWalletResponse
+	(*UnlockWalletRequest)(nil),                // 12: daemonrpc.UnlockWalletRequest
+	(*UnlockWalletResponse)(nil),               // 13: daemonrpc.UnlockWalletResponse
+	(*GetBalanceRequest)(nil),                  // 14: daemonrpc.GetBalanceRequest
+	(*GetBalanceResponse)(nil),                 // 15: daemonrpc.GetBalanceResponse
+	(*VTXO)(nil),                               // 16: daemonrpc.VTXO
+	(*ListVTXOsRequest)(nil),                   // 17: daemonrpc.ListVTXOsRequest
+	(*ListVTXOsResponse)(nil),                  // 18: daemonrpc.ListVTXOsResponse
+	(*NewAddressRequest)(nil),                  // 19: daemonrpc.NewAddressRequest
+	(*NewAddressResponse)(nil),                 // 20: daemonrpc.NewAddressResponse
+	(*NewReceiveScriptRequest)(nil),            // 21: daemonrpc.NewReceiveScriptRequest
+	(*NewReceiveScriptResponse)(nil),           // 22: daemonrpc.NewReceiveScriptResponse
+	(*GetIndexedVTXOByPkScriptRequest)(nil),    // 23: daemonrpc.GetIndexedVTXOByPkScriptRequest
+	(*GetIndexedVTXOByPkScriptResponse)(nil),   // 24: daemonrpc.GetIndexedVTXOByPkScriptResponse
+	(*GetIndexedOORSessionByTxidRequest)(nil),  // 25: daemonrpc.GetIndexedOORSessionByTxidRequest
+	(*GetIndexedOORSessionByTxidResponse)(nil), // 26: daemonrpc.GetIndexedOORSessionByTxidResponse
+	(*Output)(nil),                             // 27: daemonrpc.Output
+	(*SendVTXORequest)(nil),                    // 28: daemonrpc.SendVTXORequest
+	(*SendVTXOResponse)(nil),                   // 29: daemonrpc.SendVTXOResponse
+	(*SendOORRequest)(nil),                     // 30: daemonrpc.SendOORRequest
+	(*CustomOORInput)(nil),                     // 31: daemonrpc.CustomOORInput
+	(*SendOORResponse)(nil),                    // 32: daemonrpc.SendOORResponse
+	(*OutpointSelection)(nil),                  // 33: daemonrpc.OutpointSelection
+	(*RefreshVTXOsRequest)(nil),                // 34: daemonrpc.RefreshVTXOsRequest
+	(*RefreshVTXOsResponse)(nil),               // 35: daemonrpc.RefreshVTXOsResponse
+	(*LeaveDestination)(nil),                   // 36: daemonrpc.LeaveDestination
+	(*LeaveVTXOsRequest)(nil),                  // 37: daemonrpc.LeaveVTXOsRequest
+	(*LeaveVTXOsResponse)(nil),                 // 38: daemonrpc.LeaveVTXOsResponse
+	(*BoardRequest)(nil),                       // 39: daemonrpc.BoardRequest
+	(*BoardResponse)(nil),                      // 40: daemonrpc.BoardResponse
+	(*RoundVTXOInfo)(nil),                      // 41: daemonrpc.RoundVTXOInfo
+	(*RoundInfo)(nil),                          // 42: daemonrpc.RoundInfo
+	(*ListRoundsRequest)(nil),                  // 43: daemonrpc.ListRoundsRequest
+	(*GetRoundRequest)(nil),                    // 44: daemonrpc.GetRoundRequest
+	(*GetRoundResponse)(nil),                   // 45: daemonrpc.GetRoundResponse
+	(*ListRoundsResponse)(nil),                 // 46: daemonrpc.ListRoundsResponse
+	(*WatchRoundsRequest)(nil),                 // 47: daemonrpc.WatchRoundsRequest
+	(*WatchRoundsResponse)(nil),                // 48: daemonrpc.WatchRoundsResponse
+	(*OORSessionInfo)(nil),                     // 49: daemonrpc.OORSessionInfo
+	(*ListOORSessionsRequest)(nil),             // 50: daemonrpc.ListOORSessionsRequest
+	(*ListOORSessionsResponse)(nil),            // 51: daemonrpc.ListOORSessionsResponse
+	(*GetOORSessionRequest)(nil),               // 52: daemonrpc.GetOORSessionRequest
+	(*GetOORSessionResponse)(nil),              // 53: daemonrpc.GetOORSessionResponse
+	(*EstimateFeeRequest)(nil),                 // 54: daemonrpc.EstimateFeeRequest
+	(*EstimateFeeResponse)(nil),                // 55: daemonrpc.EstimateFeeResponse
+	(*GetFeeHistoryRequest)(nil),               // 56: daemonrpc.GetFeeHistoryRequest
+	(*FeeHistoryEntry)(nil),                    // 57: daemonrpc.FeeHistoryEntry
+	(*GetFeeHistoryResponse)(nil),              // 58: daemonrpc.GetFeeHistoryResponse
+	(*UnrollRequest)(nil),                      // 59: daemonrpc.UnrollRequest
+	(*UnrollResponse)(nil),                     // 60: daemonrpc.UnrollResponse
+	(*GetUnrollStatusRequest)(nil),             // 61: daemonrpc.GetUnrollStatusRequest
+	(*GetUnrollStatusResponse)(nil),            // 62: daemonrpc.GetUnrollStatusResponse
+	nil,                                        // 63: daemonrpc.LeaveVTXOsRequest.DestinationsEntry
 }
 var file_daemon_proto_depIdxs = []int32{
-	5,  // 0: daemonrpc.GetInfoResponse.server_info:type_name -> daemonrpc.ServerInfo
+	7,  // 0: daemonrpc.GetInfoResponse.server_info:type_name -> daemonrpc.ServerInfo
 	0,  // 1: daemonrpc.VTXO.status:type_name -> daemonrpc.VTXOStatus
 	0,  // 2: daemonrpc.ListVTXOsRequest.status_filter:type_name -> daemonrpc.VTXOStatus
-	14, // 3: daemonrpc.ListVTXOsResponse.vtxos:type_name -> daemonrpc.VTXO
+	16, // 3: daemonrpc.ListVTXOsResponse.vtxos:type_name -> daemonrpc.VTXO
 	0,  // 4: daemonrpc.GetIndexedVTXOByPkScriptRequest.status_filter:type_name -> daemonrpc.VTXOStatus
-	14, // 5: daemonrpc.GetIndexedVTXOByPkScriptResponse.vtxo:type_name -> daemonrpc.VTXO
-	25, // 6: daemonrpc.SendVTXORequest.recipients:type_name -> daemonrpc.Output
-	25, // 7: daemonrpc.SendOORRequest.recipient:type_name -> daemonrpc.Output
-	29, // 8: daemonrpc.SendOORRequest.custom_inputs:type_name -> daemonrpc.CustomOORInput
-	31, // 9: daemonrpc.RefreshVTXOsRequest.outpoints:type_name -> daemonrpc.OutpointSelection
-	31, // 10: daemonrpc.LeaveVTXOsRequest.outpoints:type_name -> daemonrpc.OutpointSelection
-	34, // 11: daemonrpc.LeaveVTXOsRequest.default_destination:type_name -> daemonrpc.LeaveDestination
-	54, // 12: daemonrpc.LeaveVTXOsRequest.destinations:type_name -> daemonrpc.LeaveVTXOsRequest.DestinationsEntry
+	16, // 5: daemonrpc.GetIndexedVTXOByPkScriptResponse.vtxo:type_name -> daemonrpc.VTXO
+	27, // 6: daemonrpc.SendVTXORequest.recipients:type_name -> daemonrpc.Output
+	27, // 7: daemonrpc.SendOORRequest.recipient:type_name -> daemonrpc.Output
+	31, // 8: daemonrpc.SendOORRequest.custom_inputs:type_name -> daemonrpc.CustomOORInput
+	33, // 9: daemonrpc.RefreshVTXOsRequest.outpoints:type_name -> daemonrpc.OutpointSelection
+	33, // 10: daemonrpc.LeaveVTXOsRequest.outpoints:type_name -> daemonrpc.OutpointSelection
+	36, // 11: daemonrpc.LeaveVTXOsRequest.default_destination:type_name -> daemonrpc.LeaveDestination
+	63, // 12: daemonrpc.LeaveVTXOsRequest.destinations:type_name -> daemonrpc.LeaveVTXOsRequest.DestinationsEntry
 	1,  // 13: daemonrpc.RoundInfo.state:type_name -> daemonrpc.RoundState
-	39, // 14: daemonrpc.RoundInfo.vtxos:type_name -> daemonrpc.RoundVTXOInfo
-	40, // 15: daemonrpc.ListRoundsResponse.rounds:type_name -> daemonrpc.RoundInfo
-	40, // 16: daemonrpc.WatchRoundsResponse.round:type_name -> daemonrpc.RoundInfo
-	48, // 17: daemonrpc.GetFeeHistoryResponse.entries:type_name -> daemonrpc.FeeHistoryEntry
-	2,  // 18: daemonrpc.GetUnrollStatusResponse.status:type_name -> daemonrpc.UnrollJobStatus
-	34, // 19: daemonrpc.LeaveVTXOsRequest.DestinationsEntry.value:type_name -> daemonrpc.LeaveDestination
-	3,  // 20: daemonrpc.DaemonService.GetInfo:input_type -> daemonrpc.GetInfoRequest
-	6,  // 21: daemonrpc.DaemonService.GenSeed:input_type -> daemonrpc.GenSeedRequest
-	8,  // 22: daemonrpc.DaemonService.InitWallet:input_type -> daemonrpc.InitWalletRequest
-	10, // 23: daemonrpc.DaemonService.UnlockWallet:input_type -> daemonrpc.UnlockWalletRequest
-	12, // 24: daemonrpc.DaemonService.GetBalance:input_type -> daemonrpc.GetBalanceRequest
-	15, // 25: daemonrpc.DaemonService.ListVTXOs:input_type -> daemonrpc.ListVTXOsRequest
-	17, // 26: daemonrpc.DaemonService.NewAddress:input_type -> daemonrpc.NewAddressRequest
-	19, // 27: daemonrpc.DaemonService.NewReceiveScript:input_type -> daemonrpc.NewReceiveScriptRequest
-	21, // 28: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:input_type -> daemonrpc.GetIndexedVTXOByPkScriptRequest
-	23, // 29: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:input_type -> daemonrpc.GetIndexedOORSessionByTxidRequest
-	26, // 30: daemonrpc.DaemonService.SendVTXO:input_type -> daemonrpc.SendVTXORequest
-	28, // 31: daemonrpc.DaemonService.SendOOR:input_type -> daemonrpc.SendOORRequest
-	32, // 32: daemonrpc.DaemonService.RefreshVTXOs:input_type -> daemonrpc.RefreshVTXOsRequest
-	35, // 33: daemonrpc.DaemonService.LeaveVTXOs:input_type -> daemonrpc.LeaveVTXOsRequest
-	37, // 34: daemonrpc.DaemonService.Board:input_type -> daemonrpc.BoardRequest
-	41, // 35: daemonrpc.DaemonService.ListRounds:input_type -> daemonrpc.ListRoundsRequest
-	43, // 36: daemonrpc.DaemonService.WatchRounds:input_type -> daemonrpc.WatchRoundsRequest
-	45, // 37: daemonrpc.DaemonService.EstimateFee:input_type -> daemonrpc.EstimateFeeRequest
-	47, // 38: daemonrpc.DaemonService.GetFeeHistory:input_type -> daemonrpc.GetFeeHistoryRequest
-	50, // 39: daemonrpc.DaemonService.Unroll:input_type -> daemonrpc.UnrollRequest
-	52, // 40: daemonrpc.DaemonService.GetUnrollStatus:input_type -> daemonrpc.GetUnrollStatusRequest
-	4,  // 41: daemonrpc.DaemonService.GetInfo:output_type -> daemonrpc.GetInfoResponse
-	7,  // 42: daemonrpc.DaemonService.GenSeed:output_type -> daemonrpc.GenSeedResponse
-	9,  // 43: daemonrpc.DaemonService.InitWallet:output_type -> daemonrpc.InitWalletResponse
-	11, // 44: daemonrpc.DaemonService.UnlockWallet:output_type -> daemonrpc.UnlockWalletResponse
-	13, // 45: daemonrpc.DaemonService.GetBalance:output_type -> daemonrpc.GetBalanceResponse
-	16, // 46: daemonrpc.DaemonService.ListVTXOs:output_type -> daemonrpc.ListVTXOsResponse
-	18, // 47: daemonrpc.DaemonService.NewAddress:output_type -> daemonrpc.NewAddressResponse
-	20, // 48: daemonrpc.DaemonService.NewReceiveScript:output_type -> daemonrpc.NewReceiveScriptResponse
-	22, // 49: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:output_type -> daemonrpc.GetIndexedVTXOByPkScriptResponse
-	24, // 50: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:output_type -> daemonrpc.GetIndexedOORSessionByTxidResponse
-	27, // 51: daemonrpc.DaemonService.SendVTXO:output_type -> daemonrpc.SendVTXOResponse
-	30, // 52: daemonrpc.DaemonService.SendOOR:output_type -> daemonrpc.SendOORResponse
-	33, // 53: daemonrpc.DaemonService.RefreshVTXOs:output_type -> daemonrpc.RefreshVTXOsResponse
-	36, // 54: daemonrpc.DaemonService.LeaveVTXOs:output_type -> daemonrpc.LeaveVTXOsResponse
-	38, // 55: daemonrpc.DaemonService.Board:output_type -> daemonrpc.BoardResponse
-	42, // 56: daemonrpc.DaemonService.ListRounds:output_type -> daemonrpc.ListRoundsResponse
-	44, // 57: daemonrpc.DaemonService.WatchRounds:output_type -> daemonrpc.WatchRoundsResponse
-	46, // 58: daemonrpc.DaemonService.EstimateFee:output_type -> daemonrpc.EstimateFeeResponse
-	49, // 59: daemonrpc.DaemonService.GetFeeHistory:output_type -> daemonrpc.GetFeeHistoryResponse
-	51, // 60: daemonrpc.DaemonService.Unroll:output_type -> daemonrpc.UnrollResponse
-	53, // 61: daemonrpc.DaemonService.GetUnrollStatus:output_type -> daemonrpc.GetUnrollStatusResponse
-	41, // [41:62] is the sub-list for method output_type
-	20, // [20:41] is the sub-list for method input_type
-	20, // [20:20] is the sub-list for extension type_name
-	20, // [20:20] is the sub-list for extension extendee
-	0,  // [0:20] is the sub-list for field type_name
+	41, // 14: daemonrpc.RoundInfo.vtxos:type_name -> daemonrpc.RoundVTXOInfo
+	1,  // 15: daemonrpc.ListRoundsRequest.state_filter:type_name -> daemonrpc.RoundState
+	42, // 16: daemonrpc.GetRoundResponse.round:type_name -> daemonrpc.RoundInfo
+	42, // 17: daemonrpc.ListRoundsResponse.rounds:type_name -> daemonrpc.RoundInfo
+	42, // 18: daemonrpc.WatchRoundsResponse.round:type_name -> daemonrpc.RoundInfo
+	2,  // 19: daemonrpc.OORSessionInfo.direction:type_name -> daemonrpc.OORSessionDirection
+	3,  // 20: daemonrpc.OORSessionInfo.status:type_name -> daemonrpc.OORSessionStatus
+	2,  // 21: daemonrpc.ListOORSessionsRequest.direction_filter:type_name -> daemonrpc.OORSessionDirection
+	3,  // 22: daemonrpc.ListOORSessionsRequest.status_filter:type_name -> daemonrpc.OORSessionStatus
+	49, // 23: daemonrpc.ListOORSessionsResponse.sessions:type_name -> daemonrpc.OORSessionInfo
+	49, // 24: daemonrpc.GetOORSessionResponse.session:type_name -> daemonrpc.OORSessionInfo
+	57, // 25: daemonrpc.GetFeeHistoryResponse.entries:type_name -> daemonrpc.FeeHistoryEntry
+	4,  // 26: daemonrpc.GetUnrollStatusResponse.status:type_name -> daemonrpc.UnrollJobStatus
+	36, // 27: daemonrpc.LeaveVTXOsRequest.DestinationsEntry.value:type_name -> daemonrpc.LeaveDestination
+	5,  // 28: daemonrpc.DaemonService.GetInfo:input_type -> daemonrpc.GetInfoRequest
+	8,  // 29: daemonrpc.DaemonService.GenSeed:input_type -> daemonrpc.GenSeedRequest
+	10, // 30: daemonrpc.DaemonService.InitWallet:input_type -> daemonrpc.InitWalletRequest
+	12, // 31: daemonrpc.DaemonService.UnlockWallet:input_type -> daemonrpc.UnlockWalletRequest
+	14, // 32: daemonrpc.DaemonService.GetBalance:input_type -> daemonrpc.GetBalanceRequest
+	17, // 33: daemonrpc.DaemonService.ListVTXOs:input_type -> daemonrpc.ListVTXOsRequest
+	19, // 34: daemonrpc.DaemonService.NewAddress:input_type -> daemonrpc.NewAddressRequest
+	21, // 35: daemonrpc.DaemonService.NewReceiveScript:input_type -> daemonrpc.NewReceiveScriptRequest
+	23, // 36: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:input_type -> daemonrpc.GetIndexedVTXOByPkScriptRequest
+	25, // 37: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:input_type -> daemonrpc.GetIndexedOORSessionByTxidRequest
+	28, // 38: daemonrpc.DaemonService.SendVTXO:input_type -> daemonrpc.SendVTXORequest
+	30, // 39: daemonrpc.DaemonService.SendOOR:input_type -> daemonrpc.SendOORRequest
+	34, // 40: daemonrpc.DaemonService.RefreshVTXOs:input_type -> daemonrpc.RefreshVTXOsRequest
+	37, // 41: daemonrpc.DaemonService.LeaveVTXOs:input_type -> daemonrpc.LeaveVTXOsRequest
+	39, // 42: daemonrpc.DaemonService.Board:input_type -> daemonrpc.BoardRequest
+	43, // 43: daemonrpc.DaemonService.ListRounds:input_type -> daemonrpc.ListRoundsRequest
+	44, // 44: daemonrpc.DaemonService.GetRound:input_type -> daemonrpc.GetRoundRequest
+	47, // 45: daemonrpc.DaemonService.WatchRounds:input_type -> daemonrpc.WatchRoundsRequest
+	50, // 46: daemonrpc.DaemonService.ListOORSessions:input_type -> daemonrpc.ListOORSessionsRequest
+	52, // 47: daemonrpc.DaemonService.GetOORSession:input_type -> daemonrpc.GetOORSessionRequest
+	54, // 48: daemonrpc.DaemonService.EstimateFee:input_type -> daemonrpc.EstimateFeeRequest
+	56, // 49: daemonrpc.DaemonService.GetFeeHistory:input_type -> daemonrpc.GetFeeHistoryRequest
+	59, // 50: daemonrpc.DaemonService.Unroll:input_type -> daemonrpc.UnrollRequest
+	61, // 51: daemonrpc.DaemonService.GetUnrollStatus:input_type -> daemonrpc.GetUnrollStatusRequest
+	6,  // 52: daemonrpc.DaemonService.GetInfo:output_type -> daemonrpc.GetInfoResponse
+	9,  // 53: daemonrpc.DaemonService.GenSeed:output_type -> daemonrpc.GenSeedResponse
+	11, // 54: daemonrpc.DaemonService.InitWallet:output_type -> daemonrpc.InitWalletResponse
+	13, // 55: daemonrpc.DaemonService.UnlockWallet:output_type -> daemonrpc.UnlockWalletResponse
+	15, // 56: daemonrpc.DaemonService.GetBalance:output_type -> daemonrpc.GetBalanceResponse
+	18, // 57: daemonrpc.DaemonService.ListVTXOs:output_type -> daemonrpc.ListVTXOsResponse
+	20, // 58: daemonrpc.DaemonService.NewAddress:output_type -> daemonrpc.NewAddressResponse
+	22, // 59: daemonrpc.DaemonService.NewReceiveScript:output_type -> daemonrpc.NewReceiveScriptResponse
+	24, // 60: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:output_type -> daemonrpc.GetIndexedVTXOByPkScriptResponse
+	26, // 61: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:output_type -> daemonrpc.GetIndexedOORSessionByTxidResponse
+	29, // 62: daemonrpc.DaemonService.SendVTXO:output_type -> daemonrpc.SendVTXOResponse
+	32, // 63: daemonrpc.DaemonService.SendOOR:output_type -> daemonrpc.SendOORResponse
+	35, // 64: daemonrpc.DaemonService.RefreshVTXOs:output_type -> daemonrpc.RefreshVTXOsResponse
+	38, // 65: daemonrpc.DaemonService.LeaveVTXOs:output_type -> daemonrpc.LeaveVTXOsResponse
+	40, // 66: daemonrpc.DaemonService.Board:output_type -> daemonrpc.BoardResponse
+	46, // 67: daemonrpc.DaemonService.ListRounds:output_type -> daemonrpc.ListRoundsResponse
+	45, // 68: daemonrpc.DaemonService.GetRound:output_type -> daemonrpc.GetRoundResponse
+	48, // 69: daemonrpc.DaemonService.WatchRounds:output_type -> daemonrpc.WatchRoundsResponse
+	51, // 70: daemonrpc.DaemonService.ListOORSessions:output_type -> daemonrpc.ListOORSessionsResponse
+	53, // 71: daemonrpc.DaemonService.GetOORSession:output_type -> daemonrpc.GetOORSessionResponse
+	55, // 72: daemonrpc.DaemonService.EstimateFee:output_type -> daemonrpc.EstimateFeeResponse
+	58, // 73: daemonrpc.DaemonService.GetFeeHistory:output_type -> daemonrpc.GetFeeHistoryResponse
+	60, // 74: daemonrpc.DaemonService.Unroll:output_type -> daemonrpc.UnrollResponse
+	62, // 75: daemonrpc.DaemonService.GetUnrollStatus:output_type -> daemonrpc.GetUnrollStatusResponse
+	52, // [52:76] is the sub-list for method output_type
+	28, // [28:52] is the sub-list for method input_type
+	28, // [28:28] is the sub-list for extension type_name
+	28, // [28:28] is the sub-list for extension extendee
+	0,  // [0:28] is the sub-list for field type_name
 }
 
 func init() { file_daemon_proto_init() }
@@ -4276,8 +4984,8 @@ func file_daemon_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_daemon_proto_rawDesc), len(file_daemon_proto_rawDesc)),
-			NumEnums:      3,
-			NumMessages:   52,
+			NumEnums:      5,
+			NumMessages:   59,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/daemonrpc/daemon.proto
+++ b/daemonrpc/daemon.proto
@@ -86,10 +86,25 @@ service DaemonService {
     // the server hasn't assigned one yet).
     rpc ListRounds (ListRoundsRequest) returns (ListRoundsResponse);
 
+    // GetRound returns one known round by server-assigned round ID. The
+    // response includes the live FSM state when the round is still in
+    // memory, or the persisted SQL status and artifacts for completed
+    // rounds.
+    rpc GetRound (GetRoundRequest) returns (GetRoundResponse);
+
     // WatchRounds opens a server-streaming connection that pushes
     // round state updates as they occur. The stream stays open until
     // the client disconnects.
     rpc WatchRounds (WatchRoundsRequest) returns (stream WatchRoundsResponse);
+
+    // ListOORSessions returns locally known out-of-round transfer sessions.
+    // Pending and failed sessions come from the durable OOR actor; completed
+    // sessions come from persisted OOR package artifacts.
+    rpc ListOORSessions (ListOORSessionsRequest)
+        returns (ListOORSessionsResponse);
+
+    // GetOORSession returns one locally known out-of-round transfer session.
+    rpc GetOORSession (GetOORSessionRequest) returns (GetOORSessionResponse);
 
     // EstimateFee returns a fee breakdown for a given VTXO amount at
     // the operator's current rates and utilization. The daemon proxies
@@ -762,6 +777,34 @@ message RoundInfo {
     // for persisted rounds (input_sig_sent, confirmed). Empty for
     // pending/in-memory rounds.
     repeated RoundVTXOInfo vtxos = 4;
+
+    // commitment_txid is the round commitment transaction id when the round
+    // has been persisted.
+    string commitment_txid = 5;
+
+    // commitment_height is the block height that confirmed the commitment
+    // transaction, when known.
+    int32 commitment_height = 6;
+
+    // creation_time is the Unix timestamp when the persisted round row was
+    // first created.
+    int64 creation_time = 7;
+
+    // last_update_time is the Unix timestamp when the persisted round row
+    // was last updated.
+    int64 last_update_time = 8;
+
+    // input_outpoints lists locally known inputs associated with this round.
+    // For boarding rounds this includes locally persisted boarding inputs.
+    repeated string input_outpoints = 9;
+
+    // output_outpoints lists locally known VTXO outpoints created by this
+    // round.
+    repeated string output_outpoints = 10;
+
+    // failure_reason contains the live FSM failure reason when available.
+    // Historical failed rounds loaded only from persistence leave this empty.
+    string failure_reason = 11;
 }
 
 message ListRoundsRequest {
@@ -780,6 +823,30 @@ message ListRoundsRequest {
     // returns only rounds that have been persisted to disk
     // (input_sig_sent, confirmed, etc.).
     bool persisted_only = 3;
+
+    // state_filter restricts results to a single state when set to a value
+    // other than ROUND_STATE_UNKNOWN.
+    RoundState state_filter = 4;
+
+    // created_after restricts persisted rows to rounds created at or after
+    // the given Unix timestamp. Pending in-memory rounds are not filtered by
+    // creation time because they do not expose a stable creation timestamp.
+    int64 created_after = 5;
+
+    // created_before restricts persisted rows to rounds created at or before
+    // the given Unix timestamp. Pending in-memory rounds are not filtered by
+    // creation time because they do not expose a stable creation timestamp.
+    int64 created_before = 6;
+}
+
+message GetRoundRequest {
+    // round_id identifies the server-assigned round to fetch.
+    string round_id = 1;
+}
+
+message GetRoundResponse {
+    // round is the matching round status.
+    RoundInfo round = 1;
 }
 
 message ListRoundsResponse {
@@ -798,6 +865,85 @@ message WatchRoundsResponse {
     // round contains the updated round state. Sent whenever a round
     // FSM transitions to a new state.
     RoundInfo round = 1;
+}
+
+enum OORSessionDirection {
+    OOR_SESSION_DIRECTION_UNSPECIFIED = 0;
+    OOR_SESSION_DIRECTION_OUTGOING = 1;
+    OOR_SESSION_DIRECTION_INCOMING = 2;
+}
+
+enum OORSessionStatus {
+    OOR_SESSION_STATUS_UNSPECIFIED = 0;
+    OOR_SESSION_STATUS_PENDING = 1;
+    OOR_SESSION_STATUS_COMPLETED = 2;
+    OOR_SESSION_STATUS_FAILED = 3;
+}
+
+message OORSessionInfo {
+    // session_id is the stable OOR session identifier.
+    string session_id = 1;
+
+    // direction is from the local client's perspective.
+    OORSessionDirection direction = 2;
+
+    // status is the coarse operation state.
+    OORSessionStatus status = 3;
+
+    // phase is the detailed OOR FSM phase string.
+    string phase = 4;
+
+    // created_at is the Unix timestamp when the persisted package was first
+    // recorded, when known.
+    int64 created_at = 5;
+
+    // updated_at is the Unix timestamp when the session/package was last
+    // updated, when known.
+    int64 updated_at = 6;
+
+    // consumed_outpoints are locally known VTXOs consumed by this session.
+    repeated string consumed_outpoints = 7;
+
+    // created_outpoints are locally known VTXOs created by this session.
+    repeated string created_outpoints = 8;
+
+    // failure_reason is populated for failed live OOR sessions when known.
+    string failure_reason = 9;
+}
+
+message ListOORSessionsRequest {
+    // page_size is the maximum number of sessions to return. If zero, the
+    // daemon uses a default page size.
+    int32 page_size = 1;
+
+    // page_token is an opaque session cursor returned by a previous
+    // ListOORSessionsResponse.
+    string page_token = 2;
+
+    // direction_filter restricts results by local direction when set.
+    OORSessionDirection direction_filter = 3;
+
+    // status_filter restricts results by operation status when set.
+    OORSessionStatus status_filter = 4;
+}
+
+message ListOORSessionsResponse {
+    // sessions lists locally known OOR operation status entries.
+    repeated OORSessionInfo sessions = 1;
+
+    // next_page_token is an opaque cursor for the next page. Empty when
+    // there are no more results.
+    string next_page_token = 2;
+}
+
+message GetOORSessionRequest {
+    // session_id identifies the OOR session to fetch.
+    string session_id = 1;
+}
+
+message GetOORSessionResponse {
+    // session is the matching OOR operation status.
+    OORSessionInfo session = 1;
 }
 
 // EstimateFeeRequest asks the operator to estimate the fee for a

--- a/daemonrpc/daemon_grpc.pb.go
+++ b/daemonrpc/daemon_grpc.pb.go
@@ -35,7 +35,10 @@ const (
 	DaemonService_LeaveVTXOs_FullMethodName                 = "/daemonrpc.DaemonService/LeaveVTXOs"
 	DaemonService_Board_FullMethodName                      = "/daemonrpc.DaemonService/Board"
 	DaemonService_ListRounds_FullMethodName                 = "/daemonrpc.DaemonService/ListRounds"
+	DaemonService_GetRound_FullMethodName                   = "/daemonrpc.DaemonService/GetRound"
 	DaemonService_WatchRounds_FullMethodName                = "/daemonrpc.DaemonService/WatchRounds"
+	DaemonService_ListOORSessions_FullMethodName            = "/daemonrpc.DaemonService/ListOORSessions"
+	DaemonService_GetOORSession_FullMethodName              = "/daemonrpc.DaemonService/GetOORSession"
 	DaemonService_EstimateFee_FullMethodName                = "/daemonrpc.DaemonService/EstimateFee"
 	DaemonService_GetFeeHistory_FullMethodName              = "/daemonrpc.DaemonService/GetFeeHistory"
 	DaemonService_Unroll_FullMethodName                     = "/daemonrpc.DaemonService/Unroll"
@@ -109,10 +112,21 @@ type DaemonServiceClient interface {
 	// Each round is identified by its round ID (or a temporary key if
 	// the server hasn't assigned one yet).
 	ListRounds(ctx context.Context, in *ListRoundsRequest, opts ...grpc.CallOption) (*ListRoundsResponse, error)
+	// GetRound returns one known round by server-assigned round ID. The
+	// response includes the live FSM state when the round is still in
+	// memory, or the persisted SQL status and artifacts for completed
+	// rounds.
+	GetRound(ctx context.Context, in *GetRoundRequest, opts ...grpc.CallOption) (*GetRoundResponse, error)
 	// WatchRounds opens a server-streaming connection that pushes
 	// round state updates as they occur. The stream stays open until
 	// the client disconnects.
 	WatchRounds(ctx context.Context, in *WatchRoundsRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[WatchRoundsResponse], error)
+	// ListOORSessions returns locally known out-of-round transfer sessions.
+	// Pending and failed sessions come from the durable OOR actor; completed
+	// sessions come from persisted OOR package artifacts.
+	ListOORSessions(ctx context.Context, in *ListOORSessionsRequest, opts ...grpc.CallOption) (*ListOORSessionsResponse, error)
+	// GetOORSession returns one locally known out-of-round transfer session.
+	GetOORSession(ctx context.Context, in *GetOORSessionRequest, opts ...grpc.CallOption) (*GetOORSessionResponse, error)
 	// EstimateFee returns a fee breakdown for a given VTXO amount at
 	// the operator's current rates and utilization. The daemon proxies
 	// this to the server's EstimateFee RPC.
@@ -298,6 +312,16 @@ func (c *daemonServiceClient) ListRounds(ctx context.Context, in *ListRoundsRequ
 	return out, nil
 }
 
+func (c *daemonServiceClient) GetRound(ctx context.Context, in *GetRoundRequest, opts ...grpc.CallOption) (*GetRoundResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetRoundResponse)
+	err := c.cc.Invoke(ctx, DaemonService_GetRound_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *daemonServiceClient) WatchRounds(ctx context.Context, in *WatchRoundsRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[WatchRoundsResponse], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	stream, err := c.cc.NewStream(ctx, &DaemonService_ServiceDesc.Streams[0], DaemonService_WatchRounds_FullMethodName, cOpts...)
@@ -316,6 +340,26 @@ func (c *daemonServiceClient) WatchRounds(ctx context.Context, in *WatchRoundsRe
 
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type DaemonService_WatchRoundsClient = grpc.ServerStreamingClient[WatchRoundsResponse]
+
+func (c *daemonServiceClient) ListOORSessions(ctx context.Context, in *ListOORSessionsRequest, opts ...grpc.CallOption) (*ListOORSessionsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListOORSessionsResponse)
+	err := c.cc.Invoke(ctx, DaemonService_ListOORSessions_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *daemonServiceClient) GetOORSession(ctx context.Context, in *GetOORSessionRequest, opts ...grpc.CallOption) (*GetOORSessionResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetOORSessionResponse)
+	err := c.cc.Invoke(ctx, DaemonService_GetOORSession_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
 
 func (c *daemonServiceClient) EstimateFee(ctx context.Context, in *EstimateFeeRequest, opts ...grpc.CallOption) (*EstimateFeeResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
@@ -424,10 +468,21 @@ type DaemonServiceServer interface {
 	// Each round is identified by its round ID (or a temporary key if
 	// the server hasn't assigned one yet).
 	ListRounds(context.Context, *ListRoundsRequest) (*ListRoundsResponse, error)
+	// GetRound returns one known round by server-assigned round ID. The
+	// response includes the live FSM state when the round is still in
+	// memory, or the persisted SQL status and artifacts for completed
+	// rounds.
+	GetRound(context.Context, *GetRoundRequest) (*GetRoundResponse, error)
 	// WatchRounds opens a server-streaming connection that pushes
 	// round state updates as they occur. The stream stays open until
 	// the client disconnects.
 	WatchRounds(*WatchRoundsRequest, grpc.ServerStreamingServer[WatchRoundsResponse]) error
+	// ListOORSessions returns locally known out-of-round transfer sessions.
+	// Pending and failed sessions come from the durable OOR actor; completed
+	// sessions come from persisted OOR package artifacts.
+	ListOORSessions(context.Context, *ListOORSessionsRequest) (*ListOORSessionsResponse, error)
+	// GetOORSession returns one locally known out-of-round transfer session.
+	GetOORSession(context.Context, *GetOORSessionRequest) (*GetOORSessionResponse, error)
 	// EstimateFee returns a fee breakdown for a given VTXO amount at
 	// the operator's current rates and utilization. The daemon proxies
 	// this to the server's EstimateFee RPC.
@@ -501,8 +556,17 @@ func (UnimplementedDaemonServiceServer) Board(context.Context, *BoardRequest) (*
 func (UnimplementedDaemonServiceServer) ListRounds(context.Context, *ListRoundsRequest) (*ListRoundsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ListRounds not implemented")
 }
+func (UnimplementedDaemonServiceServer) GetRound(context.Context, *GetRoundRequest) (*GetRoundResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetRound not implemented")
+}
 func (UnimplementedDaemonServiceServer) WatchRounds(*WatchRoundsRequest, grpc.ServerStreamingServer[WatchRoundsResponse]) error {
 	return status.Errorf(codes.Unimplemented, "method WatchRounds not implemented")
+}
+func (UnimplementedDaemonServiceServer) ListOORSessions(context.Context, *ListOORSessionsRequest) (*ListOORSessionsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListOORSessions not implemented")
+}
+func (UnimplementedDaemonServiceServer) GetOORSession(context.Context, *GetOORSessionRequest) (*GetOORSessionResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetOORSession not implemented")
 }
 func (UnimplementedDaemonServiceServer) EstimateFee(context.Context, *EstimateFeeRequest) (*EstimateFeeResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method EstimateFee not implemented")
@@ -825,6 +889,24 @@ func _DaemonService_ListRounds_Handler(srv interface{}, ctx context.Context, dec
 	return interceptor(ctx, in, info, handler)
 }
 
+func _DaemonService_GetRound_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetRoundRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DaemonServiceServer).GetRound(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DaemonService_GetRound_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DaemonServiceServer).GetRound(ctx, req.(*GetRoundRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _DaemonService_WatchRounds_Handler(srv interface{}, stream grpc.ServerStream) error {
 	m := new(WatchRoundsRequest)
 	if err := stream.RecvMsg(m); err != nil {
@@ -835,6 +917,42 @@ func _DaemonService_WatchRounds_Handler(srv interface{}, stream grpc.ServerStrea
 
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type DaemonService_WatchRoundsServer = grpc.ServerStreamingServer[WatchRoundsResponse]
+
+func _DaemonService_ListOORSessions_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListOORSessionsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DaemonServiceServer).ListOORSessions(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DaemonService_ListOORSessions_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DaemonServiceServer).ListOORSessions(ctx, req.(*ListOORSessionsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DaemonService_GetOORSession_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetOORSessionRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DaemonServiceServer).GetOORSession(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DaemonService_GetOORSession_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DaemonServiceServer).GetOORSession(ctx, req.(*GetOORSessionRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
 
 func _DaemonService_EstimateFee_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(EstimateFeeRequest)
@@ -978,6 +1096,18 @@ var DaemonService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ListRounds",
 			Handler:    _DaemonService_ListRounds_Handler,
+		},
+		{
+			MethodName: "GetRound",
+			Handler:    _DaemonService_GetRound_Handler,
+		},
+		{
+			MethodName: "ListOORSessions",
+			Handler:    _DaemonService_ListOORSessions_Handler,
+		},
+		{
+			MethodName: "GetOORSession",
+			Handler:    _DaemonService_GetOORSession_Handler,
 		},
 		{
 			MethodName: "EstimateFee",

--- a/daemonrpc/daemon_mailboxrpc.pb.go
+++ b/daemonrpc/daemon_mailboxrpc.pb.go
@@ -56,8 +56,14 @@ type DaemonServiceMailboxServer interface {
 	Board(ctx context.Context, req *BoardRequest) (*BoardResponse, error)
 	// ListRounds handles ListRounds.
 	ListRounds(ctx context.Context, req *ListRoundsRequest) (*ListRoundsResponse, error)
+	// GetRound handles GetRound.
+	GetRound(ctx context.Context, req *GetRoundRequest) (*GetRoundResponse, error)
 	// WatchRounds handles WatchRounds.
 	WatchRounds(ctx context.Context, req *WatchRoundsRequest) (*WatchRoundsResponse, error)
+	// ListOORSessions handles ListOORSessions.
+	ListOORSessions(ctx context.Context, req *ListOORSessionsRequest) (*ListOORSessionsResponse, error)
+	// GetOORSession handles GetOORSession.
+	GetOORSession(ctx context.Context, req *GetOORSessionRequest) (*GetOORSessionResponse, error)
 	// EstimateFee handles EstimateFee.
 	EstimateFee(ctx context.Context, req *EstimateFeeRequest) (*EstimateFeeResponse, error)
 	// GetFeeHistory handles GetFeeHistory.
@@ -230,6 +236,16 @@ func RegisterDaemonServiceMailboxServer(r rpc.Router, impl DaemonServiceMailboxS
 
 		return impl.ListRounds(ctx, req)
 	})
+	r.Handle("daemonrpc.DaemonService", "GetRound", func() proto.Message {
+		return &GetRoundRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*GetRoundRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.GetRound(ctx, req)
+	})
 	r.Handle("daemonrpc.DaemonService", "WatchRounds", func() proto.Message {
 		return &WatchRoundsRequest{}
 	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
@@ -239,6 +255,26 @@ func RegisterDaemonServiceMailboxServer(r rpc.Router, impl DaemonServiceMailboxS
 		}
 
 		return impl.WatchRounds(ctx, req)
+	})
+	r.Handle("daemonrpc.DaemonService", "ListOORSessions", func() proto.Message {
+		return &ListOORSessionsRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*ListOORSessionsRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.ListOORSessions(ctx, req)
+	})
+	r.Handle("daemonrpc.DaemonService", "GetOORSession", func() proto.Message {
+		return &GetOORSessionRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*GetOORSessionRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.GetOORSession(ctx, req)
 	})
 	r.Handle("daemonrpc.DaemonService", "EstimateFee", func() proto.Message {
 		return &EstimateFeeRequest{}
@@ -650,6 +686,29 @@ func (c *DaemonServiceMailboxClient) ListRounds(ctx context.Context, req *ListRo
 	return resp, nil
 }
 
+// GetRound calls the GetRound RPC.
+func (c *DaemonServiceMailboxClient) GetRound(ctx context.Context, req *GetRoundRequest, opts ...rpc.RPCOptions) (*GetRoundResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "daemonrpc.DaemonService",
+		Method:  "GetRound",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(GetRoundResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
 // WatchRounds calls the WatchRounds RPC.
 func (c *DaemonServiceMailboxClient) WatchRounds(ctx context.Context, req *WatchRoundsRequest, opts ...rpc.RPCOptions) (*WatchRoundsResponse, error) {
 	var opt rpc.RPCOptions
@@ -666,6 +725,52 @@ func (c *DaemonServiceMailboxClient) WatchRounds(ctx context.Context, req *Watch
 	}
 
 	resp := new(WatchRoundsResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// ListOORSessions calls the ListOORSessions RPC.
+func (c *DaemonServiceMailboxClient) ListOORSessions(ctx context.Context, req *ListOORSessionsRequest, opts ...rpc.RPCOptions) (*ListOORSessionsResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "daemonrpc.DaemonService",
+		Method:  "ListOORSessions",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(ListOORSessionsResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// GetOORSession calls the GetOORSession RPC.
+func (c *DaemonServiceMailboxClient) GetOORSession(ctx context.Context, req *GetOORSessionRequest, opts ...rpc.RPCOptions) (*GetOORSessionResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "daemonrpc.DaemonService",
+		Method:  "GetOORSession",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(GetOORSessionResponse)
 	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
 		return nil, err
 	}

--- a/darepod/AGENTS.md
+++ b/darepod/AGENTS.md
@@ -27,14 +27,14 @@ gRPC API.
 - `SendVTXO` — RPC handler for in-round directed sends. Validates recipients (count cap, positive and `MaxSatoshi`-bounded amounts, overflow-safe sum), resolves destinations via `resolveRecipientOutput`, and delegates to the wallet actor.
 - `resolveRecipientOutput` — Extracts pkScript and client pubkey from an `Output` proto oneof (pubkey or address). Enforces taproot-only for directed sends.
 - `registerIncomingVTXOEventRoute` — Registers the `arkrpc.IncomingVTXOEvent` mailbox route under `MethodIncomingVTXO`, dispatching decoded events to the incoming VTXO handler actor via its service key.
-- `ListOORSessions` — RPC handler that returns locally persisted OOR
-  session progress. Delegates to the OOR actor via `oor.ClientActorCfg`'s
-  session list path, mapping `OORSessionDirection` proto enum
-  ↔ `oor.SessionDirection`, and converting each summary via
-  `oorSessionSummaryToProto`. Filters by `Pending` and `Direction` from the
-  request; response fields include `SessionID`, `Direction`, `Phase`,
-  `Pending`, `RetryAfter`, `RetryReason`, `InputOutpoints`,
-  `InputAmountSat`, and `RecipientCount`.
+- `GetRound` / `ListRounds` — RPC handlers for round operation status. Live
+  rounds come from the round actor; persisted rounds come from SQL summaries
+  including commitment txid, confirmation height, creation/update timestamps,
+  locally known inputs, and created VTXOs.
+- `GetOORSession` / `ListOORSessions` — RPC handlers for OOR operation status.
+  Pending and failed sessions come from the OOR actor's `ListSessionsRequest`;
+  completed sessions come from persisted OOR package artifacts. The merge keeps
+  actor state authoritative when both live and persisted views exist.
 - `initLedgerActor` — Constructs `ledger.LedgerActor` with both `db.NewLedgerStoreDB` (double-entry ledger) and `db.NewUTXOAuditStoreDB` (UTXO audit log) as stores, starts it, registers it with the actor system under `ledger.ServiceKeyName`, and stashes the `LedgerStoreDB` on the `Server` as `s.ledgerStore` so the RPC layer can read paginated history without going through the actor mailbox. Called in `run` after the DB and delivery store are ready but before wallet unlock, since the actor does not depend on wallet state.
 - `EstimateFee` — RPC handler that proxies to the operator's `EstimateFee` over the direct gRPC connection (`s.serverConn`, reused from `fetchOperatorTerms`). No local caching: the operator's reply reflects live treasury utilization, so callers always see fresh numbers.
 - `GetFeeHistory` — RPC handler that reads through `s.ledgerStore.ListLedgerEntriesWithFeesTotal` for mutual consistency between the page and the cumulative operator-fees-paid total. Validates limit/offset bounds (offset clamped to `math.MaxInt32`) and converts sqlc rows to proto `FeeHistoryEntry` with debit/credit accounts, round_id, session_id, and event_type verbatim via `ledgerEntryToProto`.

--- a/darepod/CLAUDE.md
+++ b/darepod/CLAUDE.md
@@ -27,14 +27,14 @@ gRPC API.
 - `SendVTXO` — RPC handler for in-round directed sends. Validates recipients (count cap, positive and `MaxSatoshi`-bounded amounts, overflow-safe sum), resolves destinations via `resolveRecipientOutput`, and delegates to the wallet actor.
 - `resolveRecipientOutput` — Extracts pkScript and client pubkey from an `Output` proto oneof (pubkey or address). Enforces taproot-only for directed sends.
 - `registerIncomingVTXOEventRoute` — Registers the `arkrpc.IncomingVTXOEvent` mailbox route under `MethodIncomingVTXO`, dispatching decoded events to the incoming VTXO handler actor via its service key.
-- `ListOORSessions` — RPC handler that returns locally persisted OOR
-  session progress. Delegates to the OOR actor via `oor.ClientActorCfg`'s
-  session list path, mapping `OORSessionDirection` proto enum
-  ↔ `oor.SessionDirection`, and converting each summary via
-  `oorSessionSummaryToProto`. Filters by `Pending` and `Direction` from the
-  request; response fields include `SessionID`, `Direction`, `Phase`,
-  `Pending`, `RetryAfter`, `RetryReason`, `InputOutpoints`,
-  `InputAmountSat`, and `RecipientCount`.
+- `GetRound` / `ListRounds` — RPC handlers for round operation status. Live
+  rounds come from the round actor; persisted rounds come from SQL summaries
+  including commitment txid, confirmation height, creation/update timestamps,
+  locally known inputs, and created VTXOs.
+- `GetOORSession` / `ListOORSessions` — RPC handlers for OOR operation status.
+  Pending and failed sessions come from the OOR actor's `ListSessionsRequest`;
+  completed sessions come from persisted OOR package artifacts. The merge keeps
+  actor state authoritative when both live and persisted views exist.
 - `initLedgerActor` — Constructs `ledger.LedgerActor` with both `db.NewLedgerStoreDB` (double-entry ledger) and `db.NewUTXOAuditStoreDB` (UTXO audit log) as stores, starts it, registers it with the actor system under `ledger.ServiceKeyName`, and stashes the `LedgerStoreDB` on the `Server` as `s.ledgerStore` so the RPC layer can read paginated history without going through the actor mailbox. Called in `run` after the DB and delivery store are ready but before wallet unlock, since the actor does not depend on wallet state.
 - `EstimateFee` — RPC handler that proxies to the operator's `EstimateFee` over the direct gRPC connection (`s.serverConn`, reused from `fetchOperatorTerms`). No local caching: the operator's reply reflects live treasury utilization, so callers always see fresh numbers.
 - `GetFeeHistory` — RPC handler that reads through `s.ledgerStore.ListLedgerEntriesWithFeesTotal` for mutual consistency between the page and the cumulative operator-fees-paid total. Validates limit/offset bounds (offset clamped to `math.MaxInt32`) and converts sqlc rows to proto `FeeHistoryEntry` with debit/credit accounts, round_id, session_id, and event_type verbatim via `ledgerEntryToProto`.

--- a/darepod/rpc_operation_status.go
+++ b/darepod/rpc_operation_status.go
@@ -1,0 +1,597 @@
+package darepod
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/lightninglabs/darepo-client/db"
+	"github.com/lightninglabs/darepo-client/oor"
+	"github.com/lightninglabs/darepo-client/round"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	// defaultListOORSessionsPageSize is used when callers omit page_size.
+	defaultListOORSessionsPageSize = 100
+)
+
+// GetRound returns one live or persisted round status entry by round id.
+func (r *RPCServer) GetRound(ctx context.Context,
+	req *daemonrpc.GetRoundRequest) (*daemonrpc.GetRoundResponse, error) {
+
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument,
+			"request must be provided")
+	}
+
+	if req.RoundId == "" {
+		return nil, status.Error(codes.InvalidArgument,
+			"round_id must be provided")
+	}
+
+	if r.server.actorSystem != nil {
+		live, err := r.queryRoundStates(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, info := range live {
+			if info.GetRoundId() == req.RoundId {
+				return &daemonrpc.GetRoundResponse{
+					Round: info,
+				}, nil
+			}
+		}
+	}
+
+	if r.server.roundStore == nil {
+		return nil, status.Error(codes.NotFound, "round not found")
+	}
+
+	summary, err := r.server.roundStore.GetRoundSummary(ctx, req.RoundId)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, status.Error(codes.NotFound,
+				"round not found")
+		}
+
+		return nil, status.Errorf(codes.Internal,
+			"failed to get persisted round: %v", err)
+	}
+
+	return &daemonrpc.GetRoundResponse{
+		Round: roundSummaryToProto(summary),
+	}, nil
+}
+
+// ListOORSessions returns locally known OOR operation status entries.
+func (r *RPCServer) ListOORSessions(ctx context.Context,
+	req *daemonrpc.ListOORSessionsRequest) (
+	*daemonrpc.ListOORSessionsResponse, error) {
+
+	if req == nil {
+		req = &daemonrpc.ListOORSessionsRequest{}
+	}
+
+	pageSize := req.PageSize
+	if pageSize <= 0 {
+		pageSize = defaultListOORSessionsPageSize
+	}
+
+	sessions, err := r.listOORSessions(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	page, nextToken := pageOORSessions(sessions, req.PageToken, pageSize)
+
+	return &daemonrpc.ListOORSessionsResponse{
+		Sessions:      page,
+		NextPageToken: nextToken,
+	}, nil
+}
+
+// GetOORSession returns one locally known OOR operation status entry.
+func (r *RPCServer) GetOORSession(ctx context.Context,
+	req *daemonrpc.GetOORSessionRequest) (
+	*daemonrpc.GetOORSessionResponse, error) {
+
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument,
+			"request must be provided")
+	}
+
+	if req.SessionId == "" {
+		return nil, status.Error(codes.InvalidArgument,
+			"session_id must be provided")
+	}
+
+	sessionID, err := parseOORSessionID(req.SessionId)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	normalizedID := sessionID.String()
+
+	listReq := &daemonrpc.ListOORSessionsRequest{}
+	sessions, err := r.listOORSessions(ctx, listReq)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, session := range sessions {
+		if session.GetSessionId() == normalizedID {
+			return &daemonrpc.GetOORSessionResponse{
+				Session: session,
+			}, nil
+		}
+	}
+
+	return nil, status.Error(codes.NotFound, "OOR session not found")
+}
+
+// listOORSessions merges actor summaries and persisted package artifacts.
+func (r *RPCServer) listOORSessions(ctx context.Context,
+	req *daemonrpc.ListOORSessionsRequest) ([]*daemonrpc.OORSessionInfo,
+	error) {
+
+	merged := make(map[string]*daemonrpc.OORSessionInfo)
+
+	live, err := r.queryOORSessionSummaries(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, session := range live {
+		merged[session.GetSessionId()] = session
+	}
+
+	persisted, err := r.queryPersistedOORSessions(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, session := range persisted {
+		if existing, ok := merged[session.GetSessionId()]; ok {
+			mergeOORSessionInfo(existing, session)
+			continue
+		}
+
+		merged[session.GetSessionId()] = session
+	}
+
+	sessions := make([]*daemonrpc.OORSessionInfo, 0, len(merged))
+	for _, session := range merged {
+		sessions = append(sessions, session)
+	}
+
+	sort.Slice(sessions, func(i, j int) bool {
+		return sessions[i].GetSessionId() < sessions[j].GetSessionId()
+	})
+
+	return sessions, nil
+}
+
+// mergeOORSessionInfo fills artifact-backed fields missing from live state.
+func mergeOORSessionInfo(dst *daemonrpc.OORSessionInfo,
+	src *daemonrpc.OORSessionInfo) {
+
+	if dst == nil || src == nil {
+		return
+	}
+
+	if dst.CreatedAt == 0 {
+		dst.CreatedAt = src.GetCreatedAt()
+	}
+	if dst.UpdatedAt == 0 {
+		dst.UpdatedAt = src.GetUpdatedAt()
+	}
+	if len(dst.ConsumedOutpoints) == 0 {
+		dst.ConsumedOutpoints = append(
+			[]string(nil), src.GetConsumedOutpoints()...,
+		)
+	}
+	if len(dst.CreatedOutpoints) == 0 {
+		dst.CreatedOutpoints = append(
+			[]string(nil), src.GetCreatedOutpoints()...,
+		)
+	}
+}
+
+// queryOORSessionSummaries fetches live OOR summaries from the actor.
+func (r *RPCServer) queryOORSessionSummaries(ctx context.Context,
+	req *daemonrpc.ListOORSessionsRequest) ([]*daemonrpc.OORSessionInfo,
+	error) {
+
+	if r.server.actorSystem == nil {
+		return nil, nil
+	}
+
+	oorRef := oor.NewServiceKey().Ref(r.server.actorSystem)
+	listReq := &oor.ListSessionsRequest{
+		Direction: protoToOORSessionDirection(
+			req.GetDirectionFilter(),
+		),
+		PendingOnly: req.GetStatusFilter() ==
+			daemonrpc.OORSessionStatus_OOR_SESSION_STATUS_PENDING,
+	}
+
+	future := oorRef.Ask(ctx, listReq)
+	result := future.Await(ctx)
+
+	actorResp, err := result.Unpack()
+	if err != nil {
+		if errors.Is(err, actor.ErrNoActorsAvailable) {
+			return nil, nil
+		}
+
+		return nil, status.Errorf(codes.Internal,
+			"failed to query OOR actor: %v", err)
+	}
+
+	resp, ok := actorResp.(*oor.ListSessionsResponse)
+	if !ok {
+		return nil, status.Errorf(codes.Internal,
+			"unexpected OOR list response type: %T", actorResp)
+	}
+
+	out := make([]*daemonrpc.OORSessionInfo, 0, len(resp.Sessions))
+	for _, summary := range resp.Sessions {
+		info := oorSessionSummaryToProto(summary)
+
+		// Keep the RPC-level filter pass even though the actor also
+		// receives the filter request. This keeps persisted and live
+		// filtering behavior identical, and protects callers if future
+		// actors return extra fields that should still be filtered.
+		if !oorSessionMatchesFilters(info, req) {
+			continue
+		}
+
+		out = append(out, info)
+	}
+
+	return out, nil
+}
+
+// queryPersistedOORSessions fetches completed package status from disk.
+func (r *RPCServer) queryPersistedOORSessions(ctx context.Context,
+	req *daemonrpc.ListOORSessionsRequest) ([]*daemonrpc.OORSessionInfo,
+	error) {
+
+	if req.GetStatusFilter() ==
+		daemonrpc.OORSessionStatus_OOR_SESSION_STATUS_PENDING {
+
+		return nil, nil
+	}
+
+	store := r.newLocalOORArtifactStore()
+	if store == nil {
+		return nil, nil
+	}
+
+	direction := protoToPackageDirection(req.GetDirectionFilter())
+	packages, err := store.ListPackages(ctx, direction)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"failed to list persisted OOR packages: %v", err)
+	}
+
+	out := make([]*daemonrpc.OORSessionInfo, 0, len(packages))
+	for _, pkg := range packages {
+		info := oorPackageToProto(pkg)
+		if !oorSessionMatchesFilters(info, req) {
+			continue
+		}
+
+		out = append(out, info)
+	}
+
+	return out, nil
+}
+
+// roundSummaryToProto converts one persisted round summary to daemonrpc.
+func roundSummaryToProto(summary *db.RoundSummary) *daemonrpc.RoundInfo {
+	if summary == nil {
+		return nil
+	}
+
+	info := &daemonrpc.RoundInfo{
+		RoundId:        summary.RoundID.String(),
+		State:          dbStatusToProto(summary.Status),
+		IsTemp:         false,
+		CreationTime:   summary.CreationTime,
+		LastUpdateTime: summary.LastUpdateTime,
+	}
+
+	if summary.CommitmentTxID.IsSome() {
+		txid := summary.CommitmentTxID.UnwrapOr(chainhash.Hash{})
+		info.CommitmentTxid = txid.String()
+	}
+
+	if summary.ConfirmationHeight.IsSome() {
+		height := summary.ConfirmationHeight.UnwrapOr(0)
+		info.CommitmentHeight = height
+	}
+
+	info.InputOutpoints = outpointsToStrings(summary.InputOutpoints)
+	info.OutputOutpoints = make([]string, 0, len(summary.VTXOs))
+	for _, v := range summary.VTXOs {
+		outpoint := v.Outpoint.String()
+		info.OutputOutpoints = append(info.OutputOutpoints, outpoint)
+		info.Vtxos = append(info.Vtxos, &daemonrpc.RoundVTXOInfo{
+			Outpoint:  outpoint,
+			AmountSat: int64(v.Amount),
+		})
+	}
+
+	return info
+}
+
+// roundInfoMatchesFilters reports whether a round should be returned.
+func roundInfoMatchesFilters(info *daemonrpc.RoundInfo,
+	req *daemonrpc.ListRoundsRequest) bool {
+
+	if info == nil || req == nil {
+		return false
+	}
+
+	if req.GetStateFilter() != daemonrpc.RoundState_ROUND_STATE_UNKNOWN &&
+		info.GetState() != req.GetStateFilter() {
+
+		return false
+	}
+
+	if info.GetCreationTime() != 0 {
+		created := time.Unix(info.GetCreationTime(), 0)
+		if req.GetCreatedAfter() != 0 &&
+			created.Before(time.Unix(req.GetCreatedAfter(), 0)) {
+
+			return false
+		}
+
+		if req.GetCreatedBefore() != 0 &&
+			created.After(time.Unix(req.GetCreatedBefore(), 0)) {
+
+			return false
+		}
+	}
+
+	return true
+}
+
+// roundFailureReason returns a human-readable reason for failed live rounds.
+func roundFailureReason(state round.ClientState) string {
+	failed, ok := state.(*round.ClientFailedState)
+	if !ok || failed == nil {
+		return ""
+	}
+
+	if failed.Reason != "" {
+		return failed.Reason
+	}
+
+	if failed.Error != nil {
+		return failed.Error.Error()
+	}
+
+	return ""
+}
+
+// oorSessionSummaryToProto converts an in-memory OOR actor summary.
+func oorSessionSummaryToProto(
+	summary oor.SessionSummary) *daemonrpc.OORSessionInfo {
+
+	status := daemonrpc.OORSessionStatus_OOR_SESSION_STATUS_PENDING
+	if !summary.Pending {
+		status = daemonrpc.OORSessionStatus_OOR_SESSION_STATUS_COMPLETED
+	}
+	if summary.Phase == string(oor.OutgoingPhaseFailed) ||
+		summary.Phase == string(oor.IncomingPhaseFailed) {
+
+		status = daemonrpc.OORSessionStatus_OOR_SESSION_STATUS_FAILED
+	}
+
+	return &daemonrpc.OORSessionInfo{
+		SessionId:         summary.SessionID.String(),
+		Direction:         oorDirectionToProto(summary.Direction),
+		Status:            status,
+		Phase:             summary.Phase,
+		ConsumedOutpoints: outpointsToStrings(summary.InputOutpoints),
+		FailureReason:     summary.RetryReason,
+	}
+}
+
+// oorPackageToProto converts one persisted OOR package artifact to daemonrpc.
+func oorPackageToProto(pkg *db.OORPackageBundle) *daemonrpc.OORSessionInfo {
+	if pkg == nil {
+		return nil
+	}
+
+	completed := daemonrpc.OORSessionStatus_OOR_SESSION_STATUS_COMPLETED
+	info := &daemonrpc.OORSessionInfo{
+		SessionId: pkg.SessionID.String(),
+		Direction: packageDirectionToProto(pkg.Direction),
+		Status:    completed,
+		Phase:     "completed",
+		CreatedAt: pkg.CreatedAt.Unix(),
+		UpdatedAt: pkg.UpdatedAt.Unix(),
+	}
+
+	for _, binding := range pkg.Bindings {
+		switch binding.LinkKind {
+		case db.OORPackageLinkKindConsumedInput:
+			info.ConsumedOutpoints = append(
+				info.ConsumedOutpoints,
+				binding.Outpoint.String(),
+			)
+
+		case db.OORPackageLinkKindCreatedOutput:
+			info.CreatedOutpoints = append(
+				info.CreatedOutpoints,
+				binding.Outpoint.String(),
+			)
+		}
+	}
+
+	sort.Strings(info.ConsumedOutpoints)
+	sort.Strings(info.CreatedOutpoints)
+
+	return info
+}
+
+// oorSessionMatchesFilters reports whether a session should be returned.
+func oorSessionMatchesFilters(info *daemonrpc.OORSessionInfo,
+	req *daemonrpc.ListOORSessionsRequest) bool {
+
+	if info == nil || req == nil {
+		return false
+	}
+
+	unspecified := daemonrpc.
+		OORSessionDirection_OOR_SESSION_DIRECTION_UNSPECIFIED
+	if req.GetDirectionFilter() != unspecified &&
+		info.GetDirection() != req.GetDirectionFilter() {
+
+		return false
+	}
+
+	if req.GetStatusFilter() !=
+		daemonrpc.OORSessionStatus_OOR_SESSION_STATUS_UNSPECIFIED &&
+		info.GetStatus() != req.GetStatusFilter() {
+
+		return false
+	}
+
+	return true
+}
+
+// pageOORSessions slices sorted OOR sessions using a session-id cursor.
+func pageOORSessions(
+	sessions []*daemonrpc.OORSessionInfo, pageToken string,
+	pageSize int32) ([]*daemonrpc.OORSessionInfo, string) {
+
+	start := 0
+	if pageToken != "" {
+		for i, session := range sessions {
+			if session.GetSessionId() > pageToken {
+				start = i
+				break
+			}
+			start = i + 1
+		}
+	}
+
+	end := start + int(pageSize)
+	if end > len(sessions) {
+		end = len(sessions)
+	}
+
+	page := sessions[start:end]
+	if end >= len(sessions) {
+		return page, ""
+	}
+
+	return page, page[len(page)-1].GetSessionId()
+}
+
+// outpointsToStrings converts wire outpoints to their canonical strings.
+func outpointsToStrings(outpoints []wire.OutPoint) []string {
+	strings := make([]string, 0, len(outpoints))
+	for _, outpoint := range outpoints {
+		strings = append(strings, outpoint.String())
+	}
+
+	sort.Strings(strings)
+
+	return strings
+}
+
+// protoToOORSessionDirection maps the daemon RPC enum to the actor enum.
+func protoToOORSessionDirection(
+	direction daemonrpc.OORSessionDirection) oor.SessionDirection {
+
+	switch direction {
+	case daemonrpc.OORSessionDirection_OOR_SESSION_DIRECTION_OUTGOING:
+		return oor.SessionDirectionOutgoing
+
+	case daemonrpc.OORSessionDirection_OOR_SESSION_DIRECTION_INCOMING:
+		return oor.SessionDirectionIncoming
+
+	default:
+		return oor.SessionDirectionAll
+	}
+}
+
+// oorDirectionToProto maps the actor session direction to daemon RPC.
+func oorDirectionToProto(
+	direction oor.SessionDirection) daemonrpc.OORSessionDirection {
+
+	switch direction {
+	case oor.SessionDirectionOutgoing:
+		return daemonrpc.
+			OORSessionDirection_OOR_SESSION_DIRECTION_OUTGOING
+
+	case oor.SessionDirectionIncoming:
+		return daemonrpc.
+			OORSessionDirection_OOR_SESSION_DIRECTION_INCOMING
+
+	default:
+		return daemonrpc.
+			OORSessionDirection_OOR_SESSION_DIRECTION_UNSPECIFIED
+	}
+}
+
+// protoToPackageDirection maps an optional daemon RPC direction filter.
+func protoToPackageDirection(
+	direction daemonrpc.OORSessionDirection) *db.OORPackageDirection {
+
+	switch direction {
+	case daemonrpc.OORSessionDirection_OOR_SESSION_DIRECTION_OUTGOING:
+		outgoing := db.OORPackageDirectionOutgoing
+		return &outgoing
+
+	case daemonrpc.OORSessionDirection_OOR_SESSION_DIRECTION_INCOMING:
+		incoming := db.OORPackageDirectionIncoming
+		return &incoming
+
+	default:
+		return nil
+	}
+}
+
+// packageDirectionToProto maps persisted OOR package direction to RPC.
+func packageDirectionToProto(
+	direction db.OORPackageDirection) daemonrpc.OORSessionDirection {
+
+	switch direction {
+	case db.OORPackageDirectionOutgoing:
+		return daemonrpc.
+			OORSessionDirection_OOR_SESSION_DIRECTION_OUTGOING
+
+	case db.OORPackageDirectionIncoming:
+		return daemonrpc.
+			OORSessionDirection_OOR_SESSION_DIRECTION_INCOMING
+
+	default:
+		return daemonrpc.
+			OORSessionDirection_OOR_SESSION_DIRECTION_UNSPECIFIED
+	}
+}
+
+// parseOORSessionID converts a user-supplied hex session id string.
+func parseOORSessionID(sessionID string) (chainhash.Hash, error) {
+	hash, err := chainhash.NewHashFromStr(sessionID)
+	if err != nil {
+		return chainhash.Hash{}, fmt.Errorf("parse session id: %w", err)
+	}
+
+	return *hash, nil
+}

--- a/darepod/rpc_operation_status_test.go
+++ b/darepod/rpc_operation_status_test.go
@@ -1,0 +1,113 @@
+package darepod
+
+import (
+	"testing"
+
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPageOORSessionsUsesSessionCursor asserts OOR pagination resumes after
+// the last session id returned to the caller.
+func TestPageOORSessionsUsesSessionCursor(t *testing.T) {
+	t.Parallel()
+
+	sessions := []*daemonrpc.OORSessionInfo{
+		{SessionId: "a"},
+		{SessionId: "b"},
+		{SessionId: "c"},
+	}
+
+	page, nextToken := pageOORSessions(sessions, "", 2)
+	require.Len(t, page, 2)
+	require.Equal(t, "a", page[0].GetSessionId())
+	require.Equal(t, "b", page[1].GetSessionId())
+	require.Equal(t, "b", nextToken)
+
+	page, nextToken = pageOORSessions(sessions, nextToken, 2)
+	require.Len(t, page, 1)
+	require.Equal(t, "c", page[0].GetSessionId())
+	require.Empty(t, nextToken)
+}
+
+// TestOORSessionMatchesFilters checks direction and status filtering.
+func TestOORSessionMatchesFilters(t *testing.T) {
+	t.Parallel()
+
+	outgoing := daemonrpc.
+		OORSessionDirection_OOR_SESSION_DIRECTION_OUTGOING
+	incoming := daemonrpc.
+		OORSessionDirection_OOR_SESSION_DIRECTION_INCOMING
+	pending := daemonrpc.OORSessionStatus_OOR_SESSION_STATUS_PENDING
+
+	info := &daemonrpc.OORSessionInfo{
+		Direction: outgoing,
+		Status:    pending,
+	}
+
+	require.True(t, oorSessionMatchesFilters(
+		info, &daemonrpc.ListOORSessionsRequest{},
+	))
+
+	require.True(t, oorSessionMatchesFilters(
+		info, &daemonrpc.ListOORSessionsRequest{
+			DirectionFilter: outgoing,
+			StatusFilter:    pending,
+		},
+	))
+
+	require.False(t, oorSessionMatchesFilters(
+		info, &daemonrpc.ListOORSessionsRequest{
+			DirectionFilter: incoming,
+		},
+	))
+}
+
+// TestParseOORSessionIDNormalizesCase verifies uppercase session ids are
+// accepted and normalized to the canonical chainhash string form.
+func TestParseOORSessionIDNormalizesCase(t *testing.T) {
+	t.Parallel()
+
+	const sessionID = "ABCDEF0123456789ABCDEF0123456789" +
+		"ABCDEF0123456789ABCDEF0123456789"
+	const normalizedID = "abcdef0123456789abcdef0123456789" +
+		"abcdef0123456789abcdef0123456789"
+
+	hash, err := parseOORSessionID(sessionID)
+	require.NoError(t, err)
+	require.Equal(t, normalizedID, hash.String())
+}
+
+// TestRoundInfoMatchesFilters checks state and creation-time filtering.
+func TestRoundInfoMatchesFilters(t *testing.T) {
+	t.Parallel()
+
+	info := &daemonrpc.RoundInfo{
+		State:        daemonrpc.RoundState_ROUND_STATE_CONFIRMED,
+		CreationTime: 100,
+	}
+
+	require.True(t, roundInfoMatchesFilters(
+		info, &daemonrpc.ListRoundsRequest{},
+	))
+
+	require.True(t, roundInfoMatchesFilters(
+		info, &daemonrpc.ListRoundsRequest{
+			StateFilter: daemonrpc.
+				RoundState_ROUND_STATE_CONFIRMED,
+			CreatedAfter: 50,
+		},
+	))
+
+	require.False(t, roundInfoMatchesFilters(
+		info, &daemonrpc.ListRoundsRequest{
+			StateFilter: daemonrpc.RoundState_ROUND_STATE_FAILED,
+		},
+	))
+
+	require.False(t, roundInfoMatchesFilters(
+		info, &daemonrpc.ListRoundsRequest{
+			CreatedBefore: 50,
+		},
+	))
+}

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -2831,9 +2831,10 @@ func (r *RPCServer) queryRoundStates(
 		}
 
 		rounds = append(rounds, &daemonrpc.RoundInfo{
-			RoundId: roundID,
-			State:   clientStateToProto(info.State),
-			IsTemp:  info.IsTemp,
+			RoundId:       roundID,
+			State:         clientStateToProto(info.State),
+			IsTemp:        info.IsTemp,
+			FailureReason: roundFailureReason(info.State),
 		})
 	}
 
@@ -2861,6 +2862,26 @@ func dbStatusToProto(status string) daemonrpc.RoundState {
 	}
 }
 
+// protoRoundStateToDBStatus maps a round state filter to persisted DB status.
+func protoRoundStateToDBStatus(state daemonrpc.RoundState) (string, bool) {
+	switch state {
+	case daemonrpc.RoundState_ROUND_STATE_UNKNOWN:
+		return "", true
+
+	case daemonrpc.RoundState_ROUND_STATE_INPUT_SIG_SENT:
+		return "input_sig_sent", true
+
+	case daemonrpc.RoundState_ROUND_STATE_CONFIRMED:
+		return "confirmed", true
+
+	case daemonrpc.RoundState_ROUND_STATE_FAILED:
+		return "failed", true
+
+	default:
+		return "", false
+	}
+}
+
 // ListRounds returns round state information split into two categories:
 //   - Pending rounds: live FSM instances from the round actor. Always
 //     returned (unless persisted_only is set) and do not count against
@@ -2874,6 +2895,10 @@ func (r *RPCServer) ListRounds(ctx context.Context,
 	req *daemonrpc.ListRoundsRequest) (
 	*daemonrpc.ListRoundsResponse, error) {
 
+	if req == nil {
+		req = &daemonrpc.ListRoundsRequest{}
+	}
+
 	var rounds []*daemonrpc.RoundInfo
 
 	// Always include pending (in-memory) rounds unless the caller
@@ -2884,7 +2909,13 @@ func (r *RPCServer) ListRounds(ctx context.Context,
 			return nil, err
 		}
 
-		rounds = append(rounds, pending...)
+		for _, info := range pending {
+			if !roundInfoMatchesFilters(info, req) {
+				continue
+			}
+
+			rounds = append(rounds, info)
+		}
 	}
 
 	// Query persisted rounds from SQL with cursor pagination.
@@ -2896,10 +2927,25 @@ func (r *RPCServer) ListRounds(ctx context.Context,
 	var nextToken string
 
 	if r.server.roundStore != nil {
+		statusFilter, includePersisted := protoRoundStateToDBStatus(
+			req.GetStateFilter(),
+		)
+		if !includePersisted {
+			return &daemonrpc.ListRoundsResponse{
+				Rounds: rounds,
+			}, nil
+		}
+
 		// Request one extra row to detect whether a next page
 		// exists.
 		dbRounds, err := r.server.roundStore.ListRoundsPaginated(
-			ctx, req.PageToken, pageSize+1,
+			ctx, db.ListRoundsQuery{
+				Cursor:        req.PageToken,
+				Limit:         pageSize + 1,
+				Status:        statusFilter,
+				CreatedAfter:  req.GetCreatedAfter(),
+				CreatedBefore: req.GetCreatedBefore(),
+			},
 		)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal,
@@ -2914,23 +2960,7 @@ func (r *RPCServer) ListRounds(ctx context.Context,
 		}
 
 		for _, s := range dbRounds {
-			info := &daemonrpc.RoundInfo{
-				RoundId: s.RoundID.String(),
-				State:   dbStatusToProto(s.Status),
-				IsTemp:  false,
-			}
-
-			// Populate VTXO details for persisted rounds.
-			for _, v := range s.VTXOs {
-				info.Vtxos = append(
-					info.Vtxos,
-					&daemonrpc.RoundVTXOInfo{
-						Outpoint:  v.Outpoint.String(),
-						AmountSat: int64(v.Amount),
-					},
-				)
-			}
-
+			info := roundSummaryToProto(&s)
 			rounds = append(rounds, info)
 		}
 	}

--- a/db/oor_artifact_store.go
+++ b/db/oor_artifact_store.go
@@ -578,6 +578,39 @@ func (s *OORArtifactPersistenceStore) GetPackageForOutpoint(ctx context.Context,
 	return result, nil
 }
 
+// GetPackage returns the fully materialized package for one OOR session id.
+func (s *OORArtifactPersistenceStore) GetPackage(ctx context.Context,
+	sessionID chainhash.Hash) (*OORPackageBundle, error) {
+
+	if s == nil || s.db == nil {
+		return nil, fmt.Errorf("store must be provided")
+	}
+
+	readTx := ReadTxOption()
+
+	var result *OORPackageBundle
+	err := s.db.ExecTx(ctx, readTx, func(q OORArtifactStore) error {
+		row, err := q.GetOORPackage(ctx, sessionID[:])
+		if err != nil {
+			return err
+		}
+
+		pkg, err := materializePackageBundle(ctx, q, row)
+		if err != nil {
+			return err
+		}
+
+		result = pkg
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
 // ListPackages returns all persisted packages, optionally filtered by
 // direction.
 //

--- a/db/round_store.go
+++ b/db/round_store.go
@@ -36,6 +36,27 @@ type (
 	ListRoundsPaginatedParams = sqlc.ListRoundsPaginatedParams
 )
 
+// ListRoundsQuery controls persisted round pagination and filtering.
+type ListRoundsQuery struct {
+	// Cursor is the last round id from the previous page. Use an empty
+	// string to start from the first matching row.
+	Cursor string
+
+	// Limit is the maximum number of matching persisted rounds to return.
+	Limit int32
+
+	// Status restricts results to one persisted round status when set.
+	Status string
+
+	// CreatedAfter restricts results to rounds created at or after this
+	// Unix timestamp when non-zero.
+	CreatedAfter int64
+
+	// CreatedBefore restricts results to rounds created at or before this
+	// Unix timestamp when non-zero.
+	CreatedBefore int64
+}
+
 // RoundStore is the interface that groups all round-related database queries.
 // This is a subset of sqlc.Querier focused on round operations.
 //
@@ -1566,8 +1587,7 @@ func serializeVTXOTreePaths(
 }
 
 // RoundSummary is a lightweight round descriptor returned by paginated
-// queries. It contains only the round ID, persisted status, and the
-// VTXOs created in this round.
+// queries.
 type RoundSummary struct {
 	// RoundID is the unique identifier for this round.
 	RoundID round.RoundID
@@ -1575,6 +1595,25 @@ type RoundSummary struct {
 	// Status is the persisted status string (e.g. "input_sig_sent",
 	// "confirmed").
 	Status string
+
+	// CommitmentTxID is the commitment transaction id when persisted.
+	CommitmentTxID fn.Option[chainhash.Hash]
+
+	// ConfirmationHeight is the block height that confirmed the commitment
+	// transaction when known.
+	ConfirmationHeight fn.Option[int32]
+
+	// CreationTime is the Unix timestamp when this round row was created.
+	CreationTime int64
+
+	// LastUpdateTime is the Unix timestamp when this round row was last
+	// updated.
+	LastUpdateTime int64
+
+	// InputOutpoints are locally known round inputs. Today this is limited
+	// to persisted boarding inputs because refresh and leave inputs are
+	// not yet modeled as first-class persisted round input rows.
+	InputOutpoints []wire.OutPoint
 
 	// VTXOs lists the outpoints and amounts of VTXOs created in this
 	// round.
@@ -1591,11 +1630,167 @@ type VTXOSummary struct {
 	Amount btcutil.Amount
 }
 
+// GetRoundSummary returns one persisted round summary by round id.
+func (s *RoundPersistenceStore) GetRoundSummary(
+	ctx context.Context, roundID string) (*RoundSummary, error) {
+
+	if s == nil || s.db == nil {
+		return nil, fmt.Errorf("round store must be provided")
+	}
+
+	readTxOpts := ReadTxOption()
+
+	var summary *RoundSummary
+	err := s.db.ExecTx(ctx, readTxOpts, func(q RoundStore) error {
+		dbRound, err := q.GetRound(ctx, roundID)
+		if err != nil {
+			return err
+		}
+
+		result, err := roundSummaryFromRow(ctx, q, dbRound)
+		if err != nil {
+			return err
+		}
+
+		summary = result
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return summary, nil
+}
+
+// roundSummaryFromRow materializes a RoundSummary from a persisted row.
+func roundSummaryFromRow(ctx context.Context, q RoundStore,
+	dbRound RoundRow) (*RoundSummary, error) {
+
+	roundID, err := round.ParseRoundID(dbRound.RoundID)
+	if err != nil {
+		return nil, fmt.Errorf("parse round ID: %w", err)
+	}
+
+	vtxos, err := roundVTXOSummaries(ctx, q, dbRound.RoundID)
+	if err != nil {
+		return nil, err
+	}
+
+	inputOutpoints, err := roundBoardingInputOutpoints(
+		ctx, q, dbRound.RoundID,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	summary := &RoundSummary{
+		RoundID:        roundID,
+		Status:         dbRound.Status,
+		CreationTime:   dbRound.CreationTime,
+		LastUpdateTime: dbRound.LastUpdateTime,
+		InputOutpoints: inputOutpoints,
+		VTXOs:          vtxos,
+	}
+
+	if len(dbRound.CommitmentTxid) == chainhash.HashSize {
+		var txid chainhash.Hash
+		copy(txid[:], dbRound.CommitmentTxid)
+		summary.CommitmentTxID = fn.Some(txid)
+	}
+
+	if dbRound.ConfirmationHeight.Valid {
+		summary.ConfirmationHeight = fn.Some(
+			dbRound.ConfirmationHeight.Int32,
+		)
+	}
+
+	return summary, nil
+}
+
+// roundVTXOSummaries returns lightweight VTXO descriptors for a round.
+func roundVTXOSummaries(ctx context.Context, q RoundStore,
+	roundID string) ([]VTXOSummary, error) {
+
+	dbVTXOs, err := q.ListVTXOsByRound(ctx, roundID)
+	if err != nil {
+		return nil, fmt.Errorf("list vtxos for round %s: %w",
+			roundID, err)
+	}
+
+	vtxos := make([]VTXOSummary, 0, len(dbVTXOs))
+	for _, v := range dbVTXOs {
+		outpoint, err := outpointFromDB(
+			v.OutpointHash, v.OutpointIndex,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		vtxos = append(vtxos, VTXOSummary{
+			Outpoint: outpoint,
+			Amount:   btcutil.Amount(v.Amount),
+		})
+	}
+
+	return vtxos, nil
+}
+
+// roundBoardingInputOutpoints returns persisted boarding inputs for a round.
+func roundBoardingInputOutpoints(ctx context.Context, q RoundStore,
+	roundID string) ([]wire.OutPoint, error) {
+
+	intents, err := q.GetRoundBoardingIntents(ctx, roundID)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"get round boarding intents for %s: %w", roundID, err,
+		)
+	}
+
+	outpoints := make([]wire.OutPoint, 0, len(intents))
+	for _, intent := range intents {
+		outpoint, err := outpointFromDB(
+			intent.OutpointHash, intent.OutpointIndex,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		outpoints = append(outpoints, outpoint)
+	}
+
+	return outpoints, nil
+}
+
+// outpointFromDB converts persisted hash/index columns into a wire outpoint.
+func outpointFromDB(hashBytes []byte, index int32) (wire.OutPoint, error) {
+	if len(hashBytes) != chainhash.HashSize {
+		return wire.OutPoint{}, fmt.Errorf(
+			"outpoint hash must be %d bytes, got %d",
+			chainhash.HashSize, len(hashBytes),
+		)
+	}
+
+	if index < 0 {
+		return wire.OutPoint{}, fmt.Errorf(
+			"outpoint index must be non-negative",
+		)
+	}
+
+	var hash chainhash.Hash
+	copy(hash[:], hashBytes)
+
+	return wire.OutPoint{
+		Hash:  hash,
+		Index: uint32(index),
+	}, nil
+}
+
 // ListRoundsPaginated returns a page of persisted round summaries ordered by
-// round_id using cursor-based pagination. The cursor is the last round_id
-// from the previous page; pass "" to start from the beginning.
+// round_id using cursor-based pagination. Filters are applied before ordering
+// and limiting, so every returned page is filled from matching rows only.
 func (s *RoundPersistenceStore) ListRoundsPaginated(ctx context.Context,
-	cursor string, limit int32) ([]RoundSummary, error) {
+	query ListRoundsQuery) ([]RoundSummary, error) {
 
 	readTxOpts := ReadTxOption()
 
@@ -1603,8 +1798,11 @@ func (s *RoundPersistenceStore) ListRoundsPaginated(ctx context.Context,
 
 	err := s.db.ExecTx(ctx, readTxOpts, func(q RoundStore) error {
 		params := ListRoundsPaginatedParams{
-			Column1: cursor,
-			Limit:   limit,
+			Cursor:        query.Cursor,
+			StatusFilter:  query.Status,
+			CreatedAfter:  query.CreatedAfter,
+			CreatedBefore: query.CreatedBefore,
+			LimitCount:    query.Limit,
 		}
 
 		dbRounds, err := q.ListRoundsPaginated(ctx, params)
@@ -1614,43 +1812,12 @@ func (s *RoundPersistenceStore) ListRoundsPaginated(ctx context.Context,
 
 		summaries := make([]RoundSummary, 0, len(dbRounds))
 		for _, dbRound := range dbRounds {
-			roundID, err := round.ParseRoundID(dbRound.RoundID)
+			summary, err := roundSummaryFromRow(ctx, q, dbRound)
 			if err != nil {
-				return fmt.Errorf(
-					"parse round ID: %w", err,
-				)
+				return err
 			}
 
-			// Fetch VTXOs created in this round.
-			dbVTXOs, err := q.ListVTXOsByRound(
-				ctx, dbRound.RoundID,
-			)
-			if err != nil {
-				return fmt.Errorf(
-					"list vtxos for round %s: %w",
-					dbRound.RoundID, err,
-				)
-			}
-
-			vtxos := make([]VTXOSummary, 0, len(dbVTXOs))
-			for _, v := range dbVTXOs {
-				var hash chainhash.Hash
-				copy(hash[:], v.OutpointHash)
-
-				vtxos = append(vtxos, VTXOSummary{
-					Outpoint: wire.OutPoint{
-						Hash:  hash,
-						Index: uint32(v.OutpointIndex),
-					},
-					Amount: btcutil.Amount(v.Amount),
-				})
-			}
-
-			summaries = append(summaries, RoundSummary{
-				RoundID: roundID,
-				Status:  dbRound.Status,
-				VTXOs:   vtxos,
-			})
+			summaries = append(summaries, *summary)
 		}
 
 		result = summaries

--- a/db/round_store_test.go
+++ b/db/round_store_test.go
@@ -1039,7 +1039,9 @@ func TestListRoundsPaginated(t *testing.T) {
 	ctx := t.Context()
 
 	// Empty database returns empty results.
-	summaries, err := store.ListRoundsPaginated(ctx, "", 10)
+	summaries, err := store.ListRoundsPaginated(ctx, ListRoundsQuery{
+		Limit: 10,
+	})
 	require.NoError(t, err)
 	require.Empty(t, summaries)
 
@@ -1074,7 +1076,9 @@ func TestListRoundsPaginated(t *testing.T) {
 	}
 
 	// Fetch all rounds (limit > numRounds).
-	all, err := store.ListRoundsPaginated(ctx, "", 100)
+	all, err := store.ListRoundsPaginated(ctx, ListRoundsQuery{
+		Limit: 100,
+	})
 	require.NoError(t, err)
 	require.Len(t, all, numRounds)
 
@@ -1105,25 +1109,36 @@ func TestListRoundsPaginated(t *testing.T) {
 	}
 
 	// Test page_size limiting: request first 2 rounds.
-	page1, err := store.ListRoundsPaginated(ctx, "", 2)
+	page1, err := store.ListRoundsPaginated(ctx, ListRoundsQuery{
+		Limit: 2,
+	})
 	require.NoError(t, err)
 	require.Len(t, page1, 2)
 
 	// Use last round_id as cursor for next page.
 	cursor := page1[len(page1)-1].RoundID.String()
-	page2, err := store.ListRoundsPaginated(ctx, cursor, 2)
+	page2, err := store.ListRoundsPaginated(ctx, ListRoundsQuery{
+		Cursor: cursor,
+		Limit:  2,
+	})
 	require.NoError(t, err)
 	require.Len(t, page2, 2)
 
 	// Third page should have 1 remaining round.
 	cursor = page2[len(page2)-1].RoundID.String()
-	page3, err := store.ListRoundsPaginated(ctx, cursor, 2)
+	page3, err := store.ListRoundsPaginated(ctx, ListRoundsQuery{
+		Cursor: cursor,
+		Limit:  2,
+	})
 	require.NoError(t, err)
 	require.Len(t, page3, 1)
 
 	// Fourth page should be empty.
 	cursor = page3[0].RoundID.String()
-	page4, err := store.ListRoundsPaginated(ctx, cursor, 2)
+	page4, err := store.ListRoundsPaginated(ctx, ListRoundsQuery{
+		Cursor: cursor,
+		Limit:  2,
+	})
 	require.NoError(t, err)
 	require.Empty(t, page4)
 
@@ -1138,7 +1153,9 @@ func TestListRoundsPaginated(t *testing.T) {
 	require.NoError(t, err)
 
 	// Re-fetch all — the finalized round should show "confirmed".
-	all, err = store.ListRoundsPaginated(ctx, "", 100)
+	all, err = store.ListRoundsPaginated(ctx, ListRoundsQuery{
+		Limit: 100,
+	})
 	require.NoError(t, err)
 	for _, s := range all {
 		if s.RoundID == roundIDs[0] {
@@ -1146,6 +1163,66 @@ func TestListRoundsPaginated(t *testing.T) {
 		} else {
 			require.Equal(t, "input_sig_sent", s.Status)
 		}
+	}
+}
+
+// TestListRoundsPaginatedFiltersBeforeLimit verifies persisted round filters
+// are applied before cursor pagination and LIMIT.
+func TestListRoundsPaginatedFiltersBeforeLimit(t *testing.T) {
+	t.Parallel()
+
+	store, _ := newRoundStoreForTest(t)
+	ctx := t.Context()
+
+	const numRounds = 4
+	roundIDs := make([]round.RoundID, 0, numRounds)
+	for i := 0; i < numRounds; i++ {
+		roundID := testRoundIDDB(
+			"filtered-paginated-test-" + string(rune('a'+i)),
+		)
+		testRound := createTestRound(t, roundID)
+		state := &round.InputSigSentState{
+			RoundID:     testRound.RoundID,
+			ClientTrees: make(map[round.SignerKey]*tree.Tree),
+		}
+
+		err := store.CommitState(ctx, testRound, state)
+		require.NoError(t, err)
+
+		roundIDs = append(roundIDs, roundID)
+	}
+
+	sort.Slice(roundIDs, func(i, j int) bool {
+		return roundIDs[i].String() < roundIDs[j].String()
+	})
+
+	var txid chainhash.Hash
+	txid[0] = 0xaa
+	err := store.FinalizeRound(ctx, roundIDs[len(roundIDs)-1], txid,
+		round.ConfInfo{
+			Height:    999,
+			BlockHash: chainhash.Hash{0xbb},
+		},
+	)
+	require.NoError(t, err)
+
+	confirmed, err := store.ListRoundsPaginated(ctx, ListRoundsQuery{
+		Limit:  1,
+		Status: "confirmed",
+	})
+	require.NoError(t, err)
+	require.Len(t, confirmed, 1)
+	require.Equal(t, roundIDs[len(roundIDs)-1], confirmed[0].RoundID)
+	require.Equal(t, "confirmed", confirmed[0].Status)
+
+	inputSigSent, err := store.ListRoundsPaginated(ctx, ListRoundsQuery{
+		Limit:  2,
+		Status: "input_sig_sent",
+	})
+	require.NoError(t, err)
+	require.Len(t, inputSigSent, 2)
+	for _, summary := range inputSigSent {
+		require.Equal(t, "input_sig_sent", summary.Status)
 	}
 }
 

--- a/db/sqlc/queries/round.sql
+++ b/db/sqlc/queries/round.sql
@@ -31,9 +31,12 @@ SELECT * FROM rounds WHERE status = $1 ORDER BY creation_time DESC;
 -- ListRoundsPaginated returns rounds ordered by round_id with cursor-
 -- based pagination. When cursor is empty, returns from the beginning.
 SELECT * FROM rounds
-WHERE ($1 = '' OR round_id > $1)
+WHERE (sqlc.arg(cursor) = '' OR round_id > sqlc.arg(cursor))
+  AND (sqlc.arg(status_filter) = '' OR status = sqlc.arg(status_filter))
+  AND (sqlc.arg(created_after) = 0 OR creation_time >= sqlc.arg(created_after))
+  AND (sqlc.arg(created_before) = 0 OR creation_time <= sqlc.arg(created_before))
 ORDER BY round_id ASC
-LIMIT $2;
+LIMIT sqlc.arg(limit_count);
 
 -- name: UpdateRoundStatus :exec
 UPDATE rounds

--- a/db/sqlc/round.sql.go
+++ b/db/sqlc/round.sql.go
@@ -834,19 +834,31 @@ func (q *Queries) ListRoundsByStatus(ctx context.Context, status string) ([]Roun
 const ListRoundsPaginated = `-- name: ListRoundsPaginated :many
 SELECT round_id, start_height, confirmation_height, confirmation_block_hash, commitment_tx, commitment_txid, vtxt_tree, status, creation_time, last_update_time FROM rounds
 WHERE ($1 = '' OR round_id > $1)
+  AND ($2 = '' OR status = $2)
+  AND ($3 = 0 OR creation_time >= $3)
+  AND ($4 = 0 OR creation_time <= $4)
 ORDER BY round_id ASC
-LIMIT $2
+LIMIT $5
 `
 
 type ListRoundsPaginatedParams struct {
-	Column1 interface{}
-	Limit   int32
+	Cursor        interface{}
+	StatusFilter  interface{}
+	CreatedAfter  interface{}
+	CreatedBefore interface{}
+	LimitCount    int32
 }
 
 // ListRoundsPaginated returns rounds ordered by round_id with cursor-
 // based pagination. When cursor is empty, returns from the beginning.
 func (q *Queries) ListRoundsPaginated(ctx context.Context, arg ListRoundsPaginatedParams) ([]Round, error) {
-	rows, err := q.db.QueryContext(ctx, ListRoundsPaginated, arg.Column1, arg.Limit)
+	rows, err := q.db.QueryContext(ctx, ListRoundsPaginated,
+		arg.Cursor,
+		arg.StatusFilter,
+		arg.CreatedAfter,
+		arg.CreatedBefore,
+		arg.LimitCount,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/oor/actor.go
+++ b/oor/actor.go
@@ -131,6 +131,12 @@ func newOORActorCodec() *actor.MessageCodec {
 		},
 	)
 	codec.MustRegister(
+		ListSessionsRequestTLVType,
+		func() actor.TLVMessage {
+			return &ListSessionsRequest{}
+		},
+	)
+	codec.MustRegister(
 		DriveEventRequestTLVType,
 		func() actor.TLVMessage {
 			return &DriveEventRequest{}
@@ -377,6 +383,9 @@ func (b *oorDurableBehavior) Receive(ctx context.Context,
 	case *FindOutgoingSessionByIdempotencyKeyRequest:
 		return b.handleFindOutgoingSessionByIdempotencyKey(ctx, m)
 
+	case *ListSessionsRequest:
+		return b.handleListSessions(ctx, m)
+
 	case *DriveEventRequest:
 		return b.handleDriveEvent(ctx, m)
 
@@ -398,6 +407,167 @@ func (b *oorDurableBehavior) Receive(ctx context.Context,
 	default:
 		return fn.Err[ActorResp](fmt.Errorf("unknown message type: %T",
 			m))
+	}
+}
+
+// handleListSessions returns compact summaries for in-memory OOR sessions.
+func (b *oorDurableBehavior) handleListSessions(_ context.Context,
+	req *ListSessionsRequest) fn.Result[ActorResp] {
+
+	if req == nil {
+		return fn.Err[ActorResp](fmt.Errorf("request must be provided"))
+	}
+
+	summaries := make([]SessionSummary, 0, len(b.sessions))
+	for sessionID, handle := range b.sessions {
+		summary, err := summarizeSession(sessionID, handle)
+		if err != nil {
+			return fn.Err[ActorResp](err)
+		}
+
+		if !summaryMatchesListSessionsRequest(summary, req) {
+			continue
+		}
+
+		summaries = append(summaries, summary)
+	}
+
+	sort.Slice(summaries, func(i, j int) bool {
+		return summaries[i].SessionID.String() <
+			summaries[j].SessionID.String()
+	})
+
+	return fn.Ok[ActorResp](&ListSessionsResponse{
+		Sessions: summaries,
+	})
+}
+
+// summaryMatchesListSessionsRequest applies direction and pending filters.
+func summaryMatchesListSessionsRequest(summary SessionSummary,
+	req *ListSessionsRequest) bool {
+
+	if req.PendingOnly && !summary.Pending {
+		return false
+	}
+
+	switch req.Direction {
+	case SessionDirectionAll:
+		return true
+
+	case SessionDirectionOutgoing, SessionDirectionIncoming:
+		return summary.Direction == req.Direction
+
+	default:
+		return false
+	}
+}
+
+// summarizeSession projects a session handle into a compact status summary.
+func summarizeSession(sessionID SessionID,
+	handle *sessionHandle) (SessionSummary, error) {
+
+	if handle == nil {
+		return SessionSummary{}, fmt.Errorf("session handle must be " +
+			"provided")
+	}
+
+	state, err := handle.currentSessionState()
+	if err != nil {
+		return SessionSummary{}, err
+	}
+
+	summary := SessionSummary{
+		SessionID:   sessionID,
+		Pending:     !state.IsTerminal(),
+		RetryAfter:  handle.RetryAfter,
+		RetryReason: handle.RetryReason,
+	}
+
+	switch handle.kind {
+	case sessionKindOutgoing:
+		summary.Direction = SessionDirectionOutgoing
+		err := fillOutgoingSessionSummary(&summary, sessionID, state)
+		if err != nil {
+			return SessionSummary{}, err
+		}
+
+	case sessionKindIncoming:
+		summary.Direction = SessionDirectionIncoming
+		err := fillIncomingSessionSummary(&summary, sessionID, state)
+		if err != nil {
+			return SessionSummary{}, err
+		}
+
+	default:
+		return SessionSummary{}, fmt.Errorf("unknown session kind: %d",
+			handle.kind)
+	}
+
+	if failed, ok := state.(*Failed); ok && summary.RetryReason == "" {
+		summary.RetryReason = failed.Reason
+	}
+
+	return summary, nil
+}
+
+// fillOutgoingSessionSummary populates outgoing-specific summary fields.
+func fillOutgoingSessionSummary(summary *SessionSummary, sessionID SessionID,
+	state SessionState) error {
+
+	outgoingState, ok := state.(State)
+	if !ok {
+		return fmt.Errorf("unexpected outgoing state type: %T", state)
+	}
+
+	snapshot, err := NewOutgoingSnapshot(sessionID, outgoingState)
+	if err != nil {
+		return err
+	}
+
+	summary.Phase = string(snapshot.Phase)
+
+	for i := range snapshot.TransferInputSnapshots {
+		input := snapshot.TransferInputSnapshots[i]
+		if input == nil {
+			continue
+		}
+
+		summary.InputOutpoints = append(
+			summary.InputOutpoints, input.Outpoint,
+		)
+		summary.InputAmountSat += input.AmountSat
+	}
+
+	summary.RecipientCount = outgoingRecipientCount(outgoingState)
+
+	return nil
+}
+
+// fillIncomingSessionSummary populates incoming-specific summary fields.
+func fillIncomingSessionSummary(summary *SessionSummary, sessionID SessionID,
+	state SessionState) error {
+
+	snapshot, err := NewIncomingSnapshot(sessionID, state)
+	if err != nil {
+		return err
+	}
+
+	summary.Phase = string(snapshot.Phase)
+
+	return nil
+}
+
+// outgoingRecipientCount returns known recipient cardinality for live states.
+func outgoingRecipientCount(state State) int {
+	switch s := state.(type) {
+	case *AwaitingArkSignatures:
+		return len(s.RecipientOutputs)
+
+	case *AwaitingSubmitAccepted:
+		return len(s.RecipientOutputs)
+
+	default:
+		return 0
 	}
 }
 

--- a/oor/actor_durable_message.go
+++ b/oor/actor_durable_message.go
@@ -37,6 +37,14 @@ const (
 )
 
 const (
+	// listSessionsDirectionRecordType stores the session direction filter.
+	listSessionsDirectionRecordType tlv.Type = 1
+
+	// listSessionsPendingOnlyRecordType stores the pending-only filter.
+	listSessionsPendingOnlyRecordType tlv.Type = 3
+)
+
+const (
 	resolveIncomingPayloadSessionIDRecordType tlv.Type = 1
 	resolveIncomingPayloadPkScriptRecordType  tlv.Type = 2
 	resolveIncomingPayloadEventIDRecordType   tlv.Type = 3
@@ -1228,6 +1236,86 @@ func decodeIdempotencyKeyPayload(raw []byte) (string, error) {
 	}
 
 	return string(idKey), nil
+}
+
+// encodeListSessionsPayload encodes the durable list-sessions query filters.
+func encodeListSessionsPayload(direction SessionDirection,
+	pendingOnly bool) ([]byte, error) {
+
+	dir := uint8(direction)
+	var pending uint8
+	if pendingOnly {
+		pending = 1
+	}
+
+	records := []tlv.Record{
+		tlv.MakePrimitiveRecord(
+			listSessionsDirectionRecordType, &dir,
+		),
+		tlv.MakePrimitiveRecord(
+			listSessionsPendingOnlyRecordType, &pending,
+		),
+	}
+
+	stream, err := tlv.NewStream(records...)
+	if err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	if err := stream.Encode(&buf); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// decodeListSessionsPayload decodes the durable list-sessions query filters.
+func decodeListSessionsPayload(raw []byte) (
+	SessionDirection, bool, error) {
+
+	var (
+		dir     uint8
+		pending uint8
+	)
+
+	records := []tlv.Record{
+		tlv.MakePrimitiveRecord(
+			listSessionsDirectionRecordType, &dir,
+		),
+		tlv.MakePrimitiveRecord(
+			listSessionsPendingOnlyRecordType, &pending,
+		),
+	}
+
+	stream, err := tlv.NewStream(records...)
+	if err != nil {
+		return SessionDirectionAll, false, err
+	}
+
+	reader := bytes.NewReader(raw)
+	if _, err := stream.DecodeWithParsedTypes(reader); err != nil {
+		return SessionDirectionAll, false, err
+	}
+
+	if pending > 1 {
+		return SessionDirectionAll, false, fmt.Errorf(
+			"pending-only flag must be 0 or 1",
+		)
+	}
+
+	direction := SessionDirection(dir)
+	switch direction {
+	case SessionDirectionAll, SessionDirectionOutgoing,
+		SessionDirectionIncoming:
+
+	default:
+		return SessionDirectionAll, false, fmt.Errorf(
+			"unknown session direction: %d", dir,
+		)
+	}
+
+	return direction, pending == 1, nil
 }
 
 func encodeResolveIncomingTransferPayload(sessionID SessionID,

--- a/oor/actor_durable_message_test.go
+++ b/oor/actor_durable_message_test.go
@@ -58,6 +58,38 @@ func TestStartTransferPayloadTLVRoundTrip(t *testing.T) {
 	require.Equal(t, payload.Inputs[0], decoded.Inputs[0])
 }
 
+// TestListSessionsRequestRoundTrip verifies the durable status-query message
+// preserves its filters through TLV encoding.
+func TestListSessionsRequestRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	msg := &ListSessionsRequest{
+		Direction:   SessionDirectionIncoming,
+		PendingOnly: true,
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, msg.Encode(&buf))
+
+	var decoded ListSessionsRequest
+	require.NoError(t, decoded.Decode(&buf))
+	require.Equal(t, msg.Direction, decoded.Direction)
+	require.Equal(t, msg.PendingOnly, decoded.PendingOnly)
+}
+
+// TestListSessionsRequestRejectsUnknownDirection asserts corrupt direction
+// filters fail during decode instead of silently returning misleading output.
+func TestListSessionsRequestRejectsUnknownDirection(t *testing.T) {
+	t.Parallel()
+
+	raw, err := encodeListSessionsPayload(SessionDirection(99), false)
+	require.NoError(t, err)
+
+	var decoded ListSessionsRequest
+	err = decoded.Decode(bytes.NewReader(raw))
+	require.ErrorContains(t, err, "unknown session direction")
+}
+
 // TestStartTransferPayloadTLVRoundTripCustomInput asserts custom spend-path
 // transfer inputs encode records canonically when owner-leaf policy metadata
 // is present alongside lower-numbered optional fields.

--- a/oor/actor_messages.go
+++ b/oor/actor_messages.go
@@ -3,9 +3,11 @@ package oor
 import (
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
 	"github.com/lightninglabs/darepo-client/lib/arkscript"
 	oortx "github.com/lightninglabs/darepo-client/lib/tx/oor"
@@ -38,6 +40,10 @@ const (
 	ResumeSessionRequestTLVType    tlv.Type = 0x7014
 	ExportSnapshotRequestTLVType   tlv.Type = 0x7015
 	ResolveIncomingTransferTLVType tlv.Type = 0x7016
+
+	// ListSessionsRequestTLVType identifies ListSessionsRequest messages
+	// in the durable OOR actor mailbox.
+	ListSessionsRequestTLVType tlv.Type = 0x7017
 
 	FindOutgoingSessionByIdempotencyKeyTLVType tlv.Type = 0x7018
 )
@@ -295,6 +301,126 @@ func (m *FindOutgoingSessionByIdempotencyKeyResponse) MessageType() string {
 
 // actorRespSealed marks this as implementing the sealed ActorResp interface.
 func (m *FindOutgoingSessionByIdempotencyKeyResponse) actorRespSealed() {}
+
+// SessionDirection is a filter for listing locally known OOR sessions.
+type SessionDirection uint8
+
+const (
+	// SessionDirectionAll includes outgoing and incoming sessions.
+	SessionDirectionAll SessionDirection = iota
+
+	// SessionDirectionOutgoing includes locally sent OOR sessions.
+	SessionDirectionOutgoing
+
+	// SessionDirectionIncoming includes locally received OOR sessions.
+	SessionDirectionIncoming
+)
+
+// ListSessionsRequest asks the OOR actor for compact summaries of its
+// in-memory sessions.
+type ListSessionsRequest struct {
+	actor.BaseMessage
+
+	// Direction restricts the listed sessions by local direction.
+	Direction SessionDirection
+
+	// PendingOnly restricts the result to non-terminal sessions.
+	PendingOnly bool
+}
+
+// MessageType returns the type of this message.
+func (m *ListSessionsRequest) MessageType() string {
+	return "ListSessionsRequest"
+}
+
+// actorMsgSealed marks this as implementing the sealed ActorMsg interface.
+func (m *ListSessionsRequest) actorMsgSealed() {}
+
+// TLVType returns the unique TLV type identifier for this message.
+func (m *ListSessionsRequest) TLVType() tlv.Type {
+	return ListSessionsRequestTLVType
+}
+
+// Encode serializes the message to the provided writer.
+func (m *ListSessionsRequest) Encode(w io.Writer) error {
+	if m == nil {
+		return fmt.Errorf("list sessions request must be provided")
+	}
+
+	raw, err := encodeListSessionsPayload(m.Direction, m.PendingOnly)
+	if err != nil {
+		return err
+	}
+
+	_, err = w.Write(raw)
+
+	return err
+}
+
+// Decode deserializes the message from the provided reader.
+func (m *ListSessionsRequest) Decode(r io.Reader) error {
+	raw, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+
+	direction, pendingOnly, err := decodeListSessionsPayload(raw)
+	if err != nil {
+		return err
+	}
+
+	m.Direction = direction
+	m.PendingOnly = pendingOnly
+
+	return nil
+}
+
+// SessionSummary is a compact operation-status view of one OOR session.
+type SessionSummary struct {
+	// SessionID is the stable OOR session identifier.
+	SessionID SessionID
+
+	// Direction is from the local client perspective.
+	Direction SessionDirection
+
+	// Phase is the detailed FSM phase string.
+	Phase string
+
+	// Pending is true while the session is not terminal.
+	Pending bool
+
+	// RetryAfter is the pending retry delay, when one is scheduled.
+	RetryAfter time.Duration
+
+	// RetryReason is the pending retry or terminal failure reason.
+	RetryReason string
+
+	// InputOutpoints are locally known outgoing input VTXOs.
+	InputOutpoints []wire.OutPoint
+
+	// InputAmountSat is the total value of InputOutpoints.
+	InputAmountSat int64
+
+	// RecipientCount is the number of Ark recipients in an outgoing
+	// transfer.
+	RecipientCount int
+}
+
+// ListSessionsResponse returns OOR session summaries.
+type ListSessionsResponse struct {
+	actor.BaseMessage
+
+	// Sessions contains matching OOR session summaries.
+	Sessions []SessionSummary
+}
+
+// MessageType returns the type of this message.
+func (m *ListSessionsResponse) MessageType() string {
+	return "ListSessionsResponse"
+}
+
+// actorRespSealed marks this as implementing the sealed ActorResp interface.
+func (m *ListSessionsResponse) actorRespSealed() {}
 
 // DriveEventRequest asks the actor to feed an event into an existing session.
 //

--- a/oor/actor_test.go
+++ b/oor/actor_test.go
@@ -273,6 +273,80 @@ func TestOORClientActorHappyPath(t *testing.T) {
 		packageStore.lastSessionID)
 }
 
+// TestOORClientActorListSessionsSummarizesOutgoing verifies the operation
+// status query reports locally known OOR sessions in deterministic form.
+func TestOORClientActorListSessionsSummarizesOutgoing(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	clientKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	operatorSigner := input.NewMockSigner(
+		[]*btcec.PrivateKey{operatorKey}, nil,
+	)
+
+	const inputValue = btcutil.Amount(10_000)
+
+	inputs := []TransferInput{
+		newTestTransferInput(
+			t, clientKey, operatorKey.PubKey(), wire.OutPoint{
+				Hash:  [32]byte{0x01},
+				Index: 0,
+			}, inputValue,
+		),
+	}
+
+	recipients := []oortx.RecipientOutput{{
+		PkScript: newTestTaprootPkScript(t, clientKey.PubKey()),
+		Value:    inputValue,
+	}}
+	clientSigner := input.NewMockSigner([]*btcec.PrivateKey{clientKey}, nil)
+
+	actor := NewOORClientActor(ClientActorCfg{
+		OutboxHandler: &testOutboxHandler{
+			t:              t,
+			clientSigner:   clientSigner,
+			operatorSigner: operatorSigner,
+		},
+		PackageStore:  &testPackageStore{},
+		DeliveryStore: newTestDeliveryStore(t),
+		ActorID:       "oor-actor-list-sessions",
+	})
+	defer actor.Stop()
+
+	startResp := actor.Receive(ctx, &StartTransferRequest{
+		Policy: arkscript.CheckpointPolicy{
+			OperatorKey: operatorKey.PubKey(),
+			CSVDelay:    10,
+		},
+		Inputs:     inputs,
+		Recipients: recipients,
+	})
+	require.True(t, startResp.IsOk())
+
+	startMsg, ok := startResp.UnwrapOr(nil).(*StartTransferResponse)
+	require.True(t, ok)
+
+	listResp := actor.Receive(ctx, &ListSessionsRequest{
+		Direction: SessionDirectionOutgoing,
+	})
+	require.True(t, listResp.IsOk())
+
+	listMsg, ok := listResp.UnwrapOr(nil).(*ListSessionsResponse)
+	require.True(t, ok)
+	require.Len(t, listMsg.Sessions, 1)
+
+	summary := listMsg.Sessions[0]
+	require.Equal(t, startMsg.SessionID, summary.SessionID)
+	require.Equal(t, SessionDirectionOutgoing, summary.Direction)
+	require.Equal(t, string(OutgoingPhaseCompleted), summary.Phase)
+	require.False(t, summary.Pending)
+}
+
 // TestOORClientActorStartTransferIdempotencyKeyReturnsExistingSession verifies
 // that a retry with the same idempotency key and a different selected input
 // returns the original session without emitting a new server message.


### PR DESCRIPTION
## Summary

Fixes https://github.com/lightninglabs/darepo-client/issues/170.

This adds local operation-status surfaces for long-running daemon work:

- Add `GetRound` and enrich `ListRounds` with persisted round metadata such as commitment txid, confirmation height, timestamps, locally known inputs, and created VTXOs.
- Add `GetOORSession` and `ListOORSessions` with direction/status filters.
- Add the documented OOR actor `ListSessionsRequest` query so pending and failed OOR sessions can be inspected from live durable actor state.
- Merge live OOR actor summaries with completed persisted OOR package artifacts in the daemon RPC layer.
- Add `darepocli rounds get`, richer `rounds list` filters, `oor get`, and `oor list` commands.

## Notes

The OOR status path does not introduce a new sessions table. Pending and failed sessions are sourced from the OOR actor, while completed sessions are sourced from persisted OOR package artifacts. When both views exist for the same session, live actor state remains authoritative and persisted artifact details fill in missing artifact-backed fields.

## Validation

- `make rpc`
- `make commitmsg-lint range=origin/main..HEAD`
- `go test ./...`
- `GOGC=50 make lint`