### PR TITLE
oor: validate incoming ancestor packages (#366)

### DIFF
--- a/db/oor_artifact_store.go
+++ b/db/oor_artifact_store.go
@@ -344,6 +344,19 @@ func (s *OORArtifactPersistenceStore) UpsertPackage(ctx context.Context,
 				)
 			}
 
+			samePayload, err := sameOORPackagePayload(
+				ctx, q, existing, arkRaw, rawCheckpoints,
+			)
+			if err != nil {
+				return err
+			}
+			if !samePayload {
+				return fmt.Errorf("oor package %x already "+
+					"exists with different payload", id)
+			}
+
+			return nil
+
 		case errors.Is(err, sql.ErrNoRows):
 			// New package insert path.
 
@@ -1275,6 +1288,39 @@ func validatePackageDirection(direction OORPackageDirection) error {
 		return fmt.Errorf("unsupported package direction: %d",
 			direction)
 	}
+}
+
+// sameOORPackagePayload reports whether an existing package row already holds
+// the exact serialized payload being upserted.
+func sameOORPackagePayload(ctx context.Context, q OORArtifactStore,
+	existing sqlc.OorPackage, arkRaw []byte,
+	rawCheckpoints [][]byte) (bool, error) {
+
+	if !bytes.Equal(existing.ArkPsbt, arkRaw) {
+		return false, nil
+	}
+
+	existingCheckpoints, err := q.ListOORPackageCheckpoints(
+		ctx, existing.SessionID,
+	)
+	if err != nil {
+		return false, err
+	}
+
+	if len(existingCheckpoints) != len(rawCheckpoints) {
+		return false, nil
+	}
+
+	for i := range rawCheckpoints {
+		if !bytes.Equal(
+			existingCheckpoints[i].CheckpointPsbt,
+			rawCheckpoints[i],
+		) {
+			return false, nil
+		}
+	}
+
+	return true, nil
 }
 
 func packageDirectionCode(direction OORPackageDirection) (int32, error) {

--- a/db/oor_artifact_store_test.go
+++ b/db/oor_artifact_store_test.go
@@ -220,6 +220,50 @@ func TestOORArtifactStoreUpsertPackageDirectionConflict(t *testing.T) {
 	require.ErrorContains(t, err, "package direction conflict")
 }
 
+// TestOORArtifactStoreUpsertPackageRejectsPayloadRewrite verifies same-session
+// package persistence is retry-idempotent, not a rewrite surface.
+func TestOORArtifactStoreUpsertPackageRejectsPayloadRewrite(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store, _ := newOORArtifactStoreForTest(t)
+
+	sessionID, arkPSBT, checkpoints, _, _, _, _ := buildTestOORPackage(
+		t, 0x35,
+	)
+
+	err := store.UpsertPackage(
+		ctx, OORPackageDirectionIncoming, sessionID, arkPSBT,
+		checkpoints,
+	)
+	require.NoError(t, err)
+
+	err = store.UpsertPackage(
+		ctx, OORPackageDirectionIncoming, sessionID, arkPSBT,
+		checkpoints,
+	)
+	require.NoError(t, err)
+
+	checkpoints[0].Inputs[0].FinalScriptWitness = []byte{
+		0x01,
+		0x51,
+	}
+
+	err = store.UpsertPackage(
+		ctx, OORPackageDirectionIncoming, sessionID, arkPSBT,
+		checkpoints,
+	)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "already exists with different payload")
+
+	pkg, err := store.GetPackage(ctx, sessionID)
+	require.NoError(t, err)
+	require.Empty(
+		t, pkg.FinalCheckpointPSBTs[0].Inputs[0].
+			FinalScriptWitness,
+	)
+}
+
 // TestOORArtifactStoreGetPackageForOutpointPrefersCreatedBinding verifies that
 // outpoint lookups return the created-output package when both created and
 // consumed bindings exist for the same outpoint.

