### PR TITLE
chainfees: add multi-provider fee estimators

### DIFF
--- a/chainbackends/AGENTS.md
+++ b/chainbackends/AGENTS.md
@@ -19,8 +19,9 @@ estimation, and optional v3 package relay via a pluggable `PackageSubmitter`.
   environments that do not support package relay.
 - `LndClientTxBroadcaster` — Implements `TxBroadcaster` using
   `lndclient.WalletKitClient`.
-- `LndClientFeeEstimator` — Implements `chainfee.Estimator` using
-  `lndclient.WalletKitClient` with a 30-second per-call timeout.
+- `LndClientFeeEstimator` — Type alias for
+  `chainfees.WalletKitEstimator`, backed by `lndclient.WalletKitClient` with
+  a 15-second per-call timeout and last-good fallback semantics.
 - `LndClientChainNotifier` / `LndClientChainNotifierConfig` — Implements
   `chainntnfs.ChainNotifier` using lndclient. Uses a 15-second registration
   timeout and goroutine-based forwarding to bridge lndclient's height-only

--- a/chainbackends/CLAUDE.md
+++ b/chainbackends/CLAUDE.md
@@ -19,8 +19,9 @@ estimation, and optional v3 package relay via a pluggable `PackageSubmitter`.
   environments that do not support package relay.
 - `LndClientTxBroadcaster` — Implements `TxBroadcaster` using
   `lndclient.WalletKitClient`.
-- `LndClientFeeEstimator` — Implements `chainfee.Estimator` using
-  `lndclient.WalletKitClient` with a 30-second per-call timeout.
+- `LndClientFeeEstimator` — Type alias for
+  `chainfees.WalletKitEstimator`, backed by `lndclient.WalletKitClient` with
+  a 15-second per-call timeout and last-good fallback semantics.
 - `LndClientChainNotifier` / `LndClientChainNotifierConfig` — Implements
   `chainntnfs.ChainNotifier` using lndclient. Uses a 15-second registration
   timeout and goroutine-based forwarding to bridge lndclient's height-only

