### PR TITLE
swapwallet: defer resume until wallet ready

### DIFF
--- a/daemonrpc/errors.go
+++ b/daemonrpc/errors.go
@@ -1,0 +1,54 @@
+package daemonrpc
+
+import (
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	walletNotReadyDomain = "darepo-client/wallet"
+
+	// WalletNotReadyReason identifies gRPC FailedPrecondition errors
+	// caused by a daemon wallet lifecycle state that is not yet usable.
+	WalletNotReadyReason = "WALLET_NOT_READY"
+)
+
+// WalletNotReadyError returns a structured gRPC error for wallet lifecycle
+// preconditions. The human message may change, but callers should match the
+// stable ErrorInfo reason with IsWalletNotReadyError.
+func WalletNotReadyError(msg string) error {
+	st := status.New(codes.FailedPrecondition, msg)
+	st, err := st.WithDetails(&errdetails.ErrorInfo{
+		Reason: WalletNotReadyReason,
+		Domain: walletNotReadyDomain,
+	})
+	if err != nil {
+		return status.Error(codes.FailedPrecondition, msg)
+	}
+
+	return st.Err()
+}
+
+// IsWalletNotReadyError reports whether err is the structured wallet lifecycle
+// precondition returned by WalletNotReadyError.
+func IsWalletNotReadyError(err error) bool {
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.FailedPrecondition {
+		return false
+	}
+
+	for _, detail := range st.Details() {
+		info, ok := detail.(*errdetails.ErrorInfo)
+		if !ok {
+			continue
+		}
+
+		if info.GetDomain() == walletNotReadyDomain &&
+			info.GetReason() == WalletNotReadyReason {
+			return true
+		}
+	}
+
+	return false
+}

--- a/daemonrpc/errors_test.go
+++ b/daemonrpc/errors_test.go
@@ -1,0 +1,31 @@
+package daemonrpc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestWalletNotReadyErrorMatchesStructuredReason verifies callers can match
+// daemon wallet lifecycle preconditions without depending on message text.
+func TestWalletNotReadyErrorMatchesStructuredReason(t *testing.T) {
+	t.Parallel()
+
+	err := WalletNotReadyError("custom readiness wording")
+
+	require.True(t, IsWalletNotReadyError(err))
+	require.Equal(t, codes.FailedPrecondition, status.Code(err))
+	require.Contains(t, err.Error(), "custom readiness wording")
+}
+
+// TestIsWalletNotReadyErrorRejectsPlainFailedPrecondition verifies unrelated
+// caller errors with the same gRPC code remain terminal to swap callers.
+func TestIsWalletNotReadyErrorRejectsPlainFailedPrecondition(t *testing.T) {
+	t.Parallel()
+
+	err := status.Error(codes.FailedPrecondition, "operator rejected swap")
+
+	require.False(t, IsWalletNotReadyError(err))
+}

