### PR TITLE
docs: nightly doc-gardening sweep 2026-05-26

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -46,7 +46,7 @@ package may import from a higher layer.
 | [`fraud`](fraud/) | Fraud detection actor: watches OOR ancestor outpoints on-chain and triggers unilateral exit when an ancestor is spent |
 | [`db`](db/) | SQLite/PostgreSQL persistence: boarding, rounds, VTXOs, OOR artifacts, fee ledger |
 | [`mailbox`](mailbox/) | Mailbox protocol primitives across three sub-packages (pb, rpc, conn) |
-| [`serverconn`](serverconn/) | Unified server connector: durable egress, ingress polling, unary RPC facade |
+| [`serverconn`](serverconn/) | Unified server connector: durable egress, ingress polling, unary RPC facade. Sub-package `serverconn/mailboxpull` provides shared exponential-backoff retry primitives for mailbox pull loops. |
 
 ### Layer 3: Application & Orchestration
 

--- a/lib/arkscript/AGENTS.md
+++ b/lib/arkscript/AGENTS.md
@@ -33,7 +33,17 @@ validated invariants.
     signature over an attacker-chosen tapscript.
 - `StandardVTXOParams` — Decoded parameters for a standard Ark VTXO policy (owner key, operator key, CSV delay). Derived via `DecodeStandardVTXOParams`.
 - `ComposedPolicy` — Composes an existing `CompiledPolicy` with an additional sibling tap branch root, allowing sub-tree aggregation. Built with `ComposeWithSiblingRoot`.
-- `AnchorOutput` / `AnchorPkScript` — `AnchorPkScript` is the standard P2A keyless pkScript; `AnchorOutput` returns a zero-value `wire.TxOut` carrying it for CPFP fee bumping.
+- `AnchorOutput(opts ...AnchorOption) *wire.TxOut` — Returns a P2A output.
+  Without options the value is zero (BIP-433 ephemeral-anchor pattern: parent
+  pays 0 fee, CPFP child funds the package). Callers whose parent pays its own
+  miner fee must pass `WithAnchorValue(sats)` to lift the anchor above the P2A
+  dust threshold (240 sats); otherwise bitcoind rejects the parent as "dust, tx
+  with dust output must be 0-fee".
+- `AnchorOption` — `func(*wire.TxOut)` functional option for `AnchorOutput`.
+- `WithAnchorValue(sats int64) AnchorOption` — Sets a non-zero anchor value.
+  Any value > 240 takes the output out of the ephemeral-dust regime.
+- `AnchorPkScript` — Package-level P2A keyless pkScript byte slice (defensive
+  copy returned by `AnchorOutput` so callers cannot mutate the global).
 - `EncodedLeaf` / `EncodeTapTree` / `DecodeTapTree` — TLV-based tap tree serialization for PSBT sidecars compatible with `waddrmgr` format.
 - `EncodeStandardVTXOArtifacts(ownerKey, operatorKey, exitDelay)` — Convenience
   helper returning both the encoded policy template bytes and the canonical P2TR

--- a/lib/arkscript/CLAUDE.md
+++ b/lib/arkscript/CLAUDE.md
@@ -33,7 +33,17 @@ validated invariants.
     signature over an attacker-chosen tapscript.
 - `StandardVTXOParams` — Decoded parameters for a standard Ark VTXO policy (owner key, operator key, CSV delay). Derived via `DecodeStandardVTXOParams`.
 - `ComposedPolicy` — Composes an existing `CompiledPolicy` with an additional sibling tap branch root, allowing sub-tree aggregation. Built with `ComposeWithSiblingRoot`.
