### PR TITLE
docs: nightly doc-gardening sweep 2026-05-16

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -18,6 +18,7 @@ package may import from a higher layer.
 | [`oor`](oor/) | Out-of-round transfer coordination FSM |
 | [`wallet`](wallet/) | On-chain boarding wallet actor (address derivation, UTXO monitoring) |
 | [`ledger`](ledger/) | Client-side durable ledger actor for double-entry fee accounting |
+| [`fraud`](fraud/) | Passive recipient fraud watcher actor: monitors ancestry spend notifications for received OOR VTXOs |
 | [`lib`](lib/) | Shared domain utilities: tree paths, BIP-322, arkscript policy, types |
 | [`lib/arkscript`](lib/arkscript/) | Tapscript AST compiler and policy system for Ark taproot outputs |
 | [`lib/bip322`](lib/bip322/) | BIP-322 intent-bound message authentication |
@@ -56,13 +57,14 @@ package may import from a higher layer.
 | [`sdk/swaps`](sdk/swaps/) | Lightning-to-Ark / Ark-to-Lightning atomic swap SDK with durable FSM flows |
 | [`sdk/walletdk`](sdk/walletdk/) | Wallet-shaped SDK facade for host apps: embeds the daemon in-process, dials it over a private bufconn transport, exposes typed onboarding / balance / receive / send / swap-accounting methods. Swap methods gated behind the `swapruntime` build tag |
 | [`swapclientserver`](swapclientserver/) | Optional daemon-side swap subserver (build tag `swapruntime`): translates `swapclientrpc` RPCs into `sdk/swaps` operations and manages the daemon-local worker registry |
+| [`swapwallet`](swapwallet/) | Daemon-side `WalletService` gRPC subserver (build tags `walletrpc`+`swapruntime`): exposes wallet lifecycle and boarding RPCs without swap vocabulary |
 | [`cmd/darepod`](cmd/darepod/) | Daemon entry point |
 | [`cmd/darepocli`](cmd/darepocli/) | CLI client |
 | [`timeout`](timeout/) | Generic timeout scheduling actor |
 | [`indexer`](indexer/) | Server indexing client for receive script registration |
 | [`arkrpc`](arkrpc/) | Server-side gRPC service definitions (ArkService, IndexerService) |
 | [`arkrpc/treeconv`](arkrpc/treeconv/) | Narrow re-export of tree-path conversion helpers without the full gRPC surface |
-| [`rpc`](rpc/) | Client-side RPC message definitions (roundpb, oorpb, swapclientrpc) |
+| [`rpc`](rpc/) | Client-side RPC message definitions (roundpb, oorpb, swapclientrpc, walletrpc) |
 | [`daemonrpc`](daemonrpc/) | Daemon gRPC API definitions |
 
 ### Layer 4: Testing & Tooling
@@ -72,6 +74,7 @@ package may import from a higher layer.
 | [`harness`](harness/) | Docker-based Bitcoin/LND integration test environment |
 | [`systest`](systest/) | System-level end-to-end tests |
 | [`internal/actortest`](internal/actortest/) | Durable actor integration tests with real DB backends |
+| [`internal/indexerlimits`](internal/indexerlimits/) | Shared client-side cursor caps and validation for indexer pagination queries |
 | [`internal/testutils`](internal/testutils/) | Deterministic key/signature generation for tests |
 | [`rules`](rules/) | ast-grep linting rules for code style enforcement |
 | [`tools`](tools/) | Development tool dependencies (protoc plugins, sqlc) |

--- a/baselib/actor/AGENTS.md
+++ b/baselib/actor/AGENTS.md
@@ -38,6 +38,20 @@ crash-safe at-least-once delivery with exactly-once deduplication.
 - `ChannelMailbox[M, R]` — In-memory channel-based mailbox (non-durable, for lightweight actors).
 - `Mailbox[M, R]` — Interface for actor message queues: `Send(ctx, env) error` (blocking, returns `ErrMailboxClosed` or `ErrActorTerminated` on failure), `TrySend(env) error` (non-blocking), `Receive(ctx) iter.Seq[envelope]`, `Close()`, `IsClosed() bool`, `Drain() iter.Seq[envelope]`. `Send` previously returned `bool`; it now propagates the exact failure cause so callers can distinguish `ErrMailboxClosed`, `ErrActorTerminated`, and `context.Canceled`/`context.DeadlineExceeded` without inspecting actor state.
 - `isExpectedShutdownErr(err) bool` — Internal helper that classifies errors as expected during teardown: context cancellation/deadline, closed DB handle ("sql: database is closed", "sql: connection is already closed", "use of closed network connection"). Used by the lease loop to demote shutdown-path failures to debug instead of warn-flooding test artifacts at itest tail.
+- `Message.CorrelationKey() string` — Per-message FIFO key consumed by the
+  durable mailbox's claim path. Non-empty keys participate in per-key FIFO:
+  a message is claim-eligible only when no earlier same-key message
+  (compared by UUIDv7 `id`) exists in the same mailbox, even if the
+  earlier message is in retry backoff. Empty (the default on
+  `BaseMessage`) means the message is unkeyed and uses the existing
+  global `available_at` claim order. The override site is the concrete
+  message struct (e.g. `clientconn.ClientMessage` types in `rounds`),
+  not the framework — the framework just plumbs the value through
+  `EnqueueParams.CorrelationKey`.
+- `EnqueueParams.CorrelationKey` — Per-enqueue override stamped into the
+  `mailbox_messages.correlation_key` column. Populated automatically from
+  `msg.CorrelationKey()` by `DurableMailbox.Send`. A zero (empty) value
+  preserves the legacy unkeyed claim semantics.
 
 ## Relationships
 
@@ -54,6 +68,20 @@ crash-safe at-least-once delivery with exactly-once deduplication.
 - Transaction context (`WithTx`/`RequireTx`) enables same-DB-transaction joining between actors and their callers.
 - `Mailbox.Send` returns the exact failure error (`ErrMailboxClosed`, `ErrActorTerminated`, `context.Canceled`, `context.DeadlineExceeded`) rather than a boolean; `Tell` and `Ask` propagate this directly to callers.
 - During daemon teardown, the underlying DB is closed before every actor's lease loop has wound down. The lease loop uses `isExpectedShutdownErr` to demote these "database is closed" errors to debug level; real operational errors still surface as warnings because neither the actor context nor the outer context is done in those cases.
+- **Per-correlation-key FIFO claim.** Two messages in the same mailbox that
+  share a non-empty `CorrelationKey()` are processed in emission order
+  regardless of retry backoff. Without this invariant, a transient Tell
+  failure on msg1 would Nack-with-backoff (push `available_at` into the
+  future), and a later-enqueued msg2 with a smaller `available_at` would
+  overtake msg1 in the `LeaseNextMailboxMessage` claim. The fix is an
+  anti-join on `mailbox_messages.id` (UUIDv7, strictly orderable at
+  millisecond granularity) so the head of each correlation key drains
+  before any later same-key row is claim-eligible. Unkeyed messages
+  (empty `CorrelationKey()`) keep the legacy global `available_at`
+  order and do not interfere with keyed lanes. Head-of-line blocking
+  is bounded to the correlation key, not the mailbox; consumers are
+  already strictly serial per mailbox so this does not regress
+  throughput.
 
 ## Deep Docs
 

--- a/cmd/darepocli/darepoclicommands/AGENTS.md
+++ b/cmd/darepocli/darepoclicommands/AGENTS.md
@@ -20,6 +20,10 @@ embed the same command tree.
   subcommand and MCP tool definitions. Built from `baseMethodRegistry`,
   `vtxoLifecycleMethodRegistry`, and `sendMethodRegistry` sub-registries
   to stay within the `funlen` lint cap.
+- `getWalletClient()` — Connects to the daemon's `walletrpc` subserver
+  (built only with the `walletrpc` + `swapruntime` tags).
+- `devrpc.NewDevCmd(cfg)` — Mounts the generated low-level `dev [service]
+  [call]` command tree from the `devrpc` sub-package.
 
 ## Commands
 
@@ -70,6 +74,18 @@ embed the same command tree.
 | `unroll` | `Unroll` | Trigger a unilateral exit for the VTXO at `--outpoint txid:index`. Routes through the VTXO manager's `ForceUnrollRequest` path so the FSM transitions cleanly; the registry job is created async via the chain resolver seam. Response includes `Created` (false if already exiting) and the `ActorId` to poll. |
 | `unroll status` | `GetUnrollStatus` | Query progress for an unroll job by `--outpoint`. Reads through to the live registry first and falls back to the persisted `unilateral_exit_jobs` table for evicted/terminal jobs; `Found=false` (not an error) distinguishes "no such job" from lookup failure. |
 
+### Wallet RPC commands (`cmd_wallet_rpc.go`, `walletrpc` + `swapruntime` tags only)
+
+These commands connect to the daemon-owned `WalletService` subserver.
+
+| Command | RPC | Description |
+|---------|-----|-------------|
+| `wallet send` | `Send` | Send to an invoice or onchain address via the wallet subserver |
+| `wallet recv` | `Recv` | Open a receive swap, return BOLT-11 invoice |
+| `wallet list` | `List` | List unified wallet history (swap, OOR, boarding, exit) |
+| `wallet deposit` | `Deposit` | Return a fresh boarding address |
+| `wallet status` | `Status` | Show unified balance and pending-entry summary |
+
 ### Lightning swap commands (`cmd_swap_rpc.go`, `swapruntime` tag only)
 
 These commands connect to the daemon-owned `SwapClientService` subserver.
@@ -87,8 +103,9 @@ The daemon owns the background worker; CLI exit does not cancel an admitted swap
 ## Relationships
 
 - **Depends on**: `daemonrpc` (generated gRPC client stubs for the main
-  daemon service), `rpc/swapclientrpc` (generated gRPC stubs for the
-  optional swap subserver, `swapruntime` tag only).
+  daemon service), `rpc/swapclientrpc` (swap subserver stubs, `swapruntime`
+  tag only), `rpc/walletrpc` (wallet subserver stubs, `walletrpc` +
+  `swapruntime` tags only), `devrpc` (generated low-level dev command tree).
 - **Depended on by**: `cmd/darepocli` (main entry point).
 
 ## Deep Docs

--- a/cmd/darepocli/darepoclicommands/CLAUDE.md
+++ b/cmd/darepocli/darepoclicommands/CLAUDE.md
@@ -20,6 +20,10 @@ embed the same command tree.
   subcommand and MCP tool definitions. Built from `baseMethodRegistry`,
   `vtxoLifecycleMethodRegistry`, and `sendMethodRegistry` sub-registries
   to stay within the `funlen` lint cap.
+- `getWalletClient()` — Connects to the daemon's `walletrpc` subserver
+  (built only with the `walletrpc` + `swapruntime` tags).
+- `devrpc.NewDevCmd(cfg)` — Mounts the generated low-level `dev [service]
+  [call]` command tree from the `devrpc` sub-package.
 
 ## Commands
 
@@ -70,6 +74,18 @@ embed the same command tree.
 | `unroll` | `Unroll` | Trigger a unilateral exit for the VTXO at `--outpoint txid:index`. Routes through the VTXO manager's `ForceUnrollRequest` path so the FSM transitions cleanly; the registry job is created async via the chain resolver seam. Response includes `Created` (false if already exiting) and the `ActorId` to poll. |
 | `unroll status` | `GetUnrollStatus` | Query progress for an unroll job by `--outpoint`. Reads through to the live registry first and falls back to the persisted `unilateral_exit_jobs` table for evicted/terminal jobs; `Found=false` (not an error) distinguishes "no such job" from lookup failure. |
 
+### Wallet RPC commands (`cmd_wallet_rpc.go`, `walletrpc` + `swapruntime` tags only)
+
+These commands connect to the daemon-owned `WalletService` subserver.
+
+| Command | RPC | Description |
+|---------|-----|-------------|
+| `wallet send` | `Send` | Send to an invoice or onchain address via the wallet subserver |
+| `wallet recv` | `Recv` | Open a receive swap, return BOLT-11 invoice |
+| `wallet list` | `List` | List unified wallet history (swap, OOR, boarding, exit) |
+| `wallet deposit` | `Deposit` | Return a fresh boarding address |
+| `wallet status` | `Status` | Show unified balance and pending-entry summary |
+
 ### Lightning swap commands (`cmd_swap_rpc.go`, `swapruntime` tag only)
 
 These commands connect to the daemon-owned `SwapClientService` subserver.
@@ -87,8 +103,9 @@ The daemon owns the background worker; CLI exit does not cancel an admitted swap
 ## Relationships
 
 - **Depends on**: `daemonrpc` (generated gRPC client stubs for the main
-  daemon service), `rpc/swapclientrpc` (generated gRPC stubs for the
-  optional swap subserver, `swapruntime` tag only).
+  daemon service), `rpc/swapclientrpc` (swap subserver stubs, `swapruntime`
+  tag only), `rpc/walletrpc` (wallet subserver stubs, `walletrpc` +
+  `swapruntime` tags only), `devrpc` (generated low-level dev command tree).
 - **Depended on by**: `cmd/darepocli` (main entry point).
 
 ## Deep Docs

--- a/cmd/darepocli/darepoclicommands/devrpc/AGENTS.md
+++ b/cmd/darepocli/darepoclicommands/devrpc/AGENTS.md
@@ -1,0 +1,46 @@
+# devrpc
+
+## Purpose
+
+Generated low-level CLI command tree for the `darepocli dev` subcommand.
+Dynamically builds cobra commands from the daemon's proto file descriptors so
+every gRPC service and method is reachable from the CLI without hand-writing
+one command per RPC.
+
+## Key Types
+
+- `NewDevCmd(Config)` — Entry point. Builds the full `dev [service] [call]`
+  cobra command tree from the service registry. Returns a usable command even
+  when the registry fails to load (the failure surfaces at run time so the
+  `--help` path still works).
+- `Config` — Wiring configuration for the generated command tree, providing
+  the gRPC connection factory used when a method command is executed.
+- `registry_generated.go` — Machine-generated service registry produced by
+  `cmd/darepocli/internal/gen-devrpc`. Do not edit by hand; regenerate via
+  `make rpc` (or the relevant make target).
+
+## Relationships
+
+- **Depends on**: `daemonrpc` (proto descriptors for DaemonService),
+  `rpc/swapclientrpc` (proto descriptors for SwapClientService),
+  `google.golang.org/protobuf` (dynamic proto reflection and JSON marshalling).
+- **Depended on by**: `cmd/darepocli/darepoclicommands` (registers `dev` as a
+  subcommand of the root CLI).
+- **Sends**: → daemon gRPC endpoint: arbitrary method calls driven by proto
+  reflection.
+- **Receives**: ← API: CLI invocation with flag-bound proto field values.
+
+## Invariants
+
+- `registry_generated.go` is generated code — never edit it manually.
+  Regenerate via the `gen-devrpc` binary (see `cmd/darepocli/internal/gen-devrpc`).
+- Field binders are built from proto field descriptors at command
+  construction time; flag names match proto field names with hyphens for
+  nested fields.
+- JSON marshalling uses `google.golang.org/protobuf/encoding/protojson` for
+  round-trip-safe output.
+
+## Deep Docs
+
+- [docs/daemon_cli_guide.md](../../../../docs/daemon_cli_guide.md) — CLI reference.
+- [ARCHITECTURE.md](../../../../ARCHITECTURE.md) — System-wide package map.

--- a/cmd/darepocli/darepoclicommands/devrpc/CLAUDE.md
+++ b/cmd/darepocli/darepoclicommands/devrpc/CLAUDE.md
@@ -1,0 +1,46 @@
+# devrpc
+
+## Purpose
+
+Generated low-level CLI command tree for the `darepocli dev` subcommand.
+Dynamically builds cobra commands from the daemon's proto file descriptors so
+every gRPC service and method is reachable from the CLI without hand-writing
+one command per RPC.
+
+## Key Types
+
+- `NewDevCmd(Config)` — Entry point. Builds the full `dev [service] [call]`
+  cobra command tree from the service registry. Returns a usable command even
+  when the registry fails to load (the failure surfaces at run time so the
+  `--help` path still works).
+- `Config` — Wiring configuration for the generated command tree, providing
+  the gRPC connection factory used when a method command is executed.
+- `registry_generated.go` — Machine-generated service registry produced by
+  `cmd/darepocli/internal/gen-devrpc`. Do not edit by hand; regenerate via
+  `make rpc` (or the relevant make target).
+
+## Relationships
+
+- **Depends on**: `daemonrpc` (proto descriptors for DaemonService),
+  `rpc/swapclientrpc` (proto descriptors for SwapClientService),
+  `google.golang.org/protobuf` (dynamic proto reflection and JSON marshalling).
+- **Depended on by**: `cmd/darepocli/darepoclicommands` (registers `dev` as a
+  subcommand of the root CLI).
+- **Sends**: → daemon gRPC endpoint: arbitrary method calls driven by proto
+  reflection.
+- **Receives**: ← API: CLI invocation with flag-bound proto field values.
+
+## Invariants
+
+- `registry_generated.go` is generated code — never edit it manually.
+  Regenerate via the `gen-devrpc` binary (see `cmd/darepocli/internal/gen-devrpc`).
+- Field binders are built from proto field descriptors at command
+  construction time; flag names match proto field names with hyphens for
+  nested fields.
+- JSON marshalling uses `google.golang.org/protobuf/encoding/protojson` for
+  round-trip-safe output.
+
+## Deep Docs
+
+- [docs/daemon_cli_guide.md](../../../../docs/daemon_cli_guide.md) — CLI reference.
+- [ARCHITECTURE.md](../../../../ARCHITECTURE.md) — System-wide package map.

--- a/cmd/darepocli/internal/gen-devrpc/AGENTS.md
+++ b/cmd/darepocli/internal/gen-devrpc/AGENTS.md
@@ -1,0 +1,37 @@
+# gen-devrpc
+
+## Purpose
+
+Code generator (run via `go generate` or a make target) that walks the
+registered proto service descriptors for `DaemonService` and
+`SwapClientService` and emits `cmd/darepocli/darepoclicommands/devrpc/registry_generated.go`,
+the static registry consumed by the `darepocli dev` dynamic command tree.
+
+## Key Types
+
+- `main` — Collects service descriptors from compiled-in proto files,
+  renders Go source via a text template, formats it with `go/format`, and
+  writes the output file.
+- `serviceData` / `methodData` — Intermediate structs holding service and
+  method metadata (full name, Go name, aliases, comments) used during
+  template rendering.
+
+## Relationships
+
+- **Depends on**: `daemonrpc` (proto file descriptor for DaemonService),
+  `rpc/swapclientrpc` (proto file descriptor for SwapClientService),
+  `google.golang.org/protobuf/reflect/protoreflect` (descriptor introspection).
+- **Depended on by**: nothing at runtime; this is a build-time tool only.
+- **Generates**: `cmd/darepocli/darepoclicommands/devrpc/registry_generated.go`.
+
+## Invariants
+
+- The generator must be re-run after any `.proto` change that adds or renames
+  a service or method visible to `darepocli dev`.
+- `expectedServices` is a hardcoded allowlist; services not in the list are
+  skipped, and missing expected services cause a fatal error so the generator
+  fails loudly rather than silently omitting a service.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../../../ARCHITECTURE.md) — System-wide package map.

--- a/cmd/darepocli/internal/gen-devrpc/CLAUDE.md
+++ b/cmd/darepocli/internal/gen-devrpc/CLAUDE.md
@@ -1,0 +1,37 @@
+# gen-devrpc
+
+## Purpose
+
+Code generator (run via `go generate` or a make target) that walks the
+registered proto service descriptors for `DaemonService` and
+`SwapClientService` and emits `cmd/darepocli/darepoclicommands/devrpc/registry_generated.go`,
+the static registry consumed by the `darepocli dev` dynamic command tree.
+
+## Key Types
+
+- `main` — Collects service descriptors from compiled-in proto files,
+  renders Go source via a text template, formats it with `go/format`, and
+  writes the output file.
+- `serviceData` / `methodData` — Intermediate structs holding service and
+  method metadata (full name, Go name, aliases, comments) used during
+  template rendering.
+
+## Relationships
+
+- **Depends on**: `daemonrpc` (proto file descriptor for DaemonService),
+  `rpc/swapclientrpc` (proto file descriptor for SwapClientService),
+  `google.golang.org/protobuf/reflect/protoreflect` (descriptor introspection).
+- **Depended on by**: nothing at runtime; this is a build-time tool only.
+- **Generates**: `cmd/darepocli/darepoclicommands/devrpc/registry_generated.go`.
+
+## Invariants
+
+- The generator must be re-run after any `.proto` change that adds or renames
+  a service or method visible to `darepocli dev`.
+- `expectedServices` is a hardcoded allowlist; services not in the list are
+  skipped, and missing expected services cause a fatal error so the generator
+  fails loudly rather than silently omitting a service.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../../../ARCHITECTURE.md) — System-wide package map.

--- a/cmd/darepod/AGENTS.md
+++ b/cmd/darepod/AGENTS.md
@@ -3,9 +3,32 @@
 ## Purpose
 
 Daemon entry point. Parses flags, initializes configuration, and starts the
-`darepod.Server`.
+`darepod.Server`. Exposes `--logdir` and `--configfile` flags for persistent
+log directory override and config file selection. Conditionally registers the
+optional walletrpc subserver (`walletrpc` + `swapruntime` build tags).
+
+## Key Types
+
+- `configureSwapRuntime(cfg)` — Registers `swapclientserver` as an
+  `RPCServiceRegistrar` when the `swapruntime` build tag is present.
+- `configureWalletRPC(cfg)` — Registers `swapwallet` as an
+  `RPCServiceRegistrar` and sets `SwapConfig.SuppressResume=true` when both
+  `walletrpc` and `swapruntime` build tags are present. The stub version is a
+  no-op.
+- `readConfigFile(v, cmd)` — Loads daemon config from the file indicated by
+  `--configfile` (defaults to `<datadir>/darepod.conf`). Missing default
+  config files are silently ignored; explicitly specified files must exist.
+- `bindOORLimitFlags(v, f)` — Binds hyphenated CLI flag names to the
+  mapstructure keys used internally (e.g. `oor.limits.max-mailbox-script-bytes`
+  → `oor.limits.maxmailboxscriptbytes`).
 
 ## Relationships
 
-- **Depends on**: `darepod` (Server orchestrator).
+- **Depends on**: `darepod` (Server orchestrator), `swapclientserver`
+  (`swapruntime` tag only), `swapwallet` (`walletrpc` + `swapruntime` tags).
 - **Depended on by**: nothing (binary entry point).
+
+## Deep Docs
+
+- [docs/daemon_cli_guide.md](../../docs/daemon_cli_guide.md) — CLI reference.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/cmd/darepod/CLAUDE.md
+++ b/cmd/darepod/CLAUDE.md
@@ -3,9 +3,32 @@
 ## Purpose
 
 Daemon entry point. Parses flags, initializes configuration, and starts the
-`darepod.Server`.
+`darepod.Server`. Exposes `--logdir` and `--configfile` flags for persistent
+log directory override and config file selection. Conditionally registers the
+optional walletrpc subserver (`walletrpc` + `swapruntime` build tags).
+
+## Key Types
+
+- `configureSwapRuntime(cfg)` — Registers `swapclientserver` as an
+  `RPCServiceRegistrar` when the `swapruntime` build tag is present.
+- `configureWalletRPC(cfg)` — Registers `swapwallet` as an
+  `RPCServiceRegistrar` and sets `SwapConfig.SuppressResume=true` when both
+  `walletrpc` and `swapruntime` build tags are present. The stub version is a
+  no-op.
+- `readConfigFile(v, cmd)` — Loads daemon config from the file indicated by
+  `--configfile` (defaults to `<datadir>/darepod.conf`). Missing default
+  config files are silently ignored; explicitly specified files must exist.
+- `bindOORLimitFlags(v, f)` — Binds hyphenated CLI flag names to the
+  mapstructure keys used internally (e.g. `oor.limits.max-mailbox-script-bytes`
+  → `oor.limits.maxmailboxscriptbytes`).
 
 ## Relationships
 
-- **Depends on**: `darepod` (Server orchestrator).
+- **Depends on**: `darepod` (Server orchestrator), `swapclientserver`
+  (`swapruntime` tag only), `swapwallet` (`walletrpc` + `swapruntime` tags).
 - **Depended on by**: nothing (binary entry point).
+
+## Deep Docs
+
+- [docs/daemon_cli_guide.md](../../docs/daemon_cli_guide.md) — CLI reference.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/daemonrpc/AGENTS.md
+++ b/daemonrpc/AGENTS.md
@@ -2,13 +2,23 @@
 
 ## Purpose
 
-Daemon gRPC API definitions for wallet operations and round queries. Proto
-source: `daemonrpc/daemon.proto`.
+Daemon gRPC API definitions for wallet operations, round queries, and
+lifecycle surfaces. Generated protobuf stubs; proto source:
+`daemonrpc/daemon.proto`.
+
+## Key Types (notable additions)
+
+- `WalletState` — Tri-state wallet lifecycle enum
+  (`WALLET_STATE_NONE`, `WALLET_STATE_LOCKED`, `WALLET_STATE_READY`)
+  surfaced in `GetInfoResponse.WalletState` so callers can distinguish
+  not-yet-created from locked from ready without string-matching log output.
 
 ## Relationships
 
-- **Depends on**: nothing (proto definitions).
-- **Depended on by**: `darepod` (implements services), `cmd/darepocli` (uses generated clients).
+- **Depends on**: nothing (proto definitions + generated stubs).
+- **Depended on by**: `darepod` (implements services), `cmd/darepocli`
+  (generated gRPC clients), `sdk/walletdk` (daemon RPC client),
+  `cmd/darepocli/internal/gen-devrpc` (proto descriptor introspection).
 
 ## Invariants
 

--- a/daemonrpc/CLAUDE.md
+++ b/daemonrpc/CLAUDE.md
@@ -2,13 +2,23 @@
 
 ## Purpose
 
