### PR TITLE
multi: close walletdk visibility gaps for in-flight rounds + deposits

### DIFF
--- a/daemonrpc/daemon.pb.go
+++ b/daemonrpc/daemon.pb.go
@@ -4239,12 +4239,20 @@ type RoundInfo struct {
 	// is_temp indicates this round has a temporary key and hasn't
 	// been assigned a server round ID yet.
 	IsTemp bool `protobuf:"varint,3,opt,name=is_temp,json=isTemp,proto3" json:"is_temp,omitempty"`
-	// vtxos lists the VTXOs created by this round. Only populated
-	// for persisted rounds (input_sig_sent, confirmed). Empty for
-	// pending/in-memory rounds.
+	// vtxos lists the VTXOs the wallet expects to receive from this
+	// round. For rounds still in flight (any state before confirmed)
+	// only amount_sat is populated; the outpoint is empty because the
+	// precise leaf position in the VTXO tree is not finalised until
+	// the commitment transaction confirms. For confirmed rounds both
+	// outpoint ("txid:index") and amount_sat are populated. The
+	// commitment_txid field below carries the commitment tx hash
+	// independently once the round actor has received it from the
+	// operator, so callers do not need a populated outpoint to know
+	// which commitment they have signed.
 	Vtxos []*RoundVTXOInfo `protobuf:"bytes,4,rep,name=vtxos,proto3" json:"vtxos,omitempty"`
-	// commitment_txid is the round commitment transaction id when the round
-	// has been persisted.
+	// commitment_txid is the round commitment transaction id once the
+	// round actor has received it from the operator, or once the
+	// round has been persisted.
 	CommitmentTxid string `protobuf:"bytes,5,opt,name=commitment_txid,json=commitmentTxid,proto3" json:"commitment_txid,omitempty"`
 	// commitment_height is the block height that confirmed the commitment
 	// transaction, when known.

--- a/daemonrpc/daemon.pb.go
+++ b/daemonrpc/daemon.pb.go
@@ -121,6 +121,14 @@ const (
 	// VTXO_STATUS_SPENDING indicates the VTXO has been claimed for an
 	// out-of-round spend but the spend has not yet completed.
 	VTXOStatus_VTXO_STATUS_SPENDING VTXOStatus = 8
+	// VTXO_STATUS_PENDING_ROUND indicates a VTXO the wallet is about to
+	// receive from a round that has been signed but whose commitment
+	// transaction has not yet confirmed on-chain. Entries with this
+	// status are synthetic projections from the live round actor; they
+	// are not yet persisted, not yet spendable, and carry only the
+	// amount, originating round_id, and (once known) the commitment
+	// txid that will create them.
+	VTXOStatus_VTXO_STATUS_PENDING_ROUND VTXOStatus = 9
 )
 
 // Enum value maps for VTXOStatus.
@@ -135,6 +143,7 @@ var (
 		6: "VTXO_STATUS_UNILATERAL_EXIT",
 		7: "VTXO_STATUS_FAILED",
 		8: "VTXO_STATUS_SPENDING",
+		9: "VTXO_STATUS_PENDING_ROUND",
 	}
 	VTXOStatus_value = map[string]int32{
 		"VTXO_STATUS_UNSPECIFIED":     0,
@@ -146,6 +155,7 @@ var (
 		"VTXO_STATUS_UNILATERAL_EXIT": 6,
 		"VTXO_STATUS_FAILED":          7,
 		"VTXO_STATUS_SPENDING":        8,
+		"VTXO_STATUS_PENDING_ROUND":   9,
 	}
 )
 
@@ -6443,7 +6453,7 @@ const file_daemon_proto_rawDesc = "" +
 	"\x11WALLET_STATE_NONE\x10\x01\x12\x17\n" +
 	"\x13WALLET_STATE_LOCKED\x10\x02\x12\x16\n" +
 	"\x12WALLET_STATE_READY\x10\x03\x12\x18\n" +
-	"\x14WALLET_STATE_SYNCING\x10\x04*\x81\x02\n" +
+	"\x14WALLET_STATE_SYNCING\x10\x04*\xa0\x02\n" +
 	"\n" +
 	"VTXOStatus\x12\x1b\n" +
 	"\x17VTXO_STATUS_UNSPECIFIED\x10\x00\x12\x14\n" +
@@ -6454,7 +6464,8 @@ const file_daemon_proto_rawDesc = "" +
 	"\x11VTXO_STATUS_SPENT\x10\x05\x12\x1f\n" +
 	"\x1bVTXO_STATUS_UNILATERAL_EXIT\x10\x06\x12\x16\n" +
 	"\x12VTXO_STATUS_FAILED\x10\a\x12\x18\n" +
-	"\x14VTXO_STATUS_SPENDING\x10\b*\xf7\x03\n" +
+	"\x14VTXO_STATUS_SPENDING\x10\b\x12\x1d\n" +
+	"\x19VTXO_STATUS_PENDING_ROUND\x10\t*\xf7\x03\n" +
 	"\n" +
 	"RoundState\x12\x17\n" +
 	"\x13ROUND_STATE_UNKNOWN\x10\x00\x12\x14\n" +

--- a/daemonrpc/daemon.proto
+++ b/daemonrpc/daemon.proto
@@ -436,6 +436,15 @@ enum VTXOStatus {
     // VTXO_STATUS_SPENDING indicates the VTXO has been claimed for an
     // out-of-round spend but the spend has not yet completed.
     VTXO_STATUS_SPENDING = 8;
+
+    // VTXO_STATUS_PENDING_ROUND indicates a VTXO the wallet is about to
+    // receive from a round that has been signed but whose commitment
+    // transaction has not yet confirmed on-chain. Entries with this
+    // status are synthetic projections from the live round actor; they
+    // are not yet persisted, not yet spendable, and carry only the
+    // amount, originating round_id, and (once known) the commitment
+    // txid that will create them.
+    VTXO_STATUS_PENDING_ROUND = 9;
 }
 
 message VTXO {

--- a/daemonrpc/daemon.proto
+++ b/daemonrpc/daemon.proto
@@ -1115,13 +1115,21 @@ message RoundInfo {
     // been assigned a server round ID yet.
     bool is_temp = 3;
 
-    // vtxos lists the VTXOs created by this round. Only populated
-    // for persisted rounds (input_sig_sent, confirmed). Empty for
-    // pending/in-memory rounds.
+    // vtxos lists the VTXOs the wallet expects to receive from this
+    // round. For rounds still in flight (any state before confirmed)
+    // only amount_sat is populated; the outpoint is empty because the
+    // precise leaf position in the VTXO tree is not finalised until
+    // the commitment transaction confirms. For confirmed rounds both
+    // outpoint ("txid:index") and amount_sat are populated. The
+    // commitment_txid field below carries the commitment tx hash
+    // independently once the round actor has received it from the
+    // operator, so callers do not need a populated outpoint to know
+    // which commitment they have signed.
     repeated RoundVTXOInfo vtxos = 4;
 
-    // commitment_txid is the round commitment transaction id when the round
-    // has been persisted.
+    // commitment_txid is the round commitment transaction id once the
+    // round actor has received it from the operator, or once the
+    // round has been persisted.
     string commitment_txid = 5;
 
     // commitment_height is the block height that confirmed the commitment

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -659,12 +659,21 @@ func sumOnchainWalletConfirmed(ctx context.Context,
 }
 
 // ListVTXOs returns the set of VTXOs known to the wallet, optionally
-// filtered by status and minimum amount.
+// filtered by status and minimum amount. The VTXO_STATUS_PENDING_ROUND
+// filter is special: it bypasses the on-disk store and projects each
+// upcoming VTXO from the live round actor as a synthetic VTXO entry,
+// giving callers a way to see the outputs they have signed for but
+// which have not yet been created by an on-chain commitment.
 func (r *RPCServer) ListVTXOs(ctx context.Context,
 	req *daemonrpc.ListVTXOsRequest) (*daemonrpc.ListVTXOsResponse, error) {
 
 	if err := r.requireWalletReady(); err != nil {
 		return nil, err
+	}
+
+	if req.StatusFilter ==
+		daemonrpc.VTXOStatus_VTXO_STATUS_PENDING_ROUND {
+		return r.listPendingRoundVTXOs(ctx, req)
 	}
 
 	if r.server.vtxoStore == nil {
@@ -745,6 +754,57 @@ func (r *RPCServer) ListVTXOs(ctx context.Context,
 		}
 
 		protoVTXOs = append(protoVTXOs, protoVTXO)
+	}
+
+	return &daemonrpc.ListVTXOsResponse{
+		Vtxos: protoVTXOs,
+	}, nil
+}
+
+// listPendingRoundVTXOs projects the upcoming VTXOs from every live
+// round FSM as synthetic VTXO entries. Each entry carries the
+// expected amount, the originating round id (once assigned), and the
+// commitment txid (once the round actor has received the commitment
+// transaction). The outpoint is intentionally empty because the
+// precise leaf outpoint inside the VTXO tree is not finalised until
+// the commitment transaction confirms.
+func (r *RPCServer) listPendingRoundVTXOs(ctx context.Context,
+	req *daemonrpc.ListVTXOsRequest) (*daemonrpc.ListVTXOsResponse, error) {
+
+	rounds, err := r.queryRoundStates(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	minAmount := btcutil.Amount(req.MinAmountSat)
+	pendingRoundStatus := daemonrpc.VTXOStatus_VTXO_STATUS_PENDING_ROUND
+
+	protoVTXOs := make([]*daemonrpc.VTXO, 0)
+	for _, info := range rounds {
+		// Skip rounds whose commitment tx has already confirmed.
+		// Their VTXOs are written to the on-disk store as
+		// VTXO_STATUS_LIVE so they surface there; including them
+		// here too would cause a brief double-report in the window
+		// between commitment confirmation and the actor cleaning
+		// the round out of its in-memory map.
+		if info.State == daemonrpc.RoundState_ROUND_STATE_CONFIRMED {
+			continue
+		}
+
+		for _, v := range info.Vtxos {
+			amount := btcutil.Amount(v.AmountSat)
+			if amount < minAmount {
+				continue
+			}
+
+			protoVTXOs = append(protoVTXOs, &daemonrpc.VTXO{
+				AmountSat:      v.AmountSat,
+				Status:         pendingRoundStatus,
+				RoundId:        info.RoundId,
+				CommitmentTxid: info.CommitmentTxid,
+				Outpoint:       v.Outpoint,
+			})
+		}
 	}
 
 	return &daemonrpc.ListVTXOsResponse{

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
@@ -31,6 +32,7 @@ import (
 	"github.com/lightninglabs/darepo-client/lib/arkscript"
 	oortx "github.com/lightninglabs/darepo-client/lib/tx/oor"
 	"github.com/lightninglabs/darepo-client/lib/tx/psbtutil"
+	"github.com/lightninglabs/darepo-client/lib/types"
 	"github.com/lightninglabs/darepo-client/lwwallet"
 	"github.com/lightninglabs/darepo-client/oor"
 	"github.com/lightninglabs/darepo-client/round"
@@ -3169,15 +3171,140 @@ func (r *RPCServer) queryRoundStates(ctx context.Context) (
 			roundID = info.RoundID.String()
 		}
 
+		commitmentTxid, vtxos := liveRoundDetails(info.State)
+
 		rounds = append(rounds, &daemonrpc.RoundInfo{
-			RoundId:       roundID,
-			State:         clientStateToProto(info.State),
-			IsTemp:        info.IsTemp,
-			FailureReason: roundFailureReason(info.State),
+			RoundId:        roundID,
+			State:          clientStateToProto(info.State),
+			IsTemp:         info.IsTemp,
+			Vtxos:          vtxos,
+			CommitmentTxid: commitmentTxid,
+			FailureReason:  roundFailureReason(info.State),
 		})
 	}
 
 	return rounds, nil
+}
+
+// liveRoundDetails extracts the commitment transaction id and the
+// upcoming VTXOs the local wallet is about to receive from a live
+// (actor-served) round FSM state. The commitment txid is populated
+// from the state CommitmentTxReceived onwards. VTXO entries from
+// in-flight rounds carry only the amount because the precise leaf
+// outpoint depends on tree finalisation; once the round is
+// Confirmed the entries carry their real outpoints.
+//
+// Only VTXOs the wallet itself will own (HasLocalOwner=true) are
+// reported — the round can contain outputs destined for other
+// clients (e.g. in an in-round directed send), and surfacing those
+// here would inflate the wallet's view of its own upcoming balance.
+func liveRoundDetails(state round.ClientState) (string,
+	[]*daemonrpc.RoundVTXOInfo) {
+
+	upcomingFromVTXORequests := func(
+		reqs []types.VTXORequest) []*daemonrpc.RoundVTXOInfo {
+
+		out := make([]*daemonrpc.RoundVTXOInfo, 0, len(reqs))
+		for i := range reqs {
+			v := &reqs[i]
+			if !v.HasLocalOwner() {
+				continue
+			}
+			out = append(out, &daemonrpc.RoundVTXOInfo{
+				AmountSat: int64(v.Amount),
+			})
+		}
+
+		return out
+	}
+
+	switch s := state.(type) {
+	case *round.PendingRoundAssembly:
+		return "", upcomingFromVTXORequests(s.VTXOs)
+
+	case *round.IntentSentState:
+		return "", upcomingFromVTXORequests(s.Intents.VTXOs)
+
+	case *round.QuoteReceivedState:
+		return "", upcomingFromVTXORequests(s.Intents.VTXOs)
+
+	case *round.RoundJoinedState:
+		return "", upcomingFromVTXORequests(s.Intents.VTXOs)
+
+	case *round.CommitmentTxReceivedState:
+		return s.TxID.String(),
+			upcomingFromVTXORequests(s.Intents.VTXOs)
+
+	case *round.ConfirmedState:
+		out := make([]*daemonrpc.RoundVTXOInfo, 0, len(s.VTXOs))
+		for _, v := range s.VTXOs {
+			out = append(out, &daemonrpc.RoundVTXOInfo{
+				Outpoint: fmt.Sprintf(
+					"%s:%d", v.Outpoint.Hash,
+					v.Outpoint.Index,
+				),
+				AmountSat: int64(v.Amount),
+			})
+		}
+
+		return s.TxID.String(), out
+	}
+
+	// The MuSig2-phase states (CommitmentTxValidated through
+	// InputSigSent) all carry the same CommitmentTx + Intents pair
+	// and project onto RoundInfo identically. Fold them into one
+	// helper so the case list above does not have to grow every
+	// time a new intermediate state is added between commitment
+	// validation and input-sig-sent.
+	if pkt, vtxos, ok := psbtPhaseDetails(state); ok {
+		return commitmentPSBTTxid(pkt),
+			upcomingFromVTXORequests(vtxos)
+	}
+
+	return "", nil
+}
+
+// psbtPhaseDetails returns the commitment PSBT and the in-flight
+// VTXO intents from any MuSig2-phase state that carries them. The
+// six concrete types share the field shape but are distinct named
+// types; type-asserting against each is the price of not adding
+// methods to the FSM state contract in the round package.
+func psbtPhaseDetails(state round.ClientState) (*psbt.Packet,
+	[]types.VTXORequest, bool) {
+
+	switch s := state.(type) {
+	case *round.CommitmentTxValidatedState:
+		return s.CommitmentTx, s.Intents.VTXOs, true
+
+	case *round.ForfeitSignaturesCollectingState:
+		return s.CommitmentTx, s.Intents.VTXOs, true
+
+	case *round.NoncesSentState:
+		return s.CommitmentTx, s.Intents.VTXOs, true
+
+	case *round.NoncesAggregatedState:
+		return s.CommitmentTx, s.Intents.VTXOs, true
+
+	case *round.PartialSigsSentState:
+		return s.CommitmentTx, s.Intents.VTXOs, true
+
+	case *round.InputSigSentState:
+		return s.CommitmentTx, s.Intents.VTXOs, true
+	}
+
+	return nil, nil, false
+}
+
+// commitmentPSBTTxid returns the txid of the unsigned commitment
+// transaction carried by an in-flight round PSBT. The MuSig2 phase
+// states only carry the PSBT (not a pre-computed hash), so the txid
+// is recomputed lazily here.
+func commitmentPSBTTxid(p *psbt.Packet) string {
+	if p == nil || p.UnsignedTx == nil {
+		return ""
+	}
+
+	return p.UnsignedTx.TxHash().String()
 }
 
 // defaultListRoundsPageSize is the page size used when the client

--- a/darepod/rpc_server_test.go
+++ b/darepod/rpc_server_test.go
@@ -8,11 +8,13 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btclog/v2"
+	"github.com/google/uuid"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
 	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/lightninglabs/darepo-client/lib/actormsg"
@@ -20,8 +22,10 @@ import (
 	oortx "github.com/lightninglabs/darepo-client/lib/tx/oor"
 	"github.com/lightninglabs/darepo-client/lib/types"
 	"github.com/lightninglabs/darepo-client/oor"
+	"github.com/lightninglabs/darepo-client/round"
 	"github.com/lightninglabs/darepo-client/vtxo"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -1012,4 +1016,181 @@ func TestGetInfoConcurrentOperatorTermsAccess(t *testing.T) {
 
 	cancel()
 	<-writerDone
+}
+
+// newRoundActorWithStates registers a stub round actor under the
+// standard round service key that responds to GetClientStateRequest
+// with the supplied map of FSM states. The caller must shut down the
+// returned actor system.
+func newRoundActorWithStates(t *testing.T,
+	states map[string]round.FSMStateInfo) *actor.ActorSystem {
+
+	t.Helper()
+
+	system := actor.NewActorSystem()
+
+	behavior := actor.NewFunctionBehavior(
+		func(_ context.Context, msg actormsg.RoundReceivable,
+		) fn.Result[actormsg.RoundActorResp] {
+
+			if _, ok := msg.(*round.GetClientStateRequest); !ok {
+				t.Fatalf("unexpected message: %T", msg)
+			}
+
+			return fn.Ok[actormsg.RoundActorResp](
+				&round.GetClientStateResponse{
+					States: states,
+				},
+			)
+		},
+	)
+	_ = actor.RegisterWithSystem(
+		system, "round-stub", round.NewServiceKey(), behavior,
+	)
+
+	return system
+}
+
+// localOwnerKey returns a non-nil owner key descriptor — what
+// types.VTXORequest.HasLocalOwner uses as the locally-owned
+// sentinel. The actual pubkey value does not matter for these
+// projection-only tests; only its non-nilness does.
+func localOwnerKey(t *testing.T) keychain.KeyDescriptor {
+	t.Helper()
+
+	priv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	return keychain.KeyDescriptor{
+		PubKey: priv.PubKey(),
+	}
+}
+
+// TestQueryRoundStatesPopulatesUpcomingVTXOs verifies that a live
+// (actor-served) round in the InputSigSentState surfaces both its
+// commitment txid and the amounts of every VTXO the wallet is about
+// to receive. This pins issue #500: prior to the fix, the live path
+// returned a mostly-empty RoundInfo and the commitment txid only
+// appeared in the daemon log.
+func TestQueryRoundStatesPopulatesUpcomingVTXOs(t *testing.T) {
+	t.Parallel()
+
+	const (
+		amountA = btcutil.Amount(123_456)
+		amountB = btcutil.Amount(78_910)
+		// notOurs sits in the same intent list with a nil OwnerKey
+		// and must NOT appear in the response; the round may carry
+		// outputs destined for other clients and surfacing them
+		// here would inflate the wallet's view of upcoming
+		// balance.
+		notOurs = btcutil.Amount(999_000)
+	)
+
+	// Build a minimal commitment PSBT so liveRoundDetails can recover
+	// its txid the same way the production code does.
+	commitTx := wire.NewMsgTx(2)
+	commitTx.AddTxIn(&wire.TxIn{})
+	commitTx.AddTxOut(&wire.TxOut{Value: 250_000})
+	packet, err := psbt.NewFromUnsignedTx(commitTx)
+	require.NoError(t, err)
+	expectedTxid := commitTx.TxHash().String()
+
+	roundID := round.RoundID(uuid.New())
+	state := &round.InputSigSentState{
+		RoundID:      roundID,
+		CommitmentTx: packet,
+		Intents: round.Intents{
+			VTXOs: []types.VTXORequest{
+				{
+					Amount:   amountA,
+					OwnerKey: localOwnerKey(t),
+				},
+				{
+					Amount:   amountB,
+					OwnerKey: localOwnerKey(t),
+				},
+				{
+					// notOurs: no OwnerKey set →
+					// HasLocalOwner returns false →
+					// filtered out.
+					Amount: notOurs,
+				},
+			},
+		},
+	}
+
+	system := newRoundActorWithStates(t,
+		map[string]round.FSMStateInfo{
+			roundID.String(): {
+				State:   state,
+				RoundID: roundID,
+			},
+		},
+	)
+	defer func() {
+		require.NoError(t, system.Shutdown(t.Context()))
+	}()
+
+	srv := &RPCServer{server: &Server{actorSystem: system}}
+
+	rounds, err := srv.queryRoundStates(t.Context())
+	require.NoError(t, err)
+	require.Len(t, rounds, 1)
+
+	got := rounds[0]
+	require.Equal(t, roundID.String(), got.RoundId)
+	require.Equal(
+		t, daemonrpc.RoundState_ROUND_STATE_INPUT_SIG_SENT, got.State,
+	)
+	require.False(t, got.IsTemp)
+	require.Equal(t, expectedTxid, got.CommitmentTxid)
+
+	// Only the two locally-owned entries should be surfaced.
+	require.Len(t, got.Vtxos, 2)
+	require.Equal(t, int64(amountA), got.Vtxos[0].AmountSat)
+	require.Equal(t, int64(amountB), got.Vtxos[1].AmountSat)
+}
+
+// TestQueryRoundStatesEarlyStateOmitsCommitmentTxid verifies that
+// rounds before the CommitmentTxReceived transition still surface
+// their upcoming VTXO amounts but leave the commitment txid empty:
+// the daemon does not know it yet.
+func TestQueryRoundStatesEarlyStateOmitsCommitmentTxid(t *testing.T) {
+	t.Parallel()
+
+	roundID := round.RoundID(uuid.New())
+	state := &round.RoundJoinedState{
+		RoundID: roundID,
+		Intents: round.Intents{
+			VTXOs: []types.VTXORequest{
+				{
+					Amount:   btcutil.Amount(42_000),
+					OwnerKey: localOwnerKey(t),
+				},
+			},
+		},
+	}
+
+	system := newRoundActorWithStates(t,
+		map[string]round.FSMStateInfo{
+			roundID.String(): {
+				State:   state,
+				RoundID: roundID,
+			},
+		},
+	)
+	defer func() {
+		require.NoError(t, system.Shutdown(t.Context()))
+	}()
+
+	srv := &RPCServer{server: &Server{actorSystem: system}}
+
+	rounds, err := srv.queryRoundStates(t.Context())
+	require.NoError(t, err)
+	require.Len(t, rounds, 1)
+
+	got := rounds[0]
+	require.Empty(t, got.CommitmentTxid)
+	require.Len(t, got.Vtxos, 1)
+	require.Equal(t, int64(42_000), got.Vtxos[0].AmountSat)
 }

--- a/darepod/rpc_server_test.go
+++ b/darepod/rpc_server_test.go
@@ -1151,6 +1151,156 @@ func TestQueryRoundStatesPopulatesUpcomingVTXOs(t *testing.T) {
 	require.Equal(t, int64(amountB), got.Vtxos[1].AmountSat)
 }
 
+// TestListVTXOsPendingRoundProjectsLiveRounds verifies that
+// ListVTXOs with status_filter=VTXO_STATUS_PENDING_ROUND projects
+// the upcoming VTXOs from in-flight rounds as synthetic VTXO
+// entries. This pins issue #501: prior to the fix there was no way
+// to see VTXOs the wallet had signed for between commitment-tx
+// signing and confirmation.
+func TestListVTXOsPendingRoundProjectsLiveRounds(t *testing.T) {
+	t.Parallel()
+
+	const (
+		amountA = btcutil.Amount(50_000)
+		amountB = btcutil.Amount(25_000)
+		// belowMin sits under the min_amount_sat filter and must
+		// be elided to confirm the filter still applies on the
+		// synthetic path.
+		belowMin = btcutil.Amount(1_000)
+	)
+
+	commitTx := wire.NewMsgTx(2)
+	commitTx.AddTxIn(&wire.TxIn{})
+	commitTx.AddTxOut(&wire.TxOut{Value: 100_000})
+	packet, err := psbt.NewFromUnsignedTx(commitTx)
+	require.NoError(t, err)
+	expectedTxid := commitTx.TxHash().String()
+
+	roundID := round.RoundID(uuid.New())
+	state := &round.InputSigSentState{
+		RoundID:      roundID,
+		CommitmentTx: packet,
+		Intents: round.Intents{
+			VTXOs: []types.VTXORequest{
+				{
+					Amount:   amountA,
+					OwnerKey: localOwnerKey(t),
+				},
+				{
+					Amount:   amountB,
+					OwnerKey: localOwnerKey(t),
+				},
+				{
+					Amount:   belowMin,
+					OwnerKey: localOwnerKey(t),
+				},
+			},
+		},
+	}
+
+	system := newRoundActorWithStates(t,
+		map[string]round.FSMStateInfo{
+			roundID.String(): {
+				State:   state,
+				RoundID: roundID,
+			},
+		},
+	)
+	defer func() {
+		require.NoError(t, system.Shutdown(t.Context()))
+	}()
+
+	// Force the wallet-ready gate open without standing up a real
+	// wallet — listPendingRoundVTXOs only consults the round
+	// actor.
+	walletReady := make(chan struct{})
+	close(walletReady)
+	srv := &RPCServer{server: &Server{
+		actorSystem: system,
+		walletReady: walletReady,
+	}}
+
+	resp, err := srv.ListVTXOs(t.Context(), &daemonrpc.ListVTXOsRequest{
+		StatusFilter: daemonrpc.VTXOStatus_VTXO_STATUS_PENDING_ROUND,
+		MinAmountSat: int64(amountB),
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Vtxos, 2)
+
+	for _, v := range resp.Vtxos {
+		require.Equal(
+			t, daemonrpc.VTXOStatus_VTXO_STATUS_PENDING_ROUND,
+			v.Status,
+		)
+		require.Equal(t, roundID.String(), v.RoundId)
+		require.Equal(t, expectedTxid, v.CommitmentTxid)
+		require.Empty(t, v.Outpoint)
+	}
+	require.Equal(t, int64(amountA), resp.Vtxos[0].AmountSat)
+	require.Equal(t, int64(amountB), resp.Vtxos[1].AmountSat)
+}
+
+// TestListVTXOsPendingRoundSkipsConfirmedRounds pins the guard against
+// double-reporting: between a round's commitment-tx confirmation and
+// the actor cleaning the round out of its in-memory map, the same
+// VTXOs are already in the on-disk store as VTXO_STATUS_LIVE.
+// Surfacing them under VTXO_STATUS_PENDING_ROUND too would show the
+// upcoming-balance twice for that short window.
+func TestListVTXOsPendingRoundSkipsConfirmedRounds(t *testing.T) {
+	t.Parallel()
+
+	roundID := round.RoundID(uuid.New())
+	confirmed := &round.ConfirmedState{
+		TxID: chainhash.Hash{
+			0xab,
+			0xcd,
+		},
+		VTXOs: []*round.ClientVTXO{
+			{
+				Outpoint: wire.OutPoint{
+					Hash: chainhash.Hash{
+						0x11,
+					},
+					Index: 0,
+				},
+				Amount: btcutil.Amount(50_000),
+			},
+		},
+	}
+
+	system := newRoundActorWithStates(t,
+		map[string]round.FSMStateInfo{
+			roundID.String(): {
+				State:   confirmed,
+				RoundID: roundID,
+			},
+		},
+	)
+	defer func() {
+		require.NoError(t, system.Shutdown(t.Context()))
+	}()
+
+	walletReady := make(chan struct{})
+	close(walletReady)
+	srv := &RPCServer{server: &Server{
+		actorSystem: system,
+		walletReady: walletReady,
+	}}
+
+	resp, err := srv.ListVTXOs(
+		t.Context(), &daemonrpc.ListVTXOsRequest{
+			StatusFilter: daemonrpc.
+				VTXOStatus_VTXO_STATUS_PENDING_ROUND,
+		},
+	)
+	require.NoError(t, err)
+	require.Empty(
+		t, resp.Vtxos, "ConfirmedState VTXOs live under "+
+			"VTXO_STATUS_LIVE in the store; they must not "+
+			"double-report here",
+	)
+}
+
 // TestQueryRoundStatesEarlyStateOmitsCommitmentTxid verifies that
 // rounds before the CommitmentTxReceived transition still surface
 // their upcoming VTXO amounts but leave the commitment txid empty:

--- a/ledger/handlers.go
+++ b/ledger/handlers.go
@@ -206,6 +206,13 @@ func (a *LedgerActor) handleVTXOReceived(ctx context.Context,
 		msg.OutpointHash, msg.OutpointIndex,
 	)
 
+	// Surface the VTXO outpoint on the row's structured chain
+	// fields too. Without these the consumer-facing onchain view
+	// renders a "round"-kind entry with an empty txid and has to
+	// string-parse the description to recover the outpoint — see
+	// issue #504.
+	chainVout := int32(msg.OutpointIndex)
+
 	return a.cfg.LedgerStore.InsertLedgerEntry(
 		ctx, LedgerEntry{
 			DebitAccount:  debitAccount,
@@ -220,6 +227,8 @@ func (a *LedgerActor) handleVTXOReceived(ctx context.Context,
 			),
 			CreatedAt:      a.clk.Now().Unix(),
 			IdempotencyKey: idempotencyKey,
+			ChainTxid:      msg.OutpointHash[:],
+			ChainVout:      &chainVout,
 		},
 	)
 }

--- a/ledger/handlers_test.go
+++ b/ledger/handlers_test.go
@@ -289,6 +289,20 @@ func TestHandleVTXOReceivedRoundBoarding(t *testing.T) {
 	require.Equal(t, int64(50_000), entries[0].AmountSat)
 	require.Equal(t, EventVTXOReceived,
 		entries[0].EventType)
+
+	// The VTXO outpoint must land on the row's structured chain
+	// fields too. Issue #504: without these the wallet's onchain
+	// view renders a "round"-kind row with an empty txid and the
+	// outpoint only available by parsing the description blob.
+	require.Equal(
+		t, msg.OutpointHash[:], entries[0].ChainTxid,
+		"chain_txid must carry the VTXO outpoint hash",
+	)
+	require.NotNil(t, entries[0].ChainVout)
+	require.Equal(
+		t, int32(msg.OutpointIndex), *entries[0].ChainVout,
+		"chain_vout must carry the VTXO outpoint index",
+	)
 }
 
 // TestHandleVTXOReceivedRoundTransfer verifies that an in-round

--- a/swapwallet/history.go
+++ b/swapwallet/history.go
@@ -504,17 +504,49 @@ func walletEntryFromLedgerRow(t *daemonrpc.TransactionHistoryEntry) (
 	amount := t.GetAmountSat() * direction
 
 	return &walletrpc.WalletEntry{
-		Id:   id,
-		Kind: kind,
-		Status: statusFromLedgerConfirmation(
-			t.GetConfirmationStatus(),
-		),
+		Id:            id,
+		Kind:          kind,
+		Status:        statusForLedgerRow(t, kind),
 		AmountSat:     amount,
 		FeeSat:        t.GetFeeSat(),
 		Counterparty:  ledgerCounterparty(t, kind),
 		CreatedAtUnix: t.GetCreatedAtUnixS(),
 		UpdatedAtUnix: t.GetCreatedAtUnixS(),
 	}, true
+}
+
+// statusForLedgerRow folds the ledger row's confirmation_status and the
+// wallet-facing entry kind into the flat EntryStatus the API surfaces.
+// Most rows are a straight projection of the chain confirmation
+// signal, but DEPOSIT rows from the `wallet_utxo_created` event are a
+// special case: chain confirmation of the boarding UTXO only means the
+// funds landed on-chain, NOT that they have been boarded into a live
+// VTXO. Reporting COMPLETE there is misleading — under
+// eagerroundjoin=false the deposit can sit forever in that state
+// while remaining unspendable through any in-Ark flow. Keep DEPOSIT
+// rows backed by wallet_utxo_created at PENDING until a follow-up
+// boarding_fee_paid (or equivalent "boarded" ledger entry) flips
+// them to COMPLETE.
+func statusForLedgerRow(t *daemonrpc.TransactionHistoryEntry,
+	kind walletrpc.EntryKind) walletrpc.EntryStatus {
+
+	confirmation := statusFromLedgerConfirmation(t.GetConfirmationStatus())
+
+	if kind == walletrpc.EntryKind_ENTRY_KIND_DEPOSIT &&
+		t.GetSubtype() == ledger.EventWalletUTXOCreated &&
+		confirmation == walletrpc.EntryStatus_ENTRY_STATUS_COMPLETE {
+
+		// TODO(#503 follow-up): flip back to COMPLETE once the
+		// ledger emits a boarding_fee_paid (or equivalent
+		// "boarded into a round" entry) for this deposit. Until
+		// that signal exists, DEPOSIT rows backed by
+		// wallet_utxo_created are stuck at PENDING here — which
+		// is correct ("on-chain, not yet boarded") but loses the
+		// eventual "boarded" transition.
+		return walletrpc.EntryStatus_ENTRY_STATUS_PENDING
+	}
+
+	return confirmation
 }
 
 // classifyLedgerRow maps a ledger row's type+subtype+account triple onto

--- a/swapwallet/history_test.go
+++ b/swapwallet/history_test.go
@@ -480,3 +480,44 @@ func TestHistoryPaginationOffsetPlumbedToLedger(t *testing.T) {
 			"rows to satisfy the requested page",
 	)
 }
+
+// TestHistoryDepositStaysPendingOnChainConfirmation pins issue #503:
+// a DEPOSIT row derived from a wallet_utxo_created ledger entry must
+// not flip to COMPLETE the moment the boarding UTXO confirms on
+// chain. Under eagerroundjoin=false the deposit can sit indefinitely
+// in that state while remaining unspendable through any in-Ark flow;
+// COMPLETE there misleads the user about whether the funds have
+// actually been boarded into a VTXO.
+func TestHistoryDepositStaysPendingOnChainConfirmation(t *testing.T) {
+	t.Parallel()
+
+	h, swap, rpc := newHistoryFixture(t)
+	swap.listSwapsResp = &swapclientrpc.ListSwapsResponse{}
+	rpc.listTxResp = &daemonrpc.ListTransactionsResponse{
+		Transactions: []*daemonrpc.TransactionHistoryEntry{
+			{
+				Type:               "boarding",
+				Subtype:            ledger.EventWalletUTXOCreated,
+				ConfirmationStatus: "confirmed",
+				AmountSat:          100_000,
+				Txid:               "boarding-txid",
+				CreatedAtUnixS:     100,
+			},
+		},
+	}
+
+	resp, err := h.List(t.Context(), &walletrpc.ListRequest{})
+	require.NoError(t, err)
+	require.Len(t, resp.GetActivity().GetEntries(), 1)
+
+	entry := resp.GetActivity().GetEntries()[0]
+	require.Equal(
+		t, walletrpc.EntryKind_ENTRY_KIND_DEPOSIT, entry.GetKind(),
+	)
+	require.Equal(
+		t, walletrpc.EntryStatus_ENTRY_STATUS_PENDING,
+		entry.GetStatus(),
+		"on-chain confirmation of the boarding UTXO is NOT the "+
+			"boarded-into-a-VTXO signal",
+	)
+}

--- a/swapwallet/service_test.go
+++ b/swapwallet/service_test.go
@@ -88,6 +88,40 @@ func TestServiceBalanceProjectsDaemonGetBalance(t *testing.T) {
 	require.Equal(t, int64(5_000), resp.GetPendingOutSat())
 }
 
+// TestServiceBalanceConfirmedExcludesBoardingUTXOs pins the boarding
+// reproduction from issue #502: a wallet that holds one live VTXO and
+// one confirmed-but-not-yet-boarded UTXO must report only the VTXO
+// under confirmed_sat. The boarding UTXO is not VTXO-spendable until a
+// round adopts it, so its value belongs in pending_in_sat per the
+// proto contract on BalanceResponse.confirmed_sat
+// ("total spendable VTXO amount").
+func TestServiceBalanceConfirmedExcludesBoardingUTXOs(t *testing.T) {
+	t.Parallel()
+
+	const (
+		vtxoSat            = int64(99_745)
+		boardingConfirmed  = int64(100_000)
+		expectedConfirmed  = vtxoSat
+		expectedPendingIn  = boardingConfirmed
+		expectedPendingOut = int64(0)
+	)
+
+	svc, _, rpc := newServiceFixture(t)
+	rpc.getBalanceResp = &daemonrpc.GetBalanceResponse{
+		VtxoBalanceSat:       vtxoSat,
+		BoardingConfirmedSat: boardingConfirmed,
+		TotalConfirmedSat:    vtxoSat + boardingConfirmed,
+	}
+
+	resp, err := svc.Balance(
+		t.Context(), &walletrpc.BalanceRequest{},
+	)
+	require.NoError(t, err)
+	require.Equal(t, expectedConfirmed, resp.GetConfirmedSat())
+	require.Equal(t, expectedPendingIn, resp.GetPendingInSat())
+	require.Equal(t, expectedPendingOut, resp.GetPendingOutSat())
+}
+
 // TestServiceStatusComposesInfoBalanceAndPending confirms Status reads
 // GetInfo, GetBalance, and the pending count via the history merger.
 func TestServiceStatusComposesInfoBalanceAndPending(t *testing.T) {


### PR DESCRIPTION
## Summary

Five commits closing the user-visible visibility gaps surfaced during
walletdk guide testing on signet. Each commit is independently
reviewable and ships with a regression test that fails against the
pre-fix code.

- 46493f72 \`darepod: surface upcoming VTXOs and commitment txid for live rounds\` — closes #500
- 85a94fee \`darepod: add pending_round filter to ListVTXOs\` — closes #501
- 0c4f801a \`swapwallet: confirmed_sat should be VTXO-only\` — closes #502
- 241565ad \`swapwallet: keep DEPOSIT row PENDING after chain confirmation\` — closes #503
- 8d93568a \`ledger: stamp VTXO outpoint on vtxo_received chain fields\` — closes #504

The five issues together describe the same theme — \"what state are my
boarding funds in?\" — and were observed in one signet session with
\`eagerroundjoin=false\`. They sit in three independent layers
(\`daemonrpc\`, \`swapwallet\`/\`walletrpc\`, \`ledger\`) so they ship as one
stack rather than one tangled patch.

### #500 — live RoundInfo dropped commitment txid + upcoming VTXOs

\`queryRoundStates\` only populated \`RoundId\`, \`State\`, \`IsTemp\`, and
\`FailureReason\` for live actor-served rounds. The commitment txid was
visible in the daemon log but nowhere in the API response, and the
upcoming-VTXO set the wallet had just signed for never reached the
caller. Adds a state-aware \`liveRoundDetails\` helper that pulls the
commitment txid (from the \`TxID\` field, or by recomputing from the
embedded PSBT on MuSig2-phase states) and the per-owner VTXO amounts
(filtered to \`HasLocalOwner=true\` so outputs destined for other
clients don't inflate the local view).

### #501 — no pending-VTXO view between round-signed and commitment-confirmed

\`ark vtxos list\` only surfaced VTXOs whose commitment tx had
already confirmed; there was no enum value for \"signed but not yet
on-chain\". Adds \`VTXO_STATUS_PENDING_ROUND\` and routes \`ListVTXOs\`
with that filter to the round actor instead of the store, projecting
each in-flight round's owner-VTXOs as synthetic entries carrying
amount + round_id + commitment txid. Outpoint is left empty: the
precise leaf outpoint isn't finalised until the commitment tx
confirms. \`min_amount_sat\` still applies.

### #502 — \`walletrpc.confirmed_sat\` lumped boarding UTXOs with VTXOs

\`fetchBalance\` mapped \`daemonrpc.total_confirmed_sat → confirmed_sat\`,
which silently bundled confirmed-but-not-boarded boarding UTXOs into
the field the proto documents as \"total spendable VTXO amount\". Maps
\`vtxo_balance_sat → confirmed_sat\` and
\`boarding_confirmed_sat + boarding_unconfirmed_sat → pending_in_sat\`
so the proto contract is upheld.

### #503 — DEPOSIT activity row flipped to COMPLETE on chain confirm

\`statusFromLedgerConfirmation\` mapped every \`confirmation_status=\"confirmed\"\`
row to COMPLETE. For a DEPOSIT row backed by \`wallet_utxo_created\`
that's misleading — chain confirmation of the boarding UTXO is NOT
the boarded-into-a-VTXO signal. Under \`eagerroundjoin=false\` the row
can sit at COMPLETE indefinitely while being unspendable through any
in-Ark flow. Adds \`statusForLedgerRow(t, kind)\`; for DEPOSIT rows
backed by \`wallet_utxo_created\` the status is held at PENDING until a
follow-up \"boarded into a round\" ledger event lands (noted in the
helper's comment).

### #504 — round-kind onchain rows had empty txid + confirmation_height

\`handleVTXOReceived\` was writing the VTXO outpoint only into the
human-readable description and the idempotency key. The structured
\`ChainTxid\`/\`ChainVout\` columns sat empty, so \`list --view onchain\`
rendered round-kind entries with an empty txid that callers had to
recover by string-parsing the description. Stamps the outpoint hash
on \`ChainTxid\` and the index on \`ChainVout\` for every
\`vtxo_received\` entry.

## Test plan

- [x] \`make fmt-changed\` clean
- [x] \`make lint-changed-local\` clean across all 5 commits
- [x] \`go test ./darepod/\` passes — covers #500 and #501
- [x] \`go test -tags=\"walletrpc swapruntime\" ./swapwallet/\` passes — covers #502 and #503
- [x] \`go test ./ledger/\` passes — covers #504
- [x] Each regression test was verified to fail against the pre-fix code by stashing the impl and rerunning the targeted test
- [ ] CI green

## Notes for reviewer

- #500/#501 add a \`commitment_txid\` field and a new VTXO status enum to \`daemonrpc/daemon.proto\` — generated stubs regenerated via \`make rpc\` and bundled into the same commits per the proto-edit convention.
- #500's \`liveRoundDetails\` helper threads through \`PendingRoundAssembly\`, \`IntentSentState\`, \`QuoteReceivedState\`, \`RoundJoinedState\`, the MuSig2-phase states, \`InputSigSentState\`, and \`ConfirmedState\`. Anything else falls through to no-data, matching the prior contract.
- #503's fix is a half-step: DEPOSIT rows now stay PENDING after chain confirmation rather than reporting a misleading COMPLETE, but they cannot flip back to COMPLETE until a \"boarded into a round\" ledger event exists. That follow-up is intentionally out of scope here.