-- `AnchorOutput` / `AnchorPkScript` — `AnchorPkScript` is the standard P2A keyless pkScript; `AnchorOutput` returns a zero-value `wire.TxOut` carrying it for CPFP fee bumping.
+- `AnchorOutput(opts ...AnchorOption) *wire.TxOut` — Returns a P2A output.
+  Without options the value is zero (BIP-433 ephemeral-anchor pattern: parent
+  pays 0 fee, CPFP child funds the package). Callers whose parent pays its own
+  miner fee must pass `WithAnchorValue(sats)` to lift the anchor above the P2A
+  dust threshold (240 sats); otherwise bitcoind rejects the parent as "dust, tx
+  with dust output must be 0-fee".
+- `AnchorOption` — `func(*wire.TxOut)` functional option for `AnchorOutput`.
+- `WithAnchorValue(sats int64) AnchorOption` — Sets a non-zero anchor value.
+  Any value > 240 takes the output out of the ephemeral-dust regime.
+- `AnchorPkScript` — Package-level P2A keyless pkScript byte slice (defensive
+  copy returned by `AnchorOutput` so callers cannot mutate the global).
 - `EncodedLeaf` / `EncodeTapTree` / `DecodeTapTree` — TLV-based tap tree serialization for PSBT sidecars compatible with `waddrmgr` format.
 - `EncodeStandardVTXOArtifacts(ownerKey, operatorKey, exitDelay)` — Convenience
   helper returning both the encoded policy template bytes and the canonical P2TR

--- a/rpc/AGENTS.md
+++ b/rpc/AGENTS.md
@@ -7,7 +7,7 @@ Client-side RPC message definitions and HTTP transport in sub-packages:
 | Sub-package | Kind | Purpose |
 |-------------|------|---------|
 | `rpc/roundpb` | generated | Round protocol messages |
-| `rpc/oorpb` | generated | OOR transfer messages |
+| `rpc/oorpb` | mixed | OOR transfer messages (generated proto stubs + hand-written helpers in `payloads.go`) |
 | `rpc/swapclientrpc` | generated | Swap client service stubs |
 | `rpc/walletrpc` | generated | Highest-level wallet service stubs |
 | `rpc/restclient` | hand-written | HTTP/protoJSON transport adapter |
@@ -24,5 +24,5 @@ Client-side RPC message definitions and HTTP transport in sub-packages:
 ## Invariants
 
 - **Never edit generated code** — regenerate via `make rpc`.
-- `rpc/restclient` is the only hand-written sub-package here; all others
-  are generated protobuf stubs.
+- `rpc/restclient` and `rpc/oorpb/payloads.go` are hand-written; all other
+  files in all sub-packages are generated protobuf stubs.

--- a/rpc/CLAUDE.md
+++ b/rpc/CLAUDE.md
@@ -7,7 +7,7 @@ Client-side RPC message definitions and HTTP transport in sub-packages:
 | Sub-package | Kind | Purpose |
 |-------------|------|---------|
 | `rpc/roundpb` | generated | Round protocol messages |
-| `rpc/oorpb` | generated | OOR transfer messages |
+| `rpc/oorpb` | mixed | OOR transfer messages (generated proto stubs + hand-written helpers in `payloads.go`) |
 | `rpc/swapclientrpc` | generated | Swap client service stubs |
 | `rpc/walletrpc` | generated | Highest-level wallet service stubs |
 | `rpc/restclient` | hand-written | HTTP/protoJSON transport adapter |
@@ -24,5 +24,5 @@ Client-side RPC message definitions and HTTP transport in sub-packages:
 ## Invariants
 
 - **Never edit generated code** — regenerate via `make rpc`.
-- `rpc/restclient` is the only hand-written sub-package here; all others
-  are generated protobuf stubs.
+- `rpc/restclient` and `rpc/oorpb/payloads.go` are hand-written; all other
+  files in all sub-packages are generated protobuf stubs.