-Daemon gRPC API definitions for wallet operations and round queries. Proto
-source: `daemonrpc/daemon.proto`.
+Daemon gRPC API definitions for wallet operations, round queries, and
+lifecycle surfaces. Generated protobuf stubs; proto source:
+`daemonrpc/daemon.proto`.
+
+## Key Types (notable additions)
+
+- `WalletState` — Tri-state wallet lifecycle enum
+  (`WALLET_STATE_NONE`, `WALLET_STATE_LOCKED`, `WALLET_STATE_READY`)
+  surfaced in `GetInfoResponse.WalletState` so callers can distinguish
+  not-yet-created from locked from ready without string-matching log output.
 
 ## Relationships
 
-- **Depends on**: nothing (proto definitions).
-- **Depended on by**: `darepod` (implements services), `cmd/darepocli` (uses generated clients).
+- **Depends on**: nothing (proto definitions + generated stubs).
+- **Depended on by**: `darepod` (implements services), `cmd/darepocli`
+  (generated gRPC clients), `sdk/walletdk` (daemon RPC client),
+  `cmd/darepocli/internal/gen-devrpc` (proto descriptor introspection).
 
 ## Invariants
 

--- a/darepod/AGENTS.md
+++ b/darepod/AGENTS.md
@@ -10,12 +10,44 @@ gRPC API.
 
 - `Server` — Main daemon owning wallet, DB, chainsource actor, gRPC server, and ActorSystem. Caches `localMailboxID` (pubkey-derived), `authSigHex` (Schnorr auth) and a single `clk` (`clock.Clock`) that all sub-stores share for deterministic time injection.
 - `RPCServer` — Implements the gRPC `DaemonService` API (Board, ListRounds, WatchRounds, NewReceiveScript, SendVTXO, etc.). Includes test hooks for mailbox edge factory and round registration. Holds an in-memory `customInputLocks` map (guarded by `customInputLocksMu`) that reserves custom OOR input outpoints for the duration of a `SendOOR` call to prevent concurrent callers from double-signing the same custom input.
-- `Config` — Daemon configuration (data dir, network, RPC host, wallet type, etc.). Includes `MailboxEdgeFactory` hook for test harness transport interception and `PackageSubmitter chainbackends.PackageSubmitter` for injecting a v3 CPFP package submitter (set by the test harness via `BitcoindPackageSubmitter`, and by `cmd/darepod` from `bitcoind.{host,user,pass}` flags when present; not serialized to config files). Also carries an optional `Unroll *UnrollConfig` tuning block, and a `MaxOperatorFeeSat int64` cap fed into `ClientEnvironment.MaxOperatorFee`. Under the #270 seal-time fee handshake every server-issued `JoinRoundQuote` is compared against this cap; `Config.Validate()` fails closed when the value is non-positive (zero / unset is a misconfiguration, not "no cap"). The CLI exposes the knob as `--maxoperatorfeesat`; `DefaultMaxOperatorFeeSat` provides a generous default so a user who builds from defaults never runs with the cap fail-closed by accident.
+- `Config` — Daemon configuration (data dir, network, RPC host, wallet type,
+  etc.). Includes `MailboxEdgeFactory` hook for test harness transport
+  interception, `PackageSubmitter chainbackends.PackageSubmitter` for injecting
+  a v3 CPFP package submitter, optional `Unroll *UnrollConfig` tuning, optional
+  `Swap *SwapConfig` (swap subserver config), optional
+  `SwapWallet *SwapWalletConfig` (wallet subserver config), and
+  `MaxOperatorFeeSat int64` cap. New: `LogDirPath string` overrides the
+  network-scoped log directory used by the CLI (`logdir` mapstructure key); when
+  empty, logs go to `DataDir/logs/<network>`.
+- `SwapConfig` — Swap subserver config. New fields: `SuppressResume bool`
+  (programmatic; suppresses the swap subserver's own resume sweep so a higher
+  layer can own the lifecycle) and `Backend SwapBackend` (set by
+  `swapclientserver.Register` after the swap subserver wires; lets the walletrpc
+  subserver drive `ResumePending` in-process).
+- `SwapBackend` — Interface exposed by `swapclientserver` after `Register`:
+  `ResumePending(ctx)`. Allows walletrpc to own the unified resume policy
+  without dialing the daemon's gRPC server from inside the same process.
+- `SwapWalletConfig` — Configuration for the optional walletrpc subserver
+  (compiled in when both `walletrpc` + `swapruntime` build tags are present).
+  Fields: `Deadline`, `DefaultListLimit`, `MaxListLimit`, `SubscribeBuffer`.
+  Present in all builds so config files stay stable; fields are inert in default
+  builds.
 - `UnrollConfig` — Tuning for the unilateral-exit subsystem. Fields: `BumpAfterBlocks int32` (fee-bump cadence; zero → default 6) and `MaxFeeRateSatPerVByte int64` (cap fed to both `txconfirm` and the unroll registry; zero → each subsystem's own default). Surfaced on the `Server` via `unrollMaxFeeRate()` which gates non-positive values to zero.
 - `TriggerRoundRegistration` — Test-hook method that injects a round registration event into the round actor (in `server_round_testhook.go`).
 - `GetStoredVTXO` — Harness-only accessor that returns a persisted `vtxo.Descriptor` for a given outpoint directly from the daemon's VTXO store. Lets integration tests inspect partial unroll state without reaching into internal fields.
 - `GetVTXOLineageTx` / `VTXOLineageEntry` — Harness-only accessor that returns one transaction in a VTXO's recovery lineage plus the outpoints of its parent txs. Callers walk the lineage by recursively calling with each returned parent outpoint until `OnChainRoot=true` (the parent is the on-chain batch tx). Implemented on top of the same `unroll.LocalProofAssembler` the unroll registry uses (stashed on `Server.proofAssembler` during `initUnrollSubsystem`), but routed through the assembler's terminal-tolerant `EnsureProofForHarness` entry point so the historical lineage of an already-spent or already-forfeited VTXO is still walkable — that is the load-bearing capability for fraud-response itests where the harness force-broadcasts lineage txs of a terminal VTXO to provoke server-side classification + response. The field type `harnessProofAssembler` is a 1-method local interface that exposes ONLY the terminal-tolerant entry point, so production code paths cannot reach `EnsureProof` through this seam — production proof assembly flows exclusively through the unroll registry's own `ProofAssembler` reference, which keeps the terminal-status guard in force. NOT for production use.
 - `WalletState` — Enum (None/Locked/Ready) for wallet lifecycle.
+- `WalletLifecycleState()` — Public `Server` method returning current
+  `WalletState`. Surfaced via `GetInfo` RPC as `daemonrpc.WalletState` so
+  callers can distinguish not-yet-created from locked from ready.
+- `boardingSweepWatcher` / `resumeBoardingSweeps` / `replayPendingBoardRequest`
+  — Boarding sweep subsystem moved from direct `darepod` handlers to the wallet
+  actor. The daemon calls `resumeBoardingSweeps` (step 13) and
+  `replayPendingBoardRequest` (step 13b) after txconfirm and the round-client
+  actor register with the receptionist.
+- `fraudWatcher` / `fraudWatcherRef` — Passive recipient fraud watcher wired
+  during `initOORActor`. Arms spend watches on OOR VTXO ancestors and triggers
+  unilateral exit via the unroll registry on fraud detection.
 - `serverDurableUnaryBuilder` — Implements `serverconn.DurableUnaryRequestBuilder` by delegating to the indexer client with proof-of-control credentials.
 - `IndexerProofKey` — Public server method that derives the fixed wallet key for a given key locator and returns an `indexer.SchnorrSigner` backed by the proof-key backend. Used by `EnsureDefaultOORReceiveScript` and the `serverDurableUnaryBuilder` to produce per-request proof-of-control signatures.
 - `NewOwnedReceiveScriptSigner` — Indexer signer that resolves the wallet key for any persisted owned receive script, then delegates signing to the backend-specific signer.
@@ -63,7 +95,11 @@ gRPC API.
 
 ## Relationships
 
-- **Depends on**: `baselib/actor` (ActorSystem), `btcwbackend`, `chainbackends`, `chainsource`, `lib/actormsg`, `db`, `ledger` (accounting actor), `round`, `txconfirm`, `unroll`, `vtxo`, `wallet`, `walletcore`, `oor`, `serverconn`, `indexer`, `arkrpc`, `lndbackend`, `harness` (bitcoind package submitter wiring in `cmd/darepod`).
+- **Depends on**: `baselib/actor` (ActorSystem), `btcwbackend`, `chainbackends`,
+  `chainsource`, `lib/actormsg`, `db`, `ledger` (accounting actor), `round`,
+  `txconfirm`, `unroll`, `vtxo`, `wallet`, `walletcore`, `oor`, `serverconn`,
+  `indexer`, `arkrpc`, `lndbackend`, `fraud` (recipient fraud watcher),
+  `harness` (bitcoind package submitter wiring in `cmd/darepod`).
 - **Depended on by**: `cmd/darepod` (main entry point).
 
 ## Invariants

--- a/darepod/CLAUDE.md
+++ b/darepod/CLAUDE.md
@@ -10,12 +10,44 @@ gRPC API.
 
 - `Server` — Main daemon owning wallet, DB, chainsource actor, gRPC server, and ActorSystem. Caches `localMailboxID` (pubkey-derived), `authSigHex` (Schnorr auth) and a single `clk` (`clock.Clock`) that all sub-stores share for deterministic time injection.
 - `RPCServer` — Implements the gRPC `DaemonService` API (Board, ListRounds, WatchRounds, NewReceiveScript, SendVTXO, etc.). Includes test hooks for mailbox edge factory and round registration. Holds an in-memory `customInputLocks` map (guarded by `customInputLocksMu`) that reserves custom OOR input outpoints for the duration of a `SendOOR` call to prevent concurrent callers from double-signing the same custom input.
-- `Config` — Daemon configuration (data dir, network, RPC host, wallet type, etc.). Includes `MailboxEdgeFactory` hook for test harness transport interception and `PackageSubmitter chainbackends.PackageSubmitter` for injecting a v3 CPFP package submitter (set by the test harness via `BitcoindPackageSubmitter`, and by `cmd/darepod` from `bitcoind.{host,user,pass}` flags when present; not serialized to config files). Also carries an optional `Unroll *UnrollConfig` tuning block, and a `MaxOperatorFeeSat int64` cap fed into `ClientEnvironment.MaxOperatorFee`. Under the #270 seal-time fee handshake every server-issued `JoinRoundQuote` is compared against this cap; `Config.Validate()` fails closed when the value is non-positive (zero / unset is a misconfiguration, not "no cap"). The CLI exposes the knob as `--maxoperatorfeesat`; `DefaultMaxOperatorFeeSat` provides a generous default so a user who builds from defaults never runs with the cap fail-closed by accident.
+- `Config` — Daemon configuration (data dir, network, RPC host, wallet type,
+  etc.). Includes `MailboxEdgeFactory` hook for test harness transport
+  interception, `PackageSubmitter chainbackends.PackageSubmitter` for injecting
+  a v3 CPFP package submitter, optional `Unroll *UnrollConfig` tuning, optional
+  `Swap *SwapConfig` (swap subserver config), optional
+  `SwapWallet *SwapWalletConfig` (wallet subserver config), and
+  `MaxOperatorFeeSat int64` cap. New: `LogDirPath string` overrides the
+  network-scoped log directory used by the CLI (`logdir` mapstructure key); when
+  empty, logs go to `DataDir/logs/<network>`.
+- `SwapConfig` — Swap subserver config. New fields: `SuppressResume bool`
+  (programmatic; suppresses the swap subserver's own resume sweep so a higher
+  layer can own the lifecycle) and `Backend SwapBackend` (set by
+  `swapclientserver.Register` after the swap subserver wires; lets the walletrpc
+  subserver drive `ResumePending` in-process).
+- `SwapBackend` — Interface exposed by `swapclientserver` after `Register`:
+  `ResumePending(ctx)`. Allows walletrpc to own the unified resume policy
+  without dialing the daemon's gRPC server from inside the same process.
+- `SwapWalletConfig` — Configuration for the optional walletrpc subserver
+  (compiled in when both `walletrpc` + `swapruntime` build tags are present).
+  Fields: `Deadline`, `DefaultListLimit`, `MaxListLimit`, `SubscribeBuffer`.
+  Present in all builds so config files stay stable; fields are inert in default
+  builds.
 - `UnrollConfig` — Tuning for the unilateral-exit subsystem. Fields: `BumpAfterBlocks int32` (fee-bump cadence; zero → default 6) and `MaxFeeRateSatPerVByte int64` (cap fed to both `txconfirm` and the unroll registry; zero → each subsystem's own default). Surfaced on the `Server` via `unrollMaxFeeRate()` which gates non-positive values to zero.
 - `TriggerRoundRegistration` — Test-hook method that injects a round registration event into the round actor (in `server_round_testhook.go`).
 - `GetStoredVTXO` — Harness-only accessor that returns a persisted `vtxo.Descriptor` for a given outpoint directly from the daemon's VTXO store. Lets integration tests inspect partial unroll state without reaching into internal fields.
 - `GetVTXOLineageTx` / `VTXOLineageEntry` — Harness-only accessor that returns one transaction in a VTXO's recovery lineage plus the outpoints of its parent txs. Callers walk the lineage by recursively calling with each returned parent outpoint until `OnChainRoot=true` (the parent is the on-chain batch tx). Implemented on top of the same `unroll.LocalProofAssembler` the unroll registry uses (stashed on `Server.proofAssembler` during `initUnrollSubsystem`), but routed through the assembler's terminal-tolerant `EnsureProofForHarness` entry point so the historical lineage of an already-spent or already-forfeited VTXO is still walkable — that is the load-bearing capability for fraud-response itests where the harness force-broadcasts lineage txs of a terminal VTXO to provoke server-side classification + response. The field type `harnessProofAssembler` is a 1-method local interface that exposes ONLY the terminal-tolerant entry point, so production code paths cannot reach `EnsureProof` through this seam — production proof assembly flows exclusively through the unroll registry's own `ProofAssembler` reference, which keeps the terminal-status guard in force. NOT for production use.
 - `WalletState` — Enum (None/Locked/Ready) for wallet lifecycle.
+- `WalletLifecycleState()` — Public `Server` method returning current
+  `WalletState`. Surfaced via `GetInfo` RPC as `daemonrpc.WalletState` so
+  callers can distinguish not-yet-created from locked from ready.
+- `boardingSweepWatcher` / `resumeBoardingSweeps` / `replayPendingBoardRequest`
+  — Boarding sweep subsystem moved from direct `darepod` handlers to the wallet
+  actor. The daemon calls `resumeBoardingSweeps` (step 13) and
+  `replayPendingBoardRequest` (step 13b) after txconfirm and the round-client
+  actor register with the receptionist.
+- `fraudWatcher` / `fraudWatcherRef` — Passive recipient fraud watcher wired
+  during `initOORActor`. Arms spend watches on OOR VTXO ancestors and triggers
+  unilateral exit via the unroll registry on fraud detection.
 - `serverDurableUnaryBuilder` — Implements `serverconn.DurableUnaryRequestBuilder` by delegating to the indexer client with proof-of-control credentials.
 - `IndexerProofKey` — Public server method that derives the fixed wallet key for a given key locator and returns an `indexer.SchnorrSigner` backed by the proof-key backend. Used by `EnsureDefaultOORReceiveScript` and the `serverDurableUnaryBuilder` to produce per-request proof-of-control signatures.
 - `NewOwnedReceiveScriptSigner` — Indexer signer that resolves the wallet key for any persisted owned receive script, then delegates signing to the backend-specific signer.
@@ -63,7 +95,11 @@ gRPC API.
 
 ## Relationships
 
-- **Depends on**: `baselib/actor` (ActorSystem), `btcwbackend`, `chainbackends`, `chainsource`, `lib/actormsg`, `db`, `ledger` (accounting actor), `round`, `txconfirm`, `unroll`, `vtxo`, `wallet`, `walletcore`, `oor`, `serverconn`, `indexer`, `arkrpc`, `lndbackend`, `harness` (bitcoind package submitter wiring in `cmd/darepod`).
+- **Depends on**: `baselib/actor` (ActorSystem), `btcwbackend`, `chainbackends`,
+  `chainsource`, `lib/actormsg`, `db`, `ledger` (accounting actor), `round`,
+  `txconfirm`, `unroll`, `vtxo`, `wallet`, `walletcore`, `oor`, `serverconn`,
+  `indexer`, `arkrpc`, `lndbackend`, `fraud` (recipient fraud watcher),
+  `harness` (bitcoind package submitter wiring in `cmd/darepod`).
 - **Depended on by**: `cmd/darepod` (main entry point).
 
 ## Invariants

--- a/db/AGENTS.md
+++ b/db/AGENTS.md
@@ -21,7 +21,10 @@ backends.
   sweep_pending). Includes sweep operations: `CreatePendingBoardingSweep`,
   `MarkBoardingSweepPublished`, `MarkBoardingSweepFailed`,
   `ListBoardingSweeps`, `ListPendingBoardingSweeps`,
-  `MarkBoardingSweepInputSpent`.
+  `MarkBoardingSweepInputSpent`. Also implements pending Board request
+  persistence: `UpsertPendingBoardRequest`, `ListPendingBoardRequests`,
+  `ClearPendingBoardRequestByOutpoint`, `ClearAllPendingBoardRequests` —
+  used by the wallet actor's replay-on-restart path.
 - `NewBoardingSweep` / `BoardingSweepRecord` / `BoardingSweepInputRecord` —
   Domain types for the boarding sweep control plane. A sweep is an aggregate
   transaction spending one or more boarding outpoints; each outpoint has its
@@ -47,7 +50,9 @@ backends.
   idempotency). Joins the outer actor transaction via `actor.TxFromContext`.
   Exposes `GetAccountBalance`, `GetTotalOperatorFeesPaid`,
   `ListLedgerEntries`, `ListLedgerEntriesWithFeesTotal`,
-  `ListLedgerEntriesByType`, `CountLedgerEntries`, `ListAccounts`.
+  `ListLedgerEntriesByType`, `CountLedgerEntries`, `ListAccounts`. Now
+  persists optional `ChainTxid`, `ChainVout`, and `ConfirmationHeight` fields
+  from `ledger.LedgerEntry` via `sqlInt32Ptr` null helpers.
 - `UTXOAuditStoreDB` — Concrete adapter implementing `ledger.UTXOAuditStore`.
   Wraps `sqlc.InsertWalletUTXOLog` (ON CONFLICT DO NOTHING for idempotency)
   and query methods.
@@ -77,7 +82,12 @@ backends.
   bounds enforced during `DeserializeTree` to prevent stack overflow or OOM.
 - `resolveInputPackage` / `loadPackageBundleBySessionID` — Two-stage OOR
   ancestry resolver in `oor_unroll_resolver.go`.
-- `LatestMigrationVersion = 11` — Current schema version.
+- `LatestMigrationVersion` — Current schema version (updated as migrations land).
+- `BoardingSweepStatusPending` / `BoardingSweepStatusPublished` / etc. and
+  `BoardingSweepInputStatusPending` / etc. — Status string constants for
+  boarding sweep lifecycle. Previously defined in `db/`; now canonical in
+  `wallet/boarding_sweep_store.go` and re-exported as package-level aliases
+  in `db/boarding_sweep_store.go` for backward compatibility.
 
 ## Relationships
 

--- a/db/CLAUDE.md
+++ b/db/CLAUDE.md
@@ -21,7 +21,10 @@ backends.
   sweep_pending). Includes sweep operations: `CreatePendingBoardingSweep`,
   `MarkBoardingSweepPublished`, `MarkBoardingSweepFailed`,
   `ListBoardingSweeps`, `ListPendingBoardingSweeps`,
-  `MarkBoardingSweepInputSpent`.
+  `MarkBoardingSweepInputSpent`. Also implements pending Board request
+  persistence: `UpsertPendingBoardRequest`, `ListPendingBoardRequests`,
+  `ClearPendingBoardRequestByOutpoint`, `ClearAllPendingBoardRequests` —
+  used by the wallet actor's replay-on-restart path.
 - `NewBoardingSweep` / `BoardingSweepRecord` / `BoardingSweepInputRecord` —
   Domain types for the boarding sweep control plane. A sweep is an aggregate
   transaction spending one or more boarding outpoints; each outpoint has its
@@ -47,7 +50,9 @@ backends.
   idempotency). Joins the outer actor transaction via `actor.TxFromContext`.
   Exposes `GetAccountBalance`, `GetTotalOperatorFeesPaid`,
   `ListLedgerEntries`, `ListLedgerEntriesWithFeesTotal`,
-  `ListLedgerEntriesByType`, `CountLedgerEntries`, `ListAccounts`.
+  `ListLedgerEntriesByType`, `CountLedgerEntries`, `ListAccounts`. Now
+  persists optional `ChainTxid`, `ChainVout`, and `ConfirmationHeight` fields
+  from `ledger.LedgerEntry` via `sqlInt32Ptr` null helpers.
 - `UTXOAuditStoreDB` — Concrete adapter implementing `ledger.UTXOAuditStore`.
   Wraps `sqlc.InsertWalletUTXOLog` (ON CONFLICT DO NOTHING for idempotency)
   and query methods.
@@ -77,7 +82,12 @@ backends.
   bounds enforced during `DeserializeTree` to prevent stack overflow or OOM.
 - `resolveInputPackage` / `loadPackageBundleBySessionID` — Two-stage OOR
   ancestry resolver in `oor_unroll_resolver.go`.
-- `LatestMigrationVersion = 11` — Current schema version.
+- `LatestMigrationVersion` — Current schema version (updated as migrations land).
+- `BoardingSweepStatusPending` / `BoardingSweepStatusPublished` / etc. and
+  `BoardingSweepInputStatusPending` / etc. — Status string constants for
+  boarding sweep lifecycle. Previously defined in `db/`; now canonical in
+  `wallet/boarding_sweep_store.go` and re-exported as package-level aliases
+  in `db/boarding_sweep_store.go` for backward compatibility.
 
 ## Relationships
 

--- a/db/actordelivery/AGENTS.md
+++ b/db/actordelivery/AGENTS.md
@@ -22,7 +22,10 @@ other services can reuse durable actor storage without pulling unrelated tables.
   `*sql.Tx`. Implements `actor.DeliveryStore` directly against the transaction
   without additional `ExecTx` wrapping. `EnqueueOutbox` sets a shared
   `*outboxEnqueued` flag so `TxAwareActorDeliveryStore.ExecTx` can fire
-  outbox-wake callbacks after commit.
+  outbox-wake callbacks after commit. `EnqueueMessage` now stamps
+  `CorrelationKey` (from `actor.EnqueueParams.CorrelationKey`) onto the
+  `mailbox_messages.correlation_key` column to enable per-key FIFO claim
+  ordering in the durable mailbox.
 - `TxAwareActorDeliveryStore` — Extends `Store` with `ExecTx` support for
   atomic multi-operation workflows (implements `actor.TxAwareDeliveryStore`).
   Created via `NewTxAwareActorDeliveryStore(db, querier, clock)`. `ExecTx`

--- a/db/actordelivery/CLAUDE.md
+++ b/db/actordelivery/CLAUDE.md
@@ -22,7 +22,10 @@ other services can reuse durable actor storage without pulling unrelated tables.
   `*sql.Tx`. Implements `actor.DeliveryStore` directly against the transaction
   without additional `ExecTx` wrapping. `EnqueueOutbox` sets a shared
   `*outboxEnqueued` flag so `TxAwareActorDeliveryStore.ExecTx` can fire
-  outbox-wake callbacks after commit.
+  outbox-wake callbacks after commit. `EnqueueMessage` now stamps
+  `CorrelationKey` (from `actor.EnqueueParams.CorrelationKey`) onto the
+  `mailbox_messages.correlation_key` column to enable per-key FIFO claim
+  ordering in the durable mailbox.
 - `TxAwareActorDeliveryStore` — Extends `Store` with `ExecTx` support for
   atomic multi-operation workflows (implements `actor.TxAwareDeliveryStore`).
   Created via `NewTxAwareActorDeliveryStore(db, querier, clock)`. `ExecTx`

--- a/db/actordelivery/migrations/AGENTS.md
+++ b/db/actordelivery/migrations/AGENTS.md
@@ -13,8 +13,10 @@ generic `db/migrate` orchestration layer.
   `"actor_delivery_schema_migrations"`), `DatabaseName` (default
   `"actor_delivery"`), `LatestVersion` (downgrade guard, default
   `LatestMigrationVersion`), optional `Log btclog.Logger`.
-- `LatestMigrationVersion = 1` — Current schema version; bump when adding a
-  new SQL migration file.
+- `LatestMigrationVersion = 2` — Current schema version; bump when adding a
+  new SQL migration file. Version 2 adds the nullable `correlation_key`
+  column on `mailbox_messages` and the filtered composite index that backs
+  the per-correlation-key FIFO anti-join in `LeaseNextMailboxMessage`.
 - `RunMigrations(db, backend, cfg)` — Applies actor-delivery migrations.
   Validates inputs, applies `Config` defaults, delegates to
   `dbmigrate.RunMigrations` with postgres schema token replacements.

--- a/db/actordelivery/sqlc/AGENTS.md
+++ b/db/actordelivery/sqlc/AGENTS.md
@@ -1,0 +1,31 @@
+# db/actordelivery/sqlc
+
+## Purpose
+
+Generated sqlc query bindings for the durable actor mailbox database schema.
+Do not edit — regenerate via `make sqlc`.
+
+## Key Types
+
+- `Querier` — Generated interface exposing all typed SQL operations for
+  durable actor mailbox persistence: mailbox message enqueue/claim/ack,
+  outbox batch claiming and completion, FSM checkpoint read/write/delete,
+  Ask result store, dead-letter management, and expiry cleanup.
+- `MailboxMessage` / `OutboxMessage` / `FsmCheckpoint` / `AskResult` /
+  `DeadLetter` — Generated row structs mapping directly to SQL table columns.
+
+## Relationships
+
+- **Depends on**: nothing beyond standard `database/sql`.
+- **Depended on by**: `db/actordelivery` (production `DeliveryStore`
+  implementation that wraps these generated queries).
+
+## Invariants
+
+- All files in this directory are generated. Never edit them manually.
+- Regenerate by running `make sqlc` after changing `db/queries/` or
+  `db/schema/`.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../../ARCHITECTURE.md) — System-wide package map.

