### PR TITLE
multi: per-correlation-key FIFO claim ordering for durable mailbox

### DIFF
--- a/baselib/actor/CLAUDE.md
+++ b/baselib/actor/CLAUDE.md
@@ -38,6 +38,20 @@ crash-safe at-least-once delivery with exactly-once deduplication.
 - `ChannelMailbox[M, R]` — In-memory channel-based mailbox (non-durable, for lightweight actors).
 - `Mailbox[M, R]` — Interface for actor message queues: `Send(ctx, env) error` (blocking, returns `ErrMailboxClosed` or `ErrActorTerminated` on failure), `TrySend(env) error` (non-blocking), `Receive(ctx) iter.Seq[envelope]`, `Close()`, `IsClosed() bool`, `Drain() iter.Seq[envelope]`. `Send` previously returned `bool`; it now propagates the exact failure cause so callers can distinguish `ErrMailboxClosed`, `ErrActorTerminated`, and `context.Canceled`/`context.DeadlineExceeded` without inspecting actor state.
 - `isExpectedShutdownErr(err) bool` — Internal helper that classifies errors as expected during teardown: context cancellation/deadline, closed DB handle ("sql: database is closed", "sql: connection is already closed", "use of closed network connection"). Used by the lease loop to demote shutdown-path failures to debug instead of warn-flooding test artifacts at itest tail.
+- `Message.CorrelationKey() string` — Per-message FIFO key consumed by the
+  durable mailbox's claim path. Non-empty keys participate in per-key FIFO:
+  a message is claim-eligible only when no earlier same-key message
+  (compared by UUIDv7 `id`) exists in the same mailbox, even if the
+  earlier message is in retry backoff. Empty (the default on
+  `BaseMessage`) means the message is unkeyed and uses the existing
+  global `available_at` claim order. The override site is the concrete
+  message struct (e.g. `clientconn.ClientMessage` types in `rounds`),
+  not the framework — the framework just plumbs the value through
+  `EnqueueParams.CorrelationKey`.
+- `EnqueueParams.CorrelationKey` — Per-enqueue override stamped into the
+  `mailbox_messages.correlation_key` column. Populated automatically from
+  `msg.CorrelationKey()` by `DurableMailbox.Send`. A zero (empty) value
+  preserves the legacy unkeyed claim semantics.
 
 ## Relationships
 
@@ -54,6 +68,20 @@ crash-safe at-least-once delivery with exactly-once deduplication.
 - Transaction context (`WithTx`/`RequireTx`) enables same-DB-transaction joining between actors and their callers.
 - `Mailbox.Send` returns the exact failure error (`ErrMailboxClosed`, `ErrActorTerminated`, `context.Canceled`, `context.DeadlineExceeded`) rather than a boolean; `Tell` and `Ask` propagate this directly to callers.
 - During daemon teardown, the underlying DB is closed before every actor's lease loop has wound down. The lease loop uses `isExpectedShutdownErr` to demote these "database is closed" errors to debug level; real operational errors still surface as warnings because neither the actor context nor the outer context is done in those cases.
+- **Per-correlation-key FIFO claim.** Two messages in the same mailbox that
+  share a non-empty `CorrelationKey()` are processed in emission order
+  regardless of retry backoff. Without this invariant, a transient Tell
+  failure on msg1 would Nack-with-backoff (push `available_at` into the
+  future), and a later-enqueued msg2 with a smaller `available_at` would
+  overtake msg1 in the `LeaseNextMailboxMessage` claim. The fix is an
+  anti-join on `mailbox_messages.id` (UUIDv7, strictly orderable at
+  millisecond granularity) so the head of each correlation key drains
+  before any later same-key row is claim-eligible. Unkeyed messages
+  (empty `CorrelationKey()`) keep the legacy global `available_at`
+  order and do not interfere with keyed lanes. Head-of-line blocking
+  is bounded to the correlation key, not the mailbox; consumers are
+  already strictly serial per mailbox so this does not regress
+  throughput.
 
 ## Deep Docs
 

--- a/baselib/actor/delivery_store.go
+++ b/baselib/actor/delivery_store.go
@@ -163,6 +163,14 @@ type EnqueueParams struct {
 
 	// MaxAttempts is the maximum delivery attempts before dead-lettering.
 	MaxAttempts int
+
+	// CorrelationKey is an optional per-message tag that participates in
+	// the durable mailbox's per-key FIFO claim ordering. Non-empty keys
+	// cause the claim path to refuse to return a message when an
+	// earlier-enqueued same-key message is still in the queue, even if
+	// the earlier message is in retry backoff. Empty means the message
+	// is unkeyed and uses the existing global available_at order.
+	CorrelationKey string
 }
 
 // LeasedMessage represents a message claimed from the mailbox.

--- a/baselib/actor/durable_mailbox.go
+++ b/baselib/actor/durable_mailbox.go
@@ -211,7 +211,10 @@ func (m *DurableMailbox[M, R]) Send(ctx context.Context,
 		priority = pm.Priority()
 	}
 
