### PR TITLE
cmd/darepod: persist daemon logs

### DIFF
--- a/cmd/darepod/log_test.go
+++ b/cmd/darepod/log_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/lightninglabs/darepo-client/darepod"
+	"github.com/stretchr/testify/require"
+)
+
+var errStdoutWrite = errors.New("stdout write failed")
+
+type failingWriter struct{}
+
+func (failingWriter) Write(_ []byte) (int, error) {
+	return 0, errStdoutWrite
+}
+
+// TestConfigureDaemonLogWriterWritesStdoutAndDefaultFile verifies standalone
+// daemon logs are teed to stdout and the default network-scoped log file.
+func TestConfigureDaemonLogWriterWritesStdoutAndDefaultFile(t *testing.T) {
+	t.Parallel()
+
+	cfg := darepod.DefaultConfig()
+	cfg.DataDir = t.TempDir()
+	cfg.Network = "regtest"
+	stdout := &bytes.Buffer{}
+
+	logFile, err := configureDaemonLogWriter(cfg, stdout)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, logFile.Close())
+	})
+
+	_, err = cfg.LogWriter.Write([]byte("hello logs\n"))
+	require.NoError(t, err)
+
+	require.Equal(t, "hello logs\n", stdout.String())
+
+	logPath := filepath.Join(
+		cfg.DataDir, "logs", "regtest", daemonLogFileName,
+	)
+	logBytes, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+	require.Equal(t, "hello logs\n", string(logBytes))
+}
+
+// TestConfigureDaemonLogWriterUsesExplicitLogDir verifies --logdir controls
+// where the persistent daemon log file is created.
+func TestConfigureDaemonLogWriterUsesExplicitLogDir(t *testing.T) {
+	t.Parallel()
+
+	logDir := filepath.Join(t.TempDir(), "explicit")
+	cfg := darepod.DefaultConfig()
+	cfg.DataDir = filepath.Join(t.TempDir(), "data")
+	cfg.Network = "regtest"
+	cfg.LogDirPath = logDir
+	stdout := &bytes.Buffer{}
+
+	logFile, err := configureDaemonLogWriter(cfg, stdout)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, logFile.Close())
+	})
+
+	_, err = cfg.LogWriter.Write([]byte("custom logs\n"))
+	require.NoError(t, err)
+
+	logBytes, err := os.ReadFile(filepath.Join(logDir, daemonLogFileName))
+	require.NoError(t, err)
+	require.Equal(t, "custom logs\n", string(logBytes))
+	require.Equal(t, "custom logs\n", stdout.String())
+}
+
+// TestConfigureDaemonLogWriterKeepsFileLoggingWhenStdoutFails verifies stdout
+// write errors do not prevent persistent log writes.
+func TestConfigureDaemonLogWriterKeepsFileLoggingWhenStdoutFails(t *testing.T) {
+	t.Parallel()
+
+	cfg := darepod.DefaultConfig()
+	cfg.DataDir = t.TempDir()
+	cfg.Network = "regtest"
+
+	logFile, err := configureDaemonLogWriter(cfg, failingWriter{})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, logFile.Close())
+	})
+
+	_, err = cfg.LogWriter.Write([]byte("still persisted\n"))
+	require.NoError(t, err)
+
+	logPath := filepath.Join(
+		cfg.DataDir, "logs", "regtest", daemonLogFileName,
+	)
+	logBytes, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+	require.Equal(t, "still persisted\n", string(logBytes))
+}
+
+// TestConfigureDaemonLogWriterKeepsInjectedWriter verifies callers that set a
+// custom LogWriter retain ownership of daemon log output.
+func TestConfigureDaemonLogWriterKeepsInjectedWriter(t *testing.T) {
+	t.Parallel()
+
+	cfg := darepod.DefaultConfig()
+	var injected bytes.Buffer
+	cfg.LogWriter = &injected
+
+	logFile, err := configureDaemonLogWriter(cfg, &bytes.Buffer{})
+	require.NoError(t, err)
+	require.Nil(t, logFile)
+	require.Same(t, &injected, cfg.LogWriter)
+}

