### PR TITLE
swapwallet: hide structured OOR internals

### DIFF
--- a/db/ledger_store_test.go
+++ b/db/ledger_store_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"database/sql"
+	"fmt"
 	"testing"
 	"time"
 
@@ -107,6 +108,71 @@ func insertTransactionHistorySweepRow(t *testing.T, db *BaseDB, txid []byte,
 		t.Context(), query, txid, []byte{0x01}, "bcrt1test", amount,
 		fee, int64(2), int64(120), wallet.BoardingSweepStatusPublished,
 		int32(700), createdAt,
+	)
+	require.NoError(t, err)
+}
+
+// insertTransactionHistoryOOROutput inserts the minimum package, VTXO, and
+// binding rows needed for the transaction-history query to resolve an OOR
+// created output.
+func insertTransactionHistoryOOROutput(t *testing.T, db *BaseDB, sessionID,
+	outpointHash []byte, outpointIndex int32, amount, createdAt int64,
+	seed byte) {
+
+	t.Helper()
+
+	ctx := t.Context()
+	roundID := fmt.Sprintf("019e4bc6-d95f-7caf-93c3-409e854bbb%02x", seed)
+
+	require.NoError(
+		t,
+		db.InsertRound(
+			ctx, sqlc.InsertRoundParams{
+				RoundID:        roundID,
+				Status:         "confirmed",
+				CreationTime:   createdAt,
+				LastUpdateTime: createdAt,
+			},
+		),
+	)
+	_, err := db.UpsertOORPackage(
+		ctx, sqlc.UpsertOORPackageParams{
+			SessionID: sessionID,
+			Direction: oorPackageDirectionOutgoingCode,
+			ArkPsbt:   testBytes(8, seed+1),
+			CreatedAt: createdAt,
+			UpdatedAt: createdAt,
+		},
+	)
+	require.NoError(t, err)
+	require.NoError(
+		t,
+		db.InsertVTXO(
+			ctx, sqlc.InsertVTXOParams{
+				OutpointHash:   outpointHash,
+				OutpointIndex:  outpointIndex,
+				RoundID:        roundID,
+				Amount:         amount,
+				PkScript:       testBytes(34, seed+2),
+				Expiry:         144,
+				ClientPubkey:   testBytes(33, seed+3),
+				OperatorPubkey: testBytes(33, seed+4),
+				CommitmentTxid: testBytes(32, seed+5),
+				CreationTime:   createdAt,
+				LastUpdateTime: createdAt,
+			},
+		),
+	)
+	_, err = db.UpsertOORVTXOBinding(
+		ctx, sqlc.UpsertOORVTXOBindingParams{
+			OutpointHash:  outpointHash,
+			OutpointIndex: outpointIndex,
+			SessionID:     sessionID,
+			OutputIndex:   outpointIndex,
+			LinkKind:      oorPackageLinkKindCreatedOutputCode,
+			CreatedAt:     createdAt,
+			UpdatedAt:     createdAt,
+		},
 	)
 	require.NoError(t, err)
 }
