### PR TITLE
daemonrpc: clarify identity_pubkey vs lnd_identity_pubkey

### DIFF
--- a/daemonrpc/daemon.pb.go
+++ b/daemonrpc/daemon.pb.go
@@ -446,8 +446,10 @@ type GetInfoResponse struct {
 	// network is the active bitcoin network (mainnet, testnet, regtest,
 	// etc.).
 	Network string `protobuf:"bytes,3,opt,name=network,proto3" json:"network,omitempty"`
-	// lnd_identity_pubkey is the hex-encoded identity public key of the
-	// connected lnd node. Empty in lwwallet mode.
+	// lnd_identity_pubkey is the hex-encoded public identity key of the
+	// connected lnd node, used for Lightning Network peer identity and
+	// connectivity. Empty in lwwallet mode. This key is distinct from
+	// identity_pubkey and must not be substituted for Ark/OOR signing.
 	LndIdentityPubkey string `protobuf:"bytes,4,opt,name=lnd_identity_pubkey,json=lndIdentityPubkey,proto3" json:"lnd_identity_pubkey,omitempty"`
 	// block_height is the current best block height known to the daemon.
 	BlockHeight uint32 `protobuf:"varint,5,opt,name=block_height,json=blockHeight,proto3" json:"block_height,omitempty"`
@@ -464,9 +466,15 @@ type GetInfoResponse struct {
 	// wallet_ready indicates whether the wallet subsystem is initialized
 	// and ready to process requests.
 	WalletReady bool `protobuf:"varint,9,opt,name=wallet_ready,json=walletReady,proto3" json:"wallet_ready,omitempty"`
-	// identity_pubkey is the hex-encoded identity public key derived from
-	// the active wallet backend. In lnd mode this matches
-	// lnd_identity_pubkey.
+	// identity_pubkey is the hex-encoded daemon wallet identity public key
+	// derived from the active wallet backend's daemon identity key locator
+	// (family 6, index 0). This key is the signing identity for Ark round
+	// participation, indexer proof submission, and OOR transaction
+	// authorization. In lnd mode it is derived through lnd's WalletKit/Signer
+	// and may match the connected lnd node identity key in standard
+	// local-wallet configurations. API consumers should still treat
+	// identity_pubkey as the Ark/OOR signing key and lnd_identity_pubkey as
+	// Lightning peer identity only.
 	IdentityPubkey string `protobuf:"bytes,10,opt,name=identity_pubkey,json=identityPubkey,proto3" json:"identity_pubkey,omitempty"`
 	// server_info contains cached operator terms fetched from the Ark
 	// server during daemon bootstrap. It is empty until the daemon has
@@ -912,8 +920,10 @@ func (x *InitWalletRequest) GetSeedPassphrase() []byte {
 
 type InitWalletResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// identity_pubkey is the hex-encoded identity public key derived from
-	// the newly created wallet.
+	// identity_pubkey is the hex-encoded daemon wallet identity public key
+	// derived from the newly created wallet. This is the same key
+	// reported by GetInfoResponse.identity_pubkey and used for Ark/OOR
+	// signing flows.
 	IdentityPubkey string `protobuf:"bytes,1,opt,name=identity_pubkey,json=identityPubkey,proto3" json:"identity_pubkey,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
@@ -1004,8 +1014,9 @@ func (x *UnlockWalletRequest) GetWalletPassword() []byte {
 
 type UnlockWalletResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// identity_pubkey is the hex-encoded identity public key of the
-	// unlocked wallet.
+	// identity_pubkey is the hex-encoded daemon wallet identity public key
+	// of the unlocked wallet. This is the same key reported by
+	// GetInfoResponse.identity_pubkey and used for Ark/OOR signing flows.
 	IdentityPubkey string `protobuf:"bytes,1,opt,name=identity_pubkey,json=identityPubkey,proto3" json:"identity_pubkey,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache

--- a/daemonrpc/daemon.proto
+++ b/daemonrpc/daemon.proto
@@ -169,8 +169,10 @@ message GetInfoResponse {
     // etc.).
     string network = 3;
 
-    // lnd_identity_pubkey is the hex-encoded identity public key of the
-    // connected lnd node. Empty in lwwallet mode.
+    // lnd_identity_pubkey is the hex-encoded public identity key of the
+    // connected lnd node, used for Lightning Network peer identity and
+    // connectivity. Empty in lwwallet mode. This key is distinct from
+    // identity_pubkey and must not be substituted for Ark/OOR signing.
     string lnd_identity_pubkey = 4;
 
     // block_height is the current best block height known to the daemon.
@@ -193,9 +195,15 @@ message GetInfoResponse {
     // and ready to process requests.
     bool wallet_ready = 9;
 
-    // identity_pubkey is the hex-encoded identity public key derived from
-    // the active wallet backend. In lnd mode this matches
-    // lnd_identity_pubkey.
+    // identity_pubkey is the hex-encoded daemon wallet identity public key
+    // derived from the active wallet backend's daemon identity key locator
+    // (family 6, index 0). This key is the signing identity for Ark round
+    // participation, indexer proof submission, and OOR transaction
+    // authorization. In lnd mode it is derived through lnd's WalletKit/Signer
+    // and may match the connected lnd node identity key in standard
+    // local-wallet configurations. API consumers should still treat
+    // identity_pubkey as the Ark/OOR signing key and lnd_identity_pubkey as
+    // Lightning peer identity only.
     string identity_pubkey = 10;
 
     // server_info contains cached operator terms fetched from the Ark
@@ -288,8 +296,10 @@ message InitWalletRequest {
 }
 
 message InitWalletResponse {
-    // identity_pubkey is the hex-encoded identity public key derived from
-    // the newly created wallet.
+    // identity_pubkey is the hex-encoded daemon wallet identity public key
+    // derived from the newly created wallet. This is the same key
+    // reported by GetInfoResponse.identity_pubkey and used for Ark/OOR
+    // signing flows.
     string identity_pubkey = 1;
 }
 
@@ -300,8 +310,9 @@ message UnlockWalletRequest {
 }
 
 message UnlockWalletResponse {
-    // identity_pubkey is the hex-encoded identity public key of the
-    // unlocked wallet.
+    // identity_pubkey is the hex-encoded daemon wallet identity public key
+    // of the unlocked wallet. This is the same key reported by
+    // GetInfoResponse.identity_pubkey and used for Ark/OOR signing flows.
     string identity_pubkey = 1;
 }
 

--- a/darepod/rpc_wallet.go
+++ b/darepod/rpc_wallet.go
@@ -16,9 +16,9 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// identityKeyFamily is the key family used to derive the daemon's
-// identity public key. This matches lnd's KeyFamilyNodeKey (family 6)
-// so the derived key sits at m/1017'/coinType'/6'/0/0.
+// identityKeyFamily is the key family used to derive the daemon wallet
+// identity public key. This matches lnd's KeyFamilyNodeKey (family 6) so the
+// derived key sits at m/1017'/coinType'/6'/0/0.
 const identityKeyFamily = keychain.KeyFamilyNodeKey
 
 const receiveAuthKeyTag = "darepo/swap/receive-auth/v1"
@@ -404,10 +404,10 @@ func (r *RPCServer) UnlockWallet(ctx context.Context,
 	}, nil
 }
 
-// deriveIdentityPubkey derives the node identity public key from the
-// active self-managed wallet using KeyFamilyNodeKey (family 6, index
-// 0). This matches lnd's identity key derivation path. DeriveKey (not
-// DeriveNextKey) is used so the identity key is stable across calls.
+// deriveIdentityPubkey derives the daemon wallet identity public key from the
+// active self-managed wallet using KeyFamilyNodeKey (family 6, index 0). This
+// is the key used for Ark/OOR signing. DeriveKey (not DeriveNextKey) is used so
+// the identity key is stable across calls.
 func (r *RPCServer) deriveIdentityPubkey(
 	ctx context.Context) (string, error) {
 


### PR DESCRIPTION
Fixes #343.

The `GetInfoResponse` proto comment for `identity_pubkey` incorrectly stated that it simply matches `lnd_identity_pubkey` in lnd mode. The server derives `identity_pubkey` through the daemon wallet identity key locator and uses that key as the Ark/OOR signing identity, while `lnd_identity_pubkey` is exposed as the connected lnd node's Lightning peer identity.

This PR updates the proto source comments across `GetInfoResponse`, `InitWalletResponse`, and `UnlockWalletResponse` to:

- Clarify that `identity_pubkey` is the daemon wallet identity key used for Ark round participation, indexer proof submission, and OOR transaction authorization.
- Explicitly note that `lnd_identity_pubkey` is for Lightning peer identity only and must not be substituted for Ark/OOR signing.
- Avoid leaking Go/lnd constant names into the public proto comments while still documenting the stable locator as family 6, index 0.
- Note that the derived lnd wallet key may match the connected lnd node identity key in standard local-wallet configurations, but API consumers should still use `identity_pubkey` for Ark/OOR signing semantics.
- Cross-reference `identity_pubkey` in `InitWalletResponse` and `UnlockWalletResponse` back to `GetInfoResponse.identity_pubkey`.
- Refresh the generated daemon RPC stubs with `make rpc` so generated Go docs match the proto source.

## Validation

- `make rpc`
- `make commitmsg-lint range=origin/main..HEAD`
- `go test ./daemonrpc ./darepod`
- `GOGC=50 make lint`
- `make build`
