### PR TITLE
fraud: add recipient-side OOR fraud response watcher

### DIFF
--- a/chainsource/broadcast_errors.go
+++ b/chainsource/broadcast_errors.go
@@ -76,6 +76,7 @@ func IsIgnorableMempoolRejectReason(reason string) bool {
 		strings.ToLower(chain.ErrTxAlreadyConfirmed.Error()),
 
 		"already in mempool",
+		"txn-already-in-mempool",
 		"already known",
 	}
 

--- a/chainsource/broadcast_errors_test.go
+++ b/chainsource/broadcast_errors_test.go
@@ -87,5 +87,10 @@ func TestIsIgnorableMempoolRejectReason(t *testing.T) {
 	)
 	require.True(t, IsIgnorableMempoolRejectReason("txn already known"))
 	require.True(t, IsIgnorableMempoolRejectReason("already in mempool"))
+	require.True(
+		t, IsIgnorableMempoolRejectReason(
+			"txn-already-in-mempool",
+		),
+	)
 	require.False(t, IsIgnorableMempoolRejectReason("missing inputs"))
 }

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -34,6 +34,7 @@ import (
 	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/lightninglabs/darepo-client/db"
 	"github.com/lightninglabs/darepo-client/db/actordelivery"
+	"github.com/lightninglabs/darepo-client/fraud"
 	"github.com/lightninglabs/darepo-client/indexer"
 	"github.com/lightninglabs/darepo-client/ledger"
 	"github.com/lightninglabs/darepo-client/lib/actormsg"
@@ -280,6 +281,12 @@ type Server struct {
 		unroll.RegistryMsg, unroll.RegistryResp,
 	]]
 	unrollRegistry *unroll.UnrollRegistryActor
+
+	// fraudWatcherRef is the passive recipient-fraud watcher. It arms
+	// ancestry spend watches for received OOR VTXOs and starts unroll jobs
+	// only after a watched ancestor materializes.
+	fraudWatcherRef fn.Option[actor.ActorRef[fraud.Msg, fraud.Resp]]
+	fraudWatcher    *fraud.WatcherActor
 
 	// lazyChainResolver is the forwarding ref that connects the
 	// VTXO manager's critical-expiry path to the unroll manager.
