### PR TITLE
doc: add sample darepod config

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,6 +108,14 @@ jobs:
           GOWORK: off
 
       ########################
+      # Sample configuration check
+      ########################
+      - name: Check sample darepod config
+        run: make sample-conf-check
+        env:
+          GOWORK: off
+
+      ########################
       # SQLC code gen check
       ########################
       - name: Docker image cache

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: sqlc sqlc-check migrate-create migrate-up migrate-down gen
-.PHONY: lint lint-source lint-local lint-source-local lint-changed-local lint-native build-native-linter local-custom-gcl install-custom-gcl docker-tools fmt fmt-changed fmt-check fmt-changed-check tidy-module tidy-module-check schema-check doc-check
+.PHONY: lint lint-source lint-local lint-source-local lint-changed-local lint-native build-native-linter local-custom-gcl install-custom-gcl docker-tools fmt fmt-changed fmt-check fmt-changed-check tidy-module tidy-module-check schema-check doc-check sample-conf-check
 .PHONY: ast-lint ast-grep-fix
 .PHONY: unit unit-cover unit-race unit-swapruntime check-go-version build install clean release
 .PHONY: build build-swapruntime build-swapclient rpc install install-swapruntime help clean-networks
@@ -318,6 +318,10 @@ check-migration-version: #? Check that LatestMigrationVersion matches migration 
 doc-check: #? Verify documentation cross-links are valid
 	@$(call print, "Checking documentation cross-links.")
 	@./scripts/doc-check.sh
+
+sample-conf-check: #? Verify sample-darepod.conf matches daemon config options
+	@$(call print, "Checking sample-darepod.conf.")
+	$(GOCC) run ./scripts/check-sample-darepod-conf
 
 schema-check: #? Verify schema registry, MCP tools, and cobra commands are in sync
 	@$(call print, "Verifying schema registry consistency.")

