### PR TITLE
p-models: add durable actor mailbox model

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -155,6 +155,51 @@ jobs:
         run: GOGC=50 make lint
 
   ########################
+  # P formal model check
+  ########################
+  p-model:
+    name: P durable mailbox model
+    runs-on: [self-hosted]
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v5
+
+      - name: Setup go ${{ env.GO_VERSION }}
+        uses: ./.github/actions/setup-go
+        with:
+          go-version: '${{ env.GO_VERSION }}'
+          key-prefix: p-model
+          use-build-cache: 'no'
+
+      # The self-hosted ARC runners cannot write to the default
+      # /usr/share/dotnet, so install the SDK under the writable runner temp
+      # dir. setup-dotnet honours DOTNET_INSTALL_DIR and adds it to PATH and
+      # DOTNET_ROOT for later steps.
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+        env:
+          DOTNET_INSTALL_DIR: ${{ runner.temp }}/dotnet
+
+      - name: Install P checker
+        run: |
+          dotnet tool install --global P --version 3.0.4
+          echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
+        env:
+          DOTNET_INSTALL_DIR: ${{ runner.temp }}/dotnet
+
+      # Compiles the P model, model-checks the green safety suite
+      # (tcMailboxCorrelationKeyFIFO) and the liveness property
+      # (tcMailboxLiveness), then replays the model traces against the real
+      # actordelivery SQLite store via the Go bridge. GOWORK is disabled so the
+      # bridge builds against the module exactly as an external consumer would.
+      - name: Check P model and bridge conformance
+        run: ./p-models/scripts/check.sh
+        env:
+          GOWORK: off
+
+  ########################
   # cross compilation
   ########################
   cross-compile:

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ go.work.sum
 .claude/worktrees/
 .claude/.substrate-plan-context
 .sessions/
+
+# P model generated artifacts.
+/PGenerated/
+/PCheckerOutput/

--- a/p-models/AGENTS.md
+++ b/p-models/AGENTS.md
@@ -1,0 +1,29 @@
+# p-models
+
+This tree contains executable P models and bridge checks. Keep model-specific
+files under a named subdirectory such as `durableactor/`; keep shared runner
+scripts under `scripts/`.
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `./p-models/scripts/check.sh` | Compile the durable actor model, run P checks, then run the Go bridge |
+| `p compile -pp p-models/durableactor/infra.pproj` | Compile only the durable actor P project |
+| `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcMailboxCorrelationKeyFIFO` | Run the default durable mailbox P test case |
+| `go test ./p-models/durableactor/bridge` | Replay checked-in traces against the real Go store |
+
+## Layout
+
+- `durableactor/` — durable actor mailbox model, tests, traces, and bridge.
+- `scripts/` — top-level orchestration scripts.
+- `PGenerated/` and `PCheckerOutput/` are generated at repo root and ignored.
+
+## Rules
+
+- Models should encode ideal contracts first, then implementation profiles.
+- Keep known-bad or counterexample tests as separate test cases so the default
+  suite stays green.
+- Bridge tests should exercise real Go code where possible instead of
+  reimplementing production semantics.
+- Add traces for every model scenario that should be replayed against Go.

--- a/p-models/CLAUDE.md
+++ b/p-models/CLAUDE.md
@@ -1,0 +1,29 @@
+# p-models
+
+This tree contains executable P models and bridge checks. Keep model-specific
+files under a named subdirectory such as `durableactor/`; keep shared runner
+scripts under `scripts/`.
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `./p-models/scripts/check.sh` | Compile the durable actor model, run P checks, then run the Go bridge |
+| `p compile -pp p-models/durableactor/infra.pproj` | Compile only the durable actor P project |
+| `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcMailboxCorrelationKeyFIFO` | Run the default durable mailbox P test case |
+| `go test ./p-models/durableactor/bridge` | Replay checked-in traces against the real Go store |
+
+## Layout
+
+- `durableactor/` — durable actor mailbox model, tests, traces, and bridge.
+- `scripts/` — top-level orchestration scripts.
+- `PGenerated/` and `PCheckerOutput/` are generated at repo root and ignored.
+
+## Rules
+
+- Models should encode ideal contracts first, then implementation profiles.
+- Keep known-bad or counterexample tests as separate test cases so the default
+  suite stays green.
+- Bridge tests should exercise real Go code where possible instead of
+  reimplementing production semantics.
+- Add traces for every model scenario that should be replayed against Go.

--- a/p-models/README.md
+++ b/p-models/README.md
@@ -1,0 +1,88 @@
+# P Models
+
+This directory holds executable P models for the parts of the system where
+ordinary unit tests have a hard time covering all interesting interleavings.
+
+P is a state machine modeling language for asynchronous systems. A P model is
+written as a set of machines that exchange events. The P checker then explores
+many possible event schedules, looking for assertion failures, monitor
+violations, deadlocks, or other illegal states. This is useful for darepo-client
+because several important correctness properties are not local to one function:
+they depend on the order in which messages are leased, retried, acknowledged,
+or observed by independent actors.
+
+The model should be read as an executable specification. It states the
+behavior we want first, then checks both the abstract model and bridge traces
+against that behavior. When a production bug is found, the goal is to encode
+the ideal invariant that would have rejected the bad execution, not just add a
+single regression test for the exact SQL row sequence.
+
+## Layout
+
+- `durableactor/` models the durable actor mailbox and the
+  per-correlation-key FIFO claim contract.
+- `durableactor/bridge/` replays checked-in traces against the real Go
+  `db/actordelivery` store so the model stays connected to the shipped
+  implementation.
+- `durableactor/traces/` stores concrete scenarios shared by the model
+  documentation and the Go bridge.
+- `scripts/` contains shared entrypoints for compiling and checking models.
+
+## Durable Actor Mailbox
+
+The durable actor mailbox model captures the semantics needed by the mailbox
+correlation-key ordering fix:
+
+- enqueue and duplicate enqueue idempotence
+- lease selection by mailbox, priority, availability, and row order
+- per-correlation-key FIFO blocking
+- ack, nack, lease expiry, and dead-letter removal
+- lease token ownership
+- retry exhaustion
+- independence between different mailboxes and different correlation keys
+
+The model keeps both the old and new claim rules. The old rule,
+`LegacyAvailableAtOrder`, demonstrates how a nacked predecessor in backoff can
+be overtaken by a later same-key successor. The new rule,
+`PerCorrelationKeyFIFO`, captures the intended invariant: a live predecessor
+for the same mailbox and correlation key blocks later same-key rows, even when
+the predecessor is leased or waiting for retry.
+
+## Running
+
+Run the current green suite with:
+
+```shell
+./p-models/scripts/check.sh
+```
+
+That script:
+
+1. compiles `p-models/durableactor/infra.pproj`;
+2. runs the default P testcase, `tcMailboxCorrelationKeyFIFO`;
+3. runs `go test ./p-models/durableactor/bridge`.
+
+To demonstrate that the model would have found the original same-key reorder
+bug, run the intentional negative testcase:
+
+```shell
+p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll \
+  --testcase tcMailboxLegacyReorderCounterexample \
+  --schedules 1 \
+  --max-steps 200
+```
+
+That check runs the ideal same-key FIFO property against the legacy claim rule
+and should report one bug. The default `check.sh` suite does not run this
+negative testcase because it is expected to fail.
+
+## Adding Models
+
+Keep new models focused on durable distributed-system invariants rather than
+implementation details that are already easy to cover with unit tests. Good
+model targets include ordering, ownership, retry, crash/restart, backpressure,
+and idempotence rules.
+
+When a model has a corresponding implementation path, add a bridge or trace
+replay test so the same scenario can exercise the real code. This keeps the P
+specification useful as the implementation evolves.

--- a/p-models/durableactor/AGENTS.md
+++ b/p-models/durableactor/AGENTS.md
@@ -1,0 +1,37 @@
+# p-models/durableactor
+
+This package models the durable actor mailbox from distributed-systems first
+principles: durable enqueue, lease ownership, retry scheduling, ack/nack token
+validation, dead-letter/removal, idempotent delivery identity, and
+per-correlation-key FIFO.
+
+## Files
+
+- `infra.pproj` — P project for durable actor infrastructure checks.
+- `src/mailbox_fifo.p` — ideal mailbox spec plus claim-ordering profiles.
+- `test/mailbox_fifo_test.p` — green conformance tests and separate
+  counterexample tests.
+- `traces/*.json` — concrete scenarios replayed by the Go bridge.
+- `bridge/` — Go conformance harness against the real `db/actordelivery`
+  SQLite store and claim SQL.
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `./p-models/scripts/check.sh` | Full default check: P model plus Go bridge |
+| `p compile -pp p-models/durableactor/infra.pproj` | Compile this model |
+| `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcMailboxCorrelationKeyFIFO` | Run green durable mailbox tests |
+| `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcMailboxLegacyReorderCounterexample` | Demonstrate the old ordering bug |
+| `go test ./p-models/durableactor/bridge` | Replay traces against Go |
+
+## Modeling Guidance
+
+- Treat the P model as the ideal specification; only add implementation modes
+  when they clarify a bug or migration path.
+- New correctness properties should usually be expressed both as a direct P
+  scenario and as a bridge trace.
+- Use `0` as the model's NULL correlation key. Non-zero keys are per-lane
+  FIFO domains scoped by mailbox id.
+- Keep the default test case green. Put intentional known-bad checks in a
+  separate test case with "Counterexample" in the name.

--- a/p-models/durableactor/CLAUDE.md
+++ b/p-models/durableactor/CLAUDE.md
@@ -1,0 +1,37 @@
+# p-models/durableactor
+
+This package models the durable actor mailbox from distributed-systems first
+principles: durable enqueue, lease ownership, retry scheduling, ack/nack token
+validation, dead-letter/removal, idempotent delivery identity, and
+per-correlation-key FIFO.
+
+## Files
+
+- `infra.pproj` — P project for durable actor infrastructure checks.
+- `src/mailbox_fifo.p` — ideal mailbox spec plus claim-ordering profiles.
+- `test/mailbox_fifo_test.p` — green conformance tests and separate
+  counterexample tests.
+- `traces/*.json` — concrete scenarios replayed by the Go bridge.
+- `bridge/` — Go conformance harness against the real `db/actordelivery`
+  SQLite store and claim SQL.
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `./p-models/scripts/check.sh` | Full default check: P model plus Go bridge |
+| `p compile -pp p-models/durableactor/infra.pproj` | Compile this model |
+| `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcMailboxCorrelationKeyFIFO` | Run green durable mailbox tests |
+| `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcMailboxLegacyReorderCounterexample` | Demonstrate the old ordering bug |
+| `go test ./p-models/durableactor/bridge` | Replay traces against Go |
+
+## Modeling Guidance
+
+- Treat the P model as the ideal specification; only add implementation modes
+  when they clarify a bug or migration path.
+- New correctness properties should usually be expressed both as a direct P
+  scenario and as a bridge trace.
+- Use `0` as the model's NULL correlation key. Non-zero keys are per-lane
+  FIFO domains scoped by mailbox id.
+- Keep the default test case green. Put intentional known-bad checks in a
+  separate test case with "Counterexample" in the name.