--- a/rpc/oorpb/AGENTS.md
+++ b/rpc/oorpb/AGENTS.md
@@ -1,0 +1,62 @@
+# rpc/oorpb
+
+## Purpose
+
+OOR (out-of-round) transfer protocol message definitions and hand-written
+type helpers for the client-side submit/finalize/ack RPC flows. The package
+contains generated proto stubs plus `payloads.go`, which provides typed Go
+constructors and parsers so callers never manipulate raw proto bytes directly.
+
+## Key Types
+
+- `SigningDescriptor` — Minimal signing metadata for one OOR transfer input:
+  `Outpoint`, `VTXOPolicyTemplate`, `SpendPath`, `OwnerLeafPolicy`. Used by
+  both submit-request construction (client) and server co-signing.
+- `SubmitRejectedError` — Typed rejection error returned by
+  `ParseSubmitPackageResponse`. Carries `Code OORRejectCode` and `Reason`
+  string so callers can route on the cause (e.g.
+  `OOR_REJECT_LINEAGE_TOO_LARGE`) without string-matching.
+- `ServiceName`, `MethodSubmitPackage`, `MethodFinalizePackage`,
+  `MethodIncomingAck` — Canonical mailbox RPC service and method name
+  constants for the OOR request-response flows.
+
+## Constructors and Parsers (payloads.go)
+
+- `NewSubmitPackageRequest` — Builds a `*SubmitPackageRequest` from typed Go
+  domain objects (`*psbt.Packet`, `[]*psbt.Packet`, `[]SigningDescriptor`,
+  `[]oortx.RecipientOutput`).
+- `ParseSubmitPackageRequest` — Decodes a `*SubmitPackageRequest` back to
+  domain types. Returns an error on nil or malformed input.
+- `NewSubmitPackageResponse` — Builds the success branch of
+  `*SubmitPackageResponse`.
+- `NewSubmitPackageRejection` — Builds the rejection branch; echoes
+  `sessionID` so the client EventRouter can route the failure to the correct
+  OOR session FSM.
+- `ParseSubmitPackageResponse` — Decodes the success branch; returns
+  `*SubmitRejectedError` (via `errors.As`) for the rejection branch.
+- `NewFinalizePackageRequest` / `ParseFinalizePackageRequest` —
+  Finalize-phase typed encode/decode helpers.
+- `NewFinalizePackageResponse` / `ParseFinalizePackageResponse` —
+  Finalize-phase response helpers.
+
+## Relationships
+
+- **Depends on**: `lib/tx/oor` (`RecipientOutput`), `lib/tx/psbtutil`
+  (PSBT encode/decode), standard `btcd` types.
+- **Depended on by**: `oor` (client-side submit/finalize flows),
+  `swapclientserver` (server-side OOR co-signing).
+
+## Invariants
+
+- `payloads.go` is hand-written; the remaining `*.pb.go` files are generated
+  from `oorwire.proto` — never edit generated files directly.
+- `NewSubmitPackageRejection` echoes the session ID in the rejection proto so
+  the client-side EventRouter can route `SubmitRejectedError` to the correct
+  OOR session FSM rather than stalling the ingress cursor.
+- `ParseSubmitPackageResponse` returns a typed `*SubmitRejectedError`; use
+  `errors.As` to recover `Code` and `Reason` without string-matching.
+
+## Deep Docs
+
+- [rpc/CLAUDE.md](../CLAUDE.md) — Parent package overview.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/rpc/oorpb/CLAUDE.md
+++ b/rpc/oorpb/CLAUDE.md
@@ -1,0 +1,62 @@
+# rpc/oorpb
+
+## Purpose
+
+OOR (out-of-round) transfer protocol message definitions and hand-written
+type helpers for the client-side submit/finalize/ack RPC flows. The package
+contains generated proto stubs plus `payloads.go`, which provides typed Go
+constructors and parsers so callers never manipulate raw proto bytes directly.
+
+## Key Types
+
+- `SigningDescriptor` — Minimal signing metadata for one OOR transfer input:
+  `Outpoint`, `VTXOPolicyTemplate`, `SpendPath`, `OwnerLeafPolicy`. Used by
+  both submit-request construction (client) and server co-signing.
+- `SubmitRejectedError` — Typed rejection error returned by
+  `ParseSubmitPackageResponse`. Carries `Code OORRejectCode` and `Reason`
+  string so callers can route on the cause (e.g.
+  `OOR_REJECT_LINEAGE_TOO_LARGE`) without string-matching.
+- `ServiceName`, `MethodSubmitPackage`, `MethodFinalizePackage`,
+  `MethodIncomingAck` — Canonical mailbox RPC service and method name
+  constants for the OOR request-response flows.
+
+## Constructors and Parsers (payloads.go)
+
+- `NewSubmitPackageRequest` — Builds a `*SubmitPackageRequest` from typed Go
+  domain objects (`*psbt.Packet`, `[]*psbt.Packet`, `[]SigningDescriptor`,
+  `[]oortx.RecipientOutput`).
+- `ParseSubmitPackageRequest` — Decodes a `*SubmitPackageRequest` back to
+  domain types. Returns an error on nil or malformed input.
+- `NewSubmitPackageResponse` — Builds the success branch of
+  `*SubmitPackageResponse`.
+- `NewSubmitPackageRejection` — Builds the rejection branch; echoes
+  `sessionID` so the client EventRouter can route the failure to the correct
+  OOR session FSM.
+- `ParseSubmitPackageResponse` — Decodes the success branch; returns
+  `*SubmitRejectedError` (via `errors.As`) for the rejection branch.
+- `NewFinalizePackageRequest` / `ParseFinalizePackageRequest` —
+  Finalize-phase typed encode/decode helpers.
+- `NewFinalizePackageResponse` / `ParseFinalizePackageResponse` —
+  Finalize-phase response helpers.
+
+## Relationships
+
+- **Depends on**: `lib/tx/oor` (`RecipientOutput`), `lib/tx/psbtutil`
+  (PSBT encode/decode), standard `btcd` types.
+- **Depended on by**: `oor` (client-side submit/finalize flows),
+  `swapclientserver` (server-side OOR co-signing).
+
+## Invariants
+
+- `payloads.go` is hand-written; the remaining `*.pb.go` files are generated
+  from `oorwire.proto` — never edit generated files directly.
+- `NewSubmitPackageRejection` echoes the session ID in the rejection proto so
+  the client-side EventRouter can route `SubmitRejectedError` to the correct
+  OOR session FSM rather than stalling the ingress cursor.
+- `ParseSubmitPackageResponse` returns a typed `*SubmitRejectedError`; use
+  `errors.As` to recover `Code` and `Reason` without string-matching.
+
+## Deep Docs
+
+- [rpc/CLAUDE.md](../CLAUDE.md) — Parent package overview.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/serverconn/mailboxpull/AGENTS.md
+++ b/serverconn/mailboxpull/AGENTS.md
@@ -1,0 +1,54 @@
+# serverconn/mailboxpull
+
+## Purpose
+
+Shared retry and exponential-backoff primitives for mailbox pull loops.
+Factors out the common transport-reliability shape used by both the persistent
+identity-mailbox ingress loop in the parent `serverconn` package and by
+per-swap event consumers in the SDK, so backoff semantics stay uniform across
+all consumers.
+
+## Key Types
+
+- `BackoffConfig` — Exponential-backoff tuning: `BaseDelay` and `MaxDelay`.
+  The zero value selects package defaults (200 ms base, 30 s cap) so callers
+  that do not care about tuning can pass `BackoffConfig{}` without creating a
+  tight retry loop.
+- `DefaultBackoffConfig() BackoffConfig` — Returns the production defaults
+  (200 ms base, 30 s cap) matching `serverconn.DefaultConnectorConfig`.
+
+## Key Functions
+
+- `RetryDelay(cfg BackoffConfig, attempt int) time.Duration` — Computes
+  `min(base * 2^(attempt-1), max) * U[0.5, 1.0)` with jitter to spread
+  concurrent retries across the same endpoint.
+- `Sleep(ctx context.Context, cfg BackoffConfig, attempt *int)` — Increments
+  the attempt counter and sleeps for the next backoff interval, respecting
+  context cancellation. The caller owns `attempt` so multiple pull cycles can
+  share a single growing backoff schedule.
+- `PullWithRetry(ctx, edge, req, cfg, log)` — Calls `edge.Pull`, retrying
+  on transport errors with exponential backoff until the call succeeds or ctx
+  is cancelled. Status-level failures (`resp.Status.Ok == false`) are returned
+  to the caller; only transport errors trigger retry.
+
+## Relationships
+
+- **Depends on**: `mailbox/pb` (`MailboxServiceClient`, `PullRequest`,
+  `PullResponse`).
+- **Depended on by**: `serverconn` (ingress pull loop), `sdk/swaps` (per-swap
+  event consumers).
+
+## Invariants
+
+- `PullWithRetry` only retries transport errors, not status-level failures.
+  Status errors are protocol-level problems that retry cannot fix; the caller
+  must decide how to surface them.
+- Context cancellation returns the context error, not the underlying transport
+  error, so callers can distinguish "caller gave up" from "endpoint flapping".
+- Jitter uses non-cryptographic randomness (`math/rand/v2`) — backoff timing
+  is not security-sensitive.
+
+## Deep Docs
+
+- [serverconn/CLAUDE.md](../CLAUDE.md) — Parent package.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/serverconn/mailboxpull/CLAUDE.md
+++ b/serverconn/mailboxpull/CLAUDE.md
@@ -1,0 +1,54 @@
+# serverconn/mailboxpull
+
+## Purpose
+
+Shared retry and exponential-backoff primitives for mailbox pull loops.
+Factors out the common transport-reliability shape used by both the persistent
+identity-mailbox ingress loop in the parent `serverconn` package and by
+per-swap event consumers in the SDK, so backoff semantics stay uniform across
+all consumers.
+
+## Key Types
+
+- `BackoffConfig` — Exponential-backoff tuning: `BaseDelay` and `MaxDelay`.
+  The zero value selects package defaults (200 ms base, 30 s cap) so callers
+  that do not care about tuning can pass `BackoffConfig{}` without creating a
+  tight retry loop.
+- `DefaultBackoffConfig() BackoffConfig` — Returns the production defaults
+  (200 ms base, 30 s cap) matching `serverconn.DefaultConnectorConfig`.
+
+## Key Functions
+
+- `RetryDelay(cfg BackoffConfig, attempt int) time.Duration` — Computes
+  `min(base * 2^(attempt-1), max) * U[0.5, 1.0)` with jitter to spread
+  concurrent retries across the same endpoint.
+- `Sleep(ctx context.Context, cfg BackoffConfig, attempt *int)` — Increments
+  the attempt counter and sleeps for the next backoff interval, respecting
+  context cancellation. The caller owns `attempt` so multiple pull cycles can
+  share a single growing backoff schedule.
+- `PullWithRetry(ctx, edge, req, cfg, log)` — Calls `edge.Pull`, retrying
+  on transport errors with exponential backoff until the call succeeds or ctx
+  is cancelled. Status-level failures (`resp.Status.Ok == false`) are returned
+  to the caller; only transport errors trigger retry.
+
+## Relationships
+
+- **Depends on**: `mailbox/pb` (`MailboxServiceClient`, `PullRequest`,
+  `PullResponse`).
+- **Depended on by**: `serverconn` (ingress pull loop), `sdk/swaps` (per-swap
+  event consumers).
+
+## Invariants
+
+- `PullWithRetry` only retries transport errors, not status-level failures.
+  Status errors are protocol-level problems that retry cannot fix; the caller
+  must decide how to surface them.
+- Context cancellation returns the context error, not the underlying transport
+  error, so callers can distinguish "caller gave up" from "endpoint flapping".
+- Jitter uses non-cryptographic randomness (`math/rand/v2`) — backoff timing
+  is not security-sensitive.
+
+## Deep Docs
+
+- [serverconn/CLAUDE.md](../CLAUDE.md) — Parent package.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.


