### PR TITLE
docs: nightly doc-gardening sweep 2026-05-14

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -16,7 +16,8 @@ package may import from a higher layer.
 | [`round`](round/) | Client-side Ark round participation FSM (boarding, refresh, leave) |
 | [`vtxo`](vtxo/) | VTXO lifecycle FSM (live, forfeiting, forfeited, spent, expiring) |
 | [`oor`](oor/) | Out-of-round transfer coordination FSM |
-| [`wallet`](wallet/) | On-chain boarding wallet actor (address derivation, UTXO monitoring) |
+| [`wallet`](wallet/) | On-chain boarding wallet actor (address derivation, UTXO monitoring, boarding-timeout sweep) |
+| [`fraud`](fraud/) | Recipient fraud watcher: detects ancestor spends on OOR VTXOs and triggers unilateral exit |
 | [`ledger`](ledger/) | Client-side durable ledger actor for double-entry fee accounting |
 | [`lib`](lib/) | Shared domain utilities: tree paths, BIP-322, arkscript policy, types |
 | [`lib/arkscript`](lib/arkscript/) | Tapscript AST compiler and policy system for Ark taproot outputs |
@@ -41,7 +42,7 @@ package may import from a higher layer.
 | [`lndbackend`](lndbackend/) | `BoardingBackend` implementation via LND's wallet kit |
 | [`lwwallet`](lwwallet/) | Lightweight in-process wallet (btcwallet + Esplora, no external LND) |
 | [`btcwbackend`](btcwbackend/) | Neutrino-backed wallet backend (btcwallet + compact block filters) |
-| [`walletcore`](walletcore/) | Shared wallet abstractions and boarding logic used by lwwallet and btcwbackend |
+| [`walletcore`](walletcore/) | Shared wallet abstractions (LockID, OutputLeaser, Utxo) and boarding logic used by lwwallet, btcwbackend, and txconfirm |
 | [`proofkeys`](proofkeys/) | Interface for wallet-managed key derivation and indexer proof signing |
 | [`db`](db/) | SQLite/PostgreSQL persistence: boarding, rounds, VTXOs, OOR artifacts, fee ledger |
 | [`mailbox`](mailbox/) | Mailbox protocol primitives across three sub-packages (pb, rpc, conn) |
@@ -72,6 +73,7 @@ package may import from a higher layer.
 | [`systest`](systest/) | System-level end-to-end tests |
 | [`internal/actortest`](internal/actortest/) | Durable actor integration tests with real DB backends |
 | [`internal/testutils`](internal/testutils/) | Deterministic key/signature generation for tests |
+| [`internal/indexerlimits`](internal/indexerlimits/) | Client-side cursor byte-length bounds for indexer pagination queries |
 | [`rules`](rules/) | ast-grep linting rules for code style enforcement |
 | [`tools`](tools/) | Development tool dependencies (protoc plugins, sqlc) |
 | [`cmd/protoc-gen-mailboxrpc`](cmd/protoc-gen-mailboxrpc/) | `protoc` plugin generating typed `mailbox/rpc` client/server stubs from `.proto` service definitions |

--- a/chainbackends/AGENTS.md
+++ b/chainbackends/AGENTS.md
@@ -26,7 +26,9 @@ estimation, and optional v3 package relay via a pluggable `PackageSubmitter`.
   timeout and goroutine-based forwarding to bridge lndclient's height-only
   block events to the full `chainntnfs` interface.
 - `LNDBackendFromLndClientConfig` — Config struct for building an `LNDBackend`
-  from lndclient services (notifier, wallet kit, chain kit).
+  from lndclient services (notifier, wallet kit, chain kit). Includes an
+  optional `Log fn.Option[btclog.Logger]` field; when None, falls back to
+  `build.LoggerFromContext(ctx)` at call time.
 - `NewLNDBackendFromLndClient(cfg)` — Factory constructing a full `LNDBackend`
   from an `LNDBackendFromLndClientConfig`.
 - `PackageTxError` — Per-tx result error from a `SubmitPackage` response.

--- a/chainbackends/CLAUDE.md
+++ b/chainbackends/CLAUDE.md
@@ -26,7 +26,9 @@ estimation, and optional v3 package relay via a pluggable `PackageSubmitter`.
   timeout and goroutine-based forwarding to bridge lndclient's height-only
   block events to the full `chainntnfs` interface.
 - `LNDBackendFromLndClientConfig` — Config struct for building an `LNDBackend`
-  from lndclient services (notifier, wallet kit, chain kit).
+  from lndclient services (notifier, wallet kit, chain kit). Includes an
+  optional `Log fn.Option[btclog.Logger]` field; when None, falls back to
+  `build.LoggerFromContext(ctx)` at call time.
 - `NewLNDBackendFromLndClient(cfg)` — Factory constructing a full `LNDBackend`
   from an `LNDBackendFromLndClientConfig`.
 - `PackageTxError` — Per-tx result error from a `SubmitPackage` response.

--- a/chainsource/AGENTS.md
+++ b/chainsource/AGENTS.md
@@ -38,6 +38,13 @@ communication alongside the raw registration API.
 - `MapBlockEpoch`, `MapConfirmationEvent`, `MapSpendEvent` — Generic helpers
   that wrap a target `TellOnlyRef[Out]` and a mapping function, producing a
   `TellOnlyRef` of the source event type for actor-to-actor notification wiring.
+- `IsIgnorableBroadcastError(err error) bool` — Classifies re-broadcast errors
+  as non-fatal: already-known, already-confirmed, already-in-mempool,
+  insufficient-fee, output-already-spent. Uses both `errors.Is` sentinel
+  matching and substring checks.
+- `IsIgnorableMempoolRejectReason(reason string) bool` — Classifies
+  `testmempoolaccept` reject reasons as ignorable when the tx is already known
+  or confirmed.
 
 ## Relationships
 

--- a/chainsource/CLAUDE.md
+++ b/chainsource/CLAUDE.md
@@ -38,6 +38,13 @@ communication alongside the raw registration API.
 - `MapBlockEpoch`, `MapConfirmationEvent`, `MapSpendEvent` — Generic helpers
   that wrap a target `TellOnlyRef[Out]` and a mapping function, producing a
   `TellOnlyRef` of the source event type for actor-to-actor notification wiring.
+- `IsIgnorableBroadcastError(err error) bool` — Classifies re-broadcast errors
+  as non-fatal: already-known, already-confirmed, already-in-mempool,
+  insufficient-fee, output-already-spent. Uses both `errors.Is` sentinel
+  matching and substring checks.
+- `IsIgnorableMempoolRejectReason(reason string) bool` — Classifies
+  `testmempoolaccept` reject reasons as ignorable when the tx is already known
+  or confirmed.
 
 ## Relationships
 

--- a/cmd/darepocli/darepoclicommands/AGENTS.md
+++ b/cmd/darepocli/darepoclicommands/AGENTS.md
@@ -84,6 +84,15 @@ The daemon owns the background worker; CLI exit does not cancel an admitted swap
 | `swap resume` | `ResumeSwap` | Wake up a persisted swap worker (idempotent) |
 | `swap watch` | `SubscribeSwaps` | Stream coarse swap summary updates; `--existing` emits current rows first |
 
+### Wallet commands (`cmd_wallet.go`)
+
+| Command | RPC | Description |
+|---------|-----|-------------|
+| `wallet create` | `CreateWallet` | Create a new wallet from fresh aezeed seed. Password from stdin, env var (`WALLET_PASSWORD`), or `--wallet_password_file`. Optional `--seed_passphrase` |
+| `wallet unlock` | `UnlockWallet` | Unlock an existing wallet |
+| `wallet balance` | `GetBalance` | Show wallet balance |
+| `wallet newaddress` | `NewAddress` | Derive a new wallet address |
+
 ### Direct-client swap commands (`cmd_swap.go`, `swapdirect && !swapruntime` tag)
 
 Standalone swap execution without a running daemon. Connects directly to the

--- a/cmd/darepocli/darepoclicommands/CLAUDE.md
+++ b/cmd/darepocli/darepoclicommands/CLAUDE.md
@@ -84,6 +84,15 @@ The daemon owns the background worker; CLI exit does not cancel an admitted swap
 | `swap resume` | `ResumeSwap` | Wake up a persisted swap worker (idempotent) |
 | `swap watch` | `SubscribeSwaps` | Stream coarse swap summary updates; `--existing` emits current rows first |
 
+### Wallet commands (`cmd_wallet.go`)
+
+| Command | RPC | Description |
+|---------|-----|-------------|
+| `wallet create` | `CreateWallet` | Create a new wallet from fresh aezeed seed. Password from stdin, env var (`WALLET_PASSWORD`), or `--wallet_password_file`. Optional `--seed_passphrase` |
+| `wallet unlock` | `UnlockWallet` | Unlock an existing wallet |
+| `wallet balance` | `GetBalance` | Show wallet balance |
+| `wallet newaddress` | `NewAddress` | Derive a new wallet address |
+
 ### Direct-client swap commands (`cmd_swap.go`, `swapdirect && !swapruntime` tag)
 
 Standalone swap execution without a running daemon. Connects directly to the

--- a/darepod/AGENTS.md
+++ b/darepod/AGENTS.md
@@ -42,10 +42,26 @@ gRPC API.
 - `proxyUpstreamError(err, msg) error` — gRPC-safety helper that extracts the upstream gRPC status, preserves the code, and returns a new status carrying a generic RPC-scoped message. Errors without a status map to `codes.Unavailable` so clients can retry. Used by `EstimateFee` and `GetFeeHistory` to avoid collapsing codes to `Unknown` and leaking operator-side error text across the daemon→client boundary.
 - `quoteOperatorFee` — Internal helper that asks the operator's `ArkService.EstimateFee` via direct gRPC and returns `TotalFeeSat` as a `btcutil.Amount`. Called by `Board` and `SendVTXO` so the client's implicit fee matches the server's `validateOperatorFee` under the seal-time fee schedule. Returns zero when `serverConn` is nil (degraded mode).
 - `autoRefreshFeeQuoter` — Returns a `vtxo.RefreshFeeQuoter` closure wired into every VTXO actor for auto-refresh fee estimation. Advisory only under the #270 seal-time handshake: the closure's return value is carried on `RefreshVTXORequest.OperatorFee` for observability but is not written to the intent; the server's seal-time compute is authoritative. Falls back to `terms.MinOperatorFee` when the operator is unreachable.
