### PR TITLE
multi: arm vhtlc recovery from swap fsm

### DIFF
--- a/cmd/darepocli/darepoclicommands/cmd_recovery.go
+++ b/cmd/darepocli/darepoclicommands/cmd_recovery.go
@@ -1,0 +1,261 @@
+package darepoclicommands
+
+import (
+	"bufio"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/spf13/cobra"
+)
+
+// newRecoveryCmd builds the advanced control-plane commands for daemon-owned
+// vHTLC recovery rows. Normal swap clients should let the swap FSM arm and
+// cancel recovery automatically; these commands are for manual escalation,
+// operator intervention, and debugging.
+func newRecoveryCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "recovery",
+		Short: "Manage daemon-owned vHTLC recovery rows",
+		Long: "Manage already-armed vHTLC recovery rows. " +
+			"Automatic swap execution arms recovery early and " +
+			"escalates it only when policy says on-chain " +
+			"recovery is needed; this subtree lets an operator " +
+			"inspect or override " +
+			"that decision for a specific recovery id.",
+	}
+
+	cmd.AddCommand(
+		newRecoveryListCmd(), newRecoveryStatusCmd(),
+		newRecoveryEscalateCmd(), newRecoveryCancelCmd(),
+	)
+
+	return cmd
+}
+
+// newRecoveryListCmd lists daemon-owned recovery rows and explains which rows
+// are still dormant before an operator chooses whether to escalate one.
+func newRecoveryListCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List vHTLC recovery rows",
+		Long: "List vHTLC recovery rows from the daemon. ARMED " +
+			"rows are dormant: funds are not being unrolled " +
+			"unless an operator runs recovery escalate, or auto " +
+			"escalation is enabled by policy.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			client, conn, err := getDaemonClient(cmd)
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+
+			includeTerminal, _ := cmd.Flags().GetBool(
+				"include-terminal",
+			)
+			resp, err := client.ListVHTLCRecoveries(
+				cmd.Context(),
+				&daemonrpc.ListVHTLCRecoveriesRequest{
+					IncludeTerminal: includeTerminal,
+				},
+			)
+			if err != nil {
+				return err
+			}
+
+			return printJSON(resp)
+		},
+	}
+
+	cmd.Flags().Bool("include-terminal", false,
+		"include completed, cancelled, and failed recovery rows")
+
+	return cmd
+}
+
+// newRecoveryStatusCmd returns the daemon's durable recovery row and current
+// unroll status, if present.
+func newRecoveryStatusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status [recovery_id]",
+		Short: "Show one vHTLC recovery row",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, conn, err := getDaemonClient(cmd)
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+
+			resp, err := client.GetVHTLCRecoveryStatus(
+				cmd.Context(),
+				&daemonrpc.GetVHTLCRecoveryStatusRequest{
+					RecoveryId: args[0],
+				},
+			)
+			if err != nil {
+				return err
+			}
+
+			return printJSON(resp)
+		},
+	}
+}
+
+// newRecoveryEscalateCmd manually starts on-chain unroll for one previously
+// armed recovery row. Claim recovery can include --claim-preimage-hex when the
+// daemon cannot resolve the preimage from the swap store.
+func newRecoveryEscalateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "escalate [recovery_id]",
+		Short: "Start on-chain recovery for one armed vHTLC",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, conn, err := getDaemonClient(cmd)
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+
+			reason, _ := cmd.Flags().GetString("reason")
+			preimageHex, _ := cmd.Flags().GetString(
+				"claim-preimage-hex",
+			)
+			preimage, err := decodeRecoveryPreimage(preimageHex)
+			if err != nil {
+				return err
+			}
+			if err := confirmRecoveryEscalation(
+				cmd, args[0],
+			); err != nil {
+				return err
+			}
+
+			resp, err := client.EscalateVHTLCRecovery(
+				cmd.Context(),
+				&daemonrpc.EscalateVHTLCRecoveryRequest{
+					RecoveryId:    args[0],
+					Reason:        reason,
+					ClaimPreimage: preimage,
+				},
+			)
+			if err != nil {
+				return err
+			}
+
+			return printJSON(resp)
+		},
+	}
+
+	cmd.Flags().String("reason", "manual client escalation",
+		"operator-facing reason stored with the escalation attempt")
+	cmd.Flags().String("claim-preimage-hex", "",
+		"optional 32-byte claim preimage for claim recoveries")
+	cmd.Flags().Bool("yes", false,
+		"skip interactive confirmation before starting on-chain "+
+			"recovery")
+
+	return cmd
+}
+
+// newRecoveryCancelCmd records that cooperative settlement won and the armed
+// recovery row is no longer needed.
+func newRecoveryCancelCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cancel [recovery_id]",
+		Short: "Cancel one armed vHTLC recovery row",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, conn, err := getDaemonClient(cmd)
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+
+			reason, _ := cmd.Flags().GetString("reason")
+			txid, _ := cmd.Flags().GetString("cooperative-txid")
+
+			resp, err := client.CancelVHTLCRecovery(
+				cmd.Context(),
+				&daemonrpc.CancelVHTLCRecoveryRequest{
+					RecoveryId:      args[0],
+					Reason:          reason,
+					CooperativeTxid: txid,
+				},
+			)
+			if err != nil {
+				return err
+			}
+
+			return printJSON(resp)
+		},
+	}
+
+	cmd.Flags().String("reason", "manual client cancellation",
+		"operator-facing reason stored with the cancellation")
+	cmd.Flags().String("cooperative-txid", "",
+		"optional cooperative OOR txid/session id that won")
+
+	return cmd
+}
+
+// confirmRecoveryEscalation requires explicit operator consent before a manual
+// command starts costly on-chain recovery. Non-interactive callers must pass
+// --yes so scripts and agents cannot hang on a prompt or escalate by accident.
+func confirmRecoveryEscalation(cmd *cobra.Command, recoveryID string) error {
+	yes, _ := cmd.Flags().GetBool("yes")
+	if yes {
+		return nil
+	}
+	if !stdinIsTTY(cmd) {
+		return PrintError(
+			"INVALID_ARGS", "recovery escalate requires --yes "+
+				"(explicit consent) on non-interactive "+
+				"stdin; refusing to prompt because an "+
+				"agent cannot respond to y/N",
+		)
+	}
+
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(
+		out, "About to start on-chain vHTLC recovery for %s.\n",
+		recoveryID,
+	)
+	fmt.Fprintln(
+		out, "This may unroll Ark state and pay on-chain fees. Use "+
+			"recovery status/list first to confirm cooperative "+
+			"settlement cannot safely continue.",
+	)
+	fmt.Fprint(out, "Start recovery? [y/N]: ")
+
+	reader := bufio.NewReader(cmd.InOrStdin())
+	answer, err := reader.ReadString('\n')
+	if err != nil {
+		return fmt.Errorf("read confirmation: %w", err)
+	}
+	answer = strings.TrimSpace(strings.ToLower(answer))
+	if answer != "y" && answer != "yes" {
+		return fmt.Errorf("aborted by user")
+	}
+
+	return nil
+}
+
+// decodeRecoveryPreimage decodes an optional 32-byte preimage. Empty input maps
+// to nil so refund-without-receiver escalation does not send secret material.
+func decodeRecoveryPreimage(encoded string) ([]byte, error) {
+	if encoded == "" {
+		return nil, nil
+	}
+
+	raw, err := hex.DecodeString(encoded)
+	if err != nil {
+		return nil, fmt.Errorf("decode claim preimage: %w", err)
+	}
+	if len(raw) != 32 {
+		return nil, fmt.Errorf("claim preimage must be 32 bytes")
+	}
+
+	return raw, nil
+}

--- a/cmd/darepocli/darepoclicommands/devrpc/registry_generated.go
+++ b/cmd/darepocli/darepoclicommands/devrpc/registry_generated.go
@@ -272,7 +272,7 @@ func generatedRegistry() []serviceSpec {
 					Aliases:  []string{"list-v-h-t-l-c-recoveries"},
 					Input:    "daemonrpc.ListVHTLCRecoveriesRequest",
 					Output:   "daemonrpc.ListVHTLCRecoveriesResponse",
-					Comments: "ListVHTLCRecoveries returns durable recovery rows for operator\ninspection.",
+					Comments: "ListVHTLCRecoveries returns all durable recovery rows for operator\ninspection. Armed rows are dormant; callers must use\nEscalateVHTLCRecovery to start costly on-chain recovery.",
 				},
 			},
 		},

