### PR TITLE
Mask wallet password prompt

### DIFF
--- a/cmd/darepocli/darepoclicommands/cmd_wallet.go
+++ b/cmd/darepocli/darepoclicommands/cmd_wallet.go
@@ -3,12 +3,16 @@ package darepoclicommands
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 // newWalletCmd creates the wallet parent command with subcommands for
@@ -286,10 +290,95 @@ func readPassword(cmd *cobra.Command) ([]byte, error) {
 	// Interactive prompt (TTY).
 	fmt.Fprint(os.Stderr, "Enter wallet password: ")
 
-	scanner := bufio.NewScanner(os.Stdin)
-	if scanner.Scan() {
-		return []byte(scanner.Text()), nil
+	fd := int(os.Stdin.Fd())
+	oldState, err := term.MakeRaw(fd)
+	if err != nil {
+		return nil, fmt.Errorf("unable to configure terminal for "+
+			"password input: %w", err)
+	}
+	restoreTerminal := func() {
+		if oldState == nil {
+			return
+		}
+
+		_ = term.Restore(fd, oldState)
+		oldState = nil
+	}
+	defer restoreTerminal()
+
+	password, err := readMaskedPassword(os.Stdin, os.Stderr)
+	restoreTerminal()
+	_, printErr := fmt.Fprintln(os.Stderr)
+	if err != nil {
+		return nil, err
+	}
+	if printErr != nil {
+		return nil, fmt.Errorf("unable to finalize password prompt: %w",
+			printErr)
 	}
 
-	return nil, fmt.Errorf("unable to read password")
+	return password, nil
+}
+
+// readMaskedPassword reads a single password line while echoing one asterisk
+// per entered byte. Backspace removes the last UTF-8 rune worth of bytes. It
+// expects the terminal to already be in raw mode.
+func readMaskedPassword(input io.Reader, output io.Writer) ([]byte, error) {
+	var password []byte
+	var buf [1]byte
+
+	for {
+		n, err := input.Read(buf[:])
+		if err != nil {
+			if errors.Is(err, io.EOF) && len(password) > 0 {
+				return password, nil
+			}
+
+			return nil, fmt.Errorf("unable to read password: %w",
+				err)
+		}
+		if n == 0 {
+			continue
+		}
+
+		switch b := buf[0]; b {
+		case '\r', '\n':
+			return password, nil
+
+		case 3: // Ctrl-C.
+			return nil, fmt.Errorf("password entry interrupted")
+
+		case 4: // Ctrl-D.
+			if len(password) > 0 {
+				return password, nil
+			}
+
+			return nil, fmt.Errorf("unable to read password")
+
+		case '\b', 0x7f:
+			if len(password) == 0 {
+				continue
+			}
+
+			_, size := utf8.DecodeLastRune(password)
+			password = password[:len(password)-size]
+
+			erase := strings.Repeat("\b \b", size)
+			if _, err := fmt.Fprint(output, erase); err != nil {
+				return nil, fmt.Errorf("unable to mask "+
+					"password input: %w", err)
+			}
+
+		default:
+			if b < 0x20 {
+				continue
+			}
+
+			password = append(password, b)
+			if _, err := fmt.Fprint(output, "*"); err != nil {
+				return nil, fmt.Errorf("unable to mask "+
+					"password input: %w", err)
+			}
+		}
+	}
 }

--- a/cmd/darepocli/darepoclicommands/cmd_wallet_test.go
+++ b/cmd/darepocli/darepoclicommands/cmd_wallet_test.go
@@ -1,0 +1,92 @@
+package darepoclicommands
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadMaskedPasswordMasksInput(t *testing.T) {
+	t.Parallel()
+
+	var output bytes.Buffer
+	password, err := readMaskedPassword(
+		strings.NewReader("supersecret\n"), &output,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []byte("supersecret"), password)
+	require.Equal(
+		t,
+		strings.Repeat(
+			"*", len("supersecret"),
+		),
+		output.String(),
+	)
+	require.NotContains(t, output.String(), "supersecret")
+}
+
+func TestReadMaskedPasswordBackspace(t *testing.T) {
+	t.Parallel()
+
+	var output bytes.Buffer
+	password, err := readMaskedPassword(
+		strings.NewReader("secx\x7fret\r"), &output,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []byte("secret"), password)
+	require.Equal(t, "****\b \b***", output.String())
+}
+
+func TestReadMaskedPasswordUTF8Backspace(t *testing.T) {
+	t.Parallel()
+
+	var output bytes.Buffer
+	password, err := readMaskedPassword(
+		strings.NewReader("caf\xc3\xa9\x7feteria\n"), &output,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []byte("cafeteria"), password)
+	require.Equal(t, "*****\b \b\b \b******", output.String())
+}
+
+func TestReadMaskedPasswordInterrupt(t *testing.T) {
+	t.Parallel()
+
+	var output bytes.Buffer
+	password, err := readMaskedPassword(
+		strings.NewReader("sec\x03ret\n"), &output,
+	)
+	require.Nil(t, password)
+	require.ErrorContains(t, err, "password entry interrupted")
+	require.Equal(t, "***", output.String())
+}
+
+func TestReadMaskedPasswordWrapsReadError(t *testing.T) {
+	t.Parallel()
+
+	readErr := errors.New("synthetic read failure")
+	var output bytes.Buffer
+	password, err := readMaskedPassword(
+		errReader{err: readErr}, &output,
+	)
+	require.Nil(t, password)
+	require.ErrorIs(t, err, readErr)
+	require.ErrorContains(t, err, "unable to read password")
+	require.Empty(t, output.String())
+}
+
+type errReader struct {
+	err error
+}
+
+func (r errReader) Read(_ []byte) (int, error) {
+	if r.err != nil {
+		return 0, r.err
+	}
+
+	return 0, io.EOF
+}

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	golang.org/x/crypto v0.47.0
 	golang.org/x/exp v0.0.0-20251113190631-e25ba8c21ef6
 	golang.org/x/sync v0.19.0
+	golang.org/x/term v0.39.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217
 	google.golang.org/grpc v1.79.3
 	google.golang.org/protobuf v1.36.11
@@ -204,7 +205,6 @@ require (
 	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect
-	golang.org/x/term v0.39.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
 	golang.org/x/time v0.11.0 // indirect
 	golang.org/x/tools v0.41.0 // indirect


### PR DESCRIPTION
## Summary

- Mask interactive wallet password entry for `darepocli wallet create` and
  `darepocli wallet unlock` by switching the TTY prompt to raw input.
- Echo one `*` per entered byte while keeping the real password out of the
  terminal output.
- Preserve the existing non-interactive password sources: `DAREPOD_WALLET_PASSWORD`,
  `--wallet_password_file`, and piped stdin.
- Add focused CLI tests for masking, backspace handling, and interrupted entry.

## Root Cause

The interactive wallet password path printed `Enter wallet password:` and then
read from `os.Stdin` with a normal `bufio.Scanner`. On a TTY, the terminal keeps
echo enabled by default, so each typed password character was displayed in clear
text before the scanner returned the line.

## User Impact

Users can now run wallet create/unlock interactively without exposing their
wallet password on screen. Backspace updates the visible mask, Ctrl-C returns a
clear interruption error, and automated flows continue to behave as before.

## Validation

- `make fmt-changed`
- `make fmt-changed-check`
- `make commitmsg-lint file=/tmp/darepo-client-mask-wallet-commitmsg.txt`
- `make commitmsg-lint commit=HEAD`
- `go test ./cmd/darepocli/...`
- `go build ./cmd/darepocli`
- Manual validation from @bhandras: `darepocli wallet unlock` was tested and
  the fix was confirmed correct.