--- a/cmd/darepod/main.go
+++ b/cmd/darepod/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -12,10 +13,12 @@ import (
 	"github.com/lightninglabs/darepo-client/darepod"
 	"github.com/lightningnetwork/lnd/signal"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
 
 const daemonLogFileName = "darepod.log"
+const daemonConfigFileName = "darepod.conf"
 
 type bestEffortWriter struct {
 	w io.Writer
@@ -52,6 +55,10 @@ func newRootCmd() *cobra.Command {
 			"for wallet operations.",
 		Version: build.Version(),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := readConfigFile(v, cmd); err != nil {
+				return err
+			}
+
 			// Merge flags, environment variables, and config
 			// file into the config struct. Viper handles the
 			// precedence: flags > env > config file > defaults.
@@ -98,6 +105,10 @@ func newRootCmd() *cobra.Command {
 	f.String(
 		"logdir", cfg.LogDirPath,
 		"directory for persistent daemon logs",
+	)
+	f.String(
+		"configfile", filepath.Join(cfg.DataDir, daemonConfigFileName),
+		"path to daemon config file",
 	)
 
 	// LND connection flags.
@@ -237,6 +248,15 @@ func newRootCmd() *cobra.Command {
 	v.SetEnvPrefix("DAREPOD")
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	v.AutomaticEnv()
+	bindOORLimitFlags(v, f)
+	_ = v.BindPFlags(f)
+
+	return cmd
+}
+
+// bindOORLimitFlags binds hyphenated OOR CLI flags to the config keys used by
+// mapstructure.
+func bindOORLimitFlags(v *viper.Viper, f *pflag.FlagSet) {
 	// The CLI uses hyphenated operator-facing flag names, while
 	// mapstructure tags use the project's concatenated lowercase style.
 	// Bind explicit viper keys before BindPFlags adds the literal flag-name
@@ -257,9 +277,136 @@ func newRootCmd() *cobra.Command {
 		"oor.limits.maxmailboxscriptbytes",
 		f.Lookup("oor.limits.max-mailbox-script-bytes"),
 	)
-	_ = v.BindPFlags(f)
+}
 
-	return cmd
+// readConfigFile loads the daemon configuration from the selected properties
+// file. Missing default config files are ignored so first startup works without
+// bootstrapping an empty file; explicit config paths must exist.
+func readConfigFile(v *viper.Viper, cmd *cobra.Command) error {
+	configFile := v.GetString("configfile")
+	if configFile == "" {
+		return nil
+	}
+
+	configFile, err := expandCLIPath(configFile)
+	if err != nil {
+		return err
+	}
+	v.Set("configfile", configFile)
+
+	_, err = os.Stat(configFile)
+	switch {
+	case err == nil:
+	case errors.Is(err, os.ErrNotExist):
+		if cmd.Flags().Changed("configfile") ||
+			os.Getenv("DAREPOD_CONFIGFILE") != "" {
+			return fmt.Errorf("config file %q does not exist",
+				configFile)
+		}
+
+		return nil
+
+	default:
+		return fmt.Errorf("stat config file %q: %w", configFile, err)
+	}
+
+	config, err := readPropertiesConfig(configFile)
+	if err != nil {
+		return fmt.Errorf("read config file %q: %w", configFile, err)
+	}
+
+	if err := v.MergeConfigMap(config); err != nil {
+		return fmt.Errorf("merge config file %q: %w", configFile, err)
+	}
+
+	return nil
+}
+
+// readPropertiesConfig parses a simple key=value config file into a nested map
+// suitable for Viper.
+func readPropertiesConfig(path string) (map[string]any, error) {
+	content, err := os.ReadFile(path) //nolint:gosec // G304: operator path.
+	if err != nil {
+		return nil, err
+	}
+
+	config := make(map[string]any)
+	lines := strings.Split(string(content), "\n")
+	for i, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			return nil, fmt.Errorf("line %d: expected key=value",
+				i+1)
+		}
+
+		key = strings.TrimSpace(key)
+		if key == "" {
+			return nil, fmt.Errorf("line %d: empty key", i+1)
+		}
+
+		value = trimInlineComment(value)
+		insertConfigValue(config, strings.Split(key, "."), value)
+	}
+
+	return config, nil
+}
+
+// trimInlineComment removes whitespace-prefixed trailing comments from a config
+// value.
+func trimInlineComment(value string) string {
+	for i := 0; i < len(value); i++ {
+		if value[i] != '#' {
+			continue
+		}
+
+		if i == 0 || value[i-1] == ' ' || value[i-1] == '\t' {
+			return strings.TrimSpace(value[:i])
+		}
+	}
+
+	return strings.TrimSpace(value)
+}
+
+// insertConfigValue stores a parsed config value in a nested map under a dotted
+// key path.
+func insertConfigValue(config map[string]any, path []string, value string) {
+	key := path[0]
+	if len(path) == 1 {
+		config[key] = value
+
+		return
+	}
+
+	child, ok := config[key].(map[string]any)
+	if !ok {
+		child = make(map[string]any)
+		config[key] = child
+	}
+
+	insertConfigValue(child, path[1:], value)
+}
+
+// expandCLIPath expands a leading tilde in one CLI path.
+func expandCLIPath(path string) (string, error) {
+	if path == "~" || strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home dir: %w", err)
+		}
+
+		if path == "~" {
+			return home, nil
+		}
+
+		return filepath.Join(home, path[2:]), nil
+	}
+
+	return filepath.Clean(path), nil
 }
 
 // run validates the config, starts signal interception, and launches the