--- a/db/actordelivery/sqlc/CLAUDE.md
+++ b/db/actordelivery/sqlc/CLAUDE.md
@@ -1,0 +1,31 @@
+# db/actordelivery/sqlc
+
+## Purpose
+
+Generated sqlc query bindings for the durable actor mailbox database schema.
+Do not edit — regenerate via `make sqlc`.
+
+## Key Types
+
+- `Querier` — Generated interface exposing all typed SQL operations for
+  durable actor mailbox persistence: mailbox message enqueue/claim/ack,
+  outbox batch claiming and completion, FSM checkpoint read/write/delete,
+  Ask result store, dead-letter management, and expiry cleanup.
+- `MailboxMessage` / `OutboxMessage` / `FsmCheckpoint` / `AskResult` /
+  `DeadLetter` — Generated row structs mapping directly to SQL table columns.
+
+## Relationships
+
+- **Depends on**: nothing beyond standard `database/sql`.
+- **Depended on by**: `db/actordelivery` (production `DeliveryStore`
+  implementation that wraps these generated queries).
+
+## Invariants
+
+- All files in this directory are generated. Never edit them manually.
+- Regenerate by running `make sqlc` after changing `db/queries/` or
+  `db/schema/`.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../../ARCHITECTURE.md) — System-wide package map.

--- a/db/sqlc/AGENTS.md
+++ b/db/sqlc/AGENTS.md
@@ -1,0 +1,32 @@
+# db/sqlc
+
+## Purpose
+
+Generated sqlc query bindings for the main daemon database schema. Do not
+edit — regenerate via `make sqlc`.
+
+## Key Types
+
+- `Querier` — Generated interface for all domain SQL queries: boarding,
+  chain info, fee accounting, OOR artifacts, rounds, unilateral exits, VTXOs,
+  and UTXO audit log.
+- Domain row structs (`BoardingAddress`, `Round`, `Vtxo`, `OorArtifact`,
+  `FeeAccountingEntry`, etc.) — Generated structs mapping SQL columns to Go
+  types.
+
+## Relationships
+
+- **Depends on**: nothing beyond standard `database/sql`.
+- **Depended on by**: `db` (the `Store` wrapper that adds migration,
+  transaction helpers, and higher-level composite operations on top of
+  the generated queries).
+
+## Invariants
+
+- All files in this directory are generated. Never edit them manually.
+- Regenerate by running `make sqlc` after changing `db/queries/` or
+  `db/schema/`.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/db/sqlc/CLAUDE.md
+++ b/db/sqlc/CLAUDE.md
@@ -1,0 +1,32 @@
+# db/sqlc
+
+## Purpose
+
+Generated sqlc query bindings for the main daemon database schema. Do not
+edit — regenerate via `make sqlc`.
+
+## Key Types
+
+- `Querier` — Generated interface for all domain SQL queries: boarding,
+  chain info, fee accounting, OOR artifacts, rounds, unilateral exits, VTXOs,
+  and UTXO audit log.
+- Domain row structs (`BoardingAddress`, `Round`, `Vtxo`, `OorArtifact`,
+  `FeeAccountingEntry`, etc.) — Generated structs mapping SQL columns to Go
+  types.
+
+## Relationships
+
+- **Depends on**: nothing beyond standard `database/sql`.
+- **Depended on by**: `db` (the `Store` wrapper that adds migration,
+  transaction helpers, and higher-level composite operations on top of
+  the generated queries).
+
+## Invariants
+
+- All files in this directory are generated. Never edit them manually.
+- Regenerate by running `make sqlc` after changing `db/queries/` or
+  `db/schema/`.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/fraud/AGENTS.md
+++ b/fraud/AGENTS.md
@@ -1,0 +1,54 @@
+# fraud
+
+## Purpose
+
+Passive recipient fraud watcher. Monitors ancestry spend notifications for
+VTXOs the local client received via OOR transfers; when a watched ancestor
+is spent unexpectedly (indicating a potential double-spend or fraud attempt
+by the operator), the watcher triggers a unilateral exit via the unroll
+registry.
+
+## Key Types
+
+- `WatcherActor` — Durable actor owning all spend watches for tracked VTXOs.
+  Registered with the actor system under `ServiceKeyName`.
+- `WatcherConfig` — Wiring: `ChainSource` (for passive spend watches),
+  `UnrollRef` (to start unroll jobs on detected fraud), optional `Log`,
+  `MailboxSize` override.
+- `ServiceKey()` — Returns the typed actor service key for receptionist
+  lookup.
+- `Msg` / `Resp` — Sealed message and response surfaces.
+- `TrackVTXOsRequest` / `TrackVTXOsResp` — Ask the watcher to arm passive
+  ancestry spend watches for a list of VTXO descriptors.
+- `UntrackRequest` / `UntrackResp` — Release watches for a VTXO that is no
+  longer live (e.g., after a successful round refresh or cooperative leave).
+
+## Relationships
+
+- **Depends on**: `baselib/actor` (actor framework), `chainsource` (spend
+  notifications), `unroll` (triggers unilateral exit on fraud detection),
+  `vtxo` (VTXO descriptor type).
+- **Depended on by**: `darepod` (starts and wires the fraud watcher during
+  `initOORActor`; sends `TrackVTXOsRequest` after materializing incoming OOR
+  VTXOs).
+- **Sends**:
+  - → `unroll` registry: `EnsureUnrollRequest` (triggered when a watched
+    ancestor spend is observed and classified as fraudulent).
+  - → `chainsource`: `RegisterSpendRequest` (ancestry spend subscriptions).
+- **Receives**:
+  - ← API (via `darepod`): `TrackVTXOsRequest`, `UntrackRequest`.
+  - ← `chainsource`: spend notifications re-wrapped into internal messages.
+
+## Invariants
+
+- Watches are passive: the watcher subscribes to chainsource spend events on
+  known VTXO ancestors and never initiates proactive chain scans.
+- Unroll jobs are only started once per target outpoint; a second fraud
+  notification for the same target is a no-op (the registry deduplicates).
+- The default mailbox size (`defaultWatcherMailboxSize = 64`) is sized to
+  absorb burst spend notifications during chain reorganisations without
+  blocking the chainsource publisher.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/fraud/CLAUDE.md
+++ b/fraud/CLAUDE.md
@@ -1,0 +1,54 @@
+# fraud
+
+## Purpose
+
+Passive recipient fraud watcher. Monitors ancestry spend notifications for
+VTXOs the local client received via OOR transfers; when a watched ancestor
+is spent unexpectedly (indicating a potential double-spend or fraud attempt
+by the operator), the watcher triggers a unilateral exit via the unroll
+registry.
+
+## Key Types
+
+- `WatcherActor` — Durable actor owning all spend watches for tracked VTXOs.
+  Registered with the actor system under `ServiceKeyName`.
+- `WatcherConfig` — Wiring: `ChainSource` (for passive spend watches),
+  `UnrollRef` (to start unroll jobs on detected fraud), optional `Log`,
+  `MailboxSize` override.
+- `ServiceKey()` — Returns the typed actor service key for receptionist
+  lookup.
+- `Msg` / `Resp` — Sealed message and response surfaces.
+- `TrackVTXOsRequest` / `TrackVTXOsResp` — Ask the watcher to arm passive
+  ancestry spend watches for a list of VTXO descriptors.
+- `UntrackRequest` / `UntrackResp` — Release watches for a VTXO that is no
+  longer live (e.g., after a successful round refresh or cooperative leave).
+
+## Relationships
+
+- **Depends on**: `baselib/actor` (actor framework), `chainsource` (spend
+  notifications), `unroll` (triggers unilateral exit on fraud detection),
+  `vtxo` (VTXO descriptor type).
+- **Depended on by**: `darepod` (starts and wires the fraud watcher during
+  `initOORActor`; sends `TrackVTXOsRequest` after materializing incoming OOR
+  VTXOs).
+- **Sends**:
+  - → `unroll` registry: `EnsureUnrollRequest` (triggered when a watched
+    ancestor spend is observed and classified as fraudulent).
+  - → `chainsource`: `RegisterSpendRequest` (ancestry spend subscriptions).
+- **Receives**:
+  - ← API (via `darepod`): `TrackVTXOsRequest`, `UntrackRequest`.
+  - ← `chainsource`: spend notifications re-wrapped into internal messages.
+
+## Invariants
+
+- Watches are passive: the watcher subscribes to chainsource spend events on
+  known VTXO ancestors and never initiates proactive chain scans.
+- Unroll jobs are only started once per target outpoint; a second fraud
+  notification for the same target is a no-op (the registry deduplicates).
+- The default mailbox size (`defaultWatcherMailboxSize = 64`) is sized to
+  absorb burst spend notifications during chain reorganisations without
+  blocking the chainsource publisher.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/harness/AGENTS.md
+++ b/harness/AGENTS.md
@@ -46,3 +46,18 @@ containers with network isolation for end-to-end testing.
 - `electrsReadyTimeout` = 2 minutes — separate extended timeout for the
   electrs container HTTP readiness check.
 - Coinbase maturity: 100 blocks + 6-block buffer.
+- `maxBitcoindStartRetries` = 3 — number of times `startBitcoind` rebuilds
+  the bitcoind container when post-start RPC probing fails (guards against
+  containers whose port-forward exists but whose bitcoind process never bound
+  the RPC socket or crashed during init).
+- `bitcoindStartProbeDuration` = 5s — wall-clock window `probeBitcoindHealthy`
+  spends polling bitcoind after the first successful `getblockchaininfo`
+  response to catch the failure mode where bitcoind answers the first poll
+  and then dies before the harness's first user-driven RPC call.
+
+## Helper Functions
+
+- `containerHasExactName(container, name)` — Returns true only when a Docker
+  container's name list contains the exact string `"/<name>"`. Needed because
+  Docker name filters match substrings; stale containers with overlapping
+  prefixes must not be confused for the one under management.

--- a/harness/CLAUDE.md
+++ b/harness/CLAUDE.md
@@ -46,3 +46,18 @@ containers with network isolation for end-to-end testing.
 - `electrsReadyTimeout` = 2 minutes — separate extended timeout for the
   electrs container HTTP readiness check.
 - Coinbase maturity: 100 blocks + 6-block buffer.
+- `maxBitcoindStartRetries` = 3 — number of times `startBitcoind` rebuilds
+  the bitcoind container when post-start RPC probing fails (guards against
+  containers whose port-forward exists but whose bitcoind process never bound
+  the RPC socket or crashed during init).
+- `bitcoindStartProbeDuration` = 5s — wall-clock window `probeBitcoindHealthy`
+  spends polling bitcoind after the first successful `getblockchaininfo`
+  response to catch the failure mode where bitcoind answers the first poll
+  and then dies before the harness's first user-driven RPC call.
+
+## Helper Functions
+
+- `containerHasExactName(container, name)` — Returns true only when a Docker
+  container's name list contains the exact string `"/<name>"`. Needed because
+  Docker name filters match substrings; stale containers with overlapping
+  prefixes must not be confused for the one under management.

--- a/indexer/AGENTS.md
+++ b/indexer/AGENTS.md
@@ -20,7 +20,7 @@ proofs for proof-of-control.
 
 ## Key Methods (on `*Client`)
 
-- `BuildListVTXOsByScriptsTaprootRequest(ctx, scopes, afterCursor []byte, limit, statusFilter)` / `ListVTXOsByScriptsTaproot(ctx, scopes, afterCursor []byte, limit, statusFilter)` — Build and execute taproot-scope-proofed `ListVTXOsByScripts` queries. The `afterCursor` is opaque `[]byte` (keyset cursor) passed through unchanged, replacing the former `uint64` offset cursor. The proof covers each pkScript in the request using owner-key signatures gated on script scope.
+- `BuildListVTXOsByScriptsTaprootRequest(ctx, scopes, afterCursor []byte, limit, statusFilter)` / `ListVTXOsByScriptsTaproot(ctx, scopes, afterCursor []byte, limit, statusFilter)` — Build and execute taproot-scope-proofed `ListVTXOsByScripts` queries. The `afterCursor` is opaque `[]byte` (keyset cursor) passed through unchanged, replacing the former `uint64` offset cursor. Before embedding the cursor in the request, `BuildListVTXOsByScriptsTaprootRequest` calls `indexerlimits.ValidateVTXOsByScriptsCursor` to reject oversized cursors from untrusted callers. The proof covers each pkScript in the request using owner-key signatures gated on script scope.
 - `BuildGetOORSessionByTxidTaprootRequest` / `GetOORSessionByTxidTaproot` — Build and execute a taproot-proofed OOR session lookup by Ark txid.
 - `BuildListOORRecipientEventsByScriptTaprootRequest` / `ListOORRecipientEventsByScriptTaproot` — Build and execute a taproot-proofed listing of OOR receive events for a given pkScript.
 
@@ -31,6 +31,7 @@ proofs for proof-of-control.
 
 ## Invariants
 
+- Untrusted opaque pagination cursors are validated against `indexerlimits.MaxVTXOsByScriptsCursorBytes` before being embedded in requests; oversized cursors return an error immediately without touching the network.
 - All proof-of-control signatures are Schnorr (BIP-340) over a tagged hash of the request scope.
 - Taproot-scoped proofs (`buildTaprootScopes`) attach per-script owner signatures so the server can verify that the caller controls the scripts being queried — preventing unauthorized balance enumeration.
 - `WithSigner` returns a shallow copy; both the original and the copy share the same underlying RPC transport.

--- a/indexer/CLAUDE.md
+++ b/indexer/CLAUDE.md
@@ -20,7 +20,7 @@ proofs for proof-of-control.
 
 ## Key Methods (on `*Client`)
 
-- `BuildListVTXOsByScriptsTaprootRequest(ctx, scopes, afterCursor []byte, limit, statusFilter)` / `ListVTXOsByScriptsTaproot(ctx, scopes, afterCursor []byte, limit, statusFilter)` — Build and execute taproot-scope-proofed `ListVTXOsByScripts` queries. The `afterCursor` is opaque `[]byte` (keyset cursor) passed through unchanged, replacing the former `uint64` offset cursor. The proof covers each pkScript in the request using owner-key signatures gated on script scope.
+- `BuildListVTXOsByScriptsTaprootRequest(ctx, scopes, afterCursor []byte, limit, statusFilter)` / `ListVTXOsByScriptsTaproot(ctx, scopes, afterCursor []byte, limit, statusFilter)` — Build and execute taproot-scope-proofed `ListVTXOsByScripts` queries. The `afterCursor` is opaque `[]byte` (keyset cursor) passed through unchanged, replacing the former `uint64` offset cursor. Before embedding the cursor in the request, `BuildListVTXOsByScriptsTaprootRequest` calls `indexerlimits.ValidateVTXOsByScriptsCursor` to reject oversized cursors from untrusted callers. The proof covers each pkScript in the request using owner-key signatures gated on script scope.
 - `BuildGetOORSessionByTxidTaprootRequest` / `GetOORSessionByTxidTaproot` — Build and execute a taproot-proofed OOR session lookup by Ark txid.
 - `BuildListOORRecipientEventsByScriptTaprootRequest` / `ListOORRecipientEventsByScriptTaproot` — Build and execute a taproot-proofed listing of OOR receive events for a given pkScript.
 
@@ -31,6 +31,7 @@ proofs for proof-of-control.
 
 ## Invariants
 
+- Untrusted opaque pagination cursors are validated against `indexerlimits.MaxVTXOsByScriptsCursorBytes` before being embedded in requests; oversized cursors return an error immediately without touching the network.
 - All proof-of-control signatures are Schnorr (BIP-340) over a tagged hash of the request scope.
 - Taproot-scoped proofs (`buildTaprootScopes`) attach per-script owner signatures so the server can verify that the caller controls the scripts being queried — preventing unauthorized balance enumeration.
 - `WithSigner` returns a shallow copy; both the original and the copy share the same underlying RPC transport.

--- a/internal/indexerlimits/AGENTS.md
+++ b/internal/indexerlimits/AGENTS.md
@@ -1,0 +1,31 @@
+# internal/indexerlimits
+
+## Purpose
+
+Shared client-side resource caps for indexer query parameters. Centralises
+limit constants so that both the gRPC handler layer and the durable unary
+query layer enforce identical bounds without duplicating magic numbers.
+
+## Key Types
+
+- `MaxVTXOsByScriptsCursorBytes` — Constant (256) capping the opaque cursor
+  accepted for `ListVTXOsByScripts` pagination requests.
+- `ValidateVTXOsByScriptsCursor(cursor []byte) error` — Rejects cursors
+  exceeding `MaxVTXOsByScriptsCursorBytes`; returns a descriptive error
+  carrying the actual and allowed lengths.
+
+## Relationships
+
+- **Depends on**: nothing beyond standard `fmt`.
+- **Depended on by**: `serverconn` (validates cursors in durable unary query
+  messages before persisting them), `darepod` (RPC handler pre-validation).
+
+## Invariants
+
+- The cursor cap is intentionally generous (256 bytes vs the current 36-byte
+  server cursor) to leave room for format evolution while bounding untrusted
+  remote bytes.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/internal/indexerlimits/CLAUDE.md
+++ b/internal/indexerlimits/CLAUDE.md
@@ -1,0 +1,31 @@
+# internal/indexerlimits
+
+## Purpose
+
+Shared client-side resource caps for indexer query parameters. Centralises
+limit constants so that both the gRPC handler layer and the durable unary
+query layer enforce identical bounds without duplicating magic numbers.
+
+## Key Types
+
+- `MaxVTXOsByScriptsCursorBytes` — Constant (256) capping the opaque cursor
+  accepted for `ListVTXOsByScripts` pagination requests.
+- `ValidateVTXOsByScriptsCursor(cursor []byte) error` — Rejects cursors
+  exceeding `MaxVTXOsByScriptsCursorBytes`; returns a descriptive error
+  carrying the actual and allowed lengths.
+
+## Relationships
+
+- **Depends on**: nothing beyond standard `fmt`.
+- **Depended on by**: `serverconn` (validates cursors in durable unary query
+  messages before persisting them), `darepod` (RPC handler pre-validation).
+
+## Invariants
+
+- The cursor cap is intentionally generous (256 bytes vs the current 36-byte
+  server cursor) to leave room for format evolution while bounding untrusted
+  remote bytes.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/ledger/AGENTS.md
+++ b/ledger/AGENTS.md
@@ -3,11 +3,11 @@
 ## Purpose
 
 Client-side durable actor that serializes all accounting writes (fees, VTXO
-receipts/sends, wallet UTXO deposits, exit costs) as double-entry ledger
-entries and UTXO audit log records. Provides a crash-safe financial audit
-trail for tax reporting and fee transparency. Ledger event types:
-`wallet_utxo_created` (wallet UTXO deposit), `boarding_fee_paid`,
-`refresh_fee_paid`, `onchain_fee_paid`, `vtxo_received`, `vtxo_sent`.
+receipts/sends, wallet UTXO deposits, boarding sweep fees, exit costs) as
+double-entry ledger entries and UTXO audit log records. Provides a crash-safe
+financial audit trail for tax reporting and fee transparency. Ledger event
+types: `wallet_utxo_created`, `boarding_fee_paid`, `refresh_fee_paid`,
+`onchain_fee_paid`, `boarding_sweep_fee_paid`, `vtxo_received`, `vtxo_sent`.
 
 ## Chart of Accounts
 
@@ -40,12 +40,26 @@ accounts, see [docs/fee_ledger.md](../docs/fee_ledger.md).
 - `ActorConfig` — Configuration: logger, delivery store, ledger store, UTXO audit store, actor ID, and optional `Clock` (`fn.Option[clock.Clock]`). When None, the actor falls back to `clock.NewDefaultClock()`; tests inject a deterministic clock.
 - `Sink` — Alias for `actor.TellOnlyRef[LedgerMsg]`, constructed via `NewSink(system *actor.ActorSystem)`. Producers (round / OOR / VTXO / wallet) hold an `fn.Option[ledger.Sink]` so they can fire-and-forget emissions without resolving the service key on every event.
 - `LedgerStore` — Interface for DB persistence of ledger entries (implemented by `db.LedgerStoreDB`). Has a single `InsertLedgerEntry` method; multi-leg handlers rely on the durable actor's outer tx for atomicity rather than a batch API.
-- `LedgerEntry` — Domain-level double-entry record (debit/credit accounts, amount, round ID, session ID, event type, description, created_at, and optional `IdempotencyKey []byte` for outpoint-keyed dedup on events that carry neither a round_id nor a session_id).
+- `LedgerEntry` — Domain-level double-entry record (debit/credit accounts,
+  amount, round ID, session ID, event type, description, created_at, and
+  optional `IdempotencyKey []byte` for outpoint-keyed dedup). New fields:
+  `ChainTxid []byte`, `ChainVout *int32`, `ConfirmationHeight *int32` — first-
+  class history fields linking entries to on-chain transactions without
+  requiring callers to embed chain data in Description or IdempotencyKey.
 - `exitIdempotencyKey(hash, index) []byte` — Internal helper that derives the 36-byte `outpoint_hash || outpoint_index` dedup key `handleExitCost` stamps on both the send leg and the fee leg. Keeps outpoint-keyed entries distinct from round-keyed and session-keyed ones via the separate `idx_client_ledger_idempotent_key` partial unique index.
+- `EventBoardingSweepFeePaid` — Event type `"boarding_sweep_fee_paid"` for
+  miner fees paid during boarding timeout-path sweeps (added alongside the
+  boarding sweep migration to the wallet package).
+- `ClassificationBoardingSweepInput` / `ClassificationBoardingSweepReturn` —
+  UTXO audit classification constants for boarding sweep inputs and return
+  outputs.
 - `UTXOAuditStore` — Interface for DB persistence of UTXO audit log entries (implemented by `db.UTXOAuditStoreDB`).
 - `UTXOAuditEntry` — Domain-level UTXO audit record (outpoint, amount, event, block height, classification).
 - `LedgerMsg` / `LedgerResp` — Message and response type constraints for the durable mailbox.
-- `FeePaidMsg` — Records boarding/refresh fee payments.
+- `FeePaidMsg` — Records boarding/refresh/onchain-sweep fee payments.
+  `FeeTypeOnchainSweep` books a miner fee for on-chain sweeps (e.g. boarding
+  timeout sweep): debit `onchain_fees`, credit `wallet_balance`. `RoundID` may
+  be zero for sweep fees; keyed by sweep txid via `IdempotencyKey` instead.
 - `VTXOReceivedMsg` — Records incoming VTXOs. `Source` must be one of `SourceRoundBoarding` (client's own on-chain wallet funds boarded into a round; offsets wallet_balance), `SourceRoundRefresh` (refresh output or directed-send self-change; offsets transfers_out so the paired VTXOSent cancels on that account and only the operator fee moves vtxo_balance), `SourceRoundTransfer` (in-round receive from another participant; offsets transfers_in), or `SourceOOR` (out-of-round receive; offsets transfers_in). Any other value is rejected.
 - `VTXOSentMsg` — Records outgoing VTXO transfers. Carries either `SessionID` (32-byte OOR) or `RoundID` (16-byte in-round) — exactly one must be non-zero; both-zero and both-set inputs are rejected. Also carries an optional `Outpoint wire.OutPoint` so in-round multi-VTXO events (e.g. paired refresh emissions) disambiguate per-VTXO via an outpoint-derived `IdempotencyKey` instead of collapsing on `idx_client_ledger_idempotent_round`.
 - `ExitCostMsg` — Records a unilateral exit as two ledger entries: a send leg (`transfers_out` debit, `vtxo_balance` credit) for the net-of-fee value and a fee leg (`onchain_fees` debit, `vtxo_balance` credit) for the miner fee. Together the credits reduce `vtxo_balance` by the gross exited amount. Wallet-side movement is covered separately by the `wallet_utxo_log` audit trail.

--- a/ledger/CLAUDE.md
+++ b/ledger/CLAUDE.md
@@ -3,11 +3,11 @@
 ## Purpose
 
 Client-side durable actor that serializes all accounting writes (fees, VTXO
-receipts/sends, wallet UTXO deposits, exit costs) as double-entry ledger
-entries and UTXO audit log records. Provides a crash-safe financial audit
-trail for tax reporting and fee transparency. Ledger event types:
-`wallet_utxo_created` (wallet UTXO deposit), `boarding_fee_paid`,
-`refresh_fee_paid`, `onchain_fee_paid`, `vtxo_received`, `vtxo_sent`.
+receipts/sends, wallet UTXO deposits, boarding sweep fees, exit costs) as
+double-entry ledger entries and UTXO audit log records. Provides a crash-safe
+financial audit trail for tax reporting and fee transparency. Ledger event
+types: `wallet_utxo_created`, `boarding_fee_paid`, `refresh_fee_paid`,
+`onchain_fee_paid`, `boarding_sweep_fee_paid`, `vtxo_received`, `vtxo_sent`.
 
 ## Chart of Accounts
 
@@ -40,12 +40,26 @@ accounts, see [docs/fee_ledger.md](../docs/fee_ledger.md).
 - `ActorConfig` — Configuration: logger, delivery store, ledger store, UTXO audit store, actor ID, and optional `Clock` (`fn.Option[clock.Clock]`). When None, the actor falls back to `clock.NewDefaultClock()`; tests inject a deterministic clock.
 - `Sink` — Alias for `actor.TellOnlyRef[LedgerMsg]`, constructed via `NewSink(system *actor.ActorSystem)`. Producers (round / OOR / VTXO / wallet) hold an `fn.Option[ledger.Sink]` so they can fire-and-forget emissions without resolving the service key on every event.
 - `LedgerStore` — Interface for DB persistence of ledger entries (implemented by `db.LedgerStoreDB`). Has a single `InsertLedgerEntry` method; multi-leg handlers rely on the durable actor's outer tx for atomicity rather than a batch API.