-	// Enqueue the message.
+	// Enqueue the message. CorrelationKey opts the message into the
+	// per-key FIFO claim lane in the durable mailbox; an empty key (the
+	// default on BaseMessage) means the message uses the existing global
+	// available_at order, unaffected by keyed lanes.
 	params := EnqueueParams{
 		ID:              id,
 		MailboxID:       m.cfg.MailboxID,
@@ -223,6 +226,7 @@ func (m *DurableMailbox[M, R]) Send(ctx context.Context,
 		Priority:        priority,
 		AvailableAt:     m.clock.Now(),
 		MaxAttempts:     m.cfg.MaxAttempts,
+		CorrelationKey:  env.message.CorrelationKey(),
 	}
 
 	// Allow the sender's transaction (if any) to flow through so

--- a/baselib/actor/interface.go
+++ b/baselib/actor/interface.go
@@ -20,11 +20,23 @@ var ErrServiceKeyTypeMismatch = fmt.Errorf("service key type mismatch")
 // BaseMessage is a helper struct that can be embedded in message types defined
 // outside the actor package to satisfy the Message interface's unexported
 // messageMarker method.
+//
+// BaseMessage also provides a default CorrelationKey of "" (unkeyed). Messages
+// that need to participate in a per-key FIFO lane in a durable mailbox
+// override this by defining their own CorrelationKey method on the embedding
+// struct.
 type BaseMessage struct{}
 
 // messageMarker implements the unexported method for the Message interface,
 // allowing types that embed BaseMessage to satisfy the Message interface.
 func (BaseMessage) messageMarker() {}
+
+// CorrelationKey returns the empty string by default, which means the message
+// is unkeyed and participates in the durable mailbox's global available_at
+// claim order. Concrete message types that need per-key FIFO claim ordering
+// override this method to return a non-empty key. See the durable mailbox
+// claim semantics for the full contract.
+func (BaseMessage) CorrelationKey() string { return "" }
 
 // Message is a sealed interface for actor messages. Actors will receive
 // messages conforming to this interface. The interface is "sealed" by the
@@ -39,6 +51,16 @@ type Message interface {
 	// MessageType returns the type name of the message for
 	// routing/filtering.
 	MessageType() string
+
+	// CorrelationKey returns a non-empty string when this message
+	// participates in a per-key FIFO lane in a durable mailbox. The
+	// durable mailbox claim SQL never returns a keyed message if an
+	// earlier same-key message is still in the queue, even if the
+	// earlier message is in retry backoff. An empty string means the
+	// message is unkeyed and uses the existing global available_at
+	// claim order. The default implementation on BaseMessage returns
+	// the empty string.
+	CorrelationKey() string
 }
 
 // PriorityMessage is an extension of the Message interface for messages that

--- a/db/actordelivery/correlation_key_test.go
+++ b/db/actordelivery/correlation_key_test.go
@@ -1,0 +1,454 @@
+package actordelivery
+
+import (
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/db/sqlc"
+	"github.com/lightningnetwork/lnd/clock"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestStore opens a fresh in-memory SQLite-backed delivery store with a
+// caller-supplied test clock so reorder behaviour can be exercised
+// deterministically. Returns the store and the same clock so the caller
+// can advance time between operations.
+func newTestStore(t *testing.T) (actor.TxAwareDeliveryStore, *clock.TestClock) {
+	t.Helper()
+
+	rawDB := newSQLiteDB(t)
+	require.NoError(t, RunMigrations(rawDB, sqlc.BackendTypeSqlite))
+
+	t0 := time.Unix(1_700_000_000, 0)
+	clk := clock.NewTestClock(t0)
+
+	store, err := NewTxAwareDeliveryStoreFromDB(
+		rawDB, sqlc.BackendTypeSqlite, clk, btclog.Disabled,
+	)
+	require.NoError(t, err)
+
+	return store, clk
+}
+
+// enqueue is a tiny wrapper that stamps the test clock's current time as
+// the message's available_at so messages are immediately claim-eligible
+// unless a correlation-key invariant says otherwise.
+func enqueue(t *testing.T, store actor.TxAwareDeliveryStore,
+	clk *clock.TestClock, id, mailbox, key string) {
+
+	t.Helper()
+
+	require.NoError(
+		t,
+		store.EnqueueMessage(
+			t.Context(), actor.EnqueueParams{
+				ID:             id,
+				MailboxID:      mailbox,
+				MessageType:    "test.Msg",
+				Payload:        []byte(id),
+				Priority:       0,
+				AvailableAt:    clk.Now(),
+				MaxAttempts:    3,
+				CorrelationKey: key,
+			},
+		),
+	)
+}
+
+// TestPerKeyFIFOBlocksOvertakeOnNack is the canonical reproduction of the
+// reorder bug the migration fixes. It enqueues two keyed messages, nacks
+// the first with a delay that pushes its available_at into the future,
+// and verifies the second message is NOT returned by the claim path even
+// though its available_at is smaller — the anti-join keeps strict FIFO
+// per key.
+func TestPerKeyFIFOBlocksOvertakeOnNack(t *testing.T) {
+	t.Parallel()
+
+	store, clk := newTestStore(t)
+	ctx := t.Context()
+
+	const mailbox = "actor-A"
+	const key = "alice/round-1"
+
+	// msg1 enqueued at T=0, immediately eligible.
+	enqueue(t, store, clk, "msg-1", mailbox, key)
+
+	// Lease msg1, simulate transient send failure: nack with a long delay
+	// so msg1's available_at is now strictly in the future.
+	leased, err := store.LeaseNextMessage(
+		ctx, mailbox, "lease-1", time.Minute,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, leased)
+	require.Equal(t, "msg-1", leased.ID)
+
+	rows, err := store.NackMessage(ctx, "msg-1", "lease-1", 5*time.Second)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, rows)
+
+	// Advance to T+1s and enqueue msg2 (same key). Its available_at is
+	// now smaller than msg1's pushed-out available_at — under the old
+	// ORDER BY available_at ASC rule the claim would return msg2.
+	clk.SetTime(clk.Now().Add(1 * time.Second))
+	enqueue(t, store, clk, "msg-2", mailbox, key)
+
+	// Claim at T+1s. msg1 is still in backoff (available_at=T+5s),
+	// msg2 has available_at=T+1s. With per-key FIFO, msg2 cannot
+	// overtake msg1 — the claim must return nothing.
+	leased2, err := store.LeaseNextMessage(
+		ctx, mailbox, "lease-2", time.Minute,
+	)
+	require.NoError(t, err)
+	require.Nil(
+		t, leased2,
+		"per-key FIFO must hold msg-2 behind in-backoff msg-1",
+	)
+
+	// Advance to T+5s. msg1 is now available; claim must return msg1
+	// first.
+	clk.SetTime(clk.Now().Add(4 * time.Second))
+	leased3, err := store.LeaseNextMessage(
+		ctx, mailbox, "lease-3", time.Minute,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, leased3)
+	require.Equal(
+		t, "msg-1", leased3.ID,
+		"head-of-key must drain before any later same-key message",
+	)
+
+	// Ack msg1; now msg2 becomes the head of the key and is claimable.
+	ackRows, err := store.AckMessage(ctx, "msg-1", "lease-3")
+	require.NoError(t, err)
+	require.EqualValues(t, 1, ackRows)
+
+	leased4, err := store.LeaseNextMessage(
+		ctx, mailbox, "lease-4", time.Minute,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, leased4)
+	require.Equal(t, "msg-2", leased4.ID)
+}
+
+// TestPerKeyFIFOCrossKeyIndependence confirms that a message in backoff
+// for key K1 does not block a different keyed message K2 in the same
+// mailbox. Each key is its own FIFO lane.
+func TestPerKeyFIFOCrossKeyIndependence(t *testing.T) {
+	t.Parallel()
+
+	store, clk := newTestStore(t)
+	ctx := t.Context()
+
+	const mailbox = "actor-A"
+
+	// K1 message that we'll force into backoff.
+	enqueue(t, store, clk, "k1-msg-1", mailbox, "alice/round-1")
+	leased, err := store.LeaseNextMessage(
+		ctx, mailbox, "lease-1", time.Minute,
+	)
+	require.NoError(t, err)
+	require.Equal(t, "k1-msg-1", leased.ID)
+	_, err = store.NackMessage(ctx, "k1-msg-1", "lease-1", 10*time.Second)
+	require.NoError(t, err)
+
+	// K2 message enqueued while K1 is in backoff.
+	clk.SetTime(clk.Now().Add(1 * time.Second))
+	enqueue(t, store, clk, "k2-msg-1", mailbox, "bob/round-2")
+
+	// K2 must be claimable independently of K1's backoff.
+	leased2, err := store.LeaseNextMessage(
+		ctx, mailbox, "lease-2", time.Minute,
+	)
+	require.NoError(t, err)
+	require.NotNil(
+		t, leased2,
+		"different correlation keys must not block each other",
+	)
+	require.Equal(t, "k2-msg-1", leased2.ID)
+}
+
+// TestPerKeyFIFOUnkeyedUnaffected confirms that unkeyed messages (empty
+// correlation key) still follow the global available_at order and are
+// not blocked by, nor block, keyed messages.
+func TestPerKeyFIFOUnkeyedUnaffected(t *testing.T) {
+	t.Parallel()
+
+	store, clk := newTestStore(t)
+	ctx := t.Context()
+
+	const mailbox = "actor-A"
+
+	// Keyed msg in backoff.
+	enqueue(t, store, clk, "k-msg-1", mailbox, "alice/round-1")
+	leased, err := store.LeaseNextMessage(
+		ctx, mailbox, "lease-1", time.Minute,
+	)
+	require.NoError(t, err)
+	require.Equal(t, "k-msg-1", leased.ID)
+	_, err = store.NackMessage(ctx, "k-msg-1", "lease-1", 10*time.Second)
+	require.NoError(t, err)
+
+	// Unkeyed msg enqueued while keyed msg is in backoff.
+	clk.SetTime(clk.Now().Add(1 * time.Second))
+	enqueue(t, store, clk, "unkeyed-1", mailbox, "")
+
+	// Unkeyed message uses global available_at order, unaffected by the
+	// keyed lane.
+	leased2, err := store.LeaseNextMessage(
+		ctx, mailbox, "lease-2", time.Minute,
+	)
+	require.NoError(t, err)
+	require.NotNil(
+		t, leased2,
+		"unkeyed message must not be blocked by an unrelated key",
+	)
+	require.Equal(t, "unkeyed-1", leased2.ID)
+}
+
+// TestPerKeyFIFOAckUnblocksKey confirms that once the head-of-line
+// message for a key is acked (the normal happy path), the next same-key
+// message becomes claimable immediately.
+func TestPerKeyFIFOAckUnblocksKey(t *testing.T) {
+	t.Parallel()
+
+	store, clk := newTestStore(t)
+	ctx := t.Context()
+
+	const mailbox = "actor-A"
+	const key = "alice/round-1"
+
+	enqueue(t, store, clk, "msg-1", mailbox, key)
+	clk.SetTime(clk.Now().Add(1 * time.Second))
+	enqueue(t, store, clk, "msg-2", mailbox, key)
+
+	// First claim returns msg-1.
+	leased, err := store.LeaseNextMessage(
+		ctx, mailbox, "lease-1", time.Minute,
+	)
+	require.NoError(t, err)
+	require.Equal(t, "msg-1", leased.ID)
+
+	// While msg-1 is leased, msg-2 must NOT be claimable because
+	// msg-1 is still head of the key.
+	leased2, err := store.LeaseNextMessage(
+		ctx, mailbox, "lease-2", time.Minute,
+	)
+	require.NoError(t, err)
+	require.Nil(
+		t, leased2,
+		"msg-2 must wait while msg-1 holds the head of the key",
+	)
+
+	// Ack msg-1; the key is now drained, msg-2 becomes head.
+	_, err = store.AckMessage(ctx, "msg-1", "lease-1")
+	require.NoError(t, err)
+
+	leased3, err := store.LeaseNextMessage(
+		ctx, mailbox, "lease-3", time.Minute,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, leased3)
+	require.Equal(t, "msg-2", leased3.ID)
+}
+
+// enqueueWithMaxAttempts is a variant of enqueue that lets the caller
+// pick a max_attempts budget. Useful for exercising the
+// attempts-exhausted predecessor path without sitting through the full
+// default retry budget.
+func enqueueWithMaxAttempts(t *testing.T, store actor.TxAwareDeliveryStore,
+	clk *clock.TestClock, id, mailbox, key string, maxAttempts int) {
+
+	t.Helper()
+
+	require.NoError(
+		t,
+		store.EnqueueMessage(
+			t.Context(), actor.EnqueueParams{
+				ID:             id,
+				MailboxID:      mailbox,
+				MessageType:    "test.Msg",
+				Payload:        []byte(id),
+				Priority:       0,
+				AvailableAt:    clk.Now(),
+				MaxAttempts:    maxAttempts,
+				CorrelationKey: key,
+			},
+		),
+	)
+}
+
+// TestPerKeyFIFOExhaustedPredecessorDoesNotBlockSuccessor closes a
+// failure mode that the original anti-join left open: a same-key row
+// whose attempts have hit max_attempts but which has not yet been
+// physically deleted (e.g. a crash window between
+// MoveMailboxToDeadLetter and DeleteMailboxMessage in
+// handlePoisonMessage) used to permanently stall every later same-key
+// message via the anti-join. The fix requires the anti-join predicate
+// to match the outer eligibility predicate (m2.attempts <
+// m2.max_attempts) so exhausted rows are skipped over rather than
+// treated as live heads-of-line.
+func TestPerKeyFIFOExhaustedPredecessorDoesNotBlockSuccessor(t *testing.T) {
+	t.Parallel()
+
+	store, clk := newTestStore(t)
+	ctx := t.Context()
+
+	const mailbox = "actor-A"
+	const key = "alice/round-1"
+
+	// Drive msg-1 to attempts == max_attempts without deleting it. Two
+	// lease/nack cycles exhaust a budget of 2: each lease bumps attempts
+	// by one before the body runs, so after the second nack the row's
+	// attempts equal max_attempts and the outer SELECT will refuse to
+	// re-lease it.
+	enqueueWithMaxAttempts(t, store, clk, "msg-1", mailbox, key, 2)
+
+	leased1, err := store.LeaseNextMessage(
+		ctx, mailbox, "lease-1", time.Minute,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, leased1)
+	require.Equal(t, "msg-1", leased1.ID)
+	_, err = store.NackMessage(ctx, "msg-1", "lease-1", 1*time.Second)
+	require.NoError(t, err)
+
+	clk.SetTime(clk.Now().Add(2 * time.Second))
+
+	leased2, err := store.LeaseNextMessage(
+		ctx, mailbox, "lease-2", time.Minute,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, leased2)
+	require.Equal(t, "msg-1", leased2.ID)
+	_, err = store.NackMessage(ctx, "msg-1", "lease-2", 1*time.Second)
+	require.NoError(t, err)
+
+	clk.SetTime(clk.Now().Add(2 * time.Second))
+
+	// Sanity check: msg-1 is exhausted (attempts == max_attempts) and the
+	// outer eligibility predicate keeps it out of the candidate set, so
+	// claiming it as the head-of-key returns nothing.
+	exhausted, err := store.LeaseNextMessage(
+		ctx, mailbox, "lease-sanity", time.Minute,
+	)
+	require.NoError(t, err)
+	require.Nil(
+		t, exhausted, "exhausted predecessor must not be claimable",
+	)
+
+	// Enqueue msg-2 with the same key. msg-1 is still physically present
+	// in the table (it has not been moved to dead letters or deleted).
+	// Before the fix, the anti-join would still see msg-1 as an earlier
+	// same-key row and refuse to surface msg-2 — head-of-line blocking
+	// would be permanent. After the fix, the anti-join filters out
+	// exhausted rows and msg-2 becomes the new head of the key.
+	enqueueWithMaxAttempts(t, store, clk, "msg-2", mailbox, key, 3)
+
+	leased3, err := store.LeaseNextMessage(
+		ctx, mailbox, "lease-3", time.Minute,
+	)
+	require.NoError(t, err)
+	require.NotNil(
+		t, leased3, "exhausted same-key predecessor must not "+
+			"permanently block successor",
+	)
+	require.Equal(t, "msg-2", leased3.ID)
+}
+
+// TestPerKeyFIFOActiveLeasedPredecessorBlocksSuccessor pins the invariant
+// that an actively leased same-key predecessor (lease_until in the future,
+// retry budget remaining) blocks any later same-key message even though
+// the predecessor isn't in backoff. The anti-join deliberately does NOT
+// filter on lease_until: a row currently being processed by another
+// worker is a live head-of-line and successors must wait. The original
+// reorder fix only exercised the nack-backoff branch; this test pins the
+// actively-leased branch so a future loosening of the anti-join (e.g.
+// adding `AND m2.lease_until IS NULL OR m2.lease_until < now`) would
+// surface as a test failure rather than a silent regression.
+func TestPerKeyFIFOActiveLeasedPredecessorBlocksSuccessor(t *testing.T) {
+	t.Parallel()
+
+	store, clk := newTestStore(t)
+	ctx := t.Context()
+
+	const mailbox = "actor-A"
+	const key = "alice/round-1"
+
+	// Lease msg-1 and hold the lease (do not ack, do not nack). The
+	// row's lease_until is now in the future and attempts has been
+	// incremented, modelling a worker that is actively processing the
+	// message.
+	enqueue(t, store, clk, "msg-1", mailbox, key)
+
+	leased, err := store.LeaseNextMessage(
+		ctx, mailbox, "lease-1", time.Minute,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, leased)
+	require.Equal(t, "msg-1", leased.ID)
+
+	// Enqueue msg-2 for the same key while msg-1's lease is still
+	// live. msg-2 is fully eligible by itself (available_at = now,
+	// attempts = 0), but the anti-join must keep it behind msg-1.
+	clk.SetTime(clk.Now().Add(100 * time.Millisecond))
+	enqueue(t, store, clk, "msg-2", mailbox, key)
+
+	leased2, err := store.LeaseNextMessage(
+		ctx, mailbox, "lease-2", time.Minute,
+	)
+	require.NoError(t, err)
+	require.Nil(
+		t, leased2,
+		"actively leased same-key predecessor must block successor",
+	)
+
+	// Ack msg-1; msg-2 now becomes the head of the key and is
+	// claimable. This pins the unblock half of the contract: the
+	// head must drain (ack OR exhaust) before successors run.
+	ackRows, err := store.AckMessage(ctx, "msg-1", "lease-1")
+	require.NoError(t, err)
+	require.EqualValues(t, 1, ackRows)
+
+	leased3, err := store.LeaseNextMessage(
+		ctx, mailbox, "lease-3", time.Minute,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, leased3)
+	require.Equal(t, "msg-2", leased3.ID)
+}
+
+// TestPerKeyFIFOMailboxIsolation confirms that the per-key FIFO scope is
+// per-mailbox: the same key in two different mailboxes does not create
+// cross-mailbox head-of-line dependencies.
+func TestPerKeyFIFOMailboxIsolation(t *testing.T) {
+	t.Parallel()
+
+	store, clk := newTestStore(t)
+	ctx := t.Context()
+
+	// Same key in two different mailboxes.
+	enqueue(t, store, clk, "a-msg-1", "mailbox-A", "shared-key")
+	enqueue(t, store, clk, "b-msg-1", "mailbox-B", "shared-key")
+
+	// Force mailbox-A's message into backoff.
+	leasedA, err := store.LeaseNextMessage(
+		ctx, "mailbox-A", "lease-1", time.Minute,
+	)
+	require.NoError(t, err)
+	require.Equal(t, "a-msg-1", leasedA.ID)
+	_, err = store.NackMessage(ctx, "a-msg-1", "lease-1", 10*time.Second)
+	require.NoError(t, err)
+
+	// Mailbox-B's message must be claimable independent of mailbox-A.
+	leasedB, err := store.LeaseNextMessage(
+		ctx, "mailbox-B", "lease-2", time.Minute,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, leasedB)
+	require.Equal(
+		t, "b-msg-1", leasedB.ID,
+		"per-key FIFO must be scoped per mailbox_id",
+	)
+}

--- a/db/actordelivery/durable_actor_reorder_test.go
+++ b/db/actordelivery/durable_actor_reorder_test.go
@@ -1,0 +1,362 @@
+package actordelivery
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/db/sqlc"
+	"github.com/lightningnetwork/lnd/clock"
+	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/tlv"
+	"github.com/stretchr/testify/require"
+)
+
+// keyedTestMsg is a TLVMessage carrying an explicit correlation key. The
+// reorder test enqueues two of these with the same key to exercise the
+// per-key FIFO claim invariant through the full DurableActor +
+// SQLite-backed store stack.
+type keyedTestMsg struct {
+	actor.BaseMessage
+
+	ID  tlv.RecordT[tlv.TlvType1, []byte]
+	Key tlv.RecordT[tlv.TlvType2, []byte]
+}
+
+func newKeyedTestMsg(id, key string) *keyedTestMsg {
+	return &keyedTestMsg{
+		ID:  tlv.NewPrimitiveRecord[tlv.TlvType1, []byte]([]byte(id)),
+		Key: tlv.NewPrimitiveRecord[tlv.TlvType2, []byte]([]byte(key)),
+	}
+}
+
+// MessageType returns the type name used by the durable actor framework
+// for routing/dispatch logging.
+func (m *keyedTestMsg) MessageType() string {
+	return "actordelivery.KeyedTestMsg"
+}
+
+// TLVType returns the codec dispatch id for keyedTestMsg.
+func (m *keyedTestMsg) TLVType() tlv.Type {
+	return 0x4000
+}
+
+// Encode writes the message's two TLV records to w.
+func (m *keyedTestMsg) Encode(w io.Writer) error {
+	stream, err := tlv.NewStream(m.ID.Record(), m.Key.Record())
+	if err != nil {
+		return err
+	}
+
+	return stream.Encode(w)
+}
+
+// Decode reads the message back from r.
+func (m *keyedTestMsg) Decode(r io.Reader) error {
+	stream, err := tlv.NewStream(m.ID.Record(), m.Key.Record())
+	if err != nil {
+		return err
+	}
+
+	_, err = stream.DecodeWithParsedTypes(r)
+
+	return err
+}
+
+// CorrelationKey returns the message's per-mailbox FIFO key. Two
+// keyedTestMsgs with the same Key value participate in the same FIFO
+// lane, regardless of the durable mailbox's retry backoff timing.
+func (m *keyedTestMsg) CorrelationKey() string {
+	return string(m.Key.Val)
+}
+
+// msgID is a small helper for asserting the order of observed messages.
+func (m *keyedTestMsg) msgID() string {
+	return string(m.ID.Val)
+}
+
+// failOnceBehavior is an ActorBehavior that returns an error on its
+// first invocation for a given message ID, then succeeds on every
+// subsequent invocation. It also records the order in which it observed
+// successful processing so the test can assert reorder behaviour. The
+// firstFailure channel fires once per unique message ID at the moment
+// that message's first-attempt failure is decided, which the test uses
+// to synchronously serialise Tells against retry backoff windows.
+type failOnceBehavior struct {
+	mu             sync.Mutex
+	failureSeen    map[string]bool
+	observed       []string
+	failOnlyFor    map[string]bool
+	firstFailureCh chan string
+}
+
+// newFailOnceBehavior returns a fresh behavior that fails the first
+// time it sees each unique message ID and succeeds thereafter. If
+// failOnly is non-empty, only those IDs are subject to the
+// first-attempt failure rule; everything else succeeds outright.
+func newFailOnceBehavior(failOnly ...string) *failOnceBehavior {
+	failOnlyFor := map[string]bool{}
+	for _, id := range failOnly {
+		failOnlyFor[id] = true
+	}
+
+	return &failOnceBehavior{
+		failureSeen:    make(map[string]bool),
+		failOnlyFor:    failOnlyFor,
+		firstFailureCh: make(chan string, 16),
+	}
+}
+
+// Receive returns an error on the first invocation per message ID and
+// records the message ID on every subsequent successful invocation.
+func (b *failOnceBehavior) Receive(ctx context.Context,
+	msg *keyedTestMsg) fn.Result[int] {
+
+	b.mu.Lock()
+	id := msg.msgID()
+
+	shouldFail := len(b.failOnlyFor) == 0 || b.failOnlyFor[id]
+	if shouldFail && !b.failureSeen[id] {
+		b.failureSeen[id] = true
+		b.mu.Unlock()
+
+		select {
+		case b.firstFailureCh <- id:
+		default:
+		}
+
+		return fn.Err[int](
+			errors.New("simulated transient failure on first " +
+				"attempt"),
+		)
+	}
+
+	b.observed = append(b.observed, id)
+	b.mu.Unlock()
+
+	return fn.Ok(1)
+}
+
+// observedOrder returns a snapshot of the order in which the behavior
+// has successfully processed messages.
+func (b *failOnceBehavior) observedOrder() []string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	cp := make([]string, len(b.observed))
+	copy(cp, b.observed)
+
+	return cp
+}
+
+// longRetryPolicy returns true for up to 5 attempts with a deliberately
+// long delay so the reorder test can observe the in-backoff message
+// without racing against retry completion. The test gates msg-2's
+// enqueue on msg-1's first-attempt failure, then claims at a point
+// when msg-1's backoff is still active — the per-key FIFO must hold
+// even though msg-2 has a smaller available_at.
+func longRetryPolicy(err error, attempts int) (bool, time.Duration) {
+	if attempts >= 5 {
+		return false, 0
+	}
+
+	return true, 2 * time.Second
+}
+
+// newKeyedTestCodec returns a MessageCodec that knows how to decode
+// keyedTestMsg payloads back from the durable mailbox.
+func newKeyedTestCodec() *actor.MessageCodec {
+	codec := actor.NewMessageCodec()
+	codec.MustRegister(0x4000, func() actor.TLVMessage {
+		return &keyedTestMsg{}
+	})
+
+	return codec
+}
+
+// preEnqueueKeyed inserts a message directly into the store before the
+// actor starts. This avoids the SQLite single-connection limitation that
+// would otherwise let Tell from a test goroutine race against the actor's
+// own write transaction.
+func preEnqueueKeyed(t *testing.T, store actor.TxAwareDeliveryStore, mailbox,
+	msgID, payloadID, key string, createdAt time.Time) {
+
+	t.Helper()
+
+	msg := newKeyedTestMsg(payloadID, key)
+
+	// The actor's mailbox decodes by registered TLV type, so use the
+	// codec to produce bytes the actor's runtime can decode.
+	codec := newKeyedTestCodec()
+	payload, err := codec.Encode(msg)
+	require.NoError(t, err)
+
+	require.NoError(
+		t,
+		store.EnqueueMessage(
+			t.Context(), actor.EnqueueParams{
+				ID:             msgID,
+				MailboxID:      mailbox,
+				MessageType:    msg.MessageType(),
+				Payload:        payload,
+				AvailableAt:    createdAt,
+				MaxAttempts:    5,
+				CorrelationKey: key,
+			},
+		),
+	)
+}
+
+// TestDurableActorPerKeyFIFOSurvivesTransientFailure is the actor-level
+// equivalent of TestPerKeyFIFOBlocksOvertakeOnNack. It pre-enqueues two
+// messages with the same correlation key, then starts a real
+// DurableActor with a behavior that fails the first attempt of msg-1.
+// With the fix, msg-2 must not be processed until msg-1's retry succeeds,
+// even though msg-1 spends time in retry backoff with a larger
+// available_at than msg-2.
+func TestDurableActorPerKeyFIFOSurvivesTransientFailure(t *testing.T) {
+	t.Parallel()
+
+	rawDB := newSQLiteDB(t)
+	require.NoError(t, RunMigrations(rawDB, sqlc.BackendTypeSqlite))
+
+	store, err := NewTxAwareDeliveryStoreFromDB(
+		rawDB, sqlc.BackendTypeSqlite, clock.NewDefaultClock(),
+		btclog.Disabled,
+	)
+	require.NoError(t, err)
+
+	const mailbox = "reorder-test-actor"
+	const key = "alice/round-1"
+
+	// Pre-enqueue both messages before the actor starts so the
+	// reorder scenario is set up without concurrent writes from the
+	// test goroutine. msg-1 has the smaller created_at and is the
+	// FIFO head of the key; msg-2 follows.
+	now := time.Now()
+	preEnqueueKeyed(t, store, mailbox, "msg-1", "msg-1", key, now)
+	preEnqueueKeyed(
+		t, store, mailbox, "msg-2", "msg-2", key,
+		now.Add(time.Millisecond),
+	)
+
+	codec := newKeyedTestCodec()
+
+	// Only msg-1 hits the first-attempt failure; msg-2 succeeds on
+	// its first claim once the actor reaches it.
+	behavior := newFailOnceBehavior("msg-1")
+
+	cfg := actor.DefaultDurableActorConfig[*keyedTestMsg, int](
+		mailbox, behavior, store, codec,
+	)
+	cfg.TellRetryPolicy = longRetryPolicy
+	cfg.PollInterval = 25 * time.Millisecond
+	cfg.LeaseDuration = 5 * time.Second
+	cfg.HeartbeatInterval = 2 * time.Second
+
+	a := actor.NewDurableActor(cfg)
+
+	a.Start()
+	defer func() {
+		stopCtx, stopCancel := context.WithTimeout(
+			context.Background(), 5*time.Second,
+		)
+		defer stopCancel()
+		require.NoError(t, a.StopAndWait(stopCtx))
+	}()
+
+	// Wait until both messages have been successfully processed. The
+	// retry policy delay is 2 seconds, so the whole sequence runs in
+	// ~2-3 seconds: msg-1 fails immediately, backs off 2s, retries
+	// and succeeds, then msg-2 becomes claim-eligible and runs.
+	require.Eventually(t, func() bool {
+		return len(behavior.observedOrder()) == 2
+	}, 10*time.Second, 25*time.Millisecond,
+		"both messages should eventually be processed")
+
+	// The critical assertion: msg-1 was processed before msg-2 even
+	// though msg-2 had a strictly smaller available_at during msg-1's
+	// retry backoff window.
+	require.Equal(
+		t, []string{"msg-1", "msg-2"}, behavior.observedOrder(),
+		"per-key FIFO must hold same-key messages in emission "+
+			"order even when one transiently fails and is in "+
+			"backoff",
+	)
+}
+
+// TestDurableActorCrossKeyIndependence confirms that two messages on
+// different correlation keys can interleave freely even when one of
+// them is in retry backoff. Both messages are pre-enqueued; the first
+// key is configured to fail on its first attempt, the second key is
+// expected to succeed promptly while the first key is in backoff.
+func TestDurableActorCrossKeyIndependence(t *testing.T) {
+	t.Parallel()
+
+	rawDB := newSQLiteDB(t)
+	require.NoError(t, RunMigrations(rawDB, sqlc.BackendTypeSqlite))
+
+	store, err := NewTxAwareDeliveryStoreFromDB(
+		rawDB, sqlc.BackendTypeSqlite, clock.NewDefaultClock(),
+		btclog.Disabled,
+	)
+	require.NoError(t, err)
+
+	const mailbox = "reorder-test-cross"
+
+	// Pre-enqueue one message per key. K1 enqueues first, K2 right
+	// after. Without per-key FIFO, K1's retry backoff still wouldn't
+	// block K2 (different key); with the fix, behavior is unchanged
+	// across keys — we assert that here.
+	now := time.Now()
+	preEnqueueKeyed(
+		t, store, mailbox, "k1-msg-1", "k1-msg-1", "alice/round-1", now,
+	)
+	preEnqueueKeyed(
+		t, store, mailbox, "k2-msg-1", "k2-msg-1", "bob/round-2",
+		now.Add(time.Millisecond),
+	)
+
+	codec := newKeyedTestCodec()
+
+	// Only k1's first message hits the first-attempt failure path.
+	behavior := newFailOnceBehavior("k1-msg-1")
+
+	cfg := actor.DefaultDurableActorConfig[*keyedTestMsg, int](
+		mailbox, behavior, store, codec,
+	)
+	cfg.TellRetryPolicy = longRetryPolicy
+	cfg.PollInterval = 25 * time.Millisecond
+	cfg.LeaseDuration = 5 * time.Second
+	cfg.HeartbeatInterval = 2 * time.Second
+
+	a := actor.NewDurableActor(cfg)
+
+	a.Start()
+	defer func() {
+		stopCtx, stopCancel := context.WithTimeout(
+			context.Background(), 5*time.Second,
+		)
+		defer stopCancel()
+		require.NoError(t, a.StopAndWait(stopCtx))
+	}()
+
+	// K2 should be processed well within K1's backoff window since
+	// they're on different keys. The retry delay is 2s; if K2 has to
+	// wait for K1's retry it would fail this assertion.
+	require.Eventually(t, func() bool {
+		for _, id := range behavior.observedOrder() {
+			if id == "k2-msg-1" {
+				return true
+			}
+		}
+
+		return false
+	}, 1*time.Second, 25*time.Millisecond,
+		"K2 must process well within K1's backoff window")
+}