-- `SweepBoardingUTXOs` — RPC handler that sweeps CSV-mature boarding UTXOs back to the wallet. Resolves candidates (explicit outpoints or all confirmed/failed/expired intents), estimates the fee, builds and signs an aggregate boarding sweep tx via `buildBoardingSweepTx`, persists the record, broadcasts it, and wakes the `boardingSweepWatcher` to register spend watches. Returns a preview (no broadcast) when `broadcast=false` or no mature outputs exist.
-- `ListBoardingSweeps` — RPC handler that returns paginated persisted aggregate boarding sweeps, with optional status filter and cursor-based pagination via a numeric offset token.
-- `boardingSweepWatcher` — Daemon-owned background watcher that resumes pending boarding sweeps on startup, rate-limited rebroadcasts published sweeps, and registers chain spend notifications via `chainsource.RegisterSpend` per input. Marks sweep inputs spent when confirmed. Started by `startBoardingSweepWatcher` on wallet unlock; idempotent so the unlock path is safe to call multiple times.
-- `boardingSweepTx` / `buildBoardingSweepTx` — Constructs and signs one aggregate timeout-path sweep transaction. Iterates the weight estimate up to three times until `SerializeSize` converges so the returned `fee` and `txid` are accurate. Validates fee-percent guard (`defaultBoardingSweepMaxFeePercent = 25%`) and input cap (`defaultBoardingSweepMaxInputs = 100`).
+- `SweepBoardingUTXOs` — RPC handler for boarding-timeout sweep. Validates
+  request (non-negative fee rate, wallet ready), parses optional outpoint
+  overrides, delegates the full sweep lifecycle to the wallet actor via
+  `walletRef.Ask(&wallet.SweepBoardingUTXOsRequest)`, and converts the wallet
+  response to proto. The wallet actor handles candidate loading, fee estimation,
+  tx building, persistence, broadcast, and spend-watch registration.
+- `ListBoardingSweeps` — RPC handler returning paginated persisted boarding
+  sweeps by reading the sweep store directly (no actor hop). Supports optional
+  status filter and cursor-based pagination via numeric offset. Default limit 100,
+  max 500.
+- `newBoardingStore` — Helper constructing `db.BoardingWalletStore` for the
+  wallet actor and direct RPC reads (`boarding_sweep.go`).
+- `newSweepWallet` — Helper creating the active backend adapter (lndUnrollWallet
+  / lwUnrollWallet / btcwUnrollWallet) satisfying both `unroll.SweepWallet` and
+  `wallet.SweepSigner` (`boarding_sweep.go`).
+- `ResolveIncomingMetadataFromIndexer` / `ResolveIncomingMetadataFromIndexerWithLimits`
+  — Helpers in `incoming_metadata.go` that query the indexer for incoming VTXO
+  lineage metadata during OOR materialization. Scan depth is bounded by
+  `ReceiveLimits.MaxVTXOMatches` (default enforced by `oor.DefaultReceiveLimits()`).
+  Returns `oor.IncomingVTXOMetadata` for VTXO store persistence.
 - `OORConfig` / `OORLimitsConfig` — Configuration block for the OOR actor's incoming receive safety caps (`MaxCheckpoints`, `MaxVTXOMatches`, `MaxMailboxItems`, `MaxMailboxScriptBytes`). `Config.OORReceiveLimits()` normalizes these into `oor.ReceiveLimits` for wiring into `ClientActorCfg.Limits`.
 - `deriveIdentityKeyEarly` — Derives the client's secp256k1 identity key from LND or lwwallet before mailbox transport starts. Propagates wallet-specific errors on failure.
 - `signMailboxAuth` — Produces Schnorr auth signature. LND path uses tagged Schnorr signing RPC (`withSchnorrTag`); lwwallet path signs locally via `serverconn.SignMailboxAuth`.
@@ -63,7 +79,12 @@ gRPC API.
 
 ## Relationships
 
-- **Depends on**: `baselib/actor` (ActorSystem), `btcwbackend`, `chainbackends`, `chainsource`, `lib/actormsg`, `db`, `ledger` (accounting actor), `round`, `txconfirm`, `unroll`, `vtxo`, `wallet`, `walletcore`, `oor`, `serverconn`, `indexer`, `arkrpc`, `lndbackend`, `harness` (bitcoind package submitter wiring in `cmd/darepod`).
+- **Depends on**: `baselib/actor` (ActorSystem), `btcwbackend`, `chainbackends`,
+  `chainsource`, `lib/actormsg`, `db`, `ledger`, `round`, `txconfirm`, `unroll`,
+  `vtxo`, `wallet` (boarding sweep delegation), `walletcore`, `oor`, `serverconn`,
+  `indexer` (incoming metadata resolution), `fraud` (recipient fraud watcher),
+  `arkrpc`, `lndbackend`, `harness` (bitcoind package submitter wiring in
+  `cmd/darepod`), `internal/indexerlimits` (cursor bounds validation).
 - **Depended on by**: `cmd/darepod` (main entry point).
 
 ## Invariants
@@ -98,8 +119,14 @@ gRPC API.
 - `Server.run` registers a deferred `s.unrollRegistry.Stop()` during startup so the registry's durable persist writer drains before the actor system tears down; without this the final checkpoint of in-flight jobs could race with shutdown.
 - `registerOOREventRoutes` checks for `*oorpb.SubmitRejectedError` before a generic error check on the submit-package response. A typed server-side rejection (e.g. `OOR_REJECT_LINEAGE_TOO_LARGE`) is converted to an `oor.OutboxErrorEvent{Retryable: false}` rather than surfaced as an Adapt error, preventing the serverconn ingress dispatcher from stalling the cursor on a sticky rejection that would replay indefinitely.
 - `Unroll` and `GetUnrollStatus` guard on `s.vtxoMgrRef.IsSome()` / `s.unrollRegistryRef.IsSome()` and return `codes.Unavailable` (not `Internal`) when the subsystem is not yet initialized so clients can retry rather than treat this as a permanent failure.
-- `SweepBoardingUTXOs` always persists the sweep record before broadcasting; on broadcast failure the record is marked failed so the watcher does not attempt rebroadcast. The spend watcher is refreshed via `getBoardingSweepWatcher().Refresh` (using `context.WithoutCancel`) immediately after a successful broadcast so spend notifications start without waiting for the next poll interval.
-- `boardingSweepWatcher` uses two cancellation scopes: the per-watcher `w.ctx` for spend registration and the per-refresh `ctx` for rebroadcast RPCs. Spend registration context must be the watcher lifetime so a CLI disconnect does not cancel live spend notifications.
+- `SweepBoardingUTXOs` RPC delegates the full sweep lifecycle to the wallet
+  actor. The daemon's role is request validation and proto conversion only.
+- `ListBoardingSweeps` reads the sweep store directly (no actor hop) for
+  CRUD-only retrieval. The wallet actor owns transactional writes; RPC owns
+  read-only queries to avoid mailbox congestion on list operations.
+- `ResolveIncomingMetadataFromIndexer` scan depth is bounded by
+  `ReceiveLimits.MaxVTXOMatches` to prevent unbounded traversal on adversarial
+  inputs.
 - `OORConfig.OOR.Limits` fields are validated during `Config.Validate()`; `MaxMailboxScriptBytes` must be at least `minOORMailboxScriptBytes = 34` (P2TR script length) to avoid silently rejecting all scripts.
 - `quoteOperatorFee` returns `codes.Unavailable` (not `codes.Internal`) when `serverConn` is nil so callers that can fall back to `MinOperatorFee` can distinguish transient from permanent failures.
 

--- a/darepod/CLAUDE.md
+++ b/darepod/CLAUDE.md
@@ -42,10 +42,26 @@ gRPC API.
 - `proxyUpstreamError(err, msg) error` — gRPC-safety helper that extracts the upstream gRPC status, preserves the code, and returns a new status carrying a generic RPC-scoped message. Errors without a status map to `codes.Unavailable` so clients can retry. Used by `EstimateFee` and `GetFeeHistory` to avoid collapsing codes to `Unknown` and leaking operator-side error text across the daemon→client boundary.
 - `quoteOperatorFee` — Internal helper that asks the operator's `ArkService.EstimateFee` via direct gRPC and returns `TotalFeeSat` as a `btcutil.Amount`. Called by `Board` and `SendVTXO` so the client's implicit fee matches the server's `validateOperatorFee` under the seal-time fee schedule. Returns zero when `serverConn` is nil (degraded mode).
 - `autoRefreshFeeQuoter` — Returns a `vtxo.RefreshFeeQuoter` closure wired into every VTXO actor for auto-refresh fee estimation. Advisory only under the #270 seal-time handshake: the closure's return value is carried on `RefreshVTXORequest.OperatorFee` for observability but is not written to the intent; the server's seal-time compute is authoritative. Falls back to `terms.MinOperatorFee` when the operator is unreachable.
-- `SweepBoardingUTXOs` — RPC handler that sweeps CSV-mature boarding UTXOs back to the wallet. Resolves candidates (explicit outpoints or all confirmed/failed/expired intents), estimates the fee, builds and signs an aggregate boarding sweep tx via `buildBoardingSweepTx`, persists the record, broadcasts it, and wakes the `boardingSweepWatcher` to register spend watches. Returns a preview (no broadcast) when `broadcast=false` or no mature outputs exist.
-- `ListBoardingSweeps` — RPC handler that returns paginated persisted aggregate boarding sweeps, with optional status filter and cursor-based pagination via a numeric offset token.
-- `boardingSweepWatcher` — Daemon-owned background watcher that resumes pending boarding sweeps on startup, rate-limited rebroadcasts published sweeps, and registers chain spend notifications via `chainsource.RegisterSpend` per input. Marks sweep inputs spent when confirmed. Started by `startBoardingSweepWatcher` on wallet unlock; idempotent so the unlock path is safe to call multiple times.
-- `boardingSweepTx` / `buildBoardingSweepTx` — Constructs and signs one aggregate timeout-path sweep transaction. Iterates the weight estimate up to three times until `SerializeSize` converges so the returned `fee` and `txid` are accurate. Validates fee-percent guard (`defaultBoardingSweepMaxFeePercent = 25%`) and input cap (`defaultBoardingSweepMaxInputs = 100`).
+- `SweepBoardingUTXOs` — RPC handler for boarding-timeout sweep. Validates
+  request (non-negative fee rate, wallet ready), parses optional outpoint
+  overrides, delegates the full sweep lifecycle to the wallet actor via
+  `walletRef.Ask(&wallet.SweepBoardingUTXOsRequest)`, and converts the wallet
+  response to proto. The wallet actor handles candidate loading, fee estimation,
+  tx building, persistence, broadcast, and spend-watch registration.
+- `ListBoardingSweeps` — RPC handler returning paginated persisted boarding
+  sweeps by reading the sweep store directly (no actor hop). Supports optional
+  status filter and cursor-based pagination via numeric offset. Default limit 100,
+  max 500.
+- `newBoardingStore` — Helper constructing `db.BoardingWalletStore` for the
+  wallet actor and direct RPC reads (`boarding_sweep.go`).
+- `newSweepWallet` — Helper creating the active backend adapter (lndUnrollWallet
+  / lwUnrollWallet / btcwUnrollWallet) satisfying both `unroll.SweepWallet` and
+  `wallet.SweepSigner` (`boarding_sweep.go`).
+- `ResolveIncomingMetadataFromIndexer` / `ResolveIncomingMetadataFromIndexerWithLimits`
+  — Helpers in `incoming_metadata.go` that query the indexer for incoming VTXO
+  lineage metadata during OOR materialization. Scan depth is bounded by
+  `ReceiveLimits.MaxVTXOMatches` (default enforced by `oor.DefaultReceiveLimits()`).
+  Returns `oor.IncomingVTXOMetadata` for VTXO store persistence.
 - `OORConfig` / `OORLimitsConfig` — Configuration block for the OOR actor's incoming receive safety caps (`MaxCheckpoints`, `MaxVTXOMatches`, `MaxMailboxItems`, `MaxMailboxScriptBytes`). `Config.OORReceiveLimits()` normalizes these into `oor.ReceiveLimits` for wiring into `ClientActorCfg.Limits`.
 - `deriveIdentityKeyEarly` — Derives the client's secp256k1 identity key from LND or lwwallet before mailbox transport starts. Propagates wallet-specific errors on failure.
 - `signMailboxAuth` — Produces Schnorr auth signature. LND path uses tagged Schnorr signing RPC (`withSchnorrTag`); lwwallet path signs locally via `serverconn.SignMailboxAuth`.
@@ -63,7 +79,12 @@ gRPC API.
 
 ## Relationships
 
-- **Depends on**: `baselib/actor` (ActorSystem), `btcwbackend`, `chainbackends`, `chainsource`, `lib/actormsg`, `db`, `ledger` (accounting actor), `round`, `txconfirm`, `unroll`, `vtxo`, `wallet`, `walletcore`, `oor`, `serverconn`, `indexer`, `arkrpc`, `lndbackend`, `harness` (bitcoind package submitter wiring in `cmd/darepod`).
+- **Depends on**: `baselib/actor` (ActorSystem), `btcwbackend`, `chainbackends`,
+  `chainsource`, `lib/actormsg`, `db`, `ledger`, `round`, `txconfirm`, `unroll`,
+  `vtxo`, `wallet` (boarding sweep delegation), `walletcore`, `oor`, `serverconn`,
+  `indexer` (incoming metadata resolution), `fraud` (recipient fraud watcher),
+  `arkrpc`, `lndbackend`, `harness` (bitcoind package submitter wiring in
+  `cmd/darepod`), `internal/indexerlimits` (cursor bounds validation).
 - **Depended on by**: `cmd/darepod` (main entry point).
 
 ## Invariants
