### PR TITLE
multi: rebuild refresh output template against current operator key (#520)

### DIFF
--- a/darepod/server.go
+++ b/darepod/server.go
@@ -600,6 +600,31 @@ func (s *Server) storeOperatorTerms(terms *types.OperatorTerms) {
 	s.operatorTerms.Store(terms)
 }
 
+// fetchCurrentOperatorPubKey issues a fresh GetInfo round-trip to the
+// operator and returns the operator's current long-term public key. The
+// daemon-startup OperatorTerms cache is also refreshed as a side effect so
+// other readers see the same snapshot. Used to plumb a live operator-key
+// lookup into the wallet and VTXO subsystems so refresh emissions build
+// the NEW VTXO output's policy template against the operator's join-time
+// key — VTXOs commit to their operator key for life, so the new output's
+// key is chosen at join time and stays stable on that VTXO forever.
+func (s *Server) fetchCurrentOperatorPubKey(ctx context.Context) (
+	*btcec.PublicKey, error) {
+
+	terms, err := s.fetchOperatorTerms(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("fetch operator terms: %w", err)
+	}
+
+	// Refresh the cache so unrelated readers (e.g. GetInfo) reflect the
+	// snapshot the refresh path used. The cache was previously only
+	// hydrated at daemon startup, which is what made it the wrong source
+	// of truth in the first place.
+	s.storeOperatorTerms(terms)
+
+	return terms.PubKey, nil
+}
+
 // isServerConnected returns the latest mailbox-ingress connectivity signal
 // reported by the daemon runtime.
 func (s *Server) isServerConnected() bool {
@@ -3231,6 +3256,7 @@ func (s *Server) initWalletActor(ctx context.Context,
 		),
 		wallet.WithClock(s.clk),
 		wallet.WithEagerRoundJoin(s.cfg.EagerRoundJoin),
+		wallet.WithFetchOperatorKey(s.fetchCurrentOperatorPubKey),
 	)
 	walletKey := actor.NewServiceKey[
 		wallet.WalletMsg, wallet.WalletResp,
@@ -3436,6 +3462,7 @@ func (s *Server) initVTXOManager(ctx context.Context,
 		LedgerSink:       fn.Some(ledger.NewSink(s.actorSystem)),
 		ChainResolver:    chainResolver,
 		RefreshFeeQuoter: s.autoRefreshFeeQuoter(),
+		FetchOperatorKey: s.fetchCurrentOperatorPubKey,
 		TerminalVTXOObserver: func(ctx context.Context,
 			outpoint wire.OutPoint) error {
 

--- a/vtxo/actor.go
+++ b/vtxo/actor.go
@@ -2,9 +2,11 @@ package vtxo
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/wire"
@@ -89,6 +91,22 @@ type VTXOActorConfig struct {
 	// emits RefreshVTXORequest with OperatorFee=0, which is fine:
 	// the seal-time quote is still the source of truth.
 	RefreshFeeQuoter RefreshFeeQuoter
+
+	// FetchOperatorKey, when set, returns the operator's current
+	// long-term public key by issuing a fresh GetInfo round-trip to
+	// the operator at the moment of an auto-refresh emission. The
+	// fetched key is used to build the NEW VTXO output's policy
+	// template; the input VTXO's stored operator key is intentionally
+	// not reused for the new output because VTXOs commit to their
+	// operator key for their entire lifetime, and the new output is a
+	// fresh VTXO whose operator key is chosen at join time.
+	//
+	// A nil callback causes refreshOutputTemplate to fall back to the
+	// descriptor's stored bytes (harness paths and pre-fix behavior).
+	// A non-nil callback that errors propagates the error so the
+	// refresh fails loudly rather than silently emitting against a
+	// stale key; the next expiry tick will retry.
+	FetchOperatorKey func(context.Context) (*btcec.PublicKey, error)
 }
 
 // VTXOActor manages the lifecycle of a single VTXO. It processes events using
@@ -125,6 +143,51 @@ func NewVTXOActor(ctx context.Context, cfg *VTXOActorConfig) *VTXOActor {
 // context. If no logger is found in either location, returns btclog.Disabled.
 func (a *VTXOActor) logger(ctx context.Context) btclog.Logger {
 	return a.cfg.Log.UnwrapOr(build.LoggerFromContext(ctx))
+}
+
+// refreshOutputTemplate returns the policy template the auto-refresh emission
+// should attach to the relayed RefreshVTXORequest for the NEW VTXO output.
+//
+// The new output is a freshly-minted VTXO whose operator key is chosen at
+// join time — VTXOs commit to their operator key for life, so the input
+// VTXO's stored key must not leak into the new output. When the
+// FetchOperatorKey seam is wired, the actor issues a fresh GetInfo and uses
+// the returned key to rebuild the standard template. For non-standard shapes
+// (vHTLC etc.) the rebuild surface is unavailable and the actor falls back
+// to the descriptor's stored bytes, accepting that a key rotation across
+// those VTXOs will still be rejected by the rounds validator. When the seam
+// is unset the actor also falls back, which keeps harness paths working
+// unchanged.
+func (a *VTXOActor) refreshOutputTemplate(ctx context.Context,
+	vtxo *Descriptor) ([]byte, error) {
+
+	if a.cfg.FetchOperatorKey == nil {
+		return vtxo.EffectivePolicyTemplate()
+	}
+
+	currentKey, err := a.cfg.FetchOperatorKey(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("fetch current operator key: %w", err)
+	}
+	if currentKey == nil {
+		return nil, fmt.Errorf("fetch current operator key: nil key " +
+			"returned")
+	}
+
+	rebuilt, err := vtxo.RefreshOutputTemplate(currentKey)
+	if err != nil {
+		// Non-standard policy: keep the stored bytes. The server may
+		// still accept the request if the operator key happens to
+		// match; if not, the rounds validator will reject it and the
+		// caller will see the same error surface as before the fix.
+		if errors.Is(err, ErrRefreshOperatorKeyUnsupported) {
+			return vtxo.EffectivePolicyTemplate()
+		}
+
+		return nil, err
+	}
+
+	return rebuilt, nil
 }
 
 // emitExitCost is the VTXO-actor entry point for emitting an
@@ -347,11 +410,21 @@ func (a *VTXOActor) processOutbox(ctx context.Context,
 			// the round-specific message here since the VTXO
 			// actor has the descriptor data needed.
 			vtxo := a.cfg.VTXO
-			policyTemplate, err := vtxo.EffectivePolicyTemplate()
+			policyTemplate, err := a.refreshOutputTemplate(
+				ctx, vtxo,
+			)
 			if err != nil {
-				a.logger(ctx).ErrorS(
+				// WarnS, not ErrorS: this can fail because
+				// the FetchOperatorKey callback returned an
+				// error (operator unreachable, fresh GetInfo
+				// timed out) — an external trigger, not an
+				// internal bug. The next expiry tick will
+				// retry; skipping this emission is the right
+				// local behavior.
+				a.logger(ctx).WarnS(
 					ctx,
-					"Failed to encode refresh policy",
+					"Failed to build refresh output "+
+						"template",
 					err,
 					slog.String(
 						"outpoint",

--- a/vtxo/manager.go
+++ b/vtxo/manager.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/wire"
@@ -84,6 +85,16 @@ type ManagerConfig struct {
 	// OperatorFee=0, which is harmless because the server still
 	// fills in the residual via the JoinRoundQuote.
 	RefreshFeeQuoter RefreshFeeQuoter
+
+	// FetchOperatorKey is propagated to each spawned VTXOActor so
+	// the auto-refresh emission can fetch the operator's current
+	// long-term key at join time and rebuild the NEW VTXO output's
+	// policy template against it. A fresh fetch is used — rather
+	// than a daemon-startup cache — because VTXOs commit to their
+	// operator key for life and the new output's key is chosen at
+	// join time. Nil leaves the spawned actors falling back to the
+	// descriptor's stored bytes (the pre-fix behavior).
+	FetchOperatorKey func(context.Context) (*btcec.PublicKey, error)
 
 	// TerminalVTXOObserver receives the outpoint of VTXOs that leave the
 	// manager's active set so daemon-local observers can clean up related
@@ -560,6 +571,7 @@ func (m *Manager) spawnVTXOActor(ctx context.Context, vtxo *Descriptor) (
 		Manager:          m.managerRef,
 		LedgerSink:       m.cfg.LedgerSink,
 		RefreshFeeQuoter: m.cfg.RefreshFeeQuoter,
+		FetchOperatorKey: m.cfg.FetchOperatorKey,
 	}
 
 	vtxoActor := NewVTXOActor(ctx, actorCfg)

--- a/vtxo/policy.go
+++ b/vtxo/policy.go
@@ -2,11 +2,23 @@ package vtxo
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/lightninglabs/darepo-client/lib/arkscript"
 )
+
+// ErrRefreshOperatorKeyUnsupported is returned by RefreshOutputTemplate when
+// the descriptor's stored policy is not the standard Ark VTXO shape. The
+// operator key sits in a fixed position in standard policies but not in
+// custom ones (e.g. vHTLC), so a structural rewrite there could shift the
+// wrong field. Callers must either keep the input shape (and fail at the
+// rounds validator if the rotation still applies) or surface this error to
+// the user with rotation-specific UX.
+var ErrRefreshOperatorKeyUnsupported = errors.New("refresh-time operator key " +
+	"rewrite only supported for standard VTXO policies")
 
 // EffectivePolicyTemplate returns the semantic policy for the VTXO.
 func (d *Descriptor) EffectivePolicyTemplate() ([]byte, error) {
@@ -54,6 +66,55 @@ func (d *Descriptor) DecodeStandardPolicyTemplate() (
 	}
 
 	return arkscript.DecodeStandardVTXOParams(template)
+}
+
+// RefreshOutputTemplate returns the policy template that should be used for
+// the NEW VTXO output that a refresh round mints from this descriptor.
+//
+// The descriptor's stored PolicyTemplate field carries the operator key the
+// VTXO was originally created under (call that K1). When the operator has
+// since rotated to a different long-term key (K2), reusing the stored bytes
+// verbatim ships K1 inside the JoinRoundRequest's new VTXO template — the
+// server's rounds validator then rejects the request with
+// ErrOperatorKeyMismatch.
+//
+// The fix path: rebuild the new output's template with the caller-supplied
+// current operator key while preserving the owner key and exit delay that
+// the existing descriptor commits to. This intentionally only touches the
+// new output side; spend-time material for the old VTXO (forfeit witnesses,
+// unilateral exit script) still has to use K1 because that is what the
+// original output's taproot tree committed to.
+//
+// Only the standard Ark VTXO shape is supported here. Custom shapes (vHTLC,
+// etc.) return ErrRefreshOperatorKeyUnsupported so callers can surface the
+// limitation explicitly rather than silently producing a misshaped template.
+//
+// A nil currentOperatorKey returns an error so callers that have not wired
+// the operator-terms cache yet fail loudly instead of producing a template
+// with a zero key.
+func (d *Descriptor) RefreshOutputTemplate(
+	currentOperatorKey *btcec.PublicKey) ([]byte, error) {
+
+	if d == nil {
+		return nil, fmt.Errorf("descriptor must be provided")
+	}
+
+	if currentOperatorKey == nil {
+		return nil, fmt.Errorf("current operator key must be provided")
+	}
+
+	// Decode the stored template once so we can lift the owner key and
+	// exit delay back out — those still belong to the holder of this
+	// VTXO and survive the operator rotation untouched.
+	params, err := d.DecodeStandardPolicyTemplate()
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w",
+			ErrRefreshOperatorKeyUnsupported, err)
+	}
+
+	return arkscript.EncodeStandardVTXOTemplate(
+		params.OwnerKey, currentOperatorKey, params.ExitDelay,
+	)
 }
 
 // StandardTapScript derives the standard tapscript for descriptors that use

--- a/vtxo/refresh_operator_rotation_test.go
+++ b/vtxo/refresh_operator_rotation_test.go
@@ -1,0 +1,234 @@
+package vtxo
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/lightninglabs/darepo-client/lib/arkscript"
+	"github.com/lightninglabs/darepo-client/round"
+	"github.com/stretchr/testify/require"
+)
+
+// xOnlyEqual compares two secp256k1 keys by their Schnorr (x-only)
+// serialization, which is the form Ark policy templates commit to.
+// Comparing full pubkeys with IsEqual would spuriously fail when the
+// y-coordinate parity differs.
+func xOnlyEqual(a, b *btcec.PublicKey) bool {
+	if a == nil || b == nil {
+		return false
+	}
+
+	return bytes.Equal(
+		schnorr.SerializePubKey(a), schnorr.SerializePubKey(b),
+	)
+}
+
+// TestRefreshEmissionUsesJoinTimeOperatorKey pins the contract that the
+// auto-refresh emission must build the NEW VTXO output's policy template
+// against the operator key the client resolves at join time (via a fresh
+// GetInfo round-trip), not against the input VTXO's stored key. VTXOs
+// commit to their operator key for life; the new output is itself a fresh
+// VTXO, so its operator key is chosen at join time and is stable on that
+// new VTXO forever.
+//
+// The test exercises four behaviours through subtests:
+//
+//   - With a fetch callback that returns K2, the emitted template
+//     commits to K2 and not the descriptor's K1.
+//   - With no fetch callback wired, the emission falls back to the
+//     descriptor's stored bytes (harness path / non-standard policies).
+//   - When the fetch callback errors, refreshOutputTemplate propagates
+//     the error so the actor surfaces a failed refresh instead of
+//     silently emitting against a stale key.
+//   - When the fetch callback returns a nil key, the same propagation
+//     rule applies.
+func TestRefreshEmissionUsesJoinTimeOperatorKey(t *testing.T) {
+	t.Parallel()
+
+	t.Run("rebuilds against fetched key", func(t *testing.T) {
+		t.Parallel()
+
+		h := newVTXOTestHarness(t)
+		vtxo := h.newTestDescriptor()
+
+		_, k2 := generateTestKeyPair(t)
+		require.False(
+			t, xOnlyEqual(vtxo.OperatorKey, k2),
+			"sanity: fetched key must differ from descriptor's "+
+				"stored key",
+		)
+
+		manager := newMockManagerRef(t)
+		actor := newRefreshTestActor(
+			h, vtxo, manager,
+			func(_ context.Context) (*btcec.PublicKey, error) {
+				return k2, nil
+			},
+		)
+
+		refreshReq := drainRefreshEmission(t, h, actor, manager, vtxo)
+		params := decodeStandardParams(t, refreshReq.PolicyTemplate)
+
+		require.True(
+			t, xOnlyEqual(params.OperatorKey, k2),
+			"emitted template must commit to the operator key "+
+				"fetched at join time",
+		)
+		require.False(
+			t, xOnlyEqual(params.OperatorKey, vtxo.OperatorKey),
+			"emitted template must no longer carry the "+
+				"descriptor's stale K1",
+		)
+	})
+
+	t.Run("falls back to stored template when fetch unset",
+		func(t *testing.T) {
+			t.Parallel()
+
+			h := newVTXOTestHarness(t)
+			vtxo := h.newTestDescriptor()
+
+			manager := newMockManagerRef(t)
+			actor := newRefreshTestActor(h, vtxo, manager, nil)
+
+			refreshReq := drainRefreshEmission(
+				t, h, actor, manager, vtxo,
+			)
+			params := decodeStandardParams(
+				t, refreshReq.PolicyTemplate,
+			)
+
+			require.True(
+				t, xOnlyEqual(
+					params.OperatorKey, vtxo.OperatorKey,
+				),
+				"with no fetch wired the actor must keep "+
+					"the descriptor's stored template "+
+					"(legacy fallback)",
+			)
+		})
+
+	t.Run("propagates fetch error", func(t *testing.T) {
+		t.Parallel()
+
+		h := newVTXOTestHarness(t)
+		vtxo := h.newTestDescriptor()
+
+		fetchErr := errors.New("operator unreachable")
+		manager := newMockManagerRef(t)
+		actor := newRefreshTestActor(
+			h, vtxo, manager,
+			func(_ context.Context) (*btcec.PublicKey, error) {
+				return nil, fetchErr
+			},
+		)
+
+		_, err := actor.refreshOutputTemplate(h.ctx, vtxo)
+		require.ErrorIs(
+			t, err, fetchErr, "fetch error must propagate so "+
+				"the refresh fails instead of silently "+
+				"emitting against a stale key",
+		)
+	})
+
+	t.Run("rejects nil fetched key", func(t *testing.T) {
+		t.Parallel()
+
+		h := newVTXOTestHarness(t)
+		vtxo := h.newTestDescriptor()
+
+		manager := newMockManagerRef(t)
+		actor := newRefreshTestActor(
+			h, vtxo, manager,
+			func(_ context.Context) (*btcec.PublicKey, error) {
+				return nil, nil
+			},
+		)
+
+		_, err := actor.refreshOutputTemplate(h.ctx, vtxo)
+		require.Error(
+			t, err, "a fetch callback that returns a nil key "+
+				"must fail the refresh, not silently fall back",
+		)
+	})
+}
+
+// fetchOperatorKeyFn is the local alias for the FetchOperatorKey callback
+// signature; it keeps the newRefreshTestActor signature within the 80-col
+// line budget.
+type fetchOperatorKeyFn = func(context.Context) (*btcec.PublicKey, error)
+
+// newRefreshTestActor builds a minimal VTXOActor in LiveState wired to the
+// shared test harness. fetchOperatorKey may be nil to exercise the
+// legacy fallback path.
+func newRefreshTestActor(h *vtxoTestHarness, vtxo *Descriptor,
+	manager *mockManagerRef,
+	fetchOperatorKey fetchOperatorKeyFn) *VTXOActor {
+
+	return &VTXOActor{
+		cfg: &VTXOActorConfig{
+			VTXO:             vtxo,
+			Store:            h.store,
+			Wallet:           h.wallet,
+			ChainParams:      &chaincfg.RegressionNetParams,
+			Manager:          manager,
+			FetchOperatorKey: fetchOperatorKey,
+		},
+		state: &LiveState{
+			VTXO: vtxo,
+		},
+		env: h.env,
+	}
+}
+
+// drainRefreshEmission feeds a single ForfeitRequest through the actor's
+// processOutbox and returns the resulting RefreshVTXORequest the manager
+// received.
+func drainRefreshEmission(t *testing.T, h *vtxoTestHarness, actor *VTXOActor,
+	manager *mockManagerRef, vtxo *Descriptor) *round.RefreshVTXORequest {
+
+	t.Helper()
+
+	require.NoError(
+		t,
+		actor.processOutbox(
+			h.ctx, []VTXOOutMsg{
+				&ForfeitRequest{VTXOOutpoint: vtxo.Outpoint},
+			},
+		),
+	)
+
+	msgs := manager.getMessages()
+	require.Len(t, msgs, 1, "expected exactly one relayed message")
+
+	relayMsg, ok := msgs[0].(*RelayToRoundMsg)
+	require.True(t, ok, "expected RelayToRoundMsg, got %T", msgs[0])
+
+	refreshReq, ok := relayMsg.Payload.(*round.RefreshVTXORequest)
+	require.True(
+		t, ok, "expected RefreshVTXORequest, got %T", relayMsg.Payload,
+	)
+
+	return refreshReq
+}
+
+// decodeStandardParams decodes a serialized standard VTXO policy template
+// into its (owner, operator, exit-delay) triple.
+func decodeStandardParams(t *testing.T,
+	raw []byte) *arkscript.StandardVTXOParams {
+
+	t.Helper()
+
+	template, err := arkscript.DecodePolicyTemplate(raw)
+	require.NoError(t, err, "decode policy template")
+
+	params, err := arkscript.DecodeStandardVTXOParams(template)
+	require.NoError(t, err, "decode standard VTXO params")
+
+	return params
+}

--- a/wallet/policy.go
+++ b/wallet/policy.go
@@ -2,8 +2,22 @@ package wallet
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/lightninglabs/darepo-client/lib/arkscript"
 )
+
+// ErrRefreshOperatorKeyUnsupported is returned by RefreshOutputTemplate when
+// the descriptor's stored policy is not the standard Ark VTXO shape. The
+// operator key sits in a fixed position in standard policies but not in
+// custom ones (e.g. vHTLC), so a structural rewrite there could shift the
+// wrong field. Callers must either keep the input shape (and fail at the
+// rounds validator if the rotation still applies) or surface this error to
+// the user with rotation-specific UX.
+var ErrRefreshOperatorKeyUnsupported = errors.New("refresh-time operator key " +
+	"rewrite only supported for standard VTXO policies")
 
 // EffectivePolicyTemplate returns the semantic policy for the VTXO.
 func (d *VTXODescriptor) EffectivePolicyTemplate() ([]byte, error) {
@@ -18,4 +32,57 @@ func (d *VTXODescriptor) EffectivePolicyTemplate() ([]byte, error) {
 	}
 
 	return bytes.Clone(d.PolicyTemplate), nil
+}
+
+// RefreshOutputTemplate returns the policy template that should be used for
+// the NEW VTXO output that a refresh round mints from this descriptor.
+//
+// See vtxo.(*Descriptor).RefreshOutputTemplate for the full rationale; the
+// wallet-level descriptor type carries the same fields and needs the same
+// rewrite so the explicit RefreshVTXOs RPC path emits a join request whose
+// new-output template commits to the operator's current key.
+//
+// Only the standard Ark VTXO shape is supported. Non-standard shapes
+// (vHTLC, custom) return ErrRefreshOperatorKeyUnsupported so callers can
+// surface the limitation rather than silently producing a misshaped
+// template.
+func (d *VTXODescriptor) RefreshOutputTemplate(
+	currentOperatorKey *btcec.PublicKey) ([]byte, error) {
+
+	if d == nil {
+		return nil, fmt.Errorf("wallet VTXO descriptor must be " +
+			"provided")
+	}
+
+	if currentOperatorKey == nil {
+		return nil, fmt.Errorf("current operator key must be provided")
+	}
+
+	if len(d.PolicyTemplate) == 0 {
+		return nil, fmt.Errorf("wallet VTXO descriptor policy " +
+			"template must be provided")
+	}
+
+	// Wrap both decode failures with ErrRefreshOperatorKeyUnsupported so
+	// callers can branch with a single errors.Is check, mirroring
+	// vtxo.(*Descriptor).RefreshOutputTemplate. Without this, a
+	// DecodePolicyTemplate failure (malformed bytes or a future
+	// non-TLV shape) would propagate as a plain error and the caller's
+	// fallback path would diverge between the wallet and vtxo sides
+	// for the same input.
+	template, err := arkscript.DecodePolicyTemplate(d.PolicyTemplate)
+	if err != nil {
+		return nil, fmt.Errorf("%w: decode stored policy template: %w",
+			ErrRefreshOperatorKeyUnsupported, err)
+	}
+
+	params, err := arkscript.DecodeStandardVTXOParams(template)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w",
+			ErrRefreshOperatorKeyUnsupported, err)
+	}
+
+	return arkscript.EncodeStandardVTXOTemplate(
+		params.OwnerKey, currentOperatorKey, params.ExitDelay,
+	)
 }

--- a/wallet/refresh_operator_rotation_test.go
+++ b/wallet/refresh_operator_rotation_test.go
@@ -1,0 +1,119 @@
+package wallet
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/lightninglabs/darepo-client/lib/arkscript"
+	"github.com/stretchr/testify/require"
+)
+
+// TestComposeRefreshTemplate is the wallet-side regression, parallel to
+// vtxo.TestRefreshEmissionUsesJoinTimeOperatorKey. handleRefreshVTXOs
+// hoists a single GetInfo fetch out of its per-outpoint loop and feeds
+// the resolved key into composeRefreshTemplate per VTXO; this test
+// exercises that helper directly.
+func TestComposeRefreshTemplate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("rebuilds against resolved key", func(t *testing.T) {
+		t.Parallel()
+
+		ownerKey := newTestPubKey(t)
+		k1 := newTestPubKey(t)
+		k2 := newTestPubKey(t)
+
+		const exitDelay = uint32(144)
+		storedTemplate, err := arkscript.EncodeStandardVTXOTemplate(
+			ownerKey, k1, exitDelay,
+		)
+		require.NoError(t, err)
+
+		descriptor := &VTXODescriptor{PolicyTemplate: storedTemplate}
+
+		rebuilt, err := composeRefreshTemplate(descriptor, k2)
+		require.NoError(t, err)
+
+		params := decodeWalletStandardParams(t, rebuilt)
+		require.True(
+			t, xOnlyPubKeyEqual(params.OperatorKey, k2),
+			"emitted template must commit to the resolved key K2",
+		)
+		require.False(
+			t, xOnlyPubKeyEqual(params.OperatorKey, k1),
+			"emitted template must no longer carry K1",
+		)
+		require.True(
+			t, xOnlyPubKeyEqual(params.OwnerKey, ownerKey),
+			"owner key must be preserved across the rebuild",
+		)
+		require.Equal(
+			t, exitDelay, params.ExitDelay,
+			"exit delay must be preserved across the rebuild",
+		)
+	})
+
+	t.Run("returns stored bytes when key unresolved", func(t *testing.T) {
+		t.Parallel()
+
+		ownerKey := newTestPubKey(t)
+		k1 := newTestPubKey(t)
+
+		storedTemplate, err := arkscript.EncodeStandardVTXOTemplate(
+			ownerKey, k1, 144,
+		)
+		require.NoError(t, err)
+
+		descriptor := &VTXODescriptor{PolicyTemplate: storedTemplate}
+
+		out, err := composeRefreshTemplate(descriptor, nil)
+		require.NoError(t, err)
+		require.True(
+			t, bytes.Equal(out, storedTemplate),
+			"with no resolved key the helper must return the "+
+				"stored template verbatim (harness path)",
+		)
+	})
+}
+
+// newTestPubKey returns a freshly generated secp256k1 public key.
+func newTestPubKey(t *testing.T) *btcec.PublicKey {
+	t.Helper()
+
+	priv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	return priv.PubKey()
+}
+
+// xOnlyPubKeyEqual compares two secp256k1 keys by their Schnorr (x-only)
+// serialization. Ark policy templates commit to the x-only form, so y-
+// parity differences between the encoded and freshly-derived pubkey must
+// not be treated as a mismatch.
+func xOnlyPubKeyEqual(a, b *btcec.PublicKey) bool {
+	if a == nil || b == nil {
+		return false
+	}
+
+	return bytes.Equal(
+		schnorr.SerializePubKey(a), schnorr.SerializePubKey(b),
+	)
+}
+
+// decodeWalletStandardParams decodes a serialized standard VTXO policy
+// template into its (owner, operator, exit-delay) triple.
+func decodeWalletStandardParams(t *testing.T,
+	raw []byte) *arkscript.StandardVTXOParams {
+
+	t.Helper()
+
+	template, err := arkscript.DecodePolicyTemplate(raw)
+	require.NoError(t, err, "decode policy template")
+
+	params, err := arkscript.DecodeStandardVTXOParams(template)
+	require.NoError(t, err, "decode standard VTXO params")
+
+	return params
+}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -2,6 +2,7 @@ package wallet
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -212,6 +213,18 @@ type Ark struct {
 	// in the mailbox, push out room for self-Tells from inside the
 	// handler, and degrade the boarding-sweep resume cadence.
 	tickInflight atomic.Bool
+
+	// fetchOperatorKey, when set, returns the operator's current
+	// long-term public key by issuing a fresh GetInfo round-trip at
+	// the moment a refresh intent is composed. The fetched key is
+	// used to build the NEW VTXO output's policy template inside
+	// handleRefreshVTXOs; the input VTXO's stored key is intentionally
+	// not reused for the new output because VTXOs commit to their
+	// operator key for life and the new output's key is chosen at
+	// join time. Nil leaves the handler falling back to the
+	// descriptor's stored bytes for harness paths and for non-standard
+	// policy shapes where the rebuild surface is unavailable.
+	fetchOperatorKey func(context.Context) (*btcec.PublicKey, error)
 }
 
 // NewArk creates a new Ark wallet actor. The logger is optional and falls back
@@ -324,10 +337,60 @@ func WithTipTickInterval(d time.Duration) ArkOption {
 	}
 }
 
+// WithFetchOperatorKey wires a closure that fetches the operator's
+// current long-term public key (via a fresh GetInfo round-trip) into
+// the wallet actor. The closure is invoked when composing refresh
+// intents so the NEW VTXO output's policy template is built against
+// the operator's join-time key, rather than the daemon-startup cache
+// (which goes stale across rotations) or the descriptor's stored K1
+// (which would defeat the rotation entirely). Tests and harnesses
+// can omit the option to keep the legacy fallback to the descriptor's
+// stored template.
+func WithFetchOperatorKey(
+	fetch func(context.Context) (*btcec.PublicKey, error)) ArkOption {
+
+	return func(a *Ark) {
+		a.fetchOperatorKey = fetch
+	}
+}
+
 // logger returns the configured logger or falls back to extracting from
 // context. If no logger is found in either location, returns btclog.Disabled.
 func (a *Ark) logger(ctx context.Context) btclog.Logger {
 	return a.actorLog.UnwrapOr(build.LoggerFromContext(ctx))
+}
+
+// composeRefreshTemplate returns the policy template that the explicit
+// RefreshVTXOs handler should attach to the new VTXO output for a given
+// input descriptor, using the operator key already resolved for the
+// surrounding batch (see handleRefreshVTXOs).
+//
+// Mirrors the vtxo-side refreshOutputTemplate helper but takes the
+// resolved key as a parameter so the caller can hoist a single GetInfo
+// round-trip out of the per-outpoint loop.
+//
+// A nil currentOperatorKey means the surrounding handler is running
+// without the fetchOperatorKey seam (harness path) or with a deliberate
+// opt-out: the descriptor's stored bytes are returned verbatim. Non-
+// standard policy shapes trigger the same fallback because the rebuild
+// surface only covers the standard shape today.
+func composeRefreshTemplate(vtxo *VTXODescriptor,
+	currentOperatorKey *btcec.PublicKey) ([]byte, error) {
+
+	if currentOperatorKey == nil {
+		return vtxo.EffectivePolicyTemplate()
+	}
+
+	rebuilt, err := vtxo.RefreshOutputTemplate(currentOperatorKey)
+	if err != nil {
+		if errors.Is(err, ErrRefreshOperatorKeyUnsupported) {
+			return vtxo.EffectivePolicyTemplate()
+		}
+
+		return nil, err
+	}
+
+	return rebuilt, nil
 }
 
 // emitUTXOCreated posts a UTXOCreatedMsg to the client ledger
@@ -1347,6 +1410,52 @@ func (a *Ark) handleRefreshVTXOs(ctx context.Context,
 		})
 	}
 
