### PR TITLE
walletdk-tui: show wallet activity entries

### DIFF
--- a/cmd/walletdk-tui/app.go
+++ b/cmd/walletdk-tui/app.go
@@ -72,9 +72,10 @@ type walletClient interface {
 		error,
 	)
 
-	ListBalance(context.Context) (*walletdk.Balance, error)
+	Balance(context.Context) (*walletdk.Balance, error)
 
-	GetOnchainAddress(context.Context) (*walletdk.OnchainAddress, error)
+	Deposit(context.Context,
+		walletdk.DepositRequest) (*walletdk.DepositResult, error)
 
 	Receive(context.Context,
 		walletdk.ReceiveRequest) (*walletdk.ReceiveResult, error)
@@ -82,11 +83,11 @@ type walletClient interface {
 	Send(context.Context,
 		walletdk.SendRequest) (*walletdk.SendResult, error)
 
-	ListSwaps(context.Context,
-		walletdk.ListSwapsRequest) ([]walletdk.SwapSummary, error)
+	List(context.Context,
+		walletdk.ListRequest) (*walletdk.ListResult, error)
 
-	SubscribeSwaps(context.Context, walletdk.SubscribeSwapsRequest) (
-		<-chan walletdk.SwapSummary, <-chan error, error)
+	Subscribe(context.Context, walletdk.SubscribeRequest) (
+		<-chan walletdk.Entry, <-chan error, error)
 }
 
 // walletModel holds the Bubble Tea state for the wallet dashboard.
