### PR TITLE
unroll: persist exit policy on admission

### DIFF
--- a/unroll/actor.go
+++ b/unroll/actor.go
@@ -210,8 +210,10 @@ func (b *behavior) Receive(ctx context.Context, msg Msg) fn.Result[Resp] {
 	switch m := msg.(type) {
 	case *StartUnrollRequest:
 		return b.handleEvent(ctx, &StartEvent{
-			Height:  m.Height,
-			Trigger: m.Trigger,
+			Height:         m.Height,
+			Trigger:        m.Trigger,
+			ExitPolicyKind: m.ExitPolicyKind,
+			ExitPolicyRef:  m.ExitPolicyRef,
 		})
 
 	case *ResumeUnrollRequest:
@@ -655,12 +657,14 @@ func (b *behavior) stateResponse() *GetStateResp {
 	job := stateJob(state)
 	sweepTxid := effectiveSweepTxid(job.PlannerState, b.sweepTx)
 	resp := &GetStateResp{
-		Started:      !isIdleState(state),
-		Trigger:      stateTrigger(state),
-		Height:       stateHeight(state),
-		Phase:        phaseFromState(state),
-		PlannerState: copyPlannerState(job.PlannerState),
-		FailReason:   job.FailReason,
+		Started:        !isIdleState(state),
+		Trigger:        stateTrigger(state),
+		ExitPolicyKind: exitPolicyKind(job.ExitPolicyKind),
+		ExitPolicyRef:  job.ExitPolicyRef,
+		Height:         stateHeight(state),
+		Phase:          phaseFromState(state),
+		PlannerState:   copyPlannerState(job.PlannerState),
+		FailReason:     job.FailReason,
 	}
 
 	if sweepTxid != nil {

--- a/unroll/db_store.go
+++ b/unroll/db_store.go
@@ -30,6 +30,8 @@ func (s *DBRegistryStore) UpsertRecord(ctx context.Context,
 		TargetOutpoint: record.TargetOutpoint,
 		State:          string(record.Phase),
 		Trigger:        triggerToString(record.Trigger),
+		ExitPolicyKind: exitPolicyKind(record.ExitPolicyKind),
+		ExitPolicyRef:  record.ExitPolicyRef,
 		FailReason:     record.FailReason,
 		SweepTxid:      sweepTxidBytes(record.SweepTxid),
 	}
@@ -42,6 +44,9 @@ func (s *DBRegistryStore) UpsertRecord(ctx context.Context,
 		job.PlannerState = existing.PlannerState
 		job.DeferredCheckpoints = existing.DeferredCheckpoints
 		job.SweepTx = existing.SweepTx
+		job.ExitPolicyKind, job.ExitPolicyRef = registryExitPolicy(
+			record, existing,
+		)
 		if len(job.SweepTxid) == 0 {
 			job.SweepTxid = existing.SweepTxid
 		}
@@ -148,10 +153,27 @@ func recordFromDB(job db.UnrollJobRecord) (RegistryRecord, error) {
 		TargetOutpoint: job.TargetOutpoint,
 		ActorID:        actorIDForTarget(job.TargetOutpoint),
 		Trigger:        trigger,
+		ExitPolicyKind: exitPolicyKind(job.ExitPolicyKind),
+		ExitPolicyRef:  job.ExitPolicyRef,
 		Phase:          Phase(job.State),
 		FailReason:     job.FailReason,
 		SweepTxid:      sweepTxidFromBytes(job.SweepTxid),
 	}, nil
+}
+
+// registryExitPolicy chooses the policy identity to write when the registry
+// refines an existing DB row. Policy kind and ref are treated as one durable
+// identity pair: a record with no kind preserves both existing values, while a
+// record with any kind replaces both values so stale custom refs cannot attach
+// to a new standard policy.
+func registryExitPolicy(record RegistryRecord,
+	existing *db.UnrollJobRecord) (string, string) {
+
+	if record.ExitPolicyKind == "" && existing != nil {
+		return existing.ExitPolicyKind, existing.ExitPolicyRef
+	}
+
+	return exitPolicyKind(record.ExitPolicyKind), record.ExitPolicyRef
 }
 
 // sweepTxidBytes converts an optional txid into the stored byte format.

--- a/unroll/db_store_test.go
+++ b/unroll/db_store_test.go
@@ -3,9 +3,12 @@ package unroll
 import (
 	"testing"
 
+	"github.com/lightninglabs/darepo-client/db"
 	"github.com/stretchr/testify/require"
 )
 
+// TestTriggerStringRoundTrip verifies the durable trigger strings decode back
+// into their enum values. This keeps DB rows and logs stable across restarts.
 func TestTriggerStringRoundTrip(t *testing.T) {
 	t.Parallel()
 
@@ -44,4 +47,26 @@ func TestTriggerStringRoundTrip(t *testing.T) {
 			require.Equal(t, tc.trigger, roundTrip)
 		})
 	}
+}
+
+// TestRegistryExitPolicyTreatsKindAndRefAsPair verifies policy identity
+// preservation handles kind and ref atomically when a registry update refines
+// an existing unroll DB row.
+func TestRegistryExitPolicyTreatsKindAndRefAsPair(t *testing.T) {
+	t.Parallel()
+
+	existing := &db.UnrollJobRecord{
+		ExitPolicyKind: "vhtlc_claim",
+		ExitPolicyRef:  "recovery-1",
+	}
+
+	kind, ref := registryExitPolicy(RegistryRecord{}, existing)
+	require.Equal(t, "vhtlc_claim", kind)
+	require.Equal(t, "recovery-1", ref)
+
+	kind, ref = registryExitPolicy(RegistryRecord{
+		ExitPolicyKind: StandardVTXOTimeoutExitPolicyKind,
+	}, existing)
+	require.Equal(t, StandardVTXOTimeoutExitPolicyKind, kind)
+	require.Empty(t, ref)
 }

--- a/unroll/fsm_logic.go
+++ b/unroll/fsm_logic.go
@@ -107,6 +107,12 @@ func processEventWithJob(ctx context.Context, job *JobState, event Event,
 			nextJob.Height = e.Height
 		}
 		nextJob.Trigger = e.Trigger
+		if e.ExitPolicyKind != "" {
+			nextJob.ExitPolicyKind = exitPolicyKind(
+				e.ExitPolicyKind,
+			)
+			nextJob.ExitPolicyRef = e.ExitPolicyRef
+		}
 
 	default:
 		return nil, fmt.Errorf("unexpected event %T", event)

--- a/unroll/fsm_types.go
+++ b/unroll/fsm_types.go
@@ -83,6 +83,12 @@ type JobState struct {
 	// Trigger identifies why the actor was started.
 	Trigger StartTrigger
 
+	// ExitPolicyKind identifies the final spend policy for this job.
+	ExitPolicyKind string
+
+	// ExitPolicyRef is the policy-specific durable reference.
+	ExitPolicyRef string
+
 	// PlannerState is the durable caller-owned planning progress.
 	PlannerState unrollplan.State
 
@@ -109,6 +115,8 @@ func (j *JobState) Copy() *JobState {
 	copyState := &JobState{
 		Height:              j.Height,
 		Trigger:             j.Trigger,
+		ExitPolicyKind:      exitPolicyKind(j.ExitPolicyKind),
+		ExitPolicyRef:       j.ExitPolicyRef,
 		PlannerState:        copyPlannerState(j.PlannerState),
 		DeferredCheckpoints: deferred,
 		FailReason:          j.FailReason,
@@ -141,6 +149,13 @@ type StartEvent struct {
 
 	// Trigger identifies why the actor was started.
 	Trigger StartTrigger
+
+	// ExitPolicyKind identifies the final spend policy to persist for this
+	// target. Empty events use the standard VTXO timeout policy.
+	ExitPolicyKind string
+
+	// ExitPolicyRef is the policy-specific durable reference.
+	ExitPolicyRef string
 }
 
 // eventSealed marks StartEvent as an FSM event.
@@ -296,8 +311,10 @@ func (s *Idle) ProcessEvent(ctx context.Context, event Event,
 	switch e := event.(type) {
 	case *StartEvent:
 		job := &JobState{
-			Height:  e.Height,
-			Trigger: e.Trigger,
+			Height:         e.Height,
+			Trigger:        e.Trigger,
+			ExitPolicyKind: exitPolicyKind(e.ExitPolicyKind),
+			ExitPolicyRef:  e.ExitPolicyRef,
 		}
 
 		return deriveStateTransition(

--- a/unroll/messages.go
+++ b/unroll/messages.go
@@ -90,6 +90,13 @@ type StartUnrollRequest struct {
 
 	// Trigger identifies why the unroll started.
 	Trigger StartTrigger
+
+	// ExitPolicyKind identifies the final spend policy to persist for this
+	// target. Empty requests use the standard VTXO timeout policy.
+	ExitPolicyKind string
+
+	// ExitPolicyRef is the policy-specific durable reference.
+	ExitPolicyRef string
 }
 
 // MessageType returns the stable message type identifier.
@@ -255,6 +262,12 @@ type GetStateResp struct {
 
 	// Trigger identifies why the actor was started.
 	Trigger StartTrigger
+
+	// ExitPolicyKind identifies the final spend policy for this target.
+	ExitPolicyKind string
+
+	// ExitPolicyRef is the policy-specific durable reference.
+	ExitPolicyRef string
 
 	// Height is the current best height tracked by the actor.
 	Height int32

--- a/unroll/registry.go
+++ b/unroll/registry.go
@@ -47,6 +47,12 @@ type RegistryRecord struct {
 	// Trigger records why the target was started.
 	Trigger StartTrigger
 
+	// ExitPolicyKind identifies the final spend policy for this target.
+	ExitPolicyKind string
+
+	// ExitPolicyRef is the policy-specific durable reference.
+	ExitPolicyRef string
+
 	// Phase is the last known coarse lifecycle phase.
 	Phase Phase
 
@@ -355,6 +361,8 @@ func (r *registryBehavior) handleEnsure(ctx context.Context,
 		TargetOutpoint: req.Outpoint,
 		ActorID:        child.Ref().ID(),
 		Trigger:        req.Trigger,
+		ExitPolicyKind: exitPolicyKind(req.ExitPolicyKind),
+		ExitPolicyRef:  req.ExitPolicyRef,
 		Phase:          PhasePending,
 	}
 
@@ -371,8 +379,10 @@ func (r *registryBehavior) handleEnsure(ctx context.Context,
 	r.pending[req.Outpoint] = cloneRegistryRecord(record)
 
 	startReq := &StartUnrollRequest{
-		Height:  height,
-		Trigger: req.Trigger,
+		Height:         height,
+		Trigger:        req.Trigger,
+		ExitPolicyKind: req.ExitPolicyKind,
+		ExitPolicyRef:  req.ExitPolicyRef,
 	}
 	startCtx, cancelStart := context.WithTimeout(
 		context.WithoutCancel(ctx), childAdmissionTimeout,
@@ -1109,6 +1119,8 @@ func recordFromChildState(target wire.OutPoint, actorID string,
 		TargetOutpoint: target,
 		ActorID:        actorID,
 		Trigger:        state.Trigger,
+		ExitPolicyKind: exitPolicyKind(state.ExitPolicyKind),
+		ExitPolicyRef:  state.ExitPolicyRef,
 		Phase:          state.Phase,
 		FailReason:     state.FailReason,
 		SweepTxid:      copyHash(state.SweepTxid),
@@ -1121,13 +1133,15 @@ func statusFromRegistryRecord(record RegistryRecord,
 	active bool) *GetStatusResp {
 
 	return &GetStatusResp{
-		Found:      true,
-		Active:     active,
-		ActorID:    record.ActorID,
-		Phase:      record.Phase,
-		Trigger:    record.Trigger,
-		FailReason: record.FailReason,
-		SweepTxid:  copyHash(record.SweepTxid),
+		Found:          true,
+		Active:         active,
+		ActorID:        record.ActorID,
+		Phase:          record.Phase,
+		Trigger:        record.Trigger,
+		ExitPolicyKind: record.ExitPolicyKind,
+		ExitPolicyRef:  record.ExitPolicyRef,
+		FailReason:     record.FailReason,
+		SweepTxid:      copyHash(record.SweepTxid),
 	}
 }
 
@@ -1144,6 +1158,8 @@ func sameRegistryRecord(a, b RegistryRecord) bool {
 	if a.TargetOutpoint != b.TargetOutpoint ||
 		a.ActorID != b.ActorID ||
 		a.Trigger != b.Trigger ||
+		a.ExitPolicyKind != b.ExitPolicyKind ||
+		a.ExitPolicyRef != b.ExitPolicyRef ||
 		a.Phase != b.Phase ||
 		a.FailReason != b.FailReason {
 		return false

--- a/unroll/registry_messages.go
+++ b/unroll/registry_messages.go
@@ -31,6 +31,13 @@ type EnsureUnrollRequest struct {
 
 	// Trigger identifies why the unroll was requested.
 	Trigger StartTrigger
+
+	// ExitPolicyKind identifies the final spend policy to persist for this
+	// target. Empty requests use the standard VTXO timeout policy.
+	ExitPolicyKind string
+
+	// ExitPolicyRef is the policy-specific durable reference.
+	ExitPolicyRef string
 }
 
 // MessageType returns the stable message type identifier.
@@ -98,6 +105,12 @@ type GetStatusResp struct {
 
 	// Trigger is the original start trigger when known.
 	Trigger StartTrigger
+
+	// ExitPolicyKind identifies the final spend policy for this target.
+	ExitPolicyKind string
+
+	// ExitPolicyRef is the policy-specific durable reference.
+	ExitPolicyRef string
 
 	// FailReason is the last known terminal failure when present.
 	FailReason string

--- a/unroll/registry_test.go
+++ b/unroll/registry_test.go
@@ -978,6 +978,44 @@ func TestRegistryEnsurePersistsBeforeAck(t *testing.T) {
 	require.Equal(t, TriggerManual, record.Trigger)
 }
 
+// TestRegistryEnsurePersistsExitPolicyIdentity verifies custom admission
+// policy identity survives the registry and child actor start path. Without
+// this, custom recovery callers would persist an unroll job that restarts as a
+// standard VTXO timeout sweep.
+func TestRegistryEnsurePersistsExitPolicyIdentity(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	registry, store, jobs, _ := newRegistryHarness(t, proof, desc)
+
+	const (
+		policyKind = "vhtlc_claim"
+		policyRef  = "recovery-policy-ref"
+	)
+
+	resp, err := registry.Ref().Ask(t.Context(), &EnsureUnrollRequest{
+		Outpoint:       proof.TargetOutpoint(),
+		Trigger:        TriggerManual,
+		ExitPolicyKind: policyKind,
+		ExitPolicyRef:  policyRef,
+	}).Await(t.Context()).Unpack()
+	require.NoError(t, err)
+
+	ensureResp, ok := resp.(*EnsureUnrollResp)
+	require.True(t, ok)
+	require.True(t, ensureResp.Created)
+
+	record, err := store.GetRecord(t.Context(), proof.TargetOutpoint())
+	require.NoError(t, err)
+	require.NotNil(t, record)
+	require.Equal(t, policyKind, record.ExitPolicyKind)
+	require.Equal(t, policyRef, record.ExitPolicyRef)
+
+	job, err := jobs.GetJob(t.Context(), proof.TargetOutpoint())
+	require.NoError(t, err)
+	require.Equal(t, policyKind, job.ExitPolicyKind)
+	require.Equal(t, policyRef, job.ExitPolicyRef)
+}
+
 // TestRegistryEnsureStartsChildAfterCallerCancellation verifies that once the
 // pending control-plane row exists, caller cancellation does not leak into the
 // durable child's first StartUnrollRequest.

--- a/unroll/state_snapshot.go
+++ b/unroll/state_snapshot.go
@@ -25,6 +25,8 @@ func snapshotFromState(state State, sweepTx *wire.MsgTx) *unrollSnapshot {
 	snapshot.Height = job.Height
 	snapshot.Started = true
 	snapshot.Trigger = job.Trigger
+	snapshot.ExitPolicyKind = exitPolicyKind(job.ExitPolicyKind)
+	snapshot.ExitPolicyRef = job.ExitPolicyRef
 	snapshot.State = copyPlannerState(job.PlannerState)
 	snapshot.DeferredCheckpoints = copyDeferredCheckpoints(
 		job.DeferredCheckpoints,
@@ -74,6 +76,8 @@ func stateFromSnapshot(snapshot *unrollSnapshot) State {
 	job := &JobState{
 		Height:              snapshot.Height,
 		Trigger:             snapshot.Trigger,
+		ExitPolicyKind:      exitPolicyKind(snapshot.ExitPolicyKind),
+		ExitPolicyRef:       snapshot.ExitPolicyRef,
 		PlannerState:        copyPlannerState(snapshot.State),
 		DeferredCheckpoints: deferred,
 		FailReason:          snapshot.Fail,

--- a/unroll/state_snapshot_test.go
+++ b/unroll/state_snapshot_test.go
@@ -32,8 +32,10 @@ func TestSnapshotRoundTripByPhase(t *testing.T) {
 			name: "materialization",
 			state: &AwaitingMaterialization{
 				Job: &JobState{
-					Height:  100,
-					Trigger: TriggerFraudSpend,
+					Height:         100,
+					Trigger:        TriggerFraudSpend,
+					ExitPolicyKind: "vhtlc_claim",
+					ExitPolicyRef:  "recovery-policy-ref",
 					PlannerState: unrollState(
 						chainhash.Hash{0x01},
 						fn.None[int32](), nil,
@@ -118,6 +120,18 @@ func TestSnapshotRoundTripByPhase(t *testing.T) {
 			require.Equal(
 				t, stateTrigger(tc.state),
 				stateTrigger(restored),
+			)
+			require.Equal(
+				t, exitPolicyKind(
+					stateJob(tc.state).ExitPolicyKind,
+				),
+				exitPolicyKind(
+					stateJob(restored).ExitPolicyKind,
+				),
+			)
+			require.Equal(
+				t, stateJob(tc.state).ExitPolicyRef,
+				stateJob(restored).ExitPolicyRef,
 			)
 			require.Equal(
 				t, stateJob(tc.state).FailReason,


### PR DESCRIPTION
## Summary

Persists unroll exit policy identity at admission time so custom recovery callers do not accidentally restart as standard VTXO timeout sweeps.

Before this, `unroll` had the durable `exit_policy_kind` / `exit_policy_ref` columns and the actor could resolve a policy from a persisted snapshot, but new registry admissions had no way to carry that identity into the first `StartUnrollRequest`. New jobs therefore defaulted to `standard_vtxo_timeout` at snapshot time.

## What changed

- Adds `ExitPolicyKind` and `ExitPolicyRef` to registry admission and child start messages.
- Stores policy identity in the in-memory `JobState`, actor snapshots, registry records, DB registry adapter, and status responses.
- Preserves existing policy identity when registry control-plane updates refine or reload an existing job.
- Adds a regression test proving a custom admission is durable in both the registry record and child unroll job row.

## Validation

- `make fmt-changed-check`
- `go test ./unroll ./vhtlcrecovery/...`
- `make commitmsg-lint range="codex/vhtlc-recovery-policies..HEAD"`
- `make lint-native`
