### PR TITLE
docs: nightly doc-gardening sweep 2026-05-15

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -38,6 +38,7 @@ package may import from a higher layer.
 | [`chain`](chain/) | Bitcoind RPC utilities (package relay, `SubmitPackage`) |
 | [`txconfirm`](txconfirm/) | Generic "broadcast + CPFP fee-bump + notify on confirm" actor with per-parent fee-input reservations and BIP-125 Rule 3/4 enforcement |
 | [`unroll`](unroll/) | Durable per-target unilateral-exit actor + thin registry: owns proof assembly, materialization, CSV maturity, final sweep build, persist-before-broadcast, and control-plane record persistence |
+| [`fraud`](fraud/) | Passive OOR ancestry fraud watch actor: arms per-ancestor spend watches and triggers `unroll.EnsureUnrollRequest{TriggerFraudSpend}` on detection |
 | [`lndbackend`](lndbackend/) | `BoardingBackend` implementation via LND's wallet kit |
 | [`lwwallet`](lwwallet/) | Lightweight in-process wallet (btcwallet + Esplora, no external LND) |
 | [`btcwbackend`](btcwbackend/) | Neutrino-backed wallet backend (btcwallet + compact block filters) |
@@ -72,6 +73,7 @@ package may import from a higher layer.
 | [`systest`](systest/) | System-level end-to-end tests |
 | [`internal/actortest`](internal/actortest/) | Durable actor integration tests with real DB backends |
 | [`internal/testutils`](internal/testutils/) | Deterministic key/signature generation for tests |
+| [`internal/indexerlimits`](internal/indexerlimits/) | Client-side indexer pagination safety bounds (cursor size cap) |
 | [`rules`](rules/) | ast-grep linting rules for code style enforcement |
 | [`tools`](tools/) | Development tool dependencies (protoc plugins, sqlc) |
 | [`cmd/protoc-gen-mailboxrpc`](cmd/protoc-gen-mailboxrpc/) | `protoc` plugin generating typed `mailbox/rpc` client/server stubs from `.proto` service definitions |

--- a/baselib/actor/AGENTS.md
+++ b/baselib/actor/AGENTS.md
@@ -38,6 +38,20 @@ crash-safe at-least-once delivery with exactly-once deduplication.
 - `ChannelMailbox[M, R]` — In-memory channel-based mailbox (non-durable, for lightweight actors).
 - `Mailbox[M, R]` — Interface for actor message queues: `Send(ctx, env) error` (blocking, returns `ErrMailboxClosed` or `ErrActorTerminated` on failure), `TrySend(env) error` (non-blocking), `Receive(ctx) iter.Seq[envelope]`, `Close()`, `IsClosed() bool`, `Drain() iter.Seq[envelope]`. `Send` previously returned `bool`; it now propagates the exact failure cause so callers can distinguish `ErrMailboxClosed`, `ErrActorTerminated`, and `context.Canceled`/`context.DeadlineExceeded` without inspecting actor state.
 - `isExpectedShutdownErr(err) bool` — Internal helper that classifies errors as expected during teardown: context cancellation/deadline, closed DB handle ("sql: database is closed", "sql: connection is already closed", "use of closed network connection"). Used by the lease loop to demote shutdown-path failures to debug instead of warn-flooding test artifacts at itest tail.
+- `Message.CorrelationKey() string` — Per-message FIFO key consumed by the
+  durable mailbox's claim path. Non-empty keys participate in per-key FIFO:
+  a message is claim-eligible only when no earlier same-key message
+  (compared by UUIDv7 `id`) exists in the same mailbox, even if the
+  earlier message is in retry backoff. Empty (the default on
+  `BaseMessage`) means the message is unkeyed and uses the existing
+  global `available_at` claim order. The override site is the concrete
+  message struct (e.g. `clientconn.ClientMessage` types in `rounds`),
+  not the framework — the framework just plumbs the value through
+  `EnqueueParams.CorrelationKey`.
+- `EnqueueParams.CorrelationKey` — Per-enqueue override stamped into the
+  `mailbox_messages.correlation_key` column. Populated automatically from
+  `msg.CorrelationKey()` by `DurableMailbox.Send`. A zero (empty) value
+  preserves the legacy unkeyed claim semantics.
 
 ## Relationships
 
@@ -54,6 +68,20 @@ crash-safe at-least-once delivery with exactly-once deduplication.
 - Transaction context (`WithTx`/`RequireTx`) enables same-DB-transaction joining between actors and their callers.
 - `Mailbox.Send` returns the exact failure error (`ErrMailboxClosed`, `ErrActorTerminated`, `context.Canceled`, `context.DeadlineExceeded`) rather than a boolean; `Tell` and `Ask` propagate this directly to callers.
 - During daemon teardown, the underlying DB is closed before every actor's lease loop has wound down. The lease loop uses `isExpectedShutdownErr` to demote these "database is closed" errors to debug level; real operational errors still surface as warnings because neither the actor context nor the outer context is done in those cases.
