### PR TITLE
docs: nightly doc-gardening sweep 2026-05-17

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -27,6 +27,7 @@ package may import from a higher layer.
 | [`lib/tx/psbtutil`](lib/tx/psbtutil/) | PSBT encoding, decoding, and signature attachment helpers |
 | [`lib/recovery`](lib/recovery/) | Immutable recovery proof graph, session state machine, TLV codec for unilateral exit |
 | [`unrollplan`](unrollplan/) | Pure dependency-resolution planner driving unilateral-exit broadcast/sweep ordering |
+| [`fraud`](fraud/) | Recipient-side OOR ancestry fraud detector; watches ancestor outpoints and triggers durable unroll on materialization |
 
 ### Layer 2: Infrastructure (Chain, Storage, Messaging)
 
@@ -74,6 +75,7 @@ package may import from a higher layer.
 | [`harness`](harness/) | Docker-based Bitcoin/LND integration test environment |
 | [`systest`](systest/) | System-level end-to-end tests |
 | [`internal/actortest`](internal/actortest/) | Durable actor integration tests with real DB backends |
+| [`internal/indexerlimits`](internal/indexerlimits/) | Shared client-side bounds for indexer pagination cursors |
 | [`internal/testutils`](internal/testutils/) | Deterministic key/signature generation for tests |
 | [`rules`](rules/) | ast-grep linting rules for code style enforcement |
 | [`tools`](tools/) | Development tool dependencies (protoc plugins, sqlc) |

--- a/baselib/actor/AGENTS.md
+++ b/baselib/actor/AGENTS.md
@@ -38,6 +38,20 @@ crash-safe at-least-once delivery with exactly-once deduplication.
 - `ChannelMailbox[M, R]` — In-memory channel-based mailbox (non-durable, for lightweight actors).
 - `Mailbox[M, R]` — Interface for actor message queues: `Send(ctx, env) error` (blocking, returns `ErrMailboxClosed` or `ErrActorTerminated` on failure), `TrySend(env) error` (non-blocking), `Receive(ctx) iter.Seq[envelope]`, `Close()`, `IsClosed() bool`, `Drain() iter.Seq[envelope]`. `Send` previously returned `bool`; it now propagates the exact failure cause so callers can distinguish `ErrMailboxClosed`, `ErrActorTerminated`, and `context.Canceled`/`context.DeadlineExceeded` without inspecting actor state.
 - `isExpectedShutdownErr(err) bool` — Internal helper that classifies errors as expected during teardown: context cancellation/deadline, closed DB handle ("sql: database is closed", "sql: connection is already closed", "use of closed network connection"). Used by the lease loop to demote shutdown-path failures to debug instead of warn-flooding test artifacts at itest tail.
+- `Message.CorrelationKey() string` — Per-message FIFO key consumed by the
+  durable mailbox's claim path. Non-empty keys participate in per-key FIFO:
+  a message is claim-eligible only when no earlier same-key message
+  (compared by UUIDv7 `id`) exists in the same mailbox, even if the
+  earlier message is in retry backoff. Empty (the default on
+  `BaseMessage`) means the message is unkeyed and uses the existing
+  global `available_at` claim order. The override site is the concrete
+  message struct (e.g. `clientconn.ClientMessage` types in `rounds`),
+  not the framework — the framework just plumbs the value through
+  `EnqueueParams.CorrelationKey`.
+- `EnqueueParams.CorrelationKey` — Per-enqueue override stamped into the
+  `mailbox_messages.correlation_key` column. Populated automatically from
+  `msg.CorrelationKey()` by `DurableMailbox.Send`. A zero (empty) value
+  preserves the legacy unkeyed claim semantics.
 
 ## Relationships
 
@@ -54,6 +68,20 @@ crash-safe at-least-once delivery with exactly-once deduplication.
 - Transaction context (`WithTx`/`RequireTx`) enables same-DB-transaction joining between actors and their callers.
 - `Mailbox.Send` returns the exact failure error (`ErrMailboxClosed`, `ErrActorTerminated`, `context.Canceled`, `context.DeadlineExceeded`) rather than a boolean; `Tell` and `Ask` propagate this directly to callers.
 - During daemon teardown, the underlying DB is closed before every actor's lease loop has wound down. The lease loop uses `isExpectedShutdownErr` to demote these "database is closed" errors to debug level; real operational errors still surface as warnings because neither the actor context nor the outer context is done in those cases.
+- **Per-correlation-key FIFO claim.** Two messages in the same mailbox that
+  share a non-empty `CorrelationKey()` are processed in emission order
+  regardless of retry backoff. Without this invariant, a transient Tell
+  failure on msg1 would Nack-with-backoff (push `available_at` into the
+  future), and a later-enqueued msg2 with a smaller `available_at` would
+  overtake msg1 in the `LeaseNextMailboxMessage` claim. The fix is an
+  anti-join on `mailbox_messages.id` (UUIDv7, strictly orderable at
+  millisecond granularity) so the head of each correlation key drains
+  before any later same-key row is claim-eligible. Unkeyed messages
+  (empty `CorrelationKey()`) keep the legacy global `available_at`
+  order and do not interfere with keyed lanes. Head-of-line blocking
+  is bounded to the correlation key, not the mailbox; consumers are
+  already strictly serial per mailbox so this does not regress
+  throughput.
 
 ## Deep Docs
 

--- a/db/actordelivery/migrations/AGENTS.md
+++ b/db/actordelivery/migrations/AGENTS.md
@@ -13,8 +13,10 @@ generic `db/migrate` orchestration layer.
   `"actor_delivery_schema_migrations"`), `DatabaseName` (default
   `"actor_delivery"`), `LatestVersion` (downgrade guard, default
   `LatestMigrationVersion`), optional `Log btclog.Logger`.
-- `LatestMigrationVersion = 1` — Current schema version; bump when adding a
-  new SQL migration file.
+- `LatestMigrationVersion = 2` — Current schema version; bump when adding a
+  new SQL migration file. Version 2 adds the nullable `correlation_key`
+  column on `mailbox_messages` and the filtered composite index that backs
+  the per-correlation-key FIFO anti-join in `LeaseNextMailboxMessage`.
 - `RunMigrations(db, backend, cfg)` — Applies actor-delivery migrations.
   Validates inputs, applies `Config` defaults, delegates to
   `dbmigrate.RunMigrations` with postgres schema token replacements.

