### PR TITLE
Correlate early round quotes by accepted inputs

### DIFF
--- a/round/actor.go
+++ b/round/actor.go
@@ -794,6 +794,23 @@ func (a *RoundClientActor) findAssemblingRound() *RoundFSM {
 func (a *RoundClientActor) findRoundByOutpoints(
 	boardingOutpoints, vtxoOutpoints []wire.OutPoint) *RoundFSM {
 
+	roundFSM, ambiguous := a.findRoundByOutpointsDetailed(
+		boardingOutpoints, vtxoOutpoints,
+	)
+	if ambiguous {
+		return nil
+	}
+
+	return roundFSM
+}
+
+// findRoundByOutpointsDetailed is findRoundByOutpoints with ambiguity
+// surfaced separately from "not found". This is used by self-correlating
+// quote delivery, where ambiguity should fail loudly instead of falling back
+// to buffering.
+func (a *RoundClientActor) findRoundByOutpointsDetailed(
+	boardingOutpoints, vtxoOutpoints []wire.OutPoint) (*RoundFSM, bool) {
+
 	boardingSet := fn.NewSet(boardingOutpoints...)
 	vtxoSet := fn.NewSet(vtxoOutpoints...)
 
@@ -825,12 +842,12 @@ func (a *RoundClientActor) findRoundByOutpoints(
 			// boarding-less refreshes that all start from an
 			// empty boarding set. Refusing to guess is strictly
 			// safer than routing into the wrong FSM.
-			return nil
+			return nil, true
 		}
 		match = roundFSM
 	}
 
-	return match
+	return match, false
 }
 
 // boardingMatches checks whether the boarding outpoints of an