@@ -223,6 +289,129 @@ func TestLedgerStoreTransactionHistoryFiltersBeforePagination(t *testing.T) {
 	require.Equal(t, "boarding_sweep", sweepRows[0].Source)
 	require.Equal(t, int64(4_000), sweepRows[0].AmountSat)
 	require.Equal(t, int64(40), sweepRows[0].FeeSat)
+}
+
+// TestLedgerStoreTransactionHistoryClassifiesOORReceiveWithoutSessionID
+// verifies OOR receive rows are user-visible OOR history even though the
+// ledger cannot stamp session_id on them without colliding on multi-output
+// receives from the same session.
+func TestLedgerStoreTransactionHistoryClassifiesOORReceiveWithoutSessionID(
+	t *testing.T) {
+
+	t.Parallel()
+
+	ctx := t.Context()
+	store, db := newLedgerStoreAndDBForTest(t)
+	sessionID := testBytes(32, 0x43)
+	outpointHash := testBytes(32, 0x44)
+	outpointIndex := int32(2)
+	insertTransactionHistoryOOROutput(
+		t, db, sessionID, outpointHash, outpointIndex, 2_500, 99, 0x46,
+	)
+
+	require.NoError(
+		t,
+		store.InsertLedgerEntry(
+			ctx, ledger.LedgerEntry{
+				DebitAccount:   ledger.AccountVTXOBalance,
+				CreditAccount:  ledger.AccountTransfersIn,
+				AmountSat:      2_500,
+				EventType:      ledger.EventVTXOReceived,
+				Description:    "oor receive",
+				CreatedAt:      100,
+				IdempotencyKey: testBytes(36, 0x45),
+				ChainTxid:      outpointHash,
+				ChainVout:      &outpointIndex,
+			},
+		),
+	)
+
+	rows, err := store.ListTransactionHistory(ctx, "oor", 0, 0, 10, 0)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, "oor", rows[0].TransactionType)
+	require.Equal(t, ledger.EventVTXOReceived, rows[0].Subtype)
+	require.Equal(t, outpointHash, rows[0].Txid)
+	require.Equal(t, outpointIndex, rows[0].OutputIndex)
+	require.Equal(t, sessionID, rows[0].SessionID)
+}
+
+// TestLedgerStoreTransactionHistorySynthesizesOORReceiveFromBinding verifies
+// old ledger rows that predate structured outpoint fields can still be paired
+// through the OOR binding table without parsing descriptions.
+func TestLedgerStoreTransactionHistorySynthesizesOORReceiveFromBinding(
+	t *testing.T) {
+
+	t.Parallel()
+
+	ctx := t.Context()
+	store, db := newLedgerStoreAndDBForTest(t)
+	sessionID := testBytes(32, 0x50)
+	outpointHash := testBytes(32, 0x51)
+	outpointIndex := int32(1)
+	insertTransactionHistoryOOROutput(
+		t, db, sessionID, outpointHash, outpointIndex, 998_511, 99,
+		0x52,
+	)
+
+	require.NoError(
+		t,
+		store.InsertLedgerEntry(
+			ctx, ledger.LedgerEntry{
+				DebitAccount:  ledger.AccountVTXOBalance,
+				CreditAccount: ledger.AccountTransfersIn,
+				AmountSat:     998_511,
+				EventType:     ledger.EventVTXOReceived,
+				Description:   "old unstructured OOR receive",
+				CreatedAt:     100,
+			},
+		),
+	)
+
+	rows, err := store.ListTransactionHistory(ctx, "oor", 0, 0, 10, 0)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, "oor_binding", rows[0].Source)
+	require.Equal(t, ledger.EventVTXOReceived, rows[0].Subtype)
+	require.Equal(t, int64(998_511), rows[0].AmountSat)
+	require.Equal(t, outpointHash, rows[0].Txid)
+	require.Equal(t, outpointIndex, rows[0].OutputIndex)
+	require.Equal(t, sessionID, rows[0].SessionID)
+}
+
+// TestLedgerStoreTransactionHistoryKeepsUnstructuredReceiveRound verifies an
+// old or malformed receive row without structured outpoint fields does not
+// become OOR history merely because its accounts look like a transfer.
+func TestLedgerStoreTransactionHistoryKeepsUnstructuredReceiveRound(
+	t *testing.T) {
+
+	t.Parallel()
+
+	ctx := t.Context()
+	store, _ := newLedgerStoreAndDBForTest(t)
+
+	require.NoError(
+		t,
+		store.InsertLedgerEntry(
+			ctx, ledger.LedgerEntry{
+				DebitAccount:  ledger.AccountVTXOBalance,
+				CreditAccount: ledger.AccountTransfersIn,
+				AmountSat:     2_500,
+				EventType:     ledger.EventVTXOReceived,
+				Description:   "unstructured receive",
+				CreatedAt:     100,
+			},
+		),
+	)
+
+	oorRows, err := store.ListTransactionHistory(ctx, "oor", 0, 0, 10, 0)
+	require.NoError(t, err)
+	require.Empty(t, oorRows)
+
+	rows, err := store.ListTransactionHistory(ctx, "", 0, 0, 10, 0)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, "round", rows[0].TransactionType)
 }
 
 // TestLedgerStoreTransactionHistoryWalletUTXOCreatedChainFields verifies