+- **Per-correlation-key FIFO claim.** Two messages in the same mailbox that
+  share a non-empty `CorrelationKey()` are processed in emission order
+  regardless of retry backoff. Without this invariant, a transient Tell
+  failure on msg1 would Nack-with-backoff (push `available_at` into the
+  future), and a later-enqueued msg2 with a smaller `available_at` would
+  overtake msg1 in the `LeaseNextMailboxMessage` claim. The fix is an
+  anti-join on `mailbox_messages.id` (UUIDv7, strictly orderable at
+  millisecond granularity) so the head of each correlation key drains
+  before any later same-key row is claim-eligible. Unkeyed messages
+  (empty `CorrelationKey()`) keep the legacy global `available_at`
+  order and do not interfere with keyed lanes. Head-of-line blocking
+  is bounded to the correlation key, not the mailbox; consumers are
+  already strictly serial per mailbox so this does not regress
+  throughput.
 
 ## Deep Docs
 

--- a/chainsource/AGENTS.md
+++ b/chainsource/AGENTS.md
@@ -38,6 +38,13 @@ communication alongside the raw registration API.
 - `MapBlockEpoch`, `MapConfirmationEvent`, `MapSpendEvent` — Generic helpers
   that wrap a target `TellOnlyRef[Out]` and a mapping function, producing a
   `TellOnlyRef` of the source event type for actor-to-actor notification wiring.
+- `IsIgnorableBroadcastError(err) bool` — Returns true when `err` signals
+  that the transaction is already known to the node (e.g. already in
+  mempool, already have transaction, output already spent). Used by
+  `txconfirm` to suppress spurious rebroadcast failures on retry.
+- `IsIgnorableMempoolRejectReason(reason string) bool` — Returns true when
+  a mempool rejection string indicates the transaction is already known,
+  allowing callers to treat the submission as a silent success.
 
 ## Relationships
 

--- a/chainsource/CLAUDE.md
+++ b/chainsource/CLAUDE.md
@@ -38,6 +38,13 @@ communication alongside the raw registration API.
 - `MapBlockEpoch`, `MapConfirmationEvent`, `MapSpendEvent` — Generic helpers
   that wrap a target `TellOnlyRef[Out]` and a mapping function, producing a
   `TellOnlyRef` of the source event type for actor-to-actor notification wiring.
+- `IsIgnorableBroadcastError(err) bool` — Returns true when `err` signals
+  that the transaction is already known to the node (e.g. already in
+  mempool, already have transaction, output already spent). Used by
+  `txconfirm` to suppress spurious rebroadcast failures on retry.
+- `IsIgnorableMempoolRejectReason(reason string) bool` — Returns true when
+  a mempool rejection string indicates the transaction is already known,
+  allowing callers to treat the submission as a silent success.
 
 ## Relationships
 

--- a/db/AGENTS.md
+++ b/db/AGENTS.md
@@ -77,7 +77,7 @@ backends.
   bounds enforced during `DeserializeTree` to prevent stack overflow or OOM.
 - `resolveInputPackage` / `loadPackageBundleBySessionID` — Two-stage OOR
   ancestry resolver in `oor_unroll_resolver.go`.
-- `LatestMigrationVersion = 11` — Current schema version.
+- `LatestMigrationVersion = 13` — Current schema version.
 
 ## Relationships
 
@@ -109,6 +109,20 @@ backends.
 - **Never write raw SQL in Go** — add queries to `db/queries/`, regenerate
   with `make sqlc`.
 - Per-subsystem logging: uses instance logger instead of global package logger.
+- Migration `000013_pending_board_request` adds `pending_board_requests`
+  table keyed by `(outpoint_hash, outpoint_index)`. Persists the user's
+  explicit `Board` RPC intent (target VTXO count, timestamp) so a daemon
+  restart between Board admission and round seal replays the request
+  rather than silently dropping it. Rows are cleared when the matching
+  boarding intent transitions out of Confirmed (atomically with the state
+  change). A subsequent Board call upserts `target_vtxo_count` for
+  still-Confirmed outpoints.
+- Migration `000012_boarding_sweep_ledger_events` inserts the
+  `boarding_sweep_fee_paid` ledger event type and the
+  `boarding_sweep_input` / `boarding_sweep_return` UTXO audit
+  classifications so boarding-sweep ledger entries satisfy the
+  `ledger_entries.event_type` and `wallet_utxo_log.classification` FK
+  constraints.
 - Migration `000011_boarding_sweeps` adds `boarding_sweeps` and
   `boarding_sweep_inputs` tables plus a new `sweep_pending` boarding status.
   Input FK `FOREIGN KEY (previous_status) REFERENCES boarding_statuses` ensures

