### PR TITLE
Populate boarding history chain fields

### DIFF
--- a/darepod/rpc_fees.go
+++ b/darepod/rpc_fees.go
@@ -463,17 +463,9 @@ func transactionHistoryRowToProto(row *sqlc.ListTransactionHistoryRow) (
 	}, nil
 }
 
-// transactionHistoryTxID normalizes the nullable sqlc txid union column
-// into the human-readable chainhash string used elsewhere in the RPC API.
-func transactionHistoryTxID(raw any) (string, error) {
-	if raw == nil {
-		return "", nil
-	}
-
-	txidBytes, ok := raw.([]byte)
-	if !ok {
-		return "", fmt.Errorf("unexpected txid type %T", raw)
-	}
+// transactionHistoryTxID normalizes the nullable sqlc txid column into
+// the human-readable chainhash string used elsewhere in the RPC API.
+func transactionHistoryTxID(txidBytes []byte) (string, error) {
 	if len(txidBytes) == 0 {
 		return "", nil
 	}

--- a/db/ledger_store.go
+++ b/db/ledger_store.go
@@ -67,10 +67,30 @@ func (s *LedgerStoreDB) InsertLedgerEntry(ctx context.Context,
 					Description:    entry.Description,
 					CreatedAt:      entry.CreatedAt,
 					IdempotencyKey: entry.IdempotencyKey,
+					ChainTxid:      entry.ChainTxid,
+					ChainVout: sqlInt32Ptr(
+						entry.ChainVout,
+					),
+					ConfirmationHeight: sqlInt32Ptr(
+						entry.ConfirmationHeight,
+					),
 				},
 			)
 		},
 	)
+}
+
+// sqlInt32Ptr converts an optional int32 pointer to the nullable sqlc shape
+// used by ledger chain metadata columns.
+func sqlInt32Ptr(v *int32) sql.NullInt32 {
+	if v == nil {
+		return sql.NullInt32{}
+	}
+
+	return sql.NullInt32{
+		Int32: *v,
+		Valid: true,
+	}
 }
 
 // GetAccountBalance returns the net balance (debits minus credits) for

--- a/db/ledger_store_test.go
+++ b/db/ledger_store_test.go
@@ -68,6 +68,21 @@ func testBytes(length int, seed byte) []byte {
 	return out
 }
 
