### PR TITLE
[codex] add Ark receive and transfer status CLI

### DIFF
--- a/cmd/darepocli/darepoclicommands/cmd_oor.go
+++ b/cmd/darepocli/darepoclicommands/cmd_oor.go
@@ -152,6 +152,12 @@ func oorList(cmd *cobra.Command, _ []string) error {
 
 // oorReceive executes the NewReceiveScript RPC.
 func oorReceive(cmd *cobra.Command, _ []string) error {
+	return newReceiveScript(cmd)
+}
+
+// newReceiveScript executes the NewReceiveScript RPC shared by receive
+// command aliases.
+func newReceiveScript(cmd *cobra.Command) error {
 	client, conn, err := getDaemonClient(cmd)
 	if err != nil {
 		return err
@@ -160,6 +166,26 @@ func oorReceive(cmd *cobra.Command, _ []string) error {
 		_ = conn.Close()
 	}()
 
+	req, err := newReceiveScriptRequestFromCmd(cmd)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.NewReceiveScript(
+		cmd.Context(), req,
+	)
+	if err != nil {
+		return fmt.Errorf("NewReceiveScript RPC failed: %w", err)
+	}
+
+	return printJSON(resp)
+}
+
+// newReceiveScriptRequestFromCmd builds a NewReceiveScript request from cobra
+// flags or the generic JSON request input.
+func newReceiveScriptRequestFromCmd(cmd *cobra.Command) (
+	*daemonrpc.NewReceiveScriptRequest, error) {
+
 	req := &daemonrpc.NewReceiveScriptRequest{}
 	if err := parseRequest(cmd, req, func() error {
 		label, _ := cmd.Flags().GetString("label")
@@ -167,17 +193,10 @@ func oorReceive(cmd *cobra.Command, _ []string) error {
 
 		return nil
 	}); err != nil {
-		return err
+		return nil, err
 	}
 
-	resp, err := client.NewReceiveScript(
-		context.Background(), req,
-	)
-	if err != nil {
-		return fmt.Errorf("NewReceiveScript RPC failed: %w", err)
-	}
-
-	return printJSON(resp)
+	return req, nil
 }
 
 // parseOORDirectionFilter converts a CLI direction filter into the proto enum.

--- a/cmd/darepocli/darepoclicommands/cmd_receive.go
+++ b/cmd/darepocli/darepoclicommands/cmd_receive.go
@@ -1,0 +1,64 @@
+package darepoclicommands
+
+import (
+	"fmt"
+
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/spf13/cobra"
+)
+
+// newReceiveCmd creates the generic Ark receive command group.
+func newReceiveCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "receive",
+		Short: "Allocate and inspect Ark receive targets",
+		Long: "Allocates Ark receive targets that can be handed to " +
+			"senders for in-round or out-of-round transfers.",
+		RunE: receive,
+	}
+
+	cmd.Flags().String("label", "",
+		"optional label stored with the receive-script registration")
+
+	cmd.AddCommand(newReceiveListCmd())
+
+	return cmd
+}
+
+// newReceiveListCmd creates the receive list subcommand.
+func newReceiveListCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List registered Ark receive targets",
+		Long: "Lists receive targets this wallet registered with the " +
+			"indexer, including the derived address and pkScript.",
+		RunE: receiveList,
+	}
+
+	return cmd
+}
+
+// receive executes the generic NewReceiveScript RPC wrapper.
+func receive(cmd *cobra.Command, _ []string) error {
+	return newReceiveScript(cmd)
+}
+
+// receiveList executes the ListReceiveScripts RPC.
+func receiveList(cmd *cobra.Command, _ []string) error {
+	client, conn, err := getDaemonClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	resp, err := client.ListReceiveScripts(
+		cmd.Context(), &daemonrpc.ListReceiveScriptsRequest{},
+	)
+	if err != nil {
+		return fmt.Errorf("ListReceiveScripts RPC failed: %w", err)
+	}
+
+	return printJSON(resp)
+}

--- a/cmd/darepocli/darepoclicommands/cmd_receive_test.go
+++ b/cmd/darepocli/darepoclicommands/cmd_receive_test.go
@@ -1,0 +1,20 @@
+package darepoclicommands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewReceiveScriptRequestFromCmdForwardsLabel verifies the generic
+// receive command carries its label flag into the daemon request.
+func TestNewReceiveScriptRequestFromCmdForwardsLabel(t *testing.T) {
+	t.Parallel()
+
+	cmd := newReceiveCmd()
+	require.NoError(t, cmd.Flags().Set("label", "coffee invoice"))
+
+	req, err := newReceiveScriptRequestFromCmd(cmd)
+	require.NoError(t, err)
+	require.Equal(t, "coffee invoice", req.GetLabel())
+}

--- a/cmd/darepocli/darepoclicommands/cmd_transfers.go
+++ b/cmd/darepocli/darepoclicommands/cmd_transfers.go
@@ -1,0 +1,178 @@
+package darepoclicommands
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/spf13/cobra"
+)
+
+// newTransfersCmd creates the transfer status command group.
+func newTransfersCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "transfers",
+		Short: "Inspect Ark transfer status",
+		Long: "Lists user-facing in-round and out-of-round transfer " +
+			"status assembled from local round, OOR, and " +
+			"history data.",
+	}
+
+	cmd.AddCommand(newTransfersListCmd())
+
+	return cmd
+}
+
+// newTransfersListCmd creates the transfers list subcommand.
+func newTransfersListCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List transfer statuses",
+		Long: strings.Join([]string{
+			"Lists in-round and out-of-round transfer status.",
+			"When a direction filter is set, live in-round rows",
+			"whose direction is still unknown are still returned.",
+			"They remain visible because those rows can be useful",
+			"before the daemon has enough local outpoint context",
+			"to classify them as incoming or outgoing.",
+		}, " "),
+		RunE: transfersList,
+	}
+
+	cmd.Flags().String("mode", "all",
+		"mode filter: all, inround, or oor")
+	cmd.Flags().String("direction", "all",
+		"direction filter: all, outgoing, or incoming; pending "+
+			"in-round rows with unknown direction are always shown")
+	cmd.Flags().String("status", "all",
+		"status filter: all, pending, completed, or failed")
+	cmd.Flags().Uint32("limit", 100,
+		"maximum number of transfers to return (default 100)")
+	cmd.Flags().Uint32("offset", 0,
+		"number of filtered transfers to skip")
+
+	return cmd
+}
+
+// transfersList executes the ListTransfers RPC.
+func transfersList(cmd *cobra.Command, _ []string) error {
+	client, conn, err := getDaemonClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	req := &daemonrpc.ListTransfersRequest{}
+	if err := parseRequest(cmd, req, func() error {
+		mode, _ := cmd.Flags().GetString("mode")
+		modeFilter, err := parseTransferModeFilter(mode)
+		if err != nil {
+			return err
+		}
+		req.ModeFilter = modeFilter
+
+		direction, _ := cmd.Flags().GetString("direction")
+		directionFilter, err := parseTransferDirectionFilter(direction)
+		if err != nil {
+			return err
+		}
+		req.DirectionFilter = directionFilter
+
+		status, _ := cmd.Flags().GetString("status")
+		statusFilter, err := parseTransferStatusFilter(status)
+		if err != nil {
+			return err
+		}
+		req.StatusFilter = statusFilter
+
+		limit, _ := cmd.Flags().GetUint32("limit")
+		req.Limit = limit
+
+		offset, _ := cmd.Flags().GetUint32("offset")
+		req.Offset = offset
+
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	resp, err := client.ListTransfers(cmd.Context(), req)
+	if err != nil {
+		return fmt.Errorf("ListTransfers RPC failed: %w", err)
+	}
+
+	return printJSON(resp)
+}
+
+// parseTransferModeFilter converts a CLI mode filter into the proto enum.
+func parseTransferModeFilter(mode string) (daemonrpc.TransferMode, error) {
+	unspecified := daemonrpc.TransferMode_TRANSFER_MODE_UNSPECIFIED
+
+	switch mode {
+	case "", "all":
+		return unspecified, nil
+
+	case "inround":
+		return daemonrpc.TransferMode_TRANSFER_MODE_INROUND, nil
+
+	case "oor":
+		return daemonrpc.TransferMode_TRANSFER_MODE_OOR, nil
+
+	default:
+		return unspecified, fmt.Errorf("unknown transfer mode "+
+			"filter: %s", mode)
+	}
+}
+
+// parseTransferDirectionFilter converts a CLI direction filter into the proto
+// enum.
+func parseTransferDirectionFilter(direction string) (
+	daemonrpc.TransferDirection, error) {
+
+	const unspecified = daemonrpc.
+		TransferDirection_TRANSFER_DIRECTION_UNSPECIFIED
+
+	switch direction {
+	case "", "all":
+		return unspecified, nil
+
+	case "outgoing":
+		return daemonrpc.
+			TransferDirection_TRANSFER_DIRECTION_OUTGOING, nil
+
+	case "incoming":
+		return daemonrpc.
+			TransferDirection_TRANSFER_DIRECTION_INCOMING, nil
+
+	default:
+		return unspecified, fmt.Errorf("unknown transfer direction "+
+			"filter: %s", direction)
+	}
+}
+
+// parseTransferStatusFilter converts a CLI status filter into the proto enum.
+func parseTransferStatusFilter(status string) (daemonrpc.TransferStatus,
+	error) {
+
+	unspecified := daemonrpc.TransferStatus_TRANSFER_STATUS_UNSPECIFIED
+
+	switch status {
+	case "", "all":
+		return unspecified, nil
+
+	case "pending":
+		return daemonrpc.TransferStatus_TRANSFER_STATUS_PENDING, nil
+
+	case "completed":
+		return daemonrpc.TransferStatus_TRANSFER_STATUS_COMPLETED, nil
+
+	case "failed":
+		return daemonrpc.TransferStatus_TRANSFER_STATUS_FAILED, nil
+
+	default:
+		return unspecified, fmt.Errorf("unknown transfer status "+
+			"filter: %s", status)
+	}
+}

--- a/cmd/darepocli/darepoclicommands/cmd_transfers_test.go
+++ b/cmd/darepocli/darepoclicommands/cmd_transfers_test.go
@@ -1,0 +1,163 @@
+package darepoclicommands
+
+import (
+	"testing"
+
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseTransferFilters verifies public CLI filter strings map to the
+// daemon RPC enums.
+func TestParseTransferFilters(t *testing.T) {
+	t.Parallel()
+
+	unspecifiedMode := daemonrpc.TransferMode_TRANSFER_MODE_UNSPECIFIED
+	unspecifiedDirection := daemonrpc.
+		TransferDirection_TRANSFER_DIRECTION_UNSPECIFIED
+	unspecifiedStatus := daemonrpc.
+		TransferStatus_TRANSFER_STATUS_UNSPECIFIED
+
+	mode, err := parseTransferModeFilter("")
+	require.NoError(t, err)
+	require.Equal(t, unspecifiedMode, mode)
+
+	mode, err = parseTransferModeFilter("all")
+	require.NoError(t, err)
+	require.Equal(t, unspecifiedMode, mode)
+
+	direction, err := parseTransferDirectionFilter("")
+	require.NoError(t, err)
+	require.Equal(t, unspecifiedDirection, direction)
+
+	direction, err = parseTransferDirectionFilter("all")
+	require.NoError(t, err)
+	require.Equal(t, unspecifiedDirection, direction)
+
+	status, err := parseTransferStatusFilter("")
+	require.NoError(t, err)
+	require.Equal(t, unspecifiedStatus, status)
+
+	status, err = parseTransferStatusFilter("all")
+	require.NoError(t, err)
+	require.Equal(t, unspecifiedStatus, status)
+
+	mode, err = parseTransferModeFilter("inround")
+	require.NoError(t, err)
+	require.Equal(t, daemonrpc.TransferMode_TRANSFER_MODE_INROUND, mode)
+
+	mode, err = parseTransferModeFilter("oor")
+	require.NoError(t, err)
+	require.Equal(t, daemonrpc.TransferMode_TRANSFER_MODE_OOR, mode)
+
+	direction, err = parseTransferDirectionFilter("incoming")
+	require.NoError(t, err)
+	require.Equal(
+		t, daemonrpc.TransferDirection_TRANSFER_DIRECTION_INCOMING,
+		direction,
+	)
+
+	direction, err = parseTransferDirectionFilter("outgoing")
+	require.NoError(t, err)
+	require.Equal(
+		t, daemonrpc.TransferDirection_TRANSFER_DIRECTION_OUTGOING,
+		direction,
+	)
+
+	status, err = parseTransferStatusFilter("completed")
+	require.NoError(t, err)
+	require.Equal(
+		t, daemonrpc.TransferStatus_TRANSFER_STATUS_COMPLETED, status,
+	)
+
+	status, err = parseTransferStatusFilter("pending")
+	require.NoError(t, err)
+	require.Equal(
+		t, daemonrpc.TransferStatus_TRANSFER_STATUS_PENDING, status,
+	)
+
+	status, err = parseTransferStatusFilter("failed")
+	require.NoError(t, err)
+	require.Equal(
+		t, daemonrpc.TransferStatus_TRANSFER_STATUS_FAILED, status,
+	)
+}
+
+// TestParseTransferFiltersRejectUnknown verifies invalid filter values are
+// rejected before the CLI reaches the daemon.
+func TestParseTransferFiltersRejectUnknown(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseTransferModeFilter("boarding")
+	require.ErrorContains(t, err, "unknown transfer mode")
+
+	_, err = parseTransferDirectionFilter("sideways")
+	require.ErrorContains(t, err, "unknown transfer direction")
+
+	_, err = parseTransferStatusFilter("stuck")
+	require.ErrorContains(t, err, "unknown transfer status")
+}
+
+// TestMethodRegistryTransfersSchema verifies the schema advertises the new
+// transfer list filters.
+func TestMethodRegistryTransfersSchema(t *testing.T) {
+	t.Parallel()
+
+	method := findSchemaMethod(t, "transfers.list")
+	require.Equal(t, "ListTransfersRequest", method.RequestType)
+	require.Equal(t, "ListTransfersResponse", method.ResponseType)
+
+	params := make(map[string]schemaParam, len(method.Params))
+	for _, param := range method.Params {
+		params[param.Name] = param
+	}
+
+	require.Equal(
+		t, []string{"all", "inround", "oor"}, params["mode"].Values,
+	)
+	require.Equal(
+		t, "mode filter: all, inround, or oor",
+		params["mode"].Description,
+	)
+	require.Equal(
+		t, []string{"all", "outgoing", "incoming"},
+		params["direction"].Values,
+	)
+	require.Equal(
+		t, "direction filter: all, outgoing, or incoming; unknown "+
+			"pending rows are always shown",
+		params["direction"].Description,
+	)
+	require.Equal(
+		t, []string{"all", "pending", "completed", "failed"},
+		params["status"].Values,
+	)
+	require.Equal(
+		t, "status filter: all, pending, completed, or failed",
+		params["status"].Description,
+	)
+	require.Equal(t, "uint32", params["limit"].Type)
+	require.Equal(
+		t, "max rows to return; zero uses default",
+		params["limit"].Description,
+	)
+	require.Equal(t, "uint32", params["offset"].Type)
+	require.Equal(
+		t, "rows to skip after filtering and sorting",
+		params["offset"].Description,
+	)
+}
+
+// TestMethodRegistryReceiveSchema verifies the schema advertises generic
+// receive allocation and listing.
+func TestMethodRegistryReceiveSchema(t *testing.T) {
+	t.Parallel()
+
+	receive := findSchemaMethod(t, "receive")
+	require.Equal(t, "NewReceiveScriptRequest", receive.RequestType)
+	require.Equal(t, "NewReceiveScriptResponse", receive.ResponseType)
+
+	list := findSchemaMethod(t, "receive.list")
+	require.Equal(t, "ListReceiveScriptsRequest", list.RequestType)
+	require.Equal(t, "ListReceiveScriptsResponse", list.ResponseType)
+}

--- a/cmd/darepocli/darepoclicommands/root.go
+++ b/cmd/darepocli/darepoclicommands/root.go
@@ -59,7 +59,8 @@ func NewRootCmd() *cobra.Command {
 		newGetInfoCmd(), newWalletCmd(), newOORCmd(), newVTXOsCmd(),
 		newSendCmd(), newBoardCmd(), newSweepCmd(),
 		newListTransactionsCmd(), newRoundsCmd(), newFeesCmd(),
-		newSchemaCmd(), newMCPCmd(), newUnrollCmd(), newSwapCmd(),
+		newReceiveCmd(), newTransfersCmd(), newSchemaCmd(), newMCPCmd(),
+		newUnrollCmd(), newSwapCmd(),
 	)
 
 	return cmd

--- a/cmd/darepocli/darepoclicommands/schema_registry.go
+++ b/cmd/darepocli/darepoclicommands/schema_registry.go
@@ -52,6 +52,8 @@ func methodRegistry() []schemaMethod {
 	out := baseMethodRegistry()
 	out = append(out, vtxoLifecycleMethodRegistry()...)
 	out = append(out, sendMethodRegistry()...)
+	out = append(out, receiveMethodRegistry()...)
+	out = append(out, transferMethodRegistry()...)
 
 	return out
 }
@@ -253,6 +255,98 @@ func baseMethodRegistry() []schemaMethod {
 	}
 }
 
+// receiveMethodRegistry returns the generic receive-target schema entries.
+func receiveMethodRegistry() []schemaMethod {
+	return []schemaMethod{
+		{
+			Method:      "receive",
+			Description: "Allocate a fresh Ark receive target",
+			Params: []schemaParam{
+				{
+					Name: "label",
+					Type: "string",
+					Description: "optional indexer " +
+						"registration label",
+				},
+			},
+			RequestType:  "NewReceiveScriptRequest",
+			ResponseType: "NewReceiveScriptResponse",
+			JSONInput:    true,
+		},
+		{
+			Method:       "receive.list",
+			Description:  "List registered Ark receive targets",
+			Params:       nil,
+			RequestType:  "ListReceiveScriptsRequest",
+			ResponseType: "ListReceiveScriptsResponse",
+			JSONInput:    true,
+		},
+	}
+}
+
+// transferMethodRegistry returns the transfer status schema entries.
+func transferMethodRegistry() []schemaMethod {
+	return []schemaMethod{
+		{
+			Method:      "transfers.list",
+			Description: "List in-round and OOR transfer statuses",
+			Params: []schemaParam{
+				{
+					Name: "mode",
+					Type: "enum",
+					Description: "mode filter: all, " +
+						"inround, or oor",
+					Values: []string{
+						"all",
+						"inround",
+						"oor",
+					},
+				},
+				{
+					Name: "direction",
+					Type: "enum",
+					Description: "direction filter: all, " +
+						"outgoing, or incoming; " +
+						"unknown pending rows " +
+						"are always shown",
+					Values: []string{
+						"all",
+						"outgoing",
+						"incoming",
+					},
+				},
+				{
+					Name: "status",
+					Type: "enum",
+					Description: "status filter: all, " +
+						"pending, completed, or failed",
+					Values: []string{
+						"all",
+						"pending",
+						"completed",
+						"failed",
+					},
+				},
+				{
+					Name: "limit",
+					Type: "uint32",
+					Description: "max rows to return; " +
+						"zero uses default",
+				},
+				{
+					Name: "offset",
+					Type: "uint32",
+					Description: "rows to skip after " +
+						"filtering and sorting",
+				},
+			},
+			RequestType:  "ListTransfersRequest",
+			ResponseType: "ListTransfersResponse",
+			JSONInput:    true,
+		},
+	}
+}
+
 // vtxoLifecycleMethodRegistry returns the VTXO lifecycle commands
 // (list / refresh / leave). Split out of methodRegistry so the parent
 // stays under the funlen cap as new entries land.
@@ -405,24 +499,14 @@ func sendMethodRegistry() []schemaMethod {
 					Name: "to",
 					Type: "string",
 					Description: "recipient address " +
-						"(exactly one of to, pubkey, " +
-						"or pk_script)",
+						"(exactly one of to or pubkey)",
 				},
 				{
 					Name: "pubkey",
 					Type: "string",
 					Description: "recipient 32-byte " +
 						"x-only pubkey hex (exactly " +
-						"one of to, pubkey, or " +
-						"pk_script)",
-				},
-				{
-					Name: "pk_script",
-					Type: "string",
-					Description: "recipient raw " +
-						"pk_script hex (exactly one " +
-						"of to, pubkey, or " +
-						"pk_script)",
+						"one of to or pubkey)",
 				},
 				{
 					Name:        "amount",

--- a/daemonrpc/daemon.pb.go
+++ b/daemonrpc/daemon.pb.go
@@ -327,6 +327,156 @@ func (OORSessionStatus) EnumDescriptor() ([]byte, []int) {
 	return file_daemon_proto_rawDescGZIP(), []int{3}
 }
 
+type TransferMode int32
+
+const (
+	TransferMode_TRANSFER_MODE_UNSPECIFIED TransferMode = 0
+	TransferMode_TRANSFER_MODE_INROUND     TransferMode = 1
+	TransferMode_TRANSFER_MODE_OOR         TransferMode = 2
+)
+
+// Enum value maps for TransferMode.
+var (
+	TransferMode_name = map[int32]string{
+		0: "TRANSFER_MODE_UNSPECIFIED",
+		1: "TRANSFER_MODE_INROUND",
+		2: "TRANSFER_MODE_OOR",
+	}
+	TransferMode_value = map[string]int32{
+		"TRANSFER_MODE_UNSPECIFIED": 0,
+		"TRANSFER_MODE_INROUND":     1,
+		"TRANSFER_MODE_OOR":         2,
+	}
+)
+
+func (x TransferMode) Enum() *TransferMode {
+	p := new(TransferMode)
+	*p = x
+	return p
+}
+
+func (x TransferMode) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (TransferMode) Descriptor() protoreflect.EnumDescriptor {
+	return file_daemon_proto_enumTypes[4].Descriptor()
+}
+
+func (TransferMode) Type() protoreflect.EnumType {
+	return &file_daemon_proto_enumTypes[4]
+}
+
+func (x TransferMode) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use TransferMode.Descriptor instead.
+func (TransferMode) EnumDescriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{4}
+}
+
+type TransferDirection int32
+
+const (
+	TransferDirection_TRANSFER_DIRECTION_UNSPECIFIED TransferDirection = 0
+	TransferDirection_TRANSFER_DIRECTION_OUTGOING    TransferDirection = 1
+	TransferDirection_TRANSFER_DIRECTION_INCOMING    TransferDirection = 2
+)
+
+// Enum value maps for TransferDirection.
+var (
+	TransferDirection_name = map[int32]string{
+		0: "TRANSFER_DIRECTION_UNSPECIFIED",
+		1: "TRANSFER_DIRECTION_OUTGOING",
+		2: "TRANSFER_DIRECTION_INCOMING",
+	}
+	TransferDirection_value = map[string]int32{
+		"TRANSFER_DIRECTION_UNSPECIFIED": 0,
+		"TRANSFER_DIRECTION_OUTGOING":    1,
+		"TRANSFER_DIRECTION_INCOMING":    2,
+	}
+)
+
+func (x TransferDirection) Enum() *TransferDirection {
+	p := new(TransferDirection)
+	*p = x
+	return p
+}
+
+func (x TransferDirection) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (TransferDirection) Descriptor() protoreflect.EnumDescriptor {
+	return file_daemon_proto_enumTypes[5].Descriptor()
+}
+
+func (TransferDirection) Type() protoreflect.EnumType {
+	return &file_daemon_proto_enumTypes[5]
+}
+
+func (x TransferDirection) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use TransferDirection.Descriptor instead.
+func (TransferDirection) EnumDescriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{5}
+}
+
+type TransferStatus int32
+
+const (
+	TransferStatus_TRANSFER_STATUS_UNSPECIFIED TransferStatus = 0
+	TransferStatus_TRANSFER_STATUS_PENDING     TransferStatus = 1
+	TransferStatus_TRANSFER_STATUS_COMPLETED   TransferStatus = 2
+	TransferStatus_TRANSFER_STATUS_FAILED      TransferStatus = 3
+)
+
+// Enum value maps for TransferStatus.
+var (
+	TransferStatus_name = map[int32]string{
+		0: "TRANSFER_STATUS_UNSPECIFIED",
+		1: "TRANSFER_STATUS_PENDING",
+		2: "TRANSFER_STATUS_COMPLETED",
+		3: "TRANSFER_STATUS_FAILED",
+	}
+	TransferStatus_value = map[string]int32{
+		"TRANSFER_STATUS_UNSPECIFIED": 0,
+		"TRANSFER_STATUS_PENDING":     1,
+		"TRANSFER_STATUS_COMPLETED":   2,
+		"TRANSFER_STATUS_FAILED":      3,
+	}
+)
+
+func (x TransferStatus) Enum() *TransferStatus {
+	p := new(TransferStatus)
+	*p = x
+	return p
+}
+
+func (x TransferStatus) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (TransferStatus) Descriptor() protoreflect.EnumDescriptor {
+	return file_daemon_proto_enumTypes[6].Descriptor()
+}
+
+func (TransferStatus) Type() protoreflect.EnumType {
+	return &file_daemon_proto_enumTypes[6]
+}
+
+func (x TransferStatus) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use TransferStatus.Descriptor instead.
+func (TransferStatus) EnumDescriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{6}
+}
+
 // UnrollJobStatus represents the high-level phase of an unroll job.
 type UnrollJobStatus int32
 