@@ -1523,9 +1540,27 @@ func (a *RoundClientActor) buildVTXORequest(ctx context.Context,
 func (a *RoundClientActor) handleRoundJoined(ctx context.Context,
 	event *RoundJoined) fn.Result[actormsg.RoundActorResp] {
 
-	// Find the pending round by matching outpoints. Currently we only match
-	// boarding outpoints, but this will be extended for VTXO operations
-	// (forfeit, leave, refresh) when implemented.
+	newKeyStr := RoundKeyStr(event.RoundID.KeyString())
+	if _, ok := a.rounds[newKeyStr]; ok {
+		a.log.DebugS(ctx, "Ignoring duplicate round admission",
+			slog.String("round_id", event.RoundID.String()),
+			slog.Int(
+				"num_boarding",
+				len(event.AcceptedBoardingOutpoints),
+			),
+			slog.Int("num_vtxo", len(event.AcceptedVTXOOutpoints)),
+		)
+
+		return fn.Ok[actormsg.RoundActorResp](
+			&ServerMessageResponse{
+				Success: true,
+			},
+		)
+	}
+
+	// Find the pending round by matching the accepted inputs that the
+	// server echoed back. This keeps concurrent boarding, refresh and leave
+	// rounds from being re-keyed into the wrong FSM.
 	roundFSM := a.findRoundByOutpoints(
 		event.AcceptedBoardingOutpoints, event.AcceptedVTXOOutpoints,
 	)
@@ -1542,7 +1577,6 @@ func (a *RoundClientActor) handleRoundJoined(ctx context.Context,
 	oldKeyStr := RoundKeyStr(roundFSM.Key.KeyString())
 	delete(a.rounds, oldKeyStr)
 
-	newKeyStr := RoundKeyStr(event.RoundID.KeyString())
 	roundFSM.Key = event.RoundID
 	roundFSM.RoundID = event.RoundID
 	a.rounds[newKeyStr] = roundFSM
@@ -1588,6 +1622,71 @@ func (a *RoundClientActor) handleRoundJoined(ctx context.Context,
 			Success: true,
 		},
 	)
+}
+
+// handleEarlyQuote handles a JoinRoundQuoteReceived whose RoundID is not yet
+// tracked locally. Newer servers echo the accepted input outpoints on the quote
+// so the actor can correlate it to the temp-keyed IntentSent FSM without
+// relying on the separate RoundJoined envelope arriving first.
+func (a *RoundClientActor) handleEarlyQuote(ctx context.Context,
+	quote *JoinRoundQuoteReceived) fn.Result[actormsg.RoundActorResp] {
+
+	roundFSM, ambiguous := a.findRoundByOutpointsDetailed(
+		quote.AcceptedBoardingOutpoints, quote.AcceptedVTXOOutpoints,
+	)
+	if ambiguous {
+		return fn.Err[actormsg.RoundActorResp](
+			fmt.Errorf("ambiguous pending round for early quote: "+
+				"round_id=%s boarding=%v vtxo=%v",
+				quote.RoundID, quote.AcceptedBoardingOutpoints,
+				quote.AcceptedVTXOOutpoints),
+		)
+	}
+
+	if roundFSM == nil {
+		return a.bufferPendingQuote(ctx, quote)
+	}
+
+	oldKeyStr := RoundKeyStr(roundFSM.Key.KeyString())
+	delete(a.rounds, oldKeyStr)
+
+	newKeyStr := RoundKeyStr(quote.RoundID.KeyString())
+	roundFSM.Key = quote.RoundID
+	roundFSM.RoundID = quote.RoundID
+	a.rounds[newKeyStr] = roundFSM
+
+	a.log.InfoS(ctx, "Re-keyed round from early quote",
+		slog.String("old_key", string(oldKeyStr)),
+		slog.String("round_id", quote.RoundID.String()),
+		slog.Int(
+			"num_boarding", len(quote.AcceptedBoardingOutpoints),
+		),
+		slog.Int("num_vtxo", len(quote.AcceptedVTXOOutpoints)),
+	)
+
+	admission := &RoundJoined{
+		RoundID:                   quote.RoundID,
+		AcceptedBoardingOutpoints: quote.AcceptedBoardingOutpoints,
+		AcceptedVTXOOutpoints:     quote.AcceptedVTXOOutpoints,
+	}
+	if err := a.askEventAndProcessOutbox(
+		ctx, roundFSM, admission,
+	); err != nil {
+		return fn.Err[actormsg.RoundActorResp](
+			fmt.Errorf("FSM error processing early-quote "+
+				"admission: %w", err),
+		)
+	}
+
+	if err := a.askEventAndProcessOutbox(ctx, roundFSM, quote); err != nil {
+		return fn.Err[actormsg.RoundActorResp](
+			fmt.Errorf("FSM error processing early quote: %w", err),
+		)
+	}
+
+	return fn.Ok[actormsg.RoundActorResp](&ServerMessageResponse{
+		Success: true,
+	})
 }
 
 // maxPendingQuotes caps the number of out-of-order quotes the
@@ -1728,11 +1827,13 @@ func (a *RoundClientActor) routeServerMessageByRoundID(ctx context.Context,
 
 	// The mailbox contract allows envelopes to arrive out of order. If
 	// a JoinRoundQuoteReceived lands before its matching RoundJoined
-	// has re-keyed the FSM, buffer it so handleRoundJoined can drain
-	// it after re-keying. Every other event type without a live
+	// has re-keyed the FSM, first try to correlate it by the accepted
+	// input outpoints echoed on the quote. Legacy quotes without enough
+	// correlation data fall back to buffering so handleRoundJoined can
+	// drain them after re-keying. Every other event type without a live
 	// routing target is a real miss.
 	if quote, ok := msg.(*JoinRoundQuoteReceived); ok {
-		return nil, a.bufferPendingQuote(ctx, quote), true
+		return nil, a.handleEarlyQuote(ctx, quote), true
 	}
 
 	return nil, fn.Err[actormsg.RoundActorResp](

--- a/round/actor_test.go
+++ b/round/actor_test.go
@@ -1238,6 +1238,88 @@ func TestActorBuffersEarlyQuote(t *testing.T) {
 	)
 }
 
+// TestActorCorrelatesEarlyQuote verifies that a quote carrying accepted-input
+// correlation data can re-key the pending temp round before the separate
+// RoundJoined envelope arrives. This removes the protocol's dependency on
+// ordered mailbox delivery for JoinAck before JoinRoundQuote.
+func TestActorCorrelatesEarlyQuote(t *testing.T) {
+	t.Parallel()
+
+	h := newActorTestHarness(t)
+	h.setupMockRoundStoreForStart()
+	require.NoError(t, h.start())
+
+	intent := h.newTestBoardingIntent()
+	h.sendWalletConfirmation(intent)
+	h.sendVTXORequests(50000)
+	h.sendServerMessage(&IntentRequested{})
+
+	states := h.queryState()
+	var vtxos []types.VTXORequest
+	for _, info := range states {
+		rs, ok := info.State.(*IntentSentState)
+		if !ok {
+			continue
+		}
+		vtxos = append(vtxos, rs.Intents.VTXOs...)
+	}
+	require.NotEmpty(t, vtxos)
+
+	vtxoQuotes := make([]VTXOQuoteEntry, len(vtxos))
+	for i, v := range vtxos {
+		script, err := v.EffectivePkScript()
+		require.NoError(t, err)
+
+		vtxoQuotes[i] = VTXOQuoteEntry{
+			PkScript:     script,
+			AmountSat:    int64(v.Amount),
+			RecipientKey: v.SigningKey.PubKey.SerializeCompressed(),
+		}
+	}
+
+	var quoteID [32]byte
+	for i := range quoteID {
+		quoteID[i] = byte(i + 1)
+	}
+
+	roundID := testRoundID("self-correlating-quote")
+	h.sendServerMessage(&JoinRoundQuoteReceived{
+		RoundID: roundID,
+		AcceptedBoardingOutpoints: []wire.OutPoint{
+			intent.Outpoint,
+		},
+		Quote: &ClientQuote{
+			QuoteID:        quoteID,
+			OperatorFeeSat: 1_000,
+			VTXOQuotes:     vtxoQuotes,
+		},
+	})
+
+	states = h.queryState()
+	require.Contains(t, states, roundID.KeyString())
+
+	found := false
+	for _, info := range states {
+		switch info.State.(type) {
+		case *QuoteReceivedState, *RoundJoinedState:
+			found = true
+		}
+	}
+	require.True(
+		t, found, "self-correlating quote must advance the FSM "+
+			"without waiting for RoundJoined",
+	)
+
+	// A late RoundJoined for the same round is now a duplicate
+	// admission watermark and must not fail the actor.
+	h.sendServerMessage(&RoundJoined{
+		RoundID: roundID,
+		AcceptedBoardingOutpoints: []wire.OutPoint{
+			intent.Outpoint,
+		},
+	})
+}
+
 func TestActorServerMessageRouting(t *testing.T) {
 	t.Parallel()
 

--- a/round/events.go
+++ b/round/events.go
@@ -75,6 +75,17 @@ type JoinRoundQuoteReceived struct {
 	// RoundID is the round the quote belongs to.
 	RoundID RoundID
 
+	// AcceptedBoardingOutpoints contains the boarding outpoints accepted
+	// into this round. When the quote arrives before RoundJoined, the actor
+	// uses these outpoints to correlate the quote to the pending temp-keyed
+	// FSM.
+	AcceptedBoardingOutpoints []wire.OutPoint
+
+	// AcceptedVTXOOutpoints contains the VTXO outpoints accepted into this
+	// round. This disambiguates concurrent VTXO-only rounds when a quote
+	// arrives before RoundJoined.
+	AcceptedVTXOOutpoints []wire.OutPoint
+
 	// Quote is the server-issued quote payload.
 	Quote *ClientQuote
 }

--- a/round/from_proto.go
+++ b/round/from_proto.go
@@ -48,6 +48,22 @@ func (e *JoinRoundQuoteReceived) FromProto(p proto.Message) error {
 	}
 	e.RoundID = roundID
 
+	boardingOps, err := roundpb.OutpointsFromProto(
+		pb.GetAcceptedBoardingOutpoints(),
+	)
+	if err != nil {
+		return fmt.Errorf("accepted_boarding_outpoints: %w", err)
+	}
+	e.AcceptedBoardingOutpoints = boardingOps
+
+	vtxoOps, err := roundpb.OutpointsFromProto(
+		pb.GetAcceptedVtxoOutpoints(),
+	)
+	if err != nil {
+		return fmt.Errorf("accepted_vtxo_outpoints: %w", err)
+	}
+	e.AcceptedVTXOOutpoints = vtxoOps
+
 	if len(pb.GetQuoteId()) != 32 {
 		return fmt.Errorf("invalid quote_id length: %d, want 32",
 			len(pb.GetQuoteId()))

--- a/round/outbox_messages_test.go
+++ b/round/outbox_messages_test.go
@@ -192,6 +192,19 @@ func TestJoinRoundQuoteReceivedFromProto(t *testing.T) {
 		quoteID[i] = byte(i + 1)
 	}
 
+	boardingOutpoint := wire.OutPoint{
+		Hash: chainhash.Hash{
+			0xaa,
+		},
+		Index: 1,
+	}
+	vtxoOutpoint := wire.OutPoint{
+		Hash: chainhash.Hash{
+			0xbb,
+		},
+		Index: 2,
+	}
+
 	pb := &roundpb.JoinRoundQuote{
 		RoundId:        roundID.String(),
 		QuoteId:        quoteID[:],
@@ -235,6 +248,12 @@ func TestJoinRoundQuoteReceivedFromProto(t *testing.T) {
 				AmountSat: 20_000,
 			},
 		},
+		AcceptedBoardingOutpoints: []*roundpb.Outpoint{
+			roundpb.OutpointToProto(boardingOutpoint),
+		},
+		AcceptedVtxoOutpoints: []*roundpb.Outpoint{
+			roundpb.OutpointToProto(vtxoOutpoint),
+		},
 	}
 
 	var got JoinRoundQuoteReceived
@@ -273,6 +292,13 @@ func TestJoinRoundQuoteReceivedFromProto(t *testing.T) {
 			},
 		},
 		got.Quote.LeaveQuotes,
+	)
+	require.Equal(
+		t, []wire.OutPoint{boardingOutpoint},
+		got.AcceptedBoardingOutpoints,
+	)
+	require.Equal(
+		t, []wire.OutPoint{vtxoOutpoint}, got.AcceptedVTXOOutpoints,
 	)
 }
 

