### PR TITLE
multi: emit boarding-sweep ledger and balance entries

### DIFF
--- a/db/migrations.go
+++ b/db/migrations.go
@@ -10,7 +10,7 @@ const (
 	// daemon.
 	//
 	// NOTE: This MUST be updated when a new migration is added.
-	LatestMigrationVersion uint = 11
+	LatestMigrationVersion uint = 12
 )
 
 // MigrationTarget is a functional option that can be passed to applyMigrations

--- a/db/sqlc/fee_accounting.sql.go
+++ b/db/sqlc/fee_accounting.sql.go
@@ -247,7 +247,9 @@ FROM (
                WHEN event_type IN (
                    'boarding_fee_paid', 'wallet_utxo_created'
                ) THEN 'boarding'
-               WHEN event_type = 'onchain_fee_paid' THEN 'sweep'
+               WHEN event_type IN (
+                   'onchain_fee_paid', 'boarding_sweep_fee_paid'
+               ) THEN 'sweep'
                ELSE 'round'
            END AS transaction_type,
            event_type AS subtype,

--- a/db/sqlc/migrations/000012_boarding_sweep_ledger_events.down.sql
+++ b/db/sqlc/migrations/000012_boarding_sweep_ledger_events.down.sql
@@ -1,0 +1,11 @@
+-- Reverse 000012: remove the boarding-sweep ledger / classification rows.
+-- We only delete the seeded rows; ledger_entries / wallet_utxo_log rows
+-- referencing them are not silently rewritten because doing so would
+-- violate the append-only invariant of those tables. Operators with
+-- pre-existing boarding-sweep history must therefore manually reconcile
+-- before downgrading.
+DELETE FROM utxo_classifications
+WHERE classification IN ('boarding_sweep_input', 'boarding_sweep_return');
+
+DELETE FROM ledger_event_types
+WHERE event_type = 'boarding_sweep_fee_paid';

--- a/db/sqlc/migrations/000012_boarding_sweep_ledger_events.up.sql
+++ b/db/sqlc/migrations/000012_boarding_sweep_ledger_events.up.sql
@@ -1,0 +1,12 @@
+-- Register the boarding-sweep ledger event type so FeePaidMsg with
+-- FeeType=FeeTypeOnchainSweep (event_type="boarding_sweep_fee_paid")
+-- satisfies the ledger_entries.event_type FK constraint.
+INSERT INTO ledger_event_types (event_type) VALUES
+    ('boarding_sweep_fee_paid');
+
+-- Register the per-input / per-destination UTXO audit classifications
+-- emitted by the boarding-sweep flow alongside the ledger fee event.
+-- These satisfy the wallet_utxo_log.classification FK constraint.
+INSERT INTO utxo_classifications (classification) VALUES
+    ('boarding_sweep_input'),
+    ('boarding_sweep_return');

--- a/db/sqlc/queries/fee_accounting.sql
+++ b/db/sqlc/queries/fee_accounting.sql
@@ -58,7 +58,9 @@ FROM (
                WHEN event_type IN (
                    'boarding_fee_paid', 'wallet_utxo_created'
                ) THEN 'boarding'
-               WHEN event_type = 'onchain_fee_paid' THEN 'sweep'
+               WHEN event_type IN (
+                   'onchain_fee_paid', 'boarding_sweep_fee_paid'
+               ) THEN 'sweep'
                ELSE 'round'
            END AS transaction_type,
            event_type AS subtype,

--- a/ledger/actor.go
+++ b/ledger/actor.go
@@ -47,12 +47,13 @@ const (
 // Client-side ledger event types matching the seeded event types
 // in the migration.
 const (
-	EventBoardingFeePaid   = "boarding_fee_paid"
-	EventRefreshFeePaid    = "refresh_fee_paid"
-	EventOnchainFeePaid    = "onchain_fee_paid"
-	EventVTXOReceived      = "vtxo_received"
-	EventVTXOSent          = "vtxo_sent"
-	EventWalletUTXOCreated = "wallet_utxo_created"
+	EventBoardingFeePaid      = "boarding_fee_paid"
+	EventRefreshFeePaid       = "refresh_fee_paid"
+	EventOnchainFeePaid       = "onchain_fee_paid"
+	EventBoardingSweepFeePaid = "boarding_sweep_fee_paid"
+	EventVTXOReceived         = "vtxo_received"
+	EventVTXOSent             = "vtxo_sent"
+	EventWalletUTXOCreated    = "wallet_utxo_created"
 )
 
 // Canonical VTXOReceivedMsg.Source values. Callers must use one
@@ -87,9 +88,28 @@ const (
 // fee type is rejected by handleFeePaid with an explicit error
 // so durable-mailbox replays surface caller bugs loudly instead
 // of silently misclassifying the entry.
+//
+// FeeTypeBoarding and FeeTypeRefresh book operator (Ark protocol)
+// fees: debit fees_paid, credit vtxo_balance. They MUST be paired
+// with a same-RoundID VTXOReceivedMsg carrying the gross pre-fee
+// amount.
+//
+// FeeTypeOnchainSweep books a wallet-internal on-chain miner fee
+// (currently emitted by the boarding-sweep flow): debit
+// onchain_fees, credit wallet_balance. RoundID may be zero — the
+// fee is keyed by sweep txid via IdempotencyKey instead.
 const (
-	FeeTypeBoarding = "boarding"
-	FeeTypeRefresh  = "refresh"
+	FeeTypeBoarding     = "boarding"
+	FeeTypeRefresh      = "refresh"
+	FeeTypeOnchainSweep = "onchain_sweep"
+)
+
+// Canonical Classification values seeded by migrations specific to
+// boarding-sweep events. Callers must use these strings rather than
+// literals so the seed table and producer agree.
+const (
+	ClassificationBoardingSweepInput  = "boarding_sweep_input"
+	ClassificationBoardingSweepReturn = "boarding_sweep_return"
 )
 
 // Canonical UTXO audit classification values matching the

--- a/ledger/handlers.go
+++ b/ledger/handlers.go
@@ -56,14 +56,47 @@ func (a *LedgerActor) handleFeePaid(ctx context.Context,
 
 	roundID := roundIDOrNil(msg.RoundID)
 
-	// Map the fee type string to the appropriate event type.
-	var eventType string
+	// Operator-fee types share the same accounts (fees_paid /
+	// vtxo_balance). Onchain-sweep fees book against onchain_fees /
+	// wallet_balance instead — they are L1 miner fees paid by a
+	// wallet-internal sweep, not Ark protocol operator fees, and the
+	// fee is settled out of wallet_balance rather than VTXO balance.
+	var (
+		eventType     string
+		debitAccount  string
+		creditAccount string
+		idempotency   []byte
+		description   string
+	)
 	switch msg.FeeType {
 	case FeeTypeBoarding:
 		eventType = EventBoardingFeePaid
+		debitAccount = AccountFeesPaid
+		creditAccount = AccountVTXOBalance
+		description = fmt.Sprintf("%s fee paid in round %x",
+			msg.FeeType, msg.RoundID)
 
 	case FeeTypeRefresh:
 		eventType = EventRefreshFeePaid
+		debitAccount = AccountFeesPaid
+		creditAccount = AccountVTXOBalance
+		description = fmt.Sprintf("%s fee paid in round %x",
+			msg.FeeType, msg.RoundID)
+
+	case FeeTypeOnchainSweep:
+		eventType = EventBoardingSweepFeePaid
+		debitAccount = AccountOnchainFees
+		creditAccount = AccountWalletBalance
+
+		// Onchain-sweep fees are not associated with a round.
+		// Use the sweep txid (carried in IdempotencyKey by the
+		// caller) to dedup replays via the
+		// idx_client_ledger_idempotent_key partial unique index.
+		// Round-keyed dedup is intentionally bypassed by setting
+		// roundID to nil below.
+		roundID = nil
+		idempotency = msg.IdempotencyKey
+		description = "boarding-sweep on-chain miner fee"
 
 	default:
 		return fmt.Errorf("%w: unknown fee type %q", ErrInvalidMessage,
@@ -81,16 +114,14 @@ func (a *LedgerActor) handleFeePaid(ctx context.Context,
 
 	return a.cfg.LedgerStore.InsertLedgerEntry(
 		ctx, LedgerEntry{
-			DebitAccount:  AccountFeesPaid,
-			CreditAccount: AccountVTXOBalance,
-			AmountSat:     msg.AmountSat,
-			RoundID:       roundID,
-			EventType:     eventType,
-			Description: fmt.Sprintf(
-				"%s fee paid in round %x",
-				msg.FeeType, msg.RoundID,
-			),
-			CreatedAt: a.clk.Now().Unix(),
+			DebitAccount:   debitAccount,
+			CreditAccount:  creditAccount,
+			AmountSat:      msg.AmountSat,
+			RoundID:        roundID,
+			IdempotencyKey: idempotency,
+			EventType:      eventType,
+			Description:    description,
+			CreatedAt:      a.clk.Now().Unix(),
 		},
 	)
 }

--- a/ledger/handlers_test.go
+++ b/ledger/handlers_test.go
@@ -190,6 +190,69 @@ func TestHandleFeePaidRefresh(t *testing.T) {
 		entries[0].EventType)
 }
 
+// TestHandleFeePaidOnchainSweep verifies that a boarding-sweep miner fee
+// is booked against onchain_fees / wallet_balance with the
+// boarding_sweep_fee_paid event type, and that an empty RoundID is
+// accepted alongside a sweep-txid IdempotencyKey.
+func TestHandleFeePaidOnchainSweep(t *testing.T) {
+	t.Parallel()
+
+	a, store := newTestActor(t)
+	ctx := t.Context()
+
+	sweepTxid := [32]byte{
+		0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x11,
+		0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99,
+		0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x11,
+		0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99,
+	}
+	msg := &FeePaidMsg{
+		AmountSat:      444,
+		FeeType:        FeeTypeOnchainSweep,
+		BlockHeight:    800_650,
+		IdempotencyKey: append([]byte(nil), sweepTxid[:]...),
+	}
+
+	err := a.handleFeePaid(ctx, msg)
+	require.NoError(t, err)
+
+	entries := store.getEntries()
+	require.Len(t, entries, 1)
+	require.Equal(t, AccountOnchainFees, entries[0].DebitAccount)
+	require.Equal(t, AccountWalletBalance, entries[0].CreditAccount)
+	require.Equal(t, int64(444), entries[0].AmountSat)
+	require.Equal(t, EventBoardingSweepFeePaid, entries[0].EventType)
+
+	// Onchain-sweep fees do NOT carry a RoundID; the dedup key is the
+	// sweep txid plumbed via IdempotencyKey, so the
+	// idx_client_ledger_idempotent_key partial unique index handles
+	// replay safety.
+	require.Nil(
+		t, entries[0].RoundID,
+		"onchain-sweep fees must not carry a RoundID",
+	)
+	require.Equal(t, sweepTxid[:], entries[0].IdempotencyKey)
+}
+
+// TestHandleFeePaidOnchainSweepRejectsZeroAmount verifies that the same
+// non-positive-amount guard the operator-fee path uses also fires for
+// onchain-sweep fees.
+func TestHandleFeePaidOnchainSweepRejectsZeroAmount(t *testing.T) {
+	t.Parallel()
+
+	a, _ := newTestActor(t)
+	ctx := t.Context()
+
+	msg := &FeePaidMsg{
+		AmountSat:   0,
+		FeeType:     FeeTypeOnchainSweep,
+		BlockHeight: 800_700,
+	}
+
+	err := a.handleFeePaid(ctx, msg)
+	require.ErrorIs(t, err, ErrInvalidMessage)
+}
+
 // TestHandleVTXOReceivedRoundBoarding verifies that a boarding
 // or refresh receive is recorded with wallet_balance ->
 // vtxo_balance (own on-chain funds converted to VTXO balance).

--- a/ledger/messages.go
+++ b/ledger/messages.go
@@ -144,10 +144,11 @@ const (
 // extensibility.
 const (
 	// FeePaidMsg field types.
-	feePaidRoundIDType     tlv.Type = 1
-	feePaidAmountSatType   tlv.Type = 3
-	feePaidFeeTypeType     tlv.Type = 5
-	feePaidBlockHeightType tlv.Type = 7
+	feePaidRoundIDType        tlv.Type = 1
+	feePaidAmountSatType      tlv.Type = 3
+	feePaidFeeTypeType        tlv.Type = 5
+	feePaidBlockHeightType    tlv.Type = 7
+	feePaidIdempotencyKeyType tlv.Type = 9
 
 	// VTXOReceivedMsg field types.
 	vtxoRecvOutpointHashType  tlv.Type = 1
@@ -199,18 +200,31 @@ type LedgerResp interface {
 	ledgerRespSealed()
 }
 
-// FeePaidMsg is sent when the client pays a fee during a round
-// (boarding or refresh). The ledger actor records the expense
-// as fees_paid += AmountSat / vtxo_balance -= AmountSat.
+// FeePaidMsg is sent when the client pays a fee. Two flavors:
 //
-// Caller contract: FeePaidMsg accumulates the fee on top of a
-// paired VTXOReceivedMsg. For a boarding or refresh round, the
-// VTXOReceivedMsg for the same round MUST carry the GROSS
-// (pre-fee) amount -- the FeePaidMsg then nets vtxo_balance down
-// to the delivered post-fee value. Sending a net VTXOReceivedMsg
-// together with a FeePaidMsg will under-count vtxo_balance by
-// the fee. OOR sends and receives are already net-of-fee and do
-// not need a separate FeePaidMsg.
+//   - FeeTypeBoarding / FeeTypeRefresh: an Ark protocol fee paid
+//     to the operator during a round. Booked as
+//     fees_paid += AmountSat / vtxo_balance -= AmountSat. Keyed
+//     by RoundID via the (round_id, event_type) partial unique
+//     index.
+//   - FeeTypeOnchainSweep: an L1 miner fee paid by a wallet-
+//     internal boarding sweep. Booked as
+//     onchain_fees += AmountSat / wallet_balance -= AmountSat.
+//     Has no paired VTXOReceivedMsg; keyed by the sweep txid
+//     carried in IdempotencyKey via the
+//     idx_client_ledger_idempotent_key partial unique index.
+//     RoundID is left zero and stored as NULL.
+//
+// Caller contract (FeeTypeBoarding / FeeTypeRefresh only):
+// FeePaidMsg accumulates the fee on top of a paired
+// VTXOReceivedMsg. The VTXOReceivedMsg for the same round MUST
+// carry the GROSS (pre-fee) amount -- the FeePaidMsg then nets
+// vtxo_balance down to the delivered post-fee value. Sending a
+// net VTXOReceivedMsg together with a FeePaidMsg will
+// under-count vtxo_balance by the fee. OOR sends and receives
+// are already net-of-fee and do not need a separate FeePaidMsg.
+// FeeTypeOnchainSweep is a standalone entry and never pairs
+// with a VTXOReceivedMsg.
 type FeePaidMsg struct {
 	actor.BaseMessage
 
@@ -225,12 +239,19 @@ type FeePaidMsg struct {
 	AmountSat int64
 
 	// FeeType classifies the fee. Must be one of the
-	// FeeType* constants (FeeTypeBoarding, FeeTypeRefresh);
-	// any other value is rejected.
+	// FeeType* constants (FeeTypeBoarding, FeeTypeRefresh,
+	// FeeTypeOnchainSweep); any other value is rejected.
 	FeeType string
 
 	// BlockHeight is the confirmation block height.
 	BlockHeight uint32
+
+	// IdempotencyKey is an optional natural dedup key used by
+	// fee events that do not carry a RoundID — the boarding
+	// sweep flow for example uses the sweep txid (32 bytes).
+	// Round/refresh fees leave this empty and rely on the
+	// (round_id, event_type) partial unique index instead.
+	IdempotencyKey []byte
 }
 
 // MessageType returns the message type name for routing.
@@ -249,6 +270,7 @@ func (m *FeePaidMsg) Encode(w io.Writer) error {
 	amountSat := uint64(m.AmountSat)
 	feeType := []byte(m.FeeType)
 	blockHeight := m.BlockHeight
+	idempotency := m.IdempotencyKey
 
 	stream, err := tlv.NewStream(
 		tlv.MakePrimitiveRecord(
@@ -262,6 +284,9 @@ func (m *FeePaidMsg) Encode(w io.Writer) error {
 		),
 		tlv.MakePrimitiveRecord(
 			feePaidBlockHeightType, &blockHeight,
+		),
+		tlv.MakePrimitiveRecord(
+			feePaidIdempotencyKeyType, &idempotency,
 		),
 	)
 	if err != nil {
@@ -278,6 +303,7 @@ func (m *FeePaidMsg) Decode(r io.Reader) error {
 		amountSat   uint64
 		feeType     []byte
 		blockHeight uint32
+		idempotency []byte
 	)
 
 	stream, err := tlv.NewStream(
@@ -292,6 +318,9 @@ func (m *FeePaidMsg) Decode(r io.Reader) error {
 		),
 		tlv.MakePrimitiveRecord(
 			feePaidBlockHeightType, &blockHeight,
+		),
+		tlv.MakePrimitiveRecord(
+			feePaidIdempotencyKeyType, &idempotency,
 		),
 	)
 	if err != nil {
@@ -317,6 +346,15 @@ func (m *FeePaidMsg) Decode(r io.Reader) error {
 	m.AmountSat = amt
 	m.FeeType = string(feeType)
 	m.BlockHeight = blockHeight
+	// Preserve nil-vs-empty distinction so TLV round-trip equality
+	// matches the producer's intent. tlv.MakePrimitiveRecord on a
+	// []byte field decodes a missing record as []byte{}; tests and
+	// callers that compare IdempotencyKey == nil expect nil.
+	if len(idempotency) == 0 {
+		m.IdempotencyKey = nil
+	} else {
+		m.IdempotencyKey = idempotency
+	}
 
 	return nil
 }

--- a/wallet/boarding_sweep_actor.go
+++ b/wallet/boarding_sweep_actor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
 	"github.com/lightninglabs/darepo-client/chainsource"
+	"github.com/lightninglabs/darepo-client/ledger"
 	"github.com/lightninglabs/darepo-client/txconfirm"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 )
@@ -1013,6 +1014,8 @@ func (a *Ark) handleSweepTxNotification(ctx context.Context,
 		)
 		a.reconcileSweepInputsOnConfirm(ctx, notif)
 
+		a.emitSweepConfirmedLedger(ctx, notif)
+
 	default:
 		a.logger(ctx).WarnS(
 			ctx,
@@ -1073,6 +1076,154 @@ func (a *Ark) reconcileSweepInputsOnConfirm(ctx context.Context,
 			)
 		}
 	}
+}
+
+// emitSweepConfirmedLedger emits the double-entry ledger and UTXO audit
+// events corresponding to a boarding-sweep confirmation:
+//
+//   - one FeePaidMsg{FeeType=FeeTypeOnchainSweep} for the L1 miner fee
+//     (debit onchain_fees, credit wallet_balance), keyed by sweep txid;
+//   - one UTXOSpentMsg{Classification=boarding_sweep_input} per swept
+//     boarding outpoint (audit row recording the on-chain spend);
+//   - one UTXOCreatedMsg{Classification=boarding_sweep_return} for the
+//     sweep's destination output, but only when the destination was a
+//     wallet-derived script (skipped for caller-supplied external
+//     addresses, where the funds left the wallet entirely).
+//
+// All emissions are best-effort. Ledger Tell errors are logged but do not
+// fail the confirmation path; ledger replays are idempotent via the
+// outpoint- and txid-derived idempotency keys.
+func (a *Ark) emitSweepConfirmedLedger(ctx context.Context,
+	notif BoardingSweepTxNotification) {
+
+	if a.ledgerSink.IsNone() || a.sweepStore == nil {
+		return
+	}
+
+	// The persisted sweep record is the sole source of truth for
+	// inputs / destination / amounts at confirmation time.
+	// pendingSweeps[txid] is routinely cleared by
+	// handleSweepSpendNotification before / during confirmation as
+	// inputs resolve, and is also absent across restarts. Gating the
+	// audit and balance legs on in-memory state would silently drop
+	// them in the common case.
+	record, ok := a.lookupSweepRecord(ctx, notif.Txid)
+	if !ok {
+		a.logger(ctx).WarnS(ctx, "emit ledger: sweep record not found",
+			nil,
+			slog.String("txid", notif.Txid.String()),
+		)
+
+		return
+	}
+
+	a.ledgerSink.WhenSome(func(sink ledger.Sink) {
+		// 1. Fee leg.
+		feeMsg := &ledger.FeePaidMsg{
+			AmountSat:      int64(record.FeeAmount),
+			FeeType:        ledger.FeeTypeOnchainSweep,
+			BlockHeight:    uint32(notif.BlockHeight),
+			IdempotencyKey: append([]byte(nil), notif.Txid[:]...),
+		}
+		if err := sink.Tell(ctx, feeMsg); err != nil {
+			a.logger(ctx).WarnS(
+				ctx,
+				"emit ledger: FeePaidMsg failed",
+				err,
+				slog.String("txid", notif.Txid.String()),
+			)
+		}
+
+		// 2. Per-input audit rows (UTXOSpentMsg). Each spent row
+		// carries the boarding UTXO's value so wallet_utxo_log.
+		// amount_sat reflects the actual outflow rather than
+		// silently persisting zero. The audit log is idempotent on
+		// (outpoint, event) so replay is safe.
+		for _, in := range record.Inputs {
+			op := in.Outpoint
+			spentMsg := &ledger.UTXOSpentMsg{
+				OutpointHash:  op.Hash,
+				OutpointIndex: op.Index,
+				AmountSat:     int64(in.Amount),
+				BlockHeight:   uint32(notif.BlockHeight),
+				Classification: ledger.
+					ClassificationBoardingSweepInput,
+			}
+			if err := sink.Tell(ctx, spentMsg); err != nil {
+				a.logger(ctx).WarnS(
+					ctx,
+					"emit ledger: UTXOSpentMsg failed",
+					err,
+					slog.String("outpoint", op.String()),
+				)
+			}
+		}
+
+		// 3. Destination UTXOCreatedMsg, only for wallet-derived
+		// destinations. External destinations leave the wallet
+		// entirely; the per-input UTXOSpentMsg covers the outflow
+		// without needing a paired UTXOCreatedMsg. The persisted
+		// DestinationAddress is empty when the daemon allocated a
+		// fresh wallet output and non-empty when the caller supplied
+		// an explicit external address, which is the persisted
+		// equivalent of the in-memory destWalletDerived signal.
+		if record.DestinationAddress != "" {
+			return
+		}
+		if record.Tx == nil || len(record.Tx.TxOut) == 0 {
+			a.logger(ctx).WarnS(ctx,
+				"emit ledger: sweep record missing tx output",
+				nil, slog.String("txid",
+					notif.Txid.String()))
+
+			return
+		}
+
+		// TxOut[0] is the wallet/destination output; TxOut[1] is the
+		// P2A anchor. The builder in buildBoardingSweepTx enforces
+		// this order strictly so the wallet output stays at the
+		// canonical confirmation script the actor passes to
+		// txconfirm. Hard-coding vout 0 here mirrors that invariant.
+		outMsg := &ledger.UTXOCreatedMsg{
+			OutpointHash:  notif.Txid,
+			OutpointIndex: 0,
+			AmountSat:     record.Tx.TxOut[0].Value,
+			BlockHeight:   uint32(notif.BlockHeight),
+			Classification: ledger.
+				ClassificationBoardingSweepReturn,
+		}
+		if err := sink.Tell(ctx, outMsg); err != nil {
+			a.logger(ctx).WarnS(ctx,
+				"emit ledger: UTXOCreatedMsg failed",
+				err, slog.String("txid",
+					notif.Txid.String()))
+		}
+	})
+}
+
+// lookupSweepRecord returns the persisted sweep record for the given txid.
+// Used by the ledger-emission path at confirmation time, where in-memory
+// pendingSweeps state has already been cleared (or was never present after
+// restart) and the persisted record is the only complete source of truth
+// for inputs, destination, and amounts. Returns (nil, false) on error or
+// when no matching record is found.
+func (a *Ark) lookupSweepRecord(ctx context.Context, txid chainhash.Hash) (
+	*BoardingSweepRecord, bool) {
+
+	record, err := a.sweepStore.GetBoardingSweep(ctx, txid)
+	if err != nil {
+		a.logger(ctx).WarnS(ctx, "lookupSweepRecord: get failed",
+			err,
+			slog.String("txid", txid.String()),
+		)
+
+		return nil, false
+	}
+	if record == nil {
+		return nil, false
+	}
+
+	return record, true
 }
 
 // handleResumeBoardingSweeps reloads non-terminal sweeps from the

--- a/wallet/boarding_sweep_actor_test.go
+++ b/wallet/boarding_sweep_actor_test.go
@@ -4,15 +4,19 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
 	"github.com/lightninglabs/darepo-client/chainsource"
 	"github.com/lightninglabs/darepo-client/ledger"
+	"github.com/lightninglabs/darepo-client/lib/arkscript"
+	"github.com/lightninglabs/darepo-client/lib/tx/arktx"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -440,6 +444,320 @@ func TestSweepSpendNotificationMarksInputSpent(t *testing.T) {
 	)
 
 	store.AssertExpectations(t)
+}
+
+// capturingLedgerBehavior collects ledger messages sent through the
+// wallet actor's ledgerSink, so unit tests can assert on the boarding
+// sweep emission shape without booting a real ledger actor. The
+// internal channel is buffered to absorb the Tell volume one
+// confirmation can produce (one fee leg, one UTXOSpentMsg per input
+// up to the sweep cap, plus one optional UTXOCreatedMsg).
+type capturingLedgerBehavior struct {
+	ch chan ledger.LedgerMsg
+}
+
+// Receive records the incoming message and returns a nil response
+// (LedgerResp is fire-and-forget).
+func (c *capturingLedgerBehavior) Receive(_ context.Context,
+	msg ledger.LedgerMsg) fn.Result[ledger.LedgerResp] {
+
+	c.ch <- msg
+
+	return fn.Ok[ledger.LedgerResp](nil)
+}
+
+// newCapturingLedgerSink starts an in-memory actor backed by
+// capturingLedgerBehavior and returns the wallet-side sink plus a
+// drain helper. drain blocks until either the requested message count
+// is observed or a short test deadline elapses, so callers can write
+// the assertion the same way regardless of mailbox scheduling.
+func newCapturingLedgerSink(t *testing.T) (ledger.Sink,
+	func(want int) []ledger.LedgerMsg) {
+
+	t.Helper()
+
+	const bufferSize = 256
+
+	beh := &capturingLedgerBehavior{
+		ch: make(chan ledger.LedgerMsg, bufferSize),
+	}
+	a := actor.NewActor(actor.ActorConfig[ledger.LedgerMsg,
+		ledger.LedgerResp]{
+		ID:          "test-ledger-sink",
+		Behavior:    beh,
+		MailboxSize: bufferSize,
+	})
+	a.Start()
+	t.Cleanup(a.Stop)
+
+	sink := ledger.Sink(a.Ref())
+
+	drain := func(want int) []ledger.LedgerMsg {
+		out := make([]ledger.LedgerMsg, 0, want)
+		timeout := time.After(2 * time.Second)
+		for len(out) < want {
+			select {
+			case m := <-beh.ch:
+				out = append(out, m)
+
+			case <-timeout:
+				return out
+			}
+		}
+
+		// After hitting the expected count, briefly drain any
+		// trailing messages so tests asserting "no extras" can
+		// catch unintended emissions without false negatives.
+		settle := time.After(20 * time.Millisecond)
+		for {
+			select {
+			case m := <-beh.ch:
+				out = append(out, m)
+
+			case <-settle:
+				return out
+			}
+		}
+	}
+
+	return sink, drain
+}
+
+// TestSweepTxNotificationConfirmedEmitsLedger verifies that on a
+// confirmed sweep, the wallet actor emits a FeePaidMsg with
+// FeeTypeOnchainSweep, one UTXOSpentMsg per swept input, and (because
+// the destination is wallet-derived) a UTXOCreatedMsg for the sweep
+// destination output.
+func TestSweepTxNotificationConfirmedEmitsLedger(t *testing.T) {
+	t.Parallel()
+
+	swept := chainhash.Hash{0x42}
+	in1 := wire.OutPoint{Hash: chainhash.Hash{0xab}, Index: 0}
+	in2 := wire.OutPoint{Hash: chainhash.Hash{0xcd}, Index: 1}
+
+	store := &MockBoardingSweepStore{}
+
+	// emitSweepConfirmedLedger reads the persisted sweep record as the
+	// sole source of truth for inputs / destination / amounts, so the
+	// mock must return a populated record keyed by the sweep txid. The
+	// in-memory pendingSweeps map is intentionally NOT consulted at
+	// confirmation time, since handleSweepSpendNotification routinely
+	// clears it before the txconfirm Confirmed event arrives.
+	const (
+		input1Sat       = int64(40_000)
+		input2Sat       = int64(60_000)
+		feeSat          = int64(444)
+		anchorSat       = int64(330)
+		walletOutputSat = input1Sat + input2Sat - feeSat - anchorSat
+	)
+	sweepTx := wire.NewMsgTx(arktx.TxVersion)
+	sweepTx.AddTxOut(&wire.TxOut{
+		Value:    walletOutputSat,
+		PkScript: []byte{txscript.OP_TRUE},
+	})
+	sweepTx.AddTxOut(
+		arkscript.AnchorOutput(
+			arkscript.WithAnchorValue(anchorSat),
+		),
+	)
+	walletDerivedRecord := &BoardingSweepRecord{
+		Txid:               swept,
+		Tx:                 sweepTx,
+		DestinationAddress: "", // empty == wallet-derived
+		TotalAmount:        btcutil.Amount(input1Sat + input2Sat),
+		FeeAmount:          btcutil.Amount(feeSat),
+		Status:             "confirmed",
+		Inputs: []BoardingSweepInputRecord{
+			{
+				Txid:     swept,
+				Outpoint: in1,
+				Amount:   btcutil.Amount(input1Sat),
+				Status:   BoardingSweepInputStatusSpent,
+			},
+			{
+				Txid:     swept,
+				Outpoint: in2,
+				Amount:   btcutil.Amount(input2Sat),
+				Status:   BoardingSweepInputStatusSpent,
+			},
+		},
+	}
+	store.On(
+		"GetBoardingSweep", mock.Anything, swept,
+	).Return(walletDerivedRecord, nil)
+
+	chainSource := newMockSweepChainSource(t, 0, 0)
+	sink, drain := newCapturingLedgerSink(t)
+	a := NewArk(
+		&MockBoardingBackend{}, &MockBoardingStore{}, nil, chainSource,
+		nil, fn.Some(sink), btclog.Disabled,
+		WithBoardingSweep(
+			store, &testBoardingSweepWallet{},
+			&chaincfg.RegressionNetParams,
+		),
+	)
+
+	result := a.handleSweepTxNotification(
+		t.Context(), BoardingSweepTxNotification{
+			Confirmed:   true,
+			Txid:        swept,
+			BlockHeight: 800_650,
+			NumConfs:    1,
+		},
+	)
+	require.True(t, result.IsOk())
+
+	// Expect 4 messages: 1 FeePaidMsg + 2 UTXOSpentMsg + 1 UTXOCreatedMsg.
+	msgs := drain(4)
+	require.NotEmpty(
+		t, msgs, "confirmed sweep must emit at least the fee leg",
+	)
+
+	var (
+		feePaid     *ledger.FeePaidMsg
+		utxoSpent   []*ledger.UTXOSpentMsg
+		utxoCreated *ledger.UTXOCreatedMsg
+	)
+	for _, m := range msgs {
+		switch typed := m.(type) {
+		case *ledger.FeePaidMsg:
+			feePaid = typed
+
+		case *ledger.UTXOSpentMsg:
+			utxoSpent = append(utxoSpent, typed)
+
+		case *ledger.UTXOCreatedMsg:
+			utxoCreated = typed
+		}
+	}
+
+	require.NotNil(t, feePaid)
+	require.Equal(t, ledger.FeeTypeOnchainSweep, feePaid.FeeType)
+	require.Equal(t, feeSat, feePaid.AmountSat)
+	require.Equal(t, swept[:], feePaid.IdempotencyKey)
+
+	require.Len(
+		t, utxoSpent, 2, "one UTXOSpentMsg per swept boarding input",
+	)
+
+	// Per-input AmountSat must reflect the persisted boarding-UTXO
+	// value rather than defaulting to zero — otherwise the audit log
+	// silently records a 0-sat outflow.
+	spentByOutpoint := make(
+		map[wire.OutPoint]*ledger.UTXOSpentMsg, len(utxoSpent),
+	)
+	for _, m := range utxoSpent {
+		require.Equal(
+			t, ledger.ClassificationBoardingSweepInput,
+			m.Classification,
+		)
+		op := wire.OutPoint{
+			Hash:  m.OutpointHash,
+			Index: m.OutpointIndex,
+		}
+		spentByOutpoint[op] = m
+	}
+	require.NotNil(t, spentByOutpoint[in1])
+	require.Equal(t, input1Sat, spentByOutpoint[in1].AmountSat)
+	require.NotNil(t, spentByOutpoint[in2])
+	require.Equal(t, input2Sat, spentByOutpoint[in2].AmountSat)
+
+	require.NotNil(
+		t, utxoCreated,
+		"wallet-derived destination must emit one UTXOCreatedMsg",
+	)
+	require.Equal(
+		t, ledger.ClassificationBoardingSweepReturn,
+		utxoCreated.Classification,
+	)
+	require.Equal(t, [32]byte(swept), utxoCreated.OutpointHash)
+	require.Equal(t, walletOutputSat, utxoCreated.AmountSat)
+}
+
+// TestSweepTxNotificationConfirmedExternalDestSkipsCreated verifies that
+// when a sweep was paid to an external (non-wallet) address, the actor
+// emits the fee leg and per-input audit rows but skips the destination
+// UTXOCreatedMsg — those funds left the wallet entirely and the
+// per-input UTXOSpentMsg covers the outflow.
+func TestSweepTxNotificationConfirmedExternalDestSkipsCreated(t *testing.T) {
+	t.Parallel()
+
+	swept := chainhash.Hash{0x55}
+	in1 := wire.OutPoint{Hash: chainhash.Hash{0x11}, Index: 0}
+
+	// A non-empty DestinationAddress on the persisted record marks the
+	// sweep as paying to a caller-supplied external address (the
+	// persisted equivalent of the in-memory destWalletDerived=false
+	// signal). The destination UTXOCreatedMsg must be skipped because
+	// the funds left the wallet entirely.
+	const (
+		inputSat        = int64(40_000)
+		feeSat          = int64(222)
+		anchorSat       = int64(330)
+		externalDestSat = inputSat - feeSat - anchorSat
+	)
+	externalDestTx := wire.NewMsgTx(arktx.TxVersion)
+	externalDestTx.AddTxOut(&wire.TxOut{
+		Value:    externalDestSat,
+		PkScript: []byte{txscript.OP_TRUE},
+	})
+	externalDestTx.AddTxOut(
+		arkscript.AnchorOutput(
+			arkscript.WithAnchorValue(anchorSat),
+		),
+	)
+	externalDestRecord := &BoardingSweepRecord{
+		Txid:               swept,
+		Tx:                 externalDestTx,
+		DestinationAddress: "bcrt1pexternaladdress",
+		TotalAmount:        btcutil.Amount(inputSat),
+		FeeAmount:          btcutil.Amount(feeSat),
+		Status:             "confirmed",
+		Inputs: []BoardingSweepInputRecord{
+			{
+				Txid:     swept,
+				Outpoint: in1,
+				Amount:   btcutil.Amount(inputSat),
+				Status:   BoardingSweepInputStatusSpent,
+			},
+		},
+	}
+
+	store := &MockBoardingSweepStore{}
+	store.On(
+		"GetBoardingSweep", mock.Anything, swept,
+	).Return(externalDestRecord, nil)
+
+	chainSource := newMockSweepChainSource(t, 0, 0)
+	sink, drain := newCapturingLedgerSink(t)
+	a := NewArk(
+		&MockBoardingBackend{}, &MockBoardingStore{}, nil, chainSource,
+		nil, fn.Some(sink), btclog.Disabled,
+		WithBoardingSweep(
+			store, &testBoardingSweepWallet{},
+			&chaincfg.RegressionNetParams,
+		),
+	)
+
+	result := a.handleSweepTxNotification(
+		t.Context(), BoardingSweepTxNotification{
+			Confirmed:   true,
+			Txid:        swept,
+			BlockHeight: 800_700,
+		},
+	)
+	require.True(t, result.IsOk())
+
+	// Expect 2 messages: 1 FeePaidMsg + 1 UTXOSpentMsg. drain settles
+	// after these, so a stray UTXOCreatedMsg would still be captured.
+	msgs := drain(2)
+	for _, m := range msgs {
+		_, isCreated := m.(*ledger.UTXOCreatedMsg)
+		require.False(
+			t, isCreated, "external-destination sweep must NOT "+
+				"emit UTXOCreatedMsg",
+		)
+	}
 }
 
 // TestSweepTxNotificationFailedMarksFailed verifies that a terminal


### PR DESCRIPTION
## Summary

Stacked on top of #355. Extends the `ledger` package with a new fee
type for on-chain miner fees and emits the boarding-sweep accounting
entries from the wallet actor on sweep confirmation. Without this,
`GetFeeHistory` and the double-entry ledger silently miss the
miner-fee paid by a boarding-timeout sweep, and dashboards built on
the audit log don't see the spent boarding inputs or the swept
return output.

### Why

PR #350 (the original boarding-sweep work) and #355 (the actor
refactor) both compute the sweep miner fee and persist it to the
`boarding_sweeps` table, but neither emits a `ledger.LedgerMsg`. The
client's double-entry chart of accounts therefore drifts from
on-chain reality whenever a sweep confirms — `wallet_balance` shifts
without a counterparty entry, and the `wallet_utxo_log` audit table
has no row for the spent inputs or the swept return.

### What changed (commit-by-commit)

1. `ledger: add FeeTypeOnchainSweep and IdempotencyKey on FeePaidMsg` —
   new fee type constant for wallet-internal on-chain miner fees,
   plus an optional `IdempotencyKey []byte` field (TLV type 9) for
   producers that don't carry a `RoundID`.
2. `ledger: branch handleFeePaid by FeeType for sweep accounting` —
   route `FeeTypeOnchainSweep` to `onchain_fees` / `wallet_balance`
   instead of `fees_paid` / `vtxo_balance`, with sweep-txid-based
   dedup via the `idx_client_ledger_idempotent_key` partial unique
   index. Operator fee types unchanged.
3. `db: register boarding-sweep ledger event and classifications` —
   migration `000012` seeds the `boarding_sweep_fee_paid` event type
   and the `boarding_sweep_input` / `boarding_sweep_return` UTXO
   classifications.
4. `db: classify boarding-sweep fees under the sweep transaction type` —
   teach the fee-accounting CTE that powers `GetTransactionHistory`
   to lump `boarding_sweep_fee_paid` events under the existing
   `sweep` transaction_type alongside `onchain_fee_paid`.
5. `wallet: emit fee ledger and UTXO audit on sweep confirmation` —
   on `TxConfirmed`, the wallet actor emits one `FeePaidMsg` with
   the sweep txid as `IdempotencyKey`, one `UTXOSpentMsg` per swept
   input, and (only for wallet-derived destinations) one
   `UTXOCreatedMsg` for the sweep return. External destinations
   skip the create — the per-input spent rows already cover the
   outflow.

## Test plan

- [x] `go test ./wallet/... ./ledger/... ./db/...` — all green
- [x] `make lint-native` — 0 issues
- [ ] `make systest db=postgres` — verify migration 000012 applies
  cleanly under postgres
- [ ] Manual smoke: trigger a boarding sweep that confirms, then
  `darepocli getfeehistory` and confirm the new
  `boarding_sweep_fee_paid` event row plus the `boarding_swept_sat`
  field on `GetBalance`