### PR TITLE
darepod: surface syncing wallet state

### DIFF
--- a/daemonrpc/daemon.pb.go
+++ b/daemonrpc/daemon.pb.go
@@ -22,9 +22,9 @@ const (
 )
 
 // WalletState mirrors the daemon's in-process wallet lifecycle enum:
-// values are ordered from least to most ready so callers can compare
-// against >= LOCKED for "seed exists" semantics and == READY for "fully
-// usable" semantics.
+// callers should test the specific state they need. SYNCING and READY
+// both mean seed material is loaded, while only READY means wallet RPCs
+// are fully usable.
 type WalletState int32
 
 const (
@@ -42,6 +42,9 @@ const (
 	// WALLET_STATE_READY indicates the wallet is initialized, unlocked,
 	// and ready to sign / participate in rounds.
 	WalletState_WALLET_STATE_READY WalletState = 3
+	// WALLET_STATE_SYNCING indicates the wallet is unlocked and the
+	// backing chain source is catching up before wallet RPCs are safe.
+	WalletState_WALLET_STATE_SYNCING WalletState = 4
 )
 
 // Enum value maps for WalletState.
@@ -51,12 +54,14 @@ var (
 		1: "WALLET_STATE_NONE",
 		2: "WALLET_STATE_LOCKED",
 		3: "WALLET_STATE_READY",
+		4: "WALLET_STATE_SYNCING",
 	}
 	WalletState_value = map[string]int32{
 		"WALLET_STATE_UNSPECIFIED": 0,
 		"WALLET_STATE_NONE":        1,
 		"WALLET_STATE_LOCKED":      2,
 		"WALLET_STATE_READY":       3,
+		"WALLET_STATE_SYNCING":     4,
 	}
 )
 
