### PR TITLE
unroll: advance proofs from spend watches

### DIFF
--- a/harness/harness.go
+++ b/harness/harness.go
@@ -849,6 +849,10 @@ func (h *Harness) removeContainerByName(name string) {
 	}
 
 	for _, container := range containers {
+		if !containerHasExactName(container, name) {
+			continue
+		}
+
 		// Kill container if it's still running.
 		err := h.pool.Client.KillContainer(docker.KillContainerOptions{
 			ID: container.ID,
@@ -874,6 +878,20 @@ func (h *Harness) removeContainerByName(name string) {
 			)
 		}
 	}
+}
+
+// containerHasExactName returns true if Docker reported the exact container
+// name. Docker name filters match substrings, so callers must apply this exact
+// check before removing a supposedly stale container.
+func containerHasExactName(container docker.APIContainers, name string) bool {
+	wantName := "/" + strings.TrimPrefix(name, "/")
+	for _, haveName := range container.Names {
+		if haveName == wantName {
+			return true
+		}
+	}
+
+	return false
 }
 
 // waitContainerRunning polls until the given container is running.

--- a/harness/port_retry_test.go
+++ b/harness/port_retry_test.go
@@ -115,3 +115,68 @@ func TestRunWithPortBindRetry(t *testing.T) {
 		require.Equal(t, 1, attempts)
 	})
 }
+
+// TestContainerHasExactName asserts stale-container cleanup does not treat
+// Docker's substring name-filter matches as exact container-name matches.
+func TestContainerHasExactName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		container docker.APIContainers
+		wantName  string
+		want      bool
+	}{
+		{
+			name: "exact name",
+			container: docker.APIContainers{
+				Names: []string{
+					"/bitcoin-TestFoo",
+				},
+			},
+			wantName: "bitcoin-TestFoo",
+			want:     true,
+		},
+		{
+			name: "exact name with leading slash",
+			container: docker.APIContainers{
+				Names: []string{
+					"/bitcoin-TestFoo",
+				},
+			},
+			wantName: "/bitcoin-TestFoo",
+			want:     true,
+		},
+		{
+			name: "substring sibling",
+			container: docker.APIContainers{
+				Names: []string{
+					"/bitcoin-TestFooSubsequentRounds",
+				},
+			},
+			wantName: "bitcoin-TestFoo",
+			want:     false,
+		},
+		{
+			name: "multiple names include exact",
+			container: docker.APIContainers{
+				Names: []string{
+					"/alias",
+					"/bitcoin-TestFoo",
+				},
+			},
+			wantName: "bitcoin-TestFoo",
+			want:     true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(
+				t, tc.want, containerHasExactName(
+					tc.container, tc.wantName,
+				),
+			)
+		})
+	}
+}

--- a/unroll/actor.go
+++ b/unroll/actor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"sort"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -136,10 +137,11 @@ type behavior struct {
 	session *Session
 	pending *actorCheckpoint
 
-	sweepTx          *wire.MsgTx
-	blockSubActive   bool
-	spendWatchActive bool
-	terminalNotified bool
+	sweepTx           *wire.MsgTx
+	blockSubActive    bool
+	spendWatchActive  bool
+	proofSpendWatches map[wire.OutPoint]struct{}
+	terminalNotified  bool
 }
 
 // Receive processes one durable actor message. It is the single entry
