### PR TITLE
chainbackends: fix lnd fee rate units

### DIFF
--- a/chainbackends/lnd.go
+++ b/chainbackends/lnd.go
@@ -119,6 +119,7 @@ func (b *LNDBackend) EstimateFee(ctx context.Context, targetConf uint32) (
 
 	b.logger(ctx).DebugS(ctx, "Fee rate estimated",
 		slog.Int("target_confs", int(targetConf)),
+		slog.Int64("sat_per_kw", int64(feePerKw)),
 		slog.Int64("sat_per_vbyte", int64(satPerVByte)),
 	)
 

--- a/chainbackends/lnd_test.go
+++ b/chainbackends/lnd_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/chainsource"
+	"github.com/lightninglabs/lndclient"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 	"github.com/stretchr/testify/require"
@@ -47,12 +48,17 @@ func (n *stubNotifier) Started() bool { return true }
 
 func (n *stubNotifier) Stop() error { return nil }
 
-type stubFeeEstimator struct{}
+type stubFeeEstimator struct {
+	rate      chainfee.SatPerKWeight
+	gotTarget uint32
+}
 
-func (s *stubFeeEstimator) EstimateFeePerKW(_ uint32) (chainfee.SatPerKWeight,
-	error) {
+func (s *stubFeeEstimator) EstimateFeePerKW(target uint32) (
+	chainfee.SatPerKWeight, error) {
 
-	return 0, nil
+	s.gotTarget = target
+
+	return s.rate, nil
 }
 
 func (s *stubFeeEstimator) RelayFeePerKW() chainfee.SatPerKWeight {
@@ -62,6 +68,21 @@ func (s *stubFeeEstimator) RelayFeePerKW() chainfee.SatPerKWeight {
 func (s *stubFeeEstimator) Start() error { return nil }
 
 func (s *stubFeeEstimator) Stop() error { return nil }
+
+type stubWalletKitFeeEstimator struct {
+	lndclient.WalletKitClient
+
+	rate      chainfee.SatPerKWeight
+	gotTarget int32
+}
+
+func (s *stubWalletKitFeeEstimator) EstimateFeeRate(_ context.Context,
+	target int32) (chainfee.SatPerKWeight, error) {
+
+	s.gotTarget = target
+
+	return s.rate, nil
+}
 
 type stubBroadcaster struct{}
 
@@ -82,6 +103,40 @@ func (s *stubPackageSubmitter) SubmitPackage(_ context.Context,
 	*btcjson.SubmitPackageResult, error) {
 
 	return s.result, s.err
+}
+
+func TestLndClientFeeEstimatorReturnsWalletKitSatPerKW(t *testing.T) {
+	t.Parallel()
+
+	const wantRate = chainfee.SatPerKWeight(1_250)
+
+	walletKit := &stubWalletKitFeeEstimator{
+		rate: wantRate,
+	}
+	estimator := NewLndClientFeeEstimator(walletKit)
+
+	gotRate, err := estimator.EstimateFeePerKW(6)
+	require.NoError(t, err)
+	require.Equal(t, wantRate, gotRate)
+	require.Equal(t, int32(6), walletKit.gotTarget)
+}
+
+func TestLNDBackendEstimateFeeConvertsSatPerKWOnce(t *testing.T) {
+	t.Parallel()
+
+	const walletKitRate = chainfee.SatPerKWeight(31_774)
+
+	estimator := &stubFeeEstimator{
+		rate: walletKitRate,
+	}
+	backend := NewLNDBackend(
+		&stubNotifier{}, estimator, &stubBroadcaster{},
+	)
+
+	gotRate, err := backend.EstimateFee(t.Context(), 6)
+	require.NoError(t, err)
+	require.Equal(t, int64(walletKitRate.FeePerVByte()), int64(gotRate))
+	require.Equal(t, uint32(6), estimator.gotTarget)
 }
 
 func TestRegisterConfSurvivesCallerContextCancellation(t *testing.T) {

--- a/chainbackends/lndclient_adapters.go
+++ b/chainbackends/lndclient_adapters.go
@@ -75,14 +75,12 @@ func (e *LndClientFeeEstimator) EstimateFeePerKW(numBlocks uint32) (
 		context.Background(), 30*time.Second,
 	)
 	defer cancel()
-	satPerVByte, err := e.walletKit.EstimateFeeRate(
+	satPerKw, err := e.walletKit.EstimateFeeRate(
 		ctx, int32(numBlocks),
 	)
 	if err != nil {
 		return 0, fmt.Errorf("estimate fee rate: %w", err)
 	}
-
-	satPerKw := chainfee.SatPerVByte(satPerVByte).FeePerKWeight()
 
 	return satPerKw, nil
 }


### PR DESCRIPTION
## Summary

Fix the lndclient-backed fee estimator to preserve WalletKit's fee-rate units.

`lndclient.WalletKitClient.EstimateFeeRate` already returns a `chainfee.SatPerKWeight`. The adapter was treating that value as sat/vB and calling `FeePerKWeight()` on it, inflating the result by roughly 250x.

This exactly matches the signet symptom we saw while debugging boarding fees:

```text
WalletKit-ish rate:      31,774 sat/kW = 127 sat/vB
Buggy double conversion: 7,943,500 sat/kW = 31,774 sat/vB
Observed quote shape:    ~4.893M sat on-chain share
```

## Changes

- Return WalletKit's sat/kW value directly from `LndClientFeeEstimator.EstimateFeePerKW`.
- Keep the single sat/kW to sat/vB conversion at the `LNDBackend.EstimateFee` boundary.
- Add regression coverage for both boundaries so this cannot silently drift again.
- Log both sat/kW and sat/vB in the generic LND chain backend fee estimate log line.

## Tests

```text
go test ./chainbackends -count=1
```
