### PR TITLE
oor: use incoming metadata operator key

### DIFF
--- a/arkrpc/indexer.pb.go
+++ b/arkrpc/indexer.pb.go
@@ -1696,8 +1696,11 @@ type VTXO struct {
 	// VTXOs have exactly one entry; cross-commitment multi-input OOR VTXOs
 	// have one entry per distinct contributing commitment tx.
 	AncestryPaths []*AncestryPath `protobuf:"bytes,18,rep,name=ancestry_paths,json=ancestryPaths,proto3" json:"ancestry_paths,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// operator_pubkey is the compressed operator public key committed to this
+	// VTXO's collaborative spend path.
+	OperatorPubkey []byte `protobuf:"bytes,19,opt,name=operator_pubkey,json=operatorPubkey,proto3" json:"operator_pubkey,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *VTXO) Reset() {
@@ -1838,6 +1841,13 @@ func (x *VTXO) GetSpentByTxid() []byte {
 func (x *VTXO) GetAncestryPaths() []*AncestryPath {
 	if x != nil {
 		return x.AncestryPaths
+	}
+	return nil
+}
+
+func (x *VTXO) GetOperatorPubkey() []byte {
+	if x != nil {
+		return x.OperatorPubkey
 	}
 	return nil
 }
@@ -2761,7 +2771,7 @@ const file_indexer_proto_rawDesc = "" +
 	"\x0ftaproot_schnorr\x18\n" +
 	" \x01(\v2\x1b.arkrpc.TaprootSchnorrProofH\x00R\x0etaprootSchnorr\x12-\n" +
 	"\x06bip322\x18\v \x01(\v2\x13.arkrpc.BIP322ProofH\x00R\x06bip322B\a\n" +
-	"\x05proof\"\x86\x05\n" +
+	"\x05proof\"\xaf\x05\n" +
 	"\x04VTXO\x12,\n" +
 	"\boutpoint\x18\x01 \x01(\v2\x10.arkrpc.OutPointR\boutpoint\x12\x1b\n" +
 	"\tvalue_sat\x18\x02 \x01(\x04R\bvalueSat\x12\x1b\n" +
@@ -2781,7 +2791,8 @@ const file_indexer_proto_rawDesc = "" +
 	"\vchain_depth\x18\x0f \x01(\rR\n" +
 	"chainDepth\x12\"\n" +
 	"\rspent_by_txid\x18\x11 \x01(\fR\vspentByTxid\x12;\n" +
-	"\x0eancestry_paths\x18\x12 \x03(\v2\x14.arkrpc.AncestryPathR\rancestryPaths\"\xb1\x01\n" +
+	"\x0eancestry_paths\x18\x12 \x03(\v2\x14.arkrpc.AncestryPathR\rancestryPaths\x12'\n" +
+	"\x0foperator_pubkey\x18\x13 \x01(\fR\x0eoperatorPubkey\"\xb1\x01\n" +
 	"\x19ListVTXOsByScriptsRequest\x12-\n" +
 	"\ascripts\x18\x01 \x03(\v2\x13.arkrpc.ScriptScopeR\ascripts\x127\n" +
 	"\rstatus_filter\x18\x02 \x03(\x0e2\x12.arkrpc.VTXOStatusR\fstatusFilter\x12\x16\n" +

--- a/arkrpc/indexer.proto
+++ b/arkrpc/indexer.proto
@@ -433,6 +433,10 @@ message VTXO {
     // VTXOs have exactly one entry; cross-commitment multi-input OOR VTXOs
     // have one entry per distinct contributing commitment tx.
     repeated AncestryPath ancestry_paths = 18;
+
+    // operator_pubkey is the compressed operator public key committed to this
+    // VTXO's collaborative spend path.
+    bytes operator_pubkey = 19;
 }
 
 message ListVTXOsByScriptsRequest {

--- a/oor/actor_durable_message.go
+++ b/oor/actor_durable_message.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"time"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
@@ -121,6 +122,7 @@ const (
 	incomingMetadataMatchChainDepthRecordType     tlv.Type = 11
 	incomingMetadataMatchCreatedHeightRecordType  tlv.Type = 13
 	incomingMetadataMatchAncestryPathsRecordType  tlv.Type = 17
+	incomingMetadataMatchOperatorKeyRecordType    tlv.Type = 19
 )
 
 type startTransferPayload struct {
@@ -562,6 +564,7 @@ func encodeIncomingMetadataMatch(match IncomingMetadataMatch) ([]byte, error) {
 	batchExpiry := uint32(match.Metadata.BatchExpiry)
 	chainDepth := uint32(match.Metadata.ChainDepth)
 	createdHeight := uint32(match.Metadata.CreatedHeight)
+	operatorKey := encodeOptionalPubKey(match.Metadata.OperatorKey)
 
 	ancestryBytes, err := encodeAncestryList(match.Metadata.Ancestry)
 	if err != nil {
@@ -596,6 +599,10 @@ func encodeIncomingMetadataMatch(match IncomingMetadataMatch) ([]byte, error) {
 			incomingMetadataMatchAncestryPathsRecordType,
 			&ancestryBytes,
 		),
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchOperatorKeyRecordType,
+			&operatorKey,
+		),
 	}
 
 	stream, err := tlv.NewStream(records...)
@@ -620,6 +627,7 @@ func decodeIncomingMetadataMatch(raw []byte) (IncomingMetadataMatch, error) {
 		chainDepth     uint32
 		createdHeight  uint32
 		ancestryBytes  []byte
+		operatorKey    []byte
 	)
 
 	records := []tlv.Record{
@@ -649,6 +657,10 @@ func decodeIncomingMetadataMatch(raw []byte) (IncomingMetadataMatch, error) {
 		tlv.MakePrimitiveRecord(
 			incomingMetadataMatchAncestryPathsRecordType,
 			&ancestryBytes,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchOperatorKeyRecordType,
+			&operatorKey,
 		),
 	}
 
@@ -695,6 +707,13 @@ func decodeIncomingMetadataMatch(raw []byte) (IncomingMetadataMatch, error) {
 		return IncomingMetadataMatch{}, err
 	}
 
+	decodedOperatorKey, err := decodeOptionalPubKey(
+		operatorKey, "incoming operator key",
+	)
+	if err != nil {
+		return IncomingMetadataMatch{}, err
+	}
+
 	var decodedCommitmentTxID chainhash.Hash
 	copy(decodedCommitmentTxID[:], commitmentTxID)
 
@@ -706,9 +725,34 @@ func decodeIncomingMetadataMatch(raw []byte) (IncomingMetadataMatch, error) {
 			BatchExpiry:    decodedBatchExpiry,
 			ChainDepth:     int(decodedChainDepth),
 			CreatedHeight:  decodedCreatedHeight,
+			OperatorKey:    decodedOperatorKey,
 			Ancestry:       ancestry,
 		},
 	}, nil
+}
+
+// encodeOptionalPubKey returns the compressed encoding of pubKey, or nil when
+// no key is present.
+func encodeOptionalPubKey(pubKey *btcec.PublicKey) []byte {
+	if pubKey == nil {
+		return nil
+	}
+
+	return pubKey.SerializeCompressed()
+}
+
+// decodeOptionalPubKey parses a compressed public key when raw is non-empty.
+func decodeOptionalPubKey(raw []byte, name string) (*btcec.PublicKey, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+
+	pubKey, err := btcec.ParsePubKey(raw)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s: %w", name, err)
+	}
+
+	return pubKey, nil
 }
 
 func encodeRecipientPayload(payload recipientPayload) ([]byte, error) {

--- a/oor/actor_durable_message_test.go
+++ b/oor/actor_durable_message_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/vtxo"
@@ -310,6 +311,9 @@ func TestDriveEventRequestRoundTripIncomingMetadataResolvedEvent(t *testing.T) {
 
 	sessionID := SessionID(chainhash.Hash{10, 10, 10})
 	commitmentTxID := chainhash.Hash{11, 11, 11}
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
 	msg := &DriveEventRequest{
 		SessionID: sessionID,
 		Event: &IncomingMetadataResolvedEvent{
@@ -321,6 +325,7 @@ func TestDriveEventRequestRoundTripIncomingMetadataResolvedEvent(t *testing.T) {
 					BatchExpiry:    144,
 					ChainDepth:     2,
 					CreatedHeight:  42,
+					OperatorKey:    operatorKey.PubKey(),
 					Ancestry: []vtxo.Ancestry{{
 						CommitmentTxID: commitmentTxID,
 						TreeDepth:      0,
@@ -349,6 +354,9 @@ func TestDriveEventRequestRoundTripIncomingMetadataResolvedEvent(t *testing.T) {
 	require.EqualValues(t, 144, match.Metadata.BatchExpiry)
 	require.EqualValues(t, 2, match.Metadata.ChainDepth)
 	require.EqualValues(t, 42, match.Metadata.CreatedHeight)
+	require.True(t, match.Metadata.OperatorKey.IsEqual(
+		operatorKey.PubKey(),
+	))
 	require.Len(t, match.Metadata.Ancestry, 1)
 	require.Equal(
 		t, commitmentTxID, match.Metadata.Ancestry[0].CommitmentTxID,

--- a/oor/incoming_metadata_query.go
+++ b/oor/incoming_metadata_query.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/lightninglabs/darepo-client/arkrpc"
 	"github.com/lightninglabs/darepo-client/vtxo"
@@ -152,6 +153,13 @@ func incomingMetadataFromRPC(candidate *arkrpc.VTXO) (
 			"ancestry paths: %w", err)
 	}
 
+	operatorKey, err := incomingOperatorKeyFromRPC(
+		candidate.GetOperatorPubkey(),
+	)
+	if err != nil {
+		return IncomingVTXOMetadata{}, err
+	}
+
 	var commitmentTxID chainhash.Hash
 	copy(commitmentTxID[:], candidate.GetCommitmentTxid())
 
@@ -161,8 +169,16 @@ func incomingMetadataFromRPC(candidate *arkrpc.VTXO) (
 		BatchExpiry:    candidate.GetBatchExpiryHeight(),
 		ChainDepth:     int(candidate.GetChainDepth()),
 		CreatedHeight:  candidate.GetCreatedHeight(),
+		OperatorKey:    operatorKey,
 		Ancestry:       ancestry,
 	}, nil
+}
+
+// incomingOperatorKeyFromRPC parses the optional operator key carried by an
+// indexer VTXO response. An empty value is allowed for compatibility with
+// older indexers that predate per-VTXO operator-key metadata.
+func incomingOperatorKeyFromRPC(raw []byte) (*btcec.PublicKey, error) {
+	return decodeOptionalPubKey(raw, "indexer vtxo operator pubkey")
 }
 
 // maxAncestryPaths bounds the per-VTXO ancestry slice the indexer is

--- a/oor/incoming_metadata_query_test.go
+++ b/oor/incoming_metadata_query_test.go
@@ -1,0 +1,66 @@
+package oor
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightninglabs/darepo-client/arkrpc"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIncomingMetadataFromRPCOperatorKey verifies incoming metadata parsing
+// preserves the per-VTXO operator key returned by the indexer.
+func TestIncomingMetadataFromRPCOperatorKey(t *testing.T) {
+	t.Parallel()
+
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	commitmentTxID := chainhash.Hash{1, 2, 3}
+	meta, err := incomingMetadataFromRPC(&arkrpc.VTXO{
+		RoundId:        "round-keyed",
+		CommitmentTxid: commitmentTxID[:],
+		OperatorPubkey: operatorKey.PubKey().SerializeCompressed(),
+		AncestryPaths: []*arkrpc.AncestryPath{{
+			CommitmentTxid: commitmentTxID[:],
+		}},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, meta.OperatorKey)
+	require.True(t, meta.OperatorKey.IsEqual(operatorKey.PubKey()))
+}
+
+// TestIncomingMetadataFromRPCLegacyOperatorKey verifies older indexer
+// responses that omit operator_pubkey still decode for compatibility.
+func TestIncomingMetadataFromRPCLegacyOperatorKey(t *testing.T) {
+	t.Parallel()
+
+	commitmentTxID := chainhash.Hash{4, 5, 6}
+	meta, err := incomingMetadataFromRPC(&arkrpc.VTXO{
+		RoundId:        "round-legacy",
+		CommitmentTxid: commitmentTxID[:],
+		AncestryPaths: []*arkrpc.AncestryPath{{
+			CommitmentTxid: commitmentTxID[:],
+		}},
+	})
+	require.NoError(t, err)
+	require.Nil(t, meta.OperatorKey)
+}
+
+// TestIncomingMetadataFromRPCRejectsInvalidOperatorKey verifies malformed
+// operator key bytes fail before incoming VTXO materialization.
+func TestIncomingMetadataFromRPCRejectsInvalidOperatorKey(t *testing.T) {
+	t.Parallel()
+
+	commitmentTxID := chainhash.Hash{7, 8, 9}
+	_, err := incomingMetadataFromRPC(&arkrpc.VTXO{
+		RoundId:        "round-invalid-key",
+		CommitmentTxid: commitmentTxID[:],
+		OperatorPubkey: []byte{0x02},
+		AncestryPaths: []*arkrpc.AncestryPath{{
+			CommitmentTxid: commitmentTxID[:],
+		}},
+	})
+	require.ErrorContains(t, err, "parse indexer vtxo operator pubkey")
+}

--- a/oor/incoming_vtxo.go
+++ b/oor/incoming_vtxo.go
@@ -45,6 +45,11 @@ type IncomingVTXOMetadata struct {
 	// CreatedHeight is the block height at which the VTXO was created.
 	CreatedHeight int32
 
+	// OperatorKey is the operator public key committed to the VTXO's
+	// collaborative spend path. Older indexers may omit this, in which case
+	// materialization falls back to the handler's configured operator key.
+	OperatorKey *btcec.PublicKey
+
 	// Ancestry is the set of rooted commitment-tree fragments required
 	// to claim this VTXO unilaterally on-chain. Round-direct and
 	// single-commitment OOR VTXOs have len(Ancestry) == 1; cross-round

--- a/oor/local_persistence_handler.go
+++ b/oor/local_persistence_handler.go
@@ -92,8 +92,8 @@ type LocalPersistenceOutboxHandler struct {
 	// outpoint bindings.
 	PackageStore PackagePersistence
 
-	// OperatorKey is the operator key used to reconstruct incoming VTXO
-	// tapscripts.
+	// OperatorKey is the fallback operator key used to reconstruct incoming
+	// VTXO tapscripts when older indexer metadata omits the per-VTXO key.
 	OperatorKey *btcec.PublicKey
 
 	// ExitDelay is the unilateral CSV delay for incoming VTXO descriptors.
@@ -291,10 +291,6 @@ func (h *LocalPersistenceOutboxHandler) validateMaterializeIncoming(
 
 	if h.Store == nil {
 		return fmt.Errorf("vtxo store must be provided")
-	}
-
-	if h.OperatorKey == nil {
-		return fmt.Errorf("operator key must be provided")
 	}
 
 	if h.ResolveIncomingClientKey == nil {
@@ -508,17 +504,22 @@ func (h *LocalPersistenceOutboxHandler) materializeIncoming(
 			slog.Int("ancestry_paths", len(metadata.Ancestry)),
 			slog.Int("chain_depth", metadata.ChainDepth))
 
-		// TODO(oor-receive): Use per-round operator key from
-		// indexer metadata instead of the startup-cached
-		// OperatorKey. If the operator rotates keys, VTXOs
-		// materialized with the stale key will have an incorrect
-		// collab tapscript leaf, locking funds until the
-		// unilateral exit delay expires.
+		operatorKey := metadata.OperatorKey
+		if operatorKey == nil {
+			operatorKey = h.OperatorKey
+		}
+		if operatorKey == nil {
+			return nil, fmt.Errorf(
+				"operator key missing for incoming output %d",
+				recipient.OutputIndex,
+			)
+		}
+
 		desc, err := BuildIncomingVTXODescriptor(msg.ArkPSBT,
 			IncomingVTXOConfig{
 				OutputIndex: recipient.OutputIndex,
 				ClientKey:   clientKey,
-				OperatorKey: h.OperatorKey,
+				OperatorKey: operatorKey,
 				ExitDelay:   h.ExitDelay,
 				Metadata:    metadata,
 			},

--- a/oor/local_persistence_handler_test.go
+++ b/oor/local_persistence_handler_test.go
@@ -280,6 +280,79 @@ func TestLocalPersistenceOutboxHandlerMaterializeIncoming(t *testing.T) {
 	require.Equal(t, chainhash.Hash(sessionID), packageStore.lastSessionID)
 }
 
+// TestLocalPersistenceOutboxHandlerUsesMetadataOperatorKey asserts incoming
+// materialization prefers the per-VTXO operator key returned by the indexer
+// over the handler's compatibility fallback key.
+func TestLocalPersistenceOutboxHandlerUsesMetadataOperatorKey(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	arkPSBT, finalCheckpoints, recipients, parentCommitment, recipientKey,
+		operatorKey :=
+		buildTestIncomingMaterialization(t)
+
+	staleOperatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	sessionID := SessionID(arkPSBT.UnsignedTx.TxHash())
+	store := newTestVTXOStore()
+	handler := &LocalPersistenceOutboxHandler{
+		Store:       store,
+		OperatorKey: staleOperatorKey.PubKey(),
+		ExitDelay:   10,
+		NotifyIncomingVTXOs: func(_ context.Context,
+			_ []*vtxo.Descriptor) error {
+
+			return nil
+		},
+		ResolveIncomingClientKey: func(ctx context.Context,
+			recipient ArkRecipientOutput) (
+			keychain.KeyDescriptor, error) {
+
+			_ = ctx
+			_ = recipient
+
+			return keychain.KeyDescriptor{
+				PubKey: recipientKey.PubKey(),
+			}, nil
+		},
+	}
+
+	req := &MaterializeIncomingVTXOsRequest{
+		SessionID:            sessionID,
+		ArkPSBT:              arkPSBT,
+		FinalCheckpointPSBTs: finalCheckpoints,
+		Recipients:           recipients,
+		MetadataMatches: []IncomingMetadataMatch{{
+			OutputIndex: recipients[0].OutputIndex,
+			Metadata: IncomingVTXOMetadata{
+				RoundID:        "round-incoming",
+				CommitmentTxID: parentCommitment,
+				BatchExpiry:    1000,
+				OperatorKey:    operatorKey,
+				Ancestry: validTestIncomingAncestry(
+					parentCommitment,
+				),
+				CreatedHeight: 700,
+			},
+		}},
+	}
+
+	events, err := handler.Handle(ctx, sessionID, req)
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	require.IsType(t, &IncomingHandledEvent{}, events[0])
+
+	desc, err := store.GetVTXO(ctx, wire.OutPoint{
+		Hash:  arkPSBT.UnsignedTx.TxHash(),
+		Index: recipients[0].OutputIndex,
+	})
+	require.NoError(t, err)
+	require.True(t, desc.OperatorKey.IsEqual(operatorKey))
+	require.False(t, desc.OperatorKey.IsEqual(staleOperatorKey.PubKey()))
+}
+
 // TestLocalPersistenceOutboxHandlerMaterializeIncomingSkipsNotOwned asserts
 // non-owned recipients are skipped while owned recipients are materialized.
 func TestLocalPersistenceOutboxHandlerMaterializeIncomingSkipsNotOwned(


### PR DESCRIPTION
## Summary

Fixes lightninglabs/darepo-client#194 by carrying the operator key committed to each incoming VTXO through the OOR receive materialization path.

Today `LocalPersistenceOutboxHandler` has a daemon-startup `OperatorKey` field that is used when reconstructing incoming VTXO descriptors. That is fine while the operator key is static, but it is the wrong source of truth once an operator can rotate keys or once a client receives VTXOs from rounds created under different operator keys. In that case the output script in the Ark PSBT is committed to the per-round key, while the local materializer may derive the descriptor using the stale startup key.

This PR adds `operator_pubkey` to the indexer `VTXO` RPC shape, parses it into `IncomingVTXOMetadata`, persists it through the durable incoming metadata event encoding, and makes local materialization prefer that metadata key. The existing handler-level key remains as a compatibility fallback for older indexers that do not yet return the new field.

## Details

- Adds `VTXO.operator_pubkey` to `arkrpc/indexer.proto` and regenerates the Go stubs.
- Extends `IncomingVTXOMetadata` with `OperatorKey`.
- Parses and validates non-empty operator key bytes from `ListVTXOsByScripts` responses.
- Preserves the operator key through durable `IncomingMetadataMatch` TLV encoding, so receive sessions remain restart-safe after the metadata query resolves.
- Updates `LocalPersistenceOutboxHandler` to prefer `metadata.OperatorKey` and fall back to `h.OperatorKey` only when the metadata is absent.
- Removes the stale TODO at the materialization call site.

## Testing

- `go test ./oor`
- `make lint`
- `make unit`
- `make commitmsg-lint range=origin/main..HEAD`
