### PR TITLE
claude: add /bugreport skill for test session issue filing

### DIFF
--- a/.claude/skills/bug-report/SKILL.md
+++ b/.claude/skills/bug-report/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: bug-report
+description: >
+  File a structured GitHub issue with daemon logs, config, and environment
+  state. Use when a test session hits an error or unexpected behavior —
+  collects the current session's WRN/ERR log lines, build commit, config,
+  and Esplora reachability automatically.
+argument-hint: "[one-line description of what went wrong]"
+allowed-tools: Bash, Read
+---
+
+# Bug Report
+
+Collect runtime state from the current darepod test session and file a
+structured GitHub issue against this repository.
+
+## Steps
+
+### 1. Get the description
+
+If the user provided an argument, use it as the issue title. If not, ask for
+one sentence describing what went wrong before collecting anything.
+
+### 2. Collect session logs
+
+```bash
+# Line number where the most recent daemon session started
+START=$(grep -n "Starting darepod" ~/.darepod/logs/signet/darepod.log \
+  | tail -1 | cut -d: -f1)
+
+# Full log for the current session
+SESSION=$(tail -n +${START} ~/.darepod/logs/signet/darepod.log)
+
+# Build line (commit hash, network, wallet type)
+BUILD=$(echo "$SESSION" | grep "Starting darepod" | tail -1)
+
+# Warnings and errors from this session, capped at 40 lines
+ERRORS=$(echo "$SESSION" | grep -E '\[WRN\]|\[ERR\]' | tail -40)
+
+# Session window
+FIRST_TS=$(echo "$SESSION" | head -1 | cut -c1-19)
+LAST_TS=$(echo "$SESSION"  | tail -1 | cut -c1-19)
+```
+
+If `~/.darepod/logs/signet/darepod.log` does not exist, note that no log
+file was found and continue — do not abort.
+
+### 3. Collect environment
+
+```bash
+OS=$(sw_vers 2>/dev/null | tr '\n' ' ')
+GO_VER=$(go version 2>/dev/null)
+IPV6=$(networksetup -getinfo Wi-Fi 2>/dev/null | grep -E "IPv6")
+ESPLORA_URL=$(grep 'esploraurl' ~/.darepod/darepod.conf 2>/dev/null \
+  | cut -d= -f2)
+ESPLORA_HTTP=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 5 \
+  "${ESPLORA_URL}/blocks/tip/height" 2>/dev/null || echo "unreachable")
+DAEMON_PID=$(pgrep -x darepod || echo "not running")
+```
+
+### 4. Read config
+
+Read `~/.darepod/darepod.conf` verbatim. It contains no secrets — no
+redaction needed.
+
+### 5. Collect live wallet state
+
+Only if `pgrep -x darepod` returns a PID:
+
+```bash
+~/go/bin/darepocli --rpcserver 127.0.0.1:10029 --no-tls balance 2>&1
+~/go/bin/darepocli --rpcserver 127.0.0.1:10029 --no-tls list 2>&1 | head -30
+```
+
+If the daemon is not running, record "daemon not running at time of report".
+
+### 6. Detect affected subsystems
+
+Scan the session's `[WRN]`/`[ERR\]` lines for these log prefixes and collect
+every one that appears:
+
+| Prefix | Label      |
+|--------|------------|
+| LWWL   | lwwallet   |
+| ARKW   | wallet     |
+| WRPC   | walletrpc  |
+| ROND   | round      |
+| OORC   | oor        |
+| SVRC   | serverconn |
+| DRPD   | daemon     |
+| SWAP   | swap       |
+
+Always include the `bug` label. Add subsystem labels on top.
+
+### 7. Build the issue body
+
+```
+## Summary
+
+{user's one-line description}
+
+## Environment
+
+- **OS**: {OS}
+- **Go**: {GO_VER}
+- **Daemon**: {commit= and wallet_type= fields from BUILD line}
+- **IPv6**: {IPV6}
+- **Esplora**: {ESPLORA_URL} → HTTP {ESPLORA_HTTP}
+- **Daemon PID**: {DAEMON_PID}
+- **Session window**: {FIRST_TS} → {LAST_TS}
+
+## Config (~/.darepod/darepod.conf)
+
+\`\`\`
+{darepod.conf contents}
+\`\`\`
+
+## Warnings and Errors (this session)
+
+\`\`\`
+{ERRORS — or "none" if the session has no WRN/ERR lines}
+\`\`\`
+
+## Wallet State
+
+\`\`\`
+{balance and list output, or "daemon not running at time of report"}
+\`\`\`
+
+## Reproduction Steps
+
+<!-- What were you doing when this happened? -->
+1.
+2.
+
+## Full Session Log
+
+<details>
+<summary>Expand</summary>
+
+\`\`\`
+{SESSION — truncated to 300 lines if longer, with a note of the total
+line count}
+\`\`\`
+
+</details>
+```
+
+### 8. Preview and confirm
+
+Print the full title and body to the terminal. Then ask:
+**"File this issue now? [y/N]"**
+
+If **yes**, run:
+
+```bash
+gh issue create \
+  --title "{description}" \
+  --body  "{body}" \
+  --label "bug" \
+  --label "{each detected subsystem label}"
+```
+
+Print the resulting issue URL.
+
+If **no**, print the body so the user can copy-paste it manually and note:
+`Open a new issue at: https://github.com/lightninglabs/darepo-client/issues/new`
+
+### 9. If `gh` is not available or not authenticated
+
+Skip the filing step. Print the body and the manual URL above. Do not treat
+this as an error — a copy-pasteable report is still a good outcome.