@@ -745,6 +752,10 @@ func (s *Server) run(ctx context.Context, shutdownFn func()) error {
 
 		if s.unrollRegistry != nil {
 			s.unrollRegistry.Stop()
+		}
+
+		if s.fraudWatcher != nil {
+			s.fraudWatcher.Stop()
 		}
 
 		if s.oorSigningEffect != nil {
@@ -1778,7 +1789,7 @@ func (s *Server) startWalletDependentActors(ctx context.Context,
 	// 12. Register the unilateral-exit subsystem.
 	// -------------------------------------------------------
 	if err := s.initUnrollSubsystem(
-		ctx, chainSourceRef, vtxoManagerRef,
+		ctx, chainSourceRef,
 	); err != nil {
 		return err
 	}
@@ -3247,6 +3258,11 @@ func (s *Server) initVTXOManager(ctx context.Context,
 		LedgerSink:       fn.Some(ledger.NewSink(s.actorSystem)),
 		ChainResolver:    chainResolver,
 		RefreshFeeQuoter: s.autoRefreshFeeQuoter(),
+		TerminalVTXOObserver: func(ctx context.Context,
+			outpoint wire.OutPoint) error {
+
+			return s.untrackFraudVTXO(ctx, outpoint)
+		},
 	})
 
 	managerKey := actor.NewServiceKey[vtxo.ManagerMsg, vtxo.ManagerResp](
@@ -3443,6 +3459,11 @@ func (s *Server) initOORActor(ctx context.Context,
 		VTXOManager:     vtxoManagerRef,
 		VTXOStore:       vtxoStore,
 		LedgerSink:      fn.Some(ledger.NewSink(s.actorSystem)),
+		IncomingVTXOObserver: func(ctx context.Context,
+			descs []*vtxo.Descriptor) error {
+
+			return s.trackIncomingFraudVTXOs(ctx, descs)
+		},
 	})
 
 	// Wire the timeout callback ref using the registered service
@@ -4113,8 +4134,7 @@ func (w *btcwUnrollWallet) ReleaseOutput(_ context.Context, id wallet.LockID,
 func (s *Server) initUnrollSubsystem(ctx context.Context,
 	chainSourceRef actor.ActorRef[
 		chainsource.ChainSourceMsg, chainsource.ChainSourceResp,
-	],
-	vtxoManagerRef actor.TellOnlyRef[vtxo.ManagerMsg]) error {
+	]) error {
 
 	dbStore := db.NewStore(
 		s.db.DB, s.db.Queries, s.db.Backend(),
@@ -4196,6 +4216,11 @@ func (s *Server) initUnrollSubsystem(ctx context.Context,
 	s.unrollRegistry = registry
 	s.unrollRegistryRef = fn.Some(registry.Ref())
 
+	err := s.initFraudWatcher(ctx, chainSourceRef)
+	if err != nil {
+		return err
+	}
+
 	// 3. Restore non-terminal jobs from durable state.
 	if err := registry.RestoreNonTerminal(ctx); err != nil {
 		s.log.WarnS(ctx,
@@ -4225,6 +4250,78 @@ func (s *Server) initUnrollSubsystem(ctx context.Context,
 	s.log.InfoS(ctx, "Unroll subsystem initialized")
 
 	return nil
+}
+
+// initFraudWatcher creates the passive recipient-fraud watcher and restores
+// watches for live OOR VTXOs after daemon restart. The live VTXO set is
+// sourced from the VTXO manager (the authoritative runtime view) so the
+// watcher arms exactly the same set of VTXOs the manager has spawned
+// child actors for, rather than reading the store directly.
+func (s *Server) initFraudWatcher(ctx context.Context,
+	chainSourceRef actor.ActorRef[
+		chainsource.ChainSourceMsg, chainsource.ChainSourceResp,
+	],
+) error {
+
+	if !s.unrollRegistryRef.IsSome() {
+		return fmt.Errorf("unroll registry not initialized")
+	}
+	if !s.vtxoMgrRef.IsSome() {
+		return fmt.Errorf("VTXO manager not initialized")
+	}
+
+	//nolint:contextcheck // watcher owns its own root context lifecycle
+	watcher := fraud.NewWatcherActor(fraud.WatcherConfig{
+		ChainSource: chainSourceRef,
+		UnrollRef:   s.unrollRegistryRef.UnsafeFromSome(),
+		Log:         fn.Some(s.subLogger(fraud.Subsystem)),
+	})
+	s.fraudWatcher = watcher
+	s.fraudWatcherRef = fn.Some(watcher.Ref())
+
+	resp, err := s.vtxoMgrRef.UnsafeFromSome().Ask(
+		ctx, &vtxo.ListLiveDescriptorsRequest{},
+	).Await(ctx).Unpack()
+	if err != nil {
+		return fmt.Errorf("list live VTXOs for fraud restore: %w", err)
+	}
+	listResp, ok := resp.(*vtxo.ListLiveDescriptorsResponse)
+	if !ok {
+		return fmt.Errorf("unexpected VTXO manager response %T", resp)
+	}
+
+	return s.trackIncomingFraudVTXOs(ctx, listResp.Descriptors)
+}
+
+// trackIncomingFraudVTXOs arms recipient fraud watches for materialized OOR
+// VTXOs that still depend on preconfirmed ancestry.
+func (s *Server) trackIncomingFraudVTXOs(ctx context.Context,
+	descs []*vtxo.Descriptor) error {
+
+	if !s.fraudWatcherRef.IsSome() {
+		return fmt.Errorf("recipient fraud watcher not initialized")
+	}
+
+	return fraud.TrackVTXOs(
+		ctx, s.fraudWatcherRef.UnsafeFromSome(), descs,
+	)
+}
+
+// untrackFraudVTXO releases recipient fraud watcher interest for one VTXO.
+func (s *Server) untrackFraudVTXO(ctx context.Context,
+	outpoint wire.OutPoint) error {
+
+	if !s.fraudWatcherRef.IsSome() {
+		return nil
+	}
+
+	notifyCtx := context.WithoutCancel(ctx)
+
+	return s.fraudWatcherRef.UnsafeFromSome().Tell(
+		notifyCtx, &fraud.UntrackRequest{
+			TargetOutpoint: outpoint,
+		},
+	)
 }
 
 // unrollMaxFeeRate returns the configured max fee rate or zero to let

--- a/fraud/actor.go
+++ b/fraud/actor.go
@@ -1,0 +1,462 @@
+package fraud
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/chainsource"
+	"github.com/lightninglabs/darepo-client/unroll"
+	"github.com/lightninglabs/darepo-client/vtxo"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+)
+
+const (
+	// Subsystem is the logging subsystem label for recipient fraud watches.
+	Subsystem = "CFRD"
+
+	// ServiceKeyName is the receptionist key for the recipient fraud
+	// watcher.
+	ServiceKeyName = "recipient-fraud-watcher"
+)
+
+// ServiceKey returns the actor service key for the recipient fraud
+// watcher. Callers that need to look the watcher up via the
+// receptionist should use this rather than constructing the key
+// themselves; it locks down a single concrete instantiation site.
+func ServiceKey() actor.ServiceKey[Msg, Resp] {
+	return actor.NewServiceKey[Msg, Resp](ServiceKeyName)
+}
+
+// WatcherConfig configures the recipient fraud watcher actor.
+type WatcherConfig struct {
+	// ChainSource provides passive ancestor spend watches.
+	ChainSource actor.ActorRef[
+		chainsource.ChainSourceMsg, chainsource.ChainSourceResp,
+	]
+
+	// UnrollRef starts durable unroll jobs for affected targets.
+	UnrollRef actor.ActorRef[unroll.RegistryMsg, unroll.RegistryResp]
+
+	// Log is an optional logger.
+	Log fn.Option[btclog.Logger]
+
+	// MailboxSize overrides the watcher's actor mailbox capacity.
+	// Zero or negative applies defaultWatcherMailboxSize. Sized to
+	// absorb a burst of per-target spend notifications during a
+	// chain reorganization without blocking the chainsource
+	// publisher.
+	MailboxSize int
+}
+
+// defaultWatcherMailboxSize is the fallback mailbox capacity applied
+// when WatcherConfig.MailboxSize is zero or negative. Sized large
+// enough to absorb a burst of per-target spend notifications during a
+// chain reorganization without blocking the chainsource publisher.
+const defaultWatcherMailboxSize = 64
+
+// trackedTarget records the watch plan a recipient VTXO is currently
+// armed under.
+type trackedTarget struct {
+	plan *WatchPlan
+}
+
+// WatcherActor is the recipient fraud watcher: a passive ancestor-spend
+// monitor that calls unroll.EnsureUnroll(..., TriggerFraudSpend) when
+// any watched ancestor of a tracked OOR VTXO is observed spent on
+// chain. It is both the public handle (Ref / Stop) and the
+// actor.ActorBehavior implementation; the runtime is driven through
+// the embedded actor.
+type WatcherActor struct {
+	cfg     WatcherConfig
+	log     btclog.Logger
+	selfRef actor.TellOnlyRef[Msg]
+
+	actor *actor.Actor[Msg, Resp]
+
+	// targets indexes the watch plan armed for each recipient VTXO.
+	targets map[wire.OutPoint]*trackedTarget
+
+	// watches collects the per-ancestor-outpoint refcounted state.
+	// Its set-of-targets per outpoint doubles as the reference count
+	// so the watcher never has to keep a separate counter + a
+	// pkScript map + a target-set map in sync.
+	watches ancestorWatches
+}
+
+// Ref returns the public watcher actor reference.
+func (w *WatcherActor) Ref() actor.ActorRef[Msg, Resp] {
+	if w == nil || w.actor == nil {
+		return nil
+	}
+
+	return w.actor.Ref()
+}
+
+// Stop stops the underlying watcher actor.
+func (w *WatcherActor) Stop() {
+	if w == nil || w.actor == nil {
+		return
+	}
+
+	w.actor.Stop()
+}
+
+// NewWatcherActor creates and starts the recipient fraud watcher actor.
+func NewWatcherActor(cfg WatcherConfig) *WatcherActor {
+	w := &WatcherActor{
+		cfg:     cfg,
+		log:     cfg.Log.UnwrapOr(btclog.Disabled),
+		targets: make(map[wire.OutPoint]*trackedTarget),
+		watches: newAncestorWatches(),
+	}
+
+	mailbox := cfg.MailboxSize
+	if mailbox <= 0 {
+		mailbox = defaultWatcherMailboxSize
+	}
+	w.actor = actor.NewActor(actor.ActorConfig[Msg, Resp]{
+		ID:          ServiceKeyName,
+		Behavior:    w,
+		MailboxSize: mailbox,
+	})
+	w.selfRef = w.actor.TellRef()
+	w.actor.Start()
+
+	return w
+}
+
+// Receive processes one watcher actor message.
+func (w *WatcherActor) Receive(ctx context.Context, msg Msg) fn.Result[Resp] {
+	var (
+		resp Resp
+		err  error
+	)
+
+	switch m := msg.(type) {
+	case *TrackVTXOsRequest:
+		resp, err = w.handleTrackVTXOs(ctx, m)
+
+	case *UntrackRequest:
+		resp, err = w.handleUntrack(ctx, m)
+
+	case *SpendObservedMsg:
+		resp, err = w.handleSpendObserved(ctx, m)
+
+	default:
+		err = fmt.Errorf("unknown fraud watcher message: %T", msg)
+	}
+
+	if err != nil {
+		return fn.Err[Resp](err)
+	}
+
+	return fn.Ok[Resp](resp)
+}
+
+// OnStop releases every active spend watch. A failure on one outpoint
+// must not abandon the rest, so each failure is logged and aggregated
+// into the returned joined error.
+func (w *WatcherActor) OnStop(ctx context.Context) error {
+	var errs error
+	for _, outpoint := range w.watches.outpoints() {
+		point, ok := w.watches.pointAt(outpoint)
+		if !ok {
+			continue
+		}
+		if err := w.unregisterSpendWatchPoint(ctx, point); err != nil {
+			w.log.WarnS(
+				ctx,
+				"Failed to unregister spend watch on stop",
+				err,
+				slog.String("outpoint", outpoint.String()),
+			)
+			errs = joinTrackError(errs, err)
+		}
+	}
+
+	return errs
+}
+
+// handleTrackVTXOs admits a batch of OOR VTXO descriptors and arms their
+// ancestor spend watches. Per-descriptor failures are aggregated rather
+// than short-circuiting the batch so one malformed descriptor cannot
+// disarm fraud defenses for the rest. A summary line is emitted so
+// daemon-startup callers (which use Tell and drop the returned error)
+// still see partial failures in the operator logs.
+func (w *WatcherActor) handleTrackVTXOs(ctx context.Context,
+	req *TrackVTXOsRequest) (Resp, error) {
+
+	if req == nil {
+		return nil, fmt.Errorf("%w: track request is nil",
+			ErrWatchUnavailable)
+	}
+
+	var (
+		tracked  int
+		failures int
+		errs     error
+	)
+	for _, desc := range req.VTXOs {
+		if !shouldTrackDescriptor(desc) {
+			continue
+		}
+
+		created, err := w.trackDescriptor(ctx, desc)
+		if err != nil {
+			failures++
+			errs = joinTrackError(errs, err)
+			continue
+		}
+		if created {
+			tracked++
+		}
+	}
+
+	w.log.InfoS(ctx, "Recipient fraud track batch completed",
+		slog.Int("requested", len(req.VTXOs)),
+		slog.Int("tracked", tracked),
+		slog.Int("failures", failures),
+	)
+
+	if errs != nil {
+		return nil, errs
+	}
+
+	return &TrackVTXOsResp{Tracked: tracked}, nil
+}
+
+// trackDescriptor builds the watch plan for one VTXO descriptor and
+// retains the ancestor watches the plan demands. Returns true when the
+// descriptor was newly admitted, false when it was already tracked.
+// Roll back any successful watch registrations if a later watch fails
+// so the watcher never leaks a half-armed target.
+func (w *WatcherActor) trackDescriptor(ctx context.Context,
+	desc *vtxo.Descriptor) (bool, error) {
+
+	if _, ok := w.targets[desc.Outpoint]; ok {
+		return false, nil
+	}
+
+	plan, err := BuildWatchPlan(desc)
+	if err != nil {
+		return false, fmt.Errorf("build fraud watch plan for %s: %w",
+			desc.Outpoint, err)
+	}
+
+	registered := make([]wire.OutPoint, 0, len(plan.Watches))
+	for _, watch := range plan.Watches {
+		if err := w.retainWatch(ctx, watch, desc.Outpoint); err != nil {
+			for _, outpoint := range registered {
+				_ = w.releaseWatch(ctx, outpoint, desc.Outpoint)
+			}
+
+			return false, err
+		}
+		registered = append(registered, watch.Outpoint)
+	}
+
+	w.targets[desc.Outpoint] = &trackedTarget{plan: plan}
+
+	return true, nil
+}
+
+// handleUntrack drops fraud watcher interest in one target VTXO and
+// releases every watch the target's plan had armed. A missing target
+// is a successful no-op so callers can issue Untrack idempotently from
+// the VTXO terminal-observer path.
+//
+// Per-watch release failures are aggregated rather than short-
+// circuiting the loop: the target has already been removed from
+// w.targets when the release loop runs, so an early return would
+// strand the surviving watches with a target that no longer exists,
+// and a retried Untrack for the same outpoint would see target==nil
+// and silently succeed without finishing cleanup. Continuing through
+// the loop releases everything we can and surfaces the aggregated
+// error to the caller.
+func (w *WatcherActor) handleUntrack(ctx context.Context, req *UntrackRequest) (
+	Resp, error) {
+
+	if req == nil {
+		return nil, fmt.Errorf("untrack request is nil")
+	}
+
+	target := w.targets[req.TargetOutpoint]
+	if target == nil {
+		return &UntrackResp{}, nil
+	}
+
+	delete(w.targets, req.TargetOutpoint)
+	var errs error
+	for _, watch := range target.plan.Watches {
+		if err := w.releaseWatch(
+			ctx, watch.Outpoint, req.TargetOutpoint,
+		); err != nil {
+
+			w.log.WarnS(
+				ctx, "Failed to release fraud watch on untrack",
+				err,
+				slog.String(
+					"watch_outpoint",
+					watch.Outpoint.String(),
+				),
+				slog.String(
+					"target_outpoint",
+					req.TargetOutpoint.String(),
+				),
+			)
+			errs = joinTrackError(errs, err)
+		}
+	}
+
+	if errs != nil {
+		return nil, errs
+	}
+
+	return &UntrackResp{Removed: true}, nil
+}
+
+// handleSpendObserved fans out a watched-ancestor spend event into one
+// unroll EnsureUnroll call per affected target VTXO. Per-target
+// failures are aggregated so a single bad target does not block fraud
+// defenses for the others sharing the same ancestor.
+func (w *WatcherActor) handleSpendObserved(ctx context.Context,
+	msg *SpendObservedMsg) (Resp, error) {
+
+	if msg == nil {
+		return nil, fmt.Errorf("spend observed message is nil")
+	}
+
+	targets := w.watches.targetsOf(msg.Outpoint)
+	if len(targets) == 0 {
+		return &AckResp{}, nil
+	}
+
+	var errs error
+	for target := range targets {
+		if err := w.ensureUnroll(ctx, target); err != nil {
+			errs = joinTrackError(errs, err)
+		}
+	}
+
+	w.log.DebugS(ctx, "Triggered recipient fraud unroll",
+		slog.String("watched_outpoint", msg.Outpoint.String()),
+		slog.String("spending_txid", msg.SpendingTxid.String()),
+		slog.Int("height", int(msg.Height)),
+		slog.Int("targets", len(targets)),
+	)
+
+	if errs != nil {
+		return nil, errs
+	}
+
+	return &AckResp{}, nil
+}
+
+// retainWatch records target as interested in watch.Outpoint. On the
+// first reference for the outpoint it also registers a chainsource
+// spend watch; if that registration fails the collection stays
+// unchanged so a retry sees the same first-reference state.
+// Subsequent retains by other targets only grow the target set.
+func (w *WatcherActor) retainWatch(ctx context.Context, watch WatchPoint,
+	target wire.OutPoint) error {
+
+	if w.watches.firstRefFor(watch.Outpoint) {
+		if err := w.registerSpendWatch(ctx, watch); err != nil {
+			return err
+		}
+	}
+
+	w.watches.addTarget(watch, target)
+
+	return nil
+}
+
+// releaseWatch drops target's interest in outpoint. When the target
+// set drains to empty the watcher unregisters the chainsource spend
+// watch using the stored WatchPoint.
+func (w *WatcherActor) releaseWatch(ctx context.Context,
+	outpoint, target wire.OutPoint) error {
+
+	point, emptied := w.watches.dropTarget(outpoint, target)
+	if !emptied {
+		return nil
+	}
+
+	return w.unregisterSpendWatchPoint(ctx, point)
+}
+
+// registerSpendWatch installs a chainsource spend watch for one
+// ancestor outpoint. Watch events are mapped into SpendObservedMsg and
+// delivered back through the watcher's own mailbox.
+func (w *WatcherActor) registerSpendWatch(ctx context.Context,
+	watch WatchPoint) error {
+
+	notifyRef := chainsource.MapSpendEvent(
+		w.selfRef, func(event chainsource.SpendEvent) Msg {
+			return &SpendObservedMsg{
+				Outpoint:     event.Outpoint,
+				SpendingTxid: event.SpendingTxid,
+				Height:       event.SpendingHeight,
+			}
+		},
+	)
+
+	outpoint := watch.Outpoint
+	_, err := w.cfg.ChainSource.Ask(ctx, &chainsource.RegisterSpendRequest{
+		CallerID:    ServiceKeyName,
+		Outpoint:    &outpoint,
+		PkScript:    append([]byte(nil), watch.PkScript...),
+		HeightHint:  watch.HeightHint,
+		NotifyActor: fn.Some(notifyRef),
+	}).Await(ctx).Unpack()
+	if err != nil {
+		return fmt.Errorf("register fraud spend watch %s: %w",
+			watch.Outpoint, err)
+	}
+
+	return nil
+}
+
+// unregisterSpendWatchPoint removes the chainsource spend watch
+// installed by registerSpendWatch. The caller supplies the WatchPoint
+// (rather than looking it up by outpoint) so the helper works equally
+// well from the per-release path — where dropTarget already returned
+// the point — and from the shutdown / diagnostic path that reads the
+// collection separately.
+func (w *WatcherActor) unregisterSpendWatchPoint(ctx context.Context,
+	watch WatchPoint) error {
+
+	outpoint := watch.Outpoint
+	req := &chainsource.UnregisterSpendRequest{
+		CallerID: ServiceKeyName,
+		Outpoint: &outpoint,
+		PkScript: append([]byte(nil), watch.PkScript...),
+	}
+	_, err := w.cfg.ChainSource.Ask(ctx, req).Await(ctx).Unpack()
+	if err != nil {
+		return fmt.Errorf("unregister fraud spend watch %s: %w",
+			outpoint, err)
+	}
+
+	return nil
+}
+
+// ensureUnroll asks the unroll registry to start (or reuse) a durable
+// unroll job for one target VTXO under TriggerFraudSpend.
+func (w *WatcherActor) ensureUnroll(ctx context.Context,
+	target wire.OutPoint) error {
+
+	_, err := w.cfg.UnrollRef.Ask(ctx, &unroll.EnsureUnrollRequest{
+		Outpoint: target,
+		Trigger:  unroll.TriggerFraudSpend,
+	}).Await(ctx).Unpack()
+	if err != nil {
+		return fmt.Errorf("ensure fraud unroll for %s: %w", target, err)
+	}
+
+	return nil
+}

--- a/fraud/actor_test.go
+++ b/fraud/actor_test.go
@@ -1,0 +1,380 @@
+package fraud
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/chainsource"
+	"github.com/lightninglabs/darepo-client/unroll"
+	"github.com/lightninglabs/darepo-client/vtxo"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/stretchr/testify/require"
+)
+
+const testTimeout = time.Second
+
+// spendRef aliases the chainsource spend notification target.
+type spendRef = actor.TellOnlyRef[chainsource.SpendEvent]
+
+type fakeChainSourceRef struct {
+	mu          sync.Mutex
+	spendReqs   []*chainsource.RegisterSpendRequest
+	spendRefs   map[wire.OutPoint]spendRef
+	unregisters []wire.OutPoint
+}
+
+// ID returns the fake actor ID.
+func (f *fakeChainSourceRef) ID() string {
+	return "fake-chain"
+}
+
+// Tell is unused by these tests.
+func (f *fakeChainSourceRef) Tell(context.Context,
+	chainsource.ChainSourceMsg) error {
+
+	return nil
+}
+
+// Ask records spend registration requests.
+func (f *fakeChainSourceRef) Ask(_ context.Context,
+	msg chainsource.ChainSourceMsg,
+) actor.Future[chainsource.ChainSourceResp] {
+
+	promise := actor.NewPromise[chainsource.ChainSourceResp]()
+	switch msg := msg.(type) {
+	case *chainsource.RegisterSpendRequest:
+		if msg.Outpoint == nil {
+			promise.Complete(
+				fn.Err[chainsource.ChainSourceResp](
+					fmt.Errorf("outpoint required"),
+				),
+			)
+
+			return promise.Future()
+		}
+
+		f.mu.Lock()
+		if f.spendRefs == nil {
+			f.spendRefs = make(map[wire.OutPoint]spendRef)
+		}
+		f.spendReqs = append(f.spendReqs, msg)
+		f.spendRefs[*msg.Outpoint] = msg.NotifyActor.UnwrapOr(nil)
+		f.mu.Unlock()
+		promise.Complete(
+			fn.Ok[chainsource.ChainSourceResp](
+				&chainsource.RegisterSpendResponse{},
+			),
+		)
+
+	case *chainsource.UnregisterSpendRequest:
+		if msg.Outpoint != nil {
+			f.mu.Lock()
+			f.unregisters = append(f.unregisters, *msg.Outpoint)
+			f.mu.Unlock()
+		}
+		promise.Complete(
+			fn.Ok[chainsource.ChainSourceResp](
+				&chainsource.UnregisterSpendResponse{},
+			),
+		)
+
+	default:
+		promise.Complete(
+			fn.Err[chainsource.ChainSourceResp](
+				fmt.Errorf("unexpected chainsource msg %T",
+					msg),
+			),
+		)
+	}
+
+	return promise.Future()
+}
+
+func (f *fakeChainSourceRef) spendWatchCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return len(f.spendReqs)
+}
+
+func (f *fakeChainSourceRef) emitSpend(t *testing.T, outpoint wire.OutPoint) {
+	t.Helper()
+
+	f.mu.Lock()
+	ref := f.spendRefs[outpoint]
+	f.mu.Unlock()
+
+	require.NotNil(t, ref)
+	require.NoError(
+		t,
+		ref.Tell(
+			t.Context(), chainsource.SpendEvent{
+				Outpoint:       outpoint,
+				SpendingTxid:   testInput(99).Hash,
+				SpendingHeight: 33,
+			},
+		),
+	)
+}
+
+type fakeUnrollRef struct {
+	mu       sync.Mutex
+	requests []*unroll.EnsureUnrollRequest
+	err      error
+}
+
+// ID returns the fake actor ID.
+func (f *fakeUnrollRef) ID() string {
+	return "fake-unroll"
+}
+
+// Tell is unused by these tests.
+func (f *fakeUnrollRef) Tell(context.Context, unroll.RegistryMsg) error {
+	return nil
+}
+
+// Ask records ensure-unroll requests.
+func (f *fakeUnrollRef) Ask(_ context.Context,
+	msg unroll.RegistryMsg) actor.Future[unroll.RegistryResp] {
+
+	promise := actor.NewPromise[unroll.RegistryResp]()
+	req, ok := msg.(*unroll.EnsureUnrollRequest)
+	if !ok {
+		promise.Complete(
+			fn.Err[unroll.RegistryResp](
+				fmt.Errorf("unexpected unroll msg %T", msg),
+			),
+		)
+
+		return promise.Future()
+	}
+
+	f.mu.Lock()
+	f.requests = append(f.requests, req)
+	f.mu.Unlock()
+	if f.err != nil {
+		promise.Complete(fn.Err[unroll.RegistryResp](f.err))
+
+		return promise.Future()
+	}
+
+	promise.Complete(
+		fn.Ok[unroll.RegistryResp](
+			&unroll.EnsureUnrollResp{
+				ActorID: "child",
+				Created: true,
+			},
+		),
+	)
+
+	return promise.Future()
+}
+
+func (f *fakeUnrollRef) lastRequest(t *testing.T) *unroll.EnsureUnrollRequest {
+	t.Helper()
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	require.NotEmpty(t, f.requests)
+
+	return f.requests[len(f.requests)-1]
+}
+
+// requestCount returns the number of recorded ensure-unroll requests.
+func (f *fakeUnrollRef) requestCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return len(f.requests)
+}
+
+// TestWatcherTriggersUnrollOnAncestorSpend verifies the passive watcher calls
+// into unroll only after a watched ancestor materializes.
+func TestWatcherTriggersUnrollOnAncestorSpend(t *testing.T) {
+	treePath, source := testLeafTree(t, 1)
+	target := testInput(2)
+	desc := testDescriptor(target, treePath)
+
+	chainRef := &fakeChainSourceRef{}
+	unrollRef := &fakeUnrollRef{}
+	watcher := NewWatcherActor(WatcherConfig{
+		ChainSource: chainRef,
+		UnrollRef:   unrollRef,
+		Log:         fn.None[btclog.Logger](),
+	})
+	t.Cleanup(watcher.Stop)
+
+	resp, err := watcher.Ref().Ask(t.Context(), &TrackVTXOsRequest{
+		VTXOs: []*vtxo.Descriptor{desc},
+	}).Await(t.Context()).Unpack()
+	require.NoError(t, err)
+	trackResp, ok := resp.(*TrackVTXOsResp)
+	require.True(t, ok)
+	require.Equal(t, 1, trackResp.Tracked)
+	require.Equal(t, 2, chainRef.spendWatchCount())
+
+	chainRef.emitSpend(t, source)
+
+	require.Eventually(t, func() bool {
+		return unrollRef.requestCount() == 1
+	}, testTimeout, 10*time.Millisecond)
+
+	req := unrollRef.lastRequest(t)
+	require.Equal(t, target, req.Outpoint)
+	require.Equal(t, unroll.TriggerFraudSpend, req.Trigger)
+
+	untrackResp, err := watcher.Ref().Ask(
+		t.Context(), &UntrackRequest{TargetOutpoint: target},
+	).Await(t.Context()).Unpack()
+	require.NoError(t, err)
+	typedUntrack, ok := untrackResp.(*UntrackResp)
+	require.True(t, ok)
+	require.True(t, typedUntrack.Removed)
+
+	chainRef.mu.Lock()
+	require.Len(t, chainRef.unregisters, 2)
+	chainRef.mu.Unlock()
+}
+
+// TestWatcherTracksOnlyLiveOORVTXOs verifies admission keeps passive fraud
+// watches limited to live out-of-round VTXOs.
+func TestWatcherTracksOnlyLiveOORVTXOs(t *testing.T) {
+	treePath, _ := testLeafTree(t, 10)
+	liveOOR := testDescriptor(testInput(20), treePath)
+
+	liveRound := testDescriptor(testInput(21), treePath)
+	liveRound.ChainDepth = 0
+
+	spentOOR := testDescriptor(testInput(22), treePath)
+	spentOOR.Status = vtxo.VTXOStatusSpent
+
+	chainRef := &fakeChainSourceRef{}
+	watcher := NewWatcherActor(WatcherConfig{
+		ChainSource: chainRef,
+		UnrollRef:   &fakeUnrollRef{},
+		Log:         fn.None[btclog.Logger](),
+	})
+	t.Cleanup(watcher.Stop)
+
+	resp, err := watcher.Ref().Ask(t.Context(), &TrackVTXOsRequest{
+		VTXOs: []*vtxo.Descriptor{
+			liveRound,
+			spentOOR,
+			liveOOR,
+			nil,
+		},
+	}).Await(t.Context()).Unpack()
+	require.NoError(t, err)
+
+	trackResp, ok := resp.(*TrackVTXOsResp)
+	require.True(t, ok)
+	require.Equal(t, 1, trackResp.Tracked)
+	require.Equal(t, 2, chainRef.spendWatchCount())
+}
+
+// TestWatcherRefcountsSharedWatchOutpoints verifies shared ancestry produces
+// one chainsource watch per outpoint and unregisters only after all targets
+// release interest.
+func TestWatcherRefcountsSharedWatchOutpoints(t *testing.T) {
+	treePath, _ := testLeafTree(t, 30)
+	targetOne := testInput(31)
+	targetTwo := testInput(32)
+
+	chainRef := &fakeChainSourceRef{}
+	watcher := NewWatcherActor(WatcherConfig{
+		ChainSource: chainRef,
+		UnrollRef:   &fakeUnrollRef{},
+		Log:         fn.None[btclog.Logger](),
+	})
+	t.Cleanup(watcher.Stop)
+
+	resp, err := watcher.Ref().Ask(t.Context(), &TrackVTXOsRequest{
+		VTXOs: []*vtxo.Descriptor{
+			testDescriptor(targetOne, treePath),
+			testDescriptor(targetTwo, treePath),
+		},
+	}).Await(t.Context()).Unpack()
+	require.NoError(t, err)
+
+	trackResp, ok := resp.(*TrackVTXOsResp)
+	require.True(t, ok)
+	require.Equal(t, 2, trackResp.Tracked)
+	require.Equal(t, 2, chainRef.spendWatchCount())
+
+	_, err = watcher.Ref().Ask(
+		t.Context(), &UntrackRequest{TargetOutpoint: targetOne},
+	).Await(t.Context()).Unpack()
+	require.NoError(t, err)
+	chainRef.mu.Lock()
+	require.Empty(t, chainRef.unregisters)
+	chainRef.mu.Unlock()
+
+	_, err = watcher.Ref().Ask(
+		t.Context(), &UntrackRequest{TargetOutpoint: targetTwo},
+	).Await(t.Context()).Unpack()
+	require.NoError(t, err)
+	chainRef.mu.Lock()
+	require.Len(t, chainRef.unregisters, 2)
+	chainRef.mu.Unlock()
+}
+
+// TestWatcherBestEffortTrackKeepsValidDescriptors verifies one malformed
+// descriptor does not roll back unrelated valid watch registrations.
+func TestWatcherBestEffortTrackKeepsValidDescriptors(t *testing.T) {
+	treePath, _ := testLeafTree(t, 40)
+	good := testDescriptor(testInput(41), treePath)
+	bad := testDescriptor(testInput(42), treePath)
+	bad.Ancestry[0].TreePath = nil
+
+	chainRef := &fakeChainSourceRef{}
+	watcher := NewWatcherActor(WatcherConfig{
+		ChainSource: chainRef,
+		UnrollRef:   &fakeUnrollRef{},
+		Log:         fn.None[btclog.Logger](),
+	})
+	t.Cleanup(watcher.Stop)
+
+	_, err := watcher.Ref().Ask(t.Context(), &TrackVTXOsRequest{
+		VTXOs: []*vtxo.Descriptor{bad, good},
+	}).Await(t.Context()).Unpack()
+	require.Error(t, err)
+	require.Equal(t, 2, chainRef.spendWatchCount())
+}
+
+// TestWatcherSpendFanoutBestEffort verifies one unroll admission failure does
+// not prevent other targets sharing the same watched outpoint from being
+// attempted.
+func TestWatcherSpendFanoutBestEffort(t *testing.T) {
+	treePath, source := testLeafTree(t, 50)
+	unrollRef := &fakeUnrollRef{err: fmt.Errorf("admission failed")}
+	chainRef := &fakeChainSourceRef{}
+	watcher := NewWatcherActor(WatcherConfig{
+		ChainSource: chainRef,
+		UnrollRef:   unrollRef,
+		Log:         fn.None[btclog.Logger](),
+	})
+	t.Cleanup(watcher.Stop)
+
+	_, err := watcher.Ref().Ask(t.Context(), &TrackVTXOsRequest{
+		VTXOs: []*vtxo.Descriptor{
+			testDescriptor(testInput(51), treePath),
+			testDescriptor(testInput(52), treePath),
+		},
+	}).Await(t.Context()).Unpack()
+	require.NoError(t, err)
+
+	_, err = watcher.Ref().Ask(t.Context(), &SpendObservedMsg{
+		Outpoint:     source,
+		SpendingTxid: testInput(53).Hash,
+		Height:       33,
+	}).Await(t.Context()).Unpack()
+	require.Error(t, err)
+	require.Equal(t, 2, unrollRef.requestCount())
+}

--- a/fraud/messages.go
+++ b/fraud/messages.go
@@ -1,0 +1,121 @@
+package fraud
+
+import (
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/vtxo"
+)
+
+// Msg is the sealed fraud watcher message surface.
+type Msg interface {
+	actor.Message
+
+	fraudMsgSealed()
+}
+
+// Resp is the sealed fraud watcher response surface.
+type Resp interface {
+	actor.Message
+
+	fraudRespSealed()
+}
+
+// TrackVTXOsRequest asks the watcher to arm passive watches for descriptors.
+type TrackVTXOsRequest struct {
+	actor.BaseMessage
+
+	// VTXOs are locally materialized descriptors to consider for tracking.
+	VTXOs []*vtxo.Descriptor
+}
+
+// MessageType returns the stable actor message type.
+func (m *TrackVTXOsRequest) MessageType() string {
+	return "TrackVTXOsRequest"
+}
+
+// fraudMsgSealed seals TrackVTXOsRequest into Msg.
+func (m *TrackVTXOsRequest) fraudMsgSealed() {}
+
+// TrackVTXOsResp summarizes watcher admission.
+type TrackVTXOsResp struct {
+	actor.BaseMessage
+
+	// Tracked is the number of descriptors that resulted in active watches.
+	Tracked int
+}
+
+// MessageType returns the stable actor message type.
+func (m *TrackVTXOsResp) MessageType() string {
+	return "TrackVTXOsResp"
+}
+
+// fraudRespSealed seals TrackVTXOsResp into Resp.
+func (m *TrackVTXOsResp) fraudRespSealed() {}
+
+// UntrackRequest asks the watcher to release one target's passive watches.
+type UntrackRequest struct {
+	actor.BaseMessage
+
+	// TargetOutpoint identifies the no-longer-live target VTXO.
+	TargetOutpoint wire.OutPoint
+}
+
+// MessageType returns the stable actor message type.
+func (m *UntrackRequest) MessageType() string {
+	return "UntrackRequest"
+}
+
+// fraudMsgSealed seals UntrackRequest into Msg.
+func (m *UntrackRequest) fraudMsgSealed() {}
+
+// UntrackResp acknowledges an untrack request.
+type UntrackResp struct {
+	actor.BaseMessage
+
+	// Removed reports whether an active target was removed.
+	Removed bool
+}
+
+// MessageType returns the stable actor message type.
+func (m *UntrackResp) MessageType() string {
+	return "UntrackResp"
+}
+
+// fraudRespSealed seals UntrackResp into Resp.
+func (m *UntrackResp) fraudRespSealed() {}
+
+// SpendObservedMsg reports a spend of one watched ancestor outpoint.
+type SpendObservedMsg struct {
+	actor.BaseMessage
+
+	// Outpoint is the watched outpoint that was spent.
+	Outpoint wire.OutPoint
+
+	// SpendingTxid is the transaction that spent Outpoint.
+	SpendingTxid chainhash.Hash
+
+	// Height is the confirmation height of SpendingTxid.
+	Height int32
+}
+
+// MessageType returns the stable actor message type.
+func (m *SpendObservedMsg) MessageType() string {
+	return "SpendObservedMsg"
+}
+
+// fraudMsgSealed seals SpendObservedMsg into Msg.
+func (m *SpendObservedMsg) fraudMsgSealed() {}
+
+// AckResp is a generic acknowledgement.
+type AckResp struct {
+	actor.BaseMessage
+}
+
+// MessageType returns the stable actor message type.
+func (m *AckResp) MessageType() string {
+	return "AckResp"
+}
+
+// fraudRespSealed seals AckResp into Resp.
+func (m *AckResp) fraudRespSealed() {}

--- a/fraud/tracker.go
+++ b/fraud/tracker.go
@@ -1,0 +1,48 @@
+package fraud
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/vtxo"
+)
+
+// TrackVTXOs asks tracker to arm passive fraud watches for live OOR VTXOs.
+func TrackVTXOs(ctx context.Context, tracker actor.TellOnlyRef[Msg],
+	descs []*vtxo.Descriptor) error {
+
+	if tracker == nil {
+		return fmt.Errorf("%w: fraud tracker is nil",
+			ErrWatchUnavailable)
+	}
+
+	err := tracker.Tell(ctx, &TrackVTXOsRequest{VTXOs: descs})
+	if err != nil {
+		return fmt.Errorf("track fraud vtxos: %w", err)
+	}
+
+	return nil
+}
+
+// shouldTrackDescriptor reports whether desc needs recipient fraud defense.
+func shouldTrackDescriptor(desc *vtxo.Descriptor) bool {
+	if desc == nil {
+		return false
+	}
+	if desc.Status != vtxo.VTXOStatusLive {
+		return false
+	}
+
+	return desc.ChainDepth > 0
+}
+
+// joinTrackError appends err to existing without dropping later descriptors.
+func joinTrackError(existing, err error) error {
+	if err == nil {
+		return existing
+	}
+
+	return errors.Join(existing, err)
+}

--- a/fraud/watch_model.go
+++ b/fraud/watch_model.go
@@ -1,0 +1,189 @@
+// Package fraud detects recipient-side OOR ancestry materialization.
+package fraud
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/tree"
+	"github.com/lightninglabs/darepo-client/vtxo"
+)
+
+var (
+	// ErrWatchUnavailable indicates local state is insufficient to arm
+	// recipient fraud watches.
+	ErrWatchUnavailable = fmt.Errorf("recipient fraud watch unavailable")
+
+	// ErrWatchInvalid indicates persisted ancestry state is internally
+	// inconsistent.
+	ErrWatchInvalid = fmt.Errorf("recipient fraud watch invalid")
+)
+
+// WatchPlan is the passive ancestry watch set for one locally-owned OOR VTXO.
+type WatchPlan struct {
+	// TargetOutpoint is the VTXO to unroll if any watched ancestor spends.
+	TargetOutpoint wire.OutPoint
+
+	// Watches are the ancestor outpoints that indicate materialization has
+	// started.
+	Watches []WatchPoint
+}
+
+// WatchPoint identifies one outpoint the fraud watcher should monitor.
+type WatchPoint struct {
+	// Outpoint is the ancestor output to watch for a spend.
+	Outpoint wire.OutPoint
+
+	// PkScript is the script committed to Outpoint.
+	PkScript []byte
+
+	// HeightHint is the earliest plausible spend height.
+	HeightHint uint32
+}
+
+// BuildWatchPlan builds the passive fraud watch set for desc.
+func BuildWatchPlan(desc *vtxo.Descriptor) (*WatchPlan, error) {
+	if desc == nil {
+		return nil, fmt.Errorf("%w: descriptor is nil",
+			ErrWatchUnavailable)
+	}
+	if len(desc.Ancestry) == 0 {
+		return nil, fmt.Errorf("%w: descriptor missing ancestry",
+			ErrWatchUnavailable)
+	}
+
+	heightHint := heightHintFromCreatedHeight(desc.CreatedHeight)
+	watchesByOutpoint := make(map[wire.OutPoint]WatchPoint)
+	for i := range desc.Ancestry {
+		treePath := desc.Ancestry[i].TreePath
+		if treePath == nil || treePath.Root == nil {
+			return nil, fmt.Errorf("%w: ancestry %d missing "+
+				"tree path", ErrWatchUnavailable, i)
+		}
+		if treePath.BatchOutput == nil {
+			return nil, fmt.Errorf("%w: ancestry %d missing "+
+				"batch output", ErrWatchUnavailable, i)
+		}
+
+		err := collectTreeWatches(
+			treePath.Root, treePath.BatchOutput.PkScript,
+			heightHint, watchesByOutpoint,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("ancestry %d: %w", i, err)
+		}
+	}
+
+	watches := make([]WatchPoint, 0, len(watchesByOutpoint))
+	for _, watch := range watchesByOutpoint {
+		watches = append(watches, watch)
+	}
+	sortWatchPoints(watches)
+
+	return &WatchPlan{
+		TargetOutpoint: desc.Outpoint,
+		Watches:        watches,
+	}, nil
+}
+
+// collectTreeWatches records every on-path tree input and leaf output. Tree
+// inputs detect tree materialization; leaf-output watches detect the first OOR
+// checkpoint spending the materialized source VTXO.
+func collectTreeWatches(node *tree.Node, inputPkScript []byte,
+	heightHint uint32, watches map[wire.OutPoint]WatchPoint) error {
+
+	if node == nil {
+		return fmt.Errorf("%w: nil tree node", ErrWatchInvalid)
+	}
+	tx, err := node.ToTx()
+	if err != nil {
+		return fmt.Errorf("%w: tree node tx: %w", ErrWatchInvalid, err)
+	}
+
+	watches[node.Input] = WatchPoint{
+		Outpoint:   node.Input,
+		PkScript:   append([]byte(nil), inputPkScript...),
+		HeightHint: heightHint,
+	}
+
+	if node.IsLeaf() {
+		leafOutpoint, err := node.GetNonAnchorOutpoint()
+		if err != nil {
+			return fmt.Errorf("%w: leaf output: %w",
+				ErrWatchInvalid, err)
+		}
+		if int(leafOutpoint.Index) >= len(node.Outputs) {
+			return fmt.Errorf("%w: leaf output %s out of range",
+				ErrWatchInvalid, *leafOutpoint)
+		}
+
+		watches[*leafOutpoint] = WatchPoint{
+			Outpoint: *leafOutpoint,
+			PkScript: append(
+				[]byte(nil),
+				node.Outputs[leafOutpoint.Index].PkScript...,
+			),
+			HeightHint: heightHint,
+		}
+
+		return nil
+	}
+
+	for outputIndex, child := range node.Children {
+		if int(outputIndex) >= len(node.Outputs) {
+			return fmt.Errorf("%w: child output index %d out "+
+				"of range", ErrWatchInvalid, outputIndex)
+		}
+		childInput := wire.OutPoint{
+			Hash:  tx.TxHash(),
+			Index: outputIndex,
+		}
+		if child.Input != childInput {
+			return fmt.Errorf("%w: child input %s does not match "+
+				"parent output %s", ErrWatchInvalid,
+				child.Input, childInput)
+		}
+
+		err := collectTreeWatches(
+			child, node.Outputs[outputIndex].PkScript, heightHint,
+			watches,
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// heightHintFromCreatedHeight returns a backend-compatible chain height hint.
+func heightHintFromCreatedHeight(createdHeight int32) uint32 {
+	if createdHeight <= 0 {
+		return 1
+	}
+
+	return uint32(createdHeight)
+}
+
+// sortWatchPoints sorts watch points by outpoint for deterministic actor IO.
+func sortWatchPoints(watches []WatchPoint) {
+	sort.Slice(watches, func(i, j int) bool {
+		return outpointLess(watches[i].Outpoint, watches[j].Outpoint)
+	})
+}
+
+// outpointLess returns the canonical ordering for watch outpoints.
+// Compares the raw 32-byte hash with bytes.Compare to avoid the
+// per-call hex/reverse allocation of chainhash.Hash.String(). The
+// resulting order is only used for deterministic watch registration
+// and test assertions; the comparison direction (display-order vs
+// raw-bytes) does not matter as long as it is stable.
+func outpointLess(a, b wire.OutPoint) bool {
+	if cmp := bytes.Compare(a.Hash[:], b.Hash[:]); cmp != 0 {
+		return cmp < 0
+	}
+
+	return a.Index < b.Index
+}

--- a/fraud/watch_model_test.go
+++ b/fraud/watch_model_test.go
@@ -1,0 +1,163 @@
+package fraud
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/tree"
+	"github.com/lightninglabs/darepo-client/vtxo"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildWatchPlanIncludesTreeInputsAndLeafSource verifies passive watches
+// cover both tree materialization and checkpoint spend of the source VTXO.
+func TestBuildWatchPlanIncludesTreeInputsAndLeafSource(t *testing.T) {
+	treePath, source := testBranchTree(t, 5)
+	target := testInput(9)
+
+	plan, err := BuildWatchPlan(testDescriptor(target, treePath))
+	require.NoError(t, err)
+	require.Equal(t, target, plan.TargetOutpoint)
+
+	watched := make(map[wire.OutPoint]struct{}, len(plan.Watches))
+	for _, watch := range plan.Watches {
+		watched[watch.Outpoint] = struct{}{}
+	}
+
+	require.Contains(t, watched, treePath.Root.Input)
+	require.Contains(t, watched, treePath.Root.Children[0].Input)
+	require.Contains(t, watched, source)
+}
+
+// TestBuildWatchPlanIncludesEveryAncestry verifies multi-input OOR targets arm
+// passive watches for every ancestry fragment.
+func TestBuildWatchPlanIncludesEveryAncestry(t *testing.T) {
+	treeOne, sourceOne := testLeafTree(t, 10)
+	treeTwo, sourceTwo := testLeafTree(t, 20)
+	target := testInput(30)
+
+	plan, err := BuildWatchPlan(testDescriptor(target, treeOne, treeTwo))
+	require.NoError(t, err)
+	require.Equal(t, target, plan.TargetOutpoint)
+
+	watched := make(map[wire.OutPoint]struct{}, len(plan.Watches))
+	for _, watch := range plan.Watches {
+		watched[watch.Outpoint] = struct{}{}
+	}
+
+	require.Contains(t, watched, treeOne.Root.Input)
+	require.Contains(t, watched, sourceOne)
+	require.Contains(t, watched, treeTwo.Root.Input)
+	require.Contains(t, watched, sourceTwo)
+}
+
+// TestBuildWatchPlanRejectsMalformedAncestry verifies invalid persisted
+// ancestry is surfaced instead of arming an incomplete passive watch set.
+func TestBuildWatchPlanRejectsMalformedAncestry(t *testing.T) {
+	treePath, _ := testLeafTree(t, 40)
+	desc := testDescriptor(testInput(41), treePath)
+	desc.Ancestry[0].TreePath.Root = nil
+
+	_, err := BuildWatchPlan(desc)
+	require.ErrorIs(t, err, ErrWatchUnavailable)
+}
+
+// testLeafTree creates a one-node tree and returns its non-anchor output.
+func testLeafTree(t *testing.T, seed byte) (*tree.Tree, wire.OutPoint) {
+	t.Helper()
+
+	root := &tree.Node{
+		Input: testInput(seed),
+		Outputs: []*wire.TxOut{
+			testOut(seed, 1),
+		},
+		Children: make(map[uint32]*tree.Node),
+	}
+	source, err := root.GetNonAnchorOutpoint()
+	require.NoError(t, err)
+
+	return &tree.Tree{
+		Root:        root,
+		BatchOutput: testOut(seed, 0),
+	}, *source
+}
+
+// testBranchTree creates a two-node tree and returns the leaf output.
+func testBranchTree(t *testing.T, seed byte) (*tree.Tree, wire.OutPoint) {
+	t.Helper()
+
+	root := &tree.Node{
+		Input: testInput(seed),
+		Outputs: []*wire.TxOut{
+			testOut(seed, 1),
+		},
+		Children: make(map[uint32]*tree.Node),
+	}
+	rootTx, err := root.ToTx()
+	require.NoError(t, err)
+
+	leaf := &tree.Node{
+		Input: wire.OutPoint{
+			Hash:  rootTx.TxHash(),
+			Index: 0,
+		},
+		Outputs: []*wire.TxOut{
+			testOut(seed+1, 1),
+		},
+		Children: make(map[uint32]*tree.Node),
+	}
+	root.Children[0] = leaf
+
+	source, err := leaf.GetNonAnchorOutpoint()
+	require.NoError(t, err)
+
+	return &tree.Tree{
+		Root:        root,
+		BatchOutput: testOut(seed, 0),
+	}, *source
+}
+
+// testDescriptor creates the minimal descriptor shape watcher tests need.
+func testDescriptor(target wire.OutPoint,
+	trees ...*tree.Tree) *vtxo.Descriptor {
+
+	ancestry := make([]vtxo.Ancestry, 0, len(trees))
+	for i := range trees {
+		ancestry = append(ancestry, vtxo.Ancestry{
+			TreePath:       trees[i],
+			CommitmentTxID: trees[i].Root.Input.Hash,
+			InputIndices:   []uint32{uint32(i)},
+			TreeDepth:      1,
+		})
+	}
+
+	return &vtxo.Descriptor{
+		Outpoint:      target,
+		Ancestry:      ancestry,
+		ChainDepth:    1,
+		CreatedHeight: 7,
+		Status:        vtxo.VTXOStatusLive,
+	}
+}
+
+// testOut returns a deterministic output with a unique pkscript.
+func testOut(seed byte, index uint32) *wire.TxOut {
+	return &wire.TxOut{
+		Value: int64(1000 + index),
+		PkScript: []byte{
+			0x51, seed, byte(index),
+		},
+	}
+}
+
+// testInput returns a deterministic outpoint for seed.
+func testInput(seed byte) wire.OutPoint {
+	var h chainhash.Hash
+	h[0] = seed
+
+	return wire.OutPoint{
+		Hash:  h,
+		Index: 0,
+	}
+}

--- a/fraud/watch_set.go
+++ b/fraud/watch_set.go
@@ -1,0 +1,120 @@
+package fraud
+
+import "github.com/btcsuite/btcd/wire"
+
+// ancestorWatch is the per-outpoint state the watcher keeps for one
+// ancestor it is monitoring on chain. The targets set doubles as a
+// reference count: a chainsource spend watch stays armed for
+// outpoint while len(targets) > 0, and is unregistered when the set
+// drains to empty.
+type ancestorWatch struct {
+	// point captures the chainsource registration parameters
+	// (pkScript and height hint) used when the watch was first armed.
+	// Kept alongside the targets set so the watcher can rebuild the
+	// matching UnregisterSpendRequest when the last target releases
+	// (or at shutdown).
+	point WatchPoint
+
+	// targets is the set of recipient VTXOs that share interest in
+	// this ancestor outpoint. Each target retains the watch exactly
+	// once, so len(targets) is the watcher's reference count for
+	// outpoint.
+	targets map[wire.OutPoint]struct{}
+}
+
+// ancestorWatches collects every ancestor outpoint the watcher is
+// monitoring. The collection encapsulates the refcounted-watch
+// bookkeeping so the surrounding actor never has to keep parallel
+// maps in sync.
+type ancestorWatches map[wire.OutPoint]*ancestorWatch
+
+// newAncestorWatches returns an empty collection ready for use.
+func newAncestorWatches() ancestorWatches {
+	return make(ancestorWatches)
+}
+
+// firstRefFor reports whether outpoint is currently untracked, i.e.
+// the next addTarget on it will be the first reference. Callers use
+// this to gate a chainsource registerSpendWatch call so the watch is
+// armed exactly once for each distinct ancestor outpoint.
+func (w ancestorWatches) firstRefFor(outpoint wire.OutPoint) bool {
+	return w[outpoint] == nil
+}
+
+// addTarget records target as interested in point.Outpoint. Creates
+// the entry on the first reference. Idempotent for repeated calls by
+// the same target (the set semantics deduplicate).
+func (w ancestorWatches) addTarget(point WatchPoint, target wire.OutPoint) {
+	aw, ok := w[point.Outpoint]
+	if !ok {
+		aw = &ancestorWatch{
+			point:   point,
+			targets: make(map[wire.OutPoint]struct{}),
+		}
+		w[point.Outpoint] = aw
+	}
+	aw.targets[target] = struct{}{}
+}
+
+// dropTarget removes target from the watch for outpoint. Returns the
+// stored WatchPoint and true when the watch becomes empty: the caller
+// should unregister the chainsource spend watch using that point. The
+// entry is removed from the collection before the return, so a later
+// addTarget will treat the outpoint as a fresh first reference.
+//
+// When the watch still has other targets the bool is false and the
+// returned point is zero-valued; the chainsource watch stays armed.
+func (w ancestorWatches) dropTarget(outpoint, target wire.OutPoint) (WatchPoint,
+	bool) {
+
+	aw, ok := w[outpoint]
+	if !ok {
+		return WatchPoint{}, false
+	}
+
+	delete(aw.targets, target)
+	if len(aw.targets) > 0 {
+		return WatchPoint{}, false
+	}
+
+	point := aw.point
+	delete(w, outpoint)
+
+	return point, true
+}
+
+// targetsOf returns the set of recipient VTXOs interested in outpoint.
+// The returned map is the live collection — callers must not mutate
+// it. Nil when outpoint is not tracked.
+func (w ancestorWatches) targetsOf(
+	outpoint wire.OutPoint) map[wire.OutPoint]struct{} {
+
+	if aw, ok := w[outpoint]; ok {
+		return aw.targets
+	}
+
+	return nil
+}
+
+// outpoints returns every tracked ancestor outpoint in a freshly
+// allocated slice. Used for diagnostic / shutdown iteration where the
+// caller wants a stable snapshot independent of the underlying map.
+func (w ancestorWatches) outpoints() []wire.OutPoint {
+	ops := make([]wire.OutPoint, 0, len(w))
+	for op := range w {
+		ops = append(ops, op)
+	}
+
+	return ops
+}
+
+// pointAt returns the WatchPoint stored for outpoint, if any. Useful
+// at shutdown when the watcher must reconstruct the unregister
+// request without dropping the entry from the collection.
+func (w ancestorWatches) pointAt(outpoint wire.OutPoint) (WatchPoint, bool) {
+	if aw, ok := w[outpoint]; ok {
+		return aw.point, true
+	}
+
+	return WatchPoint{}, false
+}

--- a/fraud/watch_set_test.go
+++ b/fraud/watch_set_test.go
@@ -1,0 +1,139 @@
+package fraud
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/wire"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAncestorWatchesRefcounting verifies the refcounted lifecycle:
+// the first addTarget reports firstRefFor=true, subsequent retains by
+// other targets do not, and dropTarget only signals "empty" once the
+// last target releases.
+func TestAncestorWatchesRefcounting(t *testing.T) {
+	t.Parallel()
+
+	w := newAncestorWatches()
+
+	op := wire.OutPoint{Hash: [32]byte{0xaa}}
+	point := WatchPoint{
+		Outpoint: op,
+		PkScript: []byte{
+			0x51,
+			0x20,
+		},
+		HeightHint: 100,
+	}
+	targetA := wire.OutPoint{Hash: [32]byte{0xa1}}
+	targetB := wire.OutPoint{Hash: [32]byte{0xb1}}
+
+	require.True(
+		t, w.firstRefFor(op),
+		"empty collection must report first reference",
+	)
+
+	w.addTarget(point, targetA)
+	require.False(
+		t, w.firstRefFor(op),
+		"after addTarget the outpoint is tracked",
+	)
+	require.Equal(t, map[wire.OutPoint]struct{}{
+		targetA: {},
+	}, w.targetsOf(op))
+
+	w.addTarget(point, targetB)
+	require.Equal(t, map[wire.OutPoint]struct{}{
+		targetA: {},
+		targetB: {},
+	}, w.targetsOf(op))
+
+	// Re-adding the same target is idempotent.
+	w.addTarget(point, targetA)
+	require.Len(t, w.targetsOf(op), 2)
+
+	// Drop the first target: watch must stay armed.
+	gotPoint, emptied := w.dropTarget(op, targetA)
+	require.False(
+		t, emptied,
+		"watch must remain armed while other targets reference it",
+	)
+	require.Equal(t, WatchPoint{}, gotPoint)
+	require.Equal(t, map[wire.OutPoint]struct{}{
+		targetB: {},
+	}, w.targetsOf(op))
+
+	// Drop the last target: collection returns the stored point so
+	// the caller can unregister, and the entry is removed.
+	gotPoint, emptied = w.dropTarget(op, targetB)
+	require.True(
+		t, emptied,
+		"watch must signal empty when the last target releases",
+	)
+	require.Equal(
+		t, point, gotPoint,
+		"stored WatchPoint must round-trip to the caller",
+	)
+	require.Nil(
+		t, w.targetsOf(op),
+		"removed entry must not appear via targetsOf",
+	)
+	require.True(
+		t, w.firstRefFor(op),
+		"after the last release, the outpoint is fresh again",
+	)
+}
+
+// TestAncestorWatchesDropTargetMissing verifies that dropTarget on an
+// untracked outpoint is a quiet no-op rather than a panic.
+func TestAncestorWatchesDropTargetMissing(t *testing.T) {
+	t.Parallel()
+
+	w := newAncestorWatches()
+	op := wire.OutPoint{Hash: [32]byte{0xaa}}
+	target := wire.OutPoint{Hash: [32]byte{0xa1}}
+
+	gotPoint, emptied := w.dropTarget(op, target)
+	require.False(t, emptied)
+	require.Equal(t, WatchPoint{}, gotPoint)
+}
+
+// TestAncestorWatchesOutpointsAndPointAt verifies the iteration and
+// lookup helpers used by the shutdown path (OnStop must walk every
+// tracked outpoint and read its stored point without dropping the
+// entry).
+func TestAncestorWatchesOutpointsAndPointAt(t *testing.T) {
+	t.Parallel()
+
+	w := newAncestorWatches()
+
+	opA := wire.OutPoint{Hash: [32]byte{0x01}}
+	opB := wire.OutPoint{Hash: [32]byte{0x02}}
+	pointA := WatchPoint{Outpoint: opA, HeightHint: 100}
+	pointB := WatchPoint{Outpoint: opB, HeightHint: 200}
+	target := wire.OutPoint{Hash: [32]byte{0xff}}
+
+	w.addTarget(pointA, target)
+	w.addTarget(pointB, target)
+
+	require.ElementsMatch(
+		t, []wire.OutPoint{opA, opB}, w.outpoints(),
+	)
+
+	gotA, ok := w.pointAt(opA)
+	require.True(t, ok)
+	require.Equal(t, pointA, gotA)
+
+	gotB, ok := w.pointAt(opB)
+	require.True(t, ok)
+	require.Equal(t, pointB, gotB)
+
+	_, ok = w.pointAt(wire.OutPoint{Hash: [32]byte{0x09}})
+	require.False(t, ok)
+
+	// pointAt does not drop the entry — the outpoints list must
+	// still report both after multiple reads.
+	require.ElementsMatch(
+		t, []wire.OutPoint{opA, opB}, w.outpoints(),
+	)
+}

--- a/oor/actor.go
+++ b/oor/actor.go
@@ -107,6 +107,11 @@ type ClientActorCfg struct {
 	// sync. When None, ledger emission is silently skipped --
 	// useful for unit tests that do not register a ledger actor.
 	LedgerSink fn.Option[ledger.Sink]
+
+	// IncomingVTXOObserver receives incoming VTXO descriptors after
+	// materialization so daemon-local subsystems can arm actor-owned
+	// work without making this package depend on those subsystems.
+	IncomingVTXOObserver IncomingVTXONotifier
 }
 
 // OORClientActor wraps the outgoing-transfer client FSM in a durable actor
@@ -2118,6 +2123,18 @@ func (b *oorDurableBehavior) notifyMaterializedVTXOs(ctx context.Context,
 			ctx, "Failed to notify VTXO manager of "+
 				"materialized incoming VTXOs", err,
 			slog.Int("num_vtxos", len(descs)))
+	}
+
+	if b.cfg.IncomingVTXOObserver != nil {
+		err := b.cfg.IncomingVTXOObserver(ctx, descs)
+		if err != nil {
+			b.logger(ctx).WarnS(
+				ctx,
+				"Failed to notify incoming VTXO observer",
+				err,
+				slog.Int("num_vtxos", len(descs)),
+			)
+		}
 	}
 
 	b.emitVTXOsReceived(ctx, descs)

--- a/oor/actor_drive_event_integration_test.go
+++ b/oor/actor_drive_event_integration_test.go
@@ -262,12 +262,20 @@ func TestOORDurableBehaviorDriveIncomingHandledNotifiesVTXOManager(
 	require.NoError(t, err)
 
 	managerRef := &mockVTXOManagerRef{}
+	var observed []*vtxo.Descriptor
 	behavior := &oorDurableBehavior{
 		cfg: ClientActorCfg{
 			DeliveryStore: newTestDeliveryStore(t),
 			ActorID:       "oor-drive-incoming-handled-notify",
 			OutboxHandler: &noopOutboxHandler{},
 			VTXOManager:   managerRef,
+			IncomingVTXOObserver: func(_ context.Context,
+				descs []*vtxo.Descriptor) error {
+
+				observed = append(observed, descs...)
+
+				return nil
+			},
 		},
 		sessions: map[SessionID]*sessionHandle{
 			sessionID: {
@@ -292,6 +300,8 @@ func TestOORDurableBehaviorDriveIncomingHandledNotifiesVTXOManager(
 	require.True(t, ok)
 	require.Len(t, notification.VTXOs, 1)
 	require.Equal(t, desc.Outpoint, notification.VTXOs[0].Outpoint)
+	require.Len(t, observed, 1)
+	require.Equal(t, desc.Outpoint, observed[0].Outpoint)
 
 	state, err := session.FSM.CurrentState()
 	require.NoError(t, err)

--- a/txconfirm/broadcaster.go
+++ b/txconfirm/broadcaster.go
@@ -1505,6 +1505,26 @@ var childFailureSentinels = []error{
 	rpcclient.ErrConflictingTx,
 }
 
+// parentLikelyConfirmedSentinels are RPC sentinels that signal a parent
+// transaction's inputs are already spent on chain. When a per-tx
+// `*chainbackends.PackageTxError` for the parent unwraps to one of
+// these, the most likely explanation is that the parent itself already
+// confirmed deeply enough that bitcoind has dropped its txid from the
+// recent-rejects / mempool cache.
+//
+// The same sentinels also fire if the parent's input was double-spent
+// by a *competing* transaction. In that case the parent is genuinely
+// dead and the existing confirmation watch will never fire for the
+// parent txid. The actor falls back to the standard
+// AwaitingConfirmation timeout / external spend detection paths to
+// notice this and surface TxFailed; treating the per-package error as
+// "parent already broadcast" simply means we don't collapse to Failed
+// on the package response itself.
+var parentLikelyConfirmedSentinels = []error{
+	rpcclient.ErrMissingInputsOrSpent,
+	rpcclient.ErrMissingInputs,
+}
+
 // isAnySentinel reports whether `err` matches any of `sentinels` via
 // `errors.Is`.
 func isAnySentinel(err error, sentinels []error) bool {
@@ -1528,13 +1548,17 @@ func isAnySentinel(err error, sentinels []error) bool {
 // unknown), which lets us classify with `errors.Is` instead of grepping
 // the raw reject string.
 //
-// We accept this state if either:
+// We accept this state if any of:
 //
 //  1. A `PackageTxError` whose `Txid` equals `parentTxid` unwraps to a
 //     parent-known sentinel AND any other entry unwraps to a
 //     child-failure sentinel; OR
 //
-//  2. (Fallback) no entry for `parentTxid` is present at all. Some
+//  2. A `PackageTxError` whose `Txid` equals `parentTxid` unwraps to a
+//     parent-likely-confirmed sentinel AND any other entry unwraps to a
+//     child-failure sentinel; OR
+//
+//  3. (Fallback) no entry for `parentTxid` is present at all. Some
 //     bitcoind versions silently accept the already-known parent and
 //     only echo the rejected child, so the parent's row disappears
 //     from `tx-results`. In that case any `*PackageTxError` whose
@@ -1547,26 +1571,32 @@ func isAnySentinel(err error, sentinels []error) bool {
 //
 // The fallback is gated on `!parentSeen` rather than firing whenever
 // the RBF marker shows up: if bitcoind echoed the parent with a fatal
-// (non-known) reason, the parent is genuinely broken and we must NOT
-// silently swallow that as "already broadcast".
+// (non-known) reason that is not in the likely-confirmed set, the parent is
+// genuinely broken and we must NOT silently swallow that as "already
+// broadcast".
 func isParentKnownChildFailed(parentTxid chainhash.Hash, err error) bool {
 	if err == nil {
 		return false
 	}
 
 	var (
-		parentSeen   bool
-		parentKnown  bool
-		childFailed  bool
-		rbfReplaceOk bool
+		parentSeen            bool
+		parentKnown           bool
+		parentLikelyConfirmed bool
+		childFailed           bool
+		rbfReplaceOk          bool
 	)
 
 	visit := func(pte *chainbackends.PackageTxError) {
 		switch {
 		case pte.Txid == parentTxid:
 			parentSeen = true
-			if isAnySentinel(pte, parentKnownSentinels) {
+			switch {
+			case isAnySentinel(pte, parentKnownSentinels):
 				parentKnown = true
+
+			case isAnySentinel(pte, parentLikelyConfirmedSentinels):
+				parentLikelyConfirmed = true
 			}
 
 		case isAnySentinel(pte, childFailureSentinels):
@@ -1580,6 +1610,10 @@ func isParentKnownChildFailed(parentTxid chainhash.Hash, err error) bool {
 	chainbackends.WalkPackageTxErrors(err, visit)
 
 	if parentKnown && childFailed {
+		return true
+	}
+
+	if parentLikelyConfirmed && childFailed {
 		return true
 	}
 

--- a/txconfirm/broadcaster_test.go
+++ b/txconfirm/broadcaster_test.go
@@ -599,6 +599,25 @@ func TestBroadcasterHelperFunctions(t *testing.T) {
 			))
 		require.False(t, isParentKnownChildFailed(parent, fatal))
 
+		// Deeply-confirmed parent: bitcoind has dropped the parent's
+		// txid from its recent-rejects / mempool cache, so the
+		// re-broadcast validates fresh and hits "inputs already spent".
+		// The confirmation watch handles the existing confirmation.
+		deeplyConfirmed := fmt.Errorf("submit package: package not "+
+			"accepted: %w", errors.Join(
+			chainbackends.NewPackageTxError(
+				"W1", parent,
+				"bad-txns-inputs-missingorspent",
+			),
+			chainbackends.NewPackageTxError(
+				"W2", child,
+				"bad-txns-inputs-missingorspent",
+			),
+		))
+		require.True(
+			t, isParentKnownChildFailed(parent, deeplyConfirmed),
+		)
+
 		// Parent's txid does not appear as a parent-known entry
 		// in the error, but RBF rejection still implies a
 		// competing tx is already in mempool — defer regardless.

--- a/unroll/actor.go
+++ b/unroll/actor.go
@@ -55,6 +55,12 @@ type Config struct {
 	// MaxSweepFeeRateSatPerVByte clamps pathological fee estimates.
 	MaxSweepFeeRateSatPerVByte int64
 
+	// FraudCheckpointSafetyMargin overrides the recipient backstop
+	// margin (in blocks) for fraud-triggered unroll jobs. Zero falls
+	// back to defaultFraudCheckpointSafetyMargin. Plumbed onto the
+	// FSM Environment.
+	FraudCheckpointSafetyMargin int32
+
 	// RegistryRef receives terminal notifications from this actor when set.
 	RegistryRef actor.TellOnlyRef[RegistryMsg]
 }
@@ -444,6 +450,63 @@ func (b *behavior) ensureNodeConfirmed(ctx context.Context, txid chainhash.Hash,
 	return nil
 }
 
+// watchDeferredCheckpoint registers a confirmation watch for a ready
+// fraud-triggered checkpoint while the actor waits for the operator to confirm
+// it first.
+func (b *behavior) watchDeferredCheckpoint(ctx context.Context,
+	txid chainhash.Hash, node *recovery.Node) error {
+
+	if node == nil {
+		return fmt.Errorf("proof node %s missing", txid)
+	}
+
+	pkScript, err := safeTxOutPkScript(node.Tx, 0)
+	if err != nil {
+		return fmt.Errorf("proof node %s: %w", txid, err)
+	}
+
+	notifyRef := chainsource.MapConfirmationEvent(
+		b.selfRef, func(event chainsource.ConfirmationEvent) Msg {
+			return &TxConfirmedMsg{
+				Txid:     event.Txid,
+				Height:   event.BlockHeight,
+				NumConfs: event.NumConfs,
+			}
+		},
+	)
+
+	state, err := b.currentState()
+	if err != nil {
+		return err
+	}
+
+	height := stateHeight(state)
+	if height < 0 {
+		height = 0
+	}
+
+	txidCopy := txid
+	_, err = b.cfg.ChainSource.Ask(ctx, &chainsource.RegisterConfRequest{
+		CallerID:    b.deferredCheckpointCallerID(),
+		Txid:        &txidCopy,
+		PkScript:    append([]byte(nil), pkScript...),
+		TargetConfs: 1,
+		HeightHint:  uint32(height),
+		NotifyActor: fn.Some(notifyRef),
+	}).Await(ctx).Unpack()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// deferredCheckpointCallerID returns the stable confirmation-watch caller ID
+// used for all deferred checkpoints in this actor.
+func (b *behavior) deferredCheckpointCallerID() string {
+	return b.cfg.ActorID + "-deferred-checkpoint"
+}
+
 // stateResponse builds the current state response for callers and tests.
 func (b *behavior) stateResponse() *GetStateResp {
 	state, err := b.currentState()
@@ -533,6 +596,7 @@ func (b *behavior) ensureLoaded(ctx context.Context) error {
 
 		session, err := NewSession(
 			ctx, b.proof, b.planner, initialState, b.log,
+			b.cfg.FraudCheckpointSafetyMargin,
 		)
 		if err != nil {
 			return err
@@ -974,6 +1038,23 @@ func (b *behavior) routeOutbox(ctx context.Context,
 				}
 			}
 
+		case *WatchDeferredCheckpoints:
+			for _, txid := range evt.Txids {
+				node, ok := b.proof.Node(txid)
+				if !ok {
+					return fmt.Errorf("proof node %s "+
+						"missing for deferred "+
+						"checkpoint watch", txid)
+				}
+
+				err := b.watchDeferredCheckpoint(
+					ctx, txid, node,
+				)
+				if err != nil {
+					return err
+				}
+			}
+
 		case *RequestSweepBuild:
 			if err := b.startSweep(ctx); err != nil {
 				return err
@@ -1167,6 +1248,16 @@ func copyPlannerState(state unrollplan.State) unrollplan.State {
 	return copyState
 }
 
+// copyDeferredCheckpoints deep-copies and sorts deferred checkpoint state.
+func copyDeferredCheckpoints(
+	checkpoints []DeferredCheckpoint) []DeferredCheckpoint {
+
+	copyCheckpoints := append([]DeferredCheckpoint(nil), checkpoints...)
+	sortDeferredCheckpoints(copyCheckpoints)
+
+	return copyCheckpoints
+}
+
 // copyTx deep-copies one transaction when present.
 func copyTx(tx *wire.MsgTx) *wire.MsgTx {
 	if tx == nil {
@@ -1174,6 +1265,54 @@ func copyTx(tx *wire.MsgTx) *wire.MsgTx {
 	}
 
 	return tx.Copy()
+}
+
+// removeDeferredCheckpoint removes one deferred checkpoint when present.
+func removeDeferredCheckpoint(checkpoints []DeferredCheckpoint,
+	txid chainhash.Hash) []DeferredCheckpoint {
+
+	result := make([]DeferredCheckpoint, 0, len(checkpoints))
+	for _, checkpoint := range checkpoints {
+		if checkpoint.Txid == txid {
+			continue
+		}
+
+		result = append(result, checkpoint)
+	}
+
+	return result
+}
+
+// findDeferredCheckpoint returns the deferred checkpoint for txid if present.
+func findDeferredCheckpoint(checkpoints []DeferredCheckpoint,
+	txid chainhash.Hash) (DeferredCheckpoint, bool) {
+
+	for _, checkpoint := range checkpoints {
+		if checkpoint.Txid == txid {
+			return checkpoint, true
+		}
+	}
+
+	return DeferredCheckpoint{}, false
+}
+
+// appendDeferredCheckpoint appends a deferred checkpoint when absent.
+func appendDeferredCheckpoint(checkpoints []DeferredCheckpoint,
+	checkpoint DeferredCheckpoint) []DeferredCheckpoint {
+
+	if _, ok := findDeferredCheckpoint(checkpoints, checkpoint.Txid); ok {
+		return copyDeferredCheckpoints(checkpoints)
+	}
+
+	checkpoints = append(
+		append(
+			[]DeferredCheckpoint(nil), checkpoints...,
+		),
+		checkpoint,
+	)
+	sortDeferredCheckpoints(checkpoints)
+
+	return checkpoints
 }
 
 // removeHash removes one hash when present.
@@ -1205,6 +1344,22 @@ func containsHash(hashes []chainhash.Hash, hash chainhash.Hash) bool {
 func sortHashes(hashes []chainhash.Hash) {
 	sort.Slice(hashes, func(i, j int) bool {
 		return hashes[i].String() < hashes[j].String()
+	})
+}
+
+// sortDeferredCheckpoints sorts deferred checkpoints deterministically.
+func sortDeferredCheckpoints(checkpoints []DeferredCheckpoint) {
+	sort.Slice(checkpoints, func(i, j int) bool {
+		iDeadline := checkpoints[i].DeadlineHeight
+		jDeadline := checkpoints[j].DeadlineHeight
+		if iDeadline != jDeadline {
+			return iDeadline < jDeadline
+		}
+
+		iTxid := checkpoints[i].Txid.String()
+		jTxid := checkpoints[j].Txid.String()
+
+		return iTxid < jTxid
 	})
 }
 

--- a/unroll/actor_test.go
+++ b/unroll/actor_test.go
@@ -304,6 +304,27 @@ func (f *fakeTxConfirmRef) emitConfirmed(t *testing.T, index int,
 	require.NoError(t, err)
 }
 
+// emitConfirmedByTxid delivers a txconfirm success notification for the first
+// request matching txid.
+func (f *fakeTxConfirmRef) emitConfirmedByTxid(t *testing.T,
+	txid chainhash.Hash, height int32) {
+
+	t.Helper()
+
+	f.mu.Lock()
+	index := -1
+	for i, req := range f.requests {
+		if req.Tx.TxHash() == txid {
+			index = i
+			break
+		}
+	}
+	f.mu.Unlock()
+
+	require.NotEqual(t, -1, index)
+	f.emitConfirmed(t, index, txid, height)
+}
+
 // emitFailed delivers a txconfirm failure notification to the subscriber.
 func (f *fakeTxConfirmRef) emitFailed(t *testing.T, index int,
 	txid chainhash.Hash, reason string) {
@@ -322,6 +343,9 @@ func (f *fakeTxConfirmRef) emitFailed(t *testing.T, index int,
 	require.NoError(t, err)
 }
 
+// confRef aliases the chainsource confirmation notification target.
+type confRef = actor.TellOnlyRef[chainsource.ConfirmationEvent]
+
 // fakeChainSourceRef is a minimal chainsource actor ref for sweep fee
 // estimation tests.
 type fakeChainSourceRef struct {
@@ -331,6 +355,7 @@ type fakeChainSourceRef struct {
 	feeErr     error
 	blockRef   actor.TellOnlyRef[chainsource.BlockEpoch]
 	spendRef   actor.TellOnlyRef[chainsource.SpendEvent]
+	confRefs   map[chainhash.Hash]confRef
 }
 
 // ID returns the fake actor ID.
@@ -347,6 +372,9 @@ func (f *fakeChainSourceRef) Tell(_ context.Context,
 		return nil
 
 	case *chainsource.UnregisterSpendRequest:
+		return nil
+
+	case *chainsource.UnregisterConfRequest:
 		return nil
 	}
 
@@ -418,6 +446,30 @@ func (f *fakeChainSourceRef) Ask(_ context.Context,
 			),
 		)
 
+	case *chainsource.RegisterConfRequest:
+		if msg.Txid == nil {
+			promise.Complete(
+				fn.Err[chainsource.ChainSourceResp](
+					fmt.Errorf("register conf txid " +
+						"required"),
+				),
+			)
+
+			return promise.Future()
+		}
+
+		f.mu.Lock()
+		if f.confRefs == nil {
+			f.confRefs = make(map[chainhash.Hash]confRef)
+		}
+		f.confRefs[*msg.Txid] = msg.NotifyActor.UnwrapOr(nil)
+		f.mu.Unlock()
+		promise.Complete(
+			fn.Ok[chainsource.ChainSourceResp](
+				&chainsource.RegisterConfResponse{},
+			),
+		)
+
 	default:
 		promise.Complete(
 			fn.Err[chainsource.ChainSourceResp](
@@ -428,6 +480,37 @@ func (f *fakeChainSourceRef) Ask(_ context.Context,
 	}
 
 	return promise.Future()
+}
+
+// confWatchCount returns the number of registered confirmation watches.
+func (f *fakeChainSourceRef) confWatchCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return len(f.confRefs)
+}
+
+// emitConfirmed delivers one chainsource confirmation event to a watcher.
+func (f *fakeChainSourceRef) emitConfirmed(t *testing.T, txid chainhash.Hash,
+	height int32) {
+
+	t.Helper()
+
+	f.mu.Lock()
+	ref := f.confRefs[txid]
+	f.mu.Unlock()
+
+	require.NotNil(t, ref)
+	require.NoError(
+		t,
+		ref.Tell(
+			t.Context(), chainsource.ConfirmationEvent{
+				Txid:        txid,
+				BlockHeight: height,
+				NumConfs:    1,
+			},
+		),
+	)
 }
 
 // emitSpend delivers one spend event for the target outpoint to the subscribed
@@ -873,6 +956,118 @@ func buildLinearProof(t *testing.T) *recovery.Proof {
 	return proof
 }
 
+// buildOORProof creates a checkpoint->ark proof.
+func buildOORProof(t *testing.T) *recovery.Proof {
+	t.Helper()
+
+	checkpointTx := wire.NewMsgTx(2)
+	checkpointTx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{
+			Hash:  chainhash.Hash{1},
+			Index: 0,
+		},
+	})
+	checkpointTx.AddTxOut(&wire.TxOut{
+		Value:    70_000,
+		PkScript: []byte{txscript.OP_TRUE},
+	})
+
+	arkTx := wire.NewMsgTx(2)
+	arkTx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{
+			Hash:  checkpointTx.TxHash(),
+			Index: 0,
+		},
+	})
+	arkTx.AddTxOut(&wire.TxOut{
+		Value:    50_000,
+		PkScript: []byte{txscript.OP_TRUE},
+	})
+
+	proof, err := recovery.NewProof(
+		wire.OutPoint{Hash: arkTx.TxHash(), Index: 0},
+		144,
+		&recovery.Node{
+			Kind: recovery.NodeKindCheckpoint,
+			Tx:   checkpointTx,
+		},
+		&recovery.Node{
+			Kind: recovery.NodeKindArk,
+			Tx:   arkTx,
+		},
+	)
+	require.NoError(t, err)
+
+	return proof
+}
+
+// buildSharedArkOORProof creates two checkpoint roots feeding one ark target.
+func buildSharedArkOORProof(t *testing.T) *recovery.Proof {
+	t.Helper()
+
+	leftCheckpoint := wire.NewMsgTx(2)
+	leftCheckpoint.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{
+			Hash:  chainhash.Hash{1},
+			Index: 0,
+		},
+	})
+	leftCheckpoint.AddTxOut(&wire.TxOut{
+		Value:    40_000,
+		PkScript: []byte{txscript.OP_TRUE},
+	})
+
+	rightCheckpoint := wire.NewMsgTx(2)
+	rightCheckpoint.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{
+			Hash:  chainhash.Hash{2},
+			Index: 0,
+		},
+	})
+	rightCheckpoint.AddTxOut(&wire.TxOut{
+		Value:    45_000,
+		PkScript: []byte{txscript.OP_TRUE},
+	})
+
+	arkTx := wire.NewMsgTx(2)
+	arkTx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{
+			Hash:  leftCheckpoint.TxHash(),
+			Index: 0,
+		},
+	})
+	arkTx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{
+			Hash:  rightCheckpoint.TxHash(),
+			Index: 0,
+		},
+	})
+	arkTx.AddTxOut(&wire.TxOut{
+		Value:    70_000,
+		PkScript: []byte{txscript.OP_TRUE},
+	})
+
+	proof, err := recovery.NewProof(
+		wire.OutPoint{Hash: arkTx.TxHash(), Index: 0},
+		144,
+		&recovery.Node{
+			Kind: recovery.NodeKindCheckpoint,
+			Tx:   leftCheckpoint,
+		},
+		&recovery.Node{
+			Kind: recovery.NodeKindCheckpoint,
+			Tx:   rightCheckpoint,
+		},
+		&recovery.Node{
+			Kind: recovery.NodeKindArk,
+			Tx:   arkTx,
+		},
+	)
+	require.NoError(t, err)
+
+	return proof
+}
+
 // buildMergeProof creates a two-root proof whose target depends on both
 // ancestors.
 func buildMergeProof(t *testing.T) *recovery.Proof {
@@ -978,6 +1173,337 @@ func TestStartUnrollSubmitsInitialFrontier(t *testing.T) {
 	checkpoint, err := store.LoadCheckpoint(t.Context(), "unroll-test")
 	require.NoError(t, err)
 	require.NotNil(t, checkpoint)
+}
+
+// TestFraudTriggerDefersReadyCheckpoint verifies fraud-triggered recovery
+// watches a ready checkpoint before asking txconfirm to broadcast it.
+func TestFraudTriggerDefersReadyCheckpoint(t *testing.T) {
+	proof := buildOORProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	unrollActor, behavior, txconfirmRef, store := newActorHarness(
+		t, proof, desc,
+	)
+	chainRef, ok := behavior.cfg.ChainSource.(*fakeChainSourceRef)
+	require.True(t, ok)
+
+	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
+		Height:  100,
+		Trigger: TriggerFraudSpend,
+	})
+
+	require.Equal(t, 0, txconfirmRef.requestCount())
+	require.Equal(t, 1, chainRef.confWatchCount())
+
+	checkpoint := mustDecodeCheckpoint(t, store, "unroll-test")
+	require.Len(t, checkpoint.DeferredCheckpoints, 1)
+	require.Equal(
+		t, proof.RootTxids()[0], checkpoint.DeferredCheckpoints[0].Txid,
+	)
+	require.Equal(
+		t, int32(220), checkpoint.DeferredCheckpoints[0].DeadlineHeight,
+	)
+
+	mustAsk(t, unrollActor.Ref(), &HeightObservedMsg{Height: 219})
+	require.Equal(t, 0, txconfirmRef.requestCount())
+
+	mustAsk(t, unrollActor.Ref(), &HeightObservedMsg{Height: 220})
+	require.Eventually(t, func() bool {
+		return txconfirmRef.requestCount() >= 1
+	}, testTimeout, 10*time.Millisecond)
+	require.Equal(
+		t, proof.RootTxids()[0],
+		txconfirmRef.lastRequest(t).Tx.TxHash(),
+	)
+
+	checkpoint = mustDecodeCheckpoint(t, store, "unroll-test")
+	require.Len(t, checkpoint.DeferredCheckpoints, 0)
+	require.Equal(
+		t, []chainhash.Hash{proof.RootTxids()[0]},
+		checkpoint.State.InFlightTxids,
+	)
+}
+
+// TestFraudTriggerOperatorConfirmedCheckpointUnlocksArk verifies an operator
+// confirmation during the deferral window advances recovery without recipient
+// checkpoint broadcast.
+func TestFraudTriggerOperatorConfirmedCheckpointUnlocksArk(t *testing.T) {
+	proof := buildOORProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	unrollActor, behavior, txconfirmRef, _ := newActorHarness(
+		t, proof, desc,
+	)
+	chainRef, ok := behavior.cfg.ChainSource.(*fakeChainSourceRef)
+	require.True(t, ok)
+
+	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
+		Height:  100,
+		Trigger: TriggerFraudSpend,
+	})
+	require.Equal(t, 0, txconfirmRef.requestCount())
+
+	chainRef.emitConfirmed(t, proof.RootTxids()[0], 105)
+	require.Eventually(t, func() bool {
+		return txconfirmRef.requestCount() >= 1
+	}, testTimeout, 10*time.Millisecond)
+	require.Equal(
+		t, proof.TargetOutpoint().Hash,
+		txconfirmRef.lastRequest(t).Tx.TxHash(),
+	)
+}
+
+// TestFraudTriggerSharedArkWaitsForAllCheckpoints verifies a fraud-triggered
+// shared ark is not broadcast until every checkpoint input is confirmed.
+func TestFraudTriggerSharedArkWaitsForAllCheckpoints(t *testing.T) {
+	proof := buildSharedArkOORProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	unrollActor, behavior, txconfirmRef, _ := newActorHarness(
+		t, proof, desc,
+	)
+	chainRef, ok := behavior.cfg.ChainSource.(*fakeChainSourceRef)
+	require.True(t, ok)
+
+	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
+		Height:  100,
+		Trigger: TriggerFraudSpend,
+	})
+
+	require.Eventually(t, func() bool {
+		return chainRef.confWatchCount() == 2
+	}, testTimeout, 10*time.Millisecond)
+	require.Equal(t, 0, txconfirmRef.requestCount())
+
+	rootTxids := proof.RootTxids()
+	chainRef.emitConfirmed(t, rootTxids[0], 105)
+	time.Sleep(25 * time.Millisecond)
+	require.Equal(
+		t, 0,
+		txconfirmRef.requestCountForTxid(proof.TargetOutpoint().Hash),
+	)
+
+	chainRef.emitConfirmed(t, rootTxids[1], 106)
+	require.Eventually(t, func() bool {
+		return txconfirmRef.requestCountForTxid(
+			proof.TargetOutpoint().Hash,
+		) == 1
+	}, testTimeout, 10*time.Millisecond)
+	require.Equal(t, 1, txconfirmRef.requestCount())
+}
+
+// TestFraudTriggerSharedCheckpointsBroadcastOnceAtDeadline verifies multiple
+// deferred checkpoint roots are each broadcast once at their recipient
+// deadline, and the shared ark still waits for both confirmations.
+func TestFraudTriggerSharedCheckpointsBroadcastOnceAtDeadline(t *testing.T) {
+	proof := buildSharedArkOORProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	unrollActor, _, txconfirmRef, store := newActorHarness(t, proof, desc)
+
+	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
+		Height:  100,
+		Trigger: TriggerFraudSpend,
+	})
+	require.Equal(t, 0, txconfirmRef.requestCount())
+
+	mustAsk(t, unrollActor.Ref(), &HeightObservedMsg{Height: 220})
+	rootTxids := proof.RootTxids()
+	require.Eventually(t, func() bool {
+		return txconfirmRef.requestCountForTxid(rootTxids[0]) == 1 &&
+			txconfirmRef.requestCountForTxid(rootTxids[1]) == 1
+	}, testTimeout, 10*time.Millisecond)
+	require.Equal(t, 2, txconfirmRef.requestCount())
+	checkpoint := mustDecodeCheckpoint(t, store, "unroll-test")
+	require.ElementsMatch(t, rootTxids, checkpoint.State.InFlightTxids)
+
+	mustAsk(t, unrollActor.Ref(), &HeightObservedMsg{Height: 221})
+	time.Sleep(25 * time.Millisecond)
+	require.Equal(t, 1, txconfirmRef.requestCountForTxid(rootTxids[0]))
+	require.Equal(t, 1, txconfirmRef.requestCountForTxid(rootTxids[1]))
+
+	txconfirmRef.emitConfirmedByTxid(t, rootTxids[0], 221)
+	time.Sleep(25 * time.Millisecond)
+	require.Equal(
+		t, 0,
+		txconfirmRef.requestCountForTxid(proof.TargetOutpoint().Hash),
+	)
+
+	txconfirmRef.emitConfirmedByTxid(t, rootTxids[1], 222)
+	require.Eventually(t, func() bool {
+		return txconfirmRef.requestCountForTxid(
+			proof.TargetOutpoint().Hash,
+		) == 1
+	}, testTimeout, 10*time.Millisecond)
+	checkpoint = mustDecodeCheckpoint(t, store, "unroll-test")
+	require.Contains(
+		t, checkpoint.State.InFlightTxids, proof.TargetOutpoint().Hash,
+	)
+}
+
+// TestResumeReissuesDeferredCheckpointWatch verifies restart restores
+// deferred fraud-triggered checkpoint watches without broadcasting early.
+func TestResumeReissuesDeferredCheckpointWatch(t *testing.T) {
+	proof := buildOORProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	store := newMemCheckpointStore()
+	txconfirmRef := &fakeTxConfirmRef{}
+	chainRef := &fakeChainSourceRef{}
+	rootTxid := proof.RootTxids()[0]
+
+	raw, err := encodeCheckpoint(&actorCheckpoint{
+		Version: checkpointVersion,
+		Height:  110,
+		Started: true,
+		Trigger: TriggerFraudSpend,
+		State:   unrollplan.State{},
+		DeferredCheckpoints: []DeferredCheckpoint{{
+			Txid:           rootTxid,
+			DeadlineHeight: 220,
+		}},
+	})
+	require.NoError(t, err)
+
+	err = store.SaveCheckpoint(t.Context(), actor.CheckpointParams{
+		ActorID:   "resume-deferred-test",
+		StateType: checkpointStateType,
+		StateData: raw,
+		Version:   checkpointVersion,
+	})
+	require.NoError(t, err)
+
+	cfg := Config{
+		TargetOutpoint: proof.TargetOutpoint(),
+		ActorID:        "resume-deferred-test",
+		DeliveryStore:  store,
+		ProofAssembler: &mockProofAssembler{
+			proof: proof,
+		},
+		VTXOStore: &mockVTXOStore{
+			desc: desc,
+		},
+		TxConfirmRef: txconfirmRef,
+		ChainSource:  chainRef,
+		Wallet:       &fakeSweepWallet{},
+		Log:          fn.Some(btclog.Disabled),
+	}
+	resumeBehavior := &behavior{
+		cfg: cfg,
+		log: btclog.Disabled,
+	}
+	err = resumeBehavior.restoreCheckpoint(t.Context())
+	require.NoError(t, err)
+
+	resumedActor := actor.NewActor(actor.ActorConfig[Msg, Resp]{
+		ID:          "resume-deferred-test",
+		Behavior:    resumeBehavior,
+		MailboxSize: 64,
+	})
+	resumeBehavior.selfRef = resumedActor.TellRef()
+	resumedActor.Start()
+	t.Cleanup(resumedActor.Stop)
+
+	mustAsk(t, resumedActor.Ref(), &ResumeUnrollRequest{Height: 111})
+	require.Eventually(t, func() bool {
+		return chainRef.confWatchCount() == 1
+	}, testTimeout, 10*time.Millisecond)
+	require.Equal(t, 0, txconfirmRef.requestCount())
+
+	mustAsk(t, resumedActor.Ref(), &HeightObservedMsg{Height: 219})
+	time.Sleep(25 * time.Millisecond)
+	require.Equal(t, 0, txconfirmRef.requestCount())
+
+	mustAsk(t, resumedActor.Ref(), &HeightObservedMsg{Height: 220})
+	require.Eventually(t, func() bool {
+		return txconfirmRef.requestCountForTxid(rootTxid) == 1
+	}, testTimeout, 10*time.Millisecond)
+}
+
+// TestResumeReissuesInFlightArk verifies a fraud-triggered restart reattaches
+// to an ark transaction that had already been submitted before shutdown.
+func TestResumeReissuesInFlightArk(t *testing.T) {
+	proof := buildOORProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	store := newMemCheckpointStore()
+	txconfirmRef := &fakeTxConfirmRef{}
+	rootTxid := proof.RootTxids()[0]
+	arkTxid := proof.TargetOutpoint().Hash
+
+	raw, err := encodeCheckpoint(&actorCheckpoint{
+		Version: checkpointVersion,
+		Height:  112,
+		Started: true,
+		Trigger: TriggerFraudSpend,
+		State: unrollplan.State{
+			ConfirmedTxids: []chainhash.Hash{rootTxid},
+			InFlightTxids:  []chainhash.Hash{arkTxid},
+		},
+	})
+	require.NoError(t, err)
+
+	err = store.SaveCheckpoint(t.Context(), actor.CheckpointParams{
+		ActorID:   "resume-ark-test",
+		StateType: checkpointStateType,
+		StateData: raw,
+		Version:   checkpointVersion,
+	})
+	require.NoError(t, err)
+
+	cfg := Config{
+		TargetOutpoint: proof.TargetOutpoint(),
+		ActorID:        "resume-ark-test",
+		DeliveryStore:  store,
+		ProofAssembler: &mockProofAssembler{
+			proof: proof,
+		},
+		VTXOStore: &mockVTXOStore{
+			desc: desc,
+		},
+		TxConfirmRef: txconfirmRef,
+		ChainSource:  &fakeChainSourceRef{},
+		Wallet:       &fakeSweepWallet{},
+		Log:          fn.Some(btclog.Disabled),
+	}
+	resumeBehavior := &behavior{
+		cfg: cfg,
+		log: btclog.Disabled,
+	}
+	err = resumeBehavior.restoreCheckpoint(t.Context())
+	require.NoError(t, err)
+
+	resumedActor := actor.NewActor(actor.ActorConfig[Msg, Resp]{
+		ID:          "resume-ark-test",
+		Behavior:    resumeBehavior,
+		MailboxSize: 64,
+	})
+	resumeBehavior.selfRef = resumedActor.TellRef()
+	resumedActor.Start()
+	t.Cleanup(resumedActor.Stop)
+
+	mustAsk(t, resumedActor.Ref(), &ResumeUnrollRequest{Height: 113})
+	require.Eventually(t, func() bool {
+		return txconfirmRef.requestCountForTxid(arkTxid) == 1
+	}, testTimeout, 10*time.Millisecond)
+}
+
+// TestManualTriggerSubmitsReadyCheckpointImmediately verifies the deferral
+// policy is limited to fraud-triggered recovery.
+func TestManualTriggerSubmitsReadyCheckpointImmediately(t *testing.T) {
+	proof := buildOORProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	unrollActor, behavior, txconfirmRef, _ := newActorHarness(
+		t, proof, desc,
+	)
+	chainRef, ok := behavior.cfg.ChainSource.(*fakeChainSourceRef)
+	require.True(t, ok)
+
+	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
+		Height:  100,
+		Trigger: TriggerManual,
+	})
+
+	require.Equal(t, 1, txconfirmRef.requestCount())
+	require.Equal(t, 0, chainRef.confWatchCount())
+	require.Equal(
+		t, proof.RootTxids()[0],
+		txconfirmRef.lastRequest(t).Tx.TxHash(),
+	)
 }
 
 // TestConfirmedNodesAdvanceToSweep verifies that node confirmations move the

--- a/unroll/deferred_checkpoint_codec.go
+++ b/unroll/deferred_checkpoint_codec.go
@@ -1,0 +1,181 @@
+package unroll
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+// TLV record types for a single DeferredCheckpoint entry. Odd values
+// per the Lightning convention: unknown odd records are optional and
+// must be skipped by older decoders, so additive fields stay
+// backward-compatible.
+const (
+	deferredCheckpointTxidRecordType     tlv.Type = 1
+	deferredCheckpointDeadlineRecordType tlv.Type = 3
+)
+
+// encodeDeferredCheckpoints serializes deferred checkpoint state as a
+// varint count followed by per-entry varint-length-prefixed TLV streams,
+// each carrying the entry's fields as primitive TLV records. Per-entry
+// TLV framing keeps the encoding forward-compatible: adding a new field
+// to DeferredCheckpoint only requires a new odd TLV type; older
+// decoders skip it.
+func encodeDeferredCheckpoints(checkpoints []DeferredCheckpoint) ([]byte,
+	error) {
+
+	sorted := copyDeferredCheckpoints(checkpoints)
+
+	var (
+		buf     bytes.Buffer
+		scratch [8]byte
+	)
+
+	err := tlv.WriteVarInt(&buf, uint64(len(sorted)), &scratch)
+	if err != nil {
+		return nil, fmt.Errorf("write deferred checkpoint count: %w",
+			err)
+	}
+
+	for i := range sorted {
+		entryBytes, err := encodeDeferredCheckpointEntry(&sorted[i])
+		if err != nil {
+			return nil, fmt.Errorf("encode deferred checkpoint "+
+				"%d: %w", i, err)
+		}
+
+		err = tlv.WriteVarInt(
+			&buf,
+			uint64(
+				len(entryBytes),
+			),
+			&scratch,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("write deferred checkpoint %d "+
+				"length: %w", i, err)
+		}
+
+		if _, err := buf.Write(entryBytes); err != nil {
+			return nil, fmt.Errorf("write deferred checkpoint %d "+
+				"body: %w", i, err)
+		}
+	}
+
+	return buf.Bytes(), nil
+}
+
+// encodeDeferredCheckpointEntry encodes one DeferredCheckpoint as a TLV
+// stream of primitive records.
+func encodeDeferredCheckpointEntry(c *DeferredCheckpoint) ([]byte, error) {
+	txidBytes := c.Txid[:]
+	deadline := uint32(c.DeadlineHeight)
+
+	stream, err := tlv.NewStream(
+		tlv.MakePrimitiveRecord(
+			deferredCheckpointTxidRecordType, &txidBytes,
+		),
+		tlv.MakePrimitiveRecord(
+			deferredCheckpointDeadlineRecordType, &deadline,
+		),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("new entry stream: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := stream.Encode(&buf); err != nil {
+		return nil, fmt.Errorf("encode entry stream: %w", err)
+	}
+
+	return buf.Bytes(), nil
+}
+
+// decodeDeferredCheckpoints parses deferred checkpoint state encoded by
+// encodeDeferredCheckpoints.
+func decodeDeferredCheckpoints(raw []byte) ([]DeferredCheckpoint, error) {
+	var (
+		reader  = bytes.NewReader(raw)
+		scratch [8]byte
+	)
+
+	count, err := tlv.ReadVarInt(reader, &scratch)
+	if err != nil {
+		return nil, fmt.Errorf("read deferred checkpoint count: %w",
+			err)
+	}
+
+	checkpoints := make([]DeferredCheckpoint, 0, count)
+	for i := uint64(0); i < count; i++ {
+		entryLen, err := tlv.ReadVarInt(reader, &scratch)
+		if err != nil {
+			return nil, fmt.Errorf("read deferred checkpoint %d "+
+				"length: %w", i, err)
+		}
+
+		entry := make([]byte, entryLen)
+		if _, err := reader.Read(entry); err != nil {
+			return nil, fmt.Errorf("read deferred checkpoint %d "+
+				"body: %w", i, err)
+		}
+
+		decoded, err := decodeDeferredCheckpointEntry(entry)
+		if err != nil {
+			return nil, fmt.Errorf("decode deferred checkpoint "+
+				"%d: %w", i, err)
+		}
+
+		checkpoints = append(checkpoints, decoded)
+	}
+
+	if reader.Len() != 0 {
+		return nil, fmt.Errorf("deferred checkpoints trailing %d bytes",
+			reader.Len())
+	}
+
+	return copyDeferredCheckpoints(checkpoints), nil
+}
+
+// decodeDeferredCheckpointEntry decodes one DeferredCheckpoint from its
+// per-entry TLV stream. Unknown odd TLV types are skipped silently for
+// forward-compatibility.
+func decodeDeferredCheckpointEntry(raw []byte) (DeferredCheckpoint, error) {
+	var (
+		txidBytes []byte
+		deadline  uint32
+	)
+
+	stream, err := tlv.NewStream(
+		tlv.MakePrimitiveRecord(
+			deferredCheckpointTxidRecordType, &txidBytes,
+		),
+		tlv.MakePrimitiveRecord(
+			deferredCheckpointDeadlineRecordType, &deadline,
+		),
+	)
+	if err != nil {
+		return DeferredCheckpoint{}, fmt.Errorf("new entry stream: %w",
+			err)
+	}
+
+	if err := stream.Decode(bytes.NewReader(raw)); err != nil {
+		return DeferredCheckpoint{}, fmt.Errorf("decode entry "+
+			"stream: %w", err)
+	}
+
+	if len(txidBytes) != chainhash.HashSize {
+		return DeferredCheckpoint{}, fmt.Errorf("deferred checkpoint "+
+			"txid has %d bytes, expected %d", len(txidBytes),
+			chainhash.HashSize)
+	}
+
+	var txid chainhash.Hash
+	copy(txid[:], txidBytes)
+
+	return DeferredCheckpoint{
+		Txid:           txid,
+		DeadlineHeight: int32(deadline),
+	}, nil
+}

--- a/unroll/deferred_checkpoint_codec_test.go
+++ b/unroll/deferred_checkpoint_codec_test.go
@@ -1,0 +1,198 @@
+package unroll
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightningnetwork/lnd/tlv"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDeferredCheckpointCodecRoundTrip verifies the encoder and decoder
+// are inverses across the empty case, the canonical sort order, and a
+// representative mix of txids and deadlines.
+func TestDeferredCheckpointCodecRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   []DeferredCheckpoint
+	}{
+		{
+			name: "empty",
+			in:   nil,
+		},
+		{
+			name: "single",
+			in: []DeferredCheckpoint{
+				{
+					Txid: chainhash.Hash{
+						0xaa,
+					},
+					DeadlineHeight: 100,
+				},
+			},
+		},
+		{
+			name: "multiple sorted by encoder",
+			in: []DeferredCheckpoint{
+				{
+					Txid: chainhash.Hash{
+						0xcc,
+					},
+					DeadlineHeight: 220,
+				},
+				{
+					Txid: chainhash.Hash{
+						0xaa,
+					},
+					DeadlineHeight: 100,
+				},
+				{
+					Txid: chainhash.Hash{
+						0xbb,
+					},
+					DeadlineHeight: 200,
+				},
+			},
+		},
+		{
+			name: "negative deadline survives uint32 round-trip",
+			in: []DeferredCheckpoint{
+				{
+					Txid: chainhash.Hash{
+						0xff,
+					},
+					DeadlineHeight: -1,
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			encoded, err := encodeDeferredCheckpoints(tc.in)
+			require.NoError(t, err)
+
+			got, err := decodeDeferredCheckpoints(encoded)
+			require.NoError(t, err)
+
+			// Encoder applies canonical sort; compare against the
+			// expected sorted form so the test does not depend on
+			// input order.
+			require.Equal(t, copyDeferredCheckpoints(tc.in), got)
+		})
+	}
+}
+
+// TestDeferredCheckpointCodecForwardCompat verifies that a per-entry TLV
+// stream carrying an unknown odd TLV record decodes cleanly. This is
+// the load-bearing forward-compat guarantee that Roasbeef asked for: a
+// future client can add an extra field (odd type) and older clients
+// must skip it instead of failing the whole checkpoint decode.
+func TestDeferredCheckpointCodecForwardCompat(t *testing.T) {
+	t.Parallel()
+
+	original := DeferredCheckpoint{
+		Txid: chainhash.Hash{
+			0xab,
+			0xcd,
+		},
+		DeadlineHeight: 7,
+	}
+
+	// Splice an unknown odd-type TLV record into the per-entry stream.
+	// Layout: outer = varint(count=1) + varint(entryLen) + entry. We
+	// rebuild the buffer by re-encoding the entry with the extra
+	// record appended.
+	txidBytes := original.Txid[:]
+	deadline := uint32(original.DeadlineHeight)
+	extra := []byte{0xde, 0xad, 0xbe, 0xef}
+
+	const futureRecordType tlv.Type = 5
+
+	stream, err := tlv.NewStream(
+		tlv.MakePrimitiveRecord(
+			deferredCheckpointTxidRecordType, &txidBytes,
+		),
+		tlv.MakePrimitiveRecord(
+			deferredCheckpointDeadlineRecordType, &deadline,
+		),
+		tlv.MakePrimitiveRecord(futureRecordType, &extra),
+	)
+	require.NoError(t, err)
+
+	var entry bytes.Buffer
+	require.NoError(t, stream.Encode(&entry))
+
+	var (
+		outer   bytes.Buffer
+		scratch [8]byte
+	)
+	require.NoError(t, tlv.WriteVarInt(&outer, 1, &scratch))
+	require.NoError(
+		t,
+		tlv.WriteVarInt(
+			&outer,
+			uint64(
+				entry.Len(),
+			),
+			&scratch,
+		),
+	)
+	_, err = outer.Write(entry.Bytes())
+	require.NoError(t, err)
+
+	// Older decoder (knows only txid + deadline) must still recover
+	// the entry; the unknown record is silently skipped because its
+	// TLV type is odd.
+	got, err := decodeDeferredCheckpoints(outer.Bytes())
+	require.NoError(t, err)
+	require.Equal(t, []DeferredCheckpoint{original}, got)
+}
+
+// TestDeferredCheckpointCodecRejectsShortTxid verifies the decoder
+// rejects an entry whose txid record is not exactly 32 bytes, instead
+// of silently producing a truncated or zero-padded chainhash.
+func TestDeferredCheckpointCodecRejectsShortTxid(t *testing.T) {
+	t.Parallel()
+
+	short := []byte{0x01, 0x02, 0x03}
+	deadline := uint32(42)
+
+	stream, err := tlv.NewStream(
+		tlv.MakePrimitiveRecord(
+			deferredCheckpointTxidRecordType, &short,
+		),
+		tlv.MakePrimitiveRecord(
+			deferredCheckpointDeadlineRecordType, &deadline,
+		),
+	)
+	require.NoError(t, err)
+
+	var entry bytes.Buffer
+	require.NoError(t, stream.Encode(&entry))
+
+	var (
+		outer   bytes.Buffer
+		scratch [8]byte
+	)
+	require.NoError(t, tlv.WriteVarInt(&outer, 1, &scratch))
+	require.NoError(
+		t,
+		tlv.WriteVarInt(
+			&outer,
+			uint64(
+				entry.Len(),
+			),
+			&scratch,
+		),
+	)
+	_, err = outer.Write(entry.Bytes())
+	require.NoError(t, err)
+
+	_, err = decodeDeferredCheckpoints(outer.Bytes())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "expected 32")
+}

