### PR TITLE
indexer: bound opaque vtxo cursors

### DIFF
--- a/darepod/incoming_metadata.go
+++ b/darepod/incoming_metadata.go
@@ -10,6 +10,7 @@ import (
 	"github.com/lightninglabs/darepo-client/arkrpc"
 	"github.com/lightninglabs/darepo-client/build"
 	"github.com/lightninglabs/darepo-client/indexer"
+	"github.com/lightninglabs/darepo-client/internal/indexerlimits"
 	"github.com/lightninglabs/darepo-client/oor"
 	"github.com/lightninglabs/darepo-client/vtxo"
 )
@@ -23,12 +24,37 @@ func ResolveIncomingMetadataFromIndexer(ctx context.Context,
 	idx *indexer.Client, sessionID oor.SessionID,
 	recipient oor.ArkRecipientOutput) (oor.IncomingVTXOMetadata, error) {
 
+	return ResolveIncomingMetadataFromIndexerWithLimits(
+		ctx, idx, sessionID, recipient, oor.DefaultReceiveLimits(),
+	)
+}
+
+// ResolveIncomingMetadataFromIndexerWithLimits queries the authoritative
+// indexer inventory for the just-created OOR output and maps the result into
+// the incoming materialization metadata required by the local VTXO store,
+// applying caller-provided receive limits to pagination work.
+func ResolveIncomingMetadataFromIndexerWithLimits(ctx context.Context,
+	idx *indexer.Client, sessionID oor.SessionID,
+	recipient oor.ArkRecipientOutput,
+	limits oor.ReceiveLimits) (oor.IncomingVTXOMetadata, error) {
+
 	if idx == nil {
 		return oor.IncomingVTXOMetadata{}, fmt.Errorf("indexer " +
 			"client must be provided")
 	}
 
 	logger := build.LoggerFromContext(ctx)
+
+	// Only MaxVTXOMatches is relevant to this resolver; the other receive
+	// limits apply to mailbox payload and checkpoint decoding.
+	maxScanned := uint64(limits.MaxVTXOMatches)
+	if maxScanned == 0 {
+		maxScanned = uint64(oor.DefaultMaxVTXOMatches)
+	}
+	var pageSize uint32 = incomingMetadataIndexPageSize
+	if maxScanned < uint64(pageSize) {
+		pageSize = uint32(maxScanned)
+	}
 
 	logger.DebugS(ctx, "Resolving incoming metadata from indexer",
 		slog.String("session_id", chainhash.Hash(sessionID).String()),
@@ -37,6 +63,7 @@ func ResolveIncomingMetadataFromIndexer(ctx context.Context,
 	)
 
 	var cursor []byte
+	var scanned uint64
 	for {
 		resp, err := idx.ListVTXOsByScriptsTaproot(
 			ctx,
@@ -45,7 +72,7 @@ func ResolveIncomingMetadataFromIndexer(ctx context.Context,
 					[]byte(nil), recipient.PkScript...,
 				),
 			}},
-			cursor, incomingMetadataIndexPageSize, nil,
+			cursor, pageSize, nil,
 		)
 		if err != nil {
 			return oor.IncomingVTXOMetadata{}, fmt.Errorf("list "+
@@ -53,6 +80,13 @@ func ResolveIncomingMetadataFromIndexer(ctx context.Context,
 		}
 
 		for _, candidate := range resp.GetVtxos() {
+			scanned++
+			if scanned > maxScanned {
+				return oor.IncomingVTXOMetadata{}, fmt.Errorf(
+					"incoming metadata index scan exceeds "+
+						"limit %d", maxScanned)
+			}
+
 			match, err := matchesIncomingVTXO(
 				candidate, sessionID, recipient.OutputIndex,
 			)
@@ -95,6 +129,19 @@ func ResolveIncomingMetadataFromIndexer(ctx context.Context,
 			bytes.Equal(nextCursor, cursor) {
 
 			break
+		}
+
+		if scanned >= maxScanned {
+			return oor.IncomingVTXOMetadata{}, fmt.Errorf(
+				"incoming metadata index scan exceeds limit %d",
+				maxScanned)
+		}
+
+		if err := indexerlimits.ValidateVTXOsByScriptsCursor(
+			nextCursor,
+		); err != nil {
+			return oor.IncomingVTXOMetadata{}, fmt.Errorf(
+				"indexer next cursor: %w", err)
 		}
 
 		cursor = append(cursor[:0], nextCursor...)

--- a/darepod/incoming_metadata_test.go
+++ b/darepod/incoming_metadata_test.go
@@ -1,0 +1,269 @@
+package darepod
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	btclog "github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/arkrpc"
+	"github.com/lightninglabs/darepo-client/indexer"
+	"github.com/lightninglabs/darepo-client/internal/indexerlimits"
+	mailboxrpc "github.com/lightninglabs/darepo-client/mailbox/rpc"
+	"github.com/lightninglabs/darepo-client/oor"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+// TestResolveIncomingMetadataFromIndexerRejectsOversizedNextCursor verifies a
+// remote indexer cannot force the metadata resolver to copy and replay an
+// attacker-sized opaque cursor.
+func TestResolveIncomingMetadataFromIndexerRejectsOversizedNextCursor(
+	t *testing.T) {
+
+	t.Parallel()
+
+	idx, rpcClient, recipient, sessionID := newTestIncomingMetadataIndexer(
+		t,
+		&arkrpc.ListVTXOsByScriptsResponse{
+			Vtxos: []*arkrpc.VTXO{{
+				Outpoint: &arkrpc.OutPoint{
+					Txid: testTxIDBytes(2),
+					Vout: 0,
+				},
+			}},
+			NextCursor: make(
+				[]byte,
+				indexerlimits.MaxVTXOsByScriptsCursorBytes+1,
+			),
+		},
+	)
+
+	_, err := ResolveIncomingMetadataFromIndexerWithLimits(
+		t.Context(), idx, sessionID, recipient, oor.ReceiveLimits{
+			MaxVTXOMatches: 2,
+		},
+	)
+	require.ErrorContains(t, err, "indexer next cursor: vtxo cursor length")
+	require.Equal(t, 1, rpcClient.sendCount())
+}
+
+// TestResolveIncomingMetadataFromIndexerCapsScannedVTXOs verifies the direct
+// metadata resolver bounds pagination work even when a remote indexer keeps
+// returning non-matching VTXOs.
+func TestResolveIncomingMetadataFromIndexerCapsScannedVTXOs(t *testing.T) {
+	t.Parallel()
+
+	idx, rpcClient, recipient, sessionID := newTestIncomingMetadataIndexer(
+		t,
+		&arkrpc.ListVTXOsByScriptsResponse{
+			Vtxos: []*arkrpc.VTXO{
+				{
+					Outpoint: &arkrpc.OutPoint{
+						Txid: testTxIDBytes(2),
+						Vout: 0,
+					},
+				},
+				{
+					Outpoint: &arkrpc.OutPoint{
+						Txid: testTxIDBytes(3),
+						Vout: 0,
+					},
+				},
+			},
+		},
+	)
+
+	_, err := ResolveIncomingMetadataFromIndexerWithLimits(
+		t.Context(), idx, sessionID, recipient, oor.ReceiveLimits{
+			MaxVTXOMatches: 1,
+		},
+	)
+	require.ErrorContains(
+		t, err, "incoming metadata index scan exceeds limit 1",
+	)
+	require.Equal(t, 1, rpcClient.sendCount())
+}
+
+// TestResolveIncomingMetadataFromIndexerAllowsMatchAtScanLimit verifies the
+// scan cap is enforced per candidate, so a valid match at the final permitted
+// item is still accepted.
+func TestResolveIncomingMetadataFromIndexerAllowsMatchAtScanLimit(
+	t *testing.T) {
+
+	t.Parallel()
+
+	sessionID := oor.SessionID(testTxID(1))
+	idx, rpcClient, recipient, _ := newTestIncomingMetadataIndexer(
+		t,
+		&arkrpc.ListVTXOsByScriptsResponse{
+			Vtxos: []*arkrpc.VTXO{
+				{
+					Outpoint: &arkrpc.OutPoint{
+						Txid: testTxIDBytes(2),
+						Vout: 0,
+					},
+				},
+				testIncomingVTXO(sessionID, recipientIndex),
+			},
+		},
+	)
+
+	metadata, err := ResolveIncomingMetadataFromIndexerWithLimits(
+		t.Context(), idx, sessionID, recipient, oor.ReceiveLimits{
+			MaxVTXOMatches: 2,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, testTxID(10).String(), metadata.RoundID)
+	require.Equal(t, 1, rpcClient.sendCount())
+}
+
+// scriptedIndexerRPC returns scripted ListVTXOsByScripts responses.
+type scriptedIndexerRPC struct {
+	mu        sync.Mutex
+	responses []*arkrpc.ListVTXOsByScriptsResponse
+	sent      []*arkrpc.ListVTXOsByScriptsRequest
+	awaits    int
+}
+
+// SendRPC records the request and returns a deterministic correlation id.
+func (r *scriptedIndexerRPC) SendRPC(_ context.Context,
+	_ mailboxrpc.ServiceMethod, req proto.Message,
+	_ mailboxrpc.RPCOptions) (mailboxrpc.SendResult, error) {
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	listReq, ok := req.(*arkrpc.ListVTXOsByScriptsRequest)
+	if !ok {
+		return mailboxrpc.SendResult{}, fmt.Errorf("unexpected "+
+			"request type %T", req)
+	}
+
+	cloned := proto.Clone(listReq)
+	clonedReq, ok := cloned.(*arkrpc.ListVTXOsByScriptsRequest)
+	if !ok {
+		return mailboxrpc.SendResult{}, fmt.Errorf("unexpected cloned "+
+			"request type %T", listReq)
+	}
+	r.sent = append(r.sent, clonedReq)
+
+	return mailboxrpc.SendResult{
+		CorrelationID: "corr-1",
+	}, nil
+}
+
+// AwaitRPC copies the next scripted response into resp.
+func (r *scriptedIndexerRPC) AwaitRPC(_ context.Context, _ string,
+	resp proto.Message) error {
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.awaits >= len(r.responses) {
+		return nil
+	}
+
+	dst, ok := resp.(*arkrpc.ListVTXOsByScriptsResponse)
+	if !ok {
+		return fmt.Errorf("unexpected response type %T", resp)
+	}
+
+	proto.Merge(dst, r.responses[r.awaits])
+	r.awaits++
+
+	return nil
+}
+
+// sendCount returns the number of recorded SendRPC calls.
+func (r *scriptedIndexerRPC) sendCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return len(r.sent)
+}
+
+// newTestIncomingMetadataIndexer returns a proof-capable indexer client and a
+// recipient using a valid taproot script.
+func newTestIncomingMetadataIndexer(t *testing.T,
+	responses ...*arkrpc.ListVTXOsByScriptsResponse) (*indexer.Client,
+	*scriptedIndexerRPC, oor.ArkRecipientOutput, oor.SessionID) {
+
+	t.Helper()
+
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	pkScript := append(
+		[]byte{0x51, 0x20},
+		privKey.PubKey().SerializeCompressed()[1:]...,
+	)
+
+	rpcClient := &scriptedIndexerRPC{
+		responses: responses,
+	}
+	idx := indexer.New(
+		rpcClient, &indexer.PrivKeySchnorrSigner{
+			Key: privKey,
+		}, "test-server", "client:test",
+		fn.None[btclog.Logger](),
+	)
+
+	return idx, rpcClient, oor.ArkRecipientOutput{
+		OutputIndex: recipientIndex,
+		PkScript:    pkScript,
+	}, oor.SessionID(testTxID(1))
+}
+
+const recipientIndex uint32 = 1
+
+// testIncomingVTXO returns a minimally valid matching incoming VTXO.
+func testIncomingVTXO(sessionID oor.SessionID,
+	outputIndex uint32) *arkrpc.VTXO {
+
+	txid := chainhash.Hash(sessionID)
+
+	return &arkrpc.VTXO{
+		Outpoint: &arkrpc.OutPoint{
+			Txid: txid[:],
+			Vout: outputIndex,
+		},
+		RoundId:           testTxID(10).String(),
+		CommitmentTxid:    testTxIDBytes(11),
+		BatchOutputIndex:  0,
+		BatchExpiryHeight: 1000,
+		OperatorPubkey:    testPubKeyBytes(3),
+		ChainDepth:        1,
+		AncestryPaths: []*arkrpc.AncestryPath{{
+			CommitmentTxid: testTxIDBytes(13),
+			TreeDepth:      0,
+		}},
+	}
+}
+
+// testPubKeyBytes returns a deterministic compressed public key.
+func testPubKeyBytes(prefix byte) []byte {
+	privKey, _ := btcec.PrivKeyFromBytes(testTxIDBytes(prefix))
+
+	return privKey.PubKey().SerializeCompressed()
+}
+
+// testTxID returns a deterministic 32-byte txid.
+func testTxID(prefix byte) chainhash.Hash {
+	var txid chainhash.Hash
+	txid[0] = prefix
+
+	return txid
+}
+
+// testTxIDBytes returns a deterministic txid byte slice.
+func testTxIDBytes(prefix byte) []byte {
+	txid := testTxID(prefix)
+
+	return txid[:]
+}

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -3418,13 +3418,14 @@ func (s *Server) initOORActor(ctx context.Context,
 			_ = ark
 			_ = finalCheckpoints
 
-			return ResolveIncomingMetadataFromIndexer(
+			return ResolveIncomingMetadataFromIndexerWithLimits(
 				build.ContextWithLogger(
 					ctx, s.subLogger(Subsystem),
 				),
 				s.indexer,
 				sessionID,
 				recipient,
+				s.cfg.OORReceiveLimits(),
 			)
 		},
 	}

--- a/indexer/client.go
+++ b/indexer/client.go
@@ -14,6 +14,7 @@ import (
 	btclog "github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/arkrpc"
 	"github.com/lightninglabs/darepo-client/build"
+	"github.com/lightninglabs/darepo-client/internal/indexerlimits"
 	mailboxrpc "github.com/lightninglabs/darepo-client/mailbox/rpc"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/tlv"
@@ -603,6 +604,12 @@ func (c *Client) BuildListVTXOsByScriptsTaprootRequest(ctx context.Context,
 		slog.Int("after_cursor_len", len(afterCursor)),
 		slog.Int("limit", int(limit)),
 		slog.Int("status_filter_count", len(statusFilter)))
+
+	if err := indexerlimits.ValidateVTXOsByScriptsCursor(
+		afterCursor,
+	); err != nil {
+		return nil, fmt.Errorf("after cursor: %w", err)
+	}
 
 	scriptScopes, err := c.buildTaprootScopes(
 		ctx, scopes, purposeListVTXOsByScripts,

--- a/indexer/client_test.go
+++ b/indexer/client_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	btclog "github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/arkrpc"
+	"github.com/lightninglabs/darepo-client/internal/indexerlimits"
 	mailboxrpc "github.com/lightninglabs/darepo-client/mailbox/rpc"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/tlv"
@@ -318,6 +319,27 @@ func TestRegisterReceiveScriptTaprootUsesShortLivedProof(t *testing.T) {
 		t, uint64(offlineReceiveProofTTL/time.Second),
 		decoded.expiresAt-decoded.issuedAt,
 	)
+}
+
+// TestBuildListVTXOsByScriptsTaprootRequestRejectsOversizedCursor verifies
+// untrusted opaque pagination cursors are capped before being copied into the
+// request body.
+func TestBuildListVTXOsByScriptsTaprootRequestRejectsOversizedCursor(
+	t *testing.T) {
+
+	t.Parallel()
+
+	client := New(
+		&recordingRPCClient{}, nil, "test-server", "client:test",
+		fn.None[btclog.Logger](),
+	)
+
+	_, err := client.BuildListVTXOsByScriptsTaprootRequest(
+		t.Context(), nil,
+		make([]byte, indexerlimits.MaxVTXOsByScriptsCursorBytes+1), 1,
+		nil,
+	)
+	require.ErrorContains(t, err, "after cursor: vtxo cursor length")
 }
 
 type testMessageSchnorrSigner struct {

--- a/internal/AGENTS.md
+++ b/internal/AGENTS.md
@@ -2,14 +2,17 @@
 
 ## Purpose
 
-Internal test helpers not importable from outside the module.
+Internal helpers not importable from outside the module. This includes test
+utilities and shared production-only constants that should stay scoped to this
+module.
 
 ## Sub-Packages
 
 - `internal/actortest` — Durable actor integration tests using real DB backends (SQLite, Postgres), verifying at-least-once delivery, exactly-once dedup, FIFO ordering, and atomic state+outbox.
+- `internal/indexerlimits` — Shared client-side bounds for indexer pagination cursors.
 - `internal/testutils` — Deterministic key pair and Schnorr signature generation for tests.
 
 ## Relationships
 
 - **Depends on**: `baselib/actor`, `db` (real backends for integration tests).
-- **Depended on by**: nothing (internal, test-only).
+- **Depended on by**: internal module packages only.

--- a/internal/CLAUDE.md
+++ b/internal/CLAUDE.md
@@ -2,14 +2,17 @@
 
 ## Purpose
 
-Internal test helpers not importable from outside the module.
+Internal helpers not importable from outside the module. This includes test
+utilities and shared production-only constants that should stay scoped to this
+module.
 
 ## Sub-Packages
 
 - `internal/actortest` — Durable actor integration tests using real DB backends (SQLite, Postgres), verifying at-least-once delivery, exactly-once dedup, FIFO ordering, and atomic state+outbox.
+- `internal/indexerlimits` — Shared client-side bounds for indexer pagination cursors.
 - `internal/testutils` — Deterministic key pair and Schnorr signature generation for tests.
 
 ## Relationships
 
 - **Depends on**: `baselib/actor`, `db` (real backends for integration tests).
-- **Depended on by**: nothing (internal, test-only).
+- **Depended on by**: internal module packages only.

--- a/internal/indexerlimits/limits.go
+++ b/internal/indexerlimits/limits.go
@@ -1,0 +1,22 @@
+package indexerlimits
+
+import "fmt"
+
+const (
+	// MaxVTXOsByScriptsCursorBytes caps the opaque cursor accepted for
+	// ListVTXOsByScripts pagination. The current server cursor is a
+	// 36-byte outpoint keyset cursor; this leaves room for format evolution
+	// while bounding untrusted remote bytes.
+	MaxVTXOsByScriptsCursorBytes = 256
+)
+
+// ValidateVTXOsByScriptsCursor rejects opaque VTXO query cursors that exceed
+// the client-side resource cap.
+func ValidateVTXOsByScriptsCursor(cursor []byte) error {
+	if len(cursor) <= MaxVTXOsByScriptsCursorBytes {
+		return nil
+	}
+
+	return fmt.Errorf("vtxo cursor length %d exceeds limit %d", len(cursor),
+		MaxVTXOsByScriptsCursorBytes)
+}

--- a/oor/actor.go
+++ b/oor/actor.go
@@ -1781,6 +1781,9 @@ func (b *oorDurableBehavior) buildTransportMessage(ctx context.Context,
 			)
 		}
 
+		// The durable receive FSM performs a single bounded metadata
+		// lookup. It does not page through NextCursor or re-emit this
+		// query.
 		sendReq := &serverconn.SendListVTXOsByScriptsRequest{
 			PkScripts: pkScripts,
 			Limit:     b.cfg.Limits.MaxVTXOMatches,

--- a/serverconn/actor_tlv_test.go
+++ b/serverconn/actor_tlv_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/internal/indexerlimits"
 	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
 	mailboxrpc "github.com/lightninglabs/darepo-client/mailbox/rpc"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
@@ -267,6 +268,33 @@ func TestSendListVTXOsByScriptsRequest_TLVRoundTrip(t *testing.T) {
 	require.NotEmpty(t, decoded.IdempotencyKey)
 }
 
+// TestSendListVTXOsByScriptsRequest_EncodeRejectsOversizedCursor verifies the
+// durable query encoder refuses attacker-sized opaque cursors.
+func TestSendListVTXOsByScriptsRequest_EncodeRejectsOversizedCursor(
+	t *testing.T) {
+
+	t.Parallel()
+
+	req := &SendListVTXOsByScriptsRequest{
+		PkScripts: [][]byte{
+			{
+				0x51,
+				0x20,
+				0x01,
+			},
+		},
+		AfterCursor: make(
+			[]byte, indexerlimits.MaxVTXOsByScriptsCursorBytes+1,
+		),
+		Limit:         128,
+		CorrelationID: "corr-vtxo-query",
+	}
+
+	var encoded bytes.Buffer
+	err := req.Encode(&encoded)
+	require.ErrorContains(t, err, "after cursor: vtxo cursor length")
+}
+
 // TestSendListVTXOsByScriptsRequest_DecodesLegacyZeroCursor verifies an old
 // durable uint64(0) cursor can still replay as the empty keyset cursor.
 func TestSendListVTXOsByScriptsRequest_DecodesLegacyZeroCursor(t *testing.T) {
@@ -330,6 +358,19 @@ func TestNormalizeVTXOAfterCursorRejectsLegacyNonZero(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Equal(t, []byte("cursor-11"), cursor)
+}
+
+// TestNormalizeVTXOAfterCursorRejectsOversizedCursor verifies durable replay
+// rejects an oversized opaque cursor before copying it into actor state.
+func TestNormalizeVTXOAfterCursorRejectsOversizedCursor(t *testing.T) {
+	t.Parallel()
+
+	_, err := normalizeVTXOAfterCursor(
+		0, false,
+		make([]byte, indexerlimits.MaxVTXOsByScriptsCursorBytes+1),
+		true,
+	)
+	require.ErrorContains(t, err, "after cursor: vtxo cursor length")
 }
 
 // TestServerConnMessageMetadata verifies static message metadata methods.

--- a/serverconn/durable_unary_queries.go
+++ b/serverconn/durable_unary_queries.go
@@ -8,6 +8,7 @@ import (
 	"io"
 
 	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/internal/indexerlimits"
 	mailboxconn "github.com/lightninglabs/darepo-client/mailbox/conn"
 	mailboxrpc "github.com/lightninglabs/darepo-client/mailbox/rpc"
 	"github.com/lightningnetwork/lnd/tlv"
@@ -328,6 +329,12 @@ func (m *SendListVTXOsByScriptsRequest) QueryIdempotencyKey() string {
 
 // Encode serializes the message to the provided writer.
 func (m *SendListVTXOsByScriptsRequest) Encode(w io.Writer) error {
+	if err := indexerlimits.ValidateVTXOsByScriptsCursor(
+		m.AfterCursor,
+	); err != nil {
+		return fmt.Errorf("after cursor: %w", err)
+	}
+
 	stableBytes, err := encodeVTXOsByScriptsQueryIdentity(
 		m.PkScripts, m.AfterCursor, m.Limit, m.CorrelationID,
 	)
@@ -461,6 +468,12 @@ func normalizeVTXOAfterCursor(legacyCursor uint64, legacyCursorSet bool,
 	afterCursor []byte, afterCursorSet bool) ([]byte, error) {
 
 	if afterCursorSet {
+		if err := indexerlimits.ValidateVTXOsByScriptsCursor(
+			afterCursor,
+		); err != nil {
+			return nil, fmt.Errorf("after cursor: %w", err)
+		}
+
 		return append([]byte(nil), afterCursor...), nil
 	}
 


### PR DESCRIPTION
## Summary

This hardens the opaque `ListVTXOsByScripts` pagination cursor introduced for keyset pagination.

The honest server currently emits a 36-byte cursor (`outpoint_hash || vout`), but clients should still treat the cursor as remote-controlled opaque bytes. This adds a shared 256-byte client-side cursor cap and applies it before the cursor is copied into outgoing requests, persisted in durable serverconn messages, or replayed from the incoming metadata resolver.

The direct darepod incoming metadata resolver now also uses the configured OOR metadata match limit to bound pagination work, so a remote indexer cannot keep the resolver busy by returning non-empty pages with ever-changing cursors.

Fixes #382.

## Test Plan

- `go test ./indexer ./serverconn ./darepod ./oor`
- `go test ./...`
- `GOGC=50 make lint`