--- a/db/actordelivery/migrations/000002_mailbox_correlation_key.down.sql
+++ b/db/actordelivery/migrations/000002_mailbox_correlation_key.down.sql
@@ -1,0 +1,5 @@
+-- Roll back the correlation-key FIFO claim ordering migration.
+
+DROP INDEX IF EXISTS idx_mailbox_messages_correlation;
+
+ALTER TABLE mailbox_messages DROP COLUMN correlation_key;

--- a/db/actordelivery/migrations/000002_mailbox_correlation_key.up.sql
+++ b/db/actordelivery/migrations/000002_mailbox_correlation_key.up.sql
@@ -1,0 +1,32 @@
+-- Per-correlation-key FIFO claim ordering for the durable actor mailbox.
+--
+-- The default claim path orders by (priority DESC, available_at ASC,
+-- created_at ASC). Under transient Tell failures the framework Nacks a
+-- message with a backoff delay (available_at = now + delay). A
+-- later-enqueued message in the same logical sequence can have a smaller
+-- available_at than the in-backoff message and claim before it,
+-- producing observable out-of-order processing for downstream consumers.
+--
+-- This migration adds an optional correlation_key column. The claim
+-- query is updated separately (in mailbox.sql) to refuse to return a
+-- keyed row when an earlier same-key row is still in the mailbox, even
+-- if the earlier row is in backoff. Unkeyed messages (NULL key) keep
+-- the existing global available_at ordering and are unaffected by
+-- keyed lanes.
+--
+-- The column is nullable with no backfill: pre-upgrade in-flight rows
+-- read back as NULL and continue to participate in the global ordering.
+-- New enqueues stamp the key from the message's CorrelationKey() at
+-- enqueue time.
+
+ALTER TABLE mailbox_messages ADD COLUMN correlation_key TEXT;
+
+-- Filtered composite index supports the anti-join in the claim query.
+-- The NOT EXISTS subquery probes for an earlier same-key row (by id)
+-- scoped to the same mailbox; this index makes that probe an index
+-- seek. We index by id rather than created_at because the claim's
+-- per-key FIFO uses the UUIDv7 id column for strict sub-second
+-- ordering (the id encodes millisecond timestamp + tiebreaker bits).
+CREATE INDEX IF NOT EXISTS idx_mailbox_messages_correlation
+    ON mailbox_messages(mailbox_id, correlation_key, id)
+    WHERE correlation_key IS NOT NULL;