--- a/.claude/skills/bug-report/SKILL.md
+++ b/.claude/skills/bug-report/SKILL.md
@@ -3,8 +3,10 @@ name: bug-report
 description: >
   File a structured GitHub issue with daemon logs, config, and environment
   state. Use when a test session hits an error or unexpected behavior —
+  auto-detects the active network (mainnet/testnet/signet/regtest/simnet)
+  and chain backend (lwwallet+Esplora / btcwallet+neutrino / lnd), then
   collects the current session's WRN/ERR log lines, build commit, config,
-  and Esplora reachability automatically.
+  and backend reachability.
 argument-hint: "[one-line description of what went wrong]"
 allowed-tools: Bash, Read
 ---
@@ -21,11 +23,50 @@ structured GitHub issue against this repository.
 If the user provided an argument, use it as the issue title. If not, ask for
 one sentence describing what went wrong before collecting anything.
 
-### 2. Collect session logs
+### 2. Detect the active network and chain backend
+
+Do **not** assume a network (mainnet/testnet/signet/regtest/simnet) or a
+chain backend (lwwallet+Esplora / btcwallet+neutrino / lnd). Detect both
+from config first, then cross-check against the most recent daemon log.
 
 ```bash
-LOG=~/.darepod/logs/signet/darepod.log
+CONF=~/.darepod/darepod.conf
 
+# Helper: read a key from the conf file (uncommented), strip whitespace and
+# surrounding quotes. Returns empty if missing.
+conf_get() {
+  grep -E "^[[:space:]]*$1[[:space:]]*=" "$CONF" 2>/dev/null \
+    | tail -1 | cut -d= -f2- \
+    | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//; s/^"(.*)"$/\1/'
+}
+
+# Config-derived values. Defaults match darepod/config.go:
+#   network defaults to mainnet, wallet.type defaults to lwwallet.
+NETWORK=$(conf_get network)
+NETWORK=${NETWORK:-mainnet}
+WALLET_TYPE=$(conf_get wallet.type)
+WALLET_TYPE=${WALLET_TYPE:-lwwallet}
+
+# Cross-check against the actual log directory tree. If the config-derived
+# network has no log file but another network's log does, prefer the
+# directory that has a recent log — the operator may have switched
+# networks without updating the conf, or the conf may be elsewhere.
+LOG_ROOT=~/.darepod/logs
+LOG="$LOG_ROOT/$NETWORK/darepod.log"
+if [ ! -f "$LOG" ]; then
+  ALT=$(ls -t "$LOG_ROOT"/*/darepod.log 2>/dev/null | head -1)
+  if [ -n "$ALT" ]; then
+    LOG="$ALT"
+    # Re-derive network from the directory name so the report is
+    # consistent with the log we actually read.
+    NETWORK=$(basename "$(dirname "$ALT")")
+  fi
+fi
+```
+
+### 3. Collect session logs
+
+```bash
 if [ -f "$LOG" ]; then
   # Line where the most recent daemon session started. Fall back to line
   # 1 if no marker is found — a partial log is better than none.
@@ -36,6 +77,17 @@ if [ -f "$LOG" ]; then
   ERRORS=$(echo "$SESSION" | grep -E '\[WRN\]|\[ERR\]' | tail -40)
   FIRST_TS=$(echo "$SESSION" | head -1 | cut -c1-19)
   LAST_TS=$(echo "$SESSION"  | tail -1 | cut -c1-19)
+
+  # The "Starting darepod" line carries network=X wallet_type=Y. Prefer
+  # those values over the config when present — they reflect what the
+  # daemon actually came up with after CLI flags and env overrides.
+  if [ -n "$BUILD" ]; then
+    LOG_NET=$(echo "$BUILD" | grep -oE 'network=[a-z]+' | cut -d= -f2)
+    LOG_WALLET=$(echo "$BUILD" | grep -oE 'wallet_type=[a-z]+' \
+      | cut -d= -f2)
+    NETWORK=${LOG_NET:-$NETWORK}
+    WALLET_TYPE=${LOG_WALLET:-$WALLET_TYPE}
+  fi
 else
   SESSION="" BUILD="" ERRORS="" FIRST_TS="" LAST_TS=""
 fi
@@ -44,7 +96,7 @@ fi
 If the log file does not exist, the variables are empty — the report will
 note "no log file found" in the affected sections instead of aborting.
 
-### 3. Collect environment
+### 4. Collect environment
 
 ```bash
 OS=$(uname -srvm)