@@ -107,8 +108,8 @@ type walletModel struct {
 
 	info        *walletdk.Info
 	balance     *walletdk.Balance
-	swaps       []walletdk.SwapSummary
-	swapUpdates <-chan walletdk.SwapSummary
+	entries     []walletdk.Entry
+	swapUpdates <-chan walletdk.Entry
 	swapErrs    <-chan error
 
 	swapTable table.Model
@@ -473,14 +474,14 @@ func (m walletModel) submitReceiveForm() (walletModel, tea.Cmd) {
 		return m, nil
 	}
 
-	amount, err := strconv.ParseInt(
+	amount, err := strconv.ParseUint(
 		strings.TrimSpace(
 			m.receiveAmount.Value(),
 		),
 		10,
 		64,
 	)
-	if err != nil || amount <= 0 {
+	if err != nil || amount == 0 {
 		m.setError("amount must be a positive integer")
 
 		return m, nil
@@ -568,7 +569,7 @@ func (m *walletModel) handleSwaps(msg swapsMsg) {
 		return
 	}
 
-	m.swaps = msg.swaps
+	m.entries = msg.entries
 	m.updateSwapRows()
 	m.clearError()
 }
@@ -581,7 +582,8 @@ func (m *walletModel) handleSwapSubscription(
 		if !errors.Is(msg.err, context.Canceled) {
 			m.setError(msg.err.Error())
 			m.addActivity(
-				"swap subscription error: " + msg.err.Error(),
+				"activity subscription error: " +
+					msg.err.Error(),
 			)
 		}
 
@@ -600,26 +602,26 @@ func (m *walletModel) handleSwapUpdate(msg swapUpdateMsg) []tea.Cmd {
 		if !errors.Is(msg.err, context.Canceled) {
 			m.setError(msg.err.Error())
 			m.addActivity(
-				"swap subscription error: " + msg.err.Error(),
+				"activity subscription error: " +
+					msg.err.Error(),
 			)
 		}
 
 		return nil
 	}
 	if msg.empty {
-		m.status = "swap stream closed; reconnecting"
-		m.addActivity("swap stream closed; reconnecting")
+		m.status = "activity stream closed; reconnecting"
+		m.addActivity("activity stream closed; reconnecting")
 
 		return []tea.Cmd{m.reconnectSwapsCmd()}
 	}
 
-	m.upsertSwap(msg.swap)
+	m.upsertSwap(msg.entry)
 	m.updateSwapRows()
 	m.addActivity(
 		fmt.Sprintf(
-			"swap %s %s state=%s pending=%t", msg.swap.Direction,
-			shortHash(msg.swap.PaymentHash), msg.swap.State,
-			msg.swap.Pending,
+			"%s %s status=%s", msg.entry.Kind,
+			shortHash(msg.entry.ID), msg.entry.Status,
 		),
 	)
 
@@ -696,6 +698,8 @@ func (m *walletModel) handleAddress(msg addressMsg) []tea.Cmd {
 	m.detailBody = msg.result.Address
 	m.detailCopyLabel = "address"
 	m.detailCopyText = msg.result.Address
+	m.upsertSwap(msg.result.Entry)
+	m.updateSwapRows()
 	m.addActivity("address created: " + msg.result.Address)
 
 	return []tea.Cmd{m.refreshAllCmd()}
@@ -714,13 +718,13 @@ func (m *walletModel) handleReceive(msg receiveMsg) []tea.Cmd {
 	m.status = "receive started"
 	m.receiveAmount.SetValue("")
 	m.detailTitle = "receive invoice"
-	m.detailBody = fmt.Sprintf("payment_hash: %s\ninvoice: %s",
-		msg.result.PaymentHash, compactCopyValue(msg.result.Invoice))
+	m.detailBody = fmt.Sprintf("entry_id: %s\ninvoice: %s",
+		msg.result.Entry.ID, compactCopyValue(msg.result.Invoice))
 	m.detailCopyLabel = "invoice"
 	m.detailCopyText = msg.result.Invoice
-	m.upsertSwap(msg.result.Swap)
+	m.upsertSwap(msg.result.Entry)
 	m.updateSwapRows()
-	m.addActivity("receive started: " + msg.result.PaymentHash)
+	m.addActivity("receive started: " + msg.result.Entry.ID)
 
 	return []tea.Cmd{m.refreshAllCmd()}
 }
@@ -739,12 +743,12 @@ func (m *walletModel) handleSend(msg sendMsg) []tea.Cmd {
 	m.sendInvoice.SetValue("")
 	m.sendFee.SetValue("")
 	m.detailTitle = "send"
-	m.detailBody = "payment_hash: " + msg.result.PaymentHash
-	m.detailCopyLabel = "payment hash"
-	m.detailCopyText = msg.result.PaymentHash
-	m.upsertSwap(msg.result.Swap)
+	m.detailBody = "entry_id: " + msg.result.Entry.ID
+	m.detailCopyLabel = "entry id"
+	m.detailCopyText = msg.result.Entry.ID
+	m.upsertSwap(msg.result.Entry)
 	m.updateSwapRows()
-	m.addActivity("send started: " + msg.result.PaymentHash)
+	m.addActivity("send started: " + msg.result.Entry.ID)
 
 	return []tea.Cmd{m.refreshAllCmd()}
 }
@@ -887,30 +891,30 @@ func (m *walletModel) addActivity(line string) {
 	m.activity.Append(time.Now().Format("15:04:05") + " " + line)
 }
 
-// upsertSwap updates or appends a swap summary by payment hash.
-func (m *walletModel) upsertSwap(next walletdk.SwapSummary) {
-	for i, swap := range m.swaps {
-		if swap.PaymentHash == next.PaymentHash {
-			m.swaps[i] = next
+// upsertSwap updates or appends a wallet activity entry by id.
+func (m *walletModel) upsertSwap(next walletdk.Entry) {
+	for i, entry := range m.entries {
+		if entry.ID == next.ID {
+			m.entries[i] = next
 
 			return
 		}
 	}
 
-	m.swaps = append([]walletdk.SwapSummary{next}, m.swaps...)
+	m.entries = append([]walletdk.Entry{next}, m.entries...)
 }
 
-// updateSwapRows renders swap summaries into the table component.
+// updateSwapRows renders wallet activity entries into the table component.
 func (m *walletModel) updateSwapRows() {
-	rows := make([]table.Row, 0, len(m.swaps))
-	for _, swap := range m.swaps {
+	rows := make([]table.Row, 0, len(m.entries))
+	for _, entry := range m.entries {
 		rows = append(rows, table.Row{
-			string(swap.Direction),
-			shortHash(swap.PaymentHash),
-			swap.State,
-			fmt.Sprintf("%t", swap.Pending),
-			formatSat(swap.AmountSat),
-			formatUint(swap.FeeSat),
+			string(entry.Kind),
+			shortHash(entry.ID),
+			string(entry.Status),
+			formatSat(entry.AmountSat),
+			formatSat(entry.FeeSat),
+			shortText(entry.Counterparty, 18),
 		})
 	}
 
@@ -978,31 +982,32 @@ func (m walletModel) balanceCmd() tea.Cmd {
 		ctx, cancel := context.WithTimeout(m.ctx, rpcTimeout)
 		defer cancel()
 
-		balance, err := m.client.ListBalance(ctx)
+		balance, err := m.client.Balance(ctx)
 
 		return balanceMsg{balance: balance, err: err}
 	}
 }
 
-// swapsCmd fetches persisted swaps.
+// swapsCmd fetches wallet activity entries.
 func (m walletModel) swapsCmd() tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(m.ctx, rpcTimeout)
 		defer cancel()
 
-		swaps, err := m.client.ListSwaps(
-			ctx, walletdk.ListSwapsRequest{},
-		)
+		result, err := m.client.List(ctx, walletdk.ListRequest{})
+		if result == nil {
+			result = &walletdk.ListResult{}
+		}
 
-		return swapsMsg{swaps: swaps, err: err}
+		return swapsMsg{entries: result.Entries, err: err}
 	}
 }
 
-// connectSwapsCmd opens the daemon swap subscription once.
+// connectSwapsCmd opens the daemon wallet activity subscription once.
 func (m walletModel) connectSwapsCmd() tea.Cmd {
 	return func() tea.Msg {
-		updates, errs, err := m.client.SubscribeSwaps(
-			m.ctx, walletdk.SubscribeSwapsRequest{
+		updates, errs, err := m.client.Subscribe(
+			m.ctx, walletdk.SubscribeRequest{
 				IncludeExisting: true,
 			},
 		)
@@ -1024,16 +1029,16 @@ func (m walletModel) reconnectSwapsCmd() tea.Cmd {
 	})
 }
 
-// readSwapUpdateCmd waits for one update from the active swap stream.
+// readSwapUpdateCmd waits for one update from the active activity stream.
 func (m walletModel) readSwapUpdateCmd() tea.Cmd {
 	return func() tea.Msg {
 		select {
-		case swap, ok := <-m.swapUpdates:
+		case entry, ok := <-m.swapUpdates:
 			if !ok {
 				return swapUpdateMsg{empty: true}
 			}
 
-			return swapUpdateMsg{swap: swap}
+			return swapUpdateMsg{entry: entry}
 
 		case err, ok := <-m.swapErrs:
 			if !ok || err == nil {
@@ -1106,27 +1111,27 @@ func (m walletModel) addressCmd() tea.Cmd {
 		ctx, cancel := context.WithTimeout(m.ctx, rpcTimeout)
 		defer cancel()
 
-		result, err := m.client.GetOnchainAddress(ctx)
+		result, err := m.client.Deposit(ctx, walletdk.DepositRequest{})
 
 		return addressMsg{result: result, err: err}
 	}
 }
 
-// receiveCmd starts a Lightning-to-Ark receive swap.
-func (m walletModel) receiveCmd(amount int64) tea.Cmd {
+// receiveCmd creates a Lightning invoice payable into the wallet.
+func (m walletModel) receiveCmd(amount uint64) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(m.ctx, rpcTimeout)
 		defer cancel()
 
 		result, err := m.client.Receive(ctx, walletdk.ReceiveRequest{
-			AmountSat: amount,
+			AmountSat: int64(amount),
 		})
 
 		return receiveMsg{result: result, err: err}
 	}
 }
 
-// sendCmd starts an Ark-to-Lightning payment.
+// sendCmd starts an outbound wallet payment.
 func (m walletModel) sendCmd(invoice string, maxFee uint64) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(m.ctx, rpcTimeout)
@@ -1154,18 +1159,18 @@ type balanceMsg struct {
 }
 
 type swapsMsg struct {
-	swaps []walletdk.SwapSummary
-	err   error
+	entries []walletdk.Entry
+	err     error
 }
 
 type swapSubscriptionMsg struct {
-	updates <-chan walletdk.SwapSummary
+	updates <-chan walletdk.Entry
 	errs    <-chan error
 	err     error
 }
 
 type swapUpdateMsg struct {
-	swap  walletdk.SwapSummary
+	entry walletdk.Entry
 	err   error
 	empty bool
 }
@@ -1188,7 +1193,7 @@ type unlockWalletMsg struct {
 }
 
 type addressMsg struct {
-	result *walletdk.OnchainAddress
+	result *walletdk.DepositResult
 	err    error
 }
 

--- a/cmd/walletdk-tui/app_test.go
+++ b/cmd/walletdk-tui/app_test.go
@@ -39,24 +39,23 @@ func TestWalletModelRefreshMessagesPopulateState(t *testing.T) {
 	require.Equal(t, "regtest", model.info.Network)
 
 	next, _ = model.Update(balanceMsg{balance: &walletdk.Balance{
-		VTXOBalanceSat:    21,
-		TotalConfirmedSat: 42,
+		ConfirmedSat: 42,
 	}})
 	model = requireWalletModel(t, next)
-	require.EqualValues(t, 42, model.balance.TotalConfirmedSat)
+	require.EqualValues(t, 42, model.balance.ConfirmedSat)
 
-	swap := walletdk.SwapSummary{
-		Direction:   walletdk.SwapDirectionPay,
-		PaymentHash: "0123456789abcdef",
-		State:       "completed",
-		AmountSat:   10_000,
+	entry := walletdk.Entry{
+		ID:        "0123456789abcdef",
+		Kind:      walletdk.EntryKindSend,
+		Status:    walletdk.EntryStatusComplete,
+		AmountSat: -10_000,
 	}
-	next, _ = model.Update(swapsMsg{swaps: []walletdk.SwapSummary{swap}})
+	next, _ = model.Update(swapsMsg{entries: []walletdk.Entry{entry}})
 	model = requireWalletModel(t, next)
 
-	require.Len(t, model.swaps, 1)
+	require.Len(t, model.entries, 1)
 	require.Len(t, model.swapTable.Rows(), 1)
-	require.Equal(t, "pay", model.swapTable.Rows()[0][0])
+	require.Equal(t, "send", model.swapTable.Rows()[0][0])
 }
 
 // TestWalletModelReceiveValidationDoesNotCallClient verifies local validation.
@@ -79,14 +78,12 @@ func TestWalletModelReceiveSuccessUpdatesAccounting(t *testing.T) {
 	fake := newFakeWalletClient()
 	invoice := "lnbcrt" + strings.Repeat("a", 120) + "z"
 	fake.receiveResult = &walletdk.ReceiveResult{
-		PaymentHash: "hash",
-		Invoice:     invoice,
-		Swap: walletdk.SwapSummary{
-			Direction:   walletdk.SwapDirectionReceive,
-			PaymentHash: "hash",
-			State:       "created",
-			Pending:     true,
-			AmountSat:   123,
+		Invoice: invoice,
+		Entry: walletdk.Entry{
+			ID:        "hash",
+			Kind:      walletdk.EntryKindReceive,
+			Status:    walletdk.EntryStatusPending,
+			AmountSat: 123,
 		},
 	}
 
@@ -110,7 +107,7 @@ func TestWalletModelReceiveSuccessUpdatesAccounting(t *testing.T) {
 	require.NotContains(t, model.detailBody, invoice)
 	require.Equal(t, "invoice", model.detailCopyLabel)
 	require.Equal(t, invoice, model.detailCopyText)
-	require.Len(t, model.swaps, 1)
+	require.Len(t, model.entries, 1)
 
 	next, cmd = model.Update(keyPress("ctrl+y"))
 	model = requireWalletModel(t, next)
@@ -163,7 +160,7 @@ func TestWalletModelCreateClearsPassword(t *testing.T) {
 // TestWalletModelSwapSubscriptionUpdatesTable verifies live accounting updates.
 func TestWalletModelSwapSubscriptionUpdatesTable(t *testing.T) {
 	model := newWalletModel(t.Context(), newFakeWalletClient(), nil)
-	updates := make(chan walletdk.SwapSummary, 1)
+	updates := make(chan walletdk.Entry, 1)
 	errs := make(chan error, 1)
 
 	next, cmd := model.Update(swapSubscriptionMsg{
@@ -173,19 +170,19 @@ func TestWalletModelSwapSubscriptionUpdatesTable(t *testing.T) {
 	model = requireWalletModel(t, next)
 	require.NotNil(t, cmd)
 
-	updates <- walletdk.SwapSummary{
-		Direction:   walletdk.SwapDirectionPay,
-		PaymentHash: "abcdef",
-		State:       "completed",
-		AmountSat:   100,
+	updates <- walletdk.Entry{
+		ID:        "abcdef",
+		Kind:      walletdk.EntryKindSend,
+		Status:    walletdk.EntryStatusComplete,
+		AmountSat: -100,
 	}
 
 	msg := cmd()
 	next, _ = model.Update(msg)
 	model = requireWalletModel(t, next)
 
-	require.Len(t, model.swaps, 1)
-	require.Equal(t, "completed", model.swapTable.Rows()[0][2])
+	require.Len(t, model.entries, 1)
+	require.Equal(t, "complete", model.swapTable.Rows()[0][2])
 }
 
 // TestWalletModelReconnectsSwapSubscriptionAfterDelay verifies that a closed
@@ -203,7 +200,7 @@ func TestWalletModelReconnectsSwapSubscriptionAfterDelay(t *testing.T) {
 	cmds := model.handleSwapUpdate(swapUpdateMsg{empty: true})
 	require.Len(t, cmds, 1)
 	require.Equal(t, 0, fake.subscribeCalls)
-	require.Equal(t, "swap stream closed; reconnecting", model.status)
+	require.Equal(t, "activity stream closed; reconnecting", model.status)
 
 	msg := cmds[0]()
 	require.IsType(t, swapReconnectMsg{}, msg)
@@ -337,13 +334,13 @@ type fakeWalletClient struct {
 
 	createResult  *walletdk.CreateWalletResult
 	unlockResult  *walletdk.UnlockWalletResult
-	addressResult *walletdk.OnchainAddress
+	addressResult *walletdk.DepositResult
 	receiveResult *walletdk.ReceiveResult
 	sendResult    *walletdk.SendResult
 
 	info    *walletdk.Info
 	balance *walletdk.Balance
-	swaps   []walletdk.SwapSummary
+	entries []walletdk.Entry
 	err     error
 }
 
@@ -360,15 +357,21 @@ func newFakeWalletClient() *fakeWalletClient {
 		unlockResult: &walletdk.UnlockWalletResult{
 			IdentityPubKey: "identity",
 		},
-		addressResult: &walletdk.OnchainAddress{
+		addressResult: &walletdk.DepositResult{
 			Address: "bcrt1address",
 		},
 		receiveResult: &walletdk.ReceiveResult{
-			PaymentHash: "receive",
-			Invoice:     "invoice",
+			Invoice: "invoice",
+			Entry: walletdk.Entry{
+				ID:   "receive",
+				Kind: walletdk.EntryKindReceive,
+			},
 		},
 		sendResult: &walletdk.SendResult{
-			PaymentHash: "send",
+			Entry: walletdk.Entry{
+				ID:   "send",
+				Kind: walletdk.EntryKindSend,
+			},
 		},
 		info: &walletdk.Info{
 			Network:         "regtest",
@@ -407,16 +410,14 @@ func (f *fakeWalletClient) UnlockWallet(context.Context,
 	return f.unlockResult, f.err
 }
 
-// ListBalance satisfies walletClient.
-func (f *fakeWalletClient) ListBalance(context.Context) (*walletdk.Balance,
-	error) {
-
+// Balance satisfies walletClient.
+func (f *fakeWalletClient) Balance(context.Context) (*walletdk.Balance, error) {
 	return f.balance, f.err
 }
 
-// GetOnchainAddress satisfies walletClient.
-func (f *fakeWalletClient) GetOnchainAddress(context.Context) (
-	*walletdk.OnchainAddress, error) {
+// Deposit satisfies walletClient.
+func (f *fakeWalletClient) Deposit(context.Context, walletdk.DepositRequest) (
+	*walletdk.DepositResult, error) {
 
 	f.addressCalls++
 
@@ -441,17 +442,17 @@ func (f *fakeWalletClient) Send(context.Context, walletdk.SendRequest) (
 	return f.sendResult, f.err
 }
 
-// ListSwaps satisfies walletClient.
-func (f *fakeWalletClient) ListSwaps(context.Context,
-	walletdk.ListSwapsRequest) ([]walletdk.SwapSummary, error) {
+// List satisfies walletClient.
+func (f *fakeWalletClient) List(context.Context, walletdk.ListRequest) (
+	*walletdk.ListResult, error) {
 
-	return f.swaps, f.err
+	return &walletdk.ListResult{Entries: f.entries}, f.err
 }
 
-// SubscribeSwaps satisfies walletClient.
-func (f *fakeWalletClient) SubscribeSwaps(context.Context,
-	walletdk.SubscribeSwapsRequest) (<-chan walletdk.SwapSummary,
-	<-chan error, error) {
+// Subscribe satisfies walletClient.
+func (f *fakeWalletClient) Subscribe(context.Context,
+	walletdk.SubscribeRequest) (<-chan walletdk.Entry, <-chan error,
+	error) {
 
 	f.subscribeCalls++
 
@@ -459,7 +460,7 @@ func (f *fakeWalletClient) SubscribeSwaps(context.Context,
 		return nil, nil, f.err
 	}
 
-	updates := make(chan walletdk.SwapSummary)
+	updates := make(chan walletdk.Entry)
 	errs := make(chan error, 1)
 	errs <- errors.New("not connected")
 

--- a/cmd/walletdk-tui/main.go
+++ b/cmd/walletdk-tui/main.go
@@ -60,10 +60,6 @@ func run() error {
 		&cfg.SwapServerInsecure, "swap-server-insecure",
 		cfg.SwapServerInsecure, "disable swap server TLS",
 	)
-	flag.BoolVar(
-		&cfg.DisableSwaps, "no-swaps", cfg.DisableSwaps,
-		"start without daemon-owned swap runtime",
-	)
 	flag.Parse()
 
 	logs := newLogSink(2_000)

--- a/cmd/walletdk-tui/ui.go
+++ b/cmd/walletdk-tui/ui.go
@@ -233,7 +233,7 @@ func (m walletModel) renderHeader() string {
 // renderTabs renders the navigation row.
 func (m walletModel) renderTabs() string {
 	names := []string{
-		"Overview", "Wallet", "Receive", "Send", "Swaps", "Activity",
+		"Overview", "Wallet", "Receive", "Send", "History", "Activity",
 		"Logs",
 	}
 
@@ -329,7 +329,7 @@ func (m walletModel) renderReceive() string {
 	b.WriteString("Amount\n")
 	b.WriteString(m.receiveAmount.View())
 	b.WriteString("\n\n")
-	b.WriteString(mutedStyle.Render("Enter starts a receive swap."))
+	b.WriteString(mutedStyle.Render("Enter creates an invoice."))
 	if m.detailTitle != "" {
 		b.WriteString("\n\n")
 		b.WriteString(m.renderDetailBlock())
@@ -362,11 +362,11 @@ func (m walletModel) renderSend() string {
 	return panelStyle.Width(contentWidth(m.width)).Render(b.String())
 }
 
-// renderSwaps renders the swap accounting table.
+// renderSwaps renders the wallet activity table.
 func (m walletModel) renderSwaps() string {
-	if len(m.swaps) == 0 {
+	if len(m.entries) == 0 {
 		return panelStyle.Width(contentWidth(m.width)).Render(
-			mutedStyle.Render("No swaps yet."),
+			mutedStyle.Render("No wallet activity yet."),
 		)
 	}
 
@@ -418,16 +418,12 @@ func (m walletModel) renderBalanceBlock() string {
 
 	return strings.Join([]string{
 		labelStyle.Render("Balance"),
-		fmt.Sprintf("boarding confirmed: %s sat",
-			formatSat(m.balance.BoardingConfirmedSat)),
-		fmt.Sprintf("boarding unconfirmed: %s sat",
-			formatSat(m.balance.BoardingUnconfirmedSat)),
-		fmt.Sprintf("vtxo: %s sat",
-			formatSat(m.balance.VTXOBalanceSat)),
-		fmt.Sprintf("total confirmed: %s sat",
-			formatSat(m.balance.TotalConfirmedSat)),
-		fmt.Sprintf("on-chain wallet: %s sat",
-			formatSat(m.balance.OnchainWalletConfirmedSat)),
+		fmt.Sprintf("confirmed: %s sat",
+			formatSat(m.balance.ConfirmedSat)),
+		fmt.Sprintf("pending in: %s sat",
+			formatSat(m.balance.PendingInSat)),
+		fmt.Sprintf("pending out: %s sat",
+			formatSat(m.balance.PendingOutSat)),
 	}, "\n")
 }
 
@@ -436,7 +432,7 @@ func (m walletModel) renderDetailBlock() string {
 	if m.detailTitle == "" {
 		return mutedStyle.Render(
 			"Latest results appear here: addresses, invoices, " +
-				"payment hashes, and wallet seed words.",
+				"entry ids, and wallet seed words.",
 		)
 	}
 
@@ -462,7 +458,7 @@ func (m walletModel) renderStatus() string {
 	return okStyle.Render(m.status)
 }
 
-// swapColumns returns responsive swap table columns.
+// swapColumns returns responsive wallet activity table columns.
 func swapColumns(width int) []table.Column {
 	hashWidth := 14
 	stateWidth := 14
@@ -473,20 +469,16 @@ func swapColumns(width int) []table.Column {
 
 	return []table.Column{
 		{
-			Title: "Dir",
+			Title: "Kind",
 			Width: 8,
 		},
 		{
-			Title: "Hash",
+			Title: "ID",
 			Width: hashWidth,
 		},
 		{
-			Title: "State",
+			Title: "Status",
 			Width: stateWidth,
-		},
-		{
-			Title: "Pending",
-			Width: 8,
 		},
 		{
 			Title: "Amount",
@@ -495,6 +487,10 @@ func swapColumns(width int) []table.Column {
 		{
 			Title: "Fee",
 			Width: 10,
+		},
+		{
+			Title: "Counterparty",
+			Width: 18,
 		},
 	}
 }
@@ -526,11 +522,6 @@ func boolLabel(v bool) string {
 // formatSat formats signed satoshi values.
 func formatSat(v int64) string {
 	return strconvFormatInt(v)
-}
-
-// formatUint formats unsigned satoshi values.
-func formatUint(v uint64) string {
-	return fmt.Sprintf("%d", v)
 }
 
 // strconvFormatInt wraps integer formatting for consistent UI use.


### PR DESCRIPTION
Stacked on #440.\n\nThis PR keeps the walletdk SDK/runtime work separate and only migrates the Bubble Tea TUI from the deprecated swap-shaped compatibility API to wallet activity entries.\n\nValidation run locally:\n- go test ./sdk/walletdk ./cmd/walletdk-tui\n- go test -tags walletrpc,swapruntime ./sdk/walletdk ./cmd/walletdk-tui\n- make lint-local\n- make commitmsg-lint range=1f252fddaa7fafa438a9873949fb2b203163e68a..HEAD