### PR TITLE
actor: return mailbox send errors

### DIFF
--- a/baselib/actor/actor.go
+++ b/baselib/actor/actor.go
@@ -2,6 +2,7 @@ package actor
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -338,32 +339,26 @@ func (ref *actorRefImpl[M, R]) Tell(ctx context.Context, msg M) error {
 		promise:   nil,
 		callerCtx: sendCtx,
 	}
-	ok := ref.actor.mailbox.Send(sendCtx, env)
-
-	// If the send failed, determine the error and whether to route to DLO.
-	if !ok {
-		// Check if actor is terminated.
-		if ref.actor.ctx.Err() != nil {
+	if err := ref.actor.mailbox.Send(sendCtx, env); err != nil {
+		if errors.Is(err, ErrActorTerminated) {
 			logger(ctx).DebugS(ctx, "Tell failed, routing to DLO",
 				"actor_id", ref.actor.id,
 				"msg_type", msg.MessageType())
 
 			ref.trySendToDLO(msg)
-
-			return ErrActorTerminated
 		}
 
-		// Check if caller's context was cancelled.
-		if ctx.Err() != nil {
+		// Log caller cancellation for diagnostics; return the original
+		// mailbox error below so callers receive the exact failure.
+		if errors.Is(err, context.Canceled) ||
+			errors.Is(err, context.DeadlineExceeded) {
+
 			logger(ctx).TraceS(ctx, "Tell failed, caller cancelled",
 				"actor_id", ref.actor.id,
 				"msg_type", msg.MessageType())
-
-			return ctx.Err()
 		}
 
-		// Mailbox full or other failure.
-		return ErrMailboxFull
+		return err
 	}
 
 	return nil
@@ -403,29 +398,8 @@ func (ref *actorRefImpl[M, R]) Ask(ctx context.Context, msg M) Future[R] {
 		promise:   promise,
 		callerCtx: ctx,
 	}
-	ok := ref.actor.mailbox.Send(ctx, env)
-
-	// If the send failed (mailbox closed, context cancelled, or actor
-	// terminated), complete the promise with an appropriate error.
-	if !ok {
-		// Determine the appropriate error based on the state. Check
-		// the actor context first as actor termination takes
-		// precedence over caller context cancellation.
-		if ref.actor.ctx.Err() != nil {
-			promise.Complete(fn.Err[R](ErrActorTerminated))
-		} else {
-			err := ctx.Err()
-			if err == nil {
-				// This indicates an unexpected state: the send
-				// failed, but neither the actor nor the caller
-				// context appears to be done. Default to
-				// ErrActorTerminated as the most likely cause
-				// (e.g., mailbox was closed directly).
-				err = ErrActorTerminated
-			}
-
-			promise.Complete(fn.Err[R](err))
-		}
+	if err := ref.actor.mailbox.Send(ctx, env); err != nil {
+		promise.Complete(fn.Err[R](err))
 	}
 
 	// Return the future associated with the promise, allowing the caller to

--- a/baselib/actor/channel_mailbox.go
+++ b/baselib/actor/channel_mailbox.go
@@ -47,20 +47,20 @@ func NewChannelMailbox[M Message, R any](
 
 // Send attempts to send an envelope to the mailbox. It blocks until either the
 // envelope is accepted, the caller's context is cancelled, or the actor's
-// context is cancelled. Returns true if the envelope was successfully sent,
-// false otherwise.
+// context is cancelled. It returns nil if the envelope was successfully sent,
+// or an error describing why the send failed.
 func (m *ChannelMailbox[M, R]) Send(ctx context.Context,
-	env envelope[M, R]) bool {
+	env envelope[M, R]) error {
 
 	// Check contexts before acquiring the lock as an optimization. This
 	// allows fast-path rejection when contexts are already cancelled,
 	// avoiding unnecessary lock acquisition. The select statement below
 	// still handles the case where contexts are cancelled after this check.
-	if ctx.Err() != nil {
-		return false
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 	if m.actorCtx.Err() != nil {
-		return false
+		return ErrActorTerminated
 	}
 
 	// Hold the read lock for the entire send operation to prevent
@@ -76,7 +76,7 @@ func (m *ChannelMailbox[M, R]) Send(ctx context.Context,
 	defer m.mu.RUnlock()
 
 	if m.closed.Load() {
-		return false
+		return ErrMailboxClosed
 	}
 
 	// Attempt to send the envelope, respecting both the caller's context
@@ -87,31 +87,31 @@ func (m *ChannelMailbox[M, R]) Send(ctx context.Context,
 			"msg_type", env.message.MessageType(),
 			"queue_len", len(m.ch))
 
-		return true
+		return nil
 
 	case <-ctx.Done():
 		logger(ctx).TraceS(ctx, "Mailbox send failed, caller context cancelled",
 			"msg_type", env.message.MessageType())
 
-		return false
+		return ctx.Err()
 
 	case <-m.actorCtx.Done():
 		logger(ctx).TraceS(ctx, "Mailbox send failed, actor context cancelled",
 			"msg_type", env.message.MessageType())
 
-		return false
+		return ErrActorTerminated
 	}
 }
 
 // TrySend attempts to send an envelope to the mailbox without blocking. It
-// returns true if the envelope was successfully sent, false if the mailbox is
-// full, closed, or the actor has been terminated.
-func (m *ChannelMailbox[M, R]) TrySend(env envelope[M, R]) bool {
+// returns nil if the envelope was successfully sent, or an error if the
+// mailbox is full, closed, or the actor has been terminated.
+func (m *ChannelMailbox[M, R]) TrySend(env envelope[M, R]) error {
 	// Check if the actor has been terminated before attempting to send.
 	// This ensures TrySend respects the actor's lifecycle consistently
 	// with Send.
 	if m.actorCtx.Err() != nil {
-		return false
+		return ErrActorTerminated
 	}
 
 	// Hold the read lock for the entire send operation to prevent
@@ -120,14 +120,14 @@ func (m *ChannelMailbox[M, R]) TrySend(env envelope[M, R]) bool {
 	defer m.mu.RUnlock()
 
 	if m.closed.Load() {
-		return false
+		return ErrMailboxClosed
 	}
 
 	select {
 	case m.ch <- env:
-		return true
+		return nil
 	default:
-		return false
+		return ErrMailboxFull
 	}
 }
 

--- a/baselib/actor/durable_actor.go
+++ b/baselib/actor/durable_actor.go
@@ -2,6 +2,7 @@ package actor
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -973,28 +974,20 @@ func (ref *durableActorRefImpl[M, R]) Tell(ctx context.Context, msg M) error {
 		callerCtx: ctx,
 	}
 
-	ok := ref.actor.mailbox.Send(ctx, env)
-	if !ok {
-		// Check if actor is terminated.
-		if ref.actor.ctx.Err() != nil {
+	if err := ref.actor.mailbox.Send(ctx, env); err != nil {
+		if errors.Is(err, ErrActorTerminated) {
 			logger(ctx).DebugS(ctx, "Tell failed, routing to DLO",
 				"actor_id", ref.actor.id,
 				"msg_type", msg.MessageType())
 
 			// Use context.Background() since the actor is terminated and
 			// the original context might be done or cancelled.
+			// Return the original mailbox error below so callers receive
+			// the exact failure.
 			ref.trySendToDLO(context.Background(), msg)
-
-			return ErrActorTerminated
 		}
 
-		// Check if caller's context was cancelled.
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
-
-		// Mailbox full or other failure.
-		return ErrMailboxFull
+		return err
 	}
 
 	return nil
@@ -1025,18 +1018,8 @@ func (ref *durableActorRefImpl[M, R]) Ask(ctx context.Context, msg M) Future[R] 
 		callerCtx: ctx,
 	}
 
-	ok := ref.actor.mailbox.Send(ctx, env)
-	if !ok {
-		if ref.actor.ctx.Err() != nil {
-			promise.Complete(fn.Err[R](ErrActorTerminated))
-		} else {
-			err := ctx.Err()
-			if err == nil {
-				err = ErrActorTerminated
-			}
-
-			promise.Complete(fn.Err[R](err))
-		}
+	if err := ref.actor.mailbox.Send(ctx, env); err != nil {
+		promise.Complete(fn.Err[R](err))
 	}
 
 	return promise.Future()
@@ -1104,21 +1087,14 @@ func (ref *durableActorRefImpl[M, R]) DurableAsk(
 		correlationID:   params.CorrelationID,
 	}
 
-	ok := ref.actor.mailbox.Send(ctx, env)
-	if !ok {
-		if ref.actor.ctx.Err() != nil {
+	if err := ref.actor.mailbox.Send(ctx, env); err != nil {
+		if errors.Is(err, ErrActorTerminated) {
 			logger(ctx).DebugS(ctx, "DurableAsk failed, actor terminated",
 				"actor_id", ref.actor.id,
 				"msg_type", msg.MessageType())
-
-			return ErrActorTerminated
 		}
 
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
-
-		return ErrMailboxFull
+		return err
 	}
 
 	return nil

--- a/baselib/actor/durable_actor_test.go
+++ b/baselib/actor/durable_actor_test.go
@@ -786,6 +786,34 @@ func TestDurableActorTellToTerminatedActor(t *testing.T) {
 	require.Equal(t, ErrActorTerminated, err)
 }
 
+// TestDurableActorTellPreservesMailboxError tests that Tell returns the
+// concrete durable mailbox error instead of remapping it to ErrMailboxFull.
+func TestDurableActorTellPreservesMailboxError(t *testing.T) {
+	t.Parallel()
+
+	store := newMockDeliveryStore()
+	codec := newActorTestCodec()
+	behavior := newMockBehavior(fn.Ok(42))
+
+	cfg := DefaultDurableActorConfig("test-actor", behavior, store, codec)
+	actor := NewDurableActor(cfg)
+
+	// Leave the actor stopped so Tell exercises only durable enqueue error
+	// propagation, not mailbox receive-loop processing.
+	enqueueErr := errors.New("simulated enqueue failure")
+	store.mu.Lock()
+	store.injectEnqueueError = enqueueErr
+	store.mu.Unlock()
+
+	msg := &actorTestMsg{
+		Value: tlv.NewPrimitiveRecord[tlv.TlvType1](uint64(42)),
+	}
+
+	err := actor.Ref().Tell(context.Background(), msg)
+	require.ErrorIs(t, err, enqueueErr)
+	require.ErrorContains(t, err, "enqueue mailbox message")
+}
+
 // TestDurableActorAskToTerminatedActor tests Ask to stopped actor.
 func TestDurableActorAskToTerminatedActor(t *testing.T) {
 	t.Parallel()
@@ -1751,14 +1779,13 @@ func TestDurableAskWithMailboxFull(t *testing.T) {
 	// Wait for context to expire.
 	time.Sleep(5 * time.Millisecond)
 
-	// This should fail with ErrMailboxFull or context.DeadlineExceeded.
+	// This should fail when the context deadline is exceeded.
 	err := durableRef.DurableAsk(ctxTimeout, msg, DurableAskParams{
 		CallbackActorID: "callback-actor",
 		CorrelationID:   "test-correlation-overflow",
 	})
 
-	// Either mailbox is full or context deadline exceeded - both are acceptable.
-	require.Error(t, err)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
 // TestTxPathDeferPromisePropagatedToTxDelivery verifies that the deferPromise

--- a/baselib/actor/durable_mailbox.go
+++ b/baselib/actor/durable_mailbox.go
@@ -151,32 +151,27 @@ func NewDurableMailbox[M TLVMessage, R any](
 // making the enqueue atomic with the sender's state change. This
 // eliminates the window where a crash could commit the sender's state
 // but lose the enqueued message.
-func (m *DurableMailbox[M, R]) Send(ctx context.Context, env envelope[M, R]) bool {
+func (m *DurableMailbox[M, R]) Send(ctx context.Context, env envelope[M, R]) error {
 	m.closeMu.RLock()
 	defer m.closeMu.RUnlock()
 
-	if m.closed.Load() {
-		return false
-	}
-
-	// Check contexts before attempting send.
+	// Check lifecycle contexts before the closed flag so actor shutdown and
+	// caller cancellation keep precedence over local mailbox state.
 	select {
 	case <-ctx.Done():
-		return false
+		return ctx.Err()
 	case <-m.actorCtx.Done():
-		return false
+		return ErrActorTerminated
 	default:
 	}
 
-	// Encode the message.
-	tlvMsg, ok := any(env.message).(TLVMessage)
-	if !ok {
-		return false
+	if m.closed.Load() {
+		return ErrMailboxClosed
 	}
 
-	payload, err := m.cfg.Codec.Encode(tlvMsg)
+	payload, err := m.cfg.Codec.Encode(env.message)
 	if err != nil {
-		return false
+		return fmt.Errorf("encode mailbox message: %w", err)
 	}
 
 	// Use the outbox-propagated ID for receiver-side deduplication when
@@ -212,7 +207,7 @@ func (m *DurableMailbox[M, R]) Send(ctx context.Context, env envelope[M, R]) boo
 	params := EnqueueParams{
 		ID:              id,
 		MailboxID:       m.cfg.MailboxID,
-		MessageType:     tlvMsg.MessageType(),
+		MessageType:     env.message.MessageType(),
 		Payload:         payload,
 		PromiseID:       promiseID,
 		CallbackActorID: env.callbackActorID,
@@ -235,7 +230,7 @@ func (m *DurableMailbox[M, R]) Send(ctx context.Context, env envelope[M, R]) boo
 			m.promiseRegistryMu.Unlock()
 		}
 
-		return false
+		return fmt.Errorf("enqueue mailbox message: %w", err)
 	}
 
 	// Signal the receive loop to wake up.
@@ -244,22 +239,25 @@ func (m *DurableMailbox[M, R]) Send(ctx context.Context, env envelope[M, R]) boo
 	default:
 	}
 
-	return true
+	return nil
 }
 
 // TrySend attempts to send an envelope to the mailbox without blocking.
-// It returns true if the envelope was successfully sent, false if the
-// mailbox is full or closed.
-func (m *DurableMailbox[M, R]) TrySend(env envelope[M, R]) bool {
-	m.closeMu.RLock()
-	defer m.closeMu.RUnlock()
-
-	if m.closed.Load() {
-		return false
+// It returns nil if the envelope was successfully sent, or an error if the
+// mailbox could not accept it.
+func (m *DurableMailbox[M, R]) TrySend(env envelope[M, R]) error {
+	if m.actorCtx.Err() != nil {
+		return ErrActorTerminated
 	}
 
-	// Use a short timeout context.
-	ctx, cancel := context.WithTimeout(m.actorCtx, 100*time.Millisecond)
+	if m.closed.Load() {
+		return ErrMailboxClosed
+	}
+
+	// Use a short caller timeout context. Keep it separate from actorCtx so
+	// Send can report actor shutdown as ErrActorTerminated instead of as a
+	// caller context cancellation.
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
 	return m.Send(ctx, env)

--- a/baselib/actor/durable_mailbox_test.go
+++ b/baselib/actor/durable_mailbox_test.go
@@ -125,8 +125,8 @@ func TestDurableMailboxSend(t *testing.T) {
 	}
 
 	// Send should succeed and persist message.
-	ok := mailbox.Send(ctx, env)
-	require.True(t, ok)
+	err := mailbox.Send(ctx, env)
+	require.NoError(t, err)
 
 	// Verify message was stored.
 	store.mu.Lock()
@@ -162,8 +162,8 @@ func TestDurableMailboxSendWithPriority(t *testing.T) {
 		callerCtx: ctx,
 	}
 
-	ok := mailbox.Send(ctx, env)
-	require.True(t, ok)
+	err := mailbox.Send(ctx, env)
+	require.NoError(t, err)
 
 	// Verify priority was set.
 	store.mu.Lock()
@@ -199,8 +199,8 @@ func TestDurableMailboxSendContextCancelled(t *testing.T) {
 	}
 
 	// Send should fail with cancelled context.
-	ok := mailbox.Send(cancelledCtx, env)
-	require.False(t, ok)
+	err := mailbox.Send(cancelledCtx, env)
+	require.ErrorIs(t, err, context.Canceled)
 
 	// Verify no message was stored.
 	store.mu.Lock()
@@ -232,8 +232,8 @@ func TestDurableMailboxSendActorContextCancelled(t *testing.T) {
 	}
 
 	// Send should fail with cancelled actor context.
-	ok := mailbox.Send(context.Background(), env)
-	require.False(t, ok)
+	err := mailbox.Send(context.Background(), env)
+	require.ErrorIs(t, err, ErrActorTerminated)
 }
 
 // TestDurableMailboxSendClosedMailbox tests that Send fails on closed mailbox.
@@ -261,8 +261,8 @@ func TestDurableMailboxSendClosedMailbox(t *testing.T) {
 	}
 
 	// Send should fail on closed mailbox.
-	ok := mailbox.Send(ctx, env)
-	require.False(t, ok)
+	err := mailbox.Send(ctx, env)
+	require.ErrorIs(t, err, ErrMailboxClosed)
 }
 
 // TestDurableMailboxTrySend tests non-blocking send.
@@ -286,8 +286,8 @@ func TestDurableMailboxTrySend(t *testing.T) {
 	}
 
 	// TrySend should succeed.
-	ok := mailbox.TrySend(env)
-	require.True(t, ok)
+	err := mailbox.TrySend(env)
+	require.NoError(t, err)
 
 	// Verify message was stored.
 	store.mu.Lock()
@@ -319,8 +319,8 @@ func TestDurableMailboxReceive(t *testing.T) {
 		callerCtx: ctx,
 	}
 
-	ok := mailbox.Send(ctx, env)
-	require.True(t, ok)
+	err := mailbox.Send(ctx, env)
+	require.NoError(t, err)
 
 	// Receive should yield the message.
 	var received *durableTestMsg
@@ -437,7 +437,7 @@ func TestDurableMailboxDrain(t *testing.T) {
 		callerCtx: ctx,
 	}
 
-	mailbox.Send(ctx, env)
+	require.NoError(t, mailbox.Send(ctx, env))
 	mailbox.Close()
 
 	// Drain should return empty (messages stay in DB for recovery).
@@ -484,7 +484,7 @@ func TestDurableMailboxWakeSignal(t *testing.T) {
 	}
 
 	// Send triggers wake signal.
-	mailbox.Send(ctx, env)
+	require.NoError(t, mailbox.Send(ctx, env))
 
 	// Should receive quickly despite long poll interval.
 	select {
@@ -524,7 +524,7 @@ func TestDurableMailboxConcurrentSends(t *testing.T) {
 					message:   msg,
 					callerCtx: ctx,
 				}
-				mailbox.Send(ctx, env)
+				_ = mailbox.Send(ctx, env)
 			}
 		}(i)
 	}
@@ -562,8 +562,8 @@ func TestDurableMailbox_DeliveryPassedInEnvelope(t *testing.T) {
 		callerCtx: ctx,
 	}
 
-	ok := mailbox.Send(ctx, env)
-	require.True(t, ok)
+	err := mailbox.Send(ctx, env)
+	require.NoError(t, err)
 
 	// Receive the envelope and verify delivery is set.
 	receiveCtx, receiveCancel := context.WithTimeout(ctx, 100*time.Millisecond)
@@ -615,8 +615,8 @@ func TestDurableMailboxRapid_SendReceivePreservesData(t *testing.T) {
 			callerCtx: ctx,
 		}
 
-		ok := mailbox.Send(ctx, env)
-		require.True(rt, ok)
+		err := mailbox.Send(ctx, env)
+		require.NoError(rt, err)
 
 		// Receive with timeout.
 		receiveCtx, receiveCancel := context.WithTimeout(ctx, 100*time.Millisecond)
@@ -657,7 +657,7 @@ func TestDurableMailboxRapid_ClosePreventsSend(t *testing.T) {
 				message:   msg,
 				callerCtx: ctx,
 			}
-			mailbox.Send(ctx, env)
+			require.NoError(rt, mailbox.Send(ctx, env))
 		}
 
 		// Close.
@@ -673,8 +673,9 @@ func TestDurableMailboxRapid_ClosePreventsSend(t *testing.T) {
 				message:   msg,
 				callerCtx: ctx,
 			}
-			ok := mailbox.Send(ctx, env)
-			require.False(rt, ok, "send should fail after close")
+			err := mailbox.Send(ctx, env)
+			require.ErrorIs(rt, err, ErrMailboxClosed,
+				"send should fail after close")
 		}
 
 		// Only messages before close should be stored.
@@ -720,7 +721,7 @@ func TestDurableMailboxRapid_ConcurrentCloseAndSend(t *testing.T) {
 						message:   msg,
 						callerCtx: ctx,
 					}
-					mailbox.Send(ctx, env)
+					_ = mailbox.Send(ctx, env)
 				}
 			}(i)
 		}
@@ -891,8 +892,9 @@ func TestDurableMailboxPromiseRegistryCleanupOnEnqueueFailure(t *testing.T) {
 	)
 
 	// Inject enqueue error so Send will fail after promise registration.
+	enqueueErr := errors.New("simulated enqueue failure")
 	store.mu.Lock()
-	store.injectEnqueueError = errors.New("simulated enqueue failure")
+	store.injectEnqueueError = enqueueErr
 	store.mu.Unlock()
 
 	// Attempt to Send an Ask envelope (with promise).
@@ -908,9 +910,10 @@ func TestDurableMailboxPromiseRegistryCleanupOnEnqueueFailure(t *testing.T) {
 		callerCtx: ctx,
 	}
 
-	// Send should return false due to enqueue failure.
-	ok := mailbox.Send(ctx, env)
-	require.False(t, ok)
+	// Send should return the enqueue failure.
+	err := mailbox.Send(ctx, env)
+	require.ErrorIs(t, err, enqueueErr)
+	require.ErrorContains(t, err, "enqueue mailbox message")
 
 	// The promise registry should be empty -- the entry should have been
 	// cleaned up after the enqueue failure.
@@ -929,8 +932,8 @@ func TestDurableMailboxPromiseRegistryCleanupOnEnqueueFailure(t *testing.T) {
 			promise:   p,
 			callerCtx: ctx,
 		}
-		ok := mailbox.Send(ctx, env)
-		require.False(t, ok)
+		err := mailbox.Send(ctx, env)
+		require.ErrorIs(t, err, enqueueErr)
 	}
 
 	mailbox.promiseRegistryMu.RLock()
@@ -970,8 +973,8 @@ func TestDurableMailboxSendUsesOutboxIDFromContext(t *testing.T) {
 	outboxID := "outbox-msg-42"
 	sendCtx := WithOutboxID(ctx, outboxID)
 
-	ok := mailbox.Send(sendCtx, env)
-	require.True(t, ok)
+	err := mailbox.Send(sendCtx, env)
+	require.NoError(t, err)
 
 	// Verify the stored message uses the outbox ID, not a fresh UUID.
 	store.mu.Lock()
@@ -1016,12 +1019,12 @@ func TestDurableMailboxSendDuplicateOutboxIDIsIdempotent(t *testing.T) {
 	sendCtx := WithOutboxID(ctx, outboxID)
 
 	// First send should succeed.
-	ok := mailbox.Send(sendCtx, env)
-	require.True(t, ok)
+	err := mailbox.Send(sendCtx, env)
+	require.NoError(t, err)
 
 	// Second send with the same outbox ID should also succeed (idempotent).
-	ok = mailbox.Send(sendCtx, env)
-	require.True(t, ok)
+	err = mailbox.Send(sendCtx, env)
+	require.NoError(t, err)
 
 	// Only one message should exist in the store.
 	store.mu.Lock()
@@ -1056,8 +1059,8 @@ func TestDurableMailboxSendWithoutOutboxIDGeneratesFreshID(t *testing.T) {
 	}
 
 	// Send without outbox ID in context (regular Tell path).
-	ok := mailbox.Send(ctx, env)
-	require.True(t, ok)
+	err := mailbox.Send(ctx, env)
+	require.NoError(t, err)
 
 	// Verify a fresh UUIDv7 was generated (not empty, not a hardcoded value).
 	store.mu.Lock()
@@ -1123,8 +1126,8 @@ func TestDurableMailboxSendPreservesSenderTx(t *testing.T) {
 	require.True(t, HasTx(sendCtx))
 
 	// Send should succeed.
-	ok := mailbox.Send(sendCtx, env)
-	require.True(t, ok)
+	err := mailbox.Send(sendCtx, env)
+	require.NoError(t, err)
 
 	// The context received by EnqueueMessage should carry the
 	// sender's tx so same-DB actors share the transaction.

--- a/baselib/actor/interface.go
+++ b/baselib/actor/interface.go
@@ -107,6 +107,10 @@ type BaseActorRef interface {
 // because it is at capacity.
 var ErrMailboxFull = fmt.Errorf("mailbox full")
 
+// ErrMailboxClosed indicates that the mailbox could not accept the message
+// because it has been closed.
+var ErrMailboxClosed = fmt.Errorf("mailbox closed")
+
 // TellOnlyRef is a reference to an actor that only supports "tell" operations.
 // This is useful for scenarios where only fire-and-forget message passing is
 // needed, or to restrict capabilities.
@@ -180,18 +184,18 @@ type SystemContext interface {
 //   - Close may be called concurrently with Send/TrySend and is idempotent.
 //   - IsClosed may be called concurrently from any goroutine.
 //   - Drain should only be called after Close and from a single goroutine.
-//   - Send and TrySend return false after Close has been called.
+//   - Send and TrySend return ErrMailboxClosed after Close has been called.
 type Mailbox[M Message, R any] interface {
 	// Send attempts to send an envelope to the mailbox, blocking until
 	// either the envelope is accepted, the provided context is cancelled,
-	// or the actor's context is cancelled. It returns true if the envelope
-	// was successfully sent, false otherwise.
-	Send(ctx context.Context, env envelope[M, R]) bool
+	// or the actor's context is cancelled. It returns nil if the envelope
+	// was successfully accepted, or an error describing why it was rejected.
+	Send(ctx context.Context, env envelope[M, R]) error
 
 	// TrySend attempts to send an envelope to the mailbox without
-	// blocking. It returns true if the envelope was successfully sent,
-	// false if the mailbox is full or closed.
-	TrySend(env envelope[M, R]) bool
+	// blocking. It returns nil if the envelope was successfully accepted,
+	// or an error describing why it was rejected.
+	TrySend(env envelope[M, R]) error
 
 	// Receive returns an iterator over envelopes in the mailbox. The
 	// iterator will block when the mailbox is empty and yield envelopes as

--- a/baselib/actor/mailbox_test.go
+++ b/baselib/actor/mailbox_test.go
@@ -40,8 +40,8 @@ func TestChannelMailboxSend(t *testing.T) {
 	}
 
 	// Send should succeed.
-	ok := mailbox.Send(ctx, env)
-	require.True(t, ok, "Send should succeed")
+	err := mailbox.Send(ctx, env)
+	require.NoError(t, err, "Send should succeed")
 
 	// Verify the message can be received.
 	for receivedEnv := range mailbox.Receive(ctx) {
@@ -50,7 +50,7 @@ func TestChannelMailboxSend(t *testing.T) {
 	}
 }
 
-// TestChannelMailboxSendContextCancelled tests that Send returns false when
+// TestChannelMailboxSendContextCancelled tests that Send returns an error when
 // the caller's context is cancelled before the send completes.
 func TestChannelMailboxSendContextCancelled(t *testing.T) {
 	t.Parallel()
@@ -67,22 +67,23 @@ func TestChannelMailboxSendContextCancelled(t *testing.T) {
 		message: &testMessage{value: 1},
 		promise: nil,
 	}
-	ok := mailbox.TrySend(env)
-	require.True(t, ok, "First send should succeed")
+	err := mailbox.TrySend(env)
+	require.NoError(t, err, "First send should succeed")
 
 	// Create a cancelled context and attempt to send. This should return
-	// false immediately.
+	// the context cancellation error immediately.
 	cancelledCtx, cancelFunc := context.WithCancel(context.Background())
 	cancelFunc()
 
-	ok = mailbox.Send(cancelledCtx, envelope[*testMessage, string]{
+	err = mailbox.Send(cancelledCtx, envelope[*testMessage, string]{
 		message: &testMessage{value: 2},
 		promise: nil,
 	})
-	require.False(t, ok, "Send with cancelled context should fail")
+	require.ErrorIs(t, err, context.Canceled,
+		"Send with cancelled context should fail")
 }
 
-// TestChannelMailboxSendToClosedMailbox tests that Send returns false when
+// TestChannelMailboxSendToClosedMailbox tests that Send returns an error when
 // attempting to send to a closed mailbox.
 func TestChannelMailboxSendToClosedMailbox(t *testing.T) {
 	t.Parallel()
@@ -100,8 +101,9 @@ func TestChannelMailboxSendToClosedMailbox(t *testing.T) {
 	}
 
 	// Send should fail because the mailbox is closed.
-	ok := mailbox.Send(ctx, env)
-	require.False(t, ok, "Send to closed mailbox should fail")
+	err := mailbox.Send(ctx, env)
+	require.ErrorIs(t, err, ErrMailboxClosed,
+		"Send to closed mailbox should fail")
 }
 
 // TestChannelMailboxTrySend tests the non-blocking TrySend operation.
@@ -121,8 +123,8 @@ func TestChannelMailboxTrySend(t *testing.T) {
 	}
 
 	// First TrySend should succeed.
-	ok := mailbox.TrySend(env1)
-	require.True(t, ok, "First TrySend should succeed")
+	err := mailbox.TrySend(env1)
+	require.NoError(t, err, "First TrySend should succeed")
 
 	env2 := envelope[*testMessage, string]{
 		message: &testMessage{value: 2},
@@ -130,8 +132,9 @@ func TestChannelMailboxTrySend(t *testing.T) {
 	}
 
 	// Second TrySend should fail because the mailbox is full.
-	ok = mailbox.TrySend(env2)
-	require.False(t, ok, "TrySend to full mailbox should fail")
+	err = mailbox.TrySend(env2)
+	require.ErrorIs(t, err, ErrMailboxFull,
+		"TrySend to full mailbox should fail")
 
 	// Receive the first message.
 	for receivedEnv := range mailbox.Receive(ctx) {
@@ -140,11 +143,11 @@ func TestChannelMailboxTrySend(t *testing.T) {
 	}
 
 	// Now TrySend should succeed again.
-	ok = mailbox.TrySend(env2)
-	require.True(t, ok, "TrySend after receive should succeed")
+	err = mailbox.TrySend(env2)
+	require.NoError(t, err, "TrySend after receive should succeed")
 }
 
-// TestChannelMailboxTrySendToClosed tests that TrySend returns false when
+// TestChannelMailboxTrySendToClosed tests that TrySend returns an error when
 // attempting to send to a closed mailbox.
 func TestChannelMailboxTrySendToClosed(t *testing.T) {
 	t.Parallel()
@@ -161,8 +164,9 @@ func TestChannelMailboxTrySendToClosed(t *testing.T) {
 	}
 
 	// TrySend should fail because the mailbox is closed.
-	ok := mailbox.TrySend(env)
-	require.False(t, ok, "TrySend to closed mailbox should fail")
+	err := mailbox.TrySend(env)
+	require.ErrorIs(t, err, ErrMailboxClosed,
+		"TrySend to closed mailbox should fail")
 }
 
 // TestChannelMailboxReceive tests that Receive yields envelopes from the
@@ -184,8 +188,8 @@ func TestChannelMailboxReceive(t *testing.T) {
 			message: &testMessage{value: i},
 			promise: nil,
 		}
-		ok := mailbox.Send(ctx, env)
-		require.True(t, ok, "Send should succeed")
+		err := mailbox.Send(ctx, env)
+		require.NoError(t, err, "Send should succeed")
 	}
 
 	// Receive messages using the iterator.
@@ -220,8 +224,8 @@ func TestChannelMailboxReceiveContextCancelled(t *testing.T) {
 		message: &testMessage{value: 1},
 		promise: nil,
 	}
-	ok := mailbox.Send(context.Background(), env)
-	require.True(t, ok, "Send should succeed")
+	err := mailbox.Send(context.Background(), env)
+	require.NoError(t, err, "Send should succeed")
 
 	// Create a context that will be cancelled.
 	receiveCtx, receiveCancel := context.WithCancel(context.Background())
@@ -295,8 +299,8 @@ func TestChannelMailboxDrain(t *testing.T) {
 			message: &testMessage{value: i},
 			promise: nil,
 		}
-		ok := mailbox.Send(ctx, env)
-		require.True(t, ok, "Send should succeed")
+		err := mailbox.Send(ctx, env)
+		require.NoError(t, err, "Send should succeed")
 	}
 
 	// Close the mailbox without receiving the messages.
@@ -347,8 +351,8 @@ func TestChannelMailboxConcurrentSends(t *testing.T) {
 					},
 					promise: nil,
 				}
-				ok := mailbox.Send(ctx, env)
-				require.True(t, ok, "Send should succeed")
+				err := mailbox.Send(ctx, env)
+				require.NoError(t, err, "Send should succeed")
 			}
 		}(i)
 	}
@@ -389,8 +393,8 @@ func TestChannelMailboxZeroCapacity(t *testing.T) {
 	}
 
 	// TrySend should succeed because the mailbox has at least capacity 1.
-	ok := mailbox.TrySend(env)
-	require.True(t, ok, "TrySend should succeed with default capacity")
+	err := mailbox.TrySend(env)
+	require.NoError(t, err, "TrySend should succeed with default capacity")
 
 	// Verify the message can be received.
 	for receivedEnv := range mailbox.Receive(ctx) {
@@ -399,8 +403,8 @@ func TestChannelMailboxZeroCapacity(t *testing.T) {
 	}
 }
 
-// TestChannelMailboxSendWithActorContextCancelled tests that Send returns
-// false when the actor's context is cancelled.
+// TestChannelMailboxSendWithActorContextCancelled tests that Send returns an
+// error when the actor's context is cancelled.
 func TestChannelMailboxSendWithActorContextCancelled(t *testing.T) {
 	t.Parallel()
 
@@ -415,8 +419,8 @@ func TestChannelMailboxSendWithActorContextCancelled(t *testing.T) {
 		message: &testMessage{value: 1},
 		promise: nil,
 	}
-	ok := mailbox.TrySend(env1)
-	require.True(t, ok, "First send should succeed")
+	err := mailbox.TrySend(env1)
+	require.NoError(t, err, "First send should succeed")
 
 	// Cancel the actor context.
 	actorCancel()
@@ -427,8 +431,9 @@ func TestChannelMailboxSendWithActorContextCancelled(t *testing.T) {
 		message: &testMessage{value: 2},
 		promise: nil,
 	}
-	ok = mailbox.Send(context.Background(), env2)
-	require.False(t, ok, "Send should fail when actor context is cancelled")
+	err = mailbox.Send(context.Background(), env2)
+	require.ErrorIs(t, err, ErrActorTerminated,
+		"Send should fail when actor context is cancelled")
 }
 
 // TestChannelMailboxReceiveStopsOnClose tests that the Receive iterator stops
@@ -448,8 +453,8 @@ func TestChannelMailboxReceiveStopsOnClose(t *testing.T) {
 			message: &testMessage{value: i},
 			promise: nil,
 		}
-		ok := mailbox.Send(ctx, env)
-		require.True(t, ok, "Send should succeed")
+		err := mailbox.Send(ctx, env)
+		require.NoError(t, err, "Send should succeed")
 	}
 
 	// Start receiving in a goroutine.
@@ -603,8 +608,8 @@ func TestChannelMailboxWithPromises(t *testing.T) {
 	}
 
 	// Send the envelope with a promise.
-	ok := mailbox.Send(ctx, env)
-	require.True(t, ok, "Send should succeed")
+	err := mailbox.Send(ctx, env)
+	require.NoError(t, err, "Send should succeed")
 
 	// Receive the envelope and complete the promise.
 	for receivedEnv := range mailbox.Receive(ctx) {


### PR DESCRIPTION
## Summary

Fixes https://github.com/lightninglabs/darepo-client/issues/104.

This changes the actor mailbox contract so `Mailbox.Send` and `Mailbox.TrySend` return `error` instead of `bool`. The old boolean result collapsed closed mailboxes, caller cancellation, actor shutdown, durable encode failures, and durable store enqueue failures into the same `false` value. Callers then had to infer the cause and could report misleading fallback errors such as `ErrMailboxFull`.

## What Changed

- Added `ErrMailboxClosed` alongside the existing `ErrMailboxFull` sentinel.
- Updated `Mailbox` to return `error` from `Send` and `TrySend`.
- Updated `ChannelMailbox` to return concrete errors for:
  - caller context cancellation/deadline
  - actor termination
  - closed mailbox
  - full mailbox on `TrySend`
- Updated `DurableMailbox` to preserve the real durable failure cause:
  - caller context cancellation/deadline
  - actor termination
  - closed mailbox
  - message type/codec errors
  - durable store enqueue errors
- Updated regular and durable actor refs so `Tell`, `Ask`, and `DurableAsk` propagate the mailbox error directly instead of reverse-engineering a cause from `false`.
- Kept actor termination routing to the dead letter office when the propagated error is `ErrActorTerminated`.
- Updated mailbox and durable actor tests to assert the concrete error causes.

## Outbox Behavior

This PR intentionally keeps outbox delivery policy conservative. `OutboxPublisher.deliverMessage` already receives an error from `ref.Tell`; after this change that error is now specific enough to distinguish durable enqueue failures from closed mailbox or lifecycle failures.

The PR does not broadly reclassify delivery failures as permanent. Decode failures remain poison messages as before, while transient delivery failures still retry through the existing outbox attempt flow. This keeps the behavior change focused on preserving error context first.

## Validation

- `go test ./baselib/actor`
- `make unit pkg=baselib/actor`
- `make unit`
- `make lint`
- `make commitmsg-lint range=origin/main..HEAD`

I also ran `go test ./...`. It hit one timeout in `internal/actortest`:

```text
TestProperty_IncrementDecrement_Commutative: condition not met within timeout
```

Rerunning that exact test passed immediately:

```text
go test ./internal/actortest -run TestProperty_IncrementDecrement_Commutative -count=1 -v
```
