### PR TITLE
security: fix #375 #392 #393, mitigate #399 #400

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,6 +55,15 @@ jobs:
 
       - name: Compute image tags
         id: tags
+        env:
+          # Pass workflow_dispatch inputs through the environment rather
+          # than interpolating ${{ ... }} directly into the shell script.
+          # Direct interpolation lets an input value containing shell
+          # metacharacters break out of the quoting and inject commands
+          # before any in-script sanitization (e.g. the tr pipeline
+          # below) can run.
+          INPUT_CHECKOUT: ${{ github.event.inputs.checkout }}
+          INPUT_TAG_SUFFIX: ${{ github.event.inputs.tag_suffix }}
         run: |
           set -euo pipefail
           SHORT_SHA="$(git rev-parse --short=7 HEAD)"
@@ -79,17 +88,17 @@ jobs:
           ${REPO}:nightly-${DATE_TAG}"
               ;;
             workflow_dispatch)
-              SUFFIX="${{ github.event.inputs.tag_suffix }}"
-              # Sanitize the input ref for use in a docker tag: replace
+              # Sanitize both inputs for use in a docker tag: replace
               # any character that's not alphanumeric/dot/underscore/dash
-              # with a dash. Empty input means "current ref".
-              REF_INPUT="${{ github.event.inputs.checkout }}"
+              # with a dash. Empty checkout input means "current ref".
+              REF_INPUT="${INPUT_CHECKOUT}"
               if [[ -z "${REF_INPUT}" ]]; then
                 REF_INPUT="${SHORT_SHA}"
               fi
-              REF_SLUG="$(echo -n "${REF_INPUT}" | tr -c 'A-Za-z0-9._-' '-' | cut -c1-60)"
-              if [[ -n "${SUFFIX}" ]]; then
-                TAGS="${REPO}:manual-${REF_SLUG}-${SUFFIX}"
+              REF_SLUG="$(printf '%s' "${REF_INPUT}" | tr -c 'A-Za-z0-9._-' '-' | cut -c1-60)"
+              SUFFIX_SLUG="$(printf '%s' "${INPUT_TAG_SUFFIX}" | tr -c 'A-Za-z0-9._-' '-' | cut -c1-60)"
+              if [[ -n "${SUFFIX_SLUG}" ]]; then
+                TAGS="${REPO}:manual-${REF_SLUG}-${SUFFIX_SLUG}"
               else
                 TAGS="${REPO}:manual-${REF_SLUG}"
               fi

--- a/chainbackends/bitcoindrpc/package_submitter.go
+++ b/chainbackends/bitcoindrpc/package_submitter.go
@@ -12,11 +12,16 @@ package bitcoindrpc
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/btcsuite/btcd/btcjson"
@@ -41,20 +46,163 @@ type PackageSubmitter struct {
 	client *http.Client
 }
 
+// Option configures a PackageSubmitter.
+type Option func(*options)
+
+type options struct {
+	tlsCertPath string
+}
+
+// WithTLSCertPath configures the HTTPS submitter to trust the CA
+// certificate at path. It is intended for operators fronting bitcoind's
+// plain HTTP RPC server with a local TLS reverse proxy.
+func WithTLSCertPath(path string) Option {
+	return func(o *options) {
+		o.tlsCertPath = path
+	}
+}
+
 // New creates a submitter that talks to the given bitcoind JSON-RPC
-// endpoint. The host string is of the form "host:port"; the URL is
-// built with an "http://" scheme because bitcoind's JSON-RPC server
-// is plain HTTP by default, and TLS termination (when present) is
-// expected to be handled by a separately configured reverse proxy.
+// endpoint. Bare host:port inputs default to http:// for compatibility.
+// Use NewWithOptions when endpoint parsing or TLS configuration errors
+// need to be surfaced to the caller.
 func New(host, user, password string) *PackageSubmitter {
+	submitter, err := NewWithOptions(host, user, password)
+	if err != nil {
+
+		// New preserves the legacy no-error constructor for callers
+		// that pass the historical bare host:port form. The fallback is
+		// kept intentionally narrow: option-using callers should use
+		// NewWithOptions so malformed URLs and TLS config errors
+		// surface.
+		return &PackageSubmitter{
+			url:      fmt.Sprintf("http://%s", host),
+			user:     user,
+			password: password,
+			client: &http.Client{
+				Timeout: submitTimeout,
+			},
+		}
+	}
+
+	return submitter
+}
+
+// NewWithOptions creates a submitter that talks to the given bitcoind
+// JSON-RPC endpoint. Bare host:port inputs default to http:// unless a
+// TLS certificate path is provided, in which case they default to
+// https://. Full http:// and https:// URLs are accepted as-is.
+func NewWithOptions(host, user, password string,
+	opts ...Option) (*PackageSubmitter, error) {
+
+	var cfg options
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	endpoint, err := endpointURL(host, cfg.tlsCertPath != "")
+	if err != nil {
+		return nil, err
+	}
+	if cfg.tlsCertPath != "" && endpoint.Scheme != "https" {
+		return nil, fmt.Errorf("bitcoind TLS cert requires https "+
+			"endpoint, got %q", endpoint.Scheme)
+	}
+
+	client, err := httpClient(endpoint.Scheme, cfg.tlsCertPath)
+	if err != nil {
+		return nil, err
+	}
+
 	return &PackageSubmitter{
-		url:      fmt.Sprintf("http://%s", host),
+		url:      endpoint.String(),
 		user:     user,
 		password: password,
-		client: &http.Client{
-			Timeout: submitTimeout,
-		},
+		client:   client,
+	}, nil
+}
+
+// endpointURL normalizes the operator-supplied bitcoind endpoint into a
+// concrete http:// or https:// URL.
+func endpointURL(host string, preferHTTPS bool) (*url.URL, error) {
+	if strings.TrimSpace(host) == "" {
+		return nil, fmt.Errorf("bitcoind host is required")
 	}
+
+	raw := host
+	if !strings.Contains(raw, "://") {
+		scheme := "http"
+		if preferHTTPS {
+			scheme = "https"
+		}
+		raw = scheme + "://" + raw
+	}
+
+	endpoint, err := url.Parse(raw)
+	if err != nil {
+		return nil, fmt.Errorf("parse bitcoind endpoint %q: %w", host,
+			err)
+	}
+	if endpoint.Scheme != "http" && endpoint.Scheme != "https" {
+		return nil, fmt.Errorf("unsupported bitcoind endpoint "+
+			"scheme %q", endpoint.Scheme)
+	}
+	if endpoint.Host == "" {
+		return nil, fmt.Errorf("bitcoind endpoint %q has no host", host)
+	}
+
+	return endpoint, nil
+}
+
+// httpClient returns the HTTP client used for bitcoind RPC calls.
+func httpClient(scheme, tlsCertPath string) (*http.Client, error) {
+	// Always start from a clone of http.DefaultTransport so the
+	// submitter keeps connection pooling, keep-alives, dialer, and
+	// idle timeouts on every path (plain HTTP, HTTPS with the system
+	// trust store, or HTTPS with a custom CA) and never shares the
+	// process-global transport. The fallback only matters if a future
+	// stdlib change swaps the default-transport concrete type.
+	var transport *http.Transport
+	if dt, ok := http.DefaultTransport.(*http.Transport); ok {
+		transport = dt.Clone()
+	} else {
+		transport = &http.Transport{}
+	}
+
+	// Only an https endpoint with a custom CA needs a bespoke TLS
+	// config; an https endpoint without one verifies against the
+	// clone's default (system) trust store.
+	if scheme == "https" && tlsCertPath != "" {
+		//nolint:gosec // G304: cert path comes from operator config.
+		certBytes, err := os.ReadFile(tlsCertPath)
+		if err != nil {
+			return nil, fmt.Errorf("read bitcoind TLS cert %q: %w",
+				tlsCertPath, err)
+		}
+
+		// Augment the system trust store rather than replacing it so
+		// a custom CA is trusted in addition to the public roots.
+		// Fall back to an empty pool only if the system pool is
+		// unavailable.
+		roots, err := x509.SystemCertPool()
+		if err != nil || roots == nil {
+			roots = x509.NewCertPool()
+		}
+		if !roots.AppendCertsFromPEM(certBytes) {
+			return nil, fmt.Errorf("bitcoind TLS cert %q contains "+
+				"no PEM certificates", tlsCertPath)
+		}
+
+		transport.TLSClientConfig = &tls.Config{
+			MinVersion: tls.VersionTLS12,
+			RootCAs:    roots,
+		}
+	}
+
+	return &http.Client{
+		Timeout:   submitTimeout,
+		Transport: transport,
+	}, nil
 }
 
 // SubmitPackage implements chainbackends.PackageSubmitter by calling

