### PR TITLE
indexer: use opaque vtxo cursor

### DIFF
--- a/arkrpc/indexer.pb.go
+++ b/arkrpc/indexer.pb.go
@@ -1859,7 +1859,8 @@ type ListVTXOsByScriptsRequest struct {
 	// statuses. If empty, server default policy applies.
 	StatusFilter []VTXOStatus `protobuf:"varint,2,rep,packed,name=status_filter,json=statusFilter,proto3,enum=arkrpc.VTXOStatus" json:"status_filter,omitempty"`
 	// cursor is an opaque pagination cursor returned by a prior response.
-	Cursor uint64 `protobuf:"varint,3,opt,name=cursor,proto3" json:"cursor,omitempty"`
+	// It is only valid with the same scripts and status_filter values.
+	Cursor []byte `protobuf:"bytes,3,opt,name=cursor,proto3" json:"cursor,omitempty"`
 	// limit bounds the number of results returned.
 	Limit         uint32 `protobuf:"varint,4,opt,name=limit,proto3" json:"limit,omitempty"`
 	unknownFields protoimpl.UnknownFields
@@ -1910,11 +1911,11 @@ func (x *ListVTXOsByScriptsRequest) GetStatusFilter() []VTXOStatus {
 	return nil
 }
 
-func (x *ListVTXOsByScriptsRequest) GetCursor() uint64 {
+func (x *ListVTXOsByScriptsRequest) GetCursor() []byte {
 	if x != nil {
 		return x.Cursor
 	}
-	return 0
+	return nil
 }
 
 func (x *ListVTXOsByScriptsRequest) GetLimit() uint32 {
@@ -1925,9 +1926,10 @@ func (x *ListVTXOsByScriptsRequest) GetLimit() uint32 {
 }
 
 type ListVTXOsByScriptsResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Vtxos         []*VTXO                `protobuf:"bytes,1,rep,name=vtxos,proto3" json:"vtxos,omitempty"`
-	NextCursor    uint64                 `protobuf:"varint,2,opt,name=next_cursor,json=nextCursor,proto3" json:"next_cursor,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Vtxos []*VTXO                `protobuf:"bytes,1,rep,name=vtxos,proto3" json:"vtxos,omitempty"`
+	// next_cursor is empty when the result set is exhausted.
+	NextCursor    []byte `protobuf:"bytes,2,opt,name=next_cursor,json=nextCursor,proto3" json:"next_cursor,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1969,11 +1971,11 @@ func (x *ListVTXOsByScriptsResponse) GetVtxos() []*VTXO {
 	return nil
 }
 
-func (x *ListVTXOsByScriptsResponse) GetNextCursor() uint64 {
+func (x *ListVTXOsByScriptsResponse) GetNextCursor() []byte {
 	if x != nil {
 		return x.NextCursor
 	}
-	return 0
+	return nil
 }
 
 type GetOORSessionByTxidRequest struct {
@@ -2796,11 +2798,11 @@ const file_indexer_proto_rawDesc = "" +
 	"\x19ListVTXOsByScriptsRequest\x12-\n" +
 	"\ascripts\x18\x01 \x03(\v2\x13.arkrpc.ScriptScopeR\ascripts\x127\n" +
 	"\rstatus_filter\x18\x02 \x03(\x0e2\x12.arkrpc.VTXOStatusR\fstatusFilter\x12\x16\n" +
-	"\x06cursor\x18\x03 \x01(\x04R\x06cursor\x12\x14\n" +
+	"\x06cursor\x18\x03 \x01(\fR\x06cursor\x12\x14\n" +
 	"\x05limit\x18\x04 \x01(\rR\x05limit\"a\n" +
 	"\x1aListVTXOsByScriptsResponse\x12\"\n" +
 	"\x05vtxos\x18\x01 \x03(\v2\f.arkrpc.VTXOR\x05vtxos\x12\x1f\n" +
-	"\vnext_cursor\x18\x02 \x01(\x04R\n" +
+	"\vnext_cursor\x18\x02 \x01(\fR\n" +
 	"nextCursor\"l\n" +
 	"\x1aGetOORSessionByTxidRequest\x12+\n" +
 	"\x06script\x18\x01 \x01(\v2\x13.arkrpc.ScriptScopeR\x06script\x12!\n" +

--- a/arkrpc/indexer.proto
+++ b/arkrpc/indexer.proto
@@ -447,7 +447,8 @@ message ListVTXOsByScriptsRequest {
     repeated VTXOStatus status_filter = 2;
 
     // cursor is an opaque pagination cursor returned by a prior response.
-    uint64 cursor = 3;
+    // It is only valid with the same scripts and status_filter values.
+    bytes cursor = 3;
 
     // limit bounds the number of results returned.
     uint32 limit = 4;
@@ -455,7 +456,9 @@ message ListVTXOsByScriptsRequest {
 
 message ListVTXOsByScriptsResponse {
     repeated VTXO vtxos = 1;
-    uint64 next_cursor = 2;
+
+    // next_cursor is empty when the result set is exhausted.
+    bytes next_cursor = 2;
 }
 
 message GetOORSessionByTxidRequest {

--- a/darepod/incoming_metadata.go
+++ b/darepod/incoming_metadata.go
@@ -35,7 +35,7 @@ func ResolveIncomingMetadataFromIndexer(ctx context.Context,
 		slog.Int("output_index", int(recipient.OutputIndex)),
 		slog.String("pk_script", fmt.Sprintf("%x", recipient.PkScript)))
 
-	var cursor uint64
+	var cursor []byte
 	for {
 		resp, err := idx.ListVTXOsByScriptsTaproot(
 			ctx,
@@ -78,11 +78,13 @@ func ResolveIncomingMetadataFromIndexer(ctx context.Context,
 		}
 
 		nextCursor := resp.GetNextCursor()
-		if len(resp.GetVtxos()) == 0 || nextCursor <= cursor {
+		if len(resp.GetVtxos()) == 0 || len(nextCursor) == 0 ||
+			bytes.Equal(nextCursor, cursor) {
+
 			break
 		}
 
-		cursor = nextCursor
+		cursor = append(cursor[:0], nextCursor...)
 	}
 
 	logger.DebugS(ctx, "Incoming indexer VTXO not found",

--- a/darepod/rpc_swap_lookup.go
+++ b/darepod/rpc_swap_lookup.go
@@ -48,7 +48,7 @@ func (r *RPCServer) GetIndexedVTXOByPkScript(ctx context.Context,
 		[]indexer.TaprootScriptScope{{
 			PkScript: append([]byte(nil), req.PkScript...),
 		}},
-		0, 1, statusFilter,
+		nil, 1, statusFilter,
 	)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal,

--- a/darepod/serverconn_builder.go
+++ b/darepod/serverconn_builder.go
@@ -33,7 +33,7 @@ func (b *serverDurableUnaryBuilder) BuildListOORRecipientEventsByScriptRequest(
 // BuildListVTXOsByScriptsRequest builds the proof-gated indexer request body
 // for one or more taproot VTXO scope queries.
 func (b *serverDurableUnaryBuilder) BuildListVTXOsByScriptsRequest(
-	ctx context.Context, pkScripts [][]byte, afterCursor uint64,
+	ctx context.Context, pkScripts [][]byte, afterCursor []byte,
 	limit uint32,
 ) (proto.Message, error) {
 

--- a/indexer/client.go
+++ b/indexer/client.go
@@ -599,13 +599,13 @@ func (c *Client) buildTaprootScopes(ctx context.Context,
 // BuildListVTXOsByScriptsTaprootRequest builds a proof-gated VTXO query for
 // one or more pkScripts.
 func (c *Client) BuildListVTXOsByScriptsTaprootRequest(ctx context.Context,
-	scopes []TaprootScriptScope, afterCursor uint64, limit uint32,
+	scopes []TaprootScriptScope, afterCursor []byte, limit uint32,
 	statusFilter []arkrpc.VTXOStatus) (
 	*arkrpc.ListVTXOsByScriptsRequest, error) {
 
 	c.logger(ctx).TraceS(ctx, "Building ListVTXOsByScripts request",
 		slog.Int("scope_count", len(scopes)),
-		slog.Uint64("after_cursor", afterCursor),
+		slog.Int("after_cursor_len", len(afterCursor)),
 		slog.Int("limit", int(limit)),
 		slog.Int("status_filter_count", len(statusFilter)))
 
@@ -619,7 +619,7 @@ func (c *Client) BuildListVTXOsByScriptsTaprootRequest(ctx context.Context,
 	return &arkrpc.ListVTXOsByScriptsRequest{
 		Scripts:      scriptScopes,
 		StatusFilter: statusFilter,
-		Cursor:       afterCursor,
+		Cursor:       append([]byte(nil), afterCursor...),
 		Limit:        limit,
 	}, nil
 }
@@ -627,7 +627,7 @@ func (c *Client) BuildListVTXOsByScriptsTaprootRequest(ctx context.Context,
 // ListVTXOsByScriptsTaproot performs a proof-gated VTXO query for one
 // or more pkScripts.
 func (c *Client) ListVTXOsByScriptsTaproot(ctx context.Context,
-	scopes []TaprootScriptScope, afterCursor uint64, limit uint32,
+	scopes []TaprootScriptScope, afterCursor []byte, limit uint32,
 	statusFilter []arkrpc.VTXOStatus,
 	opts ...mailboxrpc.RPCOptions) (
 	*arkrpc.ListVTXOsByScriptsResponse, error) {

--- a/serverconn/AGENTS.md
+++ b/serverconn/AGENTS.md
@@ -22,7 +22,7 @@ background ingress polling with event routing.
 - `DurableUnaryRequestBuilder` — Interface for proof-gated request-body construction. Implementations build the actual proto request (e.g., with signed proofs) at send time, not at persist time. The interface is provided via `ConnectorConfig.DurableUnaryBuilder`.
 - `DurableUnaryQuery` — Interface implemented by transport-native durable query messages that persist raw query parameters (not a full proto). The `ServerConnectionActor` matches any `DurableUnaryQuery` generically in its `Receive` loop and calls `buildDurableUnary` to construct a `SendUnaryRequest` on the fly, using `BuildBody`, `QueryCorrelationID`, `QueryMsgID`, `QueryIdempotencyKey`, and `ServiceMethod`.
 - `SendListOORRecipientEventsByScriptRequest` — TLV-durable (type `2003`) indexer query message for phase-1 OOR receive resolution. Persists PkScript, AfterEventID, Limit, CorrelationID, MsgID, and IdempotencyKey; the proof-gated proto body is built at send time by `DurableUnaryRequestBuilder.BuildListOORRecipientEventsByScriptRequest`.
-- `SendListVTXOsByScriptsRequest` — TLV-durable (type `2004`) indexer query message for phase-2 OOR metadata resolution. Persists PkScripts (count-prefixed, length-prefixed list), AfterCursor, Limit, CorrelationID, MsgID, and IdempotencyKey; the proof-gated proto body is built by `DurableUnaryRequestBuilder.BuildListVTXOsByScriptsRequest`.
+- `SendListVTXOsByScriptsRequest` — TLV-durable (type `2004`) indexer query message for phase-2 OOR metadata resolution. Persists PkScripts (count-prefixed, length-prefixed list), opaque AfterCursor, Limit, CorrelationID, MsgID, and IdempotencyKey; the proof-gated proto body is built by `DurableUnaryRequestBuilder.BuildListVTXOsByScriptsRequest`.
 
 ## Relationships
 

--- a/serverconn/CLAUDE.md
+++ b/serverconn/CLAUDE.md
@@ -22,7 +22,7 @@ background ingress polling with event routing.
 - `DurableUnaryRequestBuilder` — Interface for proof-gated request-body construction. Implementations build the actual proto request (e.g., with signed proofs) at send time, not at persist time. The interface is provided via `ConnectorConfig.DurableUnaryBuilder`.
 - `DurableUnaryQuery` — Interface implemented by transport-native durable query messages that persist raw query parameters (not a full proto). The `ServerConnectionActor` matches any `DurableUnaryQuery` generically in its `Receive` loop and calls `buildDurableUnary` to construct a `SendUnaryRequest` on the fly, using `BuildBody`, `QueryCorrelationID`, `QueryMsgID`, `QueryIdempotencyKey`, and `ServiceMethod`.
 - `SendListOORRecipientEventsByScriptRequest` — TLV-durable (type `2003`) indexer query message for phase-1 OOR receive resolution. Persists PkScript, AfterEventID, Limit, CorrelationID, MsgID, and IdempotencyKey; the proof-gated proto body is built at send time by `DurableUnaryRequestBuilder.BuildListOORRecipientEventsByScriptRequest`.
-- `SendListVTXOsByScriptsRequest` — TLV-durable (type `2004`) indexer query message for phase-2 OOR metadata resolution. Persists PkScripts (count-prefixed, length-prefixed list), AfterCursor, Limit, CorrelationID, MsgID, and IdempotencyKey; the proof-gated proto body is built by `DurableUnaryRequestBuilder.BuildListVTXOsByScriptsRequest`.
+- `SendListVTXOsByScriptsRequest` — TLV-durable (type `2004`) indexer query message for phase-2 OOR metadata resolution. Persists PkScripts (count-prefixed, length-prefixed list), opaque AfterCursor, Limit, CorrelationID, MsgID, and IdempotencyKey; the proof-gated proto body is built by `DurableUnaryRequestBuilder.BuildListVTXOsByScriptsRequest`.
 
 ## Relationships
 

--- a/serverconn/actor_tlv_test.go
+++ b/serverconn/actor_tlv_test.go
@@ -216,7 +216,7 @@ func TestSendListVTXOsByScriptsRequest_TLVRoundTrip(t *testing.T) {
 			{0x51, 0x20, 0x01},
 			{0x51, 0x20, 0x02},
 		},
-		AfterCursor:   11,
+		AfterCursor:   []byte("cursor-11"),
 		Limit:         128,
 		CorrelationID: "corr-vtxo-query",
 	}
@@ -234,6 +234,71 @@ func TestSendListVTXOsByScriptsRequest_TLVRoundTrip(t *testing.T) {
 	require.Equal(t, original.CorrelationID, decoded.CorrelationID)
 	require.NotEmpty(t, decoded.MsgID)
 	require.NotEmpty(t, decoded.IdempotencyKey)
+}
+
+// TestSendListVTXOsByScriptsRequest_DecodesLegacyZeroCursor verifies an old
+// durable uint64(0) cursor can still replay as the empty keyset cursor.
+func TestSendListVTXOsByScriptsRequest_DecodesLegacyZeroCursor(t *testing.T) {
+	t.Parallel()
+
+	type (
+		legacyCursorTLV = listVTXOsLegacyCursorRecordTLV
+		correlationTLV  = listVTXOsCorrelationRecordTLV
+		idempotencyTLV  = listVTXOsIdempotencyRecordTLV
+	)
+
+	pkScriptsRaw, err := encodeLengthPrefixedBlobList(
+		[][]byte{{0x51, 0x20, 0x01}},
+	)
+	require.NoError(t, err)
+
+	pkScriptsRec := tlv.NewPrimitiveRecord[listVTXOsPkScriptsRecordTLV](
+		pkScriptsRaw,
+	)
+	legacyCursorRec := tlv.NewPrimitiveRecord[legacyCursorTLV](uint64(0))
+	limitRec := tlv.NewPrimitiveRecord[listVTXOsLimitRecordTLV](
+		uint64(128),
+	)
+	correlationRec := tlv.NewPrimitiveRecord[correlationTLV](
+		[]byte("corr-legacy"),
+	)
+	msgIDRec := tlv.NewPrimitiveRecord[listVTXOsMsgIDRecordTLV](
+		[]byte("msg-legacy"),
+	)
+	idempotencyRec := tlv.NewPrimitiveRecord[idempotencyTLV](
+		[]byte("idem-legacy"),
+	)
+
+	stream, err := tlv.NewStream(
+		pkScriptsRec.Record(), legacyCursorRec.Record(),
+		limitRec.Record(), correlationRec.Record(),
+		msgIDRec.Record(), idempotencyRec.Record(),
+	)
+	require.NoError(t, err)
+
+	var encoded bytes.Buffer
+	require.NoError(t, stream.Encode(&encoded))
+
+	var decoded SendListVTXOsByScriptsRequest
+	require.NoError(t, decoded.Decode(bytes.NewReader(encoded.Bytes())))
+	require.Empty(t, decoded.AfterCursor)
+	require.Equal(t, uint32(128), decoded.Limit)
+}
+
+// TestNormalizeVTXOAfterCursorRejectsLegacyNonZero verifies old durable
+// non-zero cursors are rejected because they cannot be translated to keyset
+// pagination safely.
+func TestNormalizeVTXOAfterCursorRejectsLegacyNonZero(t *testing.T) {
+	t.Parallel()
+
+	_, err := normalizeVTXOAfterCursor(1, true, nil, false)
+	require.ErrorContains(t, err, "unsupported legacy vtxo cursor 1")
+
+	cursor, err := normalizeVTXOAfterCursor(
+		0, true, []byte("cursor-11"), true,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []byte("cursor-11"), cursor)
 }
 
 // TestServerConnMessageMetadata verifies static message metadata methods.
@@ -398,7 +463,7 @@ func TestServerConnCodec_RoundTrip(t *testing.T) {
 			{0x51, 0x20, 0x05},
 			{0x51, 0x20, 0x06},
 		},
-		AfterCursor:   13,
+		AfterCursor:   []byte("cursor-13"),
 		Limit:         128,
 		CorrelationID: "corr-codec-vtxo",
 	}

--- a/serverconn/connector_test.go
+++ b/serverconn/connector_test.go
@@ -55,11 +55,11 @@ func (b *testDurableUnaryBuilder) BuildListOORRecipientEventsByScriptRequest(
 // BuildListVTXOsByScriptsRequest builds a deterministic proto body for
 // VTXO-by-scripts query tests.
 func (b *testDurableUnaryBuilder) BuildListVTXOsByScriptsRequest(
-	_ context.Context, pkScripts [][]byte, afterCursor uint64, limit uint32,
+	_ context.Context, pkScripts [][]byte, afterCursor []byte, limit uint32,
 ) (proto.Message, error) {
 
 	return wrapperspb.String(fmt.Sprintf(
-		"vtxos:%d:%d:%d", len(pkScripts), afterCursor, limit,
+		"vtxos:%d:%x:%d", len(pkScripts), afterCursor, limit,
 	)), nil
 }
 

--- a/serverconn/durable_unary_queries.go
+++ b/serverconn/durable_unary_queries.go
@@ -35,11 +35,12 @@ type (
 	listRecipientMsgIDRecordTLV       = tlv.TlvType5
 	listRecipientIdempotencyRecordTLV = tlv.TlvType6
 	listVTXOsPkScriptsRecordTLV       = tlv.TlvType1
-	listVTXOsAfterCursorRecordTLV     = tlv.TlvType2
+	listVTXOsLegacyCursorRecordTLV    = tlv.TlvType2
 	listVTXOsLimitRecordTLV           = tlv.TlvType3
 	listVTXOsCorrelationRecordTLV     = tlv.TlvType4
 	listVTXOsMsgIDRecordTLV           = tlv.TlvType5
 	listVTXOsIdempotencyRecordTLV     = tlv.TlvType6
+	listVTXOsAfterCursorRecordTLV     = tlv.TlvType7
 )
 
 // SendListOORRecipientEventsByScriptRequest describes a durable proof-gated
@@ -248,7 +249,7 @@ type SendListVTXOsByScriptsRequest struct {
 	PkScripts [][]byte
 
 	// AfterCursor is the exclusive lower bound for the VTXO query cursor.
-	AfterCursor uint64
+	AfterCursor []byte
 
 	// Limit is the maximum number of VTXOs to return.
 	Limit uint32
@@ -362,9 +363,6 @@ func (m *SendListVTXOsByScriptsRequest) Encode(w io.Writer) error {
 	pkScriptsRec := tlv.NewPrimitiveRecord[listVTXOsPkScriptsRecordTLV](
 		pkScriptsRaw,
 	)
-	afterCursorRec := tlv.NewPrimitiveRecord[listVTXOsAfterCursorRecordTLV](
-		m.AfterCursor,
-	)
 	limit := uint64(m.Limit)
 	limitRec := tlv.NewPrimitiveRecord[listVTXOsLimitRecordTLV](
 		limit,
@@ -378,11 +376,15 @@ func (m *SendListVTXOsByScriptsRequest) Encode(w io.Writer) error {
 	idempotencyRec := tlv.NewPrimitiveRecord[listVTXOsIdempotencyRecordTLV](
 		[]byte(idempotencyKey),
 	)
+	afterCursorRec := tlv.NewPrimitiveRecord[listVTXOsAfterCursorRecordTLV](
+		append([]byte(nil), m.AfterCursor...),
+	)
 
 	stream, err := tlv.NewStream(
-		pkScriptsRec.Record(), afterCursorRec.Record(),
+		pkScriptsRec.Record(),
 		limitRec.Record(), correlationRec.Record(),
 		msgIDRec.Record(), idempotencyRec.Record(),
+		afterCursorRec.Record(),
 	)
 	if err != nil {
 		return err
@@ -394,9 +396,13 @@ func (m *SendListVTXOsByScriptsRequest) Encode(w io.Writer) error {
 // Decode deserializes the message from the provided reader.
 func (m *SendListVTXOsByScriptsRequest) Decode(r io.Reader) error {
 	pkScriptsRec := tlv.ZeroRecordT[listVTXOsPkScriptsRecordTLV, []byte]()
+	legacyCursorRec := tlv.ZeroRecordT[
+		listVTXOsLegacyCursorRecordTLV,
+		uint64,
+	]()
 	afterCursorRec := tlv.ZeroRecordT[
 		listVTXOsAfterCursorRecordTLV,
-		uint64,
+		[]byte,
 	]()
 	limitRec := tlv.ZeroRecordT[listVTXOsLimitRecordTLV, uint64]()
 	correlationRec := tlv.ZeroRecordT[
@@ -410,15 +416,17 @@ func (m *SendListVTXOsByScriptsRequest) Decode(r io.Reader) error {
 	]()
 
 	stream, err := tlv.NewStream(
-		pkScriptsRec.Record(), afterCursorRec.Record(),
+		pkScriptsRec.Record(), legacyCursorRec.Record(),
 		limitRec.Record(), correlationRec.Record(),
 		msgIDRec.Record(), idempotencyRec.Record(),
+		afterCursorRec.Record(),
 	)
 	if err != nil {
 		return err
 	}
 
-	if _, err := stream.DecodeWithParsedTypes(r); err != nil {
+	parsed, err := stream.DecodeWithParsedTypes(r)
+	if err != nil {
 		return err
 	}
 
@@ -432,14 +440,49 @@ func (m *SendListVTXOsByScriptsRequest) Decode(r io.Reader) error {
 			limitRec.Val)
 	}
 
+	_, legacyCursorSet := parsed[legacyCursorRec.TlvType()]
+	_, afterCursorSet := parsed[afterCursorRec.TlvType()]
+
+	afterCursor, err := normalizeVTXOAfterCursor(
+		legacyCursorRec.Val, legacyCursorSet, afterCursorRec.Val,
+		afterCursorSet,
+	)
+	if err != nil {
+		return err
+	}
+
 	m.PkScripts = pkScripts
-	m.AfterCursor = afterCursorRec.Val
+	m.AfterCursor = afterCursor
 	m.Limit = uint32(limitRec.Val)
 	m.CorrelationID = string(correlationRec.Val)
 	m.MsgID = string(msgIDRec.Val)
 	m.IdempotencyKey = string(idempotencyRec.Val)
 
 	return nil
+}
+
+// normalizeVTXOAfterCursor selects the decoded opaque cursor or translates an
+// old uint64 cursor when replaying a durable query persisted before keyset
+// cursors existed.
+func normalizeVTXOAfterCursor(legacyCursor uint64, legacyCursorSet bool,
+	afterCursor []byte, afterCursorSet bool) ([]byte, error) {
+
+	if afterCursorSet {
+		return append([]byte(nil), afterCursor...), nil
+	}
+
+	if legacyCursorSet {
+		if legacyCursor != 0 {
+			return nil, fmt.Errorf(
+				"unsupported legacy vtxo cursor %d",
+				legacyCursor,
+			)
+		}
+
+		return nil, nil
+	}
+
+	return nil, nil
 }
 
 // serverConnMsgSealed implements the ServerConnMsg interface seal.
@@ -477,7 +520,7 @@ func encodeRecipientEventsQueryIdentity(pkScript []byte, afterEventID uint64,
 // encodeVTXOsByScriptsQueryIdentity encodes the stable identity material for
 // a VTXO-by-scripts query.
 func encodeVTXOsByScriptsQueryIdentity(pkScripts [][]byte,
-	afterCursor uint64, limit uint32,
+	afterCursor []byte, limit uint32,
 	correlationID string) ([]byte, error) {
 
 	var buf bytes.Buffer
@@ -489,9 +532,7 @@ func encodeVTXOsByScriptsQueryIdentity(pkScripts [][]byte,
 	if err := writeLengthPrefixedBlob(&buf, pkScriptsRaw); err != nil {
 		return nil, err
 	}
-	if err := binary.Write(
-		&buf, binary.BigEndian, afterCursor,
-	); err != nil {
+	if err := writeLengthPrefixedBlob(&buf, afterCursor); err != nil {
 		return nil, err
 	}
 	if err := binary.Write(

--- a/serverconn/restart_replay_test.go
+++ b/serverconn/restart_replay_test.go
@@ -188,7 +188,7 @@ func TestDurableUnary_RestartReplayPreservesStableIDs(t *testing.T) {
 			PkScripts: [][]byte{
 				{0x51, 0x20, 0x01},
 			},
-			AfterCursor:   11,
+			AfterCursor:   []byte("cursor-11"),
 			Limit:         5,
 			CorrelationID: "corr-vtxo-restart",
 		},
@@ -244,5 +244,5 @@ func TestDurableUnary_RestartReplayPreservesStableIDs(t *testing.T) {
 
 	payload := &wrapperspb.StringValue{}
 	require.NoError(t, replayed.GetBody().UnmarshalTo(payload))
-	require.Equal(t, "vtxos:1:11:5", payload.GetValue())
+	require.Equal(t, "vtxos:1:637572736f722d3131:5", payload.GetValue())
 }

--- a/serverconn/types.go
+++ b/serverconn/types.go
@@ -76,7 +76,7 @@ type DurableUnaryRequestBuilder interface {
 	// BuildListVTXOsByScriptsRequest builds the ListVTXOsByScripts unary
 	// request for the given taproot output scripts and cursor.
 	BuildListVTXOsByScriptsRequest(ctx context.Context,
-		pkScripts [][]byte, afterCursor uint64, limit uint32) (
+		pkScripts [][]byte, afterCursor []byte, limit uint32) (
 		proto.Message, error,
 	)
 }


### PR DESCRIPTION
## Summary

This is the client-side half of the fix for lightninglabs/darepo#105.

`ListVTXOsByScripts` currently exposes the pagination cursor as a numeric offset. The server needs to replace that with a keyset cursor so inserts or deletes between pages do not cause duplicate or skipped VTXOs. This PR changes the client-facing surface to treat the cursor as opaque bytes and passes those bytes through without interpretation.

## Changes

- Change `ListVTXOsByScriptsRequest.cursor` from `uint64` to `bytes`.
- Change `ListVTXOsByScriptsResponse.next_cursor` from `uint64` to `bytes`.
- Update the indexer client helpers to accept and clone `[]byte` cursors.
- Update durable serverconn query encoding so the opaque cursor is persisted and replayed as bytes.
- Preserve replay compatibility for old durable zero-valued cursors by normalizing legacy `uint64(0)` encodings to the empty cursor.
- Keep `AGENTS.md` and `CLAUDE.md` in sync for the durable query notes.

## Server Stack

The matching darepo server PR consumes this client commit and implements DB-backed keyset pagination using `(outpoint_hash, outpoint_index)` as the cursor key. This PR only updates the API and client plumbing needed for that server-side change.

## Validation

- `make rpc`
- `go test ./arkrpc ./indexer ./serverconn ./darepod ./oor`
- `make schema-check`
- `make commitmsg-lint range=origin/main..HEAD`
- `GOGC=50 make lint`
- `go test ./...` mostly passed, but `darepod/TestRunWithContextServesInjectedListener` hit a local timing failure while migrations were still running; rerunning that test directly with `go test ./darepod -run TestRunWithContextServesInjectedListener -count=1` passed.