@@ -98,8 +119,14 @@ gRPC API.
 - `Server.run` registers a deferred `s.unrollRegistry.Stop()` during startup so the registry's durable persist writer drains before the actor system tears down; without this the final checkpoint of in-flight jobs could race with shutdown.
 - `registerOOREventRoutes` checks for `*oorpb.SubmitRejectedError` before a generic error check on the submit-package response. A typed server-side rejection (e.g. `OOR_REJECT_LINEAGE_TOO_LARGE`) is converted to an `oor.OutboxErrorEvent{Retryable: false}` rather than surfaced as an Adapt error, preventing the serverconn ingress dispatcher from stalling the cursor on a sticky rejection that would replay indefinitely.
 - `Unroll` and `GetUnrollStatus` guard on `s.vtxoMgrRef.IsSome()` / `s.unrollRegistryRef.IsSome()` and return `codes.Unavailable` (not `Internal`) when the subsystem is not yet initialized so clients can retry rather than treat this as a permanent failure.
-- `SweepBoardingUTXOs` always persists the sweep record before broadcasting; on broadcast failure the record is marked failed so the watcher does not attempt rebroadcast. The spend watcher is refreshed via `getBoardingSweepWatcher().Refresh` (using `context.WithoutCancel`) immediately after a successful broadcast so spend notifications start without waiting for the next poll interval.
-- `boardingSweepWatcher` uses two cancellation scopes: the per-watcher `w.ctx` for spend registration and the per-refresh `ctx` for rebroadcast RPCs. Spend registration context must be the watcher lifetime so a CLI disconnect does not cancel live spend notifications.
+- `SweepBoardingUTXOs` RPC delegates the full sweep lifecycle to the wallet
+  actor. The daemon's role is request validation and proto conversion only.
+- `ListBoardingSweeps` reads the sweep store directly (no actor hop) for
+  CRUD-only retrieval. The wallet actor owns transactional writes; RPC owns
+  read-only queries to avoid mailbox congestion on list operations.
+- `ResolveIncomingMetadataFromIndexer` scan depth is bounded by
+  `ReceiveLimits.MaxVTXOMatches` to prevent unbounded traversal on adversarial
+  inputs.
 - `OORConfig.OOR.Limits` fields are validated during `Config.Validate()`; `MaxMailboxScriptBytes` must be at least `minOORMailboxScriptBytes = 34` (P2TR script length) to avoid silently rejecting all scripts.
 - `quoteOperatorFee` returns `codes.Unavailable` (not `codes.Internal`) when `serverConn` is nil so callers that can fall back to `MinOperatorFee` can distinguish transient from permanent failures.
 

--- a/db/AGENTS.md
+++ b/db/AGENTS.md
@@ -77,7 +77,10 @@ backends.
   bounds enforced during `DeserializeTree` to prevent stack overflow or OOM.
 - `resolveInputPackage` / `loadPackageBundleBySessionID` — Two-stage OOR
   ancestry resolver in `oor_unroll_resolver.go`.
-- `LatestMigrationVersion = 11` — Current schema version.
+- `LatestMigrationVersion = 12` — Current schema version. Migration
+  `000012_boarding_sweeps` adds the `boarding_sweeps` aggregate transaction
+  table and `boarding_sweep_inputs` per-input status table, plus the
+  `sweep_pending` boarding-intent status.
 
 ## Relationships
 

--- a/db/CLAUDE.md
+++ b/db/CLAUDE.md
@@ -77,7 +77,10 @@ backends.
   bounds enforced during `DeserializeTree` to prevent stack overflow or OOM.
 - `resolveInputPackage` / `loadPackageBundleBySessionID` — Two-stage OOR
   ancestry resolver in `oor_unroll_resolver.go`.
-- `LatestMigrationVersion = 11` — Current schema version.
+- `LatestMigrationVersion = 12` — Current schema version. Migration
+  `000012_boarding_sweeps` adds the `boarding_sweeps` aggregate transaction
+  table and `boarding_sweep_inputs` per-input status table, plus the
+  `sweep_pending` boarding-intent status.
 
 ## Relationships
 

--- a/fraud/AGENTS.md
+++ b/fraud/AGENTS.md
@@ -1,0 +1,75 @@
+# fraud
+
+## Purpose
+
+Recipient-side fraud defense for OOR VTXOs. Passively watches ancestor
+outpoints in each VTXO's materialization tree and, when a spend is
+observed, triggers a durable unilateral-exit job so the operator cannot
+claim the VTXO against a stale ancestor.
+
+## Key Types
+
+- `WatcherActor` — Actor managing the set of passive ancestry spend
+  watches. One actor per daemon; starts via `NewWatcherActor`. Service
+  key: `ServiceKeyName` (`"recipient-fraud-watcher"`), retrieved via
+  `ServiceKey()`.
+- `WatcherConfig` — Wiring: `ChainSource` (spend watch registration),
+  `UnrollRef` (starts unroll jobs on fraud detection), optional `Log`,
+  `MailboxSize` (defaults to 64 to absorb reorg-burst spend bursts).
+- `WatchPlan` — Per-VTXO passive watch set: a `TargetOutpoint` plus a
+  slice of `WatchPoint`s (ancestor outpoints to arm in chainsource).
+- `WatchPoint` — One ancestor outpoint to watch: `Outpoint`,
+  `PkScript`, `HeightHint`.
+- `TrackVTXOsRequest` / `TrackVTXOsResp` — Batch-arm watches for a
+  slice of OOR VTXO descriptors. Skips non-OOR and non-live descriptors.
+- `UntrackRequest` / `UntrackResp` — Release watches for one VTXO
+  (idempotent; silent on unknown targets).
+- `SpendObservedMsg` / `AckResp` — Internal: chainsource spend event
+  routed back to the watcher's own mailbox.
+- `Msg` / `Resp` — Sealed actor message interfaces.
+- `BuildWatchPlan(desc *vtxo.Descriptor) (*WatchPlan, error)` — Pure
+  function that walks the ancestry tree and collects all on-path tree
+  inputs and leaf outputs as watch points.
+- `TrackVTXOs(ctx, tracker, descs)` — Fire-and-forget helper used by
+  darepod at startup to arm watches for all live descriptors.
+
+## Relationships
+
+- **Depends on**: `baselib/actor` (actor framework), `chainsource`
+  (RegisterSpendRequest / UnregisterSpendRequest), `unroll`
+  (EnsureUnrollRequest with TriggerFraudSpend), `vtxo` (Descriptor,
+  Status), `lib/tree` (ancestry graph traversal).
+- **Depended on by**: `darepod` (creates actor, calls `TrackVTXOs` at
+  startup, wires `TerminalVTXOObserver` to issue `UntrackRequest`).
+- **Sends**:
+  - → `chainsource` (Ask): `RegisterSpendRequest` per ancestor
+    (first reference), `UnregisterSpendRequest` (last reference).
+  - → `unroll` (Tell): `EnsureUnrollRequest{Trigger: TriggerFraudSpend}`
+    per target when a watched ancestor is confirmed spent.
+  - → self (Tell): `SpendObservedMsg` (chainsource spend callback mapped
+    back into the actor mailbox for sequential dispatch).
+- **Receives**:
+  - ← API: `TrackVTXOsRequest`, `UntrackRequest` (from `darepod`).
+  - ← chainsource (via mapped Tell): `SpendObservedMsg`.
+
+## Invariants
+
+- Ancestor watches are reference-counted by target VTXO set. The watch
+  is armed exactly once (on first target) and unregistered when the
+  last target releases it.
+- `UntrackRequest` is idempotent: missing targets produce
+  `UntrackResp{Removed: false}` without error.
+- Only OOR descriptors with `ChainDepth > 0` are tracked; boarding and
+  round-direct VTXOs have no preconfirmed ancestry to defend against.
+- Spend fan-out is per-target: one ancestor spend can trigger unroll jobs
+  for every VTXO that depends on it, each independently idempotent via
+  the unroll registry's dedup guard.
+- `BuildWatchPlan` is pure and synchronous; actor state mutations happen
+  only inside `Receive`.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.
+- [unroll/CLAUDE.md](../unroll/CLAUDE.md) — Unroll registry that handles
+  fraud-triggered jobs.
+- [chainsource/CLAUDE.md](../chainsource/CLAUDE.md) — Spend watch API.

--- a/fraud/CLAUDE.md
+++ b/fraud/CLAUDE.md
@@ -1,0 +1,75 @@
+# fraud
+
+## Purpose
+
+Recipient-side fraud defense for OOR VTXOs. Passively watches ancestor
+outpoints in each VTXO's materialization tree and, when a spend is
+observed, triggers a durable unilateral-exit job so the operator cannot
+claim the VTXO against a stale ancestor.
+
+## Key Types
+
+- `WatcherActor` — Actor managing the set of passive ancestry spend
+  watches. One actor per daemon; starts via `NewWatcherActor`. Service
+  key: `ServiceKeyName` (`"recipient-fraud-watcher"`), retrieved via
+  `ServiceKey()`.
+- `WatcherConfig` — Wiring: `ChainSource` (spend watch registration),
+  `UnrollRef` (starts unroll jobs on fraud detection), optional `Log`,
+  `MailboxSize` (defaults to 64 to absorb reorg-burst spend bursts).
+- `WatchPlan` — Per-VTXO passive watch set: a `TargetOutpoint` plus a
+  slice of `WatchPoint`s (ancestor outpoints to arm in chainsource).
+- `WatchPoint` — One ancestor outpoint to watch: `Outpoint`,
+  `PkScript`, `HeightHint`.
+- `TrackVTXOsRequest` / `TrackVTXOsResp` — Batch-arm watches for a
+  slice of OOR VTXO descriptors. Skips non-OOR and non-live descriptors.
+- `UntrackRequest` / `UntrackResp` — Release watches for one VTXO
+  (idempotent; silent on unknown targets).
+- `SpendObservedMsg` / `AckResp` — Internal: chainsource spend event
+  routed back to the watcher's own mailbox.
+- `Msg` / `Resp` — Sealed actor message interfaces.
+- `BuildWatchPlan(desc *vtxo.Descriptor) (*WatchPlan, error)` — Pure
+  function that walks the ancestry tree and collects all on-path tree
+  inputs and leaf outputs as watch points.
+- `TrackVTXOs(ctx, tracker, descs)` — Fire-and-forget helper used by
+  darepod at startup to arm watches for all live descriptors.
+
+## Relationships
+
+- **Depends on**: `baselib/actor` (actor framework), `chainsource`
+  (RegisterSpendRequest / UnregisterSpendRequest), `unroll`
+  (EnsureUnrollRequest with TriggerFraudSpend), `vtxo` (Descriptor,
+  Status), `lib/tree` (ancestry graph traversal).
+- **Depended on by**: `darepod` (creates actor, calls `TrackVTXOs` at
+  startup, wires `TerminalVTXOObserver` to issue `UntrackRequest`).
+- **Sends**:
+  - → `chainsource` (Ask): `RegisterSpendRequest` per ancestor
+    (first reference), `UnregisterSpendRequest` (last reference).
+  - → `unroll` (Tell): `EnsureUnrollRequest{Trigger: TriggerFraudSpend}`
+    per target when a watched ancestor is confirmed spent.
+  - → self (Tell): `SpendObservedMsg` (chainsource spend callback mapped
+    back into the actor mailbox for sequential dispatch).
+- **Receives**:
+  - ← API: `TrackVTXOsRequest`, `UntrackRequest` (from `darepod`).
+  - ← chainsource (via mapped Tell): `SpendObservedMsg`.
+
+## Invariants
+
+- Ancestor watches are reference-counted by target VTXO set. The watch
+  is armed exactly once (on first target) and unregistered when the
+  last target releases it.
+- `UntrackRequest` is idempotent: missing targets produce
+  `UntrackResp{Removed: false}` without error.
+- Only OOR descriptors with `ChainDepth > 0` are tracked; boarding and
+  round-direct VTXOs have no preconfirmed ancestry to defend against.
+- Spend fan-out is per-target: one ancestor spend can trigger unroll jobs
+  for every VTXO that depends on it, each independently idempotent via
+  the unroll registry's dedup guard.
+- `BuildWatchPlan` is pure and synchronous; actor state mutations happen
+  only inside `Receive`.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.
+- [unroll/CLAUDE.md](../unroll/CLAUDE.md) — Unroll registry that handles
+  fraud-triggered jobs.
+- [chainsource/CLAUDE.md](../chainsource/CLAUDE.md) — Spend watch API.

