### PR TITLE
btcwbackend: Wire neutrino header import

### DIFF
--- a/btcwbackend/config.go
+++ b/btcwbackend/config.go
@@ -37,6 +37,16 @@ type Config struct {
 	// ConnectPeers, DNS seeding still runs when AddPeers is set.
 	AddPeers []string
 
+	// BlockHeadersSource is a local file path or HTTP(S) URL that
+	// neutrino imports block headers from before falling back to P2P
+	// sync. It must be set together with FilterHeadersSource.
+	BlockHeadersSource string
+
+	// FilterHeadersSource is a local file path or HTTP(S) URL that
+	// neutrino imports compact filter headers from before falling back
+	// to P2P sync. It must be set together with BlockHeadersSource.
+	FilterHeadersSource string
+
 	// FeeURL is the URL for the fee estimation API endpoint. The
 	// endpoint must return JSON in the format expected by
 	// chainfee.SparseConfFeeSource. Required for btcwallet mode.

--- a/btcwbackend/neutrino.go
+++ b/btcwbackend/neutrino.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btclog/v2"
 	"github.com/btcsuite/btcwallet/chain"
@@ -81,8 +82,19 @@ func WithoutGlobalDependencyLoggers() NeutrinoServiceOption {
 // after construction.
 func NewNeutrinoService(dataDir string, chainParams *chaincfg.Params,
 	connectPeers, addPeers []string, persistFilters bool,
-	logger btclog.Logger,
+	blockHeadersSource, filterHeadersSource string, logger btclog.Logger,
 	opts ...NeutrinoServiceOption) (*NeutrinoService, error) {
+
+	if chainParams == nil {
+		return nil, fmt.Errorf("chain params are required")
+	}
+
+	headersImport, err := neutrinoHeadersImportConfig(
+		blockHeadersSource, filterHeadersSource,
+	)
+	if err != nil {
+		return nil, err
+	}
 
 	// Ensure the data directory exists before attempting to
 	// open or create the bbolt database. The daemon's
@@ -119,6 +131,7 @@ func NewNeutrinoService(dataDir string, chainParams *chaincfg.Params,
 		AddPeers:      addPeers,
 		BlockCache:    blockCache.Cache,
 		PersistToDisk: persistFilters,
+		HeadersImport: headersImport,
 	}
 
 	cs, err := neutrino.NewChainService(cfg)
@@ -143,6 +156,39 @@ func NewNeutrinoService(dataDir string, chainParams *chaincfg.Params,
 	}
 
 	return svc, nil
+}
+
+// neutrinoHeadersImportConfig validates and builds the optional neutrino
+// header import configuration used for fast initial sync.
+func neutrinoHeadersImportConfig(blockHeadersSource,
+	filterHeadersSource string) (*neutrino.HeadersImportConfig, error) {
+
+	blockSet := blockHeadersSource != ""
+	filterSet := filterHeadersSource != ""
+
+	if blockSet != filterSet {
+		return nil, fmt.Errorf("both block and filter header sources " +
+			"must be specified together for headers import")
+	}
+
+	if !blockSet {
+		return nil, nil
+	}
+
+	return &neutrino.HeadersImportConfig{
+		BlockHeadersSource:  blockHeadersSource,
+		FilterHeadersSource: filterHeadersSource,
+		ValidationFlags:     neutrinoHeadersImportValidationFlags(),
+	}, nil
+}
+
+// neutrinoHeadersImportValidationFlags returns validation flags for imported
+// headers. The import path already validates network magic, header linkage, and
+// header sanity. BFFastAdd keeps that behavior aligned with neutrino's normal
+// headers-first sync path, where historical public-network headers may be added
+// without replaying every contextual timestamp and difficulty check.
+func neutrinoHeadersImportValidationFlags() blockchain.BehaviorFlags {
+	return blockchain.BFFastAdd
 }
 
 // Start begins the neutrino chain service, connecting to peers and

--- a/btcwbackend/neutrino_test.go
+++ b/btcwbackend/neutrino_test.go
@@ -1,0 +1,47 @@
+package btcwbackend
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/blockchain"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNeutrinoHeadersImportConfig verifies that btcwallet fast-sync header
+// sources are validated and mapped into neutrino's import configuration.
+func TestNeutrinoHeadersImportConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := neutrinoHeadersImportConfig("", "")
+	require.NoError(t, err)
+	require.Nil(t, cfg)
+
+	cfg, err = neutrinoHeadersImportConfig("blocks.bin", "filters.bin")
+	require.NoError(t, err)
+	require.Equal(t, "blocks.bin", cfg.BlockHeadersSource)
+	require.Equal(t, "filters.bin", cfg.FilterHeadersSource)
+	require.Equal(t, blockchain.BFFastAdd, cfg.ValidationFlags)
+}
+
+// TestNewNeutrinoServiceRequiresChainParams checks that invalid chain params
+// fail before the service touches filesystem or database resources.
+func TestNewNeutrinoServiceRequiresChainParams(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewNeutrinoService(
+		t.TempDir(), nil, nil, nil, false, "", "", nil,
+	)
+	require.ErrorContains(t, err, "chain params are required")
+}
+
+// TestNeutrinoHeadersImportConfigRequiresBothSources checks that a partial
+// import configuration fails before neutrino opens the P2P backend.
+func TestNeutrinoHeadersImportConfigRequiresBothSources(t *testing.T) {
+	t.Parallel()
+
+	_, err := neutrinoHeadersImportConfig("blocks.bin", "")
+	require.ErrorContains(t, err, "must be specified together")
+
+	_, err = neutrinoHeadersImportConfig("", "filters.bin")
+	require.ErrorContains(t, err, "must be specified together")
+}

--- a/btcwbackend/wallet.go
+++ b/btcwbackend/wallet.go
@@ -65,7 +65,8 @@ func New(cfg Config) (*Wallet, error) {
 	// Create and start the neutrino chain service.
 	neutrinoSvc, err := NewNeutrinoService(
 		neutrinoDataDir, cfg.ChainParams, cfg.ConnectPeers,
-		cfg.AddPeers, cfg.PersistFilters, walletLog, neutrinoOpts...,
+		cfg.AddPeers, cfg.PersistFilters, cfg.BlockHeadersSource,
+		cfg.FilterHeadersSource, walletLog, neutrinoOpts...,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("create neutrino service: %w", err)

--- a/cmd/darepod/main.go
+++ b/cmd/darepod/main.go
@@ -137,6 +137,16 @@ func newRootCmd() *cobra.Command {
 		"wallet.feeurl", cfg.Wallet.FeeURL,
 		"fee-estimate JSON endpoint URL (required for btcwallet)",
 	)
+	f.String(
+		"wallet.btcwallet_blockheaderssource",
+		cfg.Wallet.BtcwBlockSource,
+		"block header import source for btcwallet fast sync",
+	)
+	f.String(
+		"wallet.btcwallet_filterheaderssource",
+		cfg.Wallet.BtcwFilterSource,
+		"filter header import source for btcwallet fast sync",
+	)
 	f.Duration(
 		"wallet.pollinterval", cfg.Wallet.PollInterval,
 		"chain poll interval for lwwallet backend",

--- a/darepod/config.go
+++ b/darepod/config.go
@@ -579,6 +579,16 @@ type WalletConfig struct {
 	// "btcwallet".
 	BtcwalletAddPeers []string `mapstructure:"btcwallet_addpeers"`
 
+	// BtcwBlockSource is a local file path or HTTP(S)
+	// URL that neutrino imports block headers from on startup.
+	// Only used when Type is "btcwallet".
+	BtcwBlockSource string `mapstructure:"btcwallet_blockheaderssource"`
+
+	// BtcwFilterSource is a local file path or HTTP(S)
+	// URL that neutrino imports compact filter headers from on
+	// startup. Only used when Type is "btcwallet".
+	BtcwFilterSource string `mapstructure:"btcwallet_filterheaderssource"`
+
 	// BtcwalletDataDir is the directory for neutrino's chain data
 	// (headers, cfilters). Defaults to the network data directory.
 	// Only used when Type is "btcwallet".
@@ -701,6 +711,10 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("wallet.feeurl is required when " +
 				"wallet.type is btcwallet")
 		}
+		err := c.Wallet.validateBtcwalletHeadersImportConfig()
+		if err != nil {
+			return err
+		}
 
 	default:
 		return fmt.Errorf("unknown wallet type %q, valid values: lnd, "+
@@ -744,6 +758,21 @@ func (c *Config) Validate() error {
 		c.RPC.Gateway.AllowedOrigins,
 	); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// validateBtcwalletHeadersImportConfig checks that header import sources are
+// configured as the pair that neutrino requires.
+func (w *WalletConfig) validateBtcwalletHeadersImportConfig() error {
+	blockSet := w.BtcwBlockSource != ""
+	filterSet := w.BtcwFilterSource != ""
+
+	if blockSet != filterSet {
+		return fmt.Errorf("both wallet.btcwallet_blockheaderssource " +
+			"and wallet.btcwallet_filterheaderssource must be " +
+			"specified together for headers import")
 	}
 
 	return nil

--- a/darepod/config_btcwallet_headers_import_test.go
+++ b/darepod/config_btcwallet_headers_import_test.go
@@ -1,0 +1,63 @@
+package darepod
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestConfigValidateBtcwalletHeadersImport checks that btcwallet header import
+// sources are either configured as a complete pair or omitted.
+func TestConfigValidateBtcwalletHeadersImport(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		blockSource  string
+		filterSource string
+		wantErr      string
+	}{
+		{
+			name: "unset",
+		},
+		{
+			name:         "both set",
+			blockSource:  "blocks.bin",
+			filterSource: "filters.bin",
+		},
+		{
+			name:        "block only",
+			blockSource: "blocks.bin",
+			wantErr:     "must be specified together",
+		},
+		{
+			name:         "filter only",
+			filterSource: "filters.bin",
+			wantErr:      "must be specified together",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := DefaultConfig()
+			cfg.Network = "regtest"
+			cfg.Wallet.Type = WalletTypeBtcwallet
+			cfg.Wallet.FeeURL = "http://127.0.0.1:3001"
+			cfg.Wallet.BtcwBlockSource = tc.blockSource
+			cfg.Wallet.BtcwFilterSource = tc.filterSource
+
+			err := cfg.Validate()
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -1555,6 +1555,7 @@ func (s *Server) preStartNeutrino(ctx context.Context) error {
 	svc, err := btcwbackend.NewNeutrinoService(
 		neutrinoDataDir, s.chainParams, s.cfg.Wallet.BtcwalletPeers,
 		s.cfg.Wallet.BtcwalletAddPeers, s.cfg.Wallet.PersistFilters,
+		s.cfg.Wallet.BtcwBlockSource, s.cfg.Wallet.BtcwFilterSource,
 		walletLog, neutrinoOpts...,
 	)
 	if err != nil {
@@ -1605,6 +1606,8 @@ func (s *Server) startBtcwallet(ctx context.Context,
 		NeutrinoDataDir:      s.cfg.Wallet.BtcwalletDataDir,
 		ConnectPeers:         s.cfg.Wallet.BtcwalletPeers,
 		AddPeers:             s.cfg.Wallet.BtcwalletAddPeers,
+		BlockHeadersSource:   s.cfg.Wallet.BtcwBlockSource,
+		FilterHeadersSource:  s.cfg.Wallet.BtcwFilterSource,
 		FeeURL:               s.cfg.Wallet.FeeURL,
 		PackageSubmitter:     s.cfg.PackageSubmitter,
 		PersistFilters:       s.cfg.Wallet.PersistFilters,

--- a/docs/daemon_cli_guide.md
+++ b/docs/daemon_cli_guide.md
@@ -100,11 +100,14 @@ darepod \
 | `--debuglevel` | `info` | Logging verbosity: trace, debug, info, warn, error, critical |
 | `--logdir` | `~/.darepod/logs/<network>` | Directory for persistent daemon logs |
 | `--allow-mainnet` | `false` | Required to run on mainnet (safety guard) |
-| `--wallet.type` | `lwwallet` | Wallet backend: `lwwallet` or `lnd` |
+| `--wallet.type` | `lwwallet` | Wallet backend: `lwwallet`, `lnd`, or `btcwallet` |
 | `--wallet.esploraurl` | | Esplora REST API URL (lwwallet only) |
+| `--wallet.feeurl` | | Fee-estimate JSON endpoint URL (btcwallet only) |
+| `--wallet.btcwallet_blockheaderssource` | | Block header import source for btcwallet fast sync |
+| `--wallet.btcwallet_filterheaderssource` | | Filter header import source for btcwallet fast sync |
 | `--wallet.pollinterval` | `5s` | Esplora poll interval (lwwallet only) |
 | `--wallet.recoverywindow` | `100` | Address look-ahead window (lwwallet only) |
-| `--wallet.password_file` | | Auto-unlock password file path (lwwallet only) |
+| `--wallet.password_file` | | Auto-unlock password file path (lwwallet/btcwallet) |
 | `--lnd.host` | `localhost:10009` | lnd gRPC address |
 | `--lnd.tlspath` | | Path to lnd TLS certificate |
 | `--lnd.macaroonpath` | | Path to lnd admin macaroon |

--- a/sample-darepod.conf
+++ b/sample-darepod.conf
@@ -112,6 +112,11 @@
 # Additional persistent neutrino peers for btcwallet, as a comma-separated list.
 # wallet.btcwallet_addpeers=
 
+# Headers import for btcwallet fast initial sync. Both sources must be set
+# together. Values can be local files or HTTP(S) URLs.
+# wallet.btcwallet_blockheaderssource=
+# wallet.btcwallet_filterheaderssource=
+
 # Directory for btcwallet/neutrino chain data. Empty uses the network data dir.
 # wallet.btcwallet_datadir=
 

--- a/sdk/walletdk/embedded.go
+++ b/sdk/walletdk/embedded.go
@@ -23,19 +23,23 @@ func DefaultConfig() Config {
 	cfg := darepod.DefaultConfig()
 
 	return Config{
-		DataDir:               cfg.DataDir,
-		Network:               cfg.Network,
-		DebugLevel:            cfg.DebugLevel,
-		ServerAddress:         cfg.Server.Host,
-		ServerTransport:       Transport(cfg.Server.Transport),
-		ServerTLSCertPath:     cfg.Server.TLSCertPath,
-		ServerInsecure:        cfg.Server.Insecure,
-		WalletType:            cfg.Wallet.Type,
-		WalletEsploraURL:      cfg.Wallet.EsploraURL,
-		WalletPasswordFile:    cfg.Wallet.PasswordFile,
-		WalletPollInterval:    cfg.Wallet.PollInterval,
-		WalletRecoveryWindow:  cfg.Wallet.RecoveryWindow,
-		WalletFeeURL:          cfg.Wallet.FeeURL,
+		DataDir:              cfg.DataDir,
+		Network:              cfg.Network,
+		DebugLevel:           cfg.DebugLevel,
+		ServerAddress:        cfg.Server.Host,
+		ServerTransport:      Transport(cfg.Server.Transport),
+		ServerTLSCertPath:    cfg.Server.TLSCertPath,
+		ServerInsecure:       cfg.Server.Insecure,
+		WalletType:           cfg.Wallet.Type,
+		WalletEsploraURL:     cfg.Wallet.EsploraURL,
+		WalletPasswordFile:   cfg.Wallet.PasswordFile,
+		WalletPollInterval:   cfg.Wallet.PollInterval,
+		WalletRecoveryWindow: cfg.Wallet.RecoveryWindow,
+		WalletFeeURL:         cfg.Wallet.FeeURL,
+		WalletBtcwalletBlockHeadersSource: cfg.Wallet.
+			BtcwBlockSource,
+		WalletBtcwalletFilterHeadersSource: cfg.Wallet.
+			BtcwFilterSource,
 		SwapServerAddress:     cfg.Swap.ServerAddress,
 		SwapServerTransport:   Transport(cfg.Swap.ServerTransport),
 		SwapServerTLSCertPath: cfg.Swap.ServerTLSCertPath,
@@ -288,6 +292,14 @@ func applyConfigOverrides(daemonCfg *darepod.Config, cfg Config) {
 	}
 	if cfg.WalletFeeURL != "" {
 		daemonCfg.Wallet.FeeURL = cfg.WalletFeeURL
+	}
+	if cfg.WalletBtcwalletBlockHeadersSource != "" {
+		daemonCfg.Wallet.BtcwBlockSource =
+			cfg.WalletBtcwalletBlockHeadersSource
+	}
+	if cfg.WalletBtcwalletFilterHeadersSource != "" {
+		daemonCfg.Wallet.BtcwFilterSource =
+			cfg.WalletBtcwalletFilterHeadersSource
 	}
 
 	if daemonCfg.Swap == nil {

--- a/sdk/walletdk/embedded_config.go
+++ b/sdk/walletdk/embedded_config.go
@@ -66,6 +66,15 @@ type Config struct {
 	// WalletFeeURL is the fee estimator endpoint used by btcwallet.
 	WalletFeeURL string
 
+	// WalletBtcwalletBlockHeadersSource is a local file path or HTTP(S)
+	// URL that btcwallet/neutrino imports block headers from on startup.
+	WalletBtcwalletBlockHeadersSource string
+
+	// WalletBtcwalletFilterHeadersSource is a local file path or HTTP(S)
+	// URL that btcwallet/neutrino imports compact filter headers from on
+	// startup.
+	WalletBtcwalletFilterHeadersSource string
+
 	// SwapServerAddress is the swapdk-server address for the selected
 	// transport.
 	SwapServerAddress string


### PR DESCRIPTION
## Summary

- expose btcwallet/neutrino block and filter header import sources
- validate that both sources are configured together
- pass import options through daemon startup and walletdk embedding
- document the new config knobs

## Tests

- make unit pkg=./btcwbackend timeout=5m
- make unit pkg=./darepod timeout=5m
- make unit pkg=./cmd/darepod timeout=5m
- make unit pkg=./sdk/walletdk timeout=5m
- make lint-changed-local
- make commitmsg-lint commit=HEAD