--- a/rpc/roundpb/round.pb.go
+++ b/rpc/roundpb/round.pb.go
@@ -1638,9 +1638,17 @@ type JoinRoundQuote struct {
 	// reject_reason is populated when the server drops this
 	// client's intent at seal time (e.g. residual would be
 	// negative). QUOTE_OK indicates a valid quote.
-	RejectReason  QuoteReason `protobuf:"varint,9,opt,name=reject_reason,json=rejectReason,proto3,enum=round.v1.QuoteReason" json:"reject_reason,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	RejectReason QuoteReason `protobuf:"varint,9,opt,name=reject_reason,json=rejectReason,proto3,enum=round.v1.QuoteReason" json:"reject_reason,omitempty"`
+	// accepted_boarding_outpoints lists boarding outpoints accepted into the
+	// round. It mirrors ClientSuccessResp so clients can correlate an
+	// out-of-order quote to the correct pending round before the separate
+	// join-ack envelope arrives.
+	AcceptedBoardingOutpoints []*Outpoint `protobuf:"bytes,10,rep,name=accepted_boarding_outpoints,json=acceptedBoardingOutpoints,proto3" json:"accepted_boarding_outpoints,omitempty"`
+	// accepted_vtxo_outpoints lists VTXO outpoints involved in the round. It
+	// mirrors ClientSuccessResp and disambiguates concurrent VTXO-only joins.
+	AcceptedVtxoOutpoints []*Outpoint `protobuf:"bytes,11,rep,name=accepted_vtxo_outpoints,json=acceptedVtxoOutpoints,proto3" json:"accepted_vtxo_outpoints,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
 }
 
 func (x *JoinRoundQuote) Reset() {
@@ -1734,6 +1742,20 @@ func (x *JoinRoundQuote) GetRejectReason() QuoteReason {
 		return x.RejectReason
 	}
 	return QuoteReason_QUOTE_OK
+}
+
+func (x *JoinRoundQuote) GetAcceptedBoardingOutpoints() []*Outpoint {
+	if x != nil {
+		return x.AcceptedBoardingOutpoints
+	}
+	return nil
+}
+
+func (x *JoinRoundQuote) GetAcceptedVtxoOutpoints() []*Outpoint {
+	if x != nil {
+		return x.AcceptedVtxoOutpoints
+	}
+	return nil
 }
 
 // JoinRoundAccept is sent from client to server to explicitly
