### PR TITLE
swapclient: fetch live operator key for vHTLCs

### DIFF
--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -145,6 +145,21 @@ func (r *RPCServer) SignMailboxAuth(ctx context.Context,
 	return hex.EncodeToString(sig.Serialize()), nil
 }
 
+// OperatorPubKey fetches the current Ark operator pubkey directly from the
+// server and refreshes the daemon's cached operator terms snapshot. Optional
+// subservers that build new policy scripts should use this rather than
+// DaemonService.GetInfo so operator-key rotations are observed before the
+// policy is handed to the wallet or OOR layer.
+func (r *RPCServer) OperatorPubKey(ctx context.Context) (*btcec.PublicKey,
+	error) {
+
+	if r == nil || r.server == nil {
+		return nil, fmt.Errorf("daemon server unavailable")
+	}
+
+	return r.server.fetchCurrentOperatorPubKey(ctx)
+}
+
 // vtxoAdmissionCode maps typed VTXO admission failures to caller-actionable
 // gRPC codes while preserving Internal for unexpected selection failures.
 func vtxoAdmissionCode(err error) codes.Code {

--- a/darepod/rpc_server_test.go
+++ b/darepod/rpc_server_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btclog/v2"
 	"github.com/google/uuid"
+	"github.com/lightninglabs/darepo-client/arkrpc"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
 	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/lightninglabs/darepo-client/lib/actormsg"
@@ -976,6 +977,65 @@ func TestGetInfoIncludesServerInfo(t *testing.T) {
 	require.Equal(t, uint64(12), resp.ServerInfo.FeeRate)
 	require.Equal(t, uint64(34), resp.ServerInfo.MinOperatorFee)
 	require.Equal(t, uint32(2), resp.ServerInfo.MinConfirmations)
+}
+
+// TestOperatorPubKeyFetchesFreshTerms verifies callers that construct new
+// policy scripts can bypass GetInfo's cached server-info snapshot and refresh
+// it after a successful direct operator fetch.
+func TestOperatorPubKeyFetchesFreshTerms(t *testing.T) {
+	t.Parallel()
+
+	stalePriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	freshPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	server := &Server{
+		cfg: &Config{
+			Network: "regtest",
+			Wallet: &WalletConfig{
+				Type: WalletTypeBtcwallet,
+			},
+		},
+		log: btclog.Disabled,
+		serverConn: newBufconnClient(t, &fakeArkService{
+			getInfoResponse: &arkrpc.GetInfoResponse{
+				Pubkey: freshPriv.
+					PubKey().
+					SerializeCompressed(),
+				BoardingExitDelay:   144,
+				VtxoExitDelay:       288,
+				DustLimit:           546,
+				MinBoardingAmount:   10_000,
+				MaxBoardingAmount:   500_000,
+				FeeRate:             12,
+				MinOperatorFee:      34,
+				MinConfirmations:    2,
+				MaxOorLineageVbytes: 99,
+			},
+		}),
+	}
+	server.storeOperatorTerms(&types.OperatorTerms{
+		PubKey: stalePriv.PubKey(),
+	})
+	r := &RPCServer{server: server}
+
+	key, err := r.OperatorPubKey(context.Background())
+	require.NoError(t, err)
+	require.True(t, key.IsEqual(freshPriv.PubKey()))
+
+	info, err := r.GetInfo(
+		context.Background(), &daemonrpc.GetInfoRequest{},
+	)
+	require.NoError(t, err)
+	require.Equal(
+		t, freshPriv.PubKey().SerializeCompressed(),
+		info.GetServerInfo().GetOperatorPubkey(),
+	)
+	require.Equal(
+		t, uint32(99), server.loadOperatorTerms().MaxOORLineageVBytes,
+	)
 }
 
 // TestGetInfoConcurrentOperatorTermsAccess verifies that GetInfo can read the

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -607,9 +607,9 @@ func (s *Server) loadOperatorTerms() *types.OperatorTerms {
 	return s.operatorTerms.Load()
 }
 
-// storeOperatorTerms replaces the cached operator terms snapshot. The terms
-// are only refreshed during bootstrap today; future reconnect handling should
-// update this when server policy changes are observed.
+// storeOperatorTerms replaces the cached operator terms snapshot. Bootstrap
+// and live operator-key lookups both use this cache so ordinary status readers
+// observe the same operator policy used by policy-building paths.
 func (s *Server) storeOperatorTerms(terms *types.OperatorTerms) {
 	s.operatorTerms.Store(terms)
 }

--- a/sdk/ark/client.go
+++ b/sdk/ark/client.go
@@ -112,8 +112,9 @@ type Info struct {
 
 	// ServerInfo contains cached operator terms when the daemon has
 	// already connected to the Ark server and fetched them. It remains
-	// nil until the daemon reaches the operator-bootstrap stage, and is
-	// currently refreshed only during bootstrap.
+	// nil until the daemon reaches the operator-bootstrap stage, and can
+	// be refreshed by daemon paths that fetch the live operator key before
+	// building new policy scripts.
 	ServerInfo *ServerInfo
 }
 

--- a/swapclientserver/service.go
+++ b/swapclientserver/service.go
@@ -116,6 +116,44 @@ type swapClientService struct {
 	chainParams *chaincfg.Params
 }
 
+// operatorPubKeyFetcher returns the current Ark operator pubkey. It exists so
+// daemon-hosted swap clients can bypass the cached GetInfo snapshot when they
+// construct fresh vHTLC policies.
+type operatorPubKeyFetcher func(context.Context) (*btcec.PublicKey, error)
+
+// liveOperatorDaemonConn delegates all daemon operations to the embedded
+// connection except OperatorPubKey, which is fetched live from the daemon's
+// direct Ark transport. This keeps ordinary status reads on the cached GetInfo
+// path while ensuring newly-created swap vHTLC policies see operator-key
+// rotations before OOR funding is submitted.
+type liveOperatorDaemonConn struct {
+	swaps.DaemonConn
+
+	operatorPubKey operatorPubKeyFetcher
+}
+
+// OperatorPubKey returns the latest operator key from the direct fetcher.
+func (d *liveOperatorDaemonConn) OperatorPubKey(ctx context.Context) (
+	*btcec.PublicKey, error) {
+
+	return d.operatorPubKey(ctx)
+}
+
+// daemonWithLiveOperatorKey wraps daemon so swap policy construction does not
+// consume a stale operator key from GetInfo's cached server-info snapshot.
+func daemonWithLiveOperatorKey(daemon swaps.DaemonConn,
+	fetch operatorPubKeyFetcher) swaps.DaemonConn {
+
+	if fetch == nil {
+		return daemon
+	}
+
+	return &liveOperatorDaemonConn{
+		DaemonConn:     daemon,
+		operatorPubKey: fetch,
+	}
+}
+
 // swapRuntimeClient is the narrow part of sdk/swaps that the daemon
 // subserver needs in order to expose a background-control RPC layer. Keeping
 // this seam local makes the subserver unit-testable without duplicating swap
@@ -385,8 +423,11 @@ func newSwapClientService(ctx context.Context, rpcServer *darepod.RPCServer,
 	}
 
 	rootCtx, cancel := context.WithCancel(ctx)
+	daemonConn := daemonWithLiveOperatorKey(
+		arkClient, rpcServer.OperatorPubKey,
+	)
 	swapClient := swaps.NewSwapClientWithStore(
-		swapClients.server, arkClient, log, invoiceGen, store,
+		swapClients.server, daemonConn, log, invoiceGen, store,
 	)
 	swapClient.SetChainParams(chainParams)
 	recoveryCfg := cfg.VHTLCRecovery

--- a/swapclientserver/service_test.go
+++ b/swapclientserver/service_test.go
@@ -639,6 +639,49 @@ func TestNewSwapClientServiceRequiresRecoveryPreimageRegistry(t *testing.T) {
 	require.Nil(t, cleanup)
 }
 
+// TestDaemonWithLiveOperatorKeyUsesLiveFetcher verifies the daemon-hosted swap
+// runtime bypasses the Ark SDK facade's cached operator key.
+func TestDaemonWithLiveOperatorKeyUsesLiveFetcher(t *testing.T) {
+	t.Parallel()
+
+	stalePriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	stale := &staleOperatorDaemonConn{
+		operatorKey: stalePriv.PubKey(),
+	}
+	daemon := daemonWithLiveOperatorKey(
+		stale,
+		func(context.Context) (*btcec.PublicKey, error) {
+			return operatorPriv.PubKey(), nil
+		},
+	)
+
+	key, err := daemon.OperatorPubKey(t.Context())
+	require.NoError(t, err)
+	require.True(t, key.IsEqual(operatorPriv.PubKey()))
+	require.False(t, stale.called)
+}
+
+type staleOperatorDaemonConn struct {
+	swaps.DaemonConn
+
+	operatorKey *btcec.PublicKey
+	called      bool
+}
+
+// OperatorPubKey returns the stale key that the live wrapper must bypass.
+func (s *staleOperatorDaemonConn) OperatorPubKey(context.Context) (
+	*btcec.PublicKey, error) {
+
+	s.called = true
+
+	return s.operatorKey, nil
+}
+
 func TestNewSwapServerClientsREST(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- fetch the current Ark operator key directly when daemon-hosted swap clients build vHTLC policies
- refresh the cached daemon operator terms after that live fetch succeeds
- keep ordinary GetInfo/status reads on the existing cached server-info path

Refs #514

## Tests
- make unit pkg=darepod timeout=5m
- make unit pkg=swapclientserver tags="swapruntime" timeout=5m
- make unit log="stdlog trace" pkg=darepod case=TestOperatorPubKeyFetchesFreshTerms timeout=30s
- make unit log="stdlog trace" pkg=swapclientserver tags="swapruntime" case=TestDaemonWithLiveOperatorKeyUsesLiveFetcher timeout=30s
- make fmt-changed-check
- make lint-changed-local
- make commitmsg-lint range="origin/main..HEAD"
- git diff --check origin/main