### PR TITLE
build: alias lint-native to lint-local

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,8 @@ This file is a **map**, not a manual. Follow links for details.
 | Command | Purpose |
 |---------|---------|
 | `make build` | Compile the project |
-| `make lint-native` | Run native linter on branch changes (preferred, no Docker) |
-| `make lint-changed-local` | Run native linter on changes vs base (alternative) |
+| `make lint-local` | Run full linter locally, no Docker |
+| `make lint-changed-local` | Run local linter on changes vs base |
 | `make lint` | Run linter via Docker (CI canonical) |
 | `make install-custom-gcl` | Build native `custom-gcl` for this host |
 | `make fmt` | Format all Go source files |
@@ -58,9 +58,9 @@ Body wrapped at 72 characters. Explain WHY, not just WHAT.
 3. **Run `make fmt-changed` before every commit.**
    This applies `goimports` and `llformat` to changed handwritten Go files.
    Use `make fmt` instead when you intentionally need a full-tree format pass.
-4. **Run `make lint-native` before every commit.**
-   This builds and runs the custom linter natively via `go tool` — much
-   faster than Docker. Only lints changes on the current branch.
+4. **Run `make lint-changed-local` before every commit.**
+   This is the fast local no-Docker changed-code check. Run `make lint-local`
+   when you need the full local lint scope.
 5. **Run tests before every commit** — see [`docs/testing-guide.md`](docs/testing-guide.md).
 6. **Run `make commitmsg-lint range="origin/main..HEAD"` before pushing.**
    CI runs the same check via [`scripts/commit_message.py`](scripts/commit_message.py);

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,8 +7,8 @@ This file is a **map**, not a manual. Follow links for details.
 | Command | Purpose |
 |---------|---------|
 | `make build` | Compile the project |
-| `make lint-native` | Run native linter on branch changes (preferred, no Docker) |
-| `make lint-changed-local` | Run native linter on changes vs base (alternative) |
+| `make lint-local` | Run full linter locally, no Docker |
+| `make lint-changed-local` | Run local linter on changes vs base |
 | `make lint` | Run linter via Docker (CI canonical) |
 | `make install-custom-gcl` | Build native `custom-gcl` for this host |
 | `make fmt` | Format all Go source files |
@@ -58,9 +58,9 @@ Body wrapped at 72 characters. Explain WHY, not just WHAT.
 3. **Run `make fmt-changed` before every commit.**
    This applies `goimports` and `llformat` to changed handwritten Go files.
    Use `make fmt` instead when you intentionally need a full-tree format pass.
-4. **Run `make lint-native` before every commit.**
-   This builds and runs the custom linter natively via `go tool` — much
-   faster than Docker. Only lints changes on the current branch.
+4. **Run `make lint-changed-local` before every commit.**
+   This is the fast local no-Docker changed-code check. Run `make lint-local`
+   when you need the full local lint scope.
 5. **Run tests before every commit** — see [`docs/testing-guide.md`](docs/testing-guide.md).
 6. **Run `make commitmsg-lint range="origin/main..HEAD"` before pushing.**
    CI runs the same check via [`scripts/commit_message.py`](scripts/commit_message.py);

--- a/Makefile
+++ b/Makefile
@@ -233,11 +233,11 @@ lint-source: docker-tools
 
 lint-source-local: local-custom-gcl
 	@$(call print, "Linting source locally (no Docker).")
-	$(LOCAL_CUSTOM_GCL) run -v --timeout=15m $(LINT_WORKERS)
+	GOWORK=off $(LOCAL_CUSTOM_GCL) run -v --timeout=15m $(LINT_WORKERS)
 
 lint-changed-local: local-custom-gcl #? Run static code analysis only for changes against base=<ref> locally (no Docker)
 	@$(call print, "Linting source changes against $(LINT_BASE) locally.")
-	$(LOCAL_CUSTOM_GCL) run -v --timeout=15m $(LINT_WORKERS) \
+	GOWORK=off $(LOCAL_CUSTOM_GCL) run -v --timeout=15m $(LINT_WORKERS) \
 		--new-from-merge-base=$(LINT_BASE) \
 		--whole-files
 
@@ -245,10 +245,9 @@ build-native-linter: #? Build the custom golangci-lint binary natively via go to
 	@$(call print, "Building custom linter natively.")
 	cd $(TOOLS_DIR) && CGO_ENABLED=0 $(GOCC) tool $(GOLINT_PKG) custom
 