--- a/db/actordelivery/migrations/CLAUDE.md
+++ b/db/actordelivery/migrations/CLAUDE.md
@@ -13,8 +13,10 @@ generic `db/migrate` orchestration layer.
   `"actor_delivery_schema_migrations"`), `DatabaseName` (default
   `"actor_delivery"`), `LatestVersion` (downgrade guard, default
   `LatestMigrationVersion`), optional `Log btclog.Logger`.
-- `LatestMigrationVersion = 1` — Current schema version; bump when adding a
-  new SQL migration file.
+- `LatestMigrationVersion = 2` — Current schema version; bump when adding a
+  new SQL migration file. Version 2 adds the nullable `correlation_key`
+  column on `mailbox_messages` and the filtered composite index that backs
+  the per-correlation-key FIFO anti-join in `LeaseNextMailboxMessage`.
 - `RunMigrations(db, backend, cfg)` — Applies actor-delivery migrations.
   Validates inputs, applies `Config` defaults, delegates to
   `dbmigrate.RunMigrations` with postgres schema token replacements.

--- a/db/actordelivery/migrations/runner.go
+++ b/db/actordelivery/migrations/runner.go
@@ -16,7 +16,7 @@ const (
 	//
 	// NOTE: This MUST be updated when a new actor-delivery migration is
 	// added.
-	LatestMigrationVersion uint = 1
+	LatestMigrationVersion uint = 2
 
 	// DefaultMigrationsTable is the default migration bookkeeping table.
 	DefaultMigrationsTable = "actor_delivery_schema_migrations"

--- a/db/actordelivery/queries/mailbox.sql
+++ b/db/actordelivery/queries/mailbox.sql
@@ -12,6 +12,9 @@
 -- subsequent CompleteOutbox call fails, the retry will attempt to insert the
 -- same outbox-derived ID. The conflict clause makes this a silent no-op
 -- instead of an error, preserving exactly-once inbox semantics.
+-- correlation_key is optional (NULL = unkeyed, participates in the global
+-- available_at order). Non-NULL keys participate in per-key FIFO claim
+-- ordering: see LeaseNextMailboxMessage for the head-of-line rule.
 INSERT INTO mailbox_messages (
     id,
     mailbox_id,
@@ -23,17 +26,42 @@ INSERT INTO mailbox_messages (
     priority,
     available_at,
     max_attempts,
-    created_at
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+    created_at,
+    correlation_key
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
 ON CONFLICT (id) DO NOTHING;
 
 -- name: LeaseNextMailboxMessage :one
 -- Atomically claim the next available message for processing.
 -- Sets lease_token and lease_until, increments attempts.
 -- Returns NULL if no messages are available.
--- Ordering: priority DESC ensures high-priority (e.g., restart) messages first,
--- then available_at ASC for delivery order, then created_at ASC as a tiebreaker
--- to ensure deterministic ordering when priority and available_at are equal.
+--
+-- Ordering: priority DESC ensures high-priority (e.g., restart) messages
+-- first, then available_at ASC for delivery order, then created_at ASC as
+-- a tiebreaker to ensure deterministic ordering when priority and
+-- available_at are equal.
+--
+-- Per-correlation-key FIFO: when a row carries a non-NULL correlation_key,
+-- it is eligible only if no earlier same-key row exists in this mailbox.
+-- "Earlier" is determined by the UUIDv7 id column, which embeds a
+-- millisecond timestamp plus a per-generator tiebreaker so two messages
+-- enqueued by the same producer are always strictly orderable, even
+-- when they fall in the same second-granularity created_at bucket. This
+-- prevents a later-enqueued same-key message from overtaking a same-key
+-- message that is currently in retry backoff (available_at pushed into
+-- the future by a Nack). Unkeyed rows (NULL key) skip the anti-join
+-- and participate in the global available_at order as before; they are
+-- not affected by, and do not affect, keyed lanes.
+--
+-- The anti-join also requires the predecessor to still have retry budget
+-- (m2.attempts < m2.max_attempts). Without this clause, a same-key row
+-- that exhausted its attempts but has not yet been physically deleted
+-- (e.g. a crash window between MoveMailboxToDeadLetter and
+-- DeleteMailboxMessage in handlePoisonMessage) would permanently block
+-- every later same-key message instead of being passed over. The
+-- exhausted row is already filtered out of the outer candidate set by
+-- m.attempts < m.max_attempts, so this just brings the anti-join
+-- predicate into agreement with the eligibility predicate.
 UPDATE mailbox_messages
 SET
     lease_token = $2,
@@ -45,6 +73,16 @@ WHERE mailbox_messages.id = (
       AND m.available_at <= $4
       AND (m.lease_until IS NULL OR m.lease_until < $4)
       AND m.attempts < m.max_attempts
+      AND (
+          m.correlation_key IS NULL
+          OR NOT EXISTS (
+              SELECT 1 FROM mailbox_messages m2
+              WHERE m2.mailbox_id = m.mailbox_id
+                AND m2.correlation_key = m.correlation_key
+                AND m2.id < m.id
+                AND m2.attempts < m2.max_attempts
+          )
+      )
     ORDER BY m.priority DESC, m.available_at ASC, m.created_at ASC
     LIMIT 1
 )

--- a/db/actordelivery/sqlc/mailbox.sql.go
+++ b/db/actordelivery/sqlc/mailbox.sql.go
@@ -243,8 +243,9 @@ INSERT INTO mailbox_messages (
     priority,
     available_at,
     max_attempts,
-    created_at
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+    created_at,
+    correlation_key
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
 ON CONFLICT (id) DO NOTHING
 `
 
@@ -260,6 +261,7 @@ type EnqueueMailboxMessageParams struct {
 	AvailableAt     int64
 	MaxAttempts     int32
 	CreatedAt       int64
+	CorrelationKey  sql.NullString
 }
 
 // Durable mailbox queries.
@@ -273,6 +275,9 @@ type EnqueueMailboxMessageParams struct {
 // subsequent CompleteOutbox call fails, the retry will attempt to insert the
 // same outbox-derived ID. The conflict clause makes this a silent no-op
 // instead of an error, preserving exactly-once inbox semantics.
+// correlation_key is optional (NULL = unkeyed, participates in the global
+// available_at order). Non-NULL keys participate in per-key FIFO claim
+// ordering: see LeaseNextMailboxMessage for the head-of-line rule.
 func (q *Queries) EnqueueMailboxMessage(ctx context.Context, arg EnqueueMailboxMessageParams) error {
 	_, err := q.db.ExecContext(ctx, EnqueueMailboxMessage,
 		arg.ID,
@@ -286,6 +291,7 @@ func (q *Queries) EnqueueMailboxMessage(ctx context.Context, arg EnqueueMailboxM
 		arg.AvailableAt,
 		arg.MaxAttempts,
 		arg.CreatedAt,
+		arg.CorrelationKey,
 	)
 	return err
 }
@@ -452,7 +458,7 @@ func (q *Queries) GetFSMCheckpoint(ctx context.Context, actorID string) (FsmChec
 }
 
 const GetMailboxMessage = `-- name: GetMailboxMessage :one
-SELECT id, mailbox_id, message_type, payload, promise_id, callback_actor_id, correlation_id, priority, lease_token, lease_until, available_at, attempts, max_attempts, created_at FROM mailbox_messages WHERE id = $1
+SELECT id, mailbox_id, message_type, payload, promise_id, callback_actor_id, correlation_id, priority, lease_token, lease_until, available_at, attempts, max_attempts, created_at, correlation_key FROM mailbox_messages WHERE id = $1
 `
 
 // Get a specific mailbox message by ID.
@@ -474,6 +480,7 @@ func (q *Queries) GetMailboxMessage(ctx context.Context, id string) (MailboxMess
 		&i.Attempts,
 		&i.MaxAttempts,
 		&i.CreatedAt,
+		&i.CorrelationKey,
 	)
 	return i, err
 }
@@ -558,10 +565,20 @@ WHERE mailbox_messages.id = (
       AND m.available_at <= $4
       AND (m.lease_until IS NULL OR m.lease_until < $4)
       AND m.attempts < m.max_attempts
+      AND (
+          m.correlation_key IS NULL
+          OR NOT EXISTS (
+              SELECT 1 FROM mailbox_messages m2
+              WHERE m2.mailbox_id = m.mailbox_id
+                AND m2.correlation_key = m.correlation_key
+                AND m2.id < m.id
+                AND m2.attempts < m2.max_attempts
+          )
+      )
     ORDER BY m.priority DESC, m.available_at ASC, m.created_at ASC
     LIMIT 1
 )
-RETURNING id, mailbox_id, message_type, payload, promise_id, callback_actor_id, correlation_id, priority, lease_token, lease_until, available_at, attempts, max_attempts, created_at
+RETURNING id, mailbox_id, message_type, payload, promise_id, callback_actor_id, correlation_id, priority, lease_token, lease_until, available_at, attempts, max_attempts, created_at, correlation_key
 `
 
 type LeaseNextMailboxMessageParams struct {
@@ -574,9 +591,33 @@ type LeaseNextMailboxMessageParams struct {
 // Atomically claim the next available message for processing.
 // Sets lease_token and lease_until, increments attempts.
 // Returns NULL if no messages are available.
-// Ordering: priority DESC ensures high-priority (e.g., restart) messages first,
-// then available_at ASC for delivery order, then created_at ASC as a tiebreaker
-// to ensure deterministic ordering when priority and available_at are equal.
+//
+// Ordering: priority DESC ensures high-priority (e.g., restart) messages
+// first, then available_at ASC for delivery order, then created_at ASC as
+// a tiebreaker to ensure deterministic ordering when priority and
+// available_at are equal.
+//
+// Per-correlation-key FIFO: when a row carries a non-NULL correlation_key,
+// it is eligible only if no earlier same-key row exists in this mailbox.
+// "Earlier" is determined by the UUIDv7 id column, which embeds a
+// millisecond timestamp plus a per-generator tiebreaker so two messages
+// enqueued by the same producer are always strictly orderable, even
+// when they fall in the same second-granularity created_at bucket. This
+// prevents a later-enqueued same-key message from overtaking a same-key
+// message that is currently in retry backoff (available_at pushed into
+// the future by a Nack). Unkeyed rows (NULL key) skip the anti-join
+// and participate in the global available_at order as before; they are
+// not affected by, and do not affect, keyed lanes.
+//
+// The anti-join also requires the predecessor to still have retry budget
+// (m2.attempts < m2.max_attempts). Without this clause, a same-key row
+// that exhausted its attempts but has not yet been physically deleted
+// (e.g. a crash window between MoveMailboxToDeadLetter and
+// DeleteMailboxMessage in handlePoisonMessage) would permanently block
+// every later same-key message instead of being passed over. The
+// exhausted row is already filtered out of the outer candidate set by
+// m.attempts < m.max_attempts, so this just brings the anti-join
+// predicate into agreement with the eligibility predicate.
 func (q *Queries) LeaseNextMailboxMessage(ctx context.Context, arg LeaseNextMailboxMessageParams) (MailboxMessage, error) {
 	row := q.db.QueryRowContext(ctx, LeaseNextMailboxMessage,
 		arg.MailboxID,
@@ -600,6 +641,7 @@ func (q *Queries) LeaseNextMailboxMessage(ctx context.Context, arg LeaseNextMail
 		&i.Attempts,
 		&i.MaxAttempts,
 		&i.CreatedAt,
+		&i.CorrelationKey,
 	)
 	return i, err
 }
@@ -729,7 +771,7 @@ func (q *Queries) ListFSMCheckpoints(ctx context.Context) ([]FsmCheckpoint, erro
 }
 
 const ListMailboxMessagesByActor = `-- name: ListMailboxMessagesByActor :many
-SELECT id, mailbox_id, message_type, payload, promise_id, callback_actor_id, correlation_id, priority, lease_token, lease_until, available_at, attempts, max_attempts, created_at FROM mailbox_messages
+SELECT id, mailbox_id, message_type, payload, promise_id, callback_actor_id, correlation_id, priority, lease_token, lease_until, available_at, attempts, max_attempts, created_at, correlation_key FROM mailbox_messages
 WHERE mailbox_id = $1
 ORDER BY priority DESC, available_at ASC, created_at ASC
 `
@@ -759,6 +801,7 @@ func (q *Queries) ListMailboxMessagesByActor(ctx context.Context, mailboxID stri
 			&i.Attempts,
 			&i.MaxAttempts,
 			&i.CreatedAt,
+			&i.CorrelationKey,
 		); err != nil {
 			return nil, err
 		}

--- a/db/actordelivery/sqlc/models.go
+++ b/db/actordelivery/sqlc/models.go
@@ -50,6 +50,7 @@ type MailboxMessage struct {
 	Attempts        int32
 	MaxAttempts     int32
 	CreatedAt       int64
+	CorrelationKey  sql.NullString
 }
 
 type OutboxMessage struct {

--- a/db/actordelivery/sqlc/querier.go
+++ b/db/actordelivery/sqlc/querier.go
@@ -51,6 +51,9 @@ type Querier interface {
 	// subsequent CompleteOutbox call fails, the retry will attempt to insert the
 	// same outbox-derived ID. The conflict clause makes this a silent no-op
 	// instead of an error, preserving exactly-once inbox semantics.
+	// correlation_key is optional (NULL = unkeyed, participates in the global
+	// available_at order). Non-NULL keys participate in per-key FIFO claim
+	// ordering: see LeaseNextMailboxMessage for the head-of-line rule.
 	EnqueueMailboxMessage(ctx context.Context, arg EnqueueMailboxMessageParams) error
 	// =============================================================================
 	// Outbox Operations (CDC Pattern)
@@ -90,9 +93,33 @@ type Querier interface {
 	// Atomically claim the next available message for processing.
 	// Sets lease_token and lease_until, increments attempts.
 	// Returns NULL if no messages are available.
-	// Ordering: priority DESC ensures high-priority (e.g., restart) messages first,
-	// then available_at ASC for delivery order, then created_at ASC as a tiebreaker
-	// to ensure deterministic ordering when priority and available_at are equal.
+	//
+	// Ordering: priority DESC ensures high-priority (e.g., restart) messages
+	// first, then available_at ASC for delivery order, then created_at ASC as
+	// a tiebreaker to ensure deterministic ordering when priority and
+	// available_at are equal.
+	//
+	// Per-correlation-key FIFO: when a row carries a non-NULL correlation_key,
+	// it is eligible only if no earlier same-key row exists in this mailbox.
+	// "Earlier" is determined by the UUIDv7 id column, which embeds a
+	// millisecond timestamp plus a per-generator tiebreaker so two messages
+	// enqueued by the same producer are always strictly orderable, even
+	// when they fall in the same second-granularity created_at bucket. This
+	// prevents a later-enqueued same-key message from overtaking a same-key
+	// message that is currently in retry backoff (available_at pushed into
+	// the future by a Nack). Unkeyed rows (NULL key) skip the anti-join
+	// and participate in the global available_at order as before; they are
+	// not affected by, and do not affect, keyed lanes.
+	//
+	// The anti-join also requires the predecessor to still have retry budget
+	// (m2.attempts < m2.max_attempts). Without this clause, a same-key row
+	// that exhausted its attempts but has not yet been physically deleted
+	// (e.g. a crash window between MoveMailboxToDeadLetter and
+	// DeleteMailboxMessage in handlePoisonMessage) would permanently block
+	// every later same-key message instead of being passed over. The
+	// exhausted row is already filtered out of the outer candidate set by
+	// m.attempts < m.max_attempts, so this just brings the anti-join
+	// predicate into agreement with the eligibility predicate.
 	LeaseNextMailboxMessage(ctx context.Context, arg LeaseNextMailboxMessageParams) (MailboxMessage, error)
 	// List dead letters for a specific actor.
 	ListDeadLettersByActor(ctx context.Context, arg ListDeadLettersByActorParams) ([]DeadLetter, error)

--- a/db/actordelivery/store_impl.go
+++ b/db/actordelivery/store_impl.go
@@ -176,6 +176,9 @@ func (s *Store) EnqueueMessage(
 					AvailableAt: params.AvailableAt.Unix(),
 					MaxAttempts: int32(params.MaxAttempts),
 					CreatedAt:   createdAt,
+					CorrelationKey: toNullString(
+						params.CorrelationKey,
+					),
 				},
 			)
 		})
@@ -945,6 +948,7 @@ func (s *TxActorDeliveryStore) EnqueueMessage(
 		AvailableAt:     params.AvailableAt.Unix(),
 		MaxAttempts:     int32(params.MaxAttempts),
 		CreatedAt:       s.clock.Now().Unix(),
+		CorrelationKey:  toNullString(params.CorrelationKey),
 	})
 }
 

--- a/db/sqlc/schemas/generated_schema.sql
+++ b/db/sqlc/schemas/generated_schema.sql
@@ -307,6 +307,10 @@ CREATE INDEX idx_dead_letters_source
 CREATE INDEX idx_mailbox_messages_available
     ON mailbox_messages(mailbox_id, priority DESC, available_at ASC, created_at ASC);
 
+CREATE INDEX idx_mailbox_messages_correlation
+    ON mailbox_messages(mailbox_id, correlation_key, id)
+    WHERE correlation_key IS NOT NULL;
+
 CREATE INDEX idx_mailbox_messages_lease
     ON mailbox_messages(lease_until)
     WHERE lease_until IS NOT NULL;
@@ -480,7 +484,7 @@ CREATE TABLE mailbox_messages (
 
     -- created_at is the unix timestamp when the message was enqueued.
     created_at BIGINT NOT NULL
-);
+, correlation_key TEXT);
 
 CREATE TABLE oor_package_checkpoints (
     -- session_id references the owning OOR package row.

--- a/oor/outbox_messages.go
+++ b/oor/outbox_messages.go
@@ -116,6 +116,31 @@ func (m *SendSubmitPackageRequest) ServiceMethod() mailboxrpc.ServiceMethod {
 	}
 }
 
+// sessionCorrelationKey is the canonical per-session FIFO key for
+// client-to-server OOR outbox events. The client maintains a single
+// durable serverconn mailbox per operator, so distinguishing sessions
+// is sufficient to keep submit / finalize / ack for the same session
+// from reordering under transient Edge.Send failure. The "oor/" prefix
+// distinguishes the namespace from round keys so a session id cannot
+// collide with a round id by accident.
+func sessionCorrelationKey(sessionID SessionID) string {
+	return "oor/" + sessionID.String()
+}
+
+// CorrelationKey returns the per-session FIFO key derived from the
+// Ark PSBT. Falls back to the unkeyed lane if session derivation
+// fails (e.g. a malformed PSBT) — the message would error out at the
+// ToProto step anyway, so dropping FIFO enforcement on that pathological
+// case is acceptable.
+func (m *SendSubmitPackageRequest) CorrelationKey() string {
+	sessionID, err := sessionIDFromArk(m.ArkPSBT)
+	if err != nil {
+		return ""
+	}
+
+	return sessionCorrelationKey(sessionID)
+}
+
 // ToProto converts SendSubmitPackageRequest to the concrete proto type
 // expected by the server-side OOR dispatcher.
 func (m *SendSubmitPackageRequest) ToProto() fn.Result[proto.Message] {
@@ -209,6 +234,17 @@ func (m *SendFinalizePackageRequest) ServiceMethod() mailboxrpc.ServiceMethod {
 		Service: oorpb.ServiceName,
 		Method:  oorpb.MethodFinalizePackage,
 	}
+}
+
+// CorrelationKey returns the per-session FIFO key so finalize lands
+// in emission order behind the matching submit.
+func (m *SendFinalizePackageRequest) CorrelationKey() string {
+	sessionID, err := sessionIDFromArk(m.ArkPSBT)
+	if err != nil {
+		return ""
+	}
+
+	return sessionCorrelationKey(sessionID)
 }
 
 // ToProto converts SendFinalizePackageRequest to the concrete proto type
@@ -411,6 +447,11 @@ func (m *SendIncomingAckRequest) ServiceMethod() mailboxrpc.ServiceMethod {
 		Service: oorpb.ServiceName,
 		Method:  oorpb.MethodIncomingAck,
 	}
+}
+
+// CorrelationKey returns the per-session FIFO key.
+func (m *SendIncomingAckRequest) CorrelationKey() string {
+	return sessionCorrelationKey(m.SessionID)
 }
 
 // ToProto converts SendIncomingAckRequest to a protobuf message.

--- a/round/outbox_messages.go
+++ b/round/outbox_messages.go
@@ -66,6 +66,29 @@ func (m *JoinRoundRequest) ServiceMethod() mailboxrpc.ServiceMethod {
 	}
 }
 
+// roundCorrelationKey is the canonical per-round FIFO key for
+// client-to-server outbox events. The client maintains a single
+// durable serverconn mailbox per operator, so distinguishing rounds
+// is sufficient to keep two same-round messages from reordering under
+// transient Edge.Send failure. An empty round id maps to the unkeyed
+// lane: fresh join requests do not yet have a server-assigned round
+// and have nothing earlier to sequence against.
+func roundCorrelationKey(roundID string) string {
+	if roundID == "" {
+		return ""
+	}
+
+	return "round/" + roundID
+}
+
+// CorrelationKey returns the per-round FIFO key. JoinRoundRequest
+// instances for an unassigned round (empty RoundID) participate in the
+// unkeyed lane; subsequent same-round outbox messages cluster under
+// the assigned id.
+func (m *JoinRoundRequest) CorrelationKey() string {
+	return roundCorrelationKey(m.RoundID)
+}
+
 // JoinRoundAcceptOutbox is emitted by QuoteReceivedState after the
 // FSM decides the server's quote is acceptable (operator fee within
 // MaxOperatorFee, quote RejectReason == OK). Routed via the durable
@@ -93,6 +116,12 @@ func (m *JoinRoundAcceptOutbox) ServiceMethod() mailboxrpc.ServiceMethod {
 		Service: roundpb.ServiceName,
 		Method:  roundpb.MethodAcceptQuote,
 	}
+}
+
+// CorrelationKey returns the per-round FIFO key so the accept lands
+// in emission order with the rest of the round's outbox events.
+func (m *JoinRoundAcceptOutbox) CorrelationKey() string {
+	return roundCorrelationKey(m.RoundID.String())
 }
 
 // ToProto converts JoinRoundAcceptOutbox to the roundpb wire
@@ -135,6 +164,11 @@ func (m *JoinRoundRejectOutbox) ServiceMethod() mailboxrpc.ServiceMethod {
 	}
 }
 