--- a/indexer/AGENTS.md
+++ b/indexer/AGENTS.md
@@ -10,6 +10,8 @@ proofs for proof-of-control.
 
 - `Client` — Wraps the mailbox RPC client with automatic proof-of-control
   signing. `WithSigner` returns a shallow copy using a different signer.
+  Optional `Log fn.Option[btclog.Logger]` field; when None, falls back to
+  `build.LoggerFromContext(ctx)` or `btclog.Disabled`.
 - `SchnorrSigner` — Interface for signing proof-of-control messages.
   Implementations: `PrivKeySchnorrSigner` (raw key), `LNDSchnorrSigner`
   (LND wallet), `KeyRingSchnorrSigner` (btcwallet keyring).

--- a/indexer/CLAUDE.md
+++ b/indexer/CLAUDE.md
@@ -10,6 +10,8 @@ proofs for proof-of-control.
 
 - `Client` — Wraps the mailbox RPC client with automatic proof-of-control
   signing. `WithSigner` returns a shallow copy using a different signer.
+  Optional `Log fn.Option[btclog.Logger]` field; when None, falls back to
+  `build.LoggerFromContext(ctx)` or `btclog.Disabled`.
 - `SchnorrSigner` — Interface for signing proof-of-control messages.
   Implementations: `PrivKeySchnorrSigner` (raw key), `LNDSchnorrSigner`
   (LND wallet), `KeyRingSchnorrSigner` (btcwallet keyring).

--- a/internal/indexerlimits/AGENTS.md
+++ b/internal/indexerlimits/AGENTS.md
@@ -1,0 +1,27 @@
+# internal/indexerlimits
+
+## Purpose
+
+Client-side resource bounds for indexer query pagination cursors. Enforces a
+byte-length cap on opaque cursor values returned by the remote indexer for
+`ListVTXOsByScripts` queries to prevent memory exhaustion or parse failures
+from a misbehaving server.
+
+## Key Types
+
+- `MaxVTXOsByScriptsCursorBytes` — Constant (256). Maximum opaque cursor byte
+  length accepted for `ListVTXOsByScripts` pagination. Current server cursor
+  is a 36-byte outpoint keyset; 256 leaves room for format evolution.
+- `ValidateVTXOsByScriptsCursor(cursor []byte) error` — Returns an error if
+  `len(cursor) > MaxVTXOsByScriptsCursorBytes`.
+
+## Relationships
+
+- **Depends on**: nothing (no internal imports).
+- **Depended on by**: `indexer` (validates cursors from remote indexer),
+  `serverconn` (validates cursors in durable unary query pagination),
+  `darepod` (validates cursors in incoming RPC metadata handlers).
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/internal/indexerlimits/CLAUDE.md
+++ b/internal/indexerlimits/CLAUDE.md
@@ -1,0 +1,27 @@
+# internal/indexerlimits
+
+## Purpose
+
+Client-side resource bounds for indexer query pagination cursors. Enforces a
+byte-length cap on opaque cursor values returned by the remote indexer for
+`ListVTXOsByScripts` queries to prevent memory exhaustion or parse failures
+from a misbehaving server.
+
+## Key Types
+
+- `MaxVTXOsByScriptsCursorBytes` — Constant (256). Maximum opaque cursor byte
+  length accepted for `ListVTXOsByScripts` pagination. Current server cursor
+  is a 36-byte outpoint keyset; 256 leaves room for format evolution.
+- `ValidateVTXOsByScriptsCursor(cursor []byte) error` — Returns an error if
+  `len(cursor) > MaxVTXOsByScriptsCursorBytes`.
+
+## Relationships
+
+- **Depends on**: nothing (no internal imports).
+- **Depended on by**: `indexer` (validates cursors from remote indexer),
+  `serverconn` (validates cursors in durable unary query pagination),
+  `darepod` (validates cursors in incoming RPC metadata handlers).
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/ledger/AGENTS.md
+++ b/ledger/AGENTS.md
@@ -51,6 +51,13 @@ accounts, see [docs/fee_ledger.md](../docs/fee_ledger.md).
 - `ExitCostMsg` — Records a unilateral exit as two ledger entries: a send leg (`transfers_out` debit, `vtxo_balance` credit) for the net-of-fee value and a fee leg (`onchain_fees` debit, `vtxo_balance` credit) for the miner fee. Together the credits reduce `vtxo_balance` by the gross exited amount. Wallet-side movement is covered separately by the `wallet_utxo_log` audit trail.
 - `UTXOCreatedMsg` — Records new wallet UTXO confirmations with classification. `handleUTXOCreated` writes TWO rows per event: a `wallet_utxo_log` audit row and a double-entry ledger row (`debit wallet_balance, credit opening_balance`, `event_type = wallet_utxo_created`) stamped with an outpoint-derived idempotency key via `walletUTXOIdempotencyKey`. The deposit leg is what gives `wallet_balance` a non-negative balance in the presence of `SourceRoundBoarding` outflows.
 - `UTXOSpentMsg` — Records wallet UTXO spends with classification. Currently only writes the `wallet_utxo_log` audit row (double-entry leg for non-boarding wallet spends is a planned follow-up).
+- `FeeTypeOnchainSweep` — Fee type for wallet-internal boarding-sweep L1 miner
+  fees. Books as `debit onchain_fees, credit wallet_balance` under event type
+  `EventBoardingSweepFeePaid`.
+- `ClassificationBoardingSweepInput` — UTXO audit classification for a boarding
+  input spent in a timeout-path aggregate sweep.
+- `ClassificationBoardingSweepReturn` — UTXO audit classification for a sweep
+  output that returns funds to a wallet-derived destination.
 
 ## Relationships
 
@@ -65,7 +72,11 @@ accounts, see [docs/fee_ledger.md](../docs/fee_ledger.md).
     one `FeePaidMsg{FeeType=FeeTypeRefresh}` per round when `VTXOCreatedNotification.OperatorFeeSat > 0` and any refresh-origin VTXO was present (boarding-fee emission deferred to a follow-up).
   - ← `oor`: `VTXOSentMsg` after FinalizeAcceptedEvent; `VTXOReceivedMsg` (`Source=SourceOOR`) per descriptor in `notifyMaterializedVTXOs`.
   - ← `vtxo`: `ExitCostMsg` after chain resolver determines miner fee (currently a no-op emission with a TODO — chain resolver wiring pending).
-  - ← `wallet`: `UTXOCreatedMsg` on confirmed wallet UTXO observation. `UTXOSpentMsg` emission is pending.
+  - ← `wallet`: `UTXOCreatedMsg` on confirmed wallet UTXO observation;
+    `UTXOSpentMsg` (boarding sweep inputs, `ClassificationBoardingSweepInput`);
+    `FeePaidMsg{FeeType=FeeTypeOnchainSweep}` on sweep confirmation;
+    optionally `UTXOCreatedMsg` for sweep output
+    (`ClassificationBoardingSweepReturn`) when destination is wallet-derived.
 
 ## Caller Contract
 
@@ -109,6 +120,13 @@ pairs of messages:
 - **Unilateral exit:** `ExitCostMsg` with `AmountSat` gross and
   `ExitCostSat` fee. The handler expands this into two ledger entries
   internally (send leg + fee leg).
+- **Boarding-sweep miner fee:** `FeePaidMsg` with `FeeType=FeeTypeOnchainSweep`.
+  Books `debit onchain_fees, credit wallet_balance`. Idempotency key carries
+  the sweep txid. Emitted by the wallet actor on sweep confirmation.
+  Sweep inputs also get `UTXOSpentMsg` with
+  `Classification=ClassificationBoardingSweepInput`; wallet-derived sweep
+  output gets `UTXOCreatedMsg` with
+  `Classification=ClassificationBoardingSweepReturn`.
 
 ## Invariants
 

--- a/ledger/CLAUDE.md
+++ b/ledger/CLAUDE.md
@@ -51,6 +51,13 @@ accounts, see [docs/fee_ledger.md](../docs/fee_ledger.md).
 - `ExitCostMsg` — Records a unilateral exit as two ledger entries: a send leg (`transfers_out` debit, `vtxo_balance` credit) for the net-of-fee value and a fee leg (`onchain_fees` debit, `vtxo_balance` credit) for the miner fee. Together the credits reduce `vtxo_balance` by the gross exited amount. Wallet-side movement is covered separately by the `wallet_utxo_log` audit trail.
 - `UTXOCreatedMsg` — Records new wallet UTXO confirmations with classification. `handleUTXOCreated` writes TWO rows per event: a `wallet_utxo_log` audit row and a double-entry ledger row (`debit wallet_balance, credit opening_balance`, `event_type = wallet_utxo_created`) stamped with an outpoint-derived idempotency key via `walletUTXOIdempotencyKey`. The deposit leg is what gives `wallet_balance` a non-negative balance in the presence of `SourceRoundBoarding` outflows.
 - `UTXOSpentMsg` — Records wallet UTXO spends with classification. Currently only writes the `wallet_utxo_log` audit row (double-entry leg for non-boarding wallet spends is a planned follow-up).
+- `FeeTypeOnchainSweep` — Fee type for wallet-internal boarding-sweep L1 miner
+  fees. Books as `debit onchain_fees, credit wallet_balance` under event type
+  `EventBoardingSweepFeePaid`.
+- `ClassificationBoardingSweepInput` — UTXO audit classification for a boarding
+  input spent in a timeout-path aggregate sweep.
+- `ClassificationBoardingSweepReturn` — UTXO audit classification for a sweep
+  output that returns funds to a wallet-derived destination.
 
 ## Relationships
 
@@ -65,7 +72,11 @@ accounts, see [docs/fee_ledger.md](../docs/fee_ledger.md).
     one `FeePaidMsg{FeeType=FeeTypeRefresh}` per round when `VTXOCreatedNotification.OperatorFeeSat > 0` and any refresh-origin VTXO was present (boarding-fee emission deferred to a follow-up).
   - ← `oor`: `VTXOSentMsg` after FinalizeAcceptedEvent; `VTXOReceivedMsg` (`Source=SourceOOR`) per descriptor in `notifyMaterializedVTXOs`.
   - ← `vtxo`: `ExitCostMsg` after chain resolver determines miner fee (currently a no-op emission with a TODO — chain resolver wiring pending).
-  - ← `wallet`: `UTXOCreatedMsg` on confirmed wallet UTXO observation. `UTXOSpentMsg` emission is pending.
+  - ← `wallet`: `UTXOCreatedMsg` on confirmed wallet UTXO observation;
+    `UTXOSpentMsg` (boarding sweep inputs, `ClassificationBoardingSweepInput`);
+    `FeePaidMsg{FeeType=FeeTypeOnchainSweep}` on sweep confirmation;
+    optionally `UTXOCreatedMsg` for sweep output
+    (`ClassificationBoardingSweepReturn`) when destination is wallet-derived.
 
 ## Caller Contract
 
@@ -109,6 +120,13 @@ pairs of messages:
 - **Unilateral exit:** `ExitCostMsg` with `AmountSat` gross and
   `ExitCostSat` fee. The handler expands this into two ledger entries
   internally (send leg + fee leg).
+- **Boarding-sweep miner fee:** `FeePaidMsg` with `FeeType=FeeTypeOnchainSweep`.
+  Books `debit onchain_fees, credit wallet_balance`. Idempotency key carries
+  the sweep txid. Emitted by the wallet actor on sweep confirmation.
+  Sweep inputs also get `UTXOSpentMsg` with
+  `Classification=ClassificationBoardingSweepInput`; wallet-derived sweep
+  output gets `UTXOCreatedMsg` with
+  `Classification=ClassificationBoardingSweepReturn`.
 
 ## Invariants
 

--- a/lib/arkscript/AGENTS.md
+++ b/lib/arkscript/AGENTS.md
@@ -33,7 +33,15 @@ validated invariants.
     signature over an attacker-chosen tapscript.
 - `StandardVTXOParams` — Decoded parameters for a standard Ark VTXO policy (owner key, operator key, CSV delay). Derived via `DecodeStandardVTXOParams`.
 - `ComposedPolicy` — Composes an existing `CompiledPolicy` with an additional sibling tap branch root, allowing sub-tree aggregation. Built with `ComposeWithSiblingRoot`.
