### PR TITLE
darepocli: add listtransactions command

### DIFF
--- a/cmd/darepocli/darepoclicommands/AGENTS.md
+++ b/cmd/darepocli/darepoclicommands/AGENTS.md
@@ -28,6 +28,7 @@ embed the same command tree.
 | `oor list` | `ListOORSessions` | List locally known OOR sessions; `--status` accepts `all`/`pending`/`completed`/`failed`; `--direction` accepts `all`/`outgoing`/`incoming` |
 | `fees estimate` | `EstimateFee` | Print an itemized fee breakdown for a given VTXO amount; flags a dust-level amount on stderr |
 | `fees history` | `GetFeeHistory` | Paginate the client-side ledger entries and print the cumulative operator fee total |
+| `listtransactions` | `ListTransactions` | List local newest-first transaction history with date, offset, limit, and type filters |
 | `unroll` | `Unroll` | Trigger a unilateral exit for the VTXO at `--outpoint txid:index`. Routes through the VTXO manager's `ForceUnrollRequest` path so the FSM transitions cleanly; the registry job is created async via the chain resolver seam. Response includes `Created` (false if already exiting) and the `ActorId` to poll. |
 | `unroll status` | `GetUnrollStatus` | Query progress for an unroll job by `--outpoint`. Reads through to the live registry first and falls back to the persisted `unilateral_exit_jobs` table for evicted/terminal jobs; `Found=false` (not an error) distinguishes "no such job" from lookup failure. |
 

--- a/cmd/darepocli/darepoclicommands/CLAUDE.md
+++ b/cmd/darepocli/darepoclicommands/CLAUDE.md
@@ -28,6 +28,7 @@ embed the same command tree.
 | `oor list` | `ListOORSessions` | List locally known OOR sessions; `--status` accepts `all`/`pending`/`completed`/`failed`; `--direction` accepts `all`/`outgoing`/`incoming` |
 | `fees estimate` | `EstimateFee` | Print an itemized fee breakdown for a given VTXO amount; flags a dust-level amount on stderr |
 | `fees history` | `GetFeeHistory` | Paginate the client-side ledger entries and print the cumulative operator fee total |
+| `listtransactions` | `ListTransactions` | List local newest-first transaction history with date, offset, limit, and type filters |
 | `unroll` | `Unroll` | Trigger a unilateral exit for the VTXO at `--outpoint txid:index`. Routes through the VTXO manager's `ForceUnrollRequest` path so the FSM transitions cleanly; the registry job is created async via the chain resolver seam. Response includes `Created` (false if already exiting) and the `ActorId` to poll. |
 | `unroll status` | `GetUnrollStatus` | Query progress for an unroll job by `--outpoint`. Reads through to the live registry first and falls back to the persisted `unilateral_exit_jobs` table for evicted/terminal jobs; `Found=false` (not an error) distinguishes "no such job" from lookup failure. |
 