+// CorrelationKey returns the per-round FIFO key.
+func (m *JoinRoundRejectOutbox) CorrelationKey() string {
+	return roundCorrelationKey(m.RoundID.String())
+}
+
 // ToProto converts JoinRoundRejectOutbox to the roundpb wire
 // format. Returned as fn.Result[proto.Message] so processOutbox
 // can treat this outbox message as a ServerMessage and dispatch
@@ -173,6 +207,11 @@ func (m *SubmitNoncesRequest) ServiceMethod() mailboxrpc.ServiceMethod {
 	}
 }
 
+// CorrelationKey returns the per-round FIFO key.
+func (m *SubmitNoncesRequest) CorrelationKey() string {
+	return roundCorrelationKey(m.RoundID.String())
+}
+
 // SubmitPartialSigRequest is sent from client to server with partial
 // signatures. This implements ClientEvent and is emitted via Outbox.
 type SubmitPartialSigRequest struct {
@@ -198,6 +237,11 @@ func (m *SubmitPartialSigRequest) ServiceMethod() mailboxrpc.ServiceMethod {
 	}
 }
 
+// CorrelationKey returns the per-round FIFO key.
+func (m *SubmitPartialSigRequest) CorrelationKey() string {
+	return roundCorrelationKey(m.RoundID.String())
+}
+
 // SubmitForfeitSigRequest is sent from client to server with the boarding input
 // signature. This implements ClientEvent and is emitted via Outbox.
 type SubmitForfeitSigRequest struct {
@@ -220,6 +264,11 @@ func (m *SubmitForfeitSigRequest) ServiceMethod() mailboxrpc.ServiceMethod {
 		Service: roundpb.ServiceName,
 		Method:  roundpb.MethodSubmitForfeitSigs,
 	}
+}
+
+// CorrelationKey returns the per-round FIFO key.
+func (m *SubmitForfeitSigRequest) CorrelationKey() string {
+	return roundCorrelationKey(m.RoundID.String())
 }
 
 // ToProto converts JoinRoundRequest to a protobuf message for mailbox
