### PR TITLE
systest: add reorg stress action

### DIFF
--- a/systest/reorg_test.go
+++ b/systest/reorg_test.go
@@ -1,0 +1,52 @@
+//go:build systest
+
+package systest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/stretchr/testify/require"
+)
+
+// TestReorgStressActionConvergesAndWalletRemainsUsable verifies that the
+// systest reorg action can be injected into a live actor stack and that
+// boarding wallet chain notifications continue to work afterward.
+func TestReorgStressActionConvergesAndWalletRemainsUsable(t *testing.T) {
+	ParallelN(t)
+
+	f := NewBoardingWalletFixture(t)
+	h := f.Harness
+
+	oldTip := h.Harness.BestBlockHeader()
+	result := h.ApplyReorgAction(ReorgAction{Depth: 2})
+	newTip := h.Harness.BestBlockHeader()
+
+	require.Equal(t, oldTip.Hash, result.OldTip.Hash)
+	require.Equal(t, oldTip.Height-2, result.ForkPoint.Height)
+	require.Len(t, result.Disconnected, 2)
+	require.Len(t, result.Connected, 3)
+	require.Equal(
+		t, result.Connected[len(result.Connected)-1].Hash, newTip.Hash,
+	)
+	require.Equal(t, oldTip.Height+1, newTip.Height)
+	require.NotEqual(t, oldTip.Hash, newTip.Hash)
+
+	addrResp := f.CreateBoardingAddress(144)
+	amount := btcutil.Amount(btcutil.SatoshiPerBitcoin / 10)
+	f.FundAddress(addrResp.Address.String(), amount)
+	f.WaitForBalance(30 * time.Second)
+
+	addresses := f.GetActiveAddresses()
+	storedAddr := addresses[addrResp.Address.String()]
+	require.NotNil(t, storedAddr)
+
+	f.AssertIntentStored(storedAddr, amount)
+
+	balance := f.GetBalance()
+	require.Equal(t, 1, balance.UtxoCount)
+	require.InDelta(
+		t, int64(amount), int64(balance.TotalBalance), 10000,
+	)
+}

--- a/systest/systest.go
+++ b/systest/systest.go
@@ -233,6 +233,44 @@ func (h *SysTestHarness) WaitForLNDSync() {
 	h.Harness.WaitForLNDChainSync()
 }
 
+// ReorgAction describes a deterministic regtest reorg injected by a systest.
+type ReorgAction struct {
+	// Depth is the number of active-chain blocks to disconnect.
+	Depth int
+
+	// NewBlocks is the number of replacement-branch blocks to mine. If
+	// unset, ApplyReorgAction mines Depth+1 blocks so the replacement
+	// branch becomes active.
+	NewBlocks int
+}
+
+// ApplyReorgAction injects a deterministic regtest reorg and waits for the
+// systest-visible chain services to converge on the replacement branch.
+func (h *SysTestHarness) ApplyReorgAction(
+	action ReorgAction,
+) harness.ReorgResult {
+
+	h.t.Helper()
+
+	newBlocks := action.NewBlocks
+	if newBlocks == 0 {
+		newBlocks = action.Depth + 1
+	}
+
+	result := h.Harness.Reorg(action.Depth, newBlocks)
+	h.WaitForReorgConvergence(result)
+
+	return result
+}
+
+// WaitForReorgConvergence waits for services used by systests to observe the
+// active chain after a reorg.
+func (h *SysTestHarness) WaitForReorgConvergence(_ harness.ReorgResult) {
+	h.t.Helper()
+
+	h.WaitForLNDSync()
+}
+
 const (
 	// DefaultTimeout is the default timeout for various operations.
 	DefaultTimeout = 30 * time.Second


### PR DESCRIPTION
## Summary
- add a systest-level `ReorgAction` wrapper that injects deterministic regtest reorgs through the harness helper
- add a boarding-wallet systest that reorgs the live actor stack, then funds a boarding address and asserts balance/intent convergence

## Stress test behavior
- `TestReorgStressActionConvergesAndWalletRemainsUsable` consistently passed locally in ~19s per run
- three back-to-back runs completed in 56.7s total, so the existing 30s wallet-balance wait is enough without tightening it to local timing

## Validation
- `go test -tags=systest ./systest -run TestReorgStressActionConvergesAndWalletRemainsUsable -count=1 -timeout=10m -v`
- `go test -tags=systest ./systest -run TestReorgStressActionConvergesAndWalletRemainsUsable -count=3 -timeout=10m -v`
- `go test -tags=systest ./systest -timeout=20m`
- `go test ./harness`
- `git diff --check`
- `GOGC=50 make lint`

Stacked on #361 (`feat/arktest-reorgs`); retarget to `main` after #361 lands.
