### PR TITLE
docs: nightly doc-gardening sweep 2026-05-22

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -47,6 +47,7 @@ package may import from a higher layer.
 | [`db`](db/) | SQLite/PostgreSQL persistence: boarding, rounds, VTXOs, OOR artifacts, fee ledger |
 | [`mailbox`](mailbox/) | Mailbox protocol primitives across three sub-packages (pb, rpc, conn) |
 | [`serverconn`](serverconn/) | Unified server connector: durable egress, ingress polling, unary RPC facade |
+| [`serverconn/mailboxpull`](serverconn/mailboxpull/) | Shared retry-with-exponential-backoff primitive for mailbox pull loops; used by both the daemon ingress loop and the SDK swap event consumers |
 
 ### Layer 3: Application & Orchestration
 

--- a/scripts/check-sample-darepod-conf/AGENTS.md
+++ b/scripts/check-sample-darepod-conf/AGENTS.md
@@ -1,0 +1,34 @@
+# check-sample-darepod-conf
+
+## Purpose
+
+CI utility that verifies `sample-darepod.conf` documents every daemon config
+option with its current default value. Prevents the sample config from drifting
+out of sync with `darepod.Config` struct fields and CLI flag registrations.
+
+## Key Types
+
+- `main` — entry point; drives config-key collection, sample parsing, and diff
+  reporting.
+- `daemonFlag` — name/default pair parsed from `darepod --help` output.
+
+## Relationships
+
+- **Depends on**: `darepod` (reflection over `DefaultConfig()` for expected
+  keys), `cmd/darepod` (invoked via `go run` to extract CLI flag defaults)
+- **Depended on by**: CI (via `make` or `go run ./scripts/check-sample-darepod-conf`)
+- **Sends**: none
+- **Receives**: none
+
+## Invariants
+
+- All entries in `sample-darepod.conf` must be commented (`# key=value`);
+  any live (uncommented) config line causes a hard failure.
+- Every key present in the sample must match the live default; stale defaults
+  are reported as mismatches.
+- Flags listed in `skippedFlags` (`configfile`, `help`, `version`) are
+  intentionally excluded from coverage checks.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map

--- a/scripts/check-sample-darepod-conf/CLAUDE.md
+++ b/scripts/check-sample-darepod-conf/CLAUDE.md
@@ -1,0 +1,34 @@
+# check-sample-darepod-conf
+
+## Purpose
+
+CI utility that verifies `sample-darepod.conf` documents every daemon config
+option with its current default value. Prevents the sample config from drifting
+out of sync with `darepod.Config` struct fields and CLI flag registrations.
+
+## Key Types
+
+- `main` — entry point; drives config-key collection, sample parsing, and diff
+  reporting.
+- `daemonFlag` — name/default pair parsed from `darepod --help` output.
+
+## Relationships
+
+- **Depends on**: `darepod` (reflection over `DefaultConfig()` for expected
+  keys), `cmd/darepod` (invoked via `go run` to extract CLI flag defaults)
+- **Depended on by**: CI (via `make` or `go run ./scripts/check-sample-darepod-conf`)
+- **Sends**: none
+- **Receives**: none
+
+## Invariants
+
+- All entries in `sample-darepod.conf` must be commented (`# key=value`);
+  any live (uncommented) config line causes a hard failure.
+- Every key present in the sample must match the live default; stale defaults
+  are reported as mismatches.
+- Flags listed in `skippedFlags` (`configfile`, `help`, `version`) are
+  intentionally excluded from coverage checks.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map

