### PR TITLE
wallet: isolate client MuSig key families

### DIFF
--- a/darepod/indexer_proof_keyops.go
+++ b/darepod/indexer_proof_keyops.go
@@ -51,7 +51,7 @@ func (s *Server) indexerProofNextKeyOps() (DeriveDefaultOORReceiveKeyFunc,
 		error) {
 
 		return s.proofKeyBackend.DeriveNextKey(
-			ctx, keychain.KeyFamilyMultiSig,
+			ctx, oorReceiveKeyFamily,
 		)
 	}
 

--- a/darepod/indexer_proof_keyops_test.go
+++ b/darepod/indexer_proof_keyops_test.go
@@ -51,7 +51,7 @@ func TestIndexerProofKey(t *testing.T) {
 	require.NoError(t, err)
 
 	loc := keychain.KeyLocator{
-		Family: keychain.KeyFamilyMultiSig,
+		Family: oorReceiveKeyFamily,
 		Index:  7,
 	}
 	wantDesc := &keychain.KeyDescriptor{
@@ -89,7 +89,7 @@ func TestIndexerProofNextKeyOps(t *testing.T) {
 
 	wantDesc := &keychain.KeyDescriptor{
 		KeyLocator: keychain.KeyLocator{
-			Family: keychain.KeyFamilyMultiSig,
+			Family: oorReceiveKeyFamily,
 			Index:  11,
 		},
 		PubKey: privKey.PubKey(),
@@ -106,7 +106,7 @@ func TestIndexerProofNextKeyOps(t *testing.T) {
 
 	gotDesc, err := deriveNext(t.Context())
 	require.NoError(t, err)
-	require.Equal(t, keychain.KeyFamilyMultiSig, backend.deriveNextFamily)
+	require.Equal(t, oorReceiveKeyFamily, backend.deriveNextFamily)
 	require.Equal(t, wantDesc, gotDesc)
 
 	signer := signerFactory(*wantDesc)

--- a/darepod/receive_script_test.go
+++ b/darepod/receive_script_test.go
@@ -337,7 +337,7 @@ func testKeyDescriptor(t *testing.T, seed byte) keychain.KeyDescriptor {
 
 	return keychain.KeyDescriptor{
 		KeyLocator: keychain.KeyLocator{
-			Family: keychain.KeyFamilyMultiSig,
+			Family: oorReceiveKeyFamily,
 			Index:  uint32(seed),
 		},
 		PubKey: privKey.PubKey(),

--- a/lib/tree/batch.go
+++ b/lib/tree/batch.go
@@ -328,15 +328,17 @@ func BuildBatchOutput(vtxos []VTXODescriptor, operatorMuSigKey *btcec.PublicKey,
 	// Collect unique cosigners (operator + all client cosigners).
 	signers := []*btcec.PublicKey{operatorMuSigKey}
 	seenSigners := make(map[string]struct{})
-	operatorKeyStr := hex.EncodeToString(
-		schnorr.SerializePubKey(operatorMuSigKey),
-	)
+	operatorKeyStr := xOnlyKeyString(operatorMuSigKey)
 	seenSigners[operatorKeyStr] = struct{}{}
 
 	var totalAmount btcutil.Amount
-	for _, vtxo := range vtxos {
+	for i, vtxo := range vtxos {
 		if vtxo.Amount < 0 {
 			return nil, fmt.Errorf("vtxo amount cannot be negative")
+		}
+		if vtxo.CoSignerKey == nil {
+			return nil, fmt.Errorf("VTXO %d has nil co-signer key",
+				i)
 		}
 
 		// Check overflow before adding.
@@ -348,9 +350,12 @@ func BuildBatchOutput(vtxos []VTXODescriptor, operatorMuSigKey *btcec.PublicKey,
 		totalAmount += vtxo.Amount
 
 		// Add cosigner if not already seen.
-		keyStr := hex.EncodeToString(
-			schnorr.SerializePubKey(vtxo.CoSignerKey),
-		)
+		keyStr := xOnlyKeyString(vtxo.CoSignerKey)
+		if keyStr == operatorKeyStr {
+			return nil, fmt.Errorf("VTXO %d co-signer key matches "+
+				"operator key", i)
+		}
+
 		if _, seen := seenSigners[keyStr]; !seen {
 			seenSigners[keyStr] = struct{}{}
 			signers = append(signers, vtxo.CoSignerKey)
@@ -376,6 +381,12 @@ func BuildBatchOutput(vtxos []VTXODescriptor, operatorMuSigKey *btcec.PublicKey,
 		Value:    int64(totalAmount),
 		PkScript: pkScript,
 	}, nil
+}
+
+// xOnlyKeyString serializes a public key into the stable x-only key form used
+// for tree signer de-duplication.
+func xOnlyKeyString(key *btcec.PublicKey) string {
+	return hex.EncodeToString(schnorr.SerializePubKey(key))
 }
 
 // BuildConnectorOutput computes the pkscript and output amount for a connector

--- a/lib/tree/batch_test.go
+++ b/lib/tree/batch_test.go
@@ -830,6 +830,19 @@ func TestBuildBatchOutput(t *testing.T) {
 			require.Nil(t, output)
 			require.Contains(t, err.Error(), "sweep key")
 		})
+
+		t.Run("operator cosigner key fails", func(t *testing.T) {
+			vtxo := validVTXO
+			vtxo.CoSignerKey = operatorKey
+
+			output, err := BuildBatchOutput(
+				[]VTXODescriptor{vtxo}, operatorKey, sweepKey,
+				144,
+			)
+			require.Error(t, err)
+			require.Nil(t, output)
+			require.Contains(t, err.Error(), "operator key")
+		})
 	})
 }
 

--- a/lib/types/AGENTS.md
+++ b/lib/types/AGENTS.md
@@ -48,6 +48,7 @@ server during round participation. These types are used across `round`, `vtxo`,
 ## Invariants
 
 - `VTXOOwnerKeyFamily` (44) is the HD key family used for deriving VTXO owner signing keys.
+- `VTXOSigningKeyFamily` (45) is the HD key family used for per-round VTXO MuSig2 signing keys.
 - `JoinRoundAuthMessage` produces a deterministic byte encoding for Schnorr signature verification.
 
 ## Deep Docs

--- a/lib/types/CLAUDE.md
+++ b/lib/types/CLAUDE.md
@@ -48,6 +48,7 @@ server during round participation. These types are used across `round`, `vtxo`,
 ## Invariants
 
 - `VTXOOwnerKeyFamily` (44) is the HD key family used for deriving VTXO owner signing keys.
+- `VTXOSigningKeyFamily` (45) is the HD key family used for per-round VTXO MuSig2 signing keys.
 - `JoinRoundAuthMessage` produces a deterministic byte encoding for Schnorr signature verification.
 
 ## Deep Docs

--- a/lib/types/boarding.go
+++ b/lib/types/boarding.go
@@ -12,11 +12,19 @@ import (
 	"github.com/lightningnetwork/lnd/keychain"
 )
 
-// VTXOOwnerKeyFamily is the key family used for long-lived VTXO owner keys.
-// Owner keys are committed into the VTXO policy and must remain stable across
-// refreshes. This is distinct from the MuSig2 tree-signing key family used
-// during round construction.
-const VTXOOwnerKeyFamily keychain.KeyFamily = 44
+const (
+	// VTXOOwnerKeyFamily is the key family used for long-lived VTXO owner
+	// keys. Owner keys are committed into the VTXO policy and must remain
+	// stable across refreshes.
+	VTXOOwnerKeyFamily keychain.KeyFamily = 44
+
+	// VTXOSigningKeyFamily is the key family used for per-round VTXO
+	// MuSig2 signing keys. It is intentionally distinct from LND's
+	// internal multisig family and from the server operator family so a
+	// client sharing an LND signer with the server cannot derive the
+	// operator key as its first VTXO signing key.
+	VTXOSigningKeyFamily keychain.KeyFamily = 45
+)
 
 // OperatorTerms holds the information that the operator will share with
 // clients. It communicates the server's terms to the client.

--- a/round/actor_harness_test.go
+++ b/round/actor_harness_test.go
@@ -762,7 +762,7 @@ func (h *actorTestHarness) newTestBoardingIntentWithSuffix(
 	keyDesc := keychain.KeyDescriptor{
 		PubKey: h.clientPubKey,
 		KeyLocator: keychain.KeyLocator{
-			Family: keychain.KeyFamilyMultiSig,
+			Family: keychain.KeyFamily(wallet.BoardingKeyFamily),
 			Index:  0,
 		},
 	}
@@ -803,7 +803,7 @@ func (h *actorTestHarness) newKeyDescriptor() keychain.KeyDescriptor {
 	return keychain.KeyDescriptor{
 		PubKey: h.clientPubKey,
 		KeyLocator: keychain.KeyLocator{
-			Family: keychain.KeyFamilyMultiSig,
+			Family: types.VTXOSigningKeyFamily,
 			Index:  0,
 		},
 	}

--- a/round/actor_test.go
+++ b/round/actor_test.go
@@ -1952,11 +1952,11 @@ func TestHandleTriggerBoard(t *testing.T) {
 		},
 	}, nil).Once()
 	h.wallet.On(
-		"DeriveNextKey", mock.Anything, keychain.KeyFamilyMultiSig,
+		"DeriveNextKey", mock.Anything, types.VTXOSigningKeyFamily,
 	).Return(&keychain.KeyDescriptor{
 		PubKey: h.clientPubKey,
 		KeyLocator: keychain.KeyLocator{
-			Family: keychain.KeyFamilyMultiSig,
+			Family: types.VTXOSigningKeyFamily,
 			Index:  1,
 		},
 	}, nil).Once()
@@ -1987,7 +1987,7 @@ func TestHandleTriggerBoard(t *testing.T) {
 		regState.Intents.VTXOs[0].OwnerKey.Family,
 	)
 	require.Equal(
-		t, keychain.KeyFamilyMultiSig,
+		t, types.VTXOSigningKeyFamily,
 		regState.Intents.VTXOs[0].SigningKey.Family,
 	)
 }
@@ -2019,11 +2019,11 @@ func TestHandleTriggerBoardMultipleVTXOs(t *testing.T) {
 		}, nil).Once()
 		h.wallet.On(
 			"DeriveNextKey", mock.Anything,
-			keychain.KeyFamilyMultiSig,
+			types.VTXOSigningKeyFamily,
 		).Return(&keychain.KeyDescriptor{
 			PubKey: h.clientPubKey,
 			KeyLocator: keychain.KeyLocator{
-				Family: keychain.KeyFamilyMultiSig,
+				Family: types.VTXOSigningKeyFamily,
 				Index:  uint32(i),
 			},
 		}, nil).Once()

--- a/round/harness_test.go
+++ b/round/harness_test.go
@@ -201,7 +201,7 @@ func (m *MockClientWallet) DeriveNextKey(ctx context.Context,
 		}
 	}
 
-	if family == keychain.KeyFamilyMultiSig {
+	if family == types.VTXOSigningKeyFamily {
 		privKey, err := btcec.NewPrivateKey()
 		if err != nil {
 			return nil, err
@@ -541,8 +541,10 @@ func (h *boardingTestHarness) newTestBoardingAddress() wallet.BoardingAddress {
 		KeyDesc: keychain.KeyDescriptor{
 			PubKey: h.clientPubKey,
 			KeyLocator: keychain.KeyLocator{
-				Family: keychain.KeyFamilyMultiSig,
-				Index:  0,
+				Family: keychain.KeyFamily(
+					wallet.BoardingKeyFamily,
+				),
+				Index: 0,
 			},
 		},
 		OperatorKey: h.operatorPubKey,
@@ -597,7 +599,7 @@ func (h *boardingTestHarness) newTestVTXORequestForIntent(
 	signingKey := keychain.KeyDescriptor{
 		PubKey: h.clientPubKey,
 		KeyLocator: keychain.KeyLocator{
-			Family: keychain.KeyFamilyMultiSig,
+			Family: types.VTXOSigningKeyFamily,
 			Index:  0,
 		},
 	}
@@ -1717,7 +1719,7 @@ func (h *realSigningTestHarness) newTestBoardingIntentWithTapscript() BoardingIn
 	signingKey := keychain.KeyDescriptor{
 		PubKey: h.clientPubKey,
 		KeyLocator: keychain.KeyLocator{
-			Family: keychain.KeyFamilyMultiSig,
+			Family: keychain.KeyFamily(wallet.BoardingKeyFamily),
 			Index:  0,
 		},
 	}

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -21,7 +21,6 @@ import (
 	"github.com/lightninglabs/darepo-client/lib/types"
 	"github.com/lightninglabs/darepo-client/rpc/roundpb"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
-	"github.com/lightningnetwork/lnd/keychain"
 )
 
 // buildBoardingRequest constructs a types.BoardingRequest from a
@@ -2585,7 +2584,7 @@ func ensureVTXOSigningKeys(ctx context.Context, wallet ClientWallet,
 		}
 
 		keyDesc, err := wallet.DeriveNextKey(
-			ctx, keychain.KeyFamilyMultiSig,
+			ctx, types.VTXOSigningKeyFamily,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("derive signing key for vtxo "+

--- a/round/transitions_test.go
+++ b/round/transitions_test.go
@@ -65,7 +65,7 @@ func mkReq(t *testing.T, op *btcec.PublicKey, seed byte, owned bool) reqTree {
 		SigningKey: keychain.KeyDescriptor{
 			PubKey: signingPriv.PubKey(),
 			KeyLocator: keychain.KeyLocator{
-				Family: keychain.KeyFamilyMultiSig,
+				Family: types.VTXOSigningKeyFamily,
 				Index:  uint32(seed),
 			},
 		},

--- a/systest/send_vtxo_test.go
+++ b/systest/send_vtxo_test.go
@@ -657,7 +657,7 @@ func seedLiveVTXO(t *testing.T, cfg *darepod.Config,
 		ClientKey: keychain.KeyDescriptor{
 			PubKey: clientPriv.PubKey(),
 			KeyLocator: keychain.KeyLocator{
-				Family: keychain.KeyFamilyMultiSig,
+				Family: types.VTXOOwnerKeyFamily,
 				Index:  7,
 			},
 		},

--- a/vtxo/harness_test.go
+++ b/vtxo/harness_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/lib/actormsg"
 	"github.com/lightninglabs/darepo-client/lib/arkscript"
+	"github.com/lightninglabs/darepo-client/lib/types"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/stretchr/testify/mock"
@@ -377,7 +378,7 @@ func (h *vtxoTestHarness) newTestDescriptor() *Descriptor {
 		ClientKey: keychain.KeyDescriptor{
 			PubKey: h.clientPubKey,
 			KeyLocator: keychain.KeyLocator{
-				Family: keychain.KeyFamilyMultiSig,
+				Family: types.VTXOOwnerKeyFamily,
 				Index:  0,
 			},
 		},
@@ -645,7 +646,7 @@ func (h *realVTXOSigningHarness) newTestDescriptor() *Descriptor {
 		ClientKey: keychain.KeyDescriptor{
 			PubKey: h.clientPubKey,
 			KeyLocator: keychain.KeyLocator{
-				Family: keychain.KeyFamilyMultiSig,
+				Family: types.VTXOOwnerKeyFamily,
 				Index:  0,
 			},
 		},

--- a/vtxo/transitions_test.go
+++ b/vtxo/transitions_test.go
@@ -14,6 +14,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	// testOperatorKeyFamily is an arbitrary key family used for operator
+	// signing fixtures. It is intentionally distinct from the client VTXO
+	// owner and signing key families.
+	testOperatorKeyFamily = keychain.KeyFamily(201)
+)
+
 // TestStateProperties verifies basic properties of all states.
 func TestStateProperties(t *testing.T) {
 	t.Parallel()
@@ -1284,7 +1291,7 @@ func TestForfeitSignatureValidity(t *testing.T) {
 	operatorKeyDesc := keychain.KeyDescriptor{
 		PubKey: h.operatorPubKey,
 		KeyLocator: keychain.KeyLocator{
-			Family: keychain.KeyFamilyMultiSig,
+			Family: testOperatorKeyFamily,
 			Index:  0,
 		},
 	}


### PR DESCRIPTION
## Summary

- add a dedicated VTXO signing key family for per-round client MuSig2 keys
- move indexer proof/OOR receive derivation off LND's internal multisig family
- reject batch outputs whose VTXO co-signer key equals the operator key

## Testing

- make commitmsg-lint range=origin/main..HEAD
- make fmt-changed-check base=origin/main
- make tidy-module-check
- make lint-changed-local base=origin/main
- go test ./lib/tree -run TestBuildBatchOutput
- go test ./darepod -run 'TestIndexerProof|TestCreateOORReceiveScript|TestResolveOwnedOORReceiveScript'\n- go test ./round -run 'TestHandleTriggerBoard|TestEnsureVTXOSigningKeys|TestBuildBoardingRequest'\n\nCI after force-push: commit-message, static checks, lint, cross-compilation, unit-cover, sqlite unit, and both system-test lanes are passing; longer postgres unit and race jobs are still running.