--- a/p-models/durableactor/README.md
+++ b/p-models/durableactor/README.md
@@ -1,0 +1,88 @@
+# Durable Mailbox P Models
+
+This directory contains a focused P model for the durable actor mailbox
+ordering rule introduced by the per-correlation-key FIFO claim path.
+
+The model is intentionally infrastructure-only. It captures the claim inputs
+that matter for the bug:
+
+- mailbox id
+- UUIDv7-like row id ordering
+- optional correlation key
+- priority
+- `available_at`
+- `lease_until`
+- `attempts` / `max_attempts`
+- `created_at`
+
+`src/mailbox_fifo.p` keeps both the old available-at ordering profile and the
+new per-correlation-key FIFO profile. It also includes a stateful
+`DurableMailboxSpec` machine with token ownership, lease expiry, nack retry,
+idempotent enqueue, ack deletion, and dead-letter removal semantics. The test
+suite proves that the legacy profile permits a same-key overtake after a
+nack/backoff, while the new profile blocks same-key overtakes without blocking
+other keys, other mailboxes, or unkeyed rows.
+
+### Spec monitors
+
+The model carries two spec monitors. P does **not** activate spec monitors
+globally; each test case attaches the ones it wants with `assert <spec> in
+{ ... }`.
+
+- `SameKeyFIFOClaimsRespectLiveHead` is the global safety contract. It
+  reconstructs the live per-lane row set from the enqueue/claim/removal stream
+  and, on every keyed claim, asserts that no earlier-id row in the same
+  `(mailbox_id, correlation_key)` lane is still live (present, with retry budget
+  remaining). This is stronger than checking that claim ids merely never go
+  backwards: the production failure mode (a successor claimed while an earlier
+  same-key row sits in nack/backoff) keeps claim ids monotonic, so a
+  backwards-only check would pass on the exact bug.
+  `tcMailboxMonitorCatchesLegacyReorder` runs the legacy reorder with **no**
+  in-machine assertion and is expected to fail solely on this monitor, proving
+  it catches the bug on its own.
+- `MailboxKeyedWorkEventuallyDrains` is the liveness half of the FIFO
+  trade-off: per-key blocking must delay, never permanently starve. The liveness
+  driver enqueues a same-key pair plus a cross-key row, then leases-and-acks in
+  a loop; a model in which a row could never be claimed would leave the monitor
+  hot forever. It is checked by `tcMailboxLiveness`.
+
+The Go bridge in `bridge/` replays JSON model traces from `traces/` against the real
+`db/actordelivery` SQLite store. This keeps the P model tied to the SQL claim
+implementation rather than only to a handwritten abstraction.
+
+### Trace authoring notes
+
+Two representational details matter when writing P scenarios or bridge traces:
+
+- **Backoff is absolute in P, relative in the bridge.** The P `nack` request
+  carries an absolute `available_at` timestamp, while the bridge `nack` op
+  carries a relative `retry_after` duration (seconds added to the current
+  clock). The two express the same backoff; they are not interchangeable field
+  values, so port a scenario by recomputing the delay, not by copying the
+  number.
+- **Keep `created_at` unique within a lane.** The claim order mirrors the SQL
+  `ORDER BY m.priority DESC, m.available_at ASC, m.created_at ASC`. The model
+  adds a final `id` tie-breaker only for determinism (the SQL leaves
+  equal-`created_at` ties unordered). Giving each row a distinct `created_at`
+  keeps the model and the SQL congruent and avoids relying on that fallback.
+
+## Run
+
+```shell
+./p-models/scripts/check.sh
+```
+
+The script compiles `durableactor/infra.pproj`, checks
+`tcMailboxCorrelationKeyFIFO`, then runs the Go bridge tests.
+
+To demonstrate that the model would have found the original bug, run:
+
+```shell
+p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll \
+  --testcase tcMailboxLegacyReorderCounterexample \
+  --schedules 1 \
+  --max-steps 200
+```
+
+That intentionally checks the ideal same-key FIFO property against the legacy
+available-at claim profile and should report one bug.

