### PR TITLE
Fix round intent log attributes

### DIFF
--- a/round/events.go
+++ b/round/events.go
@@ -358,9 +358,9 @@ func (e *IntentPackage) isEmpty() bool {
 		len(e.VTXOs) == 0 && len(e.Leaves) == 0
 }
 
-// logAttributes returns structured logging attributes for the package.
-func (e *IntentPackage) logAttributes() []slog.Attr {
-	return []slog.Attr{
+// logAttributes returns structured logging arguments for the package.
+func (e *IntentPackage) logAttributes() []any {
+	return []any{
 		slog.Int("boarding_intents", len(e.Boarding)),
 		slog.Int("vtxo_requests", len(e.VTXOs)),
 		slog.Int("forfeits", len(e.Forfeits)),

--- a/round/events_test.go
+++ b/round/events_test.go
@@ -1,0 +1,88 @@
+package round
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/lightninglabs/darepo-client/lib/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIntentPackageLogAttributes verifies that intent package log attributes
+// are emitted as structured fields instead of a single malformed argument.
+func TestIntentPackageLogAttributes(t *testing.T) {
+	t.Parallel()
+
+	packageAttrs := (&IntentPackage{
+		Intents: Intents{
+			Boarding: make([]BoardingIntent, 2),
+			VTXOs:    make([]types.VTXORequest, 1),
+		},
+	}).logAttributes()
+
+	handler := &capturingHandler{}
+	logger := slog.New(handler)
+	logger.InfoContext(
+		context.Background(),
+		"Starting round assembly from intent package", packageAttrs...,
+	)
+
+	require.Equal(
+		t, "Starting round assembly from intent package",
+		handler.message,
+	)
+	require.NotContains(t, handler.attrs, "!BADKEY")
+	require.Equal(t, int64(2), handler.attrs["boarding_intents"].Int64())
+	require.Equal(t, int64(1), handler.attrs["vtxo_requests"].Int64())
+	require.Equal(t, int64(0), handler.attrs["forfeits"].Int64())
+	require.Equal(t, int64(0), handler.attrs["leaves"].Int64())
+	require.Len(t, handler.attrs, 4)
+}
+
+// capturingHandler records slog records so tests can inspect structured
+// attributes without depending on a text handler's rendered format.
+type capturingHandler struct {
+	message string
+	attrs   map[string]slog.Value
+}
+
+// Enabled allows every log record through to the capturing handler.
+func (h *capturingHandler) Enabled(context.Context, slog.Level) bool {
+	return true
+}
+
+// Handle records the message and attributes from the supplied log record.
+func (h *capturingHandler) Handle(_ context.Context, record slog.Record) error {
+	h.message = record.Message
+	h.attrs = make(map[string]slog.Value)
+	record.Attrs(func(attr slog.Attr) bool {
+		h.attrs[attr.Key] = attr.Value
+
+		return true
+	})
+
+	return nil
+}
+
+// WithAttrs returns a copy of the handler preloaded with additional attrs.
+func (h *capturingHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	handlerCopy := &capturingHandler{
+		message: h.message,
+		attrs:   make(map[string]slog.Value),
+	}
+	for key, value := range h.attrs {
+		handlerCopy.attrs[key] = value
+	}
+	for _, attr := range attrs {
+		handlerCopy.attrs[attr.Key] = attr.Value
+	}
+
+	return handlerCopy
+}
+
+// WithGroup returns the handler unchanged because these tests do not use
+// grouped attributes.
+func (h *capturingHandler) WithGroup(string) slog.Handler {
+	return h
+}

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -165,7 +165,7 @@ func (s *Idle) ProcessEvent(ctx context.Context, event ClientEvent,
 		}
 
 		env.Log.InfoS(ctx, "Starting round assembly from "+
-			"intent package", evt.logAttributes())
+			"intent package", evt.logAttributes()...)
 
 		return &ClientStateTransition{
 			NextState: &PendingRoundAssembly{
@@ -2980,7 +2980,7 @@ func (s *ClientFailedState) ProcessEvent(ctx context.Context, event ClientEvent,
 
 		env.Log.InfoS(ctx, "Recovering from failed state "+
 			"with intent package",
-			evt.logAttributes())
+			evt.logAttributes()...)
 
 		return &ClientStateTransition{
 			NextState: &Idle{},


### PR DESCRIPTION
## Summary

- Fix intent-package structured logging in the round FSM so the count fields are
  emitted as real attributes instead of `!BADKEY`.
- Change `IntentPackage.logAttributes` to return expandable logging arguments
  and spread them at both `InfoS` call sites.
- Add a regression test with a custom `slog.Handler` that captures structured
  attributes directly and verifies the expected fields appear without
  `!BADKEY`.

## Root Cause

`IntentPackage.logAttributes` returned `[]slog.Attr`, but the two call sites
passed that slice as a single variadic argument to `InfoS`. The logger expected
individual attributes or key/value pairs, so it treated the whole slice as a
malformed structured argument and rendered output like:

```text
!BADKEY="[boarding_intents=2 vtxo_requests=1 forfeits=0 leaves=0]"
```

## User Impact

Round assembly logs now expose searchable structured fields such as
`boarding_intents=2`, `vtxo_requests=1`, `forfeits=0`, and `leaves=0` instead
of hiding the useful data behind `!BADKEY`.

## Review Follow-Up

- Reworked the regression test to use a custom capturing `slog.Handler` instead
  of asserting on `slog.TextHandler` output.
- Added Go doc comments for the test and helper methods.

## Validation

- `make fmt-changed`
- `make fmt-changed-check`
- `make commitmsg-lint file=/tmp/darepo-client-round-logattrs-commitmsg.txt`
- `make commitmsg-lint commit=HEAD`
- `go test ./round`
