### PR TITLE
docs: nightly doc-gardening sweep 2026-05-25

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -47,6 +47,7 @@ package may import from a higher layer.
 | [`db`](db/) | SQLite/PostgreSQL persistence: boarding, rounds, VTXOs, OOR artifacts, fee ledger |
 | [`mailbox`](mailbox/) | Mailbox protocol primitives across three sub-packages (pb, rpc, conn) |
 | [`serverconn`](serverconn/) | Unified server connector: durable egress, ingress polling, unary RPC facade |
+| [`serverconn/mailboxpull`](serverconn/mailboxpull/) | Shared retry-and-backoff primitives for mailbox pull loops (backoff config, `PullWithRetry`) |
 
 ### Layer 3: Application & Orchestration
 

--- a/baselib/actor/AGENTS.md
+++ b/baselib/actor/AGENTS.md
@@ -68,6 +68,13 @@ crash-safe at-least-once delivery with exactly-once deduplication.
 - Transaction context (`WithTx`/`RequireTx`) enables same-DB-transaction joining between actors and their callers.
 - `Mailbox.Send` returns the exact failure error (`ErrMailboxClosed`, `ErrActorTerminated`, `context.Canceled`, `context.DeadlineExceeded`) rather than a boolean; `Tell` and `Ask` propagate this directly to callers.
 - During daemon teardown, the underlying DB is closed before every actor's lease loop has wound down. The lease loop uses `isExpectedShutdownErr` to demote these "database is closed" errors to debug level; real operational errors still surface as warnings because neither the actor context nor the outer context is done in those cases.
+- **Durable bookkeeping context isolation during shutdown**: message ack
+  and deduplication marker writes use `context.WithoutCancel(ctx)` wrapped
+  with `cleanupTimeout` so bookkeeping completes atomically even when
+  `Stop()` is called concurrently. This prevents a SQLite race where
+  database/sql auto-rolls-back a context-bound transaction while modernc
+  sqlite is still executing it, and ensures at-least-once delivery
+  guarantees hold through the stop sequence.
 - **Per-correlation-key FIFO claim.** Two messages in the same mailbox that
   share a non-empty `CorrelationKey()` are processed in emission order
   regardless of retry backoff. Without this invariant, a transient Tell

--- a/baselib/actor/CLAUDE.md
+++ b/baselib/actor/CLAUDE.md
@@ -68,6 +68,13 @@ crash-safe at-least-once delivery with exactly-once deduplication.
 - Transaction context (`WithTx`/`RequireTx`) enables same-DB-transaction joining between actors and their callers.
 - `Mailbox.Send` returns the exact failure error (`ErrMailboxClosed`, `ErrActorTerminated`, `context.Canceled`, `context.DeadlineExceeded`) rather than a boolean; `Tell` and `Ask` propagate this directly to callers.
 - During daemon teardown, the underlying DB is closed before every actor's lease loop has wound down. The lease loop uses `isExpectedShutdownErr` to demote these "database is closed" errors to debug level; real operational errors still surface as warnings because neither the actor context nor the outer context is done in those cases.
+- **Durable bookkeeping context isolation during shutdown**: message ack
+  and deduplication marker writes use `context.WithoutCancel(ctx)` wrapped
+  with `cleanupTimeout` so bookkeeping completes atomically even when
+  `Stop()` is called concurrently. This prevents a SQLite race where
+  database/sql auto-rolls-back a context-bound transaction while modernc
+  sqlite is still executing it, and ensures at-least-once delivery
+  guarantees hold through the stop sequence.
 - **Per-correlation-key FIFO claim.** Two messages in the same mailbox that
   share a non-empty `CorrelationKey()` are processed in emission order
   regardless of retry backoff. Without this invariant, a transient Tell

--- a/btcwbackend/AGENTS.md
+++ b/btcwbackend/AGENTS.md
@@ -12,8 +12,19 @@ or LND node.
 - `Wallet` — Top-level wallet wrapping `walletcore.Wallet` with neutrino chain service, chain backend, and boarding adapter. Constructors: `New` (owns neutrino lifecycle) and `NewWithNeutrino` (reuses pre-started service).
 - `NeutrinoService` — Manages the neutrino `ChainService`, its bbolt DB, and lifecycle. Pre-started by the daemon for early P2P sync.
 - `ChainBackend` — Implements `chainsource.ChainBackend` using neutrino's native `ChainNotifier` for confirmation tracking, spend detection, fee estimation, and optional direct package relay via `chainbackends.PackageSubmitter`.
-- `BoardingBackendAdapter` — Implements `wallet.BoardingBackend` and `wallet.OutputLeaser` by embedding `walletcore.BoardingBackendBase` and adding neutrino-backed `ListUnspent`, `GetTransaction`, `GetBlock`, `LeaseOutput`, and `ReleaseOutput`. Output leasing forwards to btcwallet's native lock table, casting `wallet.LockID` → `wtxmgr.LockID`.
-- `Config` — Embeds `walletcore.Config` and adds neutrino-specific fields (peers, fee URL, persist filters) plus an optional `PackageSubmitter` for v3 parent+child relay.
+- `BoardingBackendAdapter` — Implements `wallet.BoardingBackend` and
+  `wallet.OutputLeaser` by embedding `walletcore.BoardingBackendBase` and
+  adding neutrino-backed `ListUnspent`, `GetTransaction`, `GetBlock`,
+  `LeaseOutput`, and `ReleaseOutput`. Output leasing forwards to
+  btcwallet's native lock table, casting `wallet.LockID` → `wtxmgr.LockID`.
+  `ListUnspent` checks whether btcwallet's chain sync is still in progress
+  and returns an error if so, preventing UTXO enumeration during sync.
+- `Config` — Embeds `walletcore.Config` and adds neutrino-specific fields
+  (peers, fee URL, persist filters, optional `PackageSubmitter` for v3
+  parent+child relay). New fields: `BlockHeadersSource string` and
+  `FilterHeadersSource string` — local file path or HTTP(S) URL for
+  fast-sync header imports. Both must be set together or both omitted;
+  either alone is a validation error.
 
 ## Relationships
 
@@ -29,6 +40,11 @@ or LND node.
   is non-relayable without its fee-paying child.
 - Block cache size is in bytes (2 MiB default), not block count. This differs from neutrino's count-based API.
 - Taproot script imports use `KeyScopeBIP0086` (via `walletcore.BoardingBackendBase`) to ensure btcwallet's block processing tracks credits correctly.
+- `BlockHeadersSource` and `FilterHeadersSource` must both be set or both
+  omitted. Neutrino imports headers from the source before P2P fallback,
+  using `blockchain.BFFastAdd` validation flags for historical headers.
+- `ListUnspent` returns an error when btcwallet's chain sync is still
+  in progress so callers wait for a consistent UTXO view.
 
 ## Deep Docs
 

--- a/btcwbackend/CLAUDE.md
+++ b/btcwbackend/CLAUDE.md
@@ -12,8 +12,19 @@ or LND node.
 - `Wallet` — Top-level wallet wrapping `walletcore.Wallet` with neutrino chain service, chain backend, and boarding adapter. Constructors: `New` (owns neutrino lifecycle) and `NewWithNeutrino` (reuses pre-started service).
 - `NeutrinoService` — Manages the neutrino `ChainService`, its bbolt DB, and lifecycle. Pre-started by the daemon for early P2P sync.
 - `ChainBackend` — Implements `chainsource.ChainBackend` using neutrino's native `ChainNotifier` for confirmation tracking, spend detection, fee estimation, and optional direct package relay via `chainbackends.PackageSubmitter`.
-- `BoardingBackendAdapter` — Implements `wallet.BoardingBackend` and `wallet.OutputLeaser` by embedding `walletcore.BoardingBackendBase` and adding neutrino-backed `ListUnspent`, `GetTransaction`, `GetBlock`, `LeaseOutput`, and `ReleaseOutput`. Output leasing forwards to btcwallet's native lock table, casting `wallet.LockID` → `wtxmgr.LockID`.
-- `Config` — Embeds `walletcore.Config` and adds neutrino-specific fields (peers, fee URL, persist filters) plus an optional `PackageSubmitter` for v3 parent+child relay.
+- `BoardingBackendAdapter` — Implements `wallet.BoardingBackend` and
+  `wallet.OutputLeaser` by embedding `walletcore.BoardingBackendBase` and
+  adding neutrino-backed `ListUnspent`, `GetTransaction`, `GetBlock`,
+  `LeaseOutput`, and `ReleaseOutput`. Output leasing forwards to
+  btcwallet's native lock table, casting `wallet.LockID` → `wtxmgr.LockID`.
+  `ListUnspent` checks whether btcwallet's chain sync is still in progress
+  and returns an error if so, preventing UTXO enumeration during sync.
+- `Config` — Embeds `walletcore.Config` and adds neutrino-specific fields
+  (peers, fee URL, persist filters, optional `PackageSubmitter` for v3
+  parent+child relay). New fields: `BlockHeadersSource string` and
+  `FilterHeadersSource string` — local file path or HTTP(S) URL for
+  fast-sync header imports. Both must be set together or both omitted;
+  either alone is a validation error.
 
 ## Relationships
 
@@ -29,6 +40,11 @@ or LND node.
   is non-relayable without its fee-paying child.
 - Block cache size is in bytes (2 MiB default), not block count. This differs from neutrino's count-based API.
 - Taproot script imports use `KeyScopeBIP0086` (via `walletcore.BoardingBackendBase`) to ensure btcwallet's block processing tracks credits correctly.