--- a/db/CLAUDE.md
+++ b/db/CLAUDE.md
@@ -77,7 +77,7 @@ backends.
   bounds enforced during `DeserializeTree` to prevent stack overflow or OOM.
 - `resolveInputPackage` / `loadPackageBundleBySessionID` — Two-stage OOR
   ancestry resolver in `oor_unroll_resolver.go`.
-- `LatestMigrationVersion = 11` — Current schema version.
+- `LatestMigrationVersion = 13` — Current schema version.
 
 ## Relationships
 
@@ -109,6 +109,20 @@ backends.
 - **Never write raw SQL in Go** — add queries to `db/queries/`, regenerate
   with `make sqlc`.
 - Per-subsystem logging: uses instance logger instead of global package logger.
+- Migration `000013_pending_board_request` adds `pending_board_requests`
+  table keyed by `(outpoint_hash, outpoint_index)`. Persists the user's
+  explicit `Board` RPC intent (target VTXO count, timestamp) so a daemon
+  restart between Board admission and round seal replays the request
+  rather than silently dropping it. Rows are cleared when the matching
+  boarding intent transitions out of Confirmed (atomically with the state
+  change). A subsequent Board call upserts `target_vtxo_count` for
+  still-Confirmed outpoints.
+- Migration `000012_boarding_sweep_ledger_events` inserts the
+  `boarding_sweep_fee_paid` ledger event type and the
+  `boarding_sweep_input` / `boarding_sweep_return` UTXO audit
+  classifications so boarding-sweep ledger entries satisfy the
+  `ledger_entries.event_type` and `wallet_utxo_log.classification` FK
+  constraints.
 - Migration `000011_boarding_sweeps` adds `boarding_sweeps` and
   `boarding_sweep_inputs` tables plus a new `sweep_pending` boarding status.
   Input FK `FOREIGN KEY (previous_status) REFERENCES boarding_statuses` ensures

--- a/db/actordelivery/migrations/AGENTS.md
+++ b/db/actordelivery/migrations/AGENTS.md
@@ -13,8 +13,10 @@ generic `db/migrate` orchestration layer.
   `"actor_delivery_schema_migrations"`), `DatabaseName` (default
   `"actor_delivery"`), `LatestVersion` (downgrade guard, default
   `LatestMigrationVersion`), optional `Log btclog.Logger`.
-- `LatestMigrationVersion = 1` — Current schema version; bump when adding a
-  new SQL migration file.
+- `LatestMigrationVersion = 2` — Current schema version; bump when adding a
+  new SQL migration file. Version 2 adds the nullable `correlation_key`
+  column on `mailbox_messages` and the filtered composite index that backs
+  the per-correlation-key FIFO anti-join in `LeaseNextMailboxMessage`.
 - `RunMigrations(db, backend, cfg)` — Applies actor-delivery migrations.
   Validates inputs, applies `Config` defaults, delegates to
   `dbmigrate.RunMigrations` with postgres schema token replacements.