--- a/darepod/config.go
+++ b/darepod/config.go
@@ -169,6 +169,13 @@ type Config struct {
 	// DaemonService is registered.
 	RPCGatewayRegistrars []RPCGatewayRegistrar
 
+	// WalletReadyHooks are programmatic hooks that run after the
+	// wallet-derived mailbox transport and wallet-dependent actors are
+	// online, but before daemon readiness is marked. They are used by
+	// optional subservers that must register RPC surfaces while locked
+	// but defer background work until the wallet can sign.
+	WalletReadyHooks []WalletReadyHook
+
 	// Wallet configures the wallet backend used for signing, key
 	// derivation, and chain access.
 	Wallet *WalletConfig `mapstructure:"wallet"`
@@ -253,6 +260,10 @@ type RPCGatewayRegistrar func(
 	ctx context.Context, mux *runtime.ServeMux, endpoint string,
 	opts []grpc.DialOption, rpcServer *RPCServer, cfg *Config,
 ) error
+
+// WalletReadyHook runs once after the daemon wallet is unlocked and all
+// wallet-dependent daemon services have started.
+type WalletReadyHook func(ctx context.Context) error
 
 // UnrollConfig configures the unilateral-exit subsystem.
 type UnrollConfig struct {
@@ -378,9 +389,9 @@ type SwapConfig struct {
 type SwapBackend interface {
 	// ResumePending re-arms background workers for every persisted
 	// pending swap session. It is idempotent: payment hashes already
-	// owned by an active worker are skipped. Callers invoke it once at
-	// daemon startup so the gRPC server begins accepting requests with
-	// every prior session already running.
+	// owned by an active worker are skipped. Callers invoke it once
+	// when the active resume policy is allowed to start background
+	// workers.
 	ResumePending(ctx context.Context)
 }
 

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -441,33 +441,27 @@ func (r *RPCServer) requireWalletReady() error {
 		return nil
 
 	case WalletStateNone:
-		return status.Error(
-			codes.FailedPrecondition,
+		return daemonrpc.WalletNotReadyError(
 			"wallet is not ready (create first)",
 		)
 
 	case WalletStateLocked:
-		return status.Error(
-			codes.FailedPrecondition,
+		return daemonrpc.WalletNotReadyError(
 			"wallet is not ready (unlock first)",
 		)
 
 	case WalletStateUnlocking:
-		return status.Error(
-			codes.FailedPrecondition,
+		return daemonrpc.WalletNotReadyError(
 			"wallet unlock is in progress",
 		)
 
 	case WalletStateSyncing:
-		return status.Error(
-			codes.FailedPrecondition,
+		return daemonrpc.WalletNotReadyError(
 			"wallet is syncing; try again once sync completes",
 		)
 
 	default:
-		return status.Error(
-			codes.FailedPrecondition, "wallet is not ready",
-		)
+		return daemonrpc.WalletNotReadyError("wallet is not ready")
 	}
 }
 

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -1138,7 +1138,28 @@ func (s *Server) startWalletReadyServices(ctx context.Context,
 		return err
 	}
 
+	if err := s.runWalletReadyHooks(ctx); err != nil {
+		return err
+	}
+
 	s.markDaemonReady()
+
+	return nil
+}
+
+// runWalletReadyHooks runs optional post-wallet-unlock hooks in registration
+// order. Hooks are intentionally run after wallet-dependent services are
+// online so optional subservers can safely start background work that calls
+// wallet RPCs.
+func (s *Server) runWalletReadyHooks(ctx context.Context) error {
+	for _, hook := range s.cfg.WalletReadyHooks {
+		if hook == nil {
+			continue
+		}
+		if err := hook(ctx); err != nil {
+			return fmt.Errorf("wallet-ready hook: %w", err)
+		}
+	}
 
 	return nil
 }

--- a/darepod/wallet_ready_hooks_test.go
+++ b/darepod/wallet_ready_hooks_test.go
@@ -1,0 +1,58 @@
+package darepod
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunWalletReadyHooksRunsInOrder verifies optional subservers can depend
+// on deterministic wallet-ready hook ordering.
+func TestRunWalletReadyHooksRunsInOrder(t *testing.T) {
+	t.Parallel()
+
+	var calls []int
+	s := &Server{
+		cfg: &Config{
+			WalletReadyHooks: []WalletReadyHook{
+				func(context.Context) error {
+					calls = append(calls, 1)
+
+					return nil
+				},
+				nil,
+				func(context.Context) error {
+					calls = append(calls, 2)
+
+					return nil
+				},
+			},
+		},
+	}
+
+	require.NoError(t, s.runWalletReadyHooks(t.Context()))
+	require.Equal(t, []int{1, 2}, calls)
+}
+
+// TestRunWalletReadyHooksPropagatesError verifies startup fails closed when a
+// wallet-ready hook cannot start its post-unlock background work.
+func TestRunWalletReadyHooksPropagatesError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("resume failed")
+	s := &Server{
+		cfg: &Config{
+			WalletReadyHooks: []WalletReadyHook{
+				func(context.Context) error {
+					return wantErr
+				},
+			},
+		},
+	}
+
+	err := s.runWalletReadyHooks(t.Context())
+	require.ErrorIs(t, err, wantErr)
+	require.ErrorContains(t, err, "wallet-ready hook")
+}

--- a/sdk/swaps/errors.go
+++ b/sdk/swaps/errors.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/lightninglabs/darepo-client/daemonrpc"
 	loopfsm "github.com/lightninglabs/loop/fsm"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -211,6 +212,10 @@ func handleFailure(ctx context.Context, err error, runErr *error,
 		return loopfsm.NoOp
 	}
 
+	if isWalletNotReadyErr(err) {
+		return loopfsm.NoOp
+	}
+
 	if errors.Is(err, errSwapExpired) {
 		if currentExpired {
 			return loopfsm.NoOp
@@ -249,4 +254,11 @@ func handleFailure(ctx context.Context, err error, runErr *error,
 	}
 
 	return failedEvent
+}
+
+// isWalletNotReadyErr reports daemon wallet-readiness preconditions that are
+// transient across startup and unlock. These errors must not durably fail a
+// swap because a later resume can continue once the daemon wallet is ready.
+func isWalletNotReadyErr(err error) bool {
+	return daemonrpc.IsWalletNotReadyError(err)
 }

--- a/sdk/swaps/errors_test.go
+++ b/sdk/swaps/errors_test.go
@@ -1,0 +1,133 @@
+package swaps
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	loopfsm "github.com/lightninglabs/loop/fsm"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestWalletNotReadyFailureIsNonTerminal verifies transient daemon wallet
+// readiness errors do not durably fail persisted swaps.
+func TestWalletNotReadyFailureIsNonTerminal(t *testing.T) {
+	t.Parallel()
+
+	tests := []string{
+		"custom daemon readiness text",
+		"renamed syncing readiness text",
+	}
+
+	for _, msg := range tests {
+		t.Run(msg, func(t *testing.T) {
+			t.Parallel()
+
+			var runErr error
+			markFailedCalls := 0
+			event := handleFailure(
+				t.Context(),
+				daemonrpc.WalletNotReadyError(msg),
+				&runErr,
+				false,
+				false,
+				func(context.Context) error {
+					return nil
+				},
+				loopfsm.EventType("expired"),
+				func(context.Context, string) error {
+					return nil
+				},
+				loopfsm.EventType("intervention"),
+				func(context.Context, string) error {
+					markFailedCalls++
+
+					return nil
+				},
+				loopfsm.EventType("failed"),
+			)
+
+			require.Equal(t, loopfsm.NoOp, event)
+			require.Equal(t, 0, markFailedCalls)
+			require.Error(t, runErr)
+		})
+	}
+}
+
+// TestWrappedWalletNotReadyFailureIsNonTerminal verifies the structured
+// readiness marker survives normal Go error wrapping.
+func TestWrappedWalletNotReadyFailureIsNonTerminal(t *testing.T) {
+	t.Parallel()
+
+	var runErr error
+	markFailedCalls := 0
+	event := handleFailure(
+		t.Context(),
+		fmt.Errorf("resume receive swap: %w",
+			daemonrpc.WalletNotReadyError("wallet still syncing")),
+		&runErr,
+		false,
+		false,
+		func(context.Context) error {
+			return nil
+		},
+		loopfsm.EventType("expired"),
+		func(context.Context, string) error {
+			return nil
+		},
+		loopfsm.EventType("intervention"),
+		func(context.Context, string) error {
+			markFailedCalls++
+
+			return nil
+		},
+		loopfsm.EventType("failed"),
+	)
+
+	require.Equal(t, loopfsm.NoOp, event)
+	require.Equal(t, 0, markFailedCalls)
+	require.Error(t, runErr)
+}
+
+// TestUnrelatedFailedPreconditionRemainsTerminal verifies the wallet-ready
+// classifier is narrow and does not hide unrelated protocol failures.
+func TestUnrelatedFailedPreconditionRemainsTerminal(t *testing.T) {
+	t.Parallel()
+
+	var runErr error
+	var failedReason string
+	err := status.Error(
+		codes.FailedPrecondition, "operator rejected swap",
+	)
+	event := handleFailure(
+		t.Context(),
+		err,
+		&runErr,
+		false,
+		false,
+		func(context.Context) error {
+			return nil
+		},
+		loopfsm.EventType("expired"),
+		func(context.Context, string) error {
+			return nil
+		},
+		loopfsm.EventType("intervention"),
+		func(_ context.Context, reason string) error {
+			failedReason = reason
+
+			return nil
+		},
+		loopfsm.EventType("failed"),
+	)
+
+	require.Equal(t, loopfsm.EventType("failed"), event)
+	require.Equal(
+		t, "rpc error: code = FailedPrecondition desc = operator "+
+			"rejected swap", failedReason,
+	)
+	require.Error(t, runErr)
+}

--- a/sdk/walletdk/embedded.go
+++ b/sdk/walletdk/embedded.go
@@ -353,6 +353,9 @@ func cloneDaemonConfig(cfg *darepod.Config) *darepod.Config {
 	clone.RPCServiceRegistrars = append(
 		[]darepod.RPCServiceRegistrar(nil), cfg.RPCServiceRegistrars...,
 	)
+	clone.WalletReadyHooks = append(
+		[]darepod.WalletReadyHook(nil), cfg.WalletReadyHooks...,
+	)
 
 	return &clone
 }

--- a/sdk/walletdk/embedded_test.go
+++ b/sdk/walletdk/embedded_test.go
@@ -61,6 +61,11 @@ func TestCloneDaemonConfigIsolation(t *testing.T) {
 			return func() {}, nil
 		},
 	}
+	original.WalletReadyHooks = []darepod.WalletReadyHook{
+		func(context.Context) error {
+			return nil
+		},
+	}
 
 	clone := cloneDaemonConfig(original)
 

--- a/swapwallet/register.go
+++ b/swapwallet/register.go
@@ -5,6 +5,7 @@ package swapwallet
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/lightninglabs/darepo-client/darepod"
@@ -67,11 +68,18 @@ func Register(ctx context.Context, grpcServer *grpc.Server,
 			"implement swapclientrpc.SwapClientServiceServer")
 	}
 
+	var coreRPC RPCServer
+	if rpcServer != nil {
+		coreRPC = rpcServer
+	}
+
 	deps := &Deps{
 		SwapBackend: cfg.Swap.Backend,
 		SwapService: swapService,
-		RPCServer:   rpcServer,
-		Log:         rpcServer.SubLogger(darepod.WalletRPCSubsystem),
+		RPCServer:   coreRPC,
+	}
+	if rpcServer != nil {
+		deps.Log = rpcServer.SubLogger(darepod.WalletRPCSubsystem)
 	}
 
 	// Apply optional walletrpc-config overrides. The struct is present
@@ -90,15 +98,26 @@ func Register(ctx context.Context, grpcServer *grpc.Server,
 
 	walletrpc.RegisterWalletServiceServer(grpcServer, service)
 
-	// The unified resume sweep MUST run before this Register returns so
-	// the gRPC server begins accepting wallet RPCs with every pending
-	// entry already driven by a background worker.
-	runtime.resumeAll(ctx)
+	var startOnce sync.Once
+	cfg.WalletReadyHooks = append(cfg.WalletReadyHooks, func(
+		ctx context.Context) error {
 
-	// Start background goroutines (deadline watcher, future monitor
-	// loop). They anchor to the runtime's rootCtx and live until the
-	// cleanup function below cancels it.
-	runtime.start()
+		startOnce.Do(func() {
+			// The unified resume sweep must wait until the main
+			// daemon wallet and wallet-dependent actors are ready.
+			// Otherwise a locked self-managed wallet restart can
+			// resume workers early and persist transient unlock
+			// errors as terminal failures.
+			runtime.resumeAll(ctx)
+
+			// Start background goroutines after resume so
+			// subscribers and the deadline watcher observe a
+			// runtime that owns the pending rows it just resumed.
+			runtime.start()
+		})
+
+		return nil
+	})
 
 	cleanup := func() {
 		runtime.stop()

--- a/swapwallet/register_test.go
+++ b/swapwallet/register_test.go
@@ -8,7 +8,9 @@ import (
 	"testing"
 
 	"github.com/lightninglabs/darepo-client/darepod"
+	"github.com/lightninglabs/darepo-client/rpc/swapclientrpc"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 )
 
 // fakeResumeOnlyBackend implements darepod.SwapBackend but deliberately
@@ -21,6 +23,55 @@ type fakeResumeOnlyBackend struct {
 
 func (f *fakeResumeOnlyBackend) ResumePending(_ context.Context) {
 	f.resumeCalls.Add(1)
+}
+
+// fakeWalletBackend satisfies both the in-Go resume handle and the gRPC-shaped
+// swap service required by the wallet registrar.
+type fakeWalletBackend struct {
+	swapclientrpc.UnimplementedSwapClientServiceServer
+
+	resumeCalls atomic.Int32
+}
+
+func (f *fakeWalletBackend) ResumePending(_ context.Context) {
+	f.resumeCalls.Add(1)
+}
+
+// TestRegisterDefersResumeUntilWalletReadyHook confirms the wallet subserver
+// registers its RPC surface immediately but waits for the daemon's wallet-ready
+// phase before starting persisted swap workers.
+func TestRegisterDefersResumeUntilWalletReadyHook(t *testing.T) {
+	t.Parallel()
+
+	backend := &fakeWalletBackend{}
+	cfg := &darepod.Config{
+		Swap: &darepod.SwapConfig{
+			Backend:        backend,
+			SuppressResume: true,
+		},
+	}
+
+	cleanup, err := Register(
+		t.Context(), grpc.NewServer(), nil, cfg,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, cleanup)
+	t.Cleanup(cleanup)
+
+	require.Equal(
+		t, int32(0), backend.resumeCalls.Load(),
+		"registering walletrpc while locked must not resume swaps",
+	)
+	require.Len(t, cfg.WalletReadyHooks, 1)
+
+	require.NoError(t, cfg.WalletReadyHooks[0](t.Context()))
+	require.Equal(t, int32(1), backend.resumeCalls.Load())
+
+	require.NoError(t, cfg.WalletReadyHooks[0](t.Context()))
+	require.Equal(
+		t, int32(1), backend.resumeCalls.Load(),
+		"wallet-ready hook must be idempotent",
+	)
 }
 
 // TestRegisterRecoversResumeOnTypeAssertionFailure asserts that when

--- a/swapwallet/runtime.go
+++ b/swapwallet/runtime.go
@@ -47,6 +47,11 @@ type Runtime struct {
 	// wg tracks background goroutines so cleanup blocks until they exit.
 	wg sync.WaitGroup
 
+	// startOnce makes runtime startup idempotent. The daemon should run
+	// the wallet-ready hook once, but this prevents duplicate monitor or
+	// deadline goroutines if future wiring accidentally invokes it twice.
+	startOnce sync.Once
+
 	// subsMu guards subscribers.
 	subsMu sync.Mutex
 
@@ -99,22 +104,26 @@ func newRuntime(parent context.Context, deps *Deps) *Runtime {
 	}
 }
 
-// start spawns the runtime's background goroutines. Called by Register
-// after the synchronous resume sweep so the daemon never accepts a wallet
-// RPC before the deadline watcher is running and the monitor loop is
-// already consuming swap updates from the in-process swap subserver.
+// start spawns the runtime's background goroutines. The wallet-ready hook
+// calls this after the resume sweep so the deadline watcher and monitor loop
+// only run once the daemon wallet can service resumed workers. Runtime keeps
+// its own guard as a local backstop in case future wiring starts it outside
+// the wallet-ready hook.
 func (r *Runtime) start() {
-	r.wg.Add(1)
-	go r.deadlineWatcher()
+	r.startOnce.Do(func() {
+		r.wg.Add(1)
+		go r.deadlineWatcher()
 
-	r.startMonitorLoop()
+		r.startMonitorLoop()
+	})
 }
 
-// resumeAll performs the unified resume sweep. It MUST run synchronously
-// before the gRPC server begins accepting wallet RPCs so the daemon never
-// surfaces a PENDING entry it is not actively driving. The implementation is
-// staged across phases; v1 delegates to the swap backend for the swap-side
-// resume and leaves room for additional wallet-managed pending tables.
+// resumeAll performs the unified resume sweep during the daemon wallet-ready
+// phase. The wallet RPC surface may already be registered while the daemon is
+// locked, but wallet-dependent workers must wait until resumed swaps can use
+// the unlocked wallet. The implementation is staged across phases; v1
+// delegates to the swap backend for the swap-side resume and leaves room for
+// additional wallet-managed pending tables.
 func (r *Runtime) resumeAll(ctx context.Context) {
 	log := r.deps.resolveLog()
 


### PR DESCRIPTION
## Summary

- add wallet-ready hooks to run optional post-unlock daemon work after wallet-dependent services start
- defer walletrpc unified swap resume/runtime startup until the wallet-ready phase
- preserve walletdk daemon-config isolation for the new wallet-ready hook slice
- treat daemon wallet-readiness precondition errors as retryable/non-terminal by matching a shared structured gRPC ErrorInfo reason instead of message text

Fixes #492.

## Test Plan

- `make fmt-changed-check base=origin/main`
- `make commitmsg-lint range=origin/main..HEAD`
- `make unit pkg=daemonrpc timeout=5m`
- `make unit pkg=darepod timeout=5m`
- `make unit pkg=swapwallet tags="swapruntime walletrpc" timeout=5m`
- `make unit pkg=sdk/swaps timeout=5m`
- `make unit pkg=sdk/walletdk tags="walletrpc swapruntime" timeout=5m`

Note: `make lint-local` still fails on unrelated existing line-length findings in `cmd/darepocli/internal/gen-devrpc/main.go`.