@@ -2452,7 +2474,7 @@ const file_round_proto_rawDesc = "" +
 	"LeaveQuote\x12\x1b\n" +
 	"\tpk_script\x18\x01 \x01(\fR\bpkScript\x12\x1d\n" +
 	"\n" +
-	"amount_sat\x18\x02 \x01(\x03R\tamountSat\"\xa5\x03\n" +
+	"amount_sat\x18\x02 \x01(\x03R\tamountSat\"\xc5\x04\n" +
 	"\x0eJoinRoundQuote\x12\x19\n" +
 	"\bround_id\x18\x01 \x01(\tR\aroundId\x12\x19\n" +
 	"\bquote_id\x18\x02 \x01(\fR\aquoteId\x12(\n" +
@@ -2463,7 +2485,10 @@ const file_round_proto_rawDesc = "" +
 	"\x10operator_fee_sat\x18\x06 \x01(\x03R\x0eoperatorFeeSat\x124\n" +
 	"\tbreakdown\x18\a \x01(\v2\x16.round.v1.FeeBreakdownR\tbreakdown\x12(\n" +
 	"\x10quote_expires_at\x18\b \x01(\x03R\x0equoteExpiresAt\x12:\n" +
-	"\rreject_reason\x18\t \x01(\x0e2\x15.round.v1.QuoteReasonR\frejectReason\"G\n" +
+	"\rreject_reason\x18\t \x01(\x0e2\x15.round.v1.QuoteReasonR\frejectReason\x12R\n" +
+	"\x1baccepted_boarding_outpoints\x18\n" +
+	" \x03(\v2\x12.round.v1.OutpointR\x19acceptedBoardingOutpoints\x12J\n" +
+	"\x17accepted_vtxo_outpoints\x18\v \x03(\v2\x12.round.v1.OutpointR\x15acceptedVtxoOutpoints\"G\n" +
 	"\x0fJoinRoundAccept\x12\x19\n" +
 	"\bround_id\x18\x01 \x01(\tR\aroundId\x12\x19\n" +
 	"\bquote_id\x18\x02 \x01(\fR\aquoteId\"_\n" +
