### PR TITLE
darepod: pre-flight fee balance check before manual unroll

### DIFF
--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -2551,6 +2551,16 @@ func (r *RPCServer) Unroll(ctx context.Context, req *daemonrpc.UnrollRequest) (
 		}
 	}
 
+	// Before transitioning the VTXO to the terminal UnilateralExit
+	// state (which is irreversible), verify the on-chain wallet has
+	// enough confirmed balance to cover the CPFP fees required to
+	// broadcast all recovery transactions plus the final sweep.
+	if err := r.checkUnrollFeeBalance(
+		admissionCtx, outpoint,
+	); err != nil {
+		return nil, err
+	}
+
 	// Route through the VTXO manager which tells the VTXO actor to
 	// transition to UnilateralExitState. The actor's outbox handler
 	// emits ExpiringNotification through the chain resolver seam,
@@ -2580,6 +2590,139 @@ func (r *RPCServer) Unroll(ctx context.Context, req *daemonrpc.UnrollRequest) (
 		Created: unrollResp.Accepted,
 		ActorId: actorID,
 	}, nil
+}
+
+// unrollFeeConfTarget is the confirmation-target used for estimating the
+// fee rate when checking whether the wallet can cover unroll CPFP costs.
+// Six blocks is a reasonable default that matches the sweep estimator.
+const unrollFeeConfTarget = 6
+
+// estimatedCPFPChildVBytes is a conservative virtual-size estimate for
+// the CPFP child transaction the txconfirm broadcaster builds for each
+// tree or checkpoint transaction during an unroll. The child spends the
+// ephemeral P2A anchor (tiny witness), one confirmed wallet fee input
+// (taproot key-spend), and creates one wallet change output (P2TR).
+// The actual size depends on the wallet's script type but taproot is the
+// dominant path and 155 vbytes gives comfortable headroom.
+const estimatedCPFPChildVBytes int64 = 155
+
+// estimatedSweepVBytes is a conservative virtual-size estimate for the
+// timeout-path sweep spend. Matches the constant used in the unroll
+// package so the pre-flight check is consistent with the actual sweep.
+const estimatedSweepVBytes int64 = 200
+
+// unrollFeeShortfall computes the total estimated fee budget for an
+// unroll and returns the shortfall (totalRequired - confirmedBalance).
+// A non-positive shortfall means the wallet has enough funds. This is
+// a pure function that can be tested independently of server wiring.
+func unrollFeeShortfall(numRecoveryTxs int, feeRate btcutil.Amount,
+	confirmedBalance btcutil.Amount) (totalRequired, shortfall btcutil.Amount) {
+
+	perChildFee := btcutil.Amount(
+		int64(feeRate) * estimatedCPFPChildVBytes,
+	)
+	cpfpTotal := perChildFee * btcutil.Amount(numRecoveryTxs)
+
+	sweepFee := btcutil.Amount(int64(feeRate) * estimatedSweepVBytes)
+
+	totalRequired = cpfpTotal + sweepFee
+
+	if confirmedBalance >= totalRequired {
+		return totalRequired, 0
+	}
+
+	return totalRequired, totalRequired - confirmedBalance
+}
+
+// checkUnrollFeeBalance estimates the total on-chain fees the wallet
+// will need to fund all CPFP children for the recovery tree
+// transactions, any OOR checkpoint ancestors, and the final timeout
+// sweep. If the wallet's confirmed balance is insufficient the method
+// returns a FailedPrecondition gRPC error with a message describing
+// the shortfall so the user can fund the wallet before retrying.
+//
+// This check runs BEFORE the VTXO transitions to the terminal
+// UnilateralExitState so that an under-funded wallet does not strand
+// the VTXO in a state where it can no longer be cooperatively
+// refreshed or forfeited.
+func (r *RPCServer) checkUnrollFeeBalance(
+	ctx context.Context, outpoint wire.OutPoint) error {
+
+	// Both the VTXO store and the chain backend are required to
+	// produce a meaningful estimate. If either is missing the daemon
+	// is still initializing, so skip the check and let the
+	// downstream admission path surface any issues.
+	if r.server.vtxoStore == nil || r.server.chainBackend == nil {
+		return nil
+	}
+
+	desc, err := r.server.vtxoStore.GetVTXO(ctx, outpoint)
+	if err != nil {
+		// If we can't load the descriptor we cannot estimate
+		// fees. Let the admission path handle the not-found
+		// case rather than blocking a potentially valid unroll.
+		return nil
+	}
+
+	// Count the number of recovery transactions that will need
+	// CPFP fee inputs. Each ancestry fragment contributes tree
+	// transactions; OOR VTXOs also add one checkpoint transaction
+	// per hop in the OOR chain (tracked by ChainDepth).
+	var numRecoveryTxs int
+	for _, a := range desc.Ancestry {
+		if a.TreePath != nil {
+			numRecoveryTxs += a.TreePath.NumTx()
+		} else if a.TreeDepth > 0 {
+			// If the tree was pruned but the depth was
+			// persisted, use that as a rough lower bound.
+			numRecoveryTxs += int(a.TreeDepth)
+		}
+	}
+
+	numRecoveryTxs += desc.ChainDepth
+
+	if numRecoveryTxs == 0 {
+		// No recovery transactions means the commitment is
+		// already confirmed (or metadata is missing). Nothing
+		// to check.
+		return nil
+	}
+
+	// Estimate the current fee rate. If estimation fails (cold
+	// backend, regtest) fall back to a modest 2 sat/vB so we do
+	// not block the unroll entirely.
+	feeRate, err := r.server.chainBackend.EstimateFee(
+		ctx, unrollFeeConfTarget,
+	)
+	if err != nil || feeRate <= 0 {
+		feeRate = 2
+	}
+
+	// Query the on-chain wallet balance.
+	confirmedBalance := sumOnchainWalletConfirmed(
+		ctx, r.walletBalanceFetchers(), func(fetchErr error) {
+			r.server.log.WarnS(ctx,
+				"Unable to fetch wallet balance for "+
+					"unroll fee check", fetchErr)
+		},
+	)
+
+	totalRequired, shortfall := unrollFeeShortfall(
+		numRecoveryTxs, feeRate, confirmedBalance,
+	)
+	if shortfall <= 0 {
+		return nil
+	}
+
+	return status.Errorf(codes.FailedPrecondition,
+		"on-chain wallet balance too low for unroll: need "+
+			"~%d sat to cover CPFP fees for %d recovery "+
+			"transaction(s) plus the sweep, but only %d sat "+
+			"confirmed; please deposit at least %d more sat "+
+			"and wait for confirmation before retrying",
+		int64(totalRequired), numRecoveryTxs,
+		int64(confirmedBalance), int64(shortfall),
+	)
 }
 
 // GetUnrollStatus returns the current status of an unroll job for the