--- a/oor/incoming_adapter.go
+++ b/oor/incoming_adapter.go
@@ -164,8 +164,14 @@ func IncomingTransferEventFromResponseWithLimits(sessionID SessionID,
 	}
 
 	ancestors, err := packageArtifactsFromRPC(
-		recipientEvt.GetAncestorPackages(),
+		recipientEvt.GetAncestorPackages(), limits,
 	)
+	if err != nil {
+		return nil, err
+	}
+
+	root := packageArtifactForValidation(sessionID, arkPSBT, checkpoints)
+	err = validateIncomingPackageGraph(root, ancestors)
 	if err != nil {
 		return nil, err
 	}
@@ -181,8 +187,8 @@ func IncomingTransferEventFromResponseWithLimits(sessionID SessionID,
 // packageArtifactsFromRPC converts RPC package artifacts into domain
 // artifacts after enforcing the same bounded-shape policy as checkpoint
 // parsing.
-func packageArtifactsFromRPC(pkgs []*arkrpc.OORSessionPackage) (
-	[]PackageArtifact, error) {
+func packageArtifactsFromRPC(pkgs []*arkrpc.OORSessionPackage,
+	limits ReceiveLimits) ([]PackageArtifact, error) {
 
 	const maxAncestorPackages = 64
 	if len(pkgs) > maxAncestorPackages {
@@ -190,6 +196,7 @@ func packageArtifactsFromRPC(pkgs []*arkrpc.OORSessionPackage) (
 			"limit %d", len(pkgs), maxAncestorPackages)
 	}
 
+	limits = normalizeReceiveLimits(limits)
 	artifacts := make([]PackageArtifact, 0, len(pkgs))
 	for i := range pkgs {
 		pkg := pkgs[i]
@@ -207,6 +214,14 @@ func packageArtifactsFromRPC(pkgs []*arkrpc.OORSessionPackage) (
 		if err != nil {
 			return nil, fmt.Errorf("parse ancestor package ark "+
 				"psbt %d: %w", i, err)
+		}
+
+		if uint64(len(pkg.GetCheckpointPsbts())) >
+			uint64(limits.MaxCheckpoints) {
+			return nil, fmt.Errorf("ancestor package %d "+
+				"checkpoint count %d exceeds limit %d", i,
+				len(pkg.GetCheckpointPsbts()),
+				limits.MaxCheckpoints)
 		}
 
 		checkpoints := make(

--- a/oor/local_persistence_handler.go
+++ b/oor/local_persistence_handler.go
@@ -304,6 +304,18 @@ func (h *LocalPersistenceOutboxHandler) validateMaterializeIncoming(
 		return fmt.Errorf("incoming recipients must be provided")
 	}
 
+	if h.PackageStore != nil {
+		root := packageArtifactForValidation(
+			msg.SessionID, msg.ArkPSBT, msg.FinalCheckpointPSBTs,
+		)
+		err := validateIncomingPackageGraph(
+			root, msg.AncestorPackages,
+		)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/oor/local_persistence_handler_test.go
+++ b/oor/local_persistence_handler_test.go
@@ -372,6 +372,74 @@ func TestValidateIncomingPackageGraphRejectsUnconsumedAncestor(t *testing.T) {
 	)
 }
 
+// TestValidateIncomingPackageGraphAcceptsConnectedAncestor asserts a package
+// whose checkpoint spends an ancestor Ark output can carry that ancestor as
+// recovery material.
+func TestValidateIncomingPackageGraphAcceptsConnectedAncestor(t *testing.T) {
+	t.Parallel()
+
+	ancestorArk, ancestorCheckpoints, _, _, _, _ :=
+		buildTestIncomingMaterialization(t)
+	rootArk, rootCheckpoints, _, _, _, _ :=
+		buildTestIncomingMaterialization(t)
+	rootArk, rootCheckpoints = reparentTestIncomingPackage(
+		t, rootArk, rootCheckpoints, ancestorArk,
+	)
+
+	root := packageArtifactForValidation(
+		SessionID(
+			rootArk.UnsignedTx.TxHash(),
+		),
+		rootArk,
+		rootCheckpoints,
+	)
+	ancestor := packageArtifactForValidation(
+		SessionID(
+			ancestorArk.UnsignedTx.TxHash(),
+		),
+		ancestorArk,
+		ancestorCheckpoints,
+	)
+
+	err := validateIncomingPackageGraph(root, []PackageArtifact{ancestor})
+	require.NoError(t, err)
+}
+
+// TestValidateIncomingPackageGraphRejectsDuplicateAncestor asserts valid
+// ancestors still cannot be supplied more than once.
+func TestValidateIncomingPackageGraphRejectsDuplicateAncestor(t *testing.T) {
+	t.Parallel()
+
+	ancestorArk, ancestorCheckpoints, _, _, _, _ :=
+		buildTestIncomingMaterialization(t)
+	rootArk, rootCheckpoints, _, _, _, _ :=
+		buildTestIncomingMaterialization(t)
+	rootArk, rootCheckpoints = reparentTestIncomingPackage(
+		t, rootArk, rootCheckpoints, ancestorArk,
+	)
+
+	root := packageArtifactForValidation(
+		SessionID(
+			rootArk.UnsignedTx.TxHash(),
+		),
+		rootArk,
+		rootCheckpoints,
+	)
+	ancestor := packageArtifactForValidation(
+		SessionID(
+			ancestorArk.UnsignedTx.TxHash(),
+		),
+		ancestorArk,
+		ancestorCheckpoints,
+	)
+
+	err := validateIncomingPackageGraph(
+		root, []PackageArtifact{ancestor, ancestor},
+	)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "duplicate ancestor package")
+}
+
 // TestLocalPersistenceOutboxHandlerUsesMetadataOperatorKey asserts incoming
 // materialization prefers the per-VTXO operator key returned by the indexer
 // over the handler's compatibility fallback key.
@@ -1194,6 +1262,56 @@ func buildTestIncomingMaterialization(t *testing.T) (*psbt.Packet,
 	return arkPSBT, []*psbt.Packet{cp.PSBT}, recipients,
 		inputs[0].SpentVTXO.Outpoint.Hash, recipientKey,
 		operatorKey.PubKey()
+}
+
+// reparentTestIncomingPackage rewrites the test package's checkpoint input to
+// spend output zero of parentArk, then rebuilds the Ark transaction so its
+// session ID follows the new checkpoint txid.
+func reparentTestIncomingPackage(t *testing.T, arkPSBT *psbt.Packet,
+	checkpoints []*psbt.Packet,
+	parentArk *psbt.Packet) (*psbt.Packet, []*psbt.Packet) {
+
+	t.Helper()
+
+	require.Len(t, checkpoints, 1)
+	require.NotNil(t, parentArk)
+	require.NotNil(t, parentArk.UnsignedTx)
+	require.NotEmpty(t, parentArk.UnsignedTx.TxOut)
+
+	checkpoint := checkpoints[0]
+	require.NotNil(t, checkpoint)
+	require.NotNil(t, checkpoint.UnsignedTx)
+	require.NotEmpty(t, checkpoint.UnsignedTx.TxIn)
+	require.NotEmpty(t, checkpoint.UnsignedTx.TxOut)
+
+	parentTxid := parentArk.UnsignedTx.TxHash()
+	checkpoint.UnsignedTx.TxIn[0].PreviousOutPoint = wire.OutPoint{
+		Hash:  parentTxid,
+		Index: 0,
+	}
+	checkpoint.Inputs[0].WitnessUtxo = parentArk.UnsignedTx.TxOut[0]
+
+	recipients, err := ExtractArkRecipients(arkPSBT)
+	require.NoError(t, err)
+
+	outputs := make([]oortx.RecipientOutput, 0, len(recipients))
+	for i := range recipients {
+		outputs = append(outputs, oortx.RecipientOutput{
+			PkScript: recipients[i].PkScript,
+			Value:    recipients[i].Value,
+		})
+	}
+
+	arkPSBT, err = oortx.BuildArkPSBT(
+		[]oortx.CheckpointOutput{{
+			Txid:   checkpoint.UnsignedTx.TxHash(),
+			Output: checkpoint.UnsignedTx.TxOut[0],
+		}},
+		outputs,
+	)
+	require.NoError(t, err)
+
+	return arkPSBT, checkpoints
 }
 
 // validTestIncomingAncestry returns a minimal Ancestry slice that passes

--- a/oor/local_persistence_handler_test.go
+++ b/oor/local_persistence_handler_test.go
@@ -282,6 +282,96 @@ func TestLocalPersistenceOutboxHandlerMaterializeIncoming(t *testing.T) {
 	require.Equal(t, chainhash.Hash(sessionID), packageStore.lastSessionID)
 }
 
+// TestLocalPersistenceOutboxHandlerRejectsInvalidAncestorPackage asserts
+// untrusted incoming ancestor packages are validated before they can poison the
+// package store used by recovery.
+func TestLocalPersistenceOutboxHandlerRejectsInvalidAncestorPackage(
+	t *testing.T) {
+
+	t.Parallel()
+
+	arkPSBT, finalCheckpoints, recipients, _, _, operatorKey :=
+		buildTestIncomingMaterialization(t)
+
+	packageStore := &testPackageStore{}
+	handler := &LocalPersistenceOutboxHandler{
+		Store:        newTestVTXOStore(),
+		PackageStore: packageStore,
+		OperatorKey:  operatorKey,
+		ExitDelay:    10,
+		NotifyIncomingVTXOs: func(_ context.Context,
+			_ []*vtxo.Descriptor) error {
+
+			return nil
+		},
+		ResolveIncomingClientKey: func(ctx context.Context,
+			recipient ArkRecipientOutput) (keychain.KeyDescriptor,
+			error) {
+
+			_ = ctx
+			_ = recipient
+
+			return keychain.KeyDescriptor{}, nil
+		},
+	}
+
+	sessionID := SessionID(arkPSBT.UnsignedTx.TxHash())
+	ancestorID := sessionID
+	ancestorID[0] ^= 0x01
+
+	req := &MaterializeIncomingVTXOsRequest{
+		SessionID:            sessionID,
+		ArkPSBT:              arkPSBT,
+		FinalCheckpointPSBTs: finalCheckpoints,
+		Recipients:           recipients,
+		AncestorPackages: []PackageArtifact{{
+			SessionID:            ancestorID,
+			ArkPSBT:              arkPSBT,
+			FinalCheckpointPSBTs: finalCheckpoints,
+		}},
+	}
+
+	events, err := handler.Handle(t.Context(), sessionID, req)
+	require.Error(t, err)
+	require.ErrorContains(
+		t, err, "ancestor package 0 session id does not match ark txid",
+	)
+	require.Empty(t, events)
+	require.Zero(t, packageStore.packageCalls)
+}
+
+// TestValidateIncomingPackageGraphRejectsUnconsumedAncestor asserts valid but
+// unrelated ancestor packages must not be accepted as recovery ancestors.
+func TestValidateIncomingPackageGraphRejectsUnconsumedAncestor(t *testing.T) {
+	t.Parallel()
+
+	arkPSBT, finalCheckpoints, _, _, _, _ :=
+		buildTestIncomingMaterialization(t)
+	ancestorArk, ancestorCheckpoints, _, _, _, _ :=
+		buildTestIncomingMaterialization(t)
+
+	root := packageArtifactForValidation(
+		SessionID(
+			arkPSBT.UnsignedTx.TxHash(),
+		),
+		arkPSBT,
+		finalCheckpoints,
+	)
+	ancestor := packageArtifactForValidation(
+		SessionID(
+			ancestorArk.UnsignedTx.TxHash(),
+		),
+		ancestorArk,
+		ancestorCheckpoints,
+	)
+
+	err := validateIncomingPackageGraph(root, []PackageArtifact{ancestor})
+	require.Error(t, err)
+	require.ErrorContains(
+		t, err, "is not consumed by incoming package chain",
+	)
+}
+
 // TestLocalPersistenceOutboxHandlerUsesMetadataOperatorKey asserts incoming
 // materialization prefers the per-VTXO operator key returned by the indexer
 // over the handler's compatibility fallback key.
@@ -1084,6 +1174,7 @@ func buildTestIncomingMaterialization(t *testing.T) (*psbt.Packet,
 
 	cp, err := oortx.BuildCheckpointPSBT(policy, inputs[0])
 	require.NoError(t, err)
+	cp.PSBT.Inputs[0].FinalScriptWitness = []byte{0x01, 0x51}
 
 	arkPSBT, err := oortx.BuildArkPSBT(
 		[]oortx.CheckpointOutput{

--- a/oor/package_validation.go
+++ b/oor/package_validation.go
@@ -1,0 +1,152 @@
+package oor
+
+import (
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/lightninglabs/darepo-client/lib/tx/arktx"
+	oortx "github.com/lightninglabs/darepo-client/lib/tx/oor"
+)
+
+// validateIncomingPackage validates the finalized OOR package shape before
+// any untrusted incoming artifact is persisted for future recovery.
+func validateIncomingPackage(label string, sessionID SessionID,
+	ark *psbt.Packet, checkpoints []*psbt.Packet) error {
+
+	if sessionID == (SessionID{}) {
+		return fmt.Errorf("%s session id must be provided", label)
+	}
+
+	if ark == nil || ark.UnsignedTx == nil {
+		return fmt.Errorf("%s ark psbt must be provided", label)
+	}
+
+	txid := ark.UnsignedTx.TxHash()
+	if SessionID(txid) != sessionID {
+		return fmt.Errorf("%s session id does not match ark txid",
+			label)
+	}
+
+	err := oortx.ValidateFinalizePackage(ark, checkpoints)
+	if err != nil {
+		return fmt.Errorf("%s finalize package invalid: %w", label, err)
+	}
+
+	return nil
+}
+
+// validateIncomingPackageGraph validates that incoming ancestor artifacts are
+// finalized packages and that each supplied ancestor is reachable from the
+// received package's checkpoint-input chain. This avoids persisting unrelated
+// operator/indexer-supplied packages as recovery material.
+func validateIncomingPackageGraph(root PackageArtifact,
+	ancestors []PackageArtifact) error {
+
+	if err := validateIncomingPackage(
+		"incoming package", root.SessionID, root.ArkPSBT,
+		root.FinalCheckpointPSBTs,
+	); err != nil {
+		return err
+	}
+
+	ancestorBySession := make(map[SessionID]PackageArtifact, len(ancestors))
+	for i := range ancestors {
+		ancestor := ancestors[i]
+		label := fmt.Sprintf("ancestor package %d", i)
+
+		if err := validateIncomingPackage(
+			label, ancestor.SessionID, ancestor.ArkPSBT,
+			ancestor.FinalCheckpointPSBTs,
+		); err != nil {
+			return err
+		}
+
+		if ancestor.SessionID == root.SessionID {
+			return fmt.Errorf("%s duplicates incoming package",
+				label)
+		}
+
+		if _, ok := ancestorBySession[ancestor.SessionID]; ok {
+			return fmt.Errorf("duplicate ancestor package %s",
+				ancestor.SessionID.String())
+		}
+
+		ancestorBySession[ancestor.SessionID] = ancestor
+	}
+
+	reachable := make(map[SessionID]struct{}, len(ancestors))
+	walkPackageAncestors(root, ancestorBySession, reachable)
+
+	for i := range ancestors {
+		ancestor := ancestors[i]
+		if _, ok := reachable[ancestor.SessionID]; !ok {
+			return fmt.Errorf("ancestor package %s is not "+
+				"consumed by incoming package chain",
+				ancestor.SessionID.String())
+		}
+	}
+
+	return nil
+}
+
+// walkPackageAncestors marks ancestor packages reachable from pkg's finalized
+// checkpoints by following checkpoint input prevouts that spend ancestor Ark
+// outputs.
+func walkPackageAncestors(pkg PackageArtifact,
+	ancestorBySession map[SessionID]PackageArtifact,
+	reachable map[SessionID]struct{}) {
+
+	for i := range pkg.FinalCheckpointPSBTs {
+		checkpoint := pkg.FinalCheckpointPSBTs[i]
+		if checkpoint == nil || checkpoint.UnsignedTx == nil ||
+			len(checkpoint.UnsignedTx.TxIn) == 0 {
+
+			continue
+		}
+
+		prevOut := checkpoint.UnsignedTx.TxIn[0].PreviousOutPoint
+		parentID := SessionID(prevOut.Hash)
+		ancestor, ok := ancestorBySession[parentID]
+		if !ok {
+			continue
+		}
+
+		if !validAncestorOutput(ancestor.ArkPSBT, prevOut.Index) {
+			continue
+		}
+
+		if _, ok := reachable[parentID]; ok {
+			continue
+		}
+
+		reachable[parentID] = struct{}{}
+		walkPackageAncestors(ancestor, ancestorBySession, reachable)
+	}
+}
+
+// validAncestorOutput reports whether an ancestor checkpoint input references a
+// real non-anchor Ark output in the referenced ancestor package.
+func validAncestorOutput(ark *psbt.Packet, outputIndex uint32) bool {
+	if ark == nil || ark.UnsignedTx == nil {
+		return false
+	}
+
+	tx := ark.UnsignedTx
+	if outputIndex >= uint32(len(tx.TxOut)) {
+		return false
+	}
+
+	return !arktx.IsAnchorOutput(tx.TxOut[outputIndex])
+}
+
+// packageArtifactForValidation projects package fields into the common
+// validation shape.
+func packageArtifactForValidation(sessionID SessionID, ark *psbt.Packet,
+	checkpoints []*psbt.Packet) PackageArtifact {
+
+	return PackageArtifact{
+		SessionID:            sessionID,
+		ArkPSBT:              ark,
+		FinalCheckpointPSBTs: checkpoints,
+	}
+}

--- a/oor/receive_limits_test.go
+++ b/oor/receive_limits_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/lightninglabs/darepo-client/arkrpc"
+	"github.com/lightninglabs/darepo-client/lib/tx/psbtutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,6 +33,46 @@ func TestIncomingTransferEventFromResponseUsesConfiguredCheckpointLimit(
 		},
 	)
 	require.ErrorContains(t, err, "checkpoint count 2 exceeds limit 1")
+}
+
+// TestIncomingTransferEventFromResponseLimitsAncestorCheckpoints verifies the
+// RPC adapter bounds checkpoint lists on supplied ancestor packages before
+// they can enter the receive FSM.
+func TestIncomingTransferEventFromResponseLimitsAncestorCheckpoints(
+	t *testing.T) {
+
+	t.Parallel()
+
+	resp, sessionID, _, recipientEventID := buildIncomingResolveResponse(t)
+	ancestorArk, ancestorCheckpoints, _, _, _, _ :=
+		buildTestIncomingMaterialization(t)
+
+	ancestorArkRaw, err := psbtutil.Serialize(ancestorArk)
+	require.NoError(t, err)
+
+	ancestorCheckpointRaw, err := psbtutil.Serialize(
+		ancestorCheckpoints[0],
+	)
+	require.NoError(t, err)
+
+	ancestorID := SessionID(ancestorArk.UnsignedTx.TxHash())
+	resp.Events[0].AncestorPackages = []*arkrpc.OORSessionPackage{{
+		SessionId: ancestorID[:],
+		ArkPsbt:   ancestorArkRaw,
+		CheckpointPsbts: [][]byte{
+			ancestorCheckpointRaw,
+			ancestorCheckpointRaw,
+		},
+	}}
+
+	_, err = IncomingTransferEventFromResponseWithLimits(
+		sessionID, recipientEventID, resp, ReceiveLimits{
+			MaxCheckpoints: 1,
+		},
+	)
+	require.ErrorContains(
+		t, err, "ancestor package 0 checkpoint count 2 exceeds limit 1",
+	)
 }
 
 // TestIncomingMetadataMatchesFromResponseUsesConfiguredMatchLimit verifies


### PR DESCRIPTION
Closes #366.

## Summary

- Validate operator/indexer-supplied OOR ancestor packages on the incoming receive path before persisting them.
- Reject same-direction `UpsertPackage` calls that try to overwrite an existing row's Ark PSBT or checkpoint payload.

## The bug

The incoming OOR receive path persists operator/indexer-supplied ancestor packages as recovery artifacts for later unroll. Two attack vectors were open:

1. **Plant fake artifacts under arbitrary session ids.** The materialization path only checked that each ancestor PSBT was parseable, so a malicious operator/indexer response could stage arbitrary "ancestor" packages under any session id. A later unilateral exit would then load forged artifacts and either fail or chase a chain that never confirms, making the received VTXO effectively unexitable.
2. **Overwrite legitimate recovery artifacts for known session ids.** `UpsertPackage` checked only the stored direction before falling through to delete and re-insert the Ark PSBT and checkpoint rows. A response producing a parseable package for a session id the attacker already knew (e.g. they hold the original Ark transaction) could overwrite the previously stored recovery artifacts, destroying recovery state for a real received VTXO.

## The fix

**Vector (a) — ingest-time validation (`a9147ad8`).** Require `SessionID == ark_txid`, run `oortx.ValidateFinalizePackage` to check the canonical Ark PSBT shape, the exact checkpoint set, and the finalize-sig material, then walk the checkpoint-input graph to require each ancestor checkpoint to be reachable from the root. Ancestor count is capped via the existing `ReceiveLimits`. Validation runs in two places for defense in depth:

- `IncomingTransferEventFromResponseWithLimits` — the RPC adapter, so bad responses are rejected before they touch the FSM.
- `validateMaterializeIncoming` — the persistence handler, so any future code path that reaches materialization without going through the adapter is still gated.

**Vector (b) — payload-equality on duplicate upsert (`64228380`).** On a duplicate-PK upsert, compare the existing Ark PSBT and checkpoint bytes against the incoming payload. Equal payloads are treated as idempotent (early return). A mismatched payload fails with `"oor package %x already exists with different payload"`, preserving the original artifact. The compare runs inside the existing `ExecTx`; `ListOORPackageCheckpoints` orders by index ASC, so positional `bytes.Equal` is sound.

## Commit layout

Three atomic commits per the repo's commit style:

- `a9147ad8 oor: Validate incoming ancestor packages before storing`
- `9ebf1444 oor: Add coverage for ancestor package validation graph`
- `64228380 db: Reject same-direction OOR package payload rewrites`

The `db:` payload-rewrite rejection is in scope for #366 (vector b) but kept as its own commit because it is an independently reasoning-able change at a different layer. Happy to squash before merge if a reviewer prefers a single security-fix commit.

## Test plan

- [x] `oor` unit tests cover the positive (ancestor actually spent by checkpoint), duplicate-ancestor rejection, and per-ancestor checkpoint cap paths.
- [x] `db` unit tests cover the same-direction same-payload (idempotent) and same-direction divergent-payload (rejected) upsert cases.
- [x] `make fmt-changed` + native linter clean on the branch.
- [ ] Reviewer to sanity-check the reachability walk against any known multi-hop ancestor fixtures.