-- `LedgerEntry` — Domain-level double-entry record (debit/credit accounts, amount, round ID, session ID, event type, description, created_at, and optional `IdempotencyKey []byte` for outpoint-keyed dedup on events that carry neither a round_id nor a session_id).
+- `LedgerEntry` — Domain-level double-entry record (debit/credit accounts,
+  amount, round ID, session ID, event type, description, created_at, and
+  optional `IdempotencyKey []byte` for outpoint-keyed dedup). New fields:
+  `ChainTxid []byte`, `ChainVout *int32`, `ConfirmationHeight *int32` — first-
+  class history fields linking entries to on-chain transactions without
+  requiring callers to embed chain data in Description or IdempotencyKey.
 - `exitIdempotencyKey(hash, index) []byte` — Internal helper that derives the 36-byte `outpoint_hash || outpoint_index` dedup key `handleExitCost` stamps on both the send leg and the fee leg. Keeps outpoint-keyed entries distinct from round-keyed and session-keyed ones via the separate `idx_client_ledger_idempotent_key` partial unique index.
+- `EventBoardingSweepFeePaid` — Event type `"boarding_sweep_fee_paid"` for
+  miner fees paid during boarding timeout-path sweeps (added alongside the
+  boarding sweep migration to the wallet package).
+- `ClassificationBoardingSweepInput` / `ClassificationBoardingSweepReturn` —
+  UTXO audit classification constants for boarding sweep inputs and return
+  outputs.
 - `UTXOAuditStore` — Interface for DB persistence of UTXO audit log entries (implemented by `db.UTXOAuditStoreDB`).
 - `UTXOAuditEntry` — Domain-level UTXO audit record (outpoint, amount, event, block height, classification).
 - `LedgerMsg` / `LedgerResp` — Message and response type constraints for the durable mailbox.
-- `FeePaidMsg` — Records boarding/refresh fee payments.
+- `FeePaidMsg` — Records boarding/refresh/onchain-sweep fee payments.
+  `FeeTypeOnchainSweep` books a miner fee for on-chain sweeps (e.g. boarding
+  timeout sweep): debit `onchain_fees`, credit `wallet_balance`. `RoundID` may
+  be zero for sweep fees; keyed by sweep txid via `IdempotencyKey` instead.
 - `VTXOReceivedMsg` — Records incoming VTXOs. `Source` must be one of `SourceRoundBoarding` (client's own on-chain wallet funds boarded into a round; offsets wallet_balance), `SourceRoundRefresh` (refresh output or directed-send self-change; offsets transfers_out so the paired VTXOSent cancels on that account and only the operator fee moves vtxo_balance), `SourceRoundTransfer` (in-round receive from another participant; offsets transfers_in), or `SourceOOR` (out-of-round receive; offsets transfers_in). Any other value is rejected.
 - `VTXOSentMsg` — Records outgoing VTXO transfers. Carries either `SessionID` (32-byte OOR) or `RoundID` (16-byte in-round) — exactly one must be non-zero; both-zero and both-set inputs are rejected. Also carries an optional `Outpoint wire.OutPoint` so in-round multi-VTXO events (e.g. paired refresh emissions) disambiguate per-VTXO via an outpoint-derived `IdempotencyKey` instead of collapsing on `idx_client_ledger_idempotent_round`.
 - `ExitCostMsg` — Records a unilateral exit as two ledger entries: a send leg (`transfers_out` debit, `vtxo_balance` credit) for the net-of-fee value and a fee leg (`onchain_fees` debit, `vtxo_balance` credit) for the miner fee. Together the credits reduce `vtxo_balance` by the gross exited amount. Wallet-side movement is covered separately by the `wallet_utxo_log` audit trail.

--- a/lib/arkscript/AGENTS.md
+++ b/lib/arkscript/AGENTS.md
@@ -33,7 +33,19 @@ validated invariants.
     signature over an attacker-chosen tapscript.
 - `StandardVTXOParams` — Decoded parameters for a standard Ark VTXO policy (owner key, operator key, CSV delay). Derived via `DecodeStandardVTXOParams`.
 - `ComposedPolicy` — Composes an existing `CompiledPolicy` with an additional sibling tap branch root, allowing sub-tree aggregation. Built with `ComposeWithSiblingRoot`.
-- `AnchorOutput` — Creates a zero-value P2A anchor transaction output for CPFP fee bumping (replaces the removed `lib/scripts.AnchorPkScript`).
+- `AnchorOption` — Functional option type for `AnchorOutput`. Currently the only
+  implementation is `WithAnchorValue`.
+- `WithAnchorValue(sats int64) AnchorOption` — Overrides the default zero-value
+  P2A anchor with a caller-supplied satoshi amount. Per BIP-433, the P2A dust
+  threshold is 240 sats; values above 240 take the anchor out of the
+  ephemeral-dust regime so the parent transaction may pay a non-zero fee.
+  Callers whose parent tx pays its own miner fee MUST use this option to avoid
+  relay rejection with "dust, tx with dust output must be 0-fee".
+- `AnchorOutput(opts ...AnchorOption) *wire.TxOut` — Creates a P2A anchor
+  output. Without options the value is zero (canonical BIP-433 ephemeral-anchor
+  pattern used by Ark tree/forfeit/checkpoint parents that pay zero fee
+  themselves and are confirmed via a CPFP child). Pass `WithAnchorValue` when
+  the parent pays its own fee (replaces the removed `lib/scripts.AnchorPkScript`).
 - `EncodedLeaf` / `EncodeTapTree` / `DecodeTapTree` — TLV-based tap tree serialization for PSBT sidecars compatible with `waddrmgr` format.
 - `EncodeStandardVTXOArtifacts(ownerKey, operatorKey, exitDelay)` — Convenience
   helper returning both the encoded policy template bytes and the canonical P2TR

--- a/lib/arkscript/CLAUDE.md
+++ b/lib/arkscript/CLAUDE.md
@@ -33,7 +33,19 @@ validated invariants.
     signature over an attacker-chosen tapscript.
 - `StandardVTXOParams` — Decoded parameters for a standard Ark VTXO policy (owner key, operator key, CSV delay). Derived via `DecodeStandardVTXOParams`.
 - `ComposedPolicy` — Composes an existing `CompiledPolicy` with an additional sibling tap branch root, allowing sub-tree aggregation. Built with `ComposeWithSiblingRoot`.
-- `AnchorOutput` — Creates a zero-value P2A anchor transaction output for CPFP fee bumping (replaces the removed `lib/scripts.AnchorPkScript`).
+- `AnchorOption` — Functional option type for `AnchorOutput`. Currently the only
+  implementation is `WithAnchorValue`.
+- `WithAnchorValue(sats int64) AnchorOption` — Overrides the default zero-value
+  P2A anchor with a caller-supplied satoshi amount. Per BIP-433, the P2A dust
+  threshold is 240 sats; values above 240 take the anchor out of the
+  ephemeral-dust regime so the parent transaction may pay a non-zero fee.
+  Callers whose parent tx pays its own miner fee MUST use this option to avoid
+  relay rejection with "dust, tx with dust output must be 0-fee".
+- `AnchorOutput(opts ...AnchorOption) *wire.TxOut` — Creates a P2A anchor
+  output. Without options the value is zero (canonical BIP-433 ephemeral-anchor
+  pattern used by Ark tree/forfeit/checkpoint parents that pay zero fee
+  themselves and are confirmed via a CPFP child). Pass `WithAnchorValue` when
+  the parent pays its own fee (replaces the removed `lib/scripts.AnchorPkScript`).
 - `EncodedLeaf` / `EncodeTapTree` / `DecodeTapTree` — TLV-based tap tree serialization for PSBT sidecars compatible with `waddrmgr` format.
 - `EncodeStandardVTXOArtifacts(ownerKey, operatorKey, exitDelay)` — Convenience
   helper returning both the encoded policy template bytes and the canonical P2TR

--- a/mailbox/pb/AGENTS.md
+++ b/mailbox/pb/AGENTS.md
@@ -1,0 +1,35 @@
+# mailbox/pb
+
+## Purpose
+
+Generated protobuf stubs for the `MailboxService` gRPC interface — the
+bidirectional mailbox transport used between client and Ark server. Do not
+edit — regenerate via `make rpc`.
+
+## Key Types
+
+- `MailboxServiceClient` / `MailboxServiceServer` — Generated gRPC client
+  and server interfaces for the bidirectional mailbox stream.
+- `Envelope` / `RpcMeta` — Core wire types: `Envelope` carries an opaque
+  payload with routing headers; `RpcMeta` carries method, correlation ID,
+  and kind (request/response/push).
+- `mailboxrpc.pb.go` — Generated message types.
+- `mailbox_grpc.pb.go` — Generated gRPC service stubs.
+
+## Relationships
+
+- **Depends on**: `google.golang.org/protobuf` (proto runtime).
+- **Depended on by**: `serverconn` (uses `MailboxServiceClient` for the
+  egress/ingress transport), `sdk/swaps` (uses `MailboxServiceClient` for
+  the out-swap event mailbox pull).
+
+## Invariants
+
+- All files are generated. Never edit them manually.
+- Regenerate by running `make rpc` after changing `mailbox/pb/mailbox.proto`.
+
+## Deep Docs
+
+- [docs/mailbox_architecture.md](../../docs/mailbox_architecture.md) —
+  Three-layer mailbox system (pb, rpc, conn, serverconn).
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/mailbox/pb/CLAUDE.md
+++ b/mailbox/pb/CLAUDE.md
@@ -1,0 +1,35 @@
+# mailbox/pb
+
+## Purpose
+
+Generated protobuf stubs for the `MailboxService` gRPC interface — the
+bidirectional mailbox transport used between client and Ark server. Do not
+edit — regenerate via `make rpc`.
+
+## Key Types
+
+- `MailboxServiceClient` / `MailboxServiceServer` — Generated gRPC client
+  and server interfaces for the bidirectional mailbox stream.
+- `Envelope` / `RpcMeta` — Core wire types: `Envelope` carries an opaque
+  payload with routing headers; `RpcMeta` carries method, correlation ID,
+  and kind (request/response/push).
+- `mailboxrpc.pb.go` — Generated message types.
+- `mailbox_grpc.pb.go` — Generated gRPC service stubs.
+
+## Relationships
+
+- **Depends on**: `google.golang.org/protobuf` (proto runtime).
+- **Depended on by**: `serverconn` (uses `MailboxServiceClient` for the
+  egress/ingress transport), `sdk/swaps` (uses `MailboxServiceClient` for
+  the out-swap event mailbox pull).
+
+## Invariants
+
+- All files are generated. Never edit them manually.
+- Regenerate by running `make rpc` after changing `mailbox/pb/mailbox.proto`.
+
+## Deep Docs
+
+- [docs/mailbox_architecture.md](../../docs/mailbox_architecture.md) —
+  Three-layer mailbox system (pb, rpc, conn, serverconn).
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/oor/AGENTS.md
+++ b/oor/AGENTS.md
@@ -18,8 +18,11 @@ resume semantics.
   2-of-2 collab leaf; uses `MultiPrevOutFetcher` for correct BIP-341 sighash
   across multiple inputs.
 - `ClientActorCfg` — Configuration for OORClientActor (OutboxHandler,
-  ServerConn, PackageStore, DeliveryStore, VTXOManager, VTXOStore, and optional
-  `LedgerSink fn.Option[ledger.Sink]` for fire-and-forget accounting emission).
+  ServerConn, PackageStore, DeliveryStore, VTXOManager, VTXOStore, optional
+  `LedgerSink fn.Option[ledger.Sink]` for fire-and-forget accounting emission,
+  and optional `IncomingVTXOObserver IncomingVTXONotifier` — daemon-local
+  observer called after materialization so subsystems can arm actor-owned work
+  (e.g. fraud watcher) without making `oor` depend on those subsystems).
 - `OORClientActor` — Durable actor wrapping per-session state machines. Handles
   both outgoing transfers and incoming receive via three-phase async resolution.
   Emits `VTXOSentMsg` / `VTXOReceivedMsg` to the ledger actor at the two points
@@ -91,7 +94,10 @@ resume semantics.
   checkpoint PSBTs, recipients, and resolved `MetadataMatches`; sent to the
   wallet/state layer to persist incoming VTXO records.
 - `SendIncomingAckRequest` — Outbox event that asks the transport layer to ack
-  the incoming transfer to the server.
+  the incoming transfer to the server. Implements `CorrelationKey()` returning
+  `"oor/<sessionID>"` so all outbox messages for the same session are serialized
+  in emission order in the durable serverconn mailbox via the per-key FIFO
+  claim invariant.
 - `IncomingTransferNotification` — Outbox event emitted alongside metadata query
   during incoming transfer processing.
 - `ScheduleRetryRequest` — Outbox event for scheduling retryable outbox

--- a/oor/CLAUDE.md
+++ b/oor/CLAUDE.md
@@ -18,8 +18,11 @@ resume semantics.
   2-of-2 collab leaf; uses `MultiPrevOutFetcher` for correct BIP-341 sighash
   across multiple inputs.
 - `ClientActorCfg` — Configuration for OORClientActor (OutboxHandler,
-  ServerConn, PackageStore, DeliveryStore, VTXOManager, VTXOStore, and optional
-  `LedgerSink fn.Option[ledger.Sink]` for fire-and-forget accounting emission).
+  ServerConn, PackageStore, DeliveryStore, VTXOManager, VTXOStore, optional
+  `LedgerSink fn.Option[ledger.Sink]` for fire-and-forget accounting emission,
+  and optional `IncomingVTXOObserver IncomingVTXONotifier` — daemon-local
+  observer called after materialization so subsystems can arm actor-owned work
+  (e.g. fraud watcher) without making `oor` depend on those subsystems).
 - `OORClientActor` — Durable actor wrapping per-session state machines. Handles
   both outgoing transfers and incoming receive via three-phase async resolution.
   Emits `VTXOSentMsg` / `VTXOReceivedMsg` to the ledger actor at the two points
@@ -91,7 +94,10 @@ resume semantics.
   checkpoint PSBTs, recipients, and resolved `MetadataMatches`; sent to the
   wallet/state layer to persist incoming VTXO records.
 - `SendIncomingAckRequest` — Outbox event that asks the transport layer to ack
-  the incoming transfer to the server.
+  the incoming transfer to the server. Implements `CorrelationKey()` returning
+  `"oor/<sessionID>"` so all outbox messages for the same session are serialized
+  in emission order in the durable serverconn mailbox via the per-key FIFO
+  claim invariant.
 - `IncomingTransferNotification` — Outbox event emitted alongside metadata query
   during incoming transfer processing.
 - `ScheduleRetryRequest` — Outbox event for scheduling retryable outbox

--- a/round/AGENTS.md
+++ b/round/AGENTS.md
@@ -96,9 +96,14 @@ protocols with MuSig2 signing ceremonies.
 ### Outbox Messages (`outbox_messages.go`)
 
 - `ClientOutMsg` — Sealed interface for all FSM outbox messages.
+- `JoinRoundRequest` — Initial intent submission to the server. Implements
+  `CorrelationKey()` returning `"round/<RoundID>"` (or `""` for an
+  unassigned round) so messages cluster in a per-round FIFO lane in the
+  durable serverconn mailbox.
 - `JoinRoundAcceptOutbox` — Emitted after quote fee-cap check passes.
   Carries `RoundID` and `QuoteID [32]byte`; routed to
   `MethodAcceptQuote`. `ToProto()` encodes to `roundpb.JoinRoundAccept`.
+  Implements `CorrelationKey()` returning `"round/<RoundID>"`.
 - `JoinRoundRejectOutbox` — Emitted when client refuses the server's
   quote. Carries `RoundID`, `QuoteID [32]byte`, `Reason string`;
   routed to `MethodRejectQuote`. `ToProto()` encodes to

--- a/round/CLAUDE.md
+++ b/round/CLAUDE.md
@@ -96,9 +96,14 @@ protocols with MuSig2 signing ceremonies.
 ### Outbox Messages (`outbox_messages.go`)
 
 - `ClientOutMsg` — Sealed interface for all FSM outbox messages.
+- `JoinRoundRequest` — Initial intent submission to the server. Implements
+  `CorrelationKey()` returning `"round/<RoundID>"` (or `""` for an
+  unassigned round) so messages cluster in a per-round FIFO lane in the
+  durable serverconn mailbox.
 - `JoinRoundAcceptOutbox` — Emitted after quote fee-cap check passes.
   Carries `RoundID` and `QuoteID [32]byte`; routed to
   `MethodAcceptQuote`. `ToProto()` encodes to `roundpb.JoinRoundAccept`.
+  Implements `CorrelationKey()` returning `"round/<RoundID>"`.
 - `JoinRoundRejectOutbox` — Emitted when client refuses the server's
   quote. Carries `RoundID`, `QuoteID [32]byte`, `Reason string`;
   routed to `MethodRejectQuote`. `ToProto()` encodes to

--- a/rpc/oorpb/AGENTS.md
+++ b/rpc/oorpb/AGENTS.md
@@ -1,0 +1,34 @@
+# rpc/oorpb
+
+## Purpose
+
+Generated protobuf stubs for OOR (Out-of-Round) wire messages exchanged over
+the mailbox transport. Do not edit — regenerate via `make rpc`.
+
+## Key Types
+
+- `OORRejectCode` — Discriminated rejection code for server-side OOR
+  rejections, allowing clients to branch on the cause without string-matching.
+- `oorwire.pb.go` — Generated OOR message types.
+- `oorwire_grpc.pb.go` — Generated gRPC stubs.
+- `oorwire_mailboxrpc.pb.go` — Generated mailbox-transport bindings for OOR
+  messages.
+- `payloads.go` — Hand-written helpers for OOR payload construction (the only
+  non-generated file in this package).
+
+## Relationships
+
+- **Depends on**: `google.golang.org/protobuf` (proto runtime).
+- **Depended on by**: `oor` (uses OOR wire message types), `darepod` (wires
+  OOR event routing), `serverconn` (transport delivery).
+
+## Invariants
+
+- `oorwire.pb.go`, `oorwire_grpc.pb.go`, and `oorwire_mailboxrpc.pb.go` are
+  generated. Never edit them manually.
+- `payloads.go` is hand-written and may be edited directly.
+- Regenerate generated files via `make rpc`.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/rpc/oorpb/CLAUDE.md
+++ b/rpc/oorpb/CLAUDE.md
@@ -1,0 +1,34 @@
+# rpc/oorpb
+
+## Purpose
+
+Generated protobuf stubs for OOR (Out-of-Round) wire messages exchanged over
+the mailbox transport. Do not edit — regenerate via `make rpc`.
+
+## Key Types
+
+- `OORRejectCode` — Discriminated rejection code for server-side OOR
+  rejections, allowing clients to branch on the cause without string-matching.
+- `oorwire.pb.go` — Generated OOR message types.
+- `oorwire_grpc.pb.go` — Generated gRPC stubs.
+- `oorwire_mailboxrpc.pb.go` — Generated mailbox-transport bindings for OOR
+  messages.
+- `payloads.go` — Hand-written helpers for OOR payload construction (the only
+  non-generated file in this package).
+
+## Relationships
+
+- **Depends on**: `google.golang.org/protobuf` (proto runtime).
+- **Depended on by**: `oor` (uses OOR wire message types), `darepod` (wires
+  OOR event routing), `serverconn` (transport delivery).
+
+## Invariants
+
+- `oorwire.pb.go`, `oorwire_grpc.pb.go`, and `oorwire_mailboxrpc.pb.go` are
+  generated. Never edit them manually.
+- `payloads.go` is hand-written and may be edited directly.
+- Regenerate generated files via `make rpc`.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/rpc/swapclientrpc/AGENTS.md
+++ b/rpc/swapclientrpc/AGENTS.md
@@ -1,0 +1,33 @@
+# rpc/swapclientrpc
+
+## Purpose
+
+Generated protobuf stubs for the `SwapClientService` gRPC subserver, which
+exposes Lightning↔Ark swap management operations to CLI clients and the
+walletdk SDK. Do not edit the generated files — regenerate via `make rpc`.
+
+## Key Types
+
+- `SwapClientServiceClient` / `SwapClientServiceServer` — Generated gRPC
+  client and server interfaces for the optional swap subserver.
+- `SwapDirection` — Enum discriminating pay vs receive swaps.
+- `swap_client.pb.go` — Generated message types.
+- `swap_client_grpc.pb.go` — Generated gRPC service stubs.
+- `swap_client_mailboxrpc.pb.go` — Generated mailbox-transport bindings.
+
+## Relationships
+
+- **Depends on**: `google.golang.org/protobuf`.
+- **Depended on by**: `swapclientserver` (server-side handler),
+  `cmd/darepocli/darepoclicommands` (swap CLI commands),
+  `sdk/walletdk` (swap RPC client), `cmd/darepocli/internal/gen-devrpc`
+  (dev command generation).
+
+## Invariants
+
+- All `*.pb.go` and `*_grpc.pb.go` files are generated. Never edit them.
+- Regenerate via `make rpc`.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/rpc/swapclientrpc/CLAUDE.md
+++ b/rpc/swapclientrpc/CLAUDE.md
@@ -1,0 +1,33 @@
+# rpc/swapclientrpc
+
+## Purpose
+
+Generated protobuf stubs for the `SwapClientService` gRPC subserver, which
+exposes Lightning↔Ark swap management operations to CLI clients and the
+walletdk SDK. Do not edit the generated files — regenerate via `make rpc`.
+
+## Key Types
+
+- `SwapClientServiceClient` / `SwapClientServiceServer` — Generated gRPC
+  client and server interfaces for the optional swap subserver.
+- `SwapDirection` — Enum discriminating pay vs receive swaps.
+- `swap_client.pb.go` — Generated message types.
+- `swap_client_grpc.pb.go` — Generated gRPC service stubs.
+- `swap_client_mailboxrpc.pb.go` — Generated mailbox-transport bindings.
+
+## Relationships
+
+- **Depends on**: `google.golang.org/protobuf`.
+- **Depended on by**: `swapclientserver` (server-side handler),
+  `cmd/darepocli/darepoclicommands` (swap CLI commands),
+  `sdk/walletdk` (swap RPC client), `cmd/darepocli/internal/gen-devrpc`
+  (dev command generation).
+
+## Invariants
+
+- All `*.pb.go` and `*_grpc.pb.go` files are generated. Never edit them.
+- Regenerate via `make rpc`.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/rpc/walletrpc/AGENTS.md
+++ b/rpc/walletrpc/AGENTS.md
@@ -1,0 +1,39 @@
+# rpc/walletrpc
+
+## Purpose
+
+Generated protobuf stubs for the `WalletService` gRPC subserver, which
+exposes a simplified, swap-vocabulary-free wallet API (Send, Recv, List,
+Deposit, Balance, Status, SubscribeWallet) to CLI clients and the
+walletdk SDK. Do not edit the generated files — regenerate via `make rpc`.
+
+## Key Types
+
+- `WalletServiceClient` / `WalletServiceServer` — Generated gRPC client and
+  server interfaces for the wallet subserver.
+- `EntryKind` — Enum tagging each `WalletEntry` with a user-visible category
+  (SEND, RECV, EXIT, DEPOSIT, etc.).
+- `WalletEntry` — Flat history record projected from swap, OOR, boarding, and
+  exit events.
+- `wallet.pb.go` — Generated message types.
+- `wallet_grpc.pb.go` — Generated gRPC service stubs.
+- `wallet_mailboxrpc.pb.go` — Generated mailbox-transport bindings.
+
+## Relationships
+
+- **Depends on**: `google.golang.org/protobuf`.
+- **Depended on by**: `swapwallet` (server-side handler), `sdk/walletdk`
+  (wallet RPC client), `cmd/darepocli/darepoclicommands` (wallet CLI
+  commands).
+
+## Invariants
+
+- All `*.pb.go` and `*_grpc.pb.go` files are generated. Never edit them.
+- The `walletrpc` build tag controls whether the server-side handler
+  (`swapwallet`) is compiled and registered. The proto stubs are always
+  compiled regardless of the build tag.
+- Regenerate via `make rpc`.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/rpc/walletrpc/CLAUDE.md
+++ b/rpc/walletrpc/CLAUDE.md
@@ -1,0 +1,39 @@
+# rpc/walletrpc
+
+## Purpose
+
+Generated protobuf stubs for the `WalletService` gRPC subserver, which
+exposes a simplified, swap-vocabulary-free wallet API (Send, Recv, List,
+Deposit, Balance, Status, SubscribeWallet) to CLI clients and the
+walletdk SDK. Do not edit the generated files — regenerate via `make rpc`.
+
+## Key Types
+
+- `WalletServiceClient` / `WalletServiceServer` — Generated gRPC client and
+  server interfaces for the wallet subserver.
+- `EntryKind` — Enum tagging each `WalletEntry` with a user-visible category
+  (SEND, RECV, EXIT, DEPOSIT, etc.).
+- `WalletEntry` — Flat history record projected from swap, OOR, boarding, and
+  exit events.
+- `wallet.pb.go` — Generated message types.
+- `wallet_grpc.pb.go` — Generated gRPC service stubs.
+- `wallet_mailboxrpc.pb.go` — Generated mailbox-transport bindings.
+
+## Relationships
+
+- **Depends on**: `google.golang.org/protobuf`.
+- **Depended on by**: `swapwallet` (server-side handler), `sdk/walletdk`
+  (wallet RPC client), `cmd/darepocli/darepoclicommands` (wallet CLI
+  commands).
+
+## Invariants
+
+- All `*.pb.go` and `*_grpc.pb.go` files are generated. Never edit them.
+- The `walletrpc` build tag controls whether the server-side handler
+  (`swapwallet`) is compiled and registered. The proto stubs are always
+  compiled regardless of the build tag.
+- Regenerate via `make rpc`.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/scripts/check-sample-darepod-conf/AGENTS.md
+++ b/scripts/check-sample-darepod-conf/AGENTS.md
@@ -1,0 +1,31 @@
+# scripts/check-sample-darepod-conf
+
+## Purpose
+
+CI verification tool that confirms `sample-darepod.conf` documents every
+daemon configuration option at its current default value. Fails if the sample
+config is missing an option or has a stale default, preventing the documented
+example from drifting out of sync with the actual daemon flags.
+
+## Key Types
+
+- `main` — Collects expected config keys from the daemon's struct tags and
+  flag set, parses the sample config file, and reports any missing or
+  mismatched entries.
+
+## Relationships
+
+- **Depends on**: `darepod` (Config struct and default values), standard
+  `os`/`exec`/`reflect` packages.
+- **Depended on by**: nothing at runtime; invoked by CI or `make` as a
+  pre-commit check.
+
+## Invariants
+
+- Any new field added to `darepod.Config` with a mapstructure tag must also
+  be added to `sample-darepod.conf` with the correct default value, or this
+  tool will fail.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/scripts/check-sample-darepod-conf/CLAUDE.md
+++ b/scripts/check-sample-darepod-conf/CLAUDE.md
@@ -1,0 +1,31 @@
+# scripts/check-sample-darepod-conf
+
+## Purpose
+
+CI verification tool that confirms `sample-darepod.conf` documents every
+daemon configuration option at its current default value. Fails if the sample
+config is missing an option or has a stale default, preventing the documented
+example from drifting out of sync with the actual daemon flags.
+
+## Key Types
+
+- `main` — Collects expected config keys from the daemon's struct tags and
+  flag set, parses the sample config file, and reports any missing or
+  mismatched entries.
+
+## Relationships
+
+- **Depends on**: `darepod` (Config struct and default values), standard
+  `os`/`exec`/`reflect` packages.
+- **Depended on by**: nothing at runtime; invoked by CI or `make` as a
+  pre-commit check.
+
+## Invariants
+
+- Any new field added to `darepod.Config` with a mapstructure tag must also
+  be added to `sample-darepod.conf` with the correct default value, or this
+  tool will fail.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/sdk/ark/AGENTS.md
+++ b/sdk/ark/AGENTS.md
@@ -31,8 +31,16 @@ transport, without duplicating Ark runtime behavior.
 - `WrapDaemonClient` — Constructor that creates a `Client` from an
   already-connected `daemonrpc.DaemonServiceClient` and a caller-supplied
   `closeFn`.
