### PR TITLE
swaps: validate pay-side quotes

### DIFF
--- a/sdk/swaps/client.go
+++ b/sdk/swaps/client.go
@@ -7,6 +7,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btclog/v2"
 	sdkark "github.com/lightninglabs/darepo-client/sdk/ark"
 	"github.com/lightningnetwork/lnd/invoices"
@@ -447,6 +448,7 @@ type SwapClient struct {
 	claimRetryDelay          time.Duration
 	claimMaxAttempts         int
 	decodeOutSwapOnion       outSwapOnionDecoder
+	chainParams              *chaincfg.Params
 	now                      func() time.Time
 }
 
@@ -454,6 +456,13 @@ type SwapClient struct {
 // ReceiveViaLightning. Callers should configure this before starting receives.
 func (c *SwapClient) SetOutSwapEventReceiver(receiver OutSwapEventReceiver) {
 	c.outEvents = receiver
+}
+
+// SetChainParams sets the Bitcoin network used to decode pay-side
+// BOLT-11 invoices. PayViaLightning rejects invoices when no network params are
+// configured.
+func (c *SwapClient) SetChainParams(chainParams *chaincfg.Params) {
+	c.chainParams = chainParams
 }
 
 // NewSwapClient creates a new swap client. The invoice creator may be nil for
@@ -497,7 +506,32 @@ func NewSwapClientWithStore(server SwapServerConn, daemon DaemonConn,
 		claimRetryDelay:          time.Second,
 		claimMaxAttempts:         10,
 		decodeOutSwapOnion:       decodeOutSwapOnion,
+		chainParams:              invoiceCreatorChainParams(invoiceGen),
 		now:                      time.Now,
+	}
+}
+
+// invoiceCreatorChainParams returns the chain params carried by the built-in
+// invoice creators. Custom invoice creators can still configure pay invoice
+// decoding explicitly through SetChainParams.
+func invoiceCreatorChainParams(creator InvoiceCreator) *chaincfg.Params {
+	switch c := creator.(type) {
+	case *InvoiceGenerator:
+		if c == nil {
+			return nil
+		}
+
+		return c.chainParams
+
+	case *DirectInvoiceCreator:
+		if c == nil || c.generator == nil {
+			return nil
+		}
+
+		return c.generator.chainParams
+
+	default:
+		return nil
 	}
 }
 

--- a/sdk/swaps/in_swap.go
+++ b/sdk/swaps/in_swap.go
@@ -545,6 +545,13 @@ func (s *paySession) createSwap(ctx context.Context) error {
 		cfg.SettlementType = SettlementTypeLightning
 	}
 