+- `BlockHeadersSource` and `FilterHeadersSource` must both be set or both
+  omitted. Neutrino imports headers from the source before P2P fallback,
+  using `blockchain.BFFastAdd` validation flags for historical headers.
+- `ListUnspent` returns an error when btcwallet's chain sync is still
+  in progress so callers wait for a consistent UTXO view.
 
 ## Deep Docs
 

--- a/cmd/darepocli/darepoclicommands/AGENTS.md
+++ b/cmd/darepocli/darepoclicommands/AGENTS.md
@@ -25,7 +25,8 @@ The CLI surface is split into three tiers:
 | `unlock` | `walletrpc.Unlock` | Unlock an existing wallet (proxies UnlockWallet) |
 | `send <dest>` | `walletrpc.Send` | Outbound payment. `--offchain` (default) for Lightning invoice, `--onchain` for cooperative leave. No prefix sniff |
 | `recv` | `walletrpc.Recv` / `walletrpc.Deposit` | Inbound. `--offchain` (default) returns a Lightning invoice; `--onchain` returns a boarding address |
-| `activity` | `walletrpc.List` | Unified wallet activity view. Defaults to table output; `--format json` returns structured JSON. `--pending` and `--kind` narrow rows |
+| `activity` | `walletrpc.List` | Unified wallet activity view. Defaults to table output (`--format table`); `--format expanded` / `x` shows verbose single-entry layout; `--format json` returns structured JSON. `--pending` and `--kind` narrow rows |
+| `activity inspect <id>` | `walletrpc.InspectActivity` | Technical trace for one activity entry: swap summary, VTXO movements, raw ledger rows, and caveats. `--ledger-limit` caps ledger scan; `--format {expanded,x,json}` |
 | `balance` | `walletrpc.Balance` | Flat balance (confirmed_sat, pending_in_sat, pending_out_sat) |
 | `exit --outpoint TXID:VOUT` | `walletrpc.Exit` | Trigger a unilateral exit (proxies Unroll) |
 | `exit status --outpoint TXID:VOUT` | `walletrpc.ExitStatus` | Query an exit job's status (proxies GetUnrollStatus) |
@@ -75,6 +76,12 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/cmd/d
   registered.
 - `getDaemonConn()` / `getDaemonClient()` — TLS-by-default daemon
   gRPC dial; `--no-tls` opts out for local dev.
+- `getInspectionClient()` — daemon `walletrpc.WalletInspectionService`
+  dial for the `activity inspect` subcommand.
+- `printWalletActivityTable` / `printWalletActivityExpanded` — render
+  wallet activity in table or expanded (multi-line) format.
+- `printWalletInspectionExpanded` — render an `InspectActivityResponse`
+  as a human-readable technical trace (swap, VTXOs, ledger rows, notes).
 - `withWalletClient()` — maps `codes.Unimplemented` to
   `errWalletRPCDisabled` (with a pointer to `docs/walletrpc_build.md`)
   for daemons built without the walletrpc tag.

--- a/cmd/darepocli/darepoclicommands/CLAUDE.md
+++ b/cmd/darepocli/darepoclicommands/CLAUDE.md
@@ -25,7 +25,8 @@ The CLI surface is split into three tiers:
 | `unlock` | `walletrpc.Unlock` | Unlock an existing wallet (proxies UnlockWallet) |
 | `send <dest>` | `walletrpc.Send` | Outbound payment. `--offchain` (default) for Lightning invoice, `--onchain` for cooperative leave. No prefix sniff |
 | `recv` | `walletrpc.Recv` / `walletrpc.Deposit` | Inbound. `--offchain` (default) returns a Lightning invoice; `--onchain` returns a boarding address |
-| `activity` | `walletrpc.List` | Unified wallet activity view. Defaults to table output; `--format json` returns structured JSON. `--pending` and `--kind` narrow rows |
+| `activity` | `walletrpc.List` | Unified wallet activity view. Defaults to table output (`--format table`); `--format expanded` / `x` shows verbose single-entry layout; `--format json` returns structured JSON. `--pending` and `--kind` narrow rows |
+| `activity inspect <id>` | `walletrpc.InspectActivity` | Technical trace for one activity entry: swap summary, VTXO movements, raw ledger rows, and caveats. `--ledger-limit` caps ledger scan; `--format {expanded,x,json}` |
 | `balance` | `walletrpc.Balance` | Flat balance (confirmed_sat, pending_in_sat, pending_out_sat) |
 | `exit --outpoint TXID:VOUT` | `walletrpc.Exit` | Trigger a unilateral exit (proxies Unroll) |
 | `exit status --outpoint TXID:VOUT` | `walletrpc.ExitStatus` | Query an exit job's status (proxies GetUnrollStatus) |
@@ -75,6 +76,12 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/cmd/d
   registered.
 - `getDaemonConn()` / `getDaemonClient()` — TLS-by-default daemon
   gRPC dial; `--no-tls` opts out for local dev.
+- `getInspectionClient()` — daemon `walletrpc.WalletInspectionService`
+  dial for the `activity inspect` subcommand.
+- `printWalletActivityTable` / `printWalletActivityExpanded` — render
+  wallet activity in table or expanded (multi-line) format.
+- `printWalletInspectionExpanded` — render an `InspectActivityResponse`
+  as a human-readable technical trace (swap, VTXOs, ledger rows, notes).
 - `withWalletClient()` — maps `codes.Unimplemented` to
   `errWalletRPCDisabled` (with a pointer to `docs/walletrpc_build.md`)
   for daemons built without the walletrpc tag.

--- a/darepod/AGENTS.md
+++ b/darepod/AGENTS.md
@@ -169,6 +169,15 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/darep
   `serverconn.SignMailboxAuth`.
 - `fetchOperatorPubKeyDirect` — fetches operator pubkey via direct
   gRPC `GetInfo` before the mailbox runtime starts.
+- `fetchUnconfirmedBoardingBalance(ctx)` — internal RPC server helper
+  that sums zero-conf UTXOs paying to known boarding scripts and
+  populates the `UnconfirmedBalance` / `UnconfirmedUtxoCount` fields on
+  `GetBoardingBalanceResponse`. Delegates to the wallet actor's
+  `GetBoardingBalanceRequest`.
+- `fetchCurrentOperatorPubKey(ctx)` — fetches the operator's current
+  long-term key at wallet startup and wires it into `vtxo.ManagerConfig`
+  via the `FetchOperatorKey` callback, enabling operator key rotation
+  at VTXO refresh time.
 - `initLedgerActor` — constructs `ledger.LedgerActor` with both
   `LedgerStoreDB` and `UTXOAuditStoreDB`, registers under
   `ledger.ServiceKeyName`, stashes `LedgerStoreDB` on the `Server`
@@ -292,6 +301,13 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/darep
 - In btcwallet mode, neutrino is pre-started before seed availability
   so P2P sync proceeds in parallel. `neutrinoSvc` uses `fn.Option`
   and is reused by `startBtcwallet` via `NewWithNeutrino`.
+- `Config.Wallet.BtcwBlockSource` and `BtcwFilterSource` are validated
+  as a pair during `Config.Validate()`: both must be set or both omitted.
+  `sdk/walletdk` surfaces these as `WalletBtcwalletBlockHeadersSource`
+  / `WalletBtcwalletFilterHeadersSource` convenience fields.
+- Gateway CORS wildcard `"*"` origin is allowed in
+  `Config.GatewayConfig` and passed through to `gateway.BrowserHeaders`.
+  An empty non-wildcard origin string is rejected by `Config.Validate()`.
 - The neutrino sync-wait goroutine polls indefinitely (no timeout)
   with 30s progress logging — avoids leaving the wallet permanently
   unready.

--- a/darepod/CLAUDE.md
+++ b/darepod/CLAUDE.md
@@ -169,6 +169,15 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/darep
   `serverconn.SignMailboxAuth`.
 - `fetchOperatorPubKeyDirect` — fetches operator pubkey via direct
   gRPC `GetInfo` before the mailbox runtime starts.
+- `fetchUnconfirmedBoardingBalance(ctx)` — internal RPC server helper
+  that sums zero-conf UTXOs paying to known boarding scripts and
+  populates the `UnconfirmedBalance` / `UnconfirmedUtxoCount` fields on
+  `GetBoardingBalanceResponse`. Delegates to the wallet actor's
+  `GetBoardingBalanceRequest`.
+- `fetchCurrentOperatorPubKey(ctx)` — fetches the operator's current
+  long-term key at wallet startup and wires it into `vtxo.ManagerConfig`
+  via the `FetchOperatorKey` callback, enabling operator key rotation
+  at VTXO refresh time.
 - `initLedgerActor` — constructs `ledger.LedgerActor` with both
   `LedgerStoreDB` and `UTXOAuditStoreDB`, registers under
   `ledger.ServiceKeyName`, stashes `LedgerStoreDB` on the `Server`
@@ -292,6 +301,13 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/darep
 - In btcwallet mode, neutrino is pre-started before seed availability
   so P2P sync proceeds in parallel. `neutrinoSvc` uses `fn.Option`
   and is reused by `startBtcwallet` via `NewWithNeutrino`.
+- `Config.Wallet.BtcwBlockSource` and `BtcwFilterSource` are validated
+  as a pair during `Config.Validate()`: both must be set or both omitted.
+  `sdk/walletdk` surfaces these as `WalletBtcwalletBlockHeadersSource`
+  / `WalletBtcwalletFilterHeadersSource` convenience fields.
+- Gateway CORS wildcard `"*"` origin is allowed in
+  `Config.GatewayConfig` and passed through to `gateway.BrowserHeaders`.
+  An empty non-wildcard origin string is rejected by `Config.Validate()`.
 - The neutrino sync-wait goroutine polls indefinitely (no timeout)
   with 30s progress logging — avoids leaving the wallet permanently
   unready.

