### PR TITLE
walletcore: restore duplicate boarding imports

### DIFF
--- a/lwwallet/boarding_backend_test.go
+++ b/lwwallet/boarding_backend_test.go
@@ -28,30 +28,29 @@ func TestBoardingBackendDuplicateImportRestoresTracking(t *testing.T) {
 	}
 
 	tipHash := chaincfg.RegressionNetParams.GenesisHash.String()
-	esplora := httptest.NewServer(http.HandlerFunc(
-		func(w http.ResponseWriter, r *http.Request) {
-			switch r.URL.Path {
-			case "/blocks/tip/height":
-				_, err := w.Write([]byte("0"))
-				require.NoError(t, err)
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/blocks/tip/height":
+			_, err := w.Write([]byte("0"))
+			require.NoError(t, err)
 
-			case "/block-height/0":
-				_, err := w.Write([]byte(tipHash))
-				require.NoError(t, err)
+		case "/block-height/0":
+			_, err := w.Write([]byte(tipHash))
+			require.NoError(t, err)
 
-			case "/block/" + tipHash:
-				err := json.NewEncoder(w).Encode(esploraBlock{
-					ID:        tipHash,
-					Height:    0,
-					Timestamp: 1,
-				})
-				require.NoError(t, err)
+		case "/block/" + tipHash:
+			err := json.NewEncoder(w).Encode(esploraBlock{
+				ID:        tipHash,
+				Height:    0,
+				Timestamp: 1,
+			})
+			require.NoError(t, err)
 
-			default:
-				http.NotFound(w, r)
-			}
-		},
-	))
+		default:
+			http.NotFound(w, r)
+		}
+	}
+	esplora := httptest.NewServer(http.HandlerFunc(handler))
 	defer esplora.Close()
 
 	w, err := New(Config{

--- a/lwwallet/boarding_backend_test.go
+++ b/lwwallet/boarding_backend_test.go
@@ -1,0 +1,93 @@
+package lwwallet
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBoardingBackendDuplicateImportRestoresTracking verifies restart recovery
+// for lwwallet's in-memory boarding-address filter. btcwallet persists the
+// imported script, but the address filter starts empty after process restart,
+// so duplicate imports must still repopulate it.
+func TestBoardingBackendDuplicateImportRestoresTracking(t *testing.T) {
+	t.Parallel()
+
+	var seed [32]byte
+	for i := range seed {
+		seed[i] = byte(i + 1)
+	}
+
+	tipHash := chaincfg.RegressionNetParams.GenesisHash.String()
+	esplora := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/blocks/tip/height":
+				_, err := w.Write([]byte("0"))
+				require.NoError(t, err)
+
+			case "/block-height/0":
+				_, err := w.Write([]byte(tipHash))
+				require.NoError(t, err)
+
+			case "/block/" + tipHash:
+				err := json.NewEncoder(w).Encode(esploraBlock{
+					ID:        tipHash,
+					Height:    0,
+					Timestamp: 1,
+				})
+				require.NoError(t, err)
+
+			default:
+				http.NotFound(w, r)
+			}
+		},
+	))
+	defer esplora.Close()
+
+	w, err := New(Config{
+		Seed:           seed,
+		EsploraURL:     esplora.URL,
+		ChainParams:    &chaincfg.RegressionNetParams,
+		PollInterval:   time.Hour,
+		RecoveryWindow: 10,
+		DBDir:          t.TempDir(),
+		Log:            fn.None[btclog.Logger](),
+	})
+	require.NoError(t, err)
+	require.NoError(t, w.Start())
+	t.Cleanup(w.Stop)
+
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	script := &waddrmgr.Tapscript{
+		Type:          waddrmgr.TaprootFullKeyOnly,
+		FullOutputKey: privKey.PubKey(),
+	}
+
+	backend := w.BoardingBackend()
+	addr, err := backend.ImportTaprootScript(t.Context(), script)
+	require.NoError(t, err)
+	require.Contains(t, backend.SnapshotAddrs(), addr.String())
+
+	backend.Mu.Lock()
+	for key := range backend.ImportedAddrs {
+		delete(backend.ImportedAddrs, key)
+	}
+	backend.Mu.Unlock()
+
+	duplicateAddr, err := backend.ImportTaprootScript(t.Context(), script)
+	require.NoError(t, err)
+	require.Equal(t, addr.String(), duplicateAddr.String())
+	require.Contains(t, backend.SnapshotAddrs(), addr.String())
+}

--- a/walletcore/boarding_backend.go
+++ b/walletcore/boarding_backend.go
@@ -116,9 +116,10 @@ func (b *BoardingBackendBase) ImportTaprootScript(ctx context.Context,
 					"taproot script address: %w", addrErr)
 			}
 
-			b.trackImportedAddress(addr)
+			numAddrs := b.trackImportedAddress(addr)
 			b.Log.DebugS(ctx, "Tracked duplicate taproot script",
 				slog.String("address", addr.String()),
+				slog.Int("tracked_addrs", numAddrs),
 			)
 
 			return addr, nil
