### PR TITLE
darepod: fix vhtlc preimg registry startup

### DIFF
--- a/darepod/server.go
+++ b/darepod/server.go
@@ -363,14 +363,16 @@ type Server struct {
 }
 
 // NewServer allocates a Server from a validated Config. The server is
-// inert until RunUntilShutdown is called. The walletReady channel is
-// initialized here so RPC handlers can select on it immediately.
+// inert until RunUntilShutdown is called. The walletReady channel and
+// recovery preimage registry are initialized here so RPC handlers can use
+// them immediately.
 func NewServer(cfg *Config) (*Server, error) {
 	return &Server{
-		cfg:         cfg,
-		clk:         clock.NewDefaultClock(),
-		walletReady: make(chan struct{}),
-		daemonReady: make(chan struct{}),
+		cfg:            cfg,
+		clk:            clock.NewDefaultClock(),
+		walletReady:    make(chan struct{}),
+		daemonReady:    make(chan struct{}),
+		vhtlcPreimages: &unrollpolicy.PreimageResolverRegistry{},
 	}, nil
 }
 
@@ -4422,8 +4424,7 @@ func (s *Server) initUnrollSubsystem(ctx context.Context,
 	s.ueStore = ueStore
 	recoveryStore := dbStore.NewVHTLCRecoveryStore(s.clk)
 	s.vhtlcRecoveryStore = recoveryStore
-	preimages := &unrollpolicy.PreimageResolverRegistry{}
-	s.vhtlcPreimages = preimages
+	preimages := s.vhtlcPreimages
 	vtxoStore := dbStore.NewVTXOStore(s.clk)
 
 	// Build the wallet adapter shared by txconfirm and unroll


### PR DESCRIPTION
This PR attempts to fix:
```
2026-05-27 08:10:01.533 [DBG] ACTR: Transaction begin failed during shutdown err="context canceled"                                                                                                                                                                                                                                                   
2026-05-27 08:10:01.533 [DBG] ACTR: Transaction begin failed during shutdown err="context canceled"                                                                                                                                                                                                                                                   
2026-05-27 08:10:01.533 [INF] CBKD: Stopping LND chain backend                                                                                                                                                                                                                                                                                        
2026-05-27 08:10:01.533 [INF] CBKD: LND chain backend stopped                                                                                                                                                                                                                                                                                         
Error: register recovery preimage resolver: rpc error: code = Unavailable desc = vhtlc recovery preimage registry not initialized
```