### PR TITLE
unrollplan: test deep OOR ordering

### DIFF
--- a/unrollplan/doc.go
+++ b/unrollplan/doc.go
@@ -19,6 +19,27 @@
 // (restore State from disk, call Plan, continue) and makes the planner
 // amenable to property-based testing.
 //
+// # Deep OOR ordering
+//
+// Deep out-of-round recovery chains are encoded as ordinary proof
+// dependencies. A VTXO received through multiple OOR hops has an alternating
+// path through the graph:
+//
+//	tree_root -> checkpoint_1 -> ark_1 -> checkpoint_2 -> ark_2 -> ...
+//
+// Each Ark transaction spends its checkpoint output, and each later
+// checkpoint spends the previous Ark output. The planner therefore does not
+// special-case `recovery.NodeKindCheckpoint` or `recovery.NodeKindArk`; it
+// follows the transaction-input dependency graph. A checkpoint must confirm
+// before its Ark child becomes ready, and that Ark transaction must confirm
+// before the next checkpoint becomes ready.
+//
+// This is an important recovery invariant: broadcasting all checkpoints up
+// front would fail mempool acceptance for a deep OOR chain because later
+// checkpoints depend on earlier Ark transactions. Node kinds are retained for
+// callers, logs, and policy decisions, but readiness is determined only by
+// confirmed parents in the immutable proof graph.
+//
 // # No I/O
 //
 // Like `lib/recovery`, this package is deliberately synchronous and