--- a/gateway/AGENTS.md
+++ b/gateway/AGENTS.md
@@ -17,7 +17,11 @@ have a consistent configuration across all daemon sub-services.
   unconditionally (non-browser clients are not restricted); requests
   carrying an `Origin` are validated against the allowlist and rejected
   with 403 when not present. Injects CORS headers and allows GET, POST,
-  and OPTIONS methods.
+  and OPTIONS methods. The wildcard `"*"` may be included in
+  `allowedOrigins` to permit any browser origin; wildcard responses
+  return `"Access-Control-Allow-Origin: *"` without `Vary: Origin`
+  (correct per the CORS spec). Only suitable for APIs with explicit
+  per-request authentication.
 - `NormalizeEndpoint(endpoint) string` — Converts listener addresses for
   loopback dialing: `0.0.0.0` → `127.0.0.1`, `[::]` → `[::1]`, others
   pass through unchanged.
@@ -33,7 +37,10 @@ have a consistent configuration across all daemon sub-services.
 - Browser callers (those sending an `Origin` header) need an entry in
   `allowedOrigins` or the request is rejected with 403. An empty
   allowlist means no browser caller can reach the gateway; non-browser
-  clients without an `Origin` header are unaffected.
+  clients without an `Origin` header are unaffected. Including `"*"` in
+  `allowedOrigins` bypasses the per-request origin check and returns a
+  wildcard CORS header; the `Vary: Origin` header is omitted in this
+  mode (CORS-compliant behavior).
 - JSON marshaling always uses `UseProtoNames` (snake_case field names) and
   `EmitUnpopulated` (include zero/default values) for API consistency with
   grpc-gateway clients.

--- a/gateway/CLAUDE.md
+++ b/gateway/CLAUDE.md
@@ -17,7 +17,11 @@ have a consistent configuration across all daemon sub-services.
   unconditionally (non-browser clients are not restricted); requests
   carrying an `Origin` are validated against the allowlist and rejected
   with 403 when not present. Injects CORS headers and allows GET, POST,
-  and OPTIONS methods.
+  and OPTIONS methods. The wildcard `"*"` may be included in
+  `allowedOrigins` to permit any browser origin; wildcard responses
+  return `"Access-Control-Allow-Origin: *"` without `Vary: Origin`
+  (correct per the CORS spec). Only suitable for APIs with explicit
+  per-request authentication.
 - `NormalizeEndpoint(endpoint) string` — Converts listener addresses for
   loopback dialing: `0.0.0.0` → `127.0.0.1`, `[::]` → `[::1]`, others
   pass through unchanged.
@@ -33,7 +37,10 @@ have a consistent configuration across all daemon sub-services.
 - Browser callers (those sending an `Origin` header) need an entry in
   `allowedOrigins` or the request is rejected with 403. An empty
   allowlist means no browser caller can reach the gateway; non-browser
-  clients without an `Origin` header are unaffected.
+  clients without an `Origin` header are unaffected. Including `"*"` in
+  `allowedOrigins` bypasses the per-request origin check and returns a
+  wildcard CORS header; the `Vary: Origin` header is omitted in this
+  mode (CORS-compliant behavior).
 - JSON marshaling always uses `UseProtoNames` (snake_case field names) and
   `EmitUnpopulated` (include zero/default values) for API consistency with
   grpc-gateway clients.

--- a/lwwallet/AGENTS.md
+++ b/lwwallet/AGENTS.md
@@ -42,7 +42,14 @@ without an external LND node. Implements `wallet.BoardingBackend`,
   response is verified to hash to the requested key before insertion.
 - `EsploraChainService` — `chain.Interface` adapter over `EsploraClient`,
   driven by a shared `TipPoller`. Feeds btcwallet's internal address-credit