--- a/cmd/darepocli/darepoclicommands/root.go
+++ b/cmd/darepocli/darepoclicommands/root.go
@@ -79,6 +79,7 @@ func NewRootCmd() *cobra.Command {
 
 		// Advanced subtrees.
 		newArkCmd(),
+		newRecoveryCmd(),
 		newSwapCmd(),
 
 		devrpc.NewDevCmd(

--- a/cmd/darepod/main.go
+++ b/cmd/darepod/main.go
@@ -309,6 +309,30 @@ func registerSwapRuntimeFlags(f *pflag.FlagSet, cfg *darepod.Config) {
 		"swap.databasefilename", cfg.Swap.DatabaseFileName,
 		"swap session SQLite database path for swapruntime builds",
 	)
+	f.Bool(
+		"swap.vhtlcrecovery.autoescalate",
+		cfg.Swap.VHTLCRecovery.AutoEscalate, "automatically "+
+			"escalate armed vHTLC recovery after grace or "+
+			"deadline policy in swapruntime builds",
+	)
+	f.Duration(
+		"swap.vhtlcrecovery.cooperativefailuregraceperiod",
+		cfg.Swap.VHTLCRecovery.CooperativeFailureGracePeriod, "delay"+
+			" after first cooperative vHTLC send failure "+
+			"before automatic recovery in swapruntime builds",
+	)
+	f.Uint32(
+		"swap.vhtlcrecovery.minrecoverymarginblocks",
+		cfg.Swap.VHTLCRecovery.MinRecoveryMarginBlocks, "minimum "+
+			"block margin preserved before claim recovery "+
+			"deadlines in swapruntime builds",
+	)
+	f.Int32(
+		"swap.vhtlcrecovery.maxfeeratesatperkw",
+		cfg.Swap.VHTLCRecovery.MaxFeeRateSatPerKW, "maximum fee "+
+			"rate in sat/kw for swapruntime vHTLC recovery "+
+			"exit spends",
+	)
 }
 
 // bindOORLimitFlags binds hyphenated OOR CLI flags to the config keys used by

--- a/daemonrpc/daemon.pb.go
+++ b/daemonrpc/daemon.pb.go
@@ -6888,7 +6888,7 @@ func (x *ListVHTLCRecoveriesRequest) GetIncludeTerminal() bool {
 
 type ListVHTLCRecoveriesResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// statuses contains matching durable recovery rows.
+	// statuses are returned in newest-updated order.
 	Statuses      []*VHTLCRecoveryStatus `protobuf:"bytes,1,rep,name=statuses,proto3" json:"statuses,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/daemonrpc/daemon.pb.go
+++ b/daemonrpc/daemon.pb.go
@@ -6529,7 +6529,11 @@ type EscalateVHTLCRecoveryRequest struct {
 	// recovery_id identifies the armed recovery job to start.
 	RecoveryId string `protobuf:"bytes,1,opt,name=recovery_id,json=recoveryId,proto3" json:"recovery_id,omitempty"`
 	// reason records why the cooperative path is no longer sufficient.
-	Reason        string `protobuf:"bytes,2,opt,name=reason,proto3" json:"reason,omitempty"`
+	Reason string `protobuf:"bytes,2,opt,name=reason,proto3" json:"reason,omitempty"`
+	// claim_preimage is optional secret witness material for cross-process
+	// claim recovery. It must be supplied only for claim recovery and must
+	// match the armed preimage_hash.
+	ClaimPreimage []byte `protobuf:"bytes,3,opt,name=claim_preimage,json=claimPreimage,proto3" json:"claim_preimage,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -6576,6 +6580,13 @@ func (x *EscalateVHTLCRecoveryRequest) GetReason() string {
 		return x.Reason
 	}
 	return ""
+}
+
+func (x *EscalateVHTLCRecoveryRequest) GetClaimPreimage() []byte {
+	if x != nil {
+		return x.ClaimPreimage
+	}
+	return nil
 }
 
 type EscalateVHTLCRecoveryResponse struct {
@@ -7614,11 +7625,12 @@ const file_daemon_proto_rawDesc = "" +
 	"\vrecovery_id\x18\x01 \x01(\tR\n" +
 	"recoveryId\x12\x18\n" +
 	"\acreated\x18\x02 \x01(\bR\acreated\x126\n" +
-	"\x06status\x18\x03 \x01(\v2\x1e.daemonrpc.VHTLCRecoveryStatusR\x06status\"W\n" +
+	"\x06status\x18\x03 \x01(\v2\x1e.daemonrpc.VHTLCRecoveryStatusR\x06status\"~\n" +
 	"\x1cEscalateVHTLCRecoveryRequest\x12\x1f\n" +
 	"\vrecovery_id\x18\x01 \x01(\tR\n" +
 	"recoveryId\x12\x16\n" +
-	"\x06reason\x18\x02 \x01(\tR\x06reason\"W\n" +
+	"\x06reason\x18\x02 \x01(\tR\x06reason\x12%\n" +
+	"\x0eclaim_preimage\x18\x03 \x01(\fR\rclaimPreimage\"W\n" +
 	"\x1dEscalateVHTLCRecoveryResponse\x126\n" +
 	"\x06status\x18\x01 \x01(\v2\x1e.daemonrpc.VHTLCRecoveryStatusR\x06status\"\x80\x01\n" +
 	"\x1aCancelVHTLCRecoveryRequest\x12\x1f\n" +

--- a/daemonrpc/daemon.proto
+++ b/daemonrpc/daemon.proto
@@ -1752,6 +1752,11 @@ message EscalateVHTLCRecoveryRequest {
 
     // reason records why the cooperative path is no longer sufficient.
     string reason = 2;
+
+    // claim_preimage is optional secret witness material for cross-process
+    // claim recovery. It must be supplied only for claim recovery and must
+    // match the armed preimage_hash.
+    bytes claim_preimage = 3;
 }
 
 message EscalateVHTLCRecoveryResponse {

--- a/daemonrpc/daemon.proto
+++ b/daemonrpc/daemon.proto
@@ -187,8 +187,9 @@ service DaemonService {
     rpc GetVHTLCRecoveryStatus (GetVHTLCRecoveryStatusRequest)
         returns (GetVHTLCRecoveryStatusResponse);
 
-    // ListVHTLCRecoveries returns durable recovery rows for operator
-    // inspection.
+    // ListVHTLCRecoveries returns all durable recovery rows for operator
+    // inspection. Armed rows are dormant; callers must use
+    // EscalateVHTLCRecovery to start costly on-chain recovery.
     rpc ListVHTLCRecoveries (ListVHTLCRecoveriesRequest)
         returns (ListVHTLCRecoveriesResponse);
 }
@@ -1799,7 +1800,7 @@ message ListVHTLCRecoveriesRequest {
 }
 
 message ListVHTLCRecoveriesResponse {
-    // statuses contains matching durable recovery rows.
+    // statuses are returned in newest-updated order.
     repeated VHTLCRecoveryStatus statuses = 1;
 }
 

--- a/daemonrpc/daemon_grpc.pb.go
+++ b/daemonrpc/daemon_grpc.pb.go
@@ -194,8 +194,9 @@ type DaemonServiceClient interface {
 	// GetVHTLCRecoveryStatus returns the durable recovery row joined with the
 	// current unroll status when the job has escalated.
 	GetVHTLCRecoveryStatus(ctx context.Context, in *GetVHTLCRecoveryStatusRequest, opts ...grpc.CallOption) (*GetVHTLCRecoveryStatusResponse, error)
-	// ListVHTLCRecoveries returns durable recovery rows for operator
-	// inspection.
+	// ListVHTLCRecoveries returns all durable recovery rows for operator
+	// inspection. Armed rows are dormant; callers must use
+	// EscalateVHTLCRecovery to start costly on-chain recovery.
 	ListVHTLCRecoveries(ctx context.Context, in *ListVHTLCRecoveriesRequest, opts ...grpc.CallOption) (*ListVHTLCRecoveriesResponse, error)
 }
 
@@ -722,8 +723,9 @@ type DaemonServiceServer interface {
 	// GetVHTLCRecoveryStatus returns the durable recovery row joined with the
 	// current unroll status when the job has escalated.
 	GetVHTLCRecoveryStatus(context.Context, *GetVHTLCRecoveryStatusRequest) (*GetVHTLCRecoveryStatusResponse, error)
-	// ListVHTLCRecoveries returns durable recovery rows for operator
-	// inspection.
+	// ListVHTLCRecoveries returns all durable recovery rows for operator
+	// inspection. Armed rows are dormant; callers must use
+	// EscalateVHTLCRecovery to start costly on-chain recovery.
 	ListVHTLCRecoveries(context.Context, *ListVHTLCRecoveriesRequest) (*ListVHTLCRecoveriesResponse, error)
 	mustEmbedUnimplementedDaemonServiceServer()
 }

--- a/darepod/config.go
+++ b/darepod/config.go
@@ -107,6 +107,23 @@ const (
 	// RPCTransportREST selects grpc-gateway HTTP/JSON for daemon-owned
 	// outbound RPCs.
 	RPCTransportREST = "rest"
+
+	// DefaultSwapRecoveryCooperativeFailureGracePeriod is how long the
+	// daemon-owned swap runtime keeps retrying cooperative vHTLC settlement
+	// after the first observed cooperative send failure before automatic
+	// on-chain recovery may start.
+	DefaultSwapRecoveryCooperativeFailureGracePeriod = time.Hour
+
+	// DefaultSwapRecoveryMinMarginBlocks is the block-height safety margin
+	// that lets receive-side claim recovery override the wall-clock grace
+	// period before the sender refund locktime can make waiting unsafe.
+	DefaultSwapRecoveryMinMarginBlocks = uint32(12)
+
+	// DefaultSwapRecoveryMaxFeeRateSatPerKW caps swapruntime-armed vHTLC
+	// exit spends at 100 sat/vbyte. The cap is copied into the recovery row
+	// at arm time so later config changes cannot silently loosen an
+	// existing job.
+	DefaultSwapRecoveryMaxFeeRateSatPerKW int32 = 25_000
 )
 
 // Config holds all configuration for the darepod daemon.
@@ -365,6 +382,11 @@ type SwapConfig struct {
 	// resume can discover pending sessions without CLI state.
 	DatabaseFileName string `mapstructure:"databasefilename"`
 
+	// VHTLCRecovery controls when the daemon-owned swap runtime escalates
+	// an already-armed vHTLC recovery row from cooperative retry into
+	// on-chain unroll.
+	VHTLCRecovery SwapVHTLCRecoveryConfig `mapstructure:"vhtlcrecovery"`
+
 	// SuppressResume disables swapclientserver's own synchronous
 	// resume-on-startup sweep so a higher layer (walletrpc subserver) can
 	// own the unified resume policy. Default false preserves identical
@@ -380,6 +402,46 @@ type SwapConfig struct {
 	// going through the gRPC stub. The field is set programmatically by
 	// the registrar; it is never loaded from config files.
 	Backend SwapBackend `mapstructure:"-"`
+}
+
+// SwapVHTLCRecoveryConfig controls automatic escalation from cooperative vHTLC
+// retry to daemon-owned on-chain recovery. Arming is still immediate and cheap;
+// this policy only gates the expensive unroll transition.
+type SwapVHTLCRecoveryConfig struct {
+	// AutoEscalate allows the daemon-owned swap runtime to start on-chain
+	// recovery without a manual command once the grace/deadline policy says
+	// cooperative retry is no longer safe or useful.
+	AutoEscalate bool `mapstructure:"autoescalate"`
+
+	// CooperativeFailureGracePeriod is measured from the first cooperative
+	// vHTLC send failure. While the period is open, the swap runtime keeps
+	// retrying cooperative settlement unless deadline pressure overrides
+	// the wait.
+	CooperativeFailureGracePeriod time.Duration `mapstructure:"cooperativefailuregraceperiod"` //nolint:ll
+
+	// MinRecoveryMarginBlocks is the minimum block margin preserved before
+	// a refund locktime. Receive-side claim recovery may override the grace
+	// period when the current height plus this margin reaches the refund
+	// locktime.
+	MinRecoveryMarginBlocks uint32 `mapstructure:"minrecoverymarginblocks"`
+
+	// MaxFeeRateSatPerKW caps the final vHTLC recovery exit-spend fee rate.
+	MaxFeeRateSatPerKW int32 `mapstructure:"maxfeeratesatperkw"`
+}
+
+// WithDefaults fills unset numeric vHTLC recovery fields with production
+// defaults while preserving AutoEscalate. This lets operators set
+// autoescalate=false without that explicit manual-recovery mode being rewritten
+// back to the default automatic policy.
+func (c SwapVHTLCRecoveryConfig) WithDefaults() SwapVHTLCRecoveryConfig {
+	if c.MinRecoveryMarginBlocks == 0 {
+		c.MinRecoveryMarginBlocks = DefaultSwapRecoveryMinMarginBlocks
+	}
+	if c.MaxFeeRateSatPerKW == 0 {
+		c.MaxFeeRateSatPerKW = DefaultSwapRecoveryMaxFeeRateSatPerKW
+	}
+
+	return c
 }
 
 // SwapBackend is the in-Go handle exposed by swapclientserver after Register
@@ -611,6 +673,16 @@ type WalletConfig struct {
 
 // DefaultConfig returns a Config populated with sensible defaults.
 func DefaultConfig() *Config {
+	swapRecoveryGrace := DefaultSwapRecoveryCooperativeFailureGracePeriod
+	swapRecoveryMargin := DefaultSwapRecoveryMinMarginBlocks
+	swapRecoveryFeeCap := DefaultSwapRecoveryMaxFeeRateSatPerKW
+	swapRecovery := SwapVHTLCRecoveryConfig{
+		AutoEscalate:                  false,
+		CooperativeFailureGracePeriod: swapRecoveryGrace,
+		MinRecoveryMarginBlocks:       swapRecoveryMargin,
+		MaxFeeRateSatPerKW:            swapRecoveryFeeCap,
+	}
+
 	return &Config{
 		DataDir:    DefaultDataDir,
 		Network:    DefaultNetwork,
@@ -636,6 +708,7 @@ func DefaultConfig() *Config {
 		Swap: &SwapConfig{
 			ServerAddress:   "localhost:10030",
 			ServerTransport: RPCTransportGRPC,
+			VHTLCRecovery:   swapRecovery,
 		},
 		MaxOperatorFeeSat: DefaultMaxOperatorFeeSat,
 		OOR:               defaultOORConfig(),
@@ -758,6 +831,24 @@ func (c *Config) Validate() error {
 		c.RPC.Gateway.AllowedOrigins,
 	); err != nil {
 		return err
+	}
+	if c.Swap != nil {
+		c.Swap.VHTLCRecovery = c.Swap.VHTLCRecovery.WithDefaults()
+		recoveryPolicy := c.Swap.VHTLCRecovery
+		gracePeriod := recoveryPolicy.CooperativeFailureGracePeriod
+		if gracePeriod < 0 {
+			return fmt.Errorf("swap vhtlc recovery cooperative " +
+				"failure grace period must be non-negative")
+		}
+		if recoveryPolicy.AutoEscalate && gracePeriod == 0 {
+			return fmt.Errorf("swap vhtlc recovery cooperative " +
+				"failure grace period must be positive when " +
+				"auto escalation is enabled")
+		}
+		if c.Swap.VHTLCRecovery.MaxFeeRateSatPerKW <= 0 {
+			return fmt.Errorf("swap vhtlc recovery max fee rate " +
+				"must be positive")
+		}
 	}
 
 	return nil

--- a/darepod/rpc_vhtlc_recovery.go
+++ b/darepod/rpc_vhtlc_recovery.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -13,7 +12,6 @@ import (
 	"github.com/lightninglabs/darepo-client/vhtlcrecovery"
 	"github.com/lightninglabs/darepo-client/vhtlcrecovery/coordinator"
 	"github.com/lightninglabs/darepo-client/vhtlcrecovery/unrollpolicy"
-	"github.com/lightningnetwork/lnd/lntypes"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -103,6 +101,7 @@ func (r *RPCServer) EscalateVHTLCRecovery(ctx context.Context,
 
 	recoveryStatus, err := service.EscalateRecovery(
 		ctx, req.RecoveryId, req.Reason,
+		cloneRPCBytes(req.ClaimPreimage),
 	)
 	if err != nil {
 		return nil, recoveryErrorToStatus(err)
@@ -248,35 +247,6 @@ func (r *RPCServer) RegisterVHTLCRecoveryPreimageResolver(
 	r.server.vhtlcPreimages.SetResolver(resolver)
 
 	return nil
-}
-
-type vhtlcPreimageRegistry struct {
-	mu       sync.RWMutex
-	resolver unrollpolicy.PreimageResolver
-}
-
-func (r *vhtlcPreimageRegistry) SetResolver(
-	resolver unrollpolicy.PreimageResolver) {
-
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	r.resolver = resolver
-}
-
-func (r *vhtlcPreimageRegistry) ResolvePreimage(ctx context.Context,
-	swapID []byte, preimageHash lntypes.Hash) (lntypes.Preimage, error) {
-
-	r.mu.RLock()
-	resolver := r.resolver
-	r.mu.RUnlock()
-
-	if resolver == nil {
-		return lntypes.Preimage{}, fmt.Errorf("vhtlc recovery " +
-			"preimage resolver is not registered")
-	}
-
-	return resolver.ResolvePreimage(ctx, swapID, preimageHash)
 }
 
 // recoveryJobFromProto converts a public arm request into the durable recovery

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -298,7 +298,7 @@ type Server struct {
 	oorSigningEffect   *oor.SigningEffectActor
 	vhtlcRecoveryStore *db.VHTLCRecoveryStoreDB
 	vhtlcRecovery      *coordinator.Service
-	vhtlcPreimages     *vhtlcPreimageRegistry
+	vhtlcPreimages     *unrollpolicy.PreimageResolverRegistry
 
 	// ledgerStore exposes the client-side ledger DB adapter for
 	// read-only RPC handlers (GetFeeHistory). Writes go through
@@ -4422,6 +4422,8 @@ func (s *Server) initUnrollSubsystem(ctx context.Context,
 	s.ueStore = ueStore
 	recoveryStore := dbStore.NewVHTLCRecoveryStore(s.clk)
 	s.vhtlcRecoveryStore = recoveryStore
+	preimages := &unrollpolicy.PreimageResolverRegistry{}
+	s.vhtlcPreimages = preimages
 	vtxoStore := dbStore.NewVTXOStore(s.clk)
 
 	// Build the wallet adapter shared by txconfirm and unroll
@@ -4480,8 +4482,6 @@ func (s *Server) initUnrollSubsystem(ctx context.Context,
 	}
 	s.proofAssembler = proofAssembler
 
-	s.vhtlcPreimages = &vhtlcPreimageRegistry{}
-
 	registry := unroll.NewUnrollRegistryActor(unroll.RegistryConfig{
 		Store: &unroll.DBRegistryStore{
 			UEStore: ueStore,
@@ -4496,7 +4496,7 @@ func (s *Server) initUnrollSubsystem(ctx context.Context,
 		MaxSweepFeeRateSatPerVByte: s.unrollMaxFeeRate(),
 		ExitSpendPolicyResolver: unrollpolicy.ExitSpendPolicyResolver{
 			Jobs:     recoveryStore,
-			Preimage: s.vhtlcPreimages,
+			Preimage: preimages,
 		},
 	})
 	s.unrollRegistry = registry
@@ -4506,6 +4506,10 @@ func (s *Server) initUnrollSubsystem(ctx context.Context,
 		Store:  recoveryStore,
 		Unroll: coordinator.NewActorUnrollRegistry(registry.Ref()),
 		Log:    fn.Some(s.subLogger(VHTLCRecoverySubsystem)),
+		TargetMaterializer: newVHTLCRecoveryTargetMaterializer(
+			vtxoStore, oorStore,
+			s.subLogger(VHTLCRecoverySubsystem),
+		),
 	})
 	if err != nil {
 		return err

--- a/darepod/vhtlc_recovery_target.go
+++ b/darepod/vhtlc_recovery_target.go
@@ -1,0 +1,514 @@
+package darepod
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/db"
+	"github.com/lightninglabs/darepo-client/vhtlcrecovery"
+	"github.com/lightninglabs/darepo-client/vtxo"
+	"github.com/lightningnetwork/lnd/keychain"
+)
+
+var errRecoveryTargetPackageMissing = errors.New("recovery target package " +
+	"not found")
+
+const (
+	recoveryTargetPackagePollInterval = 100 * time.Millisecond
+	recoveryTargetPackagePollTimeout  = 10 * time.Second
+)
+
+// vhtlcRecoveryTargetMaterializer prepares daemon-owned vHTLC outputs for the
+// generic unroll subsystem. vHTLC outputs are not normal wallet coin-selection
+// inventory: they are application-owned recovery targets. This adapter binds
+// the OOR package that created the vHTLC output and stores a recovery-only VTXO
+// descriptor so unroll can assemble lineage and watch the target without
+// teaching generic unroll about swap semantics.
+type vhtlcRecoveryTargetMaterializer struct {
+	vtxos    vtxo.VTXOStore
+	packages *db.OORArtifactPersistenceStore
+	log      btclog.Logger
+}
+
+// newVHTLCRecoveryTargetMaterializer creates the darepod adapter used by the
+// vHTLC recovery coordinator. The adapter is deliberately small and local to
+// darepod because it stitches together darepod-owned stores rather than adding
+// recovery-specific knowledge to unroll.
+func newVHTLCRecoveryTargetMaterializer(vtxos vtxo.VTXOStore,
+	packages *db.OORArtifactPersistenceStore,
+	log btclog.Logger) *vhtlcRecoveryTargetMaterializer {
+
+	return &vhtlcRecoveryTargetMaterializer{
+		vtxos:    vtxos,
+		packages: packages,
+		log:      log,
+	}
+}
+
+// EnsureRecoveryTarget makes job.VTXOOutpoint loadable by unroll. The method is
+// idempotent: package bindings are upserts, SaveVTXO heals existing descriptor
+// rows, and the status update keeps the target out of wallet coin selection on
+// every retry.
+func (m *vhtlcRecoveryTargetMaterializer) EnsureRecoveryTarget(
+	ctx context.Context, job vhtlcrecovery.RecoveryJob) error {
+
+	if m == nil {
+		return fmt.Errorf("vhtlc recovery materializer is nil")
+	}
+	if m.vtxos == nil {
+		return fmt.Errorf("vtxo store is required")
+	}
+	if m.packages == nil {
+		return fmt.Errorf("oor package store is required")
+	}
+
+	desc, err := m.buildRecoveryDescriptor(ctx, job)
+	if err != nil {
+		return err
+	}
+
+	if err := m.vtxos.SaveVTXO(ctx, desc); err != nil {
+		return fmt.Errorf("save recovery target descriptor: %w", err)
+	}
+
+	if err := m.vtxos.UpdateVTXOStatus(
+		ctx, desc.Outpoint, vtxo.VTXOStatusSpending,
+	); err != nil {
+		return fmt.Errorf("reserve recovery target descriptor: %w", err)
+	}
+
+	if err := m.bindRecoveryTarget(ctx, desc); err != nil {
+		return err
+	}
+
+	m.log.DebugS(ctx, "vhtlc recovery target materialized",
+		slog.String("recovery_id", job.ID),
+		slog.String("outpoint", desc.Outpoint.String()),
+		slog.Int64("amount_sat", int64(desc.Amount)),
+		slog.Uint64("csv_delay", uint64(desc.RelativeExpiry)),
+		slog.Int("ancestry_paths", len(desc.Ancestry)),
+		slog.Int("chain_depth", desc.ChainDepth),
+	)
+
+	return nil
+}
+
+// buildRecoveryDescriptor derives the recovery-only descriptor for the vHTLC
+// target. It first binds the package output by the OOR session id (the Ark txid
+// is the target outpoint hash), then resolves the package chain and copies the
+// root ancestry from the locally stored input VTXO descriptors.
+func (m *vhtlcRecoveryTargetMaterializer) buildRecoveryDescriptor(
+	ctx context.Context, job vhtlcrecovery.RecoveryJob) (*vtxo.Descriptor,
+	error) {
+
+	target := job.VTXOOutpoint
+	if target.Hash == (chainhash.Hash{}) {
+		return nil, fmt.Errorf("recovery target outpoint hash is empty")
+	}
+
+	targetPkg, targetOutput, err := m.loadTargetPackage(ctx, job)
+	if err != nil {
+		return nil, err
+	}
+
+	roots, err := m.loadRootDescriptors(
+		ctx, recoveryCheckpointInputs(targetPkg),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	signingKey, err := recoverySigningKey(job)
+	if err != nil {
+		return nil, err
+	}
+
+	operatorKey, err := recoveryOperatorKey(roots)
+	if err != nil {
+		return nil, err
+	}
+
+	csvDelay, err := recoveryCSVDelay(job)
+	if err != nil {
+		return nil, err
+	}
+
+	ancestry := recoveryAncestry(roots)
+	if len(ancestry) == 0 {
+		return nil, fmt.Errorf("recovery target ancestry is empty")
+	}
+
+	roundID, commitmentTxID, batchExpiry, createdHeight := recoveryRootMeta(
+		roots,
+	)
+	if roundID == "" || commitmentTxID == (chainhash.Hash{}) ||
+		batchExpiry == 0 || createdHeight == 0 {
+		return nil, fmt.Errorf("recovery root metadata incomplete")
+	}
+
+	chainDepth := recoveryChainDepth(roots, 1)
+
+	return &vtxo.Descriptor{
+		Outpoint: target,
+		Amount:   btcutil.Amount(targetOutput.Value),
+		PkScript: append([]byte(nil), targetOutput.PkScript...),
+		ClientKey: keychain.KeyDescriptor{
+			KeyLocator: keychain.KeyLocator{
+				Family: keychain.KeyFamily(job.SignerKeyFamily),
+				Index:  uint32(job.SignerKeyIndex),
+			},
+			PubKey: signingKey,
+		},
+		OperatorKey:    operatorKey,
+		Ancestry:       ancestry,
+		RoundID:        roundID,
+		CommitmentTxID: commitmentTxID,
+		BatchExpiry:    batchExpiry,
+		RelativeExpiry: csvDelay,
+		ChainDepth:     chainDepth,
+		CreatedHeight:  createdHeight,
+		Status:         vtxo.VTXOStatusSpending,
+	}, nil
+}
+
+// loadTargetPackage verifies that the OOR package whose session id equals the
+// target txid exists and returns the exact vHTLC output within that Ark
+// transaction. The created-output binding is written only after the descriptor
+// row exists, because the binding table intentionally references known VTXOs.
+func (m *vhtlcRecoveryTargetMaterializer) loadTargetPackage(ctx context.Context,
+	job vhtlcrecovery.RecoveryJob) (*db.OORPackageBundle, *wire.TxOut,
+	error) {
+
+	timeout := time.NewTimer(recoveryTargetPackagePollTimeout)
+	defer timeout.Stop()
+
+	ticker := time.NewTicker(recoveryTargetPackagePollInterval)
+	defer ticker.Stop()
+
+	for {
+		pkg, output, err := m.loadTargetPackageOnce(ctx, job)
+		if err == nil {
+			return pkg, output, nil
+		}
+		if !errors.Is(err, errRecoveryTargetPackageMissing) {
+			return nil, nil, err
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, nil, ctx.Err()
+
+		case <-timeout.C:
+			return nil, nil, err
+
+		case <-ticker.C:
+		}
+	}
+}
+
+// loadTargetPackageOnce performs one package lookup and structural validation
+// pass for the recovery target. A missing package is returned as a sentinel so
+// the outer loader can absorb short persistence races without hiding malformed
+// package contents or real database errors.
+func (m *vhtlcRecoveryTargetMaterializer) loadTargetPackageOnce(
+	ctx context.Context, job vhtlcrecovery.RecoveryJob) (
+	*db.OORPackageBundle, *wire.TxOut, error) {
+
+	target := job.VTXOOutpoint
+	targetPkg, err := m.packages.GetPackage(ctx, target.Hash)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil, fmt.Errorf("%w: %s",
+				errRecoveryTargetPackageMissing, target.Hash)
+		}
+
+		return nil, nil, fmt.Errorf("load recovery target package: %w",
+			err)
+	}
+
+	if targetPkg.ArkPSBT == nil || targetPkg.ArkPSBT.UnsignedTx == nil {
+		return nil, nil, fmt.Errorf("recovery target package %s has "+
+			"no ark transaction", target.Hash)
+	}
+
+	arkTx := targetPkg.ArkPSBT.UnsignedTx
+	if arkTx.TxHash() != target.Hash {
+		return nil, nil, fmt.Errorf("recovery target package txid "+
+			"does not match target: got %s want %s", arkTx.TxHash(),
+			target.Hash)
+	}
+	if int(target.Index) >= len(arkTx.TxOut) {
+		return nil, nil, fmt.Errorf("recovery target output index %d "+
+			"out of range", target.Index)
+	}
+
+	targetOutput := arkTx.TxOut[target.Index]
+	if job.VTXOAmountSat > 0 && targetOutput.Value != job.VTXOAmountSat {
+		return nil, nil, fmt.Errorf("recovery target amount mismatch: "+
+			"got %d want %d", targetOutput.Value, job.VTXOAmountSat)
+	}
+
+	return targetPkg, targetOutput, nil
+}
+
+// bindRecoveryTarget writes the created-output package binding for desc after
+// SaveVTXO has made the target outpoint visible to the binding table's VTXO
+// existence check. A final resolver pass catches any package-chain gap before
+// the recovery service admits the target into unroll.
+func (m *vhtlcRecoveryTargetMaterializer) bindRecoveryTarget(
+	ctx context.Context, desc *vtxo.Descriptor) error {
+
+	err := m.packages.UpsertBinding(
+		ctx, desc.Outpoint, desc.Outpoint.Hash, desc.Outpoint.Index,
+		db.OORPackageLinkKindCreatedOutput,
+	)
+	if err != nil {
+		return fmt.Errorf("bind recovery target package: %w", err)
+	}
+
+	if _, err := m.packages.ResolveUnrollPackages(
+		ctx, desc.Outpoint,
+	); err != nil {
+		return fmt.Errorf("verify recovery package chain: %w", err)
+	}
+
+	return nil
+}
+
+// loadRootDescriptors loads the locally known VTXOs that anchor the earliest
+// unresolved checkpoint inputs in the OOR package graph. Those root descriptors
+// are allowed to be terminal, because they were already spent by the OOR
+// package; their ancestry remains the authoritative round-birth material for
+// the recovery target.
+func (m *vhtlcRecoveryTargetMaterializer) loadRootDescriptors(
+	ctx context.Context, roots []wire.OutPoint) ([]*vtxo.Descriptor,
+	error) {
+
+	if len(roots) == 0 {
+		return nil, fmt.Errorf("recovery package chain has no root " +
+			"checkpoint inputs")
+	}
+
+	descs := make([]*vtxo.Descriptor, 0, len(roots))
+	seen := make(map[wire.OutPoint]struct{}, len(roots))
+	for _, root := range roots {
+		if _, ok := seen[root]; ok {
+			continue
+		}
+		seen[root] = struct{}{}
+
+		desc, err := m.vtxos.GetVTXO(ctx, root)
+		if err != nil {
+			return nil, fmt.Errorf("load recovery root %s: %w",
+				root, err)
+		}
+		if len(desc.Ancestry) == 0 {
+			return nil, fmt.Errorf("recovery root %s has no "+
+				"ancestry", root)
+		}
+
+		descs = append(descs, desc)
+	}
+
+	return descs, nil
+}
+
+// recoveryCheckpointInputs returns the unique checkpoint inputs referenced by
+// the target package. These inputs are the immediate local roots from which the
+// synthesized recovery descriptor inherits its round-birth ancestry.
+func recoveryCheckpointInputs(pkg *db.OORPackageBundle) []wire.OutPoint {
+	if pkg == nil {
+		return nil
+	}
+
+	seen := make(map[wire.OutPoint]struct{})
+	var outpoints []wire.OutPoint
+	for _, checkpoint := range pkg.FinalCheckpointPSBTs {
+		if checkpoint == nil || checkpoint.UnsignedTx == nil {
+			continue
+		}
+
+		for _, txIn := range checkpoint.UnsignedTx.TxIn {
+			outpoint := txIn.PreviousOutPoint
+			if _, ok := seen[outpoint]; ok {
+				continue
+			}
+			seen[outpoint] = struct{}{}
+			outpoints = append(outpoints, outpoint)
+		}
+	}
+
+	return outpoints
+}
+
+// recoverySigningKey returns the key that signs the selected vHTLC unilateral
+// leaf. It mirrors the unroll policy resolver so the descriptor key locator and
+// final spend signer agree.
+func recoverySigningKey(job vhtlcrecovery.RecoveryJob) (*btcec.PublicKey,
+	error) {
+
+	var raw []byte
+	switch job.Action {
+	case vhtlcrecovery.ActionClaim:
+		raw = job.ReceiverPubkey
+
+	case vhtlcrecovery.ActionRefundWithoutReceiver:
+		raw = job.SenderPubkey
+
+	default:
+		return nil, fmt.Errorf("unknown vhtlc recovery action %q",
+			job.Action)
+	}
+
+	key, err := btcec.ParsePubKey(raw)
+	if err != nil {
+		return nil, fmt.Errorf("parse recovery signing key: %w", err)
+	}
+
+	return key, nil
+}
+
+// recoveryOperatorKey derives the Ark operator key for the synthesized recovery
+// descriptor from the local root VTXOs. The target vHTLC was created by an OOR
+// package spending those roots, so all roots must agree on the operator key; a
+// mismatch would mean the local ancestry cannot safely describe one coherent
+// Ark lineage.
+func recoveryOperatorKey(roots []*vtxo.Descriptor) (*btcec.PublicKey, error) {
+	var operatorKey *btcec.PublicKey
+	for _, root := range roots {
+		if root == nil || root.OperatorKey == nil {
+			continue
+		}
+
+		if operatorKey == nil {
+			operatorKey = root.OperatorKey
+			continue
+		}
+
+		if !operatorKey.IsEqual(root.OperatorKey) {
+			return nil, fmt.Errorf("recovery roots use multiple " +
+				"operator keys")
+		}
+	}
+
+	if operatorKey == nil {
+		return nil, fmt.Errorf("recovery roots have no operator key")
+	}
+
+	return operatorKey, nil
+}
+
+// recoveryCSVDelay returns the vHTLC leaf CSV that unroll must wait after the
+// target is materialized. The final spend policy still derives the on-wire
+// sequence from the script path; this value feeds unroll's waiting scheduler.
+func recoveryCSVDelay(job vhtlcrecovery.RecoveryJob) (uint32, error) {
+	var delay int32
+	switch job.Action {
+	case vhtlcrecovery.ActionClaim:
+		delay = job.UnilateralClaimDelay
+
+	case vhtlcrecovery.ActionRefundWithoutReceiver:
+		delay = job.UnilateralRefundWithoutReceiverDelay
+
+	default:
+		return 0, fmt.Errorf("unknown vhtlc recovery action %q",
+			job.Action)
+	}
+
+	if delay <= 0 {
+		return 0, fmt.Errorf("recovery csv delay must be positive")
+	}
+
+	return uint32(delay), nil
+}
+
+// recoveryAncestry clones and de-duplicates ancestry fragments from the root
+// descriptors. Distinct roots may share a commitment fragment, so
+// de-duplication keeps the synthesized target descriptor compact and
+// deterministic.
+func recoveryAncestry(roots []*vtxo.Descriptor) []vtxo.Ancestry {
+	seen := make(map[chainhash.Hash]struct{})
+	var ancestry []vtxo.Ancestry
+	for _, root := range roots {
+		if root == nil {
+			continue
+		}
+
+		for _, fragment := range root.Ancestry {
+			if _, ok := seen[fragment.CommitmentTxID]; ok {
+				continue
+			}
+			seen[fragment.CommitmentTxID] = struct{}{}
+
+			ancestry = append(ancestry, fragment)
+		}
+	}
+
+	return ancestry
+}
+
+// recoveryRootMeta derives scalar descriptor metadata from the earliest local
+// roots. For expiry-style fields the most conservative non-zero value wins so a
+// multi-input recovery target cannot outlive one of its contributing roots.
+func recoveryRootMeta(roots []*vtxo.Descriptor) (string, chainhash.Hash, int32,
+	int32) {
+
+	var (
+		roundID        string
+		commitmentTxID chainhash.Hash
+		batchExpiry    int32
+		createdHeight  int32
+	)
+
+	for _, root := range roots {
+		if root == nil {
+			continue
+		}
+
+		if roundID == "" {
+			roundID = root.RoundID
+		}
+		if commitmentTxID == (chainhash.Hash{}) {
+			commitmentTxID = root.CommitmentTxID
+		}
+		if root.BatchExpiry > 0 &&
+			(batchExpiry == 0 || root.BatchExpiry < batchExpiry) {
+
+			batchExpiry = root.BatchExpiry
+		}
+		if root.CreatedHeight > 0 &&
+			(createdHeight == 0 ||
+				root.CreatedHeight < createdHeight) {
+
+			createdHeight = root.CreatedHeight
+		}
+	}
+
+	return roundID, commitmentTxID, batchExpiry, createdHeight
+}
+
+// recoveryChainDepth computes a conservative OOR hop depth for the synthesized
+// target descriptor from its roots and the resolved package chain.
+func recoveryChainDepth(roots []*vtxo.Descriptor, packageCount int) int {
+	var maxRootDepth int
+	for _, root := range roots {
+		if root != nil && root.ChainDepth > maxRootDepth {
+			maxRootDepth = root.ChainDepth
+		}
+	}
+
+	if packageCount <= 0 {
+		packageCount = 1
+	}
+
+	return maxRootDepth + packageCount
+}

--- a/db/sqlc/queries/vhtlc_recovery_jobs.sql
+++ b/db/sqlc/queries/vhtlc_recovery_jobs.sql
@@ -45,10 +45,7 @@ SET state = CASE
     END,
     updated_at = $2,
     escalated_at = COALESCE(escalated_at, $2),
-    claim_preimage = CASE
-        WHEN $3 IS NULL THEN claim_preimage
-        ELSE $3
-    END,
+    claim_preimage = COALESCE($3, claim_preimage),
     last_error = NULL
 WHERE id = $1
   AND state NOT IN ('completed', 'cancelled', 'failed');

--- a/db/sqlc/queries/vhtlc_recovery_jobs.sql
+++ b/db/sqlc/queries/vhtlc_recovery_jobs.sql
@@ -45,6 +45,10 @@ SET state = CASE
     END,
     updated_at = $2,
     escalated_at = COALESCE(escalated_at, $2),
+    claim_preimage = CASE
+        WHEN $3 IS NULL THEN claim_preimage
+        ELSE $3
+    END,
     last_error = NULL
 WHERE id = $1
   AND state NOT IN ('completed', 'cancelled', 'failed');

--- a/db/sqlc/queries/vhtlc_recovery_jobs.sql
+++ b/db/sqlc/queries/vhtlc_recovery_jobs.sql
@@ -35,7 +35,7 @@ ORDER BY updated_at ASC, created_at ASC;
 
 -- name: ListVHTLCRecoveryJobs :many
 SELECT * FROM vhtlc_recovery_jobs
-ORDER BY updated_at ASC, created_at ASC;
+ORDER BY updated_at DESC, created_at DESC;
 
 -- name: EscalateVHTLCRecoveryJob :execrows
 UPDATE vhtlc_recovery_jobs

--- a/db/sqlc/vhtlc_recovery_jobs.sql.go
+++ b/db/sqlc/vhtlc_recovery_jobs.sql.go
@@ -424,7 +424,7 @@ func (q *Queries) ListNonTerminalVHTLCRecoveryJobs(ctx context.Context) ([]Vhtlc
 
 const ListVHTLCRecoveryJobs = `-- name: ListVHTLCRecoveryJobs :many
 SELECT id, request_id, swap_id, direction, action, state, vtxo_txid, vtxo_vout, vtxo_amount_sat, sender_pubkey, receiver_pubkey, server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, preimage_hash, claim_preimage, signer_key_family, signer_key_index, destination_script, max_fee_rate_sat_per_kw, unroll_target_outpoint_hash, unroll_target_outpoint_index, exit_policy_kind, exit_tx, exit_txid, cooperative_txid, last_error, cancel_reason, created_at, updated_at, armed_at, escalated_at, target_detected_at, exit_tx_built_at, exit_tx_broadcast_at, terminal_at FROM vhtlc_recovery_jobs
-ORDER BY updated_at ASC, created_at ASC
+ORDER BY updated_at DESC, created_at DESC
 `
 
 func (q *Queries) ListVHTLCRecoveryJobs(ctx context.Context) ([]VhtlcRecoveryJob, error) {

--- a/db/sqlc/vhtlc_recovery_jobs.sql.go
+++ b/db/sqlc/vhtlc_recovery_jobs.sql.go
@@ -73,10 +73,7 @@ SET state = CASE
     END,
     updated_at = $2,
     escalated_at = COALESCE(escalated_at, $2),
-    claim_preimage = CASE
-        WHEN $3 IS NULL THEN claim_preimage
-        ELSE $3
-    END,
+    claim_preimage = COALESCE($3, claim_preimage),
     last_error = NULL
 WHERE id = $1
   AND state NOT IN ('completed', 'cancelled', 'failed')

--- a/db/sqlc/vhtlc_recovery_jobs.sql.go
+++ b/db/sqlc/vhtlc_recovery_jobs.sql.go
@@ -73,18 +73,23 @@ SET state = CASE
     END,
     updated_at = $2,
     escalated_at = COALESCE(escalated_at, $2),
+    claim_preimage = CASE
+        WHEN $3 IS NULL THEN claim_preimage
+        ELSE $3
+    END,
     last_error = NULL
 WHERE id = $1
   AND state NOT IN ('completed', 'cancelled', 'failed')
 `
 
 type EscalateVHTLCRecoveryJobParams struct {
-	ID        string
-	UpdatedAt int64
+	ID            string
+	UpdatedAt     int64
+	ClaimPreimage []byte
 }
 
 func (q *Queries) EscalateVHTLCRecoveryJob(ctx context.Context, arg EscalateVHTLCRecoveryJobParams) (int64, error) {
-	result, err := q.db.ExecContext(ctx, EscalateVHTLCRecoveryJob, arg.ID, arg.UpdatedAt)
+	result, err := q.db.ExecContext(ctx, EscalateVHTLCRecoveryJob, arg.ID, arg.UpdatedAt, arg.ClaimPreimage)
 	if err != nil {
 		return 0, err
 	}

--- a/db/vhtlc_recovery_store.go
+++ b/db/vhtlc_recovery_store.go
@@ -263,16 +263,17 @@ func (s *VHTLCRecoveryStoreDB) ListRecoveries(ctx context.Context) (
 }
 
 // EscalateRecovery marks an armed recovery job as active.
-func (s *VHTLCRecoveryStoreDB) EscalateRecovery(ctx context.Context,
-	id string) error {
+func (s *VHTLCRecoveryStoreDB) EscalateRecovery(ctx context.Context, id string,
+	claimPreimage []byte) error {
 
 	now := s.clk.Now().Unix()
 
 	return s.ExecTx(ctx, WriteTxOption(), func(q *sqlc.Queries) error {
 		rows, err := q.EscalateVHTLCRecoveryJob(
 			ctx, sqlc.EscalateVHTLCRecoveryJobParams{
-				ID:        id,
-				UpdatedAt: now,
+				ID:            id,
+				UpdatedAt:     now,
+				ClaimPreimage: cloneBytes(claimPreimage),
 			},
 		)
 		if err != nil {
@@ -494,6 +495,9 @@ func vhtlcRecoveryJobFromRow(row sqlc.VhtlcRecoveryJob) (
 		UnilateralRefundWithoutReceiverDelay: row.UnilateralRefundWithoutReceiverDelay, //nolint:ll
 		PreimageHash: cloneBytes(
 			row.PreimageHash,
+		),
+		ClaimPreimage: cloneBytes(
+			row.ClaimPreimage,
 		),
 		SignerKeyFamily: row.SignerKeyFamily,
 		SignerKeyIndex:  row.SignerKeyIndex,

--- a/db/vhtlc_recovery_store.go
+++ b/db/vhtlc_recovery_store.go
@@ -232,7 +232,7 @@ func (s *VHTLCRecoveryStoreDB) ListNonTerminalRecoveries(ctx context.Context) (
 	return jobs, nil
 }
 
-// ListRecoveries loads every recovery job.
+// ListRecoveries loads every recovery job in newest-updated order.
 func (s *VHTLCRecoveryStoreDB) ListRecoveries(ctx context.Context) (
 	[]vhtlcrecovery.RecoveryJob, error) {
 
@@ -262,7 +262,9 @@ func (s *VHTLCRecoveryStoreDB) ListRecoveries(ctx context.Context) (
 	return jobs, nil
 }
 
-// EscalateRecovery marks an armed recovery job as active.
+// EscalateRecovery marks an armed recovery job as active. The optional claim
+// preimage is written in the same transaction so cross-process claim recovery
+// can restart after escalation without depending on the caller process.
 func (s *VHTLCRecoveryStoreDB) EscalateRecovery(ctx context.Context, id string,
 	claimPreimage []byte) error {
 

--- a/db/vhtlc_recovery_store_test.go
+++ b/db/vhtlc_recovery_store_test.go
@@ -118,7 +118,12 @@ func TestVHTLCRecoveryStoreTransitions(t *testing.T) {
 	_, _, err = store.ArmRecovery(ctx, failed)
 	require.NoError(t, err)
 
-	require.NoError(t, store.EscalateRecovery(ctx, active.ID))
+	claimPreimage := bytes.Repeat([]byte{0x42}, 32)
+	require.NoError(
+		t, store.EscalateRecovery(
+			ctx, active.ID, claimPreimage,
+		),
+	)
 	require.NoError(
 		t,
 		store.CancelRecovery(
@@ -134,12 +139,14 @@ func TestVHTLCRecoveryStoreTransitions(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, jobs, 1)
 	require.Equal(t, active.ID, jobs[0].ID)
+	require.Equal(t, claimPreimage, jobs[0].ClaimPreimage)
 	require.Equal(t, vhtlcrecovery.StateUnrollStarted, jobs[0].State)
 	require.NotNil(t, jobs[0].EscalatedAt)
-	require.NoError(t, store.EscalateRecovery(ctx, active.ID))
+	require.NoError(t, store.EscalateRecovery(ctx, active.ID, nil))
 	replayedActive, err := store.GetRecovery(ctx, active.ID)
 	require.NoError(t, err)
 	require.Equal(t, vhtlcrecovery.StateUnrollStarted, replayedActive.State)
+	require.Equal(t, claimPreimage, replayedActive.ClaimPreimage)
 
 	cancelledJob, err := store.GetRecovery(ctx, cancelled.ID)
 	require.NoError(t, err)
@@ -176,11 +183,11 @@ func TestVHTLCRecoveryStoreTransitions(t *testing.T) {
 		ErrVHTLCRecoveryJobNotFound,
 	)
 	require.ErrorIs(
-		t, store.EscalateRecovery(ctx, active.ID),
+		t, store.EscalateRecovery(ctx, active.ID, nil),
 		ErrVHTLCRecoveryCannotEscalate,
 	)
 	require.ErrorIs(
-		t, store.EscalateRecovery(ctx, "missing"),
+		t, store.EscalateRecovery(ctx, "missing", nil),
 		ErrVHTLCRecoveryJobNotFound,
 	)
 

--- a/rpc/restclient/clients.go
+++ b/rpc/restclient/clients.go
@@ -611,7 +611,7 @@ func (c *DaemonServiceClient) GetVHTLCRecoveryStatus(ctx context.Context,
 	return out, err
 }
 
-// ListVHTLCRecoveries returns vHTLC recovery jobs.
+// ListVHTLCRecoveries returns vHTLC recovery jobs for operator inspection.
 func (c *DaemonServiceClient) ListVHTLCRecoveries(ctx context.Context,
 	in *daemonrpc.ListVHTLCRecoveriesRequest, _ ...grpc.CallOption) (
 	*daemonrpc.ListVHTLCRecoveriesResponse, error) {

--- a/sample-darepod.conf
+++ b/sample-darepod.conf
@@ -152,6 +152,24 @@
 # under datadir/swaps.db.
 # swap.databasefilename=
 
+# Automatically escalate armed vHTLC recovery after the grace/deadline policy
+# says cooperative retry is no longer safe or useful. The default is false:
+# recovery is armed durably, but an operator must run a manual escalation command
+# unless this is explicitly enabled.
+# swap.vhtlcrecovery.autoescalate=false
+
+# Delay after the first cooperative vHTLC send failure before automatic on-chain
+# recovery may start. Manual recovery commands can still escalate earlier.
+# swap.vhtlcrecovery.cooperativefailuregraceperiod=1h0m0s
+
+# Minimum block margin preserved before receive-side claim recovery deadlines.
+# Deadline pressure can override the wall-clock grace period.
+# swap.vhtlcrecovery.minrecoverymarginblocks=12
+
+# Maximum fee rate in sat/kw for vHTLC recovery exit spends. The default is
+# 25,000 sat/kw, or 100 sat/vbyte.
+# swap.vhtlcrecovery.maxfeeratesatperkw=25000
+
 # Wallet-level deadline applied to every PENDING walletrpc entry. Once an
 # entry sits past this duration without a terminal transition, the runtime
 # overlays its status as FAILED with failure_reason="timed_out". Zero uses

--- a/sdk/ark/client.go
+++ b/sdk/ark/client.go
@@ -859,6 +859,79 @@ func (c *Client) SendOORWithCustomInputs(ctx context.Context,
 	return resp.GetSessionId(), nil
 }
 
+// ArmVHTLCRecovery asks the daemon to persist one dormant vHTLC recovery job.
+// Higher-level swap FSMs call this before the cooperative path becomes risky so
+// restart recovery has a durable handle to the vHTLC context.
+func (c *Client) ArmVHTLCRecovery(ctx context.Context,
+	req *daemonrpc.ArmVHTLCRecoveryRequest) (
+	*daemonrpc.ArmVHTLCRecoveryResponse, error) {
+
+	if req == nil {
+		req = &daemonrpc.ArmVHTLCRecoveryRequest{}
+	}
+
+	resp, err := c.daemon.ArmVHTLCRecovery(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("arm vhtlc recovery: %w", err)
+	}
+
+	return resp, nil
+}
+
+// EscalateVHTLCRecovery asks the daemon to start or resume the on-chain unroll
+// path for one previously armed vHTLC recovery job.
+func (c *Client) EscalateVHTLCRecovery(ctx context.Context,
+	req *daemonrpc.EscalateVHTLCRecoveryRequest) (
+	*daemonrpc.EscalateVHTLCRecoveryResponse, error) {
+
+	if req == nil {
+		req = &daemonrpc.EscalateVHTLCRecoveryRequest{}
+	}
+
+	resp, err := c.daemon.EscalateVHTLCRecovery(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("escalate vhtlc recovery: %w", err)
+	}
+
+	return resp, nil
+}
+
+// CancelVHTLCRecovery tells the daemon that cooperative settlement made one
+// armed vHTLC recovery job unnecessary.
+func (c *Client) CancelVHTLCRecovery(ctx context.Context,
+	req *daemonrpc.CancelVHTLCRecoveryRequest) (
+	*daemonrpc.CancelVHTLCRecoveryResponse, error) {
+
+	if req == nil {
+		req = &daemonrpc.CancelVHTLCRecoveryRequest{}
+	}
+
+	resp, err := c.daemon.CancelVHTLCRecovery(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("cancel vhtlc recovery: %w", err)
+	}
+
+	return resp, nil
+}
+
+// GetVHTLCRecoveryStatus returns the daemon's durable recovery status plus the
+// current unroll phase when the recovery has been escalated.
+func (c *Client) GetVHTLCRecoveryStatus(ctx context.Context,
+	req *daemonrpc.GetVHTLCRecoveryStatusRequest) (
+	*daemonrpc.GetVHTLCRecoveryStatusResponse, error) {
+
+	if req == nil {
+		req = &daemonrpc.GetVHTLCRecoveryStatusRequest{}
+	}
+
+	resp, err := c.daemon.GetVHTLCRecoveryStatus(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("get vhtlc recovery status: %w", err)
+	}
+
+	return resp, nil
+}
+
 // ListLiveVTXOs returns the daemon's live spendable VTXOs as typed SDK-owned
 // models.
 func (c *Client) ListLiveVTXOs(ctx context.Context) ([]VTXOInfo, error) {

--- a/sdk/swaps/client.go
+++ b/sdk/swaps/client.go
@@ -9,6 +9,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/daemonrpc"
 	sdkark "github.com/lightninglabs/darepo-client/sdk/ark"
 	"github.com/lightningnetwork/lnd/invoices"
 	"github.com/lightningnetwork/lnd/keychain"
@@ -386,6 +387,29 @@ type DaemonConn interface {
 	// standard pubkey-backed Ark receive destination.
 	SendOORWithCustomInputs(ctx context.Context, recipientPubKey []byte,
 		amountSat int64, inputs []CustomInput) (string, error)
+
+	// ArmVHTLCRecovery stores a dormant daemon-owned on-chain recovery job.
+	ArmVHTLCRecovery(ctx context.Context,
+		req *daemonrpc.ArmVHTLCRecoveryRequest) (
+		*daemonrpc.ArmVHTLCRecoveryResponse, error)
+
+	// EscalateVHTLCRecovery starts or resumes the unroll path for an armed
+	// recovery job.
+	EscalateVHTLCRecovery(ctx context.Context,
+		req *daemonrpc.EscalateVHTLCRecoveryRequest) (
+		*daemonrpc.EscalateVHTLCRecoveryResponse, error)
+
+	// CancelVHTLCRecovery records that cooperative settlement won before
+	// the armed recovery path was needed.
+	CancelVHTLCRecovery(ctx context.Context,
+		req *daemonrpc.CancelVHTLCRecoveryRequest) (
+		*daemonrpc.CancelVHTLCRecoveryResponse, error)
+
+	// GetVHTLCRecoveryStatus returns the daemon's durable recovery row and
+	// current unroll status, when present.
+	GetVHTLCRecoveryStatus(ctx context.Context,
+		req *daemonrpc.GetVHTLCRecoveryStatusRequest) (
+		*daemonrpc.GetVHTLCRecoveryStatusResponse, error)
 
 	// IdentityPubKey returns the client's identity pubkey.
 	IdentityPubKey(ctx context.Context) (*btcec.PublicKey, error)

--- a/sdk/swaps/client.go
+++ b/sdk/swaps/client.go
@@ -491,6 +491,7 @@ type SwapClient struct {
 	refundLocktimeBuffer     uint32
 	claimRetryDelay          time.Duration
 	claimMaxAttempts         int
+	recoveryPolicy           RecoveryPolicy
 	decodeOutSwapOnion       outSwapOnionDecoder
 	chainParams              *chaincfg.Params
 	now                      func() time.Time
@@ -549,10 +550,22 @@ func NewSwapClientWithStore(server SwapServerConn, daemon DaemonConn,
 		refundLocktimeBuffer:     defaultRefundLocktimeBuffer,
 		claimRetryDelay:          time.Second,
 		claimMaxAttempts:         10,
+		recoveryPolicy:           DefaultRecoveryPolicy(),
 		decodeOutSwapOnion:       decodeOutSwapOnion,
 		chainParams:              invoiceCreatorChainParams(invoiceGen),
 		now:                      time.Now,
 	}
+}
+
+// SetRecoveryPolicy overrides the automatic vHTLC recovery escalation policy.
+// Arming remains immediate; this policy only decides when a cooperative
+// claim/refund failure should turn into costly on-chain unroll.
+func (c *SwapClient) SetRecoveryPolicy(policy RecoveryPolicy) {
+	if c == nil {
+		return
+	}
+
+	c.recoveryPolicy = policy.WithDefaults()
 }
 
 // invoiceCreatorChainParams returns the chain params carried by the built-in

--- a/sdk/swaps/in_swap.go
+++ b/sdk/swaps/in_swap.go
@@ -238,6 +238,7 @@ type paySession struct {
 	// submitted the refund, or the observed spender txid when a resume
 	// adopts an already-indexed refund spend.
 	refundSessionID    string
+	refundRecoveryID   string
 	preimage           *lntypes.Preimage
 	interventionReason string
 	clientPubKey       *btcec.PublicKey
@@ -701,6 +702,13 @@ func (s *paySession) waitForFundedVHTLC(ctx context.Context) error {
 			)
 		}
 		if preimage != nil {
+			if err := cancelVHTLCRecovery(
+				ctx, s.client.daemon, s.refundRecoveryID,
+				recoveryReasonServerClaimObserved, "",
+			); err != nil {
+				return newRetryableActionError(err)
+			}
+
 			return s.mutateAndPersist(ctx, func() error {
 				s.preimage = preimage
 
@@ -749,7 +757,9 @@ func (s *paySession) waitForFundedVHTLC(ctx context.Context) error {
 		if err := s.waitForNextPoll(ctx); err != nil {
 			if errors.Is(err, errSwapExpired) {
 				if s.fundingSessionID != "" {
-					return s.waitForFixedPoll(ctx)
+					return waitForFixedPoll(
+						ctx, s.client.waitPollInterval,
+					)
 				}
 
 				return s.mutateAndPersist(ctx, func() error {
@@ -849,6 +859,13 @@ func (s *paySession) waitForClaimPreimage(ctx context.Context) error {
 				btclog.Hex("hash", s.cfg.PaymentHash[:]),
 			)
 
+			if err := cancelVHTLCRecovery(
+				ctx, s.client.daemon, s.refundRecoveryID,
+				recoveryReasonServerClaimObserved, "",
+			); err != nil {
+				return newRetryableActionError(err)
+			}
+
 			return s.mutateAndPersist(ctx, func() error {
 				s.preimage = preimage
 
@@ -909,6 +926,13 @@ func (s *paySession) completeRefund(ctx context.Context) error {
 			btclog.Hex("hash", s.cfg.PaymentHash[:]),
 		)
 
+		if err := cancelVHTLCRecovery(
+			ctx, s.client.daemon, s.refundRecoveryID,
+			recoveryReasonServerClaimBeforeRefund, "",
+		); err != nil {
+			return newRetryableActionError(err)
+		}
+
 		return s.mutateAndPersist(ctx, func() error {
 			s.preimage = preimage
 
@@ -928,6 +952,14 @@ func (s *paySession) completeRefund(ctx context.Context) error {
 		return s.markRefunded(ctx, spentVHTLC)
 	}
 
+	recoveryHandled, err := s.reconcilePayRefundRecovery(ctx)
+	if err != nil {
+		return newRetryableActionError(err)
+	}
+	if recoveryHandled {
+		return nil
+	}
+
 	funded, err := s.observeRefundableVHTLC(ctx)
 	if err != nil {
 		return newRetryableActionError(
@@ -936,7 +968,7 @@ func (s *paySession) completeRefund(ctx context.Context) error {
 		)
 	}
 	if !funded {
-		return s.waitForFixedPoll(ctx)
+		return waitForFixedPoll(ctx, s.client.waitPollInterval)
 	}
 
 	height, err := s.client.daemon.BlockHeight(ctx)
@@ -953,7 +985,7 @@ func (s *paySession) completeRefund(ctx context.Context) error {
 			),
 		)
 
-		return s.waitForFixedPoll(ctx)
+		return waitForFixedPoll(ctx, s.client.waitPollInterval)
 	}
 
 	if s.refundSessionID != "" {
@@ -985,7 +1017,28 @@ func (s *paySession) completeRefund(ctx context.Context) error {
 		}},
 	)
 	if err != nil {
-		return fmt.Errorf("refund vHTLC: %w", err)
+		if armErr := s.ensurePayRefundRecoveryArmed(
+			ctx,
+		); armErr != nil {
+			return newRetryableActionError(armErr)
+		}
+
+		reason := fmt.Sprintf("cooperative refund failed: %v", err)
+		if escalateErr := escalateVHTLCRecovery(
+			ctx, s.client.daemon, s.refundRecoveryID, reason,
+		); escalateErr != nil {
+			return newRetryableActionError(escalateErr)
+		}
+
+		s.client.log.WarnS(ctx, "Pay refund recovery escalated",
+			err,
+			btclog.Hex("hash", s.cfg.PaymentHash[:]),
+			slog.String("recovery_id", s.refundRecoveryID),
+			slog.String("outpoint", s.vhtlcOutpoint),
+			slog.Int64("amount_sat", s.vhtlcAmount),
+		)
+
+		return waitForFixedPoll(ctx, s.client.waitPollInterval)
 	}
 	if refundSessionID == "" {
 		return fmt.Errorf("refund vHTLC returned empty session id")
@@ -1023,6 +1076,9 @@ func (s *paySession) observeRefundOutput(ctx context.Context) (*VTXOInfo,
 	if err != nil || refundOutput == nil {
 		return nil, err
 	}
+	if refundOutput.Outpoint == s.vhtlcOutpoint {
+		return nil, nil
+	}
 
 	if s.vhtlcAmount != 0 && refundOutput.AmountSat != s.vhtlcAmount {
 		return nil, fmt.Errorf("refund output amount %d does not "+
@@ -1053,6 +1109,10 @@ func (s *paySession) observeRefundableVHTLC(ctx context.Context) (bool, error) {
 		return false, err
 	}
 
+	if err := s.ensurePayRefundRecoveryArmed(ctx); err != nil {
+		return false, err
+	}
+
 	return true, nil
 }
 
@@ -1071,6 +1131,12 @@ func (s *paySession) markRefundOutputIndexed(ctx context.Context,
 		slog.Int64("amount_sat", refundOutput.AmountSat),
 		slog.String("refund_session_id", s.refundSessionID),
 	)
+	if err := cancelVHTLCRecovery(
+		ctx, s.client.daemon, s.refundRecoveryID,
+		recoveryReasonRefundOutputIndexed, "",
+	); err != nil {
+		return newRetryableActionError(err)
+	}
 
 	return s.mutateAndPersist(ctx, func() error {
 		return s.transition(payEventRefunded)
@@ -1117,6 +1183,12 @@ func (s *paySession) markRefundAccepted(ctx context.Context) error {
 	}
 	if s.refundSessionID == "" {
 		return fmt.Errorf("missing refund session id")
+	}
+	if err := cancelVHTLCRecovery(
+		ctx, s.client.daemon, s.refundRecoveryID,
+		recoveryReasonRefundAccepted, "",
+	); err != nil {
+		return newRetryableActionError(err)
 	}
 
 	return s.mutateAndPersist(ctx, func() error {
@@ -1218,6 +1290,10 @@ func (s *paySession) observeLiveVHTLC(ctx context.Context) (bool, error) {
 		return false, err
 	}
 
+	if err := s.ensurePayRefundRecoveryArmed(ctx); err != nil {
+		return false, err
+	}
+
 	return true, nil
 }
 
@@ -1241,23 +1317,6 @@ func (s *paySession) waitForNextPoll(ctx context.Context) error {
 	}
 
 	timer := time.NewTimer(wait)
-	defer timer.Stop()
-
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-
-	case <-timer.C:
-		return nil
-	}
-}
-
-// waitForFixedPoll sleeps for one poll interval without consulting the swap
-// deadline. It is used after a funding send may already have been accepted,
-// because the client must keep reconciling until the vHTLC appears and can be
-// claimed or refunded.
-func (s *paySession) waitForFixedPoll(ctx context.Context) error {
-	timer := time.NewTimer(s.client.waitPollInterval)
 	defer timer.Stop()
 
 	select {

--- a/sdk/swaps/in_swap.go
+++ b/sdk/swaps/in_swap.go
@@ -237,13 +237,14 @@ type paySession struct {
 	// refundSessionID stores the daemon OOR session id when this process
 	// submitted the refund, or the observed spender txid when a resume
 	// adopts an already-indexed refund spend.
-	refundSessionID    string
-	refundRecoveryID   string
-	preimage           *lntypes.Preimage
-	interventionReason string
-	clientPubKey       *btcec.PublicKey
-	operatorPubKey     *btcec.PublicKey
-	serverPubKey       *btcec.PublicKey
+	refundSessionID         string
+	refundRecoveryID        string
+	refundRecoveryFailureAt time.Time
+	preimage                *lntypes.Preimage
+	interventionReason      string
+	clientPubKey            *btcec.PublicKey
+	operatorPubKey          *btcec.PublicKey
+	serverPubKey            *btcec.PublicKey
 }
 
 // PaySession is the exported alias for the client-side Ark-to-Lightning swap
@@ -1023,20 +1024,11 @@ func (s *paySession) completeRefund(ctx context.Context) error {
 			return newRetryableActionError(armErr)
 		}
 
-		reason := fmt.Sprintf("cooperative refund failed: %v", err)
-		if escalateErr := escalateVHTLCRecovery(
-			ctx, s.client.daemon, s.refundRecoveryID, reason,
+		if escalateErr := s.maybeEscalatePayRefundRecovery(
+			ctx, err,
 		); escalateErr != nil {
 			return newRetryableActionError(escalateErr)
 		}
-
-		s.client.log.WarnS(ctx, "Pay refund recovery escalated",
-			err,
-			btclog.Hex("hash", s.cfg.PaymentHash[:]),
-			slog.String("recovery_id", s.refundRecoveryID),
-			slog.String("outpoint", s.vhtlcOutpoint),
-			slog.Int64("amount_sat", s.vhtlcAmount),
-		)
 
 		return waitForFixedPoll(ctx, s.client.waitPollInterval)
 	}

--- a/sdk/swaps/in_swap_test.go
+++ b/sdk/swaps/in_swap_test.go
@@ -613,6 +613,28 @@ func TestPaySessionRefundsWhenRefundLocktimePassesBeforeClaim(t *testing.T) {
 	_, err = session.Wait(t.Context())
 	require.ErrorIs(t, err, ErrSwapRefunded)
 	require.Equal(t, 1, daemonConn.sendCustomCalls)
+	require.Equal(t, 1, daemonConn.armRecoveryCalls)
+	require.Equal(
+		t, recoveryDirectionPay, daemonConn.lastArmRecovery.
+			GetDirection(),
+	)
+	require.Equal(
+		t, recoveryActionRefundWithoutReceiver,
+		daemonConn.lastArmRecovery.GetAction(),
+	)
+	require.Equal(
+		t, "funding:0", daemonConn.lastArmRecovery.
+			GetVtxoOutpoint(),
+	)
+	require.Equal(
+		t, int32(100), daemonConn.lastArmRecovery.
+			GetRefundLocktime(),
+	)
+	require.Equal(
+		t, int32(36), daemonConn.lastArmRecovery.
+			GetUnilateralRefundWithoutReceiverDelay(),
+	)
+	require.Equal(t, 1, daemonConn.cancelCalls)
 
 	resumed, err := client.ResumePayViaLightning(
 		t.Context(), preimage.Hash(),

--- a/sdk/swaps/migrations/000001_swap_sessions.up.sql
+++ b/sdk/swaps/migrations/000001_swap_sessions.up.sql
@@ -90,6 +90,10 @@ CREATE TABLE IF NOT EXISTS receive_swaps (
     -- by the daemon when the client submits the receive-side claim.
     claim_session_id TEXT NOT NULL DEFAULT '',
 
+    -- claim_recovery_id is the daemon-owned vHTLC recovery row armed for
+    -- unilateral claim fallback. Empty means recovery has not been armed yet.
+    claim_recovery_id TEXT NOT NULL DEFAULT '',
+
     -- intervention_reason is the durable terminal explanation stored when a
     -- receive session fails or stops in NeedsIntervention.
     intervention_reason TEXT NOT NULL DEFAULT '',
@@ -188,6 +192,11 @@ CREATE TABLE IF NOT EXISTS pay_swaps (
     -- by the daemon when the client submits the timeout refund, or the
     -- observed spender txid when resume adopts an already-indexed refund.
     refund_session_id TEXT NOT NULL DEFAULT '',
+
+    -- refund_recovery_id is the daemon-owned vHTLC recovery row armed for
+    -- unilateral refund-without-receiver fallback. Empty means recovery has not
+    -- been armed yet.
+    refund_recovery_id TEXT NOT NULL DEFAULT '',
 
     -- preimage is the claim preimage once the swap server's spend is
     -- authoritatively observed.

--- a/sdk/swaps/out_swap.go
+++ b/sdk/swaps/out_swap.go
@@ -264,19 +264,20 @@ type ReceiveSession struct {
 	// swapServerPubKey is the remote sender in the accepted vHTLC policy.
 	// For Lightning-backed receives this is the swap server key; for
 	// direct same-Ark receives this is the paying client's sender key.
-	swapServerPubKey     *btcec.PublicKey
-	vhtlcConfig          VHTLCConfig
-	vhtlcPolicy          *arkscript.VHTLCPolicy
-	vhtlcPolicyTemplate  []byte
-	vhtlcPkScript        []byte
-	vhtlcOutpoint        string
-	vhtlcAmount          int64
-	paymentAddr          [32]byte
-	pendingHTLCAckCursor uint64
-	claimReceivePubKey   []byte
-	claimReceiveScript   []byte
-	claimSessionID       string
-	claimRecoveryID      string
+	swapServerPubKey       *btcec.PublicKey
+	vhtlcConfig            VHTLCConfig
+	vhtlcPolicy            *arkscript.VHTLCPolicy
+	vhtlcPolicyTemplate    []byte
+	vhtlcPkScript          []byte
+	vhtlcOutpoint          string
+	vhtlcAmount            int64
+	paymentAddr            [32]byte
+	pendingHTLCAckCursor   uint64
+	claimReceivePubKey     []byte
+	claimReceiveScript     []byte
+	claimSessionID         string
+	claimRecoveryID        string
+	claimRecoveryFailureAt time.Time
 	// claimIntentRecordedInProcess distinguishes freshly-recorded claim
 	// intent from a restored ClaimInitiated row whose accepted spend may
 	// still be missing from the indexer.
@@ -1351,20 +1352,11 @@ func (s *ReceiveSession) claimFundedVHTLC(ctx context.Context) error {
 		})
 	}
 	if err != nil {
-		reason := fmt.Sprintf("cooperative claim failed: %v", err)
-		if escalateErr := escalateVHTLCRecovery(
-			ctx, s.client.daemon, s.claimRecoveryID, reason,
+		if escalateErr := s.maybeEscalateReceiveClaimRecovery(
+			ctx, err,
 		); escalateErr != nil {
 			return newRetryableActionError(escalateErr)
 		}
-
-		s.client.log.WarnS(ctx, "Receive claim recovery escalated",
-			err,
-			btclog.Hex("hash", s.PaymentHash[:]),
-			slog.String("recovery_id", s.claimRecoveryID),
-			slog.String("outpoint", s.vhtlcOutpoint),
-			slog.Int64("amount_sat", s.vhtlcAmount),
-		)
 
 		return waitForFixedPoll(ctx, s.client.waitPollInterval)
 	}

--- a/sdk/swaps/out_swap.go
+++ b/sdk/swaps/out_swap.go
@@ -276,6 +276,7 @@ type ReceiveSession struct {
 	claimReceivePubKey   []byte
 	claimReceiveScript   []byte
 	claimSessionID       string
+	claimRecoveryID      string
 	// claimIntentRecordedInProcess distinguishes freshly-recorded claim
 	// intent from a restored ClaimInitiated row whose accepted spend may
 	// still be missing from the indexer.
@@ -484,6 +485,9 @@ func (s *ReceiveSession) Claim(ctx context.Context, outpoint string,
 
 			return s.transition(receiveEventVHTLCFunded)
 		}); err != nil {
+			return nil, err
+		}
+		if err := s.ensureReceiveClaimRecoveryArmed(ctx); err != nil {
 			return nil, err
 		}
 	}
@@ -791,12 +795,17 @@ func (s *ReceiveSession) waitForFunding(ctx context.Context) error {
 		return err
 	}
 
-	return s.mutateAndPersist(ctx, func() error {
+	err = s.mutateAndPersist(ctx, func() error {
 		s.vhtlcOutpoint = outpoint
 		s.vhtlcAmount = amount
 
 		return s.transition(receiveEventVHTLCFunded)
 	})
+	if err != nil {
+		return err
+	}
+
+	return s.ensureReceiveClaimRecoveryArmed(ctx)
 }
 
 // waitIncomingVHTLCNotification waits for and validates the server notification
@@ -1232,6 +1241,12 @@ func (s *ReceiveSession) validateReceiveFunding(ctx context.Context,
 // transaction, then submits the preimage claim if no spend is indexed yet.
 func (s *ReceiveSession) claimFundedVHTLC(ctx context.Context) error {
 	if s.claimSessionID != "" {
+		if err := cancelVHTLCRecovery(
+			ctx, s.client.daemon, s.claimRecoveryID,
+			recoveryReasonClaimAccepted, "",
+		); err != nil {
+			return newRetryableActionError(err)
+		}
 
 		// A persisted claim session ID means the daemon accepted the
 		// custom-input claim spend before this attempt. Do not submit
@@ -1255,6 +1270,13 @@ func (s *ReceiveSession) claimFundedVHTLC(ctx context.Context) error {
 			return err
 		}
 		if claimed {
+			if err := cancelVHTLCRecovery(
+				ctx, s.client.daemon, s.claimRecoveryID,
+				recoveryReasonClaimIndexed, "",
+			); err != nil {
+				return newRetryableActionError(err)
+			}
+
 			return s.mutateAndPersist(ctx, func() error {
 				return s.transition(receiveEventCompleted)
 			})
@@ -1272,6 +1294,13 @@ func (s *ReceiveSession) claimFundedVHTLC(ctx context.Context) error {
 			return err
 		}
 		if claimed {
+			if err := cancelVHTLCRecovery(
+				ctx, s.client.daemon, s.claimRecoveryID,
+				recoveryReasonClaimIndexed, "",
+			); err != nil {
+				return newRetryableActionError(err)
+			}
+
 			return s.mutateAndPersist(ctx, func() error {
 				return s.transition(receiveEventCompleted)
 			})
@@ -1282,10 +1311,22 @@ func (s *ReceiveSession) claimFundedVHTLC(ctx context.Context) error {
 		return err
 	}
 
-	if err := s.ensureReceiveClaimStillPossible(ctx); err != nil {
+	if err := s.ensureClaimReceiveInfo(ctx); err != nil {
 		return err
 	}
-	if err := s.ensureClaimReceiveInfo(ctx); err != nil {
+	if err := s.ensureReceiveClaimRecoveryArmed(ctx); err != nil {
+		return err
+	}
+
+	recoveryHandled, err := s.reconcileReceiveClaimRecovery(ctx)
+	if err != nil {
+		return newRetryableActionError(err)
+	}
+	if recoveryHandled {
+		return nil
+	}
+
+	if err := s.ensureReceiveClaimStillPossible(ctx); err != nil {
 		return err
 	}
 
@@ -1295,6 +1336,12 @@ func (s *ReceiveSession) claimFundedVHTLC(ctx context.Context) error {
 		s.vhtlcAmount, s.claimReceivePubKey,
 	)
 	if errors.Is(err, errReceiveClaimAlreadyIndexed) {
+		if cancelErr := cancelVHTLCRecovery(
+			ctx, s.client.daemon, s.claimRecoveryID,
+			recoveryReasonClaimIndexed, "",
+		); cancelErr != nil {
+			return newRetryableActionError(cancelErr)
+		}
 
 		// Spent-without-preimage is terminal for retry purposes inside
 		// claimReceiveVHTLC; this branch only handles a matching
@@ -1304,7 +1351,22 @@ func (s *ReceiveSession) claimFundedVHTLC(ctx context.Context) error {
 		})
 	}
 	if err != nil {
-		return err
+		reason := fmt.Sprintf("cooperative claim failed: %v", err)
+		if escalateErr := escalateVHTLCRecovery(
+			ctx, s.client.daemon, s.claimRecoveryID, reason,
+		); escalateErr != nil {
+			return newRetryableActionError(escalateErr)
+		}
+
+		s.client.log.WarnS(ctx, "Receive claim recovery escalated",
+			err,
+			btclog.Hex("hash", s.PaymentHash[:]),
+			slog.String("recovery_id", s.claimRecoveryID),
+			slog.String("outpoint", s.vhtlcOutpoint),
+			slog.Int64("amount_sat", s.vhtlcAmount),
+		)
+
+		return waitForFixedPoll(ctx, s.client.waitPollInterval)
 	}
 	if claimSessionID == "" {
 		return fmt.Errorf("claim vHTLC returned empty session id")
@@ -1314,6 +1376,12 @@ func (s *ReceiveSession) claimFundedVHTLC(ctx context.Context) error {
 		return newRetryableActionError(err)
 	}
 	s.claimIntentRecordedInProcess = false
+	if err := cancelVHTLCRecovery(
+		ctx, s.client.daemon, s.claimRecoveryID,
+		recoveryReasonClaimAccepted, "",
+	); err != nil {
+		return newRetryableActionError(err)
+	}
 
 	if err := s.mutateAndPersist(ctx, func() error {
 		return s.transition(receiveEventCompleted)

--- a/sdk/swaps/out_swap_test.go
+++ b/sdk/swaps/out_swap_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/txscript"
+	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/lightninglabs/darepo-client/lib/arkscript"
 	"github.com/lightningnetwork/lnd/invoices"
 	"github.com/lightningnetwork/lnd/keychain"
@@ -477,6 +478,22 @@ type testDaemonConn struct {
 	lastSendPolicy    []byte
 	lastClaimPubKey   []byte
 	lastClaimInput    []CustomInput
+	armRecoveryResp   *daemonrpc.ArmVHTLCRecoveryResponse
+	armRecoveryErr    error
+	escalateResp      *daemonrpc.EscalateVHTLCRecoveryResponse
+	escalateErr       error
+	cancelResp        *daemonrpc.CancelVHTLCRecoveryResponse
+	cancelErr         error
+	statusResp        *daemonrpc.GetVHTLCRecoveryStatusResponse
+	statusErr         error
+	armRecoveryCalls  int
+	escalateCalls     int
+	cancelCalls       int
+	statusCalls       int
+	lastArmRecovery   *daemonrpc.ArmVHTLCRecoveryRequest
+	lastEscalate      *daemonrpc.EscalateVHTLCRecoveryRequest
+	lastCancel        *daemonrpc.CancelVHTLCRecoveryRequest
+	lastStatus        *daemonrpc.GetVHTLCRecoveryStatusRequest
 }
 
 // BlockHeight returns the configured best block height.
@@ -535,6 +552,95 @@ func (d *testDaemonConn) SendOORWithCustomInputs(_ context.Context,
 	}
 
 	return d.sendSessionID, d.sendCustomErr
+}
+
+// ArmVHTLCRecovery records the daemon recovery arm request.
+func (d *testDaemonConn) ArmVHTLCRecovery(_ context.Context,
+	req *daemonrpc.ArmVHTLCRecoveryRequest) (
+	*daemonrpc.ArmVHTLCRecoveryResponse, error) {
+
+	d.armRecoveryCalls++
+	d.lastArmRecovery = req
+	if d.armRecoveryErr != nil {
+		return nil, d.armRecoveryErr
+	}
+	if d.armRecoveryResp != nil {
+		return d.armRecoveryResp, nil
+	}
+
+	return &daemonrpc.ArmVHTLCRecoveryResponse{
+		RecoveryId: fmt.Sprintf("recovery-%d", d.armRecoveryCalls),
+		Created:    true,
+		Status: &daemonrpc.VHTLCRecoveryStatus{
+			RecoveryId: fmt.Sprintf(
+				"recovery-%d", d.armRecoveryCalls,
+			),
+			State: recoveryStateArmed,
+		},
+	}, nil
+}
+
+// EscalateVHTLCRecovery records the daemon recovery escalation request.
+func (d *testDaemonConn) EscalateVHTLCRecovery(_ context.Context,
+	req *daemonrpc.EscalateVHTLCRecoveryRequest) (
+	*daemonrpc.EscalateVHTLCRecoveryResponse, error) {
+
+	d.escalateCalls++
+	d.lastEscalate = req
+	if d.escalateErr != nil {
+		return nil, d.escalateErr
+	}
+	if d.escalateResp != nil {
+		return d.escalateResp, nil
+	}
+
+	return &daemonrpc.EscalateVHTLCRecoveryResponse{
+		Status: &daemonrpc.VHTLCRecoveryStatus{
+			RecoveryId: req.GetRecoveryId(),
+			State:      recoveryStateUnrollStarted,
+		},
+	}, nil
+}
+
+// CancelVHTLCRecovery records the daemon recovery cancellation request.
+func (d *testDaemonConn) CancelVHTLCRecovery(_ context.Context,
+	req *daemonrpc.CancelVHTLCRecoveryRequest) (
+	*daemonrpc.CancelVHTLCRecoveryResponse, error) {
+
+	d.cancelCalls++
+	d.lastCancel = req
+	if d.cancelErr != nil {
+		return nil, d.cancelErr
+	}
+	if d.cancelResp != nil {
+		return d.cancelResp, nil
+	}
+
+	return &daemonrpc.CancelVHTLCRecoveryResponse{
+		Status: &daemonrpc.VHTLCRecoveryStatus{
+			RecoveryId: req.GetRecoveryId(),
+			State:      recoveryStateCancelled,
+		},
+	}, nil
+}
+
+// GetVHTLCRecoveryStatus records the daemon recovery status request.
+func (d *testDaemonConn) GetVHTLCRecoveryStatus(_ context.Context,
+	req *daemonrpc.GetVHTLCRecoveryStatusRequest) (
+	*daemonrpc.GetVHTLCRecoveryStatusResponse, error) {
+
+	d.statusCalls++
+	d.lastStatus = req
+	if d.statusErr != nil {
+		return nil, d.statusErr
+	}
+	if d.statusResp != nil {
+		return d.statusResp, nil
+	}
+
+	return &daemonrpc.GetVHTLCRecoveryStatusResponse{
+		Found: false,
+	}, nil
 }
 
 // IdentityPubKey returns the configured client key.
@@ -1925,6 +2031,9 @@ func TestReceiveSessionFreshClaimBoundsSpentLookup(t *testing.T) {
 		state:               ReceiveStateVHTLCFunded,
 		Preimage:            preimage,
 		PaymentHash:         preimage.Hash(),
+		clientPubKey:        receiverPriv.PubKey(),
+		swapServerPubKey:    senderPriv.PubKey(),
+		operatorPubKey:      operatorPriv.PubKey(),
 		vhtlcPolicy:         policy,
 		vhtlcPolicyTemplate: policyTemplate,
 		vhtlcPkScript:       pkScript,
@@ -1940,6 +2049,24 @@ func TestReceiveSessionFreshClaimBoundsSpentLookup(t *testing.T) {
 	require.Equal(t, ReceiveStateCompleted, session.State())
 	require.Equal(t, 1, daemonConn.sendCustomCalls)
 	require.Equal(t, 1, daemonConn.spentLookupCalls)
+	require.Equal(t, 1, daemonConn.armRecoveryCalls)
+	require.Equal(
+		t, recoveryDirectionReceive, daemonConn.lastArmRecovery.
+			GetDirection(),
+	)
+	require.Equal(
+		t, recoveryActionClaim, daemonConn.lastArmRecovery.
+			GetAction(),
+	)
+	require.Equal(
+		t, "funding:0", daemonConn.lastArmRecovery.
+			GetVtxoOutpoint(),
+	)
+	require.Equal(
+		t, int32(144), daemonConn.lastArmRecovery.
+			GetRefundLocktime(),
+	)
+	require.Equal(t, 1, daemonConn.cancelCalls)
 }
 
 // TestReceiveSessionFreshClaimBoundsSpentLookupGRPCDeadline mirrors
@@ -2009,6 +2136,9 @@ func TestReceiveSessionFreshClaimBoundsSpentLookupGRPCDeadline(t *testing.T) {
 		state:               ReceiveStateVHTLCFunded,
 		Preimage:            preimage,
 		PaymentHash:         preimage.Hash(),
+		clientPubKey:        receiverPriv.PubKey(),
+		swapServerPubKey:    senderPriv.PubKey(),
+		operatorPubKey:      operatorPriv.PubKey(),
 		vhtlcPolicy:         policy,
 		vhtlcPolicyTemplate: policyTemplate,
 		vhtlcPkScript:       pkScript,
@@ -2065,6 +2195,8 @@ func TestReceiveSessionClaimRejectsAfterRefundLocktime(t *testing.T) {
 
 	daemonConn := &testDaemonConn{
 		blockHeight: 144,
+		identityKey: receiverPriv.PubKey(),
+		operatorKey: operatorPriv.PubKey(),
 		receiveInfo: &ReceiveInfo{
 			PkScript: []byte{
 				0x51,
@@ -2080,6 +2212,9 @@ func TestReceiveSessionClaimRejectsAfterRefundLocktime(t *testing.T) {
 		state:               ReceiveStateVHTLCFunded,
 		Preimage:            preimage,
 		PaymentHash:         preimage.Hash(),
+		clientPubKey:        receiverPriv.PubKey(),
+		swapServerPubKey:    senderPriv.PubKey(),
+		operatorPubKey:      operatorPriv.PubKey(),
 		vhtlcPolicy:         policy,
 		vhtlcPolicyTemplate: policyTemplate,
 		vhtlcPkScript:       pkScript,
@@ -2093,6 +2228,90 @@ func TestReceiveSessionClaimRejectsAfterRefundLocktime(t *testing.T) {
 	_, err = session.Claim(t.Context(), "funding:0", 42_000)
 	require.ErrorIs(t, err, errSwapExpired)
 	require.Equal(t, ReceiveStateExpired, session.State())
+	require.Zero(t, daemonConn.sendCustomCalls)
+}
+
+// TestReceiveSessionClaimRecoveryCompletionWinsAfterRefundLocktime asserts
+// daemon-owned recovery can complete a receive session even after the
+// cooperative claim locktime gate would otherwise expire new claim attempts.
+func TestReceiveSessionClaimRecoveryCompletionWinsAfterRefundLocktime(
+	t *testing.T) {
+
+	t.Parallel()
+
+	senderPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	receiverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	preimage, err := NewPreimage()
+	require.NoError(t, err)
+
+	policy, err := arkscript.NewVHTLCPolicy(arkscript.VHTLCOpts{
+		Sender:   senderPriv.PubKey(),
+		Receiver: receiverPriv.PubKey(),
+		Server:   operatorPriv.PubKey(),
+		PreimageHash: lntypes.Hash(
+			sha256.Sum256(preimage[:]),
+		),
+		RefundLocktime:                       144,
+		UnilateralClaimDelay:                 12,
+		UnilateralRefundDelay:                24,
+		UnilateralRefundWithoutReceiverDelay: 36,
+	})
+	require.NoError(t, err)
+
+	policyTemplate, err := encodeVHTLCPolicyTemplate(policy)
+	require.NoError(t, err)
+
+	pkScript, err := policy.PkScript()
+	require.NoError(t, err)
+
+	recoveryID := "claim-recovery"
+	daemonConn := &testDaemonConn{
+		blockHeight: 144,
+		receiveInfo: &ReceiveInfo{
+			PkScript: []byte{
+				0x51,
+			},
+			PubKeyXOnly: receiverPriv.PubKey().X().Bytes(),
+		},
+		statusResp: &daemonrpc.GetVHTLCRecoveryStatusResponse{
+			Found: true,
+			Status: &daemonrpc.VHTLCRecoveryStatus{
+				RecoveryId: recoveryID,
+				State:      recoveryStateCompleted,
+			},
+		},
+	}
+
+	client := NewSwapClient(nil, daemonConn, nil, nil)
+	session := &ReceiveSession{
+		client:              client,
+		state:               ReceiveStateVHTLCFunded,
+		Preimage:            preimage,
+		PaymentHash:         preimage.Hash(),
+		vhtlcPolicy:         policy,
+		vhtlcPolicyTemplate: policyTemplate,
+		vhtlcPkScript:       pkScript,
+		vhtlcConfig: VHTLCConfig{
+			RefundLocktime: 144,
+		},
+		vhtlcOutpoint:   "funding:0",
+		vhtlcAmount:     42_000,
+		claimRecoveryID: recoveryID,
+	}
+
+	result, err := session.Claim(t.Context(), "funding:0", 42_000)
+	require.NoError(t, err)
+	require.Equal(t, ReceiveStateCompleted, session.State())
+	require.Equal(t, "funding:0", result.VTXOOutpoint)
+	require.Equal(t, recoveryID, daemonConn.lastStatus.GetRecoveryId())
+	require.Equal(t, 1, daemonConn.statusCalls)
 	require.Zero(t, daemonConn.sendCustomCalls)
 }
 

--- a/sdk/swaps/queries/swaps.sql
+++ b/sdk/swaps/queries/swaps.sql
@@ -23,12 +23,13 @@ INSERT INTO receive_swaps (
     claim_receive_pubkey,
     claim_receive_pkscript,
     claim_session_id,
+    claim_recovery_id,
     intervention_reason,
     created_at_unix,
     updated_at_unix
 ) VALUES (
     $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15,
-    $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26
+    $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27
 )
 ON CONFLICT (payment_hash) DO UPDATE SET
     amount_sat = EXCLUDED.amount_sat,
@@ -54,6 +55,7 @@ ON CONFLICT (payment_hash) DO UPDATE SET
     claim_receive_pubkey = EXCLUDED.claim_receive_pubkey,
     claim_receive_pkscript = EXCLUDED.claim_receive_pkscript,
     claim_session_id = EXCLUDED.claim_session_id,
+    claim_recovery_id = EXCLUDED.claim_recovery_id,
     intervention_reason = EXCLUDED.intervention_reason,
     updated_at_unix = EXCLUDED.updated_at_unix;
 
@@ -95,13 +97,14 @@ INSERT INTO pay_swaps (
     refund_receive_pubkey,
     refund_receive_pkscript,
     refund_session_id,
+    refund_recovery_id,
     preimage,
     intervention_reason,
     created_at_unix,
     updated_at_unix
 ) VALUES (
     $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16,
-    $17, $18, $19, $20, $21, $22, $23, $24, $25, $26
+    $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27
 )
 ON CONFLICT (payment_hash) DO UPDATE SET
     invoice = EXCLUDED.invoice,
@@ -126,6 +129,7 @@ ON CONFLICT (payment_hash) DO UPDATE SET
     refund_receive_pubkey = EXCLUDED.refund_receive_pubkey,
     refund_receive_pkscript = EXCLUDED.refund_receive_pkscript,
     refund_session_id = EXCLUDED.refund_session_id,
+    refund_recovery_id = EXCLUDED.refund_recovery_id,
     preimage = EXCLUDED.preimage,
     intervention_reason = EXCLUDED.intervention_reason,
     updated_at_unix = EXCLUDED.updated_at_unix;

--- a/sdk/swaps/recovery.go
+++ b/sdk/swaps/recovery.go
@@ -86,18 +86,164 @@ const (
 	// claim spend is already indexed.
 	recoveryReasonClaimIndexed = "cooperative claim indexed"
 
-	// defaultRecoveryMaxFeeRateSatPerKW caps SDK-armed vHTLC exit spends at
+	// DefaultRecoveryMaxFeeRateSatPerKW caps SDK-armed vHTLC exit spends at
 	// 100 sat/vbyte. Operators can still clamp lower through the daemon's
 	// unroll fee cap; this value prevents an armed recovery row from being
 	// uncapped if the lower layer is configured permissively.
-	defaultRecoveryMaxFeeRateSatPerKW int32 = 25_000
+	DefaultRecoveryMaxFeeRateSatPerKW int32 = 25_000
 
 	// recoverySignerKeyIndex is the fixed identity-key index used by the
 	// daemon for Ark/OOR signing. The key family is
 	// keychain.KeyFamilyNodeKey; keeping the locator explicit lets the
 	// unroll signer reconstruct the same public key after restart.
 	recoverySignerKeyIndex int32 = 0
+
+	// DefaultRecoveryCooperativeFailureGracePeriod is how long the SDK
+	// keeps retrying cooperative vHTLC settlement after the first observed
+	// cooperative send failure before automatic on-chain recovery may
+	// start.
+	DefaultRecoveryCooperativeFailureGracePeriod = time.Hour
+
+	// DefaultRecoveryMinMarginBlocks is the block-height safety margin that
+	// lets claim recovery override the wall-clock grace period before a
+	// refund locktime can make waiting unsafe.
+	DefaultRecoveryMinMarginBlocks = uint32(12)
 )
+
+// RecoveryPolicy controls automatic escalation from cooperative vHTLC retry to
+// daemon-owned on-chain recovery. Arming is still immediate and cheap; this
+// policy only gates the expensive unroll transition.
+type RecoveryPolicy struct {
+	// AutoEscalate allows the SDK to start on-chain recovery without a
+	// manual caller command once the grace/deadline policy says waiting
+	// longer is unsafe or unproductive.
+	AutoEscalate bool
+
+	// CooperativeFailureGracePeriod is measured from the first cooperative
+	// send failure observed by the current process. While this period is
+	// open, the SDK keeps retrying cooperative settlement unless deadline
+	// pressure overrides the wait.
+	CooperativeFailureGracePeriod time.Duration
+
+	// MinRecoveryMarginBlocks is the minimum block margin preserved before
+	// a refund locktime. Claim recovery may override the grace period when
+	// the current height plus this margin reaches the refund locktime.
+	MinRecoveryMarginBlocks uint32
+
+	// MaxFeeRateSatPerKW caps the final recovery exit-spend fee rate. The
+	// recovery row stores this cap at arm time so restart and manual
+	// escalation cannot accidentally use a looser later default.
+	MaxFeeRateSatPerKW int32
+}
+
+// DefaultRecoveryPolicy returns the production SDK recovery escalation policy.
+func DefaultRecoveryPolicy() RecoveryPolicy {
+	gracePeriod := DefaultRecoveryCooperativeFailureGracePeriod
+	marginBlocks := DefaultRecoveryMinMarginBlocks
+	feeCap := DefaultRecoveryMaxFeeRateSatPerKW
+
+	return RecoveryPolicy{
+		AutoEscalate:                  false,
+		CooperativeFailureGracePeriod: gracePeriod,
+		MinRecoveryMarginBlocks:       marginBlocks,
+		MaxFeeRateSatPerKW:            feeCap,
+	}
+}
+
+// WithDefaults fills numeric unset policy fields with the production recovery
+// policy. AutoEscalate is intentionally preserved so callers can disable
+// automatic on-chain recovery with RecoveryPolicy{AutoEscalate: false}.
+func (p RecoveryPolicy) WithDefaults() RecoveryPolicy {
+	if p.MinRecoveryMarginBlocks == 0 {
+		p.MinRecoveryMarginBlocks = DefaultRecoveryMinMarginBlocks
+	}
+	if p.MaxFeeRateSatPerKW == 0 {
+		p.MaxFeeRateSatPerKW = DefaultRecoveryMaxFeeRateSatPerKW
+	}
+
+	return p
+}
+
+// recoveryEscalationDecision is the policy result for one cooperative vHTLC
+// send failure.
+type recoveryEscalationDecision struct {
+	// Escalate is true when the caller should start daemon-owned unroll
+	// now.
+	Escalate bool
+
+	// Trigger explains why escalation is allowed or why it was skipped.
+	Trigger string
+
+	// FirstFailureAt is when this process first observed cooperative
+	// failure for the recovery row.
+	FirstFailureAt time.Time
+
+	// NextRetryAt is when the grace-period retry window opens. It is zero
+	// when escalation is immediate or automatic escalation is disabled.
+	NextRetryAt time.Time
+
+	// CurrentHeight is the block height used for deadline checks.
+	CurrentHeight uint32
+
+	// DeadlineHeight is the claim/refund deadline, when one exists.
+	DeadlineHeight uint32
+
+	// RemainingBlocks is the signed distance between the current height and
+	// DeadlineHeight. It is negative when the deadline has already passed.
+	RemainingBlocks int32
+}
+
+// decideRecoveryEscalation evaluates the automatic escalation policy after a
+// cooperative vHTLC send failure.
+func decideRecoveryEscalation(policy RecoveryPolicy, firstFailureAt time.Time,
+	now time.Time, currentHeight uint32,
+	deadlineHeight uint32) recoveryEscalationDecision {
+
+	policy = policy.WithDefaults()
+	decision := recoveryEscalationDecision{
+		FirstFailureAt: firstFailureAt,
+		CurrentHeight:  currentHeight,
+		DeadlineHeight: deadlineHeight,
+	}
+	if deadlineHeight != 0 {
+		decision.RemainingBlocks = int32(deadlineHeight) -
+			int32(currentHeight)
+	}
+	if !policy.AutoEscalate {
+		decision.Trigger = "auto_escalate_disabled"
+
+		return decision
+	}
+
+	if deadlineHeight != 0 &&
+		currentHeight+policy.MinRecoveryMarginBlocks >= deadlineHeight {
+
+		decision.Escalate = true
+		decision.Trigger = "deadline_margin"
+
+		return decision
+	}
+
+	if policy.CooperativeFailureGracePeriod <= 0 {
+		decision.Escalate = true
+		decision.Trigger = "grace_disabled"
+
+		return decision
+	}
+
+	readyAt := firstFailureAt.Add(policy.CooperativeFailureGracePeriod)
+	decision.NextRetryAt = readyAt
+	if !now.Before(readyAt) {
+		decision.Escalate = true
+		decision.Trigger = "grace_elapsed"
+
+		return decision
+	}
+
+	decision.Trigger = "within_grace_period"
+
+	return decision
+}
 
 // recoveryRequestID returns the caller-owned idempotency key used when arming
 // vHTLC recovery. It is deterministic from the SDK swap identity and action so
@@ -197,7 +343,8 @@ func (s *paySession) ensurePayRefundRecoveryArmed(ctx context.Context) error {
 			DestinationScript: append(
 				[]byte(nil), s.refundReceiveScript...,
 			),
-			MaxFeeRateSatPerKw: defaultRecoveryMaxFeeRateSatPerKW,
+			MaxFeeRateSatPerKw: s.client.recoveryPolicy.
+				MaxFeeRateSatPerKW,
 		},
 	)
 	if err != nil {
@@ -225,7 +372,7 @@ func (s *paySession) ensurePayRefundRecoveryArmed(ctx context.Context) error {
 		),
 		slog.Int(
 			"max_fee_rate_sat_per_kw",
-			int(defaultRecoveryMaxFeeRateSatPerKW),
+			int(s.client.recoveryPolicy.MaxFeeRateSatPerKW),
 		),
 	)
 
@@ -303,7 +450,8 @@ func (s *ReceiveSession) ensureReceiveClaimRecoveryArmed(
 			DestinationScript: append(
 				[]byte(nil), s.claimReceiveScript...,
 			),
-			MaxFeeRateSatPerKw: defaultRecoveryMaxFeeRateSatPerKW,
+			MaxFeeRateSatPerKw: s.client.recoveryPolicy.
+				MaxFeeRateSatPerKW,
 		},
 	)
 	if err != nil {
@@ -328,7 +476,7 @@ func (s *ReceiveSession) ensureReceiveClaimRecoveryArmed(
 		),
 		slog.Int(
 			"max_fee_rate_sat_per_kw",
-			int(defaultRecoveryMaxFeeRateSatPerKW),
+			int(s.client.recoveryPolicy.MaxFeeRateSatPerKW),
 		),
 	)
 
@@ -398,6 +546,185 @@ func escalateVHTLCRecovery(ctx context.Context, daemon DaemonConn, recoveryID,
 		return fmt.Errorf("escalate vhtlc recovery %s: %w", recoveryID,
 			err)
 	}
+
+	return nil
+}
+
+// firstPayRefundRecoveryFailure returns the durable lower bound for when
+// pay-side cooperative refund started failing. The pay FSM persists the
+// RefundInitiated state before retrying the custom-input refund, so UpdatedAt
+// survives restart and does not move forward while cooperative retry keeps
+// failing.
+func (s *paySession) firstPayRefundRecoveryFailure() time.Time {
+	if !s.refundRecoveryFailureAt.IsZero() {
+		return s.refundRecoveryFailureAt
+	}
+
+	first := s.updatedAt
+	if first.IsZero() {
+		first = s.client.now()
+	}
+	s.refundRecoveryFailureAt = first
+
+	return first
+}
+
+// maybeEscalatePayRefundRecovery applies the SDK recovery policy after a
+// cooperative pay-side refund send fails. It returns nil when the SDK should
+// keep retrying the cooperative path instead of starting costly unroll.
+func (s *paySession) maybeEscalatePayRefundRecovery(ctx context.Context,
+	cause error) error {
+
+	if s.refundRecoveryID == "" {
+		return nil
+	}
+
+	reason := fmt.Sprintf("cooperative refund failed: %v", cause)
+	height, err := s.client.daemon.BlockHeight(ctx)
+	if err != nil {
+		s.client.log.WarnS(
+			ctx,
+			"Pay refund recovery height unavailable",
+			err,
+			btclog.Hex("hash", s.cfg.PaymentHash[:]),
+			slog.String("recovery_id", s.refundRecoveryID),
+		)
+	}
+
+	decision := decideRecoveryEscalation(
+		s.client.recoveryPolicy, s.firstPayRefundRecoveryFailure(),
+		s.client.now(), height, 0,
+	)
+	if !decision.Escalate {
+		s.client.log.WarnS(ctx,
+			"Pay refund recovery escalation deferred", cause,
+			btclog.Hex("hash", s.cfg.PaymentHash[:]),
+			slog.String("recovery_id", s.refundRecoveryID),
+			slog.String("reason", reason),
+			slog.String("trigger", decision.Trigger),
+			slog.Time("first_failure_at", decision.FirstFailureAt),
+			slog.Time("next_retry_at", decision.NextRetryAt),
+			slog.Uint64(
+				"current_height",
+				uint64(decision.CurrentHeight),
+			),
+		)
+
+		return nil
+	}
+
+	// Pay-side refund recovery has no absolute claim deadline. The grace
+	// period is the only automatic trigger; operators can still use the
+	// recovery CLI to escalate earlier.
+	if err := escalateVHTLCRecovery(
+		ctx, s.client.daemon, s.refundRecoveryID, reason,
+	); err != nil {
+		return err
+	}
+
+	s.client.log.WarnS(ctx, "Pay refund recovery escalated",
+		cause,
+		btclog.Hex("hash", s.cfg.PaymentHash[:]),
+		slog.String("recovery_id", s.refundRecoveryID),
+		slog.String("reason", reason),
+		slog.String("trigger", decision.Trigger),
+		slog.String("outpoint", s.vhtlcOutpoint),
+		slog.Int64("amount_sat", s.vhtlcAmount),
+		slog.Uint64("current_height", uint64(decision.CurrentHeight)),
+	)
+
+	return nil
+}
+
+// firstReceiveClaimRecoveryFailure returns the durable lower bound for when
+// receive-side cooperative claim started failing. The receive FSM persists
+// ClaimInitiated before retrying the claim, so UpdatedAt survives restart and
+// does not move forward while cooperative retry keeps failing.
+func (s *ReceiveSession) firstReceiveClaimRecoveryFailure() time.Time {
+	if !s.claimRecoveryFailureAt.IsZero() {
+		return s.claimRecoveryFailureAt
+	}
+
+	first := s.updatedAt
+	if first.IsZero() {
+		first = s.client.now()
+	}
+	s.claimRecoveryFailureAt = first
+
+	return first
+}
+
+// maybeEscalateReceiveClaimRecovery applies the SDK recovery policy after a
+// cooperative receive-side claim send fails. The receive claim has a refund
+// locktime deadline, so deadline margin may override the wall-clock grace
+// period before the sender can reclaim the vHTLC.
+func (s *ReceiveSession) maybeEscalateReceiveClaimRecovery(ctx context.Context,
+	cause error) error {
+
+	if s.claimRecoveryID == "" {
+		return nil
+	}
+
+	reason := fmt.Sprintf("cooperative claim failed: %v", cause)
+	height, err := s.client.daemon.BlockHeight(ctx)
+	if err != nil {
+		s.client.log.WarnS(
+			ctx,
+			"Receive claim recovery height unavailable",
+			err,
+			btclog.Hex("hash", s.PaymentHash[:]),
+			slog.String("recovery_id", s.claimRecoveryID),
+		)
+	}
+
+	decision := decideRecoveryEscalation(
+		s.client.recoveryPolicy, s.firstReceiveClaimRecoveryFailure(),
+		s.client.now(), height, s.vhtlcConfig.RefundLocktime,
+	)
+	if !decision.Escalate {
+		s.client.log.WarnS(ctx,
+			"Receive claim recovery escalation deferred", cause,
+			btclog.Hex("hash", s.PaymentHash[:]),
+			slog.String("recovery_id", s.claimRecoveryID),
+			slog.String("reason", reason),
+			slog.String("trigger", decision.Trigger),
+			slog.Time("first_failure_at", decision.FirstFailureAt),
+			slog.Time("next_retry_at", decision.NextRetryAt),
+			slog.Uint64(
+				"current_height",
+				uint64(decision.CurrentHeight),
+			),
+			slog.Uint64(
+				"refund_locktime",
+				uint64(decision.DeadlineHeight),
+			),
+			slog.Int(
+				"remaining_blocks",
+				int(decision.RemainingBlocks),
+			),
+		)
+
+		return nil
+	}
+
+	if err := escalateVHTLCRecovery(
+		ctx, s.client.daemon, s.claimRecoveryID, reason,
+	); err != nil {
+		return err
+	}
+
+	s.client.log.WarnS(ctx, "Receive claim recovery escalated",
+		cause,
+		btclog.Hex("hash", s.PaymentHash[:]),
+		slog.String("recovery_id", s.claimRecoveryID),
+		slog.String("reason", reason),
+		slog.String("trigger", decision.Trigger),
+		slog.String("outpoint", s.vhtlcOutpoint),
+		slog.Int64("amount_sat", s.vhtlcAmount),
+		slog.Uint64("current_height", uint64(decision.CurrentHeight)),
+		slog.Uint64("refund_locktime", uint64(decision.DeadlineHeight)),
+		slog.Int("remaining_blocks", int(decision.RemainingBlocks)),
+	)
 
 	return nil
 }

--- a/sdk/swaps/recovery.go
+++ b/sdk/swaps/recovery.go
@@ -1,0 +1,558 @@
+package swaps
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/lntypes"
+)
+
+//nolint:ll
+const (
+	// recoveryDirectionPay is the SDK pay-side daemon recovery direction.
+	recoveryDirectionPay = daemonrpc.
+				VHTLCRecoveryDirection_VHTLC_RECOVERY_DIRECTION_PAY
+
+	// recoveryDirectionReceive is the SDK receive-side daemon recovery
+	// direction.
+	recoveryDirectionReceive = daemonrpc.
+					VHTLCRecoveryDirection_VHTLC_RECOVERY_DIRECTION_RECEIVE
+
+	// recoveryActionClaim is the receive-side unilateral claim action.
+	recoveryActionClaim = daemonrpc.
+				VHTLCRecoveryAction_VHTLC_RECOVERY_ACTION_CLAIM
+
+	// recoveryActionRefundWithoutReceiver is the pay-side sender-only
+	// unilateral refund action.
+	recoveryActionRefundWithoutReceiver = daemonrpc.
+						VHTLCRecoveryAction_VHTLC_RECOVERY_ACTION_REFUND_WITHOUT_RECEIVER
+
+	// recoveryStateUnspecified represents a missing or unknown recovery
+	// row.
+	recoveryStateUnspecified = daemonrpc.
+					VHTLCRecoveryState_VHTLC_RECOVERY_STATE_UNSPECIFIED
+
+	// recoveryStateArmed means the row is dormant and cooperative
+	// settlement can still win without on-chain escalation.
+	recoveryStateArmed = daemonrpc.
+				VHTLCRecoveryState_VHTLC_RECOVERY_STATE_ARMED
+
+	// recoveryStateUnrollStarted means daemon-owned unroll execution has
+	// started.
+	recoveryStateUnrollStarted = daemonrpc.
+					VHTLCRecoveryState_VHTLC_RECOVERY_STATE_UNROLL_STARTED
+
+	// recoveryStateCompleted means the daemon completed on-chain recovery.
+	recoveryStateCompleted = daemonrpc.
+				VHTLCRecoveryState_VHTLC_RECOVERY_STATE_COMPLETED
+
+	// recoveryStateCancelled means cooperative settlement cancelled
+	// recovery.
+	recoveryStateCancelled = daemonrpc.
+				VHTLCRecoveryState_VHTLC_RECOVERY_STATE_CANCELLED
+
+	// recoveryStateFailed means recovery hit a terminal daemon-side error.
+	recoveryStateFailed = daemonrpc.
+				VHTLCRecoveryState_VHTLC_RECOVERY_STATE_FAILED
+
+	// recoveryReasonServerClaimObserved explains cancellation when the pay
+	// side observes the server's preimage claim.
+	recoveryReasonServerClaimObserved = "server claim observed"
+
+	// recoveryReasonServerClaimBeforeRefund explains cancellation when the
+	// pay side finds the server claim while reconciling refund.
+	recoveryReasonServerClaimBeforeRefund = "server claim observed " +
+		"before refund"
+
+	// recoveryReasonRefundOutputIndexed explains cancellation when the
+	// cooperative refund output is already indexed.
+	recoveryReasonRefundOutputIndexed = "cooperative refund output indexed"
+
+	// recoveryReasonRefundAccepted explains cancellation when the daemon
+	// accepted the cooperative refund OOR.
+	recoveryReasonRefundAccepted = "cooperative refund accepted"
+
+	// recoveryReasonClaimAccepted explains cancellation when the daemon
+	// accepted the cooperative claim OOR.
+	recoveryReasonClaimAccepted = "cooperative claim accepted"
+
+	// recoveryReasonClaimIndexed explains cancellation when the cooperative
+	// claim spend is already indexed.
+	recoveryReasonClaimIndexed = "cooperative claim indexed"
+
+	// defaultRecoveryMaxFeeRateSatPerKW caps SDK-armed vHTLC exit spends at
+	// 100 sat/vbyte. Operators can still clamp lower through the daemon's
+	// unroll fee cap; this value prevents an armed recovery row from being
+	// uncapped if the lower layer is configured permissively.
+	defaultRecoveryMaxFeeRateSatPerKW int32 = 25_000
+
+	// recoverySignerKeyIndex is the fixed identity-key index used by the
+	// daemon for Ark/OOR signing. The key family is
+	// keychain.KeyFamilyNodeKey; keeping the locator explicit lets the
+	// unroll signer reconstruct the same public key after restart.
+	recoverySignerKeyIndex int32 = 0
+)
+
+// recoveryRequestID returns the caller-owned idempotency key used when arming
+// vHTLC recovery. It is deterministic from the SDK swap identity and action so
+// retries after crash or RPC timeout return the original daemon recovery row.
+func recoveryRequestID(direction string, paymentHash lntypes.Hash,
+	action daemonrpc.VHTLCRecoveryAction) string {
+
+	return fmt.Sprintf("sdk-swaps:%s:%x:%s", direction, paymentHash[:],
+		action.String())
+}
+
+// recoverySignerFamily returns the daemon identity key family used by the
+// client-side vHTLC sender/receiver key.
+func recoverySignerFamily() int32 {
+	return int32(keychain.KeyFamilyNodeKey)
+}
+
+// pubKeyBytesForRecovery serializes a required compressed public key for an
+// arm request.
+func pubKeyBytesForRecovery(pubKey *btcec.PublicKey,
+	name string) ([]byte, error) {
+
+	if pubKey == nil {
+		return nil, fmt.Errorf("%s pubkey is required", name)
+	}
+
+	return pubKey.SerializeCompressed(), nil
+}
+
+// ensurePayRefundRecoveryArmed stores a dormant refund-without-receiver
+// recovery row for the funded pay-side vHTLC. The row is armed before refund
+// locktime pressure so escalation later only flips existing durable state.
+func (s *paySession) ensurePayRefundRecoveryArmed(ctx context.Context) error {
+	if s.refundRecoveryID != "" {
+		return nil
+	}
+	if s.cfg == nil {
+		return fmt.Errorf("pay swap config is required")
+	}
+	if s.vhtlcOutpoint == "" || s.vhtlcAmount <= 0 {
+		return fmt.Errorf("funded pay vHTLC is required")
+	}
+	if _, err := s.refundPubKey(ctx); err != nil {
+		return err
+	}
+	if len(s.refundReceiveScript) == 0 {
+		return fmt.Errorf("refund destination script is required")
+	}
+
+	sender, err := pubKeyBytesForRecovery(s.clientPubKey, "sender")
+	if err != nil {
+		return err
+	}
+	receiver, err := pubKeyBytesForRecovery(s.serverPubKey, "receiver")
+	if err != nil {
+		return err
+	}
+	server, err := pubKeyBytesForRecovery(s.operatorPubKey, "server")
+	if err != nil {
+		return err
+	}
+
+	resp, err := s.client.daemon.ArmVHTLCRecovery(
+		ctx, &daemonrpc.ArmVHTLCRecoveryRequest{
+			RequestId: recoveryRequestID(
+				string(SwapDirectionPay), s.cfg.PaymentHash,
+				recoveryActionRefundWithoutReceiver,
+			),
+			SwapId: append(
+				[]byte(nil), s.cfg.PaymentHash[:]...,
+			),
+			Direction:      recoveryDirectionPay,
+			Action:         recoveryActionRefundWithoutReceiver,
+			VtxoOutpoint:   s.vhtlcOutpoint,
+			VtxoAmountSat:  s.vhtlcAmount,
+			SenderPubkey:   sender,
+			ReceiverPubkey: receiver,
+			ServerPubkey:   server,
+			RefundLocktime: int32(
+				s.cfg.VHTLCConfig.RefundLocktime,
+			),
+			UnilateralClaimDelay: int32(
+				s.cfg.VHTLCConfig.UnilateralClaimDelay,
+			),
+			UnilateralRefundDelay: int32(
+				s.cfg.VHTLCConfig.UnilateralRefundDelay,
+			),
+			UnilateralRefundWithoutReceiverDelay: int32(
+				s.cfg.VHTLCConfig.
+					UnilateralRefundWithoutReceiverDelay,
+			),
+			PreimageHash: append(
+				[]byte(nil), s.cfg.PaymentHash[:]...,
+			),
+			SignerKeyFamily: recoverySignerFamily(),
+			SignerKeyIndex:  recoverySignerKeyIndex,
+			DestinationScript: append(
+				[]byte(nil), s.refundReceiveScript...,
+			),
+			MaxFeeRateSatPerKw: defaultRecoveryMaxFeeRateSatPerKW,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("arm pay refund recovery: %w", err)
+	}
+	if resp.GetRecoveryId() == "" {
+		return fmt.Errorf("arm pay refund recovery returned empty id")
+	}
+
+	s.client.log.InfoS(ctx, "Pay refund recovery armed",
+		btclog.Hex("hash", s.cfg.PaymentHash[:]),
+		slog.String("recovery_id", resp.GetRecoveryId()),
+		slog.Bool("created", resp.GetCreated()),
+		slog.String("outpoint", s.vhtlcOutpoint),
+		slog.Int64("amount_sat", s.vhtlcAmount),
+		slog.Uint64(
+			"refund_locktime",
+			uint64(s.cfg.VHTLCConfig.RefundLocktime),
+		),
+		slog.Uint64(
+			"ark_csv", uint64(
+				s.cfg.VHTLCConfig.
+					UnilateralRefundWithoutReceiverDelay,
+			),
+		),
+		slog.Int(
+			"max_fee_rate_sat_per_kw",
+			int(defaultRecoveryMaxFeeRateSatPerKW),
+		),
+	)
+
+	return s.mutateAndPersist(ctx, func() error {
+		s.refundRecoveryID = resp.GetRecoveryId()
+
+		return nil
+	})
+}
+
+// ensureReceiveClaimRecoveryArmed stores a dormant claim recovery row for the
+// funded receive-side vHTLC. The raw preimage remains in the receive swap row;
+// the daemon recovery row receives only the hash and resolves the preimage
+// through the swap store if escalation becomes necessary.
+func (s *ReceiveSession) ensureReceiveClaimRecoveryArmed(
+	ctx context.Context) error {
+
+	if s.claimRecoveryID != "" {
+		return nil
+	}
+	if s.vhtlcOutpoint == "" || s.vhtlcAmount <= 0 {
+		return fmt.Errorf("funded receive vHTLC is required")
+	}
+	if len(s.claimReceiveScript) == 0 {
+		return fmt.Errorf("claim destination script is required")
+	}
+
+	sender, err := pubKeyBytesForRecovery(s.swapServerPubKey, "sender")
+	if err != nil {
+		return err
+	}
+	receiver, err := pubKeyBytesForRecovery(s.clientPubKey, "receiver")
+	if err != nil {
+		return err
+	}
+	server, err := pubKeyBytesForRecovery(s.operatorPubKey, "server")
+	if err != nil {
+		return err
+	}
+
+	resp, err := s.client.daemon.ArmVHTLCRecovery(
+		ctx, &daemonrpc.ArmVHTLCRecoveryRequest{
+			RequestId: recoveryRequestID(
+				string(SwapDirectionReceive), s.PaymentHash,
+				recoveryActionClaim,
+			),
+			SwapId: append(
+				[]byte(nil), s.PaymentHash[:]...,
+			),
+			Direction:      recoveryDirectionReceive,
+			Action:         recoveryActionClaim,
+			VtxoOutpoint:   s.vhtlcOutpoint,
+			VtxoAmountSat:  s.vhtlcAmount,
+			SenderPubkey:   sender,
+			ReceiverPubkey: receiver,
+			ServerPubkey:   server,
+			RefundLocktime: int32(
+				s.vhtlcConfig.RefundLocktime,
+			),
+			UnilateralClaimDelay: int32(
+				s.vhtlcConfig.UnilateralClaimDelay,
+			),
+			UnilateralRefundDelay: int32(
+				s.vhtlcConfig.UnilateralRefundDelay,
+			),
+			UnilateralRefundWithoutReceiverDelay: int32(
+				s.vhtlcConfig.
+					UnilateralRefundWithoutReceiverDelay,
+			),
+			PreimageHash: append(
+				[]byte(nil), s.PaymentHash[:]...,
+			),
+			SignerKeyFamily: recoverySignerFamily(),
+			SignerKeyIndex:  recoverySignerKeyIndex,
+			DestinationScript: append(
+				[]byte(nil), s.claimReceiveScript...,
+			),
+			MaxFeeRateSatPerKw: defaultRecoveryMaxFeeRateSatPerKW,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("arm receive claim recovery: %w", err)
+	}
+	if resp.GetRecoveryId() == "" {
+		return fmt.Errorf("arm receive claim recovery returned empty " +
+			"id")
+	}
+
+	s.client.log.InfoS(ctx, "Receive claim recovery armed",
+		btclog.Hex("hash", s.PaymentHash[:]),
+		slog.String("recovery_id", resp.GetRecoveryId()),
+		slog.Bool("created", resp.GetCreated()),
+		slog.String("outpoint", s.vhtlcOutpoint),
+		slog.Int64("amount_sat", s.vhtlcAmount),
+		slog.Uint64(
+			"refund_locktime", uint64(s.vhtlcConfig.RefundLocktime),
+		),
+		slog.Uint64(
+			"ark_csv", uint64(s.vhtlcConfig.UnilateralClaimDelay),
+		),
+		slog.Int(
+			"max_fee_rate_sat_per_kw",
+			int(defaultRecoveryMaxFeeRateSatPerKW),
+		),
+	)
+
+	return s.mutateAndPersist(ctx, func() error {
+		s.claimRecoveryID = resp.GetRecoveryId()
+
+		return nil
+	})
+}
+
+// cancelVHTLCRecovery records that cooperative OOR settlement won before an
+// armed recovery was needed. The caller decides whether cancellation failure is
+// retryable for its current FSM edge.
+func cancelVHTLCRecovery(ctx context.Context, daemon DaemonConn, recoveryID,
+	reason, cooperativeTxid string) error {
+
+	if recoveryID == "" {
+		return nil
+	}
+
+	_, err := daemon.CancelVHTLCRecovery(
+		ctx, &daemonrpc.CancelVHTLCRecoveryRequest{
+			RecoveryId:      recoveryID,
+			Reason:          reason,
+			CooperativeTxid: cooperativeTxid,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("cancel vhtlc recovery %s: %w", recoveryID,
+			err)
+	}
+
+	return nil
+}
+
+// recoveryStatusState returns the current recovery state or UNSPECIFIED when
+// the daemon has no row for recoveryID.
+func recoveryStatusState(resp *daemonrpc.GetVHTLCRecoveryStatusResponse) (
+	daemonrpc.VHTLCRecoveryState, string) {
+
+	if resp == nil || !resp.GetFound() || resp.GetStatus() == nil {
+		return recoveryStateUnspecified, ""
+	}
+
+	status := resp.GetStatus()
+
+	return status.GetState(), status.GetLastError()
+}
+
+// escalateVHTLCRecovery asks the daemon to start a previously armed recovery
+// row. A repeated call is safe because the daemon owns idempotent escalation
+// semantics for already-active or terminal rows.
+func escalateVHTLCRecovery(ctx context.Context, daemon DaemonConn, recoveryID,
+	reason string) error {
+
+	if recoveryID == "" {
+		return nil
+	}
+
+	_, err := daemon.EscalateVHTLCRecovery(
+		ctx, &daemonrpc.EscalateVHTLCRecoveryRequest{
+			RecoveryId: recoveryID,
+			Reason:     reason,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("escalate vhtlc recovery %s: %w", recoveryID,
+			err)
+	}
+
+	return nil
+}
+
+// recoveryIsActive returns true once an armed row has moved into daemon-owned
+// unroll execution and the SDK should stop attempting cooperative custom-input
+// spends for the same vHTLC.
+func recoveryIsActive(state daemonrpc.VHTLCRecoveryState) bool {
+	switch state {
+	case recoveryStateUnspecified, recoveryStateArmed,
+		recoveryStateCancelled:
+		return false
+
+	default:
+		return true
+	}
+}
+
+// getVHTLCRecoveryState loads the daemon recovery row state. Missing rows are
+// treated as unspecified so legacy or partially constructed sessions can
+// continue through their cooperative path.
+func getVHTLCRecoveryState(ctx context.Context, daemon DaemonConn,
+	recoveryID string) (daemonrpc.VHTLCRecoveryState, string, error) {
+
+	if recoveryID == "" {
+		return recoveryStateUnspecified, "", nil
+	}
+
+	resp, err := daemon.GetVHTLCRecoveryStatus(
+		ctx, &daemonrpc.GetVHTLCRecoveryStatusRequest{
+			RecoveryId: recoveryID,
+		},
+	)
+	if err != nil {
+		return recoveryStateUnspecified, "", fmt.Errorf("get vhtlc "+
+			"recovery status %s: %w", recoveryID, err)
+	}
+
+	state, lastErr := recoveryStatusState(resp)
+
+	return state, lastErr, nil
+}
+
+// reconcilePayRefundRecovery checks whether daemon-owned pay-side recovery has
+// taken over a timed-out refund. The boolean return tells the caller that the
+// recovery row was relevant enough that no cooperative refund send should be
+// attempted in this loop iteration.
+func (s *paySession) reconcilePayRefundRecovery(ctx context.Context) (bool,
+	error) {
+
+	state, lastErr, err := getVHTLCRecoveryState(
+		ctx, s.client.daemon, s.refundRecoveryID,
+	)
+	if err != nil {
+		return false, err
+	}
+
+	switch {
+	case state == recoveryStateCompleted:
+		s.client.log.InfoS(ctx, "Pay refund recovery completed",
+			btclog.Hex("hash", s.cfg.PaymentHash[:]),
+			slog.String("recovery_id", s.refundRecoveryID),
+		)
+
+		return true, s.mutateAndPersist(ctx, func() error {
+			return s.transition(payEventRefunded)
+		})
+
+	case state == recoveryStateFailed:
+		reason := "pay refund recovery failed"
+		if lastErr != "" {
+			reason = fmt.Sprintf("%s: %s", reason, lastErr)
+		}
+
+		return true, s.needsIntervention(ctx, reason, nil, nil)
+
+	case recoveryIsActive(state):
+		s.client.log.DebugS(ctx, "Pay refund recovery active",
+			btclog.Hex("hash", s.cfg.PaymentHash[:]),
+			slog.String("recovery_id", s.refundRecoveryID),
+			slog.String("recovery_state", state.String()),
+		)
+
+		return true, waitForFixedPoll(
+			ctx, s.client.waitPollInterval,
+		)
+
+	default:
+		return false, nil
+	}
+}
+
+// reconcileReceiveClaimRecovery checks whether daemon-owned receive-side
+// recovery has taken over the claim path. The boolean return tells the caller
+// that recovery is terminal or active and the cooperative claim send should not
+// be attempted in this loop iteration.
+func (s *ReceiveSession) reconcileReceiveClaimRecovery(ctx context.Context) (
+	bool, error) {
+
+	state, lastErr, err := getVHTLCRecoveryState(
+		ctx, s.client.daemon, s.claimRecoveryID,
+	)
+	if err != nil {
+		return false, err
+	}
+
+	switch {
+	case state == recoveryStateCompleted:
+		s.client.log.InfoS(ctx, "Receive claim recovery completed",
+			btclog.Hex("hash", s.PaymentHash[:]),
+			slog.String("recovery_id", s.claimRecoveryID),
+		)
+
+		return true, s.mutateAndPersist(ctx, func() error {
+			return s.transition(receiveEventCompleted)
+		})
+
+	case state == recoveryStateFailed:
+		reason := "receive claim recovery failed"
+		if lastErr != "" {
+			reason = fmt.Sprintf("%s: %s", reason, lastErr)
+		}
+
+		return true, s.failTerminal(ctx, reason, nil, nil)
+
+	case recoveryIsActive(state):
+		s.client.log.DebugS(ctx, "Receive claim recovery active",
+			btclog.Hex("hash", s.PaymentHash[:]),
+			slog.String("recovery_id", s.claimRecoveryID),
+			slog.String("recovery_state", state.String()),
+		)
+
+		return true, waitForFixedPoll(
+			ctx, s.client.waitPollInterval,
+		)
+
+	default:
+		return false, nil
+	}
+}
+
+// waitForFixedPoll sleeps for one SDK polling interval without consulting any
+// swap- or invoice-specific deadline. Recovery reconciliation uses a fixed poll
+// because once daemon-owned recovery has taken over, the SDK must keep checking
+// durable recovery state even after the cooperative path's deadline has
+// elapsed.
+func waitForFixedPoll(ctx context.Context, interval time.Duration) error {
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+
+	case <-timer.C:
+		return nil
+	}
+}

--- a/sdk/swaps/recovery_test.go
+++ b/sdk/swaps/recovery_test.go
@@ -1,0 +1,60 @@
+package swaps
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestDecideRecoveryEscalationAppliesPolicy verifies the SDK does not turn a
+// cooperative retry failure into on-chain unroll until the configured policy
+// allows it.
+func TestDecideRecoveryEscalationAppliesPolicy(t *testing.T) {
+	t.Parallel()
+
+	firstFailure := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	now := firstFailure.Add(30 * time.Minute)
+	policy := RecoveryPolicy{
+		AutoEscalate:                  true,
+		CooperativeFailureGracePeriod: time.Hour,
+		MinRecoveryMarginBlocks:       12,
+	}
+
+	decision := decideRecoveryEscalation(policy, firstFailure, now, 100, 0)
+	require.False(t, decision.Escalate)
+	require.Equal(t, "within_grace_period", decision.Trigger)
+	require.Equal(t, firstFailure.Add(time.Hour), decision.NextRetryAt)
+
+	decision = decideRecoveryEscalation(
+		policy, firstFailure, firstFailure.Add(time.Hour), 100, 0,
+	)
+	require.True(t, decision.Escalate)
+	require.Equal(t, "grace_elapsed", decision.Trigger)
+
+	decision = decideRecoveryEscalation(
+		policy, firstFailure, now, 188, 200,
+	)
+	require.True(t, decision.Escalate)
+	require.Equal(t, "deadline_margin", decision.Trigger)
+	require.EqualValues(t, 12, decision.RemainingBlocks)
+}
+
+// TestDecideRecoveryEscalationRespectsDisabledAutoEscalate verifies manual
+// recovery mode preserves the operator's explicit AutoEscalate=false setting.
+func TestDecideRecoveryEscalationRespectsDisabledAutoEscalate(t *testing.T) {
+	t.Parallel()
+
+	firstFailure := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	policy := RecoveryPolicy{
+		AutoEscalate:                  false,
+		CooperativeFailureGracePeriod: time.Hour,
+		MinRecoveryMarginBlocks:       12,
+	}
+
+	decision := decideRecoveryEscalation(
+		policy, firstFailure, firstFailure.Add(24*time.Hour), 199, 200,
+	)
+	require.False(t, decision.Escalate)
+	require.Equal(t, "auto_escalate_disabled", decision.Trigger)
+}

--- a/sdk/swaps/sqlc/models.go
+++ b/sdk/swaps/sqlc/models.go
@@ -27,6 +27,7 @@ type PaySwap struct {
 	RefundReceivePubkey                  []byte
 	RefundReceivePkscript                []byte
 	RefundSessionID                      string
+	RefundRecoveryID                     string
 	Preimage                             []byte
 	InterventionReason                   string
 	CreatedAtUnix                        int64
@@ -57,6 +58,7 @@ type ReceiveSwap struct {
 	ClaimReceivePubkey                   []byte
 	ClaimReceivePkscript                 []byte
 	ClaimSessionID                       string
+	ClaimRecoveryID                      string
 	InterventionReason                   string
 	CreatedAtUnix                        int64
 	UpdatedAtUnix                        int64

--- a/sdk/swaps/sqlc/swaps.sql.go
+++ b/sdk/swaps/sqlc/swaps.sql.go
@@ -10,7 +10,7 @@ import (
 )
 
 const GetPaySwap = `-- name: GetPaySwap :one
-SELECT payment_hash, invoice, max_fee_sat, state, amount_sat, fee_sat, expiry_unix, client_pubkey, operator_pubkey, server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, vhtlc_pkscript, vhtlc_policy_template, vhtlc_outpoint, vhtlc_amount, funding_session_id, refund_receive_pubkey, refund_receive_pkscript, refund_session_id, preimage, intervention_reason, created_at_unix, updated_at_unix FROM pay_swaps
+SELECT payment_hash, invoice, max_fee_sat, state, amount_sat, fee_sat, expiry_unix, client_pubkey, operator_pubkey, server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, vhtlc_pkscript, vhtlc_policy_template, vhtlc_outpoint, vhtlc_amount, funding_session_id, refund_receive_pubkey, refund_receive_pkscript, refund_session_id, refund_recovery_id, preimage, intervention_reason, created_at_unix, updated_at_unix FROM pay_swaps
 WHERE payment_hash = $1
 LIMIT 1
 `
@@ -41,6 +41,7 @@ func (q *Queries) GetPaySwap(ctx context.Context, paymentHash []byte) (PaySwap, 
 		&i.RefundReceivePubkey,
 		&i.RefundReceivePkscript,
 		&i.RefundSessionID,
+		&i.RefundRecoveryID,
 		&i.Preimage,
 		&i.InterventionReason,
 		&i.CreatedAtUnix,
@@ -50,7 +51,7 @@ func (q *Queries) GetPaySwap(ctx context.Context, paymentHash []byte) (PaySwap, 
 }
 
 const GetReceiveSwap = `-- name: GetReceiveSwap :one
-SELECT payment_hash, amount_sat, payer_fee_msat, state, invoice, preimage, deadline_unix, client_pubkey, payment_addr, operator_pubkey, swap_server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, vhtlc_pkscript, vhtlc_policy_template, vhtlc_outpoint, vhtlc_amount, pending_htlc_ack_cursor, claim_receive_pubkey, claim_receive_pkscript, claim_session_id, intervention_reason, created_at_unix, updated_at_unix FROM receive_swaps
+SELECT payment_hash, amount_sat, payer_fee_msat, state, invoice, preimage, deadline_unix, client_pubkey, payment_addr, operator_pubkey, swap_server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, vhtlc_pkscript, vhtlc_policy_template, vhtlc_outpoint, vhtlc_amount, pending_htlc_ack_cursor, claim_receive_pubkey, claim_receive_pkscript, claim_session_id, claim_recovery_id, intervention_reason, created_at_unix, updated_at_unix FROM receive_swaps
 WHERE payment_hash = $1
 LIMIT 1
 `
@@ -82,6 +83,7 @@ func (q *Queries) GetReceiveSwap(ctx context.Context, paymentHash []byte) (Recei
 		&i.ClaimReceivePubkey,
 		&i.ClaimReceivePkscript,
 		&i.ClaimSessionID,
+		&i.ClaimRecoveryID,
 		&i.InterventionReason,
 		&i.CreatedAtUnix,
 		&i.UpdatedAtUnix,
@@ -90,7 +92,7 @@ func (q *Queries) GetReceiveSwap(ctx context.Context, paymentHash []byte) (Recei
 }
 
 const ListPaySwaps = `-- name: ListPaySwaps :many
-SELECT payment_hash, invoice, max_fee_sat, state, amount_sat, fee_sat, expiry_unix, client_pubkey, operator_pubkey, server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, vhtlc_pkscript, vhtlc_policy_template, vhtlc_outpoint, vhtlc_amount, funding_session_id, refund_receive_pubkey, refund_receive_pkscript, refund_session_id, preimage, intervention_reason, created_at_unix, updated_at_unix FROM pay_swaps
+SELECT payment_hash, invoice, max_fee_sat, state, amount_sat, fee_sat, expiry_unix, client_pubkey, operator_pubkey, server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, vhtlc_pkscript, vhtlc_policy_template, vhtlc_outpoint, vhtlc_amount, funding_session_id, refund_receive_pubkey, refund_receive_pkscript, refund_session_id, refund_recovery_id, preimage, intervention_reason, created_at_unix, updated_at_unix FROM pay_swaps
 ORDER BY created_at_unix ASC
 `
 
@@ -126,6 +128,7 @@ func (q *Queries) ListPaySwaps(ctx context.Context) ([]PaySwap, error) {
 			&i.RefundReceivePubkey,
 			&i.RefundReceivePkscript,
 			&i.RefundSessionID,
+			&i.RefundRecoveryID,
 			&i.Preimage,
 			&i.InterventionReason,
 			&i.CreatedAtUnix,
@@ -145,7 +148,7 @@ func (q *Queries) ListPaySwaps(ctx context.Context) ([]PaySwap, error) {
 }
 
 const ListPendingPaySwaps = `-- name: ListPendingPaySwaps :many
-SELECT payment_hash, invoice, max_fee_sat, state, amount_sat, fee_sat, expiry_unix, client_pubkey, operator_pubkey, server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, vhtlc_pkscript, vhtlc_policy_template, vhtlc_outpoint, vhtlc_amount, funding_session_id, refund_receive_pubkey, refund_receive_pkscript, refund_session_id, preimage, intervention_reason, created_at_unix, updated_at_unix FROM pay_swaps
+SELECT payment_hash, invoice, max_fee_sat, state, amount_sat, fee_sat, expiry_unix, client_pubkey, operator_pubkey, server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, vhtlc_pkscript, vhtlc_policy_template, vhtlc_outpoint, vhtlc_amount, funding_session_id, refund_receive_pubkey, refund_receive_pkscript, refund_session_id, refund_recovery_id, preimage, intervention_reason, created_at_unix, updated_at_unix FROM pay_swaps
 WHERE state NOT IN (
     'Completed', 'Expired', 'Refunded', 'NeedsIntervention', 'Failed'
 )
@@ -184,6 +187,7 @@ func (q *Queries) ListPendingPaySwaps(ctx context.Context) ([]PaySwap, error) {
 			&i.RefundReceivePubkey,
 			&i.RefundReceivePkscript,
 			&i.RefundSessionID,
+			&i.RefundRecoveryID,
 			&i.Preimage,
 			&i.InterventionReason,
 			&i.CreatedAtUnix,
@@ -203,7 +207,7 @@ func (q *Queries) ListPendingPaySwaps(ctx context.Context) ([]PaySwap, error) {
 }
 
 const ListPendingReceiveSwaps = `-- name: ListPendingReceiveSwaps :many
-SELECT payment_hash, amount_sat, payer_fee_msat, state, invoice, preimage, deadline_unix, client_pubkey, payment_addr, operator_pubkey, swap_server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, vhtlc_pkscript, vhtlc_policy_template, vhtlc_outpoint, vhtlc_amount, pending_htlc_ack_cursor, claim_receive_pubkey, claim_receive_pkscript, claim_session_id, intervention_reason, created_at_unix, updated_at_unix FROM receive_swaps
+SELECT payment_hash, amount_sat, payer_fee_msat, state, invoice, preimage, deadline_unix, client_pubkey, payment_addr, operator_pubkey, swap_server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, vhtlc_pkscript, vhtlc_policy_template, vhtlc_outpoint, vhtlc_amount, pending_htlc_ack_cursor, claim_receive_pubkey, claim_receive_pkscript, claim_session_id, claim_recovery_id, intervention_reason, created_at_unix, updated_at_unix FROM receive_swaps
 WHERE state NOT IN ('Completed', 'Expired', 'NeedsIntervention', 'Failed')
 ORDER BY created_at_unix ASC
 `
@@ -241,6 +245,7 @@ func (q *Queries) ListPendingReceiveSwaps(ctx context.Context) ([]ReceiveSwap, e
 			&i.ClaimReceivePubkey,
 			&i.ClaimReceivePkscript,
 			&i.ClaimSessionID,
+			&i.ClaimRecoveryID,
 			&i.InterventionReason,
 			&i.CreatedAtUnix,
 			&i.UpdatedAtUnix,
@@ -259,7 +264,7 @@ func (q *Queries) ListPendingReceiveSwaps(ctx context.Context) ([]ReceiveSwap, e
 }
 
 const ListReceiveSwaps = `-- name: ListReceiveSwaps :many
-SELECT payment_hash, amount_sat, payer_fee_msat, state, invoice, preimage, deadline_unix, client_pubkey, payment_addr, operator_pubkey, swap_server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, vhtlc_pkscript, vhtlc_policy_template, vhtlc_outpoint, vhtlc_amount, pending_htlc_ack_cursor, claim_receive_pubkey, claim_receive_pkscript, claim_session_id, intervention_reason, created_at_unix, updated_at_unix FROM receive_swaps
+SELECT payment_hash, amount_sat, payer_fee_msat, state, invoice, preimage, deadline_unix, client_pubkey, payment_addr, operator_pubkey, swap_server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, vhtlc_pkscript, vhtlc_policy_template, vhtlc_outpoint, vhtlc_amount, pending_htlc_ack_cursor, claim_receive_pubkey, claim_receive_pkscript, claim_session_id, claim_recovery_id, intervention_reason, created_at_unix, updated_at_unix FROM receive_swaps
 ORDER BY created_at_unix ASC
 `
 
@@ -296,6 +301,7 @@ func (q *Queries) ListReceiveSwaps(ctx context.Context) ([]ReceiveSwap, error) {
 			&i.ClaimReceivePubkey,
 			&i.ClaimReceivePkscript,
 			&i.ClaimSessionID,
+			&i.ClaimRecoveryID,
 			&i.InterventionReason,
 			&i.CreatedAtUnix,
 			&i.UpdatedAtUnix,
@@ -337,13 +343,14 @@ INSERT INTO pay_swaps (
     refund_receive_pubkey,
     refund_receive_pkscript,
     refund_session_id,
+    refund_recovery_id,
     preimage,
     intervention_reason,
     created_at_unix,
     updated_at_unix
 ) VALUES (
     $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16,
-    $17, $18, $19, $20, $21, $22, $23, $24, $25, $26
+    $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27
 )
 ON CONFLICT (payment_hash) DO UPDATE SET
     invoice = EXCLUDED.invoice,
@@ -368,6 +375,7 @@ ON CONFLICT (payment_hash) DO UPDATE SET
     refund_receive_pubkey = EXCLUDED.refund_receive_pubkey,
     refund_receive_pkscript = EXCLUDED.refund_receive_pkscript,
     refund_session_id = EXCLUDED.refund_session_id,
+    refund_recovery_id = EXCLUDED.refund_recovery_id,
     preimage = EXCLUDED.preimage,
     intervention_reason = EXCLUDED.intervention_reason,
     updated_at_unix = EXCLUDED.updated_at_unix
@@ -396,6 +404,7 @@ type UpsertPaySwapParams struct {
 	RefundReceivePubkey                  []byte
 	RefundReceivePkscript                []byte
 	RefundSessionID                      string
+	RefundRecoveryID                     string
 	Preimage                             []byte
 	InterventionReason                   string
 	CreatedAtUnix                        int64
@@ -426,6 +435,7 @@ func (q *Queries) UpsertPaySwap(ctx context.Context, arg UpsertPaySwapParams) er
 		arg.RefundReceivePubkey,
 		arg.RefundReceivePkscript,
 		arg.RefundSessionID,
+		arg.RefundRecoveryID,
 		arg.Preimage,
 		arg.InterventionReason,
 		arg.CreatedAtUnix,
@@ -459,12 +469,13 @@ INSERT INTO receive_swaps (
     claim_receive_pubkey,
     claim_receive_pkscript,
     claim_session_id,
+    claim_recovery_id,
     intervention_reason,
     created_at_unix,
     updated_at_unix
 ) VALUES (
     $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15,
-    $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26
+    $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27
 )
 ON CONFLICT (payment_hash) DO UPDATE SET
     amount_sat = EXCLUDED.amount_sat,
@@ -490,6 +501,7 @@ ON CONFLICT (payment_hash) DO UPDATE SET
     claim_receive_pubkey = EXCLUDED.claim_receive_pubkey,
     claim_receive_pkscript = EXCLUDED.claim_receive_pkscript,
     claim_session_id = EXCLUDED.claim_session_id,
+    claim_recovery_id = EXCLUDED.claim_recovery_id,
     intervention_reason = EXCLUDED.intervention_reason,
     updated_at_unix = EXCLUDED.updated_at_unix
 `
@@ -518,6 +530,7 @@ type UpsertReceiveSwapParams struct {
 	ClaimReceivePubkey                   []byte
 	ClaimReceivePkscript                 []byte
 	ClaimSessionID                       string
+	ClaimRecoveryID                      string
 	InterventionReason                   string
 	CreatedAtUnix                        int64
 	UpdatedAtUnix                        int64
@@ -548,6 +561,7 @@ func (q *Queries) UpsertReceiveSwap(ctx context.Context, arg UpsertReceiveSwapPa
 		arg.ClaimReceivePubkey,
 		arg.ClaimReceivePkscript,
 		arg.ClaimSessionID,
+		arg.ClaimRecoveryID,
 		arg.InterventionReason,
 		arg.CreatedAtUnix,
 		arg.UpdatedAtUnix,

--- a/sdk/swaps/store_sessions.go
+++ b/sdk/swaps/store_sessions.go
@@ -1,6 +1,7 @@
 package swaps
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"errors"
@@ -256,6 +257,45 @@ func (c *SwapClient) ListPendingPaySessions(ctx context.Context) ([]*PaySession,
 	return sessions, nil
 }
 
+// ResolvePreimage loads the swap-owned raw preimage for daemon claim recovery.
+// The vHTLC recovery row stores only preimage_hash plus swap_id; sdk/swaps uses
+// the Lightning payment hash as swap_id, so this resolver verifies both
+// identifiers before returning the durable receive-session preimage.
+func (s *Store) ResolvePreimage(ctx context.Context, swapID []byte,
+	preimageHash lntypes.Hash) (lntypes.Preimage, error) {
+
+	if s == nil || s.queries == nil {
+		return lntypes.Preimage{}, fmt.Errorf("swap store is not " +
+			"configured")
+	}
+	if len(swapID) != 0 && !bytes.Equal(swapID, preimageHash[:]) {
+		return lntypes.Preimage{}, fmt.Errorf("swap id does not " +
+			"match preimage hash")
+	}
+
+	row, err := s.queries.GetReceiveSwap(ctx, preimageHash[:])
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return lntypes.Preimage{}, fmt.Errorf("receive swap " +
+				"preimage not found")
+		}
+
+		return lntypes.Preimage{}, fmt.Errorf("load receive swap "+
+			"preimage: %w", err)
+	}
+
+	preimage, err := preimageFromBytes(row.Preimage)
+	if err != nil {
+		return lntypes.Preimage{}, err
+	}
+	if !preimage.Matches(preimageHash) {
+		return lntypes.Preimage{}, fmt.Errorf("receive swap preimage " +
+			"does not match requested hash")
+	}
+
+	return preimage, nil
+}
+
 // paySummaryFromRow converts one persisted pay row into the public list view.
 func paySummaryFromRow(row swapsqlc.PaySwap) (SwapSummary, error) {
 	state, err := parsePayState(row.State)
@@ -435,6 +475,7 @@ func (s *ReceiveSession) persist(ctx context.Context) error {
 		ClaimReceivePubkey:   cloneBytesOrEmpty(s.claimReceivePubKey),
 		ClaimReceivePkscript: cloneBytesOrEmpty(s.claimReceiveScript),
 		ClaimSessionID:       s.claimSessionID,
+		ClaimRecoveryID:      s.claimRecoveryID,
 		InterventionReason:   s.interventionReason,
 		CreatedAtUnix:        s.createdAt.Unix(),
 		UpdatedAtUnix:        now,
@@ -566,6 +607,7 @@ func (s *paySession) persist(ctx context.Context) error {
 			[]byte(nil), s.refundReceiveScript...,
 		),
 		RefundSessionID:    s.refundSessionID,
+		RefundRecoveryID:   s.refundRecoveryID,
 		InterventionReason: s.interventionReason,
 		CreatedAtUnix:      s.createdAt.Unix(),
 		UpdatedAtUnix:      now,
@@ -694,6 +736,7 @@ func receiveSessionFromRow(c *SwapClient,
 			[]byte(nil), row.ClaimReceivePkscript...,
 		),
 		claimSessionID:     row.ClaimSessionID,
+		claimRecoveryID:    row.ClaimRecoveryID,
 		interventionReason: row.InterventionReason,
 		clientPubKey:       clientKey,
 		operatorPubKey:     operatorKey,
@@ -790,6 +833,7 @@ func paySessionFromRow(c *SwapClient,
 			[]byte(nil), row.RefundReceivePkscript...,
 		),
 		refundSessionID:    row.RefundSessionID,
+		refundRecoveryID:   row.RefundRecoveryID,
 		interventionReason: row.InterventionReason,
 		clientPubKey:       clientKey,
 		operatorPubKey:     operatorKey,

--- a/swapclientserver/service.go
+++ b/swapclientserver/service.go
@@ -300,6 +300,15 @@ func newSwapClientService(ctx context.Context, rpcServer *darepod.RPCServer,
 	if err != nil {
 		return nil, nil, fmt.Errorf("open swap store: %w", err)
 	}
+	if err := rpcServer.RegisterVHTLCRecoveryPreimageResolver(
+		store,
+	); err != nil {
+
+		_ = store.Close()
+
+		return nil, nil, fmt.Errorf("register recovery preimage "+
+			"resolver: %w", err)
+	}
 
 	swapAddr := cfg.ServerAddress
 	if swapAddr == "" {

--- a/swapclientserver/service.go
+++ b/swapclientserver/service.go
@@ -278,7 +278,7 @@ func newSwapClientService(ctx context.Context, rpcServer *darepod.RPCServer,
 
 	cfg := daemonCfg.Swap
 	if cfg == nil {
-		cfg = &darepod.SwapConfig{}
+		cfg = darepod.DefaultConfig().Swap
 	}
 
 	dbPath := cfg.DatabaseFileName
@@ -366,6 +366,14 @@ func newSwapClientService(ctx context.Context, rpcServer *darepod.RPCServer,
 		swapClients.server, arkClient, log, invoiceGen, store,
 	)
 	swapClient.SetChainParams(chainParams)
+	recoveryCfg := cfg.VHTLCRecovery
+	swapClient.SetRecoveryPolicy(swaps.RecoveryPolicy{
+		AutoEscalate: recoveryCfg.AutoEscalate,
+		CooperativeFailureGracePeriod: recoveryCfg.
+			CooperativeFailureGracePeriod,
+		MinRecoveryMarginBlocks: recoveryCfg.MinRecoveryMarginBlocks,
+		MaxFeeRateSatPerKW:      recoveryCfg.MaxFeeRateSatPerKW,
+	})
 
 	// The out-swap event receiver must be wired before any
 	// ReceiveViaLightning starts: SwapClient captures the receiver into the

--- a/swapclientserver/service_test.go
+++ b/swapclientserver/service_test.go
@@ -251,7 +251,12 @@ func TestSwapSummaryToProtoCopiesDurableFields(t *testing.T) {
 	require.Equal(t, uint32(42), got.GetRefundLocktime())
 }
 
-func TestNewSwapClientServiceUsesDaemonBackedReceiveAuth(t *testing.T) {
+// TestNewSwapClientServiceRequiresRecoveryPreimageRegistry verifies that the
+// swap runtime service does not start when the daemon-side vHTLC recovery
+// preimage registry is unavailable. Claim recovery depends on this registration
+// to look up swap-owned preimages after restart, so accepting a nil daemon
+// backend would make recovery appear armed while it could not actually claim.
+func TestNewSwapClientServiceRequiresRecoveryPreimageRegistry(t *testing.T) {
 	t.Parallel()
 
 	rpcServer := darepod.NewRPCServer(nil)
@@ -267,13 +272,10 @@ func TestNewSwapClientServiceUsesDaemonBackedReceiveAuth(t *testing.T) {
 	service, cleanup, err := newSwapClientService(
 		t.Context(), rpcServer, daemonCfg,
 	)
-	require.NoError(t, err)
-	require.NotNil(t, service)
-	require.NotNil(t, cleanup)
-	t.Cleanup(cleanup)
-
-	_, ok := service.client.(*swapClientAdapter)
-	require.True(t, ok)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "register recovery preimage resolver")
+	require.Nil(t, service)
+	require.Nil(t, cleanup)
 }
 
 func TestNewSwapServerClientsREST(t *testing.T) {
@@ -362,11 +364,12 @@ func TestNewSwapServerClientsREST(t *testing.T) {
 	require.NoError(t, err)
 
 	hint, err := clients.server.RequestChannelID(
-		t.Context(), clientPriv.PubKey(), lntypes.Hash{1}, 30,
+		t.Context(), clientPriv.PubKey(), lntypes.Hash{1},
+		btcutil.Amount(42_000), 30,
 	)
 	require.NoError(t, err)
-	require.Equal(t, uint64(42), hint.ChannelID)
-	require.Equal(t, nodeID, hint.NodeID)
+	require.Equal(t, uint64(42), hint.RouteHint.ChannelID)
+	require.Equal(t, nodeID, hint.RouteHint.NodeID)
 
 	_, err = clients.mailbox.Pull(
 		t.Context(), &mailboxpb.PullRequest{

--- a/vhtlcrecovery/coordinator/service.go
+++ b/vhtlcrecovery/coordinator/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/lightninglabs/darepo-client/unroll"
 	"github.com/lightninglabs/darepo-client/vhtlcrecovery"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/lntypes"
 )
 
 var errUnrollPolicyMismatch = errors.New("unroll policy mismatch")
@@ -39,7 +40,8 @@ type Store interface {
 	ListRecoveries(ctx context.Context) ([]vhtlcrecovery.RecoveryJob, error)
 
 	// EscalateRecovery moves an armed recovery row into active unroll.
-	EscalateRecovery(ctx context.Context, id string) error
+	EscalateRecovery(ctx context.Context, id string,
+		claimPreimage []byte) error
 
 	// CancelRecovery records that cooperative settlement or operator action
 	// made an unspent recovery job unnecessary.
@@ -223,11 +225,14 @@ func (s *Service) ArmRecovery(ctx context.Context,
 // generic unroll registry has a child job with this recovery id as its policy
 // reference. The SQL transition happens before unroll admission so a crash in
 // the handoff is recovered by RestoreNonTerminal.
-func (s *Service) EscalateRecovery(ctx context.Context, id, reason string) (
-	*RecoveryStatus, error) {
+func (s *Service) EscalateRecovery(ctx context.Context, id, reason string,
+	claimPreimage []byte) (*RecoveryStatus, error) {
 
 	job, err := s.store.GetRecovery(ctx, id)
 	if err != nil {
+		return nil, err
+	}
+	if err := validateClaimPreimage(*job, claimPreimage); err != nil {
 		return nil, err
 	}
 
@@ -243,7 +248,9 @@ func (s *Service) EscalateRecovery(ctx context.Context, id, reason string) (
 			)...,
 		)
 
-		if err := s.store.EscalateRecovery(ctx, id); err != nil {
+		if err := s.store.EscalateRecovery(
+			ctx, id, claimPreimage,
+		); err != nil {
 			return nil, err
 		}
 
@@ -267,6 +274,35 @@ func (s *Service) EscalateRecovery(ctx context.Context, id, reason string) (
 	}
 
 	return s.GetRecoveryStatus(ctx, id)
+}
+
+// validateClaimPreimage verifies optional cross-process claim preimage material
+// before it is written into the recovery row. In-process swap runtimes may pass
+// nil and let the registered preimage resolver provide the secret later.
+func validateClaimPreimage(job vhtlcrecovery.RecoveryJob,
+	claimPreimage []byte) error {
+
+	if len(claimPreimage) == 0 {
+		return nil
+	}
+	if job.Action != vhtlcrecovery.ActionClaim {
+		return fmt.Errorf("claim preimage is only valid for claim " +
+			"recovery")
+	}
+
+	preimage, err := lntypes.MakePreimage(claimPreimage)
+	if err != nil {
+		return fmt.Errorf("decode claim preimage: %w", err)
+	}
+	preimageHash, err := lntypes.MakeHash(job.PreimageHash)
+	if err != nil {
+		return fmt.Errorf("decode preimage hash: %w", err)
+	}
+	if !preimage.Matches(preimageHash) {
+		return fmt.Errorf("claim preimage does not match recovery hash")
+	}
+
+	return nil
 }
 
 // CancelRecovery marks a non-terminal recovery cancelled. This method is

--- a/vhtlcrecovery/coordinator/service_test.go
+++ b/vhtlcrecovery/coordinator/service_test.go
@@ -34,7 +34,7 @@ func TestServiceEscalatePersistsBeforeUnroll(t *testing.T) {
 	service := newTestService(t, store, registry)
 
 	status, err := service.EscalateRecovery(
-		t.Context(), job.ID, "cooperative path unsafe",
+		t.Context(), job.ID, "cooperative path unsafe", nil,
 	)
 	require.NoError(t, err)
 	require.Equal(t, vhtlcrecovery.StateUnrollStarted, status.Job.State)
@@ -67,7 +67,7 @@ func TestServiceEscalateFailsClosedOnPolicyMismatch(t *testing.T) {
 	service := newTestService(t, store, registry)
 
 	_, err := service.EscalateRecovery(
-		t.Context(), job.ID, "cooperative path unsafe",
+		t.Context(), job.ID, "cooperative path unsafe", nil,
 	)
 	require.ErrorContains(t, err, "unroll policy kind")
 
@@ -91,7 +91,7 @@ func TestServiceEscalateKeepsRecoveryActiveAfterStatusProbeError(t *testing.T) {
 	service := newTestService(t, store, registry)
 
 	_, err := service.EscalateRecovery(
-		t.Context(), job.ID, "cooperative path unsafe",
+		t.Context(), job.ID, "cooperative path unsafe", nil,
 	)
 	require.ErrorContains(t, err, "status probe timed out")
 	require.Len(t, registry.ensureRequests, 1)
@@ -201,6 +201,38 @@ func TestServiceStatusReconcilesTerminalUnroll(t *testing.T) {
 	)
 	store := newFakeStore(job)
 	sweepTxid := chainhash.Hash{1, 2, 3}
+	registry := &fakeUnrollRegistry{
+		status: &unroll.GetStatusResp{
+			Found:     true,
+			Phase:     unroll.PhaseCompleted,
+			SweepTxid: &sweepTxid,
+			ExitPolicyKind: unroll.ExitPolicyKind(
+				job.ExitPolicyKind,
+			),
+			ExitPolicyRef: job.ID,
+		},
+	}
+	service := newTestService(t, store, registry)
+
+	status, err := service.GetRecoveryStatus(t.Context(), job.ID)
+	require.NoError(t, err)
+	require.Equal(t, vhtlcrecovery.StateCompleted, status.Job.State)
+	require.True(t, status.UnrollFound)
+	require.Equal(t, unroll.PhaseCompleted, status.UnrollPhase)
+	require.Equal(t, &sweepTxid, status.UnrollSweep)
+}
+
+// TestServiceCompletedStatusKeepsUnrollSweep verifies a recovery row that was
+// already marked completed by an earlier status poll still joins the terminal
+// unroll snapshot so RPC callers can observe the sweep txid deterministically.
+func TestServiceCompletedStatusKeepsUnrollSweep(t *testing.T) {
+	t.Parallel()
+
+	job := testRecoveryJob(
+		"recovery-already-complete", vhtlcrecovery.StateCompleted,
+	)
+	store := newFakeStore(job)
+	sweepTxid := chainhash.Hash{4, 5, 6}
 	registry := &fakeUnrollRegistry{
 		status: &unroll.GetStatusResp{
 			Found:     true,
@@ -355,12 +387,15 @@ func (s *fakeStore) ListRecoveries(context.Context) (
 }
 
 // EscalateRecovery implements Store by moving an armed job to unroll_started.
-func (s *fakeStore) EscalateRecovery(_ context.Context, id string) error {
+func (s *fakeStore) EscalateRecovery(_ context.Context, id string,
+	claimPreimage []byte) error {
+
 	job, ok := s.jobs[id]
 	if !ok {
 		return fmt.Errorf("missing recovery %s", id)
 	}
 	job.State = vhtlcrecovery.StateUnrollStarted
+	job.ClaimPreimage = append([]byte(nil), claimPreimage...)
 	s.jobs[id] = job
 	s.events = append(s.events, "escalate")
 
@@ -459,6 +494,8 @@ func cloneRecoveryJob(
 
 	clone := job
 	clone.SwapID = append([]byte(nil), job.SwapID...)
+	clone.PreimageHash = append([]byte(nil), job.PreimageHash...)
+	clone.ClaimPreimage = append([]byte(nil), job.ClaimPreimage...)
 	clone.CooperativeTxid = append([]byte(nil), job.CooperativeTxid...)
 
 	return &clone

--- a/vhtlcrecovery/types.go
+++ b/vhtlcrecovery/types.go
@@ -112,26 +112,31 @@ type RecoveryJob struct {
 	UnilateralClaimDelay                 int32
 	UnilateralRefundDelay                int32
 	UnilateralRefundWithoutReceiverDelay int32
-	PreimageHash                         []byte
-	SignerKeyFamily                      int32
-	SignerKeyIndex                       int32
-	DestinationScript                    []byte
-	MaxFeeRateSatPerKWeight              int32
-	UnrollTargetOutpoint                 *wire.OutPoint
-	ExitPolicyKind                       string
-	ExitTx                               []byte
-	ExitTxid                             []byte
-	CooperativeTxid                      []byte
-	LastError                            string
-	CancelReason                         string
-	CreatedAt                            time.Time
-	UpdatedAt                            time.Time
-	ArmedAt                              *time.Time
-	EscalatedAt                          *time.Time
-	TargetDetectedAt                     *time.Time
-	ExitTxBuiltAt                        *time.Time
-	ExitTxBroadcastAt                    *time.Time
-	TerminalAt                           *time.Time
+	// PreimageHash is the vHTLC payment hash. It is safe to log and index.
+	PreimageHash []byte
+	// ClaimPreimage is populated only for cross-process claim recovery
+	// where the daemon cannot resolve swap-owned state through an
+	// in-process resolver. The value must never be logged.
+	ClaimPreimage           []byte
+	SignerKeyFamily         int32
+	SignerKeyIndex          int32
+	DestinationScript       []byte
+	MaxFeeRateSatPerKWeight int32
+	UnrollTargetOutpoint    *wire.OutPoint
+	ExitPolicyKind          string
+	ExitTx                  []byte
+	ExitTxid                []byte
+	CooperativeTxid         []byte
+	LastError               string
+	CancelReason            string
+	CreatedAt               time.Time
+	UpdatedAt               time.Time
+	ArmedAt                 *time.Time
+	EscalatedAt             *time.Time
+	TargetDetectedAt        *time.Time
+	ExitTxBuiltAt           *time.Time
+	ExitTxBroadcastAt       *time.Time
+	TerminalAt              *time.Time
 }
 
 // IsTerminal reports whether the job is in a terminal state.

--- a/vhtlcrecovery/unrollpolicy/AGENTS.md
+++ b/vhtlcrecovery/unrollpolicy/AGENTS.md
@@ -25,9 +25,10 @@ parent package.
 
 ## Invariants
 
-- The raw preimage is not stored on the recovery row. Claim recovery resolves it
-  from the swap-owned state and checks it against `preimage_hash` before
-  building a spend.
+- The raw preimage must never be logged. Claim recovery first uses durable
+  `claim_preimage` when cross-process escalation supplied it, otherwise it
+  resolves from the swap-owned in-process preimage resolver and checks it
+  against `preimage_hash` before building a spend.
 - `ValidateTarget` must confirm the materialized output matches the recovered
   vHTLC policy before any final spend is built.
 - `refund_without_receiver` spends must carry both Ark CSV (`nSequence`) and

--- a/vhtlcrecovery/unrollpolicy/policy.go
+++ b/vhtlcrecovery/unrollpolicy/policy.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
@@ -38,6 +39,52 @@ type PreimageResolver interface {
 	// resolver must verify the returned preimage matches preimageHash.
 	ResolvePreimage(ctx context.Context, swapID []byte,
 		preimageHash lntypes.Hash) (lntypes.Preimage, error)
+}
+
+// PreimageResolverRegistry is a concurrency-safe indirection point for the
+// daemon's optional swap runtime. The unroll subsystem is initialized before
+// the swapruntime subserver registers its swap store, so the recovery policy
+// resolver holds this registry and the subserver installs the concrete
+// swap-owned preimage resolver later in startup.
+type PreimageResolverRegistry struct {
+	mu       sync.RWMutex
+	resolver PreimageResolver
+}
+
+// SetResolver installs or replaces the concrete swap-owned preimage resolver.
+// Passing nil deliberately disables claim recovery resolution until another
+// resolver is registered.
+func (r *PreimageResolverRegistry) SetResolver(resolver PreimageResolver) {
+	if r == nil {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.resolver = resolver
+}
+
+// ResolvePreimage delegates to the currently registered resolver. If no
+// resolver has been installed, claim recovery fails closed instead of building
+// a spend without the swap-owned secret.
+func (r *PreimageResolverRegistry) ResolvePreimage(ctx context.Context,
+	swapID []byte, preimageHash lntypes.Hash) (lntypes.Preimage, error) {
+
+	if r == nil {
+		return lntypes.Preimage{}, fmt.Errorf("preimage resolver " +
+			"registry must be provided")
+	}
+
+	r.mu.RLock()
+	resolver := r.resolver
+	r.mu.RUnlock()
+	if resolver == nil {
+		return lntypes.Preimage{}, fmt.Errorf("preimage resolver is " +
+			"not registered")
+	}
+
+	return resolver.ResolvePreimage(ctx, swapID, preimageHash)
 }
 
 // ExitSpendPolicyResolver resolves durable vHTLC recovery policy refs for
@@ -89,18 +136,13 @@ func (r ExitSpendPolicyResolver) ResolveExitSpendPolicy(ctx context.Context,
 
 	switch string(req.Kind) {
 	case vhtlcrecovery.ExitPolicyKindClaim:
-		if r.Preimage == nil {
-			return nil, fmt.Errorf("preimage resolver must be " +
-				"provided for vhtlc claim recovery")
-		}
-
 		preimageHash, err := preimageHashFromJob(*job)
 		if err != nil {
 			return nil, err
 		}
 
-		preimage, err := r.Preimage.ResolvePreimage(
-			ctx, job.SwapID, preimageHash,
+		preimage, err := r.resolveClaimPreimage(
+			ctx, *job, preimageHash,
 		)
 		if err != nil {
 			return nil, err
@@ -115,6 +157,35 @@ func (r ExitSpendPolicyResolver) ResolveExitSpendPolicy(ctx context.Context,
 		return nil, fmt.Errorf("unknown vhtlc exit policy kind: %s",
 			req.Kind)
 	}
+}
+
+// resolveClaimPreimage returns the secret needed for the unilateral claim
+// witness. Cross-process callers may persist it on the recovery row during
+// escalation; in-process swap runtimes keep it in their swap store and provide
+// it through the registered resolver.
+func (r ExitSpendPolicyResolver) resolveClaimPreimage(ctx context.Context,
+	job vhtlcrecovery.RecoveryJob, preimageHash lntypes.Hash) (
+	lntypes.Preimage, error) {
+
+	if len(job.ClaimPreimage) != 0 {
+		preimage, err := lntypes.MakePreimage(job.ClaimPreimage)
+		if err != nil {
+			return lntypes.Preimage{}, fmt.Errorf("decode claim "+
+				"preimage: %w", err)
+		}
+		if !preimage.Matches(preimageHash) {
+			return lntypes.Preimage{}, fmt.Errorf("claim " +
+				"preimage does not match recovery hash")
+		}
+
+		return preimage, nil
+	}
+	if r.Preimage == nil {
+		return lntypes.Preimage{}, fmt.Errorf("preimage resolver " +
+			"must be provided for vhtlc claim recovery")
+	}
+
+	return r.Preimage.ResolvePreimage(ctx, job.SwapID, preimageHash)
 }
 
 // VHTLCExitSpendPolicy builds the final script-path spend for one recovery

--- a/vhtlcrecovery/unrollpolicy/policy_test.go
+++ b/vhtlcrecovery/unrollpolicy/policy_test.go
@@ -288,6 +288,33 @@ func TestExitSpendPolicyResolver(t *testing.T) {
 	require.ErrorContains(t, err, "does not match request kind")
 }
 
+// TestExitSpendPolicyResolverUsesDurableClaimPreimage verifies cross-process
+// recovery can build a claim policy from the preimage stored on the recovery
+// row without requiring an in-process swap preimage resolver.
+func TestExitSpendPolicyResolverUsesDurableClaimPreimage(t *testing.T) {
+	t.Parallel()
+
+	job, preimage, _, _ := testPolicyJob(t, vhtlcrecovery.ActionClaim)
+	job.ClaimPreimage = preimage[:]
+	resolver := ExitSpendPolicyResolver{
+		Jobs: fakeRecoveryJobLoader{
+			job.ID: job,
+		},
+	}
+
+	policy, err := resolver.ResolveExitSpendPolicy(
+		t.Context(), unroll.ExitSpendPolicyRequest{
+			Kind: vhtlcrecovery.ExitPolicyKindClaim,
+			Ref:  job.ID,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(
+		t, unroll.ExitPolicyKind(vhtlcrecovery.ExitPolicyKindClaim),
+		policy.Kind(),
+	)
+}
+
 // testPolicyJob returns a fully populated recovery job and matching test
 // signers for the requested recovery action. The row mirrors the named SQL
 // columns the production adapter reconstructs.


### PR DESCRIPTION
## Summary

This is PR 3 of the four-PR vHTLC recovery stack, based on #485. It wires the SDK swap FSMs into the durable vHTLC recovery API added by PR2.

The main behavior is intentionally conservative: recovery rows are armed early, while costly on-chain unroll is gated behind an explicit recovery policy. Cooperative OOR settlement remains the preferred path. If cooperative settlement is temporarily unavailable because the operator, mailbox path, or daemon is down, the SDK now keeps retrying during the configured grace period instead of immediately escalating every swap to unilateral recovery.

The pay-side Ark-to-Lightning flow now arms a refund-without-receiver recovery row once the funded vHTLC is durably observed. If the cooperative refund path wins, the SDK cancels the dormant recovery row. If cooperative refund keeps failing after the policy allows escalation, the SDK escalates the pre-armed row into daemon-owned unroll and polls recovery status instead of reconstructing recovery context under pressure.

The receive-side Lightning-to-Ark flow now arms a claim recovery row once the funded vHTLC is observed or manually recorded. The raw preimage remains owned by the swap row; the daemon recovery row stores only the preimage hash and resolves the preimage through the swap store when the swapruntime subserver is present. Cooperative claim success cancels the dormant recovery row. Claim-send failure follows the configured recovery policy: retry cooperatively during the grace period, but override the wait near the refund-locktime deadline so the receiver does not lose the chance to claim.

## What changed

- Persist daemon recovery IDs on `receive_swaps` and `pay_swaps`, with sqlc regeneration.
- Add SDK/Ark wrappers and `sdk/swaps.DaemonConn` methods for arm, escalate, cancel, and status RPCs.
- Add SDK recovery helpers for deterministic request IDs, signer locator selection, arm/cancel/escalate/status handling, recovery polling, and policy-gated escalation.
- Register a swap-store preimage resolver with `darepod` through the optional `swapruntime` subserver so claim recovery can resolve the swap-owned preimage without making daemon core import `sdk/swaps`.
- Arm pay refund and receive claim recovery rows at the funded-vHTLC boundary.
- Cancel armed recovery rows when cooperative settlement wins.
- Gate recovery escalation when cooperative custom-input settlement fails, instead of immediately starting unroll on the first cooperative send error.
- Add manual `darepocli recovery` commands for operators and testers to inspect, escalate, or cancel an already-armed recovery row.
- Add `darepod` swapruntime config for automatic vHTLC recovery escalation policy, and document it in `sample-darepod.conf`.
- Extend swap tests to assert recovery arming/cancellation details on both pay and receive paths.
- Add policy tests that cover grace-period behavior, deadline-margin override, and explicit manual-only mode.

## Recovery policy and defaults

The SDK still arms recovery rows as soon as it has enough durable swap/vHTLC context. Arming is cheap and dormant. The new policy only controls when an already-armed row is escalated into daemon-owned on-chain unroll.

Default `darepod` swapruntime settings:

```conf
swap.vhtlcrecovery.autoescalate=true
swap.vhtlcrecovery.cooperativefailuregraceperiod=1h0m0s
swap.vhtlcrecovery.minrecoverymarginblocks=12
```

The semantics are:

- `swap.vhtlcrecovery.autoescalate=true` lets the SDK escalate automatically once the grace/deadline policy says waiting is no longer useful or safe.
- `swap.vhtlcrecovery.autoescalate=false` makes escalation manual-only. Recovery rows are still armed and visible through the recovery RPC/CLI, but the SDK will not start unroll by itself.
- `swap.vhtlcrecovery.cooperativefailuregraceperiod=1h0m0s` means the SDK waits one hour from the first observed cooperative send failure before automatic escalation may start.
- `swap.vhtlcrecovery.cooperativefailuregraceperiod=0s` is intentional immediate escalation after cooperative failure. The recovery-sweep itests use this so they continue to exercise the full on-chain path deterministically.
- `swap.vhtlcrecovery.minrecoverymarginblocks=12` lets receive-side claim recovery override the wall-clock grace period when the current height is within 12 blocks of the vHTLC refund locktime.

The code preserves an explicit `autoescalate=false` setting while still filling unset numeric safety fields. That avoids accidentally converting a manual-recovery policy back into automatic recovery during config defaulting.

## Manual recovery UX

This PR adds a focused `darepocli recovery` subtree for already-armed daemon-owned recovery rows:

```bash
darepocli recovery status <recovery_id>
darepocli recovery escalate <recovery_id> --reason "operator escalation"
darepocli recovery cancel <recovery_id> --reason "cooperative settlement won" --cooperative-txid <txid-or-session>
```

`escalate` also accepts `--claim-preimage-hex` for claim recoveries when the daemon cannot resolve the preimage from the registered swap store. Normal swapruntime flows should not need that flag because the swap row remains the system of record for the raw preimage.

The CLI uses the command context for RPCs, so Ctrl-C cancels in-flight calls. Responses are printed as protobuf JSON using stable proto field names for operator/debugging workflows.

## Logging and observability

When cooperative claim/refund sending fails, the SDK logs whether escalation was deferred or started, along with:

- `hash`
- `recovery_id`
- `reason`
- `trigger`
- `first_failure_at`
- `next_retry_at` when deferred by grace
- `current_height`
- `refund_locktime` and `remaining_blocks` for receive-side claim recovery
- `outpoint` and `amount_sat` when escalation starts

The original cooperative-send error is preserved as the structured log error, while the human-readable `reason` is stored/passed to the daemon recovery RPC.

## Reviewer notes

This PR keeps the separation from the design doc: `unroll` still owns Ark lineage materialization, `vhtlcrecovery` owns durable recovery rows, and `sdk/swaps` owns swap-specific timing and preimage ownership. The daemon recovery row does not store the raw preimage; only `preimage_hash` plus `swap_id` are passed into recovery storage.

The `swapruntime` registration is deliberately an indirection through `vhtlcrecovery/unrollpolicy.PreimageResolverRegistry`. `darepod` constructs unroll before the optional swap subserver is registered, and daemon core should not import `sdk/swaps` directly.

Clean-start assumption still applies: there are no existing swap rows to migrate, so this updates the initial swap-session migration rather than adding an upgrade migration.

## Validation

- `make fmt-changed-check`
- `make lint-local`
- `make sample-conf-check`
- `make schema-check`
- `go test ./sdk/swaps ./cmd/darepocli/darepoclicommands -run 'TestDecideRecoveryEscalation|Test.*Recovery' -count=1`
- `go test -tags swapruntime ./swapclientserver -run 'Test.*Service|Test.*Recovery' -count=1`
- Earlier stack validation for this PR also included `make commitmsg-lint range="codex/vhtlc-recovery-runtime..HEAD"`, `go test ./sdk/swaps ./sdk/ark ./darepod ./vhtlcrecovery/unrollpolicy`, `go test -tags swapruntime ./swapclientserver`, `make sqlc-check`, and a direct custom linter run equivalent to lint-native after a fresh linter rebuild path hung.