-- `AnchorOutput` — Creates a zero-value P2A anchor transaction output for CPFP fee bumping (replaces the removed `lib/scripts.AnchorPkScript`).
+- `AnchorOutput(opts ...AnchorOption) *wire.TxOut` — Creates a P2A anchor output.
+  Default (no options) produces a zero-value ephemeral anchor (BIP-433) for
+  tree/forfeit/checkpoint parents paying 0 fee. Pass `WithAnchorValue(sats)`
+  when the parent pays a non-zero fee to lift the anchor above the P2A dust
+  threshold (240 sats). Returns a defensive copy preventing mutation of the
+  package-level global.
+- `AnchorOption` — Function-option type for customizing anchor value.
+  `WithAnchorValue(sats int64)` is the only implementation.
+- `AnchorPkScript` — Package-level constant: standard P2A script bytes.
 - `EncodedLeaf` / `EncodeTapTree` / `DecodeTapTree` — TLV-based tap tree serialization for PSBT sidecars compatible with `waddrmgr` format.
 - `EncodeStandardVTXOArtifacts(ownerKey, operatorKey, exitDelay)` — Convenience
   helper returning both the encoded policy template bytes and the canonical P2TR

--- a/lib/arkscript/CLAUDE.md
+++ b/lib/arkscript/CLAUDE.md
@@ -33,7 +33,15 @@ validated invariants.
     signature over an attacker-chosen tapscript.
 - `StandardVTXOParams` — Decoded parameters for a standard Ark VTXO policy (owner key, operator key, CSV delay). Derived via `DecodeStandardVTXOParams`.
 - `ComposedPolicy` — Composes an existing `CompiledPolicy` with an additional sibling tap branch root, allowing sub-tree aggregation. Built with `ComposeWithSiblingRoot`.
-- `AnchorOutput` — Creates a zero-value P2A anchor transaction output for CPFP fee bumping (replaces the removed `lib/scripts.AnchorPkScript`).
+- `AnchorOutput(opts ...AnchorOption) *wire.TxOut` — Creates a P2A anchor output.
+  Default (no options) produces a zero-value ephemeral anchor (BIP-433) for
+  tree/forfeit/checkpoint parents paying 0 fee. Pass `WithAnchorValue(sats)`
+  when the parent pays a non-zero fee to lift the anchor above the P2A dust
+  threshold (240 sats). Returns a defensive copy preventing mutation of the
+  package-level global.
+- `AnchorOption` — Function-option type for customizing anchor value.
+  `WithAnchorValue(sats int64)` is the only implementation.
+- `AnchorPkScript` — Package-level constant: standard P2A script bytes.
 - `EncodedLeaf` / `EncodeTapTree` / `DecodeTapTree` — TLV-based tap tree serialization for PSBT sidecars compatible with `waddrmgr` format.
 - `EncodeStandardVTXOArtifacts(ownerKey, operatorKey, exitDelay)` — Convenience
   helper returning both the encoded policy template bytes and the canonical P2TR

--- a/round/AGENTS.md
+++ b/round/AGENTS.md
@@ -92,6 +92,12 @@ protocols with MuSig2 signing ceremonies.
 - `IntentPackage` — Single FSM event embedding `Intents` for atomic
   delivery. Covers all pooled intent types (boarding, VTXO, forfeit,
   leave). `isEmpty()` guards against sending empty packages.
+- `VTXORequestsReceived` — Actor message (not an FSM event) carrying
+  pre-built VTXO requests. The round actor translates this into an
+  `IntentPackage`. Implements `actormsg.RoundReceivable`.
+- `ClientEvent` and `ClientOutMsg` interfaces are sealed via unexported
+  `clientEventSealed()` / `clientOutMsgSealed()` methods, preventing
+  external implementations.
 
 ### Outbox Messages (`outbox_messages.go`)
 

--- a/round/CLAUDE.md
+++ b/round/CLAUDE.md
@@ -92,6 +92,12 @@ protocols with MuSig2 signing ceremonies.
 - `IntentPackage` — Single FSM event embedding `Intents` for atomic
   delivery. Covers all pooled intent types (boarding, VTXO, forfeit,
   leave). `isEmpty()` guards against sending empty packages.
+- `VTXORequestsReceived` — Actor message (not an FSM event) carrying
+  pre-built VTXO requests. The round actor translates this into an
+  `IntentPackage`. Implements `actormsg.RoundReceivable`.
+- `ClientEvent` and `ClientOutMsg` interfaces are sealed via unexported
+  `clientEventSealed()` / `clientOutMsgSealed()` methods, preventing
+  external implementations.
 
 ### Outbox Messages (`outbox_messages.go`)
 

--- a/txconfirm/AGENTS.md
+++ b/txconfirm/AGENTS.md
@@ -38,8 +38,13 @@ each still receives its own terminal notification.
   without the full actor harness.
 - `EstimatePackageFee`, `EstimateWeight`, `SelectFeeInput` — Exported
   helpers for fee estimation and fee-input selection, usable standalone.
+- `ServiceKeyName` — Constant `"txconfirm"` used to register and look up the
+  broadcaster in the actor system.
+- `NewServiceKey()` — Returns the `actor.ServiceKey` for the broadcaster.
+- `LookupRef(system)` — Resolves the txconfirm service key and returns an
+  `ActorRef`. Defers resolution until after the broadcaster registers.
 - `Wallet` — Wallet interface the broadcaster requires: `ListUnspent`,
-  `NewWalletPkScript`, `FinalizePsbt`, plus `wallet.OutputLeaser`
+  `NewWalletPkScript`, `FinalizePsbt`, plus `walletcore.OutputLeaser`
   (`LeaseOutput` / `ReleaseOutput`) for cross-subsystem UTXO lock
   coordination.
 - `EnsureConfirmedReq` / `EnsureConfirmedResp` — Public Ask API: register
@@ -66,8 +71,9 @@ each still receives its own terminal notification.
   - `baselib/protofsm` — per-txid state machine engine.
   - `chainsource` — confirmation watches, block epochs, broadcast,
     package submission, fee estimation, preflight.
-  - `wallet` — `Utxo`, `OutputLeaser`, `LockID` types for fee-input
-    selection and wallet-level lease coordination.
+  - `walletcore` — `Utxo`, `OutputLeaser`, `LockID` types for fee-input
+    selection and wallet-level lease coordination (canonical declarations live
+    here to avoid import cycles with `wallet`).
   - `lib/tx/arktx` — canonical `TxVersion` (v3/TRUC) constant and
     `IsAnchorOutput` predicate for CPFP targeting.
 - **Depended on by**: `unroll` (plugs `TxBroadcasterActor` and

--- a/txconfirm/CLAUDE.md
+++ b/txconfirm/CLAUDE.md
@@ -38,8 +38,13 @@ each still receives its own terminal notification.
   without the full actor harness.
 - `EstimatePackageFee`, `EstimateWeight`, `SelectFeeInput` — Exported
   helpers for fee estimation and fee-input selection, usable standalone.
+- `ServiceKeyName` — Constant `"txconfirm"` used to register and look up the
+  broadcaster in the actor system.
+- `NewServiceKey()` — Returns the `actor.ServiceKey` for the broadcaster.
+- `LookupRef(system)` — Resolves the txconfirm service key and returns an
+  `ActorRef`. Defers resolution until after the broadcaster registers.
 - `Wallet` — Wallet interface the broadcaster requires: `ListUnspent`,
-  `NewWalletPkScript`, `FinalizePsbt`, plus `wallet.OutputLeaser`
+  `NewWalletPkScript`, `FinalizePsbt`, plus `walletcore.OutputLeaser`
   (`LeaseOutput` / `ReleaseOutput`) for cross-subsystem UTXO lock
   coordination.
 - `EnsureConfirmedReq` / `EnsureConfirmedResp` — Public Ask API: register
@@ -66,8 +71,9 @@ each still receives its own terminal notification.
   - `baselib/protofsm` — per-txid state machine engine.
   - `chainsource` — confirmation watches, block epochs, broadcast,
     package submission, fee estimation, preflight.
-  - `wallet` — `Utxo`, `OutputLeaser`, `LockID` types for fee-input
-    selection and wallet-level lease coordination.
+  - `walletcore` — `Utxo`, `OutputLeaser`, `LockID` types for fee-input
+    selection and wallet-level lease coordination (canonical declarations live
+    here to avoid import cycles with `wallet`).
   - `lib/tx/arktx` — canonical `TxVersion` (v3/TRUC) constant and
     `IsAnchorOutput` predicate for CPFP targeting.
 - **Depended on by**: `unroll` (plugs `TxBroadcasterActor` and

--- a/unroll/AGENTS.md
+++ b/unroll/AGENTS.md
@@ -36,7 +36,12 @@ control-plane record per target to `db` so restart can restore in-flight jobs.
   `PhaseSweepBroadcast` / `PhaseSweepConfirmation` / `PhaseCompleted` /
   `PhaseFailed`.
 - `JobState` — Durable FSM state (height, trigger, planner state,
-  `FailReason`, `SweepAttempts`).
+  `FailReason`, `SweepAttempts`, `DeferredCheckpoints` for fraud-triggered
+  checkpoint deferrals).
+- `DeferredCheckpoint` — A proof-graph checkpoint node ready to broadcast but
+  held until `DeadlineHeight` (computed as `height + csvDelay - safetyMargin`)
+  to give the operator priority publication under `TriggerFraudSpend`. Serialized
+  via `deferred_checkpoint_codec.go` (TLV record type 17 in the snapshot).
 
 ### Registry
 - `UnrollRegistryActor` — Thin coordinator over the set of
@@ -44,7 +49,9 @@ control-plane record per target to `db` so restart can restore in-flight jobs.
   admission, receives `UnrollTerminatedMsg` from children, persists records,
   and `RestoreNonTerminal` on boot.
 - `RegistryConfig` — Store, `DeliveryStore`, `ProofAssembler`, `VTXOStore`,
-  `TxConfirmRef`, `ChainSource`, `Wallet`, `MaxSweepFeeRateSatPerVByte`.
+  `TxConfirmRef`, `ChainSource`, `Wallet`, `MaxSweepFeeRateSatPerVByte`,
+  `FraudCheckpointSafetyMargin` (blocks subtracted from csvDelay to compute
+  the backstop deadline; zero falls back to `defaultFraudCheckpointSafetyMargin = 24`).
 - `RegistryRecord` — Control-plane row: `TargetOutpoint`, `ActorID`,
   `Phase`, `Trigger`, `FailReason`, `SweepTxid`.
 - `RegistryStore` — Persistence surface: `UpsertRecord`, `GetRecord`,
@@ -87,6 +94,17 @@ control-plane record per target to `db` so restart can restore in-flight jobs.
 - `safeTxOutPkScript(tx, index)` — Bounds-checking helper used at every
   `tx.TxOut[i].PkScript` site so malformed proof artifacts (operator-sourced
   OOR inputs) surface as retryable errors instead of goroutine panics.
+- `readyMaterializationTxids` — Splits planner-ready proof nodes into
+  immediate-submit transactions and deferred checkpoint watches. Under
+  `TriggerFraudSpend`, checkpoint nodes are deferred until `DeadlineHeight`
+  unless they confirm first.
+- `checkpointBackstopHeight` — Computes the first height at which the actor
+  should broadcast a fraud-triggered deferred checkpoint itself. Margin is
+  clamped to `csvDelay/2` when CSV is very short.
+- `validateDeferredCheckpoints` — Ensures every deferred checkpoint references
+  a valid checkpoint node in the proof graph and is not already confirmed.
+- `state_snapshot.go` — Helpers to convert between FSM states and durable
+  checkpoints; used by the actor's boot path to restore `DeferredCheckpoints`.
 
 ## Relationships
 
@@ -176,6 +194,14 @@ control-plane record per target to `db` so restart can restore in-flight jobs.
 - **Checkpoint persists the sweep tx** via
   `wire.MsgTx.Serialize` under `checkpointSweepTxRecordType` so restore
   produces the exact same `b.sweepTx` that the pre-broadcast commit wrote.
+- **Fraud checkpoint deferral.** Under `TriggerFraudSpend`, ready checkpoint
+  nodes are held in `job.DeferredCheckpoints` until `DeadlineHeight` unless
+  they confirm first. `DeadlineHeight = height + csvDelay - safetyMargin`
+  (clamped to `csvDelay/2` for very short CSV). `readyMaterializationTxids`
+  routes nodes into deferred vs. immediate submission; `WatchDeferredCheckpoints`
+  outbox event registers per-node confirmation watches while waiting for the
+  backstop; `shouldSubmitReadyFrontier` upgrades a node to immediate submission
+  once the deadline passes or confirmation arrives.
 - **Phase ↔ DB status mapping is lossless.** `PhaseSweepBroadcast` maps to
   `UnilateralExitJobStatusSweepBroadcasting` (=6) and
   `PhaseSweepConfirmation` maps to `UnilateralExitJobStatusSweeping` (=3) —

--- a/unroll/CLAUDE.md
+++ b/unroll/CLAUDE.md
@@ -36,7 +36,12 @@ control-plane record per target to `db` so restart can restore in-flight jobs.
   `PhaseSweepBroadcast` / `PhaseSweepConfirmation` / `PhaseCompleted` /
   `PhaseFailed`.
 - `JobState` — Durable FSM state (height, trigger, planner state,
-  `FailReason`, `SweepAttempts`).
+  `FailReason`, `SweepAttempts`, `DeferredCheckpoints` for fraud-triggered
+  checkpoint deferrals).
+- `DeferredCheckpoint` — A proof-graph checkpoint node ready to broadcast but
+  held until `DeadlineHeight` (computed as `height + csvDelay - safetyMargin`)
+  to give the operator priority publication under `TriggerFraudSpend`. Serialized
+  via `deferred_checkpoint_codec.go` (TLV record type 17 in the snapshot).
 
 ### Registry
 - `UnrollRegistryActor` — Thin coordinator over the set of