@@ -2615,37 +2640,39 @@ var file_round_proto_depIdxs = []int32{
 	22, // 23: round.v1.JoinRoundQuote.leave_quotes:type_name -> round.v1.LeaveQuote
 	20, // 24: round.v1.JoinRoundQuote.breakdown:type_name -> round.v1.FeeBreakdown
 	0,  // 25: round.v1.JoinRoundQuote.reject_reason:type_name -> round.v1.QuoteReason
-	39, // 26: round.v1.SubmitNoncesRequest.nonces:type_name -> round.v1.SubmitNoncesRequest.NoncesEntry
-	40, // 27: round.v1.SignerNonces.tx_nonces:type_name -> round.v1.SignerNonces.TxNoncesEntry
-	41, // 28: round.v1.SubmitPartialSigRequest.signatures:type_name -> round.v1.SubmitPartialSigRequest.SignaturesEntry
-	42, // 29: round.v1.SignerPartialSigs.tx_sigs:type_name -> round.v1.SignerPartialSigs.TxSigsEntry
-	1,  // 30: round.v1.BoardingInputSignature.outpoint:type_name -> round.v1.Outpoint
-	30, // 31: round.v1.SubmitForfeitSigRequest.signatures:type_name -> round.v1.BoardingInputSignature
-	1,  // 32: round.v1.ForfeitTxSig.vtxo_outpoint:type_name -> round.v1.Outpoint
-	32, // 33: round.v1.SubmitVTXOForfeitSigsRequest.forfeit_txs:type_name -> round.v1.ForfeitTxSig
-	4,  // 34: round.v1.ClientBatchInfo.VtxoTreePathsEntry.value:type_name -> round.v1.VTXOTree
-	5,  // 35: round.v1.ClientBatchInfo.ConnectorLeafMapEntry.value:type_name -> round.v1.ConnectorLeafInfo
-	27, // 36: round.v1.SubmitNoncesRequest.NoncesEntry.value:type_name -> round.v1.SignerNonces
-	29, // 37: round.v1.SubmitPartialSigRequest.SignaturesEntry.value:type_name -> round.v1.SignerPartialSigs
-	19, // 38: round.v1.RoundService.JoinRound:input_type -> round.v1.JoinRoundRequest
-	24, // 39: round.v1.RoundService.AcceptQuote:input_type -> round.v1.JoinRoundAccept
-	25, // 40: round.v1.RoundService.RejectQuote:input_type -> round.v1.JoinRoundReject
-	26, // 41: round.v1.RoundService.SubmitNonces:input_type -> round.v1.SubmitNoncesRequest
-	28, // 42: round.v1.RoundService.SubmitPartialSigs:input_type -> round.v1.SubmitPartialSigRequest
-	31, // 43: round.v1.RoundService.SubmitForfeitSigs:input_type -> round.v1.SubmitForfeitSigRequest
-	33, // 44: round.v1.RoundService.SubmitVTXOForfeitSigs:input_type -> round.v1.SubmitVTXOForfeitSigsRequest
-	7,  // 45: round.v1.RoundService.JoinRound:output_type -> round.v1.ClientSuccessResp
-	7,  // 46: round.v1.RoundService.AcceptQuote:output_type -> round.v1.ClientSuccessResp
-	7,  // 47: round.v1.RoundService.RejectQuote:output_type -> round.v1.ClientSuccessResp
-	10, // 48: round.v1.RoundService.SubmitNonces:output_type -> round.v1.ClientVTXOAggNonces
-	11, // 49: round.v1.RoundService.SubmitPartialSigs:output_type -> round.v1.ClientVTXOAggSigs
-	9,  // 50: round.v1.RoundService.SubmitForfeitSigs:output_type -> round.v1.ClientAwaitingInputSigsResp
-	7,  // 51: round.v1.RoundService.SubmitVTXOForfeitSigs:output_type -> round.v1.ClientSuccessResp
-	45, // [45:52] is the sub-list for method output_type
-	38, // [38:45] is the sub-list for method input_type
-	38, // [38:38] is the sub-list for extension type_name
-	38, // [38:38] is the sub-list for extension extendee
-	0,  // [0:38] is the sub-list for field type_name
+	1,  // 26: round.v1.JoinRoundQuote.accepted_boarding_outpoints:type_name -> round.v1.Outpoint
+	1,  // 27: round.v1.JoinRoundQuote.accepted_vtxo_outpoints:type_name -> round.v1.Outpoint
+	39, // 28: round.v1.SubmitNoncesRequest.nonces:type_name -> round.v1.SubmitNoncesRequest.NoncesEntry
+	40, // 29: round.v1.SignerNonces.tx_nonces:type_name -> round.v1.SignerNonces.TxNoncesEntry
+	41, // 30: round.v1.SubmitPartialSigRequest.signatures:type_name -> round.v1.SubmitPartialSigRequest.SignaturesEntry
+	42, // 31: round.v1.SignerPartialSigs.tx_sigs:type_name -> round.v1.SignerPartialSigs.TxSigsEntry
+	1,  // 32: round.v1.BoardingInputSignature.outpoint:type_name -> round.v1.Outpoint
+	30, // 33: round.v1.SubmitForfeitSigRequest.signatures:type_name -> round.v1.BoardingInputSignature
+	1,  // 34: round.v1.ForfeitTxSig.vtxo_outpoint:type_name -> round.v1.Outpoint
+	32, // 35: round.v1.SubmitVTXOForfeitSigsRequest.forfeit_txs:type_name -> round.v1.ForfeitTxSig
+	4,  // 36: round.v1.ClientBatchInfo.VtxoTreePathsEntry.value:type_name -> round.v1.VTXOTree
+	5,  // 37: round.v1.ClientBatchInfo.ConnectorLeafMapEntry.value:type_name -> round.v1.ConnectorLeafInfo
+	27, // 38: round.v1.SubmitNoncesRequest.NoncesEntry.value:type_name -> round.v1.SignerNonces
+	29, // 39: round.v1.SubmitPartialSigRequest.SignaturesEntry.value:type_name -> round.v1.SignerPartialSigs
+	19, // 40: round.v1.RoundService.JoinRound:input_type -> round.v1.JoinRoundRequest
+	24, // 41: round.v1.RoundService.AcceptQuote:input_type -> round.v1.JoinRoundAccept
+	25, // 42: round.v1.RoundService.RejectQuote:input_type -> round.v1.JoinRoundReject
+	26, // 43: round.v1.RoundService.SubmitNonces:input_type -> round.v1.SubmitNoncesRequest
+	28, // 44: round.v1.RoundService.SubmitPartialSigs:input_type -> round.v1.SubmitPartialSigRequest
+	31, // 45: round.v1.RoundService.SubmitForfeitSigs:input_type -> round.v1.SubmitForfeitSigRequest
+	33, // 46: round.v1.RoundService.SubmitVTXOForfeitSigs:input_type -> round.v1.SubmitVTXOForfeitSigsRequest
+	7,  // 47: round.v1.RoundService.JoinRound:output_type -> round.v1.ClientSuccessResp
+	7,  // 48: round.v1.RoundService.AcceptQuote:output_type -> round.v1.ClientSuccessResp
+	7,  // 49: round.v1.RoundService.RejectQuote:output_type -> round.v1.ClientSuccessResp
+	10, // 50: round.v1.RoundService.SubmitNonces:output_type -> round.v1.ClientVTXOAggNonces
+	11, // 51: round.v1.RoundService.SubmitPartialSigs:output_type -> round.v1.ClientVTXOAggSigs
+	9,  // 52: round.v1.RoundService.SubmitForfeitSigs:output_type -> round.v1.ClientAwaitingInputSigsResp
+	7,  // 53: round.v1.RoundService.SubmitVTXOForfeitSigs:output_type -> round.v1.ClientSuccessResp
+	47, // [47:54] is the sub-list for method output_type
+	40, // [40:47] is the sub-list for method input_type
+	40, // [40:40] is the sub-list for extension type_name
+	40, // [40:40] is the sub-list for extension extendee
+	0,  // [0:40] is the sub-list for field type_name
 }
 
 func init() { file_round_proto_init() }