-  pipeline. Constructor: `NewEsploraChainService(esplora, tipPoller, logger)`.
+  pipeline. On each tip event, walks any gap between the last delivered
+  height and the live tip, re-emitting missed heights (bounded by
+  `defaultMaxGapFillPerTipEvent = 256` per event). Constructor:
+  `NewEsploraChainService(esplora, tipPoller, logger, opts...)`.
+- `EsploraChainServiceOption` — Functional option for
+  `NewEsploraChainService`. Currently one option:
+  `WithMaxGapFillPerTipEvent(n int32)` overrides the per-event gap-fill
+  cap (used in tests to exercise bounded-walk behavior).
 - `BoardingBackendAdapter` — Implements `wallet.BoardingBackend` and
   `wallet.OutputLeaser`. Queries Esplora directly for UTXOs (bypasses
   btcwallet's UTXO tracking because btcwallet skips credit marking for
@@ -76,6 +83,11 @@ without an external LND node. Implements `wallet.BoardingBackend`,
   UTXO set, because btcwallet does not credit-mark non-default scope outputs.
 - `Stop()` explicitly closes btcwallet's internal database to prevent resource
   leaks.
+- `EsploraChainService` gap-fill is capped at 256 heights per tip event
+  (`defaultMaxGapFillPerTipEvent`) to prevent long hangs during Esplora
+  outages. Heights beyond the cap are delivered on the next tip event.
+  Out-of-order or duplicate tip events are handled explicitly and do not
+  re-deliver already-processed heights.
 
 ## Deep Docs
 

--- a/lwwallet/CLAUDE.md
+++ b/lwwallet/CLAUDE.md
@@ -42,7 +42,14 @@ without an external LND node. Implements `wallet.BoardingBackend`,
   response is verified to hash to the requested key before insertion.
 - `EsploraChainService` — `chain.Interface` adapter over `EsploraClient`,
   driven by a shared `TipPoller`. Feeds btcwallet's internal address-credit
-  pipeline. Constructor: `NewEsploraChainService(esplora, tipPoller, logger)`.
+  pipeline. On each tip event, walks any gap between the last delivered
+  height and the live tip, re-emitting missed heights (bounded by
+  `defaultMaxGapFillPerTipEvent = 256` per event). Constructor:
+  `NewEsploraChainService(esplora, tipPoller, logger, opts...)`.
+- `EsploraChainServiceOption` — Functional option for
+  `NewEsploraChainService`. Currently one option:
+  `WithMaxGapFillPerTipEvent(n int32)` overrides the per-event gap-fill
+  cap (used in tests to exercise bounded-walk behavior).
 - `BoardingBackendAdapter` — Implements `wallet.BoardingBackend` and
   `wallet.OutputLeaser`. Queries Esplora directly for UTXOs (bypasses
   btcwallet's UTXO tracking because btcwallet skips credit marking for
@@ -76,6 +83,11 @@ without an external LND node. Implements `wallet.BoardingBackend`,
   UTXO set, because btcwallet does not credit-mark non-default scope outputs.
 - `Stop()` explicitly closes btcwallet's internal database to prevent resource
   leaks.
+- `EsploraChainService` gap-fill is capped at 256 heights per tip event
+  (`defaultMaxGapFillPerTipEvent`) to prevent long hangs during Esplora
+  outages. Heights beyond the cap are delivered on the next tip event.
+  Out-of-order or duplicate tip events are handled explicitly and do not
+  re-deliver already-processed heights.
 
 ## Deep Docs
 

--- a/sdk/swaps/AGENTS.md
+++ b/sdk/swaps/AGENTS.md
@@ -28,7 +28,13 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/s
   ClaimInitiated → Completed` (or `Expired` / `NeedsIntervention` /
   `Failed`). `HTLCEventAccepted` is a durable checkpoint persisted
   after the server mailbox event is validated so funding detection
-  resumes without re-driving mailbox delivery.
+  resumes without re-driving mailbox delivery. An unpaid invoice
+  transitions to `Expired` when its deadline passes; a 10-second
+  grace window (`defaultOverdueReceiveMailboxPollWindow`) allows
+  already-delivered funding messages to arrive when the daemon
+  resumes after an invoice has exceeded its deadline.
+  `StartReceiveViaLightning` accepts an optional `memo string`
+  parameter that is embedded as the BOLT-11 invoice description.
 - `MailboxOutSwapEventReceiver` — mailbox-backed receiver. Pulls
   out-swap HTLC events from a `mailbox/pb` edge keyed by a per-session
   mailbox ID derived from the client identity key and payment hash.
@@ -66,7 +72,9 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/s
 - `PayState` / `ReceiveState` — typed FSM enums with `IsTerminal()` /
   `String()`. `ReceiveState` includes `ReceiveStateHTLCEventAccepted`.
 - `VHTLCConfig`, `InSwapConfig`, `RouteHint` — server-negotiation
-  DTOs. `SwapSummary` — flat list view for persisted sessions.
+  DTOs. `SwapSummary` — flat list view for persisted sessions. Now
+  includes an `Invoice string` field: receive swaps carry the generated
+  BOLT-11 invoice; pay swaps carry the caller-submitted invoice.
 - `OutSwapMailboxID` — derives a per-receive mailbox ID from the
   client identity key and invoice payment hash.
 - Error sentinels (exported): `ErrSwapExpired`, `ErrSwapRefunded`,
@@ -125,6 +133,10 @@ result into an `IncomingVHTLCNotification`.
   the SDK never holds the raw private key for receive-auth.
 - Error sentinels (`ErrSwapExpired`, `ErrSwapRefunded`,
   `ErrSwapSummaryNotFound`) are exported; callers use `errors.Is`.
+- An unpaid `ReceiveSession` whose invoice deadline has elapsed
+  transitions to `ReceiveStateExpired` rather than `NeedsIntervention`.
+  The 10-second mailbox poll grace window prevents false expiry when
+  daemon restart races an already-delivered funding event.
 
 ## Deep Docs
 

--- a/sdk/swaps/CLAUDE.md
+++ b/sdk/swaps/CLAUDE.md
@@ -28,7 +28,13 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/s
   ClaimInitiated → Completed` (or `Expired` / `NeedsIntervention` /
   `Failed`). `HTLCEventAccepted` is a durable checkpoint persisted
   after the server mailbox event is validated so funding detection
-  resumes without re-driving mailbox delivery.
+  resumes without re-driving mailbox delivery. An unpaid invoice
+  transitions to `Expired` when its deadline passes; a 10-second
+  grace window (`defaultOverdueReceiveMailboxPollWindow`) allows
+  already-delivered funding messages to arrive when the daemon
+  resumes after an invoice has exceeded its deadline.
+  `StartReceiveViaLightning` accepts an optional `memo string`
+  parameter that is embedded as the BOLT-11 invoice description.
 - `MailboxOutSwapEventReceiver` — mailbox-backed receiver. Pulls
   out-swap HTLC events from a `mailbox/pb` edge keyed by a per-session
   mailbox ID derived from the client identity key and payment hash.
@@ -66,7 +72,9 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/s
 - `PayState` / `ReceiveState` — typed FSM enums with `IsTerminal()` /
   `String()`. `ReceiveState` includes `ReceiveStateHTLCEventAccepted`.
 - `VHTLCConfig`, `InSwapConfig`, `RouteHint` — server-negotiation
-  DTOs. `SwapSummary` — flat list view for persisted sessions.
+  DTOs. `SwapSummary` — flat list view for persisted sessions. Now
+  includes an `Invoice string` field: receive swaps carry the generated
+  BOLT-11 invoice; pay swaps carry the caller-submitted invoice.
 - `OutSwapMailboxID` — derives a per-receive mailbox ID from the
   client identity key and invoice payment hash.
 - Error sentinels (exported): `ErrSwapExpired`, `ErrSwapRefunded`,
@@ -125,6 +133,10 @@ result into an `IncomingVHTLCNotification`.
   the SDK never holds the raw private key for receive-auth.
 - Error sentinels (`ErrSwapExpired`, `ErrSwapRefunded`,
   `ErrSwapSummaryNotFound`) are exported; callers use `errors.Is`.
+- An unpaid `ReceiveSession` whose invoice deadline has elapsed
+  transitions to `ReceiveStateExpired` rather than `NeedsIntervention`.
+  The 10-second mailbox poll grace window prevents false expiry when
+  daemon restart races an already-delivered funding event.
 
 ## Deep Docs
 

--- a/sdk/walletdk/AGENTS.md
+++ b/sdk/walletdk/AGENTS.md
@@ -33,6 +33,13 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/w
   waits for gRPC readiness, and returns a ready `*Client`. The daemon
   lifetime is owned by walletdk's `runCtx`, not the caller's `ctx`, so
   a tight startup deadline cancels dialing only.
+- `Config` convenience fields also include
+  `WalletBtcwalletBlockHeadersSource string` and
+  `WalletBtcwalletFilterHeadersSource string` — local file path or
+  HTTP(S) URL for btcwallet/neutrino block and filter header imports.
+  Both must be set together or both omitted. When set, neutrino imports
+  headers from the source before P2P fallback, enabling fast initial
+  sync without waiting for the full P2P header download.
 - `Option` — functional option accepted as variadic trailing args.
   Options apply **after** the `Config`/`DaemonConfig` merge and after
   `configureSwapRuntime` / `configureWalletRPC`, so they can override
@@ -148,6 +155,11 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/w
 - `Wait()` is single-reader: same shared channel on every call. The
   channel delivers the daemon's terminal run error then closes; a
   closed channel reads as the zero error indefinitely.
+- `WalletBtcwalletBlockHeadersSource` and
+  `WalletBtcwalletFilterHeadersSource` are btcwallet-only convenience
+  fields. They are validated and forwarded to `darepod.Config` before
+  daemon startup. Both must be set together; providing only one is a
+  validation error surfaced before `Start` returns.
 - `Subscribe` returns an unbuffered updates channel so a slow consumer
   applies backpressure end-to-end; the errs channel is cap-1 for a
   single terminal error.

--- a/sdk/walletdk/CLAUDE.md
+++ b/sdk/walletdk/CLAUDE.md
@@ -33,6 +33,13 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/w
   waits for gRPC readiness, and returns a ready `*Client`. The daemon
   lifetime is owned by walletdk's `runCtx`, not the caller's `ctx`, so
   a tight startup deadline cancels dialing only.
+- `Config` convenience fields also include
+  `WalletBtcwalletBlockHeadersSource string` and
+  `WalletBtcwalletFilterHeadersSource string` — local file path or
+  HTTP(S) URL for btcwallet/neutrino block and filter header imports.
+  Both must be set together or both omitted. When set, neutrino imports
+  headers from the source before P2P fallback, enabling fast initial
+  sync without waiting for the full P2P header download.
 - `Option` — functional option accepted as variadic trailing args.
   Options apply **after** the `Config`/`DaemonConfig` merge and after
   `configureSwapRuntime` / `configureWalletRPC`, so they can override
@@ -148,6 +155,11 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/w
 - `Wait()` is single-reader: same shared channel on every call. The
   channel delivers the daemon's terminal run error then closes; a
   closed channel reads as the zero error indefinitely.
+- `WalletBtcwalletBlockHeadersSource` and
+  `WalletBtcwalletFilterHeadersSource` are btcwallet-only convenience
+  fields. They are validated and forwarded to `darepod.Config` before
+  daemon startup. Both must be set together; providing only one is a
+  validation error surfaced before `Start` returns.
 - `Subscribe` returns an unbuffered updates channel so a slow consumer
   applies backpressure end-to-end; the errs channel is cap-1 for a
   single terminal error.

--- a/serverconn/mailboxpull/AGENTS.md
+++ b/serverconn/mailboxpull/AGENTS.md
@@ -1,0 +1,55 @@
+# serverconn/mailboxpull
+
+## Purpose
+
+Shared retry-and-backoff primitives for mailbox pull loops. Factors out
+exponential backoff with jitter so the `serverconn` ingress loop and per-swap
+event consumers in `sdk/swaps` share identical retry semantics: same curve,
+same jitter strategy, and the same context cancellation contract.
+
+## Key Types
+
+- `BackoffConfig` — Controls exponential backoff with jitter. Fields:
+  `BaseDelay` and `MaxDelay` (both: non-positive = use package defaults
+  200 ms base / 30 s cap). Zero value selects the production defaults.
+- `DefaultBackoffConfig()` — Returns the production defaults used by the
+  `serverconn` ingress loop: 200 ms base, 30 s cap.
+- `RetryDelay(cfg BackoffConfig, attempt int) time.Duration` — Returns the
+  next backoff duration: `min(base * 2^(attempt-1), max) * U[0.5, 1.0)`.
+  Uses non-cryptographic randomness for jitter. Attempt counter is
+  caller-owned.
+- `Sleep(ctx context.Context, cfg BackoffConfig, attempt *int)` — Increments
+  `*attempt` and sleeps for the next backoff interval, respecting context
+  cancellation. Multiple pull cycles may share one attempt counter so
+  backoff grows across successive failures.
+- `PullWithRetry(ctx, edge mailboxpb.MailboxServiceClient, req *mailboxpb.PullRequest, cfg BackoffConfig, log btclog.Logger)` —
+  Calls `edge.Pull`, retrying transport errors with exponential backoff
+  until success or context cancellation. Preserves cursor state across
+  reconnects (req is unchanged across retries). Returns the context error on
+  cancellation, distinguishing "caller gave up" from "endpoint flapping".
+  Status-level failures (`resp.Status` with `Ok=false`) are returned to
+  the caller rather than retried.
+
+## Relationships
+
+- **Depends on**: `mailbox/pb` (MailboxServiceClient, PullRequest, PullResponse).
+- **Depended on by**: `serverconn` (persistent identity-mailbox ingress loop),
+  `sdk/swaps` (per-swap out-swap event consumers).
+
+## Invariants
+
+- Cursor state and attempt counter are caller-owned; this package is
+  stateless. The ingress loop preserves its cursor position and grows
+  backoff across successive failures using the same counter; a successful
+  pull resets the counter.
+- `PullWithRetry` retries only on transport errors (connection refused,
+  stream reset). Application-level rejections (`resp.Status.Ok == false`)
+  are surfaced to the caller immediately.
+- The attempt counter is incremented by `Sleep` before the sleep, so
+  attempt=0 on the first call yields `BaseDelay * U[0.5, 1.0)`.
+
+## Deep Docs
+
+- [serverconn/CLAUDE.md](../CLAUDE.md) — Parent package and ingress loop
+  context.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/serverconn/mailboxpull/CLAUDE.md
+++ b/serverconn/mailboxpull/CLAUDE.md
@@ -1,0 +1,55 @@
+# serverconn/mailboxpull
+
+## Purpose
+
+Shared retry-and-backoff primitives for mailbox pull loops. Factors out
+exponential backoff with jitter so the `serverconn` ingress loop and per-swap
+event consumers in `sdk/swaps` share identical retry semantics: same curve,
+same jitter strategy, and the same context cancellation contract.
+
+## Key Types
+
+- `BackoffConfig` — Controls exponential backoff with jitter. Fields:
+  `BaseDelay` and `MaxDelay` (both: non-positive = use package defaults
+  200 ms base / 30 s cap). Zero value selects the production defaults.
+- `DefaultBackoffConfig()` — Returns the production defaults used by the
+  `serverconn` ingress loop: 200 ms base, 30 s cap.
+- `RetryDelay(cfg BackoffConfig, attempt int) time.Duration` — Returns the
+  next backoff duration: `min(base * 2^(attempt-1), max) * U[0.5, 1.0)`.
+  Uses non-cryptographic randomness for jitter. Attempt counter is
+  caller-owned.
+- `Sleep(ctx context.Context, cfg BackoffConfig, attempt *int)` — Increments
+  `*attempt` and sleeps for the next backoff interval, respecting context
+  cancellation. Multiple pull cycles may share one attempt counter so
+  backoff grows across successive failures.
+- `PullWithRetry(ctx, edge mailboxpb.MailboxServiceClient, req *mailboxpb.PullRequest, cfg BackoffConfig, log btclog.Logger)` —
+  Calls `edge.Pull`, retrying transport errors with exponential backoff
+  until success or context cancellation. Preserves cursor state across
+  reconnects (req is unchanged across retries). Returns the context error on
+  cancellation, distinguishing "caller gave up" from "endpoint flapping".
+  Status-level failures (`resp.Status` with `Ok=false`) are returned to
+  the caller rather than retried.
+
+## Relationships
+
+- **Depends on**: `mailbox/pb` (MailboxServiceClient, PullRequest, PullResponse).
+- **Depended on by**: `serverconn` (persistent identity-mailbox ingress loop),
+  `sdk/swaps` (per-swap out-swap event consumers).
+
+## Invariants
+
+- Cursor state and attempt counter are caller-owned; this package is
+  stateless. The ingress loop preserves its cursor position and grows
+  backoff across successive failures using the same counter; a successful
+  pull resets the counter.
+- `PullWithRetry` retries only on transport errors (connection refused,
+  stream reset). Application-level rejections (`resp.Status.Ok == false`)
+  are surfaced to the caller immediately.
+- The attempt counter is incremented by `Sleep` before the sleep, so
+  attempt=0 on the first call yields `BaseDelay * U[0.5, 1.0)`.
+
+## Deep Docs
+
+- [serverconn/CLAUDE.md](../CLAUDE.md) — Parent package and ingress loop
+  context.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/swapclientserver/AGENTS.md
+++ b/swapclientserver/AGENTS.md
@@ -16,10 +16,12 @@ protocol behavior remain entirely inside `sdk/swaps` and `swapdk-server`.
   not per-RPC), the process-local `active` worker map, and the `subscribers`
   map for `SubscribeSwaps` streaming.
 - `swapRuntimeClient` — Narrow interface over `sdk/swaps.SwapClient` that the
-  subserver uses for all RPC handlers and worker restarts. Methods: `StartPayViaLightning`,
-  `StartReceiveViaLightning`, `ResumePayViaLightning`,
-  `ResumeReceiveViaLightning`, `GetSwapSummary`, `ListSwapSummaries`. Keeps
-  the subserver unit-testable without running real swap FSMs.
+  subserver uses for all RPC handlers and worker restarts. Methods:
+  `StartPayViaLightning`, `StartReceiveViaLightning(ctx, amount, memo string)`,
+  `ResumePayViaLightning`, `ResumeReceiveViaLightning`, `GetSwapSummary`,
+  `ListSwapSummaries`. Keeps the subserver unit-testable without running real
+  swap FSMs. The `memo` parameter on `StartReceiveViaLightning` is forwarded
+  as the BOLT-11 invoice description.
 - `swapClientAdapter` — Thin production adapter that forwards calls to
   `*swaps.SwapClient`.
 - `paySwapSession` / `receiveSwapSession` — Minimal session interfaces
@@ -44,7 +46,7 @@ protocol behavior remain entirely inside `sdk/swaps` and `swapdk-server`.
 | RPC | Description |
 |-----|-------------|
 | `StartPay` | Persist a pay swap, start or reuse its daemon worker, return summary |
-| `StartReceive` | Persist a receive swap, start or reuse its daemon worker, return invoice + summary |
+| `StartReceive` | Persist a receive swap, start or reuse its daemon worker, return invoice + summary. Optional `memo` field sets the BOLT-11 invoice description |
 | `ResumeSwap` | Manual wake-up for a persisted swap (idempotent if worker already active) |
 | `ListSwaps` | List persisted swap summaries; optionally filter to pending only |
 | `GetSwap` | Fetch one persisted summary by hex payment hash |
@@ -86,6 +88,10 @@ protocol behavior remain entirely inside `sdk/swaps` and `swapdk-server`.
 - `idempotency_key` on `StartPay` / `StartReceive` is explicitly reserved and
   returns `Unimplemented` to guard against accidental duplicate-start
   assumptions.
+- `swapSummaryToProto` copies the `Invoice` string field from persisted swap
+  summaries into the proto response. Both pay and receive summaries expose
+  their respective invoices; receive swaps expose the generated invoice,
+  pay swaps expose the caller-submitted invoice.
 - `SetOutSwapEventReceiver` must run before any receive worker is started:
   `SwapClient` captures the receiver into the per-swap worker at start time,
   so a late install would leave already-running workers using whatever

--- a/swapclientserver/CLAUDE.md
+++ b/swapclientserver/CLAUDE.md
@@ -16,10 +16,12 @@ protocol behavior remain entirely inside `sdk/swaps` and `swapdk-server`.
   not per-RPC), the process-local `active` worker map, and the `subscribers`
   map for `SubscribeSwaps` streaming.
 - `swapRuntimeClient` — Narrow interface over `sdk/swaps.SwapClient` that the