--- a/fraud/AGENTS.md
+++ b/fraud/AGENTS.md
@@ -1,0 +1,83 @@
+# fraud
+
+## Purpose
+
+Recipient-side OOR ancestry fraud detector. Monitors the on-chain spend of
+every ancestor outpoint in the commitment tree for locally-owned OOR VTXOs and
+triggers a durable unroll job via `unroll.EnsureUnroll(..., TriggerFraudSpend)`
+when any watched ancestor is spent — indicating an operator is materializing the
+commitment tree without the client's participation.
+
+## Key Types
+
+- `WatcherActor` — Main actor. Maintains a reference-counted map of ancestor
+  outpoints → target VTXO set. Registers spend watches with `chainsource` on
+  the first reference for each outpoint, and unregisters them when the ref
+  count drops to zero. Implements `actor.ActorBehavior[Msg, Resp]`.
+- `WatcherConfig` — Wiring: `ChainSource` ref for spend watch registration,
+  `UnrollRef` for `EnsureUnrollRequest` dispatch, optional `Log`, and
+  `MailboxSize` (default 64, sized for chain reorg bursts).
+- `WatchPlan` — Passive watch set for one locally-owned OOR VTXO: the target
+  outpoint plus the list of `WatchPoint`s derived from its ancestry tree.
+- `WatchPoint` — One ancestor outpoint to watch: `Outpoint`, `PkScript`, and
+  `HeightHint`.
+- `BuildWatchPlan(desc *vtxo.Descriptor) (*WatchPlan, error)` — Derives the
+  watch plan from a VTXO descriptor's `Ancestry` field. Traverses every tree
+  path and collects all on-path tree inputs (detect materialization start) and
+  leaf outputs (detect first OOR checkpoint spending the source VTXO).
+- `Msg` / `Resp` — Sealed actor message and response surfaces.
+- `TrackVTXOsRequest` / `TrackVTXOsResp` — Batch-admit descriptors for fraud
+  watching. Per-descriptor failures are aggregated (not short-circuiting) so
+  one bad descriptor cannot disarm watches for the rest.
+- `UntrackRequest` / `UntrackResp` — Release watches for a single target VTXO.
+  Idempotent: missing targets return success.
+- `SpendObservedMsg` / `AckResp` — Internal notification from `chainsource`
+  spend watch; fans out to `EnsureUnroll` per affected target.
+- `ServiceKey()` — Returns the typed actor service key (`"recipient-fraud-watcher"`).
+- `TrackVTXOs(ctx, ref, descs)` — Convenience wrapper: Tells a batch
+  `TrackVTXOsRequest` to the watcher actor.
+
+## Relationships
+
+- **Depends on**: `baselib/actor` (actor runtime), `chainsource` (spend watch
+  registration via `RegisterSpendRequest` / `UnregisterSpendRequest`),
+  `unroll` (fraud-triggered unroll via `EnsureUnrollRequest`), `vtxo`
+  (`Descriptor`, ancestry tree), `lib/tree` (tree node traversal).
+- **Depended on by**: `darepod` (wires the fraud watcher at startup; calls
+  `TrackVTXOs` after the VTXO manager populates live descriptors).
+- **Sends**:
+  - → `chainsource` (Ask): `RegisterSpendRequest` on first reference for each
+    ancestor outpoint; `UnregisterSpendRequest` on last release.
+  - → `unroll` (Ask): `EnsureUnrollRequest{Trigger: TriggerFraudSpend}` for
+    each affected target when a watched ancestor is spent.
+- **Receives**:
+  - ← API / `darepod`: `TrackVTXOsRequest`, `UntrackRequest`
+  - ← `chainsource` (via mapped spend notification): `SpendObservedMsg`
+
+## Invariants
+
+- Watches are reference-counted per outpoint across multiple target VTXOs that
+  share ancestry. `chainsource` registration happens exactly on the first
+  reference; deregistration happens exactly when the last reference drops.
+- If watch registration fails mid-plan, already-registered watches are rolled
+  back so no half-armed target is admitted.
+- If per-watch release fails on `Untrack`, the target is already removed from
+  the tracked set. Remaining watches are released best-effort; the aggregated
+  error is returned but the target will never be re-tracked via a normal
+  `Untrack` call.
+- `OnStop` releases all active watches. Failures are aggregated, not
+  short-circuited, so a single failed deregistration cannot strand the rest.
+- `SpendObservedMsg` fans out to all targets that share the spent ancestor. A
+  failure for one target does not block unroll for the others.
+- The actor mailbox is sized at 64 by default to absorb a burst of spend
+  notifications during a chain reorg without blocking the `chainsource`
+  publisher.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.
+- [docs/durable_actor_architecture.md](../docs/durable_actor_architecture.md) —
+  Actor and durable mailbox internals.
+- [unroll/CLAUDE.md](../unroll/CLAUDE.md) — Durable unroll subsystem;
+  `TriggerFraudSpend` is the trigger kind for fraud-induced exits.
+- [vtxo/CLAUDE.md](../vtxo/CLAUDE.md) — VTXO descriptor and ancestry shape.

--- a/fraud/CLAUDE.md
+++ b/fraud/CLAUDE.md
@@ -1,0 +1,83 @@
+# fraud
+
+## Purpose
+
+Recipient-side OOR ancestry fraud detector. Monitors the on-chain spend of
+every ancestor outpoint in the commitment tree for locally-owned OOR VTXOs and
+triggers a durable unroll job via `unroll.EnsureUnroll(..., TriggerFraudSpend)`
+when any watched ancestor is spent — indicating an operator is materializing the
+commitment tree without the client's participation.
+
+## Key Types
+
+- `WatcherActor` — Main actor. Maintains a reference-counted map of ancestor
+  outpoints → target VTXO set. Registers spend watches with `chainsource` on
+  the first reference for each outpoint, and unregisters them when the ref
+  count drops to zero. Implements `actor.ActorBehavior[Msg, Resp]`.
+- `WatcherConfig` — Wiring: `ChainSource` ref for spend watch registration,
+  `UnrollRef` for `EnsureUnrollRequest` dispatch, optional `Log`, and
+  `MailboxSize` (default 64, sized for chain reorg bursts).
+- `WatchPlan` — Passive watch set for one locally-owned OOR VTXO: the target
+  outpoint plus the list of `WatchPoint`s derived from its ancestry tree.
+- `WatchPoint` — One ancestor outpoint to watch: `Outpoint`, `PkScript`, and
+  `HeightHint`.
+- `BuildWatchPlan(desc *vtxo.Descriptor) (*WatchPlan, error)` — Derives the
+  watch plan from a VTXO descriptor's `Ancestry` field. Traverses every tree
+  path and collects all on-path tree inputs (detect materialization start) and
+  leaf outputs (detect first OOR checkpoint spending the source VTXO).
+- `Msg` / `Resp` — Sealed actor message and response surfaces.
+- `TrackVTXOsRequest` / `TrackVTXOsResp` — Batch-admit descriptors for fraud
+  watching. Per-descriptor failures are aggregated (not short-circuiting) so
+  one bad descriptor cannot disarm watches for the rest.
+- `UntrackRequest` / `UntrackResp` — Release watches for a single target VTXO.
+  Idempotent: missing targets return success.
+- `SpendObservedMsg` / `AckResp` — Internal notification from `chainsource`
+  spend watch; fans out to `EnsureUnroll` per affected target.
+- `ServiceKey()` — Returns the typed actor service key (`"recipient-fraud-watcher"`).
+- `TrackVTXOs(ctx, ref, descs)` — Convenience wrapper: Tells a batch
+  `TrackVTXOsRequest` to the watcher actor.
+
+## Relationships
+
+- **Depends on**: `baselib/actor` (actor runtime), `chainsource` (spend watch
+  registration via `RegisterSpendRequest` / `UnregisterSpendRequest`),
+  `unroll` (fraud-triggered unroll via `EnsureUnrollRequest`), `vtxo`
+  (`Descriptor`, ancestry tree), `lib/tree` (tree node traversal).
+- **Depended on by**: `darepod` (wires the fraud watcher at startup; calls
+  `TrackVTXOs` after the VTXO manager populates live descriptors).
+- **Sends**:
+  - → `chainsource` (Ask): `RegisterSpendRequest` on first reference for each
+    ancestor outpoint; `UnregisterSpendRequest` on last release.
+  - → `unroll` (Ask): `EnsureUnrollRequest{Trigger: TriggerFraudSpend}` for
+    each affected target when a watched ancestor is spent.
+- **Receives**:
+  - ← API / `darepod`: `TrackVTXOsRequest`, `UntrackRequest`
+  - ← `chainsource` (via mapped spend notification): `SpendObservedMsg`
+
+## Invariants
+
+- Watches are reference-counted per outpoint across multiple target VTXOs that
+  share ancestry. `chainsource` registration happens exactly on the first
+  reference; deregistration happens exactly when the last reference drops.
+- If watch registration fails mid-plan, already-registered watches are rolled
+  back so no half-armed target is admitted.
+- If per-watch release fails on `Untrack`, the target is already removed from
+  the tracked set. Remaining watches are released best-effort; the aggregated
+  error is returned but the target will never be re-tracked via a normal
+  `Untrack` call.
+- `OnStop` releases all active watches. Failures are aggregated, not
+  short-circuited, so a single failed deregistration cannot strand the rest.
+- `SpendObservedMsg` fans out to all targets that share the spent ancestor. A
+  failure for one target does not block unroll for the others.
+- The actor mailbox is sized at 64 by default to absorb a burst of spend
+  notifications during a chain reorg without blocking the `chainsource`
+  publisher.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.
+- [docs/durable_actor_architecture.md](../docs/durable_actor_architecture.md) —
+  Actor and durable mailbox internals.
+- [unroll/CLAUDE.md](../unroll/CLAUDE.md) — Durable unroll subsystem;
+  `TriggerFraudSpend` is the trigger kind for fraud-induced exits.
+- [vtxo/CLAUDE.md](../vtxo/CLAUDE.md) — VTXO descriptor and ancestry shape.