--- a/p-models/durableactor/bridge/mailbox_trace.go
+++ b/p-models/durableactor/bridge/mailbox_trace.go
@@ -1,0 +1,338 @@
+package bridge
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/db/actordelivery"
+	"github.com/lightninglabs/darepo-client/db/sqlc"
+	"github.com/lightningnetwork/lnd/clock"
+	_ "modernc.org/sqlite"
+)
+
+// MailboxTrace is a model trace that can be replayed against the real durable
+// actor delivery store. These traces mirror the P model scenarios in
+// mailbox_fifo_test.p and keep the formal abstraction tied to the SQL claim
+// implementation.
+type MailboxTrace struct {
+	TraceID     string              `json:"trace_id"`
+	Description string              `json:"description"`
+	Events      []MailboxTraceEvent `json:"events"`
+}
+
+// MailboxTraceEvent describes one store operation in a mailbox trace.
+type MailboxTraceEvent struct {
+	Op             string `json:"op"`
+	ID             string `json:"id,omitempty"`
+	MailboxID      string `json:"mailbox_id,omitempty"`
+	CorrelationKey string `json:"correlation_key,omitempty"`
+	LeaseToken     string `json:"lease_token,omitempty"`
+	ExpectID       string `json:"expect_id,omitempty"`
+	Payload        string `json:"payload,omitempty"`
+	ExpectPayload  string `json:"expect_payload,omitempty"`
+	FailureReason  string `json:"failure_reason,omitempty"`
+	Now            *int64 `json:"now,omitempty"`
+	AvailableAt    int64  `json:"available_at,omitempty"`
+	RetryAfter     int64  `json:"retry_after,omitempty"`
+	LeaseDuration  int64  `json:"lease_duration,omitempty"`
+	MaxAttempts    int    `json:"max_attempts,omitempty"`
+	Priority       int    `json:"priority,omitempty"`
+	ExpectRows     *int64 `json:"expect_rows,omitempty"`
+
+	// ExpectDuplicate marks an enqueue op whose id already exists.
+	// Production EnqueueMessage is idempotent by durable id, so a duplicate
+	// must be a no-op that returns no error. Setting this makes the trace
+	// assert that intent at the enqueue step itself, rather than relying
+	// solely on a downstream lease assertion to observe the no-op.
+	ExpectDuplicate bool `json:"expect_duplicate,omitempty"`
+}
+
+// ParseMailboxTrace parses one mailbox model trace from disk.
+func ParseMailboxTrace(path string) (*MailboxTrace, error) {
+	//nolint:gosec // Reads checked-in bridge trace files only.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read mailbox trace: %w", err)
+	}
+
+	var trace MailboxTrace
+	if err := json.Unmarshal(data, &trace); err != nil {
+		return nil, fmt.Errorf("parse mailbox trace: %w", err)
+	}
+
+	if trace.TraceID == "" {
+		return nil, fmt.Errorf("mailbox trace missing trace_id")
+	}
+
+	return &trace, nil
+}
+
+// ParseMailboxTraceDir parses all mailbox model traces from dir.
+func ParseMailboxTraceDir(dir string) ([]*MailboxTrace, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("read mailbox trace dir: %w", err)
+	}
+
+	traces := make([]*MailboxTrace, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+
+		trace, err := ParseMailboxTrace(
+			filepath.Join(
+				dir, entry.Name(),
+			),
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		traces = append(traces, trace)
+	}
+
+	sort.Slice(traces, func(i, j int) bool {
+		return traces[i].TraceID < traces[j].TraceID
+	})
+
+	return traces, nil
+}
+
+// ReplayMailboxTrace replays a mailbox trace against the production SQLite
+// actor-delivery store.
+func ReplayMailboxTrace(t *testing.T, trace *MailboxTrace) {
+	t.Helper()
+
+	rawDB := newSQLiteDB(t)
+	requireNoError(
+		t, actordelivery.RunMigrations(
+			rawDB, sqlc.BackendTypeSqlite,
+		),
+	)
+
+	clk := clock.NewTestClock(traceTime(0))
+	store, err := actordelivery.NewTxAwareDeliveryStoreFromDB(
+		rawDB, sqlc.BackendTypeSqlite, clk, btclog.Disabled,
+	)
+	requireNoError(t, err)
+
+	for i, event := range trace.Events {
+		if event.Now != nil {
+			clk.SetTime(traceTime(*event.Now))
+		}
+
+		switch event.Op {
+		case "enqueue":
+			replayEnqueue(t, store, event)
+
+		case "lease":
+			replayLease(t, store, event)
+
+		case "nack":
+			replayNack(t, store, event)
+
+		case "ack":
+			replayAck(t, store, event)
+
+		case "dead_letter":
+			replayDeadLetter(t, store, event)
+
+		case "expire_leases":
+			replayExpireLeases(t, store)
+
+		default:
+			t.Fatalf("trace %s event %d: unknown op %q",
+				trace.TraceID, i, event.Op)
+		}
+	}
+}
+
+func replayEnqueue(t *testing.T, store actor.TxAwareDeliveryStore,
+	event MailboxTraceEvent) {
+
+	t.Helper()
+
+	maxAttempts := event.MaxAttempts
+	if maxAttempts == 0 {
+		maxAttempts = 3
+	}
+
+	payload := event.Payload
+	if payload == "" {
+		payload = event.ID
+	}
+
+	err := store.EnqueueMessage(
+		t.Context(), actor.EnqueueParams{
+			ID:             event.ID,
+			MailboxID:      event.MailboxID,
+			MessageType:    "model.TraceMsg",
+			Payload:        []byte(payload),
+			Priority:       event.Priority,
+			AvailableAt:    traceTime(event.AvailableAt),
+			MaxAttempts:    maxAttempts,
+			CorrelationKey: event.CorrelationKey,
+		},
+	)
+
+	// A duplicate enqueue must be a silent no-op rather than an error, so a
+	// future change that made EnqueueMessage reject duplicates fails here
+	// with a duplicate-specific message instead of at some later lease
+	// step.
+	if event.ExpectDuplicate {
+		if err != nil {
+			t.Fatalf("duplicate enqueue of %s expected to be an "+
+				"idempotent no-op, got error: %v", event.ID,
+				err)
+		}
+
+		return
+	}
+
+	requireNoError(t, err)
+}
+
+func replayLease(t *testing.T, store actor.TxAwareDeliveryStore,
+	event MailboxTraceEvent) {
+
+	t.Helper()
+
+	leaseDuration := time.Minute
+	if event.LeaseDuration != 0 {
+		leaseDuration = time.Duration(event.LeaseDuration) * time.Second
+	}
+
+	leased, err := store.LeaseNextMessage(
+		t.Context(), event.MailboxID, event.LeaseToken, leaseDuration,
+	)
+	requireNoError(t, err)
+
+	if event.ExpectID == "" {
+		if leased != nil {
+			t.Fatalf("expected no leased row, got %s", leased.ID)
+		}
+
+		return
+	}
+
+	if leased == nil {
+		t.Fatalf("expected leased row %s, got nil", event.ExpectID)
+	}
+
+	if leased.ID != event.ExpectID {
+		t.Fatalf("expected leased row %s, got %s", event.ExpectID,
+			leased.ID)
+	}
+
+	if event.ExpectPayload != "" &&
+		string(leased.Payload) != event.ExpectPayload {
+
+		t.Fatalf("expected leased payload %q, got %q",
+			event.ExpectPayload, string(leased.Payload))
+	}
+}
+
+func replayNack(t *testing.T, store actor.TxAwareDeliveryStore,
+	event MailboxTraceEvent) {
+
+	t.Helper()
+
+	rows, err := store.NackMessage(
+		t.Context(), event.ID, event.LeaseToken,
+		time.Duration(event.RetryAfter)*time.Second,
+	)
+	requireNoError(t, err)
+	requireExpectedRows(t, rows, event, "nack")
+}
+
+func replayAck(t *testing.T, store actor.TxAwareDeliveryStore,
+	event MailboxTraceEvent) {
+
+	t.Helper()
+
+	rows, err := store.AckMessage(
+		t.Context(), event.ID, event.LeaseToken,
+	)
+	requireNoError(t, err)
+	requireExpectedRows(t, rows, event, "ack")
+}
+
+func replayDeadLetter(t *testing.T, store actor.TxAwareDeliveryStore,
+	event MailboxTraceEvent) {
+
+	t.Helper()
+
+	reason := event.FailureReason
+	if reason == "" {
+		reason = "model trace dead letter"
+	}
+
+	requireNoError(t, store.MoveToDeadLetter(t.Context(), event.ID, reason))
+
+	deadLetter, err := store.GetDeadLetter(t.Context(), event.ID)
+	requireNoError(t, err)
+	if deadLetter == nil {
+		t.Fatalf("expected dead letter %s, got nil", event.ID)
+	}
+
+	if deadLetter.FailureReason != reason {
+		t.Fatalf("expected dead letter reason %q, got %q", reason,
+			deadLetter.FailureReason)
+	}
+}
+
+func replayExpireLeases(t *testing.T, store actor.TxAwareDeliveryStore) {
+	t.Helper()
+
+	requireNoError(t, store.ExpireLeases(t.Context()))
+}
+
+func newSQLiteDB(t *testing.T) *sql.DB {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "mailbox-bridge.db")
+	rawDB, err := sql.Open("sqlite", path)
+	requireNoError(t, err)
+
+	t.Cleanup(func() {
+		requireNoError(t, rawDB.Close())
+	})
+
+	return rawDB
+}
+
+func traceTime(seconds int64) time.Time {
+	return time.Unix(1_700_000_000+seconds, 0)
+}
+
+func requireNoError(t *testing.T, err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func requireExpectedRows(t *testing.T, rows int64, event MailboxTraceEvent,
+	op string) {
+
+	t.Helper()
+
+	expected := int64(1)
+	if event.ExpectRows != nil {
+		expected = *event.ExpectRows
+	}
+
+	if rows != expected {
+		t.Fatalf("%s affected %d rows, expected %d", op, rows, expected)
+	}
+}

--- a/p-models/durableactor/bridge/mailbox_trace_test.go
+++ b/p-models/durableactor/bridge/mailbox_trace_test.go
@@ -1,0 +1,26 @@
+package bridge
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestReplayMailboxModelTraces replays the checked-in P-model scenarios
+// against the real actor-delivery SQLite store and claim SQL.
+func TestReplayMailboxModelTraces(t *testing.T) {
+	traces, err := ParseMailboxTraceDir(filepath.Join("..", "traces"))
+	if err != nil {
+		t.Fatalf("parse mailbox traces: %v", err)
+	}
+
+	if len(traces) == 0 {
+		t.Fatal("no mailbox traces found")
+	}
+
+	for _, trace := range traces {
+		trace := trace
+		t.Run(trace.TraceID, func(t *testing.T) {
+			ReplayMailboxTrace(t, trace)
+		})
+	}
+}

--- a/p-models/durableactor/infra.pproj
+++ b/p-models/durableactor/infra.pproj
@@ -1,0 +1,8 @@
+<Project>
+<ProjectName>MailboxInfraModels</ProjectName>
+<InputFiles>
+<PFile>src/mailbox_fifo.p</PFile>
+<PFile>test/mailbox_fifo_test.p</PFile>
+</InputFiles>
+<OutputDir>PGenerated</OutputDir>
+</Project>

--- a/p-models/durableactor/src/mailbox_fifo.p
+++ b/p-models/durableactor/src/mailbox_fifo.p
@@ -1,0 +1,639 @@
+// mailbox_fifo.p - Durable actor mailbox specification model.
+//
+// Distributed-systems contract, not just a regression:
+//
+//   * Enqueue is durable and idempotent by message id.
+//   * Lease grants one temporary processing owner identified by a token.
+//   * Ack/Nack/Extend require the current token; stale owners cannot commit.
+//   * Lease expiry returns the same row to the available set for at-least-once
+//     delivery.
+//   * Nack does not remove the row; it schedules retry by moving available_at.
+//   * Exhausted rows are no longer live predecessors for FIFO blocking.
+//   * Per-correlation-key FIFO is a liveness-preserving compromise: only live
+//     same-key predecessors block, so a stuck round/session does not stop the
+//     entire actor mailbox.
+//
+// The key value 0 represents SQL NULL / unkeyed.
+
+enum MailboxClaimMode {
+    LegacyAvailableAtOrder,
+    PerCorrelationKeyFIFO
+}
+
+enum DurableMailboxOpResult {
+    MailboxOpOk,
+    MailboxOpDuplicate,
+    MailboxOpTokenMismatch,
+    MailboxOpNotFound
+}
+
+type MailboxRow = (
+    id: int,
+    mailbox_id: int,
+    correlation_key: int,
+    priority: int,
+    available_at: int,
+    lease_until: int,
+    lease_token: int,
+    attempts: int,
+    max_attempts: int,
+    created_at: int
+);
+
+type DurableMailboxEnqueueReq = (
+    reply_to: machine,
+    row: MailboxRow
+);
+
+type DurableMailboxLeaseNextReq = (
+    reply_to: machine,
+    mailbox_id: int,
+    lease_token: int,
+    now: int,
+    lease_duration: int
+);
+
+type DurableMailboxTokenReq = (
+    reply_to: machine,
+    id: int,
+    lease_token: int
+);
+
+type DurableMailboxNackReq = (
+    reply_to: machine,
+    id: int,
+    lease_token: int,
+    available_at: int
+);
+
+// DurableMailboxDeadLetterReq carries no lease token: production
+// MoveToDeadLetter(ctx, id, reason) addresses the row by id alone. The
+// canonical dead-letter target is a retry-exhausted row, and a row only
+// becomes exhausted by being leased/nacked, which clears its lease token.
+// Gating dead-letter on the token would therefore make it unreachable for
+// exactly the rows it exists to remove.
+type DurableMailboxDeadLetterReq = (
+    reply_to: machine,
+    id: int
+);
+
+event eDurableMailboxEnqueue: DurableMailboxEnqueueReq;
+event eDurableMailboxLeaseNext: DurableMailboxLeaseNextReq;
+event eDurableMailboxAck: DurableMailboxTokenReq;
+event eDurableMailboxNack: DurableMailboxNackReq;
+event eDurableMailboxExpireLeasesAt: int;
+event eDurableMailboxDeadLetter: DurableMailboxDeadLetterReq;
+
+event eDurableMailboxOpResp: (int, DurableMailboxOpResult);
+event eDurableMailboxLeaseResp: (int, DurableMailboxOpResult);
+
+// eDurableMailboxClaimed is announced on every successful lease.
+// eDurableMailboxRowEnqueued and eDurableMailboxRowRemoved let the FIFO monitor
+// reconstruct the live per-lane row set (and each row's remaining retry budget)
+// so it can check the per-correlation-key ordering contract independently of
+// any in-machine assertion. Every event carries the announcing mailbox machine
+// (mbox) as its first field: a single test case can instantiate many
+// DurableMailboxSpec machines that reuse the same row ids, so the monitor must
+// namespace its state by the originating mailbox instance. The payloads are:
+//
+//   eDurableMailboxClaimed:     (mbox, id, mailbox_id, correlation_key)
+//   eDurableMailboxRowEnqueued: (mbox, id, mailbox_id, correlation_key,
+//                                attempts, max_attempts)
+//   eDurableMailboxRowRemoved:  (mbox, id)
+event eDurableMailboxClaimed: (machine, int, int, int);
+event eDurableMailboxRowEnqueued: (machine, int, int, int, int, int);
+event eDurableMailboxRowRemoved: (machine, int);
+
+// eMailboxWorkArrived and eMailboxWorkDrained are emitted only by the liveness
+// driver to feed the non-starvation liveness monitor. Keeping them distinct
+// from the row lifecycle events means the liveness monitor stays inert in the
+// safety test cases that intentionally leave rows outstanding.
+event eMailboxWorkArrived;
+event eMailboxWorkDrained;
+
+fun NoMailboxRow(): int {
+    return 0;
+}
+
+fun NoLease(): int {
+    return -1;
+}
+
+fun NoLeaseToken(): int {
+    return 0;
+}
+
+fun NullCorrelationKey(): int {
+    return 0;
+}
+
+fun NewMailboxRow(id: int, mailbox_id: int, correlation_key: int,
+    priority: int, available_at: int, lease_until: int, lease_token: int,
+    attempts: int, max_attempts: int, created_at: int): MailboxRow {
+
+    return (
+        id = id,
+        mailbox_id = mailbox_id,
+        correlation_key = correlation_key,
+        priority = priority,
+        available_at = available_at,
+        lease_until = lease_until,
+        lease_token = lease_token,
+        attempts = attempts,
+        max_attempts = max_attempts,
+        created_at = created_at
+    );
+}
+
+fun RowHasRetryBudget(row: MailboxRow): bool {
+    return row.attempts < row.max_attempts;
+}
+
+fun RowLeaseIsAvailable(row: MailboxRow, now: int): bool {
+    return row.lease_until == NoLease() || row.lease_until < now;
+}
+
+fun RowIsClaimVisible(row: MailboxRow, mailbox_id: int, now: int): bool {
+    return row.mailbox_id == mailbox_id &&
+           row.available_at <= now &&
+           RowLeaseIsAvailable(row, now) &&
+           RowHasRetryBudget(row);
+}
+
+fun HasEarlierLiveSameKey(rows: seq[MailboxRow], row: MailboxRow): bool {
+    var i: int;
+    var pred: MailboxRow;
+
+    if (row.correlation_key == NullCorrelationKey()) {
+        return false;
+    }
+
+    i = 0;
+    while (i < sizeof(rows)) {
+        pred = rows[i];
+
+        if (pred.mailbox_id == row.mailbox_id &&
+            pred.correlation_key == row.correlation_key &&
+            pred.id < row.id &&
+            RowHasRetryBudget(pred)) {
+
+            return true;
+        }
+
+        i = i + 1;
+    }
+
+    return false;
+}
+
+fun RowEligibleUnderMode(rows: seq[MailboxRow], row: MailboxRow,
+    mailbox_id: int, now: int, mode: MailboxClaimMode): bool {
+
+    if (!RowIsClaimVisible(row, mailbox_id, now)) {
+        return false;
+    }
+
+    if (mode == PerCorrelationKeyFIFO &&
+        HasEarlierLiveSameKey(rows, row)) {
+
+        return false;
+    }
+
+    return true;
+}
+
+// RowOrdersBefore mirrors the claim query's tie-breaking. The production SQL
+// orders eligible rows by:
+//
+//   ORDER BY m.priority DESC, m.available_at ASC, m.created_at ASC
+//
+// (see db/actordelivery/queries/mailbox.sql). Those three axes are reproduced
+// exactly here. The trailing id comparison is a model-only final tie-breaker:
+// the SQL leaves rows that tie on (priority, available_at, created_at)
+// unordered under LIMIT 1, whereas P requires a deterministic choice. The
+// bridge traces keep created_at unique among same-(priority, available_at)
+// rows, so the id fallback never disagrees with the SQL in practice.
+fun RowOrdersBefore(row: MailboxRow, candidate: MailboxRow): bool {
+    if (row.priority > candidate.priority) {
+        return true;
+    }
+
+    if (row.priority < candidate.priority) {
+        return false;
+    }
+
+    if (row.available_at < candidate.available_at) {
+        return true;
+    }
+
+    if (row.available_at > candidate.available_at) {
+        return false;
+    }
+
+    if (row.created_at < candidate.created_at) {
+        return true;
+    }
+
+    if (row.created_at > candidate.created_at) {
+        return false;
+    }
+
+    return row.id < candidate.id;
+}
+
+fun ClaimNextMailboxRow(rows: seq[MailboxRow], mailbox_id: int, now: int,
+    mode: MailboxClaimMode): int {
+
+    var i: int;
+    var row: MailboxRow;
+    var candidate: MailboxRow;
+    var found: bool;
+
+    i = 0;
+    while (i < sizeof(rows)) {
+        row = rows[i];
+
+        if (RowEligibleUnderMode(rows, row, mailbox_id, now, mode)) {
+            if (!found || RowOrdersBefore(row, candidate)) {
+                found = true;
+                candidate = row;
+            }
+        }
+
+        i = i + 1;
+    }
+
+    if (!found) {
+        return NoMailboxRow();
+    }
+
+    return candidate.id;
+}
+
+fun RowExists(rows: seq[MailboxRow], id: int): bool {
+    var i: int;
+
+    i = 0;
+    while (i < sizeof(rows)) {
+        if (rows[i].id == id) {
+            return true;
+        }
+
+        i = i + 1;
+    }
+
+    return false;
+}
+
+fun RowByID(rows: seq[MailboxRow], id: int): MailboxRow {
+    var i: int;
+
+    i = 0;
+    while (i < sizeof(rows)) {
+        if (rows[i].id == id) {
+            return rows[i];
+        }
+
+        i = i + 1;
+    }
+
+    // Callers must guard RowByID with RowExists. The sentinel is only here
+    // to satisfy P's total-function requirement.
+    return NewMailboxRow(
+        NoMailboxRow(), 0, NullCorrelationKey(), 0, 0, NoLease(),
+        NoLeaseToken(), 0, 0, 0
+    );
+}
+
+fun RemoveMailboxRow(rows: seq[MailboxRow], id: int): seq[MailboxRow] {
+    var result: seq[MailboxRow];
+    var i: int;
+
+    i = 0;
+    while (i < sizeof(rows)) {
+        if (rows[i].id != id) {
+            result += (sizeof(result), rows[i]);
+        }
+
+        i = i + 1;
+    }
+
+    return result;
+}
+
+fun ReplaceMailboxRow(rows: seq[MailboxRow], row: MailboxRow):
+    seq[MailboxRow] {
+
+    var result: seq[MailboxRow];
+    var i: int;
+
+    i = 0;
+    while (i < sizeof(rows)) {
+        if (rows[i].id == row.id) {
+            result += (sizeof(result), row);
+        } else {
+            result += (sizeof(result), rows[i]);
+        }
+
+        i = i + 1;
+    }
+
+    return result;
+}
+
+// LeaseMailboxRow grants a lease and increments attempts. attempts counts
+// lease grants, not processing failures: the production LeaseNextMessage does
+// attempts = attempts + 1 in the same UPDATE that sets the lease token (see
+// db/actordelivery/queries/mailbox.sql). A row that is leased max_attempts
+// times is therefore exhausted even if every lease was followed by an honest
+// nack, which is why exhaustion is keyed on lease count here.
+fun LeaseMailboxRow(rows: seq[MailboxRow], id: int, lease_token: int,
+    lease_until: int): seq[MailboxRow] {
+
+    var row: MailboxRow;
+
+    row = RowByID(rows, id);
+    row = NewMailboxRow(
+        row.id, row.mailbox_id, row.correlation_key, row.priority,
+        row.available_at, lease_until, lease_token, row.attempts + 1,
+        row.max_attempts, row.created_at
+    );
+
+    return ReplaceMailboxRow(rows, row);
+}
+
+fun NackMailboxRow(rows: seq[MailboxRow], id: int, available_at: int):
+    seq[MailboxRow] {
+
+    var row: MailboxRow;
+
+    row = RowByID(rows, id);
+    row = NewMailboxRow(
+        row.id, row.mailbox_id, row.correlation_key, row.priority,
+        available_at, NoLease(), NoLeaseToken(), row.attempts,
+        row.max_attempts, row.created_at
+    );
+
+    return ReplaceMailboxRow(rows, row);
+}
+
+fun ExpireMailboxLeases(rows: seq[MailboxRow], now: int): seq[MailboxRow] {
+    var result: seq[MailboxRow];
+    var i: int;
+    var row: MailboxRow;
+
+    i = 0;
+    while (i < sizeof(rows)) {
+        row = rows[i];
+        if (row.lease_until != NoLease() && row.lease_until < now) {
+            row = NewMailboxRow(
+                row.id, row.mailbox_id, row.correlation_key,
+                row.priority, row.available_at, NoLease(),
+                NoLeaseToken(), row.attempts, row.max_attempts,
+                row.created_at
+            );
+        }
+
+        result += (sizeof(result), row);
+        i = i + 1;
+    }
+
+    return result;
+}
+
+fun TokenMatches(row: MailboxRow, lease_token: int): bool {
+    return row.lease_token != NoLeaseToken() &&
+           row.lease_token == lease_token;
+}
+
+// DurableMailboxSpec is the idealized persistent mailbox. It is deliberately
+// single-mailbox-table rather than single-actor: scoping by mailbox_id is part
+// of the invariant under test.
+machine DurableMailboxSpec {
+    var rows: seq[MailboxRow];
+    var mode: MailboxClaimMode;
+
+    start state Active {
+        entry (claim_mode: MailboxClaimMode) {
+            mode = claim_mode;
+        }
+
+        on eDurableMailboxEnqueue do (req: DurableMailboxEnqueueReq) {
+            if (RowExists(rows, req.row.id)) {
+                send req.reply_to, eDurableMailboxOpResp,
+                    (req.row.id, MailboxOpDuplicate);
+                return;
+            }
+
+            rows += (sizeof(rows), req.row);
+            announce eDurableMailboxRowEnqueued, (
+                this, req.row.id, req.row.mailbox_id,
+                req.row.correlation_key, req.row.attempts,
+                req.row.max_attempts
+            );
+            send req.reply_to, eDurableMailboxOpResp,
+                (req.row.id, MailboxOpOk);
+        }
+
+        on eDurableMailboxLeaseNext do (
+            req: DurableMailboxLeaseNextReq
+        ) {
+            var id: int;
+            var row: MailboxRow;
+
+            id = ClaimNextMailboxRow(
+                rows, req.mailbox_id, req.now, mode
+            );
+            if (id == NoMailboxRow()) {
+                send req.reply_to, eDurableMailboxLeaseResp,
+                    (NoMailboxRow(), MailboxOpNotFound);
+                return;
+            }
+
+            row = RowByID(rows, id);
+            rows = LeaseMailboxRow(
+                rows, id, req.lease_token,
+                req.now + req.lease_duration
+            );
+
+            announce eDurableMailboxClaimed,
+                (this, row.id, row.mailbox_id, row.correlation_key);
+            send req.reply_to, eDurableMailboxLeaseResp,
+                (id, MailboxOpOk);
+        }
+
+        on eDurableMailboxAck do (req: DurableMailboxTokenReq) {
+            var row: MailboxRow;
+
+            if (!RowExists(rows, req.id)) {
+                send req.reply_to, eDurableMailboxOpResp,
+                    (req.id, MailboxOpNotFound);
+                return;
+            }
+
+            row = RowByID(rows, req.id);
+            if (!TokenMatches(row, req.lease_token)) {
+                send req.reply_to, eDurableMailboxOpResp,
+                    (req.id, MailboxOpTokenMismatch);
+                return;
+            }
+
+            rows = RemoveMailboxRow(rows, req.id);
+            announce eDurableMailboxRowRemoved, (this, req.id);
+            send req.reply_to, eDurableMailboxOpResp,
+                (req.id, MailboxOpOk);
+        }
+
+        on eDurableMailboxNack do (req: DurableMailboxNackReq) {
+            var row: MailboxRow;
+
+            if (!RowExists(rows, req.id)) {
+                send req.reply_to, eDurableMailboxOpResp,
+                    (req.id, MailboxOpNotFound);
+                return;
+            }
+
+            row = RowByID(rows, req.id);
+            if (!TokenMatches(row, req.lease_token)) {
+                send req.reply_to, eDurableMailboxOpResp,
+                    (req.id, MailboxOpTokenMismatch);
+                return;
+            }
+
+            rows = NackMailboxRow(rows, req.id, req.available_at);
+            send req.reply_to, eDurableMailboxOpResp,
+                (req.id, MailboxOpOk);
+        }
+
+        on eDurableMailboxExpireLeasesAt do (now: int) {
+            rows = ExpireMailboxLeases(rows, now);
+        }
+
+        // Dead-letter removes a row by id, with no lease-token check, matching
+        // production MoveToDeadLetter(ctx, id, reason). This is the path the
+        // durable actor takes for a retry-exhausted row, whose lease token has
+        // already been cleared by the preceding nack.
+        on eDurableMailboxDeadLetter do (req: DurableMailboxDeadLetterReq) {
+            if (!RowExists(rows, req.id)) {
+                send req.reply_to, eDurableMailboxOpResp,
+                    (req.id, MailboxOpNotFound);
+                return;
+            }
+
+            rows = RemoveMailboxRow(rows, req.id);
+            announce eDurableMailboxRowRemoved, (this, req.id);
+            send req.reply_to, eDurableMailboxOpResp,
+                (req.id, MailboxOpOk);
+        }
+    }
+}
+
+// SameKeyFIFOClaimsRespectLiveHead is the global safety contract for the
+// per-correlation-key FIFO rule. It reconstructs the live per-lane row set from
+// the enqueue/claim/removal stream and, on every keyed claim, asserts that no
+// earlier-id row in the same (mailbox_id, correlation_key) lane is still live
+// (present and with retry budget remaining).
+//
+// This is strictly stronger than asserting claim ids are merely non-decreasing
+// per lane. The production failure mode is a successor claimed while an
+// earlier same-key row sits in nack/backoff: the claim ids 1 then 2 are
+// non-decreasing, so a backwards-only check passes on the exact bug. Tracking
+// liveness lets the monitor reject that claim directly, independent of any
+// in-machine assertion. attempts are tracked the way LeaseMailboxRow updates
+// them (one increment per claim), so an exhausted predecessor correctly stops
+// blocking, matching the SQL anti-join's m2.attempts < m2.max_attempts.
+spec SameKeyFIFOClaimsRespectLiveHead observes
+    eDurableMailboxRowEnqueued, eDurableMailboxClaimed,
+    eDurableMailboxRowRemoved {
+
+    // State is namespaced by (mbox, id): the originating mailbox machine plus
+    // the row id. rowLane maps that key to its (mailbox_id, correlation_key).
+    var rowPresent: map[(machine, int), bool];
+    var rowLane: map[(machine, int), (int, int)];
+    var rowClaims: map[(machine, int), int];
+    var rowMax: map[(machine, int), int];
+
+    start state Monitoring {
+        on eDurableMailboxRowEnqueued do (
+            row: (machine, int, int, int, int, int)
+        ) {
+            var key: (machine, int);
+
+            key = (row.0, row.1);
+            rowPresent[key] = true;
+            rowLane[key] = (row.2, row.3);
+            rowClaims[key] = row.4;
+            rowMax[key] = row.5;
+        }
+
+        on eDurableMailboxClaimed do (claim: (machine, int, int, int)) {
+            var lane: (int, int);
+            var key: (machine, int);
+            var pred: (machine, int);
+
+            key = (claim.0, claim.1);
+
+            if (claim.3 != NullCorrelationKey()) {
+                lane = (claim.2, claim.3);
+                foreach (pred in keys(rowPresent)) {
+                    if (pred.0 == claim.0 && rowPresent[pred] &&
+                        pred.1 < claim.1 && rowLane[pred] == lane &&
+                        rowClaims[pred] < rowMax[pred]) {
+
+                        assert false,
+                            "same-key claim overtook a live earlier "+
+                            "head-of-line row";
+                    }
+                }
+            }
+
+            // Mirror LeaseMailboxRow: a claim consumes one retry attempt.
+            if (key in rowClaims) {
+                rowClaims[key] = rowClaims[key] + 1;
+            }
+        }
+
+        on eDurableMailboxRowRemoved do (removed: (machine, int)) {
+            if (removed in rowPresent) {
+                rowPresent[removed] = false;
+            }
+        }
+    }
+}
+
+// MailboxKeyedWorkEventuallyDrains is the liveness half of the per-key FIFO
+// trade-off: per-correlation-key blocking must delay, never permanently starve.
+// The liveness driver announces eMailboxWorkArrived for each enqueued row and
+// eMailboxWorkDrained for each row it leases-and-acks. While any announced row
+// is still outstanding the monitor sits in the hot Draining state, so a model
+// in which an eligible row could never be claimed would leave the monitor hot
+// forever and fail the liveness check. Only the liveness driver emits these
+// events, so safety test cases that intentionally leave rows outstanding keep
+// this monitor inert in its cold start state.
+spec MailboxKeyedWorkEventuallyDrains observes
+    eMailboxWorkArrived, eMailboxWorkDrained {
+
+    var outstanding: int;
+
+    start cold state Idle {
+        ignore eMailboxWorkDrained;
+
+        on eMailboxWorkArrived do {
+            outstanding = outstanding + 1;
+            goto Draining;
+        }
+    }
+
+    hot state Draining {
+        on eMailboxWorkArrived do {
+            outstanding = outstanding + 1;
+        }
+
+        on eMailboxWorkDrained do {
+            outstanding = outstanding - 1;
+            if (outstanding == 0) {
+                goto Idle;
+            }
+        }
+    }
+}

--- a/p-models/durableactor/test/mailbox_fifo_test.p
+++ b/p-models/durableactor/test/mailbox_fifo_test.p
@@ -1,0 +1,918 @@
+// mailbox_fifo_test.p - Durable mailbox specification tests.
+
+machine TestMailboxFIFO_LegacyAvailableAtCanReorder {
+    start state Init {
+        entry {
+            var rows: seq[MailboxRow];
+            var claim_id: int;
+
+            rows += (sizeof(rows), NewMailboxRow(
+                1, 10, 100, 0, 5, NoLease(), NoLeaseToken(), 1, 3, 0
+            ));
+            rows += (sizeof(rows), NewMailboxRow(
+                2, 10, 100, 0, 1, NoLease(), NoLeaseToken(), 0, 3, 1
+            ));
+
+            claim_id = ClaimNextMailboxRow(
+                rows, 10, 1, LegacyAvailableAtOrder
+            );
+
+            assert claim_id == 2,
+                "legacy available_at ordering permits same-key overtake";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+machine TestMailboxFIFO_BlocksSameKeyBackoffOvertake {
+    start state Init {
+        entry {
+            var rows: seq[MailboxRow];
+            var claim_id: int;
+
+            rows += (sizeof(rows), NewMailboxRow(
+                1, 10, 100, 0, 5, NoLease(), NoLeaseToken(), 1, 3, 0
+            ));
+            rows += (sizeof(rows), NewMailboxRow(
+                2, 10, 100, 0, 1, NoLease(), NoLeaseToken(), 0, 3, 1
+            ));
+
+            claim_id = ClaimNextMailboxRow(
+                rows, 10, 1, PerCorrelationKeyFIFO
+            );
+            assert claim_id == NoMailboxRow(),
+                "same-key successor must wait behind backoff predecessor";
+
+            claim_id = ClaimNextMailboxRow(
+                rows, 10, 5, PerCorrelationKeyFIFO
+            );
+            assert claim_id == 1,
+                "backoff predecessor must claim before same-key successor";
+
+            rows = RemoveMailboxRow(rows, 1);
+            claim_id = ClaimNextMailboxRow(
+                rows, 10, 5, PerCorrelationKeyFIFO
+            );
+            assert claim_id == 2,
+                "successor becomes claimable after predecessor ack/removal";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+machine TestMailboxFIFO_BlocksSameKeyActiveLeaseOvertake {
+    start state Init {
+        entry {
+            var rows: seq[MailboxRow];
+            var claim_id: int;
+
+            rows += (sizeof(rows), NewMailboxRow(
+                1, 10, 100, 0, 0, 10, 55, 1, 3, 0
+            ));
+            rows += (sizeof(rows), NewMailboxRow(
+                2, 10, 100, 0, 1, NoLease(), NoLeaseToken(), 0, 3, 1
+            ));
+
+            claim_id = ClaimNextMailboxRow(
+                rows, 10, 1, PerCorrelationKeyFIFO
+            );
+
+            assert claim_id == NoMailboxRow(),
+                "same-key successor must wait while predecessor is leased";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+machine TestMailboxFIFO_CrossKeyIndependence {
+    start state Init {
+        entry {
+            var rows: seq[MailboxRow];
+            var claim_id: int;
+
+            rows += (sizeof(rows), NewMailboxRow(
+                1, 10, 100, 0, 10, NoLease(), NoLeaseToken(), 1, 3, 0
+            ));
+            rows += (sizeof(rows), NewMailboxRow(
+                2, 10, 200, 0, 1, NoLease(), NoLeaseToken(), 0, 3, 1
+            ));
+
+            claim_id = ClaimNextMailboxRow(
+                rows, 10, 1, PerCorrelationKeyFIFO
+            );
+
+            assert claim_id == 2,
+                "different keys must not block each other";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+machine TestMailboxFIFO_UnkeyedLaneUnaffected {
+    start state Init {
+        entry {
+            var rows: seq[MailboxRow];
+            var claim_id: int;
+
+            rows += (sizeof(rows), NewMailboxRow(
+                1, 10, 100, 0, 10, NoLease(), NoLeaseToken(), 1, 3, 0
+            ));
+            rows += (sizeof(rows), NewMailboxRow(
+                2, 10, NullCorrelationKey(), 0, 1, NoLease(),
+                NoLeaseToken(), 0, 3, 1
+            ));
+
+            claim_id = ClaimNextMailboxRow(
+                rows, 10, 1, PerCorrelationKeyFIFO
+            );
+
+            assert claim_id == 2,
+                "unkeyed rows must remain outside keyed head-of-line lanes";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+machine TestMailboxFIFO_ExhaustedPredecessorDoesNotBlock {
+    start state Init {
+        entry {
+            var rows: seq[MailboxRow];
+            var claim_id: int;
+
+            rows += (sizeof(rows), NewMailboxRow(
+                1, 10, 100, 0, 0, NoLease(), NoLeaseToken(), 3, 3, 0
+            ));
+            rows += (sizeof(rows), NewMailboxRow(
+                2, 10, 100, 0, 1, NoLease(), NoLeaseToken(), 0, 3, 1
+            ));
+
+            claim_id = ClaimNextMailboxRow(
+                rows, 10, 1, PerCorrelationKeyFIFO
+            );
+
+            assert claim_id == 2,
+                "exhausted same-key predecessor must not block successor";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+machine TestMailboxFIFO_MailboxIsolation {
+    start state Init {
+        entry {
+            var rows: seq[MailboxRow];
+            var claim_id: int;
+
+            rows += (sizeof(rows), NewMailboxRow(
+                1, 10, 100, 0, 10, NoLease(), NoLeaseToken(), 1, 3, 0
+            ));
+            rows += (sizeof(rows), NewMailboxRow(
+                2, 20, 100, 0, 1, NoLease(), NoLeaseToken(), 0, 3, 1
+            ));
+
+            claim_id = ClaimNextMailboxRow(
+                rows, 20, 1, PerCorrelationKeyFIFO
+            );
+
+            assert claim_id == 2,
+                "same key in another mailbox must not block this mailbox";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+machine TestDurableMailboxSpec_TokenOwnershipAndLeaseExpiry {
+    var mailbox: DurableMailboxSpec;
+
+    start state Init {
+        entry {
+            var op_resp: (int, DurableMailboxOpResult);
+            var lease_resp: (int, DurableMailboxOpResult);
+
+            mailbox = new DurableMailboxSpec(PerCorrelationKeyFIFO);
+            send mailbox, eDurableMailboxEnqueue, (
+                reply_to = this,
+                row = NewMailboxRow(
+                    10, 10, 100, 0, 0, NoLease(), NoLeaseToken(),
+                    0, 3, 0
+                )
+            );
+            receive {
+                case eDurableMailboxOpResp:
+                    (resp0: (int, DurableMailboxOpResult)) {
+                        op_resp = resp0;
+                    }
+            }
+            assert op_resp.1 == MailboxOpOk,
+                "fresh enqueue must succeed";
+
+            send mailbox, eDurableMailboxLeaseNext, (
+                reply_to = this, mailbox_id = 10, lease_token = 101,
+                now = 0, lease_duration = 5
+            );
+            receive {
+                case eDurableMailboxLeaseResp:
+                    (resp1: (int, DurableMailboxOpResult)) {
+                        lease_resp = resp1;
+                    }
+            }
+            assert lease_resp.0 == 10 && lease_resp.1 == MailboxOpOk,
+                "lease grants ownership of the row";
+
+            send mailbox, eDurableMailboxAck, (
+                reply_to = this, id = 10, lease_token = 202
+            );
+            receive {
+                case eDurableMailboxOpResp:
+                    (resp2: (int, DurableMailboxOpResult)) {
+                        op_resp = resp2;
+                    }
+            }
+            assert op_resp.1 == MailboxOpTokenMismatch,
+                "stale or wrong owner cannot ack";
+
+            send mailbox, eDurableMailboxExpireLeasesAt, 6;
+            send mailbox, eDurableMailboxLeaseNext, (
+                reply_to = this, mailbox_id = 10, lease_token = 303,
+                now = 6, lease_duration = 5
+            );
+            receive {
+                case eDurableMailboxLeaseResp:
+                    (resp3: (int, DurableMailboxOpResult)) {
+                        lease_resp = resp3;
+                    }
+            }
+            assert lease_resp.0 == 10 && lease_resp.1 == MailboxOpOk,
+                "expired lease must redeliver the same durable row";
+
+            send mailbox, eDurableMailboxAck, (
+                reply_to = this, id = 10, lease_token = 303
+            );
+            receive {
+                case eDurableMailboxOpResp:
+                    (resp4: (int, DurableMailboxOpResult)) {
+                        op_resp = resp4;
+                    }
+            }
+            assert op_resp.1 == MailboxOpOk,
+                "current owner can ack and remove the row";
+
+            send mailbox, eDurableMailboxLeaseNext, (
+                reply_to = this, mailbox_id = 10, lease_token = 404,
+                now = 6, lease_duration = 5
+            );
+            receive {
+                case eDurableMailboxLeaseResp:
+                    (resp5: (int, DurableMailboxOpResult)) {
+                        lease_resp = resp5;
+                    }
+            }
+            assert lease_resp.1 == MailboxOpNotFound,
+                "acked rows are terminal and cannot be redelivered";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+machine TestDurableMailboxSpec_NackRetryBlocksSameKey {
+    var mailbox: DurableMailboxSpec;
+
+    start state Init {
+        entry {
+            var op_resp: (int, DurableMailboxOpResult);
+            var lease_resp: (int, DurableMailboxOpResult);
+
+            mailbox = new DurableMailboxSpec(PerCorrelationKeyFIFO);
+            send mailbox, eDurableMailboxEnqueue, (
+                reply_to = this,
+                row = NewMailboxRow(
+                    1, 10, 100, 0, 0, NoLease(), NoLeaseToken(),
+                    0, 3, 0
+                )
+            );
+            receive { case eDurableMailboxOpResp:
+                (resp0: (int, DurableMailboxOpResult)) { op_resp = resp0; }
+            }
+            assert op_resp.1 == MailboxOpOk, "first enqueue succeeds";
+
+            send mailbox, eDurableMailboxLeaseNext, (
+                reply_to = this, mailbox_id = 10, lease_token = 11,
+                now = 0, lease_duration = 5
+            );
+            receive { case eDurableMailboxLeaseResp:
+                (resp1: (int, DurableMailboxOpResult)) {
+                    lease_resp = resp1;
+                }
+            }
+            assert lease_resp.0 == 1, "first row claims";
+
+            send mailbox, eDurableMailboxNack, (
+                reply_to = this, id = 1, lease_token = 11,
+                available_at = 5
+            );
+            receive { case eDurableMailboxOpResp:
+                (resp2: (int, DurableMailboxOpResult)) { op_resp = resp2; }
+            }
+            assert op_resp.1 == MailboxOpOk, "nack schedules retry";
+
+            send mailbox, eDurableMailboxEnqueue, (
+                reply_to = this,
+                row = NewMailboxRow(
+                    2, 10, 100, 0, 1, NoLease(), NoLeaseToken(),
+                    0, 3, 1
+                )
+            );
+            receive { case eDurableMailboxOpResp:
+                (resp3: (int, DurableMailboxOpResult)) { op_resp = resp3; }
+            }
+            assert op_resp.1 == MailboxOpOk, "successor enqueue succeeds";
+
+            send mailbox, eDurableMailboxLeaseNext, (
+                reply_to = this, mailbox_id = 10, lease_token = 22,
+                now = 1, lease_duration = 5
+            );
+            receive { case eDurableMailboxLeaseResp:
+                (resp4: (int, DurableMailboxOpResult)) {
+                    lease_resp = resp4;
+                }
+            }
+            assert lease_resp.1 == MailboxOpNotFound,
+                "same-key successor cannot overtake nack/backoff row";
+
+            send mailbox, eDurableMailboxLeaseNext, (
+                reply_to = this, mailbox_id = 10, lease_token = 33,
+                now = 5, lease_duration = 5
+            );
+            receive { case eDurableMailboxLeaseResp:
+                (resp5: (int, DurableMailboxOpResult)) {
+                    lease_resp = resp5;
+                }
+            }
+            assert lease_resp.0 == 1, "predecessor claims first on retry";
+
+            send mailbox, eDurableMailboxAck, (
+                reply_to = this, id = 1, lease_token = 33
+            );
+            receive { case eDurableMailboxOpResp:
+                (resp6: (int, DurableMailboxOpResult)) { op_resp = resp6; }
+            }
+            assert op_resp.1 == MailboxOpOk, "predecessor ack succeeds";
+
+            send mailbox, eDurableMailboxLeaseNext, (
+                reply_to = this, mailbox_id = 10, lease_token = 44,
+                now = 5, lease_duration = 5
+            );
+            receive { case eDurableMailboxLeaseResp:
+                (resp7: (int, DurableMailboxOpResult)) {
+                    lease_resp = resp7;
+                }
+            }
+            assert lease_resp.0 == 2,
+                "successor claims once same-key predecessor is gone";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+machine TestDurableMailboxSpec_DuplicateEnqueuePreservesFirstRow {
+    var mailbox: DurableMailboxSpec;
+
+    start state Init {
+        entry {
+            var op_resp: (int, DurableMailboxOpResult);
+            var lease_resp: (int, DurableMailboxOpResult);
+
+            mailbox = new DurableMailboxSpec(PerCorrelationKeyFIFO);
+            send mailbox, eDurableMailboxEnqueue, (
+                reply_to = this,
+                row = NewMailboxRow(
+                    50, 10, 100, 0, 0, NoLease(), NoLeaseToken(),
+                    0, 3, 0
+                )
+            );
+            receive { case eDurableMailboxOpResp:
+                (resp0: (int, DurableMailboxOpResult)) { op_resp = resp0; }
+            }
+            assert op_resp.1 == MailboxOpOk, "first enqueue succeeds";
+
+            send mailbox, eDurableMailboxEnqueue, (
+                reply_to = this,
+                row = NewMailboxRow(
+                    50, 20, 200, 0, 0, NoLease(), NoLeaseToken(),
+                    0, 3, 0
+                )
+            );
+            receive { case eDurableMailboxOpResp:
+                (resp1: (int, DurableMailboxOpResult)) { op_resp = resp1; }
+            }
+            assert op_resp.1 == MailboxOpDuplicate,
+                "duplicate enqueue is a no-op by durable id";
+
+            send mailbox, eDurableMailboxLeaseNext, (
+                reply_to = this, mailbox_id = 20, lease_token = 55,
+                now = 0, lease_duration = 5
+            );
+            receive { case eDurableMailboxLeaseResp:
+                (resp2: (int, DurableMailboxOpResult)) {
+                    lease_resp = resp2;
+                }
+            }
+            assert lease_resp.1 == MailboxOpNotFound,
+                "duplicate row must not rewrite original mailbox scope";
+
+            send mailbox, eDurableMailboxLeaseNext, (
+                reply_to = this, mailbox_id = 10, lease_token = 56,
+                now = 0, lease_duration = 5
+            );
+            receive { case eDurableMailboxLeaseResp:
+                (resp3: (int, DurableMailboxOpResult)) {
+                    lease_resp = resp3;
+                }
+            }
+            assert lease_resp.0 == 50 && lease_resp.1 == MailboxOpOk,
+                "original row remains claimable";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+machine TestDurableMailboxSpec_PriorityDoesNotPierceSameKeyFIFO {
+    start state Init {
+        entry {
+            var rows: seq[MailboxRow];
+            var claim_id: int;
+
+            rows += (sizeof(rows), NewMailboxRow(
+                1, 10, 100, 0, 10, NoLease(), NoLeaseToken(), 1, 3, 0
+            ));
+            rows += (sizeof(rows), NewMailboxRow(
+                2, 10, 100, 99, 1, NoLease(), NoLeaseToken(), 0, 3, 1
+            ));
+            rows += (sizeof(rows), NewMailboxRow(
+                3, 10, 200, 50, 1, NoLease(), NoLeaseToken(), 0, 3, 2
+            ));
+
+            claim_id = ClaimNextMailboxRow(
+                rows, 10, 1, PerCorrelationKeyFIFO
+            );
+
+            assert claim_id == 3,
+                "priority can choose among eligible heads, not overtake "+
+                "a live same-key predecessor";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+// TestMailboxFIFO_LegacyCounterexampleToIdealFIFO is intentionally excluded
+// from the default green test case. Running tcMailboxLegacyReorderCounterexample
+// should find the original bug: legacy available_at ordering returns msg-2
+// while msg-1 is still a live same-key predecessor in backoff.
+machine TestMailboxFIFO_LegacyCounterexampleToIdealFIFO {
+    var mailbox: DurableMailboxSpec;
+
+    start state Init {
+        entry {
+            var op_resp: (int, DurableMailboxOpResult);
+            var lease_resp: (int, DurableMailboxOpResult);
+
+            mailbox = new DurableMailboxSpec(LegacyAvailableAtOrder);
+            send mailbox, eDurableMailboxEnqueue, (
+                reply_to = this,
+                row = NewMailboxRow(
+                    1, 10, 100, 0, 0, NoLease(), NoLeaseToken(),
+                    0, 3, 0
+                )
+            );
+            receive { case eDurableMailboxOpResp:
+                (resp0: (int, DurableMailboxOpResult)) { op_resp = resp0; }
+            }
+            assert op_resp.1 == MailboxOpOk, "first enqueue succeeds";
+
+            send mailbox, eDurableMailboxLeaseNext, (
+                reply_to = this, mailbox_id = 10, lease_token = 11,
+                now = 0, lease_duration = 5
+            );
+            receive { case eDurableMailboxLeaseResp:
+                (resp1: (int, DurableMailboxOpResult)) {
+                    lease_resp = resp1;
+                }
+            }
+            assert lease_resp.0 == 1, "first row claims";
+
+            send mailbox, eDurableMailboxNack, (
+                reply_to = this, id = 1, lease_token = 11,
+                available_at = 5
+            );
+            receive { case eDurableMailboxOpResp:
+                (resp2: (int, DurableMailboxOpResult)) { op_resp = resp2; }
+            }
+            assert op_resp.1 == MailboxOpOk, "nack schedules retry";
+
+            send mailbox, eDurableMailboxEnqueue, (
+                reply_to = this,
+                row = NewMailboxRow(
+                    2, 10, 100, 0, 1, NoLease(), NoLeaseToken(),
+                    0, 3, 1
+                )
+            );
+            receive { case eDurableMailboxOpResp:
+                (resp3: (int, DurableMailboxOpResult)) { op_resp = resp3; }
+            }
+            assert op_resp.1 == MailboxOpOk, "successor enqueue succeeds";
+
+            send mailbox, eDurableMailboxLeaseNext, (
+                reply_to = this, mailbox_id = 10, lease_token = 22,
+                now = 1, lease_duration = 5
+            );
+            receive { case eDurableMailboxLeaseResp:
+                (resp4: (int, DurableMailboxOpResult)) {
+                    lease_resp = resp4;
+                }
+            }
+
+            assert lease_resp.1 == MailboxOpNotFound,
+                "ideal FIFO says successor must not overtake live "+
+                "same-key predecessor";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+// TestDurableMailboxSpec_DeadLetterByIdRemovesExhaustedRow exercises the
+// dead-letter path for a retry-exhausted row whose lease token has already been
+// cleared by a nack. The old token-gated model could never reach this: nack
+// clears the token, so a TokenMatches gate would reject the very rows
+// dead-lettering exists to remove. Dead-letter is by id, matching production
+// MoveToDeadLetter(ctx, id, reason).
+machine TestDurableMailboxSpec_DeadLetterByIdRemovesExhaustedRow {
+    var mailbox: DurableMailboxSpec;
+
+    start state Init {
+        entry {
+            var op_resp: (int, DurableMailboxOpResult);
+            var lease_resp: (int, DurableMailboxOpResult);
+
+            mailbox = new DurableMailboxSpec(PerCorrelationKeyFIFO);
+
+            // Row 1: max_attempts = 1, so a single lease exhausts it.
+            send mailbox, eDurableMailboxEnqueue, (
+                reply_to = this,
+                row = NewMailboxRow(
+                    1, 10, 100, 0, 0, NoLease(), NoLeaseToken(),
+                    0, 1, 0
+                )
+            );
+            receive { case eDurableMailboxOpResp:
+                (resp0: (int, DurableMailboxOpResult)) { op_resp = resp0; }
+            }
+            assert op_resp.1 == MailboxOpOk, "first enqueue succeeds";
+
+            // Row 2: same-key successor with a normal retry budget.
+            send mailbox, eDurableMailboxEnqueue, (
+                reply_to = this,
+                row = NewMailboxRow(
+                    2, 10, 100, 0, 0, NoLease(), NoLeaseToken(),
+                    0, 3, 1
+                )
+            );
+            receive { case eDurableMailboxOpResp:
+                (resp1: (int, DurableMailboxOpResult)) { op_resp = resp1; }
+            }
+            assert op_resp.1 == MailboxOpOk, "successor enqueue succeeds";
+
+            // Leasing claims row 1 (row 2 is blocked behind the live head) and
+            // pushes attempts to max_attempts, exhausting it.
+            send mailbox, eDurableMailboxLeaseNext, (
+                reply_to = this, mailbox_id = 10, lease_token = 11,
+                now = 0, lease_duration = 5
+            );
+            receive { case eDurableMailboxLeaseResp:
+                (resp2: (int, DurableMailboxOpResult)) {
+                    lease_resp = resp2;
+                }
+            }
+            assert lease_resp.0 == 1,
+                "head-of-line row claims before its successor";
+
+            // Nack clears the lease token; the row stays present but exhausted.
+            send mailbox, eDurableMailboxNack, (
+                reply_to = this, id = 1, lease_token = 11,
+                available_at = 0
+            );
+            receive { case eDurableMailboxOpResp:
+                (resp3: (int, DurableMailboxOpResult)) { op_resp = resp3; }
+            }
+            assert op_resp.1 == MailboxOpOk, "nack schedules retry";
+
+            // Dead-letter by id succeeds with no token, removing the row.
+            send mailbox, eDurableMailboxDeadLetter, (
+                reply_to = this, id = 1
+            );
+            receive { case eDurableMailboxOpResp:
+                (resp4: (int, DurableMailboxOpResult)) { op_resp = resp4; }
+            }
+            assert op_resp.1 == MailboxOpOk,
+                "dead-letter removes the exhausted row by id";
+
+            // The row is gone: a second dead-letter finds nothing.
+            send mailbox, eDurableMailboxDeadLetter, (
+                reply_to = this, id = 1
+            );
+            receive { case eDurableMailboxOpResp:
+                (resp5: (int, DurableMailboxOpResult)) { op_resp = resp5; }
+            }
+            assert op_resp.1 == MailboxOpNotFound,
+                "dead-lettered row is terminal";
+
+            // With the predecessor removed, the successor is claimable.
+            send mailbox, eDurableMailboxLeaseNext, (
+                reply_to = this, mailbox_id = 10, lease_token = 22,
+                now = 0, lease_duration = 5
+            );
+            receive { case eDurableMailboxLeaseResp:
+                (resp6: (int, DurableMailboxOpResult)) {
+                    lease_resp = resp6;
+                }
+            }
+            assert lease_resp.0 == 2,
+                "successor claims after dead-letter clears the head";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+// TestMailboxFIFO_LegacyReorderNoInlineAssert replays the production reorder
+// against the legacy claim mode but, unlike
+// TestMailboxFIFO_LegacyCounterexampleToIdealFIFO, contains NO in-machine
+// assertion. It exists to prove that the SameKeyFIFOClaimsRespectLiveHead
+// monitor catches the backoff-overtake bug on its own. Run under
+// tcMailboxMonitorCatchesLegacyReorder, which is expected to find a bug.
+machine TestMailboxFIFO_LegacyReorderNoInlineAssert {
+    var mailbox: DurableMailboxSpec;
+
+    start state Init {
+        entry {
+            var op_resp: (int, DurableMailboxOpResult);
+            var lease_resp: (int, DurableMailboxOpResult);
+
+            mailbox = new DurableMailboxSpec(LegacyAvailableAtOrder);
+            send mailbox, eDurableMailboxEnqueue, (
+                reply_to = this,
+                row = NewMailboxRow(
+                    1, 10, 100, 0, 0, NoLease(), NoLeaseToken(),
+                    0, 3, 0
+                )
+            );
+            receive { case eDurableMailboxOpResp:
+                (resp0: (int, DurableMailboxOpResult)) { op_resp = resp0; }
+            }
+
+            send mailbox, eDurableMailboxLeaseNext, (
+                reply_to = this, mailbox_id = 10, lease_token = 11,
+                now = 0, lease_duration = 5
+            );
+            receive { case eDurableMailboxLeaseResp:
+                (resp1: (int, DurableMailboxOpResult)) {
+                    lease_resp = resp1;
+                }
+            }
+
+            send mailbox, eDurableMailboxNack, (
+                reply_to = this, id = 1, lease_token = 11,
+                available_at = 5
+            );
+            receive { case eDurableMailboxOpResp:
+                (resp2: (int, DurableMailboxOpResult)) { op_resp = resp2; }
+            }
+
+            send mailbox, eDurableMailboxEnqueue, (
+                reply_to = this,
+                row = NewMailboxRow(
+                    2, 10, 100, 0, 1, NoLease(), NoLeaseToken(),
+                    0, 3, 1
+                )
+            );
+            receive { case eDurableMailboxOpResp:
+                (resp3: (int, DurableMailboxOpResult)) { op_resp = resp3; }
+            }
+
+            // Legacy ordering claims row 2 while row 1 is a live same-key head.
+            // No in-machine assertion fires here; only the global monitor can
+            // catch the violation.
+            send mailbox, eDurableMailboxLeaseNext, (
+                reply_to = this, mailbox_id = 10, lease_token = 22,
+                now = 1, lease_duration = 5
+            );
+            receive { case eDurableMailboxLeaseResp:
+                (resp4: (int, DurableMailboxOpResult)) {
+                    lease_resp = resp4;
+                }
+            }
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+// MailboxLivenessDriver drives the non-starvation liveness property. It
+// enqueues a same-key pair and a cross-key row (all available, no backoff),
+// announces eMailboxWorkArrived per row, then drains by leasing-and-acking in a
+// loop, announcing eMailboxWorkDrained per row. A correct model drains every
+// row, returning MailboxKeyedWorkEventuallyDrains to its cold state; a model in
+// which a row could never be claimed would leave it hot forever.
+machine MailboxLivenessDriver {
+    var mailbox: DurableMailboxSpec;
+
+    start state Init {
+        entry {
+            var op_resp: (int, DurableMailboxOpResult);
+
+            mailbox = new DurableMailboxSpec(PerCorrelationKeyFIFO);
+
+            send mailbox, eDurableMailboxEnqueue, (
+                reply_to = this,
+                row = NewMailboxRow(
+                    1, 10, 100, 0, 0, NoLease(), NoLeaseToken(),
+                    0, 3, 0
+                )
+            );
+            receive { case eDurableMailboxOpResp:
+                (resp0: (int, DurableMailboxOpResult)) { op_resp = resp0; }
+            }
+            announce eMailboxWorkArrived;
+
+            send mailbox, eDurableMailboxEnqueue, (
+                reply_to = this,
+                row = NewMailboxRow(
+                    2, 10, 100, 0, 0, NoLease(), NoLeaseToken(),
+                    0, 3, 1
+                )
+            );
+            receive { case eDurableMailboxOpResp:
+                (resp1: (int, DurableMailboxOpResult)) { op_resp = resp1; }
+            }
+            announce eMailboxWorkArrived;
+
+            send mailbox, eDurableMailboxEnqueue, (
+                reply_to = this,
+                row = NewMailboxRow(
+                    3, 10, 200, 0, 0, NoLease(), NoLeaseToken(),
+                    0, 3, 2
+                )
+            );
+            receive { case eDurableMailboxOpResp:
+                (resp2: (int, DurableMailboxOpResult)) { op_resp = resp2; }
+            }
+            announce eMailboxWorkArrived;
+
+            goto Draining;
+        }
+    }
+
+    state Draining {
+        entry {
+            var lease_resp: (int, DurableMailboxOpResult);
+            var op_resp: (int, DurableMailboxOpResult);
+            var token: int;
+
+            token = 1000;
+            while (true) {
+                send mailbox, eDurableMailboxLeaseNext, (
+                    reply_to = this, mailbox_id = 10, lease_token = token,
+                    now = 0, lease_duration = 5
+                );
+                receive { case eDurableMailboxLeaseResp:
+                    (resp: (int, DurableMailboxOpResult)) {
+                        lease_resp = resp;
+                    }
+                }
+
+                if (lease_resp.1 != MailboxOpOk) {
+                    break;
+                }
+
+                send mailbox, eDurableMailboxAck, (
+                    reply_to = this, id = lease_resp.0, lease_token = token
+                );
+                receive { case eDurableMailboxOpResp:
+                    (ackResp: (int, DurableMailboxOpResult)) {
+                        op_resp = ackResp;
+                    }
+                }
+                assert op_resp.1 == MailboxOpOk,
+                    "lease owner can ack the row it just claimed";
+
+                announce eMailboxWorkDrained;
+                token = token + 1;
+            }
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+machine MailboxFIFOTestDriver {
+    start state RunTests {
+        entry {
+            new TestMailboxFIFO_LegacyAvailableAtCanReorder();
+            new TestMailboxFIFO_BlocksSameKeyBackoffOvertake();
+            new TestMailboxFIFO_BlocksSameKeyActiveLeaseOvertake();
+            new TestMailboxFIFO_CrossKeyIndependence();
+            new TestMailboxFIFO_UnkeyedLaneUnaffected();
+            new TestMailboxFIFO_ExhaustedPredecessorDoesNotBlock();
+            new TestMailboxFIFO_MailboxIsolation();
+            new TestDurableMailboxSpec_TokenOwnershipAndLeaseExpiry();
+            new TestDurableMailboxSpec_NackRetryBlocksSameKey();
+            new TestDurableMailboxSpec_DuplicateEnqueuePreservesFirstRow();
+            new TestDurableMailboxSpec_PriorityDoesNotPierceSameKeyFIFO();
+            new TestDurableMailboxSpec_DeadLetterByIdRemovesExhaustedRow();
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+// Spec monitors must be explicitly attached to a test case with `assert ... in`
+// for P to check them; they are not activated globally. The safety monitor
+// SameKeyFIFOClaimsRespectLiveHead is asserted on every claim-bearing case.
+test tcMailboxCorrelationKeyFIFO [main=MailboxFIFOTestDriver]:
+  assert SameKeyFIFOClaimsRespectLiveHead in
+  { DurableMailboxSpec,
+    TestMailboxFIFO_LegacyAvailableAtCanReorder,
+    TestMailboxFIFO_BlocksSameKeyBackoffOvertake,
+    TestMailboxFIFO_BlocksSameKeyActiveLeaseOvertake,
+    TestMailboxFIFO_CrossKeyIndependence,
+    TestMailboxFIFO_UnkeyedLaneUnaffected,
+    TestMailboxFIFO_ExhaustedPredecessorDoesNotBlock,
+    TestMailboxFIFO_MailboxIsolation,
+    TestDurableMailboxSpec_TokenOwnershipAndLeaseExpiry,
+    TestDurableMailboxSpec_NackRetryBlocksSameKey,
+    TestDurableMailboxSpec_DuplicateEnqueuePreservesFirstRow,
+    TestDurableMailboxSpec_PriorityDoesNotPierceSameKeyFIFO,
+    TestDurableMailboxSpec_DeadLetterByIdRemovesExhaustedRow,
+    MailboxFIFOTestDriver };
+
+// tcMailboxLiveness checks the non-starvation liveness property: every enqueued
+// row is eventually leased and acked, draining the mailbox.
+test tcMailboxLiveness [main=MailboxLivenessDriver]:
+  assert MailboxKeyedWorkEventuallyDrains in
+  { DurableMailboxSpec, MailboxLivenessDriver };
+
+test tcMailboxLegacyReorderCounterexample
+    [main=TestMailboxFIFO_LegacyCounterexampleToIdealFIFO]:
+  assert SameKeyFIFOClaimsRespectLiveHead in
+  { DurableMailboxSpec, TestMailboxFIFO_LegacyCounterexampleToIdealFIFO };
+
+// tcMailboxMonitorCatchesLegacyReorder runs the legacy reorder with no
+// in-machine assertion, so the bug it finds is raised solely by the
+// SameKeyFIFOClaimsRespectLiveHead monitor. It is expected to find a bug.
+test tcMailboxMonitorCatchesLegacyReorder
+    [main=TestMailboxFIFO_LegacyReorderNoInlineAssert]:
+  assert SameKeyFIFOClaimsRespectLiveHead in
+  { DurableMailboxSpec, TestMailboxFIFO_LegacyReorderNoInlineAssert };

--- a/p-models/durableactor/traces/mailbox_active_lease_blocks_successor.json
+++ b/p-models/durableactor/traces/mailbox_active_lease_blocks_successor.json
@@ -1,0 +1,39 @@
+{
+  "trace_id": "mailbox_active_lease_blocks_successor",
+  "description": "Same-key successor is not claimable while an earlier same-key row has an active lease.",
+  "events": [
+    {
+      "op": "enqueue",
+      "id": "00000000-0000-7000-8000-000000000101",
+      "mailbox_id": "actor-A",
+      "correlation_key": "round/active",
+      "now": 0,
+      "available_at": 0,
+      "max_attempts": 3
+    },
+    {
+      "op": "lease",
+      "mailbox_id": "actor-A",
+      "lease_token": "lease-1",
+      "now": 0,
+      "lease_duration": 10,
+      "expect_id": "00000000-0000-7000-8000-000000000101"
+    },
+    {
+      "op": "enqueue",
+      "id": "00000000-0000-7000-8000-000000000102",
+      "mailbox_id": "actor-A",
+      "correlation_key": "round/active",
+      "now": 1,
+      "available_at": 1,
+      "max_attempts": 3
+    },
+    {
+      "op": "lease",
+      "mailbox_id": "actor-A",
+      "lease_token": "lease-2",
+      "now": 1,
+      "expect_id": ""
+    }
+  ]
+}

--- a/p-models/durableactor/traces/mailbox_correlation_key_fifo.json
+++ b/p-models/durableactor/traces/mailbox_correlation_key_fifo.json
@@ -1,0 +1,64 @@
+{
+  "trace_id": "mailbox_correlation_key_fifo",
+  "description": "Same-key successor waits behind a nacked predecessor, then claims after the predecessor is acked.",
+  "events": [
+    {
+      "op": "enqueue",
+      "id": "00000000-0000-7000-8000-000000000001",
+      "mailbox_id": "actor-A",
+      "correlation_key": "round/1",
+      "now": 0,
+      "available_at": 0,
+      "max_attempts": 3
+    },
+    {
+      "op": "lease",
+      "mailbox_id": "actor-A",
+      "lease_token": "lease-1",
+      "now": 0,
+      "expect_id": "00000000-0000-7000-8000-000000000001"
+    },
+    {
+      "op": "nack",
+      "id": "00000000-0000-7000-8000-000000000001",
+      "lease_token": "lease-1",
+      "now": 0,
+      "retry_after": 5
+    },
+    {
+      "op": "enqueue",
+      "id": "00000000-0000-7000-8000-000000000002",
+      "mailbox_id": "actor-A",
+      "correlation_key": "round/1",
+      "now": 1,
+      "available_at": 1,
+      "max_attempts": 3
+    },
+    {
+      "op": "lease",
+      "mailbox_id": "actor-A",
+      "lease_token": "lease-2",
+      "now": 1,
+      "expect_id": ""
+    },
+    {
+      "op": "lease",
+      "mailbox_id": "actor-A",
+      "lease_token": "lease-3",
+      "now": 5,
+      "expect_id": "00000000-0000-7000-8000-000000000001"
+    },
+    {
+      "op": "ack",
+      "id": "00000000-0000-7000-8000-000000000001",
+      "lease_token": "lease-3"
+    },
+    {
+      "op": "lease",
+      "mailbox_id": "actor-A",
+      "lease_token": "lease-4",
+      "now": 5,
+      "expect_id": "00000000-0000-7000-8000-000000000002"
+    }
+  ]
+}

--- a/p-models/durableactor/traces/mailbox_cross_key_independence.json
+++ b/p-models/durableactor/traces/mailbox_cross_key_independence.json
@@ -1,0 +1,45 @@
+{
+  "trace_id": "mailbox_cross_key_independence",
+  "description": "A nacked row on one key does not block another key in the same mailbox.",
+  "events": [
+    {
+      "op": "enqueue",
+      "id": "00000000-0000-7000-8000-000000000201",
+      "mailbox_id": "actor-A",
+      "correlation_key": "round/1",
+      "now": 0,
+      "available_at": 0,
+      "max_attempts": 3
+    },
+    {
+      "op": "lease",
+      "mailbox_id": "actor-A",
+      "lease_token": "lease-1",
+      "now": 0,
+      "expect_id": "00000000-0000-7000-8000-000000000201"
+    },
+    {
+      "op": "nack",
+      "id": "00000000-0000-7000-8000-000000000201",
+      "lease_token": "lease-1",
+      "now": 0,
+      "retry_after": 10
+    },
+    {
+      "op": "enqueue",
+      "id": "00000000-0000-7000-8000-000000000202",
+      "mailbox_id": "actor-A",
+      "correlation_key": "round/2",
+      "now": 1,
+      "available_at": 1,
+      "max_attempts": 3
+    },
+    {
+      "op": "lease",
+      "mailbox_id": "actor-A",
+      "lease_token": "lease-2",
+      "now": 1,
+      "expect_id": "00000000-0000-7000-8000-000000000202"
+    }
+  ]
+}

--- a/p-models/durableactor/traces/mailbox_dead_letter_unblocks_successor.json
+++ b/p-models/durableactor/traces/mailbox_dead_letter_unblocks_successor.json
@@ -1,0 +1,44 @@
+{
+  "trace_id": "mailbox_dead_letter_unblocks_successor",
+  "description": "A dead-lettered same-key predecessor is removed from the mailbox and no longer blocks its successor.",
+  "events": [
+    {
+      "op": "enqueue",
+      "id": "00000000-0000-7000-8000-000000000701",
+      "mailbox_id": "actor-A",
+      "correlation_key": "round/dead-letter",
+      "now": 0,
+      "available_at": 0,
+      "max_attempts": 3
+    },
+    {
+      "op": "enqueue",
+      "id": "00000000-0000-7000-8000-000000000702",
+      "mailbox_id": "actor-A",
+      "correlation_key": "round/dead-letter",
+      "now": 0,
+      "available_at": 0,
+      "max_attempts": 3
+    },
+    {
+      "op": "lease",
+      "mailbox_id": "actor-A",
+      "lease_token": "lease-1",
+      "now": 0,
+      "expect_id": "00000000-0000-7000-8000-000000000701"
+    },
+    {
+      "op": "dead_letter",
+      "id": "00000000-0000-7000-8000-000000000701",
+      "now": 0,
+      "failure_reason": "model trace poison message"
+    },
+    {
+      "op": "lease",
+      "mailbox_id": "actor-A",
+      "lease_token": "lease-2",
+      "now": 0,
+      "expect_id": "00000000-0000-7000-8000-000000000702"
+    }
+  ]
+}

--- a/p-models/durableactor/traces/mailbox_duplicate_enqueue_idempotent.json
+++ b/p-models/durableactor/traces/mailbox_duplicate_enqueue_idempotent.json
@@ -1,0 +1,42 @@
+{
+  "trace_id": "mailbox_duplicate_enqueue_idempotent",
+  "description": "A duplicate enqueue with the same durable id is a no-op and cannot rewrite the original mailbox scope.",
+  "events": [
+    {
+      "op": "enqueue",
+      "id": "00000000-0000-7000-8000-000000000401",
+      "mailbox_id": "actor-A",
+      "correlation_key": "round/original",
+      "payload": "original-payload",
+      "now": 0,
+      "available_at": 0,
+      "max_attempts": 3
+    },
+    {
+      "op": "enqueue",
+      "id": "00000000-0000-7000-8000-000000000401",
+      "mailbox_id": "actor-B",
+      "correlation_key": "round/duplicate",
+      "payload": "duplicate-payload",
+      "now": 0,
+      "available_at": 0,
+      "max_attempts": 3,
+      "expect_duplicate": true
+    },
+    {
+      "op": "lease",
+      "mailbox_id": "actor-B",
+      "lease_token": "lease-B",
+      "now": 0,
+      "expect_id": ""
+    },
+    {
+      "op": "lease",
+      "mailbox_id": "actor-A",
+      "lease_token": "lease-A",
+      "now": 0,
+      "expect_id": "00000000-0000-7000-8000-000000000401",
+      "expect_payload": "original-payload"
+    }
+  ]
+}

--- a/p-models/durableactor/traces/mailbox_exhausted_predecessor_does_not_block.json
+++ b/p-models/durableactor/traces/mailbox_exhausted_predecessor_does_not_block.json
@@ -1,0 +1,66 @@
+{
+  "trace_id": "mailbox_exhausted_predecessor_does_not_block",
+  "description": "An attempts-exhausted same-key row that is still physically present does not block a successor.",
+  "events": [
+    {
+      "op": "enqueue",
+      "id": "00000000-0000-7000-8000-000000000501",
+      "mailbox_id": "actor-A",
+      "correlation_key": "round/exhaust",
+      "now": 0,
+      "available_at": 0,
+      "max_attempts": 2
+    },
+    {
+      "op": "lease",
+      "mailbox_id": "actor-A",
+      "lease_token": "lease-1",
+      "now": 0,
+      "expect_id": "00000000-0000-7000-8000-000000000501"
+    },
+    {
+      "op": "nack",
+      "id": "00000000-0000-7000-8000-000000000501",
+      "lease_token": "lease-1",
+      "now": 0,
+      "retry_after": 1
+    },
+    {
+      "op": "lease",
+      "mailbox_id": "actor-A",
+      "lease_token": "lease-2",
+      "now": 2,
+      "expect_id": "00000000-0000-7000-8000-000000000501"
+    },
+    {
+      "op": "nack",
+      "id": "00000000-0000-7000-8000-000000000501",
+      "lease_token": "lease-2",
+      "now": 2,
+      "retry_after": 1
+    },
+    {
+      "op": "lease",
+      "mailbox_id": "actor-A",
+      "lease_token": "lease-sanity",
+      "now": 4,
+      "expect_id": ""
+    },
+    {
+      "op": "enqueue",
+      "id": "00000000-0000-7000-8000-000000000502",
+      "mailbox_id": "actor-A",
+      "correlation_key": "round/exhaust",
+      "now": 4,
+      "available_at": 4,
+      "max_attempts": 3
+    },
+    {
+      "op": "lease",
+      "mailbox_id": "actor-A",
+      "lease_token": "lease-3",
+      "now": 4,
+      "expect_id": "00000000-0000-7000-8000-000000000502"
+    }
+  ]
+}

--- a/p-models/durableactor/traces/mailbox_token_and_lease_expiry.json
+++ b/p-models/durableactor/traces/mailbox_token_and_lease_expiry.json
@@ -1,0 +1,53 @@
+{
+  "trace_id": "mailbox_token_and_lease_expiry",
+  "description": "Wrong-token ack is rejected, lease expiry redelivers the same row, and current-token ack removes it.",
+  "events": [
+    {
+      "op": "enqueue",
+      "id": "00000000-0000-7000-8000-000000000301",
+      "mailbox_id": "actor-A",
+      "correlation_key": "round/token",
+      "now": 0,
+      "available_at": 0,
+      "max_attempts": 3
+    },
+    {
+      "op": "lease",
+      "mailbox_id": "actor-A",
+      "lease_token": "lease-1",
+      "now": 0,
+      "lease_duration": 5,
+      "expect_id": "00000000-0000-7000-8000-000000000301"
+    },
+    {
+      "op": "ack",
+      "id": "00000000-0000-7000-8000-000000000301",
+      "lease_token": "wrong-lease",
+      "expect_rows": 0
+    },
+    {
+      "op": "expire_leases",
+      "now": 6
+    },
+    {
+      "op": "lease",
+      "mailbox_id": "actor-A",
+      "lease_token": "lease-2",
+      "now": 6,
+      "lease_duration": 5,
+      "expect_id": "00000000-0000-7000-8000-000000000301"
+    },
+    {
+      "op": "ack",
+      "id": "00000000-0000-7000-8000-000000000301",
+      "lease_token": "lease-2"
+    },
+    {
+      "op": "lease",
+      "mailbox_id": "actor-A",
+      "lease_token": "lease-3",
+      "now": 6,
+      "expect_id": ""
+    }
+  ]
+}

--- a/p-models/scripts/check.sh
+++ b/p-models/scripts/check.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Run the durable mailbox P model and the Go bridge conformance tests.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+REPO_ROOT="$(dirname "$PROJECT_DIR")"
+P_PROJ="${PROJECT_DIR}/durableactor/infra.pproj"
+BUILD_DIR="${REPO_ROOT}/PGenerated/PChecker/net8.0"
+DLL_PATH="${BUILD_DIR}/MailboxInfraModels.dll"
+
+SCHEDULES="${SCHEDULES:-50}"
+MAX_STEPS="${MAX_STEPS:-700}"
+TIMEOUT="${TIMEOUT:-300}"
+
+cd "$REPO_ROOT"
+
+echo "=== P Mailbox Infra Checking ==="
+echo "Bounds:"
+echo "  SCHEDULES: $SCHEDULES"
+echo "  MAX_STEPS: $MAX_STEPS"
+echo "  TIMEOUT: ${TIMEOUT}s"
+echo ""
+
+if ! command -v p >/dev/null 2>&1; then
+    echo "Error: P compiler not found"
+    echo "Install with: dotnet tool install --global P --version 3.0.4"
+    exit 1
+fi
+
+EXPECTED_P_VERSION="3.0.4"
+P_VERSION="$(p --version 2>/dev/null | awk '{print $NF}')"
+case "$P_VERSION" in
+    "${EXPECTED_P_VERSION}"|"${EXPECTED_P_VERSION}".*)
+        ;;
+    *)
+        echo "Warning: expected P ${EXPECTED_P_VERSION}, got ${P_VERSION:-unknown}"
+        ;;
+esac
+
+rm -rf "${REPO_ROOT}/PGenerated"
+p compile -pp "$P_PROJ"
+
+# check_green runs a test case that must hold: p check exits non-zero if it
+# finds any bug, so set -e fails the script on a regression.
+check_green() {
+    local testcase="$1"
+
+    echo ""
+    echo "=== green: ${testcase} (expect 0 bugs) ==="
+    timeout "$TIMEOUT" p check "$DLL_PATH" \
+        --testcase "$testcase" \
+        --schedules "$SCHEDULES" \
+        --max-steps "$MAX_STEPS"
+}
+
+# check_negative runs a test case that must find a bug. A clean run is itself a
+# regression: it means the model no longer detects the failure mode the test
+# exists to catch, so we invert the exit code and fail loudly.
+check_negative() {
+    local testcase="$1"
+    local schedules="${2:-$SCHEDULES}"
+
+    echo ""
+    echo "=== negative: ${testcase} (expect a bug) ==="
+    if timeout "$TIMEOUT" p check "$DLL_PATH" \
+        --testcase "$testcase" \
+        --schedules "$schedules" \
+        --max-steps "$MAX_STEPS"; then
+
+        echo "ERROR: ${testcase} found no bug, but a bug was expected"
+        return 1
+    fi
+
+    echo "OK: ${testcase} found the expected bug"
+}
+
+# Safety and liveness properties must hold.
+check_green tcMailboxCorrelationKeyFIFO
+check_green tcMailboxLiveness
+
+# The legacy reorder must still be caught two independent ways: once by the
+# in-machine assertion, and once by the SameKeyFIFOClaimsRespectLiveHead monitor
+# with no in-machine assertion. A single schedule is enough to surface it.
+check_negative tcMailboxLegacyReorderCounterexample 1
+check_negative tcMailboxMonitorCatchesLegacyReorder 1
+
+echo ""
+echo "=== Go Bridge Conformance ==="
+go test ./p-models/durableactor/bridge


### PR DESCRIPTION
## Summary

This PR adds a formal model for the durable actor mailbox claim semantics,
stacked on top of #435 (`mailbox-correlation-key-fifo`). The goal is to make
that fix precise enough that we can both explain the production failure mode and
keep checking future mailbox changes against an ideal specification.

P is a state-machine modeling language for asynchronous systems. We describe the
system as machines that exchange events, then let the checker explore many event
schedules looking for assertion failures, monitor violations, deadlocks, and
other illegal states. That is a good fit for the durable actor mailbox because
the important invariant is distributed across enqueue, lease, nack, retry,
lease-expiry, and ack transitions rather than isolated in one function.

The new model lives under `p-models/durableactor/` and covers the core mailbox
state machine:

- enqueue with duplicate-id idempotence
- lease/claim with priority and availability ordering
- per-correlation-key FIFO blocking
- ack and nack ownership by lease token
- retry backoff, retry exhaustion, and dead-letter removal
- lease expiry and later re-claim
- mailbox isolation and cross-key independence

It includes two claim modes:

- `LegacyAvailableAtOrder`, which matches the old behavior that ordered eligible
  rows by priority and `available_at`.
- `PerCorrelationKeyFIFO`, which models the fixed behavior where a live earlier
  same-mailbox/same-correlation-key row blocks later rows for that key.

## Why this helps

The issue seen in the wild was a distributed-systems ordering bug: a message that
had already been observed and nacked into backoff was no longer claim-visible,
so a later message for the same logical protocol stream could be claimed first.
That allowed the durable actor mailbox to violate the protocol's per-session or
per-round ordering assumptions even though each individual row transition looked
locally valid.

The model captures the intended global invariant instead: within a mailbox and
correlation key, live messages must be claimed in enqueue/id order. Availability,
backoff, and lease state can delay the head of the key, but they must not let a
successor overtake it.

This gives us a place to reason about the durable actor mailbox from first
principles rather than only testing specific SQL query shapes. It should help us
catch future issues around retry scheduling, leases, priority ordering,
dead-letter handling, multi-mailbox isolation, and any new mailbox behavior that
could accidentally weaken per-key ordering.

## Counterexample for the original bug

The model includes an intentional negative testcase,
`tcMailboxLegacyReorderCounterexample`, that checks the ideal same-key FIFO
property against the legacy ordering mode. It reproduces the exact class of bug
from production:

1. enqueue `msg-1` for correlation key `k`
2. lease `msg-1`
3. nack `msg-1` into backoff
4. enqueue `msg-2` for the same key
5. legacy ordering claims `msg-2` while `msg-1` is still live

That testcase is intentionally excluded from the default green suite, but it can
be run directly to show that P finds the counterexample.

## Bridge into the implementation

This also adds a Go replay bridge under `p-models/durableactor/bridge`. The
bridge loads checked-in JSON traces and replays them against the real
`db/actordelivery` SQLite store using the production migrations and
`LeaseNextMessage` path.

That bridge is important because it keeps the formal model tied to the code we
ship. As we add model-generated traces or new hand-written traces, the same
scenarios can exercise the actual SQL/store implementation rather than only the
P abstraction.

The initial traces cover:

- same-key FIFO across nack/backoff
- active lease blocking of a same-key successor
- cross-key independence
- retry-exhausted predecessor not blocking a successor
- dead-lettered predecessor removal unblocking a successor
- lease token ownership and lease expiry
- duplicate enqueue idempotence

## Docs and workflow

The PR also adds:

- `p-models/README.md`, which explains what P is, why it is useful here, and how
  the model/bridge workflow should be extended.
- `p-models/AGENTS.md` and `p-models/CLAUDE.md`.
- `p-models/durableactor/README.md`, with durable actor mailbox-specific run
  instructions and semantics.
- `p-models/durableactor/AGENTS.md` and `p-models/durableactor/CLAUDE.md`.
- `p-models/scripts/check.sh`.

The script compiles the P model, runs the default green model suite, and runs the
Go bridge tests. Generated P artifacts are ignored via `.gitignore`.

## How to run

```shell
./p-models/scripts/check.sh
```

That command compiles `p-models/durableactor/infra.pproj`, runs the default
`tcMailboxCorrelationKeyFIFO` P testcase, and then runs
`go test ./p-models/durableactor/bridge`.

To demonstrate that the model would have found the original same-key reorder
bug, run the intentional negative testcase:

```shell
p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll \
  --testcase tcMailboxLegacyReorderCounterexample \
  --schedules 1 \
  --max-steps 200
```

That check should report one bug because it checks the ideal same-key FIFO
property against the legacy claim rule.

## Validation

- `./p-models/scripts/check.sh`
- `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcMailboxLegacyReorderCounterexample --schedules 1 --max-steps 200` finds the expected intentional bug
- `go test ./p-models/durableactor/bridge`
- `make unit pkg=./db/actordelivery/...`
- `make unit pkg=./baselib/actor/...`
- `make unit pkg=./serverconn/...`
- `make fmt-changed`
- `make lint-native`

