### PR TITLE
docs: nightly doc-gardening sweep 2026-05-24

### DIFF
--- a/darepod/AGENTS.md
+++ b/darepod/AGENTS.md
@@ -157,11 +157,11 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/darep
   spend notifications per input, marks inputs spent on confirmation.
   Started by `startBoardingSweepWatcher` on wallet unlock;
   idempotent.
-- `boardingSweepTx` / `buildBoardingSweepTx` — constructs and signs
-  one aggregate timeout-path sweep tx. Iterates the weight estimate
-  up to three times until `SerializeSize` converges so `fee`/`txid`
-  are accurate. Validates `defaultBoardingSweepMaxFeePercent = 25%`
-  and `defaultBoardingSweepMaxInputs = 100`.
+- `newBoardingStore` / `newSweepWallet` — factory helpers constructing
+  the `db.BoardingWalletStore` and the per-backend `unroll.SweepWallet`
+  / `wallet.SweepSigner` adapter (lndUnrollWallet / lwUnrollWallet /
+  btcwUnrollWallet). The boarding-sweep build logic itself lives in
+  `wallet/boarding_sweep.go`.
 - `deriveIdentityKeyEarly` — derives the client's secp256k1 identity
   key from LND or lwwallet before mailbox transport starts.
 - `signMailboxAuth` — Schnorr auth. LND uses the tagged Schnorr

--- a/darepod/CLAUDE.md
+++ b/darepod/CLAUDE.md
@@ -157,11 +157,11 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/darep
   spend notifications per input, marks inputs spent on confirmation.
   Started by `startBoardingSweepWatcher` on wallet unlock;
   idempotent.
-- `boardingSweepTx` / `buildBoardingSweepTx` — constructs and signs
-  one aggregate timeout-path sweep tx. Iterates the weight estimate
-  up to three times until `SerializeSize` converges so `fee`/`txid`
-  are accurate. Validates `defaultBoardingSweepMaxFeePercent = 25%`
-  and `defaultBoardingSweepMaxInputs = 100`.
+- `newBoardingStore` / `newSweepWallet` — factory helpers constructing
+  the `db.BoardingWalletStore` and the per-backend `unroll.SweepWallet`
+  / `wallet.SweepSigner` adapter (lndUnrollWallet / lwUnrollWallet /
+  btcwUnrollWallet). The boarding-sweep build logic itself lives in
+  `wallet/boarding_sweep.go`.
 - `deriveIdentityKeyEarly` — derives the client's secp256k1 identity
   key from LND or lwwallet before mailbox transport starts.
 - `signMailboxAuth` — Schnorr auth. LND uses the tagged Schnorr