+// testHash32 returns a deterministic 32-byte hash for tests.
+func testHash32(seed byte) [32]byte {
+	var out [32]byte
+	for i := range out {
+		out[i] = seed + byte(i)
+	}
+
+	return out
+}
+
+// testInt32Ptr returns a pointer to v for optional int32 test fields.
+func testInt32Ptr(v int32) *int32 {
+	return &v
+}
+
 // insertTransactionHistorySweepRow inserts a minimal boarding_sweeps row for
 // transaction-history tests. The history query does not need sweep inputs.
 func insertTransactionHistorySweepRow(t *testing.T, db *BaseDB, txid []byte,
@@ -208,6 +223,175 @@ func TestLedgerStoreTransactionHistoryFiltersBeforePagination(t *testing.T) {
 	require.Equal(t, "boarding_sweep", sweepRows[0].Source)
 	require.Equal(t, int64(4_000), sweepRows[0].AmountSat)
 	require.Equal(t, int64(40), sweepRows[0].FeeSat)
+}
+
+// TestLedgerStoreTransactionHistoryWalletUTXOCreatedChainFields verifies
+// wallet UTXO creation ledger rows expose the chain transaction id and
+// confirmation height in the unified transaction history.
+func TestLedgerStoreTransactionHistoryWalletUTXOCreatedChainFields(
+	t *testing.T) {
+
+	t.Parallel()
+
+	ctx := t.Context()
+	store := newLedgerStoreForTest(t)
+
+	outpointHash := testHash32(0x42)
+	const (
+		outpointIndex      = uint32(7)
+		confirmationHeight = int32(304_081)
+	)
+
+	require.NoError(
+		t,
+		store.InsertLedgerEntry(
+			ctx, ledger.LedgerEntry{
+				DebitAccount:   ledger.AccountWalletBalance,
+				CreditAccount:  ledger.AccountOpeningBalance,
+				AmountSat:      100_001,
+				EventType:      ledger.EventWalletUTXOCreated,
+				Description:    "boarding deposit",
+				CreatedAt:      1_700_000_501,
+				IdempotencyKey: testBytes(36, 0x51),
+				ChainTxid:      outpointHash[:],
+				ChainVout: testInt32Ptr(
+					int32(outpointIndex),
+				),
+				ConfirmationHeight: testInt32Ptr(
+					confirmationHeight,
+				),
+			},
+		),
+	)
+
+	rows, err := store.ListTransactionHistory(ctx, "boarding", 0, 0, 10, 0)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+
+	row := rows[0]
+	require.Equal(t, "ledger", row.Source)
+	require.Equal(t, "boarding", row.TransactionType)
+	require.Equal(t, ledger.EventWalletUTXOCreated, row.Subtype)
+	require.Equal(t, "confirmed", row.Status)
+	require.Equal(t, outpointHash[:], row.Txid)
+	require.Equal(t, confirmationHeight, row.ConfirmationHeight)
+}
+
+// TestLedgerStoreTransactionHistoryWalletUTXOCreatedMissingHeight verifies a
+// wallet UTXO creation ledger row with a chain txid but no stored confirmation
+// height keeps the txid and falls back to an unknown height.
+func TestLedgerStoreTransactionHistoryWalletUTXOCreatedMissingHeight(
+	t *testing.T) {
+
+	t.Parallel()
+
+	ctx := t.Context()
+	store := newLedgerStoreForTest(t)
+
+	outpointHash := testHash32(0x62)
+	require.NoError(
+		t,
+		store.InsertLedgerEntry(
+			ctx, ledger.LedgerEntry{
+				DebitAccount:   ledger.AccountWalletBalance,
+				CreditAccount:  ledger.AccountOpeningBalance,
+				AmountSat:      100_001,
+				EventType:      ledger.EventWalletUTXOCreated,
+				Description:    "boarding deposit no audit",
+				CreatedAt:      1_700_000_600,
+				IdempotencyKey: testBytes(36, 0x61),
+				ChainTxid:      outpointHash[:],
+			},
+		),
+	)
+
+	rows, err := store.ListTransactionHistory(ctx, "boarding", 0, 0, 10, 0)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+
+	row := rows[0]
+	require.Equal(t, "ledger", row.Source)
+	require.Equal(t, "boarding", row.TransactionType)
+	require.Equal(t, ledger.EventWalletUTXOCreated, row.Subtype)
+	require.Equal(t, "confirmed", row.Status)
+	require.Equal(t, outpointHash[:], row.Txid)
+	require.Zero(t, row.ConfirmationHeight)
+}
+
+// TestLedgerStoreTransactionHistoryBoardingFeePaidHasNoChainFields verifies
+// boarding fee ledger rows keep their recorded status and empty chain fields.
+func TestLedgerStoreTransactionHistoryBoardingFeePaidHasNoChainFields(
+	t *testing.T) {
+
+	t.Parallel()
+
+	ctx := t.Context()
+	store := newLedgerStoreForTest(t)
+
+	require.NoError(
+		t,
+		store.InsertLedgerEntry(
+			ctx, ledger.LedgerEntry{
+				DebitAccount:  ledger.AccountFeesPaid,
+				CreditAccount: ledger.AccountWalletBalance,
+				AmountSat:     1_000,
+				EventType:     ledger.EventBoardingFeePaid,
+				Description:   "boarding fee paid",
+				CreatedAt:     1_700_000_700,
+			},
+		),
+	)
+
+	rows, err := store.ListTransactionHistory(ctx, "boarding", 0, 0, 10, 0)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+
+	row := rows[0]
+	require.Equal(t, "ledger", row.Source)
+	require.Equal(t, "boarding", row.TransactionType)
+	require.Equal(t, ledger.EventBoardingFeePaid, row.Subtype)
+	require.Equal(t, "recorded", row.Status)
+	require.Nil(t, row.Txid)
+	require.Zero(t, row.ConfirmationHeight)
+}
+
+// TestLedgerStoreTransactionHistoryWalletUTXOCreatedNoChainFields verifies
+// wallet UTXO creation rows do not infer chain fields from legacy
+// idempotency-key bytes during ordinary history reads.
+func TestLedgerStoreTransactionHistoryWalletUTXOCreatedNoChainFields(
+	t *testing.T) {
+
+	t.Parallel()
+
+	ctx := t.Context()
+	store := newLedgerStoreForTest(t)
+
+	require.NoError(
+		t,
+		store.InsertLedgerEntry(
+			ctx, ledger.LedgerEntry{
+				DebitAccount:   ledger.AccountWalletBalance,
+				CreditAccount:  ledger.AccountOpeningBalance,
+				AmountSat:      100_001,
+				EventType:      ledger.EventWalletUTXOCreated,
+				Description:    "boarding deposit bad key",
+				CreatedAt:      1_700_000_800,
+				IdempotencyKey: testBytes(32, 0x72),
+			},
+		),
+	)
+
+	rows, err := store.ListTransactionHistory(ctx, "boarding", 0, 0, 10, 0)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+
+	row := rows[0]
+	require.Equal(t, "ledger", row.Source)
+	require.Equal(t, "boarding", row.TransactionType)
+	require.Equal(t, ledger.EventWalletUTXOCreated, row.Subtype)
+	require.Equal(t, "confirmed", row.Status)
+	require.Nil(t, row.Txid)
+	require.Zero(t, row.ConfirmationHeight)
 }
 
 // TestLedgerStoreEntryIDsDoNotReuseAfterDelete verifies ledger entry IDs

--- a/db/migrations.go
+++ b/db/migrations.go
@@ -10,7 +10,7 @@ const (
 	// daemon.
 	//
 	// NOTE: This MUST be updated when a new migration is added.
-	LatestMigrationVersion uint = 13
+	LatestMigrationVersion uint = 14
 )
 
 // MigrationTarget is a functional option that can be passed to applyMigrations

--- a/db/sqlc/fee_accounting.sql.go
+++ b/db/sqlc/fee_accounting.sql.go
@@ -7,6 +7,7 @@ package sqlc
 
 import (
 	"context"
+	"database/sql"
 )
 
 const CountClientLedgerEntries = `-- name: CountClientLedgerEntries :one
@@ -56,28 +57,33 @@ const InsertClientLedgerEntry = `-- name: InsertClientLedgerEntry :exec
 INSERT INTO ledger_entries (
     debit_account, credit_account, amount_sat,
     round_id, session_id, idempotency_key,
-    event_type, description, created_at
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+    event_type, description, created_at,
+    chain_txid, chain_vout, confirmation_height
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
 ON CONFLICT DO NOTHING
 `
 
 type InsertClientLedgerEntryParams struct {
-	DebitAccount   string
-	CreditAccount  string
-	AmountSat      int64
-	RoundID        []byte
-	SessionID      []byte
-	IdempotencyKey []byte
-	EventType      string
-	Description    string
-	CreatedAt      int64
+	DebitAccount       string
+	CreditAccount      string
+	AmountSat          int64
+	RoundID            []byte
+	SessionID          []byte
+	IdempotencyKey     []byte
+	EventType          string
+	Description        string
+	CreatedAt          int64
+	ChainTxid          []byte
+	ChainVout          sql.NullInt32
+	ConfirmationHeight sql.NullInt32
 }
 
 // Column order matches the ledger_entries CREATE TABLE layout
-// in migration 000006 so the generated row type for SELECTs
-// stays structurally identical to the LedgerEntry model, which
-// is what the adapter returns. Changing the table column order
-// requires changing these SELECTs in lockstep.
+// from migration 000006 plus the chain metadata columns added in
+// migration 000014, so the generated row type for SELECTs stays
+// structurally identical to the LedgerEntry model returned by the
+// adapter. Changing the table column order requires changing these
+// SELECTs in lockstep.
 //
 // ON CONFLICT DO NOTHING makes the insert idempotent against
 // every partial unique index on ledger_entries:
@@ -101,6 +107,9 @@ func (q *Queries) InsertClientLedgerEntry(ctx context.Context, arg InsertClientL
 		arg.EventType,
 		arg.Description,
 		arg.CreatedAt,
+		arg.ChainTxid,
+		arg.ChainVout,
+		arg.ConfirmationHeight,
 	)
 	return err
 }
@@ -137,7 +146,8 @@ func (q *Queries) ListClientAccounts(ctx context.Context) ([]Account, error) {
 const ListClientLedgerEntries = `-- name: ListClientLedgerEntries :many
 SELECT entry_id, debit_account, credit_account, amount_sat,
        round_id, session_id, idempotency_key,
-       event_type, description, created_at
+       event_type, description, created_at,
+       chain_txid, chain_vout, confirmation_height
 FROM ledger_entries
 ORDER BY created_at DESC
 LIMIT $1 OFFSET $2
@@ -168,6 +178,9 @@ func (q *Queries) ListClientLedgerEntries(ctx context.Context, arg ListClientLed
 			&i.EventType,
 			&i.Description,
 			&i.CreatedAt,
+			&i.ChainTxid,
+			&i.ChainVout,
+			&i.ConfirmationHeight,
 		); err != nil {
 			return nil, err
 		}
@@ -185,7 +198,8 @@ func (q *Queries) ListClientLedgerEntries(ctx context.Context, arg ListClientLed
 const ListClientLedgerEntriesByType = `-- name: ListClientLedgerEntriesByType :many
 SELECT entry_id, debit_account, credit_account, amount_sat,
        round_id, session_id, idempotency_key,
-       event_type, description, created_at
+       event_type, description, created_at,
+       chain_txid, chain_vout, confirmation_height
 FROM ledger_entries
 WHERE event_type = $1
 ORDER BY created_at DESC
@@ -218,6 +232,9 @@ func (q *Queries) ListClientLedgerEntriesByType(ctx context.Context, arg ListCli
 			&i.EventType,
 			&i.Description,
 			&i.CreatedAt,
+			&i.ChainTxid,
+			&i.ChainVout,
+			&i.ConfirmationHeight,
 		); err != nil {
 			return nil, err
 		}
@@ -240,33 +257,33 @@ SELECT source, entry_id, txid, transaction_type, subtype,
 FROM (
     SELECT 0 AS source_order,
            'ledger' AS source,
-           entry_id,
-           NULL AS txid,
+           le.entry_id,
+           le.chain_txid AS txid,
            CASE
-               WHEN session_id IS NOT NULL THEN 'oor'
-               WHEN event_type IN (
+               WHEN le.session_id IS NOT NULL THEN 'oor'
+               WHEN le.event_type IN (
                    'boarding_fee_paid', 'wallet_utxo_created'
                ) THEN 'boarding'
-               WHEN event_type IN (
+               WHEN le.event_type IN (
                    'onchain_fee_paid', 'boarding_sweep_fee_paid'
                ) THEN 'sweep'
                ELSE 'round'
            END AS transaction_type,
-           event_type AS subtype,
-           amount_sat,
+           le.event_type AS subtype,
+           le.amount_sat,
            CAST(0 AS BIGINT) AS fee_sat,
-           created_at,
+           le.created_at,
            CASE
-               WHEN event_type = 'wallet_utxo_created' THEN 'confirmed'
+               WHEN le.event_type = 'wallet_utxo_created' THEN 'confirmed'
                ELSE 'recorded'
            END AS status,
-           description,
-           debit_account,
-           credit_account,
-           round_id,
-           session_id,
-           CAST(0 AS INTEGER) AS confirmation_height
-    FROM ledger_entries
+           le.description,
+           le.debit_account,
+           le.credit_account,
+           le.round_id,
+           le.session_id,
+           COALESCE(le.confirmation_height, 0) AS confirmation_height
+    FROM ledger_entries AS le
 
     UNION ALL
 
@@ -310,7 +327,7 @@ type ListTransactionHistoryParams struct {
 type ListTransactionHistoryRow struct {
 	Source             string
 	EntryID            int64
-	Txid               interface{}
+	Txid               []byte
 	TransactionType    string
 	Subtype            string
 	AmountSat          int64

--- a/db/sqlc/migrations/000014_ledger_chain_fields.down.sql
+++ b/db/sqlc/migrations/000014_ledger_chain_fields.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS idx_client_ledger_chain_txid;
+ALTER TABLE ledger_entries DROP COLUMN confirmation_height;
+ALTER TABLE ledger_entries DROP COLUMN chain_vout;
+ALTER TABLE ledger_entries DROP COLUMN chain_txid;

--- a/db/sqlc/migrations/000014_ledger_chain_fields.up.sql
+++ b/db/sqlc/migrations/000014_ledger_chain_fields.up.sql
@@ -1,0 +1,9 @@
+-- Add first-class chain metadata columns to ledger_entries so history reads do
+-- not need to decode wallet UTXO idempotency keys on every query.
+ALTER TABLE ledger_entries ADD COLUMN chain_txid BLOB;
+ALTER TABLE ledger_entries ADD COLUMN chain_vout INTEGER;
+ALTER TABLE ledger_entries ADD COLUMN confirmation_height INTEGER;
+
+CREATE INDEX IF NOT EXISTS idx_client_ledger_chain_txid
+    ON ledger_entries(chain_txid)
+    WHERE chain_txid IS NOT NULL;

--- a/db/sqlc/models.go
+++ b/db/sqlc/models.go
@@ -92,16 +92,19 @@ type ClientTreeTxid struct {
 }
 
 type LedgerEntry struct {
-	EntryID        int64
-	DebitAccount   string
-	CreditAccount  string
-	AmountSat      int64
-	RoundID        []byte
-	SessionID      []byte
-	IdempotencyKey []byte
-	EventType      string
-	Description    string
-	CreatedAt      int64
+	EntryID            int64
+	DebitAccount       string
+	CreditAccount      string
+	AmountSat          int64
+	RoundID            []byte
+	SessionID          []byte
+	IdempotencyKey     []byte
+	EventType          string
+	Description        string
+	CreatedAt          int64
+	ChainTxid          []byte
+	ChainVout          sql.NullInt32
+	ConfirmationHeight sql.NullInt32
 }
 
 type LedgerEventType struct {

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -69,10 +69,11 @@ type Querier interface {
 	InsertBoardingSweep(ctx context.Context, arg InsertBoardingSweepParams) error
 	InsertBoardingSweepInput(ctx context.Context, arg InsertBoardingSweepInputParams) error
 	// Column order matches the ledger_entries CREATE TABLE layout
-	// in migration 000006 so the generated row type for SELECTs
-	// stays structurally identical to the LedgerEntry model, which
-	// is what the adapter returns. Changing the table column order
-	// requires changing these SELECTs in lockstep.
+	// from migration 000006 plus the chain metadata columns added in
+	// migration 000014, so the generated row type for SELECTs stays
+	// structurally identical to the LedgerEntry model returned by the
+	// adapter. Changing the table column order requires changing these
+	// SELECTs in lockstep.
 	//
 	// ON CONFLICT DO NOTHING makes the insert idempotent against
 	// every partial unique index on ledger_entries:

--- a/db/sqlc/queries/fee_accounting.sql
+++ b/db/sqlc/queries/fee_accounting.sql
@@ -1,9 +1,10 @@
 -- name: InsertClientLedgerEntry :exec
 -- Column order matches the ledger_entries CREATE TABLE layout
--- in migration 000006 so the generated row type for SELECTs
--- stays structurally identical to the LedgerEntry model, which
--- is what the adapter returns. Changing the table column order
--- requires changing these SELECTs in lockstep.
+-- from migration 000006 plus the chain metadata columns added in
+-- migration 000014, so the generated row type for SELECTs stays
+-- structurally identical to the LedgerEntry model returned by the
+-- adapter. Changing the table column order requires changing these
+-- SELECTs in lockstep.
 --
 -- ON CONFLICT DO NOTHING makes the insert idempotent against
 -- every partial unique index on ledger_entries:
@@ -18,14 +19,16 @@
 INSERT INTO ledger_entries (
     debit_account, credit_account, amount_sat,
     round_id, session_id, idempotency_key,
-    event_type, description, created_at
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+    event_type, description, created_at,
+    chain_txid, chain_vout, confirmation_height
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
 ON CONFLICT DO NOTHING;
 
 -- name: ListClientLedgerEntries :many
 SELECT entry_id, debit_account, credit_account, amount_sat,
        round_id, session_id, idempotency_key,
-       event_type, description, created_at
+       event_type, description, created_at,
+       chain_txid, chain_vout, confirmation_height
 FROM ledger_entries
 ORDER BY created_at DESC
 LIMIT $1 OFFSET $2;
@@ -33,7 +36,8 @@ LIMIT $1 OFFSET $2;
 -- name: ListClientLedgerEntriesByType :many
 SELECT entry_id, debit_account, credit_account, amount_sat,
        round_id, session_id, idempotency_key,
-       event_type, description, created_at
+       event_type, description, created_at,
+       chain_txid, chain_vout, confirmation_height
 FROM ledger_entries
 WHERE event_type = $1
 ORDER BY created_at DESC
@@ -51,33 +55,33 @@ SELECT source, entry_id, txid, transaction_type, subtype,
 FROM (
     SELECT 0 AS source_order,
            'ledger' AS source,
-           entry_id,
-           NULL AS txid,
+           le.entry_id,
+           le.chain_txid AS txid,
            CASE
-               WHEN session_id IS NOT NULL THEN 'oor'
-               WHEN event_type IN (
+               WHEN le.session_id IS NOT NULL THEN 'oor'
+               WHEN le.event_type IN (
                    'boarding_fee_paid', 'wallet_utxo_created'
                ) THEN 'boarding'
-               WHEN event_type IN (
+               WHEN le.event_type IN (
                    'onchain_fee_paid', 'boarding_sweep_fee_paid'
                ) THEN 'sweep'
                ELSE 'round'
            END AS transaction_type,
-           event_type AS subtype,
-           amount_sat,
+           le.event_type AS subtype,
+           le.amount_sat,
            CAST(0 AS BIGINT) AS fee_sat,
-           created_at,
+           le.created_at,
            CASE
-               WHEN event_type = 'wallet_utxo_created' THEN 'confirmed'
+               WHEN le.event_type = 'wallet_utxo_created' THEN 'confirmed'
                ELSE 'recorded'
            END AS status,
-           description,
-           debit_account,
-           credit_account,
-           round_id,
-           session_id,
-           CAST(0 AS INTEGER) AS confirmation_height
-    FROM ledger_entries
+           le.description,
+           le.debit_account,
+           le.credit_account,
+           le.round_id,
+           le.session_id,
+           COALESCE(le.confirmation_height, 0) AS confirmation_height
+    FROM ledger_entries AS le
 
     UNION ALL
 

--- a/db/sqlc/schemas/generated_schema.sql
+++ b/db/sqlc/schemas/generated_schema.sql
@@ -263,6 +263,10 @@ CREATE INDEX idx_boarding_sweep_inputs_status
 CREATE INDEX idx_boarding_sweeps_status
     ON boarding_sweeps(status);
 
+CREATE INDEX idx_client_ledger_chain_txid
+    ON ledger_entries(chain_txid)
+    WHERE chain_txid IS NOT NULL;
+
 CREATE INDEX idx_client_ledger_created
     ON ledger_entries(created_at DESC);
 
@@ -421,7 +425,7 @@ CREATE TABLE ledger_entries (
     description TEXT NOT NULL,
 
     -- created_at is the Unix timestamp.
-    created_at BIGINT NOT NULL,
+    created_at BIGINT NOT NULL, chain_txid BLOB, chain_vout INTEGER, confirmation_height INTEGER,
 
     -- Debit and credit must target different accounts.
     CHECK (debit_account != credit_account)

--- a/ledger/actor.go
+++ b/ledger/actor.go
@@ -172,6 +172,20 @@ type LedgerEntry struct {
 	// idx_client_ledger_idempotent_key covers rows where
 	// idempotency_key IS NOT NULL.
 	IdempotencyKey []byte
+
+	// ChainTxid optionally links this ledger entry to an on-chain
+	// transaction. It is a first-class history field rather than a
+	// value callers must recover from Description or IdempotencyKey.
+	ChainTxid []byte
+
+	// ChainVout optionally records the output index within ChainTxid.
+	// Nil means this ledger entry is not tied to a concrete output.
+	ChainVout *int32
+
+	// ConfirmationHeight optionally records the block height that
+	// confirmed the on-chain transaction. Nil means the height is
+	// unknown or the ledger entry has no chain transaction.
+	ConfirmationHeight *int32
 }
 
 // LedgerStore is the interface for persisting client-side ledger

--- a/ledger/handlers.go
+++ b/ledger/handlers.go
@@ -492,6 +492,8 @@ func (a *LedgerActor) handleUTXOCreated(ctx context.Context,
 	}
 
 	now := a.clk.Now().Unix()
+	chainVout := int32(msg.OutpointIndex)
+	confirmationHeight := int32(msg.BlockHeight)
 
 	err := a.cfg.UTXOAuditStore.InsertUTXOAuditEntry(
 		ctx, UTXOAuditEntry{
@@ -524,6 +526,9 @@ func (a *LedgerActor) handleUTXOCreated(ctx context.Context,
 			IdempotencyKey: walletUTXOIdempotencyKey(
 				msg.OutpointHash, msg.OutpointIndex,
 			),
+			ChainTxid:          msg.OutpointHash[:],
+			ChainVout:          &chainVout,
+			ConfirmationHeight: &confirmationHeight,
 		},
 	)
 }


### PR DESCRIPTION
## Summary

Fixes #447 by giving ledger-backed boarding deposits first-class chain
metadata in `listtransactions`. Before this PR, a confirmed
`wallet_utxo_created` row could show an empty `txid` and
`confirmation_height: 0`, leaving the only useful outpoint data buried in the
free-form description.

## Why This Shape

The previous approach reconstructed those fields at read time by decoding the
ledger idempotency key and consulting `wallet_utxo_log`. That worked, but it
made the history query too clever and tied a user-facing RPC shape to an
internal deduplication encoding. This version stores the relationship directly
on `ledger_entries` with nullable `chain_txid`, `chain_vout`, and
`confirmation_height` columns.

New `wallet_utxo_created` rows now write the chain fields at the source, next
to the existing audit-log insert that observes the confirmed wallet outpoint.
`ListTransactionHistory` no longer inspects idempotency keys or audit-log rows;
it simply reads `chain_txid` and uses the stored confirmation height, with the
existing RPC-level `0` fallback when height is unknown. `chain_vout` is stored
with the ledger row for the complete outpoint, but `listtransactions` keeps the
existing RPC shape and only projects the txid/height fields it currently
exposes. There is intentionally no legacy backfill because these rows have not
shipped to users yet.

## What Changed

- Added migration 14 for ledger chain metadata columns and a txid index.
- Extended `ledger.LedgerEntry` and `InsertClientLedgerEntry` to carry optional
  chain metadata.
- Populated `chain_txid`, `chain_vout`, and `confirmation_height` when the
  ledger actor records a confirmed wallet UTXO.
- Simplified `ListTransactionHistory` so boarding deposit chain fields come
  from first-class ledger columns.
- Kept other boarding ledger rows, such as `boarding_fee_paid`, chainless with
  `recorded` status.
- Kept `wallet_utxo_created` history rows as `confirmed`, matching the ledger
  invariant that these entries are inserted only after the wallet reports a
  confirmed on-chain UTXO.

Example row shape added by this PR:

```json
{
  "source": "ledger",
  "type": "boarding",
  "subtype": "wallet_utxo_created",
  "txid": "<boarding transaction id>",
  "confirmation_height": 304081,
  "status": "confirmed"
}
```

## Verification

- `go test ./db ./ledger ./darepod`
- `make lint`
- `make sqlc-check`
- `make commitmsg-lint range=origin/main..HEAD`