@@ -529,12 +534,11 @@ type GetInfoResponse struct {
 	LndAlias string `protobuf:"bytes,7,opt,name=lnd_alias,json=lndAlias,proto3" json:"lnd_alias,omitempty"`
 	// wallet_type is the active wallet backend: "lnd" or "lwwallet".
 	WalletType string `protobuf:"bytes,8,opt,name=wallet_type,json=walletType,proto3" json:"wallet_type,omitempty"`
-	// wallet_state is the lifecycle state of the wallet subsystem. The
-	// ordering reflects increasing readiness: NONE (no seed exists),
-	// LOCKED (encrypted seed exists but no decryption key has been
-	// provided), READY (wallet is initialized and signing is
-	// available). Callers compare against >= LOCKED for "seed exists /
-	// unlocked" semantics and == READY for "fully usable" semantics.
+	// wallet_state is the lifecycle state of the wallet subsystem.
+	// Callers should test explicit enum values instead of relying on
+	// numeric ordering: READY is fully usable, SYNCING is unlocked but
+	// waiting for the chain backend, LOCKED still needs the wallet
+	// password, and NONE has no wallet seed on disk.
 	WalletState WalletState `protobuf:"varint,9,opt,name=wallet_state,json=walletState,proto3,enum=daemonrpc.WalletState" json:"wallet_state,omitempty"`
 	// identity_pubkey is the hex-encoded daemon wallet identity public key
 	// derived from the active wallet backend's daemon identity key locator
@@ -6425,12 +6429,13 @@ const file_daemon_proto_rawDesc = "" +
 	"\n" +
 	"sweep_txid\x18\x03 \x01(\tR\tsweepTxid\x12\x1d\n" +
 	"\n" +
-	"last_error\x18\x04 \x01(\tR\tlastError*s\n" +
+	"last_error\x18\x04 \x01(\tR\tlastError*\x8d\x01\n" +
 	"\vWalletState\x12\x1c\n" +
 	"\x18WALLET_STATE_UNSPECIFIED\x10\x00\x12\x15\n" +
 	"\x11WALLET_STATE_NONE\x10\x01\x12\x17\n" +
 	"\x13WALLET_STATE_LOCKED\x10\x02\x12\x16\n" +
-	"\x12WALLET_STATE_READY\x10\x03*\x81\x02\n" +
+	"\x12WALLET_STATE_READY\x10\x03\x12\x18\n" +
+	"\x14WALLET_STATE_SYNCING\x10\x04*\x81\x02\n" +
 	"\n" +
 	"VTXOStatus\x12\x1b\n" +
 	"\x17VTXO_STATUS_UNSPECIFIED\x10\x00\x12\x14\n" +

--- a/daemonrpc/daemon.proto
+++ b/daemonrpc/daemon.proto
@@ -169,9 +169,9 @@ service DaemonService {
 }
 
 // WalletState mirrors the daemon's in-process wallet lifecycle enum:
-// values are ordered from least to most ready so callers can compare
-// against >= LOCKED for "seed exists" semantics and == READY for "fully
-// usable" semantics.
+// callers should test the specific state they need. SYNCING and READY
+// both mean seed material is loaded, while only READY means wallet RPCs
+// are fully usable.
 enum WalletState {
     // WALLET_STATE_UNSPECIFIED is the proto3 zero value. The daemon
     // never emits this; reserved so a missing field deserializes to a
@@ -190,6 +190,10 @@ enum WalletState {
     // WALLET_STATE_READY indicates the wallet is initialized, unlocked,
     // and ready to sign / participate in rounds.
     WALLET_STATE_READY = 3;
+
+    // WALLET_STATE_SYNCING indicates the wallet is unlocked and the
+    // backing chain source is catching up before wallet RPCs are safe.
+    WALLET_STATE_SYNCING = 4;
 }
 
 message GetInfoRequest {
@@ -228,12 +232,11 @@ message GetInfoResponse {
     // wallet_type is the active wallet backend: "lnd" or "lwwallet".
     string wallet_type = 8;
 
-    // wallet_state is the lifecycle state of the wallet subsystem. The
-    // ordering reflects increasing readiness: NONE (no seed exists),
-    // LOCKED (encrypted seed exists but no decryption key has been
-    // provided), READY (wallet is initialized and signing is
-    // available). Callers compare against >= LOCKED for "seed exists /
-    // unlocked" semantics and == READY for "fully usable" semantics.
+    // wallet_state is the lifecycle state of the wallet subsystem.
+    // Callers should test explicit enum values instead of relying on
+    // numeric ordering: READY is fully usable, SYNCING is unlocked but
+    // waiting for the chain backend, LOCKED still needs the wallet
+    // password, and NONE has no wallet seed on disk.
     WalletState wallet_state = 9;
 
     // identity_pubkey is the hex-encoded daemon wallet identity public key

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -287,6 +287,12 @@ func walletStateToProto(s WalletState) daemonrpc.WalletState {
 	case WalletStateLocked:
 		return daemonrpc.WalletState_WALLET_STATE_LOCKED
 
+	case WalletStateUnlocking:
+		return daemonrpc.WalletState_WALLET_STATE_LOCKED
+
+	case WalletStateSyncing:
+		return daemonrpc.WalletState_WALLET_STATE_SYNCING
+
 	case WalletStateReady:
 		return daemonrpc.WalletState_WALLET_STATE_READY
 

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -432,12 +432,43 @@ func (r *RPCServer) GetInfo(ctx context.Context, _ *daemonrpc.GetInfoRequest) (
 // requireWalletReady returns a gRPC error if the wallet is not yet
 // ready. Callers use this to gate RPCs that need wallet access.
 func (r *RPCServer) requireWalletReady() error {
-	if !r.server.isWalletReady() {
-		return status.Errorf(codes.FailedPrecondition, "wallet is "+
-			"not ready (create or unlock first)")
+	if r.server.isWalletReady() {
+		return nil
 	}
 
-	return nil
+	switch r.server.WalletLifecycleState() {
+	case WalletStateReady:
+		return nil
+
+	case WalletStateNone:
+		return status.Error(
+			codes.FailedPrecondition,
+			"wallet is not ready (create first)",
+		)
+
+	case WalletStateLocked:
+		return status.Error(
+			codes.FailedPrecondition,
+			"wallet is not ready (unlock first)",
+		)
+
+	case WalletStateUnlocking:
+		return status.Error(
+			codes.FailedPrecondition,
+			"wallet unlock is in progress",
+		)
+
+	case WalletStateSyncing:
+		return status.Error(
+			codes.FailedPrecondition,
+			"wallet is syncing; try again once sync completes",
+		)
+
+	default:
+		return status.Error(
+			codes.FailedPrecondition, "wallet is not ready",
+		)
+	}
 }
 
 // GetBalance returns the current balance of the wallet, broken down

--- a/darepod/rpc_server_test.go
+++ b/darepod/rpc_server_test.go
@@ -704,6 +704,101 @@ func TestDeriveIdentityPubkeyPreWalletInit(t *testing.T) {
 	}
 }
 
+// TestWalletStateToProtoIncludesSyncing verifies the public GetInfo
+// state can distinguish an unlocked wallet that is still catching up
+// from a wallet that still needs its password.
+func TestWalletStateToProtoIncludesSyncing(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(
+		t, daemonrpc.WalletState_WALLET_STATE_SYNCING,
+		walletStateToProto(WalletStateSyncing),
+	)
+}
+
+// TestRequireWalletReadyErrorsExplainLifecycleState verifies callers
+// get actionable setup guidance for each non-ready wallet state.
+func TestRequireWalletReadyErrorsExplainLifecycleState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		state      WalletState
+		closeReady bool
+		wantMsg    string
+		wantErr    bool
+	}{
+		{
+			name:    "none",
+			state:   WalletStateNone,
+			wantMsg: "wallet is not ready (create first)",
+			wantErr: true,
+		},
+		{
+			name:    "locked",
+			state:   WalletStateLocked,
+			wantMsg: "wallet is not ready (unlock first)",
+			wantErr: true,
+		},
+		{
+			name:    "unlocking",
+			state:   WalletStateUnlocking,
+			wantMsg: "wallet unlock is in progress",
+			wantErr: true,
+		},
+		{
+			name:  "syncing",
+			state: WalletStateSyncing,
+			wantMsg: "wallet is syncing; try again once sync " +
+				"completes",
+			wantErr: true,
+		},
+		{
+			name:       "ready channel closed",
+			state:      WalletStateReady,
+			closeReady: true,
+			wantErr:    false,
+		},
+		{
+			name:    "ready state before channel close",
+			state:   WalletStateReady,
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			walletReady := make(chan struct{})
+			if tc.closeReady {
+				close(walletReady)
+			}
+
+			r := &RPCServer{
+				server: &Server{
+					walletReady: walletReady,
+				},
+			}
+			r.server.walletState.Store(int32(tc.state))
+
+			err := r.requireWalletReady()
+			if !tc.wantErr {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.Error(t, err)
+			st, ok := status.FromError(err)
+			require.True(t, ok)
+			require.Equal(t, codes.FailedPrecondition, st.Code())
+			require.Equal(t, tc.wantMsg, st.Message())
+		})
+	}
+}
+
 // TestSumOnchainWalletConfirmed locks in the invariant that the on-chain
 // wallet balance accumulates across every registered backend fetcher and
 // that a failing fetcher does not erase the contribution of its

--- a/darepod/rpc_wallet.go
+++ b/darepod/rpc_wallet.go
@@ -238,7 +238,7 @@ func (r *RPCServer) GenSeed(ctx context.Context,
 	currentState := WalletState(r.server.walletState.Load())
 	if currentState != WalletStateNone {
 		return nil, status.Errorf(codes.FailedPrecondition, "wallet "+
-			"already exists (state=%d)", currentState)
+			"already exists (state=%s)", currentState)
 	}
 
 	mnemonic, err := GenerateSeed(req.SeedPassphrase)
@@ -277,7 +277,7 @@ func (r *RPCServer) InitWallet(ctx context.Context,
 		state := WalletState(r.server.walletState.Load())
 
 		return nil, status.Errorf(codes.FailedPrecondition, "wallet "+
-			"already exists (state=%d)", state)
+			"already exists (state=%s)", state)
 	}
 
 	// rollbackState resets the wallet state to None so that a
@@ -349,20 +349,28 @@ func (r *RPCServer) UnlockWallet(ctx context.Context,
 				"lwwallet/btcwallet mode")
 	}
 
-	// Atomically verify the wallet is locked. We do not need a CAS
-	// here because startLwwallet (called below) will perform the
-	// Locked → Ready transition via markWalletReady. A concurrent
-	// UnlockWallet that passes this check will fail inside
-	// startLwwallet when it tries to start a second wallet.
-	currentState := WalletState(r.server.walletState.Load())
-	if currentState != WalletStateLocked {
+	// Atomically claim the Locked -> Unlocking transition before
+	// decrypting or starting the wallet backend so concurrent unlock
+	// attempts cannot start multiple wallet instances.
+	if !r.server.walletState.CompareAndSwap(
+		int32(WalletStateLocked), int32(WalletStateUnlocking),
+	) {
+
+		currentState := WalletState(r.server.walletState.Load())
+
 		return nil, status.Errorf(codes.FailedPrecondition, "wallet "+
-			"is not locked (state=%d)", currentState)
+			"is not locked (state=%s)", currentState)
+	}
+
+	rollbackState := func() {
+		r.server.walletState.Store(int32(WalletStateLocked))
 	}
 
 	// Resolve the network directory for seed lookup.
 	networkDir, err := r.server.cfg.NetworkDir()
 	if err != nil {
+		rollbackState()
+
 		return nil, status.Errorf(codes.Internal, "unable to resolve "+
 			"network directory: %v", err)
 	}
@@ -374,6 +382,8 @@ func (r *RPCServer) UnlockWallet(ctx context.Context,
 		networkDir, req.WalletPassword,
 	)
 	if err != nil {
+		rollbackState()
+
 		return nil, status.Errorf(codes.Internal, "unable to unlock "+
 			"wallet: %v", err)
 	}
@@ -382,6 +392,8 @@ func (r *RPCServer) UnlockWallet(ctx context.Context,
 
 	// Start the wallet with the decrypted seed.
 	if err := r.server.startSelfManagedWallet(ctx, seed); err != nil {
+		rollbackState()
+
 		return nil, status.Errorf(codes.Internal, "unable to start "+
 			"wallet: %v", err)
 	}

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -74,11 +74,10 @@ import (
 )
 
 // WalletState represents the lifecycle state of the wallet subsystem.
-// In lwwallet mode, the wallet transitions through these states during
-// daemon startup: None → Locked → Ready (or None → Ready if the seed
-// is provided via environment variable). The underlying type is int32
-// so it can be stored in an atomic.Int32 for lock-free concurrent
-// access.
+// In self-managed wallet modes, the daemon transitions through these
+// states during startup as seed material is discovered, decrypted, and
+// made safe for wallet RPCs. The underlying type is int32 so it can be
+// stored in an atomic.Int32 for lock-free concurrent access.
 type WalletState int32
 
 const (
@@ -91,11 +90,45 @@ const (
 	// UnlockWallet RPCs in this state.
 	WalletStateLocked
 
+	// WalletStateUnlocking indicates one UnlockWallet RPC has claimed
+	// the locked wallet and is decrypting the seed or starting the
+	// wallet backend. This state is internal and reports as LOCKED on
+	// the public GetInfo surface.
+	WalletStateUnlocking
+
+	// WalletStateSyncing indicates the wallet seed has been decrypted
+	// and the wallet backend has started, but the backing chain source
+	// has not caught up enough for wallet RPCs to be safe.
+	WalletStateSyncing
+
 	// WalletStateReady indicates the wallet is initialized and
 	// operational. All wallet RPCs (GetBalance, NewAddress, etc.)
 	// are available.
 	WalletStateReady
 )
+
+// String returns a stable name for logging and RPC precondition errors.
+func (s WalletState) String() string {
+	switch s {
+	case WalletStateNone:
+		return "none"
+
+	case WalletStateLocked:
+		return "locked"
+
+	case WalletStateUnlocking:
+		return "unlocking"
+
+	case WalletStateSyncing:
+		return "syncing"
+
+	case WalletStateReady:
+		return "ready"
+
+	default:
+		return "unknown"
+	}
+}
 
 const (
 	// arkServiceName is the protobuf service name for ArkService
@@ -1599,6 +1632,7 @@ func (s *Server) startBtcwallet(ctx context.Context,
 		ctx, "Neutrino-backed wallet started, waiting for initial "+
 			"sync in background",
 	)
+	s.walletState.Store(int32(WalletStateSyncing))
 
 	// Wait for btcwallet to fully sync with the chain before
 	// marking the wallet ready. This includes the recovery scan

--- a/rpc/walletrpc/wallet.pb.go
+++ b/rpc/walletrpc/wallet.pb.go
@@ -1641,8 +1641,9 @@ type StatusResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// ready is true when the daemon and its dependencies are up.
 	Ready bool `protobuf:"varint,1,opt,name=ready,proto3" json:"ready,omitempty"`
-	// unlocked is true when the wallet seed is loaded and signing is
-	// available.
+	// unlocked is a legacy wallet-exists signal: true once a wallet
+	// seed exists on disk or is loaded in memory. Use ready to check
+	// whether wallet RPCs are currently usable.
 	Unlocked bool `protobuf:"varint,2,opt,name=unlocked,proto3" json:"unlocked,omitempty"`
 	// network is the bitcoin network the daemon is configured for, for
 	// example "mainnet", "testnet", "signet", or "regtest".

--- a/rpc/walletrpc/wallet.proto
+++ b/rpc/walletrpc/wallet.proto
@@ -420,8 +420,9 @@ message StatusResponse {
     // ready is true when the daemon and its dependencies are up.
     bool ready = 1;
 
-    // unlocked is true when the wallet seed is loaded and signing is
-    // available.
+    // unlocked is a legacy wallet-exists signal: true once a wallet
+    // seed exists on disk or is loaded in memory. Use ready to check
+    // whether wallet RPCs are currently usable.
     bool unlocked = 2;
 
     // network is the bitcoin network the daemon is configured for, for

--- a/sdk/ark/client.go
+++ b/sdk/ark/client.go
@@ -34,10 +34,10 @@ type Client struct {
 	closeErr  error
 }
 
-// WalletState mirrors the daemon's wallet lifecycle enum so SDK consumers
-// can render a tri-state UI. Compare against >= WalletStateLocked for
-// "seed exists" semantics and == WalletStateReady for "fully usable"
-// semantics.
+// WalletState mirrors the daemon's wallet lifecycle enum so SDK
+// consumers can render wallet setup progress. WalletStateSyncing and
+// WalletStateReady mean seed material is loaded; only WalletStateReady
+// means the wallet is fully usable.
 type WalletState int32
 
 const (
@@ -56,6 +56,10 @@ const (
 	// WalletStateReady indicates the wallet is initialized, unlocked,
 	// and signing is available.
 	WalletStateReady WalletState = 3
+
+	// WalletStateSyncing indicates the wallet is unlocked and the
+	// backing chain source is catching up before wallet RPCs are safe.
+	WalletStateSyncing WalletState = 4
 )
 
 // WalletReady reports whether the daemon wallet is fully unlocked and
@@ -97,10 +101,9 @@ type Info struct {
 	WalletType string
 
 	// WalletState reports the daemon wallet lifecycle state
-	// (Unspecified/None/Locked/Ready). The values are ordered from
-	// least to most ready; callers can compare against >=
-	// WalletStateLocked for "seed exists" semantics and ==
-	// WalletStateReady for "fully usable" semantics.
+	// (Unspecified/None/Locked/Ready/Syncing). WalletStateSyncing
+	// and WalletStateReady mean seed material is loaded; only
+	// WalletStateReady means the wallet is fully usable.
 	WalletState WalletState
 
 	// IdentityPubKey is the daemon identity public key derived from the

--- a/sdk/walletdk/types.go
+++ b/sdk/walletdk/types.go
@@ -40,10 +40,10 @@ const (
 )
 
 // WalletState mirrors the daemon's wallet lifecycle enum so SDK
-// consumers can render a tri-state UI without collapsing LOCKED into
-// "not ready". The values are ordered from least to most ready;
-// compare against >= WalletStateLocked for "seed exists" semantics and
-// == WalletStateReady for "fully usable" semantics.
+// consumers can render wallet setup progress without collapsing
+// LOCKED and SYNCING into one "not ready" state. WalletStateSyncing
+// and WalletStateReady mean seed material is loaded; only
+// WalletStateReady means the wallet is fully usable.
 type WalletState int32
 
 const (
@@ -62,6 +62,10 @@ const (
 	// WalletStateReady indicates the wallet is initialized, unlocked,
 	// and signing is available.
 	WalletStateReady WalletState = 3
+
+	// WalletStateSyncing indicates the wallet is unlocked and the
+	// backing chain source is catching up before wallet RPCs are safe.
+	WalletStateSyncing WalletState = 4
 )
 
 // Info summarizes daemon readiness for wallet applications.

--- a/swapwallet/service.go
+++ b/swapwallet/service.go
@@ -192,11 +192,13 @@ func (s *Service) Status(ctx context.Context, req *walletrpc.StatusRequest) (
 		// Ready collapses to "wallet fully usable for signing".
 		Ready: state == daemonrpc.WalletState_WALLET_STATE_READY,
 
-		// Unlocked surfaces "seed material is loaded" — every state
-		// at or past LOCKED qualifies (the wallet has been
-		// instantiated even if it's still waiting on the unlock
-		// password).
-		Unlocked: state >= daemonrpc.WalletState_WALLET_STATE_LOCKED,
+		// Unlocked retains the legacy wallet-exists signal exposed
+		// by this field. Use Ready to determine whether wallet RPCs
+		// are currently usable.
+		Unlocked: state ==
+			daemonrpc.WalletState_WALLET_STATE_LOCKED ||
+			state == daemonrpc.WalletState_WALLET_STATE_SYNCING ||
+			state == daemonrpc.WalletState_WALLET_STATE_READY,
 
 		Network:      info.GetNetwork(),
 		Balance:      bal,

--- a/swapwallet/service_test.go
+++ b/swapwallet/service_test.go
@@ -117,3 +117,26 @@ func TestServiceStatusComposesInfoBalanceAndPending(t *testing.T) {
 	require.Equal(t, int64(1_000), resp.GetBalance().GetConfirmedSat())
 	require.Equal(t, uint32(1), resp.GetPendingCount())
 }
+
+// TestServiceStatusReportsSyncingWalletUnlocked confirms the wallet
+// facade reports an unlocked wallet during daemon sync without
+// promoting it to ready.
+func TestServiceStatusReportsSyncingWalletUnlocked(t *testing.T) {
+	t.Parallel()
+
+	svc, swap, rpc := newServiceFixture(t)
+	rpc.getInfoResp = &daemonrpc.GetInfoResponse{
+		WalletState: daemonrpc.WalletState_WALLET_STATE_SYNCING,
+		Network:     "regtest",
+	}
+	rpc.getBalanceResp = &daemonrpc.GetBalanceResponse{}
+	rpc.listTxResp = &daemonrpc.ListTransactionsResponse{}
+	swap.listSwapsResp = &swapclientrpc.ListSwapsResponse{}
+
+	resp, err := svc.Status(
+		t.Context(), &walletrpc.StatusRequest{},
+	)
+	require.NoError(t, err)
+	require.False(t, resp.GetReady())
+	require.True(t, resp.GetUnlocked())
+}


### PR DESCRIPTION
## Summary

- add a daemon wallet state for unlocked wallets still waiting on neutrino sync
- report syncing from wallet-gated RPCs instead of telling users to unlock again
- treat syncing wallets as unlocked-but-not-ready in the wallet facade

## Test Plan

- `make unit pkg=darepod timeout=5m`
- `make unit pkg=swapwallet tags="swapruntime walletrpc" timeout=5m`
- `make unit pkg=sdk/walletdk timeout=5m`
- `make unit pkg=sdk/ark case='TestDialRemoteGetInfo' timeout=5m`
- `git diff --check origin/main..HEAD`
- `make commitmsg-lint range=origin/main..HEAD`
