### PR TITLE
[vibecode] darepod: treat unregistered script lookups as not found

### DIFF
--- a/darepod/rpc_swap_lookup.go
+++ b/darepod/rpc_swap_lookup.go
@@ -2,6 +2,7 @@ package darepod
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -53,6 +54,11 @@ func (r *RPCServer) GetIndexedVTXOByPkScript(ctx context.Context,
 		nil, 1, statusFilter,
 	)
 	if err != nil {
+		if errors.Is(err, indexer.ErrScriptNotRegisteredForPrincipal) {
+			return &daemonrpc.GetIndexedVTXOByPkScriptResponse{},
+				nil
+		}
+
 		return nil, status.Errorf(codes.Internal, "indexer query "+
 			"failed: %v", err)
 	}

--- a/darepod/rpc_swap_lookup_test.go
+++ b/darepod/rpc_swap_lookup_test.go
@@ -1,0 +1,79 @@
+package darepod
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/lightninglabs/darepo-client/indexer"
+	mailboxrpc "github.com/lightninglabs/darepo-client/mailbox/rpc"
+	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+// TestGetIndexedVTXOByPkScriptTreatsUnregisteredScriptAsNotFound verifies
+// that unregistered scripts are mapped to an empty VTXO lookup result.
+func TestGetIndexedVTXOByPkScriptTreatsUnregisteredScriptAsNotFound(
+	t *testing.T) {
+
+	t.Parallel()
+
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	pkScript := append(
+		[]byte{0x51, 0x20},
+		privKey.PubKey().SerializeCompressed()[1:]...,
+	)
+
+	walletReady := make(chan struct{})
+	close(walletReady)
+
+	unregisteredErr := fmt.Errorf("lookup failed: %w",
+		indexer.ErrScriptNotRegisteredForPrincipal)
+	rpcServer := NewRPCServer(&Server{
+		walletReady: walletReady,
+		indexer: indexer.New(
+			&failingIndexerRPCClient{
+				err: unregisteredErr,
+			},
+			&indexer.PrivKeySchnorrSigner{
+				Key: privKey,
+			},
+			"arkd", "client:test", fn.None[btclog.Logger](),
+		),
+	})
+
+	resp, err := rpcServer.GetIndexedVTXOByPkScript(
+		t.Context(), &daemonrpc.GetIndexedVTXOByPkScriptRequest{
+			PkScript: pkScript,
+		},
+	)
+	require.NoError(t, err)
+	require.Nil(t, resp.GetVtxo())
+}
+
+type failingIndexerRPCClient struct {
+	err error
+}
+
+// SendRPC returns a static correlation id for the generated mailbox client.
+func (f *failingIndexerRPCClient) SendRPC(_ context.Context,
+	_ mailboxrpc.ServiceMethod, _ proto.Message, _ mailboxrpc.RPCOptions) (
+	mailboxrpc.SendResult, error) {
+
+	return mailboxrpc.SendResult{
+		CorrelationID: "corr-1",
+	}, nil
+}
+
+// AwaitRPC returns the configured error to simulate an indexer failure.
+func (f *failingIndexerRPCClient) AwaitRPC(_ context.Context, _ string,
+	_ proto.Message) error {
+
+	return f.err
+}

