### PR TITLE
unroll: anchor deferred checkpoint deadline to parent confirm height

### DIFF
--- a/unroll/actor_test.go
+++ b/unroll/actor_test.go
@@ -1184,6 +1184,90 @@ func buildMergeProof(t *testing.T) *recovery.Proof {
 	return proof
 }
 
+// buildMultihopOORProof creates a checkpoint_AB -> arktx_AB ->
+// checkpoint_BC -> arktx_BC (target) proof. The intermediate checkpoint_BC
+// is the only frontier item that gets promoted from blocked to ready by an
+// in-proof TxConfirmedEvent (the arktx_AB confirmation), which is the shape
+// the deferral-anchor race needs to reproduce.
+func buildMultihopOORProof(t *testing.T) *recovery.Proof {
+	t.Helper()
+
+	checkpointAB := wire.NewMsgTx(2)
+	checkpointAB.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{
+			Hash:  chainhash.Hash{1},
+			Index: 0,
+		},
+	})
+	checkpointAB.AddTxOut(&wire.TxOut{
+		Value:    70_000,
+		PkScript: []byte{txscript.OP_TRUE},
+	})
+
+	arkAB := wire.NewMsgTx(2)
+	arkAB.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{
+			Hash:  checkpointAB.TxHash(),
+			Index: 0,
+		},
+	})
+	arkAB.AddTxOut(&wire.TxOut{
+		Value:    65_000,
+		PkScript: []byte{txscript.OP_TRUE},
+	})
+
+	checkpointBC := wire.NewMsgTx(2)
+	checkpointBC.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{
+			Hash:  arkAB.TxHash(),
+			Index: 0,
+		},
+	})
+	checkpointBC.AddTxOut(&wire.TxOut{
+		Value:    60_000,
+		PkScript: []byte{txscript.OP_TRUE},
+	})
+
+	arkBC := wire.NewMsgTx(2)
+	arkBC.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{
+			Hash:  checkpointBC.TxHash(),
+			Index: 0,
+		},
+	})
+	arkBC.AddTxOut(&wire.TxOut{
+		Value:    55_000,
+		PkScript: []byte{txscript.OP_TRUE},
+	})
+
+	proof, err := recovery.NewProof(
+		wire.OutPoint{
+			Hash:  arkBC.TxHash(),
+			Index: 0,
+		},
+		144,
+		&recovery.Node{
+			Kind: recovery.NodeKindCheckpoint,
+			Tx:   checkpointAB,
+		},
+		&recovery.Node{
+			Kind: recovery.NodeKindArk,
+			Tx:   arkAB,
+		},
+		&recovery.Node{
+			Kind: recovery.NodeKindCheckpoint,
+			Tx:   checkpointBC,
+		},
+		&recovery.Node{
+			Kind: recovery.NodeKindArk,
+			Tx:   arkBC,
+		},
+	)
+	require.NoError(t, err)
+
+	return proof
+}
+
 // mustDecodeCheckpoint loads and decodes one stored actor checkpoint.
 func mustDecodeCheckpoint(t *testing.T, store *memCheckpointStore,
 	actorID string) *actorCheckpoint {
@@ -1399,6 +1483,114 @@ func TestFraudTriggerSharedCheckpointsBroadcastOnceAtDeadline(t *testing.T) {
 	require.Contains(
 		t, checkpoint.State.InFlightTxids, proof.TargetOutpoint().Hash,
 	)
+}
+
+// TestFraudTriggerDeferralAnchoredToParentConfirm verifies a non-root
+// checkpoint that is promoted to the ready frontier by a TxConfirmedEvent
+// stamps its deferral deadline against the parent's confirm height rather
+// than the FSM's current height. This is the regression case where a
+// fast bulk-flush of HeightObservedMsg events arrives before a parent's
+// TxConfirmedMsg: without the parent-anchored deadline the recipient's
+// backstop slides arbitrarily far into the future and the test harness
+// (which polls for the broadcast without mining further blocks) deadlocks.
+//
+// Proof shape: checkpoint_AB -> arktx_AB -> checkpoint_BC -> arktx_BC.
+// checkpoint_AB is the only root; checkpoint_BC is the non-root checkpoint
+// whose deferral deadline this test pins.
+func TestFraudTriggerDeferralAnchoredToParentConfirm(t *testing.T) {
+	proof := buildMultihopOORProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	unrollActor, _, txconfirmRef, store := newActorHarness(t, proof, desc)
+
+	// Lay out the four proof nodes in topological order so we can refer
+	// to them by role. Topological layers: [checkpoint_AB], [arktx_AB],
+	// [checkpoint_BC], [arktx_BC=target].
+	layers := proof.Layers()
+	require.Len(t, layers, 4)
+	require.Len(t, layers[0], 1)
+	require.Len(t, layers[1], 1)
+	require.Len(t, layers[2], 1)
+	require.Len(t, layers[3], 1)
+	checkpointAB := layers[0][0]
+	arkABTxid := layers[1][0]
+	checkpointBCTxid := layers[2][0]
+
+	arkABNode, ok := proof.Node(arkABTxid)
+	require.True(t, ok)
+	require.Equal(t, recovery.NodeKindArk, arkABNode.Kind)
+	checkpointBCNode, ok := proof.Node(checkpointBCTxid)
+	require.True(t, ok)
+	require.Equal(t, recovery.NodeKindCheckpoint, checkpointBCNode.Kind)
+
+	// CSV delay 144, default safety margin 24 → deferral window = 120.
+	// Start at height 100 so checkpoint_AB's first deadline lands at
+	// 100 + 144 - 24 = 220, matching the conventions in the other fraud
+	// trigger tests in this file.
+	const startHeight int32 = 100
+	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
+		Height:  startHeight,
+		Trigger: TriggerFraudSpend,
+	})
+
+	checkpoint := mustDecodeCheckpoint(t, store, "unroll-test")
+	require.Len(t, checkpoint.DeferredCheckpoints, 1)
+	require.Equal(
+		t, checkpointAB, checkpoint.DeferredCheckpoints[0].Txid,
+	)
+	require.Equal(
+		t, int32(220), checkpoint.DeferredCheckpoints[0].DeadlineHeight,
+	)
+
+	// Cross checkpoint_AB's deadline so the recipient broadcasts it
+	// (txconfirm submission) and then confirm it. arktx_AB then enters
+	// the ready frontier and (as an ark, not a checkpoint) is submitted
+	// immediately — but we deliberately do NOT confirm it yet.
+	mustAsk(t, unrollActor.Ref(), &HeightObservedMsg{Height: 220})
+	require.Eventually(t, func() bool {
+		return txconfirmRef.requestCountForTxid(checkpointAB) == 1
+	}, testTimeout, 10*time.Millisecond)
+
+	txconfirmRef.emitConfirmedByTxid(t, checkpointAB, 221)
+	require.Eventually(t, func() bool {
+		return txconfirmRef.requestCountForTxid(arkABTxid) == 1
+	}, testTimeout, 10*time.Millisecond)
+
+	// Race setup. Advance the FSM's job.Height far ahead of where
+	// arktx_AB will actually confirm. mustAsk is synchronous so the
+	// HeightUpdatedEvent fully lands in the FSM before the next call
+	// returns; emitConfirmedByTxid then queues the TxConfirmedMsg
+	// behind it in actor-mailbox order.
+	const racedHeight int32 = 400
+	mustAsk(t, unrollActor.Ref(), &HeightObservedMsg{Height: racedHeight})
+
+	// arktx_AB actually confirms at block 222 — well below racedHeight.
+	// This is the block where vtxo_B (checkpoint_BC's parent) becomes
+	// available. The fix anchors checkpoint_BC's deferral deadline to
+	// THIS height, not racedHeight, so:
+	//
+	//   parent-anchored deadline = 222 + 144 - 24 = 342
+	//   bug-era deadline         = racedHeight + 144 - 24 = 520
+	//
+	// 342 has already elapsed at racedHeight=400, so the FSM bypasses
+	// the deferred set entirely and hands checkpoint_BC straight to
+	// txconfirm. The bug-era deadline (520) is still in the future at
+	// height 400, so without the fix checkpoint_BC would be parked in
+	// DeferredCheckpoints with DeadlineHeight=520 and never broadcast.
+	const arkABConfirmHeight int32 = 222
+	txconfirmRef.emitConfirmedByTxid(t, arkABTxid, arkABConfirmHeight)
+
+	require.Eventually(t, func() bool {
+		return txconfirmRef.requestCountForTxid(
+			checkpointBCTxid,
+		) == 1
+	}, testTimeout, 10*time.Millisecond)
+
+	// Persisted state should not have checkpoint_BC parked in the
+	// deferred set after the immediate submission.
+	c := mustDecodeCheckpoint(t, store, "unroll-test")
+	for _, d := range c.DeferredCheckpoints {
+		require.NotEqual(t, checkpointBCTxid, d.Txid)
+	}
 }
 
 // TestResumeReissuesDeferredCheckpointWatch verifies restart restores