@@ -521,6 +570,11 @@ func (m *SubmitVTXOForfeitSigsToServer) ServiceMethod() mailboxrpc.ServiceMethod
 		Service: roundpb.ServiceName,
 		Method:  roundpb.MethodSubmitVTXOForfeitSigs,
 	}
+}
+
+// CorrelationKey returns the per-round FIFO key.
+func (m *SubmitVTXOForfeitSigsToServer) CorrelationKey() string {
+	return roundCorrelationKey(m.RoundID.String())
 }
 
 // MessageType returns the message type for logging.

--- a/serverconn/actor.go
+++ b/serverconn/actor.go
@@ -48,6 +48,7 @@ type (
 	rpcServiceRecordTLV     = tlv.TlvType5
 	rpcMethodRecordTLV      = tlv.TlvType6
 	rpcCorrelationRecordTLV = tlv.TlvType7
+	correlationKeyRecordTLV = tlv.TlvType8
 )
 
 // ServerMessage is an interface that client FSM outbox messages must implement
@@ -161,6 +162,23 @@ type SendClientEventRequest struct {
 	// "JoinRound"). Populated from ServerMessage.ServiceMethod() at
 	// send time, persisted in TLV for crash-safe replay.
 	Method string
+
+	// cachedCorrelationKey holds the per-key FIFO key that was stamped
+	// on the concrete inner message at the time the wrapper was last
+	// encoded. It exists because Decode replaces the typed inner
+	// Message with a rawServerMessage that no longer implements
+	// CorrelationKey, so a decoded wrapper has no way to recover the
+	// key from the inner field alone. The outbox-CDC delivery path
+	// hits this branch: the wrapper is encoded into the actor outbox,
+	// later decoded by OutboxPublisher, then enqueued into the
+	// serverconn mailbox for the first time, and that first enqueue
+	// is where the durable mailbox reads CorrelationKey to stamp the
+	// claim lane. Stored as []byte so Decode can hand the TLV record
+	// straight through without a copy; the read path converts to
+	// string at the CorrelationKey() boundary. Set by Decode; read
+	// by CorrelationKey as the fallback when the structural assertion
+	// on Message fails.
+	cachedCorrelationKey []byte
 }
 
 // MessageType returns a human-readable type name for logging.
