### PR TITLE
multi: Make CI tests deterministic

### DIFF
--- a/baselib/actor/durable_actor_test.go
+++ b/baselib/actor/durable_actor_test.go
@@ -1840,14 +1840,16 @@ func TestDeliveryConcurrentExtendAndNack(t *testing.T) {
 	wg.Wait()
 }
 
-// TestDurableAskWithMailboxFull tests DurableAsk behavior when mailbox is full.
-func TestDurableAskWithMailboxFull(t *testing.T) {
+// TestDurableAskWithExpiredContext tests DurableAsk behavior when the caller
+// context has already expired.
+func TestDurableAskWithExpiredContext(t *testing.T) {
 	t.Parallel()
 
 	store := newMockDeliveryStore()
 	codec := newActorTestCodec()
 
-	// Create a behavior that blocks on receive.
+	// Create a behavior that would block on receive if the expired context
+	// did not prevent DurableAsk from enqueueing the message.
 	behavior := newMockBehavior(fn.Ok(42))
 	behavior.setDelay(5 * time.Second)
 
@@ -1867,25 +1869,14 @@ func TestDurableAskWithMailboxFull(t *testing.T) {
 
 	durableRef := actor.Ref().(DurableActorRef[*actorTestMsg, int])
 
-	// Send many messages to fill the mailbox.
-	for i := 0; i < 200; i++ {
-		_ = durableRef.DurableAsk(ctx, msg, DurableAskParams{
-			CallbackActorID: "callback-actor",
-			CorrelationID:   fmt.Sprintf("test-correlation-%d", i),
-		})
-	}
-
-	// Use a context with timeout that will be exceeded.
-	ctxTimeout, cancel := context.WithTimeout(ctx, 1*time.Millisecond)
+	ctxExpired, cancel := context.WithDeadline(
+		ctx, time.Now().Add(-time.Second),
+	)
 	defer cancel()
 
-	// Wait for context to expire.
-	time.Sleep(5 * time.Millisecond)
-
-	// This should fail when the context deadline is exceeded.
-	err := durableRef.DurableAsk(ctxTimeout, msg, DurableAskParams{
+	err := durableRef.DurableAsk(ctxExpired, msg, DurableAskParams{
 		CallbackActorID: "callback-actor",
-		CorrelationID:   "test-correlation-overflow",
+		CorrelationID:   "test-correlation-expired",
 	})
 
 	require.ErrorIs(t, err, context.DeadlineExceeded)

--- a/darepod/server_rpc_listener_test.go
+++ b/darepod/server_rpc_listener_test.go
@@ -97,9 +97,7 @@ func TestRunWithContextServesInjectedListener(t *testing.T) {
 	listener := bufconn.Listen(1 << 20)
 	cfg := testConfigWithInjectedRPCListener(listener)
 	cfg.DataDir = t.TempDir()
-	cfg.Wallet.Type = WalletTypeBtcwallet
-	cfg.Wallet.FeeURL = "http://127.0.0.1:3001"
-	cfg.Wallet.EsploraURL = ""
+	cfg.Wallet.Type = WalletTypeLwwallet
 	cfg.Wallet.DisableGlobalLoggers = true
 
 	server, err := NewServer(cfg)
@@ -115,7 +113,7 @@ func TestRunWithContextServesInjectedListener(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		return server.RPCAddr() != nil
-	}, 5*time.Second, 20*time.Millisecond)
+	}, 30*time.Second, 20*time.Millisecond)
 
 	connCtx, connCancel := context.WithTimeout(
 		context.Background(), 5*time.Second,

--- a/harness/harness.go
+++ b/harness/harness.go
@@ -115,6 +115,11 @@ const (
 	// long enough to observe the death window we have actually seen in
 	// CI.
 	bitcoindStartProbeDuration = 5 * time.Second
+
+	// maxDockerDNSLabelLen keeps container names within the DNS label size
+	// Docker's embedded resolver can reliably resolve inside harness
+	// networks.
+	maxDockerDNSLabelLen = 63
 )
 
 var (
@@ -200,9 +205,13 @@ type Harness struct {
 	// artifactsDir is the base dir for all artifacts (logs, data dirs).
 	artifactsDir string
 
-	// group is the optional group name for all resources (containers,
-	// network, dirs).
+	// group is the optional group name for artifacts and labels.
 	group string
+
+	// dockerNameSuffix keeps docker resource names unique even when
+	// parallel CI jobs run the same test name with the same explicit
+	// GroupName.
+	dockerNameSuffix string
 
 	// bitcoinDataDir is the bitcoind data dir (for blocks, chainstate,
 	// wallet).
@@ -298,8 +307,8 @@ type Options struct {
 	// ArtifactsBaseDir is the base directory to create store artifacts in.
 	ArtifactsBaseDir string
 
-	// GroupName is an optional name to group all resources (containers,
-	// network, dirs) under. If empty, a random suffix is used.
+	// GroupName is an optional name to group artifacts and labels under.
+	// Docker container names always add a per-harness suffix.
 	GroupName string
 
 	// HarnessLogStdOut if true, also prints harness logs to stdout in
@@ -464,6 +473,7 @@ func (h *Harness) setupArtifactsAndLogging() {
 	} else {
 		h.group = randSuffix()
 	}
+	h.dockerNameSuffix = randSuffix()
 
 	require.NoError(h.T, os.MkdirAll(h.opts.ArtifactsBaseDir, 0o755))
 
@@ -2668,15 +2678,24 @@ func imageTag(image string) string {
 	return ""
 }
 
-// containerName returns a container name, optionally with random suffix. If the
-// harness has an explicit GroupName, use it without suffix for predictable
-// names.
+// containerName returns a container name scoped to this harness instance.
 func (h *Harness) containerName(prefix string) string {
-	if h.opts.GroupName != "" {
-		return prefix + "-" + h.group
+	name := prefix + "-" + h.group
+	if h.dockerNameSuffix == "" {
+		if len(name) > maxDockerDNSLabelLen {
+			return name[:maxDockerDNSLabelLen]
+		}
+
+		return name
 	}
 
-	return prefix + "-" + h.group + "-" + randSuffix()
+	suffix := "-" + h.dockerNameSuffix
+	maxNameLen := maxDockerDNSLabelLen - len(suffix)
+	if len(name) > maxNameLen {
+		name = name[:maxNameLen]
+	}
+
+	return name + "-" + h.dockerNameSuffix
 }
 
 // randSuffix returns a short, random suffix suitable for naming resources.

--- a/harness/port_retry_test.go
+++ b/harness/port_retry_test.go
@@ -180,3 +180,23 @@ func TestContainerHasExactName(t *testing.T) {
 		})
 	}
 }
+
+// TestContainerNameIncludesHarnessSuffix verifies explicit group names still
+// get unique Docker resource names.
+func TestContainerNameIncludesHarnessSuffix(t *testing.T) {
+	t.Parallel()
+
+	h := &Harness{
+		group:            "TestFoo",
+		dockerNameSuffix: "abc12345",
+	}
+
+	require.Equal(t, "bitcoin-TestFoo-abc12345", h.containerName("bitcoin"))
+
+	h.group = "TestFraudResponseSpentVTXOCheckpointTimeoutSweep"
+	h.dockerNameSuffix = "l4zy091q"
+
+	name := h.containerName("bitcoin")
+	require.LessOrEqual(t, len(name), maxDockerDNSLabelLen)
+	require.Contains(t, name, "-l4zy091q")
+}


### PR DESCRIPTION
## Summary

- add a per-harness suffix to Docker container names even when `GroupName` is explicit
- keep explicit group names for artifacts and labels
- make the durable ask expired-context test deterministic by using an already-expired context
- keep the injected RPC listener test on the lightweight wallet path so it does not wait on unrelated btcwallet/neutrino startup

## Verification

- `go test ./harness -run 'Test(ContainerNameIncludesHarnessSuffix|ContainerHasExactName|RunWithPortBindRetry|IsDockerPortBindError)'`
- `go test ./baselib/actor -run '^TestDurableAskWithExpiredContext$' -count=100 -tags='dev nolog'`
- `go test ./darepod -run '^TestRunWithContextServesInjectedListener$' -count=100 -tags='dev nolog'`
- `make unit-cover`
- `make lint-native`
- from the server repo, concurrently ran `TestBoardingIntegrationSingleClientSubsequentRounds` for `lwwallet` and `btcwallet` with separate artifact bases; both passed