--- a/rpc/roundpb/round.proto
+++ b/rpc/roundpb/round.proto
@@ -452,6 +452,16 @@ message JoinRoundQuote {
     // client's intent at seal time (e.g. residual would be
     // negative). QUOTE_OK indicates a valid quote.
     QuoteReason reject_reason = 9;
+
+    // accepted_boarding_outpoints lists boarding outpoints accepted into the
+    // round. It mirrors ClientSuccessResp so clients can correlate an
+    // out-of-order quote to the correct pending round before the separate
+    // join-ack envelope arrives.
+    repeated Outpoint accepted_boarding_outpoints = 10;
+
+    // accepted_vtxo_outpoints lists VTXO outpoints involved in the round. It
+    // mirrors ClientSuccessResp and disambiguates concurrent VTXO-only joins.
+    repeated Outpoint accepted_vtxo_outpoints = 11;
 }
 
 // JoinRoundAccept is sent from client to server to explicitly


### PR DESCRIPTION
## What changed

This makes `JoinRoundQuote` self-correlating by carrying the accepted boarding and VTXO outpoints that were already present on the join acknowledgement path.

On the client side, an out-of-order quote can now be matched to the pending temp-keyed round before the separate admission envelope arrives. The actor re-keys the round from the quote, synthesizes the admission event for the FSM, then processes the quote. A later duplicate admission for the same round is treated as an idempotent watermark.

## Why

Mailbox delivery does not guarantee that the join acknowledgement arrives before the seal-time quote. Without correlation data on the quote itself, a client can buffer the quote under the assigned round id while its local FSM is still temp-keyed, then miss the server's quote timeout window.

## Validation

- `go test ./round ./rpc/roundpb`
- `go test ./darepod -run TestRunWithContextServesInjectedListener -count=1`
- `go test ./sdk/ark -run TestStartEmbeddedUsesBufconnTransport -count=1`

`go test ./...` was also run; it hit timing-sensitive startup/readiness failures in the two isolated tests above, and both passed when rerun individually.