@@ -53,14 +105,65 @@ GO_VER=$(go version 2>/dev/null)
 # ifconfig works on macOS and most Linux distros.
 IPV6=$(ifconfig 2>/dev/null | awk '/inet6/ && !/fe80|::1/ {print $2; exit}')
 IPV6=${IPV6:-none}
-ESPLORA_URL=$(grep 'esploraurl' ~/.darepod/darepod.conf 2>/dev/null \
-  | cut -d= -f2)
-ESPLORA_HTTP=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 5 \
-  "${ESPLORA_URL}/blocks/tip/height" 2>/dev/null || echo "unreachable")
 DAEMON_PID=$(pgrep -x darepod || echo "not running")
+
+# Backend-specific reachability. Each wallet type has a different chain
+# data source — only probe the one that's actually in use.
+case "$WALLET_TYPE" in
+  lwwallet)
+    BACKEND_NAME="Esplora"
+    BACKEND_URL=$(conf_get wallet.esploraurl)
+    if [ -n "$BACKEND_URL" ]; then
+      BACKEND_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+        --connect-timeout 5 "${BACKEND_URL}/blocks/tip/height" \
+        2>/dev/null || echo "unreachable")
+    else
+      BACKEND_STATUS="esploraurl not set in config"
+    fi
+    ;;
+  btcwallet)
+    BACKEND_NAME="neutrino (btcwallet)"
+    # neutrino is a P2P backend — no HTTP probe. Report configured peers
+    # and the fee endpoint reachability if set.
+    PEERS=$(conf_get wallet.btcwallet_peers)
+    ADDPEERS=$(conf_get wallet.btcwallet_addpeers)
+    BACKEND_URL="peers=${PEERS:-<dns-seed>} addpeers=${ADDPEERS:-none}"
+    FEE_URL=$(conf_get wallet.feeurl)
+    if [ -n "$FEE_URL" ]; then
+      FEE_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+        --connect-timeout 5 "$FEE_URL" 2>/dev/null \
+        || echo "unreachable")
+      BACKEND_STATUS="feeurl=$FEE_URL → HTTP $FEE_STATUS"
+    else
+      BACKEND_STATUS="P2P only (no feeurl configured)"
+    fi
+    ;;
+  lnd)
+    BACKEND_NAME="lnd"
+    LND_HOST=$(conf_get lnd.host)
+    BACKEND_URL=${LND_HOST:-localhost:10009}
+    # Best-effort TCP reachability — lnd's gRPC port is not HTTP.
+    if command -v nc >/dev/null 2>&1; then
+      host=${BACKEND_URL%:*}
+      port=${BACKEND_URL##*:}
+      if nc -z -w 3 "$host" "$port" 2>/dev/null; then
+        BACKEND_STATUS="tcp reachable"
+      else
+        BACKEND_STATUS="tcp unreachable"
+      fi
+    else
+      BACKEND_STATUS="unknown (nc not installed)"
+    fi
+    ;;
+  *)
+    BACKEND_NAME="$WALLET_TYPE"
+    BACKEND_URL="(unknown backend type)"
+    BACKEND_STATUS="not probed"
+    ;;
+esac
 ```
 
-### 4. Read and redact config
+### 5. Read and redact config
 
 Read `~/.darepod/darepod.conf` and redact secrets before including in the
 report. Replace the value of any line whose key matches one of these
@@ -79,18 +182,22 @@ CONFIG=$(sed -E '
 
 Use `$CONFIG` (not the raw file) in the report body.
 
-### 5. Collect live wallet state
+### 6. Collect live wallet state
 
-Only if `pgrep -x darepod` returns a PID:
+Only if `pgrep -x darepod` returns a PID. The RPC host can be overridden in
+the config — read it before assuming the default.
 
 ```bash
