### PR TITLE
db: reject untrusted OOR ancestor packages by txid in resolver (#371)

### DIFF
--- a/db/oor_unroll_resolver.go
+++ b/db/oor_unroll_resolver.go
@@ -11,6 +11,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/db/sqlc"
+	"github.com/lightninglabs/darepo-client/lib/tx/arktx"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 )
 
@@ -226,7 +227,13 @@ func resolveInputPackage(ctx context.Context, q OORArtifactStore,
 	}
 
 	// Fall back to a session-id lookup for foreign-owned ancestors that
-	// the local wallet only has session-keyed visibility into.
+	// the local wallet only has session-keyed visibility into. Ancestor
+	// packages persisted under a session id are operator/indexer-supplied
+	// artifacts without a local outpoint binding, so we must re-verify the
+	// txid binding and the referenced output at read time before treating
+	// the package as the parent of an unroll-chain input. Trusting only
+	// the stored session id would let a poisoned row claim ancestry for
+	// any checkpoint input whose previous hash matches its session id.
 	pkg, err = loadPackageBundleBySessionID(ctx, q, input.Hash)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, true, nil
@@ -235,11 +242,39 @@ func resolveInputPackage(ctx context.Context, q OORArtifactStore,
 		return nil, false, err
 	}
 
-	if !packageCreatesOutput(pkg, input.Index) {
+	if !packageProducesAncestorOutput(pkg, input.Hash, input.Index) {
 		return nil, true, nil
 	}
 
 	return pkg, false, nil
+}
+
+// packageProducesAncestorOutput reports whether the foreign-ancestor package
+// actually produces the referenced checkpoint-input outpoint. It rejects:
+//
+//   - packages whose stored Ark transaction does not actually hash to the
+//     requested session id (txid binding mismatch from a tampered or
+//     mismatched row),
+//   - output indices outside the package's TxOut range,
+//   - references that land on the Ark anchor output, which is never a
+//     spendable VTXO and so cannot be a real ancestor checkpoint input.
+func packageProducesAncestorOutput(pkg *OORPackageBundle,
+	expectedTxid chainhash.Hash, index uint32) bool {
+
+	if pkg == nil || pkg.ArkPSBT == nil || pkg.ArkPSBT.UnsignedTx == nil {
+		return false
+	}
+
+	tx := pkg.ArkPSBT.UnsignedTx
+	if tx.TxHash() != expectedTxid {
+		return false
+	}
+
+	if index >= uint32(len(tx.TxOut)) {
+		return false
+	}
+
+	return !arktx.IsAnchorOutput(tx.TxOut[index])
 }
 
 // checkpointInputOutpoints returns de-duplicated checkpoint input outpoints
@@ -326,16 +361,6 @@ func loadPackageBundleBySessionID(ctx context.Context, q OORArtifactStore,
 	}
 
 	return materializePackageBundle(ctx, q, row)
-}
-
-// packageCreatesOutput reports whether the package's Ark transaction has the
-// output index referenced by a child checkpoint input.
-func packageCreatesOutput(pkg *OORPackageBundle, index uint32) bool {
-	if pkg == nil || pkg.ArkPSBT == nil || pkg.ArkPSBT.UnsignedTx == nil {
-		return false
-	}
-
-	return int(index) < len(pkg.ArkPSBT.UnsignedTx.TxOut)
 }
 
 // loadPackageBundleByCreatedOutputOutpoint resolves a full package bundle

--- a/db/oor_unroll_resolver_test.go
+++ b/db/oor_unroll_resolver_test.go
@@ -331,3 +331,152 @@ func TestResolveUnrollPackagesMaxDepthExceeded(t *testing.T) {
 	_, err := store.ResolveUnrollPackages(ctx, targetOutpoint)
 	require.ErrorIs(t, err, ErrResolveUnrollMaxDepthExceeded)
 }
