### PR TITLE
serverconn: sign TLS leaf binding for mailbox auth (#448)

### DIFF
--- a/darepod/server.go
+++ b/darepod/server.go
@@ -219,6 +219,20 @@ type Server struct {
 	// so response envelopes can include it without re-computing.
 	authSigHex string
 
+	// tlsLeafSPKI is the DER-encoded SubjectPublicKeyInfo of the
+	// P-256 client TLS leaf certificate this daemon dialed with.
+	// It is captured during dialServer and used to compute the
+	// secp256k1 → TLS-leaf binding signature that the server
+	// verifies against the leaf it observes on the connection
+	// (issue #448). Empty when TLS is disabled (Server.Insecure).
+	tlsLeafSPKI []byte
+
+	// tlsBindSigHex caches the hex-encoded Schnorr signature
+	// binding the client's secp256k1 identity to its TLS leaf
+	// SPKI, so direct (non-connector) response envelope sends
+	// can attach the binding header without re-signing.
+	tlsBindSigHex string
+
 	runtime *serverconn.Runtime
 	ark     *arkrpc.ArkServiceMailboxClient
 	indexer *indexer.Client
@@ -2040,6 +2054,14 @@ func (s *Server) dialServer(ctx context.Context) (*grpc.ClientConn, error) {
 		}
 
 		clientCerts = []tls.Certificate{clientCert}
+
+		// Cache the leaf SubjectPublicKeyInfo bytes so the
+		// mailbox transport can sign over them and the server
+		// can verify the secp256k1 identity is bound to the
+		// TLS leaf it observes (issue #448).
+		if clientCert.Leaf != nil {
+			s.tlsLeafSPKI = clientCert.Leaf.RawSubjectPublicKeyInfo
+		}
 	}
 
 	switch {
@@ -2664,12 +2686,18 @@ func (s *Server) handleInboundRPC(ctx context.Context,
 	}
 
 	// Include the auth signature in response headers so the
-	// server can verify identity on all envelopes.
+	// server can verify identity on all envelopes. Also include
+	// the TLS-binding signature so the server can complete
+	// first-contact registration even if this response is the
+	// first envelope it sees from us.
 	if headers == nil {
-		headers = make(map[string]string, 1)
+		headers = make(map[string]string, 2)
 	}
 	if s.authSigHex != "" {
 		headers[serverconn.AuthHeaderKey] = s.authSigHex
+	}
+	if s.tlsBindSigHex != "" {
+		headers[serverconn.TLSBindHeaderKey] = s.tlsBindSigHex
 	}
 
 	responseEnv := &mailboxpb.Envelope{
@@ -2962,6 +2990,24 @@ func (s *Server) connectAndBootstrapMailbox(ctx context.Context) error {
 
 	s.authSigHex = hex.EncodeToString(authSig.Serialize())
 
+	// When TLS is enabled (production / regtest with mTLS), bind
+	// the secp256k1 identity to the TLS leaf the server will
+	// observe. The server uses this on first-contact Send to
+	// reject envelopes whose claimed sender is not actually the
+	// owner of the connection's TLS leaf, closing the
+	// registration-time replay window described in issue #448.
+	var tlsBindSig *schnorr.Signature
+	if len(s.tlsLeafSPKI) > 0 {
+		tlsBindSig, err = s.signMailboxTLSBind(ctx, s.tlsLeafSPKI)
+		if err != nil {
+			return fmt.Errorf("sign mailbox tls bind: %w", err)
+		}
+
+		s.tlsBindSigHex = hex.EncodeToString(
+			tlsBindSig.Serialize(),
+		)
+	}
+
 	connCfg := serverconn.DefaultConnectorConfig()
 	connCfg.Edge = edge
 	connCfg.LocalMailboxID = s.localMailboxID
@@ -2970,6 +3016,7 @@ func (s *Server) connectAndBootstrapMailbox(ctx context.Context) error {
 	connCfg.Store = s.deliveryStore
 	connCfg.Dispatchers = dispatchers
 	connCfg.AuthSignature = authSig
+	connCfg.TLSBindSignature = tlsBindSig
 	connCfg.InitAuthHeader()
 	connCfg.DurableUnaryBuilder = &serverDurableUnaryBuilder{
 		server: s,
@@ -3852,6 +3899,97 @@ func (s *Server) signMailboxAuthViaKeyRing(keyRing keychain.SecretKeyRing,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("keyring sign mailbox auth: %w", err)
+	}
+
+	return sig, nil
+}
+
+// signMailboxTLSBind signs the BIP-340 tagged digest binding the
+// client's secp256k1 mailbox identity to the SubjectPublicKeyInfo
+// of the active TLS leaf certificate. The signature is sent in the
+// x-mailbox-tls-bind-sig header on every outbound envelope so the
+// server can verify, on first contact, that the secp256k1 holder
+// chose this exact TLS leaf — preventing a captured Send from
+// being replayed across a different TLS connection (issue #448).
+func (s *Server) signMailboxTLSBind(ctx context.Context,
+	tlsLeafSPKI []byte) (*schnorr.Signature, error) {
+
+	var (
+		sig *schnorr.Signature
+		err error
+	)
+
+	// In LND mode, defer to lnd's tagged Schnorr signing RPC so
+	// no private key material leaves the wallet.
+	s.lnd.WhenSome(func(lndSvc *lndclient.GrpcLndServices) {
+		msg := serverconn.MailboxTLSBindMessage(
+			s.clientKeyDesc.PubKey, tlsLeafSPKI,
+		)
+
+		tag := []byte(serverconn.MailboxTLSBindTagStr)
+
+		var rawSig []byte
+		rawSig, err = lndSvc.Signer.SignMessage(
+			ctx, msg, s.clientKeyDesc.KeyLocator,
+			lndclient.SignSchnorr(nil), withSchnorrTag(tag),
+		)
+		if err != nil {
+			err = fmt.Errorf("lnd sign mailbox tls bind: %w", err)
+
+			return
+		}
+
+		sig, err = schnorr.ParseSignature(rawSig)
+	})
+
+	if sig != nil || err != nil {
+		return sig, err
+	}
+
+	// In lwwallet mode, use the keyring's Schnorr signing
+	// directly — same surface, no private key extraction.
+	s.lwWallet.WhenSome(func(w *lwwallet.Wallet) {
+		sig, err = s.signMailboxTLSBindViaKeyRing(
+			w.KeyRing(), tlsLeafSPKI,
+		)
+	})
+
+	if sig != nil || err != nil {
+		return sig, err
+	}
+
+	// In btcwallet mode, same path via the neutrino-backed keyring.
+	s.btcwWallet.WhenSome(func(w *btcwbackend.Wallet) {
+		sig, err = s.signMailboxTLSBindViaKeyRing(
+			w.KeyRing(), tlsLeafSPKI,
+		)
+	})
+
+	if sig == nil && err == nil {
+		return nil, fmt.Errorf("no wallet backend available to sign " +
+			"mailbox tls bind")
+	}
+
+	return sig, err
+}
+
+// signMailboxTLSBindViaKeyRing signs the mailbox→TLS-leaf binding
+// digest using a keyring's SignMessageSchnorr method, with the
+// BIP-340 tag computed inside the keyring.
+func (s *Server) signMailboxTLSBindViaKeyRing(keyRing keychain.SecretKeyRing,
+	tlsLeafSPKI []byte) (*schnorr.Signature, error) {
+
+	msg := serverconn.MailboxTLSBindMessage(
+		s.clientKeyDesc.PubKey, tlsLeafSPKI,
+	)
+	tag := []byte(serverconn.MailboxTLSBindTagStr)
+
+	sig, err := keyRing.SignMessageSchnorr(
+		s.clientKeyDesc.KeyLocator, msg, false, nil, tag,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("keyring sign mailbox tls bind: %w",
+			err)
 	}
 
 	return sig, nil

--- a/serverconn/mailbox_auth.go
+++ b/serverconn/mailbox_auth.go
@@ -14,10 +14,29 @@ import (
 // to their claimed pubkey-derived mailbox ID.
 const AuthHeaderKey = "x-mailbox-auth-sig"
 
+// TLSBindHeaderKey is the envelope header key that carries the
+// Schnorr signature binding the sender's secp256k1 mailbox identity
+// to the SubjectPublicKeyInfo of the P-256 TLS leaf certificate
+// presented on the same connection. The server verifies this
+// signature against the leaf pubkey it actually observed during the
+// TLS handshake before recording the cert fingerprint binding for
+// the mailbox identity (issue #448). Without it, an attacker who
+// replays a captured Send envelope across a fresh TLS connection
+// of their own would have their leaf fingerprint bound to the
+// victim's mailbox ID.
+const TLSBindHeaderKey = "x-mailbox-tls-bind-sig"
+
 // MailboxAuthTagStr is the BIP-340 tagged hash domain separator used
 // when constructing the message digest for mailbox authentication
 // signatures. This prevents cross-protocol signature reuse.
 const MailboxAuthTagStr = "mailbox-auth"
+
+// MailboxTLSBindTagStr is the BIP-340 tagged hash domain separator
+// used when constructing the message digest that binds a
+// secp256k1 mailbox identity to the TLS leaf SubjectPublicKeyInfo.
+// Using a dedicated tag prevents a mailbox-auth signature from
+// being reinterpreted as a TLS-binding signature and vice versa.
+const MailboxTLSBindTagStr = "mailbox-tls-bind"
 
 // MailboxAuthMessage returns the raw message bytes that are fed into
 // the BIP-340 tagged hash for mailbox authentication:
@@ -96,6 +115,107 @@ func VerifyMailboxAuth(senderPubKey *btcec.PublicKey, recipientMailboxID string,
 	if !sig.Verify(digest[:], senderPubKey) {
 		return fmt.Errorf("mailbox auth signature verification failed "+
 			"for sender %x", senderPubKey.SerializeCompressed())
+	}
+
+	return nil
+}
+
+// MailboxTLSBindMessage returns the raw message bytes that are fed
+// into the BIP-340 tagged hash for binding a mailbox identity to a
+// TLS leaf certificate:
+//
+//	senderCompressedPubKey || tlsLeafSPKIDER
+//
+// The leaf is identified by its SubjectPublicKeyInfo DER bytes (i.e.
+// the x509.Certificate.RawSubjectPublicKeyInfo field). SPKI is the
+// stable, self-describing serialization of the public key plus
+// algorithm parameters, and is what TLS uses internally to commit
+// to the cert's key in the CertificateVerify proof of possession.
+// Hashing the SPKI rather than just the raw key bytes also captures
+// the curve/algorithm identifier, so a P-256 leaf cannot be
+// confused with a leaf using a different curve carrying the same
+// raw coordinates.
+func MailboxTLSBindMessage(senderPubKey *btcec.PublicKey,
+	tlsLeafSPKI []byte) []byte {
+
+	pubBytes := senderPubKey.SerializeCompressed()
+	msg := make([]byte, 0, len(pubBytes)+len(tlsLeafSPKI))
+	msg = append(msg, pubBytes...)
+	msg = append(msg, tlsLeafSPKI...)
+
+	return msg
+}
+
+// MailboxTLSBindDigest constructs the BIP-340 tagged hash digest the
+// client signs to bind its secp256k1 identity to the TLS leaf
+// SubjectPublicKeyInfo:
+//
+//	TaggedHash("mailbox-tls-bind", senderPubKey || tlsLeafSPKI)
+//
+// Using a dedicated tag keeps this digest disjoint from the regular
+// MailboxAuthDigest so neither signature can be replayed across the
+// two purposes.
+func MailboxTLSBindDigest(senderPubKey *btcec.PublicKey,
+	tlsLeafSPKI []byte) [32]byte {
+
+	msg := MailboxTLSBindMessage(senderPubKey, tlsLeafSPKI)
+	hash := chainhash.TaggedHash(
+		[]byte(MailboxTLSBindTagStr), msg,
+	)
+
+	return *hash
+}
+
+// SignMailboxTLSBind produces a Schnorr signature over the
+// mailbox-to-TLS-leaf binding digest, proving the caller holds the
+// secp256k1 private key for senderPubKey AND has chosen tlsLeafSPKI
+// as the leaf the server should expect to observe on this
+// connection.
+func SignMailboxTLSBind(privKey *btcec.PrivateKey,
+	tlsLeafSPKI []byte) (*schnorr.Signature, error) {
+
+	if len(tlsLeafSPKI) == 0 {
+		return nil, fmt.Errorf("tls leaf SPKI must not be empty")
+	}
+
+	digest := MailboxTLSBindDigest(privKey.PubKey(), tlsLeafSPKI)
+
+	sig, err := schnorr.Sign(privKey, digest[:])
+	if err != nil {
+		return nil, fmt.Errorf("schnorr sign tls bind: %w", err)
+	}
+
+	return sig, nil
+}
+
+// VerifyMailboxTLSBind verifies that sigHex is a valid Schnorr
+// signature binding senderPubKey to tlsLeafSPKI. Returns nil on
+// success. The caller is responsible for sourcing tlsLeafSPKI from
+// the observed TLS connection, not from the envelope or any other
+// client-supplied field.
+func VerifyMailboxTLSBind(senderPubKey *btcec.PublicKey,
+	tlsLeafSPKI []byte, sigHex string) error {
+
+	if len(tlsLeafSPKI) == 0 {
+		return fmt.Errorf("tls leaf SPKI must not be empty")
+	}
+
+	sigBytes, err := hex.DecodeString(sigHex)
+	if err != nil {
+		return fmt.Errorf("decode tls bind sig hex: %w", err)
+	}
+
+	sig, err := schnorr.ParseSignature(sigBytes)
+	if err != nil {
+		return fmt.Errorf("parse tls bind sig: %w", err)
+	}
+
+	digest := MailboxTLSBindDigest(senderPubKey, tlsLeafSPKI)
+
+	if !sig.Verify(digest[:], senderPubKey) {
+		return fmt.Errorf("mailbox tls-bind signature "+
+			"verification failed for sender %x",
+			senderPubKey.SerializeCompressed())
 	}
 
 	return nil

--- a/serverconn/mailbox_auth_test.go
+++ b/serverconn/mailbox_auth_test.go
@@ -103,6 +103,81 @@ func TestVerifyMailboxAuthBadHex(t *testing.T) {
 	require.Contains(t, err.Error(), "decode auth sig hex")
 }
 
+// TestSignVerifyMailboxTLSBind exercises the secp256k1 → TLS leaf
+// SPKI binding signature: a valid signature passes against the
+// signing key and leaf, and is rejected against any other key or
+// any other leaf SPKI. The test also confirms that the binding
+// digest is disjoint from the mailbox-auth digest, so the two
+// signatures cannot be swapped between header slots.
+func TestSignVerifyMailboxTLSBind(t *testing.T) {
+	t.Parallel()
+
+	clientKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	otherKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	// Two distinct fake SPKI byte strings standing in for two
+	// different TLS leaves. The signing/verification path does
+	// not parse them, so opaque bytes are sufficient.
+	leafSPKI := []byte("leaf-spki-1")
+	otherLeafSPKI := []byte("leaf-spki-2")
+
+	sig, err := SignMailboxTLSBind(clientKey, leafSPKI)
+	require.NoError(t, err)
+	require.NotNil(t, sig)
+
+	sigHex := hex.EncodeToString(sig.Serialize())
+
+	// Correct key + correct leaf: pass.
+	err = VerifyMailboxTLSBind(clientKey.PubKey(), leafSPKI, sigHex)
+	require.NoError(t, err)
+
+	// Wrong signing key: fail.
+	err = VerifyMailboxTLSBind(otherKey.PubKey(), leafSPKI, sigHex)
+	require.Error(t, err)
+
+	// Wrong leaf SPKI: fail (this is the registration-replay
+	// case from issue #448).
+	err = VerifyMailboxTLSBind(clientKey.PubKey(), otherLeafSPKI, sigHex)
+	require.Error(t, err)
+
+	// Empty SPKI: rejected upfront.
+	err = VerifyMailboxTLSBind(clientKey.PubKey(), nil, sigHex)
+	require.Error(t, err)
+
+	// A mailbox-auth signature must not verify as a TLS-bind
+	// signature. Sign over the auth digest then attempt to
+	// verify with the TLS-bind verifier — different tag means
+	// digest mismatch and rejection.
+	authSig, err := SignMailboxAuth(clientKey, "recipient-mbid")
+	require.NoError(t, err)
+
+	authSigHex := hex.EncodeToString(authSig.Serialize())
+
+	err = VerifyMailboxTLSBind(
+		clientKey.PubKey(), leafSPKI, authSigHex,
+	)
+	require.Error(t, err)
+}
+
+// TestSignMailboxTLSBindEmptySPKI guards against accidentally signing
+// over an empty SPKI, which would otherwise produce a signature that
+// any leaf could verify.
+func TestSignMailboxTLSBindEmptySPKI(t *testing.T) {
+	t.Parallel()
+
+	clientKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	_, err = SignMailboxTLSBind(clientKey, nil)
+	require.Error(t, err)
+
+	_, err = SignMailboxTLSBind(clientKey, []byte{})
+	require.Error(t, err)
+}
+
 // TestParseMailboxPubKeyInvalid verifies that invalid mailbox IDs
 // are rejected.
 func TestParseMailboxPubKeyInvalid(t *testing.T) {

--- a/serverconn/types.go
+++ b/serverconn/types.go
@@ -180,10 +180,26 @@ type ConnectorConfig struct {
 	// server verifies this signature during client registration.
 	AuthSignature *schnorr.Signature
 
+	// TLSBindSignature is the Schnorr signature binding the
+	// client's secp256k1 mailbox identity to the SPKI bytes of
+	// the TLS leaf certificate this connector dialed with. When
+	// non-nil, it is serialized as hex and included as the
+	// x-mailbox-tls-bind-sig header on every outbound envelope.
+	// The server uses this on first-contact Send to verify the
+	// TLS leaf it observes is the one the verified identity
+	// signed over, closing the registration-time replay window
+	// described in issue #448.
+	TLSBindSignature *schnorr.Signature
+
 	// authSigHex caches the hex-encoded auth signature string,
 	// computed once by InitAuthHeader to avoid per-envelope
 	// serialization.
 	authSigHex string
+
+	// tlsBindSigHex caches the hex-encoded TLS-binding signature
+	// string, computed once by InitAuthHeader. Empty when no
+	// binding signature is configured.
+	tlsBindSigHex string
 
 	// authHeaderCache holds the singleton auth-only header map
 	// for the common case where callers provide no extra headers.
@@ -191,24 +207,37 @@ type ConnectorConfig struct {
 }
 
 // InitAuthHeader pre-computes the cached auth header state from
-// AuthSignature. Must be called after AuthSignature is set and
-// before the first mergeAuthHeaders call.
+// AuthSignature and TLSBindSignature. Must be called after both
+// signature fields are set (or left nil) and before the first
+// mergeAuthHeaders call.
 func (c *ConnectorConfig) InitAuthHeader() {
 	if c.AuthSignature == nil {
 		return
 	}
 
 	c.authSigHex = hex.EncodeToString(c.AuthSignature.Serialize())
-	c.authHeaderCache = map[string]string{
+
+	cache := map[string]string{
 		AuthHeaderKey: c.authSigHex,
 	}
+
+	if c.TLSBindSignature != nil {
+		c.tlsBindSigHex = hex.EncodeToString(
+			c.TLSBindSignature.Serialize(),
+		)
+		cache[TLSBindHeaderKey] = c.tlsBindSigHex
+	}
+
+	c.authHeaderCache = cache
 }
 
 // mergeAuthHeaders returns a new header map containing both src
-// headers and the auth signature header. If AuthSignature is nil,
-// src is returned unchanged. The auth signature header always takes
-// precedence over any caller-provided header with the same key to
-// prevent accidental or malicious signature replacement.
+// headers and the auth signature headers (mailbox-auth and, if
+// configured, the TLS-binding signature). If no auth signature is
+// configured, src is returned unchanged. Server-bound auth headers
+// always take precedence over any caller-provided header with the
+// same key to prevent accidental or malicious signature
+// replacement.
 func (c *ConnectorConfig) mergeAuthHeaders(
 	src map[string]string) map[string]string {
 
@@ -221,7 +250,7 @@ func (c *ConnectorConfig) mergeAuthHeaders(
 		return c.authHeaderCache
 	}
 
-	merged := make(map[string]string, len(src)+1)
+	merged := make(map[string]string, len(src)+len(c.authHeaderCache))
 
 	// Copy caller-provided headers first.
 	for k, v := range src {
@@ -230,6 +259,11 @@ func (c *ConnectorConfig) mergeAuthHeaders(
 
 	// Auth signature always wins over caller-provided headers.
 	merged[AuthHeaderKey] = c.authSigHex
+
+	// TLS-binding signature, if configured, also wins.
+	if c.tlsBindSigHex != "" {
+		merged[TLSBindHeaderKey] = c.tlsBindSigHex
+	}
 
 	return merged
 }

--- a/serverconn/types_test.go
+++ b/serverconn/types_test.go
@@ -65,6 +65,48 @@ func TestMergeAuthHeadersAuthWins(t *testing.T) {
 	require.Equal(t, "value", result["other"])
 }
 
+// TestMergeAuthHeadersIncludesTLSBindSig verifies that when both
+// AuthSignature and TLSBindSignature are configured, mergeAuthHeaders
+// emits both headers and the TLS-binding header survives a caller-
+// supplied collision (same precedence rule as the auth header).
+func TestMergeAuthHeadersIncludesTLSBindSig(t *testing.T) {
+	t.Parallel()
+
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	authSig, err := SignMailboxAuth(privKey, "recipient")
+	require.NoError(t, err)
+
+	bindSig, err := SignMailboxTLSBind(privKey, []byte("leaf-spki"))
+	require.NoError(t, err)
+
+	cfg := &ConnectorConfig{
+		AuthSignature:    authSig,
+		TLSBindSignature: bindSig,
+	}
+	cfg.InitAuthHeader()
+
+	// Fast path: nil src returns the cached singleton with both
+	// headers present.
+	result := cfg.mergeAuthHeaders(nil)
+	require.Contains(t, result, AuthHeaderKey)
+	require.Contains(t, result, TLSBindHeaderKey)
+
+	expectedBindHex := hex.EncodeToString(bindSig.Serialize())
+	require.Equal(t, expectedBindHex, result[TLSBindHeaderKey])
+
+	// Slow path: caller-supplied headers, with a hostile attempt
+	// to override the TLS-binding header. Real binding sig wins.
+	src := map[string]string{
+		TLSBindHeaderKey: "fake-bind-sig",
+		"other":          "value",
+	}
+	result = cfg.mergeAuthHeaders(src)
+	require.Equal(t, expectedBindHex, result[TLSBindHeaderKey])
+	require.Equal(t, "value", result["other"])
+}
+
 // TestPubKeyMailboxIDNilPanics verifies that a nil key causes a panic.
 func TestPubKeyMailboxIDNilPanics(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Closes lightninglabs/darepo#448.

## Summary

Adds the client-side half of the #448 TLS-binding mTLS gap fix.

- Introduces `SignMailboxTLSBind` / `VerifyMailboxTLSBind` in
  `client/serverconn`. The signature is BIP-340 over a tagged
  (`mailbox-tls-bind`) digest of `senderPubKey || tlsLeafSPKI`, using
  the mailbox secp256k1 key.
- `darepod.dialServer` stamps the binding signature as a gRPC metadata
  header (`x-mailbox-tls-bind-sig`) on outbound mailbox calls so the
  server can verify, on first-contact Send, that the mailbox-key
  holder chose the TLS leaf the server observes.

Without this header an attacker who captured a victim's signed first
Send could replay the bytes over a TLS connection backed by an
attacker-controlled leaf and have their fingerprint bound to the
victim's mailbox ID, defeating the post-registration fingerprint
defense added in lightninglabs/darepo#443.

## Server side

Server-side enforcement lives in lightninglabs/darepo#443, which also
folds in the #448 fix to keep the rollout atomic (a soft-rollout flag
`MailboxConfig.RequireTLSBindingSig` gates strict enforcement).

## Test plan

- [x] new unit tests for `SignMailboxTLSBind` / `VerifyMailboxTLSBind`
  (wrong-key, wrong-leaf, malformed, replay across leaves)
- [x] `darepod.dialServer` stamps the header end-to-end