@@ -44,7 +49,9 @@ control-plane record per target to `db` so restart can restore in-flight jobs.
   admission, receives `UnrollTerminatedMsg` from children, persists records,
   and `RestoreNonTerminal` on boot.
 - `RegistryConfig` — Store, `DeliveryStore`, `ProofAssembler`, `VTXOStore`,
-  `TxConfirmRef`, `ChainSource`, `Wallet`, `MaxSweepFeeRateSatPerVByte`.
+  `TxConfirmRef`, `ChainSource`, `Wallet`, `MaxSweepFeeRateSatPerVByte`,
+  `FraudCheckpointSafetyMargin` (blocks subtracted from csvDelay to compute
+  the backstop deadline; zero falls back to `defaultFraudCheckpointSafetyMargin = 24`).
 - `RegistryRecord` — Control-plane row: `TargetOutpoint`, `ActorID`,
   `Phase`, `Trigger`, `FailReason`, `SweepTxid`.
 - `RegistryStore` — Persistence surface: `UpsertRecord`, `GetRecord`,
@@ -87,6 +94,17 @@ control-plane record per target to `db` so restart can restore in-flight jobs.
 - `safeTxOutPkScript(tx, index)` — Bounds-checking helper used at every
   `tx.TxOut[i].PkScript` site so malformed proof artifacts (operator-sourced
   OOR inputs) surface as retryable errors instead of goroutine panics.
+- `readyMaterializationTxids` — Splits planner-ready proof nodes into
+  immediate-submit transactions and deferred checkpoint watches. Under
+  `TriggerFraudSpend`, checkpoint nodes are deferred until `DeadlineHeight`
+  unless they confirm first.
+- `checkpointBackstopHeight` — Computes the first height at which the actor
+  should broadcast a fraud-triggered deferred checkpoint itself. Margin is
+  clamped to `csvDelay/2` when CSV is very short.
+- `validateDeferredCheckpoints` — Ensures every deferred checkpoint references
+  a valid checkpoint node in the proof graph and is not already confirmed.
+- `state_snapshot.go` — Helpers to convert between FSM states and durable
+  checkpoints; used by the actor's boot path to restore `DeferredCheckpoints`.
 
 ## Relationships
 
@@ -176,6 +194,14 @@ control-plane record per target to `db` so restart can restore in-flight jobs.
 - **Checkpoint persists the sweep tx** via
   `wire.MsgTx.Serialize` under `checkpointSweepTxRecordType` so restore
   produces the exact same `b.sweepTx` that the pre-broadcast commit wrote.
+- **Fraud checkpoint deferral.** Under `TriggerFraudSpend`, ready checkpoint
+  nodes are held in `job.DeferredCheckpoints` until `DeadlineHeight` unless
+  they confirm first. `DeadlineHeight = height + csvDelay - safetyMargin`
+  (clamped to `csvDelay/2` for very short CSV). `readyMaterializationTxids`
+  routes nodes into deferred vs. immediate submission; `WatchDeferredCheckpoints`
+  outbox event registers per-node confirmation watches while waiting for the
+  backstop; `shouldSubmitReadyFrontier` upgrades a node to immediate submission
+  once the deadline passes or confirmation arrives.
 - **Phase ↔ DB status mapping is lossless.** `PhaseSweepBroadcast` maps to
   `UnilateralExitJobStatusSweepBroadcasting` (=6) and
   `PhaseSweepConfirmation` maps to `UnilateralExitJobStatusSweeping` (=3) —

--- a/vtxo/AGENTS.md
+++ b/vtxo/AGENTS.md
@@ -19,13 +19,23 @@ when the local wallet owns the receive script.
 - `ManagerConfig` — Configuration holding Store, Wallet, ChainSource,
   ActorSystem, ChainParams, ExpiryConfig, RoundActor ref, ChainResolver ref,
   optional `Log`, optional `LedgerSink fn.Option[ledger.Sink]`,
-  `ForfeitVTXOActorAskTimeout`, and `RefreshFeeQuoter`. The manager
-  propagates the sink into each spawned `VTXOActor` for `ExitCostMsg`
-  emissions. `ForfeitVTXOActorAskTimeout` (default 5 s) bounds forfeit
-  and refresh child asks so a blocked child actor cannot monopolize the
-  manager until the outer RPC deadline. Zero uses the default; negative
-  disables the timeout. Spend-path asks keep the caller's context.
+  `ForfeitVTXOActorAskTimeout`, `RefreshFeeQuoter`, and
+  `TerminalVTXOObserver`. The manager propagates the sink into each spawned
+  `VTXOActor` for `ExitCostMsg` emissions. `ForfeitVTXOActorAskTimeout`
+  (default 5 s) bounds forfeit and refresh child asks so a blocked child
+  actor cannot monopolize the manager until the outer RPC deadline. Zero
+  uses the default; negative disables the timeout. Spend-path asks keep the
+  caller's context. `TerminalVTXOObserver` is an optional callback invoked
+  when VTXOs transition out of the active set (e.g. fraud watcher cleanup).
 - `VTXOActorConfig.LedgerSink` — Per-VTXO actor field plumbed from the manager. The `emitExitCost` helper is wired onto the unilateral-exit transition but is currently a no-op pending chain resolver integration: the actor cannot determine the on-chain miner fee until the chain resolver reports the confirmed exit-spend transaction. The emission site exists so a single future change in the chain resolver wiring enables it without touching the FSM transition logic.
+- `ListLiveDescriptorsRequest` / `ListLiveDescriptorsResponse` — Manager-facing
+  query returning the snapshot of recovered live VTXO descriptors from startup.
+  Used by daemon-local subsystems (notably the fraud watcher) to re-arm per-VTXO
+  state after restart without a direct Store dependency.
+- `Manager.liveDescriptors` — Snapshot of descriptors recovered during
+  `Manager.Start()`. This slice is the source of truth for subsystems that
+  re-arm per-VTXO state on restart; it is NOT kept in sync after Start —
+  runtime updates flow through `TerminalVTXOObserver` and materialization hooks.
 - `VTXOEvent` — Inbound events (BlockEpochEvent, ForfeitRequest, ForfeitConfirmed, SpendReserveEvent, SpendCompletedEvent, etc.).
 - `VTXOOutMsg` — Outbound messages (ForfeitRequest, ExpiringNotify, StatusUpdate, Terminated).
 - `FilterOptions` / `FilterDescriptors` — VTXO filtering by expiry status, spend state, etc.

--- a/vtxo/CLAUDE.md
+++ b/vtxo/CLAUDE.md
@@ -19,13 +19,23 @@ when the local wallet owns the receive script.
 - `ManagerConfig` — Configuration holding Store, Wallet, ChainSource,
   ActorSystem, ChainParams, ExpiryConfig, RoundActor ref, ChainResolver ref,
   optional `Log`, optional `LedgerSink fn.Option[ledger.Sink]`,
-  `ForfeitVTXOActorAskTimeout`, and `RefreshFeeQuoter`. The manager
-  propagates the sink into each spawned `VTXOActor` for `ExitCostMsg`
-  emissions. `ForfeitVTXOActorAskTimeout` (default 5 s) bounds forfeit
-  and refresh child asks so a blocked child actor cannot monopolize the
-  manager until the outer RPC deadline. Zero uses the default; negative
-  disables the timeout. Spend-path asks keep the caller's context.
+  `ForfeitVTXOActorAskTimeout`, `RefreshFeeQuoter`, and
+  `TerminalVTXOObserver`. The manager propagates the sink into each spawned
+  `VTXOActor` for `ExitCostMsg` emissions. `ForfeitVTXOActorAskTimeout`
+  (default 5 s) bounds forfeit and refresh child asks so a blocked child
+  actor cannot monopolize the manager until the outer RPC deadline. Zero
+  uses the default; negative disables the timeout. Spend-path asks keep the
+  caller's context. `TerminalVTXOObserver` is an optional callback invoked
+  when VTXOs transition out of the active set (e.g. fraud watcher cleanup).
 - `VTXOActorConfig.LedgerSink` — Per-VTXO actor field plumbed from the manager. The `emitExitCost` helper is wired onto the unilateral-exit transition but is currently a no-op pending chain resolver integration: the actor cannot determine the on-chain miner fee until the chain resolver reports the confirmed exit-spend transaction. The emission site exists so a single future change in the chain resolver wiring enables it without touching the FSM transition logic.
+- `ListLiveDescriptorsRequest` / `ListLiveDescriptorsResponse` — Manager-facing
+  query returning the snapshot of recovered live VTXO descriptors from startup.
+  Used by daemon-local subsystems (notably the fraud watcher) to re-arm per-VTXO
+  state after restart without a direct Store dependency.
+- `Manager.liveDescriptors` — Snapshot of descriptors recovered during
+  `Manager.Start()`. This slice is the source of truth for subsystems that
+  re-arm per-VTXO state on restart; it is NOT kept in sync after Start —
+  runtime updates flow through `TerminalVTXOObserver` and materialization hooks.
 - `VTXOEvent` — Inbound events (BlockEpochEvent, ForfeitRequest, ForfeitConfirmed, SpendReserveEvent, SpendCompletedEvent, etc.).
 - `VTXOOutMsg` — Outbound messages (ForfeitRequest, ExpiringNotify, StatusUpdate, Terminated).
 - `FilterOptions` / `FilterDescriptors` — VTXO filtering by expiry status, spend state, etc.

--- a/wallet/AGENTS.md
+++ b/wallet/AGENTS.md
@@ -10,14 +10,39 @@ refresh, leave, OOR spend, and directed send flows.
 
 ## Key Types
 
-- `Ark` — Main actor managing boarding addresses, UTXO enumeration, confirmation polling, admission forwarding, and VTXO selection/locking. Holds a `ledgerSink` field (`fn.Option[ledger.Sink]`) used by the `emitUTXOCreated` helper to Tell `UTXOCreatedMsg` to the ledger actor whenever a confirmed wallet UTXO is observed.
+- `Ark` — Main actor managing boarding addresses, UTXO enumeration, confirmation polling, admission forwarding, VTXO selection/locking, and aggregate boarding-timeout sweep lifecycle. Holds a `ledgerSink` field (`fn.Option[ledger.Sink]`) for wallet UTXO audit emission. When wired via `WithBoardingSweep`, also manages sweep building, persistence, broadcast, and spend/txconfirm notification correlation via `pendingSweeps` in-memory map.
 - `NewArk` — Constructor; takes the `ledgerSink` as a **required** argument (`fn.Option[ledger.Sink]`) rather than a setter, so every call site is forced to make an explicit emission choice. Production passes `fn.Some(ledger.NewSink(actorSystem))`; harnesses and unit tests that do not register a ledger actor pass `fn.None[ledger.Sink]()`.