### PR DESCRIPTION
Automated nightly documentation sweep via `.claude/skills/doc-gardening`.

## Changes

- **`lib/arkscript/CLAUDE.md`** — Updated `AnchorOutput` docs to reflect new variadic `AnchorOption` API and `WithAnchorValue` helper (the function signature changed from returning a fixed zero-value TxOut to `func(opts ...AnchorOption) *wire.TxOut`).
- **`rpc/CLAUDE.md`** — Corrected `rpc/oorpb` description from "generated" to "mixed" (it contains hand-written helpers in `payloads.go` alongside the proto stubs).
- **`rpc/oorpb/CLAUDE.md`** *(new)* — Documented the hand-written types and constructor/parser helpers in `payloads.go` (`SigningDescriptor`, `SubmitRejectedError`, `NewSubmitPackageRequest`, `ParseSubmitPackageResponse`, etc.).
- **`serverconn/mailboxpull/CLAUDE.md`** *(new)* — Documented the new shared retry/backoff package (`BackoffConfig`, `PullWithRetry`, `RetryDelay`, `Sleep`).
- **`ARCHITECTURE.md`** — Added `serverconn/mailboxpull` sub-package note to the `serverconn` row.

Workflow run: https://github.com/lightninglabs/darepo-client/actions/runs/0

Please review the updated `CLAUDE.md`/`AGENTS.md` and `ARCHITECTURE.md` diffs before merging.