--- a/serverconn/mailboxpull/AGENTS.md
+++ b/serverconn/mailboxpull/AGENTS.md
@@ -1,0 +1,40 @@
+# mailboxpull
+
+## Purpose
+
+Provides shared retry-with-exponential-backoff primitives for mailbox pull
+loops. Factors out the pull-and-retry pattern so the daemon's persistent
+identity-mailbox ingress loop (`serverconn`) and per-swap event consumers
+(`sdk/swaps`) share identical reliability semantics.
+
+## Key Types
+
+- `BackoffConfig` — base delay and cap for exponential backoff with jitter.
+- `PullWithRetry` — calls `MailboxServiceClient.Pull`, retrying transport
+  errors with backoff until success or context cancellation.
+- `RetryDelay` — computes the next backoff duration given attempt count.
+- `Sleep` — increments the attempt counter and blocks for the computed delay,
+  respecting context cancellation.
+
+## Relationships
+
+- **Depends on**: `mailbox/pb` (MailboxServiceClient interface for Pull calls)
+- **Depended on by**: `serverconn` (identity-mailbox ingress loop),
+  `sdk/swaps` (per-swap event consumer)
+- **Sends**: none
+- **Receives**: none
+
+## Invariants
+
+- Transport errors are retried; status-level failures (`resp.Status` non-nil
+  with `Ok=false`) are returned to the caller as-is.
+- Context cancellation always takes precedence over a pending transport error:
+  `ctx.Err()` is checked both before issuing `Pull` and immediately after
+  receiving a transport error, so callers get `context.Canceled` rather than
+  the underlying transport error.
+- `BackoffConfig{}` (zero value) is valid and selects package defaults
+  (200 ms base, 30 s cap).
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map

--- a/serverconn/mailboxpull/CLAUDE.md
+++ b/serverconn/mailboxpull/CLAUDE.md
@@ -1,0 +1,40 @@
+# mailboxpull
+
+## Purpose
+
+Provides shared retry-with-exponential-backoff primitives for mailbox pull
+loops. Factors out the pull-and-retry pattern so the daemon's persistent
+identity-mailbox ingress loop (`serverconn`) and per-swap event consumers
+(`sdk/swaps`) share identical reliability semantics.
+
+## Key Types
+
+- `BackoffConfig` — base delay and cap for exponential backoff with jitter.
+- `PullWithRetry` — calls `MailboxServiceClient.Pull`, retrying transport
+  errors with backoff until success or context cancellation.
+- `RetryDelay` — computes the next backoff duration given attempt count.
+- `Sleep` — increments the attempt counter and blocks for the computed delay,
+  respecting context cancellation.
+
+## Relationships
+
+- **Depends on**: `mailbox/pb` (MailboxServiceClient interface for Pull calls)
+- **Depended on by**: `serverconn` (identity-mailbox ingress loop),
+  `sdk/swaps` (per-swap event consumer)
+- **Sends**: none
+- **Receives**: none
+
+## Invariants
+
+- Transport errors are retried; status-level failures (`resp.Status` non-nil
+  with `Ok=false`) are returned to the caller as-is.
+- Context cancellation always takes precedence over a pending transport error:
+  `ctx.Err()` is checked both before issuing `Pull` and immediately after
+  receiving a transport error, so callers get `context.Canceled` rather than
+  the underlying transport error.
+- `BackoffConfig{}` (zero value) is valid and selects package defaults
+  (200 ms base, 30 s cap).
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map


### PR DESCRIPTION
Automated nightly doc-gardening sweep for 2026-05-22.

**Changes:**
- Added `serverconn/mailboxpull/CLAUDE.md` and `AGENTS.md`: documents the
  retry+exponential-backoff pull primitive shared by the daemon ingress loop
  and SDK swap event consumers.
- Added `scripts/check-sample-darepod-conf/CLAUDE.md` and `AGENTS.md`:
  documents the CI utility that verifies `sample-darepod.conf` stays in sync
  with daemon config options and CLI flag defaults.
- Updated `ARCHITECTURE.md` Layer 2 table: added `serverconn/mailboxpull`
  entry.

**Workflow run:** (nightly cron — see Actions tab)

**Review notes:** Check the updated `CLAUDE.md`/`AGENTS.md` and
`ARCHITECTURE.md` diffs for accuracy. All cross-links validated via
`make doc-check`.
