### PR TITLE
darepocli: agent-CLI hardening across wallet, swap, ark, and dev surfaces

### DIFF
--- a/cmd/darepocli/darepoclicommands/AGENTS.md
+++ b/cmd/darepocli/darepoclicommands/AGENTS.md
@@ -106,6 +106,44 @@ who want direct access.
     `swapruntime` tag only).
 - **Depended on by**: `cmd/darepocli` (main entry point).
 
+## Agent-CLI Posture
+
+This CLI is invoked routinely by AI agents, so the design follows the
+agent-cli skill checklist (see `~/.claude/skills/agent-cli/SKILL.md`).
+The relevant pieces here:
+
+- **Machine-readable output by default**: every command emits
+  proto-JSON on stdout; diagnostics go to stderr. Errors emit a
+  structured envelope `{"error":{"code":..., "message":...}}` via
+  `PrintError`.
+- **Input hardening**: `validateDestination`, `validateOutpoint`,
+  `validateFreeText`, `validateOutpointString`, and the per-verb
+  flag-combination checks treat agent inputs as adversarial. They
+  reject query / fragment characters in destinations, embedded
+  control bytes in free-text fields, malformed outpoints, and
+  ambiguous flag combinations before any RPC dispatch.
+- **Dry-run safety rails for mutating verbs**: `send` and `exit`
+  accept `--dry-run`, which runs every local validation and prints a
+  `{"dry_run":true,"method":..., "body":...}` preview on stdout
+  without dispatching the RPC. The process exits with code 10 on a
+  passing dry-run so an agent can branch on it.
+- **Semantic exit codes**: see `exit_codes.go`. 0 = success,
+  2 = invalid args (rejected client-side), 3 = wallet/auth failure,
+  4 = not found (unknown round / job / hash), 10 = dry-run passed,
+  1 = anything else. gRPC status codes from the daemon also map onto
+  this table via `ExitCodeFor`.
+- **Schema introspection**: `schema` dumps the full method registry
+  (top-level wallet verbs, ark.*, swap.*) as JSON. Each entry carries
+  a `mcp_tool` flag indicating whether the method is also exposed
+  over MCP.
+- **MCP surface**: every read-only wallet verb (`balance`, `list`,
+  `exit.status`) and every mutating wallet verb except `create` /
+  `unlock` is registered as an MCP tool via `registerMCPWalletTools`.
+  `create` / `unlock` are CLI-only by design: their inputs are
+  secrets (wallet password, seed passphrase) that must not transit
+  the MCP protocol where they could land in agent logs or provider
+  APIs.
+
 ## Invariants
 
 - The seven top-level wallet verbs ALWAYS register at the root
@@ -122,6 +160,12 @@ who want direct access.
 - JSON output (`stdout`) and diagnostic output (`stderr`) are kept on
   separate streams so shell pipelines can consume the JSON body while
   a human reading the terminal sees informative warnings.
+- The CLI and MCP surfaces share input-hardening builders
+  (`buildWalletSendRequest`, `buildWalletListRequest`,
+  `buildLeaveVTXOsRequest`, `buildOORRecipientOutput`,
+  `parseDirectionField`). Divergence between the two surfaces would
+  let one accept shapes the other rejects, so all flag-translation
+  logic for tools that exist on both lives in shared helpers.
 
 ## Deep Docs
 

--- a/cmd/darepocli/darepoclicommands/AGENTS.md
+++ b/cmd/darepocli/darepoclicommands/AGENTS.md
@@ -39,6 +39,18 @@ The CLI surface is split into three tiers:
 | `mcp` | (local) | MCP server exposing the schema as tools |
 | `dev *` | dev RPC | Generated dev RPC CLI (see `devrpc/`) |
 
+Every generated `dev <service> <method>` leaf accepts `--describe`:
+when set, it emits a JSON schema for the method's input fields and
+returns without dispatching the RPC. The schema includes the fully-
+qualified request / response type names, server-streaming bit, and
+one row per flag (path, type, repeated, oneof_group, enum_values).
+This is the agent-CLI equivalent of the root `schema` command for
+the auto-generated dev tree: agents can learn the surface of a
+proto change without recompiling or grepping `.proto` sources. The
+implementation lives in `devrpc/describe.go` and reuses the same
+fieldBinder list that powers the CLI flag surface, so the describe
+output cannot drift from what `--help` advertises.
+
 ### `ark.*` advanced commands
 
 The everyday wallet verbs compose `walletrpc` end-to-end; the `ark`

--- a/cmd/darepocli/darepoclicommands/AGENTS.md
+++ b/cmd/darepocli/darepoclicommands/AGENTS.md
@@ -67,6 +67,23 @@ who want direct access.
 | `swap resume` | `ResumeSwap` | Wake a persisted swap worker |
 | `swap watch` | `SubscribeSwaps` | Stream swap summary updates |
 
+Every swap.* verb accepts `--json` for raw proto payloads and is
+registered as an MCP tool when the binary is built with
+`-tags swapruntime`. The streaming `swap watch` verb is CLI-only;
+MCP tool calls are request/response and a long-running subscription
+fits the CLI lifecycle better. `validatePaymentHash` /
+`validateInvoice` apply on both the CLI and MCP paths to catch the
+canonical agent-hallucination patterns (whitespace, query suffixes,
+wrong-length hashes, embedded control bytes) before the daemon's
+decoder sees them.
+
+Schema entries for swap.* are listed in `schema_registry_swap.go`
+unconditionally regardless of build tag so a stub-build agent can
+still discover the surface; the CLI itself prints a clear "rebuild
+with -tags=swapruntime" error when the verb is invoked, and the
+MCP registration is what actually gets tag-gated (`mcp_swap.go` vs
+`mcp_swap_stub.go`).
+
 ## Key Types
 
 - `NewRootCmd()` — Creates the top-level cobra command with all

--- a/cmd/darepocli/darepoclicommands/AGENTS.md
+++ b/cmd/darepocli/darepoclicommands/AGENTS.md
@@ -45,6 +45,22 @@ The everyday wallet verbs compose `walletrpc` end-to-end; the `ark`
 parent surfaces the raw daemonrpc methods underlying them for callers
 who want direct access.
 
+All list-shaped `ark.*` verbs (`ark vtxos list`, `ark rounds list`,
+`ark oor list`, `ark sweep list`, `ark listtransactions`) accept
+`--fields <name1,name2,...>` to apply a field mask and `--ndjson` to
+emit one JSON object per row on its own line (newline-delimited
+JSON). Combine the two to shrink each line further. Both flags use
+the shared `renderListOutput` helper so a behavior change in one
+place flows to every list command.
+
+`ark vtxos leave --all` no longer prompts for y/N when stdin is not
+a terminal. An agent or pipeline must pass `--yes` (explicit
+consent) or `--dry_run` (preview); otherwise the command fails fast
+with an `INVALID_ARGS` envelope (exit code 2). When stdin is a TTY
+the prompt still works for operator ergonomics. The TTY check is
+exposed via the `stdinIsTTY` package variable so tests can pin both
+branches deterministically.
+
 | Command | RPC | Description |
 |---------|-----|-------------|
 | `ark vtxos {list,refresh,leave}` | `ListVTXOs` / `RefreshVTXOs` / `LeaveVTXOs` | VTXO inventory and lifecycle |

--- a/cmd/darepocli/darepoclicommands/cmd_ark.go
+++ b/cmd/darepocli/darepoclicommands/cmd_ark.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/proto"
 )
 
 // newArkCmd builds the `ark` parent that hosts the advanced low-level
@@ -67,6 +68,7 @@ func newArkListTransactionsCmd() *cobra.Command {
 		"type", "",
 		"optional type filter: boarding, round, oor, or sweep",
 	)
+	addListOutputFlags(cmd, "transaction")
 
 	return cmd
 }
@@ -120,7 +122,12 @@ func listTransactions(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("ListTransactions RPC failed: %w", err)
 	}
 
-	return printJSON(resp)
+	items := make([]proto.Message, len(resp.Transactions))
+	for i, t := range resp.Transactions {
+		items[i] = t
+	}
+
+	return renderListOutput(cmd, resp, items)
 }
 
 // parseTransactionTimeFlag parses an ISO 8601 timestamp or date-only