--- a/fraud/AGENTS.md
+++ b/fraud/AGENTS.md
@@ -1,0 +1,76 @@
+# fraud
+
+## Purpose
+
+Passive fraud-monitoring actor that arms ancestry spend watches on locally
+owned OOR VTXOs. When a watched ancestor outpoint is spent on-chain, it
+fans out one `unroll.EnsureUnrollRequest{Trigger: TriggerFraudSpend}` per
+affected VTXO so the unroll registry begins an immediate unilateral exit.
+
+## Key Types
+
+- `WatcherActor` — Non-durable actor owning the full watch set for all
+  tracked VTXOs. Created via `NewWatcherActor(WatcherConfig)`.
+- `WatcherConfig` — Config: `ChainSource` ref for spend registration,
+  `UnrollRef` for triggering exits, optional `Log`, and `MailboxSize`
+  (default `64`, sized to absorb reorg bursts without blocking the
+  chain-source publisher).
+- `ServiceKey()` — Returns the receptionist key `"recipient-fraud-watcher"`
+  used by `darepod` to look up the actor at runtime.
+- `Msg` / `Resp` — Sealed actor message/response interfaces.
+- `TrackVTXOsRequest` / `TrackVTXOsResp` — Tell the watcher to arm
+  watches for a batch of `vtxo.Descriptor` entries. The actor builds a
+  `WatchPlan` per descriptor and refcounts shared ancestor outpoints.
+- `UntrackRequest` / `UntrackResp` — Release watches for a target
+  outpoint; when refcount drops to zero the spend registration is
+  cancelled.
+- `SpendObservedMsg` / `AckResp` — Notification from `chainsource`; the
+  watcher fans out an `EnsureUnrollRequest` for every VTXO that
+  contributed to the spent ancestor.
+- `WatchPlan` — Per-descriptor ancestry watch plan produced by
+  `BuildWatchPlan(desc)`. Walks `desc.Ancestry`, derives the ancestor
+  outpoints from each `TreePath`, and records which target VTXOs depend
+  on each ancestor.
+- `WatchPoint` — One entry in a `WatchPlan`: the ancestor outpoint and
+  the target VTXO outpoint it guards.
+- `TrackVTXOs(ctx, tracker, descs)` — Convenience wrapper that calls
+  `TrackVTXOsRequest` on a `TellOnlyRef[Msg]`; returns
+  `ErrWatchUnavailable` when the actor is not registered.
+
+## Relationships
+
+- **Depends on**: `chainsource` (passive spend watches per ancestor),
+  `vtxo` (`Descriptor`, ancestry fields), `unroll` (registry for
+  fraud-triggered exits), `baselib/actor` (actor system + service key).
+- **Depended on by**: `darepod` (wires watcher at startup; calls
+  `TrackVTXOs` from the OOR materialization path after incoming VTXOs
+  are durably persisted).
+- **Sends**:
+  - → `chainsource`: `RegisterSpendRequest` per unique ancestor outpoint
+    (first reference); `UnregisterSpendRequest` when refcount drops to
+    zero.
+  - → `unroll` registry: `EnsureUnrollRequest{Trigger: TriggerFraudSpend}`
+    per affected VTXO on `SpendObservedMsg`.
+- **Receives**:
+  - ← `darepod` (via `TrackVTXOs`): `TrackVTXOsRequest`
+  - ← `darepod` (on VTXO terminal or manual untrack): `UntrackRequest`
+  - ← `chainsource` (spend notification Tell ref): `SpendObservedMsg`
+
+## Invariants
+
+- Ancestor watch registrations are refcounted: a shared ancestor outpoint
+  that appears in multiple VTXOs' ancestry is registered only once with
+  `chainsource`, and only cancelled when all depending VTXOs have been
+  untracked.
+- A spend notification fans out to all VTXOs that cited the spent
+  ancestor, even if some of those VTXOs are already in a terminal state;
+  the unroll registry dedup handles redundant `EnsureUnroll` calls.
+- `BuildWatchPlan` rejects descriptors with an empty `Ancestry` slice
+  (no tree path to watch) and returns a nil plan; callers skip tracking
+  for such VTXOs rather than registering a zero-outpoint watch.
+
+## Deep Docs
+
+- [docs/durable_actor_architecture.md](../docs/durable_actor_architecture.md) — Actor system internals.
+- [unroll/CLAUDE.md](../unroll/CLAUDE.md) — Unilateral-exit actor driven by fraud triggers.
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/fraud/CLAUDE.md
+++ b/fraud/CLAUDE.md
@@ -1,0 +1,76 @@
+# fraud
+
+## Purpose
+
+Passive fraud-monitoring actor that arms ancestry spend watches on locally
+owned OOR VTXOs. When a watched ancestor outpoint is spent on-chain, it
+fans out one `unroll.EnsureUnrollRequest{Trigger: TriggerFraudSpend}` per
+affected VTXO so the unroll registry begins an immediate unilateral exit.
+
+## Key Types
+
+- `WatcherActor` — Non-durable actor owning the full watch set for all
+  tracked VTXOs. Created via `NewWatcherActor(WatcherConfig)`.
+- `WatcherConfig` — Config: `ChainSource` ref for spend registration,
+  `UnrollRef` for triggering exits, optional `Log`, and `MailboxSize`
+  (default `64`, sized to absorb reorg bursts without blocking the
+  chain-source publisher).
+- `ServiceKey()` — Returns the receptionist key `"recipient-fraud-watcher"`
+  used by `darepod` to look up the actor at runtime.
+- `Msg` / `Resp` — Sealed actor message/response interfaces.
+- `TrackVTXOsRequest` / `TrackVTXOsResp` — Tell the watcher to arm
+  watches for a batch of `vtxo.Descriptor` entries. The actor builds a
+  `WatchPlan` per descriptor and refcounts shared ancestor outpoints.
+- `UntrackRequest` / `UntrackResp` — Release watches for a target
+  outpoint; when refcount drops to zero the spend registration is
+  cancelled.
+- `SpendObservedMsg` / `AckResp` — Notification from `chainsource`; the
+  watcher fans out an `EnsureUnrollRequest` for every VTXO that
+  contributed to the spent ancestor.
+- `WatchPlan` — Per-descriptor ancestry watch plan produced by
+  `BuildWatchPlan(desc)`. Walks `desc.Ancestry`, derives the ancestor
+  outpoints from each `TreePath`, and records which target VTXOs depend
+  on each ancestor.
+- `WatchPoint` — One entry in a `WatchPlan`: the ancestor outpoint and
+  the target VTXO outpoint it guards.
+- `TrackVTXOs(ctx, tracker, descs)` — Convenience wrapper that calls
+  `TrackVTXOsRequest` on a `TellOnlyRef[Msg]`; returns
+  `ErrWatchUnavailable` when the actor is not registered.
+
+## Relationships
+
+- **Depends on**: `chainsource` (passive spend watches per ancestor),
+  `vtxo` (`Descriptor`, ancestry fields), `unroll` (registry for
+  fraud-triggered exits), `baselib/actor` (actor system + service key).
+- **Depended on by**: `darepod` (wires watcher at startup; calls
+  `TrackVTXOs` from the OOR materialization path after incoming VTXOs
+  are durably persisted).
+- **Sends**:
+  - → `chainsource`: `RegisterSpendRequest` per unique ancestor outpoint
+    (first reference); `UnregisterSpendRequest` when refcount drops to
+    zero.
+  - → `unroll` registry: `EnsureUnrollRequest{Trigger: TriggerFraudSpend}`
+    per affected VTXO on `SpendObservedMsg`.
+- **Receives**:
+  - ← `darepod` (via `TrackVTXOs`): `TrackVTXOsRequest`
+  - ← `darepod` (on VTXO terminal or manual untrack): `UntrackRequest`
+  - ← `chainsource` (spend notification Tell ref): `SpendObservedMsg`
+
+## Invariants
+
+- Ancestor watch registrations are refcounted: a shared ancestor outpoint
+  that appears in multiple VTXOs' ancestry is registered only once with
+  `chainsource`, and only cancelled when all depending VTXOs have been
+  untracked.
+- A spend notification fans out to all VTXOs that cited the spent
+  ancestor, even if some of those VTXOs are already in a terminal state;
+  the unroll registry dedup handles redundant `EnsureUnroll` calls.
+- `BuildWatchPlan` rejects descriptors with an empty `Ancestry` slice
+  (no tree path to watch) and returns a nil plan; callers skip tracking
+  for such VTXOs rather than registering a zero-outpoint watch.
+
+## Deep Docs
+
+- [docs/durable_actor_architecture.md](../docs/durable_actor_architecture.md) — Actor system internals.
+- [unroll/CLAUDE.md](../unroll/CLAUDE.md) — Unilateral-exit actor driven by fraud triggers.
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/internal/indexerlimits/AGENTS.md
+++ b/internal/indexerlimits/AGENTS.md
@@ -1,0 +1,34 @@
+# internal/indexerlimits
+
+## Purpose
+
+Client-side safety bounds for indexer pagination to prevent resource
+exhaustion from untrusted remote servers. Validates opaque cursor blobs
+before they are used in `ListVTXOsByScripts` queries.
+
+## Key Types
+
+- `MaxVTXOsByScriptsCursorBytes = 256` — Maximum byte length accepted for
+  an opaque `ListVTXOsByScripts` pagination cursor. The current server
+  uses a 36-byte outpoint keyset cursor; the cap leaves room for format
+  evolution while bounding untrusted remote bytes.
+- `ValidateVTXOsByScriptsCursor(cursor []byte) error` — Returns an error
+  if `len(cursor)` exceeds `MaxVTXOsByScriptsCursorBytes`. Called in the
+  OOR phase-2 metadata resolution path before the cursor is forwarded
+  into the next page request.
+
+## Relationships
+
+- **Depends on**: (no internal repo imports).
+- **Depended on by**: `indexer` (cursor length validation before passing
+  server-supplied cursors to subsequent `ListVTXOsByScripts` requests).
+
+## Invariants
+
+- Validation is a pure byte-length check; no attempt is made to decode
+  or interpret the cursor format, which is server-defined and opaque to
+  the client.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/internal/indexerlimits/CLAUDE.md
+++ b/internal/indexerlimits/CLAUDE.md
@@ -1,0 +1,34 @@
+# internal/indexerlimits
+
+## Purpose
+
+Client-side safety bounds for indexer pagination to prevent resource
+exhaustion from untrusted remote servers. Validates opaque cursor blobs
+before they are used in `ListVTXOsByScripts` queries.
+
+## Key Types
+
+- `MaxVTXOsByScriptsCursorBytes = 256` — Maximum byte length accepted for
+  an opaque `ListVTXOsByScripts` pagination cursor. The current server
+  uses a 36-byte outpoint keyset cursor; the cap leaves room for format
+  evolution while bounding untrusted remote bytes.
+- `ValidateVTXOsByScriptsCursor(cursor []byte) error` — Returns an error
+  if `len(cursor)` exceeds `MaxVTXOsByScriptsCursorBytes`. Called in the
+  OOR phase-2 metadata resolution path before the cursor is forwarded
+  into the next page request.
+
+## Relationships
+
+- **Depends on**: (no internal repo imports).
+- **Depended on by**: `indexer` (cursor length validation before passing
+  server-supplied cursors to subsequent `ListVTXOsByScripts` requests).
+
+## Invariants
+
+- Validation is a pure byte-length check; no attempt is made to decode
+  or interpret the cursor format, which is server-defined and opaque to
+  the client.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/lib/arkscript/AGENTS.md
+++ b/lib/arkscript/AGENTS.md
@@ -33,7 +33,13 @@ validated invariants.
     signature over an attacker-chosen tapscript.
 - `StandardVTXOParams` — Decoded parameters for a standard Ark VTXO policy (owner key, operator key, CSV delay). Derived via `DecodeStandardVTXOParams`.
 - `ComposedPolicy` — Composes an existing `CompiledPolicy` with an additional sibling tap branch root, allowing sub-tree aggregation. Built with `ComposeWithSiblingRoot`.