-~/go/bin/darepocli --rpcserver 127.0.0.1:10029 --no-tls balance 2>&1
-~/go/bin/darepocli --rpcserver 127.0.0.1:10029 --no-tls list 2>&1 | head -30
+RPC_HOST=$(conf_get rpc.listen)
+RPC_HOST=${RPC_HOST:-127.0.0.1:10029}
+
+~/go/bin/darepocli --rpcserver "$RPC_HOST" --no-tls balance 2>&1
+~/go/bin/darepocli --rpcserver "$RPC_HOST" --no-tls list 2>&1 | head -30
 ```
 
 If the daemon is not running, record "daemon not running at time of report".
 
-### 6. Detect affected subsystems
+### 7. Detect affected subsystems
 
 Scan the session's `[WRN]`/`[ERR\]` lines for these log prefixes and collect
 every one that appears:
@@ -106,9 +213,11 @@ every one that appears:
 | DRPD   | daemon     |
 | SWAP   | swap       |
 
-Always include the `bug` label. Add subsystem labels on top.
+Always include the `bug` label. Add subsystem labels on top. Also add a
+network label (`network/signet`, `network/testnet`, etc.) derived from
+`$NETWORK` so issues can be triaged per network.
 
-### 7. Build the issue body
+### 8. Build the issue body
 
 ```
 ## Summary
@@ -119,10 +228,13 @@ Always include the `bug` label. Add subsystem labels on top.
 
 - **OS**: {OS}
 - **Go**: {GO_VER}
-- **Daemon**: {commit= and wallet_type= fields from BUILD line}
+- **Daemon**: {commit= and version= from BUILD line}
+- **Network**: {NETWORK}
+- **Wallet type**: {WALLET_TYPE}
+- **Chain backend**: {BACKEND_NAME} — {BACKEND_URL} → {BACKEND_STATUS}
 - **IPv6**: {IPV6}
-- **Esplora**: {ESPLORA_URL} → HTTP {ESPLORA_HTTP}
 - **Daemon PID**: {DAEMON_PID}
+- **Log file**: {LOG}
 - **Session window**: {FIRST_TS} → {LAST_TS}
 
 ## Config (~/.darepod/darepod.conf, secrets redacted)
@@ -162,7 +274,7 @@ line count}
 </details>
 ```
 
-### 8. Preview and confirm
+### 9. Preview and confirm
 
 Print the full title and body to the terminal. Then ask:
 **"File this issue now? [y/N]"**
@@ -174,6 +286,7 @@ gh issue create \
   --title "{description}" \
   --body  "{body}" \
   --label "bug" \
+  --label "network/{NETWORK}" \
   --label "{each detected subsystem label}"
 ```
 
@@ -182,7 +295,7 @@ Print the resulting issue URL.
 If **no**, print the body so the user can copy-paste it manually and note:
 `Open a new issue at: https://github.com/lightninglabs/darepo-client/issues/new`
 
-### 9. If `gh` is not available or not authenticated
+### 10. If `gh` is not available or not authenticated
 
 Skip the filing step. Print the body and the manual URL above. Do not treat
 this as an error — a copy-pasteable report is still a good outcome.

--- a/.claude/skills/bug-report/SKILL.md
+++ b/.claude/skills/bug-report/SKILL.md
@@ -24,33 +24,35 @@ one sentence describing what went wrong before collecting anything.
 ### 2. Collect session logs
 
 ```bash
-# Line number where the most recent daemon session started
-START=$(grep -n "Starting darepod" ~/.darepod/logs/signet/darepod.log \
-  | tail -1 | cut -d: -f1)
+LOG=~/.darepod/logs/signet/darepod.log
 
-# Full log for the current session
-SESSION=$(tail -n +${START} ~/.darepod/logs/signet/darepod.log)
+if [ -f "$LOG" ]; then
+  # Line where the most recent daemon session started. Fall back to line
+  # 1 if no marker is found — a partial log is better than none.
+  START=$(grep -n "Starting darepod" "$LOG" | tail -1 | cut -d: -f1)
+  SESSION=$(tail -n +${START:-1} "$LOG")
 
-# Build line (commit hash, network, wallet type)
-BUILD=$(echo "$SESSION" | grep "Starting darepod" | tail -1)
-
-# Warnings and errors from this session, capped at 40 lines
-ERRORS=$(echo "$SESSION" | grep -E '\[WRN\]|\[ERR\]' | tail -40)
-
-# Session window
-FIRST_TS=$(echo "$SESSION" | head -1 | cut -c1-19)
-LAST_TS=$(echo "$SESSION"  | tail -1 | cut -c1-19)
+  BUILD=$(echo "$SESSION" | grep "Starting darepod" | tail -1)
+  ERRORS=$(echo "$SESSION" | grep -E '\[WRN\]|\[ERR\]' | tail -40)
+  FIRST_TS=$(echo "$SESSION" | head -1 | cut -c1-19)
+  LAST_TS=$(echo "$SESSION"  | tail -1 | cut -c1-19)
+else
+  SESSION="" BUILD="" ERRORS="" FIRST_TS="" LAST_TS=""
+fi
 ```
 