--- a/unrollplan/planner_oor_test.go
+++ b/unrollplan/planner_oor_test.go
@@ -1,0 +1,252 @@
+package unrollplan
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/recovery"
+	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+const (
+	oorPlanStartHeight int32  = 100
+	oorCSVDelay        uint32 = 5
+)
+
+// TestPlanDeepOORChainAlternatesCheckpointAndArk verifies the concrete
+// depth-2 OOR recovery sequence. After the round-tree root confirms, each
+// checkpoint is ready only before its corresponding Ark child, and the next
+// checkpoint waits for that Ark transaction to confirm.
+func TestPlanDeepOORChainAlternatesCheckpointAndArk(t *testing.T) {
+	fixture := oorChainProofFixture(t, 2)
+	planner, proof := newPlannerFixture(t, fixture.proof)
+	state := &State{}
+
+	for index, txid := range fixture.broadcastOrder {
+		planHeight := oorPlanStartHeight + int32(index)
+		snapshot, err := planner.Plan(planHeight, state)
+		require.NoError(t, err)
+		require.Len(t, snapshot.Ready, 1)
+		require.Equal(t, txid, snapshot.Ready[0].Txid)
+		require.Equal(t, fixture.kindByTxid[txid],
+			snapshot.Ready[0].Node.Kind)
+
+		assertOORChildBlockedWhileParentInFlight(
+			t, planner, fixture, state, index, planHeight,
+		)
+
+		state.ConfirmedTxids = append(state.ConfirmedTxids, txid)
+		if txid == proof.TargetOutpoint().Hash {
+			state.TargetConfirmHeight = fn.Some(planHeight)
+		}
+	}
+
+	maturityHeight := state.TargetConfirmHeight.UnwrapOrFail(t) +
+		int32(oorCSVDelay)
+	snapshot, err := planner.Plan(maturityHeight, state)
+	require.NoError(t, err)
+	require.True(t, snapshot.AllProofConfirmed)
+	require.True(t, snapshot.TargetConfirmed)
+	require.True(t, snapshot.NeedSweep)
+}
+
+// TestPlanOORChainOrderingRapid checks the same ordering invariant over
+// random OOR depths. Every unconfirmed child remains blocked while its parent
+// is merely in flight, then becomes ready only after the parent is confirmed.
+func TestPlanOORChainOrderingRapid(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		depth := rapid.IntRange(1, 5).Draw(t, "depth")
+		fixture := oorChainProofFixture(t, depth)
+		planner, err := NewPlanner(fixture.proof)
+		require.NoError(t, err)
+		proof := fixture.proof
+		resumeIndex := rapid.IntRange(
+			0, len(fixture.broadcastOrder)-1,
+		).Draw(t, "resumeIndex")
+		confirmed := append(
+			[]chainhash.Hash(nil),
+			fixture.broadcastOrder[:resumeIndex]...,
+		)
+		if rapid.Bool().Draw(t, "reverseConfirmedOrder") {
+			reverseHashes(confirmed)
+		}
+		startHeight := rapid.Int32Range(0, 1_000_000).Draw(
+			t, "startHeight",
+		)
+		state := &State{
+			ConfirmedTxids: confirmed,
+		}
+		numBroadcasts := len(fixture.broadcastOrder)
+		targetConfirmHeight := int32(0)
+
+		for index := resumeIndex; index < numBroadcasts; index++ {
+			txid := fixture.broadcastOrder[index]
+			planHeight := startHeight + int32(index-resumeIndex)
+			snapshot, err := planner.Plan(planHeight, state)
+			require.NoError(t, err)
+			require.Len(t, snapshot.Ready, 1)
+			require.Equal(t, txid, snapshot.Ready[0].Txid)
+			require.Equal(t, fixture.kindByTxid[txid],
+				snapshot.Ready[0].Node.Kind)
+
+			assertOORChildBlockedWhileParentInFlight(
+				t, planner, fixture, state, index, planHeight,
+			)
+
+			state.ConfirmedTxids = append(
+				state.ConfirmedTxids, txid,
+			)
+			if txid == proof.TargetOutpoint().Hash {
+				targetConfirmHeight = planHeight
+				state.TargetConfirmHeight = fn.Some(planHeight)
+			}
+		}
+
+		snapshot, err := planner.Plan(
+			targetConfirmHeight+int32(oorCSVDelay), state,
+		)
+		require.NoError(t, err)
+		require.True(t, snapshot.AllProofConfirmed)
+		require.True(t, snapshot.TargetConfirmed)
+		require.True(t, snapshot.NeedSweep)
+	})
+}
+
+// TestPlanOORChainRejectsOutOfOrderInFlightState verifies the planner refuses
+// a malformed durable state that claims an Ark tx is in flight before its
+// checkpoint parent has confirmed.
+func TestPlanOORChainRejectsOutOfOrderInFlightState(t *testing.T) {
+	fixture := oorChainProofFixture(t, 2)
+	planner, _ := newPlannerFixture(t, fixture.proof)
+
+	// The generic in-flight parent invariant is covered elsewhere; this
+	// pins the same guard to the OOR-specific checkpoint/Ark topology.
+	ark1 := fixture.broadcastOrder[2]
+	_, err := planner.Plan(100, &State{
+		ConfirmedTxids: []chainhash.Hash{
+			fixture.broadcastOrder[0],
+		},
+		InFlightTxids: []chainhash.Hash{ark1},
+	})
+	require.ErrorContains(t, err, "in-flight tx")
+	require.ErrorContains(t, err, "unconfirmed parents")
+}
+
+type oorChainFixture struct {
+	proof          *recovery.Proof
+	broadcastOrder []chainhash.Hash
+	kindByTxid     map[chainhash.Hash]recovery.NodeKind
+}
+
+func oorChainProofFixture(t require.TestingT, depth int) *oorChainFixture {
+	require.GreaterOrEqual(t, depth, 1)
+
+	root := newTx(nil, 1, "oor-root")
+	nodes := []*recovery.Node{{
+		Kind: recovery.NodeKindTree,
+		Tx:   root,
+	}}
+	order := []chainhash.Hash{root.TxHash()}
+	kindByTxid := map[chainhash.Hash]recovery.NodeKind{
+		root.TxHash(): recovery.NodeKindTree,
+	}
+
+	prevOutpoint := wire.OutPoint{
+		Hash:  root.TxHash(),
+		Index: 0,
+	}
+	for hop := 1; hop <= depth; hop++ {
+		checkpoint := newTx(
+			[]wire.OutPoint{prevOutpoint}, 1,
+			fmt.Sprintf("checkpoint-%d", hop),
+		)
+		checkpointNode := &recovery.Node{
+			Kind: recovery.NodeKindCheckpoint,
+			Tx:   checkpoint,
+		}
+		nodes = append(nodes, checkpointNode)
+
+		checkpointTxid := checkpoint.TxHash()
+		order = append(order, checkpointTxid)
+		kindByTxid[checkpointTxid] = recovery.NodeKindCheckpoint
+
+		ark := newTx([]wire.OutPoint{{
+			Hash:  checkpointTxid,
+			Index: 0,
+		}}, 1, fmt.Sprintf("ark-%d", hop))
+		arkNode := &recovery.Node{
+			Kind: recovery.NodeKindArk,
+			Tx:   ark,
+		}
+		nodes = append(nodes, arkNode)
+
+		arkTxid := ark.TxHash()
+		order = append(order, arkTxid)
+		kindByTxid[arkTxid] = recovery.NodeKindArk
+
+		prevOutpoint = wire.OutPoint{
+			Hash:  arkTxid,
+			Index: 0,
+		}
+	}
+
+	proof, err := recovery.NewProof(prevOutpoint, oorCSVDelay, nodes...)
+	require.NoError(t, err)
+
+	return &oorChainFixture{
+		proof:          proof,
+		broadcastOrder: order,
+		kindByTxid:     kindByTxid,
+	}
+}
+
+func assertOORChildBlockedWhileParentInFlight(t require.TestingT,
+	planner *Planner, fixture *oorChainFixture, state *State, index int,
+	height int32) {
+
+	txid := fixture.broadcastOrder[index]
+	inFlightState := &State{
+		ConfirmedTxids: append(
+			[]chainhash.Hash(nil), state.ConfirmedTxids...,
+		),
+		InFlightTxids:       []chainhash.Hash{txid},
+		TargetConfirmHeight: state.TargetConfirmHeight,
+		Sweep:               state.Sweep,
+	}
+	snapshot, err := planner.Plan(height, inFlightState)
+	require.NoError(t, err)
+	require.Len(t, snapshot.Ready, 0)
+	require.Len(t, snapshot.InFlight, 1)
+	require.Equal(t, txid, snapshot.InFlight[0].Txid)
+
+	if index == len(fixture.broadcastOrder)-1 {
+		return
+	}
+
+	childTxid := fixture.broadcastOrder[index+1]
+	for _, blocked := range snapshot.Blocked {
+		if blocked.Txid != childTxid {
+			continue
+		}
+
+		require.Equal(t, []chainhash.Hash{txid},
+			blocked.MissingParents)
+
+		return
+	}
+
+	require.Failf(t, "child not blocked",
+		"child %s was not blocked on parent %s", childTxid, txid)
+}
+
+func reverseHashes(hashes []chainhash.Hash) {
+	for left, right := 0, len(hashes)-1; left < right; {
+		hashes[left], hashes[right] = hashes[right], hashes[left]
+		left++
+		right--
+	}
+}