-- `AnchorOutput` — Creates a zero-value P2A anchor transaction output for CPFP fee bumping (replaces the removed `lib/scripts.AnchorPkScript`).
+- `AnchorOutput(...AnchorOption) *wire.TxOut` — Creates a P2A anchor
+  transaction output for CPFP fee bumping. Defaults to zero value;
+  `WithAnchorValue(sats int64)` overrides the output amount when a
+  non-dust anchor is required (e.g. boarding sweep anchors at 330 sats).
+- `AnchorOption` — Function type for customizing `AnchorOutput`.
+- `WithAnchorValue(sats int64) AnchorOption` — Sets a non-zero value on
+  the anchor output.
 - `EncodedLeaf` / `EncodeTapTree` / `DecodeTapTree` — TLV-based tap tree serialization for PSBT sidecars compatible with `waddrmgr` format.
 - `EncodeStandardVTXOArtifacts(ownerKey, operatorKey, exitDelay)` — Convenience
   helper returning both the encoded policy template bytes and the canonical P2TR

--- a/lib/arkscript/CLAUDE.md
+++ b/lib/arkscript/CLAUDE.md
@@ -33,7 +33,13 @@ validated invariants.
     signature over an attacker-chosen tapscript.
 - `StandardVTXOParams` — Decoded parameters for a standard Ark VTXO policy (owner key, operator key, CSV delay). Derived via `DecodeStandardVTXOParams`.
 - `ComposedPolicy` — Composes an existing `CompiledPolicy` with an additional sibling tap branch root, allowing sub-tree aggregation. Built with `ComposeWithSiblingRoot`.