--- a/unroll/fsm_logic.go
+++ b/unroll/fsm_logic.go
@@ -5,9 +5,26 @@ import (
 	"fmt"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightninglabs/darepo-client/lib/recovery"
 	"github.com/lightninglabs/darepo-client/unrollplan"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 )
+
+// defaultFraudCheckpointSafetyMargin is the number of blocks subtracted
+// from a checkpoint's relative-expiry window to compute the recipient
+// backstop deadline. The margin gives the operator (or a peer
+// fraud-triggered unroll) time to publish the checkpoint first; the
+// recipient only steps in when the deadline arrives without observed
+// confirmation. 24 blocks (~4h on mainnet) is a conservative budget
+// that survives mempool congestion, fee-rate spikes, and a slow
+// operator restart while still leaving useful slack before the CSV
+// matures.
+//
+// For chains with a very short csvDelay (e.g. itest with
+// VTXOExitDelay=16) checkpointBackstopHeight clamps the margin to
+// csvDelay/2 so the deadline does not fall before the current height.
+// See checkpointBackstopHeight for the clamp logic.
+const defaultFraudCheckpointSafetyMargin int32 = 24
 
 // processEventWithJob is the single-source-of-truth update function for
 // every non-Idle state. Each concrete FSM state (AwaitingMaterialization,