--- a/cmd/darepocli/darepoclicommands/cmd_exit.go
+++ b/cmd/darepocli/darepoclicommands/cmd_exit.go
@@ -34,6 +34,10 @@ func newExitCmd() *cobra.Command {
 	cmd.Flags().String("outpoint", "",
 		"VTXO outpoint to exit (txid:vout)")
 	_ = cmd.MarkFlagRequired("outpoint")
+	cmd.Flags().Bool("dry-run", false,
+		"validate inputs locally and print the preview without "+
+			"dispatching to the daemon; exits 10 on a valid "+
+			"preview, non-zero on validation failure")
 
 	cmd.AddCommand(newExitStatusCmd())
 
@@ -43,17 +47,19 @@ func newExitCmd() *cobra.Command {
 // walletExit implements the top-level `exit` verb.
 func walletExit(cmd *cobra.Command, _ []string) error {
 	outpoint, _ := cmd.Flags().GetString("outpoint")
-	if err := validateOutpoint(outpoint); err != nil {
+	if err := invalidArgs(validateOutpoint(outpoint)); err != nil {
 		return err
+	}
+
+	req := &walletrpc.ExitRequest{Outpoint: outpoint}
+
+	if dryRun, _ := cmd.Flags().GetBool("dry-run"); dryRun {
+		return walletDryRunPreview("walletrpc.WalletService/Exit", req)
 	}
 
 	return withWalletClient(
 		cmd, func(c walletrpc.WalletServiceClient) error {
-			resp, err := c.Exit(
-				cmd.Context(), &walletrpc.ExitRequest{
-					Outpoint: outpoint,
-				},
-			)
+			resp, err := c.Exit(cmd.Context(), req)
 			if err != nil {
 				return fmt.Errorf("exit: %w", err)
 			}
@@ -89,7 +95,7 @@ func newExitStatusCmd() *cobra.Command {
 // walletExitStatus implements the `exit status` subcommand.
 func walletExitStatus(cmd *cobra.Command, _ []string) error {
 	outpoint, _ := cmd.Flags().GetString("outpoint")
-	if err := validateOutpoint(outpoint); err != nil {
+	if err := invalidArgs(validateOutpoint(outpoint)); err != nil {
 		return err
 	}
 

--- a/cmd/darepocli/darepoclicommands/cmd_mcp.go
+++ b/cmd/darepocli/darepoclicommands/cmd_mcp.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/lightninglabs/darepo-client/build"
 	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/lightninglabs/darepo-client/rpc/walletrpc"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -51,6 +52,11 @@ func mcpServe(cmd *cobra.Command, _ []string) error {
 	}
 	defer conn.Close()
 
+	// The wallet verbs live on the WalletService client; reusing the
+	// existing connection keeps TLS, --no-tls, and --tlscertpath
+	// honored across both surfaces.
+	walletClient := walletrpc.NewWalletServiceClient(conn)
+
 	server := mcp.NewServer(
 		&mcp.Implementation{
 			Name:    "darepocli",
@@ -59,7 +65,10 @@ func mcpServe(cmd *cobra.Command, _ []string) error {
 		nil,
 	)
 
-	// Register all RPC tools.
+	// Register all RPC tools. The wallet-verb registrations sit
+	// above the legacy daemonrpc tools so an agent listing tools
+	// sees the everyday surface first.
+	registerMCPWalletTools(server, walletClient)
 	registerMCPTools(server, client)
 
 	// Run on stdio transport until the client disconnects.
@@ -112,14 +121,19 @@ func registerMCPTools(s *mcp.Server, client daemonrpc.DaemonServiceClient) {
 		return r, nil, err
 	})
 
-	// balance — no parameters. Mirrors the top-level `balance` CLI
-	// verb. Uses the daemonrpc.GetBalance shape (richer than the
-	// flat walletrpc.Balance) so MCP consumers see boarding /
-	// VTXO / total breakdown without needing the walletrpc tag.
+	// daemon.balance — no parameters. Uses the daemonrpc.GetBalance
+	// shape (boarding + VTXO + total breakdown) and lives under the
+	// `daemon.*` namespace so the everyday flat `balance` tool that
+	// registerMCPWalletTools registers (walletrpc.Balance shape) is
+	// not silently overwritten by this richer-but-legacy registration.
+	// AddTool replaces tools on name collision, so the two names have
+	// to be distinct or the agent surface lies about which shape it
+	// returns.
 	type balanceArgs struct{}
 	mcp.AddTool(s, &mcp.Tool{
-		Name:        "balance",
-		Description: "Display wallet balance (boarding + VTXO + total)",
+		Name: "daemon.balance",
+		Description: "Display the daemonrpc balance breakdown " +
+			"(boarding + VTXO + total)",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, _ balanceArgs) (
 		*mcp.CallToolResult, any, error) {
 

--- a/cmd/darepocli/darepoclicommands/cmd_mcp.go
+++ b/cmd/darepocli/darepoclicommands/cmd_mcp.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/lightninglabs/darepo-client/build"
 	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/lightninglabs/darepo-client/rpc/swapclientrpc"
 	"github.com/lightninglabs/darepo-client/rpc/walletrpc"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/spf13/cobra"
@@ -67,8 +68,13 @@ func mcpServe(cmd *cobra.Command, _ []string) error {
 
 	// Register all RPC tools. The wallet-verb registrations sit
 	// above the legacy daemonrpc tools so an agent listing tools
-	// sees the everyday surface first.
+	// sees the everyday surface first. registerMCPSwapTools is a
+	// no-op in non-swapruntime builds (see mcp_swap_stub.go) so the
+	// MCP server only advertises swap.* tools when the daemon was
+	// built with the matching tag.
+	swapClient := swapclientrpc.NewSwapClientServiceClient(conn)
 	registerMCPWalletTools(server, walletClient)
+	registerMCPSwapTools(server, swapClient)
 	registerMCPTools(server, client)
 
 	// Run on stdio transport until the client disconnects.

--- a/cmd/darepocli/darepoclicommands/cmd_oor.go
+++ b/cmd/darepocli/darepoclicommands/cmd_oor.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/proto"
 )
 
 // newOORCmd creates the oor parent command with receive-target subcommands.
@@ -56,6 +57,7 @@ func newOORListCmd() *cobra.Command {
 		"maximum number of sessions to return")
 	cmd.Flags().String("page-token", "",
 		"cursor from a previous response for pagination")
+	addListOutputFlags(cmd, "OOR session")
 
 	return cmd
 }
@@ -147,7 +149,12 @@ func oorList(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("ListOORSessions RPC failed: %w", err)
 	}
 
-	return printJSON(resp)
+	items := make([]proto.Message, len(resp.Sessions))
+	for i, s := range resp.Sessions {
+		items[i] = s
+	}
+
+	return renderListOutput(cmd, resp, items)
 }
 
 // oorReceive executes the NewReceiveScript RPC.

--- a/cmd/darepocli/darepoclicommands/cmd_recv.go
+++ b/cmd/darepocli/darepoclicommands/cmd_recv.go
@@ -50,20 +50,23 @@ func newRecvCmd() *cobra.Command {
 func walletRecv(cmd *cobra.Command, _ []string) error {
 	offchain, err := resolveOffchainFlag(cmd)
 	if err != nil {
-		return err
+		return invalidArgs(err)
 	}
 
 	amt, _ := cmd.Flags().GetUint64("amt")
 	memo, _ := cmd.Flags().GetString("memo")
 	amtHint, _ := cmd.Flags().GetUint64("amt_hint")
 
-	if err := validateFreeText("--memo", memo); err != nil {
+	if err := invalidArgs(validateFreeText("--memo", memo)); err != nil {
 		return err
 	}
 
 	if offchain && amt == 0 {
-		return fmt.Errorf("--amt is required for offchain recv (use " +
-			"--onchain for a boarding address without an amount)")
+		return PrintError(
+			"INVALID_ARGS", "--amt is required for offchain "+
+				"recv (use --onchain for a boarding "+
+				"address without an amount)",
+		)
 	}
 
 	return withWalletClient(

--- a/cmd/darepocli/darepoclicommands/cmd_rounds.go
+++ b/cmd/darepocli/darepoclicommands/cmd_rounds.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/proto"
 )
 
 // newRoundsCmd creates the rounds parent command with list and watch
@@ -64,6 +65,7 @@ func newRoundsListCmd() *cobra.Command {
 		"only show persisted rounds created at or after this Unix time")
 	cmd.Flags().Int64("created-before", 0,
 		"only show persisted rounds created before this Unix time")
+	addListOutputFlags(cmd, "round")
 
 	return cmd
 }
@@ -173,7 +175,12 @@ func roundsList(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("ListRounds RPC failed: %w", err)
 	}
 
-	return printJSON(resp)
+	items := make([]proto.Message, len(resp.Rounds))
+	for i, r := range resp.Rounds {
+		items[i] = r
+	}
+
+	return renderListOutput(cmd, resp, items)
 }
 
 // roundsJoin executes the JoinNextRound RPC and prints the result.

--- a/cmd/darepocli/darepoclicommands/cmd_schema.go
+++ b/cmd/darepocli/darepoclicommands/cmd_schema.go
@@ -54,11 +54,9 @@ func schemaRun(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	PrintError(
+	return PrintError(
 		"METHOD_NOT_FOUND", fmt.Sprintf("unknown method %q; run "+
 			"'darepocli schema' to list available methods",
 			methodName),
 	)
-
-	return fmt.Errorf("unknown method: %s", methodName)
 }

--- a/cmd/darepocli/darepoclicommands/cmd_send.go
+++ b/cmd/darepocli/darepoclicommands/cmd_send.go
@@ -55,6 +55,10 @@ func newSendCmd() *cobra.Command {
 	cmd.Flags().Bool("sweep-all", false,
 		"onchain only: drain the wallet to the destination. "+
 			"--amt MUST be 0 when set.")
+	cmd.Flags().Bool("dry-run", false,
+		"validate inputs locally and print the preview without "+
+			"dispatching to the daemon; exits 10 on a valid "+
+			"preview, non-zero on validation failure")
 
 	return cmd
 }
@@ -62,13 +66,13 @@ func newSendCmd() *cobra.Command {
 // walletSend implements the top-level `send` verb.
 func walletSend(cmd *cobra.Command, args []string) error {
 	dest := args[0]
-	if err := validateDestination(dest); err != nil {
+	if err := invalidArgs(validateDestination(dest)); err != nil {
 		return err
 	}
 
 	offchain, err := resolveOffchainFlag(cmd)
 	if err != nil {
-		return err
+		return invalidArgs(err)
 	}
 
 	amt, _ := cmd.Flags().GetUint64("amt")
@@ -76,7 +80,7 @@ func walletSend(cmd *cobra.Command, args []string) error {
 	note, _ := cmd.Flags().GetString("note")
 	sweepAll, _ := cmd.Flags().GetBool("sweep-all")
 
-	if err := validateFreeText("--note", note); err != nil {
+	if err := invalidArgs(validateFreeText("--note", note)); err != nil {
 		return err
 	}
 
@@ -85,8 +89,10 @@ func walletSend(cmd *cobra.Command, args []string) error {
 	// silently-ignored flag and so a typo (forgot --onchain) gets
 	// a clear error rather than a no-op invoice send.
 	if offchain && sweepAll {
-		return fmt.Errorf("--sweep-all is only valid with --onchain " +
-			"(invoice sends drain no VTXO set)")
+		return PrintError(
+			"INVALID_ARGS", "--sweep-all is only valid with "+
+				"--onchain (invoice sends drain no VTXO set)",
+		)
 	}
 
 	// Onchain-only invariants: --sweep-all <=> amt==0. Enforce up
@@ -94,12 +100,18 @@ func walletSend(cmd *cobra.Command, args []string) error {
 	if !offchain {
 		switch {
 		case sweepAll && amt != 0:
-			return fmt.Errorf("--sweep-all requires --amt=0 (amt " +
-				"is implied by sweeping every live VTXO)")
+			return PrintError(
+				"INVALID_ARGS", "--sweep-all requires "+
+					"--amt=0 (amt is implied by "+
+					"sweeping every live VTXO)",
+			)
 
 		case !sweepAll && amt == 0:
-			return fmt.Errorf("--amt is required for onchain " +
-				"sends (use --sweep-all to drain the wallet)")
+			return PrintError(
+				"INVALID_ARGS", "--amt is required for "+
+					"onchain sends (use --sweep-all to "+
+					"drain the wallet)",
+			)
 		}
 	}
 
@@ -115,6 +127,15 @@ func walletSend(cmd *cobra.Command, args []string) error {
 		req.Destination = &walletrpc.SendRequest_OnchainAddress{
 			OnchainAddress: dest,
 		}
+	}
+
+	// --dry-run validates every invariant we just enforced and prints
+	// the proto-JSON preview without dispatching. Returning a code-10
+	// printedError lets main.go signal "dry-run passed" distinctly
+	// from a real send so an agent can stage a payment without
+	// risking a duplicate dispatch.
+	if dryRun, _ := cmd.Flags().GetBool("dry-run"); dryRun {
+		return walletDryRunPreview("walletrpc.WalletService/Send", req)
 	}
 
 	return withWalletClient(

--- a/cmd/darepocli/darepoclicommands/cmd_swap_rpc.go
+++ b/cmd/darepocli/darepoclicommands/cmd_swap_rpc.go
@@ -3,7 +3,6 @@
 package darepoclicommands
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -12,6 +11,13 @@ import (
 	"github.com/lightninglabs/darepo-client/rpc/swapclientrpc"
 	"github.com/spf13/cobra"
 )
+
+// errPaymentHashRequired is the shared message for swap show / resume
+// when neither the positional arg nor the --json input supplies a
+// payment_hash. Lifted out of the inline string concatenations so the
+// llformat wrapping cannot split the token name across a line.
+const errPaymentHashRequired = "payment_hash is required: pass the " +
+	"positional argument or --json with payment_hash"
 
 func newSwapCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -43,14 +49,20 @@ func newSwapListCmd() *cobra.Command {
 			}
 			defer conn.Close()
 
-			pendingOnly, _ := cmd.Flags().GetBool("pending")
+			req := &swapclientrpc.ListSwapsRequest{}
+			if err := parseRequest(cmd, req, func() error {
+				pendingOnly, _ := cmd.Flags().GetBool("pending")
+				req.PendingOnly = pendingOnly
 
-			resp, err := client.ListSwaps(
-				context.Background(),
-				&swapclientrpc.ListSwapsRequest{
-					PendingOnly: pendingOnly,
-				},
-			)
+				return nil
+			}); err != nil {
+				return err
+			}
+
+			// Use cmd.Context() so Ctrl+C / SIGTERM cancels the
+			// RPC. context.Background() here would leave the
+			// gRPC call running until the daemon responds.
+			resp, err := client.ListSwaps(cmd.Context(), req)
 			if err != nil {
 				return mapSwapRuntimeRPCError(err)
 			}
@@ -66,13 +78,15 @@ func newSwapListCmd() *cobra.Command {
 }
 
 // newSwapShowCmd builds the daemon-backed command that fetches one persisted
-// swap by payment hash. This exercises the GetSwap RPC directly instead of
-// teaching the CLI how to inspect the daemon-owned swap database.
+// swap by payment hash. The positional arg is OPTIONAL at the cobra layer so
+// an agent can drive the verb entirely through `--json`; the actual
+// payment_hash requirement is enforced after parseRequest returns so it
+// applies on both the positional and the --json path.
 func newSwapShowCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "show [payment_hash]",
 		Short: "Show one persisted Lightning swap session",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, conn, err := getSwapClient(cmd)
 			if err != nil {
@@ -80,12 +94,31 @@ func newSwapShowCmd() *cobra.Command {
 			}
 			defer conn.Close()
 
-			resp, err := client.GetSwap(
-				context.Background(),
-				&swapclientrpc.GetSwapRequest{
-					PaymentHash: args[0],
-				},
-			)
+			req := &swapclientrpc.GetSwapRequest{}
+			if err := parseRequest(cmd, req, func() error {
+				if len(args) != 1 {
+					return PrintError(
+						"INVALID_ARGS",
+						errPaymentHashRequired,
+					)
+				}
+				req.PaymentHash = args[0]
+
+				return nil
+			}); err != nil {
+				return err
+			}
+
+			// Post-parse validation runs on both the flag and
+			// --json paths so a malformed payment_hash slipping
+			// in via --json is still caught client-side.
+			if err := validatePaymentHash(
+				req.PaymentHash,
+			); err != nil {
+				return PrintError("INVALID_ARGS", err.Error())
+			}
+
+			resp, err := client.GetSwap(cmd.Context(), req)
 			if err != nil {
 				return mapSwapRuntimeRPCError(err)
 			}
@@ -111,14 +144,29 @@ func newSwapReceiveCmd() *cobra.Command {
 			}
 			defer conn.Close()
 
-			amount, _ := cmd.Flags().GetInt64("amount")
+			req := &swapclientrpc.StartReceiveRequest{}
+			if err := parseRequest(cmd, req, func() error {
+				amount, _ := cmd.Flags().GetInt64("amount")
+				req.AmountSat = amount
 
-			resp, err := client.StartReceive(
-				context.Background(),
-				&swapclientrpc.StartReceiveRequest{
-					AmountSat: amount,
-				},
-			)
+				return nil
+			}); err != nil {
+				return err
+			}
+
+			// Validate after parseRequest so the requirement
+			// applies whether the amount came from --amount or
+			// from --json.
+			if req.AmountSat <= 0 {
+				return PrintError(
+					"INVALID_ARGS", "amount_sat must "+
+						"be positive (pass "+
+						"--amount or --json with a "+
+						"positive amount_sat)",
+				)
+			}
+
+			resp, err := client.StartReceive(cmd.Context(), req)
 			if err != nil {
 				return mapSwapRuntimeRPCError(err)
 			}
@@ -127,9 +175,11 @@ func newSwapReceiveCmd() *cobra.Command {
 		},
 	}
 
+	// --amount is no longer cobra-required because that fires
+	// before RunE and blocks the --json path. The post-parse check
+	// above does the equivalent validation on both surfaces.
 	cmd.Flags().Int64("amount", 0,
-		"amount in satoshis to receive (required)")
-	_ = cmd.MarkFlagRequired("amount")
+		"amount in satoshis to receive (required; or pass via --json)")
 
 	return cmd
 }
@@ -148,16 +198,26 @@ func newSwapPayCmd() *cobra.Command {
 			}
 			defer conn.Close()
 
-			invoice, _ := cmd.Flags().GetString("invoice")
-			maxFee, _ := cmd.Flags().GetUint64("maxfee")
+			req := &swapclientrpc.StartPayRequest{}
+			if err := parseRequest(cmd, req, func() error {
+				invoice, _ := cmd.Flags().GetString("invoice")
+				maxFee, _ := cmd.Flags().GetUint64("maxfee")
+				req.Invoice = invoice
+				req.MaxFeeSat = maxFee
 
-			resp, err := client.StartPay(
-				context.Background(),
-				&swapclientrpc.StartPayRequest{
-					Invoice:   invoice,
-					MaxFeeSat: maxFee,
-				},
-			)
+				return nil
+			}); err != nil {
+				return err
+			}
+
+			// Validate invoice on both flag and --json paths so
+			// the agent-cli input-hardening contract holds even
+			// when an agent submits the request as raw JSON.
+			if err := validateInvoice(req.Invoice); err != nil {
+				return PrintError("INVALID_ARGS", err.Error())
+			}
+
+			resp, err := client.StartPay(cmd.Context(), req)
 			if err != nil {
 				return mapSwapRuntimeRPCError(err)
 			}
@@ -166,9 +226,10 @@ func newSwapPayCmd() *cobra.Command {
 		},
 	}
 
+	// --invoice is no longer cobra-required to keep the --json path
+	// reachable; validateInvoice runs post-parse on both surfaces.
 	cmd.Flags().String("invoice", "",
-		"BOLT-11 Lightning invoice to pay (required)")
-	_ = cmd.MarkFlagRequired("invoice")
+		"BOLT-11 Lightning invoice to pay (required; or via --json)")
 	cmd.Flags().Uint64("maxfee", 0,
 		"maximum fee in satoshis (0 = no limit)")
 
@@ -182,7 +243,7 @@ func newSwapResumeCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "resume [payment_hash]",
 		Short: "Resume a persisted Lightning swap session",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, conn, err := getSwapClient(cmd)
 			if err != nil {
@@ -190,19 +251,50 @@ func newSwapResumeCmd() *cobra.Command {
 			}
 			defer conn.Close()
 
-			direction, _ := cmd.Flags().GetString("direction")
-			rpcDirection, err := parseSwapRPCDirection(direction)
-			if err != nil {
+			req := &swapclientrpc.ResumeSwapRequest{}
+			if err := parseRequest(cmd, req, func() error {
+				if len(args) != 1 {
+					return PrintError(
+						"INVALID_ARGS",
+						errPaymentHashRequired,
+					)
+				}
+				req.PaymentHash = args[0]
+
+				direction, _ := cmd.Flags().GetString(
+					"direction",
+				)
+				rpcDirection, err := parseSwapRPCDirection(
+					direction,
+				)
+				if err != nil {
+					return PrintError(
+						"INVALID_ARGS", err.Error(),
+					)
+				}
+				req.Direction = rpcDirection
+
+				return nil
+			}); err != nil {
 				return err
 			}
 
-			resp, err := client.ResumeSwap(
-				context.Background(),
-				&swapclientrpc.ResumeSwapRequest{
-					PaymentHash: args[0],
-					Direction:   rpcDirection,
-				},
-			)
+			// Post-parse validation: payment_hash and direction
+			// are required on both the flag and --json paths.
+			if err := validatePaymentHash(
+				req.PaymentHash,
+			); err != nil {
+				return PrintError("INVALID_ARGS", err.Error())
+			}
+			if req.Direction ==
+				swapclientrpc.SwapDirection_SWAP_DIRECTION_UNSPECIFIED {
+				return PrintError(
+					"INVALID_ARGS", "direction is "+
+						"required (pay or receive)",
+				)
+			}
+
+			resp, err := client.ResumeSwap(cmd.Context(), req)
 			if err != nil {
 				return mapSwapRuntimeRPCError(err)
 			}
@@ -211,9 +303,11 @@ func newSwapResumeCmd() *cobra.Command {
 		},
 	}
 
+	// --direction is no longer cobra-required; post-parse validation
+	// enforces it on both the flag and --json paths.
 	cmd.Flags().String("direction", "",
-		"swap direction to resume: pay or receive (required)")
-	_ = cmd.MarkFlagRequired("direction")
+		"swap direction to resume: pay or receive "+
+			"(required; or via --json)")
 
 	return cmd
 }
@@ -232,17 +326,22 @@ func newSwapWatchCmd() *cobra.Command {
 			}
 			defer conn.Close()
 
-			pendingOnly, _ := cmd.Flags().GetBool("pending")
-			includeExisting, _ := cmd.Flags().GetBool(
-				"include-existing",
-			)
+			req := &swapclientrpc.SubscribeSwapsRequest{}
+			if err := parseRequest(cmd, req, func() error {
+				pendingOnly, _ := cmd.Flags().GetBool("pending")
+				includeExisting, _ := cmd.Flags().GetBool(
+					"include-existing",
+				)
+				req.PendingOnly = pendingOnly
+				req.IncludeExisting = includeExisting
+
+				return nil
+			}); err != nil {
+				return err
+			}
 
 			stream, err := client.SubscribeSwaps(
-				context.Background(),
-				&swapclientrpc.SubscribeSwapsRequest{
-					IncludeExisting: includeExisting,
-					PendingOnly:     pendingOnly,
-				},
+				cmd.Context(), req,
 			)
 			if err != nil {
 				return mapSwapRuntimeRPCError(err)
@@ -292,6 +391,10 @@ func parseSwapRPCDirection(direction string) (swapclientrpc.SwapDirection,
 	error) {
 
 	switch strings.ToLower(direction) {
+	case "":
+		return swapclientrpc.
+			SwapDirection_SWAP_DIRECTION_UNSPECIFIED, nil
+
 	case "pay":
 		return swapclientrpc.SwapDirection_SWAP_DIRECTION_PAY, nil
 

--- a/cmd/darepocli/darepoclicommands/cmd_swap_validate.go
+++ b/cmd/darepocli/darepoclicommands/cmd_swap_validate.go
@@ -1,0 +1,63 @@
+package darepoclicommands
+
+import (
+	"fmt"
+	"strings"
+)
+
+// validatePaymentHash enforces the canonical 64-char hex payment-hash
+// shape before a swap RPC ever sees it. Agents routinely paste
+// payment hashes copied out of invoices or block explorers and
+// occasionally include surrounding whitespace, a leading 0x prefix,
+// or a stray query suffix; catching those locally keeps the daemon's
+// error surface focused on real not-found cases.
+func validatePaymentHash(s string) error {
+	if s == "" {
+		return fmt.Errorf("payment_hash is required")
+	}
+	if strings.ContainsAny(s, " \t\n\r?#") {
+		return fmt.Errorf("payment_hash contains whitespace or "+
+			"query/fragment characters (got %q)", s)
+	}
+	if len(s) != 64 {
+		return fmt.Errorf("payment_hash must be 64 hex chars (got "+
+			"%d in %q)", len(s), s)
+	}
+	for _, c := range s {
+		isHex := (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') ||
+			(c >= 'A' && c <= 'F')
+		if !isHex {
+			return fmt.Errorf("payment_hash contains non-hex "+
+				"character %q", c)
+		}
+	}
+
+	return nil
+}
+
+// validateInvoice rejects obvious agent-hallucination patterns in a
+// BOLT-11 invoice string before the daemon attempts the authoritative
+// parse. We do NOT decode the bech32 envelope here: the daemon owns
+// invoice validation and the CLI just trims an early class of garbage
+// (whitespace, embedded NULs, query-string suffixes) so the daemon's
+// error surface stays focused on legitimate decode failures.
+func validateInvoice(s string) error {
+	if s == "" {
+		return fmt.Errorf("invoice is required")
+	}
+	if strings.ContainsAny(s, " \t\n\r") {
+		return fmt.Errorf("invoice contains whitespace; got %q", s)
+	}
+	if strings.ContainsAny(s, "?#") {
+		return fmt.Errorf("invoice contains query/fragment characters "+
+			"(got %q)", s)
+	}
+	for i, r := range s {
+		if r < 0x20 || r == 0x7f {
+			return fmt.Errorf("invoice contains control character "+
+				"at byte %d (0x%02x)", i, r)
+		}
+	}
+
+	return nil
+}

--- a/cmd/darepocli/darepoclicommands/cmd_swap_validate_test.go
+++ b/cmd/darepocli/darepoclicommands/cmd_swap_validate_test.go
@@ -1,0 +1,123 @@
+package darepoclicommands
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidatePaymentHashHappyPath confirms a canonical 64-hex payment
+// hash passes the validator.
+func TestValidatePaymentHashHappyPath(t *testing.T) {
+	t.Parallel()
+
+	hash := strings.Repeat("ab", 32)
+	require.NoError(t, validatePaymentHash(hash))
+}
+
+// TestValidatePaymentHashRejectsAgentHallucinations exhaustively
+// covers the agent-hallucination patterns the validator catches
+// before the daemon ever sees the payment_hash: empty, wrong length,
+// embedded whitespace, query/fragment suffix, non-hex chars.
+func TestValidatePaymentHashRejectsAgentHallucinations(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			"empty",
+			"",
+			"required",
+		},
+		{
+			"short",
+			strings.Repeat("a", 32),
+			"64 hex chars",
+		},
+		{
+			"long",
+			strings.Repeat("a", 65),
+			"64 hex chars",
+		},
+		{
+			"trailing space",
+			strings.Repeat("a", 64) + " ",
+			"whitespace",
+		},
+		{
+			"query suffix",
+			strings.Repeat("a", 60) + "?fmt",
+			"query/fragment",
+		},
+		{
+			"non-hex char",
+			strings.Repeat("a", 63) + "z",
+			"non-hex",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validatePaymentHash(tc.in)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.want)
+		})
+	}
+}
+
+// TestValidateInvoiceRejectsAgentHallucinations confirms the invoice
+// pre-screen catches the patterns the daemon's bech32 decoder would
+// otherwise have to produce confusing errors for: whitespace,
+// embedded NULs and control bytes, query/fragment suffixes.
+func TestValidateInvoiceRejectsAgentHallucinations(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			"empty",
+			"",
+			"required",
+		},
+		{
+			"whitespace",
+			"lnbcrt100 1pwlqxyz",
+			"whitespace",
+		},
+		{
+			"control char",
+			"lnbcrt100\x01pwlqxyz",
+			"control",
+		},
+		{
+			"query suffix",
+			"lnbcrt100?fmt=json",
+			"query/fragment",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateInvoice(tc.in)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.want)
+		})
+	}
+}
+
+// TestValidateInvoiceAcceptsCanonical confirms a plain BOLT-11
+// invoice passes — the validator is intentionally lax beyond
+// rejecting the early garbage class; bech32 decoding is the daemon's
+// job.
+func TestValidateInvoiceAcceptsCanonical(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, validateInvoice("lnbcrt100u1pwlqxyz"))
+}

--- a/cmd/darepocli/darepoclicommands/cmd_sweep.go
+++ b/cmd/darepocli/darepoclicommands/cmd_sweep.go
@@ -9,6 +9,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/proto"
 )
 
 // newSweepCmd creates the sweep subcommand for recovering expired boarding
@@ -64,6 +65,7 @@ func newSweepListCmd() *cobra.Command {
 			"daemon default")
 	cmd.Flags().String("page-token", "",
 		"page token returned by a previous sweep list response")
+	addListOutputFlags(cmd, "sweep")
 
 	return cmd
 }
@@ -142,7 +144,12 @@ func sweepList(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("ListBoardingSweeps RPC failed: %w", err)
 	}
 
-	return printJSON(resp)
+	items := make([]proto.Message, len(resp.Sweeps))
+	for i, s := range resp.Sweeps {
+		items[i] = s
+	}
+
+	return renderListOutput(cmd, resp, items)
 }
 
 // validateOutpointString validates the txid:index syntax accepted by sweep

--- a/cmd/darepocli/darepoclicommands/cmd_vtxos.go
+++ b/cmd/darepocli/darepoclicommands/cmd_vtxos.go
@@ -2,9 +2,9 @@ package darepoclicommands
 
 import (
 	"bufio"
-	"context"
 	"encoding/hex"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/lightninglabs/darepo-client/daemonrpc"
@@ -57,11 +57,7 @@ func newVTXOsListCmd() *cobra.Command {
 	cmd.Flags().Int64("min_amount", 0,
 		"minimum amount in sats")
 
-	cmd.Flags().String("fields", "",
-		"comma-separated field names to include")
-
-	cmd.Flags().Bool("ndjson", false,
-		"emit one JSON object per VTXO (newline-delimited)")
+	addListOutputFlags(cmd, "VTXO")
 
 	return cmd
 }
@@ -105,45 +101,20 @@ func vtxosList(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	resp, err := client.ListVTXOs(
-		context.Background(), req,
-	)
+	// cmd.Context() carries Ctrl+C / SIGTERM so the RPC actually
+	// cancels when the user interrupts the CLI. context.Background()
+	// here would orphan the request until the daemon responded.
+	resp, err := client.ListVTXOs(cmd.Context(), req)
 	if err != nil {
 		return fmt.Errorf("ListVTXOs RPC failed: %w", err)
 	}
 
-	// Parse optional output modifiers.
-	ndjson, _ := cmd.Flags().GetBool("ndjson")
-	fieldsStr, _ := cmd.Flags().GetString("fields")
-
-	// Emit newline-delimited JSON if --ndjson was specified. When
-	// combined with --fields, each line is filtered to the
-	// requested fields.
-	if ndjson {
-		items := make(
-			[]proto.Message, len(resp.Vtxos),
-		)
-		for i, v := range resp.Vtxos {
-			items[i] = v
-		}
-
-		if fieldsStr != "" {
-			fields := strings.Split(fieldsStr, ",")
-
-			return printNDJSONFields(items, fields)
-		}
-
-		return printNDJSON(items)
+	items := make([]proto.Message, len(resp.Vtxos))
+	for i, v := range resp.Vtxos {
+		items[i] = v
 	}
 
-	// Apply field mask if --fields was specified.
-	if fieldsStr != "" {
-		fields := strings.Split(fieldsStr, ",")
-
-		return printJSONFields(resp, fields)
-	}
-
-	return printJSON(resp)
+	return renderListOutput(cmd, resp, items)
 }
 
 // parseVTXOStatus converts a status string to the proto enum.
@@ -555,14 +526,21 @@ func parseDestinationValue(raw string) (*daemonrpc.LeaveDestination, error) {
 	}, nil
 }
 
-// confirmLeaveAllIfNeeded gates dispatch on an interactive y/N prompt
+// confirmLeaveAllIfNeeded gates dispatch on an explicit confirmation
 // when the resolved request selects all VTXOs. The check runs after
 // parseRequest returns so it covers both the flag-driven path and the
 // --json path; previously the prompt lived inside the flag callback
 // and an agent piping `{"all":true,...}` would silently skip the gate
 // that the bespoke-flag path enforced. Skip when --yes is set
-// (scripted use) or when req.DryRun is set (just previewing, not
-// moving funds).
+// (explicit scripted consent), when req.DryRun is set (just
+// previewing, not moving funds), or when DAREPOCLI_AGENT_MODE=1 is
+// rejected entirely.
+//
+// When stdin is not a TTY (agents, CI, pipelines), the function
+// refuses to prompt: an interactive y/N read would block forever or
+// race against piped stdin. The caller must pass --yes or --dry_run
+// explicitly. Only when stdin IS a TTY does the function fall back
+// to the interactive prompt for ergonomics during operator use.
 func confirmLeaveAllIfNeeded(cmd *cobra.Command,
 	req *daemonrpc.LeaveVTXOsRequest) error {
 
@@ -576,12 +554,62 @@ func confirmLeaveAllIfNeeded(cmd *cobra.Command,
 		return nil
 	}
 
+	// Stdin is not a TTY — refuse to prompt rather than block or
+	// race agents whose stdin is closed / piped. The agent-cli
+	// skill lists interactive prompts as an anti-pattern; this
+	// guard is the explicit replacement.
+	if !stdinIsTTY(cmd) {
+		return PrintError(
+			"INVALID_ARGS", "--all requires --yes (explicit "+
+				"consent) or --dry_run (preview) on "+
+				"non-interactive stdin; refusing to prompt "+
+				"because an agent cannot respond to y/N",
+		)
+	}
+
 	return promptLeaveAllConfirmation(cmd)
+}
+
+// stdinIsTTY is a package-level indirection over the TTY detection
+// so tests can deterministically exercise both branches without
+// depending on the process's actual stdin (which inherits from `go
+// test`'s terminal in some setups and a pipe in others).
+var stdinIsTTY = defaultStdinIsTTY
+
+// defaultStdinIsTTY reports whether the y/N prompt is safe to drive
+// on the given command, returning true when the prompt may proceed
+// and false when the caller must pass --yes or --dry_run instead.
+//
+// Two paths return true (prompt is safe):
+//
+//  1. cmd.InOrStdin() returns something other than os.Stdin. Only
+//     tests and embedded harnesses install custom stdin via
+//     cmd.SetIn; production agents do not, so a custom reader is
+//     the caller's signal that they will drive the prompt
+//     themselves (e.g. by piping a scripted "y\n").
+//
+//  2. cmd.InOrStdin() is os.Stdin and os.Stdin reports a character
+//     device, i.e. an actual terminal where the operator can answer
+//     interactively.
+//
+// All other cases (os.Stdin is a pipe / file, Stat fails) return
+// false and the caller refuses to prompt.
+func defaultStdinIsTTY(cmd *cobra.Command) bool {
+	if cmd.InOrStdin() != os.Stdin {
+		return true
+	}
+	stat, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+
+	return (stat.Mode() & os.ModeCharDevice) != 0
 }
 
 // promptLeaveAllConfirmation asks the operator to confirm a
 // --all invocation on stdin. Any answer other than "y" or "yes"
-// (case-insensitive) aborts the command.
+// (case-insensitive) aborts the command. Only called when stdin is
+// known to be a TTY (see confirmLeaveAllIfNeeded).
 func promptLeaveAllConfirmation(cmd *cobra.Command) error {
 	out := cmd.OutOrStdout()
 

--- a/cmd/darepocli/darepoclicommands/cmd_vtxos.go
+++ b/cmd/darepocli/darepoclicommands/cmd_vtxos.go
@@ -84,7 +84,7 @@ func vtxosList(cmd *cobra.Command, _ []string) error {
 				statusStr,
 			)
 			if !ok {
-				PrintError(
+				return PrintError(
 					"INVALID_STATUS",
 					fmt.Sprintf(
 						"invalid status %q, valid: %s",
@@ -93,9 +93,6 @@ func vtxosList(cmd *cobra.Command, _ []string) error {
 						),
 					),
 				)
-
-				return fmt.Errorf("invalid status filter: %s",
-					statusStr)
 			}
 
 			req.StatusFilter = statusFilter

--- a/cmd/darepocli/darepoclicommands/cmd_vtxos_leave_test.go
+++ b/cmd/darepocli/darepoclicommands/cmd_vtxos_leave_test.go
@@ -326,6 +326,42 @@ func TestConfirmLeaveAllIfNeededAcceptsYes(t *testing.T) {
 	require.NoError(t, confirmLeaveAllIfNeeded(cmd, req))
 }
 
+// TestConfirmLeaveAllIfNeededNonTTYRefusesPrompt is the agent-cli
+// regression guard: when stdin is not a terminal (the production
+// agent / pipeline path), --all without --yes or --dry_run must NOT
+// hit the y/N prompt. Instead the function fails fast with an
+// INVALID_ARGS envelope so an agent gets exit code 2 and a clear
+// error directing it to pass --yes or --dry_run, rather than
+// hanging on a read of a closed stdin.
+func TestConfirmLeaveAllIfNeededNonTTYRefusesPrompt(t *testing.T) {
+	// NOT t.Parallel() — we override the package-level
+	// stdinIsTTY indirection for this test and a parallel sibling
+	// could see the override.
+
+	prev := stdinIsTTY
+	stdinIsTTY = func(*cobra.Command) bool { return false }
+	defer func() {
+		stdinIsTTY = prev
+	}()
+
+	cmd := newVTXOsLeaveCmd()
+
+	req := &daemonrpc.LeaveVTXOsRequest{
+		Selection: &daemonrpc.LeaveVTXOsRequest_All{
+			All: true,
+		},
+	}
+
+	err := confirmLeaveAllIfNeeded(cmd, req)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "--all requires --yes")
+	require.True(
+		t, ErrorWasPrinted(err),
+		"expected a printedError so main.go can exit with the "+
+			"INVALID_ARGS code",
+	)
+}
+
 // TestConfirmLeaveAllIfNeededYesFlagBypasses verifies the --yes flag
 // short-circuits the prompt for scripted use.
 func TestConfirmLeaveAllIfNeededYesFlagBypasses(t *testing.T) {

--- a/cmd/darepocli/darepoclicommands/devrpc/command.go
+++ b/cmd/darepocli/darepoclicommands/devrpc/command.go
@@ -82,6 +82,20 @@ func newMethodCmd(cfg Config, service protoreflect.FullName,
 		Long:    method.spec.Comments,
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			// --describe short-circuits dispatch and dumps the
+			// agent-CLI schema for this method. The flag is the
+			// dev tree's equivalent of the root `schema` command:
+			// it teaches an agent the exact input shape before
+			// the first invocation.
+			describe, _ := cmd.Flags().GetBool("describe")
+			if describe {
+				desc := describeMethod(
+					service, method, binders,
+				)
+
+				return printMethodDescription(desc)
+			}
+
 			return runMethod(cmd, cfg, service, method, binders)
 		},
 	}
@@ -92,6 +106,10 @@ func newMethodCmd(cfg Config, service protoreflect.FullName,
 
 	cmd.InitDefaultHelpFlag()
 	cmd.Flags().SortFlags = false
+
+	cmd.Flags().Bool("describe", false,
+		"emit the JSON schema for this method's input fields "+
+			"(does not dispatch the RPC)")
 
 	for i := range binders {
 		binders[i].register(cmd)

--- a/cmd/darepocli/darepoclicommands/devrpc/describe.go
+++ b/cmd/darepocli/darepoclicommands/devrpc/describe.go
@@ -1,0 +1,169 @@
+package devrpc
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+// methodDescription is the agent-CLI schema dump for a single
+// generated RPC method. Fields are populated from the proto
+// descriptor so a `dev <svc> <method> --describe` invocation can
+// teach an agent the exact input shape without it having to grep
+// `.proto` files. ServerStreaming is included so an agent knows
+// whether to expect a single response or a stream.
+type methodDescription struct {
+	Method          string             `json:"method"`
+	Service         string             `json:"service"`
+	RequestType     string             `json:"request_type"`
+	ResponseType    string             `json:"response_type"`
+	ServerStreaming bool               `json:"server_streaming"`
+	Fields          []fieldDescription `json:"fields"`
+}
+
+// fieldDescription is a flat record describing one (possibly nested)
+// flag the generated CLI exposes for a method. Path mirrors the
+// dotted flag name (e.g. `recipient.address`), Type echoes the proto
+// kind ("string", "bytes", "enum", ...), and OneofGroup captures the
+// proto oneof name when the field participates in one — agents lean
+// on the oneof grouping to know which flag combinations conflict.
+type fieldDescription struct {
+	Path        string   `json:"path"`
+	Type        string   `json:"type"`
+	Repeated    bool     `json:"repeated,omitempty"`
+	OneofGroup  string   `json:"oneof_group,omitempty"`
+	EnumValues  []string `json:"enum_values,omitempty"`
+	Description string   `json:"description,omitempty"`
+}
+
+// describeMethod builds the JSON schema for a method from its proto
+// descriptor and the existing fieldBinder list. Reusing the binder
+// list (instead of re-walking the descriptor) keeps the schema and
+// the flag surface in lockstep: a flag the binder doesn't register
+// can't appear in the schema, and a flag the binder DOES register
+// always does.
+func describeMethod(service protoreflect.FullName, method rpcMethod,
+	binders []fieldBinder) methodDescription {
+
+	fields := make([]fieldDescription, 0, len(binders))
+	for i := range binders {
+		fields = append(fields, describeBinder(&binders[i]))
+	}
+
+	return methodDescription{
+		Method:          string(method.spec.Name),
+		Service:         string(service),
+		RequestType:     string(method.input.FullName()),
+		ResponseType:    string(method.output.FullName()),
+		ServerStreaming: method.spec.ServerStreaming,
+		Fields:          fields,
+	}
+}
+
+// describeBinder projects a fieldBinder into its agent-CLI schema
+// row. The proto leaf descriptor carries the kind and (for enums)
+// the value list; the binder's flagName is the dotted path an agent
+// will pass on the command line.
+func describeBinder(b *fieldBinder) fieldDescription {
+	leaf := b.leaf()
+	row := fieldDescription{
+		Path:        b.flagName,
+		Type:        describeKind(leaf, b.inputKind),
+		Repeated:    leaf.IsList(),
+		Description: descriptorComment(leaf),
+	}
+
+	// Walk the binder path to pick up the deepest oneof group
+	// the field participates in. The CLI only allows one flag per
+	// oneof to be set; an agent that knows the group name can
+	// pre-emptively avoid the conflict.
+	for _, field := range b.path {
+		if oneof := field.ContainingOneof(); oneof != nil {
+			row.OneofGroup = string(oneof.Name())
+		}
+	}
+
+	if leaf.Kind() == protoreflect.EnumKind {
+		enum := leaf.Enum()
+		values := enum.Values()
+		row.EnumValues = make([]string, 0, values.Len())
+		for i := 0; i < values.Len(); i++ {
+			row.EnumValues = append(
+				row.EnumValues,
+				string(
+					values.Get(i).Name(),
+				),
+			)
+		}
+	}
+
+	return row
+}
+
+// describeKind names the field's input kind in a way that matches
+// what the CLI accepts on the wire (rather than echoing the proto
+// Kind name verbatim). `bytes` is exposed as `hex` because that's
+// what parseScalar actually decodes; messages get the `-json`
+// suffix the binder appends.
+func describeKind(field protoreflect.FieldDescriptor,
+	inputKind fieldInputKind) string {
+
+	if inputKind == fieldJSON {
+		return "json"
+	}
+
+	// Only the scalar kinds the dev tree binder actually exposes are
+	// mapped; message / group fields are surfaced as JSON above.
+	switch field.Kind() { //nolint:exhaustive
+	case protoreflect.BoolKind:
+		return "bool"
+
+	case protoreflect.StringKind:
+		return "string"
+
+	case protoreflect.BytesKind:
+		return "hex"
+
+	case protoreflect.EnumKind:
+		return "enum"
+
+	case protoreflect.Int32Kind, protoreflect.Sint32Kind,
+		protoreflect.Sfixed32Kind:
+		return "int32"
+
+	case protoreflect.Int64Kind, protoreflect.Sint64Kind,
+		protoreflect.Sfixed64Kind:
+		return "int64"
+
+	case protoreflect.Uint32Kind, protoreflect.Fixed32Kind:
+		return "uint32"
+
+	case protoreflect.Uint64Kind, protoreflect.Fixed64Kind:
+		return "uint64"
+
+	case protoreflect.FloatKind:
+		return "float32"
+
+	case protoreflect.DoubleKind:
+		return "float64"
+	}
+
+	return strings.ToLower(field.Kind().String())
+}
+
+// printMethodDescription writes the methodDescription to stdout as
+// indented JSON. Lives next to describeMethod so the describe code
+// path stays in one place.
+func printMethodDescription(desc methodDescription) error {
+	data, err := json.MarshalIndent(desc, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal describe JSON: %w", err)
+	}
+
+	fmt.Fprintln(os.Stdout, string(data))
+
+	return nil
+}

--- a/cmd/darepocli/darepoclicommands/devrpc/describe_test.go
+++ b/cmd/darepocli/darepoclicommands/devrpc/describe_test.go
@@ -1,0 +1,141 @@
+package devrpc
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestDevDescribeDumpsMethodSchema exercises the `--describe` path:
+// the command must emit a JSON schema for the method's input fields
+// without dialing the daemon. An agent that only wants to learn the
+// surface should be able to call --describe and never trigger the
+// network.
+func TestDevDescribeDumpsMethodSchema(t *testing.T) {
+	cmd, cleanup := newTestDevCmd(t, &testDaemonServer{}, &bytes.Buffer{})
+	defer cleanup()
+
+	stdout, restore := captureStdout(t)
+	defer restore()
+
+	cmd.SetArgs([]string{"daemon", "list-vtxos", "--describe"})
+	require.NoError(t, cmd.Execute())
+
+	data := stdout()
+	require.NotEmpty(t, data)
+
+	var desc methodDescription
+	require.NoError(t, json.Unmarshal(data, &desc))
+
+	require.Equal(t, "ListVTXOs", desc.Method)
+	require.Equal(t, "daemonrpc.DaemonService", desc.Service)
+	require.Equal(t, "daemonrpc.ListVTXOsRequest", desc.RequestType)
+	require.Equal(t, "daemonrpc.ListVTXOsResponse", desc.ResponseType)
+	require.False(t, desc.ServerStreaming)
+
+	// status_filter is an enum field — describe should surface
+	// the enum value list so an agent doesn't have to grep proto
+	// sources for the legal names.
+	var statusField *fieldDescription
+	for i := range desc.Fields {
+		if desc.Fields[i].Path == "status_filter" {
+			statusField = &desc.Fields[i]
+
+			break
+		}
+	}
+	require.NotNil(t, statusField, "status_filter must appear in schema")
+	require.Equal(t, "enum", statusField.Type)
+	require.Contains(t, statusField.EnumValues, "VTXO_STATUS_LIVE")
+}
+
+// TestDevDescribeRespectsOneofGroup confirms describe records the
+// containing oneof for fields that are mutually exclusive — agents
+// rely on this signal to know which flag combinations conflict.
+func TestDevDescribeRespectsOneofGroup(t *testing.T) {
+	cmd, cleanup := newTestDevCmd(t, &testDaemonServer{}, &bytes.Buffer{})
+	defer cleanup()
+
+	stdout, restore := captureStdout(t)
+	defer restore()
+
+	cmd.SetArgs([]string{"daemon", "send-oor", "--describe"})
+	require.NoError(t, cmd.Execute())
+
+	var desc methodDescription
+	require.NoError(t, json.Unmarshal(stdout(), &desc))
+
+	// The recipient message has a oneof for destination
+	// (address / pubkey / pk_script). At least one of those
+	// nested fields must carry the oneof group name in the
+	// schema.
+	var sawOneof bool
+	for _, f := range desc.Fields {
+		if f.OneofGroup != "" && strings.HasPrefix(
+			f.Path, "recipient.",
+		) {
+
+			sawOneof = true
+
+			break
+		}
+	}
+	require.True(
+		t, sawOneof, "expected at least one recipient.* field to "+
+			"carry an oneof_group annotation; got %+v", desc.Fields,
+	)
+}
+
+// captureStdout redirects os.Stdout into a pipe for the duration of
+// the test and returns a getter for the captured bytes plus a
+// restoration func. Tests need this because printMethodDescription
+// writes directly to os.Stdout (matching the other dev commands),
+// not through the cmd's writer.
+//
+// The getter closes the pipe's write end before draining the read
+// goroutine so io.Copy in the reader sees EOF; the deferred restore
+// is idempotent so callers can keep their normal defer-restore
+// pattern without deadlocking on a double-close.
+func captureStdout(t *testing.T) (func() []byte, func()) {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	orig := os.Stdout
+	os.Stdout = w
+
+	done := make(chan []byte, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.Bytes()
+	}()
+
+	var closed bool
+	closeWriter := func() {
+		if closed {
+			return
+		}
+		closed = true
+		_ = w.Close()
+	}
+
+	restore := func() {
+		closeWriter()
+		os.Stdout = orig
+	}
+
+	getter := func() []byte {
+		closeWriter()
+
+		return <-done
+	}
+
+	return getter, restore
+}

--- a/cmd/darepocli/darepoclicommands/exit_codes.go
+++ b/cmd/darepocli/darepoclicommands/exit_codes.go
@@ -1,0 +1,163 @@
+package darepoclicommands
+
+import (
+	"errors"
+	"strings"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Exit codes follow the agent-cli skill's semantic-exit-code table so
+// agents can branch on the failure category without parsing prose.
+// 0 is success and is set by cobra implicitly when RunE returns nil.
+const (
+	// ExitGenericError is the catch-all failure code.
+	ExitGenericError = 1
+
+	// ExitInvalidArgs indicates the CLI rejected the invocation
+	// before reaching the daemon: missing required flag, malformed
+	// outpoint, conflicting --offchain/--onchain, etc.
+	ExitInvalidArgs = 2
+
+	// ExitAuthFailure indicates a wallet authentication failure
+	// (wrong password, locked wallet on a verb that requires it).
+	ExitAuthFailure = 3
+
+	// ExitNotFound indicates a queried resource does not exist on the
+	// daemon (unknown round id, missing exit job, etc.).
+	ExitNotFound = 4
+
+	// ExitDryRunOK indicates a --dry-run invocation passed all local
+	// validation; no RPC was dispatched.
+	ExitDryRunOK = 10
+)
+
+// cliError wraps an underlying error with the exit code that main.go
+// should return when the command bubbles the error out. Use New /
+// Wrap to attach a code; everything else stays as a normal error.
+type cliError struct {
+	code int
+	err  error
+}
+
+// newCLIError attaches an exit code to a fresh error.
+func newCLIError(code int, err error) error {
+	if err == nil {
+		return nil
+	}
+
+	return &cliError{code: code, err: err}
+}
+
+// Error returns the underlying error message.
+func (e *cliError) Error() string {
+	return e.err.Error()
+}
+
+// Unwrap exposes the underlying error so errors.Is / errors.As keep
+// working across the wrapper.
+func (e *cliError) Unwrap() error {
+	return e.err
+}
+
+// ExitCodeFor returns the exit code main.go should use for err. The
+// mapping is: explicit cliError code wins, then printedError's own
+// code-derived mapping; otherwise gRPC status codes map to the
+// closest semantic exit code; otherwise generic.
+func ExitCodeFor(err error) int {
+	if err == nil {
+		return 0
+	}
+
+	var ce *cliError
+	if errors.As(err, &ce) {
+		return ce.code
+	}
+
+	var pe *printedError
+	if errors.As(err, &pe) {
+		return pe.ExitCode()
+	}
+
+	// Map common gRPC status codes that the daemon returns onto the
+	// semantic exit codes the agent-cli skill prescribes. Anything
+	// not in this map falls through to the generic code so agents
+	// can still branch on the obvious cases without us needing to
+	// enumerate every daemon-side failure.
+	if s, ok := status.FromError(err); ok {
+		// Only the common cases are mapped; everything else falls
+		// through to ExitGenericError on purpose.
+		switch s.Code() { //nolint:exhaustive
+		case codes.InvalidArgument, codes.OutOfRange,
+			codes.FailedPrecondition:
+			return ExitInvalidArgs
+
+		case codes.Unauthenticated, codes.PermissionDenied:
+			return ExitAuthFailure
+
+		case codes.NotFound:
+			return ExitNotFound
+		}
+	}
+
+	// Cobra and pflag don't expose stable error sentinels for their
+	// pre-RunE validation failures (missing required flag, unknown
+	// flag, wrong positional count, invalid flag value). Treating
+	// them all as ExitGenericError would force agents to parse the
+	// prose to learn this was a flag-shape failure, so we classify
+	// by message prefix here. The set of prefixes is finite and
+	// listed in IsCobraArgError; everything else stays generic.
+	if IsCobraArgError(err) {
+		return ExitInvalidArgs
+	}
+
+	return ExitGenericError
+}
+
+// IsCobraArgError reports whether err looks like a cobra or pflag
+// pre-RunE validation failure. main.go uses this to emit an
+// INVALID_ARGS structured envelope (instead of the generic
+// EXECUTION_FAILED) so the stderr surface matches the
+// exit-code-2 mapping ExitCodeFor returns for the same error.
+func IsCobraArgError(err error) bool {
+	if err == nil {
+		return false
+	}
+	// Already-classified errors keep their original mapping; this
+	// helper is only for the bare-message cobra/pflag cases.
+	var ce *cliError
+	if errors.As(err, &ce) {
+		return false
+	}
+	var pe *printedError
+	if errors.As(err, &pe) {
+		return false
+	}
+
+	msg := err.Error()
+	for _, prefix := range cobraArgErrorPrefixes {
+		if strings.HasPrefix(msg, prefix) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// cobraArgErrorPrefixes lists the message prefixes cobra and pflag
+// use for their pre-RunE validation failures. The list mirrors the
+// fmt.Errorf calls in github.com/spf13/cobra and
+// github.com/spf13/pflag as of v1.10 / v1.0 respectively.
+var cobraArgErrorPrefixes = []string{
+	"required flag(s)",        // pflag: missing required flag
+	"unknown flag:",           // pflag: unrecognized flag
+	"unknown shorthand flag:", // pflag: unrecognized -x
+	"invalid argument",        // pflag: bad value for typed flag
+	"unknown command",         // cobra: unknown subcommand
+	"accepts ",                // cobra: ExactArgs/MaximumNArgs et al.
+	"requires at least",       // cobra: MinimumNArgs
+	"requires between",        // cobra: RangeArgs
+	"subcommand is required",  // cobra: NoArgs on a parent
+	"if any flags in the group",
+}

--- a/cmd/darepocli/darepoclicommands/exit_codes_test.go
+++ b/cmd/darepocli/darepoclicommands/exit_codes_test.go
@@ -1,0 +1,198 @@
+package darepoclicommands
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestExitCodeForCLIError verifies the explicit cliError exit codes
+// take precedence and survive errors.As-style wrapping.
+func TestExitCodeForCLIError(t *testing.T) {
+	t.Parallel()
+
+	err := newCLIError(ExitDryRunOK, errors.New("preview"))
+
+	require.Equal(t, ExitDryRunOK, ExitCodeFor(err))
+	require.Equal(t, "preview", err.Error())
+}
+
+// TestExitCodeForPrintedError verifies the printedError returned from
+// PrintError participates in the same exit-code mapping so callers
+// that `return PrintError(...)` get the right semantic code.
+func TestExitCodeForPrintedError(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		code     string
+		expected int
+	}{
+		{
+			"INVALID_STATUS",
+			ExitInvalidArgs,
+		},
+		{
+			"INVALID_OUTPOINT",
+			ExitInvalidArgs,
+		},
+		{
+			"AUTH_FAILURE",
+			ExitAuthFailure,
+		},
+		{
+			"METHOD_NOT_FOUND",
+			ExitNotFound,
+		},
+		{
+			"DRY_RUN_OK",
+			ExitDryRunOK,
+		},
+		{
+			"SOMETHING_ELSE",
+			ExitGenericError,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.code, func(t *testing.T) {
+			err := &printedError{code: tc.code, msg: "x"}
+			require.Equal(t, tc.expected, ExitCodeFor(err))
+			require.True(t, ErrorWasPrinted(err))
+		})
+	}
+}
+
+// TestExitCodeForGRPCStatus verifies daemon-returned gRPC status
+// codes map onto the matching semantic exit codes so agents can
+// branch on the failure category without parsing message prose.
+func TestExitCodeForGRPCStatus(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		code     codes.Code
+		expected int
+	}{
+		{
+			codes.InvalidArgument,
+			ExitInvalidArgs,
+		},
+		{
+			codes.OutOfRange,
+			ExitInvalidArgs,
+		},
+		{
+			codes.FailedPrecondition,
+			ExitInvalidArgs,
+		},
+		{
+			codes.Unauthenticated,
+			ExitAuthFailure,
+		},
+		{
+			codes.PermissionDenied,
+			ExitAuthFailure,
+		},
+		{
+			codes.NotFound,
+			ExitNotFound,
+		},
+		{
+			codes.Unavailable,
+			ExitGenericError,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.code.String(), func(t *testing.T) {
+			err := status.Error(tc.code, "x")
+			require.Equal(t, tc.expected, ExitCodeFor(err))
+		})
+	}
+}
+
+// TestExitCodeForNil confirms the zero-error path returns 0 so a
+// successful run from main.go doesn't accidentally exit non-zero.
+func TestExitCodeForNil(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, 0, ExitCodeFor(nil))
+	require.False(t, ErrorWasPrinted(nil))
+}
+
+// TestExitCodeForCobraArgError covers the cobra/pflag pre-RunE
+// validation classifier. Each prefix the upstream libraries emit
+// must map onto ExitInvalidArgs so an agent that passes the wrong
+// flags sees exit code 2 instead of the generic 1.
+func TestExitCodeForCobraArgError(t *testing.T) {
+	t.Parallel()
+
+	cases := []string{
+		"required flag(s) \"outpoint\" not set",
+		"unknown flag: --bogus",
+		"unknown shorthand flag: 'q' in -q",
+		"invalid argument \"foo\" for \"--amt\"",
+		"unknown command \"shrug\" for \"darepocli\"",
+		"accepts 1 arg(s), received 0",
+		"requires at least 1 arg(s), received 0",
+		"requires between 1 and 3 arg(s), received 5",
+		"subcommand is required",
+	}
+
+	for _, msg := range cases {
+		t.Run(msg, func(t *testing.T) {
+			err := errors.New(msg)
+			require.True(t, IsCobraArgError(err))
+			require.Equal(t, ExitInvalidArgs, ExitCodeFor(err))
+		})
+	}
+}
+
+// TestIsCobraArgErrorSkipsClassifiedWrappers confirms that errors
+// already carrying a cliError or printedError exit code are NOT
+// re-classified as cobra errors. The wrapper's code wins.
+func TestIsCobraArgErrorSkipsClassifiedWrappers(t *testing.T) {
+	t.Parallel()
+
+	// A printedError whose message happens to start with a cobra
+	// prefix should still keep its own ExitCode.
+	pe := &printedError{
+		code: "DRY_RUN_OK",
+		msg:  "required flag(s) \"x\" not set",
+	}
+	require.False(t, IsCobraArgError(pe))
+	require.Equal(t, ExitDryRunOK, ExitCodeFor(pe))
+
+	// A cliError wrapping a cobra-shaped message: the wrapper's
+	// explicit code wins.
+	ce := newCLIError(
+		ExitAuthFailure, errors.New("unknown flag: --x"),
+	)
+	require.False(t, IsCobraArgError(ce))
+	require.Equal(t, ExitAuthFailure, ExitCodeFor(ce))
+}
+
+// TestIsCobraArgErrorIgnoresUnrelated guards against the prefix
+// classifier accidentally swallowing a plain error whose message
+// happens to share a leading word with cobra's vocabulary but is
+// actually unrelated (an RPC failure, a network error, etc.).
+func TestIsCobraArgErrorIgnoresUnrelated(t *testing.T) {
+	t.Parallel()
+
+	cases := []string{
+		"daemon unreachable: connection refused",
+		"unrelated error",
+		"a flag set incorrectly somewhere",
+	}
+
+	for _, msg := range cases {
+		t.Run(msg, func(t *testing.T) {
+			err := errors.New(msg)
+			require.False(t, IsCobraArgError(err))
+		})
+	}
+
+	require.False(t, IsCobraArgError(nil))
+}

--- a/cmd/darepocli/darepoclicommands/list_output.go
+++ b/cmd/darepocli/darepoclicommands/list_output.go
@@ -1,0 +1,63 @@
+package darepoclicommands
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/proto"
+)
+
+// addListOutputFlags registers the standard --fields / --ndjson flags
+// that every list-shaped ark.* command needs to give agents
+// context-window discipline over potentially-large responses. Inline
+// duplication across cmd_vtxos.go, cmd_rounds.go, cmd_oor.go,
+// cmd_sweep.go, and cmd_ark.go would let one of them silently drift
+// past the documented behavior.
+func addListOutputFlags(cmd *cobra.Command, itemName string) {
+	cmd.Flags().String("fields", "",
+		"comma-separated field names to include (response is "+
+			"filtered before printing)")
+	cmd.Flags().Bool("ndjson", false,
+		fmt.Sprintf("emit one JSON object per %s (newline-delimited); "+
+			"pairs with --fields to shrink each line further",
+			itemName))
+}
+
+// renderListOutput emits resp as proto-JSON, applying the --fields
+// field mask and the --ndjson streaming flag the agent set. items is
+// the repeated payload on resp (one proto.Message per row); pass nil
+// to disable --ndjson on responses that don't carry a list shape.
+// The behavior mirrors what vtxos list shipped first:
+//
+//   - --ndjson alone: print one JSON object per item on its own line.
+//   - --ndjson with --fields: print each item filtered to the named
+//     fields.
+//   - --fields alone: print the whole response filtered to the named
+//     top-level keys (or, if a top-level repeated array is present,
+//     the named fields on each element).
+//   - neither: print the full response on stdout.
+func renderListOutput(cmd *cobra.Command, resp proto.Message,
+	items []proto.Message) error {
+
+	ndjson, _ := cmd.Flags().GetBool("ndjson")
+	fieldsStr, _ := cmd.Flags().GetString("fields")
+
+	if ndjson && items != nil {
+		if fieldsStr != "" {
+			fields := strings.Split(fieldsStr, ",")
+
+			return printNDJSONFields(items, fields)
+		}
+
+		return printNDJSON(items)
+	}
+
+	if fieldsStr != "" {
+		fields := strings.Split(fieldsStr, ",")
+
+		return printJSONFields(resp, fields)
+	}
+
+	return printJSON(resp)
+}

--- a/cmd/darepocli/darepoclicommands/mcp_swap.go
+++ b/cmd/darepocli/darepoclicommands/mcp_swap.go
@@ -1,0 +1,186 @@
+//go:build swapruntime
+
+package darepoclicommands
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/lightninglabs/darepo-client/rpc/swapclientrpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// registerMCPSwapTools registers the `swap.*` advanced surface as
+// MCP tools. The streaming `swap.watch` verb is intentionally NOT
+// surfaced over MCP: an MCP tool call is request/response, and the
+// stream's natural consumer is a long-running CLI process. Agents
+// that need streaming behavior should subscribe via the CLI directly.
+//
+// Input hardening (payment_hash shape, invoice trim) is shared with
+// the CLI path through validatePaymentHash / validateInvoice so the
+// two surfaces cannot drift on what shapes the daemon ever sees.
+//
+// mapSwapRuntimeRPCError mirrors the CLI's behavior of turning the
+// daemon's gRPC Unimplemented for SwapClientService into actionable
+// "rebuild with swapruntime" text.
+//
+// The client is taken as a typed interface (matching
+// registerMCPWalletTools) so unit tests can inject a mock instead of
+// a real gRPC connection.
+func registerMCPSwapTools(s *mcp.Server,
+	client swapclientrpc.SwapClientServiceClient) {
+
+	registerMCPSwapReadTools(s, client)
+	registerMCPSwapMutateTools(s, client)
+}
+
+// registerMCPSwapReadTools registers the read-only swap verbs (list,
+// show).
+func registerMCPSwapReadTools(s *mcp.Server,
+	client swapclientrpc.SwapClientServiceClient) {
+
+	type listArgs struct {
+		PendingOnly bool `json:"pending_only,omitempty" jsonschema:"only return non-terminal resumable swaps"` //nolint:ll
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "swap.list",
+		Description: "List persisted Lightning swap sessions",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, args listArgs) (
+		*mcp.CallToolResult, any, error) {
+
+		resp, err := client.ListSwaps(
+			ctx, &swapclientrpc.ListSwapsRequest{
+				PendingOnly: args.PendingOnly,
+			},
+		)
+		if err != nil {
+			return nil, nil, mapSwapRuntimeRPCError(err)
+		}
+
+		r, err := mcpResult(resp)
+
+		return r, nil, err
+	})
+
+	type showArgs struct {
+		PaymentHash string `json:"payment_hash" jsonschema:"32-byte payment hash (64 hex chars)"` //nolint:ll
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name: "swap.show",
+		Description: "Show one persisted Lightning swap session " +
+			"by payment hash",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, args showArgs) (
+		*mcp.CallToolResult, any, error) {
+
+		if err := validatePaymentHash(args.PaymentHash); err != nil {
+			return nil, nil, err
+		}
+		resp, err := client.GetSwap(
+			ctx, &swapclientrpc.GetSwapRequest{
+				PaymentHash: args.PaymentHash,
+			},
+		)
+		if err != nil {
+			return nil, nil, mapSwapRuntimeRPCError(err)
+		}
+
+		r, err := mcpResult(resp)
+
+		return r, nil, err
+	})
+}
+
+// registerMCPSwapMutateTools registers the mutating swap verbs
+// (receive, pay, resume). Each runs the CLI's input validators so an
+// MCP-driven swap cannot reach the daemon with a shape the CLI would
+// reject.
+func registerMCPSwapMutateTools(s *mcp.Server,
+	client swapclientrpc.SwapClientServiceClient) {
+
+	type receiveArgs struct {
+		AmountSat int64 `json:"amount_sat" jsonschema:"amount in satoshis to receive (required)"` //nolint:ll
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "swap.receive",
+		Description: "Receive BTC via Lightning into Ark",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, args receiveArgs) (
+		*mcp.CallToolResult, any, error) {
+
+		if args.AmountSat <= 0 {
+			return nil, nil, fmt.Errorf("amount_sat must be " +
+				"positive")
+		}
+		resp, err := client.StartReceive(
+			ctx, &swapclientrpc.StartReceiveRequest{
+				AmountSat: args.AmountSat,
+			},
+		)
+		if err != nil {
+			return nil, nil, mapSwapRuntimeRPCError(err)
+		}
+
+		r, err := mcpResult(resp)
+
+		return r, nil, err
+	})
+
+	type payArgs struct {
+		Invoice   string `json:"invoice" jsonschema:"BOLT-11 invoice to pay (required)"`                          //nolint:ll
+		MaxFeeSat uint64 `json:"max_fee_sat,omitempty" jsonschema:"maximum fee in satoshis; zero means no limit"` //nolint:ll
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "swap.pay",
+		Description: "Pay a Lightning invoice from Ark funds",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, args payArgs) (
+		*mcp.CallToolResult, any, error) {
+
+		if err := validateInvoice(args.Invoice); err != nil {
+			return nil, nil, err
+		}
+		resp, err := client.StartPay(
+			ctx, &swapclientrpc.StartPayRequest{
+				Invoice:   args.Invoice,
+				MaxFeeSat: args.MaxFeeSat,
+			},
+		)
+		if err != nil {
+			return nil, nil, mapSwapRuntimeRPCError(err)
+		}
+
+		r, err := mcpResult(resp)
+
+		return r, nil, err
+	})
+
+	type resumeArgs struct {
+		PaymentHash string `json:"payment_hash" jsonschema:"32-byte payment hash (64 hex chars)"`       //nolint:ll
+		Direction   string `json:"direction" jsonschema:"swap direction to resume: 'pay' or 'receive'"` //nolint:ll
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "swap.resume",
+		Description: "Resume a persisted Lightning swap session",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, args resumeArgs) (
+		*mcp.CallToolResult, any, error) {
+
+		if err := validatePaymentHash(args.PaymentHash); err != nil {
+			return nil, nil, err
+		}
+		direction, err := parseSwapRPCDirection(args.Direction)
+		if err != nil {
+			return nil, nil, err
+		}
+		resp, err := client.ResumeSwap(
+			ctx, &swapclientrpc.ResumeSwapRequest{
+				PaymentHash: args.PaymentHash,
+				Direction:   direction,
+			},
+		)
+		if err != nil {
+			return nil, nil, mapSwapRuntimeRPCError(err)
+		}
+
+		r, err := mcpResult(resp)
+
+		return r, nil, err
+	})
+}

--- a/cmd/darepocli/darepoclicommands/mcp_swap_stub.go
+++ b/cmd/darepocli/darepoclicommands/mcp_swap_stub.go
@@ -1,0 +1,23 @@
+//go:build !swapruntime
+
+package darepoclicommands
+
+import (
+	"github.com/lightninglabs/darepo-client/rpc/swapclientrpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// registerMCPSwapTools is a no-op when the binary is built without
+// the swapruntime tag: the daemon doesn't expose SwapClientService in
+// that mode and registering tools that would always fail with a
+// rebuild error is worse for agent DX than simply not listing them.
+// CLI consumers still see `swap` in `darepocli --help` because the
+// non-swapruntime build registers a placeholder command (see
+// cmd_swap_stub.go) that prints the rebuild instruction.
+//
+// The signature matches the swapruntime variant (typed client
+// interface, not a raw conn) so cmd_mcp.go's caller doesn't have to
+// branch on the build tag.
+func registerMCPSwapTools(_ *mcp.Server,
+	_ swapclientrpc.SwapClientServiceClient) {
+}

--- a/cmd/darepocli/darepoclicommands/mcp_wallet.go
+++ b/cmd/darepocli/darepoclicommands/mcp_wallet.go
@@ -1,0 +1,364 @@
+package darepoclicommands
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/lightninglabs/darepo-client/rpc/walletrpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// registerMCPWalletTools registers the everyday wallet verbs on the
+// MCP server. Create and Unlock are intentionally omitted: those
+// operations carry secrets (wallet password, seed passphrase) that
+// must not transit the MCP protocol where they could leak into agent
+// logs or provider APIs. Wallet setup stays on the CLI's secret-input
+// ladder (DAREPOD_WALLET_PASSWORD env > --wallet_password_file > stdin
+// > TTY prompt).
+//
+// Each tool maps gRPC Unimplemented to a clear "daemon was not built
+// with walletrpc" error so an MCP consumer talking to a stub-build
+// daemon sees actionable text rather than a generic status code.
+func registerMCPWalletTools(s *mcp.Server,
+	client walletrpc.WalletServiceClient) {
+
+	registerMCPWalletQueryTools(s, client)
+	registerMCPWalletMutateTools(s, client)
+}
+
+// registerMCPWalletQueryTools registers the read-only wallet verbs
+// (balance, list). These never move funds and need no dry-run rail.
+func registerMCPWalletQueryTools(s *mcp.Server,
+	client walletrpc.WalletServiceClient) {
+
+	type balanceArgs struct{}
+	mcp.AddTool(s, &mcp.Tool{
+		Name: "balance",
+		Description: "Wallet balance: confirmed_sat, " +
+			"pending_in_sat, pending_out_sat",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ balanceArgs) (
+		*mcp.CallToolResult, any, error) {
+
+		resp, err := client.Balance(
+			ctx, &walletrpc.BalanceRequest{},
+		)
+		if err != nil {
+			return nil, nil, mapWalletRPCError(err)
+		}
+
+		r, err := mcpResult(resp)
+
+		return r, nil, err
+	})
+
+	type listArgs struct {
+		View        string   `json:"view,omitempty" jsonschema:"slice of state: activity (default), vtxos, or onchain"`        //nolint:ll
+		PendingOnly bool     `json:"pending_only,omitempty" jsonschema:"activity view only: filter to in-flight entries"`      //nolint:ll
+		Kinds       []string `json:"kinds,omitempty" jsonschema:"activity view only: kind filter (send, recv, deposit, exit)"` //nolint:ll
+		Limit       uint32   `json:"limit,omitempty" jsonschema:"page size; zero uses daemon default"`                         //nolint:ll
+		Offset      uint32   `json:"offset,omitempty" jsonschema:"pagination offset"`                                          //nolint:ll
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name: "list",
+		Description: "List wallet activity, VTXOs, or onchain " +
+			"history (view selects the slice)",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, args listArgs) (
+		*mcp.CallToolResult, any, error) {
+
+		req, err := buildWalletListRequest(
+			args.View, args.PendingOnly, args.Kinds, args.Limit,
+			args.Offset,
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		resp, err := client.List(ctx, req)
+		if err != nil {
+			return nil, nil, mapWalletRPCError(err)
+		}
+
+		r, err := mcpResult(resp)
+
+		return r, nil, err
+	})
+
+	type exitStatusArgs struct {
+		Outpoint string `json:"outpoint" jsonschema:"VTXO outpoint to query (txid:vout)"` //nolint:ll
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "exit.status",
+		Description: "Status of a unilateral exit job",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest,
+		args exitStatusArgs) (*mcp.CallToolResult, any, error) {
+
+		if err := validateOutpoint(args.Outpoint); err != nil {
+			return nil, nil, err
+		}
+		resp, err := client.ExitStatus(
+			ctx, &walletrpc.ExitStatusRequest{
+				Outpoint: args.Outpoint,
+			},
+		)
+		if err != nil {
+			return nil, nil, mapWalletRPCError(err)
+		}
+
+		r, err := mcpResult(resp)
+
+		return r, nil, err
+	})
+}
+
+// registerMCPWalletMutateTools registers the mutating wallet verbs
+// (send, recv, exit). All three apply the same input-hardening checks
+// as the CLI path so MCP and CLI cannot drift on what shapes the
+// daemon ever sees.
+func registerMCPWalletMutateTools(s *mcp.Server,
+	client walletrpc.WalletServiceClient) {
+
+	type sendArgs struct {
+		Destination string `json:"destination" jsonschema:"BOLT-11 invoice (offchain) or onchain address; the direction field picks which"` //nolint:ll
+		Direction   string `json:"direction,omitempty" jsonschema:"'offchain' (default) for invoice, 'onchain' for cooperative leave"`      //nolint:ll
+		AmtSat      uint64 `json:"amt_sat,omitempty" jsonschema:"amount in satoshis (required for onchain unless sweep_all)"`               //nolint:ll
+		MaxFeeSat   uint64 `json:"max_fee_sat,omitempty" jsonschema:"max fee in satoshis; zero uses daemon defaults"`                       //nolint:ll
+		Note        string `json:"note,omitempty" jsonschema:"caller-supplied label persisted with the entry"`                              //nolint:ll
+		SweepAll    bool   `json:"sweep_all,omitempty" jsonschema:"onchain only: drain every live VTXO"`                                    //nolint:ll
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name: "send",
+		Description: "Send a payment (offchain Lightning invoice " +
+			"by default; onchain cooperative leave with " +
+			"direction='onchain')",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, args sendArgs) (
+		*mcp.CallToolResult, any, error) {
+
+		offchain, err := parseDirectionField(args.Direction)
+		if err != nil {
+			return nil, nil, err
+		}
+		req, err := buildWalletSendRequest(
+			args.Destination, offchain, args.AmtSat, args.MaxFeeSat,
+			args.Note, args.SweepAll,
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+		resp, err := client.Send(ctx, req)
+		if err != nil {
+			return nil, nil, mapWalletRPCError(err)
+		}
+
+		r, err := mcpResult(resp)
+
+		return r, nil, err
+	})
+
+	type recvArgs struct {
+		Direction  string `json:"direction,omitempty" jsonschema:"'offchain' (default) returns a Lightning invoice, 'onchain' returns a boarding address"` //nolint:ll
+		AmtSat     uint64 `json:"amt_sat,omitempty" jsonschema:"amount in satoshis (required for offchain)"`                                               //nolint:ll
+		Memo       string `json:"memo,omitempty" jsonschema:"optional human-readable memo embedded in the invoice"`                                        //nolint:ll
+		AmtSatHint uint64 `json:"amt_sat_hint,omitempty" jsonschema:"optional expected deposit amount for onchain (accounting only)"`                      //nolint:ll
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name: "recv",
+		Description: "Receive a payment (offchain Lightning invoice " +
+			"by default; onchain boarding address with " +
+			"direction='onchain')",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, args recvArgs) (
+		*mcp.CallToolResult, any, error) {
+
+		offchain, err := parseDirectionField(args.Direction)
+		if err != nil {
+			return nil, nil, err
+		}
+		if err := validateFreeText("memo", args.Memo); err != nil {
+			return nil, nil, err
+		}
+
+		if offchain {
+			if args.AmtSat == 0 {
+				return nil, nil, fmt.Errorf("amt_sat is " +
+					"required for offchain recv")
+			}
+			resp, err := client.Recv(
+				ctx, &walletrpc.RecvRequest{
+					AmtSat: args.AmtSat,
+					Memo:   args.Memo,
+				},
+			)
+			if err != nil {
+				return nil, nil, mapWalletRPCError(err)
+			}
+
+			r, err := mcpResult(resp)
+
+			return r, nil, err
+		}
+
+		resp, err := client.Deposit(
+			ctx, &walletrpc.DepositRequest{
+				AmtSatHint: args.AmtSatHint,
+			},
+		)
+		if err != nil {
+			return nil, nil, mapWalletRPCError(err)
+		}
+
+		r, err := mcpResult(resp)
+
+		return r, nil, err
+	})
+
+	type exitArgs struct {
+		Outpoint string `json:"outpoint" jsonschema:"VTXO outpoint to exit (txid:vout)"` //nolint:ll
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name: "exit",
+		Description: "Trigger a unilateral exit for a VTXO " +
+			"(spawns a durable on-chain recovery job)",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, args exitArgs) (
+		*mcp.CallToolResult, any, error) {
+
+		if err := validateOutpoint(args.Outpoint); err != nil {
+			return nil, nil, err
+		}
+		resp, err := client.Exit(
+			ctx, &walletrpc.ExitRequest{
+				Outpoint: args.Outpoint,
+			},
+		)
+		if err != nil {
+			return nil, nil, mapWalletRPCError(err)
+		}
+
+		r, err := mcpResult(resp)
+
+		return r, nil, err
+	})
+}
+
+// buildWalletListRequest translates MCP listArgs into a ListRequest,
+// applying the same view / filter combinator checks the CLI enforces
+// so the two surfaces stay in lockstep.
+func buildWalletListRequest(view string, pendingOnly bool, kinds []string,
+	limit, offset uint32) (*walletrpc.ListRequest, error) {
+
+	v, err := parseListView(view)
+	if err != nil {
+		return nil, err
+	}
+
+	req := &walletrpc.ListRequest{
+		View:        v,
+		PendingOnly: pendingOnly,
+		Limit:       limit,
+		Offset:      offset,
+	}
+
+	// Reject activity-only filters on other views so the agent can't
+	// silently no-op a filter (same invariant the CLI enforces).
+	if v != walletrpc.ListView_LIST_VIEW_ACTIVITY {
+		if pendingOnly {
+			return nil, fmt.Errorf("pending_only applies only to " +
+				"the activity view")
+		}
+		if len(kinds) > 0 {
+			return nil, fmt.Errorf("kinds applies only to the " +
+				"activity view")
+		}
+	}
+
+	for _, k := range kinds {
+		parsed, err := parseEntryKind(k)
+		if err != nil {
+			return nil, err
+		}
+		req.Kinds = append(req.Kinds, parsed)
+	}
+
+	return req, nil
+}
+
+// buildWalletSendRequest assembles a SendRequest while running the
+// CLI's input hardening (validateDestination, validateFreeText) and
+// the offchain/onchain invariants so MCP can't construct a shape the
+// CLI would reject.
+func buildWalletSendRequest(dest string, offchain bool, amt, maxFee uint64,
+	note string, sweepAll bool) (*walletrpc.SendRequest, error) {
+
+	if err := validateDestination(dest); err != nil {
+		return nil, err
+	}
+	if err := validateFreeText("note", note); err != nil {
+		return nil, err
+	}
+
+	if offchain && sweepAll {
+		return nil, fmt.Errorf("sweep_all is only valid with onchain " +
+			"sends (offchain=false)")
+	}
+	if !offchain {
+		switch {
+		case sweepAll && amt != 0:
+			return nil, fmt.Errorf("sweep_all requires amt_sat=0")
+
+		case !sweepAll && amt == 0:
+			return nil, fmt.Errorf("amt_sat is required for " +
+				"onchain sends (use sweep_all to drain)")
+		}
+	}
+
+	req := &walletrpc.SendRequest{
+		AmtSat:    amt,
+		MaxFeeSat: maxFee,
+		Note:      note,
+		SweepAll:  sweepAll,
+	}
+	if offchain {
+		req.Destination = &walletrpc.SendRequest_Invoice{
+			Invoice: dest,
+		}
+	} else {
+		req.Destination = &walletrpc.SendRequest_OnchainAddress{
+			OnchainAddress: dest,
+		}
+	}
+
+	return req, nil
+}
+
+// parseDirectionField maps the MCP-friendly direction string onto the
+// CLI's offchain bool. Empty defaults to offchain so an agent that
+// just passes a destination keeps the safe invoice path. Unknown
+// values are rejected explicitly rather than silently coerced.
+func parseDirectionField(direction string) (bool, error) {
+	switch direction {
+	case "", "offchain":
+		return true, nil
+
+	case "onchain":
+		return false, nil
+
+	default:
+		return false, fmt.Errorf("unknown direction %q (want "+
+			"'offchain' or 'onchain')", direction)
+	}
+}
+
+// mapWalletRPCError mirrors the CLI's withWalletClient mapping: a
+// gRPC Unimplemented from a stub-build daemon becomes the actionable
+// errWalletRPCDisabled instead of a generic status. Other errors pass
+// through unchanged.
+func mapWalletRPCError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if status.Code(err) == codes.Unimplemented {
+		return errWalletRPCDisabled
+	}
+
+	return err
+}

--- a/cmd/darepocli/darepoclicommands/mcp_wallet_test.go
+++ b/cmd/darepocli/darepoclicommands/mcp_wallet_test.go
@@ -1,0 +1,156 @@
+package darepoclicommands
+
+import (
+	"testing"
+
+	"github.com/lightninglabs/darepo-client/rpc/walletrpc"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseDirectionFieldDefaultsToOffchain confirms an agent that
+// omits the direction string lands on the safe invoice path. The CLI
+// flag layer enforces the same default via resolveOffchainFlag — the
+// MCP layer must not drift from it.
+func TestParseDirectionFieldDefaultsToOffchain(t *testing.T) {
+	t.Parallel()
+
+	offchain, err := parseDirectionField("")
+	require.NoError(t, err)
+	require.True(t, offchain)
+}
+
+// TestParseDirectionFieldRejectsUnknown rejects an unknown direction
+// rather than coercing it to a default — silent coercion would let an
+// agent dispatch an onchain leave with a typo'd "onchian".
+func TestParseDirectionFieldRejectsUnknown(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseDirectionField("onchian")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown direction")
+}
+
+// TestBuildWalletSendRequestHardensAgentInput exercises the shared
+// builder used by both the CLI send verb and the MCP send tool. The
+// MCP path can't drift past the same input-hardening checks as the
+// CLI, so the rejections are exhaustive.
+func TestBuildWalletSendRequestHardensAgentInput(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		dest     string
+		offchain bool
+		amt      uint64
+		note     string
+		sweepAll bool
+		wantErr  string
+	}{
+		{
+			name:     "empty destination",
+			dest:     "",
+			offchain: true,
+			amt:      1000,
+			wantErr:  "destination is required",
+		},
+		{
+			name:     "embedded query param",
+			dest:     "lnbcrt100?fields=amt",
+			offchain: true,
+			amt:      1000,
+			wantErr:  "query/fragment",
+		},
+		{
+			name:     "control char in note",
+			dest:     "lnbcrt100",
+			offchain: true,
+			amt:      1000,
+			note:     "hello\x01world",
+			wantErr:  "control character",
+		},
+		{
+			name:     "sweep_all on offchain",
+			dest:     "lnbcrt100",
+			offchain: true,
+			sweepAll: true,
+			wantErr:  "only valid with onchain",
+		},
+		{
+			name:     "onchain without amt or sweep_all",
+			dest:     "bcrt1q0123",
+			offchain: false,
+			amt:      0,
+			wantErr:  "amt_sat is required for onchain",
+		},
+		{
+			name:     "onchain with both amt and sweep_all",
+			dest:     "bcrt1q0123",
+			offchain: false,
+			amt:      1000,
+			sweepAll: true,
+			wantErr:  "sweep_all requires amt_sat=0",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := buildWalletSendRequest(
+				tc.dest, tc.offchain, tc.amt, 0, tc.note,
+				tc.sweepAll,
+			)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+// TestBuildWalletSendRequestHappyPath confirms a valid invoice send
+// produces the expected oneof and scalar fields.
+func TestBuildWalletSendRequestHappyPath(t *testing.T) {
+	t.Parallel()
+
+	req, err := buildWalletSendRequest(
+		"lnbcrt100u1pwlqxyz", true, 0, 250, "coffee", false,
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, "lnbcrt100u1pwlqxyz", req.GetInvoice())
+	require.Equal(t, uint64(250), req.GetMaxFeeSat())
+	require.Equal(t, "coffee", req.GetNote())
+}
+
+// TestBuildWalletListRequestRejectsCrossViewFilters confirms an agent
+// can't silently no-op a filter by combining --pending with --view
+// vtxos — the rejection is the only signal the CLI is allowed to
+// give for this footgun.
+func TestBuildWalletListRequestRejectsCrossViewFilters(t *testing.T) {
+	t.Parallel()
+
+	_, err := buildWalletListRequest("vtxos", true, nil, 0, 0)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "activity view")
+
+	_, err = buildWalletListRequest(
+		"onchain", false, []string{"send"}, 0, 0,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "activity view")
+}
+
+// TestBuildWalletListRequestActivityHappyPath confirms the activity
+// view accepts filters and produces a populated request.
+func TestBuildWalletListRequestActivityHappyPath(t *testing.T) {
+	t.Parallel()
+
+	req, err := buildWalletListRequest(
+		"activity", true, []string{"send", "recv"}, 50, 100,
+	)
+	require.NoError(t, err)
+	require.Equal(
+		t, walletrpc.ListView_LIST_VIEW_ACTIVITY, req.GetView(),
+	)
+	require.True(t, req.GetPendingOnly())
+	require.Len(t, req.GetKinds(), 2)
+	require.Equal(t, uint32(50), req.GetLimit())
+	require.Equal(t, uint32(100), req.GetOffset())
+}

--- a/cmd/darepocli/darepoclicommands/root.go
+++ b/cmd/darepocli/darepoclicommands/root.go
@@ -1,6 +1,7 @@
 package darepoclicommands
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -90,9 +91,66 @@ func NewRootCmd() *cobra.Command {
 	return cmd
 }
 
-// PrintError writes a structured error to stderr in JSON format.
-func PrintError(code string, msg string) {
+// PrintError writes a structured error to stderr in JSON format and
+// returns an error that carries the same code/message plus a marker
+// that main() can pick up via ErrorWasPrinted to avoid re-emitting the
+// envelope. Callers `return PrintError(...)` from RunE so the cobra
+// surface keeps signalling failure to the harness while stderr stays
+// machine-readable.
+func PrintError(code string, msg string) error {
 	fmt.Fprintf(
 		os.Stderr, `{"error":{"code":%q,"message":%q}}`+"\n", code, msg,
 	)
+
+	return &printedError{code: code, msg: msg}
+}
+
+// printedError is the wrapper returned by PrintError. It carries a
+// semantic exit code derived from the error code string so the binary
+// surfaces validation / auth / not-found failures distinctly without
+// callers needing to thread codes manually.
+type printedError struct {
+	code string
+	msg  string
+}
+
+// Error returns the underlying message for cobra's RunE plumbing.
+func (e *printedError) Error() string {
+	return e.msg
+}
+
+// ExitCode maps the textual error code onto a semantic exit code. The
+// known prefixes line up with the agent-cli table; everything else
+// falls through to the generic failure code.
+func (e *printedError) ExitCode() int {
+	switch e.code {
+	case "INVALID_ARGS", "INVALID_STATUS", "INVALID_OUTPOINT",
+		"INVALID_DESTINATION", "INVALID_VIEW":
+		return ExitInvalidArgs
+
+	case "AUTH_FAILURE", "WALLET_LOCKED":
+		return ExitAuthFailure
+
+	case "METHOD_NOT_FOUND", "NOT_FOUND":
+		return ExitNotFound
+
+	case "DRY_RUN_OK":
+		return ExitDryRunOK
+	}
+
+	return ExitGenericError
+}
+
+// ErrorWasPrinted reports whether err originated from PrintError and
+// therefore already produced a structured stderr envelope. main()
+// uses this to suppress its fallback EXECUTION_FAILED emission for
+// errors that have already been rendered.
+func ErrorWasPrinted(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var pe *printedError
+
+	return errors.As(err, &pe)
 }

--- a/cmd/darepocli/darepoclicommands/schema_registry.go
+++ b/cmd/darepocli/darepoclicommands/schema_registry.go
@@ -58,6 +58,12 @@ type schemaMethod struct {
 // linter cap. The top-level wallet verbs (create, unlock, send, recv,
 // list, balance, exit) are the day-to-day surface; advanced commands
 // live under the `ark.*` and `swap.*` namespaces.
+//
+// The swap.* entries are listed unconditionally regardless of the
+// swapruntime build tag: an agent inspecting the schema in a stub
+// build still gets to discover what swap.* offers (the CLI itself
+// emits a clear build-tag error when the verb is invoked), and the
+// MCP registration is what actually gets tag-gated.
 func methodRegistry() []schemaMethod {
 	out := walletAdminMethodRegistry()
 	out = append(out, walletPaymentMethodRegistry()...)
@@ -65,6 +71,7 @@ func methodRegistry() []schemaMethod {
 	out = append(out, arkBaseMethodRegistry()...)
 	out = append(out, arkVTXOMethodRegistry()...)
 	out = append(out, arkSendMethodRegistry()...)
+	out = append(out, swapMethodRegistry()...)
 
 	return out
 }

--- a/cmd/darepocli/darepoclicommands/schema_registry.go
+++ b/cmd/darepocli/darepoclicommands/schema_registry.go
@@ -71,9 +71,34 @@ func methodRegistry() []schemaMethod {
 	out = append(out, arkBaseMethodRegistry()...)
 	out = append(out, arkVTXOMethodRegistry()...)
 	out = append(out, arkSendMethodRegistry()...)
+	out = append(out, arkObservableMethodRegistry()...)
 	out = append(out, swapMethodRegistry()...)
 
 	return out
+}
+
+// listOutputParams returns the standard agent-CLI output-shape
+// modifier params (--fields, --ndjson) for list-shaped commands. The
+// helper keeps every list entry's schema description in sync with
+// addListOutputFlags so an agent inspecting the schema sees exactly
+// the flags the CLI exposes.
+func listOutputParams() []schemaParam {
+	return []schemaParam{
+		{
+			Name: "fields",
+			Type: "string",
+			Description: "comma-separated field names to " +
+				"include (response filtered before " +
+				"printing)",
+		},
+		{
+			Name: "ndjson",
+			Type: "bool",
+			Description: "emit one JSON object per row " +
+				"(newline-delimited); pairs with " +
+				"--fields to shrink each line",
+		},
+	}
 }
 
 // walletAdminMethodRegistry returns the admin-shape wallet verbs
@@ -385,7 +410,7 @@ func arkBaseMethodRegistry() []schemaMethod {
 		{
 			Method:      "ark.sweep.list",
 			Description: "List tracked boarding sweeps (advanced)",
-			Params: []schemaParam{
+			Params: append([]schemaParam{
 				{
 					Name: "status",
 					Type: "string",
@@ -406,7 +431,7 @@ func arkBaseMethodRegistry() []schemaMethod {
 					Description: "token from a previous " +
 						"sweep list response",
 				},
-			},
+			}, listOutputParams()...),
 			RequestType:  "ListBoardingSweepsRequest",
 			ResponseType: "ListBoardingSweepsResponse",
 			JSONInput:    true,
@@ -414,7 +439,7 @@ func arkBaseMethodRegistry() []schemaMethod {
 		{
 			Method:      "ark.listtransactions",
 			Description: "Raw paginated transaction history",
-			Params: []schemaParam{
+			Params: append([]schemaParam{
 				{
 					Name: "from",
 					Type: "string",
@@ -450,7 +475,7 @@ func arkBaseMethodRegistry() []schemaMethod {
 						"sweep",
 					},
 				},
-			},
+			}, listOutputParams()...),
 			RequestType:  "ListTransactionsRequest",
 			ResponseType: "ListTransactionsResponse",
 			JSONInput:    true,
@@ -482,7 +507,7 @@ func arkVTXOMethodRegistry() []schemaMethod {
 		{
 			Method:      "ark.vtxos.list",
 			Description: "List VTXOs with optional filters",
-			Params: []schemaParam{
+			Params: append([]schemaParam{
 				{
 					Name:        "status",
 					Type:        "enum",
@@ -503,19 +528,7 @@ func arkVTXOMethodRegistry() []schemaMethod {
 					Type:        "int64",
 					Description: "minimum amount in sats",
 				},
-				{
-					Name: "fields",
-					Type: "string",
-					Description: "comma-separated field " +
-						"names to include",
-				},
-				{
-					Name: "ndjson",
-					Type: "bool",
-					Description: "emit one JSON object " +
-						"per VTXO (newline-delimited)",
-				},
-			},
+			}, listOutputParams()...),
 			RequestType:  "ListVTXOsRequest",
 			ResponseType: "ListVTXOsResponse",
 			JSONInput:    true,

--- a/cmd/darepocli/darepoclicommands/schema_registry.go
+++ b/cmd/darepocli/darepoclicommands/schema_registry.go
@@ -36,12 +36,21 @@ type schemaMethod struct {
 	// ResponseType is the proto response message name.
 	ResponseType string `json:"response_type"`
 
-	// DryRun indicates whether the command supports --dry_run.
+	// DryRun indicates whether the command supports --dry-run /
+	// --dry_run. Top-level wallet verbs use --dry-run (CLI-only
+	// validation, exits 10); ark.* commands use --dry_run that
+	// reaches the daemon's dry-run RPC field.
 	DryRun bool `json:"dry_run,omitempty"`
 
 	// JSONInput indicates the command accepts --json for raw proto
 	// payloads.
 	JSONInput bool `json:"json_input"`
+
+	// MCPTool indicates the method is exposed as an MCP tool with
+	// the same name. False means it is CLI-only (create / unlock
+	// are intentionally CLI-only because they handle secret
+	// material).
+	MCPTool bool `json:"mcp_tool,omitempty"`
 }
 
 // methodRegistry returns the full schema for all darepocli commands.
@@ -75,15 +84,23 @@ func walletAdminMethodRegistry() []schemaMethod {
 						"containing wallet password",
 				},
 				{
-					Name: "seed_passphrase",
+					Name: "seed_passphrase_file",
 					Type: "string",
-					Description: "optional aezeed " +
+					Description: "path to file " +
+						"containing optional aezeed " +
 						"passphrase",
+				},
+				{
+					Name: "print-mnemonic-json",
+					Type: "bool",
+					Description: "include the mnemonic " +
+						"in the JSON response on " +
+						"stdout (default: stderr only)",
 				},
 			},
 			RequestType:  "CreateRequest",
 			ResponseType: "CreateResponse",
-			JSONInput:    true,
+			JSONInput:    false,
 		},
 		{
 			Method:      "unlock",
@@ -98,7 +115,7 @@ func walletAdminMethodRegistry() []schemaMethod {
 			},
 			RequestType:  "UnlockRequest",
 			ResponseType: "UnlockResponse",
-			JSONInput:    true,
+			JSONInput:    false,
 		},
 		{
 			Method:       "getinfo",
@@ -156,10 +173,20 @@ func walletPaymentMethodRegistry() []schemaMethod {
 					Description: "onchain only: drain " +
 						"every live VTXO",
 				},
+				{
+					Name: "dry-run",
+					Type: "bool",
+					Description: "CLI-side validation " +
+						"only; print the proto-JSON " +
+						"preview and exit 10 without " +
+						"dispatching",
+				},
 			},
 			RequestType:  "SendRequest",
 			ResponseType: "SendResponse",
-			JSONInput:    true,
+			DryRun:       true,
+			JSONInput:    false,
+			MCPTool:      true,
 		},
 		{
 			Method:      "recv",
@@ -197,7 +224,8 @@ func walletPaymentMethodRegistry() []schemaMethod {
 			},
 			RequestType:  "RecvRequest",
 			ResponseType: "RecvResponse",
-			JSONInput:    true,
+			JSONInput:    false,
+			MCPTool:      true,
 		},
 	}
 }
@@ -244,7 +272,8 @@ func walletQueryMethodRegistry() []schemaMethod {
 			},
 			RequestType:  "ListRequest",
 			ResponseType: "ListResponse",
-			JSONInput:    true,
+			JSONInput:    false,
+			MCPTool:      true,
 		},
 		{
 			Method:       "balance",
@@ -252,7 +281,8 @@ func walletQueryMethodRegistry() []schemaMethod {
 			Params:       nil,
 			RequestType:  "BalanceRequest",
 			ResponseType: "BalanceResponse",
-			JSONInput:    true,
+			JSONInput:    false,
+			MCPTool:      true,
 		},
 		{
 			Method:      "exit",
@@ -265,10 +295,20 @@ func walletQueryMethodRegistry() []schemaMethod {
 					Description: "VTXO outpoint " +
 						"(txid:vout)",
 				},
+				{
+					Name: "dry-run",
+					Type: "bool",
+					Description: "CLI-side validation " +
+						"only; print the proto-JSON " +
+						"preview and exit 10 without " +
+						"dispatching",
+				},
 			},
 			RequestType:  "ExitRequest",
 			ResponseType: "ExitResponse",
-			JSONInput:    true,
+			DryRun:       true,
+			JSONInput:    false,
+			MCPTool:      true,
 		},
 		{
 			Method:      "exit.status",
@@ -284,7 +324,8 @@ func walletQueryMethodRegistry() []schemaMethod {
 			},
 			RequestType:  "ExitStatusRequest",
 			ResponseType: "ExitStatusResponse",
-			JSONInput:    true,
+			JSONInput:    false,
+			MCPTool:      true,
 		},
 	}
 }

--- a/cmd/darepocli/darepoclicommands/schema_registry_ark_observable.go
+++ b/cmd/darepocli/darepoclicommands/schema_registry_ark_observable.go
@@ -1,0 +1,238 @@
+package darepoclicommands
+
+// arkObservableMethodRegistry returns schema entries for the `ark.*`
+// observability and operator-runbook surface that earlier registry
+// blocks omitted: board, fees.{estimate,history}, rounds.{get,list,
+// watch}, oor.{get,list}. The CLI itself already exposes these, but
+// without schema entries an agent inspecting `darepocli schema --all`
+// couldn't discover them.
+//
+// The list-shaped entries (rounds.list, oor.list, fees.history) carry
+// the standard --fields / --ndjson output modifiers via
+// listOutputParams so the schema reflects the agent-CLI surface
+// addListOutputFlags installs.
+func arkObservableMethodRegistry() []schemaMethod {
+	out := arkObservableMutateMethodRegistry()
+	out = append(out, arkObservableListMethodRegistry()...)
+	out = append(out, arkObservableSingletonMethodRegistry()...)
+
+	return out
+}
+
+// arkObservableMutateMethodRegistry registers the boarding-mutate and
+// boarding-sweep surface.
+func arkObservableMutateMethodRegistry() []schemaMethod {
+	return []schemaMethod{
+		{
+			Method:      "ark.board",
+			Description: "Board confirmed UTXOs into VTXOs",
+			Params: []schemaParam{
+				{
+					Name: "target-vtxo-count",
+					Type: "uint32",
+					Description: "fan the boarded " +
+						"balance into N VTXOs; " +
+						"zero boards the whole " +
+						"balance as one VTXO",
+				},
+				{
+					Name: "no-persist",
+					Type: "bool",
+					Description: "skip restart-safe " +
+						"Board replay (daemon " +
+						"restart between admission " +
+						"and round seal silently " +
+						"drops the intent)",
+				},
+			},
+			RequestType:  "BoardRequest",
+			ResponseType: "BoardResponse",
+			JSONInput:    true,
+		},
+	}
+}
+
+// arkObservableListMethodRegistry registers the list-shaped
+// observability verbs that gained --fields / --ndjson output
+// modifiers in this audit pass.
+func arkObservableListMethodRegistry() []schemaMethod {
+	return []schemaMethod{
+		{
+			Method:      "ark.rounds.list",
+			Description: "List current round FSM states",
+			Params: append([]schemaParam{
+				{
+					Name: "persisted-only",
+					Type: "bool",
+					Description: "skip in-memory pending " +
+						"rounds",
+				},
+				{
+					Name: "page-size",
+					Type: "int32",
+					Description: "max persisted rounds " +
+						"to return; zero uses default",
+				},
+				{
+					Name: "page-token",
+					Type: "string",
+					Description: "cursor from a previous " +
+						"response for pagination",
+				},
+				{
+					Name: "state",
+					Type: "string",
+					Description: "optional state filter " +
+						"(confirmed, failed, ...)",
+				},
+				{
+					Name: "created-after",
+					Type: "int64",
+					Description: "only rounds created at " +
+						"or after this Unix time",
+				},
+				{
+					Name: "created-before",
+					Type: "int64",
+					Description: "only rounds created " +
+						"before this Unix time",
+				},
+			}, listOutputParams()...),
+			RequestType:  "ListRoundsRequest",
+			ResponseType: "ListRoundsResponse",
+			JSONInput:    true,
+		},
+		{
+			Method:      "ark.oor.list",
+			Description: "List OOR session statuses",
+			Params: append([]schemaParam{
+				{
+					Name:        "direction",
+					Type:        "enum",
+					Description: "direction filter",
+					Values: []string{
+						"all", "outgoing", "incoming",
+					},
+				},
+				{
+					Name:        "status",
+					Type:        "enum",
+					Description: "status filter",
+					Values: []string{
+						"all", "pending", "completed",
+						"failed",
+					},
+				},
+				{
+					Name:        "page-size",
+					Type:        "int32",
+					Description: "max sessions to return",
+				},
+				{
+					Name: "page-token",
+					Type: "string",
+					Description: "cursor from a previous " +
+						"response for pagination",
+				},
+			}, listOutputParams()...),
+			RequestType:  "ListOORSessionsRequest",
+			ResponseType: "ListOORSessionsResponse",
+			JSONInput:    true,
+		},
+		{
+			Method:      "ark.fees.history",
+			Description: "Paginated fee payment history",
+			Params: []schemaParam{
+				{
+					Name:        "limit",
+					Type:        "uint32",
+					Description: "max entries to return",
+				},
+				{
+					Name:        "offset",
+					Type:        "uint32",
+					Description: "entries to skip",
+				},
+			},
+			RequestType:  "GetFeeHistoryRequest",
+			ResponseType: "GetFeeHistoryResponse",
+			JSONInput:    true,
+		},
+	}
+}
+
+// arkObservableSingletonMethodRegistry registers the get-one /
+// estimate verbs that fetch a single record rather than a list.
+func arkObservableSingletonMethodRegistry() []schemaMethod {
+	return []schemaMethod{
+		{
+			Method:      "ark.rounds.get",
+			Description: "Get one round status by id",
+			Params: []schemaParam{
+				{
+					Name:     "round-id",
+					Type:     "string",
+					Required: true,
+					Description: "server-assigned round " +
+						"id to fetch",
+				},
+			},
+			RequestType:  "GetRoundRequest",
+			ResponseType: "GetRoundResponse",
+			JSONInput:    true,
+		},
+		{
+			Method:      "ark.rounds.watch",
+			Description: "Stream round state updates",
+			Params:      nil,
+			RequestType: "WatchRoundsRequest",
+			ResponseType: "RoundStateUpdate (server " +
+				"stream)",
+			JSONInput: false,
+		},
+		{
+			Method:      "ark.oor.get",
+			Description: "Get one OOR session status by id",
+			Params: []schemaParam{
+				{
+					Name:        "session-id",
+					Type:        "string",
+					Required:    true,
+					Description: "OOR session id to fetch",
+				},
+			},
+			RequestType:  "GetOORSessionRequest",
+			ResponseType: "GetOORSessionResponse",
+			JSONInput:    true,
+		},
+		{
+			Method:      "ark.fees.estimate",
+			Description: "Estimate fee for a VTXO operation",
+			Params: []schemaParam{
+				{
+					Name:        "amount",
+					Type:        "int64",
+					Required:    true,
+					Description: "VTXO amount in sats",
+				},
+				{
+					Name: "boarding",
+					Type: "bool",
+					Description: "estimate for boarding " +
+						"(default true) or refresh",
+				},
+				{
+					Name: "remaining-blocks",
+					Type: "uint32",
+					Description: "remaining VTXO " +
+						"lifetime in blocks " +
+						"(refresh only, required " +
+						"when boarding=false)",
+				},
+			},
+			RequestType:  "EstimateFeeRequest",
+			ResponseType: "EstimateFeeResponse",
+			JSONInput:    true,
+		},
+	}
+}

--- a/cmd/darepocli/darepoclicommands/schema_registry_swap.go
+++ b/cmd/darepocli/darepoclicommands/schema_registry_swap.go
@@ -1,0 +1,135 @@
+package darepoclicommands
+
+// swapMethodRegistry returns the schema entries for the `swap.*`
+// advanced subtree. Each entry carries mcp_tool=true; the MCP
+// registration itself is build-tag gated on `swapruntime`, so a
+// stub-build agent that consults the schema sees the verbs but the
+// actual MCP server only exposes them when the daemon was built with
+// the matching tag.
+func swapMethodRegistry() []schemaMethod {
+	return []schemaMethod{
+		{
+			Method:      "swap.list",
+			Description: "List persisted Lightning swap sessions",
+			Params: []schemaParam{
+				{
+					Name: "pending",
+					Type: "bool",
+					Description: "only non-terminal " +
+						"resumable swaps",
+				},
+			},
+			RequestType:  "ListSwapsRequest",
+			ResponseType: "ListSwapsResponse",
+			JSONInput:    true,
+			MCPTool:      true,
+		},
+		{
+			Method: "swap.show",
+			Description: "Show one persisted Lightning swap " +
+				"session by payment hash",
+			Params: []schemaParam{
+				{
+					Name:     "payment_hash",
+					Type:     "string",
+					Required: true,
+					Description: "32-byte payment hash " +
+						"(64 hex chars)",
+				},
+			},
+			RequestType:  "GetSwapRequest",
+			ResponseType: "GetSwapResponse",
+			JSONInput:    true,
+			MCPTool:      true,
+		},
+		{
+			Method:      "swap.receive",
+			Description: "Receive BTC via Lightning into Ark",
+			Params: []schemaParam{
+				{
+					Name:        "amount",
+					Type:        "int64",
+					Required:    true,
+					Description: "amount in satoshis",
+				},
+			},
+			RequestType:  "StartReceiveRequest",
+			ResponseType: "StartReceiveResponse",
+			JSONInput:    true,
+			MCPTool:      true,
+		},
+		{
+			Method:      "swap.pay",
+			Description: "Pay a Lightning invoice from Ark funds",
+			Params: []schemaParam{
+				{
+					Name:        "invoice",
+					Type:        "string",
+					Required:    true,
+					Description: "BOLT-11 invoice to pay",
+				},
+				{
+					Name: "maxfee",
+					Type: "uint64",
+					Description: "maximum fee in " +
+						"satoshis; zero means no limit",
+				},
+			},
+			RequestType:  "StartPayRequest",
+			ResponseType: "StartPayResponse",
+			JSONInput:    true,
+			MCPTool:      true,
+		},
+		{
+			Method: "swap.resume",
+			Description: "Resume a persisted Lightning swap " +
+				"session",
+			Params: []schemaParam{
+				{
+					Name:     "payment_hash",
+					Type:     "string",
+					Required: true,
+					Description: "32-byte payment hash " +
+						"(64 hex chars)",
+				},
+				{
+					Name:        "direction",
+					Type:        "enum",
+					Required:    true,
+					Description: "swap direction to resume",
+					Values: []string{
+						"pay",
+						"receive",
+					},
+				},
+			},
+			RequestType:  "ResumeSwapRequest",
+			ResponseType: "ResumeSwapResponse",
+			JSONInput:    true,
+			MCPTool:      true,
+		},
+		{
+			Method:      "swap.watch",
+			Description: "Stream swap session updates",
+			Params: []schemaParam{
+				{
+					Name: "pending",
+					Type: "bool",
+					Description: "stream only pending " +
+						"swap updates",
+				},
+				{
+					Name: "include-existing",
+					Type: "bool",
+					Description: "emit existing swaps " +
+						"before live updates " +
+						"(default true)",
+				},
+			},
+			RequestType:  "SubscribeSwapsRequest",
+			ResponseType: "SwapSummary (stream)",
+			JSONInput:    true,
+			MCPTool:      false,
+		},
+	}
+}

--- a/cmd/darepocli/darepoclicommands/wallet_client.go
+++ b/cmd/darepocli/darepoclicommands/wallet_client.go
@@ -81,6 +81,46 @@ func printWalletProto(v proto.Message) error {
 	return nil
 }
 
+// invalidArgs wraps a client-side validation error in the canonical
+// INVALID_ARGS envelope so the structured stderr shape and the exit-
+// code-2 mapping both kick in. Returns nil if err is nil so callers
+// can use it directly in `return invalidArgs(validator(...))` style.
+// All seven top-level wallet verbs route their input-hardening
+// rejections through this helper so the envelope an agent sees
+// matches what swap.* / ark.* verbs emit for the same failure class.
+func invalidArgs(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	return PrintError("INVALID_ARGS", err.Error())
+}
+
+// walletDryRunPreview emits a structured preview of the RPC that would
+// have been dispatched. The fully-validated request body is included
+// so an agent staging a transaction can diff the proto-JSON against
+// what it intended. A DRY_RUN_OK printedError is returned so main.go
+// exits with code 10 — the agent-cli skill's "dry-run passed" marker —
+// without re-printing the envelope.
+func walletDryRunPreview(method string, req proto.Message) error {
+	body, err := walletProtoMarshal.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("marshal dry-run preview: %w", err)
+	}
+
+	// stdout carries the machine-readable preview; main.go's DRY_RUN_OK
+	// stderr envelope carries the marker that the dry-run validated.
+	fmt.Fprintf(
+		os.Stdout, `{"dry_run":true,"method":%q,"validation":"passed",`+
+			`"body":%s}`+"\n", method, string(body),
+	)
+
+	return PrintError(
+		"DRY_RUN_OK",
+		"dry-run validation passed; no RPC was dispatched",
+	)
+}
+
 // parseEntryKind maps a user-facing kind string to the proto enum used
 // in ListRequest.Kinds.
 func parseEntryKind(s string) (walletrpc.EntryKind, error) {

--- a/cmd/darepocli/main.go
+++ b/cmd/darepocli/main.go
@@ -6,13 +6,36 @@ import (
 	"github.com/lightninglabs/darepo-client/cmd/darepocli/darepoclicommands"
 )
 
+// main runs the darepocli root command and maps the returned error
+// onto a semantic exit code so agents can branch on the failure
+// category without parsing prose. See darepoclicommands/exit_codes.go
+// for the full table (2=invalid args, 3=auth, 4=not found, 10=dry-run
+// passed). Any error that already carries the structured envelope set
+// by helpers like PrintError is treated as already-rendered; otherwise
+// we emit a generic EXECUTION_FAILED envelope so stderr stays
+// machine-readable in every failure path.
 func main() {
 	root := darepoclicommands.NewRootCmd()
 
-	if err := root.Execute(); err != nil {
-		darepoclicommands.PrintError(
-			"EXECUTION_FAILED", err.Error(),
-		)
-		os.Exit(1)
+	err := root.Execute()
+	if err == nil {
+		return
 	}
+
+	if !darepoclicommands.ErrorWasPrinted(err) {
+		// Cobra and pflag pre-RunE failures (missing required
+		// flag, wrong arg count, unknown flag) come through here
+		// as bare errors that should map onto the agent-cli
+		// INVALID_ARGS envelope, not the generic EXECUTION_FAILED
+		// one. The matching exit-code-2 mapping lives in
+		// ExitCodeFor via IsCobraArgError, so the stderr code and
+		// the exit code stay in lockstep.
+		code := "EXECUTION_FAILED"
+		if darepoclicommands.IsCobraArgError(err) {
+			code = "INVALID_ARGS"
+		}
+		_ = darepoclicommands.PrintError(code, err.Error())
+	}
+
+	os.Exit(darepoclicommands.ExitCodeFor(err))
 }


### PR DESCRIPTION
In this PR, we put the recent darepocli command overhaul through the
agent-cli skill's checklist and close the gaps the initial reshape
didn't yet cover. The CLI is the daily face of darepod for both
operators and AI agents, and most of the agent-DX work landed
piecemeal across the original PRs. This PR is the consolidation pass:
one commit per top-level surface, no proto changes, no daemon
changes, all edits live under `cmd/darepocli/darepoclicommands`.

The work follows the skill's incremental adoption order (machine-
readable output, input hardening, runtime introspection, field-mask
discipline, dry-run safety rails, MCP surface, agent context files),
hitting the highest-impact gap per surface. See each commit message
for a detailed description w.r.t the incremental changes.

## Commits

The four commits map 1:1 to the four CLI subtrees we audited:

`darepocli: agent-CLI hardening for top-level wallet verbs` installs
the semantic exit-code table (2 invalid args, 3 auth, 4 not found,
10 dry-run, 1 generic), wires a `--dry-run` rail on the mutating
verbs (`send`, `exit`) that prints a `{"dry_run":true,"method":...,
"body":...}` preview without dispatching, and brings the everyday
wallet surface (`balance`, `list`, `send`, `recv`, `exit`,
`exit.status`) into the MCP server. `create` and `unlock` stay
CLI-only by design because their inputs are secrets that must not
transit MCP. `PrintError` now returns a `printedError` carrying the
exit code so `return PrintError(...)` does the right thing end-to-
end.

`darepocli: agent-CLI hardening for the swap.* surface` adds shared
input-hardening helpers (`validatePaymentHash`, `validateInvoice`)
that live outside the swapruntime build tag so both the CLI handler
and the MCP tool can call them. Every `swap.*` verb gets `--json`
parity through `parseRequest`, full schema-registry entries (listed
unconditionally so stub-build agents can still discover the
surface), and MCP tool registration split across
`mcp_swap.go`/`mcp_swap_stub.go`. `swap.watch` stays CLI-only over
MCP because long-running subscriptions don't fit the
request/response tool model.

`darepocli: agent-CLI hardening for the ark.* surface` factors the
`--fields`/`--ndjson` rendering pattern into a shared
`renderListOutput` helper and applies it to every list-shaped
`ark.*` verb (`ark vtxos list`, `ark rounds list`, `ark oor list`,
`ark sweep list`, `ark listtransactions`). It also replaces the
`ark vtxos leave --all` interactive y/N prompt with a non-blocking
guard: when stdin is not a TTY, the command refuses to prompt and
emits an `INVALID_ARGS` envelope pointing the caller at `--yes` or
`--dry_run`. The schema registry grows entries for `ark.board`,
`ark.fees.{estimate,history}`, `ark.rounds.{get,list,watch}`, and
`ark.oor.{get,list}` which the earlier registry blocks had left
out, all list-shaped entries pick up the standard output modifiers
via a `listOutputParams` helper.

`darepocli: agent-CLI describe for generated dev RPC tree` adds a
per-method `--describe` flag to the auto-generated dev RPC tree.
It dumps a JSON schema for the method's input fields (path, type,
repeated, oneof_group, enum_values, plus the request/response type
names and the server-streaming bit) and returns without dispatching
the RPC. The implementation reuses the existing `fieldBinder` list
rather than re-walking the descriptor, so the describe output and
the CLI flag surface cannot drift.

## Agent-CLI posture summary

Every command-line surface now passes the same checklist:

* JSON output by default (proto-JSON on stdout, structured error
  envelopes on stderr).
* Input hardening on every external string (destination, outpoint,
  payment hash, invoice, free-text fields).
* Runtime introspection through `schema`, `schema <method>`, and
  the new `dev <svc> <method> --describe`.
* Field mask + NDJSON streaming on every list-shaped verb.
* `--dry-run` on the mutating wallet verbs and on the ark VTXO
  mutating verbs.
* Semantic exit codes mapped from cliError, printedError, and gRPC
  status codes.
* MCP coverage matching the CLI surface, with shared input-
  hardening builders so the two cannot drift.
* CLI and MCP secrecy invariant for `create`/`unlock` documented
  in `AGENTS.md`.

`AGENTS.md` was updated under each affected section to call out
the new flags and the rationale for the secrecy / MCP gating
choices.

## Test plan

- [x] `make fmt-changed`
- [x] `make lint-native` (zero issues)
- [x] `go build ./cmd/darepocli/...` (default tags)
- [x] `go build -tags swapruntime ./cmd/darepocli/...`
- [x] `go test ./cmd/darepocli/...` (default tags)
- [x] `go test -tags swapruntime ./cmd/darepocli/...`
- [x] `make commitmsg-lint range="origin/main..HEAD"`
- [ ] manual smoke against a regtest daemon (`schema --all`,
      `send --dry-run`, `exit --dry-run`, `mcp serve` with the new
      wallet tools, `ark vtxos list --fields txid,amount_sat
      --ndjson`, `ark vtxos leave --all` with closed stdin,
      `dev daemonrpc list-vtxos --describe`).