--- a/serverconn/mailboxpull/AGENTS.md
+++ b/serverconn/mailboxpull/AGENTS.md
@@ -1,0 +1,53 @@
+# serverconn/mailboxpull
+
+## Purpose
+
+Shared retry-and-backoff primitives for mailbox pull loops. Factors out the
+uniform exponential-backoff-with-jitter pattern used by both the persistent
+identity-mailbox ingress loop in `serverconn` and per-swap event consumers in
+`sdk/swaps`, so reliability semantics stay consistent across callers.
+
+## Key Types
+
+- `BackoffConfig` — Exponential backoff parameters: `BaseDelay` (default 200 ms)
+  and `MaxDelay` (default 30 s). Zero-value selects the package defaults, so
+  `BackoffConfig{}` is valid and produces a non-busy retry loop.
+- `DefaultBackoffConfig()` — Returns the production defaults matching
+  `serverconn.DefaultConnectorConfig` so the daemon ingress loop and SDK pull
+  loops back off identically.
+- `PullWithRetry(ctx, edge, req, cfg, log)` — Calls `edge.Pull` in a loop,
+  retrying transport errors with exponential backoff until success or ctx
+  cancellation. Preserves the caller's cursor across retries; returns
+  `ctx.Err()` (not the transport error) on cancellation so callers can
+  distinguish shutdown from a flapping endpoint. Status-level failures
+  (`resp.Status` non-nil with `Ok=false`) are passed through without retry.
+- `RetryDelay(cfg, attempt)` — Computes one backoff duration: `min(base *
+  2^(attempt-1), max) * U[0.5, 1.0)`. Non-cryptographic jitter spreads
+  concurrent retriers to prevent thundering-herd on a shared endpoint.
+- `Sleep(ctx, cfg, attempt)` — Increments `*attempt` and sleeps for the next
+  backoff interval, respecting ctx cancellation.
+
+## Relationships
+
+- **Depends on**: `mailbox/pb` (`MailboxServiceClient`, `PullRequest`,
+  `PullResponse`).
+- **Depended on by**: `serverconn` (identity-mailbox ingress loop),
+  `sdk/swaps` (per-swap out-swap HTLC event pull loop via
+  `MailboxOutSwapEventReceiver`).
+
+## Invariants
+
+- `PullWithRetry` never mutates `req`; cursor state is owned by the caller
+  and survives across reconnects.
+- Context cancellation always takes precedence over transport errors: the
+  post-Pull `ctx.Err()` check runs before the backoff sleep so a
+  cancellation mid-retry surfaces as `ctx.Err()`, not the transport error.
+- `BackoffConfig{}` (zero value) is valid and uses the package defaults
+  (200 ms base, 30 s cap) — callers that do not care about tuning need not
+  initialize the struct.
+
+## Deep Docs
+
+- [serverconn/CLAUDE.md](../CLAUDE.md) — Parent package; wires the ingress
+  loop that consumes this helper.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/serverconn/mailboxpull/CLAUDE.md
+++ b/serverconn/mailboxpull/CLAUDE.md
@@ -1,0 +1,53 @@
+# serverconn/mailboxpull
+
+## Purpose
+
+Shared retry-and-backoff primitives for mailbox pull loops. Factors out the
+uniform exponential-backoff-with-jitter pattern used by both the persistent
+identity-mailbox ingress loop in `serverconn` and per-swap event consumers in
+`sdk/swaps`, so reliability semantics stay consistent across callers.
+
+## Key Types
+
+- `BackoffConfig` — Exponential backoff parameters: `BaseDelay` (default 200 ms)
+  and `MaxDelay` (default 30 s). Zero-value selects the package defaults, so
+  `BackoffConfig{}` is valid and produces a non-busy retry loop.
+- `DefaultBackoffConfig()` — Returns the production defaults matching
+  `serverconn.DefaultConnectorConfig` so the daemon ingress loop and SDK pull
+  loops back off identically.
+- `PullWithRetry(ctx, edge, req, cfg, log)` — Calls `edge.Pull` in a loop,
+  retrying transport errors with exponential backoff until success or ctx
+  cancellation. Preserves the caller's cursor across retries; returns
+  `ctx.Err()` (not the transport error) on cancellation so callers can
+  distinguish shutdown from a flapping endpoint. Status-level failures
+  (`resp.Status` non-nil with `Ok=false`) are passed through without retry.
+- `RetryDelay(cfg, attempt)` — Computes one backoff duration: `min(base *
+  2^(attempt-1), max) * U[0.5, 1.0)`. Non-cryptographic jitter spreads
+  concurrent retriers to prevent thundering-herd on a shared endpoint.
+- `Sleep(ctx, cfg, attempt)` — Increments `*attempt` and sleeps for the next
+  backoff interval, respecting ctx cancellation.
+
+## Relationships
+
+- **Depends on**: `mailbox/pb` (`MailboxServiceClient`, `PullRequest`,
+  `PullResponse`).
+- **Depended on by**: `serverconn` (identity-mailbox ingress loop),
+  `sdk/swaps` (per-swap out-swap HTLC event pull loop via
+  `MailboxOutSwapEventReceiver`).
+
+## Invariants
+
+- `PullWithRetry` never mutates `req`; cursor state is owned by the caller
+  and survives across reconnects.
+- Context cancellation always takes precedence over transport errors: the
+  post-Pull `ctx.Err()` check runs before the backoff sleep so a
+  cancellation mid-retry surfaces as `ctx.Err()`, not the transport error.
+- `BackoffConfig{}` (zero value) is valid and uses the package defaults
+  (200 ms base, 30 s cap) — callers that do not care about tuning need not
+  initialize the struct.
+
+## Deep Docs
+
+- [serverconn/CLAUDE.md](../CLAUDE.md) — Parent package; wires the ingress
+  loop that consumes this helper.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/wallet/AGENTS.md
+++ b/wallet/AGENTS.md
@@ -34,6 +34,16 @@ refresh, leave, OOR spend, and directed send flows.
 - `SendVTXOsRequest` / `SendVTXOsResponse` — Ask-request for in-round directed sends. Validates each recipient amount is within `(0, MaxSatoshi]` and that the running total never overflows `int64`, atomically selects and reserves VTXOs via `SelectAndReserveForfeitRequest`, builds forfeit + recipient VTXO intents, and registers with the round actor. Supports dry-run mode for previewing coin selection without committing. Reserved VTXOs are released via a deferred cleanup that uses `context.WithoutCancel` so cleanup survives caller disconnect; on success, a `committed` flag is set to skip the release.
 - `GetConfirmedBoardingIntentsRequest` / `GetConfirmedBoardingIntentsResponse` — Ask-request to retrieve currently confirmed boarding intents (used by the RPC/CLI layer to report boarding balance with policy metadata).
 - `VTXODescriptor.EffectivePolicyTemplate` — Decodes the serialized `PolicyTemplate` field on the wallet-level VTXO descriptor using `lib/arkscript`.