--- a/cmd/darepod/main_test.go
+++ b/cmd/darepod/main_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/lightninglabs/darepo-client/darepod"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// TestReadConfigFileLoadsProperties checks that an explicit config file is
+// merged into Viper and unmarshaled into the daemon config.
+func TestReadConfigFileLoadsProperties(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "darepod.conf")
+	err := os.WriteFile(
+		configPath, []byte(
+			"network=regtest # local "+
+				"development\nwallet.type=lnd\n",
+		),
+		0o600,
+	)
+	if err != nil {
+		t.Fatalf("write config file: %v", err)
+	}
+
+	v, cmd := newTestConfigCommand(t, "")
+	if err := cmd.Flags().Set("configfile", configPath); err != nil {
+		t.Fatalf("set configfile flag: %v", err)
+	}
+
+	if err := readConfigFile(v, cmd); err != nil {
+		t.Fatalf("read config file: %v", err)
+	}
+
+	if got := v.GetString("network"); got != "regtest" {
+		t.Fatalf("expected network regtest, got %q", got)
+	}
+	if got := v.GetString("wallet.type"); got != "lnd" {
+		t.Fatalf("expected wallet type lnd, got %q", got)
+	}
+
+	cfg := darepod.DefaultConfig()
+	if err := v.Unmarshal(cfg); err != nil {
+		t.Fatalf("unmarshal config: %v", err)
+	}
+	if cfg.Network != "regtest" {
+		t.Fatalf("expected config network regtest, got %q", cfg.Network)
+	}
+	if cfg.Wallet.Type != "lnd" {
+		t.Fatalf("expected config wallet type lnd, got %q",
+			cfg.Wallet.Type)
+	}
+}
+
+// TestReadConfigFileIgnoresMissingDefault checks that a missing default config
+// file does not block first startup.
+func TestReadConfigFileIgnoresMissingDefault(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "missing.conf")
+	v, cmd := newTestConfigCommand(t, configPath)
+
+	if err := readConfigFile(v, cmd); err != nil {
+		t.Fatalf("missing default config file should be ignored: %v",
+			err)
+	}
+}
+
+// TestReadConfigFileRejectsMissingExplicitPath checks that a missing path
+// passed via --configfile is reported as an error.
+func TestReadConfigFileRejectsMissingExplicitPath(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "missing.conf")
+	v, cmd := newTestConfigCommand(t, "")
+	if err := cmd.Flags().Set("configfile", configPath); err != nil {
+		t.Fatalf("set configfile flag: %v", err)
+	}
+
+	if err := readConfigFile(v, cmd); err == nil {
+		t.Fatalf("expected missing explicit config file to fail")
+	}
+}
+
+// TestReadConfigFileRejectsMissingEnvPath checks that a missing path passed via
+// DAREPOD_CONFIGFILE is reported as an error.
+func TestReadConfigFileRejectsMissingEnvPath(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "missing.conf")
+	t.Setenv("DAREPOD_CONFIGFILE", configPath)
+
+	v, cmd := newTestConfigCommand(t, "")
+	v.SetEnvPrefix("DAREPOD")
+	v.AutomaticEnv()
+
+	if err := readConfigFile(v, cmd); err == nil {
+		t.Fatalf("expected missing env config file to fail")
+	}
+}
+
+// newTestConfigCommand returns a minimal command and Viper instance wired with
+// the configfile flag.
+func newTestConfigCommand(t *testing.T,
+	defaultConfigPath string) (*viper.Viper, *cobra.Command) {
+
+	t.Helper()
+
+	cmd := &cobra.Command{Use: "darepod"}
+	cmd.Flags().String("configfile", defaultConfigPath, "")
+
+	v := viper.New()
+	if err := v.BindPFlag(
+		"configfile", cmd.Flags().Lookup("configfile"),
+	); err != nil {
+
+		t.Fatalf("bind configfile flag: %v", err)
+	}
+
+	return v, cmd
+}

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/modelcontextprotocol/go-sdk v1.4.0
 	github.com/ory/dockertest/v3 v3.12.0
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.47.0
@@ -166,7 +167,6 @@ require (
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 // indirect

--- a/sample-darepod.conf
+++ b/sample-darepod.conf
@@ -1,0 +1,143 @@
+# Example configuration for darepod.
+#
+# The default location for this file is ~/.darepod/darepod.conf. The default
+# location can be overwritten by specifying --configfile= when starting
+# darepod, or by setting DAREPOD_CONFIGFILE.
+#
+# Boolean values can be specified as true/false. If only one value is specified
+# for an option, it is the default value used by darepod. Empty values mean the
+# option has no default.
+#
+# This file uses top-level key=value entries because darepod reads it as a
+# properties file. Leave options commented until you want to override them.
+
+# Root data directory for daemon state.
+# datadir=~/.darepod
+
+# Bitcoin network: mainnet, testnet, regtest, simnet, or signet.
+# network=mainnet
+
+# Logging verbosity. A single level sets the global level; a comma-separated
+# list can set per-subsystem levels, for example ROND=debug,OORC=trace,info.
+# debuglevel=info
+
+# Directory for persistent daemon logs. Empty stores logs under
+# datadir/logs/<network>.
+# logdir=
+
+# Maximum duration to wait for forfeit signatures during a round. The zero
+# value uses the daemon default.
+# forfeitcollectiontimeout=0s
+
+# Explicit opt-in for mainnet operation.
+# allow-mainnet=false
+
+# Maximum operator fee, in satoshis, accepted per seal-time quote.
+# maxoperatorfeesat=1000000
+
+# lnd gRPC address.
+# lnd.host=localhost:10009
+
+# Path to lnd's TLS certificate. Empty uses the default lnd location.
+# lnd.tlspath=
+
+# Path to lnd's admin macaroon. Empty uses the default lnd location.
+# lnd.macaroonpath=
+
+# Maximum duration for individual RPC calls to lnd.
+# lnd.rpctimeout=30s
+
+# Ark operator mailbox server address.
+# server.host=localhost:10010
+
+# Path to the Ark server TLS certificate. Empty uses the system cert pool.
+# server.tlscertpath=
+
+# Disable TLS for the server connection. Intended for development only.
+# server.insecure=false
+
+# Maximum number of VTXO tree nodes accepted from the server.
+# server.maxtreenodes=50000
+
+# Daemon gRPC listen address.
+# rpc.listenaddr=localhost:10029
+
+# Path to the daemon TLS certificate. Empty auto-generates one in the data dir.
+# rpc.tlscertpath=
+
+# Path to the daemon TLS private key. Empty auto-generates one in the data dir.
+# rpc.tlskeypath=
+
+# Wallet backend type: lnd, lwwallet, or btcwallet.
+# wallet.type=lwwallet
+
+# Esplora REST API URL. Required when wallet.type=lwwallet.
+# wallet.esploraurl=
+
+# Chain poll interval for the lwwallet backend.
+# wallet.pollinterval=30s
+
+# Address recovery look-ahead window for lwwallet.
+# wallet.recoverywindow=100
+
+# Path to a file containing the wallet password for auto-unlock at startup.
+# wallet.password_file=
+
+# Exclusive neutrino peers for btcwallet, as a comma-separated list.
+# wallet.btcwallet_peers=
+
+# Additional persistent neutrino peers for btcwallet, as a comma-separated list.
+# wallet.btcwallet_addpeers=
+
+# Directory for btcwallet/neutrino chain data. Empty uses the network data dir.
+# wallet.btcwallet_datadir=
+
+# Fee-estimate JSON endpoint URL. Required when wallet.type=btcwallet.
+# wallet.feeurl=
+
+# Persist compact block filters to disk for btcwallet/neutrino.
+# wallet.persist_filters=false
+
+# Keep btcwallet/neutrino package-global loggers detached from daemon logging.
+# wallet.disable_btcwallet_global_logs=false
+
+# Number of blocks after which unroll attempts a fee-bump rebroadcast. The zero
+# value uses the unroll default.
+# unroll.bumpafterblocks=0
+
+# Maximum unroll fee rate in sat/vB. The zero value uses the unroll default.
+# unroll.maxfeeratesatpervbyte=0
+
+# Swap server gRPC address for swapruntime builds.
+# swap.serveraddress=localhost:10030
+
+# Swap server TLS certificate path for swapruntime builds.
+# swap.servertlscertpath=
+
+# Disable TLS for the swap server in swapruntime builds.
+# swap.serverinsecure=false
+
+# Swap session SQLite database path for swapruntime builds. Empty stores swaps
+# under datadir/swaps.db.
+# swap.databasefilename=
+
+# Maximum checkpoint transactions allowed in one incoming OOR transfer.
+# oor.limits.maxcheckpoints=64
+
+# Maximum VTXOs returned by one indexer lookup during incoming OOR receive.
+# oor.limits.maxvtxomatches=128
+
+# Safety cap on items decoded from one stored mailbox message.
+# oor.limits.maxmailboxitems=10000
+
+# Safety cap on mailbox address-script bytes.
+# oor.limits.maxmailboxscriptbytes=10000
+
+# Optional bitcoind RPC address for submitpackage support.
+# bitcoind.host=
+
+# Optional bitcoind RPC username.
+# bitcoind.user=
+
+# Optional bitcoind RPC password.
+# bitcoind.pass=

--- a/scripts/check-sample-darepod-conf/main.go
+++ b/scripts/check-sample-darepod-conf/main.go
@@ -1,0 +1,466 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"reflect"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/lightninglabs/darepo-client/darepod"
+)
+
+const (
+	defaultConfFile = "sample-darepod.conf"
+	mainFile        = "cmd/darepod/main.go"
+)
+
+var skippedFlags = map[string]struct{}{
+	"configfile": {},
+	"help":       {},
+	"version":    {},
+}
+
+// main verifies that sample-darepod.conf documents every daemon config option
+// with the current default value.
+func main() {
+	confFile := defaultConfFile
+	if len(os.Args) > 1 && os.Args[1] != "" {
+		confFile = os.Args[1]
+	}
+
+	expected, err := expectedConfigKeys()
+	if err != nil {
+		fail(err)
+	}
+
+	if err := addDaemonFlagKeys(expected); err != nil {
+		fail(err)
+	}
+
+	sample, err := parseSampleConfig(confFile)
+	if err != nil {
+		fail(err)
+	}
+
+	if err := checkSampleConfig(expected, sample); err != nil {
+		fail(err)
+	}
+
+	_, _ = fmt.Fprintf(
+		os.Stdout, "%d sample darepod config options checked\n",
+		len(expected),
+	)
+}
+
+// expectedConfigKeys returns the default daemon config keys derived from
+// mapstructure tags.
+func expectedConfigKeys() (map[string]string, error) {
+	cfg := darepod.DefaultConfig()
+	expected := make(map[string]string)
+
+	if err := collectConfigKeys(
+		"", reflect.ValueOf(cfg), expected,
+	); err != nil {
+		return nil, err
+	}
+
+	return expected, nil
+}
+
+// collectConfigKeys recursively collects mapstructure-tagged fields from a
+// config struct.
+func collectConfigKeys(prefix string, value reflect.Value,
+	expected map[string]string) error {
+
+	if value.Kind() == reflect.Pointer {
+		if value.IsNil() {
+			value = reflect.Zero(value.Type().Elem())
+		} else {
+			value = value.Elem()
+		}
+	}
+
+	if value.Kind() != reflect.Struct {
+		return nil
+	}
+
+	valueType := value.Type()
+	for i := 0; i < value.NumField(); i++ {
+		field := valueType.Field(i)
+		if !field.IsExported() {
+			continue
+		}
+
+		tag := strings.Split(field.Tag.Get("mapstructure"), ",")[0]
+		if tag == "" || tag == "-" {
+			continue
+		}
+
+		key := tag
+		if prefix != "" {
+			key = prefix + "." + tag
+		}
+
+		fieldValue := value.Field(i)
+		fieldKind := fieldValue.Kind()
+		if fieldKind == reflect.Pointer &&
+			fieldValue.Type().Elem().Kind() == reflect.Struct {
+
+			if err := collectConfigKeys(key, fieldValue,
+				expected); err != nil {
+				return err
+			}
+
+			continue
+		}
+		if fieldKind == reflect.Struct &&
+			fieldValue.Type() != reflect.TypeOf(time.Duration(0)) {
+
+			if err := collectConfigKeys(key, fieldValue,
+				expected); err != nil {
+				return err
+			}
+
+			continue
+		}
+
+		defaultValue, err := formatDefaultValue(fieldValue)
+		if err != nil {
+			return fmt.Errorf("format default for %s: %w", key, err)
+		}
+
+		expected[key] = defaultValue
+	}
+
+	return nil
+}
+
+// formatDefaultValue converts a default config value to the representation used
+// in sample-darepod.conf.
+func formatDefaultValue(value reflect.Value) (string, error) {
+	if value.Type() == reflect.TypeOf(time.Duration(0)) {
+		duration, ok := value.Interface().(time.Duration)
+		if !ok {
+			return "", errors.New("expected time.Duration")
+		}
+
+		return duration.String(), nil
+	}
+
+	switch value.Kind() {
+	case reflect.String:
+		return value.String(), nil
+
+	case reflect.Bool:
+		return strconv.FormatBool(value.Bool()), nil
+
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32,
+		reflect.Int64:
+		return strconv.FormatInt(value.Int(), 10), nil
+
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32,
+		reflect.Uint64:
+		return strconv.FormatUint(value.Uint(), 10), nil
+
+	case reflect.Slice:
+		if value.Len() == 0 {
+			return "", nil
+		}
+
+		parts := make([]string, value.Len())
+		for i := 0; i < value.Len(); i++ {
+			part, err := formatDefaultValue(value.Index(i))
+			if err != nil {
+				return "", err
+			}
+			parts[i] = part
+		}
+
+		return strings.Join(parts, ","), nil
+
+	default:
+		return "", fmt.Errorf("unsupported kind %s", value.Kind())
+	}
+}
+
+// addDaemonFlagKeys adds daemon CLI-only config keys and verifies source flags
+// appear in darepod help output.
+func addDaemonFlagKeys(expected map[string]string) error {
+	sourceBytes, err := os.ReadFile(mainFile)
+	if err != nil {
+		return err
+	}
+	source := string(sourceBytes)
+
+	flagAliases := explicitFlagAliases(source)
+	helpFlags, err := daemonHelpFlags()
+	if err != nil {
+		return err
+	}
+
+	flagDefaults := map[string]string{}
+	// First capture default values from the user-facing help output. This
+	// also adds daemon-only flags, such as bitcoind.*, that are not present
+	// in darepod.Config.
+	for _, flag := range helpFlags {
+		if _, ok := skippedFlags[flag.name]; ok {
+			continue
+		}
+
+		key := flag.name
+		if alias, ok := flagAliases[flag.name]; ok {
+			key = alias
+		}
+
+		if _, ok := expected[key]; ok {
+			continue
+		}
+
+		expected[key] = flag.defaultValue
+		flagDefaults[key] = flag.defaultValue
+	}
+
+	registeredFlags := registeredDaemonFlags(source)
+	// Then verify every source-registered flag appeared in help. Keeping
+	// this as a separate pass catches parser drift without losing the help
+	// defaults collected above.
+	for _, flagName := range registeredFlags {
+		if _, ok := skippedFlags[flagName]; ok {
+			continue
+		}
+
+		key := flagName
+		if alias, ok := flagAliases[flagName]; ok {
+			key = alias
+		}
+
+		if _, ok := expected[key]; ok {
+			continue
+		}
+
+		defaultValue, ok := flagDefaults[key]
+		if !ok {
+			return fmt.Errorf("daemon flag %q was registered but "+
+				"not found in darepod --help", flagName)
+		}
+
+		expected[key] = defaultValue
+	}
+
+	return nil
+}
+
+// explicitFlagAliases returns config-key aliases from explicit Viper flag
+// bindings.
+func explicitFlagAliases(source string) map[string]string {
+	re := regexp.MustCompile(
+		`(?s)v\.BindPFlag\(\s*"([^"]+)"\s*,` +
+			`\s*f\.Lookup\(\s*"([^"]+)"\s*\)`,
+	)
+	matches := re.FindAllStringSubmatch(source, -1)
+
+	aliases := make(map[string]string, len(matches))
+	for _, match := range matches {
+		configKey, flagName := match[1], match[2]
+		aliases[flagName] = configKey
+	}
+
+	return aliases
+}
+
+// registeredDaemonFlags returns daemon flag names registered with literal
+// string arguments.
+func registeredDaemonFlags(source string) []string {
+	// This checker assumes daemon flags are registered in
+	// cmd/darepod/main.go with literal string names. If flags move behind
+	// helpers or variables, update this parser alongside that refactor.
+	re := regexp.MustCompile(
+		`(?s)\bf\.(?:String|Bool|Int|Int32|Int64|Uint|` +
+			`Uint32|Uint64|Duration|StringSlice|` +
+			`StringToString)\(\s*"([^"]+)"`,
+	)
+	matches := re.FindAllStringSubmatch(source, -1)
+
+	flags := make([]string, 0, len(matches))
+	for _, match := range matches {
+		flags = append(flags, match[1])
+	}
+
+	return flags
+}
+
+type daemonFlag struct {
+	name         string
+	defaultValue string
+}
+
+// daemonHelpFlags returns the daemon flags and defaults from darepod --help.
+func daemonHelpFlags() ([]daemonFlag, error) {
+	cmd := exec.Command("go", "run", "./cmd/darepod", "--help")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("run darepod --help: %w\n%s", err,
+			string(output))
+	}
+
+	re := regexp.MustCompile(
+		`^\s+(?:-[A-Za-z],\s+)?--([A-Za-z0-9_.-]+)` +
+			`(?:\s+([A-Za-z0-9]+))?.*$`,
+	)
+	defaultRe := regexp.MustCompile(`\(default (?:"([^"]*)"|([^)]*))\)`)
+
+	var flags []daemonFlag
+	scanner := bufio.NewScanner(strings.NewReader(string(output)))
+	for scanner.Scan() {
+		line := scanner.Text()
+		match := re.FindStringSubmatch(line)
+		if match == nil {
+			continue
+		}
+
+		name := match[1]
+		valueType := match[2]
+		defaultValue := ""
+		if defaultMatch := defaultRe.FindStringSubmatch(
+			line,
+		); defaultMatch != nil {
+
+			defaultValue = defaultMatch[1]
+			if defaultValue == "" {
+				defaultValue = strings.TrimSpace(
+					defaultMatch[2],
+				)
+			}
+		} else if valueType == "" {
+			defaultValue = "false"
+		}
+
+		flags = append(flags, daemonFlag{
+			name:         name,
+			defaultValue: defaultValue,
+		})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return flags, nil
+}
+
+// parseSampleConfig returns the commented key/value entries from the sample
+// config file.
+func parseSampleConfig(confFile string) (map[string]string, error) {
+	file, err := os.Open(confFile) //nolint:gosec // G304: CI input path.
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+
+	re := regexp.MustCompile(`^\s*#\s*([A-Za-z0-9_.-]+)=(.*)$`)
+	sample := make(map[string]string)
+
+	scanner := bufio.NewScanner(file)
+	for lineNumber := 1; scanner.Scan(); lineNumber++ {
+		line := scanner.Text()
+		trimmedLine := strings.TrimSpace(line)
+		if trimmedLine != "" && !strings.HasPrefix(trimmedLine, "#") {
+			return nil, fmt.Errorf("%s:%d contains live config "+
+				"line %q; sample entries must stay commented",
+				confFile, lineNumber, trimmedLine)
+		}
+
+		match := re.FindStringSubmatch(line)
+		if match == nil {
+			continue
+		}
+
+		key, value := match[1], strings.TrimRight(match[2], " \t")
+		if _, ok := sample[key]; ok {
+			return nil, fmt.Errorf("%s:%d duplicates %q", confFile,
+				lineNumber, key)
+		}
+
+		sample[key] = value
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return sample, nil
+}
+
+// checkSampleConfig verifies the sample keys and defaults match expectations.
+func checkSampleConfig(expected, sample map[string]string) error {
+	var missing []string
+	for key := range expected {
+		if _, ok := sample[key]; !ok {
+			missing = append(missing, key)
+		}
+	}
+	sort.Strings(missing)
+
+	var stale []string
+	for key := range sample {
+		if _, ok := expected[key]; !ok {
+			stale = append(stale, key)
+		}
+	}
+	sort.Strings(stale)
+
+	var mismatched []string
+	for key, expectedValue := range expected {
+		sampleValue, ok := sample[key]
+		if !ok || sampleValue == expectedValue {
+			continue
+		}
+
+		mismatched = append(
+			mismatched, fmt.Sprintf("%s: sample %q, default %q",
+				key, sampleValue, expectedValue),
+		)
+	}
+	sort.Strings(mismatched)
+
+	if len(missing) == 0 && len(stale) == 0 && len(mismatched) == 0 {
+		return nil
+	}
+
+	var builder strings.Builder
+	if len(missing) > 0 {
+		fmt.Fprintf(&builder, "missing sample config keys:\n")
+		for _, key := range missing {
+			fmt.Fprintf(&builder, "  - %s\n", key)
+		}
+	}
+	if len(stale) > 0 {
+		fmt.Fprintf(&builder, "unknown sample config keys:\n")
+		for _, key := range stale {
+			fmt.Fprintf(&builder, "  - %s\n", key)
+		}
+	}
+	if len(mismatched) > 0 {
+		fmt.Fprintf(&builder, "sample defaults differ:\n")
+		for _, mismatch := range mismatched {
+			builder.WriteString("  - ")
+			builder.WriteString(mismatch)
+			builder.WriteByte('\n')
+		}
+	}
+
+	return errors.New(strings.TrimSpace(builder.String()))
+}
+
+// fail reports an error and exits the checker with a non-zero status.
+func fail(err error) {
+	fmt.Fprintln(os.Stderr, err)
+	os.Exit(1)
+}


### PR DESCRIPTION
## Summary

Fixes #446.

This PR adds a `sample-darepod.conf` modeled after lnd's sample config pattern, with every daemon config key commented out and set to the current default value. The sample is intentionally written as top-level `key=value` entries, because darepod now reads `~/.darepod/darepod.conf` as a simple properties-style config file.

The daemon previously had comments describing config-file precedence but never loaded a config file. This PR wires `darepod` to load the default config file when it exists, ignore a missing default file for first-run ergonomics, and fail if the user explicitly passes a missing `--configfile` path or `DAREPOD_CONFIGFILE` path. Flags and environment variables remain higher-priority than file values.

## Sample Config Gate

Adds `make sample-conf-check`, modeled on lnd's `sample-conf-check`, and runs it in CI static checks. The checker reflects `darepod.Config` `mapstructure` keys, includes daemon-only flags such as `bitcoind.*`, accounts for explicit aliases like `oor.limits.max-checkpoints -> oor.limits.maxcheckpoints`, and verifies that `sample-darepod.conf` contains the expected default value for each option. This should make future daemon config additions fail CI unless the sample config is updated at the same time.

## Tests

- `make fmt-changed`
- `make sample-conf-check`
- `go test ./cmd/darepod ./darepod`
- `make lint-changed-local`
- `make tidy-module-check`
- `make commitmsg-lint commit=HEAD`
