### PR TITLE
Expire unfunded receive swaps

### DIFF
--- a/sdk/swaps/client.go
+++ b/sdk/swaps/client.go
@@ -441,7 +441,6 @@ type SwapClient struct {
 
 	waitPollInterval         time.Duration
 	overdueReceivePollWindow time.Duration
-	waitVHTLCTimeout         time.Duration
 	fundingResumeGracePeriod time.Duration
 	claimResumeGracePeriod   time.Duration
 	fundingExpiryBuffer      time.Duration
@@ -500,7 +499,6 @@ func NewSwapClientWithStore(server SwapServerConn, daemon DaemonConn,
 		log:                      log,
 		waitPollInterval:         2 * time.Second,
 		overdueReceivePollWindow: defaultOverdueReceiveMailboxPollWindow,
-		waitVHTLCTimeout:         60 * time.Second,
 		fundingResumeGracePeriod: defaultFundingResumeGracePeriod,
 		claimResumeGracePeriod:   defaultClaimResumeGracePeriod,
 		fundingExpiryBuffer:      defaultFundingExpiryBuffer,

--- a/sdk/swaps/client.go
+++ b/sdk/swaps/client.go
@@ -440,6 +440,7 @@ type SwapClient struct {
 	log        btclog.Logger
 
 	waitPollInterval         time.Duration
+	overdueReceivePollWindow time.Duration
 	waitVHTLCTimeout         time.Duration
 	fundingResumeGracePeriod time.Duration
 	claimResumeGracePeriod   time.Duration
@@ -498,6 +499,7 @@ func NewSwapClientWithStore(server SwapServerConn, daemon DaemonConn,
 		store:                    store,
 		log:                      log,
 		waitPollInterval:         2 * time.Second,
+		overdueReceivePollWindow: defaultOverdueReceiveMailboxPollWindow,
 		waitVHTLCTimeout:         60 * time.Second,
 		fundingResumeGracePeriod: defaultFundingResumeGracePeriod,
 		claimResumeGracePeriod:   defaultClaimResumeGracePeriod,

--- a/sdk/swaps/out_swap.go
+++ b/sdk/swaps/out_swap.go
@@ -36,6 +36,12 @@ const (
 	// to surface in the indexer before retrying the spend.
 	defaultClaimResumeGracePeriod = 15 * time.Second
 
+	// defaultOverdueReceiveMailboxPollWindow is the grace window used when
+	// a daemon resumes an unpaid receive after its invoice deadline. It
+	// gives an already-delivered mailbox event time to arrive locally
+	// before the receive is expired.
+	defaultOverdueReceiveMailboxPollWindow = 10 * time.Second
+
 	// defaultClaimPreimageLookupAttempts bounds the short local retry loop
 	// used after a vHTLC spend is indexed before its preimage metadata is
 	// visible through the daemon.
@@ -679,10 +685,18 @@ func (s *ReceiveSession) waitForHTLCEvent(ctx context.Context) error {
 		return fmt.Errorf("get receive auth key: %w", err)
 	}
 
+	waitCtx, cancel := s.invoiceDeadlineContext(ctx)
+	defer cancel()
+
 	notification, err := s.waitIncomingVHTLCNotification(
-		ctx, authKey,
+		waitCtx, authKey,
 	)
 	if err != nil {
+		if invoiceDeadlineExceeded(ctx, waitCtx, err) {
+			return fmt.Errorf("receive invoice deadline "+
+				"elapsed: %w", errSwapExpired)
+		}
+
 		return err
 	}
 	if notification == nil {
@@ -694,6 +708,37 @@ func (s *ReceiveSession) waitForHTLCEvent(ctx context.Context) error {
 	}
 
 	return s.ackAcceptedHTLCEvent(ctx, notification.Ack)
+}
+
+// invoiceDeadlineContext bounds only the unpaid-invoice mailbox wait. When a
+// daemon resumes after the invoice deadline, it still gives mailbox delivery a
+// short grace window to surface an already-delivered HTLC event before the
+// receive is expired.
+func (s *ReceiveSession) invoiceDeadlineContext(ctx context.Context) (
+	context.Context, context.CancelFunc) {
+
+	if s == nil || s.client == nil || s.deadline.IsZero() {
+		return context.WithCancel(ctx)
+	}
+
+	now := s.client.currentTime()
+	if now.Before(s.deadline) {
+		return context.WithDeadline(ctx, s.deadline)
+	}
+
+	return context.WithTimeout(ctx, s.client.overdueReceivePollWindow)
+}
+
+// invoiceDeadlineExceeded reports whether the receive invoice's own deadline
+// context expired, rather than the caller/root context interrupting the wait.
+func invoiceDeadlineExceeded(parent, waitCtx context.Context, err error) bool {
+	if err == nil || waitCtx.Err() == nil || parent.Err() != nil {
+		return false
+	}
+
+	return isDeadlineExceededErr(err) || errors.Is(
+		waitCtx.Err(), context.DeadlineExceeded,
+	)
 }
 
 // waitForFunding waits until the expected accepted vHTLC is indexed as live.
@@ -708,7 +753,7 @@ func (s *ReceiveSession) waitForFunding(ctx context.Context) error {
 	}
 
 	outpoint, amount, err := s.client.waitForVHTLC(
-		ctx, s.vhtlcPkScript, s.deadline,
+		ctx, s.vhtlcPkScript, time.Time{},
 		s.ensureReceiveFundingStillPossible,
 	)
 	if err != nil {
@@ -1526,10 +1571,6 @@ func (c *SwapClient) waitForVHTLC(ctx context.Context, pkScript []byte,
 	int64, error) {
 
 	pkScriptHex := hex.EncodeToString(pkScript)
-	if deadline.IsZero() {
-		deadline = c.currentTime().Add(c.waitVHTLCTimeout)
-	}
-
 	for {
 		if err := ctx.Err(); err != nil {
 			return "", 0, err

--- a/sdk/swaps/out_swap.go
+++ b/sdk/swaps/out_swap.go
@@ -717,7 +717,7 @@ func (s *ReceiveSession) waitForHTLCEvent(ctx context.Context) error {
 func (s *ReceiveSession) invoiceDeadlineContext(ctx context.Context) (
 	context.Context, context.CancelFunc) {
 
-	if s == nil || s.client == nil || s.deadline.IsZero() {
+	if s.client == nil || s.deadline.IsZero() {
 		return context.WithCancel(ctx)
 	}
 
@@ -752,6 +752,10 @@ func (s *ReceiveSession) waitForFunding(ctx context.Context) error {
 			"yet")
 	}
 
+	// Once the HTLC event is accepted, the server may already have funded
+	// the vHTLC. Do not add a wall-clock deadline here: the refund-locktime
+	// guard below is the durable boundary, and backend/indexer outages
+	// should keep retrying until the caller shuts the worker down.
 	outpoint, amount, err := s.client.waitForVHTLC(
 		ctx, s.vhtlcPkScript, time.Time{},
 		s.ensureReceiveFundingStillPossible,

--- a/sdk/swaps/out_swap_test.go
+++ b/sdk/swaps/out_swap_test.go
@@ -211,6 +211,22 @@ type testIncomingEventReceiver struct {
 	notification *IncomingVHTLCNotification
 }
 
+type blockingOutSwapEventReceiver struct{}
+
+func (r *blockingOutSwapEventReceiver) WaitOutSwapHtlc(ctx context.Context,
+	_ lntypes.Hash, _ *btcec.PublicKey) (*OutSwapHtlcNotification, error) {
+
+	<-ctx.Done()
+
+	return nil, ctx.Err()
+}
+
+func (r *blockingOutSwapEventReceiver) AckOutSwapHtlc(_ context.Context,
+	_ lntypes.Hash, _ *btcec.PublicKey, _ uint64) error {
+
+	return fmt.Errorf("unexpected out-swap ack")
+}
+
 // WaitOutSwapHtlc is unused when the incoming vHTLC path is available.
 func (r *testIncomingEventReceiver) WaitOutSwapHtlc(context.Context,
 	lntypes.Hash, *btcec.PublicKey) (*OutSwapHtlcNotification, error) {
@@ -1338,6 +1354,166 @@ func TestReceiveSessionExpiresAtRefundLocktimeWithoutFunding(t *testing.T) {
 
 	_, err = reloaded.Wait(t.Context())
 	require.ErrorIs(t, err, errSwapExpired)
+}
+
+// TestReceiveSessionExpiresUnpaidInvoiceAtDeadline asserts an unpaid receive
+// stops waiting for the mailbox event once the persisted invoice deadline
+// elapses.
+func TestReceiveSessionExpiresUnpaidInvoiceAtDeadline(t *testing.T) {
+	t.Parallel()
+
+	store := newTestSwapStore(t)
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	serverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	creator := &testInvoiceCreator{
+		invoice: &invoices.Invoice{
+			PaymentRequest: []byte("lnrtest1swap"),
+		},
+	}
+	serverPubKey := serverPriv.PubKey().SerializeCompressed()
+	serverConn := &testSwapServerConn{
+		hint: &RouteHint{
+			NodeID:          serverPubKey,
+			ChannelID:       99,
+			FeeBaseMsat:     1,
+			FeePropPpm:      2,
+			CltvExpiryDelta: 40,
+		},
+		cfg: &VHTLCConfig{
+			RefundLocktime:                       144,
+			UnilateralClaimDelay:                 12,
+			UnilateralRefundDelay:                24,
+			UnilateralRefundWithoutReceiverDelay: 36,
+			SwapServerPubkey:                     serverPubKey,
+		},
+	}
+	daemonConn := &testDaemonConn{
+		identityKey: clientPriv.PubKey(),
+		operatorKey: operatorPriv.PubKey(),
+	}
+
+	client := NewSwapClientWithStore(
+		serverConn, daemonConn, nil, creator, store,
+	)
+	client.outEvents = &blockingOutSwapEventReceiver{}
+	client.overdueReceivePollWindow = time.Millisecond
+	useTestOnionDecoder(client, 42_000)
+
+	session, err := client.StartReceiveViaLightning(
+		t.Context(), btcutil.Amount(42_000),
+	)
+	require.NoError(t, err)
+	require.NoError(
+		t,
+		session.mutateAndPersist(
+			t.Context(),
+			func() error {
+				session.deadline = time.Now().Add(
+					10 * time.Millisecond,
+				)
+
+				return nil
+			},
+		),
+	)
+
+	_, err = session.Wait(t.Context())
+	require.ErrorIs(t, err, errSwapExpired)
+	require.Equal(t, ReceiveStateExpired, session.State())
+
+	resumed, err := client.ResumeReceiveViaLightning(
+		t.Context(), session.PaymentHash,
+	)
+	require.NoError(t, err)
+	require.Equal(t, ReceiveStateExpired, resumed.State())
+
+	pending, err := client.ListPendingReceiveSessions(t.Context())
+	require.NoError(t, err)
+	require.Empty(t, pending)
+}
+
+// TestReceiveSessionOverdueInvoiceAcceptsDeliveredEvent asserts an already
+// delivered mailbox event wins over the invoice deadline during resume.
+func TestReceiveSessionOverdueInvoiceAcceptsDeliveredEvent(t *testing.T) {
+	t.Parallel()
+
+	store := newTestSwapStore(t)
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	serverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	creator := &testInvoiceCreator{
+		invoice: &invoices.Invoice{
+			PaymentRequest: []byte("lnrtest1swap"),
+		},
+	}
+	serverPubKey := serverPriv.PubKey().SerializeCompressed()
+	serverConn := &testSwapServerConn{
+		hint: &RouteHint{
+			NodeID:          serverPubKey,
+			ChannelID:       99,
+			FeeBaseMsat:     1,
+			FeePropPpm:      2,
+			CltvExpiryDelta: 40,
+		},
+		cfg: &VHTLCConfig{
+			RefundLocktime:                       144,
+			UnilateralClaimDelay:                 12,
+			UnilateralRefundDelay:                24,
+			UnilateralRefundWithoutReceiverDelay: 36,
+			SwapServerPubkey:                     serverPubKey,
+		},
+	}
+	daemonConn := &testDaemonConn{
+		identityKey: clientPriv.PubKey(),
+		operatorKey: operatorPriv.PubKey(),
+	}
+
+	client := NewSwapClientWithStore(
+		serverConn, daemonConn, nil, creator, store,
+	)
+	client.overdueReceivePollWindow = 100 * time.Millisecond
+	useTestOnionDecoder(client, 42_000)
+
+	session, err := client.StartReceiveViaLightning(
+		t.Context(), btcutil.Amount(42_000),
+	)
+	require.NoError(t, err)
+	require.NoError(
+		t,
+		session.mutateAndPersist(
+			t.Context(),
+			func() error {
+				session.deadline = time.Now().Add(-time.Second)
+
+				return nil
+			},
+		),
+	)
+
+	resumed, err := client.ResumeReceiveViaLightning(
+		t.Context(), session.PaymentHash,
+	)
+	require.NoError(t, err)
+	require.Equal(t, ReceiveStateInvoiceCreated, resumed.State())
+
+	err = resumed.waitForHTLCEvent(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, ReceiveStateHTLCEventAccepted, resumed.State())
 }
 
 // TestReceiveSessionFailsOnAmountMismatch asserts the client stops with an

--- a/sdk/swaps/out_swap_test.go
+++ b/sdk/swaps/out_swap_test.go
@@ -734,7 +734,6 @@ func TestReceiveSessionWaitClaimsVHTLC(t *testing.T) {
 	client := NewSwapClient(serverConn, daemonConn, nil, creator)
 	useTestOnionDecoder(client, 42_000)
 	client.waitPollInterval = time.Millisecond
-	client.waitVHTLCTimeout = 50 * time.Millisecond
 
 	session, err := client.StartReceiveViaLightning(
 		t.Context(), btcutil.Amount(42_000),
@@ -1404,26 +1403,31 @@ func TestReceiveSessionExpiresUnpaidInvoiceAtDeadline(t *testing.T) {
 		serverConn, daemonConn, nil, creator, store,
 	)
 	client.outEvents = &blockingOutSwapEventReceiver{}
-	client.overdueReceivePollWindow = time.Millisecond
 	useTestOnionDecoder(client, 42_000)
 
 	session, err := client.StartReceiveViaLightning(
 		t.Context(), btcutil.Amount(42_000),
 	)
 	require.NoError(t, err)
+	deadline := time.Now().Add(-time.Second)
 	require.NoError(
 		t,
 		session.mutateAndPersist(
 			t.Context(),
 			func() error {
-				session.deadline = time.Now().Add(
-					10 * time.Millisecond,
-				)
+				session.deadline = deadline
 
 				return nil
 			},
 		),
 	)
+	// Keep the client's fake clock before the persisted deadline so the
+	// test takes the invoice-deadline branch, while the real context
+	// deadline is already elapsed. This avoids a millisecond-scale
+	// wall-clock race.
+	client.now = func() time.Time {
+		return deadline.Add(-time.Second)
+	}
 
 	_, err = session.Wait(t.Context())
 	require.ErrorIs(t, err, errSwapExpired)
@@ -1572,7 +1576,6 @@ func TestReceiveSessionFailsOnAmountMismatch(t *testing.T) {
 	)
 	useTestOnionDecoder(client, 42_000)
 	client.waitPollInterval = time.Millisecond
-	client.waitVHTLCTimeout = 50 * time.Millisecond
 
 	session, err := client.StartReceiveViaLightning(
 		t.Context(), btcutil.Amount(42_000),

--- a/swapwallet/deps.go
+++ b/swapwallet/deps.go
@@ -78,10 +78,9 @@ type RPCServer interface {
 		*daemonrpc.JoinNextRoundResponse, error)
 }
 
-// defaultWalletDeadline caps how long any single wallet entry can remain
-// PENDING before the runtime transitions it to FAILED with a timeout
-// reason. The wallet deadline lives ABOVE the swap FSM's own deadline so a
-// stuck or partially-progressed swap never leaves a user-facing row hanging.
+// defaultWalletDeadline caps how long wallet-local entries can remain PENDING
+// before the runtime projects them as FAILED with a timeout reason. Swap rows
+// use the swap FSM's own terminal state instead.
 const defaultWalletDeadline = 30 * time.Minute
 
 // defaultListLimitConst is the package-default page size used when neither
@@ -131,8 +130,8 @@ type Deps struct {
 	// when nil.
 	Log btclog.Logger
 
-	// WalletDeadline is the wallet-level deadline applied to every
-	// PENDING entry. Zero falls back to defaultWalletDeadline.
+	// WalletDeadline is the wallet-level deadline applied to wallet-local
+	// PENDING entries. Zero falls back to defaultWalletDeadline.
 	WalletDeadline time.Duration
 
 	// DefaultListLimit overrides the default page size used by List when

--- a/swapwallet/doc.go
+++ b/swapwallet/doc.go
@@ -23,13 +23,12 @@
 //   - Balance and Status surface a unified, summary-level view.
 //   - SubscribeWallet streams normalized WalletEntry updates.
 //
-// The package owns the full swap lifecycle in-process. Its runtime drives a
-// synchronous resume-on-startup sweep before the gRPC server accepts calls,
-// enforces a wallet-level deadline watcher that transitions stuck entries
-// to FAILED, and runs a monitor loop that fans normalized updates to
-// SubscribeWallet subscribers. Background goroutines are anchored to the
-// daemon root context, never to RPC-call contexts, so a CLI disconnect can
-// never cancel in-flight work.
+// The package composes the full swap lifecycle in-process. Its runtime drives
+// a synchronous resume-on-startup sweep before the gRPC server accepts calls,
+// keeps wallet-local pending entries from hanging forever, and runs a monitor
+// loop that fans normalized updates to SubscribeWallet subscribers. Background
+// goroutines are anchored to the daemon root context, never to RPC-call
+// contexts, so a CLI disconnect can never cancel in-flight work.
 //
 // The walletrpc build tag depends on swapruntime: building walletrpc without
 // swapruntime is a deliberate compile error because the subserver composes

--- a/swapwallet/history.go
+++ b/swapwallet/history.go
@@ -22,8 +22,8 @@ import (
 // own canonical persistence (swap DB, ledger entries, boarding_sweeps),
 // and swapwallet must not duplicate that state. The merger simply pulls
 // the latest pages, normalizes each row to a WalletEntry, applies the
-// caller's filters, sorts by updated_at descending, paginates, and
-// overlays the runtime's deadline-driven FAILED projections.
+// caller's filters, sorts by updated_at descending, paginates, and applies
+// wallet-local deadline projections.
 type history struct {
 	deps    *Deps
 	runtime *Runtime
@@ -137,8 +137,8 @@ func (h *history) listActivity(ctx context.Context,
 		entries = append(entries, ledgerEntries...)
 	}
 
-	// Apply wallet-level overlay (deadline timeout) BEFORE filtering so
-	// a stuck entry appears as FAILED in the wallet view even when the
+	// Apply wallet-local deadline overlays BEFORE filtering so a stuck
+	// non-swap entry appears as FAILED in the wallet view even when the
 	// caller asked for pending_only=false.
 	h.applyOverlays(entries)
 
@@ -345,6 +345,9 @@ func (h *history) collectLedgerEntries(ctx context.Context, offset,
 func (h *history) applyOverlays(entries []*walletrpc.WalletEntry) {
 	for _, e := range entries {
 		if e.GetStatus() != walletrpc.EntryStatus_ENTRY_STATUS_PENDING {
+			continue
+		}
+		if isSwapKind(e.GetKind()) {
 			continue
 		}
 		ov, ok := h.runtime.overlayFor(e.GetId())

--- a/swapwallet/history.go
+++ b/swapwallet/history.go
@@ -105,6 +105,7 @@ func (h *history) listActivity(ctx context.Context,
 	}
 
 	var entries []*walletrpc.WalletEntry
+	swapEntryIDs := make(map[string]struct{})
 
 	if h.shouldInclude(kindFilter, walletrpc.EntryKind_ENTRY_KIND_SEND) ||
 		h.shouldInclude(kindFilter,
@@ -117,6 +118,9 @@ func (h *history) listActivity(ctx context.Context,
 			return nil, fmt.Errorf("collect swap entries: %w", err)
 		}
 
+		for _, entry := range swapEntries {
+			swapEntryIDs[entry.GetId()] = struct{}{}
+		}
 		entries = append(entries, swapEntries...)
 	}
 
@@ -140,7 +144,7 @@ func (h *history) listActivity(ctx context.Context,
 	// Apply wallet-local deadline overlays BEFORE filtering so a stuck
 	// non-swap entry appears as FAILED in the wallet view even when the
 	// caller asked for pending_only=false.
-	h.applyOverlays(entries)
+	h.applyOverlays(entries, swapEntryIDs)
 
 	// Dedupe by canonical id BEFORE filtering and sorting. An OOR-backed
 	// SEND surfaces once from collectSwapEntries (swap subsystem) and
@@ -342,12 +346,14 @@ func (h *history) collectLedgerEntries(ctx context.Context, offset,
 // applyOverlays elevates entries to FAILED in place when the runtime has
 // flagged them past their wallet-level deadline. The underlying swap or
 // ledger row is left alone; the elevation is a wallet-surface projection.
-func (h *history) applyOverlays(entries []*walletrpc.WalletEntry) {
+func (h *history) applyOverlays(entries []*walletrpc.WalletEntry,
+	swapEntryIDs map[string]struct{}) {
+
 	for _, e := range entries {
 		if e.GetStatus() != walletrpc.EntryStatus_ENTRY_STATUS_PENDING {
 			continue
 		}
-		if isSwapKind(e.GetKind()) {
+		if _, ok := swapEntryIDs[e.GetId()]; ok {
 			continue
 		}
 		ov, ok := h.runtime.overlayFor(e.GetId())

--- a/swapwallet/history_test.go
+++ b/swapwallet/history_test.go
@@ -205,10 +205,9 @@ func TestHistoryKindFilterRejectsUnsupportedKind(t *testing.T) {
 	require.ErrorIs(t, err, ErrUnsupportedKind)
 }
 
-// TestHistoryOverlayProjectsTimedOutFailed confirms the runtime's
-// deadline overlay surfaces as FAILED in the history view without
-// mutating the underlying source.
-func TestHistoryOverlayProjectsTimedOutFailed(t *testing.T) {
+// TestHistorySwapRowsIgnoreTimedOutOverlay confirms swap-backed rows use the
+// swap FSM as their source of truth instead of wallet timeout overlays.
+func TestHistorySwapRowsIgnoreTimedOutOverlay(t *testing.T) {
 	t.Parallel()
 
 	h, swap, rpc := newHistoryFixture(t)
@@ -228,6 +227,43 @@ func TestHistoryOverlayProjectsTimedOutFailed(t *testing.T) {
 	// Inject overlay directly.
 	h.runtime.pendingMu.Lock()
 	h.runtime.overlay["stuck"] = overlayStatus{
+		status: walletrpc.
+			EntryStatus_ENTRY_STATUS_FAILED,
+		failureReason: "timed_out",
+	}
+	h.runtime.pendingMu.Unlock()
+
+	resp, err := h.List(t.Context(), &walletrpc.ListRequest{})
+	require.NoError(t, err)
+	require.Len(t, resp.GetActivity().GetEntries(), 1)
+	require.Equal(
+		t, walletrpc.EntryStatus_ENTRY_STATUS_PENDING,
+		resp.GetActivity().GetEntries()[0].GetStatus(),
+	)
+	require.Empty(t, resp.GetActivity().GetEntries()[0].GetFailureReason())
+}
+
+// TestHistoryWalletRowsApplyTimedOutOverlay confirms wallet-local pending rows
+// still surface the runtime's deadline projection in history.List.
+func TestHistoryWalletRowsApplyTimedOutOverlay(t *testing.T) {
+	t.Parallel()
+
+	h, swap, rpc := newHistoryFixture(t)
+	swap.listSwapsResp = &swapclientrpc.ListSwapsResponse{}
+	rpc.listTxResp = &daemonrpc.ListTransactionsResponse{
+		Transactions: []*daemonrpc.TransactionHistoryEntry{
+			{
+				Txid:               "exit-txid",
+				Type:               "sweep",
+				ConfirmationStatus: "pending",
+				CreatedAtUnixS:     100,
+			},
+		},
+	}
+
+	// Inject overlay directly.
+	h.runtime.pendingMu.Lock()
+	h.runtime.overlay["exit-txid"] = overlayStatus{
 		status: walletrpc.
 			EntryStatus_ENTRY_STATUS_FAILED,
 		failureReason: "timed_out",

--- a/swapwallet/history_test.go
+++ b/swapwallet/history_test.go
@@ -206,7 +206,8 @@ func TestHistoryKindFilterRejectsUnsupportedKind(t *testing.T) {
 }
 
 // TestHistorySwapRowsIgnoreTimedOutOverlay confirms swap-backed rows use the
-// swap FSM as their source of truth instead of wallet timeout overlays.
+// swap FSM as their source of truth instead of wallet timeout overlays, even
+// before the lazy swap summary has a populated direction.
 func TestHistorySwapRowsIgnoreTimedOutOverlay(t *testing.T) {
 	t.Parallel()
 
@@ -214,9 +215,7 @@ func TestHistorySwapRowsIgnoreTimedOutOverlay(t *testing.T) {
 	swap.listSwapsResp = &swapclientrpc.ListSwapsResponse{
 		Swaps: []*swapclientrpc.SwapSummary{
 			{
-				PaymentHash: "stuck",
-				Direction: swapclientrpc.
-					SwapDirection_SWAP_DIRECTION_PAY,
+				PaymentHash:   "stuck",
 				Pending:       true,
 				UpdatedAtUnix: 100,
 			},
@@ -239,6 +238,10 @@ func TestHistorySwapRowsIgnoreTimedOutOverlay(t *testing.T) {
 	require.Equal(
 		t, walletrpc.EntryStatus_ENTRY_STATUS_PENDING,
 		resp.GetActivity().GetEntries()[0].GetStatus(),
+	)
+	require.Equal(
+		t, walletrpc.EntryKind_ENTRY_KIND_UNSPECIFIED,
+		resp.GetActivity().GetEntries()[0].GetKind(),
 	)
 	require.Empty(t, resp.GetActivity().GetEntries()[0].GetFailureReason())
 }

--- a/swapwallet/monitor.go
+++ b/swapwallet/monitor.go
@@ -189,36 +189,18 @@ func (r *Runtime) fanOutSwapUpdate(
 		walletrpc.EntryKind_ENTRY_KIND_UNSPECIFIED,
 	)
 
-	// Wallet-local deadline overlays never apply to swap-backed rows: the
-	// swap FSM owns their terminal state. Keep the branch for future
-	// non-swap monitor sources that may still use runtime overlays.
+	// All SubscribeSwaps rows are swap-backed, including the first lazy
+	// summaries whose direction still normalizes to UNSPECIFIED. The swap
+	// FSM owns their terminal state, so wallet-local overlays are never
+	// applied here.
 	sourceStatus := entry.GetStatus()
-	if sourceStatus == walletrpc.EntryStatus_ENTRY_STATUS_PENDING &&
-		!isSwapKind(entry.GetKind()) {
-
-		if ov, ok := r.overlayFor(entry.GetId()); ok {
-			entry.Status = ov.status
-			if ov.failureReason != "" {
-				entry.FailureReason = ov.failureReason
-			}
-		}
-	}
 
 	// Keep the pending tracker in sync. Pending swap rows are explicitly
 	// cleared so stale wallet overlays cannot outlive the swap FSM source
 	// of truth.
 	switch sourceStatus {
 	case walletrpc.EntryStatus_ENTRY_STATUS_PENDING:
-		if isSwapKind(entry.GetKind()) {
-			r.clearPending(entry.GetId())
-		} else {
-			r.trackPending(
-				entry.GetId(), entry.GetKind(),
-				unixToTime(
-					entry.GetCreatedAtUnix(),
-				),
-			)
-		}
+		r.clearPending(entry.GetId())
 
 	case walletrpc.EntryStatus_ENTRY_STATUS_COMPLETE,
 		walletrpc.EntryStatus_ENTRY_STATUS_FAILED:

--- a/swapwallet/monitor.go
+++ b/swapwallet/monitor.go
@@ -163,11 +163,10 @@ func (r *Runtime) runOneSubscription(includeExisting bool) error {
 	return err
 }
 
-// fanOutSwapUpdate translates one SubscribeSwapsResponse into a
-// WalletEntry, projects the canonical id, applies the deadline overlay,
-// updates the pending tracker, and emits to subscribers. Returns an error
-// only when rootCtx has been canceled; transient errors do not stop the
-// loop.
+// fanOutSwapUpdate translates one SubscribeSwapsResponse into a WalletEntry,
+// projects the canonical id, clears any stale wallet timeout overlay for
+// swap-backed rows, and emits to subscribers. Returns an error only when
+// rootCtx has been canceled; transient errors do not stop the loop.
 func (r *Runtime) fanOutSwapUpdate(
 	resp *swapclientrpc.SubscribeSwapsResponse) error {
 
@@ -190,15 +189,13 @@ func (r *Runtime) fanOutSwapUpdate(
 		walletrpc.EntryKind_ENTRY_KIND_UNSPECIFIED,
 	)
 
-	// The deadline overlay only projects PENDING entries onto FAILED.
-	// A swap that has already entered a terminal state must take that
-	// terminal state at face value — projecting a stale FAILED overlay
-	// onto an actually-COMPLETE swap would diverge from history.List
-	// (which gates on PENDING here) and emit a misleading FAILED row to
-	// every SubscribeWallet subscriber. Mirror history.applyOverlays'
-	// guard so the source-of-truth status from the swap subsystem wins.
+	// Wallet-local deadline overlays never apply to swap-backed rows: the
+	// swap FSM owns their terminal state. Keep the branch for future
+	// non-swap monitor sources that may still use runtime overlays.
 	sourceStatus := entry.GetStatus()
-	if sourceStatus == walletrpc.EntryStatus_ENTRY_STATUS_PENDING {
+	if sourceStatus == walletrpc.EntryStatus_ENTRY_STATUS_PENDING &&
+		!isSwapKind(entry.GetKind()) {
+
 		if ov, ok := r.overlayFor(entry.GetId()); ok {
 			entry.Status = ov.status
 			if ov.failureReason != "" {
@@ -207,19 +204,21 @@ func (r *Runtime) fanOutSwapUpdate(
 		}
 	}
 
-	// Keep the pending tracker in sync. Branch on the SOURCE status,
-	// not the (possibly overlay-elevated) status: only the swap
-	// subsystem's own terminal-state transition releases the pending
-	// tracker so the synthetic timed-out overlay does not flap on the
-	// next update.
+	// Keep the pending tracker in sync. Pending swap rows are explicitly
+	// cleared so stale wallet overlays cannot outlive the swap FSM source
+	// of truth.
 	switch sourceStatus {
 	case walletrpc.EntryStatus_ENTRY_STATUS_PENDING:
-		r.trackPending(
-			entry.GetId(), entry.GetKind(),
-			unixToTime(
-				entry.GetCreatedAtUnix(),
-			),
-		)
+		if isSwapKind(entry.GetKind()) {
+			r.clearPending(entry.GetId())
+		} else {
+			r.trackPending(
+				entry.GetId(), entry.GetKind(),
+				unixToTime(
+					entry.GetCreatedAtUnix(),
+				),
+			)
+		}
 
 	case walletrpc.EntryStatus_ENTRY_STATUS_COMPLETE,
 		walletrpc.EntryStatus_ENTRY_STATUS_FAILED:

--- a/swapwallet/monitor_test.go
+++ b/swapwallet/monitor_test.go
@@ -102,11 +102,10 @@ func TestMonitorLoopFansOutSwapUpdates(t *testing.T) {
 	)
 }
 
-// TestMonitorLoopTracksPendingByPaymentHash confirms a swap row fanned
-// out from the monitor reaches subscribers under its payment_hash id
-// (the wallet-layer canonical id) and is recorded in the pending
-// tracker so the deadline watcher can age it.
-func TestMonitorLoopTracksPendingByPaymentHash(t *testing.T) {
+// TestMonitorLoopLeavesSwapPendingToFSM confirms a swap row fanned out from
+// the monitor reaches subscribers under its payment_hash id, but is not aged by
+// the wallet-level deadline tracker.
+func TestMonitorLoopLeavesSwapPendingToFSM(t *testing.T) {
 	t.Parallel()
 
 	swap := newStreamingFakeSwap()
@@ -132,7 +131,9 @@ func TestMonitorLoopTracksPendingByPaymentHash(t *testing.T) {
 	r.pendingMu.Lock()
 	_, ok := r.pending["swap-hash"]
 	r.pendingMu.Unlock()
-	require.True(t, ok, "monitor must track pending swap rows")
+	require.False(
+		t, ok, "monitor must leave pending swap rows to the swap FSM",
+	)
 }
 
 // TestMonitorLoopClearsPendingOnTerminal confirms a terminal swap event
@@ -357,12 +358,9 @@ func TestMonitorLoopTerminalStatusBeatsStaleOverlay(t *testing.T) {
 	)
 }
 
-// TestMonitorLoopOverlayDoesNotFlapOnPendingUpdate asserts the M-2 fix:
-// once a wallet-layer FAILED overlay is set, a subsequent PENDING
-// monitor update neither clears the overlay nor causes oscillation in
-// the subscriber stream. The synthetic FAILED projection stays sticky
-// until the underlying swap actually terminates.
-func TestMonitorLoopOverlayDoesNotFlapOnPendingUpdate(t *testing.T) {
+// TestMonitorLoopPendingSwapBeatsStaleOverlay asserts that a PENDING source
+// update from the swap subsystem clears any stale wallet-level timeout overlay.
+func TestMonitorLoopPendingSwapBeatsStaleOverlay(t *testing.T) {
 	t.Parallel()
 
 	swap := newStreamingFakeSwap()
@@ -393,17 +391,16 @@ func TestMonitorLoopOverlayDoesNotFlapOnPendingUpdate(t *testing.T) {
 
 	got := drainOne(t, sub)
 	require.Equal(
-		t, walletrpc.EntryStatus_ENTRY_STATUS_FAILED, got.GetStatus(),
-		"synthetic overlay must remain visible while the swap is "+
-			"still pending so the wallet surface is not flapping",
+		t, walletrpc.EntryStatus_ENTRY_STATUS_PENDING, got.GetStatus(),
+		"swap source status must beat a stale wallet timeout overlay",
 	)
-	require.Equal(t, "timed_out", got.GetFailureReason())
+	require.Empty(t, got.GetFailureReason())
 
 	r.pendingMu.Lock()
 	_, overlayKept := r.overlay["hash-stuck"]
 	r.pendingMu.Unlock()
-	require.True(
-		t, overlayKept, "a PENDING monitor update must NOT clear "+
-			"an existing wallet-layer overlay",
+	require.False(
+		t, overlayKept, "a PENDING swap update must clear the "+
+			"stale wallet-layer overlay",
 	)
 }

--- a/swapwallet/monitor_test.go
+++ b/swapwallet/monitor_test.go
@@ -104,7 +104,7 @@ func TestMonitorLoopFansOutSwapUpdates(t *testing.T) {
 
 // TestMonitorLoopLeavesSwapPendingToFSM confirms a swap row fanned out from
 // the monitor reaches subscribers under its payment_hash id, but is not aged by
-// the wallet-level deadline tracker.
+// the wallet-level deadline tracker even before its direction is populated.
 func TestMonitorLoopLeavesSwapPendingToFSM(t *testing.T) {
 	t.Parallel()
 
@@ -118,7 +118,6 @@ func TestMonitorLoopLeavesSwapPendingToFSM(t *testing.T) {
 
 	swap.updates <- &swapclientrpc.SwapSummary{
 		PaymentHash: "swap-hash",
-		Direction:   swapclientrpc.SwapDirection_SWAP_DIRECTION_PAY,
 		Pending:     true,
 	}
 	entry := drainOne(t, sub)
@@ -126,6 +125,9 @@ func TestMonitorLoopLeavesSwapPendingToFSM(t *testing.T) {
 		t, "swap-hash", entry.GetId(),
 		"swap row id must surface as payment_hash without further "+
 			"projection",
+	)
+	require.Equal(
+		t, walletrpc.EntryKind_ENTRY_KIND_UNSPECIFIED, entry.GetKind(),
 	)
 
 	r.pendingMu.Lock()
@@ -359,7 +361,8 @@ func TestMonitorLoopTerminalStatusBeatsStaleOverlay(t *testing.T) {
 }
 
 // TestMonitorLoopPendingSwapBeatsStaleOverlay asserts that a PENDING source
-// update from the swap subsystem clears any stale wallet-level timeout overlay.
+// update from the swap subsystem clears any stale wallet-level timeout overlay,
+// even before the swap direction is populated.
 func TestMonitorLoopPendingSwapBeatsStaleOverlay(t *testing.T) {
 	t.Parallel()
 
@@ -385,7 +388,6 @@ func TestMonitorLoopPendingSwapBeatsStaleOverlay(t *testing.T) {
 	// The swap subsystem still reports the swap as in-flight.
 	swap.updates <- &swapclientrpc.SwapSummary{
 		PaymentHash: "hash-stuck",
-		Direction:   swapclientrpc.SwapDirection_SWAP_DIRECTION_PAY,
 		Pending:     true,
 	}
 
@@ -395,6 +397,9 @@ func TestMonitorLoopPendingSwapBeatsStaleOverlay(t *testing.T) {
 		"swap source status must beat a stale wallet timeout overlay",
 	)
 	require.Empty(t, got.GetFailureReason())
+	require.Equal(
+		t, walletrpc.EntryKind_ENTRY_KIND_UNSPECIFIED, got.GetKind(),
+	)
 
 	r.pendingMu.Lock()
 	_, overlayKept := r.overlay["hash-stuck"]

--- a/swapwallet/recv.go
+++ b/swapwallet/recv.go
@@ -13,16 +13,14 @@ import (
 // receiver drives wallet-layer Recv flows. It is a thin composition over
 // the existing swap subserver's StartReceive RPC; the swap subsystem owns
 // the invoice signing (with a daemon-managed payment-scoped auth key via
-// PR #337), persistence, and lifecycle. swapwallet only normalizes the
-// response into a flat WalletEntry and tracks the pending row for the
-// wallet-level deadline watcher.
+// PR #337), persistence, lifecycle, and receive expiry. swapwallet only
+// normalizes the response into a flat WalletEntry.
 type receiver struct {
 	deps    *Deps
 	runtime *Runtime
 }
 
-// newReceiver constructs a receiver bound to the runtime that will track
-// the resulting pending entry.
+// newReceiver constructs a receiver bound to the shared wallet runtime.
 func newReceiver(deps *Deps, runtime *Runtime) *receiver {
 	return &receiver{deps: deps, runtime: runtime}
 }
@@ -69,15 +67,6 @@ func (r *receiver) Recv(ctx context.Context, req *walletrpc.RecvRequest) (
 		startResp.GetSwap(), req.GetMemo(), startResp.GetPaymentHash(),
 		walletrpc.EntryKind_ENTRY_KIND_RECV,
 	)
-
-	if entry.Status == walletrpc.EntryStatus_ENTRY_STATUS_PENDING {
-		r.runtime.trackPending(
-			entry.GetId(), entry.GetKind(),
-			unixToTime(
-				entry.GetCreatedAtUnix(),
-			),
-		)
-	}
 
 	return &walletrpc.RecvResponse{
 		Invoice: startResp.GetInvoice(),

--- a/swapwallet/register.go
+++ b/swapwallet/register.go
@@ -111,8 +111,8 @@ func Register(ctx context.Context, grpcServer *grpc.Server,
 			runtime.resumeAll(ctx)
 
 			// Start background goroutines after resume so
-			// subscribers and the deadline watcher observe a
-			// runtime that owns the pending rows it just resumed.
+			// subscribers observe a runtime that owns any
+			// wallet-local pending rows it just restored.
 			runtime.start()
 		})
 

--- a/swapwallet/router.go
+++ b/swapwallet/router.go
@@ -24,8 +24,7 @@ type router struct {
 	runtime *Runtime
 }
 
-// newRouter constructs a router bound to the runtime that will track the
-// resulting pending entries for the deadline watcher.
+// newRouter constructs a router bound to the shared wallet runtime.
 func newRouter(deps *Deps, runtime *Runtime) *router {
 	return &router{deps: deps, runtime: runtime}
 }
@@ -81,15 +80,6 @@ func (r *router) sendInvoice(ctx context.Context, invoice string,
 		startResp.GetSwap(), req.GetNote(), invoice,
 		walletrpc.EntryKind_ENTRY_KIND_SEND,
 	)
-
-	if entry.Status == walletrpc.EntryStatus_ENTRY_STATUS_PENDING {
-		r.runtime.trackPending(
-			entry.GetId(), entry.GetKind(),
-			unixToTime(
-				entry.GetCreatedAtUnix(),
-			),
-		)
-	}
 
 	// For invoice sends actual_amount_sat is the swap's negotiated
 	// principal: that's what is being paid to the BOLT-11 destination

--- a/swapwallet/runtime.go
+++ b/swapwallet/runtime.go
@@ -143,14 +143,11 @@ func (r *Runtime) resumeAll(ctx context.Context) {
 	r.deps.SwapBackend.ResumePending(ctx)
 }
 
-// trackPending records a new or refreshed pending entry so the deadline
-// watcher can age it. The deadline base is the time the RUNTIME first
-// observes the entry, NOT the row's original createdAt: a swap backfill
-// at daemon startup carries the original swap submit time (possibly
-// hours old), and basing the deadline on that would flip every backfilled
-// pending row to FAILED(timed_out) within the first deadline tick. The
-// deadline is a wallet-process responsibility — it must not carry stale
-// clock state from a previous process.
+// trackPending records a new or refreshed wallet-local pending entry so the
+// deadline watcher can age it. The deadline base is the time the runtime first
+// observes the entry, NOT the row's original createdAt; otherwise restored
+// entries could be projected to FAILED(timed_out) within the first deadline
+// tick after restart.
 //
 // Subsequent trackPending calls for the same id are idempotent: the
 // existing first-observed createdAt and deadline are preserved so
@@ -158,10 +155,7 @@ func (r *Runtime) resumeAll(ctx context.Context) {
 //
 // trackPending intentionally does NOT touch the overlay map: a synthetic
 // FAILED overlay set by the deadline watcher must remain visible to
-// subscribers until the underlying swap subsystem actually transitions
-// to a terminal state. clearPending is the only writer that retires the
-// overlay; this keeps a still-pending source row from oscillating the
-// wallet surface between FAILED and PENDING on every monitor push.
+// subscribers until the underlying wallet-local operation is cleared.
 func (r *Runtime) trackPending(id string, kind walletrpc.EntryKind,
 	createdAt time.Time) {
 
@@ -213,11 +207,9 @@ func (r *Runtime) overlayFor(id string) (overlayStatus, bool) {
 	return ov, ok
 }
 
-// deadlineWatcher scans pending entries on a coarse tick and elevates any
-// entry past its wallet-level deadline to FAILED in the overlay map. The
-// watcher does not mutate the underlying swap or leave state — that remains
-// the source of truth for protocol-level progress. The wallet user simply
-// sees the entry as timed out.
+// deadlineWatcher scans pending wallet-local entries on a coarse tick and
+// elevates any entry past its wallet-level deadline to FAILED in the overlay
+// map. Swap rows use the swap FSM's own terminal state instead.
 func (r *Runtime) deadlineWatcher() {
 	defer r.wg.Done()
 
@@ -239,10 +231,7 @@ func (r *Runtime) deadlineWatcher() {
 // can drive it with a fixed clock.
 //
 // Newly elevated entries are also emitted to SubscribeWallet subscribers so
-// long-lived UI consumers see the FAILED transition in real time. The
-// hung swap is — by hypothesis — never going to drive a fresh monitor
-// push, so without this fan-out the wallet surface would stay PENDING in
-// the subscription stream until next List materializes the overlay.
+// long-lived UI consumers see the FAILED transition in real time.
 func (r *Runtime) applyDeadlines(now time.Time) {
 	timedOut := r.markTimedOut(now)
 	for _, entry := range timedOut {
@@ -250,18 +239,22 @@ func (r *Runtime) applyDeadlines(now time.Time) {
 	}
 }
 
-// markTimedOut writes the FAILED overlay for every pending row whose
-// deadline has passed and returns synthesized WalletEntry rows for each
-// newly elevated entry. The slice is built under pendingMu so the
-// caller can fan it out to subscribers without holding the lock (emit
-// takes subsMu, and the runtime maintains the invariant that no two
-// runtime mutexes are held simultaneously).
+// markTimedOut writes the FAILED overlay for every wallet-local pending row
+// whose deadline has passed and returns synthesized WalletEntry rows for each
+// newly elevated entry. Swap rows are dropped from tracking so they cannot
+// diverge from the swap FSM.
 func (r *Runtime) markTimedOut(now time.Time) []*walletrpc.WalletEntry {
 	r.pendingMu.Lock()
 	defer r.pendingMu.Unlock()
 
 	var notify []*walletrpc.WalletEntry
 	for id, entry := range r.pending {
+		if isSwapKind(entry.kind) {
+			delete(r.pending, id)
+			delete(r.overlay, id)
+
+			continue
+		}
 		if _, alreadyTimedOut := r.overlay[id]; alreadyTimedOut {
 			continue
 		}
@@ -285,6 +278,14 @@ func (r *Runtime) markTimedOut(now time.Time) []*walletrpc.WalletEntry {
 	}
 
 	return notify
+}
+
+// isSwapKind reports wallet rows whose lifecycle is backed by the swap FSM.
+// Those rows must not receive synthetic wallet timeout overlays because the
+// swap store owns their terminal state.
+func isSwapKind(kind walletrpc.EntryKind) bool {
+	return kind == walletrpc.EntryKind_ENTRY_KIND_SEND ||
+		kind == walletrpc.EntryKind_ENTRY_KIND_RECV
 }
 
 // subscribe registers a channel to receive normalized WalletEntry updates

--- a/swapwallet/runtime.go
+++ b/swapwallet/runtime.go
@@ -280,9 +280,10 @@ func (r *Runtime) markTimedOut(now time.Time) []*walletrpc.WalletEntry {
 	return notify
 }
 
-// isSwapKind reports wallet rows whose lifecycle is backed by the swap FSM.
-// Those rows must not receive synthetic wallet timeout overlays because the
-// swap store owns their terminal state.
+// isSwapKind reports pinned SEND/RECV rows whose lifecycle is backed by the
+// swap FSM. SubscribeSwaps monitor updates are even stricter: every row from
+// that stream is treated as swap-backed even when its direction is still
+// UNSPECIFIED.
 func isSwapKind(kind walletrpc.EntryKind) bool {
 	return kind == walletrpc.EntryKind_ENTRY_KIND_SEND ||
 		kind == walletrpc.EntryKind_ENTRY_KIND_RECV

--- a/swapwallet/runtime_test.go
+++ b/swapwallet/runtime_test.go
@@ -30,8 +30,10 @@ func TestDeadlineWatcherFlagsStuckEntries(t *testing.T) {
 	freshID := "fresh"
 	staleID := "stale"
 
-	r.trackPending(freshID, walletrpc.EntryKind_ENTRY_KIND_SEND, time.Now())
-	r.trackPending(staleID, walletrpc.EntryKind_ENTRY_KIND_RECV, time.Now())
+	r.trackPending(freshID, walletrpc.EntryKind_ENTRY_KIND_EXIT, time.Now())
+	r.trackPending(
+		staleID, walletrpc.EntryKind_ENTRY_KIND_DEPOSIT, time.Now(),
+	)
 
 	// Tick the watcher past the deadline window. Both entries were
 	// first-observed essentially "now", so a tick at now+2*deadline is
@@ -55,7 +57,7 @@ func TestDeadlineWatcherFlagsStuckEntries(t *testing.T) {
 	r2 := newRuntime(t.Context(), deps)
 	defer r2.stop()
 	r2.trackPending(
-		freshID, walletrpc.EntryKind_ENTRY_KIND_SEND, time.Now(),
+		freshID, walletrpc.EntryKind_ENTRY_KIND_EXIT, time.Now(),
 	)
 	r2.applyDeadlines(time.Now())
 	_, freshTimedOut := r2.overlayFor(freshID)
@@ -63,6 +65,31 @@ func TestDeadlineWatcherFlagsStuckEntries(t *testing.T) {
 		t, freshTimedOut,
 		"entry inside its deadline must not be flagged as timed out",
 	)
+}
+
+// TestDeadlineWatcherIgnoresSwapRows asserts SEND/RECV rows are left to the
+// swap FSM instead of receiving a wallet-level timeout overlay.
+func TestDeadlineWatcherIgnoresSwapRows(t *testing.T) {
+	t.Parallel()
+
+	deadline := 50 * time.Millisecond
+	r := newRuntime(t.Context(), &Deps{WalletDeadline: deadline})
+	defer r.stop()
+
+	r.trackPending("send", walletrpc.EntryKind_ENTRY_KIND_SEND, time.Now())
+	r.trackPending("recv", walletrpc.EntryKind_ENTRY_KIND_RECV, time.Now())
+
+	r.applyDeadlines(time.Now().Add(2 * deadline))
+
+	_, sendTimedOut := r.overlayFor("send")
+	_, recvTimedOut := r.overlayFor("recv")
+	require.False(t, sendTimedOut)
+	require.False(t, recvTimedOut)
+
+	r.pendingMu.Lock()
+	defer r.pendingMu.Unlock()
+	require.NotContains(t, r.pending, "send")
+	require.NotContains(t, r.pending, "recv")
 }
 
 // TestDeadlineWatcherIdempotent asserts that running applyDeadlines twice
@@ -78,7 +105,7 @@ func TestDeadlineWatcherIdempotent(t *testing.T) {
 	defer r.stop()
 
 	id := "long-stuck"
-	r.trackPending(id, walletrpc.EntryKind_ENTRY_KIND_SEND, time.Now())
+	r.trackPending(id, walletrpc.EntryKind_ENTRY_KIND_EXIT, time.Now())
 
 	future := time.Now().Add(2 * deadline)
 	r.applyDeadlines(future)
@@ -108,7 +135,7 @@ func TestClearPendingDropsOverlay(t *testing.T) {
 	defer r.stop()
 
 	id := "transient"
-	r.trackPending(id, walletrpc.EntryKind_ENTRY_KIND_SEND, time.Now())
+	r.trackPending(id, walletrpc.EntryKind_ENTRY_KIND_EXIT, time.Now())
 	r.applyDeadlines(time.Now().Add(2 * deadline))
 	_, ok := r.overlayFor(id)
 	require.True(t, ok)
@@ -119,10 +146,10 @@ func TestClearPendingDropsOverlay(t *testing.T) {
 }
 
 // TestTrackPendingBasesDeadlineOnFirstObservation asserts that an entry
-// trackPending'd with a stale createdAt (e.g. a backfilled monitor push
-// at daemon startup for a swap submitted hours ago) gets a FRESH
+// trackPending'd with a stale createdAt (e.g. a restored wallet-local
+// operation submitted hours ago) gets a FRESH
 // deadline based on time.Now(), not on the source row's submit time.
-// Without this guard a restart would flip every long-pending swap to
+// Without this guard a restart would flip every long-pending wallet row to
 // FAILED(timed_out) within the first deadline tick.
 func TestTrackPendingBasesDeadlineOnFirstObservation(t *testing.T) {
 	t.Parallel()
@@ -132,9 +159,9 @@ func TestTrackPendingBasesDeadlineOnFirstObservation(t *testing.T) {
 	r := newRuntime(t.Context(), deps)
 	defer r.stop()
 
-	// Simulate a backfilled monitor push for a swap submitted 24h ago.
+	// Simulate a restored wallet-local row submitted 24h ago.
 	stale := time.Now().Add(-24 * time.Hour)
-	r.trackPending("backfilled", walletrpc.EntryKind_ENTRY_KIND_SEND, stale)
+	r.trackPending("backfilled", walletrpc.EntryKind_ENTRY_KIND_EXIT, stale)
 
 	r.pendingMu.Lock()
 	entry, ok := r.pending["backfilled"]
@@ -170,7 +197,7 @@ func TestTrackPendingIdempotentPreservesOriginalDeadline(t *testing.T) {
 	defer r.stop()
 
 	r.trackPending(
-		"id", walletrpc.EntryKind_ENTRY_KIND_SEND, time.Now(),
+		"id", walletrpc.EntryKind_ENTRY_KIND_EXIT, time.Now(),
 	)
 	r.pendingMu.Lock()
 	first := r.pending["id"].deadline
@@ -179,7 +206,7 @@ func TestTrackPendingIdempotentPreservesOriginalDeadline(t *testing.T) {
 	// Sleep a small amount and re-track; the deadline must NOT advance.
 	time.Sleep(10 * time.Millisecond)
 	r.trackPending(
-		"id", walletrpc.EntryKind_ENTRY_KIND_SEND, time.Now(),
+		"id", walletrpc.EntryKind_ENTRY_KIND_EXIT, time.Now(),
 	)
 	r.pendingMu.Lock()
 	second := r.pending["id"].deadline
@@ -209,7 +236,7 @@ func TestDeadlineWatcherEmitsTimeoutToSubscribers(t *testing.T) {
 	sub := r.subscribe()
 
 	r.trackPending(
-		"stuck", walletrpc.EntryKind_ENTRY_KIND_SEND, time.Now(),
+		"stuck", walletrpc.EntryKind_ENTRY_KIND_EXIT, time.Now(),
 	)
 	tick := time.Now().Add(2 * deadline)
 	r.applyDeadlines(tick)
@@ -218,7 +245,7 @@ func TestDeadlineWatcherEmitsTimeoutToSubscribers(t *testing.T) {
 	case got := <-sub:
 		require.Equal(t, "stuck", got.GetId())
 		require.Equal(
-			t, walletrpc.EntryKind_ENTRY_KIND_SEND, got.GetKind(),
+			t, walletrpc.EntryKind_ENTRY_KIND_EXIT, got.GetKind(),
 		)
 		require.Equal(
 			t, walletrpc.EntryStatus_ENTRY_STATUS_FAILED,
@@ -254,7 +281,7 @@ func TestDeadlineWatcherDoesNotReEmitAlreadyTimedOut(t *testing.T) {
 	sub := r.subscribe()
 
 	r.trackPending(
-		"stuck", walletrpc.EntryKind_ENTRY_KIND_SEND, time.Now(),
+		"stuck", walletrpc.EntryKind_ENTRY_KIND_EXIT, time.Now(),
 	)
 	tick := time.Now().Add(2 * deadline)
 	r.applyDeadlines(tick)
@@ -287,7 +314,7 @@ func TestSubscribeFanOutAndDropOnSlowConsumer(t *testing.T) {
 
 	entry := &walletrpc.WalletEntry{
 		Id:   "abc",
-		Kind: walletrpc.EntryKind_ENTRY_KIND_SEND,
+		Kind: walletrpc.EntryKind_ENTRY_KIND_EXIT,
 	}
 	r.emit(entry)
 


### PR DESCRIPTION
## Summary
- expire receive swaps that remain in invoice-created past the persisted invoice deadline
- add a 10s overdue-resume mailbox grace window so already-delivered funding messages can win over expiry
- keep wallet list/subscription status for SEND and RECV rows sourced from the swap FSM instead of wallet timeout overlays

Fixes #491

## Tests
- make unit pkg=sdk/swaps timeout=5m
- make unit pkg=swapwallet tags="swapruntime walletrpc" timeout=5m
- make unit pkg=swapclientserver tags="swapruntime" timeout=5m
- make fmt-changed-check base=origin/main
- make commitmsg-lint range=origin/main..HEAD
- git diff --check origin/main..HEAD

Note: make lint-local is currently blocked by unrelated line-length findings in cmd/darepocli/internal/gen-devrpc/main.go.