-  subserver uses for all RPC handlers and worker restarts. Methods: `StartPayViaLightning`,
-  `StartReceiveViaLightning`, `ResumePayViaLightning`,
-  `ResumeReceiveViaLightning`, `GetSwapSummary`, `ListSwapSummaries`. Keeps
-  the subserver unit-testable without running real swap FSMs.
+  subserver uses for all RPC handlers and worker restarts. Methods:
+  `StartPayViaLightning`, `StartReceiveViaLightning(ctx, amount, memo string)`,
+  `ResumePayViaLightning`, `ResumeReceiveViaLightning`, `GetSwapSummary`,
+  `ListSwapSummaries`. Keeps the subserver unit-testable without running real
+  swap FSMs. The `memo` parameter on `StartReceiveViaLightning` is forwarded
+  as the BOLT-11 invoice description.
 - `swapClientAdapter` — Thin production adapter that forwards calls to
   `*swaps.SwapClient`.
 - `paySwapSession` / `receiveSwapSession` — Minimal session interfaces
@@ -44,7 +46,7 @@ protocol behavior remain entirely inside `sdk/swaps` and `swapdk-server`.
 | RPC | Description |
 |-----|-------------|
 | `StartPay` | Persist a pay swap, start or reuse its daemon worker, return summary |
-| `StartReceive` | Persist a receive swap, start or reuse its daemon worker, return invoice + summary |
+| `StartReceive` | Persist a receive swap, start or reuse its daemon worker, return invoice + summary. Optional `memo` field sets the BOLT-11 invoice description |
 | `ResumeSwap` | Manual wake-up for a persisted swap (idempotent if worker already active) |
 | `ListSwaps` | List persisted swap summaries; optionally filter to pending only |
 | `GetSwap` | Fetch one persisted summary by hex payment hash |
@@ -86,6 +88,10 @@ protocol behavior remain entirely inside `sdk/swaps` and `swapdk-server`.
 - `idempotency_key` on `StartPay` / `StartReceive` is explicitly reserved and
   returns `Unimplemented` to guard against accidental duplicate-start
   assumptions.
+- `swapSummaryToProto` copies the `Invoice` string field from persisted swap
+  summaries into the proto response. Both pay and receive summaries expose
+  their respective invoices; receive swaps expose the generated invoice,
+  pay swaps expose the caller-submitted invoice.
 - `SetOutSwapEventReceiver` must run before any receive worker is started:
   `SwapClient` captures the receiver into the per-swap worker at start time,
   so a late install would leave already-running workers using whatever

--- a/swapwallet/AGENTS.md
+++ b/swapwallet/AGENTS.md
@@ -17,6 +17,13 @@ default builds avoid the swap executor's dependency graph.
 - `Service` — gRPC handler implementing `walletrpc.WalletServiceServer`.
   Thin facade: each method dispatches to `router`, `receiver`,
   `history`, or admin proxy helpers; no business logic lives here.
+- `InspectionService` — gRPC handler implementing
+  `walletrpc.WalletInspectionServiceServer`. Technical debugging surface
+  deliberately separate from the friendly `WalletService`. Provides
+  `InspectActivity`, which correlates one `WalletEntry` id to the
+  underlying swap summary, correlated ledger rows, VTXO movements, and
+  internal OOR session metadata. Callers must opt-in to see session IDs
+  and correlators hidden from the main Activity feed.
 - `Runtime` — Owns the in-process swap lifecycle: synchronous
   resume-on-startup, deadline watcher (overlays stuck entries as
   FAILED), monitor loop (fans normalized updates to subscribers).
@@ -70,6 +77,7 @@ default builds avoid the swap executor's dependency graph.
 - **Receives**:
   - ← API: `walletrpc.{Create,Unlock,Send,Recv,List,Balance,Deposit,
     Status,Exit,ExitStatus,SubscribeWallet}Request`