--- a/darepod/rpc_server_test.go
+++ b/darepod/rpc_server_test.go
@@ -945,3 +945,132 @@ func TestGetInfoConcurrentOperatorTermsAccess(t *testing.T) {
 	cancel()
 	<-writerDone
 }
+
+// TestUnrollFeeShortfall exercises the pure fee-budget math used by
+// checkUnrollFeeBalance. The function takes the number of recovery
+// transactions (tree + OOR checkpoint), the estimated fee rate, and the
+// wallet's confirmed balance, then returns the total required fees and
+// any shortfall. A zero shortfall means the wallet has enough funds.
+func TestUnrollFeeShortfall(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		numRecoveryTxs   int
+		feeRate          btcutil.Amount
+		confirmedBalance btcutil.Amount
+		wantRequired     btcutil.Amount
+		wantShortfall    btcutil.Amount
+	}{
+		{
+			// 3 recovery txs at 10 sat/vB:
+			//   CPFP: 3 * (10 * 155) = 4650
+			//   Sweep: 10 * 200 = 2000
+			//   Total: 6650
+			// Balance 10000 > 6650 → no shortfall.
+			name:             "sufficient balance",
+			numRecoveryTxs:   3,
+			feeRate:          10,
+			confirmedBalance: 10_000,
+			wantRequired:     6_650,
+			wantShortfall:    0,
+		},
+		{
+			// Same math, but balance is only 1000.
+			// Shortfall = 6650 - 1000 = 5650.
+			name:             "insufficient balance",
+			numRecoveryTxs:   3,
+			feeRate:          10,
+			confirmedBalance: 1_000,
+			wantRequired:     6_650,
+			wantShortfall:    5_650,
+		},
+		{
+			// Zero confirmed balance.
+			// Shortfall = totalRequired.
+			name:             "zero balance",
+			numRecoveryTxs:   3,
+			feeRate:          10,
+			confirmedBalance: 0,
+			wantRequired:     6_650,
+			wantShortfall:    6_650,
+		},
+		{
+			// Exactly enough.
+			name:             "exact balance",
+			numRecoveryTxs:   3,
+			feeRate:          10,
+			confirmedBalance: 6_650,
+			wantRequired:     6_650,
+			wantShortfall:    0,
+		},
+		{
+			// Single recovery tx (shallow tree, no OOR).
+			// CPFP: 1 * (2 * 155) = 310
+			// Sweep: 2 * 200 = 400
+			// Total: 710
+			name:             "single recovery tx low fee",
+			numRecoveryTxs:   1,
+			feeRate:          2,
+			confirmedBalance: 500,
+			wantRequired:     710,
+			wantShortfall:    210,
+		},
+		{
+			// Deep tree (10 txs) + 2 OOR checkpoints at high
+			// fee rate.
+			// CPFP: 12 * (50 * 155) = 93000
+			// Sweep: 50 * 200 = 10000
+			// Total: 103000
+			name:             "deep tree with OOR and high fee",
+			numRecoveryTxs:   12,
+			feeRate:          50,
+			confirmedBalance: 50_000,
+			wantRequired:     103_000,
+			wantShortfall:    53_000,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotRequired, gotShortfall := unrollFeeShortfall(
+				tc.numRecoveryTxs, tc.feeRate,
+				tc.confirmedBalance,
+			)
+			require.Equal(t, tc.wantRequired, gotRequired,
+				"totalRequired mismatch")
+			require.Equal(t, tc.wantShortfall, gotShortfall,
+				"shortfall mismatch")
+		})
+	}
+}
+
+// TestCheckUnrollFeeBalanceSkipsWhenStoreNil verifies that the fee
+// check gracefully returns nil when the server's vtxoStore or
+// chainBackend is not yet initialized. This prevents the check from
+// blocking unroll requests during early daemon startup.
+func TestCheckUnrollFeeBalanceSkipsWhenStoreNil(t *testing.T) {
+	t.Parallel()
+
+	var hash chainhash.Hash
+	hash[0] = 0xab
+	outpoint := wire.OutPoint{Hash: hash, Index: 0}
+
+	t.Run("nil vtxoStore", func(t *testing.T) {
+		t.Parallel()
+
+		r := &RPCServer{
+			server: &Server{
+				// vtxoStore is nil, chainBackend is nil.
+			},
+		}
+
+		err := r.checkUnrollFeeBalance(
+			context.Background(), outpoint,
+		)
+		require.NoError(t, err)
+	})
+}