-- `AnchorOutput` — Creates a zero-value P2A anchor transaction output for CPFP fee bumping (replaces the removed `lib/scripts.AnchorPkScript`).
+- `AnchorOutput(...AnchorOption) *wire.TxOut` — Creates a P2A anchor
+  transaction output for CPFP fee bumping. Defaults to zero value;
+  `WithAnchorValue(sats int64)` overrides the output amount when a
+  non-dust anchor is required (e.g. boarding sweep anchors at 330 sats).
+- `AnchorOption` — Function type for customizing `AnchorOutput`.
+- `WithAnchorValue(sats int64) AnchorOption` — Sets a non-zero value on
+  the anchor output.
 - `EncodedLeaf` / `EncodeTapTree` / `DecodeTapTree` — TLV-based tap tree serialization for PSBT sidecars compatible with `waddrmgr` format.
 - `EncodeStandardVTXOArtifacts(ownerKey, operatorKey, exitDelay)` — Convenience
   helper returning both the encoded policy template bytes and the canonical P2TR

--- a/wallet/AGENTS.md
+++ b/wallet/AGENTS.md
@@ -34,6 +34,21 @@ refresh, leave, OOR spend, and directed send flows.
 - `SendVTXOsRequest` / `SendVTXOsResponse` — Ask-request for in-round directed sends. Validates each recipient amount is within `(0, MaxSatoshi]` and that the running total never overflows `int64`, atomically selects and reserves VTXOs via `SelectAndReserveForfeitRequest`, builds forfeit + recipient VTXO intents, and registers with the round actor. Supports dry-run mode for previewing coin selection without committing. Reserved VTXOs are released via a deferred cleanup that uses `context.WithoutCancel` so cleanup survives caller disconnect; on success, a `committed` flag is set to skip the release.
 - `GetConfirmedBoardingIntentsRequest` / `GetConfirmedBoardingIntentsResponse` — Ask-request to retrieve currently confirmed boarding intents (used by the RPC/CLI layer to report boarding balance with policy metadata).
 - `VTXODescriptor.EffectivePolicyTemplate` — Decodes the serialized `PolicyTemplate` field on the wallet-level VTXO descriptor using `lib/arkscript`.
