### PR TITLE
gateway: Allow wildcard CORS origins

### DIFF
--- a/darepod/config.go
+++ b/darepod/config.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/btcsuite/btcd/chaincfg"
@@ -522,6 +523,7 @@ type GatewayConfig struct {
 	// AllowedOrigins lists browser origins that may call the gateway.
 	// Empty means no cross-origin browser access; requests without an
 	// Origin header, such as CLI or local service calls, are still served.
+	// Use "*" to allow browser requests from any origin.
 	AllowedOrigins []string `mapstructure:"allowedorigins"`
 
 	// Listener is an optional pre-created listener. When non-nil,
@@ -747,14 +749,15 @@ func (c *Config) Validate() error {
 	return nil
 }
 
-// validateGatewayAllowedOrigins rejects wildcard CORS grants on wallet-control
-// APIs.
+// validateGatewayAllowedOrigins rejects empty CORS origins. The wildcard
+// origin "*" is allowed for public browser gateways whose RPCs authenticate
+// explicitly per request rather than through ambient browser credentials.
 func validateGatewayAllowedOrigins(origins []string) error {
 	for _, origin := range origins {
-		switch origin {
-		case "", "*":
+		if strings.TrimSpace(origin) == "" {
 			return fmt.Errorf("rpc.gateway.allowedorigins must "+
-				"contain explicit origins, got %q", origin)
+				"contain explicit origins or '*', got %q",
+				origin)
 		}
 	}
 

--- a/darepod/server_rpc_listener_test.go
+++ b/darepod/server_rpc_listener_test.go
@@ -71,6 +71,40 @@ func TestConfigValidateAllowsDisabledGateway(t *testing.T) {
 	require.NoError(t, cfg.Validate())
 }
 
+// TestConfigValidateAllowsWildcardGatewayOrigin verifies public browser
+// gateway deployments can opt into wildcard CORS.
+func TestConfigValidateAllowsWildcardGatewayOrigin(t *testing.T) {
+	t.Parallel()
+
+	cfg := DefaultConfig()
+	cfg.Network = "regtest"
+	cfg.Wallet.EsploraURL = "http://127.0.0.1:3000"
+	cfg.RPC.Gateway.AllowedOrigins = []string{
+		"*",
+	}
+
+	require.NoError(t, cfg.Validate())
+}
+
+// TestConfigValidateRejectsEmptyGatewayOrigin keeps blank origin entries from
+// silently weakening browser-gateway configuration.
+func TestConfigValidateRejectsEmptyGatewayOrigin(t *testing.T) {
+	t.Parallel()
+
+	cfg := DefaultConfig()
+	cfg.Network = "regtest"
+	cfg.Wallet.EsploraURL = "http://127.0.0.1:3000"
+	cfg.RPC.Gateway.AllowedOrigins = []string{
+		" ",
+	}
+
+	err := cfg.Validate()
+	require.ErrorContains(
+		t, err, "rpc.gateway.allowedorigins must contain explicit "+
+			"origins or '*'",
+	)
+}
+
 // TestOpenRPCListenerUsesInjectedListener verifies the daemon reuses an
 // injected listener verbatim so embedded runtimes can own the transport.
 func TestOpenRPCListenerUsesInjectedListener(t *testing.T) {

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -43,7 +43,9 @@ func ServeMuxOptions(
 
 // BrowserHeaders wraps an HTTP handler with browser CORS handling. Empty
 // allowed origins fail closed for browser callers while still serving requests
-// without an Origin header.
+// without an Origin header. The wildcard origin "*" allows browser callers
+// from any origin and is only suitable for APIs with explicit per-request
+// authentication.
 func BrowserHeaders(next http.Handler, allowedOrigins []string,
 	metadataHeaders ...string) http.Handler {
 
@@ -53,8 +55,16 @@ func BrowserHeaders(next http.Handler, allowedOrigins []string,
 	}
 	allowedHeaders = append(allowedHeaders, metadataHeaders...)
 	origins := make(map[string]struct{}, len(allowedOrigins))
+	allowAllOrigins := false
 	for _, origin := range allowedOrigins {
-		origins[strings.TrimSpace(origin)] = struct{}{}
+		origin = strings.TrimSpace(origin)
+		if origin == "*" {
+			allowAllOrigins = true
+
+			continue
+		}
+
+		origins[origin] = struct{}{}
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -65,7 +75,7 @@ func BrowserHeaders(next http.Handler, allowedOrigins []string,
 			return
 		}
 
-		if _, ok := origins[origin]; !ok {
+		if _, ok := origins[origin]; !ok && !allowAllOrigins {
 			http.Error(
 				w, "origin not allowed", http.StatusForbidden,
 			)
@@ -73,8 +83,12 @@ func BrowserHeaders(next http.Handler, allowedOrigins []string,
 			return
 		}
 
-		w.Header().Add("Vary", "Origin")
-		w.Header().Set("Access-Control-Allow-Origin", origin)
+		if allowAllOrigins {
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+		} else {
+			w.Header().Add("Vary", "Origin")
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+		}
 		w.Header().Set("Access-Control-Allow-Headers",
 			strings.Join(allowedHeaders, ", "))
 		w.Header().Set("Access-Control-Allow-Methods",

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -56,6 +56,33 @@ func TestBrowserHeadersAllowsTrustedOrigin(t *testing.T) {
 	)
 }
 
+func TestBrowserHeadersAllowsWildcardOrigin(t *testing.T) {
+	t.Parallel()
+
+	handler := BrowserHeaders(
+		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+			t.Fatalf("preflight must not reach wrapped handler")
+		}),
+		[]string{
+			"*",
+		}, "x-darepod-auth",
+	)
+
+	req := httptest.NewRequest(http.MethodOptions, "/", nil)
+	req.Header.Set("Origin", "https://any-wallet.example")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	require.Equal(
+		t, "*", rec.Header().Get("Access-Control-Allow-Origin"),
+	)
+	require.Contains(
+		t, rec.Header().Get("Access-Control-Allow-Headers"),
+		"x-darepod-auth",
+	)
+}
+
 func TestBrowserHeadersPassesNonBrowserRequests(t *testing.T) {
 	t.Parallel()
 

--- a/sample-darepod.conf
+++ b/sample-darepod.conf
@@ -81,7 +81,8 @@
 # rpc.gateway.listenaddr=localhost:10031
 
 # Browser origins allowed to call the daemon HTTP/JSON gateway. Empty means
-# browser requests fail closed while non-browser requests still work.
+# browser requests fail closed while non-browser requests still work. Use "*"
+# to allow browser requests from any origin.
 # rpc.gateway.allowedorigins=
 
 # Path to the daemon TLS certificate. Empty auto-generates one in the data dir.


### PR DESCRIPTION
## Summary

- allow `rpc.gateway.allowedorigins=*` to return wildcard CORS headers
- keep blank origin entries invalid
- document wildcard behavior in the daemon sample config

## Test Plan

- `go test ./gateway ./darepod -run 'TestBrowserHeaders|TestConfigValidateAllowsWildcardGatewayOrigin|TestConfigValidateRejectsEmptyGatewayOrigin'`
- `make sample-conf-check`
- `GOPATH=$(go env GOPATH) make fmt-changed-check`
- `make commitmsg-lint range=origin/main..HEAD`