-If `~/.darepod/logs/signet/darepod.log` does not exist, note that no log
-file was found and continue — do not abort.
+If the log file does not exist, the variables are empty — the report will
+note "no log file found" in the affected sections instead of aborting.
 
 ### 3. Collect environment
 
 ```bash
-OS=$(sw_vers 2>/dev/null | tr '\n' ' ')
+OS=$(uname -srvm)
 GO_VER=$(go version 2>/dev/null)
-IPV6=$(networksetup -getinfo Wi-Fi 2>/dev/null | grep -E "IPv6")
+# Portable IPv6 check: any non-link-local, non-loopback inet6 address.
+# ifconfig works on macOS and most Linux distros.
+IPV6=$(ifconfig 2>/dev/null | awk '/inet6/ && !/fe80|::1/ {print $2; exit}')
+IPV6=${IPV6:-none}
 ESPLORA_URL=$(grep 'esploraurl' ~/.darepod/darepod.conf 2>/dev/null \
   | cut -d= -f2)
 ESPLORA_HTTP=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 5 \
@@ -58,10 +60,24 @@ ESPLORA_HTTP=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 5 \
 DAEMON_PID=$(pgrep -x darepod || echo "not running")
 ```
 
-### 4. Read config
+### 4. Read and redact config
 
-Read `~/.darepod/darepod.conf` verbatim. It contains no secrets — no
-redaction needed.
+Read `~/.darepod/darepod.conf` and redact secrets before including in the
+report. Replace the value of any line whose key matches one of these
+patterns with `<REDACTED>`:
+
+- `bitcoind.user`, `bitcoind.pass`, `bitcoind.rpcuser`, `bitcoind.rpcpass`,
+  `bitcoind.rpcpassword`
+- any key ending in `password`, `pass`, `secret`, `token`, or `apikey`
+
+```bash
+CONFIG=$(sed -E '
+  s/^([[:space:]]*bitcoind\.(user|pass|rpcuser|rpcpass(word)?))[[:space:]]*=.*/\1=<REDACTED>/;
+  s/^([[:space:]]*[^=]*(password|secret|token|apikey))[[:space:]]*=.*/\1=<REDACTED>/I
+' ~/.darepod/darepod.conf 2>/dev/null)
+```
+
+Use `$CONFIG` (not the raw file) in the report body.
 
 ### 5. Collect live wallet state
 
@@ -109,10 +125,10 @@ Always include the `bug` label. Add subsystem labels on top.
 - **Daemon PID**: {DAEMON_PID}
 - **Session window**: {FIRST_TS} → {LAST_TS}
 
-## Config (~/.darepod/darepod.conf)
+## Config (~/.darepod/darepod.conf, secrets redacted)
 
 \`\`\`
-{darepod.conf contents}
+{CONFIG}
 \`\`\`
 
 ## Warnings and Errors (this session)


### PR DESCRIPTION
## Summary

- Adds a Claude Code skill at `.claude/skills/bug-report/SKILL.md` that testers can invoke with `/bugreport "description"` during a signet test session
- Automatically collects the current daemon session's logs, WRN/ERR lines, build commit, `darepod.conf`, Esplora reachability, and live wallet state
- Detects affected subsystems from log prefixes (LWWL, ARKW, WRPC, etc.) and applies them as labels
- Shows a preview before filing and falls back gracefully to a copy-pasteable report if `gh` is not authenticated

## Test plan

- [ ] Run `/bugreport "test"` in a session with the daemon running — verify preview shows correct commit, config, and recent errors
- [ ] Run `/bugreport` with daemon stopped — verify "daemon not running" is noted and report still generates
- [ ] Run without `gh` auth — verify body is printed to stdout with the manual issue URL

🤖 Generated with [Claude Code](https://claude.ai/claude-code)