+- `SweepSigner` — Interface for signing boarding timeout-path sweep inputs and deriving destination pkScripts. Mirrors `unroll.SweepWallet` so the same per-backend adapters (`lndUnrollWallet`, `lwUnrollWallet`, `btcwUnrollWallet`) satisfy both without modification.
+- `BoardingSweepStore` — Persistence interface for aggregate boarding-timeout sweeps: create, publish, fail, mark inputs spent, list, and query individual records.
+- `BoardingSweepRecord` — Persisted view of one aggregate sweep: `Txid`, `Tx`, `TotalAmount`, `FeeAmount`, `Status`, `CreatedHeight`, `ConfirmedHeight`, `Inputs []BoardingSweepInputRecord`.
+- `NewBoardingSweep` / `NewBoardingSweepInput` / `BoardingSweepInputRecord` / `BoardingSweepOutput` — Write-side and read-side models for the boarding sweep persistence layer.
+- `SweepBoardingUTXOsRequest` — Ask-request to build, sign, and optionally broadcast an aggregate timeout-path sweep. When `Broadcast=false` returns a fee preview without persisting or broadcasting.
+- `ResumeBoardingSweepsRequest` — Self-Tell sent at startup (or via `WithBoardingSweep`) to re-arm per-input spend watches and resubmit pending sweeps to the broadcaster.
+- `BoardingSweepTxNotification` — Tell carrying a `txconfirm` terminal notification (confirmation or failure) for a tracked sweep tx.
+- `BoardingSweepSpendNotification` — Tell from chainsource when a watched boarding input is spent on-chain.
+- `BoardingSweepNotificationAck` — Ack for spend notifications after the actor has processed them.
+- `WithBoardingSweep(store, signer, chainParams)` — `ArkOption` that wires the boarding-sweep subsystem into the wallet actor. When omitted, sweep RPCs return a clear "subsystem not initialised" error.
 
 ## Relationships
 
@@ -52,7 +62,9 @@ refresh, leave, OOR spend, and directed send flows.
 - **Receives**:
   - ← `chainsource`: `BlockEpochNotification` (triggers UTXO polling)
   - ← `round`: `RegisterConfirmationNotifierRequest`, `UnregisterConfirmationNotifierRequest`
-  - ← API: `CreateBoardingAddressRequest`, `GetActiveBoardingAddressesRequest`, `GetBoardingBalanceRequest`, `GetConfirmedBoardingIntentsRequest`, `RefreshVTXOsRequest`, `SelectAndLockVTXOsRequest`, `LeaveVTXOsRequest`, `BoardRequest`, `CompleteSpendVTXOsRequest`, `UnlockVTXOsRequest`, `SendVTXOsRequest`
+  - ← API: `CreateBoardingAddressRequest`, `GetActiveBoardingAddressesRequest`, `GetBoardingBalanceRequest`, `GetConfirmedBoardingIntentsRequest`, `RefreshVTXOsRequest`, `SelectAndLockVTXOsRequest`, `LeaveVTXOsRequest`, `BoardRequest`, `CompleteSpendVTXOsRequest`, `UnlockVTXOsRequest`, `SendVTXOsRequest`, `SweepBoardingUTXOsRequest`, `ResumeBoardingSweepsRequest`
+  - ← `txconfirm`: `BoardingSweepTxNotification` (terminal confirmation/failure for tracked sweep txs)
+  - ← `chainsource`: `BoardingSweepSpendNotification` (confirmed spend of a watched boarding input)
 
 ## Invariants
 

--- a/wallet/CLAUDE.md
+++ b/wallet/CLAUDE.md
@@ -34,6 +34,16 @@ refresh, leave, OOR spend, and directed send flows.
 - `SendVTXOsRequest` / `SendVTXOsResponse` — Ask-request for in-round directed sends. Validates each recipient amount is within `(0, MaxSatoshi]` and that the running total never overflows `int64`, atomically selects and reserves VTXOs via `SelectAndReserveForfeitRequest`, builds forfeit + recipient VTXO intents, and registers with the round actor. Supports dry-run mode for previewing coin selection without committing. Reserved VTXOs are released via a deferred cleanup that uses `context.WithoutCancel` so cleanup survives caller disconnect; on success, a `committed` flag is set to skip the release.
 - `GetConfirmedBoardingIntentsRequest` / `GetConfirmedBoardingIntentsResponse` — Ask-request to retrieve currently confirmed boarding intents (used by the RPC/CLI layer to report boarding balance with policy metadata).
 - `VTXODescriptor.EffectivePolicyTemplate` — Decodes the serialized `PolicyTemplate` field on the wallet-level VTXO descriptor using `lib/arkscript`.
