### PR TITLE
darepocli: Pretty-print error envelopes

### DIFF
--- a/cmd/darepocli/darepoclicommands/root.go
+++ b/cmd/darepocli/darepoclicommands/root.go
@@ -1,8 +1,10 @@
 package darepoclicommands
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/lightninglabs/darepo-client/build"
@@ -91,6 +93,15 @@ func NewRootCmd() *cobra.Command {
 	return cmd
 }
 
+type errorEnvelope struct {
+	Error errorPayload `json:"error"`
+}
+
+type errorPayload struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
 // PrintError writes a structured error to stderr in JSON format and
 // returns an error that carries the same code/message plus a marker
 // that main() can pick up via ErrorWasPrinted to avoid re-emitting the
@@ -98,11 +109,27 @@ func NewRootCmd() *cobra.Command {
 // surface keeps signalling failure to the harness while stderr stays
 // machine-readable.
 func PrintError(code string, msg string) error {
-	fmt.Fprintf(
-		os.Stderr, `{"error":{"code":%q,"message":%q}}`+"\n", code, msg,
-	)
+	if err := printError(os.Stderr, code, msg); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %s\n", msg)
+	}
 
 	return &printedError{code: code, msg: msg}
+}
+
+func printError(w io.Writer, code string, msg string) error {
+	data, err := json.MarshalIndent(errorEnvelope{
+		Error: errorPayload{
+			Code:    code,
+			Message: msg,
+		},
+	}, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	_, err = fmt.Fprintln(w, string(data))
+
+	return err
 }
 
 // printedError is the wrapper returned by PrintError. It carries a

--- a/cmd/darepocli/darepoclicommands/root_test.go
+++ b/cmd/darepocli/darepoclicommands/root_test.go
@@ -1,0 +1,30 @@
+package darepoclicommands
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrintErrorFormatsIndentedJSON(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	err := printError(
+		&buf, "EXECUTION_FAILED",
+		`recv invoice: rpc error: code = Internal desc = "boom"`,
+	)
+	require.NoError(t, err)
+
+	require.JSONEq(t, `{
+		"error": {
+			"code": "EXECUTION_FAILED",
+			"message": "recv invoice: rpc error: code = Internal desc = \"boom\""
+		}
+	}`, buf.String())
+
+	require.Contains(t, buf.String(), "\n  \"error\": {\n")
+	require.Contains(t, buf.String(), "\n    \"code\": \"EXECUTION_FAILED\"")
+	require.Contains(t, buf.String(), "\n    \"message\": ")
+}

--- a/cmd/darepocli/darepoclicommands/root_test.go
+++ b/cmd/darepocli/darepoclicommands/root_test.go
@@ -2,6 +2,7 @@ package darepoclicommands
 
 import (
 	"bytes"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -10,21 +11,23 @@ import (
 func TestPrintErrorFormatsIndentedJSON(t *testing.T) {
 	t.Parallel()
 
+	const msg = `recv invoice: rpc error: code = Internal ` +
+		`desc = "boom"`
+
 	var buf bytes.Buffer
-	err := printError(
-		&buf, "EXECUTION_FAILED",
-		`recv invoice: rpc error: code = Internal desc = "boom"`,
-	)
+	err := printError(&buf, "EXECUTION_FAILED", msg)
 	require.NoError(t, err)
 
-	require.JSONEq(t, `{
-		"error": {
-			"code": "EXECUTION_FAILED",
-			"message": "recv invoice: rpc error: code = Internal desc = \"boom\""
-		}
-	}`, buf.String())
+	encoded, err := json.Marshal(msg)
+	require.NoError(t, err)
+	expected := `{"error":{"code":"EXECUTION_FAILED","message":` +
+		string(encoded) + `}}`
+	require.JSONEq(t, expected, buf.String())
 
 	require.Contains(t, buf.String(), "\n  \"error\": {\n")
-	require.Contains(t, buf.String(), "\n    \"code\": \"EXECUTION_FAILED\"")
+	require.Contains(
+		t, buf.String(),
+		"\n    \"code\": \"EXECUTION_FAILED\"",
+	)
 	require.Contains(t, buf.String(), "\n    \"message\": ")
 }


### PR DESCRIPTION
## Summary

- Pretty-print structured CLI error envelopes with `json.MarshalIndent`.
- Preserve the existing `error.code` / `error.message` JSON contract for tools.
- Add a focused regression test for the visible indentation and JSON shape.

## Test

- `go test ./cmd/darepocli/...`