@@ -214,6 +216,7 @@ func (b *behavior) Receive(ctx context.Context, msg Msg) fn.Result[Resp] {
 func (b *behavior) OnStop(ctx context.Context) error {
 	b.unsubscribeBlocks(ctx)
 	b.unregisterSpendWatch(ctx)
+	b.unregisterProofSpendWatches(ctx)
 
 	if b.session != nil && b.session.FSM != nil {
 		b.session.FSM.Stop()
@@ -427,6 +430,10 @@ func (b *behavior) ensureNodeConfirmed(ctx context.Context, txid chainhash.Hash,
 	pkScript, err := safeTxOutPkScript(node.Tx, 0)
 	if err != nil {
 		return fmt.Errorf("proof node %s: %w", txid, err)
+	}
+
+	if err := b.ensureProofSpendWatches(ctx, txid, node); err != nil {
+		return err
 	}
 
 	resp, err := b.cfg.TxConfirmRef.Ask(ctx, &txconfirm.EnsureConfirmedReq{
@@ -772,6 +779,7 @@ func (b *behavior) ensureSpendWatch(ctx context.Context) error {
 		b.selfRef,
 		func(event chainsource.SpendEvent) Msg {
 			return &SpendObservedMsg{
+				Outpoint:       event.Outpoint,
 				SpendingTxid:   event.SpendingTxid,
 				SpendingHeight: event.SpendingHeight,
 			}
@@ -819,24 +827,174 @@ func (b *behavior) spendCallerID() string {
 	return fmt.Sprintf("unroll-spend.%s", b.cfg.TargetOutpoint.String())
 }
 
+// ensureProofSpendWatches registers spend watches on proof node outputs that
+// later in-proof child nodes consume. Neutrino can miss the direct
+// confirmation notification under load, but a spend of one of these outputs
+// still proves the parent proof transaction confirmed.
+func (b *behavior) ensureProofSpendWatches(ctx context.Context,
+	txid chainhash.Hash, node *recovery.Node) error {
+
+	if node == nil {
+		return fmt.Errorf("proof node %s missing", txid)
+	}
+	if b.proof == nil {
+		return fmt.Errorf("proof required for spend watches")
+	}
+
+	outpoints, err := b.proofChildInputOutpoints(txid)
+	if err != nil {
+		return err
+	}
+	if len(outpoints) > 0 && b.proofSpendWatches == nil {
+		b.proofSpendWatches = make(map[wire.OutPoint]struct{})
+	}
+
+	heightHint := uint32(0)
+	if b.desc != nil && b.desc.CreatedHeight > 0 {
+		heightHint = uint32(b.desc.CreatedHeight)
+	}
+
+	for _, outpoint := range outpoints {
+		if outpoint == b.cfg.TargetOutpoint {
+			continue
+		}
+		if _, ok := b.proofSpendWatches[outpoint]; ok {
+			continue
+		}
+
+		pkScript, err := safeTxOutPkScript(node.Tx, outpoint.Index)
+		if err != nil {
+			return fmt.Errorf("proof node %s: %w", txid, err)
+		}
+
+		notifyRef := chainsource.MapSpendEvent(
+			b.selfRef,
+			func(event chainsource.SpendEvent) Msg {
+				return &SpendObservedMsg{
+					Outpoint:       event.Outpoint,
+					SpendingTxid:   event.SpendingTxid,
+					SpendingHeight: event.SpendingHeight,
+				}
+			},
+		)
+
+		_, err = b.cfg.ChainSource.Ask(
+			ctx, &chainsource.RegisterSpendRequest{
+				CallerID:    b.proofSpendCallerID(outpoint),
+				Outpoint:    &outpoint,
+				PkScript:    pkScript,
+				HeightHint:  heightHint,
+				NotifyActor: fn.Some(notifyRef),
+			},
+		).Await(ctx).Unpack()
+		if err != nil {
+			return fmt.Errorf("register proof spend watch: %w", err)
+		}
+
+		b.proofSpendWatches[outpoint] = struct{}{}
+	}
+
+	return nil
+}
+
+// proofChildInputOutpoints returns the proof-node outputs that are consumed by
+// in-proof children of txid. Recovery proofs can include Ark transactions that
+// create several sibling outputs; only the output actually referenced by a
+// child belongs to this target's materialization path.
+func (b *behavior) proofChildInputOutpoints(txid chainhash.Hash) (
+	[]wire.OutPoint, error) {
+
+	children, err := b.proof.ChildTxids(txid)
+	if err != nil {
+		return nil, err
+	}
+
+	seen := make(map[wire.OutPoint]struct{})
+	outpoints := make([]wire.OutPoint, 0, len(children))
+
+	for _, childTxid := range children {
+		child, ok := b.proof.Node(childTxid)
+		if !ok {
+			return nil, fmt.Errorf("child proof node %s missing",
+				childTxid)
+		}
+		if child.Tx == nil {
+			return nil, fmt.Errorf("child proof node %s has nil tx",
+				childTxid)
+		}
+
+		for _, txIn := range child.Tx.TxIn {
+			if txIn == nil || txIn.PreviousOutPoint.Hash != txid {
+				continue
+			}
+
+			outpoint := txIn.PreviousOutPoint
+			if _, ok := seen[outpoint]; ok {
+				continue
+			}
+
+			seen[outpoint] = struct{}{}
+			outpoints = append(outpoints, outpoint)
+		}
+	}
+
+	sort.Slice(outpoints, func(i, j int) bool {
+		return outpoints[i].Index < outpoints[j].Index
+	})
+
+	return outpoints, nil
+}
+
+// unregisterProofSpendWatches cancels all proof-node spend watches on stop.
+func (b *behavior) unregisterProofSpendWatches(ctx context.Context) {
+	for outpoint := range b.proofSpendWatches {
+		err := b.cfg.ChainSource.Tell(
+			ctx, &chainsource.UnregisterSpendRequest{
+				CallerID: b.proofSpendCallerID(outpoint),
+				Outpoint: &outpoint,
+			},
+		)
+		if err != nil {
+			b.log.WarnS(
+				ctx,
+				"Failed to unregister proof spend watch",
+				err,
+				slog.String("outpoint", outpoint.String()),
+			)
+
+			continue
+		}
+
+		delete(b.proofSpendWatches, outpoint)
+	}
+}
+
+// proofSpendCallerID returns the stable proof-node spend-watch registration
+// ID.
+func (b *behavior) proofSpendCallerID(outpoint wire.OutPoint) string {
+	return fmt.Sprintf("unroll-proof-spend.%s.%s",
+		b.cfg.TargetOutpoint.String(), outpoint.String())
+}
+
 // handleSpendObserved processes a chainsource spend notification on the
-// target outpoint. The spend watch is a safety net — it fires whenever
-// ANY transaction spends the target, and we have to classify what we are
-// looking at before we decide the unroll job is dead.
+// target or proof-node outpoint. Spend watches are a safety net — they fire
+// when a proof output is consumed on chain, and we have to classify what we
+// are looking at before deciding whether the unroll job is dead.
 //
-// Three cases:
+// Four cases:
 //
-//  1. The spender is a known node in our recovery proof. That means an
-//     ancestor (the target itself, or a transitive parent further up the
-//     tree) just confirmed; this is normal materialization traffic
-//     already being tracked by txconfirm. Swallow the event, but use its
-//     block height to advance the planner's view of the chain.
+//  1. The spent output belongs to a known node in our recovery proof.
+//     That proves the parent transaction confirmed, even if txconfirm's
+//     direct confirmation notification was missed or delayed.
 //
-//  2. The spender is our own final sweep (matched by the sweep txid
+//  2. The spender is a known node in our recovery proof. That means an
+//     ancestor just confirmed; this is normal materialization traffic.
+//
+//  3. The spender is our own final sweep (matched by the sweep txid
 //     recorded in planner state). Again benign — our sweep confirming is
 //     the goal — so just propagate the height.
 //
-//  3. Anything else: the target was spent by someone else. This can
+//  4. Anything else: the watched output was spent by someone else. This can
 //     happen if the operator cooperatively claims it, if a fraud party
 //     beats us to a signed spend, or if a reorg replays a different
 //     history. In all cases the unroll job cannot finish; drive FailEvent
@@ -853,21 +1011,26 @@ func (b *behavior) handleSpendObserved(ctx context.Context,
 		return fn.Ok[Resp](&AckResp{})
 	}
 
-	// Case 1: the spender is a proof-graph node. That means an
-	// ancestor of our target just confirmed on chain — totally
-	// expected. chainsource will also be sending us the corresponding
-	// TxConfirmedMsg via the txconfirm subscription; here we only
-	// use the event to bump the best-height watermark so planner
-	// snapshots are consistent.
 	if b.proof != nil {
+		acked, err := b.ackProofOutputSpend(ctx, msg)
+		if err != nil {
+			return fn.Err[Resp](err)
+		}
+		if acked {
+			return fn.Ok[Resp](&AckResp{})
+		}
+
+		// Case 2: the spender is a proof-graph node. That means an
+		// ancestor of our target just confirmed on chain.
 		if _, ok := b.proof.Node(msg.SpendingTxid); ok {
-			return b.handleEvent(ctx, &HeightUpdatedEvent{
+			return b.handleEvent(ctx, &TxConfirmedEvent{
+				Txid:   msg.SpendingTxid,
 				Height: msg.SpendingHeight,
 			})
 		}
 	}
 
-	// Case 2: the spender is our own sweep. Same benign outcome — we
+	// Case 3: the spender is our own sweep. Same benign outcome — we
 	// are watching our own success from a different vantage point.
 	// Compare against the sweep txid recorded in planner state
 	// (SweepBroadcastedEvent populates that) rather than b.sweepTx,
@@ -885,17 +1048,61 @@ func (b *behavior) handleSpendObserved(ctx context.Context,
 		}
 	}
 
-	// Case 3: neither of the above. Someone else spent the target.
+	// Case 4: neither of the above. Someone else spent the watched output.
 	// This happens if the operator cooperatively claimed the VTXO,
 	// if a reorg replaced history, or in fraud scenarios. There is
 	// no way for this unroll to proceed, so terminate with a
 	// reason string that identifies the spender for operator
 	// triage.
-	reason := fmt.Sprintf("target %s spent externally by tx %s at "+
-		"height %d", b.cfg.TargetOutpoint, msg.SpendingTxid,
+	spentOutpoint := b.cfg.TargetOutpoint
+	if msg.Outpoint != (wire.OutPoint{}) {
+		spentOutpoint = msg.Outpoint
+	}
+	reason := fmt.Sprintf("watched outpoint %s spent externally by tx %s "+
+		"at height %d", spentOutpoint, msg.SpendingTxid,
 		msg.SpendingHeight)
 
 	return b.handleEvent(ctx, &FailEvent{Reason: reason})
+}
+
+// ackProofOutputSpend records proof-output spend evidence and reports whether
+// the observation is fully handled. If a proof output is spent by an unknown
+// transaction, the parent proof tx is still confirmed, but the caller must
+// continue into the external-spend failure path.
+func (b *behavior) ackProofOutputSpend(ctx context.Context,
+	msg *SpendObservedMsg) (bool, error) {
+
+	if msg.Outpoint == (wire.OutPoint{}) ||
+		msg.Outpoint == b.cfg.TargetOutpoint {
+		return false, nil
+	}
+
+	if _, ok := b.proof.Node(msg.Outpoint.Hash); !ok {
+		return false, nil
+	}
+
+	err := b.driveEvent(ctx, &TxConfirmedEvent{
+		Txid:   msg.Outpoint.Hash,
+		Height: msg.SpendingHeight,
+	})
+	if err != nil {
+		return false, err
+	}
+
+	if msg.SpendingTxid == msg.Outpoint.Hash {
+		return true, nil
+	}
+
+	if _, ok := b.proof.Node(msg.SpendingTxid); !ok {
+		return false, nil
+	}
+
+	event := &TxConfirmedEvent{
+		Txid:   msg.SpendingTxid,
+		Height: msg.SpendingHeight,
+	}
+
+	return true, b.driveEvent(ctx, event)
 }
 
 // inTerminalState reports whether the FSM has already reached a terminal

--- a/unroll/actor_test.go
+++ b/unroll/actor_test.go
@@ -377,10 +377,14 @@ type fakeChainSourceRef struct {
 	feeRate    int64
 	feeErr     error
 	blockRef   actor.TellOnlyRef[chainsource.BlockEpoch]
-	spendRef   actor.TellOnlyRef[chainsource.SpendEvent]
+	spendRefs  map[wire.OutPoint]spendEventRef
+	spendRegs  []wire.OutPoint
 	confRefs   map[chainhash.Hash]confRef
 	confReqs   map[chainhash.Hash]*confReq
 }
+
+// spendEventRef is the fake chain-source spend notification actor reference.
+type spendEventRef = actor.TellOnlyRef[chainsource.SpendEvent]
 
 // ID returns the fake actor ID.
 func (f *fakeChainSourceRef) ID() string {
@@ -462,7 +466,18 @@ func (f *fakeChainSourceRef) Ask(_ context.Context,
 
 	case *chainsource.RegisterSpendRequest:
 		f.mu.Lock()
-		f.spendRef = msg.NotifyActor.UnwrapOr(nil)
+		if f.spendRefs == nil {
+			f.spendRefs = make(
+				map[wire.OutPoint]spendEventRef,
+			)
+		}
+
+		outpoint := wire.OutPoint{}
+		if msg.Outpoint != nil {
+			outpoint = *msg.Outpoint
+		}
+		f.spendRefs[outpoint] = msg.NotifyActor.UnwrapOr(nil)
+		f.spendRegs = append(f.spendRegs, outpoint)
 		f.mu.Unlock()
 		promise.Complete(
 			fn.Ok[chainsource.ChainSourceResp](
@@ -561,15 +576,15 @@ func (f *fakeChainSourceRef) emitConfirmed(t *testing.T, txid chainhash.Hash,
 	)
 }
 
-// emitSpend delivers one spend event for the target outpoint to the subscribed
-// actor.
-func (f *fakeChainSourceRef) emitSpend(t *testing.T,
-	spendingTxid chainhash.Hash, height int32) {
+// emitSpendForOutpoint delivers one spend event for a specific watched
+// outpoint.
+func (f *fakeChainSourceRef) emitSpendForOutpoint(t *testing.T,
+	outpoint wire.OutPoint, spendingTxid chainhash.Hash, height int32) {
 
 	t.Helper()
 
 	f.mu.Lock()
-	ref := f.spendRef
+	ref := f.spendRefs[outpoint]
 	f.mu.Unlock()
 
 	require.NotNil(t, ref)
@@ -577,11 +592,20 @@ func (f *fakeChainSourceRef) emitSpend(t *testing.T,
 		t,
 		ref.Tell(
 			t.Context(), chainsource.SpendEvent{
+				Outpoint:       outpoint,
 				SpendingTxid:   spendingTxid,
 				SpendingHeight: height,
 			},
 		),
 	)
+}
+
+// spendRegistrations returns a snapshot of registered spend outpoints.
+func (f *fakeChainSourceRef) spendRegistrations() []wire.OutPoint {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return append([]wire.OutPoint(nil), f.spendRegs...)
 }
 
 // fakeSweepWallet is a minimal signer plus wallet-destination test double.
@@ -990,6 +1014,57 @@ func buildLinearProof(t *testing.T) *recovery.Proof {
 		wire.OutPoint{
 			Hash:  targetTx.TxHash(),
 			Index: 0,
+		},
+		2, &recovery.Node{
+			Kind: recovery.NodeKindTree,
+			Tx:   rootTx,
+		}, &recovery.Node{
+			Kind: recovery.NodeKindTree,
+			Tx:   targetTx,
+		},
+	)
+	require.NoError(t, err)
+
+	return proof
+}
+
+// buildSiblingOutputProof creates a root->target proof where the target tx has
+// a sibling output at index zero and the real target at index one.
+func buildSiblingOutputProof(t *testing.T) *recovery.Proof {
+	t.Helper()
+
+	rootTx := wire.NewMsgTx(2)
+	rootTx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{
+			Hash:  chainhash.Hash{1},
+			Index: 0,
+		},
+	})
+	rootTx.AddTxOut(&wire.TxOut{
+		Value:    70_000,
+		PkScript: []byte{txscript.OP_TRUE},
+	})
+
+	targetTx := wire.NewMsgTx(2)
+	targetTx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{
+			Hash:  rootTx.TxHash(),
+			Index: 0,
+		},
+	})
+	targetTx.AddTxOut(&wire.TxOut{
+		Value:    20_000,
+		PkScript: []byte{txscript.OP_TRUE},
+	})
+	targetTx.AddTxOut(&wire.TxOut{
+		Value:    50_000,
+		PkScript: []byte{txscript.OP_TRUE},
+	})
+
+	proof, err := recovery.NewProof(
+		wire.OutPoint{
+			Hash:  targetTx.TxHash(),
+			Index: 1,
 		},
 		2, &recovery.Node{
 			Kind: recovery.NodeKindTree,
@@ -1774,6 +1849,198 @@ func TestManualTriggerSubmitsReadyCheckpointImmediately(t *testing.T) {
 	)
 }
 
+// TestProofSpendObservationAdvancesMaterialization verifies that a spend of a
+// watched proof-node output is enough to mark the spent proof node confirmed.
+// This is important for neutrino-backed clients because the spend watch can
+// fire even if the direct confirmation notification is delayed or missed.
+func TestProofSpendObservationAdvancesMaterialization(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	unrollActor, beh, txconfirmRef, store := newActorHarness(t, proof, desc)
+
+	chainSource, ok := beh.cfg.ChainSource.(*fakeChainSourceRef)
+	require.True(t, ok)
+
+	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
+		Height:  100,
+		Trigger: TriggerManual,
+	})
+	require.Equal(t, 1, txconfirmRef.requestCount())
+
+	rootOutpoint := wire.OutPoint{
+		Hash:  proof.RootTxids()[0],
+		Index: 0,
+	}
+	require.Eventually(t, func() bool {
+		for _, outpoint := range chainSource.spendRegistrations() {
+			if outpoint == rootOutpoint {
+				return true
+			}
+		}
+
+		return false
+	}, testTimeout, 10*time.Millisecond)
+
+	chainSource.emitSpendForOutpoint(
+		t, rootOutpoint, proof.TargetOutpoint().Hash, 101,
+	)
+
+	require.Eventually(t, func() bool {
+		stateResp, ok := mustAsk(
+			t, unrollActor.Ref(), &GetStateRequest{},
+		).(*GetStateResp)
+		require.True(t, ok)
+
+		return stateResp.Phase == PhaseCSVPending
+	}, testTimeout, 10*time.Millisecond)
+
+	checkpoint := mustDecodeCheckpoint(t, store, "unroll-test")
+	require.Contains(
+		t, checkpoint.State.ConfirmedTxids, proof.RootTxids()[0],
+	)
+	require.Contains(
+		t, checkpoint.State.ConfirmedTxids, proof.TargetOutpoint().Hash,
+	)
+}
+
+// TestLegacyProofSpendObservationAdvancesKnownSpender verifies the
+// backwards-compatible spend message path. Older durable mailboxes may replay
+// SpendObservedMsg without the spent outpoint, so the actor still treats a
+// known proof-node spender as confirmation evidence for that proof node.
+func TestLegacyProofSpendObservationAdvancesKnownSpender(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	unrollActor, _, txconfirmRef, store := newActorHarness(t, proof, desc)
+
+	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
+		Height:  100,
+		Trigger: TriggerManual,
+	})
+	txconfirmRef.emitConfirmed(t, 0, proof.RootTxids()[0], 101)
+	require.Eventually(t, func() bool {
+		return txconfirmRef.requestCountForTxid(
+			proof.TargetOutpoint().Hash,
+		) == 1
+	}, testTimeout, 10*time.Millisecond)
+
+	mustAsk(t, unrollActor.Ref(), &SpendObservedMsg{
+		SpendingTxid:   proof.TargetOutpoint().Hash,
+		SpendingHeight: 102,
+	})
+
+	require.Eventually(t, func() bool {
+		stateResp, ok := mustAsk(
+			t, unrollActor.Ref(), &GetStateRequest{},
+		).(*GetStateResp)
+		require.True(t, ok)
+
+		return stateResp.Phase == PhaseCSVPending
+	}, testTimeout, 10*time.Millisecond)
+
+	checkpoint := mustDecodeCheckpoint(t, store, "unroll-test")
+	require.Contains(
+		t, checkpoint.State.ConfirmedTxids, proof.TargetOutpoint().Hash,
+	)
+}
+
+// TestProofSpendWatchesSkipTargetSiblings verifies the proof-spend fallback
+// only watches outputs that are consumed by in-proof child nodes. An OOR tx can
+// create a sibling output next to the target, and that sibling may be spent by
+// another local or remote owner without affecting this target's unroll.
+func TestProofSpendWatchesSkipTargetSiblings(t *testing.T) {
+	proof := buildSiblingOutputProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	unrollActor, beh, txconfirmRef, _ := newActorHarness(t, proof, desc)
+
+	chainSource, ok := beh.cfg.ChainSource.(*fakeChainSourceRef)
+	require.True(t, ok)
+
+	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
+		Height:  100,
+		Trigger: TriggerManual,
+	})
+
+	rootTxid := proof.RootTxids()[0]
+	rootOutpoint := wire.OutPoint{
+		Hash:  rootTxid,
+		Index: 0,
+	}
+	require.Eventually(t, func() bool {
+		for _, outpoint := range chainSource.spendRegistrations() {
+			if outpoint == rootOutpoint {
+				return true
+			}
+		}
+
+		return false
+	}, testTimeout, 10*time.Millisecond)
+
+	txconfirmRef.emitConfirmed(t, 0, rootTxid, 101)
+	require.Eventually(t, func() bool {
+		return txconfirmRef.requestCountForTxid(
+			proof.TargetOutpoint().Hash,
+		) == 1
+	}, testTimeout, 10*time.Millisecond)
+
+	targetSibling := wire.OutPoint{
+		Hash:  proof.TargetOutpoint().Hash,
+		Index: 0,
+	}
+	for _, outpoint := range chainSource.spendRegistrations() {
+		require.NotEqual(t, targetSibling, outpoint)
+	}
+}
+
+// TestExternalProofSpendTerminatesActor verifies that an unknown spend of a
+// watched proof-node output fails the unroll job instead of being swallowed as
+// benign materialization progress.
+func TestExternalProofSpendTerminatesActor(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	unrollActor, beh, _, _ := newActorHarness(t, proof, desc)
+
+	chainSource, ok := beh.cfg.ChainSource.(*fakeChainSourceRef)
+	require.True(t, ok)
+
+	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
+		Height:  100,
+		Trigger: TriggerManual,
+	})
+
+	rootOutpoint := wire.OutPoint{
+		Hash:  proof.RootTxids()[0],
+		Index: 0,
+	}
+	require.Eventually(t, func() bool {
+		for _, outpoint := range chainSource.spendRegistrations() {
+			if outpoint == rootOutpoint {
+				return true
+			}
+		}
+
+		return false
+	}, testTimeout, 10*time.Millisecond)
+
+	externalTxid := chainhash.Hash{0xee}
+	chainSource.emitSpendForOutpoint(t, rootOutpoint, externalTxid, 101)
+
+	require.Eventually(t, func() bool {
+		stateResp, ok := mustAsk(
+			t, unrollActor.Ref(), &GetStateRequest{},
+		).(*GetStateResp)
+		require.True(t, ok)
+
+		return stateResp.Phase == PhaseFailed
+	}, testTimeout, 10*time.Millisecond)
+
+	stateResp, ok := mustAsk(
+		t, unrollActor.Ref(), &GetStateRequest{},
+	).(*GetStateResp)
+	require.True(t, ok)
+	require.Contains(t, stateResp.FailReason, rootOutpoint.String())
+	require.Contains(t, stateResp.FailReason, "spent externally")
+}
+
 // TestConfirmedNodesAdvanceToSweep verifies that node confirmations move the
 // actor from proof materialization into final sweep submission.
 func TestConfirmedNodesAdvanceToSweep(t *testing.T) {
@@ -2529,15 +2796,20 @@ func TestExternalSpendTerminatesActor(t *testing.T) {
 
 	// Ensure spend watch is registered.
 	require.Eventually(t, func() bool {
-		chainSource.mu.Lock()
-		defer chainSource.mu.Unlock()
+		for _, outpoint := range chainSource.spendRegistrations() {
+			if outpoint == proof.TargetOutpoint() {
+				return true
+			}
+		}
 
-		return chainSource.spendRef != nil
+		return false
 	}, testTimeout, 10*time.Millisecond)
 
 	// Simulate an external party spending the target VTXO.
 	externalTxid := chainhash.Hash{0xee}
-	chainSource.emitSpend(t, externalTxid, 101)
+	chainSource.emitSpendForOutpoint(
+		t, proof.TargetOutpoint(), externalTxid, 101,
+	)
 
 	require.Eventually(t, func() bool {
 		stateResp, ok := mustAsk(

--- a/unroll/messages.go
+++ b/unroll/messages.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
 	"github.com/lightninglabs/darepo-client/unrollplan"
 	"github.com/lightningnetwork/lnd/tlv"
@@ -69,8 +70,10 @@ const (
 	txFailedTxidRecType   tlv.Type = 1
 	txFailedReasonRecType tlv.Type = 3
 
-	spendObservedTxidRecType   tlv.Type = 1
-	spendObservedHeightRecType tlv.Type = 3
+	spendObservedTxidRecType     tlv.Type = 1
+	spendObservedHeightRecType   tlv.Type = 3
+	spendObservedOutHashRecType  tlv.Type = 5
+	spendObservedOutIndexRecType tlv.Type = 7
 )
 
 // StartTrigger identifies what caused the unroll actor to start.
@@ -469,11 +472,14 @@ func (m *TxFailedMsg) Decode(r io.Reader) error {
 // unrollMsgSealed seals TxFailedMsg into the message surface.
 func (m *TxFailedMsg) unrollMsgSealed() {}
 
-// SpendObservedMsg reports that the target outpoint was spent on-chain.
+// SpendObservedMsg reports that a watched outpoint was spent on-chain.
 type SpendObservedMsg struct {
 	actor.BaseMessage
 
-	// SpendingTxid is the transaction that spent the target.
+	// Outpoint is the watched output that was spent.
+	Outpoint wire.OutPoint
+
+	// SpendingTxid is the transaction that spent the watched outpoint.
 	SpendingTxid chainhash.Hash
 
 	// SpendingHeight is the block height of the spending transaction.
@@ -499,10 +505,16 @@ func (m *SpendObservedMsg) Priority() int {
 func (m *SpendObservedMsg) Encode(w io.Writer) error {
 	txid := [32]byte(m.SpendingTxid)
 	height := uint32(m.SpendingHeight)
+	outHash := [32]byte(m.Outpoint.Hash)
+	outIndex := m.Outpoint.Index
 
 	stream, err := tlv.NewStream(
 		tlv.MakePrimitiveRecord(spendObservedTxidRecType, &txid),
 		tlv.MakePrimitiveRecord(spendObservedHeightRecType, &height),
+		tlv.MakePrimitiveRecord(spendObservedOutHashRecType, &outHash),
+		tlv.MakePrimitiveRecord(
+			spendObservedOutIndexRecType, &outIndex,
+		),
 	)
 	if err != nil {
 		return fmt.Errorf("create stream: %w", err)
@@ -514,13 +526,19 @@ func (m *SpendObservedMsg) Encode(w io.Writer) error {
 // Decode deserializes the message from a TLV stream.
 func (m *SpendObservedMsg) Decode(r io.Reader) error {
 	var (
-		txid   [32]byte
-		height uint32
+		txid     [32]byte
+		height   uint32
+		outHash  [32]byte
+		outIndex uint32
 	)
 
 	stream, err := tlv.NewStream(
 		tlv.MakePrimitiveRecord(spendObservedTxidRecType, &txid),
 		tlv.MakePrimitiveRecord(spendObservedHeightRecType, &height),
+		tlv.MakePrimitiveRecord(spendObservedOutHashRecType, &outHash),
+		tlv.MakePrimitiveRecord(
+			spendObservedOutIndexRecType, &outIndex,
+		),
 	)
 	if err != nil {
 		return fmt.Errorf("create stream: %w", err)
@@ -532,6 +550,10 @@ func (m *SpendObservedMsg) Decode(r io.Reader) error {
 
 	m.SpendingTxid = chainhash.Hash(txid)
 	m.SpendingHeight = int32(height)
+	m.Outpoint = wire.OutPoint{
+		Hash:  chainhash.Hash(outHash),
+		Index: outIndex,
+	}
 
 	return nil
 }

--- a/unroll/messages_test.go
+++ b/unroll/messages_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/stretchr/testify/require"
 )
 
@@ -102,6 +103,12 @@ func TestDurableMessageTLVRoundTrip(t *testing.T) {
 		t.Parallel()
 
 		orig := &SpendObservedMsg{
+			Outpoint: wire.OutPoint{
+				Hash: chainhash.Hash{
+					0xcd,
+				},
+				Index: 9,
+			},
 			SpendingTxid:   txid,
 			SpendingHeight: 777,
 		}
@@ -111,6 +118,7 @@ func TestDurableMessageTLVRoundTrip(t *testing.T) {
 
 		got := &SpendObservedMsg{}
 		require.NoError(t, got.Decode(bytes.NewReader(buf.Bytes())))
+		require.Equal(t, orig.Outpoint, got.Outpoint)
 		require.Equal(t, orig.SpendingTxid, got.SpendingTxid)
 		require.Equal(t, orig.SpendingHeight, got.SpendingHeight)
 	})


### PR DESCRIPTION
## Summary

This PR makes unilateral unroll progress reliable for neutrino-backed clients when the direct confirmation callback for a proof transaction is delayed or missed. It also fixes a harness cleanup isolation bug exposed by the parent repo's daemon itest move to `parallel=4`.

The unroll actor already watched the target outpoint as a safety net. This extends that idea to in-flight proof-node outputs: when the actor asks txconfirm to materialize a proof node, it also registers spend watches for the proof-node outputs that are actually consumed by later in-proof child transactions. If a later proof transaction spends one of those outputs, the spend itself proves the parent proof transaction confirmed, so the unroll FSM can record the parent confirmation and continue into CSV wait.

The watch set is intentionally derived from the proof graph rather than assuming output zero. Multi-input OOR can create sibling outputs next to the target VTXO, and those siblings may be spent by another owner. Watching only the child-consumed proof outpoints keeps the neutrino fallback while avoiding false external-spend failures for unrelated sibling outputs.

## Why

The btcwallet/neutrino `TestOORIntegrationMultiInputTransfer` path could get stuck in `UNROLL_JOB_STATUS_MATERIALIZING`. The chain had enough information to show the proof path was progressing, but the actor was waiting only on txconfirm's direct confirmation callback for the parent proof transaction.

CI also exposed a sharper multi-input case: the target VTXO can live at output index 1 while output index 0 belongs to a sibling. A naive `txid:0` proof-output watch makes the sibling spend look like an external spend for the target unroll job. This PR fixes both pieces by using proof-output spend observations as progress evidence, while deriving the watched outpoints from actual child transaction inputs.

While validating the parent repo's daemon itests at `parallel=4`, CI also exposed a harness issue in stale Docker cleanup. Docker name filters are substring filters, so cleanup for `bitcoin-TestBoardingIntegrationSingleClient` could match and remove `bitcoin-TestBoardingIntegrationSingleClientSubsequentRounds`. The harness now exact-matches the names returned by Docker before removing a supposedly stale container.

## Changes

- Record the watched outpoint in `SpendObservedMsg` so the actor can distinguish target spends from proof-output spends.
- Register proof-output spend watches for proof nodes submitted through txconfirm.
- Derive proof-output watches from in-proof child transaction inputs instead of assuming output zero.
- Treat a proof-output spend by a later proof node as confirmation of the proof transaction that created the spent output.
- Preserve safety for unknown spends: if a proof output is spent by a tx outside the proof graph, the parent proof tx is marked confirmed but the unroll still fails as externally spent.
- Add unit coverage for proof-output spend observation advancing materialization, unknown proof-output spends terminating the job, and sibling outputs being ignored when they are not part of this target's proof path.
- Exact-match Docker container names before harness stale-container cleanup removes anything.
- Add harness unit coverage for exact container-name matching, including sibling test names where one is a prefix of another.

## Validation

- `make fmt-changed-check`
- `go test ./unroll`
- `go test ./harness`
- `make lint-native`
- `make commitmsg-lint commit=HEAD`
- Parent repo targeted btcwallet/neutrino smoke:
  `make itest backend=btcwallet shard=oor-sends icase='^TestOORIntegrationMultiInputTransfer$' parallel=1`
- Parent repo targeted lnd smoke:
  `make itest backend=lnd shard=oor-sends icase='^TestOORIntegrationMultiInputTransfer$' parallel=1`
- Parent repo GitHub CI run `25879725400` passed with daemon itest shards at `parallel=4`.

The parent btcwallet/neutrino smoke passed locally in 263.66s with the client submodule bump included. The parent lnd smoke passed locally in 128.72s.