+- `WalletState` — Tri-state enum (`WalletStateUnspecified=0`, `WalletStateNone=1`,
+  `WalletStateLocked=2`, `WalletStateReady=3`) mirroring
+  `daemonrpc.WalletState`. Values are ordered least-to-most ready; callers use
+  `>= WalletStateLocked` for "seed exists" semantics and `== WalletStateReady`
+  for "fully usable" semantics.
 - `Info` / `ServerInfo` / `Seed` / `WalletInitResult` — SDK-owned typed
-  models for daemon status and wallet bootstrap flows.
+  models for daemon status and wallet bootstrap flows. `Info.WalletState` (type
+  `WalletState`) replaces the former `Info.WalletReady bool`; use the
+  `Info.WalletReady()` method as a convenience predicate over
+  `WalletState == WalletStateReady`.
 - `VTXOInfo` — Typed VTXO view (Outpoint, AmountSat, Status, BatchExpiry,
   RoundID, CreatedHeight, etc.) returned by `ListLiveVTXOs` /
   `ListSpentVTXOs`.

--- a/sdk/ark/CLAUDE.md
+++ b/sdk/ark/CLAUDE.md
@@ -31,8 +31,16 @@ transport, without duplicating Ark runtime behavior.
 - `WrapDaemonClient` — Constructor that creates a `Client` from an
   already-connected `daemonrpc.DaemonServiceClient` and a caller-supplied
   `closeFn`.
+- `WalletState` — Tri-state enum (`WalletStateUnspecified=0`, `WalletStateNone=1`,
+  `WalletStateLocked=2`, `WalletStateReady=3`) mirroring
+  `daemonrpc.WalletState`. Values are ordered least-to-most ready; callers use
+  `>= WalletStateLocked` for "seed exists" semantics and `== WalletStateReady`
+  for "fully usable" semantics.
 - `Info` / `ServerInfo` / `Seed` / `WalletInitResult` — SDK-owned typed
-  models for daemon status and wallet bootstrap flows.
+  models for daemon status and wallet bootstrap flows. `Info.WalletState` (type
+  `WalletState`) replaces the former `Info.WalletReady bool`; use the
+  `Info.WalletReady()` method as a convenience predicate over
+  `WalletState == WalletStateReady`.
 - `VTXOInfo` — Typed VTXO view (Outpoint, AmountSat, Status, BatchExpiry,
   RoundID, CreatedHeight, etc.) returned by `ListLiveVTXOs` /
   `ListSpentVTXOs`.

--- a/sdk/swaps/AGENTS.md
+++ b/sdk/swaps/AGENTS.md
@@ -15,7 +15,9 @@ inside the same Ark instance without bridging through Lightning.
 - `SwapClient` — Top-level entry point. Constructed via `NewSwapClient`
   (no persistence) or `NewSwapClientWithStore` (SQLite-backed). Drives
   both pay and receive flows. Holds an `OutSwapEventReceiver` that can be
-  overridden via `SetOutSwapEventReceiver`.
+  overridden via `SetOutSwapEventReceiver`. `SetChainParams(*chaincfg.Params)`
+  configures the Bitcoin network used to decode pay-side BOLT-11 invoices;
+  pay flows reject invoices when no params are configured.
 - `PaySession` — Owns one Ark-to-Lightning pay flow. FSM states:
   `Created → SwapCreated → FundingInitiated → VHTLCFunded →
   WaitingForClaim → Completed` (or `Expired / RefundInitiated →
@@ -109,6 +111,15 @@ flow falls back to `WaitOutSwapHtlc` and converts the result into an
 - OOR session IDs must be persisted before transitioning; failure wraps in
   `newRetryableActionError` so the FSM retries rather than advancing past
   a durable boundary.
+- Pay flows call `validateInSwapQuote` (in `in_swap_quote.go`) before funding
+  the vHTLC; the server quote must match the caller's invoice amount within the
+  fee limit. This guard requires `chainParams` to decode the BOLT-11 invoice —
+  pay flows return an error if no chain params are configured via
+  `SetChainParams`.
+- `NewSwapClientWithStore` auto-extracts `chainParams` from built-in
+  `InvoiceCreator` implementations (`InvoiceGenerator`, `DirectInvoiceCreator`)
+  via `invoiceCreatorChainParams`. Custom `InvoiceCreator` implementations must
+  call `SetChainParams` explicitly.
 - The store is optional: `NewSwapClient` (no store) and
   `NewSwapClientWithStore` are both valid; all `persist()` calls are
   no-ops when `store == nil`.

--- a/sdk/swaps/CLAUDE.md
+++ b/sdk/swaps/CLAUDE.md
@@ -15,7 +15,9 @@ inside the same Ark instance without bridging through Lightning.
 - `SwapClient` — Top-level entry point. Constructed via `NewSwapClient`
   (no persistence) or `NewSwapClientWithStore` (SQLite-backed). Drives
   both pay and receive flows. Holds an `OutSwapEventReceiver` that can be
-  overridden via `SetOutSwapEventReceiver`.
+  overridden via `SetOutSwapEventReceiver`. `SetChainParams(*chaincfg.Params)`
+  configures the Bitcoin network used to decode pay-side BOLT-11 invoices;
+  pay flows reject invoices when no params are configured.
 - `PaySession` — Owns one Ark-to-Lightning pay flow. FSM states:
   `Created → SwapCreated → FundingInitiated → VHTLCFunded →
   WaitingForClaim → Completed` (or `Expired / RefundInitiated →
@@ -109,6 +111,15 @@ flow falls back to `WaitOutSwapHtlc` and converts the result into an
 - OOR session IDs must be persisted before transitioning; failure wraps in
   `newRetryableActionError` so the FSM retries rather than advancing past
   a durable boundary.
+- Pay flows call `validateInSwapQuote` (in `in_swap_quote.go`) before funding
+  the vHTLC; the server quote must match the caller's invoice amount within the
+  fee limit. This guard requires `chainParams` to decode the BOLT-11 invoice —
+  pay flows return an error if no chain params are configured via
+  `SetChainParams`.
+- `NewSwapClientWithStore` auto-extracts `chainParams` from built-in
+  `InvoiceCreator` implementations (`InvoiceGenerator`, `DirectInvoiceCreator`)
+  via `invoiceCreatorChainParams`. Custom `InvoiceCreator` implementations must
+  call `SetChainParams` explicitly.
 - The store is optional: `NewSwapClient` (no store) and
   `NewSwapClientWithStore` are both valid; all `persist()` calls are
   no-ops when `store == nil`.

--- a/sdk/swaps/sqlc/AGENTS.md
+++ b/sdk/swaps/sqlc/AGENTS.md
@@ -1,0 +1,28 @@
+# sdk/swaps/sqlc
+
+## Purpose
+
+Generated sqlc query bindings for the swap client's isolated SQLite database.
+Do not edit — regenerate via `make sqlc`.
+
+## Key Types
+
+- `Querier` — Generated interface for swap-session persistence operations
+  (insert/update/get/list swap sessions).
+- Generated row structs — Map SQL columns to typed Go fields for swap session
+  records.
+
+## Relationships
+
+- **Depends on**: nothing beyond standard `database/sql`.
+- **Depended on by**: `sdk/swaps` (the `Store` type wraps these generated
+  queries with migration and higher-level session helpers).
+
+## Invariants
+
+- All files are generated. Never edit them manually.
+- Regenerate via `make sqlc` after changing swap-related query or schema files.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../../ARCHITECTURE.md) — System-wide package map.

--- a/sdk/swaps/sqlc/CLAUDE.md
+++ b/sdk/swaps/sqlc/CLAUDE.md
@@ -1,0 +1,28 @@
+# sdk/swaps/sqlc
+
+## Purpose
+
+Generated sqlc query bindings for the swap client's isolated SQLite database.
+Do not edit — regenerate via `make sqlc`.
+
+## Key Types
+
+- `Querier` — Generated interface for swap-session persistence operations
+  (insert/update/get/list swap sessions).
+- Generated row structs — Map SQL columns to typed Go fields for swap session
+  records.
+
+## Relationships
+
+- **Depends on**: nothing beyond standard `database/sql`.
+- **Depended on by**: `sdk/swaps` (the `Store` type wraps these generated
+  queries with migration and higher-level session helpers).
+
+## Invariants
+
+- All files are generated. Never edit them manually.
+- Regenerate via `make sqlc` after changing swap-related query or schema files.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../../ARCHITECTURE.md) — System-wide package map.

--- a/sdk/walletdk/AGENTS.md
+++ b/sdk/walletdk/AGENTS.md
@@ -13,26 +13,40 @@ graph.
 ## Key Types
 
 - `Client` — Concurrency-safe wallet handle. Owns the embedded daemon
-  lifecycle, the private `bufconn` gRPC connection, and the daemon-owned swap
-  RPC clients. `Stop`/`Close` are aliases; both are idempotent.
+  lifecycle, the private `bufconn` gRPC connection, and the daemon-owned RPC
+  clients (daemon, swap, wallet). `Stop`/`Close` are aliases; both are
+  idempotent.
 - `Config` — Embedded daemon + wallet facade config. Two usage modes:
   zero-value plus convenience fields (`DataDir`, `Network`, `ServerAddress`,
   …), or a caller-owned `DaemonConfig` plus only the convenience fields the
   host wants to override. The convenience booleans (`AllowMainnet`,
   `ServerInsecure`, `SwapServerInsecure`) are `fn.Option[bool]`: `fn.None`
   defers to `DaemonConfig`, `fn.Some(v)` forces that value.
+- `ConnectConfig` — Configuration for `Connect` (remote daemon mode); holds
+  `Address` and optional `DialOptions`.
+- `Connect(ctx, ConnectConfig)` — Returns a `*Client` connected to an
+  external daemon (no embedded daemon). Complement to `Start` for remote
+  usage.
 - `DefaultConfig` — Returns a walletdk `Config` populated from
   `darepod.DefaultConfig()`. Convenience starting point for hosts.
 - `Start` — Boots the embedded daemon, dials it, waits for gRPC readiness,
   and returns a ready-to-use `*Client`. Detaches the daemon lifetime from the
   caller's `ctx` so a tight startup deadline does not kill the daemon.
-- `Info` / `Balance` / `OnchainAddress` / `CreateWalletResult` /
-  `UnlockWalletResult` — Wrapper-owned wallet DTOs. Mobile and JS bridges see
-  these, not protobuf types.
+- `WalletState` — Enum (`WalletStateNone`, `WalletStateLocked`,
+  `WalletStateReady`) mirroring the daemon's tri-state for host UI surfaces.
+- `Info` — Includes `WalletState` for the new tri-state wallet readiness
+  field surfaced via `GetInfo`.
+- `Balance` / `DepositRequest` / `DepositResult` — Onchain deposit address
+  and balance DTOs.
 - `ReceiveRequest` / `ReceiveResult` / `SendRequest` / `SendResult` —
-  Wrapper-owned swap-start DTOs. Receive returns a BOLT-11 invoice plus the
-  initial durable swap summary; Send returns the payment hash plus the
-  initial summary.
+  Wrapper-owned swap-start DTOs (swap-runtime only).
+- `ListRequest` / `ListResult` / `Entry` / `EntryKind` / `EntryStatus` —
+  Unified wallet history page request/response DTOs used by `List` and
+  `Subscribe` (walletrpc only).
+- `Status` — Unified balance + pending-entry summary DTO used by `Status`
+  (walletrpc only).
+- `SubscribeRequest` — Configuration for the `Subscribe` streaming call;
+  optional `ExistingEntries bool` to emit current rows first.
 - `SwapSummary` — Wrapper-owned durable swap view used for `ListSwaps`,
   `GetSwap`, `ResumeSwap`, and `SubscribeSwaps`. Stable lowercase `State`
   string is owned by `convert.go`, intentionally decoupled from the proto
@@ -42,34 +56,40 @@ graph.
 - `ErrSwapRuntimeUnavailable` — Sentinel returned by `Receive`, `Send`,
   `ListSwaps`, `GetSwap`, `ResumeSwap`, and `SubscribeSwaps` when the package
   is built without the `swapruntime` tag.
+- `WalletRPC()` — Returns the private `walletrpc.WalletServiceClient` for
+  advanced callers.
 
 ## RPC Methods (host-facing API)
 
 | Method | Description |
 |--------|-------------|
-| `GetInfo` | Daemon readiness snapshot: version, network, identity, wallet/server readiness |
+| `GetInfo` | Daemon readiness snapshot: version, network, identity, wallet/server readiness, `WalletState` |
 | `CreateWallet` | Create or import the embedded daemon wallet (auto-generates seed when mnemonic empty) |
 | `UnlockWallet` | Unlock an existing embedded daemon wallet |
-| `ListBalance` | Confirmed/unconfirmed boarding, VTXO, and on-chain balance buckets |
-| `GetOnchainAddress` | Allocate a fresh boarding address |
+| `Balance` | Confirmed/unconfirmed boarding, VTXO, and on-chain balance buckets |
+| `Deposit` | Allocate a fresh boarding address (walletrpc only) |
 | `Receive` | Start a Lightning-to-Ark receive swap (swapruntime only) |
-| `Send` | Start an Ark-to-Lightning payment swap (swapruntime only) |
+| `Send` | Start an Ark-to-Lightning payment or onchain send (walletrpc only) |
+| `List` | Page through unified wallet history — swap, OOR, boarding, exit (walletrpc only) |
+| `Status` | Unified balance + pending-entry summary (walletrpc only) |
+| `Subscribe` | Stream `Entry` updates; optionally emit existing rows first (walletrpc only) |
 | `ListSwaps` | List persisted daemon-owned swap summaries (swapruntime only) |
 | `GetSwap` | Fetch one persisted swap by hex payment hash (swapruntime only) |
 | `ResumeSwap` | Wake one pending persisted swap worker (swapruntime only) |
 | `SubscribeSwaps` | Stream swap summary updates; optionally include existing rows (swapruntime only) |
 | `Stop` / `Close` | Shut down the embedded daemon and release the private transport |
-| `Wait` | Single-reader channel yielding the daemon's terminal run error |
-| `GRPCConn` / `ArkRPC` / `SwapRPC` | Escape hatches exposing the underlying private gRPC connection and raw RPC clients |
+| `Wait` | Channel yielding the daemon's terminal run error (multi-reader via context.AfterFunc) |
+| `GRPCConn` / `ArkRPC` / `SwapRPC` / `WalletRPC` | Escape hatches for the underlying gRPC connection and raw RPC clients |
 
 ## Relationships
 
 - **Depends on**: `darepod` (embedded daemon runtime, default config,
   validation), `daemonrpc` (wallet, balance, info, address RPCs),
-  `rpc/swapclientrpc` (daemon-owned swap RPCs), `swapclientserver`
-  (`swapruntime` build only — registers the daemon-side swap subserver via
-  `RPCServiceRegistrars`), `google.golang.org/grpc/test/bufconn`
-  (in-process transport).
+  `rpc/swapclientrpc` (daemon-owned swap RPCs), `rpc/walletrpc`
+  (daemon-owned wallet RPCs), `swapclientserver` (`swapruntime` build only —
+  registers the swap subserver via `RPCServiceRegistrars`), `swapwallet`
+  (`walletrpc` + `swapruntime` build only — registers the wallet subserver),
+  `google.golang.org/grpc/test/bufconn` (in-process transport).
 - **Depended on by**: host Go apps, gomobile / React Native / WASM bridges,
   and `cmd/walletdk-tui` (Bubble Tea manual-test TUI; tracked in a sibling
   PR).
@@ -118,6 +138,12 @@ graph.
 - `SubscribeSwaps` returns an unbuffered updates channel so a slow consumer
   applies backpressure end-to-end; the errs channel is cap-1 for a single
   terminal error.
+- Wallet-RPC methods (`Deposit`, `Send`, `List`, `Status`, `Subscribe`)
+  return `ErrWalletRPCUnavailable` synchronously when the daemon was not
+  compiled with both `walletrpc` and `swapruntime` tags. This is checked via
+  `requireWalletRPC()` before any gRPC is attempted.
+- `Connect` (remote mode) sets `canWallet` based on whether the daemon's
+  `GetInfo` response advertises a `WalletService` capability.
 
 ## Deep Docs
 

--- a/sdk/walletdk/CLAUDE.md
+++ b/sdk/walletdk/CLAUDE.md
@@ -13,26 +13,40 @@ graph.
 ## Key Types
 
 - `Client` — Concurrency-safe wallet handle. Owns the embedded daemon
-  lifecycle, the private `bufconn` gRPC connection, and the daemon-owned swap
-  RPC clients. `Stop`/`Close` are aliases; both are idempotent.
+  lifecycle, the private `bufconn` gRPC connection, and the daemon-owned RPC
+  clients (daemon, swap, wallet). `Stop`/`Close` are aliases; both are
+  idempotent.
 - `Config` — Embedded daemon + wallet facade config. Two usage modes:
   zero-value plus convenience fields (`DataDir`, `Network`, `ServerAddress`,
   …), or a caller-owned `DaemonConfig` plus only the convenience fields the
   host wants to override. The convenience booleans (`AllowMainnet`,
   `ServerInsecure`, `SwapServerInsecure`) are `fn.Option[bool]`: `fn.None`
   defers to `DaemonConfig`, `fn.Some(v)` forces that value.
+- `ConnectConfig` — Configuration for `Connect` (remote daemon mode); holds
+  `Address` and optional `DialOptions`.
+- `Connect(ctx, ConnectConfig)` — Returns a `*Client` connected to an
+  external daemon (no embedded daemon). Complement to `Start` for remote
+  usage.
 - `DefaultConfig` — Returns a walletdk `Config` populated from
   `darepod.DefaultConfig()`. Convenience starting point for hosts.
 - `Start` — Boots the embedded daemon, dials it, waits for gRPC readiness,
   and returns a ready-to-use `*Client`. Detaches the daemon lifetime from the
   caller's `ctx` so a tight startup deadline does not kill the daemon.
-- `Info` / `Balance` / `OnchainAddress` / `CreateWalletResult` /
-  `UnlockWalletResult` — Wrapper-owned wallet DTOs. Mobile and JS bridges see
-  these, not protobuf types.
+- `WalletState` — Enum (`WalletStateNone`, `WalletStateLocked`,
+  `WalletStateReady`) mirroring the daemon's tri-state for host UI surfaces.
+- `Info` — Includes `WalletState` for the new tri-state wallet readiness
+  field surfaced via `GetInfo`.
+- `Balance` / `DepositRequest` / `DepositResult` — Onchain deposit address
+  and balance DTOs.
 - `ReceiveRequest` / `ReceiveResult` / `SendRequest` / `SendResult` —
-  Wrapper-owned swap-start DTOs. Receive returns a BOLT-11 invoice plus the
-  initial durable swap summary; Send returns the payment hash plus the
-  initial summary.
+  Wrapper-owned swap-start DTOs (swap-runtime only).
+- `ListRequest` / `ListResult` / `Entry` / `EntryKind` / `EntryStatus` —
+  Unified wallet history page request/response DTOs used by `List` and
+  `Subscribe` (walletrpc only).
+- `Status` — Unified balance + pending-entry summary DTO used by `Status`
+  (walletrpc only).
+- `SubscribeRequest` — Configuration for the `Subscribe` streaming call;
+  optional `ExistingEntries bool` to emit current rows first.
 - `SwapSummary` — Wrapper-owned durable swap view used for `ListSwaps`,
   `GetSwap`, `ResumeSwap`, and `SubscribeSwaps`. Stable lowercase `State`
   string is owned by `convert.go`, intentionally decoupled from the proto
@@ -42,34 +56,40 @@ graph.
 - `ErrSwapRuntimeUnavailable` — Sentinel returned by `Receive`, `Send`,
   `ListSwaps`, `GetSwap`, `ResumeSwap`, and `SubscribeSwaps` when the package
   is built without the `swapruntime` tag.
+- `WalletRPC()` — Returns the private `walletrpc.WalletServiceClient` for
+  advanced callers.
 
 ## RPC Methods (host-facing API)
 
 | Method | Description |
 |--------|-------------|
-| `GetInfo` | Daemon readiness snapshot: version, network, identity, wallet/server readiness |
+| `GetInfo` | Daemon readiness snapshot: version, network, identity, wallet/server readiness, `WalletState` |
 | `CreateWallet` | Create or import the embedded daemon wallet (auto-generates seed when mnemonic empty) |
 | `UnlockWallet` | Unlock an existing embedded daemon wallet |
-| `ListBalance` | Confirmed/unconfirmed boarding, VTXO, and on-chain balance buckets |
-| `GetOnchainAddress` | Allocate a fresh boarding address |
+| `Balance` | Confirmed/unconfirmed boarding, VTXO, and on-chain balance buckets |
+| `Deposit` | Allocate a fresh boarding address (walletrpc only) |
 | `Receive` | Start a Lightning-to-Ark receive swap (swapruntime only) |
-| `Send` | Start an Ark-to-Lightning payment swap (swapruntime only) |
+| `Send` | Start an Ark-to-Lightning payment or onchain send (walletrpc only) |
+| `List` | Page through unified wallet history — swap, OOR, boarding, exit (walletrpc only) |
+| `Status` | Unified balance + pending-entry summary (walletrpc only) |
+| `Subscribe` | Stream `Entry` updates; optionally emit existing rows first (walletrpc only) |
 | `ListSwaps` | List persisted daemon-owned swap summaries (swapruntime only) |
 | `GetSwap` | Fetch one persisted swap by hex payment hash (swapruntime only) |
 | `ResumeSwap` | Wake one pending persisted swap worker (swapruntime only) |
 | `SubscribeSwaps` | Stream swap summary updates; optionally include existing rows (swapruntime only) |
 | `Stop` / `Close` | Shut down the embedded daemon and release the private transport |
-| `Wait` | Single-reader channel yielding the daemon's terminal run error |
-| `GRPCConn` / `ArkRPC` / `SwapRPC` | Escape hatches exposing the underlying private gRPC connection and raw RPC clients |
+| `Wait` | Channel yielding the daemon's terminal run error (multi-reader via context.AfterFunc) |
+| `GRPCConn` / `ArkRPC` / `SwapRPC` / `WalletRPC` | Escape hatches for the underlying gRPC connection and raw RPC clients |
 
 ## Relationships
 
 - **Depends on**: `darepod` (embedded daemon runtime, default config,
   validation), `daemonrpc` (wallet, balance, info, address RPCs),
-  `rpc/swapclientrpc` (daemon-owned swap RPCs), `swapclientserver`
-  (`swapruntime` build only — registers the daemon-side swap subserver via
-  `RPCServiceRegistrars`), `google.golang.org/grpc/test/bufconn`
-  (in-process transport).
+  `rpc/swapclientrpc` (daemon-owned swap RPCs), `rpc/walletrpc`
+  (daemon-owned wallet RPCs), `swapclientserver` (`swapruntime` build only —
+  registers the swap subserver via `RPCServiceRegistrars`), `swapwallet`
+  (`walletrpc` + `swapruntime` build only — registers the wallet subserver),
+  `google.golang.org/grpc/test/bufconn` (in-process transport).
 - **Depended on by**: host Go apps, gomobile / React Native / WASM bridges,
   and `cmd/walletdk-tui` (Bubble Tea manual-test TUI; tracked in a sibling
   PR).
@@ -118,6 +138,12 @@ graph.
 - `SubscribeSwaps` returns an unbuffered updates channel so a slow consumer
   applies backpressure end-to-end; the errs channel is cap-1 for a single
   terminal error.
