### PR TITLE
darepocli: sweep expired boarding UTXOs

### DIFF
--- a/cmd/darepocli/darepoclicommands/cmd_sweep.go
+++ b/cmd/darepocli/darepoclicommands/cmd_sweep.go
@@ -1,0 +1,166 @@
+package darepoclicommands
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/spf13/cobra"
+)
+
+// newSweepCmd creates the sweep subcommand for recovering expired boarding
+// UTXOs through their unilateral timeout path.
+func newSweepCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "sweep",
+		Short: "Sweep expired boarding UTXOs",
+		Long: "Scans boarding UTXOs whose CSV timeout path has " +
+			"matured and prints the recoverable amount, " +
+			"estimated fee, and net amount. If no mature " +
+			"outputs are available, the command returns an " +
+			"empty preview. Pass --broadcast to publish one " +
+			"aggregate sweep transaction. The daemon records " +
+			"the sweep as pending and marks the boarding " +
+			"outputs swept after confirmed spends.",
+		RunE: sweep,
+	}
+	cmd.AddCommand(newSweepListCmd())
+
+	cmd.Flags().StringSlice("outpoint", nil,
+		"boarding UTXO outpoint to sweep (txid:index); repeatable")
+	cmd.Flags().Bool("broadcast", false,
+		"broadcast aggregate sweep and track it until confirmed spent")
+	cmd.Flags().Int64("fee-rate-sat-per-vbyte", 0,
+		"fee rate override in sat/vbyte; zero estimates by conf target")
+	cmd.Flags().Uint32("conf-target", 0,
+		"confirmation target for fee estimation; zero uses default")
+	cmd.Flags().String("sweep-address", "",
+		"optional sweep destination; empty uses a fresh wallet address")
+
+	return cmd
+}
+
+// newSweepListCmd creates the subcommand for listing tracked sweep
+// transactions.
+func newSweepListCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List tracked boarding sweeps",
+		Long: "Lists aggregate boarding sweep transactions persisted " +
+			"by the daemon, including their lifecycle status, " +
+			"fee, confirmation height, and per-input spend " +
+			"state.",
+		RunE: sweepList,
+	}
+
+	cmd.Flags().String("status", "",
+		"optional status filter: pending, published, confirmed, "+
+			"external_resolved, or failed")
+	cmd.Flags().Uint32("page-size", 0,
+		"maximum tracked sweeps to return; zero uses the "+
+			"daemon default")
+	cmd.Flags().String("page-token", "",
+		"page token returned by a previous sweep list response")
+
+	return cmd
+}
+
+// sweep executes the SweepBoardingUTXOs RPC and prints the result.
+func sweep(cmd *cobra.Command, _ []string) error {
+	client, conn, err := getDaemonClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	req := &daemonrpc.SweepBoardingUTXOsRequest{}
+	fromFlags := func() error {
+		outpoints, _ := cmd.Flags().GetStringSlice("outpoint")
+		broadcast, _ := cmd.Flags().GetBool("broadcast")
+		feeRate, _ := cmd.Flags().GetInt64("fee-rate-sat-per-vbyte")
+		confTarget, _ := cmd.Flags().GetUint32("conf-target")
+		sweepAddress, _ := cmd.Flags().GetString("sweep-address")
+
+		if feeRate < 0 {
+			return fmt.Errorf(
+				"fee-rate-sat-per-vbyte must be non-negative",
+			)
+		}
+		for _, outpoint := range outpoints {
+			if err := validateOutpointString(outpoint); err != nil {
+				return fmt.Errorf(
+					"invalid --outpoint %q: %w",
+					outpoint, err,
+				)
+			}
+		}
+
+		req.Outpoints = outpoints
+		req.Broadcast = broadcast
+		req.FeeRateSatPerVbyte = feeRate
+		req.ConfTarget = confTarget
+		req.SweepAddress = sweepAddress
+
+		return nil
+	}
+
+	if err := parseRequest(cmd, req, fromFlags); err != nil {
+		return err
+	}
+
+	resp, err := client.SweepBoardingUTXOs(context.Background(), req)
+	if err != nil {
+		return fmt.Errorf("SweepBoardingUTXOs RPC failed: %w", err)
+	}
+
+	return printJSON(resp)
+}
+
+// sweepList executes the ListBoardingSweeps RPC and prints the result.
+func sweepList(cmd *cobra.Command, _ []string) error {
+	client, conn, err := getDaemonClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	statusFilter, _ := cmd.Flags().GetString("status")
+	pageSize, _ := cmd.Flags().GetUint32("page-size")
+	pageToken, _ := cmd.Flags().GetString("page-token")
+	req := &daemonrpc.ListBoardingSweepsRequest{
+		Status:    statusFilter,
+		PageSize:  pageSize,
+		PageToken: pageToken,
+	}
+
+	resp, err := client.ListBoardingSweeps(context.Background(), req)
+	if err != nil {
+		return fmt.Errorf("ListBoardingSweeps RPC failed: %w", err)
+	}
+
+	return printJSON(resp)
+}
+
+// validateOutpointString validates the txid:index syntax accepted by sweep
+// outpoint flags before making an RPC.
+func validateOutpointString(outpoint string) error {
+	parts := strings.SplitN(outpoint, ":", 2)
+	if len(parts) != 2 {
+		return fmt.Errorf("expected txid:index")
+	}
+	if _, err := chainhash.NewHashFromStr(parts[0]); err != nil {
+		return fmt.Errorf("invalid txid: %w", err)
+	}
+	if _, err := strconv.ParseUint(parts[1], 10, 32); err != nil {
+		return fmt.Errorf("invalid index: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/darepocli/darepoclicommands/root.go
+++ b/cmd/darepocli/darepoclicommands/root.go
@@ -57,6 +57,7 @@ func NewRootCmd() *cobra.Command {
 		newVTXOsCmd(),
 		newSendCmd(),
 		newBoardCmd(),
+		newSweepCmd(),
 		newRoundsCmd(),
 		newFeesCmd(),
 		newSchemaCmd(),

--- a/cmd/darepocli/darepoclicommands/schema_registry.go
+++ b/cmd/darepocli/darepoclicommands/schema_registry.go
@@ -123,6 +123,75 @@ func baseMethodRegistry() []schemaMethod {
 			JSONInput:    true,
 		},
 		{
+			Method:      "sweep",
+			Description: "Sweep expired boarding UTXOs",
+			Params: []schemaParam{
+				{
+					Name: "outpoint",
+					Type: "string[]",
+					Description: "boarding UTXO " +
+						"outpoint(s) to sweep " +
+						"(txid:index)",
+				},
+				{
+					Name: "broadcast",
+					Type: "bool",
+					Description: "broadcast aggregate " +
+						"sweep and track confirmation",
+				},
+				{
+					Name: "fee_rate_sat_per_vbyte",
+					Type: "int64",
+					Description: "fee rate override; " +
+						"zero estimates by target",
+				},
+				{
+					Name: "conf_target",
+					Type: "uint32",
+					Description: "confirmation target; " +
+						"zero uses default",
+				},
+				{
+					Name: "sweep_address",
+					Type: "string",
+					Description: "optional destination; " +
+						"empty uses wallet address",
+				},
+			},
+			RequestType:  "SweepBoardingUTXOsRequest",
+			ResponseType: "SweepBoardingUTXOsResponse",
+			JSONInput:    true,
+		},
+		{
+			Method:      "sweep.list",
+			Description: "List tracked boarding sweeps",
+			Params: []schemaParam{
+				{
+					Name: "status",
+					Type: "string",
+					Description: "status filter: " +
+						"pending, published, " +
+						"confirmed, " +
+						"external_resolved, or failed",
+				},
+				{
+					Name: "page_size",
+					Type: "uint32",
+					Description: "maximum sweeps to " +
+						"return; zero uses default",
+				},
+				{
+					Name: "page_token",
+					Type: "string",
+					Description: "token from a previous " +
+						"sweep list response",
+				},
+			},
+			RequestType:  "ListBoardingSweepsRequest",
+			ResponseType: "ListBoardingSweepsResponse",
+			JSONInput:    true,
+		},
+		{
 			Method:      "oor.receive",
 			Description: "Allocate a fresh receive script",
 			Params: []schemaParam{

--- a/daemonrpc/daemon.pb.go
+++ b/daemonrpc/daemon.pb.go
@@ -3315,6 +3315,652 @@ func (x *BoardResponse) GetVtxoCount() uint32 {
 	return 0
 }
 
+type SweepBoardingUTXOsRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// outpoints optionally restricts sweeping to specific boarding UTXOs,
+	// formatted as "txid:index". Empty means scan all sweepable boarding
+	// intents.
+	Outpoints []string `protobuf:"bytes,1,rep,name=outpoints,proto3" json:"outpoints,omitempty"`
+	// broadcast makes the RPC publish one aggregate sweep transaction and
+	// record it as pending confirmation. The daemon marks boarding intents
+	// swept only after the chain backend reports their outpoints as spent.
+	// The default false value only previews candidates, totals, and fees.
+	Broadcast bool `protobuf:"varint,2,opt,name=broadcast,proto3" json:"broadcast,omitempty"`
+	// fee_rate_sat_per_vbyte optionally overrides fee estimation. A zero value
+	// asks the daemon to estimate a fee rate from conf_target.
+	FeeRateSatPerVbyte int64 `protobuf:"varint,3,opt,name=fee_rate_sat_per_vbyte,json=feeRateSatPerVbyte,proto3" json:"fee_rate_sat_per_vbyte,omitempty"`
+	// conf_target is the target confirmation count used for fee estimation.
+	// A zero value uses the daemon default.
+	ConfTarget uint32 `protobuf:"varint,4,opt,name=conf_target,json=confTarget,proto3" json:"conf_target,omitempty"`
+	// sweep_address optionally overrides the destination for the aggregate
+	// sweep. Empty means sweep into a fresh wallet address.
+	SweepAddress  string `protobuf:"bytes,5,opt,name=sweep_address,json=sweepAddress,proto3" json:"sweep_address,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SweepBoardingUTXOsRequest) Reset() {
+	*x = SweepBoardingUTXOsRequest{}
+	mi := &file_daemon_proto_msgTypes[44]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SweepBoardingUTXOsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SweepBoardingUTXOsRequest) ProtoMessage() {}
+
+func (x *SweepBoardingUTXOsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[44]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SweepBoardingUTXOsRequest.ProtoReflect.Descriptor instead.
+func (*SweepBoardingUTXOsRequest) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{44}
+}
+
+func (x *SweepBoardingUTXOsRequest) GetOutpoints() []string {
+	if x != nil {
+		return x.Outpoints
+	}
+	return nil
+}
+
+func (x *SweepBoardingUTXOsRequest) GetBroadcast() bool {
+	if x != nil {
+		return x.Broadcast
+	}
+	return false
+}
+
+func (x *SweepBoardingUTXOsRequest) GetFeeRateSatPerVbyte() int64 {
+	if x != nil {
+		return x.FeeRateSatPerVbyte
+	}
+	return 0
+}
+
+func (x *SweepBoardingUTXOsRequest) GetConfTarget() uint32 {
+	if x != nil {
+		return x.ConfTarget
+	}
+	return 0
+}
+
+func (x *SweepBoardingUTXOsRequest) GetSweepAddress() string {
+	if x != nil {
+		return x.SweepAddress
+	}
+	return ""
+}
+
+type BoardingSweepOutput struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// outpoint is the boarding UTXO that can be swept.
+	Outpoint string `protobuf:"bytes,1,opt,name=outpoint,proto3" json:"outpoint,omitempty"`
+	// amount_sat is the value of the boarding UTXO.
+	AmountSat int64 `protobuf:"varint,2,opt,name=amount_sat,json=amountSat,proto3" json:"amount_sat,omitempty"`
+	// maturity_height is the first block height at which the CSV timeout path
+	// can be spent.
+	MaturityHeight int32 `protobuf:"varint,3,opt,name=maturity_height,json=maturityHeight,proto3" json:"maturity_height,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *BoardingSweepOutput) Reset() {
+	*x = BoardingSweepOutput{}
+	mi := &file_daemon_proto_msgTypes[45]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BoardingSweepOutput) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BoardingSweepOutput) ProtoMessage() {}
+
+func (x *BoardingSweepOutput) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[45]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BoardingSweepOutput.ProtoReflect.Descriptor instead.
+func (*BoardingSweepOutput) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{45}
+}
+
+func (x *BoardingSweepOutput) GetOutpoint() string {
+	if x != nil {
+		return x.Outpoint
+	}
+	return ""
+}
+
+func (x *BoardingSweepOutput) GetAmountSat() int64 {
+	if x != nil {
+		return x.AmountSat
+	}
+	return 0
+}
+
+func (x *BoardingSweepOutput) GetMaturityHeight() int32 {
+	if x != nil {
+		return x.MaturityHeight
+	}
+	return 0
+}
+
+type SweepBoardingUTXOsResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// status is "preview", "published", or "failed".
+	Status string `protobuf:"bytes,1,opt,name=status,proto3" json:"status,omitempty"`
+	// current_height is the best chain height used for the maturity scan.
+	CurrentHeight int32 `protobuf:"varint,2,opt,name=current_height,json=currentHeight,proto3" json:"current_height,omitempty"`
+	// sweepable_outputs contains the mature boarding UTXOs included in the
+	// aggregate sweep preview or broadcast.
+	SweepableOutputs []*BoardingSweepOutput `protobuf:"bytes,3,rep,name=sweepable_outputs,json=sweepableOutputs,proto3" json:"sweepable_outputs,omitempty"`
+	// total_amount_sat is the total value of all sweepable outputs.
+	TotalAmountSat int64 `protobuf:"varint,4,opt,name=total_amount_sat,json=totalAmountSat,proto3" json:"total_amount_sat,omitempty"`
+	// estimated_fee_sat is the fee required for the aggregate sweep
+	// transaction at fee_rate_sat_per_vbyte.
+	EstimatedFeeSat int64 `protobuf:"varint,5,opt,name=estimated_fee_sat,json=estimatedFeeSat,proto3" json:"estimated_fee_sat,omitempty"`
+	// net_amount_sat is total_amount_sat minus estimated_fee_sat.
+	NetAmountSat int64 `protobuf:"varint,6,opt,name=net_amount_sat,json=netAmountSat,proto3" json:"net_amount_sat,omitempty"`
+	// fee_rate_sat_per_vbyte is the fee rate used to build the aggregate
+	// sweep.
+	FeeRateSatPerVbyte int64 `protobuf:"varint,7,opt,name=fee_rate_sat_per_vbyte,json=feeRateSatPerVbyte,proto3" json:"fee_rate_sat_per_vbyte,omitempty"`
+	// conf_target is the confirmation target used when fee estimation was
+	// requested.
+	ConfTarget uint32 `protobuf:"varint,8,opt,name=conf_target,json=confTarget,proto3" json:"conf_target,omitempty"`
+	// txid is the aggregate sweep transaction id. Preview responses set the
+	// txid of the signed transaction built for the current request; a later
+	// broadcast can differ if inputs, fees, or destination change.
+	Txid string `protobuf:"bytes,9,opt,name=txid,proto3" json:"txid,omitempty"`
+	// fee_paid_sat is set when broadcast=true and records the actual fee paid
+	// by the aggregate sweep transaction. The fee is known at publication;
+	// confirmation is tracked asynchronously by the daemon.
+	FeePaidSat int64 `protobuf:"varint,10,opt,name=fee_paid_sat,json=feePaidSat,proto3" json:"fee_paid_sat,omitempty"`
+	// tx_vbytes is the virtual byte size of the signed aggregate sweep
+	// transaction.
+	TxVbytes int64 `protobuf:"varint,11,opt,name=tx_vbytes,json=txVbytes,proto3" json:"tx_vbytes,omitempty"`
+	// failure_reason carries aggregate build, broadcast, or persistence
+	// errors.
+	FailureReason string `protobuf:"bytes,12,opt,name=failure_reason,json=failureReason,proto3" json:"failure_reason,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SweepBoardingUTXOsResponse) Reset() {
+	*x = SweepBoardingUTXOsResponse{}
+	mi := &file_daemon_proto_msgTypes[46]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SweepBoardingUTXOsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SweepBoardingUTXOsResponse) ProtoMessage() {}
+
+func (x *SweepBoardingUTXOsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[46]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SweepBoardingUTXOsResponse.ProtoReflect.Descriptor instead.
+func (*SweepBoardingUTXOsResponse) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{46}
+}
+
+func (x *SweepBoardingUTXOsResponse) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
+func (x *SweepBoardingUTXOsResponse) GetCurrentHeight() int32 {
+	if x != nil {
+		return x.CurrentHeight
+	}
+	return 0
+}
+
+func (x *SweepBoardingUTXOsResponse) GetSweepableOutputs() []*BoardingSweepOutput {
+	if x != nil {
+		return x.SweepableOutputs
+	}
+	return nil
+}
+
+func (x *SweepBoardingUTXOsResponse) GetTotalAmountSat() int64 {
+	if x != nil {
+		return x.TotalAmountSat
+	}
+	return 0
+}
+
+func (x *SweepBoardingUTXOsResponse) GetEstimatedFeeSat() int64 {
+	if x != nil {
+		return x.EstimatedFeeSat
+	}
+	return 0
+}
+
+func (x *SweepBoardingUTXOsResponse) GetNetAmountSat() int64 {
+	if x != nil {
+		return x.NetAmountSat
+	}
+	return 0
+}
+
+func (x *SweepBoardingUTXOsResponse) GetFeeRateSatPerVbyte() int64 {
+	if x != nil {
+		return x.FeeRateSatPerVbyte
+	}
+	return 0
+}
+
+func (x *SweepBoardingUTXOsResponse) GetConfTarget() uint32 {
+	if x != nil {
+		return x.ConfTarget
+	}
+	return 0
+}
+
+func (x *SweepBoardingUTXOsResponse) GetTxid() string {
+	if x != nil {
+		return x.Txid
+	}
+	return ""
+}
+
+func (x *SweepBoardingUTXOsResponse) GetFeePaidSat() int64 {
+	if x != nil {
+		return x.FeePaidSat
+	}
+	return 0
+}
+
+func (x *SweepBoardingUTXOsResponse) GetTxVbytes() int64 {
+	if x != nil {
+		return x.TxVbytes
+	}
+	return 0
+}
+
+func (x *SweepBoardingUTXOsResponse) GetFailureReason() string {
+	if x != nil {
+		return x.FailureReason
+	}
+	return ""
+}
+
+type ListBoardingSweepsRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// status optionally filters tracked sweeps by persisted status:
+	// "pending", "published", "confirmed", "external_resolved", or
+	// "failed". Empty lists all.
+	Status string `protobuf:"bytes,1,opt,name=status,proto3" json:"status,omitempty"`
+	// page_size limits the number of sweeps returned. Zero uses the daemon
+	// default.
+	PageSize uint32 `protobuf:"varint,2,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
+	// page_token is the opaque token returned by a previous response.
+	PageToken     string `protobuf:"bytes,3,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListBoardingSweepsRequest) Reset() {
+	*x = ListBoardingSweepsRequest{}
+	mi := &file_daemon_proto_msgTypes[47]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListBoardingSweepsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListBoardingSweepsRequest) ProtoMessage() {}
+
+func (x *ListBoardingSweepsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[47]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListBoardingSweepsRequest.ProtoReflect.Descriptor instead.
+func (*ListBoardingSweepsRequest) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{47}
+}
+
+func (x *ListBoardingSweepsRequest) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
+func (x *ListBoardingSweepsRequest) GetPageSize() uint32 {
+	if x != nil {
+		return x.PageSize
+	}
+	return 0
+}
+
+func (x *ListBoardingSweepsRequest) GetPageToken() string {
+	if x != nil {
+		return x.PageToken
+	}
+	return ""
+}
+
+type BoardingSweepInput struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// outpoint is the boarding UTXO tracked by this sweep.
+	Outpoint string `protobuf:"bytes,1,opt,name=outpoint,proto3" json:"outpoint,omitempty"`
+	// amount_sat is the value of the boarding UTXO.
+	AmountSat int64 `protobuf:"varint,2,opt,name=amount_sat,json=amountSat,proto3" json:"amount_sat,omitempty"`
+	// status is the persisted per-input status: "pending", "published",
+	// "spent", "external_spent", or "failed".
+	Status string `protobuf:"bytes,3,opt,name=status,proto3" json:"status,omitempty"`
+	// spent_by_txid is set after the chain backend reports a confirmed spend.
+	SpentByTxid string `protobuf:"bytes,4,opt,name=spent_by_txid,json=spentByTxid,proto3" json:"spent_by_txid,omitempty"`
+	// spent_height is the block height of the confirmed spend when known.
+	SpentHeight   int32 `protobuf:"varint,5,opt,name=spent_height,json=spentHeight,proto3" json:"spent_height,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BoardingSweepInput) Reset() {
+	*x = BoardingSweepInput{}
+	mi := &file_daemon_proto_msgTypes[48]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BoardingSweepInput) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BoardingSweepInput) ProtoMessage() {}
+
+func (x *BoardingSweepInput) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[48]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BoardingSweepInput.ProtoReflect.Descriptor instead.
+func (*BoardingSweepInput) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{48}
+}
+
+func (x *BoardingSweepInput) GetOutpoint() string {
+	if x != nil {
+		return x.Outpoint
+	}
+	return ""
+}
+
+func (x *BoardingSweepInput) GetAmountSat() int64 {
+	if x != nil {
+		return x.AmountSat
+	}
+	return 0
+}
+
+func (x *BoardingSweepInput) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
+func (x *BoardingSweepInput) GetSpentByTxid() string {
+	if x != nil {
+		return x.SpentByTxid
+	}
+	return ""
+}
+
+func (x *BoardingSweepInput) GetSpentHeight() int32 {
+	if x != nil {
+		return x.SpentHeight
+	}
+	return 0
+}
+
+type BoardingSweep struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// txid is the aggregate sweep transaction id.
+	Txid string `protobuf:"bytes,1,opt,name=txid,proto3" json:"txid,omitempty"`
+	// status is the persisted aggregate status: "pending", "published",
+	// "confirmed", "external_resolved", or "failed".
+	Status string `protobuf:"bytes,2,opt,name=status,proto3" json:"status,omitempty"`
+	// destination_address is the caller-specified sweep address, if any.
+	DestinationAddress string `protobuf:"bytes,3,opt,name=destination_address,json=destinationAddress,proto3" json:"destination_address,omitempty"`
+	// total_amount_sat is the total value of every sweep input.
+	TotalAmountSat int64 `protobuf:"varint,4,opt,name=total_amount_sat,json=totalAmountSat,proto3" json:"total_amount_sat,omitempty"`
+	// fee_paid_sat is the fee paid by the aggregate sweep transaction.
+	FeePaidSat int64 `protobuf:"varint,5,opt,name=fee_paid_sat,json=feePaidSat,proto3" json:"fee_paid_sat,omitempty"`
+	// fee_rate_sat_per_vbyte is the fee rate used to build the sweep.
+	FeeRateSatPerVbyte int64 `protobuf:"varint,6,opt,name=fee_rate_sat_per_vbyte,json=feeRateSatPerVbyte,proto3" json:"fee_rate_sat_per_vbyte,omitempty"`
+	// tx_vbytes is the virtual byte size of the sweep transaction.
+	TxVbytes int64 `protobuf:"varint,7,opt,name=tx_vbytes,json=txVbytes,proto3" json:"tx_vbytes,omitempty"`
+	// created_height is the best chain height when the sweep was created.
+	CreatedHeight int32 `protobuf:"varint,8,opt,name=created_height,json=createdHeight,proto3" json:"created_height,omitempty"`
+	// confirmed_height is set once every tracked input has confirmed spent.
+	ConfirmedHeight int32 `protobuf:"varint,9,opt,name=confirmed_height,json=confirmedHeight,proto3" json:"confirmed_height,omitempty"`
+	// inputs contains the boarding outpoints tracked by this sweep.
+	Inputs []*BoardingSweepInput `protobuf:"bytes,10,rep,name=inputs,proto3" json:"inputs,omitempty"`
+	// failure_reason carries the terminal local failure reason for failed
+	// sweeps.
+	FailureReason string `protobuf:"bytes,11,opt,name=failure_reason,json=failureReason,proto3" json:"failure_reason,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BoardingSweep) Reset() {
+	*x = BoardingSweep{}
+	mi := &file_daemon_proto_msgTypes[49]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BoardingSweep) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BoardingSweep) ProtoMessage() {}
+
+func (x *BoardingSweep) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[49]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BoardingSweep.ProtoReflect.Descriptor instead.
+func (*BoardingSweep) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{49}
+}
+
+func (x *BoardingSweep) GetTxid() string {
+	if x != nil {
+		return x.Txid
+	}
+	return ""
+}
+
+func (x *BoardingSweep) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
+func (x *BoardingSweep) GetDestinationAddress() string {
+	if x != nil {
+		return x.DestinationAddress
+	}
+	return ""
+}
+
+func (x *BoardingSweep) GetTotalAmountSat() int64 {
+	if x != nil {
+		return x.TotalAmountSat
+	}
+	return 0
+}
+
+func (x *BoardingSweep) GetFeePaidSat() int64 {
+	if x != nil {
+		return x.FeePaidSat
+	}
+	return 0
+}
+
+func (x *BoardingSweep) GetFeeRateSatPerVbyte() int64 {
+	if x != nil {
+		return x.FeeRateSatPerVbyte
+	}
+	return 0
+}
+
+func (x *BoardingSweep) GetTxVbytes() int64 {
+	if x != nil {
+		return x.TxVbytes
+	}
+	return 0
+}
+
+func (x *BoardingSweep) GetCreatedHeight() int32 {
+	if x != nil {
+		return x.CreatedHeight
+	}
+	return 0
+}
+
+func (x *BoardingSweep) GetConfirmedHeight() int32 {
+	if x != nil {
+		return x.ConfirmedHeight
+	}
+	return 0
+}
+
+func (x *BoardingSweep) GetInputs() []*BoardingSweepInput {
+	if x != nil {
+		return x.Inputs
+	}
+	return nil
+}
+
+func (x *BoardingSweep) GetFailureReason() string {
+	if x != nil {
+		return x.FailureReason
+	}
+	return ""
+}
+
+type ListBoardingSweepsResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// sweeps are returned newest first by creation time.
+	Sweeps []*BoardingSweep `protobuf:"bytes,1,rep,name=sweeps,proto3" json:"sweeps,omitempty"`
+	// next_page_token is set when another page is available.
+	NextPageToken string `protobuf:"bytes,2,opt,name=next_page_token,json=nextPageToken,proto3" json:"next_page_token,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListBoardingSweepsResponse) Reset() {
+	*x = ListBoardingSweepsResponse{}
+	mi := &file_daemon_proto_msgTypes[50]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListBoardingSweepsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListBoardingSweepsResponse) ProtoMessage() {}
+
+func (x *ListBoardingSweepsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[50]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListBoardingSweepsResponse.ProtoReflect.Descriptor instead.
+func (*ListBoardingSweepsResponse) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{50}
+}
+
+func (x *ListBoardingSweepsResponse) GetSweeps() []*BoardingSweep {
+	if x != nil {
+		return x.Sweeps
+	}
+	return nil
+}
+
+func (x *ListBoardingSweepsResponse) GetNextPageToken() string {
+	if x != nil {
+		return x.NextPageToken
+	}
+	return ""
+}
+
 // RoundVTXOInfo describes a VTXO created in a round.
 type RoundVTXOInfo struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -3328,7 +3974,7 @@ type RoundVTXOInfo struct {
 
 func (x *RoundVTXOInfo) Reset() {
 	*x = RoundVTXOInfo{}
-	mi := &file_daemon_proto_msgTypes[44]
+	mi := &file_daemon_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3340,7 +3986,7 @@ func (x *RoundVTXOInfo) String() string {
 func (*RoundVTXOInfo) ProtoMessage() {}
 
 func (x *RoundVTXOInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[44]
+	mi := &file_daemon_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3353,7 +3999,7 @@ func (x *RoundVTXOInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoundVTXOInfo.ProtoReflect.Descriptor instead.
 func (*RoundVTXOInfo) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{44}
+	return file_daemon_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *RoundVTXOInfo) GetOutpoint() string {
@@ -3413,7 +4059,7 @@ type RoundInfo struct {
 
 func (x *RoundInfo) Reset() {
 	*x = RoundInfo{}
-	mi := &file_daemon_proto_msgTypes[45]
+	mi := &file_daemon_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3425,7 +4071,7 @@ func (x *RoundInfo) String() string {
 func (*RoundInfo) ProtoMessage() {}
 
 func (x *RoundInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[45]
+	mi := &file_daemon_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3438,7 +4084,7 @@ func (x *RoundInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoundInfo.ProtoReflect.Descriptor instead.
 func (*RoundInfo) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{45}
+	return file_daemon_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *RoundInfo) GetRoundId() string {
@@ -3550,7 +4196,7 @@ type ListRoundsRequest struct {
 
 func (x *ListRoundsRequest) Reset() {
 	*x = ListRoundsRequest{}
-	mi := &file_daemon_proto_msgTypes[46]
+	mi := &file_daemon_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3562,7 +4208,7 @@ func (x *ListRoundsRequest) String() string {
 func (*ListRoundsRequest) ProtoMessage() {}
 
 func (x *ListRoundsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[46]
+	mi := &file_daemon_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3575,7 +4221,7 @@ func (x *ListRoundsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRoundsRequest.ProtoReflect.Descriptor instead.
 func (*ListRoundsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{46}
+	return file_daemon_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *ListRoundsRequest) GetPageSize() int32 {
@@ -3630,7 +4276,7 @@ type GetRoundRequest struct {
 
 func (x *GetRoundRequest) Reset() {
 	*x = GetRoundRequest{}
-	mi := &file_daemon_proto_msgTypes[47]
+	mi := &file_daemon_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3642,7 +4288,7 @@ func (x *GetRoundRequest) String() string {
 func (*GetRoundRequest) ProtoMessage() {}
 
 func (x *GetRoundRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[47]
+	mi := &file_daemon_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3655,7 +4301,7 @@ func (x *GetRoundRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRoundRequest.ProtoReflect.Descriptor instead.
 func (*GetRoundRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{47}
+	return file_daemon_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *GetRoundRequest) GetRoundId() string {
@@ -3675,7 +4321,7 @@ type GetRoundResponse struct {
 
 func (x *GetRoundResponse) Reset() {
 	*x = GetRoundResponse{}
-	mi := &file_daemon_proto_msgTypes[48]
+	mi := &file_daemon_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3687,7 +4333,7 @@ func (x *GetRoundResponse) String() string {
 func (*GetRoundResponse) ProtoMessage() {}
 
 func (x *GetRoundResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[48]
+	mi := &file_daemon_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3700,7 +4346,7 @@ func (x *GetRoundResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRoundResponse.ProtoReflect.Descriptor instead.
 func (*GetRoundResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{48}
+	return file_daemon_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *GetRoundResponse) GetRound() *RoundInfo {
@@ -3723,7 +4369,7 @@ type ListRoundsResponse struct {
 
 func (x *ListRoundsResponse) Reset() {
 	*x = ListRoundsResponse{}
-	mi := &file_daemon_proto_msgTypes[49]
+	mi := &file_daemon_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3735,7 +4381,7 @@ func (x *ListRoundsResponse) String() string {
 func (*ListRoundsResponse) ProtoMessage() {}
 
 func (x *ListRoundsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[49]
+	mi := &file_daemon_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3748,7 +4394,7 @@ func (x *ListRoundsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRoundsResponse.ProtoReflect.Descriptor instead.
 func (*ListRoundsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{49}
+	return file_daemon_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *ListRoundsResponse) GetRounds() []*RoundInfo {
@@ -3773,7 +4419,7 @@ type WatchRoundsRequest struct {
 
 func (x *WatchRoundsRequest) Reset() {
 	*x = WatchRoundsRequest{}
-	mi := &file_daemon_proto_msgTypes[50]
+	mi := &file_daemon_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3785,7 +4431,7 @@ func (x *WatchRoundsRequest) String() string {
 func (*WatchRoundsRequest) ProtoMessage() {}
 
 func (x *WatchRoundsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[50]
+	mi := &file_daemon_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3798,7 +4444,7 @@ func (x *WatchRoundsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchRoundsRequest.ProtoReflect.Descriptor instead.
 func (*WatchRoundsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{50}
+	return file_daemon_proto_rawDescGZIP(), []int{57}
 }
 
 type WatchRoundsResponse struct {
@@ -3812,7 +4458,7 @@ type WatchRoundsResponse struct {
 
 func (x *WatchRoundsResponse) Reset() {
 	*x = WatchRoundsResponse{}
-	mi := &file_daemon_proto_msgTypes[51]
+	mi := &file_daemon_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3824,7 +4470,7 @@ func (x *WatchRoundsResponse) String() string {
 func (*WatchRoundsResponse) ProtoMessage() {}
 
 func (x *WatchRoundsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[51]
+	mi := &file_daemon_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3837,7 +4483,7 @@ func (x *WatchRoundsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchRoundsResponse.ProtoReflect.Descriptor instead.
 func (*WatchRoundsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{51}
+	return file_daemon_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *WatchRoundsResponse) GetRound() *RoundInfo {
@@ -3875,7 +4521,7 @@ type OORSessionInfo struct {
 
 func (x *OORSessionInfo) Reset() {
 	*x = OORSessionInfo{}
-	mi := &file_daemon_proto_msgTypes[52]
+	mi := &file_daemon_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3887,7 +4533,7 @@ func (x *OORSessionInfo) String() string {
 func (*OORSessionInfo) ProtoMessage() {}
 
 func (x *OORSessionInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[52]
+	mi := &file_daemon_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3900,7 +4546,7 @@ func (x *OORSessionInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OORSessionInfo.ProtoReflect.Descriptor instead.
 func (*OORSessionInfo) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{52}
+	return file_daemon_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *OORSessionInfo) GetSessionId() string {
@@ -3984,7 +4630,7 @@ type ListOORSessionsRequest struct {
 
 func (x *ListOORSessionsRequest) Reset() {
 	*x = ListOORSessionsRequest{}
-	mi := &file_daemon_proto_msgTypes[53]
+	mi := &file_daemon_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3996,7 +4642,7 @@ func (x *ListOORSessionsRequest) String() string {
 func (*ListOORSessionsRequest) ProtoMessage() {}
 
 func (x *ListOORSessionsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[53]
+	mi := &file_daemon_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4009,7 +4655,7 @@ func (x *ListOORSessionsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListOORSessionsRequest.ProtoReflect.Descriptor instead.
 func (*ListOORSessionsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{53}
+	return file_daemon_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *ListOORSessionsRequest) GetPageSize() int32 {
@@ -4053,7 +4699,7 @@ type ListOORSessionsResponse struct {
 
 func (x *ListOORSessionsResponse) Reset() {
 	*x = ListOORSessionsResponse{}
-	mi := &file_daemon_proto_msgTypes[54]
+	mi := &file_daemon_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4065,7 +4711,7 @@ func (x *ListOORSessionsResponse) String() string {
 func (*ListOORSessionsResponse) ProtoMessage() {}
 
 func (x *ListOORSessionsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[54]
+	mi := &file_daemon_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4078,7 +4724,7 @@ func (x *ListOORSessionsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListOORSessionsResponse.ProtoReflect.Descriptor instead.
 func (*ListOORSessionsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{54}
+	return file_daemon_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *ListOORSessionsResponse) GetSessions() []*OORSessionInfo {
@@ -4105,7 +4751,7 @@ type GetOORSessionRequest struct {
 
 func (x *GetOORSessionRequest) Reset() {
 	*x = GetOORSessionRequest{}
-	mi := &file_daemon_proto_msgTypes[55]
+	mi := &file_daemon_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4117,7 +4763,7 @@ func (x *GetOORSessionRequest) String() string {
 func (*GetOORSessionRequest) ProtoMessage() {}
 
 func (x *GetOORSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[55]
+	mi := &file_daemon_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4130,7 +4776,7 @@ func (x *GetOORSessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetOORSessionRequest.ProtoReflect.Descriptor instead.
 func (*GetOORSessionRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{55}
+	return file_daemon_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *GetOORSessionRequest) GetSessionId() string {
@@ -4150,7 +4796,7 @@ type GetOORSessionResponse struct {
 
 func (x *GetOORSessionResponse) Reset() {
 	*x = GetOORSessionResponse{}
-	mi := &file_daemon_proto_msgTypes[56]
+	mi := &file_daemon_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4162,7 +4808,7 @@ func (x *GetOORSessionResponse) String() string {
 func (*GetOORSessionResponse) ProtoMessage() {}
 
 func (x *GetOORSessionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[56]
+	mi := &file_daemon_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4175,7 +4821,7 @@ func (x *GetOORSessionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetOORSessionResponse.ProtoReflect.Descriptor instead.
 func (*GetOORSessionResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{56}
+	return file_daemon_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *GetOORSessionResponse) GetSession() *OORSessionInfo {
@@ -4203,7 +4849,7 @@ type EstimateFeeRequest struct {
 
 func (x *EstimateFeeRequest) Reset() {
 	*x = EstimateFeeRequest{}
-	mi := &file_daemon_proto_msgTypes[57]
+	mi := &file_daemon_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4215,7 +4861,7 @@ func (x *EstimateFeeRequest) String() string {
 func (*EstimateFeeRequest) ProtoMessage() {}
 
 func (x *EstimateFeeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[57]
+	mi := &file_daemon_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4228,7 +4874,7 @@ func (x *EstimateFeeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EstimateFeeRequest.ProtoReflect.Descriptor instead.
 func (*EstimateFeeRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{57}
+	return file_daemon_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *EstimateFeeRequest) GetAmountSat() int64 {
@@ -4282,7 +4928,7 @@ type EstimateFeeResponse struct {
 
 func (x *EstimateFeeResponse) Reset() {
 	*x = EstimateFeeResponse{}
-	mi := &file_daemon_proto_msgTypes[58]
+	mi := &file_daemon_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4294,7 +4940,7 @@ func (x *EstimateFeeResponse) String() string {
 func (*EstimateFeeResponse) ProtoMessage() {}
 
 func (x *EstimateFeeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[58]
+	mi := &file_daemon_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4307,7 +4953,7 @@ func (x *EstimateFeeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EstimateFeeResponse.ProtoReflect.Descriptor instead.
 func (*EstimateFeeResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{58}
+	return file_daemon_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *EstimateFeeResponse) GetLiquidityFeeSat() int64 {
@@ -4377,7 +5023,7 @@ type GetFeeHistoryRequest struct {
 
 func (x *GetFeeHistoryRequest) Reset() {
 	*x = GetFeeHistoryRequest{}
-	mi := &file_daemon_proto_msgTypes[59]
+	mi := &file_daemon_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4389,7 +5035,7 @@ func (x *GetFeeHistoryRequest) String() string {
 func (*GetFeeHistoryRequest) ProtoMessage() {}
 
 func (x *GetFeeHistoryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[59]
+	mi := &file_daemon_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4402,7 +5048,7 @@ func (x *GetFeeHistoryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetFeeHistoryRequest.ProtoReflect.Descriptor instead.
 func (*GetFeeHistoryRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{59}
+	return file_daemon_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *GetFeeHistoryRequest) GetLimit() uint32 {
@@ -4477,7 +5123,7 @@ type FeeHistoryEntry struct {
 
 func (x *FeeHistoryEntry) Reset() {
 	*x = FeeHistoryEntry{}
-	mi := &file_daemon_proto_msgTypes[60]
+	mi := &file_daemon_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4489,7 +5135,7 @@ func (x *FeeHistoryEntry) String() string {
 func (*FeeHistoryEntry) ProtoMessage() {}
 
 func (x *FeeHistoryEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[60]
+	mi := &file_daemon_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4502,7 +5148,7 @@ func (x *FeeHistoryEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FeeHistoryEntry.ProtoReflect.Descriptor instead.
 func (*FeeHistoryEntry) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{60}
+	return file_daemon_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *FeeHistoryEntry) GetEntryId() int64 {
@@ -4582,7 +5228,7 @@ type GetFeeHistoryResponse struct {
 
 func (x *GetFeeHistoryResponse) Reset() {
 	*x = GetFeeHistoryResponse{}
-	mi := &file_daemon_proto_msgTypes[61]
+	mi := &file_daemon_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4594,7 +5240,7 @@ func (x *GetFeeHistoryResponse) String() string {
 func (*GetFeeHistoryResponse) ProtoMessage() {}
 
 func (x *GetFeeHistoryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[61]
+	mi := &file_daemon_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4607,7 +5253,7 @@ func (x *GetFeeHistoryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetFeeHistoryResponse.ProtoReflect.Descriptor instead.
 func (*GetFeeHistoryResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{61}
+	return file_daemon_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *GetFeeHistoryResponse) GetEntries() []*FeeHistoryEntry {
@@ -4635,7 +5281,7 @@ type UnrollRequest struct {
 
 func (x *UnrollRequest) Reset() {
 	*x = UnrollRequest{}
-	mi := &file_daemon_proto_msgTypes[62]
+	mi := &file_daemon_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4647,7 +5293,7 @@ func (x *UnrollRequest) String() string {
 func (*UnrollRequest) ProtoMessage() {}
 
 func (x *UnrollRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[62]
+	mi := &file_daemon_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4660,7 +5306,7 @@ func (x *UnrollRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnrollRequest.ProtoReflect.Descriptor instead.
 func (*UnrollRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{62}
+	return file_daemon_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *UnrollRequest) GetOutpoint() string {
@@ -4683,7 +5329,7 @@ type UnrollResponse struct {
 
 func (x *UnrollResponse) Reset() {
 	*x = UnrollResponse{}
-	mi := &file_daemon_proto_msgTypes[63]
+	mi := &file_daemon_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4695,7 +5341,7 @@ func (x *UnrollResponse) String() string {
 func (*UnrollResponse) ProtoMessage() {}
 
 func (x *UnrollResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[63]
+	mi := &file_daemon_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4708,7 +5354,7 @@ func (x *UnrollResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnrollResponse.ProtoReflect.Descriptor instead.
 func (*UnrollResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{63}
+	return file_daemon_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *UnrollResponse) GetCreated() bool {
@@ -4735,7 +5381,7 @@ type GetUnrollStatusRequest struct {
 
 func (x *GetUnrollStatusRequest) Reset() {
 	*x = GetUnrollStatusRequest{}
-	mi := &file_daemon_proto_msgTypes[64]
+	mi := &file_daemon_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4747,7 +5393,7 @@ func (x *GetUnrollStatusRequest) String() string {
 func (*GetUnrollStatusRequest) ProtoMessage() {}
 
 func (x *GetUnrollStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[64]
+	mi := &file_daemon_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4760,7 +5406,7 @@ func (x *GetUnrollStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUnrollStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetUnrollStatusRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{64}
+	return file_daemon_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *GetUnrollStatusRequest) GetOutpoint() string {
@@ -4788,7 +5434,7 @@ type GetUnrollStatusResponse struct {
 
 func (x *GetUnrollStatusResponse) Reset() {
 	*x = GetUnrollStatusResponse{}
-	mi := &file_daemon_proto_msgTypes[65]
+	mi := &file_daemon_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4800,7 +5446,7 @@ func (x *GetUnrollStatusResponse) String() string {
 func (*GetUnrollStatusResponse) ProtoMessage() {}
 
 func (x *GetUnrollStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[65]
+	mi := &file_daemon_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4813,7 +5459,7 @@ func (x *GetUnrollStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUnrollStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetUnrollStatusResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{65}
+	return file_daemon_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *GetUnrollStatusResponse) GetFound() bool {
@@ -5039,7 +5685,64 @@ const file_daemon_proto_rawDesc = "" +
 	"\rBoardResponse\x12\x16\n" +
 	"\x06status\x18\x01 \x01(\tR\x06status\x12\x1d\n" +
 	"\n" +
-	"vtxo_count\x18\x02 \x01(\rR\tvtxoCount\"J\n" +
+	"vtxo_count\x18\x02 \x01(\rR\tvtxoCount\"\xd1\x01\n" +
+	"\x19SweepBoardingUTXOsRequest\x12\x1c\n" +
+	"\toutpoints\x18\x01 \x03(\tR\toutpoints\x12\x1c\n" +
+	"\tbroadcast\x18\x02 \x01(\bR\tbroadcast\x122\n" +
+	"\x16fee_rate_sat_per_vbyte\x18\x03 \x01(\x03R\x12feeRateSatPerVbyte\x12\x1f\n" +
+	"\vconf_target\x18\x04 \x01(\rR\n" +
+	"confTarget\x12#\n" +
+	"\rsweep_address\x18\x05 \x01(\tR\fsweepAddress\"y\n" +
+	"\x13BoardingSweepOutput\x12\x1a\n" +
+	"\boutpoint\x18\x01 \x01(\tR\boutpoint\x12\x1d\n" +
+	"\n" +
+	"amount_sat\x18\x02 \x01(\x03R\tamountSat\x12'\n" +
+	"\x0fmaturity_height\x18\x03 \x01(\x05R\x0ematurityHeight\"\xf3\x03\n" +
+	"\x1aSweepBoardingUTXOsResponse\x12\x16\n" +
+	"\x06status\x18\x01 \x01(\tR\x06status\x12%\n" +
+	"\x0ecurrent_height\x18\x02 \x01(\x05R\rcurrentHeight\x12K\n" +
+	"\x11sweepable_outputs\x18\x03 \x03(\v2\x1e.daemonrpc.BoardingSweepOutputR\x10sweepableOutputs\x12(\n" +
+	"\x10total_amount_sat\x18\x04 \x01(\x03R\x0etotalAmountSat\x12*\n" +
+	"\x11estimated_fee_sat\x18\x05 \x01(\x03R\x0festimatedFeeSat\x12$\n" +
+	"\x0enet_amount_sat\x18\x06 \x01(\x03R\fnetAmountSat\x122\n" +
+	"\x16fee_rate_sat_per_vbyte\x18\a \x01(\x03R\x12feeRateSatPerVbyte\x12\x1f\n" +
+	"\vconf_target\x18\b \x01(\rR\n" +
+	"confTarget\x12\x12\n" +
+	"\x04txid\x18\t \x01(\tR\x04txid\x12 \n" +
+	"\ffee_paid_sat\x18\n" +
+	" \x01(\x03R\n" +
+	"feePaidSat\x12\x1b\n" +
+	"\ttx_vbytes\x18\v \x01(\x03R\btxVbytes\x12%\n" +
+	"\x0efailure_reason\x18\f \x01(\tR\rfailureReason\"o\n" +
+	"\x19ListBoardingSweepsRequest\x12\x16\n" +
+	"\x06status\x18\x01 \x01(\tR\x06status\x12\x1b\n" +
+	"\tpage_size\x18\x02 \x01(\rR\bpageSize\x12\x1d\n" +
+	"\n" +
+	"page_token\x18\x03 \x01(\tR\tpageToken\"\xae\x01\n" +
+	"\x12BoardingSweepInput\x12\x1a\n" +
+	"\boutpoint\x18\x01 \x01(\tR\boutpoint\x12\x1d\n" +
+	"\n" +
+	"amount_sat\x18\x02 \x01(\x03R\tamountSat\x12\x16\n" +
+	"\x06status\x18\x03 \x01(\tR\x06status\x12\"\n" +
+	"\rspent_by_txid\x18\x04 \x01(\tR\vspentByTxid\x12!\n" +
+	"\fspent_height\x18\x05 \x01(\x05R\vspentHeight\"\xb9\x03\n" +
+	"\rBoardingSweep\x12\x12\n" +
+	"\x04txid\x18\x01 \x01(\tR\x04txid\x12\x16\n" +
+	"\x06status\x18\x02 \x01(\tR\x06status\x12/\n" +
+	"\x13destination_address\x18\x03 \x01(\tR\x12destinationAddress\x12(\n" +
+	"\x10total_amount_sat\x18\x04 \x01(\x03R\x0etotalAmountSat\x12 \n" +
+	"\ffee_paid_sat\x18\x05 \x01(\x03R\n" +
+	"feePaidSat\x122\n" +
+	"\x16fee_rate_sat_per_vbyte\x18\x06 \x01(\x03R\x12feeRateSatPerVbyte\x12\x1b\n" +
+	"\ttx_vbytes\x18\a \x01(\x03R\btxVbytes\x12%\n" +
+	"\x0ecreated_height\x18\b \x01(\x05R\rcreatedHeight\x12)\n" +
+	"\x10confirmed_height\x18\t \x01(\x05R\x0fconfirmedHeight\x125\n" +
+	"\x06inputs\x18\n" +
+	" \x03(\v2\x1d.daemonrpc.BoardingSweepInputR\x06inputs\x12%\n" +
+	"\x0efailure_reason\x18\v \x01(\tR\rfailureReason\"v\n" +
+	"\x1aListBoardingSweepsResponse\x120\n" +
+	"\x06sweeps\x18\x01 \x03(\v2\x18.daemonrpc.BoardingSweepR\x06sweeps\x12&\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"J\n" +
 	"\rRoundVTXOInfo\x12\x1a\n" +
 	"\boutpoint\x18\x01 \x01(\tR\boutpoint\x12\x1d\n" +
 	"\n" +
@@ -5196,7 +5899,7 @@ const file_daemon_proto_rawDesc = "" +
 	"\x1dUNROLL_JOB_STATUS_CSV_PENDING\x10\x03\x12\x1e\n" +
 	"\x1aUNROLL_JOB_STATUS_SWEEPING\x10\x04\x12\x1f\n" +
 	"\x1bUNROLL_JOB_STATUS_COMPLETED\x10\x05\x12\x1c\n" +
-	"\x18UNROLL_JOB_STATUS_FAILED\x10\x062\xa7\x12\n" +
+	"\x18UNROLL_JOB_STATUS_FAILED\x10\x062\xed\x13\n" +
 	"\rDaemonService\x12@\n" +
 	"\aGetInfo\x12\x19.daemonrpc.GetInfoRequest\x1a\x1a.daemonrpc.GetInfoResponse\x12@\n" +
 	"\aGenSeed\x12\x19.daemonrpc.GenSeedRequest\x1a\x1a.daemonrpc.GenSeedResponse\x12I\n" +
@@ -5220,7 +5923,9 @@ const file_daemon_proto_rawDesc = "" +
 	"\fRefreshVTXOs\x12\x1e.daemonrpc.RefreshVTXOsRequest\x1a\x1f.daemonrpc.RefreshVTXOsResponse\x12I\n" +
 	"\n" +
 	"LeaveVTXOs\x12\x1c.daemonrpc.LeaveVTXOsRequest\x1a\x1d.daemonrpc.LeaveVTXOsResponse\x12:\n" +
-	"\x05Board\x12\x17.daemonrpc.BoardRequest\x1a\x18.daemonrpc.BoardResponse\x12I\n" +
+	"\x05Board\x12\x17.daemonrpc.BoardRequest\x1a\x18.daemonrpc.BoardResponse\x12a\n" +
+	"\x12SweepBoardingUTXOs\x12$.daemonrpc.SweepBoardingUTXOsRequest\x1a%.daemonrpc.SweepBoardingUTXOsResponse\x12a\n" +
+	"\x12ListBoardingSweeps\x12$.daemonrpc.ListBoardingSweepsRequest\x1a%.daemonrpc.ListBoardingSweepsResponse\x12I\n" +
 	"\n" +
 	"ListRounds\x12\x1c.daemonrpc.ListRoundsRequest\x1a\x1d.daemonrpc.ListRoundsResponse\x12C\n" +
 	"\bGetRound\x12\x1a.daemonrpc.GetRoundRequest\x1a\x1b.daemonrpc.GetRoundResponse\x12N\n" +
@@ -5245,7 +5950,7 @@ func file_daemon_proto_rawDescGZIP() []byte {
 }
 
 var file_daemon_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 67)
+var file_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 74)
 var file_daemon_proto_goTypes = []any{
 	(VTXOStatus)(0),                               // 0: daemonrpc.VTXOStatus
 	(RoundState)(0),                               // 1: daemonrpc.RoundState
@@ -5296,29 +6001,36 @@ var file_daemon_proto_goTypes = []any{
 	(*LeaveVTXOsResponse)(nil),                    // 46: daemonrpc.LeaveVTXOsResponse
 	(*BoardRequest)(nil),                          // 47: daemonrpc.BoardRequest
 	(*BoardResponse)(nil),                         // 48: daemonrpc.BoardResponse
-	(*RoundVTXOInfo)(nil),                         // 49: daemonrpc.RoundVTXOInfo
-	(*RoundInfo)(nil),                             // 50: daemonrpc.RoundInfo
-	(*ListRoundsRequest)(nil),                     // 51: daemonrpc.ListRoundsRequest
-	(*GetRoundRequest)(nil),                       // 52: daemonrpc.GetRoundRequest
-	(*GetRoundResponse)(nil),                      // 53: daemonrpc.GetRoundResponse
-	(*ListRoundsResponse)(nil),                    // 54: daemonrpc.ListRoundsResponse
-	(*WatchRoundsRequest)(nil),                    // 55: daemonrpc.WatchRoundsRequest
-	(*WatchRoundsResponse)(nil),                   // 56: daemonrpc.WatchRoundsResponse
-	(*OORSessionInfo)(nil),                        // 57: daemonrpc.OORSessionInfo
-	(*ListOORSessionsRequest)(nil),                // 58: daemonrpc.ListOORSessionsRequest
-	(*ListOORSessionsResponse)(nil),               // 59: daemonrpc.ListOORSessionsResponse
-	(*GetOORSessionRequest)(nil),                  // 60: daemonrpc.GetOORSessionRequest
-	(*GetOORSessionResponse)(nil),                 // 61: daemonrpc.GetOORSessionResponse
-	(*EstimateFeeRequest)(nil),                    // 62: daemonrpc.EstimateFeeRequest
-	(*EstimateFeeResponse)(nil),                   // 63: daemonrpc.EstimateFeeResponse
-	(*GetFeeHistoryRequest)(nil),                  // 64: daemonrpc.GetFeeHistoryRequest
-	(*FeeHistoryEntry)(nil),                       // 65: daemonrpc.FeeHistoryEntry
-	(*GetFeeHistoryResponse)(nil),                 // 66: daemonrpc.GetFeeHistoryResponse
-	(*UnrollRequest)(nil),                         // 67: daemonrpc.UnrollRequest
-	(*UnrollResponse)(nil),                        // 68: daemonrpc.UnrollResponse
-	(*GetUnrollStatusRequest)(nil),                // 69: daemonrpc.GetUnrollStatusRequest
-	(*GetUnrollStatusResponse)(nil),               // 70: daemonrpc.GetUnrollStatusResponse
-	nil,                                           // 71: daemonrpc.LeaveVTXOsRequest.DestinationsEntry
+	(*SweepBoardingUTXOsRequest)(nil),             // 49: daemonrpc.SweepBoardingUTXOsRequest
+	(*BoardingSweepOutput)(nil),                   // 50: daemonrpc.BoardingSweepOutput
+	(*SweepBoardingUTXOsResponse)(nil),            // 51: daemonrpc.SweepBoardingUTXOsResponse
+	(*ListBoardingSweepsRequest)(nil),             // 52: daemonrpc.ListBoardingSweepsRequest
+	(*BoardingSweepInput)(nil),                    // 53: daemonrpc.BoardingSweepInput
+	(*BoardingSweep)(nil),                         // 54: daemonrpc.BoardingSweep
+	(*ListBoardingSweepsResponse)(nil),            // 55: daemonrpc.ListBoardingSweepsResponse
+	(*RoundVTXOInfo)(nil),                         // 56: daemonrpc.RoundVTXOInfo
+	(*RoundInfo)(nil),                             // 57: daemonrpc.RoundInfo
+	(*ListRoundsRequest)(nil),                     // 58: daemonrpc.ListRoundsRequest
+	(*GetRoundRequest)(nil),                       // 59: daemonrpc.GetRoundRequest
+	(*GetRoundResponse)(nil),                      // 60: daemonrpc.GetRoundResponse
+	(*ListRoundsResponse)(nil),                    // 61: daemonrpc.ListRoundsResponse
+	(*WatchRoundsRequest)(nil),                    // 62: daemonrpc.WatchRoundsRequest
+	(*WatchRoundsResponse)(nil),                   // 63: daemonrpc.WatchRoundsResponse
+	(*OORSessionInfo)(nil),                        // 64: daemonrpc.OORSessionInfo
+	(*ListOORSessionsRequest)(nil),                // 65: daemonrpc.ListOORSessionsRequest
+	(*ListOORSessionsResponse)(nil),               // 66: daemonrpc.ListOORSessionsResponse
+	(*GetOORSessionRequest)(nil),                  // 67: daemonrpc.GetOORSessionRequest
+	(*GetOORSessionResponse)(nil),                 // 68: daemonrpc.GetOORSessionResponse
+	(*EstimateFeeRequest)(nil),                    // 69: daemonrpc.EstimateFeeRequest
+	(*EstimateFeeResponse)(nil),                   // 70: daemonrpc.EstimateFeeResponse
+	(*GetFeeHistoryRequest)(nil),                  // 71: daemonrpc.GetFeeHistoryRequest
+	(*FeeHistoryEntry)(nil),                       // 72: daemonrpc.FeeHistoryEntry
+	(*GetFeeHistoryResponse)(nil),                 // 73: daemonrpc.GetFeeHistoryResponse
+	(*UnrollRequest)(nil),                         // 74: daemonrpc.UnrollRequest
+	(*UnrollResponse)(nil),                        // 75: daemonrpc.UnrollResponse
+	(*GetUnrollStatusRequest)(nil),                // 76: daemonrpc.GetUnrollStatusRequest
+	(*GetUnrollStatusResponse)(nil),               // 77: daemonrpc.GetUnrollStatusResponse
+	nil,                                           // 78: daemonrpc.LeaveVTXOsRequest.DestinationsEntry
 }
 var file_daemon_proto_depIdxs = []int32{
 	7,  // 0: daemonrpc.GetInfoResponse.server_info:type_name -> daemonrpc.ServerInfo
@@ -5333,83 +6045,90 @@ var file_daemon_proto_depIdxs = []int32{
 	41, // 9: daemonrpc.RefreshVTXOsRequest.outpoints:type_name -> daemonrpc.OutpointSelection
 	41, // 10: daemonrpc.LeaveVTXOsRequest.outpoints:type_name -> daemonrpc.OutpointSelection
 	44, // 11: daemonrpc.LeaveVTXOsRequest.default_destination:type_name -> daemonrpc.LeaveDestination
-	71, // 12: daemonrpc.LeaveVTXOsRequest.destinations:type_name -> daemonrpc.LeaveVTXOsRequest.DestinationsEntry
-	1,  // 13: daemonrpc.RoundInfo.state:type_name -> daemonrpc.RoundState
-	49, // 14: daemonrpc.RoundInfo.vtxos:type_name -> daemonrpc.RoundVTXOInfo
-	1,  // 15: daemonrpc.ListRoundsRequest.state_filter:type_name -> daemonrpc.RoundState
-	50, // 16: daemonrpc.GetRoundResponse.round:type_name -> daemonrpc.RoundInfo
-	50, // 17: daemonrpc.ListRoundsResponse.rounds:type_name -> daemonrpc.RoundInfo
-	50, // 18: daemonrpc.WatchRoundsResponse.round:type_name -> daemonrpc.RoundInfo
-	2,  // 19: daemonrpc.OORSessionInfo.direction:type_name -> daemonrpc.OORSessionDirection
-	3,  // 20: daemonrpc.OORSessionInfo.status:type_name -> daemonrpc.OORSessionStatus
-	2,  // 21: daemonrpc.ListOORSessionsRequest.direction_filter:type_name -> daemonrpc.OORSessionDirection
-	3,  // 22: daemonrpc.ListOORSessionsRequest.status_filter:type_name -> daemonrpc.OORSessionStatus
-	57, // 23: daemonrpc.ListOORSessionsResponse.sessions:type_name -> daemonrpc.OORSessionInfo
-	57, // 24: daemonrpc.GetOORSessionResponse.session:type_name -> daemonrpc.OORSessionInfo
-	65, // 25: daemonrpc.GetFeeHistoryResponse.entries:type_name -> daemonrpc.FeeHistoryEntry
-	4,  // 26: daemonrpc.GetUnrollStatusResponse.status:type_name -> daemonrpc.UnrollJobStatus
-	44, // 27: daemonrpc.LeaveVTXOsRequest.DestinationsEntry.value:type_name -> daemonrpc.LeaveDestination
-	5,  // 28: daemonrpc.DaemonService.GetInfo:input_type -> daemonrpc.GetInfoRequest
-	8,  // 29: daemonrpc.DaemonService.GenSeed:input_type -> daemonrpc.GenSeedRequest
-	10, // 30: daemonrpc.DaemonService.InitWallet:input_type -> daemonrpc.InitWalletRequest
-	12, // 31: daemonrpc.DaemonService.UnlockWallet:input_type -> daemonrpc.UnlockWalletRequest
-	14, // 32: daemonrpc.DaemonService.GetBalance:input_type -> daemonrpc.GetBalanceRequest
-	17, // 33: daemonrpc.DaemonService.ListVTXOs:input_type -> daemonrpc.ListVTXOsRequest
-	19, // 34: daemonrpc.DaemonService.NewAddress:input_type -> daemonrpc.NewAddressRequest
-	21, // 35: daemonrpc.DaemonService.NewReceiveScript:input_type -> daemonrpc.NewReceiveScriptRequest
-	23, // 36: daemonrpc.DaemonService.ReceiveAuthKey:input_type -> daemonrpc.ReceiveAuthKeyRequest
-	25, // 37: daemonrpc.DaemonService.SignReceiveAuthMessage:input_type -> daemonrpc.SignReceiveAuthMessageRequest
-	27, // 38: daemonrpc.DaemonService.SignReceiveAuthMessageCompact:input_type -> daemonrpc.SignReceiveAuthMessageCompactRequest
-	29, // 39: daemonrpc.DaemonService.ReceiveAuthECDH:input_type -> daemonrpc.ReceiveAuthECDHRequest
-	31, // 40: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:input_type -> daemonrpc.GetIndexedVTXOByPkScriptRequest
-	33, // 41: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:input_type -> daemonrpc.GetIndexedOORSessionByTxidRequest
-	36, // 42: daemonrpc.DaemonService.SendVTXO:input_type -> daemonrpc.SendVTXORequest
-	38, // 43: daemonrpc.DaemonService.SendOOR:input_type -> daemonrpc.SendOORRequest
-	42, // 44: daemonrpc.DaemonService.RefreshVTXOs:input_type -> daemonrpc.RefreshVTXOsRequest
-	45, // 45: daemonrpc.DaemonService.LeaveVTXOs:input_type -> daemonrpc.LeaveVTXOsRequest
-	47, // 46: daemonrpc.DaemonService.Board:input_type -> daemonrpc.BoardRequest
-	51, // 47: daemonrpc.DaemonService.ListRounds:input_type -> daemonrpc.ListRoundsRequest
-	52, // 48: daemonrpc.DaemonService.GetRound:input_type -> daemonrpc.GetRoundRequest
-	55, // 49: daemonrpc.DaemonService.WatchRounds:input_type -> daemonrpc.WatchRoundsRequest
-	58, // 50: daemonrpc.DaemonService.ListOORSessions:input_type -> daemonrpc.ListOORSessionsRequest
-	60, // 51: daemonrpc.DaemonService.GetOORSession:input_type -> daemonrpc.GetOORSessionRequest
-	62, // 52: daemonrpc.DaemonService.EstimateFee:input_type -> daemonrpc.EstimateFeeRequest
-	64, // 53: daemonrpc.DaemonService.GetFeeHistory:input_type -> daemonrpc.GetFeeHistoryRequest
-	67, // 54: daemonrpc.DaemonService.Unroll:input_type -> daemonrpc.UnrollRequest
-	69, // 55: daemonrpc.DaemonService.GetUnrollStatus:input_type -> daemonrpc.GetUnrollStatusRequest
-	6,  // 56: daemonrpc.DaemonService.GetInfo:output_type -> daemonrpc.GetInfoResponse
-	9,  // 57: daemonrpc.DaemonService.GenSeed:output_type -> daemonrpc.GenSeedResponse
-	11, // 58: daemonrpc.DaemonService.InitWallet:output_type -> daemonrpc.InitWalletResponse
-	13, // 59: daemonrpc.DaemonService.UnlockWallet:output_type -> daemonrpc.UnlockWalletResponse
-	15, // 60: daemonrpc.DaemonService.GetBalance:output_type -> daemonrpc.GetBalanceResponse
-	18, // 61: daemonrpc.DaemonService.ListVTXOs:output_type -> daemonrpc.ListVTXOsResponse
-	20, // 62: daemonrpc.DaemonService.NewAddress:output_type -> daemonrpc.NewAddressResponse
-	22, // 63: daemonrpc.DaemonService.NewReceiveScript:output_type -> daemonrpc.NewReceiveScriptResponse
-	24, // 64: daemonrpc.DaemonService.ReceiveAuthKey:output_type -> daemonrpc.ReceiveAuthKeyResponse
-	26, // 65: daemonrpc.DaemonService.SignReceiveAuthMessage:output_type -> daemonrpc.SignReceiveAuthMessageResponse
-	28, // 66: daemonrpc.DaemonService.SignReceiveAuthMessageCompact:output_type -> daemonrpc.SignReceiveAuthMessageCompactResponse
-	30, // 67: daemonrpc.DaemonService.ReceiveAuthECDH:output_type -> daemonrpc.ReceiveAuthECDHResponse
-	32, // 68: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:output_type -> daemonrpc.GetIndexedVTXOByPkScriptResponse
-	34, // 69: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:output_type -> daemonrpc.GetIndexedOORSessionByTxidResponse
-	37, // 70: daemonrpc.DaemonService.SendVTXO:output_type -> daemonrpc.SendVTXOResponse
-	40, // 71: daemonrpc.DaemonService.SendOOR:output_type -> daemonrpc.SendOORResponse
-	43, // 72: daemonrpc.DaemonService.RefreshVTXOs:output_type -> daemonrpc.RefreshVTXOsResponse
-	46, // 73: daemonrpc.DaemonService.LeaveVTXOs:output_type -> daemonrpc.LeaveVTXOsResponse
-	48, // 74: daemonrpc.DaemonService.Board:output_type -> daemonrpc.BoardResponse
-	54, // 75: daemonrpc.DaemonService.ListRounds:output_type -> daemonrpc.ListRoundsResponse
-	53, // 76: daemonrpc.DaemonService.GetRound:output_type -> daemonrpc.GetRoundResponse
-	56, // 77: daemonrpc.DaemonService.WatchRounds:output_type -> daemonrpc.WatchRoundsResponse
-	59, // 78: daemonrpc.DaemonService.ListOORSessions:output_type -> daemonrpc.ListOORSessionsResponse
-	61, // 79: daemonrpc.DaemonService.GetOORSession:output_type -> daemonrpc.GetOORSessionResponse
-	63, // 80: daemonrpc.DaemonService.EstimateFee:output_type -> daemonrpc.EstimateFeeResponse
-	66, // 81: daemonrpc.DaemonService.GetFeeHistory:output_type -> daemonrpc.GetFeeHistoryResponse
-	68, // 82: daemonrpc.DaemonService.Unroll:output_type -> daemonrpc.UnrollResponse
-	70, // 83: daemonrpc.DaemonService.GetUnrollStatus:output_type -> daemonrpc.GetUnrollStatusResponse
-	56, // [56:84] is the sub-list for method output_type
-	28, // [28:56] is the sub-list for method input_type
-	28, // [28:28] is the sub-list for extension type_name
-	28, // [28:28] is the sub-list for extension extendee
-	0,  // [0:28] is the sub-list for field type_name
+	78, // 12: daemonrpc.LeaveVTXOsRequest.destinations:type_name -> daemonrpc.LeaveVTXOsRequest.DestinationsEntry
+	50, // 13: daemonrpc.SweepBoardingUTXOsResponse.sweepable_outputs:type_name -> daemonrpc.BoardingSweepOutput
+	53, // 14: daemonrpc.BoardingSweep.inputs:type_name -> daemonrpc.BoardingSweepInput
+	54, // 15: daemonrpc.ListBoardingSweepsResponse.sweeps:type_name -> daemonrpc.BoardingSweep
+	1,  // 16: daemonrpc.RoundInfo.state:type_name -> daemonrpc.RoundState
+	56, // 17: daemonrpc.RoundInfo.vtxos:type_name -> daemonrpc.RoundVTXOInfo
+	1,  // 18: daemonrpc.ListRoundsRequest.state_filter:type_name -> daemonrpc.RoundState
+	57, // 19: daemonrpc.GetRoundResponse.round:type_name -> daemonrpc.RoundInfo
+	57, // 20: daemonrpc.ListRoundsResponse.rounds:type_name -> daemonrpc.RoundInfo
+	57, // 21: daemonrpc.WatchRoundsResponse.round:type_name -> daemonrpc.RoundInfo
+	2,  // 22: daemonrpc.OORSessionInfo.direction:type_name -> daemonrpc.OORSessionDirection
+	3,  // 23: daemonrpc.OORSessionInfo.status:type_name -> daemonrpc.OORSessionStatus
+	2,  // 24: daemonrpc.ListOORSessionsRequest.direction_filter:type_name -> daemonrpc.OORSessionDirection
+	3,  // 25: daemonrpc.ListOORSessionsRequest.status_filter:type_name -> daemonrpc.OORSessionStatus
+	64, // 26: daemonrpc.ListOORSessionsResponse.sessions:type_name -> daemonrpc.OORSessionInfo
+	64, // 27: daemonrpc.GetOORSessionResponse.session:type_name -> daemonrpc.OORSessionInfo
+	72, // 28: daemonrpc.GetFeeHistoryResponse.entries:type_name -> daemonrpc.FeeHistoryEntry
+	4,  // 29: daemonrpc.GetUnrollStatusResponse.status:type_name -> daemonrpc.UnrollJobStatus
+	44, // 30: daemonrpc.LeaveVTXOsRequest.DestinationsEntry.value:type_name -> daemonrpc.LeaveDestination
+	5,  // 31: daemonrpc.DaemonService.GetInfo:input_type -> daemonrpc.GetInfoRequest
+	8,  // 32: daemonrpc.DaemonService.GenSeed:input_type -> daemonrpc.GenSeedRequest
+	10, // 33: daemonrpc.DaemonService.InitWallet:input_type -> daemonrpc.InitWalletRequest
+	12, // 34: daemonrpc.DaemonService.UnlockWallet:input_type -> daemonrpc.UnlockWalletRequest
+	14, // 35: daemonrpc.DaemonService.GetBalance:input_type -> daemonrpc.GetBalanceRequest
+	17, // 36: daemonrpc.DaemonService.ListVTXOs:input_type -> daemonrpc.ListVTXOsRequest
+	19, // 37: daemonrpc.DaemonService.NewAddress:input_type -> daemonrpc.NewAddressRequest
+	21, // 38: daemonrpc.DaemonService.NewReceiveScript:input_type -> daemonrpc.NewReceiveScriptRequest
+	23, // 39: daemonrpc.DaemonService.ReceiveAuthKey:input_type -> daemonrpc.ReceiveAuthKeyRequest
+	25, // 40: daemonrpc.DaemonService.SignReceiveAuthMessage:input_type -> daemonrpc.SignReceiveAuthMessageRequest
+	27, // 41: daemonrpc.DaemonService.SignReceiveAuthMessageCompact:input_type -> daemonrpc.SignReceiveAuthMessageCompactRequest
+	29, // 42: daemonrpc.DaemonService.ReceiveAuthECDH:input_type -> daemonrpc.ReceiveAuthECDHRequest
+	31, // 43: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:input_type -> daemonrpc.GetIndexedVTXOByPkScriptRequest
+	33, // 44: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:input_type -> daemonrpc.GetIndexedOORSessionByTxidRequest
+	36, // 45: daemonrpc.DaemonService.SendVTXO:input_type -> daemonrpc.SendVTXORequest
+	38, // 46: daemonrpc.DaemonService.SendOOR:input_type -> daemonrpc.SendOORRequest
+	42, // 47: daemonrpc.DaemonService.RefreshVTXOs:input_type -> daemonrpc.RefreshVTXOsRequest
+	45, // 48: daemonrpc.DaemonService.LeaveVTXOs:input_type -> daemonrpc.LeaveVTXOsRequest
+	47, // 49: daemonrpc.DaemonService.Board:input_type -> daemonrpc.BoardRequest
+	49, // 50: daemonrpc.DaemonService.SweepBoardingUTXOs:input_type -> daemonrpc.SweepBoardingUTXOsRequest
+	52, // 51: daemonrpc.DaemonService.ListBoardingSweeps:input_type -> daemonrpc.ListBoardingSweepsRequest
+	58, // 52: daemonrpc.DaemonService.ListRounds:input_type -> daemonrpc.ListRoundsRequest
+	59, // 53: daemonrpc.DaemonService.GetRound:input_type -> daemonrpc.GetRoundRequest
+	62, // 54: daemonrpc.DaemonService.WatchRounds:input_type -> daemonrpc.WatchRoundsRequest
+	65, // 55: daemonrpc.DaemonService.ListOORSessions:input_type -> daemonrpc.ListOORSessionsRequest
+	67, // 56: daemonrpc.DaemonService.GetOORSession:input_type -> daemonrpc.GetOORSessionRequest
+	69, // 57: daemonrpc.DaemonService.EstimateFee:input_type -> daemonrpc.EstimateFeeRequest
+	71, // 58: daemonrpc.DaemonService.GetFeeHistory:input_type -> daemonrpc.GetFeeHistoryRequest
+	74, // 59: daemonrpc.DaemonService.Unroll:input_type -> daemonrpc.UnrollRequest
+	76, // 60: daemonrpc.DaemonService.GetUnrollStatus:input_type -> daemonrpc.GetUnrollStatusRequest
+	6,  // 61: daemonrpc.DaemonService.GetInfo:output_type -> daemonrpc.GetInfoResponse
+	9,  // 62: daemonrpc.DaemonService.GenSeed:output_type -> daemonrpc.GenSeedResponse
+	11, // 63: daemonrpc.DaemonService.InitWallet:output_type -> daemonrpc.InitWalletResponse
+	13, // 64: daemonrpc.DaemonService.UnlockWallet:output_type -> daemonrpc.UnlockWalletResponse
+	15, // 65: daemonrpc.DaemonService.GetBalance:output_type -> daemonrpc.GetBalanceResponse
+	18, // 66: daemonrpc.DaemonService.ListVTXOs:output_type -> daemonrpc.ListVTXOsResponse
+	20, // 67: daemonrpc.DaemonService.NewAddress:output_type -> daemonrpc.NewAddressResponse
+	22, // 68: daemonrpc.DaemonService.NewReceiveScript:output_type -> daemonrpc.NewReceiveScriptResponse
+	24, // 69: daemonrpc.DaemonService.ReceiveAuthKey:output_type -> daemonrpc.ReceiveAuthKeyResponse
+	26, // 70: daemonrpc.DaemonService.SignReceiveAuthMessage:output_type -> daemonrpc.SignReceiveAuthMessageResponse
+	28, // 71: daemonrpc.DaemonService.SignReceiveAuthMessageCompact:output_type -> daemonrpc.SignReceiveAuthMessageCompactResponse
+	30, // 72: daemonrpc.DaemonService.ReceiveAuthECDH:output_type -> daemonrpc.ReceiveAuthECDHResponse
+	32, // 73: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:output_type -> daemonrpc.GetIndexedVTXOByPkScriptResponse
+	34, // 74: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:output_type -> daemonrpc.GetIndexedOORSessionByTxidResponse
+	37, // 75: daemonrpc.DaemonService.SendVTXO:output_type -> daemonrpc.SendVTXOResponse
+	40, // 76: daemonrpc.DaemonService.SendOOR:output_type -> daemonrpc.SendOORResponse
+	43, // 77: daemonrpc.DaemonService.RefreshVTXOs:output_type -> daemonrpc.RefreshVTXOsResponse
+	46, // 78: daemonrpc.DaemonService.LeaveVTXOs:output_type -> daemonrpc.LeaveVTXOsResponse
+	48, // 79: daemonrpc.DaemonService.Board:output_type -> daemonrpc.BoardResponse
+	51, // 80: daemonrpc.DaemonService.SweepBoardingUTXOs:output_type -> daemonrpc.SweepBoardingUTXOsResponse
+	55, // 81: daemonrpc.DaemonService.ListBoardingSweeps:output_type -> daemonrpc.ListBoardingSweepsResponse
+	61, // 82: daemonrpc.DaemonService.ListRounds:output_type -> daemonrpc.ListRoundsResponse
+	60, // 83: daemonrpc.DaemonService.GetRound:output_type -> daemonrpc.GetRoundResponse
+	63, // 84: daemonrpc.DaemonService.WatchRounds:output_type -> daemonrpc.WatchRoundsResponse
+	66, // 85: daemonrpc.DaemonService.ListOORSessions:output_type -> daemonrpc.ListOORSessionsResponse
+	68, // 86: daemonrpc.DaemonService.GetOORSession:output_type -> daemonrpc.GetOORSessionResponse
+	70, // 87: daemonrpc.DaemonService.EstimateFee:output_type -> daemonrpc.EstimateFeeResponse
+	73, // 88: daemonrpc.DaemonService.GetFeeHistory:output_type -> daemonrpc.GetFeeHistoryResponse
+	75, // 89: daemonrpc.DaemonService.Unroll:output_type -> daemonrpc.UnrollResponse
+	77, // 90: daemonrpc.DaemonService.GetUnrollStatus:output_type -> daemonrpc.GetUnrollStatusResponse
+	61, // [61:91] is the sub-list for method output_type
+	31, // [31:61] is the sub-list for method input_type
+	31, // [31:31] is the sub-list for extension type_name
+	31, // [31:31] is the sub-list for extension extendee
+	0,  // [0:31] is the sub-list for field type_name
 }
 
 func init() { file_daemon_proto_init() }
@@ -5440,7 +6159,7 @@ func file_daemon_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_daemon_proto_rawDesc), len(file_daemon_proto_rawDesc)),
 			NumEnums:      5,
-			NumMessages:   67,
+			NumMessages:   74,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/daemonrpc/daemon.proto
+++ b/daemonrpc/daemon.proto
@@ -99,6 +99,16 @@ service DaemonService {
     // the round FSM, which emits a JoinRoundRequest to the server.
     rpc Board (BoardRequest) returns (BoardResponse);
 
+    // SweepBoardingUTXOs sweeps boarding UTXOs whose CSV timeout path is
+    // mature back to the wallet.
+    rpc SweepBoardingUTXOs (SweepBoardingUTXOsRequest)
+        returns (SweepBoardingUTXOsResponse);
+
+    // ListBoardingSweeps returns persisted aggregate boarding sweep
+    // transactions and their tracked inputs.
+    rpc ListBoardingSweeps (ListBoardingSweepsRequest)
+        returns (ListBoardingSweepsResponse);
+
     // ListRounds returns the current state of all round FSM instances.
     // Each round is identified by its round ID (or a temporary key if
     // the server hasn't assigned one yet).
@@ -761,6 +771,168 @@ message BoardResponse {
     // vtxo_count is the number of VTXO target outputs accepted for
     // boarding. It is zero when status is "no_boarding_utxos".
     uint32 vtxo_count = 2;
+}
+
+message SweepBoardingUTXOsRequest {
+    // outpoints optionally restricts sweeping to specific boarding UTXOs,
+    // formatted as "txid:index". Empty means scan all sweepable boarding
+    // intents.
+    repeated string outpoints = 1;
+
+    // broadcast makes the RPC publish one aggregate sweep transaction and
+    // record it as pending confirmation. The daemon marks boarding intents
+    // swept only after the chain backend reports their outpoints as spent.
+    // The default false value only previews candidates, totals, and fees.
+    bool broadcast = 2;
+
+    // fee_rate_sat_per_vbyte optionally overrides fee estimation. A zero value
+    // asks the daemon to estimate a fee rate from conf_target.
+    int64 fee_rate_sat_per_vbyte = 3;
+
+    // conf_target is the target confirmation count used for fee estimation.
+    // A zero value uses the daemon default.
+    uint32 conf_target = 4;
+
+    // sweep_address optionally overrides the destination for the aggregate
+    // sweep. Empty means sweep into a fresh wallet address.
+    string sweep_address = 5;
+}
+
+message BoardingSweepOutput {
+    // outpoint is the boarding UTXO that can be swept.
+    string outpoint = 1;
+
+    // amount_sat is the value of the boarding UTXO.
+    int64 amount_sat = 2;
+
+    // maturity_height is the first block height at which the CSV timeout path
+    // can be spent.
+    int32 maturity_height = 3;
+}
+
+message SweepBoardingUTXOsResponse {
+    // status is "preview", "published", or "failed".
+    string status = 1;
+
+    // current_height is the best chain height used for the maturity scan.
+    int32 current_height = 2;
+
+    // sweepable_outputs contains the mature boarding UTXOs included in the
+    // aggregate sweep preview or broadcast.
+    repeated BoardingSweepOutput sweepable_outputs = 3;
+
+    // total_amount_sat is the total value of all sweepable outputs.
+    int64 total_amount_sat = 4;
+
+    // estimated_fee_sat is the fee required for the aggregate sweep
+    // transaction at fee_rate_sat_per_vbyte.
+    int64 estimated_fee_sat = 5;
+
+    // net_amount_sat is total_amount_sat minus estimated_fee_sat.
+    int64 net_amount_sat = 6;
+
+    // fee_rate_sat_per_vbyte is the fee rate used to build the aggregate
+    // sweep.
+    int64 fee_rate_sat_per_vbyte = 7;
+
+    // conf_target is the confirmation target used when fee estimation was
+    // requested.
+    uint32 conf_target = 8;
+
+    // txid is the aggregate sweep transaction id. Preview responses set the
+    // txid of the signed transaction built for the current request; a later
+    // broadcast can differ if inputs, fees, or destination change.
+    string txid = 9;
+
+    // fee_paid_sat is set when broadcast=true and records the actual fee paid
+    // by the aggregate sweep transaction. The fee is known at publication;
+    // confirmation is tracked asynchronously by the daemon.
+    int64 fee_paid_sat = 10;
+
+    // tx_vbytes is the virtual byte size of the signed aggregate sweep
+    // transaction.
+    int64 tx_vbytes = 11;
+
+    // failure_reason carries aggregate build, broadcast, or persistence
+    // errors.
+    string failure_reason = 12;
+}
+
+message ListBoardingSweepsRequest {
+    // status optionally filters tracked sweeps by persisted status:
+    // "pending", "published", "confirmed", "external_resolved", or
+    // "failed". Empty lists all.
+    string status = 1;
+
+    // page_size limits the number of sweeps returned. Zero uses the daemon
+    // default.
+    uint32 page_size = 2;
+
+    // page_token is the opaque token returned by a previous response.
+    string page_token = 3;
+}
+
+message BoardingSweepInput {
+    // outpoint is the boarding UTXO tracked by this sweep.
+    string outpoint = 1;
+
+    // amount_sat is the value of the boarding UTXO.
+    int64 amount_sat = 2;
+
+    // status is the persisted per-input status: "pending", "published",
+    // "spent", "external_spent", or "failed".
+    string status = 3;
+
+    // spent_by_txid is set after the chain backend reports a confirmed spend.
+    string spent_by_txid = 4;
+
+    // spent_height is the block height of the confirmed spend when known.
+    int32 spent_height = 5;
+}
+
+message BoardingSweep {
+    // txid is the aggregate sweep transaction id.
+    string txid = 1;
+
+    // status is the persisted aggregate status: "pending", "published",
+    // "confirmed", "external_resolved", or "failed".
+    string status = 2;
+
+    // destination_address is the caller-specified sweep address, if any.
+    string destination_address = 3;
+
+    // total_amount_sat is the total value of every sweep input.
+    int64 total_amount_sat = 4;
+
+    // fee_paid_sat is the fee paid by the aggregate sweep transaction.
+    int64 fee_paid_sat = 5;
+
+    // fee_rate_sat_per_vbyte is the fee rate used to build the sweep.
+    int64 fee_rate_sat_per_vbyte = 6;
+
+    // tx_vbytes is the virtual byte size of the sweep transaction.
+    int64 tx_vbytes = 7;
+
+    // created_height is the best chain height when the sweep was created.
+    int32 created_height = 8;
+
+    // confirmed_height is set once every tracked input has confirmed spent.
+    int32 confirmed_height = 9;
+
+    // inputs contains the boarding outpoints tracked by this sweep.
+    repeated BoardingSweepInput inputs = 10;
+
+    // failure_reason carries the terminal local failure reason for failed
+    // sweeps.
+    string failure_reason = 11;
+}
+
+message ListBoardingSweepsResponse {
+    // sweeps are returned newest first by creation time.
+    repeated BoardingSweep sweeps = 1;
+
+    // next_page_token is set when another page is available.
+    string next_page_token = 2;
 }
 
 // RoundState represents the lifecycle state of a client's round FSM.

--- a/daemonrpc/daemon_grpc.pb.go
+++ b/daemonrpc/daemon_grpc.pb.go
@@ -38,6 +38,8 @@ const (
 	DaemonService_RefreshVTXOs_FullMethodName                  = "/daemonrpc.DaemonService/RefreshVTXOs"
 	DaemonService_LeaveVTXOs_FullMethodName                    = "/daemonrpc.DaemonService/LeaveVTXOs"
 	DaemonService_Board_FullMethodName                         = "/daemonrpc.DaemonService/Board"
+	DaemonService_SweepBoardingUTXOs_FullMethodName            = "/daemonrpc.DaemonService/SweepBoardingUTXOs"
+	DaemonService_ListBoardingSweeps_FullMethodName            = "/daemonrpc.DaemonService/ListBoardingSweeps"
 	DaemonService_ListRounds_FullMethodName                    = "/daemonrpc.DaemonService/ListRounds"
 	DaemonService_GetRound_FullMethodName                      = "/daemonrpc.DaemonService/GetRound"
 	DaemonService_WatchRounds_FullMethodName                   = "/daemonrpc.DaemonService/WatchRounds"
@@ -123,6 +125,12 @@ type DaemonServiceClient interface {
 	// confirmed boarding UTXOs. This sends IntentRequested to
 	// the round FSM, which emits a JoinRoundRequest to the server.
 	Board(ctx context.Context, in *BoardRequest, opts ...grpc.CallOption) (*BoardResponse, error)
+	// SweepBoardingUTXOs sweeps boarding UTXOs whose CSV timeout path is
+	// mature back to the wallet.
+	SweepBoardingUTXOs(ctx context.Context, in *SweepBoardingUTXOsRequest, opts ...grpc.CallOption) (*SweepBoardingUTXOsResponse, error)
+	// ListBoardingSweeps returns persisted aggregate boarding sweep
+	// transactions and their tracked inputs.
+	ListBoardingSweeps(ctx context.Context, in *ListBoardingSweepsRequest, opts ...grpc.CallOption) (*ListBoardingSweepsResponse, error)
 	// ListRounds returns the current state of all round FSM instances.
 	// Each round is identified by its round ID (or a temporary key if
 	// the server hasn't assigned one yet).
@@ -357,6 +365,26 @@ func (c *daemonServiceClient) Board(ctx context.Context, in *BoardRequest, opts 
 	return out, nil
 }
 
+func (c *daemonServiceClient) SweepBoardingUTXOs(ctx context.Context, in *SweepBoardingUTXOsRequest, opts ...grpc.CallOption) (*SweepBoardingUTXOsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SweepBoardingUTXOsResponse)
+	err := c.cc.Invoke(ctx, DaemonService_SweepBoardingUTXOs_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *daemonServiceClient) ListBoardingSweeps(ctx context.Context, in *ListBoardingSweepsRequest, opts ...grpc.CallOption) (*ListBoardingSweepsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListBoardingSweepsResponse)
+	err := c.cc.Invoke(ctx, DaemonService_ListBoardingSweeps_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *daemonServiceClient) ListRounds(ctx context.Context, in *ListRoundsRequest, opts ...grpc.CallOption) (*ListRoundsResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(ListRoundsResponse)
@@ -530,6 +558,12 @@ type DaemonServiceServer interface {
 	// confirmed boarding UTXOs. This sends IntentRequested to
 	// the round FSM, which emits a JoinRoundRequest to the server.
 	Board(context.Context, *BoardRequest) (*BoardResponse, error)
+	// SweepBoardingUTXOs sweeps boarding UTXOs whose CSV timeout path is
+	// mature back to the wallet.
+	SweepBoardingUTXOs(context.Context, *SweepBoardingUTXOsRequest) (*SweepBoardingUTXOsResponse, error)
+	// ListBoardingSweeps returns persisted aggregate boarding sweep
+	// transactions and their tracked inputs.
+	ListBoardingSweeps(context.Context, *ListBoardingSweepsRequest) (*ListBoardingSweepsResponse, error)
 	// ListRounds returns the current state of all round FSM instances.
 	// Each round is identified by its round ID (or a temporary key if
 	// the server hasn't assigned one yet).
@@ -630,6 +664,12 @@ func (UnimplementedDaemonServiceServer) LeaveVTXOs(context.Context, *LeaveVTXOsR
 }
 func (UnimplementedDaemonServiceServer) Board(context.Context, *BoardRequest) (*BoardResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Board not implemented")
+}
+func (UnimplementedDaemonServiceServer) SweepBoardingUTXOs(context.Context, *SweepBoardingUTXOsRequest) (*SweepBoardingUTXOsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SweepBoardingUTXOs not implemented")
+}
+func (UnimplementedDaemonServiceServer) ListBoardingSweeps(context.Context, *ListBoardingSweepsRequest) (*ListBoardingSweepsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListBoardingSweeps not implemented")
 }
 func (UnimplementedDaemonServiceServer) ListRounds(context.Context, *ListRoundsRequest) (*ListRoundsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ListRounds not implemented")
@@ -1021,6 +1061,42 @@ func _DaemonService_Board_Handler(srv interface{}, ctx context.Context, dec func
 	return interceptor(ctx, in, info, handler)
 }
 
+func _DaemonService_SweepBoardingUTXOs_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SweepBoardingUTXOsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DaemonServiceServer).SweepBoardingUTXOs(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DaemonService_SweepBoardingUTXOs_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DaemonServiceServer).SweepBoardingUTXOs(ctx, req.(*SweepBoardingUTXOsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DaemonService_ListBoardingSweeps_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListBoardingSweepsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DaemonServiceServer).ListBoardingSweeps(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DaemonService_ListBoardingSweeps_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DaemonServiceServer).ListBoardingSweeps(ctx, req.(*ListBoardingSweepsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _DaemonService_ListRounds_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(ListRoundsRequest)
 	if err := dec(in); err != nil {
@@ -1258,6 +1334,14 @@ var DaemonService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Board",
 			Handler:    _DaemonService_Board_Handler,
+		},
+		{
+			MethodName: "SweepBoardingUTXOs",
+			Handler:    _DaemonService_SweepBoardingUTXOs_Handler,
+		},
+		{
+			MethodName: "ListBoardingSweeps",
+			Handler:    _DaemonService_ListBoardingSweeps_Handler,
 		},
 		{
 			MethodName: "ListRounds",

--- a/daemonrpc/daemon_mailboxrpc.pb.go
+++ b/daemonrpc/daemon_mailboxrpc.pb.go
@@ -62,6 +62,10 @@ type DaemonServiceMailboxServer interface {
 	LeaveVTXOs(ctx context.Context, req *LeaveVTXOsRequest) (*LeaveVTXOsResponse, error)
 	// Board handles Board.
 	Board(ctx context.Context, req *BoardRequest) (*BoardResponse, error)
+	// SweepBoardingUTXOs handles SweepBoardingUTXOs.
+	SweepBoardingUTXOs(ctx context.Context, req *SweepBoardingUTXOsRequest) (*SweepBoardingUTXOsResponse, error)
+	// ListBoardingSweeps handles ListBoardingSweeps.
+	ListBoardingSweeps(ctx context.Context, req *ListBoardingSweepsRequest) (*ListBoardingSweepsResponse, error)
 	// ListRounds handles ListRounds.
 	ListRounds(ctx context.Context, req *ListRoundsRequest) (*ListRoundsResponse, error)
 	// GetRound handles GetRound.
@@ -273,6 +277,26 @@ func RegisterDaemonServiceMailboxServer(r rpc.Router, impl DaemonServiceMailboxS
 		}
 
 		return impl.Board(ctx, req)
+	})
+	r.Handle("daemonrpc.DaemonService", "SweepBoardingUTXOs", func() proto.Message {
+		return &SweepBoardingUTXOsRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*SweepBoardingUTXOsRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.SweepBoardingUTXOs(ctx, req)
+	})
+	r.Handle("daemonrpc.DaemonService", "ListBoardingSweeps", func() proto.Message {
+		return &ListBoardingSweepsRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*ListBoardingSweepsRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.ListBoardingSweeps(ctx, req)
 	})
 	r.Handle("daemonrpc.DaemonService", "ListRounds", func() proto.Message {
 		return &ListRoundsRequest{}
@@ -796,6 +820,52 @@ func (c *DaemonServiceMailboxClient) Board(ctx context.Context, req *BoardReques
 	}
 
 	resp := new(BoardResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// SweepBoardingUTXOs calls the SweepBoardingUTXOs RPC.
+func (c *DaemonServiceMailboxClient) SweepBoardingUTXOs(ctx context.Context, req *SweepBoardingUTXOsRequest, opts ...rpc.RPCOptions) (*SweepBoardingUTXOsResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "daemonrpc.DaemonService",
+		Method:  "SweepBoardingUTXOs",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(SweepBoardingUTXOsResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// ListBoardingSweeps calls the ListBoardingSweeps RPC.
+func (c *DaemonServiceMailboxClient) ListBoardingSweeps(ctx context.Context, req *ListBoardingSweepsRequest, opts ...rpc.RPCOptions) (*ListBoardingSweepsResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "daemonrpc.DaemonService",
+		Method:  "ListBoardingSweeps",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(ListBoardingSweepsResponse)
 	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
 		return nil, err
 	}

--- a/darepod/boarding_sweep.go
+++ b/darepod/boarding_sweep.go
@@ -1,0 +1,427 @@
+package darepod
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/chainsource"
+	"github.com/lightninglabs/darepo-client/db"
+	"github.com/lightninglabs/darepo-client/lib/arkscript"
+	"github.com/lightninglabs/darepo-client/lib/tx/arktx"
+	"github.com/lightninglabs/darepo-client/lndbackend"
+	"github.com/lightninglabs/darepo-client/unroll"
+	"github.com/lightninglabs/darepo-client/wallet"
+)
+
+const (
+	// defaultBoardingSweepFallbackFeeRateSatPerVByte is used when a
+	// fresh regtest or backend cannot yet provide a fee estimate. Callers
+	// can pass an explicit fee rate when recovering in hotter mempools.
+	defaultBoardingSweepFallbackFeeRateSatPerVByte int64 = 2
+
+	// defaultBoardingSweepConfTarget is used when the caller asks the
+	// daemon to estimate the sweep fee rate without specifying a target.
+	defaultBoardingSweepConfTarget uint32 = 6
+
+	// boardingSweepHighFeeRateWarningSatPerVByte is only an operator
+	// warning threshold. High fee estimates are still used, then the
+	// aggregate fee is bounded by value below.
+	boardingSweepHighFeeRateWarningSatPerVByte int64 = 100
+
+	// defaultBoardingSweepMaxFeePercent refuses sweeps whose absolute fee
+	// would burn too much of the selected boarding value.
+	defaultBoardingSweepMaxFeePercent int64 = 25
+
+	// defaultBoardingSweepMaxInputs caps one aggregate sweep below the
+	// standard weight limit and keeps operator mistakes bounded.
+	defaultBoardingSweepMaxInputs = 100
+
+	// boardingSweepPolicyVersion is the spend-info policy version used by
+	// existing boarding scripts.
+	boardingSweepPolicyVersion = 1
+)
+
+// boardingSweepTx describes one signed boarding timeout-path sweep
+// transaction and the fee paid by that transaction.
+type boardingSweepTx struct {
+	tx     *wire.MsgTx
+	fee    btcutil.Amount
+	vbytes int64
+}
+
+// boardingSweepInput holds a validated boarding input and its previous output.
+type boardingSweepInput struct {
+	intent       wallet.BoardingIntent
+	targetOutput *wire.TxOut
+}
+
+// boardingSweepChainBackend is the chain subset needed to scan maturity,
+// estimate fees, and broadcast sweep transactions.
+type boardingSweepChainBackend interface {
+	BestBlock(ctx context.Context) (int32, chainhash.Hash, error)
+	EstimateFee(
+		ctx context.Context, targetConf uint32,
+	) (btcutil.Amount, error)
+	BroadcastTx(ctx context.Context, tx *wire.MsgTx, label string) error
+}
+
+// newBoardingStore returns a concrete boarding store for RPC-only direct
+// reads and status updates.
+func (s *Server) newBoardingStore() *db.BoardingWalletStore {
+	dbStore := db.NewStore(
+		s.db.DB, s.db.Queries, s.db.Backend(),
+		s.subLogger(db.Subsystem),
+	)
+
+	return dbStore.NewBoardingStore(s.chainParams, s.clk)
+}
+
+// newSweepWallet returns the wallet adapter used to sign timeout-path sweep
+// inputs and derive sweep destination scripts.
+func (s *Server) newSweepWallet() (unroll.SweepWallet, error) {
+	switch s.cfg.Wallet.Type {
+	case WalletTypeLnd:
+		if !s.lnd.IsSome() {
+			return nil, fmt.Errorf("lnd wallet not initialized")
+		}
+
+		lndSvc := s.lnd.UnsafeFromSome()
+		clientWallet := lndbackend.NewClientWallet(
+			lndSvc.Signer, lndSvc.WalletKit,
+		)
+		boardingBackend := lndbackend.NewBoardingBackend(
+			lndSvc.WalletKit, lndSvc.ChainKit,
+		)
+
+		return &lndUnrollWallet{
+			ClientWallet:    clientWallet,
+			boardingBackend: boardingBackend,
+		}, nil
+
+	case WalletTypeLwwallet:
+		if !s.lwWallet.IsSome() {
+			return nil, fmt.Errorf(
+				"lightweight wallet not initialized",
+			)
+		}
+
+		return &lwUnrollWallet{
+			Wallet: s.lwWallet.UnsafeFromSome(),
+		}, nil
+
+	case WalletTypeBtcwallet:
+		if !s.btcwWallet.IsSome() {
+			return nil, fmt.Errorf("btcwallet not initialized")
+		}
+
+		return &btcwUnrollWallet{
+			Wallet: s.btcwWallet.UnsafeFromSome(),
+		}, nil
+
+	default:
+		return nil, fmt.Errorf(
+			"unknown wallet type %q", s.cfg.Wallet.Type,
+		)
+	}
+}
+
+// boardingSweepFeeRate resolves the caller's requested fee rate or asks the
+// chain backend for an estimate at the requested confirmation target.
+func boardingSweepFeeRate(ctx context.Context,
+	chainBackend boardingSweepChainBackend, feeRateSatPerVByte int64,
+	confTarget uint32) (int64, uint32, error) {
+
+	if feeRateSatPerVByte > 0 {
+		return feeRateSatPerVByte, confTarget, nil
+	}
+	if confTarget == 0 {
+		confTarget = defaultBoardingSweepConfTarget
+	}
+
+	feeRate, err := chainBackend.EstimateFee(ctx, confTarget)
+	if err != nil {
+		return defaultBoardingSweepFallbackFeeRateSatPerVByte,
+			confTarget, err
+	}
+
+	satPerVByte := int64(feeRate)
+	switch {
+	case satPerVByte <= 0:
+		return defaultBoardingSweepFallbackFeeRateSatPerVByte,
+			confTarget, nil
+
+	default:
+		return satPerVByte, confTarget, nil
+	}
+}
+
+// boardingSweepMaturityHeight returns the first block height at which a
+// confirmed boarding output's CSV timeout path can be spent.
+func boardingSweepMaturityHeight(intent wallet.BoardingIntent) int32 {
+	return intent.ChainInfo.ConfHeight + int32(intent.Address.ExitDelay)
+}
+
+// boardingSweepTargetOutput returns the actual txout being swept.
+func boardingSweepTargetOutput(intent wallet.BoardingIntent) (*wire.TxOut,
+	error) {
+
+	tx := intent.ChainInfo.ConfTx
+	if tx == nil {
+		return nil, fmt.Errorf(
+			"boarding intent missing confirmation tx",
+		)
+	}
+	if tx.TxHash() != intent.Outpoint.Hash {
+		return nil, fmt.Errorf("boarding confirmation tx mismatch")
+	}
+
+	index := intent.Outpoint.Index
+	if index >= uint32(len(tx.TxOut)) {
+		return nil, fmt.Errorf(
+			"boarding outpoint index %d out of range", index,
+		)
+	}
+
+	targetOutput := tx.TxOut[index]
+	wantScript, err := txscript.PayToAddrScript(intent.Address.Address)
+	if err != nil {
+		return nil, fmt.Errorf("boarding address pkscript: %w", err)
+	}
+	if !bytes.Equal(targetOutput.PkScript, wantScript) {
+		return nil, fmt.Errorf("boarding target pkscript mismatch")
+	}
+
+	return targetOutput, nil
+}
+
+// buildBoardingSweepTx constructs and signs one timeout-path sweep transaction
+// that spends all mature boarding UTXOs into one wallet output.
+func buildBoardingSweepTx(sweepWallet unroll.SweepWallet,
+	intents []wallet.BoardingIntent, sweepPkScript []byte,
+	feeRateSatPerVByte int64) (
+	*boardingSweepTx, error) {
+
+	if sweepWallet == nil {
+		return nil, fmt.Errorf("sweep wallet must be provided")
+	}
+	if len(intents) == 0 {
+		return nil, fmt.Errorf("no sweep inputs")
+	}
+	if len(intents) > defaultBoardingSweepMaxInputs {
+		return nil, fmt.Errorf(
+			"too many sweep inputs: %d exceeds max %d",
+			len(intents), defaultBoardingSweepMaxInputs,
+		)
+	}
+	if feeRateSatPerVByte <= 0 {
+		return nil, fmt.Errorf("fee rate must be positive")
+	}
+
+	inputs, totalInput, err := boardingSweepInputs(intents)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(sweepPkScript) == 0 {
+		return nil, fmt.Errorf("sweep pkscript must be provided")
+	}
+
+	vbytes := estimateBoardingSweepVBytes(len(inputs))
+	var signedSweep *boardingSweepTx
+	for range 3 {
+		// The first pass starts from a conservative estimate. Schnorr
+		// sigs are fixed width, but iterating lets output value and
+		// witness weight settle before we return fee and txid.
+		signedSweep, err = signBoardingSweepTx(
+			sweepWallet, inputs, totalInput, sweepPkScript,
+			feeRateSatPerVByte, vbytes,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if signedSweep.vbytes == vbytes {
+			return signedSweep, nil
+		}
+
+		vbytes = signedSweep.vbytes
+	}
+
+	return nil, fmt.Errorf("sweep vsize estimate did not converge")
+}
+
+// boardingSweepInputs validates each boarding intent and returns the total
+// spendable input amount.
+func boardingSweepInputs(intents []wallet.BoardingIntent) (
+	[]boardingSweepInput, btcutil.Amount, error) {
+
+	inputs := make([]boardingSweepInput, 0, len(intents))
+	var totalInput btcutil.Amount
+	for _, intent := range intents {
+		targetOutput, err := boardingSweepTargetOutput(intent)
+		if err != nil {
+			return nil, 0, err
+		}
+		if intent.Address.KeyDesc.PubKey == nil {
+			return nil, 0, fmt.Errorf(
+				"boarding intent %s missing client key",
+				intent.Outpoint,
+			)
+		}
+		if intent.Address.OperatorKey == nil {
+			return nil, 0, fmt.Errorf(
+				"boarding intent %s missing operator key",
+				intent.Outpoint,
+			)
+		}
+
+		inputs = append(inputs, boardingSweepInput{
+			intent:       intent,
+			targetOutput: targetOutput,
+		})
+		totalInput += btcutil.Amount(targetOutput.Value)
+	}
+
+	return inputs, totalInput, nil
+}
+
+// signBoardingSweepTx builds a transaction for the target vsize estimate and
+// signs every boarding timeout input.
+func signBoardingSweepTx(sweepWallet unroll.SweepWallet,
+	inputs []boardingSweepInput, totalInput btcutil.Amount,
+	sweepPkScript []byte, feeRateSatPerVByte, estimatedVBytes int64) (
+	*boardingSweepTx, error) {
+
+	fee := btcutil.Amount(feeRateSatPerVByte * estimatedVBytes)
+	if err := validateBoardingSweepFee(totalInput, fee); err != nil {
+		return nil, err
+	}
+
+	sweepValue := totalInput - fee
+	if sweepValue <= 0 {
+		return nil, fmt.Errorf(
+			"sweep value %d not positive after fee %d",
+			sweepValue, fee,
+		)
+	}
+
+	tx := wire.NewMsgTx(arktx.TxVersion)
+	prevOuts := make(map[wire.OutPoint]*wire.TxOut, len(inputs))
+	for _, input := range inputs {
+		intent := input.intent
+		tx.AddTxIn(&wire.TxIn{
+			PreviousOutPoint: intent.Outpoint,
+			Sequence: blockchain.LockTimeToSequence(
+				false, intent.Address.ExitDelay,
+			),
+		})
+		prevOuts[intent.Outpoint] = input.targetOutput
+	}
+	tx.AddTxOut(&wire.TxOut{
+		Value:    int64(sweepValue),
+		PkScript: append([]byte(nil), sweepPkScript...),
+	})
+
+	prevFetcher := txscript.NewMultiPrevOutFetcher(prevOuts)
+	sigHashes := txscript.NewTxSigHashes(tx, prevFetcher)
+	for idx, input := range inputs {
+		intent := input.intent
+		spendInfo, err := arkscript.NewVTXOSpendInfoFromPolicy(
+			intent.Address.KeyDesc.PubKey,
+			intent.Address.OperatorKey,
+			intent.Address.ExitDelay,
+			boardingSweepPolicyVersion,
+		)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"timeout spend info %s: %w",
+				intent.Outpoint, err,
+			)
+		}
+
+		signDesc := spendInfo.BuildSignDescriptor(
+			intent.Address.KeyDesc, input.targetOutput, sigHashes,
+			prevFetcher, idx,
+		)
+
+		witness, err := arkscript.VTXOTimeoutSpendWitness(
+			sweepWallet, signDesc, tx,
+		)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"timeout witness %s: %w", intent.Outpoint,
+				err,
+			)
+		}
+
+		tx.TxIn[idx].Witness = witness
+	}
+
+	return &boardingSweepTx{
+		tx:     tx,
+		fee:    fee,
+		vbytes: boardingSweepTxVBytes(tx),
+	}, nil
+}
+
+// validateBoardingSweepFee refuses aggregate sweeps that would spend too much
+// of the selected boarding value on miner fees.
+func validateBoardingSweepFee(totalInput, fee btcutil.Amount) error {
+	maxFee := totalInput * btcutil.Amount(
+		defaultBoardingSweepMaxFeePercent,
+	) / 100
+	if fee <= maxFee {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"sweep fee %d exceeds max %d (%d%% of total input %d)",
+		fee, maxFee, defaultBoardingSweepMaxFeePercent,
+		totalInput,
+	)
+}
+
+// estimateBoardingSweepVBytes returns the first-pass vsize estimate for an
+// aggregate boarding sweep.
+func estimateBoardingSweepVBytes(inputCount int) int64 {
+	const (
+		// These constants are deliberately loose for the first pass.
+		// The builder signs the tx and recomputes exact vsize before
+		// returning, so this only avoids an initial underpayment.
+		boardingSweepBaseVBytes     = int64(40)
+		boardingSweepPerInputVBytes = int64(160)
+	)
+
+	return boardingSweepBaseVBytes +
+		int64(inputCount)*boardingSweepPerInputVBytes
+}
+
+// boardingSweepTxVBytes returns the signed transaction virtual size in vbytes.
+func boardingSweepTxVBytes(tx *wire.MsgTx) int64 {
+	weight := tx.SerializeSizeStripped()*3 + tx.SerializeSize()
+
+	return int64((weight + 3) / 4)
+}
+
+// broadcastBoardingSweep broadcasts one signed boarding sweep and treats
+// duplicate-broadcast style errors as success.
+func broadcastBoardingSweep(ctx context.Context,
+	chainBackend boardingSweepChainBackend, sweep *boardingSweepTx,
+	label string) error {
+
+	if sweep == nil || sweep.tx == nil {
+		return fmt.Errorf("sweep transaction must be provided")
+	}
+
+	err := chainBackend.BroadcastTx(ctx, sweep.tx, label)
+	if err != nil && !chainsource.IsIgnorableBroadcastError(err) {
+		return fmt.Errorf("broadcast sweep: %w", err)
+	}
+
+	return nil
+}

--- a/darepod/boarding_sweep_test.go
+++ b/darepod/boarding_sweep_test.go
@@ -1,0 +1,362 @@
+package darepod
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"testing"
+
+	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/arkscript"
+	"github.com/lightninglabs/darepo-client/lib/tx/arktx"
+	"github.com/lightninglabs/darepo-client/unroll"
+	"github.com/lightninglabs/darepo-client/wallet"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/stretchr/testify/require"
+)
+
+// testBoardingSweepWallet is a deterministic signer plus wallet-destination
+// test double.
+type testBoardingSweepWallet struct{}
+
+// NewWalletPkScript returns a deterministic destination script.
+func (w *testBoardingSweepWallet) NewWalletPkScript(
+	context.Context) ([]byte, error) {
+
+	return []byte{txscript.OP_TRUE}, nil
+}
+
+// SignOutputRaw returns a dummy schnorr signature.
+func (w *testBoardingSweepWallet) SignOutputRaw(*wire.MsgTx,
+	*input.SignDescriptor) (input.Signature, error) {
+
+	return testBoardingSweepSignature{}, nil
+}
+
+// ComputeInputScript is unused by the boarding timeout sweep helper.
+func (w *testBoardingSweepWallet) ComputeInputScript(*wire.MsgTx,
+	*input.SignDescriptor) (*input.Script, error) {
+
+	return nil, fmt.Errorf("unused")
+}
+
+// MuSig2CreateSession is unused by the boarding timeout sweep helper.
+func (w *testBoardingSweepWallet) MuSig2CreateSession(input.MuSig2Version,
+	keychain.KeyLocator, []*btcec.PublicKey, *input.MuSig2Tweaks,
+	[][musig2.PubNonceSize]byte, *musig2.Nonces) (*input.MuSig2SessionInfo,
+	error) {
+
+	return nil, fmt.Errorf("unused")
+}
+
+// MuSig2RegisterNonces is unused by the boarding timeout sweep helper.
+func (w *testBoardingSweepWallet) MuSig2RegisterNonces(
+	input.MuSig2SessionID, [][musig2.PubNonceSize]byte) (bool, error) {
+
+	return false, fmt.Errorf("unused")
+}
+
+// MuSig2RegisterCombinedNonce is unused by the boarding timeout sweep helper.
+func (w *testBoardingSweepWallet) MuSig2RegisterCombinedNonce(
+	input.MuSig2SessionID, [musig2.PubNonceSize]byte) error {
+
+	return fmt.Errorf("unused")
+}
+
+// MuSig2GetCombinedNonce is unused by the boarding timeout sweep helper.
+func (w *testBoardingSweepWallet) MuSig2GetCombinedNonce(
+	input.MuSig2SessionID) ([musig2.PubNonceSize]byte, error) {
+
+	return [musig2.PubNonceSize]byte{}, fmt.Errorf("unused")
+}
+
+// MuSig2Sign is unused by the boarding timeout sweep helper.
+func (w *testBoardingSweepWallet) MuSig2Sign(input.MuSig2SessionID,
+	[sha256.Size]byte, bool) (*musig2.PartialSignature, error) {
+
+	return nil, fmt.Errorf("unused")
+}
+
+// MuSig2CombineSig is unused by the boarding timeout sweep helper.
+func (w *testBoardingSweepWallet) MuSig2CombineSig(input.MuSig2SessionID,
+	[]*musig2.PartialSignature) (*schnorr.Signature, bool, error) {
+
+	return nil, false, fmt.Errorf("unused")
+}
+
+// MuSig2Cleanup is unused by the boarding timeout sweep helper.
+func (w *testBoardingSweepWallet) MuSig2Cleanup(
+	input.MuSig2SessionID) error {
+
+	return nil
+}
+
+// testBoardingSweepSignature is a fixed-size dummy signature.
+type testBoardingSweepSignature struct{}
+
+// Serialize returns a deterministic signature blob.
+func (s testBoardingSweepSignature) Serialize() []byte {
+	return bytes.Repeat([]byte{1}, 64)
+}
+
+// Verify always succeeds for the test signature.
+func (s testBoardingSweepSignature) Verify([]byte, *btcec.PublicKey) bool {
+	return true
+}
+
+// testBoardingSweepIntent builds a confirmed boarding intent whose timeout
+// policy matches the stored output script.
+func testBoardingSweepIntent(t *testing.T, amount btcutil.Amount,
+	confHeight int32, exitDelay uint32) wallet.BoardingIntent {
+
+	t.Helper()
+
+	clientPrivKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	operatorPrivKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	tapscript, err := arkscript.VTXOTapScript(
+		clientPrivKey.PubKey(), operatorPrivKey.PubKey(), exitDelay,
+	)
+	require.NoError(t, err)
+
+	taprootKey := txscript.ComputeTaprootOutputKey(
+		&arkscript.ARKNUMSKey, tapscript.RootHash,
+	)
+	address, err := btcutil.NewAddressTaproot(
+		taprootKey.SerializeCompressed()[1:],
+		&chaincfg.RegressionNetParams,
+	)
+	require.NoError(t, err)
+
+	pkScript, err := txscript.PayToAddrScript(address)
+	require.NoError(t, err)
+
+	confTx := wire.NewMsgTx(arktx.TxVersion)
+	confTx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{
+			Hash:  chainhash.Hash{0x01},
+			Index: 0,
+		},
+	})
+	confTx.AddTxOut(&wire.TxOut{
+		Value:    int64(amount),
+		PkScript: pkScript,
+	})
+
+	outpoint := wire.OutPoint{
+		Hash:  confTx.TxHash(),
+		Index: 0,
+	}
+
+	return wallet.BoardingIntent{
+		Address: wallet.BoardingAddress{
+			Address:     address,
+			Tapscript:   tapscript,
+			OperatorKey: operatorPrivKey.PubKey(),
+			ExitDelay:   exitDelay,
+			KeyDesc: keychain.KeyDescriptor{
+				PubKey: clientPrivKey.PubKey(),
+			},
+		},
+		Outpoint: outpoint,
+		ChainInfo: wallet.BoardingChainInfo{
+			ConfHeight: confHeight,
+			ConfTx:     confTx,
+			OutPoint:   outpoint,
+			Amount:     amount,
+		},
+		Status: wallet.BoardingStatusConfirmed,
+	}
+}
+
+// TestBuildBoardingSweepTx verifies the timeout sweep builder spends multiple
+// boarding outpoints through the CSV path and pays one wallet output after
+// fees.
+func TestBuildBoardingSweepTx(t *testing.T) {
+	t.Parallel()
+
+	const (
+		amountSat         = btcutil.Amount(50_000)
+		feeRateSatPerByte = int64(2)
+		exitDelay         = uint32(10)
+	)
+
+	intent1 := testBoardingSweepIntent(t, amountSat, 100, exitDelay)
+	intent2 := testBoardingSweepIntent(t, amountSat*2, 100, exitDelay)
+
+	sweep, err := buildBoardingSweepTx(
+		&testBoardingSweepWallet{}, []wallet.BoardingIntent{
+			intent1, intent2,
+		}, []byte{txscript.OP_TRUE}, feeRateSatPerByte,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, sweep)
+
+	require.Equal(t, btcutil.Amount(feeRateSatPerByte*sweep.vbytes),
+		sweep.fee)
+
+	tx := sweep.tx
+	require.Equal(t, int32(arktx.TxVersion), tx.Version)
+	require.Len(t, tx.TxIn, 2)
+	require.Len(t, tx.TxOut, 1)
+	require.Equal(t, intent1.Outpoint, tx.TxIn[0].PreviousOutPoint)
+	require.Equal(t, intent2.Outpoint, tx.TxIn[1].PreviousOutPoint)
+	require.Equal(
+		t, blockchain.LockTimeToSequence(false, exitDelay),
+		tx.TxIn[0].Sequence,
+	)
+	require.NotEmpty(t, tx.TxIn[0].Witness)
+	require.NotEmpty(t, tx.TxIn[1].Witness)
+	require.Equal(
+		t, int64(amountSat*3-sweep.fee), tx.TxOut[0].Value,
+	)
+	require.Equal(t, []byte{txscript.OP_TRUE}, tx.TxOut[0].PkScript)
+}
+
+// TestBoardingSweepTargetOutputRejectsMismatchedTx verifies that a persisted
+// intent cannot pair one confirmation transaction with another txid.
+func TestBoardingSweepTargetOutputRejectsMismatchedTx(t *testing.T) {
+	t.Parallel()
+
+	intent := testBoardingSweepIntent(t, 50_000, 100, 10)
+	intent.Outpoint.Hash[0] ^= 0x01
+
+	_, err := boardingSweepTargetOutput(intent)
+	require.ErrorContains(t, err, "confirmation tx mismatch")
+}
+
+// TestBoardingSweepTargetOutputRejectsMismatchedScript verifies the target
+// output must still pay the persisted boarding address.
+func TestBoardingSweepTargetOutputRejectsMismatchedScript(t *testing.T) {
+	t.Parallel()
+
+	intent := testBoardingSweepIntent(t, 50_000, 100, 10)
+	intent.ChainInfo.ConfTx.TxOut[0].PkScript = []byte{txscript.OP_TRUE}
+	intent.Outpoint.Hash = intent.ChainInfo.ConfTx.TxHash()
+
+	_, err := boardingSweepTargetOutput(intent)
+	require.ErrorContains(t, err, "pkscript mismatch")
+}
+
+// TestBuildBoardingSweepTxRejectsTooManyInputs verifies one aggregate sweep
+// cannot grow past the bounded input cap.
+func TestBuildBoardingSweepTxRejectsTooManyInputs(t *testing.T) {
+	t.Parallel()
+
+	intents := make([]wallet.BoardingIntent, 0,
+		defaultBoardingSweepMaxInputs+1)
+	for i := 0; i <= defaultBoardingSweepMaxInputs; i++ {
+		intent := testBoardingSweepIntent(t, 50_000, 100, 10)
+		intent.ChainInfo.ConfTx.LockTime = uint32(i)
+		intent.Outpoint.Hash = intent.ChainInfo.ConfTx.TxHash()
+		intent.ChainInfo.OutPoint = intent.Outpoint
+		intents = append(intents, intent)
+	}
+
+	_, err := buildBoardingSweepTx(
+		&testBoardingSweepWallet{}, intents, []byte{txscript.OP_TRUE},
+		2,
+	)
+	require.ErrorContains(t, err, "too many sweep inputs")
+}
+
+// TestBuildBoardingSweepTxRejectsExcessiveFee verifies the builder refuses
+// sweeps whose absolute fee would burn too much of the selected input value.
+func TestBuildBoardingSweepTxRejectsExcessiveFee(t *testing.T) {
+	t.Parallel()
+
+	intent := testBoardingSweepIntent(t, 50_000, 100, 10)
+
+	_, err := buildBoardingSweepTx(
+		&testBoardingSweepWallet{},
+		[]wallet.BoardingIntent{intent},
+		[]byte{txscript.OP_TRUE},
+		10_000,
+	)
+	require.ErrorContains(t, err, "sweep fee")
+	require.ErrorContains(t, err, "exceeds max")
+}
+
+// TestBoardingSweepMaturityHeight verifies the CSV maturity calculation.
+func TestBoardingSweepMaturityHeight(t *testing.T) {
+	t.Parallel()
+
+	intent := testBoardingSweepIntent(t, 50_000, 144, 12)
+	require.Equal(t, int32(156), boardingSweepMaturityHeight(intent))
+}
+
+// TestEstimateBoardingSweepVBytes verifies the aggregate sweep estimate grows
+// by input count while sharing one output.
+func TestEstimateBoardingSweepVBytes(t *testing.T) {
+	t.Parallel()
+
+	oneInput := estimateBoardingSweepVBytes(1)
+	twoInputs := estimateBoardingSweepVBytes(2)
+
+	require.Equal(t, int64(200), oneInput)
+	require.Less(t, twoInputs, oneInput*2)
+}
+
+// TestBoardingSweepPkScript verifies sweep destination selection uses a wallet
+// script by default and validates caller-provided addresses.
+func TestBoardingSweepPkScript(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	wallet := &testBoardingSweepWallet{}
+
+	walletScript, err := boardingSweepPkScript(
+		ctx, wallet, &chaincfg.RegressionNetParams, "", true,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []byte{txscript.OP_TRUE}, walletScript)
+
+	previewScript, err := boardingSweepPkScript(
+		ctx, wallet, &chaincfg.RegressionNetParams, "", false,
+	)
+	require.NoError(t, err)
+	require.Len(t, previewScript, 34)
+
+	addr, err := btcutil.NewAddressWitnessPubKeyHash(
+		bytes.Repeat([]byte{2}, 20), &chaincfg.RegressionNetParams,
+	)
+	require.NoError(t, err)
+
+	addrScript, err := boardingSweepPkScript(
+		ctx, wallet, &chaincfg.RegressionNetParams, addr.String(),
+		false,
+	)
+	require.NoError(t, err)
+
+	expectedScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+	require.Equal(t, expectedScript, addrScript)
+
+	mainnetAddr, err := btcutil.NewAddressWitnessPubKeyHash(
+		bytes.Repeat([]byte{3}, 20), &chaincfg.MainNetParams,
+	)
+	require.NoError(t, err)
+
+	mainnetAddrString := mainnetAddr.String()
+	_, err = boardingSweepPkScript(
+		ctx, wallet, &chaincfg.RegressionNetParams, mainnetAddrString,
+		false,
+	)
+	require.ErrorContains(t, err, "wrong network")
+}
+
+var _ unroll.SweepWallet = (*testBoardingSweepWallet)(nil)
+var _ input.Signature = testBoardingSweepSignature{}

--- a/darepod/boarding_sweep_watcher.go
+++ b/darepod/boarding_sweep_watcher.go
@@ -1,0 +1,392 @@
+package darepod
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/chainsource"
+	"github.com/lightninglabs/darepo-client/db"
+)
+
+const (
+	// defaultBoardingSweepRefreshInterval controls watcher rescans for
+	// pending sweeps and unresolved input watches.
+	defaultBoardingSweepRefreshInterval = time.Minute
+
+	// defaultBoardingSweepRebroadcastInterval is the minimum time between
+	// repeated rebroadcast attempts for a sweep that is already published.
+	defaultBoardingSweepRebroadcastInterval = 10 * time.Minute
+
+	// boardingSweepBroadcastLabel is attached to boarding sweep txes.
+	boardingSweepBroadcastLabel = "ark boarding timeout sweep"
+)
+
+// boardingSweepWatcher resumes pending boarding sweeps, rebroadcasts their raw
+// transactions, and marks boarding intents swept after confirmed input spends.
+type boardingSweepWatcher struct {
+	store        *db.BoardingWalletStore
+	chainBackend chainsource.ChainBackend
+	log          btclog.Logger
+	interval     time.Duration
+
+	ctx    context.Context //nolint:containedctx
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+
+	mu            sync.Mutex
+	registrations map[wire.OutPoint]func()
+	rebroadcasts  map[chainhash.Hash]time.Time
+}
+
+// newBoardingSweepWatcher creates a watcher for persisted boarding sweeps.
+func newBoardingSweepWatcher(store *db.BoardingWalletStore,
+	chainBackend chainsource.ChainBackend, log btclog.Logger,
+	interval time.Duration) *boardingSweepWatcher {
+
+	if interval == 0 {
+		interval = defaultBoardingSweepRefreshInterval
+	}
+
+	return &boardingSweepWatcher{
+		store:         store,
+		chainBackend:  chainBackend,
+		log:           log,
+		interval:      interval,
+		registrations: make(map[wire.OutPoint]func()),
+		rebroadcasts:  make(map[chainhash.Hash]time.Time),
+	}
+}
+
+// startBoardingSweepWatcher starts the daemon-owned watcher for pending
+// boarding sweep transactions. It is idempotent so wallet-unlock paths can call
+// it after the chain backend becomes available.
+func (s *Server) startBoardingSweepWatcher(ctx context.Context) error {
+	s.boardingSweepWatcherMu.Lock()
+	defer s.boardingSweepWatcherMu.Unlock()
+
+	if s.boardingSweepWatcher != nil {
+		return nil
+	}
+	if s.chainBackend == nil {
+		return fmt.Errorf("chain backend not initialized")
+	}
+
+	watcher := newBoardingSweepWatcher(
+		s.newBoardingStore(), s.chainBackend, s.subLogger(Subsystem), 0,
+	)
+	if err := watcher.Start(ctx); err != nil {
+		return err
+	}
+
+	s.boardingSweepWatcher = watcher
+	s.log.InfoS(ctx, "Boarding sweep watcher started")
+
+	return nil
+}
+
+// getBoardingSweepWatcher returns the started watcher, if any.
+func (s *Server) getBoardingSweepWatcher() *boardingSweepWatcher {
+	s.boardingSweepWatcherMu.RLock()
+	defer s.boardingSweepWatcherMu.RUnlock()
+
+	return s.boardingSweepWatcher
+}
+
+// Start begins recovery for pending sweeps and periodically refreshes watches.
+func (w *boardingSweepWatcher) Start(ctx context.Context) error {
+	if w.store == nil {
+		return fmt.Errorf("boarding sweep store missing")
+	}
+	if w.chainBackend == nil {
+		return fmt.Errorf("chain backend missing")
+	}
+
+	w.ctx, w.cancel = context.WithCancel(ctx)
+	// The initial scan is intentionally tied to the watcher lifetime so a
+	// caller returning cannot tear down spend notifications.
+	if err := w.Refresh(w.ctx); err != nil { //nolint:contextcheck
+		return err
+	}
+
+	w.wg.Add(1)
+	go w.run()
+
+	return nil
+}
+
+// Stop cancels pending watches and waits for background work to finish.
+func (w *boardingSweepWatcher) Stop() {
+	if w.cancel != nil {
+		w.cancel()
+	}
+
+	w.mu.Lock()
+	for _, cancel := range w.registrations {
+		cancel()
+	}
+	w.registrations = make(map[wire.OutPoint]func())
+	w.mu.Unlock()
+
+	w.wg.Wait()
+}
+
+// Refresh reloads pending sweeps, registers missing spend watches, and
+// best-effort rebroadcasts unresolved sweep transactions.
+func (w *boardingSweepWatcher) Refresh(ctx context.Context) error {
+	sweeps, err := w.store.ListPendingBoardingSweeps(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, sweep := range sweeps {
+		for _, input := range sweep.Inputs {
+			switch input.Status {
+			case db.BoardingSweepInputStatusPending,
+				db.BoardingSweepInputStatusPublished:
+			default:
+				continue
+			}
+
+			// Watches follow the daemon watcher lifetime, not the
+			// refresh caller.
+			err := w.watchInput( //nolint:contextcheck
+				w.ctx, input.Outpoint,
+			)
+			if err != nil {
+				w.log.WarnS(ctx, "Unable to watch boarding sweep input",
+					err,
+					slog.String("outpoint",
+						input.Outpoint.String()),
+					slog.String("txid",
+						sweep.Txid.String()))
+			}
+		}
+
+		if err := w.rebroadcastSweep(ctx, sweep); err != nil {
+			w.log.WarnS(ctx, "Unable to rebroadcast boarding sweep",
+				err, slog.String("txid", sweep.Txid.String()))
+		}
+	}
+
+	return nil
+}
+
+// run periodically refreshes pending sweep watches until shutdown.
+func (w *boardingSweepWatcher) run() {
+	defer w.wg.Done()
+
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			if err := w.Refresh(w.ctx); err != nil {
+				w.log.WarnS(w.ctx,
+					"Unable to refresh boarding sweeps", err)
+			}
+
+		case <-w.ctx.Done():
+			return
+		}
+	}
+}
+
+// watchInput registers a confirmed-spend watch for a boarding outpoint if one
+// is not already active.
+func (w *boardingSweepWatcher) watchInput(ctx context.Context,
+	outpoint wire.OutPoint) error {
+
+	w.mu.Lock()
+	if _, ok := w.registrations[outpoint]; ok {
+		w.mu.Unlock()
+		return nil
+	}
+	w.mu.Unlock()
+
+	intent, err := w.store.GetIntent(ctx, outpoint)
+	if err != nil {
+		return fmt.Errorf("load boarding intent: %w", err)
+	}
+
+	txOut, err := boardingSweepTargetOutput(*intent)
+	if err != nil {
+		return fmt.Errorf("boarding target output: %w", err)
+	}
+
+	heightHint := uint32(intent.ChainInfo.ConfHeight)
+	// Spend notifications must live until the watcher stops, even when a
+	// short-lived RPC request was the trigger for this refresh.
+	registration, err := w.chainBackend.RegisterSpend( //nolint:contextcheck
+		w.ctx, &outpoint, txOut.PkScript, heightHint,
+	)
+	if err != nil {
+		return fmt.Errorf("register spend: %w", err)
+	}
+
+	w.mu.Lock()
+	if _, ok := w.registrations[outpoint]; ok {
+		w.mu.Unlock()
+		registration.Cancel()
+		return nil
+	}
+	w.registrations[outpoint] = registration.Cancel
+	w.mu.Unlock()
+
+	w.wg.Add(1)
+	go w.monitorInput(outpoint, registration)
+
+	return nil
+}
+
+// monitorInput waits for a confirmed spend notification for one boarding
+// outpoint and records it in the sweep store.
+func (w *boardingSweepWatcher) monitorInput(outpoint wire.OutPoint,
+	registration *chainsource.SpendRegistration) {
+
+	defer w.wg.Done()
+	defer func() {
+		w.mu.Lock()
+		delete(w.registrations, outpoint)
+		w.mu.Unlock()
+		registration.Cancel()
+	}()
+
+	select {
+	case spend, ok := <-registration.Spend:
+		if !ok || spend == nil {
+			w.log.DebugS(w.ctx, "Boarding sweep spend watch closed",
+				slog.String("outpoint", outpoint.String()))
+			return
+		}
+
+		if err := w.recordSpend(w.ctx, outpoint, spend); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				w.log.DebugS(
+					w.ctx, "Boarding sweep spend already resolved",
+					slog.String("outpoint", outpoint.String()),
+				)
+
+				return
+			}
+
+			w.log.WarnS(w.ctx,
+				"Unable to record boarding sweep spend", err,
+				slog.String("outpoint", outpoint.String()))
+		}
+
+	case <-w.ctx.Done():
+		return
+	}
+}
+
+// recordSpend updates the pending sweep state for one confirmed spend event.
+func (w *boardingSweepWatcher) recordSpend(ctx context.Context,
+	outpoint wire.OutPoint, spend *chainsource.SpendDetail) error {
+
+	spendingTxid, err := boardingSpendTxid(spend)
+	if err != nil {
+		return err
+	}
+
+	resolved, err := w.store.MarkBoardingSweepInputSpent(
+		ctx, outpoint, spendingTxid, spend.SpendingHeight,
+	)
+	if err != nil {
+		return err
+	}
+
+	w.log.InfoS(ctx, "Boarding sweep input spent",
+		slog.String("outpoint", outpoint.String()),
+		slog.String("spending_txid", spendingTxid.String()),
+		slog.Int("height", int(spend.SpendingHeight)))
+	if resolved {
+		w.log.InfoS(ctx, "Boarding sweep resolved",
+			slog.String("spending_txid", spendingTxid.String()),
+			slog.Int("height", int(spend.SpendingHeight)))
+	}
+
+	return nil
+}
+
+// rebroadcastSweep rebroadcasts the exact persisted sweep transaction. It does
+// not rebuild, replace, or fee-bump the sweep.
+func (w *boardingSweepWatcher) rebroadcastSweep(ctx context.Context,
+	sweep db.BoardingSweepRecord) error {
+
+	if !w.shouldRebroadcastSweep(sweep) {
+		return nil
+	}
+
+	err := w.chainBackend.BroadcastTx(
+		ctx, sweep.Tx, boardingSweepBroadcastLabel,
+	)
+	if err != nil && !chainsource.IsIgnorableBroadcastError(err) {
+		return fmt.Errorf("broadcast sweep: %w", err)
+	}
+
+	if sweep.Status == db.BoardingSweepStatusPending {
+		if err := w.store.MarkBoardingSweepPublished(
+			ctx, sweep.Txid,
+		); err != nil {
+			return fmt.Errorf("mark sweep published: %w", err)
+		}
+	}
+
+	w.markSweepRebroadcast(sweep.Txid)
+
+	return nil
+}
+
+// shouldRebroadcastSweep returns true when the watcher should try publishing a
+// persisted sweep transaction. Pending rows are always retried so crash-before
+// MarkPublished recovery is immediate; already-published rows are rate-limited.
+func (w *boardingSweepWatcher) shouldRebroadcastSweep(
+	sweep db.BoardingSweepRecord) bool {
+
+	if sweep.Status == db.BoardingSweepStatusPending {
+		return true
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	last, ok := w.rebroadcasts[sweep.Txid]
+	if !ok {
+		return true
+	}
+
+	return time.Since(last) >= defaultBoardingSweepRebroadcastInterval
+}
+
+// markSweepRebroadcast records a rebroadcast attempt for rate limiting.
+func (w *boardingSweepWatcher) markSweepRebroadcast(txid chainhash.Hash) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	w.rebroadcasts[txid] = time.Now()
+}
+
+// boardingSpendTxid returns the txid for a spend notification.
+func boardingSpendTxid(
+	spend *chainsource.SpendDetail) (chainhash.Hash, error) {
+
+	switch {
+	case spend == nil:
+		return chainhash.Hash{}, fmt.Errorf("missing spend detail")
+	case spend.SpenderTxHash != nil:
+		return *spend.SpenderTxHash, nil
+	case spend.SpendingTx != nil:
+		return spend.SpendingTx.TxHash(), nil
+	default:
+		return chainhash.Hash{}, fmt.Errorf("spend missing txid")
+	}
+}

--- a/darepod/boarding_sweep_watcher_test.go
+++ b/darepod/boarding_sweep_watcher_test.go
@@ -1,0 +1,344 @@
+package darepod
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/chainsource"
+	"github.com/lightninglabs/darepo-client/db"
+	"github.com/lightninglabs/darepo-client/wallet"
+	"github.com/lightningnetwork/lnd/clock"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBoardingSweepWatcherResolvesPublishedSweep verifies the watcher reloads
+// a published sweep, rebroadcasts its raw transaction, watches its input, and
+// marks the boarding intent swept after a confirmed spend.
+func TestBoardingSweepWatcherResolvesPublishedSweep(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := newBoardingSweepWatcherStore(t)
+
+	sweep := createTestBoardingSweep(
+		t, ctx, store, db.BoardingSweepStatusPublished,
+	)
+
+	backend := newFakeBoardingSweepBackend()
+	watcher := newBoardingSweepWatcher(
+		store, backend, btclog.Disabled, time.Hour,
+	)
+	require.NoError(t, watcher.Start(ctx))
+	defer watcher.Stop()
+
+	require.Eventually(t, func() bool {
+		return backend.broadcastCount() == 1 &&
+			backend.spendChan(sweep.intent.Outpoint) != nil
+	}, time.Second, 10*time.Millisecond)
+
+	require.NoError(t, watcher.Refresh(ctx))
+	require.Equal(t, 1, backend.broadcastCount())
+
+	backend.spendChan(sweep.intent.Outpoint) <- &chainsource.SpendDetail{
+		SpentOutPoint:     &sweep.intent.Outpoint,
+		SpenderTxHash:     &sweep.txid,
+		SpendingTx:        sweep.tx,
+		SpendingHeight:    200,
+		SpenderInputIndex: 0,
+	}
+
+	require.Eventually(t, func() bool {
+		updated, err := store.GetIntent(ctx, sweep.intent.Outpoint)
+		require.NoError(t, err)
+
+		return updated.Status == wallet.BoardingStatusSwept
+	}, time.Second, 10*time.Millisecond)
+
+	pending, err := store.ListPendingBoardingSweeps(ctx)
+	require.NoError(t, err)
+	require.Empty(t, pending)
+}
+
+// TestBoardingSweepWatcherPublishesPendingSweep verifies a sweep persisted
+// before a crash is rebroadcast and promoted to published on watcher startup.
+func TestBoardingSweepWatcherPublishesPendingSweep(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := newBoardingSweepWatcherStore(t)
+	createTestBoardingSweep(t, ctx, store, db.BoardingSweepStatusPending)
+
+	backend := newFakeBoardingSweepBackend()
+	watcher := newBoardingSweepWatcher(
+		store, backend, btclog.Disabled, time.Hour,
+	)
+	require.NoError(t, watcher.Start(ctx))
+	defer watcher.Stop()
+
+	require.Eventually(t, func() bool {
+		sweeps, err := store.ListBoardingSweeps(
+			ctx, db.BoardingSweepStatusPublished, 10, 0,
+		)
+		require.NoError(t, err)
+
+		return backend.broadcastCount() == 1 && len(sweeps) == 1
+	}, time.Second, 10*time.Millisecond)
+}
+
+// TestBoardingSweepWatcherRefreshIsIdempotent verifies repeated refreshes do
+// not create duplicate watches or rebroadcast published sweeps within backoff.
+func TestBoardingSweepWatcherRefreshIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := newBoardingSweepWatcherStore(t)
+	sweep := createTestBoardingSweep(
+		t, ctx, store, db.BoardingSweepStatusPublished,
+	)
+
+	backend := newFakeBoardingSweepBackend()
+	watcher := newBoardingSweepWatcher(
+		store, backend, btclog.Disabled, time.Hour,
+	)
+	require.NoError(t, watcher.Start(ctx))
+	defer watcher.Stop()
+
+	require.Eventually(t, func() bool {
+		return backend.broadcastCount() == 1 &&
+			backend.registerCount() == 1 &&
+			backend.spendChan(sweep.intent.Outpoint) != nil
+	}, time.Second, 10*time.Millisecond)
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 5)
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			errs <- watcher.Refresh(ctx)
+		}()
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, 1, backend.broadcastCount())
+	require.Equal(t, 1, backend.registerCount())
+}
+
+// newBoardingSweepWatcherStore creates a migrated boarding store for watcher
+// tests.
+func newBoardingSweepWatcherStore(t *testing.T) *db.BoardingWalletStore {
+	t.Helper()
+
+	testDB := db.NewTestDB(t)
+	sqlStore := db.NewStore(
+		testDB.DB, testDB.Queries, testDB.Backend(), btclog.Disabled,
+	)
+
+	return sqlStore.NewBoardingStore(
+		&chaincfg.RegressionNetParams, clock.NewDefaultClock(),
+	)
+}
+
+// testBoardingSweepState groups a persisted sweep and its single input.
+type testBoardingSweepState struct {
+	intent wallet.BoardingIntent
+	tx     *wire.MsgTx
+	txid   chainhash.Hash
+}
+
+// createTestBoardingSweep persists one sweep in the requested status.
+func createTestBoardingSweep(t *testing.T, ctx context.Context,
+	store *db.BoardingWalletStore, status string) testBoardingSweepState {
+
+	t.Helper()
+
+	intent := testBoardingSweepIntent(t, 50_000, 100, 10)
+	require.NoError(t, store.InsertBoardingAddress(ctx, &intent.Address))
+	require.NoError(t, store.InsertBoardingIntents(ctx, intent))
+
+	sweepTx := wire.NewMsgTx(2)
+	sweepTx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: intent.Outpoint,
+	})
+	sweepTx.AddTxOut(&wire.TxOut{
+		Value:    49_000,
+		PkScript: []byte{txscript.OP_TRUE},
+	})
+	sweepTxid := sweepTx.TxHash()
+
+	require.NoError(t, store.CreatePendingBoardingSweep(
+		ctx, db.NewBoardingSweep{
+			Tx:                 sweepTx,
+			TotalAmount:        intent.ChainInfo.Amount,
+			FeeAmount:          1_000,
+			FeeRateSatPerVByte: 2,
+			VBytes:             500,
+			CreatedHeight:      120,
+			Inputs: []db.NewBoardingSweepInput{{
+				Outpoint:       intent.Outpoint,
+				Amount:         intent.ChainInfo.Amount,
+				PreviousStatus: intent.Status,
+			}},
+		},
+	))
+	if status == db.BoardingSweepStatusPublished {
+		require.NoError(t, store.MarkBoardingSweepPublished(
+			ctx, sweepTxid,
+		))
+	}
+
+	return testBoardingSweepState{
+		intent: intent,
+		tx:     sweepTx,
+		txid:   sweepTxid,
+	}
+}
+
+// fakeBoardingSweepBackend is a minimal chain backend for watcher tests.
+type fakeBoardingSweepBackend struct {
+	mu         sync.Mutex
+	broadcasts int
+	registers  int
+	spends     map[wire.OutPoint]chan *chainsource.SpendDetail
+	cancels    map[wire.OutPoint]*sync.Once
+}
+
+// newFakeBoardingSweepBackend creates a test chain backend.
+func newFakeBoardingSweepBackend() *fakeBoardingSweepBackend {
+	return &fakeBoardingSweepBackend{
+		spends:  make(map[wire.OutPoint]chan *chainsource.SpendDetail),
+		cancels: make(map[wire.OutPoint]*sync.Once),
+	}
+}
+
+// EstimateFee returns a fixed test fee rate.
+func (f *fakeBoardingSweepBackend) EstimateFee(context.Context,
+	uint32) (btcutil.Amount, error) {
+
+	return 1, nil
+}
+
+// BestBlock returns a fixed test tip.
+func (f *fakeBoardingSweepBackend) BestBlock(context.Context) (
+	int32, chainhash.Hash, error) {
+
+	return 200, chainhash.Hash{}, nil
+}
+
+// TestMempoolAccept is unused by the watcher.
+func (f *fakeBoardingSweepBackend) TestMempoolAccept(
+	context.Context, ...*wire.MsgTx) ([]chainsource.MempoolAcceptResult,
+	error) {
+
+	return nil, nil
+}
+
+// BroadcastTx records one broadcast attempt.
+func (f *fakeBoardingSweepBackend) BroadcastTx(context.Context, *wire.MsgTx,
+	string) error {
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.broadcasts++
+
+	return nil
+}
+
+// RegisterConf is unused by the watcher.
+func (f *fakeBoardingSweepBackend) RegisterConf(context.Context,
+	*chainhash.Hash, []byte, uint32, uint32, bool) (
+	*chainsource.ConfRegistration, error) {
+
+	return nil, nil
+}
+
+// RegisterSpend records one spend watch channel by outpoint.
+func (f *fakeBoardingSweepBackend) RegisterSpend(_ context.Context,
+	outpoint *wire.OutPoint, _ []byte, _ uint32) (
+	*chainsource.SpendRegistration, error) {
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.registers++
+	ch := make(chan *chainsource.SpendDetail, 1)
+	f.spends[*outpoint] = ch
+	once := &sync.Once{}
+	f.cancels[*outpoint] = once
+
+	return &chainsource.SpendRegistration{
+		Spend: ch,
+		Cancel: func() {
+			once.Do(func() {
+				close(ch)
+			})
+		},
+	}, nil
+}
+
+// RegisterBlocks is unused by the watcher.
+func (f *fakeBoardingSweepBackend) RegisterBlocks(context.Context) (
+	*chainsource.BlockRegistration, error) {
+
+	return nil, nil
+}
+
+// SubmitPackage is unused by the watcher.
+func (f *fakeBoardingSweepBackend) SubmitPackage(context.Context,
+	[]*wire.MsgTx, *wire.MsgTx) error {
+
+	return nil
+}
+
+// Start is a no-op for the test backend.
+func (f *fakeBoardingSweepBackend) Start() error {
+	return nil
+}
+
+// Stop is a no-op for the test backend.
+func (f *fakeBoardingSweepBackend) Stop() error {
+	return nil
+}
+
+// broadcastCount returns the number of recorded broadcast attempts.
+func (f *fakeBoardingSweepBackend) broadcastCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.broadcasts
+}
+
+// registerCount returns the number of recorded spend registrations.
+func (f *fakeBoardingSweepBackend) registerCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.registers
+}
+
+// spendChan returns the registered spend channel for an outpoint.
+func (f *fakeBoardingSweepBackend) spendChan(
+	outpoint wire.OutPoint) chan *chainsource.SpendDetail {
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.spends[outpoint]
+}
+
+var _ chainsource.ChainBackend = (*fakeBoardingSweepBackend)(nil)

--- a/darepod/rpc_boarding_sweep.go
+++ b/darepod/rpc_boarding_sweep.go
@@ -1,0 +1,546 @@
+package darepod
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"math"
+	"strconv"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/lightninglabs/darepo-client/db"
+	"github.com/lightninglabs/darepo-client/unroll"
+	"github.com/lightninglabs/darepo-client/wallet"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	// boardingSweepStatusPreview means the aggregate sweep transaction was
+	// previewed but the caller did not opt in to broadcasting it, or no
+	// output is currently sweepable.
+	boardingSweepStatusPreview = "preview"
+
+	// defaultListBoardingSweepsPageSize is used when no page size is
+	// requested.
+	defaultListBoardingSweepsPageSize = uint32(100)
+
+	// maxListBoardingSweepsPageSize prevents one RPC from loading an
+	// unbounded sweep history.
+	maxListBoardingSweepsPageSize = uint32(500)
+)
+
+// defaultBoardingSweepStatuses are the persisted lifecycle states that may
+// still correspond to a raw boarding UTXO recoverable by the CSV timeout path.
+var defaultBoardingSweepStatuses = [...]wallet.BoardingStatus{
+	wallet.BoardingStatusConfirmed,
+	wallet.BoardingStatusFailed,
+	wallet.BoardingStatusExpired,
+}
+
+// SweepBoardingUTXOs sweeps CSV-mature boarding UTXOs back to the wallet.
+func (r *RPCServer) SweepBoardingUTXOs(ctx context.Context,
+	req *daemonrpc.SweepBoardingUTXOsRequest) (
+	*daemonrpc.SweepBoardingUTXOsResponse, error) {
+
+	if req == nil {
+		req = &daemonrpc.SweepBoardingUTXOsRequest{}
+	}
+
+	if err := r.requireWalletReady(); err != nil {
+		return nil, err
+	}
+	if r.server.chainBackend == nil {
+		return nil, status.Errorf(
+			codes.Internal, "chain backend not initialized",
+		)
+	}
+	if req.GetFeeRateSatPerVbyte() < 0 {
+		return nil, status.Errorf(
+			codes.InvalidArgument,
+			"fee_rate_sat_per_vbyte must be non-negative",
+		)
+	}
+
+	store := r.server.newBoardingStore()
+	sweepWallet, err := r.server.newSweepWallet()
+	if err != nil {
+		return nil, status.Errorf(
+			codes.Internal, "sweep wallet unavailable: %v", err,
+		)
+	}
+
+	height, _, err := r.server.chainBackend.BestBlock(ctx)
+	if err != nil {
+		return nil, status.Errorf(
+			codes.Internal, "best block lookup failed: %v", err,
+		)
+	}
+
+	intents, err := boardingSweepCandidates(
+		ctx, store, req.GetOutpoints(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	feeRate, confTarget, feeErr := boardingSweepFeeRate(
+		ctx, r.server.chainBackend, req.GetFeeRateSatPerVbyte(),
+		req.GetConfTarget(),
+	)
+	if feeErr != nil {
+		r.server.log.DebugS(
+			ctx, "Falling back to default boarding sweep fee rate",
+			feeErr,
+			slog.Uint64("conf_target", uint64(confTarget)),
+			slog.Int64("fee_rate_sat_per_vbyte", feeRate),
+		)
+	}
+	if feeRate > boardingSweepHighFeeRateWarningSatPerVByte {
+		r.server.log.WarnS(
+			ctx, "High boarding sweep fee rate",
+			nil,
+			slog.Int64("fee_rate_sat_per_vbyte", feeRate),
+			slog.Int64("warning_threshold_sat_per_vbyte",
+				boardingSweepHighFeeRateWarningSatPerVByte),
+		)
+	}
+	sweepable := make([]wallet.BoardingIntent, 0, len(intents))
+	outputs := make([]*daemonrpc.BoardingSweepOutput, 0, len(intents))
+	var totalAmount btcutil.Amount
+	for _, intent := range intents {
+		maturityHeight := boardingSweepMaturityHeight(intent)
+		if height < maturityHeight {
+			continue
+		}
+
+		outputs = append(outputs, newBoardingSweepOutput(intent))
+		sweepable = append(sweepable, intent)
+		totalAmount += intent.ChainInfo.Amount
+	}
+
+	resp := &daemonrpc.SweepBoardingUTXOsResponse{
+		CurrentHeight:      height,
+		SweepableOutputs:   outputs,
+		TotalAmountSat:     int64(totalAmount),
+		FeeRateSatPerVbyte: feeRate,
+		ConfTarget:         confTarget,
+	}
+	if len(sweepable) == 0 {
+		resp.Status = boardingSweepStatusPreview
+
+		return resp, nil
+	}
+
+	sweepPkScript, scriptErr := boardingSweepPkScript(
+		ctx, sweepWallet, r.server.chainParams, req.GetSweepAddress(),
+		req.GetBroadcast(),
+	)
+	if scriptErr != nil {
+		return failedBoardingSweepResponse(resp, scriptErr)
+	}
+
+	sweep, buildErr := buildBoardingSweepTx(sweepWallet, sweepable,
+		sweepPkScript,
+		feeRate)
+	if buildErr != nil {
+		return failedBoardingSweepResponse(resp, buildErr)
+	}
+
+	resp.EstimatedFeeSat = int64(sweep.fee)
+	resp.NetAmountSat = int64(totalAmount - sweep.fee)
+	resp.TxVbytes = sweep.vbytes
+	txid := sweep.tx.TxHash()
+	resp.Txid = txid.String()
+
+	if !req.GetBroadcast() {
+		resp.Status = boardingSweepStatusPreview
+
+		return resp, nil
+	}
+
+	persistErr := store.CreatePendingBoardingSweep(
+		ctx, db.NewBoardingSweep{
+			Tx:                 sweep.tx,
+			DestinationAddress: req.GetSweepAddress(),
+			TotalAmount:        totalAmount,
+			FeeAmount:          sweep.fee,
+			FeeRateSatPerVByte: feeRate,
+			VBytes:             sweep.vbytes,
+			CreatedHeight:      height,
+			Inputs:             newBoardingSweepInputs(sweepable),
+		},
+	)
+	if persistErr != nil {
+		return failedBoardingSweepResponse(resp, persistErr)
+	}
+
+	broadcastErr := broadcastBoardingSweep(
+		ctx, r.server.chainBackend, sweep, "ark boarding timeout sweep",
+	)
+	if broadcastErr != nil {
+		markErr := store.MarkBoardingSweepFailed(
+			ctx, txid, broadcastErr,
+		)
+		if markErr != nil {
+			r.server.log.WarnS(
+				ctx, "Unable to mark boarding sweep failed",
+				markErr,
+				slog.String("txid", txid.String()),
+			)
+
+			return failedBoardingSweepResponse(
+				resp, fmt.Errorf("%w; mark failed: %w",
+					broadcastErr, markErr),
+			)
+		}
+
+		return failedBoardingSweepResponse(resp, broadcastErr)
+	}
+
+	resp.Status = db.BoardingSweepStatusPublished
+	resp.FeePaidSat = int64(sweep.fee)
+
+	if err := store.MarkBoardingSweepPublished(ctx, txid); err != nil {
+		r.server.log.WarnS(
+			ctx, "Unable to mark boarding sweep published",
+			err, slog.String("txid", txid.String()),
+		)
+	}
+
+	if watcher := r.server.getBoardingSweepWatcher(); watcher != nil {
+		refreshCtx := context.WithoutCancel(ctx)
+		if err := watcher.Refresh(refreshCtx); err != nil {
+			r.server.log.WarnS(
+				ctx, "Unable to refresh boarding sweep watcher",
+				err, slog.String("txid", txid.String()),
+			)
+		}
+	}
+
+	return resp, nil
+}
+
+// ListBoardingSweeps returns the daemon's persisted aggregate boarding sweeps.
+func (r *RPCServer) ListBoardingSweeps(ctx context.Context,
+	req *daemonrpc.ListBoardingSweepsRequest) (
+	*daemonrpc.ListBoardingSweepsResponse, error) {
+
+	if req == nil {
+		req = &daemonrpc.ListBoardingSweepsRequest{}
+	}
+	if err := r.requireWalletReady(); err != nil {
+		return nil, err
+	}
+
+	statusFilter := req.GetStatus()
+	if statusFilter != "" && !boardingSweepStatusFilterValid(statusFilter) {
+		return nil, status.Errorf(
+			codes.InvalidArgument,
+			"unknown boarding sweep status %q", statusFilter,
+		)
+	}
+
+	pageSize := req.GetPageSize()
+	if pageSize == 0 {
+		pageSize = defaultListBoardingSweepsPageSize
+	}
+	if pageSize > maxListBoardingSweepsPageSize {
+		pageSize = maxListBoardingSweepsPageSize
+	}
+
+	offset, err := listBoardingSweepsOffset(req.GetPageToken())
+	if err != nil {
+		return nil, status.Errorf(
+			codes.InvalidArgument, "invalid page token: %v", err,
+		)
+	}
+
+	store := r.server.newBoardingStore()
+	records, err := store.ListBoardingSweeps(
+		ctx, statusFilter, int32(pageSize)+1, int32(offset),
+	)
+	if err != nil {
+		return nil, status.Errorf(
+			codes.Internal, "list boarding sweeps: %v", err,
+		)
+	}
+
+	nextToken := ""
+	if len(records) > int(pageSize) {
+		records = records[:pageSize]
+		nextToken = strconv.FormatInt(offset+int64(pageSize), 10)
+	}
+
+	resp := &daemonrpc.ListBoardingSweepsResponse{
+		Sweeps: make(
+			[]*daemonrpc.BoardingSweep, 0, len(records),
+		),
+		NextPageToken: nextToken,
+	}
+	for _, record := range records {
+		resp.Sweeps = append(resp.Sweeps, newBoardingSweep(record))
+	}
+
+	return resp, nil
+}
+
+// failedBoardingSweepResponse records an aggregate sweep failure in the RPC
+// response body while preserving a successful RPC transport status.
+func failedBoardingSweepResponse(
+	resp *daemonrpc.SweepBoardingUTXOsResponse, err error) (
+	*daemonrpc.SweepBoardingUTXOsResponse, error) {
+
+	resp.Status = db.BoardingSweepStatusFailed
+	resp.FailureReason = err.Error()
+
+	return resp, nil
+}
+
+// boardingSweepCandidates loads the requested boarding intents, or the default
+// set of confirmed/failed/expired intents when no outpoints are specified.
+func boardingSweepCandidates(ctx context.Context,
+	store *db.BoardingWalletStore, outpointStrings []string) (
+	[]wallet.BoardingIntent, error) {
+
+	if len(outpointStrings) == 0 {
+		return defaultBoardingSweepCandidates(ctx, store)
+	}
+
+	intents := make([]wallet.BoardingIntent, 0, len(outpointStrings))
+	seen := make(map[wire.OutPoint]struct{}, len(outpointStrings))
+	for _, outpointString := range outpointStrings {
+		outpoint, err := parseOutpointString(outpointString)
+		if err != nil {
+			return nil, status.Errorf(
+				codes.InvalidArgument, "parse outpoint %q: %v",
+				outpointString, err,
+			)
+		}
+		if _, ok := seen[outpoint]; ok {
+			continue
+		}
+		seen[outpoint] = struct{}{}
+
+		intent, err := store.GetIntent(ctx, outpoint)
+		if err != nil {
+			return nil, status.Errorf(
+				codes.NotFound, "load boarding intent %s: %v",
+				outpoint, err,
+			)
+		}
+
+		if !boardingIntentSweepableStatus(intent.Status) {
+			continue
+		}
+
+		intents = append(intents, *intent)
+	}
+
+	return intents, nil
+}
+
+// defaultBoardingSweepCandidates loads every persisted boarding intent whose
+// lifecycle status may still correspond to an unspent boarding UTXO.
+func defaultBoardingSweepCandidates(ctx context.Context,
+	store *db.BoardingWalletStore) ([]wallet.BoardingIntent, error) {
+
+	intents, err := store.FetchBoardingIntentsBySweepableStatuses(
+		ctx, defaultBoardingSweepStatuses,
+	)
+	if err != nil {
+		return nil, status.Errorf(
+			codes.Internal,
+			"load boarding intents by status: %v", err,
+		)
+	}
+
+	return intents, nil
+}
+
+// newBoardingSweepOutput builds the static fields for one sweepable output.
+func newBoardingSweepOutput(
+	intent wallet.BoardingIntent) *daemonrpc.BoardingSweepOutput {
+
+	return &daemonrpc.BoardingSweepOutput{
+		Outpoint:       intent.Outpoint.String(),
+		AmountSat:      int64(intent.ChainInfo.Amount),
+		MaturityHeight: boardingSweepMaturityHeight(intent),
+	}
+}
+
+// newBoardingSweepInputs converts sweepable boarding intents into the DB input
+// records needed to recover and watch the published aggregate sweep.
+func newBoardingSweepInputs(
+	intents []wallet.BoardingIntent) []db.NewBoardingSweepInput {
+
+	inputs := make([]db.NewBoardingSweepInput, 0, len(intents))
+	for _, intent := range intents {
+		inputs = append(inputs, db.NewBoardingSweepInput{
+			Outpoint:       intent.Outpoint,
+			Amount:         intent.ChainInfo.Amount,
+			PreviousStatus: intent.Status,
+		})
+	}
+
+	return inputs
+}
+
+// boardingSweepPkScript returns the caller-provided destination script or asks
+// the wallet for a fresh sweep address when no override is set.
+func boardingSweepPkScript(ctx context.Context,
+	sweepWallet unroll.SweepWallet, chainParams *chaincfg.Params,
+	sweepAddress string, broadcast bool) ([]byte, error) {
+
+	if sweepAddress == "" {
+		if !broadcast {
+			return boardingSweepPreviewPkScript(), nil
+		}
+
+		pkScript, err := sweepWallet.NewWalletPkScript(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("sweep pkscript: %w", err)
+		}
+		if len(pkScript) == 0 {
+			return nil, fmt.Errorf("wallet returned empty pkscript")
+		}
+
+		return pkScript, nil
+	}
+
+	addr, err := btcutil.DecodeAddress(sweepAddress, chainParams)
+	if err != nil {
+		return nil, fmt.Errorf("decode sweep address: %w", err)
+	}
+	if !addr.IsForNet(chainParams) {
+		return nil, fmt.Errorf("sweep address is for the wrong network")
+	}
+
+	pkScript, err := txscript.PayToAddrScript(addr)
+	if err != nil {
+		return nil, fmt.Errorf("sweep address pkscript: %w", err)
+	}
+
+	return pkScript, nil
+}
+
+// boardingSweepPreviewPkScript returns a fixed-size P2TR script for previews
+// that do not provide an explicit destination. This avoids allocating a fresh
+// wallet address just to estimate the aggregate sweep fee. Broadcast sweeps use
+// the wallet-provided script instead, so their estimate matches the actual
+// destination type.
+func boardingSweepPreviewPkScript() []byte {
+	const p2trProgramLen = 32
+
+	pkScript := make([]byte, 2+p2trProgramLen)
+	pkScript[0] = txscript.OP_1
+	pkScript[1] = p2trProgramLen
+
+	return pkScript
+}
+
+// boardingIntentSweepableStatus returns true for persisted status values that
+// may still correspond to an unspent raw boarding UTXO.
+func boardingIntentSweepableStatus(
+	status wallet.BoardingStatus) bool {
+
+	for _, sweepable := range defaultBoardingSweepStatuses {
+		if status == sweepable {
+			return true
+		}
+	}
+
+	return false
+}
+
+// boardingSweepStatusFilterValid returns true for listable aggregate sweep
+// statuses.
+func boardingSweepStatusFilterValid(status string) bool {
+	switch status {
+	case db.BoardingSweepStatusPending,
+		db.BoardingSweepStatusPublished,
+		db.BoardingSweepStatusConfirmed,
+		db.BoardingSweepStatusExternalResolved,
+		db.BoardingSweepStatusFailed:
+
+		return true
+
+	default:
+		return false
+	}
+}
+
+// newBoardingSweep converts one persisted aggregate sweep into its RPC shape.
+func newBoardingSweep(
+	record db.BoardingSweepRecord) *daemonrpc.BoardingSweep {
+
+	sweep := &daemonrpc.BoardingSweep{
+		Txid:               record.Txid.String(),
+		Status:             record.Status,
+		DestinationAddress: record.DestinationAddress,
+		TotalAmountSat:     int64(record.TotalAmount),
+		FeePaidSat:         int64(record.FeeAmount),
+		FeeRateSatPerVbyte: record.FeeRateSatPerVByte,
+		TxVbytes:           record.VBytes,
+		CreatedHeight:      record.CreatedHeight,
+		Inputs:             newBoardingSweepInputRecords(record.Inputs),
+	}
+	if record.ConfirmedHeight.Valid {
+		sweep.ConfirmedHeight = record.ConfirmedHeight.Int32
+	}
+	if record.LastError.Valid {
+		sweep.FailureReason = record.LastError.String
+	}
+
+	return sweep
+}
+
+// listBoardingSweepsOffset parses the simple offset page token used by the
+// sweep list RPC.
+func listBoardingSweepsOffset(token string) (int64, error) {
+	if token == "" {
+		return 0, nil
+	}
+
+	offset, err := strconv.ParseInt(token, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	if offset < 0 {
+		return 0, fmt.Errorf("offset must be non-negative")
+	}
+	if offset > math.MaxInt32 {
+		return 0, fmt.Errorf("offset too large")
+	}
+
+	return offset, nil
+}
+
+// newBoardingSweepInputRecords converts persisted sweep inputs into their RPC
+// shape.
+func newBoardingSweepInputRecords(
+	inputs []db.BoardingSweepInputRecord) []*daemonrpc.BoardingSweepInput {
+
+	records := make([]*daemonrpc.BoardingSweepInput, 0, len(inputs))
+	for _, input := range inputs {
+		record := &daemonrpc.BoardingSweepInput{
+			Outpoint:  input.Outpoint.String(),
+			AmountSat: int64(input.Amount),
+			Status:    input.Status,
+		}
+		if input.SpentByTxid.Valid {
+			record.SpentByTxid = input.SpentByTxid.String
+		}
+		if input.SpentHeight.Valid {
+			record.SpentHeight = input.SpentHeight.Int32
+		}
+
+		records = append(records, record)
+	}
+
+	return records
+}

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -275,6 +275,11 @@ type Server struct {
 	]]
 	unrollRegistry *unroll.UnrollRegistryActor
 
+	// boardingSweepWatcher resumes and reconciles published boarding timeout
+	// sweeps until their tracked outpoints are confirmed spent.
+	boardingSweepWatcherMu sync.RWMutex
+	boardingSweepWatcher   *boardingSweepWatcher
+
 	// lazyChainResolver is the forwarding ref that connects the
 	// VTXO manager's critical-expiry path to the unroll manager.
 	// Created before the VTXO manager so actors can reference it
@@ -743,6 +748,10 @@ func (s *Server) run(ctx context.Context,
 			s.unrollRegistry.Stop()
 		}
 
+		if watcher := s.getBoardingSweepWatcher(); watcher != nil {
+			watcher.Stop()
+		}
+
 		if s.oorSigningEffect != nil {
 			//nolint:contextcheck // bounded shutdown
 			err := s.oorSigningEffect.StopAndWait(shutdownCtx)
@@ -935,21 +944,12 @@ func (s *Server) run(ctx context.Context,
 	// wallet may not be unlocked yet, so everything is deferred
 	// to a background goroutine that fires after walletReady.
 	if s.isWalletReady() {
-		if err := s.connectAndBootstrapMailbox(ctx); err != nil {
-			return err
-		}
-
-		if err := s.startWalletDependentActors(
+		err := s.startWalletReadyServices(
 			ctx, chainSourceRef, timeoutRef,
-		); err != nil {
+		)
+		if err != nil {
 			return err
 		}
-
-		if err := s.startMailboxIngress(ctx); err != nil {
-			return err
-		}
-
-		s.markDaemonReady()
 	} else {
 		// Launch a goroutine that waits for the wallet to
 		// become ready (via InitWallet or UnlockWallet RPC)
@@ -978,36 +978,16 @@ func (s *Server) run(ctx context.Context,
 				)
 			}
 
-			if err := s.connectAndBootstrapMailbox(
-				ctx,
-			); err != nil {
-				s.log.ErrorS(ctx,
-					"Failed to bootstrap mailbox "+
-						"transport", err,
-				)
-
-				return
-			}
-
-			if err := s.startWalletDependentActors(
+			err := s.startWalletReadyServices(
 				ctx, chainSourceRef, timeoutRef,
-			); err != nil {
+			)
+			if err != nil {
 				s.log.ErrorS(ctx,
-					"Failed to start wallet actors",
+					"Failed to start wallet-ready services",
 					err)
 
 				return
 			}
-
-			if err := s.startMailboxIngress(ctx); err != nil {
-				s.log.ErrorS(ctx,
-					"Failed to start mailbox ingress",
-					err)
-
-				return
-			}
-
-			s.markDaemonReady()
 		}()
 		defer deferredWg.Wait()
 
@@ -1026,6 +1006,36 @@ func (s *Server) run(ctx context.Context,
 	<-ctx.Done()
 
 	s.log.InfoS(ctx, "Shutting down darepod")
+
+	return nil
+}
+
+// startWalletReadyServices starts the services that need wallet-derived keys
+// and chain access.
+func (s *Server) startWalletReadyServices(ctx context.Context,
+	chainSourceRef actor.ActorRef[
+		chainsource.ChainSourceMsg, chainsource.ChainSourceResp,
+	], timeoutRef actor.TellOnlyRef[timeout.Msg]) error {
+
+	if err := s.startBoardingSweepWatcher(ctx); err != nil {
+		return err
+	}
+
+	if err := s.connectAndBootstrapMailbox(ctx); err != nil {
+		return err
+	}
+
+	if err := s.startWalletDependentActors(
+		ctx, chainSourceRef, timeoutRef,
+	); err != nil {
+		return err
+	}
+
+	if err := s.startMailboxIngress(ctx); err != nil {
+		return err
+	}
+
+	s.markDaemonReady()
 
 	return nil
 }

--- a/db/boarding_sweep_store.go
+++ b/db/boarding_sweep_store.go
@@ -1,0 +1,618 @@
+package db
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/db/sqlc"
+	"github.com/lightninglabs/darepo-client/lib/tx/arktx"
+	"github.com/lightninglabs/darepo-client/wallet"
+)
+
+const (
+	// BoardingSweepStatusPending means the sweep transaction is persisted
+	// but has not yet been accepted for broadcast.
+	BoardingSweepStatusPending = "pending"
+
+	// BoardingSweepStatusPublished means the sweep transaction was accepted
+	// for broadcast and is waiting for confirmed input spends.
+	BoardingSweepStatusPublished = "published"
+
+	// BoardingSweepStatusConfirmed means every tracked input has been
+	// confirmed spent.
+	BoardingSweepStatusConfirmed = "confirmed"
+
+	// BoardingSweepStatusExternalResolved means every tracked input has
+	// been confirmed spent, but none by the sweep transaction we published.
+	BoardingSweepStatusExternalResolved = "external_resolved"
+
+	// BoardingSweepStatusFailed means the sweep hit a terminal local error
+	// before it could be watched to completion.
+	BoardingSweepStatusFailed = "failed"
+
+	// BoardingSweepInputStatusPending means the persisted input is not yet
+	// known to be broadcast.
+	BoardingSweepInputStatusPending = "pending"
+
+	// BoardingSweepInputStatusPublished means the input belongs to a
+	// broadcast sweep and is waiting for a confirmed spend.
+	BoardingSweepInputStatusPublished = "published"
+
+	// BoardingSweepInputStatusSpent means the input was confirmed spent by
+	// the sweep transaction we published.
+	BoardingSweepInputStatusSpent = "spent"
+
+	// BoardingSweepInputStatusExternalSpent means the input was confirmed
+	// spent by a transaction other than the sweep transaction we published.
+	BoardingSweepInputStatusExternalSpent = "external_spent"
+
+	// BoardingSweepInputStatusFailed means the input belonged to a sweep
+	// that failed before confirmation watching completed.
+	BoardingSweepInputStatusFailed = "failed"
+)
+
+// NewBoardingSweepInput describes one boarding outpoint assigned to a new
+// aggregate sweep transaction.
+type NewBoardingSweepInput struct {
+	// Outpoint is the boarding UTXO being swept.
+	Outpoint wire.OutPoint
+
+	// Amount is the boarding UTXO value.
+	Amount btcutil.Amount
+
+	// PreviousStatus is the status before the sweep moved this intent
+	// into the pending lifecycle.
+	PreviousStatus wallet.BoardingStatus
+}
+
+// NewBoardingSweep describes one aggregate boarding sweep to persist before
+// broadcast.
+type NewBoardingSweep struct {
+	// Tx is the fully signed aggregate sweep transaction.
+	Tx *wire.MsgTx
+
+	// DestinationAddress is the optional human-readable sweep destination.
+	DestinationAddress string
+
+	// TotalAmount is the sum of all sweep input values.
+	TotalAmount btcutil.Amount
+
+	// FeeAmount is the fee paid by the sweep transaction.
+	FeeAmount btcutil.Amount
+
+	// FeeRateSatPerVByte is the fee rate used to build the sweep.
+	FeeRateSatPerVByte int64
+
+	// VBytes is the sweep transaction virtual byte size.
+	VBytes int64
+
+	// CreatedHeight is the best chain height when the sweep was created.
+	CreatedHeight int32
+
+	// Inputs are the boarding outputs consumed by the sweep transaction.
+	Inputs []NewBoardingSweepInput
+}
+
+// BoardingSweepRecord is one persisted aggregate boarding sweep and its inputs.
+type BoardingSweepRecord struct {
+	// Txid is the sweep transaction id.
+	Txid chainhash.Hash
+
+	// Tx is the signed sweep transaction.
+	Tx *wire.MsgTx
+
+	// DestinationAddress is the optional address supplied at publication
+	// time. It is empty when the daemon generated a fresh wallet output.
+	DestinationAddress string
+
+	// TotalAmount is the sum of every sweep input value.
+	TotalAmount btcutil.Amount
+
+	// FeeAmount is the absolute fee paid by the sweep transaction.
+	FeeAmount btcutil.Amount
+
+	// FeeRateSatPerVByte is the fee rate used to build the sweep.
+	FeeRateSatPerVByte int64
+
+	// VBytes is the virtual byte size of the sweep transaction.
+	VBytes int64
+
+	// Status is the persisted sweep lifecycle status.
+	Status string
+
+	// CreatedHeight is the best chain height when the sweep was created.
+	CreatedHeight int32
+
+	// ConfirmedHeight is set once every tracked input has confirmed spent.
+	ConfirmedHeight sql.NullInt32
+
+	// LastError is the last terminal local error recorded for the sweep.
+	LastError sql.NullString
+
+	// Inputs are the boarding outpoints tracked by this sweep.
+	Inputs []BoardingSweepInputRecord
+}
+
+// BoardingSweepInputRecord is one persisted boarding sweep input.
+type BoardingSweepInputRecord struct {
+	// Txid is the aggregate sweep transaction id.
+	Txid chainhash.Hash
+
+	// Outpoint is the boarding UTXO being watched.
+	Outpoint wire.OutPoint
+
+	// Amount is the boarding UTXO value.
+	Amount btcutil.Amount
+
+	// Status is the per-input sweep lifecycle status.
+	Status string
+
+	// SpentByTxid is the confirmed spending transaction when known.
+	SpentByTxid sql.NullString
+
+	// SpentHeight is the confirmation height of the spending transaction.
+	SpentHeight sql.NullInt32
+}
+
+// CreatePendingBoardingSweep atomically records a sweep and moves its boarding
+// intents into sweep_pending before the transaction is broadcast.
+func (b *BoardingWalletStore) CreatePendingBoardingSweep(ctx context.Context,
+	sweep NewBoardingSweep) error {
+
+	if sweep.Tx == nil {
+		return fmt.Errorf("sweep tx must be provided")
+	}
+	if len(sweep.Inputs) == 0 {
+		return fmt.Errorf("sweep inputs must be provided")
+	}
+
+	var raw bytes.Buffer
+	if err := sweep.Tx.Serialize(&raw); err != nil {
+		return fmt.Errorf("serialize sweep tx: %w", err)
+	}
+
+	txid := sweep.Tx.TxHash()
+	now := b.clock.Now().Unix()
+	pendingStatus := BoardingSweepInputStatusPending
+
+	return b.db.ExecTx(ctx, WriteTxOption(), func(q BoardingStore) error {
+		params := sqlc.InsertBoardingSweepParams{
+			Txid:               txid[:],
+			RawTx:              raw.Bytes(),
+			DestinationAddress: sweep.DestinationAddress,
+			TotalAmount:        int64(sweep.TotalAmount),
+			FeeAmount:          int64(sweep.FeeAmount),
+			FeeRateSatPerVbyte: sweep.FeeRateSatPerVByte,
+			Vbytes:             sweep.VBytes,
+			Status:             BoardingSweepStatusPending,
+			CreatedHeight:      sweep.CreatedHeight,
+			CreatedTime:        now,
+			PublishedTime:      sql.NullInt64{},
+			ConfirmedHeight:    sql.NullInt32{},
+			LastError:          sql.NullString{},
+		}
+		err := q.InsertBoardingSweep(ctx, params)
+		if err != nil {
+			return fmt.Errorf("insert boarding sweep: %w", err)
+		}
+
+		for _, input := range sweep.Inputs {
+			prevStatus, err := statusToString(input.PreviousStatus)
+			if err != nil {
+				return err
+			}
+
+			err = q.InsertBoardingSweepInput(
+				ctx, sqlc.InsertBoardingSweepInputParams{
+					Txid:         txid[:],
+					OutpointHash: input.Outpoint.Hash[:],
+					OutpointIndex: int32(
+						input.Outpoint.Index,
+					),
+					Amount:         int64(input.Amount),
+					PreviousStatus: prevStatus,
+					Status:         pendingStatus,
+					SpentByTxid:    nil,
+					SpentHeight:    sql.NullInt32{},
+					LastUpdateTime: now,
+				},
+			)
+			if err != nil {
+				return fmt.Errorf("insert sweep input: %w", err)
+			}
+
+			err = q.UpdateBoardingIntentStatus(
+				ctx, sqlc.UpdateBoardingIntentStatusParams{
+					OutpointHash: input.Outpoint.Hash[:],
+					OutpointIndex: int32(
+						input.Outpoint.Index,
+					),
+					Status:         "sweep_pending",
+					LastUpdateTime: now,
+				},
+			)
+			if err != nil {
+				return fmt.Errorf(
+					"mark intent pending: %w", err,
+				)
+			}
+		}
+
+		return nil
+	})
+}
+
+// MarkBoardingSweepPublished marks a persisted sweep and all unresolved inputs
+// as published after the transaction is accepted for broadcast.
+func (b *BoardingWalletStore) MarkBoardingSweepPublished(ctx context.Context,
+	txid chainhash.Hash) error {
+
+	now := b.clock.Now().Unix()
+	publishedStatus := BoardingSweepInputStatusPublished
+	return b.db.ExecTx(ctx, WriteTxOption(), func(q BoardingStore) error {
+		err := q.MarkBoardingSweepStatus(
+			ctx, sqlc.MarkBoardingSweepStatusParams{
+				Txid:            txid[:],
+				Status:          BoardingSweepStatusPublished,
+				PublishedTime:   sqlInt64(now),
+				ConfirmedHeight: sql.NullInt32{},
+				LastError:       sql.NullString{},
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("mark sweep published: %w", err)
+		}
+
+		err = q.MarkBoardingSweepInputsStatus(
+			ctx, sqlc.MarkBoardingSweepInputsStatusParams{
+				Txid:           txid[:],
+				Status:         publishedStatus,
+				LastUpdateTime: now,
+			},
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"mark sweep inputs published: %w", err,
+			)
+		}
+
+		return nil
+	})
+}
+
+// MarkBoardingSweepFailed restores pending boarding intents to their previous
+// status and records a terminal local sweep failure.
+func (b *BoardingWalletStore) MarkBoardingSweepFailed(ctx context.Context,
+	txid chainhash.Hash, failure error) error {
+
+	var errText string
+	if failure != nil {
+		errText = failure.Error()
+	}
+
+	now := b.clock.Now().Unix()
+
+	return b.db.ExecTx(ctx, WriteTxOption(), func(q BoardingStore) error {
+		inputs, err := q.ListBoardingSweepInputs(ctx, txid[:])
+		if err != nil {
+			return fmt.Errorf("list sweep inputs: %w", err)
+		}
+
+		for _, input := range inputs {
+			err = q.UpdateBoardingIntentStatus(
+				ctx, sqlc.UpdateBoardingIntentStatusParams{
+					OutpointHash:   input.OutpointHash,
+					OutpointIndex:  input.OutpointIndex,
+					Status:         input.PreviousStatus,
+					LastUpdateTime: now,
+				},
+			)
+			if err != nil {
+				return fmt.Errorf(
+					"restore intent status: %w", err,
+				)
+			}
+		}
+
+		err = q.MarkBoardingSweepStatus(
+			ctx, sqlc.MarkBoardingSweepStatusParams{
+				Txid:            txid[:],
+				Status:          BoardingSweepStatusFailed,
+				PublishedTime:   sql.NullInt64{},
+				ConfirmedHeight: sql.NullInt32{},
+				LastError:       sqlStr(errText),
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("mark sweep failed: %w", err)
+		}
+
+		err = q.MarkBoardingSweepInputsStatus(
+			ctx, sqlc.MarkBoardingSweepInputsStatusParams{
+				Txid:           txid[:],
+				Status:         BoardingSweepInputStatusFailed,
+				LastUpdateTime: now,
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("mark sweep inputs failed: %w", err)
+		}
+
+		return nil
+	})
+}
+
+// ListBoardingSweeps returns persisted aggregate sweeps. If status is
+// non-empty, only sweeps in that lifecycle status are returned.
+func (b *BoardingWalletStore) ListBoardingSweeps(ctx context.Context,
+	status string, limit, offset int32) ([]BoardingSweepRecord, error) {
+
+	var records []BoardingSweepRecord
+	err := b.db.ExecTx(ctx, ReadTxOption(), func(q BoardingStore) error {
+		rows, err := q.ListBoardingSweeps(
+			ctx, sqlc.ListBoardingSweepsParams{
+				StatusFilter: status,
+				PageLimit:    limit,
+				PageOffset:   offset,
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("list boarding sweeps: %w", err)
+		}
+
+		records = make([]BoardingSweepRecord, 0, len(rows))
+		for _, row := range rows {
+			record, err := boardingSweepRecordFromRow(ctx, q, row)
+			if err != nil {
+				return err
+			}
+
+			records = append(records, record)
+		}
+
+		return nil
+	})
+
+	return records, err
+}
+
+// ListPendingBoardingSweeps returns every unresolved boarding sweep with its
+// watched inputs.
+func (b *BoardingWalletStore) ListPendingBoardingSweeps(
+	ctx context.Context) ([]BoardingSweepRecord, error) {
+
+	var records []BoardingSweepRecord
+	err := b.db.ExecTx(ctx, ReadTxOption(), func(q BoardingStore) error {
+		rows, err := q.ListPendingBoardingSweeps(ctx)
+		if err != nil {
+			return fmt.Errorf("list pending sweeps: %w", err)
+		}
+
+		records = make([]BoardingSweepRecord, 0, len(rows))
+		for _, row := range rows {
+			record, err := boardingSweepRecordFromRow(ctx, q, row)
+			if err != nil {
+				return err
+			}
+
+			records = append(records, record)
+		}
+
+		return nil
+	})
+
+	return records, err
+}
+
+// MarkBoardingSweepInputSpent records a confirmed spend for the watched
+// boarding outpoint and resolves the aggregate sweep once every input is spent.
+func (b *BoardingWalletStore) MarkBoardingSweepInputSpent(
+	ctx context.Context, outpoint wire.OutPoint,
+	spendingTxid chainhash.Hash, spendingHeight int32) (bool, error) {
+
+	now := b.clock.Now().Unix()
+	var resolved bool
+
+	err := b.db.ExecTx(ctx, WriteTxOption(), func(q BoardingStore) error {
+		sweepRow, err := q.GetBoardingSweepByInput(
+			ctx, sqlc.GetBoardingSweepByInputParams{
+				OutpointHash:  outpoint.Hash[:],
+				OutpointIndex: int32(outpoint.Index),
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("get sweep by input: %w", err)
+		}
+
+		sweepTxid, err := hashFromBytes(sweepRow.Txid)
+		if err != nil {
+			return fmt.Errorf("decode sweep txid: %w", err)
+		}
+
+		inputStatus := BoardingSweepInputStatusExternalSpent
+		if sweepTxid == spendingTxid {
+			inputStatus = BoardingSweepInputStatusSpent
+		}
+
+		err = q.MarkBoardingSweepInputSpentByOutpoint(
+			ctx, sqlc.MarkBoardingSweepInputSpentByOutpointParams{
+				OutpointHash:   outpoint.Hash[:],
+				OutpointIndex:  int32(outpoint.Index),
+				Status:         inputStatus,
+				SpentByTxid:    spendingTxid[:],
+				SpentHeight:    sqlInt32(spendingHeight),
+				LastUpdateTime: now,
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("mark sweep input spent: %w", err)
+		}
+
+		count, err := q.CountUnresolvedBoardingSweepInputs(
+			ctx, sweepTxid[:],
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"count unresolved sweep inputs: %w", err,
+			)
+		}
+		if count != 0 {
+			return nil
+		}
+
+		inputs, err := q.ListBoardingSweepInputs(ctx, sweepTxid[:])
+		if err != nil {
+			return fmt.Errorf("list sweep inputs: %w", err)
+		}
+		for _, input := range inputs {
+			err = q.UpdateBoardingIntentStatus(
+				ctx, sqlc.UpdateBoardingIntentStatusParams{
+					OutpointHash:   input.OutpointHash,
+					OutpointIndex:  input.OutpointIndex,
+					Status:         "swept",
+					LastUpdateTime: now,
+				},
+			)
+			if err != nil {
+				return fmt.Errorf("mark intent swept: %w", err)
+			}
+		}
+
+		sweepStatus := BoardingSweepStatusExternalResolved
+		for _, input := range inputs {
+			if input.Status == BoardingSweepInputStatusSpent {
+				sweepStatus = BoardingSweepStatusConfirmed
+				break
+			}
+		}
+
+		err = q.MarkBoardingSweepStatus(
+			ctx, sqlc.MarkBoardingSweepStatusParams{
+				Txid:            sweepTxid[:],
+				Status:          sweepStatus,
+				PublishedTime:   sql.NullInt64{},
+				ConfirmedHeight: sqlInt32(spendingHeight),
+				LastError:       sql.NullString{},
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("mark sweep confirmed: %w", err)
+		}
+
+		resolved = true
+
+		return nil
+	})
+
+	return resolved, err
+}
+
+// boardingSweepRecordFromRow converts one sqlc sweep row into the daemon-facing
+// record and loads its input rows.
+func boardingSweepRecordFromRow(ctx context.Context, q BoardingStore,
+	row BoardingSweepRow) (BoardingSweepRecord, error) {
+
+	txid, err := hashFromBytes(row.Txid)
+	if err != nil {
+		return BoardingSweepRecord{}, fmt.Errorf("decode txid: %w", err)
+	}
+
+	tx := wire.NewMsgTx(arktx.TxVersion)
+	if err := tx.Deserialize(bytes.NewReader(row.RawTx)); err != nil {
+		return BoardingSweepRecord{}, fmt.Errorf(
+			"decode raw tx: %w", err,
+		)
+	}
+
+	inputRows, err := q.ListBoardingSweepInputs(ctx, row.Txid)
+	if err != nil {
+		return BoardingSweepRecord{}, fmt.Errorf(
+			"load sweep inputs: %w", err,
+		)
+	}
+
+	inputs := make([]BoardingSweepInputRecord, 0, len(inputRows))
+	for _, inputRow := range inputRows {
+		input, err := boardingSweepInputRecordFromRow(inputRow)
+		if err != nil {
+			return BoardingSweepRecord{}, err
+		}
+
+		inputs = append(inputs, input)
+	}
+
+	return BoardingSweepRecord{
+		Txid:               txid,
+		Tx:                 tx,
+		DestinationAddress: row.DestinationAddress,
+		TotalAmount:        btcutil.Amount(row.TotalAmount),
+		FeeAmount:          btcutil.Amount(row.FeeAmount),
+		FeeRateSatPerVByte: row.FeeRateSatPerVbyte,
+		VBytes:             row.Vbytes,
+		Status:             row.Status,
+		CreatedHeight:      row.CreatedHeight,
+		ConfirmedHeight:    row.ConfirmedHeight,
+		LastError:          row.LastError,
+		Inputs:             inputs,
+	}, nil
+}
+
+// boardingSweepInputRecordFromRow converts one sqlc sweep input row into a
+// typed outpoint record.
+func boardingSweepInputRecordFromRow(
+	row BoardingSweepInputRow) (BoardingSweepInputRecord, error) {
+
+	txid, err := hashFromBytes(row.Txid)
+	if err != nil {
+		return BoardingSweepInputRecord{}, fmt.Errorf("decode txid: %w",
+			err)
+	}
+
+	outpointHash, err := hashFromBytes(row.OutpointHash)
+	if err != nil {
+		return BoardingSweepInputRecord{}, fmt.Errorf(
+			"decode outpoint hash: %w", err)
+	}
+
+	spentBy := sql.NullString{}
+	if len(row.SpentByTxid) == chainhash.HashSize {
+		spentHash, err := hashFromBytes(row.SpentByTxid)
+		if err != nil {
+			return BoardingSweepInputRecord{}, fmt.Errorf(
+				"decode spending txid: %w", err)
+		}
+		spentBy = sqlStr(spentHash.String())
+	}
+
+	return BoardingSweepInputRecord{
+		Txid: txid,
+		Outpoint: wire.OutPoint{
+			Hash:  outpointHash,
+			Index: uint32(row.OutpointIndex),
+		},
+		Amount:      btcutil.Amount(row.Amount),
+		Status:      row.Status,
+		SpentByTxid: spentBy,
+		SpentHeight: row.SpentHeight,
+	}, nil
+}
+
+// hashFromBytes converts a database hash blob into a chainhash.Hash.
+func hashFromBytes(raw []byte) (chainhash.Hash, error) {
+	if len(raw) != chainhash.HashSize {
+		return chainhash.Hash{}, fmt.Errorf(
+			"expected %d-byte hash, got %d",
+			chainhash.HashSize, len(raw),
+		)
+	}
+
+	var hash chainhash.Hash
+	copy(hash[:], raw)
+
+	return hash, nil
+}

--- a/db/boarding_wallet.go
+++ b/db/boarding_wallet.go
@@ -36,8 +36,18 @@ type (
 // IntentHeightFilter filters boarding intents by status and min conf height.
 type IntentHeightFilter = sqlc.ListBoardingIntentsByStatusAndMinHeightParams
 
+// BoardingSweepRow is the persisted aggregate boarding sweep transaction row.
+type BoardingSweepRow = sqlc.BoardingSweep
+
+// BoardingSweepInputRow is the persisted per-input boarding sweep row.
+type BoardingSweepInputRow = sqlc.BoardingSweepInput
+
 // BoardingStore is the interface that groups all boarding-related database
 // queries. This is a subset of sqlc.Querier focused on boarding operations.
+//
+// focused on a single store capability.
+//
+//nolint:interfacebloat // Grouping all boarding queries keeps ExecTx closures
 type BoardingStore interface {
 	InsertBoardingAddress(ctx context.Context, arg NewAddrParams) error
 
@@ -54,6 +64,10 @@ type BoardingStore interface {
 
 	ListBoardingIntentsByStatus(
 		ctx context.Context, status string) ([]BoardingIntentRow, error)
+	ListBoardingIntentsBySweepableStatuses(
+		ctx context.Context,
+		arg sqlc.ListBoardingIntentsBySweepableStatusesParams,
+	) ([]BoardingIntentRow, error)
 
 	ListAllBoardingIntents(ctx context.Context) ([]BoardingIntentRow, error)
 
@@ -66,6 +80,47 @@ type BoardingStore interface {
 	ListBoardingIntentsByStatusAndMinHeight(
 		ctx context.Context, arg IntentHeightFilter,
 	) ([]BoardingIntentRow, error)
+	UpdateBoardingIntentStatus(
+		ctx context.Context, arg sqlc.UpdateBoardingIntentStatusParams,
+	) error
+	InsertBoardingSweep(
+		ctx context.Context, arg sqlc.InsertBoardingSweepParams,
+	) error
+	InsertBoardingSweepInput(
+		ctx context.Context, arg sqlc.InsertBoardingSweepInputParams,
+	) error
+	GetBoardingSweep(ctx context.Context, txid []byte) (
+		BoardingSweepRow, error)
+	GetBoardingSweepByInput(
+		ctx context.Context, arg sqlc.GetBoardingSweepByInputParams,
+	) (BoardingSweepRow, error)
+	ListBoardingSweepInputs(ctx context.Context, txid []byte) (
+		[]BoardingSweepInputRow, error)
+	ListBoardingSweeps(
+		ctx context.Context, arg sqlc.ListBoardingSweepsParams,
+	) (
+		[]BoardingSweepRow, error)
+	ListPendingBoardingSweeps(ctx context.Context) (
+		[]BoardingSweepRow, error)
+	ListPendingBoardingSweepInputs(ctx context.Context) (
+		[]BoardingSweepInputRow, error)
+	MarkBoardingSweepStatus(
+		ctx context.Context, arg sqlc.MarkBoardingSweepStatusParams,
+	) error
+	MarkBoardingSweepInputStatus(
+		ctx context.Context,
+		arg sqlc.MarkBoardingSweepInputStatusParams,
+	) error
+	MarkBoardingSweepInputsStatus(
+		ctx context.Context,
+		arg sqlc.MarkBoardingSweepInputsStatusParams,
+	) error
+	MarkBoardingSweepInputSpentByOutpoint(
+		ctx context.Context,
+		arg sqlc.MarkBoardingSweepInputSpentByOutpointParams,
+	) error
+	CountUnresolvedBoardingSweepInputs(
+		ctx context.Context, txid []byte) (int64, error)
 }
 
 // BatchedBoardingStore combines BoardingStore with transaction support via the
@@ -318,6 +373,65 @@ func (b *BoardingWalletStore) FetchBoardingIntentsByStatus(ctx context.Context,
 	return result, err
 }
 
+// FetchBoardingIntentsBySweepableStatuses returns all boarding intents in the
+// lifecycle states that can still represent a timeout-path sweep candidate.
+func (b *BoardingWalletStore) FetchBoardingIntentsBySweepableStatuses(
+	ctx context.Context, statuses [3]wallet.BoardingStatus,
+) ([]wallet.BoardingIntent, error) {
+
+	status0, err := statusToString(statuses[0])
+	if err != nil {
+		return nil, err
+	}
+
+	status1, err := statusToString(statuses[1])
+	if err != nil {
+		return nil, err
+	}
+
+	status2, err := statusToString(statuses[2])
+	if err != nil {
+		return nil, err
+	}
+
+	readTxOpts := ReadTxOption()
+
+	var result []wallet.BoardingIntent
+
+	err = b.db.ExecTx(ctx, readTxOpts, func(q BoardingStore) error {
+		dbIntents, err := q.ListBoardingIntentsBySweepableStatuses(
+			ctx, sqlc.ListBoardingIntentsBySweepableStatusesParams{
+				Status:   status0,
+				Status_2: status1,
+				Status_3: status2,
+			},
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"list boarding intents by statuses: %w", err,
+			)
+		}
+
+		intents := make([]wallet.BoardingIntent, 0, len(dbIntents))
+		for _, dbIntent := range dbIntents {
+			intent, err := b.dbIntentToDomainIntent(
+				ctx, q, dbIntent,
+			)
+			if err != nil {
+				return fmt.Errorf("convert intent: %w", err)
+			}
+
+			intents = append(intents, *intent)
+		}
+
+		result = intents
+
+		return nil
+	})
+
+	return result, err
+}
+
 // FetchBoardingIntentOutpoints returns just the outpoints of all boarding
 // intents. This is more efficient than FetchBoardingIntents when only the
 // outpoints are needed (e.g., for seenUtxos initialization).
@@ -403,6 +517,36 @@ func (b *BoardingWalletStore) FetchBoardingIntentsByStatusAndMinHeight(
 	})
 
 	return result, err
+}
+
+// UpdateBoardingIntentStatus updates one boarding intent's lifecycle status.
+func (b *BoardingWalletStore) UpdateBoardingIntentStatus(ctx context.Context,
+	outpoint wire.OutPoint, status wallet.BoardingStatus) error {
+
+	statusStr, err := statusToString(status)
+	if err != nil {
+		return err
+	}
+
+	writeTxOpts := WriteTxOption()
+
+	return b.db.ExecTx(ctx, writeTxOpts, func(q BoardingStore) error {
+		params := sqlc.UpdateBoardingIntentStatusParams{
+			OutpointHash:   outpoint.Hash[:],
+			OutpointIndex:  int32(outpoint.Index),
+			Status:         statusStr,
+			LastUpdateTime: b.clock.Now().Unix(),
+		}
+
+		err := q.UpdateBoardingIntentStatus(ctx, params)
+		if err != nil {
+			return fmt.Errorf(
+				"update boarding intent status: %w", err,
+			)
+		}
+
+		return nil
+	})
 }
 
 // GetIntent retrieves a boarding intent by its outpoint (primary key). Returns
@@ -699,6 +843,8 @@ func statusToString(status wallet.BoardingStatus) (string, error) {
 		return "expired", nil
 	case wallet.BoardingStatusSwept:
 		return "swept", nil
+	case wallet.BoardingStatusSweepPending:
+		return "sweep_pending", nil
 	default:
 		return "", fmt.Errorf("unknown boarding status: %d", status)
 	}
@@ -718,6 +864,8 @@ func stringToStatus(status string) (wallet.BoardingStatus, error) {
 		return wallet.BoardingStatusExpired, nil
 	case "swept":
 		return wallet.BoardingStatusSwept, nil
+	case "sweep_pending":
+		return wallet.BoardingStatusSweepPending, nil
 	default:
 		return 0, fmt.Errorf("unknown boarding status: %q", status)
 	}

--- a/db/boarding_wallet.md
+++ b/db/boarding_wallet.md
@@ -10,9 +10,9 @@ calculations and address management.
 
 ## Schema Overview
 
-The boarding wallet schema consists of three tables:
+The boarding wallet schema consists of five tables:
 
-1. **boarding_statuses**: Enum-like table defining the five possible boarding
+1. **boarding_statuses**: Enum-like table defining the six possible boarding
    intent lifecycle states.
 
 2. **boarding_addresses**: Stores generated boarding addresses with their
@@ -22,12 +22,20 @@ The boarding wallet schema consists of three tables:
 3. **boarding_intents**: Tracks individual boarding attempts from on-chain
    confirmation through round completion.
 
+4. **boarding_sweeps**: Tracks aggregate timeout-path sweep transactions that
+   have been built for expired boarding outputs.
+
+5. **boarding_sweep_inputs**: Tracks each boarding outpoint consumed by a
+   pending or published aggregate sweep transaction.
+
 ## Entity Relationship Diagram
 
 ```mermaid
 erDiagram
     boarding_statuses ||--o{ boarding_intents : "enforces"
     boarding_addresses ||--o{ boarding_intents : "has"
+    boarding_intents ||--o{ boarding_sweep_inputs : "watched by"
+    boarding_sweeps ||--o{ boarding_sweep_inputs : "contains"
 
     boarding_statuses {
         BIGINT id "PK"
@@ -59,6 +67,34 @@ erDiagram
         BIGINT creation_time
         BIGINT last_update_time
     }
+
+    boarding_sweeps {
+        BLOB txid "PK"
+        BLOB raw_tx
+        TEXT destination_address
+        BIGINT total_amount
+        BIGINT fee_amount
+        BIGINT fee_rate_sat_per_vbyte
+        BIGINT vbytes
+        TEXT status "Idx"
+        INTEGER created_height
+        BIGINT created_time
+        BIGINT published_time
+        INTEGER confirmed_height
+        TEXT last_error
+    }
+
+    boarding_sweep_inputs {
+        BLOB txid "PK, FK"
+        BLOB outpoint_hash "PK, FK, Idx"
+        INTEGER outpoint_index "PK, FK"
+        BIGINT amount
+        TEXT previous_status
+        TEXT status "Idx"
+        BLOB spent_by_txid
+        INTEGER spent_height
+        BIGINT last_update_time
+    }
 ```
 
 ## Table Details
@@ -74,6 +110,8 @@ foreign key constraint.
 - `failed` (2): Boarding attempt failed (server rejection, timeout, etc.)
 - `expired` (3): CSV timeout expired, funds recoverable via timeout path
 - `swept` (4): Funds swept to a new address (either via round or timeout path)
+- `sweep_pending` (5): Included in a published timeout-path sweep and waiting
+for the chain backend to report the boarding outpoint as spent
 
 This table is static after migration and enforces type safety at the database
 level.
@@ -227,8 +265,51 @@ recoverable via CSV path
 
 - **expired**: CSV timeout has passed, funds can be recovered unilaterally
 
+- **sweep_pending**: A timeout-path sweep transaction has been published and
+the daemon is watching the boarding outpoint for a confirmed spend
+
 - **swept**: Funds have been moved (either via successful round or timeout
 recovery)
+
+### Timeout Sweep Recovery Flow
+
+1. `SweepBoardingUTXOs` builds one signed aggregate transaction that spends
+   every selected CSV-mature boarding output into one destination output.
+   Callers may pass `sweep_address` to choose that destination explicitly;
+   otherwise the daemon asks the wallet for a fresh address.
+
+2. With `broadcast=false`, the RPC only previews the transaction, fee, and
+   txid. No database state is changed.
+
+3. With `broadcast=true`, the daemon persists `boarding_sweeps` and
+   `boarding_sweep_inputs` rows before broadcast and moves the selected
+   intents to `sweep_pending`.
+
+4. After broadcast succeeds, the sweep and unresolved inputs move from
+   `pending` to `published`.
+
+5. The daemon-owned boarding sweep watcher starts after wallet unlock, reloads
+   pending sweeps on startup, registers confirmed-spend watches for each input
+   outpoint, and rebroadcasts the exact stored raw transaction best-effort.
+   It does not rebuild, replace, or fee-bump the transaction. Already
+   published sweeps are rate-limited between rebroadcast attempts.
+
+6. When the chain backend reports an input as spent, the watcher records
+   `spent_by_txid` and `spent_height`. Inputs spent by the stored sweep tx are
+   marked `spent`; inputs spent by another transaction are marked
+   `external_spent`.
+
+7. Once every input for an aggregate sweep is resolved, the sweep is marked
+   `confirmed` if at least one input was spent by the stored sweep tx. If all
+   inputs were spent by other transactions, the aggregate is marked
+   `external_resolved`. The corresponding boarding intents are marked `swept`
+   because the original boarding outpoints are no longer recoverable by this
+   daemon.
+
+8. `ListBoardingSweeps` exposes the persisted aggregate sweeps and input
+   states so operators can inspect whether a sweep is still `published`, has
+   reached `confirmed`, was `external_resolved`, or failed before confirmation
+   tracking completed.
 
 ## Constraints and Invariants
 
@@ -239,9 +320,16 @@ key enforced)
 - Every `boarding_intent.status` must be a valid status from
 `boarding_statuses` (foreign key enforced)
 
+- Every `boarding_sweep_input` references one persisted sweep transaction and
+one persisted boarding intent
+
 **Uniqueness**:
 - Each `pk_script` identifies exactly one boarding address
 - Each `(outpoint_hash, outpoint_index)` identifies exactly one boarding intent
+- Each `(txid, outpoint_hash, outpoint_index)` identifies exactly one tracked
+sweep input
+- At most one active (`pending` or `published`) sweep input may exist for the
+same boarding outpoint
 - A boarding address can have multiple intents (user sends to same address
 multiple times)
 
@@ -256,6 +344,10 @@ application logic ensures valid state machine transitions. The foreign key to
 - `status` indexed for filtering by lifecycle stage
 - `conf_height` indexed for range queries and backlog delivery
 - `last_confirmed_height` indexed in `boarding_addresses` for startup recovery
+- `boarding_sweeps.status` and `boarding_sweep_inputs.status` indexed for
+watcher startup and periodic recovery scans
+- `boarding_sweep_inputs(outpoint_hash, outpoint_index)` indexed so spend
+notifications can resolve the owning pending sweep efficiently
 
 **Upsert optimization**: Using `ON CONFLICT DO UPDATE` with COALESCE prevents
 overwriting already-set fields, reducing transaction contention and preserving

--- a/db/boarding_wallet_test.go
+++ b/db/boarding_wallet_test.go
@@ -92,6 +92,75 @@ func createTestBoardingAddress(t *testing.T,
 	return boardingAddr, clientPrivKey
 }
 
+// createSweepStoreIntent inserts one confirmed boarding intent for sweep store
+// tests.
+func createSweepStoreIntent(t *testing.T,
+	store *BoardingWalletStore) wallet.BoardingIntent {
+
+	t.Helper()
+
+	return createSweepStoreIntentWithSeed(t, store, 0x99)
+}
+
+// createSweepStoreIntentWithSeed inserts one confirmed boarding intent using a
+// caller-selected seed for tests that need multiple distinct outpoints.
+func createSweepStoreIntentWithSeed(t *testing.T,
+	store *BoardingWalletStore, seed byte) wallet.BoardingIntent {
+
+	t.Helper()
+
+	ctx := t.Context()
+	boardingAddr, _ := createTestBoardingAddress(t, uint32(seed))
+	require.NoError(t, store.InsertBoardingAddress(ctx, boardingAddr))
+
+	pkScript, err := txscript.PayToAddrScript(boardingAddr.Address)
+	require.NoError(t, err)
+
+	confTx := wire.NewMsgTx(2)
+	confTx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{
+			Hash:  chainhash.Hash{seed},
+			Index: 0,
+		},
+	})
+	confTx.AddTxOut(&wire.TxOut{
+		Value:    10_000,
+		PkScript: pkScript,
+	})
+
+	outpoint := wire.OutPoint{
+		Hash:  confTx.TxHash(),
+		Index: 0,
+	}
+
+	intent := wallet.BoardingIntent{
+		Address:  *boardingAddr,
+		Outpoint: outpoint,
+		ChainInfo: wallet.BoardingChainInfo{
+			ConfHeight: 100,
+			ConfHash:   chainhash.Hash{0xaa},
+			ConfTx:     confTx,
+			OutPoint:   outpoint,
+			Amount:     10_000,
+		},
+		Status: wallet.BoardingStatusConfirmed,
+	}
+	require.NoError(t, store.InsertBoardingIntents(ctx, intent))
+
+	return intent
+}
+
+// dbSweepInputStatus returns the only input status in a one-input sweep test.
+func dbSweepInputStatus(t *testing.T,
+	inputs []BoardingSweepInputRecord) string {
+
+	t.Helper()
+
+	require.Len(t, inputs, 1)
+
+	return inputs[0].Status
+}
+
 // TestBoardingAddressRoundTrip tests inserting and retrieving a boarding
 // address.
 func TestBoardingAddressRoundTrip(t *testing.T) {
@@ -280,6 +349,48 @@ func TestBoardingIntentLifecycle(t *testing.T) {
 	require.Equal(t, wallet.BoardingStatusAdopted, retrievedIntent.Status)
 }
 
+// TestUpdateBoardingIntentStatus verifies the narrow status update helper used
+// by recovery flows that do not rewrite the full boarding intent.
+func TestUpdateBoardingIntentStatus(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store, _ := newBoardingStoreForTest(t)
+
+	boardingAddr, _ := createTestBoardingAddress(t, 0)
+
+	err := store.InsertBoardingAddress(ctx, boardingAddr)
+	require.NoError(t, err)
+
+	outpoint := wire.OutPoint{
+		Hash:  chainhash.Hash{0xaa, 0xbb},
+		Index: 0,
+	}
+	intent := wallet.BoardingIntent{
+		Address:  *boardingAddr,
+		Outpoint: outpoint,
+		ChainInfo: wallet.BoardingChainInfo{
+			ConfHeight: 100,
+			ConfHash:   chainhash.Hash{0xcc, 0xdd},
+			OutPoint:   outpoint,
+			Amount:     100000,
+		},
+		Status: wallet.BoardingStatusConfirmed,
+	}
+
+	err = store.InsertBoardingIntents(ctx, intent)
+	require.NoError(t, err)
+
+	err = store.UpdateBoardingIntentStatus(
+		ctx, outpoint, wallet.BoardingStatusSwept,
+	)
+	require.NoError(t, err)
+
+	retrievedIntent, err := store.GetIntent(ctx, outpoint)
+	require.NoError(t, err)
+	require.Equal(t, wallet.BoardingStatusSwept, retrievedIntent.Status)
+}
+
 // TestFetchBoardingIntentsByStatus tests filtering intents by status.
 func TestFetchBoardingIntentsByStatus(t *testing.T) {
 	t.Parallel()
@@ -300,6 +411,7 @@ func TestFetchBoardingIntentsByStatus(t *testing.T) {
 		wallet.BoardingStatusFailed,
 		wallet.BoardingStatusExpired,
 		wallet.BoardingStatusSwept,
+		wallet.BoardingStatusSweepPending,
 	}
 
 	for i, status := range statuses {
@@ -351,6 +463,316 @@ func TestFetchBoardingIntentsByStatus(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Len(t, sweptIntents, 1)
+
+	pendingIntents, err := store.FetchBoardingIntentsByStatus(
+		ctx, wallet.BoardingStatusSweepPending,
+	)
+	require.NoError(t, err)
+	require.Len(t, pendingIntents, 1)
+}
+
+// TestBoardingSweepStoreTracksPendingAndResolved verifies the durable sweep
+// lifecycle moves intents to pending and only marks them swept after a
+// confirmed spend.
+func TestBoardingSweepStoreTracksPendingAndResolved(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store, _ := newBoardingStoreForTest(t)
+
+	intent := createSweepStoreIntent(t, store)
+	sweepTx := wire.NewMsgTx(2)
+	sweepTx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: intent.Outpoint,
+	})
+	sweepTx.AddTxOut(&wire.TxOut{
+		Value:    int64(intent.ChainInfo.Amount - 500),
+		PkScript: []byte{txscript.OP_TRUE},
+	})
+	sweepTxid := sweepTx.TxHash()
+
+	err := store.CreatePendingBoardingSweep(ctx, NewBoardingSweep{
+		Tx:                 sweepTx,
+		DestinationAddress: "bcrt1test",
+		TotalAmount:        intent.ChainInfo.Amount,
+		FeeAmount:          500,
+		FeeRateSatPerVByte: 2,
+		VBytes:             250,
+		CreatedHeight:      200,
+		Inputs: []NewBoardingSweepInput{{
+			Outpoint:       intent.Outpoint,
+			Amount:         intent.ChainInfo.Amount,
+			PreviousStatus: intent.Status,
+		}},
+	})
+	require.NoError(t, err)
+
+	updated, err := store.GetIntent(ctx, intent.Outpoint)
+	require.NoError(t, err)
+	require.Equal(t, wallet.BoardingStatusSweepPending, updated.Status)
+
+	pending, err := store.ListPendingBoardingSweeps(ctx)
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	require.Equal(t, dbSweepInputStatus(t, pending[0].Inputs),
+		BoardingSweepInputStatusPending)
+	require.Equal(t, btcutil.Amount(500), pending[0].FeeAmount)
+	require.Equal(t, int64(250), pending[0].VBytes)
+
+	allSweeps, err := store.ListBoardingSweeps(ctx, "", 10, 0)
+	require.NoError(t, err)
+	require.Len(t, allSweeps, 1)
+	require.Equal(t, "bcrt1test", allSweeps[0].DestinationAddress)
+	require.Equal(t, btcutil.Amount(500), allSweeps[0].FeeAmount)
+	require.Equal(t, int64(2), allSweeps[0].FeeRateSatPerVByte)
+
+	filteredSweeps, err := store.ListBoardingSweeps(
+		ctx, BoardingSweepStatusPublished, 10, 0,
+	)
+	require.NoError(t, err)
+	require.Empty(t, filteredSweeps)
+
+	err = store.MarkBoardingSweepPublished(ctx, sweepTxid)
+	require.NoError(t, err)
+
+	filteredSweeps, err = store.ListBoardingSweeps(
+		ctx, BoardingSweepStatusPublished, 10, 0,
+	)
+	require.NoError(t, err)
+	require.Len(t, filteredSweeps, 1)
+
+	pending, err = store.ListPendingBoardingSweeps(ctx)
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	require.Equal(t, dbSweepInputStatus(t, pending[0].Inputs),
+		BoardingSweepInputStatusPublished)
+
+	resolved, err := store.MarkBoardingSweepInputSpent(
+		ctx, intent.Outpoint, sweepTxid, 222,
+	)
+	require.NoError(t, err)
+	require.True(t, resolved)
+
+	pending, err = store.ListPendingBoardingSweeps(ctx)
+	require.NoError(t, err)
+	require.Empty(t, pending)
+
+	filteredSweeps, err = store.ListBoardingSweeps(
+		ctx, BoardingSweepStatusConfirmed, 10, 0,
+	)
+	require.NoError(t, err)
+	require.Len(t, filteredSweeps, 1)
+	require.True(t, filteredSweeps[0].ConfirmedHeight.Valid)
+	require.Equal(t, int32(222), filteredSweeps[0].ConfirmedHeight.Int32)
+	require.Equal(t, BoardingSweepInputStatusSpent,
+		dbSweepInputStatus(t, filteredSweeps[0].Inputs))
+
+	updated, err = store.GetIntent(ctx, intent.Outpoint)
+	require.NoError(t, err)
+	require.Equal(t, wallet.BoardingStatusSwept, updated.Status)
+}
+
+// TestBoardingSweepFailedRestoresIntent verifies failed broadcasts put inputs
+// back into their pre-sweep boarding status.
+func TestBoardingSweepFailedRestoresIntent(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store, _ := newBoardingStoreForTest(t)
+
+	intent := createSweepStoreIntent(t, store)
+	sweepTx := wire.NewMsgTx(2)
+	sweepTx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: intent.Outpoint,
+	})
+	sweepTx.AddTxOut(&wire.TxOut{
+		Value:    int64(intent.ChainInfo.Amount - 500),
+		PkScript: []byte{txscript.OP_TRUE},
+	})
+	sweepTxid := sweepTx.TxHash()
+
+	err := store.CreatePendingBoardingSweep(ctx, NewBoardingSweep{
+		Tx:                 sweepTx,
+		DestinationAddress: "",
+		TotalAmount:        intent.ChainInfo.Amount,
+		FeeAmount:          500,
+		FeeRateSatPerVByte: 2,
+		VBytes:             250,
+		CreatedHeight:      200,
+		Inputs: []NewBoardingSweepInput{{
+			Outpoint:       intent.Outpoint,
+			Amount:         intent.ChainInfo.Amount,
+			PreviousStatus: intent.Status,
+		}},
+	})
+	require.NoError(t, err)
+
+	err = store.MarkBoardingSweepFailed(
+		ctx, sweepTxid, sql.ErrConnDone,
+	)
+	require.NoError(t, err)
+
+	updated, err := store.GetIntent(ctx, intent.Outpoint)
+	require.NoError(t, err)
+	require.Equal(t, wallet.BoardingStatusConfirmed, updated.Status)
+}
+
+// TestBoardingSweepExternalSpendResolvesSeparately verifies an externally
+// spent sweep input does not make the aggregate look confirmed by our tx.
+func TestBoardingSweepExternalSpendResolvesSeparately(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store, _ := newBoardingStoreForTest(t)
+
+	intent := createSweepStoreIntent(t, store)
+	sweepTx := wire.NewMsgTx(2)
+	sweepTx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: intent.Outpoint,
+	})
+	sweepTx.AddTxOut(&wire.TxOut{
+		Value:    int64(intent.ChainInfo.Amount - 500),
+		PkScript: []byte{txscript.OP_TRUE},
+	})
+	sweepTxid := sweepTx.TxHash()
+
+	err := store.CreatePendingBoardingSweep(ctx, NewBoardingSweep{
+		Tx:                 sweepTx,
+		TotalAmount:        intent.ChainInfo.Amount,
+		FeeAmount:          500,
+		FeeRateSatPerVByte: 2,
+		VBytes:             250,
+		CreatedHeight:      200,
+		Inputs: []NewBoardingSweepInput{{
+			Outpoint:       intent.Outpoint,
+			Amount:         intent.ChainInfo.Amount,
+			PreviousStatus: intent.Status,
+		}},
+	})
+	require.NoError(t, err)
+
+	externalTxid := chainhash.Hash{0xee}
+	resolved, err := store.MarkBoardingSweepInputSpent(
+		ctx, intent.Outpoint, externalTxid, 333,
+	)
+	require.NoError(t, err)
+	require.True(t, resolved)
+	require.NotEqual(t, sweepTxid, externalTxid)
+
+	external, err := store.ListBoardingSweeps(
+		ctx, BoardingSweepStatusExternalResolved, 10, 0,
+	)
+	require.NoError(t, err)
+	require.Len(t, external, 1)
+	require.Equal(t, BoardingSweepInputStatusExternalSpent,
+		dbSweepInputStatus(t, external[0].Inputs))
+	require.Equal(t, int32(333), external[0].ConfirmedHeight.Int32)
+
+	confirmed, err := store.ListBoardingSweeps(
+		ctx, BoardingSweepStatusConfirmed, 10, 0,
+	)
+	require.NoError(t, err)
+	require.Empty(t, confirmed)
+}
+
+// TestActiveBoardingSweepInputUnique verifies the DB enforces that one
+// boarding outpoint can only belong to one active sweep at a time.
+func TestActiveBoardingSweepInputUnique(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store, _ := newBoardingStoreForTest(t)
+
+	intent := createSweepStoreIntent(t, store)
+	firstTx := wire.NewMsgTx(2)
+	firstTx.AddTxIn(&wire.TxIn{PreviousOutPoint: intent.Outpoint})
+	firstTx.AddTxOut(&wire.TxOut{
+		Value:    9_000,
+		PkScript: []byte{txscript.OP_TRUE},
+	})
+
+	err := store.CreatePendingBoardingSweep(ctx, NewBoardingSweep{
+		Tx:                 firstTx,
+		TotalAmount:        intent.ChainInfo.Amount,
+		FeeAmount:          1_000,
+		FeeRateSatPerVByte: 2,
+		VBytes:             250,
+		CreatedHeight:      200,
+		Inputs: []NewBoardingSweepInput{{
+			Outpoint:       intent.Outpoint,
+			Amount:         intent.ChainInfo.Amount,
+			PreviousStatus: intent.Status,
+		}},
+	})
+	require.NoError(t, err)
+
+	secondTx := wire.NewMsgTx(2)
+	secondTx.AddTxIn(&wire.TxIn{PreviousOutPoint: intent.Outpoint})
+	secondTx.AddTxOut(&wire.TxOut{
+		Value:    8_000,
+		PkScript: []byte{txscript.OP_TRUE},
+	})
+	secondTx.LockTime = 1
+
+	err = store.CreatePendingBoardingSweep(ctx, NewBoardingSweep{
+		Tx:                 secondTx,
+		TotalAmount:        intent.ChainInfo.Amount,
+		FeeAmount:          2_000,
+		FeeRateSatPerVByte: 2,
+		VBytes:             250,
+		CreatedHeight:      201,
+		Inputs: []NewBoardingSweepInput{{
+			Outpoint:       intent.Outpoint,
+			Amount:         intent.ChainInfo.Amount,
+			PreviousStatus: intent.Status,
+		}},
+	})
+	require.Error(t, err)
+}
+
+// TestListBoardingSweepsPaginates verifies the store only loads the requested
+// page window.
+func TestListBoardingSweepsPaginates(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store, _ := newBoardingStoreForTest(t)
+
+	for i := byte(1); i <= 3; i++ {
+		intent := createSweepStoreIntentWithSeed(t, store, i)
+		sweepTx := wire.NewMsgTx(2)
+		sweepTx.AddTxIn(&wire.TxIn{
+			PreviousOutPoint: intent.Outpoint,
+		})
+		sweepTx.AddTxOut(&wire.TxOut{
+			Value:    9_000,
+			PkScript: []byte{txscript.OP_TRUE},
+		})
+		sweepTx.LockTime = uint32(i)
+
+		err := store.CreatePendingBoardingSweep(ctx, NewBoardingSweep{
+			Tx:                 sweepTx,
+			TotalAmount:        intent.ChainInfo.Amount,
+			FeeAmount:          1_000,
+			FeeRateSatPerVByte: 2,
+			VBytes:             250,
+			CreatedHeight:      int32(200 + i),
+			Inputs: []NewBoardingSweepInput{{
+				Outpoint:       intent.Outpoint,
+				Amount:         intent.ChainInfo.Amount,
+				PreviousStatus: intent.Status,
+			}},
+		})
+		require.NoError(t, err)
+	}
+
+	firstPage, err := store.ListBoardingSweeps(ctx, "", 2, 0)
+	require.NoError(t, err)
+	require.Len(t, firstPage, 2)
+
+	secondPage, err := store.ListBoardingSweeps(ctx, "", 2, 2)
+	require.NoError(t, err)
+	require.Len(t, secondPage, 1)
 }
 
 // TestFetchBoardingIntents tests fetching all intents.

--- a/db/migrations.go
+++ b/db/migrations.go
@@ -10,7 +10,7 @@ const (
 	// daemon.
 	//
 	// NOTE: This MUST be updated when a new migration is added.
-	LatestMigrationVersion uint = 10
+	LatestMigrationVersion uint = 11
 )
 
 // MigrationTarget is a functional option that can be passed to applyMigrations

--- a/db/sqlc/boarding.sql.go
+++ b/db/sqlc/boarding.sql.go
@@ -7,6 +7,7 @@ package sqlc
 
 import (
 	"context"
+	"database/sql"
 )
 
 const CountBoardingIntentsByStatus = `-- name: CountBoardingIntentsByStatus :one
@@ -16,6 +17,19 @@ WHERE status = $1
 
 func (q *Queries) CountBoardingIntentsByStatus(ctx context.Context, status string) (int64, error) {
 	row := q.db.QueryRowContext(ctx, CountBoardingIntentsByStatus, status)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+const CountUnresolvedBoardingSweepInputs = `-- name: CountUnresolvedBoardingSweepInputs :one
+SELECT COUNT(*) FROM boarding_sweep_inputs
+WHERE txid = $1
+  AND status IN ('pending', 'published')
+`
+
+func (q *Queries) CountUnresolvedBoardingSweepInputs(ctx context.Context, txid []byte) (int64, error) {
+	row := q.db.QueryRowContext(ctx, CountUnresolvedBoardingSweepInputs, txid)
 	var count int64
 	err := row.Scan(&count)
 	return count, err
@@ -67,6 +81,67 @@ func (q *Queries) GetBoardingIntent(ctx context.Context, arg GetBoardingIntentPa
 		&i.CreationTime,
 		&i.LastUpdateTime,
 		&i.TxProof,
+	)
+	return i, err
+}
+
+const GetBoardingSweep = `-- name: GetBoardingSweep :one
+SELECT txid, raw_tx, destination_address, total_amount, fee_amount, fee_rate_sat_per_vbyte, vbytes, status, created_height, created_time, published_time, confirmed_height, last_error FROM boarding_sweeps
+WHERE txid = $1
+`
+
+func (q *Queries) GetBoardingSweep(ctx context.Context, txid []byte) (BoardingSweep, error) {
+	row := q.db.QueryRowContext(ctx, GetBoardingSweep, txid)
+	var i BoardingSweep
+	err := row.Scan(
+		&i.Txid,
+		&i.RawTx,
+		&i.DestinationAddress,
+		&i.TotalAmount,
+		&i.FeeAmount,
+		&i.FeeRateSatPerVbyte,
+		&i.Vbytes,
+		&i.Status,
+		&i.CreatedHeight,
+		&i.CreatedTime,
+		&i.PublishedTime,
+		&i.ConfirmedHeight,
+		&i.LastError,
+	)
+	return i, err
+}
+
+const GetBoardingSweepByInput = `-- name: GetBoardingSweepByInput :one
+SELECT bs.txid, bs.raw_tx, bs.destination_address, bs.total_amount, bs.fee_amount, bs.fee_rate_sat_per_vbyte, bs.vbytes, bs.status, bs.created_height, bs.created_time, bs.published_time, bs.confirmed_height, bs.last_error
+FROM boarding_sweeps bs
+JOIN boarding_sweep_inputs bsi ON bsi.txid = bs.txid
+WHERE bsi.outpoint_hash = $1
+  AND bsi.outpoint_index = $2
+  AND bsi.status IN ('pending', 'published')
+`
+
+type GetBoardingSweepByInputParams struct {
+	OutpointHash  []byte
+	OutpointIndex int32
+}
+
+func (q *Queries) GetBoardingSweepByInput(ctx context.Context, arg GetBoardingSweepByInputParams) (BoardingSweep, error) {
+	row := q.db.QueryRowContext(ctx, GetBoardingSweepByInput, arg.OutpointHash, arg.OutpointIndex)
+	var i BoardingSweep
+	err := row.Scan(
+		&i.Txid,
+		&i.RawTx,
+		&i.DestinationAddress,
+		&i.TotalAmount,
+		&i.FeeAmount,
+		&i.FeeRateSatPerVbyte,
+		&i.Vbytes,
+		&i.Status,
+		&i.CreatedHeight,
+		&i.CreatedTime,
+		&i.PublishedTime,
+		&i.ConfirmedHeight,
+		&i.LastError,
 	)
 	return i, err
 }
@@ -174,6 +249,122 @@ func (q *Queries) InsertBoardingIntent(ctx context.Context, arg InsertBoardingIn
 		arg.TxProof,
 		arg.Status,
 		arg.CreationTime,
+		arg.LastUpdateTime,
+	)
+	return err
+}
+
+const InsertBoardingSweep = `-- name: InsertBoardingSweep :exec
+
+INSERT INTO boarding_sweeps (
+    txid,
+    raw_tx,
+    destination_address,
+    total_amount,
+    fee_amount,
+    fee_rate_sat_per_vbyte,
+    vbytes,
+    status,
+    created_height,
+    created_time,
+    published_time,
+    confirmed_height,
+    last_error
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+ON CONFLICT (txid) DO UPDATE SET
+    raw_tx = excluded.raw_tx,
+    destination_address = excluded.destination_address,
+    total_amount = excluded.total_amount,
+    fee_amount = excluded.fee_amount,
+    fee_rate_sat_per_vbyte = excluded.fee_rate_sat_per_vbyte,
+    vbytes = excluded.vbytes,
+    status = excluded.status,
+    created_height = excluded.created_height,
+    created_time = excluded.created_time,
+    published_time = excluded.published_time,
+    confirmed_height = excluded.confirmed_height,
+    last_error = excluded.last_error
+`
+
+type InsertBoardingSweepParams struct {
+	Txid               []byte
+	RawTx              []byte
+	DestinationAddress string
+	TotalAmount        int64
+	FeeAmount          int64
+	FeeRateSatPerVbyte int64
+	Vbytes             int64
+	Status             string
+	CreatedHeight      int32
+	CreatedTime        int64
+	PublishedTime      sql.NullInt64
+	ConfirmedHeight    sql.NullInt32
+	LastError          sql.NullString
+}
+
+// Boarding sweep queries.
+func (q *Queries) InsertBoardingSweep(ctx context.Context, arg InsertBoardingSweepParams) error {
+	_, err := q.db.ExecContext(ctx, InsertBoardingSweep,
+		arg.Txid,
+		arg.RawTx,
+		arg.DestinationAddress,
+		arg.TotalAmount,
+		arg.FeeAmount,
+		arg.FeeRateSatPerVbyte,
+		arg.Vbytes,
+		arg.Status,
+		arg.CreatedHeight,
+		arg.CreatedTime,
+		arg.PublishedTime,
+		arg.ConfirmedHeight,
+		arg.LastError,
+	)
+	return err
+}
+
+const InsertBoardingSweepInput = `-- name: InsertBoardingSweepInput :exec
+INSERT INTO boarding_sweep_inputs (
+    txid,
+    outpoint_hash,
+    outpoint_index,
+    amount,
+    previous_status,
+    status,
+    spent_by_txid,
+    spent_height,
+    last_update_time
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+ON CONFLICT (txid, outpoint_hash, outpoint_index) DO UPDATE SET
+    amount = excluded.amount,
+    previous_status = excluded.previous_status,
+    status = excluded.status,
+    spent_by_txid = excluded.spent_by_txid,
+    spent_height = excluded.spent_height,
+    last_update_time = excluded.last_update_time
+`
+
+type InsertBoardingSweepInputParams struct {
+	Txid           []byte
+	OutpointHash   []byte
+	OutpointIndex  int32
+	Amount         int64
+	PreviousStatus string
+	Status         string
+	SpentByTxid    []byte
+	SpentHeight    sql.NullInt32
+	LastUpdateTime int64
+}
+
+func (q *Queries) InsertBoardingSweepInput(ctx context.Context, arg InsertBoardingSweepInputParams) error {
+	_, err := q.db.ExecContext(ctx, InsertBoardingSweepInput,
+		arg.Txid,
+		arg.OutpointHash,
+		arg.OutpointIndex,
+		arg.Amount,
+		arg.PreviousStatus,
+		arg.Status,
+		arg.SpentByTxid,
+		arg.SpentHeight,
 		arg.LastUpdateTime,
 	)
 	return err
@@ -455,6 +646,338 @@ func (q *Queries) ListBoardingIntentsByStatusAndMinHeight(ctx context.Context, a
 		return nil, err
 	}
 	return items, nil
+}
+
+const ListBoardingIntentsBySweepableStatuses = `-- name: ListBoardingIntentsBySweepableStatuses :many
+SELECT outpoint_hash, outpoint_index, pk_script, amount, conf_height, conf_hash, conf_tx, status, creation_time, last_update_time, tx_proof FROM boarding_intents
+WHERE status IN ($1, $2, $3)
+ORDER BY creation_time DESC
+`
+
+type ListBoardingIntentsBySweepableStatusesParams struct {
+	Status   string
+	Status_2 string
+	Status_3 string
+}
+
+func (q *Queries) ListBoardingIntentsBySweepableStatuses(ctx context.Context, arg ListBoardingIntentsBySweepableStatusesParams) ([]BoardingIntent, error) {
+	rows, err := q.db.QueryContext(ctx, ListBoardingIntentsBySweepableStatuses, arg.Status, arg.Status_2, arg.Status_3)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []BoardingIntent
+	for rows.Next() {
+		var i BoardingIntent
+		if err := rows.Scan(
+			&i.OutpointHash,
+			&i.OutpointIndex,
+			&i.PkScript,
+			&i.Amount,
+			&i.ConfHeight,
+			&i.ConfHash,
+			&i.ConfTx,
+			&i.Status,
+			&i.CreationTime,
+			&i.LastUpdateTime,
+			&i.TxProof,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const ListBoardingSweepInputs = `-- name: ListBoardingSweepInputs :many
+SELECT txid, outpoint_hash, outpoint_index, amount, previous_status, status, spent_by_txid, spent_height, last_update_time FROM boarding_sweep_inputs
+WHERE txid = $1
+ORDER BY outpoint_hash ASC, outpoint_index ASC
+`
+
+func (q *Queries) ListBoardingSweepInputs(ctx context.Context, txid []byte) ([]BoardingSweepInput, error) {
+	rows, err := q.db.QueryContext(ctx, ListBoardingSweepInputs, txid)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []BoardingSweepInput
+	for rows.Next() {
+		var i BoardingSweepInput
+		if err := rows.Scan(
+			&i.Txid,
+			&i.OutpointHash,
+			&i.OutpointIndex,
+			&i.Amount,
+			&i.PreviousStatus,
+			&i.Status,
+			&i.SpentByTxid,
+			&i.SpentHeight,
+			&i.LastUpdateTime,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const ListBoardingSweeps = `-- name: ListBoardingSweeps :many
+SELECT txid, raw_tx, destination_address, total_amount, fee_amount, fee_rate_sat_per_vbyte, vbytes, status, created_height, created_time, published_time, confirmed_height, last_error FROM boarding_sweeps
+WHERE ($1 = '' OR status = $1)
+ORDER BY created_time DESC
+LIMIT $3
+OFFSET $2
+`
+
+type ListBoardingSweepsParams struct {
+	StatusFilter interface{}
+	PageOffset   int32
+	PageLimit    int32
+}
+
+func (q *Queries) ListBoardingSweeps(ctx context.Context, arg ListBoardingSweepsParams) ([]BoardingSweep, error) {
+	rows, err := q.db.QueryContext(ctx, ListBoardingSweeps, arg.StatusFilter, arg.PageOffset, arg.PageLimit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []BoardingSweep
+	for rows.Next() {
+		var i BoardingSweep
+		if err := rows.Scan(
+			&i.Txid,
+			&i.RawTx,
+			&i.DestinationAddress,
+			&i.TotalAmount,
+			&i.FeeAmount,
+			&i.FeeRateSatPerVbyte,
+			&i.Vbytes,
+			&i.Status,
+			&i.CreatedHeight,
+			&i.CreatedTime,
+			&i.PublishedTime,
+			&i.ConfirmedHeight,
+			&i.LastError,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const ListPendingBoardingSweepInputs = `-- name: ListPendingBoardingSweepInputs :many
+SELECT txid, outpoint_hash, outpoint_index, amount, previous_status, status, spent_by_txid, spent_height, last_update_time FROM boarding_sweep_inputs
+WHERE status IN ('pending', 'published')
+ORDER BY last_update_time ASC
+`
+
+func (q *Queries) ListPendingBoardingSweepInputs(ctx context.Context) ([]BoardingSweepInput, error) {
+	rows, err := q.db.QueryContext(ctx, ListPendingBoardingSweepInputs)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []BoardingSweepInput
+	for rows.Next() {
+		var i BoardingSweepInput
+		if err := rows.Scan(
+			&i.Txid,
+			&i.OutpointHash,
+			&i.OutpointIndex,
+			&i.Amount,
+			&i.PreviousStatus,
+			&i.Status,
+			&i.SpentByTxid,
+			&i.SpentHeight,
+			&i.LastUpdateTime,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const ListPendingBoardingSweeps = `-- name: ListPendingBoardingSweeps :many
+SELECT txid, raw_tx, destination_address, total_amount, fee_amount, fee_rate_sat_per_vbyte, vbytes, status, created_height, created_time, published_time, confirmed_height, last_error FROM boarding_sweeps
+WHERE status IN ('pending', 'published')
+ORDER BY created_time ASC
+`
+
+func (q *Queries) ListPendingBoardingSweeps(ctx context.Context) ([]BoardingSweep, error) {
+	rows, err := q.db.QueryContext(ctx, ListPendingBoardingSweeps)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []BoardingSweep
+	for rows.Next() {
+		var i BoardingSweep
+		if err := rows.Scan(
+			&i.Txid,
+			&i.RawTx,
+			&i.DestinationAddress,
+			&i.TotalAmount,
+			&i.FeeAmount,
+			&i.FeeRateSatPerVbyte,
+			&i.Vbytes,
+			&i.Status,
+			&i.CreatedHeight,
+			&i.CreatedTime,
+			&i.PublishedTime,
+			&i.ConfirmedHeight,
+			&i.LastError,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const MarkBoardingSweepInputSpentByOutpoint = `-- name: MarkBoardingSweepInputSpentByOutpoint :exec
+UPDATE boarding_sweep_inputs
+SET status = $3,
+    spent_by_txid = $4,
+    spent_height = $5,
+    last_update_time = $6
+WHERE outpoint_hash = $1
+  AND outpoint_index = $2
+  AND status IN ('pending', 'published')
+`
+
+type MarkBoardingSweepInputSpentByOutpointParams struct {
+	OutpointHash   []byte
+	OutpointIndex  int32
+	Status         string
+	SpentByTxid    []byte
+	SpentHeight    sql.NullInt32
+	LastUpdateTime int64
+}
+
+func (q *Queries) MarkBoardingSweepInputSpentByOutpoint(ctx context.Context, arg MarkBoardingSweepInputSpentByOutpointParams) error {
+	_, err := q.db.ExecContext(ctx, MarkBoardingSweepInputSpentByOutpoint,
+		arg.OutpointHash,
+		arg.OutpointIndex,
+		arg.Status,
+		arg.SpentByTxid,
+		arg.SpentHeight,
+		arg.LastUpdateTime,
+	)
+	return err
+}
+
+const MarkBoardingSweepInputStatus = `-- name: MarkBoardingSweepInputStatus :exec
+UPDATE boarding_sweep_inputs
+SET status = $4,
+    spent_by_txid = COALESCE($5, spent_by_txid),
+    spent_height = COALESCE($6, spent_height),
+    last_update_time = $7
+WHERE txid = $1
+  AND outpoint_hash = $2
+  AND outpoint_index = $3
+`
+
+type MarkBoardingSweepInputStatusParams struct {
+	Txid           []byte
+	OutpointHash   []byte
+	OutpointIndex  int32
+	Status         string
+	SpentByTxid    []byte
+	SpentHeight    sql.NullInt32
+	LastUpdateTime int64
+}
+
+func (q *Queries) MarkBoardingSweepInputStatus(ctx context.Context, arg MarkBoardingSweepInputStatusParams) error {
+	_, err := q.db.ExecContext(ctx, MarkBoardingSweepInputStatus,
+		arg.Txid,
+		arg.OutpointHash,
+		arg.OutpointIndex,
+		arg.Status,
+		arg.SpentByTxid,
+		arg.SpentHeight,
+		arg.LastUpdateTime,
+	)
+	return err
+}
+
+const MarkBoardingSweepInputsStatus = `-- name: MarkBoardingSweepInputsStatus :exec
+UPDATE boarding_sweep_inputs
+SET status = $2,
+    last_update_time = $3
+WHERE txid = $1
+  AND status IN ('pending', 'published')
+`
+
+type MarkBoardingSweepInputsStatusParams struct {
+	Txid           []byte
+	Status         string
+	LastUpdateTime int64
+}
+
+func (q *Queries) MarkBoardingSweepInputsStatus(ctx context.Context, arg MarkBoardingSweepInputsStatusParams) error {
+	_, err := q.db.ExecContext(ctx, MarkBoardingSweepInputsStatus, arg.Txid, arg.Status, arg.LastUpdateTime)
+	return err
+}
+
+const MarkBoardingSweepStatus = `-- name: MarkBoardingSweepStatus :exec
+UPDATE boarding_sweeps
+SET status = $2,
+    published_time = COALESCE($3, published_time),
+    confirmed_height = COALESCE($4, confirmed_height),
+    last_error = $5
+WHERE txid = $1
+`
+
+type MarkBoardingSweepStatusParams struct {
+	Txid            []byte
+	Status          string
+	PublishedTime   sql.NullInt64
+	ConfirmedHeight sql.NullInt32
+	LastError       sql.NullString
+}
+
+func (q *Queries) MarkBoardingSweepStatus(ctx context.Context, arg MarkBoardingSweepStatusParams) error {
+	_, err := q.db.ExecContext(ctx, MarkBoardingSweepStatus,
+		arg.Txid,
+		arg.Status,
+		arg.PublishedTime,
+		arg.ConfirmedHeight,
+		arg.LastError,
+	)
+	return err
 }
 
 const SumBoardingIntentAmountsByStatus = `-- name: SumBoardingIntentAmountsByStatus :one

--- a/db/sqlc/migrations/000011_boarding_sweeps.down.sql
+++ b/db/sqlc/migrations/000011_boarding_sweeps.down.sql
@@ -1,0 +1,13 @@
+UPDATE boarding_intents
+SET status = 'expired'
+WHERE status = 'sweep_pending';
+
+DROP INDEX IF EXISTS idx_boarding_sweep_inputs_active_outpoint;
+DROP INDEX IF EXISTS idx_boarding_sweep_inputs_outpoint;
+DROP INDEX IF EXISTS idx_boarding_sweep_inputs_status;
+DROP TABLE IF EXISTS boarding_sweep_inputs;
+
+DROP INDEX IF EXISTS idx_boarding_sweeps_status;
+DROP TABLE IF EXISTS boarding_sweeps;
+
+DELETE FROM boarding_statuses WHERE status_name = 'sweep_pending';

--- a/db/sqlc/migrations/000011_boarding_sweeps.up.sql
+++ b/db/sqlc/migrations/000011_boarding_sweeps.up.sql
@@ -1,0 +1,72 @@
+-- Boarding sweep tracking.
+--
+-- A broadcast boarding sweep is not complete until the chain backend reports
+-- the swept boarding outpoints as spent. These tables persist the published
+-- sweep transaction and each input so the daemon can resume spend watches and
+-- rebroadcast the exact same transaction after restart.
+
+INSERT INTO boarding_statuses (id, status_name) VALUES
+    (5, 'sweep_pending');
+
+CREATE TABLE IF NOT EXISTS boarding_sweeps (
+    txid BLOB PRIMARY KEY NOT NULL,
+    raw_tx BLOB NOT NULL,
+    destination_address TEXT NOT NULL,
+    total_amount BIGINT NOT NULL,
+    fee_amount BIGINT NOT NULL,
+    fee_rate_sat_per_vbyte BIGINT NOT NULL,
+    vbytes BIGINT NOT NULL,
+    status TEXT NOT NULL CHECK (
+        status IN (
+            'pending',
+            'published',
+            'confirmed',
+            'external_resolved',
+            'failed'
+        )
+    ),
+    created_height INTEGER NOT NULL,
+    created_time BIGINT NOT NULL,
+    published_time BIGINT,
+    confirmed_height INTEGER,
+    last_error TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_boarding_sweeps_status
+    ON boarding_sweeps(status);
+
+CREATE TABLE IF NOT EXISTS boarding_sweep_inputs (
+    txid BLOB NOT NULL,
+    outpoint_hash BLOB NOT NULL,
+    outpoint_index INTEGER NOT NULL,
+    amount BIGINT NOT NULL,
+    previous_status TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (
+        status IN (
+            'pending',
+            'published',
+            'spent',
+            'external_spent',
+            'failed'
+        )
+    ),
+    spent_by_txid BLOB,
+    spent_height INTEGER,
+    last_update_time BIGINT NOT NULL,
+
+    PRIMARY KEY (txid, outpoint_hash, outpoint_index),
+    FOREIGN KEY (txid) REFERENCES boarding_sweeps(txid),
+    FOREIGN KEY (previous_status) REFERENCES boarding_statuses(status_name),
+    FOREIGN KEY (outpoint_hash, outpoint_index)
+        REFERENCES boarding_intents(outpoint_hash, outpoint_index)
+);
+
+CREATE INDEX IF NOT EXISTS idx_boarding_sweep_inputs_status
+    ON boarding_sweep_inputs(status);
+
+CREATE INDEX IF NOT EXISTS idx_boarding_sweep_inputs_outpoint
+    ON boarding_sweep_inputs(outpoint_hash, outpoint_index);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_boarding_sweep_inputs_active_outpoint
+    ON boarding_sweep_inputs(outpoint_hash, outpoint_index)
+    WHERE status IN ('pending', 'published');

--- a/db/sqlc/models.go
+++ b/db/sqlc/models.go
@@ -49,6 +49,34 @@ type BoardingStatus struct {
 	StatusName string
 }
 
+type BoardingSweep struct {
+	Txid               []byte
+	RawTx              []byte
+	DestinationAddress string
+	TotalAmount        int64
+	FeeAmount          int64
+	FeeRateSatPerVbyte int64
+	Vbytes             int64
+	Status             string
+	CreatedHeight      int32
+	CreatedTime        int64
+	PublishedTime      sql.NullInt64
+	ConfirmedHeight    sql.NullInt32
+	LastError          sql.NullString
+}
+
+type BoardingSweepInput struct {
+	Txid           []byte
+	OutpointHash   []byte
+	OutpointIndex  int32
+	Amount         int64
+	PreviousStatus string
+	Status         string
+	SpentByTxid    []byte
+	SpentHeight    sql.NullInt32
+	LastUpdateTime int64
+}
+
 type ChainInfo struct {
 	ID          int64
 	ChainName   string

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -11,6 +11,7 @@ import (
 type Querier interface {
 	CountBoardingIntentsByStatus(ctx context.Context, status string) (int64, error)
 	CountClientLedgerEntries(ctx context.Context) (int64, error)
+	CountUnresolvedBoardingSweepInputs(ctx context.Context, txid []byte) (int64, error)
 	CountUnspentVTXOs(ctx context.Context) (int64, error)
 	// CountVTXOsByStatus returns the count of VTXOs with the specified status.
 	CountVTXOsByStatus(ctx context.Context, status int32) (int64, error)
@@ -27,6 +28,8 @@ type Querier interface {
 	FinalizeRound(ctx context.Context, arg FinalizeRoundParams) error
 	GetBoardingAddress(ctx context.Context, pkScript []byte) (BoardingAddress, error)
 	GetBoardingIntent(ctx context.Context, arg GetBoardingIntentParams) (BoardingIntent, error)
+	GetBoardingSweep(ctx context.Context, txid []byte) (BoardingSweep, error)
+	GetBoardingSweepByInput(ctx context.Context, arg GetBoardingSweepByInputParams) (BoardingSweep, error)
 	GetChainInfo(ctx context.Context, chainName string) (ChainInfo, error)
 	GetClientAccountBalance(ctx context.Context, accountID string) (int64, error)
 	GetClientTreeByTxid(ctx context.Context, txid []byte) (RoundClientTree, error)
@@ -60,6 +63,9 @@ type Querier interface {
 	InsertBoardingAddress(ctx context.Context, arg InsertBoardingAddressParams) error
 	// Boarding intent queries.
 	InsertBoardingIntent(ctx context.Context, arg InsertBoardingIntentParams) error
+	// Boarding sweep queries.
+	InsertBoardingSweep(ctx context.Context, arg InsertBoardingSweepParams) error
+	InsertBoardingSweepInput(ctx context.Context, arg InsertBoardingSweepInputParams) error
 	// Column order matches the ledger_entries CREATE TABLE layout
 	// in migration 000006 so the generated row type for SELECTs
 	// stays structurally identical to the LedgerEntry model, which
@@ -111,6 +117,9 @@ type Querier interface {
 	ListBoardingIntentsByPkScript(ctx context.Context, pkScript []byte) ([]BoardingIntent, error)
 	ListBoardingIntentsByStatus(ctx context.Context, status string) ([]BoardingIntent, error)
 	ListBoardingIntentsByStatusAndMinHeight(ctx context.Context, arg ListBoardingIntentsByStatusAndMinHeightParams) ([]BoardingIntent, error)
+	ListBoardingIntentsBySweepableStatuses(ctx context.Context, arg ListBoardingIntentsBySweepableStatusesParams) ([]BoardingIntent, error)
+	ListBoardingSweepInputs(ctx context.Context, txid []byte) ([]BoardingSweepInput, error)
+	ListBoardingSweeps(ctx context.Context, arg ListBoardingSweepsParams) ([]BoardingSweep, error)
 	ListChainInfo(ctx context.Context) ([]ChainInfo, error)
 	ListClientAccounts(ctx context.Context) ([]Account, error)
 	ListClientLedgerEntries(ctx context.Context, arg ListClientLedgerEntriesParams) ([]LedgerEntry, error)
@@ -138,6 +147,8 @@ type Querier interface {
 	ListOORRecipientCursors(ctx context.Context) ([]OorRecipientCursor, error)
 	ListOORVTXOBindingsBySession(ctx context.Context, sessionID []byte) ([]ListOORVTXOBindingsBySessionRow, error)
 	ListOwnedReceiveScripts(ctx context.Context) ([]OwnedReceiveScript, error)
+	ListPendingBoardingSweepInputs(ctx context.Context) ([]BoardingSweepInput, error)
+	ListPendingBoardingSweeps(ctx context.Context) ([]BoardingSweep, error)
 	ListRoundsByStatus(ctx context.Context, status string) ([]Round, error)
 	// ListRoundsPaginated returns rounds ordered by round_id with cursor-
 	// based pagination. When cursor is empty, returns from the beginning.
@@ -164,6 +175,10 @@ type Querier interface {
 	ListWalletUTXOLog(ctx context.Context, arg ListWalletUTXOLogParams) ([]WalletUtxoLog, error)
 	ListWalletUTXOLogByBlock(ctx context.Context, blockHeight int32) ([]WalletUtxoLog, error)
 	ListWalletUTXOLogByClassification(ctx context.Context, arg ListWalletUTXOLogByClassificationParams) ([]WalletUtxoLog, error)
+	MarkBoardingSweepInputSpentByOutpoint(ctx context.Context, arg MarkBoardingSweepInputSpentByOutpointParams) error
+	MarkBoardingSweepInputStatus(ctx context.Context, arg MarkBoardingSweepInputStatusParams) error
+	MarkBoardingSweepInputsStatus(ctx context.Context, arg MarkBoardingSweepInputsStatusParams) error
+	MarkBoardingSweepStatus(ctx context.Context, arg MarkBoardingSweepStatusParams) error
 	MarkUnilateralExitJobTerminal(ctx context.Context, arg MarkUnilateralExitJobTerminalParams) error
 	// MarkVTXOForfeited marks a VTXO as forfeited and records the forfeit
 	// transaction ID and replacement VTXO outpoint. Called when the new round's

--- a/db/sqlc/queries/boarding.sql
+++ b/db/sqlc/queries/boarding.sql
@@ -63,6 +63,11 @@ SELECT * FROM boarding_intents
 WHERE status = $1
 ORDER BY creation_time DESC;
 
+-- name: ListBoardingIntentsBySweepableStatuses :many
+SELECT * FROM boarding_intents
+WHERE status IN ($1, $2, $3)
+ORDER BY creation_time DESC;
+
 -- name: ListAllBoardingIntents :many
 SELECT * FROM boarding_intents
 ORDER BY creation_time DESC;
@@ -81,6 +86,132 @@ ORDER BY conf_height DESC;
 UPDATE boarding_intents
 SET status = $3, last_update_time = $4
 WHERE outpoint_hash = $1 AND outpoint_index = $2;
+
+-- Boarding sweep queries.
+
+-- name: InsertBoardingSweep :exec
+INSERT INTO boarding_sweeps (
+    txid,
+    raw_tx,
+    destination_address,
+    total_amount,
+    fee_amount,
+    fee_rate_sat_per_vbyte,
+    vbytes,
+    status,
+    created_height,
+    created_time,
+    published_time,
+    confirmed_height,
+    last_error
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+ON CONFLICT (txid) DO UPDATE SET
+    raw_tx = excluded.raw_tx,
+    destination_address = excluded.destination_address,
+    total_amount = excluded.total_amount,
+    fee_amount = excluded.fee_amount,
+    fee_rate_sat_per_vbyte = excluded.fee_rate_sat_per_vbyte,
+    vbytes = excluded.vbytes,
+    status = excluded.status,
+    created_height = excluded.created_height,
+    created_time = excluded.created_time,
+    published_time = excluded.published_time,
+    confirmed_height = excluded.confirmed_height,
+    last_error = excluded.last_error;
+
+-- name: InsertBoardingSweepInput :exec
+INSERT INTO boarding_sweep_inputs (
+    txid,
+    outpoint_hash,
+    outpoint_index,
+    amount,
+    previous_status,
+    status,
+    spent_by_txid,
+    spent_height,
+    last_update_time
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+ON CONFLICT (txid, outpoint_hash, outpoint_index) DO UPDATE SET
+    amount = excluded.amount,
+    previous_status = excluded.previous_status,
+    status = excluded.status,
+    spent_by_txid = excluded.spent_by_txid,
+    spent_height = excluded.spent_height,
+    last_update_time = excluded.last_update_time;
+
+-- name: GetBoardingSweep :one
+SELECT * FROM boarding_sweeps
+WHERE txid = $1;
+
+-- name: GetBoardingSweepByInput :one
+SELECT bs.*
+FROM boarding_sweeps bs
+JOIN boarding_sweep_inputs bsi ON bsi.txid = bs.txid
+WHERE bsi.outpoint_hash = $1
+  AND bsi.outpoint_index = $2
+  AND bsi.status IN ('pending', 'published');
+
+-- name: ListPendingBoardingSweeps :many
+SELECT * FROM boarding_sweeps
+WHERE status IN ('pending', 'published')
+ORDER BY created_time ASC;
+
+-- name: ListBoardingSweeps :many
+SELECT * FROM boarding_sweeps
+WHERE (sqlc.arg(status_filter) = '' OR status = sqlc.arg(status_filter))
+ORDER BY created_time DESC
+LIMIT sqlc.arg(page_limit)
+OFFSET sqlc.arg(page_offset);
+
+-- name: ListBoardingSweepInputs :many
+SELECT * FROM boarding_sweep_inputs
+WHERE txid = $1
+ORDER BY outpoint_hash ASC, outpoint_index ASC;
+
+-- name: ListPendingBoardingSweepInputs :many
+SELECT * FROM boarding_sweep_inputs
+WHERE status IN ('pending', 'published')
+ORDER BY last_update_time ASC;
+
+-- name: MarkBoardingSweepStatus :exec
+UPDATE boarding_sweeps
+SET status = $2,
+    published_time = COALESCE($3, published_time),
+    confirmed_height = COALESCE($4, confirmed_height),
+    last_error = $5
+WHERE txid = $1;
+
+-- name: MarkBoardingSweepInputStatus :exec
+UPDATE boarding_sweep_inputs
+SET status = $4,
+    spent_by_txid = COALESCE($5, spent_by_txid),
+    spent_height = COALESCE($6, spent_height),
+    last_update_time = $7
+WHERE txid = $1
+  AND outpoint_hash = $2
+  AND outpoint_index = $3;
+
+-- name: MarkBoardingSweepInputsStatus :exec
+UPDATE boarding_sweep_inputs
+SET status = $2,
+    last_update_time = $3
+WHERE txid = $1
+  AND status IN ('pending', 'published');
+
+-- name: MarkBoardingSweepInputSpentByOutpoint :exec
+UPDATE boarding_sweep_inputs
+SET status = $3,
+    spent_by_txid = $4,
+    spent_height = $5,
+    last_update_time = $6
+WHERE outpoint_hash = $1
+  AND outpoint_index = $2
+  AND status IN ('pending', 'published');
+
+-- name: CountUnresolvedBoardingSweepInputs :one
+SELECT COUNT(*) FROM boarding_sweep_inputs
+WHERE txid = $1
+  AND status IN ('pending', 'published');
 
 -- name: CountBoardingIntentsByStatus :one
 SELECT COUNT(*) FROM boarding_intents

--- a/db/sqlc/schemas/generated_schema.sql
+++ b/db/sqlc/schemas/generated_schema.sql
@@ -106,6 +106,56 @@ CREATE TABLE boarding_statuses (
     status_name TEXT UNIQUE NOT NULL
 );
 
+CREATE TABLE boarding_sweep_inputs (
+    txid BLOB NOT NULL,
+    outpoint_hash BLOB NOT NULL,
+    outpoint_index INTEGER NOT NULL,
+    amount BIGINT NOT NULL,
+    previous_status TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (
+        status IN (
+            'pending',
+            'published',
+            'spent',
+            'external_spent',
+            'failed'
+        )
+    ),
+    spent_by_txid BLOB,
+    spent_height INTEGER,
+    last_update_time BIGINT NOT NULL,
+
+    PRIMARY KEY (txid, outpoint_hash, outpoint_index),
+    FOREIGN KEY (txid) REFERENCES boarding_sweeps(txid),
+    FOREIGN KEY (previous_status) REFERENCES boarding_statuses(status_name),
+    FOREIGN KEY (outpoint_hash, outpoint_index)
+        REFERENCES boarding_intents(outpoint_hash, outpoint_index)
+);
+
+CREATE TABLE boarding_sweeps (
+    txid BLOB PRIMARY KEY NOT NULL,
+    raw_tx BLOB NOT NULL,
+    destination_address TEXT NOT NULL,
+    total_amount BIGINT NOT NULL,
+    fee_amount BIGINT NOT NULL,
+    fee_rate_sat_per_vbyte BIGINT NOT NULL,
+    vbytes BIGINT NOT NULL,
+    status TEXT NOT NULL CHECK (
+        status IN (
+            'pending',
+            'published',
+            'confirmed',
+            'external_resolved',
+            'failed'
+        )
+    ),
+    created_height INTEGER NOT NULL,
+    created_time BIGINT NOT NULL,
+    published_time BIGINT,
+    confirmed_height INTEGER,
+    last_error TEXT
+);
+
 CREATE TABLE chain_info (
     id BIGINT PRIMARY KEY,
     chain_name TEXT NOT NULL UNIQUE,
@@ -199,6 +249,19 @@ CREATE INDEX idx_boarding_intents_pk_script
 
 CREATE INDEX idx_boarding_intents_status
     ON boarding_intents(status);
+
+CREATE UNIQUE INDEX idx_boarding_sweep_inputs_active_outpoint
+    ON boarding_sweep_inputs(outpoint_hash, outpoint_index)
+    WHERE status IN ('pending', 'published');
+
+CREATE INDEX idx_boarding_sweep_inputs_outpoint
+    ON boarding_sweep_inputs(outpoint_hash, outpoint_index);
+
+CREATE INDEX idx_boarding_sweep_inputs_status
+    ON boarding_sweep_inputs(status);
+
+CREATE INDEX idx_boarding_sweeps_status
+    ON boarding_sweeps(status);
 
 CREATE INDEX idx_client_ledger_created
     ON ledger_entries(created_at DESC);

--- a/db/sqlutils.go
+++ b/db/sqlutils.go
@@ -24,8 +24,6 @@ var (
 // uses when an integer field can be permitted to be NULL.  We use the
 // constraints.Integer constraint here which maps to all signed and unsigned
 // integer types.
-//
-//nolint:unused
 func sqlInt64[T constraints.Integer](num T) sql.NullInt64 {
 	return sql.NullInt64{
 		Int64: int64(num),
@@ -37,8 +35,6 @@ func sqlInt64[T constraints.Integer](num T) sql.NullInt64 {
 // uses when an integer field can be permitted to be NULL.  We use the
 // constraints.Integer constraint here which maps to all signed and unsigned
 // integer types.
-//
-//nolint:unused
 func sqlInt32[T constraints.Integer](num T) sql.NullInt32 {
 	return sql.NullInt32{
 		Int32: int32(num),
@@ -72,8 +68,6 @@ func sqlBool(b bool) sql.NullBool {
 
 // sqlStr turns a string into the NullString that sql/sqlc uses when a string
 // can be permitted to be NULL.
-//
-//nolint:unused
 func sqlStr(s string) sql.NullString {
 	if s == "" {
 		return sql.NullString{}

--- a/wallet/interfaces.go
+++ b/wallet/interfaces.go
@@ -288,6 +288,11 @@ const (
 	// BoardingStatusSwept indicates that the boarding UTXO has been spent
 	// via the CSV timeout path to recover funds.
 	BoardingStatusSwept BoardingStatus = 4
+
+	// BoardingStatusSweepPending indicates that the boarding UTXO has been
+	// included in a published timeout-path sweep transaction and is waiting
+	// for the chain backend to report the outpoint as spent.
+	BoardingStatusSweepPending BoardingStatus = 5
 )
 
 // BoardingAddress represents a derived boarding address with all the


### PR DESCRIPTION
## Summary

Fixes #152.

This adds daemon-side recovery for expired boarding UTXOs and exposes it through `darepocli sweep`. The command is preview-first: running `darepocli sweep` reports the mature outputs that would be swept now, the aggregate amount, fee estimate, net amount, fee rate, confirmation target, vsize, and the signed preview txid without broadcasting or mutating wallet state.

Broadcasting is explicit. Passing `--broadcast` publishes one aggregate sweep transaction that spends all mature candidate boarding outputs into a single destination output. Broadcast does not mark the outputs recovered immediately; the daemon persists the signed sweep, tracks each input, and only marks boarding intents `swept` after the chain backend reports confirmed spends.

The sweep destination defaults to a fresh wallet address on broadcast. Callers can override it with `--sweep-address`, which is useful when recovering to a specific wallet or external address. Preview mode without `--sweep-address` uses a size-equivalent placeholder destination, so it does not allocate a fresh wallet address just to estimate fees.

The PR also adds `darepocli sweep list`, so operators can inspect persisted sweep state without opening the client DB by hand.

## Details

- Adds `SweepBoardingUTXOs` to the daemon RPC surface.
- Adds `ListBoardingSweeps` to expose persisted aggregate sweep state.
- Adds `darepocli sweep` and `darepocli sweep list`.
- Adds schema-registry entries for `sweep` and `sweep.list`.
- Scans persisted boarding intents in statuses that may still represent raw boarding outputs: `confirmed`, `failed`, and `expired`.
- Supports explicit `--outpoint <txid>:<vout>` filters, or scans all sweepable persisted intents when no outpoints are specified.
- Filters sweep responses down to mature outputs that would actually be included in the aggregate sweep.
- Returns `status=preview` even when the mature sweepable set is empty, so an empty scan is an empty preview rather than a separate result state.
- Builds one signed timeout-path sweep transaction with all mature inputs and one output, avoiding the old one-transaction-per-output fee shape.
- Caps one aggregate sweep at 100 inputs so the daemon cannot accidentally build an enormous or non-standard transaction.
- Reports aggregate fee information: `estimated_fee_sat` for previews, `fee_paid_sat` for broadcasts, and `tx_vbytes` for both.
- Supports `--fee-rate-sat-per-vbyte` to explicitly price the aggregate sweep.
- Uses high fee estimates instead of silently clamping them at 100 sat/vB; the daemon logs a warning above that threshold and then applies the aggregate value guard below.
- Refuses to build sweeps whose fee would exceed 25% of the selected boarding value.
- Supports `--conf-target` to control fee estimation when no explicit fee rate is provided.
- Supports `--sweep-address`; empty means the daemon asks the wallet for a fresh destination script only when broadcasting.
- Treats duplicate-broadcast style errors as success so retries can continue confirmation tracking.
- Adds durable `boarding_sweeps` and `boarding_sweep_inputs` tables for restart recovery and CLI inspection.
- Adds a `sweep_pending` boarding intent status so published-but-unconfirmed sweep inputs are not selected again.
- Adds a daemon watcher that starts after wallet unlock, reloads pending sweeps on startup, registers confirmed-spend watches for each input, and rebroadcasts the exact persisted raw transaction best-effort.

## Lifecycle

Preview mode builds the real aggregate sweep transaction when there are mature outputs and returns its `txid`, fee, vsize, and selected outputs. If there are no mature outputs, it still returns `status=preview` with an empty `sweepable_outputs` list and zero totals. Preview mode does not persist anything or change boarding intent state.

Broadcast mode persists the signed transaction before publication, moves each selected intent to `sweep_pending`, broadcasts the transaction, and returns `status=published` once the transaction is accepted or already known. The watcher then owns recovery completion.

Post-broadcast bookkeeping failures are logged by the daemon rather than exposed as a separate user-facing status. Once the transaction has been published, the important user-visible fact is that it may confirm and the watcher/restart path can reconcile it from persisted state.

On daemon restart, the watcher reloads pending and published sweeps from the database, registers spend watches for unresolved inputs, and rebroadcasts the exact stored raw transaction. Sweeps still marked `pending` are rebroadcast immediately because they may represent a crash before publish bookkeeping completed. Already `published` sweeps are rebroadcast at most once every ten minutes to avoid needless mempool churn.

When the chain backend reports that all inputs in the aggregate sweep were confirmed spent by our stored sweep transaction, the store marks the aggregate sweep `confirmed` and moves the boarding intents to `swept`. If every tracked input was spent by another transaction, the aggregate sweep resolves as `external_resolved` instead, so the CLI does not imply that our sweep recovered the funds.

If broadcast fails before the tx is accepted, the store marks the sweep failed and restores each boarding intent to its previous status so a later sweep can retry.

## Limitations / Non-goals

- No RBF, CPFP, fee bumping, rebuild, or input reselection.
- No chunking yet; one sweep is capped at 100 inputs and callers can rerun the command or pass explicit outpoints for additional batches.
- There is no absolute fee-rate cap. High daemon fee estimates and explicit caller fee rates are allowed, but the aggregate sweep is refused if fees would consume more than 25% of the selected input value.
- `sweep list` is paginated with default page size 100 and maximum page size 500.
- The watcher starts only after the wallet is ready/unlocked because it needs wallet and chain backend access.
- There is no feature flag; the command is preview-first and broadcasting remains opt-in through `--broadcast`.
- Application-level build, persist, and broadcast failures are returned as `status=failed` plus `failure_reason` in an OK RPC response. Invalid arguments and unavailable daemon dependencies still return normal gRPC errors.
- The down migration moves any `sweep_pending` intents back to `expired` before dropping the sweep tables/status row.

## CLI examples

Preview all mature candidates using the default fee-estimation target:

```bash
darepocli sweep
```

Preview specific boarding outpoints:

```bash
darepocli sweep \
  --outpoint <txid>:<vout> \
  --outpoint <txid>:<vout>
```

Preview with an explicit fee rate:

```bash
darepocli sweep --fee-rate-sat-per-vbyte 3
```

Preview with a custom fee-estimation target:

```bash
darepocli sweep --conf-target 12
```

Preview to an explicit destination address:

```bash
darepocli sweep --sweep-address <address>
```

Broadcast the aggregate sweep and track it until confirmed spent:

```bash
darepocli sweep --broadcast
```

Broadcast to an explicit destination address:

```bash
darepocli sweep \
  --broadcast \
  --fee-rate-sat-per-vbyte 2 \
  --sweep-address <address>
```

List all persisted sweeps:

```bash
darepocli sweep list
```

List only currently published sweeps:

```bash
darepocli sweep list --status published
```

List confirmed sweep history:

```bash
darepocli sweep list --status confirmed
```

Page through sweep history:

```bash
darepocli sweep list --page-size 50
darepocli sweep list --page-size 50 --page-token <next_page_token>
```

## Result model

Top-level `sweep` status values are:

- `preview`: the request did not publish a transaction. When mature outputs exist, the response includes the signed aggregate preview txid, fee, vsize, and selected outputs. When no mature outputs exist, the response is an empty preview with zero totals.
- `published`: aggregate sweep transaction was accepted for broadcast and is tracked until confirmed spent.
- `failed`: the aggregate sweep could not be built, persisted, or broadcast. The `failure_reason` field explains the failure.

`darepocli sweep` response fields are centered on the action the command performs:

- `sweepable_outputs`: mature boarding outputs included in the aggregate sweep.
- `total_amount_sat`: total value of mature sweep candidates.
- `estimated_fee_sat`: aggregate fee estimate for the built transaction.
- `net_amount_sat`: `total_amount_sat - estimated_fee_sat`.
- `fee_rate_sat_per_vbyte`: fee rate used to build the aggregate transaction. Fee rates above 100 sat/vB are allowed and warned in daemon logs; excessive absolute fees fail the sweep before broadcast.
- `conf_target`: confirmation target used when estimating fees.
- `txid`: aggregate sweep transaction id. Preview responses include the txid of the signed transaction built for that request; a later broadcast can differ if inputs, fees, or destination change. Empty previews have no txid.
- `fee_paid_sat`: set after broadcast and equal to the aggregate transaction fee paid.
- `tx_vbytes`: signed aggregate transaction virtual size.
- `failure_reason`: aggregate build, broadcast, or persistence failure reason for failed responses.

`darepocli sweep list` returns durable sweep records:

- `txid`: aggregate sweep transaction id.
- `status`: `pending`, `published`, `confirmed`, `external_resolved`, or `failed`.
- `destination_address`: sweep output destination when caller-specified.
- `total_amount_sat`, `fee_paid_sat`, `fee_rate_sat_per_vbyte`, and `tx_vbytes`: aggregate transaction accounting.
- `created_height` and `confirmed_height`: publication and confirmation heights known to the daemon.
- `inputs`: each boarding outpoint included in the aggregate sweep, with its amount, input status, spending txid, and spent height.
- `failure_reason`: stored failure reason for failed sweeps.
- `next_page_token`: page token for the next page, when present.

The sweep command does not try to be a full boarding-output inventory command. Non-mature or otherwise non-sweepable boarding intents are excluded from `sweepable_outputs`; if we want full boarding intent listing later, that should be a separate list command/RPC.

## Manual smoke

I tested this through parent `arktest` with a fresh LND-backed client daemon in a disposable arktest run. The parent arktest worktree was rebuilt against this PR head before running the smoke.

Multi-output aggregate sweep:

- Started arktest with one client: `./arktest --datadir /tmp/arktest-sweep-pr350-state start --client alice --group-name arktest-sweep-pr350 --artifacts-dir /tmp/arktest-sweep-pr350-artifacts`.
- Boarded two outputs, 120000 sats and 130000 sats.
- `darepocli sweep list` returned an empty `sweeps` array before any sweep was published.
- Before CSV maturity, `darepocli sweep` returned `status=preview` with an empty `sweepable_outputs` list and zero totals.
- After mining past the boarding CSV delay, `darepocli sweep --fee-rate-sat-per-vbyte 2` selected both mature outputs in one preview transaction.
- Preview accounting was `total_amount_sat=250000`, `estimated_fee_sat=444`, `net_amount_sat=249556`, `fee_rate_sat_per_vbyte=2`, `tx_vbytes=222`.
- `darepocli sweep --broadcast --fee-rate-sat-per-vbyte 2` published aggregate txid `bc6e2e75b6668e70e384402698904034b7b60045431e19fe23ac198016e6d5da`.
- `darepocli sweep list --status published` showed one sweep record with both inputs in `published`.
- After mining one block and waiting for the watcher, `darepocli sweep list --status confirmed` showed the sweep as `confirmed`, `confirmed_height=651`, and both inputs as `spent` by the aggregate sweep txid.

## Validation

- `make commitmsg-lint range=origin/main..HEAD`
- `go test ./db ./darepod ./cmd/darepocli/darepoclicommands ./daemonrpc`
- `go test -tags="dev nolog" ./db ./darepod ./cmd/darepocli/darepoclicommands ./daemonrpc`
- `make build`
- `GOGC=50 make lint`
- parent arktest smoke described above

