### PR TITLE
protofsm: log event types only at debug, full spew at trace

### DIFF
--- a/baselib/protofsm/state_machine.go
+++ b/baselib/protofsm/state_machine.go
@@ -399,8 +399,16 @@ func (s *StateMachine[InternalEvent, OutboxEvent, Env]) applyEvents(
 	//nolint:ll
 	for nextEvent := eventQueue.Dequeue(); nextEvent.IsSome(); nextEvent = eventQueue.Dequeue() {
 		err := fn.MapOptionZ(nextEvent, func(event InternalEvent) error {
+			// Log the event type at debug level to keep
+			// steady-state output compact. The full event payload
+			// (which may include auth blobs, signatures, etc.) is
+			// only spewed at trace.
 			s.log.DebugS(ctx, "Processing event",
-				"event", lnutils.SpewLogClosure(event),
+				btclog.Fmt("event_type", "%T", event),
+			)
+			s.log.TraceS(
+				ctx, "Processing event payload", "event",
+				lnutils.SpewLogClosure(event),
 			)
 
 			// Apply the state transition function of the current
@@ -421,12 +429,20 @@ func (s *StateMachine[InternalEvent, OutboxEvent, Env]) applyEvents(
 			) error {
 
 				// Next, we'll add any new emitted events to our
-				// event queue.
+				// event queue. As above, debug only carries the
+				// event type; the full body is left to trace.
 				for _, inEvent := range events.InternalEvent {
 					s.log.DebugS(
 						ctx,
 						"Adding new internal event to "+
 							"queue",
+						btclog.Fmt(
+							"event_type", "%T",
+							inEvent,
+						),
+					)
+					s.log.TraceS(
+						ctx, "Internal event payload",
 						"event",
 						lnutils.SpewLogClosure(inEvent),
 					)


### PR DESCRIPTION
## Summary

- `Processing event` and `Adding new internal event to queue` in the FSM driver previously emitted a full `lnutils.SpewLogClosure` dump of the event at debug level. In practice that prints kilobytes of hex-encoded `Auth` blobs, MuSig2 signatures, PSBT bytes, etc. on every event a state machine processes, so in a steady-state arkd it's by far the largest contributor to log volume.
- Split each log site in two: debug now carries only the event type (`btclog.Fmt("event_type", "%T", event)`), and a sibling `TraceS` line keeps the full `SpewLogClosure` dump available when an operator explicitly cranks the FSM subsystem to trace for deep diagnostics.

## Test plan

- [x] `make lint-native` — 0 issues.
- [x] Spot-check that round FSM still progresses through `Created → IntentCollecting → QuoteSent → ...` at debug level — output now lists `event_type=*rounds.ClientJoinIntentEvent` instead of the spewed body.
- [ ] In a separate trace run, confirm the full spew still shows up under `TraceS "Processing event payload"`.