--- a/chainbackends/bitcoindrpc/package_submitter_test.go
+++ b/chainbackends/bitcoindrpc/package_submitter_test.go
@@ -1,0 +1,117 @@
+package bitcoindrpc
+
+import (
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewWithOptionsURLAndTLS verifies endpoint normalization and custom
+// CA wiring for TLS-fronted bitcoind RPC deployments.
+func TestNewWithOptionsURLAndTLS(t *testing.T) {
+	t.Parallel()
+
+	certPath := writeTestCert(t)
+
+	tests := []struct {
+		name       string
+		host       string
+		certPath   string
+		wantURL    string
+		wantTLS    bool
+		wantErrSub string
+	}{
+		{
+			name:    "bare host defaults to http",
+			host:    "127.0.0.1:8332",
+			wantURL: "http://127.0.0.1:8332",
+		},
+		{
+			name:    "https URL is preserved",
+			host:    "https://bitcoind.example:8332",
+			wantURL: "https://bitcoind.example:8332",
+		},
+		{
+			name:     "cert path upgrades bare host to https",
+			host:     "bitcoind.example:8332",
+			certPath: certPath,
+			wantURL:  "https://bitcoind.example:8332",
+			wantTLS:  true,
+		},
+		{
+			name:     "https URL accepts custom cert",
+			host:     "https://bitcoind.example:8332",
+			certPath: certPath,
+			wantURL:  "https://bitcoind.example:8332",
+			wantTLS:  true,
+		},
+		{
+			name:       "custom cert rejects explicit http",
+			host:       "http://bitcoind.example:8332",
+			certPath:   certPath,
+			wantErrSub: "requires https",
+		},
+		{
+			name:       "unsupported scheme",
+			host:       "ftp://bitcoind.example:8332",
+			wantErrSub: "unsupported",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			submitter, err := NewWithOptions(
+				tc.host, "user", "pass",
+				WithTLSCertPath(tc.certPath),
+			)
+			if tc.wantErrSub != "" {
+				require.ErrorContains(t, err, tc.wantErrSub)
+
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.wantURL, submitter.url)
+
+			if !tc.wantTLS {
+				return
+			}
+
+			transport, ok := submitter.client.Transport.(*http.
+				Transport)
+			require.True(t, ok)
+			require.NotSame(t, http.DefaultTransport, transport)
+			require.NotNil(t, transport.TLSClientConfig)
+			require.NotNil(t, transport.TLSClientConfig.RootCAs)
+		})
+	}
+}
+
+// writeTestCert writes a valid PEM certificate for TLS configuration tests.
+func writeTestCert(t *testing.T) string {
+	t.Helper()
+
+	server := httptest.NewTLSServer(
+		http.HandlerFunc(
+			func(http.ResponseWriter, *http.Request) {},
+		),
+	)
+	t.Cleanup(server.Close)
+
+	pemBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: server.Certificate().Raw,
+	})
+
+	path := filepath.Join(t.TempDir(), "bitcoind.pem")
+	err := os.WriteFile(path, pemBytes, 0o600)
+	require.NoError(t, err)
+
+	return path
+}

