### PR TITLE
lint: enable contextcheck

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -109,7 +109,6 @@ linters:
     - gochecknoinits
 
     # Disabled pending a larger cleanup PR.
-    - contextcheck
     - noctx
     - tparallel
     - unparam

--- a/btcwbackend/chain_backend.go
+++ b/btcwbackend/chain_backend.go
@@ -360,6 +360,8 @@ func (b *ChainBackend) handlePackageResult(ctx context.Context,
 // RegisterConf registers for confirmation notifications using
 // neutrino's chain notifier. The registration returns a
 // ConfRegistration with channels for receiving confirmation events.
+//
+//nolint:contextcheck // returned registration Cancel owns forwarder lifetime
 func (b *ChainBackend) RegisterConf(ctx context.Context,
 	txid *chainhash.Hash, pkScript []byte, numConfs uint32,
 	heightHint uint32,
@@ -443,6 +445,8 @@ func (b *ChainBackend) RegisterConf(ctx context.Context,
 
 // RegisterSpend registers for spend notifications using neutrino's
 // chain notifier.
+//
+//nolint:contextcheck // returned registration Cancel owns forwarder lifetime
 func (b *ChainBackend) RegisterSpend(ctx context.Context,
 	outpoint *wire.OutPoint, pkScript []byte,
 	heightHint uint32) (*chainsource.SpendRegistration, error) {
@@ -511,6 +515,8 @@ func (b *ChainBackend) RegisterSpend(ctx context.Context,
 
 // RegisterBlocks registers for new block notifications using
 // neutrino's chain notifier.
+//
+//nolint:contextcheck // returned registration Cancel owns forwarder lifetime
 func (b *ChainBackend) RegisterBlocks(
 	ctx context.Context) (*chainsource.BlockRegistration, error) {
 

--- a/chainbackends/lnd.go
+++ b/chainbackends/lnd.go
@@ -266,6 +266,8 @@ func (b *LNDBackend) SubmitPackage(ctx context.Context,
 // RegisterConf registers for confirmation notifications using lnd's chain
 // notifier. The registration returns a ConfRegistration with channels for
 // receiving confirmation events.
+//
+//nolint:contextcheck // returned registration Cancel owns forwarder lifetime
 func (b *LNDBackend) RegisterConf(ctx context.Context,
 	txid *chainhash.Hash, pkScript []byte, numConfs uint32,
 	heightHint uint32,
@@ -338,6 +340,8 @@ func (b *LNDBackend) RegisterConf(ctx context.Context,
 // RegisterSpend registers for spend notifications using lnd's chain notifier.
 // The registration returns a SpendRegistration with channels for receiving
 // spend events.
+//
+//nolint:contextcheck // returned registration Cancel owns forwarder lifetime
 func (b *LNDBackend) RegisterSpend(ctx context.Context,
 	outpoint *wire.OutPoint, pkScript []byte,
 	heightHint uint32) (*chainsource.SpendRegistration, error) {

--- a/chainsource/block_epoch_actor.go
+++ b/chainsource/block_epoch_actor.go
@@ -158,6 +158,7 @@ func (a *BlockEpochActor) handleSubscribeBlocks(actorCtx context.Context,
 	// Register with the backend to receive block notifications. We do this
 	// before starting the goroutine so we can return an error to the
 	// caller if registration fails.
+	//nolint:contextcheck // actor root context owns registration lifetime
 	registration, err := a.cfg.Backend.RegisterBlocks(a.ctx)
 	if err != nil {
 		return fn.Err[EpochResp](fmt.Errorf(

--- a/chainsource/conf_actor.go
+++ b/chainsource/conf_actor.go
@@ -161,6 +161,7 @@ func (a *ConfActor) handleRegisterConf(actorCtx context.Context,
 	regCtx, regCancel := context.WithTimeout(a.ctx, 10*time.Second)
 	defer regCancel()
 
+	//nolint:contextcheck // actor root context owns registration lifetime
 	registration, err := a.cfg.Backend.RegisterConf(
 		regCtx, a.txid, a.pkScript, a.targetConfs, a.heightHint,
 		a.includeBlock,

--- a/chainsource/spend_actor.go
+++ b/chainsource/spend_actor.go
@@ -148,6 +148,7 @@ func (a *SpendActor) handleRegisterSpend(actorCtx context.Context,
 	// Register with the backend to receive spend notifications. We do this
 	// before starting the goroutine so we can return an error to the
 	// caller if registration fails.
+	//nolint:contextcheck // actor root context owns registration lifetime
 	registration, err := a.cfg.Backend.RegisterSpend(
 		a.ctx, a.outpoint, a.pkScript, a.heightHint,
 	)

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -710,10 +710,12 @@ func (s *Server) run(ctx context.Context,
 	// -------------------------------------------------------
 	// 3. Initialize the actor system.
 	// -------------------------------------------------------
+	//nolint:contextcheck // actor system owns process-root lifecycle
 	s.actorSystem = actor.NewActorSystemWithConfig(actor.SystemConfig{
 		MailboxCapacity: actor.DefaultConfig().MailboxCapacity,
 		Log:             fn.Some(s.subLogger(actor.Subsystem)),
 	})
+	//nolint:contextcheck // shutdown uses bounded process-root context
 	defer func() {
 		if s.actorSystem == nil {
 			return
@@ -724,11 +726,13 @@ func (s *Server) run(ctx context.Context,
 		)
 		defer shutdownCancel()
 
+		//nolint:contextcheck // bounded shutdown
 		if err := s.actorSystem.Shutdown(shutdownCtx); err != nil {
 			s.log.WarnS(shutdownCtx, "Actor system shutdown "+
 				"did not complete cleanly", err)
 		}
 	}()
+	//nolint:contextcheck // shutdown uses bounded process-root context
 	defer func() {
 		shutdownCtx, shutdownCancel := context.WithTimeout(
 			context.Background(), DefaultShutdownTimeout,
@@ -740,6 +744,7 @@ func (s *Server) run(ctx context.Context,
 		}
 
 		if s.oorSigningEffect != nil {
+			//nolint:contextcheck // bounded shutdown
 			err := s.oorSigningEffect.StopAndWait(shutdownCtx)
 			if err != nil {
 				s.log.WarnS(
@@ -750,6 +755,7 @@ func (s *Server) run(ctx context.Context,
 		}
 
 		if s.oorActor != nil {
+			//nolint:contextcheck // bounded shutdown
 			err := s.oorActor.StopAndWait(shutdownCtx)
 			if err != nil {
 				s.log.WarnS(
@@ -764,10 +770,12 @@ func (s *Server) run(ctx context.Context,
 
 		if s.runtime != nil {
 			s.setServerConnected(false)
+			//nolint:contextcheck // bounded shutdown
 			_ = s.runtime.StopAndWait(shutdownCtx)
 		}
 
 		if s.actorSystem != nil {
+			//nolint:contextcheck // bounded shutdown
 			err := s.actorSystem.Shutdown(shutdownCtx)
 			if err != nil {
 				s.log.WarnS(
@@ -1177,6 +1185,8 @@ func (s *Server) tryAutoUnlockLwwallet(ctx context.Context) {
 // startLwwallet creates and starts the lightweight wallet from the
 // given raw seed. On success it populates s.lwWallet and marks the
 // wallet as ready.
+//
+//nolint:contextcheck // wallet backend owns lifecycle after daemon startup
 func (s *Server) startLwwallet(ctx context.Context,
 	seed [rawSeedLen]byte) error {
 
@@ -1416,6 +1426,8 @@ func (s *Server) preStartNeutrino(ctx context.Context) error {
 // preStartNeutrino, it is reused; otherwise a new one is created.
 // On success it populates s.btcwWallet and marks the wallet as
 // ready.
+//
+//nolint:contextcheck // wallet backend owns lifecycle after daemon startup
 func (s *Server) startBtcwallet(ctx context.Context,
 	seed [rawSeedLen]byte) error {
 
@@ -2594,6 +2606,8 @@ func (s *Server) handleInboundRPC(ctx context.Context,
 // initDatabase opens the SQLite database and creates the actor
 // delivery store used by the serverconn runtime for at-least-once
 // envelope delivery.
+//
+//nolint:contextcheck // database constructor owns migration startup context
 func (s *Server) initDatabase(ctx context.Context) error {
 	networkDir, err := s.cfg.NetworkDir()
 	if err != nil {
@@ -2674,6 +2688,8 @@ func (s *Server) initLedgerActor(ctx context.Context) error {
 // initRPCClients creates the Ark and indexer mailbox RPC clients. Both
 // use the runtime's unary facade to issue RPCs to the server through
 // the mailbox transport.
+//
+//nolint:contextcheck // RPC facades own mailbox-backed lifecycles
 func (s *Server) initRPCClients(ctx context.Context) {
 	s.ark = arkrpc.NewArkServiceMailboxClient(s.runtime.Unary())
 
@@ -2737,6 +2753,8 @@ func (s *Server) initRPCClients(ctx context.Context) {
 // type-erased key used by the actor outbox publisher, then starts the shared
 // publisher loop. OOR transport handoff uses this path so the OOR actor can
 // commit its own state before serverconn mailbox enqueue runs.
+//
+//nolint:contextcheck // outbox publisher owns lifecycle after startup
 func (s *Server) startActorOutboxPublisher(ctx context.Context) error {
 	if s.runtime == nil {
 		return fmt.Errorf("serverconn runtime must be initialized")
@@ -2789,6 +2807,8 @@ func (s *Server) startActorOutboxPublisher(ctx context.Context) error {
 // ark operator, fetches the operator pubkey, and wires the mailbox
 // transport runtime. This is called synchronously for LND (wallet
 // always ready) or after walletReady fires for lwwallet/btcwallet.
+//
+//nolint:contextcheck // mailbox runtime owns lifecycle after bootstrap
 func (s *Server) connectAndBootstrapMailbox(
 	ctx context.Context) error {
 
@@ -2983,6 +3003,8 @@ func (s *Server) initWalletActor(ctx context.Context,
 // signing, and forfeit signing. It requires the operator's terms
 // (fetched from the server) and references to the chain source and
 // wallet actors.
+//
+//nolint:contextcheck // round actor owns lifecycle after registration
 func (s *Server) initRoundActor(ctx context.Context,
 	chainSourceRef actor.ActorRef[
 		chainsource.ChainSourceMsg, chainsource.ChainSourceResp,
@@ -3196,6 +3218,8 @@ func (s *Server) initVTXOManager(ctx context.Context,
 //     incoming VTXOs, handles incoming ack.
 //   - SigningOutboxHandler (Next delegate): signs Ark and checkpoint
 //     PSBTs, schedules retries.
+//
+//nolint:contextcheck // OOR actors own lifecycle after registration
 func (s *Server) initOORActor(ctx context.Context,
 	vtxoManagerRef actor.TellOnlyRef[vtxo.ManagerMsg]) error {
 
@@ -4019,6 +4043,8 @@ func (w *btcwUnrollWallet) ReleaseOutput(_ context.Context, id wallet.LockID,
 // initUnrollSubsystem creates and wires the new unilateral-exit runtime:
 // shared tx confirmation, per-target unroll actors behind the registry, and
 // the VTXO critical-expiry handoff into that registry.
+//
+//nolint:contextcheck // unroll actors own lifecycle after registration
 func (s *Server) initUnrollSubsystem(ctx context.Context,
 	chainSourceRef actor.ActorRef[
 		chainsource.ChainSourceMsg, chainsource.ChainSourceResp,

--- a/lwwallet/boarding_backend.go
+++ b/lwwallet/boarding_backend.go
@@ -66,7 +66,7 @@ func (b *BoardingBackendAdapter) ListUnspent(ctx context.Context,
 	}
 
 	// Get the current tip height for confirmation calculation.
-	tipHeight, err := b.esplora.GetTipHeight()
+	tipHeight, err := b.esplora.GetTipHeight(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("get tip height: %w", err)
 	}
@@ -76,7 +76,7 @@ func (b *BoardingBackendAdapter) ListUnspent(ctx context.Context,
 	var utxos []*wallet.Utxo
 
 	for addrStr, addr := range addrs {
-		esploraUtxos, err := b.esplora.GetAddressUtxos(addrStr)
+		esploraUtxos, err := b.esplora.GetAddressUtxos(ctx, addrStr)
 		if err != nil {
 			b.Log.WarnS(ctx,
 				"Failed to query Esplora for address UTXOs",
@@ -151,7 +151,7 @@ func (b *BoardingBackendAdapter) GetTransaction(ctx context.Context,
 			slog.String("txid", txid.String()),
 		)
 
-		tx, err = b.esplora.GetRawTx(txid)
+		tx, err = b.esplora.GetRawTx(ctx, txid)
 		if err != nil {
 			return nil, fmt.Errorf(
 				"get transaction: %w", err,
@@ -163,7 +163,7 @@ func (b *BoardingBackendAdapter) GetTransaction(ctx context.Context,
 
 	// Fetch the confirmation status from Esplora to get the block
 	// hash and height. Both are needed for TxProof construction.
-	status, err := b.esplora.GetTxStatus(txid)
+	status, err := b.esplora.GetTxStatus(ctx, txid)
 	if err != nil {
 		b.Log.WarnS(ctx,
 			"Failed fetching tx status from Esplora", err,
@@ -192,7 +192,7 @@ func (b *BoardingBackendAdapter) GetBlock(ctx context.Context,
 	b.Log.DebugS(ctx, "Fetching block from Esplora",
 		slog.String("block_hash", blockHash.String()))
 
-	block, err := b.esplora.GetRawBlock(blockHash)
+	block, err := b.esplora.GetRawBlock(ctx, blockHash)
 	if err != nil {
 		return nil, fmt.Errorf("get block: %w", err)
 	}

--- a/lwwallet/chain_backend.go
+++ b/lwwallet/chain_backend.go
@@ -251,10 +251,10 @@ func (b *ChainBackend) Stop() error {
 
 // EstimateFee returns the estimated fee rate in satoshis per vbyte for a
 // transaction to confirm within the target number of blocks.
-func (b *ChainBackend) EstimateFee(_ context.Context,
+func (b *ChainBackend) EstimateFee(ctx context.Context,
 	targetConf uint32) (btcutil.Amount, error) {
 
-	estimates, err := b.esplora.GetFeeEstimates()
+	estimates, err := b.esplora.GetFeeEstimates(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("get fee estimates: %w", err)
 	}
@@ -335,10 +335,10 @@ func (b *ChainBackend) TestMempoolAccept(_ context.Context,
 }
 
 // BroadcastTx broadcasts a transaction via the Esplora API.
-func (b *ChainBackend) BroadcastTx(_ context.Context,
+func (b *ChainBackend) BroadcastTx(ctx context.Context,
 	tx *wire.MsgTx, _ string) error {
 
-	_, err := b.esplora.BroadcastTx(tx)
+	_, err := b.esplora.BroadcastTx(ctx, tx)
 	if err != nil {
 		return fmt.Errorf("broadcast tx: %w", err)
 	}
@@ -445,6 +445,7 @@ func (b *ChainBackend) RegisterConf(ctx context.Context,
 	// without that, a slow Esplora response could outlive the
 	// chain backend and write into a torn-down subscriber.
 	b.wg.Add(1)
+	//nolint:contextcheck // registration cancel/Stop own one-shot lifetime
 	go b.runConfOneShot(id, reg)
 
 	return &chainsource.ConfRegistration{
@@ -541,6 +542,7 @@ func (b *ChainBackend) RegisterSpend(ctx context.Context,
 	// already spent at registration time. See RegisterConf for the
 	// O(N²)-vs-O(1) rationale and the b.wg lifecycle note.
 	b.wg.Add(1)
+	//nolint:contextcheck // registration cancel/Stop own one-shot lifetime
 	go b.runSpendOneShot(id, reg)
 
 	return &chainsource.SpendRegistration{
@@ -829,7 +831,7 @@ func (b *ChainBackend) checkSingleConf(reg *confRegistration,
 func (b *ChainBackend) checkConfByTxid(reg *confRegistration,
 	currentHeight int32) *chainsource.TxConfirmation {
 
-	status, err := b.esplora.GetTxStatus(*reg.txid)
+	status, err := b.esplora.GetTxStatus(context.Background(), *reg.txid)
 	if err != nil {
 		return nil
 	}
@@ -851,7 +853,7 @@ func (b *ChainBackend) checkConfByTxid(reg *confRegistration,
 		return nil
 	}
 
-	tx, err := b.esplora.GetRawTx(*reg.txid)
+	tx, err := b.esplora.GetRawTx(context.Background(), *reg.txid)
 	if err != nil {
 		return nil
 	}
@@ -864,7 +866,9 @@ func (b *ChainBackend) checkConfByTxid(reg *confRegistration,
 
 	// Fetch the full block if requested.
 	if reg.includeBlock {
-		block, err := b.esplora.GetRawBlock(*blockHash)
+		block, err := b.esplora.GetRawBlock(
+			context.Background(), *blockHash,
+		)
 		if err == nil {
 			conf.Block = block
 		}
@@ -879,7 +883,9 @@ func (b *ChainBackend) checkConfByTxid(reg *confRegistration,
 func (b *ChainBackend) checkConfByScript(reg *confRegistration,
 	currentHeight int32) *chainsource.TxConfirmation {
 
-	utxos, err := b.esplora.GetScriptUtxos(reg.pkScript)
+	utxos, err := b.esplora.GetScriptUtxos(
+		context.Background(), reg.pkScript,
+	)
 	if err != nil {
 		return nil
 	}
@@ -907,7 +913,7 @@ func (b *ChainBackend) checkConfByScript(reg *confRegistration,
 			continue
 		}
 
-		tx, err := b.esplora.GetRawTx(*txid)
+		tx, err := b.esplora.GetRawTx(context.Background(), *txid)
 		if err != nil {
 			continue
 		}
@@ -919,7 +925,9 @@ func (b *ChainBackend) checkConfByScript(reg *confRegistration,
 		}
 
 		if reg.includeBlock {
-			block, err := b.esplora.GetRawBlock(*blockHash)
+			block, err := b.esplora.GetRawBlock(
+				context.Background(), *blockHash,
+			)
 			if err == nil {
 				conf.Block = block
 			}
@@ -995,7 +1003,7 @@ func (b *ChainBackend) checkSingleSpend(
 		return nil
 	}
 
-	outspend, err := b.esplora.GetOutspend(
+	outspend, err := b.esplora.GetOutspend(context.Background(),
 		reg.outpoint.Hash, reg.outpoint.Index,
 	)
 	if err != nil {
@@ -1011,7 +1019,9 @@ func (b *ChainBackend) checkSingleSpend(
 		return nil
 	}
 
-	spendingTx, err := b.esplora.GetRawTx(*spenderHash)
+	spendingTx, err := b.esplora.GetRawTx(
+		context.Background(), *spenderHash,
+	)
 	if err != nil {
 		return nil
 	}

--- a/lwwallet/esplora.go
+++ b/lwwallet/esplora.go
@@ -192,8 +192,8 @@ func scriptHashHex(pkScript []byte) string {
 }
 
 // GetTipHeight returns the current best block height.
-func (c *EsploraClient) GetTipHeight() (int32, error) {
-	body, err := c.get("/blocks/tip/height")
+func (c *EsploraClient) GetTipHeight(ctx context.Context) (int32, error) {
+	body, err := c.get(ctx, "/blocks/tip/height")
 	if err != nil {
 		return 0, fmt.Errorf("get tip height: %w", err)
 	}
@@ -207,8 +207,10 @@ func (c *EsploraClient) GetTipHeight() (int32, error) {
 }
 
 // GetTipHash returns the current best block hash.
-func (c *EsploraClient) GetTipHash() (chainhash.Hash, error) {
-	body, err := c.get("/blocks/tip/hash")
+func (c *EsploraClient) GetTipHash(
+	ctx context.Context) (chainhash.Hash, error) {
+
+	body, err := c.get(ctx, "/blocks/tip/hash")
 	if err != nil {
 		return chainhash.Hash{}, fmt.Errorf("get tip hash: %w", err)
 	}
@@ -227,7 +229,7 @@ func (c *EsploraClient) GetTipHash() (chainhash.Hash, error) {
 // block hash. Results are memoized in blockHeaderCache because the
 // header for a confirmed block hash is immutable. Concurrent misses
 // for the same hash are coalesced via blockHeaderSF.
-func (c *EsploraClient) GetBlockHeader(
+func (c *EsploraClient) GetBlockHeader(ctx context.Context,
 	blockHash chainhash.Hash) (*esploraBlock, error) {
 
 	if cached, err := c.blockHeaderCache.Get(blockHash); err == nil &&
@@ -247,7 +249,7 @@ func (c *EsploraClient) GetBlockHeader(
 				return cached.header, nil
 			}
 
-			body, err := c.get("/block/" + blockHash.String())
+			body, err := c.get(ctx, "/block/"+blockHash.String())
 			if err != nil {
 				return nil, fmt.Errorf(
 					"get block header: %w", err,
@@ -286,7 +288,7 @@ func (c *EsploraClient) GetBlockHeader(
 				blockHash,
 				cachedBlockHeader{header: &block},
 			); putErr != nil {
-				c.log.WarnS(context.Background(),
+				c.log.WarnS(ctx,
 					"Block header cache Put failed",
 					putErr,
 					slog.String(
@@ -311,11 +313,11 @@ func (c *EsploraClient) GetBlockHeader(
 }
 
 // GetBlockHashByHeight returns the block hash at the given height.
-func (c *EsploraClient) GetBlockHashByHeight(
+func (c *EsploraClient) GetBlockHashByHeight(ctx context.Context,
 	height int32) (chainhash.Hash, error) {
 
-	body, err := c.get(
-		"/block-height/" + strconv.FormatInt(int64(height), 10),
+	body, err := c.get(ctx,
+		"/block-height/"+strconv.FormatInt(int64(height), 10),
 	)
 	if err != nil {
 		return chainhash.Hash{}, fmt.Errorf(
@@ -339,7 +341,7 @@ func (c *EsploraClient) GetBlockHashByHeight(
 // into a wire.BlockHeader. Results are memoized in rawHeaderCache
 // because the header for a confirmed block hash is immutable.
 // Concurrent misses for the same hash are coalesced via rawHeaderSF.
-func (c *EsploraClient) GetRawBlockHeader(
+func (c *EsploraClient) GetRawBlockHeader(ctx context.Context,
 	blockHash chainhash.Hash) (*wire.BlockHeader, error) {
 
 	if cached, err := c.rawHeaderCache.Get(blockHash); err == nil &&
@@ -356,8 +358,8 @@ func (c *EsploraClient) GetRawBlockHeader(
 				return cached.header, nil
 			}
 
-			body, err := c.get(
-				"/block/" + blockHash.String() + "/header",
+			body, err := c.get(ctx,
+				"/block/"+blockHash.String()+"/header",
 			)
 			if err != nil {
 				return nil, fmt.Errorf(
@@ -400,7 +402,7 @@ func (c *EsploraClient) GetRawBlockHeader(
 				blockHash,
 				cachedRawHeader{header: &header},
 			); putErr != nil {
-				c.log.WarnS(context.Background(),
+				c.log.WarnS(ctx,
 					"Raw header cache Put failed",
 					putErr,
 					slog.String(
@@ -430,7 +432,7 @@ func (c *EsploraClient) GetRawBlockHeader(
 // misses for the same hash are coalesced via rawBlockSF — full
 // mainnet blocks approach 4 MiB so collapsing a thundering herd is
 // load-bearing for the rate-limit budget of the Esplora endpoint.
-func (c *EsploraClient) GetRawBlock(
+func (c *EsploraClient) GetRawBlock(ctx context.Context,
 	blockHash chainhash.Hash) (*wire.MsgBlock, error) {
 
 	if cached, err := c.rawBlockCache.Get(blockHash); err == nil &&
@@ -447,8 +449,8 @@ func (c *EsploraClient) GetRawBlock(
 				return cached.block, nil
 			}
 
-			body, err := c.get(
-				"/block/" + blockHash.String() + "/raw",
+			body, err := c.get(ctx,
+				"/block/"+blockHash.String()+"/raw",
 			)
 			if err != nil {
 				return nil, fmt.Errorf(
@@ -480,7 +482,7 @@ func (c *EsploraClient) GetRawBlock(
 					size:  uint64(len(body)),
 				},
 			); putErr != nil {
-				c.log.WarnS(context.Background(),
+				c.log.WarnS(ctx,
 					"Raw block cache Put failed",
 					putErr,
 					slog.String(
@@ -505,12 +507,12 @@ func (c *EsploraClient) GetRawBlock(
 }
 
 // GetScriptUtxos returns all UTXOs for the given pkScript.
-func (c *EsploraClient) GetScriptUtxos(
+func (c *EsploraClient) GetScriptUtxos(ctx context.Context,
 	pkScript []byte) ([]esploraUtxo, error) {
 
 	hash := scriptHashHex(pkScript)
 	path := "/scripthash/" + hash + "/utxo"
-	body, err := c.get(path)
+	body, err := c.get(ctx, path)
 	if err != nil {
 		return nil, fmt.Errorf("get script utxos: %w", err)
 	}
@@ -522,7 +524,7 @@ func (c *EsploraClient) GetScriptUtxos(
 
 	// Log raw response when no UTXOs found to aid debugging.
 	if len(utxos) == 0 {
-		c.log.DebugS(context.Background(),
+		c.log.DebugS(ctx,
 			"Esplora returned empty UTXO list",
 			slog.String("path", path),
 			slog.String("raw_response",
@@ -536,11 +538,11 @@ func (c *EsploraClient) GetScriptUtxos(
 // This uses the /address/:address/utxo endpoint which avoids the need
 // to compute a scripthash. The response format is identical to the
 // scripthash UTXO endpoint.
-func (c *EsploraClient) GetAddressUtxos(
+func (c *EsploraClient) GetAddressUtxos(ctx context.Context,
 	address string) ([]esploraUtxo, error) {
 
 	path := "/address/" + address + "/utxo"
-	body, err := c.get(path)
+	body, err := c.get(ctx, path)
 	if err != nil {
 		return nil, fmt.Errorf("get address utxos: %w", err)
 	}
@@ -552,7 +554,7 @@ func (c *EsploraClient) GetAddressUtxos(
 
 	// Log raw response when no UTXOs found to aid debugging.
 	if len(utxos) == 0 {
-		c.log.DebugS(context.Background(),
+		c.log.DebugS(ctx,
 			"Esplora address query returned empty",
 			slog.String("path", path),
 			slog.String("raw_response",
@@ -563,10 +565,10 @@ func (c *EsploraClient) GetAddressUtxos(
 }
 
 // GetTxStatus returns the confirmation status for a transaction.
-func (c *EsploraClient) GetTxStatus(
+func (c *EsploraClient) GetTxStatus(ctx context.Context,
 	txid chainhash.Hash) (*esploraTxStatus, error) {
 
-	body, err := c.get("/tx/" + txid.String() + "/status")
+	body, err := c.get(ctx, "/tx/"+txid.String()+"/status")
 	if err != nil {
 		return nil, fmt.Errorf("get tx status: %w", err)
 	}
@@ -583,7 +585,7 @@ func (c *EsploraClient) GetTxStatus(
 // Results are memoized in txCache because a confirmed transaction's
 // contents are content-addressed by its txid. Concurrent misses for
 // the same txid are coalesced via txSF.
-func (c *EsploraClient) GetRawTx(
+func (c *EsploraClient) GetRawTx(ctx context.Context,
 	txid chainhash.Hash) (*wire.MsgTx, error) {
 
 	if cached, err := c.txCache.Get(txid); err == nil &&
@@ -600,7 +602,7 @@ func (c *EsploraClient) GetRawTx(
 				return cached.tx, nil
 			}
 
-			body, err := c.get("/tx/" + txid.String() + "/raw")
+			body, err := c.get(ctx, "/tx/"+txid.String()+"/raw")
 			if err != nil {
 				return nil, fmt.Errorf(
 					"get raw tx: %w", err,
@@ -630,7 +632,7 @@ func (c *EsploraClient) GetRawTx(
 				tx:   &tx,
 				size: uint64(len(body)),
 			}); putErr != nil {
-				c.log.WarnS(context.Background(),
+				c.log.WarnS(ctx,
 					"Tx cache Put failed", putErr,
 					slog.String("txid", txid.String()))
 			}
@@ -653,7 +655,9 @@ func (c *EsploraClient) GetRawTx(
 
 // BroadcastTx broadcasts a raw transaction to the network. Returns the
 // txid string on success.
-func (c *EsploraClient) BroadcastTx(tx *wire.MsgTx) (string, error) {
+func (c *EsploraClient) BroadcastTx(ctx context.Context,
+	tx *wire.MsgTx) (string, error) {
+
 	var buf bytes.Buffer
 	if err := tx.Serialize(&buf); err != nil {
 		return "", fmt.Errorf("serialize tx: %w", err)
@@ -661,7 +665,7 @@ func (c *EsploraClient) BroadcastTx(tx *wire.MsgTx) (string, error) {
 
 	txHex := hex.EncodeToString(buf.Bytes())
 
-	body, err := c.post("/tx", txHex)
+	body, err := c.post(ctx, "/tx", txHex)
 	if err != nil {
 		return "", fmt.Errorf("broadcast tx: %w", err)
 	}
@@ -672,8 +676,10 @@ func (c *EsploraClient) BroadcastTx(tx *wire.MsgTx) (string, error) {
 // GetFeeEstimates returns the fee estimates from the Esplora API. The
 // returned map has string keys representing confirmation targets and float64
 // values representing fee rates in sat/vB.
-func (c *EsploraClient) GetFeeEstimates() (map[string]float64, error) {
-	body, err := c.get("/fee-estimates")
+func (c *EsploraClient) GetFeeEstimates(
+	ctx context.Context) (map[string]float64, error) {
+
+	body, err := c.get(ctx, "/fee-estimates")
 	if err != nil {
 		return nil, fmt.Errorf("get fee estimates: %w", err)
 	}
@@ -687,14 +693,14 @@ func (c *EsploraClient) GetFeeEstimates() (map[string]float64, error) {
 }
 
 // GetOutspend returns the spending status of a specific output.
-func (c *EsploraClient) GetOutspend(txid chainhash.Hash,
-	vout uint32) (*esploraOutspend, error) {
+func (c *EsploraClient) GetOutspend(ctx context.Context,
+	txid chainhash.Hash, vout uint32) (*esploraOutspend, error) {
 
 	path := fmt.Sprintf(
 		"/tx/%s/outspend/%d", txid.String(), vout,
 	)
 
-	body, err := c.get(path)
+	body, err := c.get(ctx, path)
 	if err != nil {
 		return nil, fmt.Errorf("get outspend: %w", err)
 	}
@@ -708,8 +714,17 @@ func (c *EsploraClient) GetOutspend(txid chainhash.Hash,
 }
 
 // get performs an HTTP GET request and returns the response body.
-func (c *EsploraClient) get(path string) ([]byte, error) {
-	resp, err := c.httpClient.Get(c.baseURL + path)
+func (c *EsploraClient) get(ctx context.Context,
+	path string) ([]byte, error) {
+
+	req, err := http.NewRequestWithContext(
+		ctx, http.MethodGet, c.baseURL+path, nil,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("build GET request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req) //nolint:gosec // G704: trusted URL
 	if err != nil {
 		return nil, err
 	}
@@ -733,7 +748,7 @@ func (c *EsploraClient) get(path string) ([]byte, error) {
 // TestMempoolAccept validates transactions against mempool policy
 // without broadcasting them. This uses the Esplora POST /txs/test
 // endpoint which proxies to Bitcoin Core's testmempoolaccept RPC.
-func (c *EsploraClient) TestMempoolAccept(
+func (c *EsploraClient) TestMempoolAccept(ctx context.Context,
 	txns []*wire.MsgTx,
 	maxFeeRate float64) ([]testMempoolAcceptResult, error) {
 
@@ -763,10 +778,15 @@ func (c *EsploraClient) TestMempoolAccept(
 		)
 	}
 
-	resp, err := c.httpClient.Post(
-		url, "application/json",
-		bytes.NewReader(jsonBody),
+	req, err := http.NewRequestWithContext(
+		ctx, http.MethodPost, url, bytes.NewReader(jsonBody),
 	)
+	if err != nil {
+		return nil, fmt.Errorf("build test mempool request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req) //nolint:gosec // G704: trusted URL
 	if err != nil {
 		return nil, fmt.Errorf("test mempool accept: %w", err)
 	}
@@ -867,8 +887,6 @@ func (c *EsploraClient) SubmitPackage(ctx context.Context,
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	// URL is the operator-configured Esplora base URL, not user input;
-	// the same c.baseURL is used by every other method in this file.
 	resp, err := c.httpClient.Do(req) //nolint:gosec // G704: trusted URL
 	if err != nil {
 		return fmt.Errorf("submit package: %w", err)
@@ -926,13 +944,18 @@ func (c *EsploraClient) SubmitPackage(ctx context.Context,
 
 // post performs an HTTP POST request with a text body and returns the
 // response body.
-func (c *EsploraClient) post(path string,
-	body string) ([]byte, error) {
+func (c *EsploraClient) post(ctx context.Context,
+	path string, body string) ([]byte, error) {
 
-	resp, err := c.httpClient.Post(
-		c.baseURL+path, "text/plain",
-		strings.NewReader(body),
+	req, err := http.NewRequestWithContext(
+		ctx, http.MethodPost, c.baseURL+path, strings.NewReader(body),
 	)
+	if err != nil {
+		return nil, fmt.Errorf("build POST request: %w", err)
+	}
+	req.Header.Set("Content-Type", "text/plain")
+
+	resp, err := c.httpClient.Do(req) //nolint:gosec // G704: trusted URL
 	if err != nil {
 		return nil, err
 	}

--- a/lwwallet/esplora_cache_test.go
+++ b/lwwallet/esplora_cache_test.go
@@ -35,14 +35,14 @@ func TestEsploraCacheRejectsTxHashMismatch(t *testing.T) {
 
 	c := NewEsploraClient(srv.URL, btclog.Disabled)
 
-	tx, err := c.GetRawTx(wantTxid)
+	tx, err := c.GetRawTx(t.Context(), wantTxid)
 	require.Error(t, err)
 	require.Nil(t, tx)
 	require.Contains(t, err.Error(), "tx hash mismatch")
 
 	// A second request still goes through the network (no cache
 	// poison) and still rejects.
-	tx2, err2 := c.GetRawTx(wantTxid)
+	tx2, err2 := c.GetRawTx(t.Context(), wantTxid)
 	require.Error(t, err2)
 	require.Nil(t, tx2)
 }
@@ -75,7 +75,7 @@ func TestEsploraCacheRejectsBlockHashMismatch(t *testing.T) {
 
 	c := NewEsploraClient(srv.URL, btclog.Disabled)
 
-	block, err := c.GetRawBlock(wantHash)
+	block, err := c.GetRawBlock(t.Context(), wantHash)
 	require.Error(t, err)
 	require.Nil(t, block)
 	require.Contains(t, err.Error(), "raw block hash mismatch")
@@ -101,7 +101,7 @@ func TestEsploraCacheRejectsBlockHeaderHashMismatch(t *testing.T) {
 
 	c := NewEsploraClient(srv.URL, btclog.Disabled)
 
-	hdr, err := c.GetBlockHeader(wantHash)
+	hdr, err := c.GetBlockHeader(t.Context(), wantHash)
 	require.Error(t, err)
 	require.Nil(t, hdr)
 	require.Contains(t, err.Error(), "block id mismatch")
@@ -132,13 +132,13 @@ func TestEsploraCacheTxHitCount(t *testing.T) {
 	c := NewEsploraClient(srv.URL, btclog.Disabled)
 
 	// First call: cache miss, one HTTP hit.
-	tx1, err := c.GetRawTx(txid)
+	tx1, err := c.GetRawTx(t.Context(), txid)
 	require.NoError(t, err)
 	require.NotNil(t, tx1)
 	require.Equal(t, int64(1), hits.Load())
 
 	// Second call: cache hit, no additional HTTP hit.
-	tx2, err := c.GetRawTx(txid)
+	tx2, err := c.GetRawTx(t.Context(), txid)
 	require.NoError(t, err)
 	require.Same(t, tx1, tx2,
 		"expected cache to return same pointer")

--- a/lwwallet/esplora_chain.go
+++ b/lwwallet/esplora_chain.go
@@ -52,6 +52,11 @@ type EsploraChainService struct {
 	// processed TipBlock event.
 	bestBlock waddrmgr.BlockStamp
 
+	// runCtx is the service lifecycle context captured at Start. It
+	// bounds Esplora HTTP calls made through btcwallet's chain.Interface,
+	// whose methods do not accept a context parameter.
+	runCtx context.Context //nolint:containedctx
+
 	quit     chan struct{}
 	stopOnce sync.Once
 	wg       sync.WaitGroup
@@ -79,6 +84,7 @@ func NewEsploraChainService(esplora *EsploraClient,
 // goroutine that translates each TipBlock event into btcwallet
 // chain notifications.
 func (s *EsploraChainService) Start(ctx context.Context) error {
+	//nolint:contextcheck // tip subscription lifecycle is owned by Stop
 	tipHeight, tipHash, tipTime, sub, err :=
 		s.tipPoller.BestBlockAndSubscribe()
 	if err != nil {
@@ -91,6 +97,7 @@ func (s *EsploraChainService) Start(ctx context.Context) error {
 		Hash:      tipHash,
 		Timestamp: tipTime,
 	}
+	s.runCtx = ctx
 	s.mu.Unlock()
 
 	// Send ClientConnected so btcwallet knows the chain backend
@@ -113,8 +120,7 @@ func (s *EsploraChainService) Start(ctx context.Context) error {
 // both reach close(s.quit) and panic on a double close.
 func (s *EsploraChainService) Stop() {
 	s.stopOnce.Do(func() {
-		s.log.InfoS(context.Background(),
-			"Stopping Esplora chain service")
+		s.log.InfoS(s.requestContext(), "Stopping Esplora chain service")
 
 		close(s.quit)
 	})
@@ -123,6 +129,20 @@ func (s *EsploraChainService) Stop() {
 // WaitForShutdown blocks until the polling goroutine has exited.
 func (s *EsploraChainService) WaitForShutdown() {
 	s.wg.Wait()
+}
+
+// requestContext returns the service lifecycle context captured by Start.
+// Chain interface methods do not receive caller contexts, so they use this
+// root to let daemon shutdown cancel in-flight Esplora HTTP requests.
+func (s *EsploraChainService) requestContext() context.Context {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.runCtx != nil {
+		return s.runCtx
+	}
+
+	return context.Background()
 }
 
 // GetBestBlock returns the hash and height of the current best block.
@@ -143,7 +163,7 @@ func (s *EsploraChainService) GetBestBlock() (
 func (s *EsploraChainService) GetBlock(
 	hash *chainhash.Hash) (*wire.MsgBlock, error) {
 
-	return s.esplora.GetRawBlock(*hash)
+	return s.esplora.GetRawBlock(s.requestContext(), *hash)
 }
 
 // GetBlockHash returns the block hash at the given height. The height
@@ -151,7 +171,9 @@ func (s *EsploraChainService) GetBlock(
 func (s *EsploraChainService) GetBlockHash(
 	height int64) (*chainhash.Hash, error) {
 
-	hash, err := s.esplora.GetBlockHashByHeight(int32(height))
+	hash, err := s.esplora.GetBlockHashByHeight(
+		s.requestContext(), int32(height),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -164,7 +186,7 @@ func (s *EsploraChainService) GetBlockHash(
 func (s *EsploraChainService) GetBlockHeader(
 	hash *chainhash.Hash) (*wire.BlockHeader, error) {
 
-	return s.esplora.GetRawBlockHeader(*hash)
+	return s.esplora.GetRawBlockHeader(s.requestContext(), *hash)
 }
 
 // IsCurrent returns true because the Esplora backend is assumed to
@@ -181,6 +203,8 @@ func (s *EsploraChainService) IsCurrent() bool {
 func (s *EsploraChainService) FilterBlocks(
 	req *chain.FilterBlocksRequest) (
 	*chain.FilterBlocksResponse, error) {
+
+	ctx := s.requestContext()
 
 	// Build a pkScript lookup table from the address sets so we
 	// can efficiently match transaction outputs.
@@ -213,7 +237,9 @@ func (s *EsploraChainService) FilterBlocks(
 	}
 
 	for batchIdx, blockMeta := range req.Blocks {
-		block, err := s.esplora.GetRawBlock(blockMeta.Hash)
+		block, err := s.esplora.GetRawBlock(
+			ctx, blockMeta.Hash,
+		)
 		if err != nil {
 			return nil, fmt.Errorf(
 				"get block %s: %w",
@@ -347,7 +373,8 @@ func (s *EsploraChainService) BlockStamp() (
 func (s *EsploraChainService) SendRawTransaction(tx *wire.MsgTx,
 	allowHighFees bool) (*chainhash.Hash, error) {
 
-	_, err := s.esplora.BroadcastTx(tx)
+	ctx := s.requestContext()
+	_, err := s.esplora.BroadcastTx(ctx, tx)
 	if err != nil {
 		return nil, fmt.Errorf("broadcast tx: %w", err)
 	}
@@ -375,6 +402,8 @@ func (s *EsploraChainService) Rescan(startHash *chainhash.Hash,
 	addrs []btcutil.Address,
 	outpoints map[wire.OutPoint]btcutil.Address) error {
 
+	ctx := s.requestContext()
+
 	// Build the pkScript lookup from addresses.
 	addrScripts := make(map[string]struct{})
 	for _, addr := range addrs {
@@ -387,7 +416,9 @@ func (s *EsploraChainService) Rescan(startHash *chainhash.Hash,
 	}
 
 	// Look up the starting block height.
-	startBlock, err := s.esplora.GetBlockHeader(*startHash)
+	startBlock, err := s.esplora.GetBlockHeader(
+		ctx, *startHash,
+	)
 	if err != nil {
 		return fmt.Errorf("get start block header: %w", err)
 	}
@@ -395,12 +426,12 @@ func (s *EsploraChainService) Rescan(startHash *chainhash.Hash,
 	startHeight := startBlock.Height
 
 	// Get the current chain tip.
-	tipHeight, err := s.esplora.GetTipHeight()
+	tipHeight, err := s.esplora.GetTipHeight(ctx)
 	if err != nil {
 		return fmt.Errorf("get tip height for rescan: %w", err)
 	}
 
-	s.log.InfoS(context.Background(), "Starting chain rescan",
+	s.log.InfoS(ctx, "Starting chain rescan",
 		slog.Int("start_height", int(startHeight)),
 		slog.Int("tip_height", int(tipHeight)),
 		slog.Int("watched_addrs", len(addrs)),
@@ -412,21 +443,27 @@ func (s *EsploraChainService) Rescan(startHash *chainhash.Hash,
 
 	// Walk each block from start to tip.
 	for height := startHeight; height <= tipHeight; height++ {
-		blockHash, err := s.esplora.GetBlockHashByHeight(height)
+		blockHash, err := s.esplora.GetBlockHashByHeight(
+			ctx, height,
+		)
 		if err != nil {
 			return fmt.Errorf(
 				"get block hash at %d: %w", height, err,
 			)
 		}
 
-		block, err := s.esplora.GetRawBlock(blockHash)
+		block, err := s.esplora.GetRawBlock(
+			ctx, blockHash,
+		)
 		if err != nil {
 			return fmt.Errorf(
 				"get block at %d: %w", height, err,
 			)
 		}
 
-		blockHeader, err := s.esplora.GetBlockHeader(blockHash)
+		blockHeader, err := s.esplora.GetBlockHeader(
+			ctx, blockHash,
+		)
 		if err != nil {
 			return fmt.Errorf(
 				"get block header at %d: %w", height, err,
@@ -480,7 +517,7 @@ func (s *EsploraChainService) Rescan(startHash *chainhash.Hash,
 		)
 	}
 
-	s.log.InfoS(context.Background(), "Chain rescan complete",
+	s.log.InfoS(ctx, "Chain rescan complete",
 		slog.Int("tip_height", int(tipHeight)),
 		slog.Int("pending_notifications", len(pending)))
 
@@ -538,16 +575,16 @@ func (s *EsploraChainService) NotifyReceived(
 	addrs []btcutil.Address) error {
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	for _, addr := range addrs {
 		s.watchedAddrs[addr.String()] = addr
 	}
+	totalWatched := len(s.watchedAddrs)
+	s.mu.Unlock()
 
-	s.log.DebugS(context.Background(),
+	s.log.DebugS(s.requestContext(),
 		"Registered addresses for notifications",
 		slog.Int("new_addrs", len(addrs)),
-		slog.Int("total_watched", len(s.watchedAddrs)))
+		slog.Int("total_watched", totalWatched))
 
 	return nil
 }
@@ -577,7 +614,7 @@ func (s *EsploraChainService) TestMempoolAccept(
 	txns []*wire.MsgTx,
 	maxFeeRate float64) ([]*btcjson.TestMempoolAcceptResult, error) {
 
-	esploraResults, err := s.esplora.TestMempoolAccept(
+	esploraResults, err := s.esplora.TestMempoolAccept(s.requestContext(),
 		txns, maxFeeRate,
 	)
 	if err != nil {
@@ -686,7 +723,7 @@ func (s *EsploraChainService) processTipEvent(ctx context.Context,
 	// builders) reuse the response.
 	var relevantTxs []*wtxmgr.TxRecord
 	if len(watchedScripts) > 0 {
-		block, err := s.esplora.GetRawBlock(event.Hash)
+		block, err := s.esplora.GetRawBlock(ctx, event.Hash)
 		if err != nil {
 			s.log.WarnS(ctx,
 				"Chain service block fetch failed", err,
@@ -695,7 +732,7 @@ func (s *EsploraChainService) processTipEvent(ctx context.Context,
 			return
 		}
 
-		relevantTxs = s.filterBlockTxs(
+		relevantTxs = s.filterBlockTxs(ctx,
 			block, watchedScripts, blockMeta.Time,
 		)
 	}
@@ -741,7 +778,8 @@ func (s *EsploraChainService) processTipEvent(ctx context.Context,
 
 // filterBlockTxs checks all transactions in the block against the
 // watched pkScripts and returns TxRecords for matching transactions.
-func (s *EsploraChainService) filterBlockTxs(block *wire.MsgBlock,
+func (s *EsploraChainService) filterBlockTxs(ctx context.Context,
+	block *wire.MsgBlock,
 	watchedScripts map[string]struct{},
 	blockTime time.Time) []*wtxmgr.TxRecord {
 
@@ -758,7 +796,7 @@ func (s *EsploraChainService) filterBlockTxs(block *wire.MsgBlock,
 		}
 
 		txHash := tx.TxHash()
-		s.log.DebugS(context.Background(),
+		s.log.DebugS(ctx,
 			"Found relevant transaction in block",
 			slog.String("txid", txHash.String()),
 			slog.Int("num_outputs", len(tx.TxOut)))

--- a/lwwallet/esplora_test.go
+++ b/lwwallet/esplora_test.go
@@ -63,7 +63,7 @@ func TestEsploraGetTipHeight(t *testing.T) {
 	defer srv.Close()
 
 	client := NewEsploraClient(srv.URL, btclog.Disabled)
-	height, err := client.GetTipHeight()
+	height, err := client.GetTipHeight(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, int32(850123), height)
 }
@@ -87,7 +87,7 @@ func TestEsploraGetTipHash(t *testing.T) {
 	defer srv.Close()
 
 	client := NewEsploraClient(srv.URL, btclog.Disabled)
-	hash, err := client.GetTipHash()
+	hash, err := client.GetTipHash(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, hashStr, hash.String())
 }
@@ -110,7 +110,7 @@ func TestEsploraGetBlockHashByHeight(t *testing.T) {
 	defer srv.Close()
 
 	client := NewEsploraClient(srv.URL, btclog.Disabled)
-	hash, err := client.GetBlockHashByHeight(100)
+	hash, err := client.GetBlockHashByHeight(t.Context(), 100)
 	require.NoError(t, err)
 	require.Equal(t, hashStr, hash.String())
 }
@@ -140,7 +140,7 @@ func TestEsploraGetBlockHeader(t *testing.T) {
 	defer srv.Close()
 
 	client := NewEsploraClient(srv.URL, btclog.Disabled)
-	block, err := client.GetBlockHeader(*blockHash)
+	block, err := client.GetBlockHeader(t.Context(), *blockHash)
 	require.NoError(t, err)
 	require.Equal(t, int32(100), block.Height)
 	require.Equal(t, int64(1231006505), block.Timestamp)
@@ -187,7 +187,7 @@ func TestEsploraGetScriptUtxos(t *testing.T) {
 	defer srv.Close()
 
 	client := NewEsploraClient(srv.URL, btclog.Disabled)
-	utxos, err := client.GetScriptUtxos(pkScript)
+	utxos, err := client.GetScriptUtxos(t.Context(), pkScript)
 	require.NoError(t, err)
 	require.Len(t, utxos, 2)
 	require.Equal(t, int64(100000), utxos[0].Value)
@@ -221,7 +221,7 @@ func TestEsploraGetTxStatus(t *testing.T) {
 	defer srv.Close()
 
 	client := NewEsploraClient(srv.URL, btclog.Disabled)
-	status, err := client.GetTxStatus(*txid)
+	status, err := client.GetTxStatus(t.Context(), *txid)
 	require.NoError(t, err)
 	require.True(t, status.Confirmed)
 	require.Equal(t, uint32(750000), status.BlockHeight)
@@ -249,7 +249,7 @@ func TestEsploraGetFeeEstimates(t *testing.T) {
 	defer srv.Close()
 
 	client := NewEsploraClient(srv.URL, btclog.Disabled)
-	estimates, err := client.GetFeeEstimates()
+	estimates, err := client.GetFeeEstimates(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, 25.0, estimates["1"])
 	require.Equal(t, 5.0, estimates["25"])
@@ -284,7 +284,7 @@ func TestEsploraGetOutspend(t *testing.T) {
 	defer srv.Close()
 
 	client := NewEsploraClient(srv.URL, btclog.Disabled)
-	outspend, err := client.GetOutspend(*txid, 0)
+	outspend, err := client.GetOutspend(t.Context(), *txid, 0)
 	require.NoError(t, err)
 	require.True(t, outspend.Spent)
 	require.Equal(t, "abcd1234", outspend.Txid)
@@ -320,7 +320,7 @@ func TestEsploraBroadcastTx(t *testing.T) {
 	})
 
 	client := NewEsploraClient(srv.URL, btclog.Disabled)
-	txid, err := client.BroadcastTx(tx)
+	txid, err := client.BroadcastTx(t.Context(), tx)
 	require.NoError(t, err)
 	require.Equal(t, "aabbccdd", txid)
 }
@@ -406,7 +406,7 @@ func TestEsploraHTTPError(t *testing.T) {
 	defer srv.Close()
 
 	client := NewEsploraClient(srv.URL, btclog.Disabled)
-	_, err := client.GetTipHeight()
+	_, err := client.GetTipHeight(t.Context())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "404")
 }

--- a/lwwallet/tip_poller.go
+++ b/lwwallet/tip_poller.go
@@ -127,13 +127,15 @@ func (t *TipPoller) Start() error {
 		t.mu.Unlock()
 	}
 
-	height, err := t.esplora.GetTipHeight()
+	height, err := t.esplora.GetTipHeight(context.Background())
 	if err != nil {
 		resetStarted()
 		return fmt.Errorf("get initial tip height: %w", err)
 	}
 
-	hash, err := t.esplora.GetBlockHashByHeight(height)
+	hash, err := t.esplora.GetBlockHashByHeight(
+		context.Background(), height,
+	)
 	if err != nil {
 		resetStarted()
 		return fmt.Errorf("get initial tip hash: %w", err)
@@ -146,7 +148,10 @@ func (t *TipPoller) Start() error {
 	// serve `/block/<hash>` for the initial seed even when the
 	// tested path never reads `tipTime`.
 	var tipTime time.Time
-	if header, hdrErr := t.esplora.GetBlockHeader(hash); hdrErr == nil {
+	header, hdrErr := t.esplora.GetBlockHeader(
+		context.Background(), hash,
+	)
+	if hdrErr == nil {
 		tipTime = time.Unix(header.Timestamp, 0)
 	} else {
 		t.log.WarnS(context.Background(),
@@ -270,7 +275,7 @@ func (t *TipPoller) pollLoop() {
 // remainder of the cycle so subscribers never see an out-of-order
 // event; the next tick re-attempts from the same starting point.
 func (t *TipPoller) poll() {
-	newHeight, err := t.esplora.GetTipHeight()
+	newHeight, err := t.esplora.GetTipHeight(context.Background())
 	if err != nil {
 		t.log.WarnS(context.Background(),
 			"Tip poller GetTipHeight failed", err)
@@ -302,7 +307,9 @@ func (t *TipPoller) poll() {
 		slog.Int("new_height", int(newHeight)))
 
 	for height := oldHeight + 1; height <= newHeight; height++ {
-		hash, err := t.esplora.GetBlockHashByHeight(height)
+		hash, err := t.esplora.GetBlockHashByHeight(
+			context.Background(), height,
+		)
 		if err != nil {
 			t.log.WarnS(context.Background(),
 				"Tip poller GetBlockHashByHeight failed",
@@ -311,7 +318,9 @@ func (t *TipPoller) poll() {
 			return
 		}
 
-		header, err := t.esplora.GetBlockHeader(hash)
+		header, err := t.esplora.GetBlockHeader(
+			context.Background(), hash,
+		)
 		if err != nil {
 			t.log.WarnS(context.Background(),
 				"Tip poller GetBlockHeader failed", err,

--- a/oor/actor.go
+++ b/oor/actor.go
@@ -349,8 +349,8 @@ func (a *OORClientActor) Stop() {
 //
 // StopAndWait is safe to call multiple times.
 func (a *OORClientActor) StopAndWait(ctx context.Context) error {
-	a.cfg.Log.UnwrapOr(build.LoggerFromContext(context.Background())).InfoS(
-		context.Background(), "Stopping OOR client actor",
+	a.cfg.Log.UnwrapOr(build.LoggerFromContext(ctx)).InfoS(
+		ctx, "Stopping OOR client actor",
 		slog.String("actor_id", a.cfg.ActorID),
 	)
 
@@ -360,8 +360,8 @@ func (a *OORClientActor) StopAndWait(ctx context.Context) error {
 		}
 	}
 
-	a.cfg.Log.UnwrapOr(build.LoggerFromContext(context.Background())).InfoS(
-		context.Background(), "OOR client actor stopped",
+	a.cfg.Log.UnwrapOr(build.LoggerFromContext(ctx)).InfoS(
+		ctx, "OOR client actor stopped",
 		slog.String("actor_id", a.cfg.ActorID),
 	)
 

--- a/oor/signing_outbox_handler.go
+++ b/oor/signing_outbox_handler.go
@@ -66,7 +66,7 @@ func (h *SigningOutboxHandler) Handle(ctx context.Context,
 			slog.String("session_id", sessionID.String()),
 			slog.Int("num_checkpoints", len(msg.CoSignedCheckpointPSBTs)))
 
-		return h.handleCheckpointSignatures(msg)
+		return h.handleCheckpointSignatures(ctx, msg)
 
 	case *ScheduleRetryRequest:
 		logger(ctx).InfoS(ctx, "Scheduling retry",
@@ -118,7 +118,7 @@ func (h *SigningOutboxHandler) handleArkSignatures(
 
 // handleCheckpointSignatures attaches client-side collaborative VTXO spend
 // signatures to each checkpoint PSBT.
-func (h *SigningOutboxHandler) handleCheckpointSignatures(
+func (h *SigningOutboxHandler) handleCheckpointSignatures(ctx context.Context,
 	msg *RequestCheckpointSignatures) ([]Event, error) {
 
 	if h.Signer == nil {
@@ -133,7 +133,7 @@ func (h *SigningOutboxHandler) handleCheckpointSignatures(
 	}
 
 	logCheckpointSummary(
-		context.Background(),
+		ctx,
 		"Checkpoint signatures attached",
 		msg.CoSignedCheckpointPSBTs,
 	)

--- a/round/actor.go
+++ b/round/actor.go
@@ -204,6 +204,11 @@ type RoundClientActor struct {
 	// log is the logger for this actor instance.
 	log btclog.Logger
 
+	// runCtx is the actor lifecycle context captured at Start. It is used
+	// for registrations that must outlive one Receive turn but should
+	// still stop when the actor is stopped.
+	runCtx context.Context //nolint:containedctx
+
 	// rounds tracks all round FSMs keyed by their RoundKey. Rounds start
 	// with a TempRoundKey and are re-keyed to their server-assigned RoundID
 	// when received via RoundJoined. This enables concurrent round assembly.
@@ -919,10 +924,7 @@ func (a *RoundClientActor) registerCommitmentConfirmation(ctx context.Context,
 		NotifyActor: fn.Some(mappedRef),
 	}
 
-	// Use a background context for the confirmation registration. The
-	// ConfActor needs a long-lived context that won't be cancelled when
-	// the current message processing completes.
-	if err := a.cfg.ChainSource.Tell(context.Background(), confReq); err != nil {
+	if err := a.cfg.ChainSource.Tell(a.registrationCtx(ctx), confReq); err != nil {
 		a.log.WarnS(ctx, "Failed to register confirmation", err)
 	}
 }
@@ -1013,10 +1015,24 @@ func (a *RoundClientActor) OnStop(ctx context.Context) error {
 	return nil
 }
 
+// registrationCtx returns the actor-owned context used for registrations that
+// must outlive the current Receive call. Some tests construct actor shells
+// without calling Start, so the fallback detaches cancellation from the current
+// call while preserving context values for logs and tracing.
+func (a *RoundClientActor) registrationCtx(ctx context.Context) context.Context {
+	if a.runCtx != nil {
+		return a.runCtx
+	}
+
+	return context.WithoutCancel(ctx)
+}
+
 // Start initializes the actor by registering with the wallet actor to receive
 // boarding UTXO confirmation notifications, and resuming any active rounds.
 // This should be called once after actor creation to restore state.
 func (a *RoundClientActor) Start(ctx context.Context) error {
+	a.runCtx = ctx
+
 	a.log.InfoS(ctx, "Starting round client actor",
 		slog.String("name", a.cfg.Name))
 
@@ -2248,11 +2264,8 @@ func (a *RoundClientActor) processConfirmationRequest(
 		slog.Int("height_hint", int(heightHint)),
 		slog.Int("target_confs", int(m.TargetConfs)))
 
-	// Use a background context for the confirmation registration.
-	// The ConfActor needs a long-lived context that won't be
-	// cancelled when the current message processing completes.
 	if err := a.cfg.ChainSource.Tell(
-		context.Background(), confReq,
+		a.registrationCtx(ctx), confReq,
 	); err != nil {
 		a.log.WarnS(ctx,
 			"Failed to register confirmation",

--- a/sdk/ark/embedded.go
+++ b/sdk/ark/embedded.go
@@ -39,6 +39,8 @@ type EmbeddedConfig struct {
 
 // StartEmbedded starts a darepod runtime in-process and returns an SDK facade
 // that communicates with it over an injected in-memory listener.
+//
+//nolint:contextcheck // embedded daemon lifetime is detached from dial ctx
 func StartEmbedded(ctx context.Context,
 	cfg EmbeddedConfig) (*Client, error) {
 

--- a/serverconn/runtime.go
+++ b/serverconn/runtime.go
@@ -72,6 +72,7 @@ func NewRuntime(cfg ConnectorConfig) (*Runtime, error) {
 // Start launches durable egress processing and ingress pulling. Returns an
 // error if the ingress checkpoint cannot be loaded from the store.
 func (r *Runtime) Start(ctx context.Context) error {
+	//nolint:contextcheck // durable actor owns lifecycle
 	r.StartEgress()
 
 	if err := r.StartIngress(ctx); err != nil {

--- a/timeout/actor.go
+++ b/timeout/actor.go
@@ -145,6 +145,7 @@ func (a *Actor) handleSchedule(_ context.Context,
 	// any actor state directly. Instead it Tells an internalTimerFired
 	// message back into self, where Receive will deliver the
 	// user-visible ExpiredMsg single-threadedly.
+	//nolint:contextcheck // timer callback outlives scheduling actor turn
 	timer := a.clock.AfterFunc(req.Duration, func() {
 		self, ok := a.loadSelf()
 		if !ok {
@@ -200,6 +201,7 @@ func (a *Actor) handleScheduleRecurring(_ context.Context,
 		callback: req.Callback,
 	}
 
+	//nolint:contextcheck // recurring timer is owned by timeout actor
 	a.armRecurring(req.ID, gen, req.Interval)
 
 	return fn.Ok[Resp](&AckResponse{
@@ -261,6 +263,7 @@ func (a *Actor) handleTickFired(ctx context.Context,
 		FiredAt: m.FiredAt,
 	})
 
+	//nolint:contextcheck // recurring timer is owned by timeout actor
 	a.armRecurring(m.ID, entry.gen, entry.interval)
 
 	return fn.Ok[Resp](&AckResponse{

--- a/txconfirm/actor.go
+++ b/txconfirm/actor.go
@@ -1209,6 +1209,7 @@ func (a *TxBroadcasterActor) notifyOneTerminal(ctx context.Context,
 
 	case <-notifyCtx.Done():
 		a.terminalNotifyInflight[inflightKey] = struct{}{}
+		//nolint:contextcheck // async result outlives ctx
 		a.completeTerminalNotifyAsync(
 			inflightKey, txid, subscriberID, errChan, cancel,
 		)

--- a/txconfirm/actor_test.go
+++ b/txconfirm/actor_test.go
@@ -346,6 +346,7 @@ func (f *fakeChainSourceRef) handleAsk(_ context.Context,
 			f.confConfs[*req.Txid] = req.TargetConfs
 			if event, ok := f.alreadyConfirmed[*req.Txid]; ok {
 				notifyRef := req.NotifyActor.UnwrapOr(nil)
+				//nolint:contextcheck // fake backend
 				_ = notifyRef.Tell(context.Background(), event)
 			}
 		}

--- a/txconfirm/broadcaster.go
+++ b/txconfirm/broadcaster.go
@@ -398,6 +398,7 @@ func (b *CPFPBroadcaster) releaseWalletLeasesAsync(_ context.Context,
 	}
 
 	outpoints = append([]wire.OutPoint(nil), outpoints...)
+	//nolint:contextcheck // wallet lease release is bounded independently
 	go func() {
 		ctx, cancel := context.WithTimeout(
 			context.Background(), DefaultFeeInputLeaseExpiry,

--- a/unroll/actor.go
+++ b/unroll/actor.go
@@ -204,9 +204,7 @@ func (b *behavior) Receive(ctx context.Context, msg Msg) fn.Result[Resp] {
 }
 
 // OnStop stops any loaded protofsm session.
-func (b *behavior) OnStop(context.Context) error {
-	ctx := context.Background()
-
+func (b *behavior) OnStop(ctx context.Context) error {
 	b.unsubscribeBlocks(ctx)
 	b.unregisterSpendWatch(ctx)
 

--- a/unroll/actor_test.go
+++ b/unroll/actor_test.go
@@ -162,6 +162,7 @@ func (f *fakeTxConfirmRef) Ask(_ context.Context,
 			height = 1
 		}
 
+		//nolint:contextcheck // fake txconfirm delivers immediately
 		err := req.Subscriber.Tell(
 			context.Background(),
 			&txconfirm.TxConfirmed{

--- a/unroll/registry.go
+++ b/unroll/registry.go
@@ -458,6 +458,8 @@ func (r *registryBehavior) handleEnsure(ctx context.Context,
 			slog.String("actor_id", child.Ref().ID()),
 		)
 
+		// Registry persistence retries are actor-owned follow-up work.
+		//nolint:contextcheck
 		r.requestPersist(req.Outpoint, 0)
 	}
 
@@ -500,6 +502,8 @@ func (r *registryBehavior) failAdmittedChild(ctx context.Context,
 			slog.String("outpoint", target.String()),
 			slog.String("actor_id", child.Ref().ID()),
 		)
+		// Registry persistence retries are actor-owned follow-up work.
+		//nolint:contextcheck
 		r.requestPersist(target, 0)
 	}
 }
@@ -664,11 +668,15 @@ func (r *registryBehavior) handleTerminated(ctx context.Context,
 			record.ActorID = child.Ref().ID()
 		}
 
+		// Terminal child drain uses its own bounded cleanup context.
+		//nolint:contextcheck
 		stopChildAfterDrain(child)
 		delete(r.active, req.Outpoint)
 	}
 
 	r.pending[req.Outpoint] = cloneRegistryRecord(record)
+	// Registry persistence retries are actor-owned follow-up work.
+	//nolint:contextcheck
 	r.requestPersist(req.Outpoint, 0)
 
 	return fn.Ok[RegistryResp](&RegistryAckResp{})
@@ -794,6 +802,8 @@ func (r *registryBehavior) handlePersistActiveRecord(ctx context.Context,
 			slog.String("outpoint", req.Outpoint.String()),
 			slog.Int("attempt", req.Attempt+1),
 		)
+		// Store retry timers are owned by the registry after this turn.
+		//nolint:contextcheck
 		r.schedulePersistRetry(req.Outpoint, req.Attempt+1)
 
 		return fn.Ok[RegistryResp](&RegistryAckResp{})
@@ -812,6 +822,8 @@ func (r *registryBehavior) handlePersistActiveRecord(ctx context.Context,
 	}
 
 	r.persisting[req.Outpoint] = cloneRegistryRecord(record)
+	// Async store writes outlive the registry receive turn by design.
+	//nolint:contextcheck
 	r.persistRecordAsync(req.Outpoint, req.Attempt, record)
 
 	return fn.Ok[RegistryResp](&RegistryAckResp{})
@@ -844,6 +856,8 @@ func (r *registryBehavior) handlePersistRecordResult(ctx context.Context,
 		if ok && sameRegistryRecord(record, req.Record) {
 			delete(r.pending, req.Outpoint)
 		} else if ok {
+			// Registry persistence retries are actor-owned work.
+			//nolint:contextcheck
 			r.requestPersist(req.Outpoint, 0)
 		}
 
@@ -859,8 +873,12 @@ func (r *registryBehavior) handlePersistRecordResult(ctx context.Context,
 
 	record, ok := r.pending[req.Outpoint]
 	if ok && sameRegistryRecord(record, req.Record) {
+		// Store retry timers are owned by the registry after this turn.
+		//nolint:contextcheck
 		r.schedulePersistRetry(req.Outpoint, req.Attempt+1)
 	} else if ok {
+		// Registry persistence retries are actor-owned follow-up work.
+		//nolint:contextcheck
 		r.requestPersist(req.Outpoint, 0)
 	}
 
@@ -875,6 +893,7 @@ func (r *registryBehavior) spawn(ctx context.Context,
 		return r.spawnFunc(ctx, target)
 	}
 
+	//nolint:contextcheck // child actor owns its own durable lifecycle
 	return NewVTXOUnrollActor(Config{
 		TargetOutpoint:             target,
 		DeliveryStore:              r.cfg.DeliveryStore,

--- a/unroll/registry_test.go
+++ b/unroll/registry_test.go
@@ -405,17 +405,20 @@ func newRegistryHarnessWithSpawn(t *testing.T,
 			cfg: childCfg,
 			log: btclog.Disabled,
 		}
+		//nolint:contextcheck // test restore uses t.Context as root
 		err := childBehavior.restoreCheckpoint(t.Context())
 		if err != nil {
 			return nil, err
 		}
 
+		//nolint:contextcheck // test child actor owns its own lifecycle
 		childActor := actor.NewActor(actor.ActorConfig[Msg, Resp]{
 			ID:          actorIDForTarget(target),
 			Behavior:    childBehavior,
 			MailboxSize: 64,
 		})
 		childBehavior.selfRef = childActor.TellRef()
+		//nolint:contextcheck // test child actor owns its own lifecycle
 		childActor.Start()
 
 		return &VTXOUnrollActor{
@@ -812,6 +815,8 @@ func TestRegistryStatusUsesCachedActiveRecord(t *testing.T) {
 			},
 		)
 
+		// Test children are owned by t.Cleanup after creation.
+		//nolint:contextcheck
 		return newTestUnrollChild(t, target, behavior), nil
 	}
 
@@ -1005,6 +1010,8 @@ func TestRegistryEnsureStartsChildAfterCallerCancellation(t *testing.T) {
 			},
 		)
 
+		// Test children are owned by t.Cleanup after creation.
+		//nolint:contextcheck
 		return newTestUnrollChild(t, target, behavior), nil
 	}
 
@@ -1075,6 +1082,8 @@ func TestRegistryEnsureMarksRealStartErrorFailed(t *testing.T) {
 			},
 		)
 
+		// Test children are owned by t.Cleanup after creation.
+		//nolint:contextcheck
 		return newTestUnrollChild(t, target, behavior), nil
 	}
 


### PR DESCRIPTION
## Summary

Fixes #273.

This enables `contextcheck` in the main golangci-lint config and cleans up the current context-propagation findings on `main`.

The issue was originally filed with a smaller hit list, but the current tree had more contextcheck findings after later actor, wallet, and OOR changes. I split the cleanup into two buckets: places where cancellation really should propagate into lower-level work, and places where the code intentionally starts work owned by a registration, actor, timer, daemon component, or bounded async cleanup path.

## What Changed

### Esplora request contexts

The `lwwallet` Esplora helpers now accept `context.Context` and build HTTP requests with `http.NewRequestWithContext`.

That covers:

- tip height and tip hash reads
- block hash, block header, and raw block reads
- raw transaction reads
- script/address UTXO reads
- tx status and outspend reads
- fee estimates
- tx broadcast
- package relay submission
- `testmempoolaccept`

Request-scoped callers now pass their own context, so wallet, boarding, and chain-service work can stop promptly when the caller is cancelled or the daemon is shutting down. Long-lived internal paths, such as tip polling and registration checks, pass an explicit lifecycle root where the work intentionally outlives an individual request.

The Esplora HTTP gosec suppressions also now sit on the `http.Client.Do` calls where this repo's gosec runner actually reports G704, with the accurate "trusted URL" rationale.

### Esplora chain-service lifecycle context

`EsploraChainService` now captures the context passed to `Start` and uses that service lifecycle context for btcwallet chain-interface methods that do not accept their own `context.Context` parameter.

That includes block fetches, block hash/header lookups, block filtering, transaction broadcast, rescans, notification logging, and `TestMempoolAccept`.

This preserves the important property that these btcwallet callbacks are not tied to a short-lived caller context, while still allowing daemon shutdown to cancel in-flight Esplora HTTP calls instead of waiting for the HTTP client timeout.

### OOR context propagation

OOR shutdown and checkpoint-signing logs had a caller context available but fell back to `context.Background()`.

Those paths now reuse the inherited context so shutdown diagnostics, deadlines, and scoped logger values stay attached to the work that is actually waiting for shutdown or handling checkpoint-signing results.

### Actor-owned registration contexts

Round confirmation registrations now use the round actor lifecycle context captured in `Start`. This lets confirmation watches outlive the current actor receive turn, but still ties their submission to actor/daemon shutdown instead of an unbounded `context.Background()` root.

The fallback for test-only actor shells uses `context.WithoutCancel(ctx)` so cancellation is detached while context values for logs/tracing are preserved.

### Intentional context roots

Several `contextcheck` findings were intentional lifecycle boundaries. These now have targeted `//nolint:contextcheck` comments at the handoff site instead of keeping the linter disabled globally.

Examples include:

- chain notification registrations whose returned `Cancel` owns the forwarding goroutine lifetime
- actor startup paths where the actor owns its lifecycle after registration
- timer callbacks that fire after the scheduling actor turn has completed
- async cleanup and retry loops with their own owner or timeout
- daemon startup and shutdown roots
- test actors whose lifetime is owned by `t.Cleanup`

## Out Of Scope

This PR intentionally does not enable `noctx`, `testifylint`, or `intrange`.

The Esplora request-context work fixes the important HTTP context propagation covered by this PR, but the remaining `noctx`, `testifylint`, and `intrange` cleanups are separate policy changes and should stay in their own follow-ups.

## Validation

```sh
make commitmsg-lint range=origin/main..HEAD

tools/custom-gcl run --enable-only=contextcheck --timeout=15m \
  --build-tags='test_postgres,test_sqlite,systest' \
  --max-issues-per-linter=0 --max-same-issues=0

go test ./lwwallet ./round ./timeout

GOGC=50 make lint-native
```
