### PR TITLE
Tolerate stale vHTLC recovery state

### DIFF
--- a/darepod/rpc_vhtlc_recovery.go
+++ b/darepod/rpc_vhtlc_recovery.go
@@ -141,6 +141,10 @@ func (r *RPCServer) CancelVHTLCRecovery(ctx context.Context,
 		ctx, req.RecoveryId, req.Reason, cooperativeTxid,
 	)
 	if err != nil {
+		if errors.Is(err, db.ErrVHTLCRecoveryJobNotFound) {
+			return &daemonrpc.CancelVHTLCRecoveryResponse{}, nil
+		}
+
 		return nil, recoveryErrorToStatus(err)
 	}
 

--- a/darepod/rpc_vhtlc_recovery_test.go
+++ b/darepod/rpc_vhtlc_recovery_test.go
@@ -2,9 +2,14 @@ package darepod
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/lightninglabs/darepo-client/db"
+	"github.com/lightninglabs/darepo-client/unroll"
+	"github.com/lightninglabs/darepo-client/vhtlcrecovery"
 	"github.com/lightninglabs/darepo-client/vhtlcrecovery/coordinator"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -32,4 +37,99 @@ func TestArmVHTLCRecoveryRequiresRequestID(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, codes.InvalidArgument, status.Code(err))
 	require.Contains(t, status.Convert(err).Message(), "request_id")
+}
+
+// TestCancelVHTLCRecoveryMissingIsIdempotent verifies stale swap metadata can
+// cancel a recovery row that disappeared with a local database reset without
+// wedging the swap FSM behind a permanent NotFound.
+func TestCancelVHTLCRecoveryMissingIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	walletReady := make(chan struct{})
+	close(walletReady)
+
+	recoveryService, err := coordinator.NewService(
+		coordinator.ServiceConfig{
+			Store:  missingRecoveryStore{},
+			Unroll: noopUnrollRegistry{},
+		},
+	)
+	require.NoError(t, err)
+
+	rpcServer := &RPCServer{
+		server: &Server{
+			walletReady:   walletReady,
+			vhtlcRecovery: recoveryService,
+		},
+	}
+
+	resp, err := rpcServer.CancelVHTLCRecovery(
+		context.Background(), &daemonrpc.CancelVHTLCRecoveryRequest{
+			RecoveryId: "missing-recovery",
+			Reason:     "cooperative settlement observed",
+		},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Nil(t, resp.GetStatus())
+}
+
+type missingRecoveryStore struct{}
+
+func (missingRecoveryStore) ArmRecovery(context.Context,
+	vhtlcrecovery.RecoveryJob) (*vhtlcrecovery.RecoveryJob, bool, error) {
+
+	return nil, false, errors.New("unexpected arm recovery")
+}
+
+func (missingRecoveryStore) GetRecovery(context.Context, string) (
+	*vhtlcrecovery.RecoveryJob, error) {
+
+	return nil, db.ErrVHTLCRecoveryJobNotFound
+}
+
+func (missingRecoveryStore) ListNonTerminalRecoveries(context.Context) (
+	[]vhtlcrecovery.RecoveryJob, error) {
+
+	return nil, errors.New("unexpected list non-terminal recoveries")
+}
+
+func (missingRecoveryStore) ListRecoveries(context.Context) (
+	[]vhtlcrecovery.RecoveryJob, error) {
+
+	return nil, errors.New("unexpected list recoveries")
+}
+
+func (missingRecoveryStore) EscalateRecovery(context.Context, string,
+	[]byte) error {
+
+	return errors.New("unexpected escalate recovery")
+}
+
+func (missingRecoveryStore) CancelRecovery(context.Context, string, string,
+	[]byte) error {
+
+	return errors.New("unexpected cancel recovery")
+}
+
+func (missingRecoveryStore) CompleteRecovery(context.Context, string) error {
+	return errors.New("unexpected complete recovery")
+}
+
+func (missingRecoveryStore) FailRecovery(context.Context, string, error) error {
+	return errors.New("unexpected fail recovery")
+}
+
+type noopUnrollRegistry struct{}
+
+func (noopUnrollRegistry) EnsureUnroll(context.Context,
+	unroll.EnsureUnrollRequest) (*unroll.EnsureUnrollResp, error) {
+
+	return nil, errors.New("unexpected ensure unroll")
+}
+
+func (noopUnrollRegistry) GetStatus(context.Context, wire.OutPoint) (
+	*unroll.GetStatusResp, error) {
+
+	return nil, errors.New("unexpected get unroll status")
 }

