### PR TITLE
[codex] unroll: use conservative proof watch height

### DIFF
--- a/unroll/actor.go
+++ b/unroll/actor.go
@@ -396,6 +396,12 @@ func safeTxOutPkScript(tx *wire.MsgTx, index uint32) ([]byte, error) {
 	return append([]byte(nil), tx.TxOut[index].PkScript...), nil
 }
 
+// proofNodeHeightHint is the earliest safe confirmation height hint for
+// proof-graph transactions. Roots and intermediate OOR checkpoint ancestors
+// can confirm before the target descriptor's CreatedHeight, so proof watches
+// must not use the target creation height as a lower bound.
+const proofNodeHeightHint uint32 = 1
+
 // ensureNodeConfirmed hands one ready proof-graph node to txconfirm and
 // threads any immediate rejection back through the FSM.
 //
@@ -427,6 +433,7 @@ func (b *behavior) ensureNodeConfirmed(ctx context.Context, txid chainhash.Hash,
 		Tx:                   node.Tx,
 		ConfirmationPkScript: pkScript,
 		Label:                "unroll-node-" + txid.String(),
+		HeightHint:           proofNodeHeightHint,
 		Subscriber:           b.notificationRef(),
 	}).Await(ctx).Unpack()
 	if err != nil {
@@ -475,23 +482,13 @@ func (b *behavior) watchDeferredCheckpoint(ctx context.Context,
 		},
 	)
 
-	state, err := b.currentState()
-	if err != nil {
-		return err
-	}
-
-	height := stateHeight(state)
-	if height < 0 {
-		height = 0
-	}
-
 	txidCopy := txid
 	_, err = b.cfg.ChainSource.Ask(ctx, &chainsource.RegisterConfRequest{
 		CallerID:    b.deferredCheckpointCallerID(),
 		Txid:        &txidCopy,
 		PkScript:    append([]byte(nil), pkScript...),
 		TargetConfs: 1,
-		HeightHint:  uint32(height),
+		HeightHint:  proofNodeHeightHint,
 		NotifyActor: fn.Some(notifyRef),
 	}).Await(ctx).Unpack()
 	if err != nil {
@@ -1018,21 +1015,7 @@ func (b *behavior) routeOutbox(ctx context.Context,
 						"missing on reissue", txid)
 				}
 
-				pkScript, err := safeTxOutPkScript(node.Tx, 0)
-				if err != nil {
-					return fmt.Errorf("proof node %s: %w",
-						txid, err)
-				}
-
-				_, err = b.cfg.TxConfirmRef.Ask(
-					ctx, &txconfirm.EnsureConfirmedReq{
-						Tx:                   node.Tx,
-						ConfirmationPkScript: pkScript,
-						Label: "unroll-node-" +
-							txid.String(),
-						Subscriber: b.notificationRef(),
-					},
-				).Await(ctx).Unpack()
+				err := b.ensureNodeConfirmed(ctx, txid, node)
 				if err != nil {
 					return err
 				}

--- a/unroll/actor_test.go
+++ b/unroll/actor_test.go
@@ -207,6 +207,26 @@ func (f *fakeTxConfirmRef) lastRequest(
 	return f.requests[len(f.requests)-1]
 }
 