+- `SweepBoardingUTXOsRequest` / `SweepBoardingUTXOsResponse` — Ask-request
+  to the `BoardingSweepActor` to build (and optionally broadcast) an
+  aggregate boarding sweep transaction. `Request.Broadcast bool` controls
+  whether the result is persisted and submitted to the network.
+  `Response.Tx`, `Response.Fee`, and `Response.Txid` are always populated
+  for previewing; `Response.Persisted bool` indicates whether the row was
+  written to the boarding sweep store.
+- `BoardingSweepActor` — Durable actor that builds, signs, and optionally
+  broadcasts an aggregate transaction spending one or more CSV-mature
+  boarding outpoints to the backing wallet's change address. Fee tunables:
+  fallback rate 2 sat/vB, default conf target 6, max fee 25% of total
+  boarding value, max 100 inputs, P2A anchor value 330 sats.
+- `NewBoardingSweep` / `NewBoardingSweepInput` — Domain types for the
+  boarding sweep control plane (passed to `db.BoardingWalletStore` for
+  persistence).
 
 ## Relationships
 

--- a/wallet/CLAUDE.md
+++ b/wallet/CLAUDE.md
@@ -34,6 +34,21 @@ refresh, leave, OOR spend, and directed send flows.
 - `SendVTXOsRequest` / `SendVTXOsResponse` — Ask-request for in-round directed sends. Validates each recipient amount is within `(0, MaxSatoshi]` and that the running total never overflows `int64`, atomically selects and reserves VTXOs via `SelectAndReserveForfeitRequest`, builds forfeit + recipient VTXO intents, and registers with the round actor. Supports dry-run mode for previewing coin selection without committing. Reserved VTXOs are released via a deferred cleanup that uses `context.WithoutCancel` so cleanup survives caller disconnect; on success, a `committed` flag is set to skip the release.
 - `GetConfirmedBoardingIntentsRequest` / `GetConfirmedBoardingIntentsResponse` — Ask-request to retrieve currently confirmed boarding intents (used by the RPC/CLI layer to report boarding balance with policy metadata).
 - `VTXODescriptor.EffectivePolicyTemplate` — Decodes the serialized `PolicyTemplate` field on the wallet-level VTXO descriptor using `lib/arkscript`.
+- `SweepBoardingUTXOsRequest` / `SweepBoardingUTXOsResponse` — Ask-request
+  to the `BoardingSweepActor` to build (and optionally broadcast) an
+  aggregate boarding sweep transaction. `Request.Broadcast bool` controls
+  whether the result is persisted and submitted to the network.
+  `Response.Tx`, `Response.Fee`, and `Response.Txid` are always populated
+  for previewing; `Response.Persisted bool` indicates whether the row was
+  written to the boarding sweep store.
+- `BoardingSweepActor` — Durable actor that builds, signs, and optionally
+  broadcasts an aggregate transaction spending one or more CSV-mature
+  boarding outpoints to the backing wallet's change address. Fee tunables:
+  fallback rate 2 sat/vB, default conf target 6, max fee 25% of total
+  boarding value, max 100 inputs, P2A anchor value 330 sats.
+- `NewBoardingSweep` / `NewBoardingSweepInput` — Domain types for the
+  boarding sweep control plane (passed to `db.BoardingWalletStore` for
+  persistence).
 
 ## Relationships
 

--- a/walletcore/AGENTS.md
+++ b/walletcore/AGENTS.md
@@ -12,6 +12,19 @@ btcwallet.BtcWallet regardless of the underlying chain source.
 - `Wallet` — Core wallet struct embedding `input.Signer`. Provides key derivation, P2TR address generation, balance queries, and UTXO listing. Also implements `proofkeys.Backend` (via `ProofSigner` method). Chain-specific implementations embed this to satisfy `round.ClientWallet`.
 - `BoardingBackendBase` — Shared boarding functionality: taproot script import under BIP86 scope, imported address tracking for UTXO filtering, and HD key derivation. Chain-specific adapters embed this and add `ListUnspent`, `GetTransaction`, `GetBlock`.
 - `Config` — Base configuration (seed, chain params, recovery window, DB dir, logger) shared by all btcwallet-backed wallet backends.