--- a/cmd/darepocli/darepoclicommands/cmd_transactions.go
+++ b/cmd/darepocli/darepoclicommands/cmd_transactions.go
@@ -1,0 +1,139 @@
+package darepoclicommands
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/spf13/cobra"
+)
+
+const transactionDateLayout = "2006-01-02"
+
+// newListTransactionsCmd creates the top-level listtransactions command.
+func newListTransactionsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "listtransactions",
+		Short: "List local transaction history",
+		Long: "Returns a paginated newest-first transaction " +
+			"history from the daemon's local accounting " +
+			"database, with optional date and type filters.",
+		RunE: listTransactions,
+	}
+
+	f := cmd.Flags()
+	f.String("from", "",
+		"only include entries at or after this ISO 8601 time")
+	f.String("to", "",
+		"only include entries at or before this ISO 8601 time")
+	f.Uint32("limit", 50, "maximum number of entries")
+	f.Uint32("offset", 0, "number of filtered entries to skip")
+	f.String("type", "",
+		"optional type filter: boarding, round, oor, or sweep")
+
+	return cmd
+}
+
+// listTransactions executes the ListTransactions RPC.
+func listTransactions(cmd *cobra.Command, _ []string) error {
+	client, conn, err := getDaemonClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	req := &daemonrpc.ListTransactionsRequest{}
+	if err := parseRequest(cmd, req, func() error {
+		from, _ := cmd.Flags().GetString("from")
+		to, _ := cmd.Flags().GetString("to")
+		limit, _ := cmd.Flags().GetUint32("limit")
+		offset, _ := cmd.Flags().GetUint32("offset")
+		filter, _ := cmd.Flags().GetString("type")
+
+		fromUnix, err := parseTransactionTimeFlag("--from", from)
+		if err != nil {
+			return err
+		}
+		toUnix, err := parseTransactionTimeFlag("--to", to)
+		if err != nil {
+			return err
+		}
+		err = validateTransactionTimeWindow(fromUnix, toUnix)
+		if err != nil {
+			return err
+		}
+		if !transactionTypeFlagValid(filter) {
+			return fmt.Errorf(
+				"--type must be one of boarding, round, " +
+					"oor, or sweep",
+			)
+		}
+
+		req.FromUnixS = fromUnix
+		req.ToUnixS = toUnix
+		req.Limit = limit
+		req.Offset = offset
+		req.Type = filter
+
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	resp, err := client.ListTransactions(cmd.Context(), req)
+	if err != nil {
+		return fmt.Errorf("ListTransactions RPC failed: %w", err)
+	}
+
+	return printJSON(resp)
+}
+
+// parseTransactionTimeFlag parses an ISO 8601 timestamp or date-only value
+// into Unix seconds. Empty values leave the corresponding RPC bound open.
+func parseTransactionTimeFlag(name, value string) (int64, error) {
+	if value == "" {
+		return 0, nil
+	}
+
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err == nil {
+		return parsed.Unix(), nil
+	}
+
+	parsed, dateErr := time.Parse(transactionDateLayout, value)
+	if dateErr == nil {
+		if name == "--to" {
+			endOfDay := parsed.Add(24*time.Hour - time.Second)
+
+			return endOfDay.Unix(), nil
+		}
+
+		return parsed.Unix(), nil
+	}
+
+	return 0, fmt.Errorf("%s must be an ISO 8601 timestamp "+
+		"(for example 2026-05-08T00:00:00Z) or date "+
+		"(for example 2026-05-08)", name)
+}
+
+// transactionTypeFlagValid returns true for the public transaction type
+// filters accepted by the listtransactions command.
+func transactionTypeFlagValid(filter string) bool {
+	switch filter {
+	case "", "boarding", "round", "oor", "sweep":
+		return true
+
+	default:
+		return false
+	}
+}
+
+// validateTransactionTimeWindow returns an error when both bounds are set and
+// the lower bound is after the upper bound.
+func validateTransactionTimeWindow(fromUnix, toUnix int64) error {
+	if fromUnix != 0 && toUnix != 0 && fromUnix > toUnix {
+		return fmt.Errorf("--from must be before or equal to --to")
+	}
+
+	return nil
+}

--- a/cmd/darepocli/darepoclicommands/cmd_transactions_test.go
+++ b/cmd/darepocli/darepoclicommands/cmd_transactions_test.go
@@ -1,0 +1,82 @@
+package darepoclicommands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseTransactionTimeFlag verifies listtransactions accepts both full
+// RFC3339 timestamps and ISO date-only filters.
+func TestParseTransactionTimeFlag(t *testing.T) {
+	t.Parallel()
+
+	full, err := parseTransactionTimeFlag(
+		"--from", "2026-05-08T12:34:56Z",
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(1778243696), full)
+
+	dateOnly, err := parseTransactionTimeFlag("--to", "2026-05-08")
+	require.NoError(t, err)
+	require.Equal(t, int64(1778284799), dateOnly)
+
+	open, err := parseTransactionTimeFlag("--from", "")
+	require.NoError(t, err)
+	require.Zero(t, open)
+
+	_, err = parseTransactionTimeFlag("--from", "May 8")
+	require.ErrorContains(t, err, "ISO 8601")
+	require.ErrorContains(t, err, "2026-05-08T00:00:00Z")
+	require.ErrorContains(t, err, "2026-05-08")
+}
+
+// TestValidateTransactionTimeWindow verifies the CLI rejects inverted local
+// timestamp bounds before sending a ListTransactions request.
+func TestValidateTransactionTimeWindow(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, validateTransactionTimeWindow(10, 0))
+	require.NoError(t, validateTransactionTimeWindow(0, 10))
+	require.NoError(t, validateTransactionTimeWindow(10, 10))
+	require.NoError(t, validateTransactionTimeWindow(10, 11))
+
+	err := validateTransactionTimeWindow(11, 10)
+	require.ErrorContains(t, err, "--from must be before")
+}
+
+// TestTransactionTypeFlagValid verifies the CLI rejects typos locally before
+// sending a ListTransactions request.
+func TestTransactionTypeFlagValid(t *testing.T) {
+	t.Parallel()
+
+	filters := []string{"", "boarding", "round", "oor", "sweep"}
+	for _, filter := range filters {
+		require.True(t, transactionTypeFlagValid(filter), filter)
+	}
+	require.False(t, transactionTypeFlagValid("fees"))
+}
+
+// TestMethodRegistryListTransactionsSchema verifies the public schema
+// advertises listtransactions and all expected filters.
+func TestMethodRegistryListTransactionsSchema(t *testing.T) {
+	t.Parallel()
+
+	method := findSchemaMethod(t, "listtransactions")
+	require.Equal(t, "ListTransactionsRequest", method.RequestType)
+	require.Equal(t, "ListTransactionsResponse", method.ResponseType)
+	require.True(t, method.JSONInput)
+
+	params := make(map[string]schemaParam, len(method.Params))
+	for _, param := range method.Params {
+		params[param.Name] = param
+	}
+
+	require.Contains(t, params, "from")
+	require.Contains(t, params, "to")
+	require.Contains(t, params, "limit")
+	require.Contains(t, params, "offset")
+	require.Equal(t, []string{
+		"boarding", "round", "oor", "sweep",
+	}, params["type"].Values)
+}

--- a/cmd/darepocli/darepoclicommands/root.go
+++ b/cmd/darepocli/darepoclicommands/root.go
@@ -58,6 +58,7 @@ func NewRootCmd() *cobra.Command {
 		newSendCmd(),
 		newBoardCmd(),
 		newSweepCmd(),
+		newListTransactionsCmd(),
 		newRoundsCmd(),
 		newFeesCmd(),
 		newSchemaCmd(),

--- a/cmd/darepocli/darepoclicommands/schema_registry.go
+++ b/cmd/darepocli/darepoclicommands/schema_registry.go
@@ -192,6 +192,50 @@ func baseMethodRegistry() []schemaMethod {
 			JSONInput:    true,
 		},
 		{
+			Method:      "listtransactions",
+			Description: "List local transaction history",
+			Params: []schemaParam{
+				{
+					Name: "from",
+					Type: "string",
+					Description: "ISO 8601 lower " +
+						"timestamp bound",
+				},
+				{
+					Name: "to",
+					Type: "string",
+					Description: "ISO 8601 upper " +
+						"timestamp bound",
+				},
+				{
+					Name: "limit",
+					Type: "uint32",
+					Description: "maximum entries to " +
+						"return; zero uses default",
+				},
+				{
+					Name: "offset",
+					Type: "uint32",
+					Description: "number of filtered " +
+						"entries to skip",
+				},
+				{
+					Name:        "type",
+					Type:        "enum",
+					Description: "transaction type filter",
+					Values: []string{
+						"boarding",
+						"round",
+						"oor",
+						"sweep",
+					},
+				},
+			},
+			RequestType:  "ListTransactionsRequest",
+			ResponseType: "ListTransactionsResponse",
+			JSONInput:    true,
+		},
+		{
 			Method:      "oor.receive",
 			Description: "Allocate a fresh receive script",
 			Params: []schemaParam{

--- a/daemonrpc/daemon.pb.go
+++ b/daemonrpc/daemon.pb.go
@@ -5281,6 +5281,335 @@ func (x *GetFeeHistoryResponse) GetTotalFeesPaidSat() int64 {
 	return 0
 }
 
+type ListTransactionsRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// from_unix_s filters entries created at or after this Unix timestamp.
+	// A zero value leaves the lower bound open.
+	FromUnixS int64 `protobuf:"varint,1,opt,name=from_unix_s,json=fromUnixS,proto3" json:"from_unix_s,omitempty"`
+	// to_unix_s filters entries created at or before this Unix timestamp. A
+	// zero value leaves the upper bound open.
+	ToUnixS int64 `protobuf:"varint,2,opt,name=to_unix_s,json=toUnixS,proto3" json:"to_unix_s,omitempty"`
+	// limit bounds the number of results. Zero uses the daemon default.
+	Limit uint32 `protobuf:"varint,3,opt,name=limit,proto3" json:"limit,omitempty"`
+	// offset is the number of filtered entries to skip.
+	Offset uint32 `protobuf:"varint,4,opt,name=offset,proto3" json:"offset,omitempty"`
+	// type filters entries by high-level transaction type. Accepted values
+	// are "boarding", "round", "oor", and "sweep". Empty lists all.
+	// "sweep" includes tracked boarding sweep transactions and
+	// chain-sweep-related ledger entries, such as unilateral-exit
+	// onchain_fee_paid rows.
+	Type          string `protobuf:"bytes,5,opt,name=type,proto3" json:"type,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListTransactionsRequest) Reset() {
+	*x = ListTransactionsRequest{}
+	mi := &file_daemon_proto_msgTypes[69]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListTransactionsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListTransactionsRequest) ProtoMessage() {}
+
+func (x *ListTransactionsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[69]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListTransactionsRequest.ProtoReflect.Descriptor instead.
+func (*ListTransactionsRequest) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{69}
+}
+
+func (x *ListTransactionsRequest) GetFromUnixS() int64 {
+	if x != nil {
+		return x.FromUnixS
+	}
+	return 0
+}
+
+func (x *ListTransactionsRequest) GetToUnixS() int64 {
+	if x != nil {
+		return x.ToUnixS
+	}
+	return 0
+}
+
+func (x *ListTransactionsRequest) GetLimit() uint32 {
+	if x != nil {
+		return x.Limit
+	}
+	return 0
+}
+
+func (x *ListTransactionsRequest) GetOffset() uint32 {
+	if x != nil {
+		return x.Offset
+	}
+	return 0
+}
+
+func (x *ListTransactionsRequest) GetType() string {
+	if x != nil {
+		return x.Type
+	}
+	return ""
+}
+
+type TransactionHistoryEntry struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// source names the local persistence source: "ledger" or
+	// "boarding_sweep".
+	Source string `protobuf:"bytes,1,opt,name=source,proto3" json:"source,omitempty"`
+	// type is the high-level category: "boarding", "round", "oor", or
+	// "sweep".
+	Type string `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty"`
+	// subtype carries the ledger event type or sweep lifecycle status.
+	Subtype string `protobuf:"bytes,3,opt,name=subtype,proto3" json:"subtype,omitempty"`
+	// amount_sat is the gross transaction amount in satoshis.
+	AmountSat int64 `protobuf:"varint,4,opt,name=amount_sat,json=amountSat,proto3" json:"amount_sat,omitempty"`
+	// fee_sat is set for persisted aggregate sweep transactions.
+	FeeSat int64 `protobuf:"varint,5,opt,name=fee_sat,json=feeSat,proto3" json:"fee_sat,omitempty"`
+	// created_at_unix_s is the local Unix timestamp for the row.
+	CreatedAtUnixS int64 `protobuf:"varint,6,opt,name=created_at_unix_s,json=createdAtUnixS,proto3" json:"created_at_unix_s,omitempty"`
+	// confirmation_status is "confirmed", "recorded", or the persisted
+	// aggregate sweep status.
+	ConfirmationStatus string `protobuf:"bytes,7,opt,name=confirmation_status,json=confirmationStatus,proto3" json:"confirmation_status,omitempty"`
+	// description is a human-readable local note.
+	Description string `protobuf:"bytes,8,opt,name=description,proto3" json:"description,omitempty"`
+	// entry_id is set for ledger-backed rows.
+	EntryId int64 `protobuf:"varint,9,opt,name=entry_id,json=entryId,proto3" json:"entry_id,omitempty"`
+	// txid is set for transaction-backed rows such as aggregate boarding
+	// sweeps.
+	Txid string `protobuf:"bytes,10,opt,name=txid,proto3" json:"txid,omitempty"`
+	// debit_account names the account debited by a ledger-backed row.
+	DebitAccount string `protobuf:"bytes,11,opt,name=debit_account,json=debitAccount,proto3" json:"debit_account,omitempty"`
+	// credit_account names the account credited by a ledger-backed row.
+	CreditAccount string `protobuf:"bytes,12,opt,name=credit_account,json=creditAccount,proto3" json:"credit_account,omitempty"`
+	// round_id is the 16-byte round UUID associated with the row, when
+	// applicable.
+	RoundId []byte `protobuf:"bytes,13,opt,name=round_id,json=roundId,proto3" json:"round_id,omitempty"`
+	// session_id is the 32-byte OOR session identifier associated with the
+	// row, when applicable.
+	SessionId []byte `protobuf:"bytes,14,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	// confirmation_height is set when the source records a chain
+	// confirmation height.
+	ConfirmationHeight int32 `protobuf:"varint,15,opt,name=confirmation_height,json=confirmationHeight,proto3" json:"confirmation_height,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *TransactionHistoryEntry) Reset() {
+	*x = TransactionHistoryEntry{}
+	mi := &file_daemon_proto_msgTypes[70]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TransactionHistoryEntry) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TransactionHistoryEntry) ProtoMessage() {}
+
+func (x *TransactionHistoryEntry) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[70]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TransactionHistoryEntry.ProtoReflect.Descriptor instead.
+func (*TransactionHistoryEntry) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{70}
+}
+
+func (x *TransactionHistoryEntry) GetSource() string {
+	if x != nil {
+		return x.Source
+	}
+	return ""
+}
+
+func (x *TransactionHistoryEntry) GetType() string {
+	if x != nil {
+		return x.Type
+	}
+	return ""
+}
+
+func (x *TransactionHistoryEntry) GetSubtype() string {
+	if x != nil {
+		return x.Subtype
+	}
+	return ""
+}
+
+func (x *TransactionHistoryEntry) GetAmountSat() int64 {
+	if x != nil {
+		return x.AmountSat
+	}
+	return 0
+}
+
+func (x *TransactionHistoryEntry) GetFeeSat() int64 {
+	if x != nil {
+		return x.FeeSat
+	}
+	return 0
+}
+
+func (x *TransactionHistoryEntry) GetCreatedAtUnixS() int64 {
+	if x != nil {
+		return x.CreatedAtUnixS
+	}
+	return 0
+}
+
+func (x *TransactionHistoryEntry) GetConfirmationStatus() string {
+	if x != nil {
+		return x.ConfirmationStatus
+	}
+	return ""
+}
+
+func (x *TransactionHistoryEntry) GetDescription() string {
+	if x != nil {
+		return x.Description
+	}
+	return ""
+}
+
+func (x *TransactionHistoryEntry) GetEntryId() int64 {
+	if x != nil {
+		return x.EntryId
+	}
+	return 0
+}
+
+func (x *TransactionHistoryEntry) GetTxid() string {
+	if x != nil {
+		return x.Txid
+	}
+	return ""
+}
+
+func (x *TransactionHistoryEntry) GetDebitAccount() string {
+	if x != nil {
+		return x.DebitAccount
+	}
+	return ""
+}
+
+func (x *TransactionHistoryEntry) GetCreditAccount() string {
+	if x != nil {
+		return x.CreditAccount
+	}
+	return ""
+}
+
+func (x *TransactionHistoryEntry) GetRoundId() []byte {
+	if x != nil {
+		return x.RoundId
+	}
+	return nil
+}
+
+func (x *TransactionHistoryEntry) GetSessionId() []byte {
+	if x != nil {
+		return x.SessionId
+	}
+	return nil
+}
+
+func (x *TransactionHistoryEntry) GetConfirmationHeight() int32 {
+	if x != nil {
+		return x.ConfirmationHeight
+	}
+	return 0
+}
+
+type ListTransactionsResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// transactions are returned newest first by created_at_unix_s.
+	Transactions []*TransactionHistoryEntry `protobuf:"bytes,1,rep,name=transactions,proto3" json:"transactions,omitempty"`
+	// next_offset is the offset to pass to the next request when has_more is
+	// true.
+	NextOffset uint32 `protobuf:"varint,2,opt,name=next_offset,json=nextOffset,proto3" json:"next_offset,omitempty"`
+	// has_more is true when another page is available.
+	HasMore       bool `protobuf:"varint,3,opt,name=has_more,json=hasMore,proto3" json:"has_more,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListTransactionsResponse) Reset() {
+	*x = ListTransactionsResponse{}
+	mi := &file_daemon_proto_msgTypes[71]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListTransactionsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListTransactionsResponse) ProtoMessage() {}
+
+func (x *ListTransactionsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[71]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListTransactionsResponse.ProtoReflect.Descriptor instead.
+func (*ListTransactionsResponse) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{71}
+}
+
+func (x *ListTransactionsResponse) GetTransactions() []*TransactionHistoryEntry {
+	if x != nil {
+		return x.Transactions
+	}
+	return nil
+}
+
+func (x *ListTransactionsResponse) GetNextOffset() uint32 {
+	if x != nil {
+		return x.NextOffset
+	}
+	return 0
+}
+
+func (x *ListTransactionsResponse) GetHasMore() bool {
+	if x != nil {
+		return x.HasMore
+	}
+	return false
+}
+
 type UnrollRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// outpoint is the VTXO outpoint to unilaterally exit, formatted as
@@ -5292,7 +5621,7 @@ type UnrollRequest struct {
 
 func (x *UnrollRequest) Reset() {
 	*x = UnrollRequest{}
-	mi := &file_daemon_proto_msgTypes[69]
+	mi := &file_daemon_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5304,7 +5633,7 @@ func (x *UnrollRequest) String() string {
 func (*UnrollRequest) ProtoMessage() {}
 
 func (x *UnrollRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[69]
+	mi := &file_daemon_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5317,7 +5646,7 @@ func (x *UnrollRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnrollRequest.ProtoReflect.Descriptor instead.
 func (*UnrollRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{69}
+	return file_daemon_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *UnrollRequest) GetOutpoint() string {
@@ -5340,7 +5669,7 @@ type UnrollResponse struct {
 
 func (x *UnrollResponse) Reset() {
 	*x = UnrollResponse{}
-	mi := &file_daemon_proto_msgTypes[70]
+	mi := &file_daemon_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5352,7 +5681,7 @@ func (x *UnrollResponse) String() string {
 func (*UnrollResponse) ProtoMessage() {}
 
 func (x *UnrollResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[70]
+	mi := &file_daemon_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5365,7 +5694,7 @@ func (x *UnrollResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnrollResponse.ProtoReflect.Descriptor instead.
 func (*UnrollResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{70}
+	return file_daemon_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *UnrollResponse) GetCreated() bool {
@@ -5392,7 +5721,7 @@ type GetUnrollStatusRequest struct {
 
 func (x *GetUnrollStatusRequest) Reset() {
 	*x = GetUnrollStatusRequest{}
-	mi := &file_daemon_proto_msgTypes[71]
+	mi := &file_daemon_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5404,7 +5733,7 @@ func (x *GetUnrollStatusRequest) String() string {
 func (*GetUnrollStatusRequest) ProtoMessage() {}
 
 func (x *GetUnrollStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[71]
+	mi := &file_daemon_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5417,7 +5746,7 @@ func (x *GetUnrollStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUnrollStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetUnrollStatusRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{71}
+	return file_daemon_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *GetUnrollStatusRequest) GetOutpoint() string {
@@ -5445,7 +5774,7 @@ type GetUnrollStatusResponse struct {
 
 func (x *GetUnrollStatusResponse) Reset() {
 	*x = GetUnrollStatusResponse{}
-	mi := &file_daemon_proto_msgTypes[72]
+	mi := &file_daemon_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5457,7 +5786,7 @@ func (x *GetUnrollStatusResponse) String() string {
 func (*GetUnrollStatusResponse) ProtoMessage() {}
 
 func (x *GetUnrollStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[72]
+	mi := &file_daemon_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5470,7 +5799,7 @@ func (x *GetUnrollStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUnrollStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetUnrollStatusResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{72}
+	return file_daemon_proto_rawDescGZIP(), []int{75}
 }
 
 func (x *GetUnrollStatusResponse) GetFound() bool {
@@ -5849,7 +6178,37 @@ const file_daemon_proto_rawDesc = "" +
 	"session_id\x18\t \x01(\fR\tsessionId\"|\n" +
 	"\x15GetFeeHistoryResponse\x124\n" +
 	"\aentries\x18\x01 \x03(\v2\x1a.daemonrpc.FeeHistoryEntryR\aentries\x12-\n" +
-	"\x13total_fees_paid_sat\x18\x02 \x01(\x03R\x10totalFeesPaidSat\"+\n" +
+	"\x13total_fees_paid_sat\x18\x02 \x01(\x03R\x10totalFeesPaidSat\"\x97\x01\n" +
+	"\x17ListTransactionsRequest\x12\x1e\n" +
+	"\vfrom_unix_s\x18\x01 \x01(\x03R\tfromUnixS\x12\x1a\n" +
+	"\tto_unix_s\x18\x02 \x01(\x03R\atoUnixS\x12\x14\n" +
+	"\x05limit\x18\x03 \x01(\rR\x05limit\x12\x16\n" +
+	"\x06offset\x18\x04 \x01(\rR\x06offset\x12\x12\n" +
+	"\x04type\x18\x05 \x01(\tR\x04type\"\xfb\x03\n" +
+	"\x17TransactionHistoryEntry\x12\x16\n" +
+	"\x06source\x18\x01 \x01(\tR\x06source\x12\x12\n" +
+	"\x04type\x18\x02 \x01(\tR\x04type\x12\x18\n" +
+	"\asubtype\x18\x03 \x01(\tR\asubtype\x12\x1d\n" +
+	"\n" +
+	"amount_sat\x18\x04 \x01(\x03R\tamountSat\x12\x17\n" +
+	"\afee_sat\x18\x05 \x01(\x03R\x06feeSat\x12)\n" +
+	"\x11created_at_unix_s\x18\x06 \x01(\x03R\x0ecreatedAtUnixS\x12/\n" +
+	"\x13confirmation_status\x18\a \x01(\tR\x12confirmationStatus\x12 \n" +
+	"\vdescription\x18\b \x01(\tR\vdescription\x12\x19\n" +
+	"\bentry_id\x18\t \x01(\x03R\aentryId\x12\x12\n" +
+	"\x04txid\x18\n" +
+	" \x01(\tR\x04txid\x12#\n" +
+	"\rdebit_account\x18\v \x01(\tR\fdebitAccount\x12%\n" +
+	"\x0ecredit_account\x18\f \x01(\tR\rcreditAccount\x12\x19\n" +
+	"\bround_id\x18\r \x01(\fR\aroundId\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x0e \x01(\fR\tsessionId\x12/\n" +
+	"\x13confirmation_height\x18\x0f \x01(\x05R\x12confirmationHeight\"\x9e\x01\n" +
+	"\x18ListTransactionsResponse\x12F\n" +
+	"\ftransactions\x18\x01 \x03(\v2\".daemonrpc.TransactionHistoryEntryR\ftransactions\x12\x1f\n" +
+	"\vnext_offset\x18\x02 \x01(\rR\n" +
+	"nextOffset\x12\x19\n" +
+	"\bhas_more\x18\x03 \x01(\bR\ahasMore\"+\n" +
 	"\rUnrollRequest\x12\x1a\n" +
 	"\boutpoint\x18\x01 \x01(\tR\boutpoint\"E\n" +
 	"\x0eUnrollResponse\x12\x18\n" +
@@ -5910,7 +6269,7 @@ const file_daemon_proto_rawDesc = "" +
 	"\x1dUNROLL_JOB_STATUS_CSV_PENDING\x10\x03\x12\x1e\n" +
 	"\x1aUNROLL_JOB_STATUS_SWEEPING\x10\x04\x12\x1f\n" +
 	"\x1bUNROLL_JOB_STATUS_COMPLETED\x10\x05\x12\x1c\n" +
-	"\x18UNROLL_JOB_STATUS_FAILED\x10\x062\xed\x13\n" +
+	"\x18UNROLL_JOB_STATUS_FAILED\x10\x062\xca\x14\n" +
 	"\rDaemonService\x12@\n" +
 	"\aGetInfo\x12\x19.daemonrpc.GetInfoRequest\x1a\x1a.daemonrpc.GetInfoResponse\x12@\n" +
 	"\aGenSeed\x12\x19.daemonrpc.GenSeedRequest\x1a\x1a.daemonrpc.GenSeedResponse\x12I\n" +
@@ -5944,7 +6303,8 @@ const file_daemon_proto_rawDesc = "" +
 	"\x0fListOORSessions\x12!.daemonrpc.ListOORSessionsRequest\x1a\".daemonrpc.ListOORSessionsResponse\x12R\n" +
 	"\rGetOORSession\x12\x1f.daemonrpc.GetOORSessionRequest\x1a .daemonrpc.GetOORSessionResponse\x12L\n" +
 	"\vEstimateFee\x12\x1d.daemonrpc.EstimateFeeRequest\x1a\x1e.daemonrpc.EstimateFeeResponse\x12R\n" +
-	"\rGetFeeHistory\x12\x1f.daemonrpc.GetFeeHistoryRequest\x1a .daemonrpc.GetFeeHistoryResponse\x12=\n" +
+	"\rGetFeeHistory\x12\x1f.daemonrpc.GetFeeHistoryRequest\x1a .daemonrpc.GetFeeHistoryResponse\x12[\n" +
+	"\x10ListTransactions\x12\".daemonrpc.ListTransactionsRequest\x1a#.daemonrpc.ListTransactionsResponse\x12=\n" +
 	"\x06Unroll\x12\x18.daemonrpc.UnrollRequest\x1a\x19.daemonrpc.UnrollResponse\x12X\n" +
 	"\x0fGetUnrollStatus\x12!.daemonrpc.GetUnrollStatusRequest\x1a\".daemonrpc.GetUnrollStatusResponseB2Z0github.com/lightninglabs/darepo-client/daemonrpcb\x06proto3"
 
@@ -5961,7 +6321,7 @@ func file_daemon_proto_rawDescGZIP() []byte {
 }
 
 var file_daemon_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 74)
+var file_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 77)
 var file_daemon_proto_goTypes = []any{
 	(VTXOStatus)(0),                               // 0: daemonrpc.VTXOStatus
 	(RoundState)(0),                               // 1: daemonrpc.RoundState
@@ -6037,11 +6397,14 @@ var file_daemon_proto_goTypes = []any{
 	(*GetFeeHistoryRequest)(nil),                  // 71: daemonrpc.GetFeeHistoryRequest
 	(*FeeHistoryEntry)(nil),                       // 72: daemonrpc.FeeHistoryEntry
 	(*GetFeeHistoryResponse)(nil),                 // 73: daemonrpc.GetFeeHistoryResponse
-	(*UnrollRequest)(nil),                         // 74: daemonrpc.UnrollRequest
-	(*UnrollResponse)(nil),                        // 75: daemonrpc.UnrollResponse
-	(*GetUnrollStatusRequest)(nil),                // 76: daemonrpc.GetUnrollStatusRequest
-	(*GetUnrollStatusResponse)(nil),               // 77: daemonrpc.GetUnrollStatusResponse
-	nil,                                           // 78: daemonrpc.LeaveVTXOsRequest.DestinationsEntry
+	(*ListTransactionsRequest)(nil),               // 74: daemonrpc.ListTransactionsRequest
+	(*TransactionHistoryEntry)(nil),               // 75: daemonrpc.TransactionHistoryEntry
+	(*ListTransactionsResponse)(nil),              // 76: daemonrpc.ListTransactionsResponse
+	(*UnrollRequest)(nil),                         // 77: daemonrpc.UnrollRequest
+	(*UnrollResponse)(nil),                        // 78: daemonrpc.UnrollResponse
+	(*GetUnrollStatusRequest)(nil),                // 79: daemonrpc.GetUnrollStatusRequest
+	(*GetUnrollStatusResponse)(nil),               // 80: daemonrpc.GetUnrollStatusResponse
+	nil,                                           // 81: daemonrpc.LeaveVTXOsRequest.DestinationsEntry
 }
 var file_daemon_proto_depIdxs = []int32{
 	7,  // 0: daemonrpc.GetInfoResponse.server_info:type_name -> daemonrpc.ServerInfo
@@ -6056,7 +6419,7 @@ var file_daemon_proto_depIdxs = []int32{
 	41, // 9: daemonrpc.RefreshVTXOsRequest.outpoints:type_name -> daemonrpc.OutpointSelection
 	41, // 10: daemonrpc.LeaveVTXOsRequest.outpoints:type_name -> daemonrpc.OutpointSelection
 	44, // 11: daemonrpc.LeaveVTXOsRequest.default_destination:type_name -> daemonrpc.LeaveDestination
-	78, // 12: daemonrpc.LeaveVTXOsRequest.destinations:type_name -> daemonrpc.LeaveVTXOsRequest.DestinationsEntry
+	81, // 12: daemonrpc.LeaveVTXOsRequest.destinations:type_name -> daemonrpc.LeaveVTXOsRequest.DestinationsEntry
 	50, // 13: daemonrpc.SweepBoardingUTXOsResponse.sweepable_outputs:type_name -> daemonrpc.BoardingSweepOutput
 	53, // 14: daemonrpc.BoardingSweep.inputs:type_name -> daemonrpc.BoardingSweepInput
 	54, // 15: daemonrpc.ListBoardingSweepsResponse.sweeps:type_name -> daemonrpc.BoardingSweep
@@ -6073,73 +6436,76 @@ var file_daemon_proto_depIdxs = []int32{
 	64, // 26: daemonrpc.ListOORSessionsResponse.sessions:type_name -> daemonrpc.OORSessionInfo
 	64, // 27: daemonrpc.GetOORSessionResponse.session:type_name -> daemonrpc.OORSessionInfo
 	72, // 28: daemonrpc.GetFeeHistoryResponse.entries:type_name -> daemonrpc.FeeHistoryEntry
-	4,  // 29: daemonrpc.GetUnrollStatusResponse.status:type_name -> daemonrpc.UnrollJobStatus
-	44, // 30: daemonrpc.LeaveVTXOsRequest.DestinationsEntry.value:type_name -> daemonrpc.LeaveDestination
-	5,  // 31: daemonrpc.DaemonService.GetInfo:input_type -> daemonrpc.GetInfoRequest
-	8,  // 32: daemonrpc.DaemonService.GenSeed:input_type -> daemonrpc.GenSeedRequest
-	10, // 33: daemonrpc.DaemonService.InitWallet:input_type -> daemonrpc.InitWalletRequest
-	12, // 34: daemonrpc.DaemonService.UnlockWallet:input_type -> daemonrpc.UnlockWalletRequest
-	14, // 35: daemonrpc.DaemonService.GetBalance:input_type -> daemonrpc.GetBalanceRequest
-	17, // 36: daemonrpc.DaemonService.ListVTXOs:input_type -> daemonrpc.ListVTXOsRequest
-	19, // 37: daemonrpc.DaemonService.NewAddress:input_type -> daemonrpc.NewAddressRequest
-	21, // 38: daemonrpc.DaemonService.NewReceiveScript:input_type -> daemonrpc.NewReceiveScriptRequest
-	23, // 39: daemonrpc.DaemonService.ReceiveAuthKey:input_type -> daemonrpc.ReceiveAuthKeyRequest
-	25, // 40: daemonrpc.DaemonService.SignReceiveAuthMessage:input_type -> daemonrpc.SignReceiveAuthMessageRequest
-	27, // 41: daemonrpc.DaemonService.SignReceiveAuthMessageCompact:input_type -> daemonrpc.SignReceiveAuthMessageCompactRequest
-	29, // 42: daemonrpc.DaemonService.ReceiveAuthECDH:input_type -> daemonrpc.ReceiveAuthECDHRequest
-	31, // 43: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:input_type -> daemonrpc.GetIndexedVTXOByPkScriptRequest
-	33, // 44: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:input_type -> daemonrpc.GetIndexedOORSessionByTxidRequest
-	36, // 45: daemonrpc.DaemonService.SendVTXO:input_type -> daemonrpc.SendVTXORequest
-	38, // 46: daemonrpc.DaemonService.SendOOR:input_type -> daemonrpc.SendOORRequest
-	42, // 47: daemonrpc.DaemonService.RefreshVTXOs:input_type -> daemonrpc.RefreshVTXOsRequest
-	45, // 48: daemonrpc.DaemonService.LeaveVTXOs:input_type -> daemonrpc.LeaveVTXOsRequest
-	47, // 49: daemonrpc.DaemonService.Board:input_type -> daemonrpc.BoardRequest
-	49, // 50: daemonrpc.DaemonService.SweepBoardingUTXOs:input_type -> daemonrpc.SweepBoardingUTXOsRequest
-	52, // 51: daemonrpc.DaemonService.ListBoardingSweeps:input_type -> daemonrpc.ListBoardingSweepsRequest
-	58, // 52: daemonrpc.DaemonService.ListRounds:input_type -> daemonrpc.ListRoundsRequest
-	59, // 53: daemonrpc.DaemonService.GetRound:input_type -> daemonrpc.GetRoundRequest
-	62, // 54: daemonrpc.DaemonService.WatchRounds:input_type -> daemonrpc.WatchRoundsRequest
-	65, // 55: daemonrpc.DaemonService.ListOORSessions:input_type -> daemonrpc.ListOORSessionsRequest
-	67, // 56: daemonrpc.DaemonService.GetOORSession:input_type -> daemonrpc.GetOORSessionRequest
-	69, // 57: daemonrpc.DaemonService.EstimateFee:input_type -> daemonrpc.EstimateFeeRequest
-	71, // 58: daemonrpc.DaemonService.GetFeeHistory:input_type -> daemonrpc.GetFeeHistoryRequest
-	74, // 59: daemonrpc.DaemonService.Unroll:input_type -> daemonrpc.UnrollRequest
-	76, // 60: daemonrpc.DaemonService.GetUnrollStatus:input_type -> daemonrpc.GetUnrollStatusRequest
-	6,  // 61: daemonrpc.DaemonService.GetInfo:output_type -> daemonrpc.GetInfoResponse
-	9,  // 62: daemonrpc.DaemonService.GenSeed:output_type -> daemonrpc.GenSeedResponse
-	11, // 63: daemonrpc.DaemonService.InitWallet:output_type -> daemonrpc.InitWalletResponse
-	13, // 64: daemonrpc.DaemonService.UnlockWallet:output_type -> daemonrpc.UnlockWalletResponse
-	15, // 65: daemonrpc.DaemonService.GetBalance:output_type -> daemonrpc.GetBalanceResponse
-	18, // 66: daemonrpc.DaemonService.ListVTXOs:output_type -> daemonrpc.ListVTXOsResponse
-	20, // 67: daemonrpc.DaemonService.NewAddress:output_type -> daemonrpc.NewAddressResponse
-	22, // 68: daemonrpc.DaemonService.NewReceiveScript:output_type -> daemonrpc.NewReceiveScriptResponse
-	24, // 69: daemonrpc.DaemonService.ReceiveAuthKey:output_type -> daemonrpc.ReceiveAuthKeyResponse
-	26, // 70: daemonrpc.DaemonService.SignReceiveAuthMessage:output_type -> daemonrpc.SignReceiveAuthMessageResponse
-	28, // 71: daemonrpc.DaemonService.SignReceiveAuthMessageCompact:output_type -> daemonrpc.SignReceiveAuthMessageCompactResponse
-	30, // 72: daemonrpc.DaemonService.ReceiveAuthECDH:output_type -> daemonrpc.ReceiveAuthECDHResponse
-	32, // 73: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:output_type -> daemonrpc.GetIndexedVTXOByPkScriptResponse
-	34, // 74: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:output_type -> daemonrpc.GetIndexedOORSessionByTxidResponse
-	37, // 75: daemonrpc.DaemonService.SendVTXO:output_type -> daemonrpc.SendVTXOResponse
-	40, // 76: daemonrpc.DaemonService.SendOOR:output_type -> daemonrpc.SendOORResponse
-	43, // 77: daemonrpc.DaemonService.RefreshVTXOs:output_type -> daemonrpc.RefreshVTXOsResponse
-	46, // 78: daemonrpc.DaemonService.LeaveVTXOs:output_type -> daemonrpc.LeaveVTXOsResponse
-	48, // 79: daemonrpc.DaemonService.Board:output_type -> daemonrpc.BoardResponse
-	51, // 80: daemonrpc.DaemonService.SweepBoardingUTXOs:output_type -> daemonrpc.SweepBoardingUTXOsResponse
-	55, // 81: daemonrpc.DaemonService.ListBoardingSweeps:output_type -> daemonrpc.ListBoardingSweepsResponse
-	61, // 82: daemonrpc.DaemonService.ListRounds:output_type -> daemonrpc.ListRoundsResponse
-	60, // 83: daemonrpc.DaemonService.GetRound:output_type -> daemonrpc.GetRoundResponse
-	63, // 84: daemonrpc.DaemonService.WatchRounds:output_type -> daemonrpc.WatchRoundsResponse
-	66, // 85: daemonrpc.DaemonService.ListOORSessions:output_type -> daemonrpc.ListOORSessionsResponse
-	68, // 86: daemonrpc.DaemonService.GetOORSession:output_type -> daemonrpc.GetOORSessionResponse
-	70, // 87: daemonrpc.DaemonService.EstimateFee:output_type -> daemonrpc.EstimateFeeResponse
-	73, // 88: daemonrpc.DaemonService.GetFeeHistory:output_type -> daemonrpc.GetFeeHistoryResponse
-	75, // 89: daemonrpc.DaemonService.Unroll:output_type -> daemonrpc.UnrollResponse
-	77, // 90: daemonrpc.DaemonService.GetUnrollStatus:output_type -> daemonrpc.GetUnrollStatusResponse
-	61, // [61:91] is the sub-list for method output_type
-	31, // [31:61] is the sub-list for method input_type
-	31, // [31:31] is the sub-list for extension type_name
-	31, // [31:31] is the sub-list for extension extendee
-	0,  // [0:31] is the sub-list for field type_name
+	75, // 29: daemonrpc.ListTransactionsResponse.transactions:type_name -> daemonrpc.TransactionHistoryEntry
+	4,  // 30: daemonrpc.GetUnrollStatusResponse.status:type_name -> daemonrpc.UnrollJobStatus
+	44, // 31: daemonrpc.LeaveVTXOsRequest.DestinationsEntry.value:type_name -> daemonrpc.LeaveDestination
+	5,  // 32: daemonrpc.DaemonService.GetInfo:input_type -> daemonrpc.GetInfoRequest
+	8,  // 33: daemonrpc.DaemonService.GenSeed:input_type -> daemonrpc.GenSeedRequest
+	10, // 34: daemonrpc.DaemonService.InitWallet:input_type -> daemonrpc.InitWalletRequest
+	12, // 35: daemonrpc.DaemonService.UnlockWallet:input_type -> daemonrpc.UnlockWalletRequest
+	14, // 36: daemonrpc.DaemonService.GetBalance:input_type -> daemonrpc.GetBalanceRequest
+	17, // 37: daemonrpc.DaemonService.ListVTXOs:input_type -> daemonrpc.ListVTXOsRequest
+	19, // 38: daemonrpc.DaemonService.NewAddress:input_type -> daemonrpc.NewAddressRequest
+	21, // 39: daemonrpc.DaemonService.NewReceiveScript:input_type -> daemonrpc.NewReceiveScriptRequest
+	23, // 40: daemonrpc.DaemonService.ReceiveAuthKey:input_type -> daemonrpc.ReceiveAuthKeyRequest
+	25, // 41: daemonrpc.DaemonService.SignReceiveAuthMessage:input_type -> daemonrpc.SignReceiveAuthMessageRequest
+	27, // 42: daemonrpc.DaemonService.SignReceiveAuthMessageCompact:input_type -> daemonrpc.SignReceiveAuthMessageCompactRequest
+	29, // 43: daemonrpc.DaemonService.ReceiveAuthECDH:input_type -> daemonrpc.ReceiveAuthECDHRequest
+	31, // 44: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:input_type -> daemonrpc.GetIndexedVTXOByPkScriptRequest
+	33, // 45: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:input_type -> daemonrpc.GetIndexedOORSessionByTxidRequest
+	36, // 46: daemonrpc.DaemonService.SendVTXO:input_type -> daemonrpc.SendVTXORequest
+	38, // 47: daemonrpc.DaemonService.SendOOR:input_type -> daemonrpc.SendOORRequest
+	42, // 48: daemonrpc.DaemonService.RefreshVTXOs:input_type -> daemonrpc.RefreshVTXOsRequest
+	45, // 49: daemonrpc.DaemonService.LeaveVTXOs:input_type -> daemonrpc.LeaveVTXOsRequest
+	47, // 50: daemonrpc.DaemonService.Board:input_type -> daemonrpc.BoardRequest
+	49, // 51: daemonrpc.DaemonService.SweepBoardingUTXOs:input_type -> daemonrpc.SweepBoardingUTXOsRequest
+	52, // 52: daemonrpc.DaemonService.ListBoardingSweeps:input_type -> daemonrpc.ListBoardingSweepsRequest
+	58, // 53: daemonrpc.DaemonService.ListRounds:input_type -> daemonrpc.ListRoundsRequest
+	59, // 54: daemonrpc.DaemonService.GetRound:input_type -> daemonrpc.GetRoundRequest
+	62, // 55: daemonrpc.DaemonService.WatchRounds:input_type -> daemonrpc.WatchRoundsRequest
+	65, // 56: daemonrpc.DaemonService.ListOORSessions:input_type -> daemonrpc.ListOORSessionsRequest
+	67, // 57: daemonrpc.DaemonService.GetOORSession:input_type -> daemonrpc.GetOORSessionRequest
+	69, // 58: daemonrpc.DaemonService.EstimateFee:input_type -> daemonrpc.EstimateFeeRequest
+	71, // 59: daemonrpc.DaemonService.GetFeeHistory:input_type -> daemonrpc.GetFeeHistoryRequest
+	74, // 60: daemonrpc.DaemonService.ListTransactions:input_type -> daemonrpc.ListTransactionsRequest
+	77, // 61: daemonrpc.DaemonService.Unroll:input_type -> daemonrpc.UnrollRequest
+	79, // 62: daemonrpc.DaemonService.GetUnrollStatus:input_type -> daemonrpc.GetUnrollStatusRequest
+	6,  // 63: daemonrpc.DaemonService.GetInfo:output_type -> daemonrpc.GetInfoResponse
+	9,  // 64: daemonrpc.DaemonService.GenSeed:output_type -> daemonrpc.GenSeedResponse
+	11, // 65: daemonrpc.DaemonService.InitWallet:output_type -> daemonrpc.InitWalletResponse
+	13, // 66: daemonrpc.DaemonService.UnlockWallet:output_type -> daemonrpc.UnlockWalletResponse
+	15, // 67: daemonrpc.DaemonService.GetBalance:output_type -> daemonrpc.GetBalanceResponse
+	18, // 68: daemonrpc.DaemonService.ListVTXOs:output_type -> daemonrpc.ListVTXOsResponse
+	20, // 69: daemonrpc.DaemonService.NewAddress:output_type -> daemonrpc.NewAddressResponse
+	22, // 70: daemonrpc.DaemonService.NewReceiveScript:output_type -> daemonrpc.NewReceiveScriptResponse
+	24, // 71: daemonrpc.DaemonService.ReceiveAuthKey:output_type -> daemonrpc.ReceiveAuthKeyResponse
+	26, // 72: daemonrpc.DaemonService.SignReceiveAuthMessage:output_type -> daemonrpc.SignReceiveAuthMessageResponse
+	28, // 73: daemonrpc.DaemonService.SignReceiveAuthMessageCompact:output_type -> daemonrpc.SignReceiveAuthMessageCompactResponse
+	30, // 74: daemonrpc.DaemonService.ReceiveAuthECDH:output_type -> daemonrpc.ReceiveAuthECDHResponse
+	32, // 75: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:output_type -> daemonrpc.GetIndexedVTXOByPkScriptResponse
+	34, // 76: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:output_type -> daemonrpc.GetIndexedOORSessionByTxidResponse
+	37, // 77: daemonrpc.DaemonService.SendVTXO:output_type -> daemonrpc.SendVTXOResponse
+	40, // 78: daemonrpc.DaemonService.SendOOR:output_type -> daemonrpc.SendOORResponse
+	43, // 79: daemonrpc.DaemonService.RefreshVTXOs:output_type -> daemonrpc.RefreshVTXOsResponse
+	46, // 80: daemonrpc.DaemonService.LeaveVTXOs:output_type -> daemonrpc.LeaveVTXOsResponse
+	48, // 81: daemonrpc.DaemonService.Board:output_type -> daemonrpc.BoardResponse
+	51, // 82: daemonrpc.DaemonService.SweepBoardingUTXOs:output_type -> daemonrpc.SweepBoardingUTXOsResponse
+	55, // 83: daemonrpc.DaemonService.ListBoardingSweeps:output_type -> daemonrpc.ListBoardingSweepsResponse
+	61, // 84: daemonrpc.DaemonService.ListRounds:output_type -> daemonrpc.ListRoundsResponse
+	60, // 85: daemonrpc.DaemonService.GetRound:output_type -> daemonrpc.GetRoundResponse
+	63, // 86: daemonrpc.DaemonService.WatchRounds:output_type -> daemonrpc.WatchRoundsResponse
+	66, // 87: daemonrpc.DaemonService.ListOORSessions:output_type -> daemonrpc.ListOORSessionsResponse
+	68, // 88: daemonrpc.DaemonService.GetOORSession:output_type -> daemonrpc.GetOORSessionResponse
+	70, // 89: daemonrpc.DaemonService.EstimateFee:output_type -> daemonrpc.EstimateFeeResponse
+	73, // 90: daemonrpc.DaemonService.GetFeeHistory:output_type -> daemonrpc.GetFeeHistoryResponse
+	76, // 91: daemonrpc.DaemonService.ListTransactions:output_type -> daemonrpc.ListTransactionsResponse
+	78, // 92: daemonrpc.DaemonService.Unroll:output_type -> daemonrpc.UnrollResponse
+	80, // 93: daemonrpc.DaemonService.GetUnrollStatus:output_type -> daemonrpc.GetUnrollStatusResponse
+	63, // [63:94] is the sub-list for method output_type
+	32, // [32:63] is the sub-list for method input_type
+	32, // [32:32] is the sub-list for extension type_name
+	32, // [32:32] is the sub-list for extension extendee
+	0,  // [0:32] is the sub-list for field type_name
 }
 
 func init() { file_daemon_proto_init() }
@@ -6170,7 +6536,7 @@ func file_daemon_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_daemon_proto_rawDesc), len(file_daemon_proto_rawDesc)),
 			NumEnums:      5,
-			NumMessages:   74,
+			NumMessages:   77,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/daemonrpc/daemon.proto
+++ b/daemonrpc/daemon.proto
@@ -143,6 +143,11 @@ service DaemonService {
     // client's local accounting database.
     rpc GetFeeHistory (GetFeeHistoryRequest) returns (GetFeeHistoryResponse);
 
+    // ListTransactions returns a paginated transaction history from
+    // the client's local accounting and sweep databases.
+    rpc ListTransactions (ListTransactionsRequest)
+        returns (ListTransactionsResponse);
+
     // Unroll triggers a unilateral exit for the specified VTXO outpoint.
     // The daemon will assemble the recovery proof, spawn a durable unroll
     // job, and drive the on-chain recovery process to completion.
@@ -1338,6 +1343,95 @@ message GetFeeHistoryResponse {
     // total_fees_paid_sat is the cumulative total of all fees
     // paid by this client.
     int64 total_fees_paid_sat = 2;
+}
+
+message ListTransactionsRequest {
+    // from_unix_s filters entries created at or after this Unix timestamp.
+    // A zero value leaves the lower bound open.
+    int64 from_unix_s = 1;
+
+    // to_unix_s filters entries created at or before this Unix timestamp. A
+    // zero value leaves the upper bound open.
+    int64 to_unix_s = 2;
+
+    // limit bounds the number of results. Zero uses the daemon default.
+    uint32 limit = 3;
+
+    // offset is the number of filtered entries to skip.
+    uint32 offset = 4;
+
+    // type filters entries by high-level transaction type. Accepted values
+    // are "boarding", "round", "oor", and "sweep". Empty lists all.
+    // "sweep" includes tracked boarding sweep transactions and
+    // chain-sweep-related ledger entries, such as unilateral-exit
+    // onchain_fee_paid rows.
+    string type = 5;
+}
+
+message TransactionHistoryEntry {
+    // source names the local persistence source: "ledger" or
+    // "boarding_sweep".
+    string source = 1;
+
+    // type is the high-level category: "boarding", "round", "oor", or
+    // "sweep".
+    string type = 2;
+
+    // subtype carries the ledger event type or sweep lifecycle status.
+    string subtype = 3;
+
+    // amount_sat is the gross transaction amount in satoshis.
+    int64 amount_sat = 4;
+
+    // fee_sat is set for persisted aggregate sweep transactions.
+    int64 fee_sat = 5;
+
+    // created_at_unix_s is the local Unix timestamp for the row.
+    int64 created_at_unix_s = 6;
+
+    // confirmation_status is "confirmed", "recorded", or the persisted
+    // aggregate sweep status.
+    string confirmation_status = 7;
+
+    // description is a human-readable local note.
+    string description = 8;
+
+    // entry_id is set for ledger-backed rows.
+    int64 entry_id = 9;
+
+    // txid is set for transaction-backed rows such as aggregate boarding
+    // sweeps.
+    string txid = 10;
+
+    // debit_account names the account debited by a ledger-backed row.
+    string debit_account = 11;
+
+    // credit_account names the account credited by a ledger-backed row.
+    string credit_account = 12;
+
+    // round_id is the 16-byte round UUID associated with the row, when
+    // applicable.
+    bytes round_id = 13;
+
+    // session_id is the 32-byte OOR session identifier associated with the
+    // row, when applicable.
+    bytes session_id = 14;
+
+    // confirmation_height is set when the source records a chain
+    // confirmation height.
+    int32 confirmation_height = 15;
+}
+
+message ListTransactionsResponse {
+    // transactions are returned newest first by created_at_unix_s.
+    repeated TransactionHistoryEntry transactions = 1;
+
+    // next_offset is the offset to pass to the next request when has_more is
+    // true.
+    uint32 next_offset = 2;
+
+    // has_more is true when another page is available.
+    bool has_more = 3;
 }
 
 message UnrollRequest {

--- a/daemonrpc/daemon_grpc.pb.go
+++ b/daemonrpc/daemon_grpc.pb.go
@@ -47,6 +47,7 @@ const (
 	DaemonService_GetOORSession_FullMethodName                 = "/daemonrpc.DaemonService/GetOORSession"
 	DaemonService_EstimateFee_FullMethodName                   = "/daemonrpc.DaemonService/EstimateFee"
 	DaemonService_GetFeeHistory_FullMethodName                 = "/daemonrpc.DaemonService/GetFeeHistory"
+	DaemonService_ListTransactions_FullMethodName              = "/daemonrpc.DaemonService/ListTransactions"
 	DaemonService_Unroll_FullMethodName                        = "/daemonrpc.DaemonService/Unroll"
 	DaemonService_GetUnrollStatus_FullMethodName               = "/daemonrpc.DaemonService/GetUnrollStatus"
 )
@@ -157,6 +158,9 @@ type DaemonServiceClient interface {
 	// GetFeeHistory returns paginated fee ledger entries from the
 	// client's local accounting database.
 	GetFeeHistory(ctx context.Context, in *GetFeeHistoryRequest, opts ...grpc.CallOption) (*GetFeeHistoryResponse, error)
+	// ListTransactions returns a paginated transaction history from
+	// the client's local accounting and sweep databases.
+	ListTransactions(ctx context.Context, in *ListTransactionsRequest, opts ...grpc.CallOption) (*ListTransactionsResponse, error)
 	// Unroll triggers a unilateral exit for the specified VTXO outpoint.
 	// The daemon will assemble the recovery proof, spawn a durable unroll
 	// job, and drive the on-chain recovery process to completion.
@@ -464,6 +468,16 @@ func (c *daemonServiceClient) GetFeeHistory(ctx context.Context, in *GetFeeHisto
 	return out, nil
 }
 
+func (c *daemonServiceClient) ListTransactions(ctx context.Context, in *ListTransactionsRequest, opts ...grpc.CallOption) (*ListTransactionsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListTransactionsResponse)
+	err := c.cc.Invoke(ctx, DaemonService_ListTransactions_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *daemonServiceClient) Unroll(ctx context.Context, in *UnrollRequest, opts ...grpc.CallOption) (*UnrollResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(UnrollResponse)
@@ -590,6 +604,9 @@ type DaemonServiceServer interface {
 	// GetFeeHistory returns paginated fee ledger entries from the
 	// client's local accounting database.
 	GetFeeHistory(context.Context, *GetFeeHistoryRequest) (*GetFeeHistoryResponse, error)
+	// ListTransactions returns a paginated transaction history from
+	// the client's local accounting and sweep databases.
+	ListTransactions(context.Context, *ListTransactionsRequest) (*ListTransactionsResponse, error)
 	// Unroll triggers a unilateral exit for the specified VTXO outpoint.
 	// The daemon will assemble the recovery proof, spawn a durable unroll
 	// job, and drive the on-chain recovery process to completion.
@@ -691,6 +708,9 @@ func (UnimplementedDaemonServiceServer) EstimateFee(context.Context, *EstimateFe
 }
 func (UnimplementedDaemonServiceServer) GetFeeHistory(context.Context, *GetFeeHistoryRequest) (*GetFeeHistoryResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetFeeHistory not implemented")
+}
+func (UnimplementedDaemonServiceServer) ListTransactions(context.Context, *ListTransactionsRequest) (*ListTransactionsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListTransactions not implemented")
 }
 func (UnimplementedDaemonServiceServer) Unroll(context.Context, *UnrollRequest) (*UnrollResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Unroll not implemented")
@@ -1216,6 +1236,24 @@ func _DaemonService_GetFeeHistory_Handler(srv interface{}, ctx context.Context, 
 	return interceptor(ctx, in, info, handler)
 }
 
+func _DaemonService_ListTransactions_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListTransactionsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DaemonServiceServer).ListTransactions(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DaemonService_ListTransactions_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DaemonServiceServer).ListTransactions(ctx, req.(*ListTransactionsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _DaemonService_Unroll_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(UnrollRequest)
 	if err := dec(in); err != nil {
@@ -1366,6 +1404,10 @@ var DaemonService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetFeeHistory",
 			Handler:    _DaemonService_GetFeeHistory_Handler,
+		},
+		{
+			MethodName: "ListTransactions",
+			Handler:    _DaemonService_ListTransactions_Handler,
 		},
 		{
 			MethodName: "Unroll",

--- a/daemonrpc/daemon_mailboxrpc.pb.go
+++ b/daemonrpc/daemon_mailboxrpc.pb.go
@@ -80,6 +80,8 @@ type DaemonServiceMailboxServer interface {
 	EstimateFee(ctx context.Context, req *EstimateFeeRequest) (*EstimateFeeResponse, error)
 	// GetFeeHistory handles GetFeeHistory.
 	GetFeeHistory(ctx context.Context, req *GetFeeHistoryRequest) (*GetFeeHistoryResponse, error)
+	// ListTransactions handles ListTransactions.
+	ListTransactions(ctx context.Context, req *ListTransactionsRequest) (*ListTransactionsResponse, error)
 	// Unroll handles Unroll.
 	Unroll(ctx context.Context, req *UnrollRequest) (*UnrollResponse, error)
 	// GetUnrollStatus handles GetUnrollStatus.
@@ -367,6 +369,16 @@ func RegisterDaemonServiceMailboxServer(r rpc.Router, impl DaemonServiceMailboxS
 		}
 
 		return impl.GetFeeHistory(ctx, req)
+	})
+	r.Handle("daemonrpc.DaemonService", "ListTransactions", func() proto.Message {
+		return &ListTransactionsRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*ListTransactionsRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.ListTransactions(ctx, req)
 	})
 	r.Handle("daemonrpc.DaemonService", "Unroll", func() proto.Message {
 		return &UnrollRequest{}
@@ -1027,6 +1039,29 @@ func (c *DaemonServiceMailboxClient) GetFeeHistory(ctx context.Context, req *Get
 	}
 
 	resp := new(GetFeeHistoryResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// ListTransactions calls the ListTransactions RPC.
+func (c *DaemonServiceMailboxClient) ListTransactions(ctx context.Context, req *ListTransactionsRequest, opts ...rpc.RPCOptions) (*ListTransactionsResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "daemonrpc.DaemonService",
+		Method:  "ListTransactions",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(ListTransactionsResponse)
 	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
 		return nil, err
 	}

--- a/darepod/rpc_fees.go
+++ b/darepod/rpc_fees.go
@@ -2,9 +2,11 @@ package darepod
 
 import (
 	"context"
+	"fmt"
 	"math"
 
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/lightninglabs/darepo-client/arkrpc"
 	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/lightninglabs/darepo-client/db/sqlc"
@@ -20,6 +22,9 @@ import (
 const (
 	maxFeeHistoryLimit     = 1000
 	defaultFeeHistoryLimit = 50
+
+	maxTransactionHistoryLimit     = 1000
+	defaultTransactionHistoryLimit = 50
 )
 
 // quoteOperatorFee asks the operator's EstimateFee RPC for the
@@ -282,6 +287,95 @@ func (r *RPCServer) GetFeeHistory(ctx context.Context,
 	}, nil
 }
 
+// ListTransactions returns a unified newest-first history page from the
+// client's local accounting and sweep databases. The ledger actor owns all
+// writes; this RPC only reads committed rows and applies filters before
+// pagination in SQL.
+func (r *RPCServer) ListTransactions(ctx context.Context,
+	req *daemonrpc.ListTransactionsRequest) (
+	*daemonrpc.ListTransactionsResponse, error) {
+
+	if req == nil {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"request is required")
+	}
+	if req.Offset > math.MaxInt32 {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"offset must be <= %d", math.MaxInt32)
+	}
+	if req.FromUnixS < 0 {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"from_unix_s must be non-negative")
+	}
+	if req.ToUnixS < 0 {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"to_unix_s must be non-negative")
+	}
+	if req.FromUnixS != 0 && req.ToUnixS != 0 &&
+		req.FromUnixS > req.ToUnixS {
+
+		return nil, status.Errorf(codes.InvalidArgument,
+			"from_unix_s must be <= to_unix_s")
+	}
+	if !transactionTypeFilterValid(req.Type) {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"unknown transaction type %q", req.Type)
+	}
+	if r.server.ledgerStore == nil {
+		return nil, status.Errorf(codes.Unavailable,
+			"ledger store not initialized")
+	}
+
+	limit := req.Limit
+	switch {
+	case limit == 0:
+		limit = defaultTransactionHistoryLimit
+	case limit > maxTransactionHistoryLimit:
+		limit = maxTransactionHistoryLimit
+	}
+
+	rows, err := r.server.ledgerStore.ListTransactionHistory(
+		ctx, req.Type, req.FromUnixS, req.ToUnixS,
+		int32(limit)+1, int32(req.Offset),
+	)
+	if err != nil {
+		r.server.log.WarnS(ctx,
+			"ListTransactions history read failed", err)
+
+		return nil, status.Error(codes.Internal,
+			"transaction history read failed")
+	}
+
+	hasMore := len(rows) > int(limit)
+	if hasMore {
+		rows = rows[:limit]
+	}
+
+	entries := make([]*daemonrpc.TransactionHistoryEntry, 0, len(rows))
+	for i := range rows {
+		entry, err := transactionHistoryRowToProto(&rows[i])
+		if err != nil {
+			r.server.log.WarnS(ctx,
+				"ListTransactions row conversion failed", err)
+
+			return nil, status.Error(codes.Internal,
+				"transaction history conversion failed")
+		}
+
+		entries = append(entries, entry)
+	}
+
+	resp := &daemonrpc.ListTransactionsResponse{
+		Transactions: entries,
+		HasMore:      hasMore,
+	}
+	if hasMore {
+		resp.NextOffset = req.Offset + limit
+	}
+
+	return resp, nil
+}
+
 // proxyUpstreamError returns a gRPC status error for a proxied
 // upstream call. When the upstream error carries a gRPC status,
 // its code is preserved so client-side retry/backoff logic still
@@ -322,4 +416,69 @@ func ledgerEntryToProto(
 		RoundId:        row.RoundID,
 		SessionId:      row.SessionID,
 	}
+}
+
+// transactionTypeFilterValid returns true for the public high-level
+// transaction history categories accepted by ListTransactions.
+func transactionTypeFilterValid(filter string) bool {
+	switch filter {
+	case "", "boarding", "round", "oor", "sweep":
+		return true
+
+	default:
+		return false
+	}
+}
+
+// transactionHistoryRowToProto converts the sqlc union row into its
+// public RPC representation.
+func transactionHistoryRowToProto(
+	row *sqlc.ListTransactionHistoryRow) (
+	*daemonrpc.TransactionHistoryEntry, error) {
+
+	txid, err := transactionHistoryTxID(row.Txid)
+	if err != nil {
+		return nil, err
+	}
+
+	return &daemonrpc.TransactionHistoryEntry{
+		Source:             row.Source,
+		Type:               row.TransactionType,
+		Subtype:            row.Subtype,
+		AmountSat:          row.AmountSat,
+		FeeSat:             row.FeeSat,
+		CreatedAtUnixS:     row.CreatedAt,
+		ConfirmationStatus: row.Status,
+		Description:        row.Description,
+		EntryId:            row.EntryID,
+		Txid:               txid,
+		DebitAccount:       row.DebitAccount,
+		CreditAccount:      row.CreditAccount,
+		RoundId:            row.RoundID,
+		SessionId:          row.SessionID,
+		ConfirmationHeight: row.ConfirmationHeight,
+	}, nil
+}
+
+// transactionHistoryTxID normalizes the nullable sqlc txid union column
+// into the human-readable chainhash string used elsewhere in the RPC API.
+func transactionHistoryTxID(raw any) (string, error) {
+	if raw == nil {
+		return "", nil
+	}
+
+	txidBytes, ok := raw.([]byte)
+	if !ok {
+		return "", fmt.Errorf("unexpected txid type %T", raw)
+	}
+	if len(txidBytes) == 0 {
+		return "", nil
+	}
+
+	txid, err := chainhash.NewHash(txidBytes)
+	if err != nil {
+		return "", fmt.Errorf("decode txid: %w", err)
+	}
+
+	return txid.String(), nil
 }

--- a/darepod/rpc_fees_test.go
+++ b/darepod/rpc_fees_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/arkrpc"
 	"github.com/lightninglabs/darepo-client/daemonrpc"
@@ -115,6 +116,80 @@ func TestGetFeeHistoryValidatesRequest(t *testing.T) {
 			r := newTestRPCServer()
 
 			_, err := r.GetFeeHistory(t.Context(), tc.req)
+			require.Error(t, err)
+			require.Equal(t, tc.code, status.Code(err),
+				"expected %s, got %s: %v",
+				tc.code, status.Code(err), err)
+		})
+	}
+}
+
+// TestListTransactionsValidatesRequest covers ListTransactions' pre-read
+// guards so malformed pagination, date windows, and type filters fail before
+// the DB layer is touched.
+func TestListTransactionsValidatesRequest(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		req  *daemonrpc.ListTransactionsRequest
+		code codes.Code
+	}{
+		{
+			name: "nil request",
+			req:  nil,
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "offset overflow",
+			req: &daemonrpc.ListTransactionsRequest{
+				Offset: uint32(math.MaxInt32) + 1,
+			},
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "negative from",
+			req: &daemonrpc.ListTransactionsRequest{
+				FromUnixS: -1,
+			},
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "negative to",
+			req: &daemonrpc.ListTransactionsRequest{
+				ToUnixS: -1,
+			},
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "inverted window",
+			req: &daemonrpc.ListTransactionsRequest{
+				FromUnixS: 20,
+				ToUnixS:   10,
+			},
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "unknown type",
+			req: &daemonrpc.ListTransactionsRequest{
+				Type: "bogus",
+			},
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "nil ledger store",
+			req: &daemonrpc.ListTransactionsRequest{
+				Limit: 10,
+			},
+			code: codes.Unavailable,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := newTestRPCServer()
+
+			_, err := r.ListTransactions(t.Context(), tc.req)
 			require.Error(t, err)
 			require.Equal(t, tc.code, status.Code(err),
 				"expected %s, got %s: %v",
@@ -430,4 +505,85 @@ func TestLedgerEntryToProtoExitCost(t *testing.T) {
 	require.Equal(t, ledger.EventOnchainFeePaid, got.EventType)
 	require.Empty(t, got.RoundId)
 	require.Empty(t, got.SessionId)
+}
+
+// TestTransactionHistoryRowToProtoLedger verifies that a ledger-backed
+// transaction row maps the common history fields and leaves txid empty.
+func TestTransactionHistoryRowToProtoLedger(t *testing.T) {
+	t.Parallel()
+
+	row := &sqlc.ListTransactionHistoryRow{
+		Source:          "ledger",
+		EntryID:         99,
+		TransactionType: "oor",
+		Subtype:         ledger.EventVTXOSent,
+		AmountSat:       12_000,
+		FeeSat:          0,
+		CreatedAt:       1_700_000_300,
+		Status:          "recorded",
+		Description:     "oor send",
+		DebitAccount:    ledger.AccountTransfersOut,
+		CreditAccount:   ledger.AccountVTXOBalance,
+		SessionID:       make([]byte, 32),
+	}
+
+	got, err := transactionHistoryRowToProto(row)
+	require.NoError(t, err)
+
+	require.Equal(t, "ledger", got.Source)
+	require.Equal(t, "oor", got.Type)
+	require.Equal(t, ledger.EventVTXOSent, got.Subtype)
+	require.Equal(t, int64(12_000), got.AmountSat)
+	require.Equal(t, int64(1_700_000_300), got.CreatedAtUnixS)
+	require.Equal(t, "recorded", got.ConfirmationStatus)
+	require.Equal(t, int64(99), got.EntryId)
+	require.Empty(t, got.Txid)
+	require.Equal(t, ledger.AccountTransfersOut, got.DebitAccount)
+	require.Equal(t, ledger.AccountVTXOBalance, got.CreditAccount)
+}
+
+// TestTransactionHistoryRowToProtoSweep verifies sweep-backed rows expose the
+// transaction id, fee, and confirmation height fields.
+func TestTransactionHistoryRowToProtoSweep(t *testing.T) {
+	t.Parallel()
+
+	txidBytes := make([]byte, chainhash.HashSize)
+	for i := range txidBytes {
+		txidBytes[i] = byte(i + 1)
+	}
+	wantTxid, err := chainhash.NewHash(txidBytes)
+	require.NoError(t, err)
+
+	row := &sqlc.ListTransactionHistoryRow{
+		Source:             "boarding_sweep",
+		Txid:               txidBytes,
+		TransactionType:    "sweep",
+		Subtype:            "confirmed",
+		AmountSat:          50_000,
+		FeeSat:             500,
+		CreatedAt:          1_700_000_400,
+		Status:             "confirmed",
+		Description:        "boarding timeout sweep",
+		ConfirmationHeight: 144,
+	}
+
+	got, err := transactionHistoryRowToProto(row)
+	require.NoError(t, err)
+
+	require.Equal(t, "sweep", got.Type)
+	require.Equal(t, wantTxid.String(), got.Txid)
+	require.Equal(t, int64(500), got.FeeSat)
+	require.Equal(t, int32(144), got.ConfirmationHeight)
+}
+
+// TestTransactionHistoryRowToProtoRejectsBadTxID pins corrupted sweep history
+// handling: bad txid blobs fail conversion rather than returning misleading
+// history.
+func TestTransactionHistoryRowToProtoRejectsBadTxID(t *testing.T) {
+	t.Parallel()
+
+	_, err := transactionHistoryRowToProto(&sqlc.ListTransactionHistoryRow{
+		Txid: []byte{1, 2, 3},
+	})
+	require.ErrorContains(t, err, "decode txid")
 }

--- a/db/ledger_store.go
+++ b/db/ledger_store.go
@@ -198,6 +198,37 @@ func (s *LedgerStoreDB) ListLedgerEntriesByType(ctx context.Context,
 	return entries, err
 }
 
+// ListTransactionHistory returns a unified newest-first page of
+// ledger-backed activity and tracked boarding sweep transactions. The
+// type and timestamp filters are applied in SQL before pagination so a
+// filtered request never returns an empty page just because earlier
+// unfiltered rows did not match.
+func (s *LedgerStoreDB) ListTransactionHistory(ctx context.Context,
+	typeFilter string, fromUnixS, toUnixS int64, limit, offset int32) (
+	[]sqlc.ListTransactionHistoryRow, error) {
+
+	var entries []sqlc.ListTransactionHistoryRow
+	err := s.ExecTx(
+		ctx, ReadTxOption(),
+		func(qtx *sqlc.Queries) error {
+			var txErr error
+			entries, txErr = qtx.ListTransactionHistory(
+				ctx, sqlc.ListTransactionHistoryParams{
+					TypeFilter: typeFilter,
+					FromUnixS:  fromUnixS,
+					ToUnixS:    toUnixS,
+					PageLimit:  limit,
+					PageOffset: offset,
+				},
+			)
+
+			return txErr
+		},
+	)
+
+	return entries, err
+}
+
 // CountLedgerEntries returns the total number of ledger entries within
 // a read transaction.
 func (s *LedgerStoreDB) CountLedgerEntries(

--- a/db/ledger_store_test.go
+++ b/db/ledger_store_test.go
@@ -57,6 +57,44 @@ func makeLedgerEntry(debit, credit string, amount int64,
 	}
 }
 
+// testBytes returns a deterministic byte slice with the requested length.
+func testBytes(length int, seed byte) []byte {
+	out := make([]byte, length)
+	for i := range out {
+		out[i] = seed + byte(i)
+	}
+
+	return out
+}
+
+// insertTransactionHistorySweepRow inserts a minimal boarding_sweeps row for
+// transaction-history tests. The history query does not need sweep inputs.
+func insertTransactionHistorySweepRow(t *testing.T, db *BaseDB, txid []byte,
+	amount, fee, createdAt int64) {
+
+	t.Helper()
+
+	query := `INSERT INTO boarding_sweeps (
+		txid, raw_tx, destination_address, total_amount,
+		fee_amount, fee_rate_sat_per_vbyte, vbytes, status,
+		created_height, created_time
+	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	if db.Backend() == sqlc.BackendTypePostgres {
+		query = `INSERT INTO boarding_sweeps (
+			txid, raw_tx, destination_address, total_amount,
+			fee_amount, fee_rate_sat_per_vbyte, vbytes, status,
+			created_height, created_time
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`
+	}
+
+	_, err := db.ExecContext(
+		t.Context(), query, txid, []byte{0x01}, "bcrt1test",
+		amount, fee, int64(2), int64(120),
+		BoardingSweepStatusPublished, int32(700), createdAt,
+	)
+	require.NoError(t, err)
+}
+
 // TestLedgerStoreInsertAndRetrieve verifies that a single ledger entry
 // can be inserted and retrieved via ListLedgerEntries.
 func TestLedgerStoreInsertAndRetrieve(t *testing.T) {
@@ -87,6 +125,73 @@ func TestLedgerStoreInsertAndRetrieve(t *testing.T) {
 	require.Equal(t, entry.EventType, got.EventType)
 	require.Equal(t, entry.Description, got.Description)
 	require.Equal(t, entry.CreatedAt, got.CreatedAt)
+}
+
+// TestLedgerStoreTransactionHistoryFiltersBeforePagination verifies the
+// unified transaction-history query applies type and date filters before
+// LIMIT/OFFSET. A filtered page should find matching older rows instead of
+// returning empty just because newer rows have different types.
+func TestLedgerStoreTransactionHistoryFiltersBeforePagination(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store, db := newLedgerStoreAndDBForTest(t)
+
+	require.NoError(t, store.InsertLedgerEntry(ctx, ledger.LedgerEntry{
+		DebitAccount:  ledger.AccountTransfersOut,
+		CreditAccount: ledger.AccountVTXOBalance,
+		AmountSat:     1_000,
+		SessionID:     testBytes(32, 1),
+		EventType:     ledger.EventVTXOSent,
+		Description:   "oor send",
+		CreatedAt:     100,
+	}))
+	require.NoError(t, store.InsertLedgerEntry(ctx, ledger.LedgerEntry{
+		DebitAccount:  ledger.AccountVTXOBalance,
+		CreditAccount: ledger.AccountWalletBalance,
+		AmountSat:     2_000,
+		RoundID:       testBytes(16, 2),
+		EventType:     ledger.EventVTXOReceived,
+		Description:   "round receive",
+		CreatedAt:     200,
+	}))
+	require.NoError(t, store.InsertLedgerEntry(ctx, ledger.LedgerEntry{
+		DebitAccount:   ledger.AccountWalletBalance,
+		CreditAccount:  ledger.AccountOpeningBalance,
+		AmountSat:      3_000,
+		EventType:      ledger.EventWalletUTXOCreated,
+		Description:    "boarding deposit",
+		CreatedAt:      300,
+		IdempotencyKey: testBytes(36, 3),
+	}))
+	insertTransactionHistorySweepRow(
+		t, db, testBytes(32, 4), 4_000, 40, 400,
+	)
+
+	oorRows, err := store.ListTransactionHistory(ctx, "oor", 0, 0, 1, 0)
+	require.NoError(t, err)
+	require.Len(t, oorRows, 1)
+	require.Equal(t, "oor", oorRows[0].TransactionType)
+	require.Equal(t, int64(100), oorRows[0].CreatedAt)
+
+	windowRows, err := store.ListTransactionHistory(
+		ctx, "", 150, 350, 10, 0,
+	)
+	require.NoError(t, err)
+	require.Len(t, windowRows, 2)
+	require.Equal(t, []string{"boarding", "round"}, []string{
+		windowRows[0].TransactionType,
+		windowRows[1].TransactionType,
+	})
+
+	sweepRows, err := store.ListTransactionHistory(
+		ctx, "sweep", 0, 0, 10, 0,
+	)
+	require.NoError(t, err)
+	require.Len(t, sweepRows, 1)
+	require.Equal(t, "boarding_sweep", sweepRows[0].Source)
+	require.Equal(t, int64(4_000), sweepRows[0].AmountSat)
+	require.Equal(t, int64(40), sweepRows[0].FeeSat)
 }
 
 // TestLedgerStoreEntryIDsDoNotReuseAfterDelete verifies ledger entry IDs

--- a/db/sqlc/fee_accounting.sql.go
+++ b/db/sqlc/fee_accounting.sql.go
@@ -231,3 +231,143 @@ func (q *Queries) ListClientLedgerEntriesByType(ctx context.Context, arg ListCli
 	}
 	return items, nil
 }
+
+const ListTransactionHistory = `-- name: ListTransactionHistory :many
+SELECT source, entry_id, txid, transaction_type, subtype,
+       amount_sat, fee_sat, created_at, status, description,
+       debit_account, credit_account, round_id, session_id,
+       confirmation_height
+FROM (
+    SELECT 0 AS source_order,
+           'ledger' AS source,
+           entry_id,
+           NULL AS txid,
+           CASE
+               WHEN session_id IS NOT NULL THEN 'oor'
+               WHEN event_type IN (
+                   'boarding_fee_paid', 'wallet_utxo_created'
+               ) THEN 'boarding'
+               WHEN event_type = 'onchain_fee_paid' THEN 'sweep'
+               ELSE 'round'
+           END AS transaction_type,
+           event_type AS subtype,
+           amount_sat,
+           CAST(0 AS BIGINT) AS fee_sat,
+           created_at,
+           CASE
+               WHEN event_type = 'wallet_utxo_created' THEN 'confirmed'
+               ELSE 'recorded'
+           END AS status,
+           description,
+           debit_account,
+           credit_account,
+           round_id,
+           session_id,
+           CAST(0 AS INTEGER) AS confirmation_height
+    FROM ledger_entries
+
+    UNION ALL
+
+    SELECT 1 AS source_order,
+           'boarding_sweep' AS source,
+           CAST(0 AS BIGINT) AS entry_id,
+           txid,
+           'sweep' AS transaction_type,
+           status AS subtype,
+           total_amount AS amount_sat,
+           fee_amount AS fee_sat,
+           created_time AS created_at,
+           status,
+           'boarding timeout sweep' AS description,
+           '' AS debit_account,
+           '' AS credit_account,
+           NULL AS round_id,
+           NULL AS session_id,
+           COALESCE(confirmed_height, 0) AS confirmation_height
+    FROM boarding_sweeps
+) AS history
+WHERE ($1 = ''
+       OR transaction_type = $1)
+  AND ($2 = 0
+       OR created_at >= $2)
+  AND ($3 = 0
+       OR created_at <= $3)
+ORDER BY created_at DESC, source_order ASC, entry_id DESC, txid DESC
+LIMIT $5
+OFFSET $4
+`
+
+type ListTransactionHistoryParams struct {
+	TypeFilter interface{}
+	FromUnixS  interface{}
+	ToUnixS    interface{}
+	PageOffset int32
+	PageLimit  int32
+}
+
+type ListTransactionHistoryRow struct {
+	Source             string
+	EntryID            int64
+	Txid               interface{}
+	TransactionType    string
+	Subtype            string
+	AmountSat          int64
+	FeeSat             int64
+	CreatedAt          int64
+	Status             string
+	Description        string
+	DebitAccount       string
+	CreditAccount      string
+	RoundID            []byte
+	SessionID          []byte
+	ConfirmationHeight int32
+}
+
+// ListTransactionHistory returns a unified newest-first history from the
+// client-side ledger and tracked boarding sweep transactions. Filters are
+// applied before LIMIT/OFFSET so filtered pagination never skips over matching
+// rows hidden behind non-matching entries.
+func (q *Queries) ListTransactionHistory(ctx context.Context, arg ListTransactionHistoryParams) ([]ListTransactionHistoryRow, error) {
+	rows, err := q.db.QueryContext(ctx, ListTransactionHistory,
+		arg.TypeFilter,
+		arg.FromUnixS,
+		arg.ToUnixS,
+		arg.PageOffset,
+		arg.PageLimit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListTransactionHistoryRow
+	for rows.Next() {
+		var i ListTransactionHistoryRow
+		if err := rows.Scan(
+			&i.Source,
+			&i.EntryID,
+			&i.Txid,
+			&i.TransactionType,
+			&i.Subtype,
+			&i.AmountSat,
+			&i.FeeSat,
+			&i.CreatedAt,
+			&i.Status,
+			&i.Description,
+			&i.DebitAccount,
+			&i.CreditAccount,
+			&i.RoundID,
+			&i.SessionID,
+			&i.ConfirmationHeight,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -153,6 +153,11 @@ type Querier interface {
 	// ListRoundsPaginated returns rounds ordered by round_id with cursor-
 	// based pagination. When cursor is empty, returns from the beginning.
 	ListRoundsPaginated(ctx context.Context, arg ListRoundsPaginatedParams) ([]Round, error)
+	// ListTransactionHistory returns a unified newest-first history from the
+	// client-side ledger and tracked boarding sweep transactions. Filters are
+	// applied before LIMIT/OFFSET so filtered pagination never skips over matching
+	// rows hidden behind non-matching entries.
+	ListTransactionHistory(ctx context.Context, arg ListTransactionHistoryParams) ([]ListTransactionHistoryRow, error)
 	// ListUnspentVTXOAncestryPaths returns every ancestry row whose parent
 	// VTXO is unspent (status != 4 AND spent = FALSE), mirroring the filter
 	// on ListUnspentVTXOs. Companion to the round-side ListVTXOs path.

--- a/db/sqlc/queries/fee_accounting.sql
+++ b/db/sqlc/queries/fee_accounting.sql
@@ -39,6 +39,74 @@ WHERE event_type = $1
 ORDER BY created_at DESC
 LIMIT $2 OFFSET $3;
 
+-- name: ListTransactionHistory :many
+-- ListTransactionHistory returns a unified newest-first history from the
+-- client-side ledger and tracked boarding sweep transactions. Filters are
+-- applied before LIMIT/OFFSET so filtered pagination never skips over matching
+-- rows hidden behind non-matching entries.
+SELECT source, entry_id, txid, transaction_type, subtype,
+       amount_sat, fee_sat, created_at, status, description,
+       debit_account, credit_account, round_id, session_id,
+       confirmation_height
+FROM (
+    SELECT 0 AS source_order,
+           'ledger' AS source,
+           entry_id,
+           NULL AS txid,
+           CASE
+               WHEN session_id IS NOT NULL THEN 'oor'
+               WHEN event_type IN (
+                   'boarding_fee_paid', 'wallet_utxo_created'
+               ) THEN 'boarding'
+               WHEN event_type = 'onchain_fee_paid' THEN 'sweep'
+               ELSE 'round'
+           END AS transaction_type,
+           event_type AS subtype,
+           amount_sat,
+           CAST(0 AS BIGINT) AS fee_sat,
+           created_at,
+           CASE
+               WHEN event_type = 'wallet_utxo_created' THEN 'confirmed'
+               ELSE 'recorded'
+           END AS status,
+           description,
+           debit_account,
+           credit_account,
+           round_id,
+           session_id,
+           CAST(0 AS INTEGER) AS confirmation_height
+    FROM ledger_entries
+
+    UNION ALL
+
+    SELECT 1 AS source_order,
+           'boarding_sweep' AS source,
+           CAST(0 AS BIGINT) AS entry_id,
+           txid,
+           'sweep' AS transaction_type,
+           status AS subtype,
+           total_amount AS amount_sat,
+           fee_amount AS fee_sat,
+           created_time AS created_at,
+           status,
+           'boarding timeout sweep' AS description,
+           '' AS debit_account,
+           '' AS credit_account,
+           NULL AS round_id,
+           NULL AS session_id,
+           COALESCE(confirmed_height, 0) AS confirmation_height
+    FROM boarding_sweeps
+) AS history
+WHERE (sqlc.arg(type_filter) = ''
+       OR transaction_type = sqlc.arg(type_filter))
+  AND (sqlc.arg(from_unix_s) = 0
+       OR created_at >= sqlc.arg(from_unix_s))
+  AND (sqlc.arg(to_unix_s) = 0
+       OR created_at <= sqlc.arg(to_unix_s))
+ORDER BY created_at DESC, source_order ASC, entry_id DESC, txid DESC
+LIMIT sqlc.arg(page_limit)
+OFFSET sqlc.arg(page_offset);
+
 -- name: GetClientAccountBalance :one
 SELECT CAST(COALESCE(
     (SELECT SUM(le1.amount_sat) FROM ledger_entries le1

--- a/docs/daemon_cli_guide.md
+++ b/docs/daemon_cli_guide.md
@@ -322,6 +322,40 @@ darepocli send oor --pubkey <pubkey_xonly_hex> --amount 25000 --no-tls
 darepocli send oor --pk_script <pk_script_hex> --amount 25000 --no-tls
 ```
 
+#### `listtransactions`
+
+List local transaction history from the daemon's persisted accounting and
+boarding-sweep records. Entries are returned newest first and can be filtered
+by ISO 8601 timestamps or high-level type.
+
+The `sweep` type includes tracked boarding sweep transactions and
+chain-sweep-related ledger entries, such as unilateral-exit `onchain_fee_paid`
+fee rows. The `source` and `subtype` fields distinguish those cases in the
+response.
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--from` | string | Include entries at or after this ISO 8601 timestamp or date |
+| `--to` | string | Include entries at or before this ISO 8601 timestamp or date |
+| `--limit` | uint32 | Maximum entries to return |
+| `--offset` | uint32 | Number of filtered entries to skip |
+| `--type` | string | Optional filter: boarding, round, oor, or sweep |
+
+```bash
+# Recent local history
+darepocli listtransactions --limit 25 --no-tls
+
+# OOR history during a specific window
+darepocli listtransactions \
+  --type oor \
+  --from 2026-05-01T00:00:00Z \
+  --to 2026-05-08T23:59:59Z \
+  --no-tls
+
+# Second page of boarding-related entries
+darepocli listtransactions --type boarding --limit 50 --offset 50 --no-tls
+```
+
 #### `schema`
 
 Introspect available CLI commands and their parameters.


### PR DESCRIPTION
## Summary

Fixes #154.

Adds a `ListTransactions` daemon RPC and a top-level `darepocli listtransactions` command for browsing local transaction history.

The new history stream is built from committed local records:

- client ledger entries for boarding, round, and OOR accounting activity,
- tracked aggregate boarding sweeps from `boarding_sweeps`, including fee and confirmation status.

Entries are returned newest first and include amount, type, subtype, timestamp, source, confirmation status, and the relevant identifiers (`entry_id`, `txid`, `round_id`, `session_id`) when available.

## Filters and pagination

`darepocli listtransactions` supports:

- `--from` and `--to` ISO 8601 timestamp/date filters,
- `--limit` and `--offset` pagination,
- `--type boarding|round|oor|sweep`.

The backing SQL query applies type and timestamp filters before `LIMIT`/`OFFSET`, so filtered pages do not appear empty just because newer unfiltered rows did not match.

## Notes

Ledger-backed rows use `confirmation_status=recorded` for off-chain/accounting events and `confirmed` for wallet UTXO confirmation rows. Sweep-backed rows expose the persisted aggregate sweep status (`pending`, `published`, `confirmed`, `external_resolved`, or `failed`).

## Validation

```text
go test ./db ./darepod ./cmd/darepocli/darepoclicommands
go test ./...
make schema-check
make sqlc-check
GOGC=50 make lint
make commitmsg-lint range=origin/main..HEAD
```