--- a/cmd/darepod/main.go
+++ b/cmd/darepod/main.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/lightninglabs/darepo-client/build"
@@ -12,6 +14,20 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
+
+const daemonLogFileName = "darepod.log"
+
+type bestEffortWriter struct {
+	w io.Writer
+}
+
+func (b bestEffortWriter) Write(p []byte) (int, error) {
+	if b.w != nil {
+		_, _ = b.w.Write(p)
+	}
+
+	return len(p), nil
+}
 
 func main() {
 	root := newRootCmd()
@@ -78,6 +94,10 @@ func newRootCmd() *cobra.Command {
 	f.String(
 		"debuglevel", cfg.DebugLevel,
 		"logging verbosity (trace, debug, info, warn, error, critical)",
+	)
+	f.String(
+		"logdir", cfg.LogDirPath,
+		"directory for persistent daemon logs",
 	)
 
 	// LND connection flags.
@@ -249,6 +269,16 @@ func run(cfg *darepod.Config) error {
 		return fmt.Errorf("invalid config: %w", err)
 	}
 
+	logFile, err := configureDaemonLogWriter(cfg, os.Stdout)
+	if err != nil {
+		return fmt.Errorf("configure daemon log file: %w", err)
+	}
+	if logFile != nil {
+		defer func() {
+			_ = logFile.Close()
+		}()
+	}
+
 	// Intercept OS signals for graceful shutdown.
 	shutdownInterceptor, err := signal.Intercept()
 	if err != nil {
@@ -256,4 +286,37 @@ func run(cfg *darepod.Config) error {
 	}
 
 	return darepod.Main(cfg, shutdownInterceptor)
+}
+
+// configureDaemonLogWriter makes the standalone daemon write logs to both
+// stdout and a persistent log file. Embedders that provide LogWriter keep full
+// control of the sink.
+func configureDaemonLogWriter(cfg *darepod.Config,
+	stdout io.Writer) (*os.File, error) {
+
+	if cfg.LogWriter != nil {
+		return nil, nil
+	}
+
+	logDir, err := cfg.LogDir()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := os.MkdirAll(logDir, 0o700); err != nil {
+		return nil, fmt.Errorf("create log directory %q: %w", logDir,
+			err)
+	}
+
+	logFilePath := filepath.Join(logDir, daemonLogFileName)
+	logFile, err := os.OpenFile( //nolint:gosec // G304: operator log path.
+		logFilePath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("open log file %q: %w", logFilePath, err)
+	}
+
+	cfg.LogWriter = io.MultiWriter(bestEffortWriter{stdout}, logFile)
+
+	return logFile, nil
 }

--- a/darepod/config.go
+++ b/darepod/config.go
@@ -114,6 +114,11 @@ type Config struct {
 	// Valid levels: trace, debug, info, warn, error, critical, off.
 	DebugLevel string `mapstructure:"debuglevel"`
 
+	// LogDirPath overrides the network-scoped directory used by the CLI
+	// for persistent daemon log files. When empty, logs are written under
+	// DataDir/logs/<network>.
+	LogDirPath string `mapstructure:"logdir"`
+
 	// LogWriter is the sink for daemon log output. When nil, darepod
 	// writes logs to stdout.
 	LogWriter io.Writer
@@ -613,6 +618,10 @@ func (c *Config) NetworkDir() (string, error) {
 
 // LogDir returns the network-scoped log directory.
 func (c *Config) LogDir() (string, error) {
+	if c.LogDirPath != "" {
+		return expandTilde(c.LogDirPath)
+	}
+
 	dataDir, err := expandTilde(c.DataDir)
 	if err != nil {
 		return "", err

--- a/darepod/config_logdir_test.go
+++ b/darepod/config_logdir_test.go
@@ -1,0 +1,39 @@
+package darepod
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestConfigLogDirUsesNetworkScopedDefault verifies the default log directory
+// stays under the configured data directory and current network.
+func TestConfigLogDirUsesNetworkScopedDefault(t *testing.T) {
+	t.Parallel()
+
+	dataDir := t.TempDir()
+	cfg := DefaultConfig()
+	cfg.DataDir = dataDir
+	cfg.Network = "regtest"
+
+	logDir, err := cfg.LogDir()
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(dataDir, "logs", "regtest"), logDir)
+}
+
+// TestConfigLogDirUsesExplicitLogDir verifies an explicit log directory
+// replaces the default data-directory-derived path.
+func TestConfigLogDirUsesExplicitLogDir(t *testing.T) {
+	t.Parallel()
+
+	explicitLogDir := filepath.Join(t.TempDir(), "custom-logs")
+	cfg := DefaultConfig()
+	cfg.DataDir = filepath.Join(t.TempDir(), "unused-data")
+	cfg.Network = "regtest"
+	cfg.LogDirPath = explicitLogDir
+
+	logDir, err := cfg.LogDir()
+	require.NoError(t, err)
+	require.Equal(t, explicitLogDir, logDir)
+}

--- a/docs/daemon_cli_guide.md
+++ b/docs/daemon_cli_guide.md
@@ -73,6 +73,7 @@ darepod \
 | `--datadir` | `~/.darepod` | Root data directory for all daemon state |
 | `--network` | `mainnet` | Bitcoin network: mainnet, testnet, regtest, simnet, signet |
 | `--debuglevel` | `info` | Logging verbosity: trace, debug, info, warn, error, critical |
+| `--logdir` | `~/.darepod/logs/<network>` | Directory for persistent daemon logs |
 | `--allow-mainnet` | `false` | Required to run on mainnet (safety guard) |
 | `--wallet.type` | `lwwallet` | Wallet backend: `lwwallet` or `lnd` |
 | `--wallet.esploraurl` | | Esplora REST API URL (lwwallet only) |


### PR DESCRIPTION
## Summary

This PR makes the standalone `darepod` command persist daemon logs to disk while preserving the existing stdout behavior. When no log directory is configured, the CLI now creates `darepod.log` under the network-scoped default log directory, which resolves to `~/.darepod/logs/<network>/darepod.log` with the standard config. Operators can set `--logdir` or `DAREPOD_LOGDIR` to place the log file somewhere else. Programmatic embedders that already provide `Config.LogWriter` keep full control of logging, so SDK/in-process callers do not unexpectedly create local log files.

Closes #413.

## Testing

- `make fmt-changed`
- `go test ./cmd/darepod ./darepod`
- `make commitmsg-lint commit=HEAD`
