### PR TITLE
wallet: keep adopted boarding balance pending

### DIFF
--- a/daemonrpc/daemon.pb.go
+++ b/daemonrpc/daemon.pb.go
@@ -1388,8 +1388,10 @@ type GetBalanceResponse struct {
 	// vtxo_balance_sat is the total balance held in live (spendable)
 	// VTXOs.
 	VtxoBalanceSat int64 `protobuf:"varint,3,opt,name=vtxo_balance_sat,json=vtxoBalanceSat,proto3" json:"vtxo_balance_sat,omitempty"`
-	// total_confirmed_sat is the sum of all confirmed balances
-	// (boarding_confirmed_sat + vtxo_balance_sat).
+	// total_confirmed_sat is the sum of boarding_confirmed_sat +
+	// vtxo_balance_sat. boarding_adopted_sat is intentionally excluded
+	// because adopted funds are no longer confirmed boarding UTXOs and
+	// the resulting VTXOs are not yet live.
 	TotalConfirmedSat int64 `protobuf:"varint,4,opt,name=total_confirmed_sat,json=totalConfirmedSat,proto3" json:"total_confirmed_sat,omitempty"`
 	// onchain_wallet_confirmed_sat is the total confirmed on-chain
 	// balance of the backing wallet (all confirmed UTXOs, including
@@ -1408,8 +1410,14 @@ type GetBalanceResponse struct {
 	// total_confirmed_sat — once swept the funds reappear under
 	// onchain_wallet_confirmed_sat.
 	BoardingSweptSat int64 `protobuf:"varint,7,opt,name=boarding_swept_sat,json=boardingSweptSat,proto3" json:"boarding_swept_sat,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// boarding_adopted_sat is the total amount of boarding UTXOs that
+	// have been accepted into a persisted round checkpoint but whose
+	// resulting VTXOs are not yet live. These funds are no longer visible
+	// as boarding address UTXOs, but remain pending inbound balance until
+	// the round's commitment transaction confirms.
+	BoardingAdoptedSat int64 `protobuf:"varint,8,opt,name=boarding_adopted_sat,json=boardingAdoptedSat,proto3" json:"boarding_adopted_sat,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *GetBalanceResponse) Reset() {
@@ -1487,6 +1495,13 @@ func (x *GetBalanceResponse) GetBoardingPendingSweepSat() int64 {
 func (x *GetBalanceResponse) GetBoardingSweptSat() int64 {
 	if x != nil {
 		return x.BoardingSweptSat
+	}
+	return 0
+}
+
+func (x *GetBalanceResponse) GetBoardingAdoptedSat() int64 {
+	if x != nil {
+		return x.BoardingAdoptedSat
 	}
 	return 0
 }
@@ -7252,7 +7267,7 @@ const file_daemon_proto_rawDesc = "" +
 	"\x0fwallet_password\x18\x01 \x01(\fR\x0ewalletPassword\"?\n" +
 	"\x14UnlockWalletResponse\x12'\n" +
 	"\x0fidentity_pubkey\x18\x01 \x01(\tR\x0eidentityPubkey\"\x13\n" +
-	"\x11GetBalanceRequest\"\x8a\x03\n" +
+	"\x11GetBalanceRequest\"\xbc\x03\n" +
 	"\x12GetBalanceResponse\x124\n" +
 	"\x16boarding_confirmed_sat\x18\x01 \x01(\x03R\x14boardingConfirmedSat\x128\n" +
 	"\x18boarding_unconfirmed_sat\x18\x02 \x01(\x03R\x16boardingUnconfirmedSat\x12(\n" +
@@ -7260,7 +7275,8 @@ const file_daemon_proto_rawDesc = "" +
 	"\x13total_confirmed_sat\x18\x04 \x01(\x03R\x11totalConfirmedSat\x12?\n" +
 	"\x1conchain_wallet_confirmed_sat\x18\x05 \x01(\x03R\x19onchainWalletConfirmedSat\x12;\n" +
 	"\x1aboarding_pending_sweep_sat\x18\x06 \x01(\x03R\x17boardingPendingSweepSat\x12,\n" +
-	"\x12boarding_swept_sat\x18\a \x01(\x03R\x10boardingSweptSat\"\xc6\x03\n" +
+	"\x12boarding_swept_sat\x18\a \x01(\x03R\x10boardingSweptSat\x120\n" +
+	"\x14boarding_adopted_sat\x18\b \x01(\x03R\x12boardingAdoptedSat\"\xc6\x03\n" +
 	"\x04VTXO\x12\x1a\n" +
 	"\boutpoint\x18\x01 \x01(\tR\boutpoint\x12\x1d\n" +
 	"\n" +

--- a/daemonrpc/daemon.proto
+++ b/daemonrpc/daemon.proto
@@ -402,8 +402,10 @@ message GetBalanceResponse {
     // VTXOs.
     int64 vtxo_balance_sat = 3;
 
-    // total_confirmed_sat is the sum of all confirmed balances
-    // (boarding_confirmed_sat + vtxo_balance_sat).
+    // total_confirmed_sat is the sum of boarding_confirmed_sat +
+    // vtxo_balance_sat. boarding_adopted_sat is intentionally excluded
+    // because adopted funds are no longer confirmed boarding UTXOs and
+    // the resulting VTXOs are not yet live.
     int64 total_confirmed_sat = 4;
 
     // onchain_wallet_confirmed_sat is the total confirmed on-chain
@@ -425,6 +427,13 @@ message GetBalanceResponse {
     // total_confirmed_sat — once swept the funds reappear under
     // onchain_wallet_confirmed_sat.
     int64 boarding_swept_sat = 7;
+
+    // boarding_adopted_sat is the total amount of boarding UTXOs that
+    // have been accepted into a persisted round checkpoint but whose
+    // resulting VTXOs are not yet live. These funds are no longer visible
+    // as boarding address UTXOs, but remain pending inbound balance until
+    // the round's commitment transaction confirms.
+    int64 boarding_adopted_sat = 8;
 }
 
 // VTXOStatus represents the lifecycle state of a virtual transaction

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -484,7 +484,7 @@ func (r *RPCServer) GetBalance(ctx context.Context,
 	// runs one ListUnspent per tip advance, and a slow backend can
 	// keep that call in flight long enough to stall the mailbox while
 	// a GetBalance Ask sits queued behind it. The actor's
-	// handleGetBoardingBalance is a pure read of three
+	// handleGetBoardingBalance is a pure read of boarding lifecycle
 	// FetchBoardingIntentsByStatus calls with no in-memory actor
 	// state, so this direct store read returns the same value
 	// without queuing behind the backlog. See bug-2 in BUGS_FOUND.md
@@ -564,6 +564,14 @@ func (r *RPCServer) fetchBoardingBalance(ctx context.Context,
 		return fmt.Errorf("fetch confirmed boarding balance: %w", err)
 	}
 	resp.BoardingConfirmedSat = int64(sumAmounts(confirmed))
+
+	adopted, err := boardingStore.FetchBoardingIntentsByStatus(
+		ctx, wallet.BoardingStatusAdopted,
+	)
+	if err != nil {
+		return fmt.Errorf("fetch adopted boarding balance: %w", err)
+	}
+	resp.BoardingAdoptedSat = int64(sumAmounts(adopted))
 
 	pendingSweep, err := boardingStore.FetchBoardingIntentsByStatus(
 		ctx, wallet.BoardingStatusSweepPending,

--- a/swapwallet/AGENTS.md
+++ b/swapwallet/AGENTS.md
@@ -115,9 +115,11 @@ default builds avoid the swap executor's dependency graph.
 - **`Balance` projection** maps daemonrpc fields onto the walletrpc
   shape: `confirmed_sat` is VTXO-only (`vtxo_balance_sat`),
   `pending_in_sat` sums `boarding_confirmed_sat +
-  boarding_unconfirmed_sat`, and `pending_out_sat` mirrors
-  `boarding_pending_sweep_sat`. Confirmed-but-not-yet-boarded UTXOs
-  must NOT inflate `confirmed_sat` (issue #502).
+  boarding_unconfirmed_sat + boarding_adopted_sat`, and
+  `pending_out_sat` mirrors `boarding_pending_sweep_sat`.
+  Confirmed-but-not-yet-boarded UTXOs must NOT inflate
+  `confirmed_sat` (issue #502), and adopted-but-not-yet-live VTXOs
+  must stay pending inbound until commitment confirmation (issue #542).
 
 ## Deep Docs
 

--- a/swapwallet/CLAUDE.md
+++ b/swapwallet/CLAUDE.md
@@ -115,9 +115,11 @@ default builds avoid the swap executor's dependency graph.
 - **`Balance` projection** maps daemonrpc fields onto the walletrpc
   shape: `confirmed_sat` is VTXO-only (`vtxo_balance_sat`),
   `pending_in_sat` sums `boarding_confirmed_sat +
-  boarding_unconfirmed_sat`, and `pending_out_sat` mirrors
-  `boarding_pending_sweep_sat`. Confirmed-but-not-yet-boarded UTXOs
-  must NOT inflate `confirmed_sat` (issue #502).
+  boarding_unconfirmed_sat + boarding_adopted_sat`, and
+  `pending_out_sat` mirrors `boarding_pending_sweep_sat`.
+  Confirmed-but-not-yet-boarded UTXOs must NOT inflate
+  `confirmed_sat` (issue #502), and adopted-but-not-yet-live VTXOs
+  must stay pending inbound until commitment confirmation (issue #542).
 
 ## Deep Docs
 

--- a/swapwallet/service.go
+++ b/swapwallet/service.go
@@ -297,16 +297,22 @@ func (s *Service) fetchBalance(ctx context.Context) (*walletrpc.BalanceResponse,
 	// user can actually send right now. Boarding-confirmed funds
 	// are NOT spendable as VTXOs until `ark board` registers them
 	// into a round, so they belong in pending_in_sat alongside
-	// boarding-unconfirmed. The daemon's GetBalance shape returns
-	// total_confirmed_sat = vtxo_balance_sat + boarding_confirmed_sat;
-	// mapping that conflated total onto confirmed_sat would tell the
-	// user they have spendable balance immediately after a faucet
-	// deposit, before any round commit, which the proto contract
-	// (and the `send` verb's runtime check) explicitly disallow.
+	// boarding-unconfirmed. Once a round checkpoint adopts the boarding
+	// UTXO, the funding output disappears from ListUnspent before the
+	// resulting VTXO becomes live; keep that adopted amount in
+	// pending_in_sat so the user does not see balance drop to zero
+	// during commitment confirmation. The daemon's GetBalance shape
+	// returns total_confirmed_sat = vtxo_balance_sat +
+	// boarding_confirmed_sat; mapping that conflated total onto
+	// confirmed_sat would tell the user they have spendable balance
+	// immediately after a faucet deposit, before any round commit, which
+	// the proto contract (and the `send` verb's runtime check)
+	// explicitly disallow.
 	return &walletrpc.BalanceResponse{
 		ConfirmedSat: bal.GetVtxoBalanceSat(),
 		PendingInSat: bal.GetBoardingConfirmedSat() +
-			bal.GetBoardingUnconfirmedSat(),
+			bal.GetBoardingUnconfirmedSat() +
+			bal.GetBoardingAdoptedSat(),
 		PendingOutSat: bal.GetBoardingPendingSweepSat(),
 	}, nil
 }

--- a/swapwallet/service_test.go
+++ b/swapwallet/service_test.go
@@ -83,6 +83,7 @@ func TestServiceBalanceProjectsDaemonGetBalance(t *testing.T) {
 		VtxoBalanceSat:          75_000,
 		BoardingConfirmedSat:    100_000,
 		BoardingUnconfirmedSat:  20_000,
+		BoardingAdoptedSat:      15_000,
 		TotalConfirmedSat:       175_000, // ignored by the mapping
 		BoardingPendingSweepSat: 5_000,
 	}
@@ -92,8 +93,29 @@ func TestServiceBalanceProjectsDaemonGetBalance(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Equal(t, int64(75_000), resp.GetConfirmedSat())
-	require.Equal(t, int64(120_000), resp.GetPendingInSat())
+	require.Equal(t, int64(135_000), resp.GetPendingInSat())
 	require.Equal(t, int64(5_000), resp.GetPendingOutSat())
+}
+
+// TestServiceBalanceKeepsAdoptedBoardingPending pins issue #542: after a
+// boarding UTXO is adopted into a round, the underlying on-chain UTXO is
+// spent before the resulting VTXO is live. The balance must keep that value
+// pending inbound rather than dropping to zero during commitment confirmation.
+func TestServiceBalanceKeepsAdoptedBoardingPending(t *testing.T) {
+	t.Parallel()
+
+	svc, _, rpc := newServiceFixture(t)
+	rpc.getBalanceResp = &daemonrpc.GetBalanceResponse{
+		BoardingAdoptedSat: 100_000,
+	}
+
+	resp, err := svc.Balance(
+		t.Context(), &walletrpc.BalanceRequest{},
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), resp.GetConfirmedSat())
+	require.Equal(t, int64(100_000), resp.GetPendingInSat())
+	require.Equal(t, int64(0), resp.GetPendingOutSat())
 }
 
 // TestServiceBalanceConfirmedExcludesBoardingUTXOs pins the boarding

--- a/wallet/interfaces.go
+++ b/wallet/interfaces.go
@@ -121,8 +121,8 @@ var MessageSpec = struct {
 		*GetActiveBoardingAddressesResponse,
 	]
 
-	// GetBoardingBalance returns the total balance across all confirmed
-	// boarding UTXOs.
+	// GetBoardingBalance returns the balance breakdown across boarding
+	// lifecycle states.
 	GetBoardingBalance Ask[
 		*GetBoardingBalanceRequest,
 		*GetBoardingBalanceResponse,

--- a/wallet/messages.go
+++ b/wallet/messages.go
@@ -116,9 +116,8 @@ func (m *GetBoardingBalanceRequest) MessageType() string {
 // walletMsgSealed implements the sealed WalletMsg interface.
 func (m *GetBoardingBalanceRequest) walletMsgSealed() {}
 
-// GetBoardingBalanceResponse contains the total boarding balance, UTXO
-// count, and the boarding-sweep accounting projections used by the daemon
-// monitoring surface.
+// GetBoardingBalanceResponse contains the total boarding balance, UTXO count,
+// and lifecycle accounting projections used by the daemon monitoring surface.
 type GetBoardingBalanceResponse struct {
 	actor.BaseMessage
 
@@ -137,6 +136,10 @@ type GetBoardingBalanceResponse struct {
 	// UnconfirmedUtxoCount is the number of zero-conf boarding UTXOs
 	// included in UnconfirmedBalance.
 	UnconfirmedUtxoCount int
+
+	// AdoptedBalance is the total amount of boarding UTXOs accepted into a
+	// persisted round checkpoint whose resulting VTXOs are not yet live.
+	AdoptedBalance btcutil.Amount
 
 	// PendingSweepBalance is the total amount of boarding UTXOs that
 	// have been included in a published-but-unconfirmed boarding-sweep

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -801,12 +801,13 @@ func (a *Ark) handleGetActiveBoardingAddresses(ctx context.Context,
 	return fn.Ok[WalletResp](resp)
 }
 
-// handleGetBoardingBalance queries boarding intents in their three
-// monitoring-relevant statuses (confirmed / sweep_pending / swept) and
-// sums them. Sweep-pending and swept totals power the
-// boarding_pending_sweep_sat and boarding_swept_sat fields exposed
-// through GetBalance, so dashboards see boarding funds in flight even
-// while a sweep tx awaits confirmation.
+// handleGetBoardingBalance queries boarding intents in their
+// monitoring-relevant statuses (confirmed / adopted / sweep_pending / swept)
+// and sums them. Adopted totals keep funds visible after a round checkpoint
+// spends the boarding UTXO but before the resulting VTXO confirms.
+// Sweep-pending and swept totals power the boarding_pending_sweep_sat and
+// boarding_swept_sat fields exposed through GetBalance, so dashboards see
+// boarding funds in flight even while a sweep tx awaits confirmation.
 //
 // CONTRACT: this handler must remain a pure read of the boarding
 // store. `darepod.RPCServer.fetchBoardingBalance` deliberately
@@ -825,6 +826,15 @@ func (a *Ark) handleGetBoardingBalance(ctx context.Context,
 	if err != nil {
 		return fn.Err[WalletResp](
 			fmt.Errorf("fetch confirmed intents: %w", err),
+		)
+	}
+
+	adopted, err := a.store.FetchBoardingIntentsByStatus(
+		ctx, BoardingStatusAdopted,
+	)
+	if err != nil {
+		return fn.Err[WalletResp](
+			fmt.Errorf("fetch adopted intents: %w", err),
 		)
 	}
 
@@ -868,6 +878,7 @@ func (a *Ark) handleGetBoardingBalance(ctx context.Context,
 		UtxoCount:            len(confirmed),
 		UnconfirmedBalance:   unconfirmed,
 		UnconfirmedUtxoCount: unconfirmedCount,
+		AdoptedBalance:       sumAmounts(adopted),
 		PendingSweepBalance:  sumAmounts(pendingSweep),
 		SweptBalance:         sumAmounts(swept),
 	}

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -1214,13 +1214,13 @@ func TestGetBoardingBalance(t *testing.T) {
 
 	backend := &MockBoardingBackend{}
 	store := &MockBoardingStore{}
-	// handleGetBoardingBalance now queries three statuses (confirmed,
-	// sweep_pending, swept) so monitoring callers can break boarding
-	// balance down by lifecycle. Empty results are sufficient for the
-	// happy-path zero-balance assertion.
+	// handleGetBoardingBalance queries lifecycle statuses (confirmed,
+	// adopted, sweep_pending, swept) so monitoring callers can break
+	// boarding balance down by lifecycle. Empty results are sufficient for
+	// the happy-path zero-balance assertion.
 	for _, status := range []BoardingStatus{
-		BoardingStatusConfirmed, BoardingStatusSweepPending,
-		BoardingStatusSwept,
+		BoardingStatusConfirmed, BoardingStatusAdopted,
+		BoardingStatusSweepPending, BoardingStatusSwept,
 	} {
 		store.On(
 			"FetchBoardingIntentsByStatus",
@@ -1259,8 +1259,67 @@ func TestGetBoardingBalance(t *testing.T) {
 	require.Equal(t, 0, resp.UtxoCount)
 	require.Equal(t, btcutil.Amount(0), resp.UnconfirmedBalance)
 	require.Equal(t, 0, resp.UnconfirmedUtxoCount)
+	require.Equal(t, btcutil.Amount(0), resp.AdoptedBalance)
 	require.Equal(t, btcutil.Amount(0), resp.PendingSweepBalance)
 	require.Equal(t, btcutil.Amount(0), resp.SweptBalance)
+
+	backend.AssertExpectations(t)
+	store.AssertExpectations(t)
+}
+
+// TestGetBoardingBalanceIncludesAdoptedIntents verifies that a boarding UTXO
+// adopted into a round remains visible while the resulting VTXO is not yet
+// live.
+func TestGetBoardingBalanceIncludesAdoptedIntents(t *testing.T) {
+	t.Parallel()
+
+	backend := &MockBoardingBackend{}
+	store := &MockBoardingStore{}
+	store.On(
+		"FetchBoardingIntentsByStatus",
+		mock.Anything, BoardingStatusConfirmed,
+	).Return([]BoardingIntent{}, nil)
+	store.On(
+		"FetchBoardingIntentsByStatus",
+		mock.Anything, BoardingStatusAdopted,
+	).Return([]BoardingIntent{{
+		Status: BoardingStatusAdopted,
+		ChainInfo: BoardingChainInfo{
+			Amount: 100_000,
+		},
+	}}, nil)
+	store.On(
+		"FetchBoardingIntentsByStatus",
+		mock.Anything, BoardingStatusSweepPending,
+	).Return([]BoardingIntent{}, nil)
+	store.On(
+		"FetchBoardingIntentsByStatus",
+		mock.Anything, BoardingStatusSwept,
+	).Return([]BoardingIntent{}, nil)
+	backend.On(
+		"ListUnspent", mock.Anything, int32(0), int32(
+			MaxConfsForListUnspent,
+		),
+	).Return([]*Utxo{}, nil)
+
+	epochChan := make(chan chainsource.BlockEpoch, 1)
+	chainSource := newMockChainSourceActor(epochChan)
+
+	walletActor := NewArk(
+		backend, store, nil, chainSource, nil, fn.None[ledger.Sink](),
+		btclog.Disabled,
+	)
+
+	result := walletActor.Receive(
+		t.Context(), &GetBoardingBalanceRequest{},
+	)
+	require.True(t, result.IsOk())
+
+	respVal, _ := result.Unpack()
+	resp := respVal.(*GetBoardingBalanceResponse) //nolint:forcetypeassert
+	require.Equal(t, btcutil.Amount(100_000), resp.AdoptedBalance)
+	require.Equal(t, btcutil.Amount(0), resp.TotalBalance)
+	require.Equal(t, btcutil.Amount(0), resp.UnconfirmedBalance)
 
 	backend.AssertExpectations(t)
 	store.AssertExpectations(t)
@@ -1274,8 +1333,8 @@ func TestGetBoardingBalanceFiltersUnconfirmedUTXOs(t *testing.T) {
 	backend := &MockBoardingBackend{}
 	store := &MockBoardingStore{}
 	for _, status := range []BoardingStatus{
-		BoardingStatusConfirmed, BoardingStatusSweepPending,
-		BoardingStatusSwept,
+		BoardingStatusConfirmed, BoardingStatusAdopted,
+		BoardingStatusSweepPending, BoardingStatusSwept,
 	} {
 		store.On(
 			"FetchBoardingIntentsByStatus",


### PR DESCRIPTION
## Summary

Fixes #542 by keeping boarded funds visible while they are adopted into a round but before the resulting VTXO is live.

When a boarding UTXO is accepted into a persisted round checkpoint, the intent moves to `BoardingStatusAdopted`. During that window the original on-chain UTXO can disappear from wallet `ListUnspent`, while the new VTXO is not spendable yet because the commitment has not confirmed. The balance projection previously skipped this adopted state, so wallet balance could temporarily drop to zero.

This adds explicit adopted-boarding accounting to `GetBalance` and maps it into wallet `pending_in_sat`, while keeping `confirmed_sat` VTXO-only.

## Validation

- `make rpc`
- `make fmt-changed`
- `make unit pkg=./wallet`
- `make unit-swapruntime pkg=./swapwallet`
- `make unit pkg=./darepod`
- `make unit pkg=./daemonrpc`
- `go run scripts/verify-schema-registry/main.go`
- `git diff --check`
- `make lint-changed-local`