--- a/sdk/swaps/errors.go
+++ b/sdk/swaps/errors.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/lightninglabs/darepo-client/daemonrpc"
 	loopfsm "github.com/lightninglabs/loop/fsm"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+const unregisteredScriptErrText = "script not registered for principal"
 
 var (
 	// ErrSwapExpired is returned when a client-side swap reaches its
@@ -188,6 +191,25 @@ func isDeadlineExceededErr(err error) bool {
 	}
 
 	return status.Code(err) == codes.DeadlineExceeded
+}
+
+// isUnregisteredScriptErr reports an authoritative indexer rejection for a
+// script that is no longer bound to the caller's current mailbox principal.
+func isUnregisteredScriptErr(err error) bool {
+	if err == nil || !strings.Contains(
+		err.Error(), unregisteredScriptErrText,
+	) {
+		return false
+	}
+
+	switch status.Code(err) {
+	case codes.Unauthenticated, codes.PermissionDenied, codes.Internal,
+		codes.Unknown:
+		return true
+
+	default:
+		return false
+	}
 }
 
 // handleFailure persists the terminal swap state associated with err and

--- a/sdk/swaps/out_swap.go
+++ b/sdk/swaps/out_swap.go
@@ -1652,12 +1652,10 @@ func encodeVHTLCPolicyTemplate(policy *arkscript.VHTLCPolicy) ([]byte, error) {
 //
 // The polled pkScript is derived locally from the vHTLC policy parameters
 // supplied by the swap server. A persistent loop where the indexer keeps
-// rejecting the query (e.g. "Unauthenticated: script not registered for
-// principal") usually means the local and remote `lib/arkscript` packages
-// disagree on the vHTLC script structure, so the funded output is at a
-// different pkScript than this side derives. The bundled log includes the
-// indexer's error wording and the queried pkScript so the operator can
-// match it against the on-chain output for diagnosis.
+// rejecting the query because the script is not registered to the current
+// principal is terminal for this receive attempt: either the local and remote
+// script derivation disagree, or stale local swap metadata survived a daemon
+// reset while the corresponding server-side script registration did not.
 func (c *SwapClient) waitForVHTLC(ctx context.Context, pkScript []byte,
 	deadline time.Time, keepWaiting func(context.Context) error) (string,
 	int64, error) {
@@ -1674,6 +1672,14 @@ func (c *SwapClient) waitForVHTLC(ctx context.Context, pkScript []byte,
 				slog.String("err", err.Error()),
 				slog.String("pk_script", pkScriptHex),
 			)
+			if isUnregisteredScriptErr(err) {
+				return "", 0, newFailureError(
+					fmt.Sprintf("vHTLC script %s is not "+
+						"registered for current "+
+						"principal", pkScriptHex),
+					err,
+				)
+			}
 		}
 		if vtxo != nil {
 			c.log.InfoS(ctx, "Found funded vHTLC",

--- a/sdk/swaps/out_swap_test.go
+++ b/sdk/swaps/out_swap_test.go
@@ -1,6 +1,7 @@
 package swaps
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -450,6 +451,54 @@ func TestWaitIncomingVHTLCNotificationRejectsMissingAckCursor(t *testing.T) {
 	require.Zero(t, session.pendingHTLCAckCursor)
 }
 
+// TestCancelVHTLCRecoveryIgnoresNotFound verifies stale local swap metadata can
+// forget a recovery id that no longer exists in the daemon's durable recovery
+// table.
+func TestCancelVHTLCRecoveryIgnoresNotFound(t *testing.T) {
+	t.Parallel()
+
+	daemonConn := &testDaemonConn{
+		cancelErr: status.Error(codes.NotFound, "missing recovery"),
+	}
+
+	err := cancelVHTLCRecovery(
+		t.Context(), daemonConn, "missing-recovery",
+		recoveryReasonClaimAccepted, "",
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, daemonConn.cancelCalls)
+	require.Equal(
+		t, "missing-recovery", daemonConn.lastCancel.GetRecoveryId(),
+	)
+}
+
+// TestWaitForVHTLCFailsOnUnregisteredScript verifies stale accepted receive
+// events stop retrying once the current principal can no longer query the
+// expected script.
+func TestWaitForVHTLCFailsOnUnregisteredScript(t *testing.T) {
+	t.Parallel()
+
+	pkScript := bytes.Repeat([]byte{0x02}, 34)
+	daemonConn := &testDaemonConn{
+		liveLookupErr: status.Error(
+			codes.Internal, "indexer query failed: rpc error: "+
+				"code = Unauthenticated desc = script not "+
+				"registered for principal",
+		),
+	}
+	client := NewSwapClient(nil, daemonConn, nil, nil)
+
+	_, _, err := client.waitForVHTLC(
+		t.Context(), pkScript, time.Time{}, nil,
+	)
+	require.Error(t, err)
+	require.Contains(
+		t, failureReason(err),
+		"not registered for current principal",
+	)
+	require.Equal(t, 1, daemonConn.liveLookupCalls)
+}
+
 type testDaemonConn struct {
 	identityKey       *btcec.PublicKey
 	operatorKey       *btcec.PublicKey
@@ -469,11 +518,13 @@ type testDaemonConn struct {
 	sendPolicyErr     error
 	sendCustomErr     error
 	listSpentErr      error
+	liveLookupErr     error
 	spentLookupErr    error
 	spentLookupBlock  time.Duration
 	spendOnCustom     bool
 	sendPolicyCalls   int
 	sendCustomCalls   int
+	liveLookupCalls   int
 	spentLookupCalls  int
 	lastSendPolicy    []byte
 	lastClaimPubKey   []byte
@@ -762,6 +813,11 @@ func (d *testDaemonConn) ListSpentVTXOs(context.Context) ([]VTXOInfo, error) {
 // FindLiveVTXOByPkScript returns the preconfigured vHTLC.
 func (d *testDaemonConn) FindLiveVTXOByPkScript(_ context.Context,
 	pkScript []byte) (*VTXOInfo, error) {
+
+	d.liveLookupCalls++
+	if d.liveLookupErr != nil {
+		return nil, d.liveLookupErr
+	}
 
 	if d.liveByPkScript != nil {
 		scriptKey := hex.EncodeToString(pkScript)

--- a/sdk/swaps/recovery.go
+++ b/sdk/swaps/recovery.go
@@ -11,6 +11,8 @@ import (
 	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lntypes"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 //nolint:ll
@@ -505,6 +507,10 @@ func cancelVHTLCRecovery(ctx context.Context, daemon DaemonConn, recoveryID,
 		},
 	)
 	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return nil
+		}
+
 		return fmt.Errorf("cancel vhtlc recovery %s: %w", recoveryID,
 			err)
 	}


### PR DESCRIPTION
## Summary

Fixes the stale vHTLC recovery follow-up from #543 by handling two stale local-state paths after a daemon database reset.

First, canceling a missing vHTLC recovery row is now treated as an idempotent success. If old swap metadata still has a `recovery_id` but the daemon's durable recovery table no longer has that row, cooperative settlement already won on that path, so cancellation can safely behave like the row was already gone.

Second, receive-side funding polls now stop when the authoritative indexer says the accepted vHTLC script is not registered for the current principal. That condition is persistent for the current identity: either script derivation disagrees, or stale local swap metadata survived while the server-side script registration did not. Retrying the same query only repeats the same stale-state log, so the receive FSM records a terminal failure with a clear reason.

## Validation

- `make fmt-changed`
- `make unit pkg=./darepod case=TestCancelVHTLCRecoveryMissingIsIdempotent`
- `make unit pkg=./sdk/swaps case=TestCancelVHTLCRecoveryIgnoresNotFound`
- `make unit pkg=./sdk/swaps case=TestWaitForVHTLCFailsOnUnregisteredScript`
- `make unit pkg=./darepod`
- `make unit pkg=./sdk/swaps`
- `make lint-changed-local`
- `git diff --check`
- `make commitmsg-lint range="HEAD~1..HEAD"`