### PR TITLE
darepod: register --wallet.feeurl CLI flag

### DIFF
--- a/cmd/darepod/main.go
+++ b/cmd/darepod/main.go
@@ -104,10 +104,14 @@ func newRootCmd() *cobra.Command {
 
 	// Wallet backend flags.
 	f.String("wallet.type", cfg.Wallet.Type,
-		"wallet backend type (lnd, lwwallet)",
+		"wallet backend type (lnd, lwwallet, btcwallet)",
 	)
 	f.String("wallet.esploraurl", cfg.Wallet.EsploraURL,
 		"esplora REST API URL (required for lwwallet)",
+	)
+	f.String("wallet.feeurl", cfg.Wallet.FeeURL,
+		"fee-estimate JSON endpoint URL "+
+			"(required for btcwallet)",
 	)
 	f.Duration("wallet.pollinterval", cfg.Wallet.PollInterval,
 		"chain poll interval for lwwallet backend",
@@ -117,7 +121,7 @@ func newRootCmd() *cobra.Command {
 	)
 	f.String("wallet.password_file", cfg.Wallet.PasswordFile,
 		"path to file containing wallet password for "+
-			"auto-unlock at startup (lwwallet mode)",
+			"auto-unlock at startup (lwwallet/btcwallet)",
 	)
 
 	// Optional bitcoind direct connection for package relay.


### PR DESCRIPTION
## Summary

In this PR, we add the missing CLI binding for `wallet.feeurl`
to `cmd/darepod/main.go`. The `Wallet.FeeURL` config field
already exists in `darepod/config.go` and `Validate()` rejects
btcwallet deployments without a fee URL, but `main.go`'s
`f.String` registry only had bindings for type, esploraurl,
pollinterval, recoverywindow, and password_file. That left
`DAREPOD_WALLET_FEEURL` (viper's auto-bound env var) as the only
path to set it.

That's awkward in chart-driven deploys: every other wallet flag
is a normal `--wallet.foo=`, but feeurl had to be smuggled in
through a Deployment `env:` block — see the workaround in
[lightning-infra/charts/darepod templates/deployment.yaml](https://github.com/lightninglabs/lightning-infra/pull/3194)
that auto-injects the env var when wallet.type=btcwallet. With
this flag, that chart can drop the env-var dance and pass
`--wallet.feeurl` the same way it passes `--wallet.esploraurl`.

While here, expand the `wallet.type` help text to include
`btcwallet` (was listed only as `lnd, lwwallet` even though the
daemon supports btcwallet) and tighten the password_file
description to reflect that it applies to btcwallet too, not
just lwwallet.

## Test plan

- [x] `go build ./cmd/darepod`
- [x] `darepod --help` shows `--wallet.feeurl` with the right
      description
- [x] `darepod --help` shows the corrected wallet.type help
      (lnd, lwwallet, btcwallet) and password_file description
- [ ] Follow-up: drop the DAREPOD_WALLET_FEEURL env-var injection
      from lightning-infra#3194 once this lands and a new darepod
      image is built