+- Wallet-RPC methods (`Deposit`, `Send`, `List`, `Status`, `Subscribe`)
+  return `ErrWalletRPCUnavailable` synchronously when the daemon was not
+  compiled with both `walletrpc` and `swapruntime` tags. This is checked via
+  `requireWalletRPC()` before any gRPC is attempted.
+- `Connect` (remote mode) sets `canWallet` based on whether the daemon's
+  `GetInfo` response advertises a `WalletService` capability.
 
 ## Deep Docs
 

--- a/serverconn/AGENTS.md
+++ b/serverconn/AGENTS.md
@@ -18,6 +18,13 @@ background ingress polling with event routing.
 - `AuthHeaderKey` — Envelope header key (`x-mailbox-auth-sig`) for the Schnorr auth signature.
 - `GenerateClientTLSCert` — Creates an ephemeral P-256 mTLS client cert with the secp256k1 identity pubkey hex as Subject CN. Returns error on nil key.
 - `AckState` — Four-cursor watermark state machine (PullCursor, DispatchCommittedTo, AckTarget, AckCommittedTo).
+- `SendClientEventRequest` — Durable TLV-encoded outbox message wrapping a
+  round/OOR outbox event for delivery over the mailbox. Implements
+  `actor.Message.CorrelationKey()` by forwarding the inner concrete message's
+  `CorrelationKey()` (in-process path) or a `cachedCorrelationKey` decoded
+  from TLV field 8 (outbox-CDC replay path). Without this forwarding, the
+  wrapper's embedded `BaseMessage` default of `""` would erase the inner key
+  at enqueue and land every outbox row in the unkeyed claim lane.
 - `SendUnaryRequest` — Durable typed unary request that becomes a real unary RPC after commit. The response arrives via KIND_RESPONSE and, if no in-memory waiter exists, falls back to durable route dispatch via the EventRouter.
 - `DurableUnaryRequestBuilder` — Interface for proof-gated request-body construction. Implementations build the actual proto request (e.g., with signed proofs) at send time, not at persist time. The interface is provided via `ConnectorConfig.DurableUnaryBuilder`.
 - `DurableUnaryQuery` — Interface implemented by transport-native durable query messages that persist raw query parameters (not a full proto). The `ServerConnectionActor` matches any `DurableUnaryQuery` generically in its `Receive` loop and calls `buildDurableUnary` to construct a `SendUnaryRequest` on the fly, using `BuildBody`, `QueryCorrelationID`, `QueryMsgID`, `QueryIdempotencyKey`, and `ServiceMethod`.
@@ -44,6 +51,10 @@ background ingress polling with event routing.
 - Ack watermark only advances AFTER durable local dispatch commit (prevents message loss on crash).
 - Unary RPC responses use in-memory registry first; if no waiter exists (crash replay), the ingress falls back to durable EventRouter dispatch. The ResponseRegistry returns a tri-state delivery result (waiter/buffered/dropped) so the ingress knows whether to route durably.
 - `SendClientEventRequest` auto-derives `Service`/`Method` from `Message.ServiceMethod()` when callers leave them empty, preventing silent drops.
+- `SendClientEventRequest.CorrelationKey()` MUST propagate the inner message's
+  key to the durable mailbox. The TLV codec persists it in field 8 so the
+  outbox-CDC decode path can recover it even after `rawServerMessage` replaces
+  the typed inner message.
 - Idempotency keys are derived from message payload hash; same key on retry enables server deduplication.
 - Ingress loop checkpoints pull cursor and ack state; on restart, resumes from checkpoint.
 - `DurableUnaryQuery` values are handled generically in `ServerConnectionActor.Receive` via `buildDurableUnary`: the query is converted to a `SendUnaryRequest` using the configured `DurableUnaryRequestBuilder`. Adding a new durable indexer query type requires only implementing `DurableUnaryQuery` — no new `Receive` case is needed.

--- a/serverconn/CLAUDE.md
+++ b/serverconn/CLAUDE.md
@@ -18,6 +18,13 @@ background ingress polling with event routing.
 - `AuthHeaderKey` — Envelope header key (`x-mailbox-auth-sig`) for the Schnorr auth signature.
 - `GenerateClientTLSCert` — Creates an ephemeral P-256 mTLS client cert with the secp256k1 identity pubkey hex as Subject CN. Returns error on nil key.
 - `AckState` — Four-cursor watermark state machine (PullCursor, DispatchCommittedTo, AckTarget, AckCommittedTo).
+- `SendClientEventRequest` — Durable TLV-encoded outbox message wrapping a
+  round/OOR outbox event for delivery over the mailbox. Implements
+  `actor.Message.CorrelationKey()` by forwarding the inner concrete message's
+  `CorrelationKey()` (in-process path) or a `cachedCorrelationKey` decoded
+  from TLV field 8 (outbox-CDC replay path). Without this forwarding, the
+  wrapper's embedded `BaseMessage` default of `""` would erase the inner key
+  at enqueue and land every outbox row in the unkeyed claim lane.
 - `SendUnaryRequest` — Durable typed unary request that becomes a real unary RPC after commit. The response arrives via KIND_RESPONSE and, if no in-memory waiter exists, falls back to durable route dispatch via the EventRouter.
 - `DurableUnaryRequestBuilder` — Interface for proof-gated request-body construction. Implementations build the actual proto request (e.g., with signed proofs) at send time, not at persist time. The interface is provided via `ConnectorConfig.DurableUnaryBuilder`.
 - `DurableUnaryQuery` — Interface implemented by transport-native durable query messages that persist raw query parameters (not a full proto). The `ServerConnectionActor` matches any `DurableUnaryQuery` generically in its `Receive` loop and calls `buildDurableUnary` to construct a `SendUnaryRequest` on the fly, using `BuildBody`, `QueryCorrelationID`, `QueryMsgID`, `QueryIdempotencyKey`, and `ServiceMethod`.
@@ -44,6 +51,10 @@ background ingress polling with event routing.
 - Ack watermark only advances AFTER durable local dispatch commit (prevents message loss on crash).
 - Unary RPC responses use in-memory registry first; if no waiter exists (crash replay), the ingress falls back to durable EventRouter dispatch. The ResponseRegistry returns a tri-state delivery result (waiter/buffered/dropped) so the ingress knows whether to route durably.
 - `SendClientEventRequest` auto-derives `Service`/`Method` from `Message.ServiceMethod()` when callers leave them empty, preventing silent drops.
+- `SendClientEventRequest.CorrelationKey()` MUST propagate the inner message's
+  key to the durable mailbox. The TLV codec persists it in field 8 so the
+  outbox-CDC decode path can recover it even after `rawServerMessage` replaces
+  the typed inner message.
 - Idempotency keys are derived from message payload hash; same key on retry enables server deduplication.
 - Ingress loop checkpoints pull cursor and ack state; on restart, resumes from checkpoint.
 - `DurableUnaryQuery` values are handled generically in `ServerConnectionActor.Receive` via `buildDurableUnary`: the query is converted to a `SendUnaryRequest` using the configured `DurableUnaryRequestBuilder`. Adding a new durable indexer query type requires only implementing `DurableUnaryQuery` — no new `Receive` case is needed.

--- a/serverconn/hellotestpb/AGENTS.md
+++ b/serverconn/hellotestpb/AGENTS.md
@@ -1,0 +1,31 @@
+# serverconn/hellotestpb
+
+## Purpose
+
+Minimal generated protobuf stubs used exclusively in `serverconn` integration
+tests to validate the mailbox transport without depending on production proto
+definitions. Do not edit — regenerate via `make rpc` if the proto changes.
+
+## Key Types
+
+- `HelloRequest` / `HelloResponse` — Simple request/response pair used in
+  test scenarios.
+- `HelloServiceClient` / `HelloServiceServer` — Generated gRPC stubs for the
+  test hello service.
+- `hello_mailboxrpc.pb.go` — Generated mailbox-transport bindings for the
+  hello service.
+
+## Relationships
+
+- **Depends on**: `google.golang.org/protobuf`.
+- **Depended on by**: `serverconn` test files only.
+
+## Invariants
+
+- All files are generated. Never edit them manually.
+- This package is test-only infrastructure and must not be imported by
+  production code.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/serverconn/hellotestpb/CLAUDE.md
+++ b/serverconn/hellotestpb/CLAUDE.md
@@ -1,0 +1,31 @@
+# serverconn/hellotestpb
+
+## Purpose
+
+Minimal generated protobuf stubs used exclusively in `serverconn` integration
+tests to validate the mailbox transport without depending on production proto
+definitions. Do not edit — regenerate via `make rpc` if the proto changes.
+
+## Key Types
+
+- `HelloRequest` / `HelloResponse` — Simple request/response pair used in
+  test scenarios.
+- `HelloServiceClient` / `HelloServiceServer` — Generated gRPC stubs for the
+  test hello service.
+- `hello_mailboxrpc.pb.go` — Generated mailbox-transport bindings for the
+  hello service.
+
+## Relationships
+
+- **Depends on**: `google.golang.org/protobuf`.
+- **Depended on by**: `serverconn` test files only.
+
+## Invariants
+
+- All files are generated. Never edit them manually.
+- This package is test-only infrastructure and must not be imported by
+  production code.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/swapclientserver/AGENTS.md
+++ b/swapclientserver/AGENTS.md
@@ -33,11 +33,14 @@ protocol behavior remain entirely inside `sdk/swaps` and `swapdk-server`.
   by a `swapruntime`-tagged `darepod` binary. Opens the daemon-owned SQLite
   swap store, dials `swapdk-server`, creates an in-process Ark SDK facade over
   `darepod.RPCServer`, wires `swaps.NewSwapClientWithStore`, installs a
-  `MailboxOutSwapEventReceiver` (empty mailbox ID — receiver derives the
-  per-swap mailbox from client identity + payment hash) on the
-  `SwapClient` so out-swap HTLC events flow over the mailbox transport,
-  registers the gRPC subserver, calls `resumePending`, and returns a cleanup
-  function.
+  `MailboxOutSwapEventReceiver` on the `SwapClient`, registers the gRPC
+  subserver, populates `cfg.Swap.Backend` with `ResumePending`, and — unless
+  `cfg.Swap.SuppressResume` is true — calls `resumePending` synchronously.
+  When `SuppressResume` is true a higher-layer subserver (walletrpc) owns the
+  resume timing.
+- `ResumePending(ctx)` — Public method satisfying `darepod.SwapBackend`.
+  Exposes the private `resumePending` helper so the walletrpc subserver can
+  drive it after its own pre-conditions are met.
 
 ## RPC Methods
 
@@ -77,9 +80,12 @@ protocol behavior remain entirely inside `sdk/swaps` and `swapdk-server`.
 - `SubscribeSwaps` subscribers are best-effort, buffered (16), and
   non-blocking. Slow subscribers may miss a terminal-state update; they can
   recover current state with `GetSwap` or `ListSwaps`.
-- `Register` calls `resumePending` synchronously before returning so the
-  daemon gRPC server begins accepting calls with all prior sessions already
-  driven by a worker.
+- `Register` populates `cfg.Swap.Backend` before the resume sweep so a
+  higher layer (walletrpc) can call `ResumePending` even when
+  `SuppressResume=true`. When `SuppressResume=false` (default), `Register`
+  calls `resumePending` synchronously before returning so the daemon gRPC
+  server begins accepting calls with all prior sessions already driven by a
+  worker.
 - Swap state, persistence, and protocol behavior are never duplicated in this
   layer — they stay in `sdk/swaps`. This package is a worker registry and RPC
   facade only.

--- a/swapclientserver/CLAUDE.md
+++ b/swapclientserver/CLAUDE.md
@@ -33,11 +33,14 @@ protocol behavior remain entirely inside `sdk/swaps` and `swapdk-server`.
   by a `swapruntime`-tagged `darepod` binary. Opens the daemon-owned SQLite
   swap store, dials `swapdk-server`, creates an in-process Ark SDK facade over
   `darepod.RPCServer`, wires `swaps.NewSwapClientWithStore`, installs a
-  `MailboxOutSwapEventReceiver` (empty mailbox ID — receiver derives the
-  per-swap mailbox from client identity + payment hash) on the
-  `SwapClient` so out-swap HTLC events flow over the mailbox transport,
-  registers the gRPC subserver, calls `resumePending`, and returns a cleanup
-  function.
+  `MailboxOutSwapEventReceiver` on the `SwapClient`, registers the gRPC
+  subserver, populates `cfg.Swap.Backend` with `ResumePending`, and — unless
+  `cfg.Swap.SuppressResume` is true — calls `resumePending` synchronously.
+  When `SuppressResume` is true a higher-layer subserver (walletrpc) owns the
+  resume timing.
+- `ResumePending(ctx)` — Public method satisfying `darepod.SwapBackend`.
+  Exposes the private `resumePending` helper so the walletrpc subserver can
+  drive it after its own pre-conditions are met.
 
 ## RPC Methods
 
@@ -77,9 +80,12 @@ protocol behavior remain entirely inside `sdk/swaps` and `swapdk-server`.
 - `SubscribeSwaps` subscribers are best-effort, buffered (16), and
   non-blocking. Slow subscribers may miss a terminal-state update; they can
   recover current state with `GetSwap` or `ListSwaps`.
-- `Register` calls `resumePending` synchronously before returning so the
-  daemon gRPC server begins accepting calls with all prior sessions already
-  driven by a worker.
+- `Register` populates `cfg.Swap.Backend` before the resume sweep so a
+  higher layer (walletrpc) can call `ResumePending` even when
+  `SuppressResume=true`. When `SuppressResume=false` (default), `Register`
+  calls `resumePending` synchronously before returning so the daemon gRPC
+  server begins accepting calls with all prior sessions already driven by a
+  worker.
 - Swap state, persistence, and protocol behavior are never duplicated in this
   layer — they stay in `sdk/swaps`. This package is a worker registry and RPC
   facade only.

--- a/swaprpc/AGENTS.md
+++ b/swaprpc/AGENTS.md
@@ -1,0 +1,30 @@
+# swaprpc
+
+## Purpose
+
+Generated protobuf stubs for the daemon-internal swap RPC wire protocol used
+by `swapclientserver` to communicate with the remote swap server over
+mailbox-backed channels. Do not edit — regenerate via `make rpc`.
+
+## Key Types
+
+- `SettlementType` — Enum identifying whether a swap bridges through
+  Lightning or settles in-Ark (same Ark instance).
+- `swap.pb.go` — Generated message types for swap session negotiation.
+- `swap_grpc.pb.go` — Generated gRPC stubs.
+- `swap_mailboxrpc.pb.go` — Generated mailbox-transport bindings.
+
+## Relationships
+
+- **Depends on**: `google.golang.org/protobuf`.
+- **Depended on by**: `swapclientserver` (uses swap wire types for
+  server-to-client swap negotiation messages).
+
+## Invariants
+
+- All files are generated. Never edit them manually.
+- Regenerate via `make rpc`.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/swaprpc/CLAUDE.md
+++ b/swaprpc/CLAUDE.md
@@ -1,0 +1,30 @@
+# swaprpc
+
+## Purpose
+
+Generated protobuf stubs for the daemon-internal swap RPC wire protocol used
+by `swapclientserver` to communicate with the remote swap server over
+mailbox-backed channels. Do not edit — regenerate via `make rpc`.
+
+## Key Types
+
+- `SettlementType` — Enum identifying whether a swap bridges through
+  Lightning or settles in-Ark (same Ark instance).
+- `swap.pb.go` — Generated message types for swap session negotiation.
+- `swap_grpc.pb.go` — Generated gRPC stubs.
+- `swap_mailboxrpc.pb.go` — Generated mailbox-transport bindings.
+
+## Relationships
+
+- **Depends on**: `google.golang.org/protobuf`.
+- **Depended on by**: `swapclientserver` (uses swap wire types for
+  server-to-client swap negotiation messages).
+
+## Invariants
+
+- All files are generated. Never edit them manually.
+- Regenerate via `make rpc`.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/swapwallet/AGENTS.md
+++ b/swapwallet/AGENTS.md
@@ -1,0 +1,79 @@
+# swapwallet
+
+## Purpose
+
+Daemon-side `WalletService` gRPC subserver (build tags: `walletrpc` +
+`swapruntime`). Composes the swap subsystem, the Ark SDK facade, the
+daemon-managed signer, the cooperative-leave RPC, the wallet actor, and the
+unified ledger history surface into a single swap-vocabulary-free wallet API.
+Callers see Send, Recv, List, Deposit, Balance, Status, and SubscribeWallet
+without ever encountering swap or OOR concepts.
+
+## Key Types
+
+- `Service` — gRPC handler implementing `walletrpc.WalletServiceServer`. Pure
+  wiring: each method delegates to `router`, `recv`, `history`, or `runtime`.
+- `Deps` — Aggregate dependency bag: `RPCServer` (daemon-side RPC handle),
+  `SwapBackend` (swap resume/execution), config fields
+  (`SwapWalletConfig`), logger.
+- `RPCServer` — Interface over `darepod.RPCServer` exposing the specific
+  methods `swapwallet` needs (LeaveVTXOs, CreateBoardingAddress, GetBalance,
+  SignReceiveAuthMessage, ListTransactions, etc.) without importing darepod.
+- `Runtime` — Owns the in-process swap lifecycle: synchronous
+  resume-on-startup sweep, wallet-level deadline watcher (overlays FAILED
+  status on timed-out entries), subscribe fan-out via per-subscriber channels,
+  and pending-entry tracking.
+- `Register(ctx, grpcServer, rpcServer, cfg)` — Entry point called by
+  `darepod` when both build tags are present. Wires deps, starts the runtime,
+  drives the synchronous resume sweep, and registers the `WalletService`
+  handler.
+
+## Relationships
+
+- **Depends on**: `darepod` (RPCServer interface), `rpc/walletrpc` (proto
+  stubs), `swapclientserver` (swap backend via `darepod.SwapBackend`),
+  `sdk/swaps` (swap FSM types), `google.golang.org/grpc`.
+- **Depended on by**: `cmd/darepod` (registers the subserver when both
+  `walletrpc` and `swapruntime` build tags are present), `sdk/walletdk`
+  (consumes via the `WalletServiceClient` gRPC stub).
+- **Sends**:
+  - → `darepod.RPCServer`: LeaveVTXOs, GetBalance, ListTransactions,
+    CreateBoardingAddress, SignReceiveAuthMessage, and other RPCServer methods
+    (in-process calls, not gRPC).
+  - → swap backend: `ResumePending` (once at startup), then per-receive and
+    per-send swap invocations.
+- **Receives**:
+  - ← `cmd/darepod` (via `Register`): daemon startup wiring.
+  - ← API (gRPC): `SendRequest`, `RecvRequest`, `ListRequest`,
+    `DepositRequest`, `BalanceRequest`, `StatusRequest`,
+    `SubscribeWalletRequest`.
+
+## Invariants
+
+- Build tag guard: `walletrpc` implies `swapruntime`; building walletrpc
+  without swapruntime is a deliberate compile error because `swapwallet`
+  depends on the swap executor.
+- The runtime drives a synchronous `ResumePending` sweep before the gRPC
+  server accepts wallet calls, ensuring all prior pending sessions have active
+  workers before the first new call arrives.
+- Background goroutines (deadline watcher, monitor fan-out) are anchored to
+  the daemon root context passed to `Register`, never to RPC-call contexts.
+  A CLI disconnect cannot cancel in-flight swap work.
+- The deadline watcher overlays the wallet-level FAILED status above the swap
+  FSM's own deadline; it never mutates underlying swap state.
+- `SubscribeWallet` delivers entries on per-subscriber buffered channels;
+  a slow consumer that fills its buffer will drop updates and must reconcile
+  via `List` on reconnect.
+- `SuppressResume` on `darepod.SwapConfig` is set by `Register` so
+  `swapclientserver.Register` skips its own resume sweep and lets `swapwallet`
+  own the unified resume lifecycle.
+
+## Deep Docs
+
+- [rpc/walletrpc/CLAUDE.md](../rpc/walletrpc/CLAUDE.md) — Generated proto
+  stubs consumed by this package.
+- [swapclientserver/CLAUDE.md](../swapclientserver/CLAUDE.md) — Swap subserver
+  this package coordinates with for resume and execution.
+- [sdk/walletdk/CLAUDE.md](../sdk/walletdk/CLAUDE.md) — SDK that exposes
+  the wallet API to host applications.
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/swapwallet/CLAUDE.md
+++ b/swapwallet/CLAUDE.md
@@ -1,0 +1,79 @@
+# swapwallet
+
+## Purpose
+
+Daemon-side `WalletService` gRPC subserver (build tags: `walletrpc` +
+`swapruntime`). Composes the swap subsystem, the Ark SDK facade, the
+daemon-managed signer, the cooperative-leave RPC, the wallet actor, and the
+unified ledger history surface into a single swap-vocabulary-free wallet API.
+Callers see Send, Recv, List, Deposit, Balance, Status, and SubscribeWallet
+without ever encountering swap or OOR concepts.
+
+## Key Types
+
+- `Service` — gRPC handler implementing `walletrpc.WalletServiceServer`. Pure
+  wiring: each method delegates to `router`, `recv`, `history`, or `runtime`.
+- `Deps` — Aggregate dependency bag: `RPCServer` (daemon-side RPC handle),
+  `SwapBackend` (swap resume/execution), config fields
+  (`SwapWalletConfig`), logger.
+- `RPCServer` — Interface over `darepod.RPCServer` exposing the specific
+  methods `swapwallet` needs (LeaveVTXOs, CreateBoardingAddress, GetBalance,
+  SignReceiveAuthMessage, ListTransactions, etc.) without importing darepod.
+- `Runtime` — Owns the in-process swap lifecycle: synchronous
+  resume-on-startup sweep, wallet-level deadline watcher (overlays FAILED
+  status on timed-out entries), subscribe fan-out via per-subscriber channels,
+  and pending-entry tracking.
+- `Register(ctx, grpcServer, rpcServer, cfg)` — Entry point called by
+  `darepod` when both build tags are present. Wires deps, starts the runtime,
+  drives the synchronous resume sweep, and registers the `WalletService`
+  handler.
+
+## Relationships
+
+- **Depends on**: `darepod` (RPCServer interface), `rpc/walletrpc` (proto
+  stubs), `swapclientserver` (swap backend via `darepod.SwapBackend`),
+  `sdk/swaps` (swap FSM types), `google.golang.org/grpc`.
+- **Depended on by**: `cmd/darepod` (registers the subserver when both
+  `walletrpc` and `swapruntime` build tags are present), `sdk/walletdk`
+  (consumes via the `WalletServiceClient` gRPC stub).
+- **Sends**:
+  - → `darepod.RPCServer`: LeaveVTXOs, GetBalance, ListTransactions,
+    CreateBoardingAddress, SignReceiveAuthMessage, and other RPCServer methods
+    (in-process calls, not gRPC).
+  - → swap backend: `ResumePending` (once at startup), then per-receive and
+    per-send swap invocations.
+- **Receives**:
+  - ← `cmd/darepod` (via `Register`): daemon startup wiring.
+  - ← API (gRPC): `SendRequest`, `RecvRequest`, `ListRequest`,
+    `DepositRequest`, `BalanceRequest`, `StatusRequest`,
+    `SubscribeWalletRequest`.
+
+## Invariants
+
+- Build tag guard: `walletrpc` implies `swapruntime`; building walletrpc
+  without swapruntime is a deliberate compile error because `swapwallet`
+  depends on the swap executor.
+- The runtime drives a synchronous `ResumePending` sweep before the gRPC
+  server accepts wallet calls, ensuring all prior pending sessions have active
+  workers before the first new call arrives.
+- Background goroutines (deadline watcher, monitor fan-out) are anchored to
+  the daemon root context passed to `Register`, never to RPC-call contexts.
+  A CLI disconnect cannot cancel in-flight swap work.
+- The deadline watcher overlays the wallet-level FAILED status above the swap
+  FSM's own deadline; it never mutates underlying swap state.
+- `SubscribeWallet` delivers entries on per-subscriber buffered channels;
+  a slow consumer that fills its buffer will drop updates and must reconcile
+  via `List` on reconnect.
+- `SuppressResume` on `darepod.SwapConfig` is set by `Register` so
+  `swapclientserver.Register` skips its own resume sweep and lets `swapwallet`
+  own the unified resume lifecycle.
+
+## Deep Docs
+
+- [rpc/walletrpc/CLAUDE.md](../rpc/walletrpc/CLAUDE.md) — Generated proto
+  stubs consumed by this package.
+- [swapclientserver/CLAUDE.md](../swapclientserver/CLAUDE.md) — Swap subserver
+  this package coordinates with for resume and execution.
+- [sdk/walletdk/CLAUDE.md](../sdk/walletdk/CLAUDE.md) — SDK that exposes
+  the wallet API to host applications.
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/txconfirm/AGENTS.md
+++ b/txconfirm/AGENTS.md
@@ -39,12 +39,18 @@ each still receives its own terminal notification.
 - `EstimatePackageFee`, `EstimateWeight`, `SelectFeeInput` — Exported
   helpers for fee estimation and fee-input selection, usable standalone.
 - `Wallet` — Wallet interface the broadcaster requires: `ListUnspent`,
-  `NewWalletPkScript`, `FinalizePsbt`, plus `wallet.OutputLeaser`
+  `NewWalletPkScript`, `FinalizePsbt`, plus `walletcore.OutputLeaser`
   (`LeaseOutput` / `ReleaseOutput`) for cross-subsystem UTXO lock
   coordination.
 - `EnsureConfirmedReq` / `EnsureConfirmedResp` — Public Ask API: register
-  interest in a txid with a `TargetConfs`, `ConfirmationPkScript`, and a
-  subscriber that receives the terminal notification.
+  interest in a txid with a `TargetConfs`, `ConfirmationPkScript`,
+  optional `HeightHint` (earliest safe confirmation height; zero derives
+  from current best height minus a safety margin), and a subscriber that
+  receives the terminal notification.
+- `ServiceKeyName` / `NewServiceKey()` / `LookupRef(system)` — Service
+  discovery helpers. Producer subsystems (unroll registry, wallet boarding
+  sweep actor) use `NewServiceKey()` or `LookupRef` to obtain a broadcaster
+  ref from the actor system without coupling to concrete types.
 - `CancelInterestReq` / `CancelInterestResp` — Public Ask API: drop a
   subscriber; the last subscriber's cancel also tears down tracking.
 - `TxConfirmed` / `TxFailed` — Terminal `Notification` types delivered to