--- a/chainbackends/lnd_test.go
+++ b/chainbackends/lnd_test.go
@@ -113,7 +113,8 @@ func TestLndClientFeeEstimatorReturnsWalletKitSatPerKW(t *testing.T) {
 	walletKit := &stubWalletKitFeeEstimator{
 		rate: wantRate,
 	}
-	estimator := NewLndClientFeeEstimator(walletKit)
+	estimator, err := NewLndClientFeeEstimator(walletKit)
+	require.NoError(t, err)
 
 	gotRate, err := estimator.EstimateFeePerKW(6)
 	require.NoError(t, err)

--- a/chainbackends/lndclient_adapters.go
+++ b/chainbackends/lndclient_adapters.go
@@ -10,6 +10,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/build"
+	"github.com/lightninglabs/darepo-client/chainfees"
 	"github.com/lightninglabs/lndclient"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
@@ -42,55 +43,13 @@ func (b *LndClientTxBroadcaster) PublishTransaction(ctx context.Context,
 var _ TxBroadcaster = (*LndClientTxBroadcaster)(nil)
 
 // LndClientFeeEstimator implements chainfee.Estimator using lndclient.
-type LndClientFeeEstimator struct {
-	walletKit lndclient.WalletKitClient
-}
+type LndClientFeeEstimator = chainfees.WalletKitEstimator
 
 // NewLndClientFeeEstimator creates a new fee estimator backed by lndclient.
 func NewLndClientFeeEstimator(
 	walletKit lndclient.WalletKitClient) *LndClientFeeEstimator {
 
-	return &LndClientFeeEstimator{
-		walletKit: walletKit,
-	}
-}
-
-// Start is a no-op for lndclient-backed estimators since the connection is
-// already established.
-func (e *LndClientFeeEstimator) Start() error {
-	return nil
-}
-
-// Stop is a no-op for lndclient-backed estimators.
-func (e *LndClientFeeEstimator) Stop() error {
-	return nil
-}
-
-// EstimateFeePerKW returns the estimated fee rate in satoshis per kilo-weight
-// unit for the given confirmation target.
-func (e *LndClientFeeEstimator) EstimateFeePerKW(numBlocks uint32) (
-	chainfee.SatPerKWeight, error) {
-
-	ctx, cancel := context.WithTimeout(
-		context.Background(), 30*time.Second,
-	)
-	defer cancel()
-	satPerKw, err := e.walletKit.EstimateFeeRate(
-		ctx, int32(numBlocks),
-	)
-	if err != nil {
-		return 0, fmt.Errorf("estimate fee rate: %w", err)
-	}
-
-	return satPerKw, nil
-}
-
-// RelayFeePerKW returns the minimum fee rate required for transactions to be
-// relayed. For remote lnd, we return a reasonable default.
-func (e *LndClientFeeEstimator) RelayFeePerKW() chainfee.SatPerKWeight {
-
-	// Default relay fee of 1 sat/vbyte = 250 sat/kw.
-	return chainfee.SatPerKWeight(250)
+	return chainfees.NewWalletKitEstimator(walletKit, nil)
 }
 
 // Ensure LndClientFeeEstimator implements chainfee.Estimator.

--- a/chainbackends/lndclient_adapters.go
+++ b/chainbackends/lndclient_adapters.go
@@ -50,8 +50,8 @@ type LndClientFeeEstimator = chainfees.WalletKitEstimator
 // successful rate (or the relay floor before any success) rather than
 // propagating the error, so a transient WalletKit outage does not abort fee
 // estimation on the standalone LND backend path.
-func NewLndClientFeeEstimator(
-	walletKit lndclient.WalletKitClient) *LndClientFeeEstimator {
+func NewLndClientFeeEstimator(walletKit lndclient.WalletKitClient) (
+	*LndClientFeeEstimator, error) {
 
 	return chainfees.NewFallbackWalletKitEstimator(walletKit, nil)
 }
@@ -372,7 +372,9 @@ func (c LNDBackendFromLndClientConfig) WithLogger(
 // services. This is a convenience function for creating a backend from a
 // remote lnd connection. The config must include LND; use WithLogger() to
 // inject a specific logger.
-func NewLNDBackendFromLndClient(cfg LNDBackendFromLndClientConfig) *LNDBackend {
+func NewLNDBackendFromLndClient(cfg LNDBackendFromLndClientConfig) (*LNDBackend,
+	error) {
+
 	cfg.Log.UnwrapOr(btclog.Disabled).InfoS(
 		context.Background(),
 		"Creating LND backend from lndclient services",
@@ -384,12 +386,15 @@ func NewLNDBackendFromLndClient(cfg LNDBackendFromLndClientConfig) *LNDBackend {
 		LND: cfg.LND,
 		Log: cfg.Log,
 	})
-	feeEstimator := NewLndClientFeeEstimator(cfg.LND.WalletKit)
+	feeEstimator, err := NewLndClientFeeEstimator(cfg.LND.WalletKit)
+	if err != nil {
+		return nil, fmt.Errorf("create fee estimator: %w", err)
+	}
 	broadcaster := NewLndClientTxBroadcaster(cfg.LND.WalletKit)
 
 	backend := NewLNDBackend(notifier, feeEstimator, broadcaster)
 	backend.Log = cfg.Log
 	backend.packageSubmitter = cfg.PackageSubmitter
 
-	return backend
+	return backend, nil
 }

--- a/chainbackends/lndclient_adapters.go
+++ b/chainbackends/lndclient_adapters.go
@@ -46,10 +46,14 @@ var _ TxBroadcaster = (*LndClientTxBroadcaster)(nil)
 type LndClientFeeEstimator = chainfees.WalletKitEstimator
 
 // NewLndClientFeeEstimator creates a new fee estimator backed by lndclient.
+// It uses last-good fallback semantics: a WalletKit error returns the last
+// successful rate (or the relay floor before any success) rather than
+// propagating the error, so a transient WalletKit outage does not abort fee
+// estimation on the standalone LND backend path.
 func NewLndClientFeeEstimator(
 	walletKit lndclient.WalletKitClient) *LndClientFeeEstimator {
 
-	return chainfees.NewWalletKitEstimator(walletKit, nil)
+	return chainfees.NewFallbackWalletKitEstimator(walletKit, nil)
 }
 
 // Ensure LndClientFeeEstimator implements chainfee.Estimator.

--- a/chainfees/doc.go
+++ b/chainfees/doc.go
@@ -1,0 +1,3 @@
+// Package chainfees provides reusable chainfee.Estimator implementations and
+// combinators for wallet and daemon chain backends.
+package chainfees

--- a/chainfees/log.go
+++ b/chainfees/log.go
@@ -1,0 +1,4 @@
+package chainfees
+
+// Subsystem is the logging subsystem tag for the chainfees fee estimators.
+const Subsystem = "FEES"

--- a/chainfees/mempoolspace.go
+++ b/chainfees/mempoolspace.go
@@ -1,0 +1,254 @@
+package chainfees
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
+)
+
+const (
+	defaultMempoolSpaceTimeout  = 5 * time.Second
+	defaultMempoolSpaceCacheTTL = 30 * time.Second
+	maxMempoolSpaceSatPerVByte  = 1_000_000
+	satPerVByteToSatPerKWeight  = 250
+
+	mempoolSpaceMainnetURL = "https://mempool.space/api/v1/fees/recommended"
+	mempoolSpaceTestnetURL = "https://mempool.space/testnet/api/v1/fees/" +
+		"recommended"
+	mempoolSpaceTestnet4URL = "https://mempool.space/testnet4/api/v1/fees" +
+		"/recommended"
+	mempoolSpaceSignetURL = "https://mempool.space/signet/api/v1/fees/" +
+		"recommended"
+)
+
+// MempoolSpaceConfig configures a MempoolSpaceEstimator.
+type MempoolSpaceConfig struct {
+	// URL optionally overrides the network-default mempool.space endpoint.
+	URL string
+
+	// Params selects the default endpoint when URL is empty.
+	Params *chaincfg.Params
+
+	// Log is an optional structured logger.
+	Log btclog.Logger
+
+	// Timeout bounds each HTTP request.
+	Timeout time.Duration
+
+	// CacheTTL controls how long a successful recommended-fee response is
+	// reused before the estimator queries mempool.space again.
+	CacheTTL time.Duration
+}
+
+// MempoolSpaceEstimator estimates fees from mempool.space's recommended-fee
+// endpoint.
+type MempoolSpaceEstimator struct {
+	url    string
+	client *http.Client
+	log    btclog.Logger
+
+	mu           sync.Mutex
+	cacheTTL     time.Duration
+	cacheExpires time.Time
+	cachedFees   mempoolSpaceRecommendedFees
+	now          func() time.Time
+}
+
+type mempoolSpaceRecommendedFees struct {
+	FastestFee  int64 `json:"fastestFee"`  //nolint:tagliatelle
+	HalfHourFee int64 `json:"halfHourFee"` //nolint:tagliatelle
+	HourFee     int64 `json:"hourFee"`     //nolint:tagliatelle
+	EconomyFee  int64 `json:"economyFee"`  //nolint:tagliatelle
+	MinimumFee  int64 `json:"minimumFee"`  //nolint:tagliatelle
+}
+
+// NewMempoolSpaceEstimator creates a fee estimator backed by mempool.space.
+func NewMempoolSpaceEstimator(cfg MempoolSpaceConfig) (*MempoolSpaceEstimator,
+	error) {
+
+	url := cfg.URL
+	if url == "" {
+		var err error
+		url, err = DefaultMempoolSpaceURL(cfg.Params)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	log := cfg.Log
+	if log == nil {
+		log = btclog.Disabled
+	}
+
+	timeout := cfg.Timeout
+	if timeout <= 0 {
+		timeout = defaultMempoolSpaceTimeout
+	}
+
+	cacheTTL := cfg.CacheTTL
+	if cacheTTL <= 0 {
+		cacheTTL = defaultMempoolSpaceCacheTTL
+	}
+
+	return &MempoolSpaceEstimator{
+		url: url,
+		client: &http.Client{
+			Timeout: timeout,
+		},
+		log:      log,
+		cacheTTL: cacheTTL,
+		now:      time.Now,
+	}, nil
+}
+
+// DefaultMempoolSpaceURL returns the recommended-fee endpoint for params.
+func DefaultMempoolSpaceURL(params *chaincfg.Params) (string, error) {
+	if params == nil {
+		return "", fmt.Errorf("chain params are required")
+	}
+
+	switch {
+	case params.Net == wire.MainNet:
+		return mempoolSpaceMainnetURL, nil
+
+	case params.Net == wire.TestNet3:
+		return mempoolSpaceTestnetURL, nil
+
+	case params.Net == wire.TestNet4:
+		return mempoolSpaceTestnet4URL, nil
+
+	case params.Name == chaincfg.SigNetParams.Name:
+		return mempoolSpaceSignetURL, nil
+
+	default:
+		return "", fmt.Errorf("unsupported mempool.space network %q",
+			params.Name)
+	}
+}
+
+// EstimateFeePerKW returns a mempool.space recommended fee for confTarget.
+func (e *MempoolSpaceEstimator) EstimateFeePerKW(confTarget uint32) (
+	chainfee.SatPerKWeight, error) {
+
+	fees, err := e.recommendedFees()
+	if err != nil {
+		return 0, err
+	}
+
+	satPerVByte := fees.forTarget(confTarget)
+	if satPerVByte <= 0 {
+		return 0, fmt.Errorf("mempool.space returned non-positive fee "+
+			"rate %d sat/vB for target %d", satPerVByte, confTarget)
+	}
+	if satPerVByte > maxMempoolSpaceSatPerVByte {
+		return 0, fmt.Errorf("mempool.space returned excessive fee "+
+			"rate %d sat/vB for target %d", satPerVByte, confTarget)
+	}
+
+	// 1 vbyte is 4 weight units, so 1 sat/vB is exactly 250 sat/kW.
+	rate := chainfee.SatPerKWeight(satPerVByte * satPerVByteToSatPerKWeight)
+	if rate < chainfee.FeePerKwFloor {
+		rate = chainfee.FeePerKwFloor
+	}
+
+	e.log.DebugS(context.Background(), "mempool.space fee estimate",
+		slog.Uint64("conf_target", uint64(confTarget)),
+		slog.Int64("rate_sat_kw", int64(rate)),
+		slog.Int64("rate_sat_vbyte", int64(rate.FeePerVByte())),
+	)
+
+	return rate, nil
+}
+
+// Start is a no-op because MempoolSpaceEstimator fetches on demand.
+func (e *MempoolSpaceEstimator) Start() error { return nil }
+
+// Stop is a no-op because MempoolSpaceEstimator fetches on demand.
+func (e *MempoolSpaceEstimator) Stop() error { return nil }
+
+// RelayFeePerKW returns the floor relay fee.
+func (e *MempoolSpaceEstimator) RelayFeePerKW() chainfee.SatPerKWeight {
+	return chainfee.FeePerKwFloor
+}
+
+func (e *MempoolSpaceEstimator) fetchRecommendedFees() (
+	mempoolSpaceRecommendedFees, error) {
+
+	resp, err := e.client.Get(e.url)
+	if err != nil {
+		return mempoolSpaceRecommendedFees{}, fmt.Errorf("query "+
+			"mempool.space fees: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return mempoolSpaceRecommendedFees{}, fmt.Errorf("query "+
+			"mempool.space fees: status %s", resp.Status)
+	}
+
+	var fees mempoolSpaceRecommendedFees
+	if err := json.NewDecoder(resp.Body).Decode(&fees); err != nil {
+		return mempoolSpaceRecommendedFees{}, fmt.Errorf("decode "+
+			"mempool.space fees: %w", err)
+	}
+
+	return fees, nil
+}
+
+func (e *MempoolSpaceEstimator) recommendedFees() (mempoolSpaceRecommendedFees,
+	error) {
+
+	now := e.now()
+	e.mu.Lock()
+	if now.Before(e.cacheExpires) {
+		fees := e.cachedFees
+		e.mu.Unlock()
+
+		return fees, nil
+	}
+	e.mu.Unlock()
+
+	fees, err := e.fetchRecommendedFees()
+	if err != nil {
+		return mempoolSpaceRecommendedFees{}, err
+	}
+
+	e.mu.Lock()
+	e.cachedFees = fees
+	e.cacheExpires = e.now().Add(e.cacheTTL)
+	e.mu.Unlock()
+
+	return fees, nil
+}
+
+func (f mempoolSpaceRecommendedFees) forTarget(target uint32) int64 {
+	switch {
+	case target <= 1:
+		return f.FastestFee
+
+	case target <= 3:
+		return f.HalfHourFee
+
+	case target <= 6:
+		return f.HourFee
+
+	case target <= 144:
+		return f.EconomyFee
+
+	default:
+		return f.MinimumFee
+	}
+}
+
+var _ chainfee.Estimator = (*MempoolSpaceEstimator)(nil)

--- a/chainfees/mempoolspace.go
+++ b/chainfees/mempoolspace.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
+	"net"
 	"net/http"
+	"net/url"
 	"sync"
 	"time"
 
@@ -20,6 +23,14 @@ const (
 	defaultMempoolSpaceCacheTTL = 30 * time.Second
 	maxMempoolSpaceSatPerVByte  = 1_000_000
 	satPerVByteToSatPerKWeight  = 250
+
+	// maxMempoolSpaceResponseBytes bounds the recommended-fee response body
+	// we are willing to read. A valid response is a small JSON object with
+	// five integer fields (well under 1 KiB); the generous 64 KiB cap
+	// guards against a malicious or misbehaving endpoint streaming an
+	// unbounded body to exhaust memory, since http.Client.Timeout bounds
+	// wall-clock time but not the number of bytes read.
+	maxMempoolSpaceResponseBytes = 64 << 10
 
 	mempoolSpaceMainnetURL = "https://mempool.space/api/v1/fees/recommended"
 	mempoolSpaceTestnetURL = "https://mempool.space/testnet/api/v1/fees/" +
@@ -75,13 +86,21 @@ type mempoolSpaceRecommendedFees struct {
 func NewMempoolSpaceEstimator(cfg MempoolSpaceConfig) (*MempoolSpaceEstimator,
 	error) {
 
-	url := cfg.URL
-	if url == "" {
+	endpoint := cfg.URL
+	if endpoint == "" {
 		var err error
-		url, err = DefaultMempoolSpaceURL(cfg.Params)
+		endpoint, err = DefaultMempoolSpaceURL(cfg.Params)
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	// Reject a non-TLS override before it can leak fee data to a network
+	// attacker who could tamper with the response (plaintext http is
+	// allowed only for loopback, which the local httptest server relies
+	// on).
+	if err := validateMempoolSpaceURL(endpoint); err != nil {
+		return nil, err
 	}
 
 	log := cfg.Log
@@ -100,7 +119,7 @@ func NewMempoolSpaceEstimator(cfg MempoolSpaceConfig) (*MempoolSpaceEstimator,
 	}
 
 	return &MempoolSpaceEstimator{
-		url: url,
+		url: endpoint,
 		client: &http.Client{
 			Timeout: timeout,
 		},
@@ -133,6 +152,51 @@ func DefaultMempoolSpaceURL(params *chaincfg.Params) (string, error) {
 		return "", fmt.Errorf("unsupported mempool.space network %q",
 			params.Name)
 	}
+}
+
+// validateMempoolSpaceURL rejects an endpoint that would expose fee data to
+// tampering. It requires an absolute https URL, permitting plaintext http only
+// for a loopback host (used by the local test server).
+func validateMempoolSpaceURL(raw string) error {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid mempool.space URL %q: %w", raw, err)
+	}
+
+	if parsed.Host == "" {
+		return fmt.Errorf("mempool.space URL %q must be absolute "+
+			"with a host", raw)
+	}
+
+	switch parsed.Scheme {
+	case "https":
+		return nil
+
+	case "http":
+		if isLoopbackHost(parsed.Hostname()) {
+			return nil
+		}
+
+		return fmt.Errorf("mempool.space URL %q must use https; "+
+			"plaintext http is only allowed for loopback", raw)
+
+	default:
+		return fmt.Errorf("mempool.space URL %q has unsupported "+
+			"scheme %q", raw, parsed.Scheme)
+	}
+}
+
+// isLoopbackHost reports whether host is "localhost" or a loopback IP literal.
+func isLoopbackHost(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+
+	return false
 }
 
 // EstimateFeePerKW returns a mempool.space recommended fee for confTarget.
@@ -197,8 +261,12 @@ func (e *MempoolSpaceEstimator) fetchRecommendedFees() (
 			"mempool.space fees: status %s", resp.Status)
 	}
 
+	// Bound the body we read so a malicious or misbehaving endpoint cannot
+	// exhaust memory with an unbounded response.
+	body := io.LimitReader(resp.Body, maxMempoolSpaceResponseBytes)
+
 	var fees mempoolSpaceRecommendedFees
-	if err := json.NewDecoder(resp.Body).Decode(&fees); err != nil {
+	if err := json.NewDecoder(body).Decode(&fees); err != nil {
 		return mempoolSpaceRecommendedFees{}, fmt.Errorf("decode "+
 			"mempool.space fees: %w", err)
 	}

--- a/chainfees/mempoolspace_test.go
+++ b/chainfees/mempoolspace_test.go
@@ -218,3 +218,89 @@ func TestMempoolSpaceEstimatorCachesRecommendedFees(t *testing.T) {
 	require.Greater(t, third, second)
 	require.Equal(t, uint32(2), requests.Load())
 }
+
+func TestMempoolSpaceEstimatorRejectsInsecureURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		url     string
+		wantErr string
+	}{
+		{
+			name: "https ok",
+			url:  "https://mempool.space/api/v1/fees/recommended",
+		},
+		{
+			name: "loopback http ok",
+			url:  "http://127.0.0.1:3000/api",
+		},
+		{
+			name: "localhost http ok",
+			url:  "http://localhost:3000/api",
+		},
+		{
+			name:    "public http rejected",
+			url:     "http://mempool.space/api/v1/fees/recommended",
+			wantErr: "must use https",
+		},
+		{
+			name:    "unsupported scheme rejected",
+			url:     "ftp://mempool.space/fees",
+			wantErr: "unsupported scheme",
+		},
+		{
+			name:    "missing host rejected",
+			url:     "https://",
+			wantErr: "must be absolute",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := NewMempoolSpaceEstimator(MempoolSpaceConfig{
+				URL: tc.url,
+			})
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.ErrorContains(t, err, tc.wantErr)
+		})
+	}
+}
+
+func TestMempoolSpaceEstimatorBoundsResponseBody(t *testing.T) {
+	t.Parallel()
+
+	// The server streams a valid prefix followed by megabytes of padding
+	// inside an unterminated JSON object. The LimitReader truncates the
+	// body, so the decode fails rather than buffering the whole stream into
+	// memory.
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			_, err := fmt.Fprint(w, `{"fastestFee": 8, "pad": "`)
+			require.NoError(t, err)
+
+			padding := make([]byte, maxMempoolSpaceResponseBytes*2)
+			for i := range padding {
+				padding[i] = 'A'
+			}
+			_, err = w.Write(padding)
+			require.NoError(t, err)
+		},
+	))
+	defer server.Close()
+
+	estimator, err := NewMempoolSpaceEstimator(MempoolSpaceConfig{
+		URL: server.URL,
+	})
+	require.NoError(t, err)
+
+	_, err = estimator.EstimateFeePerKW(1)
+	require.ErrorContains(t, err, "decode mempool.space fees")
+}

--- a/chainfees/mempoolspace_test.go
+++ b/chainfees/mempoolspace_test.go
@@ -1,0 +1,220 @@
+package chainfees
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultMempoolSpaceURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		params *chaincfg.Params
+		want   string
+	}{
+		{
+			name:   "mainnet",
+			params: &chaincfg.MainNetParams,
+			want:   mempoolSpaceMainnetURL,
+		},
+		{
+			name:   "testnet3",
+			params: &chaincfg.TestNet3Params,
+			want:   mempoolSpaceTestnetURL,
+		},
+		{
+			name:   "testnet4",
+			params: &chaincfg.TestNet4Params,
+			want:   mempoolSpaceTestnet4URL,
+		},
+		{
+			name:   "signet",
+			params: &chaincfg.SigNetParams,
+			want:   mempoolSpaceSignetURL,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := DefaultMempoolSpaceURL(tc.params)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestMempoolSpaceEstimatorMapsTargets(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			_, err := fmt.Fprint(w, `{
+				"fastestFee": 8,
+				"halfHourFee": 6,
+				"hourFee": 4,
+				"economyFee": 2,
+				"minimumFee": 1
+			}`)
+			require.NoError(t, err)
+		},
+	))
+	defer server.Close()
+
+	estimator, err := NewMempoolSpaceEstimator(MempoolSpaceConfig{
+		URL: server.URL,
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name   string
+		target uint32
+		want   chainfee.SatPerKWeight
+	}{
+		{
+			name:   "fastest",
+			target: 1,
+			want:   chainfee.SatPerKWeight(2_000),
+		},
+		{
+			name:   "half hour",
+			target: 3,
+			want:   chainfee.SatPerKWeight(1_500),
+		},
+		{
+			name:   "hour",
+			target: 6,
+			want:   chainfee.SatPerKWeight(1_000),
+		},
+		{
+			name:   "economy",
+			target: 12,
+			want:   chainfee.SatPerKWeight(500),
+		},
+		{
+			name:   "minimum",
+			target: 1_008,
+			want:   chainfee.FeePerKwFloor,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := estimator.EstimateFeePerKW(tc.target)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestMempoolSpaceEstimatorRejectsNonPositiveRates(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			_, err := fmt.Fprint(w, `{
+				"fastestFee": 0,
+				"halfHourFee": 0,
+				"hourFee": 0,
+				"economyFee": 0,
+				"minimumFee": 0
+			}`)
+			require.NoError(t, err)
+		},
+	))
+	defer server.Close()
+
+	estimator, err := NewMempoolSpaceEstimator(MempoolSpaceConfig{
+		URL: server.URL,
+	})
+	require.NoError(t, err)
+
+	_, err = estimator.EstimateFeePerKW(6)
+	require.ErrorContains(t, err, "non-positive fee rate")
+}
+
+func TestMempoolSpaceEstimatorRejectsExcessiveRates(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			_, err := fmt.Fprintf(w, `{
+				"fastestFee": %d,
+				"halfHourFee": %d,
+				"hourFee": %d,
+				"economyFee": %d,
+				"minimumFee": %d
+			}`, maxMempoolSpaceSatPerVByte+1,
+				maxMempoolSpaceSatPerVByte+1,
+				maxMempoolSpaceSatPerVByte+1,
+				maxMempoolSpaceSatPerVByte+1,
+				maxMempoolSpaceSatPerVByte+1)
+			require.NoError(t, err)
+		},
+	))
+	defer server.Close()
+
+	estimator, err := NewMempoolSpaceEstimator(MempoolSpaceConfig{
+		URL: server.URL,
+	})
+	require.NoError(t, err)
+
+	_, err = estimator.EstimateFeePerKW(6)
+	require.ErrorContains(t, err, "excessive fee rate")
+}
+
+func TestMempoolSpaceEstimatorCachesRecommendedFees(t *testing.T) {
+	t.Parallel()
+
+	var requests atomic.Uint32
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			count := requests.Add(1)
+			_, err := fmt.Fprintf(w, `{
+				"fastestFee": %d,
+				"halfHourFee": %d,
+				"hourFee": %d,
+				"economyFee": %d,
+				"minimumFee": %d
+			}`, count, count, count, count, count)
+			require.NoError(t, err)
+		},
+	))
+	defer server.Close()
+
+	estimator, err := NewMempoolSpaceEstimator(MempoolSpaceConfig{
+		URL:      server.URL,
+		CacheTTL: time.Minute,
+	})
+	require.NoError(t, err)
+
+	now := time.Unix(100, 0)
+	estimator.now = func() time.Time {
+		return now
+	}
+
+	first, err := estimator.EstimateFeePerKW(6)
+	require.NoError(t, err)
+	second, err := estimator.EstimateFeePerKW(6)
+	require.NoError(t, err)
+	require.Equal(t, first, second)
+	require.Equal(t, uint32(1), requests.Load())
+
+	now = now.Add(time.Minute)
+	third, err := estimator.EstimateFeePerKW(6)
+	require.NoError(t, err)
+	require.Greater(t, third, second)
+	require.Equal(t, uint32(2), requests.Load())
+}