--- a/internal/indexerlimits/AGENTS.md
+++ b/internal/indexerlimits/AGENTS.md
@@ -1,0 +1,27 @@
+# internal/indexerlimits
+
+## Purpose
+
+Shared client-side bounds for indexer pagination cursors. Prevents untrusted
+remote bytes from growing unboundedly when passed through client pagination
+logic.
+
+## Key Types
+
+- `MaxVTXOsByScriptsCursorBytes` — Constant (256 bytes) capping the opaque
+  cursor accepted for `ListVTXOsByScripts` pagination. The current server
+  cursor is a 36-byte outpoint keyset; the cap leaves room for format
+  evolution while bounding untrusted remote bytes.
+- `ValidateVTXOsByScriptsCursor(cursor []byte) error` — Rejects cursors that
+  exceed `MaxVTXOsByScriptsCursorBytes`.
+
+## Relationships
+
+- **Depends on**: nothing (stdlib only).
+- **Depended on by**: `serverconn` (validates `AfterCursor` on
+  `SendListVTXOsByScriptsRequest` before enqueueing the durable query).
+
+## Deep Docs
+
+- [internal/CLAUDE.md](../CLAUDE.md) — Parent package overview.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/internal/indexerlimits/CLAUDE.md
+++ b/internal/indexerlimits/CLAUDE.md
@@ -1,0 +1,27 @@
+# internal/indexerlimits
+
+## Purpose
+
+Shared client-side bounds for indexer pagination cursors. Prevents untrusted
+remote bytes from growing unboundedly when passed through client pagination
+logic.
+
+## Key Types
+
+- `MaxVTXOsByScriptsCursorBytes` — Constant (256 bytes) capping the opaque
+  cursor accepted for `ListVTXOsByScripts` pagination. The current server
+  cursor is a 36-byte outpoint keyset; the cap leaves room for format
+  evolution while bounding untrusted remote bytes.
+- `ValidateVTXOsByScriptsCursor(cursor []byte) error` — Rejects cursors that
+  exceed `MaxVTXOsByScriptsCursorBytes`.
+
+## Relationships
+
+- **Depends on**: nothing (stdlib only).
+- **Depended on by**: `serverconn` (validates `AfterCursor` on
+  `SendListVTXOsByScriptsRequest` before enqueueing the durable query).
+
+## Deep Docs
+
+- [internal/CLAUDE.md](../CLAUDE.md) — Parent package overview.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/ledger/AGENTS.md
+++ b/ledger/AGENTS.md
@@ -7,7 +7,8 @@ receipts/sends, wallet UTXO deposits, exit costs) as double-entry ledger
 entries and UTXO audit log records. Provides a crash-safe financial audit
 trail for tax reporting and fee transparency. Ledger event types:
 `wallet_utxo_created` (wallet UTXO deposit), `boarding_fee_paid`,
-`refresh_fee_paid`, `onchain_fee_paid`, `vtxo_received`, `vtxo_sent`.
+`refresh_fee_paid`, `onchain_fee_paid`, `boarding_sweep_fee_paid`,
+`vtxo_received`, `vtxo_sent`.
 
 ## Chart of Accounts
 
@@ -45,12 +46,35 @@ accounts, see [docs/fee_ledger.md](../docs/fee_ledger.md).
 - `UTXOAuditStore` — Interface for DB persistence of UTXO audit log entries (implemented by `db.UTXOAuditStoreDB`).
 - `UTXOAuditEntry` — Domain-level UTXO audit record (outpoint, amount, event, block height, classification).
 - `LedgerMsg` / `LedgerResp` — Message and response type constraints for the durable mailbox.
-- `FeePaidMsg` — Records boarding/refresh fee payments.
+- `FeePaidMsg` — Records fee payments. Two flavors:
+  - `FeeTypeBoarding` / `FeeTypeRefresh`: Ark protocol fees paid to the
+    operator during a round. Keyed by `RoundID`; booked as
+    `fees_paid += AmountSat / vtxo_balance -= AmountSat`.
+  - `FeeTypeOnchainSweep`: L1 miner fee paid by a boarding-timeout sweep.
+    Keyed by sweep txid via `IdempotencyKey []byte` (the sweep txid bytes);
+    booked as `onchain_fees += AmountSat / wallet_balance -= AmountSat`.
+    Has no paired `VTXOReceivedMsg`. Emitted by the boarding sweep actor at
+    confirmation time.
+  New field: `IdempotencyKey []byte` (TLV type 9) for dedup on events that
+  carry neither a `RoundID` nor a `SessionID`.
 - `VTXOReceivedMsg` — Records incoming VTXOs. `Source` must be one of `SourceRoundBoarding` (client's own on-chain wallet funds boarded into a round; offsets wallet_balance), `SourceRoundRefresh` (refresh output or directed-send self-change; offsets transfers_out so the paired VTXOSent cancels on that account and only the operator fee moves vtxo_balance), `SourceRoundTransfer` (in-round receive from another participant; offsets transfers_in), or `SourceOOR` (out-of-round receive; offsets transfers_in). Any other value is rejected.
 - `VTXOSentMsg` — Records outgoing VTXO transfers. Carries either `SessionID` (32-byte OOR) or `RoundID` (16-byte in-round) — exactly one must be non-zero; both-zero and both-set inputs are rejected. Also carries an optional `Outpoint wire.OutPoint` so in-round multi-VTXO events (e.g. paired refresh emissions) disambiguate per-VTXO via an outpoint-derived `IdempotencyKey` instead of collapsing on `idx_client_ledger_idempotent_round`.
 - `ExitCostMsg` — Records a unilateral exit as two ledger entries: a send leg (`transfers_out` debit, `vtxo_balance` credit) for the net-of-fee value and a fee leg (`onchain_fees` debit, `vtxo_balance` credit) for the miner fee. Together the credits reduce `vtxo_balance` by the gross exited amount. Wallet-side movement is covered separately by the `wallet_utxo_log` audit trail.
 - `UTXOCreatedMsg` — Records new wallet UTXO confirmations with classification. `handleUTXOCreated` writes TWO rows per event: a `wallet_utxo_log` audit row and a double-entry ledger row (`debit wallet_balance, credit opening_balance`, `event_type = wallet_utxo_created`) stamped with an outpoint-derived idempotency key via `walletUTXOIdempotencyKey`. The deposit leg is what gives `wallet_balance` a non-negative balance in the presence of `SourceRoundBoarding` outflows.
 - `UTXOSpentMsg` — Records wallet UTXO spends with classification. Currently only writes the `wallet_utxo_log` audit row (double-entry leg for non-boarding wallet spends is a planned follow-up).
+
+## Constants
+
+New constants added for boarding-sweep flows:
+- `EventBoardingSweepFeePaid = "boarding_sweep_fee_paid"` — Event type for the
+  miner fee paid by a boarding-timeout sweep transaction.
+- `FeeTypeOnchainSweep = "onchain_sweep"` — Fee type value for `FeePaidMsg`
+  when recording a boarding sweep's L1 miner fee. Booked as
+  `onchain_fees += AmountSat / wallet_balance -= AmountSat`.
+- `ClassificationBoardingSweepInput = "boarding_sweep_input"` — UTXO
+  classification for boarding outputs swept by the boarding-sweep actor.
+- `ClassificationBoardingSweepReturn = "boarding_sweep_return"` — UTXO
+  classification for the change/return output of a boarding sweep.
 
 ## Relationships
 
@@ -109,6 +133,12 @@ pairs of messages:
 - **Unilateral exit:** `ExitCostMsg` with `AmountSat` gross and
   `ExitCostSat` fee. The handler expands this into two ledger entries
   internally (send leg + fee leg).
+- **Boarding-timeout sweep (miner fee):** `FeePaidMsg{FeeType=FeeTypeOnchainSweep,
+  AmountSat=fee, IdempotencyKey=sweepTxidBytes}`. Emitted by the boarding sweep
+  actor at confirmation height. Booked as
+  `onchain_fees += AmountSat / wallet_balance -= AmountSat`. No paired
+  `VTXOReceivedMsg` — the sweep moves on-chain wallet funds to a different
+  wallet address, with the fee as the only balance change.
 
 ## Invariants
 

--- a/ledger/CLAUDE.md
+++ b/ledger/CLAUDE.md
@@ -7,7 +7,8 @@ receipts/sends, wallet UTXO deposits, exit costs) as double-entry ledger
 entries and UTXO audit log records. Provides a crash-safe financial audit
 trail for tax reporting and fee transparency. Ledger event types:
 `wallet_utxo_created` (wallet UTXO deposit), `boarding_fee_paid`,