@@ -66,14 +72,16 @@ each still receives its own terminal notification.
   - `baselib/protofsm` — per-txid state machine engine.
   - `chainsource` — confirmation watches, block epochs, broadcast,
     package submission, fee estimation, preflight.
-  - `wallet` — `Utxo`, `OutputLeaser`, `LockID` types for fee-input
-    selection and wallet-level lease coordination.
+  - `walletcore` — `Utxo`, `OutputLeaser`, `LockID` types for fee-input
+    selection and wallet-level lease coordination (avoids import cycle with
+    `wallet`).
   - `lib/tx/arktx` — canonical `TxVersion` (v3/TRUC) constant and
     `IsAnchorOutput` predicate for CPFP targeting.
 - **Depended on by**: `unroll` (plugs `TxBroadcasterActor` and
   `CPFPBroadcaster` into boarding sweep / unilateral exit flows),
-  `btcwbackend` (fee-input selection helper), `darepod` (wiring),
-  `db` (schema references).
+  `wallet` (boarding sweep actor looks up the shared broadcaster via
+  `LookupRef`), `btcwbackend` (fee-input selection helper), `darepod`
+  (wiring), `db` (schema references).
 - **Sends**:
   - → `chainsource` (Ask): `BestHeightRequest`, `SubscribeBlocksRequest`,
     `RegisterConfRequest`, `UnregisterConfRequest`, `BroadcastTxRequest`,
@@ -112,10 +120,17 @@ each still receives its own terminal notification.
   RBF requires the new child to double-spend the previous child's fee
   input.
 - **Wallet-level lease coordination**: every reserved fee UTXO is also
-  leased via `Wallet.LeaseOutput` (caller-scoped `txconfirmLockID`)
-  and released on eviction / fallback. Lease errors are soft — the
+  leased via `Wallet.LeaseOutput` (caller-scoped `txconfirmLockID`, a
+  `walletcore.LockID` derived from `"darepo-client:txconfirm"`) and
+  released on eviction / fallback. Lease errors are soft — the
   in-memory reservation map is the source of truth — but the lease
   closes a narrow cross-subsystem race.
+- **`HeightHint` matters for proof-graph ancestors.** Callers that
+  submit proof nodes (e.g. `unroll`) must pass `HeightHint = 1` (the
+  `proofNodeHeightHint` constant) so chainsource scans from genesis.
+  Proof roots and intermediate OOR checkpoint ancestors can confirm
+  before the target descriptor's `CreatedHeight`, so using the target
+  height as a hint would silently miss already-confirmed nodes.
 - **Child vsize is script-aware**: `estimateChildVSize` uses
   `input.TxWeightEstimator` with the actual fee-input and change
   pkScripts (P2TR, P2WKH, nested-P2WKH, …) to size the CPFP child,

--- a/txconfirm/CLAUDE.md
+++ b/txconfirm/CLAUDE.md
@@ -39,12 +39,18 @@ each still receives its own terminal notification.
 - `EstimatePackageFee`, `EstimateWeight`, `SelectFeeInput` — Exported
   helpers for fee estimation and fee-input selection, usable standalone.
 - `Wallet` — Wallet interface the broadcaster requires: `ListUnspent`,
-  `NewWalletPkScript`, `FinalizePsbt`, plus `wallet.OutputLeaser`
+  `NewWalletPkScript`, `FinalizePsbt`, plus `walletcore.OutputLeaser`
   (`LeaseOutput` / `ReleaseOutput`) for cross-subsystem UTXO lock
   coordination.
 - `EnsureConfirmedReq` / `EnsureConfirmedResp` — Public Ask API: register
-  interest in a txid with a `TargetConfs`, `ConfirmationPkScript`, and a
-  subscriber that receives the terminal notification.
+  interest in a txid with a `TargetConfs`, `ConfirmationPkScript`,
+  optional `HeightHint` (earliest safe confirmation height; zero derives
+  from current best height minus a safety margin), and a subscriber that
+  receives the terminal notification.
+- `ServiceKeyName` / `NewServiceKey()` / `LookupRef(system)` — Service
+  discovery helpers. Producer subsystems (unroll registry, wallet boarding
+  sweep actor) use `NewServiceKey()` or `LookupRef` to obtain a broadcaster
+  ref from the actor system without coupling to concrete types.
 - `CancelInterestReq` / `CancelInterestResp` — Public Ask API: drop a
   subscriber; the last subscriber's cancel also tears down tracking.
 - `TxConfirmed` / `TxFailed` — Terminal `Notification` types delivered to
@@ -66,14 +72,16 @@ each still receives its own terminal notification.
   - `baselib/protofsm` — per-txid state machine engine.
   - `chainsource` — confirmation watches, block epochs, broadcast,
     package submission, fee estimation, preflight.
-  - `wallet` — `Utxo`, `OutputLeaser`, `LockID` types for fee-input
-    selection and wallet-level lease coordination.
+  - `walletcore` — `Utxo`, `OutputLeaser`, `LockID` types for fee-input
+    selection and wallet-level lease coordination (avoids import cycle with
+    `wallet`).
   - `lib/tx/arktx` — canonical `TxVersion` (v3/TRUC) constant and
     `IsAnchorOutput` predicate for CPFP targeting.
 - **Depended on by**: `unroll` (plugs `TxBroadcasterActor` and
   `CPFPBroadcaster` into boarding sweep / unilateral exit flows),
-  `btcwbackend` (fee-input selection helper), `darepod` (wiring),
-  `db` (schema references).
+  `wallet` (boarding sweep actor looks up the shared broadcaster via
+  `LookupRef`), `btcwbackend` (fee-input selection helper), `darepod`
+  (wiring), `db` (schema references).
 - **Sends**:
   - → `chainsource` (Ask): `BestHeightRequest`, `SubscribeBlocksRequest`,
     `RegisterConfRequest`, `UnregisterConfRequest`, `BroadcastTxRequest`,
@@ -112,10 +120,17 @@ each still receives its own terminal notification.
   RBF requires the new child to double-spend the previous child's fee
   input.
 - **Wallet-level lease coordination**: every reserved fee UTXO is also
-  leased via `Wallet.LeaseOutput` (caller-scoped `txconfirmLockID`)
-  and released on eviction / fallback. Lease errors are soft — the
+  leased via `Wallet.LeaseOutput` (caller-scoped `txconfirmLockID`, a
+  `walletcore.LockID` derived from `"darepo-client:txconfirm"`) and
+  released on eviction / fallback. Lease errors are soft — the
   in-memory reservation map is the source of truth — but the lease
   closes a narrow cross-subsystem race.
+- **`HeightHint` matters for proof-graph ancestors.** Callers that
+  submit proof nodes (e.g. `unroll`) must pass `HeightHint = 1` (the
+  `proofNodeHeightHint` constant) so chainsource scans from genesis.
+  Proof roots and intermediate OOR checkpoint ancestors can confirm
+  before the target descriptor's `CreatedHeight`, so using the target
+  height as a hint would silently miss already-confirmed nodes.
 - **Child vsize is script-aware**: `estimateChildVSize` uses
   `input.TxWeightEstimator` with the actual fee-input and change
   pkScripts (P2TR, P2WKH, nested-P2WKH, …) to size the CPFP child,

--- a/unroll/AGENTS.md
+++ b/unroll/AGENTS.md
@@ -17,11 +17,15 @@ control-plane record per target to `db` so restart can restore in-flight jobs.
   planner, and cached sweep transaction for this one VTXO.
 - `Config` — Per-actor wiring: `TargetOutpoint`, `ActorID`, `DeliveryStore`,
   `ProofAssembler`, `VTXOStore`, `TxConfirmRef`, `ChainSource`, `Wallet`
-  (`SweepWallet`), `MaxSweepFeeRateSatPerVByte`, and a `RegistryRef` for
-  terminal notifications.
+  (`SweepWallet`), `MaxSweepFeeRateSatPerVByte`,
+  `FraudCheckpointSafetyMargin` (block backstop for fraud-triggered jobs;
+  zero falls back to `defaultFraudCheckpointSafetyMargin`), and a
+  `RegistryRef` for terminal notifications.
 - `behavior` — Actor behavior. Holds `b.sweepTx` (restored from checkpoint on
-  boot) so retries and replays converge on a single sweep txid / pkScript
-  under `txconfirm`'s txid-keyed dedup.
+  boot) and `b.proofSpendWatches map[wire.OutPoint]struct{}` (active spend
+  watches on proof-graph ancestor outpoints for fraud-triggered deferred
+  checkpoint scenarios) so retries and replays converge on a single sweep
+  txid / pkScript under `txconfirm`'s txid-keyed dedup.
 - `Msg` / `Resp` / `Event` / `OutboxEvent` — Sealed durable-mailbox,
   response, FSM event, and FSM outbox surfaces.
 - `StartUnrollRequest` / `ResumeUnrollRequest` / `HeightObservedMsg` /
@@ -87,6 +91,11 @@ control-plane record per target to `db` so restart can restore in-flight jobs.
 - `safeTxOutPkScript(tx, index)` — Bounds-checking helper used at every
   `tx.TxOut[i].PkScript` site so malformed proof artifacts (operator-sourced
   OOR inputs) surface as retryable errors instead of goroutine panics.
+- `proofNodeHeightHint` — Constant `1` passed as `HeightHint` to
+  `txconfirm.EnsureConfirmedReq` for all proof-graph nodes. Proof roots and
+  intermediate OOR checkpoint ancestors can confirm before the target VTXO's
+  creation height; using the target height would cause `chainsource` to miss
+  already-confirmed nodes silently.
 
 ## Relationships
 

--- a/unroll/CLAUDE.md
+++ b/unroll/CLAUDE.md
@@ -17,11 +17,15 @@ control-plane record per target to `db` so restart can restore in-flight jobs.
   planner, and cached sweep transaction for this one VTXO.
 - `Config` — Per-actor wiring: `TargetOutpoint`, `ActorID`, `DeliveryStore`,
   `ProofAssembler`, `VTXOStore`, `TxConfirmRef`, `ChainSource`, `Wallet`
-  (`SweepWallet`), `MaxSweepFeeRateSatPerVByte`, and a `RegistryRef` for
-  terminal notifications.
+  (`SweepWallet`), `MaxSweepFeeRateSatPerVByte`,
+  `FraudCheckpointSafetyMargin` (block backstop for fraud-triggered jobs;
+  zero falls back to `defaultFraudCheckpointSafetyMargin`), and a
+  `RegistryRef` for terminal notifications.
 - `behavior` — Actor behavior. Holds `b.sweepTx` (restored from checkpoint on
-  boot) so retries and replays converge on a single sweep txid / pkScript
-  under `txconfirm`'s txid-keyed dedup.
+  boot) and `b.proofSpendWatches map[wire.OutPoint]struct{}` (active spend
+  watches on proof-graph ancestor outpoints for fraud-triggered deferred
+  checkpoint scenarios) so retries and replays converge on a single sweep
+  txid / pkScript under `txconfirm`'s txid-keyed dedup.
 - `Msg` / `Resp` / `Event` / `OutboxEvent` — Sealed durable-mailbox,
   response, FSM event, and FSM outbox surfaces.
 - `StartUnrollRequest` / `ResumeUnrollRequest` / `HeightObservedMsg` /
@@ -87,6 +91,11 @@ control-plane record per target to `db` so restart can restore in-flight jobs.
 - `safeTxOutPkScript(tx, index)` — Bounds-checking helper used at every
   `tx.TxOut[i].PkScript` site so malformed proof artifacts (operator-sourced
   OOR inputs) surface as retryable errors instead of goroutine panics.
+- `proofNodeHeightHint` — Constant `1` passed as `HeightHint` to
+  `txconfirm.EnsureConfirmedReq` for all proof-graph nodes. Proof roots and
+  intermediate OOR checkpoint ancestors can confirm before the target VTXO's
+  creation height; using the target height would cause `chainsource` to miss
+  already-confirmed nodes silently.
 
 ## Relationships
 

--- a/vtxo/AGENTS.md
+++ b/vtxo/AGENTS.md
@@ -15,16 +15,27 @@ when the local wallet owns the receive script.
 
 - `VTXOState` — Sealed interface for all states (Live, Spending, Spent, PendingForfeit, Forfeiting, Forfeited, UnilateralExit, Failed).
 - `Descriptor` — Complete VTXO metadata: `Outpoint`, `Amount`, `PkScript`, `OwnerKey` (keychain.KeyDescriptor), `OperatorKey`, `TapScript`, `TreePath`, `RoundID`, `CommitmentTxID`, `BatchExpiry`, `RelativeExpiry`, `TreeDepth`, `ChainDepth` (OOR hop count), `CreatedHeight`, `Status`.
-- `Manager` — Actor managing per-VTXO FSM instances, lifecycle, and admission gating. Configured via `ManagerConfig`.
+- `Manager` — Actor managing per-VTXO FSM instances, lifecycle, and admission
+  gating. Configured via `ManagerConfig`. Maintains a `liveDescriptors`
+  snapshot populated during `Start()` from durable state; the snapshot is
+  returned verbatim by `ListLiveDescriptorsRequest` without a DB round-trip.
 - `ManagerConfig` — Configuration holding Store, Wallet, ChainSource,
   ActorSystem, ChainParams, ExpiryConfig, RoundActor ref, ChainResolver ref,
   optional `Log`, optional `LedgerSink fn.Option[ledger.Sink]`,
-  `ForfeitVTXOActorAskTimeout`, and `RefreshFeeQuoter`. The manager
-  propagates the sink into each spawned `VTXOActor` for `ExitCostMsg`
-  emissions. `ForfeitVTXOActorAskTimeout` (default 5 s) bounds forfeit
-  and refresh child asks so a blocked child actor cannot monopolize the
-  manager until the outer RPC deadline. Zero uses the default; negative
-  disables the timeout. Spend-path asks keep the caller's context.
+  `ForfeitVTXOActorAskTimeout`, `RefreshFeeQuoter`, and optional
+  `TerminalVTXOObserver func(context.Context, wire.OutPoint) error`. The
+  manager propagates the sink into each spawned `VTXOActor` for `ExitCostMsg`
+  emissions. `ForfeitVTXOActorAskTimeout` (default 5 s) bounds forfeit and
+  refresh child asks so a blocked child actor cannot monopolize the manager
+  until the outer RPC deadline. Zero uses the default; negative disables the
+  timeout. Spend-path asks keep the caller's context.
+  `TerminalVTXOObserver` is called when a VTXO leaves the active set so
+  daemon-local subsystems (e.g. the fraud watcher) can clean up related work.
+- `ListLiveDescriptorsRequest` / `ListLiveDescriptorsResponse` — Ask-message
+  pair for retrieving the `[]*Descriptor` snapshot the manager populated from
+  durable state at `Start()`. Used by daemon-local subsystems (notably the
+  fraud watcher) to re-arm per-VTXO state after restart without taking a
+  direct dependency on the VTXO store. The response slice is caller-owned.
 - `VTXOActorConfig.LedgerSink` — Per-VTXO actor field plumbed from the manager. The `emitExitCost` helper is wired onto the unilateral-exit transition but is currently a no-op pending chain resolver integration: the actor cannot determine the on-chain miner fee until the chain resolver reports the confirmed exit-spend transaction. The emission site exists so a single future change in the chain resolver wiring enables it without touching the FSM transition logic.
 - `VTXOEvent` — Inbound events (BlockEpochEvent, ForfeitRequest, ForfeitConfirmed, SpendReserveEvent, SpendCompletedEvent, etc.).
 - `VTXOOutMsg` — Outbound messages (ForfeitRequest, ExpiringNotify, StatusUpdate, Terminated).
@@ -52,6 +63,7 @@ when the local wallet owns the receive script.
 - **Receives**:
   - ← `round`: `ForfeitRequestEvent`, `ForfeitConfirmedEvent`, `ForfeitSignedEvent`, `ForfeitReleasedEvent`, `BlockEpochEvent`, `PendingForfeitEvent`, `SpendReserveEvent`, `SpendReleasedEvent`, `SpendCompletedEvent`, `ResumeVTXOEvent`
   - ← `wallet` (via `lib/actormsg`): `SelectAndReserveSpendRequest`, `ReleaseSpendRequest`, `CompleteSpendRequest`, `ReserveForfeitRequest`, `ReleaseForfeitRequest`, `SelectAndReserveForfeitRequest`
+  - ← `darepod` (via Ask): `ListLiveDescriptorsRequest`
   - ← `chainsource` (via Manager): `BlockEpochEvent`
   - ← `serverconn` (via `EventRouter` route `MethodIncomingVTXO`): `IncomingVTXOMsg` (wrapping `arkrpc.IncomingVTXOEvent`), routed to `IncomingVTXOHandler`
 

--- a/vtxo/CLAUDE.md
+++ b/vtxo/CLAUDE.md
@@ -15,16 +15,27 @@ when the local wallet owns the receive script.
 
 - `VTXOState` — Sealed interface for all states (Live, Spending, Spent, PendingForfeit, Forfeiting, Forfeited, UnilateralExit, Failed).
 - `Descriptor` — Complete VTXO metadata: `Outpoint`, `Amount`, `PkScript`, `OwnerKey` (keychain.KeyDescriptor), `OperatorKey`, `TapScript`, `TreePath`, `RoundID`, `CommitmentTxID`, `BatchExpiry`, `RelativeExpiry`, `TreeDepth`, `ChainDepth` (OOR hop count), `CreatedHeight`, `Status`.
-- `Manager` — Actor managing per-VTXO FSM instances, lifecycle, and admission gating. Configured via `ManagerConfig`.
+- `Manager` — Actor managing per-VTXO FSM instances, lifecycle, and admission
+  gating. Configured via `ManagerConfig`. Maintains a `liveDescriptors`
+  snapshot populated during `Start()` from durable state; the snapshot is
+  returned verbatim by `ListLiveDescriptorsRequest` without a DB round-trip.
 - `ManagerConfig` — Configuration holding Store, Wallet, ChainSource,
   ActorSystem, ChainParams, ExpiryConfig, RoundActor ref, ChainResolver ref,
   optional `Log`, optional `LedgerSink fn.Option[ledger.Sink]`,
-  `ForfeitVTXOActorAskTimeout`, and `RefreshFeeQuoter`. The manager
-  propagates the sink into each spawned `VTXOActor` for `ExitCostMsg`
-  emissions. `ForfeitVTXOActorAskTimeout` (default 5 s) bounds forfeit
-  and refresh child asks so a blocked child actor cannot monopolize the
-  manager until the outer RPC deadline. Zero uses the default; negative
-  disables the timeout. Spend-path asks keep the caller's context.
+  `ForfeitVTXOActorAskTimeout`, `RefreshFeeQuoter`, and optional
+  `TerminalVTXOObserver func(context.Context, wire.OutPoint) error`. The
+  manager propagates the sink into each spawned `VTXOActor` for `ExitCostMsg`
+  emissions. `ForfeitVTXOActorAskTimeout` (default 5 s) bounds forfeit and
+  refresh child asks so a blocked child actor cannot monopolize the manager
+  until the outer RPC deadline. Zero uses the default; negative disables the
+  timeout. Spend-path asks keep the caller's context.
+  `TerminalVTXOObserver` is called when a VTXO leaves the active set so
+  daemon-local subsystems (e.g. the fraud watcher) can clean up related work.
+- `ListLiveDescriptorsRequest` / `ListLiveDescriptorsResponse` — Ask-message
+  pair for retrieving the `[]*Descriptor` snapshot the manager populated from
+  durable state at `Start()`. Used by daemon-local subsystems (notably the
+  fraud watcher) to re-arm per-VTXO state after restart without taking a
+  direct dependency on the VTXO store. The response slice is caller-owned.
 - `VTXOActorConfig.LedgerSink` — Per-VTXO actor field plumbed from the manager. The `emitExitCost` helper is wired onto the unilateral-exit transition but is currently a no-op pending chain resolver integration: the actor cannot determine the on-chain miner fee until the chain resolver reports the confirmed exit-spend transaction. The emission site exists so a single future change in the chain resolver wiring enables it without touching the FSM transition logic.
 - `VTXOEvent` — Inbound events (BlockEpochEvent, ForfeitRequest, ForfeitConfirmed, SpendReserveEvent, SpendCompletedEvent, etc.).
 - `VTXOOutMsg` — Outbound messages (ForfeitRequest, ExpiringNotify, StatusUpdate, Terminated).
@@ -52,6 +63,7 @@ when the local wallet owns the receive script.
 - **Receives**:
   - ← `round`: `ForfeitRequestEvent`, `ForfeitConfirmedEvent`, `ForfeitSignedEvent`, `ForfeitReleasedEvent`, `BlockEpochEvent`, `PendingForfeitEvent`, `SpendReserveEvent`, `SpendReleasedEvent`, `SpendCompletedEvent`, `ResumeVTXOEvent`
   - ← `wallet` (via `lib/actormsg`): `SelectAndReserveSpendRequest`, `ReleaseSpendRequest`, `CompleteSpendRequest`, `ReserveForfeitRequest`, `ReleaseForfeitRequest`, `SelectAndReserveForfeitRequest`
+  - ← `darepod` (via Ask): `ListLiveDescriptorsRequest`
   - ← `chainsource` (via Manager): `BlockEpochEvent`
   - ← `serverconn` (via `EventRouter` route `MethodIncomingVTXO`): `IncomingVTXOMsg` (wrapping `arkrpc.IncomingVTXOEvent`), routed to `IncomingVTXOHandler`
 

--- a/wallet/AGENTS.md
+++ b/wallet/AGENTS.md
@@ -13,8 +13,35 @@ refresh, leave, OOR spend, and directed send flows.
 - `Ark` — Main actor managing boarding addresses, UTXO enumeration, confirmation polling, admission forwarding, and VTXO selection/locking. Holds a `ledgerSink` field (`fn.Option[ledger.Sink]`) used by the `emitUTXOCreated` helper to Tell `UTXOCreatedMsg` to the ledger actor whenever a confirmed wallet UTXO is observed.
 - `NewArk` — Constructor; takes the `ledgerSink` as a **required** argument (`fn.Option[ledger.Sink]`) rather than a setter, so every call site is forced to make an explicit emission choice. Production passes `fn.Some(ledger.NewSink(actorSystem))`; harnesses and unit tests that do not register a ledger actor pass `fn.None[ledger.Sink]()`.
 - `emitUTXOCreated(ctx, utxo, blockHeight, classification)` — Internal helper that null-safely builds a `ledger.UTXOCreatedMsg` from a wallet `Utxo` and Tells it to `ledgerSink`. Negative block heights clamp to `0` rather than wrapping under a direct `uint32` cast; nil `utxo` and `fn.None` sink are silent no-ops.
-- `LockID` — `[32]byte` caller-scoped output lease identifier used to associate leased UTXOs with a specific subsystem (`txconfirmLockID` in `txconfirm`, etc.).
-- `OutputLeaser` — Interface for UTXO output leasing: `LeaseOutput(ctx, outpoint, lockID, expiry)` and `ReleaseOutput(ctx, outpoint, lockID)`. Implemented by all three `BoardingBackend` implementations (`btcwbackend`, `lndbackend`, `lwwallet`) to coordinate cross-subsystem UTXO reservation.
+- `LockID` — Type alias for `walletcore.LockID` (`[32]byte` caller-scoped
+  output lease identifier). The canonical declaration lives in `walletcore`
+  to break the import cycle between `wallet` and `txconfirm`.
+- `OutputLeaser` — Type alias for `walletcore.OutputLeaser`; canonical
+  declaration in `walletcore`. Implemented by all three `BoardingBackend`
+  backends (`btcwbackend`, `lndbackend`, `lwwallet`).
+- `Utxo` — Type alias for `walletcore.Utxo`. Canonical declaration in
+  `walletcore`.
+- `SweepSigner` — Interface providing cryptographic and address operations
+  needed for boarding-timeout sweep transactions. Mirrors
+  `unroll.SweepWallet`'s shape so the per-backend `*UnrollWallet` adapters
+  in `darepod` satisfy both without modification.
+- `SweepBoardingUTXOsRequest` / `SweepBoardingUTXOsResponse` — Ask-request
+  for building and optionally broadcasting a boarding timeout-path aggregate
+  sweep transaction. Business logic (fee guard, input cap, CPFP anchor, fee
+  estimation) previously in `darepod/boarding_sweep.go` now lives in
+  `wallet/boarding_sweep.go`.
+- `ResumeBoardingSweepsRequest` / `ResumeBoardingSweepsResponse` — Ask-request
+  for re-arming chainsource spend watches and re-submitting each persisted
+  pending boarding sweep to `txconfirm`. Driven by `darepod.resumeBoardingSweeps`
+  after both the txconfirm broadcaster and the round-client actor have
+  registered with the receptionist.
+- `ReplayPendingBoardRequest` / `ReplayPendingBoardResponse` — Ask-request
+  for replaying any persisted Board RPC that was issued before the last
+  shutdown. Driven after the round-client actor registers.
+- `BoardingSweepSpendNotification` — Tell-message delivered by chainsource
+  when a monitored boarding sweep input is confirmed spent.
+- `WithBoardingSweep(store, signer, txconfirmRef)` — Functional option that
+  enables the boarding-sweep subsystem on the wallet actor.
 - `BoardingBackend` — Interface for wallet integration (key derivation, taproot import, ListUnspent). `GetTransaction` returns `*TxInfo` (containing tx, block hash, and block height).
 - `TxInfo` — Struct wrapping a confirmed transaction with its block hash and block height. Returned by `BoardingBackend.GetTransaction`.
 - `BoardingStore` — Interface for persisting boarding addresses and intents.
