### PR TITLE
vhtlcrecovery: add unroll exit policies

### DIFF
--- a/vhtlcrecovery/unrollpolicy/AGENTS.md
+++ b/vhtlcrecovery/unrollpolicy/AGENTS.md
@@ -1,0 +1,36 @@
+# vhtlcrecovery/unrollpolicy
+
+## Purpose
+
+Adapter package that turns durable vHTLC recovery rows into concrete
+`unroll.ExitSpendPolicy` implementations. The parent `vhtlcrecovery` package
+owns the durable control-plane types, while `unroll` owns generic VTXO
+materialization and final-spend execution.
+
+This subpackage exists to keep that boundary explicit without introducing an
+import cycle: `db` imports `vhtlcrecovery`, and `unroll` imports `db`, so the
+adapter that imports both `unroll` and `vhtlcrecovery` must live below the
+parent package.
+
+## Key Types
+
+- `ExitSpendPolicyResolver` - resolves an unroll `(exit_policy_kind,
+  exit_policy_ref)` pair into a vHTLC-specific exit policy.
+- `VHTLCExitSpendPolicy` - validates the materialized vHTLC target output and
+  builds the final claim or refund-without-receiver spend.
+- `RecoveryJobLoader` - narrow store interface for loading a recovery job by
+  id.
+- `PreimageResolver` - narrow interface for loading the swap-owned preimage
+  when claim recovery needs it.
+
+## Invariants
+
+- The raw preimage is not stored on the recovery row. Claim recovery resolves it
+  from the swap-owned state and checks it against `preimage_hash` before
+  building a spend.
+- `ValidateTarget` must confirm the materialized output matches the recovered
+  vHTLC policy before any final spend is built.
+- `refund_without_receiver` spends must carry both Ark CSV (`nSequence`) and
+  invoice/vHTLC CLTV (`nLockTime`).
+- Fee-cap checks happen before building the signed final spend. Persistence and
+  broadcast remain owned by `unroll`.

--- a/vhtlcrecovery/unrollpolicy/doc.go
+++ b/vhtlcrecovery/unrollpolicy/doc.go
@@ -1,0 +1,3 @@
+// Package unrollpolicy adapts durable vHTLC recovery rows into unroll exit
+// spend policies.
+package unrollpolicy