@@ -128,6 +145,23 @@ func deriveStateTransition(_ context.Context, job *JobState, env *Environment,
 			"populated")
 	}
 
+	// Reject a zero CSV delay under TriggerFraudSpend up front. The
+	// fraud trigger relies on a deferral window between checkpoint
+	// readiness and the recipient backstop deadline; with csvDelay=0
+	// checkpointBackstopHeight returns the current height and the
+	// recipient broadcasts the checkpoint immediately, defeating the
+	// deferral. This combination is almost certainly a
+	// misconfiguration; surface it loudly rather than silently
+	// submitting checkpoints without any deferral window.
+	if job.Trigger == TriggerFraudSpend && env.Proof.CSVDelay() == 0 {
+		return nil, fmt.Errorf("fraud-trigger unroll requires a " +
+			"non-zero CSV delay")
+	}
+
+	if err := validateDeferredCheckpoints(job, env); err != nil {
+		return nil, err
+	}
+
 	// Guard against checkpoint/proof drift: every txid recorded as
 	// confirmed or in-flight must resolve against the current proof
 	// graph. A mismatch means the checkpoint references a transaction
@@ -178,6 +212,14 @@ func deriveStateTransition(_ context.Context, job *JobState, env *Environment,
 			unrollplan.SweepStatusBroadcasted
 		if sweepBroadcasted {
 			outbox = append(outbox, &ReissueSweepConfirmation{})
+		}
+
+		if len(job.DeferredCheckpoints) > 0 {
+			outbox = append(outbox, &WatchDeferredCheckpoints{
+				Txids: deferredCheckpointTxids(
+					job.DeferredCheckpoints,
+				),
+			})
 		}
 	}
 