@@ -37,8 +64,13 @@ refresh, leave, OOR spend, and directed send flows.
 
 ## Relationships
 
-- **Depends on**: `baselib/actor` (actor system), `chainsource` (block epoch notifications), `lib/actormsg` (VTXO manager admission types), `ledger` (`Sink` alias for emission + `UTXOCreatedMsg` / `ClassificationDeposit` constants).
-- **Depended on by**: `round` (boarding intents, types: `BoardingAddress`, `SelectedVTXO`), `db` (persistence), `darepod` (wiring).
+- **Depends on**: `baselib/actor` (actor system), `chainsource` (block epoch
+  notifications), `lib/actormsg` (VTXO manager admission types), `ledger`
+  (`Sink` alias for emission + `UTXOCreatedMsg` / `ClassificationDeposit`
+  constants), `walletcore` (`LockID`, `Utxo`, `OutputLeaser` canonical types),
+  `txconfirm` (boarding sweep actor looks up broadcaster via `LookupRef`).
+- **Depended on by**: `round` (boarding intents, types: `BoardingAddress`,
+  `SelectedVTXO`), `db` (persistence), `darepod` (wiring).
 - **Sends**:
   - → `round` (via registered notifier): `BoardingUtxoConfirmedEvent`
   - → `round` (via `lib/actormsg`): `TriggerBoardMsg` (VTXO amounts for
@@ -52,7 +84,13 @@ refresh, leave, OOR spend, and directed send flows.
 - **Receives**:
   - ← `chainsource`: `BlockEpochNotification` (triggers UTXO polling)
   - ← `round`: `RegisterConfirmationNotifierRequest`, `UnregisterConfirmationNotifierRequest`
-  - ← API: `CreateBoardingAddressRequest`, `GetActiveBoardingAddressesRequest`, `GetBoardingBalanceRequest`, `GetConfirmedBoardingIntentsRequest`, `RefreshVTXOsRequest`, `SelectAndLockVTXOsRequest`, `LeaveVTXOsRequest`, `BoardRequest`, `CompleteSpendVTXOsRequest`, `UnlockVTXOsRequest`, `SendVTXOsRequest`
+  - ← API: `CreateBoardingAddressRequest`, `GetActiveBoardingAddressesRequest`,
+    `GetBoardingBalanceRequest`, `GetConfirmedBoardingIntentsRequest`,
+    `RefreshVTXOsRequest`, `SelectAndLockVTXOsRequest`, `LeaveVTXOsRequest`,
+    `BoardRequest`, `CompleteSpendVTXOsRequest`, `UnlockVTXOsRequest`,
+    `SendVTXOsRequest`, `SweepBoardingUTXOsRequest`,
+    `ResumeBoardingSweepsRequest`, `ReplayPendingBoardRequest`
+  - ← `chainsource` (spend notifications): `BoardingSweepSpendNotification`
 
 ## Invariants
 
@@ -65,7 +103,18 @@ refresh, leave, OOR spend, and directed send flows.
 - Local ownership of a round-produced VTXO is no longer tracked with a per-intent `IsOwner` flag. `types.VTXORequest` / `round.VTXOIntent` no longer carry `IsOwner`; at round confirmation time the round FSM asks a `round.OwnedScriptChecker` (backed in production by the OOR owned-receive-scripts store) which pkScripts to persist as local balance. The wallet's only job is to supply the correct `OwnerKey` per intent — local-origin owner keys keep their populated `KeyLocator` so `handleRegisterIntent` registers them via `OwnedScriptRegistrar`, while remote recipients carry a zero `KeyLocator` and are intentionally left unregistered.
 - `handleSendVTXOs` uses a `defer`-based release rather than a `releaseAndFail` helper: any error path (including dry-run) falls through to the deferred release, and the `committed` flag is set only after the round actor accepts the intent. Context is preserved via `context.WithoutCancel` so cleanup is not dropped when the caller disconnects.
 - `handleSendVTXOs` rejects pre-flight any directed send with multiple recipients and exactly-zero change residual under the #270 seal-time fee handshake. The server is the amount authority and absorbs the operator fee out of the designated `IsChange=true` slot; if there is no residual to absorb the fee against, the server has no slack to deduct fees without silently shifting them onto a recipient leg. The wallet refuses the request rather than letting the server pick the loser.
-- `VTXOReader` / `VTXODescriptor` / `SelectedVTXO` break the vtxo → round → wallet import cycle by providing wallet-level types that don't reference `vtxo.Descriptor` directly.
+- `VTXOReader` / `VTXODescriptor` / `SelectedVTXO` break the vtxo → round →
+  wallet import cycle by providing wallet-level types that don't reference
+  `vtxo.Descriptor` directly.
+- `LockID`, `OutputLeaser`, and `Utxo` are type aliases pointing to
+  `walletcore`. Do not declare new `wallet`-specific copies; use `walletcore`
+  directly when the import cycle must be avoided.
+- Boarding sweep logic (fee estimation, fee-guard, CPFP anchor, input cap) now
+  lives in `wallet/boarding_sweep.go` rather than `darepod`. The
+  `darepod.SweepBoardingUTXOs` RPC handler delegates to the wallet actor.
+- `ResumeBoardingSweepsRequest` MUST be driven by `darepod` AFTER the txconfirm
+  broadcaster and round-client actor are registered. Driving from inside
+  `wallet.Ark.Start` would race service-key resolution.
 - Per-subsystem logging via `build.LoggerFromContext` (no global mutable loggers).
 
 ## Deep Docs

--- a/wallet/CLAUDE.md
+++ b/wallet/CLAUDE.md
@@ -13,8 +13,35 @@ refresh, leave, OOR spend, and directed send flows.
 - `Ark` — Main actor managing boarding addresses, UTXO enumeration, confirmation polling, admission forwarding, and VTXO selection/locking. Holds a `ledgerSink` field (`fn.Option[ledger.Sink]`) used by the `emitUTXOCreated` helper to Tell `UTXOCreatedMsg` to the ledger actor whenever a confirmed wallet UTXO is observed.
 - `NewArk` — Constructor; takes the `ledgerSink` as a **required** argument (`fn.Option[ledger.Sink]`) rather than a setter, so every call site is forced to make an explicit emission choice. Production passes `fn.Some(ledger.NewSink(actorSystem))`; harnesses and unit tests that do not register a ledger actor pass `fn.None[ledger.Sink]()`.
 - `emitUTXOCreated(ctx, utxo, blockHeight, classification)` — Internal helper that null-safely builds a `ledger.UTXOCreatedMsg` from a wallet `Utxo` and Tells it to `ledgerSink`. Negative block heights clamp to `0` rather than wrapping under a direct `uint32` cast; nil `utxo` and `fn.None` sink are silent no-ops.
-- `LockID` — `[32]byte` caller-scoped output lease identifier used to associate leased UTXOs with a specific subsystem (`txconfirmLockID` in `txconfirm`, etc.).
-- `OutputLeaser` — Interface for UTXO output leasing: `LeaseOutput(ctx, outpoint, lockID, expiry)` and `ReleaseOutput(ctx, outpoint, lockID)`. Implemented by all three `BoardingBackend` implementations (`btcwbackend`, `lndbackend`, `lwwallet`) to coordinate cross-subsystem UTXO reservation.
+- `LockID` — Type alias for `walletcore.LockID` (`[32]byte` caller-scoped
+  output lease identifier). The canonical declaration lives in `walletcore`
+  to break the import cycle between `wallet` and `txconfirm`.
+- `OutputLeaser` — Type alias for `walletcore.OutputLeaser`; canonical
+  declaration in `walletcore`. Implemented by all three `BoardingBackend`
+  backends (`btcwbackend`, `lndbackend`, `lwwallet`).
+- `Utxo` — Type alias for `walletcore.Utxo`. Canonical declaration in
+  `walletcore`.
+- `SweepSigner` — Interface providing cryptographic and address operations
+  needed for boarding-timeout sweep transactions. Mirrors
+  `unroll.SweepWallet`'s shape so the per-backend `*UnrollWallet` adapters
+  in `darepod` satisfy both without modification.
+- `SweepBoardingUTXOsRequest` / `SweepBoardingUTXOsResponse` — Ask-request
+  for building and optionally broadcasting a boarding timeout-path aggregate
+  sweep transaction. Business logic (fee guard, input cap, CPFP anchor, fee
+  estimation) previously in `darepod/boarding_sweep.go` now lives in
+  `wallet/boarding_sweep.go`.
+- `ResumeBoardingSweepsRequest` / `ResumeBoardingSweepsResponse` — Ask-request
+  for re-arming chainsource spend watches and re-submitting each persisted
+  pending boarding sweep to `txconfirm`. Driven by `darepod.resumeBoardingSweeps`
+  after both the txconfirm broadcaster and the round-client actor have
+  registered with the receptionist.
+- `ReplayPendingBoardRequest` / `ReplayPendingBoardResponse` — Ask-request
+  for replaying any persisted Board RPC that was issued before the last
+  shutdown. Driven after the round-client actor registers.
+- `BoardingSweepSpendNotification` — Tell-message delivered by chainsource
+  when a monitored boarding sweep input is confirmed spent.
+- `WithBoardingSweep(store, signer, txconfirmRef)` — Functional option that
+  enables the boarding-sweep subsystem on the wallet actor.
 - `BoardingBackend` — Interface for wallet integration (key derivation, taproot import, ListUnspent). `GetTransaction` returns `*TxInfo` (containing tx, block hash, and block height).
 - `TxInfo` — Struct wrapping a confirmed transaction with its block hash and block height. Returned by `BoardingBackend.GetTransaction`.
 - `BoardingStore` — Interface for persisting boarding addresses and intents.
@@ -37,8 +64,13 @@ refresh, leave, OOR spend, and directed send flows.
 
 ## Relationships
 
-- **Depends on**: `baselib/actor` (actor system), `chainsource` (block epoch notifications), `lib/actormsg` (VTXO manager admission types), `ledger` (`Sink` alias for emission + `UTXOCreatedMsg` / `ClassificationDeposit` constants).
-- **Depended on by**: `round` (boarding intents, types: `BoardingAddress`, `SelectedVTXO`), `db` (persistence), `darepod` (wiring).
+- **Depends on**: `baselib/actor` (actor system), `chainsource` (block epoch
+  notifications), `lib/actormsg` (VTXO manager admission types), `ledger`
+  (`Sink` alias for emission + `UTXOCreatedMsg` / `ClassificationDeposit`
+  constants), `walletcore` (`LockID`, `Utxo`, `OutputLeaser` canonical types),
+  `txconfirm` (boarding sweep actor looks up broadcaster via `LookupRef`).
+- **Depended on by**: `round` (boarding intents, types: `BoardingAddress`,
+  `SelectedVTXO`), `db` (persistence), `darepod` (wiring).
 - **Sends**:
   - → `round` (via registered notifier): `BoardingUtxoConfirmedEvent`
   - → `round` (via `lib/actormsg`): `TriggerBoardMsg` (VTXO amounts for
@@ -52,7 +84,13 @@ refresh, leave, OOR spend, and directed send flows.
 - **Receives**:
   - ← `chainsource`: `BlockEpochNotification` (triggers UTXO polling)
   - ← `round`: `RegisterConfirmationNotifierRequest`, `UnregisterConfirmationNotifierRequest`
-  - ← API: `CreateBoardingAddressRequest`, `GetActiveBoardingAddressesRequest`, `GetBoardingBalanceRequest`, `GetConfirmedBoardingIntentsRequest`, `RefreshVTXOsRequest`, `SelectAndLockVTXOsRequest`, `LeaveVTXOsRequest`, `BoardRequest`, `CompleteSpendVTXOsRequest`, `UnlockVTXOsRequest`, `SendVTXOsRequest`
+  - ← API: `CreateBoardingAddressRequest`, `GetActiveBoardingAddressesRequest`,
+    `GetBoardingBalanceRequest`, `GetConfirmedBoardingIntentsRequest`,
+    `RefreshVTXOsRequest`, `SelectAndLockVTXOsRequest`, `LeaveVTXOsRequest`,
+    `BoardRequest`, `CompleteSpendVTXOsRequest`, `UnlockVTXOsRequest`,
+    `SendVTXOsRequest`, `SweepBoardingUTXOsRequest`,
+    `ResumeBoardingSweepsRequest`, `ReplayPendingBoardRequest`
+  - ← `chainsource` (spend notifications): `BoardingSweepSpendNotification`
 
 ## Invariants
 
@@ -65,7 +103,18 @@ refresh, leave, OOR spend, and directed send flows.
 - Local ownership of a round-produced VTXO is no longer tracked with a per-intent `IsOwner` flag. `types.VTXORequest` / `round.VTXOIntent` no longer carry `IsOwner`; at round confirmation time the round FSM asks a `round.OwnedScriptChecker` (backed in production by the OOR owned-receive-scripts store) which pkScripts to persist as local balance. The wallet's only job is to supply the correct `OwnerKey` per intent — local-origin owner keys keep their populated `KeyLocator` so `handleRegisterIntent` registers them via `OwnedScriptRegistrar`, while remote recipients carry a zero `KeyLocator` and are intentionally left unregistered.
 - `handleSendVTXOs` uses a `defer`-based release rather than a `releaseAndFail` helper: any error path (including dry-run) falls through to the deferred release, and the `committed` flag is set only after the round actor accepts the intent. Context is preserved via `context.WithoutCancel` so cleanup is not dropped when the caller disconnects.
 - `handleSendVTXOs` rejects pre-flight any directed send with multiple recipients and exactly-zero change residual under the #270 seal-time fee handshake. The server is the amount authority and absorbs the operator fee out of the designated `IsChange=true` slot; if there is no residual to absorb the fee against, the server has no slack to deduct fees without silently shifting them onto a recipient leg. The wallet refuses the request rather than letting the server pick the loser.
-- `VTXOReader` / `VTXODescriptor` / `SelectedVTXO` break the vtxo → round → wallet import cycle by providing wallet-level types that don't reference `vtxo.Descriptor` directly.
+- `VTXOReader` / `VTXODescriptor` / `SelectedVTXO` break the vtxo → round →
+  wallet import cycle by providing wallet-level types that don't reference
+  `vtxo.Descriptor` directly.
+- `LockID`, `OutputLeaser`, and `Utxo` are type aliases pointing to
+  `walletcore`. Do not declare new `wallet`-specific copies; use `walletcore`
+  directly when the import cycle must be avoided.
+- Boarding sweep logic (fee estimation, fee-guard, CPFP anchor, input cap) now
+  lives in `wallet/boarding_sweep.go` rather than `darepod`. The
+  `darepod.SweepBoardingUTXOs` RPC handler delegates to the wallet actor.
+- `ResumeBoardingSweepsRequest` MUST be driven by `darepod` AFTER the txconfirm
+  broadcaster and round-client actor are registered. Driving from inside
+  `wallet.Ark.Start` would race service-key resolution.
 - Per-subsystem logging via `build.LoggerFromContext` (no global mutable loggers).
 
 ## Deep Docs

--- a/walletcore/AGENTS.md
+++ b/walletcore/AGENTS.md
@@ -2,27 +2,58 @@
 
 ## Purpose
 
-Shared btcwallet wrapping used by both lwwallet (Esplora-backed) and btcwbackend
-(neutrino-backed) wallet implementations. Extracts common HD key management,
-signing, address generation, and balance operations that delegate to
-btcwallet.BtcWallet regardless of the underlying chain source.
+Shared btcwallet wrapping and cycle-breaking shared types used by both
+lwwallet (Esplora-backed) and btcwbackend (neutrino-backed) wallet
+implementations. Extracts common HD key management, signing, address
+generation, balance operations, and the canonical `LockID` / `Utxo` /
+`OutputLeaser` types that would otherwise create import cycles between
+`wallet`, `txconfirm`, and backend packages.
 
 ## Key Types
 
-- `Wallet` — Core wallet struct embedding `input.Signer`. Provides key derivation, P2TR address generation, balance queries, and UTXO listing. Also implements `proofkeys.Backend` (via `ProofSigner` method). Chain-specific implementations embed this to satisfy `round.ClientWallet`.
-- `BoardingBackendBase` — Shared boarding functionality: taproot script import under BIP86 scope, imported address tracking for UTXO filtering, and HD key derivation. Chain-specific adapters embed this and add `ListUnspent`, `GetTransaction`, `GetBlock`.
-- `Config` — Base configuration (seed, chain params, recovery window, DB dir, logger) shared by all btcwallet-backed wallet backends.
+- `Wallet` — Core wallet struct embedding `input.Signer`. Provides key
+  derivation, P2TR address generation, balance queries, and UTXO listing.
+  Also implements `proofkeys.Backend` (via `ProofSigner` method).
+  Chain-specific implementations embed this to satisfy `round.ClientWallet`.
+- `BoardingBackendBase` — Shared boarding functionality: taproot script
+  import under BIP86 scope, imported address tracking for UTXO filtering,
+  and HD key derivation. Chain-specific adapters embed this and add
+  `ListUnspent`, `GetTransaction`, `GetBlock`.
+- `Config` — Base configuration (seed, chain params, recovery window, DB
+  dir, logger) shared by all btcwallet-backed wallet backends.
+- `LockID` — `[32]byte` caller-scoped identifier for wallet output leases.
+  Lives here (not in `wallet`) so packages that would otherwise import-cycle
+  with `wallet` (notably `txconfirm`) can reference a single shared type.
+  `wallet.LockID` is a type alias for this.
+- `Utxo` — Simplified unspent output view (Outpoint, PkScript, Amount,
+  Confirmations) used for boarding UTXO detection and fee-input selection.
+  `wallet.Utxo` is a type alias for this.
+- `OutputLeaser` — Interface for UTXO output leasing (`LeaseOutput` /
+  `ReleaseOutput`). Lives here to break the `wallet` ↔ `txconfirm` import
+  cycle. `wallet.OutputLeaser` is a type alias for this.
 
 ## Relationships
 
-- **Depends on**: `build` (context logger extraction), `proofkeys` (implements Backend), `indexer` (SchnorrSigner interface).
-- **Depended on by**: `lwwallet` (embeds Wallet + BoardingBackendBase), `btcwbackend` (embeds Wallet + BoardingBackendBase), `darepod` (proof key backend).
+- **Depends on**: `build` (context logger extraction), `proofkeys` (implements
+  Backend), `indexer` (SchnorrSigner interface).
+- **Depended on by**: `lwwallet` (embeds Wallet + BoardingBackendBase),
+  `btcwbackend` (embeds Wallet + BoardingBackendBase), `darepod` (proof key
+  backend), `txconfirm` (uses `LockID`, `Utxo`, `OutputLeaser` to avoid
+  importing `wallet`), `wallet` (re-exports via type aliases).
 
 ## Invariants
 
-- Taproot scripts must be imported under `KeyScopeBIP0086` (not the custom chain key scope), because btcwallet's block processing skips credit tracking for non-default scopes (`chainntfns.go:IsDefaultScope` check).
-- `ImportedAddrs` is in-memory only; repopulated on restart from the database by the wallet actor's `handleStartupRecovery`.
-- `WalletPassphrase` is shared across all wallet backends for both `PrivatePass` and `PublicPass`.
+- Taproot scripts must be imported under `KeyScopeBIP0086` (not the custom
+  chain key scope), because btcwallet's block processing skips credit
+  tracking for non-default scopes (`chainntfns.go:IsDefaultScope` check).
+- `ImportedAddrs` is in-memory only; repopulated on restart from the database
+  by the wallet actor's `handleStartupRecovery`.
+- `WalletPassphrase` is shared across all wallet backends for both
+  `PrivatePass` and `PublicPass`.
+- `LockID`, `Utxo`, and `OutputLeaser` are the **canonical** declarations;
+  `wallet.LockID`, `wallet.Utxo`, and `wallet.OutputLeaser` are type aliases
+  pointing here. Code that would cycle through `wallet` must import
+  `walletcore` directly.
 
 ## Deep Docs
 

--- a/walletcore/CLAUDE.md
+++ b/walletcore/CLAUDE.md
@@ -2,27 +2,58 @@
 
 ## Purpose
 
-Shared btcwallet wrapping used by both lwwallet (Esplora-backed) and btcwbackend
-(neutrino-backed) wallet implementations. Extracts common HD key management,
-signing, address generation, and balance operations that delegate to
-btcwallet.BtcWallet regardless of the underlying chain source.
+Shared btcwallet wrapping and cycle-breaking shared types used by both
+lwwallet (Esplora-backed) and btcwbackend (neutrino-backed) wallet
+implementations. Extracts common HD key management, signing, address
+generation, balance operations, and the canonical `LockID` / `Utxo` /
+`OutputLeaser` types that would otherwise create import cycles between
+`wallet`, `txconfirm`, and backend packages.
 
 ## Key Types
 
-- `Wallet` — Core wallet struct embedding `input.Signer`. Provides key derivation, P2TR address generation, balance queries, and UTXO listing. Also implements `proofkeys.Backend` (via `ProofSigner` method). Chain-specific implementations embed this to satisfy `round.ClientWallet`.
-- `BoardingBackendBase` — Shared boarding functionality: taproot script import under BIP86 scope, imported address tracking for UTXO filtering, and HD key derivation. Chain-specific adapters embed this and add `ListUnspent`, `GetTransaction`, `GetBlock`.
-- `Config` — Base configuration (seed, chain params, recovery window, DB dir, logger) shared by all btcwallet-backed wallet backends.
+- `Wallet` — Core wallet struct embedding `input.Signer`. Provides key
+  derivation, P2TR address generation, balance queries, and UTXO listing.
+  Also implements `proofkeys.Backend` (via `ProofSigner` method).
+  Chain-specific implementations embed this to satisfy `round.ClientWallet`.
+- `BoardingBackendBase` — Shared boarding functionality: taproot script
+  import under BIP86 scope, imported address tracking for UTXO filtering,
+  and HD key derivation. Chain-specific adapters embed this and add
+  `ListUnspent`, `GetTransaction`, `GetBlock`.
+- `Config` — Base configuration (seed, chain params, recovery window, DB
+  dir, logger) shared by all btcwallet-backed wallet backends.
+- `LockID` — `[32]byte` caller-scoped identifier for wallet output leases.
+  Lives here (not in `wallet`) so packages that would otherwise import-cycle
+  with `wallet` (notably `txconfirm`) can reference a single shared type.
+  `wallet.LockID` is a type alias for this.
+- `Utxo` — Simplified unspent output view (Outpoint, PkScript, Amount,
+  Confirmations) used for boarding UTXO detection and fee-input selection.
+  `wallet.Utxo` is a type alias for this.
+- `OutputLeaser` — Interface for UTXO output leasing (`LeaseOutput` /
+  `ReleaseOutput`). Lives here to break the `wallet` ↔ `txconfirm` import
+  cycle. `wallet.OutputLeaser` is a type alias for this.
 
 ## Relationships
 
-- **Depends on**: `build` (context logger extraction), `proofkeys` (implements Backend), `indexer` (SchnorrSigner interface).
-- **Depended on by**: `lwwallet` (embeds Wallet + BoardingBackendBase), `btcwbackend` (embeds Wallet + BoardingBackendBase), `darepod` (proof key backend).
+- **Depends on**: `build` (context logger extraction), `proofkeys` (implements
+  Backend), `indexer` (SchnorrSigner interface).
+- **Depended on by**: `lwwallet` (embeds Wallet + BoardingBackendBase),
+  `btcwbackend` (embeds Wallet + BoardingBackendBase), `darepod` (proof key
+  backend), `txconfirm` (uses `LockID`, `Utxo`, `OutputLeaser` to avoid
+  importing `wallet`), `wallet` (re-exports via type aliases).
 
 ## Invariants
 
-- Taproot scripts must be imported under `KeyScopeBIP0086` (not the custom chain key scope), because btcwallet's block processing skips credit tracking for non-default scopes (`chainntfns.go:IsDefaultScope` check).
-- `ImportedAddrs` is in-memory only; repopulated on restart from the database by the wallet actor's `handleStartupRecovery`.
-- `WalletPassphrase` is shared across all wallet backends for both `PrivatePass` and `PublicPass`.
+- Taproot scripts must be imported under `KeyScopeBIP0086` (not the custom
+  chain key scope), because btcwallet's block processing skips credit
+  tracking for non-default scopes (`chainntfns.go:IsDefaultScope` check).
+- `ImportedAddrs` is in-memory only; repopulated on restart from the database
+  by the wallet actor's `handleStartupRecovery`.
+- `WalletPassphrase` is shared across all wallet backends for both
+  `PrivatePass` and `PublicPass`.
+- `LockID`, `Utxo`, and `OutputLeaser` are the **canonical** declarations;
+  `wallet.LockID`, `wallet.Utxo`, and `wallet.OutputLeaser` are type aliases
+  pointing here. Code that would cycle through `wallet` must import
+  `walletcore` directly.
 
 ## Deep Docs
 


### PR DESCRIPTION
Automated nightly doc-gardening sweep for 2026-05-16.

## Summary

- Created CLAUDE.md / AGENTS.md for **15 new packages**: `fraud`, `swapwallet`, `internal/indexerlimits`, `rpc/walletrpc`, `rpc/swapclientrpc`, `rpc/oorpb`, `mailbox/pb`, `swaprpc`, `db/sqlc`, `db/actordelivery/sqlc`, `sdk/swaps/sqlc`, `serverconn/hellotestpb`, `scripts/check-sample-darepod-conf`, `cmd/darepocli/darepoclicommands/devrpc`, `cmd/darepocli/internal/gen-devrpc`.
- Updated CLAUDE.md / AGENTS.md for **26 stale packages** whose Go sources changed since the 2026-05-12 sweep.
- Updated `ARCHITECTURE.md` to list `fraud`, `swapwallet`, `internal/indexerlimits`, and `rpc/walletrpc`.
- `make doc-check` passes cleanly.

## Review notes

Please review the updated `CLAUDE.md` / `AGENTS.md` diffs for accuracy, and check that the `ARCHITECTURE.md` layer tables reflect the new packages correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
