### PR TITLE
swaprpc: quote payer-paid out-swap fees

### DIFF
--- a/sdk/swaps/client.go
+++ b/sdk/swaps/client.go
@@ -65,6 +65,10 @@ type SwapSummary struct {
 	// FeeSat is the negotiated swap-server fee in satoshis when known.
 	FeeSat uint64
 
+	// PayerFeeMsat is the payer-paid Lightning route fee quoted for
+	// receive swaps. It is not deducted from AmountSat.
+	PayerFeeMsat uint64
+
 	// MaxFeeSat is the caller-provided maximum routing fee for pay swaps.
 	MaxFeeSat uint64
 
@@ -194,6 +198,19 @@ type RouteHint struct {
 	// CltvExpiryDelta is the CLTV expiry delta required by this
 	// hop.
 	CltvExpiryDelta uint32
+}
+
+// OutSwapQuote is the complete server quote for one Lightning-to-Ark receive
+// route.
+type OutSwapQuote struct {
+	// RouteHint is the private hop hint the SDK embeds in the invoice.
+	RouteHint *RouteHint
+
+	// ReceiveAmountSat is the exact Ark amount the receiver expects.
+	ReceiveAmountSat btcutil.Amount
+
+	// PayerFeeMsat is the payer-paid route fee quoted by the swap server.
+	PayerFeeMsat uint64
 }
 
 // VHTLCConfig holds the timelocks and keys for a vHTLC.
@@ -338,8 +355,8 @@ type InSwapConfig struct {
 type SwapServerConn interface {
 	// RequestChannelID asks the server for a route hint for this swap.
 	RequestChannelID(ctx context.Context, vhtlcPubkey *btcec.PublicKey,
-		paymentHash lntypes.Hash,
-		expirySeconds uint32) (*RouteHint, error)
+		paymentHash lntypes.Hash, amountSat btcutil.Amount,
+		expirySeconds uint32) (*OutSwapQuote, error)
 
 	// CreateInSwap initiates an Ark->LN swap on the server.
 	CreateInSwap(ctx context.Context, invoice string, maxFeeSat uint64,

--- a/sdk/swaps/grpc_conn.go
+++ b/sdk/swaps/grpc_conn.go
@@ -6,6 +6,7 @@ import (
 	"math"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/lightninglabs/darepo-client/rpc/restclient"
 	"github.com/lightninglabs/darepo-client/swaprpc"
 	"github.com/lightningnetwork/lnd/lntypes"
@@ -40,10 +41,13 @@ func NewRESTSwapServerConn(addr string,
 // Lightning-to-Ark receive flow.
 func (g *GRPCSwapServerConn) RequestChannelID(ctx context.Context,
 	vhtlcPubkey *btcec.PublicKey, paymentHash lntypes.Hash,
-	expirySeconds uint32) (*RouteHint, error) {
+	amountSat btcutil.Amount, expirySeconds uint32) (*OutSwapQuote, error) {
 
 	if vhtlcPubkey == nil {
 		return nil, fmt.Errorf("vHTLC pubkey must be provided")
+	}
+	if amountSat <= 0 {
+		return nil, fmt.Errorf("receive amount must be positive")
 	}
 
 	resp, err := g.client.RequestChannelId(
@@ -54,6 +58,7 @@ func (g *GRPCSwapServerConn) RequestChannelID(ctx context.Context,
 			PaymentHash: append(
 				[]byte(nil), paymentHash[:]...,
 			),
+			AmountMsat: uint64(amountSat) * 1000,
 		},
 	)
 	if err != nil {
@@ -65,7 +70,13 @@ func (g *GRPCSwapServerConn) RequestChannelID(ctx context.Context,
 		return nil, err
 	}
 
-	return hint, nil
+	return &OutSwapQuote{
+		RouteHint: hint,
+		// The server binds the route to the requested amount but does
+		// not echo it, so keep the caller's amount in the quote.
+		ReceiveAmountSat: amountSat,
+		PayerFeeMsat:     resp.GetPayerFeeMsat(),
+	}, nil
 }
 
 // CreateInSwap initiates one Ark-to-Lightning swap on the swap server.

--- a/sdk/swaps/in_swap_test.go
+++ b/sdk/swaps/in_swap_test.go
@@ -38,7 +38,8 @@ type testInSwapServerConn struct {
 
 // RequestChannelID is unused in these tests.
 func (c *testInSwapServerConn) RequestChannelID(_ context.Context,
-	_ *btcec.PublicKey, _ lntypes.Hash, _ uint32) (*RouteHint, error) {
+	_ *btcec.PublicKey, _ lntypes.Hash, _ btcutil.Amount, _ uint32) (
+	*OutSwapQuote, error) {
 
 	return nil, nil
 }

--- a/sdk/swaps/invoice_test.go
+++ b/sdk/swaps/invoice_test.go
@@ -101,3 +101,46 @@ func TestInvoiceGeneratorIncludesPaymentAddress(t *testing.T) {
 	)
 	require.True(t, decoded.Features.HasFeature(lnwire.PaymentAddrOptional))
 }
+
+// TestInvoiceGeneratorPreservesPayerFeeRouteHint verifies receive invoices
+// encode the payer-paid route fee and keep multi-part payments disabled.
+func TestInvoiceGeneratorPreservesPayerFeeRouteHint(t *testing.T) {
+	t.Parallel()
+
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	creator := NewEphemeralInvoiceGenerator(
+		privKey, nil, &chaincfg.RegressionNetParams,
+	)
+
+	preimage, err := NewPreimage()
+	require.NoError(t, err)
+
+	routeHint := &RouteHint{
+		NodeID:          privKey.PubKey().SerializeCompressed(),
+		ChannelID:       42,
+		FeeBaseMsat:     0,
+		FeePropPpm:      10_000,
+		CltvExpiryDelta: 40,
+	}
+
+	invoice, _, err := creator.CreateInvoice(
+		context.Background(), btcutil.Amount(50_000),
+		"swap", routeHint, time.Hour, &preimage,
+	)
+	require.NoError(t, err)
+
+	decoded, err := zpay32.Decode(
+		string(invoice.PaymentRequest), &chaincfg.RegressionNetParams,
+	)
+	require.NoError(t, err)
+	require.Len(t, decoded.RouteHints, 1)
+	require.Len(t, decoded.RouteHints[0], 1)
+
+	hop := decoded.RouteHints[0][0]
+	require.Equal(t, uint32(0), hop.FeeBaseMSat)
+	require.Equal(t, uint32(10_000), hop.FeeProportionalMillionths)
+	require.False(t, decoded.Features.HasFeature(lnwire.MPPOptional))
+	require.False(t, decoded.Features.HasFeature(lnwire.MPPRequired))
+}

--- a/sdk/swaps/migrations/000001_swap_sessions.up.sql
+++ b/sdk/swaps/migrations/000001_swap_sessions.up.sql
@@ -14,6 +14,10 @@ CREATE TABLE IF NOT EXISTS receive_swaps (
     -- amount_sat is the requested invoice amount in satoshis.
     amount_sat BIGINT NOT NULL,
 
+    -- payer_fee_msat is the payer-paid route fee quoted by the swap server.
+    -- The fee is not deducted from amount_sat.
+    payer_fee_msat BIGINT NOT NULL,
+
     -- state is the current client-side receive FSM state name.
     state TEXT NOT NULL,
 

--- a/sdk/swaps/out_swap.go
+++ b/sdk/swaps/out_swap.go
@@ -254,6 +254,7 @@ type ReceiveSession struct {
 	client         *SwapClient
 	amountSat      btcutil.Amount
 	memo           string
+	payerFeeMsat   uint64
 	state          ReceiveState
 	deadline       time.Time
 	createdAt      time.Time
@@ -632,19 +633,25 @@ func (s *ReceiveSession) prepareInvoice(ctx context.Context) error {
 	// database. The session is persisted before the invoice is returned to
 	// the caller.
 	expiry := time.Duration(defaultReceiveExpirySeconds) * time.Second
-	hint, err := s.client.server.RequestChannelID(
-		ctx, clientKey, paymentHash, defaultReceiveExpirySeconds,
+	quote, err := s.client.server.RequestChannelID(
+		ctx, clientKey, paymentHash, s.amountSat,
+		defaultReceiveExpirySeconds,
 	)
 	if err != nil {
 		return fmt.Errorf("request channel ID: %w", err)
 	}
+	if quote == nil || quote.RouteHint == nil {
+		return fmt.Errorf("route quote must be provided")
+	}
 
 	s.client.log.InfoS(ctx, "Received route hint from swap server",
-		slog.Uint64("channel_id", hint.ChannelID),
+		slog.Uint64("channel_id", quote.RouteHint.ChannelID),
+		slog.Uint64("payer_fee_msat", quote.PayerFeeMsat),
 	)
 
 	inv, hash, err := s.client.invoiceGen.CreateInvoiceWithKey(
-		ctx, s.amountSat, s.memo, hint, expiry, authKey, &preimage,
+		ctx, s.amountSat, s.memo, quote.RouteHint, expiry, authKey,
+		&preimage,
 	)
 	if err != nil {
 		return fmt.Errorf("create invoice: %w", err)
@@ -666,6 +673,7 @@ func (s *ReceiveSession) prepareInvoice(ctx context.Context) error {
 		s.Invoice = string(inv.PaymentRequest)
 		s.Preimage = preimage
 		s.PaymentHash = hash
+		s.payerFeeMsat = quote.PayerFeeMsat
 		s.deadline = s.client.currentTime().Add(expiry)
 		if s.createdAt.IsZero() {
 			s.createdAt = s.client.currentTime()

--- a/sdk/swaps/out_swap_test.go
+++ b/sdk/swaps/out_swap_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math"
 	"testing"
 	"time"
 
@@ -76,6 +77,51 @@ func TestStartReceiveRejectsInvalidAmount(t *testing.T) {
 		t.Context(), btcutil.MaxSatoshi+1,
 	)
 	require.ErrorContains(t, err, "exceeds max bitcoin supply")
+}
+
+// TestStartReceiveRejectsPayerFeeOverflow verifies quoted route fees must fit
+// the signed SQLite column before a receive session can be persisted.
+func TestStartReceiveRejectsPayerFeeOverflow(t *testing.T) {
+	t.Parallel()
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	serverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	creator := &testInvoiceCreator{
+		invoice: &invoices.Invoice{
+			PaymentRequest: []byte("lnrtest1swap"),
+		},
+	}
+	serverPubKey := serverPriv.PubKey().SerializeCompressed()
+	serverConn := &testSwapServerConn{
+		hint: &RouteHint{
+			NodeID:          serverPubKey,
+			ChannelID:       99,
+			FeeBaseMsat:     1,
+			FeePropPpm:      2,
+			CltvExpiryDelta: 40,
+		},
+		payerFeeMsat: uint64(math.MaxInt64) + 1,
+	}
+	daemonConn := &testDaemonConn{
+		identityKey: clientPriv.PubKey(),
+		operatorKey: operatorPriv.PubKey(),
+	}
+
+	client := NewSwapClientWithStore(
+		serverConn, daemonConn, nil, creator, newTestSwapStore(t),
+	)
+	_, err = client.StartReceiveViaLightning(
+		t.Context(), btcutil.Amount(42_000),
+	)
+	require.ErrorContains(t, err, "payer fee")
+	require.ErrorContains(t, err, "overflows int64")
 }
 
 // TestStartReceiveDerivesReceiveAuthKeyPerPaymentHash verifies new receive
@@ -198,6 +244,7 @@ func TestAcceptInArkHtlcEventBuildsSenderReceiverPolicy(t *testing.T) {
 
 type testSwapServerConn struct {
 	hint          *RouteHint
+	payerFeeMsat  uint64
 	cfg           *VHTLCConfig
 	htlcAmountSat uint64
 	waitErr       error
@@ -209,6 +256,7 @@ type testSwapServerConn struct {
 	lastAckCursor uint64
 
 	lastVhtlcPubkey *btcec.PublicKey
+	lastAmountSat   btcutil.Amount
 }
 
 type testIncomingEventReceiver struct {
@@ -254,12 +302,17 @@ func (r *testIncomingEventReceiver) WaitIncomingVHTLC(context.Context,
 
 // RequestChannelID returns the preconfigured out-swap route hint.
 func (c *testSwapServerConn) RequestChannelID(_ context.Context,
-	vhtlcPubkey *btcec.PublicKey, _ lntypes.Hash, _ uint32) (*RouteHint,
-	error) {
+	vhtlcPubkey *btcec.PublicKey, _ lntypes.Hash, amountSat btcutil.Amount,
+	_ uint32) (*OutSwapQuote, error) {
 
 	c.lastVhtlcPubkey = vhtlcPubkey
+	c.lastAmountSat = amountSat
 
-	return c.hint, nil
+	return &OutSwapQuote{
+		RouteHint:        c.hint,
+		ReceiveAmountSat: amountSat,
+		PayerFeeMsat:     c.payerFeeMsat,
+	}, nil
 }
 
 // WaitOutSwapHtlc returns the preconfigured out-swap HTLC event.
@@ -943,6 +996,7 @@ func TestReceiveSessionResumeFromStore(t *testing.T) {
 			FeePropPpm:      2,
 			CltvExpiryDelta: 40,
 		},
+		payerFeeMsat: 123_000,
 		cfg: &VHTLCConfig{
 			RefundLocktime:                       144,
 			UnilateralClaimDelay:                 12,
@@ -974,6 +1028,8 @@ func TestReceiveSessionResumeFromStore(t *testing.T) {
 		t.Context(), btcutil.Amount(42_000),
 	)
 	require.NoError(t, err)
+	require.EqualValues(t, 42_000, serverConn.lastAmountSat)
+	require.EqualValues(t, 123_000, session.payerFeeMsat)
 	require.Equal(t, 1, daemonConn.receiveAllocCalls)
 
 	daemonConn.vhtlc = &VTXOInfo{
@@ -992,6 +1048,7 @@ func TestReceiveSessionResumeFromStore(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Equal(t, ReceiveStateInvoiceCreated, resumed.State())
+	require.EqualValues(t, 123_000, resumed.payerFeeMsat)
 
 	result, err := resumed.Wait(t.Context())
 	require.NoError(t, err)

--- a/sdk/swaps/queries/swaps.sql
+++ b/sdk/swaps/queries/swaps.sql
@@ -2,6 +2,7 @@
 INSERT INTO receive_swaps (
     payment_hash,
     amount_sat,
+    payer_fee_msat,
     state,
     invoice,
     preimage,
@@ -26,11 +27,12 @@ INSERT INTO receive_swaps (
     created_at_unix,
     updated_at_unix
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16,
-    $17, $18, $19, $20, $21, $22, $23, $24, $25
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15,
+    $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26
 )
 ON CONFLICT (payment_hash) DO UPDATE SET
     amount_sat = EXCLUDED.amount_sat,
+    payer_fee_msat = EXCLUDED.payer_fee_msat,
     state = EXCLUDED.state,
     invoice = EXCLUDED.invoice,
     preimage = EXCLUDED.preimage,

--- a/sdk/swaps/rest_conn_test.go
+++ b/sdk/swaps/rest_conn_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/lightninglabs/darepo-client/swaprpc"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/stretchr/testify/require"
@@ -36,7 +37,8 @@ func TestRESTSwapServerConnRequestChannelID(t *testing.T) {
 
 				body, err := protojson.Marshal(
 					&swaprpc.RequestChannelIdResponse{
-						RouteHint: routeHint,
+						RouteHint:    routeHint,
+						PayerFeeMsat: 123,
 					},
 				)
 				require.NoError(t, err)
@@ -55,10 +57,14 @@ func TestRESTSwapServerConnRequestChannelID(t *testing.T) {
 	require.NoError(t, err)
 
 	client := NewRESTSwapServerConn(server.URL)
-	hint, err := client.RequestChannelID(
-		t.Context(), clientPriv.PubKey(), lntypes.Hash{1}, 30,
+	quote, err := client.RequestChannelID(
+		t.Context(), clientPriv.PubKey(), lntypes.Hash{1},
+		btcutil.Amount(42_000), 30,
 	)
 	require.NoError(t, err)
+	hint := quote.RouteHint
 	require.Equal(t, uint64(42), hint.ChannelID)
 	require.Equal(t, nodeID, hint.NodeID)
+	require.EqualValues(t, 42_000, quote.ReceiveAmountSat)
+	require.EqualValues(t, 123, quote.PayerFeeMsat)
 }

--- a/sdk/swaps/sqlc/models.go
+++ b/sdk/swaps/sqlc/models.go
@@ -36,6 +36,7 @@ type PaySwap struct {
 type ReceiveSwap struct {
 	PaymentHash                          []byte
 	AmountSat                            int64
+	PayerFeeMsat                         int64
 	State                                string
 	Invoice                              string
 	Preimage                             []byte

--- a/sdk/swaps/sqlc/swaps.sql.go
+++ b/sdk/swaps/sqlc/swaps.sql.go
@@ -50,7 +50,7 @@ func (q *Queries) GetPaySwap(ctx context.Context, paymentHash []byte) (PaySwap, 
 }
 
 const GetReceiveSwap = `-- name: GetReceiveSwap :one
-SELECT payment_hash, amount_sat, state, invoice, preimage, deadline_unix, client_pubkey, payment_addr, operator_pubkey, swap_server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, vhtlc_pkscript, vhtlc_policy_template, vhtlc_outpoint, vhtlc_amount, pending_htlc_ack_cursor, claim_receive_pubkey, claim_receive_pkscript, claim_session_id, intervention_reason, created_at_unix, updated_at_unix FROM receive_swaps
+SELECT payment_hash, amount_sat, payer_fee_msat, state, invoice, preimage, deadline_unix, client_pubkey, payment_addr, operator_pubkey, swap_server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, vhtlc_pkscript, vhtlc_policy_template, vhtlc_outpoint, vhtlc_amount, pending_htlc_ack_cursor, claim_receive_pubkey, claim_receive_pkscript, claim_session_id, intervention_reason, created_at_unix, updated_at_unix FROM receive_swaps
 WHERE payment_hash = $1
 LIMIT 1
 `
@@ -61,6 +61,7 @@ func (q *Queries) GetReceiveSwap(ctx context.Context, paymentHash []byte) (Recei
 	err := row.Scan(
 		&i.PaymentHash,
 		&i.AmountSat,
+		&i.PayerFeeMsat,
 		&i.State,
 		&i.Invoice,
 		&i.Preimage,
@@ -202,7 +203,7 @@ func (q *Queries) ListPendingPaySwaps(ctx context.Context) ([]PaySwap, error) {
 }
 
 const ListPendingReceiveSwaps = `-- name: ListPendingReceiveSwaps :many
-SELECT payment_hash, amount_sat, state, invoice, preimage, deadline_unix, client_pubkey, payment_addr, operator_pubkey, swap_server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, vhtlc_pkscript, vhtlc_policy_template, vhtlc_outpoint, vhtlc_amount, pending_htlc_ack_cursor, claim_receive_pubkey, claim_receive_pkscript, claim_session_id, intervention_reason, created_at_unix, updated_at_unix FROM receive_swaps
+SELECT payment_hash, amount_sat, payer_fee_msat, state, invoice, preimage, deadline_unix, client_pubkey, payment_addr, operator_pubkey, swap_server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, vhtlc_pkscript, vhtlc_policy_template, vhtlc_outpoint, vhtlc_amount, pending_htlc_ack_cursor, claim_receive_pubkey, claim_receive_pkscript, claim_session_id, intervention_reason, created_at_unix, updated_at_unix FROM receive_swaps
 WHERE state NOT IN ('Completed', 'Expired', 'NeedsIntervention', 'Failed')
 ORDER BY created_at_unix ASC
 `
@@ -219,6 +220,7 @@ func (q *Queries) ListPendingReceiveSwaps(ctx context.Context) ([]ReceiveSwap, e
 		if err := rows.Scan(
 			&i.PaymentHash,
 			&i.AmountSat,
+			&i.PayerFeeMsat,
 			&i.State,
 			&i.Invoice,
 			&i.Preimage,
@@ -257,7 +259,7 @@ func (q *Queries) ListPendingReceiveSwaps(ctx context.Context) ([]ReceiveSwap, e
 }
 
 const ListReceiveSwaps = `-- name: ListReceiveSwaps :many
-SELECT payment_hash, amount_sat, state, invoice, preimage, deadline_unix, client_pubkey, payment_addr, operator_pubkey, swap_server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, vhtlc_pkscript, vhtlc_policy_template, vhtlc_outpoint, vhtlc_amount, pending_htlc_ack_cursor, claim_receive_pubkey, claim_receive_pkscript, claim_session_id, intervention_reason, created_at_unix, updated_at_unix FROM receive_swaps
+SELECT payment_hash, amount_sat, payer_fee_msat, state, invoice, preimage, deadline_unix, client_pubkey, payment_addr, operator_pubkey, swap_server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, vhtlc_pkscript, vhtlc_policy_template, vhtlc_outpoint, vhtlc_amount, pending_htlc_ack_cursor, claim_receive_pubkey, claim_receive_pkscript, claim_session_id, intervention_reason, created_at_unix, updated_at_unix FROM receive_swaps
 ORDER BY created_at_unix ASC
 `
 
@@ -273,6 +275,7 @@ func (q *Queries) ListReceiveSwaps(ctx context.Context) ([]ReceiveSwap, error) {
 		if err := rows.Scan(
 			&i.PaymentHash,
 			&i.AmountSat,
+			&i.PayerFeeMsat,
 			&i.State,
 			&i.Invoice,
 			&i.Preimage,
@@ -435,6 +438,7 @@ const UpsertReceiveSwap = `-- name: UpsertReceiveSwap :exec
 INSERT INTO receive_swaps (
     payment_hash,
     amount_sat,
+    payer_fee_msat,
     state,
     invoice,
     preimage,
@@ -459,11 +463,12 @@ INSERT INTO receive_swaps (
     created_at_unix,
     updated_at_unix
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16,
-    $17, $18, $19, $20, $21, $22, $23, $24, $25
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15,
+    $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26
 )
 ON CONFLICT (payment_hash) DO UPDATE SET
     amount_sat = EXCLUDED.amount_sat,
+    payer_fee_msat = EXCLUDED.payer_fee_msat,
     state = EXCLUDED.state,
     invoice = EXCLUDED.invoice,
     preimage = EXCLUDED.preimage,
@@ -492,6 +497,7 @@ ON CONFLICT (payment_hash) DO UPDATE SET
 type UpsertReceiveSwapParams struct {
 	PaymentHash                          []byte
 	AmountSat                            int64
+	PayerFeeMsat                         int64
 	State                                string
 	Invoice                              string
 	Preimage                             []byte
@@ -521,6 +527,7 @@ func (q *Queries) UpsertReceiveSwap(ctx context.Context, arg UpsertReceiveSwapPa
 	_, err := q.db.ExecContext(ctx, UpsertReceiveSwap,
 		arg.PaymentHash,
 		arg.AmountSat,
+		arg.PayerFeeMsat,
 		arg.State,
 		arg.Invoice,
 		arg.Preimage,

--- a/sdk/swaps/store_sessions.go
+++ b/sdk/swaps/store_sessions.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"math"
 	"sort"
 	"time"
 
@@ -308,6 +309,7 @@ func receiveSummaryFromRow(row swapsqlc.ReceiveSwap) (SwapSummary, error) {
 		State:          state.String(),
 		Pending:        !state.IsTerminal(),
 		AmountSat:      row.AmountSat,
+		PayerFeeMsat:   uint64(row.PayerFeeMsat),
 		VHTLCOutpoint:  row.VhtlcOutpoint,
 		VHTLCAmountSat: row.VhtlcAmount,
 		ClaimSessionID: row.ClaimSessionID,
@@ -392,10 +394,15 @@ func (s *ReceiveSession) persist(ctx context.Context) error {
 	}
 
 	now := s.client.currentTime().Unix()
+	if s.payerFeeMsat > math.MaxInt64 {
+		return fmt.Errorf("payer fee %d msat overflows int64",
+			s.payerFeeMsat)
+	}
 
 	params := swapsqlc.UpsertReceiveSwapParams{
 		PaymentHash:  append([]byte(nil), s.PaymentHash[:]...),
 		AmountSat:    int64(s.amountSat),
+		PayerFeeMsat: int64(s.payerFeeMsat),
 		State:        s.state.String(),
 		Invoice:      s.Invoice,
 		Preimage:     append([]byte(nil), s.Preimage[:]...),
@@ -659,8 +666,11 @@ func receiveSessionFromRow(c *SwapClient,
 		PaymentHash: paymentHash,
 		client:      c,
 		amountSat:   btcutil.Amount(row.AmountSat),
-		state:       state,
-		deadline:    time.Unix(row.DeadlineUnix, 0),
+		payerFeeMsat: uint64(
+			row.PayerFeeMsat,
+		),
+		state:    state,
+		deadline: time.Unix(row.DeadlineUnix, 0),
 		vhtlcConfig: restoreVHTLCConfig(
 			row.RefundLocktime, row.UnilateralClaimDelay,
 			row.UnilateralRefundDelay,

--- a/sdk/swaps/store_test.go
+++ b/sdk/swaps/store_test.go
@@ -200,6 +200,7 @@ func TestListSwapSummariesIncludesFeesAndPendingFilter(t *testing.T) {
 		ctx, swapsqlc.UpsertReceiveSwapParams{
 			PaymentHash:         receiveHash[:],
 			AmountSat:           21_000,
+			PayerFeeMsat:        123_000,
 			State:               receiveState,
 			Invoice:             "ln-receive",
 			Preimage:            receivePreimage[:],
@@ -245,6 +246,7 @@ func TestListSwapSummariesIncludesFeesAndPendingFilter(t *testing.T) {
 	require.Equal(t, SwapDirectionReceive, all[1].Direction)
 	require.Equal(t, "ln-receive", all[1].Invoice)
 	require.EqualValues(t, 0, all[1].FeeSat)
+	require.EqualValues(t, 123_000, all[1].PayerFeeMsat)
 	require.True(t, all[1].Pending)
 	require.False(t, all[2].Pending)
 
@@ -263,6 +265,7 @@ func TestListSwapSummariesIncludesFeesAndPendingFilter(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, SwapDirectionReceive, receiveSummary.Direction)
 	require.Equal(t, receiveState, receiveSummary.State)
+	require.EqualValues(t, 123_000, receiveSummary.PayerFeeMsat)
 }
 
 // testHash returns a deterministic 32-byte hash-like value.

--- a/swaprpc/swap.pb.go
+++ b/swaprpc/swap.pb.go
@@ -89,7 +89,12 @@ type RequestChannelIdRequest struct {
 	// payment_hash is the invoice payment hash. The swap server combines it
 	// with client_vhtlc_pubkey to derive a unique virtual channel ID without
 	// adding a separate auth identity.
-	PaymentHash   []byte `protobuf:"bytes,3,opt,name=payment_hash,json=paymentHash,proto3" json:"payment_hash,omitempty"`
+	PaymentHash []byte `protobuf:"bytes,3,opt,name=payment_hash,json=paymentHash,proto3" json:"payment_hash,omitempty"`
+	// amount_msat is the exact amount the Ark receiver expects to receive,
+	// expressed in millisatoshis. The swap server's out-swap fee is charged to
+	// the Lightning payer through the route hint and does not reduce this
+	// amount.
+	AmountMsat    uint64 `protobuf:"varint,4,opt,name=amount_msat,json=amountMsat,proto3" json:"amount_msat,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -145,11 +150,22 @@ func (x *RequestChannelIdRequest) GetPaymentHash() []byte {
 	return nil
 }
 
+func (x *RequestChannelIdRequest) GetAmountMsat() uint64 {
+	if x != nil {
+		return x.AmountMsat
+	}
+	return 0
+}
+
 // RequestChannelIdResponse returns the route hint for one receive negotiation.
 type RequestChannelIdResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// route_hint contains the hop hint the client should embed in the invoice.
-	RouteHint     *RouteHint `protobuf:"bytes,1,opt,name=route_hint,json=routeHint,proto3" json:"route_hint,omitempty"`
+	RouteHint *RouteHint `protobuf:"bytes,1,opt,name=route_hint,json=routeHint,proto3" json:"route_hint,omitempty"`
+	// payer_fee_msat is the quoted Lightning route fee paid by the sender for
+	// the swap server's virtual hop. Callers that want a "payer pays" total
+	// compute it as amount_msat plus payer_fee_msat.
+	PayerFeeMsat  uint64 `protobuf:"varint,2,opt,name=payer_fee_msat,json=payerFeeMsat,proto3" json:"payer_fee_msat,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -189,6 +205,13 @@ func (x *RequestChannelIdResponse) GetRouteHint() *RouteHint {
 		return x.RouteHint
 	}
 	return nil
+}
+
+func (x *RequestChannelIdResponse) GetPayerFeeMsat() uint64 {
+	if x != nil {
+		return x.PayerFeeMsat
+	}
+	return 0
 }
 
 // OutSwapHtlcEvent describes one server-funded intercepted HTLC. The event is
@@ -791,14 +814,17 @@ var File_swap_proto protoreflect.FileDescriptor
 const file_swap_proto_rawDesc = "" +
 	"\n" +
 	"\n" +
-	"swap.proto\x12\aswaprpc\x1a\x1fgoogle/protobuf/timestamp.proto\"\x93\x01\n" +
+	"swap.proto\x12\aswaprpc\x1a\x1fgoogle/protobuf/timestamp.proto\"\xb4\x01\n" +
 	"\x17RequestChannelIdRequest\x12%\n" +
 	"\x0eexpiry_seconds\x18\x01 \x01(\rR\rexpirySeconds\x12.\n" +
 	"\x13client_vhtlc_pubkey\x18\x02 \x01(\fR\x11clientVhtlcPubkey\x12!\n" +
-	"\fpayment_hash\x18\x03 \x01(\fR\vpaymentHash\"M\n" +
+	"\fpayment_hash\x18\x03 \x01(\fR\vpaymentHash\x12\x1f\n" +
+	"\vamount_msat\x18\x04 \x01(\x04R\n" +
+	"amountMsat\"s\n" +
 	"\x18RequestChannelIdResponse\x121\n" +
 	"\n" +
-	"route_hint\x18\x01 \x01(\v2\x12.swaprpc.RouteHintR\trouteHint\"\xac\x01\n" +
+	"route_hint\x18\x01 \x01(\v2\x12.swaprpc.RouteHintR\trouteHint\x12$\n" +
+	"\x0epayer_fee_msat\x18\x02 \x01(\x04R\fpayerFeeMsat\"\xac\x01\n" +
 	"\x10OutSwapHtlcEvent\x12!\n" +
 	"\fpayment_hash\x18\x01 \x01(\fR\vpaymentHash\x12\x1d\n" +
 	"\n" +

--- a/swaprpc/swap.proto
+++ b/swaprpc/swap.proto
@@ -47,12 +47,23 @@ message RequestChannelIdRequest {
     // with client_vhtlc_pubkey to derive a unique virtual channel ID without
     // adding a separate auth identity.
     bytes payment_hash = 3;
+
+    // amount_msat is the exact amount the Ark receiver expects to receive,
+    // expressed in millisatoshis. The swap server's out-swap fee is charged to
+    // the Lightning payer through the route hint and does not reduce this
+    // amount.
+    uint64 amount_msat = 4;
 }
 
 // RequestChannelIdResponse returns the route hint for one receive negotiation.
 message RequestChannelIdResponse {
     // route_hint contains the hop hint the client should embed in the invoice.
     RouteHint route_hint = 1;
+
+    // payer_fee_msat is the quoted Lightning route fee paid by the sender for
+    // the swap server's virtual hop. Callers that want a "payer pays" total
+    // compute it as amount_msat plus payer_fee_msat.
+    uint64 payer_fee_msat = 2;
 }
 
 // OutSwapHtlcEvent describes one server-funded intercepted HTLC. The event is


### PR DESCRIPTION
## Summary

This PR adds the client-side protocol and SDK support for payer-paid out-swap route fees. The receive amount remains the Ark amount the receiver expects, while the swap server can quote a separate Lightning route fee that the payer pays through the private route hint.

Concretely, `RequestChannelIdRequest` now carries `amount_msat`, and `RequestChannelIdResponse` returns `payer_fee_msat` alongside the route hint. There is intentionally no client-visible quote-expiry field: the server still owns its internal route-registration TTL, but the SDK API only exposes the price the payer needs to pay on top of the invoice amount.

The SDK persists the quoted payer fee on receive sessions, exposes `PayerFeeMsat` in receive summaries, and continues to encode invoices whose amount is exactly the requested Ark receive amount. The fee is represented in the private route hint, not added to the invoice face value and not deducted from the Ark receive amount.

The SDK schema is edited in place because there are no deployed users. The new receive-session column is `payer_fee_msat`, required at insert time.

## Validation

- `make rpc`
- `make sqlc`
- `make fmt-changed-check`
- `make commitmsg-lint range='origin/main..HEAD'`
- `go test -count=1 ./sdk/swaps ./rpc/restclient`
- `make lint-local`