+  - ← API: `walletrpc.InspectActivityRequest` (WalletInspectionService)
 
 ## Invariants
 
@@ -103,10 +111,24 @@ default builds avoid the swap executor's dependency graph.
   and Onchain.
 - VTXOs view filters out terminal internal states (FORFEITED, SPENT,
   FAILED) so the wallet view stays focused on actionable VTXOs.
-- The runtime's deadline overlay elevates stuck PENDING entries to
-  FAILED with `failure_reason="timed_out"` BEFORE filtering, so a
-  stuck row appears as FAILED even when the caller asks for
-  `pending_only=false`.
+- The runtime's deadline overlay elevates wallet-local stuck PENDING
+  entries to FAILED with `failure_reason="timed_out"` BEFORE filtering.
+  Swap-backed rows (SEND/RECV) trust the swap FSM's own terminal state
+  and skip the wallet deadline overlay. A stuck wallet-local row appears
+  as FAILED even when the caller asks for `pending_only=false`.
+- **OOR ledger hiding**: The Activity feed hides internal OOR
+  transaction legs (send-receive pairs within the same session) to avoid
+  noise. `internalOORLedgerEntries` correlates swap metadata (session
+  IDs) and ledger fields to identify which rows are internal plumbing
+  vs. user-facing movements. `InspectActivity` exposes all ledger rows
+  including their hidden status so debugging tools can reconstruct the
+  full execution trace.
+- **Boarding confirmation tracking**: `collectPendingBoardingEntries`
+  adds a synthetic pending DEPOSIT row for unconfirmed on-chain funds
+  (from `boarding_unconfirmed_sat` balance field). Once the boarding
+  UTXO confirms and the ledger emits `wallet_utxo_created`, the
+  synthetic row is replaced by the durable ledger row so unconfirmed
+  boarding funds remain visible throughout.
 - **DEPOSIT rows backed by the `wallet_utxo_created` ledger event**
   are pinned to `ENTRY_STATUS_PENDING` even after chain confirmation
   (`statusForLedgerRow`), because a boarding UTXO landing on-chain

--- a/swapwallet/CLAUDE.md
+++ b/swapwallet/CLAUDE.md
@@ -17,6 +17,13 @@ default builds avoid the swap executor's dependency graph.
 - `Service` — gRPC handler implementing `walletrpc.WalletServiceServer`.
   Thin facade: each method dispatches to `router`, `receiver`,
   `history`, or admin proxy helpers; no business logic lives here.
+- `InspectionService` — gRPC handler implementing
+  `walletrpc.WalletInspectionServiceServer`. Technical debugging surface
+  deliberately separate from the friendly `WalletService`. Provides
+  `InspectActivity`, which correlates one `WalletEntry` id to the
+  underlying swap summary, correlated ledger rows, VTXO movements, and
+  internal OOR session metadata. Callers must opt-in to see session IDs
+  and correlators hidden from the main Activity feed.
 - `Runtime` — Owns the in-process swap lifecycle: synchronous
   resume-on-startup, deadline watcher (overlays stuck entries as
   FAILED), monitor loop (fans normalized updates to subscribers).
@@ -70,6 +77,7 @@ default builds avoid the swap executor's dependency graph.
 - **Receives**:
   - ← API: `walletrpc.{Create,Unlock,Send,Recv,List,Balance,Deposit,
     Status,Exit,ExitStatus,SubscribeWallet}Request`
+  - ← API: `walletrpc.InspectActivityRequest` (WalletInspectionService)
 
 ## Invariants
 
@@ -103,10 +111,24 @@ default builds avoid the swap executor's dependency graph.
   and Onchain.
 - VTXOs view filters out terminal internal states (FORFEITED, SPENT,
   FAILED) so the wallet view stays focused on actionable VTXOs.
-- The runtime's deadline overlay elevates stuck PENDING entries to
-  FAILED with `failure_reason="timed_out"` BEFORE filtering, so a
-  stuck row appears as FAILED even when the caller asks for
-  `pending_only=false`.
+- The runtime's deadline overlay elevates wallet-local stuck PENDING
+  entries to FAILED with `failure_reason="timed_out"` BEFORE filtering.
+  Swap-backed rows (SEND/RECV) trust the swap FSM's own terminal state
+  and skip the wallet deadline overlay. A stuck wallet-local row appears
+  as FAILED even when the caller asks for `pending_only=false`.
+- **OOR ledger hiding**: The Activity feed hides internal OOR
+  transaction legs (send-receive pairs within the same session) to avoid
+  noise. `internalOORLedgerEntries` correlates swap metadata (session
+  IDs) and ledger fields to identify which rows are internal plumbing
+  vs. user-facing movements. `InspectActivity` exposes all ledger rows
+  including their hidden status so debugging tools can reconstruct the
+  full execution trace.
+- **Boarding confirmation tracking**: `collectPendingBoardingEntries`
+  adds a synthetic pending DEPOSIT row for unconfirmed on-chain funds
+  (from `boarding_unconfirmed_sat` balance field). Once the boarding
+  UTXO confirms and the ledger emits `wallet_utxo_created`, the
+  synthetic row is replaced by the durable ledger row so unconfirmed
+  boarding funds remain visible throughout.
 - **DEPOSIT rows backed by the `wallet_utxo_created` ledger event**
   are pinned to `ENTRY_STATUS_PENDING` even after chain confirmation
   (`statusForLedgerRow`), because a boarding UTXO landing on-chain

--- a/vtxo/AGENTS.md
+++ b/vtxo/AGENTS.md
@@ -19,13 +19,22 @@ when the local wallet owns the receive script.
 - `ManagerConfig` — Configuration holding Store, Wallet, ChainSource,
   ActorSystem, ChainParams, ExpiryConfig, RoundActor ref, ChainResolver ref,
   optional `Log`, optional `LedgerSink fn.Option[ledger.Sink]`,
-  `ForfeitVTXOActorAskTimeout`, and `RefreshFeeQuoter`. The manager
-  propagates the sink into each spawned `VTXOActor` for `ExitCostMsg`
-  emissions. `ForfeitVTXOActorAskTimeout` (default 5 s) bounds forfeit
+  `ForfeitVTXOActorAskTimeout`, `RefreshFeeQuoter`, and optional
+  `FetchOperatorKey func(context.Context) (*btcec.PublicKey, error)`. The
+  manager propagates the sink and `FetchOperatorKey` into each spawned
+  `VTXOActor`. `ForfeitVTXOActorAskTimeout` (default 5 s) bounds forfeit
   and refresh child asks so a blocked child actor cannot monopolize the
   manager until the outer RPC deadline. Zero uses the default; negative
   disables the timeout. Spend-path asks keep the caller's context.
 - `VTXOActorConfig.LedgerSink` — Per-VTXO actor field plumbed from the manager. The `emitExitCost` helper is wired onto the unilateral-exit transition but is currently a no-op pending chain resolver integration: the actor cannot determine the on-chain miner fee until the chain resolver reports the confirmed exit-spend transaction. The emission site exists so a single future change in the chain resolver wiring enables it without touching the FSM transition logic.
+- `ErrRefreshOperatorKeyUnsupported` — Sentinel returned by
+  `RefreshOutputTemplate` when the VTXO uses a non-standard policy
+  shape that cannot be rebuilt with a new operator key.
+- `(d *Descriptor) RefreshOutputTemplate(currentOperatorKey *btcec.PublicKey) ([]byte, error)` —
+  Rebuilds the policy template for the NEW VTXO output using the
+  caller-supplied current operator key while preserving owner key and
+  exit delay. Only supports standard Ark policy shapes; non-standard
+  shapes return `ErrRefreshOperatorKeyUnsupported`.
 - `VTXOEvent` — Inbound events (BlockEpochEvent, ForfeitRequest, ForfeitConfirmed, SpendReserveEvent, SpendCompletedEvent, etc.).
 - `VTXOOutMsg` — Outbound messages (ForfeitRequest, ExpiringNotify, StatusUpdate, Terminated).
 - `FilterOptions` / `FilterDescriptors` — VTXO filtering by expiry status, spend state, etc.
@@ -42,7 +51,7 @@ when the local wallet owns the receive script.
 
 ## Relationships
 
-- **Depends on**: `baselib/protofsm` (FSM engine), `baselib/actor` (actor system), `lib/tree` (tree paths), `lib/arkscript` (taproot construction and policy helpers in `IncomingVTXOHandler`), `lib/actormsg` (admission message types), `arkrpc` (`IncomingVTXOEvent`), `chainsource` (block epochs), `ledger` (`Sink` + `ExitCostMsg` for planned exit cost emission).
+- **Depends on**: `baselib/protofsm` (FSM engine), `baselib/actor` (actor system), `lib/tree` (tree paths), `lib/arkscript` (taproot construction, policy template helpers, operator key rotation), `lib/actormsg` (admission message types), `arkrpc` (`IncomingVTXOEvent`), `chainsource` (block epochs), `ledger` (`Sink` + `ExitCostMsg` for planned exit cost emission).
 - **Depended on by**: `round` (triggers forfeit requests), `oor` (incoming VTXOs), `wallet` (admission gating), `db` (persistence), `darepod` (wiring, owned-script adapters, incoming event route).
 - **Sends**:
   - → `round` (via manager relay): `RelayToRoundMsg` wrapping `ForfeitSignatureSubmission`