@@ -385,11 +535,11 @@ func (x UnrollJobStatus) String() string {
 }
 
 func (UnrollJobStatus) Descriptor() protoreflect.EnumDescriptor {
-	return file_daemon_proto_enumTypes[4].Descriptor()
+	return file_daemon_proto_enumTypes[7].Descriptor()
 }
 
 func (UnrollJobStatus) Type() protoreflect.EnumType {
-	return &file_daemon_proto_enumTypes[4]
+	return &file_daemon_proto_enumTypes[7]
 }
 
 func (x UnrollJobStatus) Number() protoreflect.EnumNumber {
@@ -398,7 +548,7 @@ func (x UnrollJobStatus) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use UnrollJobStatus.Descriptor instead.
 func (UnrollJobStatus) EnumDescriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{4}
+	return file_daemon_proto_rawDescGZIP(), []int{7}
 }
 
 type GetInfoRequest struct {
@@ -1599,7 +1749,10 @@ type NewReceiveScriptResponse struct {
 	// key_index is the wallet key index used to derive the receive key.
 	KeyIndex uint32 `protobuf:"varint,4,opt,name=key_index,json=keyIndex,proto3" json:"key_index,omitempty"`
 	// label is the registration label stored with the indexer.
-	Label         string `protobuf:"bytes,5,opt,name=label,proto3" json:"label,omitempty"`
+	Label string `protobuf:"bytes,5,opt,name=label,proto3" json:"label,omitempty"`
+	// address is the bech32m taproot address for pk_script_hex on the active
+	// chain network.
+	Address       string `protobuf:"bytes,6,opt,name=address,proto3" json:"address,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1669,6 +1822,167 @@ func (x *NewReceiveScriptResponse) GetLabel() string {
 	return ""
 }
 
+func (x *NewReceiveScriptResponse) GetAddress() string {
+	if x != nil {
+		return x.Address
+	}
+	return ""
+}
+
+type ReceiveTarget struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// address is the bech32m taproot address callers can hand to a sender.
+	Address string `protobuf:"bytes,1,opt,name=address,proto3" json:"address,omitempty"`
+	// pk_script_hex is the raw taproot output script encoded as hex.
+	PkScriptHex string `protobuf:"bytes,2,opt,name=pk_script_hex,json=pkScriptHex,proto3" json:"pk_script_hex,omitempty"`
+	// label is the informational registration label stored with the indexer.
+	Label string `protobuf:"bytes,3,opt,name=label,proto3" json:"label,omitempty"`
+	// expires_at_unix_s is the indexer-side expiration time for this
+	// registration. Zero means the indexer default applies.
+	ExpiresAtUnixS uint64 `protobuf:"varint,4,opt,name=expires_at_unix_s,json=expiresAtUnixS,proto3" json:"expires_at_unix_s,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *ReceiveTarget) Reset() {
+	*x = ReceiveTarget{}
+	mi := &file_daemon_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ReceiveTarget) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ReceiveTarget) ProtoMessage() {}
+
+func (x *ReceiveTarget) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ReceiveTarget.ProtoReflect.Descriptor instead.
+func (*ReceiveTarget) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *ReceiveTarget) GetAddress() string {
+	if x != nil {
+		return x.Address
+	}
+	return ""
+}
+
+func (x *ReceiveTarget) GetPkScriptHex() string {
+	if x != nil {
+		return x.PkScriptHex
+	}
+	return ""
+}
+
+func (x *ReceiveTarget) GetLabel() string {
+	if x != nil {
+		return x.Label
+	}
+	return ""
+}
+
+func (x *ReceiveTarget) GetExpiresAtUnixS() uint64 {
+	if x != nil {
+		return x.ExpiresAtUnixS
+	}
+	return 0
+}
+
+type ListReceiveScriptsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListReceiveScriptsRequest) Reset() {
+	*x = ListReceiveScriptsRequest{}
+	mi := &file_daemon_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListReceiveScriptsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListReceiveScriptsRequest) ProtoMessage() {}
+
+func (x *ListReceiveScriptsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListReceiveScriptsRequest.ProtoReflect.Descriptor instead.
+func (*ListReceiveScriptsRequest) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{19}
+}
+
+type ListReceiveScriptsResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// targets is the set of active receive targets registered for this wallet.
+	Targets       []*ReceiveTarget `protobuf:"bytes,1,rep,name=targets,proto3" json:"targets,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListReceiveScriptsResponse) Reset() {
+	*x = ListReceiveScriptsResponse{}
+	mi := &file_daemon_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListReceiveScriptsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListReceiveScriptsResponse) ProtoMessage() {}
+
+func (x *ListReceiveScriptsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListReceiveScriptsResponse.ProtoReflect.Descriptor instead.
+func (*ListReceiveScriptsResponse) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *ListReceiveScriptsResponse) GetTargets() []*ReceiveTarget {
+	if x != nil {
+		return x.Targets
+	}
+	return nil
+}
+
 type ReceiveAuthKeyRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// payment_hash is the 32-byte Lightning payment hash for the receive
@@ -1680,7 +1994,7 @@ type ReceiveAuthKeyRequest struct {
 
 func (x *ReceiveAuthKeyRequest) Reset() {
 	*x = ReceiveAuthKeyRequest{}
-	mi := &file_daemon_proto_msgTypes[18]
+	mi := &file_daemon_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1692,7 +2006,7 @@ func (x *ReceiveAuthKeyRequest) String() string {
 func (*ReceiveAuthKeyRequest) ProtoMessage() {}
 
 func (x *ReceiveAuthKeyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[18]
+	mi := &file_daemon_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1705,7 +2019,7 @@ func (x *ReceiveAuthKeyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReceiveAuthKeyRequest.ProtoReflect.Descriptor instead.
 func (*ReceiveAuthKeyRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{18}
+	return file_daemon_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *ReceiveAuthKeyRequest) GetPaymentHash() []byte {
@@ -1726,7 +2040,7 @@ type ReceiveAuthKeyResponse struct {
 
 func (x *ReceiveAuthKeyResponse) Reset() {
 	*x = ReceiveAuthKeyResponse{}
-	mi := &file_daemon_proto_msgTypes[19]
+	mi := &file_daemon_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1738,7 +2052,7 @@ func (x *ReceiveAuthKeyResponse) String() string {
 func (*ReceiveAuthKeyResponse) ProtoMessage() {}
 
 func (x *ReceiveAuthKeyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[19]
+	mi := &file_daemon_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1751,7 +2065,7 @@ func (x *ReceiveAuthKeyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReceiveAuthKeyResponse.ProtoReflect.Descriptor instead.
 func (*ReceiveAuthKeyResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{19}
+	return file_daemon_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *ReceiveAuthKeyResponse) GetPubkey() []byte {
@@ -1777,7 +2091,7 @@ type SignReceiveAuthMessageRequest struct {
 
 func (x *SignReceiveAuthMessageRequest) Reset() {
 	*x = SignReceiveAuthMessageRequest{}
-	mi := &file_daemon_proto_msgTypes[20]
+	mi := &file_daemon_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1789,7 +2103,7 @@ func (x *SignReceiveAuthMessageRequest) String() string {
 func (*SignReceiveAuthMessageRequest) ProtoMessage() {}
 
 func (x *SignReceiveAuthMessageRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[20]
+	mi := &file_daemon_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1802,7 +2116,7 @@ func (x *SignReceiveAuthMessageRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignReceiveAuthMessageRequest.ProtoReflect.Descriptor instead.
 func (*SignReceiveAuthMessageRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{20}
+	return file_daemon_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *SignReceiveAuthMessageRequest) GetPaymentHash() []byte {
@@ -1836,7 +2150,7 @@ type SignReceiveAuthMessageResponse struct {
 
 func (x *SignReceiveAuthMessageResponse) Reset() {
 	*x = SignReceiveAuthMessageResponse{}
-	mi := &file_daemon_proto_msgTypes[21]
+	mi := &file_daemon_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1848,7 +2162,7 @@ func (x *SignReceiveAuthMessageResponse) String() string {
 func (*SignReceiveAuthMessageResponse) ProtoMessage() {}
 
 func (x *SignReceiveAuthMessageResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[21]
+	mi := &file_daemon_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1861,7 +2175,7 @@ func (x *SignReceiveAuthMessageResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignReceiveAuthMessageResponse.ProtoReflect.Descriptor instead.
 func (*SignReceiveAuthMessageResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{21}
+	return file_daemon_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *SignReceiveAuthMessageResponse) GetSignature() []byte {
@@ -1887,7 +2201,7 @@ type SignReceiveAuthMessageCompactRequest struct {
 
 func (x *SignReceiveAuthMessageCompactRequest) Reset() {
 	*x = SignReceiveAuthMessageCompactRequest{}
-	mi := &file_daemon_proto_msgTypes[22]
+	mi := &file_daemon_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1899,7 +2213,7 @@ func (x *SignReceiveAuthMessageCompactRequest) String() string {
 func (*SignReceiveAuthMessageCompactRequest) ProtoMessage() {}
 
 func (x *SignReceiveAuthMessageCompactRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[22]
+	mi := &file_daemon_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1912,7 +2226,7 @@ func (x *SignReceiveAuthMessageCompactRequest) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use SignReceiveAuthMessageCompactRequest.ProtoReflect.Descriptor instead.
 func (*SignReceiveAuthMessageCompactRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{22}
+	return file_daemon_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *SignReceiveAuthMessageCompactRequest) GetPaymentHash() []byte {
@@ -1946,7 +2260,7 @@ type SignReceiveAuthMessageCompactResponse struct {
 
 func (x *SignReceiveAuthMessageCompactResponse) Reset() {
 	*x = SignReceiveAuthMessageCompactResponse{}
-	mi := &file_daemon_proto_msgTypes[23]
+	mi := &file_daemon_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1958,7 +2272,7 @@ func (x *SignReceiveAuthMessageCompactResponse) String() string {
 func (*SignReceiveAuthMessageCompactResponse) ProtoMessage() {}
 
 func (x *SignReceiveAuthMessageCompactResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[23]
+	mi := &file_daemon_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1971,7 +2285,7 @@ func (x *SignReceiveAuthMessageCompactResponse) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use SignReceiveAuthMessageCompactResponse.ProtoReflect.Descriptor instead.
 func (*SignReceiveAuthMessageCompactResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{23}
+	return file_daemon_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *SignReceiveAuthMessageCompactResponse) GetSignature() []byte {
@@ -1994,7 +2308,7 @@ type ReceiveAuthECDHRequest struct {
 
 func (x *ReceiveAuthECDHRequest) Reset() {
 	*x = ReceiveAuthECDHRequest{}
-	mi := &file_daemon_proto_msgTypes[24]
+	mi := &file_daemon_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2006,7 +2320,7 @@ func (x *ReceiveAuthECDHRequest) String() string {
 func (*ReceiveAuthECDHRequest) ProtoMessage() {}
 
 func (x *ReceiveAuthECDHRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[24]
+	mi := &file_daemon_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2019,7 +2333,7 @@ func (x *ReceiveAuthECDHRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReceiveAuthECDHRequest.ProtoReflect.Descriptor instead.
 func (*ReceiveAuthECDHRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{24}
+	return file_daemon_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *ReceiveAuthECDHRequest) GetPaymentHash() []byte {
@@ -2046,7 +2360,7 @@ type ReceiveAuthECDHResponse struct {
 
 func (x *ReceiveAuthECDHResponse) Reset() {
 	*x = ReceiveAuthECDHResponse{}
-	mi := &file_daemon_proto_msgTypes[25]
+	mi := &file_daemon_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2058,7 +2372,7 @@ func (x *ReceiveAuthECDHResponse) String() string {
 func (*ReceiveAuthECDHResponse) ProtoMessage() {}
 
 func (x *ReceiveAuthECDHResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[25]
+	mi := &file_daemon_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2071,7 +2385,7 @@ func (x *ReceiveAuthECDHResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReceiveAuthECDHResponse.ProtoReflect.Descriptor instead.
 func (*ReceiveAuthECDHResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{25}
+	return file_daemon_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *ReceiveAuthECDHResponse) GetSharedSecret() []byte {
@@ -2094,7 +2408,7 @@ type GetIndexedVTXOByPkScriptRequest struct {
 
 func (x *GetIndexedVTXOByPkScriptRequest) Reset() {
 	*x = GetIndexedVTXOByPkScriptRequest{}
-	mi := &file_daemon_proto_msgTypes[26]
+	mi := &file_daemon_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2106,7 +2420,7 @@ func (x *GetIndexedVTXOByPkScriptRequest) String() string {
 func (*GetIndexedVTXOByPkScriptRequest) ProtoMessage() {}
 
 func (x *GetIndexedVTXOByPkScriptRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[26]
+	mi := &file_daemon_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2119,7 +2433,7 @@ func (x *GetIndexedVTXOByPkScriptRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetIndexedVTXOByPkScriptRequest.ProtoReflect.Descriptor instead.
 func (*GetIndexedVTXOByPkScriptRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{26}
+	return file_daemon_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *GetIndexedVTXOByPkScriptRequest) GetPkScript() []byte {
@@ -2146,7 +2460,7 @@ type GetIndexedVTXOByPkScriptResponse struct {
 
 func (x *GetIndexedVTXOByPkScriptResponse) Reset() {
 	*x = GetIndexedVTXOByPkScriptResponse{}
-	mi := &file_daemon_proto_msgTypes[27]
+	mi := &file_daemon_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2158,7 +2472,7 @@ func (x *GetIndexedVTXOByPkScriptResponse) String() string {
 func (*GetIndexedVTXOByPkScriptResponse) ProtoMessage() {}
 
 func (x *GetIndexedVTXOByPkScriptResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[27]
+	mi := &file_daemon_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2171,7 +2485,7 @@ func (x *GetIndexedVTXOByPkScriptResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetIndexedVTXOByPkScriptResponse.ProtoReflect.Descriptor instead.
 func (*GetIndexedVTXOByPkScriptResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{27}
+	return file_daemon_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *GetIndexedVTXOByPkScriptResponse) GetVtxo() *VTXO {
@@ -2193,7 +2507,7 @@ type GetIndexedOORSessionByTxidRequest struct {
 
 func (x *GetIndexedOORSessionByTxidRequest) Reset() {
 	*x = GetIndexedOORSessionByTxidRequest{}
-	mi := &file_daemon_proto_msgTypes[28]
+	mi := &file_daemon_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2205,7 +2519,7 @@ func (x *GetIndexedOORSessionByTxidRequest) String() string {
 func (*GetIndexedOORSessionByTxidRequest) ProtoMessage() {}
 
 func (x *GetIndexedOORSessionByTxidRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[28]
+	mi := &file_daemon_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2218,7 +2532,7 @@ func (x *GetIndexedOORSessionByTxidRequest) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use GetIndexedOORSessionByTxidRequest.ProtoReflect.Descriptor instead.
 func (*GetIndexedOORSessionByTxidRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{28}
+	return file_daemon_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *GetIndexedOORSessionByTxidRequest) GetPkScript() []byte {
@@ -2248,7 +2562,7 @@ type GetIndexedOORSessionByTxidResponse struct {
 
 func (x *GetIndexedOORSessionByTxidResponse) Reset() {
 	*x = GetIndexedOORSessionByTxidResponse{}
-	mi := &file_daemon_proto_msgTypes[29]
+	mi := &file_daemon_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2260,7 +2574,7 @@ func (x *GetIndexedOORSessionByTxidResponse) String() string {
 func (*GetIndexedOORSessionByTxidResponse) ProtoMessage() {}
 
 func (x *GetIndexedOORSessionByTxidResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[29]
+	mi := &file_daemon_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2273,7 +2587,7 @@ func (x *GetIndexedOORSessionByTxidResponse) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use GetIndexedOORSessionByTxidResponse.ProtoReflect.Descriptor instead.
 func (*GetIndexedOORSessionByTxidResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{29}
+	return file_daemon_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *GetIndexedOORSessionByTxidResponse) GetArkPsbt() []byte {
@@ -2311,7 +2625,7 @@ type Output struct {
 
 func (x *Output) Reset() {
 	*x = Output{}
-	mi := &file_daemon_proto_msgTypes[30]
+	mi := &file_daemon_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2323,7 +2637,7 @@ func (x *Output) String() string {
 func (*Output) ProtoMessage() {}
 
 func (x *Output) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[30]
+	mi := &file_daemon_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2336,7 +2650,7 @@ func (x *Output) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Output.ProtoReflect.Descriptor instead.
 func (*Output) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{30}
+	return file_daemon_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *Output) GetDestination() isOutput_Destination {
@@ -2433,7 +2747,7 @@ type SendVTXORequest struct {
 
 func (x *SendVTXORequest) Reset() {
 	*x = SendVTXORequest{}
-	mi := &file_daemon_proto_msgTypes[31]
+	mi := &file_daemon_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2445,7 +2759,7 @@ func (x *SendVTXORequest) String() string {
 func (*SendVTXORequest) ProtoMessage() {}
 
 func (x *SendVTXORequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[31]
+	mi := &file_daemon_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2458,7 +2772,7 @@ func (x *SendVTXORequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendVTXORequest.ProtoReflect.Descriptor instead.
 func (*SendVTXORequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{31}
+	return file_daemon_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *SendVTXORequest) GetRecipients() []*Output {
@@ -2498,7 +2812,7 @@ type SendVTXOResponse struct {
 
 func (x *SendVTXOResponse) Reset() {
 	*x = SendVTXOResponse{}
-	mi := &file_daemon_proto_msgTypes[32]
+	mi := &file_daemon_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2510,7 +2824,7 @@ func (x *SendVTXOResponse) String() string {
 func (*SendVTXOResponse) ProtoMessage() {}
 
 func (x *SendVTXOResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[32]
+	mi := &file_daemon_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2523,7 +2837,7 @@ func (x *SendVTXOResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendVTXOResponse.ProtoReflect.Descriptor instead.
 func (*SendVTXOResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{32}
+	return file_daemon_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *SendVTXOResponse) GetStatus() string {
@@ -2583,7 +2897,7 @@ type SendOORRequest struct {
 
 func (x *SendOORRequest) Reset() {
 	*x = SendOORRequest{}
-	mi := &file_daemon_proto_msgTypes[33]
+	mi := &file_daemon_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2595,7 +2909,7 @@ func (x *SendOORRequest) String() string {
 func (*SendOORRequest) ProtoMessage() {}
 
 func (x *SendOORRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[33]
+	mi := &file_daemon_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2608,7 +2922,7 @@ func (x *SendOORRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendOORRequest.ProtoReflect.Descriptor instead.
 func (*SendOORRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{33}
+	return file_daemon_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *SendOORRequest) GetRecipient() *Output {
@@ -2662,7 +2976,7 @@ type CustomOORInput struct {
 
 func (x *CustomOORInput) Reset() {
 	*x = CustomOORInput{}
-	mi := &file_daemon_proto_msgTypes[34]
+	mi := &file_daemon_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2674,7 +2988,7 @@ func (x *CustomOORInput) String() string {
 func (*CustomOORInput) ProtoMessage() {}
 
 func (x *CustomOORInput) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[34]
+	mi := &file_daemon_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2687,7 +3001,7 @@ func (x *CustomOORInput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CustomOORInput.ProtoReflect.Descriptor instead.
 func (*CustomOORInput) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{34}
+	return file_daemon_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *CustomOORInput) GetOutpoint() string {
@@ -2738,7 +3052,7 @@ type SendOORResponse struct {
 
 func (x *SendOORResponse) Reset() {
 	*x = SendOORResponse{}
-	mi := &file_daemon_proto_msgTypes[35]
+	mi := &file_daemon_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2750,7 +3064,7 @@ func (x *SendOORResponse) String() string {
 func (*SendOORResponse) ProtoMessage() {}
 
 func (x *SendOORResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[35]
+	mi := &file_daemon_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2763,7 +3077,7 @@ func (x *SendOORResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendOORResponse.ProtoReflect.Descriptor instead.
 func (*SendOORResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{35}
+	return file_daemon_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *SendOORResponse) GetStatus() string {
@@ -2793,7 +3107,7 @@ type OutpointSelection struct {
 
 func (x *OutpointSelection) Reset() {
 	*x = OutpointSelection{}
-	mi := &file_daemon_proto_msgTypes[36]
+	mi := &file_daemon_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2805,7 +3119,7 @@ func (x *OutpointSelection) String() string {
 func (*OutpointSelection) ProtoMessage() {}
 
 func (x *OutpointSelection) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[36]
+	mi := &file_daemon_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2818,7 +3132,7 @@ func (x *OutpointSelection) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OutpointSelection.ProtoReflect.Descriptor instead.
 func (*OutpointSelection) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{36}
+	return file_daemon_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *OutpointSelection) GetOutpoints() []string {
@@ -2843,7 +3157,7 @@ type RefreshVTXOsRequest struct {
 
 func (x *RefreshVTXOsRequest) Reset() {
 	*x = RefreshVTXOsRequest{}
-	mi := &file_daemon_proto_msgTypes[37]
+	mi := &file_daemon_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2855,7 +3169,7 @@ func (x *RefreshVTXOsRequest) String() string {
 func (*RefreshVTXOsRequest) ProtoMessage() {}
 
 func (x *RefreshVTXOsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[37]
+	mi := &file_daemon_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2868,7 +3182,7 @@ func (x *RefreshVTXOsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RefreshVTXOsRequest.ProtoReflect.Descriptor instead.
 func (*RefreshVTXOsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{37}
+	return file_daemon_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *RefreshVTXOsRequest) GetSelection() isRefreshVTXOsRequest_Selection {
@@ -2935,7 +3249,7 @@ type RefreshVTXOsResponse struct {
 
 func (x *RefreshVTXOsResponse) Reset() {
 	*x = RefreshVTXOsResponse{}
-	mi := &file_daemon_proto_msgTypes[38]
+	mi := &file_daemon_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2947,7 +3261,7 @@ func (x *RefreshVTXOsResponse) String() string {
 func (*RefreshVTXOsResponse) ProtoMessage() {}
 
 func (x *RefreshVTXOsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[38]
+	mi := &file_daemon_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2960,7 +3274,7 @@ func (x *RefreshVTXOsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RefreshVTXOsResponse.ProtoReflect.Descriptor instead.
 func (*RefreshVTXOsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{38}
+	return file_daemon_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *RefreshVTXOsResponse) GetQueuedOutpoints() []string {
@@ -2994,7 +3308,7 @@ type LeaveDestination struct {
 
 func (x *LeaveDestination) Reset() {
 	*x = LeaveDestination{}
-	mi := &file_daemon_proto_msgTypes[39]
+	mi := &file_daemon_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3006,7 +3320,7 @@ func (x *LeaveDestination) String() string {
 func (*LeaveDestination) ProtoMessage() {}
 
 func (x *LeaveDestination) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[39]
+	mi := &file_daemon_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3019,7 +3333,7 @@ func (x *LeaveDestination) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LeaveDestination.ProtoReflect.Descriptor instead.
 func (*LeaveDestination) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{39}
+	return file_daemon_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *LeaveDestination) GetTarget() isLeaveDestination_Target {
@@ -3100,7 +3414,7 @@ type LeaveVTXOsRequest struct {
 
 func (x *LeaveVTXOsRequest) Reset() {
 	*x = LeaveVTXOsRequest{}
-	mi := &file_daemon_proto_msgTypes[40]
+	mi := &file_daemon_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3112,7 +3426,7 @@ func (x *LeaveVTXOsRequest) String() string {
 func (*LeaveVTXOsRequest) ProtoMessage() {}
 
 func (x *LeaveVTXOsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[40]
+	mi := &file_daemon_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3125,7 +3439,7 @@ func (x *LeaveVTXOsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LeaveVTXOsRequest.ProtoReflect.Descriptor instead.
 func (*LeaveVTXOsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{40}
+	return file_daemon_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *LeaveVTXOsRequest) GetSelection() isLeaveVTXOsRequest_Selection {
@@ -3208,7 +3522,7 @@ type LeaveVTXOsResponse struct {
 
 func (x *LeaveVTXOsResponse) Reset() {
 	*x = LeaveVTXOsResponse{}
-	mi := &file_daemon_proto_msgTypes[41]
+	mi := &file_daemon_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3220,7 +3534,7 @@ func (x *LeaveVTXOsResponse) String() string {
 func (*LeaveVTXOsResponse) ProtoMessage() {}
 
 func (x *LeaveVTXOsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[41]
+	mi := &file_daemon_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3233,7 +3547,7 @@ func (x *LeaveVTXOsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LeaveVTXOsResponse.ProtoReflect.Descriptor instead.
 func (*LeaveVTXOsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{41}
+	return file_daemon_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *LeaveVTXOsResponse) GetQueuedOutpoints() []string {
@@ -3271,7 +3585,7 @@ type BoardRequest struct {
 
 func (x *BoardRequest) Reset() {
 	*x = BoardRequest{}
-	mi := &file_daemon_proto_msgTypes[42]
+	mi := &file_daemon_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3283,7 +3597,7 @@ func (x *BoardRequest) String() string {
 func (*BoardRequest) ProtoMessage() {}
 
 func (x *BoardRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[42]
+	mi := &file_daemon_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3296,7 +3610,7 @@ func (x *BoardRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoardRequest.ProtoReflect.Descriptor instead.
 func (*BoardRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{42}
+	return file_daemon_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *BoardRequest) GetTargetVtxoCount() uint32 {
@@ -3327,7 +3641,7 @@ type BoardResponse struct {
 
 func (x *BoardResponse) Reset() {
 	*x = BoardResponse{}
-	mi := &file_daemon_proto_msgTypes[43]
+	mi := &file_daemon_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3339,7 +3653,7 @@ func (x *BoardResponse) String() string {
 func (*BoardResponse) ProtoMessage() {}
 
 func (x *BoardResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[43]
+	mi := &file_daemon_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3352,7 +3666,7 @@ func (x *BoardResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoardResponse.ProtoReflect.Descriptor instead.
 func (*BoardResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{43}
+	return file_daemon_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *BoardResponse) GetStatus() string {
@@ -3395,7 +3709,7 @@ type SweepBoardingUTXOsRequest struct {
 
 func (x *SweepBoardingUTXOsRequest) Reset() {
 	*x = SweepBoardingUTXOsRequest{}
-	mi := &file_daemon_proto_msgTypes[44]
+	mi := &file_daemon_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3407,7 +3721,7 @@ func (x *SweepBoardingUTXOsRequest) String() string {
 func (*SweepBoardingUTXOsRequest) ProtoMessage() {}
 
 func (x *SweepBoardingUTXOsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[44]
+	mi := &file_daemon_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3420,7 +3734,7 @@ func (x *SweepBoardingUTXOsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SweepBoardingUTXOsRequest.ProtoReflect.Descriptor instead.
 func (*SweepBoardingUTXOsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{44}
+	return file_daemon_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *SweepBoardingUTXOsRequest) GetOutpoints() []string {
@@ -3473,7 +3787,7 @@ type BoardingSweepOutput struct {
 
 func (x *BoardingSweepOutput) Reset() {
 	*x = BoardingSweepOutput{}
-	mi := &file_daemon_proto_msgTypes[45]
+	mi := &file_daemon_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3485,7 +3799,7 @@ func (x *BoardingSweepOutput) String() string {
 func (*BoardingSweepOutput) ProtoMessage() {}
 
 func (x *BoardingSweepOutput) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[45]
+	mi := &file_daemon_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3498,7 +3812,7 @@ func (x *BoardingSweepOutput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoardingSweepOutput.ProtoReflect.Descriptor instead.
 func (*BoardingSweepOutput) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{45}
+	return file_daemon_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *BoardingSweepOutput) GetOutpoint() string {
@@ -3564,7 +3878,7 @@ type SweepBoardingUTXOsResponse struct {
 
 func (x *SweepBoardingUTXOsResponse) Reset() {
 	*x = SweepBoardingUTXOsResponse{}
-	mi := &file_daemon_proto_msgTypes[46]
+	mi := &file_daemon_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3576,7 +3890,7 @@ func (x *SweepBoardingUTXOsResponse) String() string {
 func (*SweepBoardingUTXOsResponse) ProtoMessage() {}
 
 func (x *SweepBoardingUTXOsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[46]
+	mi := &file_daemon_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3589,7 +3903,7 @@ func (x *SweepBoardingUTXOsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SweepBoardingUTXOsResponse.ProtoReflect.Descriptor instead.
 func (*SweepBoardingUTXOsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{46}
+	return file_daemon_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *SweepBoardingUTXOsResponse) GetStatus() string {
@@ -3693,7 +4007,7 @@ type ListBoardingSweepsRequest struct {
 
 func (x *ListBoardingSweepsRequest) Reset() {
 	*x = ListBoardingSweepsRequest{}
-	mi := &file_daemon_proto_msgTypes[47]
+	mi := &file_daemon_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3705,7 +4019,7 @@ func (x *ListBoardingSweepsRequest) String() string {
 func (*ListBoardingSweepsRequest) ProtoMessage() {}
 
 func (x *ListBoardingSweepsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[47]
+	mi := &file_daemon_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3718,7 +4032,7 @@ func (x *ListBoardingSweepsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBoardingSweepsRequest.ProtoReflect.Descriptor instead.
 func (*ListBoardingSweepsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{47}
+	return file_daemon_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *ListBoardingSweepsRequest) GetStatus() string {
@@ -3761,7 +4075,7 @@ type BoardingSweepInput struct {
 
 func (x *BoardingSweepInput) Reset() {
 	*x = BoardingSweepInput{}
-	mi := &file_daemon_proto_msgTypes[48]
+	mi := &file_daemon_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3773,7 +4087,7 @@ func (x *BoardingSweepInput) String() string {
 func (*BoardingSweepInput) ProtoMessage() {}
 
 func (x *BoardingSweepInput) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[48]
+	mi := &file_daemon_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3786,7 +4100,7 @@ func (x *BoardingSweepInput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoardingSweepInput.ProtoReflect.Descriptor instead.
 func (*BoardingSweepInput) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{48}
+	return file_daemon_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *BoardingSweepInput) GetOutpoint() string {
@@ -3856,7 +4170,7 @@ type BoardingSweep struct {
 
 func (x *BoardingSweep) Reset() {
 	*x = BoardingSweep{}
-	mi := &file_daemon_proto_msgTypes[49]
+	mi := &file_daemon_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3868,7 +4182,7 @@ func (x *BoardingSweep) String() string {
 func (*BoardingSweep) ProtoMessage() {}
 
 func (x *BoardingSweep) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[49]
+	mi := &file_daemon_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3881,7 +4195,7 @@ func (x *BoardingSweep) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoardingSweep.ProtoReflect.Descriptor instead.
 func (*BoardingSweep) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{49}
+	return file_daemon_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *BoardingSweep) GetTxid() string {
@@ -3973,7 +4287,7 @@ type ListBoardingSweepsResponse struct {
 
 func (x *ListBoardingSweepsResponse) Reset() {
 	*x = ListBoardingSweepsResponse{}
-	mi := &file_daemon_proto_msgTypes[50]
+	mi := &file_daemon_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3985,7 +4299,7 @@ func (x *ListBoardingSweepsResponse) String() string {
 func (*ListBoardingSweepsResponse) ProtoMessage() {}
 
 func (x *ListBoardingSweepsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[50]
+	mi := &file_daemon_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3998,7 +4312,7 @@ func (x *ListBoardingSweepsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBoardingSweepsResponse.ProtoReflect.Descriptor instead.
 func (*ListBoardingSweepsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{50}
+	return file_daemon_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *ListBoardingSweepsResponse) GetSweeps() []*BoardingSweep {
@@ -4028,7 +4342,7 @@ type RoundVTXOInfo struct {
 
 func (x *RoundVTXOInfo) Reset() {
 	*x = RoundVTXOInfo{}
-	mi := &file_daemon_proto_msgTypes[51]
+	mi := &file_daemon_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4040,7 +4354,7 @@ func (x *RoundVTXOInfo) String() string {
 func (*RoundVTXOInfo) ProtoMessage() {}
 
 func (x *RoundVTXOInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[51]
+	mi := &file_daemon_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4053,7 +4367,7 @@ func (x *RoundVTXOInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoundVTXOInfo.ProtoReflect.Descriptor instead.
 func (*RoundVTXOInfo) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{51}
+	return file_daemon_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *RoundVTXOInfo) GetOutpoint() string {
@@ -4113,7 +4427,7 @@ type RoundInfo struct {
 
 func (x *RoundInfo) Reset() {
 	*x = RoundInfo{}
-	mi := &file_daemon_proto_msgTypes[52]
+	mi := &file_daemon_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4125,7 +4439,7 @@ func (x *RoundInfo) String() string {
 func (*RoundInfo) ProtoMessage() {}
 
 func (x *RoundInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[52]
+	mi := &file_daemon_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4138,7 +4452,7 @@ func (x *RoundInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoundInfo.ProtoReflect.Descriptor instead.
 func (*RoundInfo) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{52}
+	return file_daemon_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *RoundInfo) GetRoundId() string {
@@ -4250,7 +4564,7 @@ type ListRoundsRequest struct {
 
 func (x *ListRoundsRequest) Reset() {
 	*x = ListRoundsRequest{}
-	mi := &file_daemon_proto_msgTypes[53]
+	mi := &file_daemon_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4262,7 +4576,7 @@ func (x *ListRoundsRequest) String() string {
 func (*ListRoundsRequest) ProtoMessage() {}
 
 func (x *ListRoundsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[53]
+	mi := &file_daemon_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4275,7 +4589,7 @@ func (x *ListRoundsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRoundsRequest.ProtoReflect.Descriptor instead.
 func (*ListRoundsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{53}
+	return file_daemon_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *ListRoundsRequest) GetPageSize() int32 {
@@ -4330,7 +4644,7 @@ type GetRoundRequest struct {
 
 func (x *GetRoundRequest) Reset() {
 	*x = GetRoundRequest{}
-	mi := &file_daemon_proto_msgTypes[54]
+	mi := &file_daemon_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4342,7 +4656,7 @@ func (x *GetRoundRequest) String() string {
 func (*GetRoundRequest) ProtoMessage() {}
 
 func (x *GetRoundRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[54]
+	mi := &file_daemon_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4355,7 +4669,7 @@ func (x *GetRoundRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRoundRequest.ProtoReflect.Descriptor instead.
 func (*GetRoundRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{54}
+	return file_daemon_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *GetRoundRequest) GetRoundId() string {
@@ -4375,7 +4689,7 @@ type GetRoundResponse struct {
 
 func (x *GetRoundResponse) Reset() {
 	*x = GetRoundResponse{}
-	mi := &file_daemon_proto_msgTypes[55]
+	mi := &file_daemon_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4387,7 +4701,7 @@ func (x *GetRoundResponse) String() string {
 func (*GetRoundResponse) ProtoMessage() {}
 
 func (x *GetRoundResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[55]
+	mi := &file_daemon_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4400,7 +4714,7 @@ func (x *GetRoundResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRoundResponse.ProtoReflect.Descriptor instead.
 func (*GetRoundResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{55}
+	return file_daemon_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *GetRoundResponse) GetRound() *RoundInfo {
@@ -4423,7 +4737,7 @@ type ListRoundsResponse struct {
 
 func (x *ListRoundsResponse) Reset() {
 	*x = ListRoundsResponse{}
-	mi := &file_daemon_proto_msgTypes[56]
+	mi := &file_daemon_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4435,7 +4749,7 @@ func (x *ListRoundsResponse) String() string {
 func (*ListRoundsResponse) ProtoMessage() {}
 
 func (x *ListRoundsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[56]
+	mi := &file_daemon_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4448,7 +4762,7 @@ func (x *ListRoundsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRoundsResponse.ProtoReflect.Descriptor instead.
 func (*ListRoundsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{56}
+	return file_daemon_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *ListRoundsResponse) GetRounds() []*RoundInfo {
@@ -4473,7 +4787,7 @@ type WatchRoundsRequest struct {
 
 func (x *WatchRoundsRequest) Reset() {
 	*x = WatchRoundsRequest{}
-	mi := &file_daemon_proto_msgTypes[57]
+	mi := &file_daemon_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4485,7 +4799,7 @@ func (x *WatchRoundsRequest) String() string {
 func (*WatchRoundsRequest) ProtoMessage() {}
 
 func (x *WatchRoundsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[57]
+	mi := &file_daemon_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4498,7 +4812,7 @@ func (x *WatchRoundsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchRoundsRequest.ProtoReflect.Descriptor instead.
 func (*WatchRoundsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{57}
+	return file_daemon_proto_rawDescGZIP(), []int{60}
 }
 
 type WatchRoundsResponse struct {
@@ -4512,7 +4826,7 @@ type WatchRoundsResponse struct {
 
 func (x *WatchRoundsResponse) Reset() {
 	*x = WatchRoundsResponse{}
-	mi := &file_daemon_proto_msgTypes[58]
+	mi := &file_daemon_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4524,7 +4838,7 @@ func (x *WatchRoundsResponse) String() string {
 func (*WatchRoundsResponse) ProtoMessage() {}
 
 func (x *WatchRoundsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[58]
+	mi := &file_daemon_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4537,7 +4851,7 @@ func (x *WatchRoundsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchRoundsResponse.ProtoReflect.Descriptor instead.
 func (*WatchRoundsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{58}
+	return file_daemon_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *WatchRoundsResponse) GetRound() *RoundInfo {
@@ -4575,7 +4889,7 @@ type OORSessionInfo struct {
 
 func (x *OORSessionInfo) Reset() {
 	*x = OORSessionInfo{}
-	mi := &file_daemon_proto_msgTypes[59]
+	mi := &file_daemon_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4587,7 +4901,7 @@ func (x *OORSessionInfo) String() string {
 func (*OORSessionInfo) ProtoMessage() {}
 
 func (x *OORSessionInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[59]
+	mi := &file_daemon_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4600,7 +4914,7 @@ func (x *OORSessionInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OORSessionInfo.ProtoReflect.Descriptor instead.
 func (*OORSessionInfo) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{59}
+	return file_daemon_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *OORSessionInfo) GetSessionId() string {
@@ -4684,7 +4998,7 @@ type ListOORSessionsRequest struct {
 
 func (x *ListOORSessionsRequest) Reset() {
 	*x = ListOORSessionsRequest{}
-	mi := &file_daemon_proto_msgTypes[60]
+	mi := &file_daemon_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4696,7 +5010,7 @@ func (x *ListOORSessionsRequest) String() string {
 func (*ListOORSessionsRequest) ProtoMessage() {}
 
 func (x *ListOORSessionsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[60]
+	mi := &file_daemon_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4709,7 +5023,7 @@ func (x *ListOORSessionsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListOORSessionsRequest.ProtoReflect.Descriptor instead.
 func (*ListOORSessionsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{60}
+	return file_daemon_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *ListOORSessionsRequest) GetPageSize() int32 {
@@ -4753,7 +5067,7 @@ type ListOORSessionsResponse struct {
 
 func (x *ListOORSessionsResponse) Reset() {
 	*x = ListOORSessionsResponse{}
-	mi := &file_daemon_proto_msgTypes[61]
+	mi := &file_daemon_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4765,7 +5079,7 @@ func (x *ListOORSessionsResponse) String() string {
 func (*ListOORSessionsResponse) ProtoMessage() {}
 
 func (x *ListOORSessionsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[61]
+	mi := &file_daemon_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4778,7 +5092,7 @@ func (x *ListOORSessionsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListOORSessionsResponse.ProtoReflect.Descriptor instead.
 func (*ListOORSessionsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{61}
+	return file_daemon_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *ListOORSessionsResponse) GetSessions() []*OORSessionInfo {
@@ -4805,7 +5119,7 @@ type GetOORSessionRequest struct {
 
 func (x *GetOORSessionRequest) Reset() {
 	*x = GetOORSessionRequest{}
-	mi := &file_daemon_proto_msgTypes[62]
+	mi := &file_daemon_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4817,7 +5131,7 @@ func (x *GetOORSessionRequest) String() string {
 func (*GetOORSessionRequest) ProtoMessage() {}
 
 func (x *GetOORSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[62]
+	mi := &file_daemon_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4830,7 +5144,7 @@ func (x *GetOORSessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetOORSessionRequest.ProtoReflect.Descriptor instead.
 func (*GetOORSessionRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{62}
+	return file_daemon_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *GetOORSessionRequest) GetSessionId() string {
@@ -4850,7 +5164,7 @@ type GetOORSessionResponse struct {
 
 func (x *GetOORSessionResponse) Reset() {
 	*x = GetOORSessionResponse{}
-	mi := &file_daemon_proto_msgTypes[63]
+	mi := &file_daemon_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4862,7 +5176,7 @@ func (x *GetOORSessionResponse) String() string {
 func (*GetOORSessionResponse) ProtoMessage() {}
 
 func (x *GetOORSessionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[63]
+	mi := &file_daemon_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4875,7 +5189,7 @@ func (x *GetOORSessionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetOORSessionResponse.ProtoReflect.Descriptor instead.
 func (*GetOORSessionResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{63}
+	return file_daemon_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *GetOORSessionResponse) GetSession() *OORSessionInfo {
@@ -4903,7 +5217,7 @@ type EstimateFeeRequest struct {
 
 func (x *EstimateFeeRequest) Reset() {
 	*x = EstimateFeeRequest{}
-	mi := &file_daemon_proto_msgTypes[64]
+	mi := &file_daemon_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4915,7 +5229,7 @@ func (x *EstimateFeeRequest) String() string {
 func (*EstimateFeeRequest) ProtoMessage() {}
 
 func (x *EstimateFeeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[64]
+	mi := &file_daemon_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4928,7 +5242,7 @@ func (x *EstimateFeeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EstimateFeeRequest.ProtoReflect.Descriptor instead.
 func (*EstimateFeeRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{64}
+	return file_daemon_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *EstimateFeeRequest) GetAmountSat() int64 {
@@ -4982,7 +5296,7 @@ type EstimateFeeResponse struct {
 
 func (x *EstimateFeeResponse) Reset() {
 	*x = EstimateFeeResponse{}
-	mi := &file_daemon_proto_msgTypes[65]
+	mi := &file_daemon_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4994,7 +5308,7 @@ func (x *EstimateFeeResponse) String() string {
 func (*EstimateFeeResponse) ProtoMessage() {}
 
 func (x *EstimateFeeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[65]
+	mi := &file_daemon_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5007,7 +5321,7 @@ func (x *EstimateFeeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EstimateFeeResponse.ProtoReflect.Descriptor instead.
 func (*EstimateFeeResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{65}
+	return file_daemon_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *EstimateFeeResponse) GetLiquidityFeeSat() int64 {
@@ -5077,7 +5391,7 @@ type GetFeeHistoryRequest struct {
 
 func (x *GetFeeHistoryRequest) Reset() {
 	*x = GetFeeHistoryRequest{}
-	mi := &file_daemon_proto_msgTypes[66]
+	mi := &file_daemon_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5089,7 +5403,7 @@ func (x *GetFeeHistoryRequest) String() string {
 func (*GetFeeHistoryRequest) ProtoMessage() {}
 
 func (x *GetFeeHistoryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[66]
+	mi := &file_daemon_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5102,7 +5416,7 @@ func (x *GetFeeHistoryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetFeeHistoryRequest.ProtoReflect.Descriptor instead.
 func (*GetFeeHistoryRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{66}
+	return file_daemon_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *GetFeeHistoryRequest) GetLimit() uint32 {
@@ -5177,7 +5491,7 @@ type FeeHistoryEntry struct {
 
 func (x *FeeHistoryEntry) Reset() {
 	*x = FeeHistoryEntry{}
-	mi := &file_daemon_proto_msgTypes[67]
+	mi := &file_daemon_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5189,7 +5503,7 @@ func (x *FeeHistoryEntry) String() string {
 func (*FeeHistoryEntry) ProtoMessage() {}
 
 func (x *FeeHistoryEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[67]
+	mi := &file_daemon_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5202,7 +5516,7 @@ func (x *FeeHistoryEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FeeHistoryEntry.ProtoReflect.Descriptor instead.
 func (*FeeHistoryEntry) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{67}
+	return file_daemon_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *FeeHistoryEntry) GetEntryId() int64 {
@@ -5282,7 +5596,7 @@ type GetFeeHistoryResponse struct {
 
 func (x *GetFeeHistoryResponse) Reset() {
 	*x = GetFeeHistoryResponse{}
-	mi := &file_daemon_proto_msgTypes[68]
+	mi := &file_daemon_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5294,7 +5608,7 @@ func (x *GetFeeHistoryResponse) String() string {
 func (*GetFeeHistoryResponse) ProtoMessage() {}
 
 func (x *GetFeeHistoryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[68]
+	mi := &file_daemon_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5307,7 +5621,7 @@ func (x *GetFeeHistoryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetFeeHistoryResponse.ProtoReflect.Descriptor instead.
 func (*GetFeeHistoryResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{68}
+	return file_daemon_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *GetFeeHistoryResponse) GetEntries() []*FeeHistoryEntry {
@@ -5348,7 +5662,7 @@ type ListTransactionsRequest struct {
 
 func (x *ListTransactionsRequest) Reset() {
 	*x = ListTransactionsRequest{}
-	mi := &file_daemon_proto_msgTypes[69]
+	mi := &file_daemon_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5360,7 +5674,7 @@ func (x *ListTransactionsRequest) String() string {
 func (*ListTransactionsRequest) ProtoMessage() {}
 
 func (x *ListTransactionsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[69]
+	mi := &file_daemon_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5373,7 +5687,7 @@ func (x *ListTransactionsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTransactionsRequest.ProtoReflect.Descriptor instead.
 func (*ListTransactionsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{69}
+	return file_daemon_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *ListTransactionsRequest) GetFromUnixS() int64 {
@@ -5456,7 +5770,7 @@ type TransactionHistoryEntry struct {
 
 func (x *TransactionHistoryEntry) Reset() {
 	*x = TransactionHistoryEntry{}
-	mi := &file_daemon_proto_msgTypes[70]
+	mi := &file_daemon_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5468,7 +5782,7 @@ func (x *TransactionHistoryEntry) String() string {
 func (*TransactionHistoryEntry) ProtoMessage() {}
 
 func (x *TransactionHistoryEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[70]
+	mi := &file_daemon_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5481,7 +5795,7 @@ func (x *TransactionHistoryEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TransactionHistoryEntry.ProtoReflect.Descriptor instead.
 func (*TransactionHistoryEntry) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{70}
+	return file_daemon_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *TransactionHistoryEntry) GetSource() string {
@@ -5604,7 +5918,7 @@ type ListTransactionsResponse struct {
 
 func (x *ListTransactionsResponse) Reset() {
 	*x = ListTransactionsResponse{}
-	mi := &file_daemon_proto_msgTypes[71]
+	mi := &file_daemon_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5616,7 +5930,7 @@ func (x *ListTransactionsResponse) String() string {
 func (*ListTransactionsResponse) ProtoMessage() {}
 
 func (x *ListTransactionsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[71]
+	mi := &file_daemon_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5629,7 +5943,7 @@ func (x *ListTransactionsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTransactionsResponse.ProtoReflect.Descriptor instead.
 func (*ListTransactionsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{71}
+	return file_daemon_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *ListTransactionsResponse) GetTransactions() []*TransactionHistoryEntry {
@@ -5653,6 +5967,338 @@ func (x *ListTransactionsResponse) GetHasMore() bool {
 	return false
 }
 
+type TransferInfo struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// transfer_id is a stable local identifier for this transfer status row.
+	TransferId string `protobuf:"bytes,1,opt,name=transfer_id,json=transferId,proto3" json:"transfer_id,omitempty"`
+	// mode identifies whether this transfer used a round or OOR session.
+	Mode TransferMode `protobuf:"varint,2,opt,name=mode,proto3,enum=daemonrpc.TransferMode" json:"mode,omitempty"`
+	// direction is from the local wallet's perspective when the daemon has
+	// enough local input/output ownership data to infer it. Live in-memory
+	// in-round entries may report TRANSFER_DIRECTION_UNSPECIFIED until they
+	// are persisted with outpoint context.
+	Direction TransferDirection `protobuf:"varint,3,opt,name=direction,proto3,enum=daemonrpc.TransferDirection" json:"direction,omitempty"`
+	// status is the coarse lifecycle state.
+	Status TransferStatus `protobuf:"varint,4,opt,name=status,proto3,enum=daemonrpc.TransferStatus" json:"status,omitempty"`
+	// phase carries the detailed round state, OOR phase, or history subtype.
+	Phase string `protobuf:"bytes,5,opt,name=phase,proto3" json:"phase,omitempty"`
+	// amount_sat is the known transfer amount in satoshis. Live in-memory
+	// in-round entries and OOR session rows may leave this zero until a
+	// history source supplies a persisted amount.
+	AmountSat int64 `protobuf:"varint,6,opt,name=amount_sat,json=amountSat,proto3" json:"amount_sat,omitempty"`
+	// round_id is set for in-round transfers when known.
+	RoundId string `protobuf:"bytes,7,opt,name=round_id,json=roundId,proto3" json:"round_id,omitempty"`
+	// session_id is set for OOR transfers when known.
+	SessionId string `protobuf:"bytes,8,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	// input_outpoints are locally known consumed VTXOs.
+	InputOutpoints []string `protobuf:"bytes,9,rep,name=input_outpoints,json=inputOutpoints,proto3" json:"input_outpoints,omitempty"`
+	// output_outpoints are locally known created VTXOs.
+	OutputOutpoints []string `protobuf:"bytes,10,rep,name=output_outpoints,json=outputOutpoints,proto3" json:"output_outpoints,omitempty"`
+	// txid is the commitment or package transaction id when known.
+	Txid string `protobuf:"bytes,11,opt,name=txid,proto3" json:"txid,omitempty"`
+	// confirmation_height is set when the transfer has a known chain
+	// confirmation height.
+	ConfirmationHeight int32 `protobuf:"varint,12,opt,name=confirmation_height,json=confirmationHeight,proto3" json:"confirmation_height,omitempty"`
+	// created_at_unix_s is the local creation time when known.
+	CreatedAtUnixS int64 `protobuf:"varint,13,opt,name=created_at_unix_s,json=createdAtUnixS,proto3" json:"created_at_unix_s,omitempty"`
+	// updated_at_unix_s is the local update time when known.
+	UpdatedAtUnixS int64 `protobuf:"varint,14,opt,name=updated_at_unix_s,json=updatedAtUnixS,proto3" json:"updated_at_unix_s,omitempty"`
+	// failure_reason is populated for failed live operations when known.
+	FailureReason string `protobuf:"bytes,15,opt,name=failure_reason,json=failureReason,proto3" json:"failure_reason,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TransferInfo) Reset() {
+	*x = TransferInfo{}
+	mi := &file_daemon_proto_msgTypes[75]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TransferInfo) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TransferInfo) ProtoMessage() {}
+
+func (x *TransferInfo) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[75]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TransferInfo.ProtoReflect.Descriptor instead.
+func (*TransferInfo) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{75}
+}
+
+func (x *TransferInfo) GetTransferId() string {
+	if x != nil {
+		return x.TransferId
+	}
+	return ""
+}
+
+func (x *TransferInfo) GetMode() TransferMode {
+	if x != nil {
+		return x.Mode
+	}
+	return TransferMode_TRANSFER_MODE_UNSPECIFIED
+}
+
+func (x *TransferInfo) GetDirection() TransferDirection {
+	if x != nil {
+		return x.Direction
+	}
+	return TransferDirection_TRANSFER_DIRECTION_UNSPECIFIED
+}
+
+func (x *TransferInfo) GetStatus() TransferStatus {
+	if x != nil {
+		return x.Status
+	}
+	return TransferStatus_TRANSFER_STATUS_UNSPECIFIED
+}
+
+func (x *TransferInfo) GetPhase() string {
+	if x != nil {
+		return x.Phase
+	}
+	return ""
+}
+
+func (x *TransferInfo) GetAmountSat() int64 {
+	if x != nil {
+		return x.AmountSat
+	}
+	return 0
+}
+
+func (x *TransferInfo) GetRoundId() string {
+	if x != nil {
+		return x.RoundId
+	}
+	return ""
+}
+
+func (x *TransferInfo) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+func (x *TransferInfo) GetInputOutpoints() []string {
+	if x != nil {
+		return x.InputOutpoints
+	}
+	return nil
+}
+
+func (x *TransferInfo) GetOutputOutpoints() []string {
+	if x != nil {
+		return x.OutputOutpoints
+	}
+	return nil
+}
+
+func (x *TransferInfo) GetTxid() string {
+	if x != nil {
+		return x.Txid
+	}
+	return ""
+}
+
+func (x *TransferInfo) GetConfirmationHeight() int32 {
+	if x != nil {
+		return x.ConfirmationHeight
+	}
+	return 0
+}
+
+func (x *TransferInfo) GetCreatedAtUnixS() int64 {
+	if x != nil {
+		return x.CreatedAtUnixS
+	}
+	return 0
+}
+
+func (x *TransferInfo) GetUpdatedAtUnixS() int64 {
+	if x != nil {
+		return x.UpdatedAtUnixS
+	}
+	return 0
+}
+
+func (x *TransferInfo) GetFailureReason() string {
+	if x != nil {
+		return x.FailureReason
+	}
+	return ""
+}
+
+type ListTransfersRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// mode_filter restricts results to one transfer mode when set.
+	ModeFilter TransferMode `protobuf:"varint,1,opt,name=mode_filter,json=modeFilter,proto3,enum=daemonrpc.TransferMode" json:"mode_filter,omitempty"`
+	// direction_filter restricts results to one local direction when set.
+	// Rows whose direction is TRANSFER_DIRECTION_UNSPECIFIED are always
+	// included regardless of this filter, because live in-round rows can be
+	// useful before the daemon has enough local input/output ownership data to
+	// classify direction.
+	DirectionFilter TransferDirection `protobuf:"varint,2,opt,name=direction_filter,json=directionFilter,proto3,enum=daemonrpc.TransferDirection" json:"direction_filter,omitempty"`
+	// status_filter restricts results to one coarse transfer status when set.
+	StatusFilter TransferStatus `protobuf:"varint,3,opt,name=status_filter,json=statusFilter,proto3,enum=daemonrpc.TransferStatus" json:"status_filter,omitempty"`
+	// limit bounds the number of status rows returned. Zero uses the daemon
+	// default. Values above the daemon maximum are silently capped to that
+	// maximum.
+	Limit uint32 `protobuf:"varint,4,opt,name=limit,proto3" json:"limit,omitempty"`
+	// offset skips this many rows after filtering and newest-first sorting.
+	Offset        uint32 `protobuf:"varint,5,opt,name=offset,proto3" json:"offset,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListTransfersRequest) Reset() {
+	*x = ListTransfersRequest{}
+	mi := &file_daemon_proto_msgTypes[76]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListTransfersRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListTransfersRequest) ProtoMessage() {}
+
+func (x *ListTransfersRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[76]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListTransfersRequest.ProtoReflect.Descriptor instead.
+func (*ListTransfersRequest) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{76}
+}
+
+func (x *ListTransfersRequest) GetModeFilter() TransferMode {
+	if x != nil {
+		return x.ModeFilter
+	}
+	return TransferMode_TRANSFER_MODE_UNSPECIFIED
+}
+
+func (x *ListTransfersRequest) GetDirectionFilter() TransferDirection {
+	if x != nil {
+		return x.DirectionFilter
+	}
+	return TransferDirection_TRANSFER_DIRECTION_UNSPECIFIED
+}
+
+func (x *ListTransfersRequest) GetStatusFilter() TransferStatus {
+	if x != nil {
+		return x.StatusFilter
+	}
+	return TransferStatus_TRANSFER_STATUS_UNSPECIFIED
+}
+
+func (x *ListTransfersRequest) GetLimit() uint32 {
+	if x != nil {
+		return x.Limit
+	}
+	return 0
+}
+
+func (x *ListTransfersRequest) GetOffset() uint32 {
+	if x != nil {
+		return x.Offset
+	}
+	return 0
+}
+
+type ListTransfersResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// transfers are returned newest first by their best known update time.
+	// Unknown-direction rows may be present even when the request sets a
+	// direction filter; see ListTransfersRequest.direction_filter. Callers
+	// should not rely on this pass-through as exclusive-filter semantics; it
+	// may narrow once live rows always carry direction hints.
+	Transfers []*TransferInfo `protobuf:"bytes,1,rep,name=transfers,proto3" json:"transfers,omitempty"`
+	// next_offset is the offset to pass to the next request when has_more is
+	// true.
+	NextOffset uint32 `protobuf:"varint,2,opt,name=next_offset,json=nextOffset,proto3" json:"next_offset,omitempty"`
+	// has_more is true when another page is available.
+	HasMore       bool `protobuf:"varint,3,opt,name=has_more,json=hasMore,proto3" json:"has_more,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListTransfersResponse) Reset() {
+	*x = ListTransfersResponse{}
+	mi := &file_daemon_proto_msgTypes[77]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListTransfersResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListTransfersResponse) ProtoMessage() {}
+
+func (x *ListTransfersResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[77]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListTransfersResponse.ProtoReflect.Descriptor instead.
+func (*ListTransfersResponse) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{77}
+}
+
+func (x *ListTransfersResponse) GetTransfers() []*TransferInfo {
+	if x != nil {
+		return x.Transfers
+	}
+	return nil
+}
+
+func (x *ListTransfersResponse) GetNextOffset() uint32 {
+	if x != nil {
+		return x.NextOffset
+	}
+	return 0
+}
+
+func (x *ListTransfersResponse) GetHasMore() bool {
+	if x != nil {
+		return x.HasMore
+	}
+	return false
+}
+
 type UnrollRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// outpoint is the VTXO outpoint to unilaterally exit, formatted as
@@ -5664,7 +6310,7 @@ type UnrollRequest struct {
 
 func (x *UnrollRequest) Reset() {
 	*x = UnrollRequest{}
-	mi := &file_daemon_proto_msgTypes[72]
+	mi := &file_daemon_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5676,7 +6322,7 @@ func (x *UnrollRequest) String() string {
 func (*UnrollRequest) ProtoMessage() {}
 
 func (x *UnrollRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[72]
+	mi := &file_daemon_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5689,7 +6335,7 @@ func (x *UnrollRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnrollRequest.ProtoReflect.Descriptor instead.
 func (*UnrollRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{72}
+	return file_daemon_proto_rawDescGZIP(), []int{78}
 }
 
 func (x *UnrollRequest) GetOutpoint() string {
@@ -5712,7 +6358,7 @@ type UnrollResponse struct {
 
 func (x *UnrollResponse) Reset() {
 	*x = UnrollResponse{}
-	mi := &file_daemon_proto_msgTypes[73]
+	mi := &file_daemon_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5724,7 +6370,7 @@ func (x *UnrollResponse) String() string {
 func (*UnrollResponse) ProtoMessage() {}
 
 func (x *UnrollResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[73]
+	mi := &file_daemon_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5737,7 +6383,7 @@ func (x *UnrollResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnrollResponse.ProtoReflect.Descriptor instead.
 func (*UnrollResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{73}
+	return file_daemon_proto_rawDescGZIP(), []int{79}
 }
 
 func (x *UnrollResponse) GetCreated() bool {
@@ -5764,7 +6410,7 @@ type GetUnrollStatusRequest struct {
 
 func (x *GetUnrollStatusRequest) Reset() {
 	*x = GetUnrollStatusRequest{}
-	mi := &file_daemon_proto_msgTypes[74]
+	mi := &file_daemon_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5776,7 +6422,7 @@ func (x *GetUnrollStatusRequest) String() string {
 func (*GetUnrollStatusRequest) ProtoMessage() {}
 
 func (x *GetUnrollStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[74]
+	mi := &file_daemon_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5789,7 +6435,7 @@ func (x *GetUnrollStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUnrollStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetUnrollStatusRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{74}
+	return file_daemon_proto_rawDescGZIP(), []int{80}
 }
 
 func (x *GetUnrollStatusRequest) GetOutpoint() string {
@@ -5817,7 +6463,7 @@ type GetUnrollStatusResponse struct {
 
 func (x *GetUnrollStatusResponse) Reset() {
 	*x = GetUnrollStatusResponse{}
-	mi := &file_daemon_proto_msgTypes[75]
+	mi := &file_daemon_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5829,7 +6475,7 @@ func (x *GetUnrollStatusResponse) String() string {
 func (*GetUnrollStatusResponse) ProtoMessage() {}
 
 func (x *GetUnrollStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[75]
+	mi := &file_daemon_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5842,7 +6488,7 @@ func (x *GetUnrollStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUnrollStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetUnrollStatusResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{75}
+	return file_daemon_proto_rawDescGZIP(), []int{81}
 }
 
 func (x *GetUnrollStatusResponse) GetFound() bool {
@@ -5960,14 +6606,23 @@ const file_daemon_proto_rawDesc = "" +
 	"\x12NewAddressResponse\x12\x18\n" +
 	"\aaddress\x18\x01 \x01(\tR\aaddress\"/\n" +
 	"\x17NewReceiveScriptRequest\x12\x14\n" +
-	"\x05label\x18\x01 \x01(\tR\x05label\"\xba\x01\n" +
+	"\x05label\x18\x01 \x01(\tR\x05label\"\xd4\x01\n" +
 	"\x18NewReceiveScriptResponse\x12\"\n" +
 	"\rpk_script_hex\x18\x01 \x01(\tR\vpkScriptHex\x12(\n" +
 	"\x10pubkey_xonly_hex\x18\x02 \x01(\tR\x0epubkeyXonlyHex\x12\x1d\n" +
 	"\n" +
 	"key_family\x18\x03 \x01(\rR\tkeyFamily\x12\x1b\n" +
 	"\tkey_index\x18\x04 \x01(\rR\bkeyIndex\x12\x14\n" +
-	"\x05label\x18\x05 \x01(\tR\x05label\":\n" +
+	"\x05label\x18\x05 \x01(\tR\x05label\x12\x18\n" +
+	"\aaddress\x18\x06 \x01(\tR\aaddress\"\x8e\x01\n" +
+	"\rReceiveTarget\x12\x18\n" +
+	"\aaddress\x18\x01 \x01(\tR\aaddress\x12\"\n" +
+	"\rpk_script_hex\x18\x02 \x01(\tR\vpkScriptHex\x12\x14\n" +
+	"\x05label\x18\x03 \x01(\tR\x05label\x12)\n" +
+	"\x11expires_at_unix_s\x18\x04 \x01(\x04R\x0eexpiresAtUnixS\"\x1b\n" +
+	"\x19ListReceiveScriptsRequest\"P\n" +
+	"\x1aListReceiveScriptsResponse\x122\n" +
+	"\atargets\x18\x01 \x03(\v2\x18.daemonrpc.ReceiveTargetR\atargets\":\n" +
 	"\x15ReceiveAuthKeyRequest\x12!\n" +
 	"\fpayment_hash\x18\x01 \x01(\fR\vpaymentHash\"0\n" +
 	"\x16ReceiveAuthKeyResponse\x12\x16\n" +
@@ -6255,6 +6910,38 @@ const file_daemon_proto_rawDesc = "" +
 	"\ftransactions\x18\x01 \x03(\v2\".daemonrpc.TransactionHistoryEntryR\ftransactions\x12\x1f\n" +
 	"\vnext_offset\x18\x02 \x01(\rR\n" +
 	"nextOffset\x12\x19\n" +
+	"\bhas_more\x18\x03 \x01(\bR\ahasMore\"\xd0\x04\n" +
+	"\fTransferInfo\x12\x1f\n" +
+	"\vtransfer_id\x18\x01 \x01(\tR\n" +
+	"transferId\x12+\n" +
+	"\x04mode\x18\x02 \x01(\x0e2\x17.daemonrpc.TransferModeR\x04mode\x12:\n" +
+	"\tdirection\x18\x03 \x01(\x0e2\x1c.daemonrpc.TransferDirectionR\tdirection\x121\n" +
+	"\x06status\x18\x04 \x01(\x0e2\x19.daemonrpc.TransferStatusR\x06status\x12\x14\n" +
+	"\x05phase\x18\x05 \x01(\tR\x05phase\x12\x1d\n" +
+	"\n" +
+	"amount_sat\x18\x06 \x01(\x03R\tamountSat\x12\x19\n" +
+	"\bround_id\x18\a \x01(\tR\aroundId\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\b \x01(\tR\tsessionId\x12'\n" +
+	"\x0finput_outpoints\x18\t \x03(\tR\x0einputOutpoints\x12)\n" +
+	"\x10output_outpoints\x18\n" +
+	" \x03(\tR\x0foutputOutpoints\x12\x12\n" +
+	"\x04txid\x18\v \x01(\tR\x04txid\x12/\n" +
+	"\x13confirmation_height\x18\f \x01(\x05R\x12confirmationHeight\x12)\n" +
+	"\x11created_at_unix_s\x18\r \x01(\x03R\x0ecreatedAtUnixS\x12)\n" +
+	"\x11updated_at_unix_s\x18\x0e \x01(\x03R\x0eupdatedAtUnixS\x12%\n" +
+	"\x0efailure_reason\x18\x0f \x01(\tR\rfailureReason\"\x87\x02\n" +
+	"\x14ListTransfersRequest\x128\n" +
+	"\vmode_filter\x18\x01 \x01(\x0e2\x17.daemonrpc.TransferModeR\n" +
+	"modeFilter\x12G\n" +
+	"\x10direction_filter\x18\x02 \x01(\x0e2\x1c.daemonrpc.TransferDirectionR\x0fdirectionFilter\x12>\n" +
+	"\rstatus_filter\x18\x03 \x01(\x0e2\x19.daemonrpc.TransferStatusR\fstatusFilter\x12\x14\n" +
+	"\x05limit\x18\x04 \x01(\rR\x05limit\x12\x16\n" +
+	"\x06offset\x18\x05 \x01(\rR\x06offset\"\x8a\x01\n" +
+	"\x15ListTransfersResponse\x125\n" +
+	"\ttransfers\x18\x01 \x03(\v2\x17.daemonrpc.TransferInfoR\ttransfers\x12\x1f\n" +
+	"\vnext_offset\x18\x02 \x01(\rR\n" +
+	"nextOffset\x12\x19\n" +
 	"\bhas_more\x18\x03 \x01(\bR\ahasMore\"+\n" +
 	"\rUnrollRequest\x12\x1a\n" +
 	"\boutpoint\x18\x01 \x01(\tR\boutpoint\"E\n" +
@@ -6308,7 +6995,20 @@ const file_daemon_proto_rawDesc = "" +
 	"\x1eOOR_SESSION_STATUS_UNSPECIFIED\x10\x00\x12\x1e\n" +
 	"\x1aOOR_SESSION_STATUS_PENDING\x10\x01\x12 \n" +
 	"\x1cOOR_SESSION_STATUS_COMPLETED\x10\x02\x12\x1d\n" +
-	"\x19OOR_SESSION_STATUS_FAILED\x10\x03*\xfa\x01\n" +
+	"\x19OOR_SESSION_STATUS_FAILED\x10\x03*_\n" +
+	"\fTransferMode\x12\x1d\n" +
+	"\x19TRANSFER_MODE_UNSPECIFIED\x10\x00\x12\x19\n" +
+	"\x15TRANSFER_MODE_INROUND\x10\x01\x12\x15\n" +
+	"\x11TRANSFER_MODE_OOR\x10\x02*y\n" +
+	"\x11TransferDirection\x12\"\n" +
+	"\x1eTRANSFER_DIRECTION_UNSPECIFIED\x10\x00\x12\x1f\n" +
+	"\x1bTRANSFER_DIRECTION_OUTGOING\x10\x01\x12\x1f\n" +
+	"\x1bTRANSFER_DIRECTION_INCOMING\x10\x02*\x89\x01\n" +
+	"\x0eTransferStatus\x12\x1f\n" +
+	"\x1bTRANSFER_STATUS_UNSPECIFIED\x10\x00\x12\x1b\n" +
+	"\x17TRANSFER_STATUS_PENDING\x10\x01\x12\x1d\n" +
+	"\x19TRANSFER_STATUS_COMPLETED\x10\x02\x12\x1a\n" +
+	"\x16TRANSFER_STATUS_FAILED\x10\x03*\xfa\x01\n" +
 	"\x0fUnrollJobStatus\x12!\n" +
 	"\x1dUNROLL_JOB_STATUS_UNSPECIFIED\x10\x00\x12\x1d\n" +
 	"\x19UNROLL_JOB_STATUS_PENDING\x10\x01\x12#\n" +
@@ -6316,7 +7016,7 @@ const file_daemon_proto_rawDesc = "" +
 	"\x1dUNROLL_JOB_STATUS_CSV_PENDING\x10\x03\x12\x1e\n" +
 	"\x1aUNROLL_JOB_STATUS_SWEEPING\x10\x04\x12\x1f\n" +
 	"\x1bUNROLL_JOB_STATUS_COMPLETED\x10\x05\x12\x1c\n" +
-	"\x18UNROLL_JOB_STATUS_FAILED\x10\x062\xca\x14\n" +
+	"\x18UNROLL_JOB_STATUS_FAILED\x10\x062\x81\x16\n" +
 	"\rDaemonService\x12@\n" +
 	"\aGetInfo\x12\x19.daemonrpc.GetInfoRequest\x1a\x1a.daemonrpc.GetInfoResponse\x12@\n" +
 	"\aGenSeed\x12\x19.daemonrpc.GenSeedRequest\x1a\x1a.daemonrpc.GenSeedResponse\x12I\n" +
@@ -6328,7 +7028,8 @@ const file_daemon_proto_rawDesc = "" +
 	"\tListVTXOs\x12\x1b.daemonrpc.ListVTXOsRequest\x1a\x1c.daemonrpc.ListVTXOsResponse\x12I\n" +
 	"\n" +
 	"NewAddress\x12\x1c.daemonrpc.NewAddressRequest\x1a\x1d.daemonrpc.NewAddressResponse\x12[\n" +
-	"\x10NewReceiveScript\x12\".daemonrpc.NewReceiveScriptRequest\x1a#.daemonrpc.NewReceiveScriptResponse\x12U\n" +
+	"\x10NewReceiveScript\x12\".daemonrpc.NewReceiveScriptRequest\x1a#.daemonrpc.NewReceiveScriptResponse\x12a\n" +
+	"\x12ListReceiveScripts\x12$.daemonrpc.ListReceiveScriptsRequest\x1a%.daemonrpc.ListReceiveScriptsResponse\x12U\n" +
 	"\x0eReceiveAuthKey\x12 .daemonrpc.ReceiveAuthKeyRequest\x1a!.daemonrpc.ReceiveAuthKeyResponse\x12m\n" +
 	"\x16SignReceiveAuthMessage\x12(.daemonrpc.SignReceiveAuthMessageRequest\x1a).daemonrpc.SignReceiveAuthMessageResponse\x12\x82\x01\n" +
 	"\x1dSignReceiveAuthMessageCompact\x12/.daemonrpc.SignReceiveAuthMessageCompactRequest\x1a0.daemonrpc.SignReceiveAuthMessageCompactResponse\x12X\n" +
@@ -6351,7 +7052,8 @@ const file_daemon_proto_rawDesc = "" +
 	"\rGetOORSession\x12\x1f.daemonrpc.GetOORSessionRequest\x1a .daemonrpc.GetOORSessionResponse\x12L\n" +
 	"\vEstimateFee\x12\x1d.daemonrpc.EstimateFeeRequest\x1a\x1e.daemonrpc.EstimateFeeResponse\x12R\n" +
 	"\rGetFeeHistory\x12\x1f.daemonrpc.GetFeeHistoryRequest\x1a .daemonrpc.GetFeeHistoryResponse\x12[\n" +
-	"\x10ListTransactions\x12\".daemonrpc.ListTransactionsRequest\x1a#.daemonrpc.ListTransactionsResponse\x12=\n" +
+	"\x10ListTransactions\x12\".daemonrpc.ListTransactionsRequest\x1a#.daemonrpc.ListTransactionsResponse\x12R\n" +
+	"\rListTransfers\x12\x1f.daemonrpc.ListTransfersRequest\x1a .daemonrpc.ListTransfersResponse\x12=\n" +
 	"\x06Unroll\x12\x18.daemonrpc.UnrollRequest\x1a\x19.daemonrpc.UnrollResponse\x12X\n" +
 	"\x0fGetUnrollStatus\x12!.daemonrpc.GetUnrollStatusRequest\x1a\".daemonrpc.GetUnrollStatusResponseB2Z0github.com/lightninglabs/darepo-client/daemonrpcb\x06proto3"
 
@@ -6367,192 +7069,213 @@ func file_daemon_proto_rawDescGZIP() []byte {
 	return file_daemon_proto_rawDescData
 }
 
-var file_daemon_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 77)
+var file_daemon_proto_enumTypes = make([]protoimpl.EnumInfo, 8)
+var file_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 83)
 var file_daemon_proto_goTypes = []any{
 	(VTXOStatus)(0),                               // 0: daemonrpc.VTXOStatus
 	(RoundState)(0),                               // 1: daemonrpc.RoundState
 	(OORSessionDirection)(0),                      // 2: daemonrpc.OORSessionDirection
 	(OORSessionStatus)(0),                         // 3: daemonrpc.OORSessionStatus
-	(UnrollJobStatus)(0),                          // 4: daemonrpc.UnrollJobStatus
-	(*GetInfoRequest)(nil),                        // 5: daemonrpc.GetInfoRequest
-	(*GetInfoResponse)(nil),                       // 6: daemonrpc.GetInfoResponse
-	(*ServerInfo)(nil),                            // 7: daemonrpc.ServerInfo
-	(*GenSeedRequest)(nil),                        // 8: daemonrpc.GenSeedRequest
-	(*GenSeedResponse)(nil),                       // 9: daemonrpc.GenSeedResponse
-	(*InitWalletRequest)(nil),                     // 10: daemonrpc.InitWalletRequest
-	(*InitWalletResponse)(nil),                    // 11: daemonrpc.InitWalletResponse
-	(*UnlockWalletRequest)(nil),                   // 12: daemonrpc.UnlockWalletRequest
-	(*UnlockWalletResponse)(nil),                  // 13: daemonrpc.UnlockWalletResponse
-	(*GetBalanceRequest)(nil),                     // 14: daemonrpc.GetBalanceRequest
-	(*GetBalanceResponse)(nil),                    // 15: daemonrpc.GetBalanceResponse
-	(*VTXO)(nil),                                  // 16: daemonrpc.VTXO
-	(*ListVTXOsRequest)(nil),                      // 17: daemonrpc.ListVTXOsRequest
-	(*ListVTXOsResponse)(nil),                     // 18: daemonrpc.ListVTXOsResponse
-	(*NewAddressRequest)(nil),                     // 19: daemonrpc.NewAddressRequest
-	(*NewAddressResponse)(nil),                    // 20: daemonrpc.NewAddressResponse
-	(*NewReceiveScriptRequest)(nil),               // 21: daemonrpc.NewReceiveScriptRequest
-	(*NewReceiveScriptResponse)(nil),              // 22: daemonrpc.NewReceiveScriptResponse
-	(*ReceiveAuthKeyRequest)(nil),                 // 23: daemonrpc.ReceiveAuthKeyRequest
-	(*ReceiveAuthKeyResponse)(nil),                // 24: daemonrpc.ReceiveAuthKeyResponse
-	(*SignReceiveAuthMessageRequest)(nil),         // 25: daemonrpc.SignReceiveAuthMessageRequest
-	(*SignReceiveAuthMessageResponse)(nil),        // 26: daemonrpc.SignReceiveAuthMessageResponse
-	(*SignReceiveAuthMessageCompactRequest)(nil),  // 27: daemonrpc.SignReceiveAuthMessageCompactRequest
-	(*SignReceiveAuthMessageCompactResponse)(nil), // 28: daemonrpc.SignReceiveAuthMessageCompactResponse
-	(*ReceiveAuthECDHRequest)(nil),                // 29: daemonrpc.ReceiveAuthECDHRequest
-	(*ReceiveAuthECDHResponse)(nil),               // 30: daemonrpc.ReceiveAuthECDHResponse
-	(*GetIndexedVTXOByPkScriptRequest)(nil),       // 31: daemonrpc.GetIndexedVTXOByPkScriptRequest
-	(*GetIndexedVTXOByPkScriptResponse)(nil),      // 32: daemonrpc.GetIndexedVTXOByPkScriptResponse
-	(*GetIndexedOORSessionByTxidRequest)(nil),     // 33: daemonrpc.GetIndexedOORSessionByTxidRequest
-	(*GetIndexedOORSessionByTxidResponse)(nil),    // 34: daemonrpc.GetIndexedOORSessionByTxidResponse
-	(*Output)(nil),                                // 35: daemonrpc.Output
-	(*SendVTXORequest)(nil),                       // 36: daemonrpc.SendVTXORequest
-	(*SendVTXOResponse)(nil),                      // 37: daemonrpc.SendVTXOResponse
-	(*SendOORRequest)(nil),                        // 38: daemonrpc.SendOORRequest
-	(*CustomOORInput)(nil),                        // 39: daemonrpc.CustomOORInput
-	(*SendOORResponse)(nil),                       // 40: daemonrpc.SendOORResponse
-	(*OutpointSelection)(nil),                     // 41: daemonrpc.OutpointSelection
-	(*RefreshVTXOsRequest)(nil),                   // 42: daemonrpc.RefreshVTXOsRequest
-	(*RefreshVTXOsResponse)(nil),                  // 43: daemonrpc.RefreshVTXOsResponse
-	(*LeaveDestination)(nil),                      // 44: daemonrpc.LeaveDestination
-	(*LeaveVTXOsRequest)(nil),                     // 45: daemonrpc.LeaveVTXOsRequest
-	(*LeaveVTXOsResponse)(nil),                    // 46: daemonrpc.LeaveVTXOsResponse
-	(*BoardRequest)(nil),                          // 47: daemonrpc.BoardRequest
-	(*BoardResponse)(nil),                         // 48: daemonrpc.BoardResponse
-	(*SweepBoardingUTXOsRequest)(nil),             // 49: daemonrpc.SweepBoardingUTXOsRequest
-	(*BoardingSweepOutput)(nil),                   // 50: daemonrpc.BoardingSweepOutput
-	(*SweepBoardingUTXOsResponse)(nil),            // 51: daemonrpc.SweepBoardingUTXOsResponse
-	(*ListBoardingSweepsRequest)(nil),             // 52: daemonrpc.ListBoardingSweepsRequest
-	(*BoardingSweepInput)(nil),                    // 53: daemonrpc.BoardingSweepInput
-	(*BoardingSweep)(nil),                         // 54: daemonrpc.BoardingSweep
-	(*ListBoardingSweepsResponse)(nil),            // 55: daemonrpc.ListBoardingSweepsResponse
-	(*RoundVTXOInfo)(nil),                         // 56: daemonrpc.RoundVTXOInfo
-	(*RoundInfo)(nil),                             // 57: daemonrpc.RoundInfo
-	(*ListRoundsRequest)(nil),                     // 58: daemonrpc.ListRoundsRequest
-	(*GetRoundRequest)(nil),                       // 59: daemonrpc.GetRoundRequest
-	(*GetRoundResponse)(nil),                      // 60: daemonrpc.GetRoundResponse
-	(*ListRoundsResponse)(nil),                    // 61: daemonrpc.ListRoundsResponse
-	(*WatchRoundsRequest)(nil),                    // 62: daemonrpc.WatchRoundsRequest
-	(*WatchRoundsResponse)(nil),                   // 63: daemonrpc.WatchRoundsResponse
-	(*OORSessionInfo)(nil),                        // 64: daemonrpc.OORSessionInfo
-	(*ListOORSessionsRequest)(nil),                // 65: daemonrpc.ListOORSessionsRequest
-	(*ListOORSessionsResponse)(nil),               // 66: daemonrpc.ListOORSessionsResponse
-	(*GetOORSessionRequest)(nil),                  // 67: daemonrpc.GetOORSessionRequest
-	(*GetOORSessionResponse)(nil),                 // 68: daemonrpc.GetOORSessionResponse
-	(*EstimateFeeRequest)(nil),                    // 69: daemonrpc.EstimateFeeRequest
-	(*EstimateFeeResponse)(nil),                   // 70: daemonrpc.EstimateFeeResponse
-	(*GetFeeHistoryRequest)(nil),                  // 71: daemonrpc.GetFeeHistoryRequest
-	(*FeeHistoryEntry)(nil),                       // 72: daemonrpc.FeeHistoryEntry
-	(*GetFeeHistoryResponse)(nil),                 // 73: daemonrpc.GetFeeHistoryResponse
-	(*ListTransactionsRequest)(nil),               // 74: daemonrpc.ListTransactionsRequest
-	(*TransactionHistoryEntry)(nil),               // 75: daemonrpc.TransactionHistoryEntry
-	(*ListTransactionsResponse)(nil),              // 76: daemonrpc.ListTransactionsResponse
-	(*UnrollRequest)(nil),                         // 77: daemonrpc.UnrollRequest
-	(*UnrollResponse)(nil),                        // 78: daemonrpc.UnrollResponse
-	(*GetUnrollStatusRequest)(nil),                // 79: daemonrpc.GetUnrollStatusRequest
-	(*GetUnrollStatusResponse)(nil),               // 80: daemonrpc.GetUnrollStatusResponse
-	nil,                                           // 81: daemonrpc.LeaveVTXOsRequest.DestinationsEntry
+	(TransferMode)(0),                             // 4: daemonrpc.TransferMode
+	(TransferDirection)(0),                        // 5: daemonrpc.TransferDirection
+	(TransferStatus)(0),                           // 6: daemonrpc.TransferStatus
+	(UnrollJobStatus)(0),                          // 7: daemonrpc.UnrollJobStatus
+	(*GetInfoRequest)(nil),                        // 8: daemonrpc.GetInfoRequest
+	(*GetInfoResponse)(nil),                       // 9: daemonrpc.GetInfoResponse
+	(*ServerInfo)(nil),                            // 10: daemonrpc.ServerInfo
+	(*GenSeedRequest)(nil),                        // 11: daemonrpc.GenSeedRequest
+	(*GenSeedResponse)(nil),                       // 12: daemonrpc.GenSeedResponse
+	(*InitWalletRequest)(nil),                     // 13: daemonrpc.InitWalletRequest
+	(*InitWalletResponse)(nil),                    // 14: daemonrpc.InitWalletResponse
+	(*UnlockWalletRequest)(nil),                   // 15: daemonrpc.UnlockWalletRequest
+	(*UnlockWalletResponse)(nil),                  // 16: daemonrpc.UnlockWalletResponse
+	(*GetBalanceRequest)(nil),                     // 17: daemonrpc.GetBalanceRequest
+	(*GetBalanceResponse)(nil),                    // 18: daemonrpc.GetBalanceResponse
+	(*VTXO)(nil),                                  // 19: daemonrpc.VTXO
+	(*ListVTXOsRequest)(nil),                      // 20: daemonrpc.ListVTXOsRequest
+	(*ListVTXOsResponse)(nil),                     // 21: daemonrpc.ListVTXOsResponse
+	(*NewAddressRequest)(nil),                     // 22: daemonrpc.NewAddressRequest
+	(*NewAddressResponse)(nil),                    // 23: daemonrpc.NewAddressResponse
+	(*NewReceiveScriptRequest)(nil),               // 24: daemonrpc.NewReceiveScriptRequest
+	(*NewReceiveScriptResponse)(nil),              // 25: daemonrpc.NewReceiveScriptResponse
+	(*ReceiveTarget)(nil),                         // 26: daemonrpc.ReceiveTarget
+	(*ListReceiveScriptsRequest)(nil),             // 27: daemonrpc.ListReceiveScriptsRequest
+	(*ListReceiveScriptsResponse)(nil),            // 28: daemonrpc.ListReceiveScriptsResponse
+	(*ReceiveAuthKeyRequest)(nil),                 // 29: daemonrpc.ReceiveAuthKeyRequest
+	(*ReceiveAuthKeyResponse)(nil),                // 30: daemonrpc.ReceiveAuthKeyResponse
+	(*SignReceiveAuthMessageRequest)(nil),         // 31: daemonrpc.SignReceiveAuthMessageRequest
+	(*SignReceiveAuthMessageResponse)(nil),        // 32: daemonrpc.SignReceiveAuthMessageResponse
+	(*SignReceiveAuthMessageCompactRequest)(nil),  // 33: daemonrpc.SignReceiveAuthMessageCompactRequest
+	(*SignReceiveAuthMessageCompactResponse)(nil), // 34: daemonrpc.SignReceiveAuthMessageCompactResponse
+	(*ReceiveAuthECDHRequest)(nil),                // 35: daemonrpc.ReceiveAuthECDHRequest
+	(*ReceiveAuthECDHResponse)(nil),               // 36: daemonrpc.ReceiveAuthECDHResponse
+	(*GetIndexedVTXOByPkScriptRequest)(nil),       // 37: daemonrpc.GetIndexedVTXOByPkScriptRequest
+	(*GetIndexedVTXOByPkScriptResponse)(nil),      // 38: daemonrpc.GetIndexedVTXOByPkScriptResponse
+	(*GetIndexedOORSessionByTxidRequest)(nil),     // 39: daemonrpc.GetIndexedOORSessionByTxidRequest
+	(*GetIndexedOORSessionByTxidResponse)(nil),    // 40: daemonrpc.GetIndexedOORSessionByTxidResponse
+	(*Output)(nil),                                // 41: daemonrpc.Output
+	(*SendVTXORequest)(nil),                       // 42: daemonrpc.SendVTXORequest
+	(*SendVTXOResponse)(nil),                      // 43: daemonrpc.SendVTXOResponse
+	(*SendOORRequest)(nil),                        // 44: daemonrpc.SendOORRequest
+	(*CustomOORInput)(nil),                        // 45: daemonrpc.CustomOORInput
+	(*SendOORResponse)(nil),                       // 46: daemonrpc.SendOORResponse
+	(*OutpointSelection)(nil),                     // 47: daemonrpc.OutpointSelection
+	(*RefreshVTXOsRequest)(nil),                   // 48: daemonrpc.RefreshVTXOsRequest
+	(*RefreshVTXOsResponse)(nil),                  // 49: daemonrpc.RefreshVTXOsResponse
+	(*LeaveDestination)(nil),                      // 50: daemonrpc.LeaveDestination
+	(*LeaveVTXOsRequest)(nil),                     // 51: daemonrpc.LeaveVTXOsRequest
+	(*LeaveVTXOsResponse)(nil),                    // 52: daemonrpc.LeaveVTXOsResponse
+	(*BoardRequest)(nil),                          // 53: daemonrpc.BoardRequest
+	(*BoardResponse)(nil),                         // 54: daemonrpc.BoardResponse
+	(*SweepBoardingUTXOsRequest)(nil),             // 55: daemonrpc.SweepBoardingUTXOsRequest
+	(*BoardingSweepOutput)(nil),                   // 56: daemonrpc.BoardingSweepOutput
+	(*SweepBoardingUTXOsResponse)(nil),            // 57: daemonrpc.SweepBoardingUTXOsResponse
+	(*ListBoardingSweepsRequest)(nil),             // 58: daemonrpc.ListBoardingSweepsRequest
+	(*BoardingSweepInput)(nil),                    // 59: daemonrpc.BoardingSweepInput
+	(*BoardingSweep)(nil),                         // 60: daemonrpc.BoardingSweep
+	(*ListBoardingSweepsResponse)(nil),            // 61: daemonrpc.ListBoardingSweepsResponse
+	(*RoundVTXOInfo)(nil),                         // 62: daemonrpc.RoundVTXOInfo
+	(*RoundInfo)(nil),                             // 63: daemonrpc.RoundInfo
+	(*ListRoundsRequest)(nil),                     // 64: daemonrpc.ListRoundsRequest
+	(*GetRoundRequest)(nil),                       // 65: daemonrpc.GetRoundRequest
+	(*GetRoundResponse)(nil),                      // 66: daemonrpc.GetRoundResponse
+	(*ListRoundsResponse)(nil),                    // 67: daemonrpc.ListRoundsResponse
+	(*WatchRoundsRequest)(nil),                    // 68: daemonrpc.WatchRoundsRequest
+	(*WatchRoundsResponse)(nil),                   // 69: daemonrpc.WatchRoundsResponse
+	(*OORSessionInfo)(nil),                        // 70: daemonrpc.OORSessionInfo
+	(*ListOORSessionsRequest)(nil),                // 71: daemonrpc.ListOORSessionsRequest
+	(*ListOORSessionsResponse)(nil),               // 72: daemonrpc.ListOORSessionsResponse
+	(*GetOORSessionRequest)(nil),                  // 73: daemonrpc.GetOORSessionRequest
+	(*GetOORSessionResponse)(nil),                 // 74: daemonrpc.GetOORSessionResponse
+	(*EstimateFeeRequest)(nil),                    // 75: daemonrpc.EstimateFeeRequest
+	(*EstimateFeeResponse)(nil),                   // 76: daemonrpc.EstimateFeeResponse
+	(*GetFeeHistoryRequest)(nil),                  // 77: daemonrpc.GetFeeHistoryRequest
+	(*FeeHistoryEntry)(nil),                       // 78: daemonrpc.FeeHistoryEntry
+	(*GetFeeHistoryResponse)(nil),                 // 79: daemonrpc.GetFeeHistoryResponse
+	(*ListTransactionsRequest)(nil),               // 80: daemonrpc.ListTransactionsRequest
+	(*TransactionHistoryEntry)(nil),               // 81: daemonrpc.TransactionHistoryEntry
+	(*ListTransactionsResponse)(nil),              // 82: daemonrpc.ListTransactionsResponse
+	(*TransferInfo)(nil),                          // 83: daemonrpc.TransferInfo
+	(*ListTransfersRequest)(nil),                  // 84: daemonrpc.ListTransfersRequest
+	(*ListTransfersResponse)(nil),                 // 85: daemonrpc.ListTransfersResponse
+	(*UnrollRequest)(nil),                         // 86: daemonrpc.UnrollRequest
+	(*UnrollResponse)(nil),                        // 87: daemonrpc.UnrollResponse
+	(*GetUnrollStatusRequest)(nil),                // 88: daemonrpc.GetUnrollStatusRequest
+	(*GetUnrollStatusResponse)(nil),               // 89: daemonrpc.GetUnrollStatusResponse
+	nil,                                           // 90: daemonrpc.LeaveVTXOsRequest.DestinationsEntry
 }
 var file_daemon_proto_depIdxs = []int32{
-	7,  // 0: daemonrpc.GetInfoResponse.server_info:type_name -> daemonrpc.ServerInfo
+	10, // 0: daemonrpc.GetInfoResponse.server_info:type_name -> daemonrpc.ServerInfo
 	0,  // 1: daemonrpc.VTXO.status:type_name -> daemonrpc.VTXOStatus
 	0,  // 2: daemonrpc.ListVTXOsRequest.status_filter:type_name -> daemonrpc.VTXOStatus
-	16, // 3: daemonrpc.ListVTXOsResponse.vtxos:type_name -> daemonrpc.VTXO
-	0,  // 4: daemonrpc.GetIndexedVTXOByPkScriptRequest.status_filter:type_name -> daemonrpc.VTXOStatus
-	16, // 5: daemonrpc.GetIndexedVTXOByPkScriptResponse.vtxo:type_name -> daemonrpc.VTXO
-	35, // 6: daemonrpc.SendVTXORequest.recipients:type_name -> daemonrpc.Output
-	35, // 7: daemonrpc.SendOORRequest.recipient:type_name -> daemonrpc.Output
-	39, // 8: daemonrpc.SendOORRequest.custom_inputs:type_name -> daemonrpc.CustomOORInput
-	41, // 9: daemonrpc.RefreshVTXOsRequest.outpoints:type_name -> daemonrpc.OutpointSelection
-	41, // 10: daemonrpc.LeaveVTXOsRequest.outpoints:type_name -> daemonrpc.OutpointSelection
-	44, // 11: daemonrpc.LeaveVTXOsRequest.default_destination:type_name -> daemonrpc.LeaveDestination
-	81, // 12: daemonrpc.LeaveVTXOsRequest.destinations:type_name -> daemonrpc.LeaveVTXOsRequest.DestinationsEntry
-	50, // 13: daemonrpc.SweepBoardingUTXOsResponse.sweepable_outputs:type_name -> daemonrpc.BoardingSweepOutput
-	53, // 14: daemonrpc.BoardingSweep.inputs:type_name -> daemonrpc.BoardingSweepInput
-	54, // 15: daemonrpc.ListBoardingSweepsResponse.sweeps:type_name -> daemonrpc.BoardingSweep
-	1,  // 16: daemonrpc.RoundInfo.state:type_name -> daemonrpc.RoundState
-	56, // 17: daemonrpc.RoundInfo.vtxos:type_name -> daemonrpc.RoundVTXOInfo
-	1,  // 18: daemonrpc.ListRoundsRequest.state_filter:type_name -> daemonrpc.RoundState
-	57, // 19: daemonrpc.GetRoundResponse.round:type_name -> daemonrpc.RoundInfo
-	57, // 20: daemonrpc.ListRoundsResponse.rounds:type_name -> daemonrpc.RoundInfo
-	57, // 21: daemonrpc.WatchRoundsResponse.round:type_name -> daemonrpc.RoundInfo
-	2,  // 22: daemonrpc.OORSessionInfo.direction:type_name -> daemonrpc.OORSessionDirection
-	3,  // 23: daemonrpc.OORSessionInfo.status:type_name -> daemonrpc.OORSessionStatus
-	2,  // 24: daemonrpc.ListOORSessionsRequest.direction_filter:type_name -> daemonrpc.OORSessionDirection
-	3,  // 25: daemonrpc.ListOORSessionsRequest.status_filter:type_name -> daemonrpc.OORSessionStatus
-	64, // 26: daemonrpc.ListOORSessionsResponse.sessions:type_name -> daemonrpc.OORSessionInfo
-	64, // 27: daemonrpc.GetOORSessionResponse.session:type_name -> daemonrpc.OORSessionInfo
-	72, // 28: daemonrpc.GetFeeHistoryResponse.entries:type_name -> daemonrpc.FeeHistoryEntry
-	75, // 29: daemonrpc.ListTransactionsResponse.transactions:type_name -> daemonrpc.TransactionHistoryEntry
-	4,  // 30: daemonrpc.GetUnrollStatusResponse.status:type_name -> daemonrpc.UnrollJobStatus
-	44, // 31: daemonrpc.LeaveVTXOsRequest.DestinationsEntry.value:type_name -> daemonrpc.LeaveDestination
-	5,  // 32: daemonrpc.DaemonService.GetInfo:input_type -> daemonrpc.GetInfoRequest
-	8,  // 33: daemonrpc.DaemonService.GenSeed:input_type -> daemonrpc.GenSeedRequest
-	10, // 34: daemonrpc.DaemonService.InitWallet:input_type -> daemonrpc.InitWalletRequest
-	12, // 35: daemonrpc.DaemonService.UnlockWallet:input_type -> daemonrpc.UnlockWalletRequest
-	14, // 36: daemonrpc.DaemonService.GetBalance:input_type -> daemonrpc.GetBalanceRequest
-	17, // 37: daemonrpc.DaemonService.ListVTXOs:input_type -> daemonrpc.ListVTXOsRequest
-	19, // 38: daemonrpc.DaemonService.NewAddress:input_type -> daemonrpc.NewAddressRequest
-	21, // 39: daemonrpc.DaemonService.NewReceiveScript:input_type -> daemonrpc.NewReceiveScriptRequest
-	23, // 40: daemonrpc.DaemonService.ReceiveAuthKey:input_type -> daemonrpc.ReceiveAuthKeyRequest
-	25, // 41: daemonrpc.DaemonService.SignReceiveAuthMessage:input_type -> daemonrpc.SignReceiveAuthMessageRequest
-	27, // 42: daemonrpc.DaemonService.SignReceiveAuthMessageCompact:input_type -> daemonrpc.SignReceiveAuthMessageCompactRequest
-	29, // 43: daemonrpc.DaemonService.ReceiveAuthECDH:input_type -> daemonrpc.ReceiveAuthECDHRequest
-	31, // 44: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:input_type -> daemonrpc.GetIndexedVTXOByPkScriptRequest
-	33, // 45: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:input_type -> daemonrpc.GetIndexedOORSessionByTxidRequest
-	36, // 46: daemonrpc.DaemonService.SendVTXO:input_type -> daemonrpc.SendVTXORequest
-	38, // 47: daemonrpc.DaemonService.SendOOR:input_type -> daemonrpc.SendOORRequest
-	42, // 48: daemonrpc.DaemonService.RefreshVTXOs:input_type -> daemonrpc.RefreshVTXOsRequest
-	45, // 49: daemonrpc.DaemonService.LeaveVTXOs:input_type -> daemonrpc.LeaveVTXOsRequest
-	47, // 50: daemonrpc.DaemonService.Board:input_type -> daemonrpc.BoardRequest
-	49, // 51: daemonrpc.DaemonService.SweepBoardingUTXOs:input_type -> daemonrpc.SweepBoardingUTXOsRequest
-	52, // 52: daemonrpc.DaemonService.ListBoardingSweeps:input_type -> daemonrpc.ListBoardingSweepsRequest
-	58, // 53: daemonrpc.DaemonService.ListRounds:input_type -> daemonrpc.ListRoundsRequest
-	59, // 54: daemonrpc.DaemonService.GetRound:input_type -> daemonrpc.GetRoundRequest
-	62, // 55: daemonrpc.DaemonService.WatchRounds:input_type -> daemonrpc.WatchRoundsRequest
-	65, // 56: daemonrpc.DaemonService.ListOORSessions:input_type -> daemonrpc.ListOORSessionsRequest
-	67, // 57: daemonrpc.DaemonService.GetOORSession:input_type -> daemonrpc.GetOORSessionRequest
-	69, // 58: daemonrpc.DaemonService.EstimateFee:input_type -> daemonrpc.EstimateFeeRequest
-	71, // 59: daemonrpc.DaemonService.GetFeeHistory:input_type -> daemonrpc.GetFeeHistoryRequest
-	74, // 60: daemonrpc.DaemonService.ListTransactions:input_type -> daemonrpc.ListTransactionsRequest
-	77, // 61: daemonrpc.DaemonService.Unroll:input_type -> daemonrpc.UnrollRequest
-	79, // 62: daemonrpc.DaemonService.GetUnrollStatus:input_type -> daemonrpc.GetUnrollStatusRequest
-	6,  // 63: daemonrpc.DaemonService.GetInfo:output_type -> daemonrpc.GetInfoResponse
-	9,  // 64: daemonrpc.DaemonService.GenSeed:output_type -> daemonrpc.GenSeedResponse
-	11, // 65: daemonrpc.DaemonService.InitWallet:output_type -> daemonrpc.InitWalletResponse
-	13, // 66: daemonrpc.DaemonService.UnlockWallet:output_type -> daemonrpc.UnlockWalletResponse
-	15, // 67: daemonrpc.DaemonService.GetBalance:output_type -> daemonrpc.GetBalanceResponse
-	18, // 68: daemonrpc.DaemonService.ListVTXOs:output_type -> daemonrpc.ListVTXOsResponse
-	20, // 69: daemonrpc.DaemonService.NewAddress:output_type -> daemonrpc.NewAddressResponse
-	22, // 70: daemonrpc.DaemonService.NewReceiveScript:output_type -> daemonrpc.NewReceiveScriptResponse
-	24, // 71: daemonrpc.DaemonService.ReceiveAuthKey:output_type -> daemonrpc.ReceiveAuthKeyResponse
-	26, // 72: daemonrpc.DaemonService.SignReceiveAuthMessage:output_type -> daemonrpc.SignReceiveAuthMessageResponse
-	28, // 73: daemonrpc.DaemonService.SignReceiveAuthMessageCompact:output_type -> daemonrpc.SignReceiveAuthMessageCompactResponse
-	30, // 74: daemonrpc.DaemonService.ReceiveAuthECDH:output_type -> daemonrpc.ReceiveAuthECDHResponse
-	32, // 75: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:output_type -> daemonrpc.GetIndexedVTXOByPkScriptResponse
-	34, // 76: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:output_type -> daemonrpc.GetIndexedOORSessionByTxidResponse
-	37, // 77: daemonrpc.DaemonService.SendVTXO:output_type -> daemonrpc.SendVTXOResponse
-	40, // 78: daemonrpc.DaemonService.SendOOR:output_type -> daemonrpc.SendOORResponse
-	43, // 79: daemonrpc.DaemonService.RefreshVTXOs:output_type -> daemonrpc.RefreshVTXOsResponse
-	46, // 80: daemonrpc.DaemonService.LeaveVTXOs:output_type -> daemonrpc.LeaveVTXOsResponse
-	48, // 81: daemonrpc.DaemonService.Board:output_type -> daemonrpc.BoardResponse
-	51, // 82: daemonrpc.DaemonService.SweepBoardingUTXOs:output_type -> daemonrpc.SweepBoardingUTXOsResponse
-	55, // 83: daemonrpc.DaemonService.ListBoardingSweeps:output_type -> daemonrpc.ListBoardingSweepsResponse
-	61, // 84: daemonrpc.DaemonService.ListRounds:output_type -> daemonrpc.ListRoundsResponse
-	60, // 85: daemonrpc.DaemonService.GetRound:output_type -> daemonrpc.GetRoundResponse
-	63, // 86: daemonrpc.DaemonService.WatchRounds:output_type -> daemonrpc.WatchRoundsResponse
-	66, // 87: daemonrpc.DaemonService.ListOORSessions:output_type -> daemonrpc.ListOORSessionsResponse
-	68, // 88: daemonrpc.DaemonService.GetOORSession:output_type -> daemonrpc.GetOORSessionResponse
-	70, // 89: daemonrpc.DaemonService.EstimateFee:output_type -> daemonrpc.EstimateFeeResponse
-	73, // 90: daemonrpc.DaemonService.GetFeeHistory:output_type -> daemonrpc.GetFeeHistoryResponse
-	76, // 91: daemonrpc.DaemonService.ListTransactions:output_type -> daemonrpc.ListTransactionsResponse
-	78, // 92: daemonrpc.DaemonService.Unroll:output_type -> daemonrpc.UnrollResponse
-	80, // 93: daemonrpc.DaemonService.GetUnrollStatus:output_type -> daemonrpc.GetUnrollStatusResponse
-	63, // [63:94] is the sub-list for method output_type
-	32, // [32:63] is the sub-list for method input_type
-	32, // [32:32] is the sub-list for extension type_name
-	32, // [32:32] is the sub-list for extension extendee
-	0,  // [0:32] is the sub-list for field type_name
+	19, // 3: daemonrpc.ListVTXOsResponse.vtxos:type_name -> daemonrpc.VTXO
+	26, // 4: daemonrpc.ListReceiveScriptsResponse.targets:type_name -> daemonrpc.ReceiveTarget
+	0,  // 5: daemonrpc.GetIndexedVTXOByPkScriptRequest.status_filter:type_name -> daemonrpc.VTXOStatus
+	19, // 6: daemonrpc.GetIndexedVTXOByPkScriptResponse.vtxo:type_name -> daemonrpc.VTXO
+	41, // 7: daemonrpc.SendVTXORequest.recipients:type_name -> daemonrpc.Output
+	41, // 8: daemonrpc.SendOORRequest.recipient:type_name -> daemonrpc.Output
+	45, // 9: daemonrpc.SendOORRequest.custom_inputs:type_name -> daemonrpc.CustomOORInput
+	47, // 10: daemonrpc.RefreshVTXOsRequest.outpoints:type_name -> daemonrpc.OutpointSelection
+	47, // 11: daemonrpc.LeaveVTXOsRequest.outpoints:type_name -> daemonrpc.OutpointSelection
+	50, // 12: daemonrpc.LeaveVTXOsRequest.default_destination:type_name -> daemonrpc.LeaveDestination
+	90, // 13: daemonrpc.LeaveVTXOsRequest.destinations:type_name -> daemonrpc.LeaveVTXOsRequest.DestinationsEntry
+	56, // 14: daemonrpc.SweepBoardingUTXOsResponse.sweepable_outputs:type_name -> daemonrpc.BoardingSweepOutput
+	59, // 15: daemonrpc.BoardingSweep.inputs:type_name -> daemonrpc.BoardingSweepInput
+	60, // 16: daemonrpc.ListBoardingSweepsResponse.sweeps:type_name -> daemonrpc.BoardingSweep
+	1,  // 17: daemonrpc.RoundInfo.state:type_name -> daemonrpc.RoundState
+	62, // 18: daemonrpc.RoundInfo.vtxos:type_name -> daemonrpc.RoundVTXOInfo
+	1,  // 19: daemonrpc.ListRoundsRequest.state_filter:type_name -> daemonrpc.RoundState
+	63, // 20: daemonrpc.GetRoundResponse.round:type_name -> daemonrpc.RoundInfo
+	63, // 21: daemonrpc.ListRoundsResponse.rounds:type_name -> daemonrpc.RoundInfo
+	63, // 22: daemonrpc.WatchRoundsResponse.round:type_name -> daemonrpc.RoundInfo
+	2,  // 23: daemonrpc.OORSessionInfo.direction:type_name -> daemonrpc.OORSessionDirection
+	3,  // 24: daemonrpc.OORSessionInfo.status:type_name -> daemonrpc.OORSessionStatus
+	2,  // 25: daemonrpc.ListOORSessionsRequest.direction_filter:type_name -> daemonrpc.OORSessionDirection
+	3,  // 26: daemonrpc.ListOORSessionsRequest.status_filter:type_name -> daemonrpc.OORSessionStatus
+	70, // 27: daemonrpc.ListOORSessionsResponse.sessions:type_name -> daemonrpc.OORSessionInfo
+	70, // 28: daemonrpc.GetOORSessionResponse.session:type_name -> daemonrpc.OORSessionInfo
+	78, // 29: daemonrpc.GetFeeHistoryResponse.entries:type_name -> daemonrpc.FeeHistoryEntry
+	81, // 30: daemonrpc.ListTransactionsResponse.transactions:type_name -> daemonrpc.TransactionHistoryEntry
+	4,  // 31: daemonrpc.TransferInfo.mode:type_name -> daemonrpc.TransferMode
+	5,  // 32: daemonrpc.TransferInfo.direction:type_name -> daemonrpc.TransferDirection
+	6,  // 33: daemonrpc.TransferInfo.status:type_name -> daemonrpc.TransferStatus
+	4,  // 34: daemonrpc.ListTransfersRequest.mode_filter:type_name -> daemonrpc.TransferMode
+	5,  // 35: daemonrpc.ListTransfersRequest.direction_filter:type_name -> daemonrpc.TransferDirection
+	6,  // 36: daemonrpc.ListTransfersRequest.status_filter:type_name -> daemonrpc.TransferStatus
+	83, // 37: daemonrpc.ListTransfersResponse.transfers:type_name -> daemonrpc.TransferInfo
+	7,  // 38: daemonrpc.GetUnrollStatusResponse.status:type_name -> daemonrpc.UnrollJobStatus
+	50, // 39: daemonrpc.LeaveVTXOsRequest.DestinationsEntry.value:type_name -> daemonrpc.LeaveDestination
+	8,  // 40: daemonrpc.DaemonService.GetInfo:input_type -> daemonrpc.GetInfoRequest
+	11, // 41: daemonrpc.DaemonService.GenSeed:input_type -> daemonrpc.GenSeedRequest
+	13, // 42: daemonrpc.DaemonService.InitWallet:input_type -> daemonrpc.InitWalletRequest
+	15, // 43: daemonrpc.DaemonService.UnlockWallet:input_type -> daemonrpc.UnlockWalletRequest
+	17, // 44: daemonrpc.DaemonService.GetBalance:input_type -> daemonrpc.GetBalanceRequest
+	20, // 45: daemonrpc.DaemonService.ListVTXOs:input_type -> daemonrpc.ListVTXOsRequest
+	22, // 46: daemonrpc.DaemonService.NewAddress:input_type -> daemonrpc.NewAddressRequest
+	24, // 47: daemonrpc.DaemonService.NewReceiveScript:input_type -> daemonrpc.NewReceiveScriptRequest
+	27, // 48: daemonrpc.DaemonService.ListReceiveScripts:input_type -> daemonrpc.ListReceiveScriptsRequest
+	29, // 49: daemonrpc.DaemonService.ReceiveAuthKey:input_type -> daemonrpc.ReceiveAuthKeyRequest
+	31, // 50: daemonrpc.DaemonService.SignReceiveAuthMessage:input_type -> daemonrpc.SignReceiveAuthMessageRequest
+	33, // 51: daemonrpc.DaemonService.SignReceiveAuthMessageCompact:input_type -> daemonrpc.SignReceiveAuthMessageCompactRequest
+	35, // 52: daemonrpc.DaemonService.ReceiveAuthECDH:input_type -> daemonrpc.ReceiveAuthECDHRequest
+	37, // 53: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:input_type -> daemonrpc.GetIndexedVTXOByPkScriptRequest
+	39, // 54: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:input_type -> daemonrpc.GetIndexedOORSessionByTxidRequest
+	42, // 55: daemonrpc.DaemonService.SendVTXO:input_type -> daemonrpc.SendVTXORequest
+	44, // 56: daemonrpc.DaemonService.SendOOR:input_type -> daemonrpc.SendOORRequest
+	48, // 57: daemonrpc.DaemonService.RefreshVTXOs:input_type -> daemonrpc.RefreshVTXOsRequest
+	51, // 58: daemonrpc.DaemonService.LeaveVTXOs:input_type -> daemonrpc.LeaveVTXOsRequest
+	53, // 59: daemonrpc.DaemonService.Board:input_type -> daemonrpc.BoardRequest
+	55, // 60: daemonrpc.DaemonService.SweepBoardingUTXOs:input_type -> daemonrpc.SweepBoardingUTXOsRequest
+	58, // 61: daemonrpc.DaemonService.ListBoardingSweeps:input_type -> daemonrpc.ListBoardingSweepsRequest
+	64, // 62: daemonrpc.DaemonService.ListRounds:input_type -> daemonrpc.ListRoundsRequest
+	65, // 63: daemonrpc.DaemonService.GetRound:input_type -> daemonrpc.GetRoundRequest
+	68, // 64: daemonrpc.DaemonService.WatchRounds:input_type -> daemonrpc.WatchRoundsRequest
+	71, // 65: daemonrpc.DaemonService.ListOORSessions:input_type -> daemonrpc.ListOORSessionsRequest
+	73, // 66: daemonrpc.DaemonService.GetOORSession:input_type -> daemonrpc.GetOORSessionRequest
+	75, // 67: daemonrpc.DaemonService.EstimateFee:input_type -> daemonrpc.EstimateFeeRequest
+	77, // 68: daemonrpc.DaemonService.GetFeeHistory:input_type -> daemonrpc.GetFeeHistoryRequest
+	80, // 69: daemonrpc.DaemonService.ListTransactions:input_type -> daemonrpc.ListTransactionsRequest
+	84, // 70: daemonrpc.DaemonService.ListTransfers:input_type -> daemonrpc.ListTransfersRequest
+	86, // 71: daemonrpc.DaemonService.Unroll:input_type -> daemonrpc.UnrollRequest
+	88, // 72: daemonrpc.DaemonService.GetUnrollStatus:input_type -> daemonrpc.GetUnrollStatusRequest
+	9,  // 73: daemonrpc.DaemonService.GetInfo:output_type -> daemonrpc.GetInfoResponse
+	12, // 74: daemonrpc.DaemonService.GenSeed:output_type -> daemonrpc.GenSeedResponse
+	14, // 75: daemonrpc.DaemonService.InitWallet:output_type -> daemonrpc.InitWalletResponse
+	16, // 76: daemonrpc.DaemonService.UnlockWallet:output_type -> daemonrpc.UnlockWalletResponse
+	18, // 77: daemonrpc.DaemonService.GetBalance:output_type -> daemonrpc.GetBalanceResponse
+	21, // 78: daemonrpc.DaemonService.ListVTXOs:output_type -> daemonrpc.ListVTXOsResponse
+	23, // 79: daemonrpc.DaemonService.NewAddress:output_type -> daemonrpc.NewAddressResponse
+	25, // 80: daemonrpc.DaemonService.NewReceiveScript:output_type -> daemonrpc.NewReceiveScriptResponse
+	28, // 81: daemonrpc.DaemonService.ListReceiveScripts:output_type -> daemonrpc.ListReceiveScriptsResponse
+	30, // 82: daemonrpc.DaemonService.ReceiveAuthKey:output_type -> daemonrpc.ReceiveAuthKeyResponse
+	32, // 83: daemonrpc.DaemonService.SignReceiveAuthMessage:output_type -> daemonrpc.SignReceiveAuthMessageResponse
+	34, // 84: daemonrpc.DaemonService.SignReceiveAuthMessageCompact:output_type -> daemonrpc.SignReceiveAuthMessageCompactResponse
+	36, // 85: daemonrpc.DaemonService.ReceiveAuthECDH:output_type -> daemonrpc.ReceiveAuthECDHResponse
+	38, // 86: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:output_type -> daemonrpc.GetIndexedVTXOByPkScriptResponse
+	40, // 87: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:output_type -> daemonrpc.GetIndexedOORSessionByTxidResponse
+	43, // 88: daemonrpc.DaemonService.SendVTXO:output_type -> daemonrpc.SendVTXOResponse
+	46, // 89: daemonrpc.DaemonService.SendOOR:output_type -> daemonrpc.SendOORResponse
+	49, // 90: daemonrpc.DaemonService.RefreshVTXOs:output_type -> daemonrpc.RefreshVTXOsResponse
+	52, // 91: daemonrpc.DaemonService.LeaveVTXOs:output_type -> daemonrpc.LeaveVTXOsResponse
+	54, // 92: daemonrpc.DaemonService.Board:output_type -> daemonrpc.BoardResponse
+	57, // 93: daemonrpc.DaemonService.SweepBoardingUTXOs:output_type -> daemonrpc.SweepBoardingUTXOsResponse
+	61, // 94: daemonrpc.DaemonService.ListBoardingSweeps:output_type -> daemonrpc.ListBoardingSweepsResponse
+	67, // 95: daemonrpc.DaemonService.ListRounds:output_type -> daemonrpc.ListRoundsResponse
+	66, // 96: daemonrpc.DaemonService.GetRound:output_type -> daemonrpc.GetRoundResponse
+	69, // 97: daemonrpc.DaemonService.WatchRounds:output_type -> daemonrpc.WatchRoundsResponse
+	72, // 98: daemonrpc.DaemonService.ListOORSessions:output_type -> daemonrpc.ListOORSessionsResponse
+	74, // 99: daemonrpc.DaemonService.GetOORSession:output_type -> daemonrpc.GetOORSessionResponse
+	76, // 100: daemonrpc.DaemonService.EstimateFee:output_type -> daemonrpc.EstimateFeeResponse
+	79, // 101: daemonrpc.DaemonService.GetFeeHistory:output_type -> daemonrpc.GetFeeHistoryResponse
+	82, // 102: daemonrpc.DaemonService.ListTransactions:output_type -> daemonrpc.ListTransactionsResponse
+	85, // 103: daemonrpc.DaemonService.ListTransfers:output_type -> daemonrpc.ListTransfersResponse
+	87, // 104: daemonrpc.DaemonService.Unroll:output_type -> daemonrpc.UnrollResponse
+	89, // 105: daemonrpc.DaemonService.GetUnrollStatus:output_type -> daemonrpc.GetUnrollStatusResponse
+	73, // [73:106] is the sub-list for method output_type
+	40, // [40:73] is the sub-list for method input_type
+	40, // [40:40] is the sub-list for extension type_name
+	40, // [40:40] is the sub-list for extension extendee
+	0,  // [0:40] is the sub-list for field type_name
 }
 
 func init() { file_daemon_proto_init() }
@@ -6560,20 +7283,20 @@ func file_daemon_proto_init() {
 	if File_daemon_proto != nil {
 		return
 	}
-	file_daemon_proto_msgTypes[30].OneofWrappers = []any{
+	file_daemon_proto_msgTypes[33].OneofWrappers = []any{
 		(*Output_Address)(nil),
 		(*Output_Pubkey)(nil),
 		(*Output_PolicyTemplate)(nil),
 	}
-	file_daemon_proto_msgTypes[37].OneofWrappers = []any{
+	file_daemon_proto_msgTypes[40].OneofWrappers = []any{
 		(*RefreshVTXOsRequest_Outpoints)(nil),
 		(*RefreshVTXOsRequest_All)(nil),
 	}
-	file_daemon_proto_msgTypes[39].OneofWrappers = []any{
+	file_daemon_proto_msgTypes[42].OneofWrappers = []any{
 		(*LeaveDestination_Address)(nil),
 		(*LeaveDestination_PkScript)(nil),
 	}
-	file_daemon_proto_msgTypes[40].OneofWrappers = []any{
+	file_daemon_proto_msgTypes[43].OneofWrappers = []any{
 		(*LeaveVTXOsRequest_Outpoints)(nil),
 		(*LeaveVTXOsRequest_All)(nil),
 	}
@@ -6582,8 +7305,8 @@ func file_daemon_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_daemon_proto_rawDesc), len(file_daemon_proto_rawDesc)),
-			NumEnums:      5,
-			NumMessages:   77,
+			NumEnums:      8,
+			NumMessages:   83,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/daemonrpc/daemon.proto
+++ b/daemonrpc/daemon.proto
@@ -47,6 +47,11 @@ service DaemonService {
     rpc NewReceiveScript (NewReceiveScriptRequest)
         returns (NewReceiveScriptResponse);
 
+    // ListReceiveScripts lists receive targets currently registered for this
+    // wallet's mailbox principal.
+    rpc ListReceiveScripts (ListReceiveScriptsRequest)
+        returns (ListReceiveScriptsResponse);
+
     // ReceiveAuthKey returns the per-payment receive-auth public key.
     rpc ReceiveAuthKey (ReceiveAuthKeyRequest) returns (ReceiveAuthKeyResponse);
 
@@ -147,6 +152,10 @@ service DaemonService {
     // the client's local accounting and sweep databases.
     rpc ListTransactions (ListTransactionsRequest)
         returns (ListTransactionsResponse);
+
+    // ListTransfers returns a user-facing transfer status view stitched
+    // together from local round state, OOR sessions, and transaction history.
+    rpc ListTransfers (ListTransfersRequest) returns (ListTransfersResponse);
 
     // Unroll triggers a unilateral exit for the specified VTXO outpoint.
     // The daemon will assemble the recovery proof, spawn a durable unroll
@@ -488,6 +497,33 @@ message NewReceiveScriptResponse {
 
     // label is the registration label stored with the indexer.
     string label = 5;
+
+    // address is the bech32m taproot address for pk_script_hex on the active
+    // chain network.
+    string address = 6;
+}
+
+message ReceiveTarget {
+    // address is the bech32m taproot address callers can hand to a sender.
+    string address = 1;
+
+    // pk_script_hex is the raw taproot output script encoded as hex.
+    string pk_script_hex = 2;
+
+    // label is the informational registration label stored with the indexer.
+    string label = 3;
+
+    // expires_at_unix_s is the indexer-side expiration time for this
+    // registration. Zero means the indexer default applies.
+    uint64 expires_at_unix_s = 4;
+}
+
+message ListReceiveScriptsRequest {
+}
+
+message ListReceiveScriptsResponse {
+    // targets is the set of active receive targets registered for this wallet.
+    repeated ReceiveTarget targets = 1;
 }
 
 message ReceiveAuthKeyRequest {
@@ -1450,6 +1486,117 @@ message TransactionHistoryEntry {
 message ListTransactionsResponse {
     // transactions are returned newest first by created_at_unix_s.
     repeated TransactionHistoryEntry transactions = 1;
+
+    // next_offset is the offset to pass to the next request when has_more is
+    // true.
+    uint32 next_offset = 2;
+
+    // has_more is true when another page is available.
+    bool has_more = 3;
+}
+
+enum TransferMode {
+    TRANSFER_MODE_UNSPECIFIED = 0;
+    TRANSFER_MODE_INROUND = 1;
+    TRANSFER_MODE_OOR = 2;
+}
+
+enum TransferDirection {
+    TRANSFER_DIRECTION_UNSPECIFIED = 0;
+    TRANSFER_DIRECTION_OUTGOING = 1;
+    TRANSFER_DIRECTION_INCOMING = 2;
+}
+
+enum TransferStatus {
+    TRANSFER_STATUS_UNSPECIFIED = 0;
+    TRANSFER_STATUS_PENDING = 1;
+    TRANSFER_STATUS_COMPLETED = 2;
+    TRANSFER_STATUS_FAILED = 3;
+}
+
+message TransferInfo {
+    // transfer_id is a stable local identifier for this transfer status row.
+    string transfer_id = 1;
+
+    // mode identifies whether this transfer used a round or OOR session.
+    TransferMode mode = 2;
+
+    // direction is from the local wallet's perspective when the daemon has
+    // enough local input/output ownership data to infer it. Live in-memory
+    // in-round entries may report TRANSFER_DIRECTION_UNSPECIFIED until they
+    // are persisted with outpoint context.
+    TransferDirection direction = 3;
+
+    // status is the coarse lifecycle state.
+    TransferStatus status = 4;
+
+    // phase carries the detailed round state, OOR phase, or history subtype.
+    string phase = 5;
+
+    // amount_sat is the known transfer amount in satoshis. Live in-memory
+    // in-round entries and OOR session rows may leave this zero until a
+    // history source supplies a persisted amount.
+    int64 amount_sat = 6;
+
+    // round_id is set for in-round transfers when known.
+    string round_id = 7;
+
+    // session_id is set for OOR transfers when known.
+    string session_id = 8;
+
+    // input_outpoints are locally known consumed VTXOs.
+    repeated string input_outpoints = 9;
+
+    // output_outpoints are locally known created VTXOs.
+    repeated string output_outpoints = 10;
+
+    // txid is the commitment or package transaction id when known.
+    string txid = 11;
+
+    // confirmation_height is set when the transfer has a known chain
+    // confirmation height.
+    int32 confirmation_height = 12;
+
+    // created_at_unix_s is the local creation time when known.
+    int64 created_at_unix_s = 13;
+
+    // updated_at_unix_s is the local update time when known.
+    int64 updated_at_unix_s = 14;
+
+    // failure_reason is populated for failed live operations when known.
+    string failure_reason = 15;
+}
+
+message ListTransfersRequest {
+    // mode_filter restricts results to one transfer mode when set.
+    TransferMode mode_filter = 1;
+
+    // direction_filter restricts results to one local direction when set.
+    // Rows whose direction is TRANSFER_DIRECTION_UNSPECIFIED are always
+    // included regardless of this filter, because live in-round rows can be
+    // useful before the daemon has enough local input/output ownership data to
+    // classify direction.
+    TransferDirection direction_filter = 2;
+
+    // status_filter restricts results to one coarse transfer status when set.
+    TransferStatus status_filter = 3;
+
+    // limit bounds the number of status rows returned. Zero uses the daemon
+    // default. Values above the daemon maximum are silently capped to that
+    // maximum.
+    uint32 limit = 4;
+
+    // offset skips this many rows after filtering and newest-first sorting.
+    uint32 offset = 5;
+}
+
+message ListTransfersResponse {
+    // transfers are returned newest first by their best known update time.
+    // Unknown-direction rows may be present even when the request sets a
+    // direction filter; see ListTransfersRequest.direction_filter. Callers
+    // should not rely on this pass-through as exclusive-filter semantics; it
+    // may narrow once live rows always carry direction hints.
+    repeated TransferInfo transfers = 1;
 
     // next_offset is the offset to pass to the next request when has_more is
     // true.

--- a/daemonrpc/daemon_grpc.pb.go
+++ b/daemonrpc/daemon_grpc.pb.go
@@ -27,6 +27,7 @@ const (
 	DaemonService_ListVTXOs_FullMethodName                     = "/daemonrpc.DaemonService/ListVTXOs"
 	DaemonService_NewAddress_FullMethodName                    = "/daemonrpc.DaemonService/NewAddress"
 	DaemonService_NewReceiveScript_FullMethodName              = "/daemonrpc.DaemonService/NewReceiveScript"
+	DaemonService_ListReceiveScripts_FullMethodName            = "/daemonrpc.DaemonService/ListReceiveScripts"
 	DaemonService_ReceiveAuthKey_FullMethodName                = "/daemonrpc.DaemonService/ReceiveAuthKey"
 	DaemonService_SignReceiveAuthMessage_FullMethodName        = "/daemonrpc.DaemonService/SignReceiveAuthMessage"
 	DaemonService_SignReceiveAuthMessageCompact_FullMethodName = "/daemonrpc.DaemonService/SignReceiveAuthMessageCompact"
@@ -48,6 +49,7 @@ const (
 	DaemonService_EstimateFee_FullMethodName                   = "/daemonrpc.DaemonService/EstimateFee"
 	DaemonService_GetFeeHistory_FullMethodName                 = "/daemonrpc.DaemonService/GetFeeHistory"
 	DaemonService_ListTransactions_FullMethodName              = "/daemonrpc.DaemonService/ListTransactions"
+	DaemonService_ListTransfers_FullMethodName                 = "/daemonrpc.DaemonService/ListTransfers"
 	DaemonService_Unroll_FullMethodName                        = "/daemonrpc.DaemonService/Unroll"
 	DaemonService_GetUnrollStatus_FullMethodName               = "/daemonrpc.DaemonService/GetUnrollStatus"
 )
@@ -90,6 +92,9 @@ type DaemonServiceClient interface {
 	// matching taproot receive script with the indexer, and returns the
 	// script details needed to hand the destination to a sender.
 	NewReceiveScript(ctx context.Context, in *NewReceiveScriptRequest, opts ...grpc.CallOption) (*NewReceiveScriptResponse, error)
+	// ListReceiveScripts lists receive targets currently registered for this
+	// wallet's mailbox principal.
+	ListReceiveScripts(ctx context.Context, in *ListReceiveScriptsRequest, opts ...grpc.CallOption) (*ListReceiveScriptsResponse, error)
 	// ReceiveAuthKey returns the per-payment receive-auth public key.
 	ReceiveAuthKey(ctx context.Context, in *ReceiveAuthKeyRequest, opts ...grpc.CallOption) (*ReceiveAuthKeyResponse, error)
 	// SignReceiveAuthMessage signs one message with the per-payment
@@ -161,6 +166,9 @@ type DaemonServiceClient interface {
 	// ListTransactions returns a paginated transaction history from
 	// the client's local accounting and sweep databases.
 	ListTransactions(ctx context.Context, in *ListTransactionsRequest, opts ...grpc.CallOption) (*ListTransactionsResponse, error)
+	// ListTransfers returns a user-facing transfer status view stitched
+	// together from local round state, OOR sessions, and transaction history.
+	ListTransfers(ctx context.Context, in *ListTransfersRequest, opts ...grpc.CallOption) (*ListTransfersResponse, error)
 	// Unroll triggers a unilateral exit for the specified VTXO outpoint.
 	// The daemon will assemble the recovery proof, spawn a durable unroll
 	// job, and drive the on-chain recovery process to completion.
@@ -253,6 +261,16 @@ func (c *daemonServiceClient) NewReceiveScript(ctx context.Context, in *NewRecei
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(NewReceiveScriptResponse)
 	err := c.cc.Invoke(ctx, DaemonService_NewReceiveScript_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *daemonServiceClient) ListReceiveScripts(ctx context.Context, in *ListReceiveScriptsRequest, opts ...grpc.CallOption) (*ListReceiveScriptsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListReceiveScriptsResponse)
+	err := c.cc.Invoke(ctx, DaemonService_ListReceiveScripts_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -478,6 +496,16 @@ func (c *daemonServiceClient) ListTransactions(ctx context.Context, in *ListTran
 	return out, nil
 }
 
+func (c *daemonServiceClient) ListTransfers(ctx context.Context, in *ListTransfersRequest, opts ...grpc.CallOption) (*ListTransfersResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListTransfersResponse)
+	err := c.cc.Invoke(ctx, DaemonService_ListTransfers_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *daemonServiceClient) Unroll(ctx context.Context, in *UnrollRequest, opts ...grpc.CallOption) (*UnrollResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(UnrollResponse)
@@ -536,6 +564,9 @@ type DaemonServiceServer interface {
 	// matching taproot receive script with the indexer, and returns the
 	// script details needed to hand the destination to a sender.
 	NewReceiveScript(context.Context, *NewReceiveScriptRequest) (*NewReceiveScriptResponse, error)
+	// ListReceiveScripts lists receive targets currently registered for this
+	// wallet's mailbox principal.
+	ListReceiveScripts(context.Context, *ListReceiveScriptsRequest) (*ListReceiveScriptsResponse, error)
 	// ReceiveAuthKey returns the per-payment receive-auth public key.
 	ReceiveAuthKey(context.Context, *ReceiveAuthKeyRequest) (*ReceiveAuthKeyResponse, error)
 	// SignReceiveAuthMessage signs one message with the per-payment
@@ -607,6 +638,9 @@ type DaemonServiceServer interface {
 	// ListTransactions returns a paginated transaction history from
 	// the client's local accounting and sweep databases.
 	ListTransactions(context.Context, *ListTransactionsRequest) (*ListTransactionsResponse, error)
+	// ListTransfers returns a user-facing transfer status view stitched
+	// together from local round state, OOR sessions, and transaction history.
+	ListTransfers(context.Context, *ListTransfersRequest) (*ListTransfersResponse, error)
 	// Unroll triggers a unilateral exit for the specified VTXO outpoint.
 	// The daemon will assemble the recovery proof, spawn a durable unroll
 	// job, and drive the on-chain recovery process to completion.
@@ -648,6 +682,9 @@ func (UnimplementedDaemonServiceServer) NewAddress(context.Context, *NewAddressR
 }
 func (UnimplementedDaemonServiceServer) NewReceiveScript(context.Context, *NewReceiveScriptRequest) (*NewReceiveScriptResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method NewReceiveScript not implemented")
+}
+func (UnimplementedDaemonServiceServer) ListReceiveScripts(context.Context, *ListReceiveScriptsRequest) (*ListReceiveScriptsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListReceiveScripts not implemented")
 }
 func (UnimplementedDaemonServiceServer) ReceiveAuthKey(context.Context, *ReceiveAuthKeyRequest) (*ReceiveAuthKeyResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ReceiveAuthKey not implemented")
@@ -711,6 +748,9 @@ func (UnimplementedDaemonServiceServer) GetFeeHistory(context.Context, *GetFeeHi
 }
 func (UnimplementedDaemonServiceServer) ListTransactions(context.Context, *ListTransactionsRequest) (*ListTransactionsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ListTransactions not implemented")
+}
+func (UnimplementedDaemonServiceServer) ListTransfers(context.Context, *ListTransfersRequest) (*ListTransfersResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListTransfers not implemented")
 }
 func (UnimplementedDaemonServiceServer) Unroll(context.Context, *UnrollRequest) (*UnrollResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Unroll not implemented")
@@ -879,6 +919,24 @@ func _DaemonService_NewReceiveScript_Handler(srv interface{}, ctx context.Contex
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(DaemonServiceServer).NewReceiveScript(ctx, req.(*NewReceiveScriptRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DaemonService_ListReceiveScripts_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListReceiveScriptsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DaemonServiceServer).ListReceiveScripts(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DaemonService_ListReceiveScripts_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DaemonServiceServer).ListReceiveScripts(ctx, req.(*ListReceiveScriptsRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -1254,6 +1312,24 @@ func _DaemonService_ListTransactions_Handler(srv interface{}, ctx context.Contex
 	return interceptor(ctx, in, info, handler)
 }
 
+func _DaemonService_ListTransfers_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListTransfersRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DaemonServiceServer).ListTransfers(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DaemonService_ListTransfers_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DaemonServiceServer).ListTransfers(ctx, req.(*ListTransfersRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _DaemonService_Unroll_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(UnrollRequest)
 	if err := dec(in); err != nil {
@@ -1328,6 +1404,10 @@ var DaemonService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "NewReceiveScript",
 			Handler:    _DaemonService_NewReceiveScript_Handler,
+		},
+		{
+			MethodName: "ListReceiveScripts",
+			Handler:    _DaemonService_ListReceiveScripts_Handler,
 		},
 		{
 			MethodName: "ReceiveAuthKey",
@@ -1408,6 +1488,10 @@ var DaemonService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ListTransactions",
 			Handler:    _DaemonService_ListTransactions_Handler,
+		},
+		{
+			MethodName: "ListTransfers",
+			Handler:    _DaemonService_ListTransfers_Handler,
 		},
 		{
 			MethodName: "Unroll",

--- a/daemonrpc/daemon_mailboxrpc.pb.go
+++ b/daemonrpc/daemon_mailboxrpc.pb.go
@@ -40,6 +40,8 @@ type DaemonServiceMailboxServer interface {
 	NewAddress(ctx context.Context, req *NewAddressRequest) (*NewAddressResponse, error)
 	// NewReceiveScript handles NewReceiveScript.
 	NewReceiveScript(ctx context.Context, req *NewReceiveScriptRequest) (*NewReceiveScriptResponse, error)
+	// ListReceiveScripts handles ListReceiveScripts.
+	ListReceiveScripts(ctx context.Context, req *ListReceiveScriptsRequest) (*ListReceiveScriptsResponse, error)
 	// ReceiveAuthKey handles ReceiveAuthKey.
 	ReceiveAuthKey(ctx context.Context, req *ReceiveAuthKeyRequest) (*ReceiveAuthKeyResponse, error)
 	// SignReceiveAuthMessage handles SignReceiveAuthMessage.
@@ -82,6 +84,8 @@ type DaemonServiceMailboxServer interface {
 	GetFeeHistory(ctx context.Context, req *GetFeeHistoryRequest) (*GetFeeHistoryResponse, error)
 	// ListTransactions handles ListTransactions.
 	ListTransactions(ctx context.Context, req *ListTransactionsRequest) (*ListTransactionsResponse, error)
+	// ListTransfers handles ListTransfers.
+	ListTransfers(ctx context.Context, req *ListTransfersRequest) (*ListTransfersResponse, error)
 	// Unroll handles Unroll.
 	Unroll(ctx context.Context, req *UnrollRequest) (*UnrollResponse, error)
 	// GetUnrollStatus handles GetUnrollStatus.
@@ -169,6 +173,16 @@ func RegisterDaemonServiceMailboxServer(r rpc.Router, impl DaemonServiceMailboxS
 		}
 
 		return impl.NewReceiveScript(ctx, req)
+	})
+	r.Handle("daemonrpc.DaemonService", "ListReceiveScripts", func() proto.Message {
+		return &ListReceiveScriptsRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*ListReceiveScriptsRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.ListReceiveScripts(ctx, req)
 	})
 	r.Handle("daemonrpc.DaemonService", "ReceiveAuthKey", func() proto.Message {
 		return &ReceiveAuthKeyRequest{}
@@ -380,6 +394,16 @@ func RegisterDaemonServiceMailboxServer(r rpc.Router, impl DaemonServiceMailboxS
 
 		return impl.ListTransactions(ctx, req)
 	})
+	r.Handle("daemonrpc.DaemonService", "ListTransfers", func() proto.Message {
+		return &ListTransfersRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*ListTransfersRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.ListTransfers(ctx, req)
+	})
 	r.Handle("daemonrpc.DaemonService", "Unroll", func() proto.Message {
 		return &UnrollRequest{}
 	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
@@ -579,6 +603,29 @@ func (c *DaemonServiceMailboxClient) NewReceiveScript(ctx context.Context, req *
 	}
 
 	resp := new(NewReceiveScriptResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// ListReceiveScripts calls the ListReceiveScripts RPC.
+func (c *DaemonServiceMailboxClient) ListReceiveScripts(ctx context.Context, req *ListReceiveScriptsRequest, opts ...rpc.RPCOptions) (*ListReceiveScriptsResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "daemonrpc.DaemonService",
+		Method:  "ListReceiveScripts",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(ListReceiveScriptsResponse)
 	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
 		return nil, err
 	}
@@ -1062,6 +1109,29 @@ func (c *DaemonServiceMailboxClient) ListTransactions(ctx context.Context, req *
 	}
 
 	resp := new(ListTransactionsResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// ListTransfers calls the ListTransfers RPC.
+func (c *DaemonServiceMailboxClient) ListTransfers(ctx context.Context, req *ListTransfersRequest, opts ...rpc.RPCOptions) (*ListTransfersResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "daemonrpc.DaemonService",
+		Method:  "ListTransfers",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(ListTransfersResponse)
 	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
 		return nil, err
 	}

--- a/darepod/rpc_oor_receive.go
+++ b/darepod/rpc_oor_receive.go
@@ -80,7 +80,16 @@ func (r *RPCServer) NewReceiveScript(ctx context.Context,
 			"key descriptor")
 	}
 
+	address, err := addressFromTaprootPkScript(
+		pkScript, r.server.chainParams,
+	)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "unable to format "+
+			"receive address: %v", err)
+	}
+
 	return &daemonrpc.NewReceiveScriptResponse{
+		Address:     address,
 		PkScriptHex: hex.EncodeToString(pkScript),
 		PubkeyXonlyHex: hex.EncodeToString(
 			schnorr.SerializePubKey(keyDesc.PubKey),

--- a/darepod/rpc_receive_targets.go
+++ b/darepod/rpc_receive_targets.go
@@ -1,0 +1,108 @@
+package darepod
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/lightninglabs/darepo-client/arkrpc"
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// ListReceiveScripts returns active receive targets registered to this
+// wallet's mailbox principal.
+func (r *RPCServer) ListReceiveScripts(ctx context.Context,
+	req *daemonrpc.ListReceiveScriptsRequest) (
+	*daemonrpc.ListReceiveScriptsResponse, error) {
+
+	if err := r.requireWalletReady(); err != nil {
+		return nil, err
+	}
+
+	if r.server.indexer == nil {
+		return nil, status.Error(
+			codes.FailedPrecondition,
+			"indexer client not initialized",
+		)
+	}
+
+	resp, err := r.server.indexer.ListMyReceiveScripts(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unavailable, "unable to list "+
+			"receive scripts: %v", err)
+	}
+
+	// Receive-script registrations are expected to remain small for the
+	// local-wallet CLI flows this RPC currently serves.
+	// TODO(ListReceiveScripts pagination): Add limit/cursor support if
+	// these registrations become long-lived enough to grow without bound.
+	targets := make([]*daemonrpc.ReceiveTarget, 0, len(resp.GetScripts()))
+	for _, script := range resp.GetScripts() {
+		target, err := receiveTargetFromRegisteredScript(
+			script, r.server.chainParams,
+		)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "unable to "+
+				"format receive target: %v", err)
+		}
+
+		targets = append(targets, target)
+	}
+
+	return &daemonrpc.ListReceiveScriptsResponse{
+		Targets: targets,
+	}, nil
+}
+
+// receiveTargetFromRegisteredScript converts an indexer receive-script
+// registration into the daemon's user-facing receive target type.
+func receiveTargetFromRegisteredScript(script *arkrpc.RegisteredReceiveScript,
+	params *chaincfg.Params) (*daemonrpc.ReceiveTarget, error) {
+
+	if script == nil {
+		return nil, fmt.Errorf("receive script is nil")
+	}
+
+	address, err := addressFromTaprootPkScript(script.GetPkScript(), params)
+	if err != nil {
+		return nil, err
+	}
+
+	return &daemonrpc.ReceiveTarget{
+		Address:        address,
+		PkScriptHex:    hex.EncodeToString(script.GetPkScript()),
+		Label:          script.GetLabel(),
+		ExpiresAtUnixS: script.GetExpiresAtUnixS(),
+	}, nil
+}
+
+// addressFromTaprootPkScript returns the bech32m address committed to by a
+// native v1 taproot pkScript.
+func addressFromTaprootPkScript(pkScript []byte,
+	params *chaincfg.Params) (string, error) {
+
+	if params == nil {
+		return "", fmt.Errorf("chain params are nil")
+	}
+
+	if !txscript.IsPayToTaproot(pkScript) {
+		return "", fmt.Errorf("pk_script is not a native taproot " +
+			"output script")
+	}
+
+	parsedScript, err := txscript.ParsePkScript(pkScript)
+	if err != nil {
+		return "", fmt.Errorf("parse taproot pkScript: %w", err)
+	}
+
+	addr, err := parsedScript.Address(params)
+	if err != nil {
+		return "", fmt.Errorf("derive taproot address: %w", err)
+	}
+
+	return addr.EncodeAddress(), nil
+}

--- a/darepod/rpc_receive_targets_test.go
+++ b/darepod/rpc_receive_targets_test.go
@@ -1,0 +1,108 @@
+package darepod
+
+import (
+	"context"
+	"encoding/hex"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/lightninglabs/darepo-client/arkrpc"
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestListReceiveScriptsRequiresWalletReady verifies the receive-list RPC
+// returns the shared wallet readiness error before touching the indexer.
+func TestListReceiveScriptsRequiresWalletReady(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRPCServer()
+	_, err := r.ListReceiveScripts(
+		context.Background(), &daemonrpc.ListReceiveScriptsRequest{},
+	)
+
+	require.Equal(t, codes.FailedPrecondition, status.Code(err))
+	require.ErrorContains(t, err, "wallet is not ready")
+}
+
+// TestAddressFromTaprootPkScript verifies native taproot scripts are rendered
+// as network-correct bech32m addresses.
+func TestAddressFromTaprootPkScript(t *testing.T) {
+	t.Parallel()
+
+	addr, pkScript := testTaprootReceiveScript(t)
+
+	encoded, err := addressFromTaprootPkScript(
+		pkScript, &chaincfg.TestNet3Params,
+	)
+	require.NoError(t, err)
+	require.Equal(t, addr.EncodeAddress(), encoded)
+}
+
+// TestAddressFromTaprootPkScriptRejectsNonTaproot verifies the receive-target
+// formatter fails closed for scripts that cannot be represented as a v1
+// taproot address.
+func TestAddressFromTaprootPkScriptRejectsNonTaproot(t *testing.T) {
+	t.Parallel()
+
+	_, err := addressFromTaprootPkScript(
+		[]byte{txscript.OP_0}, &chaincfg.TestNet3Params,
+	)
+	require.ErrorContains(t, err, "not a native taproot")
+}
+
+// TestReceiveTargetFromRegisteredScriptRejectsNil verifies defensive receive
+// target formatting rejects missing indexer records before dereferencing them.
+func TestReceiveTargetFromRegisteredScriptRejectsNil(t *testing.T) {
+	t.Parallel()
+
+	_, err := receiveTargetFromRegisteredScript(
+		nil, &chaincfg.TestNet3Params,
+	)
+	require.ErrorContains(t, err, "receive script is nil")
+}
+
+// TestReceiveTargetFromRegisteredScript verifies registered receive-script
+// metadata is preserved while deriving the user-facing address.
+func TestReceiveTargetFromRegisteredScript(t *testing.T) {
+	t.Parallel()
+
+	addr, pkScript := testTaprootReceiveScript(t)
+	target, err := receiveTargetFromRegisteredScript(
+		&arkrpc.RegisteredReceiveScript{
+			PkScript:       pkScript,
+			ExpiresAtUnixS: 123,
+			Label:          "coffee",
+		}, &chaincfg.TestNet3Params,
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, addr.EncodeAddress(), target.GetAddress())
+	require.Equal(t, hex.EncodeToString(pkScript), target.GetPkScriptHex())
+	require.Equal(t, "coffee", target.GetLabel())
+	require.EqualValues(t, 123, target.GetExpiresAtUnixS())
+}
+
+// testTaprootReceiveScript returns a deterministic testnet taproot address and
+// pkScript pair for receive-target tests.
+func testTaprootReceiveScript(t *testing.T) (*btcutil.AddressTaproot, []byte) {
+	t.Helper()
+
+	key, err := hex.DecodeString(
+		"00010203040506070809000102030405060708090001020304050607080" +
+			"90001",
+	)
+	require.NoError(t, err)
+
+	addr, err := btcutil.NewAddressTaproot(key, &chaincfg.TestNet3Params)
+	require.NoError(t, err)
+
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+
+	return addr, pkScript
+}

--- a/darepod/rpc_transfers.go
+++ b/darepod/rpc_transfers.go
@@ -1,0 +1,752 @@
+package darepod
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/lightninglabs/darepo-client/ledger"
+)
+
+const (
+	// defaultListTransfersLimit is used when callers omit a transfer list
+	// limit.
+	defaultListTransfersLimit uint32 = 100
+
+	// maxListTransfersLimit caps transfer list pages so a broad transfer
+	// history request cannot force an unbounded response.
+	maxListTransfersLimit uint32 = 1000
+
+	// maxTransferSourceOffset mirrors the signed SQL offset bound enforced
+	// by ListTransactions when transfer history pagination walks source
+	// pages.
+	maxTransferSourceOffset uint32 = math.MaxInt32
+
+	// transactionHistoryStatusFailed mirrors the persisted transaction
+	// history status copied into
+	// TransactionHistoryEntry.confirmation_status.
+	transactionHistoryStatusFailed = "failed"
+)
+
+// ListTransfers returns a user-facing status view for in-round and OOR
+// transfers known to the daemon.
+func (r *RPCServer) ListTransfers(ctx context.Context,
+	req *daemonrpc.ListTransfersRequest) (*daemonrpc.ListTransfersResponse,
+	error) {
+
+	if err := r.requireWalletReady(); err != nil {
+		return nil, err
+	}
+
+	limit := req.GetLimit()
+	switch {
+	case limit == 0:
+		limit = defaultListTransfersLimit
+
+	case limit > maxListTransfersLimit:
+		limit = maxListTransfersLimit
+	}
+
+	// The limit is applied after collection, filtering, and deduplication
+	// so the returned page is globally newest-first across all sources.
+	transfers, err := r.collectTransfers(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	sortTransfersNewestFirst(transfers)
+
+	start := clampedTransferStart(req.GetOffset(), len(transfers))
+	end := start + int(limit)
+	hasMore := end < len(transfers)
+	if end > len(transfers) {
+		end = len(transfers)
+	}
+
+	resp := &daemonrpc.ListTransfersResponse{
+		Transfers: transfers[start:end],
+		HasMore:   hasMore,
+	}
+	if hasMore {
+		resp.NextOffset = nextTransferOffset(req.GetOffset(), limit)
+	}
+
+	return resp, nil
+}
+
+// collectTransfers gathers transfers from existing status/history stores and
+// applies shared request filters before caller-side sorting and pagination.
+func (r *RPCServer) collectTransfers(ctx context.Context,
+	req *daemonrpc.ListTransfersRequest) ([]*daemonrpc.TransferInfo,
+	error) {
+
+	var transfers []*daemonrpc.TransferInfo
+
+	if transferModeAllowed(
+		req, daemonrpc.TransferMode_TRANSFER_MODE_INROUND,
+	) {
+
+		if transferStatusAllowed(
+			req, daemonrpc.TransferStatus_TRANSFER_STATUS_PENDING,
+		) {
+
+			// Round status and ledger history are separate
+			// snapshots. A round that completes between reads can
+			// briefly appear once as a pending round row and once
+			// as a committed history row; the source-prefixed
+			// transfer ids keep those rows distinguishable.
+			pending, err := r.pendingRoundTransfers(ctx)
+			if err != nil {
+				return nil, err
+			}
+
+			transfers = append(transfers, pending...)
+		}
+
+		if transferHistoryStatusAllowed(req) {
+			history, err := r.roundHistoryTransfers(ctx)
+			if err != nil {
+				return nil, err
+			}
+
+			transfers = append(transfers, history...)
+		}
+	}
+
+	if transferModeAllowed(req, daemonrpc.TransferMode_TRANSFER_MODE_OOR) {
+		oorTransfers, err := r.oorTransfers(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		transfers = append(transfers, oorTransfers...)
+	}
+
+	// The first implementation intentionally normalizes all matching local
+	// sources in memory before sorting. Source-level mode checks avoid
+	// unnecessary scans, while the final predicate keeps the full filter
+	// logic in one place until the stores grow a shared pagination model.
+	// A future shared transfer store can push limit/filter handling into
+	// the source queries if O(total history) scans become too expensive.
+	filtered := make([]*daemonrpc.TransferInfo, 0, len(transfers))
+	for _, transfer := range transfers {
+		if transferMatchesFilters(transfer, req) {
+			filtered = append(filtered, transfer)
+		}
+	}
+
+	return dedupeTransfers(filtered), nil
+}
+
+// pendingRoundTransfers converts non-terminal round FSM states into pending
+// in-round transfer status rows.
+func (r *RPCServer) pendingRoundTransfers(ctx context.Context) (
+	[]*daemonrpc.TransferInfo, error) {
+
+	liveRounds, err := r.queryRoundStates(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		transfers  []*daemonrpc.TransferInfo
+		roundIndex int
+	)
+	for _, round := range liveRounds {
+		status := transferStatusFromRoundState(round.GetState())
+		if status != daemonrpc.TransferStatus_TRANSFER_STATUS_PENDING {
+			continue
+		}
+
+		transfers = append(
+			transfers, transferFromRound(round, status, roundIndex),
+		)
+		roundIndex++
+	}
+
+	var nextToken string
+	for {
+		// A pending round can exist in both live FSM state and
+		// persisted round summaries. Rows with the same round id are
+		// deduped after filtering; a temporary live row without a round
+		// id can only be kept as a transient extra pending row, which
+		// is preferable to hiding active local round state.
+		// A round that is live and also persisted as pending appears
+		// twice with the same round id; dedupeTransfers keeps the
+		// first row when status and id tie.
+		// TODO(darepo-client#451): Push pending-status filtering into
+		// ListRounds once it supports a proto-level state filter so
+		// broad transfer-list calls do not need to scan every
+		// persisted page. The scan is exhaustive until then so
+		// ListTransfers.HasMore reflects the merged result set rather
+		// than a source-scan cap.
+		roundResp, err := r.ListRounds(
+			ctx, &daemonrpc.ListRoundsRequest{
+				PageSize:      int32(maxListTransfersLimit),
+				PageToken:     nextToken,
+				PersistedOnly: true,
+			},
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, round := range roundResp.GetRounds() {
+			status := transferStatusFromRoundState(round.GetState())
+			if status != daemonrpc.
+				TransferStatus_TRANSFER_STATUS_PENDING {
+
+				// Terminal persisted rounds are shown through
+				// transaction history, which has amount and
+				// ledger context that the round summary does
+				// not carry.
+				continue
+			}
+
+			transfers = append(
+				transfers, transferFromRound(
+					round, status, roundIndex,
+				),
+			)
+			roundIndex++
+		}
+
+		nextToken = roundResp.GetNextPageToken()
+		if nextToken == "" {
+			break
+		}
+	}
+
+	return transfers, nil
+}
+
+// roundHistoryTransfers reads committed round transaction history rows and
+// converts them into transfer status rows.
+func (r *RPCServer) roundHistoryTransfers(ctx context.Context) (
+	[]*daemonrpc.TransferInfo, error) {
+
+	mode := daemonrpc.TransferMode_TRANSFER_MODE_INROUND
+	var transfers []*daemonrpc.TransferInfo
+	for offset := uint32(0); ; {
+		resp, err := r.ListTransactions(
+			ctx, &daemonrpc.ListTransactionsRequest{
+				Limit:  maxListTransfersLimit,
+				Offset: offset,
+				Type:   ledger.TransactionTypeRound,
+			},
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, tx := range resp.GetTransactions() {
+			transfers = append(
+				transfers, transferFromTransaction(tx, mode),
+			)
+		}
+
+		if !resp.GetHasMore() {
+			break
+		}
+
+		nextOffset := resp.GetNextOffset()
+		if nextOffset <= offset ||
+			nextOffset > maxTransferSourceOffset {
+
+			break
+		}
+
+		offset = nextOffset
+	}
+
+	return transfers, nil
+}
+
+// oorTransfers converts locally known OOR sessions into the shared transfer
+// status row type.
+func (r *RPCServer) oorTransfers(ctx context.Context) (
+	[]*daemonrpc.TransferInfo, error) {
+
+	sessions, err := r.listOORSessions(
+		ctx, &daemonrpc.ListOORSessionsRequest{},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	transfers := make([]*daemonrpc.TransferInfo, 0, len(sessions))
+	for _, session := range sessions {
+		transfers = append(transfers, transferFromOORSession(session))
+	}
+
+	return transfers, nil
+}
+
+// transferFromRound converts one round status snapshot into a transfer row.
+func transferFromRound(round *daemonrpc.RoundInfo,
+	status daemonrpc.TransferStatus,
+	roundIndex int) *daemonrpc.TransferInfo {
+
+	mode := daemonrpc.TransferMode_TRANSFER_MODE_INROUND
+	direction := transferDirectionFromRound(round)
+
+	id := round.GetRoundId()
+	if id == "" {
+		id = temporaryRoundTransferID(round, roundIndex)
+	}
+
+	return &daemonrpc.TransferInfo{
+		TransferId:         "round:" + id,
+		Mode:               mode,
+		Direction:          direction,
+		Status:             status,
+		Phase:              round.GetState().String(),
+		RoundId:            round.GetRoundId(),
+		InputOutpoints:     round.GetInputOutpoints(),
+		OutputOutpoints:    round.GetOutputOutpoints(),
+		Txid:               round.GetCommitmentTxid(),
+		ConfirmationHeight: round.GetCommitmentHeight(),
+		CreatedAtUnixS:     round.GetCreationTime(),
+		UpdatedAtUnixS:     round.GetLastUpdateTime(),
+		FailureReason:      round.GetFailureReason(),
+	}
+}
+
+// transferDirectionFromRound infers direction from locally known round
+// outpoints when persisted round summaries expose them. Inputs take priority
+// because a local round is treated as outgoing once it spends local VTXOs; any
+// local outputs in that same summary are change-like context rather than the
+// primary transfer direction.
+func transferDirectionFromRound(
+	round *daemonrpc.RoundInfo) daemonrpc.TransferDirection {
+
+	switch {
+	case len(round.GetInputOutpoints()) > 0:
+		return daemonrpc.TransferDirection_TRANSFER_DIRECTION_OUTGOING
+
+	case len(round.GetOutputOutpoints()) > 0:
+		return daemonrpc.TransferDirection_TRANSFER_DIRECTION_INCOMING
+
+	default:
+		// Live in-memory rounds currently expose phase, but not the
+		// local input/output ownership needed to classify direction.
+		return daemonrpc.
+			TransferDirection_TRANSFER_DIRECTION_UNSPECIFIED
+	}
+}
+
+// temporaryRoundTransferID builds a best-effort response-local identifier for
+// live round states that have not yet received a server-assigned round id.
+// These temporary ids are not stable across daemon restarts.
+func temporaryRoundTransferID(round *daemonrpc.RoundInfo,
+	roundIndex int) string {
+
+	parts := []string{
+		fmt.Sprintf("is_temp:%v", round.GetIsTemp()),
+		round.GetState().String(),
+		fmt.Sprintf("created:%d", round.GetCreationTime()),
+		fmt.Sprintf("updated:%d", round.GetLastUpdateTime()),
+		"tx:" + round.GetCommitmentTxid(),
+		"in:" + strings.Join(round.GetInputOutpoints(), ","),
+		"out:" + strings.Join(round.GetOutputOutpoints(), ","),
+	}
+
+	digest := sha256.Sum256([]byte(strings.Join(parts, "\x00")))
+
+	return fmt.Sprintf("is_temp:%v:%x:index:%d", round.GetIsTemp(),
+		digest[:8], roundIndex)
+}
+
+// transferFromTransaction converts one committed transaction history row into
+// a transfer row.
+func transferFromTransaction(tx *daemonrpc.TransactionHistoryEntry,
+	mode daemonrpc.TransferMode) *daemonrpc.TransferInfo {
+
+	return &daemonrpc.TransferInfo{
+		TransferId:         transactionTransferID(tx, mode),
+		Mode:               mode,
+		Direction:          transferDirectionFromTransaction(tx),
+		Status:             transferStatusFromTransaction(tx),
+		Phase:              tx.GetSubtype(),
+		AmountSat:          tx.GetAmountSat(),
+		RoundId:            hex.EncodeToString(tx.GetRoundId()),
+		SessionId:          hex.EncodeToString(tx.GetSessionId()),
+		Txid:               tx.GetTxid(),
+		ConfirmationHeight: tx.GetConfirmationHeight(),
+		CreatedAtUnixS:     tx.GetCreatedAtUnixS(),
+		// Transaction history rows are immutable, so created time is
+		// also the best available update time for sorting.
+		UpdatedAtUnixS: tx.GetCreatedAtUnixS(),
+	}
+}
+
+// transferStatusFromTransaction infers coarse transfer status from
+// transaction-history lifecycle fields.
+func transferStatusFromTransaction(
+	tx *daemonrpc.TransactionHistoryEntry) daemonrpc.TransferStatus {
+
+	status := strings.ToLower(tx.GetConfirmationStatus())
+	if status == transactionHistoryStatusFailed {
+		return daemonrpc.TransferStatus_TRANSFER_STATUS_FAILED
+	}
+
+	// Ledger-backed round transaction history currently records successful
+	// VTXO movement as typed ledger events. Failed transfer lifecycle is
+	// represented by confirmation_status rather than fuzzy subtype names.
+	return daemonrpc.TransferStatus_TRANSFER_STATUS_COMPLETED
+}
+
+// transferFromOORSession converts one OOR session status into a transfer row.
+func transferFromOORSession(
+	session *daemonrpc.OORSessionInfo) *daemonrpc.TransferInfo {
+
+	return &daemonrpc.TransferInfo{
+		TransferId: "oor:" + session.GetSessionId(),
+		Mode:       daemonrpc.TransferMode_TRANSFER_MODE_OOR,
+		Direction: transferDirectionFromOOR(
+			session.GetDirection(),
+		),
+		Status: transferStatusFromOOR(session.GetStatus()),
+		Phase:  session.GetPhase(),
+		// TODO: Populate AmountSat when OORSessionInfo or a
+		// history-backed merge exposes the package amount. The live OOR
+		// session source currently carries outpoints and status, but
+		// not the value moved by the transfer.
+		SessionId:       session.GetSessionId(),
+		InputOutpoints:  session.GetConsumedOutpoints(),
+		OutputOutpoints: session.GetCreatedOutpoints(),
+		CreatedAtUnixS:  session.GetCreatedAt(),
+		UpdatedAtUnixS:  session.GetUpdatedAt(),
+		FailureReason:   session.GetFailureReason(),
+	}
+}
+
+// transactionTransferID builds a stable local identifier for transaction
+// history rows surfaced as transfer entries.
+func transactionTransferID(tx *daemonrpc.TransactionHistoryEntry,
+	mode daemonrpc.TransferMode) string {
+
+	switch mode {
+	case daemonrpc.TransferMode_TRANSFER_MODE_INROUND:
+		roundID := hex.EncodeToString(tx.GetRoundId())
+		if roundID != "" {
+			return fmt.Sprintf("round:%s:%d", roundID,
+				tx.GetEntryId())
+		}
+
+	case daemonrpc.TransferMode_TRANSFER_MODE_OOR:
+		sessionID := hex.EncodeToString(tx.GetSessionId())
+		if sessionID != "" {
+			return fmt.Sprintf("oor:%s:%d", sessionID,
+				tx.GetEntryId())
+		}
+
+	default:
+		// Defensive fallback for future callers that pass a history row
+		// without first choosing an in-round or OOR transfer mode. The
+		// ledger prefix keeps that caller error visible in the response
+		// identifier without making this pure conversion helper log.
+	}
+
+	return fmt.Sprintf("ledger:%d", tx.GetEntryId())
+}
+
+// transferDirectionFromTransaction infers local direction from ledger event
+// names and accounts.
+func transferDirectionFromTransaction(
+	tx *daemonrpc.TransactionHistoryEntry) daemonrpc.TransferDirection {
+
+	// These constants are the ledger package's canonical labels for the
+	// VTXO transfer events and accounts emitted into transaction history.
+	switch tx.GetSubtype() {
+	case ledger.EventVTXOReceived:
+		return daemonrpc.TransferDirection_TRANSFER_DIRECTION_INCOMING
+
+	case ledger.EventVTXOSent:
+		return daemonrpc.TransferDirection_TRANSFER_DIRECTION_OUTGOING
+	}
+
+	if tx.GetCreditAccount() == ledger.AccountTransfersIn {
+		return daemonrpc.TransferDirection_TRANSFER_DIRECTION_INCOMING
+	}
+
+	if tx.GetDebitAccount() == ledger.AccountTransfersOut {
+		return daemonrpc.TransferDirection_TRANSFER_DIRECTION_OUTGOING
+	}
+
+	return daemonrpc.
+		TransferDirection_TRANSFER_DIRECTION_UNSPECIFIED
+}
+
+// transferDirectionFromOOR converts an OOR direction enum into the shared
+// transfer direction enum.
+func transferDirectionFromOOR(
+	direction daemonrpc.OORSessionDirection) daemonrpc.TransferDirection {
+
+	switch direction {
+	case daemonrpc.OORSessionDirection_OOR_SESSION_DIRECTION_INCOMING:
+		return daemonrpc.TransferDirection_TRANSFER_DIRECTION_INCOMING
+
+	case daemonrpc.OORSessionDirection_OOR_SESSION_DIRECTION_OUTGOING:
+		return daemonrpc.TransferDirection_TRANSFER_DIRECTION_OUTGOING
+
+	default:
+		return daemonrpc.
+			TransferDirection_TRANSFER_DIRECTION_UNSPECIFIED
+	}
+}
+
+// transferStatusFromOOR converts an OOR status enum into the shared transfer
+// status enum.
+func transferStatusFromOOR(
+	status daemonrpc.OORSessionStatus) daemonrpc.TransferStatus {
+
+	switch status {
+	case daemonrpc.OORSessionStatus_OOR_SESSION_STATUS_PENDING:
+		return daemonrpc.TransferStatus_TRANSFER_STATUS_PENDING
+
+	case daemonrpc.OORSessionStatus_OOR_SESSION_STATUS_FAILED:
+		return daemonrpc.TransferStatus_TRANSFER_STATUS_FAILED
+
+	case daemonrpc.OORSessionStatus_OOR_SESSION_STATUS_COMPLETED:
+		return daemonrpc.TransferStatus_TRANSFER_STATUS_COMPLETED
+
+	default:
+		// Preserve forward compatibility: new OOR statuses surface as
+		// unspecified until this projection learns their terminality.
+		return daemonrpc.TransferStatus_TRANSFER_STATUS_UNSPECIFIED
+	}
+}
+
+// transferStatusFromRoundState converts a round FSM state into the shared
+// transfer status enum.
+func transferStatusFromRoundState(
+	state daemonrpc.RoundState) daemonrpc.TransferStatus {
+
+	switch state {
+	case daemonrpc.RoundState_ROUND_STATE_CONFIRMED:
+		return daemonrpc.TransferStatus_TRANSFER_STATUS_COMPLETED
+
+	case daemonrpc.RoundState_ROUND_STATE_FAILED:
+		return daemonrpc.TransferStatus_TRANSFER_STATUS_FAILED
+
+	default:
+		return daemonrpc.TransferStatus_TRANSFER_STATUS_PENDING
+	}
+}
+
+// transferModeAllowed reports whether a source with mode should be included
+// for the request's mode filter.
+func transferModeAllowed(req *daemonrpc.ListTransfersRequest,
+	mode daemonrpc.TransferMode) bool {
+
+	return req.GetModeFilter() ==
+		daemonrpc.TransferMode_TRANSFER_MODE_UNSPECIFIED ||
+		req.GetModeFilter() == mode
+}
+
+// transferStatusAllowed reports whether a source with status should be
+// included for the request's status filter.
+func transferStatusAllowed(req *daemonrpc.ListTransfersRequest,
+	status daemonrpc.TransferStatus) bool {
+
+	return req.GetStatusFilter() ==
+		daemonrpc.TransferStatus_TRANSFER_STATUS_UNSPECIFIED ||
+		req.GetStatusFilter() == status
+}
+
+// transferHistoryStatusAllowed reports whether committed history rows can
+// match the request's status filter.
+func transferHistoryStatusAllowed(req *daemonrpc.ListTransfersRequest) bool {
+	return transferStatusAllowed(
+		req, daemonrpc.TransferStatus_TRANSFER_STATUS_COMPLETED,
+	) || transferStatusAllowed(
+		req, daemonrpc.TransferStatus_TRANSFER_STATUS_FAILED,
+	)
+}
+
+// transferMatchesFilters reports whether a transfer survives the request's
+// mode, direction, and status filters.
+func transferMatchesFilters(transfer *daemonrpc.TransferInfo,
+	req *daemonrpc.ListTransfersRequest) bool {
+
+	if transfer == nil {
+		return false
+	}
+
+	if req.GetModeFilter() !=
+		daemonrpc.TransferMode_TRANSFER_MODE_UNSPECIFIED &&
+		transfer.GetMode() != req.GetModeFilter() {
+		return false
+	}
+
+	if req.GetDirectionFilter() !=
+		daemonrpc.TransferDirection_TRANSFER_DIRECTION_UNSPECIFIED &&
+		!transferDirectionMatchesFilter(
+			transfer.GetDirection(), req.GetDirectionFilter(),
+		) {
+		return false
+	}
+
+	if req.GetStatusFilter() !=
+		daemonrpc.TransferStatus_TRANSFER_STATUS_UNSPECIFIED &&
+		transfer.GetStatus() != req.GetStatusFilter() {
+		return false
+	}
+
+	return true
+}
+
+// transferDirectionMatchesFilter reports whether a known or unknown transfer
+// direction should survive a requested direction filter.
+func transferDirectionMatchesFilter(
+	direction, filter daemonrpc.TransferDirection) bool {
+
+	if direction == daemonrpc.
+		TransferDirection_TRANSFER_DIRECTION_UNSPECIFIED {
+
+		// Live in-round rows can be useful even before the local
+		// input/output hints needed for direction classification exist.
+		return true
+	}
+
+	return direction == filter
+}
+
+// dedupeTransfers collapses rows that describe the same logical transfer
+// across live status and committed transaction-history snapshots.
+func dedupeTransfers(
+	transfers []*daemonrpc.TransferInfo) []*daemonrpc.TransferInfo {
+
+	// TODO(darepo-client#451): If OOR transfer history rows are added,
+	// dedupe OOR transfers by session id in the same pass.
+	roundIndexes := make(map[string]int)
+	deduped := make([]*daemonrpc.TransferInfo, 0, len(transfers))
+	for _, transfer := range transfers {
+		roundID := transfer.GetRoundId()
+		if transfer.GetMode() !=
+			daemonrpc.TransferMode_TRANSFER_MODE_INROUND ||
+			roundID == "" {
+
+			deduped = append(deduped, transfer)
+			continue
+		}
+
+		index, ok := roundIndexes[roundID]
+		if !ok {
+			roundIndexes[roundID] = len(deduped)
+			deduped = append(deduped, transfer)
+			continue
+		}
+
+		if transferSupersedesRoundDuplicate(transfer, deduped[index]) {
+			deduped[index] = transfer
+		}
+	}
+
+	return deduped
+}
+
+// transferSupersedesRoundDuplicate reports whether a later duplicate round
+// row carries more authoritative status or timing information.
+func transferSupersedesRoundDuplicate(
+	candidate, current *daemonrpc.TransferInfo) bool {
+
+	candidateStatus := candidate.GetStatus()
+	currentStatus := current.GetStatus()
+	pending := daemonrpc.TransferStatus_TRANSFER_STATUS_PENDING
+	if currentStatus == pending && candidateStatus != pending {
+		return true
+	}
+
+	if currentStatus != pending && candidateStatus == pending {
+		return false
+	}
+
+	candidateTime := transferSortTime(candidate)
+	currentTime := transferSortTime(current)
+	if candidateTime != currentTime {
+		return candidateTime > currentTime
+	}
+
+	candidateEntryID, candidateOK := roundHistoryEntryID(candidate)
+	currentEntryID, currentOK := roundHistoryEntryID(current)
+	if candidateOK && currentOK && candidateEntryID != currentEntryID {
+		return candidateEntryID > currentEntryID
+	}
+
+	// Fall back to the full id for temporary or future row formats that do
+	// not carry a parseable numeric ledger suffix.
+	return candidate.GetTransferId() > current.GetTransferId()
+}
+
+// roundHistoryEntryID extracts the numeric ledger entry suffix from a
+// history-backed in-round transfer id.
+func roundHistoryEntryID(transfer *daemonrpc.TransferInfo) (int64, bool) {
+	id, ok := strings.CutPrefix(transfer.GetTransferId(), "round:")
+	if !ok {
+		return 0, false
+	}
+
+	_, suffix, ok := strings.Cut(id, ":")
+	if !ok {
+		return 0, false
+	}
+
+	entryID, err := strconv.ParseInt(suffix, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+
+	return entryID, true
+}
+
+// clampedTransferStart converts a uint32 transfer-list offset into a safe
+// slice start index without overflowing int on 32-bit platforms.
+func clampedTransferStart(offset uint32, transferCount int) int {
+	if uint64(offset) > uint64(transferCount) {
+		return transferCount
+	}
+
+	return int(offset)
+}
+
+// nextTransferOffset advances a transfer-list offset, capping on uint32
+// overflow so a response never wraps the pagination cursor.
+func nextTransferOffset(offset, limit uint32) uint32 {
+	if ^uint32(0)-offset < limit {
+		return ^uint32(0)
+	}
+
+	return offset + limit
+}
+
+// sortTransfersNewestFirst orders transfer rows by their best known update
+// time, breaking ties by stable transfer id.
+func sortTransfersNewestFirst(transfers []*daemonrpc.TransferInfo) {
+	sort.SliceStable(transfers, func(i, j int) bool {
+		left := transferSortTime(transfers[i])
+		right := transferSortTime(transfers[j])
+		if left == right {
+			return transfers[i].GetTransferId() >
+				transfers[j].GetTransferId()
+		}
+
+		return left > right
+	})
+}
+
+// transferSortTime returns the timestamp used for newest-first ordering.
+func transferSortTime(transfer *daemonrpc.TransferInfo) int64 {
+	if transfer.GetUpdatedAtUnixS() != 0 {
+		return transfer.GetUpdatedAtUnixS()
+	}
+
+	return transfer.GetCreatedAtUnixS()
+}

--- a/darepod/rpc_transfers_test.go
+++ b/darepod/rpc_transfers_test.go
@@ -1,0 +1,546 @@
+package darepod
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/lightninglabs/darepo-client/ledger"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestListTransfersRequiresWalletReady verifies the transfer-list RPC returns
+// the shared wallet readiness error before scanning status/history sources.
+func TestListTransfersRequiresWalletReady(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRPCServer()
+	_, err := r.ListTransfers(
+		context.Background(), &daemonrpc.ListTransfersRequest{},
+	)
+
+	require.Equal(t, codes.FailedPrecondition, status.Code(err))
+	require.ErrorContains(t, err, "wallet is not ready")
+}
+
+// TestTransferDirectionFromTransaction verifies ledger-backed transfer rows
+// are classified from the local wallet's perspective.
+func TestTransferDirectionFromTransaction(t *testing.T) {
+	t.Parallel()
+
+	unspecified := daemonrpc.
+		TransferDirection_TRANSFER_DIRECTION_UNSPECIFIED
+
+	tests := []struct {
+		name     string
+		tx       *daemonrpc.TransactionHistoryEntry
+		expected daemonrpc.TransferDirection
+	}{
+		{
+			name: "received subtype",
+			tx: &daemonrpc.TransactionHistoryEntry{
+				Subtype: ledger.EventVTXOReceived,
+			},
+			expected: daemonrpc.
+				TransferDirection_TRANSFER_DIRECTION_INCOMING,
+		},
+		{
+			name: "sent subtype",
+			tx: &daemonrpc.TransactionHistoryEntry{
+				Subtype: ledger.EventVTXOSent,
+			},
+			expected: daemonrpc.
+				TransferDirection_TRANSFER_DIRECTION_OUTGOING,
+		},
+		{
+			name: "transfers in account",
+			tx: &daemonrpc.TransactionHistoryEntry{
+				CreditAccount: ledger.AccountTransfersIn,
+			},
+			expected: daemonrpc.
+				TransferDirection_TRANSFER_DIRECTION_INCOMING,
+		},
+		{
+			name: "transfers out account",
+			tx: &daemonrpc.TransactionHistoryEntry{
+				DebitAccount: ledger.AccountTransfersOut,
+			},
+			expected: daemonrpc.
+				TransferDirection_TRANSFER_DIRECTION_OUTGOING,
+		},
+		{
+			name: "subtype wins over account",
+			tx: &daemonrpc.TransactionHistoryEntry{
+				Subtype:      ledger.EventVTXOReceived,
+				DebitAccount: ledger.AccountTransfersOut,
+			},
+			expected: daemonrpc.
+				TransferDirection_TRANSFER_DIRECTION_INCOMING,
+		},
+		{
+			name:     "unknown",
+			tx:       &daemonrpc.TransactionHistoryEntry{},
+			expected: unspecified,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(
+				t, test.expected,
+				transferDirectionFromTransaction(test.tx),
+			)
+		})
+	}
+}
+
+// TestTransferStatusFromTransaction verifies persisted transaction history rows
+// map to the public coarse transfer status enum.
+func TestTransferStatusFromTransaction(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		tx       *daemonrpc.TransactionHistoryEntry
+		expected daemonrpc.TransferStatus
+	}{
+		{
+			name: "recorded row",
+			tx: &daemonrpc.TransactionHistoryEntry{
+				ConfirmationStatus: "recorded",
+			},
+			expected: daemonrpc.
+				TransferStatus_TRANSFER_STATUS_COMPLETED,
+		},
+		{
+			name: "failed status",
+			tx: &daemonrpc.TransactionHistoryEntry{
+				ConfirmationStatus: "failed",
+			},
+			expected: daemonrpc.
+				TransferStatus_TRANSFER_STATUS_FAILED,
+		},
+		{
+			name: "failed word in subtype",
+			tx: &daemonrpc.TransactionHistoryEntry{
+				Subtype: "pre_failed_state_reset",
+			},
+			expected: daemonrpc.
+				TransferStatus_TRANSFER_STATUS_COMPLETED,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(
+				t, test.expected,
+				transferStatusFromTransaction(test.tx),
+			)
+		})
+	}
+}
+
+// TestTransferDirectionFromRound verifies pending round rows use local
+// outpoint ownership hints when the round summary exposes them.
+func TestTransferDirectionFromRound(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(
+		t, daemonrpc.TransferDirection_TRANSFER_DIRECTION_OUTGOING,
+		transferDirectionFromRound(
+			&daemonrpc.RoundInfo{
+				InputOutpoints: []string{"aaa:0"},
+			},
+		),
+	)
+	require.Equal(
+		t, daemonrpc.TransferDirection_TRANSFER_DIRECTION_INCOMING,
+		transferDirectionFromRound(
+			&daemonrpc.RoundInfo{
+				OutputOutpoints: []string{"bbb:1"},
+			},
+		),
+	)
+	require.Equal(
+		t, daemonrpc.TransferDirection_TRANSFER_DIRECTION_UNSPECIFIED,
+		transferDirectionFromRound(
+			&daemonrpc.RoundInfo{},
+		),
+	)
+}
+
+// TestTransferMatchesFilters verifies mode, direction, and status filters are
+// all enforced by the shared transfer list predicate.
+func TestTransferMatchesFilters(t *testing.T) {
+	t.Parallel()
+
+	incoming := daemonrpc.TransferDirection_TRANSFER_DIRECTION_INCOMING
+	outgoing := daemonrpc.TransferDirection_TRANSFER_DIRECTION_OUTGOING
+	unknownDirection := daemonrpc.
+		TransferDirection_TRANSFER_DIRECTION_UNSPECIFIED
+	completed := daemonrpc.TransferStatus_TRANSFER_STATUS_COMPLETED
+	failed := daemonrpc.TransferStatus_TRANSFER_STATUS_FAILED
+	inround := daemonrpc.TransferMode_TRANSFER_MODE_INROUND
+	oor := daemonrpc.TransferMode_TRANSFER_MODE_OOR
+
+	transfer := &daemonrpc.TransferInfo{
+		Mode:      inround,
+		Direction: incoming,
+		Status:    completed,
+	}
+
+	require.True(
+		t,
+		transferMatchesFilters(
+			transfer, &daemonrpc.ListTransfersRequest{},
+		),
+	)
+	require.True(
+		t,
+		transferMatchesFilters(
+			transfer, &daemonrpc.ListTransfersRequest{
+				ModeFilter:      inround,
+				DirectionFilter: incoming,
+				StatusFilter:    completed,
+			},
+		),
+	)
+	require.False(
+		t,
+		transferMatchesFilters(
+			transfer, &daemonrpc.ListTransfersRequest{
+				DirectionFilter: outgoing,
+			},
+		),
+	)
+	require.False(
+		t,
+		transferMatchesFilters(
+			nil, &daemonrpc.ListTransfersRequest{},
+		),
+	)
+	require.False(
+		t,
+		transferMatchesFilters(
+			transfer, &daemonrpc.ListTransfersRequest{
+				ModeFilter: oor,
+			},
+		),
+	)
+	require.False(
+		t,
+		transferMatchesFilters(
+			transfer, &daemonrpc.ListTransfersRequest{
+				StatusFilter: failed,
+			},
+		),
+	)
+	require.True(
+		t,
+		transferMatchesFilters(
+			&daemonrpc.TransferInfo{
+				Mode:      inround,
+				Direction: unknownDirection,
+				Status:    completed,
+			}, &daemonrpc.ListTransfersRequest{
+				DirectionFilter: outgoing,
+			},
+		),
+	)
+}
+
+// TestTransferStatusFromRoundState verifies round FSM states map onto the
+// coarse transfer status enum.
+func TestTransferStatusFromRoundState(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(
+		t, daemonrpc.TransferStatus_TRANSFER_STATUS_COMPLETED,
+		transferStatusFromRoundState(
+			daemonrpc.RoundState_ROUND_STATE_CONFIRMED,
+		),
+	)
+	require.Equal(
+		t, daemonrpc.TransferStatus_TRANSFER_STATUS_FAILED,
+		transferStatusFromRoundState(
+			daemonrpc.RoundState_ROUND_STATE_FAILED,
+		),
+	)
+	require.Equal(
+		t, daemonrpc.TransferStatus_TRANSFER_STATUS_PENDING,
+		transferStatusFromRoundState(
+			daemonrpc.RoundState_ROUND_STATE_UNKNOWN,
+		),
+	)
+}
+
+// TestDedupeTransfers verifies terminal history rows replace pending
+// round-status rows for the same persisted round id.
+func TestDedupeTransfers(t *testing.T) {
+	t.Parallel()
+
+	inround := daemonrpc.TransferMode_TRANSFER_MODE_INROUND
+	pending := daemonrpc.TransferStatus_TRANSFER_STATUS_PENDING
+	completed := daemonrpc.TransferStatus_TRANSFER_STATUS_COMPLETED
+
+	transfers := []*daemonrpc.TransferInfo{
+		{
+			TransferId:     "round:abc",
+			Mode:           inround,
+			Status:         pending,
+			RoundId:        "abc",
+			UpdatedAtUnixS: 20,
+		},
+		{
+			TransferId:     "round:abc:7",
+			Mode:           inround,
+			Status:         completed,
+			RoundId:        "abc",
+			UpdatedAtUnixS: 10,
+		},
+		{
+			TransferId:     "round:abc:10",
+			Mode:           inround,
+			Status:         completed,
+			RoundId:        "abc",
+			UpdatedAtUnixS: 10,
+		},
+		{
+			TransferId: "round:",
+			Mode:       inround,
+			Status:     pending,
+		},
+	}
+
+	deduped := dedupeTransfers(transfers)
+
+	require.Len(t, deduped, 2)
+	require.Equal(t, "round:abc:10", deduped[0].GetTransferId())
+	require.Equal(t, "round:", deduped[1].GetTransferId())
+}
+
+// TestTransferHistoryStatusAllowed verifies pending-only requests can skip
+// committed round history scans.
+func TestTransferHistoryStatusAllowed(t *testing.T) {
+	t.Parallel()
+
+	completed := daemonrpc.TransferStatus_TRANSFER_STATUS_COMPLETED
+	failed := daemonrpc.TransferStatus_TRANSFER_STATUS_FAILED
+	pending := daemonrpc.TransferStatus_TRANSFER_STATUS_PENDING
+
+	require.True(
+		t,
+		transferHistoryStatusAllowed(
+			&daemonrpc.ListTransfersRequest{},
+		),
+	)
+	require.True(
+		t,
+		transferHistoryStatusAllowed(
+			&daemonrpc.ListTransfersRequest{
+				StatusFilter: completed,
+			},
+		),
+	)
+	require.True(
+		t,
+		transferHistoryStatusAllowed(
+			&daemonrpc.ListTransfersRequest{
+				StatusFilter: failed,
+			},
+		),
+	)
+	require.False(
+		t,
+		transferHistoryStatusAllowed(
+			&daemonrpc.ListTransfersRequest{
+				StatusFilter: pending,
+			},
+		),
+	)
+}
+
+// TestTransferSupersedesRoundDuplicate verifies duplicate round rows prefer
+// terminal history and then the newest numeric history entry id.
+func TestTransferSupersedesRoundDuplicate(t *testing.T) {
+	t.Parallel()
+
+	inround := daemonrpc.TransferMode_TRANSFER_MODE_INROUND
+	pending := daemonrpc.TransferStatus_TRANSFER_STATUS_PENDING
+	completed := daemonrpc.TransferStatus_TRANSFER_STATUS_COMPLETED
+
+	pendingRound := &daemonrpc.TransferInfo{
+		TransferId:     "round:abc",
+		Mode:           inround,
+		Status:         pending,
+		RoundId:        "abc",
+		UpdatedAtUnixS: 20,
+	}
+	completedRound := &daemonrpc.TransferInfo{
+		TransferId:     "round:abc:7",
+		Mode:           inround,
+		Status:         completed,
+		RoundId:        "abc",
+		UpdatedAtUnixS: 10,
+	}
+	newerHistoryEntry := &daemonrpc.TransferInfo{
+		TransferId:     "round:abc:10",
+		Mode:           inround,
+		Status:         completed,
+		RoundId:        "abc",
+		UpdatedAtUnixS: 10,
+	}
+
+	require.True(
+		t, transferSupersedesRoundDuplicate(
+			completedRound, pendingRound,
+		),
+	)
+	require.False(
+		t, transferSupersedesRoundDuplicate(
+			pendingRound, completedRound,
+		),
+	)
+	require.True(
+		t, transferSupersedesRoundDuplicate(
+			newerHistoryEntry, completedRound,
+		),
+	)
+}
+
+// TestRoundHistoryEntryID verifies only round history ids with numeric ledger
+// suffixes are parsed as dedupe tie-breakers.
+func TestRoundHistoryEntryID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		id       string
+		expected int64
+		ok       bool
+	}{
+		{
+			name:     "round history",
+			id:       "round:abc:7",
+			expected: 7,
+			ok:       true,
+		},
+		{
+			name: "oor history",
+			id:   "oor:sess:7",
+		},
+		{
+			name: "ledger fallback",
+			id:   "ledger:7",
+		},
+		{
+			name: "malformed",
+			id:   "round:abc:not-a-number",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			entryID, ok := roundHistoryEntryID(
+				&daemonrpc.TransferInfo{
+					TransferId: test.id,
+				},
+			)
+			require.Equal(t, test.ok, ok)
+			require.Equal(t, test.expected, entryID)
+		})
+	}
+}
+
+// TestClampedTransferStart verifies transfer pagination cannot overflow a
+// platform int while converting from the RPC cursor type.
+func TestClampedTransferStart(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, 3, clampedTransferStart(3, 10))
+	require.Equal(t, 10, clampedTransferStart(10, 10))
+	require.Equal(t, 10, clampedTransferStart(11, 10))
+	require.Equal(t, 10, clampedTransferStart(^uint32(0), 10))
+}
+
+// TestNextTransferOffset verifies transfer pagination cursors advance without
+// wrapping on uint32 overflow.
+func TestNextTransferOffset(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, uint32(12), nextTransferOffset(10, 2))
+	require.Equal(t, ^uint32(0), nextTransferOffset(^uint32(0)-1, 2))
+}
+
+// TestSortTransfersNewestFirst verifies transfer rows sort by best known
+// update time and then by transfer id.
+func TestSortTransfersNewestFirst(t *testing.T) {
+	t.Parallel()
+
+	transfers := []*daemonrpc.TransferInfo{
+		{
+			TransferId:     "b",
+			CreatedAtUnixS: 3,
+		},
+		{
+			TransferId:     "d",
+			CreatedAtUnixS: 7,
+		},
+		{
+			TransferId:     "e",
+			UpdatedAtUnixS: 6,
+		},
+		{
+			TransferId:     "a",
+			UpdatedAtUnixS: 5,
+		},
+		{
+			TransferId:     "c",
+			UpdatedAtUnixS: 5,
+		},
+	}
+
+	sortTransfersNewestFirst(transfers)
+
+	require.Equal(t, "d", transfers[0].GetTransferId())
+	require.Equal(t, "e", transfers[1].GetTransferId())
+	require.Equal(t, "c", transfers[2].GetTransferId())
+	require.Equal(t, "a", transfers[3].GetTransferId())
+	require.Equal(t, "b", transfers[4].GetTransferId())
+}
+
+// TestTemporaryRoundTransferID verifies live rounds without server ids still
+// receive distinct local transfer ids.
+func TestTemporaryRoundTransferID(t *testing.T) {
+	t.Parallel()
+
+	round := &daemonrpc.RoundInfo{
+		IsTemp:         true,
+		State:          daemonrpc.RoundState_ROUND_STATE_JOINED,
+		CreationTime:   10,
+		LastUpdateTime: 12,
+		CommitmentTxid: "commitment",
+		InputOutpoints: []string{
+			"aaa:0",
+		},
+		OutputOutpoints: []string{
+			"bbb:1",
+		},
+	}
+
+	first := temporaryRoundTransferID(round, 0)
+	second := temporaryRoundTransferID(round, 1)
+
+	require.NotEmpty(t, first)
+	require.Contains(t, first, "is_temp:true")
+	require.Less(t, len(first), 64)
+	require.NotEqual(t, first, second)
+}

--- a/ledger/actor.go
+++ b/ledger/actor.go
@@ -56,6 +56,10 @@ const (
 	EventWalletUTXOCreated    = "wallet_utxo_created"
 )
 
+// TransactionTypeRound is the transaction-history type label for rows tied to
+// Ark round activity.
+const TransactionTypeRound = "round"
+
 // Canonical VTXOReceivedMsg.Source values. Callers must use one
 // of these strings; any other value causes handleVTXOReceived to
 // return an error rather than silently misclassify the entry.


### PR DESCRIPTION
## Summary

This PR makes the Ark CLI receive/status story usable without forcing users to know which lower-level protocol path they are exercising or to inspect daemon internals.

Today the CLI can create a boarding address, but there is no friendly generic receive command and no single place to inspect in-round/OOR transfer activity. That makes quick local testing awkward: users can generate a receive script, but then have to infer what happened by stitching together other command output.

This adds:

- `darepo receive` as the friendly default receive target command.
- `darepo receive list` to show locally known reusable receive/boarding targets.
- `darepo transfers list` to show in-round and OOR sends/receives with status.
- filters for transfer mode, direction, status, limit, and offset.
- daemon RPCs backing those CLI surfaces: `ListReceiveScripts` and `ListTransfers`.
- a bech32m address in `NewReceiveScriptResponse`, so callers no longer need to derive it from the returned script.

## User-Facing Examples

Create a generic Ark receive target:

```bash
darepocli receive
```

The command uses the same receive-script machinery as OOR receive target creation, but exposes it under the simpler command name users expect when they just want an address to hand out.

Create the same kind of receive target through the existing OOR namespace:

```bash
darepocli oor receive
```

Both commands return the pkScript plus the derived bech32m address. Existing scripts that call `oor receive` keep working, while new local-testing flows can use `receive` directly.

List receive targets this wallet/daemon knows about:

```bash
darepocli receive list
```

This is useful after a test session where multiple boarding/receive addresses were generated and you want to recover the exact script/address pairs without digging through logs.

List all transfer activity:

```bash
darepocli transfers list
```

List only pending in-round activity:

```bash
darepocli transfers list --mode inround --status pending
```

List only completed OOR receives:

```bash
darepocli transfers list --mode oor --direction incoming --status completed
```

Page through a larger history:

```bash
darepocli transfers list --limit 25 --offset 25
```

The transfer rows include stable identifiers, mode, direction, status, amount, timestamps where available, and context such as txid/round ID/error text depending on the source record.

## API Changes

- `NewReceiveScriptResponse` now includes `address`, derived from the taproot pkScript and the active network parameters.
- `ListReceiveScripts` returns the local receive targets indexed by the daemon.
- `ListTransfers` returns a normalized view over:
  - pending non-terminal in-round operations from round status tracking,
  - completed/failed in-round rows from transaction history,
  - OOR send/receive sessions from OOR session tracking.

The transfer list intentionally normalizes these sources into one response so CLI callers do not need separate commands for “in-round send”, “in-round receive”, “OOR send”, and “OOR receive” just to answer “what happened?”

## Current Limitations

`ListTransfers` aggregates several existing status/history sources in memory and then applies the public `limit`/`offset` page. That is expected to be fine for the small local-wallet histories this CLI is aimed at today, but it is not yet a database-level merged cursor for very large archival wallets. The code carries a TODO to replace the full scan with source-aware cursors if transfer history grows enough to need that.

Some rows can only expose the data available from their source. Live in-round rows may have unknown direction until local input/output hints or persisted ledger rows exist. Direction filters keep those unknown live rows visible rather than hiding pending activity behind `--direction incoming` or `--direction outgoing`. OOR receive/session rows can also report `amount_sat = 0` when the local status source does not yet know the final amount. The CLI still shows these rows so users can track lifecycle status instead of losing pending activity entirely.

## Schema Registry

The method registry now includes schemas for:

- `receive`
- `receive.list`
- `transfers.list`

It also refreshes the stale `send.oor` schema so it advertises the actual destination inputs: exactly one of `to` or `pubkey`. The removed `pk_script` schema entry was not accepted by the command parser, so this is a registry correction rather than a daemon/API removal.

## Validation

- `go test ./...`
- `make fmt-changed`
- `make fmt-changed-check`
- `make lint-native`
- `make commitmsg-lint range="origin/main..HEAD"`
- `make schema-check`
- `make doc-check` (passes; reports pre-existing CLAUDE.md/AGENTS.md divergence warnings in `baselib/actor` and `db/actordelivery/migrations`)
- `git diff --check`