+	// Resolve the operator key once for the whole batch. Every new VTXO
+	// minted in this round commits to the same key, so a single fresh
+	// GetInfo round-trip is enough — per-outpoint fetches would just
+	// fan the same answer out N times and could disagree under a
+	// concurrent rotation. A fetch error fails the whole RPC: refreshing
+	// against an unknown key would just queue a doomed intent. When the
+	// seam is unset (harness paths) resolvedOperatorKey stays nil and
+	// composeRefreshTemplate falls back to the descriptor's stored bytes.
+	var resolvedOperatorKey *btcec.PublicKey
+	if a.fetchOperatorKey != nil {
+		key, err := a.fetchOperatorKey(ctx)
+		if err != nil {
+			a.logger(ctx).WarnS(
+				ctx,
+				"Failed to fetch current operator key for "+
+					"refresh",
+				err,
+			)
+
+			return fn.Ok[WalletResp](&RefreshVTXOsResponse{
+				Errors: allTargetErrors(
+					req.TargetOutpoints,
+					fmt.Errorf("fetch current "+
+						"operator key: %w", err),
+				),
+			})
+		}
+
+		if key == nil {
+			err := fmt.Errorf("operator key fetch returned nil")
+			a.logger(ctx).WarnS(
+				ctx,
+				"Refresh aborted: nil operator key",
+				err,
+			)
+
+			return fn.Ok[WalletResp](&RefreshVTXOsResponse{
+				Errors: allTargetErrors(
+					req.TargetOutpoints, err,
+				),
+			})
+		}
+
+		resolvedOperatorKey = key
+	}
+
 	// Build intent package by loading each VTXO descriptor and
 	// constructing the corresponding forfeit + VTXO request pair.
 	var (
@@ -1376,7 +1485,16 @@ func (a *Ark) handleRefreshVTXOs(ctx context.Context,
 		// otherwise ship a Forfeits/VTXOs mismatch to
 		// RegisterIntentMsg and reserve a VTXO into
 		// PendingForfeitState with no replacement.
-		policyTemplate, err := vtxo.EffectivePolicyTemplate()
+		//
+		// composeRefreshTemplate uses the join-time operator key
+		// resolved above to rebuild the new output's template.
+		// The resolved key is nil when the fetchOperatorKey seam
+		// is unwired, in which case the helper falls back to the
+		// descriptor's stored bytes (harness paths and non-standard
+		// policy shapes).
+		policyTemplate, err := composeRefreshTemplate(
+			vtxo, resolvedOperatorKey,
+		)
 		if err != nil {
 			a.logger(ctx).WarnS(ctx,
 				"Failed to load refresh policy",


### PR DESCRIPTION
## Summary

Fixes #520. After an operator key rotation, the client's refresh path
silently constructed a `JoinRoundRequest` whose new VTXO output template
still carried the operator's pre-rotation key (K1), and the server
rejected the round with `ErrOperatorKeyMismatch`. This PR rebuilds the
new output's standard policy template against the operator's current
long-term key (K2) while leaving spend-time material for the old VTXO
untouched (it still has to commit to K1, because the on-chain output's
taproot tree was built against K1).

The cause sat in two places, both of which cloned the descriptor's stored
`PolicyTemplate` bytes verbatim into the new output:

- `vtxo/actor.go` — auto-refresh emission on expiry (`processOutbox` /
  `ForfeitRequest`).
- `wallet/wallet.go` — explicit `RefreshVTXOs` RPC handler
  (`handleRefreshVTXOs`).

Both now consult a `func() *btcec.PublicKey` provider wired in by
`darepod` from the cached `OperatorTerms` snapshot, and rebuild the new
output's template against the returned key. When the provider is unset
or the descriptor's stored policy is not the standard shape (vHTLC,
custom), the code falls back to the descriptor's stored bytes so legacy
paths and non-standard policies keep their current behavior.

## What's in the diff

- **`vtxo/policy.go`, `wallet/policy.go`** — new `RefreshOutputTemplate`
  helper on each descriptor type. Standard shape only; non-standard
  shapes return `ErrRefreshOperatorKeyUnsupported` so callers can fall
  back or surface rotation-specific UX explicitly.
- **`vtxo/actor.go`, `vtxo/manager.go`** — new `CurrentOperatorKey func()`
  field on `VTXOActorConfig` and `ManagerConfig` (manager forwards to
  each spawned actor). The auto-refresh emission goes through a new
  `refreshOutputTemplate` helper that prefers the rebuilt template and
  falls back to the stored bytes on non-standard shapes.
- **`wallet/wallet.go`** — new `WithCurrentOperatorKey` `ArkOption` and a
  parallel `refreshOutputTemplate` helper used by `handleRefreshVTXOs`.
- **`darepod/server.go`** — small `currentOperatorPubKey()` accessor that
  reads the cached `OperatorTerms`, wired into both `wallet.NewArk` and
  the `vtxo.ManagerConfig` at construction time.
- **`vtxo/refresh_operator_rotation_test.go`** — regression test with two
  subtests:
  - **rebuilds against rotated key when provider wired** — pins the fix:
    a `VTXOActor` configured with a `CurrentOperatorKey` returning K2
    emits a `RefreshVTXORequest` whose `PolicyTemplate` decodes to K2,
    not the K1 baked into the descriptor.
  - **falls back to stored template when provider unset** — pins the
    legacy path so harness tests and non-standard policy holders keep
    working unchanged.

## Design notes for review

1. **Forfeit and unilateral-exit material is intentionally untouched.**
   Only the new output's template is rewritten. The forfeit witness,
   control block, and unilateral exit script for the *input* VTXO still
   commit to K1 because that is what the on-chain output's taproot tree
   was built against. This matches the acceptance criteria in #520.

2. **Non-standard policies keep the legacy fallback.** vHTLC and other
   custom shapes still ship the stored bytes verbatim. A user holding a
   vHTLC VTXO under K1 across a rotation will see the same failure as
   before — out of scope for #520, but worth a follow-up if it matters.

3. **A nil provider is treated as 'not wired yet'.** The actor and wallet
   helpers fall back to `EffectivePolicyTemplate` so harnesses that don't
   mock `OperatorTerms` keep their current behavior.

## Test plan

- [x] `go test ./vtxo/ ./wallet/ ./darepod/ -count=1` — green
  (full unit suites for the three touched packages)
- [x] New regression test `TestRefreshEmissionUsesCurrentOperatorKey`
  passes both subtests
- [ ] Verify CI is green
- [ ] Recommended follow-up before bumping the submodule pointer in
  `darepo`: re-run the existing `TestRefreshIntegrationSingleVTXOLifecycle`
  itest against this branch to confirm the seal-time fee handshake and
  forfeit signing still work end-to-end through the new emission path
  (this PR's tests don't drive a real round).