--- a/indexer/client.go
+++ b/indexer/client.go
@@ -3,8 +3,10 @@ package indexer
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -18,7 +20,15 @@ import (
 	mailboxrpc "github.com/lightninglabs/darepo-client/mailbox/rpc"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/tlv"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
+
+// ErrScriptNotRegisteredForPrincipal is returned when a proof-gated script
+// query targets a script that has not been registered for the calling
+// principal.
+var ErrScriptNotRegisteredForPrincipal = errors.New("script not registered " +
+	"for principal")
 
 // Client is a small convenience wrapper around the generated
 // arkrpc.IndexerServiceMailboxClient that helps construct canonical receive
@@ -642,10 +652,30 @@ func (c *Client) ListVTXOsByScriptsTaproot(ctx context.Context,
 
 	resp, err := c.rpc.ListVTXOsByScripts(ctx, req, firstOpt(opts))
 	if err != nil {
-		return nil, err
+		return nil, normalizeScriptScopeError(err)
 	}
 
 	return resp, nil
+}
+
+// normalizeScriptScopeError wraps server-side script authorization failures
+// with a stable client-side sentinel while preserving the original RPC error.
+func normalizeScriptScopeError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	errMsg := err.Error()
+	if !strings.Contains(errMsg,
+		ErrScriptNotRegisteredForPrincipal.Error()) {
+		return err
+	}
+
+	if status.Code(err) != codes.Unauthenticated {
+		return err
+	}
+
+	return fmt.Errorf("%w: %w", ErrScriptNotRegisteredForPrincipal, err)
 }
 
 // BuildGetOORSessionByTxidTaprootRequest builds the proof-gated indexer

--- a/indexer/client_test.go
+++ b/indexer/client_test.go
@@ -3,6 +3,7 @@ package indexer
 import (
 	"bytes"
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -17,6 +18,8 @@ import (
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/tlv"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -342,6 +345,40 @@ func TestBuildListVTXOsByScriptsTaprootRequestRejectsOversizedCursor(
 	require.ErrorContains(t, err, "after cursor: vtxo cursor length")
 }
 
+// TestListVTXOsByScriptsTaprootWrapsUnregisteredScriptError verifies that the
+// client exposes unregistered script failures as a stable sentinel error.
+func TestListVTXOsByScriptsTaprootWrapsUnregisteredScriptError(t *testing.T) {
+	t.Parallel()
+
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	pkScript := append(
+		[]byte{0x51, 0x20},
+		privKey.PubKey().SerializeCompressed()[1:]...,
+	)
+	rpcClient := &recordingRPCClient{
+		awaitErr: status.Error(
+			codes.Unauthenticated,
+			ErrScriptNotRegisteredForPrincipal.Error(),
+		),
+	}
+	client := New(
+		rpcClient, &PrivKeySchnorrSigner{
+			Key: privKey,
+		}, "test-server", "client:test",
+		fn.None[btclog.Logger](),
+	)
+
+	_, err = client.ListVTXOsByScriptsTaproot(
+		t.Context(), []TaprootScriptScope{{
+			PkScript: pkScript,
+		}}, nil, 1, nil,
+	)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrScriptNotRegisteredForPrincipal))
+}
+
 type testMessageSchnorrSigner struct {
 	result    []byte
 	message   []byte
@@ -486,8 +523,9 @@ func TestProofTagImmutable(t *testing.T) {
 }
 
 type recordingRPCClient struct {
-	mu      sync.Mutex
-	lastReq proto.Message
+	mu       sync.Mutex
+	lastReq  proto.Message
+	awaitErr error
 }
 
 // SendRPC records the last request and returns a static correlation pair.
@@ -509,7 +547,7 @@ func (r *recordingRPCClient) SendRPC(_ context.Context,
 func (r *recordingRPCClient) AwaitRPC(_ context.Context, _ string,
 	_ proto.Message) error {
 
-	return nil
+	return r.awaitErr
 }
 
 // lastRegisterReceiveScriptRequest returns the last recorded registration


### PR DESCRIPTION
_These changes are needed for my first-contact Nautilus integration. I'm still not familiar with darepo-client code, so treat them as a complete vibe-code._

---

This PR makes proof-gated indexer lookups distinguish an expected "script not registered for principal" response from real indexer failures.

The indexer client now wraps that response with a stable sentinel error, so callers can use `errors.Is` instead of matching gRPC error strings. The daemon then maps that sentinel to an empty `GetIndexedVTXOByPkScript` response, which matches the existing "no VTXO found" behavior.

This is needed for flows that poll for script-backed Ark outputs before the script has an indexed VTXO. In that case the absence is a normal "not found yet" condition, not an internal daemon failure.