+- `SweepSigner` — Interface for signing boarding timeout-path sweep inputs and deriving destination pkScripts. Mirrors `unroll.SweepWallet` so the same per-backend adapters (`lndUnrollWallet`, `lwUnrollWallet`, `btcwUnrollWallet`) satisfy both without modification.
+- `BoardingSweepStore` — Persistence interface for aggregate boarding-timeout sweeps: create, publish, fail, mark inputs spent, list, and query individual records.
+- `BoardingSweepRecord` — Persisted view of one aggregate sweep: `Txid`, `Tx`, `TotalAmount`, `FeeAmount`, `Status`, `CreatedHeight`, `ConfirmedHeight`, `Inputs []BoardingSweepInputRecord`.
+- `NewBoardingSweep` / `NewBoardingSweepInput` / `BoardingSweepInputRecord` / `BoardingSweepOutput` — Write-side and read-side models for the boarding sweep persistence layer.
+- `SweepBoardingUTXOsRequest` — Ask-request to build, sign, and optionally broadcast an aggregate timeout-path sweep. When `Broadcast=false` returns a fee preview without persisting or broadcasting.
+- `ResumeBoardingSweepsRequest` — Self-Tell sent at startup (or via `WithBoardingSweep`) to re-arm per-input spend watches and resubmit pending sweeps to the broadcaster.
+- `BoardingSweepTxNotification` — Tell carrying a `txconfirm` terminal notification (confirmation or failure) for a tracked sweep tx.
+- `BoardingSweepSpendNotification` — Tell from chainsource when a watched boarding input is spent on-chain.
+- `BoardingSweepNotificationAck` — Ack for spend notifications after the actor has processed them.
+- `WithBoardingSweep(store, signer, chainParams)` — `ArkOption` that wires the boarding-sweep subsystem into the wallet actor. When omitted, sweep RPCs return a clear "subsystem not initialised" error.
 
 ## Relationships
 
@@ -52,7 +62,9 @@ refresh, leave, OOR spend, and directed send flows.
 - **Receives**:
   - ← `chainsource`: `BlockEpochNotification` (triggers UTXO polling)
   - ← `round`: `RegisterConfirmationNotifierRequest`, `UnregisterConfirmationNotifierRequest`
-  - ← API: `CreateBoardingAddressRequest`, `GetActiveBoardingAddressesRequest`, `GetBoardingBalanceRequest`, `GetConfirmedBoardingIntentsRequest`, `RefreshVTXOsRequest`, `SelectAndLockVTXOsRequest`, `LeaveVTXOsRequest`, `BoardRequest`, `CompleteSpendVTXOsRequest`, `UnlockVTXOsRequest`, `SendVTXOsRequest`
+  - ← API: `CreateBoardingAddressRequest`, `GetActiveBoardingAddressesRequest`, `GetBoardingBalanceRequest`, `GetConfirmedBoardingIntentsRequest`, `RefreshVTXOsRequest`, `SelectAndLockVTXOsRequest`, `LeaveVTXOsRequest`, `BoardRequest`, `CompleteSpendVTXOsRequest`, `UnlockVTXOsRequest`, `SendVTXOsRequest`, `SweepBoardingUTXOsRequest`, `ResumeBoardingSweepsRequest`
+  - ← `txconfirm`: `BoardingSweepTxNotification` (terminal confirmation/failure for tracked sweep txs)
+  - ← `chainsource`: `BoardingSweepSpendNotification` (confirmed spend of a watched boarding input)
 
 ## Invariants
 


### PR DESCRIPTION
Automated nightly documentation sweep for 2026-05-24.

**Changes:**
- Added `serverconn/mailboxpull/CLAUDE.md` + `AGENTS.md` (new hand-written package missing docs)
- Updated `wallet/CLAUDE.md` + `AGENTS.md` to document new boarding-sweep types (`SweepSigner`, `BoardingSweepStore`, `BoardingSweepRecord`, `SweepBoardingUTXOsRequest`, `ResumeBoardingSweepsRequest`, and related notification types added in the boarding-sweep refactor)
- Updated `darepod/CLAUDE.md` + `AGENTS.md` to fix stale reference to `boardingSweepTx`/`buildBoardingSweepTx` (moved to `wallet/boarding_sweep.go`)

Please review the updated CLAUDE.md/AGENTS.md diffs for accuracy.