--- a/unroll/fsm_logic.go
+++ b/unroll/fsm_logic.go
@@ -57,6 +57,21 @@ func processEventWithJob(ctx context.Context, job *JobState, event Event,
 	nextJob := job.Copy()
 	reissue := false
 
+	// deferralAnchor pins the base height used when stamping a brand-new
+	// DeferredCheckpoint deadline this turn. A TxConfirmedEvent that
+	// promotes a child to the planner's ready frontier carries the parent's
+	// own confirmation height in e.Height; that is the height at which the
+	// child became unblocked, and it is the height we want the operator's
+	// deferral window measured from. Without this anchor the deadline
+	// collapses onto whatever job.Height has already drifted to (e.g. a
+	// bulk-flush of cached HeightUpdatedEvents that ran ahead of the
+	// TxConfirmedEvent in the actor mailbox), pushing the recipient's
+	// backstop arbitrarily far into the future. Non-confirmation events
+	// leave the anchor unset so deriveStateTransition falls back to
+	// job.Height for the StartEvent and ResumeEvent paths, preserving the
+	// previous behavior there.
+	deferralAnchor := fn.None[int32]()
+
 	switch e := event.(type) {
 	case *ResumeEvent:
 		if e.Height > nextJob.Height {
@@ -71,6 +86,7 @@ func processEventWithJob(ctx context.Context, job *JobState, event Event,
 
 	case *TxConfirmedEvent:
 		applyConfirmedEvent(nextJob, e, env)
+		deferralAnchor = fn.Some(e.Height)
 
 	case *TxFailedEvent:
 		applyFailedEvent(nextJob, e)
@@ -96,7 +112,7 @@ func processEventWithJob(ctx context.Context, job *JobState, event Event,
 		return nil, fmt.Errorf("unexpected event %T", event)
 	}
 
-	return deriveStateTransition(ctx, nextJob, env, reissue)
+	return deriveStateTransition(ctx, nextJob, env, reissue, deferralAnchor)
 }
 
 // deriveStateTransition is the core "what FSM state should we be in
@@ -134,7 +150,8 @@ func processEventWithJob(ctx context.Context, job *JobState, event Event,
 // deterministically in unit tests, which is why the FSM intentionally
 // lives separate from the behavior.
 func deriveStateTransition(_ context.Context, job *JobState, env *Environment,
-	reissue bool) (*StateTransition, error) {
+	reissue bool,
+	deferralAnchor fn.Option[int32]) (*StateTransition, error) {
 
 	if job == nil {
 		return nil, fmt.Errorf("job state must be provided")
@@ -279,7 +296,7 @@ func deriveStateTransition(_ context.Context, job *JobState, env *Environment,
 		// txconfirm layer either way, but a clean planner state
 		// is a nicer invariant to hold).
 		readyTxids, watchTxids := readyMaterializationTxids(
-			job, env, snapshot.Ready,
+			job, env, snapshot.Ready, deferralAnchor,
 		)
 		if len(watchTxids) > 0 {
 			outbox = append(outbox, &WatchDeferredCheckpoints{
@@ -468,12 +485,23 @@ func readyTxids(frontier []unrollplan.TxFrontier) []chainhash.Hash {
 
 // readyMaterializationTxids splits planner-ready proof nodes into transactions
 // to submit now and deferred checkpoint watches to register.
+//
+// deferralAnchor pins the height used as the base of any newly-stamped
+// DeferredCheckpoint deadline. When set (a TxConfirmedEvent just promoted
+// these frontier items), it is the parent's confirmation height, so the
+// deferral window measures the operator's response time from when the
+// child actually became unblocked. When unset (StartEvent / ResumeEvent),
+// we fall back to job.Height — the only signal available before any
+// confirmation event has arrived.
 func readyMaterializationTxids(job *JobState, env *Environment,
-	frontier []unrollplan.TxFrontier) ([]chainhash.Hash, []chainhash.Hash) {
+	frontier []unrollplan.TxFrontier,
+	deferralAnchor fn.Option[int32]) ([]chainhash.Hash, []chainhash.Hash) {
 
 	if job == nil || env == nil || env.Proof == nil {
 		return readyTxids(frontier), nil
 	}
+
+	deadlineBase := deferralAnchor.UnwrapOr(job.Height)
 
 	ready := make([]chainhash.Hash, 0, len(frontier))
 	watch := make([]chainhash.Hash, 0, len(frontier))
@@ -492,7 +520,7 @@ func readyMaterializationTxids(job *JobState, env *Environment,
 		}
 
 		deadline := checkpointBackstopHeight(
-			job.Height, env.Proof.CSVDelay(),
+			deadlineBase, env.Proof.CSVDelay(),
 			env.FraudCheckpointSafetyMargin,
 		)
 		if deadline <= job.Height {

--- a/unroll/fsm_types.go
+++ b/unroll/fsm_types.go
@@ -9,6 +9,7 @@ import (
 	"github.com/lightninglabs/darepo-client/baselib/protofsm"
 	"github.com/lightninglabs/darepo-client/lib/recovery"
 	"github.com/lightninglabs/darepo-client/unrollplan"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
 )
 
 // StateMachine is the protofsm instance for one VTXO unroll session.
@@ -299,7 +300,9 @@ func (s *Idle) ProcessEvent(ctx context.Context, event Event,
 			Trigger: e.Trigger,
 		}
 
-		return deriveStateTransition(ctx, job, env, false)
+		return deriveStateTransition(
+			ctx, job, env, false, fn.None[int32](),
+		)
 
 	case *ResumeEvent:
 		job := &JobState{
@@ -308,7 +311,9 @@ func (s *Idle) ProcessEvent(ctx context.Context, event Event,
 			FailReason: "",
 		}
 
-		return deriveStateTransition(ctx, job, env, true)
+		return deriveStateTransition(
+			ctx, job, env, true, fn.None[int32](),
+		)
 
 	default:
 		return nil, fmt.Errorf("unexpected event %T in %s", event, s)


### PR DESCRIPTION
## Summary

Stamp a brand-new `DeferredCheckpoint.DeadlineHeight` against the parent's actual confirmation height instead of the FSM's current `job.Height`. Fixes a flaky-test race where cached `HeightUpdatedEvent`s draining ahead of a `TxConfirmedEvent` in the actor mailbox pushed the recipient backstop arbitrarily far into the future.

## Root cause

Fraud-triggered unroll defers each newly-ready checkpoint with `DeadlineHeight = job.Height + csvDelay - margin`. `job.Height` advances on every `HeightUpdatedEvent`, but `TxConfirmedEvent`s arrive interleaved through the same actor mailbox. When LWWL bulk-processes a batch of blocks faster than the parent's `TxConfirmedEvent` is dequeued, `job.Height` is already past the parent's actual confirmation block by the time the child gets promoted. The stamped deadline therefore measures the deferral window from a moving target instead of from where the parent actually confirmed.

Repro in CI: `TestRecipientFraudPartialOperator` on the lwwallet backend ([failing run](https://github.com/lightninglabs/darepo/actions/runs/25839724052/job/75922299161)). arktx_AB confirmed at chain height 135. LWWL flushed blocks 135→144 in one ms-scale batch. The unroll FSM drained 10 `HeightUpdatedEvent`s before the `TxConfirmedMsg` for arktx_AB; by then `job.Height = 144` and checkpoint_BC was parked with `DeadlineHeight = 152` instead of the intended `143`. The chain stayed at 144 for the rest of the test and the deadline never tripped.

## Fix

Thread a `deferralAnchor fn.Option[int32]` through `processEventWithJob` → `deriveStateTransition` → `readyMaterializationTxids`.

- `TxConfirmedEvent` sets the anchor to `e.Height` — the height at which the now-promoted child actually became unblocked.
- Every other event leaves the anchor unset; `readyMaterializationTxids` falls back to `job.Height`, preserving the previous behavior on `StartEvent` / `ResumeEvent` / `HeightUpdatedEvent` paths.
- The `deadline <= job.Height` short-circuit still uses `job.Height`, so a back-dated confirmation whose anchored deadline has already elapsed is submitted immediately instead of parked.

No durable state shape change: `DeferredCheckpoint`, the TLV codec, and the persisted checkpoint format are untouched. The anchor is a per-turn parameter only.

## Validation

- `go test ./unroll` — pass
- Added `TestFraudTriggerDeferralAnchoredToParentConfirm`, a multihop `checkpoint_AB -> arktx_AB -> checkpoint_BC -> arktx_BC` regression test that forces `job.Height` ahead of arktx_AB's confirm block before its `TxConfirmedMsg` lands and asserts checkpoint_BC is handed straight to txconfirm. Verified to fail without the fix.
- From the parent `darepo` checkout:
  - `make itest backend=lwwallet icase=TestRecipientFraudPartialOperator` — PASS (249.81s)
  - `make itest backend=lnd icase=TestRecipientFraudPartialOperator` — PASS (259.47s)