+- `WithBoardingSweep(store, signer, chainParams)` — Option that wires the
+  boarding-sweep subsystem into the `Ark` actor. Without this option the sweep
+  handlers are no-ops.
 - `emitUTXOCreated(ctx, utxo, blockHeight, classification)` — Internal helper that null-safely builds a `ledger.UTXOCreatedMsg` from a wallet `Utxo` and Tells it to `ledgerSink`. Negative block heights clamp to `0` rather than wrapping under a direct `uint32` cast; nil `utxo` and `fn.None` sink are silent no-ops.
-- `LockID` — `[32]byte` caller-scoped output lease identifier used to associate leased UTXOs with a specific subsystem (`txconfirmLockID` in `txconfirm`, etc.).
-- `OutputLeaser` — Interface for UTXO output leasing: `LeaseOutput(ctx, outpoint, lockID, expiry)` and `ReleaseOutput(ctx, outpoint, lockID)`. Implemented by all three `BoardingBackend` implementations (`btcwbackend`, `lndbackend`, `lwwallet`) to coordinate cross-subsystem UTXO reservation.
+- `LockID` — Type alias for `walletcore.LockID`. Canonical declaration lives in
+  `walletcore` to break import cycles with packages like `txconfirm`.
+- `OutputLeaser` — Type alias for `walletcore.OutputLeaser`. Same rationale.
+  Implemented by all three `BoardingBackend` implementations (`btcwbackend`,
+  `lndbackend`, `lwwallet`) to coordinate cross-subsystem UTXO reservation.
 - `BoardingBackend` — Interface for wallet integration (key derivation, taproot import, ListUnspent). `GetTransaction` returns `*TxInfo` (containing tx, block hash, and block height).
 - `TxInfo` — Struct wrapping a confirmed transaction with its block hash and block height. Returned by `BoardingBackend.GetTransaction`.
-- `BoardingStore` — Interface for persisting boarding addresses and intents.
+- `BoardingStore` — Interface for persisting boarding addresses, intents, and
+  boarding sweep records.
+- `BoardingSweepStore` — Interface for persisting aggregate boarding-sweep
+  records. Methods: `CreatePendingBoardingSweep`, `MarkBoardingSweepPublished`,
+  `MarkBoardingSweepFailed`, `MarkBoardingSweepInputSpent`,
+  `ListBoardingSweeps`, `GetBoardingSweep`, `ListPendingBoardingSweeps`,
+  `FetchBoardingIntentsBySweepableStatuses`, `GetIntent`.
+- `SweepSigner` — Signing interface for boarding-timeout sweep txs: embeds
+  `input.Signer` and adds `NewWalletPkScript`. Satisfied by all three
+  `BoardingBackend` implementations.
+- `SweepBoardingUTXOsRequest` / `SweepBoardingUTXOsResponse` — Ask-request for
+  building and broadcasting an aggregate boarding-timeout sweep.
+- `ResumeBoardingSweepsRequest` / `ResumeBoardingSweepsResponse` — Resume
+  persisted sweeps from a prior run at startup.
+- `BoardingSweepSpendNotification` — Tell from chainsource when a sweep input
+  is confirmed spent on-chain.
+- `BoardingSweepTxNotification` — Tell from txconfirm when a sweep tx confirms
+  or fails.
+- `BoardingSweepOutput` — Describes one mature boarding output included in a
+  sweep response.
 - `VTXOReader` — Read-only interface for loading VTXO descriptors by outpoint. Wallet uses this to build intent packages without importing `vtxo` directly.
 - `VTXODescriptor` — Wallet-level VTXO descriptor (outpoint, amount, pkscript, tree, expiry). Avoids direct dependency on `vtxo.Descriptor`.
 - `SelectedVTXO` — Describes a VTXO selected and locked for use as a transfer input (outpoint, amount, pkscript). Breaks the vtxo → round → wallet import cycle.
@@ -37,7 +62,13 @@ refresh, leave, OOR spend, and directed send flows.
 
 ## Relationships
 
-- **Depends on**: `baselib/actor` (actor system), `chainsource` (block epoch notifications), `lib/actormsg` (VTXO manager admission types), `ledger` (`Sink` alias for emission + `UTXOCreatedMsg` / `ClassificationDeposit` constants).
+- **Depends on**: `baselib/actor` (actor system), `chainsource` (block epoch
+  notifications + spend watches for boarding sweeps), `lib/actormsg` (VTXO
+  manager admission types), `ledger` (`Sink` alias + `UTXOCreatedMsg` /
+  `UTXOSpentMsg` / `FeePaidMsg` / `ClassificationDeposit` /
+  `ClassificationBoardingSweepInput` / `ClassificationBoardingSweepReturn` /
+  `FeeTypeOnchainSweep`), `txconfirm` (EnsureConfirmedReq for sweep broadcast
+  and confirmation), `walletcore` (LockID, OutputLeaser type declarations).
 - **Depended on by**: `round` (boarding intents, types: `BoardingAddress`, `SelectedVTXO`), `db` (persistence), `darepod` (wiring).
 - **Sends**:
   - → `round` (via registered notifier): `BoardingUtxoConfirmedEvent`
@@ -52,7 +83,15 @@ refresh, leave, OOR spend, and directed send flows.
 - **Receives**:
   - ← `chainsource`: `BlockEpochNotification` (triggers UTXO polling)
   - ← `round`: `RegisterConfirmationNotifierRequest`, `UnregisterConfirmationNotifierRequest`
-  - ← API: `CreateBoardingAddressRequest`, `GetActiveBoardingAddressesRequest`, `GetBoardingBalanceRequest`, `GetConfirmedBoardingIntentsRequest`, `RefreshVTXOsRequest`, `SelectAndLockVTXOsRequest`, `LeaveVTXOsRequest`, `BoardRequest`, `CompleteSpendVTXOsRequest`, `UnlockVTXOsRequest`, `SendVTXOsRequest`
+  - ← `chainsource` (via mapped spend watch): `BoardingSweepSpendNotification`
+    (per-input, when sweep is in-flight)
+  - ← `txconfirm` (via mapped TxConfirmed/TxFailed): `BoardingSweepTxNotification`
+    (when sweep tx confirms or fails)
+  - ← API: `CreateBoardingAddressRequest`, `GetActiveBoardingAddressesRequest`,
+    `GetBoardingBalanceRequest`, `GetConfirmedBoardingIntentsRequest`,
+    `RefreshVTXOsRequest`, `SelectAndLockVTXOsRequest`, `LeaveVTXOsRequest`,
+    `BoardRequest`, `CompleteSpendVTXOsRequest`, `UnlockVTXOsRequest`,
+    `SendVTXOsRequest`, `SweepBoardingUTXOsRequest`, `ResumeBoardingSweepsRequest`
 
 ## Invariants
 
@@ -67,6 +106,16 @@ refresh, leave, OOR spend, and directed send flows.
 - `handleSendVTXOs` rejects pre-flight any directed send with multiple recipients and exactly-zero change residual under the #270 seal-time fee handshake. The server is the amount authority and absorbs the operator fee out of the designated `IsChange=true` slot; if there is no residual to absorb the fee against, the server has no slack to deduct fees without silently shifting them onto a recipient leg. The wallet refuses the request rather than letting the server pick the loser.
 - `VTXOReader` / `VTXODescriptor` / `SelectedVTXO` break the vtxo → round → wallet import cycle by providing wallet-level types that don't reference `vtxo.Descriptor` directly.
 - Per-subsystem logging via `build.LoggerFromContext` (no global mutable loggers).
+- Boarding sweep txs are v3/TRUC with an above-dust P2A anchor (330 sats) so the
+  parent can pay its own fee without hitting the ephemeral-dust rule.
+- One aggregate sweep caps at `defaultBoardingSweepMaxInputs = 100` inputs.
+- Sweep fee validation rejects sweeps burning more than
+  `defaultBoardingSweepMaxFeePercent = 25%` of selected boarding value.
+- Sweep-input spend watches deduplicate against `pendingSweepInputs` to prevent
+  duplicate chainsource registrations when the same outpoint appears in multiple
+  aggregates or resume calls.
+- `ResumeBoardingSweepsRequest` uses the persisted sweep record (not in-memory
+  state) as the sole source of truth across restarts.
 
 ## Deep Docs
 

--- a/wallet/CLAUDE.md
+++ b/wallet/CLAUDE.md
@@ -10,14 +10,39 @@ refresh, leave, OOR spend, and directed send flows.
 
 ## Key Types
 
-- `Ark` — Main actor managing boarding addresses, UTXO enumeration, confirmation polling, admission forwarding, and VTXO selection/locking. Holds a `ledgerSink` field (`fn.Option[ledger.Sink]`) used by the `emitUTXOCreated` helper to Tell `UTXOCreatedMsg` to the ledger actor whenever a confirmed wallet UTXO is observed.
+- `Ark` — Main actor managing boarding addresses, UTXO enumeration, confirmation polling, admission forwarding, VTXO selection/locking, and aggregate boarding-timeout sweep lifecycle. Holds a `ledgerSink` field (`fn.Option[ledger.Sink]`) for wallet UTXO audit emission. When wired via `WithBoardingSweep`, also manages sweep building, persistence, broadcast, and spend/txconfirm notification correlation via `pendingSweeps` in-memory map.
 - `NewArk` — Constructor; takes the `ledgerSink` as a **required** argument (`fn.Option[ledger.Sink]`) rather than a setter, so every call site is forced to make an explicit emission choice. Production passes `fn.Some(ledger.NewSink(actorSystem))`; harnesses and unit tests that do not register a ledger actor pass `fn.None[ledger.Sink]()`.
+- `WithBoardingSweep(store, signer, chainParams)` — Option that wires the
+  boarding-sweep subsystem into the `Ark` actor. Without this option the sweep
+  handlers are no-ops.
 - `emitUTXOCreated(ctx, utxo, blockHeight, classification)` — Internal helper that null-safely builds a `ledger.UTXOCreatedMsg` from a wallet `Utxo` and Tells it to `ledgerSink`. Negative block heights clamp to `0` rather than wrapping under a direct `uint32` cast; nil `utxo` and `fn.None` sink are silent no-ops.
-- `LockID` — `[32]byte` caller-scoped output lease identifier used to associate leased UTXOs with a specific subsystem (`txconfirmLockID` in `txconfirm`, etc.).
-- `OutputLeaser` — Interface for UTXO output leasing: `LeaseOutput(ctx, outpoint, lockID, expiry)` and `ReleaseOutput(ctx, outpoint, lockID)`. Implemented by all three `BoardingBackend` implementations (`btcwbackend`, `lndbackend`, `lwwallet`) to coordinate cross-subsystem UTXO reservation.
+- `LockID` — Type alias for `walletcore.LockID`. Canonical declaration lives in
+  `walletcore` to break import cycles with packages like `txconfirm`.
+- `OutputLeaser` — Type alias for `walletcore.OutputLeaser`. Same rationale.
+  Implemented by all three `BoardingBackend` implementations (`btcwbackend`,
+  `lndbackend`, `lwwallet`) to coordinate cross-subsystem UTXO reservation.
 - `BoardingBackend` — Interface for wallet integration (key derivation, taproot import, ListUnspent). `GetTransaction` returns `*TxInfo` (containing tx, block hash, and block height).
 - `TxInfo` — Struct wrapping a confirmed transaction with its block hash and block height. Returned by `BoardingBackend.GetTransaction`.
