### PR TITLE
wallet+darepod: persist Board RPC, replay on restart (#416)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ This file is a **map**, not a manual. Follow links for details.
 | `make rpc` | Regenerate protobuf stubs |
 | `make sqlc` | Regenerate type-safe DB queries |
 | `make ast-lint` | Check ast-grep style rules |
+| `make commitmsg-lint range="origin/main..HEAD"` | Lint commit messages on the current branch |
 | `make systest` | Run system integration tests (sqlite) |
 | `make systest db=postgres` | Run system integration tests (postgres) |
 
@@ -61,10 +62,15 @@ Body wrapped at 72 characters. Explain WHY, not just WHAT.
    This builds and runs the custom linter natively via `go tool` — much
    faster than Docker. Only lints changes on the current branch.
 5. **Run tests before every commit** — see [`docs/testing-guide.md`](docs/testing-guide.md).
-6. **No underscores in Go test names** — `TestFoo` not `Test_Foo`.
-7. Use early returns; do not nest error handling.
-8. Do not batch actor messages without backpressure.
-9. Comments explain WHY and HOW, not WHAT.
+6. **Run `make commitmsg-lint range="origin/main..HEAD"` before pushing.**
+   CI runs the same check via [`scripts/commit_message.py`](scripts/commit_message.py);
+   subjects must be `<package>: <summary>` ≤69 chars and body lines must wrap
+   to 72. Use `python3 scripts/commit_message.py reword --commit <sha>` to
+   rewrite an offending commit in place.
+7. **No underscores in Go test names** — `TestFoo` not `Test_Foo`.
+8. Use early returns; do not nest error handling.
+9. Do not batch actor messages without backpressure.
+10. Comments explain WHY and HOW, not WHAT.
 
 ## Review Skills
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ This file is a **map**, not a manual. Follow links for details.
 | `make rpc` | Regenerate protobuf stubs |
 | `make sqlc` | Regenerate type-safe DB queries |
 | `make ast-lint` | Check ast-grep style rules |
+| `make commitmsg-lint range="origin/main..HEAD"` | Lint commit messages on the current branch |
 | `make systest` | Run system integration tests (sqlite) |
 | `make systest db=postgres` | Run system integration tests (postgres) |
 
@@ -61,10 +62,15 @@ Body wrapped at 72 characters. Explain WHY, not just WHAT.
    This builds and runs the custom linter natively via `go tool` — much
    faster than Docker. Only lints changes on the current branch.
 5. **Run tests before every commit** — see [`docs/testing-guide.md`](docs/testing-guide.md).
-6. **No underscores in Go test names** — `TestFoo` not `Test_Foo`.
-7. Use early returns; do not nest error handling.
-8. Do not batch actor messages without backpressure.
-9. Comments explain WHY and HOW, not WHAT.
+6. **Run `make commitmsg-lint range="origin/main..HEAD"` before pushing.**
+   CI runs the same check via [`scripts/commit_message.py`](scripts/commit_message.py);
+   subjects must be `<package>: <summary>` ≤69 chars and body lines must wrap
+   to 72. Use `python3 scripts/commit_message.py reword --commit <sha>` to
+   rewrite an offending commit in place.
+7. **No underscores in Go test names** — `TestFoo` not `Test_Foo`.
+8. Use early returns; do not nest error handling.
+9. Do not batch actor messages without backpressure.
+10. Comments explain WHY and HOW, not WHAT.
 
 ## Review Skills
 

--- a/cmd/darepocli/darepoclicommands/cmd_board.go
+++ b/cmd/darepocli/darepoclicommands/cmd_board.go
@@ -27,6 +27,13 @@ func newBoardCmd() *cobra.Command {
 		"number of VTXOs to fan the boarded balance into",
 	)
 
+	cmd.Flags().Bool(
+		"no-persist", false,
+		"opt out of restart-safe Board replay: do not persist "+
+			"the Board intent, so a daemon restart between "+
+			"admission and round seal silently drops it",
+	)
+
 	return cmd
 }
 
