### PR TITLE
oor: make incoming limits configurable

### DIFF
--- a/cmd/darepod/main.go
+++ b/cmd/darepod/main.go
@@ -165,11 +165,62 @@ func newRootCmd() *cobra.Command {
 			"per seal-time quote; must be positive",
 	)
 
+	// OOR safety limits. These are advanced knobs; most operators
+	// should keep the defaults unless a limit-exceeded error says
+	// otherwise after a protocol upgrade or operator/indexer change.
+	f.Uint32("oor.limits.max-checkpoints", cfg.OOR.Limits.MaxCheckpoints,
+		"maximum checkpoint transactions allowed in one incoming "+
+			"OOR transfer; raise only if logs show "+
+			"\"max checkpoints exceeded\" after an "+
+			"Ark-protocol upgrade",
+	)
+	f.Uint32(
+		"oor.limits.max-vtxo-matches",
+		cfg.OOR.Limits.MaxVTXOMatches,
+		"maximum VTXOs returned by one indexer lookup during "+
+			"incoming OOR receive; raise only if logs show "+
+			"\"max metadata matches exceeded\"; higher values "+
+			"use more memory per query",
+	)
+	f.Uint32("oor.limits.max-mailbox-items",
+		cfg.OOR.Limits.MaxMailboxItems,
+		"safety cap on items decoded from one stored mailbox "+
+			"message; protects against malformed or oversized "+
+			"payloads",
+	)
+	f.Uint32(
+		"oor.limits.max-mailbox-script-bytes",
+		cfg.OOR.Limits.MaxMailboxScriptBytes,
+		"safety cap on the size of an address script stored "+
+			"in the mailbox, in bytes; standard Bitcoin scripts "+
+			"are well under 100; must be at least 34",
+	)
+
 	// Bind all flags to viper so Unmarshal populates the config
 	// struct from the combined flag/env/file sources.
 	v.SetEnvPrefix("DAREPOD")
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	v.AutomaticEnv()
+	// The CLI uses hyphenated operator-facing flag names, while
+	// mapstructure tags use the project's concatenated lowercase style.
+	// Bind explicit viper keys before BindPFlags adds the literal flag-name
+	// aliases.
+	_ = v.BindPFlag(
+		"oor.limits.maxcheckpoints",
+		f.Lookup("oor.limits.max-checkpoints"),
+	)
+	_ = v.BindPFlag(
+		"oor.limits.maxvtxomatches",
+		f.Lookup("oor.limits.max-vtxo-matches"),
+	)
+	_ = v.BindPFlag(
+		"oor.limits.maxmailboxitems",
+		f.Lookup("oor.limits.max-mailbox-items"),
+	)
+	_ = v.BindPFlag(
+		"oor.limits.maxmailboxscriptbytes",
+		f.Lookup("oor.limits.max-mailbox-script-bytes"),
+	)
 	_ = v.BindPFlags(f)
 
 	return cmd

--- a/darepod/config.go
+++ b/darepod/config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/lightninglabs/darepo-client/chainbackends"
 	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
+	"github.com/lightninglabs/darepo-client/oor"
 	"github.com/lightninglabs/darepo-client/rpc/roundpb"
 	"google.golang.org/grpc"
 )
@@ -180,6 +181,9 @@ type Config struct {
 	// (0.01 BTC), generous enough for regtest/testnet but well
 	// below any reasonable mainnet abuse threshold.
 	MaxOperatorFeeSat int64 `mapstructure:"maxoperatorfeesat"`
+
+	// OOR configures off-band receive/send actor behavior.
+	OOR *OORConfig `mapstructure:"oor"`
 }
 
 // RPCServiceRegistrar registers one optional daemon gRPC subserver on the
@@ -204,6 +208,63 @@ type UnrollConfig struct {
 	// MaxFeeRateSatPerVByte caps fee estimates to prevent runaway
 	// fees. Zero uses the default of 100 sat/vB.
 	MaxFeeRateSatPerVByte int64 `mapstructure:"maxfeeratesatpervbyte"`
+}
+
+// OORConfig configures off-band transfer actor behavior.
+type OORConfig struct {
+	// Limits configures advanced incoming OOR receive safety caps.
+	Limits *OORLimitsConfig `mapstructure:"limits"`
+}
+
+// OORLimitsConfig configures advanced incoming OOR receive safety caps.
+type OORLimitsConfig struct {
+	// MaxCheckpoints caps checkpoint transactions allowed in one incoming
+	// OOR transfer.
+	MaxCheckpoints uint32 `mapstructure:"maxcheckpoints"`
+
+	// MaxVTXOMatches caps VTXOs returned by one indexer lookup during
+	// incoming OOR receive.
+	MaxVTXOMatches uint32 `mapstructure:"maxvtxomatches"`
+
+	// MaxMailboxItems caps items decoded from one stored mailbox message.
+	MaxMailboxItems uint32 `mapstructure:"maxmailboxitems"`
+
+	// MaxMailboxScriptBytes caps address-script bytes decoded from one
+	// stored mailbox message.
+	MaxMailboxScriptBytes uint32 `mapstructure:"maxmailboxscriptbytes"`
+}
+
+// minOORMailboxScriptBytes is the smallest standard script cap accepted by
+// daemon config validation. It covers a v1 P2TR output script.
+const minOORMailboxScriptBytes uint32 = 34
+
+// defaultOORConfig returns daemon defaults for OOR actor settings.
+func defaultOORConfig() *OORConfig {
+	limits := oor.DefaultReceiveLimits()
+
+	return &OORConfig{
+		Limits: &OORLimitsConfig{
+			MaxCheckpoints:        limits.MaxCheckpoints,
+			MaxVTXOMatches:        limits.MaxVTXOMatches,
+			MaxMailboxItems:       limits.MaxMailboxItems,
+			MaxMailboxScriptBytes: limits.MaxMailboxScriptBytes,
+		},
+	}
+}
+
+// OORReceiveLimits returns the incoming OOR receive limits configured for this
+// daemon.
+func (c *Config) OORReceiveLimits() oor.ReceiveLimits {
+	if c == nil || c.OOR == nil || c.OOR.Limits == nil {
+		return oor.DefaultReceiveLimits()
+	}
+
+	return oor.ReceiveLimits{
+		MaxCheckpoints:        c.OOR.Limits.MaxCheckpoints,
+		MaxVTXOMatches:        c.OOR.Limits.MaxVTXOMatches,
+		MaxMailboxItems:       c.OOR.Limits.MaxMailboxItems,
+		MaxMailboxScriptBytes: c.OOR.Limits.MaxMailboxScriptBytes,
+	}
 }
 
 // SwapConfig configures the optional daemon-owned swap executor.
@@ -387,6 +448,7 @@ func DefaultConfig() *Config {
 			ServerAddress: "localhost:10030",
 		},
 		MaxOperatorFeeSat: DefaultMaxOperatorFeeSat,
+		OOR:               defaultOORConfig(),
 	}
 }
 
@@ -419,6 +481,16 @@ func (c *Config) Validate() error {
 			"maxoperatorfeesat must be positive: got %d",
 			c.MaxOperatorFeeSat,
 		)
+	}
+
+	if c.OOR == nil {
+		c.OOR = defaultOORConfig()
+	}
+	if c.OOR.Limits == nil {
+		c.OOR.Limits = defaultOORConfig().Limits
+	}
+	if err := validateOORLimitsConfig(c.OOR.Limits); err != nil {
+		return err
 	}
 
 	// Validate wallet config.