+	err = validateInSwapQuote(
+		s.invoice, s.maxFeeSat, cfg, s.client.chainParams,
+	)
+	if err != nil {
+		return fmt.Errorf("validate in-swap quote: %w", err)
+	}
+
 	operatorKey, err := s.client.daemon.OperatorPubKey(ctx)
 	if err != nil {
 		return fmt.Errorf("get operator pubkey: %w", err)

--- a/sdk/swaps/in_swap_quote.go
+++ b/sdk/swaps/in_swap_quote.go
@@ -1,0 +1,102 @@
+package swaps
+
+import (
+	"fmt"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/zpay32"
+)
+
+// maxInt64Uint is the largest positive int64 value represented as uint64 for
+// checked amount conversions.
+const maxInt64Uint = uint64(1<<63 - 1)
+
+// decodePayInvoice decodes one pay-side BOLT-11 invoice against the client's
+// configured Bitcoin network.
+func decodePayInvoice(invoice string,
+	chainParams *chaincfg.Params) (*zpay32.Invoice, error) {
+
+	if chainParams == nil {
+		return nil, fmt.Errorf("pay invoice chain params are required")
+	}
+
+	decoded, err := zpay32.Decode(invoice, chainParams)
+	if err != nil {
+		return nil, fmt.Errorf("decode invoice: %w", err)
+	}
+
+	return decoded, nil
+}
+
+// extractInvoiceAmountSat extracts a positive whole-satoshi invoice amount.
+func extractInvoiceAmountSat(msat *lnwire.MilliSatoshi) (uint64, error) {
+	if msat == nil {
+		return 0, fmt.Errorf("invoice amount is required")
+	}
+
+	amountMSat := uint64(*msat)
+	if amountMSat == 0 {
+		return 0, fmt.Errorf("invoice amount must be positive")
+	}
+	if amountMSat%1000 != 0 {
+		return 0, fmt.Errorf("invoice amount must be whole satoshis")
+	}
+
+	return amountMSat / 1000, nil
+}
+
+// validateInSwapQuote verifies that the server quote is bound to the caller's
+// invoice and fee limit before the client funds the quoted vHTLC.
+func validateInSwapQuote(invoice string, maxFeeSat uint64, cfg *InSwapConfig,
+	chainParams *chaincfg.Params) error {
+
+	if cfg == nil {
+		return fmt.Errorf("in-swap config is required")
+	}
+	if cfg.AmountSat <= 0 {
+		return fmt.Errorf("in-swap amount must be positive")
+	}
+
+	decoded, err := decodePayInvoice(invoice, chainParams)
+	if err != nil {
+		return err
+	}
+
+	if decoded.PaymentHash == nil {
+		return fmt.Errorf("invoice payment hash is required")
+	}
+
+	invoiceHash := lntypes.Hash(*decoded.PaymentHash)
+	if invoiceHash != cfg.PaymentHash {
+		return fmt.Errorf("in-swap payment hash does not match invoice")
+	}
+
+	amountSat, err := extractInvoiceAmountSat(decoded.MilliSat)
+	if err != nil {
+		return err
+	}
+
+	if cfg.FeeSat > maxFeeSat {
+		return fmt.Errorf("in-swap fee %d exceeds max fee %d",
+			cfg.FeeSat, maxFeeSat)
+	}
+
+	if cfg.FeeSat > maxInt64Uint {
+		return fmt.Errorf("in-swap fee overflows int64 range")
+	}
+
+	if amountSat > maxInt64Uint-cfg.FeeSat {
+		return fmt.Errorf("in-swap amount overflows int64 range")
+	}
+
+	expectedAmountSat := amountSat + cfg.FeeSat
+	if uint64(cfg.AmountSat) != expectedAmountSat {
+		return fmt.Errorf("in-swap amount %d does not equal invoice "+
+			"amount %d plus fee %d", cfg.AmountSat, amountSat,
+			cfg.FeeSat)
+	}
+
+	return nil
+}

--- a/sdk/swaps/in_swap_test.go
+++ b/sdk/swaps/in_swap_test.go
@@ -8,11 +8,28 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/zpay32"
 	"github.com/stretchr/testify/require"
+)
+
+const (
+	// testInSwapAmountSat is the total vHTLC amount returned by the fake
+	// swap server.
+	testInSwapAmountSat = 42_000
+
+	// testInSwapFeeSat is the swap server fee returned by the fake swap
+	// server.
+	testInSwapFeeSat = 123
+
+	// testInSwapInvoiceSat is the original Lightning invoice amount.
+	testInSwapInvoiceSat = testInSwapAmountSat - testInSwapFeeSat
 )
 
 type testInSwapServerConn struct {
@@ -38,6 +55,277 @@ func (c *testInSwapServerConn) Close() error {
 	return nil
 }
 
+// testPayInvoice creates a regtest BOLT-11 invoice for the supplied preimage
+// and amount.
+func testPayInvoice(t *testing.T, preimage lntypes.Preimage,
+	amountSat btcutil.Amount) string {
+
+	t.Helper()
+
+	invoiceKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	creator := NewEphemeralInvoiceGenerator(
+		invoiceKey, nil, &chaincfg.RegressionNetParams,
+	)
+
+	invoice, hash, err := creator.CreateInvoice(
+		t.Context(), amountSat, "pay", &RouteHint{
+			NodeID: invoiceKey.
+				PubKey().
+				SerializeCompressed(),
+			ChannelID:       1,
+			CltvExpiryDelta: 40,
+		},
+		time.Hour, &preimage,
+	)
+	require.NoError(t, err)
+	require.Equal(t, preimage.Hash(), hash)
+
+	return string(invoice.PaymentRequest)
+}
+
+// testValidPayInvoice creates the standard pay-side test invoice.
+func testValidPayInvoice(t *testing.T, preimage lntypes.Preimage) string {
+	t.Helper()
+
+	return testPayInvoice(
+		t, preimage, btcutil.Amount(testInSwapInvoiceSat),
+	)
+}
+
+// testAmountlessPayInvoice creates a valid regtest BOLT-11 invoice without an
+// amount.
+func testAmountlessPayInvoice(t *testing.T, preimage lntypes.Preimage) string {
+	t.Helper()
+
+	invoiceKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	invoice, err := zpay32.NewInvoice(
+		&chaincfg.RegressionNetParams, preimage.Hash(), time.Now(),
+		zpay32.Description("pay"),
+	)
+	require.NoError(t, err)
+
+	paymentRequest, err := invoice.Encode(zpay32.MessageSigner{
+		SignCompact: func(msg []byte) ([]byte, error) {
+			return ecdsa.SignCompact(invoiceKey, msg, true), nil
+		},
+	})
+	require.NoError(t, err)
+
+	return paymentRequest
+}
+
+// configureTestPayClient sets the regtest invoice network on a test client.
+func configureTestPayClient(client *SwapClient) *SwapClient {
+	client.SetChainParams(&chaincfg.RegressionNetParams)
+
+	return client
+}
+
+// testInSwapConfig returns a valid fake in-swap quote for the standard pay
+// invoice used by the tests.
+func testInSwapConfig(serverPubkey *btcec.PublicKey, preimage lntypes.Preimage,
+	expiry time.Time) *InSwapConfig {
+
+	return &InSwapConfig{
+		PaymentHash:  preimage.Hash(),
+		AmountSat:    testInSwapAmountSat,
+		FeeSat:       testInSwapFeeSat,
+		ServerPubkey: serverPubkey,
+		VHTLCConfig: VHTLCConfig{
+			RefundLocktime:                       144,
+			UnilateralClaimDelay:                 12,
+			UnilateralRefundDelay:                24,
+			UnilateralRefundWithoutReceiverDelay: 36,
+		},
+		Expiry: expiry,
+	}
+}
+
+// cloneInSwapConfig returns a shallow copy of cfg for validation tests that
+// mutate one quoted field at a time.
+func cloneInSwapConfig(cfg *InSwapConfig) *InSwapConfig {
+	clone := *cfg
+
+	return &clone
+}
+
+// TestValidateInSwapQuoteRejectsServerMismatches verifies the client treats
+// the swap server response as a quote that must match the caller's invoice.
+func TestValidateInSwapQuoteRejectsServerMismatches(t *testing.T) {
+	t.Parallel()
+
+	serverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	preimage, err := NewPreimage()
+	require.NoError(t, err)
+	invoice := testValidPayInvoice(t, preimage)
+
+	cfg := testInSwapConfig(
+		serverPriv.PubKey(), preimage, time.Now().Add(time.Minute),
+	)
+	err = validateInSwapQuote(
+		invoice, testInSwapFeeSat, cfg, &chaincfg.RegressionNetParams,
+	)
+	require.NoError(t, err)
+
+	otherPreimage, err := NewPreimage()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		invoice     string
+		maxFeeSat   uint64
+		chainParams *chaincfg.Params
+		mutate      func(*InSwapConfig)
+		wantErr     string
+	}{{
+		name:        "missing chain params",
+		invoice:     invoice,
+		maxFeeSat:   testInSwapFeeSat,
+		chainParams: nil,
+		wantErr:     "chain params",
+	}, {
+		name:        "wrong network",
+		invoice:     invoice,
+		maxFeeSat:   testInSwapFeeSat,
+		chainParams: &chaincfg.MainNetParams,
+		wantErr:     "decode invoice",
+	}, {
+		name:        "payment hash mismatch",
+		invoice:     invoice,
+		maxFeeSat:   testInSwapFeeSat,
+		chainParams: &chaincfg.RegressionNetParams,
+		mutate: func(cfg *InSwapConfig) {
+			cfg.PaymentHash = otherPreimage.Hash()
+		},
+		wantErr: "payment hash does not match",
+	}, {
+		name:        "fee above caller limit",
+		invoice:     invoice,
+		maxFeeSat:   testInSwapFeeSat - 1,
+		chainParams: &chaincfg.RegressionNetParams,
+		wantErr:     "exceeds max fee",
+	}, {
+		name:        "fee overflows int64",
+		invoice:     invoice,
+		maxFeeSat:   ^uint64(0),
+		chainParams: &chaincfg.RegressionNetParams,
+		mutate: func(cfg *InSwapConfig) {
+			cfg.FeeSat = maxInt64Uint + 1
+		},
+		wantErr: "fee overflows int64 range",
+	}, {
+		name:        "amount below invoice plus fee",
+		invoice:     invoice,
+		maxFeeSat:   testInSwapFeeSat,
+		chainParams: &chaincfg.RegressionNetParams,
+		mutate: func(cfg *InSwapConfig) {
+			cfg.AmountSat--
+		},
+		wantErr: "does not equal invoice amount",
+	}, {
+		name:        "amount above invoice plus fee",
+		invoice:     invoice,
+		maxFeeSat:   testInSwapFeeSat,
+		chainParams: &chaincfg.RegressionNetParams,
+		mutate: func(cfg *InSwapConfig) {
+			cfg.AmountSat++
+		},
+		wantErr: "does not equal invoice amount",
+	}}
+
+	for _, test := range tests {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := cloneInSwapConfig(cfg)
+			if test.mutate != nil {
+				test.mutate(cfg)
+			}
+
+			err := validateInSwapQuote(
+				test.invoice, test.maxFeeSat, cfg,
+				test.chainParams,
+			)
+			require.ErrorContains(t, err, test.wantErr)
+		})
+	}
+}
+
+// TestValidateInSwapQuoteRejectsAmountlessInvoice verifies pay swaps require a
+// fixed BOLT-11 amount because the client cannot safely infer it from the
+// server quote.
+func TestValidateInSwapQuoteRejectsAmountlessInvoice(t *testing.T) {
+	t.Parallel()
+
+	serverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	preimage, err := NewPreimage()
+	require.NoError(t, err)
+	invoice := testAmountlessPayInvoice(t, preimage)
+
+	cfg := testInSwapConfig(
+		serverPriv.PubKey(), preimage, time.Now().Add(time.Minute),
+	)
+	err = validateInSwapQuote(
+		invoice, testInSwapFeeSat, cfg, &chaincfg.RegressionNetParams,
+	)
+	require.ErrorContains(t, err, "invoice amount")
+}
+
+// TestPaySessionRejectsUnboundInSwapQuote verifies quote validation runs
+// before the client funds the server-returned vHTLC.
+func TestPaySessionRejectsUnboundInSwapQuote(t *testing.T) {
+	t.Parallel()
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	serverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	preimage, err := NewPreimage()
+	require.NoError(t, err)
+	invoice := testValidPayInvoice(t, preimage)
+
+	otherPreimage, err := NewPreimage()
+	require.NoError(t, err)
+
+	cfg := testInSwapConfig(
+		serverPriv.PubKey(), otherPreimage, time.Now().Add(time.Minute),
+	)
+	serverConn := &testInSwapServerConn{
+		cfg: cfg,
+	}
+
+	daemonConn := &testDaemonConn{
+		identityKey: clientPriv.PubKey(),
+		operatorKey: operatorPriv.PubKey(),
+	}
+
+	client := configureTestPayClient(
+		NewSwapClient(serverConn, daemonConn, nil, nil),
+	)
+
+	session, err := client.StartPayViaLightning(
+		t.Context(), invoice, testInSwapFeeSat,
+	)
+	require.Nil(t, session)
+	require.ErrorContains(t, err, "payment hash does not match")
+	require.Zero(t, daemonConn.sendPolicyCalls)
+}
+
 // TestPayViaLightningReturnsClaimPreimage asserts the SDK recovers the
 // preimage from the spending OOR package after the vHTLC is claimed.
 func TestPayViaLightningReturnsClaimPreimage(t *testing.T) {
@@ -54,12 +342,13 @@ func TestPayViaLightningReturnsClaimPreimage(t *testing.T) {
 
 	preimage, err := NewPreimage()
 	require.NoError(t, err)
+	invoice := testValidPayInvoice(t, preimage)
 
 	serverConn := &testInSwapServerConn{
 		cfg: &InSwapConfig{
 			PaymentHash:  preimage.Hash(),
-			AmountSat:    42_000,
-			FeeSat:       123,
+			AmountSat:    testInSwapAmountSat,
+			FeeSat:       testInSwapFeeSat,
 			ServerPubkey: serverPriv.PubKey(),
 			VHTLCConfig: VHTLCConfig{
 				RefundLocktime:                       144,
@@ -88,19 +377,20 @@ func TestPayViaLightningReturnsClaimPreimage(t *testing.T) {
 		},
 	}
 
-	client := NewSwapClient(serverConn, daemonConn, nil, nil)
+	client := configureTestPayClient(
+		NewSwapClient(serverConn, daemonConn, nil, nil),
+	)
 	client.waitPollInterval = time.Millisecond
 	client.fundingExpiryBuffer = 0
 
 	result, err := client.PayViaLightning(
-		t.Context(),
-		"lnrtest1invoice", 0,
+		t.Context(), invoice, testInSwapFeeSat,
 	)
 	require.NoError(t, err)
 	require.Equal(t, preimage.Hash(), result.PaymentHash)
 	require.Equal(t, preimage, result.Preimage)
 	require.Equal(t, "funding-session", result.FundingSessionID)
-	require.EqualValues(t, 123, result.FeeSat)
+	require.EqualValues(t, testInSwapFeeSat, result.FeeSat)
 	require.NotEmpty(t, daemonConn.lastSendPolicy)
 }
 
@@ -121,12 +411,13 @@ func TestPayViaLightningRequiresClaimPreimage(t *testing.T) {
 
 	preimage, err := NewPreimage()
 	require.NoError(t, err)
+	invoice := testValidPayInvoice(t, preimage)
 
 	serverConn := &testInSwapServerConn{
 		cfg: &InSwapConfig{
 			PaymentHash:  preimage.Hash(),
-			AmountSat:    42_000,
-			FeeSat:       123,
+			AmountSat:    testInSwapAmountSat,
+			FeeSat:       testInSwapFeeSat,
 			ServerPubkey: serverPriv.PubKey(),
 			VHTLCConfig: VHTLCConfig{
 				RefundLocktime:                       144,
@@ -144,12 +435,13 @@ func TestPayViaLightningRequiresClaimPreimage(t *testing.T) {
 		sendSessionID: "funding-session",
 	}
 
-	client := NewSwapClient(serverConn, daemonConn, nil, nil)
+	client := configureTestPayClient(
+		NewSwapClient(serverConn, daemonConn, nil, nil),
+	)
 	client.waitPollInterval = time.Millisecond
 
 	result, err := client.PayViaLightning(
-		t.Context(),
-		"lnrtest1invoice", 0,
+		t.Context(), invoice, testInSwapFeeSat,
 	)
 	require.ErrorIs(t, err, errSwapExpired)
 	require.Nil(t, result)
@@ -176,13 +468,14 @@ func TestPaySessionRefundsFundedVHTLCOnTimeout(t *testing.T) {
 
 	preimage, err := NewPreimage()
 	require.NoError(t, err)
+	invoice := testValidPayInvoice(t, preimage)
 
 	now := time.Unix(1_700_000_000, 0)
 	serverConn := &testInSwapServerConn{
 		cfg: &InSwapConfig{
 			PaymentHash:  preimage.Hash(),
-			AmountSat:    42_000,
-			FeeSat:       123,
+			AmountSat:    testInSwapAmountSat,
+			FeeSat:       testInSwapFeeSat,
 			ServerPubkey: serverPriv.PubKey(),
 			VHTLCConfig: VHTLCConfig{
 				RefundLocktime:                       100,
@@ -201,7 +494,7 @@ func TestPaySessionRefundsFundedVHTLCOnTimeout(t *testing.T) {
 		sendSessionID: "refund-session",
 		vhtlc: &VTXOInfo{
 			Outpoint:  "funding:0",
-			AmountSat: 42_000,
+			AmountSat: testInSwapAmountSat,
 		},
 		receiveInfo: &ReceiveInfo{
 			PubKeyXOnly: clientPriv.PubKey().X().Bytes(),
@@ -210,16 +503,17 @@ func TestPaySessionRefundsFundedVHTLCOnTimeout(t *testing.T) {
 		spendOnCustom: true,
 	}
 
-	client := NewSwapClientWithStore(
-		serverConn, daemonConn, nil, nil, store,
+	client := configureTestPayClient(
+		NewSwapClientWithStore(
+			serverConn, daemonConn, nil, nil, store,
+		),
 	)
 	client.waitPollInterval = time.Millisecond
 	client.refundLocktimeBuffer = 0
 	client.now = func() time.Time { return now }
 
 	session, err := client.StartPayViaLightning(
-		t.Context(),
-		"lnrtest1invoice", 0,
+		t.Context(), invoice, testInSwapFeeSat,
 	)
 	require.NoError(t, err)
 
@@ -262,12 +556,13 @@ func TestPaySessionRefundsWhenRefundLocktimePassesBeforeClaim(t *testing.T) {
 
 	preimage, err := NewPreimage()
 	require.NoError(t, err)
+	invoice := testValidPayInvoice(t, preimage)
 
 	serverConn := &testInSwapServerConn{
 		cfg: &InSwapConfig{
 			PaymentHash:  preimage.Hash(),
-			AmountSat:    42_000,
-			FeeSat:       123,
+			AmountSat:    testInSwapAmountSat,
+			FeeSat:       testInSwapFeeSat,
 			ServerPubkey: serverPriv.PubKey(),
 			VHTLCConfig: VHTLCConfig{
 				RefundLocktime:                       100,
@@ -286,7 +581,7 @@ func TestPaySessionRefundsWhenRefundLocktimePassesBeforeClaim(t *testing.T) {
 		sendSessionID: "refund-session",
 		vhtlc: &VTXOInfo{
 			Outpoint:  "funding:0",
-			AmountSat: 42_000,
+			AmountSat: testInSwapAmountSat,
 		},
 		receiveInfo: &ReceiveInfo{
 			PubKeyXOnly: clientPriv.PubKey().X().Bytes(),
@@ -295,15 +590,16 @@ func TestPaySessionRefundsWhenRefundLocktimePassesBeforeClaim(t *testing.T) {
 		spendOnCustom: true,
 	}
 
-	client := NewSwapClientWithStore(
-		serverConn, daemonConn, nil, nil, store,
+	client := configureTestPayClient(
+		NewSwapClientWithStore(
+			serverConn, daemonConn, nil, nil, store,
+		),
 	)
 	client.waitPollInterval = time.Millisecond
 	client.refundLocktimeBuffer = 0
 
 	session, err := client.StartPayViaLightning(
-		t.Context(),
-		"lnrtest1invoice", 0,
+		t.Context(), invoice, testInSwapFeeSat,
 	)
 	require.NoError(t, err)
 
@@ -344,12 +640,13 @@ func TestPaySessionResumeFromStore(t *testing.T) {
 
 	preimage, err := NewPreimage()
 	require.NoError(t, err)
+	invoice := testValidPayInvoice(t, preimage)
 
 	serverConn := &testInSwapServerConn{
 		cfg: &InSwapConfig{
 			PaymentHash:  preimage.Hash(),
-			AmountSat:    42_000,
-			FeeSat:       123,
+			AmountSat:    testInSwapAmountSat,
+			FeeSat:       testInSwapFeeSat,
 			ServerPubkey: serverPriv.PubKey(),
 			VHTLCConfig: VHTLCConfig{
 				RefundLocktime:                       144,
@@ -367,14 +664,15 @@ func TestPaySessionResumeFromStore(t *testing.T) {
 		sendSessionID: "funding-session",
 	}
 
-	client := NewSwapClientWithStore(
-		serverConn, daemonConn, nil, nil, store,
+	client := configureTestPayClient(
+		NewSwapClientWithStore(
+			serverConn, daemonConn, nil, nil, store,
+		),
 	)
 	client.waitPollInterval = time.Millisecond
 
 	session, err := client.StartPayViaLightning(
-		t.Context(),
-		"lnrtest1invoice", 0,
+		t.Context(), invoice, testInSwapFeeSat,
 	)
 	require.NoError(t, err)
 	require.Equal(t, PayStateSwapCreated, session.State())
@@ -389,8 +687,10 @@ func TestPaySessionResumeFromStore(t *testing.T) {
 		},
 	}
 
-	resumedClient := NewSwapClientWithStore(
-		serverConn, daemonConn, nil, nil, store,
+	resumedClient := configureTestPayClient(
+		NewSwapClientWithStore(
+			serverConn, daemonConn, nil, nil, store,
+		),
 	)
 	resumedClient.waitPollInterval = time.Millisecond
 
@@ -426,12 +726,13 @@ func TestPaySessionCancelDoesNotPersistFailed(t *testing.T) {
 
 	preimage, err := NewPreimage()
 	require.NoError(t, err)
+	invoice := testValidPayInvoice(t, preimage)
 
 	serverConn := &testInSwapServerConn{
 		cfg: &InSwapConfig{
 			PaymentHash:  preimage.Hash(),
-			AmountSat:    42_000,
-			FeeSat:       123,
+			AmountSat:    testInSwapAmountSat,
+			FeeSat:       testInSwapFeeSat,
 			ServerPubkey: serverPriv.PubKey(),
 			VHTLCConfig: VHTLCConfig{
 				RefundLocktime:                       144,
@@ -449,14 +750,15 @@ func TestPaySessionCancelDoesNotPersistFailed(t *testing.T) {
 		sendSessionID: "funding-session",
 	}
 
-	client := NewSwapClientWithStore(
-		serverConn, daemonConn, nil, nil, store,
+	client := configureTestPayClient(
+		NewSwapClientWithStore(
+			serverConn, daemonConn, nil, nil, store,
+		),
 	)
 	client.waitPollInterval = time.Millisecond
 
 	session, err := client.StartPayViaLightning(
-		t.Context(),
-		"lnrtest1invoice", 0,
+		t.Context(), invoice, testInSwapFeeSat,
 	)
 	require.NoError(t, err)
 
@@ -468,8 +770,10 @@ func TestPaySessionCancelDoesNotPersistFailed(t *testing.T) {
 	_, err = session.Wait(waitCtx)
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 
-	resumedClient := NewSwapClientWithStore(
-		serverConn, daemonConn, nil, nil, store,
+	resumedClient := configureTestPayClient(
+		NewSwapClientWithStore(
+			serverConn, daemonConn, nil, nil, store,
+		),
 	)
 	resumed, err := resumedClient.ResumePayViaLightning(
 		t.Context(), preimage.Hash(),
@@ -498,6 +802,7 @@ func TestPaySessionResumeFundingGraceSkipsImmediateResend(t *testing.T) {
 
 	preimage, err := NewPreimage()
 	require.NoError(t, err)
+	invoice := testValidPayInvoice(t, preimage)
 
 	now := time.Unix(1_700_000_000, 0)
 	grace := 50 * time.Millisecond
@@ -505,8 +810,8 @@ func TestPaySessionResumeFundingGraceSkipsImmediateResend(t *testing.T) {
 	serverConn := &testInSwapServerConn{
 		cfg: &InSwapConfig{
 			PaymentHash:  preimage.Hash(),
-			AmountSat:    42_000,
-			FeeSat:       123,
+			AmountSat:    testInSwapAmountSat,
+			FeeSat:       testInSwapFeeSat,
 			ServerPubkey: serverPriv.PubKey(),
 			VHTLCConfig: VHTLCConfig{
 				RefundLocktime:                       144,
@@ -524,16 +829,17 @@ func TestPaySessionResumeFundingGraceSkipsImmediateResend(t *testing.T) {
 		sendSessionID: "funding-session",
 	}
 
-	client := NewSwapClientWithStore(
-		serverConn, daemonConn, nil, nil, store,
+	client := configureTestPayClient(
+		NewSwapClientWithStore(
+			serverConn, daemonConn, nil, nil, store,
+		),
 	)
 	client.waitPollInterval = time.Millisecond
 	client.fundingResumeGracePeriod = grace
 	client.now = func() time.Time { return now }
 
 	session, err := client.StartPayViaLightning(
-		t.Context(),
-		"lnrtest1invoice", 0,
+		t.Context(), invoice, testInSwapFeeSat,
 	)
 	require.NoError(t, err)
 
@@ -542,8 +848,10 @@ func TestPaySessionResumeFundingGraceSkipsImmediateResend(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	resumedClient := NewSwapClientWithStore(
-		serverConn, daemonConn, nil, nil, store,
+	resumedClient := configureTestPayClient(
+		NewSwapClientWithStore(
+			serverConn, daemonConn, nil, nil, store,
+		),
 	)
 	resumedClient.waitPollInterval = time.Millisecond
 	resumedClient.fundingResumeGracePeriod = grace
@@ -585,6 +893,7 @@ func TestPaySessionResumeFundingGraceEventuallyRetries(t *testing.T) {
 
 	preimage, err := NewPreimage()
 	require.NoError(t, err)
+	invoice := testValidPayInvoice(t, preimage)
 
 	start := time.Unix(1_700_000_000, 0)
 	grace := 10 * time.Millisecond
@@ -592,8 +901,8 @@ func TestPaySessionResumeFundingGraceEventuallyRetries(t *testing.T) {
 	serverConn := &testInSwapServerConn{
 		cfg: &InSwapConfig{
 			PaymentHash:  preimage.Hash(),
-			AmountSat:    42_000,
-			FeeSat:       123,
+			AmountSat:    testInSwapAmountSat,
+			FeeSat:       testInSwapFeeSat,
 			ServerPubkey: serverPriv.PubKey(),
 			VHTLCConfig: VHTLCConfig{
 				RefundLocktime:                       144,
@@ -611,16 +920,17 @@ func TestPaySessionResumeFundingGraceEventuallyRetries(t *testing.T) {
 		sendSessionID: "funding-session",
 	}
 
-	client := NewSwapClientWithStore(
-		serverConn, daemonConn, nil, nil, store,
+	client := configureTestPayClient(
+		NewSwapClientWithStore(
+			serverConn, daemonConn, nil, nil, store,
+		),
 	)
 	client.waitPollInterval = time.Millisecond
 	client.fundingResumeGracePeriod = grace
 	client.now = func() time.Time { return start }
 
 	session, err := client.StartPayViaLightning(
-		t.Context(),
-		"lnrtest1invoice", 0,
+		t.Context(), invoice, testInSwapFeeSat,
 	)
 	require.NoError(t, err)
 
@@ -629,8 +939,10 @@ func TestPaySessionResumeFundingGraceEventuallyRetries(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	resumedClient := NewSwapClientWithStore(
-		serverConn, daemonConn, nil, nil, store,
+	resumedClient := configureTestPayClient(
+		NewSwapClientWithStore(
+			serverConn, daemonConn, nil, nil, store,
+		),
 	)
 	resumedClient.waitPollInterval = time.Millisecond
 	resumedClient.fundingResumeGracePeriod = grace
@@ -681,12 +993,13 @@ func TestPaySessionRefundsAmountMismatch(t *testing.T) {
 
 	preimage, err := NewPreimage()
 	require.NoError(t, err)
+	invoice := testValidPayInvoice(t, preimage)
 
 	serverConn := &testInSwapServerConn{
 		cfg: &InSwapConfig{
 			PaymentHash:  preimage.Hash(),
-			AmountSat:    42_000,
-			FeeSat:       123,
+			AmountSat:    testInSwapAmountSat,
+			FeeSat:       testInSwapFeeSat,
 			ServerPubkey: serverPriv.PubKey(),
 			VHTLCConfig: VHTLCConfig{
 				RefundLocktime:                       144,
@@ -714,14 +1027,15 @@ func TestPaySessionRefundsAmountMismatch(t *testing.T) {
 		spendOnCustom: true,
 	}
 
-	client := NewSwapClientWithStore(
-		serverConn, daemonConn, nil, nil, store,
+	client := configureTestPayClient(
+		NewSwapClientWithStore(
+			serverConn, daemonConn, nil, nil, store,
+		),
 	)
 	client.waitPollInterval = time.Millisecond
 
 	session, err := client.StartPayViaLightning(
-		t.Context(),
-		"lnrtest1invoice", 0,
+		t.Context(), invoice, testInSwapFeeSat,
 	)
 	require.NoError(t, err)
 
@@ -758,12 +1072,13 @@ func TestPaySessionFailsNearRefundLocktime(t *testing.T) {
 
 	preimage, err := NewPreimage()
 	require.NoError(t, err)
+	invoice := testValidPayInvoice(t, preimage)
 
 	serverConn := &testInSwapServerConn{
 		cfg: &InSwapConfig{
 			PaymentHash:  preimage.Hash(),
-			AmountSat:    42_000,
-			FeeSat:       123,
+			AmountSat:    testInSwapAmountSat,
+			FeeSat:       testInSwapFeeSat,
 			ServerPubkey: serverPriv.PubKey(),
 			VHTLCConfig: VHTLCConfig{
 				RefundLocktime:                       100,
@@ -781,14 +1096,15 @@ func TestPaySessionFailsNearRefundLocktime(t *testing.T) {
 		blockHeight: 99,
 	}
 
-	client := NewSwapClientWithStore(
-		serverConn, daemonConn, nil, nil, store,
+	client := configureTestPayClient(
+		NewSwapClientWithStore(
+			serverConn, daemonConn, nil, nil, store,
+		),
 	)
 	client.waitPollInterval = time.Millisecond
 
 	session, err := client.StartPayViaLightning(
-		t.Context(),
-		"lnrtest1invoice", 0,
+		t.Context(), invoice, testInSwapFeeSat,
 	)
 	require.NoError(t, err)
 
@@ -824,14 +1140,15 @@ func TestPaySessionExpiresBeforeUnsafeLateFunding(t *testing.T) {
 
 	preimage, err := NewPreimage()
 	require.NoError(t, err)
+	invoice := testValidPayInvoice(t, preimage)
 
 	now := time.Unix(1_700_000_000, 0)
 
 	serverConn := &testInSwapServerConn{
 		cfg: &InSwapConfig{
 			PaymentHash:  preimage.Hash(),
-			AmountSat:    42_000,
-			FeeSat:       123,
+			AmountSat:    testInSwapAmountSat,
+			FeeSat:       testInSwapFeeSat,
 			ServerPubkey: serverPriv.PubKey(),
 			VHTLCConfig: VHTLCConfig{
 				RefundLocktime:                       200,
@@ -849,15 +1166,16 @@ func TestPaySessionExpiresBeforeUnsafeLateFunding(t *testing.T) {
 		blockHeight: 100,
 	}
 
-	client := NewSwapClientWithStore(
-		serverConn, daemonConn, nil, nil, store,
+	client := configureTestPayClient(
+		NewSwapClientWithStore(
+			serverConn, daemonConn, nil, nil, store,
+		),
 	)
 	client.now = func() time.Time { return now }
 	client.fundingExpiryBuffer = 5 * time.Second
 
 	session, err := client.StartPayViaLightning(
-		t.Context(),
-		"lnrtest1invoice", 0,
+		t.Context(), invoice, testInSwapFeeSat,
 	)
 	require.NoError(t, err)
 
@@ -891,12 +1209,13 @@ func TestPaySessionNeedsInterventionOnSpentWithoutPreimage(t *testing.T) {
 
 	preimage, err := NewPreimage()
 	require.NoError(t, err)
+	invoice := testValidPayInvoice(t, preimage)
 
 	serverConn := &testInSwapServerConn{
 		cfg: &InSwapConfig{
 			PaymentHash:  preimage.Hash(),
-			AmountSat:    42_000,
-			FeeSat:       123,
+			AmountSat:    testInSwapAmountSat,
+			FeeSat:       testInSwapFeeSat,
 			ServerPubkey: serverPriv.PubKey(),
 			VHTLCConfig: VHTLCConfig{
 				RefundLocktime:                       200,
@@ -915,20 +1234,21 @@ func TestPaySessionNeedsInterventionOnSpentWithoutPreimage(t *testing.T) {
 		sendSessionID: "funding-session",
 		spentVTXO: &VTXOInfo{
 			Outpoint:    "funding:0",
-			AmountSat:   42_000,
+			AmountSat:   testInSwapAmountSat,
 			SpentByTxID: "deadbeef",
 		},
 		indexedPackage: &OORPackageInfo{},
 	}
 
-	client := NewSwapClientWithStore(
-		serverConn, daemonConn, nil, nil, store,
+	client := configureTestPayClient(
+		NewSwapClientWithStore(
+			serverConn, daemonConn, nil, nil, store,
+		),
 	)
 	client.waitPollInterval = time.Millisecond
 
 	session, err := client.StartPayViaLightning(
-		t.Context(),
-		"lnrtest1invoice", 0,
+		t.Context(), invoice, testInSwapFeeSat,
 	)
 	require.NoError(t, err)
 
@@ -945,7 +1265,7 @@ func TestPaySessionNeedsInterventionOnSpentWithoutPreimage(t *testing.T) {
 		"spent without claim preimage",
 	)
 	require.Equal(t, "funding:0", resumed.vhtlcOutpoint)
-	require.EqualValues(t, 42_000, resumed.vhtlcAmount)
+	require.EqualValues(t, testInSwapAmountSat, resumed.vhtlcAmount)
 }
 
 // TestWaitForInSwapClaimObservationToleratesPreimageLag asserts an indexed
@@ -960,7 +1280,7 @@ func TestWaitForInSwapClaimObservationToleratesPreimageLag(t *testing.T) {
 	daemonConn := &testDaemonConn{
 		spentVTXO: &VTXOInfo{
 			Outpoint:  "funding:0",
-			AmountSat: 42_000,
+			AmountSat: testInSwapAmountSat,
 			SpentByTxID: "0123456789abcdef0123456789abcdef" +
 				"0123456789abcdef0123456789abcdef",
 		},


### PR DESCRIPTION
## Summary

Fixes #367.

This PR makes Ark-to-Lightning pay swaps validate the swap-server quote against the caller's original BOLT-11 invoice before the client builds or funds the vHTLC.

The client now decodes the invoice locally and requires:

- the server-returned payment hash to match the invoice payment hash
- the invoice to carry a fixed, positive, whole-satoshi amount
- the quoted fee to stay within the caller's `maxFeeSat`
- the quoted vHTLC amount to equal `invoice amount + quoted fee`

That changes the swap server response from trusted truth into a quote the client verifies before funding. A malicious or compromised server can no longer swap in a hash it controls, inflate the funded amount, or charge beyond the caller's max fee without the client rejecting the session before any OOR funding attempt.

## Network Handling

Pay-side invoice decoding uses configured Bitcoin chain params instead of trying every network. The built-in invoice generators carry chain params, so the CLI and daemon service paths configure this automatically through the existing `NewSwapClientWithStore` wiring.

Pay-only SDK callers that construct `SwapClient` without one of the built-in invoice generators must call `SetChainParams` before `PayViaLightning`/`StartPayViaLightning`. If params are missing, pay swaps fail closed before funding.

## Tests

The pay-side tests now generate real regtest BOLT-11 invoices bound to each test preimage instead of using placeholder invoice strings. New coverage asserts quote validation rejects:

- missing invoice network params
- wrong-network invoices
- mismatched server payment hashes
- server fees above the caller limit
- quoted amounts that do not equal invoice amount plus fee
- amountless invoices

The FSM wiring is also covered by a test that verifies a mismatched server quote is rejected before any funding send is attempted.

## Validation

- `make fmt-changed`
- `go test ./sdk/swaps`
- `go test ./cmd/darepocli/darepoclicommands`
- `go test -tags swapruntime ./swapclientserver`
- `make commitmsg-lint range=origin/main..HEAD`
- `make lint-native`