@@ -93,6 +102,13 @@ when the local wallet owns the receive script.
 - Incoming VTXOs are saved with `Status: VTXOStatusLive` and empty `Ancestry` (the round commitment tree is not pushed alongside the event); `db.VTXOPersistenceStore.descriptorToInsertParams` accepts an empty tree-path blob to support this.
 - The `CommitmentTxID` on a materialized incoming VTXO comes from `IncomingVTXOEvent.CommitmentTxid`, which is the round commitment txid — **not** the leaf txid in the outpoint.
 - Per-subsystem logging: `ManagerConfig.Log` provides an optional instance logger; falls back to `build.LoggerFromContext` (no global mutable loggers).
+- When `FetchOperatorKey` is set on `ManagerConfig`, auto-refresh
+  emissions fetch the operator's current long-term key at join time so
+  the NEW VTXO output commits to the current key rather than the key
+  stored in the input VTXO's descriptor. Fetch errors are logged at warn
+  level and cause the refresh to be skipped; the next expiry tick
+  retries naturally. Non-standard policy shapes fall back to the
+  descriptor's stored bytes.
 
 ## Deep Docs
 

--- a/vtxo/CLAUDE.md
+++ b/vtxo/CLAUDE.md
@@ -19,13 +19,22 @@ when the local wallet owns the receive script.
 - `ManagerConfig` — Configuration holding Store, Wallet, ChainSource,
   ActorSystem, ChainParams, ExpiryConfig, RoundActor ref, ChainResolver ref,
   optional `Log`, optional `LedgerSink fn.Option[ledger.Sink]`,
-  `ForfeitVTXOActorAskTimeout`, and `RefreshFeeQuoter`. The manager
-  propagates the sink into each spawned `VTXOActor` for `ExitCostMsg`
-  emissions. `ForfeitVTXOActorAskTimeout` (default 5 s) bounds forfeit
+  `ForfeitVTXOActorAskTimeout`, `RefreshFeeQuoter`, and optional
+  `FetchOperatorKey func(context.Context) (*btcec.PublicKey, error)`. The
+  manager propagates the sink and `FetchOperatorKey` into each spawned
+  `VTXOActor`. `ForfeitVTXOActorAskTimeout` (default 5 s) bounds forfeit
   and refresh child asks so a blocked child actor cannot monopolize the
   manager until the outer RPC deadline. Zero uses the default; negative
   disables the timeout. Spend-path asks keep the caller's context.
 - `VTXOActorConfig.LedgerSink` — Per-VTXO actor field plumbed from the manager. The `emitExitCost` helper is wired onto the unilateral-exit transition but is currently a no-op pending chain resolver integration: the actor cannot determine the on-chain miner fee until the chain resolver reports the confirmed exit-spend transaction. The emission site exists so a single future change in the chain resolver wiring enables it without touching the FSM transition logic.
+- `ErrRefreshOperatorKeyUnsupported` — Sentinel returned by
+  `RefreshOutputTemplate` when the VTXO uses a non-standard policy
+  shape that cannot be rebuilt with a new operator key.
+- `(d *Descriptor) RefreshOutputTemplate(currentOperatorKey *btcec.PublicKey) ([]byte, error)` —
+  Rebuilds the policy template for the NEW VTXO output using the
+  caller-supplied current operator key while preserving owner key and
+  exit delay. Only supports standard Ark policy shapes; non-standard
+  shapes return `ErrRefreshOperatorKeyUnsupported`.
 - `VTXOEvent` — Inbound events (BlockEpochEvent, ForfeitRequest, ForfeitConfirmed, SpendReserveEvent, SpendCompletedEvent, etc.).
 - `VTXOOutMsg` — Outbound messages (ForfeitRequest, ExpiringNotify, StatusUpdate, Terminated).
 - `FilterOptions` / `FilterDescriptors` — VTXO filtering by expiry status, spend state, etc.
@@ -42,7 +51,7 @@ when the local wallet owns the receive script.
 
 ## Relationships
 
-- **Depends on**: `baselib/protofsm` (FSM engine), `baselib/actor` (actor system), `lib/tree` (tree paths), `lib/arkscript` (taproot construction and policy helpers in `IncomingVTXOHandler`), `lib/actormsg` (admission message types), `arkrpc` (`IncomingVTXOEvent`), `chainsource` (block epochs), `ledger` (`Sink` + `ExitCostMsg` for planned exit cost emission).
+- **Depends on**: `baselib/protofsm` (FSM engine), `baselib/actor` (actor system), `lib/tree` (tree paths), `lib/arkscript` (taproot construction, policy template helpers, operator key rotation), `lib/actormsg` (admission message types), `arkrpc` (`IncomingVTXOEvent`), `chainsource` (block epochs), `ledger` (`Sink` + `ExitCostMsg` for planned exit cost emission).
 - **Depended on by**: `round` (triggers forfeit requests), `oor` (incoming VTXOs), `wallet` (admission gating), `db` (persistence), `darepod` (wiring, owned-script adapters, incoming event route).
 - **Sends**:
   - → `round` (via manager relay): `RelayToRoundMsg` wrapping `ForfeitSignatureSubmission`
@@ -93,6 +102,13 @@ when the local wallet owns the receive script.
 - Incoming VTXOs are saved with `Status: VTXOStatusLive` and empty `Ancestry` (the round commitment tree is not pushed alongside the event); `db.VTXOPersistenceStore.descriptorToInsertParams` accepts an empty tree-path blob to support this.
 - The `CommitmentTxID` on a materialized incoming VTXO comes from `IncomingVTXOEvent.CommitmentTxid`, which is the round commitment txid — **not** the leaf txid in the outpoint.
 - Per-subsystem logging: `ManagerConfig.Log` provides an optional instance logger; falls back to `build.LoggerFromContext` (no global mutable loggers).
+- When `FetchOperatorKey` is set on `ManagerConfig`, auto-refresh
+  emissions fetch the operator's current long-term key at join time so
+  the NEW VTXO output commits to the current key rather than the key
+  stored in the input VTXO's descriptor. Fetch errors are logged at warn
+  level and cause the refresh to be skipped; the next expiry tick
+  retries naturally. Non-standard policy shapes fall back to the
+  descriptor's stored bytes.
 
 ## Deep Docs
 

--- a/wallet/AGENTS.md
+++ b/wallet/AGENTS.md
@@ -34,10 +34,28 @@ refresh, leave, OOR spend, and directed send flows.
 - `SendVTXOsRequest` / `SendVTXOsResponse` — Ask-request for in-round directed sends. Validates each recipient amount is within `(0, MaxSatoshi]` and that the running total never overflows `int64`, atomically selects and reserves VTXOs via `SelectAndReserveForfeitRequest`, builds forfeit + recipient VTXO intents, and registers with the round actor. Supports dry-run mode for previewing coin selection without committing. Reserved VTXOs are released via a deferred cleanup that uses `context.WithoutCancel` so cleanup survives caller disconnect; on success, a `committed` flag is set to skip the release.
 - `GetConfirmedBoardingIntentsRequest` / `GetConfirmedBoardingIntentsResponse` — Ask-request to retrieve currently confirmed boarding intents (used by the RPC/CLI layer to report boarding balance with policy metadata).
 - `VTXODescriptor.EffectivePolicyTemplate` — Decodes the serialized `PolicyTemplate` field on the wallet-level VTXO descriptor using `lib/arkscript`.
+- `ErrRefreshOperatorKeyUnsupported` — Sentinel returned by
+  `VTXODescriptor.RefreshOutputTemplate` for non-standard policy shapes.
+- `(d *VTXODescriptor) RefreshOutputTemplate(currentOperatorKey *btcec.PublicKey) ([]byte, error)` —
+  Wallet-level equivalent of `vtxo.Descriptor.RefreshOutputTemplate`.
+  Rebuilds the policy template for the NEW VTXO output using the
+  caller-supplied current operator key while preserving owner key and
+  exit delay. Wraps decode failures with `ErrRefreshOperatorKeyUnsupported`
+  so callers can branch with a single `errors.Is` check.
+- `WithFetchOperatorKey(fetch func(context.Context) (*btcec.PublicKey, error)) ArkOption` —
+  Wires a closure that fetches the operator's current long-term key via
+  a single `GetInfo` round-trip into the wallet actor. Invoked once per
+  refresh batch in `handleRefreshVTXOs` so every new VTXO in the round
+  commits to the same operator key.
+- `GetBoardingBalanceRequest` / `GetBoardingBalanceResponse` — Ask-request
+  for boarding balance. `GetBoardingBalanceResponse` now carries
+  `UnconfirmedBalance btcutil.Amount` (sum of zero-conf UTXOs paying to
+  boarding scripts) and `UnconfirmedUtxoCount int` alongside the existing
+  confirmed balance fields.
 
 ## Relationships
 
-- **Depends on**: `baselib/actor` (actor system), `chainsource` (block epoch notifications), `lib/actormsg` (VTXO manager admission types), `ledger` (`Sink` alias for emission + `UTXOCreatedMsg` / `ClassificationDeposit` constants).
+- **Depends on**: `baselib/actor` (actor system), `chainsource` (block epoch notifications), `lib/actormsg` (VTXO manager admission types), `ledger` (`Sink` alias for emission + `UTXOCreatedMsg` / `ClassificationDeposit` constants), `lib/arkscript` (policy template rebuild for operator key rotation).
 - **Depended on by**: `round` (boarding intents, types: `BoardingAddress`, `SelectedVTXO`), `db` (persistence), `darepod` (wiring).
 - **Sends**:
   - → `round` (via registered notifier): `BoardingUtxoConfirmedEvent`