@@ -236,7 +278,14 @@ func deriveStateTransition(_ context.Context, job *JobState, env *Environment,
 		// runs do not try to resubmit (idempotent at the
 		// txconfirm layer either way, but a clean planner state
 		// is a nicer invariant to hold).
-		readyTxids := readyTxids(snapshot.Ready)
+		readyTxids, watchTxids := readyMaterializationTxids(
+			job, env, snapshot.Ready,
+		)
+		if len(watchTxids) > 0 {
+			outbox = append(outbox, &WatchDeferredCheckpoints{
+				Txids: watchTxids,
+			})
+		}
 		if len(readyTxids) > 0 {
 			job.PlannerState.InFlightTxids = appendUniqueSorted(
 				job.PlannerState.InFlightTxids, readyTxids...,
@@ -314,6 +363,9 @@ func applyConfirmedEvent(job *JobState, event *TxConfirmedEvent,
 	job.PlannerState.InFlightTxids = removeHash(
 		job.PlannerState.InFlightTxids, event.Txid,
 	)
+	job.DeferredCheckpoints = removeDeferredCheckpoint(
+		job.DeferredCheckpoints, event.Txid,
+	)
 
 	if env != nil && env.Proof != nil &&
 		event.Txid == env.Proof.TargetOutpoint().Hash &&
@@ -358,6 +410,9 @@ func applyFailedEvent(job *JobState, event *TxFailedEvent) {
 	// Proof-tx failure is always terminal.
 	job.PlannerState.InFlightTxids = removeHash(
 		job.PlannerState.InFlightTxids, event.Txid,
+	)
+	job.DeferredCheckpoints = removeDeferredCheckpoint(
+		job.DeferredCheckpoints, event.Txid,
 	)
 
 	job.FailReason = event.Reason
@@ -409,4 +464,151 @@ func readyTxids(frontier []unrollplan.TxFrontier) []chainhash.Hash {
 	sortHashes(txids)
 
 	return txids
+}
+
+// readyMaterializationTxids splits planner-ready proof nodes into transactions
+// to submit now and deferred checkpoint watches to register.
+func readyMaterializationTxids(job *JobState, env *Environment,
+	frontier []unrollplan.TxFrontier) ([]chainhash.Hash, []chainhash.Hash) {
+
+	if job == nil || env == nil || env.Proof == nil {
+		return readyTxids(frontier), nil
+	}
+
+	ready := make([]chainhash.Hash, 0, len(frontier))
+	watch := make([]chainhash.Hash, 0, len(frontier))
+	for i := range frontier {
+		item := frontier[i]
+		if shouldSubmitReadyFrontier(job, item) {
+			ready = append(ready, item.Txid)
+			continue
+		}
+
+		if _, ok := findDeferredCheckpoint(
+			job.DeferredCheckpoints, item.Txid,
+		); ok {
+
+			continue
+		}
+
+		deadline := checkpointBackstopHeight(
+			job.Height, env.Proof.CSVDelay(),
+			env.FraudCheckpointSafetyMargin,
+		)
+		if deadline <= job.Height {
+			ready = append(ready, item.Txid)
+			continue
+		}
+
+		job.DeferredCheckpoints = appendDeferredCheckpoint(
+			job.DeferredCheckpoints, DeferredCheckpoint{
+				Txid:           item.Txid,
+				DeadlineHeight: deadline,
+			},
+		)
+		watch = append(watch, item.Txid)
+	}
+
+	sortHashes(ready)
+	sortHashes(watch)
+
+	return ready, watch
+}
+
+// shouldSubmitReadyFrontier reports whether a planner-ready node should be
+// handed to txconfirm immediately.
+func shouldSubmitReadyFrontier(job *JobState, item unrollplan.TxFrontier) bool {
+	if job.Trigger != TriggerFraudSpend {
+		return true
+	}
+
+	if item.Node == nil || item.Node.Kind != recovery.NodeKindCheckpoint {
+		return true
+	}
+
+	deferred, ok := findDeferredCheckpoint(
+		job.DeferredCheckpoints, item.Txid,
+	)
+	if !ok {
+		return false
+	}
+
+	if job.Height < deferred.DeadlineHeight {
+		return false
+	}
+
+	job.DeferredCheckpoints = removeDeferredCheckpoint(
+		job.DeferredCheckpoints, item.Txid,
+	)
+
+	return true
+}
+
+// checkpointBackstopHeight returns the first height at which a fraud-triggered
+// unroll should broadcast a ready checkpoint itself. A non-positive
+// configuredMargin falls back to defaultFraudCheckpointSafetyMargin; the
+// effective margin is then clamped to csvDelay/2 if csvDelay is too small to
+// absorb it, so the deadline never falls before the current height.
+func checkpointBackstopHeight(height int32, csvDelay uint32,
+	configuredMargin int32) int32 {
+
+	margin := configuredMargin
+	if margin <= 0 {
+		margin = defaultFraudCheckpointSafetyMargin
+	}
+
+	delay := int32(csvDelay)
+	if delay <= margin {
+		margin = delay / 2
+	}
+
+	return height + delay - margin
+}
+
+// deferredCheckpointTxids projects deferred checkpoints into sorted txids.
+func deferredCheckpointTxids(
+	checkpoints []DeferredCheckpoint) []chainhash.Hash {
+
+	txids := make([]chainhash.Hash, 0, len(checkpoints))
+	for _, checkpoint := range checkpoints {
+		txids = append(txids, checkpoint.Txid)
+	}
+
+	sortHashes(txids)
+
+	return txids
+}
+
+// validateDeferredCheckpoints checks that every deferred checkpoint still
+// references a checkpoint node in the immutable proof graph.
+func validateDeferredCheckpoints(job *JobState, env *Environment) error {
+	seen := make(map[chainhash.Hash]struct{}, len(job.DeferredCheckpoints))
+	for _, checkpoint := range job.DeferredCheckpoints {
+		if _, ok := seen[checkpoint.Txid]; ok {
+			return fmt.Errorf("duplicate deferred checkpoint %s",
+				checkpoint.Txid)
+		}
+		seen[checkpoint.Txid] = struct{}{}
+
+		txid := checkpoint.Txid
+		node, ok := env.Proof.Node(txid)
+		if !ok {
+			return fmt.Errorf("deferred checkpoint %s is not "+
+				"in proof", txid)
+		}
+		if node.Kind != recovery.NodeKindCheckpoint {
+			return fmt.Errorf("deferred checkpoint %s has kind %s",
+				txid, node.Kind)
+		}
+		if containsHash(job.PlannerState.ConfirmedTxids, txid) {
+			return fmt.Errorf("deferred checkpoint %s is confirmed",
+				txid)
+		}
+		if containsHash(job.PlannerState.InFlightTxids, txid) {
+			return fmt.Errorf("deferred checkpoint %s is in-flight",
+				txid)
+		}
+	}
+
+	return nil
 }

--- a/unroll/fsm_types.go
+++ b/unroll/fsm_types.go
@@ -29,6 +29,19 @@ type Environment struct {
 
 	// Planner evaluates ready, blocked, CSV, and sweep progress.
 	Planner *unrollplan.Planner
+
+	// FraudCheckpointSafetyMargin is the number of blocks subtracted
+	// from a checkpoint's relative-expiry window to compute the
+	// recipient backstop deadline under TriggerFraudSpend. The
+	// margin gives the operator (or a peer fraud-triggered unroll)
+	// time to publish the checkpoint first; the recipient only steps
+	// in when the deadline arrives without observed confirmation.
+	//
+	// Zero falls back to defaultFraudCheckpointSafetyMargin.
+	// checkpointBackstopHeight clamps the effective margin to
+	// csvDelay/2 for chains with a very short CSV so the deadline
+	// does not fall before the current height.
+	FraudCheckpointSafetyMargin int32
 }
 
 // contextErrorReporter reports protofsm execution errors through the actor
@@ -72,6 +85,11 @@ type JobState struct {
 	// PlannerState is the durable caller-owned planning progress.
 	PlannerState unrollplan.State
 
+	// DeferredCheckpoints tracks fraud-triggered checkpoint
+	// transactions that are ready but intentionally not broadcast yet,
+	// giving the operator time to confirm them first.
+	DeferredCheckpoints []DeferredCheckpoint
+
 	// FailReason records a terminal failure reason, if any.
 	FailReason string
 
@@ -86,15 +104,28 @@ func (j *JobState) Copy() *JobState {
 		return nil
 	}
 
+	deferred := copyDeferredCheckpoints(j.DeferredCheckpoints)
 	copyState := &JobState{
-		Height:        j.Height,
-		Trigger:       j.Trigger,
-		PlannerState:  copyPlannerState(j.PlannerState),
-		FailReason:    j.FailReason,
-		SweepAttempts: j.SweepAttempts,
+		Height:              j.Height,
+		Trigger:             j.Trigger,
+		PlannerState:        copyPlannerState(j.PlannerState),
+		DeferredCheckpoints: deferred,
+		FailReason:          j.FailReason,
+		SweepAttempts:       j.SweepAttempts,
 	}
 
 	return copyState
+}
+
+// DeferredCheckpoint is a fraud-triggered checkpoint that is ready to be
+// materialized, but is held until DeadlineHeight unless it confirms first.
+type DeferredCheckpoint struct {
+	// Txid identifies the checkpoint transaction.
+	Txid chainhash.Hash
+
+	// DeadlineHeight is the first height at which the recipient should
+	// broadcast the checkpoint itself.
+	DeadlineHeight int32
 }
 
 // Event is the sealed input event surface accepted by the unroll FSM.
@@ -209,6 +240,16 @@ type ReissueInFlightTransactions struct {
 
 // outboxEventSealed marks ReissueInFlightTransactions as an outbox event.
 func (o *ReissueInFlightTransactions) outboxEventSealed() {}
+
+// WatchDeferredCheckpoints asks the actor boundary to watch deferred
+// checkpoints for operator confirmation while waiting for the backstop height.
+type WatchDeferredCheckpoints struct {
+	// Txids are the deferred checkpoint txids to watch.
+	Txids []chainhash.Hash
+}
+
+// outboxEventSealed marks WatchDeferredCheckpoints as an outbox event.
+func (o *WatchDeferredCheckpoints) outboxEventSealed() {}
 
 // RequestSweepBuild asks the actor boundary to build and submit the final
 // timeout sweep.

--- a/unroll/registry.go
+++ b/unroll/registry.go
@@ -110,6 +110,16 @@ type RegistryConfig struct {
 
 	// MaxSweepFeeRateSatPerVByte clamps pathological fee estimates.
 	MaxSweepFeeRateSatPerVByte int64
+
+	// FraudCheckpointSafetyMargin overrides the default backstop
+	// margin (in blocks) the recipient subtracts from the relative
+	// expiry when deciding to self-broadcast a fraud-triggered
+	// checkpoint. Zero applies defaultFraudCheckpointSafetyMargin;
+	// the effective margin is always clamped to csvDelay/2 when
+	// csvDelay is too small to absorb the configured value. Plumbed
+	// into every spawned VTXOUnrollActor and from there into the
+	// FSM Environment.
+	FraudCheckpointSafetyMargin int32
 }
 
 // UnrollRegistryActor wraps the thin unroll registry actor.
@@ -898,16 +908,17 @@ func (r *registryBehavior) spawn(ctx context.Context, target wire.OutPoint) (
 
 	//nolint:contextcheck // child actor owns its own durable lifecycle
 	return NewVTXOUnrollActor(Config{
-		TargetOutpoint:             target,
-		DeliveryStore:              r.cfg.DeliveryStore,
-		ProofAssembler:             r.cfg.ProofAssembler,
-		VTXOStore:                  r.cfg.VTXOStore,
-		TxConfirmRef:               r.cfg.TxConfirmRef,
-		ChainSource:                r.cfg.ChainSource,
-		Wallet:                     r.cfg.Wallet,
-		Log:                        r.cfg.Log,
-		MaxSweepFeeRateSatPerVByte: r.cfg.MaxSweepFeeRateSatPerVByte,
-		RegistryRef:                r.selfRef,
+		TargetOutpoint:              target,
+		DeliveryStore:               r.cfg.DeliveryStore,
+		ProofAssembler:              r.cfg.ProofAssembler,
+		VTXOStore:                   r.cfg.VTXOStore,
+		TxConfirmRef:                r.cfg.TxConfirmRef,
+		ChainSource:                 r.cfg.ChainSource,
+		Wallet:                      r.cfg.Wallet,
+		Log:                         r.cfg.Log,
+		MaxSweepFeeRateSatPerVByte:  r.cfg.MaxSweepFeeRateSatPerVByte,
+		FraudCheckpointSafetyMargin: r.cfg.FraudCheckpointSafetyMargin,
+		RegistryRef:                 r.selfRef,
 	})
 }
 

--- a/unroll/session.go
+++ b/unroll/session.go
@@ -23,9 +23,12 @@ type Session struct {
 }
 
 // NewSession creates a new unroll FSM session with the provided initial state.
+// fraudCheckpointSafetyMargin overrides the recipient backstop margin (in
+// blocks) baked into the FSM Environment; zero falls back to
+// defaultFraudCheckpointSafetyMargin.
 func NewSession(ctx context.Context, proof *recovery.Proof,
-	planner *unrollplan.Planner, initial State,
-	logger btclog.Logger) (*Session, error) {
+	planner *unrollplan.Planner, initial State, logger btclog.Logger,
+	fraudCheckpointSafetyMargin int32) (*Session, error) {
 
 	if proof == nil {
 		return nil, fmt.Errorf("proof must be provided")
@@ -50,8 +53,9 @@ func NewSession(ctx context.Context, proof *recovery.Proof,
 		),
 		InitialState: initial,
 		Env: &Environment{
-			Proof:   proof,
-			Planner: planner,
+			Proof:                       proof,
+			Planner:                     planner,
+			FraudCheckpointSafetyMargin: fraudCheckpointSafetyMargin,
 		},
 	}
 

--- a/unroll/snapshot.go
+++ b/unroll/snapshot.go
@@ -32,6 +32,8 @@ import (
 //   - SweepAttempts: number of sweep build/broadcast failures so far,
 //     compared against maxSweepAttempts when deciding whether to keep
 //     retrying.
+//   - DeferredCheckpoints: fraud-triggered checkpoint nodes that are being
+//     watched for operator confirmation before the recipient backstop.
 //
 // TLV was picked over JSON for three reasons: schema evolution (new
 // optional records slot in without breaking old readers), determinism
@@ -77,18 +79,23 @@ const (
 	// checkpointSweepAttemptsRecordType carries the cumulative count of
 	// sweep-build attempts.
 	checkpointSweepAttemptsRecordType tlv.Type = 15
+
+	// checkpointDeferredCheckpointsRecordType carries fraud-triggered
+	// checkpoint deferrals.
+	checkpointDeferredCheckpointsRecordType tlv.Type = 17
 )
 
 // actorCheckpoint is the durable checkpoint shape for one VTXO unroll actor.
 type actorCheckpoint struct {
-	Version       uint8
-	Height        int32
-	Started       bool
-	Trigger       StartTrigger
-	State         unrollplan.State
-	SweepTx       *wire.MsgTx
-	Fail          string
-	SweepAttempts int
+	Version             uint8
+	Height              int32
+	Started             bool
+	Trigger             StartTrigger
+	State               unrollplan.State
+	SweepTx             *wire.MsgTx
+	Fail                string
+	SweepAttempts       int
+	DeferredCheckpoints []DeferredCheckpoint
 }
 
 // encodeCheckpoint serializes one actor checkpoint into canonical TLV
@@ -168,6 +175,22 @@ func encodeCheckpoint(value *actorCheckpoint) ([]byte, error) {
 		),
 	)
 
+	if len(value.DeferredCheckpoints) > 0 {
+		deferredBytes, err := encodeDeferredCheckpoints(
+			value.DeferredCheckpoints,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("encode deferred "+
+				"checkpoints: %w", err)
+		}
+		records = append(
+			records, tlv.MakePrimitiveRecord(
+				checkpointDeferredCheckpointsRecordType,
+				&deferredBytes,
+			),
+		)
+	}
+
 	stream, err := tlv.NewStream(records...)
 	if err != nil {
 		return nil, fmt.Errorf("create checkpoint stream: %w", err)
@@ -197,14 +220,15 @@ func encodeCheckpoint(value *actorCheckpoint) ([]byte, error) {
 // truncated state.
 func decodeCheckpoint(raw []byte) (*actorCheckpoint, error) {
 	var (
-		version    uint8
-		height     uint32
-		started    uint8
-		trigger    uint32
-		stateBytes []byte
-		sweepBytes []byte
-		failBytes  []byte
-		attempts   uint32
+		version       uint8
+		height        uint32
+		started       uint8
+		trigger       uint32
+		stateBytes    []byte
+		sweepBytes    []byte
+		failBytes     []byte
+		attempts      uint32
+		deferredBytes []byte
 	)
 
 	stream, err := tlv.NewStream(
@@ -231,6 +255,9 @@ func decodeCheckpoint(raw []byte) (*actorCheckpoint, error) {
 		),
 		tlv.MakePrimitiveRecord(
 			checkpointSweepAttemptsRecordType, &attempts,
+		),
+		tlv.MakePrimitiveRecord(
+			checkpointDeferredCheckpointsRecordType, &deferredBytes,
 		),
 	)
 	if err != nil {
@@ -275,6 +302,15 @@ func decodeCheckpoint(raw []byte) (*actorCheckpoint, error) {
 
 	if _, ok := parsed[checkpointFailRecordType]; ok {
 		checkpoint.Fail = string(failBytes)
+	}
+
+	if _, ok := parsed[checkpointDeferredCheckpointsRecordType]; ok {
+		checkpoints, err := decodeDeferredCheckpoints(deferredBytes)
+		if err != nil {
+			return nil, fmt.Errorf("decode deferred "+
+				"checkpoints: %w", err)
+		}
+		checkpoint.DeferredCheckpoints = checkpoints
 	}
 
 	return checkpoint, nil

--- a/unroll/snapshot_test.go
+++ b/unroll/snapshot_test.go
@@ -97,6 +97,20 @@ func TestCheckpointCodecRoundTripHandcrafted(t *testing.T) {
 				SweepAttempts: 3,
 			},
 		},
+		{
+			name: "deferred_checkpoint",
+			checkpoint: &actorCheckpoint{
+				Version: checkpointVersion,
+				Height:  150,
+				Started: true,
+				Trigger: TriggerFraudSpend,
+				State:   unrollplan.State{},
+				DeferredCheckpoints: []DeferredCheckpoint{{
+					Txid:           targetTxid,
+					DeadlineHeight: 270,
+				}},
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -232,6 +246,20 @@ func drawCheckpoint(t *rapid.T) *actorCheckpoint {
 
 	if rapid.Bool().Draw(t, "hasFail") {
 		cp.Fail = rapid.StringN(1, 128, -1).Draw(t, "failReason")
+	}
+
+	if rapid.Bool().Draw(t, "hasDeferredCheckpoints") {
+		numDeferred := rapid.IntRange(1, 4).Draw(t, "numDeferred")
+		for i, txid := range drawDistinctHashesCk(
+			t, numDeferred, "deferred", nil,
+		) {
+			cp.DeferredCheckpoints = append(
+				cp.DeferredCheckpoints, DeferredCheckpoint{
+					Txid:           txid,
+					DeadlineHeight: int32(100 + i),
+				},
+			)
+		}
 	}
 
 	return cp
@@ -422,8 +450,31 @@ func checkpointsEqual(a, b *actorCheckpoint) bool {
 	if !plannerStatesEqualCk(a.State, b.State) {
 		return false
 	}
+	if !deferredCheckpointsEqualCk(
+		a.DeferredCheckpoints, b.DeferredCheckpoints,
+	) {
+		return false
+	}
 
 	return txsEqualCk(a.SweepTx, b.SweepTx)
+}
+
+// deferredCheckpointsEqualCk compares deferred checkpoints by value after
+// canonical sorting.
+func deferredCheckpointsEqualCk(a, b []DeferredCheckpoint) bool {
+	a = copyDeferredCheckpoints(a)
+	b = copyDeferredCheckpoints(b)
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+
+	return true
 }
 
 // plannerStatesEqualCk compares two unrollplan.State values using
@@ -522,6 +573,9 @@ func requireCheckpointEqual(t *testing.T, want, got *actorCheckpoint) {
 	require.Equal(t, want.Trigger, got.Trigger)
 	require.Equal(t, want.Fail, got.Fail)
 	require.Equal(t, want.SweepAttempts, got.SweepAttempts)
+	require.ElementsMatch(
+		t, want.DeferredCheckpoints, got.DeferredCheckpoints,
+	)
 	require.ElementsMatch(
 		t, want.State.ConfirmedTxids, got.State.ConfirmedTxids,
 	)

--- a/unroll/state_snapshot.go
+++ b/unroll/state_snapshot.go
@@ -26,6 +26,9 @@ func checkpointFromState(state State, sweepTx *wire.MsgTx) *actorCheckpoint {
 	checkpoint.Started = true
 	checkpoint.Trigger = job.Trigger
 	checkpoint.State = copyPlannerState(job.PlannerState)
+	checkpoint.DeferredCheckpoints = copyDeferredCheckpoints(
+		job.DeferredCheckpoints,
+	)
 	if sweepTxid := effectiveSweepTxid(
 		job.PlannerState, sweepTx,
 	); sweepTxid != nil {
@@ -67,12 +70,14 @@ func stateFromCheckpoint(checkpoint *actorCheckpoint) State {
 		return &Idle{}
 	}
 
+	deferred := copyDeferredCheckpoints(checkpoint.DeferredCheckpoints)
 	job := &JobState{
-		Height:        checkpoint.Height,
-		Trigger:       checkpoint.Trigger,
-		PlannerState:  copyPlannerState(checkpoint.State),
-		FailReason:    checkpoint.Fail,
-		SweepAttempts: checkpoint.SweepAttempts,
+		Height:              checkpoint.Height,
+		Trigger:             checkpoint.Trigger,
+		PlannerState:        copyPlannerState(checkpoint.State),
+		DeferredCheckpoints: deferred,
+		FailReason:          checkpoint.Fail,
+		SweepAttempts:       checkpoint.SweepAttempts,
 	}
 
 	switch phaseFromPlannerState(job) {

--- a/unroll/state_snapshot_test.go
+++ b/unroll/state_snapshot_test.go
@@ -16,6 +16,13 @@ func TestCheckpointRoundTripByPhase(t *testing.T) {
 	targetTxid := chainhash.Hash{0xAA}
 	sweepTxid := chainhash.Hash{0xBB}
 
+	deferred := []DeferredCheckpoint{{
+		Txid: chainhash.Hash{
+			0x02,
+		},
+		DeadlineHeight: 220,
+	}}
+
 	testCases := []struct {
 		name  string
 		state State
@@ -26,11 +33,12 @@ func TestCheckpointRoundTripByPhase(t *testing.T) {
 			state: &AwaitingMaterialization{
 				Job: &JobState{
 					Height:  100,
-					Trigger: TriggerManual,
+					Trigger: TriggerFraudSpend,
 					PlannerState: unrollState(
 						chainhash.Hash{0x01},
 						fn.None[int32](), nil,
 					),
+					DeferredCheckpoints: deferred,
 				},
 			},
 			typ: &AwaitingMaterialization{},
@@ -118,6 +126,10 @@ func TestCheckpointRoundTripByPhase(t *testing.T) {
 			require.Equal(
 				t, stateJob(tc.state).PlannerState,
 				stateJob(restored).PlannerState,
+			)
+			require.Equal(
+				t, stateJob(tc.state).DeferredCheckpoints,
+				stateJob(restored).DeferredCheckpoints,
 			)
 		})
 	}

--- a/vtxo/actor_test.go
+++ b/vtxo/actor_test.go
@@ -850,6 +850,48 @@ func TestManagerGetActiveVTXOCount(t *testing.T) {
 	require.Equal(t, 3, countResp.Count)
 }
 
+// TestManagerListLiveDescriptors verifies the manager returns a snapshot
+// of the live descriptors recovered at Start. This is the path daemon-
+// local subsystems (recipient fraud watcher) use to re-arm per-VTXO
+// state on restart.
+func TestManagerListLiveDescriptors(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	// Empty manager: response carries an empty descriptor slice.
+	manager := &Manager{
+		actors: make(map[wire.OutPoint]VTXOActorRef),
+	}
+	result := manager.Receive(ctx, &ListLiveDescriptorsRequest{})
+	resp, err := result.Unpack()
+	require.NoError(t, err)
+	listResp, ok := resp.(*ListLiveDescriptorsResponse)
+	require.True(
+		t, ok, "expected ListLiveDescriptorsResponse, got %T", resp,
+	)
+	require.Empty(t, listResp.Descriptors)
+
+	// Populate liveDescriptors as Start would have.
+	a := &Descriptor{Outpoint: wire.OutPoint{Hash: [32]byte{0xa}}}
+	b := &Descriptor{Outpoint: wire.OutPoint{Hash: [32]byte{0xb}}}
+	manager.liveDescriptors = []*Descriptor{a, b}
+
+	result = manager.Receive(ctx, &ListLiveDescriptorsRequest{})
+	resp, err = result.Unpack()
+	require.NoError(t, err)
+	listResp, ok = resp.(*ListLiveDescriptorsResponse)
+	require.True(
+		t, ok, "expected ListLiveDescriptorsResponse, got %T", resp,
+	)
+	require.Equal(t, []*Descriptor{a, b}, listResp.Descriptors)
+
+	// Response is a defensive copy: mutating it must not affect the
+	// manager's internal slice.
+	listResp.Descriptors[0] = nil
+	require.Equal(t, a, manager.liveDescriptors[0])
+}
+
 // TestManagerRelayToRound verifies the manager forwards RelayToRoundMsg
 // payloads to the round actor. This is the liveness path: when a VTXO
 // actor detects approaching expiry and emits a ForfeitRequest, the

--- a/vtxo/manager.go
+++ b/vtxo/manager.go
@@ -84,6 +84,11 @@ type ManagerConfig struct {
 	// OperatorFee=0, which is harmless because the server still
 	// fills in the residual via the JoinRoundQuote.
 	RefreshFeeQuoter RefreshFeeQuoter
+
+	// TerminalVTXOObserver receives the outpoint of VTXOs that leave the
+	// manager's active set so daemon-local observers can clean up related
+	// actor-owned work.
+	TerminalVTXOObserver func(context.Context, wire.OutPoint) error
 }
 
 // Manager coordinates VTXO actor lifecycle - spawning new actors when VTXOs
@@ -99,6 +104,14 @@ type Manager struct {
 
 	// actors tracks active VTXO actors by outpoint.
 	actors map[wire.OutPoint]VTXOActorRef
+
+	// liveDescriptors snapshots the live VTXO descriptors recovered
+	// from the store during Start. The list is the source of truth for
+	// daemon-local subsystems that need to re-arm per-VTXO state on
+	// restart (notably the recipient fraud watcher) and is not kept
+	// in sync after Start; runtime updates flow through the materialize
+	// and terminate hooks instead.
+	liveDescriptors []*Descriptor
 }
 
 // NewManager creates a new VTXO Manager.
@@ -204,6 +217,7 @@ func (m *Manager) Start(ctx context.Context,
 		}
 
 		m.actors[vtxo.Outpoint] = ref
+		m.liveDescriptors = append(m.liveDescriptors, vtxo)
 
 		m.logger(ctx).InfoS(ctx, "Recovered VTXO actor",
 			slog.String("outpoint", vtxo.Outpoint.String()),
@@ -261,6 +275,14 @@ func (m *Manager) Receive(ctx context.Context,
 	case *GetActiveVTXOCountRequest:
 		return fn.Ok[ManagerResp](&GetActiveVTXOCountResponse{
 			Count: len(m.actors),
+		})
+
+	case *ListLiveDescriptorsRequest:
+		descs := make([]*Descriptor, len(m.liveDescriptors))
+		copy(descs, m.liveDescriptors)
+
+		return fn.Ok[ManagerResp](&ListLiveDescriptorsResponse{
+			Descriptors: descs,
 		})
 
 	case *ForceUnrollRequest:
@@ -465,6 +487,18 @@ func (m *Manager) handleVTXOTerminated(ctx context.Context,
 		slog.String("final_state", msg.FinalState),
 		slog.String("reason", msg.Reason),
 	)
+
+	if m.cfg.TerminalVTXOObserver != nil {
+		err := m.cfg.TerminalVTXOObserver(ctx, msg.Outpoint)
+		if err != nil {
+			m.logger(ctx).WarnS(
+				ctx,
+				"Failed to notify terminal VTXO observer",
+				err,
+				slog.String("outpoint", msg.Outpoint.String()),
+			)
+		}
+	}
 
 	return fn.Ok[ManagerResp](&VTXOTerminatedResp{})
 }

--- a/vtxo/manager_observer_test.go
+++ b/vtxo/manager_observer_test.go
@@ -1,0 +1,41 @@
+package vtxo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/round"
+	"github.com/stretchr/testify/require"
+)
+
+// TestManagerTerminalVTXOObserver verifies manager cleanup notifies the
+// terminal observer after dropping the child actor reference.
+func TestManagerTerminalVTXOObserver(t *testing.T) {
+	outpoint := wire.OutPoint{
+		Hash: [32]byte{
+			1,
+		},
+		Index: 2,
+	}
+
+	var observed []wire.OutPoint
+	manager := NewManager(&ManagerConfig{
+		TerminalVTXOObserver: func(_ context.Context,
+			outpoint wire.OutPoint) error {
+
+			observed = append(observed, outpoint)
+
+			return nil
+		},
+	})
+
+	resp := manager.Receive(t.Context(), &round.VTXOTerminatedMsg{
+		Outpoint:   outpoint,
+		FinalState: "spent",
+		Reason:     "test",
+	})
+	require.True(t, resp.IsOk())
+	require.Len(t, observed, 1)
+	require.Equal(t, outpoint, observed[0])
+}

--- a/vtxo/messages.go
+++ b/vtxo/messages.go
@@ -86,6 +86,34 @@ type GetActiveVTXOCountResponse struct {
 // VTXOManagerResp implements actormsg.VTXOManagerResp marker interface.
 func (r *GetActiveVTXOCountResponse) VTXOManagerResp() {}
 
+// ListLiveDescriptorsRequest requests the descriptors of the VTXOs
+// the manager recovered from durable state at Start time. Daemon-local
+// subsystems use the response to re-arm per-VTXO state (notably the
+// recipient fraud watcher) after restart without taking a direct
+// dependency on the VTXO store.
+type ListLiveDescriptorsRequest struct {
+	actor.BaseMessage
+}
+
+// MessageType returns the message type identifier.
+func (r *ListLiveDescriptorsRequest) MessageType() string {
+	return "ListLiveDescriptorsRequest"
+}
+
+// VTXOManagerMsg implements actormsg.VTXOManagerMsg marker interface.
+func (r *ListLiveDescriptorsRequest) VTXOManagerMsg() {}
+
+// ListLiveDescriptorsResponse returns the descriptors of the live VTXOs
+// the manager recovered at Start.
+type ListLiveDescriptorsResponse struct {
+	// Descriptors is the snapshot of recovered live descriptors. The
+	// slice is caller-owned and safe to mutate.
+	Descriptors []*Descriptor
+}
+
+// VTXOManagerResp implements actormsg.VTXOManagerResp marker interface.
+func (r *ListLiveDescriptorsResponse) VTXOManagerResp() {}
+
 // =============================================================================
 // Relay messages: VTXO actor → Manager → external actor
 // =============================================================================


### PR DESCRIPTION
## Summary

Adds the client-side recipient fraud-response defense for preconfirmed OOR VTXOs.

Receiving a live OOR VTXO arms passive ancestor spend watches. When any watched ancestor materializes on chain the watcher starts (or reuses) a durable unroll job under `TriggerFraudSpend`. The unroll job materializes the full proof DAG required for the target, defers checkpoint broadcasts to give the operator a window to broadcast first, broadcasts ark transactions promptly once their parents confirm, waits CSV, and sweeps to the wallet.

Fixes lightninglabs/darepo-client#345.

Paired with the server-side integration tests in lightninglabs/darepo#334 — the server PR's submodule pointer bumps to this branch's tip, and its recipient fraud itest suite (`TestRecipientFraud*`) exercises this client end-to-end.

## Details

- `fraud` is a slim passive package: it has **no** `txconfirm` dependency and never broadcasts checkpoint or ark transactions. It builds a `WatchPlan` from each live OOR VTXO's descriptor ancestry, deduplicates shared watch outpoints via refcounting, and on an observed ancestor spend fans out `unroll.EnsureUnrollRequest{Trigger: TriggerFraudSpend}` per affected target. Terminal VTXO transitions release passive watches so the watcher does not pay fees for VTXOs the wallet no longer owns.
- `unroll` owns full fraud-triggered recovery execution. Under `TriggerFraudSpend` it defers ready checkpoint nodes to a deadline computed from CSV delay and recipient safety margin, registers confirmation watches by deterministic txid, and broadcasts the checkpoint through `txconfirm` only if the deadline arrives without operator confirmation. Ark nodes are never deferred — once their checkpoint parents confirm, they go to `txconfirm` immediately. The deferred-checkpoint state is durable: `JobState.DeferredCheckpoints` round-trips through the actor's TLV checkpoint codec, and `ResumeEvent` reissues every persisted watch on restart.
- `oor` and `vtxo` gain optional `IncomingVTXOObserver` and `TerminalVTXOObserver` callback hooks. `darepod` wires these to the fraud watcher so incoming OOR materialization arms watches and terminal VTXO cleanup releases them, all without those packages taking a direct dependency on `fraud`.
- `txconfirm` package re-broadcasts now tolerate a deeply-confirmed parent that bitcoind dropped from its rejects cache. The `bad-txns-inputs-missingorspent` / `bad-txns-inputs-missing` combination on the parent plus a child-failure sentinel is treated as "parent already broadcast", letting the actor fall through to its existing confirmation watch instead of collapsing to `Failed`. This unblocks the fraud-triggered handoff where the operator's checkpoint confirms before the recipient deadline.

Mempool observation is intentionally **not** implemented for deferred checkpoints. Neutrino-backed clients cannot inspect the mempool, and supporting only some backends would create a silent two-mode behavior. The recipient deferral relies on chain confirmation plus the deadline backstop, which is uniform across backends.

## Validation

- `make lint-native` clean.
- `go test -race ./fraud ./unroll ./oor ./vtxo ./txconfirm ./chainsource` green.
- Full recipient fraud itest suite (`TestRecipientFraud*` in lightninglabs/darepo#334) passes against this branch: `BroadcastsArkAfterRestart`, `DefersToOperator`, `MultihopRatchet`, `PartialOperator`, `MultiInputOOR`, `CleanupOnOnwardSpend`.

## Design notes

See `docs/recipient_fraud_unroll_execplan.md` (added in the `darepod` commit) for the ExecPlan that motivated this branch's design pivot from "fraud package owns recovery execution" to "fraud is passive detection, unroll owns recovery DAG materialization under `TriggerFraudSpend`".