### PR TITLE
sdk/swaps: format vHTLC poll error correctly and document version-skew hint

### DIFF
--- a/sdk/swaps/out_swap.go
+++ b/sdk/swaps/out_swap.go
@@ -1649,6 +1649,15 @@ func encodeVHTLCPolicyTemplate(policy *arkscript.VHTLCPolicy) ([]byte, error) {
 
 // waitForVHTLC polls the authoritative indexer until the expected vHTLC is
 // live, then returns its outpoint and amount.
+//
+// The polled pkScript is derived locally from the vHTLC policy parameters
+// supplied by the swap server. A persistent loop where the indexer keeps
+// rejecting the query (e.g. "Unauthenticated: script not registered for
+// principal") usually means the local and remote `lib/arkscript` packages
+// disagree on the vHTLC script structure, so the funded output is at a
+// different pkScript than this side derives. The bundled log includes the
+// indexer's error wording and the queried pkScript so the operator can
+// match it against the on-chain output for diagnosis.
 func (c *SwapClient) waitForVHTLC(ctx context.Context, pkScript []byte,
 	deadline time.Time, keepWaiting func(context.Context) error) (string,
 	int64, error) {
@@ -1662,7 +1671,7 @@ func (c *SwapClient) waitForVHTLC(ctx context.Context, pkScript []byte,
 		vtxo, err := c.daemon.FindLiveVTXOByPkScript(ctx, pkScript)
 		if err != nil {
 			c.log.DebugS(ctx, "Unable to query vHTLC state",
-				err,
+				slog.String("err", err.Error()),
 				slog.String("pk_script", pkScriptHex),
 			)
 		}


### PR DESCRIPTION
## Summary

Fixes the cosmetic `!BADKEY=` prefix on the vHTLC-state-query log line in `sdk/swaps/out_swap.go:waitForVHTLC`, and documents on the function the actual cause of the recurring loop reported in #538: a `lib/arkscript` version skew between client and server producing different vHTLC pkScripts for the same swap parameters.

No behavior change. Pure observability fix.

## What it actually broke

The btclog/v2 surface splits structured loggers by level:

```
WarnS  (ctx, msg, err error, attrs ...any)   // err is typed
ErrorS (ctx, msg, err error, attrs ...any)   // err is typed
DebugS (ctx, msg,             attrs ...any)  // no err parameter
InfoS  (ctx, msg,             attrs ...any)  // no err parameter
```

The current call:

```go
c.log.DebugS(ctx, "Unable to query vHTLC state",
    err,                                  // positional `any` → slog can't pair it
    slog.String("pk_script", pkScriptHex),
)
```

passes `err` as a positional `any` rather than a key/value pair or an `slog.Attr`, so `slog` renders it as an unkeyed value and emits `!BADKEY=\"…\"`. Visible in the bug report from #538:

```
[DBG] SWAP: Unable to query vHTLC state !BADKEY=\"…\" pk_script=…
```

Switching to `slog.String(\"err\", err.Error())` matches the pattern already used at line 1615 (`vHTLC claim retry scheduled`) and gives:

```
[DBG] SWAP: Unable to query vHTLC state err=\"…\" pk_script=…
```

## Why the doc comment matters

The other thing the #538 thread surfaced is that the user-visible indexer error — `Unauthenticated: script not registered for principal` — is **misleading** when the real condition is a script-format mismatch. The indexer reaches that branch because there is no row at the queried pkScript (so row-based template auth has nothing to enumerate), and per-principal proof-of-control hasn't been pre-arranged either, so it falls through to the second auth path and reports its failure wording.

When the loop is caused by a `lib/arkscript` skew (e.g. darepo-client#484 reshaping leaf 6 to gate sender refunds by CLTV), the symptom is identical: client polls an address that no one will ever fund. Without a hint, the next operator hitting this will burn the same time chasing an auth red herring. The doc comment leaves the breadcrumb in place.

## What it deliberately does NOT do

- No new daemon RPC. Today's row-based template auth at the indexer (`participantKeysFromRow` deriving from the persisted vHTLC policy) is sufficient: once client and server agree on the vHTLC script, the user's identity key is automatically authorized via the cooperative-claim settlement pair, no pre-registration needed.
- No `RegisterReceiveScriptTaproot` for the vHTLC pkScript. The earlier analysis on #538 floated this, but on a closer look it doesn't actually fix this incident (the format-mismatched script wouldn't exist on the indexer at all) and would only really pay off if arkd later tightens auth to require explicit per-principal registration for every script-scope query.

## Test plan

- [x] `go build ./sdk/swaps/...`
- [ ] Manual: trigger an indexer error in the poll loop and confirm the log renders as `err=\"…\" pk_script=…`, no `!BADKEY=`.

## Related

- Live incident root cause: deployment skew between user's darepod (post-#484) and signet swapdk-ark-client image (pre-#484). The fix half is rolled in [lightning-infra#3263](https://github.com/lightninglabs/lightning-infra/pull/3263). #538 has the timeline.