### PR TITLE
unroll: introduce exit spend policies

### DIFF
--- a/db/sqlc/migrations/000008_unroll_jobs.up.sql
+++ b/db/sqlc/migrations/000008_unroll_jobs.up.sql
@@ -39,6 +39,14 @@ CREATE TABLE IF NOT EXISTS unroll_jobs (
     -- deferred_checkpoints records fraud-triggered checkpoint deferrals.
     deferred_checkpoints BLOB,
 
+    -- exit_policy_kind identifies the policy used for the final exit spend.
+    -- The resolver validates this extension point so future policy kinds do
+    -- not require rebuilding this table on SQLite.
+    exit_policy_kind TEXT NOT NULL,
+
+    -- exit_policy_ref optionally points at policy-specific durable state.
+    exit_policy_ref TEXT,
+
     -- sweep_tx stores the exact final sweep transaction bytes after build.
     sweep_tx BLOB,
 

--- a/db/sqlc/models.go
+++ b/db/sqlc/models.go
@@ -516,6 +516,8 @@ type UnrollJob struct {
 	TargetConfirmHeight sql.NullInt32
 	PlannerState        []byte
 	DeferredCheckpoints []byte
+	ExitPolicyKind      string
+	ExitPolicyRef       sql.NullString
 	SweepTx             []byte
 	SweepTxid           []byte
 	SweepConfirmHeight  sql.NullInt32

--- a/db/sqlc/queries/unroll_jobs.sql
+++ b/db/sqlc/queries/unroll_jobs.sql
@@ -4,10 +4,12 @@
 INSERT INTO unroll_jobs (
     target_outpoint_hash, target_outpoint_index, state, trigger,
     best_height, target_confirm_height, planner_state, deferred_checkpoints,
-    sweep_tx, sweep_txid, sweep_confirm_height, sweep_attempts, fail_reason,
-    created_at, updated_at
+    exit_policy_kind, exit_policy_ref, sweep_tx, sweep_txid,
+    sweep_confirm_height, sweep_attempts, fail_reason, created_at,
+    updated_at
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15,
+    $16, $17
 )
 ON CONFLICT (target_outpoint_hash, target_outpoint_index) DO UPDATE SET
     state = EXCLUDED.state,
@@ -16,6 +18,8 @@ ON CONFLICT (target_outpoint_hash, target_outpoint_index) DO UPDATE SET
     target_confirm_height = EXCLUDED.target_confirm_height,
     planner_state = EXCLUDED.planner_state,
     deferred_checkpoints = EXCLUDED.deferred_checkpoints,
+    exit_policy_kind = EXCLUDED.exit_policy_kind,
+    exit_policy_ref = EXCLUDED.exit_policy_ref,
     sweep_tx = EXCLUDED.sweep_tx,
     sweep_txid = EXCLUDED.sweep_txid,
     sweep_confirm_height = EXCLUDED.sweep_confirm_height,

--- a/db/sqlc/schemas/generated_schema.sql
+++ b/db/sqlc/schemas/generated_schema.sql
@@ -1205,6 +1205,14 @@ CREATE TABLE unroll_jobs (
     -- deferred_checkpoints records fraud-triggered checkpoint deferrals.
     deferred_checkpoints BLOB,
 
+    -- exit_policy_kind identifies the policy used for the final exit spend.
+    -- The resolver validates this extension point so future policy kinds do
+    -- not require rebuilding this table on SQLite.
+    exit_policy_kind TEXT NOT NULL,
+
+    -- exit_policy_ref optionally points at policy-specific durable state.
+    exit_policy_ref TEXT,
+
     -- sweep_tx stores the exact final sweep transaction bytes after build.
     sweep_tx BLOB,
 

--- a/db/sqlc/unroll_jobs.sql.go
+++ b/db/sqlc/unroll_jobs.sql.go
@@ -103,7 +103,7 @@ func (q *Queries) DeleteUnrollWatchesForJob(ctx context.Context, arg DeleteUnrol
 }
 
 const GetUnrollJob = `-- name: GetUnrollJob :one
-SELECT target_outpoint_hash, target_outpoint_index, state, trigger, best_height, target_confirm_height, planner_state, deferred_checkpoints, sweep_tx, sweep_txid, sweep_confirm_height, sweep_attempts, fail_reason, created_at, updated_at FROM unroll_jobs
+SELECT target_outpoint_hash, target_outpoint_index, state, trigger, best_height, target_confirm_height, planner_state, deferred_checkpoints, exit_policy_kind, exit_policy_ref, sweep_tx, sweep_txid, sweep_confirm_height, sweep_attempts, fail_reason, created_at, updated_at FROM unroll_jobs
 WHERE target_outpoint_hash = $1
   AND target_outpoint_index = $2
 `
@@ -125,6 +125,8 @@ func (q *Queries) GetUnrollJob(ctx context.Context, arg GetUnrollJobParams) (Unr
 		&i.TargetConfirmHeight,
 		&i.PlannerState,
 		&i.DeferredCheckpoints,
+		&i.ExitPolicyKind,
+		&i.ExitPolicyRef,
 		&i.SweepTx,
 		&i.SweepTxid,
 		&i.SweepConfirmHeight,
@@ -215,7 +217,7 @@ func (q *Queries) ListDueUnrollEffectIDs(ctx context.Context, arg ListDueUnrollE
 }
 
 const ListNonTerminalUnrollJobs = `-- name: ListNonTerminalUnrollJobs :many
-SELECT target_outpoint_hash, target_outpoint_index, state, trigger, best_height, target_confirm_height, planner_state, deferred_checkpoints, sweep_tx, sweep_txid, sweep_confirm_height, sweep_attempts, fail_reason, created_at, updated_at FROM unroll_jobs
+SELECT target_outpoint_hash, target_outpoint_index, state, trigger, best_height, target_confirm_height, planner_state, deferred_checkpoints, exit_policy_kind, exit_policy_ref, sweep_tx, sweep_txid, sweep_confirm_height, sweep_attempts, fail_reason, created_at, updated_at FROM unroll_jobs
 WHERE state NOT IN ('completed', 'failed')
 ORDER BY created_at ASC
 `
@@ -238,6 +240,8 @@ func (q *Queries) ListNonTerminalUnrollJobs(ctx context.Context) ([]UnrollJob, e
 			&i.TargetConfirmHeight,
 			&i.PlannerState,
 			&i.DeferredCheckpoints,
+			&i.ExitPolicyKind,
+			&i.ExitPolicyRef,
 			&i.SweepTx,
 			&i.SweepTxid,
 			&i.SweepConfirmHeight,
@@ -475,10 +479,12 @@ const UpsertUnrollJob = `-- name: UpsertUnrollJob :exec
 INSERT INTO unroll_jobs (
     target_outpoint_hash, target_outpoint_index, state, trigger,
     best_height, target_confirm_height, planner_state, deferred_checkpoints,
-    sweep_tx, sweep_txid, sweep_confirm_height, sweep_attempts, fail_reason,
-    created_at, updated_at
+    exit_policy_kind, exit_policy_ref, sweep_tx, sweep_txid,
+    sweep_confirm_height, sweep_attempts, fail_reason, created_at,
+    updated_at
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15,
+    $16, $17
 )
 ON CONFLICT (target_outpoint_hash, target_outpoint_index) DO UPDATE SET
     state = EXCLUDED.state,
@@ -487,6 +493,8 @@ ON CONFLICT (target_outpoint_hash, target_outpoint_index) DO UPDATE SET
     target_confirm_height = EXCLUDED.target_confirm_height,
     planner_state = EXCLUDED.planner_state,
     deferred_checkpoints = EXCLUDED.deferred_checkpoints,
+    exit_policy_kind = EXCLUDED.exit_policy_kind,
+    exit_policy_ref = EXCLUDED.exit_policy_ref,
     sweep_tx = EXCLUDED.sweep_tx,
     sweep_txid = EXCLUDED.sweep_txid,
     sweep_confirm_height = EXCLUDED.sweep_confirm_height,
@@ -504,6 +512,8 @@ type UpsertUnrollJobParams struct {
 	TargetConfirmHeight sql.NullInt32
 	PlannerState        []byte
 	DeferredCheckpoints []byte
+	ExitPolicyKind      string
+	ExitPolicyRef       sql.NullString
 	SweepTx             []byte
 	SweepTxid           []byte
 	SweepConfirmHeight  sql.NullInt32
@@ -524,6 +534,8 @@ func (q *Queries) UpsertUnrollJob(ctx context.Context, arg UpsertUnrollJobParams
 		arg.TargetConfirmHeight,
 		arg.PlannerState,
 		arg.DeferredCheckpoints,
+		arg.ExitPolicyKind,
+		arg.ExitPolicyRef,
 		arg.SweepTx,
 		arg.SweepTxid,
 		arg.SweepConfirmHeight,

--- a/db/unroll_job_store.go
+++ b/db/unroll_job_store.go
@@ -19,6 +19,14 @@ var (
 	ErrUnrollJobNotFound = errors.New("unroll job not found")
 )
 
+const (
+	// StandardUnrollExitPolicyKind is the built-in final spend policy for
+	// normal VTXO timeout sweeps. This mirrors
+	// unroll.StandardVTXOTimeoutExitPolicyKind without importing unroll
+	// into the db package.
+	StandardUnrollExitPolicyKind = "standard_vtxo_timeout"
+)
+
 // UnrollJobRecord is the restart-safe SQL state for one VTXO unroll target.
 type UnrollJobRecord struct {
 	TargetOutpoint      wire.OutPoint
@@ -28,6 +36,8 @@ type UnrollJobRecord struct {
 	TargetConfirmHeight *int32
 	PlannerState        []byte
 	DeferredCheckpoints []byte
+	ExitPolicyKind      string
+	ExitPolicyRef       string
 	SweepTx             []byte
 	SweepTxid           []byte
 	SweepConfirmHeight  *int32
@@ -171,6 +181,11 @@ func (s *UnrollJobPersistenceStore) UpsertJob(ctx context.Context,
 		createdAt = nowUnix
 	}
 
+	exitPolicyKind := job.ExitPolicyKind
+	if exitPolicyKind == "" {
+		exitPolicyKind = StandardUnrollExitPolicyKind
+	}
+
 	target := job.TargetOutpoint
 	writeFn := func(q UnrollJobStore) error {
 		err := q.UpsertUnrollJob(
@@ -190,6 +205,11 @@ func (s *UnrollJobPersistenceStore) UpsertJob(ctx context.Context,
 				DeferredCheckpoints: append(
 					[]byte(nil), job.DeferredCheckpoints...,
 				),
+				ExitPolicyKind: exitPolicyKind,
+				ExitPolicyRef: sql.NullString{
+					String: job.ExitPolicyRef,
+					Valid:  job.ExitPolicyRef != "",
+				},
 				SweepTx:   append([]byte(nil), job.SweepTx...),
 				SweepTxid: append([]byte(nil), job.SweepTxid...),
 				SweepConfirmHeight: nullableInt32(
@@ -744,6 +764,10 @@ func unrollJobRecordFromRow(row sqlc.UnrollJob) (UnrollJobRecord, error) {
 		SweepAttempts:      row.SweepAttempts,
 		CreatedAt:          time.Unix(row.CreatedAt, 0),
 		UpdatedAt:          time.Unix(row.UpdatedAt, 0),
+	}
+	record.ExitPolicyKind = row.ExitPolicyKind
+	if row.ExitPolicyRef.Valid {
+		record.ExitPolicyRef = row.ExitPolicyRef.String
 	}
 	if row.FailReason.Valid {
 		record.FailReason = row.FailReason.String

--- a/db/unroll_job_store_test.go
+++ b/db/unroll_job_store_test.go
@@ -112,6 +112,7 @@ func TestUnrollJobStoreUpsertPersistsNamedArtifacts(t *testing.T) {
 		Trigger:        "manual",
 		BestHeight:     111,
 		PlannerState:   []byte{0x01},
+		ExitPolicyRef:  "policy-ref-a",
 		SweepTx:        sweepTx,
 		SweepTxid:      sweepTxid,
 		TxProgress: []UnrollTxProgressRecord{{
@@ -135,6 +136,7 @@ func TestUnrollJobStoreUpsertPersistsNamedArtifacts(t *testing.T) {
 		Trigger:        "manual",
 		BestHeight:     112,
 		PlannerState:   []byte{0x02},
+		ExitPolicyRef:  "policy-ref-a",
 		SweepTx:        sweepTx,
 		SweepTxid:      sweepTxid,
 		TxProgress: []UnrollTxProgressRecord{{
@@ -156,6 +158,8 @@ func TestUnrollJobStoreUpsertPersistsNamedArtifacts(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, job)
 	require.Equal(t, "completed", job.State)
+	require.Equal(t, StandardUnrollExitPolicyKind, job.ExitPolicyKind)
+	require.Equal(t, "policy-ref-a", job.ExitPolicyRef)
 	require.Equal(t, sweepTxid, job.SweepTxid)
 	require.Equal(t, sweepTx, job.SweepTx)
 	require.Len(t, job.TxProgress, 1)

--- a/unroll/actor.go
+++ b/unroll/actor.go
@@ -55,6 +55,11 @@ type Config struct {
 		chainsource.ChainSourceMsg, chainsource.ChainSourceResp,
 	]
 
+	// ExitSpendPolicyResolver reconstructs the exit policy for the durable
+	// kind/ref stored on the unroll job. If nil, the actor uses the
+	// built-in standard VTXO timeout resolver.
+	ExitSpendPolicyResolver ExitSpendPolicyResolver
+
 	// Wallet provides sweep destination derivation and
 	// timeout-path signing.
 	Wallet SweepWallet
@@ -381,9 +386,29 @@ func (b *behavior) startSweep(ctx context.Context) error {
 	// prior attempt inside this actor lifetime) so we converge on a
 	// single sweep txid / wallet pkScript across retries.
 	if b.sweepTx == nil {
+		policy, err := b.resolveExitSpendPolicy(ctx)
+		if err != nil {
+			return b.driveEvent(ctx, &SweepBuildFailedEvent{
+				Reason: err.Error(),
+			})
+		}
+
+		b.log.InfoS(ctx, "Building unroll exit spend",
+			slog.String(
+				"target_outpoint",
+				b.cfg.TargetOutpoint.String(),
+			),
+			slog.String(
+				"exit_policy_kind",
+				policy.Kind(),
+			),
+			slog.Uint64("csv_delay", uint64(policy.CSVDelay())),
+		)
+
 		sweepTx, err := buildSweepTx(
 			ctx, b.cfg.Wallet, b.cfg.ChainSource, b.proof, b.desc,
-			b.cfg.MaxSweepFeeRateSatPerVByte,
+			b.cfg.MaxSweepFeeRateSatPerVByte, b.currentHeight(),
+			policy,
 		)
 		if err != nil {
 			return b.driveEvent(ctx, &SweepBuildFailedEvent{
@@ -392,6 +417,18 @@ func (b *behavior) startSweep(ctx context.Context) error {
 		}
 
 		b.sweepTx = sweepTx
+	} else {
+		sweepTxid := b.sweepTx.TxHash()
+		b.log.DebugS(ctx, "Reusing persisted unroll exit spend",
+			slog.String(
+				"target_outpoint",
+				b.cfg.TargetOutpoint.String(),
+			),
+			slog.String(
+				"exit_policy_kind", b.exitPolicyKind(),
+			),
+			slog.String("txid", sweepTxid.String()),
+		)
 	}
 
 	// Persist the built sweep before asking txconfirm to broadcast, so
@@ -407,6 +444,15 @@ func (b *behavior) startSweep(ctx context.Context) error {
 	}
 
 	sweepLabel := "unroll-sweep-" + b.cfg.TargetOutpoint.String()
+	sweepTxid := b.sweepTx.TxHash()
+
+	b.log.InfoS(ctx, "Submitting unroll exit spend",
+		slog.String("target_outpoint", b.cfg.TargetOutpoint.String()),
+		slog.String(
+			"exit_policy_kind", b.exitPolicyKind(),
+		),
+		slog.String("txid", sweepTxid.String()),
+	)
 
 	_, err = b.cfg.TxConfirmRef.Ask(ctx, &txconfirm.EnsureConfirmedReq{
 		Tx:                   b.sweepTx,
@@ -420,9 +466,50 @@ func (b *behavior) startSweep(ctx context.Context) error {
 
 	b.markRuntimeEffectDone(ctx, "build-sweep")
 
-	sweepTxid := b.sweepTx.TxHash()
-
 	return b.driveEvent(ctx, &SweepBroadcastedEvent{Txid: sweepTxid})
+}
+
+// exitPolicyKind returns the durable policy kind for the current job.
+func (b *behavior) exitPolicyKind() string {
+	if b.pending == nil {
+		return StandardVTXOTimeoutExitPolicyKind
+	}
+
+	return exitPolicyKind(b.pending.ExitPolicyKind)
+}
+
+// exitPolicyRef returns the durable policy ref for the current job.
+func (b *behavior) exitPolicyRef() string {
+	if b.pending == nil {
+		return ""
+	}
+
+	return b.pending.ExitPolicyRef
+}
+
+// currentHeight returns the last persisted height for policy construction.
+func (b *behavior) currentHeight() int32 {
+	if b.pending == nil {
+		return 0
+	}
+
+	return b.pending.Height
+}
+
+// resolveExitSpendPolicy reconstructs the exit policy for this job.
+func (b *behavior) resolveExitSpendPolicy(ctx context.Context) (ExitSpendPolicy,
+	error) {
+
+	resolver := b.cfg.ExitSpendPolicyResolver
+	if resolver == nil {
+		resolver = standardExitSpendPolicyResolver{}
+	}
+
+	return resolver.ResolveExitSpendPolicy(ctx, ExitSpendPolicyRequest{
+		Kind:               b.exitPolicyKind(),
+		Ref:                b.exitPolicyRef(),
+		StandardDescriptor: b.desc,
+	})
 }
 
 // safeTxOutPkScript returns a defensive copy of tx.TxOut[index].PkScript.

--- a/unroll/actor_test.go
+++ b/unroll/actor_test.go
@@ -2198,7 +2198,7 @@ func TestResumeReissuesSweepConfirmation(t *testing.T) {
 	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
 	sweepTx, err := buildSweepTx(
 		t.Context(), &fakeSweepWallet{}, &fakeChainSourceRef{}, proof,
-		desc, 0,
+		desc, 0, 110, NewStandardVTXOExitSpendPolicy(desc),
 	)
 	require.NoError(t, err)
 
@@ -2271,12 +2271,64 @@ func TestBuildSweepTx(t *testing.T) {
 
 	sweepTx, err := buildSweepTx(
 		t.Context(), &fakeSweepWallet{}, &fakeChainSourceRef{}, proof,
-		desc, 0,
+		desc, 0, 110, NewStandardVTXOExitSpendPolicy(desc),
 	)
 	require.NoError(t, err)
 	require.Len(t, sweepTx.TxIn, 1)
 	require.Len(t, sweepTx.TxOut, 1)
+	require.Equal(t, desc.RelativeExpiry, sweepTx.TxIn[0].Sequence)
 	require.NotEmpty(t, sweepTx.TxIn[0].Witness)
+}
+
+// TestStandardVTXOExitSpendPolicyRejectsNilTarget verifies the policy checks
+// that a materialized output is present before building an exit spend.
+func TestStandardVTXOExitSpendPolicyRejectsNilTarget(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	policy := NewStandardVTXOExitSpendPolicy(desc)
+
+	err := policy.ValidateTarget(nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "target output")
+
+	err = policy.ValidateTarget(&wire.TxOut{Value: 0})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "positive")
+}
+
+// TestStandardExitSpendPolicyResolver verifies the default resolver maps the
+// durable standard policy identity back to the standard policy implementation.
+func TestStandardExitSpendPolicyResolver(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+
+	policy, err := (standardExitSpendPolicyResolver{}).ResolveExitSpendPolicy(
+		t.Context(), ExitSpendPolicyRequest{
+			Kind:               StandardVTXOTimeoutExitPolicyKind,
+			StandardDescriptor: desc,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, StandardVTXOTimeoutExitPolicyKind, policy.Kind())
+	require.Equal(t, desc.RelativeExpiry, policy.CSVDelay())
+
+	_, err = (standardExitSpendPolicyResolver{}).ResolveExitSpendPolicy(
+		t.Context(), ExitSpendPolicyRequest{
+			Kind:               StandardVTXOTimeoutExitPolicyKind,
+			Ref:                "non-empty",
+			StandardDescriptor: desc,
+		},
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ref must be empty")
+
+	_, err = (standardExitSpendPolicyResolver{}).ResolveExitSpendPolicy(
+		t.Context(), ExitSpendPolicyRequest{
+			Kind: "unknown_policy",
+		},
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown exit policy kind")
 }
 
 // TestBuildSweepTxFallsBackWithoutFeeEstimate verifies the sweep builder uses
@@ -2288,7 +2340,7 @@ func TestBuildSweepTxFallsBackWithoutFeeEstimate(t *testing.T) {
 	sweepTx, err := buildSweepTx(
 		t.Context(), &fakeSweepWallet{}, &fakeChainSourceRef{
 			feeErr: fmt.Errorf("no fee estimates available"),
-		}, proof, desc, 0,
+		}, proof, desc, 0, 110, NewStandardVTXOExitSpendPolicy(desc),
 	)
 	require.NoError(t, err)
 

--- a/unroll/interfaces.go
+++ b/unroll/interfaces.go
@@ -29,6 +29,80 @@ type SweepWallet interface {
 	NewWalletPkScript(ctx context.Context) ([]byte, error)
 }
 
+const (
+	// StandardVTXOTimeoutExitPolicyKind identifies the built-in timeout
+	// sweep policy for normal Ark VTXOs.
+	StandardVTXOTimeoutExitPolicyKind = "standard_vtxo_timeout"
+)
+
+// ExitSpendRequest carries the materialized on-chain output and local signing
+// context needed to build the final exit spend.
+type ExitSpendRequest struct {
+	// TargetOutpoint is the materialized on-chain output to spend.
+	TargetOutpoint wire.OutPoint
+
+	// TargetOutput is the output being spent.
+	TargetOutput *wire.TxOut
+
+	// DestinationPkScript receives the recovered funds.
+	DestinationPkScript []byte
+
+	// FeeRateSatPerVByte is the selected fee rate for the exit spend.
+	FeeRateSatPerVByte int64
+
+	// CurrentHeight is the last persisted best chain height from the
+	// unroll job. It may lag the live chain tip and is unused by the
+	// standard policy, but is available to future policies that need
+	// height context for timelock validation.
+	CurrentHeight int32
+
+	// Signer signs the exit spend.
+	Signer input.Signer
+}
+
+// ExitSpendPolicyRequest identifies the durable exit policy to reconstruct.
+type ExitSpendPolicyRequest struct {
+	// Kind is the durable policy kind persisted with the unroll job.
+	Kind string
+
+	// Ref is an optional policy-specific durable-state reference.
+	Ref string
+
+	// StandardDescriptor is the descriptor used by the built-in standard
+	// VTXO timeout policy. Custom resolvers may ignore it when their
+	// policy-specific state is addressed by Kind and Ref.
+	StandardDescriptor *vtxo.Descriptor
+}
+
+// ExitSpendPolicy describes how unroll spends the materialized target output
+// once the Ark lineage has been brought on chain.
+type ExitSpendPolicy interface {
+	// Kind returns the durable policy kind persisted with the unroll job.
+	Kind() string
+
+	// CSVDelay returns the relative delay required by this policy.
+	CSVDelay() uint32
+
+	// ValidateTarget verifies this policy can spend the materialized target
+	// output.
+	ValidateTarget(target *wire.TxOut) error
+
+	// BuildSpendTx builds and signs the exit transaction.
+	BuildSpendTx(ctx context.Context,
+		req ExitSpendRequest) (*wire.MsgTx, error)
+}
+
+// ExitSpendPolicyResolver reconstructs a policy from the durable identity
+// stored with an unroll job. Custom actor factories can inject resolvers for
+// their policy families; the built-in actor default handles standard VTXO
+// timeout jobs.
+type ExitSpendPolicyResolver interface {
+	// ResolveExitSpendPolicy returns the policy for the given kind/ref
+	// pair.
+	ResolveExitSpendPolicy(ctx context.Context,
+		req ExitSpendPolicyRequest) (ExitSpendPolicy, error)
+}
+
 // ChainSource is the subset of the chainsource actor API used by the unroll
 // actor.
 type ChainSource = chainsource.ChainSourceMsg

--- a/unroll/snapshot.go
+++ b/unroll/snapshot.go
@@ -18,6 +18,8 @@ type unrollSnapshot struct {
 	Started             bool
 	Trigger             StartTrigger
 	State               unrollplan.State
+	ExitPolicyKind      string
+	ExitPolicyRef       string
 	SweepTx             *wire.MsgTx
 	Fail                string
 	SweepAttempts       int
@@ -65,6 +67,8 @@ func jobRecordFromSnapshot(target wire.OutPoint,
 		),
 		PlannerState:        plannerState,
 		DeferredCheckpoints: deferred,
+		ExitPolicyKind:      exitPolicyKind(snapshot.ExitPolicyKind),
+		ExitPolicyRef:       snapshot.ExitPolicyRef,
 		SweepTx:             sweepTx,
 		SweepTxid:           sweepTxid,
 		SweepAttempts:       int32(snapshot.SweepAttempts),
@@ -250,6 +254,8 @@ func snapshotFromJobRecord(record *db.UnrollJobRecord) (*unrollSnapshot,
 		Started:             record.State != string(PhasePending),
 		Trigger:             trigger,
 		State:               *plannerState,
+		ExitPolicyKind:      exitPolicyKind(record.ExitPolicyKind),
+		ExitPolicyRef:       record.ExitPolicyRef,
 		SweepTx:             sweepTx,
 		Fail:                record.FailReason,
 		SweepAttempts:       int(record.SweepAttempts),
@@ -258,6 +264,17 @@ func snapshotFromJobRecord(record *db.UnrollJobRecord) (*unrollSnapshot,
 			[]db.UnrollWatchRecord(nil), record.Watches...,
 		),
 	}, nil
+}
+
+func exitPolicyKind(kind string) string {
+	// The DB column is NOT NULL, but in-memory callers and older tests can
+	// still build a snapshot directly. Default those programmatic paths to
+	// the only behavior that existed before policy identities were added.
+	if kind == "" {
+		return StandardVTXOTimeoutExitPolicyKind
+	}
+
+	return kind
 }
 
 func serializeTx(tx *wire.MsgTx) ([]byte, error) {

--- a/unroll/state_snapshot.go
+++ b/unroll/state_snapshot.go
@@ -13,7 +13,8 @@ import (
 // snapshot shape.
 func snapshotFromState(state State, sweepTx *wire.MsgTx) *unrollSnapshot {
 	snapshot := &unrollSnapshot{
-		SweepTx: copyTx(sweepTx),
+		ExitPolicyKind: StandardVTXOTimeoutExitPolicyKind,
+		SweepTx:        copyTx(sweepTx),
 	}
 
 	if state == nil || isIdleState(state) {

--- a/unroll/sweep.go
+++ b/unroll/sweep.go
@@ -28,6 +28,166 @@ const (
 	defaultMaxSweepFeeRateSatPerVByte int64 = 100
 )
 
+// StandardVTXOExitSpendPolicy builds the normal timeout-path sweep used by
+// standard Ark VTXOs.
+type StandardVTXOExitSpendPolicy struct {
+	desc *vtxo.Descriptor
+}
+
+// standardExitSpendPolicyResolver resolves the built-in standard VTXO timeout
+// policy used when no custom resolver is configured.
+type standardExitSpendPolicyResolver struct{}
+
+// ResolveExitSpendPolicy reconstructs the built-in standard exit policy.
+func (r standardExitSpendPolicyResolver) ResolveExitSpendPolicy(
+	ctx context.Context, req ExitSpendPolicyRequest) (ExitSpendPolicy,
+	error) {
+
+	// Unused today; kept on the interface for future resolvers that need
+	// cancellable store lookups.
+	_ = ctx
+
+	if req.Kind != StandardVTXOTimeoutExitPolicyKind {
+		return nil, fmt.Errorf("unknown exit policy kind: %s", req.Kind)
+	}
+
+	if req.Ref != "" {
+		return nil, fmt.Errorf("standard exit policy ref must be empty")
+	}
+
+	return NewStandardVTXOExitSpendPolicy(req.StandardDescriptor), nil
+}
+
+// NewStandardVTXOExitSpendPolicy creates the built-in standard VTXO timeout
+// exit policy.
+func NewStandardVTXOExitSpendPolicy(
+	desc *vtxo.Descriptor) *StandardVTXOExitSpendPolicy {
+
+	return &StandardVTXOExitSpendPolicy{desc: desc}
+}
+
+// Kind returns the durable policy kind.
+func (p *StandardVTXOExitSpendPolicy) Kind() string {
+	return StandardVTXOTimeoutExitPolicyKind
+}
+
+// CSVDelay returns the descriptor relative expiry used by the timeout path.
+func (p *StandardVTXOExitSpendPolicy) CSVDelay() uint32 {
+	if p == nil || p.desc == nil {
+		return 0
+	}
+
+	return p.desc.RelativeExpiry
+}
+
+// ValidateTarget checks that a target output was materialized. Standard VTXO
+// unroll keeps the proof-derived output authoritative for behavior
+// compatibility with the existing unroll path.
+func (p *StandardVTXOExitSpendPolicy) ValidateTarget(target *wire.TxOut) error {
+	switch {
+	case p == nil:
+		return fmt.Errorf("standard exit policy must be provided")
+
+	case p.desc == nil:
+		return fmt.Errorf("descriptor must be provided")
+
+	case target == nil:
+		return fmt.Errorf("target output must be provided")
+	}
+
+	if target.Value <= 0 {
+		return fmt.Errorf("target output value must be positive")
+	}
+
+	return nil
+}
+
+// BuildSpendTx builds and signs the standard timeout-path sweep.
+//
+// The produced transaction is version 3 (TRUC). CSV-relative timelocks work
+// for any version >=2, but the shared txconfirm CPFP broadcaster gates parent
+// tx submission on BIP-431 semantics. The transaction has one input spending
+// req.TargetOutpoint with Sequence set to the descriptor's RelativeExpiry, and
+// one output paying req.DestinationPkScript with value inputValue - fee.
+// Signing uses the taproot timeout-path leaf rebuilt from the descriptor's
+// policy keys and CSV delay.
+func (p *StandardVTXOExitSpendPolicy) BuildSpendTx(ctx context.Context,
+	req ExitSpendRequest) (*wire.MsgTx, error) {
+
+	// Unused by the standard policy; future policies may use it for
+	// cancellable signer or store work.
+	_ = ctx
+
+	if err := p.ValidateTarget(req.TargetOutput); err != nil {
+		return nil, err
+	}
+
+	if req.Signer == nil {
+		return nil, fmt.Errorf("signer must be provided")
+	}
+
+	if len(req.DestinationPkScript) == 0 {
+		return nil, fmt.Errorf("destination pkscript must be provided")
+	}
+
+	if req.FeeRateSatPerVByte <= 0 {
+		return nil, fmt.Errorf("fee rate must be positive")
+	}
+
+	desc := p.desc
+	if desc.ClientKey.PubKey == nil {
+		return nil, fmt.Errorf("descriptor missing ClientKey pubkey")
+	}
+	if desc.OperatorKey == nil {
+		return nil, fmt.Errorf("descriptor missing OperatorKey")
+	}
+
+	sweepTx := wire.NewMsgTx(arktx.TxVersion)
+	sweepTx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: req.TargetOutpoint,
+		Sequence:         p.CSVDelay(),
+	})
+
+	inputValue := btcutil.Amount(req.TargetOutput.Value)
+	fee := btcutil.Amount(req.FeeRateSatPerVByte * estimatedSweepVBytes)
+	sweepValue := inputValue - fee
+	if sweepValue <= 0 {
+		return nil, fmt.Errorf("sweep value %d not positive "+
+			"after fee %d", sweepValue, fee)
+	}
+
+	sweepTx.AddTxOut(&wire.TxOut{
+		Value:    int64(sweepValue),
+		PkScript: append([]byte(nil), req.DestinationPkScript...),
+	})
+
+	spendInfo, err := arkscript.NewVTXOSpendInfoFromPolicy(
+		desc.ClientKey.PubKey, desc.OperatorKey, p.CSVDelay(), 1,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("timeout spend info: %w", err)
+	}
+
+	prevFetcher := txscript.NewCannedPrevOutputFetcher(
+		req.TargetOutput.PkScript, req.TargetOutput.Value,
+	)
+	sigHashes := txscript.NewTxSigHashes(sweepTx, prevFetcher)
+	signDesc := spendInfo.BuildSignDescriptor(
+		desc.ClientKey, req.TargetOutput, sigHashes, prevFetcher, 0,
+	)
+
+	witness, err := arkscript.VTXOTimeoutSpendWitness(
+		req.Signer, signDesc, sweepTx,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("timeout witness: %w", err)
+	}
+
+	sweepTx.TxIn[0].Witness = witness
+
+	return sweepTx, nil
+}
+
 // estimateSweepFeeRate asks chainsource for a 6-block fee estimate and
 // clamps it to a sane range.
 //
@@ -84,35 +244,14 @@ func estimateSweepFeeRate(ctx context.Context,
 	return feeRate, nil
 }
 
-// buildSweepTx constructs and signs the final timeout-path sweep.
-//
-// Structure of the produced transaction:
-//
-//   - Version 3 (TRUC). CSV-relative timelocks work for any version >=2;
-//     v3 is required because the shared txconfirm CPFP broadcaster gates
-//     parent tx submission on BIP-431 (TRUC) semantics.
-//   - One input spending proof.TargetOutpoint with Sequence set to the
-//     descriptor's RelativeExpiry. That sequence value is what arms the
-//     CSV check on chain; spending earlier is consensus-invalid, so the
-//     actor must wait for the CSV to mature (AwaitingCSV) before
-//     submitting.
-//   - One P2TR output paying to a fresh wallet pkScript. Value =
-//     inputValue - fee. A non-positive sweep value fails construction
-//     outright since publishing a tx with value <= 0 is nonsensical.
-//
-// Signing uses the taproot timeout-path leaf (leaf index 1 in the
-// standard VTXO tap tree). The leaf script is rebuilt from the
-// descriptor's policy keys and CSV delay via arkscript, and the
-// resulting witness is stored on TxIn[0].
-//
-// This function is deliberately pure: every IO boundary (fee estimate,
-// wallet pkScript, wallet signing) is threaded in through parameters so
-// buildSweepTx is directly test-friendly with injected fakes.
+// buildSweepTx resolves the common IO inputs for the final exit spend and
+// delegates transaction construction to policy.BuildSpendTx.
 func buildSweepTx(ctx context.Context, wallet SweepWallet,
 	chainSource actor.ActorRef[
 		chainsource.ChainSourceMsg, chainsource.ChainSourceResp,
 	], proof *recovery.Proof,
-	desc *vtxo.Descriptor, maxFeeRate int64) (*wire.MsgTx, error) {
+	desc *vtxo.Descriptor, maxFeeRate int64, currentHeight int32,
+	policy ExitSpendPolicy) (*wire.MsgTx, error) {
 
 	if wallet == nil {
 		return nil, fmt.Errorf("sweep wallet must be provided")
@@ -130,10 +269,10 @@ func buildSweepTx(ctx context.Context, wallet SweepWallet,
 		return nil, fmt.Errorf("descriptor must be provided")
 	}
 
-	// Resolve the target's TxOut (value + pkScript). This is the
-	// source of truth for fee math and signing — the VTXO descriptor
-	// stores a redundant PkScript but the proof-derived output is
-	// authoritative.
+	if policy == nil {
+		return nil, fmt.Errorf("exit spend policy must be provided")
+	}
+
 	targetOutput, err := proof.TargetOutput()
 	if err != nil {
 		return nil, err
@@ -157,82 +296,12 @@ func buildSweepTx(ctx context.Context, wallet SweepWallet,
 		return nil, fmt.Errorf("wallet returned empty pkscript")
 	}
 
-	// Version 3 (TRUC) — CSV works for any v>=2, but the shared
-	// txconfirm CPFP broadcaster rejects non-v3 parents because the
-	// anchor-detection heuristic and package-relay strategy assume
-	// BIP-431 semantics. Sequence = desc.RelativeExpiry is what tells
-	// consensus "this input is only valid at least RelativeExpiry
-	// blocks after the target confirmed" — the same CSV the planner
-	// is tracking off-chain.
-	sweepTx := wire.NewMsgTx(arktx.TxVersion)
-	sweepTx.AddTxIn(&wire.TxIn{
-		PreviousOutPoint: proof.TargetOutpoint(),
-		Sequence:         desc.RelativeExpiry,
+	return policy.BuildSpendTx(ctx, ExitSpendRequest{
+		TargetOutpoint:      proof.TargetOutpoint(),
+		TargetOutput:        targetOutput,
+		DestinationPkScript: sweepPkScript,
+		FeeRateSatPerVByte:  feeRate,
+		CurrentHeight:       currentHeight,
+		Signer:              wallet,
 	})
-
-	// Fee math is deliberately simple: a conservative static vsize
-	// estimate (taproot key-path + timeout leaf spend fits well under
-	// the estimatedSweepVBytes budget) times the clamped fee rate.
-	// The dust check below handles the pathological case of a VTXO
-	// whose value is below the sweep fee at current rates — in that
-	// case the unroll cannot produce a viable spend and must fail.
-	inputValue := btcutil.Amount(targetOutput.Value)
-	fee := btcutil.Amount(feeRate * estimatedSweepVBytes)
-	sweepValue := inputValue - fee
-	if sweepValue <= 0 {
-		return nil, fmt.Errorf("sweep value %d not positive "+
-			"after fee %d", sweepValue, fee)
-	}
-
-	sweepTx.AddTxOut(&wire.TxOut{
-		Value: int64(sweepValue),
-
-		// Defensive copy: sweepPkScript came from the wallet and
-		// the returned tx lives on past this call.
-		PkScript: append([]byte(nil), sweepPkScript...),
-	})
-
-	if desc.ClientKey.PubKey == nil {
-		return nil, fmt.Errorf("descriptor missing ClientKey pubkey")
-	}
-	if desc.OperatorKey == nil {
-		return nil, fmt.Errorf("descriptor missing OperatorKey")
-	}
-
-	// Derive the timeout-path spend info from the policy keys. The
-	// legacy leaf index 1 maps to the CSV-gated exit leaf in the
-	// standard VTXO tap tree.
-	spendInfo, err := arkscript.NewVTXOSpendInfoFromPolicy(
-		desc.ClientKey.PubKey, desc.OperatorKey, desc.RelativeExpiry, 1,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("timeout spend info: %w", err)
-	}
-
-	// BuildSignDescriptor wires together everything the taproot
-	// signer needs: the client key to sign with, the prevout being
-	// spent (value + pkScript), pre-computed sighashes for the new
-	// tx, and the input index (0 — we only have one input).
-	prevFetcher := txscript.NewCannedPrevOutputFetcher(
-		targetOutput.PkScript, targetOutput.Value,
-	)
-	sigHashes := txscript.NewTxSigHashes(sweepTx, prevFetcher)
-	signDesc := spendInfo.BuildSignDescriptor(
-		desc.ClientKey, targetOutput, sigHashes, prevFetcher, 0,
-	)
-
-	// Sign and assemble the taproot timeout-path witness. This is
-	// the only IO path that crosses into the wallet — from here on
-	// the sweep tx is fully signed and byte-stable, which is what
-	// lets startSweep persist its bytes before broadcasting.
-	witness, err := arkscript.VTXOTimeoutSpendWitness(
-		wallet, signDesc, sweepTx,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("timeout witness: %w", err)
-	}
-
-	sweepTx.TxIn[0].Witness = witness
-
-	return sweepTx, nil
 }


### PR DESCRIPTION
## Summary

This is PR 1 of the vHTLC on-chain recovery stack. It introduces the behavior-neutral `ExitSpendPolicy` seam inside `unroll` so the package can keep owning Ark lineage materialization while delegating the final materialized-output spend to a small policy interface.

This PR intentionally keeps standard VTXO timeout recovery as the only implemented policy. It persists the exit policy identity on `unroll_jobs`, routes the existing timeout sweep through `StandardVTXOExitSpendPolicy`, and adds structured logs around building/submitting the exit spend. No vHTLC or swap semantics are introduced here.

The branch is clean-start relative to the SQL durability work: there are no existing users or in-flight unroll jobs to migrate, so this updates the existing unroll schema rather than adding upgrade/backfill migrations.

## Verification

- `make fmt-changed-check`
- `make sqlc-check`
- `make sql-durability-check`
- `go test ./unroll ./db`
- `go test ./...`

## Stack

Base: `codex/durable-workflows`

Next PRs are expected to add the vHTLC recovery subsystem, SDK swap integration, and then swapdk-server integration.
