### PR TITLE
sdk/swaps: make per-swap mailbox receiver survive transport errors

### DIFF
--- a/sdk/swaps/out_swap_mailbox.go
+++ b/sdk/swaps/out_swap_mailbox.go
@@ -7,8 +7,10 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btclog/v2"
 	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
 	"github.com/lightninglabs/darepo-client/serverconn"
+	"github.com/lightninglabs/darepo-client/serverconn/mailboxpull"
 	"github.com/lightninglabs/darepo-client/swaprpc"
 	"github.com/lightningnetwork/lnd/lntypes"
 )
@@ -37,20 +39,60 @@ type MailboxOutSwapEventReceiver struct {
 	mailboxID        string
 	pullWaitTimeout  time.Duration
 	pullMaxEnvelopes uint32
+
+	// pullBackoff controls the exponential backoff schedule applied when
+	// edge.Pull returns a transport error. The default schedule matches
+	// the serverconn ingress loop so the daemon's reconnect cadence is
+	// uniform across both consumers.
+	pullBackoff mailboxpull.BackoffConfig
+
+	// log receives one WARN per failed pull attempt. nil is treated as a
+	// no-op logger.
+	log btclog.Logger
+}
+
+// MailboxReceiverOption tweaks a MailboxOutSwapEventReceiver at construction
+// time. Defaults match the production wiring; tests use these to drive the
+// retry schedule deterministically.
+type MailboxReceiverOption func(*MailboxOutSwapEventReceiver)
+
+// WithMailboxPullBackoff overrides the exponential backoff schedule used when
+// edge.Pull returns a transport error.
+func WithMailboxPullBackoff(
+	cfg mailboxpull.BackoffConfig) MailboxReceiverOption {
+
+	return func(r *MailboxOutSwapEventReceiver) {
+		r.pullBackoff = cfg
+	}
+}
+
+// WithMailboxReceiverLog wires a structured logger so retry attempts surface
+// in daemon logs alongside the equivalent serverconn ingress messages.
+func WithMailboxReceiverLog(log btclog.Logger) MailboxReceiverOption {
+	return func(r *MailboxOutSwapEventReceiver) {
+		r.log = log
+	}
 }
 
 // NewMailboxOutSwapEventReceiver creates a mailbox-backed out-swap event
 // receiver. When mailboxID is empty, WaitOutSwapHtlc derives the mailbox from
 // the client identity key supplied by the caller.
 func NewMailboxOutSwapEventReceiver(edge mailboxpb.MailboxServiceClient,
-	mailboxID string) *MailboxOutSwapEventReceiver {
+	mailboxID string,
+	opts ...MailboxReceiverOption) *MailboxOutSwapEventReceiver {
 
-	return &MailboxOutSwapEventReceiver{
+	r := &MailboxOutSwapEventReceiver{
 		edge:             edge,
 		mailboxID:        mailboxID,
 		pullWaitTimeout:  5 * time.Second,
 		pullMaxEnvelopes: 1,
+		pullBackoff:      mailboxpull.DefaultBackoffConfig(),
 	}
+	for _, opt := range opts {
+		opt(r)
+	}
+
+	return r
 }
 
 // WaitOutSwapHtlc waits until the matching out-swap HTLC mailbox event is
@@ -74,12 +116,15 @@ func (r *MailboxOutSwapEventReceiver) WaitOutSwapHtlc(ctx context.Context,
 
 	cursor := uint64(0)
 	for {
-		resp, err := r.edge.Pull(ctx, &mailboxpb.PullRequest{
+		req := &mailboxpb.PullRequest{
 			MailboxId:     mailboxID,
 			MaxEnvelopes:  r.pullMaxEnvelopes,
 			WaitTimeoutMs: uint32(r.pullWaitTimeout.Milliseconds()),
 			Cursor:        cursor,
-		})
+		}
+		resp, err := mailboxpull.PullWithRetry(
+			ctx, r.edge, req, r.pullBackoff, r.log,
+		)
 		if err != nil {
 			return nil, fmt.Errorf("pull out-swap mailbox: %w", err)
 		}
@@ -143,12 +188,15 @@ func (r *MailboxOutSwapEventReceiver) WaitIncomingVHTLC(ctx context.Context,
 
 	cursor := uint64(0)
 	for {
-		resp, err := r.edge.Pull(ctx, &mailboxpb.PullRequest{
+		req := &mailboxpb.PullRequest{
 			MailboxId:     mailboxID,
 			MaxEnvelopes:  r.pullMaxEnvelopes,
 			WaitTimeoutMs: uint32(r.pullWaitTimeout.Milliseconds()),
 			Cursor:        cursor,
-		})
+		}
+		resp, err := mailboxpull.PullWithRetry(
+			ctx, r.edge, req, r.pullBackoff, r.log,
+		)
 		if err != nil {
 			return nil, fmt.Errorf("pull incoming vHTLC "+
 				"mailbox: %w", err)

--- a/sdk/swaps/out_swap_mailbox_test.go
+++ b/sdk/swaps/out_swap_mailbox_test.go
@@ -7,16 +7,44 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
+	"github.com/lightninglabs/darepo-client/serverconn/mailboxpull"
 	"github.com/lightninglabs/darepo-client/swaprpc"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
+// pullStep is one step in a scripted pull sequence: either an error is
+// returned (simulating a transport failure) or a response is delivered. Used
+// by testOutSwapMailboxEdge to drive disconnect/reconnect scenarios.
+type pullStep struct {
+	err  error
+	resp *mailboxpb.PullResponse
+}
+
 type testOutSwapMailboxEdge struct {
+	// pullResp, when non-nil, is returned for every Pull call. Legacy
+	// single-shot behavior used by tests that don't care about reconnect.
 	pullResp *mailboxpb.PullResponse
-	ackReq   *mailboxpb.AckUpToRequest
+
+	// pullScript drives a sequence of Pull outcomes when non-empty. Steps
+	// are consumed in order; once exhausted, subsequent calls behave as
+	// if the script never ended (so leaked test goroutines time out
+	// against ctx rather than panicking).
+	pullScript []pullStep
+
+	// pullCursors records the cursor sent on every Pull request so tests
+	// can assert that retries reuse the prior cursor instead of resetting
+	// to zero.
+	pullCursors []uint64
+
+	// pullCalls counts how many times Pull was invoked.
+	pullCalls int
+
+	ackReq *mailboxpb.AckUpToRequest
 }
 
 func (t *testOutSwapMailboxEdge) Send(context.Context, *mailboxpb.SendRequest,
@@ -25,8 +53,27 @@ func (t *testOutSwapMailboxEdge) Send(context.Context, *mailboxpb.SendRequest,
 	return nil, nil
 }
 
-func (t *testOutSwapMailboxEdge) Pull(context.Context, *mailboxpb.PullRequest,
-	...grpc.CallOption) (*mailboxpb.PullResponse, error) {
+func (t *testOutSwapMailboxEdge) Pull(_ context.Context,
+	req *mailboxpb.PullRequest, _ ...grpc.CallOption) (
+	*mailboxpb.PullResponse, error) {
+
+	t.pullCursors = append(t.pullCursors, req.GetCursor())
+	idx := t.pullCalls
+	t.pullCalls++
+
+	if len(t.pullScript) > 0 {
+		if idx >= len(t.pullScript) {
+			// Exhausted script: keep returning the last step so a
+			// stuck outer loop times out on ctx rather than
+			// dereferencing nil.
+			step := t.pullScript[len(t.pullScript)-1]
+
+			return step.resp, step.err
+		}
+		step := t.pullScript[idx]
+
+		return step.resp, step.err
+	}
 
 	return t.pullResp, nil
 }
@@ -42,6 +89,15 @@ func (t *testOutSwapMailboxEdge) AckUpTo(_ context.Context,
 			Ok: true,
 		},
 	}, nil
+}
+
+// fastReceiverBackoff is the zero-wait backoff used by reconnect tests so we
+// don't add wall time to the suite.
+func fastReceiverBackoff() mailboxpull.BackoffConfig {
+	return mailboxpull.BackoffConfig{
+		BaseDelay: time.Microsecond,
+		MaxDelay:  time.Microsecond,
+	}
 }
 
 // TestMailboxOutSwapEventReceiverPullsAndAcks verifies that the SDK pulls a
@@ -210,4 +266,206 @@ func TestMailboxOutSwapEventReceiverPullsInArkEvent(t *testing.T) {
 		edge.ackReq.GetMailboxId(),
 	)
 	require.Equal(t, uint64(13), edge.ackReq.GetCursor())
+}
+
+// successfulOutSwapPullResp builds a one-envelope PullResponse carrying the
+// out-swap HTLC event matching paymentHash. Used by reconnect tests so each
+// case can wire its own scripted sequence of failures + this final success.
+func successfulOutSwapPullResp(t *testing.T, paymentHash lntypes.Hash,
+	swapserverKey *btcec.PublicKey, eventSeq,
+	nextCursor uint64) (*mailboxpb.PullResponse, error) {
+
+	t.Helper()
+
+	// Hoist the inner event so the VHTLCConfig literal sits at a shallower
+	// indent level. gofmt aligns struct field colons to the longest field
+	// name (UnilateralRefundWithoutReceiverDelay = 38 chars), and at the
+	// deeper anypb.New(...) nesting that alignment overflows the 80-char
+	// limit on every adjacent field.
+	protoEvent := &swaprpc.OutSwapHtlcEvent{
+		PaymentHash: paymentHash[:],
+		AmountSat:   1_000,
+		VhtlcConfig: &swaprpc.VHTLCConfig{
+			RefundLocktime:                       144,
+			UnilateralClaimDelay:                 12,
+			UnilateralRefundDelay:                24,
+			UnilateralRefundWithoutReceiverDelay: 36,
+			SwapserverPubkey: swapserverKey.
+				SerializeCompressed(),
+		},
+	}
+	body, err := anypb.New(&swaprpc.SwapMailboxEvent{
+		Event: &swaprpc.SwapMailboxEvent_OutSwapHtlc{
+			OutSwapHtlc: protoEvent,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &mailboxpb.PullResponse{
+		Status: &mailboxpb.Status{
+			Ok: true,
+		},
+		NextCursor: nextCursor,
+		Envelopes: []*mailboxpb.Envelope{{
+			Type:     outSwapMailboxEventType,
+			Body:     body,
+			EventSeq: eventSeq,
+			Rpc: &mailboxpb.RpcMeta{
+				Kind:    mailboxpb.RpcMeta_KIND_EVENT,
+				Service: outSwapMailboxEventService,
+				Method:  outSwapMailboxEventMethod,
+			},
+		}},
+	}, nil
+}
+
+// TestMailboxOutSwapEventReceiverRetriesOnUnavailable verifies that transient
+// codes.Unavailable errors (which is what a TCP RST against the mailbox
+// endpoint looks like to gRPC) are retried until the receiver gets a real
+// event, instead of failing the swap on the first blip.
+//
+// This is the regression test for issue #505.
+func TestMailboxOutSwapEventReceiverRetriesOnUnavailable(t *testing.T) {
+	t.Parallel()
+
+	authKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	hash := lntypes.Hash{1, 2, 3}
+	successResp, err := successfulOutSwapPullResp(
+		t, hash, authKey.PubKey(), 11, 12,
+	)
+	require.NoError(t, err)
+
+	edge := &testOutSwapMailboxEdge{
+		pullScript: []pullStep{
+			{
+				err: status.Error(codes.Unavailable, "rst1"),
+			},
+			{
+				err: status.Error(codes.Unavailable, "rst2"),
+			},
+			{
+				err: status.Error(codes.Unavailable, "rst3"),
+			},
+			{
+				resp: successResp,
+			},
+		},
+	}
+	receiver := NewMailboxOutSwapEventReceiver(
+		edge, "",
+		WithMailboxPullBackoff(
+			fastReceiverBackoff(),
+		),
+	)
+	receiver.pullWaitTimeout = time.Millisecond
+
+	notification, err := receiver.WaitOutSwapHtlc(
+		t.Context(), hash, authKey.PubKey(),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, notification)
+	require.Equal(t, hash, notification.Event.PaymentHash)
+	require.Equal(t, uint64(12), notification.AckCursor)
+
+	// Three transport failures + one success.
+	require.Equal(t, 4, edge.pullCalls)
+}
+
+// TestMailboxOutSwapEventReceiverRespectsCtxCancel verifies that a cancelled
+// ctx is honored promptly even when the endpoint keeps flapping; the receiver
+// must not loop forever after the caller (typically the swap FSM shutting
+// down) bails out.
+func TestMailboxOutSwapEventReceiverRespectsCtxCancel(t *testing.T) {
+	t.Parallel()
+
+	authKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	hash := lntypes.Hash{4, 5, 6}
+	edge := &testOutSwapMailboxEdge{
+		pullScript: []pullStep{
+			{
+				err: status.Error(codes.Unavailable, "rst"),
+			},
+		},
+	}
+	receiver := NewMailboxOutSwapEventReceiver(
+		edge, "",
+		WithMailboxPullBackoff(
+			fastReceiverBackoff(),
+		),
+	)
+	receiver.pullWaitTimeout = time.Millisecond
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err = receiver.WaitOutSwapHtlc(ctx, hash, authKey.PubKey())
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// TestMailboxOutSwapEventReceiverPreservesCursorAcrossRetry verifies that
+// when a pull advances the cursor (e.g. by returning an empty batch with a
+// non-zero NextCursor) and a subsequent attempt fails transiently, the
+// retried pull resumes from the advanced cursor rather than rewinding to
+// zero. Without cursor preservation the receiver would re-scan envelopes
+// the server has already delivered, potentially double-processing events.
+func TestMailboxOutSwapEventReceiverPreservesCursorAcrossRetry(t *testing.T) {
+	t.Parallel()
+
+	authKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	hash := lntypes.Hash{7, 8, 9}
+	successResp, err := successfulOutSwapPullResp(
+		t, hash, authKey.PubKey(), 6, 7,
+	)
+	require.NoError(t, err)
+
+	edge := &testOutSwapMailboxEdge{
+		pullScript: []pullStep{
+			// First pull: empty batch, but advance the cursor to
+			// 5 so the next iteration of the outer loop carries
+			// that cursor forward.
+			{resp: &mailboxpb.PullResponse{
+				Status: &mailboxpb.Status{
+					Ok: true,
+				},
+				NextCursor: 5,
+			}},
+			// Transport blip: must not reset the cursor.
+			{
+				err: status.Error(codes.Unavailable, "rst"),
+			},
+			// Server eventually delivers the real event.
+			{
+				resp: successResp,
+			},
+		},
+	}
+	receiver := NewMailboxOutSwapEventReceiver(
+		edge, "",
+		WithMailboxPullBackoff(
+			fastReceiverBackoff(),
+		),
+	)
+	receiver.pullWaitTimeout = time.Millisecond
+
+	notification, err := receiver.WaitOutSwapHtlc(
+		t.Context(), hash, authKey.PubKey(),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, notification)
+	require.Equal(t, uint64(7), notification.AckCursor)
+
+	// Three Pull calls: empty batch (cursor 0), failed retry attempt
+	// (cursor 5), success (cursor 5).
+	require.Equal(
+		t, []uint64{0, 5, 5}, edge.pullCursors,
+		"cursor must not rewind to zero on transient error",
+	)
 }

--- a/serverconn/connector_test.go
+++ b/serverconn/connector_test.go
@@ -773,28 +773,7 @@ func TestIngress_PartialDispatch_NoDuplicateRedelivery(t *testing.T) {
 	)
 }
 
-// TestRetryDelay verifies the exponential backoff formula with jitter.
-func TestRetryDelay(t *testing.T) {
-	t.Parallel()
-
-	base := 100 * time.Millisecond
-	maxDelay := 5 * time.Second
-
-	// First attempt should be approximately base (within jitter range).
-	d := retryDelay(base, maxDelay, 1)
-	require.GreaterOrEqual(t, d, base/2)
-	require.LessOrEqual(t, d, base)
-
-	// High attempt should be capped at maxDelay.
-	d = retryDelay(base, maxDelay, 100)
-	require.LessOrEqual(t, d, maxDelay)
-	require.GreaterOrEqual(t, d, maxDelay/2)
-}
-
-// TestRetryDelay_DefaultsOnZero verifies that zero base/max get defaults.
-func TestRetryDelay_DefaultsOnZero(t *testing.T) {
-	t.Parallel()
-
-	d := retryDelay(0, 0, 1)
-	require.Greater(t, d, time.Duration(0))
-}
+// Backoff formula tests now live in serverconn/mailboxpull/pull_test.go
+// (TestRetryDelayClampsToMax, TestRetryDelayUsesDefaults) -- the formula
+// itself moved to that subpackage so the SDK pull loop and this actor's
+// ingress loop share one schedule.

--- a/serverconn/ingress.go
+++ b/serverconn/ingress.go
@@ -5,14 +5,12 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"math"
-	"math/rand/v2"
-	"time"
 
 	"github.com/lightninglabs/darepo-client/baselib/actor"
 	mailboxconn "github.com/lightninglabs/darepo-client/mailbox/conn"
 	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
 	mailboxrpc "github.com/lightninglabs/darepo-client/mailbox/rpc"
+	"github.com/lightninglabs/darepo-client/serverconn/mailboxpull"
 )
 
 // ingressLoop is the main pull-dispatch-ack loop. It runs in its own
@@ -441,49 +439,22 @@ func (a *ServerConnectionActor) saveCheckpoint(
 
 // sleepBackoff sleeps for an exponential backoff duration with jitter,
 // respecting context cancellation. The fail count is incremented on entry
-// and used to calculate the delay.
+// and used to calculate the delay. The actual backoff arithmetic lives in
+// mailboxpull.Sleep so the SDK pull loop and this loop share the same
+// schedule.
 func (a *ServerConnectionActor) sleepBackoff(ctx context.Context,
 	failCount *int) {
 
-	*failCount++
-	delay := retryDelay(
-		a.cfg.RetryBaseDelay, a.cfg.RetryMaxDelay, *failCount,
-	)
-
-	timer := time.NewTimer(delay)
-	defer timer.Stop()
-
-	select {
-	case <-ctx.Done():
-	case <-timer.C:
-	}
+	mailboxpull.Sleep(ctx, a.backoffConfig(), failCount)
 }
 
-// retryDelay returns an exponential backoff duration with jitter, capped at
-// maxDelay. The formula is: min(base * 2^attempt, max) * (0.5 + rand(0.5)).
-func retryDelay(
-	base time.Duration, maxDelay time.Duration, attempt int,
-) time.Duration {
-
-	if base <= 0 {
-		base = 200 * time.Millisecond
+// backoffConfig snapshots the actor's backoff knobs into the shared
+// mailboxpull config shape.
+func (a *ServerConnectionActor) backoffConfig() mailboxpull.BackoffConfig {
+	return mailboxpull.BackoffConfig{
+		BaseDelay: a.cfg.RetryBaseDelay,
+		MaxDelay:  a.cfg.RetryMaxDelay,
 	}
-	if maxDelay <= 0 {
-		maxDelay = 30 * time.Second
-	}
-
-	// Exponential backoff: base * 2^attempt.
-	delay := float64(base) * math.Pow(2, float64(attempt-1))
-	if delay > float64(maxDelay) {
-		delay = float64(maxDelay)
-	}
-
-	// Add jitter: multiply by a random factor in [0.5, 1.0).
-	// Crypto-grade randomness is not needed for backoff jitter.
-	jitter := 0.5 + rand.Float64()*0.5 //nolint:gosec
-	delay *= jitter
-
-	return time.Duration(delay)
 }
 
 // statusError wraps a mailbox status failure for error reporting.

--- a/serverconn/mailboxpull/pull.go
+++ b/serverconn/mailboxpull/pull.go
@@ -1,0 +1,150 @@
+// Package mailboxpull provides shared retry+backoff primitives for mailbox
+// pull loops. The same shape is needed by the persistent identity-mailbox
+// ingress loop in the parent serverconn package and by per-swap event
+// consumers in the SDK; this package factors that shape out so reliability
+// semantics stay uniform across both consumers.
+package mailboxpull
+
+import (
+	"context"
+	"log/slog"
+	"math"
+	"math/rand/v2"
+	"time"
+
+	"github.com/btcsuite/btclog/v2"
+	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
+)
+
+// Default backoff parameters mirror serverconn.DefaultConnectorConfig so the
+// daemon ingress loop and any SDK pull loop back off identically when the
+// shared mailbox endpoint is flapping.
+const (
+	defaultBaseDelay = 200 * time.Millisecond
+	defaultMaxDelay  = 30 * time.Second
+)
+
+// BackoffConfig controls exponential backoff with jitter for retryable pull
+// failures. The zero value selects the package defaults (200 ms base, 30 s
+// cap) so callers that do not care about backoff tuning can pass
+// BackoffConfig{} without producing a tight retry loop.
+type BackoffConfig struct {
+	// BaseDelay is the initial backoff increment. A non-positive value
+	// selects the default (200 ms).
+	BaseDelay time.Duration
+
+	// MaxDelay caps the exponential backoff delay. A non-positive value
+	// selects the default (30 s).
+	MaxDelay time.Duration
+}
+
+// DefaultBackoffConfig returns the production defaults used by the serverconn
+// ingress loop: 200 ms base, 30 s cap.
+func DefaultBackoffConfig() BackoffConfig {
+	return BackoffConfig{
+		BaseDelay: defaultBaseDelay,
+		MaxDelay:  defaultMaxDelay,
+	}
+}
+
+// RetryDelay returns an exponential backoff duration with jitter, capped at
+// cfg.MaxDelay. The formula is
+//
+//	min(base * 2^(attempt-1), max) * U[0.5, 1.0).
+//
+// The jitter uses non-cryptographic randomness because backoff timing is not
+// security sensitive.
+func RetryDelay(cfg BackoffConfig, attempt int) time.Duration {
+	base := cfg.BaseDelay
+	if base <= 0 {
+		base = defaultBaseDelay
+	}
+	maxDelay := cfg.MaxDelay
+	if maxDelay <= 0 {
+		maxDelay = defaultMaxDelay
+	}
+
+	// Exponential backoff: base * 2^(attempt-1).
+	delay := float64(base) * math.Pow(2, float64(attempt-1))
+	if delay > float64(maxDelay) {
+		delay = float64(maxDelay)
+	}
+
+	// Add jitter: multiply by a random factor in [0.5, 1.0). Spread
+	// concurrent retries across the same endpoint so they do not
+	// synchronize into a thundering herd.
+	jitter := 0.5 + rand.Float64()*0.5 //nolint:gosec
+	delay *= jitter
+
+	return time.Duration(delay)
+}
+
+// Sleep increments *attempt and sleeps for the next backoff interval,
+// respecting context cancellation. The attempt counter is owned by the
+// caller so multiple pull cycles can share a single backoff schedule
+// (i.e. successive failures grow the delay, while a success resets it).
+func Sleep(ctx context.Context, cfg BackoffConfig, attempt *int) {
+	*attempt++
+	delay := RetryDelay(cfg, *attempt)
+
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+	case <-timer.C:
+	}
+}
+
+// PullWithRetry calls edge.Pull, retrying transport errors with exponential
+// backoff until the call succeeds or ctx is done. The cursor and other
+// request fields are passed through verbatim — the helper does not mutate
+// req — so the caller's cursor state is preserved across reconnects.
+//
+// On context cancellation the context error is returned, not the underlying
+// transport error, so callers can distinguish "caller gave up" from "endpoint
+// is flapping". A nil logger is treated as btclog.Disabled.
+//
+// Status-level failures (resp.Status non-nil with Ok=false) are returned to
+// the caller in resp; this helper retries only on transport errors. The
+// caller decides how to handle a status error — usually that means surfacing
+// it to the caller of the outer Wait loop, since it indicates a deterministic
+// protocol-level problem rather than a transient network blip.
+func PullWithRetry(ctx context.Context, edge mailboxpb.MailboxServiceClient,
+	req *mailboxpb.PullRequest, cfg BackoffConfig,
+	log btclog.Logger) (*mailboxpb.PullResponse, error) {
+
+	if log == nil {
+		log = btclog.Disabled
+	}
+
+	var failCount int
+	for {
+		// Bail out before issuing a fresh Pull if the caller has
+		// already cancelled. This avoids a needless round trip in the
+		// common shutdown path.
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		resp, err := edge.Pull(ctx, req)
+		if err == nil {
+			return resp, nil
+		}
+
+		// Distinguish "we are shutting down" from "endpoint is
+		// flapping" — callers further up the stack treat ctx
+		// cancellation as a normal early exit, not a swap failure.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+
+		log.WarnS(ctx, "Mailbox pull failed, retrying",
+			err,
+			slog.String("mailbox_id", req.GetMailboxId()),
+			slog.Uint64("cursor", req.GetCursor()),
+		)
+
+		Sleep(ctx, cfg, &failCount)
+	}
+}

--- a/serverconn/mailboxpull/pull_test.go
+++ b/serverconn/mailboxpull/pull_test.go
@@ -1,0 +1,246 @@
+package mailboxpull
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// fastBackoff returns a backoff config that essentially eliminates sleeps so
+// tests don't add wall-time to the suite.
+func fastBackoff() BackoffConfig {
+	return BackoffConfig{
+		BaseDelay: time.Microsecond,
+		MaxDelay:  time.Microsecond,
+	}
+}
+
+// pullStep is one step in a scripted pull sequence: either an error or a
+// response is returned to the caller.
+type pullStep struct {
+	err  error
+	resp *mailboxpb.PullResponse
+}
+
+// scriptedEdge implements MailboxServiceClient by consuming a scripted
+// sequence of Pull outcomes, recording the cursor of every request so tests
+// can assert that retries reuse the caller's cursor instead of rewinding.
+type scriptedEdge struct {
+	script  []pullStep
+	cursors []uint64
+	calls   int
+
+	// onPull is invoked at the start of every Pull call, before the
+	// scripted step is consumed. Tests use this to drive side effects
+	// like ctx cancellation between attempts — fields like calls and
+	// cursors are already updated when the hook runs, so the hook can
+	// inspect which attempt is in flight.
+	onPull func()
+}
+
+func (e *scriptedEdge) Send(context.Context, *mailboxpb.SendRequest,
+	...grpc.CallOption) (*mailboxpb.SendResponse, error) {
+
+	return nil, nil
+}
+
+func (e *scriptedEdge) Pull(_ context.Context, req *mailboxpb.PullRequest,
+	_ ...grpc.CallOption) (*mailboxpb.PullResponse, error) {
+
+	e.cursors = append(e.cursors, req.GetCursor())
+	idx := e.calls
+	e.calls++
+	if e.onPull != nil {
+		e.onPull()
+	}
+	if idx >= len(e.script) {
+
+		// Exhausted script: behave like a permanently flapping
+		// endpoint so callers that don't manage ctx will hit ctx
+		// timeout rather than panic.
+		return nil, status.Error(codes.Unavailable, "exhausted")
+	}
+	step := e.script[idx]
+
+	return step.resp, step.err
+}
+
+func (e *scriptedEdge) AckUpTo(context.Context, *mailboxpb.AckUpToRequest,
+	...grpc.CallOption) (*mailboxpb.AckUpToResponse, error) {
+
+	return nil, nil
+}
+
+// TestPullWithRetrySucceedsFirstTry verifies the happy path: a single
+// successful Pull is forwarded verbatim with no retry.
+func TestPullWithRetrySucceedsFirstTry(t *testing.T) {
+	t.Parallel()
+
+	want := &mailboxpb.PullResponse{NextCursor: 42}
+	edge := &scriptedEdge{script: []pullStep{{resp: want}}}
+
+	resp, err := PullWithRetry(
+		t.Context(), edge, &mailboxpb.PullRequest{
+			Cursor: 7,
+		},
+		fastBackoff(),
+		nil,
+	)
+	require.NoError(t, err)
+	require.Same(t, want, resp)
+	require.Equal(t, 1, edge.calls)
+	require.Equal(t, []uint64{7}, edge.cursors)
+}
+
+// TestPullWithRetryRetriesTransientErrors verifies that a transient
+// Unavailable error is retried until success, and the cursor is preserved
+// across attempts.
+func TestPullWithRetryRetriesTransientErrors(t *testing.T) {
+	t.Parallel()
+
+	want := &mailboxpb.PullResponse{NextCursor: 99}
+	edge := &scriptedEdge{
+		script: []pullStep{
+			{
+				err: status.Error(codes.Unavailable, "rst1"),
+			},
+			{
+				err: status.Error(codes.Unavailable, "rst2"),
+			},
+			{
+				err: status.Error(codes.Unavailable, "rst3"),
+			},
+			{
+				resp: want,
+			},
+		},
+	}
+
+	resp, err := PullWithRetry(
+		t.Context(), edge, &mailboxpb.PullRequest{
+			Cursor: 17,
+		},
+		fastBackoff(),
+		nil,
+	)
+	require.NoError(t, err)
+	require.Same(t, want, resp)
+	require.Equal(t, 4, edge.calls)
+	require.Equal(
+		t, []uint64{17, 17, 17, 17}, edge.cursors,
+		"cursor must be preserved across retries",
+	)
+}
+
+// TestPullWithRetryRespectsCtxCancel verifies that a cancelled ctx causes the
+// helper to return ctx.Err() promptly even while the endpoint keeps failing.
+func TestPullWithRetryRespectsCtxCancel(t *testing.T) {
+	t.Parallel()
+
+	edge := &scriptedEdge{
+		script: []pullStep{
+			{
+				err: status.Error(codes.Unavailable, "rst"),
+			},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err := PullWithRetry(
+		ctx, edge, &mailboxpb.PullRequest{
+			Cursor: 1,
+		},
+		fastBackoff(),
+		nil,
+	)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// TestPullWithRetryReturnsCtxErrAfterCancel verifies that if the ctx is
+// cancelled between Pull attempts (i.e. after edge.Pull has returned a
+// transport error but before the helper schedules its backoff sleep), the
+// helper returns ctx.Err() rather than the underlying transport error. This
+// pins the asymmetry where ctx cancellation must take precedence: callers
+// further up the stack treat ctx.Canceled as a normal early exit, while a
+// transport error would be wrapped and surfaced as a swap failure.
+func TestPullWithRetryReturnsCtxErrAfterCancel(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	transportErr := errors.New("transport boom")
+
+	// Drive cancellation from inside the mock Pull callback so the helper
+	// actually executes Pull, observes the transport error, and *then*
+	// finds ctx done on its post-Pull re-check. Cancelling before the
+	// call would just trip the opening ctx.Err() guard, which is the
+	// same code path as TestPullWithRetryRespectsCtxCancel.
+	edge := &scriptedEdge{
+		script: []pullStep{
+			{
+				err: transportErr,
+			},
+		},
+		onPull: func() {
+			cancel()
+		},
+	}
+
+	_, err := PullWithRetry(
+		ctx, edge, &mailboxpb.PullRequest{
+			Cursor: 1,
+		},
+		fastBackoff(),
+		nil,
+	)
+	require.ErrorIs(
+		t, err, context.Canceled,
+		"ctx error must take precedence over transport error",
+	)
+
+	// The helper must have invoked Pull exactly once: the post-Pull
+	// ctx.Err() check should bail before a retry attempt fires.
+	require.Equal(
+		t, 1, edge.calls,
+		"helper must reach the post-Pull ctx re-check, not retry",
+	)
+}
+
+// TestRetryDelayClampsToMax verifies the exponential backoff is capped at
+// MaxDelay regardless of attempt count.
+func TestRetryDelayClampsToMax(t *testing.T) {
+	t.Parallel()
+
+	cfg := BackoffConfig{
+		BaseDelay: 100 * time.Millisecond,
+		MaxDelay:  500 * time.Millisecond,
+	}
+
+	// At attempt=20, raw 2^19 * 100ms is wildly larger than 500ms; the
+	// helper must clamp. Jitter is in [0.5, 1.0), so the upper bound is
+	// MaxDelay.
+	for i := 0; i < 100; i++ {
+		d := RetryDelay(cfg, 20)
+		require.LessOrEqual(t, d, cfg.MaxDelay)
+		require.GreaterOrEqual(t, d, cfg.MaxDelay/2)
+	}
+}
+
+// TestRetryDelayUsesDefaults verifies that a zero-value BackoffConfig falls
+// back to package defaults rather than spinning with no delay.
+func TestRetryDelayUsesDefaults(t *testing.T) {
+	t.Parallel()
+
+	d := RetryDelay(BackoffConfig{}, 1)
+	// First attempt: base * 2^0 = base = 200ms, * jitter in [0.5, 1.0).
+	require.GreaterOrEqual(t, d, defaultBaseDelay/2)
+	require.LessOrEqual(t, d, defaultBaseDelay)
+}

--- a/swapclientserver/service.go
+++ b/swapclientserver/service.go
@@ -366,9 +366,16 @@ func newSwapClientService(ctx context.Context, rpcServer *darepod.RPCServer,
 	// so installing the receiver here, immediately after construction, is
 	// the only correct point. An empty mailbox ID makes the receiver derive
 	// the per-swap mailbox from the client identity key and payment hash.
+	//
+	// We pass the service logger so the receiver's pull retry attempts
+	// surface in operator logs alongside the equivalent serverconn ingress
+	// WARNs; without this the SDK side flaps silently while the daemon
+	// ingress logs the same endpoint failures, which is the visibility gap
+	// that made #505 hard to diagnose from logs alone.
 	swapClient.SetOutSwapEventReceiver(
 		swaps.NewMailboxOutSwapEventReceiver(
 			swapClients.mailbox, "",
+			swaps.WithMailboxReceiverLog(log),
 		),
 	)
 


### PR DESCRIPTION
Closes #505.

In this PR, we make the SDK swap event receiver survive transient mailbox transport errors instead of treating them as terminal swap failures. The bug surfaced on signet: receive swap `77b3f54b...` (20 000 sats) died after a single `codes.Unavailable` TCP RST against the operator/mailbox endpoint, even though the `serverconn` ingress loop on the same daemon survived eight identical RSTs against the same endpoint over the same log window. The mailbox protocol is supposed to be connectionless at the message layer, so the SDK was clearly missing reliability semantics the daemon already had.

The fix is option B from the issue body: extract the retry+backoff+cursor primitives `serverconn/ingress.go` was already using inline, expose them as a small `serverconn/mailboxpull` package, and have `MailboxOutSwapEventReceiver` build on the same helper. Both consumers now back off identically when the shared mailbox endpoint flaps. The SDK's outer matching loop is unchanged: `cursor` is still a local `uint64` advanced from `resp.NextCursor` on success, and the helper does not mutate the `PullRequest`, so a reconnect resumes from the last cursor instead of rewinding to zero. The wait is bounded only by `ctx` cancellation and the swap deadline, which is what the connectionless-at-the-message-layer contract calls for.

Option C from the issue body (fold per-swap events onto the identity mailbox via the existing `EventRouter` and demultiplex by payment hash) is the right destination, but it needs `swapserver`-side coordination in a separate repo, so it's deferred to a follow-up. This PR closes the immediate bug without touching the per-swap mailbox layering.

See each commit message for a detailed description w.r.t the incremental changes.

## Helper shape

`mailboxpull.PullWithRetry` calls `Edge.Pull` and retries any non-`ctx` error after exponential backoff with jitter. It returns `ctx.Err` on cancellation rather than the underlying transport error, so callers further up the stack (the receive FSM, etc.) can tell "we're shutting down" from "endpoint is flapping." A nil logger is treated as `btclog.Disabled`. The zero-value `BackoffConfig` falls back to the package defaults (200 ms base, 30 s cap, matching `serverconn`), so callers cannot accidentally produce a tight retry loop by leaving the config blank.

`ServerConnectionActor.sleepBackoff` now delegates to `mailboxpull.Sleep` via a snapshot of the existing `RetryBaseDelay` / `RetryMaxDelay` knobs on `ConnectorConfig`. The outer `ingressLoop` body (ack → pull → dispatch → checkpoint) is untouched on purpose: replacing `pullBatch` with `PullWithRetry` would change how the dispatch/ack backoff counter interacts with pull failures, and that thread is worth pulling separately.

## Test coverage

The legacy `testOutSwapMailboxEdge` returned a single static `PullResponse` for every call and ignored the request cursor, so it couldn't tell a clean first-pull success from a disconnect-then-reconnect. We extend it with a `pullScript` of typed steps (each step is either an error or a response, consumed in order) and record every cursor seen on the wire, so the new cases drive the receiver deterministically without adding wall time to the suite.

Three new cases pin the contract the old loop violated. `RetriesOnUnavailable` scripts three `codes.Unavailable` errors followed by a successful envelope and asserts the receiver keeps pulling instead of failing on the first blip; this is the direct regression test for #505. `RespectsCtxCancel` scripts a permanently flapping endpoint, cancels the context, and asserts the receiver returns `context.Canceled` promptly rather than spinning forever. `PreservesCursorAcrossRetry` threads an empty batch that advances the cursor to 5, a transient `Unavailable`, and then a real event, and asserts the second and third pull requests both carry cursor 5: the previous code would have rewound to zero and potentially re-processed already-delivered envelopes.

## Test plan

- [x] `go test ./sdk/swaps/... ./serverconn/...` passes locally
- [x] new `serverconn/mailboxpull/pull_test.go` cases cover success, retry-then-success, ctx-cancel-mid-backoff, cursor pass-through
- [x] three new SDK cases (`TestMailboxOutSwapEventReceiverRetriesOnUnavailable`, `TestMailboxOutSwapEventReceiverRespectsCtxCancel`, `TestMailboxOutSwapEventReceiverPreservesCursorAcrossRetry`) pass
- [x] existing `TestMailboxOutSwapEventReceiverPullsAndAcks` / `TestMailboxOutSwapEventReceiverPullsInArkEvent` still pass unmodified
- [x] `make fmt-changed` and lint-local clean on the diff
- [x] `make commitmsg-lint range="origin/main..HEAD"` clean