-`refresh_fee_paid`, `onchain_fee_paid`, `vtxo_received`, `vtxo_sent`.
+`refresh_fee_paid`, `onchain_fee_paid`, `boarding_sweep_fee_paid`,
+`vtxo_received`, `vtxo_sent`.
 
 ## Chart of Accounts
 
@@ -45,12 +46,35 @@ accounts, see [docs/fee_ledger.md](../docs/fee_ledger.md).
 - `UTXOAuditStore` — Interface for DB persistence of UTXO audit log entries (implemented by `db.UTXOAuditStoreDB`).
 - `UTXOAuditEntry` — Domain-level UTXO audit record (outpoint, amount, event, block height, classification).
 - `LedgerMsg` / `LedgerResp` — Message and response type constraints for the durable mailbox.
-- `FeePaidMsg` — Records boarding/refresh fee payments.
+- `FeePaidMsg` — Records fee payments. Two flavors:
+  - `FeeTypeBoarding` / `FeeTypeRefresh`: Ark protocol fees paid to the
+    operator during a round. Keyed by `RoundID`; booked as
+    `fees_paid += AmountSat / vtxo_balance -= AmountSat`.
+  - `FeeTypeOnchainSweep`: L1 miner fee paid by a boarding-timeout sweep.
+    Keyed by sweep txid via `IdempotencyKey []byte` (the sweep txid bytes);
+    booked as `onchain_fees += AmountSat / wallet_balance -= AmountSat`.
+    Has no paired `VTXOReceivedMsg`. Emitted by the boarding sweep actor at
+    confirmation time.
+  New field: `IdempotencyKey []byte` (TLV type 9) for dedup on events that
+  carry neither a `RoundID` nor a `SessionID`.
 - `VTXOReceivedMsg` — Records incoming VTXOs. `Source` must be one of `SourceRoundBoarding` (client's own on-chain wallet funds boarded into a round; offsets wallet_balance), `SourceRoundRefresh` (refresh output or directed-send self-change; offsets transfers_out so the paired VTXOSent cancels on that account and only the operator fee moves vtxo_balance), `SourceRoundTransfer` (in-round receive from another participant; offsets transfers_in), or `SourceOOR` (out-of-round receive; offsets transfers_in). Any other value is rejected.
 - `VTXOSentMsg` — Records outgoing VTXO transfers. Carries either `SessionID` (32-byte OOR) or `RoundID` (16-byte in-round) — exactly one must be non-zero; both-zero and both-set inputs are rejected. Also carries an optional `Outpoint wire.OutPoint` so in-round multi-VTXO events (e.g. paired refresh emissions) disambiguate per-VTXO via an outpoint-derived `IdempotencyKey` instead of collapsing on `idx_client_ledger_idempotent_round`.
 - `ExitCostMsg` — Records a unilateral exit as two ledger entries: a send leg (`transfers_out` debit, `vtxo_balance` credit) for the net-of-fee value and a fee leg (`onchain_fees` debit, `vtxo_balance` credit) for the miner fee. Together the credits reduce `vtxo_balance` by the gross exited amount. Wallet-side movement is covered separately by the `wallet_utxo_log` audit trail.
 - `UTXOCreatedMsg` — Records new wallet UTXO confirmations with classification. `handleUTXOCreated` writes TWO rows per event: a `wallet_utxo_log` audit row and a double-entry ledger row (`debit wallet_balance, credit opening_balance`, `event_type = wallet_utxo_created`) stamped with an outpoint-derived idempotency key via `walletUTXOIdempotencyKey`. The deposit leg is what gives `wallet_balance` a non-negative balance in the presence of `SourceRoundBoarding` outflows.
 - `UTXOSpentMsg` — Records wallet UTXO spends with classification. Currently only writes the `wallet_utxo_log` audit row (double-entry leg for non-boarding wallet spends is a planned follow-up).
+
+## Constants
+
+New constants added for boarding-sweep flows:
+- `EventBoardingSweepFeePaid = "boarding_sweep_fee_paid"` — Event type for the
+  miner fee paid by a boarding-timeout sweep transaction.
+- `FeeTypeOnchainSweep = "onchain_sweep"` — Fee type value for `FeePaidMsg`
+  when recording a boarding sweep's L1 miner fee. Booked as
+  `onchain_fees += AmountSat / wallet_balance -= AmountSat`.
+- `ClassificationBoardingSweepInput = "boarding_sweep_input"` — UTXO
+  classification for boarding outputs swept by the boarding-sweep actor.
+- `ClassificationBoardingSweepReturn = "boarding_sweep_return"` — UTXO
+  classification for the change/return output of a boarding sweep.
 
 ## Relationships
 
@@ -109,6 +133,12 @@ pairs of messages:
 - **Unilateral exit:** `ExitCostMsg` with `AmountSat` gross and
   `ExitCostSat` fee. The handler expands this into two ledger entries
   internally (send leg + fee leg).
+- **Boarding-timeout sweep (miner fee):** `FeePaidMsg{FeeType=FeeTypeOnchainSweep,
+  AmountSat=fee, IdempotencyKey=sweepTxidBytes}`. Emitted by the boarding sweep
+  actor at confirmation height. Booked as
+  `onchain_fees += AmountSat / wallet_balance -= AmountSat`. No paired
+  `VTXOReceivedMsg` — the sweep moves on-chain wallet funds to a different
+  wallet address, with the fee as the only balance change.
 
 ## Invariants
 

--- a/serverconn/AGENTS.md
+++ b/serverconn/AGENTS.md
@@ -29,7 +29,16 @@ background ingress polling with event routing.
 - **Depends on**: `baselib/actor` (DurableActor infrastructure), `mailbox/*` (Envelope, RpcMeta, MailboxServiceClient).
 - **Depended on by**: `round` (outbound RPCs), `oor` (durable transport), `darepod` (wiring).
 - **Sends (egress → remote mailbox)**:
-  - `SendClientEventRequest` (durable): wraps `JoinRoundRequest`, `JoinRoundAccept`, `JoinRoundReject`, `SubmitNoncesRequest`, `SubmitPartialSigRequest`, `SubmitForfeitSigRequest`. `JoinRoundAccept` / `JoinRoundReject` are the explicit responses to a server-issued seal-time `JoinRoundQuote` (#270); both echo the `quote_id` so the server can drop stale responses after a reseal.
+  - `SendClientEventRequest` (durable): wraps `JoinRoundRequest`,
+    `JoinRoundAccept`, `JoinRoundReject`, `SubmitNoncesRequest`,
+    `SubmitPartialSigRequest`, `SubmitForfeitSigRequest`. `JoinRoundAccept` /
+    `JoinRoundReject` echo the `quote_id` so the server can drop stale
+    responses after a reseal. `CorrelationKey()` forwards the inner message's
+    per-key FIFO key (e.g. `"round/<id>"`, `"oor/<session>"`); when the
+    wrapper is decoded from the outbox CDC table the inner type becomes a
+    `rawServerMessage` that no longer carries the key, so `Encode` persists
+    the key in a dedicated TLV record (`correlationKeyRecordTLV = 8`) and
+    `Decode` caches it in `cachedCorrelationKey []byte` for the fallback path.
   - `SendRPCRequest` (unary, non-durable): low-latency request-response RPCs
   - transport-native durable query messages for proof-gated indexer lookups
 - **Routes (ingress → local actors via EventRouter)**:
@@ -44,6 +53,7 @@ background ingress polling with event routing.
 - Ack watermark only advances AFTER durable local dispatch commit (prevents message loss on crash).
 - Unary RPC responses use in-memory registry first; if no waiter exists (crash replay), the ingress falls back to durable EventRouter dispatch. The ResponseRegistry returns a tri-state delivery result (waiter/buffered/dropped) so the ingress knows whether to route durably.
 - `SendClientEventRequest` auto-derives `Service`/`Method` from `Message.ServiceMethod()` when callers leave them empty, preventing silent drops.
+- `SendClientEventRequest.CorrelationKey()` must survive TLV round-trips through the outbox CDC table. `Encode` persists the inner message's key in a dedicated TLV field; `Decode` caches it in `cachedCorrelationKey`. Without this, the decoded wrapper loses the inner key (the inner becomes `*rawServerMessage`) and all outbox events land in the unkeyed durable mailbox lane, erasing the per-key FIFO ordering established by `round` and `oor` outbox messages.
 - Idempotency keys are derived from message payload hash; same key on retry enables server deduplication.
 - Ingress loop checkpoints pull cursor and ack state; on restart, resumes from checkpoint.
 - `DurableUnaryQuery` values are handled generically in `ServerConnectionActor.Receive` via `buildDurableUnary`: the query is converted to a `SendUnaryRequest` using the configured `DurableUnaryRequestBuilder`. Adding a new durable indexer query type requires only implementing `DurableUnaryQuery` — no new `Receive` case is needed.

--- a/serverconn/CLAUDE.md
+++ b/serverconn/CLAUDE.md
@@ -29,7 +29,16 @@ background ingress polling with event routing.
 - **Depends on**: `baselib/actor` (DurableActor infrastructure), `mailbox/*` (Envelope, RpcMeta, MailboxServiceClient).
 - **Depended on by**: `round` (outbound RPCs), `oor` (durable transport), `darepod` (wiring).
 - **Sends (egress → remote mailbox)**:
-  - `SendClientEventRequest` (durable): wraps `JoinRoundRequest`, `JoinRoundAccept`, `JoinRoundReject`, `SubmitNoncesRequest`, `SubmitPartialSigRequest`, `SubmitForfeitSigRequest`. `JoinRoundAccept` / `JoinRoundReject` are the explicit responses to a server-issued seal-time `JoinRoundQuote` (#270); both echo the `quote_id` so the server can drop stale responses after a reseal.
+  - `SendClientEventRequest` (durable): wraps `JoinRoundRequest`,
+    `JoinRoundAccept`, `JoinRoundReject`, `SubmitNoncesRequest`,
+    `SubmitPartialSigRequest`, `SubmitForfeitSigRequest`. `JoinRoundAccept` /
+    `JoinRoundReject` echo the `quote_id` so the server can drop stale
+    responses after a reseal. `CorrelationKey()` forwards the inner message's
+    per-key FIFO key (e.g. `"round/<id>"`, `"oor/<session>"`); when the
+    wrapper is decoded from the outbox CDC table the inner type becomes a
+    `rawServerMessage` that no longer carries the key, so `Encode` persists
+    the key in a dedicated TLV record (`correlationKeyRecordTLV = 8`) and
+    `Decode` caches it in `cachedCorrelationKey []byte` for the fallback path.
   - `SendRPCRequest` (unary, non-durable): low-latency request-response RPCs
   - transport-native durable query messages for proof-gated indexer lookups
 - **Routes (ingress → local actors via EventRouter)**:
@@ -44,6 +53,7 @@ background ingress polling with event routing.
 - Ack watermark only advances AFTER durable local dispatch commit (prevents message loss on crash).
 - Unary RPC responses use in-memory registry first; if no waiter exists (crash replay), the ingress falls back to durable EventRouter dispatch. The ResponseRegistry returns a tri-state delivery result (waiter/buffered/dropped) so the ingress knows whether to route durably.
 - `SendClientEventRequest` auto-derives `Service`/`Method` from `Message.ServiceMethod()` when callers leave them empty, preventing silent drops.
+- `SendClientEventRequest.CorrelationKey()` must survive TLV round-trips through the outbox CDC table. `Encode` persists the inner message's key in a dedicated TLV field; `Decode` caches it in `cachedCorrelationKey`. Without this, the decoded wrapper loses the inner key (the inner becomes `*rawServerMessage`) and all outbox events land in the unkeyed durable mailbox lane, erasing the per-key FIFO ordering established by `round` and `oor` outbox messages.
 - Idempotency keys are derived from message payload hash; same key on retry enables server deduplication.
 - Ingress loop checkpoints pull cursor and ack state; on restart, resumes from checkpoint.
 - `DurableUnaryQuery` values are handled generically in `ServerConnectionActor.Receive` via `buildDurableUnary`: the query is converted to a `SendUnaryRequest` using the configured `DurableUnaryRequestBuilder`. Adding a new durable indexer query type requires only implementing `DurableUnaryQuery` — no new `Receive` case is needed.

--- a/unroll/AGENTS.md
+++ b/unroll/AGENTS.md
@@ -36,7 +36,17 @@ control-plane record per target to `db` so restart can restore in-flight jobs.
   `PhaseSweepBroadcast` / `PhaseSweepConfirmation` / `PhaseCompleted` /
   `PhaseFailed`.
 - `JobState` — Durable FSM state (height, trigger, planner state,
-  `FailReason`, `SweepAttempts`).
+  `FailReason`, `SweepAttempts`, `DeferredCheckpoints []DeferredCheckpoint`).
+- `DeferredCheckpoint` — A fraud-triggered checkpoint transaction that is ready
+  to be materialized but held until `DeadlineHeight` so the operator can
+  confirm it first. Fields: `Txid chainhash.Hash`, `DeadlineHeight int32`.
+- `WatchDeferredCheckpoints` — FSM outbox event asking the actor boundary to
+  watch deferred checkpoints for operator confirmation while waiting for the
+  backstop height. `Txids []chainhash.Hash`.
+- `Config.FraudCheckpointSafetyMargin int32` — Blocks subtracted from a
+  checkpoint's relative-expiry window to compute the recipient backstop
+  deadline under `TriggerFraudSpend`. The margin gives the operator time to
+  publish the checkpoint first. Zero falls back to `defaultFraudCheckpointSafetyMargin`.
 
 ### Registry
 - `UnrollRegistryActor` — Thin coordinator over the set of

--- a/unroll/CLAUDE.md
+++ b/unroll/CLAUDE.md
@@ -36,7 +36,17 @@ control-plane record per target to `db` so restart can restore in-flight jobs.
   `PhaseSweepBroadcast` / `PhaseSweepConfirmation` / `PhaseCompleted` /
   `PhaseFailed`.
 - `JobState` — Durable FSM state (height, trigger, planner state,
-  `FailReason`, `SweepAttempts`).
+  `FailReason`, `SweepAttempts`, `DeferredCheckpoints []DeferredCheckpoint`).
+- `DeferredCheckpoint` — A fraud-triggered checkpoint transaction that is ready
+  to be materialized but held until `DeadlineHeight` so the operator can
+  confirm it first. Fields: `Txid chainhash.Hash`, `DeadlineHeight int32`.
+- `WatchDeferredCheckpoints` — FSM outbox event asking the actor boundary to
+  watch deferred checkpoints for operator confirmation while waiting for the
+  backstop height. `Txids []chainhash.Hash`.
+- `Config.FraudCheckpointSafetyMargin int32` — Blocks subtracted from a
+  checkpoint's relative-expiry window to compute the recipient backstop
+  deadline under `TriggerFraudSpend`. The margin gives the operator time to
+  publish the checkpoint first. Zero falls back to `defaultFraudCheckpointSafetyMargin`.
 
 ### Registry
 - `UnrollRegistryActor` — Thin coordinator over the set of

--- a/vtxo/AGENTS.md
+++ b/vtxo/AGENTS.md
@@ -19,17 +19,26 @@ when the local wallet owns the receive script.
 - `ManagerConfig` — Configuration holding Store, Wallet, ChainSource,
   ActorSystem, ChainParams, ExpiryConfig, RoundActor ref, ChainResolver ref,
   optional `Log`, optional `LedgerSink fn.Option[ledger.Sink]`,
-  `ForfeitVTXOActorAskTimeout`, and `RefreshFeeQuoter`. The manager
-  propagates the sink into each spawned `VTXOActor` for `ExitCostMsg`
-  emissions. `ForfeitVTXOActorAskTimeout` (default 5 s) bounds forfeit
-  and refresh child asks so a blocked child actor cannot monopolize the
-  manager until the outer RPC deadline. Zero uses the default; negative
-  disables the timeout. Spend-path asks keep the caller's context.
+  `ForfeitVTXOActorAskTimeout`, `RefreshFeeQuoter`, and optional
+  `TerminalVTXOObserver func(context.Context, wire.OutPoint) error`. The
+  manager propagates the sink into each spawned `VTXOActor` for `ExitCostMsg`
+  emissions. `ForfeitVTXOActorAskTimeout` (default 5 s) bounds forfeit and
+  refresh child asks so a blocked child actor cannot monopolize the manager
+  until the outer RPC deadline. Zero uses the default; negative disables the
+  timeout. Spend-path asks keep the caller's context.
+  `TerminalVTXOObserver`, when non-nil, is invoked with the outpoint of each
+  VTXO that leaves the manager's active set; enables daemon-local subsystems
+  (e.g. the recipient fraud watcher) to release actor-owned per-VTXO work.
 - `VTXOActorConfig.LedgerSink` — Per-VTXO actor field plumbed from the manager. The `emitExitCost` helper is wired onto the unilateral-exit transition but is currently a no-op pending chain resolver integration: the actor cannot determine the on-chain miner fee until the chain resolver reports the confirmed exit-spend transaction. The emission site exists so a single future change in the chain resolver wiring enables it without touching the FSM transition logic.
 - `VTXOEvent` — Inbound events (BlockEpochEvent, ForfeitRequest, ForfeitConfirmed, SpendReserveEvent, SpendCompletedEvent, etc.).
 - `VTXOOutMsg` — Outbound messages (ForfeitRequest, ExpiringNotify, StatusUpdate, Terminated).
 - `FilterOptions` / `FilterDescriptors` — VTXO filtering by expiry status, spend state, etc.
 - `GetActiveVTXOCountRequest` / `GetActiveVTXOCountResponse` — Ask-message for querying active VTXO count from the manager.
+- `ListLiveDescriptorsRequest` / `ListLiveDescriptorsResponse` — Ask-message for
+  retrieving the snapshot of VTXO descriptors the manager recovered from durable
+  state at `Start` time. Used by daemon-local subsystems (e.g. the recipient
+  fraud watcher) to re-arm per-VTXO state after a restart without taking a
+  direct dependency on the VTXO store. The slice is caller-owned.
 - `ManagerMsg` / `ManagerResp` — Type aliases for `actormsg.VTXOManagerMsg` / `actormsg.VTXOManagerResp` (admission types live in `lib/actormsg` to avoid import cycles).
 - `IncomingVTXOHandler` — Actor that consumes `arkrpc.IncomingVTXOEvent` push notifications, looks up the receive script in the owned-script store, builds a `Descriptor` (with tapscript derived via `lib/arkscript`), persists it via `VTXOSaver`, and tells the manager via `VTXOsMaterializedNotification`. Only `VTXO_EVENT_TYPE_CREATED` events are acted on; unknown event kinds and unowned scripts are silently ignored. Inputs are validated for outpoint shape, pkScript presence, and `int64`/`MaxSatoshi` value bounds before any DB write.
 - `IncomingVTXOMsg` / `IncomingVTXOResp` — Actor envelope wrapping an `arkrpc.IncomingVTXOEvent` and the `any`-typed response.
@@ -54,6 +63,9 @@ when the local wallet owns the receive script.
   - ← `wallet` (via `lib/actormsg`): `SelectAndReserveSpendRequest`, `ReleaseSpendRequest`, `CompleteSpendRequest`, `ReserveForfeitRequest`, `ReleaseForfeitRequest`, `SelectAndReserveForfeitRequest`
   - ← `chainsource` (via Manager): `BlockEpochEvent`
   - ← `serverconn` (via `EventRouter` route `MethodIncomingVTXO`): `IncomingVTXOMsg` (wrapping `arkrpc.IncomingVTXOEvent`), routed to `IncomingVTXOHandler`
+  - ← API (manager): `ListLiveDescriptorsRequest` (returns startup snapshot of
+    live descriptors for daemon-local subsystems to re-arm per-VTXO state)
+  - ← API (manager): `GetActiveVTXOCountRequest`, `ForceUnrollRequest`
 
 ## Multi-Tree Ancestry
 

--- a/vtxo/CLAUDE.md
+++ b/vtxo/CLAUDE.md
@@ -19,17 +19,26 @@ when the local wallet owns the receive script.
 - `ManagerConfig` — Configuration holding Store, Wallet, ChainSource,
   ActorSystem, ChainParams, ExpiryConfig, RoundActor ref, ChainResolver ref,
   optional `Log`, optional `LedgerSink fn.Option[ledger.Sink]`,
-  `ForfeitVTXOActorAskTimeout`, and `RefreshFeeQuoter`. The manager
-  propagates the sink into each spawned `VTXOActor` for `ExitCostMsg`
-  emissions. `ForfeitVTXOActorAskTimeout` (default 5 s) bounds forfeit
-  and refresh child asks so a blocked child actor cannot monopolize the
-  manager until the outer RPC deadline. Zero uses the default; negative
-  disables the timeout. Spend-path asks keep the caller's context.
+  `ForfeitVTXOActorAskTimeout`, `RefreshFeeQuoter`, and optional
+  `TerminalVTXOObserver func(context.Context, wire.OutPoint) error`. The
+  manager propagates the sink into each spawned `VTXOActor` for `ExitCostMsg`
+  emissions. `ForfeitVTXOActorAskTimeout` (default 5 s) bounds forfeit and
+  refresh child asks so a blocked child actor cannot monopolize the manager
+  until the outer RPC deadline. Zero uses the default; negative disables the
+  timeout. Spend-path asks keep the caller's context.
+  `TerminalVTXOObserver`, when non-nil, is invoked with the outpoint of each
+  VTXO that leaves the manager's active set; enables daemon-local subsystems
+  (e.g. the recipient fraud watcher) to release actor-owned per-VTXO work.
 - `VTXOActorConfig.LedgerSink` — Per-VTXO actor field plumbed from the manager. The `emitExitCost` helper is wired onto the unilateral-exit transition but is currently a no-op pending chain resolver integration: the actor cannot determine the on-chain miner fee until the chain resolver reports the confirmed exit-spend transaction. The emission site exists so a single future change in the chain resolver wiring enables it without touching the FSM transition logic.
 - `VTXOEvent` — Inbound events (BlockEpochEvent, ForfeitRequest, ForfeitConfirmed, SpendReserveEvent, SpendCompletedEvent, etc.).
 - `VTXOOutMsg` — Outbound messages (ForfeitRequest, ExpiringNotify, StatusUpdate, Terminated).
 - `FilterOptions` / `FilterDescriptors` — VTXO filtering by expiry status, spend state, etc.
 - `GetActiveVTXOCountRequest` / `GetActiveVTXOCountResponse` — Ask-message for querying active VTXO count from the manager.
+- `ListLiveDescriptorsRequest` / `ListLiveDescriptorsResponse` — Ask-message for
+  retrieving the snapshot of VTXO descriptors the manager recovered from durable
+  state at `Start` time. Used by daemon-local subsystems (e.g. the recipient
+  fraud watcher) to re-arm per-VTXO state after a restart without taking a
+  direct dependency on the VTXO store. The slice is caller-owned.
 - `ManagerMsg` / `ManagerResp` — Type aliases for `actormsg.VTXOManagerMsg` / `actormsg.VTXOManagerResp` (admission types live in `lib/actormsg` to avoid import cycles).
 - `IncomingVTXOHandler` — Actor that consumes `arkrpc.IncomingVTXOEvent` push notifications, looks up the receive script in the owned-script store, builds a `Descriptor` (with tapscript derived via `lib/arkscript`), persists it via `VTXOSaver`, and tells the manager via `VTXOsMaterializedNotification`. Only `VTXO_EVENT_TYPE_CREATED` events are acted on; unknown event kinds and unowned scripts are silently ignored. Inputs are validated for outpoint shape, pkScript presence, and `int64`/`MaxSatoshi` value bounds before any DB write.
 - `IncomingVTXOMsg` / `IncomingVTXOResp` — Actor envelope wrapping an `arkrpc.IncomingVTXOEvent` and the `any`-typed response.
@@ -54,6 +63,9 @@ when the local wallet owns the receive script.
   - ← `wallet` (via `lib/actormsg`): `SelectAndReserveSpendRequest`, `ReleaseSpendRequest`, `CompleteSpendRequest`, `ReserveForfeitRequest`, `ReleaseForfeitRequest`, `SelectAndReserveForfeitRequest`
   - ← `chainsource` (via Manager): `BlockEpochEvent`
   - ← `serverconn` (via `EventRouter` route `MethodIncomingVTXO`): `IncomingVTXOMsg` (wrapping `arkrpc.IncomingVTXOEvent`), routed to `IncomingVTXOHandler`
+  - ← API (manager): `ListLiveDescriptorsRequest` (returns startup snapshot of
+    live descriptors for daemon-local subsystems to re-arm per-VTXO state)
+  - ← API (manager): `GetActiveVTXOCountRequest`, `ForceUnrollRequest`
 
 ## Multi-Tree Ancestry
 

--- a/wallet/AGENTS.md
+++ b/wallet/AGENTS.md
@@ -34,11 +34,53 @@ refresh, leave, OOR spend, and directed send flows.
 - `SendVTXOsRequest` / `SendVTXOsResponse` — Ask-request for in-round directed sends. Validates each recipient amount is within `(0, MaxSatoshi]` and that the running total never overflows `int64`, atomically selects and reserves VTXOs via `SelectAndReserveForfeitRequest`, builds forfeit + recipient VTXO intents, and registers with the round actor. Supports dry-run mode for previewing coin selection without committing. Reserved VTXOs are released via a deferred cleanup that uses `context.WithoutCancel` so cleanup survives caller disconnect; on success, a `committed` flag is set to skip the release.
 - `GetConfirmedBoardingIntentsRequest` / `GetConfirmedBoardingIntentsResponse` — Ask-request to retrieve currently confirmed boarding intents (used by the RPC/CLI layer to report boarding balance with policy metadata).
 - `VTXODescriptor.EffectivePolicyTemplate` — Decodes the serialized `PolicyTemplate` field on the wallet-level VTXO descriptor using `lib/arkscript`.
+- `SweepSigner` — Interface for the boarding-sweep actor: `input.Signer` +
+  `NewWalletPkScript(ctx) ([]byte, error)`. Intentionally mirrors
+  `unroll.SweepWallet` so the existing per-backend adapters satisfy it
+  without modification.
+- `BoardingSweepStore` — Persistence interface for aggregate boarding-timeout
+  sweeps: `CreatePendingBoardingSweep`, `MarkBoardingSweepPublished`,
+  `MarkBoardingSweepFailed`, `MarkBoardingSweepInputSpent`,
+  `ListBoardingSweeps`, `GetBoardingSweep`, `ListPendingBoardingSweeps`,
+  `FetchBoardingIntentsBySweepableStatuses`, `GetIntent`. The concrete
+  implementation lives in `db/`.
+- `BoardingSweepRecord` — One persisted aggregate sweep + its inputs
+  (`[]BoardingSweepInputRecord`). Carries `Txid`, `Tx`, `TotalAmount`,
+  `FeeAmount`, `FeeRateSatPerVByte`, `VBytes`, `Status`, `CreatedHeight`,
+  `ConfirmedHeight`, `LastError`.
+- `BoardingSweepInputRecord` — One tracked boarding outpoint within an
+  aggregate sweep.
+- `BoardingSweepOutput` — Output record for the sweep transaction destination.
+- `NewBoardingSweep` / `NewBoardingSweepInput` — Insertion shapes passed to
+  `CreatePendingBoardingSweep`.
+- `BoardingSweepTxNotification` / `BoardingSweepSpendNotification` /
+  `BoardingSweepNotificationAck` — Actor-internal messages used by the
+  boarding sweep subsystem for txconfirm callbacks.
+- `ResumeBoardingSweepsRequest` / `ResumeBoardingSweepsResponse` — Ask-message
+  to restart in-flight sweeps after a daemon restart.
+- `WithBoardingSweep(store, signer, chainParams)` — `ArkOption` that wires the
+  boarding-sweep subsystem into the wallet actor. When omitted the RPC paths
+  for boarding sweeps return an explicit error. The txconfirm ref is resolved
+  lazily via the actor receptionist so callers do not need to guarantee
+  actor-init ordering.
+- `PendingBoardRequest` / `PendingBoardRequestStore` — Per-outpoint durable
+  row persisted before each `TriggerBoardMsg` Tell so a crash after persist
+  but before round delivery does not lose the boarding intent.
+- `ReplayPendingBoardRequest` / `ReplayPendingBoardResponse` — Ask-message to
+  re-send pending board requests to the round actor on daemon restart.
+- `BoardingSweepStatusPending` / other `BoardingSweepStatus*` — Lifecycle
+  status constants for the boarding sweep state machine.
 
 ## Relationships
 
-- **Depends on**: `baselib/actor` (actor system), `chainsource` (block epoch notifications), `lib/actormsg` (VTXO manager admission types), `ledger` (`Sink` alias for emission + `UTXOCreatedMsg` / `ClassificationDeposit` constants).
-- **Depended on by**: `round` (boarding intents, types: `BoardingAddress`, `SelectedVTXO`), `db` (persistence), `darepod` (wiring).
+- **Depends on**: `baselib/actor` (actor system), `chainsource` (block epoch
+  notifications), `lib/actormsg` (VTXO manager admission types), `ledger`
+  (`Sink` alias for emission + `UTXOCreatedMsg` / `ClassificationDeposit`
+  constants), `txconfirm` (boarding sweep broadcast + confirmation, resolved
+  lazily via receptionist), `lib/arkscript` (boarding script decode for
+  sweep construction), `walletcore` (`LockID`, `OutputLeaser`).
+- **Depended on by**: `round` (boarding intents, types: `BoardingAddress`,
+  `SelectedVTXO`), `db` (persistence), `darepod` (wiring).
 - **Sends**:
   - → `round` (via registered notifier): `BoardingUtxoConfirmedEvent`
   - → `round` (via `lib/actormsg`): `TriggerBoardMsg` (VTXO amounts for
@@ -52,7 +94,14 @@ refresh, leave, OOR spend, and directed send flows.
 - **Receives**:
   - ← `chainsource`: `BlockEpochNotification` (triggers UTXO polling)
   - ← `round`: `RegisterConfirmationNotifierRequest`, `UnregisterConfirmationNotifierRequest`
-  - ← API: `CreateBoardingAddressRequest`, `GetActiveBoardingAddressesRequest`, `GetBoardingBalanceRequest`, `GetConfirmedBoardingIntentsRequest`, `RefreshVTXOsRequest`, `SelectAndLockVTXOsRequest`, `LeaveVTXOsRequest`, `BoardRequest`, `CompleteSpendVTXOsRequest`, `UnlockVTXOsRequest`, `SendVTXOsRequest`
+  - ← `txconfirm` (boarding sweep path, via registered callback):
+    `BoardingSweepTxNotification`, `BoardingSweepSpendNotification`
+  - ← API: `CreateBoardingAddressRequest`, `GetActiveBoardingAddressesRequest`,
+    `GetBoardingBalanceRequest`, `GetConfirmedBoardingIntentsRequest`,
+    `RefreshVTXOsRequest`, `SelectAndLockVTXOsRequest`, `LeaveVTXOsRequest`,
+    `BoardRequest`, `CompleteSpendVTXOsRequest`, `UnlockVTXOsRequest`,
+    `SendVTXOsRequest`, `ResumeBoardingSweepsRequest`,
+    `ReplayPendingBoardRequest`
 
 ## Invariants
 

--- a/wallet/CLAUDE.md
+++ b/wallet/CLAUDE.md
@@ -34,11 +34,53 @@ refresh, leave, OOR spend, and directed send flows.
 - `SendVTXOsRequest` / `SendVTXOsResponse` — Ask-request for in-round directed sends. Validates each recipient amount is within `(0, MaxSatoshi]` and that the running total never overflows `int64`, atomically selects and reserves VTXOs via `SelectAndReserveForfeitRequest`, builds forfeit + recipient VTXO intents, and registers with the round actor. Supports dry-run mode for previewing coin selection without committing. Reserved VTXOs are released via a deferred cleanup that uses `context.WithoutCancel` so cleanup survives caller disconnect; on success, a `committed` flag is set to skip the release.
 - `GetConfirmedBoardingIntentsRequest` / `GetConfirmedBoardingIntentsResponse` — Ask-request to retrieve currently confirmed boarding intents (used by the RPC/CLI layer to report boarding balance with policy metadata).
 - `VTXODescriptor.EffectivePolicyTemplate` — Decodes the serialized `PolicyTemplate` field on the wallet-level VTXO descriptor using `lib/arkscript`.
+- `SweepSigner` — Interface for the boarding-sweep actor: `input.Signer` +
+  `NewWalletPkScript(ctx) ([]byte, error)`. Intentionally mirrors
+  `unroll.SweepWallet` so the existing per-backend adapters satisfy it
+  without modification.
+- `BoardingSweepStore` — Persistence interface for aggregate boarding-timeout
+  sweeps: `CreatePendingBoardingSweep`, `MarkBoardingSweepPublished`,
+  `MarkBoardingSweepFailed`, `MarkBoardingSweepInputSpent`,
+  `ListBoardingSweeps`, `GetBoardingSweep`, `ListPendingBoardingSweeps`,
+  `FetchBoardingIntentsBySweepableStatuses`, `GetIntent`. The concrete
+  implementation lives in `db/`.
+- `BoardingSweepRecord` — One persisted aggregate sweep + its inputs
+  (`[]BoardingSweepInputRecord`). Carries `Txid`, `Tx`, `TotalAmount`,
+  `FeeAmount`, `FeeRateSatPerVByte`, `VBytes`, `Status`, `CreatedHeight`,
+  `ConfirmedHeight`, `LastError`.
+- `BoardingSweepInputRecord` — One tracked boarding outpoint within an
+  aggregate sweep.
+- `BoardingSweepOutput` — Output record for the sweep transaction destination.
+- `NewBoardingSweep` / `NewBoardingSweepInput` — Insertion shapes passed to
+  `CreatePendingBoardingSweep`.
+- `BoardingSweepTxNotification` / `BoardingSweepSpendNotification` /
+  `BoardingSweepNotificationAck` — Actor-internal messages used by the
+  boarding sweep subsystem for txconfirm callbacks.
+- `ResumeBoardingSweepsRequest` / `ResumeBoardingSweepsResponse` — Ask-message
+  to restart in-flight sweeps after a daemon restart.
+- `WithBoardingSweep(store, signer, chainParams)` — `ArkOption` that wires the
+  boarding-sweep subsystem into the wallet actor. When omitted the RPC paths
+  for boarding sweeps return an explicit error. The txconfirm ref is resolved
+  lazily via the actor receptionist so callers do not need to guarantee
+  actor-init ordering.
+- `PendingBoardRequest` / `PendingBoardRequestStore` — Per-outpoint durable
+  row persisted before each `TriggerBoardMsg` Tell so a crash after persist
+  but before round delivery does not lose the boarding intent.
+- `ReplayPendingBoardRequest` / `ReplayPendingBoardResponse` — Ask-message to
+  re-send pending board requests to the round actor on daemon restart.
+- `BoardingSweepStatusPending` / other `BoardingSweepStatus*` — Lifecycle
+  status constants for the boarding sweep state machine.
 
 ## Relationships
 
-- **Depends on**: `baselib/actor` (actor system), `chainsource` (block epoch notifications), `lib/actormsg` (VTXO manager admission types), `ledger` (`Sink` alias for emission + `UTXOCreatedMsg` / `ClassificationDeposit` constants).
-- **Depended on by**: `round` (boarding intents, types: `BoardingAddress`, `SelectedVTXO`), `db` (persistence), `darepod` (wiring).
+- **Depends on**: `baselib/actor` (actor system), `chainsource` (block epoch
+  notifications), `lib/actormsg` (VTXO manager admission types), `ledger`
+  (`Sink` alias for emission + `UTXOCreatedMsg` / `ClassificationDeposit`
+  constants), `txconfirm` (boarding sweep broadcast + confirmation, resolved
+  lazily via receptionist), `lib/arkscript` (boarding script decode for
+  sweep construction), `walletcore` (`LockID`, `OutputLeaser`).
+- **Depended on by**: `round` (boarding intents, types: `BoardingAddress`,
+  `SelectedVTXO`), `db` (persistence), `darepod` (wiring).
 - **Sends**:
   - → `round` (via registered notifier): `BoardingUtxoConfirmedEvent`
   - → `round` (via `lib/actormsg`): `TriggerBoardMsg` (VTXO amounts for
@@ -52,7 +94,14 @@ refresh, leave, OOR spend, and directed send flows.
 - **Receives**:
   - ← `chainsource`: `BlockEpochNotification` (triggers UTXO polling)
   - ← `round`: `RegisterConfirmationNotifierRequest`, `UnregisterConfirmationNotifierRequest`
-  - ← API: `CreateBoardingAddressRequest`, `GetActiveBoardingAddressesRequest`, `GetBoardingBalanceRequest`, `GetConfirmedBoardingIntentsRequest`, `RefreshVTXOsRequest`, `SelectAndLockVTXOsRequest`, `LeaveVTXOsRequest`, `BoardRequest`, `CompleteSpendVTXOsRequest`, `UnlockVTXOsRequest`, `SendVTXOsRequest`
+  - ← `txconfirm` (boarding sweep path, via registered callback):
+    `BoardingSweepTxNotification`, `BoardingSweepSpendNotification`
+  - ← API: `CreateBoardingAddressRequest`, `GetActiveBoardingAddressesRequest`,
+    `GetBoardingBalanceRequest`, `GetConfirmedBoardingIntentsRequest`,
+    `RefreshVTXOsRequest`, `SelectAndLockVTXOsRequest`, `LeaveVTXOsRequest`,
+    `BoardRequest`, `CompleteSpendVTXOsRequest`, `UnlockVTXOsRequest`,
+    `SendVTXOsRequest`, `ResumeBoardingSweepsRequest`,
+    `ReplayPendingBoardRequest`
 
 ## Invariants
 


### PR DESCRIPTION
Automated nightly documentation sweep via `.claude/skills/doc-gardening`.

## Summary

- **New packages documented**: `fraud` (recipient-side OOR ancestry fraud
  detector actor), `internal/indexerlimits` (indexer pagination cursor bounds)
- **Stale packages updated**: `vtxo`, `ledger`, `wallet`, `unroll`,
  `serverconn` — reflecting the boarding-sweep subsystem, fraud watcher
  wiring, per-key FIFO correlation key forwarding, and deferred checkpoint
  support added since the last sweep
- **ARCHITECTURE.md**: added `fraud` and `internal/indexerlimits` to the
  layer tables
- **AGENTS.md sync**: `baselib/actor` and `db/actordelivery/migrations`
  AGENTS.md copies were lagging behind their CLAUDE.md counterparts and
  are now re-synced

## Review

Please review the updated `CLAUDE.md`/`AGENTS.md` diffs in:
`fraud/`, `internal/indexerlimits/`, `vtxo/`, `ledger/`, `wallet/`,
`unroll/`, `serverconn/`, and `ARCHITECTURE.md`.

`make doc-check` passes on this branch.