### PR TITLE
multi: Harden CI flake paths

### DIFF
--- a/txconfirm/broadcaster.go
+++ b/txconfirm/broadcaster.go
@@ -886,7 +886,17 @@ func (b *CPFPBroadcaster) fallbackDirectBroadcast(ctx context.Context,
 	b.log.WarnS(ctx, "CPFP unavailable; broadcasting parent directly",
 		err, "txid", txid, "stage", stage, "label", req.Label)
 
-	return b.broadcastDirect(ctx, req, txid)
+	result, directErr := b.broadcastDirect(ctx, req, txid)
+	if directErr == nil {
+		return result, nil
+	}
+
+	// Anchor parents often have zero fee and only relay once the CPFP child
+	// is accepted. If the direct fallback also fails, keep the tracked tx
+	// non-terminal so the caller can retry on later blocks or observe an
+	// external package that won the race.
+	return nil, fmt.Errorf("%w: %s: %w; direct parent broadcast: %w",
+		ErrCPFPFeeInputUnavailable, stage, err, directErr)
 }
 
 // EstimateFeeRate returns the current fee rate in sat/vbyte, clamped by the

--- a/txconfirm/broadcaster_test.go
+++ b/txconfirm/broadcaster_test.go
@@ -871,6 +871,43 @@ func TestFeeOutpointReleasedOnCPFPFallback(t *testing.T) {
 	)
 }
 
+// TestCPFPFallbackDirectRejectIsRetryable verifies that a CPFP setup failure
+// followed by a direct parent broadcast rejection does not surface as a hard
+// broadcast failure. Anchor parents usually rely on the child package for fees,
+// so the caller should keep the confirmation watch live and retry later.
+func TestCPFPFallbackDirectRejectIsRetryable(t *testing.T) {
+	tx := makeTestTx(true)
+	txid := tx.TxHash()
+	utxo := makeWalletUTXO(t)
+
+	chain := newFakeChainSourceRef(100)
+	chain.broadcastErr = fmt.Errorf("min relay fee not met")
+	broadcaster := NewCPFPBroadcaster(BroadcasterConfig{
+		ChainSource: chain,
+		Wallet: &failingWallet{
+			utxos:        []*walletcore.Utxo{utxo},
+			changeScript: p2trTestPkScript(t),
+			finalizeErr:  fmt.Errorf("finalize failed"),
+		},
+	})
+
+	result, err := broadcaster.broadcastWithCPFP(
+		t.Context(), 100, &BroadcastRequest{
+			Tx: tx,
+		}, txid, 1,
+	)
+	require.ErrorIs(t, err, ErrCPFPFeeInputUnavailable)
+	require.Nil(t, result)
+	require.Equal(t, 1, chain.broadcastCallCount())
+	require.Equal(t, 0, chain.packageCallCount())
+
+	_, stillTracked := broadcaster.parentStates[txid]
+	require.False(
+		t, stillTracked,
+		"parent state should be released after CPFP fallback reject",
+	)
+}
+
 // TestFeeOutpointReleasedOnPreflightFailure verifies that when
 // TestMempoolAccept preflight rejects the package, the
 // tentatively-reserved fee outpoint is released so the caller's next


### PR DESCRIPTION
## Summary

- keep anchor-parent broadcasts retryable when CPFP setup fails and the direct parent fallback is rejected
- add a txconfirm regression test for the retryable direct-reject fallback

## Context

This branch is rebased on the latest `origin/main`, which already includes the bitcoind startup/readiness retry from #434. The remaining diff here is the txconfirm hardening that prevents a direct fallback rejection from turning a CPFP setup failure into a terminal tracked-tx failure.

## Validation

- `make -C client fmt-changed`
- `go test ./txconfirm` in `client/`
- `make -C client lint-native`