+// requestByTxid returns the first txconfirm request matching txid.
+func (f *fakeTxConfirmRef) requestByTxid(t *testing.T,
+	txid chainhash.Hash) *txconfirm.EnsureConfirmedReq {
+
+	t.Helper()
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	for _, req := range f.requests {
+		if req.Tx.TxHash() == txid {
+			return req
+		}
+	}
+
+	require.Failf(t, "txconfirm request not found", "txid=%s", txid)
+
+	return nil
+}
+
 // requestCount returns the number of recorded ensure requests.
 func (f *fakeTxConfirmRef) requestCount() int {
 	f.mu.Lock()
@@ -346,6 +366,9 @@ func (f *fakeTxConfirmRef) emitFailed(t *testing.T, index int,
 // confRef aliases the chainsource confirmation notification target.
 type confRef = actor.TellOnlyRef[chainsource.ConfirmationEvent]
 
+// confReq aliases the chainsource confirmation request.
+type confReq = chainsource.RegisterConfRequest
+
 // fakeChainSourceRef is a minimal chainsource actor ref for sweep fee
 // estimation tests.
 type fakeChainSourceRef struct {
@@ -356,6 +379,7 @@ type fakeChainSourceRef struct {
 	blockRef   actor.TellOnlyRef[chainsource.BlockEpoch]
 	spendRef   actor.TellOnlyRef[chainsource.SpendEvent]
 	confRefs   map[chainhash.Hash]confRef
+	confReqs   map[chainhash.Hash]*confReq
 }
 
 // ID returns the fake actor ID.
@@ -462,7 +486,16 @@ func (f *fakeChainSourceRef) Ask(_ context.Context,
 		if f.confRefs == nil {
 			f.confRefs = make(map[chainhash.Hash]confRef)
 		}
+		if f.confReqs == nil {
+			f.confReqs = map[chainhash.Hash]*confReq{}
+		}
+
+		reqCopy := *msg
+		txidCopy := *msg.Txid
+		reqCopy.Txid = &txidCopy
+		reqCopy.PkScript = append([]byte(nil), msg.PkScript...)
 		f.confRefs[*msg.Txid] = msg.NotifyActor.UnwrapOr(nil)
+		f.confReqs[*msg.Txid] = &reqCopy
 		f.mu.Unlock()
 		promise.Complete(
 			fn.Ok[chainsource.ChainSourceResp](
@@ -488,6 +521,21 @@ func (f *fakeChainSourceRef) confWatchCount() int {
 	defer f.mu.Unlock()
 
 	return len(f.confRefs)
+}
+
+// confRequest returns the registered confirmation request for txid.
+func (f *fakeChainSourceRef) confRequest(t *testing.T,
+	txid chainhash.Hash) *confReq {
+
+	t.Helper()
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	req := f.confReqs[txid]
+	require.NotNil(t, req)
+
+	return req
 }
 
 // emitConfirmed delivers one chainsource confirmation event to a watcher.
@@ -1180,6 +1228,7 @@ func TestStartUnrollSubmitsInitialFrontier(t *testing.T) {
 func TestFraudTriggerDefersReadyCheckpoint(t *testing.T) {
 	proof := buildOORProof(t)
 	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	desc.CreatedHeight = 77
 	unrollActor, behavior, txconfirmRef, store := newActorHarness(
 		t, proof, desc,
 	)
@@ -1193,6 +1242,10 @@ func TestFraudTriggerDefersReadyCheckpoint(t *testing.T) {
 
 	require.Equal(t, 0, txconfirmRef.requestCount())
 	require.Equal(t, 1, chainRef.confWatchCount())
+	require.Equal(
+		t, uint32(1),
+		chainRef.confRequest(t, proof.RootTxids()[0]).HeightHint,
+	)
 
 	checkpoint := mustDecodeCheckpoint(t, store, "unroll-test")
 	require.Len(t, checkpoint.DeferredCheckpoints, 1)
@@ -1214,6 +1267,11 @@ func TestFraudTriggerDefersReadyCheckpoint(t *testing.T) {
 		t, proof.RootTxids()[0],
 		txconfirmRef.lastRequest(t).Tx.TxHash(),
 	)
+	require.Equal(
+		t, uint32(1), txconfirmRef.requestByTxid(
+			t, proof.RootTxids()[0],
+		).HeightHint,
+	)
 
 	checkpoint = mustDecodeCheckpoint(t, store, "unroll-test")
 	require.Len(t, checkpoint.DeferredCheckpoints, 0)
@@ -1229,6 +1287,7 @@ func TestFraudTriggerDefersReadyCheckpoint(t *testing.T) {
 func TestFraudTriggerOperatorConfirmedCheckpointUnlocksArk(t *testing.T) {
 	proof := buildOORProof(t)
 	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	desc.CreatedHeight = 77
 	unrollActor, behavior, txconfirmRef, _ := newActorHarness(
 		t, proof, desc,
 	)
@@ -1248,6 +1307,11 @@ func TestFraudTriggerOperatorConfirmedCheckpointUnlocksArk(t *testing.T) {
 	require.Equal(
 		t, proof.TargetOutpoint().Hash,
 		txconfirmRef.lastRequest(t).Tx.TxHash(),
+	)
+	require.Equal(
+		t, uint32(1), txconfirmRef.requestByTxid(
+			t, proof.TargetOutpoint().Hash,
+		).HeightHint,
 	)
 }
 
@@ -1342,6 +1406,7 @@ func TestFraudTriggerSharedCheckpointsBroadcastOnceAtDeadline(t *testing.T) {
 func TestResumeReissuesDeferredCheckpointWatch(t *testing.T) {
 	proof := buildOORProof(t)
 	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	desc.CreatedHeight = 77
 	store := newMemCheckpointStore()
 	txconfirmRef := &fakeTxConfirmRef{}
 	chainRef := &fakeChainSourceRef{}
@@ -1403,6 +1468,9 @@ func TestResumeReissuesDeferredCheckpointWatch(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return chainRef.confWatchCount() == 1
 	}, testTimeout, 10*time.Millisecond)
+	require.Equal(
+		t, uint32(1), chainRef.confRequest(t, rootTxid).HeightHint,
+	)
 	require.Equal(t, 0, txconfirmRef.requestCount())
 
 	mustAsk(t, resumedActor.Ref(), &HeightObservedMsg{Height: 219})
@@ -1413,6 +1481,10 @@ func TestResumeReissuesDeferredCheckpointWatch(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return txconfirmRef.requestCountForTxid(rootTxid) == 1
 	}, testTimeout, 10*time.Millisecond)
+	require.Equal(
+		t, uint32(1),
+		txconfirmRef.requestByTxid(t, rootTxid).HeightHint,
+	)
 }
 
 // TestResumeReissuesInFlightArk verifies a fraud-triggered restart reattaches
@@ -1420,6 +1492,7 @@ func TestResumeReissuesDeferredCheckpointWatch(t *testing.T) {
 func TestResumeReissuesInFlightArk(t *testing.T) {
 	proof := buildOORProof(t)
 	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	desc.CreatedHeight = 77
 	store := newMemCheckpointStore()
 	txconfirmRef := &fakeTxConfirmRef{}
 	rootTxid := proof.RootTxids()[0]
@@ -1480,6 +1553,9 @@ func TestResumeReissuesInFlightArk(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return txconfirmRef.requestCountForTxid(arkTxid) == 1
 	}, testTimeout, 10*time.Millisecond)
+	require.Equal(
+		t, uint32(1), txconfirmRef.requestByTxid(t, arkTxid).HeightHint,
+	)
 }
 
 // TestManualTriggerSubmitsReadyCheckpointImmediately verifies the deferral


### PR DESCRIPTION
## Summary

Use the earliest chain height as the confirmation height hint for unroll proof-graph transactions and deferred checkpoint watches. The restart reissue path routes through the same proof-node confirmation helper, so reattached watches use the same conservative hint.

Target spend watches and final sweep confirmation watches keep their existing tighter hints.

## Root Cause

Fraud-triggered unroll can discover proof transactions after another actor or test flow has already mined them. The previous current-height hint caused lnd confirmation subscriptions to miss historical confirmations, which could strand the unroll actor waiting for callbacks that never arrived.

A target descriptor creation height is also not conservative enough for every proof node, because roots and intermediate OOR checkpoint ancestors can confirm before the target VTXO is created.

## Validation

- `go test ./unroll`
- `make fmt-changed`
- `make lint-changed-local`
- `make itest icase=TestRecipientFraudMultihopRatchet` from the parent `darepo` checkout