--- a/vhtlcrecovery/unrollpolicy/policy.go
+++ b/vhtlcrecovery/unrollpolicy/policy.go
@@ -1,0 +1,483 @@
+package unrollpolicy
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/arkscript"
+	"github.com/lightninglabs/darepo-client/lib/tx/arktx"
+	"github.com/lightninglabs/darepo-client/unroll"
+	"github.com/lightninglabs/darepo-client/vhtlcrecovery"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/lntypes"
+)
+
+const (
+	// estimatedVHTLCExitVBytes is a conservative virtual-size estimate for
+	// one final vHTLC exit spend. The signed transaction is persisted
+	// before broadcast, so exact fee accounting can be refined in a later
+	// worker pass without changing restart safety.
+	estimatedVHTLCExitVBytes = 260
+)
+
+// RecoveryJobLoader loads a durable recovery job by id.
+type RecoveryJobLoader interface {
+	// GetRecovery loads one recovery job row.
+	GetRecovery(ctx context.Context,
+		id string) (*vhtlcrecovery.RecoveryJob, error)
+}
+
+// PreimageResolver loads the raw preimage owned by the swap row.
+type PreimageResolver interface {
+	// ResolvePreimage returns the preimage for a recovery job. The
+	// resolver must verify the returned preimage matches preimageHash.
+	ResolvePreimage(ctx context.Context, swapID []byte,
+		preimageHash lntypes.Hash) (lntypes.Preimage, error)
+}
+
+// ExitSpendPolicyResolver resolves durable vHTLC recovery policy refs for
+// unroll. It is deliberately small: the resolver loads the recovery row by id,
+// verifies that the requested policy kind matches the row, and then constructs
+// the concrete script-path spend policy that the generic unroll actor can use.
+type ExitSpendPolicyResolver struct {
+	Jobs     RecoveryJobLoader
+	Preimage PreimageResolver
+}
+
+// ResolveExitSpendPolicy reconstructs the vHTLC exit spend policy for unroll.
+// Claim policies additionally resolve the swap-owned preimage and verify it
+// against the row's preimage hash before returning the spend policy. Refund
+// without receiver does not need a preimage resolver, which keeps sender-side
+// recovery independent from claim-only secret material.
+func (r ExitSpendPolicyResolver) ResolveExitSpendPolicy(ctx context.Context,
+	req unroll.ExitSpendPolicyRequest) (unroll.ExitSpendPolicy, error) {
+
+	if r.Jobs == nil {
+		return nil, fmt.Errorf("recovery job loader must be provided")
+	}
+	if req.Ref == "" {
+		return nil, fmt.Errorf("vhtlc recovery policy ref is required")
+	}
+
+	job, err := r.Jobs.GetRecovery(ctx, req.Ref)
+	if err != nil {
+		return nil, err
+	}
+	if job.ExitPolicyKind != req.Kind {
+		return nil, fmt.Errorf("recovery job policy kind %q does not "+
+			"match request kind %q", job.ExitPolicyKind, req.Kind)
+	}
+
+	switch req.Kind {
+	case vhtlcrecovery.ExitPolicyKindClaim:
+		if r.Preimage == nil {
+			return nil, fmt.Errorf("preimage resolver must be " +
+				"provided for vhtlc claim recovery")
+		}
+
+		preimageHash, err := preimageHashFromJob(*job)
+		if err != nil {
+			return nil, err
+		}
+
+		preimage, err := r.Preimage.ResolvePreimage(
+			ctx, job.SwapID, preimageHash,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		return NewClaimExitSpendPolicy(*job, preimage)
+
+	case vhtlcrecovery.ExitPolicyKindRefundWithoutReceiver:
+		return NewRefundWithoutReceiverExitSpendPolicy(*job)
+
+	default:
+		return nil, fmt.Errorf("unknown vhtlc exit policy kind: %s",
+			req.Kind)
+	}
+}
+
+// VHTLCExitSpendPolicy builds the final script-path spend for one recovery
+// action. The policy is reconstructed from explicit recovery-row columns, then
+// handed to unroll as a generic final-spend strategy. It does not persist or
+// broadcast transactions; unroll owns those restart-safety responsibilities.
+type VHTLCExitSpendPolicy struct {
+	job       vhtlcrecovery.RecoveryJob
+	policy    *arkscript.VHTLCPolicy
+	spendPath *arkscript.SpendPath
+	keyDesc   keychain.KeyDescriptor
+}
+
+// NewClaimExitSpendPolicy creates a preimage claim exit policy. The caller
+// supplies the raw preimage from swap-owned state, and this constructor
+// verifies it against the durable preimage hash before deriving the unilateral
+// claim spend path. The raw preimage is only kept in the witness material owned
+// by the spend path; it is not written back into the recovery row.
+func NewClaimExitSpendPolicy(job vhtlcrecovery.RecoveryJob,
+	preimage lntypes.Preimage) (*VHTLCExitSpendPolicy, error) {
+
+	policy, err := policyFromJob(job)
+	if err != nil {
+		return nil, err
+	}
+	if !preimage.Matches(policy.PreimageHash) {
+		return nil, fmt.Errorf("preimage does not match recovery hash")
+	}
+
+	spendPath, err := policy.CompiledPolicy.SpendPathForNode(
+		policy.UnilateralClaimClosure, [][]byte{
+			preimage[:],
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("unilateral claim spend path: %w", err)
+	}
+
+	return newVHTLCExitSpendPolicy(job, policy, spendPath)
+}
+
+// NewRefundWithoutReceiverExitSpendPolicy creates a sender-only refund policy.
+// This path models the unilateral leaf used after on-chain materialization when
+// receiver cooperation is unavailable. The resulting spend must satisfy both
+// the Ark CSV delay and the vHTLC refund CLTV locktime.
+func NewRefundWithoutReceiverExitSpendPolicy(job vhtlcrecovery.RecoveryJob) (
+	*VHTLCExitSpendPolicy, error) {
+
+	policy, err := policyFromJob(job)
+	if err != nil {
+		return nil, err
+	}
+
+	spendPath, err := policy.CompiledPolicy.SpendPathForNode(
+		policy.UnilateralRefundWithoutReceiverClosure, nil,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("unilateral refund without receiver "+
+			"spend path: %w", err)
+	}
+
+	return newVHTLCExitSpendPolicy(job, policy, spendPath)
+}
+
+// newVHTLCExitSpendPolicy validates action-specific context and returns a
+// concrete policy. It is shared by both public constructors so direct callers
+// get the same action/policy-kind checks as resolver-driven callers.
+func newVHTLCExitSpendPolicy(job vhtlcrecovery.RecoveryJob,
+	policy *arkscript.VHTLCPolicy,
+	spendPath *arkscript.SpendPath) (*VHTLCExitSpendPolicy, error) {
+
+	if err := spendPath.Validate(); err != nil {
+		return nil, err
+	}
+
+	key, err := signingKey(job)
+	if err != nil {
+		return nil, err
+	}
+
+	return &VHTLCExitSpendPolicy{
+		job:       job,
+		policy:    policy,
+		spendPath: spendPath,
+		keyDesc: keychain.KeyDescriptor{
+			KeyLocator: keychain.KeyLocator{
+				Family: keychain.KeyFamily(job.SignerKeyFamily),
+				Index:  uint32(job.SignerKeyIndex),
+			},
+			PubKey: key,
+		},
+	}, nil
+}
+
+// Kind returns the durable policy kind persisted on the recovery and unroll
+// rows. Returning the durable value keeps unroll's stored `(kind, ref)`
+// identity aligned with the concrete policy that was reconstructed from it.
+func (p *VHTLCExitSpendPolicy) Kind() string {
+	if p == nil {
+		return ""
+	}
+
+	return p.job.ExitPolicyKind
+}
+
+// CSVDelay returns the raw block delay unroll waits before spending. The value
+// is used for scheduler/waiting logic only: the final transaction still uses
+// spendPath.RequiredSequence so the script-derived sequence is the on-wire
+// source of truth.
+func (p *VHTLCExitSpendPolicy) CSVDelay() uint32 {
+	if p == nil {
+		return 0
+	}
+
+	switch p.job.Action {
+	case vhtlcrecovery.ActionClaim:
+		return uint32(p.job.UnilateralClaimDelay)
+
+	case vhtlcrecovery.ActionRefundWithoutReceiver:
+		return uint32(p.job.UnilateralRefundWithoutReceiverDelay)
+	}
+
+	// Policy construction validates the action, so reaching this point
+	// means a new action was added without updating the policy adapter.
+	panic(fmt.Sprintf("unhandled vhtlc recovery action %s", p.job.Action))
+}
+
+// ValidateTarget verifies the materialized output matches the vHTLC policy.
+// Recovery must fail closed if unroll materializes a different script, because
+// spending a mismatched target would mean the durable recovery row no longer
+// describes the on-chain output being swept.
+func (p *VHTLCExitSpendPolicy) ValidateTarget(target *wire.TxOut) error {
+	switch {
+	case p == nil:
+		return fmt.Errorf("vhtlc exit policy must be provided")
+
+	case p.policy == nil:
+		return fmt.Errorf("vhtlc policy must be provided")
+
+	case target == nil:
+		return fmt.Errorf("target output must be provided")
+
+	case target.Value <= 0:
+		return fmt.Errorf("target output value must be positive")
+	}
+
+	pkScript, err := p.policy.PkScript()
+	if err != nil {
+		return fmt.Errorf("vhtlc pkscript: %w", err)
+	}
+	if !bytes.Equal(target.PkScript, pkScript) {
+		return fmt.Errorf("target output pkscript does not match " +
+			"vhtlc policy")
+	}
+
+	return nil
+}
+
+// BuildSpendTx builds and signs the final vHTLC exit spend. It validates the
+// target output, enforces the recovery fee cap, applies the script-derived
+// sequence and locktime, and returns a fully witnessed transaction for unroll
+// to persist before broadcast.
+func (p *VHTLCExitSpendPolicy) BuildSpendTx(ctx context.Context,
+	req unroll.ExitSpendRequest) (*wire.MsgTx, error) {
+
+	// Unused today; kept for interface symmetry with policies that may
+	// need cancellable wallet or store work.
+	_ = ctx
+
+	if err := p.ValidateTarget(req.TargetOutput); err != nil {
+		return nil, err
+	}
+	if req.Signer == nil {
+		return nil, fmt.Errorf("signer must be provided")
+	}
+	if len(req.DestinationPkScript) == 0 {
+		return nil, fmt.Errorf("destination pkscript must be provided")
+	}
+	if req.FeeRateSatPerVByte <= 0 {
+		return nil, fmt.Errorf("fee rate must be positive")
+	}
+	if err := p.validateFeeRate(req.FeeRateSatPerVByte); err != nil {
+		return nil, err
+	}
+
+	tx := wire.NewMsgTx(arktx.TxVersion)
+	tx.LockTime = p.spendPath.RequiredLockTime
+	tx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: req.TargetOutpoint,
+		Sequence:         p.spendPath.RequiredSequence,
+	})
+
+	inputValue := btcutil.Amount(req.TargetOutput.Value)
+	fee := btcutil.Amount(
+		req.FeeRateSatPerVByte * estimatedVHTLCExitVBytes,
+	)
+	exitValue := inputValue - fee
+	if exitValue <= 0 {
+		return nil, fmt.Errorf("exit value %d not positive "+
+			"after fee %d", exitValue, fee)
+	}
+
+	tx.AddTxOut(&wire.TxOut{
+		Value:    int64(exitValue),
+		PkScript: append([]byte(nil), req.DestinationPkScript...),
+	})
+
+	prevFetcher := txscript.NewCannedPrevOutputFetcher(
+		req.TargetOutput.PkScript, req.TargetOutput.Value,
+	)
+	sigHashes := txscript.NewTxSigHashes(tx, prevFetcher)
+	signDesc := p.spendPath.BuildSignDescriptor(
+		p.keyDesc, req.TargetOutput, sigHashes, prevFetcher, 0,
+	)
+
+	sig, err := req.Signer.SignOutputRaw(tx, signDesc)
+	if err != nil {
+		return nil, fmt.Errorf("sign vhtlc exit spend: %w", err)
+	}
+
+	witness, err := p.spendPath.SingleSigWitness(
+		sig, txscript.SigHashDefault,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("vhtlc exit witness: %w", err)
+	}
+	tx.TxIn[0].Witness = witness
+
+	return tx, nil
+}
+
+// validateFeeRate enforces the recovery row's fee cap. The unroll actor passes
+// fee rates in sat/vByte, while recovery rows store the operator policy as
+// sat/kw, so this converts before comparing to avoid unit drift at the
+// boundary.
+func (p *VHTLCExitSpendPolicy) validateFeeRate(feeRateSatPerVByte int64) error {
+	feeRateSatPerKWeight := feeRateSatPerVByte * 250
+	if feeRateSatPerKWeight <= int64(p.job.MaxFeeRateSatPerKWeight) {
+		return nil
+	}
+
+	return fmt.Errorf("fee rate %d sat/kw exceeds cap %d sat/kw",
+		feeRateSatPerKWeight, p.job.MaxFeeRateSatPerKWeight)
+}
+
+// policyFromJob reconstructs the vHTLC policy from durable row columns. Each
+// field is decoded and range-checked before calling into arkscript so malformed
+// SQL state fails with a recovery-specific error instead of a later script
+// construction surprise.
+func policyFromJob(job vhtlcrecovery.RecoveryJob) (*arkscript.VHTLCPolicy,
+	error) {
+
+	sender, err := parsePubKey(job.SenderPubkey, "sender")
+	if err != nil {
+		return nil, err
+	}
+	receiver, err := parsePubKey(job.ReceiverPubkey, "receiver")
+	if err != nil {
+		return nil, err
+	}
+	server, err := parsePubKey(job.ServerPubkey, "server")
+	if err != nil {
+		return nil, err
+	}
+
+	preimageHash, err := preimageHashFromJob(job)
+	if err != nil {
+		return nil, err
+	}
+
+	refundLocktime, err := uint32Field(
+		job.RefundLocktime, "refund locktime",
+	)
+	if err != nil {
+		return nil, err
+	}
+	claimDelay, err := uint32Field(
+		job.UnilateralClaimDelay, "unilateral claim delay",
+	)
+	if err != nil {
+		return nil, err
+	}
+	refundDelay, err := uint32Field(
+		job.UnilateralRefundDelay, "unilateral refund delay",
+	)
+	if err != nil {
+		return nil, err
+	}
+	rwrDelay, err := uint32Field(
+		job.UnilateralRefundWithoutReceiverDelay,
+		"unilateral refund without receiver delay",
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return arkscript.NewVHTLCPolicy(arkscript.VHTLCOpts{
+		Sender:                               sender,
+		Receiver:                             receiver,
+		Server:                               server,
+		PreimageHash:                         preimageHash,
+		RefundLocktime:                       refundLocktime,
+		UnilateralClaimDelay:                 claimDelay,
+		UnilateralRefundDelay:                refundDelay,
+		UnilateralRefundWithoutReceiverDelay: rwrDelay,
+	})
+}
+
+// signingKey returns the key that signs the selected unilateral leaf. It also
+// re-checks the action-to-policy-kind mapping so direct constructor callers
+// cannot accidentally build a claim spend using a refund policy row, or the
+// other way around.
+func signingKey(job vhtlcrecovery.RecoveryJob) (*btcec.PublicKey, error) {
+	var keyBytes []byte
+	switch job.Action {
+	case vhtlcrecovery.ActionClaim:
+		if job.ExitPolicyKind != vhtlcrecovery.ExitPolicyKindClaim {
+			return nil, fmt.Errorf("claim action has "+
+				"policy kind %q", job.ExitPolicyKind)
+		}
+		keyBytes = job.ReceiverPubkey
+
+	case vhtlcrecovery.ActionRefundWithoutReceiver:
+		if job.ExitPolicyKind !=
+			vhtlcrecovery.ExitPolicyKindRefundWithoutReceiver {
+			return nil, fmt.Errorf("refund action has "+
+				"policy kind %q", job.ExitPolicyKind)
+		}
+		keyBytes = job.SenderPubkey
+
+	default:
+		return nil, fmt.Errorf("unknown vhtlc recovery action: %s",
+			job.Action)
+	}
+
+	return parsePubKey(keyBytes, "signing")
+}
+
+// parsePubKey parses a compressed public key from durable storage. The name is
+// included in the error so operators and tests can distinguish which recovery
+// column is malformed.
+func parsePubKey(raw []byte, name string) (*btcec.PublicKey, error) {
+	key, err := btcec.ParsePubKey(raw)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s pubkey: %w", name, err)
+	}
+
+	return key, nil
+}
+
+// preimageHashFromJob decodes the stored payment hash. Recovery stores only
+// the hash, not the raw preimage, so this helper enforces the exact fixed-size
+// encoding before any claim path can ask the swap store for secret material.
+func preimageHashFromJob(job vhtlcrecovery.RecoveryJob) (lntypes.Hash, error) {
+	var hash lntypes.Hash
+	if len(job.PreimageHash) != len(hash) {
+		return hash, fmt.Errorf("preimage hash must be %d "+
+			"bytes, got %d", len(hash), len(job.PreimageHash))
+	}
+
+	copy(hash[:], job.PreimageHash)
+
+	return hash, nil
+}
+
+// uint32Field converts a signed SQL field into its script-domain value. SQL
+// stores the values as signed integers for portability, while arkscript expects
+// unsigned locktime/delay values; non-positive values are rejected before the
+// cast to avoid accidental wraparound.
+func uint32Field(value int32, name string) (uint32, error) {
+	if value <= 0 {
+		return 0, fmt.Errorf("%s must be positive", name)
+	}
+
+	return uint32(value), nil
+}
+
+// Compile-time interface checks.
+var _ unroll.ExitSpendPolicy = (*VHTLCExitSpendPolicy)(nil)
+var _ unroll.ExitSpendPolicyResolver = (*ExitSpendPolicyResolver)(nil)