--- a/cmd/darepod/main.go
+++ b/cmd/darepod/main.go
@@ -71,9 +71,16 @@ func newRootCmd() *cobra.Command {
 			host := v.GetString("bitcoind.host")
 			user := v.GetString("bitcoind.user")
 			pass := v.GetString("bitcoind.pass")
+			cookie := v.GetString("bitcoind.rpccookie")
 			if host != "" {
+				u, p, err := resolveBitcoindAuth(
+					user, pass, cookie,
+				)
+				if err != nil {
+					return err
+				}
 				cfg.PackageSubmitter = bitcoindrpc.New(
-					host, user, pass,
+					host, u, p,
 				)
 			}
 
@@ -170,8 +177,17 @@ func newRootCmd() *cobra.Command {
 	f.String("bitcoind.user", "",
 		"bitcoind RPC username",
 	)
-	f.String("bitcoind.pass", "",
-		"bitcoind RPC password",
+	f.String(
+		"bitcoind.pass", "", "bitcoind RPC password (prefer "+
+			"bitcoind.rpccookie: command-line passwords are "+
+			"visible to other users via 'ps')",
+	)
+	f.String(
+		"bitcoind.rpccookie", "", "path to bitcoind's '.cookie' "+
+			"auth file. Mutually exclusive with "+
+			"bitcoind.user/bitcoind.pass; preferred because "+
+			"the password never appears in process args or "+
+			"persistent config",
 	)
 
 	// Daemon RPC server flags.
@@ -543,4 +559,44 @@ func configureDaemonLogWriter(cfg *darepod.Config,
 	cfg.LogWriter = io.MultiWriter(bestEffortWriter{stdout}, logFile)
 
 	return logFile, nil
+}
+
+// resolveBitcoindAuth picks the bitcoind RPC credentials to use, given
+// the operator-supplied user/pass values and an optional path to a
+// bitcoind '.cookie' file. Cookie auth is preferred because it
+// removes two leak paths that plain user/pass have: passwords on the
+// command line are visible to every local process via 'ps', and
+// passwords in a persistent config file survive across restarts and
+// backups. The cookie file is regenerated on every bitcoind startup
+// and is mode 0600 by bitcoind. Mutual exclusion mirrors lnd's
+// behaviour and prevents silent precedence surprises.
+func resolveBitcoindAuth(user, pass, cookiePath string) (string, string,
+	error) {
+
+	if cookiePath != "" && (user != "" || pass != "") {
+		return "", "", fmt.Errorf("bitcoind.rpccookie is mutually " +
+			"exclusive with bitcoind.user / bitcoind.pass; set " +
+			"one or the other")
+	}
+
+	if cookiePath == "" {
+		return user, pass, nil
+	}
+
+	//nolint:gosec // G304: cookie path comes from operator config.
+	data, err := os.ReadFile(cookiePath)
+	if err != nil {
+		return "", "", fmt.Errorf("read bitcoind cookie %q: %w",
+			cookiePath, err)
+	}
+
+	// bitcoind writes "<user>:<password>" with no trailing newline,
+	// but tolerate stray whitespace from manual edits or copies.
+	parts := strings.SplitN(strings.TrimSpace(string(data)), ":", 2)
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("bitcoind cookie %q has unexpected "+
+			"format: want <user>:<password>", cookiePath)
+	}
+
+	return parts[0], parts[1], nil
 }

--- a/cmd/darepod/main.go
+++ b/cmd/darepod/main.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -68,20 +70,9 @@ func newRootCmd() *cobra.Command {
 
 			// Wire bitcoind package submitter for V3
 			// ephemeral anchor package relay (unroll).
-			host := v.GetString("bitcoind.host")
-			user := v.GetString("bitcoind.user")
-			pass := v.GetString("bitcoind.pass")
-			cookie := v.GetString("bitcoind.rpccookie")
-			if host != "" {
-				u, p, err := resolveBitcoindAuth(
-					user, pass, cookie,
-				)
-				if err != nil {
-					return err
-				}
-				cfg.PackageSubmitter = bitcoindrpc.New(
-					host, u, p,
-				)
+			err := configureBitcoindSubmitter(v, cfg)
+			if err != nil {
+				return err
 			}
 
 			configureSwapRuntime(cfg)
@@ -168,27 +159,7 @@ func newRootCmd() *cobra.Command {
 			"at startup (lwwallet/btcwallet)",
 	)
 
-	// Optional bitcoind direct connection for package relay.
-	// Required for V3 ephemeral anchor transactions (unroll).
-	f.String(
-		"bitcoind.host", "",
-		"bitcoind RPC address (host:port) for submitpackage support",
-	)
-	f.String("bitcoind.user", "",
-		"bitcoind RPC username",
-	)
-	f.String(
-		"bitcoind.pass", "", "bitcoind RPC password (prefer "+
-			"bitcoind.rpccookie: command-line passwords are "+
-			"visible to other users via 'ps')",
-	)
-	f.String(
-		"bitcoind.rpccookie", "", "path to bitcoind's '.cookie' "+
-			"auth file. Mutually exclusive with "+
-			"bitcoind.user/bitcoind.pass; preferred because "+
-			"the password never appears in process args or "+
-			"persistent config",
-	)
+	registerBitcoindFlags(f)
 
 	// Daemon RPC server flags.
 	f.String(
@@ -559,6 +530,148 @@ func configureDaemonLogWriter(cfg *darepod.Config,
 	cfg.LogWriter = io.MultiWriter(bestEffortWriter{stdout}, logFile)
 
 	return logFile, nil
+}
+
+// registerBitcoindFlags registers optional direct bitcoind package relay
+// flags. Direct bitcoind relay is used for V3 ephemeral anchor transactions.
+func registerBitcoindFlags(f *pflag.FlagSet) {
+	f.String(
+		"bitcoind.host", "",
+		"bitcoind RPC address (host:port) for submitpackage support",
+	)
+	f.String("bitcoind.user", "",
+		"bitcoind RPC username",
+	)
+	f.String(
+		"bitcoind.pass", "", "bitcoind RPC password (prefer "+
+			"bitcoind.rpccookie: command-line passwords are "+
+			"visible to other users via 'ps')",
+	)
+	f.String(
+		"bitcoind.rpccookie", "", "path to bitcoind's '.cookie' "+
+			"auth file. Mutually exclusive with "+
+			"bitcoind.user/bitcoind.pass; preferred because "+
+			"the password never appears in process args or "+
+			"persistent config",
+	)
+	f.String(
+		"bitcoind.tlscertpath", "", "path to a PEM CA certificate "+
+			"for HTTPS bitcoind RPC. Bare bitcoind.host values "+
+			"use https:// when this is set",
+	)
+}
+
+// configureBitcoindSubmitter wires the optional bitcoind package
+// submitter onto cfg, reading the bitcoind.* config keys from v.
+// Bitcoind support is opt-in: when bitcoind.host is unset the daemon
+// runs without a direct submitpackage path (lnd v3 relay is used
+// instead when available).
+func configureBitcoindSubmitter(v *viper.Viper, cfg *darepod.Config) error {
+	host := v.GetString("bitcoind.host")
+	if host == "" {
+		return nil
+	}
+
+	user, pass, err := resolveBitcoindAuth(
+		v.GetString("bitcoind.user"), v.GetString("bitcoind.pass"),
+		v.GetString("bitcoind.rpccookie"),
+	)
+	if err != nil {
+		return err
+	}
+
+	tlsCertPath := v.GetString("bitcoind.tlscertpath")
+	submitter, err := bitcoindrpc.NewWithOptions(
+		host, user, pass, bitcoindrpc.WithTLSCertPath(tlsCertPath),
+	)
+	if err != nil {
+		return err
+	}
+
+	// Plain HTTP with Basic Auth exposes the cookie/password and the
+	// submitpackage payload to anyone observing the network path. We
+	// only warn (rather than refuse) because some operators deliberately
+	// run bitcoind over a trusted local network; HTTPS can be enabled by
+	// setting bitcoind.host to an https:// URL or by providing
+	// bitcoind.tlscertpath with a bare host.
+	if !isLoopbackHost(host) &&
+		!isBitcoindHTTPSEndpoint(host, tlsCertPath) {
+
+		fmt.Fprintf(
+			os.Stderr, "WARNING: bitcoind.host %q is not "+
+				"loopback. The RPC connection is plain HTTP "+
+				"with Basic Auth, so credentials and "+
+				"submitpackage payloads are sent in "+
+				"cleartext over the network. Run bitcoind "+
+				"on the same host (127.0.0.1) or front it "+
+				"with a TLS reverse proxy reachable only "+
+				"over a trusted link.\n", host,
+		)
+	}
+
+	cfg.PackageSubmitter = submitter
+
+	return nil
+}
+
+// isLoopbackHost reports whether the given bitcoind RPC address points
+// at the local machine. It accepts a full URL ("http://...", "https://
+// ..."), a bare "host:port", or a bare host. URLs are parsed via
+// url.Parse + u.Hostname() so bracketed IPv6 addresses ("[::1]:8332")
+// and trailing paths ("127.0.0.1:8332/wallet/foo") are handled
+// correctly. The "localhost" hostname is treated as loopback even
+// though it is technically a name lookup, matching the expectation
+// operators have when they write it in a config file.
+func isLoopbackHost(host string) bool {
+	if host == "" {
+		return false
+	}
+
+	// A bare IP literal (including IPv6 like "::1") doesn't parse
+	// usefully through url.Parse — "http://::1" treats the ":" as
+	// part of the scheme delimiter. Try the direct ParseIP path
+	// first so this case is handled before any URL parsing.
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+
+	// Synthesise a scheme when missing so url.Parse populates the
+	// authority component (otherwise the input ends up in Path).
+	// This is what makes bracketed IPv6 like "[::1]:8332" parse
+	// correctly via u.Hostname(), which strips the brackets.
+	parseURL := host
+	if !strings.HasPrefix(host, "http://") &&
+		!strings.HasPrefix(host, "https://") {
+
+		parseURL = "http://" + host
+	}
+
+	u, err := url.Parse(parseURL)
+	if err != nil {
+		return false
+	}
+
+	raw := u.Hostname()
+	if raw == "localhost" {
+		return true
+	}
+
+	ip := net.ParseIP(raw)
+
+	return ip != nil && ip.IsLoopback()
+}
+
+// isBitcoindHTTPSEndpoint reports whether configureBitcoindSubmitter
+// will configure an HTTPS endpoint for the given host/TLS settings.
+func isBitcoindHTTPSEndpoint(host, tlsCertPath string) bool {
+	if strings.HasPrefix(host, "https://") {
+		return true
+	}
+	if strings.Contains(host, "://") {
+		return false
+	}
+
+	return tlsCertPath != ""
 }
 
 // resolveBitcoindAuth picks the bitcoind RPC credentials to use, given

--- a/cmd/darepod/main_test.go
+++ b/cmd/darepod/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/lightninglabs/darepo-client/darepod"
@@ -120,4 +121,139 @@ func newTestConfigCommand(t *testing.T,
 	}
 
 	return v, cmd
+}
+
+// TestResolveBitcoindAuth covers the three branches of cookie-vs-
+// user/pass credential resolution: passthrough, cookie-file parsing,
+// and the mutual-exclusion guard.
+func TestResolveBitcoindAuth(t *testing.T) {
+	t.Parallel()
+
+	writeCookie := func(t *testing.T, contents string) string {
+		t.Helper()
+
+		dir := t.TempDir()
+		path := filepath.Join(dir, "bitcoind.cookie")
+		err := os.WriteFile(path, []byte(contents), 0o600)
+		if err != nil {
+			t.Fatalf("write cookie: %v", err)
+		}
+
+		return path
+	}
+
+	tests := []struct {
+		name       string
+		user       string
+		pass       string
+		cookie     func(t *testing.T) string
+		wantUser   string
+		wantPass   string
+		wantErrSub string
+	}{
+		{
+			name: "no inputs is passthrough",
+		},
+		{
+			name:     "explicit user and password are passthrough",
+			user:     "alice",
+			pass:     "secret",
+			wantUser: "alice",
+			wantPass: "secret",
+		},
+		{
+			name: "cookie only is parsed",
+			cookie: func(t *testing.T) string {
+				return writeCookie(t, "__cookie__:abc123")
+			},
+			wantUser: "__cookie__",
+			wantPass: "abc123",
+		},
+		{
+			name: "cookie tolerates surrounding whitespace",
+			cookie: func(t *testing.T) string {
+				return writeCookie(t, "  __cookie__:abc123\n")
+			},
+			wantUser: "__cookie__",
+			wantPass: "abc123",
+		},
+		{
+			name: "cookie preserves colons inside the password",
+			cookie: func(t *testing.T) string {
+				return writeCookie(t, "__cookie__:abc:def:ghi")
+			},
+			wantUser: "__cookie__",
+			wantPass: "abc:def:ghi",
+		},
+		{
+			name: "cookie plus user is rejected",
+			user: "alice",
+			cookie: func(t *testing.T) string {
+				return writeCookie(t, "__cookie__:abc123")
+			},
+			wantErrSub: "mutually exclusive",
+		},
+		{
+			name: "cookie plus pass is rejected",
+			pass: "secret",
+			cookie: func(t *testing.T) string {
+				return writeCookie(t, "__cookie__:abc123")
+			},
+			wantErrSub: "mutually exclusive",
+		},
+		{
+			name: "malformed cookie is reported",
+			cookie: func(t *testing.T) string {
+				return writeCookie(t, "no-colon-here")
+			},
+			wantErrSub: "unexpected format",
+		},
+		{
+			name: "missing cookie file is reported",
+			cookie: func(_ *testing.T) string {
+				return "/nonexistent/path/to/cookie"
+			},
+			wantErrSub: "read bitcoind cookie",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var cookiePath string
+			if tc.cookie != nil {
+				cookiePath = tc.cookie(t)
+			}
+
+			user, pass, err := resolveBitcoindAuth(
+				tc.user, tc.pass, cookiePath,
+			)
+			if tc.wantErrSub != "" {
+				if err == nil ||
+					!strings.Contains(
+						err.Error(), tc.wantErrSub,
+					) {
+
+					t.Fatalf("want error containing "+
+						"%q, got %v", tc.wantErrSub,
+						err)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if user != tc.wantUser {
+				t.Fatalf("user: want %q, got %q", tc.wantUser,
+					user)
+			}
+			if pass != tc.wantPass {
+				t.Fatalf("pass: want %q, got %q", tc.wantPass,
+					pass)
+			}
+		})
+	}
 }

--- a/cmd/darepod/main_test.go
+++ b/cmd/darepod/main_test.go
@@ -123,6 +123,160 @@ func newTestConfigCommand(t *testing.T,
 	return v, cmd
 }
 
+// TestIsLoopbackHost pins the URL parsing that decides whether the
+// cleartext warning should fire. Edge cases that previously slipped
+// through net.SplitHostPort: bracketed IPv6, hosts that carry a path,
+// and the full URL forms with explicit http:// / https:// schemes.
+func TestIsLoopbackHost(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		host string
+		want bool
+	}{
+		// Loopback shapes.
+		{
+			"127.0.0.1:8332",
+			true,
+		},
+		{
+			"127.0.0.1",
+			true,
+		},
+		{
+			"localhost:8332",
+			true,
+		},
+		{
+			"localhost",
+			true,
+		},
+		{
+			"[::1]:8332",
+			true,
+		},
+		{
+			"::1",
+			true,
+		},
+		{
+			"http://127.0.0.1:8332",
+			true,
+		},
+		{
+			"https://127.0.0.1:8332",
+			true,
+		},
+		{
+			"http://localhost",
+			true,
+		},
+		{
+			"http://[::1]:8332",
+			true,
+		},
+		{
+			"https://[::1]:8332",
+			true,
+		},
+		{
+			"127.0.0.1:8332/wallet/foo",
+			true,
+		},
+		{
+			"http://127.0.0.1:8332/wallet/foo",
+			true,
+		},
+		// every 127/8 address is loopback
+		{
+			"127.0.0.2:8332",
+			true,
+		},
+
+		// Non-loopback.
+		{
+			"10.0.0.5:8332",
+			false,
+		},
+		{
+			"bitcoind.example.com:8332",
+			false,
+		},
+		{
+			"https://bitcoind.example.com:8332",
+			false,
+		},
+		{
+			"[fd00::1]:8332",
+			false,
+		},
+
+		// Degenerate.
+		{
+			"",
+			false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.host, func(t *testing.T) {
+			t.Parallel()
+
+			if got := isLoopbackHost(tc.host); got != tc.want {
+				t.Fatalf("isLoopbackHost(%q) = %v, want %v",
+					tc.host, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIsBitcoindHTTPSEndpoint verifies the warning gate used for
+// non-loopback bitcoind RPC connections.
+func TestIsBitcoindHTTPSEndpoint(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		host        string
+		tlsCertPath string
+		want        bool
+	}{
+		{
+			name: "explicit https",
+			host: "https://bitcoind.example:8332",
+			want: true,
+		},
+		{
+			name:        "bare host with cert",
+			host:        "bitcoind.example:8332",
+			tlsCertPath: "/path/to/ca.pem",
+			want:        true,
+		},
+		{
+			name:        "explicit http cert remains plaintext",
+			host:        "http://bitcoind.example:8332",
+			tlsCertPath: "/path/to/ca.pem",
+			want:        false,
+		},
+		{
+			name: "bare host without cert",
+			host: "bitcoind.example:8332",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := isBitcoindHTTPSEndpoint(tc.host, tc.tlsCertPath)
+			if got != tc.want {
+				t.Fatalf("isBitcoindHTTPSEndpoint() = "+
+					"%v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestResolveBitcoindAuth covers the three branches of cookie-vs-
 // user/pass credential resolution: passthrough, cookie-file parsing,
 // and the mutual-exclusion guard.

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -4558,10 +4558,39 @@ func (s *Server) initUnrollSubsystem(ctx context.Context,
 		return err
 	}
 
-	// 3. Restore non-terminal jobs from durable state.
+	// 3. Restore non-terminal jobs from durable state. A failure here
+	// is fatal at boot: any non-terminal record we silently drop is a
+	// VTXO that already transitioned to unilateral_exit but whose
+	// recovery actor will not be respawned by RestoreNonTerminal or
+	// re-driven by handleEnsure (the dormant non-terminal record makes
+	// EnsureUnroll return Created=false). The previous WarnS-only
+	// posture let unilateral-exit recovery sit dormant until manual
+	// intervention; for VTXOs near expiry that translates to lost
+	// funds. Fail closed so the operator notices.
 	if err := registry.RestoreNonTerminal(ctx); err != nil {
-		s.log.WarnS(ctx,
-			"Failed to restore unroll jobs", err)
+		return fmt.Errorf("restore non-terminal unroll jobs: %w", err)
+	}
+
+	// 3a. Convergent boot-time recovery for VTXOs that are already in
+	// VTXOStatusUnilateralExit in the VTXO store but have no matching
+	// unroll registry record. The two writes are not atomic: the VTXO
+	// actor flips status in its own DB tx and then Tells the chain
+	// resolver, which eventually triggers a separate registry
+	// UpsertRecord. A crash, full mailbox, or context cancel between
+	// those steps leaves the VTXO terminal-from-the-manager's
+	// perspective (it will not respawn a child actor) while the
+	// registry has nothing to drive forward. Without this scan such a
+	// VTXO stays stranded until the next manual EnsureUnroll. The
+	// scan is convergent: EnsureUnrollRequest dedups against
+	// r.active / r.pending / store.GetRecord, so a target that
+	// already has a record (e.g. just restored above) is a benign
+	// no-op. Per-target failures are collected and returned after the
+	// scan so startup fails closed instead of serving traffic with a
+	// known-stranded VTXO.
+	if err := s.recoverOrphanedUnrollJobs(
+		ctx, vtxoStore, registry,
+	); err != nil {
+		return fmt.Errorf("recover orphaned unroll jobs: %w", err)
 	}
 	if err := recoverySvc.RestoreNonTerminal(ctx); err != nil {
 		s.log.WarnS(ctx, "Failed to restore vhtlc recovery jobs",
@@ -4589,6 +4618,112 @@ func (s *Server) initUnrollSubsystem(ctx context.Context,
 	}
 
 	s.log.InfoS(ctx, "Unroll subsystem initialized")
+
+	return nil
+}
+
+// recoverOrphanedUnrollJobs closes the atomicity gap between the VTXO
+// store's status flip to VTXOStatusUnilateralExit and the unroll
+// registry's UpsertRecord (#400). It lists every VTXO that the store
+// believes is already exiting and admits an EnsureUnrollRequest for
+// each so the registry's dedup path (r.active / r.pending /
+// Store.GetRecord) either confirms an existing record or spawns a
+// fresh recovery actor.
+//
+// Whole-scan failures (e.g. the VTXO store query itself errors) are
+// fatal at the caller: without a recovery scan we have no other
+// trigger for an orphaned VTXO until the next manual EnsureUnroll.
+// Per-target failures are collected and returned after the scan so startup
+// fails closed instead of serving traffic while known unilateral-exit VTXOs
+// remain stranded.
+func (s *Server) recoverOrphanedUnrollJobs(ctx context.Context,
+	vtxoStore vtxo.VTXOStore, registry *unroll.UnrollRegistryActor) error {
+
+	descs, err := vtxoStore.ListVTXOsByStatus(
+		ctx, vtxo.VTXOStatusUnilateralExit,
+	)
+	if err != nil {
+		return fmt.Errorf("list unilateral-exit VTXOs: %w", err)
+	}
+
+	if len(descs) == 0 {
+		return nil
+	}
+
+	ref := registry.Ref()
+	recovered := 0
+	var recoveryErrs []error
+	for _, desc := range descs {
+		op := desc.Outpoint
+
+		resp, askErr := ref.Ask(ctx, &unroll.EnsureUnrollRequest{
+			Outpoint: op,
+			Trigger:  unroll.TriggerRestart,
+		}).Await(ctx).Unpack()
+		if askErr != nil {
+			s.log.WarnS(ctx, "Failed to recover orphaned "+
+				"unroll job; VTXO remains stranded until "+
+				"next boot", askErr,
+				slog.String("outpoint", op.String()),
+			)
+
+			if ctx.Err() != nil {
+				return fmt.Errorf("orphan recovery aborted: %w",
+					ctx.Err())
+			}
+
+			recoveryErrs = append(
+				recoveryErrs,
+				fmt.Errorf(
+					"%s: %w", op.String(), askErr,
+				),
+			)
+
+			continue
+		}
+
+		// EnsureUnrollRequest is defined to return *EnsureUnrollResp
+		// on success, so a successful Ask + a different concrete
+		// type would mean the registry contract changed without
+		// this call site catching up. Treat it as a recovery
+		// failure rather than silently mis-counting.
+		ensureResp, ok := resp.(*unroll.EnsureUnrollResp)
+		if !ok {
+			s.log.WarnS(ctx, "Unroll registry returned an "+
+				"unexpected response type during orphan "+
+				"recovery; treating as failure", nil,
+				slog.String("outpoint", op.String()),
+				slog.String(
+					"response_type",
+					fmt.Sprintf("%T", resp),
+				),
+			)
+
+			recoveryErrs = append(
+				recoveryErrs,
+				fmt.Errorf(
+					"%s: unexpected response type %T",
+					op.String(), resp,
+				),
+			)
+
+			continue
+		}
+		if ensureResp.Created {
+			recovered++
+		}
+	}
+
+	if recovered > 0 {
+		s.log.InfoS(ctx, "Recovered orphaned unroll jobs",
+			slog.Int("count", recovered),
+			slog.Int("scanned", len(descs)),
+		)
+	}
+	if len(recoveryErrs) > 0 {
+		return fmt.Errorf("recover %d orphaned unroll job(s): %w",
+			len(recoveryErrs), errors.Join(recoveryErrs...))
+	}
 
 	return nil
 }

--- a/sample-darepod.conf
+++ b/sample-darepod.conf
@@ -205,8 +205,19 @@
 # Optional bitcoind RPC address for submitpackage support.
 # bitcoind.host=
 
-# Optional bitcoind RPC username.
+# Optional bitcoind RPC username. Mutually exclusive with
+# bitcoind.rpccookie.
 # bitcoind.user=
 
-# Optional bitcoind RPC password.
+# Optional bitcoind RPC password. Avoid passing this on the command
+# line: process arguments are visible to other users via 'ps'. Prefer
+# bitcoind.rpccookie (below) which keeps the secret out of process
+# args and persistent config.
 # bitcoind.pass=
+
+# Optional path to bitcoind's '.cookie' authentication file. bitcoind
+# writes this file at startup (mode 0600) and rotates it on every
+# restart, so the credential lives only on disk under bitcoind's data
+# directory rather than in this config or in process args. Mutually
+# exclusive with bitcoind.user / bitcoind.pass.
+# bitcoind.rpccookie=

--- a/sample-darepod.conf
+++ b/sample-darepod.conf
@@ -221,3 +221,9 @@
 # directory rather than in this config or in process args. Mutually
 # exclusive with bitcoind.user / bitcoind.pass.
 # bitcoind.rpccookie=
+
+# Optional path to a PEM CA certificate for HTTPS bitcoind RPC. When
+# this is set with a bare bitcoind.host value, darepod connects with
+# https://. Use this when bitcoind RPC is fronted by a TLS reverse
+# proxy.
+# bitcoind.tlscertpath=

--- a/unroll/actor.go
+++ b/unroll/actor.go
@@ -245,6 +245,20 @@ func (b *behavior) handleEvent(ctx context.Context,
 	}
 
 	if b.inTerminalState() {
+		// The FSM is already terminal — either we reached this
+		// state inside the current actor lifetime and have nothing
+		// new to do, or we just restored from a terminal checkpoint
+		// on boot and the registry's view is still the older
+		// non-terminal record. notifyRegistryIfTerminal is a no-op
+		// in the first case (terminalNotified short-circuits it)
+		// and the load-bearing call in the second: without it, the
+		// restored child sits in r.active forever while
+		// handleGetStatus serves the stale non-terminal record from
+		// r.pending. terminalNotified is in-memory and resets on
+		// every restart, so a restored terminal checkpoint always
+		// drives one notification through.
+		b.notifyRegistryIfTerminal(ctx)
+
 		return fn.Ok[Resp](&AckResp{})
 	}
 

--- a/unroll/registry.go
+++ b/unroll/registry.go
@@ -274,6 +274,29 @@ func (m *persistRecordResultMsg) MessageType() string {
 // registryMsgSealed seals persistRecordResultMsg into the registry surface.
 func (m *persistRecordResultMsg) registryMsgSealed() {}
 
+// childAdmissionResultMsg reports the eventual result of a child start
+// request after the registry's synchronous admission wait timed out.
+type childAdmissionResultMsg struct {
+	actor.BaseMessage
+
+	// Outpoint identifies the target whose start completed late.
+	Outpoint wire.OutPoint
+
+	// ActorID identifies the child that produced the late result.
+	ActorID string
+
+	// Err is populated when the child start failed.
+	Err string
+}
+
+// MessageType returns the stable message type identifier.
+func (m *childAdmissionResultMsg) MessageType() string {
+	return "childAdmissionResultMsg"
+}
+
+// registryMsgSealed seals childAdmissionResultMsg into the registry surface.
+func (m *childAdmissionResultMsg) registryMsgSealed() {}
+
 // restoreNonTerminalMsg drives the boot-time restore of every non-terminal
 // record through the registry actor's goroutine. Sending it via Ask keeps
 // all mutations of r.active and r.pending serialized with concurrent
@@ -327,6 +350,9 @@ func (r *registryBehavior) Receive(ctx context.Context,
 
 	case *persistRecordResultMsg:
 		return r.handlePersistRecordResult(ctx, req)
+
+	case *childAdmissionResultMsg:
+		return r.handleChildAdmissionResult(ctx, req)
 
 	case *restoreNonTerminalMsg:
 		return r.handleRestoreNonTerminal(ctx)
@@ -517,42 +543,42 @@ func (r *registryBehavior) handleEnsure(ctx context.Context,
 	)
 	defer cancelStart()
 
-	_, err = child.Ref().Ask(startCtx, startReq).Await(startCtx).Unpack()
+	startFuture := child.Ref().Ask(context.WithoutCancel(ctx), startReq)
+	_, err = startFuture.Await(startCtx).Unpack()
 	if err != nil {
 		// Two failure classes here, treated very differently:
 		//
-		//   1. Cancellation race — the admission context (or the
-		//      child's own actor context) ended before the child
-		//      committed its first message. The pending row is
-		//      already durable, so re-issuing the StartUnrollRequest
-		//      via a fire-and-forget Tell hands the work off to the
-		//      child's durable mailbox poll loop. Caller still sees
-		//      Created=true because the job IS admitted; the FSM
-		//      will catch up off the persisted message.
+		//   1. Cancellation race — the admission context ended
+		//      before the child responded. baselib/actor's durable
+		//      Ask persists the message inside mailbox.Send BEFORE
+		//      returning the future, so a context error from Await
+		//      proves only that we stopped waiting; the message is
+		//      already in the child's durable mailbox and the FSM
+		//      will pick it up via the normal claim loop. We do
+		//      NOT re-issue the request via Tell here: that would
+		//      enqueue a second copy of an identical
+		//      StartUnrollRequest, and the original Ask future may
+		//      still complete (success or failure) inside the
+		//      actor afterwards with no one listening. Returning
+		//      Created=true is honest — the job IS durably
+		//      admitted. The child's eventual terminal transition
+		//      (success or failure) flows back through
+		//      notifyRegistryIfTerminal so the registry record
+		//      cannot stay PhasePending forever.
 		//
 		//   2. Real start error — proof assembly, store, planner.
-		//      Hide it under a Created=true would silently strand
-		//      the user's funds in unilateral_exit with no progress.
-		//      We mark the durable row PhaseFailed so GetUnrollStatus
-		//      surfaces a terminal status instead of "not found".
+		//      Hiding it under a Created=true would silently strand
+		//      the user's funds in unilateral_exit with no
+		//      progress. Mark the durable row PhaseFailed so
+		//      GetUnrollStatus surfaces a terminal status.
 		if isCancellationRace(err) {
-			tellErr := child.Ref().Tell(
-				context.WithoutCancel(ctx), startReq,
+			r.watchChildAdmissionResult(
+				context.WithoutCancel(ctx), req.Outpoint, child,
+				startFuture,
 			)
-			if tellErr != nil {
-				r.failAdmittedChild(
-					ctx, req.Outpoint, child,
-					fmt.Errorf("requeue start child: %w",
-						tellErr),
-				)
-
-				return fn.Err[RegistryResp](
-					fmt.Errorf("start child: %w", err),
-				)
-			}
-
-			r.log.WarnS(ctx, "Requeued unroll child start "+
-				"after admission context ended", err,
+			r.log.WarnS(ctx, "Unroll child start did not "+
+				"respond before admission timeout; trusting "+
+				"durable enqueue", err,
 				slog.String("outpoint", req.Outpoint.String()),
 				slog.String("actor_id", child.Ref().ID()),
 			)
@@ -620,6 +646,61 @@ func (r *registryBehavior) handleEnsure(ctx context.Context,
 	})
 }
 
+// watchChildAdmissionResult waits for a previously enqueued child start to
+// finish after the registry has already returned Created=true to the caller.
+// The wait runs outside the registry actor goroutine, then reports back via a
+// normal registry message so r.active / r.pending mutations remain serialized.
+func (r *registryBehavior) watchChildAdmissionResult(ctx context.Context,
+	target wire.OutPoint, child *VTXOUnrollActor,
+	future actor.Future[Resp]) {
+
+	actorID := child.Ref().ID()
+	go func() {
+		_, err := future.Await(ctx).Unpack()
+		if err == nil || isCancellationRace(err) ||
+			errors.Is(err, actor.ErrActorTerminated) {
+			return
+		}
+
+		tellErr := r.selfRef.Tell(ctx,
+			&childAdmissionResultMsg{
+				Outpoint: target,
+				ActorID:  actorID,
+				Err:      err.Error(),
+			},
+		)
+		if tellErr != nil {
+			r.log.WarnS(
+				ctx,
+				"Failed to report late unroll child start "+
+					"result",
+				tellErr,
+				slog.String("outpoint", target.String()),
+				slog.String("actor_id", actorID),
+			)
+		}
+	}()
+}
+
+// handleChildAdmissionResult converts a late child start failure into the
+// same terminal registry state that a synchronous start failure would have
+// produced.
+func (r *registryBehavior) handleChildAdmissionResult(ctx context.Context,
+	req *childAdmissionResultMsg) fn.Result[RegistryResp] {
+
+	child, ok := r.active[req.Outpoint]
+	if !ok || child.Ref().ID() != req.ActorID {
+		return fn.Ok[RegistryResp](&RegistryAckResp{})
+	}
+
+	r.failAdmittedChild(
+		ctx, req.Outpoint, child, fmt.Errorf("start child: %s",
+			req.Err),
+	)
+
+	return fn.Ok[RegistryResp](&RegistryAckResp{})
+}
+
 // failAdmittedChild records a terminal failure for a child that already has
 // a durable pending row. This keeps GetUnrollStatus from falling back to
 // "not found" after VTXO ownership has moved to unilateral exit.
@@ -660,10 +741,10 @@ func (r *registryBehavior) failAdmittedChild(ctx context.Context,
 }
 
 // isCancellationRace reports whether admission should preserve the pending
-// row and retry instead of converting the job into a deterministic failure.
-//
-// Three error classes count as the same "lifecycle ended too early"
-// signal:
+// row and trust the durable mailbox instead of converting the job into a
+// deterministic failure. It covers only the cases where mailbox.Send is
+// known to have completed (the durable enqueue happened) and the future's
+// Await stopped waiting:
 //
 //   - context.Canceled: the admission ctx (RPC ctx via WithoutCancel +
 //     WithTimeout) reached its bound while the child was still
@@ -672,19 +753,15 @@ func (r *registryBehavior) failAdmittedChild(ctx context.Context,
 //   - context.DeadlineExceeded: same shape as Canceled but driven by the
 //     WithTimeout cap rather than an explicit cancel. Same handoff.
 //
-//   - actor.ErrActorTerminated: the child actor's own ctx ended (e.g.
-//     during a fast-shutdown race or a follow-on Stop). The durable
-//     mailbox still holds the message, so RestoreNonTerminal on the
-//     next boot will respawn the actor and re-process the persisted
-//     StartUnrollRequest.
-//
-// All three are recoverable via the durable retry path; treating them
-// as terminal failure would strand the VTXO in unilateral_exit with no
-// surviving registry record after eviction.
+// actor.ErrActorTerminated is intentionally NOT classified as a race:
+// baselib/actor's durable Ask short-circuits and returns that error
+// BEFORE calling mailbox.Send when the actor's own ctx is already done,
+// so there is no persisted message to trust. Letting it fall through to
+// failAdmittedChild surfaces a deterministic terminal record instead of
+// pretending the job is in flight.
 func isCancellationRace(err error) bool {
 	return errors.Is(err, context.Canceled) ||
-		errors.Is(err, context.DeadlineExceeded) ||
-		errors.Is(err, actor.ErrActorTerminated)
+		errors.Is(err, context.DeadlineExceeded)
 }
 
 // handleGetStatus answers a status probe from the registry's cached

--- a/unroll/registry.go
+++ b/unroll/registry.go
@@ -1014,6 +1014,7 @@ func (r *registryBehavior) handleRestoreNonTerminal(
 		})
 	}
 
+	var restoreErrs []error
 	for i := range records {
 		record := records[i]
 		if _, ok := r.active[record.TargetOutpoint]; ok {
@@ -1035,6 +1036,14 @@ func (r *registryBehavior) handleRestoreNonTerminal(
 				slog.String("actor_id", record.ActorID),
 			)
 
+			restoreErrs = append(
+				restoreErrs,
+				fmt.Errorf(
+					"%s: %w",
+					record.TargetOutpoint.String(), err,
+				),
+			)
+
 			continue
 		}
 
@@ -1045,6 +1054,14 @@ func (r *registryBehavior) handleRestoreNonTerminal(
 		// without an extra store lookup, and so handleGetStatus
 		// answers from cache while the restored child runs.
 		r.pending[record.TargetOutpoint] = cloneRegistryRecord(record)
+	}
+
+	if len(restoreErrs) > 0 {
+		return fn.Ok[RegistryResp](&restoreNonTerminalResp{
+			Err: fmt.Errorf("restore %d unroll job(s): %w",
+				len(restoreErrs), errors.Join(restoreErrs...)).
+				Error(),
+		})
 	}
 
 	return fn.Ok[RegistryResp](&restoreNonTerminalResp{})

--- a/unroll/registry_test.go
+++ b/unroll/registry_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -1505,6 +1506,62 @@ func TestRegistryRestoreFailureLeavesRecordRetryable(t *testing.T) {
 	require.True(t, status.Found)
 	require.True(t, status.Active)
 	require.Equal(t, PhaseMaterializing, status.Phase)
+}
+
+// TestRegistryLateAdmissionFailureMarksFailed verifies that when the
+// registry's synchronous admission wait times out, the eventual child
+// start result is still observed and a late deterministic start failure
+// becomes a terminal registry record instead of leaving PhasePending
+// forever.
+func TestRegistryLateAdmissionFailureMarksFailed(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	store := newMemRegistryStore()
+
+	registry := newRegistryHarnessWithSpawn(t, RegistryConfig{
+		Store:          store,
+		DeliveryStore:  newMemCheckpointStore(),
+		ProofAssembler: &mockProofAssembler{proof: proof},
+		VTXOStore:      &mockVTXOStore{desc: desc},
+		TxConfirmRef:   &fakeTxConfirmRef{},
+		ChainSource:    &fakeRegistryChainSourceRef{height: 200},
+		Wallet:         &fakeSweepWallet{},
+	})
+	t.Cleanup(registry.Stop)
+
+	target := proof.TargetOutpoint()
+	child := newTestUnrollChild(
+		t, target, actor.NewFunctionBehavior(
+			func(context.Context, Msg) fn.Result[Resp] {
+				return fn.Ok[Resp](&AckResp{})
+			},
+		),
+	)
+
+	record := RegistryRecord{
+		TargetOutpoint: target,
+		ActorID:        child.Ref().ID(),
+		Trigger:        TriggerManual,
+		Phase:          PhasePending,
+	}
+	require.NoError(t, store.UpsertRecord(t.Context(), record))
+	registry.behavior.active[target] = child
+	registry.behavior.pending[target] = cloneRegistryRecord(record)
+
+	promise := actor.NewPromise[Resp]()
+	registry.behavior.watchChildAdmissionResult(
+		t.Context(), target, child, promise.Future(),
+	)
+	promise.Complete(fn.Err[Resp](errors.New("late start boom")))
+
+	require.Eventually(t, func() bool {
+		record, err := store.GetRecord(t.Context(), target)
+		require.NoError(t, err)
+
+		return record != nil &&
+			record.Phase == PhaseFailed &&
+			strings.Contains(record.FailReason, "late start boom")
+	}, testTimeout, 10*time.Millisecond)
 }
 
 // TestRegistryEnsureRestoresFailedNonTerminalRecord verifies that when a

--- a/unroll/registry_test.go
+++ b/unroll/registry_test.go
@@ -1373,13 +1373,13 @@ func TestRegistryTerminalStatusRemainsQueryableWhilePersistBlocked(
 }
 
 // TestRegistryRestoreFailureLeavesRecordRetryable verifies that a
-// transient failure during RestoreNonTerminal does NOT mark the durable
-// record terminal: a subsequent RestoreNonTerminal call (e.g. on the
-// next daemon boot, after the transient ChainSource / DB issue is
-// resolved) must still find and resume the job. This is the regression
-// guard for issue #381 ("Restore failure permanently disables unroll
-// recovery"): an attacker or backend outage that fails the resume Ask
-// on one boot must not strand a recovery-critical job forever.
+// transient failure during RestoreNonTerminal fails the boot attempt
+// without marking the durable record terminal: a subsequent
+// RestoreNonTerminal call (e.g. on the next daemon boot, after the
+// transient ChainSource / DB issue is resolved) must still find and
+// resume the job. This is the regression guard for issue #381
+// ("Restore failure permanently disables unroll recovery") and #400
+// ("restore failure is only logged").
 func TestRegistryRestoreFailureLeavesRecordRetryable(t *testing.T) {
 	proof := buildLinearProof(t)
 	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
@@ -1436,11 +1436,11 @@ func TestRegistryRestoreFailureLeavesRecordRetryable(t *testing.T) {
 	}
 	registry.behavior.spawnFunc = failingSpawn
 
-	// RestoreNonTerminal must NOT return an error and must NOT mark
-	// the record terminal; the durable record stays non-terminal so a
-	// future retry path can pick it up.
+	// RestoreNonTerminal must return an error so daemon startup fails
+	// closed, but must NOT mark the record terminal; the durable record
+	// stays non-terminal so a future retry path can pick it up.
 	err = registry.RestoreNonTerminal(t.Context())
-	require.NoError(t, err)
+	require.ErrorContains(t, err, "restore 1 unroll job")
 	require.EqualValues(t, 1, attempts.Load())
 
 	record, err := store.GetRecord(t.Context(), proof.TargetOutpoint())


### PR DESCRIPTION
## Summary

Triage and fix for `security`-labeled issues from the May 2026 Codex
scanner findings.

- **#375** Workflow dispatch CI command injection (high)
- **#392** Terminal unroll checkpoints can be hidden after restart (medium)
- **#393** Unroll start timeout can leave recovery job pending forever (medium)
- **#399** Plaintext bitcoind RPC credentials (medium)
- **#400** Unroll jobs can be orphaned without recovery (medium)

## Commits

| Commit | Issue | What |
|---|---|---|
| `e60c4855` | #375 | Route `workflow_dispatch` inputs through `env:` to block YAML-to-bash interpolation injection |
| `d49868be` | #399 | `--bitcoind.rpccookie` flag reads bitcoind's `.cookie` file so the password never appears in `ps`/config/backups |
| `76e2694a` | #399 | Add HTTPS/TLS support for non-loopback bitcoind RPC, preserve default HTTP transport settings, and warn only for non-loopback plaintext endpoints |
| `88d6216c` | #393 | Remove the duplicate Start `Tell`, keep the original durable Ask result observable after admission timeout, and mark late deterministic start failures terminal |
| `b6b6c81c` | #392 | Notify the registry from the terminal short-circuit on restore so a terminal checkpoint loaded against a non-terminal record converges |
| `9c2b35a9` | #400 | Fail closed on unroll restore gaps: fatal restore errors, boot-time orphan scan, and aggregate per-target orphan recovery failures |

## Issues closed

- Closes #375
- Closes #392
- Closes #393
- Closes #399
- Closes #400

## Notes

For #399, cookie auth closes the local credential leak paths
(`ps`, shell history, persistent config, backups), and the HTTPS/TLS
support closes the non-loopback wire-cleartext path for deployments that
front bitcoind RPC with TLS.

For #400, startup now fails closed instead of serving traffic when known
unilateral-exit recovery work could not be restored or recovered. The
boot scan repairs the practical cross-store gap by admitting every VTXO
already in `UnilateralExit`; existing active, pending, or stored unroll
records remain idempotent no-ops through registry dedup.

## Test plan

- [x] `make unit pkg=./chainbackends/bitcoindrpc timeout=5m`
- [x] `make unit pkg=./cmd/darepod timeout=5m`
- [x] `make unit pkg=./unroll timeout=5m`
- [x] `make unit pkg=./darepod timeout=5m`
- [x] `make fmt-changed-check`
- [x] `make lint-changed-local`
- [x] `make commitmsg-lint range="origin/main..HEAD"`

## Known follow-ups

- Regression test for the #392 terminal-on-restore scenario requires
  constructing a serialized terminal checkpoint matching the TLV codec.
- A true single-transaction refactor spanning the VTXO and unroll stores
  remains useful defense-in-depth, but the daemon now fails closed and
  repairs orphaned unilateral-exit work before serving traffic.