-lint-native: check-go-version build-native-linter #? Run static code analysis without Docker (faster on macOS)
-	@$(call print, "Linting source (native).")
-	GOWORK=off $(LOCAL_CUSTOM_GCL) run -v --timeout=15m $(LINT_WORKERS) \
-		--new-from-rev=$$(git merge-base HEAD $(LINT_BASE))
+lint-native: #? Deprecated alias for lint-local
+	@$(call print, "lint-native is deprecated; use lint-local instead.")
+	@$(MAKE) lint-local
 
 # Globs to exclude generated files from ast-grep.
 AST_GREP_EXCLUDE := --globs '!**/*.pb.go' --globs '!**/*.pb.gw.go' --globs '!**/*.pb.json.go' --globs '!**/db/sqlc/*.go'
@@ -279,10 +278,10 @@ fmt: $(GOIMPORTS_BIN) $(LLFORMAT_BIN) #? Format handwritten Go source and import
 fmt-changed: $(GOIMPORTS_BIN) $(LLFORMAT_BIN) #? Format changed handwritten Go source and imports
 	@$(call print, "Fixing imports for Go source changes against $(FMT_BASE).")
 	@./scripts/llformat-files.sh changed "$(FMT_BASE)" | \
-		xargs -0 $(GOIMPORTS_BIN) -w
+		xargs -0 -r $(GOIMPORTS_BIN) -w
 	@$(call print, "Formatting Go source changes against $(FMT_BASE).")
 	@./scripts/llformat-files.sh changed "$(FMT_BASE)" | \
-		xargs -0 $(LLFORMAT_BIN) -w
+		xargs -0 -r $(LLFORMAT_BIN) -w
 
 fmt-check: fmt #? Verify code is formatted correctly
 	@$(call print, "Checking fmt results.")

--- a/scripts/local-custom-gcl.sh
+++ b/scripts/local-custom-gcl.sh
@@ -4,17 +4,52 @@ set -eu
 
 dest="${1:?usage: local-custom-gcl.sh <dest>}"
 script_dir=$(CDPATH='' cd -- "$(dirname "$0")" && pwd)
+repo_root=$(CDPATH='' cd -- "$script_dir/.." && pwd)
+config_file="$repo_root/tools/.custom-gcl.yml"
+expected_version=$(
+	sed -n 's/^version:[[:space:]]*//p' "$config_file" | head -n 1
+)
+
+binary_version() {
+	"$1" --version 2>/dev/null | awk '
+		{
+			for (i = 1; i <= NF; i++) {
+				if ($i == "version") {
+					print $(i + 1)
+					exit
+				}
+			}
+		}
+	' | sed 's/-custom-gcl$//'
+}
+
+use_if_current() {
+	bin="$1"
+	label="$2"
+	version=$(binary_version "$bin" || true)
+
+	if [ "$version" = "$expected_version" ]; then
+		echo "Using ${label}: $bin"
+		return 0
+	fi
+
+	if [ -n "$version" ]; then
+		echo "Ignoring stale ${label}: $bin ($version != $expected_version)"
+	fi
+
+	return 1
+}
 
 mkdir -p "$(dirname "$dest")"
 
-if command -v custom-gcl >/dev/null 2>&1; then
+if command -v custom-gcl >/dev/null 2>&1 &&
+	use_if_current "$(command -v custom-gcl)" "custom-gcl from PATH"; then
 	ln -sf "$(command -v custom-gcl)" "$dest"
 	echo "Using custom-gcl from PATH."
 	exit 0
 fi
 
-if [ -x "$dest" ]; then
-	echo "Using local linter binary: $dest"
+if [ -x "$dest" ] && use_if_current "$dest" "local linter binary"; then
 	exit 0
 fi
 


### PR DESCRIPTION
## Summary

This makes `lint-native` a deprecated compatibility wrapper for `lint-local`, so the two local/no-Docker lint target names no longer exercise different scopes.

The local lint path now preserves `GOWORK=off`, and the local custom linter helper checks the configured golangci-lint version before reusing an existing `custom-gcl` binary. That avoids reusing stale binaries after the repo config moves forward.

The docs now recommend `make lint-changed-local` for quick pre-commit changed-code linting, with `make lint-local` reserved for the full local lint scope.

This also mirrors `darepo`'s `xargs -r` guard in `fmt-changed`, so non-Go-only PRs do not invoke formatters with an empty path list.

## Verification

- `make fmt-changed-check base=origin/main`
- `make tidy-module-check && make sample-conf-check && make schema-check && make sqlc-check`
- `make lint-local`
- `make -n lint-native`
- `make commitmsg-lint commit=HEAD`
- `git diff --check HEAD^ HEAD`