@@ -129,11 +130,11 @@ func (b *BoardingBackendBase) ImportTaprootScript(ctx context.Context,
 
 	addr := managedAddr.Address()
 
-	b.trackImportedAddress(addr)
+	numAddrs := b.trackImportedAddress(addr)
 
 	b.Log.DebugS(ctx, "Imported taproot script via btcwallet",
 		slog.String("address", addr.String()),
-		slog.Int("tracked_addrs", len(b.SnapshotAddrs())),
+		slog.Int("tracked_addrs", numAddrs),
 	)
 
 	return addr, nil
@@ -141,10 +142,16 @@ func (b *BoardingBackendBase) ImportTaprootScript(ctx context.Context,
 
 // trackImportedAddress records an imported address so ListUnspent
 // implementations can filter results to only return boarding UTXOs.
-func (b *BoardingBackendBase) trackImportedAddress(addr btcutil.Address) {
+// Returns the number of currently tracked addresses after the insert,
+// which lets callers log the count without a separate locked read or
+// a full map copy via SnapshotAddrs.
+func (b *BoardingBackendBase) trackImportedAddress(addr btcutil.Address) int {
 	b.Mu.Lock()
 	b.ImportedAddrs[addr.String()] = addr
+	numAddrs := len(b.ImportedAddrs)
 	b.Mu.Unlock()
+
+	return numAddrs
 }
 
 // addressForTaprootScript derives the P2TR address that btcwallet stores for

--- a/walletcore/boarding_backend.go
+++ b/walletcore/boarding_backend.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"sync"
 
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btclog/v2"
 	"github.com/btcsuite/btcwallet/waddrmgr"
@@ -108,24 +109,59 @@ func (b *BoardingBackendBase) ImportTaprootScript(ctx context.Context,
 		waddrmgr.KeyScopeBIP0086, script,
 	)
 	if err != nil {
+		if waddrmgr.IsError(err, waddrmgr.ErrDuplicateAddress) {
+			addr, addrErr := b.addressForTaprootScript(script)
+			if addrErr != nil {
+				return nil, fmt.Errorf("derive duplicate "+
+					"taproot script address: %w", addrErr)
+			}
+
+			b.trackImportedAddress(addr)
+			b.Log.DebugS(ctx, "Tracked duplicate taproot script",
+				slog.String("address", addr.String()),
+			)
+
+			return addr, nil
+		}
+
 		return nil, fmt.Errorf("import taproot script: %w", err)
 	}
 
 	addr := managedAddr.Address()
 
-	// Track the imported address so ListUnspent implementations
-	// can filter results to only return boarding UTXOs.
-	b.Mu.Lock()
-	b.ImportedAddrs[addr.String()] = addr
-	numAddrs := len(b.ImportedAddrs)
-	b.Mu.Unlock()
+	b.trackImportedAddress(addr)
 
 	b.Log.DebugS(ctx, "Imported taproot script via btcwallet",
 		slog.String("address", addr.String()),
-		slog.Int("tracked_addrs", numAddrs),
+		slog.Int("tracked_addrs", len(b.SnapshotAddrs())),
 	)
 
 	return addr, nil
+}
+
+// trackImportedAddress records an imported address so ListUnspent
+// implementations can filter results to only return boarding UTXOs.
+func (b *BoardingBackendBase) trackImportedAddress(addr btcutil.Address) {
+	b.Mu.Lock()
+	b.ImportedAddrs[addr.String()] = addr
+	b.Mu.Unlock()
+}
+
+// addressForTaprootScript derives the P2TR address that btcwallet stores for
+// a tapscript import. This lets restart recovery repopulate the in-memory
+// address filter when btcwallet reports that a persisted import already exists.
+func (b *BoardingBackendBase) addressForTaprootScript(
+	script *waddrmgr.Tapscript) (btcutil.Address, error) {
+
+	taprootKey, err := script.TaprootKey()
+	if err != nil {
+		return nil, fmt.Errorf("calculate taproot key: %w", err)
+	}
+
+	return btcutil.NewAddressTaproot(
+		schnorr.SerializePubKey(taprootKey),
+		b.BtcWallet.InternalWallet().ChainParams(),
+	)
 }
 
 // SnapshotAddrs returns a snapshot of the currently imported


### PR DESCRIPTION
## Summary

Fixes #487 by making btcwallet-backed taproot script imports idempotent for the duplicate-address case.

When lwwallet restarts, btcwallet still has the imported boarding script in its DB, but `walletcore.BoardingBackendBase.ImportTaprootScript` used to return on `ErrDuplicateAddress` before repopulating the in-memory `ImportedAddrs` filter. That left lwwallet polling Esplora with an empty address set, so funded boarding UTXOs were never found after restart.

This PR derives the P2TR address from the duplicate tapscript, restores it into `ImportedAddrs`, and returns success. A focused lwwallet regression test covers the restart-shaped path by clearing the in-memory filter and re-importing the same tapscript.

## Tests

```
go test ./lwwallet -run TestBoardingBackendDuplicateImportRestoresTracking -count=1
go test ./walletcore ./lwwallet ./btcwbackend ./wallet
make commitmsg-lint commit=HEAD
```