@@ -475,6 +547,39 @@ func (c *Config) Validate() error {
 	if c.RPC.Listener == nil && c.RPC.ListenAddr == "" {
 		return fmt.Errorf("rpc listen address or injected " +
 			"listener is required")
+	}
+
+	return nil
+}
+
+// validateOORLimitsConfig rejects OOR safety caps that would disable receive
+// decoding or make one configured cap impossible to satisfy under another.
+func validateOORLimitsConfig(limits *OORLimitsConfig) error {
+	if limits.MaxCheckpoints == 0 {
+		return fmt.Errorf("oor.limits.maxcheckpoints must be positive")
+	}
+
+	if limits.MaxVTXOMatches == 0 {
+		return fmt.Errorf("oor.limits.maxvtxomatches must be positive")
+	}
+
+	if limits.MaxMailboxItems == 0 {
+		return fmt.Errorf("oor.limits.maxmailboxitems must be positive")
+	}
+
+	if limits.MaxMailboxScriptBytes < minOORMailboxScriptBytes {
+		return fmt.Errorf("oor.limits.maxmailboxscriptbytes must be "+
+			"at least %d bytes", minOORMailboxScriptBytes)
+	}
+
+	if limits.MaxMailboxItems < limits.MaxCheckpoints {
+		return fmt.Errorf("oor.limits.maxmailboxitems must be >= " +
+			"oor.limits.maxcheckpoints")
+	}
+
+	if limits.MaxMailboxItems < limits.MaxVTXOMatches {
+		return fmt.Errorf("oor.limits.maxmailboxitems must be >= " +
+			"oor.limits.maxvtxomatches")
 	}
 
 	return nil

--- a/darepod/config_oor_limits_test.go
+++ b/darepod/config_oor_limits_test.go
@@ -1,0 +1,101 @@
+package darepod
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// validOORLimitsTestConfig returns a baseline daemon config that reaches OOR
+// limit validation without failing unrelated required settings first.
+func validOORLimitsTestConfig() *Config {
+	cfg := DefaultConfig()
+	cfg.Network = "regtest"
+	cfg.Server.Host = "127.0.0.1:10010"
+	cfg.Wallet.EsploraURL = "http://127.0.0.1:3000"
+
+	return cfg
+}
+
+// TestConfigValidateRejectsInvalidOORLimits verifies daemon config validation
+// rejects OOR safety caps that are zero, too small for standard scripts, or
+// inconsistent with each other.
+func TestConfigValidateRejectsInvalidOORLimits(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		mutate  func(*OORLimitsConfig)
+		wantErr string
+	}{
+		{
+			name: "zero checkpoints",
+			mutate: func(limits *OORLimitsConfig) {
+				limits.MaxCheckpoints = 0
+			},
+			wantErr: "oor.limits.maxcheckpoints",
+		},
+		{
+			name: "zero vtxo matches",
+			mutate: func(limits *OORLimitsConfig) {
+				limits.MaxVTXOMatches = 0
+			},
+			wantErr: "oor.limits.maxvtxomatches",
+		},
+		{
+			name: "zero mailbox items",
+			mutate: func(limits *OORLimitsConfig) {
+				limits.MaxMailboxItems = 0
+			},
+			wantErr: "oor.limits.maxmailboxitems",
+		},
+		{
+			name: "script cap below standard taproot script",
+			mutate: func(limits *OORLimitsConfig) {
+				limits.MaxMailboxScriptBytes =
+					minOORMailboxScriptBytes - 1
+			},
+			wantErr: "oor.limits.maxmailboxscriptbytes",
+		},
+		{
+			name: "mailbox items below checkpoints",
+			mutate: func(limits *OORLimitsConfig) {
+				limits.MaxCheckpoints = 3
+				limits.MaxVTXOMatches = 2
+				limits.MaxMailboxItems = 2
+			},
+			wantErr: "oor.limits.maxmailboxitems",
+		},
+		{
+			name: "mailbox items below vtxo matches",
+			mutate: func(limits *OORLimitsConfig) {
+				limits.MaxCheckpoints = 2
+				limits.MaxVTXOMatches = 3
+				limits.MaxMailboxItems = 2
+			},
+			wantErr: "oor.limits.maxmailboxitems",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := validOORLimitsTestConfig()
+			tc.mutate(cfg.OOR.Limits)
+
+			err := cfg.Validate()
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+// TestConfigValidateAcceptsDefaultOORLimits verifies the shipped OOR safety
+// defaults pass daemon config validation.
+func TestConfigValidateAcceptsDefaultOORLimits(t *testing.T) {
+	t.Parallel()
+
+	cfg := validOORLimitsTestConfig()
+	require.NoError(t, cfg.Validate())
+}

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -2115,6 +2115,7 @@ func (s *Server) registerIncomingVTXOEventRoute(
 // DriveEventRequest, and Tell's it to the OOR actor via service key.
 func (s *Server) registerOOREventRoutes(router *serverconn.EventRouter) { //nolint:funlen,ll
 	oorKey := oor.NewServiceKey()
+	limits := s.cfg.OORReceiveLimits()
 
 	// SubmitPackage: server accepted the submit and returned co-signed
 	// checkpoint PSBTs. Adapt into a DriveEventRequest carrying a
@@ -2262,8 +2263,8 @@ func (s *Server) registerOOREventRoutes(router *serverconn.EventRouter) { //noli
 					"ListVTXOsByScriptsResponse, got %T", p)
 			}
 
-			matches, err := oor.IncomingMetadataMatchesFromResponse(
-				sessionID, resp,
+			matches, err := incomingMetadataMatchesFromResponse(
+				sessionID, resp, limits,
 			)
 			if err != nil {
 				return nil, err
@@ -2327,9 +2328,11 @@ func (s *Server) registerOOREventRoutes(router *serverconn.EventRouter) { //noli
 					"got %T", p)
 			}
 
-			incomingEvent, err := oor.IncomingTransferEventFromResponse( //nolint:ll
-				sessionID, recipientEventID, resp,
-			)
+			incomingEvent, err :=
+				oor.IncomingTransferEventFromResponseWithLimits( //nolint:ll
+					sessionID, recipientEventID, resp,
+					limits,
+				)
 			if err != nil {
 				return nil, err
 			}
@@ -2375,6 +2378,17 @@ func (s *Server) registerOOREventRoutes(router *serverconn.EventRouter) { //noli
 	// oorpb proto defines an ack RPC. SendIncomingAckRequest is
 	// classified as a transport event but currently has no
 	// server-push response route.
+}
+
+// incomingMetadataMatchesFromResponse keeps registerOOREventRoutes below the
+// line-length limit while preserving the configured OOR receive caps.
+func incomingMetadataMatchesFromResponse(sessionID oor.SessionID,
+	resp *arkrpc.ListVTXOsByScriptsResponse,
+	limits oor.ReceiveLimits) ([]oor.IncomingMetadataMatch, error) {
+
+	return oor.IncomingMetadataMatchesFromResponseWithLimits(
+		sessionID, resp, limits,
+	)
 }
 
 // registerRoundEventRoutes registers round protocol server-push event
@@ -3386,6 +3400,7 @@ func (s *Server) initOORActor(ctx context.Context,
 	s.oorActor = oor.NewOORClientActor(oor.ClientActorCfg{
 		Log:             fn.Some(s.subLogger(oor.Subsystem)),
 		OutboxHandler:   outboxHandler,
+		Limits:          s.cfg.OORReceiveLimits(),
 		ServerConn:      s.runtime.TellRef(),
 		TransportOutbox: true,
 		SigningEffect:   s.oorSigningEffect.Ref(),

--- a/oor/actor.go
+++ b/oor/actor.go
@@ -24,10 +24,6 @@ import (
 const (
 	oorCheckpointStateType = "oor.sessions"
 	oorCheckpointVersion   = 2
-
-	// incomingMetadataQueryLimit is the default page size for durable
-	// ListVTXOsByScripts lookups used by the receive FSM.
-	incomingMetadataQueryLimit uint32 = 128
 )
 
 // OutboxHandler executes FSM outbox requests and returns follow-up events.
@@ -52,6 +48,10 @@ type ClientActorCfg struct {
 
 	// OutboxHandler executes side effects emitted by the FSM.
 	OutboxHandler OutboxHandler
+
+	// Limits configures defense-in-depth bounds for incoming OOR
+	// receive payloads. Zero fields use DefaultReceiveLimits.
+	Limits ReceiveLimits
 
 	// ServerConn is a reference to the ServerConnectionActor for sending
 	// transport events (submit, finalize, ack) to the server. When set,
@@ -132,13 +132,16 @@ var signingEffectOutboxCodec = NewSigningEffectCodec()
 //
 // IMPORTANT: every type that implements ActorMsg must be registered here;
 // omissions cause runtime dispatch failures with no compile-time warning.
-func newOORActorCodec() *actor.MessageCodec {
+func newOORActorCodec(limits ReceiveLimits) *actor.MessageCodec {
 	codec := actor.NewMessageCodec()
+	limits = normalizeReceiveLimits(limits)
 
 	codec.MustRegister(
 		StartTransferRequestTLVType,
 		func() actor.TLVMessage {
-			return &StartTransferRequest{}
+			return &StartTransferRequest{
+				limits: limits,
+			}
 		},
 	)
 	codec.MustRegister(
@@ -156,13 +159,17 @@ func newOORActorCodec() *actor.MessageCodec {
 	codec.MustRegister(
 		DriveEventRequestTLVType,
 		func() actor.TLVMessage {
-			return &DriveEventRequest{}
+			return &DriveEventRequest{
+				limits: limits,
+			}
 		},
 	)
 	codec.MustRegister(
 		ResolveIncomingTransferTLVType,
 		func() actor.TLVMessage {
-			return &ResolveIncomingTransferRequest{}
+			return &ResolveIncomingTransferRequest{
+				limits: limits,
+			}
 		},
 	)
 	codec.MustRegister(
@@ -174,7 +181,9 @@ func newOORActorCodec() *actor.MessageCodec {
 	codec.MustRegister(
 		RestoreSessionRequestTLVType,
 		func() actor.TLVMessage {
-			return &RestoreSessionRequest{}
+			return &RestoreSessionRequest{
+				limits: limits,
+			}
 		},
 	)
 	codec.MustRegister(
@@ -206,6 +215,8 @@ func newOORActorCodec() *actor.MessageCodec {
 // messages. If startup prerequisites fail, the returned actor stores the error
 // and surfaces it on Receive.
 func NewOORClientActor(cfg ClientActorCfg) *OORClientActor {
+	cfg.Limits = normalizeReceiveLimits(cfg.Limits)
+
 	if cfg.ActorID == "" {
 		cfg.ActorID = fmt.Sprintf("oor-client-%s", uuid.NewString())
 	}
@@ -224,7 +235,7 @@ func NewOORClientActor(cfg ClientActorCfg) *OORClientActor {
 		return actorRef
 	}
 
-	codec := newOORActorCodec()
+	codec := newOORActorCodec(cfg.Limits)
 
 	behavior := &oorDurableBehavior{
 		cfg:      cfg,
@@ -1697,7 +1708,6 @@ func (b *oorDurableBehavior) buildTransportMessage(ctx context.Context,
 
 	case *QueryIncomingMetadataRequest:
 		recipients := queryReq.Recipients
-
 		filter, ok := b.cfg.OutboxHandler.(incomingMetadataFilter)
 		if ok {
 			var err error
@@ -1728,7 +1738,7 @@ func (b *oorDurableBehavior) buildTransportMessage(ctx context.Context,
 
 		sendReq := &serverconn.SendListVTXOsByScriptsRequest{
 			PkScripts: pkScripts,
-			Limit:     incomingMetadataQueryLimit,
+			Limit:     b.cfg.Limits.MaxVTXOMatches,
 			CorrelationID: IncomingMetadataCorrelationID(
 				queryReq.SessionID,
 			),

--- a/oor/actor_durable_message.go
+++ b/oor/actor_durable_message.go
@@ -186,6 +186,16 @@ func encodeStartTransferPayload(payload startTransferPayload) ([]byte, error) {
 }
 
 func decodeStartTransferPayload(raw []byte) (startTransferPayload, error) {
+	return decodeStartTransferPayloadWithLimits(
+		raw, ReceiveLimits{},
+	)
+}
+
+// decodeStartTransferPayloadWithLimits decodes a start-transfer payload and
+// applies receive limits to nested input and recipient lists.
+func decodeStartTransferPayloadWithLimits(raw []byte,
+	limits ReceiveLimits) (startTransferPayload, error) {
+
 	var (
 		operatorKey []byte
 		csvDelay    uint32
@@ -220,12 +230,16 @@ func decodeStartTransferPayload(raw []byte) (startTransferPayload, error) {
 		return startTransferPayload{}, err
 	}
 
-	inputs, err := decodeTransferInputSnapshots(inputsRaw)
+	inputs, err := decodeTransferInputSnapshotsWithLimits(
+		inputsRaw, limits,
+	)
 	if err != nil {
 		return startTransferPayload{}, err
 	}
 
-	recipientsPayload, err := decodeRecipientPayloads(recipients)
+	recipientsPayload, err := decodeRecipientPayloadsWithLimits(
+		recipients, limits,
+	)
 	if err != nil {
 		return startTransferPayload{}, err
 	}
@@ -253,8 +267,12 @@ func encodeRecipientPayloads(payloads []recipientPayload) ([]byte, error) {
 	return encodeLengthPrefixedBlobList(blobs)
 }
 
-func decodeRecipientPayloads(raw []byte) ([]recipientPayload, error) {
-	blobs, err := decodeLengthPrefixedBlobList(raw)
+// decodeRecipientPayloadsWithLimits decodes recipient payloads using the
+// supplied receive limits for the outer blob list.
+func decodeRecipientPayloadsWithLimits(raw []byte,
+	limits ReceiveLimits) ([]recipientPayload, error) {
+
+	blobs, err := decodeLengthPrefixedBlobListWithLimits(raw, limits)
 	if err != nil {
 		return nil, err
 	}
@@ -282,8 +300,12 @@ func encodeOutPointList(outpoints []wire.OutPoint) ([]byte, error) {
 	return encodeLengthPrefixedBlobList(blobs)
 }
 
-func decodeOutPointList(raw []byte) ([]wire.OutPoint, error) {
-	blobs, err := decodeLengthPrefixedBlobList(raw)
+// decodeOutPointListWithLimits decodes outpoints using the supplied receive
+// limits for the outer blob list.
+func decodeOutPointListWithLimits(raw []byte,
+	limits ReceiveLimits) ([]wire.OutPoint, error) {
+
+	blobs, err := decodeLengthPrefixedBlobListWithLimits(raw, limits)
 	if err != nil {
 		return nil, err
 	}
@@ -317,17 +339,21 @@ func encodeIncomingMetadataMatches(matches []IncomingMetadataMatch) ([]byte,
 	return encodeLengthPrefixedBlobList(blobs)
 }
 
-func decodeIncomingMetadataMatches(
-	raw []byte) ([]IncomingMetadataMatch, error) {
+// decodeIncomingMetadataMatchesWithLimits decodes incoming metadata matches
+// using the supplied receive limits for nested metadata and ancestry lists.
+func decodeIncomingMetadataMatchesWithLimits(raw []byte,
+	limits ReceiveLimits) ([]IncomingMetadataMatch, error) {
 
-	blobs, err := decodeLengthPrefixedBlobList(raw)
+	blobs, err := decodeLengthPrefixedBlobListWithLimits(raw, limits)
 	if err != nil {
 		return nil, err
 	}
 
 	matches := make([]IncomingMetadataMatch, 0, len(blobs))
 	for i := range blobs {
-		match, err := decodeIncomingMetadataMatch(blobs[i])
+		match, err := decodeIncomingMetadataMatchWithLimits(
+			blobs[i], limits,
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -365,13 +391,16 @@ func encodeAncestryList(ancestry []vtxo.Ancestry) ([]byte, error) {
 	return encodeLengthPrefixedBlobList(blobs)
 }
 
-// decodeAncestryList is the inverse of encodeAncestryList.
-func decodeAncestryList(raw []byte) ([]vtxo.Ancestry, error) {
+// decodeAncestryListWithLimits decodes ancestry entries using the supplied
+// receive limits for the outer blob list.
+func decodeAncestryListWithLimits(raw []byte,
+	limits ReceiveLimits) ([]vtxo.Ancestry, error) {
+
 	if len(raw) == 0 {
 		return nil, nil
 	}
 
-	blobs, err := decodeLengthPrefixedBlobList(raw)
+	blobs, err := decodeLengthPrefixedBlobListWithLimits(raw, limits)
 	if err != nil {
 		return nil, err
 	}
@@ -618,7 +647,11 @@ func encodeIncomingMetadataMatch(match IncomingMetadataMatch) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func decodeIncomingMetadataMatch(raw []byte) (IncomingMetadataMatch, error) {
+// decodeIncomingMetadataMatchWithLimits decodes one incoming metadata match
+// and applies receive limits to its ancestry list.
+func decodeIncomingMetadataMatchWithLimits(raw []byte,
+	limits ReceiveLimits) (IncomingMetadataMatch, error) {
+
 	var (
 		outputIndex    uint32
 		roundID        []byte
@@ -702,7 +735,7 @@ func decodeIncomingMetadataMatch(raw []byte) (IncomingMetadataMatch, error) {
 		return IncomingMetadataMatch{}, err
 	}
 
-	ancestry, err := decodeAncestryList(ancestryBytes)
+	ancestry, err := decodeAncestryListWithLimits(ancestryBytes, limits)
 	if err != nil {
 		return IncomingMetadataMatch{}, err
 	}
@@ -842,7 +875,17 @@ func encodeTransferInputSnapshots(inputs []*TransferInputSnapshot) ([]byte,
 func decodeTransferInputSnapshots(raw []byte) ([]*TransferInputSnapshot,
 	error) {
 
-	blobs, err := decodeLengthPrefixedBlobList(raw)
+	return decodeTransferInputSnapshotsWithLimits(
+		raw, ReceiveLimits{},
+	)
+}
+
+// decodeTransferInputSnapshotsWithLimits decodes transfer-input snapshots
+// using the supplied receive limits for the outer blob list.
+func decodeTransferInputSnapshotsWithLimits(raw []byte,
+	limits ReceiveLimits) ([]*TransferInputSnapshot, error) {
+
+	blobs, err := decodeLengthPrefixedBlobListWithLimits(raw, limits)
 	if err != nil {
 		return nil, err
 	}
@@ -1401,8 +1444,10 @@ func encodeResolveIncomingTransferPayload(sessionID SessionID,
 	return buf.Bytes(), nil
 }
 
-func decodeResolveIncomingTransferPayload(raw []byte) (SessionID, []byte,
-	uint64, error) {
+// decodeResolveIncomingTransferPayloadWithLimits decodes an incoming-transfer
+// hint while enforcing the configured mailbox script byte limit.
+func decodeResolveIncomingTransferPayloadWithLimits(raw []byte,
+	limits ReceiveLimits) (SessionID, []byte, uint64, error) {
 
 	var (
 		sessionBytes      []byte
@@ -1440,16 +1485,14 @@ func decodeResolveIncomingTransferPayload(raw []byte) (SessionID, []byte,
 		return SessionID{}, nil, 0, err
 	}
 
-	// TODO(oor-receive): The maxPkScriptLen limit guards against
-	// unbounded allocations from a corrupted or malicious TLV payload.
-	// Standard Bitcoin pk_scripts are well under 10 000 bytes; raise
-	// this constant via a tracked issue if a new script type requires
-	// a longer encoding.
-	const maxPkScriptLen = 10_000
-	if len(recipientPkScript) > maxPkScriptLen {
+	limits = normalizeReceiveLimits(limits)
+	if uint64(len(recipientPkScript)) >
+		uint64(limits.MaxMailboxScriptBytes) {
+
 		return SessionID{}, nil, 0, fmt.Errorf(
-			"recipient pk_script length %d exceeds limit %d",
-			len(recipientPkScript), maxPkScriptLen,
+			"max mailbox script bytes exceeded: recipient "+
+				"pk_script length %d exceeds limit %d",
+			len(recipientPkScript), limits.MaxMailboxScriptBytes,
 		)
 	}
 
@@ -1482,6 +1525,16 @@ func encodeRestoreSnapshotPayload(snapshot *OutgoingSnapshot) ([]byte, error) {
 }
 
 func decodeRestoreSnapshotPayload(raw []byte) (*OutgoingSnapshot, error) {
+	return decodeRestoreSnapshotPayloadWithLimits(
+		raw, ReceiveLimits{},
+	)
+}
+
+// decodeRestoreSnapshotPayloadWithLimits decodes a restore payload and applies
+// receive limits to the embedded snapshot.
+func decodeRestoreSnapshotPayloadWithLimits(raw []byte,
+	limits ReceiveLimits) (*OutgoingSnapshot, error) {
+
 	var snapshotRaw []byte
 	records := []tlv.Record{
 		tlv.MakePrimitiveRecord(
@@ -1499,7 +1552,7 @@ func decodeRestoreSnapshotPayload(raw []byte) (*OutgoingSnapshot, error) {
 		return nil, err
 	}
 
-	return decodeOutgoingSnapshot(snapshotRaw)
+	return decodeOutgoingSnapshotWithLimits(snapshotRaw, limits)
 }
 
 func encodeDriveEventRequestPayload(sessionID SessionID, event Event) ([]byte,
@@ -1544,7 +1597,11 @@ func encodeDriveEventRequestPayload(sessionID SessionID, event Event) ([]byte,
 	return buf.Bytes(), nil
 }
 
-func decodeDriveEventRequestPayload(raw []byte) (SessionID, Event, error) {
+// decodeDriveEventRequestPayloadWithLimits decodes a drive-event request and
+// applies receive limits to the embedded event payload.
+func decodeDriveEventRequestPayloadWithLimits(raw []byte,
+	limits ReceiveLimits) (SessionID, Event, error) {
+
 	var (
 		sessionBytes []byte
 		eventPayload []byte
@@ -1574,7 +1631,7 @@ func decodeDriveEventRequestPayload(raw []byte) (SessionID, Event, error) {
 		return SessionID{}, nil, err
 	}
 
-	event, err := decodeEventPayload(eventPayload)
+	event, err := decodeEventPayloadWithLimits(eventPayload, limits)
 	if err != nil {
 		return SessionID{}, nil, err
 	}
@@ -1797,7 +1854,11 @@ func encodeEventPayload(event Event) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func decodeEventPayload(raw []byte) (Event, error) {
+// decodeEventPayloadWithLimits decodes an event payload and applies receive
+// limits to nested list-shaped event fields.
+func decodeEventPayloadWithLimits(raw []byte,
+	limits ReceiveLimits) (Event, error) {
+
 	var (
 		eventKind       uint64
 		submitSession   []byte
@@ -1882,14 +1943,9 @@ func decodeEventPayload(raw []byte) (Event, error) {
 			}
 		}
 
-		checkpointRaw, err := decodeLengthPrefixedBlobList(
-			checkpointPSBT,
+		checkpoints, err := decodeCheckpointPSBTsWithLimits(
+			checkpointPSBT, limits,
 		)
-		if err != nil {
-			return nil, err
-		}
-
-		checkpoints, err := parsePSBTSlice(checkpointRaw)
 		if err != nil {
 			return nil, err
 		}
@@ -1901,14 +1957,9 @@ func decodeEventPayload(raw []byte) (Event, error) {
 		}, nil
 
 	case eventKindCheckpointsSigned:
-		checkpointRaw, err := decodeLengthPrefixedBlobList(
-			checkpointPSBT,
+		checkpoints, err := decodeCheckpointPSBTsWithLimits(
+			checkpointPSBT, limits,
 		)
-		if err != nil {
-			return nil, err
-		}
-
-		checkpoints, err := parsePSBTSlice(checkpointRaw)
 		if err != nil {
 			return nil, err
 		}
@@ -1939,19 +1990,16 @@ func decodeEventPayload(raw []byte) (Event, error) {
 			return nil, err
 		}
 
-		checkpointRaw, err := decodeLengthPrefixedBlobList(
-			checkpointPSBT,
+		checkpoints, err := decodeCheckpointPSBTsWithLimits(
+			checkpointPSBT, limits,
 		)
 		if err != nil {
 			return nil, err
 		}
 
-		checkpoints, err := parsePSBTSlice(checkpointRaw)
-		if err != nil {
-			return nil, err
-		}
-
-		ancestors, err := decodePackageArtifacts(ancestorPayload)
+		ancestors, err := decodePackageArtifactsWithLimits(
+			ancestorPayload, limits,
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -1963,7 +2011,9 @@ func decodeEventPayload(raw []byte) (Event, error) {
 		}, nil
 
 	case eventKindIncomingHandled:
-		outpoints, err := decodeOutPointList(outpointPayload)
+		outpoints, err := decodeOutPointListWithLimits(
+			outpointPayload, limits,
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -1973,8 +2023,8 @@ func decodeEventPayload(raw []byte) (Event, error) {
 		}, nil
 
 	case eventKindIncomingMetadata:
-		matches, err := decodeIncomingMetadataMatches(
-			metadataPayload,
+		matches, err := decodeIncomingMetadataMatchesWithLimits(
+			metadataPayload, limits,
 		)
 		if err != nil {
 			return nil, err
@@ -1998,6 +2048,21 @@ func decodeEventPayload(raw []byte) (Event, error) {
 	default:
 		return nil, fmt.Errorf("unknown event kind: %d", eventKind)
 	}
+}
+
+// decodeCheckpointPSBTsWithLimits decodes checkpoint PSBT lists using receive
+// limits for the outer blob list.
+func decodeCheckpointPSBTsWithLimits(raw []byte,
+	limits ReceiveLimits) ([]*psbt.Packet, error) {
+
+	checkpointRaw, err := decodeLengthPrefixedBlobListWithLimits(
+		raw, limits,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return parsePSBTSlice(checkpointRaw)
 }
 
 func validateSubmitAcceptedIdentity(sessionID SessionID,
@@ -2079,6 +2144,16 @@ func encodeLengthPrefixedBlobList(blobs [][]byte) ([]byte, error) {
 }
 
 func decodeLengthPrefixedBlobList(raw []byte) ([][]byte, error) {
+	return decodeLengthPrefixedBlobListWithLimits(
+		raw, ReceiveLimits{},
+	)
+}
+
+// decodeLengthPrefixedBlobListWithLimits decodes a blob list after enforcing
+// the configured item-count cap before allocating the output slice.
+func decodeLengthPrefixedBlobListWithLimits(raw []byte,
+	limits ReceiveLimits) ([][]byte, error) {
+
 	var scratch [8]byte
 
 	reader := bytes.NewReader(raw)
@@ -2087,16 +2162,12 @@ func decodeLengthPrefixedBlobList(raw []byte) ([][]byte, error) {
 		return nil, err
 	}
 
-	// TODO(oor-receive): The maxBlobListCount limit is a pragmatic
-	// upper bound to prevent unbounded slice allocation from a
-	// malformed or malicious TLV payload. Raise this constant via a
-	// tracked issue if any blob-list field legitimately needs more
-	// entries.
-	const maxBlobListCount = 10_000
-	if count > maxBlobListCount {
+	limits = normalizeReceiveLimits(limits)
+	if count > uint64(limits.MaxMailboxItems) {
 		return nil, fmt.Errorf(
-			"blob list count %d exceeds limit %d",
-			count, maxBlobListCount,
+			"max mailbox items exceeded: blob list count %d "+
+				"exceeds limit %d",
+			count, limits.MaxMailboxItems,
 		)
 	}
 

--- a/oor/actor_messages.go
+++ b/oor/actor_messages.go
@@ -78,6 +78,8 @@ type ActorResp interface {
 type StartTransferRequest struct {
 	actor.BaseMessage
 
+	limits ReceiveLimits
+
 	// Policy defines the operator checkpoint policy used to build the
 	// transfer package.
 	Policy arkscript.CheckpointPolicy
@@ -163,7 +165,9 @@ func (m *StartTransferRequest) Decode(r io.Reader) error {
 		return err
 	}
 
-	payload, err := decodeStartTransferPayload(raw)
+	payload, err := decodeStartTransferPayloadWithLimits(
+		raw, m.limits,
+	)
 	if err != nil {
 		return err
 	}
@@ -428,6 +432,8 @@ func (m *ListSessionsResponse) actorRespSealed() {}
 type DriveEventRequest struct {
 	actor.BaseMessage
 
+	limits ReceiveLimits
+
 	// SessionID identifies the session to drive.
 	SessionID SessionID
 
@@ -474,7 +480,9 @@ func (m *DriveEventRequest) Decode(r io.Reader) error {
 		return err
 	}
 
-	sessionID, event, err := decodeDriveEventRequestPayload(raw)
+	sessionID, event, err := decodeDriveEventRequestPayloadWithLimits(
+		raw, m.limits,
+	)
 	if err != nil {
 		return err
 	}
@@ -508,6 +516,8 @@ func (m *DriveEventResponse) actorRespSealed() {}
 // can safely re-drive the work.
 type ResolveIncomingTransferRequest struct {
 	actor.BaseMessage
+
+	limits ReceiveLimits
 
 	// SessionID identifies the incoming transfer session.
 	SessionID SessionID
@@ -563,7 +573,9 @@ func (m *ResolveIncomingTransferRequest) Decode(r io.Reader) error {
 	}
 
 	sessionID, recipientPkScript, recipientEventID, err :=
-		decodeResolveIncomingTransferPayload(raw)
+		decodeResolveIncomingTransferPayloadWithLimits(
+			raw, m.limits,
+		)
 	if err != nil {
 		return err
 	}
@@ -646,6 +658,8 @@ func (m *GetStateResponse) actorRespSealed() {}
 type RestoreSessionRequest struct {
 	actor.BaseMessage
 
+	limits ReceiveLimits
+
 	// Snapshot is the durable-ish client-side snapshot for an outgoing
 	// transfer.
 	Snapshot *OutgoingSnapshot
@@ -683,7 +697,9 @@ func (m *RestoreSessionRequest) Decode(r io.Reader) error {
 		return err
 	}
 
-	snapshot, err := decodeRestoreSnapshotPayload(raw)
+	snapshot, err := decodeRestoreSnapshotPayloadWithLimits(
+		raw, m.limits,
+	)
 	if err != nil {
 		return err
 	}

--- a/oor/actor_test.go
+++ b/oor/actor_test.go
@@ -1132,6 +1132,73 @@ func TestOORClientActorFiltersIncomingMetadataQueryRecipients(t *testing.T) {
 	)
 }
 
+// TestOORClientActorUsesConfiguredIncomingMetadataQueryLimit verifies the
+// durable incoming metadata query page size tracks ClientActorCfg limits.
+func TestOORClientActorUsesConfiguredIncomingMetadataQueryLimit(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	mockConn := newMockServerConnRef(t)
+	behavior := &oorDurableBehavior{
+		cfg: ClientActorCfg{
+			ServerConn: mockConn,
+			Limits: ReceiveLimits{
+				MaxVTXOMatches: 7,
+			},
+		},
+	}
+
+	err := behavior.sendTransportEvent(ctx, &QueryIncomingMetadataRequest{
+		SessionID: SessionID{0x02},
+		Recipients: []ArkRecipientOutput{{
+			OutputIndex: 0,
+			PkScript:    []byte{0x51, 0x20, 0x03},
+			Value:       1000,
+		}},
+	})
+	require.NoError(t, err)
+
+	query := mockConn.lastVTXOQuery()
+	require.EqualValues(t, 7, query.Limit)
+}
+
+// TestOORActorCodecUsesConfiguredIncomingDecodeLimits verifies the
+// ClientActorCfg-backed codec constructors apply incoming receive decode caps.
+func TestOORActorCodecUsesConfiguredIncomingDecodeLimits(t *testing.T) {
+	t.Parallel()
+
+	// MaxCheckpoints and MaxVTXOMatches are covered at the adapter layer in
+	// receive_limits_test.go; this test covers mailbox codec decode caps.
+	codec := newOORActorCodec(ReceiveLimits{
+		MaxMailboxItems:       1,
+		MaxMailboxScriptBytes: 1,
+	})
+
+	startRaw, err := codec.Encode(&StartTransferRequest{
+		Recipients: []oortx.RecipientOutput{
+			{PkScript: []byte{0x51}},
+			{PkScript: []byte{0x52}},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = codec.Decode(startRaw)
+	require.ErrorContains(t, err, "blob list count 2 exceeds limit 1")
+
+	resolveRaw, err := codec.Encode(&ResolveIncomingTransferRequest{
+		SessionID:         SessionID{0x03},
+		RecipientPkScript: []byte{0x51, 0x20},
+		RecipientEventID:  1,
+	})
+	require.NoError(t, err)
+
+	_, err = codec.Decode(resolveRaw)
+	require.ErrorContains(
+		t, err, "recipient pk_script length 2 exceeds limit 1",
+	)
+}
+
 // TestOORClientActorTransportViaServerConn verifies that transport outbox
 // events (submit, finalize, ack) are Tell'd to the serverconn actor when
 // configured, while local events (signing, persistence) continue through

--- a/oor/incoming_adapter.go
+++ b/oor/incoming_adapter.go
@@ -96,6 +96,19 @@ func IncomingTransferEventFromResponse(sessionID SessionID,
 	resp *arkrpc.ListOORRecipientEventsByScriptResponse) (
 	*IncomingTransferEvent, error) {
 
+	return IncomingTransferEventFromResponseWithLimits(
+		sessionID, recipientEventID, resp, ReceiveLimits{},
+	)
+}
+
+// IncomingTransferEventFromResponseWithLimits validates and converts one
+// ListOORRecipientEventsByScriptResponse payload using the supplied
+// defense-in-depth limits. Zero limit fields use package defaults.
+func IncomingTransferEventFromResponseWithLimits(sessionID SessionID,
+	recipientEventID uint64,
+	resp *arkrpc.ListOORRecipientEventsByScriptResponse,
+	limits ReceiveLimits) (*IncomingTransferEvent, error) {
+
 	if resp == nil {
 		return nil, fmt.Errorf("incoming transfer response must be " +
 			"provided")
@@ -134,16 +147,15 @@ func IncomingTransferEventFromResponse(sessionID SessionID,
 		return nil, fmt.Errorf("parse ark psbt: %w", err)
 	}
 
-	// TODO(oor-receive): The maxCheckpointPSBTs limit is a pragmatic
-	// upper bound for the OOR checkpoint chain depth. If the protocol
-	// ever allows deeper chains this constant should be raised via a
-	// tracked issue rather than silently increasing memory exposure.
-	const maxCheckpointPSBTs = 64
-	if len(recipientEvt.GetCheckpointPsbts()) > maxCheckpointPSBTs { //nolint:ll
+	limits = normalizeReceiveLimits(limits)
+	if uint64(len(recipientEvt.GetCheckpointPsbts())) >
+		uint64(limits.MaxCheckpoints) {
+
 		return nil, fmt.Errorf(
-			"checkpoint count %d exceeds limit %d",
+			"max checkpoints exceeded: checkpoint count %d "+
+				"exceeds limit %d",
 			len(recipientEvt.GetCheckpointPsbts()),
-			maxCheckpointPSBTs,
+			limits.MaxCheckpoints,
 		)
 	}
 

--- a/oor/incoming_metadata_query.go
+++ b/oor/incoming_metadata_query.go
@@ -72,17 +72,28 @@ func IncomingMetadataMatchesFromResponse(
 	resp *arkrpc.ListVTXOsByScriptsResponse,
 ) ([]IncomingMetadataMatch, error) {
 
+	return IncomingMetadataMatchesFromResponseWithLimits(
+		sessionID, resp, ReceiveLimits{},
+	)
+}
+
+// IncomingMetadataMatchesFromResponseWithLimits filters an indexer
+// ListVTXOsByScriptsResponse down to entries created by the given Ark session
+// using the supplied defense-in-depth limits. Zero limit fields use package
+// defaults.
+func IncomingMetadataMatchesFromResponseWithLimits(
+	sessionID SessionID,
+	resp *arkrpc.ListVTXOsByScriptsResponse,
+	limits ReceiveLimits,
+) ([]IncomingMetadataMatch, error) {
+
 	if resp == nil {
 		return nil, fmt.Errorf(
 			"incoming metadata response must be provided",
 		)
 	}
 
-	// TODO(oor-receive): The maxIncomingMetadataMatches limit guards
-	// against unbounded allocations from a malicious or misconfigured
-	// indexer response. Raise this constant via a tracked issue if the
-	// protocol ever allows more outputs per incoming transfer.
-	const maxIncomingMetadataMatches = 128
+	limits = normalizeReceiveLimits(limits)
 
 	matches := make([]IncomingMetadataMatch, 0, len(resp.GetVtxos()))
 	for _, candidate := range resp.GetVtxos() {
@@ -109,11 +120,14 @@ func IncomingMetadataMatchesFromResponse(
 			Metadata:    metadata,
 		})
 
-		if len(matches) > maxIncomingMetadataMatches {
+		if uint64(len(matches)) >
+			uint64(limits.MaxVTXOMatches) {
+
 			return nil, fmt.Errorf(
-				"incoming metadata match count "+
+				"max metadata matches exceeded: "+
+					"incoming metadata match count "+
 					"exceeds limit %d",
-				maxIncomingMetadataMatches,
+				limits.MaxVTXOMatches,
 			)
 		}
 	}

--- a/oor/outgoing_snapshot_codec.go
+++ b/oor/outgoing_snapshot_codec.go
@@ -99,6 +99,16 @@ func encodeSessionsCheckpoint(
 }
 
 func decodeSessionsCheckpoint(raw []byte) (sessionsCheckpoint, error) {
+	return decodeSessionsCheckpointWithLimits(
+		raw, ReceiveLimits{},
+	)
+}
+
+// decodeSessionsCheckpointWithLimits decodes a checkpoint and applies receive
+// limits to all nested session snapshot lists.
+func decodeSessionsCheckpointWithLimits(raw []byte,
+	limits ReceiveLimits) (sessionsCheckpoint, error) {
+
 	var (
 		version     uint64
 		outgoingRaw []byte
@@ -125,7 +135,9 @@ func decodeSessionsCheckpoint(raw []byte) (sessionsCheckpoint, error) {
 		return sessionsCheckpoint{}, err
 	}
 
-	outgoingBlobs, err := decodeLengthPrefixedBlobList(outgoingRaw)
+	outgoingBlobs, err := decodeLengthPrefixedBlobListWithLimits(
+		outgoingRaw, limits,
+	)
 	if err != nil {
 		return sessionsCheckpoint{}, err
 	}
@@ -133,7 +145,9 @@ func decodeSessionsCheckpoint(raw []byte) (sessionsCheckpoint, error) {
 	outgoingSnapshots := make([]*OutgoingSnapshot, 0,
 		len(outgoingBlobs))
 	for i := range outgoingBlobs {
-		snapshot, err := decodeOutgoingSnapshot(outgoingBlobs[i])
+		snapshot, err := decodeOutgoingSnapshotWithLimits(
+			outgoingBlobs[i], limits,
+		)
 		if err != nil {
 			return sessionsCheckpoint{}, err
 		}
@@ -143,8 +157,8 @@ func decodeSessionsCheckpoint(raw []byte) (sessionsCheckpoint, error) {
 
 	incomingSnapshots := make([]*IncomingSnapshot, 0)
 	if len(incomingRaw) != 0 {
-		incomingBlobs, err := decodeLengthPrefixedBlobList(
-			incomingRaw,
+		incomingBlobs, err := decodeLengthPrefixedBlobListWithLimits(
+			incomingRaw, limits,
 		)
 		if err != nil {
 			return sessionsCheckpoint{}, err
@@ -153,8 +167,8 @@ func decodeSessionsCheckpoint(raw []byte) (sessionsCheckpoint, error) {
 		incomingSnapshots = make([]*IncomingSnapshot, 0,
 			len(incomingBlobs))
 		for i := range incomingBlobs {
-			snapshot, err := decodeIncomingSnapshot(
-				incomingBlobs[i],
+			snapshot, err := decodeIncomingSnapshotWithLimits(
+				incomingBlobs[i], limits,
 			)
 			if err != nil {
 				return sessionsCheckpoint{}, err
@@ -266,6 +280,14 @@ func encodeOutgoingSnapshot(snapshot *OutgoingSnapshot) ([]byte, error) {
 }
 
 func decodeOutgoingSnapshot(raw []byte) (*OutgoingSnapshot, error) {
+	return decodeOutgoingSnapshotWithLimits(raw, ReceiveLimits{})
+}
+
+// decodeOutgoingSnapshotWithLimits decodes one outgoing snapshot and applies
+// receive limits to nested checkpoint and transfer-input lists.
+func decodeOutgoingSnapshotWithLimits(raw []byte,
+	limits ReceiveLimits) (*OutgoingSnapshot, error) {
+
 	var (
 		version            uint64
 		sessionBytes       []byte
@@ -317,7 +339,9 @@ func decodeOutgoingSnapshot(raw []byte) (*OutgoingSnapshot, error) {
 		return nil, err
 	}
 
-	checkpointPSBTs, err := decodeLengthPrefixedBlobList(checkpointPSBTsRaw)
+	checkpointPSBTs, err := decodeLengthPrefixedBlobListWithLimits(
+		checkpointPSBTsRaw, limits,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -325,7 +349,9 @@ func decodeOutgoingSnapshot(raw []byte) (*OutgoingSnapshot, error) {
 		checkpointPSBTs = nil
 	}
 
-	inputSnapshots, err := decodeTransferInputSnapshots(inputSnapshotsRaw)
+	inputSnapshots, err := decodeTransferInputSnapshotsWithLimits(
+		inputSnapshotsRaw, limits,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/oor/package_artifact_codec.go
+++ b/oor/package_artifact_codec.go
@@ -34,21 +34,25 @@ func encodePackageArtifacts(artifacts []PackageArtifact) ([]byte, error) {
 	return encodeLengthPrefixedBlobList(blobs)
 }
 
-// decodePackageArtifacts deserializes package artifacts encoded by
-// encodePackageArtifacts.
-func decodePackageArtifacts(raw []byte) ([]PackageArtifact, error) {
+// decodePackageArtifactsWithLimits deserializes package artifacts while
+// applying the supplied receive limits to nested blob-list fields.
+func decodePackageArtifactsWithLimits(raw []byte,
+	limits ReceiveLimits) ([]PackageArtifact, error) {
+
 	if len(raw) == 0 {
 		return nil, nil
 	}
 
-	blobs, err := decodeLengthPrefixedBlobList(raw)
+	blobs, err := decodeLengthPrefixedBlobListWithLimits(raw, limits)
 	if err != nil {
 		return nil, err
 	}
 
 	artifacts := make([]PackageArtifact, 0, len(blobs))
 	for i := range blobs {
-		artifact, err := decodePackageArtifact(blobs[i])
+		artifact, err := decodePackageArtifactWithLimits(
+			blobs[i], limits,
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -118,8 +122,11 @@ func encodePackageArtifact(artifact PackageArtifact) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// decodePackageArtifact deserializes one package artifact TLV stream.
-func decodePackageArtifact(raw []byte) (PackageArtifact, error) {
+// decodePackageArtifactWithLimits deserializes one package artifact while
+// applying the supplied receive limits to its checkpoint list.
+func decodePackageArtifactWithLimits(raw []byte,
+	limits ReceiveLimits) (PackageArtifact, error) {
+
 	var (
 		sessionBytes []byte
 		arkPSBT      []byte
@@ -158,7 +165,9 @@ func decodePackageArtifact(raw []byte) (PackageArtifact, error) {
 		return PackageArtifact{}, err
 	}
 
-	checkpointRaw, err := decodeLengthPrefixedBlobList(checkpoints)
+	checkpointRaw, err := decodeLengthPrefixedBlobListWithLimits(
+		checkpoints, limits,
+	)
 	if err != nil {
 		return PackageArtifact{}, err
 	}

--- a/oor/receive_limits.go
+++ b/oor/receive_limits.go
@@ -1,0 +1,77 @@
+package oor
+
+const (
+	// DefaultMaxCheckpoints caps checkpoint transactions accepted in one
+	// incoming transfer.
+	DefaultMaxCheckpoints uint32 = 64
+
+	// DefaultMaxVTXOMatches caps matching VTXOs accepted from one indexer
+	// lookup during incoming receive.
+	DefaultMaxVTXOMatches uint32 = 128
+
+	// DefaultMaxMailboxItems caps length-prefixed mailbox item counts
+	// before allocating the decoded slice.
+	DefaultMaxMailboxItems uint32 = 10_000
+
+	// DefaultMaxMailboxScriptBytes caps persisted incoming-recipient
+	// script hints decoded from the mailbox.
+	DefaultMaxMailboxScriptBytes uint32 = 10_000
+)
+
+// ReceiveLimits groups bounds for the incoming OOR receive path. Zero fields
+// use the package defaults. Functions accepting ReceiveLimits normalize their
+// inputs before enforcing any cap.
+type ReceiveLimits struct {
+	// MaxCheckpoints caps checkpoint transactions accepted in one incoming
+	// transfer.
+	MaxCheckpoints uint32
+
+	// MaxVTXOMatches caps matching VTXOs accepted from one indexer lookup
+	// during incoming receive. The durable metadata query also uses this
+	// value as its page-size limit.
+	MaxVTXOMatches uint32
+
+	// MaxMailboxItems caps length-prefixed mailbox item counts before the
+	// decoder allocates the output slice.
+	MaxMailboxItems uint32
+
+	// MaxMailboxScriptBytes caps persisted incoming-recipient script hints
+	// decoded from the mailbox.
+	MaxMailboxScriptBytes uint32
+}
+
+// DefaultReceiveLimits returns the default OOR incoming receive limits.
+func DefaultReceiveLimits() ReceiveLimits {
+	return ReceiveLimits{
+		MaxCheckpoints:        DefaultMaxCheckpoints,
+		MaxVTXOMatches:        DefaultMaxVTXOMatches,
+		MaxMailboxItems:       DefaultMaxMailboxItems,
+		MaxMailboxScriptBytes: DefaultMaxMailboxScriptBytes,
+	}
+}
+
+// normalizeReceiveLimits fills zero-valued fields with package defaults so
+// callers can override one limit without restating the whole set.
+func normalizeReceiveLimits(
+	limits ReceiveLimits) ReceiveLimits {
+
+	defaults := DefaultReceiveLimits()
+
+	if limits.MaxCheckpoints == 0 {
+		limits.MaxCheckpoints = defaults.MaxCheckpoints
+	}
+
+	if limits.MaxVTXOMatches == 0 {
+		limits.MaxVTXOMatches = defaults.MaxVTXOMatches
+	}
+
+	if limits.MaxMailboxItems == 0 {
+		limits.MaxMailboxItems = defaults.MaxMailboxItems
+	}
+
+	if limits.MaxMailboxScriptBytes == 0 {
+		limits.MaxMailboxScriptBytes = defaults.MaxMailboxScriptBytes
+	}
+
+	return limits
+}

--- a/oor/receive_limits_test.go
+++ b/oor/receive_limits_test.go
@@ -1,0 +1,119 @@
+package oor
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightninglabs/darepo-client/arkrpc"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIncomingTransferEventFromResponseUsesConfiguredCheckpointLimit verifies
+// incoming transfer response adaptation enforces the configured checkpoint cap.
+func TestIncomingTransferEventFromResponseUsesConfiguredCheckpointLimit(
+	t *testing.T) {
+
+	t.Parallel()
+
+	resp, sessionID, _, recipientEventID := buildIncomingResolveResponse(t)
+	recipientEvt := resp.Events[0]
+	require.Len(t, recipientEvt.CheckpointPsbts, 1)
+
+	recipientEvt.CheckpointPsbts = append(
+		recipientEvt.CheckpointPsbts,
+		append([]byte(nil), recipientEvt.CheckpointPsbts[0]...),
+	)
+
+	_, err := IncomingTransferEventFromResponseWithLimits(
+		sessionID, recipientEventID, resp, ReceiveLimits{
+			MaxCheckpoints: 1,
+		},
+	)
+	require.ErrorContains(t, err, "checkpoint count 2 exceeds limit 1")
+}
+
+// TestIncomingMetadataMatchesFromResponseUsesConfiguredMatchLimit verifies
+// incoming metadata response adaptation enforces the configured match cap.
+func TestIncomingMetadataMatchesFromResponseUsesConfiguredMatchLimit(
+	t *testing.T) {
+
+	t.Parallel()
+
+	sessionID := SessionID(chainhash.Hash{1, 2, 3})
+	commitmentTxID := chainhash.Hash{4, 5, 6}
+
+	resp := &arkrpc.ListVTXOsByScriptsResponse{
+		Vtxos: []*arkrpc.VTXO{
+			testIncomingMetadataVTXO(sessionID, commitmentTxID, 0),
+			testIncomingMetadataVTXO(sessionID, commitmentTxID, 1),
+		},
+	}
+
+	_, err := IncomingMetadataMatchesFromResponseWithLimits(
+		sessionID, resp, ReceiveLimits{
+			MaxVTXOMatches: 1,
+		},
+	)
+	require.ErrorContains(
+		t, err, "incoming metadata match count exceeds limit 1",
+	)
+}
+
+// TestDecodeResolveIncomingTransferPayloadUsesConfiguredPkScriptLimit verifies
+// mailbox resolve payload decoding enforces the configured recipient script
+// byte cap.
+func TestDecodeResolveIncomingTransferPayloadUsesConfiguredPkScriptLimit(
+	t *testing.T) {
+
+	t.Parallel()
+
+	raw, err := encodeResolveIncomingTransferPayload(
+		SessionID(chainhash.Hash{7, 8, 9}), []byte{0x51, 0x20}, 3,
+	)
+	require.NoError(t, err)
+
+	_, _, _, err = decodeResolveIncomingTransferPayloadWithLimits(
+		raw, ReceiveLimits{
+			MaxMailboxScriptBytes: 1,
+		},
+	)
+	require.ErrorContains(
+		t, err, "recipient pk_script length 2 exceeds limit 1",
+	)
+}
+
+// TestDecodeLengthPrefixedBlobListUsesConfiguredCountLimit verifies the shared
+// mailbox blob-list decoder enforces the configured item-count cap.
+func TestDecodeLengthPrefixedBlobListUsesConfiguredCountLimit(
+	t *testing.T) {
+
+	t.Parallel()
+
+	raw, err := encodeLengthPrefixedBlobList([][]byte{{0x01}, {0x02}})
+	require.NoError(t, err)
+
+	_, err = decodeLengthPrefixedBlobListWithLimits(
+		raw, ReceiveLimits{
+			MaxMailboxItems: 1,
+		},
+	)
+	require.ErrorContains(t, err, "blob list count 2 exceeds limit 1")
+}
+
+// testIncomingMetadataVTXO builds a minimal RPC VTXO that can be converted
+// into an IncomingMetadataMatch by the response adapter.
+func testIncomingMetadataVTXO(sessionID SessionID,
+	commitmentTxID chainhash.Hash, outputIndex uint32) *arkrpc.VTXO {
+
+	return &arkrpc.VTXO{
+		Outpoint: &arkrpc.OutPoint{
+			Txid: sessionID[:],
+			Vout: outputIndex,
+		},
+		RoundId:        "round-configured-limit",
+		CommitmentTxid: commitmentTxID[:],
+		AncestryPaths: []*arkrpc.AncestryPath{{
+			CommitmentTxid: commitmentTxID[:],
+		}},
+	}
+}

--- a/oor/receive_snapshot.go
+++ b/oor/receive_snapshot.go
@@ -311,8 +311,11 @@ func encodeIncomingSnapshot(snapshot *IncomingSnapshot) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// decodeIncomingSnapshot deserializes an incoming snapshot from TLV bytes.
-func decodeIncomingSnapshot(raw []byte) (*IncomingSnapshot, error) {
+// decodeIncomingSnapshotWithLimits decodes one incoming snapshot and applies
+// receive limits to nested checkpoint and ancestor-package lists.
+func decodeIncomingSnapshotWithLimits(raw []byte,
+	limits ReceiveLimits) (*IncomingSnapshot, error) {
+
 	var (
 		version           uint64
 		sessionBytes      []byte
@@ -374,7 +377,9 @@ func decodeIncomingSnapshot(raw []byte) (*IncomingSnapshot, error) {
 		return nil, err
 	}
 
-	checkpoints, err := decodeLengthPrefixedBlobList(checkpointsRaw)
+	checkpoints, err := decodeLengthPrefixedBlobListWithLimits(
+		checkpointsRaw, limits,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -386,7 +391,9 @@ func decodeIncomingSnapshot(raw []byte) (*IncomingSnapshot, error) {
 		arkPSBT = nil
 	}
 
-	decodedPackages, err := decodePackageArtifacts(ancestorPackages)
+	decodedPackages, err := decodePackageArtifactsWithLimits(
+		ancestorPackages, limits,
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Fixes #193 by replacing hardcoded incoming OOR receive safety limits with configurable values.

The PR adds an `oor.ReceiveLimits` config surface for the OOR actor, keeps the current default values, and wires those limits into incoming transfer response parsing, incoming VTXO-match parsing, stored mailbox item-list decoding, and stored mailbox address-script decode checks. The daemon exposes matching advanced `oor.limits.*` config fields and CLI flags with operator-oriented names:

- `oor.limits.max-checkpoints`
- `oor.limits.max-vtxo-matches`
- `oor.limits.max-mailbox-items`
- `oor.limits.max-mailbox-script-bytes`

## Impact

Existing OOR package callers keep the same behavior when limits are unset. Daemon config now validates explicit limit settings during startup so invalid caps fail fast instead of surfacing later during receive processing. Operators and daemon deployments can tune these bounds as protocol shape changes, while retaining OOM protection and diagnostic error messages that include the active limit. The CLI help names the log symptom that would prompt changing each advanced knob.

## Validation

- `go run ./cmd/darepod --help`
- `go test ./oor ./darepod ./cmd/darepod`
- `go test ./...`
- `git diff --check`