### PR DESCRIPTION
Fixes #450.

## Problem

Running `da unroll --outpoint <outpoint>` when the on-chain wallet has
zero confirmed balance irreversibly transitions the VTXO to
`UnilateralExitState`, then the unroll fails because there are no funds
for CPFP fee inputs. Once in `UnilateralExitState` the VTXO can no
longer be cooperatively refreshed or forfeited — the user is stuck.

## Solution

Add a pre-flight fee check in the `Unroll` RPC handler **before** the
VTXO transitions to the terminal state. The check:

1. Loads the VTXO descriptor and counts recovery transactions
   (tree path nodes from each ancestry fragment + OOR checkpoint hops).
2. Estimates the current fee rate (6-block target, falls back to 2
   sat/vB if estimation fails).
3. Computes total required fees:
   `(numRecoveryTxs × feeRate × 155vB) + (feeRate × 200vB)`
   where 155 vB is the estimated CPFP child size and 200 vB is the
   sweep transaction size.
4. Compares against the wallet's confirmed balance.
5. If insufficient, returns a `FailedPrecondition` gRPC error with a
   message describing exactly how many more sats are needed.

The check degrades gracefully: if the VTXO store, chain backend, or
descriptor is unavailable (daemon still initializing), it returns nil
and lets the downstream admission path handle errors.

## Test plan

- [x] `TestUnrollFeeShortfall` — table-driven tests covering sufficient
  balance, insufficient balance, zero balance, exact balance, single
  recovery tx, and deep tree + OOR scenarios.
- [x] `TestCheckUnrollFeeBalanceSkipsWhenStoreNil` — verifies the check
  gracefully skips when server stores are not initialized.
- [x] Existing `TestUnrollAdmissionSurvivesCallerCancellation` still
  passes (its test server has no vtxoStore/chainBackend, so the check
  returns nil).
- [x] `go build ./darepod/...` — clean.
- [x] `go vet ./darepod/...` — clean.
- [x] `go test ./darepod/...` — all pass.