@@ -52,7 +70,7 @@ refresh, leave, OOR spend, and directed send flows.
 - **Receives**:
   - ← `chainsource`: `BlockEpochNotification` (triggers UTXO polling)
   - ← `round`: `RegisterConfirmationNotifierRequest`, `UnregisterConfirmationNotifierRequest`
-  - ← API: `CreateBoardingAddressRequest`, `GetActiveBoardingAddressesRequest`, `GetBoardingBalanceRequest`, `GetConfirmedBoardingIntentsRequest`, `RefreshVTXOsRequest`, `SelectAndLockVTXOsRequest`, `LeaveVTXOsRequest`, `BoardRequest`, `CompleteSpendVTXOsRequest`, `UnlockVTXOsRequest`, `SendVTXOsRequest`
+  - ← API: `CreateBoardingAddressRequest`, `GetActiveBoardingAddressesRequest`, `GetBoardingBalanceRequest`, `GetConfirmedBoardingIntentsRequest`, `RefreshVTXOsRequest`, `SelectAndLockVTXOsRequest`, `LeaveVTXOsRequest`, `BoardRequest`, `CompleteSpendVTXOsRequest`, `UnlockVTXOsRequest`, `SendVTXOsRequest`, `GetBoardingBalanceRequest`
 
 ## Invariants
 
@@ -68,6 +86,12 @@ refresh, leave, OOR spend, and directed send flows.
 - `handleSendVTXOs` rejects pre-flight any directed send with multiple recipients and exactly-zero change residual under the #270 seal-time fee handshake. The server is the amount authority and absorbs the operator fee out of the designated `IsChange=true` slot; if there is no residual to absorb the fee against, the server has no slack to deduct fees without silently shifting them onto a recipient leg. The wallet refuses the request rather than letting the server pick the loser.
 - `VTXOReader` / `VTXODescriptor` / `SelectedVTXO` break the vtxo → round → wallet import cycle by providing wallet-level types that don't reference `vtxo.Descriptor` directly.
 - Per-subsystem logging via `build.LoggerFromContext` (no global mutable loggers).
+- When `WithFetchOperatorKey` is wired, `handleRefreshVTXOs` fetches the
+  operator's current long-term key **once** for the whole batch via a
+  single `GetInfo` call. Every new VTXO minted in that round commits to
+  the same key, avoiding N redundant round-trips. Fetch errors fail the
+  whole RPC. For non-standard policy shapes or when the option is unset
+  (harness paths), the handler falls back to the descriptor's stored bytes.
 
 ## Deep Docs
 

--- a/wallet/CLAUDE.md
+++ b/wallet/CLAUDE.md
@@ -34,10 +34,28 @@ refresh, leave, OOR spend, and directed send flows.
 - `SendVTXOsRequest` / `SendVTXOsResponse` — Ask-request for in-round directed sends. Validates each recipient amount is within `(0, MaxSatoshi]` and that the running total never overflows `int64`, atomically selects and reserves VTXOs via `SelectAndReserveForfeitRequest`, builds forfeit + recipient VTXO intents, and registers with the round actor. Supports dry-run mode for previewing coin selection without committing. Reserved VTXOs are released via a deferred cleanup that uses `context.WithoutCancel` so cleanup survives caller disconnect; on success, a `committed` flag is set to skip the release.
 - `GetConfirmedBoardingIntentsRequest` / `GetConfirmedBoardingIntentsResponse` — Ask-request to retrieve currently confirmed boarding intents (used by the RPC/CLI layer to report boarding balance with policy metadata).
 - `VTXODescriptor.EffectivePolicyTemplate` — Decodes the serialized `PolicyTemplate` field on the wallet-level VTXO descriptor using `lib/arkscript`.
+- `ErrRefreshOperatorKeyUnsupported` — Sentinel returned by
+  `VTXODescriptor.RefreshOutputTemplate` for non-standard policy shapes.
+- `(d *VTXODescriptor) RefreshOutputTemplate(currentOperatorKey *btcec.PublicKey) ([]byte, error)` —
+  Wallet-level equivalent of `vtxo.Descriptor.RefreshOutputTemplate`.
+  Rebuilds the policy template for the NEW VTXO output using the
+  caller-supplied current operator key while preserving owner key and
+  exit delay. Wraps decode failures with `ErrRefreshOperatorKeyUnsupported`
+  so callers can branch with a single `errors.Is` check.
+- `WithFetchOperatorKey(fetch func(context.Context) (*btcec.PublicKey, error)) ArkOption` —
+  Wires a closure that fetches the operator's current long-term key via
+  a single `GetInfo` round-trip into the wallet actor. Invoked once per
+  refresh batch in `handleRefreshVTXOs` so every new VTXO in the round
+  commits to the same operator key.
+- `GetBoardingBalanceRequest` / `GetBoardingBalanceResponse` — Ask-request
+  for boarding balance. `GetBoardingBalanceResponse` now carries
+  `UnconfirmedBalance btcutil.Amount` (sum of zero-conf UTXOs paying to
+  boarding scripts) and `UnconfirmedUtxoCount int` alongside the existing
+  confirmed balance fields.
 
 ## Relationships
 
-- **Depends on**: `baselib/actor` (actor system), `chainsource` (block epoch notifications), `lib/actormsg` (VTXO manager admission types), `ledger` (`Sink` alias for emission + `UTXOCreatedMsg` / `ClassificationDeposit` constants).
+- **Depends on**: `baselib/actor` (actor system), `chainsource` (block epoch notifications), `lib/actormsg` (VTXO manager admission types), `ledger` (`Sink` alias for emission + `UTXOCreatedMsg` / `ClassificationDeposit` constants), `lib/arkscript` (policy template rebuild for operator key rotation).
 - **Depended on by**: `round` (boarding intents, types: `BoardingAddress`, `SelectedVTXO`), `db` (persistence), `darepod` (wiring).
 - **Sends**:
   - → `round` (via registered notifier): `BoardingUtxoConfirmedEvent`
@@ -52,7 +70,7 @@ refresh, leave, OOR spend, and directed send flows.
 - **Receives**:
   - ← `chainsource`: `BlockEpochNotification` (triggers UTXO polling)
   - ← `round`: `RegisterConfirmationNotifierRequest`, `UnregisterConfirmationNotifierRequest`
-  - ← API: `CreateBoardingAddressRequest`, `GetActiveBoardingAddressesRequest`, `GetBoardingBalanceRequest`, `GetConfirmedBoardingIntentsRequest`, `RefreshVTXOsRequest`, `SelectAndLockVTXOsRequest`, `LeaveVTXOsRequest`, `BoardRequest`, `CompleteSpendVTXOsRequest`, `UnlockVTXOsRequest`, `SendVTXOsRequest`
+  - ← API: `CreateBoardingAddressRequest`, `GetActiveBoardingAddressesRequest`, `GetBoardingBalanceRequest`, `GetConfirmedBoardingIntentsRequest`, `RefreshVTXOsRequest`, `SelectAndLockVTXOsRequest`, `LeaveVTXOsRequest`, `BoardRequest`, `CompleteSpendVTXOsRequest`, `UnlockVTXOsRequest`, `SendVTXOsRequest`, `GetBoardingBalanceRequest`
 
 ## Invariants
 
@@ -68,6 +86,12 @@ refresh, leave, OOR spend, and directed send flows.
 - `handleSendVTXOs` rejects pre-flight any directed send with multiple recipients and exactly-zero change residual under the #270 seal-time fee handshake. The server is the amount authority and absorbs the operator fee out of the designated `IsChange=true` slot; if there is no residual to absorb the fee against, the server has no slack to deduct fees without silently shifting them onto a recipient leg. The wallet refuses the request rather than letting the server pick the loser.
 - `VTXOReader` / `VTXODescriptor` / `SelectedVTXO` break the vtxo → round → wallet import cycle by providing wallet-level types that don't reference `vtxo.Descriptor` directly.
 - Per-subsystem logging via `build.LoggerFromContext` (no global mutable loggers).
+- When `WithFetchOperatorKey` is wired, `handleRefreshVTXOs` fetches the
+  operator's current long-term key **once** for the whole batch via a
+  single `GetInfo` call. Every new VTXO minted in that round commits to
+  the same key, avoiding N redundant round-trips. Fetch errors fail the
+  whole RPC. For non-standard policy shapes or when the option is unset
+  (harness paths), the handler falls back to the descriptor's stored bytes.
 
 ## Deep Docs
 


### PR DESCRIPTION
## Summary

- Updated per-package `CLAUDE.md`/`AGENTS.md` for 13 packages with Go changes since last sweep: `swapwallet`, `vtxo`, `wallet`, `lwwallet`, `btcwbackend`, `gateway`, `swapclientserver`, `cmd/darepocli/darepoclicommands`, `sdk/swaps`, `sdk/walletdk`, `darepod`, `baselib/actor`
- Created new `serverconn/mailboxpull/CLAUDE.md` + `AGENTS.md` for new package
- Updated `ARCHITECTURE.md` to include `serverconn/mailboxpull` in the Layer 2 table

Key changes documented: `InspectionService` in swapwallet, operator key rotation via `FetchOperatorKey` in vtxo/wallet, Esplora gap-fill in lwwallet, neutrino header import in btcwbackend/walletdk, wildcard CORS in gateway, invoice memo in swapclientserver/sdk/swaps, `activity inspect` command in CLI, durable actor shutdown bookkeeping invariant.

Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

## Review

Please review the updated `CLAUDE.md`/`AGENTS.md` and `ARCHITECTURE.md` diffs for accuracy.