### PR TITLE
arkscript: gate sender vhtlc refunds by cltv

### DIFF
--- a/lib/arkscript/policy_template_test.go
+++ b/lib/arkscript/policy_template_test.go
@@ -155,12 +155,12 @@ func TestVHTLCSettlementPairs(t *testing.T) {
 		opts.Sender, opts.Server,
 	)
 	require.NoError(t, err)
-	require.Len(t, senderPairs, 1)
+	require.Len(t, senderPairs, 2)
 	require.Equal(
 		t, opts.UnilateralRefundDelay,
 		senderPairs[0].AuthPath.RequiredSequence,
 	)
-	// The sender's unilateral auth path (CSV + Multisig) has no CLTV.
+	// The sender/receiver refund auth path (CSV + Multisig) has no CLTV.
 	require.Zero(t, senderPairs[0].AuthPath.RequiredLockTime)
 	// The paired forfeit path is the cooperative Refund (all-party
 	// multisig) which also has no CLTV.
@@ -169,6 +169,25 @@ func TestVHTLCSettlementPairs(t *testing.T) {
 		senderPairs[0].ForfeitPath.RequiredSequence,
 	)
 	require.Zero(t, senderPairs[0].ForfeitPath.RequiredLockTime)
+
+	require.Equal(
+		t, opts.UnilateralRefundWithoutReceiverDelay,
+		senderPairs[1].AuthPath.RequiredSequence,
+	)
+	require.Equal(
+		t, opts.RefundLocktime,
+		senderPairs[1].AuthPath.RequiredLockTime,
+	)
+	// The sender-only refund auth path is both CSV-gated by Ark exit
+	// safety and CLTV-gated by the invoice refund locktime.
+	require.Equal(
+		t, uint32(0xfffffffe),
+		senderPairs[1].ForfeitPath.RequiredSequence,
+	)
+	require.Equal(
+		t, opts.RefundLocktime,
+		senderPairs[1].ForfeitPath.RequiredLockTime,
+	)
 
 	receiverPairs, err := policy.Template.SettlementPairsForParticipant(
 		opts.Receiver, opts.Server,

--- a/lib/arkscript/vhtlc.go
+++ b/lib/arkscript/vhtlc.go
@@ -77,8 +77,8 @@ type VHTLCPolicy struct {
 //  4. UnilateralClaim (exit): CSV(delay) + HashLock(preimage) +
 //     Checksig(receiver)
 //  5. UnilateralRefund (exit): CSV(delay) + Multisig([sender, receiver])
-//  6. UnilateralRefundWithoutReceiver (exit): CSV(delay) +
-//     Checksig(sender)
+//  6. UnilateralRefundWithoutReceiver (exit): CSV(delay) + CLTV(locktime)
+//     + Checksig(sender)
 func NewVHTLCPolicy(opts VHTLCOpts) (*VHTLCPolicy, error) {
 	if err := opts.validate(); err != nil {
 		return nil, err
@@ -162,12 +162,15 @@ func NewVHTLCPolicy(opts VHTLCOpts) (*VHTLCPolicy, error) {
 	}
 
 	// 6. UnilateralRefundWithoutReceiver: CSV(delay) +
-	// Multisig([sender]).
+	// CLTV(locktime) + Multisig([sender]).
 	unilateralRefundWithoutReceiverClosure := &CSV{
 		Lock: refundNoRecvSeq,
-		Inner: &Multisig{
-			Keys: []*btcec.PublicKey{
-				opts.Sender,
+		Inner: &Condition{
+			Predicate: refundPredicate,
+			Inner: &Multisig{
+				Keys: []*btcec.PublicKey{
+					opts.Sender,
+				},
 			},
 		},
 	}
@@ -302,6 +305,9 @@ func (opts *VHTLCOpts) validate() error {
 
 	case opts.PreimageHash == lntypes.Hash{}:
 		return fmt.Errorf("vhtlc: preimage hash must not be zero")
+
+	case opts.RefundLocktime == 0:
+		return fmt.Errorf("vhtlc: refund locktime must be non-zero")
 
 	case opts.UnilateralClaimDelay == 0:
 		return fmt.Errorf("vhtlc: unilateral claim delay must be " +

--- a/lib/arkscript/vhtlc_test.go
+++ b/lib/arkscript/vhtlc_test.go
@@ -210,7 +210,8 @@ func TestVHTLCNamedAccessors(t *testing.T) {
 		{
 			"UnilateralRefundWithoutReceiver",
 			policy.UnilateralRefundWithoutReceiverClosure,
-			opts.UnilateralRefundWithoutReceiverDelay, 0,
+			opts.UnilateralRefundWithoutReceiverDelay,
+			opts.RefundLocktime,
 		},
 	}
 
@@ -304,7 +305,7 @@ func TestVHTLCTxContextDerivation(t *testing.T) {
 	require.Equal(t, opts.UnilateralRefundDelay, urSeq)
 	require.Equal(t, uint32(0), urLocktime)
 
-	// UnilateralRefundWithoutReceiverClosure: CSV + Checksig.
+	// UnilateralRefundWithoutReceiverClosure: CSV + CLTV + Checksig.
 	urwrSeq := DeriveSequence(
 		policy.UnilateralRefundWithoutReceiverClosure,
 	)
@@ -313,7 +314,7 @@ func TestVHTLCTxContextDerivation(t *testing.T) {
 	)
 	require.Equal(t, opts.UnilateralRefundWithoutReceiverDelay,
 		urwrSeq)
-	require.Equal(t, uint32(0), urwrLocktime)
+	require.Equal(t, opts.RefundLocktime, urwrLocktime)
 }
 
 // TestVHTLCDeterminism tests that vHTLC construction is deterministic.
@@ -420,7 +421,7 @@ func TestVHTLCScriptDisassembly(t *testing.T) {
 			policy.UnilateralRefundClosure,
 		},
 		{
-			"UnilateralRefundWithoutReceiver (CSV+Checksig)",
+			"UnilateralRefundWithoutReceiver (CSV+CLTV+Checksig)",
 			policy.UnilateralRefundWithoutReceiverClosure,
 		},
 	}
@@ -459,5 +460,13 @@ func TestVHTLCValidation(t *testing.T) {
 		_, err := NewVHTLCPolicy(bad)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "zero")
+	})
+
+	t.Run("zero refund locktime", func(t *testing.T) {
+		bad := opts
+		bad.RefundLocktime = 0
+		_, err := NewVHTLCPolicy(bad)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "refund locktime")
 	})
 }


### PR DESCRIPTION
## Summary

This stacked PR tightens the vHTLC sender refund-without-receiver leaf so the sender-only unilateral path is gated by both the Ark CSV delay and the invoice/vHTLC refund CLTV.

Before this change, the cooperative refund-without-receiver path carried the refund CLTV, but the unilateral sender-only path was only CSV-gated. For recovery, that is too weak: after unroll materializes the Ark output, the sender should still be unable to refund without receiver cooperation until the invoice refund locktime has passed.

## What changed

- Wrap `UnilateralRefundWithoutReceiverClosure` in the existing refund CLTV predicate inside the CSV gate.
- Update vHTLC tx-context tests so the sender-only unilateral refund path now requires both `nSequence = unilateral_refund_without_receiver_delay` and `nLockTime = refund_locktime`.
- Update settlement-pair tests to account for the sender-only refund branch now matching the CLTV-gated operator-backed refund-without-receiver path.

## Reviewer notes

This PR intentionally does not implement the recovery worker yet. It only corrects the script policy shape that the later vHTLC recovery exit policy will spend through.

The important invariant is:

```text
refund_without_receiver unilateral recovery = Ark CSV + invoice/vHTLC CLTV + sender signature
```

## Validation

- `make fmt-changed-check`
- `go test ./lib/arkscript`
- `make commitmsg-lint range="codex/vhtlc-recovery-jobs..HEAD"`
- `make lint-native`