--- a/chainfees/min_estimator.go
+++ b/chainfees/min_estimator.go
@@ -35,8 +35,9 @@ type MinEstimator struct {
 // NewMinEstimator constructs a chainfee.Estimator that chooses the lowest
 // successful estimate from children. Children should propagate backend errors
 // instead of returning stale fallback rates, otherwise a fallback floor can
-// incorrectly win over another provider's live estimate. Use
-// NewFailFastWalletKitEstimator when composing WalletKit in this selector.
+// incorrectly win over another provider's live estimate. The default
+// NewWalletKitEstimator is fail-fast and safe to compose here; do not pass a
+// NewFallbackWalletKitEstimator child into this selector.
 func NewMinEstimator(log btclog.Logger,
 	children ...NamedEstimator) (*MinEstimator, error) {
 

--- a/chainfees/min_estimator.go
+++ b/chainfees/min_estimator.go
@@ -1,0 +1,245 @@
+package chainfees
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
+)
+
+const minEstimatorDivergenceWarnPct = 20
+
+// NamedEstimator gives a child estimator a stable name for logs.
+type NamedEstimator struct {
+	// Name identifies the estimator in logs.
+	Name string
+
+	// Estimator is the wrapped fee estimator.
+	Estimator chainfee.Estimator
+}
+
+// MinEstimator queries multiple fee estimators and returns the minimum
+// successful estimate.
+type MinEstimator struct {
+	log      btclog.Logger
+	children []NamedEstimator
+
+	mu       sync.Mutex
+	lastRate chainfee.SatPerKWeight
+}
+
+// NewMinEstimator constructs a chainfee.Estimator that chooses the lowest
+// successful estimate from children. Children should propagate backend errors
+// instead of returning stale fallback rates, otherwise a fallback floor can
+// incorrectly win over another provider's live estimate. Use
+// NewFailFastWalletKitEstimator when composing WalletKit in this selector.
+func NewMinEstimator(log btclog.Logger,
+	children ...NamedEstimator) (*MinEstimator, error) {
+
+	if log == nil {
+		log = btclog.Disabled
+	}
+
+	if len(children) == 0 {
+		return nil, fmt.Errorf("at least one fee estimator is required")
+	}
+
+	for idx, child := range children {
+		if child.Name == "" {
+			return nil, fmt.Errorf("fee estimator %d has "+
+				"empty name", idx)
+		}
+		if child.Estimator == nil {
+			return nil, fmt.Errorf("fee estimator %q is nil",
+				child.Name)
+		}
+	}
+
+	return &MinEstimator{
+		log:      log,
+		children: children,
+	}, nil
+}
+
+// EstimateFeePerKW returns the minimum successful estimate for confTarget.
+func (e *MinEstimator) EstimateFeePerKW(confTarget uint32) (
+	chainfee.SatPerKWeight, error) {
+
+	var (
+		selectedName string
+		selectedRate chainfee.SatPerKWeight
+		maxRate      chainfee.SatPerKWeight
+		found        bool
+		lastErr      error
+	)
+
+	for _, child := range e.children {
+		rate, err := child.Estimator.EstimateFeePerKW(confTarget)
+		if err != nil {
+			lastErr = err
+			e.log.WarnS(
+				context.Background(),
+				"Fee provider estimate failed",
+				err,
+				slog.String("provider", child.Name),
+				slog.Uint64("conf_target", uint64(confTarget)),
+			)
+
+			continue
+		}
+
+		if rate < chainfee.FeePerKwFloor {
+			e.log.WarnS(context.Background(),
+				"Fee provider returned sub-floor rate; "+
+					"clamping",
+				fmt.Errorf("rate %d below floor %d", rate,
+					chainfee.FeePerKwFloor),
+				slog.String("provider", child.Name),
+				slog.Int64("raw_sat_kw", int64(rate)),
+			)
+			rate = chainfee.FeePerKwFloor
+		}
+
+		e.log.DebugS(context.Background(), "Fee provider estimate",
+			slog.String("provider", child.Name),
+			slog.Uint64("conf_target", uint64(confTarget)),
+			slog.Int64("rate_sat_kw", int64(rate)),
+			slog.Int64("rate_sat_vbyte", int64(rate.FeePerVByte())),
+		)
+
+		if !found || rate < selectedRate {
+			selectedName = child.Name
+			selectedRate = rate
+		}
+		if !found || rate > maxRate {
+			maxRate = rate
+		}
+		found = true
+	}
+
+	if !found {
+		fallback := e.fallbackRate()
+		e.log.WarnS(context.Background(),
+			"All fee providers failed; falling back to last "+
+				"successful rate",
+			lastErr,
+			slog.Uint64("conf_target", uint64(confTarget)),
+			slog.Int64("fallback_sat_kw", int64(fallback)),
+		)
+
+		return fallback, nil
+	}
+
+	if estimateDiverges(selectedRate, maxRate) {
+		e.log.InfoS(
+			context.Background(),
+			"Fee provider estimates diverged",
+			slog.Uint64("conf_target", uint64(confTarget)),
+			slog.Int64("min_sat_kw", int64(selectedRate)),
+			slog.Int64("max_sat_kw", int64(maxRate)),
+		)
+	}
+
+	e.log.InfoS(context.Background(), "Fee estimator selected provider",
+		slog.String("strategy", "min"),
+		slog.String("provider", selectedName),
+		slog.Uint64("conf_target", uint64(confTarget)),
+		slog.Int64("rate_sat_kw", int64(selectedRate)),
+		slog.Int64("rate_sat_vbyte", int64(selectedRate.FeePerVByte())),
+	)
+
+	e.mu.Lock()
+	e.lastRate = selectedRate
+	e.mu.Unlock()
+
+	return selectedRate, nil
+}
+
+// Start starts all child estimators.
+func (e *MinEstimator) Start() error {
+	var started []NamedEstimator
+	for _, child := range e.children {
+		if err := child.Estimator.Start(); err != nil {
+			startErr := fmt.Errorf("start fee estimator %q: %w",
+				child.Name, err)
+
+			return errors.Join(startErr, stopEstimators(started))
+		}
+
+		started = append(started, child)
+	}
+
+	return nil
+}
+
+// Stop stops all child estimators.
+func (e *MinEstimator) Stop() error {
+	var stopErr error
+	for _, child := range e.children {
+		if err := child.Estimator.Stop(); err != nil {
+			stopErr = errors.Join(
+				stopErr, fmt.Errorf("stop fee estimator "+
+					"%q: %w", child.Name, err),
+			)
+		}
+	}
+
+	return stopErr
+}
+
+// RelayFeePerKW returns the highest relay fee floor reported by a child.
+func (e *MinEstimator) RelayFeePerKW() chainfee.SatPerKWeight {
+	relayFee := chainfee.FeePerKwFloor
+	for _, child := range e.children {
+		childRelayFee := child.Estimator.RelayFeePerKW()
+		if childRelayFee > relayFee {
+			relayFee = childRelayFee
+		}
+	}
+
+	return relayFee
+}
+
+func (e *MinEstimator) fallbackRate() chainfee.SatPerKWeight {
+	e.mu.Lock()
+	cached := e.lastRate
+	e.mu.Unlock()
+
+	if cached < chainfee.FeePerKwFloor {
+		return chainfee.FeePerKwFloor
+	}
+
+	return cached
+}
+
+func stopEstimators(children []NamedEstimator) error {
+	var stopErr error
+	for i := len(children) - 1; i >= 0; i-- {
+		child := children[i]
+		if err := child.Estimator.Stop(); err != nil {
+			stopErr = errors.Join(
+				stopErr, fmt.Errorf("stop fee estimator %q "+
+					"after start failure: %w", child.Name,
+					err),
+			)
+		}
+	}
+
+	return stopErr
+}
+
+func estimateDiverges(minRate, maxRate chainfee.SatPerKWeight) bool {
+	if minRate <= 0 || maxRate <= minRate {
+		return false
+	}
+
+	threshold := minRate + (minRate * minEstimatorDivergenceWarnPct / 100)
+
+	return maxRate > threshold
+}
+
+var _ chainfee.Estimator = (*MinEstimator)(nil)

--- a/chainfees/min_estimator_test.go
+++ b/chainfees/min_estimator_test.go
@@ -1,0 +1,263 @@
+package chainfees
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
+	"github.com/stretchr/testify/require"
+)
+
+type testEstimator struct {
+	rate      chainfee.SatPerKWeight
+	relayFee  chainfee.SatPerKWeight
+	err       error
+	started   bool
+	stopped   bool
+	gotTarget uint32
+	startErr  error
+	stopErr   error
+}
+
+func (e *testEstimator) EstimateFeePerKW(target uint32) (chainfee.SatPerKWeight,
+	error) {
+
+	e.gotTarget = target
+
+	if e.err != nil {
+		return 0, e.err
+	}
+
+	return e.rate, nil
+}
+
+func (e *testEstimator) RelayFeePerKW() chainfee.SatPerKWeight {
+	return e.relayFee
+}
+
+func (e *testEstimator) Start() error {
+	e.started = true
+
+	return e.startErr
+}
+
+func (e *testEstimator) Stop() error {
+	e.stopped = true
+
+	return e.stopErr
+}
+
+func TestMinEstimatorChoosesLowestSuccessfulRate(t *testing.T) {
+	t.Parallel()
+
+	high := &testEstimator{
+		rate: chainfee.SatPerKWeight(10_000),
+	}
+	low := &testEstimator{
+		rate: chainfee.SatPerKWeight(500),
+	}
+
+	estimator, err := NewMinEstimator(nil,
+		NamedEstimator{
+			Name:      "walletkit",
+			Estimator: high,
+		},
+		NamedEstimator{
+			Name:      "mempool-space",
+			Estimator: low,
+		},
+	)
+	require.NoError(t, err)
+
+	got, err := estimator.EstimateFeePerKW(6)
+	require.NoError(t, err)
+	require.Equal(t, low.rate, got)
+	require.Equal(t, uint32(6), high.gotTarget)
+	require.Equal(t, uint32(6), low.gotTarget)
+}
+
+func TestMinEstimatorSkipsFailedProvider(t *testing.T) {
+	t.Parallel()
+
+	good := &testEstimator{
+		rate: chainfee.SatPerKWeight(750),
+	}
+
+	estimator, err := NewMinEstimator(nil,
+		NamedEstimator{
+			Name: "broken",
+			Estimator: &testEstimator{
+				err: fmt.Errorf("boom"),
+			},
+		},
+		NamedEstimator{
+			Name:      "good",
+			Estimator: good,
+		},
+	)
+	require.NoError(t, err)
+
+	got, err := estimator.EstimateFeePerKW(3)
+	require.NoError(t, err)
+	require.Equal(t, good.rate, got)
+}
+
+func TestMinEstimatorFallsBackToLastGoodRate(t *testing.T) {
+	t.Parallel()
+
+	child := &testEstimator{
+		rate: chainfee.SatPerKWeight(900),
+	}
+	estimator, err := NewMinEstimator(nil, NamedEstimator{
+		Name:      "child",
+		Estimator: child,
+	})
+	require.NoError(t, err)
+
+	got, err := estimator.EstimateFeePerKW(6)
+	require.NoError(t, err)
+	require.Equal(t, child.rate, got)
+
+	child.err = fmt.Errorf("offline")
+	got, err = estimator.EstimateFeePerKW(6)
+	require.NoError(t, err)
+	require.Equal(t, child.rate, got)
+}
+
+func TestMinEstimatorFallbackStartsAtFloor(t *testing.T) {
+	t.Parallel()
+
+	estimator, err := NewMinEstimator(nil, NamedEstimator{
+		Name: "broken",
+		Estimator: &testEstimator{
+			err: fmt.Errorf("offline"),
+		},
+	})
+	require.NoError(t, err)
+
+	got, err := estimator.EstimateFeePerKW(6)
+	require.NoError(t, err)
+	require.Equal(t, chainfee.FeePerKwFloor, got)
+}
+
+func TestMinEstimatorRelayFeeUsesHighestFloor(t *testing.T) {
+	t.Parallel()
+
+	estimator, err := NewMinEstimator(nil,
+		NamedEstimator{
+			Name: "low",
+			Estimator: &testEstimator{
+				relayFee: chainfee.SatPerKWeight(300),
+			},
+		},
+		NamedEstimator{
+			Name: "high",
+			Estimator: &testEstimator{
+				relayFee: chainfee.SatPerKWeight(1_000),
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	require.Equal(
+		t, chainfee.SatPerKWeight(1_000), estimator.RelayFeePerKW(),
+	)
+}
+
+func TestMinEstimatorStartsAndStopsChildren(t *testing.T) {
+	t.Parallel()
+
+	child := &testEstimator{}
+	estimator, err := NewMinEstimator(nil, NamedEstimator{
+		Name:      "child",
+		Estimator: child,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, estimator.Start())
+	require.True(t, child.started)
+
+	require.NoError(t, estimator.Stop())
+	require.True(t, child.stopped)
+}
+
+func TestMinEstimatorStopsStartedChildrenAfterStartFailure(t *testing.T) {
+	t.Parallel()
+
+	started := &testEstimator{}
+	failing := &testEstimator{
+		startErr: fmt.Errorf("start failed"),
+	}
+	unstarted := &testEstimator{}
+	estimator, err := NewMinEstimator(nil,
+		NamedEstimator{
+			Name:      "started",
+			Estimator: started,
+		},
+		NamedEstimator{
+			Name:      "failing",
+			Estimator: failing,
+		},
+		NamedEstimator{
+			Name:      "unstarted",
+			Estimator: unstarted,
+		},
+	)
+	require.NoError(t, err)
+
+	err = estimator.Start()
+	require.ErrorContains(t, err, "start fee estimator")
+	require.True(t, started.started)
+	require.True(t, started.stopped)
+	require.True(t, failing.started)
+	require.False(t, failing.stopped)
+	require.False(t, unstarted.started)
+	require.False(t, unstarted.stopped)
+}
+
+func TestMinEstimatorStopAggregatesErrors(t *testing.T) {
+	t.Parallel()
+
+	errOne := fmt.Errorf("one")
+	errTwo := fmt.Errorf("two")
+	first := &testEstimator{stopErr: errOne}
+	second := &testEstimator{stopErr: errTwo}
+	estimator, err := NewMinEstimator(nil,
+		NamedEstimator{
+			Name:      "first",
+			Estimator: first,
+		},
+		NamedEstimator{
+			Name:      "second",
+			Estimator: second,
+		},
+	)
+	require.NoError(t, err)
+
+	err = estimator.Stop()
+	require.Error(t, err)
+	require.True(t, errors.Is(err, errOne))
+	require.True(t, errors.Is(err, errTwo))
+	require.True(t, first.stopped)
+	require.True(t, second.stopped)
+}
+
+func TestEstimateDiverges(t *testing.T) {
+	t.Parallel()
+
+	require.False(
+		t,
+		estimateDiverges(
+			chainfee.SatPerKWeight(1_000),
+			chainfee.SatPerKWeight(1_200),
+		),
+	)
+	require.True(
+		t,
+		estimateDiverges(
+			chainfee.SatPerKWeight(1_000),
+			chainfee.SatPerKWeight(1_201),
+		),
+	)
+}

--- a/chainfees/walletkit.go
+++ b/chainfees/walletkit.go
@@ -139,7 +139,17 @@ func (e *WalletKitEstimator) EstimateFeePerKW(confTarget uint32) (
 				err)
 		}
 
-		fallback := e.fallbackRate()
+		fallback, ok := e.cachedRate()
+		if !ok {
+
+			// We have no prior successful estimate to fall back
+			// to, so we fail closed rather than serving the relay
+			// floor, which would silently underpay a transaction
+			// on a cold start.
+			return 0, fmt.Errorf("estimate walletkit fee rate (no "+
+				"cached rate for fallback): %w", err)
+		}
+
 		e.log.WarnS(
 			context.Background(),
 			"WalletKit EstimateFeeRate failed; falling back "+
@@ -188,18 +198,21 @@ func (e *WalletKitEstimator) RelayFeePerKW() chainfee.SatPerKWeight {
 	return chainfee.FeePerKwFloor
 }
 
-// fallbackRate returns the last successful WalletKit rate, clamped to the relay
-// floor.
-func (e *WalletKitEstimator) fallbackRate() chainfee.SatPerKWeight {
+// cachedRate returns the last successful WalletKit rate and whether one has
+// been recorded yet. Successful estimates are clamped to the relay floor before
+// caching, so a sub-floor cached value means no estimate has succeeded yet. A
+// fallback estimator has nothing safe to serve before its first success, so
+// callers must fail closed when ok is false rather than inventing a floor rate.
+func (e *WalletKitEstimator) cachedRate() (chainfee.SatPerKWeight, bool) {
 	e.mu.Lock()
 	cached := e.lastRate
 	e.mu.Unlock()
 
 	if cached < chainfee.FeePerKwFloor {
-		return chainfee.FeePerKwFloor
+		return 0, false
 	}
 
-	return cached
+	return cached, true
 }
 
 var _ chainfee.Estimator = (*WalletKitEstimator)(nil)

--- a/chainfees/walletkit.go
+++ b/chainfees/walletkit.go
@@ -54,7 +54,7 @@ type WalletKitEstimatorConfig struct {
 // NewFallbackWalletKitEstimator for a standalone estimator that should serve a
 // stale rate instead of failing.
 func NewWalletKitEstimator(walletKit lndclient.WalletKitClient,
-	log btclog.Logger) *WalletKitEstimator {
+	log btclog.Logger) (*WalletKitEstimator, error) {
 
 	return NewWalletKitEstimatorWithConfig(WalletKitEstimatorConfig{
 		WalletKit: walletKit,
@@ -65,7 +65,7 @@ func NewWalletKitEstimator(walletKit lndclient.WalletKitClient,
 // NewWalletKitEstimatorWithTimeout builds a fail-fast WalletKitEstimator with a
 // custom per-call timeout.
 func NewWalletKitEstimatorWithTimeout(walletKit lndclient.WalletKitClient,
-	log btclog.Logger, timeout time.Duration) *WalletKitEstimator {
+	log btclog.Logger, timeout time.Duration) (*WalletKitEstimator, error) {
 
 	return NewWalletKitEstimatorWithConfig(WalletKitEstimatorConfig{
 		WalletKit: walletKit,
@@ -80,7 +80,7 @@ func NewWalletKitEstimatorWithTimeout(walletKit lndclient.WalletKitClient,
 // never compose it inside a selector, where a stale fallback could beat
 // another live provider.
 func NewFallbackWalletKitEstimator(walletKit lndclient.WalletKitClient,
-	log btclog.Logger) *WalletKitEstimator {
+	log btclog.Logger) (*WalletKitEstimator, error) {
 
 	return NewWalletKitEstimatorWithConfig(WalletKitEstimatorConfig{
 		WalletKit:       walletKit,
@@ -89,12 +89,14 @@ func NewFallbackWalletKitEstimator(walletKit lndclient.WalletKitClient,
 	})
 }
 
-// NewWalletKitEstimatorWithConfig builds a WalletKitEstimator from cfg.
-func NewWalletKitEstimatorWithConfig(
-	cfg WalletKitEstimatorConfig) *WalletKitEstimator {
+// NewWalletKitEstimatorWithConfig builds a WalletKitEstimator from cfg. It
+// returns an error when the WalletKit client is missing, rather than a typed
+// nil pointer that would panic on first use once boxed into an interface.
+func NewWalletKitEstimatorWithConfig(cfg WalletKitEstimatorConfig) (
+	*WalletKitEstimator, error) {
 
 	if cfg.WalletKit == nil {
-		return nil
+		return nil, fmt.Errorf("walletkit client is required")
 	}
 
 	log := cfg.Log
@@ -112,7 +114,7 @@ func NewWalletKitEstimatorWithConfig(
 		log:             log,
 		estimateTimeout: timeout,
 		fallbackOnError: cfg.FallbackOnError,
-	}
+	}, nil
 }
 
 // EstimateFeePerKW returns the current chain fee rate for the given

--- a/chainfees/walletkit.go
+++ b/chainfees/walletkit.go
@@ -40,44 +40,52 @@ type WalletKitEstimatorConfig struct {
 	Timeout time.Duration
 
 	// FallbackOnError makes WalletKit errors return the last successful
-	// rate, or the relay floor before any successful estimate. Leave this
-	// disabled when composing WalletKit inside a selector so stale/floor
-	// values cannot beat another live provider.
+	// rate, or the relay floor before any successful estimate. It defaults
+	// to disabled (fail-fast): errors propagate to the caller. Only enable
+	// it for a standalone estimator that prefers a stale rate over a hard
+	// failure; never enable it when composing WalletKit inside a selector,
+	// where a stale/floor value could beat another live provider.
 	FallbackOnError bool
 }
 
-// NewWalletKitEstimator builds a WalletKitEstimator backed by walletKit.
+// NewWalletKitEstimator builds a fail-fast WalletKitEstimator backed by
+// walletKit: WalletKit errors propagate to the caller. This is the safe
+// default for composing WalletKit inside a selector. Use
+// NewFallbackWalletKitEstimator for a standalone estimator that should serve a
+// stale rate instead of failing.
 func NewWalletKitEstimator(walletKit lndclient.WalletKitClient,
-	log btclog.Logger) *WalletKitEstimator {
-
-	return NewWalletKitEstimatorWithConfig(WalletKitEstimatorConfig{
-		WalletKit:       walletKit,
-		Log:             log,
-		FallbackOnError: true,
-	})
-}
-
-// NewWalletKitEstimatorWithTimeout builds a WalletKitEstimator with a custom
-// per-call timeout.
-func NewWalletKitEstimatorWithTimeout(walletKit lndclient.WalletKitClient,
-	log btclog.Logger, timeout time.Duration) *WalletKitEstimator {
-
-	return NewWalletKitEstimatorWithConfig(WalletKitEstimatorConfig{
-		WalletKit:       walletKit,
-		Log:             log,
-		Timeout:         timeout,
-		FallbackOnError: true,
-	})
-}
-
-// NewFailFastWalletKitEstimator builds a WalletKitEstimator that propagates
-// WalletKit errors to the caller instead of returning a cached fallback rate.
-func NewFailFastWalletKitEstimator(walletKit lndclient.WalletKitClient,
 	log btclog.Logger) *WalletKitEstimator {
 
 	return NewWalletKitEstimatorWithConfig(WalletKitEstimatorConfig{
 		WalletKit: walletKit,
 		Log:       log,
+	})
+}
+
+// NewWalletKitEstimatorWithTimeout builds a fail-fast WalletKitEstimator with a
+// custom per-call timeout.
+func NewWalletKitEstimatorWithTimeout(walletKit lndclient.WalletKitClient,
+	log btclog.Logger, timeout time.Duration) *WalletKitEstimator {
+
+	return NewWalletKitEstimatorWithConfig(WalletKitEstimatorConfig{
+		WalletKit: walletKit,
+		Log:       log,
+		Timeout:   timeout,
+	})
+}
+
+// NewFallbackWalletKitEstimator builds a WalletKitEstimator that returns the
+// last successful rate (or the relay floor before any success) instead of
+// propagating WalletKit errors. Use this only for a standalone estimator;
+// never compose it inside a selector, where a stale fallback could beat
+// another live provider.
+func NewFallbackWalletKitEstimator(walletKit lndclient.WalletKitClient,
+	log btclog.Logger) *WalletKitEstimator {
+
+	return NewWalletKitEstimatorWithConfig(WalletKitEstimatorConfig{
+		WalletKit:       walletKit,
+		Log:             log,
+		FallbackOnError: true,
 	})
 }
 

--- a/chainfees/walletkit.go
+++ b/chainfees/walletkit.go
@@ -1,0 +1,195 @@
+package chainfees
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/lndclient"
+	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
+)
+
+const defaultWalletKitEstimateTimeout = 15 * time.Second
+
+// WalletKitEstimator implements chainfee.Estimator by proxying fee estimates
+// to an lndclient WalletKitClient.
+type WalletKitEstimator struct {
+	walletKit lndclient.WalletKitClient
+	log       btclog.Logger
+
+	estimateTimeout time.Duration
+	fallbackOnError bool
+
+	mu       sync.Mutex
+	lastRate chainfee.SatPerKWeight
+}
+
+// WalletKitEstimatorConfig configures a WalletKitEstimator.
+type WalletKitEstimatorConfig struct {
+	// WalletKit is the lndclient WalletKit client used for fee estimates.
+	WalletKit lndclient.WalletKitClient
+
+	// Log is an optional structured logger.
+	Log btclog.Logger
+
+	// Timeout bounds each WalletKit fee estimate call.
+	Timeout time.Duration
+
+	// FallbackOnError makes WalletKit errors return the last successful
+	// rate, or the relay floor before any successful estimate. Leave this
+	// disabled when composing WalletKit inside a selector so stale/floor
+	// values cannot beat another live provider.
+	FallbackOnError bool
+}
+
+// NewWalletKitEstimator builds a WalletKitEstimator backed by walletKit.
+func NewWalletKitEstimator(walletKit lndclient.WalletKitClient,
+	log btclog.Logger) *WalletKitEstimator {
+
+	return NewWalletKitEstimatorWithConfig(WalletKitEstimatorConfig{
+		WalletKit:       walletKit,
+		Log:             log,
+		FallbackOnError: true,
+	})
+}
+
+// NewWalletKitEstimatorWithTimeout builds a WalletKitEstimator with a custom
+// per-call timeout.
+func NewWalletKitEstimatorWithTimeout(walletKit lndclient.WalletKitClient,
+	log btclog.Logger, timeout time.Duration) *WalletKitEstimator {
+
+	return NewWalletKitEstimatorWithConfig(WalletKitEstimatorConfig{
+		WalletKit:       walletKit,
+		Log:             log,
+		Timeout:         timeout,
+		FallbackOnError: true,
+	})
+}
+
+// NewFailFastWalletKitEstimator builds a WalletKitEstimator that propagates
+// WalletKit errors to the caller instead of returning a cached fallback rate.
+func NewFailFastWalletKitEstimator(walletKit lndclient.WalletKitClient,
+	log btclog.Logger) *WalletKitEstimator {
+
+	return NewWalletKitEstimatorWithConfig(WalletKitEstimatorConfig{
+		WalletKit: walletKit,
+		Log:       log,
+	})
+}
+
+// NewWalletKitEstimatorWithConfig builds a WalletKitEstimator from cfg.
+func NewWalletKitEstimatorWithConfig(
+	cfg WalletKitEstimatorConfig) *WalletKitEstimator {
+
+	if cfg.WalletKit == nil {
+		return nil
+	}
+
+	log := cfg.Log
+	if log == nil {
+		log = btclog.Disabled
+	}
+
+	timeout := cfg.Timeout
+	if timeout <= 0 {
+		timeout = defaultWalletKitEstimateTimeout
+	}
+
+	return &WalletKitEstimator{
+		walletKit:       cfg.WalletKit,
+		log:             log,
+		estimateTimeout: timeout,
+		fallbackOnError: cfg.FallbackOnError,
+	}
+}
+
+// EstimateFeePerKW returns the current chain fee rate for the given
+// confirmation target, in sat/kW.
+func (e *WalletKitEstimator) EstimateFeePerKW(confTarget uint32) (
+	chainfee.SatPerKWeight, error) {
+
+	target := int32(confTarget)
+	if confTarget > math.MaxInt32 {
+		target = math.MaxInt32
+	}
+
+	ctx, cancel := context.WithTimeout(
+		context.Background(), e.estimateTimeout,
+	)
+	defer cancel()
+
+	rate, err := e.walletKit.EstimateFeeRate(ctx, target)
+	if err != nil {
+		if !e.fallbackOnError {
+			return 0, fmt.Errorf("estimate walletkit fee rate: %w",
+				err)
+		}
+
+		fallback := e.fallbackRate()
+		e.log.WarnS(
+			context.Background(),
+			"WalletKit EstimateFeeRate failed; falling back "+
+				"to last successful rate",
+			err,
+			slog.Int64("fallback_sat_kw", int64(fallback)),
+		)
+
+		return fallback, nil
+	}
+
+	if rate < chainfee.FeePerKwFloor {
+		e.log.WarnS(
+			context.Background(),
+			"WalletKit returned sub-floor rate; clamping",
+			fmt.Errorf("rate %d below floor %d", rate,
+				chainfee.FeePerKwFloor),
+			slog.Int64("raw_sat_kw", int64(rate)),
+		)
+		rate = chainfee.FeePerKwFloor
+	}
+
+	e.log.DebugS(
+		context.Background(),
+		"WalletKit EstimateFeeRate succeeded",
+		slog.Uint64("conf_target", uint64(target)),
+		slog.Int64("rate_sat_kw", int64(rate)),
+		slog.Int64("rate_sat_vbyte", int64(rate.FeePerVByte())),
+	)
+
+	e.mu.Lock()
+	e.lastRate = rate
+	e.mu.Unlock()
+
+	return rate, nil
+}
+
+// Start is a no-op. The backing lndclient owns its own lifecycle.
+func (e *WalletKitEstimator) Start() error { return nil }
+
+// Stop is a no-op. The backing lndclient owns its own lifecycle.
+func (e *WalletKitEstimator) Stop() error { return nil }
+
+// RelayFeePerKW returns the floor relay fee.
+func (e *WalletKitEstimator) RelayFeePerKW() chainfee.SatPerKWeight {
+	return chainfee.FeePerKwFloor
+}
+
+// fallbackRate returns the last successful WalletKit rate, clamped to the relay
+// floor.
+func (e *WalletKitEstimator) fallbackRate() chainfee.SatPerKWeight {
+	e.mu.Lock()
+	cached := e.lastRate
+	e.mu.Unlock()
+
+	if cached < chainfee.FeePerKwFloor {
+		return chainfee.FeePerKwFloor
+	}
+
+	return cached
+}
+
+var _ chainfee.Estimator = (*WalletKitEstimator)(nil)

--- a/chainfees/walletkit_test.go
+++ b/chainfees/walletkit_test.go
@@ -65,7 +65,7 @@ func TestWalletKitEstimatorFallsBackToLastGoodRate(t *testing.T) {
 	walletKit := &testWalletKit{
 		rate: 1_200,
 	}
-	estimator := NewWalletKitEstimator(walletKit, nil)
+	estimator := NewFallbackWalletKitEstimator(walletKit, nil)
 
 	gotRate, err := estimator.EstimateFeePerKW(6)
 	require.NoError(t, err)
@@ -77,13 +77,28 @@ func TestWalletKitEstimatorFallsBackToLastGoodRate(t *testing.T) {
 	require.Equal(t, walletKit.rate, gotRate)
 }
 
-func TestWalletKitEstimatorCanPropagateErrors(t *testing.T) {
+func TestWalletKitEstimatorFallsBackToFloorBeforeFirstSuccess(t *testing.T) {
 	t.Parallel()
 
 	walletKit := &testWalletKit{
 		err: fmt.Errorf("offline"),
 	}
-	estimator := NewFailFastWalletKitEstimator(walletKit, nil)
+	estimator := NewFallbackWalletKitEstimator(walletKit, nil)
+
+	// With no successful estimate cached yet, a fallback estimator returns
+	// the relay floor (not an error).
+	gotRate, err := estimator.EstimateFeePerKW(6)
+	require.NoError(t, err)
+	require.Equal(t, chainfee.FeePerKwFloor, gotRate)
+}
+
+func TestWalletKitEstimatorFailsFastByDefault(t *testing.T) {
+	t.Parallel()
+
+	walletKit := &testWalletKit{
+		err: fmt.Errorf("offline"),
+	}
+	estimator := NewWalletKitEstimator(walletKit, nil)
 
 	_, err := estimator.EstimateFeePerKW(6)
 	require.ErrorContains(t, err, "estimate walletkit fee rate")

--- a/chainfees/walletkit_test.go
+++ b/chainfees/walletkit_test.go
@@ -80,7 +80,7 @@ func TestWalletKitEstimatorFallsBackToLastGoodRate(t *testing.T) {
 	require.Equal(t, walletKit.rate, gotRate)
 }
 
-func TestWalletKitEstimatorFallsBackToFloorBeforeFirstSuccess(t *testing.T) {
+func TestWalletKitEstimatorFailsClosedBeforeFirstSuccess(t *testing.T) {
 	t.Parallel()
 
 	walletKit := &testWalletKit{
@@ -89,11 +89,11 @@ func TestWalletKitEstimatorFallsBackToFloorBeforeFirstSuccess(t *testing.T) {
 	estimator, err := NewFallbackWalletKitEstimator(walletKit, nil)
 	require.NoError(t, err)
 
-	// With no successful estimate cached yet, a fallback estimator returns
-	// the relay floor (not an error).
-	gotRate, err := estimator.EstimateFeePerKW(6)
-	require.NoError(t, err)
-	require.Equal(t, chainfee.FeePerKwFloor, gotRate)
+	// With no successful estimate cached yet, even a fallback estimator
+	// fails closed rather than serving the relay floor, which would
+	// silently underpay.
+	_, err = estimator.EstimateFeePerKW(6)
+	require.ErrorContains(t, err, "no cached rate for fallback")
 }
 
 func TestWalletKitEstimatorFailsFastByDefault(t *testing.T) {

--- a/chainfees/walletkit_test.go
+++ b/chainfees/walletkit_test.go
@@ -1,0 +1,90 @@
+package chainfees
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/lightninglabs/lndclient"
+	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
+	"github.com/stretchr/testify/require"
+)
+
+type testWalletKit struct {
+	lndclient.WalletKitClient
+
+	rate      chainfee.SatPerKWeight
+	err       error
+	gotTarget int32
+}
+
+func (w *testWalletKit) EstimateFeeRate(_ context.Context, target int32) (
+	chainfee.SatPerKWeight, error) {
+
+	w.gotTarget = target
+
+	if w.err != nil {
+		return 0, w.err
+	}
+
+	return w.rate, nil
+}
+
+func TestWalletKitEstimatorReturnsSatPerKW(t *testing.T) {
+	t.Parallel()
+
+	const wantRate = chainfee.SatPerKWeight(1_250)
+
+	walletKit := &testWalletKit{
+		rate: wantRate,
+	}
+	estimator := NewWalletKitEstimator(walletKit, nil)
+
+	gotRate, err := estimator.EstimateFeePerKW(6)
+	require.NoError(t, err)
+	require.Equal(t, wantRate, gotRate)
+	require.Equal(t, int32(6), walletKit.gotTarget)
+}
+
+func TestWalletKitEstimatorClampsSubFloorRate(t *testing.T) {
+	t.Parallel()
+
+	walletKit := &testWalletKit{
+		rate: 1,
+	}
+	estimator := NewWalletKitEstimator(walletKit, nil)
+
+	gotRate, err := estimator.EstimateFeePerKW(6)
+	require.NoError(t, err)
+	require.Equal(t, chainfee.FeePerKwFloor, gotRate)
+}
+
+func TestWalletKitEstimatorFallsBackToLastGoodRate(t *testing.T) {
+	t.Parallel()
+
+	walletKit := &testWalletKit{
+		rate: 1_200,
+	}
+	estimator := NewWalletKitEstimator(walletKit, nil)
+
+	gotRate, err := estimator.EstimateFeePerKW(6)
+	require.NoError(t, err)
+	require.Equal(t, walletKit.rate, gotRate)
+
+	walletKit.err = fmt.Errorf("offline")
+	gotRate, err = estimator.EstimateFeePerKW(6)
+	require.NoError(t, err)
+	require.Equal(t, walletKit.rate, gotRate)
+}
+
+func TestWalletKitEstimatorCanPropagateErrors(t *testing.T) {
+	t.Parallel()
+
+	walletKit := &testWalletKit{
+		err: fmt.Errorf("offline"),
+	}
+	estimator := NewFailFastWalletKitEstimator(walletKit, nil)
+
+	_, err := estimator.EstimateFeePerKW(6)
+	require.ErrorContains(t, err, "estimate walletkit fee rate")
+}

--- a/chainfees/walletkit_test.go
+++ b/chainfees/walletkit_test.go
@@ -38,7 +38,8 @@ func TestWalletKitEstimatorReturnsSatPerKW(t *testing.T) {
 	walletKit := &testWalletKit{
 		rate: wantRate,
 	}
-	estimator := NewWalletKitEstimator(walletKit, nil)
+	estimator, err := NewWalletKitEstimator(walletKit, nil)
+	require.NoError(t, err)
 
 	gotRate, err := estimator.EstimateFeePerKW(6)
 	require.NoError(t, err)
@@ -52,7 +53,8 @@ func TestWalletKitEstimatorClampsSubFloorRate(t *testing.T) {
 	walletKit := &testWalletKit{
 		rate: 1,
 	}
-	estimator := NewWalletKitEstimator(walletKit, nil)
+	estimator, err := NewWalletKitEstimator(walletKit, nil)
+	require.NoError(t, err)
 
 	gotRate, err := estimator.EstimateFeePerKW(6)
 	require.NoError(t, err)
@@ -65,7 +67,8 @@ func TestWalletKitEstimatorFallsBackToLastGoodRate(t *testing.T) {
 	walletKit := &testWalletKit{
 		rate: 1_200,
 	}
-	estimator := NewFallbackWalletKitEstimator(walletKit, nil)
+	estimator, err := NewFallbackWalletKitEstimator(walletKit, nil)
+	require.NoError(t, err)
 
 	gotRate, err := estimator.EstimateFeePerKW(6)
 	require.NoError(t, err)
@@ -83,7 +86,8 @@ func TestWalletKitEstimatorFallsBackToFloorBeforeFirstSuccess(t *testing.T) {
 	walletKit := &testWalletKit{
 		err: fmt.Errorf("offline"),
 	}
-	estimator := NewFallbackWalletKitEstimator(walletKit, nil)
+	estimator, err := NewFallbackWalletKitEstimator(walletKit, nil)
+	require.NoError(t, err)
 
 	// With no successful estimate cached yet, a fallback estimator returns
 	// the relay floor (not an error).
@@ -98,8 +102,17 @@ func TestWalletKitEstimatorFailsFastByDefault(t *testing.T) {
 	walletKit := &testWalletKit{
 		err: fmt.Errorf("offline"),
 	}
-	estimator := NewWalletKitEstimator(walletKit, nil)
+	estimator, err := NewWalletKitEstimator(walletKit, nil)
+	require.NoError(t, err)
 
-	_, err := estimator.EstimateFeePerKW(6)
+	_, err = estimator.EstimateFeePerKW(6)
 	require.ErrorContains(t, err, "estimate walletkit fee rate")
+}
+
+func TestWalletKitEstimatorRequiresWalletKit(t *testing.T) {
+	t.Parallel()
+
+	estimator, err := NewWalletKitEstimator(nil, nil)
+	require.ErrorContains(t, err, "walletkit client is required")
+	require.Nil(t, estimator)
 }

--- a/cmd/darepod/main.go
+++ b/cmd/darepod/main.go
@@ -263,6 +263,8 @@ func newRootCmd() *cobra.Command {
 			"100; must be at least 34",
 	)
 
+	registerFeeEstimationFlags(f, cfg)
+
 	// Bind all flags to viper so Unmarshal populates the config
 	// struct from the combined flag/env/file sources.
 	v.SetEnvPrefix("DAREPOD")
@@ -272,6 +274,26 @@ func newRootCmd() *cobra.Command {
 	_ = v.BindPFlags(f)
 
 	return cmd
+}
+
+// registerFeeEstimationFlags registers the optional external fee-provider
+// flags for the lnd wallet backend. Disabled by default; when enabled, the lnd
+// fee estimator selects the lower of the local WalletKit estimate and the
+// mempool.space estimate.
+func registerFeeEstimationFlags(f *pflag.FlagSet, cfg *darepod.Config) {
+	f.Bool(
+		"feeestimation.mempoolspace.enabled",
+		cfg.MempoolSpaceFeeEnabled(),
+		"enable the mempool.space fee provider for the lnd wallet "+
+			"backend; the estimator then selects the lower of "+
+			"the local lnd and mempool.space fee rates",
+	)
+	f.String(
+		"feeestimation.mempoolspace.url", cfg.MempoolSpaceFeeURL(),
+		"override the network-default mempool.space "+
+			"recommended-fee endpoint; must be an absolute "+
+			"https URL",
+	)
 }
 
 // registerArkServerFlags registers the daemon's outbound Ark operator flags.

--- a/darepod/config.go
+++ b/darepod/config.go
@@ -263,6 +263,10 @@ type Config struct {
 	// OOR configures off-band receive/send actor behavior.
 	OOR *OORConfig `mapstructure:"oor"`
 
+	// FeeEstimation configures optional external chain fee providers for
+	// the lnd wallet backend (e.g. mempool.space). Disabled by default.
+	FeeEstimation *FeeEstimationConfig `mapstructure:"feeestimation"`
+
 	// EagerRoundJoin makes the wallet actor drive round-joining
 	// without waiting for a follow-up Board / LeaveVTXOs RPC. With
 	// the flag on, every freshly confirmed boarding UTXO runs the
@@ -373,6 +377,50 @@ type UnrollConfig struct {
 	// MaxFeeRateSatPerVByte caps fee estimates to prevent runaway
 	// fees. Zero uses the default of 100 sat/vB.
 	MaxFeeRateSatPerVByte int64 `mapstructure:"maxfeeratesatpervbyte"`
+}
+
+// FeeEstimationConfig groups optional external chain fee providers used by the
+// lnd wallet backend's fee estimator. It is namespaced separately from the
+// wallet config so its mempool.space provider is not confused with the
+// Esplora/mempool.space chain backend that powers the lwwallet.
+type FeeEstimationConfig struct {
+	// MempoolSpace configures the optional mempool.space fee provider.
+	MempoolSpace *MempoolSpaceFeeConfig `mapstructure:"mempoolspace"`
+}
+
+// MempoolSpaceFeeConfig configures the optional mempool.space fee provider.
+// When enabled, the lnd chain backend composes a minimum-selecting fee
+// estimator over the local WalletKit estimator and a mempool.space estimator,
+// choosing the lower of the two live estimates.
+type MempoolSpaceFeeConfig struct {
+	// Enabled turns on the mempool.space fee provider. It applies only to
+	// the lnd wallet backend; the lwwallet and btcwallet backends own their
+	// own fee sources.
+	Enabled bool `mapstructure:"enabled"`
+
+	// URL optionally overrides the network-default mempool.space
+	// recommended-fee endpoint. It must be an absolute https URL (plaintext
+	// http is rejected except for a loopback host). When empty, the
+	// network-default endpoint is used.
+	URL string `mapstructure:"url"`
+}
+
+// MempoolSpaceFeeEnabled reports whether the mempool.space fee provider is
+// enabled. It is nil-safe so callers do not need to probe the nested config.
+func (c *Config) MempoolSpaceFeeEnabled() bool {
+	return c.FeeEstimation != nil &&
+		c.FeeEstimation.MempoolSpace != nil &&
+		c.FeeEstimation.MempoolSpace.Enabled
+}
+
+// MempoolSpaceFeeURL returns the configured mempool.space endpoint override, or
+// the empty string when none is set (the network default is then used).
+func (c *Config) MempoolSpaceFeeURL() string {
+	if c.FeeEstimation == nil || c.FeeEstimation.MempoolSpace == nil {
+		return ""
+	}
+
+	return c.FeeEstimation.MempoolSpace.URL
 }
 
 // OORConfig configures off-band transfer actor behavior.
@@ -820,7 +868,10 @@ func DefaultConfig() *Config {
 		},
 		MaxOperatorFeeSat: DefaultMaxOperatorFeeSat,
 		OOR:               defaultOORConfig(),
-		EagerRoundJoin:    defaultEagerRoundJoin(),
+		FeeEstimation: &FeeEstimationConfig{
+			MempoolSpace: &MempoolSpaceFeeConfig{},
+		},
+		EagerRoundJoin: defaultEagerRoundJoin(),
 	}
 }
 
@@ -904,6 +955,14 @@ func (c *Config) Validate() error {
 	default:
 		return fmt.Errorf("unknown wallet type %q, valid values: lnd, "+
 			"lwwallet, btcwallet", c.Wallet.Type)
+	}
+
+	// The mempool.space fee provider only composes with the lnd backend's
+	// fee estimator; the lwwallet and btcwallet backends own their own fee
+	// sources, so enabling it there would silently do nothing.
+	if c.MempoolSpaceFeeEnabled() && c.Wallet.Type != WalletTypeLnd {
+		return fmt.Errorf("feeestimation.mempoolspace is only "+
+			"supported with wallet.type lnd, not %q", c.Wallet.Type)
 	}
 
 	if c.Server == nil {

--- a/darepod/config_mempoolspace_fee_test.go
+++ b/darepod/config_mempoolspace_fee_test.go
@@ -1,0 +1,110 @@
+package darepod
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// lndBaseConfig returns a minimal valid lnd-backed config for fee-provider
+// validation tests.
+func lndBaseConfig() *Config {
+	cfg := DefaultConfig()
+	cfg.Network = "regtest"
+	cfg.Server.Host = "127.0.0.1:10010"
+	cfg.Wallet.Type = WalletTypeLnd
+	cfg.Lnd.Host = "127.0.0.1:10009"
+
+	return cfg
+}
+
+// TestMempoolSpaceFeeAccessorsAreNilSafe asserts the accessor helpers tolerate
+// a partially-populated or absent fee-estimation config without panicking.
+func TestMempoolSpaceFeeAccessorsAreNilSafe(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{}
+	require.False(t, cfg.MempoolSpaceFeeEnabled())
+	require.Empty(t, cfg.MempoolSpaceFeeURL())
+
+	cfg.FeeEstimation = &FeeEstimationConfig{}
+	require.False(t, cfg.MempoolSpaceFeeEnabled())
+	require.Empty(t, cfg.MempoolSpaceFeeURL())
+
+	cfg.FeeEstimation.MempoolSpace = &MempoolSpaceFeeConfig{
+		Enabled: true,
+		URL:     "https://mempool.space/api/v1/fees/recommended",
+	}
+	require.True(t, cfg.MempoolSpaceFeeEnabled())
+	require.Equal(
+		t, "https://mempool.space/api/v1/fees/recommended",
+		cfg.MempoolSpaceFeeURL(),
+	)
+}
+
+// TestDefaultConfigDisablesMempoolSpaceFee locks in that the provider is off by
+// default so an operator building from defaults never silently queries an
+// external endpoint.
+func TestDefaultConfigDisablesMempoolSpaceFee(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, DefaultConfig().MempoolSpaceFeeEnabled())
+}
+
+// TestConfigValidateAcceptsMempoolSpaceFeeOnLnd asserts the provider validates
+// on the lnd wallet backend.
+func TestConfigValidateAcceptsMempoolSpaceFeeOnLnd(t *testing.T) {
+	t.Parallel()
+
+	cfg := lndBaseConfig()
+	cfg.FeeEstimation.MempoolSpace.Enabled = true
+
+	require.NoError(t, cfg.Validate())
+}
+
+// TestConfigValidateRejectsMempoolSpaceFeeOffLnd asserts enabling the provider
+// on a non-lnd backend fails validation rather than silently doing nothing.
+func TestConfigValidateRejectsMempoolSpaceFeeOffLnd(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		walletType string
+		setup      func(*Config)
+	}{
+		{
+			name:       "lwwallet",
+			walletType: WalletTypeLwwallet,
+			setup: func(c *Config) {
+				c.Wallet.EsploraURL = "http://127.0.0.1:3000"
+			},
+		},
+		{
+			name:       "btcwallet",
+			walletType: WalletTypeBtcwallet,
+			setup: func(c *Config) {
+				c.Wallet.FeeURL = "http://127.0.0.1:3000/fees"
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := DefaultConfig()
+			cfg.Network = "regtest"
+			cfg.Server.Host = "127.0.0.1:10010"
+			cfg.Wallet.Type = tc.walletType
+			tc.setup(cfg)
+			cfg.FeeEstimation.MempoolSpace.Enabled = true
+
+			err := cfg.Validate()
+			require.Error(t, err)
+			require.Contains(
+				t, err.Error(),
+				"feeestimation.mempoolspace is only supported",
+			)
+		})
+	}
+}

--- a/darepod/logging.go
+++ b/darepod/logging.go
@@ -5,6 +5,7 @@ import (
 	"github.com/lightninglabs/darepo-client/baselib/actor"
 	"github.com/lightninglabs/darepo-client/btcwbackend"
 	"github.com/lightninglabs/darepo-client/chainbackends"
+	"github.com/lightninglabs/darepo-client/chainfees"
 	"github.com/lightninglabs/darepo-client/db"
 	"github.com/lightninglabs/darepo-client/indexer"
 	"github.com/lightninglabs/darepo-client/lndbackend"
@@ -34,6 +35,7 @@ var allSubsystems = []string{
 	serverconn.Subsystem,
 	chainbackends.Subsystem,
 	chainbackends.LndClientSubsystem,
+	chainfees.Subsystem,
 	lndbackend.Subsystem,
 	indexer.Subsystem,
 	db.Subsystem,

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -31,6 +31,7 @@ import (
 	"github.com/lightninglabs/darepo-client/btcwbackend"
 	"github.com/lightninglabs/darepo-client/build"
 	"github.com/lightninglabs/darepo-client/chainbackends"
+	"github.com/lightninglabs/darepo-client/chainfees"
 	"github.com/lightninglabs/darepo-client/chainsource"
 	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/lightninglabs/darepo-client/db"
@@ -2024,6 +2025,64 @@ func (s *Server) registerChainSourceActor(
 	return ref
 }
 
+// lndFeeEstimator builds the chain fee estimator for the lnd wallet backend.
+// By default it returns the WalletKit-backed estimator with last-good fallback.
+// When the mempool.space provider is enabled, it instead returns a
+// minimum-selecting estimator composed over a fail-fast WalletKit estimator and
+// a mempool.space estimator, so the lower of the two live rates wins.
+func (s *Server) lndFeeEstimator(ctx context.Context,
+	walletKit lndclient.WalletKitClient) (chainfee.Estimator, error) {
+
+	if !s.cfg.MempoolSpaceFeeEnabled() {
+		return chainbackends.NewLndClientFeeEstimator(walletKit)
+	}
+
+	// Inside the selector the WalletKit child must fail fast: a stale
+	// fallback rate could otherwise beat the mempool.space live estimate.
+	walletKitEst, err := chainfees.NewWalletKitEstimator(
+		walletKit, s.subLogger(chainbackends.LndClientSubsystem),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create walletkit fee estimator: %w",
+			err)
+	}
+
+	mempoolEst, err := chainfees.NewMempoolSpaceEstimator(
+		chainfees.MempoolSpaceConfig{
+			URL:    s.cfg.MempoolSpaceFeeURL(),
+			Params: s.chainParams,
+			Log:    s.subLogger(chainfees.Subsystem),
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create mempool.space fee estimator: %w",
+			err)
+	}
+
+	estimator, err := chainfees.NewMinEstimator(
+		s.subLogger(chainfees.Subsystem),
+		chainfees.NamedEstimator{
+			Name:      "walletkit",
+			Estimator: walletKitEst,
+		},
+		chainfees.NamedEstimator{
+			Name:      "mempoolspace",
+			Estimator: mempoolEst,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create min fee estimator: %w", err)
+	}
+
+	s.log.InfoS(
+		ctx, "mempool.space fee provider enabled; lnd fee "+
+			"estimator selects the minimum of the local and "+
+			"mempool.space rates",
+	)
+
+	return estimator, nil
+}
+
 // initChainBackend creates and starts the chain backend appropriate
 // for the configured wallet type. In lnd mode it uses the lndclient
 // chain notifier and fee estimator. In lwwallet mode it uses the
@@ -2049,9 +2108,7 @@ func (s *Server) initChainBackend(ctx context.Context) error {
 				),
 			},
 		)
-		feeEstimator, err := chainbackends.NewLndClientFeeEstimator(
-			lndSvc.WalletKit,
-		)
+		feeEstimator, err := s.lndFeeEstimator(ctx, lndSvc.WalletKit)
 		if err != nil {
 			return fmt.Errorf("create lnd fee estimator: %w", err)
 		}

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -2049,10 +2049,14 @@ func (s *Server) initChainBackend(ctx context.Context) error {
 				),
 			},
 		)
+		feeEstimator, err := chainbackends.NewLndClientFeeEstimator(
+			lndSvc.WalletKit,
+		)
+		if err != nil {
+			return fmt.Errorf("create lnd fee estimator: %w", err)
+		}
 		backend := chainbackends.NewLNDBackend(
-			notifier, chainbackends.NewLndClientFeeEstimator(
-				lndSvc.WalletKit,
-			),
+			notifier, feeEstimator,
 			chainbackends.NewLndClientTxBroadcaster(
 				lndSvc.WalletKit,
 			),

--- a/sample-darepod.conf
+++ b/sample-darepod.conf
@@ -169,6 +169,15 @@
 # Keep btcwallet/neutrino package-global loggers detached from daemon logging.
 # wallet.disable_btcwallet_global_logs=false
 
+# Optional mempool.space fee provider for the lnd wallet backend. When enabled,
+# the lnd fee estimator selects the lower of the local lnd estimate and the
+# mempool.space estimate. Only applies to wallet.type=lnd.
+# feeestimation.mempoolspace.enabled=false
+
+# Override the network-default mempool.space recommended-fee endpoint. Must be
+# an absolute https URL. Empty uses the per-network default.
+# feeestimation.mempoolspace.url=
+
 # Number of blocks after which unroll attempts a fee-bump rebroadcast. The zero
 # value uses the unroll default.
 # unroll.bumpafterblocks=0

--- a/sdk/walletdk/embedded.go
+++ b/sdk/walletdk/embedded.go
@@ -362,6 +362,14 @@ func cloneDaemonConfig(cfg *darepod.Config) *darepod.Config {
 		oorCfg := *cfg.OOR
 		clone.OOR = &oorCfg
 	}
+	if cfg.FeeEstimation != nil {
+		feeCfg := *cfg.FeeEstimation
+		if cfg.FeeEstimation.MempoolSpace != nil {
+			mempoolCfg := *cfg.FeeEstimation.MempoolSpace
+			feeCfg.MempoolSpace = &mempoolCfg
+		}
+		clone.FeeEstimation = &feeCfg
+	}
 
 	clone.RPCServiceRegistrars = append(
 		[]darepod.RPCServiceRegistrar(nil), cfg.RPCServiceRegistrars...,

--- a/systest/systest.go
+++ b/systest/systest.go
@@ -182,13 +182,16 @@ func (h *SysTestHarness) NewBoardingBackend() wallet.BoardingBackend {
 // NewChainBackend creates a new ChainBackend connected to the shared LND.
 // The subsystem logger is passed via config to enable proper logging.
 func (h *SysTestHarness) NewChainBackend() chainsource.ChainBackend {
-	return chainbackends.NewLNDBackendFromLndClient(
+	backend, err := chainbackends.NewLNDBackendFromLndClient(
 		chainbackends.LNDBackendFromLndClientConfig{
 			LND: h.Harness.LND,
 		}.WithLogger(
 			h.SubLogger(chainbackends.LndClientSubsystem),
 		),
 	)
+	require.NoError(h.t, err)
+
+	return backend
 }
 
 // NewChainSourceActor creates and spawns a ChainSourceActor using the shared


### PR DESCRIPTION
## Summary

Adds a reusable `chainfees` package with:

- WalletKit-backed `chainfee.Estimator` with sub-floor clamping, timeout handling, and last-good fallback.
- mempool.space-backed estimator with network-aware default endpoints and sat/vB to sat/kW conversion.
- minimum-selector estimator that queries multiple named child estimators, logs individual results, warns on divergence, and uses the lowest successful estimate.

This is intended to let arkd compose WalletKit/LND and HTTP fee providers without duplicating client-side fee plumbing.

## Verification

- `go test ./chainfees ./chainbackends`
- `make fmt-changed`
- `make lint-native`
- `go test ./darepod`
- `go test ./...` was run; one `./darepod` listener startup test timed out during the full-package run while migrations were still running, and the direct package rerun passed.