--- a/db/sqlc/fee_accounting.sql.go
+++ b/db/sqlc/fee_accounting.sql.go
@@ -258,9 +258,15 @@ FROM (
     SELECT 0 AS source_order,
            'ledger' AS source,
            le.entry_id,
-           le.chain_txid AS txid,
+           COALESCE(le.chain_txid, oor_created.outpoint_hash) AS txid,
            CASE
                WHEN le.session_id IS NOT NULL THEN 'oor'
+               WHEN le.event_type = 'vtxo_received'
+                    AND le.round_id IS NULL
+                    AND oor_created.session_id IS NOT NULL
+                    AND le.debit_account = 'vtxo_balance'
+                    AND le.credit_account = 'transfers_in'
+               THEN 'oor'
                WHEN le.event_type IN (
                    'boarding_fee_paid', 'wallet_utxo_created'
                ) THEN 'boarding'
@@ -286,10 +292,15 @@ FROM (
            le.debit_account,
            le.credit_account,
            le.round_id,
-           le.session_id,
+           COALESCE(le.session_id, oor_created.session_id) AS session_id,
            COALESCE(le.confirmation_height, 0) AS confirmation_height,
-           COALESCE(le.chain_vout, -1) AS output_index
+           COALESCE(le.chain_vout, oor_created.outpoint_index, -1) AS
+               output_index
     FROM ledger_entries AS le
+    LEFT JOIN oor_vtxo_bindings AS oor_created
+        ON oor_created.outpoint_hash = le.chain_txid
+       AND oor_created.outpoint_index = le.chain_vout
+       AND oor_created.link_kind = 0
     LEFT JOIN (
         SELECT allocated.outpoint_hash,
                allocated.outpoint_index,
@@ -370,6 +381,43 @@ FROM (
     ) AS boarding_round
         ON boarding_round.outpoint_hash = le.chain_txid
        AND boarding_round.outpoint_index = le.chain_vout
+
+    UNION ALL
+
+    SELECT 0 AS source_order,
+           'oor_binding' AS source,
+           -CAST(ROW_NUMBER() OVER (
+               ORDER BY b.session_id, b.output_index,
+                        b.outpoint_hash, b.outpoint_index
+           ) AS BIGINT) AS entry_id,
+           b.outpoint_hash AS txid,
+           'oor' AS transaction_type,
+           'vtxo_received' AS subtype,
+           v.amount AS amount_sat,
+           CAST(0 AS BIGINT) AS fee_sat,
+           b.created_at,
+           'recorded' AS status,
+           'OOR VTXO created' AS description,
+           'vtxo_balance' AS debit_account,
+           'transfers_in' AS credit_account,
+           NULL AS round_id,
+           b.session_id,
+           CAST(0 AS INTEGER) AS confirmation_height,
+           b.outpoint_index AS output_index
+    FROM oor_vtxo_bindings AS b
+    JOIN vtxos AS v
+        ON v.outpoint_hash = b.outpoint_hash
+       AND v.outpoint_index = b.outpoint_index
+    WHERE b.link_kind = 0
+      AND NOT EXISTS (
+          SELECT 1
+          FROM ledger_entries AS le_existing
+          WHERE le_existing.event_type = 'vtxo_received'
+            AND le_existing.chain_txid = b.outpoint_hash
+            AND le_existing.chain_vout = b.outpoint_index
+            AND le_existing.debit_account = 'vtxo_balance'
+            AND le_existing.credit_account = 'transfers_in'
+      )
 
     UNION ALL
 

--- a/db/sqlc/queries/fee_accounting.sql
+++ b/db/sqlc/queries/fee_accounting.sql
@@ -56,9 +56,15 @@ FROM (
     SELECT 0 AS source_order,
            'ledger' AS source,
            le.entry_id,
-           le.chain_txid AS txid,
+           COALESCE(le.chain_txid, oor_created.outpoint_hash) AS txid,
            CASE
                WHEN le.session_id IS NOT NULL THEN 'oor'
+               WHEN le.event_type = 'vtxo_received'
+                    AND le.round_id IS NULL
+                    AND oor_created.session_id IS NOT NULL
+                    AND le.debit_account = 'vtxo_balance'
+                    AND le.credit_account = 'transfers_in'
+               THEN 'oor'
                WHEN le.event_type IN (
                    'boarding_fee_paid', 'wallet_utxo_created'
                ) THEN 'boarding'
@@ -84,10 +90,15 @@ FROM (
            le.debit_account,
            le.credit_account,
            le.round_id,
-           le.session_id,
+           COALESCE(le.session_id, oor_created.session_id) AS session_id,
            COALESCE(le.confirmation_height, 0) AS confirmation_height,
-           COALESCE(le.chain_vout, -1) AS output_index
+           COALESCE(le.chain_vout, oor_created.outpoint_index, -1) AS
+               output_index
     FROM ledger_entries AS le
+    LEFT JOIN oor_vtxo_bindings AS oor_created
+        ON oor_created.outpoint_hash = le.chain_txid
+       AND oor_created.outpoint_index = le.chain_vout
+       AND oor_created.link_kind = 0
     LEFT JOIN (
         SELECT allocated.outpoint_hash,
                allocated.outpoint_index,
@@ -168,6 +179,43 @@ FROM (
     ) AS boarding_round
         ON boarding_round.outpoint_hash = le.chain_txid
        AND boarding_round.outpoint_index = le.chain_vout
+
+    UNION ALL
+
+    SELECT 0 AS source_order,
+           'oor_binding' AS source,
+           -CAST(ROW_NUMBER() OVER (
+               ORDER BY b.session_id, b.output_index,
+                        b.outpoint_hash, b.outpoint_index
+           ) AS BIGINT) AS entry_id,
+           b.outpoint_hash AS txid,
+           'oor' AS transaction_type,
+           'vtxo_received' AS subtype,
+           v.amount AS amount_sat,
+           CAST(0 AS BIGINT) AS fee_sat,
+           b.created_at,
+           'recorded' AS status,
+           'OOR VTXO created' AS description,
+           'vtxo_balance' AS debit_account,
+           'transfers_in' AS credit_account,
+           NULL AS round_id,
+           b.session_id,
+           CAST(0 AS INTEGER) AS confirmation_height,
+           b.outpoint_index AS output_index
+    FROM oor_vtxo_bindings AS b
+    JOIN vtxos AS v
+        ON v.outpoint_hash = b.outpoint_hash
+       AND v.outpoint_index = b.outpoint_index
+    WHERE b.link_kind = 0
+      AND NOT EXISTS (
+          SELECT 1
+          FROM ledger_entries AS le_existing
+          WHERE le_existing.event_type = 'vtxo_received'
+            AND le_existing.chain_txid = b.outpoint_hash
+            AND le_existing.chain_vout = b.outpoint_index
+            AND le_existing.debit_account = 'vtxo_balance'
+            AND le_existing.credit_account = 'transfers_in'
+      )
 
     UNION ALL
 

--- a/swapwallet/history.go
+++ b/swapwallet/history.go
@@ -383,7 +383,7 @@ func (h *history) collectLedgerEntries(ctx context.Context, offset,
 		return nil, err
 	}
 
-	hidden := internalOORSends(resp.GetTransactions(), correlations)
+	hidden := internalOORLedgerEntries(resp.GetTransactions(), correlations)
 	out := make([]*walletrpc.WalletEntry, 0, len(resp.GetTransactions()))
 	for _, t := range resp.GetTransactions() {
 		if _, ok := hidden[t.GetEntryId()]; ok {
@@ -451,14 +451,18 @@ func swapOORCorrelationsFromSwaps(
 	return out
 }
 
-// internalOORSends returns ledger entry IDs for OOR send legs that are internal
-// to swap execution. It only hides rows when the ledger session lines up with
-// structured swap metadata, which keeps two same-amount swaps from racing each
-// other through amount-only matching.
-func internalOORSends(rows []*daemonrpc.TransactionHistoryEntry,
+// internalOORLedgerEntries returns ledger entry IDs for OOR legs that are
+// internal to swap execution or represent wallet-local OOR change. Send legs
+// are hidden only when structured swap metadata proves the external payment
+// amount. Receive legs paired with a send in the same session are change and
+// stay out of activity list noise; inspection still exposes the ledger rows.
+func internalOORLedgerEntries(rows []*daemonrpc.TransactionHistoryEntry,
 	correlations swapOORCorrelations) map[int64]struct{} {
 
 	receivedBySession := make(map[string]int64)
+	receiveRowsBySession := make(
+		map[string][]*daemonrpc.TransactionHistoryEntry,
+	)
 	for _, row := range rows {
 		session, ok := oorReceiveSessionID(row)
 		if !ok {
@@ -466,6 +470,9 @@ func internalOORSends(rows []*daemonrpc.TransactionHistoryEntry,
 		}
 
 		receivedBySession[session] += row.GetAmountSat()
+		receiveRowsBySession[session] = append(
+			receiveRowsBySession[session], row,
+		)
 	}
 
 	hidden := make(map[int64]struct{})
@@ -478,6 +485,10 @@ func internalOORSends(rows []*daemonrpc.TransactionHistoryEntry,
 		received := receivedBySession[session]
 		if received == 0 {
 			continue
+		}
+
+		for _, receiveRow := range receiveRowsBySession[session] {
+			hidden[receiveRow.GetEntryId()] = struct{}{}
 		}
 
 		switch delta := row.GetAmountSat() - received; {
@@ -514,7 +525,8 @@ func oorSendSessionID(row *daemonrpc.TransactionHistoryEntry) (string, bool) {
 		row.GetSubtype() != ledger.EventVTXOSent ||
 		row.GetDebitAccount() != ledger.AccountTransfersOut ||
 		row.GetCreditAccount() != ledger.AccountVTXOBalance ||
-		row.GetAmountSat() <= 0 || len(row.GetSessionId()) == 0 {
+		row.GetAmountSat() <= 0 ||
+		len(row.GetSessionId()) != chainhash.HashSize {
 		return "", false
 	}
 
@@ -541,20 +553,36 @@ func oorReceiveSessionID(row *daemonrpc.TransactionHistoryEntry) (string,
 func oorReceiveRef(row *daemonrpc.TransactionHistoryEntry) (string, uint32,
 	bool) {
 
-	if row == nil || row.GetSubtype() != ledger.EventVTXOReceived ||
+	if row == nil || row.GetType() != "oor" ||
+		row.GetSubtype() != ledger.EventVTXOReceived ||
 		row.GetDebitAccount() != ledger.AccountVTXOBalance ||
 		row.GetCreditAccount() != ledger.AccountTransfersIn ||
 		row.GetAmountSat() <= 0 {
 		return "", 0, false
 	}
 
-	session := strings.ToLower(row.GetTxid())
-	if len(session) != 64 {
-		return "", 0, false
+	var session string
+	if len(row.GetSessionId()) > 0 {
+		if len(row.GetSessionId()) != chainhash.HashSize {
+			return "", 0, false
+		}
+
+		hash, err := chainhash.NewHash(row.GetSessionId())
+		if err != nil {
+			return "", 0, false
+		}
+
+		session = hash.String()
+	} else {
+		session = strings.ToLower(row.GetTxid())
+		if len(session) != 64 {
+			return "", 0, false
+		}
+		if _, err := hex.DecodeString(session); err != nil {
+			return "", 0, false
+		}
 	}
-	if _, err := hex.DecodeString(session); err != nil {
-		return "", 0, false
-	}
+
 	if row.GetOutputIndex() < 0 {
 		return "", 0, false
 	}

--- a/swapwallet/history_test.go
+++ b/swapwallet/history_test.go
@@ -4,6 +4,7 @@ package swapwallet
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -253,7 +254,7 @@ func TestHistoryHidesReceiveClaimOORSend(t *testing.T) {
 				CreatedAtUnixS: 100,
 			},
 			{
-				Type:           "round",
+				Type:           "oor",
 				Subtype:        ledger.EventVTXOReceived,
 				AmountSat:      1_000,
 				DebitAccount:   ledger.AccountVTXOBalance,
@@ -310,6 +311,58 @@ func TestHistoryKeepsUnpairedOORSend(t *testing.T) {
 	require.Equal(t, int64(-1_000), entries[0].GetAmountSat())
 }
 
+// TestOORSendSessionIDRequiresHashSizedSession confirms malformed OOR session
+// IDs are ignored instead of being normalized into correlation keys.
+func TestOORSendSessionIDRequiresHashSizedSession(t *testing.T) {
+	t.Parallel()
+
+	row := &daemonrpc.TransactionHistoryEntry{
+		Type:          "oor",
+		Subtype:       ledger.EventVTXOSent,
+		AmountSat:     1_000,
+		DebitAccount:  ledger.AccountTransfersOut,
+		CreditAccount: ledger.AccountVTXOBalance,
+		SessionId: []byte{
+			1,
+			2,
+			3,
+		},
+	}
+
+	_, ok := oorSendSessionID(row)
+	require.False(t, ok)
+
+	sessionID := testBytes(chainhash.HashSize, 0x51)
+	row.SessionId = sessionID
+
+	session, ok := oorSendSessionID(row)
+	require.True(t, ok)
+	require.Equal(t, testSessionString(t, sessionID), session)
+}
+
+// TestOORReceiveRefRequiresOORType confirms the OOR change correlation path
+// only consumes rows already classified as OOR history by the daemon.
+func TestOORReceiveRefRequiresOORType(t *testing.T) {
+	t.Parallel()
+
+	row := &daemonrpc.TransactionHistoryEntry{
+		Type:          "round",
+		Subtype:       ledger.EventVTXOReceived,
+		AmountSat:     1_000,
+		DebitAccount:  ledger.AccountVTXOBalance,
+		CreditAccount: ledger.AccountTransfersIn,
+		Txid:          strings.Repeat("a", 64),
+		OutputIndex:   0,
+	}
+
+	_, _, ok := oorReceiveRef(row)
+	require.False(t, ok)
+
+	row.Type = "oor"
+	_, _, ok = oorReceiveRef(row)
+	require.True(t, ok)
+}
+
 // TestHistoryHidesPayFundingOORInput confirms wallet activity does not show
 // the full input consumed to fund a pay-swap vHTLC when the input's change
 // came back to the wallet and the delta is already represented by the swap
@@ -348,7 +401,7 @@ func TestHistoryHidesPayFundingOORInput(t *testing.T) {
 				CreatedAtUnixS: 100,
 			},
 			{
-				Type:           "round",
+				Type:           "oor",
 				Subtype:        ledger.EventVTXOReceived,
 				AmountSat:      998_511,
 				DebitAccount:   ledger.AccountVTXOBalance,
@@ -411,7 +464,7 @@ func TestHistoryKeepsSameAmountUnmatchedFundingInput(t *testing.T) {
 				CreatedAtUnixS: 100,
 			},
 			{
-				Type:          "round",
+				Type:          "oor",
 				Subtype:       ledger.EventVTXOReceived,
 				AmountSat:     998_511,
 				DebitAccount:  ledger.AccountVTXOBalance,
@@ -431,7 +484,7 @@ func TestHistoryKeepsSameAmountUnmatchedFundingInput(t *testing.T) {
 				CreatedAtUnixS: 99,
 			},
 			{
-				Type:          "round",
+				Type:          "oor",
 				Subtype:       ledger.EventVTXOReceived,
 				AmountSat:     998_511,
 				DebitAccount:  ledger.AccountVTXOBalance,
@@ -478,7 +531,7 @@ func TestHistoryKeepsOORSendWithChangeWithoutSwap(t *testing.T) {
 				CreatedAtUnixS: 100,
 			},
 			{
-				Type:           "round",
+				Type:           "oor",
 				Subtype:        ledger.EventVTXOReceived,
 				AmountSat:      998_511,
 				DebitAccount:   ledger.AccountVTXOBalance,

--- a/swapwallet/inspection.go
+++ b/swapwallet/inspection.go
@@ -379,7 +379,9 @@ func correlateOORPairs(swap *swapclientrpc.SwapSummary,
 func hiddenOORLedgerRows(swaps []*swapclientrpc.SwapSummary,
 	rows []*daemonrpc.TransactionHistoryEntry) map[int64]struct{} {
 
-	return internalOORSends(rows, swapOORCorrelationsFromSwaps(swaps))
+	return internalOORLedgerEntries(
+		rows, swapOORCorrelationsFromSwaps(swaps),
+	)
 }
 
 // ledgerTraceRows projects daemon transaction rows onto the inspection RPC

--- a/swapwallet/inspection_test.go
+++ b/swapwallet/inspection_test.go
@@ -71,7 +71,7 @@ func TestInspectActivityShowsPayFundingTrace(t *testing.T) {
 				CreatedAtUnixS: 100,
 			},
 			{
-				Type:           "round",
+				Type:           "oor",
 				Subtype:        ledger.EventVTXOReceived,
 				AmountSat:      998_511,
 				DebitAccount:   ledger.AccountVTXOBalance,
@@ -103,7 +103,7 @@ func TestInspectActivityShowsPayFundingTrace(t *testing.T) {
 
 	require.True(t, ledgerByID[13].GetHiddenFromActivity())
 	require.Equal(t, "spent_input", ledgerByID[13].GetRole())
-	require.False(t, ledgerByID[14].GetHiddenFromActivity())
+	require.True(t, ledgerByID[14].GetHiddenFromActivity())
 	require.Equal(t, "change_output", ledgerByID[14].GetRole())
 	require.Equal(t, int32(1), ledgerByID[14].GetOutputIndex())
 


### PR DESCRIPTION
Follow-up to #498.

## Motivation

The friendly wallet activity feed should not show ledger rows that are implementation details of OOR-backed swap execution. The previous follow-up only tightened malformed OOR send session handling, but testing showed the correct model also needs two related constraints:

- OOR receive rows should be correlated through structured OOR artifact bindings instead of description parsing.
- OOR receive rows paired with an OOR send in the same session are wallet-local change/materialization rows and should be hidden from the activity list, while remaining visible in inspection.

## Changes

- Classify structured OOR receive ledger rows as `oor` when they are transfer-in rows with an OOR created-output binding.
- Enrich structured receive rows with the OOR binding session id for swap/change correlation.
- Synthesize OOR receive rows from `oor_vtxo_bindings` and `vtxos` for older local rows that predate structured ledger outpoints.
- Require OOR receive correlation to consume rows already classified as `oor`.
- Hide paired OOR receive rows from activity when an OOR send in the same session proves they are wallet-local change/materialization.
- Keep OOR send hiding anchored to structured swap metadata, including the exact external payment amount.
- Require OOR send session ids to be exactly `chainhash.HashSize` before normalization.
- Keep inspection output able to show the hidden ledger rows and their roles.

## Validation

```sh
make fmt-changed-check base=origin/main
make sqlc-check
go test ./db ./darepod ./cmd/darepocli/darepoclicommands -tags 'walletrpc swapruntime'
go test ./swapwallet -tags 'walletrpc swapruntime'
```