+
+// TestResolveUnrollPackagesRejectsTxidMismatchedAncestor verifies that the
+// foreign-ancestor fallback rejects a persisted package whose stored Ark tx
+// does not actually hash to the requested session id. Such a row would
+// otherwise let a poisoned operator/indexer response stand in as the parent
+// of any checkpoint input whose previous hash happened to match the rogue
+// session id.
+func TestResolveUnrollPackagesRejectsTxidMismatchedAncestor(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store, roundStore := newOORArtifactStoreForTest(t)
+
+	// Build a parent package and rebind its row under a session id that
+	// does not match the actual ark txid. This simulates a poisoned
+	// session-keyed row written by a buggy or malicious code path that
+	// did not enforce the txid binding at write time.
+	parentSession, parentArk, parentCheckpoints, _,
+		_, _, _ := buildTestOORPackageWithInput(
+		t, 0xa1, wire.OutPoint{
+			Hash: chainhash.Hash{0xa1, 0xaa},
+		},
+	)
+
+	rogueSession := chainhash.Hash{0xde, 0xad, 0xbe, 0xef}
+	require.NotEqual(t, parentSession, rogueSession)
+
+	err := store.UpsertPackage(
+		ctx, OORPackageDirectionIncoming, rogueSession, parentArk,
+		parentCheckpoints,
+	)
+	require.NoError(t, err)
+
+	// Build a child package whose checkpoint input claims the rogue
+	// session id as its parent. The fallback lookup will succeed at the
+	// DB layer, so the txid-binding check is what must keep the
+	// poisoned ancestor out of the resolved chain.
+	rogueParentOutpoint := wire.OutPoint{
+		Hash:  rogueSession,
+		Index: 0,
+	}
+
+	childSession, childArk, childCheckpoints, childOutpoint, childScript,
+		childValue, _ := buildTestOORPackageWithInput(
+		t, 0xa2, rogueParentOutpoint,
+	)
+
+	err = store.UpsertPackage(
+		ctx, OORPackageDirectionIncoming, childSession, childArk,
+		childCheckpoints,
+	)
+	require.NoError(t, err)
+
+	seedBindingOutpoint(
+		t, ctx, roundStore, childOutpoint, childScript, childValue,
+	)
+
+	err = store.UpsertBinding(
+		ctx, childOutpoint, childSession, 0,
+		OORPackageLinkKindCreatedOutput,
+	)
+	require.NoError(t, err)
+
+	resolved, err := store.ResolveUnrollPackages(ctx, childOutpoint)
+	require.NoError(t, err)
+	require.NotNil(t, resolved)
+
+	// The poisoned ancestor must be rejected: only the child package
+	// remains and the rogue parent outpoint is surfaced as unresolved.
+	require.Len(t, resolved.Packages, 1)
+	require.Equal(t, childSession, resolved.Packages[0].SessionID)
+	require.Len(t, resolved.UnresolvedCheckpointInputs, 1)
+	require.Equal(
+		t, rogueParentOutpoint, resolved.UnresolvedCheckpointInputs[0],
+	)
+}
+
+// TestResolveUnrollPackagesRejectsAnchorOutputAncestor verifies the
+// foreign-ancestor fallback rejects a persisted package whose claimed
+// parent output index lands on the Ark anchor output. Anchor outputs are
+// never spendable VTXOs, so a child checkpoint that purports to spend one
+// could only originate from a malformed or malicious package and must not
+// be accepted as resolved ancestry.
+func TestResolveUnrollPackagesRejectsAnchorOutputAncestor(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store, roundStore := newOORArtifactStoreForTest(t)
+
+	// The fixture builds an Ark PSBT with output 0 = recipient and
+	// output 1 = anchor. We point the child checkpoint input at output 1.
+	parentSession, parentArk, parentCheckpoints, _,
+		_, _, _ := buildTestOORPackageWithInput(
+		t, 0xb1, wire.OutPoint{
+			Hash: chainhash.Hash{0xb1, 0xaa},
+		},
+	)
+
+	err := store.UpsertPackage(
+		ctx, OORPackageDirectionIncoming, parentSession, parentArk,
+		parentCheckpoints,
+	)
+	require.NoError(t, err)
+
+	require.True(
+		t, len(parentArk.UnsignedTx.TxOut) >= 2,
+		"fixture must produce both recipient and anchor outputs",
+	)
+
+	anchorParentOutpoint := wire.OutPoint{
+		Hash:  parentSession,
+		Index: 1,
+	}
+
+	childSession, childArk, childCheckpoints, childOutpoint, childScript,
+		childValue, _ := buildTestOORPackageWithInput(
+		t, 0xb2, anchorParentOutpoint,
+	)
+
+	err = store.UpsertPackage(
+		ctx, OORPackageDirectionIncoming, childSession, childArk,
+		childCheckpoints,
+	)
+	require.NoError(t, err)
+
+	seedBindingOutpoint(
+		t, ctx, roundStore, childOutpoint, childScript, childValue,
+	)
+
+	err = store.UpsertBinding(
+		ctx, childOutpoint, childSession, 0,
+		OORPackageLinkKindCreatedOutput,
+	)
+	require.NoError(t, err)
+
+	resolved, err := store.ResolveUnrollPackages(ctx, childOutpoint)
+	require.NoError(t, err)
+	require.NotNil(t, resolved)
+
+	// The parent package exists and the txid binding is correct, but
+	// the referenced output is the anchor, so the fallback must refuse
+	// to graft it onto the unroll chain.
+	require.Len(t, resolved.Packages, 1)
+	require.Equal(t, childSession, resolved.Packages[0].SessionID)
+	require.Len(t, resolved.UnresolvedCheckpointInputs, 1)
+	require.Equal(
+		t, anchorParentOutpoint, resolved.UnresolvedCheckpointInputs[0],
+	)
+}


### PR DESCRIPTION
Closes #371.

## Summary

`db.resolveInputPackage` (in `oor_unroll_resolver.go`) did a session-id fallback `loadPackageBundleBySessionID(ctx, q, input.Hash)` and accepted the row if the requested output index was within bounds (`packageCreatesOutput`). It never verified `pkg.ArkPSBT.UnsignedTx.TxHash() == input.Hash` or rejected the Ark anchor output. A poisoned `oor_package` row (planted via any writer that does not go through #366's receive-path validation, e.g. the outgoing OOR actor or test paths) could therefore be grafted onto an unroll chain, stranding the resolved VTXO.

This is the **read/resolution path**, distinct from #366 (`fix/366-validate-oor-ancestor-packages`), which hardens only the receive **write** path. Defense in depth.

## Fix

`packageCreatesOutput` is replaced with `packageProducesAncestorOutput(pkg, expectedTxid, index)` which adds:
- txid binding: `pkg.ArkPSBT.UnsignedTx.TxHash() == expectedTxid`
- non-anchor check: the requested output must not be the Ark anchor

Mismatches return as "unresolved input" (graceful degradation to the existing recovery path).

## Test plan

- [x] new `TestResolveUnrollPackagesRejectsTxidMismatchedAncestor` — poisoned row whose `ArkPSBT` does not hash to its `session_id` is rejected
- [x] new `TestResolveUnrollPackagesRejectsAnchorOutputAncestor` — package whose claimed parent output index lands on the anchor is rejected
- [x] both fail without the fix
- [x] `make lint-native` — 0 issues
- [x] `go test ./db/... ./unroll/... -count=1` — pass

Related: complementary to #366 (write path) and disjoint from #374 (incoming-VTXO ancestry index).
