### PR TITLE
walletdk: add embedded wallet SDK and TUI

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -54,6 +54,7 @@ package may import from a higher layer.
 | [`darepod`](darepod/) | Daemon orchestrator: wires all subsystems, exposes gRPC API |
 | [`sdk/ark`](sdk/ark/) | Consumer-facing Go SDK facade: remote or embedded daemon access with typed models |
 | [`sdk/swaps`](sdk/swaps/) | Lightning-to-Ark / Ark-to-Lightning atomic swap SDK with durable FSM flows |
+| [`sdk/walletdk`](sdk/walletdk/) | Wallet-shaped SDK facade for host apps: embeds the daemon in-process, dials it over a private bufconn transport, exposes typed onboarding / balance / receive / send / swap-accounting methods. Swap methods gated behind the `swapruntime` build tag |
 | [`swapclientserver`](swapclientserver/) | Optional daemon-side swap subserver (build tag `swapruntime`): translates `swapclientrpc` RPCs into `sdk/swaps` operations and manages the daemon-local worker registry |
 | [`cmd/darepod`](cmd/darepod/) | Daemon entry point |
 | [`cmd/darepocli`](cmd/darepocli/) | CLI client |

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@ into specific topics below.
 | [fee_ledger.md](fee_ledger.md) | Client-side double-entry fee ledger: chart of accounts, per-flow walkthroughs, emission sites, replay safety |
 | [fee-change-model.md](fee-change-model.md) | Seal-time fee handshake (#270): change-output designation rules, 11-scenario catalogue, proto contract, CLI mapping |
 | [sdk_layered_architecture.md](sdk_layered_architecture.md) | SDK layering rationale: `sdk/ark` facade, remote vs. embedded modes, `sdk/swaps` future direction |
+| [walletdk_integration.md](walletdk_integration.md) | Basic `walletdk` integration flow, startup/config examples, swap accounting, and wrapper guidance |
 | [swap_background_execution.md](swap_background_execution.md) | Optional build-tagged daemon executor for background swap progress and daemon-backed CLI control |
 | [mailbox_architecture.md](mailbox_architecture.md) | Three-layer mailbox system: pb, rpc, conn, serverconn |
 | [RPC_MAILBOX_CONTRACT.md](RPC_MAILBOX_CONTRACT.md) | Envelope semantics, at-least-once delivery, ack watermarks |

--- a/docs/walletdk_integration.md
+++ b/docs/walletdk_integration.md
@@ -1,0 +1,316 @@
+# walletdk Integration Guide
+
+`walletdk` is the wallet-facing SDK for applications that want a small,
+stable API over the embedded `darepod` client daemon. It starts the daemon
+in-process, connects to it over a private `bufconn` gRPC transport, and exposes
+wallet-shaped methods for onboarding, balances, Lightning receives, Lightning
+sends, and swap accounting.
+
+The package is intended to be the layer that app developers wrap for mobile,
+desktop, React Native, gomobile, or host-language bridges. Application code
+should call `walletdk` rather than reimplement daemon RPC wiring or swap state
+machines.
+
+## Package
+
+```go
+import "github.com/lightninglabs/darepo-client/sdk/walletdk"
+```
+
+Swap send and receive support requires the `swapruntime` build tag:
+
+```sh
+go build -tags swapruntime ./cmd/your-wallet
+go test -tags swapruntime ./sdk/walletdk
+```
+
+Without that tag, wallet bootstrapping and Ark daemon RPC wrappers still build,
+but `Receive`, `Send`, `ListSwaps`, `GetSwap`, `ResumeSwap`, and
+`SubscribeSwaps` fail with `walletdk.ErrSwapRuntimeUnavailable`.
+
+## Runtime Model
+
+`walletdk.Start` owns a full embedded daemon runtime:
+
+1. Build a `walletdk.Config`.
+2. Start the embedded daemon with `walletdk.Start`.
+3. Create or unlock the wallet.
+4. Poll or subscribe to wallet and swap state.
+5. Call `Stop` when the host app shuts down.
+
+The returned `*walletdk.Client` is safe for concurrent use. The client owns
+daemon shutdown, private gRPC connection shutdown, and the swap RPC clients
+registered on the embedded daemon.
+
+## Minimal Startup
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/lightninglabs/darepo-client/sdk/walletdk"
+	"github.com/lightningnetwork/lnd/fn/v2"
+)
+
+func main() {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cfg := walletdk.DefaultConfig()
+	cfg.DataDir = "/tmp/example-wallet"
+	cfg.Network = "regtest"
+	cfg.ServerAddress = "127.0.0.1:10010"
+	cfg.ServerInsecure = fn.Some(true)
+	cfg.WalletType = "lwwallet"
+	cfg.WalletEsploraURL = "http://127.0.0.1:3002"
+	cfg.SwapServerAddress = "127.0.0.1:11010"
+	cfg.SwapServerInsecure = fn.Some(true)
+	cfg.LogWriter = io.Discard
+
+	client, err := walletdk.Start(ctx, cfg)
+	if err != nil {
+		panic(err)
+	}
+	defer client.Stop()
+
+	info, err := client.GetInfo(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("network=%s wallet_ready=%v\n",
+		info.Network, info.WalletReady)
+}
+```
+
+Use a durable app-specific `DataDir`. It contains wallet state, daemon state,
+and swap accounting. Deleting it deletes the local wallet database and local
+swap history.
+
+## Create Or Unlock
+
+Most apps should treat wallet bootstrap as a two-branch flow:
+
+1. Start `walletdk`.
+2. Call `GetInfo`.
+3. If `WalletReady` is false and this is first run, call `CreateWallet`.
+4. If a wallet already exists but is locked, call `UnlockWallet`.
+5. Persist only the user-approved backup material or password material your
+   product is designed to own.
+
+```go
+password := []byte("correct horse battery staple")
+
+created, err := client.CreateWallet(ctx, walletdk.CreateWalletRequest{
+	WalletPassword: password,
+})
+if err != nil {
+	panic(err)
+}
+
+fmt.Println("identity:", created.IdentityPubKey)
+fmt.Println("mnemonic:", created.Mnemonic)
+```
+
+For an existing wallet:
+
+```go
+unlocked, err := client.UnlockWallet(ctx, walletdk.UnlockWalletRequest{
+	WalletPassword: password,
+})
+if err != nil {
+	panic(err)
+}
+
+fmt.Println("identity:", unlocked.IdentityPubKey)
+```
+
+`CreateWallet` returns the mnemonic when it generated a new seed. Show it once,
+require the user to back it up, and avoid writing it to logs.
+
+## Wallet Operations
+
+Fetch a balance:
+
+```go
+balance, err := client.ListBalance(ctx)
+if err != nil {
+	panic(err)
+}
+
+fmt.Println("confirmed:", balance.TotalConfirmedSat)
+fmt.Println("ark vtxo:", balance.VTXOBalanceSat)
+```
+
+Allocate an onboarding address:
+
+```go
+addr, err := client.GetOnchainAddress(ctx)
+if err != nil {
+	panic(err)
+}
+
+fmt.Println(addr.Address)
+```
+
+Start a Lightning-to-Ark receive:
+
+```go
+receive, err := client.Receive(ctx, walletdk.ReceiveRequest{
+	AmountSat: 50_000,
+})
+if err != nil {
+	panic(err)
+}
+
+fmt.Println("invoice:", receive.Invoice)
+fmt.Println("payment hash:", receive.PaymentHash)
+fmt.Println("initial state:", receive.Swap.State)
+```
+
+Start an Ark-to-Lightning send:
+
+```go
+send, err := client.Send(ctx, walletdk.SendRequest{
+	Invoice:   bolt11Invoice,
+	MaxFeeSat: 1_000,
+})
+if err != nil {
+	panic(err)
+}
+
+fmt.Println("payment hash:", send.PaymentHash)
+fmt.Println("initial state:", send.Swap.State)
+```
+
+## Swap Accounting
+
+Use `ListSwaps` for the durable accounting view:
+
+```go
+swaps, err := client.ListSwaps(ctx, walletdk.ListSwapsRequest{
+	PendingOnly: false,
+})
+if err != nil {
+	panic(err)
+}
+
+for _, swap := range swaps {
+	fmt.Println(swap.Direction, swap.PaymentHash, swap.State, swap.Pending)
+}
+```
+
+Use `SubscribeSwaps` to drive live UI updates:
+
+```go
+subCtx, stopSub := context.WithCancel(context.Background())
+defer stopSub()
+
+updates, errs, err := client.SubscribeSwaps(
+	subCtx, walletdk.SubscribeSwapsRequest{
+		IncludeExisting: true,
+		PendingOnly:     false,
+	},
+)
+if err != nil {
+	panic(err)
+}
+
+go func() {
+	for {
+		select {
+		case update, ok := <-updates:
+			if !ok {
+				return
+			}
+
+			fmt.Println("swap update:", update.PaymentHash, update.State)
+
+		case err, ok := <-errs:
+			if ok && err != nil {
+				fmt.Println("swap subscription error:", err)
+			}
+
+			return
+		}
+	}
+}()
+```
+
+After startup, applications can call `ResumeSwap` for pending swaps or rely on
+future app-specific startup logic to resume all pending work. Keep the durable
+swap list as the UI source of truth instead of inventing a second local payment
+state model.
+
+## Shutdown
+
+Always stop the SDK on application shutdown:
+
+```go
+if err := client.Stop(); err != nil {
+	// Log at warn/info level for normal app shutdown paths.
+	fmt.Println("wallet shutdown:", err)
+}
+```
+
+`Stop` and `Close` are aliases and are idempotent. `Wait` exposes the embedded
+daemon's terminal run error for hosts that want to monitor daemon death:
+
+```go
+go func() {
+	if err := <-client.Wait(); err != nil {
+		fmt.Println("wallet runtime stopped:", err)
+	}
+}()
+```
+
+## Wrapper Guidance
+
+Keep host-language bindings thin:
+
+- Own one `*walletdk.Client` per wallet runtime.
+- Expose explicit `Start`, `Stop`, `CreateWallet`, `UnlockWallet`,
+  `ListBalance`, `GetOnchainAddress`, `Receive`, `Send`, `ListSwaps`, and
+  `SubscribeSwaps` methods.
+- Convert SDK structs into plain host DTOs. Do not expose protobuf messages to
+  mobile or JavaScript callers.
+- Accept caller-provided timeouts or cancellation handles for every operation.
+- Route `Config.LogWriter` into the host logging system or a UI log buffer.
+- Treat `DataDir`, wallet password handling, and mnemonic display as product
+  security decisions owned by the host app.
+
+For gomobile or React Native bridges, prefer a small manager object with string
+or JSON DTO methods. For example, a bridge can hold the Go client internally and
+return JSON-encoded `Balance`, `ReceiveResult`, and `SwapSummary` values to the
+host UI.
+
+For browser WASM, do not assume the current embedded daemon can run unchanged
+inside a browser sandbox. The daemon expects filesystem, networking, timers,
+and gRPC behavior that are more natural in native Go targets. A practical WASM
+path is to keep the same wallet-shaped API but back it with a remote daemon or
+host-provided transport until the daemon runtime is adapted for browser storage
+and networking.
+
+## LLM Integration Checklist
+
+When generating wallet code against `walletdk`, follow this checklist:
+
+1. Import `github.com/lightninglabs/darepo-client/sdk/walletdk`.
+2. Build with `-tags swapruntime` if the code calls swap methods.
+3. Use `walletdk.DefaultConfig()` and override only deployment-specific fields.
+4. Set a durable `DataDir`.
+5. Set `Network`, Ark operator connection fields, wallet backend fields, and
+   swap server fields.
+6. Start with `walletdk.Start(ctx, cfg)`.
+7. Create or unlock the wallet before balance, address, receive, or send
+   operations.
+8. Display `ReceiveResult.Invoice` as the canonical BOLT-11 value.
+9. Use `ListSwaps` and `SubscribeSwaps` for payment accounting.
+10. Call `Stop` during app shutdown.
+11. Never log wallet passwords, seed passphrases, mnemonics, or full invoices
+    unless the product explicitly asks for that debug behavior.

--- a/sdk/walletdk/AGENTS.md
+++ b/sdk/walletdk/AGENTS.md
@@ -1,0 +1,136 @@
+# sdk/walletdk
+
+## Purpose
+
+Wallet-shaped SDK facade for host apps that want a small, stable Go API over
+an embedded `darepod` client daemon. `Start` boots the daemon in-process,
+dials it over a private `bufconn` gRPC transport, and exposes typed methods
+for onboarding, balances, Lightning-to-Ark receives, Ark-to-Lightning sends,
+and swap accounting. Daemon-owned swap send and receive are gated behind the
+`swapruntime` build tag so default builds avoid the swap executor's dependency
+graph.
+
+## Key Types
+
+- `Client` — Concurrency-safe wallet handle. Owns the embedded daemon
+  lifecycle, the private `bufconn` gRPC connection, and the daemon-owned swap
+  RPC clients. `Stop`/`Close` are aliases; both are idempotent.
+- `Config` — Embedded daemon + wallet facade config. Two usage modes:
+  zero-value plus convenience fields (`DataDir`, `Network`, `ServerAddress`,
+  …), or a caller-owned `DaemonConfig` plus only the convenience fields the
+  host wants to override. The convenience booleans (`AllowMainnet`,
+  `ServerInsecure`, `SwapServerInsecure`) are `fn.Option[bool]`: `fn.None`
+  defers to `DaemonConfig`, `fn.Some(v)` forces that value.
+- `DefaultConfig` — Returns a walletdk `Config` populated from
+  `darepod.DefaultConfig()`. Convenience starting point for hosts.
+- `Start` — Boots the embedded daemon, dials it, waits for gRPC readiness,
+  and returns a ready-to-use `*Client`. Detaches the daemon lifetime from the
+  caller's `ctx` so a tight startup deadline does not kill the daemon.
+- `Info` / `Balance` / `OnchainAddress` / `CreateWalletResult` /
+  `UnlockWalletResult` — Wrapper-owned wallet DTOs. Mobile and JS bridges see
+  these, not protobuf types.
+- `ReceiveRequest` / `ReceiveResult` / `SendRequest` / `SendResult` —
+  Wrapper-owned swap-start DTOs. Receive returns a BOLT-11 invoice plus the
+  initial durable swap summary; Send returns the payment hash plus the
+  initial summary.
+- `SwapSummary` — Wrapper-owned durable swap view used for `ListSwaps`,
+  `GetSwap`, `ResumeSwap`, and `SubscribeSwaps`. Stable lowercase `State`
+  string is owned by `convert.go`, intentionally decoupled from the proto
+  enum's renumbering.
+- `SwapDirection` (`"pay"`, `"receive"`) — Public direction enum for resume
+  requests and summary inspection.
+- `ErrSwapRuntimeUnavailable` — Sentinel returned by `Receive`, `Send`,
+  `ListSwaps`, `GetSwap`, `ResumeSwap`, and `SubscribeSwaps` when the package
+  is built without the `swapruntime` tag.
+
+## RPC Methods (host-facing API)
+
+| Method | Description |
+|--------|-------------|
+| `GetInfo` | Daemon readiness snapshot: version, network, identity, wallet/server readiness |
+| `CreateWallet` | Create or import the embedded daemon wallet (auto-generates seed when mnemonic empty) |
+| `UnlockWallet` | Unlock an existing embedded daemon wallet |
+| `ListBalance` | Confirmed/unconfirmed boarding, VTXO, and on-chain balance buckets |
+| `GetOnchainAddress` | Allocate a fresh boarding address |
+| `Receive` | Start a Lightning-to-Ark receive swap (swapruntime only) |
+| `Send` | Start an Ark-to-Lightning payment swap (swapruntime only) |
+| `ListSwaps` | List persisted daemon-owned swap summaries (swapruntime only) |
+| `GetSwap` | Fetch one persisted swap by hex payment hash (swapruntime only) |
+| `ResumeSwap` | Wake one pending persisted swap worker (swapruntime only) |
+| `SubscribeSwaps` | Stream swap summary updates; optionally include existing rows (swapruntime only) |
+| `Stop` / `Close` | Shut down the embedded daemon and release the private transport |
+| `Wait` | Single-reader channel yielding the daemon's terminal run error |
+| `GRPCConn` / `ArkRPC` / `SwapRPC` | Escape hatches exposing the underlying private gRPC connection and raw RPC clients |
+
+## Relationships
+
+- **Depends on**: `darepod` (embedded daemon runtime, default config,
+  validation), `daemonrpc` (wallet, balance, info, address RPCs),
+  `rpc/swapclientrpc` (daemon-owned swap RPCs), `swapclientserver`
+  (`swapruntime` build only — registers the daemon-side swap subserver via
+  `RPCServiceRegistrars`), `google.golang.org/grpc/test/bufconn`
+  (in-process transport).
+- **Depended on by**: host Go apps, gomobile / React Native / WASM bridges,
+  and `cmd/walletdk-tui` (Bubble Tea manual-test TUI; tracked in a sibling
+  PR).
+- **Sends**:
+  - → `darepod` (in-process via bufconn): all daemon RPCs listed above are
+    routed across the private gRPC connection rather than the daemon's
+    public listener.
+- **Receives**:
+  - ← API: host application calls (`CreateWallet`, `Receive`, `Send`,
+    `SubscribeSwaps`, …). walletdk does not register any RPC handlers itself;
+    it only consumes them.
+
+## Invariants
+
+- `Client` is safe for concurrent use.
+- The embedded daemon's lifetime is owned by walletdk's `runCtx`, not by the
+  caller's `Start` context. A startup deadline cancels dialing, not the
+  daemon. `Stop`/`Close` is the only correct way to terminate the runtime
+  (the `//nolint:contextcheck` on `Start` guards this).
+- `Start` does not return until either gRPC reports `Ready` against the
+  embedded daemon, the daemon exits early with an error, or the caller's
+  startup `ctx` is cancelled.
+- A caller-supplied `DaemonConfig` is deep-copied via `cloneDaemonConfig`
+  before walletdk mutates it (`RPC.Listener` is replaced and
+  `RPCServiceRegistrars` may be appended to). New reference-typed fields
+  added to `darepod.Config` require matching clone logic.
+- Convenience booleans in `Config` are tri-state `fn.Option[bool]`: `fn.None`
+  defers to `DaemonConfig`, `fn.Some(true)` / `fn.Some(false)` forces that
+  value. There is no enable-only ambiguity.
+- Secret-bearing slices (`SeedPassphrase`, `WalletPassword`, `Mnemonic`) are
+  cloned at the SDK boundary via `bytes.Clone` / `append` before being handed
+  to the daemon RPC layer so host apps can zero their own copies on return
+  without racing the RPC marshaller.
+- Swap-touching methods (`Receive`, `Send`, `ListSwaps`, `GetSwap`,
+  `ResumeSwap`, `SubscribeSwaps`) fail with `ErrSwapRuntimeUnavailable` on
+  builds that omit the `swapruntime` tag. The error is returned synchronously
+  at the wrapper boundary, before any RPC is attempted.
+- `SwapSummary.State` is a wrapper-owned lowercase string, not the generated
+  proto enum. The explicit `SWAP_STATE_UNSPECIFIED` enum value maps to
+  `"unspecified"`; unknown future enum values fall back to the lowercased
+  proto name (minus the `SWAP_STATE_` prefix) so a new state surfaces in
+  host UIs rather than being silently erased.
+- `Wait()` is multi-reader: each call returns a fresh channel that delivers
+  the same terminal error and then closes. Backed by `context.AfterFunc` on
+  the runtime context, so no per-call goroutine is leaked.
+- `SubscribeSwaps` returns an unbuffered updates channel so a slow consumer
+  applies backpressure end-to-end; the errs channel is cap-1 for a single
+  terminal error.
+
+## Deep Docs
+
+- [docs/walletdk_integration.md](../../docs/walletdk_integration.md) —
+  Integration flow, startup/config examples, swap accounting, and host
+  wrapper guidance.
+- [docs/sdk_layered_architecture.md](../../docs/sdk_layered_architecture.md) —
+  Layering rationale: `sdk/ark` facade, remote vs. embedded modes,
+  `sdk/swaps` future direction (walletdk sits one layer above `sdk/ark` for
+  wallet-shaped hosts).
+- [sdk/ark/CLAUDE.md](../ark/CLAUDE.md) — Lower-level Ark SDK facade.
+- [sdk/swaps/CLAUDE.md](../swaps/CLAUDE.md) — Swap FSM and durable session
+  semantics surfaced through walletdk's swap methods.
+- [swapclientserver/CLAUDE.md](../../swapclientserver/CLAUDE.md) — Daemon-side
+  swap subserver registered when walletdk is built with `-tags swapruntime`.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/sdk/walletdk/CLAUDE.md
+++ b/sdk/walletdk/CLAUDE.md
@@ -1,0 +1,136 @@
+# sdk/walletdk
+
+## Purpose
+
+Wallet-shaped SDK facade for host apps that want a small, stable Go API over
+an embedded `darepod` client daemon. `Start` boots the daemon in-process,
+dials it over a private `bufconn` gRPC transport, and exposes typed methods
+for onboarding, balances, Lightning-to-Ark receives, Ark-to-Lightning sends,
+and swap accounting. Daemon-owned swap send and receive are gated behind the
+`swapruntime` build tag so default builds avoid the swap executor's dependency
+graph.
+
+## Key Types
+
+- `Client` — Concurrency-safe wallet handle. Owns the embedded daemon
+  lifecycle, the private `bufconn` gRPC connection, and the daemon-owned swap
+  RPC clients. `Stop`/`Close` are aliases; both are idempotent.
+- `Config` — Embedded daemon + wallet facade config. Two usage modes:
+  zero-value plus convenience fields (`DataDir`, `Network`, `ServerAddress`,
+  …), or a caller-owned `DaemonConfig` plus only the convenience fields the
+  host wants to override. The convenience booleans (`AllowMainnet`,
+  `ServerInsecure`, `SwapServerInsecure`) are `fn.Option[bool]`: `fn.None`
+  defers to `DaemonConfig`, `fn.Some(v)` forces that value.
+- `DefaultConfig` — Returns a walletdk `Config` populated from
+  `darepod.DefaultConfig()`. Convenience starting point for hosts.
+- `Start` — Boots the embedded daemon, dials it, waits for gRPC readiness,
+  and returns a ready-to-use `*Client`. Detaches the daemon lifetime from the
+  caller's `ctx` so a tight startup deadline does not kill the daemon.
+- `Info` / `Balance` / `OnchainAddress` / `CreateWalletResult` /
+  `UnlockWalletResult` — Wrapper-owned wallet DTOs. Mobile and JS bridges see
+  these, not protobuf types.
+- `ReceiveRequest` / `ReceiveResult` / `SendRequest` / `SendResult` —
+  Wrapper-owned swap-start DTOs. Receive returns a BOLT-11 invoice plus the
+  initial durable swap summary; Send returns the payment hash plus the
+  initial summary.
+- `SwapSummary` — Wrapper-owned durable swap view used for `ListSwaps`,
+  `GetSwap`, `ResumeSwap`, and `SubscribeSwaps`. Stable lowercase `State`
+  string is owned by `convert.go`, intentionally decoupled from the proto
+  enum's renumbering.
+- `SwapDirection` (`"pay"`, `"receive"`) — Public direction enum for resume
+  requests and summary inspection.
+- `ErrSwapRuntimeUnavailable` — Sentinel returned by `Receive`, `Send`,
+  `ListSwaps`, `GetSwap`, `ResumeSwap`, and `SubscribeSwaps` when the package
+  is built without the `swapruntime` tag.
+
+## RPC Methods (host-facing API)
+
+| Method | Description |
+|--------|-------------|
+| `GetInfo` | Daemon readiness snapshot: version, network, identity, wallet/server readiness |
+| `CreateWallet` | Create or import the embedded daemon wallet (auto-generates seed when mnemonic empty) |
+| `UnlockWallet` | Unlock an existing embedded daemon wallet |
+| `ListBalance` | Confirmed/unconfirmed boarding, VTXO, and on-chain balance buckets |
+| `GetOnchainAddress` | Allocate a fresh boarding address |
+| `Receive` | Start a Lightning-to-Ark receive swap (swapruntime only) |
+| `Send` | Start an Ark-to-Lightning payment swap (swapruntime only) |
+| `ListSwaps` | List persisted daemon-owned swap summaries (swapruntime only) |
+| `GetSwap` | Fetch one persisted swap by hex payment hash (swapruntime only) |
+| `ResumeSwap` | Wake one pending persisted swap worker (swapruntime only) |
+| `SubscribeSwaps` | Stream swap summary updates; optionally include existing rows (swapruntime only) |
+| `Stop` / `Close` | Shut down the embedded daemon and release the private transport |
+| `Wait` | Single-reader channel yielding the daemon's terminal run error |
+| `GRPCConn` / `ArkRPC` / `SwapRPC` | Escape hatches exposing the underlying private gRPC connection and raw RPC clients |
+
+## Relationships
+
+- **Depends on**: `darepod` (embedded daemon runtime, default config,
+  validation), `daemonrpc` (wallet, balance, info, address RPCs),
+  `rpc/swapclientrpc` (daemon-owned swap RPCs), `swapclientserver`
+  (`swapruntime` build only — registers the daemon-side swap subserver via
+  `RPCServiceRegistrars`), `google.golang.org/grpc/test/bufconn`
+  (in-process transport).
+- **Depended on by**: host Go apps, gomobile / React Native / WASM bridges,
+  and `cmd/walletdk-tui` (Bubble Tea manual-test TUI; tracked in a sibling
+  PR).
+- **Sends**:
+  - → `darepod` (in-process via bufconn): all daemon RPCs listed above are
+    routed across the private gRPC connection rather than the daemon's
+    public listener.
+- **Receives**:
+  - ← API: host application calls (`CreateWallet`, `Receive`, `Send`,
+    `SubscribeSwaps`, …). walletdk does not register any RPC handlers itself;
+    it only consumes them.
+
+## Invariants
+
+- `Client` is safe for concurrent use.
+- The embedded daemon's lifetime is owned by walletdk's `runCtx`, not by the
+  caller's `Start` context. A startup deadline cancels dialing, not the
+  daemon. `Stop`/`Close` is the only correct way to terminate the runtime
+  (the `//nolint:contextcheck` on `Start` guards this).
+- `Start` does not return until either gRPC reports `Ready` against the
+  embedded daemon, the daemon exits early with an error, or the caller's
+  startup `ctx` is cancelled.
+- A caller-supplied `DaemonConfig` is deep-copied via `cloneDaemonConfig`
+  before walletdk mutates it (`RPC.Listener` is replaced and
+  `RPCServiceRegistrars` may be appended to). New reference-typed fields
+  added to `darepod.Config` require matching clone logic.
+- Convenience booleans in `Config` are tri-state `fn.Option[bool]`: `fn.None`
+  defers to `DaemonConfig`, `fn.Some(true)` / `fn.Some(false)` forces that
+  value. There is no enable-only ambiguity.
+- Secret-bearing slices (`SeedPassphrase`, `WalletPassword`, `Mnemonic`) are
+  cloned at the SDK boundary via `bytes.Clone` / `append` before being handed
+  to the daemon RPC layer so host apps can zero their own copies on return
+  without racing the RPC marshaller.
+- Swap-touching methods (`Receive`, `Send`, `ListSwaps`, `GetSwap`,
+  `ResumeSwap`, `SubscribeSwaps`) fail with `ErrSwapRuntimeUnavailable` on
+  builds that omit the `swapruntime` tag. The error is returned synchronously
+  at the wrapper boundary, before any RPC is attempted.
+- `SwapSummary.State` is a wrapper-owned lowercase string, not the generated
+  proto enum. The explicit `SWAP_STATE_UNSPECIFIED` enum value maps to
+  `"unspecified"`; unknown future enum values fall back to the lowercased
+  proto name (minus the `SWAP_STATE_` prefix) so a new state surfaces in
+  host UIs rather than being silently erased.
+- `Wait()` is multi-reader: each call returns a fresh channel that delivers
+  the same terminal error and then closes. Backed by `context.AfterFunc` on
+  the runtime context, so no per-call goroutine is leaked.
+- `SubscribeSwaps` returns an unbuffered updates channel so a slow consumer
+  applies backpressure end-to-end; the errs channel is cap-1 for a single
+  terminal error.
+
+## Deep Docs
+
+- [docs/walletdk_integration.md](../../docs/walletdk_integration.md) —
+  Integration flow, startup/config examples, swap accounting, and host
+  wrapper guidance.
+- [docs/sdk_layered_architecture.md](../../docs/sdk_layered_architecture.md) —
+  Layering rationale: `sdk/ark` facade, remote vs. embedded modes,
+  `sdk/swaps` future direction (walletdk sits one layer above `sdk/ark` for
+  wallet-shaped hosts).
+- [sdk/ark/CLAUDE.md](../ark/CLAUDE.md) — Lower-level Ark SDK facade.
+- [sdk/swaps/CLAUDE.md](../swaps/CLAUDE.md) — Swap FSM and durable session
+  semantics surfaced through walletdk's swap methods.
+- [swapclientserver/CLAUDE.md](../../swapclientserver/CLAUDE.md) — Daemon-side
+  swap subserver registered when walletdk is built with `-tags swapruntime`.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/sdk/walletdk/client.go
+++ b/sdk/walletdk/client.go
@@ -1,0 +1,421 @@
+package walletdk
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/lightninglabs/darepo-client/rpc/swapclientrpc"
+	"google.golang.org/grpc"
+)
+
+const defaultCloseTimeout = 5 * time.Second
+
+// Client is the wallet-facing SDK handle. It is safe for concurrent use.
+type Client struct {
+	conn    grpc.ClientConnInterface
+	daemon  daemonrpc.DaemonServiceClient
+	swaps   swapclientrpc.SwapClientServiceClient
+	canSwap bool
+
+	// runtime carries the embedded daemon's terminal signal (done channel
+	// + runErr). nil when the Client wraps an externally-owned daemon and
+	// has no runtime to wait on.
+	runtime *daemonRuntime
+
+	closeFn   func(context.Context) error
+	closeOnce sync.Once
+	closeErr  error
+}
+
+// Stop shuts down the embedded daemon and releases the private transport.
+func (c *Client) Stop() error {
+	return c.close()
+}
+
+// Close is an alias for Stop for callers that expect io-style cleanup.
+func (c *Client) Close() error {
+	return c.close()
+}
+
+// Wait returns a channel that yields the embedded daemon's terminal run error.
+//
+// Each call returns a fresh channel that receives the terminal error (if any)
+// and is then closed, so multiple goroutines can each select on Wait()
+// independently and observe the same result. For Clients that do not own a
+// daemon runtime, Wait returns an already-closed channel.
+//
+// Delivery is scheduled via context.AfterFunc on the runtime context, so no
+// explicit goroutine is leaked per Wait() call: the runtime fires the
+// callback for us when the daemon exits.
+func (c *Client) Wait() <-chan error {
+	out := make(chan error, 1)
+	if c == nil || c.runtime == nil {
+		close(out)
+
+		return out
+	}
+
+	context.AfterFunc(c.runtime.ctx, func() {
+		if c.runtime.runErr != nil {
+			out <- c.runtime.runErr
+		}
+		close(out)
+	})
+
+	return out
+}
+
+// GRPCConn returns the private gRPC client connection used by walletdk.
+func (c *Client) GRPCConn() grpc.ClientConnInterface {
+	if c == nil {
+		return nil
+	}
+
+	return c.conn
+}
+
+// ArkRPC returns the raw daemon RPC client for advanced callers.
+func (c *Client) ArkRPC() daemonrpc.DaemonServiceClient {
+	if c == nil {
+		return nil
+	}
+
+	return c.daemon
+}
+
+// SwapRPC returns the raw daemon-owned swap RPC client for advanced callers.
+func (c *Client) SwapRPC() swapclientrpc.SwapClientServiceClient {
+	if c == nil {
+		return nil
+	}
+
+	return c.swaps
+}
+
+// GetInfo returns the current daemon readiness snapshot.
+func (c *Client) GetInfo(ctx context.Context) (*Info, error) {
+	resp, err := c.daemon.GetInfo(ctx, &daemonrpc.GetInfoRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("get daemon info: %w", err)
+	}
+
+	return &Info{
+		Version:         resp.GetVersion(),
+		Commit:          resp.GetCommit(),
+		Network:         resp.GetNetwork(),
+		BlockHeight:     resp.GetBlockHeight(),
+		ServerConnected: resp.GetServerConnected(),
+		WalletType:      resp.GetWalletType(),
+		WalletReady:     resp.GetWalletReady(),
+		IdentityPubKey:  resp.GetIdentityPubkey(),
+	}, nil
+}
+
+// CreateWallet creates or imports the embedded daemon wallet.
+//
+// All secret-bearing byte slices (seed passphrase, wallet password) are cloned
+// before being handed to the daemon RPC layer. The generated protobuf request
+// types alias their input slices and the protobuf marshaller may retain
+// references for longer than the caller expects; defensively cloning here lets
+// host applications zero their own copies on return without racing the RPC
+// goroutines that may still be touching the marshalled buffers.
+func (c *Client) CreateWallet(ctx context.Context, req CreateWalletRequest) (
+	*CreateWalletResult, error) {
+
+	mnemonic := append([]string(nil), req.Mnemonic...)
+	var encipheredSeed []byte
+
+	if len(mnemonic) == 0 {
+		seed, err := c.daemon.GenSeed(ctx, &daemonrpc.GenSeedRequest{
+			SeedPassphrase: bytes.Clone(req.SeedPassphrase),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("generate wallet seed: %w", err)
+		}
+
+		mnemonic = append([]string(nil), seed.GetMnemonic()...)
+		encipheredSeed = bytes.Clone(seed.GetEncipheredSeed())
+	}
+
+	initResp, err := c.daemon.InitWallet(ctx,
+		&daemonrpc.InitWalletRequest{
+			Mnemonic:       mnemonic,
+			SeedPassphrase: bytes.Clone(req.SeedPassphrase),
+			WalletPassword: bytes.Clone(req.WalletPassword),
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("initialize wallet: %w", err)
+	}
+
+	return &CreateWalletResult{
+		Mnemonic:       mnemonic,
+		EncipheredSeed: encipheredSeed,
+		IdentityPubKey: initResp.GetIdentityPubkey(),
+	}, nil
+}
+
+// UnlockWallet unlocks an existing embedded daemon wallet.
+func (c *Client) UnlockWallet(ctx context.Context, req UnlockWalletRequest) (
+	*UnlockWalletResult, error) {
+
+	resp, err := c.daemon.UnlockWallet(ctx,
+		&daemonrpc.UnlockWalletRequest{
+			WalletPassword: bytes.Clone(req.WalletPassword),
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("unlock wallet: %w", err)
+	}
+
+	return &UnlockWalletResult{
+		IdentityPubKey: resp.GetIdentityPubkey(),
+	}, nil
+}
+
+// ListBalance returns the wallet's simplified balance buckets.
+func (c *Client) ListBalance(ctx context.Context) (*Balance, error) {
+	resp, err := c.daemon.GetBalance(ctx, &daemonrpc.GetBalanceRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("get wallet balance: %w", err)
+	}
+
+	return &Balance{
+		BoardingConfirmedSat:      resp.GetBoardingConfirmedSat(),
+		BoardingUnconfirmedSat:    resp.GetBoardingUnconfirmedSat(),
+		VTXOBalanceSat:            resp.GetVtxoBalanceSat(),
+		TotalConfirmedSat:         resp.GetTotalConfirmedSat(),
+		OnchainWalletConfirmedSat: resp.GetOnchainWalletConfirmedSat(),
+	}, nil
+}
+
+// GetOnchainAddress allocates a fresh onboarding address.
+func (c *Client) GetOnchainAddress(ctx context.Context) (*OnchainAddress,
+	error) {
+
+	resp, err := c.daemon.NewAddress(ctx, &daemonrpc.NewAddressRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("get on-chain address: %w", err)
+	}
+
+	return &OnchainAddress{Address: resp.GetAddress()}, nil
+}
+
+// Receive starts a Lightning-to-Ark receive swap in the embedded daemon.
+func (c *Client) Receive(ctx context.Context, req ReceiveRequest) (
+	*ReceiveResult, error) {
+
+	if err := c.requireSwaps(); err != nil {
+		return nil, err
+	}
+	if req.AmountSat <= 0 {
+		return nil, fmt.Errorf("amount_sat must be positive")
+	}
+
+	resp, err := c.swaps.StartReceive(ctx,
+		&swapclientrpc.StartReceiveRequest{
+			AmountSat: req.AmountSat,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("start receive swap: %w", err)
+	}
+
+	return &ReceiveResult{
+		PaymentHash: resp.GetPaymentHash(),
+		Invoice:     resp.GetInvoice(),
+		Swap:        swapSummaryFromProto(resp.GetSwap()),
+	}, nil
+}
+
+// Send starts an Ark-to-Lightning payment in the embedded daemon.
+func (c *Client) Send(ctx context.Context, req SendRequest) (*SendResult,
+	error) {
+
+	if err := c.requireSwaps(); err != nil {
+		return nil, err
+	}
+	if req.Invoice == "" {
+		return nil, fmt.Errorf("invoice is required")
+	}
+
+	resp, err := c.swaps.StartPay(ctx, &swapclientrpc.StartPayRequest{
+		Invoice:   req.Invoice,
+		MaxFeeSat: req.MaxFeeSat,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("start pay swap: %w", err)
+	}
+
+	return &SendResult{
+		PaymentHash: resp.GetPaymentHash(),
+		Swap:        swapSummaryFromProto(resp.GetSwap()),
+	}, nil
+}
+
+// ListSwaps returns persisted daemon-owned swap summaries.
+func (c *Client) ListSwaps(ctx context.Context, req ListSwapsRequest) (
+	[]SwapSummary, error) {
+
+	if err := c.requireSwaps(); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.swaps.ListSwaps(ctx, &swapclientrpc.ListSwapsRequest{
+		PendingOnly: req.PendingOnly,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list swaps: %w", err)
+	}
+
+	swaps := make([]SwapSummary, 0, len(resp.GetSwaps()))
+	for _, swap := range resp.GetSwaps() {
+		swaps = append(swaps, swapSummaryFromProto(swap))
+	}
+
+	return swaps, nil
+}
+
+// GetSwap returns one persisted swap summary.
+func (c *Client) GetSwap(ctx context.Context, req GetSwapRequest) (*SwapSummary,
+	error) {
+
+	if err := c.requireSwaps(); err != nil {
+		return nil, err
+	}
+	if req.PaymentHash == "" {
+		return nil, fmt.Errorf("payment_hash is required")
+	}
+
+	resp, err := c.swaps.GetSwap(ctx, &swapclientrpc.GetSwapRequest{
+		PaymentHash: req.PaymentHash,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get swap: %w", err)
+	}
+
+	summary := swapSummaryFromProto(resp.GetSwap())
+
+	return &summary, nil
+}
+
+// ResumeSwap asks the daemon to wake one persisted pending swap.
+func (c *Client) ResumeSwap(ctx context.Context, req ResumeSwapRequest) (
+	*SwapSummary, error) {
+
+	if err := c.requireSwaps(); err != nil {
+		return nil, err
+	}
+	if req.PaymentHash == "" {
+		return nil, fmt.Errorf("payment_hash is required")
+	}
+
+	resp, err := c.swaps.ResumeSwap(ctx, &swapclientrpc.ResumeSwapRequest{
+		PaymentHash: req.PaymentHash,
+		Direction:   swapDirectionToProto(req.Direction),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("resume swap: %w", err)
+	}
+
+	summary := swapSummaryFromProto(resp.GetSwap())
+
+	return &summary, nil
+}
+
+// SubscribeSwaps streams daemon-owned swap summary updates until ctx ends.
+//
+// The returned updates channel is unbuffered so a slow consumer applies
+// backpressure on the proxy goroutine, which in turn applies backpressure on
+// the daemon's server-streaming send. The errs channel is cap-1 so a single
+// terminal error is always deliverable without blocking the proxy. Both
+// channels are closed together when the stream ends, giving callers a single
+// signal to tear down their selector regardless of which side cancelled.
+func (c *Client) SubscribeSwaps(ctx context.Context,
+	req SubscribeSwapsRequest) (<-chan SwapSummary, <-chan error, error) {
+
+	if err := c.requireSwaps(); err != nil {
+		return nil, nil, err
+	}
+
+	stream, err := c.swaps.SubscribeSwaps(
+		ctx, &swapclientrpc.SubscribeSwapsRequest{
+			IncludeExisting: req.IncludeExisting,
+			PendingOnly:     req.PendingOnly,
+		},
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("subscribe swaps: %w", err)
+	}
+
+	updates := make(chan SwapSummary)
+	errs := make(chan error, 1)
+	go func() {
+		defer close(updates)
+		defer close(errs)
+
+		for {
+			resp, err := stream.Recv()
+			if err != nil {
+				if errors.Is(err, io.EOF) {
+					return
+				}
+
+				errs <- fmt.Errorf("receive swap update: %w",
+					err)
+
+				return
+			}
+
+			select {
+			case updates <- swapSummaryFromProto(resp.GetSwap()):
+			case <-ctx.Done():
+				errs <- fmt.Errorf("swap subscription "+
+					"closed: %w", ctx.Err())
+
+				return
+			}
+		}
+	}()
+
+	return updates, errs, nil
+}
+
+// requireSwaps fails fast when the build does not include the daemon-owned
+// swap executor, giving embedders a stable error before any RPC is attempted.
+func (c *Client) requireSwaps() error {
+	if c == nil || !c.canSwap {
+		return ErrSwapRuntimeUnavailable
+	}
+
+	return nil
+}
+
+// close releases resources once so Stop and Close can be used
+// interchangeably by different host integrations.
+func (c *Client) close() error {
+	if c == nil {
+		return nil
+	}
+
+	c.closeOnce.Do(func() {
+		if c.closeFn == nil {
+			return
+		}
+
+		closeCtx, cancel := context.WithTimeout(
+			context.Background(), defaultCloseTimeout,
+		)
+		defer cancel()
+
+		c.closeErr = c.closeFn(closeCtx)
+	})
+
+	return c.closeErr
+}

--- a/sdk/walletdk/convert.go
+++ b/sdk/walletdk/convert.go
@@ -1,0 +1,155 @@
+package walletdk
+
+import (
+	"strings"
+	"time"
+
+	"github.com/lightninglabs/darepo-client/rpc/swapclientrpc"
+)
+
+// swapSummaryFromProto copies the daemon RPC summary into wrapper-owned
+// fields so mobile and UI callers do not need protobuf types.
+func swapSummaryFromProto(summary *swapclientrpc.SwapSummary) SwapSummary {
+	if summary == nil {
+		return SwapSummary{}
+	}
+
+	return SwapSummary{
+		Direction: swapDirectionFromProto(
+			summary.GetDirection(),
+		),
+		PaymentHash:      summary.GetPaymentHash(),
+		State:            swapStateFromProto(summary.GetState()),
+		Pending:          summary.GetPending(),
+		AmountSat:        summary.GetAmountSat(),
+		FeeSat:           summary.GetFeeSat(),
+		MaxFeeSat:        summary.GetMaxFeeSat(),
+		VHTLCOutpoint:    summary.GetVhtlcOutpoint(),
+		VHTLCAmountSat:   summary.GetVhtlcAmountSat(),
+		FundingSessionID: summary.GetFundingSessionId(),
+		ClaimSessionID:   summary.GetClaimSessionId(),
+		RefundSessionID:  summary.GetRefundSessionId(),
+		TerminalReason:   summary.GetTerminalReason(),
+		CreatedAt:        unixTime(summary.GetCreatedAtUnix()),
+		UpdatedAt:        unixTime(summary.GetUpdatedAtUnix()),
+		Deadline:         unixTime(summary.GetDeadlineUnix()),
+		RefundLocktime:   summary.GetRefundLocktime(),
+	}
+}
+
+// swapDirectionFromProto maps the generated enum into walletdk's compact
+// string-like direction type. Unknown future enum values fall back to the
+// lowercased proto name (minus the SWAP_DIRECTION_ prefix) so a new value
+// added to the proto surfaces in host UIs instead of erasing into "".
+func swapDirectionFromProto(
+	direction swapclientrpc.SwapDirection) SwapDirection {
+
+	switch direction {
+	case swapclientrpc.SwapDirection_SWAP_DIRECTION_UNSPECIFIED:
+		return ""
+
+	case swapclientrpc.SwapDirection_SWAP_DIRECTION_PAY:
+		return SwapDirectionPay
+
+	case swapclientrpc.SwapDirection_SWAP_DIRECTION_RECEIVE:
+		return SwapDirectionReceive
+
+	default:
+		return SwapDirection(
+			strings.ToLower(
+				strings.TrimPrefix(
+					direction.String(),
+					"SWAP_DIRECTION_",
+				),
+			),
+		)
+	}
+}
+
+// swapDirectionToProto maps the public direction back to the daemon RPC enum
+// used by resume requests.
+func swapDirectionToProto(direction SwapDirection) swapclientrpc.SwapDirection {
+	switch direction {
+	case SwapDirectionPay:
+		return swapclientrpc.SwapDirection_SWAP_DIRECTION_PAY
+
+	case SwapDirectionReceive:
+		return swapclientrpc.SwapDirection_SWAP_DIRECTION_RECEIVE
+
+	default:
+		return swapclientrpc.SwapDirection_SWAP_DIRECTION_UNSPECIFIED
+	}
+}
+
+// swapStateFromProto returns stable lowercase state names for display and
+// bridge layers.
+//
+// The wrapper deliberately owns the string form so the SDK contract is
+// independent of how the proto enum is named or renumbered. Host UIs and
+// React Native / gomobile bridges can switch on these values without taking a
+// dependency on the generated enum type. Unknown future enum values fall back
+// to the lowercased proto name (minus the SWAP_STATE_ prefix) so a new state
+// added to the proto surfaces in host UIs instead of being silently flattened
+// into "unspecified".
+func swapStateFromProto(state swapclientrpc.SwapState) string {
+	switch state {
+	case swapclientrpc.SwapState_SWAP_STATE_UNSPECIFIED:
+		return "unspecified"
+
+	case swapclientrpc.SwapState_SWAP_STATE_CREATED:
+		return "created"
+
+	case swapclientrpc.SwapState_SWAP_STATE_SWAP_CREATED:
+		return "swap_created"
+
+	case swapclientrpc.SwapState_SWAP_STATE_FUNDING_INITIATED:
+		return "funding_initiated"
+
+	case swapclientrpc.SwapState_SWAP_STATE_VHTLC_FUNDED:
+		return "vhtlc_funded"
+
+	case swapclientrpc.SwapState_SWAP_STATE_WAITING_FOR_CLAIM:
+		return "waiting_for_claim"
+
+	case swapclientrpc.SwapState_SWAP_STATE_COMPLETED:
+		return "completed"
+
+	case swapclientrpc.SwapState_SWAP_STATE_EXPIRED:
+		return "expired"
+
+	case swapclientrpc.SwapState_SWAP_STATE_REFUND_INITIATED:
+		return "refund_initiated"
+
+	case swapclientrpc.SwapState_SWAP_STATE_REFUNDED:
+		return "refunded"
+
+	case swapclientrpc.SwapState_SWAP_STATE_NEEDS_INTERVENTION:
+		return "needs_intervention"
+
+	case swapclientrpc.SwapState_SWAP_STATE_FAILED:
+		return "failed"
+
+	case swapclientrpc.SwapState_SWAP_STATE_INVOICE_CREATED:
+		return "invoice_created"
+
+	case swapclientrpc.SwapState_SWAP_STATE_CLAIM_INITIATED:
+		return "claim_initiated"
+
+	default:
+		return strings.ToLower(
+			strings.TrimPrefix(
+				state.String(),
+				"SWAP_STATE_",
+			),
+		)
+	}
+}
+
+// unixTime preserves unset timestamp fields as zero time values.
+func unixTime(sec int64) time.Time {
+	if sec == 0 {
+		return time.Time{}
+	}
+
+	return time.Unix(sec, 0)
+}

--- a/sdk/walletdk/convert_test.go
+++ b/sdk/walletdk/convert_test.go
@@ -1,0 +1,104 @@
+package walletdk
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lightninglabs/darepo-client/rpc/swapclientrpc"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSwapSummaryFromProto guards the wrapper-owned accounting DTO from
+// accidental protobuf field drift.
+func TestSwapSummaryFromProto(t *testing.T) {
+	proto := &swapclientrpc.SwapSummary{
+		Direction: swapclientrpc.
+			SwapDirection_SWAP_DIRECTION_PAY,
+		PaymentHash:      "hash",
+		State:            swapclientrpc.SwapState_SWAP_STATE_COMPLETED,
+		Pending:          true,
+		AmountSat:        1000,
+		FeeSat:           12,
+		MaxFeeSat:        30,
+		VhtlcOutpoint:    "txid:0",
+		VhtlcAmountSat:   900,
+		FundingSessionId: "funding",
+		ClaimSessionId:   "claim",
+		RefundSessionId:  "refund",
+		TerminalReason:   "done",
+		CreatedAtUnix:    11,
+		UpdatedAtUnix:    12,
+		DeadlineUnix:     13,
+		RefundLocktime:   42,
+	}
+
+	summary := swapSummaryFromProto(proto)
+	require.Equal(t, SwapDirectionPay, summary.Direction)
+	require.Equal(t, "hash", summary.PaymentHash)
+	require.Equal(t, "completed", summary.State)
+	require.True(t, summary.Pending)
+	require.EqualValues(t, 1000, summary.AmountSat)
+	require.EqualValues(t, 12, summary.FeeSat)
+	require.EqualValues(t, 30, summary.MaxFeeSat)
+	require.Equal(t, "txid:0", summary.VHTLCOutpoint)
+	require.EqualValues(t, 900, summary.VHTLCAmountSat)
+	require.Equal(t, "funding", summary.FundingSessionID)
+	require.Equal(t, "claim", summary.ClaimSessionID)
+	require.Equal(t, "refund", summary.RefundSessionID)
+	require.Equal(t, "done", summary.TerminalReason)
+	require.Equal(t, time.Unix(11, 0), summary.CreatedAt)
+	require.Equal(t, time.Unix(12, 0), summary.UpdatedAt)
+	require.Equal(t, time.Unix(13, 0), summary.Deadline)
+	require.EqualValues(t, 42, summary.RefundLocktime)
+}
+
+// TestSwapDirectionToProto verifies resume requests use the expected daemon
+// RPC direction enum.
+func TestSwapDirectionToProto(t *testing.T) {
+	require.Equal(
+		t, swapclientrpc.SwapDirection_SWAP_DIRECTION_PAY,
+		swapDirectionToProto(SwapDirectionPay),
+	)
+	require.Equal(
+		t, swapclientrpc.SwapDirection_SWAP_DIRECTION_RECEIVE,
+		swapDirectionToProto(SwapDirectionReceive),
+	)
+	require.Equal(
+		t, swapclientrpc.SwapDirection_SWAP_DIRECTION_UNSPECIFIED,
+		swapDirectionToProto(""),
+	)
+}
+
+// TestSwapStateFromProtoUnknownFallback verifies that unknown future enum
+// values fall back to a lowercased proto name rather than being flattened
+// into "unspecified". The latter is reserved for the explicit UNSPECIFIED
+// enum value so host UIs can distinguish the two.
+func TestSwapStateFromProtoUnknownFallback(t *testing.T) {
+	require.Equal(
+		t, "unspecified", swapStateFromProto(
+			swapclientrpc.SwapState_SWAP_STATE_UNSPECIFIED,
+		),
+	)
+
+	// A value that is not listed in the proto generates a String() of the
+	// form "SwapState(<n>)" — the trim leaves the parenthesized form,
+	// which is fine: it is a stable, non-empty signal that something new
+	// is happening rather than a silent erase.
+	unknown := swapStateFromProto(swapclientrpc.SwapState(9999))
+	require.NotEqual(t, "unspecified", unknown)
+	require.NotEmpty(t, unknown)
+}
+
+// TestSwapDirectionFromProtoUnknownFallback mirrors the state-unknown test
+// for direction. Unspecified maps to the empty string; future values must
+// produce a non-empty fallback.
+func TestSwapDirectionFromProtoUnknownFallback(t *testing.T) {
+	require.Equal(
+		t, SwapDirection(""), swapDirectionFromProto(
+			swapclientrpc.SwapDirection_SWAP_DIRECTION_UNSPECIFIED,
+		),
+	)
+
+	unknown := swapDirectionFromProto(swapclientrpc.SwapDirection(9999))
+	require.NotEmpty(t, unknown)
+}

--- a/sdk/walletdk/doc.go
+++ b/sdk/walletdk/doc.go
@@ -1,0 +1,11 @@
+// Package walletdk provides an opinionated wallet SDK over a darepod runtime.
+//
+// The package is intentionally a facade over the daemon and its RPC services.
+// Start embeds the daemon in-process, connects to it over bufconn, and exposes
+// a small wallet-shaped API for onboarding, balances, Lightning-to-Ark
+// receives, Ark-to-Lightning sends, and swap accounting. Advanced callers can
+// still fetch the underlying daemon and swap RPC clients for lower-level work.
+//
+// Swap send and receive operations require building with the swapruntime tag so
+// the daemon-owned swap executor is registered on the embedded RPC server.
+package walletdk

--- a/sdk/walletdk/embedded.go
+++ b/sdk/walletdk/embedded.go
@@ -1,0 +1,434 @@
+package walletdk
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/lightninglabs/darepo-client/darepod"
+	"github.com/lightninglabs/darepo-client/rpc/swapclientrpc"
+	"github.com/lightningnetwork/lnd/fn/v2"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+const defaultBufConnSize = 1 << 20
+
+// daemonRuntime carries the embedded daemon's terminal signal so the startup,
+// shutdown, and Wait paths share one source of truth.
+//
+// The lifecycle is modeled as a context whose cancellation marks the daemon
+// having exited. runErr is written before the context is cancelled so any
+// goroutine observing ctx.Done() is then free to read runErr without further
+// synchronization (Go memory model: the write happens-before the receive that
+// observes the cancellation).
+//
+// signalExit is sync.Once-guarded so the daemon goroutine, panic recovery,
+// and any defensive callers cannot race on the runErr write or accidentally
+// trigger ordering issues. context.CancelFunc itself is already idempotent.
+//
+// ctx here is a lifecycle signal owned by daemonRuntime, not a per-request
+// context; storing it lets Wait and waitForReady reuse context.AfterFunc
+// without an extra goroutine — hence the containedctx suppression below.
+//
+//nolint:containedctx
+type daemonRuntime struct {
+	ctx       context.Context
+	cancelFn  context.CancelFunc
+	runErr    error
+	closeOnce sync.Once
+}
+
+// newDaemonRuntime constructs a runtime whose context is cancelled the first
+// time signalExit is called.
+func newDaemonRuntime() *daemonRuntime {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	return &daemonRuntime{
+		ctx:      ctx,
+		cancelFn: cancel,
+	}
+}
+
+// signalExit records the daemon's terminal error and cancels the runtime
+// context. Safe to call multiple times; only the first call wins.
+func (rt *daemonRuntime) signalExit(err error) {
+	rt.closeOnce.Do(func() {
+		rt.runErr = err
+		rt.cancelFn()
+	})
+}
+
+// Done returns a channel that is closed when the daemon exits. After
+// observing the close, callers may read runErr to inspect the terminal error.
+func (rt *daemonRuntime) Done() <-chan struct{} {
+	return rt.ctx.Done()
+}
+
+// DefaultConfig returns a walletdk config with darepod defaults. Swap methods
+// are enabled only when the package is built with the swapruntime tag.
+func DefaultConfig() Config {
+	cfg := darepod.DefaultConfig()
+
+	return Config{
+		DataDir:               cfg.DataDir,
+		Network:               cfg.Network,
+		DebugLevel:            cfg.DebugLevel,
+		ServerAddress:         cfg.Server.Host,
+		ServerTLSCertPath:     cfg.Server.TLSCertPath,
+		ServerInsecure:        fn.Some(cfg.Server.Insecure),
+		WalletType:            cfg.Wallet.Type,
+		WalletEsploraURL:      cfg.Wallet.EsploraURL,
+		WalletPasswordFile:    cfg.Wallet.PasswordFile,
+		WalletPollInterval:    cfg.Wallet.PollInterval,
+		WalletRecoveryWindow:  cfg.Wallet.RecoveryWindow,
+		WalletFeeURL:          cfg.Wallet.FeeURL,
+		SwapServerAddress:     cfg.Swap.ServerAddress,
+		SwapServerTLSCertPath: cfg.Swap.ServerTLSCertPath,
+		SwapServerInsecure:    fn.Some(cfg.Swap.ServerInsecure),
+		SwapDatabaseFileName:  cfg.Swap.DatabaseFileName,
+		MaxOperatorFeeSat:     cfg.MaxOperatorFeeSat,
+	}
+}
+
+// Start starts an embedded darepod runtime and returns the wallet facade.
+//
+//nolint:contextcheck // embedded daemon lifetime is detached from dial ctx
+func Start(ctx context.Context, cfg Config) (*Client, error) {
+	daemonCfg, err := daemonConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	swapsEnabled := !cfg.DisableSwaps && swapRuntimeAvailable()
+	if err := configureSwapRuntime(daemonCfg, swapsEnabled); err != nil {
+		return nil, err
+	}
+
+	bufferSize := cfg.BufferSize
+	if bufferSize == 0 {
+		bufferSize = defaultBufConnSize
+	}
+
+	listener := bufconn.Listen(bufferSize)
+	if daemonCfg.RPC == nil {
+		daemonCfg.RPC = &darepod.RPCConfig{}
+	}
+	daemonCfg.RPC.Listener = listener
+
+	if err := daemonCfg.Validate(); err != nil {
+		_ = listener.Close()
+
+		return nil, fmt.Errorf("invalid daemon config: %w", err)
+	}
+
+	server, err := darepod.NewServer(daemonCfg)
+	if err != nil {
+		_ = listener.Close()
+
+		return nil, fmt.Errorf("create embedded daemon: %w", err)
+	}
+
+	// The daemon outlives the caller's dial context: callers pass a ctx
+	// that may carry a tight startup deadline, but the daemon's lifetime is
+	// tied to runCtx, which is only cancelled by Stop or the failure paths
+	// below. That is what the //nolint:contextcheck directive on Start is
+	// guarding.
+	runCtx, cancel := context.WithCancel(context.Background())
+
+	rt := newDaemonRuntime()
+	go func() {
+		// Capture any panic from the daemon goroutine into the
+		// terminal error so Wait/Stop see a real error rather than
+		// blocking forever on an un-cancelled runtime.
+		defer func() {
+			if r := recover(); r != nil {
+				rt.signalExit(
+					fmt.Errorf("embedded daemon "+
+						"panicked: %v", r),
+				)
+			}
+		}()
+
+		rt.signalExit(server.RunWithContext(runCtx))
+	}()
+
+	dialOpts := []grpc.DialOption{
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithContextDialer(func(dialCtx context.Context, _ string) (
+			net.Conn, error) {
+
+			return listener.DialContext(dialCtx)
+		}),
+	}
+
+	conn, err := grpc.NewClient("passthrough:///bufnet", dialOpts...)
+	if err != nil {
+		cancel()
+		shutdownCtx, shutdownCancel := context.WithTimeout(
+			context.Background(), defaultCloseTimeout,
+		)
+		runErr := waitForRunExit(shutdownCtx, rt)
+		shutdownCancel()
+		listenerErr := listener.Close()
+
+		return nil, fmt.Errorf("dial embedded daemon: %w",
+			errors.Join(err, runErr, listenerErr))
+	}
+
+	if err := waitForReady(ctx, conn, rt); err != nil {
+		closeErr := conn.Close()
+		cancel()
+		shutdownCtx, shutdownCancel := context.WithTimeout(
+			context.Background(), defaultCloseTimeout,
+		)
+		runErr := waitForRunExit(shutdownCtx, rt)
+		shutdownCancel()
+		listenerErr := listener.Close()
+
+		return nil, fmt.Errorf("wait for embedded daemon readiness: %w",
+			errors.Join(err, closeErr, runErr, listenerErr))
+	}
+
+	return &Client{
+		conn:    conn,
+		daemon:  daemonrpc.NewDaemonServiceClient(conn),
+		swaps:   swapclientrpc.NewSwapClientServiceClient(conn),
+		canSwap: swapsEnabled,
+		runtime: rt,
+		closeFn: func(closeCtx context.Context) error {
+			closeErr := conn.Close()
+			cancel()
+			runErr := waitForRunExit(closeCtx, rt)
+			listenerErr := listener.Close()
+
+			return errors.Join(closeErr, runErr, listenerErr)
+		},
+	}, nil
+}
+
+// daemonConfig builds the daemon config from either a full caller-supplied
+// config or the walletdk convenience fields.
+func daemonConfig(cfg Config) (*darepod.Config, error) {
+	var daemonCfg *darepod.Config
+	if cfg.DaemonConfig != nil {
+		daemonCfg = cloneDaemonConfig(cfg.DaemonConfig)
+	} else {
+		daemonCfg = darepod.DefaultConfig()
+	}
+
+	applyConfigOverrides(daemonCfg, cfg)
+
+	return daemonCfg, nil
+}
+
+// applyConfigOverrides applies only explicitly set convenience fields so a
+// caller-provided DaemonConfig keeps ownership of detailed daemon knobs.
+//
+// The tri-state booleans (AllowMainnet, ServerInsecure, SwapServerInsecure)
+// are fn.Option[bool]: fn.None means "no override, defer to DaemonConfig", and
+// fn.Some(v) forces that exact value. This lets callers explicitly clear a
+// true-by-default flag without having to construct a full DaemonConfig.
+func applyConfigOverrides(daemonCfg *darepod.Config, cfg Config) {
+	if cfg.DataDir != "" {
+		daemonCfg.DataDir = cfg.DataDir
+	}
+	if cfg.Network != "" {
+		daemonCfg.Network = cfg.Network
+	}
+	if cfg.DebugLevel != "" {
+		daemonCfg.DebugLevel = cfg.DebugLevel
+	}
+	if cfg.LogWriter != nil {
+		daemonCfg.LogWriter = cfg.LogWriter
+	}
+	cfg.AllowMainnet.WhenSome(func(v bool) {
+		daemonCfg.AllowMainnet = v
+	})
+	if cfg.MaxOperatorFeeSat != 0 {
+		daemonCfg.MaxOperatorFeeSat = cfg.MaxOperatorFeeSat
+	}
+
+	if daemonCfg.Server == nil {
+		daemonCfg.Server = &darepod.ServerConfig{}
+	}
+	if cfg.ServerAddress != "" {
+		daemonCfg.Server.Host = cfg.ServerAddress
+	}
+	if cfg.ServerTLSCertPath != "" {
+		daemonCfg.Server.TLSCertPath = cfg.ServerTLSCertPath
+	}
+	cfg.ServerInsecure.WhenSome(func(v bool) {
+		daemonCfg.Server.Insecure = v
+	})
+
+	if daemonCfg.Wallet == nil {
+		daemonCfg.Wallet = &darepod.WalletConfig{}
+	}
+	if cfg.WalletType != "" {
+		daemonCfg.Wallet.Type = cfg.WalletType
+	}
+	if cfg.WalletEsploraURL != "" {
+		daemonCfg.Wallet.EsploraURL = cfg.WalletEsploraURL
+	}
+	if cfg.WalletPasswordFile != "" {
+		daemonCfg.Wallet.PasswordFile = cfg.WalletPasswordFile
+	}
+	if cfg.WalletPollInterval != 0 {
+		daemonCfg.Wallet.PollInterval = cfg.WalletPollInterval
+	}
+	if cfg.WalletRecoveryWindow != 0 {
+		daemonCfg.Wallet.RecoveryWindow = cfg.WalletRecoveryWindow
+	}
+	if cfg.WalletFeeURL != "" {
+		daemonCfg.Wallet.FeeURL = cfg.WalletFeeURL
+	}
+
+	if daemonCfg.Swap == nil {
+		daemonCfg.Swap = &darepod.SwapConfig{}
+	}
+	if cfg.SwapServerAddress != "" {
+		daemonCfg.Swap.ServerAddress = cfg.SwapServerAddress
+	}
+	if cfg.SwapServerTLSCertPath != "" {
+		daemonCfg.Swap.ServerTLSCertPath = cfg.SwapServerTLSCertPath
+	}
+	cfg.SwapServerInsecure.WhenSome(func(v bool) {
+		daemonCfg.Swap.ServerInsecure = v
+	})
+	if cfg.SwapDatabaseFileName != "" {
+		daemonCfg.Swap.DatabaseFileName = cfg.SwapDatabaseFileName
+	}
+}
+
+// cloneDaemonConfig copies reference-typed daemon config fields before walletdk
+// injects its private listener and optional service registrars.
+//
+// Start mutates the daemon config (assigning daemonCfg.RPC.Listener and
+// appending to RPCServiceRegistrars). When the caller supplies their own
+// DaemonConfig, we must not write those changes back into the caller's
+// pointer graph, otherwise a second Start call (or any caller-side inspection
+// of the config) would see walletdk's bufconn listener and registrars. Hence
+// the per-subgroup shallow copies below; new pointer/slice fields added to
+// darepod.Config in the future need a matching clone here.
+// TestCloneDaemonConfigCoversReferenceFields in embedded_test.go reflects over
+// darepod.Config and fails when a new pointer/slice/map field is added without
+// a matching clone.
+func cloneDaemonConfig(cfg *darepod.Config) *darepod.Config {
+	clone := *cfg
+
+	if cfg.Lnd != nil {
+		lndCfg := *cfg.Lnd
+		clone.Lnd = &lndCfg
+	}
+	if cfg.Server != nil {
+		serverCfg := *cfg.Server
+		clone.Server = &serverCfg
+	}
+	if cfg.RPC != nil {
+		rpcCfg := *cfg.RPC
+		clone.RPC = &rpcCfg
+	}
+	if cfg.Wallet != nil {
+		walletCfg := *cfg.Wallet
+		walletCfg.BtcwalletPeers = append(
+			[]string(nil), cfg.Wallet.BtcwalletPeers...,
+		)
+		walletCfg.BtcwalletAddPeers = append(
+			[]string(nil), cfg.Wallet.BtcwalletAddPeers...,
+		)
+		clone.Wallet = &walletCfg
+	}
+	if cfg.Unroll != nil {
+		unrollCfg := *cfg.Unroll
+		clone.Unroll = &unrollCfg
+	}
+	if cfg.Swap != nil {
+		swapCfg := *cfg.Swap
+		clone.Swap = &swapCfg
+	}
+	if cfg.OOR != nil {
+		oorCfg := *cfg.OOR
+		clone.OOR = &oorCfg
+	}
+
+	clone.RPCServiceRegistrars = append(
+		[]darepod.RPCServiceRegistrar(nil), cfg.RPCServiceRegistrars...,
+	)
+
+	return &clone
+}
+
+// waitForRunExit bounds shutdown waits when startup or Stop cancels the
+// embedded daemon runtime.
+func waitForRunExit(ctx context.Context, rt *daemonRuntime) error {
+	select {
+	case <-rt.Done():
+		return rt.runErr
+
+	case <-ctx.Done():
+		return fmt.Errorf("wait for embedded daemon shutdown: %w",
+			ctx.Err())
+	}
+}
+
+// waitForReady forces the lazy gRPC client to dial the embedded daemon before
+// Start returns.
+//
+// grpc.NewClient is intentionally lazy: it does not dial until the first RPC.
+// Start's contract is that callers can use the returned Client immediately, so
+// we explicitly Connect and then poll connectivity state transitions until
+// either gRPC reports Ready or the daemon exits early.
+//
+// The death watch piggybacks on context.AfterFunc: when the daemon runtime
+// context is cancelled, watchCtx is also cancelled, which unblocks
+// WaitForStateChange. This replaces an earlier per-iteration goroutine that
+// could race the loop and silently drop the daemon-death signal.
+func waitForReady(ctx context.Context, conn *grpc.ClientConn,
+	rt *daemonRuntime) error {
+
+	conn.Connect()
+
+	watchCtx, watchCancel := context.WithCancel(ctx)
+	defer watchCancel()
+
+	//nolint:contextcheck // rt.ctx is the daemon lifecycle signal, not a
+	// request context to inherit; using it here is exactly the point.
+	stop := context.AfterFunc(rt.ctx, watchCancel)
+	defer stop()
+
+	for {
+		state := conn.GetState()
+		if state == connectivity.Ready {
+			return nil
+		}
+		if state == connectivity.Shutdown {
+			return errors.New("grpc connection shut down before " +
+				"readiness")
+		}
+
+		if !conn.WaitForStateChange(watchCtx, state) {
+			select {
+			case <-rt.Done():
+				if rt.runErr != nil {
+					return fmt.Errorf("embedded daemon "+
+						"exited before readiness: %w",
+						rt.runErr)
+				}
+
+				return errors.New("embedded daemon exited " +
+					"before readiness")
+
+			default:
+			}
+
+			return fmt.Errorf("wait for grpc readiness: %w",
+				ctx.Err())
+		}
+	}
+}

--- a/sdk/walletdk/embedded_test.go
+++ b/sdk/walletdk/embedded_test.go
@@ -1,0 +1,202 @@
+package walletdk
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/lightninglabs/darepo-client/darepod"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// TestCloneDaemonConfigIsolation verifies that cloneDaemonConfig produces a
+// graph whose reference-typed fields can be mutated independently of the
+// original. This is the actual contract Start relies on when it injects its
+// bufconn listener and swap registrar into the cloned config.
+//
+// The test reflects over darepod.Config and fails on any pointer/slice/map
+// field whose clone aliases the original. Adding a new reference-typed field
+// to darepod.Config without updating cloneDaemonConfig will surface here as
+// either a "still nil after clone" failure (when the test fixture is also out
+// of date) or, more importantly, an aliasing failure (when the fixture is
+// updated but the clone is not).
+func TestCloneDaemonConfigIsolation(t *testing.T) {
+	original := darepod.DefaultConfig()
+
+	// Make sure every reference-typed field we currently know about is
+	// non-nil/non-empty so we can detect aliasing. New fields added to
+	// darepod.Config require updating this fixture too — the test below
+	// flags any reference-typed field that remains nil after this setup.
+	if original.Lnd == nil {
+		original.Lnd = &darepod.LndConfig{}
+	}
+	if original.Server == nil {
+		original.Server = &darepod.ServerConfig{}
+	}
+	if original.RPC == nil {
+		original.RPC = &darepod.RPCConfig{}
+	}
+	if original.Wallet == nil {
+		original.Wallet = &darepod.WalletConfig{}
+	}
+	original.Wallet.BtcwalletPeers = []string{"peer-a"}
+	original.Wallet.BtcwalletAddPeers = []string{"add-peer-a"}
+	if original.Unroll == nil {
+		original.Unroll = &darepod.UnrollConfig{}
+	}
+	if original.Swap == nil {
+		original.Swap = &darepod.SwapConfig{}
+	}
+	if original.OOR == nil {
+		original.OOR = &darepod.OORConfig{}
+	}
+	original.RPCServiceRegistrars = []darepod.RPCServiceRegistrar{
+		func(context.Context, *grpc.Server, *darepod.RPCServer,
+			*darepod.Config) (func(), error) {
+
+			return func() {}, nil
+		},
+	}
+
+	clone := cloneDaemonConfig(original)
+
+	origV := reflect.ValueOf(original).Elem()
+	cloneV := reflect.ValueOf(clone).Elem()
+
+	for i := 0; i < origV.NumField(); i++ {
+		fieldName := origV.Type().Field(i).Name
+		origF := origV.Field(i)
+		cloneF := cloneV.Field(i)
+
+		switch origF.Kind() {
+		case reflect.Ptr:
+			if origF.IsNil() {
+				// Skip pointer fields the fixture doesn't
+				// populate; the assertion below would be
+				// vacuously satisfied anyway.
+				continue
+			}
+			require.NotNil(
+				t, cloneF.Interface(),
+				"clone field %s is nil but original is set",
+				fieldName,
+			)
+			require.NotEqualf(
+				t, origF.Pointer(), cloneF.Pointer(),
+				"clone field %s aliases the original "+
+					"pointer (add a deep-copy in "+
+					"cloneDaemonConfig)", fieldName,
+			)
+
+		case reflect.Slice:
+			if origF.Len() == 0 {
+				continue
+			}
+			require.Greaterf(
+				t, cloneF.Len(), 0, "clone field %s is "+
+					"empty but original is populated",
+				fieldName,
+			)
+			origHeader := origF.Index(0).UnsafeAddr()
+			cloneHeader := cloneF.Index(0).UnsafeAddr()
+			require.NotEqualf(
+				t, origHeader, cloneHeader, "clone slice %s "+
+					"shares backing array with original "+
+					"(add an append-based copy in "+
+					"cloneDaemonConfig)", fieldName,
+			)
+
+		case reflect.Map:
+			// We do not currently clone any maps. If a map field
+			// is ever added to darepod.Config, this branch flags
+			// the gap loudly so the contributor can decide
+			// whether the map needs cloning.
+			if !origF.IsNil() {
+				t.Fatalf("darepod.Config grew a map field %q "+
+					"that cloneDaemonConfig does "+
+					"not handle", fieldName)
+			}
+
+		default:
+			// Value-typed fields (scalars, structs, interfaces,
+			// funcs, etc.) do not need deep-copy because they are
+			// already isolated by the outer struct copy that
+			// cloneDaemonConfig performs.
+		}
+	}
+}
+
+// TestClientStopIdempotent verifies that Stop, Close, and repeated calls all
+// invoke the underlying closeFn exactly once. Hosts often call Stop from
+// multiple shutdown paths (signal handler, defer, error cleanup) so the
+// double-close contract must hold.
+func TestClientStopIdempotent(t *testing.T) {
+	var calls atomic.Int32
+	client := &Client{
+		closeFn: func(context.Context) error {
+			calls.Add(1)
+
+			return nil
+		},
+	}
+
+	require.NoError(t, client.Stop())
+	require.NoError(t, client.Stop())
+	require.NoError(t, client.Close())
+	require.EqualValues(
+		t, 1, calls.Load(),
+		"closeFn must be invoked exactly once across Stop/Close calls",
+	)
+}
+
+// TestClientWaitFanOut verifies that multiple concurrent Wait() callers each
+// receive the daemon's terminal error. Earlier implementations exposed a
+// single shared channel, so the second selector observed only the
+// already-closed signal — see PR #365 review item (2).
+func TestClientWaitFanOut(t *testing.T) {
+	rt := newDaemonRuntime()
+	client := &Client{runtime: rt}
+
+	const subscribers = 4
+	channels := make([]<-chan error, subscribers)
+	for i := range channels {
+		channels[i] = client.Wait()
+	}
+
+	wantErr := errors.New("daemon boom")
+	rt.signalExit(wantErr)
+
+	for i, ch := range channels {
+		select {
+		case got := <-ch:
+			require.ErrorIsf(
+				t, got, wantErr, "subscriber %d did not "+
+					"receive terminal error", i,
+			)
+
+		case <-time.After(time.Second):
+			t.Fatalf("subscriber %d timed out waiting for "+
+				"terminal error", i)
+		}
+	}
+}
+
+// TestDaemonRuntimeSignalExitOnce locks in the contract that signalExit only
+// records the first terminal error and never panics on repeat calls.
+func TestDaemonRuntimeSignalExitOnce(t *testing.T) {
+	rt := newDaemonRuntime()
+
+	first := errors.New("first")
+	second := errors.New("second")
+
+	rt.signalExit(first)
+	rt.signalExit(second)
+	rt.signalExit(nil)
+
+	<-rt.Done()
+	require.Same(t, first, rt.runErr)
+}

--- a/sdk/walletdk/errors.go
+++ b/sdk/walletdk/errors.go
@@ -1,0 +1,8 @@
+package walletdk
+
+import "errors"
+
+// ErrSwapRuntimeUnavailable reports that walletdk was built without the
+// daemon-owned swap executor needed by Send and Receive.
+var ErrSwapRuntimeUnavailable = errors.New("walletdk swap runtime " +
+	"unavailable; rebuild with -tags swapruntime")

--- a/sdk/walletdk/swapruntime.go
+++ b/sdk/walletdk/swapruntime.go
@@ -1,0 +1,34 @@
+//go:build swapruntime
+
+package walletdk
+
+import (
+	"github.com/lightninglabs/darepo-client/darepod"
+	"github.com/lightninglabs/darepo-client/swapclientserver"
+)
+
+// configureSwapRuntime registers the daemon-owned swap executor when the
+// package is built with the swapruntime tag.
+//
+// The build-tag split exists so default walletdk builds do not pull in the
+// swap executor's dependency graph (sdk/swaps, swap store, swapdk-server
+// transport). Hosts that ship Lightning swap support opt in via -tags
+// swapruntime; the stub file in swapruntime_stub.go is the negative half of
+// the same contract and keeps the public Client method set identical across
+// both build flavors.
+func configureSwapRuntime(cfg *darepod.Config, enabled bool) error {
+	if !enabled {
+		return nil
+	}
+
+	cfg.RPCServiceRegistrars = append(
+		cfg.RPCServiceRegistrars, swapclientserver.Register,
+	)
+
+	return nil
+}
+
+// swapRuntimeAvailable reports whether this build can register swap RPCs.
+func swapRuntimeAvailable() bool {
+	return true
+}

--- a/sdk/walletdk/swapruntime_stub.go
+++ b/sdk/walletdk/swapruntime_stub.go
@@ -1,0 +1,16 @@
+//go:build !swapruntime
+
+package walletdk
+
+import "github.com/lightninglabs/darepo-client/darepod"
+
+// configureSwapRuntime keeps default builds compiling. Swap methods return
+// ErrSwapRuntimeUnavailable when the executor is absent.
+func configureSwapRuntime(_ *darepod.Config, enabled bool) error {
+	return nil
+}
+
+// swapRuntimeAvailable reports that default builds omit the swap executor.
+func swapRuntimeAvailable() bool {
+	return false
+}

--- a/sdk/walletdk/swapruntime_stub_test.go
+++ b/sdk/walletdk/swapruntime_stub_test.go
@@ -1,0 +1,29 @@
+//go:build !swapruntime
+
+package walletdk
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSwapMethodsRequireSwapRuntime makes default builds fail swap calls before
+// they attempt an unregistered RPC.
+func TestSwapMethodsRequireSwapRuntime(t *testing.T) {
+	client := &Client{}
+
+	_, err := client.Receive(context.Background(), ReceiveRequest{
+		AmountSat: 1,
+	})
+	require.ErrorIs(t, err, ErrSwapRuntimeUnavailable)
+
+	_, err = client.Send(context.Background(), SendRequest{
+		Invoice: "invoice",
+	})
+	require.ErrorIs(t, err, ErrSwapRuntimeUnavailable)
+
+	_, err = client.ListSwaps(context.Background(), ListSwapsRequest{})
+	require.ErrorIs(t, err, ErrSwapRuntimeUnavailable)
+}

--- a/sdk/walletdk/types.go
+++ b/sdk/walletdk/types.go
@@ -1,0 +1,214 @@
+package walletdk
+
+import (
+	"io"
+	"time"
+
+	"github.com/lightninglabs/darepo-client/darepod"
+	"github.com/lightningnetwork/lnd/fn/v2"
+)
+
+// Config controls the embedded daemon and wallet facade.
+type Config struct {
+	// DaemonConfig supplies the full daemon config. When nil, walletdk
+	// starts from darepod.DefaultConfig and applies the convenience fields
+	// below.
+	DaemonConfig *darepod.Config
+
+	// DisableSwaps starts the daemon without registering the daemon-owned
+	// swap executor. Send and Receive require swaps to be enabled.
+	DisableSwaps bool
+
+	// DataDir is the root directory for daemon and wallet state.
+	DataDir string
+
+	// Network selects the bitcoin network.
+	Network string
+
+	// DebugLevel controls daemon logging verbosity.
+	DebugLevel string
+
+	// LogWriter receives daemon logs. Nil uses darepod's default stdout.
+	LogWriter io.Writer
+
+	// AllowMainnet is the tri-state mainnet-allow flag. fn.None defers to
+	// DaemonConfig; fn.Some(true)/fn.Some(false) forces that value.
+	AllowMainnet fn.Option[bool]
+
+	// ServerAddress is the Ark operator mailbox edge server address.
+	ServerAddress string
+
+	// ServerTLSCertPath pins the Ark operator TLS certificate.
+	ServerTLSCertPath string
+
+	// ServerInsecure is the tri-state TLS-disable flag for the Ark
+	// operator connection. fn.None defers to DaemonConfig;
+	// fn.Some(true)/fn.Some(false) forces that value.
+	ServerInsecure fn.Option[bool]
+
+	// WalletType selects the backing wallet implementation.
+	WalletType string
+
+	// WalletEsploraURL is used by the lwwallet backend.
+	WalletEsploraURL string
+
+	// WalletPasswordFile enables daemon auto-unlock for lwwallet.
+	WalletPasswordFile string
+
+	// WalletPollInterval overrides the lwwallet chain poll interval.
+	WalletPollInterval time.Duration
+
+	// WalletRecoveryWindow overrides the wallet address look-ahead window.
+	WalletRecoveryWindow uint32
+
+	// WalletFeeURL is the fee estimator endpoint used by btcwallet.
+	WalletFeeURL string
+
+	// SwapServerAddress is the swapdk-server gRPC address.
+	SwapServerAddress string
+
+	// SwapServerTLSCertPath pins the swapdk-server TLS certificate.
+	SwapServerTLSCertPath string
+
+	// SwapServerInsecure is the tri-state TLS-disable flag for the swap
+	// server connection. fn.None defers to DaemonConfig; fn.Some(true)/
+	// fn.Some(false) forces that value.
+	SwapServerInsecure fn.Option[bool]
+
+	// SwapDatabaseFileName is the daemon-owned swap SQLite database path.
+	SwapDatabaseFileName string
+
+	// MaxOperatorFeeSat caps the per-round operator fee the daemon accepts.
+	MaxOperatorFeeSat int64
+
+	// BufferSize overrides the bufconn listener buffer size.
+	BufferSize int
+}
+
+// Info summarizes daemon readiness for wallet applications.
+type Info struct {
+	Version         string
+	Commit          string
+	Network         string
+	BlockHeight     uint32
+	ServerConnected bool
+	WalletType      string
+	WalletReady     bool
+	IdentityPubKey  string
+}
+
+// CreateWalletRequest creates or imports a daemon wallet.
+type CreateWalletRequest struct {
+	Mnemonic       []string
+	SeedPassphrase []byte
+	WalletPassword []byte
+}
+
+// CreateWalletResult returns the seed words and daemon identity.
+type CreateWalletResult struct {
+	Mnemonic       []string
+	EncipheredSeed []byte
+	IdentityPubKey string
+}
+
+// UnlockWalletRequest unlocks an existing daemon wallet.
+type UnlockWalletRequest struct {
+	WalletPassword []byte
+}
+
+// UnlockWalletResult returns the daemon identity after unlock.
+type UnlockWalletResult struct {
+	IdentityPubKey string
+}
+
+// Balance is the simplified wallet balance view.
+type Balance struct {
+	BoardingConfirmedSat      int64
+	BoardingUnconfirmedSat    int64
+	VTXOBalanceSat            int64
+	TotalConfirmedSat         int64
+	OnchainWalletConfirmedSat int64
+}
+
+// OnchainAddress is a fresh boarding address.
+type OnchainAddress struct {
+	Address string
+}
+
+// ReceiveRequest starts a Lightning-to-Ark receive swap.
+type ReceiveRequest struct {
+	AmountSat int64
+}
+
+// ReceiveResult contains the invoice and initial durable swap state.
+type ReceiveResult struct {
+	PaymentHash string
+	Invoice     string
+	Swap        SwapSummary
+}
+
+// SendRequest starts an Ark-to-Lightning payment.
+type SendRequest struct {
+	Invoice   string
+	MaxFeeSat uint64
+}
+
+// SendResult contains the payment hash and initial durable swap state.
+type SendResult struct {
+	PaymentHash string
+	Swap        SwapSummary
+}
+
+// ListSwapsRequest controls swap listing.
+type ListSwapsRequest struct {
+	PendingOnly bool
+}
+
+// GetSwapRequest fetches one swap by payment hash.
+type GetSwapRequest struct {
+	PaymentHash string
+}
+
+// ResumeSwapRequest wakes one pending daemon-owned swap worker.
+type ResumeSwapRequest struct {
+	PaymentHash string
+	Direction   SwapDirection
+}
+
+// SubscribeSwapsRequest controls swap update subscriptions.
+type SubscribeSwapsRequest struct {
+	IncludeExisting bool
+	PendingOnly     bool
+}
+
+// SwapDirection identifies the swap direction.
+type SwapDirection string
+
+const (
+	// SwapDirectionPay is an Ark-to-Lightning payment.
+	SwapDirectionPay SwapDirection = "pay"
+
+	// SwapDirectionReceive is a Lightning-to-Ark receive.
+	SwapDirectionReceive SwapDirection = "receive"
+)
+
+// SwapSummary is the wrapper-friendly view of one persisted swap.
+type SwapSummary struct {
+	Direction        SwapDirection
+	PaymentHash      string
+	State            string
+	Pending          bool
+	AmountSat        int64
+	FeeSat           uint64
+	MaxFeeSat        uint64
+	VHTLCOutpoint    string
+	VHTLCAmountSat   int64
+	FundingSessionID string
+	ClaimSessionID   string
+	RefundSessionID  string
+	TerminalReason   string
+	CreatedAt        time.Time
+	UpdatedAt        time.Time
+	Deadline         time.Time
+	RefundLocktime   uint32
+}

--- a/swapclientserver/AGENTS.md
+++ b/swapclientserver/AGENTS.md
@@ -32,8 +32,12 @@ protocol behavior remain entirely inside `sdk/swaps` and `swapdk-server`.
 - `Register(ctx, grpcServer, rpcServer, cfg)` — Top-level entry point called
   by a `swapruntime`-tagged `darepod` binary. Opens the daemon-owned SQLite
   swap store, dials `swapdk-server`, creates an in-process Ark SDK facade over
-  `darepod.RPCServer`, wires `swaps.NewSwapClientWithStore`, registers the
-  gRPC subserver, calls `resumePending`, and returns a cleanup function.
+  `darepod.RPCServer`, wires `swaps.NewSwapClientWithStore`, installs a
+  `MailboxOutSwapEventReceiver` (empty mailbox ID — receiver derives the
+  per-swap mailbox from client identity + payment hash) on the
+  `SwapClient` so out-swap HTLC events flow over the mailbox transport,
+  registers the gRPC subserver, calls `resumePending`, and returns a cleanup
+  function.
 
 ## RPC Methods
 
@@ -82,6 +86,12 @@ protocol behavior remain entirely inside `sdk/swaps` and `swapdk-server`.
 - `idempotency_key` on `StartPay` / `StartReceive` is explicitly reserved and
   returns `Unimplemented` to guard against accidental duplicate-start
   assumptions.
+- `SetOutSwapEventReceiver` must run before any receive worker is started:
+  `SwapClient` captures the receiver into the per-swap worker at start time,
+  so a late install would leave already-running workers using whatever
+  receiver was previously installed. `Register` therefore installs the
+  mailbox receiver immediately after `NewSwapClientWithStore`, before
+  `resumePending` revives persisted sessions.
 
 ## Deep Docs
 

--- a/swapclientserver/CLAUDE.md
+++ b/swapclientserver/CLAUDE.md
@@ -32,8 +32,12 @@ protocol behavior remain entirely inside `sdk/swaps` and `swapdk-server`.
 - `Register(ctx, grpcServer, rpcServer, cfg)` — Top-level entry point called
   by a `swapruntime`-tagged `darepod` binary. Opens the daemon-owned SQLite
   swap store, dials `swapdk-server`, creates an in-process Ark SDK facade over
-  `darepod.RPCServer`, wires `swaps.NewSwapClientWithStore`, registers the
-  gRPC subserver, calls `resumePending`, and returns a cleanup function.
+  `darepod.RPCServer`, wires `swaps.NewSwapClientWithStore`, installs a
+  `MailboxOutSwapEventReceiver` (empty mailbox ID — receiver derives the
+  per-swap mailbox from client identity + payment hash) on the
+  `SwapClient` so out-swap HTLC events flow over the mailbox transport,
+  registers the gRPC subserver, calls `resumePending`, and returns a cleanup
+  function.
 
 ## RPC Methods
 
@@ -82,6 +86,12 @@ protocol behavior remain entirely inside `sdk/swaps` and `swapdk-server`.
 - `idempotency_key` on `StartPay` / `StartReceive` is explicitly reserved and
   returns `Unimplemented` to guard against accidental duplicate-start
   assumptions.
+- `SetOutSwapEventReceiver` must run before any receive worker is started:
+  `SwapClient` captures the receiver into the per-swap worker at start time,
+  so a late install would leave already-running workers using whatever
+  receiver was previously installed. `Register` therefore installs the
+  mailbox receiver immediately after `NewSwapClientWithStore`, before
+  `resumePending` revives persisted sessions.
 
 ## Deep Docs
 

--- a/swapclientserver/service.go
+++ b/swapclientserver/service.go
@@ -19,6 +19,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/darepod"
+	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
 	"github.com/lightninglabs/darepo-client/rpc/swapclientrpc"
 	sdkark "github.com/lightninglabs/darepo-client/sdk/ark"
 	"github.com/lightninglabs/darepo-client/sdk/swaps"
@@ -294,6 +295,19 @@ func newSwapClientService(ctx context.Context, rpcServer *darepod.RPCServer,
 	rootCtx, cancel := context.WithCancel(ctx)
 	swapClient := swaps.NewSwapClientWithStore(
 		serverConn, arkClient, log, invoiceGen, store,
+	)
+	// The out-swap event receiver must be wired before any
+	// ReceiveViaLightning starts: SwapClient captures the receiver into the
+	// receive worker at start time, so a late SetOutSwapEventReceiver would
+	// leave already-running workers using whatever receiver (if any) was
+	// installed earlier. resumePending below kicks off persisted workers,
+	// so installing the receiver here, immediately after construction, is
+	// the only correct point. An empty mailbox ID makes the receiver derive
+	// the per-swap mailbox from the client identity key and payment hash.
+	swapClient.SetOutSwapEventReceiver(
+		swaps.NewMailboxOutSwapEventReceiver(
+			mailboxpb.NewMailboxServiceClient(swapConn), "",
+		),
 	)
 
 	service := &swapClientService{


### PR DESCRIPTION
## Summary

- add `sdk/walletdk`, a wallet-shaped facade over an embedded darepod runtime
- wire daemon-owned swap runtime mailbox events for walletdk receive/send flows
- add a Bubble Tea `walletdk-tui` for manual wallet, swap, accounting, and log testing
- document basic walletdk integration patterns for developers and LLMs

## Test Plan

- `make fmt-changed-check`
- `make commitmsg-lint range=origin/main..HEAD`
- `go test -tags swapruntime ./sdk/walletdk ./cmd/walletdk-tui ./swapclientserver`
- `make lint`