+- `LockID` — `[32]byte` caller-scoped output lease identifier. A stable
+  value shared by all callers that need to cross-subsystem coordinate
+  UTXO reservations (e.g. `txconfirmLockID` in `txconfirm`). Leases
+  round-trip across restart by casting directly to `wtxmgr.LockID`.
+- `Utxo` — Simplified confirmed UTXO representation used for fee-input
+  selection: `Outpoint wire.OutPoint`, `PkScript []byte`,
+  `Amount btcutil.Amount`, `Confirmations int32`.
+- `OutputLeaser` — Interface for cross-subsystem UTXO reservation:
+  `LeaseOutput(ctx, outpoint, lockID LockID, expiry time.Time) error`
+  and `ReleaseOutput(ctx, outpoint, lockID LockID) error`. Implemented
+  by all three backing wallet backends (`btcwbackend`, `lndbackend`,
+  `lwwallet`) and consumed by `txconfirm.CPFPBroadcaster` for fee-input
+  lock coordination.
 
 ## Relationships
 

--- a/walletcore/CLAUDE.md
+++ b/walletcore/CLAUDE.md
@@ -12,6 +12,19 @@ btcwallet.BtcWallet regardless of the underlying chain source.
 - `Wallet` — Core wallet struct embedding `input.Signer`. Provides key derivation, P2TR address generation, balance queries, and UTXO listing. Also implements `proofkeys.Backend` (via `ProofSigner` method). Chain-specific implementations embed this to satisfy `round.ClientWallet`.
 - `BoardingBackendBase` — Shared boarding functionality: taproot script import under BIP86 scope, imported address tracking for UTXO filtering, and HD key derivation. Chain-specific adapters embed this and add `ListUnspent`, `GetTransaction`, `GetBlock`.
 - `Config` — Base configuration (seed, chain params, recovery window, DB dir, logger) shared by all btcwallet-backed wallet backends.
+- `LockID` — `[32]byte` caller-scoped output lease identifier. A stable
+  value shared by all callers that need to cross-subsystem coordinate
+  UTXO reservations (e.g. `txconfirmLockID` in `txconfirm`). Leases
+  round-trip across restart by casting directly to `wtxmgr.LockID`.
+- `Utxo` — Simplified confirmed UTXO representation used for fee-input
+  selection: `Outpoint wire.OutPoint`, `PkScript []byte`,
+  `Amount btcutil.Amount`, `Confirmations int32`.
+- `OutputLeaser` — Interface for cross-subsystem UTXO reservation:
+  `LeaseOutput(ctx, outpoint, lockID LockID, expiry time.Time) error`
+  and `ReleaseOutput(ctx, outpoint, lockID LockID) error`. Implemented
+  by all three backing wallet backends (`btcwbackend`, `lndbackend`,
+  `lwwallet`) and consumed by `txconfirm.CPFPBroadcaster` for fee-input
+  lock coordination.
 
 ## Relationships
 


### PR DESCRIPTION
Automated nightly documentation sweep via `.claude/skills/doc-gardening`.

## Changes

**New per-package docs (CLAUDE.md + AGENTS.md):**
- `fraud/` — New passive OOR ancestry fraud-watch actor package
- `internal/indexerlimits/` — New indexer pagination safety bounds package

**Updated per-package docs (CLAUDE.md + AGENTS.md):**
- `baselib/actor/` — Sync AGENTS.md divergence (CorrelationKey FIFO invariant)
- `chainsource/` — Add `IsIgnorableBroadcastError`, `IsIgnorableMempoolRejectReason` helpers
- `db/` — Bump `LatestMigrationVersion` 11 → 13; document migrations 12 (boarding-sweep ledger events) and 13 (pending board requests)
- `db/actordelivery/migrations/` — Sync AGENTS.md divergence
- `lib/arkscript/` — Add `AnchorOption`, `WithAnchorValue` for non-zero P2A anchors
- `wallet/` — Add `SweepBoardingUTXOsRequest/Response`, `BoardingSweepActor`, `NewBoardingSweep/Input` types
- `walletcore/` — Add `LockID`, `Utxo`, `OutputLeaser` types from `output_leaser.go`

**ARCHITECTURE.md:**
- Add `fraud` to Layer 2 (Infrastructure)
- Add `internal/indexerlimits` to Layer 4 (Testing & Tooling)

Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

Please review the updated CLAUDE.md/AGENTS.md and ARCHITECTURE.md diffs.