--- a/vhtlcrecovery/unrollpolicy/policy_test.go
+++ b/vhtlcrecovery/unrollpolicy/policy_test.go
@@ -1,0 +1,329 @@
+package unrollpolicy
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/internal/testutils"
+	"github.com/lightninglabs/darepo-client/unroll"
+	"github.com/lightninglabs/darepo-client/vhtlcrecovery"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/stretchr/testify/require"
+)
+
+// TestClaimExitSpendPolicyBuildsPreimageSpend verifies claim recovery builds a
+// transaction that uses the receiver key, waits the claim CSV delay, and places
+// the swap preimage into the script-path witness.
+func TestClaimExitSpendPolicyBuildsPreimageSpend(t *testing.T) {
+	t.Parallel()
+
+	job, preimage, _, receiverSigner := testPolicyJob(
+		t, vhtlcrecovery.ActionClaim,
+	)
+
+	policy, err := NewClaimExitSpendPolicy(job, preimage)
+	require.NoError(t, err)
+	require.Equal(t, vhtlcrecovery.ExitPolicyKindClaim, policy.Kind())
+	require.Equal(t, uint32(job.UnilateralClaimDelay), policy.CSVDelay())
+
+	targetOutput := testPolicyTargetOutput(t, job)
+	spendTx, err := policy.BuildSpendTx(
+		t.Context(), unroll.ExitSpendRequest{
+			TargetOutpoint:      job.VTXOOutpoint,
+			TargetOutput:        targetOutput,
+			DestinationPkScript: []byte{txscript.OP_TRUE},
+			FeeRateSatPerVByte:  2,
+			Signer:              receiverSigner,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		blockchain.LockTimeToSequence(
+			false, uint32(job.UnilateralClaimDelay),
+		),
+		spendTx.TxIn[0].Sequence,
+	)
+	require.Equal(t, uint32(0), spendTx.LockTime)
+	require.Len(t, spendTx.TxIn[0].Witness, 4)
+	require.True(t, bytes.Equal(preimage[:], spendTx.TxIn[0].Witness[1]))
+}
+
+// TestClaimExitSpendPolicyRejectsWrongPreimage verifies the constructor fails
+// closed if the swap store returns a preimage that does not match the recovery
+// row's durable preimage hash.
+func TestClaimExitSpendPolicyRejectsWrongPreimage(t *testing.T) {
+	t.Parallel()
+
+	job, _, _, _ := testPolicyJob(t, vhtlcrecovery.ActionClaim)
+	wrongPreimage, err := lntypes.MakePreimage(
+		bytes.Repeat(
+			[]byte{0x99}, 32,
+		),
+	)
+	require.NoError(t, err)
+
+	_, err = NewClaimExitSpendPolicy(job, wrongPreimage)
+	require.ErrorContains(t, err, "preimage does not match")
+}
+
+// TestRefundWithoutReceiverExitSpendPolicyBuildsCSVCLTVSpend verifies sender
+// refund-without-receiver recovery builds a transaction with both Ark CSV
+// sequence and vHTLC refund CLTV locktime requirements.
+func TestRefundWithoutReceiverExitSpendPolicyBuildsCSVCLTVSpend(t *testing.T) {
+	t.Parallel()
+
+	job, _, senderSigner, _ := testPolicyJob(
+		t, vhtlcrecovery.ActionRefundWithoutReceiver,
+	)
+
+	policy, err := NewRefundWithoutReceiverExitSpendPolicy(job)
+	require.NoError(t, err)
+	require.Equal(
+		t, vhtlcrecovery.ExitPolicyKindRefundWithoutReceiver,
+		policy.Kind(),
+	)
+	require.Equal(
+		t, uint32(job.UnilateralRefundWithoutReceiverDelay),
+		policy.CSVDelay(),
+	)
+
+	targetOutput := testPolicyTargetOutput(t, job)
+	spendTx, err := policy.BuildSpendTx(
+		t.Context(), unroll.ExitSpendRequest{
+			TargetOutpoint:      job.VTXOOutpoint,
+			TargetOutput:        targetOutput,
+			DestinationPkScript: []byte{txscript.OP_TRUE},
+			FeeRateSatPerVByte:  2,
+			Signer:              senderSigner,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		blockchain.LockTimeToSequence(
+			false, uint32(
+				job.UnilateralRefundWithoutReceiverDelay,
+			),
+		),
+		spendTx.TxIn[0].Sequence,
+	)
+	require.Equal(t, uint32(job.RefundLocktime), spendTx.LockTime)
+	require.Len(t, spendTx.TxIn[0].Witness, 3)
+}
+
+// TestVHTLCExitSpendPolicyRejectsWrongTarget verifies the policy refuses to
+// spend a materialized output whose pkScript does not match the vHTLC recovered
+// from durable recovery columns.
+func TestVHTLCExitSpendPolicyRejectsWrongTarget(t *testing.T) {
+	t.Parallel()
+
+	job, _, _, _ := testPolicyJob(
+		t, vhtlcrecovery.ActionRefundWithoutReceiver,
+	)
+	policy, err := NewRefundWithoutReceiverExitSpendPolicy(job)
+	require.NoError(t, err)
+
+	err = policy.ValidateTarget(&wire.TxOut{
+		Value:    job.VTXOAmountSat,
+		PkScript: []byte{txscript.OP_TRUE},
+	})
+	require.ErrorContains(t, err, "pkscript does not match")
+}
+
+// TestVHTLCExitSpendPolicyRejectsFeeAboveCap verifies the policy enforces the
+// recovery row's max-fee-rate guard before constructing a signed spend.
+func TestVHTLCExitSpendPolicyRejectsFeeAboveCap(t *testing.T) {
+	t.Parallel()
+
+	job, _, senderSigner, _ := testPolicyJob(
+		t, vhtlcrecovery.ActionRefundWithoutReceiver,
+	)
+	policy, err := NewRefundWithoutReceiverExitSpendPolicy(job)
+	require.NoError(t, err)
+
+	_, err = policy.BuildSpendTx(
+		t.Context(), unroll.ExitSpendRequest{
+			TargetOutpoint:      job.VTXOOutpoint,
+			TargetOutput:        testPolicyTargetOutput(t, job),
+			DestinationPkScript: []byte{txscript.OP_TRUE},
+			FeeRateSatPerVByte:  11,
+			Signer:              senderSigner,
+		},
+	)
+	require.ErrorContains(t, err, "exceeds cap")
+}
+
+// TestExitSpendPolicyResolver verifies the resolver reconstructs both vHTLC
+// policy families from durable `(kind, ref)` identity and rejects mismatched
+// request kinds.
+func TestExitSpendPolicyResolver(t *testing.T) {
+	t.Parallel()
+
+	job, preimage, _, _ := testPolicyJob(t, vhtlcrecovery.ActionClaim)
+	resolver := ExitSpendPolicyResolver{
+		Jobs: fakeRecoveryJobLoader{
+			job.ID: job,
+		},
+		Preimage: fakePreimageResolver{
+			preimage: preimage,
+		},
+	}
+
+	policy, err := resolver.ResolveExitSpendPolicy(
+		t.Context(), unroll.ExitSpendPolicyRequest{
+			Kind: vhtlcrecovery.ExitPolicyKindClaim,
+			Ref:  job.ID,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, vhtlcrecovery.ExitPolicyKindClaim, policy.Kind())
+
+	refundJob, _, _, _ := testPolicyJob(
+		t, vhtlcrecovery.ActionRefundWithoutReceiver,
+	)
+	refundResolver := ExitSpendPolicyResolver{
+		Jobs: fakeRecoveryJobLoader{
+			refundJob.ID: refundJob,
+		},
+	}
+	refundPolicy, err := refundResolver.ResolveExitSpendPolicy(
+		t.Context(), unroll.ExitSpendPolicyRequest{
+			Kind: vhtlcrecovery.ExitPolicyKindRefundWithoutReceiver,
+			Ref:  refundJob.ID,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(
+		t, vhtlcrecovery.ExitPolicyKindRefundWithoutReceiver,
+		refundPolicy.Kind(),
+	)
+
+	_, err = resolver.ResolveExitSpendPolicy(
+		t.Context(), unroll.ExitSpendPolicyRequest{
+			Kind: vhtlcrecovery.ExitPolicyKindRefundWithoutReceiver,
+			Ref:  job.ID,
+		},
+	)
+	require.ErrorContains(t, err, "does not match request kind")
+}
+
+// testPolicyJob returns a fully populated recovery job and matching test
+// signers for the requested recovery action. The row mirrors the named SQL
+// columns the production adapter reconstructs.
+func testPolicyJob(t *testing.T, action string) (vhtlcrecovery.RecoveryJob,
+	lntypes.Preimage, input.Signer, input.Signer) {
+
+	t.Helper()
+
+	sender, senderSigner := testutils.CreateKey(31)
+	receiver, receiverSigner := testutils.CreateKey(32)
+	server, _ := testutils.CreateKey(33)
+
+	preimage, err := lntypes.MakePreimage(bytes.Repeat([]byte{0x42}, 32))
+	require.NoError(t, err)
+	preimageHash := preimage.Hash()
+	senderKey := sender.SerializeCompressed()
+	receiverKey := receiver.SerializeCompressed()
+	serverKey := server.SerializeCompressed()
+
+	policyKind, err := vhtlcrecovery.ExitPolicyKindForAction(action)
+	require.NoError(t, err)
+
+	return vhtlcrecovery.RecoveryJob{
+		ID:        "recovery-policy",
+		RequestID: "request-policy",
+		SwapID:    []byte("swap-policy"),
+		Direction: vhtlcrecovery.DirectionReceive,
+		Action:    action,
+		State:     vhtlcrecovery.StateArmed,
+		VTXOOutpoint: wire.OutPoint{
+			Hash: chainhash.Hash{
+				0x44,
+			},
+			Index: 2,
+		},
+		VTXOAmountSat:                        500_000,
+		SenderPubkey:                         senderKey,
+		ReceiverPubkey:                       receiverKey,
+		ServerPubkey:                         serverKey,
+		RefundLocktime:                       500_000,
+		UnilateralClaimDelay:                 12,
+		UnilateralRefundDelay:                24,
+		UnilateralRefundWithoutReceiverDelay: 36,
+		PreimageHash:                         preimageHash[:],
+		SignerKeyFamily:                      6,
+		SignerKeyIndex:                       9,
+		DestinationScript: []byte{
+			txscript.OP_TRUE,
+		},
+		MaxFeeRateSatPerKWeight: 2_500,
+		ExitPolicyKind:          policyKind,
+	}, preimage, senderSigner, receiverSigner
+}
+
+// testPolicyTargetOutput reconstructs the vHTLC policy for a recovery job and
+// returns the on-chain output that ValidateTarget should accept.
+func testPolicyTargetOutput(t *testing.T,
+	job vhtlcrecovery.RecoveryJob) *wire.TxOut {
+
+	t.Helper()
+
+	policy, err := policyFromJob(job)
+	require.NoError(t, err)
+
+	pkScript, err := policy.PkScript()
+	require.NoError(t, err)
+
+	return &wire.TxOut{
+		Value:    job.VTXOAmountSat,
+		PkScript: pkScript,
+	}
+}
+
+type fakeRecoveryJobLoader map[string]vhtlcrecovery.RecoveryJob
+
+// GetRecovery implements RecoveryJobLoader for resolver tests.
+func (f fakeRecoveryJobLoader) GetRecovery(_ context.Context, id string) (
+	*vhtlcrecovery.RecoveryJob, error) {
+
+	job, ok := f[id]
+	if !ok {
+		return nil, errTestNotFound
+	}
+
+	return &job, nil
+}
+
+type fakePreimageResolver struct {
+	preimage lntypes.Preimage
+}
+
+// ResolvePreimage implements PreimageResolver and enforces the same
+// hash-matching contract as the production swap store adapter should.
+func (f fakePreimageResolver) ResolvePreimage(_ context.Context, _ []byte,
+	preimageHash lntypes.Hash) (lntypes.Preimage, error) {
+
+	if !f.preimage.Matches(preimageHash) {
+		return lntypes.Preimage{}, errTestNotFound
+	}
+
+	return f.preimage, nil
+}
+
+var errTestNotFound = &testError{"not found"}
+
+type testError struct {
+	msg string
+}
+
+// Error returns the stable test error string.
+func (e *testError) Error() string {
+	return e.msg
+}


### PR DESCRIPTION
## Summary

Adds the vHTLC recovery adapter that lets `unroll` resolve a durable `(exit_policy_kind, recovery_id)` into a concrete exit spend policy without teaching `unroll` about swap semantics.

The new `vhtlcrecovery/unrollpolicy` package owns the adapter boundary: `vhtlcrecovery` keeps the durable recovery job model, `unroll` keeps the generic exit-spend interface, and this package imports both to reconstruct and execute the vHTLC-specific unilateral leaves.

## What changed

- Adds an `ExitSpendPolicyResolver` implementation for vHTLC recovery jobs.
- Adds claim and sender refund-without-receiver `ExitSpendPolicy` implementations.
- Reconstructs the vHTLC policy from named recovery job columns.
- Validates that the materialized target output matches the expected vHTLC pkScript before spending.
- Builds and signs claim spends with the resolved preimage.
- Builds and signs sender refund-without-receiver spends with both Ark CSV sequence and invoice/vHTLC CLTV locktime.
- Enforces the recovery row fee cap before constructing the final exit spend.

## Review notes

This is intentionally a new subpackage rather than logic in the parent `vhtlcrecovery` package. The parent package is imported by `db`, while `unroll` already imports `db`; putting the adapter in `vhtlcrecovery/unrollpolicy` avoids an import cycle and keeps the control-plane types separate from the unroll adapter.

## Validation

- `make fmt-changed-check`
- `go test ./lib/arkscript ./vhtlcrecovery/... ./unroll`
- `make commitmsg-lint range="codex/vhtlc-refund-cltv..HEAD"`
- `make lint-native`