-- `BoardingStore` — Interface for persisting boarding addresses and intents.
+- `BoardingStore` — Interface for persisting boarding addresses, intents, and
+  boarding sweep records.
+- `BoardingSweepStore` — Interface for persisting aggregate boarding-sweep
+  records. Methods: `CreatePendingBoardingSweep`, `MarkBoardingSweepPublished`,
+  `MarkBoardingSweepFailed`, `MarkBoardingSweepInputSpent`,
+  `ListBoardingSweeps`, `GetBoardingSweep`, `ListPendingBoardingSweeps`,
+  `FetchBoardingIntentsBySweepableStatuses`, `GetIntent`.
+- `SweepSigner` — Signing interface for boarding-timeout sweep txs: embeds
+  `input.Signer` and adds `NewWalletPkScript`. Satisfied by all three
+  `BoardingBackend` implementations.
+- `SweepBoardingUTXOsRequest` / `SweepBoardingUTXOsResponse` — Ask-request for
+  building and broadcasting an aggregate boarding-timeout sweep.
+- `ResumeBoardingSweepsRequest` / `ResumeBoardingSweepsResponse` — Resume
+  persisted sweeps from a prior run at startup.
+- `BoardingSweepSpendNotification` — Tell from chainsource when a sweep input
+  is confirmed spent on-chain.
+- `BoardingSweepTxNotification` — Tell from txconfirm when a sweep tx confirms
+  or fails.
+- `BoardingSweepOutput` — Describes one mature boarding output included in a
+  sweep response.
 - `VTXOReader` — Read-only interface for loading VTXO descriptors by outpoint. Wallet uses this to build intent packages without importing `vtxo` directly.
 - `VTXODescriptor` — Wallet-level VTXO descriptor (outpoint, amount, pkscript, tree, expiry). Avoids direct dependency on `vtxo.Descriptor`.
 - `SelectedVTXO` — Describes a VTXO selected and locked for use as a transfer input (outpoint, amount, pkscript). Breaks the vtxo → round → wallet import cycle.
@@ -37,7 +62,13 @@ refresh, leave, OOR spend, and directed send flows.
 
 ## Relationships
 
-- **Depends on**: `baselib/actor` (actor system), `chainsource` (block epoch notifications), `lib/actormsg` (VTXO manager admission types), `ledger` (`Sink` alias for emission + `UTXOCreatedMsg` / `ClassificationDeposit` constants).
+- **Depends on**: `baselib/actor` (actor system), `chainsource` (block epoch
+  notifications + spend watches for boarding sweeps), `lib/actormsg` (VTXO
+  manager admission types), `ledger` (`Sink` alias + `UTXOCreatedMsg` /
+  `UTXOSpentMsg` / `FeePaidMsg` / `ClassificationDeposit` /
+  `ClassificationBoardingSweepInput` / `ClassificationBoardingSweepReturn` /
+  `FeeTypeOnchainSweep`), `txconfirm` (EnsureConfirmedReq for sweep broadcast
+  and confirmation), `walletcore` (LockID, OutputLeaser type declarations).
 - **Depended on by**: `round` (boarding intents, types: `BoardingAddress`, `SelectedVTXO`), `db` (persistence), `darepod` (wiring).
 - **Sends**:
   - → `round` (via registered notifier): `BoardingUtxoConfirmedEvent`
@@ -52,7 +83,15 @@ refresh, leave, OOR spend, and directed send flows.
 - **Receives**:
   - ← `chainsource`: `BlockEpochNotification` (triggers UTXO polling)
   - ← `round`: `RegisterConfirmationNotifierRequest`, `UnregisterConfirmationNotifierRequest`
-  - ← API: `CreateBoardingAddressRequest`, `GetActiveBoardingAddressesRequest`, `GetBoardingBalanceRequest`, `GetConfirmedBoardingIntentsRequest`, `RefreshVTXOsRequest`, `SelectAndLockVTXOsRequest`, `LeaveVTXOsRequest`, `BoardRequest`, `CompleteSpendVTXOsRequest`, `UnlockVTXOsRequest`, `SendVTXOsRequest`
+  - ← `chainsource` (via mapped spend watch): `BoardingSweepSpendNotification`
+    (per-input, when sweep is in-flight)
+  - ← `txconfirm` (via mapped TxConfirmed/TxFailed): `BoardingSweepTxNotification`
+    (when sweep tx confirms or fails)
+  - ← API: `CreateBoardingAddressRequest`, `GetActiveBoardingAddressesRequest`,
+    `GetBoardingBalanceRequest`, `GetConfirmedBoardingIntentsRequest`,
+    `RefreshVTXOsRequest`, `SelectAndLockVTXOsRequest`, `LeaveVTXOsRequest`,
+    `BoardRequest`, `CompleteSpendVTXOsRequest`, `UnlockVTXOsRequest`,
+    `SendVTXOsRequest`, `SweepBoardingUTXOsRequest`, `ResumeBoardingSweepsRequest`
 
 ## Invariants
 
@@ -67,6 +106,16 @@ refresh, leave, OOR spend, and directed send flows.
 - `handleSendVTXOs` rejects pre-flight any directed send with multiple recipients and exactly-zero change residual under the #270 seal-time fee handshake. The server is the amount authority and absorbs the operator fee out of the designated `IsChange=true` slot; if there is no residual to absorb the fee against, the server has no slack to deduct fees without silently shifting them onto a recipient leg. The wallet refuses the request rather than letting the server pick the loser.
 - `VTXOReader` / `VTXODescriptor` / `SelectedVTXO` break the vtxo → round → wallet import cycle by providing wallet-level types that don't reference `vtxo.Descriptor` directly.
 - Per-subsystem logging via `build.LoggerFromContext` (no global mutable loggers).
+- Boarding sweep txs are v3/TRUC with an above-dust P2A anchor (330 sats) so the
+  parent can pay its own fee without hitting the ephemeral-dust rule.
+- One aggregate sweep caps at `defaultBoardingSweepMaxInputs = 100` inputs.
+- Sweep fee validation rejects sweeps burning more than
+  `defaultBoardingSweepMaxFeePercent = 25%` of selected boarding value.
+- Sweep-input spend watches deduplicate against `pendingSweepInputs` to prevent
+  duplicate chainsource registrations when the same outpoint appears in multiple
+  aggregates or resume calls.
+- `ResumeBoardingSweepsRequest` uses the persisted sweep record (not in-memory
+  state) as the sole source of truth across restarts.
 
 ## Deep Docs
 

--- a/walletcore/AGENTS.md
+++ b/walletcore/AGENTS.md
@@ -12,11 +12,25 @@ btcwallet.BtcWallet regardless of the underlying chain source.
 - `Wallet` — Core wallet struct embedding `input.Signer`. Provides key derivation, P2TR address generation, balance queries, and UTXO listing. Also implements `proofkeys.Backend` (via `ProofSigner` method). Chain-specific implementations embed this to satisfy `round.ClientWallet`.
 - `BoardingBackendBase` — Shared boarding functionality: taproot script import under BIP86 scope, imported address tracking for UTXO filtering, and HD key derivation. Chain-specific adapters embed this and add `ListUnspent`, `GetTransaction`, `GetBlock`.
 - `Config` — Base configuration (seed, chain params, recovery window, DB dir, logger) shared by all btcwallet-backed wallet backends.
+- `LockID` — `[32]byte` caller-scoped output lease identifier. Lives in
+  `walletcore` (not `wallet`) so packages like `txconfirm` that would create
+  import cycles through `wallet` can depend on a single canonical type. Each
+  subsystem derives a stable ID (e.g. `sha256("txconfirm")[:32]`). Re-exported
+  as a type alias from `wallet`.
+- `OutputLeaser` — Interface for wallet backends supporting output locking:
+  `LeaseOutput(ctx, id, outpoint, expiry)` and `ReleaseOutput(ctx, id,
+  outpoint)`. Shape matches btcwallet and lndclient WalletKit directly.
+  Re-exported as a type alias from `wallet`.
+- `Utxo` — Simplified UTXO representation (outpoint, pkScript, amount,
+  confirmations) for boarding-UTXO detection and fee-input selection.
 
 ## Relationships
 
 - **Depends on**: `build` (context logger extraction), `proofkeys` (implements Backend), `indexer` (SchnorrSigner interface).
-- **Depended on by**: `lwwallet` (embeds Wallet + BoardingBackendBase), `btcwbackend` (embeds Wallet + BoardingBackendBase), `darepod` (proof key backend).
+- **Depended on by**: `lwwallet` (embeds Wallet + BoardingBackendBase),
+  `btcwbackend` (embeds Wallet + BoardingBackendBase), `darepod` (proof key
+  backend), `txconfirm` (LockID + OutputLeaser + Utxo without cycling through
+  wallet), `wallet` (re-exports LockID and OutputLeaser as type aliases).
 
 ## Invariants
 

--- a/walletcore/CLAUDE.md
+++ b/walletcore/CLAUDE.md
@@ -12,11 +12,25 @@ btcwallet.BtcWallet regardless of the underlying chain source.
 - `Wallet` — Core wallet struct embedding `input.Signer`. Provides key derivation, P2TR address generation, balance queries, and UTXO listing. Also implements `proofkeys.Backend` (via `ProofSigner` method). Chain-specific implementations embed this to satisfy `round.ClientWallet`.
 - `BoardingBackendBase` — Shared boarding functionality: taproot script import under BIP86 scope, imported address tracking for UTXO filtering, and HD key derivation. Chain-specific adapters embed this and add `ListUnspent`, `GetTransaction`, `GetBlock`.
 - `Config` — Base configuration (seed, chain params, recovery window, DB dir, logger) shared by all btcwallet-backed wallet backends.
+- `LockID` — `[32]byte` caller-scoped output lease identifier. Lives in
+  `walletcore` (not `wallet`) so packages like `txconfirm` that would create
+  import cycles through `wallet` can depend on a single canonical type. Each
+  subsystem derives a stable ID (e.g. `sha256("txconfirm")[:32]`). Re-exported
+  as a type alias from `wallet`.
+- `OutputLeaser` — Interface for wallet backends supporting output locking:
+  `LeaseOutput(ctx, id, outpoint, expiry)` and `ReleaseOutput(ctx, id,
+  outpoint)`. Shape matches btcwallet and lndclient WalletKit directly.
+  Re-exported as a type alias from `wallet`.
+- `Utxo` — Simplified UTXO representation (outpoint, pkScript, amount,
+  confirmations) for boarding-UTXO detection and fee-input selection.
 
 ## Relationships
 
 - **Depends on**: `build` (context logger extraction), `proofkeys` (implements Backend), `indexer` (SchnorrSigner interface).
-- **Depended on by**: `lwwallet` (embeds Wallet + BoardingBackendBase), `btcwbackend` (embeds Wallet + BoardingBackendBase), `darepod` (proof key backend).
+- **Depended on by**: `lwwallet` (embeds Wallet + BoardingBackendBase),
+  `btcwbackend` (embeds Wallet + BoardingBackendBase), `darepod` (proof key
+  backend), `txconfirm` (LockID + OutputLeaser + Utxo without cycling through
+  wallet), `wallet` (re-exports LockID and OutputLeaser as type aliases).
 
 ## Invariants
 


### PR DESCRIPTION
Automated nightly doc-gardening sweep for 2026-05-14.

## Summary

- Created new `fraud/CLAUDE.md` (recipient fraud watcher actor — new package)
- Created new `internal/indexerlimits/CLAUDE.md` (cursor bounds utility — new package)
- Updated 14 existing packages: `unroll`, `vtxo`, `wallet`, `walletcore`, `darepod`, `ledger`, `txconfirm`, `chainsource`, `lib/arkscript`, `db`, `round`, `cmd/darepocli/darepoclicommands`, `chainbackends`, `indexer`
- Updated `ARCHITECTURE.md` to list `fraud` and `internal/indexerlimits`
- All CLAUDE.md files mirrored to AGENTS.md

## Key changes reflected

- **fraud**: New recipient fraud-watcher actor that arms passive chainsource spend watches on OOR VTXO ancestry and triggers `TriggerFraudSpend` unroll jobs
- **unroll**: Fraud-triggered checkpoint deferral (`DeferredCheckpoint`, `FraudCheckpointSafetyMargin`)
- **wallet / walletcore**: Boarding-timeout sweep actor subsystem; `LockID`/`OutputLeaser`/`Utxo` moved to `walletcore`
- **darepod**: `SweepBoardingUTXOs` now delegates to wallet actor; incoming metadata helpers
- **ledger**: `FeeTypeOnchainSweep`, boarding-sweep UTXO classifications
- **db**: `LatestMigrationVersion = 12`

## Review checklist

- [ ] Review ARCHITECTURE.md diff for layer accuracy
- [ ] Review `fraud/CLAUDE.md` for completeness
- [ ] Review `wallet/CLAUDE.md` boarding-sweep additions
- [ ] Review `darepod/CLAUDE.md` updated sweep invariants

🤖 Generated with [Claude Code](https://claude.com/claude-code)