@@ -42,6 +49,9 @@ func board(cmd *cobra.Command, _ []string) error {
 	if err := parseRequest(cmd, req, func() error {
 		count, _ := cmd.Flags().GetUint32("target-vtxo-count")
 		req.TargetVtxoCount = count
+
+		noPersist, _ := cmd.Flags().GetBool("no-persist")
+		req.NoPersist = noPersist
 
 		return nil
 	}); err != nil {

--- a/daemonrpc/daemon.pb.go
+++ b/daemonrpc/daemon.pb.go
@@ -3256,8 +3256,17 @@ type BoardRequest struct {
 	// balance out into this many VTXO outputs in the next round. Zero
 	// preserves the legacy behavior of creating one boarded VTXO.
 	TargetVtxoCount uint32 `protobuf:"varint,1,opt,name=target_vtxo_count,json=targetVtxoCount,proto3" json:"target_vtxo_count,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// no_persist opts out of restart-safe Board replay. When set, the
+	// daemon does NOT persist the user's intent to pending_board_requests,
+	// so a crash between Board admission and round seal silently drops
+	// the request rather than re-issuing it on the next start. Default
+	// (false) is the safe behavior: the daemon persists each admitted
+	// confirmed outpoint and replays the Board through the wallet's
+	// self-Tell on startup until the round adopts or the user fires a
+	// fresh Board.
+	NoPersist     bool `protobuf:"varint,2,opt,name=no_persist,json=noPersist,proto3" json:"no_persist,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *BoardRequest) Reset() {
@@ -3295,6 +3304,13 @@ func (x *BoardRequest) GetTargetVtxoCount() uint32 {
 		return x.TargetVtxoCount
 	}
 	return 0
+}
+
+func (x *BoardRequest) GetNoPersist() bool {
+	if x != nil {
+		return x.NoPersist
+	}
+	return false
 }
 
 type BoardResponse struct {
@@ -6048,9 +6064,11 @@ const file_daemon_proto_rawDesc = "" +
 	"\tselection\"W\n" +
 	"\x12LeaveVTXOsResponse\x12)\n" +
 	"\x10queued_outpoints\x18\x01 \x03(\tR\x0fqueuedOutpoints\x12\x16\n" +
-	"\x06status\x18\x02 \x01(\tR\x06status\":\n" +
+	"\x06status\x18\x02 \x01(\tR\x06status\"Y\n" +
 	"\fBoardRequest\x12*\n" +
-	"\x11target_vtxo_count\x18\x01 \x01(\rR\x0ftargetVtxoCount\"F\n" +
+	"\x11target_vtxo_count\x18\x01 \x01(\rR\x0ftargetVtxoCount\x12\x1d\n" +
+	"\n" +
+	"no_persist\x18\x02 \x01(\bR\tnoPersist\"F\n" +
 	"\rBoardResponse\x12\x16\n" +
 	"\x06status\x18\x01 \x01(\tR\x06status\x12\x1d\n" +
 	"\n" +

--- a/daemonrpc/daemon.proto
+++ b/daemonrpc/daemon.proto
@@ -792,6 +792,16 @@ message BoardRequest {
     // balance out into this many VTXO outputs in the next round. Zero
     // preserves the legacy behavior of creating one boarded VTXO.
     uint32 target_vtxo_count = 1;
+
+    // no_persist opts out of restart-safe Board replay. When set, the
+    // daemon does NOT persist the user's intent to pending_board_requests,
+    // so a crash between Board admission and round seal silently drops
+    // the request rather than re-issuing it on the next start. Default
+    // (false) is the safe behavior: the daemon persists each admitted
+    // confirmed outpoint and replays the Board through the wallet's
+    // self-Tell on startup until the round adopts or the user fires a
+    // fresh Board.
+    bool no_persist = 2;
 }
 
 message BoardResponse {

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -1238,6 +1238,7 @@ func (r *RPCServer) Board(ctx context.Context, req *daemonrpc.BoardRequest) (
 
 	boardReq := &wallet.BoardRequest{
 		TargetVTXOCount: req.GetTargetVtxoCount(),
+		NoPersist:       req.GetNoPersist(),
 	}
 
 	future := wRef.Ask(ctx, boardReq)

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -1798,6 +1798,22 @@ func (s *Server) startWalletDependentActors(ctx context.Context,
 	}
 
 	// -------------------------------------------------------
+	// 13b. Replay any persisted Board RPC the user issued before the
+	//      last shutdown. Like resumeBoardingSweeps, this Ask MUST run
+	//      AFTER the round-client actor has registered with the
+	//      receptionist (step 11) — the replay's downstream
+	//      TriggerBoardMsg dispatch goes through the actor system,
+	//      and a Tell against an unresolved service key is a silent
+	//      drop. Driving the replay from wallet.Ark.Start would race
+	//      the registration and leave the recovered Board orphaned.
+	// -------------------------------------------------------
+	if err := s.replayPendingBoardRequest(ctx, walletRef); err != nil {
+		s.log.WarnS(ctx, "Failed to replay pending Board request",
+			err,
+		)
+	}
+
+	// -------------------------------------------------------
 	// 14. Register the OOR client actor.
 	// -------------------------------------------------------
 	if err := s.initOORActor(ctx, vtxoManagerRef); err != nil {
@@ -1805,6 +1821,28 @@ func (s *Server) startWalletDependentActors(ctx context.Context,
 	}
 
 	s.log.InfoS(ctx, "Wallet-dependent actors started")
+
+	return nil
+}
+
+// replayPendingBoardRequest Asks the wallet actor to replay any
+// persisted Board RPC across daemon restart. Called once during
+// startup, after the round-client actor has registered with the
+// receptionist, so the wallet's handleBoard can resolve the round
+// actor via the service-key router without racing.
+//
+// A failure here does not block daemon startup: a fresh Board RPC by
+// the user overwrites the pending rows, and a future restart re-tries
+// the replay. Returning the error lets the caller decide whether to
+// surface it.
+func (s *Server) replayPendingBoardRequest(ctx context.Context,
+	walletRef actor.ActorRef[wallet.WalletMsg, wallet.WalletResp]) error {
+
+	future := walletRef.Ask(ctx, &wallet.ReplayPendingBoardRequest{})
+	result := future.Await(ctx)
+	if result.IsErr() {
+		return fmt.Errorf("ask replay pending board: %w", result.Err())
+	}
 
 	return nil
 }
@@ -3042,6 +3080,7 @@ func (s *Server) initWalletActor(ctx context.Context,
 		wallet.WithBoardingSweep(
 			s.boardingSweepStore, sweepSigner, s.chainParams,
 		),
+		wallet.WithClock(s.clk),
 	)
 	walletKey := actor.NewServiceKey[
 		wallet.WalletMsg, wallet.WalletResp,

--- a/db/boarding_wallet.go
+++ b/db/boarding_wallet.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"math"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
@@ -132,6 +133,17 @@ type BoardingStore interface {
 
 	CountUnresolvedBoardingSweepInputs(ctx context.Context,
 		txid []byte) (int64, error)
+
+	UpsertPendingBoardRequest(ctx context.Context,
+		arg sqlc.UpsertPendingBoardRequestParams) error
+
+	ListPendingBoardRequests(ctx context.Context) (
+		[]sqlc.PendingBoardRequest, error)
+
+	ClearPendingBoardRequestByOutpoint(ctx context.Context,
+		arg sqlc.ClearPendingBoardRequestByOutpointParams) error
+
+	ClearAllPendingBoardRequests(ctx context.Context) error
 }
 
 // BatchedBoardingStore combines BoardingStore with transaction support via the
@@ -891,6 +903,142 @@ func stringToStatus(status string) (wallet.BoardingStatus, error) {
 	default:
 		return 0, fmt.Errorf("unknown boarding status: %q", status)
 	}
+}
+
+// UpsertPendingBoardRequests persists one row per confirmed boarding outpoint
+// that the original Board RPC admitted. All rows share the same
+// target_vtxo_count and requested_at_unix, so the table records both "what
+// the user asked for" and "which specific UTXOs the call was bound to".
+// Rows are inserted under a single transaction so the persist is atomic from
+// the wallet's perspective.
+func (b *BoardingWalletStore) UpsertPendingBoardRequests(ctx context.Context,
+	reqs []wallet.PendingBoardRequest) error {
+
+	if len(reqs) == 0 {
+		return nil
+	}
+
+	writeTxOpts := WriteTxOption()
+
+	return b.db.ExecTx(ctx, writeTxOpts, func(q BoardingStore) error {
+		for _, req := range reqs {
+			// Reject values that would overflow the int32
+			// column. A caller-supplied target_vtxo_count
+			// outside this range indicates a programming
+			// error upstream, not user data.
+			if req.TargetVTXOCount > math.MaxInt32 {
+				return fmt.Errorf("target_vtxo_count %d "+
+					"exceeds int32 max",
+					req.TargetVTXOCount)
+			}
+
+			err := q.UpsertPendingBoardRequest(
+				ctx, sqlc.UpsertPendingBoardRequestParams{
+					OutpointHash: req.Outpoint.Hash[:],
+					OutpointIndex: int32(
+						req.Outpoint.Index,
+					),
+					TargetVtxoCount: int32(
+						req.TargetVTXOCount,
+					),
+					RequestedAtUnix: req.RequestedAt,
+				},
+			)
+			if err != nil {
+				return fmt.Errorf("upsert pending board "+
+					"request: %w", err)
+			}
+		}
+
+		return nil
+	})
+}
+
+// ListPendingBoardRequests returns every persisted Board RPC intent ordered
+// by request time. Each row is keyed by the confirmed boarding outpoint it
+// was admitted against; replay decides per-row whether the underlying intent
+// is still Confirmed.
+func (b *BoardingWalletStore) ListPendingBoardRequests(ctx context.Context) (
+	[]wallet.PendingBoardRequest, error) {
+
+	readTxOpts := ReadTxOption()
+
+	var result []wallet.PendingBoardRequest
+
+	err := b.db.ExecTx(ctx, readTxOpts, func(q BoardingStore) error {
+		rows, err := q.ListPendingBoardRequests(ctx)
+		if err != nil {
+			return fmt.Errorf("list pending board requests: %w",
+				err)
+		}
+
+		result = make([]wallet.PendingBoardRequest, 0, len(rows))
+		for _, row := range rows {
+			// Defensive: the column is INTEGER, so negative
+			// values should never appear, but clamp at zero
+			// rather than truncating into a bogus uint32 if
+			// they ever do.
+			count := uint32(0)
+			if row.TargetVtxoCount > 0 {
+				count = uint32(row.TargetVtxoCount)
+			}
+
+			hash, err := chainhash.NewHash(row.OutpointHash)
+			if err != nil {
+				return fmt.Errorf("parse outpoint hash: %w",
+					err)
+			}
+
+			result = append(
+				result, wallet.PendingBoardRequest{
+					Outpoint: wire.OutPoint{
+						Hash: *hash,
+						Index: uint32(
+							row.OutpointIndex,
+						),
+					},
+					TargetVTXOCount: count,
+					RequestedAt:     row.RequestedAtUnix,
+				},
+			)
+		}
+
+		return nil
+	})
+
+	return result, err
+}
+
+// ClearPendingBoardRequestByOutpoint removes a single pending row. Called
+// from the round persistence transaction once the matching boarding intent
+// transitions Confirmed → Adopted so the row cannot rebind to an unrelated
+// future deposit.
+func (b *BoardingWalletStore) ClearPendingBoardRequestByOutpoint(
+	ctx context.Context, outpoint wire.OutPoint) error {
+
+	writeTxOpts := WriteTxOption()
+
+	return b.db.ExecTx(ctx, writeTxOpts, func(q BoardingStore) error {
+		return q.ClearPendingBoardRequestByOutpoint(
+			ctx, sqlc.ClearPendingBoardRequestByOutpointParams{
+				OutpointHash:  outpoint.Hash[:],
+				OutpointIndex: int32(outpoint.Index),
+			},
+		)
+	})
+}
+
+// ClearAllPendingBoardRequests removes every persisted Board RPC intent.
+// Used by the wallet's startup sweep when no confirmed intent remains for
+// any persisted row so the next start does not re-walk stale rows.
+func (b *BoardingWalletStore) ClearAllPendingBoardRequests(
+	ctx context.Context) error {
+
+	writeTxOpts := WriteTxOption()
+
+	return b.db.ExecTx(ctx, writeTxOpts, func(q BoardingStore) error {
+		return q.ClearAllPendingBoardRequests(ctx)
+	})
 }
 
 // Compile-time check that BoardingWalletStore implements BoardingStore.

--- a/db/boarding_wallet_test.go
+++ b/db/boarding_wallet_test.go
@@ -1321,3 +1321,107 @@ func TestIntentTxProofCorruptDecodesAsNone(t *testing.T) {
 		"corrupt blob must decode as None, not error",
 	)
 }
+
+// TestPendingBoardRequestRoundTrip pins down the persistence contract that
+// backs the post-restart Board replay. The table is keyed by outpoint, so
+// every property below is expressed per-row: an empty store reports an
+// empty slice, an upsert is durable, a second upsert with the same
+// outpoint replaces the row in place, ClearByOutpoint removes one row
+// without touching the others, and ClearAll empties the table.
+func TestPendingBoardRequestRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store, _ := newBoardingStoreForTest(t)
+
+	// Empty table must report an empty slice rather than an error so
+	// the wallet's startup replay can distinguish "nothing pending"
+	// from "DB failure".
+	got, err := store.ListPendingBoardRequests(ctx)
+	require.NoError(t, err)
+	require.Empty(t, got, "empty store must report an empty slice")
+
+	op1 := wire.OutPoint{Hash: chainhash.Hash{0x01}, Index: 0}
+	op2 := wire.OutPoint{Hash: chainhash.Hash{0x02}, Index: 7}
+
+	// Bulk upsert installs one row per outpoint.
+	first := []wallet.PendingBoardRequest{
+		{
+			Outpoint:        op1,
+			TargetVTXOCount: 3,
+			RequestedAt:     1_700_000_000,
+		},
+		{
+			Outpoint:        op2,
+			TargetVTXOCount: 3,
+			RequestedAt:     1_700_000_000,
+		},
+	}
+	require.NoError(t, store.UpsertPendingBoardRequests(ctx, first))
+
+	got, err = store.ListPendingBoardRequests(ctx)
+	require.NoError(t, err)
+	require.ElementsMatch(
+		t, first, got, "rows must round-trip after upsert",
+	)
+
+	// Upserting the same outpoints with a new target_vtxo_count must
+	// replace in place (no duplicate rows). This is the property the
+	// replay relies on: a second Board call overrides the prior one for
+	// any still-Confirmed outpoint.
+	second := []wallet.PendingBoardRequest{
+		{
+			Outpoint:        op1,
+			TargetVTXOCount: 7,
+			RequestedAt:     1_700_000_500,
+		},
+		{
+			Outpoint:        op2,
+			TargetVTXOCount: 7,
+			RequestedAt:     1_700_000_500,
+		},
+	}
+	require.NoError(t, store.UpsertPendingBoardRequests(ctx, second))
+
+	got, err = store.ListPendingBoardRequests(ctx)
+	require.NoError(t, err)
+	require.ElementsMatch(
+		t, second, got,
+		"second upsert must replace prior rows, not append",
+	)
+
+	// ClearByOutpoint removes one row without touching the other.
+	require.NoError(t,
+		store.ClearPendingBoardRequestByOutpoint(ctx, op1))
+
+	got, err = store.ListPendingBoardRequests(ctx)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, op2, got[0].Outpoint)
+
+	// ClearByOutpoint on a missing outpoint must be a benign no-op so
+	// the round-state commit transaction does not error if the wallet
+	// already swept the row.
+	require.NoError(t,
+		store.ClearPendingBoardRequestByOutpoint(ctx, op1))
+
+	// ClearAll empties the table; calling it again is a benign no-op.
+	require.NoError(t, store.ClearAllPendingBoardRequests(ctx))
+	require.NoError(t, store.ClearAllPendingBoardRequests(ctx))
+
+	got, err = store.ListPendingBoardRequests(ctx)
+	require.NoError(t, err)
+	require.Empty(t, got)
+
+	// Empty-input upsert is a no-op (does not error, does not write).
+	require.NoError(t, store.UpsertPendingBoardRequests(ctx, nil))
+	require.NoError(
+		t,
+		store.UpsertPendingBoardRequests(
+			ctx, []wallet.PendingBoardRequest{},
+		),
+	)
+	got, err = store.ListPendingBoardRequests(ctx)
+	require.NoError(t, err)
+	require.Empty(t, got)
+}

--- a/db/migrations.go
+++ b/db/migrations.go
@@ -10,7 +10,7 @@ const (
 	// daemon.
 	//
 	// NOTE: This MUST be updated when a new migration is added.
-	LatestMigrationVersion uint = 12
+	LatestMigrationVersion uint = 13
 )
 
 // MigrationTarget is a functional option that can be passed to applyMigrations

--- a/db/round_store.go
+++ b/db/round_store.go
@@ -34,6 +34,12 @@ type (
 	InsertRoundParams         = sqlc.InsertRoundParams
 	InsertVTXOParams          = sqlc.InsertVTXOParams
 	ListRoundsPaginatedParams = sqlc.ListRoundsPaginatedParams
+
+	// ClearPendingBoardParams aliases the sqlc-generated
+	// clear-by-outpoint params so call sites can spell the type
+	// concisely (the generated name exceeds the line-length cap
+	// when nested inside the CommitState transaction body).
+	ClearPendingBoardParams = sqlc.ClearPendingBoardRequestByOutpointParams
 )
 
 // ListRoundsQuery controls persisted round pagination and filtering.
@@ -173,6 +179,14 @@ type RoundStore interface {
 	UpdateBoardingIntentStatus(ctx context.Context,
 		arg sqlc.UpdateBoardingIntentStatusParams) error
 
+	// ClearPendingBoardRequestByOutpoint deletes the pending Board RPC
+	// row bound to one outpoint. Called from CommitState in the same
+	// transaction that marks the matching intent Adopted, so a stale
+	// pending row can never rebind to an unrelated future boarding
+	// deposit.
+	ClearPendingBoardRequestByOutpoint(ctx context.Context,
+		arg sqlc.ClearPendingBoardRequestByOutpointParams) error
+
 	ListRoundsPaginated(ctx context.Context,
 		arg ListRoundsPaginatedParams) ([]RoundRow, error)
 
@@ -301,6 +315,29 @@ func (s *RoundPersistenceStore) CommitState(ctx context.Context, r *round.Round,
 				if err != nil {
 					return fmt.Errorf("mark boarding "+
 						"intent adopted: %w", err)
+				}
+
+				// Clear the pending Board RPC row bound to
+				// this outpoint in the same transaction.
+				// Once the intent is Adopted, the user's
+				// Board call is durably checkpointed in the
+				// round itself; the pending row is no longer
+				// load-bearing and a stale row would
+				// otherwise rebind a future Board replay to
+				// an unrelated boarding deposit.
+				clearParams := ClearPendingBoardParams{
+					OutpointHash: intent.Outpoint.Hash[:],
+					OutpointIndex: int32(
+						intent.Outpoint.Index,
+					),
+				}
+				err = q.ClearPendingBoardRequestByOutpoint(
+					ctx, clearParams,
+				)
+				if err != nil {
+					return fmt.Errorf("clear pending "+
+						"board request for adopted "+
+						"intent: %w", err)
 				}
 			}
 		}

--- a/db/sqlc/boarding.sql.go
+++ b/db/sqlc/boarding.sql.go
@@ -10,6 +10,30 @@ import (
 	"database/sql"
 )
 
+const ClearAllPendingBoardRequests = `-- name: ClearAllPendingBoardRequests :exec
+DELETE FROM pending_board_requests
+`
+
+func (q *Queries) ClearAllPendingBoardRequests(ctx context.Context) error {
+	_, err := q.db.ExecContext(ctx, ClearAllPendingBoardRequests)
+	return err
+}
+
+const ClearPendingBoardRequestByOutpoint = `-- name: ClearPendingBoardRequestByOutpoint :exec
+DELETE FROM pending_board_requests
+WHERE outpoint_hash = $1 AND outpoint_index = $2
+`
+
+type ClearPendingBoardRequestByOutpointParams struct {
+	OutpointHash  []byte
+	OutpointIndex int32
+}
+
+func (q *Queries) ClearPendingBoardRequestByOutpoint(ctx context.Context, arg ClearPendingBoardRequestByOutpointParams) error {
+	_, err := q.db.ExecContext(ctx, ClearPendingBoardRequestByOutpoint, arg.OutpointHash, arg.OutpointIndex)
+	return err
+}
+
 const CountBoardingIntentsByStatus = `-- name: CountBoardingIntentsByStatus :one
 SELECT COUNT(*) FROM boarding_intents
 WHERE status = $1
@@ -785,6 +809,40 @@ func (q *Queries) ListBoardingSweeps(ctx context.Context, arg ListBoardingSweeps
 	return items, nil
 }
 
+const ListPendingBoardRequests = `-- name: ListPendingBoardRequests :many
+SELECT outpoint_hash, outpoint_index, target_vtxo_count, requested_at_unix
+FROM pending_board_requests
+ORDER BY requested_at_unix ASC, outpoint_hash ASC, outpoint_index ASC
+`
+
+func (q *Queries) ListPendingBoardRequests(ctx context.Context) ([]PendingBoardRequest, error) {
+	rows, err := q.db.QueryContext(ctx, ListPendingBoardRequests)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []PendingBoardRequest
+	for rows.Next() {
+		var i PendingBoardRequest
+		if err := rows.Scan(
+			&i.OutpointHash,
+			&i.OutpointIndex,
+			&i.TargetVtxoCount,
+			&i.RequestedAtUnix,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const ListPendingBoardingSweepInputs = `-- name: ListPendingBoardingSweepInputs :many
 SELECT txid, outpoint_hash, outpoint_index, amount, previous_status, status, spent_by_txid, spent_height, last_update_time FROM boarding_sweep_inputs
 WHERE status IN ('pending', 'published')
@@ -1014,6 +1072,44 @@ func (q *Queries) UpdateBoardingIntentStatus(ctx context.Context, arg UpdateBoar
 		arg.OutpointIndex,
 		arg.Status,
 		arg.LastUpdateTime,
+	)
+	return err
+}
+
+const UpsertPendingBoardRequest = `-- name: UpsertPendingBoardRequest :exec
+
+INSERT INTO pending_board_requests (
+    outpoint_hash,
+    outpoint_index,
+    target_vtxo_count,
+    requested_at_unix
+) VALUES ($1, $2, $3, $4)
+ON CONFLICT (outpoint_hash, outpoint_index) DO UPDATE
+SET target_vtxo_count = excluded.target_vtxo_count,
+    requested_at_unix = excluded.requested_at_unix
+`
+
+type UpsertPendingBoardRequestParams struct {
+	OutpointHash    []byte
+	OutpointIndex   int32
+	TargetVtxoCount int32
+	RequestedAtUnix int64
+}
+
+// Pending board request queries.
+//
+// Each row binds the user's explicit Board RPC target_vtxo_count to one
+// confirmed boarding outpoint that the call admitted. On daemon restart the
+// wallet lists every row and replays a single Board through the same actor
+// path the live RPC uses; rows whose outpoints are no longer Confirmed (the
+// intent has already adopted, swept, or failed) are cleared so the next
+// start is a no-op.
+func (q *Queries) UpsertPendingBoardRequest(ctx context.Context, arg UpsertPendingBoardRequestParams) error {
+	_, err := q.db.ExecContext(ctx, UpsertPendingBoardRequest,
+		arg.OutpointHash,
+		arg.OutpointIndex,
+		arg.TargetVtxoCount,
+		arg.RequestedAtUnix,
 	)
 	return err
 }

--- a/db/sqlc/migrations/000013_pending_board_request.down.sql
+++ b/db/sqlc/migrations/000013_pending_board_request.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS pending_board_requests;

--- a/db/sqlc/migrations/000013_pending_board_request.up.sql
+++ b/db/sqlc/migrations/000013_pending_board_request.up.sql
@@ -1,0 +1,31 @@
+-- Records the user's explicit Board RPC intent so a daemon restart between
+-- Board admission and round seal does not silently drop the request.
+--
+-- Rows are keyed by the confirmed boarding outpoint (outpoint_hash,
+-- outpoint_index) that the original Board call admitted: one row per intent
+-- the call covered. This binds each pending request to the specific UTXOs
+-- the user pointed at, so a replay can never rebind a stale target_vtxo_count
+-- to a fresh, unrelated boarding deposit. Rows are cleared when the matching
+-- boarding intent transitions out of Confirmed (e.g. via the round-state
+-- checkpoint that flips the intent to Adopted), so the cleanup runs in the
+-- same SQL transaction as the state change rather than via a cross-actor
+-- callback.
+--
+-- target_vtxo_count and requested_at_unix are denormalised onto every row
+-- belonging to the same Board call. A subsequent Board call upserts the
+-- value of target_vtxo_count for every still-Confirmed outpoint; rows for
+-- already-adopted outpoints are unaffected because they have already been
+-- cleared.
+CREATE TABLE IF NOT EXISTS pending_board_requests (
+    outpoint_hash BLOB NOT NULL,
+    outpoint_index INTEGER NOT NULL,
+
+    target_vtxo_count INTEGER NOT NULL DEFAULT 0,
+
+    requested_at_unix BIGINT NOT NULL,
+
+    PRIMARY KEY (outpoint_hash, outpoint_index),
+
+    CHECK (target_vtxo_count >= 0),
+    CHECK (requested_at_unix > 0)
+);

--- a/db/sqlc/models.go
+++ b/db/sqlc/models.go
@@ -167,6 +167,13 @@ type OwnedReceiveScriptSource struct {
 	Name   string
 }
 
+type PendingBoardRequest struct {
+	OutpointHash    []byte
+	OutpointIndex   int32
+	TargetVtxoCount int32
+	RequestedAtUnix int64
+}
+
 type Round struct {
 	RoundID               string
 	StartHeight           int32

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -9,6 +9,8 @@ import (
 )
 
 type Querier interface {
+	ClearAllPendingBoardRequests(ctx context.Context) error
+	ClearPendingBoardRequestByOutpoint(ctx context.Context, arg ClearPendingBoardRequestByOutpointParams) error
 	CountBoardingIntentsByStatus(ctx context.Context, status string) (int64, error)
 	CountClientLedgerEntries(ctx context.Context) (int64, error)
 	CountUnresolvedBoardingSweepInputs(ctx context.Context, txid []byte) (int64, error)
@@ -147,6 +149,7 @@ type Querier interface {
 	ListOORRecipientCursors(ctx context.Context) ([]OorRecipientCursor, error)
 	ListOORVTXOBindingsBySession(ctx context.Context, sessionID []byte) ([]ListOORVTXOBindingsBySessionRow, error)
 	ListOwnedReceiveScripts(ctx context.Context) ([]OwnedReceiveScript, error)
+	ListPendingBoardRequests(ctx context.Context) ([]PendingBoardRequest, error)
 	ListPendingBoardingSweepInputs(ctx context.Context) ([]BoardingSweepInput, error)
 	ListPendingBoardingSweeps(ctx context.Context) ([]BoardingSweep, error)
 	ListRoundsByStatus(ctx context.Context, status string) ([]Round, error)
@@ -209,6 +212,15 @@ type Querier interface {
 	UpsertOORRecipientCursor(ctx context.Context, arg UpsertOORRecipientCursorParams) error
 	UpsertOORVTXOBinding(ctx context.Context, arg UpsertOORVTXOBindingParams) (int64, error)
 	UpsertOwnedReceiveScript(ctx context.Context, arg UpsertOwnedReceiveScriptParams) error
+	// Pending board request queries.
+	//
+	// Each row binds the user's explicit Board RPC target_vtxo_count to one
+	// confirmed boarding outpoint that the call admitted. On daemon restart the
+	// wallet lists every row and replays a single Board through the same actor
+	// path the live RPC uses; rows whose outpoints are no longer Confirmed (the
+	// intent has already adopted, swept, or failed) are cleared so the next
+	// start is a no-op.
+	UpsertPendingBoardRequest(ctx context.Context, arg UpsertPendingBoardRequestParams) error
 	// Unilateral-exit job control-plane queries.
 	UpsertUnilateralExitJob(ctx context.Context, arg UpsertUnilateralExitJobParams) error
 }

--- a/db/sqlc/queries/boarding.sql
+++ b/db/sqlc/queries/boarding.sql
@@ -228,3 +228,35 @@ SELECT outpoint_hash, outpoint_index FROM boarding_intents;
 SELECT * FROM boarding_intents
 WHERE status = $1 AND conf_height >= $2
 ORDER BY conf_height ASC;
+
+-- Pending board request queries.
+--
+-- Each row binds the user's explicit Board RPC target_vtxo_count to one
+-- confirmed boarding outpoint that the call admitted. On daemon restart the
+-- wallet lists every row and replays a single Board through the same actor
+-- path the live RPC uses; rows whose outpoints are no longer Confirmed (the
+-- intent has already adopted, swept, or failed) are cleared so the next
+-- start is a no-op.
+
+-- name: UpsertPendingBoardRequest :exec
+INSERT INTO pending_board_requests (
+    outpoint_hash,
+    outpoint_index,
+    target_vtxo_count,
+    requested_at_unix
+) VALUES ($1, $2, $3, $4)
+ON CONFLICT (outpoint_hash, outpoint_index) DO UPDATE
+SET target_vtxo_count = excluded.target_vtxo_count,
+    requested_at_unix = excluded.requested_at_unix;
+
+-- name: ListPendingBoardRequests :many
+SELECT outpoint_hash, outpoint_index, target_vtxo_count, requested_at_unix
+FROM pending_board_requests
+ORDER BY requested_at_unix ASC, outpoint_hash ASC, outpoint_index ASC;
+
+-- name: ClearPendingBoardRequestByOutpoint :exec
+DELETE FROM pending_board_requests
+WHERE outpoint_hash = $1 AND outpoint_index = $2;
+
+-- name: ClearAllPendingBoardRequests :exec
+DELETE FROM pending_board_requests;

--- a/db/sqlc/schemas/generated_schema.sql
+++ b/db/sqlc/schemas/generated_schema.sql
@@ -697,6 +697,20 @@ CREATE TABLE owned_receive_scripts (
     FOREIGN KEY (source) REFERENCES owned_receive_script_sources(source)
 );
 
+CREATE TABLE pending_board_requests (
+    outpoint_hash BLOB NOT NULL,
+    outpoint_index INTEGER NOT NULL,
+
+    target_vtxo_count INTEGER NOT NULL DEFAULT 0,
+
+    requested_at_unix BIGINT NOT NULL,
+
+    PRIMARY KEY (outpoint_hash, outpoint_index),
+
+    CHECK (target_vtxo_count >= 0),
+    CHECK (requested_at_unix > 0)
+);
+
 CREATE TABLE processed_messages (
     -- id is the message ID that was processed.
     id TEXT PRIMARY KEY,

--- a/wallet/board_replay_test.go
+++ b/wallet/board_replay_test.go
@@ -1,0 +1,380 @@
+package wallet
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/ledger"
+	"github.com/lightninglabs/darepo-client/lib/actormsg"
+	"github.com/lightningnetwork/lnd/clock"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// boardReplayTestOutpoint returns a deterministic, unique outpoint for a
+// per-test seed so multiple confirmed-intent fixtures in one test do not
+// collide on their primary key.
+func boardReplayTestOutpoint(seed byte) wire.OutPoint {
+	return wire.OutPoint{
+		Hash: chainhash.Hash{
+			seed,
+		},
+		Index: 0,
+	}
+}
+
+// boardReplayTestIntent builds a minimal confirmed BoardingIntent fixture
+// suitable for FetchBoardingIntentsByStatus expectations in the replay
+// tests.
+func boardReplayTestIntent(seed byte, amount btcutil.Amount) BoardingIntent {
+	op := boardReplayTestOutpoint(seed)
+
+	return BoardingIntent{
+		Outpoint: op,
+		ChainInfo: BoardingChainInfo{
+			OutPoint: op,
+			Amount:   amount,
+		},
+		Status: BoardingStatusConfirmed,
+	}
+}
+
+// newBoardReplayTestWallet wires a wallet with a registered mock round actor
+// so handleBoard's Tell to the round-service-key path can be observed. The
+// MockBoardingStore is left to the caller to configure.
+func newBoardReplayTestWallet(t *testing.T, store *MockBoardingStore,
+	clk clock.Clock) (*Ark, *mockRoundActorBehavior) {
+
+	t.Helper()
+
+	system := actor.NewActorSystem()
+	t.Cleanup(func() {
+		// Use Background ctx because t.Context is cancelled before
+		// Cleanup runs.
+		err := system.Shutdown(context.Background())
+		require.NoError(t, err)
+	})
+
+	roundActor := &mockRoundActorBehavior{}
+	roundKey := actormsg.RoundActorServiceKey()
+	actor.RegisterWithSystem(
+		system, actormsg.RoundActorServiceKeyName, roundKey, roundActor,
+	)
+
+	w := NewArk(
+		nil, store, nil, nil, system, fn.None[ledger.Sink](),
+		btclog.Disabled, WithClock(clk),
+	)
+
+	return w, roundActor
+}
+
+// TestHandleBoardPersistsOneRowPerConfirmedOutpoint pins down the H-1 fix:
+// handleBoard writes one PendingBoardRequest row per BoardingStatusConfirmed
+// intent the call admits, bound to the confirmed outpoint. Each row carries
+// the same target_vtxo_count and requested_at_unix.
+func TestHandleBoardPersistsOneRowPerConfirmedOutpoint(t *testing.T) {
+	t.Parallel()
+
+	intentA := boardReplayTestIntent(0x01, 25_000)
+	intentB := boardReplayTestIntent(0x02, 75_000)
+
+	store := &MockBoardingStore{}
+	store.On(
+		"FetchBoardingIntentsByStatus", mock.Anything,
+		BoardingStatusConfirmed,
+	).Return([]BoardingIntent{intentA, intentB}, nil)
+
+	fixedTime := time.Unix(1_700_000_000, 0)
+	clk := clock.NewTestClock(fixedTime)
+
+	want := []PendingBoardRequest{
+		{
+			Outpoint:        intentA.Outpoint,
+			TargetVTXOCount: 3,
+			RequestedAt:     fixedTime.Unix(),
+		},
+		{
+			Outpoint:        intentB.Outpoint,
+			TargetVTXOCount: 3,
+			RequestedAt:     fixedTime.Unix(),
+		},
+	}
+	store.On(
+		"UpsertPendingBoardRequests", mock.Anything, want,
+	).Return(nil)
+
+	w, roundActor := newBoardReplayTestWallet(t, store, clk)
+
+	result := w.Receive(t.Context(), &BoardRequest{TargetVTXOCount: 3})
+	require.True(
+		t, result.IsOk(),
+		"Board must succeed when round Tell succeeds; got %v",
+		result.Err(),
+	)
+
+	store.AssertExpectations(t)
+
+	// The Tell to the round actor is asynchronous via the service-key
+	// router, so the actor system needs a moment to dispatch it. Poll
+	// until the mock observes the call instead of sleeping for a fixed
+	// duration.
+	require.Eventually(t, func() bool {
+		return roundActor.TriggerBoardCalls() == 1
+	}, 2*time.Second, 10*time.Millisecond,
+		"round actor must receive exactly one TriggerBoardMsg")
+}
+
+// TestHandleBoardPersistFailureSkipsRoundTell verifies the persist-before-Tell
+// invariant: if the wallet cannot persist the pending rows, the round actor
+// MUST NOT receive a TriggerBoardMsg. Otherwise a crash between Tell and
+// persist would leave the round holding an in-memory intent with no on-disk
+// marker — the exact failure mode #416 reported.
+func TestHandleBoardPersistFailureSkipsRoundTell(t *testing.T) {
+	t.Parallel()
+
+	intent := boardReplayTestIntent(0x11, 50_000)
+
+	store := &MockBoardingStore{}
+	store.On(
+		"FetchBoardingIntentsByStatus", mock.Anything,
+		BoardingStatusConfirmed,
+	).Return([]BoardingIntent{intent}, nil)
+
+	wantErr := errors.New("simulated persist failure")
+	store.On(
+		"UpsertPendingBoardRequests", mock.Anything,
+		mock.Anything,
+	).Return(wantErr)
+
+	clk := clock.NewTestClock(time.Unix(1_700_000_000, 0))
+	w, roundActor := newBoardReplayTestWallet(t, store, clk)
+
+	result := w.Receive(t.Context(), &BoardRequest{TargetVTXOCount: 0})
+	require.True(
+		t, result.IsErr(),
+		"Board must fail when persist fails so caller retries",
+	)
+	require.ErrorContains(t, result.Err(), "persist pending board request")
+	require.ErrorIs(t, result.Err(), wantErr)
+
+	require.Equal(
+		t, 0, roundActor.TriggerBoardCalls(),
+		"round actor must NOT be Told when persist failed",
+	)
+}
+
+// TestReplayClearsAllRowsWhenNoOutpointIsStillConfirmed verifies the H-1
+// stale-row sweep: when every persisted row points at an outpoint that has
+// already moved out of Confirmed (e.g. the round adopted, swept, or
+// failed), the wallet wipes the table and skips the self-Tell. This is the
+// "round already completed" branch that prevents a stale target_vtxo_count
+// from re-firing against a fresh, unrelated deposit.
+func TestReplayClearsAllRowsWhenNoOutpointIsStillConfirmed(t *testing.T) {
+	t.Parallel()
+
+	op := boardReplayTestOutpoint(0x21)
+	pending := []PendingBoardRequest{
+		{
+			Outpoint:        op,
+			TargetVTXOCount: 5,
+			RequestedAt:     1_700_000_000,
+		},
+	}
+
+	store := &MockBoardingStore{}
+	store.On(
+		"ListPendingBoardRequests", mock.Anything,
+	).Return(pending, nil)
+
+	// Confirmed set excludes the pending row's outpoint, so every
+	// pending row is stale.
+	store.On(
+		"FetchBoardingIntentsByStatus", mock.Anything,
+		BoardingStatusConfirmed,
+	).Return([]BoardingIntent(nil), nil)
+
+	store.On(
+		"ClearAllPendingBoardRequests", mock.Anything,
+	).Return(nil)
+
+	clk := clock.NewTestClock(time.Unix(1_700_000_000, 0))
+	w, roundActor := newBoardReplayTestWallet(t, store, clk)
+
+	// Run only the replay path. Pass a TellOnly self-ref that records
+	// whether the wallet self-Tells anything; for the all-stale branch
+	// it must not.
+	selfRef := actor.NewChannelTellOnlyRef[WalletMsg](
+		"test-wallet-self", 4,
+	)
+
+	err := w.replayPendingBoardOnStart(t.Context(), selfRef)
+	require.NoError(t, err)
+
+	store.AssertExpectations(t)
+	require.Equal(
+		t, 0, roundActor.TriggerBoardCalls(),
+		"no round Tell when every pending row is stale",
+	)
+}
+
+// TestReplaySelfTellsBoardWhenOutpointIsStillConfirmed verifies the H-2 fix:
+// when at least one persisted row points at a still-Confirmed outpoint, the
+// wallet self-Tells a BoardRequest carrying the persisted target_vtxo_count.
+// FIFO ordering of the wallet's own mailbox guarantees this replay is
+// dispatched before any gRPC-issued BoardRequest, closing the startup race.
+func TestReplaySelfTellsBoardWhenOutpointIsStillConfirmed(t *testing.T) {
+	t.Parallel()
+
+	liveOp := boardReplayTestOutpoint(0x31)
+	staleOp := boardReplayTestOutpoint(0x32)
+
+	pending := []PendingBoardRequest{
+		{
+			Outpoint:        liveOp,
+			TargetVTXOCount: 4,
+			RequestedAt:     1_700_000_000,
+		},
+		{
+			Outpoint:        staleOp,
+			TargetVTXOCount: 4,
+			RequestedAt:     1_700_000_000,
+		},
+	}
+
+	store := &MockBoardingStore{}
+	store.On(
+		"ListPendingBoardRequests", mock.Anything,
+	).Return(pending, nil)
+
+	// Only liveOp is in the Confirmed set; staleOp is stale.
+	store.On(
+		"FetchBoardingIntentsByStatus", mock.Anything,
+		BoardingStatusConfirmed,
+	).Return([]BoardingIntent{
+		{
+			Outpoint: liveOp,
+			ChainInfo: BoardingChainInfo{
+				OutPoint: liveOp,
+				Amount:   25_000,
+			},
+			Status: BoardingStatusConfirmed,
+		},
+	}, nil)
+
+	// In the replay path the wallet must NOT bulk-clear: at least one
+	// row is live. Stale-row cleanup happens via the round-adoption
+	// transition (see db.RoundPersistenceStore.CommitState).
+	store.AssertNotCalled(t, "ClearAllPendingBoardRequests",
+		mock.Anything)
+
+	clk := clock.NewTestClock(time.Unix(1_700_000_000, 0))
+	w, _ := newBoardReplayTestWallet(t, store, clk)
+
+	selfRef := actor.NewChannelTellOnlyRef[WalletMsg](
+		"test-wallet-self", 4,
+	)
+
+	err := w.replayPendingBoardOnStart(t.Context(), selfRef)
+	require.NoError(t, err)
+
+	// One BoardRequest must be enqueued on the self-ref carrying the
+	// persisted target_vtxo_count. AwaitMessage drains the channel
+	// helper with a bounded timeout so the test fails fast rather than
+	// hanging if replay silently skipped the Tell.
+	msg, ok := selfRef.AwaitMessage(2 * time.Second)
+	require.True(t, ok, "expected replay to self-Tell a BoardRequest")
+	boardReq, ok := msg.(*BoardRequest)
+	require.True(t, ok, "expected *BoardRequest, got %T", msg)
+	require.Equal(t, uint32(4), boardReq.TargetVTXOCount)
+
+	store.AssertExpectations(t)
+}
+
+// TestHandleBoardNoPersistSkipsUpsert verifies the CLI/RPC opt-out: when
+// BoardRequest.NoPersist is true, the wallet does NOT write to
+// pending_board_requests. The round actor still receives TriggerBoardMsg so
+// the boarding flow proceeds; a daemon restart between admission and round
+// seal will silently drop the request — the user's explicit choice.
+func TestHandleBoardNoPersistSkipsUpsert(t *testing.T) {
+	t.Parallel()
+
+	intent := boardReplayTestIntent(0x41, 60_000)
+
+	store := &MockBoardingStore{}
+	store.On(
+		"FetchBoardingIntentsByStatus", mock.Anything,
+		BoardingStatusConfirmed,
+	).Return([]BoardingIntent{intent}, nil)
+
+	// Explicitly refuse any UpsertPendingBoardRequests call; if the
+	// wallet writes despite NoPersist, the mock's strict assertion
+	// fails this test.
+	store.AssertNotCalled(
+		t, "UpsertPendingBoardRequests", mock.Anything, mock.Anything,
+	)
+
+	clk := clock.NewTestClock(time.Unix(1_700_000_000, 0))
+	w, roundActor := newBoardReplayTestWallet(t, store, clk)
+
+	result := w.Receive(t.Context(), &BoardRequest{
+		TargetVTXOCount: 2,
+		NoPersist:       true,
+	})
+	require.True(
+		t, result.IsOk(),
+		"Board with NoPersist must still succeed; got %v", result.Err(),
+	)
+
+	store.AssertExpectations(t)
+	store.AssertNotCalled(
+		t, "UpsertPendingBoardRequests", mock.Anything, mock.Anything,
+	)
+
+	require.Eventually(t, func() bool {
+		return roundActor.TriggerBoardCalls() == 1
+	}, 2*time.Second, 10*time.Millisecond,
+		"round actor must still receive TriggerBoardMsg with "+
+			"NoPersist set")
+}
+
+// TestReplayEmptyStoreIsNoOp verifies that a wallet with no persisted Board
+// rows skips the replay path entirely — no ClearAll, no self-Tell, no
+// FetchBoardingIntentsByStatus. This is the common happy path on a fresh
+// daemon start.
+func TestReplayEmptyStoreIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	store := &MockBoardingStore{}
+	store.On(
+		"ListPendingBoardRequests", mock.Anything,
+	).Return([]PendingBoardRequest(nil), nil)
+
+	clk := clock.NewTestClock(time.Unix(1_700_000_000, 0))
+	w, _ := newBoardReplayTestWallet(t, store, clk)
+
+	selfRef := actor.NewChannelTellOnlyRef[WalletMsg](
+		"test-wallet-self", 1,
+	)
+
+	err := w.replayPendingBoardOnStart(t.Context(), selfRef)
+	require.NoError(t, err)
+
+	store.AssertExpectations(t)
+	store.AssertNotCalled(
+		t, "FetchBoardingIntentsByStatus", mock.Anything, mock.Anything,
+	)
+	store.AssertNotCalled(t, "ClearAllPendingBoardRequests",
+		mock.Anything)
+
+	_, gotMsg := selfRef.AwaitMessage(50 * time.Millisecond)
+	require.False(t, gotMsg, "empty store must not self-Tell")
+}

--- a/wallet/boarding_sweep_actor.go
+++ b/wallet/boarding_sweep_actor.go
@@ -173,6 +173,42 @@ func (m *ResumeBoardingSweepsResponse) MessageType() string {
 
 func (m *ResumeBoardingSweepsResponse) walletRespSealed() {}
 
+// ReplayPendingBoardRequest is an Ask the daemon sends to the wallet
+// once every dependent actor (in particular the round-client actor)
+// is registered, asking it to replay any persisted Board RPC the user
+// issued before the last shutdown. The wallet's self-Tell pattern
+// inside Start would otherwise process the replay BEFORE the round
+// actor is reachable through the receptionist, silently dropping the
+// downstream TriggerBoardMsg.
+type ReplayPendingBoardRequest struct {
+	actor.BaseMessage
+}
+
+// MessageType returns the message type identifier.
+func (m *ReplayPendingBoardRequest) MessageType() string {
+	return "ReplayPendingBoardRequest"
+}
+
+func (m *ReplayPendingBoardRequest) walletMsgSealed() {}
+
+// ReplayPendingBoardResponse acknowledges that the wallet has either
+// re-issued a BoardRequest into its own mailbox or determined there is
+// nothing live to replay.
+type ReplayPendingBoardResponse struct {
+	actor.BaseMessage
+
+	// Replayed is true when the wallet self-Telled a BoardRequest as
+	// part of replay; false when no live pending row was found.
+	Replayed bool
+}
+
+// MessageType returns the message type identifier.
+func (m *ReplayPendingBoardResponse) MessageType() string {
+	return "ReplayPendingBoardResponse"
+}
+
+func (m *ReplayPendingBoardResponse) walletRespSealed() {}
+
 // BoardingSweepSpendNotification is a Tell carrying a chainsource spend
 // event for a boarding-sweep input. Emitted by the chainsource subscription
 // the wallet actor sets up via MapSpendEvent.

--- a/wallet/interfaces.go
+++ b/wallet/interfaces.go
@@ -337,9 +337,60 @@ type BoardingIntent struct {
 	Status BoardingStatus
 }
 
+// PendingBoardRequestStore is the persistence surface for restart-safe Board
+// RPC replay. Rows are keyed by the confirmed boarding outpoint the original
+// Board call admitted, so a replay binds the persisted target_vtxo_count to
+// the specific UTXOs the user pointed at — never to an unrelated future
+// deposit. The wallet writes rows from handleBoard, the round-state
+// checkpoint clears them when the intent transitions to Adopted, and the
+// wallet's startup hook reads them to decide whether to self-Tell a Board
+// replay.
+//
+// Split out from BoardingStore so the parent interface stays under the
+// interfacebloat cap.
+type PendingBoardRequestStore interface {
+	// UpsertPendingBoardRequests records the user's explicit Board RPC
+	// intent. One row is persisted per confirmed boarding outpoint the
+	// Board call admitted. All rows are written under a single
+	// transaction so the persist is atomic; an empty slice is a benign
+	// no-op.
+	UpsertPendingBoardRequests(ctx context.Context,
+		reqs []PendingBoardRequest) error
+
+	// ListPendingBoardRequests returns every persisted Board RPC intent
+	// keyed by the outpoint it was admitted against. Rows are ordered
+	// by requested_at_unix ascending so callers can group by Board
+	// call. An empty slice is returned when nothing is pending.
+	ListPendingBoardRequests(ctx context.Context) (
+		[]PendingBoardRequest,
+		error,
+	)
+
+	// ClearPendingBoardRequestByOutpoint removes a single pending row.
+	// Called from the round persistence transaction when the matching
+	// boarding intent transitions out of Confirmed (Adopted, Swept,
+	// etc.) so the cleanup runs atomically with the state change.
+	ClearPendingBoardRequestByOutpoint(ctx context.Context,
+		outpoint wire.OutPoint) error
+
+	// ClearAllPendingBoardRequests removes every persisted Board RPC
+	// intent. Used by the wallet's startup sweep when no confirmed
+	// intent remains for any persisted row so the next start is a
+	// no-op.
+	ClearAllPendingBoardRequests(ctx context.Context) error
+}
+
 // BoardingStore defines the storage interface for boarding addresses and
-// intents used by the wallet actor.
+// intents used by the wallet actor. Embeds PendingBoardRequestStore so the
+// pending-Board-replay surface is part of the same contract. One logical
+// store covers boarding addresses, intents, and pending-Board replay rows
+// — splitting further would fragment transaction boundaries across the
+// same SQL table family.
+//
+//nolint:interfacebloat
 type BoardingStore interface {
+	PendingBoardRequestStore
+
 	// InsertBoardingAddress persists a boarding address when it is first
 	// created. This method is idempotent.
 	InsertBoardingAddress(ctx context.Context, addr *BoardingAddress) error
@@ -390,4 +441,30 @@ type BoardingStore interface {
 	// boarding pkScript.
 	LookupIntentByScript(ctx context.Context,
 		pkScript []byte) (*BoardingIntent, error)
+}
+
+// PendingBoardRequest captures one persisted row of a user-issued Board RPC.
+// The wallet writes one row per confirmed boarding outpoint the Board call
+// admitted and re-reads them on startup so the request survives daemon
+// restart between Board admission and round seal. The Outpoint binds the
+// row to a specific UTXO so a stale row cannot rebind to an unrelated
+// future deposit.
+type PendingBoardRequest struct {
+	// Outpoint identifies the confirmed boarding intent this row is
+	// bound to. Replay only re-issues TriggerBoardMsg for a row whose
+	// Outpoint still resolves to a BoardingStatusConfirmed intent at
+	// startup time.
+	Outpoint wire.OutPoint
+
+	// TargetVTXOCount mirrors BoardRequest.TargetVTXOCount: zero means
+	// "collapse the confirmed boarding balance into one VTXO", non-zero
+	// fans the balance into that many VTXOs. Denormalised onto every
+	// row in the same Board call.
+	TargetVTXOCount uint32
+
+	// RequestedAt is the unix-second timestamp at which the Board RPC
+	// was originally admitted. Denormalised onto every row in the same
+	// Board call; replay uses the smallest value across all rows as the
+	// "earliest still-pending Board call" for logging.
+	RequestedAt int64
 }

--- a/wallet/messages.go
+++ b/wallet/messages.go
@@ -531,6 +531,15 @@ type BoardRequest struct {
 	// TargetVTXOCount is the requested number of boarded VTXOs. Zero means
 	// one output, preserving the legacy single-VTXO board behavior.
 	TargetVTXOCount uint32
+
+	// NoPersist opts out of restart-safe Board replay. When true, the
+	// wallet skips the UpsertPendingBoardRequests write entirely so a
+	// crash between admission and round seal silently drops the request.
+	// Default false is the safe behavior: the wallet persists one row
+	// per admitted confirmed outpoint and replays via its own startup
+	// self-Tell. The startup replay path always sets this to false so
+	// a replay re-persists with a fresh timestamp.
+	NoPersist bool
 }
 
 // MessageType returns the message type identifier for logging and debugging.

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -417,23 +417,14 @@ func (a *Ark) Start(ctx context.Context,
 	// "not found", silently orphaning every persisted pending sweep.
 	// The daemon explicitly Asks the wallet to resume after step 12.
 
-	// Replay any persisted Board RPC the user issued before the last
-	// shutdown. Self-Tell of a BoardRequest lands ahead of any external
-	// gRPC-issued Board because the actor system has not yet started
-	// dispatching outside messages to the wallet's mailbox. This closes
-	// the startup race between gRPC admission and replay that an
-	// out-of-band Ask from the daemon would otherwise open.
-	if err := a.replayPendingBoardOnStart(ctx, selfRef); err != nil {
-		// A replay failure must NOT block daemon startup: the next
-		// user-issued Board RPC will overwrite the rows, and a
-		// future restart re-tries. We log at Warn (recoverable
-		// external state, not an internal bug) so operators can
-		// see the failure without the daemon falling over.
-		a.logger(ctx).WarnS(
-			ctx, "Failed to replay pending Board request on "+
-				"startup", err,
-		)
-	}
+	// Replay of any persisted Board RPC is intentionally NOT dispatched
+	// here. The wallet starts before the round-client actor registers
+	// with the receptionist, so a self-Tell from Start would land
+	// handleBoard's downstream TriggerBoardMsg against an unresolved
+	// service key and silently drop the replay. The daemon explicitly
+	// Asks the wallet to replay (ReplayPendingBoardRequest) once the
+	// round-client actor is up, mirroring the resumeBoardingSweeps
+	// startup-ordering fix.
 
 	a.logger(ctx).InfoS(ctx, "Boarding wallet actor started")
 
@@ -522,6 +513,9 @@ func (a *Ark) Receive(ctx context.Context,
 
 	case *ResumeBoardingSweepsRequest:
 		return a.handleResumeBoardingSweeps(ctx, m)
+
+	case *ReplayPendingBoardRequest:
+		return a.handleReplayPendingBoard(ctx, m)
 
 	case BoardingSweepSpendNotification:
 		return a.handleSweepSpendNotification(ctx, m)
@@ -1578,14 +1572,19 @@ func (a *Ark) handleBoard(ctx context.Context,
 	return fn.Ok[WalletResp](resp)
 }
 
-// replayPendingBoardOnStart is invoked from the wallet's Start hook (not
-// from the actor's Receive loop) to recover a user's Board RPC across
-// daemon restart. The replay self-Tells a BoardRequest into the wallet's
-// own mailbox so handleBoard runs against a real BoardingStore read and
-// re-persists with a fresh timestamp; FIFO ordering of the mailbox
-// guarantees that any user-issued Board RPC arriving over gRPC will be
-// processed AFTER the replay, eliminating the startup race between gRPC
-// admission and replay.
+// replayPendingBoardOnStart is invoked from handleReplayPendingBoard
+// (driven by the daemon's startWalletDependentActors hook) to recover
+// a user's Board RPC across daemon restart. The replay self-Tells a
+// BoardRequest into the wallet's own mailbox so handleBoard runs
+// against a real BoardingStore read and re-persists with a fresh
+// timestamp; FIFO ordering of the mailbox guarantees that any
+// user-issued Board RPC arriving over gRPC after the daemon's
+// ReplayPendingBoardRequest Ask returns will be processed AFTER the
+// replay, eliminating the gRPC-admission-vs-replay startup race.
+// Running from a Receive-time handler rather than Start also closes
+// the round-actor-registration race: by the time the daemon Asks us
+// to replay, the round-client actor is already on the receptionist
+// so the downstream TriggerBoardMsg dispatch resolves cleanly.
 //
 // Per-row semantics: every pending row is bound to one specific boarding
 // outpoint. Rows whose outpoint is no longer Confirmed are stale: they
@@ -1676,9 +1675,12 @@ func (a *Ark) replayPendingBoardOnStart(ctx context.Context,
 
 	// Self-Tell the BoardRequest. handleBoard will re-walk the confirmed
 	// set, re-persist rows with a fresh timestamp, and Tell the round
-	// actor. The self-Tell lands in the wallet's mailbox BEFORE any
-	// gRPC-driven BoardRequest because Start runs synchronously before
-	// the actor system starts dispatching external messages.
+	// actor. The daemon Asks this method from
+	// startWalletDependentActors only after the round-client actor has
+	// registered with the receptionist, so the downstream
+	// TriggerBoardMsg dispatch from handleBoard sees a live round-actor
+	// ref rather than a "not found" lookup that would silently drop the
+	// replay.
 	err = selfRef.Tell(ctx, &BoardRequest{
 		TargetVTXOCount: liveTarget,
 	})
@@ -1687,6 +1689,26 @@ func (a *Ark) replayPendingBoardOnStart(ctx context.Context,
 	}
 
 	return nil
+}
+
+// handleReplayPendingBoard is the Ask handler for
+// ReplayPendingBoardRequest. The daemon issues this Ask once every
+// dependent actor (round-client, vtxo-manager, txconfirm, etc.) is
+// registered, which is the earliest moment the replayed Board's
+// downstream TriggerBoardMsg can be delivered through the actor
+// receptionist. The handler is a thin wrapper around
+// replayPendingBoardOnStart so the existing logic (and its test
+// coverage) is reused without duplication.
+func (a *Ark) handleReplayPendingBoard(ctx context.Context,
+	_ *ReplayPendingBoardRequest) fn.Result[WalletResp] {
+
+	if err := a.replayPendingBoardOnStart(ctx, a.selfRef); err != nil {
+		return fn.Err[WalletResp](
+			fmt.Errorf("replay pending board: %w", err),
+		)
+	}
+
+	return fn.Ok[WalletResp](&ReplayPendingBoardResponse{})
 }
 
 // splitBoardingAmount fans a confirmed boarding balance into count VTXO

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -22,6 +22,7 @@ import (
 	"github.com/lightninglabs/darepo-client/lib/arkscript"
 	"github.com/lightninglabs/darepo-client/lib/types"
 	"github.com/lightninglabs/taproot-assets/proof"
+	"github.com/lightningnetwork/lnd/clock"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 )
 
@@ -163,6 +164,11 @@ type Ark struct {
 	// map is owned by the actor's single-threaded Receive loop and is
 	// kept in lockstep with each pendingSweepState.inputs entry.
 	pendingSweepInputs map[wire.OutPoint]chainhash.Hash
+
+	// clk is the clock used to stamp persistence timestamps. Tests pass
+	// a deterministic clock via WithClock; production wires the
+	// server-wide clock instance so all stores share one source of time.
+	clk clock.Clock
 }
 
 // NewArk creates a new Ark wallet actor. The logger is optional and falls back
@@ -204,6 +210,7 @@ func NewArk(backend BoardingBackend, store BoardingStore, vtxoReader VTXOReader,
 		pendingSweepInputs: make(
 			map[wire.OutPoint]chainhash.Hash,
 		),
+		clk: clock.NewDefaultClock(),
 	}
 	for _, opt := range opts {
 		opt(a)
@@ -235,6 +242,16 @@ func WithBoardingSweep(store BoardingSweepStore, signer SweepSigner,
 		a.sweepStore = store
 		a.sweepSigner = signer
 		a.sweepChainParams = chainParams
+	}
+}
+
+// WithClock overrides the wallet's clock with a caller-supplied instance.
+// Production wires this with the daemon-wide clock so persist timestamps
+// share one source of truth; tests use this to freeze time. When omitted,
+// the wallet falls back to clock.NewDefaultClock().
+func WithClock(clk clock.Clock) ArkOption {
+	return func(a *Ark) {
+		a.clk = clk
 	}
 }
 
@@ -399,6 +416,24 @@ func (a *Ark) Start(ctx context.Context,
 	// scheduling-unlucky resume would observe txconfirm.LookupRef as
 	// "not found", silently orphaning every persisted pending sweep.
 	// The daemon explicitly Asks the wallet to resume after step 12.
+
+	// Replay any persisted Board RPC the user issued before the last
+	// shutdown. Self-Tell of a BoardRequest lands ahead of any external
+	// gRPC-issued Board because the actor system has not yet started
+	// dispatching outside messages to the wallet's mailbox. This closes
+	// the startup race between gRPC admission and replay that an
+	// out-of-band Ask from the daemon would otherwise open.
+	if err := a.replayPendingBoardOnStart(ctx, selfRef); err != nil {
+		// A replay failure must NOT block daemon startup: the next
+		// user-issued Board RPC will overwrite the rows, and a
+		// future restart re-tries. We log at Warn (recoverable
+		// external state, not an internal bug) so operators can
+		// see the failure without the daemon falling over.
+		a.logger(ctx).WarnS(
+			ctx, "Failed to replay pending Board request on "+
+				"startup", err,
+		)
+	}
 
 	a.logger(ctx).InfoS(ctx, "Boarding wallet actor started")
 
@@ -1464,6 +1499,51 @@ func (a *Ark) handleBoard(ctx context.Context,
 		slog.Int64("vtxo_amount", int64(vtxoAmount)),
 		slog.Int("vtxo_count", len(vtxoAmounts)))
 
+	// Persist the user's explicit Board intent BEFORE handing the
+	// request to the round actor. The ordering matters for restart
+	// recovery: a crash between Tell and persist would leave the round
+	// actor holding the intent in memory with no on-disk marker, so the
+	// next daemon start would silently drop the user's request. With
+	// persist-first, every crash window is either:
+	//
+	//   - pre-persist: no row, no Tell — the user sees an error and
+	//     retries (idempotent).
+	//   - post-persist, pre-Tell: rows exist, no Tell. On restart the
+	//     wallet's Start re-issues TriggerBoardMsg via a self-Tell of
+	//     the same BoardRequest.
+	//   - post-Tell: rows exist, round actor has the request. On
+	//     restart the round actor is empty but the wallet re-issues
+	//     and we converge on the same state.
+	//
+	// One row is written per confirmed boarding outpoint that the call
+	// admitted. Rows are cleared in the same SQL transaction as the
+	// round-state checkpoint that flips each intent to Adopted (see
+	// db.RoundPersistenceStore.CommitState), so the row can never
+	// outlive the intent it was admitted against.
+	if !req.NoPersist {
+		now := a.clk.Now().Unix()
+		pendingRows := make(
+			[]PendingBoardRequest, 0, len(intents),
+		)
+		for _, intent := range intents {
+			pendingRows = append(
+				pendingRows, PendingBoardRequest{
+					Outpoint:        intent.Outpoint,
+					TargetVTXOCount: req.TargetVTXOCount,
+					RequestedAt:     now,
+				},
+			)
+		}
+		if err := a.store.UpsertPendingBoardRequests(
+			ctx, pendingRows,
+		); err != nil {
+			return fn.Err[WalletResp](
+				fmt.Errorf("persist pending board request: %w",
+					err),
+			)
+		}
+	}
+
 	// Forward to round actor via service key lookup. The round actor
 	// registers the VTXO output requests and triggers the round join.
 	if a.actorSystem == nil {
@@ -1480,6 +1560,10 @@ func (a *Ark) handleBoard(ctx context.Context,
 			Amounts: vtxoAmounts,
 		},
 	); err != nil {
+		// The persisted row stays in place so the next daemon
+		// start (or a fresh Board RPC) will retry. Returning the
+		// error here lets the caller surface the Tell failure
+		// without leaving the user thinking Board succeeded.
 		return fn.Err[WalletResp](
 			fmt.Errorf("forward board to round actor: %w", err),
 		)
@@ -1492,6 +1576,117 @@ func (a *Ark) handleBoard(ctx context.Context,
 	}
 
 	return fn.Ok[WalletResp](resp)
+}
+
+// replayPendingBoardOnStart is invoked from the wallet's Start hook (not
+// from the actor's Receive loop) to recover a user's Board RPC across
+// daemon restart. The replay self-Tells a BoardRequest into the wallet's
+// own mailbox so handleBoard runs against a real BoardingStore read and
+// re-persists with a fresh timestamp; FIFO ordering of the mailbox
+// guarantees that any user-issued Board RPC arriving over gRPC will be
+// processed AFTER the replay, eliminating the startup race between gRPC
+// admission and replay.
+//
+// Per-row semantics: every pending row is bound to one specific boarding
+// outpoint. Rows whose outpoint is no longer Confirmed are stale: they
+// belong to a Board call whose round has already adopted/swept/failed.
+// Those rows are deleted in bulk via ClearAllPendingBoardRequests when
+// none of the persisted outpoints have a live Confirmed intent. When at
+// least one outpoint is still Confirmed, the wallet self-Tells a single
+// BoardRequest carrying the original target_vtxo_count.
+func (a *Ark) replayPendingBoardOnStart(ctx context.Context,
+	selfRef actor.TellOnlyRef[WalletMsg]) error {
+
+	pending, err := a.store.ListPendingBoardRequests(ctx)
+	if err != nil {
+		return fmt.Errorf("list pending board requests: %w", err)
+	}
+
+	if len(pending) == 0 {
+		return nil
+	}
+
+	// Reconcile the persisted rows against the current set of confirmed
+	// boarding intents. A pending row is "live" only if its outpoint
+	// still has a BoardingStatusConfirmed intent — otherwise the round
+	// it was admitted into has already moved on and the row is stale.
+	confirmed, err := a.store.FetchBoardingIntentsByStatus(
+		ctx, BoardingStatusConfirmed,
+	)
+	if err != nil {
+		return fmt.Errorf("fetch confirmed boarding intents: %w", err)
+	}
+
+	confirmedSet := make(map[wire.OutPoint]struct{}, len(confirmed))
+	for _, intent := range confirmed {
+		confirmedSet[intent.Outpoint] = struct{}{}
+	}
+
+	var liveTarget uint32
+	var earliestRequestedAt int64
+	var liveOutpoints int
+	for _, row := range pending {
+		if _, ok := confirmedSet[row.Outpoint]; !ok {
+			continue
+		}
+
+		liveOutpoints++
+
+		// All rows in the same Board call carry the same
+		// target_vtxo_count; if multiple Board calls left rows behind,
+		// the most recent target wins (rows are ordered ASC by
+		// requested_at_unix, so the last live row wins).
+		liveTarget = row.TargetVTXOCount
+
+		if earliestRequestedAt == 0 ||
+			row.RequestedAt < earliestRequestedAt {
+
+			earliestRequestedAt = row.RequestedAt
+		}
+	}
+
+	if liveOutpoints == 0 {
+		// Every pending row references an outpoint that is no longer
+		// Confirmed. The Board these rows belonged to has already
+		// completed; sweep them so the next start is a no-op.
+		if err := a.store.ClearAllPendingBoardRequests(
+			ctx,
+		); err != nil {
+			return fmt.Errorf("clear stale pending board "+
+				"requests: %w", err)
+		}
+
+		a.logger(ctx).InfoS(
+			ctx,
+			"Cleared stale pending Board rows on startup",
+			slog.Int("stale_row_count", len(pending)),
+		)
+
+		return nil
+	}
+
+	a.logger(ctx).InfoS(
+		ctx,
+		"Replaying persisted Board request after restart",
+		slog.Int("target_vtxo_count", int(liveTarget)),
+		slog.Int("live_outpoint_count", liveOutpoints),
+		slog.Int("stale_row_count", len(pending)-liveOutpoints),
+		slog.Int64("earliest_requested_at_unix", earliestRequestedAt),
+	)
+
+	// Self-Tell the BoardRequest. handleBoard will re-walk the confirmed
+	// set, re-persist rows with a fresh timestamp, and Tell the round
+	// actor. The self-Tell lands in the wallet's mailbox BEFORE any
+	// gRPC-driven BoardRequest because Start runs synchronously before
+	// the actor system starts dispatching external messages.
+	err = selfRef.Tell(ctx, &BoardRequest{
+		TargetVTXOCount: liveTarget,
+	})
+	if err != nil {
+		return fmt.Errorf("self-tell pending board request: %w", err)
+	}
+
+	return nil
 }
 
 // splitBoardingAmount fans a confirmed boarding balance into count VTXO

--- a/wallet/wallet_admission_test.go
+++ b/wallet/wallet_admission_test.go
@@ -3,6 +3,7 @@ package wallet
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -366,6 +367,14 @@ func TestSelectAndLockNoActorSystem(t *testing.T) {
 // mockRoundActorBehavior implements actor.ActorBehavior for the round actor
 // service key type. It responds to RegisterIntentMsg with a configurable
 // error, enabling wallet handler tests without a real round actor.
+//
+// The TriggerBoardMsg counter is updated from the actor's goroutine and
+// read from test goroutines via TriggerBoardCalls(), so it MUST be
+// accessed under a mutex; the wallet's Tell-based dispatch to the round
+// actor is asynchronous, so a poll-based test (require.Eventually) would
+// otherwise race the actor's Receive loop. The same mutex covers the
+// captured-message pointer because pointer assignment is not atomic on
+// 64-bit reads/writes.
 type mockRoundActorBehavior struct {
 	// registerErr when set causes RegisterIntentMsg to fail.
 	registerErr error
@@ -376,6 +385,34 @@ type mockRoundActorBehavior struct {
 	// capturedIntent holds the last RegisterIntentMsg received, so
 	// tests can inspect the intent package contents.
 	capturedIntent *actormsg.RegisterIntentMsg
+
+	// mu guards the TriggerBoardMsg fields below. The RegisterIntentMsg
+	// fields above are safe without locking because every existing
+	// caller drives them through an Ask/Await that synchronously
+	// publishes the actor-goroutine write before the test goroutine
+	// reads. The TriggerBoardMsg path is Tell-based, so it needs an
+	// explicit happens-before edge for the test to observe.
+	mu sync.Mutex
+
+	// triggerBoardCalls tracks how many times TriggerBoardMsg was
+	// received, so Board / replay tests can assert the round actor was
+	// (or was not) re-tickled. Read under mu.
+	triggerBoardCalls int
+
+	// capturedTriggerBoard holds the last TriggerBoardMsg received so
+	// tests can inspect the VTXO amounts and target count handed
+	// across. Read under mu.
+	capturedTriggerBoard *actormsg.TriggerBoardMsg
+}
+
+// TriggerBoardCalls returns a snapshot of triggerBoardCalls under the
+// mock's mutex so test goroutines can poll the counter without racing
+// the actor's Receive loop.
+func (m *mockRoundActorBehavior) TriggerBoardCalls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.triggerBoardCalls
 }
 
 // Receive processes round actor messages from the wallet.
@@ -392,6 +429,14 @@ func (m *mockRoundActorBehavior) Receive(_ context.Context,
 				m.registerErr,
 			)
 		}
+
+		return fn.Ok[actormsg.RoundActorResp](nil)
+
+	case *actormsg.TriggerBoardMsg:
+		m.mu.Lock()
+		m.triggerBoardCalls++
+		m.capturedTriggerBoard = typedMsg
+		m.mu.Unlock()
 
 		return fn.Ok[actormsg.RoundActorResp](nil)
 

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -206,6 +206,42 @@ func (m *MockBoardingStore) LookupIntentByScript(ctx context.Context,
 	return args.Get(0).(*BoardingIntent), args.Error(1)
 }
 
+func (m *MockBoardingStore) UpsertPendingBoardRequests(ctx context.Context,
+	reqs []PendingBoardRequest) error {
+
+	args := m.Called(ctx, reqs)
+
+	return args.Error(0)
+}
+
+func (m *MockBoardingStore) ListPendingBoardRequests(ctx context.Context) (
+	[]PendingBoardRequest, error) {
+
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	//nolint:forcetypeassert
+	return args.Get(0).([]PendingBoardRequest), args.Error(1)
+}
+
+func (m *MockBoardingStore) ClearPendingBoardRequestByOutpoint(
+	ctx context.Context, outpoint wire.OutPoint) error {
+
+	args := m.Called(ctx, outpoint)
+
+	return args.Error(0)
+}
+
+func (m *MockBoardingStore) ClearAllPendingBoardRequests(
+	ctx context.Context) error {
+
+	args := m.Called(ctx)
+
+	return args.Error(0)
+}
+
 // mockChainSourceBehavior implements actor.ActorBehavior for testing.
 type mockChainSourceBehavior struct {
 	epochChan chan chainsource.BlockEpoch


### PR DESCRIPTION
In this PR, we fix [#416](https://github.com/lightninglabs/darepo-client/issues/416): a `darepocli board` call that returned `registered` was silently dropped on daemon restart. The user saw a confirmed boarding balance, the CLI happily reported the request was accepted, and the next `darepocli rounds watch` came back empty because the round actor only checkpoints state at the InputSigSent point of no return. Every prior step lived in memory, so a restart between admission and seal wiped the in-flight registration and the user's intent with it.

The shape of the fix is to persist the user's Board intent (not the round FSM) and replay it on the next start. A single-row `pending_board_requests` table records the request as soon as `handleBoard` admits it, and the daemon's startup path asks the wallet to re-issue `TriggerBoardMsg` once the round actor is registered. When confirmed boarding intents have already transitioned to Adopted/Swept (the prior round actually completed before restart), the wallet clears the row instead of replaying. See each commit message for a detailed description w.r.t the incremental changes.

This PR pairs with [lightninglabs/darepo#XXX](https://github.com/lightninglabs/darepo) which teaches the server's `IntentCollectingState` to treat a same-client re-join as a replacement rather than rejecting it as `client already registered`. Both sides are needed: the client-side replay alone bounces off the operator while the pre-restart registration is still alive in the round's IntentCollectingState, and the server-side replacement alone doesn't help if the client never reissues. The integration test in the paired darepo PR drives the full restart-recovery scenario end to end.

## Ordering invariant

The single subtle thing in `handleBoard` is the order: we persist the row _before_ telling the round actor, not after. The persist-first ordering closes the only window where a crash could leave the round actor holding an in-memory intent with no on-disk marker. Under the new ordering, every crash window converges: pre-persist crashes are a no-op, post-persist pre-Tell crashes replay on next start, post-Tell crashes also replay on next start, and a Tell failure after persist leaves the row in place so the next startup retries. If persistence itself fails we return the error rather than silently admitting an unrecoverable request.

## Replay through `handleBoard` (not a synthetic Tell)

The replay path re-issues `BoardRequest` through the same `handleBoard` entry that the live RPC uses, rather than synthesising a `TriggerBoardMsg` directly. Two reasons. First, this keeps the persistence write inside the same handler, so a replay followed by another crash before seal leaves a fresh pending row with an updated `requested_at_unix` timestamp. Second, any future invariant added to `handleBoard` (extra pre-flight checks, side effects, etc.) automatically applies to the recovery path without a second integration point.

## Schema choice

The migration uses `PRIMARY KEY (id)` + `CHECK (id = 1)` in a separate clause rather than the inline `INTEGER PRIMARY KEY` form. The SQLite -> Postgres replacer (in `db/migrate/migrations.go`) rewrites the inline form to `BIGSERIAL PRIMARY KEY`, which would otherwise allocate an unused sequence under Postgres. We declare the constraint explicitly to side-step that.

## Test plan

- [x] `make unit pkg=./db case=TestPendingBoardRequestRoundTrip` pins down the store contract (empty -> None, upsert durable, second upsert replaces, clear is idempotent).
- [x] `make unit pkg=./wallet ./db ./darepod` (all green, no regressions).
- [x] `make lint-native` clean.
- [x] Restart-recovery itest in the paired darepo PR passes end to end (board -> restart -> replay observable -> manual `TriggerBatch` -> confirmed VTXO).
- [x] Existing restart itests (`TestBoardingIntegrationRestartAfterRoundBroadcast`, `TestBoardingIntegrationRestartAfterInputSigSent`) still pass.