### PR TITLE
round: explain seal-time quote rejections

### DIFF
--- a/round/quote_echo_test.go
+++ b/round/quote_echo_test.go
@@ -272,26 +272,60 @@ func TestFromProtoRejectsUnknownRejectReason(t *testing.T) {
 	require.Contains(t, err.Error(), "reject_reason")
 }
 
-// TestEvaluateQuoteRendersNamedRejectReason verifies the error
-// rendering on a server-rejected quote uses the named enum value
-// rather than a raw integer.
-func TestEvaluateQuoteRendersNamedRejectReason(t *testing.T) {
+// TestEvaluateQuoteRendersActionableRejectReason verifies error rendering on
+// server-rejected quotes preserves the named enum while explaining the
+// operator action needed to recover.
+func TestEvaluateQuoteRendersActionableRejectReason(t *testing.T) {
 	t.Parallel()
 
-	intents, _ := buildEchoTestIntents(t)
-	quote := quoteFromIntents(t, intents, 5_000)
-	quote.RejectReason = roundpb.QuoteReason_INSUFFICIENT_RESIDUAL
+	tests := []struct {
+		name     string
+		reason   roundpb.QuoteReason
+		contains []string
+	}{{
+		name:   "insufficient residual",
+		reason: roundpb.QuoteReason_INSUFFICIENT_RESIDUAL,
+		contains: []string{
+			"INSUFFICIENT_RESIDUAL",
+			"not enough value remains",
+			"use a larger input",
+			"reduce fixed outputs",
+		},
+	}, {
+		name:   "invalid change designation",
+		reason: roundpb.QuoteReason_INVALID_CHANGE_DESIGNATION,
+		contains: []string{
+			"INVALID_CHANGE_DESIGNATION",
+			"exactly one change output",
+			"should be reported",
+		},
+	}}
 
-	env := quoteReceivedTestEnv(10_000)
-	decision := evaluateQuote(env, RoundID{}, intents, quote)
-	rej, ok := decision.(*QuoteRejected)
-	require.True(t, ok)
-	require.Contains(t, rej.Reason, "INSUFFICIENT_RESIDUAL")
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			intents, _ := buildEchoTestIntents(t)
+			quote := quoteFromIntents(t, intents, 5_000)
+			quote.RejectReason = test.reason
+
+			env := quoteReceivedTestEnv(10_000)
+			decision := evaluateQuote(
+				env, RoundID{}, intents, quote,
+			)
+			rej, ok := decision.(*QuoteRejected)
+			require.True(t, ok)
+			for _, fragment := range test.contains {
+				require.Contains(t, rej.Reason, fragment)
+			}
+		})
+	}
 
 	// Sanity: a proto marshal+unmarshal cycle preserves the
 	// enum name round-trip by keeping the value.
 	pb := &roundpb.JoinRoundQuote{
-		RejectReason: quote.RejectReason,
+		RejectReason: roundpb.QuoteReason_INSUFFICIENT_RESIDUAL,
 	}
 	raw, err := proto.Marshal(pb)
 	require.NoError(t, err)

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -789,10 +789,7 @@ func evaluateQuote(env *ClientEnvironment, roundID RoundID, intents Intents,
 		return &QuoteRejected{
 			RoundID: roundID,
 			QuoteID: quote.QuoteID,
-			Reason: fmt.Sprintf(
-				"server rejected intent: %s",
-				quote.RejectReason,
-			),
+			Reason:  quoteRejectReason(quote.RejectReason),
 		}
 	}
 
@@ -862,6 +859,27 @@ func evaluateQuote(env *ClientEnvironment, roundID RoundID, intents Intents,
 	return &QuoteAccepted{
 		RoundID: roundID,
 		QuoteID: quote.QuoteID,
+	}
+}
+
+// quoteRejectReason formats server-side quote rejections for operator-facing
+// logs and operation status output.
+func quoteRejectReason(reason roundpb.QuoteReason) string {
+	switch reason {
+	case roundpb.QuoteReason_INSUFFICIENT_RESIDUAL:
+		return fmt.Sprintf("server rejected intent: %s (not enough "+
+			"value remains for the change output after seal-time "+
+			"operator fees; use a larger input or reduce fixed "+
+			"outputs)", reason)
+
+	case roundpb.QuoteReason_INVALID_CHANGE_DESIGNATION:
+		return fmt.Sprintf("server rejected intent: %s (the intent "+
+			"must have exactly one change output when it has "+
+			"multiple outputs; this is unexpected when using the "+
+			"standard client and should be reported)", reason)
+
+	default:
+		return fmt.Sprintf("server rejected intent: %s", reason)
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR improves the client-side error text recorded when a seal-time quote is rejected by the server.

The FSM already preserved the raw `QuoteReason` enum, but that made operator-facing logs and operation status read like `INSUFFICIENT_RESIDUAL` without explaining the practical cause. The new formatter keeps the enum for searching while adding recovery-oriented text for the current server rejection classes.

For the issue case, the client now reports that `INSUFFICIENT_RESIDUAL` means the change output does not have enough value left after seal-time operator fees, and suggests using a larger input or reducing fixed outputs.

For `INVALID_CHANGE_DESIGNATION`, the message now explains the one-change-output rule and notes that seeing this through the standard client is unexpected and should be reported.

Fixes lightninglabs/darepo#434.

## Validation

- `go test ./round`
- `make fmt-changed`
- `make lint-native`
- `make commitmsg-lint range=origin/main..HEAD`