### PR DESCRIPTION
## Summary

This PR resolves the deep OOR unroll-ordering audit by making the ordering requirement explicit in `unrollplan` docs and covering it with concrete and property-based planner tests.

The planner already gates readiness on transaction-input dependencies from the immutable recovery proof. For a deep OOR lineage that means the graph naturally forces:

```text
round tree root -> checkpoint_1 -> ark_1 -> checkpoint_2 -> ark_2 -> ...
```

Each Ark tx spends its checkpoint output, and each later checkpoint spends the previous Ark output. The planner therefore does not need node-kind special cases; `NodeKindCheckpoint` and `NodeKindArk` remain useful metadata for callers/logs/policy, while readiness is determined by confirmed parents in the proof graph.

Fixes #269.

## Acceptance criteria

- Code audit: `Planner.Plan` calls `State.Validate` before planning, walks `proof.Layers()` topologically, and only places a tx in `Ready` when all in-proof parents are confirmed.
- Depth-2 unit test: `TestPlanDeepOORChainAlternatesCheckpointAndArk` walks the concrete root/checkpoint/Ark/checkpoint/Ark order and verifies children remain blocked while parents are merely in flight.
- Property test: `TestPlanOORChainOrderingRapid` checks the same confirmation-gated ordering for OOR depths 1 through 5, including randomized resume points, randomized planning heights, and reversed persisted confirmation order.
- Malformed state handling: `TestPlanOORChainRejectsOutOfOrderInFlightState` verifies the planner rejects a state that marks an Ark tx in flight before its checkpoint parent confirms.
- Documentation: `unrollplan/doc.go` now documents the deep OOR ordering invariant and why readiness follows proof dependencies instead of node kinds.
- Integration test: not added here because the issue explicitly scopes this to “when server-side OOR multi-hop available”. This PR locks the client-side planner invariant now; a later integration test can exercise Alice -> Bob -> Carol once multi-hop server support is available in the test harness.

## Validation

```text
go test ./lib/recovery ./unrollplan ./unroll
GOGC=50 make lint
make commitmsg-lint range=origin/main..HEAD
go test ./...
```

The first full `go test ./...` run hit two unrelated-looking tests outside this change (`darepod` listener startup and `sdk/swaps` funding-grace resume). Both passed when rerun directly, and later full `go test ./...` passes completed successfully.