@@ -238,9 +256,21 @@ func (m *SendClientEventRequest) Encode(w io.Writer) error {
 		[]byte(method),
 	)
 
+	// Persist the per-key FIFO key alongside the routing metadata so
+	// a wrapper round-tripped through the outbox CDC table still
+	// surfaces the right key on first enqueue into the serverconn
+	// mailbox. Computing via CorrelationKey() consults the cached
+	// value first (covering re-Encode of a previously decoded
+	// wrapper), then falls back to the structural assertion on the
+	// concrete inner Message (the normal pre-Encode path).
+	corrKeyBytes := []byte(m.CorrelationKey())
+	corrKeyRec := tlv.NewPrimitiveRecord[correlationKeyRecordTLV](
+		corrKeyBytes,
+	)
+
 	stream, err := tlv.NewStream(
 		payload.Record(), msgIDRec.Record(), idemRec.Record(),
-		svcRec.Record(), methodRec.Record(),
+		svcRec.Record(), methodRec.Record(), corrKeyRec.Record(),
 	)
 	if err != nil {
 		return err
@@ -263,10 +293,11 @@ func (m *SendClientEventRequest) Decode(r io.Reader) error {
 	idemRec := tlv.ZeroRecordT[idempotencyRecordTLV, []byte]()
 	svcRec := tlv.ZeroRecordT[rpcServiceRecordTLV, []byte]()
 	methodRec := tlv.ZeroRecordT[rpcMethodRecordTLV, []byte]()
+	corrKeyRec := tlv.ZeroRecordT[correlationKeyRecordTLV, []byte]()
 
 	stream, err := tlv.NewStream(
 		payload.Record(), msgIDRec.Record(), idemRec.Record(),
-		svcRec.Record(), methodRec.Record(),
+		svcRec.Record(), methodRec.Record(), corrKeyRec.Record(),
 	)
 	if err != nil {
 		return err
@@ -281,8 +312,50 @@ func (m *SendClientEventRequest) Decode(r io.Reader) error {
 	m.IdempotencyKey = string(idemRec.Val)
 	m.Service = string(svcRec.Val)
 	m.Method = string(methodRec.Val)
+	m.cachedCorrelationKey = corrKeyRec.Val
 
 	return nil
+}
+
+// CorrelationKey forwards the inner ServerMessage's per-key FIFO key so
+// the durable mailbox's per-correlation-key claim invariant fires on the
+// right lane (e.g. "oor/<session>", "round/<id>"). Without this hop the
+// wrapper's embedded BaseMessage default ("") would erase the inner key
+// at enqueue and every outbox row would land in the unkeyed lane, leaving
+// the original Nack-with-backoff reorder window open.
+//
+// The inner field is typed as ServerMessage (ToProto + ServiceMethod);
+// the per-key contract lives on actor.Message. We use a structural
+// assertion so the forward works for any concrete outbox message that
+// opts in to per-key FIFO without coupling ServerMessage to the actor
+// interface. That assertion covers the in-process pre-Encode path where
+// the inner Message is the concrete OOR/round outbox type.
+//
+// After TLV decode the inner becomes a *rawServerMessage that no longer
+// satisfies the assertion. That is the path the outbox-CDC delivery uses:
+// sendTransportEvent encodes the wrapper into the actor outbox, the
+// OutboxPublisher decodes it later, and then Tells the decoded wrapper
+// into the serverconn mailbox for the first time. The durable mailbox
+// reads CorrelationKey on that first enqueue, so we have to surface
+// the key from somewhere other than the now-erased inner type. Encode
+// persists the inner key in its own TLV record and Decode caches it on
+// cachedCorrelationKey; this method falls back to that cache when the
+// structural assertion misses.
+func (m *SendClientEventRequest) CorrelationKey() string {
+	if m == nil {
+		return ""
+	}
+
+	if m.Message != nil {
+		keyed, ok := m.Message.(interface{ CorrelationKey() string })
+		if ok {
+			if key := keyed.CorrelationKey(); key != "" {
+				return key
+			}
+		}
+	}
+
+	return string(m.cachedCorrelationKey)
 }
 
 // serverConnMsgSealed implements the ServerConnMsg interface seal.

--- a/serverconn/actor_correlation_key_test.go
+++ b/serverconn/actor_correlation_key_test.go
@@ -1,0 +1,266 @@
+package serverconn
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/lightninglabs/darepo-client/baselib/actor"
+	mailboxrpc "github.com/lightninglabs/darepo-client/mailbox/rpc"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+// keyedServerMessage is a ServerMessage that also satisfies the
+// actor.Message contract and stamps a custom correlation key. It models
+// the OOR/round outbox messages (e.g. SendSubmitPackageRequest) which
+// opt in to per-key FIFO claim ordering on the durable mailbox.
+type keyedServerMessage struct {
+	actor.BaseMessage
+
+	key     string
+	payload []byte
+}
+
+// MessageType returns the type name for routing and logging.
+func (m *keyedServerMessage) MessageType() string {
+	return "keyedServerMessage"
+}
+
+// CorrelationKey returns the per-key FIFO key stamped on the message.
+func (m *keyedServerMessage) CorrelationKey() string { return m.key }
+
+// ServiceMethod returns deterministic routing metadata.
+func (m *keyedServerMessage) ServiceMethod() mailboxrpc.ServiceMethod {
+	return mailboxrpc.ServiceMethod{Service: "test.svc", Method: "Push"}
+}
+
+// ToProto wraps the payload bytes in a wrapperspb so the request can be
+// serialized through the standard TLV path.
+func (m *keyedServerMessage) ToProto() fn.Result[proto.Message] {
+	return fn.Ok[proto.Message](wrapperspb.Bytes(m.payload))
+}
+
+// TestSendClientEventRequestForwardsInnerCorrelationKey verifies that the
+// wrapper exposes the inner ServerMessage's correlation key so the durable
+// mailbox stamps the right per-key FIFO lane at enqueue. Without the
+// forward the embedded BaseMessage default ("") would land every wrapped
+// outbox row in the unkeyed lane and the per-key claim invariant would
+// never trigger for production traffic.
+func TestSendClientEventRequestForwardsInnerCorrelationKey(t *testing.T) {
+	t.Parallel()
+
+	const innerKey = "oor/abc123"
+
+	req := &SendClientEventRequest{
+		Message: &keyedServerMessage{
+			key:     innerKey,
+			payload: []byte("submit-package"),
+		},
+	}
+
+	require.Equal(t, innerKey, req.CorrelationKey())
+}
+
+// TestSendClientEventRequestUnkeyedInnerReturnsEmpty covers the
+// opt-out path: when the inner ServerMessage's CorrelationKey is
+// empty (the BaseMessage default), the wrapper must also return ""
+// so the message keeps the legacy global available_at claim order
+// and does not synthesize a phantom lane.
+func TestSendClientEventRequestUnkeyedInnerReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	req := &SendClientEventRequest{
+		Message: &keyedServerMessage{
+			key:     "",
+			payload: []byte("unkeyed"),
+		},
+	}
+
+	require.Equal(t, "", req.CorrelationKey())
+}
+
+// TestSendClientEventRequestNonImplementerReturnsEmpty covers the
+// post-decode path: rawServerMessage (and any other ServerMessage that
+// does not implement CorrelationKey) must yield "" without panicking.
+// CorrelationKey is only consumed at enqueue, so this branch only
+// matters defensively — a future wrapper that calls CorrelationKey
+// after Decode must still see a stable empty value.
+func TestSendClientEventRequestNonImplementerReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	req := &SendClientEventRequest{
+		Message: &bytesServerMessage{
+			payload: []byte("legacy"),
+		},
+	}
+
+	require.Equal(t, "", req.CorrelationKey())
+}
+
+// TestSendClientEventRequestNilMessageReturnsEmpty guards the
+// degenerate case where the wrapper is constructed without a Message.
+// The forward must not panic on the nil interface assertion.
+func TestSendClientEventRequestNilMessageReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	req := &SendClientEventRequest{}
+
+	require.Equal(t, "", req.CorrelationKey())
+}
+
+// capturingEnqueueStore wraps memCheckpointStore and records the
+// EnqueueParams seen by EnqueueMessage. Used to assert that the inner
+// CorrelationKey survives the wrapper hop and reaches the persistence
+// layer with the expected value.
+type capturingEnqueueStore struct {
+	*memCheckpointStore
+
+	lastParams actor.EnqueueParams
+	called     bool
+}
+
+// EnqueueMessage records the incoming params before delegating to the
+// underlying in-memory store.
+func (s *capturingEnqueueStore) EnqueueMessage(ctx context.Context,
+	params actor.EnqueueParams) error {
+
+	s.lastParams = params
+	s.called = true
+
+	return s.memCheckpointStore.EnqueueMessage(ctx, params)
+}
+
+// TestSendClientEventRequestTLVRoundTripPreservesKey pins down the
+// outbox-CDC delivery path: when OOR/round wraps an outbox event in
+// SendClientEventRequest and writes it to the actor outbox, the wrapper
+// is decoded later by OutboxPublisher and Tell'd into the serverconn
+// mailbox for the first time. That first enqueue is where the durable
+// mailbox reads CorrelationKey to stamp the claim lane, but Decode
+// replaces the concrete inner Message with a *rawServerMessage that no
+// longer implements CorrelationKey. Without persisting the key in the
+// wrapper's TLV stream, the structural assertion in CorrelationKey
+// would miss and the row would land in the unkeyed lane (defeating
+// per-session FIFO for transport-outbox-enabled deployments). The fix
+// writes the key into its own TLV record at Encode and caches it on
+// Decode. This test exercises that roundtrip.
+func TestSendClientEventRequestTLVRoundTripPreservesKey(t *testing.T) {
+	t.Parallel()
+
+	const innerKey = "oor/abc123"
+
+	original := &SendClientEventRequest{
+		Message: &keyedServerMessage{
+			key:     innerKey,
+			payload: []byte("outbox-cdc-event"),
+		},
+	}
+
+	// Sanity: the pre-encode wrapper exposes the key via the
+	// structural assertion on the concrete inner message.
+	require.Equal(t, innerKey, original.CorrelationKey())
+
+	var buf bytes.Buffer
+	require.NoError(t, original.Encode(&buf))
+
+	var decoded SendClientEventRequest
+	require.NoError(t, decoded.Decode(bytes.NewReader(buf.Bytes())))
+
+	// After Decode the inner is a *rawServerMessage and the
+	// structural assertion misses; the wrapper must surface the
+	// cached key persisted in the TLV stream.
+	_, isRaw := decoded.Message.(*rawServerMessage)
+	require.True(
+		t, isRaw,
+		"decode replaces concrete inner with rawServerMessage",
+	)
+	require.Equal(t, innerKey, decoded.CorrelationKey())
+
+	// Re-encoding the decoded wrapper must persist the cached key so
+	// any further hop through outbox CDC keeps the lane stable.
+	var buf2 bytes.Buffer
+	require.NoError(t, decoded.Encode(&buf2))
+
+	var roundTripped SendClientEventRequest
+	require.NoError(
+		t,
+		roundTripped.Decode(
+			bytes.NewReader(
+				buf2.Bytes(),
+			),
+		),
+	)
+	require.Equal(t, innerKey, roundTripped.CorrelationKey())
+}
+
+// TestSendClientEventRequestTLVRoundTripPreservesEmptyKey covers the
+// opt-out path through the TLV stream: an inner message with no
+// correlation key (or one that resolves to "" via the unkeyed fallback,
+// e.g. a malformed PSBT in SendSubmitPackageRequest) must round-trip
+// to an empty cached key, keeping the row in the legacy unkeyed lane.
+func TestSendClientEventRequestTLVRoundTripPreservesEmptyKey(t *testing.T) {
+	t.Parallel()
+
+	original := &SendClientEventRequest{
+		Message: &keyedServerMessage{
+			key:     "",
+			payload: []byte("unkeyed-event"),
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, original.Encode(&buf))
+
+	var decoded SendClientEventRequest
+	require.NoError(t, decoded.Decode(bytes.NewReader(buf.Bytes())))
+
+	require.Equal(t, "", decoded.CorrelationKey())
+}
+
+// TestSendClientEventRequestPlumbsCorrelationKeyToStore is the
+// integration-level regression test for H-1: a stamped outbox message
+// wrapped in SendClientEventRequest and Tell'd to the durable actor must
+// reach the DeliveryStore.EnqueueMessage call site with a non-empty
+// CorrelationKey on EnqueueParams. Before the wrapper forward this
+// assertion failed — every wrapped row landed with CorrelationKey == ""
+// even when the inner message carried a per-session key. With the
+// forward in place the captured params carry the inner key, which is
+// exactly what the per-correlation-key FIFO claim path consumes.
+func TestSendClientEventRequestPlumbsCorrelationKeyToStore(t *testing.T) {
+	t.Parallel()
+
+	const innerKey = "round/feedface"
+
+	mb := newInMemoryMailbox()
+	base := newMemCheckpointStore()
+	store := &capturingEnqueueStore{memCheckpointStore: base}
+
+	// Build the config with the base store so the helper's concrete
+	// type fits, then swap to the capturing decorator on the interface
+	// field. Production wires the store the same way: through the
+	// actor.DeliveryStore interface on ConnectorConfig.Store.
+	cfg := newTestConnectorConfig(mb, base)
+	cfg.Store = store
+	cfg.Codec = NewServerConnCodec()
+
+	durable := newDurableConnectorForTest(cfg, 50*time.Millisecond)
+	durable.Start()
+	defer durable.Stop()
+
+	err := durable.TellRef().Tell(t.Context(), &SendClientEventRequest{
+		Message: &keyedServerMessage{
+			key:     innerKey,
+			payload: []byte("stamped-event"),
+		},
+	})
+	require.NoError(t, err)
+
+	require.True(t, store.called, "EnqueueMessage must be invoked")
+	require.Equal(
+		t, innerKey, store.lastParams.CorrelationKey,
+		"wrapper must forward inner CorrelationKey into EnqueueParams",
+	)
+}


### PR DESCRIPTION
## Summary

In this PR, we close a structural reorder window in the durable actor
mailbox by adding a per-correlation-key FIFO claim invariant, then stamp
the matching keys on the client-to-server OOR and round outbox messages
so the invariant fires on production traffic. The framework primitive
lands first, then the SQL claim + schema, then the per-message stamping
for the two FSMs that need it. See each commit message for the per-step
rationale.

## The bug

When a Tell to the serverconn durable mailbox transiently failed (e.g.
a gRPC blip on `Edge.Send`), the actor runtime nacked the message with
the default exponential backoff (1s, 2s, 4s, 8s, 16s) by pushing
`available_at` into the future. The existing claim SQL orders by
`(priority DESC, available_at ASC, created_at ASC)`, so a later-enqueued
message in the same mailbox with a smaller `available_at` could overtake
the in-backoff predecessor on the next `LeaseNextMailboxMessage`. Any
pair of logically-sequenced outbox events sharing a per-client mailbox
could reorder. The concrete bite is round: a transient send failure on
`SubmitNoncesRequest` would let the follow-up `SubmitPartialSigRequest`
for the same round overtake it, and the server would see partial sigs
before nonces, outside the protocol contract.

## Approach

We add a `CorrelationKey() string` method to the `actor.Message`
interface with a default empty value on `BaseMessage`. The durable
mailbox reads the key at enqueue and stamps it on a new
`mailbox_messages.correlation_key` column (NULL when empty). The claim
SQL gains a `NOT EXISTS` anti-join: a keyed row is claim-eligible only
if no earlier same-key, same-mailbox, retry-budget-remaining row exists.
"Earlier" is the row's UUIDv7 `id`, which embeds a millisecond timestamp
plus a per-generator tiebreaker so two messages from the same producer
are strictly orderable even when they fall in the same second-granularity
`created_at` bucket.

Unkeyed rows (NULL `correlation_key`) skip the anti-join entirely and
keep the legacy global `available_at` order. They are not blocked by
keyed lanes, and they do not block them. The default is opt-in: every
existing `TLVMessage` implementer keeps the empty key from `BaseMessage`,
so the schema change is back-compat for in-flight rows and the migration
is nullable with no backfill.

A filtered composite index on `(mailbox_id, correlation_key, id) WHERE
correlation_key IS NOT NULL` keeps the anti-join probe an index seek
under load. Head-of-line blocking is bounded to the correlation key, not
the mailbox; per-mailbox consumers are already strictly serial so this
does not regress throughput.

## Stamping

Round stamps `roundCorrelationKey(roundID)` on its seven
client-to-server outbox messages: `JoinRoundRequest`,
`JoinRoundAcceptOutbox`, `JoinRoundRejectOutbox`, `SubmitNoncesRequest`,
`SubmitPartialSigRequest`, `SubmitForfeitSigRequest`,
`SubmitVTXOForfeitSigsToServer`. A `JoinRoundRequest` with an empty
`RoundID` (fresh join, no server-assigned id yet) falls back to the
unkeyed lane; it's the first message for the round and has nothing
earlier to sequence against.

OOR stamps `sessionCorrelationKey(sessionID)` on its three
client-to-server outbox messages: `SendSubmitPackageRequest`,
`SendFinalizePackageRequest`, `SendIncomingAckRequest`. Submit and
finalize derive the session id from the embedded `ArkPSBT` via
`sessionIDFromArk`; `SendIncomingAckRequest` already carries an explicit
`SessionID`. A malformed PSBT falls back to the unkeyed lane (the
message would error out at `ToProto` anyway).

The `"oor/"` and `"round/"` namespace prefixes keep the two key spaces
disjoint so a session id can never accidentally collide with a round id.

## Wrapper hop and dead-letter gap (review followups)

A multi-agent code review of the original five commits surfaced two
issues, both addressed in the same branch ahead of opening the PR.

The first was that the OOR and round outbox messages were stamped on
the inner concrete type but were then wrapped in
`serverconn.SendClientEventRequest` before reaching the durable mailbox.
`SendClientEventRequest` embeds `actor.BaseMessage`, so its
`CorrelationKey()` returned `""` and the inner key was lost at the
wrapper hop. Every wrapped row would have landed in the unkeyed lane and
the per-key invariant would never have fired on production traffic. The
fix adds a `CorrelationKey()` method on the wrapper that forwards the
inner `ServerMessage`'s key via a structural type assertion, so any
concrete message that opts in is supported without coupling
`ServerMessage` to the actor interface.

The second was that the anti-join did not filter exhausted predecessors.
A same-key row whose `attempts == max_attempts` but which had not yet
been physically deleted (e.g. a crash window between `MoveToDeadLetter`
and `DeleteMailboxMessage` in `handlePoisonMessage`) would permanently
block every later same-key message even though the outer eligibility
predicate already excluded it from being re-leased. The anti-join now
carries `AND m2.attempts < m2.max_attempts` so its predicate agrees
with the outer eligibility predicate.

## Tests

Two layers cover the invariant. `db/actordelivery/correlation_key_test.go`
drives the SQL claim path directly with a test clock: the canonical
reorder reproduction (`TestPerKeyFIFOBlocksOvertakeOnNack`), cross-key
independence, unkeyed-lane orthogonality, ack-unblocks-key, mailbox
isolation, and the exhausted-predecessor regression test that fails
without the dead-letter-gap fix.

`db/actordelivery/durable_actor_reorder_test.go` exercises the same
invariant through a real `DurableActor` with a behavior that errors on
the first attempt and succeeds on retry, asserting emission order
survives transient failure end to end.

For the wrapper-forwarding fix,
`serverconn/actor_correlation_key_test.go` covers the four wrapper
branches (keyed inner, unkeyed inner, non-implementer post-decode, nil
`Message`) plus an integration test that drives a stamped
`SendClientEventRequest` through the `DurableActor` and asserts the
inner key reaches `EnqueueParams.CorrelationKey` at the store layer.
Without the forward the captured params carry an empty string and the
test fails.

## Test plan

- [x] `make unit pkg=./db/actordelivery/...`
- [x] `make unit pkg=./baselib/actor/...`
- [x] `make unit pkg=./serverconn/...`
- [x] `make lint-native`
- [x] Verified `TestPerKeyFIFOExhaustedPredecessorDoesNotBlockSuccessor`
      fails on the pre-fix SQL and passes with the anti-join attempts
      filter in place.
- [x] Verified `TestSendClientEventRequestPlumbsCorrelationKeyToStore`
      requires the wrapper forwarding hop to pass (empty inner key would
      land in the unkeyed lane).